### PR TITLE
Enhance Erdős #871: Partitioning Additive Bases - DISPROVED

### DIFF
--- a/src/data/proofs/erdos-871/annotations.json
+++ b/src/data/proofs/erdos-871/annotations.json
@@ -1,0 +1,178 @@
+[
+  {
+    "id": "ann-871-header",
+    "proofId": "erdos-871",
+    "range": { "startLine": 1, "endLine": 30 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "Erdős Problem #871 asked whether an additive basis A of order 2 with r_A(n) → ∞ can always be partitioned into two disjoint order-2 bases. Daniel Larsen (2026) proved the answer is NO using an AI-assisted construction with Claude Opus 4.5.",
+    "mathContext": "The problem sits between two known results: (1) for fixed threshold r_A(n) ≥ t, partition can fail; (2) for r_A(n) > c log n, partition is possible. The r_A(n) → ∞ case was open until Larsen's disproof.",
+    "significance": "critical",
+    "relatedConcepts": ["additive-basis", "partition", "representation-function"]
+  },
+  {
+    "id": "ann-871-repfunc",
+    "proofId": "erdos-871",
+    "range": { "startLine": 40, "endLine": 42 },
+    "type": "definition",
+    "title": "Representation Function",
+    "content": "r_A(n) = |{(a,b) ∈ A × A : a + b = n}| counts ordered pairs summing to n. This measures how 'redundantly' n is covered by the sumset A + A. More representations mean more flexibility for partition.",
+    "mathContext": "We use Set.ncard for the cardinality of the set of pairs. The function is noncomputable since it involves arbitrary infinite sets.",
+    "significance": "critical",
+    "relatedConcepts": ["sumset", "counting", "pairs"]
+  },
+  {
+    "id": "ann-871-sumset",
+    "proofId": "erdos-871",
+    "range": { "startLine": 44, "endLine": 46 },
+    "type": "definition",
+    "title": "Sumset A + A",
+    "content": "The sumset A + A = {a + b : a, b ∈ A} is the set of all pairwise sums from A. An order-2 basis is a set whose sumset covers all but finitely many naturals.",
+    "mathContext": "This is the foundational concept for additive bases. The notation A +ₛ B is used for sumset unions in some contexts.",
+    "significance": "key",
+    "relatedConcepts": ["additive-combinatorics", "sumset", "coverage"]
+  },
+  {
+    "id": "ann-871-basis",
+    "proofId": "erdos-871",
+    "range": { "startLine": 50, "endLine": 56 },
+    "type": "definition",
+    "title": "Additive Basis of Order 2",
+    "content": "A is an additive basis of order 2 if A + A covers all sufficiently large n. Equivalently, the complement (A + A)ᶜ is finite. The equivalence is proved in basis2_equiv.",
+    "mathContext": "The 'order' refers to how many elements are summed. Order 2 means pairs a + b; order 3 would need a + b + c.",
+    "significance": "critical",
+    "relatedConcepts": ["order", "coverage", "finite-exception"]
+  },
+  {
+    "id": "ann-871-equiv",
+    "proofId": "erdos-871",
+    "range": { "startLine": 58, "endLine": 86 },
+    "type": "theorem",
+    "title": "Equivalence of Definitions",
+    "content": "The two definitions of order-2 basis are equivalent: (1) ∃N₀, ∀n ≥ N₀, n ∈ A + A, and (2) (A + A)ᶜ is finite. The proof uses BddAbove for the finite complement case.",
+    "mathContext": "This equivalence is standard but the formal proof requires careful handling of the cases where the complement is empty vs nonempty.",
+    "significance": "supporting",
+    "relatedConcepts": ["equivalence", "complement", "bounded"]
+  },
+  {
+    "id": "ann-871-tendsto",
+    "proofId": "erdos-871",
+    "range": { "startLine": 90, "endLine": 96 },
+    "type": "definition",
+    "title": "r_A(n) → ∞ Condition",
+    "content": "RepTendsToInfty(A) says that r_A(n) grows without bound as n → ∞. This is formalized using Filter.Tendsto to atTop. The weaker RepEventuallyGe(A, t) says r_A(n) ≥ t eventually.",
+    "mathContext": "The Tendsto characterization lets us extract: for any t, eventually r_A(n) ≥ t. This is proved in repTendsToInfty_implies_eventuallyGe.",
+    "significance": "key",
+    "relatedConcepts": ["tendsto", "growth", "eventually"]
+  },
+  {
+    "id": "ann-871-implication",
+    "proofId": "erdos-871",
+    "range": { "startLine": 98, "endLine": 115 },
+    "type": "theorem",
+    "title": "Growth Implication",
+    "content": "If r_A(n) → ∞, then for any fixed t, r_A(n) ≥ t eventually. This shows the r_A(n) → ∞ condition is strictly stronger than having a fixed threshold.",
+    "mathContext": "The proof uses the atTop filter characterization of limits. We extract the witness N₀ from the Tendsto definition.",
+    "significance": "key",
+    "relatedConcepts": ["implication", "threshold", "filter"]
+  },
+  {
+    "id": "ann-871-partition",
+    "proofId": "erdos-871",
+    "range": { "startLine": 119, "endLine": 121 },
+    "type": "definition",
+    "title": "Partition into Bases",
+    "content": "CanPartitionIntoBases(A) asserts that A can be split into disjoint sets B and C, each of which is itself an order-2 basis. This is the property the conjecture asked about.",
+    "mathContext": "The partition requirement is B ∩ C = ∅ and B ∪ C = A. Both B and C must independently cover all large integers.",
+    "significance": "critical",
+    "relatedConcepts": ["partition", "disjoint", "coverage"]
+  },
+  {
+    "id": "ann-871-conjecture",
+    "proofId": "erdos-871",
+    "range": { "startLine": 125, "endLine": 129 },
+    "type": "definition",
+    "title": "The Erdős Conjecture",
+    "content": "Erdos871Conjecture states: for all A, if A is an order-2 basis with r_A(n) → ∞, then A can be partitioned into two disjoint order-2 bases. This is what Larsen disproved.",
+    "mathContext": "The conjecture seemed plausible because growing representations suggest 'enough room' to split. The disproof shows this intuition fails.",
+    "significance": "critical",
+    "relatedConcepts": ["conjecture", "quantifier", "disproof"]
+  },
+  {
+    "id": "ann-871-nathanson-neg",
+    "proofId": "erdos-871",
+    "range": { "startLine": 133, "endLine": 137 },
+    "type": "axiom",
+    "title": "Erdős-Nathanson Negative Result",
+    "content": "For any fixed threshold t, there exists a basis A with r_A(n) ≥ t (eventually) that cannot be partitioned. This was known since 1989 and inspired the stronger conjecture.",
+    "mathContext": "The construction uses a 'blocking' technique to ensure any partition fails. Larsen extended this to handle r_A(n) → ∞.",
+    "significance": "key",
+    "relatedConcepts": ["erdos-nathanson", "counterexample", "threshold"]
+  },
+  {
+    "id": "ann-871-nathanson-pos",
+    "proofId": "erdos-871",
+    "range": { "startLine": 141, "endLine": 146 },
+    "type": "axiom",
+    "title": "Erdős-Nathanson Positive Result",
+    "content": "When r_A(n) > c log n for c > (log 4/3)^{-1} ≈ 3.48, partition IS possible. This shows logarithmic growth is sufficient for partition.",
+    "mathContext": "The threshold c ≈ 3.48 comes from a probabilistic argument. Faster growth gives more 'slack' for splitting.",
+    "significance": "key",
+    "relatedConcepts": ["positive-result", "logarithmic", "threshold"]
+  },
+  {
+    "id": "ann-871-counterexample",
+    "proofId": "erdos-871",
+    "range": { "startLine": 150, "endLine": 153 },
+    "type": "axiom",
+    "title": "Larsen's Counterexample",
+    "content": "There exists a basis A with r_A(n) → ∞ that cannot be partitioned. This is the key axiom that disproves the conjecture. The construction was found with AI assistance.",
+    "mathContext": "The axiom states existence; the construction sketch in the file explains the technique. Full details are in Larsen's paper.",
+    "significance": "critical",
+    "relatedConcepts": ["counterexample", "disproof", "ai-assisted"]
+  },
+  {
+    "id": "ann-871-disproved",
+    "proofId": "erdos-871",
+    "range": { "startLine": 155, "endLine": 159 },
+    "type": "theorem",
+    "title": "Disproof Theorem",
+    "content": "erdos_871_disproved proves ¬Erdos871Conjecture. The proof applies the conjecture to the Larsen counterexample, obtaining a contradiction.",
+    "mathContext": "This is a classic proof by contradiction: assume the conjecture, apply to the counterexample, derive False.",
+    "significance": "critical",
+    "relatedConcepts": ["disproof", "contradiction", "negation"]
+  },
+  {
+    "id": "ann-871-blocking",
+    "proofId": "erdos-871",
+    "range": { "startLine": 182, "endLine": 185 },
+    "type": "definition",
+    "title": "Blocking Property",
+    "content": "HasBlockingProperty(A) says: for any partition B ∪ C = A, infinitely many n satisfy n ∉ B + B or n ∉ C + C. This prevents both parts from being bases.",
+    "mathContext": "The blocking is quantified using Filter.Frequently (∃ᶠ), meaning infinitely many failures. This is the key obstruction to partition.",
+    "significance": "key",
+    "relatedConcepts": ["blocking", "frequently", "obstruction"]
+  },
+  {
+    "id": "ann-871-blocking-thm",
+    "proofId": "erdos-871",
+    "range": { "startLine": 187, "endLine": 221 },
+    "type": "theorem",
+    "title": "Blocking Prevents Partition",
+    "content": "If A has the blocking property, then A cannot be partitioned into two bases. The proof shows that the 'frequently fails' condition contradicts both parts being bases (which must cover all large n).",
+    "mathContext": "The proof uses the Filter.Frequently characterization to derive a contradiction with the eventually-covers property of bases.",
+    "significance": "key",
+    "relatedConcepts": ["implication", "contradiction", "coverage"]
+  },
+  {
+    "id": "ann-871-larsen-blocking",
+    "proofId": "erdos-871",
+    "range": { "startLine": 223, "endLine": 225 },
+    "type": "axiom",
+    "title": "Larsen Construction",
+    "content": "The Larsen construction produces A with: (1) A is an order-2 basis, (2) r_A(n) → ∞, (3) A has the blocking property. This combines the positive aspects with the partition-preventing feature.",
+    "mathContext": "The key insight is that the blocking property can be maintained even as representations grow unboundedly.",
+    "significance": "key",
+    "relatedConcepts": ["construction", "combination", "technique"]
+  }
+]

--- a/src/data/proofs/erdos-871/index.ts
+++ b/src/data/proofs/erdos-871/index.ts
@@ -1,0 +1,4 @@
+import meta from './meta.json'
+import annotations from './annotations.json'
+
+export { meta, annotations }

--- a/src/data/proofs/erdos-871/meta.json
+++ b/src/data/proofs/erdos-871/meta.json
@@ -1,0 +1,106 @@
+{
+  "id": "erdos-871",
+  "title": "Erdős Problem #871: Partitioning Additive Bases of Order 2",
+  "slug": "erdos-871",
+  "description": "Can an additive basis A of order 2 with r_A(n) → ∞ be partitioned into two disjoint additive bases of order 2? DISPROVED by Daniel Larsen (2026).",
+  "meta": {
+    "author": "Daniel Larsen (2026)",
+    "sourceUrl": "https://erdosproblems.com/871",
+    "status": "complete",
+    "proofRepoPath": "Proofs/Erdos871Problem.lean",
+    "tags": ["erdos", "additive-combinatorics", "number-theory", "additive-basis", "partition", "disproved"],
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 871,
+    "erdosUrl": "https://erdosproblems.com/871",
+    "erdosProblemStatus": "disproved (lean)",
+    "mathlib_version": "4.15.0",
+    "mathlibDependencies": [
+      "Mathlib.Data.Set.Basic",
+      "Mathlib.Order.Filter.Basic",
+      "Mathlib.Topology.Basic",
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.Algebra.BigOperators.Basic"
+    ],
+    "originalContributions": [
+      "Formal definition of additive basis of order 2",
+      "Representation function r_A(n) formalization",
+      "Partition predicate for bases",
+      "Blocking property preventing partition",
+      "Formal disproof using Larsen's counterexample"
+    ]
+  },
+  "overview": {
+    "historicalContext": "This problem was posed by Erdős and Nathanson in 1988 and concerns partitioning additive bases. An additive basis of order 2 is a set A such that A + A covers all sufficiently large integers. The representation function r_A(n) counts how many ways n can be written as a + b with a, b ∈ A.\n\nErdős and Nathanson (1989) showed that for any fixed threshold t, there exists a basis A with r_A(n) ≥ t for all large n that cannot be partitioned into two disjoint bases. They also proved that partition IS possible when r_A(n) > c log n for c > (log 4/3)^{-1} ≈ 3.48.\n\nThe problem asked about the intermediate case: if r_A(n) → ∞ (growing without bound, but possibly slower than log n), can A always be partitioned? Daniel Larsen (2026) showed the answer is NO, disproving the conjecture using an AI-assisted proof with Claude Opus 4.5.",
+    "problemStatement": "Let $A$ be an additive basis of order 2, meaning $A + A$ covers all sufficiently large integers. Let $r_A(n) = |\\{(a,b) \\in A \\times A : a + b = n\\}|$ be the representation function.\n\n**Question:** If $\\lim_{n \\to \\infty} r_A(n) = \\infty$, can $A$ always be partitioned into two disjoint additive bases of order 2?\n\n**Answer:** NO (Larsen 2026)",
+    "proofStrategy": "The formalization establishes the key definitions: additive basis, representation function, and partition into bases. The disproof uses a 'blocking property' construction: for any partition B ∪ C = A, infinitely many integers n fail to be covered by both B + B and C + C simultaneously.\n\nThe Larsen construction modifies the Erdős-Nathanson approach to ensure r_A(n) → ∞ while maintaining this blocking property. The formal proof shows that any set with the blocking property cannot be partitioned into two bases.",
+    "keyInsights": [
+      "**Representation Function**: r_A(n) counts how many ways n = a + b with a, b ∈ A; it measures 'redundancy' of coverage",
+      "**Threshold vs Growth**: Having r_A(n) ≥ t (fixed) is too weak, while r_A(n) > c log n is strong enough for partition",
+      "**Blocking Property**: A construction prevents partition by ensuring for any split, some integers are missed by at least one part",
+      "**AI-Assisted Discovery**: The counterexample was found using Claude Opus 4.5, demonstrating AI utility in mathematical research",
+      "**Gap Closure**: The result shows r_A(n) → ∞ behaves like the fixed-threshold case, not like the logarithmic case"
+    ]
+  },
+  "sections": [
+    {
+      "title": "Core Definitions",
+      "startLine": 38,
+      "endLine": 86,
+      "summary": "Defines representation function, sumset, and additive basis of order 2"
+    },
+    {
+      "title": "Growth Conditions",
+      "startLine": 88,
+      "endLine": 115,
+      "summary": "RepTendsToInfty and RepEventuallyGe conditions on r_A(n)"
+    },
+    {
+      "title": "Partition Predicate",
+      "startLine": 117,
+      "endLine": 121,
+      "summary": "Definition of CanPartitionIntoBases"
+    },
+    {
+      "title": "The Conjecture",
+      "startLine": 123,
+      "endLine": 129,
+      "summary": "Formal statement of Erdős Problem #871"
+    },
+    {
+      "title": "Erdős-Nathanson Results",
+      "startLine": 131,
+      "endLine": 146,
+      "summary": "1989 negative and positive results on partitioning"
+    },
+    {
+      "title": "Larsen Counterexample",
+      "startLine": 148,
+      "endLine": 159,
+      "summary": "The disproof axiom and main theorem"
+    },
+    {
+      "title": "Blocking Property",
+      "startLine": 182,
+      "endLine": 225,
+      "summary": "Technical blocking condition preventing partition"
+    },
+    {
+      "title": "Summary",
+      "startLine": 227,
+      "endLine": 256,
+      "summary": "Overview of results and references"
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős Problem #871 has been DISPROVED. The conjecture that additive bases with r_A(n) → ∞ can always be partitioned into two disjoint bases is FALSE. Daniel Larsen (2026) constructed a counterexample using a modification of the Erdős-Nathanson blocking technique.",
+    "implications": "The result clarifies the boundary between partitionable and non-partitionable bases. The growth condition r_A(n) → ∞ is insufficient for partition; one needs faster growth like r_A(n) > c log n. This advances understanding of the structure of additive bases.",
+    "openQuestions": [
+      "What is the minimal growth rate of r_A(n) that guarantees partition?",
+      "Is r_A(n) = ω(1) but r_A(n) = o(log n) the critical regime?",
+      "Can the blocking construction be made explicit?",
+      "Are there other structural conditions that guarantee partition?",
+      "What about partition into more than two bases?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Stub enhancement for Erdős Problem #871 on partitioning additive bases of order 2.

## Changes
- Enhanced meta.json and annotations.json for the existing comprehensive Lean proof (257 lines)
- Updated meta.json with historical context on the AI-assisted disproof
- Created annotations.json with 16 educational annotations covering:
  - Representation function r_A(n) definition
  - Additive basis of order 2 formalization
  - Growth conditions (RepTendsToInfty vs RepEventuallyGe)
  - Erdős-Nathanson 1989 results (positive and negative)
  - Larsen's 2026 counterexample
  - Blocking property preventing partition

## Problem Summary
- **Question**: Can an order-2 basis A with r_A(n) → ∞ be partitioned into two disjoint order-2 bases?
- **Status**: DISPROVED by Daniel Larsen (2026)
- **Method**: AI-assisted proof using Claude Opus 4.5
- **Key insight**: Blocking property can be maintained even as r_A(n) → ∞

## Checklist
- [x] Lean proof compiles
- [x] pnpm build succeeds
- [x] Annotations align with Lean file

🤖 Generated by enhancer-3