### PR TITLE
Enhance Erdős #543: Random Subset Sums in Abelian Groups (OPEN)

### DIFF
--- a/src/data/proofs/erdos-543/annotations.json
+++ b/src/data/proofs/erdos-543/annotations.json
@@ -1,12 +1,25 @@
 [
   {
+    "id": "ann-543-header",
+    "proofId": "erdos-543",
+    "range": { "startLine": 1, "endLine": 25 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #543: Random Subset Sums in Abelian Groups**\n\nDefine f(N) as the minimal k such that a random k-subset of an abelian group of size N spans all elements via subset sums with probability ≥ 1/2.\n\n**Question**: Is f(N) ≤ log₂ N + o(log log N)?\n\n**Known**: f(N) ≤ log₂ N + O(log log N) (Erdős-Rényi 1965)\n\n**Erdős's Belief**: NO - the O(log log N) term is optimal.",
+    "mathContext": "This problem connects probability theory with additive combinatorics. It asks how many random elements are needed to generate all subset sums in a group.",
+    "significance": "critical",
+    "relatedConcepts": ["Subset sums", "Probabilistic method", "Additive combinatorics"]
+  },
+  {
     "id": "ann-543-subsetsum",
     "proofId": "erdos-543",
     "range": { "startLine": 42, "endLine": 44 },
     "type": "definition",
     "title": "Subset Sums",
-    "content": "The set of all elements expressible as ∑_{x ∈ S} x for some subset S ⊆ A. This captures what elements can be 'reached' from A.",
-    "significance": "key"
+    "content": "**subsetSums A**: The set of all elements expressible as ∑_{x ∈ S} x for some subset S ⊆ A.\n\nThis captures what elements can be 'reached' from A via subset sums.",
+    "mathContext": "Subset sums are fundamental in additive combinatorics. The subset sum problem (deciding if a target is reachable) is NP-complete.",
+    "significance": "key",
+    "relatedConcepts": ["Subset sum problem", "Additive sets"]
   },
   {
     "id": "ann-543-spanning",
@@ -14,8 +27,10 @@
     "range": { "startLine": 46, "endLine": 48 },
     "type": "definition",
     "title": "Spanning Set",
-    "content": "A set A spans G if every element of G is a subset sum of A. The goal is to find the minimal size for this with high probability.",
-    "significance": "key"
+    "content": "**IsSpanningSet A**: A set A spans G if every element of G is a subset sum of A.\n\nEquivalently: subsetSums A = G.",
+    "mathContext": "This is analogous to generating sets in group theory, but uses subset sums instead of arbitrary combinations.",
+    "significance": "key",
+    "relatedConcepts": ["Generating sets", "Group covers"]
   },
   {
     "id": "ann-543-probability",
@@ -23,8 +38,10 @@
     "range": { "startLine": 58, "endLine": 64 },
     "type": "definition",
     "title": "Spanning Probability",
-    "content": "The fraction of k-subsets of G that span all of G. This is what we want to be ≥ 1/2.",
-    "significance": "supporting"
+    "content": "**spanningProbability G k**: The fraction of k-subsets of G that span all of G.\n\nWe want this probability ≥ 1/2.",
+    "mathContext": "This is a uniform probability over all k-subsets, counting how many are 'good' (spanning).",
+    "significance": "supporting",
+    "relatedConcepts": ["Uniform distribution", "Counting arguments"]
   },
   {
     "id": "ann-543-minimal",
@@ -32,8 +49,10 @@
     "range": { "startLine": 66, "endLine": 71 },
     "type": "definition",
     "title": "Minimal Spanning Size",
-    "content": "The minimal k such that a random k-subset spans G with probability ≥ 1/2. This is f(N) for a specific group.",
-    "significance": "key"
+    "content": "**minimalSpanningSize G**: The minimal k such that a random k-subset spans G with probability ≥ 1/2.\n\nThis is f(N) for a specific group G of size N.",
+    "mathContext": "Uses Nat.find to get the minimal k, which exists since the full group certainly spans.",
+    "significance": "key",
+    "relatedConcepts": ["Threshold functions", "Probabilistic method"]
   },
   {
     "id": "ann-543-ffunction",
@@ -41,26 +60,10 @@
     "range": { "startLine": 73, "endLine": 77 },
     "type": "definition",
     "title": "The Function f(N)",
-    "content": "The supremum over all abelian groups of size N. This is the function from the problem statement.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-543-empty",
-    "proofId": "erdos-543",
-    "range": { "startLine": 81, "endLine": 95 },
-    "type": "theorem",
-    "title": "Empty Set Spans Only Trivial Group",
-    "content": "The empty set has only one subset sum (0), so it spans G iff G = {0}.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-543-mono",
-    "proofId": "erdos-543",
-    "range": { "startLine": 102, "endLine": 107 },
-    "type": "theorem",
-    "title": "Monotonicity of Spanning Probability",
-    "content": "Larger sets are more likely to span: if k₁ ≤ k₂, then P(k₁-subset spans) ≤ P(k₂-subset spans).",
-    "significance": "supporting"
+    "content": "**f(N)**: The supremum of minimalSpanningSize over all abelian groups of size N.\n\nThis is the function from the problem statement - the worst-case over all groups.",
+    "mathContext": "The supremum ensures f(N) captures the hardest group structure for subset sum spanning.",
+    "significance": "critical",
+    "relatedConcepts": ["Extremal function", "Worst-case analysis"]
   },
   {
     "id": "ann-543-erdosrenyi",
@@ -68,8 +71,10 @@
     "range": { "startLine": 111, "endLine": 119 },
     "type": "theorem",
     "title": "Erdős-Rényi Upper Bound (1965)",
-    "content": "The main known result: f(N) ≤ log₂ N + O(log log N). Uses probabilistic methods to show most random sets of this size span.",
-    "significance": "critical"
+    "content": "**erdos_renyi_upper_bound**:\n\nf(N) ≤ log₂ N + C · log(log N) for some constant C > 0.\n\nThis is the main known result, establishing the O(log log N) upper bound.",
+    "mathContext": "From [ErRe65]. Uses probabilistic counting to show most random sets of this size span the group.",
+    "significance": "critical",
+    "relatedConcepts": ["Probabilistic method", "Logarithmic bounds"]
   },
   {
     "id": "ann-543-littleo",
@@ -77,8 +82,10 @@
     "range": { "startLine": 129, "endLine": 136 },
     "type": "definition",
     "title": "The Little-o Conjecture",
-    "content": "The question: can O(log log N) be improved to o(log log N)? For every ε > 0, eventually f(N) ≤ log₂ N + ε·log log N.",
-    "significance": "critical"
+    "content": "**LittleOConjecture**: For every ε > 0, eventually f(N) ≤ log₂ N + ε · log log N.\n\nThis asks: can O(log log N) be improved to o(log log N)?",
+    "mathContext": "If true, the log log N term is not inherent and can be made arbitrarily small (relative to log log N).",
+    "significance": "critical",
+    "relatedConcepts": ["Little-o notation", "Asymptotic improvement"]
   },
   {
     "id": "ann-543-counter",
@@ -86,8 +93,10 @@
     "range": { "startLine": 138, "endLine": 145 },
     "type": "definition",
     "title": "Erdős's Counter-Conjecture",
-    "content": "Erdős believed the answer is NO: there exists ε > 0 such that infinitely many N have f(N) > log₂ N + ε·log log N.",
-    "significance": "critical"
+    "content": "**ErdosCounterConjecture**: There exists ε > 0 such that infinitely many N have f(N) > log₂ N + ε · log log N.\n\nErdős believed this is TRUE - the log log N term is necessary.",
+    "mathContext": "This would establish that some groups inherently require the extra log log N term due to collision effects.",
+    "significance": "critical",
+    "relatedConcepts": ["Lower bounds", "Collision probability"]
   },
   {
     "id": "ann-543-complementary",
@@ -95,8 +104,10 @@
     "range": { "startLine": 147, "endLine": 159 },
     "type": "theorem",
     "title": "Conjectures are Complementary",
-    "content": "The little-o conjecture and Erdős's counter-conjecture are logical negations. Exactly one must be true.",
-    "significance": "key"
+    "content": "**conjectures_complementary**: LittleOConjecture ↔ ¬ErdosCounterConjecture\n\nThe two conjectures are logical negations. Exactly one must be true.",
+    "mathContext": "This is a logical equivalence showing the problem has a binary answer.",
+    "significance": "key",
+    "relatedConcepts": ["Dichotomy", "Logical equivalence"]
   },
   {
     "id": "ann-543-lower",
@@ -104,17 +115,21 @@
     "range": { "startLine": 163, "endLine": 169 },
     "type": "theorem",
     "title": "Naive Lower Bound",
-    "content": "A k-subset has at most 2^k subset sums, so f(N) ≥ log₂ N - 1. This is the information-theoretic limit.",
-    "significance": "key"
+    "content": "**naive_lower_bound**: f(N) ≥ log₂ N - 1\n\nA k-subset has at most 2^k subset sums, so we need 2^k ≥ N to cover all elements.",
+    "mathContext": "This is an information-theoretic lower bound - you can't cover more elements than you have subset sums.",
+    "significance": "key",
+    "relatedConcepts": ["Information theory", "Counting lower bounds"]
   },
   {
     "id": "ann-543-cyclic",
     "proofId": "erdos-543",
     "range": { "startLine": 182, "endLine": 189 },
     "type": "definition",
-    "title": "Cyclic Groups",
-    "content": "For cyclic groups ℤ/Nℤ, f_cyclic(N) may have special structure. The problem asks about all abelian groups.",
-    "significance": "supporting"
+    "title": "Cyclic Group Case",
+    "content": "**f_cyclic(N)**: The spanning threshold for cyclic groups ℤ/Nℤ.\n\nCyclic groups may have special structure that makes spanning easier or harder.",
+    "mathContext": "Cyclic groups are the simplest abelian groups. The problem asks about all abelian groups, not just cyclic ones.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cyclic groups", "ZMod"]
   },
   {
     "id": "ann-543-prime",
@@ -122,7 +137,20 @@
     "range": { "startLine": 191, "endLine": 195 },
     "type": "theorem",
     "title": "Prime Order Groups",
-    "content": "For prime p, ℤ/pℤ is a field. If |A| ≥ p, then A = ℤ/pℤ and trivially spans.",
-    "significance": "supporting"
+    "content": "**prime_case_structure**: For prime p, if |A| ≥ p in ℤ/pℤ, then A spans.\n\nThis is because ℤ/pℤ has only p elements, so A = ℤ/pℤ.",
+    "mathContext": "Prime order groups are fields, giving additional structure. But the interesting case is when |A| << p.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finite fields", "Prime order"]
+  },
+  {
+    "id": "ann-543-summary",
+    "proofId": "erdos-543",
+    "range": { "startLine": 199, "endLine": 228 },
+    "type": "theorem",
+    "title": "Problem Summary",
+    "content": "**Erdős Problem #543: OPEN**\n\n**Question**: Is f(N) ≤ log₂ N + o(log log N)?\n\n**Known**:\n- Upper: f(N) ≤ log₂ N + O(log log N) (Erdős-Rényi)\n- Lower: f(N) ≥ log₂ N - O(1)\n\n**Erdős's Belief**: NO - the O(log log N) is tight.",
+    "mathContext": "The gap between O(log log N) and o(log log N) is the key open question.",
+    "significance": "critical",
+    "relatedConcepts": ["Open problems", "Tight bounds"]
   }
 ]

