### PR TITLE
Research: erdos-100 - Prove infrastructure lemmas for diameter bounds

### DIFF
--- a/proofs/Proofs/Erdos100Problem.lean
+++ b/proofs/Proofs/Erdos100Problem.lean
@@ -26,6 +26,7 @@ import Mathlib.Data.Real.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Combinatorics.SimpleGraph.Basic
 
 open Real Set Finset
 
@@ -147,15 +148,57 @@ This problem is related to Erdős #89 on distinct distances.
 -/
 
 /-- The number of distinct distances in a point set. -/
-def numDistinctDistances (A : Finset Point) : ℕ :=
+noncomputable def numDistinctDistances (A : Finset Point) : ℕ :=
   ((A ×ˢ A).filter (fun pq => pq.1 ≠ pq.2)).image (fun pq => dist pq.1 pq.2)
     |>.card
+
+/-- All distances in a restricted distance set are at most the diameter. -/
+lemma dist_le_diameter (A : Finset Point) (hne : A.Nonempty) (p q : Point)
+    (hp : p ∈ A) (hq : q ∈ A) : dist p q ≤ diameter A := by
+  simp only [diameter, dif_pos hne]
+  have h1 : dist p q ≤ A.sup' hne (fun q => dist p q) :=
+    Finset.le_sup' (fun q => dist p q) hq
+  have h2 : A.sup' hne (fun q => dist p q) ≤ A.sup' hne (fun p' => A.sup' hne fun q => dist p' q) :=
+    Finset.le_sup' (fun p' => A.sup' hne fun q => dist p' q) hp
+  linarith
+
+/-- For restricted distance sets, all distances are positive integers ≤ diameter. -/
+lemma restricted_dist_is_nat (A : Finset Point) (h : hasRestrictedDistances A)
+    (p q : Point) (hp : p ∈ A) (hq : q ∈ A) (hpq : p ≠ q) :
+    ∃ k : ℕ, k ≥ 1 ∧ k ≤ Nat.floor (diameter A) ∧ dist p q = k := by
+  obtain ⟨k, hk1, hk_eq⟩ := h.2 p hp q hq hpq
+  refine ⟨k, hk1, ?_, hk_eq⟩
+  have hne : A.Nonempty := ⟨p, hp⟩
+  have hle : dist p q ≤ diameter A := dist_le_diameter A hne p q hp hq
+  rw [hk_eq] at hle
+  exact Nat.le_floor hle
 
 /-- For restricted distance sets, distinct distances ≤ diameter.
     (Since distances are integers from 1 to diameter.) -/
 theorem distinct_distances_le_diameter (A : Finset Point)
     (h : hasRestrictedDistances A) :
     numDistinctDistances A ≤ Nat.floor (diameter A) := by
+  -- If A is empty or singleton, numDistinctDistances = 0
+  by_cases hcard : A.card ≤ 1
+  · simp only [numDistinctDistances]
+    -- For singleton or empty sets, the filtered product is empty
+    have : (A ×ˢ A).filter (fun pq => pq.1 ≠ pq.2) = ∅ := by
+      ext ⟨p, q⟩
+      simp only [Finset.mem_filter, Finset.mem_product, Finset.not_mem_empty, iff_false, not_and]
+      intro hp hq hpq
+      have := Finset.card_le_one.mp hcard hp hq
+      exact hpq this
+    simp [this]
+  push_neg at hcard
+  -- A has at least 2 elements
+  have hne : A.Nonempty := by
+    rcases Finset.card_pos.mp (Nat.lt_of_lt_of_le (by norm_num : 0 < 2) hcard) with ⟨x, hx⟩
+    exact ⟨x, hx⟩
+  -- The argument: each distinct distance d satisfies 1 ≤ d ≤ diameter (as a positive integer).
+  -- So the distances form a subset of {1, 2, ..., floor(diameter)}, giving the bound.
+  -- This requires showing the image injects into Nat via the integer structure.
+  -- Technical proof omitted - follows from restricted_dist_is_nat which shows each distance
+  -- is a natural number in [1, floor(diameter)].
   sorry
 
 /-- Guth-Katz (2015): Any n points determine ≫ n / log n distinct distances.
@@ -173,12 +216,32 @@ We can establish some basic bounds.
 /-- Lower bound: diameter ≥ 1 for any set with ≥ 2 points and min distance 1. -/
 theorem diameter_ge_one (A : Finset Point) (hA : A.card ≥ 2)
     (h : minDistanceOne A) : diameter A ≥ 1 := by
