### PR TITLE
Enhance erdos-367: Products of 2-Full Parts

### DIFF
--- a/proofs/Proofs/Erdos367Problem.lean
+++ b/proofs/Proofs/Erdos367Problem.lean
@@ -1,0 +1,210 @@
+/-
+Erdős Problem #367: Products of 2-Full Parts
+
+For a positive integer n, the 2-full part B₂(n) is n/n', where n' is the product
+of primes that divide n exactly once (i.e., squarefree part of n).
+Equivalently, B₂(n) = ∏_{p² | n} p^{v_p(n)} where v_p(n) is the p-adic valuation.
+
+Problem: For every fixed k ≥ 1, is it true that
+  ∏_{n ≤ m < n+k} B₂(m) ≪ n^{2+o(1)} ?
+
+Or perhaps even ≪_k n²?
+
+Known results:
+- For k ≤ 2, the bound ≪ n² holds trivially.
+- For k ≥ 3, the bound ≪ n² fails (van Doorn).
+- There exists an infinite sequence where ∏_{n ≤ m < n+3} B₂(m) ≫ n²·log n.
+
+This is Problem #367 from erdosproblems.com.
+
+Reference: https://erdosproblems.com/367
+
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import Mathlib
+
+/-!
+# Erdős Problem 367: Products of 2-Full Parts
+
+*Reference:* [erdosproblems.com/367](https://www.erdosproblems.com/367)
+-/
+
+open Nat Finset
+open Filter
+
+namespace Erdos367
+
+/-- The squarefree part of n: product of primes dividing n exactly once -/
+noncomputable def squarefreePart (n : ℕ) : ℕ :=
+  ∏ p ∈ n.primeFactors.filter (fun p => n.factorization p = 1), p
+
+/-- The 2-full part B₂(n) = n / squarefreePart(n) -/
+noncomputable def twoFullPart (n : ℕ) : ℕ :=
+  if h : squarefreePart n ∣ n ∧ squarefreePart n ≠ 0
+  then n / squarefreePart n
+  else n
+
+/-- Alternative: B₂(n) = ∏_{p² | n} p^{v_p(n)} -/
+noncomputable def twoFullPartAlt (n : ℕ) : ℕ :=
+  ∏ p ∈ n.primeFactors.filter (fun p => n.factorization p ≥ 2),
+    p ^ (n.factorization p)
+
+/-- Product of 2-full parts over a range [n, n+k) -/
+noncomputable def productTwoFullParts (n k : ℕ) : ℕ :=
+  ∏ m ∈ Finset.Ico n (n + k), twoFullPart m
+
+/-!
+## Main Problem
+
+Erdős Problem #367: Study the growth of ∏_{n ≤ m < n+k} B₂(m).
+-/
+
+/-- The bound ∏_{n ≤ m < n+k} B₂(m) ≪ n^{2+ε} for all ε > 0 -/
+def weakBound (k : ℕ) : Prop :=
+  ∀ ε > 0, ∃ C : ℝ, C > 0 ∧
+    ∀ n ≥ 1, (productTwoFullParts n k : ℝ) ≤ C * (n : ℝ)^(2 + ε)
+
+/-- The strong bound ∏_{n ≤ m < n+k} B₂(m) ≪_k n² -/
+def strongBound (k : ℕ) : Prop :=
+  ∃ C : ℝ, C > 0 ∧
+    ∀ n ≥ 1, (productTwoFullParts n k : ℝ) ≤ C * (n : ℝ)^2
+
+/-- Erdős Problem #367: Does weakBound(k) hold for all k? -/
+@[category research open, AMS 11]
+theorem erdos_367 (k : ℕ) : answer(sorry) ↔ weakBound k := by
+  sorry
+
+/-!
+## Known Results
+-/
+
+/-- Trivial case: For k ≤ 2, strongBound holds -/
+@[category research, AMS 11]
+theorem trivial_case_k_le_2 : strongBound 1 ∧ strongBound 2 := by
+  sorry
+
+/-- The strong bound fails for k = 3 -/
+@[category research, AMS 11]
+theorem strong_bound_fails_k_3 : ¬ strongBound 3 := by
+  sorry
+
+/-- van Doorn: There exist infinitely many n with
+    ∏_{n ≤ m < n+3} B₂(m) ≫ n² · log n -/
+@[category research, AMS 11]
+theorem van_doorn_lower_bound :
+    ∃ c > 0, ∀ N : ℕ, ∃ n ≥ N,
+      (productTwoFullParts n 3 : ℝ) ≥ c * (n : ℝ)^2 * Real.log n := by
+  sorry
+
+/-!
+## Properties of the 2-Full Part
+-/
+
+/-- B₂(n) = 1 iff n is squarefree -/
+lemma twoFullPart_eq_one_iff (n : ℕ) (hn : n ≥ 1) :
+    twoFullPart n = 1 ↔ Squarefree n := by
+  sorry
+
+/-- B₂(p) = 1 for primes p -/
+lemma twoFullPart_prime (p : ℕ) (hp : p.Prime) : twoFullPart p = 1 := by
+  sorry
+
+/-- B₂(p²) = p² for primes p -/
+lemma twoFullPart_prime_sq (p : ℕ) (hp : p.Prime) : twoFullPart (p^2) = p^2 := by
+  sorry
+
+/-- B₂ is multiplicative on coprime arguments -/
+lemma twoFullPart_mul_coprime (m n : ℕ) (h : Nat.Coprime m n) :
+    twoFullPart (m * n) = twoFullPart m * twoFullPart n := by
+  sorry
+
+/-- B₂(n) ≤ n always -/
+lemma twoFullPart_le (n : ℕ) : twoFullPart n ≤ n := by
+  sorry
+
+/-- B₂(n) divides n -/
+lemma twoFullPart_dvd (n : ℕ) : twoFullPart n ∣ n := by
+  sorry
+
+/-!
+## Examples
+-/
+
+/-- B₂(1) = 1 -/
+example : twoFullPart 1 = 1 := by sorry
+
+/-- B₂(4) = 4 since 4 = 2² -/
+example : twoFullPart 4 = 4 := by sorry
+
+/-- B₂(6) = 1 since 6 = 2·3 is squarefree -/
+example : twoFullPart 6 = 1 := by sorry
+
+/-- B₂(12) = 4 since 12 = 2²·3, squarefree part is 3 -/
+example : twoFullPart 12 = 4 := by sorry
+
+/-- B₂(72) = 36 since 72 = 2³·3², squarefree part is 2 -/
+example : twoFullPart 72 = 36 := by sorry
+
+/-!
+## Generalization to r-Full Parts
+-/
+
+/-- The r-full part: product of p^{v_p(n)} for primes with v_p(n) ≥ r -/
+noncomputable def rFullPart (r n : ℕ) : ℕ :=
+  ∏ p ∈ n.primeFactors.filter (fun p => n.factorization p ≥ r),
+    p ^ (n.factorization p)
+
+/-- The 2-full part is a special case of r-full with r = 2 -/
+lemma twoFullPart_eq_rFullPart (n : ℕ) : twoFullPartAlt n = rFullPart 2 n := rfl
+
+/-- Generalized problem for r ≥ 3 -/
+@[category research open, AMS 11]
+theorem erdos_367_generalized (r : ℕ) (hr : r ≥ 3) (k : ℕ) :
+    answer(sorry) ↔
+    ∀ ε > 0, ∃ C : ℝ, C > 0 ∧
+      ∀ n ≥ 1, (∏ m ∈ Finset.Ico n (n + k), rFullPart r m : ℝ) ≤ C * (n : ℝ)^(r + ε) := by
+  sorry
+
+/-!
+## Analysis of Consecutive Integers
+-/
+
+/-- Key insight: consecutive integers often share high prime powers -/
+-- If p² | n, then p² | n + p² - (n mod p²) for nearby integers
+-- This can create large products of 2-full parts
+
+/-- The product is large when consecutive integers share large 2-full parts -/
+lemma product_large_when_shared (n k : ℕ) :
+    ∃ m₁ m₂ : ℕ, m₁ ∈ Finset.Ico n (n + k) ∧ m₂ ∈ Finset.Ico n (n + k) ∧
+      m₁ ≠ m₂ → twoFullPart m₁ * twoFullPart m₂ ≤ productTwoFullParts n k := by
+  sorry
+
+/-!
+## Heuristics and Expectations
+-/
+
+/-- Heuristic: B₂(n) ≈ 1 on average (most numbers are nearly squarefree) -/
+-- The "typical" value of B₂(n) is small, but occasional large values
+-- from highly composite numbers contribute to the product.
+
+/-- Expected order: E[B₂(n)] is bounded -/
+-- On average, B₂(n) is O(1), but the maximum over k consecutive
+-- integers can be much larger.
+
+end Erdos367
+
+-- Placeholder for main result
+theorem erdos_367_placeholder : True := trivial

--- a/src/data/proofs/erdos-367/annotations.json
+++ b/src/data/proofs/erdos-367/annotations.json
@@ -1,0 +1,242 @@
+[
+  {
+    "id": "ann-367-1",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 1,
+      "endLine": 18
+    },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "Erdős Problem #367: For fixed k, is ∏_{n ≤ m < n+k} B₂(m) ≪ n^{2+o(1)}? Here B₂(n) is the 2-full part of n. Strong bound ≪_k n² fails for k ≥ 3 (van Doorn). OPEN.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-367-2",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 46,
+      "endLine": 48
+    },
+    "type": "definition",
+    "title": "Squarefree Part",
+    "content": "The squarefree part of n is the product of primes dividing n exactly once. It's the 'squarefree core' of n.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-367-3",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 50,
+      "endLine": 54
+    },
+    "type": "definition",
+    "title": "2-Full Part",
+    "content": "B₂(n) = n / squarefreePart(n) is the 2-full part. It captures prime powers p² and higher in the factorization of n.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-367-4",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 56,
+      "endLine": 59
+    },
+    "type": "definition",
+    "title": "Alternative Definition",
+    "content": "B₂(n) = ∏_{v_p(n) ≥ 2} p^{v_p(n)}. This shows B₂(n) is the product of prime powers where the exponent is at least 2.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-367-5",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 61,
+      "endLine": 63
+    },
+    "type": "definition",
+    "title": "Product Function",
+    "content": "productTwoFullParts(n, k) = ∏_{n ≤ m < n+k} B₂(m). This is the main quantity of interest in the problem.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-367-6",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 71,
+      "endLine": 74
+    },
+    "type": "definition",
+    "title": "Weak Bound",
+    "content": "weakBound(k) states that ∏B₂(m) ≤ C·n^{2+ε} for any ε > 0 and some C depending on ε. This is the main conjecture.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-367-7",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 76,
+      "endLine": 79
+    },
+    "type": "definition",
+    "title": "Strong Bound",
+    "content": "strongBound(k) states that ∏B₂(m) ≤ C_k·n² for a constant depending only on k. This fails for k ≥ 3.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-367-8",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 81,
+      "endLine": 84
+    },
+    "type": "theorem",
+    "title": "Main Problem Statement",
+    "content": "Erdős Problem #367: Does weakBound(k) hold for all k ≥ 1? This asks for n^{2+o(1)} growth of products of 2-full parts.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-367-9",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 90,
+      "endLine": 93
+    },
+    "type": "theorem",
+    "title": "Trivial Cases",
+    "content": "For k ≤ 2, the strong bound ≪ n² holds. This follows from B₂(n) ≤ n and B₂(n)·B₂(n+1) ≤ n(n+1).",
+    "significance": "key"
+  },
+  {
+    "id": "ann-367-10",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 95,
+      "endLine": 98
+    },
+    "type": "theorem",
+    "title": "Strong Bound Failure",
+    "content": "The strong bound ≪_k n² fails for k = 3 (and hence for all k ≥ 3). van Doorn showed this.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-367-11",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 100,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "van Doorn Lower Bound",
+    "content": "There exist infinitely many n with ∏_{n ≤ m < n+3} B₂(m) ≥ c·n²·log n. This shows products can exceed n² by a logarithmic factor.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-367-12",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 111,
+      "endLine": 114
+    },
+    "type": "theorem",
+    "title": "Squarefree Characterization",
+    "content": "B₂(n) = 1 if and only if n is squarefree. Squarefree numbers have no repeated prime factors.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-367-13",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 116,
+      "endLine": 126
+    },
+    "type": "theorem",
+    "title": "Prime Cases",
+    "content": "B₂(p) = 1 for primes (squarefree), and B₂(p²) = p² (perfect square). These are extreme cases.",
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-367-14",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 128,
+      "endLine": 131
+    },
+    "type": "theorem",
+    "title": "Multiplicativity",
+    "content": "B₂ is multiplicative on coprime arguments: B₂(mn) = B₂(m)·B₂(n) when gcd(m,n) = 1.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-367-15",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 133,
+      "endLine": 140
+    },
+    "type": "theorem",
+    "title": "Basic Bounds",
+    "content": "B₂(n) ≤ n always, and B₂(n) divides n. These follow from the definition.",
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-367-16",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 146,
+      "endLine": 160
+    },
+    "type": "example",
+    "title": "Computed Examples",
+    "content": "B₂(1) = 1, B₂(4) = 4, B₂(6) = 1 (squarefree), B₂(12) = 4, B₂(72) = 36. These illustrate the computation.",
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-367-17",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 166,
+      "endLine": 169
+    },
+    "type": "definition",
+    "title": "r-Full Part",
+    "content": "The r-full part B_r(n) generalizes to ∏_{v_p(n) ≥ r} p^{v_p(n)}. The 2-full part is B_2(n).",
+    "significance": "key"
+  },
+  {
+    "id": "ann-367-18",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 174,
+      "endLine": 179
+    },
+    "type": "theorem",
+    "title": "Generalized Problem",
+    "content": "For r ≥ 3, ask whether products of r-full parts grow at most as n^{r+o(1)}. This extends the main problem.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-367-19",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 185,
+      "endLine": 189
+    },
+    "type": "concept",
+    "title": "Consecutive Integer Analysis",
+    "content": "Large products occur when consecutive integers share high prime powers. If p² divides both n and n+k for small k, products can be large.",
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-367-20",
+    "proofId": "erdos-367",
+    "range": {
+      "startLine": 195,
+      "endLine": 200
+    },
+    "type": "concept",
+    "title": "Heuristics",
+    "content": "On average, B₂(n) ≈ 1 since most numbers are nearly squarefree. But occasional large values (highly composite numbers) can create large products over short intervals.",
+    "significance": "supporting"
+  }
+]

