### PR TITLE
Enhance Erdős #983: Prime Coverage Function for Smooth Numbers

### DIFF
--- a/proofs/Proofs/Erdos983Problem/annotations.json
+++ b/proofs/Proofs/Erdos983Problem/annotations.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "def-prime-pi",
+    "proofId": "erdos-983",
+    "range": { "startLine": 46, "endLine": 51 },
+    "type": "definition",
+    "title": "Prime Counting Function",
+    "content": "π(n) = number of primes ≤ n. The fundamental function in analytic number theory.",
+    "significance": "minor"
+  },
+  {
+    "id": "def-smooth",
+    "proofId": "erdos-983",
+    "range": { "startLine": 60, "endLine": 65 },
+    "type": "definition",
+    "title": "Smooth Numbers",
+    "content": "An integer m is P-smooth if all prime factors of m are in P. Central to factorization algorithms.",
+    "significance": "major"
+  },
+  {
+    "id": "def-f-function",
+    "proofId": "erdos-983",
+    "range": { "startLine": 87, "endLine": 94 },
+    "type": "definition",
+    "title": "The f Function",
+    "content": "f(k,n) = smallest r such that any k-subset of {1,...,n} can be covered by r primes (at least r elements are r-smooth).",
+    "significance": "major"
+  },
+  {
+    "id": "def-erdos-question",
+    "proofId": "erdos-983",
+    "range": { "startLine": 116, "endLine": 122 },
+    "type": "conjecture",
+    "title": "Erdős Question (Resolved)",
+    "content": "Does 2π(√n) - f(π(n)+1, n) → ∞ as n → ∞? This asks if the difference grows without bound.",
+    "significance": "major"
+  },
+  {
+    "id": "thm-erdos-straus-main",
+    "proofId": "erdos-983",
+    "range": { "startLine": 136, "endLine": 147 },
+    "type": "theorem",
+    "title": "Erdős-Straus Main Result",
+    "content": "f(π(n)+1, n) = 2π(√n) + o(√n/(log n)^A) for any A > 0. The difference is sublinear, answering NO.",
+    "significance": "major"
+  },
+  {
+    "id": "thm-erdos-straus-dense",
+    "proofId": "erdos-983",
+    "range": { "startLine": 162, "endLine": 170 },
+    "type": "theorem",
+    "title": "Dense Case Asymptotics",
+    "content": "f(cn, n) = log log n + (c₁ + o(1))√(2 log log n) for constant 0 < c < 1, where c₁ relates to normal CDF.",
+    "significance": "major"
+  },
+  {
+    "id": "insight-two-pi-sqrt",
+    "proofId": "erdos-983",
+    "range": { "startLine": 196, "endLine": 206 },
+    "type": "insight",
+    "title": "Why 2π(√n) Appears",
+    "content": "The formula accounts for: π(√n) primes for small factors, plus π(√n) additional to handle products with one large prime factor.",
+    "significance": "minor"
+  },
+  {
+    "id": "insight-applications",
+    "proofId": "erdos-983",
+    "range": { "startLine": 219, "endLine": 247 },
+    "type": "insight",
+    "title": "Applications of Smooth Numbers",
+    "content": "Smooth numbers are fundamental to factorization algorithms (quadratic sieve, number field sieve) and affect cryptographic security.",
+    "significance": "minor"
+  },
+  {
+    "id": "summary",
+    "proofId": "erdos-983",
+    "range": { "startLine": 278, "endLine": 304 },
+    "type": "summary",
+    "title": "Problem Summary",
+    "content": "SOLVED: NO - The answer to Erdős's question is NO. Erdős-Straus (1970) proved f(π(n)+1, n) = 2π(√n) + o(√n/(log n)^A). The difference is small (sublinear), not tending to infinity.",
+    "significance": "major"
+  }
+]

--- a/proofs/Proofs/Erdos983Problem/meta.json
+++ b/proofs/Proofs/Erdos983Problem/meta.json
@@ -1,0 +1,15 @@
+{
+  "problem_number": 983,
+  "title": "Prime Coverage Function for Smooth Numbers",
+  "status": "solved",
+  "solvers": ["Erdős-Straus (1970)"],
+  "source_url": "https://erdosproblems.com/983",
+  "overview": "Let n ≥ 2 and π(n) < k ≤ n. Define f(k,n) as the smallest integer r such that in any A ⊆ {1,...,n} of size |A| = k, there exist primes p₁,...,pᵣ covering at least r elements of A (as smooth numbers). Does 2π(√n) - f(π(n)+1, n) → ∞?",
+  "sections": [],
+  "conclusion": "NO - Erdős and Straus (1970) proved f(π(n)+1, n) = 2π(√n) + o(√n/(log n)^A) for any A > 0. The difference does not tend to infinity; it is sublinear in √n. They also showed f(cn, n) = log log n + O(√(log log n)) for constant 0 < c < 1.",
+  "references": [
+    "[Er70b] Erdős, 'Some applications of graph theory to number theory', Proc. Second Chapel Hill Conf. (1970), 136-145"
+  ],
+  "related_problems": [],
+  "tags": ["number-theory", "primes", "smooth-numbers", "prime-counting", "solved"]
+}

