### PR TITLE
Enhance erdos-404: Prime Power Divisibility of Factorial Sums

### DIFF
--- a/proofs/Proofs/Erdos404Problem.lean
+++ b/proofs/Proofs/Erdos404Problem.lean
@@ -1,0 +1,188 @@
+/-
+Erdős Problem #404: Prime Power Divisibility of Factorial Sums
+
+For which integers a ≥ 1 and primes p is there a finite upper bound on those k such that
+there exist a = a₁ < a₂ < ··· < aₙ with p^k | (a₁! + a₂! + ··· + aₙ!)?
+
+Let f(a, p) denote the greatest such k if it exists. How does f(a, p) behave?
+
+Secondary question: Is there a prime p and an infinite sequence a₁ < a₂ < ···
+such that if p^{mₖ} is the highest power of p dividing ∑_{i≤k} aᵢ!, then mₖ → ∞?
+
+Known results:
+- Lin: f(2, 2) ≤ 254
+
+This is Problem #404 from erdosproblems.com.
+
+Reference: https://erdosproblems.com/404
+
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import Mathlib
+
+/-!
+# Erdős Problem 404: Prime Power Divisibility of Factorial Sums
+
+*Reference:* [erdosproblems.com/404](https://www.erdosproblems.com/404)
+-/
+
+open Nat Finset
+open Filter
+
+namespace Erdos404
+
+/-- A strictly increasing sequence starting at a -/
+structure StrictIncSeq (a : ℕ) where
+  length : ℕ
+  seq : Fin length → ℕ
+  starts_at_a : length > 0 → seq ⟨0, by omega⟩ = a
+  strictly_increasing : ∀ i j : Fin length, i < j → seq i < seq j
+
+/-- The sum of factorials over a sequence -/
+noncomputable def factorialSum (s : StrictIncSeq a) : ℕ :=
+  ∑ i : Fin s.length, (s.seq i).factorial
+
+/-- p^k divides the factorial sum -/
+def dividesByPrimePower (a k : ℕ) (p : ℕ) : Prop :=
+  ∃ s : StrictIncSeq a, p^k ∣ factorialSum s
+
+/-- The set of k such that some sequence starting at a has p^k | sum of factorials -/
+def divisiblePowers (a : ℕ) (p : ℕ) : Set ℕ :=
+  {k | dividesByPrimePower a k p}
+
+/-- f(a, p) = sup {k | p^k divides some factorial sum starting at a} -/
+noncomputable def f (a : ℕ) (p : ℕ) : ℕ∞ :=
+  sSup (divisiblePowers a p : Set ℕ)
+
+/-!
+## Main Questions
+
+Erdős Problem #404 asks about the finiteness and behavior of f(a, p).
+-/
+
+/-- Question 1: For which (a, p) is f(a, p) finite? -/
+@[category research open, AMS 11]
+theorem erdos_404_q1 (a : ℕ) (p : ℕ) (hp : p.Prime) :
+    answer(sorry) ↔ f a p < ⊤ := by
+  sorry
+
+/-- Question 2: How does f(a, p) behave as a function of a and p? -/
+-- This is a qualitative question about the structure of f
+
+/-- Secondary question: Does there exist p and sequence with mₖ → ∞? -/
+def secondaryQuestion : Prop :=
+  ∃ p : ℕ, p.Prime ∧ ∃ seq : ℕ → ℕ, StrictMono seq ∧
+    Tendsto (fun k => padicValNat p (∑ i ∈ Finset.range (k+1), (seq i).factorial)) atTop atTop
+
+@[category research open, AMS 11]
+theorem erdos_404_secondary : answer(sorry) ↔ secondaryQuestion := by
+  sorry
+
+/-!
+## Known Results
+-/
+
+/-- Lin's bound: f(2, 2) ≤ 254 -/
+@[category research solved, AMS 11]
+theorem lin_bound : f 2 2 ≤ 254 := by
+  sorry
+
+/-- This means: for any strictly increasing sequence starting at 2,
+    2^255 does not divide the sum of factorials -/
+lemma lin_bound_meaning : ∀ s : StrictIncSeq 2, ¬(2^255 ∣ factorialSum s) := by
+  sorry
+
+/-!
+## p-adic Analysis of Factorials
+-/
+
+/-- Legendre's formula: v_p(n!) = ∑_{i≥1} ⌊n/p^i⌋ -/
+noncomputable def legendreSum (n p : ℕ) : ℕ :=
+  ∑ i ∈ Finset.range (Nat.log p n + 1), n / p^(i+1)
+
+lemma legendre_formula (n p : ℕ) (hp : p.Prime) (hn : n ≥ 1) :
+    padicValNat p n.factorial = legendreSum n p := by
+  sorry
+
+/-- For large n, v_p(n!) ≈ n/(p-1) -/
+lemma padic_val_factorial_asymp (p : ℕ) (hp : p.Prime) :
+    Tendsto (fun n => (padicValNat p n.factorial : ℝ) / n) atTop (nhds (1/(p-1))) := by
+  sorry
+
+/-!
+## Structure of Factorial Sums
+-/
+
+/-- If a₁ < a₂, then a₂! dominates and a₁! + a₂! ≡ a₁! (mod a₂!) -/
+lemma factorial_sum_mod (a₁ a₂ : ℕ) (h : a₁ < a₂) :
+    a₁.factorial + a₂.factorial ≡ a₁.factorial [MOD a₂.factorial] := by
+  sorry
+
+/-- The p-adic valuation of a sum depends on cancellation -/
+-- If all terms have the same p-adic valuation, the sum might have higher or equal valuation
+-- Cancellation can increase the valuation
+
+/-- Key observation: a₁! + a₂! = a₁!(1 + (a₂!/a₁!)) -/
+lemma factorial_sum_factored (a₁ a₂ : ℕ) (h : a₁ ≤ a₂) :
+    a₁.factorial + a₂.factorial = a₁.factorial * (1 + a₂.factorial / a₁.factorial) := by
+  sorry
+
+/-!
+## Examples
+-/
+
+/-- Example: 2! + 3! = 2 + 6 = 8 = 2³, so f(2, 2) ≥ 3 -/
+example : 2^3 ∣ Nat.factorial 2 + Nat.factorial 3 := by
+  native_decide
+
+/-- Example: 1! + 2! = 1 + 2 = 3, so 3 | 1! + 2! -/
+example : 3 ∣ Nat.factorial 1 + Nat.factorial 2 := by
+  native_decide
+
+/-- For p > a, we have v_p(a!) = 0, so v_p(a₁! + ··· + aₙ!) = v_p(sum of small numbers) -/
+-- This makes the problem easier for large primes
+
+/-!
+## Heuristics
+-/
+
+/-- Heuristic: For fixed a, as p → ∞, f(a, p) should decrease -/
+-- Larger primes divide fewer numbers, making high powers harder to achieve
+
+/-- Heuristic: For fixed p, as a → ∞, f(a, p) might increase -/
+-- Larger starting points give access to larger factorials with more p factors
+
+/-- The problem cannot be resolved by finite computation -/
+-- Even if f(a, p) < ∞, verifying this requires infinite search
+
+/-!
+## Special Cases
+-/
+
+/-- For a = 1: studying 1! + larger factorials -/
+-- 1! = 1, so we're asking about 1 + (larger factorials)
+
+/-- For p = 2: the most studied case -/
+-- Lin's bound gives f(2, 2) ≤ 254
+-- The structure of 2-adic valuations is well-understood
+
+/-- When does equality f(a, p) = k hold? -/
+-- This means p^k divides some sum, but p^{k+1} never does
+
+end Erdos404
+
+-- Placeholder for main result
+theorem erdos_404_placeholder : True := trivial

--- a/src/data/proofs/erdos-404/annotations.json
+++ b/src/data/proofs/erdos-404/annotations.json
@@ -1,0 +1,242 @@
+[
+  {
+    "id": "ann-404-1",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 1,
+      "endLine": 14
+    },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "Erdős Problem #404: For which (a, p) is f(a,p) = sup{k : p^k | some factorial sum} finite? Lin showed f(2,2) ≤ 254. Also asks if v_p(∑aᵢ!) can → ∞. OPEN.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-404-2",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 44,
+      "endLine": 50
+    },
+    "type": "definition",
+    "title": "Strictly Increasing Sequence",
+    "content": "A StrictIncSeq starting at a is a finite sequence a = a₁ < a₂ < ··· < aₙ. These are the index sets for factorial sums.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-404-3",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 52,
+      "endLine": 54
+    },
+    "type": "definition",
+    "title": "Factorial Sum",
+    "content": "factorialSum(s) = a₁! + a₂! + ··· + aₙ! is the sum of factorials over the sequence. We study divisibility of this sum.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-404-4",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 56,
+      "endLine": 62
+    },
+    "type": "definition",
+    "title": "Divisibility Predicate",
+    "content": "dividesByPrimePower(a, k, p) holds if there exists a sequence starting at a whose factorial sum is divisible by p^k.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-404-5",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 64,
+      "endLine": 66
+    },
+    "type": "definition",
+    "title": "The Function f(a,p)",
+    "content": "f(a,p) = sup{k : p^k divides some factorial sum starting at a}. This is the central function of the problem.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-404-6",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 74,
+      "endLine": 77
+    },
+    "type": "theorem",
+    "title": "Main Question",
+    "content": "Question 1: For which (a, p) is f(a,p) < ∞? This asks when there's a uniform bound on prime power divisibility.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-404-7",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 82,
+      "endLine": 87
+    },
+    "type": "definition",
+    "title": "Secondary Question",
+    "content": "Does there exist p and sequence {aᵢ} with v_p(∑_{i≤k} aᵢ!) → ∞? This asks if partial sums can have unbounded p-adic valuation.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-404-8",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 96,
+      "endLine": 98
+    },
+    "type": "theorem",
+    "title": "Lin's Bound",
+    "content": "Lin proved f(2,2) ≤ 254. No sum of factorials starting at 2 is divisible by 2^255.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-404-9",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 100,
+      "endLine": 102
+    },
+    "type": "theorem",
+    "title": "Lin's Bound Meaning",
+    "content": "For any strictly increasing sequence starting at 2, the sum of factorials is not divisible by 2^255.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-404-10",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 108,
+      "endLine": 111
+    },
+    "type": "definition",
+    "title": "Legendre's Formula",
+    "content": "v_p(n!) = ∑_{i≥1} ⌊n/p^i⌋. This gives the exact p-adic valuation of factorials.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-404-11",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 113,
+      "endLine": 116
+    },
+    "type": "theorem",
+    "title": "Legendre Formula Proof",
+    "content": "The p-adic valuation of n! equals the Legendre sum ∑⌊n/p^i⌋. This is a classical result in number theory.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-404-12",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 118,
+      "endLine": 120
+    },
+    "type": "theorem",
+    "title": "Asymptotic Formula",
+    "content": "For large n, v_p(n!) ≈ n/(p-1). This approximation governs the growth of p-adic valuations.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-404-13",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 126,
+      "endLine": 129
+    },
+    "type": "theorem",
+    "title": "Factorial Sum Modular",
+    "content": "If a₁ < a₂, then a₁! + a₂! ≡ a₁! (mod a₂!). The larger factorial dominates modularly.",
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-404-14",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 134,
+      "endLine": 137
+    },
+    "type": "theorem",
+    "title": "Factored Form",
+    "content": "a₁! + a₂! = a₁!(1 + a₂!/a₁!). This factorization helps analyze divisibility.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-404-15",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 143,
+      "endLine": 145
+    },
+    "type": "example",
+    "title": "Example: 2! + 3!",
+    "content": "2! + 3! = 2 + 6 = 8 = 2³, showing f(2,2) ≥ 3. This is a simple case demonstrating the phenomenon.",
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-404-16",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 147,
+      "endLine": 149
+    },
+    "type": "example",
+    "title": "Example: 1! + 2!",
+    "content": "1! + 2! = 1 + 2 = 3, which is divisible by 3. This shows f(1,3) ≥ 1.",
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-404-17",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 151,
+      "endLine": 152
+    },
+    "type": "concept",
+    "title": "Large Primes",
+    "content": "For p > a, we have v_p(a!) = 0, simplifying the analysis. The problem is easier for large primes.",
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-404-18",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 158,
+      "endLine": 165
+    },
+    "type": "concept",
+    "title": "Heuristics",
+    "content": "For fixed a, f(a,p) should decrease as p → ∞. For fixed p, f(a,p) might increase as a → ∞. The problem cannot be resolved by finite computation.",
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-404-19",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 171,
+      "endLine": 175
+    },
+    "type": "concept",
+    "title": "Special Cases",
+    "content": "For a = 1, we study 1 + larger factorials. For p = 2, Lin's bound applies. These are the most accessible cases.",
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-404-20",
+    "proofId": "erdos-404",
+    "range": {
+      "startLine": 177,
+      "endLine": 178
+    },
+    "type": "concept",
+    "title": "Equality Question",
+    "content": "When does f(a,p) = k exactly? This requires p^k dividing some sum but p^{k+1} never dividing any sum.",
+    "significance": "supporting"
+  }
+]

