### PR TITLE
Add Bertrand's Postulate proof (Wiedijk #98)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -7,6 +7,7 @@ import Proofs.AreaOfCircle
 import Proofs.ArithmeticSeries
 import Proofs.BezoutIdentity
 import Proofs.BinomialTheorem
+import Proofs.BertrandsPostulate
 import Proofs.BirthdayProblem
 import Proofs.BorsukUlam
 import Proofs.BrouwerFixedPoint

--- a/proofs/Proofs/BertrandsPostulate.lean
+++ b/proofs/Proofs/BertrandsPostulate.lean
@@ -1,0 +1,165 @@
+import Mathlib.NumberTheory.Bertrand
+import Mathlib.Tactic
+
+/-!
+# Bertrand's Postulate
+
+## What This Proves
+Bertrand's Postulate: For every integer n > 1, there exists a prime p such that n < p ≤ 2n.
+
+Equivalently: between any number greater than 1 and its double, there is always at least
+one prime number.
+
+## Historical Context
+Joseph Bertrand conjectured this result in 1845 after verifying it for all n up to 3 million.
+Pafnuty Chebyshev gave the first proof in 1852 using analytic techniques. In 1932, the
+19-year-old Paul Erdős published an elegant elementary proof that has become the standard
+approach. The theorem is sometimes called the "Bertrand-Chebyshev theorem."
+
+## Approach
+- **Foundation (from Mathlib):** We use `Mathlib.NumberTheory.Bertrand` which provides
+  the complete proof following Erdős's approach via analysis of the central binomial
+  coefficient.
+- **Original Contributions:** Pedagogical wrapper theorems with documentation explaining
+  the theorem's significance, equivalent formulations, and interesting corollaries.
+- **Proof Techniques Demonstrated:** The underlying Mathlib proof analyzes the prime
+  factorization of C(2n, n) = (2n)!/(n!)² to derive bounds on prime distribution.
+
+## Status
+- [x] Complete proof
+- [x] Uses Mathlib for main result
+- [x] Proves extensions/corollaries
+- [x] Pedagogical example
+- [ ] Incomplete (has sorries)
+
+## Mathlib Dependencies
+- `Mathlib.NumberTheory.Bertrand` : Complete proof of Bertrand's Postulate
+- `Nat.exists_prime_lt_and_le_two_mul` : Main theorem statement
+- `Nat.bertrand` : Alias for the main theorem
+
+## Why This Theorem is Important
+Bertrand's Postulate has numerous applications:
+- Provides explicit bounds on prime gaps (gap < n for primes near n)
+- Used in proofs about the distribution of primes
+- Foundation for stronger results like the Prime Number Theorem
+- Applications in combinatorics and algorithms requiring "nearby" primes
+
+## Wiedijk's 100 Theorems: #98
+-/
+
+namespace BertrandsPostulate
+
+/-! ## The Main Theorem -/
+
+/-- **Bertrand's Postulate (Main Statement)**
+
+    For any positive natural number n, there exists a prime p with n < p ≤ 2n.
+
+    This is the core result: between n and 2n (inclusive), there's always a prime.
+    Note: Mathlib states this as n < p ≤ 2n, which is equivalent to n < p < 2n + 1. -/
+theorem bertrand_postulate (n : ℕ) (hn : 0 < n) : ∃ p, Nat.Prime p ∧ n < p ∧ p ≤ 2 * n :=
+  Nat.exists_prime_lt_and_le_two_mul n (Nat.pos_iff_ne_zero.mp hn)
+
+/-- **Bertrand's Postulate (Alternative Name)**
+
+    An alias for the main theorem using Mathlib's naming convention. -/
+theorem bertrand (n : ℕ) (hn : 0 < n) : ∃ p, Nat.Prime p ∧ n < p ∧ p ≤ 2 * n :=
+  Nat.bertrand n (Nat.pos_iff_ne_zero.mp hn)
+
+/-! ## Corollaries -/
+
+/-- **Existence of primes in intervals**
+
+    For n ≥ 1, there's a prime between n and 2n (exclusive on left, inclusive on right). -/
+theorem exists_prime_between (n : ℕ) (hn : 1 ≤ n) : ∃ p, Nat.Prime p ∧ n < p ∧ p ≤ 2 * n := by
+  exact bertrand_postulate n hn
+
+/-- **Prime gaps are bounded**
+
+    For any prime p > 2, the next prime is at most 2p - 1.
+    (Since there's a prime q with p < q ≤ 2p.) -/
+theorem prime_gap_bounded (p : ℕ) (hp : Nat.Prime p) :
+    ∃ q, Nat.Prime q ∧ p < q ∧ q ≤ 2 * p :=
+  bertrand_postulate p hp.pos
+
+/-- **Infinitude of primes (via Bertrand)**
+
+    Bertrand's Postulate implies there are infinitely many primes.
+    For any n, apply Bertrand to get a prime > n. -/
+theorem primes_infinite_via_bertrand : ∀ n : ℕ, ∃ p, Nat.Prime p ∧ p > n := by
+  intro n
+  cases' n with n
+  · -- n = 0: any prime works
+    use 2
+    exact ⟨Nat.prime_two, by omega⟩
+  · -- n = Nat.succ n ≥ 1
+    obtain ⟨p, hp_prime, hp_gt, _⟩ := bertrand_postulate (n + 1) (by omega)
+    exact ⟨p, hp_prime, hp_gt⟩
+
+/-- **No largest prime (via Bertrand)**
+
+    Another consequence: there is no largest prime number. -/
+theorem no_largest_prime_via_bertrand : ¬∃ p, Nat.Prime p ∧ ∀ q, Nat.Prime q → q ≤ p := by
+  intro ⟨p, _, h_largest⟩
+  obtain ⟨q, hq_prime, hq_gt⟩ := primes_infinite_via_bertrand p
+  have hq_le := h_largest q hq_prime
+  omega
+
+/-! ## Stronger Bounds for Large n
+
+The proof works by first establishing the result for n ≥ 512 via analysis of
+the central binomial coefficient, then using a descending chain of known primes
+to cover smaller values. -/
+
+/-- **Bertrand's Postulate for large n**
+
+    For n ≥ 512, the postulate holds. This is the "main engine" of the proof,
+    where the Erdős-style analysis of C(2n,n) applies directly. -/
+theorem bertrand_large (n : ℕ) (hn : 512 ≤ n) : ∃ p, Nat.Prime p ∧ n < p ∧ p ≤ 2 * n :=
+  Nat.exists_prime_lt_and_le_two_mul_eventually n hn
+
+/-! ## Examples
+
+### Concrete instances of Bertrand's Postulate:
+
+**n = 1:** Primes between 1 and 2: {2}. ✓
+
+**n = 2:** Primes between 2 and 4: {3}. ✓
+
+**n = 3:** Primes between 3 and 6: {5}. ✓
+
+**n = 10:** Primes between 10 and 20: {11, 13, 17, 19}. ✓
+
+**n = 100:** Primes between 100 and 200: {101, 103, 107, 109, 113, ...}. ✓
+
+### The "descending chain" for small n:
+
+The proof uses this chain of primes, each more than half the next:
+983, 491, 241, 127, 61, 31, 17, 11, 7, 5, 3, 2
+
+For any n ≤ 512, we find a prime in this chain that lies in (n, 2n].
+-/
+
+/-! ## Connection to Prime Number Theorem
+
+Bertrand's Postulate is a stepping stone to the Prime Number Theorem (PNT).
+
+While Bertrand guarantees at least one prime in (n, 2n], the PNT tells us
+approximately how many: about n/ln(n) primes exist between 1 and n.
+
+For the interval (n, 2n], the PNT predicts roughly n/ln(n) primes,
+far more than Bertrand's guaranteed minimum of 1.
+
+The Riemann Hypothesis, if true, would give even tighter bounds on the
+distribution of primes in such intervals. -/
+
+/-! ## Key Theorems Summary -/
+
+#check bertrand_postulate
+#check bertrand
+#check exists_prime_between
+#check prime_gap_bounded
+#check primes_infinite_via_bertrand
+#check no_largest_prime_via_bertrand
+
+end BertrandsPostulate

--- a/src/data/proofs/bertrands-postulate/annotations.json
+++ b/src/data/proofs/bertrands-postulate/annotations.json
@@ -1,0 +1,70 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "bertrands-postulate",
+    "range": {
+      "startLine": 1,
+      "endLine": 2
+    },
+    "type": "concept",
+    "title": "Primes Are Never Far Apart",
+    "content": "Bertrand's Postulate guarantees that primes are distributed densely enough that between any positive integer $n$ and its double $2n$, there's always at least one prime.\n\n$$\\forall n > 0, \\exists p \\text{ prime}: n < p \\leq 2n$$\n\nThis means:\n- After 2, the next prime (3) is at most 4\n- After 100, there's a prime before 200\n- Prime gaps grow, but not too fast",
+    "significance": "critical",
+    "relatedConcepts": [
+      "prime gaps",
+      "prime distribution",
+      "number theory"
+    ]
+  },
+  {
+    "id": "ann-historical",
+    "proofId": "bertrands-postulate",
+    "range": {
+      "startLine": 4,
+      "endLine": 48
+    },
+    "type": "insight",
+    "title": "Three Mathematical Giants",
+    "content": "**Bertrand (1845)**: Conjectured the result after checking it for all $n$ up to 3 million by hand calculation.\n\n**Chebyshev (1852)**: Proved the conjecture using analytic techniques involving his famous $\\vartheta$ and $\\psi$ functions.\n\n**Erdős (1932)**: Published an elementary proof at age 19—his first paper. This launched a legendary career of 1,500+ papers and became the standard approach taught today.",
+    "mathContext": "The proof evolved from analytic to elementary methods.",
+    "significance": "key",
+    "relatedConcepts": [
+      "history of mathematics",
+      "analytic number theory"
+    ]
+  },
+  {
+    "id": "ann-small-cases",
+    "proofId": "bertrands-postulate",
+    "range": {
+      "startLine": 121,
+      "endLine": 141
+    },
+    "type": "insight",
+    "title": "The Descending Prime Chain",
+    "content": "For small $n$ (< 512), an explicit chain of primes covers all cases:\n\n983, 491, 241, 127, 61, 31, 17, 11, 7, 5, 3, 2\n\nEach prime $p$ in this list satisfies $p > q/2$ where $q$ is the previous prime. This ensures every $n < 521$ has a prime in $(n, 2n]$.\n\nExample: For $n = 50$, we find 61 in the chain with $50 < 61 \\leq 100$. ✓",
+    "significance": "key",
+    "relatedConcepts": [
+      "constructive proofs",
+      "explicit bounds"
+    ]
+  },
+  {
+    "id": "ann-pnt-connection",
+    "proofId": "bertrands-postulate",
+    "range": {
+      "startLine": 143,
+      "endLine": 154
+    },
+    "type": "insight",
+    "title": "Beyond Bertrand: The Prime Number Theorem",
+    "content": "Bertrand's Postulate is a \"first step\" toward understanding prime distribution. The **Prime Number Theorem** (1896) goes further:\n\n$$\\pi(x) \\sim \\frac{x}{\\ln x}$$\n\nThis tells us *how many* primes exist below $x$, not just that primes exist in certain ranges.\n\nFor the interval $(n, 2n]$, the PNT predicts roughly $n/\\ln n$ primes—far more than Bertrand's guaranteed minimum of 1.",
+    "mathContext": "$\\pi(x)$ counts primes up to $x$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Prime Number Theorem",
+      "asymptotic analysis",
+      "Riemann Hypothesis"
+    ]
+  }
+]

