### PR TITLE
feat: Add session limit checks to Aristotle agent

### DIFF
--- a/.loom/roles/aristotle-agent.md
+++ b/.loom/roles/aristotle-agent.md
@@ -58,6 +58,15 @@ if [[ -f "$REPO_ROOT/.loom/signals/stop-aristotle" ]] || \
     exit 0
 fi
 
+# Check session usage limits
+throttle=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --throttle 2>/dev/null || echo "4")
+if [[ "$throttle" -ge 3 ]]; then
+    usage_info=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --human 2>/dev/null || echo "Unknown")
+    echo "$(date +%H:%M): Throttled (level $throttle) - $usage_info" >> "$REPO_ROOT/.loom/logs/aristotle.actions.log"
+    echo "Session usage high (throttle level $throttle). Pausing until reset."
+    exit 0
+fi
+
 # Check for pause signal - wait for continue
 while [[ -f "$REPO_ROOT/.loom/signals/pause-aristotle" ]] || \
       [[ -f "$REPO_ROOT/.loom/signals/pause-all" ]]; do


### PR DESCRIPTION
## Summary
Integrates `check-usage.sh` script into the Aristotle agent to respect Claude API session limits.

## Changes
- Added usage check in the "Check Signals" section of aristotle-agent.md
- Agent checks throttle level before starting each cycle
- Logs throttle events to action log for observability
- Exits gracefully when throttle level >= 3 (approaching limits)

## Throttle Behavior

| Level | Aristotle Behavior |
|-------|-------------------|
| 0-2 | Normal operation |
| 3-4 | Exit gracefully, wait for reset |

## Testing
- Verified script exists at `.loom/scripts/check-usage.sh`
- Fallback behavior (echo "4") handles missing database gracefully

Closes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)