### PR TITLE
Fix blank page on proof pages by adding error handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { AuthProvider } from '@/contexts/AuthContext'
+import { ErrorBoundary } from '@/components/ErrorBoundary'
 
 // Lazy load pages for code splitting
 const HomePage = lazy(() => import('@/pages/HomePage').then(m => ({ default: m.HomePage })))
@@ -21,21 +22,23 @@ function LoadingSpinner() {
 
 function App() {
   return (
-    <AuthProvider>
-      <BrowserRouter>
-        <Suspense fallback={<LoadingSpinner />}>
-          <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/proof/:slug" element={<ProofPage />} />
-            <Route path="/research" element={<ResearchPage />} />
-            <Route path="/research/:slug" element={<ResearchProblemPage />} />
-            <Route path="/submit" element={<SubmitPage />} />
-            <Route path="/about" element={<AboutPage />} />
-            <Route path="/erdos" element={<ErdosPage />} />
-          </Routes>
-        </Suspense>
-      </BrowserRouter>
-    </AuthProvider>
+    <ErrorBoundary>
+      <AuthProvider>
+        <BrowserRouter>
+          <Suspense fallback={<LoadingSpinner />}>
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/proof/:slug" element={<ProofPage />} />
+              <Route path="/research" element={<ResearchPage />} />
+              <Route path="/research/:slug" element={<ResearchProblemPage />} />
+              <Route path="/submit" element={<SubmitPage />} />
+              <Route path="/about" element={<AboutPage />} />
+              <Route path="/erdos" element={<ErdosPage />} />
+            </Routes>
+          </Suspense>
+        </BrowserRouter>
+      </AuthProvider>
+    </ErrorBoundary>
   )
 }
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import { Component, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+
+interface Props {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+/**
+ * Error boundary component that catches JavaScript errors in child components.
+ * Displays a fallback UI instead of crashing the whole app.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('ErrorBoundary caught an error:', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback
+      }
+
+      return (
+        <div className="h-screen flex flex-col items-center justify-center gap-4 p-8">
+          <div className="text-center max-w-md">
+            <h1 className="text-2xl font-bold mb-2 text-red-400">Something went wrong</h1>
+            <p className="text-muted-foreground mb-4">
+              An error occurred while rendering this page.
+            </p>
+            {this.state.error && (
+              <pre className="text-left text-xs bg-muted p-4 rounded-lg overflow-auto max-h-48 mb-4">
+                {this.state.error.message}
+              </pre>
+            )}
+            <Link to="/" className="text-annotation hover:underline">
+              ← Back to home
+            </Link>
+          </div>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/src/pages/ProofPage.tsx
+++ b/src/pages/ProofPage.tsx
@@ -17,6 +17,7 @@ export function ProofPage() {
   const { slug } = useParams<{ slug: string }>()
   const [proofData, setProofData] = useState<ProofData | null>(null)
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const [selectedLine, setSelectedLine] = useState<number | null>(null)
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const viewerRef = useRef<HTMLDivElement>(null)
@@ -25,10 +26,17 @@ export function ProofPage() {
   useEffect(() => {
     setLoading(true)
     setProofData(null)
-    getProofAsync(slug || '').then((data) => {
-      setProofData(data || null)
-      setLoading(false)
-    })
+    setError(null)
+    getProofAsync(slug || '')
+      .then((data) => {
+        setProofData(data || null)
+        setLoading(false)
+      })
+      .catch((err) => {
+        console.error(`Failed to load proof '${slug}':`, err)
+        setError(err instanceof Error ? err.message : 'Unknown error loading proof')
+        setLoading(false)
+      })
   }, [slug])
 
   // Find annotation for selected line
@@ -66,6 +74,25 @@ export function ProofPage() {
       <div className="h-screen flex flex-col items-center justify-center gap-4">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-annotation" />
         <p className="text-muted-foreground">Loading proof...</p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="h-screen flex flex-col items-center justify-center gap-4 p-8">
+        <div className="text-center max-w-md">
+          <h1 className="text-2xl font-bold mb-2 text-red-400">Error Loading Proof</h1>
+          <p className="text-muted-foreground mb-4">
+            Failed to load proof &quot;{slug}&quot;
+          </p>
+          <pre className="text-left text-xs bg-muted p-4 rounded-lg overflow-auto max-h-48 mb-4">
+            {error}
+          </pre>
+          <Link to="/" className="text-annotation hover:underline">
+            ← Back to home
+          </Link>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- Fix blank page issue on `/proof/erdos-1018` and other proof pages
- Add `ErrorBoundary` component to catch React render errors
- Add error state handling in `ProofPage` for async loading failures

## Changes
1. **`src/components/ErrorBoundary.tsx`** (new) - React error boundary component
2. **`src/App.tsx`** - Wrap routes with ErrorBoundary
3. **`src/pages/ProofPage.tsx`** - Add error state and `.catch()` for async loading

## Test plan
- [ ] Navigate to `/proof/erdos-1018` - should show error message or content (not blank)
- [ ] Navigate to `/proof/sqrt2-irrational` - should work normally
- [ ] Trigger a render error - should show ErrorBoundary fallback
- [ ] Build passes (`pnpm build`)

Closes #1067

🤖 Generated with [Claude Code](https://claude.com/claude-code)