--- a/src/data/proofs/bertrands-postulate/annotations.source.json
+++ b/src/data/proofs/bertrands-postulate/annotations.source.json
@@ -1,0 +1,136 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "bertrands-postulate",
+    "anchor": {
+      "type": "imports"
+    },
+    "type": "concept",
+    "title": "Primes Are Never Far Apart",
+    "content": "Bertrand's Postulate guarantees that primes are distributed densely enough that between any positive integer $n$ and its double $2n$, there's always at least one prime.\n\n$$\\forall n > 0, \\exists p \\text{ prime}: n < p \\leq 2n$$\n\nThis means:\n- After 2, the next prime (3) is at most 4\n- After 100, there's a prime before 200\n- Prime gaps grow, but not too fast",
+    "significance": "critical",
+    "relatedConcepts": [
+      "prime gaps",
+      "prime distribution",
+      "number theory"
+    ]
+  },
+  {
+    "id": "ann-historical",
+    "proofId": "bertrands-postulate",
+    "anchor": {
+      "type": "section-doc",
+      "contains": "What This Proves"
+    },
+    "type": "insight",
+    "title": "Three Mathematical Giants",
+    "content": "**Bertrand (1845)**: Conjectured the result after checking it for all $n$ up to 3 million by hand calculation.\n\n**Chebyshev (1852)**: Proved the conjecture using analytic techniques involving his famous $\\vartheta$ and $\\psi$ functions.\n\n**Erdős (1932)**: Published an elementary proof at age 19—his first paper. This launched a legendary career of 1,500+ papers and became the standard approach taught today.",
+    "mathContext": "The proof evolved from analytic to elementary methods.",
+    "significance": "key",
+    "relatedConcepts": [
+      "history of mathematics",
+      "analytic number theory"
+    ]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "bertrands-postulate",
+    "anchor": {
+      "type": "theorem",
+      "name": "bertrand_postulate"
+    },
+    "type": "theorem",
+    "title": "The Main Statement",
+    "content": "**Bertrand's Postulate**: For any positive natural number $n$, there exists a prime $p$ with $n < p \\leq 2n$.\n\n```lean\ntheorem bertrand_postulate (n : ℕ) (hn : 0 < n) :\n    ∃ p, Nat.Prime p ∧ n < p ∧ p ≤ 2 * n\n```\n\nWe wrap Mathlib's `Nat.exists_prime_lt_and_le_two_mul`, converting the hypothesis from `n ≠ 0` to `0 < n`.",
+    "mathContext": "$\\exists p \\text{ prime}: n < p \\leq 2n$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "prime numbers",
+      "existence proofs"
+    ]
+  },
+  {
+    "id": "ann-prime-gaps",
+    "proofId": "bertrands-postulate",
+    "anchor": {
+      "type": "theorem",
+      "name": "prime_gap_bounded"
+    },
+    "type": "insight",
+    "title": "Bounded Prime Gaps",
+    "content": "A direct corollary: **prime gaps are bounded by the prime itself**.\n\nIf $p$ is prime, the next prime $q$ satisfies $q \\leq 2p$.\n\nThis means the gap $g = q - p$ satisfies $g < p$.\n\nFor comparison:\n- Gap after 2: at most 2 (actual: 1, next is 3)\n- Gap after 7: at most 7 (actual: 4, next is 11)\n- Gap after 113: at most 113 (actual: 14, next is 127)",
+    "mathContext": "$p_{n+1} - p_n < p_n$",
+    "significance": "key",
+    "relatedConcepts": [
+      "prime gaps",
+      "consecutive primes"
+    ]
+  },
+  {
+    "id": "ann-infinitude",
+    "proofId": "bertrands-postulate",
+    "anchor": {
+      "type": "theorem",
+      "name": "primes_infinite_via_bertrand"
+    },
+    "type": "technique",
+    "title": "Infinitude of Primes (Alternative Proof)",
+    "content": "Bertrand's Postulate provides yet another proof that there are infinitely many primes:\n\n1. Given any $n$, apply Bertrand to get prime $p$ with $n < p$\n2. This prime $p > n$\n3. Since $n$ was arbitrary, primes are unbounded\n4. Therefore there are infinitely many primes\n\nThis is distinct from Euclid's factorial argument, showing how the same result can arise from different perspectives.",
+    "significance": "key",
+    "relatedConcepts": [
+      "infinitude of primes",
+      "Euclid's theorem"
+    ]
+  },
+  {
+    "id": "ann-erdos-proof",
+    "proofId": "bertrands-postulate",
+    "anchor": {
+      "type": "theorem",
+      "name": "bertrand_large"
+    },
+    "type": "technique",
+    "title": "Erdős's Central Binomial Approach",
+    "content": "For large $n$ (≥ 512), the proof analyzes the **central binomial coefficient** $\\binom{2n}{n}$:\n\n1. **Lower bound**: $\\binom{2n}{n} > \\frac{4^n}{2n}$\n\n2. **Upper bound (if no prime in $(n, 2n]$)**: The prime factorization is constrained by primes ≤ $n$\n\n3. **Contradiction**: These bounds conflict for $n \\geq 512$\n\nThe key insight: primes in $(n, 2n]$ divide $\\binom{2n}{n}$ exactly once, so their absence shrinks the factorization.",
+    "mathContext": "Analyze $\\binom{2n}{n} = \\frac{(2n)!}{(n!)^2}$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "binomial coefficients",
+      "prime factorization"
+    ]
+  },
+  {
+    "id": "ann-small-cases",
+    "proofId": "bertrands-postulate",
+    "anchor": {
+      "type": "section-doc",
+      "contains": "Examples"
+    },
+    "type": "insight",
+    "title": "The Descending Prime Chain",
+    "content": "For small $n$ (< 512), an explicit chain of primes covers all cases:\n\n983, 491, 241, 127, 61, 31, 17, 11, 7, 5, 3, 2\n\nEach prime $p$ in this list satisfies $p > q/2$ where $q$ is the previous prime. This ensures every $n < 521$ has a prime in $(n, 2n]$.\n\nExample: For $n = 50$, we find 61 in the chain with $50 < 61 \\leq 100$. ✓",
+    "significance": "key",
+    "relatedConcepts": [
+      "constructive proofs",
+      "explicit bounds"
+    ]
+  },
+  {
+    "id": "ann-pnt-connection",
+    "proofId": "bertrands-postulate",
+    "anchor": {
+      "type": "section-doc",
+      "contains": "Connection to Prime Number Theorem"
+    },
+    "type": "insight",
+    "title": "Beyond Bertrand: The Prime Number Theorem",
+    "content": "Bertrand's Postulate is a \"first step\" toward understanding prime distribution. The **Prime Number Theorem** (1896) goes further:\n\n$$\\pi(x) \\sim \\frac{x}{\\ln x}$$\n\nThis tells us *how many* primes exist below $x$, not just that primes exist in certain ranges.\n\nFor the interval $(n, 2n]$, the PNT predicts roughly $n/\\ln n$ primes—far more than Bertrand's guaranteed minimum of 1.",
+    "mathContext": "$\\pi(x)$ counts primes up to $x$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Prime Number Theorem",
+      "asymptotic analysis",
+      "Riemann Hypothesis"
+    ]
+  }
+]

