### PR TITLE
Add Divisibility by 3 Rule proof (Wiedijk #85)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -38,3 +38,4 @@ import Proofs.ArithmeticSeries
 import Proofs.SubsetCount
 import Proofs.IntermediateValueTheorem
 import Proofs.PerfectNumbers
+import Proofs.DivisibilityBy3

--- a/proofs/Proofs/DivisibilityBy3.lean
+++ b/proofs/Proofs/DivisibilityBy3.lean
@@ -1,0 +1,235 @@
+import Mathlib.Data.Nat.Digits
+import Mathlib.Tactic
+
+/-!
+# Divisibility by 3 Rule (Wiedijk #85)
+
+## What This Proves
+A natural number is divisible by 3 if and only if the sum of its digits (in base 10)
+is divisible by 3.
+
+$$3 | n \iff 3 | \text{(sum of digits of } n \text{)}$$
+
+More generally: $n \equiv \text{(digit sum)} \pmod 3$
+
+## Approach
+- **Foundation (from Mathlib):** We use Mathlib's `Nat.three_dvd_iff` which directly proves
+  the divisibility-by-3 rule using digit representation.
+- **Key Insight:** Since 10 ≡ 1 (mod 3), we have 10^k ≡ 1 (mod 3) for all k.
+  Therefore if n = d₀ + d₁·10 + d₂·10² + ..., then n ≡ d₀ + d₁ + d₂ + ... (mod 3).
+- **Proof Techniques:** Modular arithmetic, digit representation, induction on digit list.
+
+## Status
+- [x] Complete proof
+- [x] Uses Mathlib for main result
+- [x] Proves corollaries (divisibility by 9)
+- [x] Pedagogical examples
+- [ ] Incomplete (has sorries)
+
+## Mathlib Dependencies
+- `Nat.digits` : Digit representation in arbitrary base
+- `Nat.three_dvd_iff` : 3 ∣ n ↔ 3 ∣ (digits 10 n).sum
+- `Nat.nine_dvd_iff` : 9 ∣ n ↔ 9 ∣ (digits 10 n).sum
+- `Nat.modEq_three_digits_sum` : n ≡ (digits 10 n).sum [MOD 3]
+- `Nat.modEq_nine_digits_sum` : n ≡ (digits 10 n).sum [MOD 9]
+
+## Historical Note
+The divisibility-by-3 rule has been known since ancient times and appears in many
+cultures' mathematical traditions. It's one of the most practical divisibility tests,
+easily performed mentally by summing digits.
+
+This is #85 on Wiedijk's list of 100 theorems.
+-/
+
+namespace DivisibilityBy3
+
+/-! ## The Key Insight: Why This Works
+
+The magic behind divisibility by 3 comes from a simple observation about base 10:
+
+  10 ≡ 1 (mod 3)
+
+This means 10^k ≡ 1^k = 1 (mod 3) for any k ≥ 0.
+
+When we write a number n in base 10:
+  n = d₀ + d₁·10 + d₂·10² + d₃·10³ + ...
+
+Taking both sides modulo 3:
+  n ≡ d₀ + d₁·1 + d₂·1 + d₃·1 + ... (mod 3)
+  n ≡ d₀ + d₁ + d₂ + d₃ + ... (mod 3)
+  n ≡ (sum of digits) (mod 3)
+
+Therefore: 3 | n ⟺ 3 | (sum of digits)
+-/
+
+/-! ## The Main Theorem: Divisibility by 3 Rule -/
+
+/-- **Divisibility by 3 Rule (Wiedijk #85)**
+
+A natural number n is divisible by 3 if and only if the sum of its decimal digits
+is divisible by 3.
+
+Example: 123 has digit sum 1+2+3 = 6, and 3 | 6, so 3 | 123. Indeed, 123 = 3 × 41. -/
+theorem divisibility_by_3 (n : ℕ) : 3 ∣ n ↔ 3 ∣ (Nat.digits 10 n).sum :=
+  Nat.three_dvd_iff n
+
+/-- The congruence form: n is congruent to its digit sum modulo 3. -/
+theorem modEq_three_digits (n : ℕ) : n ≡ (Nat.digits 10 n).sum [MOD 3] :=
+  Nat.modEq_three_digits_sum n
+
+/-! ## Corollary: Divisibility by 9 Rule
+
+The same principle applies to 9, since 10 ≡ 1 (mod 9) as well.
+This gives us the classic "casting out nines" technique. -/
+
+/-- **Divisibility by 9 Rule**
+
+A natural number n is divisible by 9 if and only if the sum of its decimal digits
+is divisible by 9.
+
+Example: 729 has digit sum 7+2+9 = 18, and 9 | 18, so 9 | 729. Indeed, 729 = 9 × 81. -/
+theorem divisibility_by_9 (n : ℕ) : 9 ∣ n ↔ 9 ∣ (Nat.digits 10 n).sum :=
+  Nat.nine_dvd_iff n
+
+/-- The congruence form: n is congruent to its digit sum modulo 9. -/
+theorem modEq_nine_digits (n : ℕ) : n ≡ (Nat.digits 10 n).sum [MOD 9] :=
+  Nat.modEq_nine_digits_sum n
+
+/-! ## The General Principle
+
+The divisibility rules for 3 and 9 are special cases of a general theorem:
+For any base b and divisor d where b ≡ 1 (mod d), we have n ≡ (digit sum in base b) (mod d). -/
+
+/-- **Generalized Divisibility Rule**
+
+For any base b ≥ 2 and any d > 0 such that b % d = 1,
+a number n is congruent to the sum of its base-b digits modulo d. -/
+theorem modEq_digits_sum_general (d b : ℕ) (_hb : 2 ≤ b) (_hd : 0 < d) (h : b % d = 1) (n : ℕ) :
+    n ≡ (Nat.digits b n).sum [MOD d] :=
+  Nat.modEq_digits_sum d b h n
+
+/-- **Generalized Divisibility Rule (iff form)**
+
+For any base b ≥ 2 and any d > 0 such that b % d = 1,
+d divides n if and only if d divides the sum of n's base-b digits. -/
+theorem dvd_iff_dvd_digits_sum_general (d b : ℕ) (_hb : 2 ≤ b) (_hd : 0 < d) (h : b % d = 1) (n : ℕ) :
+    d ∣ n ↔ d ∣ (Nat.digits b n).sum :=
+  Nat.dvd_iff_dvd_digits_sum d b h n
+
+/-! ## Examples and Verification
+
+Let's verify the divisibility rules with concrete examples. -/
+
+/-- 123 is divisible by 3 (digits sum to 1+2+3 = 6) -/
+example : 3 ∣ 123 := by
+  rw [divisibility_by_3]
+  native_decide
+
+/-- 123 is not divisible by 9 (digits sum to 6, and 9 ∤ 6) -/
+example : ¬(9 ∣ 123) := by
+  rw [divisibility_by_9]
+  native_decide
+
+/-- 729 is divisible by 9 (digits sum to 7+2+9 = 18) -/
+example : 9 ∣ 729 := by
+  rw [divisibility_by_9]
+  native_decide
+
+/-- 729 = 3^6 is also divisible by 3 -/
+example : 3 ∣ 729 := by
+  rw [divisibility_by_3]
+  native_decide
+
+/-- 1000 is not divisible by 3 (digits sum to 1) -/
+example : ¬(3 ∣ 1000) := by
+  rw [divisibility_by_3]
+  native_decide
+
+/-- 999 is divisible by both 3 and 9 (digits sum to 27) -/
+example : 3 ∣ 999 ∧ 9 ∣ 999 := by
+  constructor
+  · rw [divisibility_by_3]; native_decide
+  · rw [divisibility_by_9]; native_decide
+
+/-- 12345 is divisible by 3 (1+2+3+4+5 = 15) but not by 9 -/
+example : 3 ∣ 12345 ∧ ¬(9 ∣ 12345) := by
+  constructor
+  · rw [divisibility_by_3]; native_decide
+  · rw [divisibility_by_9]; native_decide
+
+/-! ## Digit Representation Properties
+
+Understanding how digits work is key to seeing why the rule holds. -/
+
+/-- The digits of 123 in base 10 are [3, 2, 1] (least significant first) -/
+example : Nat.digits 10 123 = [3, 2, 1] := by native_decide
+
+/-- The sum of digits of 123 is 6 -/
+example : (Nat.digits 10 123).sum = 6 := by native_decide
+
+/-- The digits of 1000 are [0, 0, 0, 1] -/
+example : Nat.digits 10 1000 = [0, 0, 0, 1] := by native_decide
+
+/-- Zero has no digits (empty list) -/
+example : Nat.digits 10 0 = [] := by native_decide
+
+/-- Single-digit numbers have one digit -/
+example : Nat.digits 10 7 = [7] := by native_decide
+
+/-! ## Why It Works: The Proof Idea
+
+The proof relies on two key facts:
+
+1. **Base Representation**: Any natural number n can be written as
+   n = Nat.ofDigits 10 (Nat.digits 10 n)
+
+2. **Modular Equivalence of Base**:
+   10 ≡ 1 (mod 3) and 10 ≡ 1 (mod 9)
+
+   This means when we expand n = d₀ + 10·d₁ + 10²·d₂ + ...,
+   modulo 3 (or 9), each power of 10 contributes just 1.
+
+   Therefore: n ≡ d₀ + d₁ + d₂ + ... ≡ (digit sum) (mod 3 or 9)
+-/
+
+/-- 10 ≡ 1 (mod 3) -/
+example : 10 % 3 = 1 := by native_decide
+
+/-- 10 ≡ 1 (mod 9) -/
+example : 10 % 9 = 1 := by native_decide
+
+/-- 100 ≡ 1 (mod 3) -/
+example : 100 % 3 = 1 := by native_decide
+
+/-- 100 ≡ 1 (mod 9) -/
+example : 100 % 9 = 1 := by native_decide
+
+/-! ## Applications: Iterative Digit Sums
+
+A practical application: you can repeatedly sum digits until you get a single digit.
+The result (called the digital root) determines divisibility by 3 and 9. -/
+
+/-- If a number's digits sum to a value, and that value is divisible by 3,
+    then the original number is divisible by 3. -/
+theorem div_3_of_digit_sum_div_3 {n : ℕ} (h : 3 ∣ (Nat.digits 10 n).sum) : 3 ∣ n :=
+  (divisibility_by_3 n).mpr h
+
+/-- If a number's digits sum to a value, and that value is divisible by 9,
+    then the original number is divisible by 9. -/
+theorem div_9_of_digit_sum_div_9 {n : ℕ} (h : 9 ∣ (Nat.digits 10 n).sum) : 9 ∣ n :=
+  (divisibility_by_9 n).mpr h
+
+/-- Transitivity: if 3 divides a number, it divides its digit sum -/
+theorem digit_sum_div_3_of_div_3 {n : ℕ} (h : 3 ∣ n) : 3 ∣ (Nat.digits 10 n).sum :=
+  (divisibility_by_3 n).mp h
+
+/-- Transitivity: if 9 divides a number, it divides its digit sum -/
+theorem digit_sum_div_9_of_div_9 {n : ℕ} (h : 9 ∣ n) : 9 ∣ (Nat.digits 10 n).sum :=
+  (divisibility_by_9 n).mp h
+
+#check divisibility_by_3
+#check divisibility_by_9
+#check modEq_three_digits
+#check modEq_nine_digits
+
+end DivisibilityBy3

--- a/src/data/proofs/divisibility-by-3/annotations.json
+++ b/src/data/proofs/divisibility-by-3/annotations.json
@@ -1,0 +1,111 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "divisibility-by-3",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "concept",
+    "title": "Divisibility by 3 Rule",
+    "content": "A natural number is divisible by 3 if and only if the sum of its decimal digits is divisible by 3:\n\n$$3 | n \\iff 3 | (d_0 + d_1 + d_2 + \\cdots)$$\n\nThis is one of the most practical divisibility tests, easily performed mentally.\n\nThis is Wiedijk's 100 Theorems #85.",
+    "significance": "critical",
+    "relatedConcepts": ["divisibility", "modular arithmetic", "digit sum"]
+  },
+  {
+    "id": "ann-key-insight",
+    "proofId": "divisibility-by-3",
+    "range": { "startLine": 42, "endLine": 62 },
+    "type": "concept",
+    "title": "The Key Insight",
+    "content": "The rule works because $10 \\equiv 1 \\pmod 3$.\n\nThis means every power of 10 is also congruent to 1 modulo 3:\n$$10^k \\equiv 1^k = 1 \\pmod 3$$\n\nSo when we write $n = d_0 + d_1 \\cdot 10 + d_2 \\cdot 10^2 + \\cdots$, we get:\n$$n \\equiv d_0 + d_1 + d_2 + \\cdots \\pmod 3$$",
+    "mathContext": "$10 \\equiv 1 \\pmod 3$",
+    "significance": "critical",
+    "relatedConcepts": ["modular equivalence", "powers of 10"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "divisibility-by-3",
+    "range": { "startLine": 64, "endLine": 77 },
+    "type": "theorem",
+    "title": "Main Theorem: Divisibility by 3",
+    "content": "**Divisibility by 3 Rule (Wiedijk #85)**:\n\n```lean\ntheorem divisibility_by_3 (n : ℕ) :\n    3 ∣ n ↔ 3 ∣ (Nat.digits 10 n).sum\n```\n\nThis follows from Mathlib's `Nat.three_dvd_iff`.\n\nExample: 123 has digits [3, 2, 1], sum = 6. Since 3 | 6, we have 3 | 123.",
+    "mathContext": "$3 | n \\iff 3 | \\text{(digit sum)}$",
+    "significance": "critical",
+    "relatedConcepts": ["Nat.digits", "divisibility"]
+  },
+  {
+    "id": "ann-modEq-form",
+    "proofId": "divisibility-by-3",
+    "range": { "startLine": 79, "endLine": 82 },
+    "type": "theorem",
+    "title": "Congruence Form",
+    "content": "The stronger form shows n is congruent (not just divisible) to its digit sum:\n\n```lean\ntheorem modEq_three_digits (n : ℕ) :\n    n ≡ (Nat.digits 10 n).sum [MOD 3]\n```\n\nThis means n and its digit sum have the same remainder when divided by 3.",
+    "mathContext": "$n \\equiv \\text{(digit sum)} \\pmod 3$",
+    "significance": "key",
+    "relatedConcepts": ["modular congruence", "remainder"]
+  },
+  {
+    "id": "ann-divisibility-9",
+    "proofId": "divisibility-by-3",
+    "range": { "startLine": 84, "endLine": 97 },
+    "type": "theorem",
+    "title": "Divisibility by 9 (Corollary)",
+    "content": "The same principle gives divisibility by 9, since $10 \\equiv 1 \\pmod 9$ as well.\n\n```lean\ntheorem divisibility_by_9 (n : ℕ) :\n    9 ∣ n ↔ 9 ∣ (Nat.digits 10 n).sum\n```\n\nThis is the basis of 'casting out nines' - an ancient technique for checking arithmetic.",
+    "mathContext": "$9 | n \\iff 9 | \\text{(digit sum)}$",
+    "significance": "key",
+    "relatedConcepts": ["casting out nines", "arithmetic verification"]
+  },
+  {
+    "id": "ann-general",
+    "proofId": "divisibility-by-3",
+    "range": { "startLine": 99, "endLine": 117 },
+    "type": "concept",
+    "title": "General Principle",
+    "content": "The rule generalizes to any base b and divisor d where $b \\equiv 1 \\pmod d$.\n\nFor example:\n- Base 10, divisor 3: works because $10 \\equiv 1 \\pmod 3$\n- Base 10, divisor 9: works because $10 \\equiv 1 \\pmod 9$\n- Base 8, divisor 7: works because $8 \\equiv 1 \\pmod 7$",
+    "mathContext": "$b \\equiv 1 \\pmod d \\implies n \\equiv \\text{(digit sum in base }b\\text{)} \\pmod d$",
+    "significance": "key",
+    "relatedConcepts": ["generalization", "arbitrary base"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "divisibility-by-3",
+    "range": { "startLine": 119, "endLine": 158 },
+    "type": "example",
+    "title": "Verification Examples",
+    "content": "Concrete examples:\n\n| Number | Digit Sum | ÷3? | ÷9? |\n|--------|-----------|-----|-----|\n| 123    | 6         | ✓   | ✗   |\n| 729    | 18        | ✓   | ✓   |\n| 1000   | 1         | ✗   | ✗   |\n| 999    | 27        | ✓   | ✓   |\n| 12345  | 15        | ✓   | ✗   |\n\nEach is verified using `native_decide`.",
+    "mathContext": "Concrete verification",
+    "significance": "supporting",
+    "relatedConcepts": ["concrete examples", "native_decide"]
+  },
+  {
+    "id": "ann-digit-repr",
+    "proofId": "divisibility-by-3",
+    "range": { "startLine": 160, "endLine": 177 },
+    "type": "concept",
+    "title": "Digit Representation",
+    "content": "Mathlib's `Nat.digits 10 n` returns digits in **least-significant-first** order:\n\n| Number | Digits       | Sum |\n|--------|--------------|-----|\n| 123    | [3, 2, 1]    | 6   |\n| 1000   | [0, 0, 0, 1] | 1   |\n| 7      | [7]          | 7   |\n| 0      | []           | 0   |",
+    "mathContext": "Nat.digits returns [d₀, d₁, d₂, ...]",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.digits", "list representation"]
+  },
+  {
+    "id": "ann-modular-examples",
+    "proofId": "divisibility-by-3",
+    "range": { "startLine": 195, "endLine": 205 },
+    "type": "example",
+    "title": "Modular Arithmetic Examples",
+    "content": "Verification that powers of 10 are congruent to 1:\n\n- $10 \\% 3 = 1$ ✓\n- $10 \\% 9 = 1$ ✓\n- $100 \\% 3 = 1$ ✓\n- $100 \\% 9 = 1$ ✓\n\nThis is why the rule works for all natural numbers.",
+    "mathContext": "$10^k \\equiv 1 \\pmod{3}$ and $10^k \\equiv 1 \\pmod{9}$",
+    "significance": "supporting",
+    "relatedConcepts": ["powers of 10", "modular verification"]
+  },
+  {
+    "id": "ann-applications",
+    "proofId": "divisibility-by-3",
+    "range": { "startLine": 207, "endLine": 228 },
+    "type": "concept",
+    "title": "Applications",
+    "content": "The theorems support iterative digit summing:\n\n1. **Digital Root**: Keep summing digits until you get a single digit\n2. **Quick Divisibility Check**: 3 | n iff 3 | (final digit root)\n\nFor example: 99999 → 45 → 9 → 9, so 99999 is divisible by 9.\n\nThese application theorems formalize both directions of the iff.",
+    "mathContext": "Iterative digit sums",
+    "significance": "key",
+    "relatedConcepts": ["digital root", "iterative computation"]
+  }
+]

--- a/src/data/proofs/divisibility-by-3/index.ts
+++ b/src/data/proofs/divisibility-by-3/index.ts
@@ -1,0 +1,34 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DivisibilityBy3.lean?raw'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+export const divisibilityBy3Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const divisibilityBy3Annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const divisibilityBy3Data: ProofData = {
+  proof: divisibilityBy3Proof,
+  annotations: divisibilityBy3Annotations,
+}

--- a/src/data/proofs/divisibility-by-3/meta.json
+++ b/src/data/proofs/divisibility-by-3/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "divisibility-by-3",
+  "title": "Divisibility by 3 Rule",
+  "slug": "divisibility-by-3",
+  "description": "A natural number is divisible by 3 if and only if the sum of its digits is divisible by 3. This ancient divisibility test works because 10 ≡ 1 (mod 3).",
+  "meta": {
+    "author": "Ancient mathematicians (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Divisibility_rule#Divisibility_by_3_or_9",
+    "date": "Ancient",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "modular-arithmetic",
+      "classic",
+      "easy"
+    ],
+    "proofRepoPath": "Proofs/DivisibilityBy3.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.three_dvd_iff",
+        "description": "3 ∣ n ↔ 3 ∣ (digits 10 n).sum",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "Nat.nine_dvd_iff",
+        "description": "9 ∣ n ↔ 9 ∣ (digits 10 n).sum",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "Nat.modEq_three_digits_sum",
+        "description": "n ≡ (digits 10 n).sum [MOD 3]",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "Nat.modEq_nine_digits_sum",
+        "description": "n ≡ (digits 10 n).sum [MOD 9]",
+        "module": "Mathlib.Data.Nat.Digits"
+      }
+    ],
+    "originalContributions": [
+      "Pedagogical documentation explaining why the rule works",
+      "Generalized divisibility theorem for arbitrary bases",
+      "Divisibility by 9 as a corollary",
+      "Concrete examples with verification",
+      "Application theorems for iterative digit sums"
+    ],
+    "dateAdded": "12/26/25",
+    "wiedijkNumber": 85
+  },
+  "overview": {
+    "historicalContext": "The divisibility-by-3 rule is one of the oldest and most widely known divisibility tests. It has been used across cultures for mental arithmetic and checking calculations for centuries.\n\nThe rule appears in various ancient mathematical traditions, as the observation that 10 ≡ 1 (mod 3) makes the test particularly natural for base-10 arithmetic. This same principle gives us the divisibility-by-9 rule (since 10 ≡ 1 (mod 9) as well) and the technique of 'casting out nines' for verifying arithmetic.\n\nThe mathematical generalization states: for any base b and divisor d where b ≡ 1 (mod d), a number is divisible by d if and only if its digit sum (in base b) is divisible by d.",
+    "problemStatement": "**Divisibility by 3 Rule (Wiedijk #85):**\n\nA natural number $n$ is divisible by 3 if and only if the sum of its decimal digits is divisible by 3.\n\n$$3 | n \\iff 3 | (d_0 + d_1 + d_2 + \\cdots)$$\n\nwhere $n = d_0 + d_1 \\cdot 10 + d_2 \\cdot 10^2 + \\cdots$ is the decimal representation.\n\n**Stronger Form (Congruence):**\n\n$$n \\equiv (d_0 + d_1 + d_2 + \\cdots) \\pmod 3$$\n\n**Corollary (Divisibility by 9):**\n\n$$9 | n \\iff 9 | (d_0 + d_1 + d_2 + \\cdots)$$",
+    "proofStrategy": "The proof relies on the key observation that 10 ≡ 1 (mod 3).\n\n1. **Base Representation**: Any natural number n can be written as:\n   $$n = d_0 + d_1 \\cdot 10 + d_2 \\cdot 10^2 + d_3 \\cdot 10^3 + \\cdots$$\n\n2. **Modular Reduction**: Since $10 \\equiv 1 \\pmod 3$, we have:\n   $$10^k \\equiv 1^k = 1 \\pmod 3$$ for all $k \\geq 0$.\n\n3. **Apply to Each Term**: Taking the equation modulo 3:\n   $$n \\equiv d_0 \\cdot 1 + d_1 \\cdot 1 + d_2 \\cdot 1 + \\cdots \\pmod 3$$\n   $$n \\equiv d_0 + d_1 + d_2 + \\cdots \\pmod 3$$\n\n4. **Conclude**: Therefore $3 | n$ if and only if $3 | (d_0 + d_1 + d_2 + \\cdots)$.\n\nThe same argument works for 9 since $10 \\equiv 1 \\pmod 9$ as well.",
+    "keyInsights": [
+      "10 ≡ 1 (mod 3) is the fundamental reason the rule works",
+      "The same principle gives divisibility by 9 (casting out nines)",
+      "The rule generalizes: for base b and divisor d with b ≡ 1 (mod d)",
+      "Iteratively summing digits gives the 'digital root'",
+      "This is one of the most practical mental arithmetic techniques"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Introduction",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Overview of the divisibility by 3 rule and its significance as Wiedijk #85."
+    },
+    {
+      "id": "key-insight",
+      "title": "The Key Insight",
+      "startLine": 42,
+      "endLine": 62,
+      "summary": "Explanation of why the rule works: 10 ≡ 1 (mod 3)."
+    },
+    {
+      "id": "main-theorems",
+      "title": "Main Theorems",
+      "startLine": 64,
+      "endLine": 97,
+      "summary": "The divisibility by 3 and 9 rules with both divisibility and congruence forms."
+    },
+    {
+      "id": "general-principle",
+      "title": "General Principle",
+      "startLine": 99,
+      "endLine": 117,
+      "summary": "Generalization to arbitrary bases and divisors."
+    },
+    {
+      "id": "examples",
+      "title": "Examples",
+      "startLine": 119,
+      "endLine": 177,
+      "summary": "Concrete examples verifying the divisibility rules."
+    },
+    {
+      "id": "proof-explanation",
+      "title": "Why It Works",
+      "startLine": 179,
+      "endLine": 205,
+      "summary": "Detailed explanation of the proof idea with modular arithmetic examples."
+    },
+    {
+      "id": "applications",
+      "title": "Applications",
+      "startLine": 207,
+      "endLine": 228,
+      "summary": "Theorems for iterative digit sums and transitivity properties."
+    }
+  ],
+  "conclusion": {
+    "summary": "The divisibility by 3 rule is fully verified using Mathlib's digit representation infrastructure. We prove both the divisibility and congruence forms, extend to divisibility by 9, and provide a generalized theorem for arbitrary bases.",
+    "implications": "This proof demonstrates several important concepts:\n\n1. **Practical Mental Arithmetic**: The rule is one of the most useful divisibility tests, easily computed without paper.\n\n2. **Modular Arithmetic**: The proof showcases how modular equivalences propagate through arithmetic operations.\n\n3. **Generalization**: The same principle works for any (base, divisor) pair where base ≡ 1 (mod divisor). For example, in base 8 (octal), the rule works for divisibility by 7.\n\n4. **Casting Out Nines**: The divisibility-by-9 corollary forms the basis of the ancient technique for checking arithmetic calculations.\n\n5. **Digital Root**: Iteratively applying the rule gives the digital root, useful in numerology and checksum algorithms.",
+    "openQuestions": [
+      "What other divisibility rules have similarly elegant proofs?",
+      "How do divisibility rules extend to different number bases?",
+      "What's the most efficient algorithm for computing digital roots?",
+      "Are there practical applications of the generalized divisibility theorem?"
+    ]
+  }
+}

