### PR TITLE
Document intentional sorries in RamanujanSumFallacy proof

### DIFF
--- a/src/data/proofs/ramanujan-sum-fallacy/meta.json
+++ b/src/data/proofs/ramanujan-sum-fallacy/meta.json
@@ -6,12 +6,21 @@
   "meta": {
     "status": "disputed",
     "tags": ["fallacy", "divergent-series", "analysis", "zeta-function", "educational"],
+    "badge": "pedagogical",
+    "sorries": 9,
+    "sorriesIntentional": true,
+    "sorriesExplanation": "All 9 sorries in this file are INTENTIONALLY unprovable. They mark steps in the famous '1+2+3+...=-1/12' fallacy that are mathematically impossible. Each sorry documents where Lean's type system catches an invalid manipulation of divergent series. These sorries should NOT be filled - they demonstrate the educational value of formal verification in catching fallacies.",
     "mathlib_version": "4.10.0",
-    "proofRepoPath": "Proofs/RamanujanFallacy.lean",
+    "proofRepoPath": "Proofs/RamanujanSumFallacy.lean",
     "externalReferences": [
       {
         "title": "Numberphile: ASTOUNDING: 1+2+3+4+... = -1/12",
         "url": "https://www.youtube.com/watch?v=w-I6XTVZXww",
+        "type": "video"
+      },
+      {
+        "title": "Mathologer: Numberphile v. Math: the truth about 1+2+3+...=-1/12",
+        "url": "https://www.youtube.com/watch?v=YuIIjLr6vUA",
         "type": "video"
       }
     ]


### PR DESCRIPTION
## Summary

Add badge taxonomy metadata to the Ramanujan Sum Fallacy proof to properly document that its 9 sorries are **intentionally unprovable**.

## Changes

- Added `badge: "pedagogical"` - this is a learning example demonstrating how Lean catches fallacies
- Added `sorries: 9` - count per the new taxonomy schema
- Added `sorriesIntentional: true` - flag indicating these should NOT be filled
- Added `sorriesExplanation` - detailed explanation of why the sorries are mathematically impossible
- Fixed `proofRepoPath` from "RamanujanFallacy.lean" to "RamanujanSumFallacy.lean"
- Added Mathologer video as additional external reference (debunks the fallacy)

## Context

The RamanujanSumFallacy file demonstrates why the famous "1+2+3+...=-1/12" claim cannot be proven in standard mathematics. Each sorry marks an impossible step:

1. Assigning values to divergent series (Grandi's series ≠ 1/2)
2. Manipulating non-summable series (requires Summable hypothesis)
3. Treating infinity as a number

The sorries are educational - they show exactly where Lean's type system catches the fallacy.

## Test Plan

- [x] Verified JSON is syntactically valid
- [x] Verified badge type matches taxonomy in BADGE_TAXONOMY.md
- [x] Verified sorry count matches Lean file (9 sorries)

Closes #44