### PR TITLE
Add proof: Gödel's First Incompleteness Theorem

### DIFF
--- a/PROOFS_ROADMAP.md
+++ b/PROOFS_ROADMAP.md
@@ -12,6 +12,7 @@ A curated list of proofs to add to Lean Genius, selected for educational value, 
 | Russell's 1+1=2 | Foundations | Verified | Beginner |
 | Cantor's Diagonalization | Set Theory | Verified | Intermediate |
 | Fundamental Theorem of Calculus | Analysis | Verified | Intermediate |
+| Gödel's First Incompleteness | Mathematical Logic | Pending | Advanced |
 
 ---
 

--- a/src/data/proofs/godel-incompleteness/annotations.json
+++ b/src/data/proofs/godel-incompleteness/annotations.json
@@ -1,0 +1,201 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 1, "endLine": 20 },
+    "type": "concept",
+    "title": "The Theorem That Changed Everything",
+    "content": "Gödel's 1931 paper is one of the most important in the history of mathematics and logic. It proved that Hilbert's dream of a complete, consistent formal foundation for mathematics was impossible.\n\nThe theorem states that any formal system $F$ capable of expressing basic arithmetic must be **incomplete**: there exist true statements that $F$ cannot prove. This isn't a flaw in our axioms—it's a fundamental limitation of formal reasoning itself.\n\nThis formalization presents the key conceptual components. A complete proof would require thousands of lines defining syntax, proof systems, and primitive recursive functions.",
+    "significance": "critical",
+    "relatedConcepts": ["Hilbert's Program", "formal systems", "metamathematics"]
+  },
+  {
+    "id": "ann-formula-type",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 27, "endLine": 27 },
+    "type": "definition",
+    "title": "The Formula Type",
+    "content": "We axiomatize `Formula` as an abstract type representing well-formed formulas in our formal system. In a full formalization, this would be an inductive type defining the syntax of first-order arithmetic:\n\n- Variables: $x, y, z, \\ldots$\n- Constants: $0, 1, 2, \\ldots$\n- Functions: $+, \\times, S$ (successor)\n- Relations: $=, <$\n- Logical connectives: $\\land, \\lor, \\neg, \\rightarrow$\n- Quantifiers: $\\forall, \\exists$\n\nEvery formula in Peano Arithmetic can be built from these primitives.",
+    "significance": "key",
+    "relatedConcepts": ["formal syntax", "first-order logic", "Peano Arithmetic"]
+  },
+  {
+    "id": "ann-provability",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 30, "endLine": 32 },
+    "type": "definition",
+    "title": "The Provability Predicate",
+    "content": "The statement $\\vdash \\phi$ means \"$\\phi$ is provable in the formal system $F$.\" A proof is a finite sequence of formulas where each step follows from previous steps by inference rules.\n\nCrucially, provability is a **syntactic** notion—it depends only on the formal rules, not on whether $\\phi$ is \"true\" in any model. This distinction between provability and truth is central to Gödel's argument.",
+    "mathContext": "$\\vdash \\phi$ iff there exists a proof of $\\phi$ from the axioms of $F$",
+    "significance": "critical",
+    "relatedConcepts": ["proof", "derivation", "syntactic consequence"]
+  },
+  {
+    "id": "ann-consistency",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 44, "endLine": 46 },
+    "type": "definition",
+    "title": "Consistency",
+    "content": "A system is **consistent** if there's no formula $\\phi$ such that both $\\phi$ and $\\neg\\phi$ are provable. Equivalently, by the principle of explosion, if the system were inconsistent, *every* formula would be provable.\n\nGödel's theorem assumes consistency: if your system proves contradictions, the theorem doesn't apply (but your system is useless anyway).\n\nGödel originally used a stronger condition called **$\\omega$-consistency**, but Rosser later showed simple consistency suffices with a cleverer construction.",
+    "mathContext": "$\\text{Consistent}(F) \\iff \\neg\\exists\\phi(\\vdash\\phi \\land \\vdash\\neg\\phi)$",
+    "significance": "critical",
+    "prerequisites": ["ann-provability"],
+    "relatedConcepts": ["ω-consistency", "Rosser's trick", "soundness"]
+  },
+  {
+    "id": "ann-godel-numbering",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 55, "endLine": 56 },
+    "type": "concept",
+    "title": "Gödel Numbering: The Key Innovation",
+    "content": "Gödel's revolutionary insight was to assign a unique natural number to every formula. This encoding, called **Gödel numbering**, allows the formal system to reason about its own syntax.\n\nFor example, the formula \"$0 = 0$\" might receive Gödel number 4,782,969. The number encodes the structure: which symbols appear, in what order, how they combine.\n\nWith this encoding, questions about formulas become questions about numbers. \"Is $\\phi$ provable?\" becomes \"Does the number $\\ulcorner\\phi\\urcorner$ have property $P$?\" And arithmetic can talk about properties of numbers!",
+    "mathContext": "$\\ulcorner\\phi\\urcorner$ denotes the Gödel number of formula $\\phi$",
+    "significance": "critical",
+    "relatedConcepts": ["encoding", "arithmetization", "metamathematics"]
+  },
+  {
+    "id": "ann-encoding-injective",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 59, "endLine": 59 },
+    "type": "insight",
+    "title": "Injectivity of Encoding",
+    "content": "The Gödel numbering must be **injective**: different formulas get different numbers. This ensures we can uniquely identify formulas by their codes.\n\nGödel used prime factorization for his encoding. For instance, a sequence of symbols $(a_1, a_2, \\ldots, a_n)$ might be encoded as $2^{a_1} \\cdot 3^{a_2} \\cdot 5^{a_3} \\cdots p_n^{a_n}$ where $p_i$ is the $i$th prime. The fundamental theorem of arithmetic guarantees unique decoding.",
+    "significance": "supporting",
+    "prerequisites": ["ann-godel-numbering"],
+    "relatedConcepts": ["prime factorization", "encoding schemes"]
+  },
+  {
+    "id": "ann-prov-formula",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 79, "endLine": 82 },
+    "type": "definition",
+    "title": "The Provability Formula",
+    "content": "Here's where things get magical. We can express provability *inside* the system using a formula $\\text{Prov}(x)$.\n\n$\\text{Prov}(n)$ is a formula that says: \"The formula with Gödel number $n$ is provable.\" This is possible because checking if something is a valid proof is a mechanical procedure—it can be expressed as an arithmetic statement about the numbers encoding the proof and the formula.\n\nThe key is that proofs are finite symbol sequences, verification is algorithmic, and algorithms can be expressed in arithmetic (via primitive recursive functions).",
+    "mathContext": "$\\text{Prov}(\\ulcorner\\phi\\urcorner)$ represents \"$\\phi$ is provable\"",
+    "significance": "critical",
+    "prerequisites": ["ann-godel-numbering"],
+    "relatedConcepts": ["representability", "primitive recursive", "formal provability"]
+  },
+  {
+    "id": "ann-prov-complete",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 85, "endLine": 85 },
+    "type": "theorem",
+    "title": "Representability of Provability",
+    "content": "This axiom captures a key property: if $\\phi$ is actually provable, then the system can prove that $\\phi$ is provable.\n\nFormally: $\\vdash\\phi \\Rightarrow \\vdash\\text{Prov}(\\ulcorner\\phi\\urcorner)$\n\nThis is not trivial! It requires showing that the Gödel encoding preserves enough structure that proofs of provability can be internalized. It's one of the technical heart of the incompleteness proof.",
+    "mathContext": "$\\vdash\\phi \\implies \\vdash\\text{Prov}(\\ulcorner\\phi\\urcorner)$",
+    "significance": "critical",
+    "prerequisites": ["ann-prov-formula"],
+    "relatedConcepts": ["Hilbert-Bernays derivability conditions", "Löb's theorem"]
+  },
+  {
+    "id": "ann-diagonal-lemma",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 96, "endLine": 102 },
+    "type": "theorem",
+    "title": "The Diagonal Lemma (Fixed Point Theorem)",
+    "content": "This is the formal engine of self-reference. For any property $P(x)$ expressible in the system, there exists a sentence $\\gamma$ such that:\n\n$\\gamma \\iff P(\\ulcorner\\gamma\\urcorner)$\n\nIn other words, $\\gamma$ says \"I have property $P$.\" The sentence refers to itself—not by name, but by describing its own Gödel number!\n\nThe construction uses the substitution function and diagonalization, similar to Cantor's proof that the reals are uncountable. It's the formalization of the Liar's Paradox mechanism.",
+    "mathContext": "$\\forall P. \\exists\\gamma. \\gamma \\iff P(\\ulcorner\\gamma\\urcorner)$",
+    "significance": "critical",
+    "relatedConcepts": ["self-reference", "fixed point", "Liar's Paradox", "diagonalization"]
+  },
+  {
+    "id": "ann-not-prov",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 117, "endLine": 117 },
+    "type": "definition",
+    "title": "The Unprovability Predicate",
+    "content": "We define $\\text{NotProv}(n)$ as $\\neg\\text{Prov}(n)$—\"the formula with Gödel number $n$ is *not* provable.\"\n\nThis is the property we'll plug into the Diagonal Lemma to create the Gödel sentence.",
+    "mathContext": "$\\text{NotProv}(n) \\stackrel{\\text{def}}{=} \\neg\\text{Prov}(n)$",
+    "significance": "key",
+    "prerequisites": ["ann-prov-formula"],
+    "relatedConcepts": ["negation", "unprovability"]
+  },
+  {
+    "id": "ann-godel-sentence-construction",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 120, "endLine": 122 },
+    "type": "theorem",
+    "title": "Existence of the Gödel Sentence",
+    "content": "By the Diagonal Lemma applied to $\\text{NotProv}$, there exists a sentence $G$ such that:\n\n$G \\iff \\neg\\text{Prov}(\\ulcorner G\\urcorner)$\n\nTranslating to English: $G$ says \"I am not provable.\" This is the formal realization of the Liar's Paradox, but replacing \"false\" with \"unprovable\" avoids the contradiction—instead, we get incompleteness.",
+    "mathContext": "$G \\iff \\neg\\text{Prov}(\\ulcorner G\\urcorner)$",
+    "significance": "critical",
+    "prerequisites": ["ann-diagonal-lemma", "ann-not-prov"],
+    "relatedConcepts": ["Gödel sentence", "self-reference"]
+  },
+  {
+    "id": "ann-g-not-provable",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 141, "endLine": 155 },
+    "type": "tactic",
+    "title": "G Is Not Provable",
+    "content": "This is the heart of the argument. Assume for contradiction that $G$ is provable.\n\n1. By representability, $\\vdash\\text{Prov}(\\ulcorner G\\urcorner)$\n2. But $G \\iff \\neg\\text{Prov}(\\ulcorner G\\urcorner)$, so $\\vdash\\neg\\text{Prov}(\\ulcorner G\\urcorner)$\n3. We've proved both $\\text{Prov}(\\ulcorner G\\urcorner)$ and $\\neg\\text{Prov}(\\ulcorner G\\urcorner)$\n4. This contradicts consistency!\n\nTherefore, if the system is consistent, $G$ cannot be provable. But $G$ *says* \"I am not provable\"—so $G$ is true! A true sentence that cannot be proved.",
+    "mathContext": "$\\text{Consistent}(F) \\implies \\neg\\vdash G$",
+    "significance": "critical",
+    "prerequisites": ["ann-godel-sentence-construction", "ann-prov-complete"],
+    "relatedConcepts": ["proof by contradiction", "consistency"]
+  },
+  {
+    "id": "ann-first-incompleteness",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 171, "endLine": 173 },
+    "type": "definition",
+    "title": "Syntactic Completeness",
+    "content": "A system is **complete** if for every sentence $\\phi$, either $\\phi$ or $\\neg\\phi$ is provable. This means the system can always decide any question expressible in its language.\n\nThe First Incompleteness Theorem shows this is impossible for consistent systems expressing arithmetic: there exist sentences (like $G$) where neither the sentence nor its negation is provable.",
+    "mathContext": "$\\text{Complete}(F) \\iff \\forall\\phi(\\vdash\\phi \\lor \\vdash\\neg\\phi)$",
+    "significance": "key",
+    "relatedConcepts": ["decidability", "Post's theorem"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 176, "endLine": 184 },
+    "type": "theorem",
+    "title": "The First Incompleteness Theorem",
+    "content": "The theorem in its full glory: **No consistent formal system capable of expressing arithmetic is complete.**\n\nThe proof considers both cases:\n- If $G$ is provable: contradiction (we showed this)\n- If $\\neg G$ is provable: $\\neg G$ says \"$G$ is provable,\" which (with $\\omega$-consistency) leads to contradiction\n\nEither way, completeness fails. Mathematics is forever incomplete.",
+    "mathContext": "$\\text{Consistent}(F) \\implies \\neg\\text{Complete}(F)$",
+    "significance": "critical",
+    "prerequisites": ["ann-g-not-provable", "ann-first-incompleteness"],
+    "relatedConcepts": ["Second Incompleteness Theorem", "Tarski's theorem"]
+  },
+  {
+    "id": "ann-hilbert-program",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 192, "endLine": 196 },
+    "type": "concept",
+    "title": "Death of Hilbert's Program",
+    "content": "David Hilbert had proposed that:\n1. All mathematics could be formalized in a complete, consistent system\n2. The consistency of this system could be proved by \"finitary\" means\n\nGödel's First Incompleteness Theorem killed (1): no complete system exists. His Second Incompleteness Theorem killed (2): no consistent system can prove its own consistency.\n\nThis was a shock to the mathematical community. The dream of absolute certainty in mathematics was over.",
+    "significance": "key",
+    "relatedConcepts": ["Hilbert", "formalism", "finitism"]
+  },
+  {
+    "id": "ann-limits",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 198, "endLine": 201 },
+    "type": "insight",
+    "title": "The Inexhaustibility of Mathematics",
+    "content": "Gödel's theorem reveals something profound: mathematical truth is inexhaustible. No matter how many axioms we add, there will always be truths beyond our reach.\n\nWe can always add $G$ as a new axiom—then the system proves what it couldn't before. But immediately, a new Gödel sentence $G'$ emerges that the expanded system cannot prove. It's turtles all the way down.",
+    "significance": "key",
+    "relatedConcepts": ["axiom extension", "ordinal analysis", "transfinite hierarchy"]
+  },
+  {
+    "id": "ann-mechanism-debate",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 203, "endLine": 206 },
+    "type": "concept",
+    "title": "Mind vs. Machine",
+    "content": "Some philosophers (notably Roger Penrose and J.R. Lucas) have argued that Gödel's theorem shows human minds are not machines—we can \"see\" that $G$ is true even though no formal system can prove it.\n\nThis interpretation is controversial. Critics argue that humans are also subject to limitations, and our \"seeing\" the truth of $G$ depends on assumptions (like consistency) that we cannot verify.\n\nThe debate continues: does mathematical intuition transcend computation, or are we also bounded by our own version of incompleteness?",
+    "significance": "supporting",
+    "relatedConcepts": ["mechanism", "Lucas-Penrose argument", "philosophy of mind"]
+  },
+  {
+    "id": "ann-arithmetization",
+    "proofId": "godel-incompleteness",
+    "range": { "startLine": 228, "endLine": 230 },
+    "type": "insight",
+    "title": "Arithmetizing Metamathematics",
+    "content": "Gödel's deepest insight was that *statements about the formal system* could be expressed *within* the formal system. This is \"arithmetization of metamathematics.\"\n\nBefore Gödel, people thought of mathematics and metamathematics as separate levels. Gödel showed the levels could interweave: a number can encode a proof, and arithmetic can verify the encoding.\n\nThis same technique underlies the undecidability of the Halting Problem, Chaitin's incompleteness, and much of theoretical computer science.",
+    "significance": "critical",
+    "relatedConcepts": ["metamathematics", "Halting Problem", "Chaitin's Omega"]
+  }
+]

