### PR TITLE
feat: Add session limit checks to deployer agent

### DIFF
--- a/.loom/roles/deployer.md
+++ b/.loom/roles/deployer.md
@@ -153,4 +153,14 @@ if [[ -f "$REPO_ROOT/.loom/signals/stop-deployer" ]] || \
     echo "Stop signal received. Exiting."
     exit 0
 fi
+
+# Check session usage limits (deployer has high priority - only pause at critical)
+throttle=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --throttle 2>/dev/null || echo "4")
+if [[ "$throttle" -ge 4 ]]; then
+    echo "$(date +%H:%M): Session limit critical (level $throttle). Deferring deployment."
+    exit 0
+fi
+if [[ "$throttle" -ge 3 ]]; then
+    echo "$(date +%H:%M): Session usage high (level $throttle). Proceeding with caution."
+fi
 ```


### PR DESCRIPTION
## Summary
Integrates `check-usage.sh` script into the deployer agent to respect Claude API session limits.

## Changes
- Added usage check in the "Stop Conditions" section of deployer.md
- Agent checks throttle level before each deployment iteration
- Logs warning at level 3 but proceeds (deployments are high priority)
- Only defers deployment at level 4 (critical)

## Throttle Behavior

| Level | Deployer Behavior |
|-------|-------------------|
| 0-2 | Normal operation |
| 3 | Log warning, proceed (deployments are important) |
| 4 | Defer deployment, exit cleanly |

Note: Deployer has higher priority than research agents - only pauses at critical levels.

## Testing
- Verified script exists at `.loom/scripts/check-usage.sh`
- Fallback behavior (echo "4") handles missing database gracefully

Closes #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)