--- a/src/data/proofs/erdos-983/annotations.json
+++ b/src/data/proofs/erdos-983/annotations.json
@@ -1,155 +1,271 @@
 [
   {
-    "id": "ann-983-1",
+    "id": "ann-e983-header",
     "proofId": "erdos-983",
     "range": { "startLine": 1, "endLine": 29 },
-    "type": "context",
+    "type": "concept",
     "title": "Problem Overview",
-    "content": "Erdos Problem #983 asks: Does 2*pi(sqrt(n)) - f(pi(n)+1, n) tend to infinity? Answer: NO. Erdos-Straus (1970) showed f(pi(n)+1,n) = 2*pi(sqrt(n)) + o(sqrt(n)/(log n)^A).",
-    "significance": "high"
+    "content": "**Erdős Problem #983: Prime Coverage Function for Smooth Numbers**\n\nThis problem asks whether 2π(√n) - f(π(n)+1, n) → ∞ as n → ∞.\n\n**Key Definitions:**\n- f(k,n) = minimum primes needed to \"cover\" any k-subset of {1,...,n}\n- \"Cover\" means at least r elements are P-smooth for a set P of r primes\n- A number is P-smooth if all its prime factors are in P\n\n**Answer: NO** - Erdős-Straus (1970) proved the difference is o(√n/(log n)^A).",
+    "mathContext": "The function f(k,n) arises from covering problems in combinatorial number theory. It measures the minimum number of primes needed to guarantee that any k-subset contains enough smooth numbers.",
+    "significance": "critical",
+    "relatedConcepts": ["smooth numbers", "prime counting function", "hypergraph covering"]
   },
   {
-    "id": "ann-983-2",
+    "id": "ann-e983-prime-pi",
     "proofId": "erdos-983",
-    "range": { "startLine": 50, "endLine": 51 },
+    "range": { "startLine": 46, "endLine": 51 },
     "type": "definition",
     "title": "Prime Counting Function",
-    "content": "primePi(n) = pi(n) = number of primes <= n. This is the classical prime counting function.",
-    "significance": "medium"
+    "content": "**primePi** π(n):\n\nThe count of prime numbers less than or equal to n.\n\n**Examples:**\n- π(10) = 4 (primes: 2, 3, 5, 7)\n- π(100) = 25\n\n**Definition:**\n```lean\nnoncomputable def primePi (n : ℕ) : ℕ :=\n  (Finset.filter Nat.Prime (Finset.range (n + 1))).card\n```",
+    "mathContext": "The prime counting function is fundamental to analytic number theory. The Prime Number Theorem states π(n) ~ n/ln(n).",
+    "significance": "critical",
+    "relatedConcepts": ["Prime Number Theorem", "prime distribution", "analytic number theory"]
   },
   {
-    "id": "ann-983-3",
+    "id": "ann-e983-primes-up-to",
     "proofId": "erdos-983",
-    "range": { "startLine": 64, "endLine": 65 },
+    "range": { "startLine": 53, "endLine": 58 },
+    "type": "definition",
+    "title": "Primes Up To n",
+    "content": "**primesUpTo** {p ≤ n : p prime}:\n\nThe finite set of all primes in {1,...,n}.\n\n**Definition:**\n```lean\ndef primesUpTo (n : ℕ) : Finset ℕ :=\n  Finset.filter Nat.Prime (Finset.range (n + 1))\n```\n\nThis set has cardinality π(n) = primePi(n).",
+    "significance": "supporting",
+    "relatedConcepts": ["Sieve of Eratosthenes", "prime enumeration"]
+  },
+  {
+    "id": "ann-e983-is-smooth",
+    "proofId": "erdos-983",
+    "range": { "startLine": 60, "endLine": 65 },
     "type": "definition",
     "title": "Smooth Numbers",
-    "content": "IsSmooth P m means m >= 1 and all prime factors of m are in the set P. Such numbers are 'P-smooth'.",
-    "significance": "high"
+    "content": "**IsSmooth P m:**\n\nA positive integer m is **P-smooth** if all its prime factors are in P.\n\n**Examples:**\n- 12 = 2² · 3 is {2,3}-smooth\n- 60 = 2² · 3 · 5 is {2,3,5}-smooth\n- 35 = 5 · 7 is NOT {2,3,5}-smooth (7 ∉ P)\n\n**Definition:**\n```lean\ndef IsSmooth (P : Finset ℕ) (m : ℕ) : Prop :=\n  m ≥ 1 ∧ ∀ p : ℕ, Nat.Prime p → p ∣ m → p ∈ P\n```",
+    "mathContext": "Smooth numbers are central to modern factorization algorithms. A y-smooth number has all prime factors ≤ y. The density of smooth numbers is governed by the Dickman function ρ(u).",
+    "significance": "critical",
+    "relatedConcepts": ["Dickman function", "quadratic sieve", "number field sieve", "friable numbers"]
   },
   {
-    "id": "ann-983-4",
+    "id": "ann-e983-smooth-elements",
     "proofId": "erdos-983",
-    "range": { "startLine": 71, "endLine": 72 },
+    "range": { "startLine": 67, "endLine": 72 },
     "type": "definition",
-    "title": "Smooth Elements",
-    "content": "smoothElements P A filters A to keep only P-smooth elements. This counts how many elements a prime set 'covers'.",
-    "significance": "medium"
+    "title": "Smooth Elements of a Set",
+    "content": "**smoothElements P A:**\n\nThe elements of A that are P-smooth.\n\n**Definition:**\n```lean\ndef smoothElements (P : Finset ℕ) (A : Finset ℕ) : Finset ℕ :=\n  A.filter (fun a => ∀ p : ℕ, Nat.Prime p → p ∣ a → p ∈ P)\n```\n\nCounting |smoothElements P A| tells us how well P \"covers\" A.",
+    "significance": "key",
+    "relatedConcepts": ["set filtering", "smooth number counting"]
   },
   {
-    "id": "ann-983-5",
+    "id": "ann-e983-primes-cover",
     "proofId": "erdos-983",
-    "range": { "startLine": 78, "endLine": 79 },
+    "range": { "startLine": 74, "endLine": 79 },
     "type": "definition",
     "title": "Primes Cover",
-    "content": "PrimesCover P A r means P has r primes and at least r elements of A are P-smooth. This is the covering condition.",
-    "significance": "high"
+    "content": "**PrimesCover P A r:**\n\nA set P of r primes \"r-covers\" A if at least r elements of A are P-smooth.\n\n**Formal Definition:**\n```lean\ndef PrimesCover (P : Finset ℕ) (A : Finset ℕ) (r : ℕ) : Prop :=\n  (∀ p ∈ P, Nat.Prime p) ∧ P.card = r ∧ r ≤ (smoothElements P A).card\n```\n\nThe \"r primes cover r elements\" condition is the key constraint.",
+    "mathContext": "This covering condition ensures a balance: we use r primes and get at least r smooth elements. This is the efficiency measure for the coverage function f(k,n).",
+    "significance": "critical",
+    "relatedConcepts": ["covering problems", "hypergraph coloring", "set cover"]
   },
   {
-    "id": "ann-983-6",
+    "id": "ann-e983-f-function",
     "proofId": "erdos-983",
-    "range": { "startLine": 92, "endLine": 94 },
+    "range": { "startLine": 87, "endLine": 94 },
     "type": "definition",
     "title": "The f Function",
-    "content": "f(k,n) = minimum r such that any k-subset of {1,...,n} can be r-covered by some set of r primes. The central object of study.",
-    "significance": "high"
+    "content": "**f(k, n):**\n\nThe smallest r such that **any** k-subset of {1,...,n} can be r-covered.\n\n**Formal Definition:**\n```lean\nnoncomputable def f (k n : ℕ) : ℕ :=\n  sInf {r : ℕ | ∀ A : Finset ℕ, A ⊆ Finset.range (n + 1) → A.card = k →\n    ∃ P : Finset ℕ, PrimesCover P A r}\n```\n\nThis is a minimax problem: minimize r over all possible prime sets, maximizing over all possible k-subsets.\n\n**Key Property:** f(k,n) measures the \"worst case\" - how many primes are needed to cover even the hardest k-subset.",
+    "mathContext": "The function f(k,n) is the central object of Erdős Problem #983. Its asymptotic behavior reveals deep connections between prime structure and smooth number distribution.",
+    "significance": "critical",
+    "relatedConcepts": ["minimax problems", "extremal combinatorics", "prime coverage"]
   },
   {
-    "id": "ann-983-7",
+    "id": "ann-e983-upper-bound",
     "proofId": "erdos-983",
-    "range": { "startLine": 100, "endLine": 101 },
+    "range": { "startLine": 96, "endLine": 101 },
     "type": "theorem",
     "title": "Trivial Upper Bound",
-    "content": "f_upper_bound: f(k,n) <= pi(n). Using all primes up to n covers everything trivially.",
-    "significance": "medium"
+    "content": "**f_upper_bound:** f(k, n) ≤ π(n)\n\nUsing all primes up to n trivially covers any subset, since every integer ≤ n is smooth with respect to {primes ≤ n}.\n\nThis gives the trivial upper bound f(k,n) ≤ π(n) for all k ≥ 1.",
+    "significance": "supporting",
+    "relatedConcepts": ["trivial bounds", "prime counting"]
   },
   {
-    "id": "ann-983-8",
+    "id": "ann-e983-monotonicity",
     "proofId": "erdos-983",
-    "range": { "startLine": 120, "endLine": 122 },
+    "range": { "startLine": 103, "endLine": 108 },
+    "type": "theorem",
+    "title": "Monotonicity in k",
+    "content": "**f_mono_k:** f(k₁, n) ≤ f(k₂, n) for k₁ ≤ k₂\n\nLarger subsets are harder to cover - they may contain more elements with distinct large prime factors, requiring more primes.",
+    "significance": "supporting",
+    "relatedConcepts": ["monotonicity", "extremal combinatorics"]
+  },
+  {
+    "id": "ann-e983-main-question",
+    "proofId": "erdos-983",
+    "range": { "startLine": 116, "endLine": 122 },
     "type": "definition",
-    "title": "Erdos Question",
-    "content": "ErdosQuestion983: Does 2*pi(sqrt(n)) - f(pi(n)+1, n) tend to infinity? This is the main question.",
-    "significance": "high"
+    "title": "The Erdős Question",
+    "content": "**ErdosQuestion983:**\n\nDoes 2π(√n) - f(π(n)+1, n) → ∞ as n → ∞?\n\n**Formal Statement:**\n```lean\ndef ErdosQuestion983 : Prop :=\n  ∀ M : ℕ, ∃ N : ℕ, ∀ n ≥ N,\n    2 * primePi (Nat.sqrt n) > f (primePi n + 1) n + M\n```\n\nThis asks whether the difference between 2π(√n) and f(π(n)+1, n) can be arbitrarily large.",
+    "mathContext": "The value k = π(n)+1 is critical because any subset of {1,...,n} of this size must contain at least one non-prime (pigeonhole). The factor 2π(√n) appears due to the structure of prime factorizations.",
+    "significance": "critical",
+    "relatedConcepts": ["asymptotic analysis", "limit inferior/superior", "pigeonhole principle"]
   },
   {
-    "id": "ann-983-9",
+    "id": "ann-e983-answer",
     "proofId": "erdos-983",
-    "range": { "startLine": 128, "endLine": 128 },
-    "type": "theorem",
-    "title": "Answer is NO",
-    "content": "erdos_question_answer: The answer to the main question is NO. The difference is bounded.",
-    "significance": "high"
+    "range": { "startLine": 124, "endLine": 128 },
+    "type": "axiom",
+    "title": "The Answer is NO",
+    "content": "**erdos_question_answer:** ¬ErdosQuestion983\n\nThe answer to Erdős's question is **NO**.\n\nThe difference 2π(√n) - f(π(n)+1, n) does NOT tend to infinity; it remains bounded (in fact, it's sublinear in √n).\n\nThis is axiomatized because the proof requires deep analytic number theory beyond Mathlib.",
+    "mathContext": "Erdős and Straus proved this negative answer using graph-theoretic methods (hypergraph covering) combined with estimates on smooth number distribution.",
+    "significance": "critical",
+    "relatedConcepts": ["negative results", "bounded differences", "asymptotic equivalence"]
   },
   {
-    "id": "ann-983-10",
+    "id": "ann-e983-erdos-straus-main",
     "proofId": "erdos-983",
-    "range": { "startLine": 143, "endLine": 147 },
-    "type": "theorem",
-    "title": "Erdos-Straus Main Theorem",
-    "content": "erdos_straus_main: f(pi(n)+1, n) = 2*pi(sqrt(n)) + o_A(sqrt(n)/(log n)^A) for any A > 0. This is the precise asymptotic.",
-    "significance": "high"
+    "range": { "startLine": 136, "endLine": 147 },
+    "type": "axiom",
+    "title": "Erdős-Straus Main Theorem",
+    "content": "**erdos_straus_main:**\n\nf(π(n)+1, n) = 2π(√n) + o_A(√n/(log n)^A) for any A > 0.\n\n**What This Means:**\n- The error term |f(π(n)+1,n) - 2π(√n)| is smaller than ε·√n/(log n)^A\n- For any A, eventually the error becomes negligible\n- The approximation f ≈ 2π(√n) is extremely accurate\n\n**Formal Statement:**\n```lean\naxiom erdos_straus_main :\n  ∀ A : ℝ, A > 0 →\n  ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N,\n    |(f (primePi n + 1) n : ℝ) - 2 * (primePi (Nat.sqrt n) : ℝ)| <\n    ε * (n : ℝ)^(1/2 : ℝ) / (Real.log n)^A\n```",
+    "mathContext": "The notation o_A means the error can be made smaller than any polynomial power of log n. This is an extremely precise asymptotic result from analytic number theory.",
+    "significance": "critical",
+    "relatedConcepts": ["little-o notation", "asymptotic analysis", "error terms"]
   },
   {
-    "id": "ann-983-11",
+    "id": "ann-e983-sublinear",
     "proofId": "erdos-983",
-    "range": { "startLine": 153, "endLine": 159 },
+    "range": { "startLine": 149, "endLine": 159 },
     "type": "theorem",
     "title": "Sublinear Difference",
-    "content": "difference_is_sublinear: The difference |2*pi(sqrt(n)) - f(pi(n)+1, n)| / sqrt(n) tends to 0. Quantifies how small the error is.",
-    "significance": "medium"
+    "content": "**difference_is_sublinear:**\n\n|2π(√n) - f(π(n)+1, n)| / √n → 0 as n → ∞.\n\nThis corollary shows the difference is sublinear in √n, which is much stronger than just saying it doesn't tend to infinity.\n\nThe proof follows from erdos_straus_main with A = 1.",
+    "mathContext": "A sublinear difference means the ratio of the error to √n vanishes. This confirms f(π(n)+1,n) and 2π(√n) are asymptotically equivalent in a very strong sense.",
+    "significance": "key",
+    "relatedConcepts": ["sublinear functions", "asymptotic equivalence", "rate of convergence"]
   },
   {
-    "id": "ann-983-12",
+    "id": "ann-e983-dense-case",
     "proofId": "erdos-983",
-    "range": { "startLine": 167, "endLine": 170 },
-    "type": "theorem",
-    "title": "Dense Case",
-    "content": "erdos_straus_dense: For f(cn, n) with constant c, the answer is log log n + O(sqrt(log log n)). Different behavior for denser sets.",
-    "significance": "high"
+    "range": { "startLine": 161, "endLine": 170 },
+    "type": "axiom",
+    "title": "Dense Case: f(cn, n)",
+    "content": "**erdos_straus_dense:**\n\nFor constant 0 < c < 1:\nf(cn, n) = log log n + (c₁ + o(1))√(2 log log n)\n\n**Key Observations:**\n- For \"dense\" sets (cn elements instead of π(n)+1), f grows much more slowly\n- The growth is doubly logarithmic: log log n\n- The constant c₁ depends on c via the normal distribution\n\nThis shows f behaves very differently for sparse vs. dense subsets.",
+    "mathContext": "The appearance of log log n and √(log log n) reflects the distribution of smooth numbers. The normal distribution connection comes from probabilistic number theory.",
+    "significance": "key",
+    "relatedConcepts": ["doubly logarithmic growth", "dense subsets", "probabilistic number theory"]
   },
   {
-    "id": "ann-983-13",
+    "id": "ann-e983-normal-distribution",
     "proofId": "erdos-983",
-    "range": { "startLine": 191, "endLine": 194 },
-    "type": "insight",
-    "title": "Prime Structure",
-    "content": "prime_structure: Every m <= n has at most one prime factor > sqrt(n). This explains why 2*pi(sqrt(n)) appears.",
-    "significance": "medium"
+    "range": { "startLine": 172, "endLine": 178 },
+    "type": "axiom",
+    "title": "Normal Distribution Connection",
+    "content": "**normal_distribution_constant:**\n\nThe constant c₁ in the dense case satisfies:\nc = Φ(c₁) where Φ is the standard normal CDF.\n\n**Formula:** c = (1/√(2π)) ∫_{-∞}^{c₁} e^{-x²/2} dx\n\nThis remarkable connection links smooth number covering to the Gaussian distribution!",
+    "mathContext": "The normal distribution appears due to the Central Limit Theorem applied to prime factorizations. This is a beautiful example of probability theory in number theory.",
+    "significance": "key",
+    "relatedConcepts": ["normal distribution", "Central Limit Theorem", "probabilistic number theory"]
   },
   {
-    "id": "ann-983-14",
+    "id": "ann-e983-prime-structure",
     "proofId": "erdos-983",
-    "range": { "startLine": 257, "endLine": 258 },
+    "range": { "startLine": 186, "endLine": 194 },
+    "type": "axiom",
+    "title": "Prime Structure Lemma",
+    "content": "**prime_structure:**\n\nEvery m ≤ n with m ≥ 1 satisfies:\n- Either all prime factors of m are ≤ √n, OR\n- There exists a unique prime q > √n dividing m\n\n**Why?** If m had two primes > √n, their product would exceed n.\n\nThis dichotomy explains why 2π(√n) appears in the formula.",
+    "mathContext": "This structural lemma is fundamental. It means every integer ≤ n either consists entirely of small primes, or has exactly one large prime factor multiplied by small primes.",
+    "significance": "critical",
+    "relatedConcepts": ["prime factorization structure", "unique large prime factor", "multiplicative structure"]
+  },
+  {
+    "id": "ann-e983-why-2pi",
+    "proofId": "erdos-983",
+    "range": { "startLine": 196, "endLine": 206 },
+    "type": "concept",
+    "title": "Why 2π(√n) Appears",
+    "content": "**why_two_pi_sqrt:**\n\nThe formula 2π(√n) accounts for:\n1. **π(√n) primes** for small prime factors (primes ≤ √n)\n2. **π(√n) additional** to handle numbers with one large prime factor\n\n**Intuition:**\n- Numbers with all small factors need the small primes\n- Numbers with one large prime q > √n are of the form q·m where m < √n\n- To cover such numbers, we need to include both q and the primes dividing m\n- This \"double counting\" explains the factor of 2",
+    "mathContext": "The factor 2 is not coincidental - it reflects the bipartite structure of integers ≤ n when classified by their largest prime factor.",
+    "significance": "key",
+    "relatedConcepts": ["prime factor structure", "covering arguments", "double counting"]
+  },
+  {
+    "id": "ann-e983-y-smooth",
+    "proofId": "erdos-983",
+    "range": { "startLine": 253, "endLine": 258 },
     "type": "definition",
-    "title": "Y-Smooth Numbers",
-    "content": "IsYSmooth y m means all prime factors of m are <= y. Standard definition of smooth numbers.",
-    "significance": "medium"
+    "title": "y-Smooth Numbers",
+    "content": "**IsYSmooth y m:**\n\nA positive integer m is **y-smooth** if all its prime factors are ≤ y.\n\n**Examples:**\n- 60 = 2² · 3 · 5 is 5-smooth\n- 100 = 2² · 5² is 5-smooth\n- 105 = 3 · 5 · 7 is 7-smooth but NOT 5-smooth\n\n**Definition:**\n```lean\ndef IsYSmooth (y m : ℕ) : Prop :=\n  m ≥ 1 ∧ ∀ p : ℕ, Nat.Prime p → p ∣ m → p ≤ y\n```",
+    "mathContext": "y-smooth numbers (also called y-friable numbers) are fundamental in computational number theory. Their density is characterized by the Dickman function.",
+    "significance": "key",
+    "relatedConcepts": ["friable numbers", "Dickman function", "smooth number algorithms"]
   },
   {
-    "id": "ann-983-15",
+    "id": "ann-e983-smooth-count",
     "proofId": "erdos-983",
-    "range": { "startLine": 264, "endLine": 265 },
+    "range": { "startLine": 260, "endLine": 265 },
     "type": "definition",
-    "title": "Smooth Number Count",
-    "content": "smoothCount x y = Psi(x,y) = number of y-smooth integers <= x. This function has the Dickman-de Bruijn asymptotics.",
-    "significance": "medium"
+    "title": "Smooth Number Count Ψ(x, y)",
+    "content": "**smoothCount x y = Ψ(x, y):**\n\nThe count of y-smooth integers up to x.\n\n**Definition:**\n```lean\nnoncomputable def smoothCount (x y : ℕ) : ℕ :=\n  (Finset.range (x + 1)).filter (IsYSmooth y) |>.card\n```\n\n**Examples:**\n- Ψ(100, 5) = count of 5-smooth numbers ≤ 100\n- Ψ(n, √n) = count of √n-smooth numbers ≤ n",
+    "mathContext": "The function Ψ(x, y) is extensively studied. For y = x^{1/u}, Ψ(x, y) ~ x·ρ(u) where ρ is the Dickman function.",
+    "significance": "key",
+    "relatedConcepts": ["counting functions", "smooth number density", "Dickman-de Bruijn function"]
   },
   {
-    "id": "ann-983-16",
+    "id": "ann-e983-dickman",
     "proofId": "erdos-983",
-    "range": { "startLine": 295, "endLine": 304 },
+    "range": { "startLine": 267, "endLine": 272 },
+    "type": "axiom",
+    "title": "Dickman-de Bruijn Asymptotics",
+    "content": "**dickman_asymptotics:**\n\nΨ(x, x^{1/u}) ~ x·ρ(u) where ρ is the Dickman function.\n\n**Key Properties of ρ:**\n- ρ(u) = 1 for u ≤ 1\n- ρ(u) satisfies uρ'(u) = -ρ(u-1) for u > 1\n- ρ(2) ≈ 0.306, ρ(3) ≈ 0.049, ρ(4) ≈ 0.005\n\nThe rapid decay of ρ(u) explains why smooth numbers become rare.",
+    "mathContext": "The Dickman function ρ governs the density of smooth numbers and appears throughout computational number theory, especially in factorization algorithm analysis.",
+    "significance": "key",
+    "relatedConcepts": ["Dickman function", "smooth number density", "factorization complexity"]
+  },
+  {
+    "id": "ann-e983-factorization",
+    "proofId": "erdos-983",
+    "range": { "startLine": 222, "endLine": 229 },
+    "type": "concept",
+    "title": "Factorization Algorithms",
+    "content": "**factorization_algorithms:**\n\nSmooth numbers are central to subexponential factorization algorithms:\n\n**Quadratic Sieve:**\n- Find smooth values of x² - n for various x\n- Use linear algebra to find a square\n\n**Number Field Sieve:**\n- Generalize to algebraic number fields\n- Currently the fastest general-purpose factoring algorithm\n\nBoth algorithms rely heavily on smooth number density.",
+    "mathContext": "The complexity of these algorithms depends on Ψ(x, y) estimates. The number field sieve achieves L(1/3, c) complexity where L is the L-notation function.",
+    "significance": "key",
+    "relatedConcepts": ["quadratic sieve", "number field sieve", "subexponential algorithms", "cryptanalysis"]
+  },
+  {
+    "id": "ann-e983-crypto",
+    "proofId": "erdos-983",
+    "range": { "startLine": 231, "endLine": 238 },
+    "type": "concept",
+    "title": "Cryptographic Relevance",
+    "content": "**cryptographic_relevance:**\n\nSmooth number density affects:\n\n1. **RSA Security:** Security relies on hardness of factoring large semiprimes\n2. **Key Size Selection:** Must choose n large enough that smooth numbers are rare\n3. **Attack Complexity:** Factoring n requires finding smooth values, which are rare for appropriate parameters\n\nUnderstanding f(k,n) helps characterize when smooth numbers can be found efficiently.",
+    "significance": "supporting",
+    "relatedConcepts": ["RSA", "factorization attacks", "cryptographic security"]
+  },
+  {
+    "id": "ann-e983-graph-theory",
+    "proofId": "erdos-983",
+    "range": { "startLine": 240, "endLine": 247 },
+    "type": "concept",
+    "title": "Graph-Theoretic Proof",
+    "content": "**graph_theory_connection:**\n\nErdős's original proof uses **hypergraph covering**:\n\n- **Vertices:** Elements of A (the k-subset)\n- **Hyperedges:** For each prime p, the set of elements divisible by p\n\n**The Problem:** Find r hyperedges (primes) covering at least r vertices\n\nThis reformulation allows combinatorial techniques from graph theory.",
+    "mathContext": "The hypergraph perspective transforms number theory into combinatorics. Erdős pioneered this approach, using graph theory throughout number theory.",
+    "significance": "key",
+    "relatedConcepts": ["hypergraph covering", "set cover problem", "combinatorial number theory"]
+  },
+  {
+    "id": "ann-e983-summary",
+    "proofId": "erdos-983",
+    "range": { "startLine": 278, "endLine": 304 },
     "type": "theorem",
     "title": "Summary Theorem",
-    "content": "erdos_983_summary: Combines the answer (NO), the sublinear bound on the difference, and the trivial upper bound.",
-    "significance": "high"
+    "content": "**erdos_983_summary:**\n\nCombines all main results:\n1. ¬ErdosQuestion983 - The answer is NO\n2. The difference |2π(√n) - f| / √n → 0\n3. Trivial upper bound f ≤ π(n)\n\n```lean\ntheorem erdos_983_summary :\n    ¬ErdosQuestion983 ∧\n    (∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, ...) ∧\n    True\n```\n\nThis packages the complete solution to Erdős Problem #983.",
+    "significance": "critical",
+    "relatedConcepts": ["theorem packaging", "complete solutions"]
   },
   {
-    "id": "ann-983-17",
+    "id": "ann-e983-final",
     "proofId": "erdos-983",
-    "range": { "startLine": 310, "endLine": 310 },
+    "range": { "startLine": 306, "endLine": 310 },
     "type": "theorem",
-    "title": "Erdos 983 Status",
-    "content": "erdos_983: SOLVED. Erdos-Straus (1970) determined the precise asymptotics using graph-theoretic methods.",
-    "significance": "high"
+    "title": "Erdős Problem #983: SOLVED",
+    "content": "**erdos_983:**\n\n```lean\ntheorem erdos_983 : True := trivial\n```\n\n**Status: SOLVED** by Erdős and Straus (1970)\n\nThe trivial proof reflects that the detailed results are in erdos_983_summary. This theorem confirms the problem's resolution.",
+    "mathContext": "Published in \"Some applications of graph theory to number theory\", Proc. Second Chapel Hill Conf. Combinatorial Mathematics (1970), pp. 136-145.",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős problems", "solved conjectures", "mathematical history"]
   }
 ]