--- a/src/data/proofs/bertrands-postulate/index.ts
+++ b/src/data/proofs/bertrands-postulate/index.ts
@@ -1,0 +1,37 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, TacticState } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import tacticStatesJson from './tacticStates.json'
+import sourceRaw from '../../../../proofs/Proofs/BertrandsPostulate.lean?raw'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+export const bertrandsPostulateProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const bertrandsPostulateAnnotations: Annotation[] = annotationsJson as Annotation[]
+export const bertrandsPostulateTacticStates: TacticState[] = tacticStatesJson as TacticState[]
+
+export const bertrandsPostulateData: ProofData = {
+  proof: bertrandsPostulateProof,
+  annotations: bertrandsPostulateAnnotations,
+  tacticStates: bertrandsPostulateTacticStates,
+}

--- a/src/data/proofs/bertrands-postulate/meta.json
+++ b/src/data/proofs/bertrands-postulate/meta.json
@@ -1,0 +1,84 @@
+{
+  "id": "bertrands-postulate",
+  "title": "Bertrand's Postulate",
+  "slug": "bertrands-postulate",
+  "description": "For every integer n > 1, there exists a prime p such that n < p ≤ 2n. Conjectured by Bertrand (1845), first proved by Chebyshev (1852), with an elegant elementary proof by Erdős (1932).",
+  "meta": {
+    "author": "Chebyshev (1852), Erdős (1932)",
+    "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/Bertrand.html",
+    "date": "1852",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BertrandsPostulate.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "prime-gaps",
+      "classic",
+      "erdos"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.exists_prime_lt_and_le_two_mul",
+        "description": "Main Bertrand's Postulate theorem",
+        "module": "Mathlib.NumberTheory.Bertrand"
+      },
+      {
+        "theorem": "Nat.bertrand",
+        "description": "Alias for the main theorem",
+        "module": "Mathlib.NumberTheory.Bertrand"
+      }
+    ],
+    "originalContributions": [
+      "Pedagogical wrapper with clear documentation",
+      "Corollaries: prime gaps are bounded, infinitude of primes via Bertrand",
+      "Connection to Prime Number Theorem explained"
+    ],
+    "dateAdded": "12/26/25",
+    "wiedijkNumber": 98
+  },
+  "overview": {
+    "historicalContext": "Joseph Bertrand conjectured this result in 1845 after verifying it computationally for all integers up to 3 million. Pafnuty Chebyshev provided the first proof in 1852 using analytic methods involving the Chebyshev functions. In 1932, the 19-year-old Paul Erdős published an elegant elementary proof that avoided complex analysis entirely, relying instead on clever analysis of the central binomial coefficient.\n\nThe theorem is sometimes called the \"Bertrand-Chebyshev theorem\" in honor of both the conjecturer and first prover. Erdős's proof became his first published paper and launched his legendary mathematical career.\n\nBertrand's Postulate is a stepping stone toward the Prime Number Theorem, which gives the asymptotic density of primes. While Bertrand guarantees at least one prime in (n, 2n], the PNT tells us there are approximately n/ln(n) primes below n.",
+    "problemStatement": "**Bertrand's Postulate**: For every positive integer $n$, there exists a prime $p$ such that:\n\n$$n < p \\leq 2n$$\n\nEquivalently: between any positive integer and its double, there is always at least one prime number.\n\nThis gives an explicit upper bound on prime gaps: if $p$ is prime, the next prime is at most $2p$.",
+    "proofStrategy": "The Mathlib proof follows Erdős's elementary approach:\n\n1. **Central Binomial Coefficient**: Analyze $\\binom{2n}{n} = \\frac{(2n)!}{(n!)^2}$\n\n2. **Prime Factorization**: Examine which primes divide $\\binom{2n}{n}$ and with what multiplicity\n\n3. **Upper Bound**: Show that if no prime exists in $(n, 2n]$, then the prime factorization of $\\binom{2n}{n}$ is \"too small\"\n\n4. **Lower Bound**: Use the inequality $4^n / (2n) < \\binom{2n}{n}$\n\n5. **Contradiction**: For large $n$ (specifically $n \\geq 512$), these bounds conflict\n\n6. **Small Cases**: Handle $n < 512$ by exhibiting an explicit descending chain of primes:\n   983, 491, 241, 127, 61, 31, 17, 11, 7, 5, 3, 2\n   where each prime is more than half but at most double the next.",
+    "keyInsights": [
+      "The central binomial coefficient $\\binom{2n}{n}$ encodes information about primes in $(n, 2n]$",
+      "Primes in $(n, 2n]$ divide $\\binom{2n}{n}$ exactly once (they appear in $(2n)!$ but not in $(n!)^2$)",
+      "The absence of such primes would make $\\binom{2n}{n}$ \"too small\" compared to its known lower bound",
+      "Erdős's proof is entirely elementary—no complex analysis or calculus required"
+    ]
+  },
+  "sections": [
+    {
+      "id": "main-theorem",
+      "title": "The Main Theorem",
+      "startLine": 52,
+      "endLine": 67,
+      "summary": "Bertrand's Postulate: for any positive n, there exists a prime p with n < p ≤ 2n. Includes an alias using Mathlib's naming convention."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries",
+      "startLine": 69,
+      "endLine": 106,
+      "summary": "Consequences including: existence of primes in intervals, prime gaps are bounded, and infinitude of primes (derived from Bertrand)."
+    },
+    {
+      "id": "large-n",
+      "title": "Stronger Bounds for Large n",
+      "startLine": 108,
+      "endLine": 119,
+      "summary": "The theorem for n ≥ 512, where the Erdős-style analysis of C(2n,n) applies directly."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization wraps Mathlib's complete proof of Bertrand's Postulate, which follows the elementary approach of Erdős. The proof demonstrates that advanced results in number theory can be established without complex analysis.\n\nThe key insight is that the central binomial coefficient's prime factorization is constrained by the distribution of primes—if there were no prime between n and 2n, the factorization would be too \"sparse\" to match the coefficient's known magnitude.",
+    "implications": "Bertrand's Postulate has several important applications:\n\n1. **Prime Gaps**: Provides an explicit bound on gaps between consecutive primes—the gap after prime p is at most p.\n\n2. **Algorithmic Applications**: Guarantees a prime can always be found in a known range, useful for primality-related algorithms.\n\n3. **Foundation for Stronger Results**: Leads to refinements like Nagura's theorem (1952): for n > 25, there's a prime between n and (1.2)n.\n\n4. **Historical Significance**: Erdős's proof at age 19 launched a legendary career with over 1,500 papers.",
+    "openQuestions": [
+      "Cramér's Conjecture: Are prime gaps bounded by O((log p)²)?",
+      "Is there always a prime between n² and (n+1)² (Legendre's conjecture)?",
+      "What is the precise density of primes in short intervals?"
+    ]
+  }
+}

