### PR TITLE
Verify: Russell's 1+1=2 proof

### DIFF
--- a/scripts/import-proof.cjs
+++ b/scripts/import-proof.cjs
@@ -30,6 +30,7 @@ const PROOFS_REPO_PATH = process.env.PROOFS_REPO_PATH || DEFAULT_PROOFS_PATH;
 // Mapping from Lean file names to frontend slug names
 const PROOF_MAPPING = {
   'Sqrt2Irrational': 'sqrt2-irrational',
+  'OnePlusOne': 'russell-1-plus-1',
   // Add more mappings as proofs are added:
   // 'InfinitudePrimes': 'infinitude-primes',
   // 'CantorDiagonalization': 'cantor-diagonalization',
@@ -79,26 +80,31 @@ function toSlug(name) {
     .toLowerCase();
 }
 
+function getContentsString(contents) {
+  if (typeof contents === 'string') {
+    return contents;
+  }
+  if (Array.isArray(contents)) {
+    return contents.map(t => t.raw || '').join('');
+  }
+  return '';
+}
+
 function convertLeanInkToTacticStates(leanInkData) {
   const tacticStates = [];
   let currentLine = 1;
 
   for (const item of leanInkData) {
     if (item._type === 'text') {
-      const content = typeof item.contents === 'string'
-        ? item.contents
-        : item.contents?.map(t => t.raw || '').join('') || '';
+      const content = getContentsString(item.contents);
       currentLine += (content.match(/\n/g) || []).length;
     }
 
     if (item._type === 'sentence' && item.goals && item.goals.length > 0) {
-      const tactic = item.contents
-        ?.map(t => t.raw || '')
-        .join('')
-        .trim() || '';
+      const tactic = getContentsString(item.contents).trim();
 
       if (!tactic || tactic === '' || /^\s*$/.test(tactic)) {
-        const content = item.contents?.map(t => t.raw || '').join('') || '';
+        const content = getContentsString(item.contents);
         currentLine += (content.match(/\n/g) || []).length;
         continue;
       }
@@ -128,7 +134,7 @@ function convertLeanInkToTacticStates(leanInkData) {
         });
       }
 
-      const content = item.contents?.map(t => t.raw || '').join('') || '';
+      const content = getContentsString(item.contents);
       currentLine += (content.match(/\n/g) || []).length;
     }
   }