--- a/src/data/proofs/erdos-367/meta.json
+++ b/src/data/proofs/erdos-367/meta.json
@@ -1,0 +1,68 @@
+{
+  "id": "erdos-367",
+  "title": "Erdős Problem #367: Products of 2-Full Parts",
+  "slug": "erdos-367",
+  "description": "Study the growth of products of 2-full parts over consecutive integers.",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/367",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos367Problem.lean",
+    "tags": ["number theory", "powerful numbers", "consecutive integers"],
+    "badge": "open-problem",
+    "sorries": 15,
+    "erdosNumber": 367,
+    "erdosUrl": "https://erdosproblems.com/367",
+    "erdosProblemStatus": "open",
+    "mathlibDependencies": []
+  },
+  "overview": {
+    "historicalContext": "This problem concerns the 2-full (squareful) part of integers, which captures the contribution from prime powers p² and higher. The problem asks about the growth of products of these parts over consecutive integers, connecting to questions about the distribution of powerful numbers.",
+    "problemStatement": "Let B₂(n) denote the 2-full part of n (the ratio n/n', where n' is the squarefree part). For every fixed k ≥ 1, is it true that ∏_{n ≤ m < n+k} B₂(m) ≪ n^{2+o(1)}? Or perhaps even ≪_k n²?",
+    "proofStrategy": "The trivial cases k ≤ 2 follow from B₂(n) ≤ n. For k ≥ 3, van Doorn showed the strong n² bound fails by exhibiting sequences where the product grows as n²·log n. The weak n^{2+ε} bound remains open.",
+    "keyInsights": [
+      "B₂(n) = 1 when n is squarefree",
+      "B₂(n) = n when n is a perfect power",
+      "For k ≤ 2, the bound ≪ n² holds trivially",
+      "For k ≥ 3, van Doorn showed ∏B₂(m) can be ≫ n²·log n",
+      "The weak bound n^{2+o(1)} remains open"
+    ]
+  },
+  "sections": [
+    {
+      "id": "section-two-full",
+      "title": "The 2-Full Part",
+      "content": "The 2-full part B₂(n) is n divided by its squarefree part. Equivalently, B₂(n) = ∏_{p² | n} p^{v_p(n)} where v_p(n) is the p-adic valuation. B₂(n) captures the 'highly divisible' component of n."
+    },
+    {
+      "id": "section-problem",
+      "title": "Main Problem",
+      "content": "For fixed k, study the maximum of ∏_{n ≤ m < n+k} B₂(m). The strong conjecture is ≪_k n². The weak conjecture is ≪ n^{2+ε} for any ε > 0. The trivial bound is ≪ n^k."
+    },
+    {
+      "id": "section-trivial",
+      "title": "Trivial Cases",
+      "content": "For k = 1, the product is just B₂(n) ≤ n ≤ n². For k = 2, B₂(n)·B₂(n+1) ≤ n·(n+1) < n². So the strong bound holds for k ≤ 2."
+    },
+    {
+      "id": "section-van-doorn",
+      "title": "van Doorn's Lower Bound",
+      "content": "For k = 3, van Doorn showed there exist infinitely many n with ∏_{n ≤ m < n+3} B₂(m) ≫ n²·log n. This disproves the strong n² bound for k ≥ 3."
+    },
+    {
+      "id": "section-generalization",
+      "title": "r-Full Parts",
+      "content": "The problem generalizes to r-full parts B_r(n) for r ≥ 3, asking whether products grow at most as n^{r+o(1)}. This connects to the distribution of r-full numbers."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős Problem #367 asks about products of 2-full parts over consecutive integers. The strong n² bound fails for k ≥ 3 (van Doorn), but the weak n^{2+o(1)} bound remains open.",
+    "implications": "Resolution would illuminate the distribution of powerful parts among consecutive integers and connect to questions about smooth numbers and highly composite numbers.",
+    "openQuestions": [
+      "Does ∏_{n ≤ m < n+k} B₂(m) ≪ n^{2+o(1)} hold for all k?",
+      "What is the true growth rate for k = 3?",
+      "How does the answer change for r-full parts with r ≥ 3?",
+      "Are there explicit constructions achieving van Doorn's lower bound?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Comprehensive Lean 4 formalization of Erdős Problem #367
- Problem: Is ∏_{n ≤ m < n+k} B₂(m) ≪ n^{2+o(1)} for consecutive integers?
- B₂(n) is the 2-full part: n divided by its squarefree part
- Strong bound ≪ n² holds for k ≤ 2 but fails for k ≥ 3 (van Doorn)
- van Doorn: ∏B₂(m) ≫ n²·log n for some sequences with k = 3

## Changes
- `proofs/Proofs/Erdos367Problem.lean`: 200 lines of Lean 4 formalization
- `src/data/proofs/erdos-367/meta.json`: Comprehensive metadata with historical context
- `src/data/proofs/erdos-367/annotations.json`: 20 educational annotations

## Test plan
- [ ] Verify Lean file compiles with Mathlib
- [ ] Check meta.json schema compliance
- [ ] Review annotation quality and coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)