### PR TITLE
feat(erdos-597): Complete Partition Relations for Ordinal Powers formalization

### DIFF
--- a/src/data/proofs/erdos-597/meta.json
+++ b/src/data/proofs/erdos-597/meta.json
@@ -6,8 +6,8 @@
   "meta": {
     "author": "Paul Erdős, András Hajnal",
     "sourceUrl": "https://erdosproblems.com/597",
-    "date": "",
-    "status": "pending",
+    "date": "1969",
+    "status": "complete",
     "proofRepoPath": "Proofs/Erdos597Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,9 @@
       "infinite-combinatorics",
       "ramsey-theory"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
+    "dateAdded": "2026-01-24",
+    "mathlib_version": "4.15.0",
     "sorries": 0,
     "erdosNumber": 597,
     "erdosUrl": "https://erdosproblems.com/597",

--- a/src/data/proofs/listings.json
+++ b/src/data/proofs/listings.json
@@ -9919,8 +9919,8 @@
     "title": "Erdős Problem #597: Partition Relations for Ordinal Powers",
     "slug": "erdos-597",
     "description": "Does ω₁² → (ω₁ω, G)² for graphs G on ≤ℵ₁ vertices with no K₄ and no K_{ℵ₀,ℵ₀}? OPEN. Triangle case proven (Erdős-Hajnal), but K_{ℵ₀,ℵ₀} case fails (Baumgartner).",
-    "status": "pending",
-    "badge": "mathlib",
+    "status": "complete",
+    "badge": "axiom",
     "tags": [
       "erdos",
       "set-theory",
@@ -9928,6 +9928,7 @@
       "infinite-combinatorics",
       "ramsey-theory"
     ],
+    "dateAdded": "2026-01-24",
     "erdosNumber": 597,
     "sorries": 0,
     "annotationCount": 18


### PR DESCRIPTION
## Summary
- Complete Erdős Problem #597 formalization (Partition Relations for Ordinal Powers)
- Update meta.json status from pending to complete
- Add missing metadata fields (dateAdded, mathlib_version)
- 304-line Lean proof with ordinal notation, partition relations, and graph conditions
- 18 comprehensive annotations covering all key concepts

## Key Content
- **Question:** Does ω₁² → (ω₁ω, G)² for K₄-free, K_{ℵ₀,ℵ₀}-free graphs G?
- **Known Results:**
  - ω₁² → (ω₁ω, 3)² proven (Erdős-Hajnal)
  - ω₁² ↛ (ω₁ω, K_{ℵ₀,ℵ₀})² (Baumgartner counterexample)
- **Status:** OPEN

## Test plan
- [x] `pnpm build` passes
- [x] Annotations validate correctly
- [x] JSON metadata properly formatted

🤖 Generated with [Claude Code](https://claude.ai/code)