### PR TITLE
Fix proof verification status and add repo cross-references

### DIFF
--- a/src/data/proofs/cantor-diagonalization/meta.json
+++ b/src/data/proofs/cantor-diagonalization/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Georg Cantor (1891)",
     "date": "1891",
-    "status": "verified",
+    "status": "pending",
     "tags": ["set-theory", "infinity", "cardinality", "classic", "intermediate"]
   },
   "overview": {

--- a/src/data/proofs/infinitude-primes/meta.json
+++ b/src/data/proofs/infinitude-primes/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid (formalized by Yannis Konstantoulas)",
     "sourceUrl": "https://github.com/ykonstant1/InfinitePrimes",
     "date": "~300 BCE",
-    "status": "verified",
+    "status": "pending",
     "tags": ["number-theory", "primes", "classic", "euclid", "beginner-friendly"]
   },
   "overview": {

--- a/src/data/proofs/russell-1-plus-1/meta.json
+++ b/src/data/proofs/russell-1-plus-1/meta.json
@@ -7,7 +7,7 @@
     "author": "Bertrand Russell & Alfred North Whitehead (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Principia_Mathematica",
     "date": "1910",
-    "status": "verified",
+    "status": "pending",
     "tags": ["foundations", "peano-arithmetic", "type-theory", "classic", "beginner"]
   },
   "overview": {

--- a/src/data/proofs/sqrt2-irrational/meta.json
+++ b/src/data/proofs/sqrt2-irrational/meta.json
@@ -6,7 +6,8 @@
   "meta": {
     "status": "verified",
     "tags": ["number-theory", "classic", "irrationality"],
-    "mathlib_version": "4.10.0"
+    "mathlib_version": "4.10.0",
+    "proofRepoPath": "Proofs/Sqrt2Irrational.lean"
   },
   "overview": {
     "historicalContext": "The discovery that $\\sqrt{2}$ is irrational is attributed to the ancient Greeks, possibly Hippasus of Metapontum around 500 BCE. The Pythagoreans had built their philosophy on the belief that all quantities could be expressed as ratios of whole numbers—\"all is number.\" The discovery that the diagonal of a unit square (which has length $\\sqrt{2}$ by the Pythagorean theorem) cannot be so expressed shattered this worldview.\n\nAccording to legend, Hippasus was drowned at sea for revealing this disturbing truth. Whether or not the legend is true, the mathematical crisis was real: it forced Greek mathematicians to distinguish between *number* (arithmetic) and *magnitude* (geometry), a distinction that would persist for two millennia until the rigorous construction of the real numbers in the 19th century.\n\nThis proof represents one of the earliest examples of proof by contradiction (*reductio ad absurdum*) in mathematics, and remains a cornerstone of mathematical education to this day.",

--- a/src/types/proof.ts
+++ b/src/types/proof.ts
@@ -31,6 +31,8 @@ export interface ProofMeta {
   mathlib_version?: string
   status: 'verified' | 'pending' | 'disputed'
   tags: string[]
+  /** Path to verified Lean source in lean-genius-proofs repo (e.g., "Proofs/Sqrt2Irrational.lean") */
+  proofRepoPath?: string
 }
 
 export interface ProofSection {


### PR DESCRIPTION
## Summary

- Add `proofRepoPath` field to `ProofMeta` type for linking to lean-genius-proofs repository
- Update sqrt2-irrational with cross-reference (only fully verified proof)
- Change 3 proofs from "verified" to "pending" status to reflect reality:
  - infinitude-primes
  - cantor-diagonalization  
  - russell-1-plus-1

## Context

We're adopting a hybrid repo structure:
- **lean-genius** (this repo): Web viewer with processed JSON data
- **lean-genius-proofs**: Verified Lean sources + LeanInk output

Proofs should only be marked "verified" when they have:
1. Corresponding Lean code in lean-genius-proofs
2. LeanInk output with tactic states

## Test plan

- [ ] Verify the app still builds: `pnpm build`
- [ ] Check that sqrt2-irrational shows as verified
- [ ] Check that other proofs show appropriate pending status

🤖 Generated with [Claude Code](https://claude.com/claude-code)