### PR TITLE
feat(erdos-423): Formalize sums of consecutive terms sequence

### DIFF
--- a/proofs/Proofs/Erdos423Problem.lean
+++ b/proofs/Proofs/Erdos423Problem.lean
@@ -1,0 +1,154 @@
+/-
+Erdős Problem #423: Sums of Consecutive Terms Sequence
+
+Source: https://erdosproblems.com/423
+Status: OPEN
+
+Statement:
+Let a₁ = 1, a₂ = 2. For k ≥ 3, define aₖ as the least integer > a_{k-1}
+which is the sum of at least two consecutive terms of the sequence.
+
+The sequence begins: 1, 2, 3, 5, 6, 8, 10, 11, ...
+
+What is the asymptotic behaviour of this sequence?
+
+Known:
+- The sequence a(n) - n is nondecreasing and unbounded (Bolan, Tang 2024-2025)
+- Infinitely many integers do not appear in the sequence
+
+OEIS: A005243
+References: [Er77c, p.71], [ErGr80, p.83]
+-/
+
+import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.List.Range
+import Mathlib.Order.Filter.Basic
+import Mathlib.Tactic
+
+open Nat Finset
+
+namespace Erdos423
+
+/-! ## Part I: The Sequence Definition -/
+
+/-- The Erdős-Hofstadter sequence: a₁ = 1, a₂ = 2, and for k ≥ 3,
+    aₖ is the least integer > a_{k-1} that equals the sum of at least
+    two consecutive terms a_i + a_{i+1} + ... + a_j for some i ≤ j < k. -/
+noncomputable def consSeq : ℕ → ℕ := sorry -- Well-defined by greedy construction
+
+/-- Initial values. -/
+axiom consSeq_zero : consSeq 0 = 1
+axiom consSeq_one : consSeq 1 = 2
+
+/-- The sequence is strictly increasing. -/
+axiom consSeq_strictMono : StrictMono consSeq
+
+/-! ## Part II: Consecutive Sum Property -/
+
+/-- The sum of consecutive terms a_i + a_{i+1} + ... + a_j. -/
+noncomputable def consecutiveSum (i j : ℕ) : ℕ :=
+  (Finset.Icc i j).sum consSeq
+
+/-- A number m is a consecutive sum of the sequence up to index n
+    if m = a_i + a_{i+1} + ... + a_j for some i ≤ j < n with j - i ≥ 1. -/
+def IsConsecutiveSum (m n : ℕ) : Prop :=
+  ∃ i j, i ≤ j ∧ j < n ∧ j > i ∧ consecutiveSum i j = m
+
+/-- The defining property: a(k) is the least integer > a(k-1)
+    that is a consecutive sum. -/
+axiom consSeq_is_consecutive_sum (k : ℕ) (hk : k ≥ 2) :
+    IsConsecutiveSum (consSeq k) k
+
+/-- No smaller integer > a(k-1) is a consecutive sum. -/
+axiom consSeq_minimal (k : ℕ) (hk : k ≥ 2) (m : ℕ)
+    (hm₁ : consSeq (k - 1) < m) (hm₂ : m < consSeq k) :
+    ¬IsConsecutiveSum m k
+
+/-! ## Part III: Known Initial Values -/
+
+/-- The first several terms of the sequence (OEIS A005243). -/
+axiom consSeq_values :
+    consSeq 2 = 3 ∧ consSeq 3 = 5 ∧ consSeq 4 = 6 ∧
+    consSeq 5 = 8 ∧ consSeq 6 = 10 ∧ consSeq 7 = 11
+
+/-- Verification: 3 = 1 + 2 (consecutive sum a₁ + a₂). -/
+axiom verify_three : consecutiveSum 0 1 = 3
+
+/-- Verification: 5 = 2 + 3 (consecutive sum a₂ + a₃). -/
+axiom verify_five : consecutiveSum 1 2 = 5
+
+/-! ## Part IV: Growth Properties -/
+
+/-- The sequence grows at least linearly: a(n) ≥ n + 1. -/
+axiom consSeq_lower_bound (n : ℕ) : consSeq n ≥ n + 1
+
+/-- The excess a(n) - n is nondecreasing (Bolan, Tang). -/
+axiom excess_nondecreasing :
+    ∀ m n : ℕ, m ≤ n → consSeq m - m ≤ consSeq n - n
+
+/-- The excess a(n) - n is unbounded (Bolan, Tang). -/
+axiom excess_unbounded :
+    Filter.Tendsto (fun n => (consSeq n : ℤ) - (n : ℤ)) Filter.atTop Filter.atTop
+
+/-! ## Part V: Missing Numbers -/
+
+/-- The set of positive integers that appear in the sequence. -/
+def seqRange : Set ℕ := {m | ∃ n, consSeq n = m}
+
+/-- The set of positive integers NOT in the sequence. -/
+def missingNumbers : Set ℕ := {m | m ≥ 1 ∧ m ∉ seqRange}
+
+/-- Infinitely many integers do not appear (Bolan, Tang). -/
+axiom infinitely_many_missing : Set.Infinite missingNumbers
+
+/-- 4 is the first missing number (not a consecutive sum at the right moment). -/
+axiom four_is_missing : 4 ∈ missingNumbers
+
+/-! ## Part VI: The Main Question -/
+
+/--
+**Erdős Problem #423 (OPEN):**
+What is the asymptotic behaviour of the sequence?
+
+Possible formulations:
+1. Is a(n) ~ cn for some constant c > 1?
+2. Does a(n)/n converge?
+3. What is the density of seqRange?
+-/
+def ErdosQuestion423_convergence : Prop :=
+  ∃ C : ℝ, C > 1 ∧
+    Filter.Tendsto (fun n => (consSeq n : ℝ) / (n : ℝ)) Filter.atTop (nhds C)
+
+def ErdosQuestion423_density : Prop :=
+  ∃ d : ℝ, 0 < d ∧ d < 1 ∧
+    Filter.Tendsto
+      (fun N => ((Finset.range (N + 1)).filter (· ∈ seqRange)).card / (N + 1 : ℝ))
+      Filter.atTop (nhds d)
+
+/-! ## Part VII: Summary -/
+
+/--
+**Erdős Problem #423: Summary**
+
+PROBLEM: Let a₁=1, a₂=2, and for k≥3, aₖ is the least integer > a_{k-1}
+that is a sum of at least two consecutive terms. What is the asymptotic
+behaviour?
+
+STATUS: OPEN
+
+KNOWN:
+- Sequence: 1, 2, 3, 5, 6, 8, 10, 11, ... (OEIS A005243)
+- a(n) - n is nondecreasing and unbounded (Bolan, Tang)
+- Infinitely many integers are not in the sequence
+- 4 is the first missing number
+-/
+theorem erdos_423_known :
+    (∀ m n, m ≤ n → consSeq m - m ≤ consSeq n - n) ∧
+    Set.Infinite missingNumbers := by
+  exact ⟨excess_nondecreasing, infinitely_many_missing⟩
+
+/-- The problem remains OPEN. -/
+theorem erdos_423_status : True := trivial
+
+end Erdos423

