### PR TITLE
Fix Erdős #144: Update badge to axiom

### DIFF
--- a/src/data/proofs/erdos-144/meta.json
+++ b/src/data/proofs/erdos-144/meta.json
@@ -16,7 +16,7 @@
       "density",
       "probabilistic-number-theory"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 144,
     "erdosUrl": "https://erdosproblems.com/144",


### PR DESCRIPTION
## Summary
Minor fix for Erdős Problem #144 - Propinquity of Divisors.

## Changes
- Fixed badge from "mathlib" to "axiom" since the proof uses axiomatized theorems (Maier-Tenenbaum, Erdős-Hall)
- Proof content was already complete from previous enhancement

## Note
This stub was already well-enhanced. Only the badge needed correction.

🤖 Generated by enhancer-1