### PR TITLE
Enhance Erdős #23: Triangle-Free Graphs and Bipartiteness

### DIFF
--- a/src/data/proofs/erdos-23/meta.json
+++ b/src/data/proofs/erdos-23/meta.json
@@ -20,7 +20,9 @@
     "sorries": 0,
     "erdosNumber": 23,
     "erdosUrl": "https://erdosproblems.com/23",
-    "erdosProblemStatus": "open"
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-01-18",
+    "mathlib_version": "4.15.0"
   },
   "overview": {
     "historicalContext": "Posed by Erdős in 1971, with a generalization in 1992. The problem asks how close triangle-free graphs are to being bipartite, measured by edge deletions. The blow-up of C₅ shows n² deletions can be necessary; the conjecture is that n² always suffices.",


### PR DESCRIPTION
## Summary
- Comprehensive Lean 4 formalization of Erdős Problem #23 (OPEN)
- Already had detailed formalization with Graph structure, bipartiteness, triangle-freeness
- Includes C₅ blow-up construction with verified triangle-freeness
- Balogh-Clemen-Lidický (2021) bound: 1.064n²
- Generalized conjecture for higher odd girth
- 17 annotations already present
- Added dateAdded and mathlib_version to meta.json

## Key Content
- Graph, IsBipartite, ContainsTriangle, IsTriangleFree definitions
- C5 definition with verified c5_triangle_free theorem
- c5BlowUpGraph construction with verified c5_blowup_triangle_free
- ErdosConjecture23 and GeneralizedConjecture definitions

## Test plan
- [x] `pnpm build` passes
- [x] annotations.json validates against schema
- [x] meta.json contains complete historical context

🤖 Generated with [Claude Code](https://claude.com/claude-code)