--- a/src/data/proofs/erdos-423/annotations.json
+++ b/src/data/proofs/erdos-423/annotations.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "erdos-423-header",
+    "proofId": "erdos-423",
+    "type": "context",
+    "range": { "startLine": 1, "endLine": 21 },
+    "title": "Problem Overview",
+    "content": "Erdős Problem #423: Let a₁=1, a₂=2, and for k≥3, aₖ is the least integer > a_{k-1} that is a sum of at least two consecutive terms. What is the asymptotic behaviour? OPEN. Sequence: 1, 2, 3, 5, 6, 8, 10, 11, ... (OEIS A005243).",
+    "mathContext": "A greedy sequence defined by consecutive-sum representability. Each term must equal some aᵢ + aᵢ₊₁ + ... + aⱼ with j > i. Related to Ulam-type constructions.",
+    "significance": "essential",
+    "relatedConcepts": ["greedy sequences", "consecutive sums", "Ulam sequences"]
+  },
+  {
+    "id": "erdos-423-definition",
+    "proofId": "erdos-423",
+    "type": "definition",
+    "range": { "startLine": 33, "endLine": 64 },
+    "title": "Sequence and Consecutive Sum Property",
+    "content": "consSeq: ℕ → ℕ (noncomputable). Initial values a(0)=1, a(1)=2. consSeq_strictMono (axiom). consecutiveSum(i,j): sum of terms from index i to j. IsConsecutiveSum(m,n): m is a consecutive sum from the first n terms. consSeq_is_consecutive_sum (axiom), consSeq_minimal (axiom).",
+    "mathContext": "The sequence is well-defined by a greedy algorithm: at each step, pick the smallest valid integer.",
+    "significance": "essential",
+    "relatedConcepts": ["greedy algorithm", "StrictMono", "Finset.sum"]
+  },
+  {
+    "id": "erdos-423-values",
+    "proofId": "erdos-423",
+    "type": "result",
+    "range": { "startLine": 66, "endLine": 78 },
+    "title": "Initial Values",
+    "content": "consSeq_values (axiom): first 8 terms are 1, 2, 3, 5, 6, 8, 10, 11. verify_three (axiom): 3 = a(0)+a(1). verify_five (axiom): 5 = a(1)+a(2).",
+    "mathContext": "The sequence skips 4 because 4 cannot be written as a sum of consecutive terms at the time it would be needed.",
+    "significance": "supporting",
+    "relatedConcepts": ["OEIS A005243", "computation"]
+  },
+  {
+    "id": "erdos-423-growth",
+    "proofId": "erdos-423",
+    "type": "result",
+    "range": { "startLine": 80, "endLine": 93 },
+    "title": "Growth Properties (Bolan, Tang)",
+    "content": "consSeq_lower_bound (axiom): a(n) ≥ n+1. excess_nondecreasing (axiom): a(m)-m ≤ a(n)-n for m ≤ n. excess_unbounded (axiom): a(n)-n → ∞.",
+    "mathContext": "The sequence grows strictly faster than linearly. The excess a(n)-n is both nondecreasing and unbounded, recent results from 2024-2025.",
+    "significance": "essential",
+    "relatedConcepts": ["superlinear growth", "Filter.Tendsto", "excess function"]
+  },
+  {
+    "id": "erdos-423-missing",
+    "proofId": "erdos-423",
+    "type": "result",
+    "range": { "startLine": 95, "endLine": 108 },
+    "title": "Missing Numbers",
+    "content": "seqRange: set of values appearing in the sequence. missingNumbers: positive integers not in seqRange. infinitely_many_missing (axiom): Set.Infinite missingNumbers. four_is_missing (axiom): 4 is the first missing number.",
+    "mathContext": "The sequence does not cover all positive integers. The missing numbers form an infinite set, with 4 being the first gap.",
+    "significance": "essential",
+    "relatedConcepts": ["Set.Infinite", "missing values", "gaps"]
+  },
+  {
+    "id": "erdos-423-question",
+    "proofId": "erdos-423",
+    "type": "conjecture",
+    "range": { "startLine": 110, "endLine": 126 },
+    "title": "Asymptotic Questions (OPEN)",
+    "content": "ErdosQuestion423_convergence: does a(n)/n → C for some C > 1? ErdosQuestion423_density: does the sequence have a natural density 0 < d < 1?",
+    "mathContext": "The main open question. If a(n)/n converges, the limit C would determine the density as 1/C.",
+    "significance": "essential",
+    "relatedConcepts": ["asymptotic density", "growth rate", "Filter.Tendsto"]
+  },
+  {
+    "id": "erdos-423-summary",
+    "proofId": "erdos-423",
+    "type": "result",
+    "range": { "startLine": 128, "endLine": 154 },
+    "title": "Summary: OPEN",
+    "content": "erdos_423_known (proved): combines excess nondecreasing and infinitely many missing. erdos_423_status (proved): True. Problem remains OPEN.",
+    "mathContext": "The summary theorem combines the two main known results into a single statement.",
+    "significance": "essential",
+    "relatedConcepts": ["open problem", "summary"]
+  }
+]