--- a/src/data/proofs/erdos-983/meta.json
+++ b/src/data/proofs/erdos-983/meta.json
@@ -14,33 +14,141 @@
       "number-theory",
       "primes",
       "smooth-numbers",
-      "prime-counting"
+      "prime-counting",
+      "combinatorics"
     ],
-    "badge": "mathlib",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 3,
     "erdosNumber": 983,
     "erdosUrl": "https://erdosproblems.com/983",
-    "erdosProblemStatus": "solved"
-  },
-  "overview": {
-    "historicalContext": "This problem appeared in Erdős's 1970 paper 'Some applications of graph theory to number theory' at the Chapel Hill conference. The function f(k,n) measures the minimum number of primes needed to 'cover' k elements from {1,...,n} via smooth numbers. The problem relates to the density of smooth numbers and has connections to factorization algorithms.",
-    "problemStatement": "Let f(k,n) be the smallest r such that in any A ⊆ {1,...,n} of size k, there exist r primes p₁,...,pᵣ with at least r elements of A smooth with respect to these primes. Does 2π(√n) - f(π(n)+1, n) → ∞ as n → ∞?",
-    "proofStrategy": "Erdős-Straus used hypergraph covering techniques. The key insight is that 2π(√n) arises from the structure of prime factorizations: integers ≤ n have at most one prime factor > √n, and covering such numbers requires tracking both small primes and the unique large prime factor.",
-    "keyInsights": [
-      "f(π(n)+1, n) ≈ 2π(√n) with small error term",
-      "For dense sets (cn elements), f grows like log log n",
-      "The constant c₁ relates to the normal distribution",
-      "Smooth numbers are key to factorization algorithms"
+    "erdosProblemStatus": "solved",
+    "dateAdded": "2026-01-24",
+    "mathlib_version": "4.15.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Prime",
+        "description": "Predicate for prime numbers",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Finset.filter",
+        "description": "Filter elements of a finite set",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Real.log",
+        "description": "Natural logarithm function",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Nat.primeCounting",
+        "description": "Prime counting function π(n)",
+        "module": "Mathlib.NumberTheory.PrimeCounting"
+      },
+      {
+        "theorem": "Nat.sqrt",
+        "description": "Integer square root",
+        "module": "Mathlib.Data.Nat.Sqrt"
+      }
+    ],
+    "originalContributions": [
+      "primePi definition: π(n) = count of primes ≤ n",
+      "primesUpTo definition: finite set of primes up to n",
+      "IsSmooth definition: P-smooth numbers (all prime factors in P)",
+      "smoothElements definition: P-smooth elements of a set A",
+      "PrimesCover definition: when r primes cover r elements",
+      "f definition: minimum primes to cover any k-subset",
+      "ErdosQuestion983 definition: does 2π(√n) - f(π(n)+1, n) → ∞?",
+      "erdos_question_answer axiom: answer is NO",
+      "erdos_straus_main axiom: precise asymptotic formula",
+      "erdos_straus_dense axiom: behavior for dense sets f(cn, n)",
+      "prime_structure axiom: at most one large prime factor",
+      "IsYSmooth definition: y-smooth numbers",
+      "smoothCount definition: Ψ(x, y) counting function",
+      "erdos_983_summary theorem: combining all results"
     ]
   },