--- a/src/data/proofs/russell-1-plus-1/index.ts
+++ b/src/data/proofs/russell-1-plus-1/index.ts
@@ -1,6 +1,7 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, TacticState } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
+import tacticStatesJson from './tacticStates.json'
 import sourceRaw from './source.lean?raw'
 
 const meta = metaJson as {
@@ -27,8 +28,10 @@ export const russell1Plus1Proof: Proof = {
 }
 
 export const russell1Plus1Annotations: Annotation[] = annotationsJson as Annotation[]
+export const russell1Plus1TacticStates: TacticState[] = tacticStatesJson as TacticState[]
 
 export const russell1Plus1Data: ProofData = {
   proof: russell1Plus1Proof,
   annotations: russell1Plus1Annotations,
+  tacticStates: russell1Plus1TacticStates,
 }

--- a/src/data/proofs/russell-1-plus-1/meta.json
+++ b/src/data/proofs/russell-1-plus-1/meta.json
@@ -7,8 +7,9 @@
     "author": "Bertrand Russell & Alfred North Whitehead (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Principia_Mathematica",
     "date": "1910",
-    "status": "pending",
-    "tags": ["foundations", "peano-arithmetic", "type-theory", "classic", "beginner"]
+    "status": "verified",
+    "tags": ["foundations", "peano-arithmetic", "type-theory", "classic", "beginner"],
+    "proofRepoPath": "Proofs/OnePlusOne.lean"
   },
   "overview": {
     "historicalContext": "In 1910, Bertrand Russell and Alfred North Whitehead published *Principia Mathematica*, an ambitious attempt to derive all mathematical truths from a small set of logical axioms. The famous claim that it took 362 pages to prove 1+1=2 has become a popular meme about mathematical rigor—though it's slightly misleading. Those 362 pages were building the entire logical machinery needed to even *state* what numbers are, not just proving one equation.\n\nRussell was motivated by the foundational crisis in mathematics, particularly paradoxes like his own Russell's Paradox which showed naive set theory was inconsistent. Principia introduced a ramified type theory to avoid these paradoxes, defining numbers as equivalence classes of sets with the same cardinality.",

--- a/src/data/proofs/russell-1-plus-1/tacticStates.json
+++ b/src/data/proofs/russell-1-plus-1/tacticStates.json
@@ -1,0 +1,1224 @@
+[
+  {
+    "line": 56,
+    "tactic": "by",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 58,
+    "tactic": "unfold one two add",
+    "goalsBefore": [
+      {
+        "hypotheses": [],
+        "conclusion": "(zero.succ + zero).succ = zero.succ.succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [],
+        "conclusion": "(zero.succ + zero).succ = zero.succ.succ"
+      }
+    ]
+  },
+  {
+    "line": 64,
+    "tactic": "rfl",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 77,
+    "tactic": "by",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 78,
+    "tactic": "induction n with",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "n"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "zero + n = n"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "n"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "zero + n = n"
+      }
+    ]
+  },
+  {
+    "line": 79,
+    "tactic": "| zero =>",
+    "goalsBefore": [
+      {
+        "name": "zero",
+        "hypotheses": [],
+        "conclusion": "zero + zero = zero"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "zero",
+        "hypotheses": [],
+        "conclusion": "zero + zero = zero"
+      }
+    ]
+  },
+  {
+    "line": 79,
+    "tactic": "rfl",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 80,
+    "tactic": "| succ n ih =>",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "zero + n = n"
+          }
+        ],
+        "conclusion": "zero + n.succ = n.succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "zero + n = n"
+          }
+        ],
+        "conclusion": "zero + n.succ = n.succ"
+      }
+    ]
+  },
+  {
+    "line": 81,
+    "tactic": "unfold add",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "zero + n = n"
+          }
+        ],
+        "conclusion": "(zero + n).succ = n.succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "zero + n = n"
+          }
+        ],
+        "conclusion": "(zero + n).succ = n.succ"
+      }
+    ]
+  },
+  {
+    "line": 82,
+    "tactic": "rw [",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "zero + n = n"
+          }
+        ],
+        "conclusion": "(zero + n).succ = n.succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "zero + n = n"
+          }
+        ],
+        "conclusion": "(zero + n).succ = n.succ"
+      }
+    ]
+  },
+  {
+    "line": 82,
+    "tactic": "ih",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "zero + n = n"
+          }
+        ],
+        "conclusion": "n.succ = n.succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "zero + n = n"
+          }
+        ],
+        "conclusion": "n.succ = n.succ"
+      }
+    ]
+  },
+  {
+    "line": 82,
+    "tactic": "]",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 87,
+    "tactic": "by",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 88,
+    "tactic": "induction m with",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "n",
+              "m"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "n.succ + m = (n + m).succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "n",
+              "m"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "n.succ + m = (n + m).succ"
+      }
+    ]
+  },
+  {
+    "line": 89,
+    "tactic": "| zero =>",
+    "goalsBefore": [
+      {
+        "name": "zero",
+        "hypotheses": [
+          {
+            "names": [
+              "n"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "n.succ + zero = (n + zero).succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "zero",
+        "hypotheses": [
+          {
+            "names": [
+              "n"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "n.succ + zero = (n + zero).succ"
+      }
+    ]
+  },
+  {
+    "line": 89,
+    "tactic": "rfl",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 90,
+    "tactic": "| succ m ih =>",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n",
+              "m"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n.succ + m = (n + m).succ"
+          }
+        ],
+        "conclusion": "n.succ + m.succ = (n + m.succ).succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n",
+              "m"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n.succ + m = (n + m).succ"
+          }
+        ],
+        "conclusion": "n.succ + m.succ = (n + m.succ).succ"
+      }
+    ]
+  },
+  {
+    "line": 91,
+    "tactic": "unfold add",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n",
+              "m"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n.succ + m = (n + m).succ"
+          }
+        ],
+        "conclusion": "(n.succ + m).succ = (n + m).succ.succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n",
+              "m"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n.succ + m = (n + m).succ"
+          }
+        ],
+        "conclusion": "(n.succ + m).succ = (n + m).succ.succ"
+      }
+    ]
+  },
+  {
+    "line": 92,
+    "tactic": "rw [",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n",
+              "m"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n.succ + m = (n + m).succ"
+          }
+        ],
+        "conclusion": "(n.succ + m).succ = (n + m).succ.succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n",
+              "m"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n.succ + m = (n + m).succ"
+          }
+        ],
+        "conclusion": "(n.succ + m).succ = (n + m).succ.succ"
+      }
+    ]
+  },
+  {
+    "line": 92,
+    "tactic": "ih",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n",
+              "m"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n.succ + m = (n + m).succ"
+          }
+        ],
+        "conclusion": "(n + m).succ.succ = (n + m).succ.succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "n",
+              "m"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n.succ + m = (n + m).succ"
+          }
+        ],
+        "conclusion": "(n + m).succ.succ = (n + m).succ.succ"
+      }
+    ]
+  },
+  {
+    "line": 92,
+    "tactic": "]",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 95,
+    "tactic": "by",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 96,
+    "tactic": "induction n with",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "n",
+              "m"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "n + m = m + n"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "n",
+              "m"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "n + m = m + n"
+      }
+    ]
+  },
+  {
+    "line": 97,
+    "tactic": "| zero =>",
+    "goalsBefore": [
+      {
+        "name": "zero",
+        "hypotheses": [
+          {
+            "names": [
+              "m"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "zero + m = m + zero"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "zero",
+        "hypotheses": [
+          {
+            "names": [
+              "m"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "zero + m = m + zero"
+      }
+    ]
+  },
+  {
+    "line": 98,
+    "tactic": "rw [",
+    "goalsBefore": [
+      {
+        "name": "zero",
+        "hypotheses": [
+          {
+            "names": [
+              "m"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "zero + m = m + zero"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "zero",
+        "hypotheses": [
+          {
+            "names": [
+              "m"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "zero + m = m + zero"
+      }
+    ]
+  },
+  {
+    "line": 98,
+    "tactic": "zero_add",
+    "goalsBefore": [
+      {
+        "name": "zero",
+        "hypotheses": [
+          {
+            "names": [
+              "m"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "m = m + zero"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "zero",
+        "hypotheses": [
+          {
+            "names": [
+              "m"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "m = m + zero"
+      }
+    ]
+  },
+  {
+    "line": 98,
+    "tactic": "]",
+    "goalsBefore": [
+      {
+        "name": "zero",
+        "hypotheses": [
+          {
+            "names": [
+              "m"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "m = m + zero"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "zero",
+        "hypotheses": [
+          {
+            "names": [
+              "m"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "m = m + zero"
+      }
+    ]
+  },
+  {
+    "line": 99,
+    "tactic": "rfl",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 100,
+    "tactic": "| succ n ih =>",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "m",
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n + m = m + n"
+          }
+        ],
+        "conclusion": "n.succ + m = m + n.succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "m",
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n + m = m + n"
+          }
+        ],
+        "conclusion": "n.succ + m = m + n.succ"
+      }
+    ]
+  },
+  {
+    "line": 101,
+    "tactic": "rw [",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "m",
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n + m = m + n"
+          }
+        ],
+        "conclusion": "n.succ + m = m + n.succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "m",
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n + m = m + n"
+          }
+        ],
+        "conclusion": "n.succ + m = m + n.succ"
+      }
+    ]
+  },
+  {
+    "line": 101,
+    "tactic": "succ_add,",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "m",
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n + m = m + n"
+          }
+        ],
+        "conclusion": "(n + m).succ = m + n.succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "m",
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n + m = m + n"
+          }
+        ],
+        "conclusion": "(n + m).succ = m + n.succ"
+      }
+    ]
+  },
+  {
+    "line": 101,
+    "tactic": "add_succ,",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "m",
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n + m = m + n"
+          }
+        ],
+        "conclusion": "(n + m).succ = (m + n).succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "m",
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n + m = m + n"
+          }
+        ],
+        "conclusion": "(n + m).succ = (m + n).succ"
+      }
+    ]
+  },
+  {
+    "line": 101,
+    "tactic": "ih",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "m",
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n + m = m + n"
+          }
+        ],
+        "conclusion": "(m + n).succ = (m + n).succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "m",
+              "n"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "n + m = m + n"
+          }
+        ],
+        "conclusion": "(m + n).succ = (m + n).succ"
+      }
+    ]
+  },
+  {
+    "line": 101,
+    "tactic": "]",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 104,
+    "tactic": "by",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 105,
+    "tactic": "induction c with",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "a",
+              "b",
+              "c"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "a + b + c = a + (b + c)"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "a",
+              "b",
+              "c"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "a + b + c = a + (b + c)"
+      }
+    ]
+  },
+  {
+    "line": 106,
+    "tactic": "| zero =>",
+    "goalsBefore": [
+      {
+        "name": "zero",
+        "hypotheses": [
+          {
+            "names": [
+              "a",
+              "b"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "a + b + zero = a + (b + zero)"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "zero",
+        "hypotheses": [
+          {
+            "names": [
+              "a",
+              "b"
+            ],
+            "type": "ℕ"
+          }
+        ],
+        "conclusion": "a + b + zero = a + (b + zero)"
+      }
+    ]
+  },
+  {
+    "line": 106,
+    "tactic": "rfl",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 107,
+    "tactic": "| succ c ih =>",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "a",
+              "b",
+              "c"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "a + b + c = a + (b + c)"
+          }
+        ],
+        "conclusion": "a + b + c.succ = a + (b + c.succ)"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "a",
+              "b",
+              "c"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "a + b + c = a + (b + c)"
+          }
+        ],
+        "conclusion": "a + b + c.succ = a + (b + c.succ)"
+      }
+    ]
+  },
+  {
+    "line": 108,
+    "tactic": "simp only [add_succ]",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "a",
+              "b",
+              "c"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "a + b + c = a + (b + c)"
+          }
+        ],
+        "conclusion": "(a + b + c).succ = (a + (b + c)).succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "a",
+              "b",
+              "c"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "a + b + c = a + (b + c)"
+          }
+        ],
+        "conclusion": "(a + b + c).succ = (a + (b + c)).succ"
+      }
+    ]
+  },
+  {
+    "line": 109,
+    "tactic": "rw [",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "a",
+              "b",
+              "c"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "a + b + c = a + (b + c)"
+          }
+        ],
+        "conclusion": "(a + b + c).succ = (a + (b + c)).succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "a",
+              "b",
+              "c"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "a + b + c = a + (b + c)"
+          }
+        ],
+        "conclusion": "(a + b + c).succ = (a + (b + c)).succ"
+      }
+    ]
+  },
+  {
+    "line": 109,
+    "tactic": "ih",
+    "goalsBefore": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "a",
+              "b",
+              "c"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "a + b + c = a + (b + c)"
+          }
+        ],
+        "conclusion": "(a + (b + c)).succ = (a + (b + c)).succ"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "succ",
+        "hypotheses": [
+          {
+            "names": [
+              "a",
+              "b",
+              "c"
+            ],
+            "type": "ℕ"
+          },
+          {
+            "names": [
+              "ih"
+            ],
+            "type": "a + b + c = a + (b + c)"
+          }
+        ],
+        "conclusion": "(a + (b + c)).succ = (a + (b + c)).succ"
+      }
+    ]
+  },
+  {
+    "line": 109,
+    "tactic": "]",
+    "goalsBefore": [],
+    "goalsAfter": []
+  }
+]


### PR DESCRIPTION
## Summary

Adds verified Lean 4 proof with LeanInk tactic state extraction for Russell's 1+1=2.

## Changes

- **lean-genius-proofs**: Added `Proofs/OnePlusOne.lean` with full Peano arithmetic construction
- **This repo**:
  - Imported 43 tactic states from LeanInk output
  - Updated status from `pending` to `verified`
  - Added `proofRepoPath: "Proofs/OnePlusOne.lean"` cross-reference
  - Fixed `import-proof.cjs` to handle string contents (was breaking on simple tactics)

## Proof Contents

The proof builds natural numbers from scratch using Peano axioms:
- Inductive definition of ℕ (zero, succ)
- Recursive definition of addition
- Main theorem: `one + one = two` (proved by `rfl`)
- Bonus: commutativity, associativity of addition

## Test Plan

- [x] `pnpm build` passes
- [x] Lean proof compiles in lean-genius-proofs
- [x] LeanInk extraction successful (43 tactic states)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)