### PR TITLE
Enhance Erdős Problem #696: Prime Divisor Chains with Congruences

### DIFF
--- a/proofs/Proofs/Erdos696Problem/annotations.json
+++ b/proofs/Proofs/Erdos696Problem/annotations.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "def-prime-chain",
+    "proofId": "erdos-696",
+    "range": { "startLine": 47, "endLine": 57 },
+    "type": "definition",
+    "title": "Prime Divisor Chain",
+    "content": "A sequence of primes p₁ < p₂ < ... < pₗ all dividing n where p_{i+1} ≡ 1 (mod p_i). This reflects multiplicative group structure.",
+    "significance": "major"
+  },
+  {
+    "id": "def-h-function",
+    "proofId": "erdos-696",
+    "range": { "startLine": 59, "endLine": 65 },
+    "type": "definition",
+    "title": "Function h(n)",
+    "content": "h(n) is the maximum length of a prime chain dividing n. The central function of the problem.",
+    "significance": "major"
+  },
+  {
+    "id": "def-divisor-chain",
+    "proofId": "erdos-696",
+    "range": { "startLine": 67, "endLine": 77 },
+    "type": "definition",
+    "title": "Divisor Chain",
+    "content": "A sequence of divisors d₁ < d₂ < ... < dᵤ all dividing n where d_{i+1} ≡ 1 (mod d_i). Allows composite divisors unlike prime chains.",
+    "significance": "major"
+  },
+  {
+    "id": "def-H-function",
+    "proofId": "erdos-696",
+    "range": { "startLine": 79, "endLine": 85 },
+    "type": "definition",
+    "title": "Function H(n)",
+    "content": "H(n) is the maximum length of a divisor chain dividing n. Always satisfies H(n) ≥ h(n).",
+    "significance": "major"
+  },
+  {
+    "id": "thm-h-le-H",
+    "proofId": "erdos-696",
+    "range": { "startLine": 104, "endLine": 105 },
+    "type": "theorem",
+    "title": "h(n) ≤ H(n)",
+    "content": "Every prime chain is a divisor chain, so h(n) ≤ H(n) always holds.",
+    "significance": "minor"
+  },
+  {
+    "id": "def-iterated-log",
+    "proofId": "erdos-696",
+    "range": { "startLine": 123, "endLine": 133 },
+    "type": "definition",
+    "title": "Iterated Logarithm",
+    "content": "log*(n) = 0 if n ≤ 1, else 1 + log*(log n). This grows extremely slowly - log*(n) ≤ 5 for all n ≤ 2^65536.",
+    "significance": "major"
+  },
+  {
+    "id": "thm-h-to-infinity",
+    "proofId": "erdos-696",
+    "range": { "startLine": 151, "endLine": 156 },
+    "type": "theorem",
+    "title": "h(n) → ∞ for Almost All n",
+    "content": "van Doorn proved that for any fixed k, the density of n with h(n) < k is 0. This is a partial resolution of the problem.",
+    "significance": "major"
+  },
+  {
+    "id": "conj-normal-order",
+    "proofId": "erdos-696",
+    "range": { "startLine": 158, "endLine": 165 },
+    "type": "conjecture",
+    "title": "Normal Order Conjecture",
+    "content": "Erdős conjectured that h(n) has normal order log*(n). For almost all n: h(n) ~ log*(n).",
+    "significance": "major"
+  },
+  {
+    "id": "conj-ratio",
+    "proofId": "erdos-696",
+    "range": { "startLine": 167, "endLine": 172 },
+    "type": "conjecture",
+    "title": "Ratio Conjecture",
+    "content": "The main open question: Is H(n)/h(n) → ∞ for almost all n? This asks if composite divisors give asymptotically longer chains.",
+    "significance": "major"
+  },
+  {
+    "id": "def-sophie-germain",
+    "proofId": "erdos-696",
+    "range": { "startLine": 188, "endLine": 196 },
+    "type": "definition",
+    "title": "Sophie Germain Primes",
+    "content": "If p and 2p+1 are both prime (Sophie Germain pair), then (p, 2p+1) forms a chain of length 2 since 2p+1 ≡ 1 (mod p).",
+    "significance": "minor"
+  },
+  {
+    "id": "def-cunningham",
+    "proofId": "erdos-696",
+    "range": { "startLine": 198, "endLine": 206 },
+    "type": "definition",
+    "title": "Cunningham Chains",
+    "content": "A Cunningham chain of length k is p₁, p₂, ..., pₖ where p_{i+1} = 2p_i + 1 and all are prime. These give prime chains of length k.",
+    "significance": "minor"
+  },
+  {
+    "id": "thm-van-doorn",
+    "proofId": "erdos-696",
+    "range": { "startLine": 289, "endLine": 298 },
+    "type": "theorem",
+    "title": "van Doorn's Proof",
+    "content": "The key result: h(n) → ∞ for almost all n. Uses Dirichlet's theorem - for small p dividing n, there's positive density of primes q ≡ 1 (mod p).",
+    "significance": "major"
+  },
+  {
+    "id": "thm-summary",
+    "proofId": "erdos-696",
+    "range": { "startLine": 312, "endLine": 337 },
+    "type": "theorem",
+    "title": "Problem Status Summary",
+    "content": "PARTIALLY SOLVED: (1) h(n) → ∞ proved, (2) normal order conjecture open, (3) ratio question H(n)/h(n) → ∞ is OPEN.",
+    "significance": "major"
+  }
+]