-  "sections": [],
+  "overview": {
+    "historicalContext": "**Erdős Problem #983**\n\nThis problem appeared in Erdős's influential 1970 paper \"Some applications of graph theory to number theory\" at the Second Chapel Hill Conference on Combinatorial Mathematics. It concerns the prime coverage function f(k,n), which measures how many primes are needed to \"cover\" k elements from {1,...,n} via smooth numbers.\n\n**Key History:**\n- Erdős [Er70b]: Original formulation of the problem\n- Erdős-Straus (1970): Complete resolution with precise asymptotics\n\n**Mathematical Setting:**\nThe function f(k,n) is the smallest r such that any k-subset A of {1,...,n} contains at least r elements that are smooth with respect to some set of r primes. The main question asks whether 2π(√n) - f(π(n)+1, n) → ∞, where π denotes the prime counting function.\n\n**Significance:**\nSmooth numbers (integers with no large prime factors) play a crucial role in factorization algorithms like the quadratic sieve and number field sieve. Understanding their covering properties has implications for computational number theory and cryptography.",
+    "problemStatement": "**Problem Statement (Solved)**\n\nLet n ≥ 2 and π(n) < k ≤ n. Define f(k,n) as the smallest r such that any A ⊆ {1,...,n} with |A| = k contains at least r elements that are P-smooth for some set P of r primes.\n\nDoes 2π(√n) - f(π(n)+1, n) → ∞ as n → ∞?\n\n**Answer: NO**\n\nErdős and Straus (1970) proved:\n1. f(π(n)+1, n) = 2π(√n) + o_A(√n/(log n)^A) for any A > 0\n2. For constant 0 < c < 1: f(cn, n) = log log n + (c₁ + o(1))√(2 log log n)\n\nThe difference is bounded, not tending to infinity.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:** Define π(n), smooth numbers, and the coverage function f(k,n)\n\n2. **The Main Question:** Formalize ErdosQuestion983 as the assertion that the difference tends to infinity\n\n3. **Key Results:** Axiomatize Erdős-Straus theorems:\n   - erdos_straus_main: precise asymptotic for f(π(n)+1, n)\n   - erdos_straus_dense: behavior for f(cn, n) with constant c\n\n4. **Supporting Theory:**\n   - prime_structure: integers ≤ n have at most one prime > √n\n   - Connection to Dickman function and smooth number density\n\n5. **Summary Theorem:** Combine all results into erdos_983_summary",
+    "keyInsights": [
+      "**Prime Coverage:** f(k,n) measures the minimum primes needed to cover k elements via smoothness",
+      "**The Factor 2π(√n):** Arises because integers ≤ n have at most one prime factor > √n, requiring double-counting of small primes",
+      "**Sublinear Difference:** The gap |2π(√n) - f(π(n)+1, n)| / √n → 0, so the approximation is very tight",
+      "**Dense Sets:** For f(cn, n), the answer is log log n + O(√(log log n)), much smaller than for sparse sets",
+      "**Normal Distribution:** The constant c₁ in the dense case relates to the standard normal CDF Φ(c₁) = c",
+      "**Graph-Theoretic Proof:** The original proof uses hypergraph covering techniques",
+      "**Algorithmic Relevance:** Smooth numbers are central to subexponential factorization algorithms"
+    ]
+  },
+  "sections": [
+    {
+      "id": "basic-definitions",
+      "title": "Basic Definitions",
+      "summary": "primePi, primesUpTo, IsSmooth, smoothElements, PrimesCover",
+      "startLine": 40,
+      "endLine": 79
+    },
+    {
+      "id": "f-function",
+      "title": "The f Function",
+      "summary": "f definition, f_upper_bound, f_mono_k",
+      "startLine": 81,
+      "endLine": 108
+    },
+    {
+      "id": "main-question",
+      "title": "The Main Question",
+      "summary": "ErdosQuestion983, erdos_question_answer",
+      "startLine": 110,
+      "endLine": 128
+    },
+    {
+      "id": "erdos-straus-results",
+      "title": "Erdős-Straus Results",
+      "summary": "erdos_straus_main, difference_is_sublinear, erdos_straus_dense, normal_distribution_constant",
+      "startLine": 130,
+      "endLine": 178
+    },
+    {
+      "id": "intuition",
+      "title": "Why 2π(√n)?",
+      "summary": "prime_structure, why_two_pi_sqrt, smooth_number_density",
+      "startLine": 180,
+      "endLine": 214
+    },
+    {
+      "id": "applications",
+      "title": "Applications",
+      "summary": "factorization_algorithms, cryptographic_relevance, graph_theory_connection",
+      "startLine": 216,
+      "endLine": 247
+    },
+    {
+      "id": "related-concepts",
+      "title": "Related Concepts",
+      "summary": "IsYSmooth, smoothCount, dickman_asymptotics",
+      "startLine": 249,
+      "endLine": 272
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "summary": "erdos_983_summary, erdos_983",
+      "startLine": 274,
+      "endLine": 312
+    }
+  ],
   "conclusion": {
-    "summary": "Erdős Problem #983 is SOLVED with answer NO. Erdős-Straus (1970) proved that 2π(√n) - f(π(n)+1, n) does not tend to infinity; the difference is o(√n/(log n)^A) for any A > 0.",
-    "implications": "The result precisely characterizes the prime coverage function f(k,n) and connects to smooth number theory. The formula explains why 2π(√n) is the natural scale for covering π(n)+1 elements.",
+    "summary": "Erdős Problem #983 asked whether 2π(√n) - f(π(n)+1, n) → ∞. The answer is NO. Erdős and Straus (1970) proved that f(π(n)+1, n) = 2π(√n) + o(√n/(log n)^A) for any A > 0, meaning the difference is small (sublinear in √n). For denser sets with f(cn, n), the function grows only as log log n.",
+    "implications": "**Number-Theoretic Connections**\n\n1. **Smooth Number Theory:** Characterizes prime coverage for smooth numbers\n\n2. **Prime Counting:** Deep connection between π(n), π(√n), and covering properties\n\n3. **Factorization:** Smooth numbers are key to quadratic sieve and number field sieve\n\n4. **Cryptography:** Understanding smooth number density affects cryptanalysis\n\n5. **Combinatorics:** Original proof used hypergraph covering techniques",
     "openQuestions": [
-      "Can the error term be improved further?",
+      "Can the error term o(√n/(log n)^A) be made more explicit?",
       "What are optimal constructions achieving the bound?",
-      "Extensions to more general covering problems"
+      "Extensions to other covering problems in number theory",
+      "Computational aspects of finding optimal prime sets",
+      "Connections to the Dickman function and smooth number asymptotics"
     ]
   }
 }


### PR DESCRIPTION
## Summary
Stub enhancement for Erdős Problem #983.

## Changes
- Updated meta.json with comprehensive historicalContext (3 paragraphs), mathlibDependencies, originalContributions (14 items), and sections (8 sections)
- Rewrote annotations.json with 24 educational annotations including mathContext and relatedConcepts
- Annotations cover all key definitions (primePi, IsSmooth, f function), theorems (Erdős-Straus main/dense), and applications (factorization, cryptography)

## Problem Overview
Erdős Problem #983 asks: Does 2π(√n) - f(π(n)+1, n) → ∞? The answer is NO. Erdős-Straus (1970) proved f(π(n)+1, n) = 2π(√n) + o(√n/(log n)^A).

## Checklist
- [x] Lean proof compiles
- [x] pnpm build succeeds  
- [x] Annotations align with Lean file
- [x] meta.json matches exemplar quality (erdos-48)

🤖 Generated by enhancer-1