### PR TITLE
Enhance Erdős #981: Character Sum Stabilization Threshold

### DIFF
--- a/proofs/Proofs/Erdos981Problem/annotations.json
+++ b/proofs/Proofs/Erdos981Problem/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "def-legendre",
+    "proofId": "erdos-981",
+    "range": { "startLine": 51, "endLine": 57 },
+    "type": "definition",
+    "title": "Legendre Symbol and Character Sum",
+    "content": "(n/p) = +1 if n is QR mod p, -1 if NQR, 0 if p|n. Character sum Σ(n/p) measures cancellation.",
+    "significance": "major"
+  },
+  {
+    "id": "def-f-eps",
+    "proofId": "erdos-981",
+    "range": { "startLine": 66, "endLine": 74 },
+    "type": "definition",
+    "title": "Stabilization Threshold f_ε(p)",
+    "content": "f_ε(p) = smallest m such that |Σ_{n≤N}(n/p)| < εN for all N ≥ m. When sums become 'permanently small'.",
+    "significance": "major"
+  },
+  {
+    "id": "thm-elliott",
+    "proofId": "erdos-981",
+    "range": { "startLine": 95, "endLine": 109 },
+    "type": "theorem",
+    "title": "Elliott's Theorem (1969)",
+    "content": "Σ_{p<x} f_ε(p) ~ c_ε · x/log x for some c_ε > 0. Solves the problem completely.",
+    "significance": "major"
+  },
+  {
+    "id": "thm-polya-vinogradov",
+    "proofId": "erdos-981",
+    "range": { "startLine": 115, "endLine": 123 },
+    "type": "theorem",
+    "title": "Pólya-Vinogradov Inequality",
+    "content": "|Σ_{n≤N}(n/p)| ≤ √p · log p. Classical bound on character sums.",
+    "significance": "minor"
+  },
+  {
+    "id": "thm-burgess",
+    "proofId": "erdos-981",
+    "range": { "startLine": 142, "endLine": 145 },
+    "type": "theorem",
+    "title": "Burgess Bound (1962)",
+    "content": "Improved bounds for short character sums. Key tool in the proof.",
+    "significance": "minor"
+  },
+  {
+    "id": "summary",
+    "proofId": "erdos-981",
+    "range": { "startLine": 182, "endLine": 212 },
+    "type": "summary",
+    "title": "Problem Summary",
+    "content": "SOLVED: Elliott (1969) proved Σf_ε(p) ~ c_ε · x/log x. Character sums cancel due to equidistribution of quadratic residues.",
+    "significance": "major"
+  }
+]

--- a/proofs/Proofs/Erdos981Problem/meta.json
+++ b/proofs/Proofs/Erdos981Problem/meta.json
@@ -1,0 +1,17 @@
+{
+  "problem_number": 981,
+  "title": "Character Sum Stabilization Threshold",
+  "status": "solved",
+  "solvers": ["Elliott (1969)"],
+  "source_url": "https://erdosproblems.com/981",
+  "overview": "Let f_ε(p) be the smallest m such that |Σ_{n≤N} (n/p)| < εN for all N ≥ m, where (n/p) is the Legendre symbol. Prove Σ_{p<x} f_ε(p) ~ c_ε · x/log x.",
+  "sections": [],
+  "conclusion": "SOLVED by Elliott (1969, Indag. Math.). The sum of stabilization thresholds over primes follows the Prime Number Theorem form x/log x. Character sums exhibit cancellation due to equidistribution of quadratic residues.",
+  "references": [
+    "[El69] Elliott, 'A conjecture of Erdős concerning character sums', Indag. Math. (1969)",
+    "[Er65b] Original problem statement",
+    "[TaZh25] Tang-Zhang (2025) - Alternative formulation"
+  ],
+  "related_problems": [],
+  "tags": ["number-theory", "character-sums", "legendre-symbol", "prime-number-theorem", "solved"]
+}


### PR DESCRIPTION
## Summary
- Add meta.json and annotations.json for Erdős problem #981
- Problem asks for asymptotic of sum of stabilization thresholds over primes
- SOLVED by Elliott (1969): Σf_ε(p) ~ c_ε · x/log x

## Test plan
- [x] Lean file already exists with comprehensive formalization
- [x] Build passes successfully
- [x] Metadata files created with correct structure

🤖 Generated with [Claude Code](https://claude.ai/code)