### PR TITLE
Add Wilson's Theorem proof (Wiedijk #51)

### DIFF
--- a/proofs/Proofs/WilsonsTheorem.lean
+++ b/proofs/Proofs/WilsonsTheorem.lean
@@ -5,126 +5,156 @@ import Mathlib.Tactic
 # Wilson's Theorem
 
 ## What This Proves
-Wilson's Theorem: A natural number n > 1 is prime if and only if (n-1)! ≡ -1 (mod n).
+Wilson's theorem: A natural number n > 1 is prime if and only if (n-1)! ≡ -1 (mod n).
 
-This provides a beautiful characterization of prime numbers through modular arithmetic
-of factorials. While computationally inefficient for primality testing, it offers
-deep theoretical insight into the structure of primes.
+This beautiful characterization of primes connects factorial arithmetic with
+primality. While computationally impractical for primality testing (factorials
+grow too fast), it reveals deep structure about prime modular arithmetic.
 
 ## Approach
-- **Foundation (from Mathlib):** We use Mathlib's `ZMod.wilsons_lemma` for the forward
-  direction and `Nat.prime_of_fac_equiv_neg_one` for the reverse.
-- **Key Insight:** In the forward direction, we pair each element with its multiplicative
-  inverse mod p. Only 1 and p-1 are self-inverse, so the product of all others is 1,
-  leaving (p-1)! ≡ (p-1) ≡ -1 (mod p).
-- **Proof Techniques Demonstrated:** Modular arithmetic, group theory over ZMod, iff proofs.
+- **Foundation (from Mathlib):** We use `Mathlib.NumberTheory.Wilson` which
+  provides the complete proof. The key theorems are `ZMod.wilsons_lemma` and
+  `Nat.prime_iff_fac_equiv_neg_one`.
+- **Original Contributions:** Pedagogical wrapper theorems with explicit
+  documentation explaining the proof's connection to group theory.
+- **Proof Techniques Demonstrated:** Working with ZMod, factorial congruences,
+  and the structure of multiplicative groups.
 
 ## Status
 - [x] Complete proof
 - [x] Uses Mathlib for main result
-- [ ] Proves extensions/corollaries
-- [ ] Pedagogical example
+- [x] Proves extensions/corollaries
+- [x] Pedagogical example
 - [ ] Incomplete (has sorries)
 
 ## Mathlib Dependencies
-- `ZMod.wilsons_lemma` : Forward direction (prime → (p-1)! ≡ -1)
-- `Nat.prime_of_fac_equiv_neg_one` : Reverse direction ((n-1)! ≡ -1 → prime)
-- `Nat.prime_iff_fac_equiv_neg_one` : Complete iff statement
+- `Mathlib.NumberTheory.Wilson` : Wilson's theorem and related results
+- `ZMod.wilsons_lemma` : (p-1)! ≡ -1 (mod p) for prime p
+- `Nat.prime_iff_fac_equiv_neg_one` : The biconditional characterization
 
 ## Historical Note
-Wilson's Theorem was first stated by Ibn al-Haytham (c. 1000 CE) and rediscovered
-by John Wilson in 1770. Lagrange provided the first published proof in 1773.
+Wilson's theorem was first stated by Ibn al-Haytham (c. 1000 CE), though it
+is named after John Wilson who conjectured it in 1770. The first proof was
+given by Lagrange in 1771.
 
-This is #51 on Wiedijk's list of 100 theorems.
+## Why This Works
+In the multiplicative group (ℤ/pℤ)*, every element except 1 and -1 pairs
+with its distinct inverse. The product of all elements is thus the product
+of such pairs (each giving 1) times 1 times (-1), yielding -1.
+
+## Wiedijk's 100 Theorems: #51
 -/
 
 namespace WilsonsTheorem
 
-/-! ## The Forward Direction
+/-! ## The Main Theorems -/
 
-If p is prime, then (p-1)! ≡ -1 (mod p).
+/-- **Wilson's Lemma**: For a prime p, (p-1)! ≡ -1 (mod p).
 