--- a/src/data/proofs/godel-incompleteness/index.ts
+++ b/src/data/proofs/godel-incompleteness/index.ts
@@ -1,0 +1,34 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from './source.lean?raw'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+export const godelIncompletenessProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const godelIncompletenessAnnotations: Annotation[] = annotationsJson as Annotation[]
+
+export const godelIncompletenessData: ProofData = {
+  proof: godelIncompletenessProof,
+  annotations: godelIncompletenessAnnotations,
+}

--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -1,0 +1,114 @@
+{
+  "id": "godel-incompleteness",
+  "title": "Gödel's First Incompleteness Theorem",
+  "slug": "godel-incompleteness",
+  "description": "Any consistent formal system capable of expressing basic arithmetic contains statements that are true but unprovable within the system. This 1931 theorem shattered Hilbert's program and revealed fundamental limits of formal reasoning.",
+  "meta": {
+    "author": "Kurt Gödel (formalized sketch in Lean 4)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/G%C3%B6del%27s_incompleteness_theorems",
+    "date": "1931",
+    "status": "pending",
+    "tags": ["logic", "foundations", "incompleteness", "self-reference", "advanced"]
+  },
+  "overview": {
+    "historicalContext": "In 1931, Kurt Gödel, a 25-year-old logician in Vienna, published a paper that would fundamentally change our understanding of mathematics and logic. His *Incompleteness Theorems* demonstrated that the dream of a complete, consistent foundation for mathematics—Hilbert's Program—was impossible.\n\nDavid Hilbert had proposed that all mathematical truths could be derived from a fixed set of axioms using formal rules. Gödel showed this was a fantasy: any system powerful enough to do arithmetic would contain truths it could never prove. The implications rippled through philosophy, computer science (anticipating the Halting Problem), and our understanding of the limits of human knowledge.",
+    "problemStatement": "**Gödel's First Incompleteness Theorem:** If $F$ is a consistent formal system capable of expressing basic arithmetic, then there exists a sentence $G$ such that:\n\n1. $G$ is true (in the standard model of arithmetic)\n2. $G$ is not provable in $F$\n3. $\\neg G$ is not provable in $F$ (assuming $\\omega$-consistency)\n\nIn other words: $F$ is *incomplete*—there are truths it cannot reach.",
+    "proofStrategy": "The proof proceeds through a remarkable self-referential construction:\n\n1. **Gödel Numbering:** Encode every formula as a natural number, allowing the system to \"talk about\" its own formulas\n2. **Representability:** Show that the provability relation can be expressed *within* the system via a formula $\\text{Prov}(x)$\n3. **Diagonal Lemma:** Construct a sentence $G$ that says \"$G$ is not provable\"—formal self-reference\n4. **The Contradiction:** If $G$ were provable, the system would prove both $\\text{Prov}(\\ulcorner G \\urcorner)$ and $\\neg\\text{Prov}(\\ulcorner G \\urcorner)$, violating consistency\n5. **Conclusion:** $G$ must be true but unprovable",
+    "keyInsights": [
+      "Gödel's key innovation was *arithmetizing* metamathematics—proofs become numbers, derivations become calculations",
+      "The Diagonal Lemma transforms the ancient Liar's Paradox ('This sentence is false') into rigorous mathematics by replacing 'false' with 'unprovable'",
+      "Any formal system powerful enough to express arithmetic can encode statements about its own provability, enabling self-reference",
+      "The theorem applies to *any* consistent, sufficiently strong system—not just Peano Arithmetic but ZFC set theory and beyond",
+      "This proof foreshadows the Halting Problem: the same diagonalization technique shows computers have inherent limitations"
+    ]
+  },
+  "sections": [
+    {
+      "id": "introduction",
+      "title": "Introduction",
+      "startLine": 1,
+      "endLine": 20,
+      "summary": "Overview of the theorem and its historical significance, explaining how Gödel shattered Hilbert's dream of a complete formal mathematics."
+    },
+    {
+      "id": "formal-system",
+      "title": "The Formal System",
+      "startLine": 22,
+      "endLine": 38,
+      "summary": "Axiomatizing the minimal requirements for a formal system F capable of expressing arithmetic, including formulas, provability, and negation."
+    },
+    {
+      "id": "consistency",
+      "title": "Consistency Assumption",
+      "startLine": 40,
+      "endLine": 49,
+      "summary": "Defining consistency: no formula can have both itself and its negation provable. This is the key assumption for the theorem."
+    },
+    {
+      "id": "godel-numbering",
+      "title": "Gödel Numbering",
+      "startLine": 51,
+      "endLine": 68,
+      "summary": "The revolutionary encoding scheme that assigns unique natural numbers to formulas, allowing the system to reason about its own syntax."
+    },
+    {
+      "id": "representability",
+      "title": "Representability",
+      "startLine": 70,
+      "endLine": 87,
+      "summary": "The crucial property that provability itself can be expressed within the system, enabling self-reference about provability."
+    },
+    {
+      "id": "diagonal-lemma",
+      "title": "The Diagonal Lemma",
+      "startLine": 89,
+      "endLine": 110,
+      "summary": "The heart of Gödel's construction—a fixed point theorem that enables formulas to 'talk about themselves' in a precise sense."
+    },
+    {
+      "id": "godel-sentence",
+      "title": "The Gödel Sentence",
+      "startLine": 112,
+      "endLine": 132,
+      "summary": "Constructing G—the sentence that says 'I am not provable'—by applying the diagonal lemma to the negation of provability."
+    },
+    {
+      "id": "incompleteness-argument",
+      "title": "The Incompleteness Argument",
+      "startLine": 134,
+      "endLine": 164,
+      "summary": "The central proof: showing that if G were provable, we'd have a contradiction, so G must be true but unprovable."
+    },
+    {
+      "id": "first-incompleteness-theorem",
+      "title": "The First Incompleteness Theorem",
+      "startLine": 166,
+      "endLine": 185,
+      "summary": "The main theorem stated formally: no consistent system capable of expressing arithmetic is complete."
+    },
+    {
+      "id": "philosophical-implications",
+      "title": "Philosophical Implications",
+      "startLine": 187,
+      "endLine": 210,
+      "summary": "The profound consequences: death of Hilbert's program, limits of formalization, the inexhaustibility of mathematics, and the mind-mechanism debate."
+    },
+    {
+      "id": "summary",
+      "title": "The Construction Summarized",
+      "startLine": 212,
+      "endLine": 241,
+      "summary": "A concise summary of the proof strategy: encoding, representability, self-reference, the truth of G, and the final conclusion."
+    }
+  ],
+  "conclusion": {
+    "summary": "Gödel's First Incompleteness Theorem demonstrates that mathematical truth forever exceeds formal provability. Any consistent system powerful enough to express arithmetic contains true statements it cannot prove. This isn't a flaw in specific systems—it's a fundamental feature of formal reasoning itself.",
+    "implications": "The incompleteness theorems transformed our understanding of foundations. Hilbert's vision of a complete, mechanizable mathematics was shown to be impossible. In computer science, the same techniques yield the undecidability of the Halting Problem. Philosophically, the theorems raise profound questions: Does human mathematical insight transcend algorithmic computation? Is there a limit to what we can know through formal methods? Gödel's work suggests that creativity and intuition in mathematics cannot be fully captured by any fixed set of rules.",
+    "openQuestions": [
+      "Can human mathematical reasoning genuinely transcend formal systems, or are we also bound by incompleteness?",
+      "What is the relationship between Gödel incompleteness, Turing undecidability, and Chaitin incompleteness?",
+      "Are there 'natural' mathematical statements (not self-referential) that are independent of standard axioms?",
+      "Could new axioms (like large cardinals) help us prove currently unprovable statements, and how do we know which axioms to trust?"
+    ]
+  }
+}

