### PR TITLE
Complete Fundamental Theorem of Algebra proof (4 sorries)

### DIFF
--- a/proofs/Proofs/FundamentalTheoremAlgebra.lean
+++ b/proofs/Proofs/FundamentalTheoremAlgebra.lean
@@ -67,7 +67,23 @@ theorem fundamental_theorem_of_algebra {p : ℂ[X]} (hp : 0 < degree p) :
 theorem no_roots_implies_constant {p : ℂ[X]} (h : ∀ z : ℂ, ¬IsRoot p z) :
     degree p = 0 := by
   -- If degree > 0, then by FTA there's a root, contradicting h
-  sorry
+  by_contra hp
+  -- We need to show 0 < degree p to apply FTA
+  have hp_pos : 0 < degree p := by
+    rcases eq_or_ne p 0 with rfl | hp_ne
+    · -- If p = 0, every z is a root: IsRoot 0 z ↔ eval z 0 = 0 ↔ True
+      simp [IsRoot] at h
+    · -- p ≠ 0, so degree p = natDegree p ≥ 0
+      -- Since degree p ≠ 0 (from hp), we have degree p > 0
+      rw [Polynomial.degree_eq_natDegree hp_ne]
+      have hnd : natDegree p ≠ 0 := by
+        intro hzero
+        rw [Polynomial.degree_eq_natDegree hp_ne, hzero] at hp
+        simp at hp
+      exact WithBot.coe_pos.mpr (Nat.pos_of_ne_zero hnd)
+  -- By FTA, there exists a root
+  obtain ⟨z, hz⟩ := Complex.exists_root hp_pos
+  exact h z hz
 
 /-
   Algebraic Closure
@@ -99,15 +115,30 @@ theorem splits_over_complex (p : ℂ[X]) : Splits (RingHom.id ℂ) p :=
 
 -- The number of roots equals the degree (for non-zero polynomials)
 -- In an algebraically closed field, a polynomial of degree n has exactly n roots
-theorem card_roots_eq_degree {p : ℂ[X]} (hp : p ≠ 0) :
+theorem card_roots_eq_degree {p : ℂ[X]} (_hp : p ≠ 0) :
     Multiset.card (roots p) = natDegree p := by
-  sorry  -- Requires full theory of algebraically closed fields
+  -- In an algebraically closed field, a polynomial splits completely
+  have hsplit : Splits (RingHom.id ℂ) p := IsAlgClosed.splits_codomain p
+  -- For a polynomial that splits, the number of roots equals the natDegree
+  have h := Polynomial.natDegree_eq_card_roots hsplit
+  -- map (RingHom.id ℂ) p = p, so roots are the same
+  simp only [Polynomial.map_id] at h
+  exact h.symm
 
 -- Every monic polynomial equals the product of (X - root) over its roots
 -- This is the complete factorization theorem for algebraically closed fields
 theorem monic_prod_roots {p : ℂ[X]} (hp : Monic p) :
     p = ((roots p).map (fun r => X - C r)).prod := by
-  sorry  -- Requires full factorization theory
+  -- For a monic polynomial over an algebraically closed field,
+  -- p = prod (X - r) over all roots r
+  have hsplit : Splits (RingHom.id ℂ) p := IsAlgClosed.splits_codomain p
+  -- Get the root count equality
+  have hcard : Multiset.card (roots p) = natDegree p := by
+    have h := Polynomial.natDegree_eq_card_roots hsplit
+    simp only [Polynomial.map_id] at h
+    exact h.symm
+  -- Use Mathlib's theorem: monic polynomial equals product of linear factors
+  exact (Polynomial.prod_multiset_X_sub_C_of_monic_of_roots_card_eq hp hcard).symm
 
 /-
   Why This Matters
@@ -130,9 +161,37 @@ theorem monic_prod_roots {p : ℂ[X]} (hp : Monic p) :
 -- This follows directly from the fundamental theorem
 theorem quadratic_has_root (a b c : ℂ) (ha : a ≠ 0) :
     ∃ z : ℂ, a * z ^ 2 + b * z + c = 0 := by
-  -- The polynomial a*X² + b*X + c has degree 2 (since a ≠ 0)
-  -- so by FTA it has a root
-  sorry
+  -- Construct the polynomial p(X) = a*X² + b*X + c
+  let p : ℂ[X] := C a * X ^ 2 + C b * X + C c
+  -- Show degree p = 2 (since a ≠ 0)
+  have hdeg : degree p = 2 := by
+    have h1 : degree (C a * X ^ 2) = 2 := by
+      simp only [← mul_comm (X ^ 2) (C a), degree_mul, degree_C ha, degree_X_pow, zero_add]
+      rfl
+    have h2 : degree (C b * X + C c) < degree (C a * X ^ 2) := by
+      have hbx : degree (C b * X) ≤ 1 := by
+        rcases eq_or_ne b 0 with rfl | hb
+        · simp [degree_zero]
+        · simp only [← mul_comm X (C b), degree_mul, degree_C hb, degree_X, zero_add]
+          rfl
+      have hc : degree (C c) ≤ 0 := degree_C_le
+      calc degree (C b * X + C c) ≤ max (degree (C b * X)) (degree (C c)) := degree_add_le _ _
+        _ ≤ max 1 0 := max_le_max hbx hc
+        _ = 1 := by rfl
+        _ < 2 := by norm_num
+        _ = degree (C a * X ^ 2) := h1.symm
+    -- p = C a * X ^ 2 + (C b * X + C c)
+    have hassoc : p = C a * X ^ 2 + (C b * X + C c) := by ring
+    calc degree p = degree (C a * X ^ 2 + (C b * X + C c)) := by rw [hassoc]
+      _ = degree (C a * X ^ 2) := degree_add_eq_left_of_degree_lt h2
+      _ = 2 := h1
+  -- Apply FTA: degree > 0 implies existence of root
+  have hpos : 0 < degree p := by rw [hdeg]; norm_num
+  obtain ⟨z, hz⟩ := Complex.exists_root hpos
+  use z
+  -- Unfold the polynomial evaluation
+  simp only [IsRoot, eval_add, eval_mul, eval_pow, eval_X, eval_C, p] at hz
+  exact hz
 
 end FundamentalTheoremAlgebra
 


### PR DESCRIPTION
## Summary
- Completed 4 sorries in `Proofs/FundamentalTheoremAlgebra.lean`:
  - `no_roots_implies_constant`: Contrapositive of FTA - if no roots, degree = 0
  - `card_roots_eq_degree`: Number of roots equals natDegree for non-zero polynomials
  - `monic_prod_roots`: Complete factorization theorem for monic polynomials
  - `quadratic_has_root`: Every quadratic equation has a complex root

## Test plan
- [x] `lake build Proofs.FundamentalTheoremAlgebra` compiles successfully
- [x] All 4 sorries replaced with complete proofs
- [x] Proofs use existing Mathlib infrastructure (IsAlgClosed, splits_codomain)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)