### PR TITLE
Define proof badge taxonomy and metadata format

### DIFF
--- a/proofs/BADGE_TAXONOMY.md
+++ b/proofs/BADGE_TAXONOMY.md
@@ -1,0 +1,137 @@
+# Proof Badge Taxonomy
+
+This document defines the badge system for categorizing proofs in Lean Genius based on their relationship to Mathlib and their pedagogical purpose.
+
+## Badge Categories
+
+| Badge ID | Display Name | Emoji | Color | Description |
+|----------|--------------|-------|-------|-------------|
+| `original` | Original Proof | 🏆 | Gold (#F59E0B) | Novel formalization with minimal Mathlib delegation. The main theorem is proven from first principles or with a unique approach. |
+| `mathlib-exploration` | Mathlib Exploration | 📚 | Blue (#3B82F6) | Uses Mathlib for the main theorem, but provides valuable extensions, corollaries, or pedagogical presentation. |
+| `pedagogical` | Learning Example | 🎓 | Green (#10B981) | Focused on teaching Lean techniques, syntax, or proof patterns. May be simple by design. |
+| `from-axioms` | From Axioms | ⚡ | Purple (#8B5CF6) | Proves from first principles with no or minimal imports. Demonstrates foundational reasoning. |
+| `wip` | Work in Progress | 🚧 | Orange (#F97316) | Has `sorry` statements or incomplete sections. Under active development. |
+
+## Badge Selection Criteria
+
+### 🏆 Original Proof
+Use when:
+- The main theorem is NOT directly imported from Mathlib
+- The proof approach is novel or differs from Mathlib's
+- Minimal delegation to existing theorems
+
+Examples: `CantorDiagonalization`, `HaltingProblem`, `InfinitudePrimes`, `PythagoreanTheorem`
+
+### 📚 Mathlib Exploration
+Use when:
+- The main theorem comes from Mathlib (e.g., `Complex.exists_root`)
+- The file proves useful corollaries or extensions
+- Provides pedagogical value in how to USE Mathlib
+
+Examples: `FundamentalTheoremAlgebra`, `EulerIdentity`, `Sqrt2Irrational`
+
+### 🎓 Learning Example
+Use when:
+- Primary purpose is teaching Lean syntax or concepts
+- Proof complexity is intentionally low
+- Demonstrates specific proof techniques or patterns
+
+Examples: `OnePlusOne`, `Sqrt2`
+
+### ⚡ From Axioms
+Use when:
+- No imports or only `Tactic` imports
+- Builds all definitions from scratch
+- Demonstrates what Mathlib abstracts away
+
+Examples: `HaltingProblem` (no imports), `OnePlusOne` (Peano construction)
+
+### 🚧 Work in Progress
+Use when:
+- File contains `sorry` statements
+- Proof is incomplete or partial
+- Under active development
+
+Examples: `BorsukUlam`, `BrouwerFixedPoint`, `FourColorTheorem`
+
+## Metadata Schema
+
+Each proof's `meta.json` should include badge information:
+
+```json
+{
+  "meta": {
+    "status": "verified",
+    "tags": ["algebra", "complex-analysis"],
+    "badge": "mathlib-exploration",
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.exists_root",
+        "description": "Every non-constant complex polynomial has a root",
+        "module": "Mathlib.Analysis.Complex.Polynomial.Basic"
+      }
+    ],
+    "sorries": 0,
+    "originalContributions": [
+      "Contrapositive formulation (no_roots_implies_constant)",
+      "Complete factorization theorem (monic_prod_roots)"
+    ]
+  }
+}
+```
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `badge` | `BadgeType` | One of the badge IDs above |
+| `sorries` | `number` | Count of `sorry` statements in the Lean file |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mathlibDependencies` | `MathlibDependency[]` | Key theorems imported from Mathlib |
+| `originalContributions` | `string[]` | What this proof adds beyond Mathlib |
+
+## UI Display
+
+Badges should be displayed:
+1. **Prominently on proof cards** - Top corner or header
+2. **Filterable in proof list** - Users can filter by badge type
+3. **With tooltip explanation** - Hover shows badge meaning
+4. **Color-coded** - Visual distinction between categories
+
+## Philosophy
+
+Lean Genius aims to be:
+
+1. **Honest** - We clearly show what comes from Mathlib vs. what's original
+2. **Educational** - Badges help users find proofs matching their learning goals
+3. **Valuable** - We don't just wrap Mathlib; we teach how to use it effectively
+4. **Transparent** - Sorries and WIP status are clearly marked, not hidden
+
+## Examples by Badge
+
+### 🏆 Original Proofs
+- **Cantor's Diagonalization** - Complete diagonal argument without Mathlib's set theory
+- **Halting Problem** - Self-contained with zero imports
+- **Infinitude of Primes** - Euclid's proof using basic Mathlib
+
+### 📚 Mathlib Explorations
+- **Fundamental Theorem of Algebra** - Uses `Complex.exists_root`, proves corollaries
+- **Euler's Identity** - Uses `Complex.exp_pi_mul_I`, demonstrates special functions
+- **√2 Irrational** - Uses `irrational_sqrt_two`, shows proof techniques
+
+### 🎓 Learning Examples
+- **1+1=2** - Peano arithmetic fundamentals
+- **Basic Sqrt2** - Minimal proof template
+
+### ⚡ From Axioms
+- **Halting Problem** - Pure logic, no imports
+- **1+1=2 (Peano section)** - Builds natural numbers manually
+
+### 🚧 Work in Progress
+- **Borsuk-Ulam** - 3 sorries (requires algebraic topology)
+- **Four Color Theorem** - 5 sorries (requires computer verification)
+- **Navier-Stokes** - Partial formalization of millennium problem

--- a/src/data/proofs/borsuk-ulam/meta.json
+++ b/src/data/proofs/borsuk-ulam/meta.json
@@ -9,7 +9,26 @@
     "date": "1933",
     "status": "verified",
     "proofRepoPath": "Proofs/BorsukUlam.lean",
-    "tags": ["topology", "algebraic-topology", "covering-spaces", "advanced"]
+    "tags": ["topology", "algebraic-topology", "covering-spaces", "advanced"],
+    "badge": "wip",
+    "sorries": 3,
+    "mathlibDependencies": [
+      {
+        "theorem": "Topology.Basic",
+        "description": "Foundational topology definitions",
+        "module": "Mathlib.Topology.Basic"
+      },
+      {
+        "theorem": "Analysis.InnerProductSpace",
+        "description": "Inner product space and norm definitions",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Proof structure and logical framework",
+      "Gadget function construction",
+      "Connection to covering spaces (outlined)"
+    ]
   },
   "overview": {
     "historicalContext": "The Borsuk-Ulam theorem was conjectured by Stanislaw Ulam and proved by Karol Borsuk in 1933. It emerged from the Polish school of topology and quickly became one of the most celebrated results in algebraic topology.\n\nThe theorem has a beautifully intuitive interpretation: at any given moment, there exist two antipodal points on Earth (opposite ends of a diameter) that have exactly the same temperature AND the same atmospheric pressure. This 'weather interpretation' makes abstract topology tangible.\n\nWhat makes Borsuk-Ulam remarkable is its wide range of applications. In 1978, Laszlo Lovasz used it to prove Kneser's conjecture about graph coloring, launching the field of topological combinatorics. It also implies the Ham Sandwich Theorem (any n objects in n-dimensional space can be simultaneously bisected by a single hyperplane) and has applications to fair division problems.",

--- a/src/data/proofs/cantor-diagonalization/meta.json
+++ b/src/data/proofs/cantor-diagonalization/meta.json
@@ -7,7 +7,21 @@
     "author": "Georg Cantor (1891)",
     "date": "1891",
     "status": "verified",
-    "tags": ["set-theory", "infinity", "cardinality", "classic", "intermediate"]
+    "tags": ["set-theory", "infinity", "cardinality", "classic", "intermediate"],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Logic.Function.Basic",
+        "description": "Basic function definitions and properties",
+        "module": "Mathlib.Logic.Function.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Complete diagonal argument formalization",
+      "Power set generalization (cantor_powerset)",
+      "Connection to Russell's Paradox"
+    ]
   },
   "overview": {
     "historicalContext": "Georg Cantor published this proof in 1891, though he had already proven the uncountability of the reals in 1874 using a different argument. The diagonal method proved far more influential, becoming a fundamental technique in logic, computability theory, and mathematics.\n\nCantor's work was revolutionary and controversial. The idea that there could be different 'sizes' of infinity challenged centuries of mathematical intuition. Leopold Kronecker famously opposed Cantor's work, but David Hilbert declared: 'No one shall expel us from the paradise that Cantor has created.'\n\nThe diagonal argument's influence extends far beyond set theory. Alan Turing used a diagonal construction to prove the undecidability of the halting problem (1936). Kurt Godel used diagonalization in his incompleteness theorems (1931). The technique appears throughout theoretical computer science in proofs about computational limits.",

--- a/src/data/proofs/fundamental-theorem-algebra/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra/meta.json
@@ -8,7 +8,32 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_algebra",
     "date": "1799",
     "status": "verified",
-    "tags": ["algebra", "complex-analysis", "polynomials", "algebraic-closure", "intermediate"]
+    "tags": ["algebra", "complex-analysis", "polynomials", "algebraic-closure", "intermediate"],
+    "badge": "mathlib-exploration",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.exists_root",
+        "description": "Every non-constant complex polynomial has at least one root",
+        "module": "Mathlib.Analysis.Complex.Polynomial.Basic"
+      },
+      {
+        "theorem": "IsAlgClosed.splits_codomain",
+        "description": "Polynomials over algebraically closed fields split completely",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic"
+      },
+      {
+        "theorem": "Polynomial.natDegree_eq_card_roots",
+        "description": "For split polynomials, degree equals number of roots",
+        "module": "Mathlib.Algebra.Polynomial.Splits"
+      }
+    ],
+    "originalContributions": [
+      "no_roots_implies_constant - contrapositive formulation of FTA",
+      "card_roots_eq_degree - root counting theorem",
+      "monic_prod_roots - complete factorization theorem",
+      "quadratic_has_root - explicit quadratic case"
+    ]
   },
   "overview": {
     "historicalContext": "The Fundamental Theorem of Algebra has a fascinating history spanning centuries. First conjectured by Albert Girard in 1629, it was attempted by many great mathematicians including d'Alembert, Euler, and Lagrange. Carl Friedrich Gauss provided the first rigorous proof in his 1799 doctoral dissertation, though he would go on to publish three more proofs throughout his career.\n\nDespite its name, the theorem is fundamentally analytic rather than algebraic. Every known proof relies on some completeness property of the real numbers - whether through analysis, topology, or complex function theory. The proof in Mathlib uses Liouville's theorem from complex analysis: a bounded entire function must be constant.",

--- a/src/data/proofs/halting-problem/meta.json
+++ b/src/data/proofs/halting-problem/meta.json
@@ -7,7 +7,15 @@
     "author": "Alan Turing (1936)",
     "date": "1936",
     "status": "verified",
-    "tags": ["computability", "undecidability", "diagonalization", "classic", "intermediate"]
+    "tags": ["computability", "undecidability", "diagonalization", "classic", "intermediate"],
+    "badge": "from-axioms",
+    "sorries": 0,
+    "mathlibDependencies": [],
+    "originalContributions": [
+      "Complete proof with zero imports",
+      "Self-contained formalization of diagonal argument",
+      "Demonstrates pure logical reasoning in Lean"
+    ]
   },
   "overview": {
     "historicalContext": "Alan Turing published this groundbreaking result in 1936, the same paper where he introduced the Turing machine model of computation. Working independently from Alonzo Church (who proved an equivalent result using lambda calculus), Turing established that there are fundamental limits to what can be computed.\n\nThe halting problem was the first concrete example of an undecidable problem, and it remains the canonical example in computer science education. The proof technique - diagonalization - connects deeply to Cantor's work on uncountability (1891) and Godel's incompleteness theorems (1931).\n\nThe practical implications are profound: no static analysis tool can perfectly detect all infinite loops, no compiler can optimize away all non-terminating code, and no verification system can automatically prove termination for all programs.",

--- a/src/types/proof.ts
+++ b/src/types/proof.ts
@@ -23,6 +23,65 @@ export interface ProofConclusion {
   openQuestions?: string[]
 }
 
+/**
+ * Badge types for categorizing proofs based on their relationship to Mathlib
+ * See proofs/BADGE_TAXONOMY.md for full documentation
+ */
+export type ProofBadge =
+  | 'original'           // 🏆 Novel formalization with minimal Mathlib delegation
+  | 'mathlib-exploration' // 📚 Uses Mathlib for main theorem, proves extensions
+  | 'pedagogical'        // 🎓 Focused on teaching Lean techniques
+  | 'from-axioms'        // ⚡ Proves from first principles, no/minimal imports
+  | 'wip'                // 🚧 Has sorries or incomplete sections
+
+/**
+ * Display information for proof badges
+ */
+export const BADGE_INFO: Record<ProofBadge, { emoji: string; label: string; color: string; description: string }> = {
+  'original': {
+    emoji: '🏆',
+    label: 'Original Proof',
+    color: '#F59E0B',
+    description: 'Novel formalization with minimal Mathlib delegation'
+  },
+  'mathlib-exploration': {
+    emoji: '📚',
+    label: 'Mathlib Exploration',
+    color: '#3B82F6',
+    description: 'Uses Mathlib for main theorem, proves extensions/corollaries'
+  },
+  'pedagogical': {
+    emoji: '🎓',
+    label: 'Learning Example',
+    color: '#10B981',
+    description: 'Focused on teaching Lean techniques'
+  },
+  'from-axioms': {
+    emoji: '⚡',
+    label: 'From Axioms',
+    color: '#8B5CF6',
+    description: 'Proves from first principles with no/minimal imports'
+  },
+  'wip': {
+    emoji: '🚧',
+    label: 'Work in Progress',
+    color: '#F97316',
+    description: 'Has sorries or incomplete sections'
+  }
+}
+
+/**
+ * A theorem or lemma imported from Mathlib
+ */
+export interface MathlibDependency {
+  /** The theorem name (e.g., "Complex.exists_root") */
+  theorem: string
+  /** Brief description of what it provides */
+  description: string
+  /** The Mathlib module (e.g., "Mathlib.Analysis.Complex.Polynomial.Basic") */
+  module?: string
+}
+
 export interface ProofMeta {
   author?: string
   authorHandle?: string
@@ -33,6 +92,16 @@ export interface ProofMeta {
   tags: string[]
   /** Path to verified Lean source in proofs/ directory (e.g., "Proofs/Sqrt2Irrational.lean") */
   proofRepoPath?: string
+
+  // Badge system fields
+  /** The proof's category badge - see BADGE_TAXONOMY.md */
+  badge?: ProofBadge
+  /** Key theorems imported from Mathlib */
+  mathlibDependencies?: MathlibDependency[]
+  /** Number of sorry statements in the Lean file (0 = complete) */
+  sorries?: number
+  /** What this proof contributes beyond Mathlib */
+  originalContributions?: string[]
 }
 
 export interface ProofSection {


### PR DESCRIPTION
## Summary

Defines the badge system for categorizing proofs based on their relationship to Mathlib:

- **🏆 Original** - Novel formalization with minimal Mathlib delegation
- **📚 Mathlib Exploration** - Uses Mathlib for main theorem, proves extensions
- **🎓 Pedagogical** - Focused on teaching Lean techniques
- **⚡ From Axioms** - Proves from first principles with no/minimal imports
- **🚧 Work in Progress** - Has sorries or incomplete sections

## Changes

### Documentation
- `proofs/BADGE_TAXONOMY.md` - Complete taxonomy with selection criteria, schema, and examples

### TypeScript Types
- `ProofBadge` union type
- `BADGE_INFO` constant with display metadata (emoji, label, color, description)
- `MathlibDependency` interface
- Extended `ProofMeta` with badge, mathlibDependencies, sorries, originalContributions

### Example Badges Applied
| Proof | Badge | Reason |
|-------|-------|--------|
| Cantor Diagonalization | 🏆 original | Complete proof, minimal Mathlib |
| Fundamental Theorem of Algebra | 📚 mathlib-exploration | Uses `Complex.exists_root`, proves corollaries |
| Halting Problem | ⚡ from-axioms | Zero imports, pure logic |
| Borsuk-Ulam | 🚧 wip | 3 sorries remaining |

## Test Plan
- [x] `pnpm run build` succeeds
- [x] TypeScript types compile correctly
- [x] Example proofs updated with new schema

## Next Steps (separate issues)
- #54: Apply badges to all 19 proofs
- #55: Display badges in UI

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)