### PR TITLE
Add Erdős problems infrastructure to gallery

### DIFF
--- a/src/components/ui/proof-badge.tsx
+++ b/src/components/ui/proof-badge.tsx
@@ -1,4 +1,4 @@
-import { BADGE_INFO, WIEDIJK_BADGE_INFO, WIEDIJK_THEOREMS, type ProofBadge as ProofBadgeType } from '@/types/proof'
+import { BADGE_INFO, WIEDIJK_BADGE_INFO, WIEDIJK_THEOREMS, ERDOS_BADGE_INFO, ERDOS_PROBLEMS, type ProofBadge as ProofBadgeType, type ErdosProblemStatus } from '@/types/proof'
 import { Tooltip, TooltipTrigger, TooltipContent } from './tooltip'
 
 interface ProofBadgeProps {
@@ -98,6 +98,75 @@ export function WiedijkBadge({
           onClick={(e) => e.stopPropagation()}
         >
           View on Wiedijk's list →
+        </a>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+interface ErdosBadgeProps {
+  number?: number
+  solvedBy?: string
+  problemStatus?: ErdosProblemStatus
+  size?: 'sm' | 'md'
+  className?: string
+}
+
+/**
+ * Displays a badge for Erdős Problems from erdosproblems.com
+ */
+export function ErdosBadge({
+  number,
+  solvedBy,
+  problemStatus,
+  size = 'sm',
+  className = ''
+}: ErdosBadgeProps) {
+  if (!number) return null
+
+  const sizeClasses = size === 'sm'
+    ? 'h-6 min-w-6 px-1.5 text-[10px]'
+    : 'h-8 min-w-8 px-2 text-xs'
+
+  const problemName = ERDOS_PROBLEMS[number] || `Problem #${number}`
+  const statusEmoji = problemStatus === 'solved' ? '✓' : problemStatus === 'partially-solved' ? '◐' : '○'
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={`inline-flex items-center justify-center gap-1 rounded-full font-bold shrink-0 ${sizeClasses} ${className}`}
+          style={{
+            backgroundColor: `${ERDOS_BADGE_INFO.color}25`,
+            color: ERDOS_BADGE_INFO.textColor,
+            border: `1.5px solid ${ERDOS_BADGE_INFO.color}50`
+          }}
+        >
+          <span>E</span>
+          <span>{number}</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p className="font-medium">Erdős Problem #{number}</p>
+        <p className="text-muted-foreground">{problemName}</p>
+        {problemStatus && (
+          <p className="text-xs mt-1">
+            Status: {statusEmoji} {problemStatus}
+          </p>
+        )}
+        {solvedBy && (
+          <p className="text-xs text-annotation mt-1">
+            Solved by: {solvedBy}
+          </p>
+        )}
+        <a
+          href={`${ERDOS_BADGE_INFO.url}${number}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-annotation hover:underline mt-1 block"
+          onClick={(e) => e.stopPropagation()}
+        >
+          View on erdosproblems.com →
         </a>
       </TooltipContent>
     </Tooltip>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,8 +4,8 @@ import { listings } from '@/data/proofs'
 import { useAuth } from '@/contexts/AuthContext'
 import { UserMenu } from '@/components/auth/UserMenu'
 import { Footer } from '@/components/Footer'
-import { ProofBadge, WiedijkBadge, BadgeFilter, MathlibIndicator } from '@/components/ui/proof-badge'
-import { WIEDIJK_BADGE_INFO, HILBERT_BADGE_INFO, MILLENNIUM_BADGE_INFO } from '@/types/proof'
+import { ProofBadge, WiedijkBadge, ErdosBadge, BadgeFilter, MathlibIndicator } from '@/components/ui/proof-badge'
+import { WIEDIJK_BADGE_INFO, HILBERT_BADGE_INFO, MILLENNIUM_BADGE_INFO, ERDOS_BADGE_INFO } from '@/types/proof'
 import { BookOpen, ArrowRight, Clock, CheckCircle, AlertCircle, Plus, Filter, ArrowUpDown, Search } from 'lucide-react'
 import type { ProofBadge as ProofBadgeType, ProofListing } from '@/types/proof'
 
@@ -26,6 +26,7 @@ export function HomePage() {
   const [showWiedijkOnly, setShowWiedijkOnly] = useState(false)
   const [showHilbertOnly, setShowHilbertOnly] = useState(false)
   const [showMillenniumOnly, setShowMillenniumOnly] = useState(false)
+  const [showErdosOnly, setShowErdosOnly] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
 
   // Filter and sort proofs
@@ -70,6 +71,13 @@ export function HomePage() {
       )
     }
 
+    // Filter by Erdős Problems
+    if (showErdosOnly) {
+      filtered = filtered.filter((listing) =>
+        listing.erdosNumber !== undefined
+      )
+    }
+
     // Sort proofs
     return [...filtered].sort((a, b) => {
       switch (sortBy) {
@@ -83,7 +91,7 @@ export function HomePage() {
           return 0
       }
     })
-  }, [searchQuery, selectedBadges, sortBy, showWiedijkOnly, showHilbertOnly, showMillenniumOnly])
+  }, [searchQuery, selectedBadges, sortBy, showWiedijkOnly, showHilbertOnly, showMillenniumOnly, showErdosOnly])
 
   const handleBadgeToggle = (badge: ProofBadgeType) => {
     setSelectedBadges((prev) => {
@@ -99,6 +107,7 @@ export function HomePage() {
     setShowWiedijkOnly(false)
     setShowHilbertOnly(false)
     setShowMillenniumOnly(false)
+    setShowErdosOnly(false)
     setSearchQuery('')
   }
 
@@ -178,16 +187,16 @@ export function HomePage() {
             <button
               onClick={() => setShowFilters(!showFilters)}
               className={`flex items-center gap-1.5 text-sm transition-colors ${
-                showFilters || selectedBadges.length > 0 || showWiedijkOnly || showHilbertOnly || showMillenniumOnly
+                showFilters || selectedBadges.length > 0 || showWiedijkOnly || showHilbertOnly || showMillenniumOnly || showErdosOnly
                   ? 'text-annotation'
                   : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               <Filter className="h-4 w-4" />
               <span>Filter</span>
-              {(selectedBadges.length > 0 || showWiedijkOnly || showHilbertOnly || showMillenniumOnly) && (
+              {(selectedBadges.length > 0 || showWiedijkOnly || showHilbertOnly || showMillenniumOnly || showErdosOnly) && (
                 <span className="bg-annotation/20 text-annotation px-1.5 py-0.5 rounded text-xs">
-                  {selectedBadges.length + (showWiedijkOnly ? 1 : 0) + (showHilbertOnly ? 1 : 0) + (showMillenniumOnly ? 1 : 0)}
+                  {selectedBadges.length + (showWiedijkOnly ? 1 : 0) + (showHilbertOnly ? 1 : 0) + (showMillenniumOnly ? 1 : 0) + (showErdosOnly ? 1 : 0)}
                 </span>
               )}
             </button>
@@ -199,7 +208,7 @@ export function HomePage() {
           <div className="mb-6 p-4 bg-card border border-border rounded-lg">
             <div className="flex items-center justify-between mb-3">
               <span className="text-sm font-medium">Filter by Category</span>
-              {(selectedBadges.length > 0 || showWiedijkOnly || showHilbertOnly || showMillenniumOnly) && (
+              {(selectedBadges.length > 0 || showWiedijkOnly || showHilbertOnly || showMillenniumOnly || showErdosOnly) && (
                 <button
                   onClick={clearFilters}
                   className="text-xs text-muted-foreground hover:text-foreground"
@@ -285,6 +294,30 @@ export function HomePage() {
                 </span>
                 <span className="hidden sm:inline">Millennium</span>
               </button>
+              {/* Erdős Filter Toggle */}
+              <button
+                onClick={() => setShowErdosOnly(!showErdosOnly)}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all
+                  ${showErdosOnly
+                    ? 'ring-2 ring-offset-2 ring-offset-background'
+                    : 'opacity-50 hover:opacity-75'
+                  }`}
+                style={{
+                  backgroundColor: `${ERDOS_BADGE_INFO.color}20`,
+                  color: ERDOS_BADGE_INFO.textColor,
+                  ...(showErdosOnly && { ringColor: ERDOS_BADGE_INFO.color })
+                }}
+              >
+                <span className="inline-flex items-center justify-center h-4 w-4 rounded-full text-[9px] font-bold"
+                  style={{
+                    backgroundColor: `${ERDOS_BADGE_INFO.color}40`,
+                    color: ERDOS_BADGE_INFO.textColor
+                  }}
+                >
+                  E
+                </span>
+                <span className="hidden sm:inline">Erdős</span>
+              </button>
             </div>
           </div>
         )}
@@ -305,6 +338,8 @@ export function HomePage() {
               <div className="flex items-start gap-3 mb-3">
                 {listing.wiedijkNumber ? (
                   <WiedijkBadge number={listing.wiedijkNumber} size="md" />
+                ) : listing.erdosNumber ? (
+                  <ErdosBadge number={listing.erdosNumber} size="md" />
                 ) : (
                   <div className="h-10 w-10 rounded-lg bg-annotation/20 flex items-center justify-center flex-shrink-0">
                     <BookOpen className="h-5 w-5 text-annotation" />
@@ -358,10 +393,10 @@ export function HomePage() {
         </div>
 
         {/* Empty state when filters result in no proofs */}
-        {proofs.length === 0 && (searchQuery.trim() || selectedBadges.length > 0 || showWiedijkOnly || showHilbertOnly || showMillenniumOnly) && (
+        {proofs.length === 0 && (searchQuery.trim() || selectedBadges.length > 0 || showWiedijkOnly || showHilbertOnly || showMillenniumOnly || showErdosOnly) && (
           <div className="text-center py-12">
             <p className="text-muted-foreground mb-4">
-              No proofs match your search{selectedBadges.length > 0 || showWiedijkOnly || showHilbertOnly || showMillenniumOnly ? ' and filters' : ''}.
+              No proofs match your search{selectedBadges.length > 0 || showWiedijkOnly || showHilbertOnly || showMillenniumOnly || showErdosOnly ? ' and filters' : ''}.
             </p>
             <button
               onClick={clearFilters}

--- a/src/types/proof.ts
+++ b/src/types/proof.ts
@@ -202,6 +202,40 @@ export const MILLENNIUM_PROBLEMS: Record<MillenniumProblem, string> = {
 }
 
 /**
+ * Display information for Erdős Problems badge
+ */
+export const ERDOS_BADGE_INFO = {
+  color: '#22C55E', // Green - distinct from other collections
+  textColor: '#22C55E',
+  label: 'Erdős Problems',
+  description: 'A problem from Paul Erdős\'s collection at erdosproblems.com',
+  url: 'https://www.erdosproblems.com/'
+}
+
+/**
+ * Status of an Erdős problem
+ */
+export type ErdosProblemStatus = 'open' | 'solved' | 'partially-solved'
+
+/**
+ * Mapping of some notable Erdős problem numbers to their names
+ * See: https://www.erdosproblems.com/
+ */
+export const ERDOS_PROBLEMS: Record<number, string> = {
+  1: 'Covering Congruences',
+  28: 'Sum-Free Sets',
+  99: 'Squares in Arithmetic Progression',
+  124: 'Prime Gaps Conjecture',
+  178: 'Distinct Sums from Sets',
+  206: 'Chromatic Number of the Plane',
+  365: 'Erdős-Straus Conjecture',
+  396: 'Cameron-Erdős Conjecture',
+  434: 'Erdős-Ko-Rado Problem',
+  461: 'Multiplication Table Problem',
+  702: 'Erdős-Turán Conjecture on Additive Bases'
+}
+
+/**
  * A theorem or lemma imported from Mathlib
  */
 export interface MathlibDependency {
@@ -241,6 +275,20 @@ export interface ProofMeta {
   hilbertNumber?: number
   /** Millennium Prize Problem identifier if applicable */
   millenniumProblem?: MillenniumProblem
+
+  // Erdős Problems fields
+  /** Erdős problem number from erdosproblems.com */
+  erdosNumber?: number
+  /** Direct URL to the problem on erdosproblems.com */
+  erdosUrl?: string
+  /** Who solved the problem (person or AI system) */
+  erdosSolvedBy?: string
+  /** When the problem was solved (date string) */
+  erdosSolvedDate?: string
+  /** Prize money if applicable */
+  erdosPrizeValue?: string
+  /** Current status of the Erdős problem */
+  erdosProblemStatus?: ErdosProblemStatus
 }
 
 export interface ProofSection {
@@ -309,6 +357,7 @@ export interface ProofListing {
   wiedijkNumber?: number
   hilbertNumber?: number
   millenniumProblem?: MillenniumProblem
+  erdosNumber?: number
   mathlibCount?: number
   sorries?: number
   annotationCount: number


### PR DESCRIPTION
## Summary
- Adds TypeScript types for Erdős problem metadata (`erdosNumber`, `erdosUrl`, `erdosSolvedBy`, `erdosSolvedDate`, `erdosPrizeValue`, `erdosProblemStatus`)
- Adds `ErdosBadge` component with tooltip linking to erdosproblems.com
- Adds Erdős filter toggle to the gallery filter panel (consistent with Wiedijk/Hilbert/Millennium pattern)
- Displays Erdős badge on proof cards when `erdosNumber` is set

## Test plan
- [ ] Verify gallery loads without errors
- [ ] Verify Erdős filter button appears in filter panel
- [ ] Verify clicking Erdős filter shows only proofs with `erdosNumber`
- [ ] When Erdős proofs are added, verify badge displays correctly on cards
- [ ] Verify ErdosBadge tooltip links to erdosproblems.com

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)