### PR TITLE
Add proof: Four Color Theorem

### DIFF
--- a/PROOFS_ROADMAP.md
+++ b/PROOFS_ROADMAP.md
@@ -14,6 +14,7 @@ A curated list of proofs to add to Lean Genius, selected for educational value, 
 | Fundamental Theorem of Calculus | Analysis | Verified | Intermediate |
 | Gödel's First Incompleteness | Mathematical Logic | Pending | Advanced |
 | Pythagorean Theorem | Geometry | Verified | Beginner |
+| Four Color Theorem | Graph Theory | Pending | Advanced |
 
 ---
 

--- a/src/data/proofs/four-color-theorem/annotations.json
+++ b/src/data/proofs/four-color-theorem/annotations.json
@@ -1,0 +1,164 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 1, "endLine": 20 },
+    "type": "concept",
+    "title": "The Theorem That Took 124 Years",
+    "content": "The Four Color Theorem has a remarkable history. Posed in 1852, it resisted proof for over a century, defeating many brilliant mathematicians. Its eventual 1976 proof required something unprecedented: a computer checking thousands of cases no human could verify.\n\nThe theorem states that any map can be colored with at most four colors such that no two adjacent regions share a color. While easy to state and seemingly simple, the proof revealed deep connections between graph theory, combinatorics, and computation.\n\nThis formalization presents the conceptual structure. The complete proof (Appel-Haken 1976, Gonthier 2005) requires computer verification of 1,936 configurations.",
+    "significance": "critical",
+    "relatedConcepts": ["graph theory", "computer-assisted proof", "planar graphs"]
+  },
+  {
+    "id": "ann-graph-structure",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 28, "endLine": 32 },
+    "type": "definition",
+    "title": "Graphs and Their Structure",
+    "content": "We model maps as graphs where vertices represent regions and edges connect adjacent regions. This transforms the map coloring problem into a graph coloring problem.\n\nA graph $G = (V, E)$ consists of:\n- A set $V$ of vertices (the regions)\n- A set $E$ of edges (adjacency relations)\n- Edges are symmetric: if region A borders B, then B borders A\n\nThis abstraction lets us apply graph-theoretic tools to a geometric problem.",
+    "significance": "key",
+    "relatedConcepts": ["vertex", "edge", "adjacency"]
+  },
+  {
+    "id": "ann-coloring",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 34, "endLine": 43 },
+    "type": "definition",
+    "title": "Graph Coloring",
+    "content": "A **proper k-coloring** assigns one of k colors to each vertex such that adjacent vertices receive different colors. The **chromatic number** $\\chi(G)$ is the minimum k for which a proper k-coloring exists.\n\nThe Four Color Theorem states: $\\chi(G) \\leq 4$ for all planar graphs G.\n\nNote that we need $k \\geq 4$ for some graphs (like the complete graph $K_4$, where every vertex connects to every other). The theorem says 4 always suffices for planar graphs.",
+    "mathContext": "$\\chi(G) = \\min\\{k : G \\text{ is } k\\text{-colorable}\\}$",
+    "significance": "key",
+    "relatedConcepts": ["chromatic number", "proper coloring", "k-colorable"]
+  },
+  {
+    "id": "ann-planar",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 53, "endLine": 60 },
+    "type": "definition",
+    "title": "Planar Graphs",
+    "content": "A graph is **planar** if it can be drawn in the plane with no edge crossings. Equivalently, it can be embedded on a sphere.\n\nNot all graphs are planar! The complete graph $K_5$ (5 vertices, all connected) and the complete bipartite graph $K_{3,3}$ are the 'forbidden minors'—every non-planar graph contains one of these as a substructure.\n\nPlanarity is essential to the theorem. Non-planar graphs can require arbitrarily many colors.",
+    "significance": "critical",
+    "relatedConcepts": ["planar embedding", "Kuratowski's theorem", "forbidden minors"]
+  },
+  {
+    "id": "ann-euler",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 67, "endLine": 77 },
+    "type": "theorem",
+    "title": "Euler's Formula: The Fundamental Constraint",
+    "content": "For any connected planar graph embedded in the plane:\n\n$$V - E + F = 2$$\n\nwhere V = vertices, E = edges, F = faces (including the unbounded outer face).\n\nThis remarkable formula constrains planar graph structure. Combined with the handshaking lemma (sum of degrees = 2E), it implies every planar graph has a vertex of degree at most 5.\n\nThis 'low-degree vertex' existence is the entry point for inductive proofs of coloring theorems.",
+    "mathContext": "$V - E + F = 2$ for connected planar graphs",
+    "significance": "critical",
+    "prerequisites": ["ann-planar"],
+    "relatedConcepts": ["Euler characteristic", "handshaking lemma", "degree"]
+  },
+  {
+    "id": "ann-low-degree",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 82, "endLine": 84 },
+    "type": "theorem",
+    "title": "Every Planar Graph Has a Low-Degree Vertex",
+    "content": "Every planar graph with at least one vertex has a vertex of degree at most 5.\n\n**Proof sketch:** By Euler's formula and handshaking, the average degree in a planar graph is less than 6. Therefore, some vertex must have degree at most 5.\n\nThis result is crucial: it guarantees we can always find a 'removable' vertex for inductive arguments. It's why the Five Color Theorem is easy (6 colors would be trivial, 5 requires one trick, 4 requires computer assistance).",
+    "mathContext": "$\\forall G$ planar, $\\exists v \\in V(G)$ with $\\deg(v) \\leq 5$",
+    "significance": "key",
+    "prerequisites": ["ann-euler"],
+    "relatedConcepts": ["minimum degree", "induction base"]
+  },
+  {
+    "id": "ann-five-color",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 91, "endLine": 107 },
+    "type": "theorem",
+    "title": "The Five Color Theorem",
+    "content": "Every planar graph is 5-colorable. This is much easier than Four Color!\n\n**Proof by induction:**\n1. Find a vertex v of degree ≤ 5\n2. Remove v to get smaller graph G'\n3. By induction, G' is 5-colorable\n4. Restore v: it has ≤ 5 neighbors using ≤ 5 colors\n5. If all 5 colors appear among neighbors, use Kempe chains to free one\n6. Color v with the freed color\n\nThe key insight: with 5 colors and ≤ 5 neighbors, we can always make room. With 4 colors, this argument fails—hence the difficulty of the Four Color Theorem.",
+    "mathContext": "$\\chi(G) \\leq 5$ for all planar graphs G",
+    "significance": "key",
+    "prerequisites": ["ann-low-degree"],
+    "relatedConcepts": ["Heawood's proof", "induction on vertices"]
+  },
+  {
+    "id": "ann-kempe-chains",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 126, "endLine": 145 },
+    "type": "concept",
+    "title": "Kempe Chains: The Color-Swapping Trick",
+    "content": "A **Kempe chain** for colors a and b starting at vertex v is the maximal connected subgraph of vertices colored a or b containing v.\n\nThe crucial property: swapping colors a ↔ b on a Kempe chain produces another valid coloring! Adjacent vertices still have different colors because:\n- Vertices outside the chain keep their colors\n- Inside the chain, neighbors alternate between a and b\n\nKempe invented this for his 1879 'proof' of Four Colors. His argument was flawed, but the technique is correct and essential. The flaw was in handling cases where multiple Kempe chains interact.",
+    "significance": "critical",
+    "relatedConcepts": ["color swapping", "connected component", "Kempe's fallacy"]
+  },
+  {
+    "id": "ann-kempe-swap",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 147, "endLine": 155 },
+    "type": "theorem",
+    "title": "Kempe Chain Swapping Preserves Validity",
+    "content": "If we have a proper coloring and swap colors along a Kempe chain, the result is still a proper coloring.\n\n**Why it works:**\n- Any edge with both endpoints in the chain: before, one was color a, one was b; after, they're swapped but still different\n- Any edge with one endpoint in, one out: the outside endpoint keeps its original color (not a or b), so still different from the inside endpoint\n- Any edge with both endpoints outside: unchanged\n\nThis lets us 'free up' a color at a specific vertex by pushing conflicting colors elsewhere.",
+    "mathContext": "Swapping on Kempe chain preserves $\\forall(u,v) \\in E: c(u) \\neq c(v)$",
+    "significance": "key",
+    "prerequisites": ["ann-kempe-chains"],
+    "relatedConcepts": ["proper coloring", "color permutation"]
+  },
+  {
+    "id": "ann-reducibility",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 172, "endLine": 188 },
+    "type": "concept",
+    "title": "Reducibility: Configurations That Can't Block Coloring",
+    "content": "A configuration C is **reducible** if it cannot appear in a minimal counterexample to Four Color. That is: if a planar graph G contains C, then G is 4-colorable (or G can be simplified to a smaller graph that's 4-colorable).\n\nProving reducibility requires showing that any 4-coloring of the graph minus the configuration can be extended to include it. This involves analyzing all possible colorings of the boundary and showing Kempe chains can always make room.\n\nFor many configurations, this case analysis is astronomically complex—too many cases for human verification. This is where computers become essential.",
+    "significance": "critical",
+    "relatedConcepts": ["minimal counterexample", "configuration", "extendability"]
+  },
+  {
+    "id": "ann-unavoidability",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 205, "endLine": 218 },
+    "type": "concept",
+    "title": "Unavoidability: Covering All Planar Graphs",
+    "content": "A set S of configurations is **unavoidable** if every planar graph contains at least one configuration from S.\n\nThe proof uses **discharging**: assign each vertex an initial 'charge' (typically 6 - degree), then redistribute charges according to rules. The total charge is fixed by Euler's formula.\n\nBy carefully designed discharging rules, we can show that if no configuration from S appears, some vertex ends up with positive charge when it shouldn't. Contradiction!\n\nAppel-Haken's 1,936 configurations form an unavoidable set. Combined with their reducibility, this proves Four Color.",
+    "mathContext": "$\\forall G$ planar, $\\exists C \\in S$ with $C \\subseteq G$",
+    "significance": "critical",
+    "relatedConcepts": ["discharging method", "charge transfer", "averaging argument"]
+  },
+  {
+    "id": "ann-computer-verification",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 234, "endLine": 258 },
+    "type": "concept",
+    "title": "Computer-Assisted Proof",
+    "content": "The Appel-Haken proof (1976) required:\n- 1,200 hours of computer time\n- Verification of 1,936 configurations\n- 400+ pages of hand-written supporting proofs\n\nInitial reception was skeptical. How can we trust a proof no human can check? What if there's a bug in the program?\n\nGeorges Gonthier's 2005 Coq formalization addressed these concerns by reducing trust to a small, verified proof-checking kernel. The proof certificate is machine-checkable, and the checker itself is tiny enough to be human-verified.\n\nThis paradigm shift—from 'trust the program' to 'trust the proof checker'—has become foundational in formal methods.",
+    "significance": "key",
+    "relatedConcepts": ["Coq", "formal verification", "proof assistant"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 280, "endLine": 293 },
+    "type": "theorem",
+    "title": "The Four Color Theorem",
+    "content": "**Theorem:** Every planar graph is 4-colorable.\n\n**Proof structure:**\n1. Assume a minimal counterexample G exists (smallest non-4-colorable planar graph)\n2. By unavoidability, G contains some reducible configuration C\n3. By reducibility, we can simplify G to a smaller graph G'\n4. By minimality of G, the smaller G' is 4-colorable\n5. By reducibility, G' being 4-colorable means G is 4-colorable\n6. Contradiction! No minimal counterexample exists.\n\nTherefore, all planar graphs are 4-colorable.",
+    "mathContext": "$\\forall G$ planar, $\\chi(G) \\leq 4$",
+    "significance": "critical",
+    "prerequisites": ["ann-reducibility", "ann-unavoidability"],
+    "relatedConcepts": ["proof by contradiction", "well-founded induction"]
+  },
+  {
+    "id": "ann-philosophy",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 302, "endLine": 325 },
+    "type": "concept",
+    "title": "What Is a Proof?",
+    "content": "The Four Color Theorem forced mathematics to confront fundamental questions:\n\n**Can we trust computer proofs?** The 1976 proof relied on software that could have bugs. Many mathematicians were uncomfortable with a proof they couldn't personally verify.\n\n**Is machine verification better than human verification?** Gonthier's Coq formalization shifts trust to a small proof checker. Arguably, this is more reliable than human review of complex arguments.\n\n**Does beauty matter?** Mathematicians often seek 'elegant' proofs. Four Color has only an 'ugly' proof—massive case analysis. Does this diminish the result?\n\n**The future:** As mathematics grows more complex, computer assistance becomes essential. The question is how to maintain rigor, not whether to use computers.",
+    "significance": "key",
+    "relatedConcepts": ["philosophy of mathematics", "proof theory", "formal verification"]
+  },
+  {
+    "id": "ann-gonthier",
+    "proofId": "four-color-theorem",
+    "range": { "startLine": 249, "endLine": 255 },
+    "type": "insight",
+    "title": "Gonthier's Coq Formalization",
+    "content": "In 2005, Georges Gonthier completed a full formalization of the Four Color Theorem in Coq. This was a landmark achievement:\n\n- **Complete verification:** Every step machine-checked, including all 1,936 configurations\n- **Independent verification:** The Coq proof is a certificate anyone can verify using the proof checker\n- **Trust reduction:** We no longer trust Appel-Haken's program; we trust Coq's small kernel\n\nThe formalization took several person-years but provided certainty that the theorem is correct. It demonstrated that even massive computational proofs can be made rigorous through formal methods.",
+    "significance": "key",
+    "relatedConcepts": ["Coq proof assistant", "SSReflect", "proof certificate"]
+  }
+]