--- a/src/data/proofs/index.ts
+++ b/src/data/proofs/index.ts
@@ -31,6 +31,7 @@ import { intermediateValueTheoremData } from './intermediate-value-theorem'
 import { mathematicalInductionData } from './mathematical-induction'
 import { arithmeticSeriesData } from './arithmetic-series'
 import { subsetCountData } from './subset-count'
+import { divisibilityBy3Data } from './divisibility-by-3'
 import type { ProofData } from '@/types/proof'
 
 export const proofs: Record<string, ProofData> = {
@@ -67,6 +68,7 @@ export const proofs: Record<string, ProofData> = {
   'mathematical-induction': mathematicalInductionData,
   'arithmetic-series': arithmeticSeriesData,
   'subset-count': subsetCountData,
+  'divisibility-by-3': divisibilityBy3Data,
 }
 
 export function getProof(slug: string): ProofData | undefined {


### PR DESCRIPTION
## Summary

Implements Wiedijk #85: Divisibility by 3 Rule - a natural number is divisible by 3 if and only if the sum of its decimal digits is divisible by 3.

## Changes

- **New proof file**: `proofs/Proofs/DivisibilityBy3.lean`
  - Main theorem: `divisibility_by_3` using Mathlib's `Nat.three_dvd_iff`
  - Congruence form: `modEq_three_digits`
  - Divisibility by 9 corollary: `divisibility_by_9`, `modEq_nine_digits`
  - Generalized theorem for arbitrary bases
  - Pedagogical examples and documentation

- **Proof card data**: `src/data/proofs/divisibility-by-3/`
  - `meta.json`: Proof metadata with Wiedijk reference
  - `annotations.json`: Inline annotations for the proof viewer
  - `index.ts`: TypeScript module exports

- **Updated imports**: 
  - `proofs/Proofs.lean`: Added import for DivisibilityBy3
  - `src/data/proofs/index.ts`: Registered new proof

## Key Insight

The rule works because $10 \equiv 1 \pmod 3$, so $10^k \equiv 1 \pmod 3$ for all k. This means when we expand a number $n = d_0 + d_1 \cdot 10 + d_2 \cdot 10^2 + \ldots$, we get $n \equiv d_0 + d_1 + d_2 + \ldots \pmod 3$.

## Test Plan

- [x] Lean 4 proof compiles without errors
- [x] Build completes successfully
- [x] No new lint errors introduced

Closes #118