### PR TITLE
Enhance Erdős #1128: Monochromatic Cubes in Cardinal Products

### DIFF
--- a/src/data/proofs/erdos-1128/meta.json
+++ b/src/data/proofs/erdos-1128/meta.json
@@ -16,12 +16,35 @@
       "partition-calculus",
       "cardinals"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1128,
     "erdosUrl": "https://erdosproblems.com/1128",
     "erdosProblemStatus": "disproved",
-    "erdosPrizeValue": "$50"
+    "erdosPrizeValue": "$50",
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.Basic",
+        "description": "Cardinal arithmetic",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Set.Basic",
+        "description": "Basic set operations",
+        "module": "Mathlib.Data.Set.Basic"
+      }
+    ],
+    "originalContributions": [
+      "aleph_1 axiom: declaration of ℵ₁ cardinal",
+      "aleph_0 definition: ℵ₀ = Cardinal.omega",
+      "TwoColoring definition: A × B × C → Bool",
+      "isMonochromatic definition: constant coloring on a cube",
+      "hasCardinalityAleph0 definition: countably infinite subset",
+      "erdos_hajnal_conjecture definition: the partition property statement",
+      "prikry_mills_disproof axiom: the conjecture is FALSE",
+      "exists_bad_coloring theorem: derived from disproof",
+      "erdos_1128_status theorem: complete problem status"
+    ]
   },
   "overview": {
     "historicalContext": "A problem of Erdős and Hajnal in partition calculus, asking whether the cardinal Ramsey property ℵ₁³ → (ℵ₀)³₂ holds. Prikry and Mills disproved it in 1978 with a counterexample, though their proof remained unpublished. The result was later documented by Todorčević (1994) and Komjáth (2025).",

--- a/src/data/proofs/listings.json
+++ b/src/data/proofs/listings.json
@@ -2830,7 +2830,7 @@
     "slug": "erdos-1128",
     "description": "Let A, B, C have cardinality ℵ₁. Must any 2-coloring of A × B × C contain a countably infinite monochromatic cube A₁ × B₁ × C₁? DISPROVED by Prikry-Mills (1978): NO, such colorings exist with no ℵ₀ × ℵ₀ × ℵ₀ monochromatic cube.",
     "status": "complete",
-    "badge": "mathlib",
+    "badge": "axiom",
     "tags": [
       "erdos",
       "set-theory",
@@ -2839,6 +2839,7 @@
       "cardinals"
     ],
     "erdosNumber": 1128,
+    "mathlibCount": 2,
     "sorries": 0,
     "annotationCount": 18
   },


### PR DESCRIPTION
## Summary
Stub enhancement for Erdős Problem #1128 (Monochromatic Cubes in Cardinal Products).

## Changes
- Fixed badge from "mathlib" to "axiom"
- Added `mathlibDependencies`: Cardinal.Basic, Set.Basic
- Added 9 `originalContributions` documenting key definitions and theorems

## Problem Overview
Let A, B, C have cardinality ℵ₁. Must any 2-coloring of A × B × C contain a countably infinite monochromatic cube A₁ × B₁ × C₁?

**Status:** DISPROVED by Prikry-Mills (1978) - NO such cube is guaranteed!
**Prize:** $50

In partition notation: ℵ₁³ ↛ (ℵ₀)³₂

## Checklist
- [x] Lean proof compiles (no sorries)
- [x] pnpm build succeeds
- [x] Annotations align with Lean file (18 comprehensive annotations)

🤖 Generated by enhancer-3