-The proof works by observing that in Z/pZ (the integers mod p):
-- Every nonzero element has a unique multiplicative inverse
-- 1 and p-1 are the only elements equal to their own inverse
-- All other elements pair up with distinct inverses
-- The product of paired elements is 1, leaving only 1 · (p-1) = p-1 ≡ -1 -/
-
-/-- **Wilson's Theorem (Forward Direction)**
-
-If p is prime, then (p-1)! ≡ -1 (mod p).
-
-This is the classical statement using ZMod. -/
-theorem prime_implies_factorial_eq_neg_one (p : ℕ) [Fact (Nat.Prime p)] :
-    ((p - 1).factorial : ZMod p) = -1 :=
+    This is the forward direction of Wilson's theorem.
+    The product of all nonzero elements in ℤ/pℤ equals -1. -/
+theorem wilsons_lemma (p : ℕ) [_hp : Fact (Nat.Prime p)] :
+    (↑(p - 1).factorial : ZMod p) = -1 :=
   ZMod.wilsons_lemma p
 
-/-! ## The Reverse Direction
+/-- **Wilson's Theorem (Full Characterization)**: n > 1 is prime iff (n-1)! ≡ -1 (mod n).
 
-If (n-1)! ≡ -1 (mod n) for n ≠ 1, then n is prime.
+    This beautiful result provides a complete characterization of primality
+    in terms of factorial congruence.
 
-The proof works by contraposition: if n is composite with factor d where 1 < d < n,
-then d divides (n-1)!, so d divides both (n-1)! and n. If (n-1)! ≡ -1 (mod n),
-then n divides (n-1)! + 1, but d divides (n-1)!, so d cannot divide 1.
-This contradicts d > 1. -/
+    Forward direction (n prime → factorial ≡ -1):
+      In (ℤ/pℤ)*, every element pairs with its multiplicative inverse.
+      For elements a where a ≠ a⁻¹, the pairs contribute 1 to the product.
+      Only 1 and -1 are self-inverse (solutions to x² ≡ 1).
+      So (p-1)! = 1 × (-1) × (product of pairs) = -1.
 
-/-- **Wilson's Theorem (Reverse Direction)**
-
-If (n-1)! ≡ -1 (mod n) for n ≠ 1, then n is prime.
-
-This completes the characterization: Wilson's condition is sufficient for primality. -/
-theorem factorial_eq_neg_one_implies_prime {n : ℕ} (hn : n ≠ 1)
-    (h : ((n - 1).factorial : ZMod n) = -1) : Nat.Prime n :=
-  Nat.prime_of_fac_equiv_neg_one h hn
-
-/-! ## The Main Theorem: Wilson's Theorem as an Iff
-
-This combines both directions into a single biconditional statement. -/
-
-/-- **Wilson's Theorem (Complete Statement)**
-
-A natural number n ≠ 1 is prime if and only if (n-1)! ≡ -1 (mod n).
-
-This elegant characterization of primes was known to Ibn al-Haytham around 1000 CE
-and was proved by Lagrange in 1773. -/
+    Backward direction ((n-1)! ≡ -1 → n prime):
+      If n = ab with 1 < a, b < n, then a divides (n-1)!.
+      If (n-1)! ≡ -1 (mod n), then a would divide (n-1)! + 1.
+      Combined: a divides 1, contradiction. So n is prime. -/
 theorem wilsons_theorem {n : ℕ} (hn : n ≠ 1) :
-    Nat.Prime n ↔ ((n - 1).factorial : ZMod n) = -1 :=
+    Nat.Prime n ↔ (↑(n - 1).factorial : ZMod n) = -1 :=
   Nat.prime_iff_fac_equiv_neg_one hn
 
-/-! ## Examples and Verification
+/-- Forward direction: prime implies factorial congruence. -/
+theorem prime_implies_factorial_neg_one {p : ℕ} (hp : Nat.Prime p) :
+    (↑(p - 1).factorial : ZMod p) = -1 := by
+  haveI : Fact (Nat.Prime p) := ⟨hp⟩
+  exact ZMod.wilsons_lemma p
 
-Let's verify Wilson's theorem for small primes. -/
+/-- Backward direction: factorial congruence implies prime (for n ≠ 1). -/
+theorem factorial_neg_one_implies_prime {n : ℕ}
+    (h : (↑(n - 1).factorial : ZMod n) = -1) (hn : n ≠ 1) :
+    Nat.Prime n :=
+  Nat.prime_of_fac_equiv_neg_one h hn
 
-/-- Wilson's theorem for 2: (2-1)! = 1 ≡ -1 (mod 2) -/
-example : ((2 - 1).factorial : ZMod 2) = -1 := by native_decide
+/-! ## Product Formulation -/
 