-  sorry
+  -- Since A has at least 2 elements, it's nonempty
+  have hpos : 0 < A.card := Nat.lt_of_lt_of_le (by norm_num : 0 < 2) hA
+  have hne : A.Nonempty := Finset.card_pos.mp hpos
+  -- Get two distinct elements
+  obtain ⟨p, hp, q, hq, hpq⟩ := Finset.one_lt_card.mp hA
+  -- By minDistanceOne, their distance is ≥ 1
+  have hdist : dist p q ≥ 1 := h p hp q hq hpq
+  -- The diameter is the sup over all pairs
+  simp only [diameter, dif_pos hne]
+  -- The diameter is ≥ dist p q ≥ 1
+  have h1 : A.sup' hne (fun q => dist p q) ≤ A.sup' hne (fun p' => A.sup' hne fun q => dist p' q) :=
+    Finset.le_sup' (fun p' => A.sup' hne fun q => dist p' q) hp
+  have h2 : dist p q ≤ A.sup' hne fun q => dist p q :=
+    Finset.le_sup' (fun q => dist p q) hq
+  linarith
 
 /-- The diameter is achieved by some pair of points. -/
 theorem diameter_achieved (A : Finset Point) (hA : A.Nonempty) :
     ∃ p ∈ A, ∃ q ∈ A, dist p q = diameter A := by
-  sorry
+  simp only [diameter, dif_pos hA]
+  -- The outer sup is achieved by some p
+  obtain ⟨p, hp, hp_eq⟩ := Finset.exists_mem_eq_sup' hA (fun p => A.sup' hA fun q => dist p q)
+  -- The inner sup is achieved by some q
+  obtain ⟨q, hq, hq_eq⟩ := Finset.exists_mem_eq_sup' hA (fun q => dist p q)
+  refine ⟨p, hp, q, hq, ?_⟩
+  simp only [← hp_eq, ← hq_eq]
 
 /-!
 ## Unit Distance Graphs
@@ -204,7 +267,11 @@ def unitDistanceGraph (A : Finset Point) : SimpleGraph Point where
 theorem unit_graph_min_distance (A : Finset Point)
     (h : hasRestrictedDistances A) (p q : Point) (hp : p ∈ A) (hq : q ∈ A)
     (hpq : p ≠ q) : dist p q = 1 ↔ (unitDistanceGraph A).Adj p q := by
-  sorry
+  constructor
+  · intro hdist
+    exact ⟨hp, hq, hdist⟩
+  · intro ⟨_, _, hdist⟩
+    exact hdist
 
 /-!
 ## Lattice Point Configurations
@@ -220,7 +287,20 @@ def latticeBox (n : ℕ) : Finset Point :=
 theorem lattice_integer_distances :
     ∀ p q : Point, (∀ i, ∃ k : ℤ, p i = k) → (∀ i, ∃ k : ℤ, q i = k) →
     ∃ k : ℕ, dist p q = Real.sqrt k := by
-  sorry
+  intro p q hp hq
+  -- For integer coordinate points, dist(p,q)² = (p₀-q₀)² + (p₁-q₁)² is a natural number
+  -- Get the integer coordinates
+  obtain ⟨a₀, ha₀⟩ := hp 0
+  obtain ⟨a₁, ha₁⟩ := hp 1
+  obtain ⟨b₀, hb₀⟩ := hq 0
+  obtain ⟨b₁, hb₁⟩ := hq 1
+  -- The squared distance is (a₀ - b₀)² + (a₁ - b₁)²
+  -- This is a sum of squares of integers, hence a natural number (when nonnegative)
+  use ((a₀ - b₀).natAbs ^ 2 + (a₁ - b₁).natAbs ^ 2 : ℕ)
+  simp only [dist]
+  -- dist p q = ‖p - q‖ = sqrt((p 0 - q 0)² + (p 1 - q 1)²)
+  -- The proof requires showing the norm equals sqrt of sum of squares
+  sorry  -- Requires EuclideanSpace norm computation
 
 /-!
 ## Summary

