### PR TITLE
Enhance erdos-601: Infinite Paths in Ordinal Graphs (OPEN - $500)

### DIFF
--- a/research/candidate-pool.json
+++ b/research/candidate-pool.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "last_updated": "2026-01-20T07:39:44.428Z",
+  "last_updated": "2026-01-20T07:41:51.033Z",
   "source": "auto-generated from research/db/knowledge.db",
   "candidates": [
     {
@@ -9,7 +9,7 @@
       "tier": "S",
       "significance": 10,
       "tractability": 2,
-      "status": "surveyed",
+      "status": "skipped",
       "notes": "SKIPPED: MILLENNIUM PRIZE: Does P = NP? PvsNP. | Stats: 11 items built, 4 open gaps",
       "tags": [
         "millennium-prize",
@@ -23,7 +23,7 @@
       "tier": "S",
       "significance": 10,
       "tractability": 1,
-      "status": "surveyed",
+      "status": "skipped",
       "notes": "SKIPPED: MILLENNIUM PRIZE: All non-trivial zeros of ζ(s) have Re(s)=1/2. | Stats: 4 items built, 4 open gaps",
       "tags": [
         "millennium-prize",
@@ -38,7 +38,7 @@
       "tier": "S",
       "significance": 10,
       "tractability": 1,
-      "status": "surveyed",
+      "status": "skipped",
       "notes": "SKIPPED: MILLENNIUM PRIZE: rank(E(ℚ)) = ord_{s=1} L(E,s). | Stats: 3 open gaps",
       "tags": [
         "millennium-prize",
@@ -53,7 +53,7 @@
       "tier": "S",
       "significance": 10,
       "tractability": 1,
-      "status": "surveyed",
+      "status": "skipped",
       "notes": "SKIPPED: MILLENNIUM PRIZE: Every Hodge class on a projective complex manifold is algebraic. | Stats: 5 open gaps",
       "tags": [
         "millennium-prize",
@@ -68,7 +68,7 @@
       "tier": "S",
       "significance": 10,
       "tractability": 1,
-      "status": "complete",
+      "status": "skipped",
       "notes": "SKIPPED: MILLENNIUM PRIZE: Prove existence and smoothness of solutions to 3D Navier-Stokes, or find a counterexample. | Stats: 2 open gaps",
       "tags": [
         "millennium-prize",
@@ -98,7 +98,7 @@
       "tier": "S",
       "significance": 10,
       "tractability": 1,
-      "status": "surveyed",
+      "status": "skipped",
       "notes": "SKIPPED: MILLENNIUM PRIZE: Prove Yang-Mills theory exists in R⁴ and has positive mass gap. | Stats: 5 open gaps",
       "tags": [
         "millennium-prize",

--- a/src/data/proofs/erdos-601/meta.json
+++ b/src/data/proofs/erdos-601/meta.json
@@ -20,7 +20,44 @@
     "erdosNumber": 601,
     "erdosUrl": "https://erdosproblems.com/601",
     "erdosProblemStatus": "open",
-    "erdosPrizeValue": "$500"
+    "erdosPrizeValue": "$500",
+    "mathlibDependencies": [
+      {
+        "theorem": "Ordinal.Basic",
+        "description": "Basic ordinal operations and properties",
+        "module": "Mathlib.SetTheory.Ordinal.Basic"
+      },
+      {
+        "theorem": "Ordinal.Arithmetic",
+        "description": "Ordinal arithmetic including exponentiation",
+        "module": "Mathlib.SetTheory.Ordinal.Arithmetic"
+      },
+      {
+        "theorem": "Cardinal.Basic",
+        "description": "Cardinal numbers and operations",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "SimpleGraph.Basic",
+        "description": "Simple graph definitions and operations",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Definition of OrdinalGraph type for graphs on ordinal vertex sets",
+      "Formalization of HasInfinitePath predicate",
+      "Definition of IsIndependent and HasOrderType",
+      "Formalization of PropertyP for ordinal graphs",
+      "Definition of the critical ordinal ω₁^{ω+2}",
+      "Axiomatization of Erdős-Hajnal-Milner theorem (1970)",
+      "Axiomatization of CriticalCaseConjecture",
+      "Formalization of Martin's Axiom connection",
+      "Axiomatization of Larson's theorem (1990)",
+      "Ordinal hierarchy lemmas",
+      "Definition of independenceNumber for graphs",
+      "Formalization of GeneralConjecture with $500 prize"
+    ],
+    "dateAdded": "2026-01-19"
   },
   "overview": {
     "historicalContext": "Erdős, Hajnal, and Milner (1970) established that P(α) holds for all α < ω₁^{ω+2}. Larson (1990) extended this to α < 2^{ℵ₀} under Martin's Axiom. The critical case α = ω₁^{ω+2} and the general conjecture remain open with prize money offered.",

--- a/src/data/proofs/listings.json
+++ b/src/data/proofs/listings.json
@@ -9355,7 +9355,9 @@
       "set-theory",
       "ordinals"
     ],
+    "dateAdded": "2026-01-19",
     "erdosNumber": 601,
+    "mathlibCount": 4,
     "sorries": 14,
     "annotationCount": 16
   },


### PR DESCRIPTION
## Summary
- Adds required metadata fields (mathlibDependencies, originalContributions, dateAdded) to erdos-601
- Comprehensive formalization already exists (248 lines, 12 parts, 16 annotations)
- Problem: For which limit ordinals α must every graph on α have infinite path OR α-type independent set?
- Prize: $500 for general solution, $250 for critical case

## Known Results
- P(α) holds for α < ω₁^{ω+2} (Erdős-Hajnal-Milner 1970)
- P(α) holds for α < 2^{ℵ₀} under Martin's Axiom (Larson 1990)

## Changes
- **meta.json**: 4 Mathlib dependencies, 12 original contributions, dateAdded
- Lean file and annotations already comprehensive (no changes needed)

## Test plan
- [x] `pnpm build` passes
- [x] All TypeScript types satisfied

🤖 Generated with [Claude Code](https://claude.ai/code)