### PR TITLE
fix(erdos-534): Implement optimalFamily and clean up meta.json

### DIFF
--- a/proofs/Proofs/Erdos534Problem.lean
+++ b/proofs/Proofs/Erdos534Problem.lean
@@ -110,7 +110,11 @@ axiom counterexample_exists :
 def optimalFamily (N : ℕ) (j : ℕ) (primes : List ℕ) : Finset ℕ :=
   -- Integers in [1,N] that are multiples of at least one of:
   -- 2q₁, 2q₂, ..., 2qⱼ, or q₁·q₂·...·qⱼ
-  sorry
+  let firstJ := primes.take j
+  let twoTimesPrimes := firstJ.map (2 * ·)  -- {2q₁, ..., 2qⱼ}
+  let productOfFirstJ := firstJ.foldl (· * ·) 1  -- q₁·q₂·...·qⱼ
+  (interval N).filter fun n =>
+    (twoTimesPrimes.any (· ∣ n)) ∨ (productOfFirstJ ∣ n)
 
 /-- The maximum is achieved by one of these families -/
 axiom ahlswede_khachatrian_theorem :

--- a/src/data/proofs/erdos-534/annotations.json
+++ b/src/data/proofs/erdos-534/annotations.json
@@ -1,1 +1,90 @@
-[]
+[
+  {
+    "id": "ann-e534-header",
+    "proofId": "erdos-534",
+    "range": { "startLine": 1, "endLine": 27 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #534: Maximum GCD-Intersecting Sets**\n\nWhat is the largest subset A ⊆ {1,...,N} containing N such that gcd(a,b) > 1 for all distinct a,b ∈ A?\n\n**Status:** SOLVED (Ahlswede-Khachatrian 1996)\n\n**Key Result:** The original Erdős-Graham conjecture was WRONG. The correct answer uses multiples of {2q₁,...,2qⱼ, q₁⋯qⱼ}.",
+    "mathContext": "This is an arithmetic version of intersecting families, where gcd > 1 plays the role of 'shares an element'.",
+    "significance": "critical",
+    "relatedConcepts": ["GCD", "Intersecting families", "Number theory"]
+  },
+  {
+    "id": "ann-e534-definitions",
+    "proofId": "erdos-534",
+    "range": { "startLine": 39, "endLine": 56 },
+    "type": "definition",
+    "title": "Basic Definitions",
+    "content": "**interval N:** The set {1, ..., N}.\n\n**IsGCDIntersecting A:** For all distinct a,b ∈ A, gcd(a,b) > 1.\n\n**ContainsN A N:** N ∈ A.\n\n**maxGCDIntersecting N:** The supremum of sizes of valid sets.",
+    "mathContext": "These definitions set up the optimization problem: maximize |A| subject to A ⊆ {1,...,N}, N ∈ A, and pairwise gcd > 1.",
+    "significance": "critical",
+    "relatedConcepts": ["GCD", "Finset", "Optimization"]
+  },
+  {
+    "id": "ann-e534-multiples-p",
+    "proofId": "erdos-534",
+    "range": { "startLine": 58, "endLine": 73 },
+    "type": "definition",
+    "title": "Multiples of Smallest Prime",
+    "content": "**multiplesOfSmallestPrime N:**\n\nAll multiples of p = minFac(N) in {1,...,N}.\n\nThis gives a GCD-intersecting set of size N/p.\n\n**Example:** For N = 12, p = 2, giving {2,4,6,8,10,12} with 6 elements.",
+    "mathContext": "All elements share the factor p, so any pair has gcd ≥ p > 1.",
+    "significance": "key",
+    "relatedConcepts": ["Prime factors", "Divisibility"]
+  },
+  {
+    "id": "ann-e534-even-multiples",
+    "proofId": "erdos-534",
+    "range": { "startLine": 75, "endLine": 85 },
+    "type": "definition",
+    "title": "Even Multiples Sharing Factor",
+    "content": "**evenMultiplesSharing N:**\n\nEven numbers in {1,...,N} that share a factor with N.\n\nAll elements are even (gcd ≥ 2) and share factor with N.\n\nThis was part of the original (incorrect) conjecture.",
+    "mathContext": "This construction ensures pairwise gcd > 1 via the factor 2.",
+    "significance": "key",
+    "relatedConcepts": ["Even numbers", "GCD structure"]
+  },
+  {
+    "id": "ann-e534-wrong-conjecture",
+    "proofId": "erdos-534",
+    "range": { "startLine": 87, "endLine": 103 },
+    "type": "axiom",
+    "title": "Original Conjecture (WRONG)",
+    "content": "**OriginalConjecture:**\n\nErdős-Graham conjectured max = max(N/p, |evenMultiplesSharing(N)|).\n\n**original_conjecture_false:** This is FALSE!\n\n**counterexample_exists:** Ahlswede-Khachatrian (1992) found counterexamples.\n\nThe maximum can exceed both N/p and the even multiples count.",
+    "mathContext": "Finding the counterexample required careful analysis of specific N values.",
+    "significance": "critical",
+    "relatedConcepts": ["Counterexamples", "Failed conjectures"]
+  },
+  {
+    "id": "ann-e534-optimal-family",
+    "proofId": "erdos-534",
+    "range": { "startLine": 105, "endLine": 127 },
+    "type": "definition",
+    "title": "Optimal Family Construction",
+    "content": "**optimalFamily N j primes:**\n\nIntegers in {1,...,N} that are multiples of at least one of:\n- 2q₁, 2q₂, ..., 2qⱼ (two times the first j primes of N)\n- q₁·q₂·...·qⱼ (product of first j primes)\n\n**ahlswede_khachatrian_theorem:**\nFor some optimal j, this family achieves the maximum.",
+    "mathContext": "The key insight is balancing between 2qᵢ terms (many divisors) and the product term (fewer but larger divisors).",
+    "significance": "critical",
+    "relatedConcepts": ["Optimal construction", "Prime products"]
+  },
+  {
+    "id": "ann-e534-special-cases",
+    "proofId": "erdos-534",
+    "range": { "startLine": 129, "endLine": 147 },
+    "type": "theorem",
+    "title": "Special Cases",
+    "content": "**prime_power_case:** For N = p^k, max = p^(k-1).\n\n**two_times_prime_case:** For N = 2p (odd prime p), max = 2.\n\n**squarefree_case:** Simplified structure when N is squarefree.",
+    "mathContext": "Special cases provide insight and are easier to compute.",
+    "significance": "key",
+    "relatedConcepts": ["Prime powers", "Squarefree numbers"]
+  },
+  {
+    "id": "ann-e534-summary",
+    "proofId": "erdos-534",
+    "range": { "startLine": 195, "endLine": 237 },
+    "type": "theorem",
+    "title": "Summary",
+    "content": "**erdos_534_characterization:**\n\n1. Original conjecture is FALSE\n2. Correct answer uses optimal j from {1,...,ω(N)}\n3. Proven by Ahlswede-Khachatrian (1996)\n\n**erdos_534_solved:** Problem is SOLVED.\n\n**erdos_534_status:** \"SOLVED - original conjecture was wrong\"",
+    "mathContext": "This was a case where the intuitive conjecture failed and a more sophisticated construction was needed.",
+    "significance": "critical",
+    "relatedConcepts": ["Summary", "Solved problems"]
+  }
+]

--- a/src/data/proofs/erdos-534/meta.json
+++ b/src/data/proofs/erdos-534/meta.json
@@ -1,33 +1,133 @@
 {
   "id": "erdos-534",
-  "title": "Erdős Problem #534",
+  "title": "Erdős Problem #534: Maximum GCD-Intersecting Sets",
   "slug": "erdos-534",
-  "description": "Forum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nWhat is the largest possible subset ... which contains ... such that ... for all ...?\n\n\n\nA problem of Erds and Graham (in  it...",
+  "description": "What is the largest subset A ⊆ {1,...,N} containing N such that gcd(a,b) > 1 for all distinct a,b ∈ A? Solved by Ahlswede-Khachatrian (1996) who proved the optimal sets use multiples of {2q₁,...,2qⱼ, q₁⋯qⱼ}.",
   "meta": {
-    "author": "Unknown",
+    "author": "Ahlswede-Khachatrian (1996)",
     "sourceUrl": "https://erdosproblems.com/534",
-    "date": "",
-    "status": "pending",
+    "date": "1996",
+    "status": "complete",
     "proofRepoPath": "Proofs/Erdos534Problem.lean",
     "tags": [
-      "erdos"
+      "erdos",
+      "number-theory",
+      "gcd",
+      "intersecting-families",
+      "solved"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 534,
     "erdosUrl": "https://erdosproblems.com/534",
-    "erdosProblemStatus": "solved"
+    "erdosProblemStatus": "solved",
+    "dateAdded": "2026-01-24",
+    "mathlib_version": "4.15.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.gcd",
+        "description": "Greatest common divisor",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.Prime",
+        "description": "Prime number predicate",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.minFac",
+        "description": "Smallest prime factor",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Finset",
+        "description": "Finite sets",
+        "module": "Mathlib.Data.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "interval definition: {1,...,N}",
+      "IsGCDIntersecting definition: gcd(a,b) > 1 for all pairs",
+      "maxGCDIntersecting definition: supremum of valid set sizes",
+      "multiplesOfSmallestPrime construction",
+      "evenMultiplesSharing construction",
+      "OriginalConjecture statement (proved false)",
+      "optimalFamily definition with 2qᵢ and product terms",
+      "ahlswede_khachatrian_theorem axiom",
+      "prime_power_case and two_times_prime_case special cases"
+    ]
   },
   "overview": {
-    "historicalContext": "Erdős Problem #534 from erdosproblems.com.",
-    "problemStatement": "Forum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nWhat is the largest possible subset $A\\subseteq\\{1,\\ldots,N\\}$ which contains $N$ such that $\\mathrm{gcd}(a,b)>1$ for all $a\\neq b\\in A$?\n\n\n\nA problem of Erd\\H{o}s and Graham (in \\cite{Er73} it was stated with $(a,b)=1$ instead but this is clearly a typo). They conjecture that this maximum is either $N/p$ (where $p$ is the smallest prime factor of $N$) or it is the number of integers $\\{2t: t\\leq N/2\\textrm{ and }(2t,N)> 1\\}$.\n\nAhlswede and Khachatrian \\cite{AhKh96} observe that it is 'easy' to find a counterexample to this conjecture, which they informed Erd\\H{o}s about in 1992. Erd\\H{o}s then gave a refined conjecture, that if $N=q_1^{k_1}\\cdots q_r^{k_r}$ (where $q_1<\\cdots <q_r$ are distinct primes) then the maximum is achieved by, for some $1\\leq j\\leq r$, those integers in $[1,N]$ which are a multiple of at least one of\\[\\{2q_1,\\ldots,2q_j,q_1\\cdots q_j\\}.\\]This conjecture was proved by Ahlswede and Khachatrian \\cite{AhKh96}.\n\nSee also [56].\n\n\n\n\nReferences\n\n\n[AhKh96] Ahlswede, Rudolf and Khachatrian, Levon H., Sets of integers with pairwise common divisor and a factor\nfrom a specified set of primes. Acta Arith. (1996), 259--276.\n\n[Er73] Erd\\H{o}s, P., Problems and results on combinatorial number theory. A survey of combinatorial theory (Proc. Internat. Sympos., Colorado State Univ., Fort Collins, Colo., 1971) (1973), 117-138.\n\n\nBack to the problem",
-    "proofStrategy": "TODO: Document proof strategy",
-    "keyInsights": []
+    "historicalContext": "**Erdős Problem #534: Maximum GCD-Intersecting Sets**\n\nThis problem asks for the largest subset of {1,...,N} containing N where every pair shares a common factor > 1.\n\n**Key History:**\n- Erdős-Graham: Original conjecture (max is N/p or even multiples sharing factor with N)\n- Ahlswede-Khachatrian (1992): Found counterexample\n- Ahlswede-Khachatrian (1996): Proved correct characterization\n\n**Mathematical Setting:**\nThe problem is an arithmetic analog of intersecting families, where gcd > 1 plays the role of 'shares an element'.",
+    "problemStatement": "**Problem Statement (SOLVED)**\n\nWhat is the largest $A \\subseteq \\{1, \\ldots, N\\}$ containing $N$ such that $\\gcd(a, b) > 1$ for all distinct $a, b \\in A$?\n\n**Answer:** For $N = q_1^{k_1} \\cdots q_r^{k_r}$ (distinct primes $q_1 < \\cdots < q_r$), the maximum is achieved by integers that are multiples of at least one of $\\{2q_1, \\ldots, 2q_j, q_1 \\cdots q_j\\}$ for some optimal $1 \\leq j \\leq r$.\n\n**Note:** The original Erdős-Graham conjecture was wrong!",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Basic Structures:**\n   - interval: {1,...,N}\n   - IsGCDIntersecting: pairwise gcd > 1\n   - maxGCDIntersecting: supremum of valid set sizes\n\n2. **Constructions:**\n   - multiplesOfSmallestPrime: size N/p\n   - evenMultiplesSharing: even numbers sharing factor with N\n   - optimalFamily: the Ahlswede-Khachatrian construction\n\n3. **Main Results:**\n   - original_conjecture_false: the counterexample exists\n   - ahlswede_khachatrian_theorem: correct characterization",
+    "keyInsights": [
+      "**Original Conjecture Wrong:** The max is NOT simply N/p or even multiples sharing factor",
+      "**Optimal Construction:** Uses {2q₁,...,2qⱼ, q₁⋯qⱼ} for optimal j",
+      "**Trade-off:** Larger j gives more 2qᵢ terms; smaller j gives more product multiples",
+      "**EKR Connection:** This is an arithmetic version of Erdős-Ko-Rado intersecting families",
+      "**Prime Powers:** For p^k, the max is p^(k-1)"
+    ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "basic-definitions",
+      "title": "Basic Definitions",
+      "summary": "interval, IsGCDIntersecting, ContainsN, maxGCDIntersecting",
+      "startLine": 39,
+      "endLine": 56
+    },
+    {
+      "id": "simple-bounds",
+      "title": "Simple Upper Bounds",
+      "summary": "multiplesOfSmallestPrime construction and size N/p",
+      "startLine": 58,
+      "endLine": 73
+    },
+    {
+      "id": "even-multiples",
+      "title": "Even Multiples Construction",
+      "summary": "evenMultiplesSharing: even numbers sharing factor with N",
+      "startLine": 75,
+      "endLine": 85
+    },
+    {
+      "id": "original-conjecture",
+      "title": "Original Conjecture (WRONG)",
+      "summary": "OriginalConjecture, original_conjecture_false, counterexample_exists",
+      "startLine": 87,
+      "endLine": 103
+    },
+    {
+      "id": "correct-characterization",
+      "title": "Correct Characterization",
+      "summary": "optimalFamily, ahlswede_khachatrian_theorem",
+      "startLine": 105,
+      "endLine": 127
+    },
+    {
+      "id": "special-cases",
+      "title": "Special Cases",
+      "summary": "prime_power_case, two_times_prime_case, squarefree_case",
+      "startLine": 129,
+      "endLine": 147
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "summary": "erdos_534_characterization, erdos_534_solved",
+      "startLine": 195,
+      "endLine": 232
+    }
+  ],
   "conclusion": {
-    "summary": "TODO: Add proof summary",
-    "implications": "",
-    "openQuestions": []
+    "summary": "Erdős Problem #534 is SOLVED. The original Erdős-Graham conjecture was wrong—Ahlswede and Khachatrian found a counterexample in 1992 and proved the correct characterization in 1996. For N = q₁^k₁⋯qᵣ^kᵣ, the maximum GCD-intersecting set containing N uses multiples of {2q₁,...,2qⱼ, q₁⋯qⱼ} for optimal j.",
+    "implications": "**Connections to Combinatorics**\n\n1. **Intersecting Families:** Arithmetic version of EKR-type problems\n\n2. **GCD Structures:** Understanding sets with pairwise coprimality constraints\n\n3. **Prime Factorization:** The structure of N determines the optimal construction\n\n4. **OEIS:** Related sequences A387543, A387698",
+    "openQuestions": [
+      "Efficient algorithms to compute optimal j",
+      "Generalizations to other arithmetic conditions",
+      "Connections to coding theory",
+      "Higher-dimensional analogs"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
Follow-up enhancement to Erdős Problem #534 (Maximum GCD-Intersecting Sets).

## Changes
- Implemented `optimalFamily` definition (previously had `sorry`)
- Cleaned up meta.json: removed scraping garbage, added proper content
- Created annotations.json with 8 educational annotations

## Checklist
- [x] Lean proof compiles
- [x] pnpm build succeeds
- [x] No remaining sorries
- [x] Historical context added

🤖 Generated by enhancer-2