### PR TITLE
Mark Erdős #440 complete: LCM of Consecutive Sequence Elements - SOLVED

### DIFF
--- a/src/data/proofs/erdos-440/meta.json
+++ b/src/data/proofs/erdos-440/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Endre Szemerédi",
     "sourceUrl": "https://erdosproblems.com/440",
     "date": "1980",
-    "status": "pending",
+    "status": "complete",
     "proofRepoPath": "Proofs/Erdos440Problem.lean",
     "tags": [
       "erdos",


### PR DESCRIPTION
## Summary
- Updates status from pending to complete for erdos-440
- The problem was already fully enhanced with:
  - 317-line Lean formalization covering LCM of consecutive elements
  - Complete meta.json with historical context (Erdős-Szemerédi 1980, Tao, van Doorn)
  - 18 annotations explaining key concepts

## Erdős Problem #440
**Question:** For infinite sequence A = {a₁ < a₂ < ...}, let A(x) count indices i with lcm(aᵢ, aᵢ₊₁) ≤ x. Is A(x) = O(√x)? What is max liminf A(x)/√x?

**Answer (SOLVED):**
- YES, A(x) = O(√x) for any sequence (Tao's elementary proof)
- liminf A(x)/√x ≤ 1 always, with equality for A = ℕ (Erdős-Szemerédi 1980)
- Sharp bound: A(x) ≤ (c + o(1))√x where c ≈ 1.86 is optimal (van Doorn)

## Test plan
- [x] Build succeeds with `pnpm build`
- [x] Lean file compiles
- [x] Annotations validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)