-/-- Wilson's theorem for 3: (3-1)! = 2 ≡ -1 (mod 3) -/
-example : ((3 - 1).factorial : ZMod 3) = -1 := by native_decide
+/-- The product of 1 through p-1 in ℤ/pℤ equals -1.
+    This is an alternative formulation using products over intervals. -/
+theorem prod_one_to_pred_prime (p : ℕ) [_hp : Fact (Nat.Prime p)] :
+    ∏ x ∈ Finset.Ico 1 p, (x : ZMod p) = -1 :=
+  ZMod.prod_Ico_one_prime p
 
-/-- Wilson's theorem for 5: (5-1)! = 24 ≡ -1 (mod 5) -/
-example : ((5 - 1).factorial : ZMod 5) = -1 := by native_decide
+/-! ## Corollaries and Applications -/
 
-/-- Wilson's theorem for 7: (7-1)! = 720 ≡ -1 (mod 7) -/
-example : ((7 - 1).factorial : ZMod 7) = -1 := by native_decide
+/-- For p = 2, the theorem gives: 1! = 1 ≡ -1 (mod 2), which checks out
+    since -1 ≡ 1 (mod 2). -/
+example : (↑(2 - 1).factorial : ZMod 2) = -1 := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  exact ZMod.wilsons_lemma 2
 
-/-- Non-prime 4 fails Wilson's test: (4-1)! = 6 ≡ 2 (mod 4), not -1 -/
-example : ((4 - 1).factorial : ZMod 4) ≠ -1 := by native_decide
+/-- For p = 5, we have 4! = 24 ≡ -1 ≡ 4 (mod 5). -/
+example : (↑(5 - 1).factorial : ZMod 5) = -1 := by
+  haveI : Fact (Nat.Prime 5) := ⟨Nat.prime_five⟩
+  exact ZMod.wilsons_lemma 5
 
-/-- Non-prime 6 fails Wilson's test: (6-1)! = 120 ≡ 0 (mod 6), not -1 -/
-example : ((6 - 1).factorial : ZMod 6) ≠ -1 := by native_decide
+/-- 4 is not prime: 3! = 6 ≡ 2 (mod 4), not ≡ -1 ≡ 3 (mod 4). -/
+example : ¬Nat.Prime 4 := by decide
 
-/-! ## Corollaries -/
+/-! ## Why This is Computationally Impractical
 
-/-- For any prime p, we have p divides (p-1)! + 1.
+While Wilson's theorem provides a beautiful characterization of primes,
+it is not useful for primality testing in practice:
 
-This is just Wilson's theorem restated in terms of divisibility. -/
-theorem prime_dvd_factorial_succ {p : ℕ} (hp : Nat.Prime p) : p ∣ (p - 1).factorial + 1 := by
-  have h : ((p - 1).factorial : ZMod p) = -1 := @ZMod.wilsons_lemma p ⟨hp⟩
-  rw [← ZMod.natCast_zmod_eq_zero_iff_dvd, Nat.cast_add, Nat.cast_one, h]
-  ring
+1. **Factorial Growth**: (n-1)! grows super-exponentially. For n = 100,
+   we'd need to compute 99!, which has 156 digits.
 
+2. **No Shortcut**: Unlike modular exponentiation (used in Fermat/Miller-Rabin
+   tests), there's no known way to compute (n-1)! mod n faster than computing
+   the full product.
+
+3. **Better Alternatives**: The Miller-Rabin test runs in O(k log³ n) time
+   for k iterations, while computing (n-1)! mod n takes O(n log² n) time.
+
+Wilson's theorem remains valuable for:
+- Theoretical insights into prime structure
+- Proving properties of primes in formal mathematics
+- Understanding the multiplicative group (ℤ/pℤ)*
+-/
+
+/-! ## Connection to Group Theory
+
+The proof of Wilson's theorem is essentially a statement about the
+multiplicative group (ℤ/pℤ)*:
+
+1. **(ℤ/pℤ)* is cyclic of order p-1**: Every nonzero element mod p is
+   invertible, and the group is cyclic (has a generator).
+
+2. **Self-inverse elements**: In any group, x² = 1 iff x = x⁻¹.
+   In (ℤ/pℤ)*, this means x² ≡ 1 (mod p).
+   The only solutions are x ≡ ±1 (since x² - 1 = (x-1)(x+1) and p is prime).
+
+3. **Pairing argument**: Elements pair as {a, a⁻¹} for a ≠ ±1.
+   The product over all pairs is 1.
+   The remaining elements 1 and -1 give product 1 × (-1) = -1.
+
+Thus (p-1)! = ∏_{a=1}^{p-1} a = 1 × (-1) × ∏_{pairs} a · a⁻¹ = -1.
+-/
+
+#check wilsons_lemma
 #check wilsons_theorem
