### PR TITLE
enhance(erdos-226): Entire Functions Preserving Rationality

### DIFF
--- a/proofs/Proofs/Erdos226Problem.lean
+++ b/proofs/Proofs/Erdos226Problem.lean
@@ -36,14 +36,13 @@ import Mathlib.Analysis.Complex.Basic
 import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Data.Set.Countable
 import Mathlib.Topology.Order.Basic
+import Mathlib.Tactic
 
 open Complex Set
 
 namespace Erdos226
 
-/-
-## Part I: Entire Functions
--/
+/-! ## Part I: Entire Functions -/
 
 /--
 **Entire Function:**
@@ -67,9 +66,7 @@ A function is non-linear if it is not of the form f(x) = ax + b.
 def IsNonLinear (f : ℂ → ℂ) : Prop :=
   ¬∃ (a b : ℂ), ∀ z, f z = a * z + b
 
-/-
-## Part II: Countable Dense Sets
--/
+/-! ## Part II: Countable Dense Sets -/
 
 /--
 **Countable Dense Set:**
@@ -87,9 +84,7 @@ theorem rationals_countable_dense : IsCountableDense (Set.range (↑· : ℚ →
   · exact Set.countable_range _
   · exact Rat.denseRange_ratCast
 
-/-
-## Part III: The Rationality Preservation Property
--/
+/-! ## Part III: The Rationality Preservation Property -/
 
 /--
 **Rationality Preservation:**
@@ -105,9 +100,7 @@ A function maps set A exactly onto set B, preserving membership.
 def MapsSetToSet (f : ℝ → ℝ) (A B : Set ℝ) : Prop :=
   ∀ x : ℝ, x ∈ A ↔ f x ∈ B
 
-/-
-## Part IV: The Original Question
--/
+/-! ## Part IV: The Original Question -/
 
 /--
 **The Erdős Question:**
@@ -120,9 +113,7 @@ def ErdosQuestion : Prop :=
     IsNonLinear f ∧
     ∀ x : ℝ, (∃ q : ℚ, (q : ℝ) = x) ↔ (∃ q : ℚ, (q : ℝ) = (f x).re)
 
-/-
-## Part V: The General Question
--/
+/-! ## Part V: The General Question -/
 
 /--
 **The General Question:**
@@ -136,9 +127,7 @@ def GeneralQuestion : Prop :=
     ∃ (f : ℂ → ℂ), IsEntire f ∧
       ∀ x : ℝ, x ∈ A ↔ (f x).re ∈ B
 
-/-
-## Part VI: Barth-Schneider Theorem (1970)
--/
+/-! ## Part VI: Barth-Schneider Theorem (1970) -/
 
 /--
 **Barth-Schneider Theorem (1970):**
@@ -170,9 +159,7 @@ axiom barth_schneider_monotone :
       (∀ x : ℝ, x ∈ A ↔ (f x).re ∈ B) ∧
       StrictMono (fun x : ℝ => (f x).re)
 
-/-
-## Part VII: The Answer to Erdős's Question
--/
+/-! ## Part VII: The Answer to Erdős's Question -/
 
 /--
 **Erdős's Question is Answered Affirmatively:**
@@ -218,9 +205,7 @@ theorem general_question_affirmative : GeneralQuestion := by
   use f
   exact ⟨hf_trans.1, hf_maps⟩
 
-/-
-## Part VIII: Extensions
--/
+/-! ## Part VIII: Extensions -/
 
 /--
 **Complex Extension (1971):**
@@ -243,9 +228,7 @@ additional properties (monotone on ℝ, specific growth, etc.).
 -/
 axiom construction_flexibility : True
 
-/-
-## Part IX: Why This Works
--/
+/-! ## Part IX: Why This Works -/
 
 /--
 **Key Insight 1: Weierstrass Products:**
@@ -277,9 +260,7 @@ axiom no_polynomial_works :
     ¬∃ (p : Polynomial ℝ), p.natDegree > 1 ∧
       ∀ x : ℝ, (∃ q : ℚ, (q : ℝ) = x) ↔ (∃ q : ℚ, (q : ℝ) = p.eval x)
 
-/-
-## Part X: Summary
--/
+/-! ## Part X: Summary -/
 
 /--
 **Complete Solution to Erdős Problem #226:**

--- a/src/data/proofs/erdos-226/annotations.json
+++ b/src/data/proofs/erdos-226/annotations.json
@@ -1,160 +1,101 @@
 [
   {
-    "id": "ann-e226-header",
+    "id": "erdos-226-header",
     "proofId": "erdos-226",
+    "type": "context",
     "range": { "startLine": 1, "endLine": 33 },
-    "type": "concept",
     "title": "Problem Overview",
-    "content": "**Erdős Problem #226: Entire Functions Preserving Rationality**\n\nIs there an entire non-linear function f such that for all x ∈ ℝ:\n\nx is rational ↔ f(x) is rational?\n\n**Answer:** YES (Barth-Schneider, 1970)\n\nMore strongly: For ANY two countable dense sets A, B ⊂ ℝ, a transcendental entire function mapping A to B exists.",
-    "mathContext": "A beautiful problem at the intersection of complex analysis and number theory, solved by constructing transcendental entire functions with precise arithmetic properties.",
-    "significance": "critical",
-    "relatedConcepts": ["Entire functions", "Transcendental functions", "Dense sets", "Weierstrass products"]
+    "content": "Erdős Problem #226: Is there an entire non-linear f with x ∈ ℚ ↔ f(x) ∈ ℚ? SOLVED: YES by Barth-Schneider (1970). For any countable dense A, B ⊂ ℝ, a transcendental entire f with f(A) = B exists. Extended to ℂ in 1971.",
+    "mathContext": "Problem 2.31 in Hayman [Ha74]. Barth-Schneider [BaSc70] proved the general result. Connects complex analysis to arithmetic of dense sets.",
+    "significance": "essential",
+    "relatedConcepts": ["entire functions", "transcendental functions", "countable dense sets", "Weierstrass products"]
   },
   {
-    "id": "ann-e226-entire",
+    "id": "erdos-226-definitions",
     "proofId": "erdos-226",
-    "range": { "startLine": 48, "endLine": 54 },
     "type": "definition",
-    "title": "Entire Function",
-    "content": "**IsEntire:**\n\nA function f : ℂ → ℂ is entire if it is holomorphic (complex differentiable) on all of ℂ.\n\n**Type:** Differentiable ℂ f\n\nExamples: polynomials, exp, sin, cos. Counter-examples: 1/z (pole at 0), sqrt (branch point).",
-    "mathContext": "Entire functions are the 'nicest' complex functions - they have power series expansions valid on all of ℂ.",
-    "significance": "critical",
-    "relatedConcepts": ["Complex analysis", "Holomorphic functions", "Power series"]
+    "range": { "startLine": 45, "endLine": 68 },
+    "title": "Entire Function Definitions",
+    "content": "IsEntire(f): Differentiable ℂ f. IsTranscendental(f): IsEntire f ∧ not a polynomial. IsNonLinear(f): not of form f(z) = az + b.",
+    "mathContext": "IsEntire uses Mathlib's Differentiable. IsTranscendental excludes polynomials. IsNonLinear excludes affine functions.",
+    "significance": "essential",
+    "relatedConcepts": ["Differentiable", "Polynomial", "complex analysis"]
   },
   {
-    "id": "ann-e226-transcendental",
+    "id": "erdos-226-countable-dense",
     "proofId": "erdos-226",
-    "range": { "startLine": 56, "endLine": 61 },
+    "type": "result",
+    "range": { "startLine": 69, "endLine": 86 },
+    "title": "Countable Dense Sets",
+    "content": "IsCountableDense(S): S.Countable ∧ Dense S. rationals_countable_dense (proved): ℚ is countable dense in ℝ, using Set.countable_range and Rat.denseRange_ratCast.",
+    "mathContext": "ℚ is the canonical countable dense subset. The proof uses two Mathlib lemmas directly.",
+    "significance": "essential",
+    "relatedConcepts": ["Set.Countable", "Dense", "Rat.denseRange_ratCast"]
+  },
+  {
+    "id": "erdos-226-questions",
+    "proofId": "erdos-226",
     "type": "definition",
-    "title": "Transcendental Entire Function",
-    "content": "**IsTranscendental:**\n\nAn entire function is transcendental if it is NOT a polynomial.\n\nExamples: e^z, sin(z), cos(z). These have infinitely many zeros, while polynomials have finitely many.",
-    "mathContext": "Transcendental entire functions are 'more complicated' than polynomials - they have essential singularities at infinity.",
-    "significance": "critical",
-    "relatedConcepts": ["Polynomial", "Essential singularity", "Picard theorems"]
+    "range": { "startLine": 87, "endLine": 129 },
+    "title": "The Questions",
+    "content": "PreservesRationality(f): ∀ x, (∃ q, q = x) ↔ (∃ q, q = f x). MapsSetToSet(f, A, B): ∀ x, x ∈ A ↔ f x ∈ B. ErdosQuestion: ∃ entire non-linear f preserving rationality. GeneralQuestion: ∀ countable dense A, B, ∃ entire f mapping A to B.",
+    "mathContext": "ErdosQuestion is the original problem. GeneralQuestion is the natural generalization to arbitrary countable dense pairs.",
+    "significance": "essential",
+    "relatedConcepts": ["rationality preservation", "set mapping", "complex functions"]
   },
   {
-    "id": "ann-e226-countable-dense",
+    "id": "erdos-226-barth-schneider",
     "proofId": "erdos-226",
-    "range": { "startLine": 74, "endLine": 79 },
-    "type": "definition",
-    "title": "Countable Dense Set",
-    "content": "**IsCountableDense:**\n\nA set S ⊂ ℝ is countable dense if:\n1. S is countable (can be enumerated)\n2. S is dense (every interval contains points of S)\n\n**Examples:** ℚ (rationals), algebraic numbers, {m/2^n : m,n ∈ ℤ}.",
-    "significance": "key",
-    "relatedConcepts": ["Countable sets", "Dense sets", "Baire category"]
-  },
-  {
-    "id": "ann-e226-rationals-dense",
-    "proofId": "erdos-226",
-    "range": { "startLine": 81, "endLine": 88 },
-    "type": "theorem",
-    "title": "Rationals are Countable Dense",
-    "content": "**rationals_countable_dense:**\n\nℚ is the canonical example of a countable dense subset of ℝ.\n\n**Proof:** Countability follows from ℚ ≅ ℤ × ℤ⁺. Density follows from Archimedean property.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e226-erdos-question",
-    "proofId": "erdos-226",
-    "range": { "startLine": 112, "endLine": 121 },
-    "type": "definition",
-    "title": "The Erdős Question",
-    "content": "**ErdosQuestion:**\n\nDoes there exist an entire non-linear function f : ℂ → ℂ such that for all x ∈ ℝ:\n\nx ∈ ℚ ↔ f(x) ∈ ℚ?\n\nThe function must preserve rationality in both directions: rationals map to rationals, and ONLY rationals map to rationals.",
-    "mathContext": "This is the original question posed by Erdős, appearing as Problem 2.31 in Hayman's 1974 collection.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e226-general-question",
-    "proofId": "erdos-226",
-    "range": { "startLine": 127, "endLine": 137 },
-    "type": "definition",
-    "title": "The General Question",
-    "content": "**GeneralQuestion:**\n\nFor ANY two countable dense sets A, B ⊆ ℝ, does there exist an entire function f such that f(A) = B?\n\nThis is the natural generalization: can we map any countable dense set to any other?",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e226-barth-schneider",
-    "proofId": "erdos-226",
-    "range": { "startLine": 143, "endLine": 157 },
-    "type": "axiom",
+    "type": "result",
+    "range": { "startLine": 130, "endLine": 161 },
     "title": "Barth-Schneider Theorem (1970)",
-    "content": "**barth_schneider_1970:**\n\nFor any countable dense sets A, B ⊂ ℝ, there exists a transcendental entire function f such that:\n\nf(z) ∈ B ↔ z ∈ A (when restricted to ℝ)\n\nThis powerful result says we can map ANY countable dense set to ANY other while staying within the class of entire functions.",
-    "mathContext": "Published in 'Entire functions mapping countable dense subsets of the reals onto each other monotonically', J. London Math. Soc. (1970).",
-    "significance": "critical",
-    "relatedConcepts": ["Weierstrass products", "Interpolation", "Function construction"]
+    "content": "barth_schneider_1970 (axiom): ∀ countable dense A, B ⊂ ℝ, ∃ transcendental entire f with z ∈ A ↔ f(z) ∈ B. barth_schneider_monotone (axiom): additionally StrictMono on ℝ.",
+    "mathContext": "Barth-Schneider [BaSc70] constructed such functions using Weierstrass products. The monotone version appears in the same paper.",
+    "significance": "essential",
+    "relatedConcepts": ["Barth-Schneider", "Weierstrass products", "StrictMono"]
   },
   {
-    "id": "ann-e226-monotone",
+    "id": "erdos-226-answer",
     "proofId": "erdos-226",
-    "range": { "startLine": 159, "endLine": 171 },
-    "type": "axiom",
-    "title": "Monotonicity on ℝ",
-    "content": "**barth_schneider_monotone:**\n\nThe Barth-Schneider construction can produce a function that is strictly monotone on ℝ.\n\nThis is remarkable: a transcendental entire function can be monotone on the real line while mapping countable dense sets to each other.",
-    "significance": "key"
+    "type": "result",
+    "range": { "startLine": 162, "endLine": 207 },
+    "title": "The Answer: YES",
+    "content": "erdos_question_affirmative (proved): ErdosQuestion holds. Derived from barth_schneider_1970 with A = B = ℚ. Transcendental implies non-linear via polynomial degree argument. general_question_affirmative (proved): GeneralQuestion holds directly.",
+    "mathContext": "The proof applies barth_schneider_1970 to Set.range (↑· : ℚ → ℝ), uses rationals_countable_dense, then shows transcendental → non-linear.",
+    "significance": "essential",
+    "relatedConcepts": ["Iff.rfl", "Polynomial.eval", "ring_nf"]
   },
   {
-    "id": "ann-e226-answer-yes",
+    "id": "erdos-226-extensions",
     "proofId": "erdos-226",
-    "range": { "startLine": 177, "endLine": 208 },
-    "type": "theorem",
-    "title": "Answer: YES",
-    "content": "**erdos_question_affirmative:**\n\nThe answer to Erdős's question is YES.\n\n**Proof:** Apply Barth-Schneider with A = B = ℚ. The resulting function:\n1. Is entire (holomorphic on ℂ)\n2. Is non-linear (in fact transcendental)\n3. Preserves rationality: x ∈ ℚ ↔ f(x) ∈ ℚ",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e226-general-yes",
-    "proofId": "erdos-226",
-    "range": { "startLine": 210, "endLine": 219 },
-    "type": "theorem",
-    "title": "General Question: YES",
-    "content": "**general_question_affirmative:**\n\nThe general question is also answered YES.\n\nFor ANY two countable dense sets A, B, the Barth-Schneider theorem provides an entire function mapping A to B.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e226-complex-extension",
-    "proofId": "erdos-226",
-    "range": { "startLine": 225, "endLine": 237 },
-    "type": "axiom",
-    "title": "Complex Extension (1971)",
-    "content": "**barth_schneider_complex:**\n\nBarth and Schneider extended their result to ℂ in 1971.\n\nFor countable dense A, B ⊆ ℂ, there exists a transcendental entire f with f(A) = B.\n\nThis is even stronger: we can work in the full complex plane.",
-    "mathContext": "Published in 'Entire functions mapping arbitrary countable dense sets and their complements onto each other', J. London Math. Soc. (1971/72).",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e226-weierstrass",
-    "proofId": "erdos-226",
-    "range": { "startLine": 250, "endLine": 255 },
-    "type": "concept",
-    "title": "Weierstrass Products",
-    "content": "**Key Technique: Weierstrass Products**\n\nThe construction uses Weierstrass products to build entire functions with prescribed zeros.\n\nGiven a sequence of zeros {a_n}, we can build an entire function with exactly those zeros using infinite products.",
-    "mathContext": "Weierstrass showed every entire function can be factored in terms of its zeros.",
+    "type": "result",
+    "range": { "startLine": 208, "endLine": 230 },
+    "title": "Complex Extension",
+    "content": "barth_schneider_complex (axiom): for countable dense A, B ⊆ ℂ, ∃ transcendental entire f with z ∈ A ↔ f z ∈ B. Extended by Barth-Schneider in 1971 [BaSc71].",
+    "mathContext": "The 1971 paper extends the real result to the full complex plane.",
     "significance": "supporting",
-    "relatedConcepts": ["Infinite products", "Zeros of entire functions"]
+    "relatedConcepts": ["complex extension", "countable dense subsets of ℂ"]
   },
   {
-    "id": "ann-e226-no-polynomial",
+    "id": "erdos-226-techniques",
     "proofId": "erdos-226",
-    "range": { "startLine": 264, "endLine": 272 },
-    "type": "theorem",
-    "title": "No Polynomial Works",
-    "content": "**no_polynomial_works:**\n\nNo polynomial (of degree > 1) can preserve rationality.\n\n**Intuition:** A polynomial of degree n takes each value at most n times. But there are infinitely many rationals mapping to infinitely many rationals - this forces transcendence.",
-    "mathContext": "This uses algebraic number theory: if p(x) is rational for all rational x, then p must have special form.",
-    "significance": "key"
+    "type": "context",
+    "range": { "startLine": 231, "endLine": 262 },
+    "title": "Construction Techniques",
+    "content": "Weierstrass products build entire functions with prescribed zeros. Interpolation maintains entirety and bijectivity. no_polynomial_works (axiom): no polynomial of degree > 1 preserves rationality.",
+    "mathContext": "Placeholder axioms for proof techniques. no_polynomial_works uses algebraic number theory.",
+    "significance": "supporting",
+    "relatedConcepts": ["Weierstrass products", "interpolation", "algebraic number theory"]
   },
   {
-    "id": "ann-e226-main",
+    "id": "erdos-226-summary",
     "proofId": "erdos-226",
-    "range": { "startLine": 306, "endLine": 310 },
-    "type": "theorem",
-    "title": "Erdős Problem #226: SOLVED",
-    "content": "**erdos_226:**\n\nComplete solution: YES, there exists an entire non-linear function preserving rationality.\n\nThe function is necessarily transcendental and can be made monotone on ℝ.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e226-summary",
-    "proofId": "erdos-226",
-    "range": { "startLine": 284, "endLine": 310 },
-    "type": "theorem",
-    "title": "Complete Summary",
-    "content": "**erdos_226_summary:**\n\n1. **Original Question:** ∃ entire non-linear f with x ∈ ℚ ↔ f(x) ∈ ℚ? → YES\n2. **General Question:** ∃ entire f with f(A) = B for countable dense A, B? → YES\n3. **Transcendence:** The function must be transcendental\n4. **Monotonicity:** Can be made strictly monotone on ℝ\n5. **Extension:** Works for countable dense subsets of ℂ too",
-    "significance": "critical"
+    "type": "result",
+    "range": { "startLine": 263, "endLine": 312 },
+    "title": "Summary: SOLVED",
+    "content": "erdos_226_summary (proved): ErdosQuestion ∧ GeneralQuestion ∧ True. erdos_226 := erdos_question_affirmative. erdos_226_answer (proved): ∃ entire transcendental f preserving rationality. Problem SOLVED.",
+    "mathContext": "erdos_226_summary := ⟨erdos_question_affirmative, general_question_affirmative, trivial⟩.",
+    "significance": "essential",
+    "relatedConcepts": ["solved problems", "entire functions", "rationality"]
   }
 ]

--- a/src/data/proofs/erdos-226/meta.json
+++ b/src/data/proofs/erdos-226/meta.json
@@ -2,171 +2,116 @@
   "id": "erdos-226",
   "title": "Erdős Problem #226: Entire Functions Preserving Rationality",
   "slug": "erdos-226",
-  "description": "Is there an entire non-linear function f such that x ∈ ℚ ↔ f(x) ∈ ℚ for all real x? SOLVED: YES by Barth-Schneider (1970) - transcendental entire functions with this property exist.",
+  "description": "Is there an entire non-linear function f such that x ∈ ℚ ↔ f(x) ∈ ℚ for all real x? SOLVED: YES by Barth-Schneider (1970). For any two countable dense sets A, B ⊂ ℝ, a transcendental entire function mapping A to B exists.",
   "meta": {
     "author": "Barth-Schneider (1970 solution), Erdős (problem), Hayman (collection)",
     "sourceUrl": "https://erdosproblems.com/226",
-    "date": "1970",
-    "status": "complete",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos226Problem.lean",
     "tags": [
-      "erdos",
       "complex-analysis",
       "entire-functions",
       "transcendental-functions",
       "rationality",
-      "countable-dense-sets",
-      "solved"
+      "countable-dense-sets"
     ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 226,
     "erdosUrl": "https://erdosproblems.com/226",
-    "erdosProblemStatus": "solved",
-    "dateAdded": "2026-01-18",
-    "mathlib_version": "4.26.0",
-    "mathlibDependencies": [
-      {
-        "theorem": "Differentiable",
-        "description": "Differentiability predicate for complex functions",
-        "module": "Mathlib.Analysis.Complex.Basic"
-      },
-      {
-        "theorem": "Set.Countable",
-        "description": "Countable sets",
-        "module": "Mathlib.Data.Set.Countable"
-      },
-      {
-        "theorem": "Dense",
-        "description": "Dense sets in topological spaces",
-        "module": "Mathlib.Topology.Basic"
-      },
-      {
-        "theorem": "Rat.denseRange_ratCast",
-        "description": "Rationals are dense in reals",
-        "module": "Mathlib.Topology.Instances.Rat"
-      },
-      {
-        "theorem": "Polynomial",
-        "description": "Polynomial type and evaluation",
-        "module": "Mathlib.Algebra.Polynomial.Basic"
-      },
-      {
-        "theorem": "StrictMono",
-        "description": "Strictly monotone functions",
-        "module": "Mathlib.Order.Monotone.Basic"
-      }
-    ],
-    "originalContributions": [
-      "IsEntire definition: entire (holomorphic on ℂ) functions",
-      "IsTranscendental definition: entire but not polynomial",
-      "IsNonLinear definition: not affine linear",
-      "IsCountableDense definition: countable and dense sets",
-      "rationals_countable_dense theorem: ℚ is countable dense in ℝ",
-      "PreservesRationality definition: f(x) ∈ ℚ ↔ x ∈ ℚ",
-      "ErdosQuestion definition: the original problem statement",
-      "GeneralQuestion definition: generalization to any countable dense sets",
-      "barth_schneider_1970 axiom: the main theorem",
-      "barth_schneider_monotone axiom: monotonicity version",
-      "barth_schneider_complex axiom: extension to ℂ",
-      "erdos_question_affirmative theorem: answer is YES",
-      "general_question_affirmative theorem: generalization is YES",
-      "erdos_226 theorem: main result"
-    ]
+    "erdosProblemStatus": "solved"
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #226**\n\nThis problem concerns the interplay between complex analysis and number theory.\n\n**Key History:**\n- Erdős posed the original question about rationality-preserving entire functions\n- Hayman included it as Problem 2.31 in his 1974 collection 'Research problems in function theory'\n- Barth and Schneider solved it affirmatively in 1970\n- They proved a much stronger result: for ANY two countable dense sets A, B ⊂ ℝ, such functions exist\n- In 1971, they extended the result to countable dense subsets of ℂ\n\n**Mathematical Context:**\n- The function must be transcendental (no polynomial works)\n- The construction uses Weierstrass products and careful interpolation\n- The function can be made monotone on ℝ",
-    "problemStatement": "**Problem Statement (Solved)**\n\nIs there an entire non-linear function f : ℂ → ℂ such that for all x ∈ ℝ:\n\nx is rational ↔ f(x) is rational?\n\n**Generalization:** For any two countable dense sets A, B ⊆ ℝ, is there an entire function with f(A) = B?\n\n**Answer: YES** (Barth-Schneider, 1970)\n\nFor any countable dense sets A, B ⊂ ℝ, there exists a transcendental entire function f such that f(z) ∈ B if and only if z ∈ A (when restricted to ℝ). Taking A = B = ℚ answers the original question.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Entire Functions:** Define IsEntire (differentiable on ℂ), IsTranscendental (not polynomial)\n\n2. **Countable Dense Sets:** Define IsCountableDense, prove ℚ is countable dense\n\n3. **The Questions:** Formalize ErdosQuestion and GeneralQuestion\n\n4. **Barth-Schneider:** Axiomatize their 1970 theorem and monotone version\n\n5. **Main Results:** Derive erdos_question_affirmative from barth_schneider_1970\n\n6. **Extensions:** Axiomatize the 1971 complex extension",
+    "historicalContext": "Erdős Problem #226 concerns the interplay between complex analysis and number theory. Erdős asked whether an entire non-linear function can preserve rationality. Hayman included it as Problem 2.31 in his 1974 collection. Barth and Schneider solved it affirmatively in 1970, proving a stronger result for any pair of countable dense sets. In 1971, they extended it to countable dense subsets of ℂ.",
+    "problemStatement": "Is there an entire non-linear function f : ℂ → ℂ such that for all x ∈ ℝ, x ∈ ℚ ↔ f(x) ∈ ℚ? More generally, for any countable dense A, B ⊆ ℝ, does an entire function with f(A) = B exist? SOLVED: YES (Barth-Schneider, 1970).",
+    "proofStrategy": "The formalization defines IsEntire, IsTranscendental, IsCountableDense, and proves ℚ is countable dense. ErdosQuestion and GeneralQuestion are formalized. Barth-Schneider theorem is axiomatized. The main results erdos_question_affirmative and general_question_affirmative are derived from the axiom. Extensions to ℂ and the no-polynomial result are included.",
     "keyInsights": [
-      "**Transcendence Required:** The function must be transcendental - no polynomial can preserve rationality while being non-constant",
-      "**Monotonicity Possible:** The function can be made strictly monotone on ℝ",
-      "**Full Generality:** Result holds for ANY pair of countable dense sets, not just ℚ",
-      "**Complex Extension:** The theorem extends to countable dense subsets of ℂ",
-      "**Construction:** Uses Weierstrass products to build entire functions with prescribed behavior"
+      "The function must be transcendental — no polynomial can preserve rationality while being non-linear",
+      "The function can be made strictly monotone on ℝ",
+      "Result holds for ANY pair of countable dense sets, not just ℚ",
+      "The theorem extends to countable dense subsets of ℂ (1971)",
+      "Construction uses Weierstrass products and interpolation"
     ]
   },
   "sections": [
     {
       "id": "entire-functions",
-      "title": "Entire Functions",
-      "summary": "IsEntire, IsTranscendental, IsNonLinear definitions",
-      "startLine": 44,
-      "endLine": 68
+      "title": "Part 1: Entire Functions",
+      "startLine": 45,
+      "endLine": 68,
+      "summary": "IsEntire (Differentiable ℂ f), IsTranscendental (entire and not polynomial), IsNonLinear (not affine) definitions."
     },
     {
       "id": "countable-dense",
-      "title": "Countable Dense Sets",
-      "summary": "IsCountableDense definition, rationals_countable_dense theorem",
-      "startLine": 70,
-      "endLine": 88
+      "title": "Part 2: Countable Dense Sets",
+      "startLine": 69,
+      "endLine": 86,
+      "summary": "IsCountableDense definition. rationals_countable_dense: proved ℚ is countable dense in ℝ using Set.countable_range and Rat.denseRange_ratCast."
     },
     {
       "id": "rationality-preservation",
-      "title": "Rationality Preservation",
-      "summary": "PreservesRationality, MapsSetToSet definitions",
-      "startLine": 90,
-      "endLine": 106
+      "title": "Part 3: Rationality Preservation",
+      "startLine": 87,
+      "endLine": 102,
+      "summary": "PreservesRationality (f(x) ∈ ℚ ↔ x ∈ ℚ) and MapsSetToSet (x ∈ A ↔ f(x) ∈ B) definitions."
     },
     {
       "id": "original-question",
-      "title": "The Original Question",
-      "summary": "ErdosQuestion definition - the original problem",
-      "startLine": 108,
-      "endLine": 121
+      "title": "Part 4: The Original Question",
+      "startLine": 103,
+      "endLine": 115,
+      "summary": "ErdosQuestion: ∃ entire non-linear f with x ∈ ℚ ↔ f(x) ∈ ℚ."
     },
     {
       "id": "general-question",
-      "title": "The General Question",
-      "summary": "GeneralQuestion definition - generalization to any dense sets",
-      "startLine": 123,
-      "endLine": 137
+      "title": "Part 5: The General Question",
+      "startLine": 116,
+      "endLine": 129,
+      "summary": "GeneralQuestion: for all countable dense A, B, ∃ entire f mapping A to B."
     },
     {
       "id": "barth-schneider",
-      "title": "Barth-Schneider Theorem",
-      "summary": "barth_schneider_1970, barth_schneider_monotone axioms",
-      "startLine": 139,
-      "endLine": 171
+      "title": "Part 6: Barth-Schneider Theorem",
+      "startLine": 130,
+      "endLine": 161,
+      "summary": "barth_schneider_1970 axiom (transcendental entire f with f(A) = B) and barth_schneider_monotone axiom (monotone version)."
     },
     {
       "id": "main-answer",
-      "title": "The Answer",
-      "summary": "erdos_question_affirmative, general_question_affirmative theorems",
-      "startLine": 173,
-      "endLine": 219
+      "title": "Part 7: The Answer",
+      "startLine": 162,
+      "endLine": 207,
+      "summary": "erdos_question_affirmative (proved from barth_schneider_1970 with A=B=ℚ) and general_question_affirmative (proved directly)."
     },
     {
       "id": "extensions",
-      "title": "Extensions",
-      "summary": "barth_schneider_complex axiom - extension to ℂ",
-      "startLine": 221,
-      "endLine": 244
+      "title": "Part 8: Extensions",
+      "startLine": 208,
+      "endLine": 230,
+      "summary": "barth_schneider_complex axiom (1971 extension to countable dense subsets of ℂ) and construction_flexibility placeholder."
     },
     {
       "id": "insights",
-      "title": "Why This Works",
-      "summary": "Weierstrass products, interpolation, no_polynomial_works",
-      "startLine": 246,
-      "endLine": 272
+      "title": "Part 9: Why This Works",
+      "startLine": 231,
+      "endLine": 262,
+      "summary": "Weierstrass products, interpolation technique (placeholders), and no_polynomial_works axiom."
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "summary": "erdos_226_summary, erdos_226, erdos_226_answer theorems",
-      "startLine": 280,
-      "endLine": 331
+      "title": "Part 10: Summary",
+      "startLine": 263,
+      "endLine": 312,
+      "summary": "erdos_226_summary (proved), erdos_226, erdos_226_answer theorems. Problem SOLVED."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #226 asked whether there exists an entire non-linear function preserving rationality (x ∈ ℚ ↔ f(x) ∈ ℚ). Barth and Schneider (1970) proved YES by establishing a much stronger result: for any two countable dense sets A, B ⊂ ℝ, a transcendental entire function exists mapping A to B. The function can be made monotone on ℝ, and the result extends to ℂ.",
-    "implications": "**Complex Analysis Connections**\n\n1. **Transcendental Functions:** The solution requires going beyond polynomials\n\n2. **Weierstrass Theory:** The construction uses Weierstrass products and interpolation\n\n3. **Dense Sets:** Countable dense sets have remarkable flexibility for function mapping\n\n4. **Number-Theoretic Implications:** Shows surprising freedom in relating algebraic and analytic properties\n\n5. **Extensions:** The technique extends to higher-dimensional settings",
+    "summary": "Erdős Problem #226 was SOLVED by Barth and Schneider (1970). An entire non-linear function preserving rationality exists. More generally, for any countable dense sets A, B ⊂ ℝ, a transcendental entire function maps A to B. The result extends to ℂ.",
+    "implications": "The solution reveals surprising flexibility: transcendental entire functions can precisely control which points map to which. Connects complex analysis (Weierstrass products) to arithmetic properties of dense sets.",
     "openQuestions": [
       "Can the growth rate of the constructed function be controlled?",
       "What is the smallest order of growth needed?",
-      "Can similar results be obtained for other algebraic sets?",
-      "What about preserving algebraic numbers instead of rationals?",
-      "Effective/constructive versions of the result?"
+      "Can similar results be obtained for algebraic numbers?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- **Polish** of Erdős Problem #226 (Entire Functions Preserving Rationality) — SOLVED by Barth-Schneider (1970)
- Added `import Mathlib.Tactic`; fixed section headers to `/-!` syntax
- Removed non-standard meta fields; fixed status, tags, annotation schema
- Consolidated annotations from 15 to 9 with correct types and significance
- 312 lines, 0 sorries, 9 annotations, 10 sections

## Test plan
- [x] `pnpm build` passes
- [x] Lean file has 0 sorries
- [x] All annotations have correct types and significance
- [x] Meta.json sections have proper schema (id, title, startLine, endLine, summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)