### PR TITLE
Fix √2 generalization documentation and cleanup

### DIFF
--- a/proofs/Proofs/Sqrt2Irrational.lean
+++ b/proofs/Proofs/Sqrt2Irrational.lean
@@ -1,6 +1,5 @@
 import Mathlib.Data.Real.Irrational
 import Mathlib.Algebra.Ring.Parity
-import Mathlib.NumberTheory.Zsqrtd.Basic
 import Mathlib.Tactic
 
 /-!
@@ -18,8 +17,8 @@ rational q ≥ 0. This demonstrates that the √2 proof technique extends to
 ## Approach
 - **Foundation (from Mathlib):** The main theorem `irrational_sqrt_two` is
   provided directly by Mathlib. We use it via `exact irrational_sqrt_two`.
-  For the generalization, we use `irrational_sqrt_of_nonarchimedean` and
-  related theorems from `Mathlib.Data.Real.Irrational`.
+  For the generalization, we use `Nat.Prime.irrational_sqrt` for primes and
+  `irrational_sqrt_natCast_iff` for the general non-square case.
 - **Original Contributions:** This file demonstrates the classical parity-based
   proof structure, provides supporting lemmas about even/odd numbers,
   proves specific cases (√3, √5, √6, √7), and includes pedagogical examples.

--- a/src/data/proofs/sqrt2-irrational/annotations.json
+++ b/src/data/proofs/sqrt2-irrational/annotations.json
@@ -190,7 +190,7 @@
     "range": { "startLine": 198, "endLine": 210 },
     "type": "theorem",
     "title": "The General Theorem",
-    "content": "**Main Result**: For any natural number $n \\geq 1$ that is not a perfect square, $\\sqrt{n}$ is irrational. This single theorem subsumes all the specific cases: √2, √3, √5, √6, √7, √8, √10, ...",
+    "content": "**Main Result**: For any natural number $n$ that is not a perfect square, $\\sqrt{n}$ is irrational. This single theorem subsumes all the specific cases: √2, √3, √5, √6, √7, √8, √10, ...",
     "mathContext": "The theorem `irrational_sqrt_of_not_square` uses Mathlib's `irrational_sqrt_natCast_iff` which establishes the result based on `¬ IsSquare n`.",
     "significance": "critical",
     "prerequisites": ["ann-sqrt3-proof", "ann-sqrt6-proof"],


### PR DESCRIPTION
## Summary
Follow-up fixes from PR #74 review feedback.

## Changes
- Remove unused import `Mathlib.NumberTheory.Zsqrtd.Basic`
- Fix documentation: changed `irrational_sqrt_of_nonarchimedean` to correct function names (`Nat.Prime.irrational_sqrt` and `irrational_sqrt_natCast_iff`)
- Fix annotation: removed incorrect "$n \geq 1$" constraint (theorem doesn't require it)

## Test plan
- [ ] Verify Lean proof still compiles
- [ ] Verify JSON is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)