### PR TITLE
Enhance Erdős #271: Stanley Sequences

### DIFF
--- a/proofs/Proofs/Erdos271Problem/annotations.json
+++ b/proofs/Proofs/Erdos271Problem/annotations.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "def-three-ap",
+    "proofId": "erdos-271",
+    "range": { "startLine": 45, "endLine": 51 },
+    "type": "definition",
+    "title": "Three-term Arithmetic Progression",
+    "content": "Three distinct numbers a, b, c form a 3-AP if 2b = a + c (equally spaced).",
+    "significance": "major"
+  },
+  {
+    "id": "def-ap-free",
+    "proofId": "erdos-271",
+    "range": { "startLine": 54, "endLine": 58 },
+    "type": "definition",
+    "title": "AP-Free Set",
+    "content": "A set contains no three-term arithmetic progression. Central to Szemerédi-type problems.",
+    "significance": "major"
+  },
+  {
+    "id": "def-stanley-seq",
+    "proofId": "erdos-271",
+    "range": { "startLine": 85, "endLine": 93 },
+    "type": "definition",
+    "title": "Stanley Sequence",
+    "content": "A(n) is the greedy sequence: a₀ = 0, a₁ = n, and aₖ₊₁ = smallest integer preserving AP-freeness.",
+    "significance": "major"
+  },
+  {
+    "id": "thm-a1-char",
+    "proofId": "erdos-271",
+    "range": { "startLine": 128, "endLine": 133 },
+    "type": "theorem",
+    "title": "A(1) Characterization",
+    "content": "A(1) = integers with no digit 2 in base-3 expansion. These are sums of distinct powers of 3.",
+    "significance": "major"
+  },
+  {
+    "id": "thm-a1-growth",
+    "proofId": "erdos-271",
+    "range": { "startLine": 149, "endLine": 156 },
+    "type": "theorem",
+    "title": "A(1) Growth Rate",
+    "content": "The k-th element of A(1) is Θ(k^{log₂3}) ≈ Θ(k^{1.585}).",
+    "significance": "major"
+  },
+  {
+    "id": "conj-dichotomy",
+    "proofId": "erdos-271",
+    "range": { "startLine": 213, "endLine": 220 },
+    "type": "conjecture",
+    "title": "Odlyzko-Stanley Dichotomy (Open)",
+    "content": "Every Stanley sequence has either k^{log₂3} growth (like A(1)) or k²/log k growth (like A(4)?).",
+    "significance": "major"
+  },
+  {
+    "id": "thm-moy",
+    "proofId": "erdos-271",
+    "range": { "startLine": 235, "endLine": 242 },
+    "type": "theorem",
+    "title": "Moy's Upper Bound (2011)",
+    "content": "For all Stanley sequences: aₖ ≤ (1/2 + ε)k² for sufficiently large k.",
+    "significance": "major"
+  },
+  {
+    "id": "thm-vd-explicit",
+    "proofId": "erdos-271",
+    "range": { "startLine": 244, "endLine": 249 },
+    "type": "theorem",
+    "title": "Explicit Upper Bound",
+    "content": "aₖ ≤ (k-1)(k+2)/2 + n for all k (van Doorn-Sothanaphan).",
+    "significance": "major"
+  },
+  {
+    "id": "summary",
+    "proofId": "erdos-271",
+    "range": { "startLine": 320, "endLine": 347 },
+    "type": "summary",
+    "title": "Problem Summary",
+    "content": "PARTIALLY SOLVED: A(1), A(3^k), A(2·3^k) characterized. Upper bounds proven. OPEN: Dichotomy conjecture, general explicit formulas.",
+    "significance": "major"
+  }
+]

--- a/proofs/Proofs/Erdos271Problem/meta.json
+++ b/proofs/Proofs/Erdos271Problem/meta.json
@@ -1,0 +1,17 @@
+{
+  "problem_number": 271,
+  "title": "Stanley Sequences",
+  "status": "partially_solved",
+  "solvers": ["Odlyzko-Stanley (1978)", "Moy (2011)", "van Doorn-Sothanaphan"],
+  "source_url": "https://erdosproblems.com/271",
+  "overview": "For any n, let A(n) be the greedy sequence starting with 0, n that avoids three-term arithmetic progressions. Can the elements be explicitly determined? How fast do they grow?",
+  "sections": [],
+  "conclusion": "PARTIALLY SOLVED: A(1) = base-3 numbers without digit 2. Similar for A(3^k), A(2·3^k). Upper bound aₖ ≤ (1/2 + ε)k² proven (Moy). OPEN: Odlyzko-Stanley dichotomy conjecture (either k^{log₂3} or k²/log k growth).",
+  "references": [
+    "Odlyzko-Stanley (1978) - Characterizations, dichotomy conjecture",
+    "Moy (2011) - Upper bound (1/2 + ε)k²",
+    "van Doorn-Sothanaphan - Explicit upper bound aₖ ≤ (k-1)(k+2)/2 + n"
+  ],
+  "related_problems": [],
+  "tags": ["combinatorics", "arithmetic-progressions", "greedy-algorithms", "sequences", "partially-solved"]
+}


### PR DESCRIPTION
## Summary
- Add meta.json and annotations.json for Erdős problem #271
- Problem concerns greedy AP-free sequences starting with 0, n
- PARTIALLY SOLVED: A(1), A(3^k), A(2·3^k) characterized; dichotomy conjecture open

## Test plan
- [x] Lean file already exists with comprehensive formalization
- [x] Build passes successfully
- [x] Metadata files created with correct structure

🤖 Generated with [Claude Code](https://claude.ai/code)