--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -1,0 +1,69 @@
+{
+  "id": "erdos-404",
+  "title": "Erdős Problem #404: Prime Power Divisibility of Factorial Sums",
+  "slug": "erdos-404",
+  "description": "For which (a, p) is there a bound on k such that p^k divides some sum of factorials starting at a?",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/404",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos404Problem.lean",
+    "tags": ["number theory", "factorials", "p-adic valuation", "divisibility"],
+    "badge": "open-problem",
+    "sorries": 8,
+    "erdosNumber": 404,
+    "erdosUrl": "https://erdosproblems.com/404",
+    "erdosProblemStatus": "open",
+    "mathlibDependencies": []
+  },
+  "overview": {
+    "historicalContext": "This problem concerns the divisibility of sums of factorials by prime powers. It connects p-adic analysis with combinatorial number theory. Lin proved that f(2,2) ≤ 254, establishing a concrete upper bound for one case. The problem cannot be resolved by finite computation alone.",
+    "problemStatement": "For which integers a ≥ 1 and primes p is there a finite upper bound on k such that there exist a = a₁ < a₂ < ··· < aₙ with p^k | (a₁! + ··· + aₙ!)? If f(a,p) denotes the greatest such k, how does it behave? Also: Is there p and sequence with v_p(∑aᵢ!) → ∞?",
+    "proofStrategy": "The analysis uses p-adic valuations and Legendre's formula v_p(n!) = ∑⌊n/p^i⌋. Understanding when sums of factorials have high p-adic valuation requires analyzing cancellation patterns and the structure of factorial ratios.",
+    "keyInsights": [
+      "f(a,p) = sup{k : p^k | some factorial sum starting at a}",
+      "Lin proved f(2,2) ≤ 254",
+      "Legendre's formula gives v_p(n!) ≈ n/(p-1)",
+      "The problem cannot be resolved by finite computation",
+      "Secondary question asks if v_p(∑aᵢ!) can grow unboundedly"
+    ]
+  },
+  "sections": [
+    {
+      "id": "section-definition",
+      "title": "The Function f(a,p)",
+      "content": "f(a,p) is the supremum of k such that p^k divides some sum a₁! + ··· + aₙ! where a = a₁ < a₂ < ··· is strictly increasing. The question is whether f(a,p) is always finite."
+    },
+    {
+      "id": "section-secondary",
+      "title": "Secondary Question",
+      "content": "Is there a prime p and infinite sequence a₁ < a₂ < ··· such that v_p(∑_{i≤k} aᵢ!) → ∞ as k → ∞? This asks if partial sums can achieve arbitrarily high p-adic valuations."
+    },
+    {
+      "id": "section-lin",
+      "title": "Lin's Result",
+      "content": "Lin proved f(2,2) ≤ 254, meaning no sum of factorials starting at 2 can be divisible by 2^255. This is the main known quantitative result."
+    },
+    {
+      "id": "section-padic",
+      "title": "p-adic Analysis",
+      "content": "Legendre's formula v_p(n!) = ∑⌊n/p^i⌋ gives the p-adic valuation of factorials. For large n, v_p(n!) ≈ n/(p-1). Sums of factorials can have cancellation affecting their p-adic valuation."
+    },
+    {
+      "id": "section-structure",
+      "title": "Structure of Sums",
+      "content": "For a₁ < a₂, we have a₁! + a₂! = a₁!(1 + a₂!/a₁!). The ratio a₂!/a₁! = (a₁+1)(a₁+2)···a₂ determines how divisibility extends."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős Problem #404 asks about the divisibility of factorial sums by prime powers. The function f(a,p) measures the maximum power of p that can divide such sums. Lin showed f(2,2) ≤ 254. The general behavior of f(a,p) and the secondary question remain open.",
+    "implications": "Resolution would illuminate the arithmetic structure of factorial sums and their p-adic properties. Understanding f(a,p) connects to deep questions about how factorials combine arithmetically.",
+    "openQuestions": [
+      "Is f(a,p) finite for all a and primes p?",
+      "How does f(a,p) grow with a for fixed p?",
+      "Can v_p(∑aᵢ!) → ∞ for some sequence?",
+      "What is the exact value of f(2,2)?",
+      "Are there other primes p where f(2,p) is bounded?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Comprehensive Lean 4 formalization of Erdős Problem #404
- Problem: For which (a, p) is f(a,p) = sup{k : p^k | some factorial sum} finite?
- f(a,p) measures the maximum prime power dividing sums a₁! + a₂! + ···
- Lin proved f(2,2) ≤ 254 (no sum starting at 2 is divisible by 2^255)
- Secondary question: Can v_p(∑aᵢ!) → ∞ for some sequence?

## Changes
- `proofs/Proofs/Erdos404Problem.lean`: 180 lines of Lean 4 formalization
- `src/data/proofs/erdos-404/meta.json`: Comprehensive metadata with historical context
- `src/data/proofs/erdos-404/annotations.json`: 20 educational annotations

## Test plan
- [ ] Verify Lean file compiles with Mathlib
- [ ] Check meta.json schema compliance
- [ ] Review annotation quality and coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)