--- a/src/data/proofs/erdos-423/index.ts
+++ b/src/data/proofs/erdos-423/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos423Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-423/meta.json
+++ b/src/data/proofs/erdos-423/meta.json
@@ -1,0 +1,97 @@
+{
+  "id": "erdos-423",
+  "title": "Erdős Problem #423: Sums of Consecutive Terms Sequence",
+  "slug": "erdos-423",
+  "description": "Let a₁=1, a₂=2. For k≥3, aₖ is the least integer > a_{k-1} that is a sum of at least two consecutive terms. What is the asymptotic behaviour? OPEN.",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/423",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos423Problem.lean",
+    "tags": [
+      "number-theory",
+      "sequences",
+      "additive-combinatorics",
+      "asymptotics",
+      "open-problem"
+    ],
+    "badge": "axiom",
+    "sorries": 1,
+    "erdosNumber": 423,
+    "erdosUrl": "https://erdosproblems.com/423",
+    "erdosProblemStatus": "open"
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #423 from [Er77c, p.71] defines a greedy sequence where each new term must be a sum of at least two consecutive earlier terms. Credited to Hofstadter's inspiration from a similar Ulam-type question. Recent progress by Bolan and Tang (2024-2025) shows the excess a(n)-n is nondecreasing and unbounded, and infinitely many integers are missing from the sequence. OEIS A005243.",
+    "problemStatement": "Let a₁=1, a₂=2. For k≥3, aₖ is the least integer > a_{k-1} which is the sum of at least two consecutive terms a_i + a_{i+1} + ... + a_j for some i ≤ j < k. What is the asymptotic behaviour of this sequence? OPEN.",
+    "proofStrategy": "The formalization defines the sequence (noncomputable), the consecutive sum property, initial values, growth properties (excess nondecreasing and unbounded), missing numbers (infinitely many), and asymptotic questions (convergence of a(n)/n, density). The known results theorem erdos_423_known is proved from axioms.",
+    "keyInsights": [
+      "Each term is the smallest integer exceeding the previous that equals a sum of consecutive earlier terms",
+      "The sequence grows strictly faster than linearly: a(n) - n is unbounded (Bolan, Tang)",
+      "Infinitely many integers are missing, with 4 being the first",
+      "The asymptotic growth rate and density of the sequence are unknown",
+      "Related to Ulam-type sequence constructions (Problem #342)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "Part I: The Sequence Definition",
+      "startLine": 33,
+      "endLine": 43,
+      "summary": "Defines consSeq: ℕ → ℕ with initial values 1, 2. Axiom: strict monotonicity."
+    },
+    {
+      "id": "consecutive-sum",
+      "title": "Part II: Consecutive Sum Property",
+      "startLine": 45,
+      "endLine": 64,
+      "summary": "Defines consecutiveSum and IsConsecutiveSum. Axioms: consSeq_is_consecutive_sum and consSeq_minimal."
+    },
+    {
+      "id": "initial-values",
+      "title": "Part III: Known Initial Values",
+      "startLine": 66,
+      "endLine": 78,
+      "summary": "Axiom consSeq_values: first 8 terms (1,2,3,5,6,8,10,11). Axioms: verify_three, verify_five."
+    },
+    {
+      "id": "growth",
+      "title": "Part IV: Growth Properties",
+      "startLine": 80,
+      "endLine": 93,
+      "summary": "Axioms: consSeq_lower_bound (a(n) ≥ n+1), excess_nondecreasing, excess_unbounded (Bolan, Tang)."
+    },
+    {
+      "id": "missing",
+      "title": "Part V: Missing Numbers",
+      "startLine": 95,
+      "endLine": 108,
+      "summary": "Defines seqRange and missingNumbers. Axioms: infinitely_many_missing, four_is_missing."
+    },
+    {
+      "id": "main-question",
+      "title": "Part VI: The Main Question",
+      "startLine": 110,
+      "endLine": 126,
+      "summary": "Defines ErdosQuestion423_convergence (a(n)/n → C) and ErdosQuestion423_density (density of sequence range)."
+    },
+    {
+      "id": "summary",
+      "title": "Part VII: Summary",
+      "startLine": 128,
+      "endLine": 154,
+      "summary": "Proved: erdos_423_known (combines nondecreasing excess and infinite missing), erdos_423_status (trivial). OPEN."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős Problem #423 asks about the asymptotic behaviour of a greedy sequence built from sums of consecutive terms. Recent progress shows the excess a(n)-n grows unboundedly and infinitely many integers are missing, but the precise growth rate remains open.",
+    "implications": "Resolution would clarify the structure of greedy sequences defined by consecutive-sum constraints, connecting to additive combinatorics and the theory of Ulam-type sequences.",
+    "openQuestions": [
+      "What is the asymptotic growth rate of a(n)?",
+      "Does a(n)/n converge? If so, to what constant?",
+      "What is the density of the set of integers appearing in the sequence?",
+      "How does this relate to the Ulam sequence (Problem #342)?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- New formalization of Erdős Problem #423 (sums of consecutive terms sequence) from stub
- Defines the Erdős-Hofstadter sequence, consecutive sum property, growth properties, missing numbers, and asymptotic questions
- Incorporates recent results by Bolan and Tang (2024-2025): excess a(n)-n is nondecreasing and unbounded, infinitely many integers missing
- 154 lines, 1 sorry (noncomputable sequence definition), 7 annotations, badge: axiom
- Problem **OPEN**

## Test plan
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)