--- a/src/data/proofs/bertrands-postulate/tacticStates.json
+++ b/src/data/proofs/bertrands-postulate/tacticStates.json
@@ -1,0 +1,233 @@
+[
+  {
+    "line": 74,
+    "tactic": "by",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 75,
+    "tactic": "exact bertrand_postulate n hn",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          { "names": ["n"], "type": "ℕ" },
+          { "names": ["hn"], "type": "1 ≤ n" }
+        ],
+        "conclusion": "∃ p, Nat.Prime p ∧ n < p ∧ p ≤ 2 * n"
+      }
+    ],
+    "goalsAfter": []
+  },
+  {
+    "line": 89,
+    "tactic": "by",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 90,
+    "tactic": "intro n",
+    "goalsBefore": [
+      {
+        "hypotheses": [],
+        "conclusion": "∀ (n : ℕ), ∃ p, Nat.Prime p ∧ p > n"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          { "names": ["n"], "type": "ℕ" }
+        ],
+        "conclusion": "∃ p, Nat.Prime p ∧ p > n"
+      }
+    ]
+  },
+  {
+    "line": 91,
+    "tactic": "cases' n with n",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          { "names": ["n"], "type": "ℕ" }
+        ],
+        "conclusion": "∃ p, Nat.Prime p ∧ p > n"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [],
+        "conclusion": "∃ p, Nat.Prime p ∧ p > Nat.zero"
+      },
+      {
+        "hypotheses": [
+          { "names": ["n"], "type": "ℕ" }
+        ],
+        "conclusion": "∃ p, Nat.Prime p ∧ p > Nat.succ n"
+      }
+    ]
+  },
+  {
+    "line": 93,
+    "tactic": "use 2",
+    "goalsBefore": [
+      {
+        "hypotheses": [],
+        "conclusion": "∃ p, Nat.Prime p ∧ p > Nat.zero"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [],
+        "conclusion": "Nat.Prime 2 ∧ 2 > Nat.zero"
+      }
+    ]
+  },
+  {
+    "line": 94,
+    "tactic": "exact ⟨Nat.prime_two, by omega⟩",
+    "goalsBefore": [
+      {
+        "hypotheses": [],
+        "conclusion": "Nat.Prime 2 ∧ 2 > Nat.zero"
+      }
+    ],
+    "goalsAfter": []
+  },
+  {
+    "line": 96,
+    "tactic": "obtain ⟨p, hp_prime, hp_gt, _⟩ := bertrand_postulate (n + 1) (by omega)",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          { "names": ["n"], "type": "ℕ" }
+        ],
+        "conclusion": "∃ p, Nat.Prime p ∧ p > Nat.succ n"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          { "names": ["n"], "type": "ℕ" },
+          { "names": ["p"], "type": "ℕ" },
+          { "names": ["hp_prime"], "type": "Nat.Prime p" },
+          { "names": ["hp_gt"], "type": "n + 1 < p" }
+        ],
+        "conclusion": "∃ p, Nat.Prime p ∧ p > Nat.succ n"
+      }
+    ]
+  },
+  {
+    "line": 97,
+    "tactic": "exact ⟨p, hp_prime, hp_gt⟩",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          { "names": ["n"], "type": "ℕ" },
+          { "names": ["p"], "type": "ℕ" },
+          { "names": ["hp_prime"], "type": "Nat.Prime p" },
+          { "names": ["hp_gt"], "type": "n + 1 < p" }
+        ],
+        "conclusion": "∃ p, Nat.Prime p ∧ p > Nat.succ n"
+      }
+    ],
+    "goalsAfter": []
+  },
+  {
+    "line": 102,
+    "tactic": "by",
+    "goalsBefore": [],
+    "goalsAfter": []
+  },
+  {
+    "line": 103,
+    "tactic": "intro ⟨p, _, h_largest⟩",
+    "goalsBefore": [
+      {
+        "hypotheses": [],
+        "conclusion": "¬∃ p, Nat.Prime p ∧ ∀ (q : ℕ), Nat.Prime q → q ≤ p"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          { "names": ["p"], "type": "ℕ" },
+          { "names": ["h_largest"], "type": "∀ (q : ℕ), Nat.Prime q → q ≤ p" }
+        ],
+        "conclusion": "False"
+      }
+    ]
+  },
+  {
+    "line": 104,
+    "tactic": "obtain ⟨q, hq_prime, hq_gt⟩ := primes_infinite_via_bertrand p",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          { "names": ["p"], "type": "ℕ" },
+          { "names": ["h_largest"], "type": "∀ (q : ℕ), Nat.Prime q → q ≤ p" }
+        ],
+        "conclusion": "False"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          { "names": ["p"], "type": "ℕ" },
+          { "names": ["h_largest"], "type": "∀ (q : ℕ), Nat.Prime q → q ≤ p" },
+          { "names": ["q"], "type": "ℕ" },
+          { "names": ["hq_prime"], "type": "Nat.Prime q" },
+          { "names": ["hq_gt"], "type": "q > p" }
+        ],
+        "conclusion": "False"
+      }
+    ]
+  },
+  {
+    "line": 105,
+    "tactic": "have hq_le := h_largest q hq_prime",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          { "names": ["p"], "type": "ℕ" },
+          { "names": ["h_largest"], "type": "∀ (q : ℕ), Nat.Prime q → q ≤ p" },
+          { "names": ["q"], "type": "ℕ" },
+          { "names": ["hq_prime"], "type": "Nat.Prime q" },
+          { "names": ["hq_gt"], "type": "q > p" }
+        ],
+        "conclusion": "False"
+      }
+    ],
+    "goalsAfter": [
+      {
+        "hypotheses": [
+          { "names": ["p"], "type": "ℕ" },
+          { "names": ["h_largest"], "type": "∀ (q : ℕ), Nat.Prime q → q ≤ p" },
+          { "names": ["q"], "type": "ℕ" },
+          { "names": ["hq_prime"], "type": "Nat.Prime q" },
+          { "names": ["hq_gt"], "type": "q > p" },
+          { "names": ["hq_le"], "type": "q ≤ p" }
+        ],
+        "conclusion": "False"
+      }
+    ]
+  },
+  {
+    "line": 106,
+    "tactic": "omega",
+    "goalsBefore": [
+      {
+        "hypotheses": [
+          { "names": ["p"], "type": "ℕ" },
+          { "names": ["h_largest"], "type": "∀ (q : ℕ), Nat.Prime q → q ≤ p" },
+          { "names": ["q"], "type": "ℕ" },
+          { "names": ["hq_prime"], "type": "Nat.Prime q" },
+          { "names": ["hq_gt"], "type": "q > p" },
+          { "names": ["hq_le"], "type": "q ≤ p" }
+        ],
+        "conclusion": "False"
+      }
+    ],
+    "goalsAfter": []
+  }
+]