--- a/src/data/proofs/four-color-theorem/index.ts
+++ b/src/data/proofs/four-color-theorem/index.ts
@@ -1,0 +1,34 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from './source.lean?raw'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+export const fourColorTheoremProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const fourColorTheoremAnnotations: Annotation[] = annotationsJson as Annotation[]
+
+export const fourColorTheoremData: ProofData = {
+  proof: fourColorTheoremProof,
+  annotations: fourColorTheoremAnnotations,
+}

--- a/src/data/proofs/four-color-theorem/meta.json
+++ b/src/data/proofs/four-color-theorem/meta.json
@@ -1,0 +1,107 @@
+{
+  "id": "four-color-theorem",
+  "title": "Four Color Theorem",
+  "slug": "four-color-theorem",
+  "description": "Every planar map can be colored with at most four colors such that no adjacent regions share a color. First major theorem proved by computer (1976), the proof sparked debates about the nature of mathematical truth.",
+  "meta": {
+    "author": "Appel & Haken (formalized sketch in Lean 4)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Four_color_theorem",
+    "date": "1976",
+    "status": "pending",
+    "tags": ["graph-theory", "combinatorics", "computer-assisted-proof", "advanced"]
+  },
+  "overview": {
+    "historicalContext": "The Four Color Problem captivated mathematicians for over a century. First posed in 1852 by Francis Guthrie while coloring a map of England, it asked: can every map be colored with just four colors so that no two adjacent regions share the same color?\n\nMany attempted proofs failed. Alfred Kempe published a 'proof' in 1879 that stood for 11 years before Percy Heawood found a fatal flaw. In 1976, Kenneth Appel and Wolfgang Haken finally proved the theorem—but their proof required a computer to check 1,936 reducible configurations. This was the first major theorem proved with essential computer assistance, sparking philosophical debates: Is a proof humans cannot verify still a 'proof'?\n\nIn 2005, Georges Gonthier formalized the complete proof in Coq, providing a machine-verified certificate that settled remaining doubts about the computer calculations.",
+    "problemStatement": "**The Four Color Theorem:** Every planar graph $G$ is 4-colorable. Equivalently, every map on a plane or sphere can be colored with at most 4 colors such that no two adjacent regions share the same color.\n\nFormally: $\\chi(G) \\leq 4$ for every planar graph $G$, where $\\chi(G)$ is the chromatic number (minimum colors needed).",
+    "proofStrategy": "The proof combines two key ideas:\n\n1. **Reducibility:** Show that certain configurations cannot appear in a minimal counterexample. If a graph contains a reducible configuration, it can be simplified while preserving its 4-colorability status.\n\n2. **Unavoidability:** Prove that every planar graph must contain at least one configuration from a finite set of reducible configurations.\n\nTogether, these imply no minimal counterexample exists—thus all planar graphs are 4-colorable.\n\nThe challenge: the unavoidable set required checking 1,936 configurations, each requiring computer verification of reducibility. Gonthier's Coq formalization verified this exhaustively.",
+    "keyInsights": [
+      "The theorem is equivalent to showing every planar graph has chromatic number at most 4—graph coloring and map coloring are dual problems",
+      "Euler's formula (V - E + F = 2) constrains planar graph structure, guaranteeing vertices of low degree exist",
+      "The Kempe chain argument (swapping colors along alternating paths) is the key technique, though Kempe's original proof misapplied it",
+      "Reducibility proofs use discharging: redistributing a 'charge' among vertices to derive contradictions",
+      "Computer-assisted proofs raised foundational questions: What makes a proof 'acceptable' to the mathematical community?"
+    ]
+  },
+  "sections": [
+    {
+      "id": "introduction",
+      "title": "Introduction",
+      "startLine": 1,
+      "endLine": 23,
+      "summary": "Overview of the Four Color Theorem, its history from 1852 to 1976, and why it became a landmark in computer-assisted mathematics."
+    },
+    {
+      "id": "graph-theory-setup",
+      "title": "Graph Theory Foundations",
+      "startLine": 25,
+      "endLine": 52,
+      "summary": "Defining planar graphs, graph coloring, and the key concepts needed to state the theorem precisely."
+    },
+    {
+      "id": "euler-formula",
+      "title": "Euler's Formula",
+      "startLine": 54,
+      "endLine": 77,
+      "summary": "The fundamental constraint on planar graphs: V - E + F = 2, which forces every planar graph to have vertices of degree at most 5."
+    },
+    {
+      "id": "five-color-theorem",
+      "title": "The Five Color Theorem",
+      "startLine": 79,
+      "endLine": 120,
+      "summary": "A warm-up: proving every planar graph is 5-colorable using Kempe chains. This proof works; the difficulty is reducing 5 to 4."
+    },
+    {
+      "id": "kempe-chains",
+      "title": "Kempe Chains",
+      "startLine": 122,
+      "endLine": 155,
+      "summary": "The technique of swapping colors along alternating paths. Kempe's insight was correct, but his application to four colors was flawed."
+    },
+    {
+      "id": "reducibility",
+      "title": "Reducibility",
+      "startLine": 157,
+      "endLine": 195,
+      "summary": "A configuration is reducible if any planar graph containing it can be simplified while preserving 4-colorability. This is where computer verification becomes essential."
+    },
+    {
+      "id": "unavoidability",
+      "title": "Unavoidability",
+      "startLine": 197,
+      "endLine": 230,
+      "summary": "Using discharging to prove every planar graph contains at least one reducible configuration from a finite set."
+    },
+    {
+      "id": "computer-verification",
+      "title": "Computer Verification",
+      "startLine": 232,
+      "endLine": 265,
+      "summary": "How Appel-Haken's 1976 proof and Gonthier's 2005 Coq formalization verified 1,936 configurations exhaustively."
+    },
+    {
+      "id": "main-theorem",
+      "title": "The Main Theorem",
+      "startLine": 267,
+      "endLine": 295,
+      "summary": "Combining unavoidability and reducibility to conclude: no minimal counterexample exists, so all planar graphs are 4-colorable."
+    },
+    {
+      "id": "philosophical-implications",
+      "title": "Philosophical Implications",
+      "startLine": 297,
+      "endLine": 330,
+      "summary": "The debate over computer-assisted proofs: can we trust what we cannot humanly verify? How Gonthier's formalization addressed these concerns."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Four Color Theorem demonstrates that every planar map can be colored with at most four colors such that no adjacent regions share a color. Its proof, requiring computer verification of nearly 2,000 configurations, marked a turning point in the philosophy of mathematics.",
+    "implications": "The theorem's proof challenged traditional notions of mathematical proof. Appel and Haken's 1976 work was initially met with skepticism—how can we trust a proof no human can fully check? Gonthier's 2005 Coq formalization provided a different kind of certainty: instead of trusting a fallible computer program, we now trust a small, verified proof-checking kernel. This approach—using formal verification to establish trust in complex proofs—has become increasingly important in both mathematics and software engineering.",
+    "openQuestions": [
+      "Is there a 'human-readable' proof of the Four Color Theorem that doesn't require computer case analysis?",
+      "Can the set of unavoidable reducible configurations be significantly reduced?",
+      "What other long-standing conjectures might yield to computer-assisted proof techniques?",
+      "As formal verification matures, will machine-checked proofs become the standard for publication in mathematics?"
+    ]
+  }
+}

--- a/src/data/proofs/four-color-theorem/source.lean
+++ b/src/data/proofs/four-color-theorem/source.lean
@@ -1,0 +1,371 @@
+/-
+  The Four Color Theorem
+
+  Every planar graph can be colored with at most four colors such that
+  no two adjacent vertices share the same color.
+
+  This formalization presents the key conceptual components of the proof:
+  1. Planar graphs and colorability
+  2. Euler's formula for planar graphs
+  3. The Five Color Theorem (a tractable warm-up)
+  4. Kempe chains and color swapping
+  5. Reducibility and unavoidability
+  6. The main theorem
+
+  This is an illustrative proof sketch. The complete proof (Appel-Haken 1976,
+  Gonthier 2005) requires computer verification of 1,936 configurations.
+
+  Historical note: First posed in 1852, proved in 1976, and formally
+  verified in Coq in 2005 by Georges Gonthier.
+-/
+
+namespace FourColor
+
+-- ============================================================
+-- PART 1: Graph Theory Foundations
+-- ============================================================
+
+-- A graph is a set of vertices with edges between them
+structure Graph where
+  Vertex : Type
+  Edge : Vertex → Vertex → Prop
+  edge_symm : ∀ u v, Edge u v → Edge v u
+
+-- A coloring assigns colors to vertices
+def Coloring (G : Graph) (k : Nat) := G.Vertex → Fin k
+
+-- A coloring is proper if adjacent vertices have different colors
+def ProperColoring (G : Graph) (k : Nat) (c : Coloring G k) : Prop :=
+  ∀ u v, G.Edge u v → c u ≠ c v
+
+-- A graph is k-colorable if it admits a proper k-coloring
+def Colorable (G : Graph) (k : Nat) : Prop :=
+  ∃ c : Coloring G k, ProperColoring G k c
+
+-- The chromatic number is the minimum k for which G is k-colorable
+noncomputable def chromaticNumber (G : Graph) : Nat :=
+  Nat.find (⟨G.Vertex → Fin (Nat.card G.Vertex + 1),
+    sorry⟩ : ∃ k, Colorable G k)
+
+-- ============================================================
+-- PART 2: Planar Graphs
+-- ============================================================
+
+-- A graph is planar if it can be embedded in the plane without edge crossings
+-- We axiomatize this property
+axiom Planar : Graph → Prop
+
+-- Planarity is preserved under subgraphs
+axiom planar_subgraph : ∀ G H, Planar G → (∀ v, H.Vertex = G.Vertex) →
+  (∀ u v, H.Edge u v → G.Edge u v) → Planar H
+
+-- ============================================================
+-- PART 3: Euler's Formula
+-- ============================================================
+
+-- For a connected planar graph: V - E + F = 2
+-- where V = vertices, E = edges, F = faces (including outer face)
+
+-- Count of vertices, edges, and faces for a finite planar graph
+axiom vertexCount : Graph → Nat
+axiom edgeCount : Graph → Nat
+axiom faceCount : Graph → Nat
+
+-- Euler's formula for connected planar graphs
+axiom euler_formula : ∀ G, Planar G →
+  vertexCount G - edgeCount G + faceCount G = 2
+
+-- Key consequence: every planar graph has a vertex of degree ≤ 5
+-- This follows from Euler's formula via an averaging argument
+
+-- Degree of a vertex (number of neighbors)
+noncomputable def degree (G : Graph) (v : G.Vertex) : Nat := sorry
+
+-- Every planar graph with at least one vertex has a vertex of degree ≤ 5
+axiom exists_low_degree_vertex : ∀ G, Planar G →
+  (∃ _ : G.Vertex, True) → ∃ v : G.Vertex, degree G v ≤ 5
+
+-- ============================================================
+-- PART 4: The Five Color Theorem (Warm-up)
+-- ============================================================
+
+/-
+  The Five Color Theorem is much easier to prove than Four Color.
+  We prove it by induction on vertices:
+
+  Base case: The empty graph is trivially 5-colorable.
+
+  Inductive step: Given a planar graph G with n vertices:
+  1. Find a vertex v of degree ≤ 5 (guaranteed by Euler)
+  2. Remove v to get G' with n-1 vertices
+  3. By induction, G' is 5-colorable
+  4. Restore v: it has ≤ 5 neighbors, using ≤ 5 colors
+  5. Since we have 5 colors and ≤ 5 neighbors, one color is always free
+-/
+
+-- Graph with a vertex removed
+axiom removeVertex : (G : Graph) → G.Vertex → Graph
+
+-- Removing a vertex preserves planarity
+axiom remove_preserves_planar : ∀ G v, Planar G → Planar (removeVertex G v)
+
+-- Five Color Theorem
+theorem five_color_theorem : ∀ G, Planar G → Colorable G 5 := by
+  intro G hPlanar
+  -- Proof by strong induction on number of vertices
+  -- For each vertex v of degree ≤ 5:
+  --   Remove v, color the rest by induction
+  --   Since v has ≤ 5 neighbors and we have 5 colors,
+  --   at least one color is available for v
+  sorry
+
+-- ============================================================
+-- PART 5: Kempe Chains
+-- ============================================================
+
+/-
+  Kempe's brilliant idea: given a proper coloring, we can "swap" colors
+  along connected components of vertices using two colors.
+
+  A Kempe chain for colors a and b starting at vertex v is the maximal
+  connected component of vertices colored a or b that contains v.
+
+  Swapping a ↔ b on a Kempe chain produces another proper coloring.
+
+  This technique is key to both the Five and Four Color theorems,
+  but Kempe's original application to Four Colors was flawed.
+-/
+
+-- A Kempe chain is a path of alternating colors
+structure KempeChain (G : Graph) (k : Nat) (c : Coloring G k) where
+  color1 : Fin k
+  color2 : Fin k
+  vertices : List G.Vertex
+  colors_differ : color1 ≠ color2
+  alternating : ∀ v ∈ vertices, c v = color1 ∨ c v = color2
+  connected : ∀ i, i + 1 < vertices.length →
+    G.Edge (vertices.get ⟨i, sorry⟩) (vertices.get ⟨i + 1, sorry⟩)
+
+-- Swapping colors on a Kempe chain preserves properness
+axiom kempe_swap_proper : ∀ G k (c : Coloring G k) (chain : KempeChain G k c),
+  ProperColoring G k c →
+  ∃ c', ProperColoring G k c' ∧
+    (∀ v ∈ chain.vertices,
+      (c v = chain.color1 → c' v = chain.color2) ∧
+      (c v = chain.color2 → c' v = chain.color1)) ∧
+    (∀ v, v ∉ chain.vertices → c' v = c v)
+
+-- ============================================================
+-- PART 6: Reducibility
+-- ============================================================
+
+/-
+  A configuration C is REDUCIBLE if:
+  Whenever C appears in a planar graph G, we can conclude G is 4-colorable
+  without directly coloring G.
+
+  Specifically: if G contains C, we can find a smaller graph G' such that
+  any 4-coloring of G' extends to a 4-coloring of G (possibly with
+  Kempe chain adjustments).
+
+  Checking reducibility requires case analysis of how colorings extend.
+  For the Four Color Theorem, this analysis is too complex for humans
+  and required computer verification.
+-/
+
+-- A configuration is a small graph pattern
+structure Configuration where
+  pattern : Graph
+  boundary : List pattern.Vertex  -- vertices connected to rest of graph
+
+-- A configuration is reducible if it can always be eliminated
+-- in the search for a minimal counterexample
+def Reducible (C : Configuration) : Prop :=
+  ∀ G, Planar G →
+    -- If G contains C...
+    (∃ embed : C.pattern.Vertex → G.Vertex,
+      ∀ u v, C.pattern.Edge u v → G.Edge (embed u) (embed v)) →
+    -- Then G is 4-colorable
+    Colorable G 4
+
+-- Key fact: there exists a set of 1,936 reducible configurations
+-- (verified by computer in Appel-Haken and formalized by Gonthier)
+axiom reducible_configurations : List Configuration
+axiom all_reducible : ∀ C ∈ reducible_configurations, Reducible C
+
+-- ============================================================
+-- PART 7: Unavoidability
+-- ============================================================
+
+/-
+  A set S of configurations is UNAVOIDABLE if every planar graph
+  contains at least one configuration from S.
+
+  The proof uses "discharging": assign initial charges to vertices
+  based on degree, then redistribute charges according to rules.
+  The total charge is fixed by Euler's formula. If we can show the
+  final charge implies some configuration must exist, we're done.
+
+  Appel and Haken showed their 1,936 configurations are unavoidable.
+-/
+
+def Unavoidable (configs : List Configuration) : Prop :=
+  ∀ G, Planar G → ∃ C ∈ configs,
+    ∃ embed : C.pattern.Vertex → G.Vertex,
+      ∀ u v, C.pattern.Edge u v → G.Edge (embed u) (embed v)
+
+-- The discharging method proves unavoidability
+-- Initial charge: 6 - degree(v) for each vertex
+-- Discharging rules redistribute charge while preserving total
+-- Final analysis shows some reducible configuration must appear
+
+axiom unavoidable_set : Unavoidable reducible_configurations
+
+-- ============================================================
+-- PART 8: Computer Verification
+-- ============================================================
+
+/-
+  The Appel-Haken proof (1976) required:
+  - 1,200 hours of computer time
+  - Verification of 1,936 configurations
+  - 400+ pages of hand verification for discharging rules
+
+  Many mathematicians were skeptical: How do we know the program is correct?
+
+  Georges Gonthier's Coq formalization (2005) addressed this:
+  - Every step machine-checked by Coq's small trusted kernel
+  - The proof itself is a certificate anyone can verify
+  - Reduced trust from "large program" to "small proof checker"
+
+  This established a new paradigm: formal proof as the gold standard
+  for complex mathematical theorems.
+-/
+
+-- We axiomatize that the computer verification was successful
+axiom computer_verified_reducibility :
+  ∀ C ∈ reducible_configurations, Reducible C
+
+axiom computer_verified_unavoidability :
+  Unavoidable reducible_configurations
+
+-- ============================================================
+-- PART 9: The Four Color Theorem
+-- ============================================================
+
+/-
+  Main argument by contradiction:
+
+  1. Suppose there exists a non-4-colorable planar graph
+  2. Take a minimal counterexample G (fewest vertices)
+  3. By unavoidability, G contains some reducible configuration C
+  4. By reducibility of C, G can be simplified to G'
+  5. G' is smaller, so by minimality, G' is 4-colorable
+  6. But reducibility means G' being 4-colorable implies G is 4-colorable
+  7. Contradiction!
+
+  Therefore, all planar graphs are 4-colorable.
+-/
+
+-- A minimal counterexample (if it existed)
+def MinimalCounterexample (G : Graph) : Prop :=
+  Planar G ∧ ¬Colorable G 4 ∧
+  ∀ G', Planar G' → vertexCount G' < vertexCount G → Colorable G' 4
+
+-- No minimal counterexample exists
+theorem no_minimal_counterexample : ¬∃ G, MinimalCounterexample G := by
+  intro ⟨G, hMin⟩
+  -- G contains some unavoidable configuration C
+  have ⟨C, hC_in, embed, hEmbed⟩ := unavoidable_set G hMin.1
+  -- C is reducible
+  have hRed := all_reducible C hC_in
+  -- Therefore G is 4-colorable
+  have hCol := hRed G hMin.1 ⟨embed, hEmbed⟩
+  -- Contradiction with ¬Colorable G 4
+  exact hMin.2.1 hCol
+
+-- The Four Color Theorem
+theorem four_color_theorem : ∀ G, Planar G → Colorable G 4 := by
+  intro G hPlanar
+  -- By well-founded induction on vertex count
+  -- If G is not 4-colorable, find minimal counterexample
+  -- But no minimal counterexample exists (proved above)
+  by_contra h
+  -- Take minimal counterexample in the class of non-4-colorable planar graphs
+  sorry -- Requires well-founded induction setup
+
+-- Stated in terms of chromatic number
+theorem chromatic_number_at_most_four : ∀ G, Planar G → chromaticNumber G ≤ 4 := by
+  intro G hPlanar
+  have h := four_color_theorem G hPlanar
+  sorry -- chromaticNumber definition implies this
+
+-- ============================================================
+-- PART 10: Philosophical Implications
+-- ============================================================
+
+/-
+  The Four Color Theorem raised profound questions:
+
+  1. WHAT IS A PROOF?
+     Traditional proofs can be surveyed by humans. The Four Color proof
+     cannot—it essentially relies on computer verification. Is this still
+     mathematics?
+
+  2. TRUST AND VERIFICATION
+     We trust the proof because we trust the computer program. But programs
+     have bugs. Gonthier's Coq formalization shifts trust to a smaller
+     kernel: the proof checker itself.
+
+  3. FORMALIZATION AS FOUNDATION
+     Rather than trusting informal arguments or large programs, we can
+     trust machine-checked formal proofs. The proof *is* the certificate.
+
+  4. THE FUTURE OF MATHEMATICS
+     As theorems grow more complex, computer assistance becomes essential.
+     The question is not whether to use computers, but how to ensure
+     correctness. Formal verification provides one answer.
+
+  5. BEAUTY VS TRUTH
+     Many mathematicians hoped for an "elegant" proof of Four Color.
+     The computer-assisted proof is undeniably ugly but undeniably correct.
+     Does mathematical aesthetics matter if we have certainty?
+-/
+
+-- ============================================================
+-- PART 11: Summary
+-- ============================================================
+
+/-
+  The Proof in a Nutshell:
+
+  1. EULER'S CONSTRAINT: Planar graphs have structural limitations
+     (every planar graph has a vertex of degree ≤ 5)
+
+  2. FIVE COLORS: Easy by induction—always one spare color
+
+  3. FOUR COLORS: Kempe chains help, but don't quite work
+     (Kempe's 1879 "proof" was flawed)
+
+  4. REDUCIBILITY: Certain configurations can be eliminated from
+     any minimal counterexample
+
+  5. UNAVOIDABILITY: Every planar graph contains at least one
+     reducible configuration (proved by discharging)
+
+  6. COMPUTER VERIFICATION: Both reducibility and unavoidability
+     require checking 1,936 configurations by computer
+
+  7. CONCLUSION: No minimal counterexample exists, so every
+     planar graph is 4-colorable
+
+  The genius was combining classical graph theory with computational
+  muscle—and later, with formal verification to ensure correctness.
+-/
+
+end FourColor
+
+-- Final type check of the main theorems
+#check @FourColor.four_color_theorem
+#check @FourColor.five_color_theorem
+#check @FourColor.no_minimal_counterexample

--- a/src/data/proofs/index.ts
+++ b/src/data/proofs/index.ts
@@ -7,6 +7,7 @@ import { fundamentalTheoremCalculusData } from './fundamental-theorem-calculus'
 import { fundamentalTheoremAlgebraData } from './fundamental-theorem-algebra'
 import { godelIncompletenessData } from './godel-incompleteness'
 import { pythagoreanTheoremData } from './pythagorean-theorem'
+import { fourColorTheoremData } from './four-color-theorem'
 import type { ProofData } from '@/types/proof'
 
 export const proofs: Record<string, ProofData> = {
@@ -19,6 +20,7 @@ export const proofs: Record<string, ProofData> = {
   'fundamental-theorem-algebra': fundamentalTheoremAlgebraData,
   'godel-incompleteness': godelIncompletenessData,
   'pythagorean-theorem': pythagoreanTheoremData,
+  'four-color-theorem': fourColorTheoremData,
 }
 
 export function getProof(slug: string): ProofData | undefined {


### PR DESCRIPTION
## Summary

Adds the Four Color Theorem proof to Lean Genius. This theorem states that every planar map can be colored with at most four colors such that no adjacent regions share a color.

## Changes

- Created `src/data/proofs/four-color-theorem/` with:
  - `meta.json` - Comprehensive metadata with historical context, proof strategy, and key insights
  - `source.lean` - Lean 4 proof sketch covering graph coloring, planarity, Euler's formula, Kempe chains, reducibility, unavoidability, and the main theorem
  - `annotations.json` - Rich annotations explaining the theorem's significance and the computer-assisted proof debate
  - `index.ts` - Export file for the proof data
- Updated `src/data/proofs/index.ts` to include the Four Color Theorem
- Updated `PROOFS_ROADMAP.md` to add the theorem to the Current Proofs table

## Historical Significance

The Four Color Theorem was:
- First major theorem proved by computer (Appel & Haken, 1976)
- Required verification of 1,936 reducible configurations
- Formally verified in Coq by Georges Gonthier (2005)
- Sparked debates about the nature of mathematical proof

## Test Plan

- [x] TypeScript type check passes
- [x] Build completes successfully
- [x] Proof exports correctly in the proofs index

Closes #10