### PR TITLE
Enhance Erdős #444: Generalized Divisor Functions

### DIFF
--- a/src/data/proofs/erdos-444/meta.json
+++ b/src/data/proofs/erdos-444/meta.json
@@ -16,11 +16,46 @@
       "harmonic-sums",
       "extremal"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 444,
     "erdosUrl": "https://erdosproblems.com/444",
-    "erdosProblemStatus": "solved"
+    "erdosProblemStatus": "solved",
+    "dateAdded": "2026-01-18",
+    "mathlib_version": "4.15.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.Infinite",
+        "description": "Infinite sets predicate",
+        "module": "Mathlib.Data.Set.Basic"
+      },
+      {
+        "theorem": "Finset.filter",
+        "description": "Filtering finite sets",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sup",
+        "description": "Supremum over finite sets",
+        "module": "Mathlib.Data.Finset.Lattice"
+      },
+      {
+        "theorem": "Filter.atTop",
+        "description": "Filter at infinity for limits",
+        "module": "Mathlib.Order.Filter.AtTopBot"
+      }
+    ],
+    "originalContributions": [
+      "InfiniteSubset definition: infinite subsets of ℕ",
+      "d_A definition: generalized divisor function counting A-divisors",
+      "H_A definition: partial harmonic sum over A",
+      "M_A definition: maximum A-divisor count",
+      "erdos_graham_conjecture definition: the main statement",
+      "erdos_graham_conjecture_true axiom: the result holds",
+      "Special cases: A = ℕ gives d(n), A = primes gives ω(n)",
+      "erdos_444_status theorem: main result via axiom",
+      "limsup_infinite theorem: statement for all k"
+    ]
   },
   "overview": {
     "historicalContext": "From Erdős and Graham's 'Old and New Problems and Results in Combinatorial Number Theory' (1980), page 88. The problem studies the relationship between restricted divisor functions and partial harmonic sums. Erdős and Sárközy resolved it in their paper 'Some asymptotic formulas on generalized divisor functions IV'.",


### PR DESCRIPTION
## Summary
- Enhanced meta.json with proper mathlib dependencies and original contributions
- Verified existing Lean proof and annotations are comprehensive

## Problem
**Erdős Problem #444:** Let A ⊆ ℕ be infinite and d_A(n) count divisors of n belonging to A. Is it true that for every k:

$$\limsup_{x\to \infty} \frac{\max_{n<x}d_A(n)}{\left(\sum_{a\in A, a<x}\frac{1}{a}\right)^k}=\infty$$

**Answer: SOLVED** (Erdős-Sárközy, 1980)
- The maximum divisor count grows faster than ANY fixed power of the harmonic sum
- Applies to ALL infinite subsets A of ℕ

## Key Formalizations
- `InfiniteSubset`, `d_A`, `H_A`, `M_A` definitions for generalized divisor functions
- `erdos_graham_conjecture` — the main statement about limsup = ∞
- `erdos_graham_conjecture_true` axiom — the result holds
- Special cases: A = ℕ (standard divisor d(n)), A = primes (ω(n))
- `limsup_infinite` theorem — statement for all k and infinite A

## Changes
- Updated meta.json with mathlib dependencies (Set.Infinite, Finset.filter, etc.)
- Added originalContributions documenting all formalized definitions
- Corrected badge to 'axiom' (uses axioms for main result)

## Test plan
- [x] `pnpm build` passes
- [x] All JSON files valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)