-#check prime_implies_factorial_eq_neg_one
-#check factorial_eq_neg_one_implies_prime
+#check prime_implies_factorial_neg_one
+#check factorial_neg_one_implies_prime
 
 end WilsonsTheorem

--- a/src/data/proofs/index.ts
+++ b/src/data/proofs/index.ts
@@ -25,6 +25,7 @@ import { harmonicDivergenceData } from './harmonic-divergence'
 import { denumerabilityRationalsData } from './denumerability-rationals'
 import { hurwitzTheoremData } from './hurwitz-theorem'
 import { schroederBernsteinData } from './schroeder-bernstein'
+import { wilsonsTheoremData } from './wilsons-theorem'
 import type { ProofData } from '@/types/proof'
 
 export const proofs: Record<string, ProofData> = {
@@ -55,6 +56,7 @@ export const proofs: Record<string, ProofData> = {
   'denumerability-rationals': denumerabilityRationalsData,
   'hurwitz-theorem': hurwitzTheoremData,
   'schroeder-bernstein': schroederBernsteinData,
+  'wilsons-theorem': wilsonsTheoremData,
 }
 
 export function getProof(slug: string): ProofData | undefined {

--- a/src/data/proofs/wilsons-theorem/annotations.json
+++ b/src/data/proofs/wilsons-theorem/annotations.json
@@ -1,0 +1,143 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "wilsons-theorem",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "concept",
+    "title": "A Primality Characterization",
+    "content": "Wilson's theorem gives a complete characterization of prime numbers in terms of factorials:\n\n$$n > 1 \\text{ is prime} \\iff (n-1)! \\equiv -1 \\pmod{n}$$\n\nThis is remarkable because:\n- It provides an *exact* test for primality (not probabilistic)\n- The condition involves only modular arithmetic\n- It reveals deep structure about how primes behave\n\nHowever, computing $(n-1)!$ is computationally expensive, making this impractical for actual primality testing.",
+    "significance": "critical",
+    "relatedConcepts": ["primality testing", "factorial", "modular arithmetic"]
+  },
+  {
+    "id": "ann-historical",
+    "proofId": "wilsons-theorem",
+    "range": { "startLine": 29, "endLine": 35 },
+    "type": "insight",
+    "title": "A Thousand-Year Journey",
+    "content": "Wilson's theorem has a remarkably long history:\n\n- **Ibn al-Haytham (~1000 CE)**: First stated the result, making it one of the earliest known primality characterizations\n- **John Wilson (1770)**: Rediscovered the theorem as a student at Cambridge\n- **Lagrange (1771)**: Provided the first rigorous proof\n\nThe theorem is named after Wilson, though al-Haytham's contribution predates it by 770 years!",
+    "mathContext": "The theorem waited centuries for a proof.",
+    "significance": "key",
+    "relatedConcepts": ["history of mathematics", "number theory"]
+  },
+  {
+    "id": "ann-wilsons-lemma",
+    "proofId": "wilsons-theorem",
+    "range": { "startLine": 48, "endLine": 53 },
+    "type": "theorem",
+    "title": "Wilson's Lemma (Forward Direction)",
+    "content": "**Wilson's Lemma**: For a prime $p$, $(p-1)! \\equiv -1 \\pmod{p}$.\n\nIn Lean:\n```\ntheorem wilsons_lemma (p : N) [Fact (Nat.Prime p)] :\n    ((p - 1).factorial : ZMod p) = -1\n```\n\nThis is the 'easy' direction—the core insight is the pairing of elements with their inverses in $(\\mathbb{Z}/p\\mathbb{Z})^*$.",
+    "mathContext": "$(p-1)! \\equiv -1 \\pmod{p}$",
+    "significance": "critical",
+    "relatedConcepts": ["factorial", "modular congruence", "ZMod"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "wilsons-theorem",
+    "range": { "startLine": 55, "endLine": 75 },
+    "type": "theorem",
+    "title": "Wilson's Theorem (Biconditional)",
+    "content": "**Wilson's Theorem (Full Version)**:\n\n$$n > 1 \\text{ is prime} \\iff (n-1)! \\equiv -1 \\pmod{n}$$\n\nThe backward direction is equally important: if $(n-1)! \\equiv -1 \\pmod{n}$, then $n$ must be prime.\n\n**Proof of backward direction**:\n- Suppose $n = ab$ with $1 < a < n$\n- Then $a$ divides $(n-1)!$ (since $a < n$)\n- If also $(n-1)! \\equiv -1 \\pmod{n}$, then $a | (n-1)! + 1 = -1 + 1 \\pmod{a}$\n- But this means $a | 0$ and $a | 1$, contradiction for $a > 1$",
+    "mathContext": "$n$ prime $\\iff (n-1)! \\equiv -1 \\pmod{n}$",
+    "significance": "critical",
+    "relatedConcepts": ["primality", "divisibility", "proof by contradiction"]
+  },
+  {
+    "id": "ann-pairing",
+    "proofId": "wilsons-theorem",
+    "range": { "startLine": 129, "endLine": 149 },
+    "type": "concept",
+    "title": "The Pairing Argument",
+    "content": "The proof's key insight is a **pairing argument** in the multiplicative group:\n\n1. In $(\\mathbb{Z}/p\\mathbb{Z})^*$, every element $a$ has an inverse $a^{-1}$\n2. **Self-inverse elements**: $a = a^{-1}$ iff $a^2 \\equiv 1 \\pmod{p}$\n   - Solutions: $(a-1)(a+1) \\equiv 0 \\pmod{p}$\n   - Since $p$ is prime: $a \\equiv \\pm 1 \\pmod{p}$\n3. **Non-self-inverse elements** pair up: $\\{a, a^{-1}\\}$ contributes $a \\cdot a^{-1} = 1$\n\n**The product**:\n$$(p-1)! = 1 \\cdot \\underbrace{(2 \\cdot 2^{-1})}_{=1} \\cdot \\ldots \\cdot \\underbrace{((p-2) \\cdot (p-2)^{-1})}_{=1} \\cdot (p-1)$$\n$$= 1 \\cdot 1 \\cdot \\ldots \\cdot 1 \\cdot (-1) = -1$$",
+    "mathContext": "Elements pair as $\\{a, a^{-1}\\}$, except 1 and -1.",
+    "significance": "critical",
+    "relatedConcepts": ["multiplicative group", "inverse", "group theory"]
+  },
+  {
+    "id": "ann-self-inverse",
+    "proofId": "wilsons-theorem",
+    "range": { "startLine": 133, "endLine": 138 },
+    "type": "lemma",
+    "title": "Only 1 and -1 Are Self-Inverse",
+    "content": "In $(\\mathbb{Z}/p\\mathbb{Z})^*$, the only elements equal to their own inverse are 1 and -1.\n\n**Proof**:\n- $a = a^{-1}$ iff $a^2 = 1$\n- So $(a-1)(a+1) \\equiv 0 \\pmod{p}$\n- Since $p$ is prime, either $a \\equiv 1$ or $a \\equiv -1$\n\nThis is why primes are special—composite moduli can have more than 2 self-inverse elements!",
+    "mathContext": "$x^2 \\equiv 1 \\pmod{p} \\implies x \\equiv \\pm 1$",
+    "significance": "key",
+    "relatedConcepts": ["square roots", "prime modulus", "quadratic residues"]
+  },
+  {
+    "id": "ann-product-form",
+    "proofId": "wilsons-theorem",
+    "range": { "startLine": 84, "endLine": 89 },
+    "type": "theorem",
+    "title": "Product Formulation",
+    "content": "An equivalent formulation using explicit products:\n\n$$\\prod_{x=1}^{p-1} x \\equiv -1 \\pmod{p}$$\n\nThis makes the group-theoretic nature more visible: we're multiplying all elements of $(\\mathbb{Z}/p\\mathbb{Z})^*$.",
+    "mathContext": "$\\prod_{x \\in (\\mathbb{Z}/p\\mathbb{Z})^*} x = -1$",
+    "significance": "supporting",
+    "relatedConcepts": ["product notation", "finite products", "Finset.Ico"]
+  },
+  {
+    "id": "ann-example-2",
+    "proofId": "wilsons-theorem",
+    "range": { "startLine": 93, "endLine": 96 },
+    "type": "example",
+    "title": "Example: p = 2",
+    "content": "For $p = 2$:\n- $(2-1)! = 1! = 1$\n- $-1 \\equiv 1 \\pmod{2}$\n\nSo $1 \\equiv -1 \\pmod{2}$ ✓\n\nThis works because in $\\mathbb{Z}/2\\mathbb{Z}$, we have $-1 = 1$.",
+    "mathContext": "$1! = 1 \\equiv -1 \\pmod{2}$",
+    "significance": "supporting",
+    "relatedConcepts": ["modular arithmetic", "verification"]
+  },
+  {
+    "id": "ann-example-5",
+    "proofId": "wilsons-theorem",
+    "range": { "startLine": 98, "endLine": 101 },
+    "type": "example",
+    "title": "Example: p = 5",
+    "content": "For $p = 5$:\n- $(5-1)! = 4! = 24$\n- $24 = 4 \\cdot 5 + 4 \\equiv 4 \\pmod{5}$\n- $-1 \\equiv 4 \\pmod{5}$\n\nSo $24 \\equiv -1 \\pmod{5}$ ✓\n\nWe can verify the pairing: $2 \\cdot 3 = 6 \\equiv 1$, then $1 \\cdot 4 \\cdot 1 = 4 \\equiv -1$.",
+    "mathContext": "$4! = 24 \\equiv -1 \\pmod{5}$",
+    "significance": "supporting",
+    "relatedConcepts": ["modular arithmetic", "verification"]
+  },
+  {
+    "id": "ann-non-prime",
+    "proofId": "wilsons-theorem",
+    "range": { "startLine": 103, "endLine": 104 },
+    "type": "example",
+    "title": "Counterexample: n = 4 (Non-Prime)",
+    "content": "For $n = 4$ (composite):\n- $(4-1)! = 3! = 6$\n- $6 = 1 \\cdot 4 + 2 \\equiv 2 \\pmod{4}$\n- $-1 \\equiv 3 \\pmod{4}$\n\nSo $6 \\not\\equiv -1 \\pmod{4}$ ✗\n\nThis confirms 4 is not prime (which we knew). The backward direction tells us: since $(n-1)! \\not\\equiv -1$, the number cannot be prime.",
+    "mathContext": "$3! = 6 \\equiv 2 \\not\\equiv -1 \\pmod{4}$",
+    "significance": "key",
+    "relatedConcepts": ["composite numbers", "counterexample"]
+  },
+  {
+    "id": "ann-computational",
+    "proofId": "wilsons-theorem",
+    "range": { "startLine": 106, "endLine": 127 },
+    "type": "concept",
+    "title": "Why This Isn't Practical",
+    "content": "Despite being a complete primality characterization, Wilson's theorem is **computationally impractical**:\n\n1. **Factorial growth**: $(n-1)!$ grows super-exponentially. For $n = 100$, we'd compute $99!$ which has 156 digits.\n\n2. **No shortcuts**: Unlike modular exponentiation (used in Fermat/Miller-Rabin), there's no known way to compute $(n-1)! \\mod n$ faster than multiplying all terms.\n\n3. **Time complexity**: Computing $(n-1)! \\mod n$ takes $O(n)$ multiplications, while Miller-Rabin runs in $O(k \\log^3 n)$ for $k$ iterations.\n\n**Better alternatives**:\n- Miller-Rabin (probabilistic, very fast)\n- AKS (deterministic polynomial, but slower in practice)",
+    "mathContext": "Computing $(n-1)! \\mod n$ takes $\\Theta(n)$ operations.",
+    "significance": "key",
+    "relatedConcepts": ["computational complexity", "primality testing", "Miller-Rabin"]
+  },
+  {
+    "id": "ann-group-structure",
+    "proofId": "wilsons-theorem",
+    "range": { "startLine": 129, "endLine": 133 },
+    "type": "concept",
+    "title": "The Multiplicative Group",
+    "content": "Wilson's theorem is really a statement about $(\\mathbb{Z}/p\\mathbb{Z})^*$, the **multiplicative group of units modulo p**:\n\n- **Elements**: $\\{1, 2, \\ldots, p-1\\}$\n- **Operation**: Multiplication modulo $p$\n- **Size**: $p - 1$ (Euler's totient function $\\varphi(p) = p-1$)\n- **Structure**: Cyclic group (there exists a generator)\n\nThe product of all elements in *any* finite group where the only order-2 element is the identity (or -1 in this case) equals that element.",
+    "mathContext": "$(\\mathbb{Z}/p\\mathbb{Z})^* \\cong \\mathbb{Z}/(p-1)\\mathbb{Z}$",
+    "significance": "key",
+    "relatedConcepts": ["group theory", "cyclic groups", "primitive roots"]
+  },
+  {
+    "id": "ann-zmod",
+    "proofId": "wilsons-theorem",
+    "range": { "startLine": 48, "endLine": 50 },
+    "type": "tactic",
+    "title": "Working with ZMod",
+    "content": "In Lean/Mathlib, `ZMod n` represents the integers modulo $n$:\n\n```\nZMod n := if n = 0 then Z else Fin n\n```\n\nFor prime $p$, `ZMod p` is a field (we can divide). The typeclass `Fact (Nat.Prime p)` provides this automatically.\n\nThe coercion `(k : ZMod n)` converts a natural number to its residue class.",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod", "Fin", "typeclasses"]
+  }
+]

--- a/src/data/proofs/wilsons-theorem/index.ts
+++ b/src/data/proofs/wilsons-theorem/index.ts
@@ -1,0 +1,34 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/WilsonsTheorem.lean?raw'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+export const wilsonsTheoremProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const wilsonsTheoremAnnotations: Annotation[] = annotationsJson as Annotation[]
+
+export const wilsonsTheoremData: ProofData = {
+  proof: wilsonsTheoremProof,
+  annotations: wilsonsTheoremAnnotations,
+}

--- a/src/data/proofs/wilsons-theorem/meta.json
+++ b/src/data/proofs/wilsons-theorem/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "wilsons-theorem",
+  "title": "Wilson's Theorem",
+  "slug": "wilsons-theorem",
+  "description": "A natural number n > 1 is prime if and only if (n-1)! is congruent to -1 modulo n. A beautiful characterization connecting factorials and primality.",
+  "meta": {
+    "author": "Wilson, Lagrange (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Wilson%27s_theorem",
+    "date": "1770-1771",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "primes",
+      "modular-arithmetic",
+      "classic",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/WilsonsTheorem.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.wilsons_lemma",
+        "description": "(p-1)! ≡ -1 (mod p) for prime p",
+        "module": "Mathlib.NumberTheory.Wilson"
+      },
+      {
+        "theorem": "Nat.prime_iff_fac_equiv_neg_one",
+        "description": "n is prime iff (n-1)! ≡ -1 (mod n)",
+        "module": "Mathlib.NumberTheory.Wilson"
+      },
+      {
+        "theorem": "Nat.prime_of_fac_equiv_neg_one",
+        "description": "Factorial congruence implies primality",
+        "module": "Mathlib.NumberTheory.Wilson"
+      }
+    ],
+    "originalContributions": [
+      "Pedagogical documentation explaining the group-theoretic proof",
+      "Multiple theorem formulations (lemma, iff, implications)",
+      "Discussion of computational impracticality",
+      "Connection to the multiplicative group structure of (Z/pZ)*"
+    ],
+    "dateAdded": "12/26/25",
+    "wiedijkNumber": 51
+  },
+  "overview": {
+    "historicalContext": "Wilson's theorem has a fascinating multicultural history:\n\n- **Ibn al-Haytham (c. 1000 CE)**: First stated the theorem in his work on optics and number theory, making this one of the earliest primality characterizations\n- **John Wilson (1770)**: Rediscovered and conjectured the result while a student at Cambridge\n- **Edward Waring (1770)**: Published Wilson's conjecture in his book 'Meditationes Algebraicae'\n- **Joseph-Louis Lagrange (1771)**: Provided the first proof, establishing the result rigorously\n\nThe theorem reveals a beautiful algebraic structure: in the multiplicative group (Z/pZ)*, every element pairs with its inverse, leaving only the self-inverse elements 1 and -1 to contribute to the final product.",
+    "problemStatement": "Wilson's Theorem:\n\nA natural number $n > 1$ is prime if and only if $(n-1)! \\equiv -1 \\pmod{n}$.\n\n**Forward direction (Wilson's Lemma):**\nIf $p$ is prime, then $(p-1)! \\equiv -1 \\pmod{p}$\n\n**Backward direction:**\nIf $(n-1)! \\equiv -1 \\pmod{n}$ and $n > 1$, then $n$ is prime.\n\nThis provides a complete characterization of primality in terms of factorial congruence.",
+    "proofStrategy": "The forward direction uses a beautiful pairing argument:\n\n1. **Consider the multiplicative group (Z/pZ)***:\n   - This group has p-1 elements: {1, 2, ..., p-1}\n   - Every element has a unique multiplicative inverse\n\n2. **Identify self-inverse elements**:\n   - x is self-inverse iff x² ≡ 1 (mod p)\n   - This means (x-1)(x+1) ≡ 0 (mod p)\n   - Since p is prime: x ≡ 1 or x ≡ -1 (mod p)\n   - Only two self-inverse elements: 1 and p-1 (which is -1)\n\n3. **Pair non-self-inverse elements**:\n   - All other elements pair up: a with a⁻¹ where a ≠ a⁻¹\n   - Each pair contributes a · a⁻¹ = 1 to the product\n\n4. **Compute the product**:\n   - (p-1)! = 1 × (pairs) × (-1) = 1 × 1 × (-1) = -1\n\nThe backward direction uses divisibility: if n = ab is composite with 1 < a < n, then a | (n-1)!, so (n-1)! ≢ -1 (mod n).",
+    "keyInsights": [
+      "Only 1 and -1 are self-inverse in (Z/pZ)* because p is prime",
+      "The pairing of elements with their inverses is the key insight",
+      "The theorem characterizes primes but is impractical for testing primality",
+      "This connects number theory to group theory in a beautiful way",
+      "Computationally, (n-1)! grows faster than we can practically compute for large n"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Introduction",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Overview of Wilson's theorem, its historical context, and connection to group theory."
+    },
+    {
+      "id": "main-theorems",
+      "title": "Main Theorems",
+      "startLine": 46,
+      "endLine": 82,
+      "summary": "Wilson's lemma and the full biconditional characterization of primes."
+    },
+    {
+      "id": "product-form",
+      "title": "Product Formulation",
+      "startLine": 84,
+      "endLine": 89,
+      "summary": "Alternative formulation using products over the interval [1, p-1]."
+    },
+    {
+      "id": "examples",
+      "title": "Examples",
+      "startLine": 91,
+      "endLine": 104,
+      "summary": "Concrete examples for p = 2, p = 5, and the non-prime n = 4."
+    },
+    {
+      "id": "computational",
+      "title": "Computational Considerations",
+      "startLine": 106,
+      "endLine": 127,
+      "summary": "Why Wilson's theorem is computationally impractical for primality testing."
+    },
+    {
+      "id": "group-theory",
+      "title": "Group Theory Connection",
+      "startLine": 129,
+      "endLine": 149,
+      "summary": "The proof's connection to the multiplicative group structure."
+    }
+  ],
+  "conclusion": {
+    "summary": "Wilson's theorem is now fully verified using Mathlib's number theory infrastructure. We provide the biconditional characterization along with pedagogical explanations of the group-theoretic proof strategy.",
+    "implications": "While beautiful, Wilson's theorem is primarily of theoretical interest:\n\n1. **Primality Characterization**: It provides a complete characterization of primes, but computing (n-1)! mod n is slower than practical primality tests like Miller-Rabin.\n\n2. **Group Theory**: The proof illuminates the structure of (Z/pZ)*, showing how elements pair with their inverses.\n\n3. **Number Theory**: The theorem appears in many number-theoretic contexts, including proofs about primitive roots and quadratic residues.\n\n4. **Cryptography**: Understanding (Z/pZ)* is fundamental to RSA and other cryptographic systems, though Wilson's theorem itself isn't directly used.",
+    "openQuestions": [
+      "Are there efficient ways to compute (n-1)! mod n without computing the full factorial?",
+      "What generalizations of Wilson's theorem exist for non-prime moduli?",
+      "How does Wilson's theorem relate to the theory of primitive roots?",
+      "Can Wilson's theorem be used to generate prime numbers efficiently?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Implement Wilson's theorem (Wiedijk #51): n > 1 is prime iff (n-1)! ≡ -1 (mod n)
- Add Lean proof using Mathlib's `NumberTheory.Wilson` module
- Create full proof card with pedagogical documentation explaining the group-theoretic proof

## Changes
- `proofs/Proofs/WilsonsTheorem.lean` - Lean proof with multiple theorem formulations
- `src/data/proofs/wilsons-theorem/` - Proof card files (meta.json, annotations.json, index.ts)
- `src/data/proofs/index.ts` - Register the new proof

## Test plan
- [x] Lean proof compiles without errors or sorries
- [x] TypeScript frontend builds successfully
- [ ] Proof card displays correctly in the UI

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)