--- a/src/data/proofs/index.ts
+++ b/src/data/proofs/index.ts
@@ -14,6 +14,7 @@ import { eulerIdentityData } from './euler-identity'
 import { brouwerFixedPointData } from './brouwer-fixed-point'
 import { ramanujanSumFallacyData } from './ramanujan-sum-fallacy'
 import { abelRuffiniData } from './abel-ruffini'
+import { bertrandsPostulateData } from './bertrands-postulate'
 import { borsukUlamData } from './borsuk-ulam'
 import { centralLimitTheoremData } from './central-limit-theorem'
 import { fermatsLastTheoremData } from './fermats-last-theorem'
@@ -55,6 +56,7 @@ export const proofs: Record<string, ProofData> = {
   'brouwer-fixed-point': brouwerFixedPointData,
   'ramanujan-sum-fallacy': ramanujanSumFallacyData,
   'abel-ruffini': abelRuffiniData,
+  'bertrands-postulate': bertrandsPostulateData,
   'borsuk-ulam': borsukUlamData,
   'central-limit-theorem': centralLimitTheoremData,
   'fermats-last-theorem': fermatsLastTheoremData,


### PR DESCRIPTION
## Summary

- Adds Bertrand's Postulate (Wiedijk #98): For every n > 0, there exists a prime p with n < p ≤ 2n
- Uses Mathlib's `Nat.exists_prime_lt_and_le_two_mul` as the foundation
- Includes pedagogical wrapper theorems and corollaries (prime gaps bounded, infinitude of primes)
- Full annotations and documentation explaining Erdős's elementary proof approach

Closes #177

## Test plan

- [x] Lean proof builds without errors (`lake build Proofs.BertrandsPostulate`)
- [x] TypeScript builds successfully (`pnpm run build`)
- [ ] Proof displays correctly in the web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)