### PR TITLE
Verify: Fundamental Theorem of Calculus

### DIFF
--- a/scripts/import-proof.cjs
+++ b/scripts/import-proof.cjs
@@ -30,6 +30,7 @@ const PROOFS_REPO_PATH = process.env.PROOFS_REPO_PATH || DEFAULT_PROOFS_PATH;
 // Mapping from Lean file names to frontend slug names
 const PROOF_MAPPING = {
   'Sqrt2Irrational': 'sqrt2-irrational',
+  'FundamentalTheoremCalculus': 'fundamental-theorem-calculus',
   // Add more mappings as proofs are added:
   // 'InfinitudePrimes': 'infinitude-primes',
   // 'CantorDiagonalization': 'cantor-diagonalization',

--- a/src/data/proofs/fundamental-theorem-calculus/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus/meta.json
@@ -7,7 +7,8 @@
     "author": "Newton & Leibniz (1680s), Cauchy (1820s)",
     "date": "1680s",
     "status": "verified",
-    "tags": ["analysis", "calculus", "integration", "differentiation", "classic", "intermediate"]
+    "tags": ["analysis", "calculus", "integration", "differentiation", "classic", "intermediate"],
+    "proofRepoPath": "Proofs/FundamentalTheoremCalculus.lean"
   },
   "overview": {
     "historicalContext": "The Fundamental Theorem of Calculus (FTC) represents one of mathematics' greatest unifications. Isaac Newton and Gottfried Leibniz independently discovered it in the 1680s, though their bitter priority dispute would rage for decades.\n\nNewton developed his 'method of fluxions' while avoiding the plague at Woolsthorpe Manor (1665-1666), but published much later. Leibniz independently created his differential calculus in the 1670s, with superior notation that we still use today (dx, dy, ∫).\n\nWhile Newton and Leibniz grasped the theorem intuitively, rigorous proof required the epsilon-delta foundations developed by Cauchy (1821) and perfected by Weierstrass (1860s). The theorem connects area (integration) with slope (differentiation) - two concepts that appear completely unrelated until FTC reveals their deep connection.",
@@ -26,43 +27,43 @@
       "id": "setup",
       "title": "Setup and Imports",
       "startLine": 1,
-      "endLine": 25,
-      "summary": "Introduces the historical context and imports Mathlib's calculus and integration libraries."
+      "endLine": 29,
+      "summary": "Introduces the historical context, imports Mathlib's calculus and integration libraries, and opens the namespace."
     },
     {
       "id": "integral-function",
       "title": "The Integral Function",
-      "startLine": 27,
-      "endLine": 38,
+      "startLine": 31,
+      "endLine": 42,
       "summary": "Defines F(x) = ∫ₐˣ f(t)dt, the cumulative integral that measures accumulated area."
     },
     {
       "id": "ftc-part1",
       "title": "FTC Part 1: Differentiation of Integrals",
-      "startLine": 40,
-      "endLine": 53,
+      "startLine": 44,
+      "endLine": 59,
       "summary": "Proves that the derivative of an integral recovers the original function: F'(x) = f(x)."
     },
     {
       "id": "ftc-part2",
       "title": "FTC Part 2: Evaluation of Integrals",
-      "startLine": 55,
-      "endLine": 80,
+      "startLine": 61,
+      "endLine": 86,
       "summary": "Proves that the integral of a derivative equals the net change: ∫ₐᵇ F' = F(b) - F(a)."
     },
     {
       "id": "antiderivatives",
       "title": "Antiderivatives and Uniqueness",
-      "startLine": 82,
-      "endLine": 124,
+      "startLine": 88,
+      "endLine": 139,
       "summary": "Shows that the integral function is an antiderivative, and that antiderivatives differ only by constants."
     },
     {
-      "id": "constant-theorem",
-      "title": "Zero Derivative Implies Constant",
-      "startLine": 126,
-      "endLine": 148,
-      "summary": "Proves that a function with zero derivative everywhere must be constant, using the Mean Value Theorem."
+      "id": "checks",
+      "title": "Type Checking",
+      "startLine": 141,
+      "endLine": 146,
+      "summary": "Verifies the types of the main theorems using #check commands."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/fundamental-theorem-calculus/tacticStates.json
+++ b/src/data/proofs/fundamental-theorem-calculus/tacticStates.json
@@ -1,0 +1,1380 @@
+[
+  {
+    "line": 55,
+    "tactic": "by",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 56,
+    "tactic": "apply ftc_part1",
+    "goalsBefore": [
+      {
+        "name": "hf_cont",
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "ContinuousAt f x"
+      },
+      {
+        "name": "hf_int",
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "IntervalIntegrable f volume a x"
+      },
+      {
+        "name": "hf_meas",
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "StronglyMeasurableAtFilter f (𝓝 x) volume"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "hf_cont",
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "ContinuousAt f x"
+      },
+      {
+        "name": "hf_int",
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "IntervalIntegrable f volume a x"
+      },
+      {
+        "name": "hf_meas",
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "StronglyMeasurableAtFilter f (𝓝 x) volume"
+      }
+    ]
+  },
+  {
+    "line": 57,
+    "tactic": "·",
+    "goalsBefore": [
+      {
+        "name": "hf_cont",
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "ContinuousAt f x"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "hf_cont",
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "ContinuousAt f x"
+      }
+    ]
+  },
+  {
+    "line": 57,
+    "tactic": "exact hf.continuousAt",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 58,
+    "tactic": "·",
+    "goalsBefore": [
+      {
+        "name": "hf_int",
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "IntervalIntegrable f volume a x"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "hf_int",
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "IntervalIntegrable f volume a x"
+      }
+    ]
+  },
+  {
+    "line": 58,
+    "tactic": "exact hf.intervalIntegrable a x",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 59,
+    "tactic": "·",
+    "goalsBefore": [
+      {
+        "name": "hf_meas",
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "StronglyMeasurableAtFilter f (𝓝 x) volume"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "hf_meas",
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "StronglyMeasurableAtFilter f (𝓝 x) volume"
+      }
+    ]
+  },
+  {
+    "line": 59,
+    "tactic": "exact hf.stronglyMeasurableAtFilter volume (𝓝 x)",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 107,
+    "tactic": "by",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 108,
+    "tactic": "intro x",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "HasDerivAt (integralFunction f a) (f x) x"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "a"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "hf"
+            ],
+            "type": "Continuous f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "HasDerivAt (integralFunction f a) (f x) x"
+      }
+    ]
+  },
+  {
+    "line": 109,
+    "tactic": "exact ftc_part1_continuous hf x",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 115,
+    "tactic": "by",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 116,
+    "tactic": "have hdiff : Differentiable ℝ F := fun z => (hF z).differentiableAt",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "F"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "∀ (x : ℝ), HasDerivAt F 0 x"
+          },
+          {
+            "names": [
+              "hdiff"
+            ],
+            "type": "Differentiable ℝ F"
+          }
+        ],
+        "conclusion": "∀ (x y : ℝ), F x = F y"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "F"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "∀ (x : ℝ), HasDerivAt F 0 x"
+          },
+          {
+            "names": [
+              "hdiff"
+            ],
+            "type": "Differentiable ℝ F"
+          }
+        ],
+        "conclusion": "∀ (x y : ℝ), F x = F y"
+      }
+    ]
+  },
+  {
+    "line": 117,
+    "tactic": "have hderiv : ∀ z, deriv F z = 0 := fun z => (hF z).deriv",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "F"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "∀ (x : ℝ), HasDerivAt F 0 x"
+          },
+          {
+            "names": [
+              "hdiff"
+            ],
+            "type": "Differentiable ℝ F"
+          },
+          {
+            "names": [
+              "hderiv"
+            ],
+            "type": "∀ (z : ℝ), deriv F z = 0"
+          }
+        ],
+        "conclusion": "∀ (x y : ℝ), F x = F y"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "F"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "∀ (x : ℝ), HasDerivAt F 0 x"
+          },
+          {
+            "names": [
+              "hdiff"
+            ],
+            "type": "Differentiable ℝ F"
+          },
+          {
+            "names": [
+              "hderiv"
+            ],
+            "type": "∀ (z : ℝ), deriv F z = 0"
+          }
+        ],
+        "conclusion": "∀ (x y : ℝ), F x = F y"
+      }
+    ]
+  },
+  {
+    "line": 118,
+    "tactic": "intro x y",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "F"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "∀ (x : ℝ), HasDerivAt F 0 x"
+          },
+          {
+            "names": [
+              "hdiff"
+            ],
+            "type": "Differentiable ℝ F"
+          },
+          {
+            "names": [
+              "hderiv"
+            ],
+            "type": "∀ (z : ℝ), deriv F z = 0"
+          },
+          {
+            "names": [
+              "x",
+              "y"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "F x = F y"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "F"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "∀ (x : ℝ), HasDerivAt F 0 x"
+          },
+          {
+            "names": [
+              "hdiff"
+            ],
+            "type": "Differentiable ℝ F"
+          },
+          {
+            "names": [
+              "hderiv"
+            ],
+            "type": "∀ (z : ℝ), deriv F z = 0"
+          },
+          {
+            "names": [
+              "x",
+              "y"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "F x = F y"
+      }
+    ]
+  },
+  {
+    "line": 120,
+    "tactic": "exact is_const_of_deriv_eq_zero hdiff hderiv x y",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 126,
+    "tactic": "by",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 128,
+    "tactic": "use F 0 - G 0",
+    "goalsBefore": [
+      {
+        "name": "h",
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          }
+        ],
+        "conclusion": "∀ (x : ℝ), F x - G x = F 0 - G 0"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "h",
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          }
+        ],
+        "conclusion": "∀ (x : ℝ), F x - G x = F 0 - G 0"
+      }
+    ]
+  },
+  {
+    "line": 129,
+    "tactic": "intro x",
+    "goalsBefore": [
+      {
+        "name": "h",
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "F x - G x = F 0 - G 0"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "h",
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "F x - G x = F 0 - G 0"
+      }
+    ]
+  },
+  {
+    "line": 131,
+    "tactic": "have h : ∀ y, HasDerivAt (fun z => F z - G z) 0 y :=",
+    "goalsBefore": [
+      {
+        "name": "h",
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "F x - G x = F 0 - G 0"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "h",
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "F x - G x = F 0 - G 0"
+      }
+    ]
+  },
+  {
+    "line": 131,
+    "tactic": "by",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 132,
+    "tactic": "intro y",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x",
+              "y"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "HasDerivAt (fun z => F z - G z) 0 y"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x",
+              "y"
+            ],
+            "type": "ℝ"
+          }
+        ],
+        "conclusion": "HasDerivAt (fun z => F z - G z) 0 y"
+      }
+    ]
+  },
+  {
+    "line": 133,
+    "tactic": "have := (hF y).sub (hG y)",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x",
+              "y"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "this"
+            ],
+            "type": "HasDerivAt (fun x => F x - G x) (f y - f y) y"
+          }
+        ],
+        "conclusion": "HasDerivAt (fun z => F z - G z) 0 y"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x",
+              "y"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "this"
+            ],
+            "type": "HasDerivAt (fun x => F x - G x) (f y - f y) y"
+          }
+        ],
+        "conclusion": "HasDerivAt (fun z => F z - G z) 0 y"
+      }
+    ]
+  },
+  {
+    "line": 134,
+    "tactic": "simp at this",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x",
+              "y"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "this"
+            ],
+            "type": "HasDerivAt (fun x => F x - G x) 0 y"
+          }
+        ],
+        "conclusion": "HasDerivAt (fun z => F z - G z) 0 y"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x",
+              "y"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "this"
+            ],
+            "type": "HasDerivAt (fun x => F x - G x) 0 y"
+          }
+        ],
+        "conclusion": "HasDerivAt (fun z => F z - G z) 0 y"
+      }
+    ]
+  },
+  {
+    "line": 135,
+    "tactic": "exact this",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 137,
+    "tactic": "have hconst := hasDerivAt_zero_implies_constant h",
+    "goalsBefore": [
+      {
+        "name": "h",
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "h"
+            ],
+            "type": "∀ (y : ℝ), HasDerivAt (fun z => F z - G z) 0 y"
+          },
+          {
+            "names": [
+              "hconst"
+            ],
+            "type": "∀ (x y : ℝ), F x - G x = F y - G y"
+          }
+        ],
+        "conclusion": "F x - G x = F 0 - G 0"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "h",
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "h"
+            ],
+            "type": "∀ (y : ℝ), HasDerivAt (fun z => F z - G z) 0 y"
+          },
+          {
+            "names": [
+              "hconst"
+            ],
+            "type": "∀ (x y : ℝ), F x - G x = F y - G y"
+          }
+        ],
+        "conclusion": "F x - G x = F 0 - G 0"
+      }
+    ]
+  },
+  {
+    "line": 138,
+    "tactic": "have := hconst x 0",
+    "goalsBefore": [
+      {
+        "name": "h",
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "h"
+            ],
+            "type": "∀ (y : ℝ), HasDerivAt (fun z => F z - G z) 0 y"
+          },
+          {
+            "names": [
+              "hconst"
+            ],
+            "type": "∀ (x y : ℝ), F x - G x = F y - G y"
+          },
+          {
+            "names": [
+              "this"
+            ],
+            "type": "F x - G x = F 0 - G 0"
+          }
+        ],
+        "conclusion": "F x - G x = F 0 - G 0"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "name": "h",
+        "hypotheses": [
+          {
+            "names": [
+              "F",
+              "G",
+              "f"
+            ],
+            "type": "ℝ → ℝ"
+          },
+          {
+            "names": [
+              "hF"
+            ],
+            "type": "IsAntiderivative F f"
+          },
+          {
+            "names": [
+              "hG"
+            ],
+            "type": "IsAntiderivative G f"
+          },
+          {
+            "names": [
+              "x"
+            ],
+            "type": "ℝ"
+          },
+          {
+            "names": [
+              "h"
+            ],
+            "type": "∀ (y : ℝ), HasDerivAt (fun z => F z - G z) 0 y"
+          },
+          {
+            "names": [
+              "hconst"
+            ],
+            "type": "∀ (x y : ℝ), F x - G x = F y - G y"
+          },
+          {
+            "names": [
+              "this"
+            ],
+            "type": "F x - G x = F 0 - G 0"
+          }
+        ],
+        "conclusion": "F x - G x = F 0 - G 0"
+      }
+    ]
+  },
+  {
+    "line": 139,
+    "tactic": "linarith",
+    "goalsBefore": [],
+    "goalsAfter": []
+  }
+]


### PR DESCRIPTION
## Summary

- Wrote verified Lean 4 proof of the Fundamental Theorem of Calculus in `lean-genius-proofs` repo
- Imported 28 tactic states from LeanInk for the interactive proof viewer
- Updated source.lean to match the verified proof (fixed Mathlib API compatibility)
- Added proofRepoPath reference for cross-repo linking

## Changes

- `scripts/import-proof.cjs`: Added mapping for FundamentalTheoremCalculus
- `src/data/proofs/fundamental-theorem-calculus/source.lean`: Updated to working Lean 4 proof
- `src/data/proofs/fundamental-theorem-calculus/meta.json`: Added proofRepoPath, updated sections
- `src/data/proofs/fundamental-theorem-calculus/tacticStates.json`: New file with 28 tactic states

## Test plan

- [ ] Verify tacticStates.json loads correctly in proof viewer
- [ ] Check that sections correspond to correct line ranges
- [ ] Confirm proofRepoPath links correctly to lean-genius-proofs

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)