### PR TITLE
Enhance Erdős #487: LCM Triples in Dense Sets

### DIFF
--- a/src/data/proofs/erdos-487/annotations.json
+++ b/src/data/proofs/erdos-487/annotations.json
@@ -65,21 +65,21 @@
   {
     "id": "ann-e487-davenport",
     "proofId": "erdos-487",
-    "range": { "startLine": 112, "endLine": 149 },
+    "range": { "startLine": 113, "endLine": 158 },
     "type": "axiom",
     "title": "Davenport-Erdős 1936",
-    "content": "**davenport_erdos_1936:**\n\nIf A ⊆ ℕ has positive upper density, then A contains an infinite divisibility chain a₁ | a₂ | a₃ | ...\n\nThis is a precursor to Problem #487. Divisibility chains give structure to dense sets.",
+    "content": "**davenport_erdos_1936:**\n\nIf A ⊆ ℕ has positive upper density, then A contains an infinite divisibility chain a₁ | a₂ | a₃ | ...\n\n**coprime_multipliers_lcm_triple:**\n\nIf gcd(k, m) = 1 with k > 1, m > 1, then (a*k, a*m, a*k*m) is an LCM triple.\n\nThis is proved directly using Nat.Coprime.lcm_eq_mul.",
     "mathContext": "Published in 'On sequences of positive integers' [DaEr36]. Uses density arguments.",
     "significance": "key",
-    "relatedConcepts": ["Divisibility", "Dense sets"]
+    "relatedConcepts": ["Divisibility", "Dense sets", "Coprimality"]
   },
   {
     "id": "ann-e487-kleitman",
     "proofId": "erdos-487",
-    "range": { "startLine": 150, "endLine": 187 },
+    "range": { "startLine": 161, "endLine": 223 },
     "type": "axiom",
     "title": "Kleitman's Theorem 1971",
-    "content": "**kleitman_1971:**\n\nUnion-free collections F ⊆ P([n]) satisfy:\n|F| ≤ (1 + o(1)) · C(n, ⌊n/2⌋)\n\nThis is exponentially smaller than 2^n (since C(n,n/2) ≈ 2^n/√n).\n\nThe bound implies union-free = o(2^n), which resolves Problem #487.",
+    "content": "**kleitman_1971:**\n\nUnion-free collections F ⊆ P([n]) satisfy:\n|F| ≤ (1 + o(1)) · C(n, ⌊n/2⌋)\n\nThis is exponentially smaller than 2^n (since C(n,n/2) ≈ 2^n/√n).\n\n**union_free_is_little_o:**\n\nThe corollary that |F| / 2^n < ε for large n. Proved using Kleitman's bound and the asymptotics of C(n, n/2).",
     "mathContext": "Published in 'Collections of subsets containing no two sets and their union', Proceedings AMS (1971).",
     "significance": "critical",
     "relatedConcepts": ["Extremal combinatorics", "Binomial coefficients"]
@@ -87,7 +87,7 @@
   {
     "id": "ann-e487-main",
     "proofId": "erdos-487",
-    "range": { "startLine": 188, "endLine": 209 },
+    "range": { "startLine": 226, "endLine": 246 },
     "type": "theorem",
     "title": "Main Theorem",
     "content": "**lcm_triple_in_dense_set:**\n\nIf A ⊆ ℕ has positive upper density, then A contains distinct a, b, c with lcm(a,b) = c.\n\n**infinitely_many_lcm_triples:**\n\nIn fact, there are infinitely many such triples.\n\nThese are the main results resolving Erdős Problem #487.",
@@ -97,7 +97,7 @@
   {
     "id": "ann-e487-example-6",
     "proofId": "erdos-487",
-    "range": { "startLine": 214, "endLine": 230 },
+    "range": { "startLine": 248, "endLine": 272 },
     "type": "theorem",
     "title": "Example: Multiples of 6",
     "content": "**multiples_of_6_example:** IsLCMTriple 12 18 36\n\nA = {6, 12, 18, 24, ...} has density 1/6.\n\nlcm(12, 18) = 36 ∈ A gives an explicit LCM triple.\n\nVerified computationally with native_decide.",
@@ -107,10 +107,10 @@
   {
     "id": "ann-e487-example-pow2",
     "proofId": "erdos-487",
-    "range": { "startLine": 231, "endLine": 243 },
+    "range": { "startLine": 273, "endLine": 302 },
     "type": "theorem",
     "title": "Counterexample: Powers of 2",
-    "content": "**powers_of_2_no_lcm_triple:**\n\nA = {1, 2, 4, 8, 16, ...} has NO LCM triples.\n\nlcm(2^i, 2^j) = 2^(max i j) = max(a, b), so c ∈ {a, b}.\n\nBut this set has density 0, so the theorem doesn't apply.",
+    "content": "**powers_of_2_no_lcm_triple:**\n\nA = {1, 2, 4, 8, 16, ...} has NO LCM triples.\n\nlcm(2^i, 2^j) = 2^(max i j), which equals either a or b.\n\nProved using Nat.Prime.pow_max_lcm and case analysis on max.\n\nBut this set has density 0, so the theorem doesn't apply.",
     "mathContext": "This shows density is necessary - sparse sets can avoid LCM triples.",
     "significance": "supporting",
     "relatedConcepts": ["Counterexamples", "Powers of 2"]
@@ -118,7 +118,7 @@
   {
     "id": "ann-e487-example-even",
     "proofId": "erdos-487",
-    "range": { "startLine": 244, "endLine": 259 },
+    "range": { "startLine": 303, "endLine": 313 },
     "type": "theorem",
     "title": "Example: Even Numbers",
     "content": "**even_numbers_example:** IsLCMTriple 4 6 12\n\nA = {2, 4, 6, 8, ...} has density 1/2.\n\nlcm(4, 6) = 12 ∈ A gives an explicit LCM triple.\n\nThe even numbers have many LCM triples due to their density.",
@@ -128,7 +128,7 @@
   {
     "id": "ann-e487-proof-outline",
     "proofId": "erdos-487",
-    "range": { "startLine": 260, "endLine": 283 },
+    "range": { "startLine": 315, "endLine": 337 },
     "type": "concept",
     "title": "Proof Outline",
     "content": "**Proof by contradiction:**\n\n1. Assume A has density δ > 0 but no LCM triples.\n2. Map A via prime factorization to a collection F of sets.\n3. F is union-free (since LCM ↔ union).\n4. By Kleitman: |F| = o(2^(log N)) = o(N).\n5. But |A ∩ [1,N]| ≥ δN for large N.\n6. Contradiction: δN ≤ o(N) fails.",
@@ -139,7 +139,7 @@
   {
     "id": "ann-e487-summary",
     "proofId": "erdos-487",
-    "range": { "startLine": 284, "endLine": 316 },
+    "range": { "startLine": 339, "endLine": 371 },
     "type": "theorem",
     "title": "Summary Theorem",
     "content": "**erdos_487_summary:**\n\nCombines both main results:\n\n1. Dense sets contain LCM triples (main result)\n2. Kleitman's bound on union-free collections (the tool)\n\n**Conclusion:** Erdős Problem #487 is SOLVED affirmatively.",

--- a/src/data/proofs/erdos-487/meta.json
+++ b/src/data/proofs/erdos-487/meta.json
@@ -17,7 +17,7 @@
       "lcm"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 487,
     "erdosUrl": "https://erdosproblems.com/487",
     "erdosProblemStatus": "solved"


### PR DESCRIPTION
## Summary
Stub enhancement for Erdős Problem #487 (LCM Triples in Dense Sets).

## Changes
- Fixed incorrect theorem: replaced `divisibility_chain_gives_lcm` with `coprime_multipliers_lcm_triple`
  - The original theorem had a bug (b = c violates distinctness)
  - New theorem: if gcd(k,m) = 1 then (a*k, a*m, a*k*m) is an LCM triple
- Proved `union_free_is_little_o` corollary
  - Uses Kleitman's bound and binomial coefficient asymptotics
- Proved `powers_of_2_no_lcm_triple`
  - Shows powers of 2 have no LCM triples since lcm(2^i, 2^j) = 2^(max i j) ∈ {a, b}
- Updated meta.json: sorries 3 → 0
- Updated annotations.json with correct line numbers

## Checklist
- [x] Lean proof compiles
- [x] pnpm build succeeds
- [x] Annotations align with Lean file
- [x] No remaining sorries

🤖 Generated by enhancer-2