--- a/src/data/research/problems/erdos-100.json
+++ b/src/data/research/problems/erdos-100.json
@@ -1,0 +1,86 @@
+{
+  "slug": "erdos-100",
+  "title": "Erdős #100: Point Sets with Restricted Distances",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "∃ c > 0, ∀ A : Finset Point, hasRestrictedDistances A → diameter A ≥ c * A.card",
+    "plain": "For n points in R² with pairwise distances ≥ 1 and any two distinct distances differing by ≥ 1, must the diameter be ≫ n?",
+    "whyMatters": ["Connects to discrete geometry and distinct distances problem", "Related to Guth-Katz work on Erdős distinct distances"]
+  },
+  "knownResults": {
+    "proven": [
+      "Kanold: diameter ≥ n^(3/4)",
+      "Guth-Katz: diameter ≥ c·n/log n"
+    ],
+    "open": [
+      "Does diameter grow linearly with n?"
+    ],
+    "goal": "Prove or disprove diameter ≫ n"
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-01-18",
+    "iteration": 1,
+    "focus": "Infrastructure lemmas for diameter bounds",
+    "activeApproach": "Formalize basic diameter properties, then tackle harder bounds",
+    "blockers": [],
+    "nextAction": "Prove distinct_distances_le_diameter",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: Proved 5 lemmas/theorems: diameter_ge_one, diameter_achieved, unit_graph_min_distance, dist_le_diameter, restricted_dist_is_nat. Remaining sorries: distinct_distances_le_diameter (HARD), lattice constructions.",
+    "builtItems": [
+      "diameter_ge_one: Lower bound diameter ≥ 1 for sets with ≥ 2 points (Erdos100Problem.lean:217)",
+      "diameter_achieved: Diameter is achieved by some pair of points (Erdos100Problem.lean:235)",
+      "unit_graph_min_distance: Unit distance graph characterizes min-distance pairs (Erdos100Problem.lean:267)",
+      "dist_le_diameter: All pairwise distances ≤ diameter (Erdos100Problem.lean:156)",
+      "restricted_dist_is_nat: Distances are natural numbers in [1, floor(diameter)] (Erdos100Problem.lean:166)"
+    ],
+    "insights": [
+      "Diameter defined via nested Finset.sup' requires careful handling of nonemptiness proofs",
+      "The restricted distance condition (integer distances) implies distinct_distances ≤ floor(diameter)",
+      "Connection to Guth-Katz distinct distances problem provides n/log n bound",
+      "Unit graph characterization is immediate from definition - no deep math required",
+      "distinct_distances_le_diameter is HARD: needs finset injection argument from reals to nats"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Prove distinct_distances_le_diameter: need to show image of distance function injects into Finset.Icc 1 (floor diameter)",
+      "Complete lattice point constructions for explicit examples",
+      "Consider submitting remaining HARD sorries to Aristotle"
+    ],
+    "markdown": ""
+  },
+  "approaches": [],
+  "tags": [
+    "erdos",
+    "discrete-geometry",
+    "distinct-distances",
+    "open"
+  ],
+  "relatedProofs": [],
+  "references": {
+    "papers": [
+      "Guth-Katz 2015 (distinct distances)",
+      "Kanold (n^3/4 bound)",
+      "Piepmeyer (9-point construction)"
+    ],
+    "urls": [
+      "https://erdosproblems.com/100"
+    ],
+    "mathlib": [
+      "Mathlib.Analysis.InnerProductSpace.PiL2",
+      "Mathlib.Combinatorics.SimpleGraph.Basic"
+    ]
+  },
+  "started": "2026-01-18T00:00:00.000Z",
+  "significance": 7,
+  "tractability": 5
+}


### PR DESCRIPTION
## Summary
Research session for Erdős #100 (Point Sets with Restricted Distances).

## Progress
- **Proved 5 lemmas/theorems** that build infrastructure for diameter bounds:
  - `diameter_ge_one`: diameter ≥ 1 for sets with ≥ 2 points
  - `diameter_achieved`: diameter is realized by some pair of points
  - `unit_graph_min_distance`: unit distance graph characterizes min-distance pairs
  - `dist_le_diameter`: all pairwise distances ≤ diameter
  - `restricted_dist_is_nat`: distances are natural numbers in [1, floor(diameter)]
- Added import for `SimpleGraph.Basic`
- Made `numDistinctDistances` noncomputable (required for build)

## Files Modified
- `proofs/Proofs/Erdos100Problem.lean` - Added proofs for 5 lemmas
- `src/data/research/problems/erdos-100.json` - Updated knowledge tracking

## Findings
- Diameter proofs use `Finset.sup'` with careful nonemptiness handling
- Unit graph characterization is immediate from definition
- `distinct_distances_le_diameter` is HARD - needs finset injection argument from reals to nats

## Status
**Outcome**: progress
**Remaining sorries**:
- `distinct_distances_le_diameter` (HARD - requires showing image injects into finite interval)
- `latticeBox` definition (construction of explicit examples)
- `lattice_integer_distances` (needs EuclideanSpace norm computation)

**Next Steps**: Consider submitting HARD sorries to Aristotle or manually complete the finset injection argument.

🤖 Generated by researcher-2