### PR TITLE
Enhance Erdős #721: Van der Waerden Numbers W(3,k)

### DIFF
--- a/src/data/proofs/erdos-721/annotations.json
+++ b/src/data/proofs/erdos-721/annotations.json
@@ -9,7 +9,9 @@
     "type": "concept",
     "title": "Problem Overview",
     "content": "Erdős Problem #721: Give reasonable bounds for the van der Waerden number W(3,k). Two specific challenges: (1) non-trivial lower bounds, (2) prove W(3,k) < exp(k^c) for c < 1. SOLVED: Both challenges met through work of Green, Hunter, Schoen, and Bloom-Sisask.",
-    "significance": "critical"
+    "mathContext": "Van der Waerden numbers lie at the intersection of Ramsey theory and additive combinatorics, connecting to density theorems for arithmetic progressions.",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey theory", "Van der Waerden theorem", "Arithmetic progressions", "Additive combinatorics"]
   },
   {
     "id": "ann-721-2",
@@ -21,7 +23,9 @@
     "type": "definition",
     "title": "Van der Waerden's Theorem",
     "content": "Van der Waerden's theorem (1927): For any r colors and k, there exists W(r,k) such that any r-coloring of {1,...,W(r,k)} contains a monochromatic k-term arithmetic progression. A foundational result in Ramsey theory.",
-    "significance": "critical"
+    "mathContext": "One of the earliest Ramsey-theoretic results, showing that sufficiently long sequences cannot avoid monochromatic patterns.",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey theory", "Arithmetic progressions", "Monochromatic subsets"]
   },
   {
     "id": "ann-721-3",
@@ -33,7 +37,9 @@
     "type": "definition",
     "title": "The Number W(3,k)",
     "content": "W(3,k) is the off-diagonal van der Waerden number: the minimum n such that any red/blue coloring of {1,...,n} contains either a red 3-term AP or a blue k-term AP. Asymmetric - we fix one color's AP length at 3.",
-    "significance": "critical"
+    "mathContext": "Off-diagonal van der Waerden numbers are easier to study than diagonal ones, offering insight into the general behavior.",
+    "significance": "critical",
+    "relatedConcepts": ["Van der Waerden numbers", "2-colorings", "Ramsey asymmetry"]
   },
   {
     "id": "ann-721-4",

--- a/src/data/proofs/erdos-721/meta.json
+++ b/src/data/proofs/erdos-721/meta.json
@@ -16,11 +16,44 @@
       "arithmetic-progressions",
       "additive-combinatorics"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 1,
     "erdosNumber": 721,
     "erdosUrl": "https://erdosproblems.com/721",
-    "erdosProblemStatus": "solved"
+    "erdosProblemStatus": "solved",
+    "dateAdded": "2025-01-22",
+    "mathlib_version": "4.15.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.exp",
+        "description": "Real exponential function",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exp"
+      },
+      {
+        "theorem": "Real.log",
+        "description": "Real logarithm function",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.rpow",
+        "description": "Real power function",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ],
+    "originalContributions": [
+      "W: Van der Waerden number axiom",
+      "W_exists, W_increasing: Basic properties",
+      "W_known_values: Small known values",
+      "graham_conjecture: Definition and its falsity",
+      "green_lower_bound: Superpolynomial lower bound",
+      "hunter_lower_bound: Improved exponent 2 lower bound",
+      "W_superpolynomial: Theorem for superpolynomial growth",
+      "schoen_upper_bound: First subexponential bound",
+      "bloom_sisask_upper_bound: Current best bound",
+      "exact_growth_conjecture: Open growth rate question",
+      "erdos_721_status: Main status theorem",
+      "W_bounds_summary: Combined bounds"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in 1980-81, asking for bounds on W(3,k). Graham famously conjectured W(3,k) ≪ k², but this polynomial bound was spectacularly disproved by Green in 2022 who showed superpolynomial growth. The problem was fully resolved through a sequence of breakthroughs: Green's lower bound (2022), Hunter's improvement (2022), Schoen's subexponential upper bound (2021), and the Kelley-Meka/Bloom-Sisask advances (2023).",


### PR DESCRIPTION
## Summary
- Add mathlibDependencies array with Real.exp, Real.log, Real.rpow
- Add originalContributions listing key definitions and theorems
- Add mathContext and relatedConcepts to annotations
- Fix badge to "axiom" (proof uses axioms for Green/Hunter/Schoen/Bloom-Sisask bounds)

## Problem Overview
Erdős Problem #721 asks for reasonable bounds on W(3,k), the van der Waerden number for 3-APs vs k-APs. Two specific challenges:
1. Give non-trivial lower bounds
2. Prove W(3,k) < exp(k^c) for some c < 1

**Status: SOLVED** - Both challenges met:
- Lower bound: exp(c(log k)²/log log k) [Hunter 2022]
- Upper bound: exp(C(log k)^9) [Bloom-Sisask 2023]
- Graham's polynomial conjecture W(3,k) ≪ k² is FALSE [Green 2022]

## Test plan
- [x] pnpm build succeeds
- [x] meta.json has required fields (mathlibDependencies, originalContributions)
- [x] annotations.json has mathContext and relatedConcepts

🤖 Generated with [Claude Code](https://claude.ai/code)