### PR TITLE
feat(agents): add daemon mode for infinite retry in long-running agents

### DIFF
--- a/scripts/aristotle/launch-agent.sh
+++ b/scripts/aristotle/launch-agent.sh
@@ -274,11 +274,12 @@ PROMPT_EOF
         sleep 0.3
     fi
 
-    # Launch Claude with resilient wrapper for error handling
+    # Launch Claude with resilient wrapper in DAEMON mode for infinite retry
+    # The --daemon flag ensures the Aristotle agent survives API outages indefinitely
     sleep 0.5
     local prompt="You are the Aristotle agent. Read $prompt_file for your instructions, then start the queue management workflow."
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
-    tmux send-keys -t "$SESSION_NAME" "ENHANCER_ID=aristotle $wrapper_script --prompt '$prompt' --log '$LOG_FILE' --max-retries 5" Enter
+    tmux send-keys -t "$SESSION_NAME" "ENHANCER_ID=aristotle $wrapper_script --daemon --prompt '$prompt' --log '$LOG_FILE'" Enter
 
     print_success "Launched Aristotle agent"
     echo ""

--- a/scripts/deploy/launch-agent.sh
+++ b/scripts/deploy/launch-agent.sh
@@ -133,10 +133,11 @@ launch_agent() {
     print_info "Launching deployer agent..."
     print_info "Interval: $INTERVAL minutes"
 
-    # Launch in tmux with resilient wrapper for error handling
+    # Launch in tmux with resilient wrapper in DAEMON mode for infinite retry
+    # The --daemon flag ensures the deployer survives API outages indefinitely
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
     tmux new-session -d -s "$SESSION_NAME" -c "$REPO_ROOT" \
-        "ENHANCER_ID=deployer REPO_ROOT=$REPO_ROOT $wrapper_script --prompt 'You are the deployer agent. Read $prompt_file for your instructions, then start the deploy loop.' --log '$LOG_FILE' --max-retries 5"
+        "ENHANCER_ID=deployer REPO_ROOT=$REPO_ROOT $wrapper_script --daemon --prompt 'You are the deployer agent. Read $prompt_file for your instructions, then start the deploy loop.' --log '$LOG_FILE'"
 
     print_success "Launched deployer agent"
     echo ""


### PR DESCRIPTION
## Summary

Adds a `--daemon` flag to `scripts/agents/claude-wrapper.sh` that enables infinite retry for agents that should run indefinitely (deployer, aristotle).

**Problem**: Long-running daemon agents would permanently die after exhausting retry attempts (5 retries over ~31 minutes). The deployer died after 18+ hours of successful operation when it hit a series of API errors.

**Solution**: Add daemon mode that:
- Never exits due to exhausted retries
- Keeps retrying with exponential backoff (capped at 30 min)
- Resets backoff on successful completion
- Only exits on explicit stop signal

## Changes

- `scripts/agents/claude-wrapper.sh`: Add `--daemon` flag and `run_daemon()` function
- `scripts/deploy/launch-agent.sh`: Use `--daemon` mode
- `scripts/aristotle/launch-agent.sh`: Use `--daemon` mode

## Test plan

- [ ] Launch deployer with daemon mode: `./scripts/deploy/launch-agent.sh`
- [ ] Verify wrapper logs show "DAEMON mode"
- [ ] Verify agent survives after successful completion (restarts)
- [ ] Verify agent keeps retrying during simulated API failures
- [ ] Verify stop signal (`touch .loom/signals/stop-deployer`) causes clean exit

Closes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)