--- a/proofs/Proofs/Erdos696Problem/meta.json
+++ b/proofs/Proofs/Erdos696Problem/meta.json
@@ -1,0 +1,16 @@
+{
+  "problem_number": 696,
+  "title": "Chains of Prime Divisors with Congruence Conditions",
+  "status": "open",
+  "solvers": [],
+  "source_url": "https://erdosproblems.com/696",
+  "overview": "Let h(n) be the largest ℓ such that there is a sequence of primes p₁ < p₂ < ... < pₗ all dividing n with p_{i+1} ≡ 1 (mod p_i). Let H(n) be the analogous function for general divisors. Questions: (1) Estimate h(n) and H(n). (2) Is H(n)/h(n) → ∞ for almost all n?",
+  "sections": [],
+  "conclusion": "PARTIALLY SOLVED - van Doorn proved h(n) → ∞ for almost all n. Erdős conjectured the normal order of h(n) is log*(n) (iterated logarithm). The ratio question H(n)/h(n) → ∞ remains OPEN.",
+  "references": [
+    "Erdős [Er79e, p.81] - Original problem",
+    "van Doorn - Proof that h(n) → ∞ for almost all n"
+  ],
+  "related_problems": [695],
+  "tags": ["number-theory", "divisors", "prime-chains", "congruences", "partially-solved"]
+}


### PR DESCRIPTION
## Summary
- Added meta.json and annotations.json for the existing Lean formalization
- Problem #696 defines h(n) (longest prime chain with p_{i+1} ≡ 1 mod p_i) and H(n) (same for all divisors)
- **PARTIALLY SOLVED** - van Doorn proved h(n) → ∞ for almost all n
- Key open questions:
  - Normal order of h(n) ≈ log*(n)?
  - H(n)/h(n) → ∞ for almost all n?
- The formalization includes:
  - Prime chain and divisor chain definitions
  - h(n) and H(n) functions
  - Iterated logarithm log*(n) definition
  - van Doorn's result and density arguments
  - Sophie Germain and Cunningham chain connections
  - Upper bounds (h(n) ≤ ω(n), H(n) ≤ log₂(n))

## Test plan
- [x] Build succeeds with `pnpm build`
- [x] meta.json follows required schema
- [x] annotations.json correctly references proof line numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)