--- a/src/data/proofs/godel-incompleteness/source.lean
+++ b/src/data/proofs/godel-incompleteness/source.lean
@@ -1,0 +1,261 @@
+/-
+  Gödel's First Incompleteness Theorem
+
+  Any consistent formal system F capable of expressing basic arithmetic
+  contains statements that are true but unprovable within F.
+
+  This formalization presents the key conceptual components of the proof:
+  1. Gödel numbering - encoding formulas as natural numbers
+  2. Representability - expressing arithmetic within the formal system
+  3. The Diagonal Lemma - achieving self-reference
+  4. The Gödel sentence - "This statement is unprovable"
+  5. The incompleteness argument
+
+  This is an illustrative proof sketch capturing the essential structure.
+  A complete formalization would require thousands of lines defining
+  formal syntax, proof systems, and computability theory.
+
+  Historical note: Proved by Kurt Gödel in 1931, this theorem shattered
+  Hilbert's program to establish a complete, consistent foundation for
+  all of mathematics.
+-/
+
+namespace Godel
+
+-- ============================================================
+-- PART 1: The Formal System
+-- ============================================================
+
+-- We axiomatize the minimal requirements for a formal system F
+-- capable of expressing arithmetic
+
+-- Formulas in the system (abstract type)
+axiom Formula : Type
+
+-- Provability predicate: F ⊢ φ means φ is provable in F
+axiom Provable : Formula → Prop
+
+notation:50 "⊢ " φ => Provable φ
+
+-- Negation of formulas
+axiom neg : Formula → Formula
+prefix:75 "¬ᶠ" => neg
+
+-- The system can express basic arithmetic
+-- (We assume natural numbers are definable)
+axiom numeral : Nat → Formula
+
+-- ============================================================
+-- PART 2: Consistency Assumption
+-- ============================================================
+
+-- Consistency: there is no formula φ such that both φ and ¬φ are provable
+def Consistent : Prop :=
+  ∀ φ : Formula, ¬(⊢ φ ∧ ⊢ ¬ᶠφ)
+
+-- ω-consistency: a stronger condition Gödel originally used
+-- If ⊢ ∃x.P(x), then for some n, ⊢ P(n)
+-- (We use simple consistency here, following later simplifications)
+
+-- ============================================================
+-- PART 3: Gödel Numbering
+-- ============================================================
+
+-- Every formula can be encoded as a natural number
+axiom godelNum : Formula → Nat
+
+-- This encoding is injective (different formulas get different numbers)
+axiom godelNum_injective : ∀ φ ψ : Formula, godelNum φ = godelNum ψ → φ = ψ
+
+-- We can recover formulas from their Gödel numbers (partial)
+axiom decode : Nat → Option Formula
+
+-- Encoding and decoding are inverse operations
+axiom decode_godelNum : ∀ φ : Formula, decode (godelNum φ) = some φ
+
+-- ============================================================
+-- PART 4: Representability
+-- ============================================================
+
+-- Key property: provability itself is representable in the system
+-- There exists a formula Prov(x) such that:
+--   F ⊢ Prov(⌜φ⌝) ↔ F ⊢ φ
+-- where ⌜φ⌝ is the numeral for the Gödel number of φ
+
+-- The provability predicate expressed as a formula
+axiom ProvFormula : Nat → Formula
+
+-- Notation: Prov(n) represents "the formula with Gödel number n is provable"
+notation:50 "Prov(" n ")" => ProvFormula n
+
+-- Representability: if φ is provable, then Prov(⌜φ⌝) is provable
+axiom prov_complete : ∀ φ : Formula, ⊢ φ → ⊢ Prov(godelNum φ)
+
+-- ============================================================
+-- PART 5: The Diagonal Lemma (Fixed Point Theorem)
+-- ============================================================
+
+-- This is the heart of Gödel's construction
+-- For any property P(x) expressible in F, there exists a sentence γ
+-- such that F ⊢ γ ↔ P(⌜γ⌝)
+-- In other words: γ says "I have property P"
+
+-- Equivalence of formulas (both directions provable)
+axiom Equiv : Formula → Formula → Prop
+notation:50 φ " ⟺ " ψ => Equiv φ ψ
+
+-- The substitution function for building self-reference
+-- sub(φ, n) substitutes numeral n into φ
+axiom sub : Formula → Nat → Formula
+
+-- The diagonal lemma (Gödel's fixed point theorem)
+axiom diagonal_lemma :
+  ∀ P : Nat → Formula,
+  ∃ γ : Formula, γ ⟺ P (godelNum γ)
+
+-- This lemma allows formulas to "talk about themselves"
+-- It's the formal version of the Liar's Paradox construction
+
+-- ============================================================
+-- PART 6: The Gödel Sentence
+-- ============================================================
+
+-- Apply the diagonal lemma to the negation of provability
+-- We want: G ⟺ ¬Prov(⌜G⌝)
+-- In English: "G says 'I am not provable'"
+
+-- Negation of the provability formula
+def NotProv (n : Nat) : Formula := ¬ᶠ(Prov(n))
+
+-- The Gödel sentence exists by the diagonal lemma
+theorem godel_sentence_exists :
+  ∃ G : Formula, G ⟺ NotProv (godelNum G) :=
+  diagonal_lemma NotProv
+
+-- Get the Gödel sentence
+noncomputable def G : Formula :=
+  Classical.choose godel_sentence_exists
+
+-- G is equivalent to "G is not provable"
+theorem G_self_reference : G ⟺ NotProv (godelNum G) :=
+  Classical.choose_spec godel_sentence_exists
+
+-- ============================================================
+-- PART 7: The Incompleteness Argument
+-- ============================================================
+
+-- We need equivalence to imply co-provability
+axiom equiv_implies_coprovable :
+  ∀ φ ψ : Formula, φ ⟺ ψ → (⊢ φ ↔ ⊢ ψ)
+
+-- If the system is consistent, G is not provable
+theorem G_not_provable (h_consistent : Consistent) : ¬(⊢ G) := by
+  intro hG  -- Assume G is provable
+  -- By self-reference, G ⟺ ¬Prov(⌜G⌝)
+  have h_self := G_self_reference
+  -- Since G is provable, Prov(⌜G⌝) is provable
+  have h_prov : ⊢ Prov(godelNum G) := prov_complete G hG
+  -- By equivalence, ¬Prov(⌜G⌝) is provable (since G is)
+  have h_not_prov : ⊢ NotProv (godelNum G) :=
+    (equiv_implies_coprovable G (NotProv (godelNum G)) h_self).mp hG
+  -- But NotProv(n) = ¬Prov(n), so we have ⊢ ¬Prov(⌜G⌝)
+  -- This contradicts consistency: we proved both Prov(⌜G⌝) and ¬Prov(⌜G⌝)
+  unfold NotProv at h_not_prov
+  exact h_consistent (Prov(godelNum G)) ⟨h_prov, h_not_prov⟩
+
+-- The Gödel sentence is true (in the standard model)
+-- If G were false, then "G is not provable" would be false
+-- meaning G would be provable, contradicting the above
+-- Therefore G is true but unprovable
+
+-- ============================================================
+-- PART 8: The First Incompleteness Theorem
+-- ============================================================
+
+-- Completeness would mean every true sentence is provable
+-- We define a weaker notion: syntactic completeness
+def Complete : Prop :=
+  ∀ φ : Formula, ⊢ φ ∨ ⊢ ¬ᶠφ
+
+-- First Incompleteness Theorem:
+-- No consistent system capable of expressing arithmetic is complete
+theorem first_incompleteness (h_consistent : Consistent) : ¬Complete := by
+  intro h_complete
+  -- By completeness, either ⊢ G or ⊢ ¬G
+  cases h_complete G with
+  | inl hG =>
+    -- Case 1: G is provable - contradicts G_not_provable
+    exact G_not_provable h_consistent hG
+  | inr hNotG =>
+    -- Case 2: ¬G is provable
+    -- ¬G says "G is provable" (negation of "G is not provable")
+    -- If ¬G is provable and the system is sound, then G is provable
+    -- This contradicts Case 1, so the system must be incomplete
+    -- (Full proof requires ω-consistency or additional assumptions)
+    sorry  -- Requires stronger assumptions about ¬G
+
+-- ============================================================
+-- PART 9: Philosophical Implications
+-- ============================================================
+
+/-
+  Gödel's theorem has profound implications:
+
+  1. INCOMPLETENESS OF ARITHMETIC
+     Peano Arithmetic, ZFC, and any sufficiently strong consistent
+     system contains true but unprovable statements.
+
+  2. DEATH OF HILBERT'S PROGRAM
+     Hilbert hoped to prove the consistency of mathematics using
+     finitary methods. Gödel's second incompleteness theorem shows
+     this is impossible: no consistent system can prove its own
+     consistency (unless it's inconsistent).
+
+  3. LIMITS OF FORMALIZATION
+     There will always be mathematical truths that escape any
+     fixed formal system. Mathematics is inexhaustible.
+
+  4. MECHANISM VS MIND
+     Some argue this shows human mathematical reasoning transcends
+     any algorithmic process. This interpretation is controversial.
+
+  5. THE LIAR'S PARADOX REDEEMED
+     Gödel transformed the ancient paradox "This sentence is false"
+     into rigorous mathematics by replacing "false" with "unprovable."
+-/
+
+-- ============================================================
+-- PART 10: The Construction Summarized
+-- ============================================================
+
+/-
+  The Proof in a Nutshell:
+
+  1. ENCODING: Assign each formula φ a unique natural number ⌜φ⌝
+     (the Gödel number). This lets the system "talk about" formulas.
+
+  2. REPRESENTABILITY: The provability relation is expressible
+     within the system via a formula Prov(x).
+
+  3. SELF-REFERENCE: By the diagonal lemma, construct G such that
+     G ⟺ ¬Prov(⌜G⌝), i.e., G says "I am not provable."
+
+  4. TRUTH OF G: If the system is consistent:
+     - If ⊢ G, then ⊢ Prov(⌜G⌝) (by representability)
+     - But G says ⊢ ¬Prov(⌜G⌝)
+     - Contradiction! So G is not provable.
+
+  5. CONCLUSION: G is true (it correctly asserts its unprovability)
+     but not provable. The system is incomplete.
+
+  The genius of Gödel was to arithmetize metamathematics:
+  proofs become numbers, derivations become calculations,
+  and the system can reflect on itself.
+-/
+
+end Godel
+
+-- Final type check of the main theorem
+#check @Godel.first_incompleteness
+#check @Godel.G_not_provable
+#check @Godel.diagonal_lemma

--- a/src/data/proofs/index.ts
+++ b/src/data/proofs/index.ts
@@ -4,6 +4,7 @@ import { infinitudePrimesData } from './infinitude-primes'
 import { russell1Plus1Data } from './russell-1-plus-1'
 import { cantorDiagonalizationData } from './cantor-diagonalization'
 import { fundamentalTheoremCalculusData } from './fundamental-theorem-calculus'
+import { godelIncompletenessData } from './godel-incompleteness'
 import type { ProofData } from '@/types/proof'
 
 export const proofs: Record<string, ProofData> = {
@@ -13,6 +14,7 @@ export const proofs: Record<string, ProofData> = {
   'russell-1-plus-1': russell1Plus1Data,
   'cantor-diagonalization': cantorDiagonalizationData,
   'fundamental-theorem-calculus': fundamentalTheoremCalculusData,
+  'godel-incompleteness': godelIncompletenessData,
 }
 
 export function getProof(slug: string): ProofData | undefined {


### PR DESCRIPTION
## Summary

- Adds Gödel's First Incompleteness Theorem as a new proof page
- Includes illustrative Lean 4 formalization with key conceptual components: Gödel numbering, representability, diagonal lemma, and the incompleteness argument
- Rich educational content: historical context (Hilbert's Program, 1931 Vienna), proof strategy, and philosophical implications
- 18 detailed annotations covering concepts from formal systems to the inexhaustibility of mathematics

## Test plan

- [ ] Verify build succeeds (`pnpm build`)
- [ ] Check proof page renders at `/proof/godel-incompleteness`
- [ ] Verify annotations display correctly
- [ ] Confirm overview and conclusion sections render with LaTeX math

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)