--- a/src/data/proofs/erdos-543/meta.json
+++ b/src/data/proofs/erdos-543/meta.json
@@ -16,11 +16,53 @@
       "probability",
       "additive-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 8,
     "erdosNumber": 543,
     "erdosUrl": "https://erdosproblems.com/543",
-    "erdosProblemStatus": "open"
+    "erdosProblemStatus": "open",
+    "mathlibDependencies": [
+      {
+        "theorem": "AddCommGroup",
+        "description": "Additive commutative groups for abelian group structure",
+        "module": "Mathlib.Algebra.Group.Subgroup.Basic"
+      },
+      {
+        "theorem": "Fintype",
+        "description": "Finite type for finite groups",
+        "module": "Mathlib.Algebra.Group.Fintype"
+      },
+      {
+        "theorem": "Finset",
+        "description": "Finite sets for subsets and powersets",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "powersetCard",
+        "description": "k-subsets of a finite set",
+        "module": "Mathlib.Data.Finset.Powerset"
+      },
+      {
+        "theorem": "Real.logb",
+        "description": "Logarithm function for bounds",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "ZMod",
+        "description": "Cyclic groups for special cases",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Definition of subsetSums for additive groups",
+      "IsSpanningSet predicate for subset sum coverage",
+      "spanningProbability formalization via k-subset counting",
+      "minimalSpanningSize definition using Nat.find",
+      "LittleOConjecture formalizing the o(log log N) question",
+      "ErdosCounterConjecture capturing Erdős's belief",
+      "Proof that conjectures are logical negations",
+      "Special case analysis for cyclic and prime groups"
+    ]
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős and Rényi's 1965 work on probabilistic methods in group theory [ErRe65]. They proved f(N) ≤ log₂ N + O(log log N), and the question asks whether the O(log log N) term can be improved to o(log log N). Erdős believed this improvement is impossible.",


### PR DESCRIPTION
## Summary

- **Problem**: Is f(N) ≤ log₂ N + o(log log N)? where f(N) is the minimal k such that a random k-subset of an abelian group of size N spans all elements via subset sums with probability ≥ 1/2
- **Status**: OPEN
- **Erdős's Belief**: NO - the O(log log N) term is optimal

### Metadata Enhancements
- Added mathlibDependencies: AddCommGroup, Fintype, Finset, powersetCard, Real.logb, ZMod
- Added originalContributions documenting key formalizations
- Updated badge from wip to axiom
- Enhanced annotations with mathContext and relatedConcepts (14 annotations)

### Key Formalizations
- `subsetSums`: Set of elements expressible as subset sums
- `IsSpanningSet`: Predicate for subset sum coverage
- `spanningProbability`: Fraction of k-subsets that span
- `minimalSpanningSize`: Minimal k for probability ≥ 1/2
- `LittleOConjecture`: The o(log log N) question
- `ErdosCounterConjecture`: Erdős's belief (negation)
- `conjectures_complementary`: Proof they are negations

## Test plan
- [x] `pnpm build` passes
- [x] meta.json validates with all required fields
- [x] annotations.json has proper structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)