### PR TITLE
Enhance Erdős #47: Unit fractions from dense sets

### DIFF
--- a/proofs/Proofs/Erdos47Problem.lean
+++ b/proofs/Proofs/Erdos47Problem.lean
@@ -1,0 +1,154 @@
+/-!
+# Erdős Problem #47: Unit Fractions from Dense Sets
+
+**Source:** [erdosproblems.com/47](https://erdosproblems.com/47)
+**Status:** SOLVED (Bloom [Bl21], improved by Liu–Sawhney [LiSa24])
+
+## Statement
+
+If δ > 0 and N is sufficiently large, and A ⊆ {1, …, N} satisfies
+∑_{a ∈ A} 1/a > δ log N, must there exist S ⊆ A such that ∑_{n ∈ S} 1/n = 1?
+
+## Background
+
+Bloom proved the answer is YES with threshold ∑ 1/a ≫ (log log log N)/(log log N) · log N.
+Liu and Sawhney improved this to ∑ 1/a ≫ (log N)^{4/5 + o(1)}.
+Erdős conjectured ≫ (log log N)² might suffice; Pomerance showed this is optimal.
+
+## Approach
+
+We formalize the key definitions (unit fraction subsets, reciprocal sum
+density) and state Bloom's theorem and the Liu–Sawhney improvement
+as axioms. The density threshold is captured via the reciprocal sum.
+-/
+
+import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Rat.Basic
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Order.Filter.Basic
+import Mathlib.Tactic
+
+open Finset Filter
+
+namespace Erdos47
+
+/-! ## Part I: Unit Fraction Subsets -/
+
+/--
+The reciprocal sum of a finite set of positive integers: ∑_{a ∈ A} 1/a.
+Computed over ℚ for exactness.
+-/
+noncomputable def reciprocalSum (A : Finset ℕ) : ℚ :=
+  A.sum fun a => if a = 0 then 0 else (1 : ℚ) / a
+
+/--
+A set S has unit fraction sum: ∑_{n ∈ S} 1/n = 1.
+-/
+def HasUnitFractionSum (S : Finset ℕ) : Prop :=
+  (∀ n ∈ S, n ≥ 1) ∧ reciprocalSum S = 1
+
+/--
+A set A contains a unit fraction subset: there exists S ⊆ A
+with ∑_{n ∈ S} 1/n = 1.
+-/
+def ContainsUnitFraction (A : Finset ℕ) : Prop :=
+  ∃ S : Finset ℕ, S ⊆ A ∧ S.Nonempty ∧ HasUnitFractionSum S
+
+/-! ## Part II: Dense Subsets of {1, ..., N} -/
+
+/--
+The interval {1, …, N} as a Finset.
+-/
+def Icc1 (N : ℕ) : Finset ℕ := (Finset.range N).image (· + 1)
+
+/--
+A ⊆ {1, …, N} with large reciprocal sum (at least δ · log N).
+-/
+def IsDenseSubset (A : Finset ℕ) (N : ℕ) (δ : ℚ) : Prop :=
+  A ⊆ Icc1 N ∧
+  (∀ a ∈ A, a ≥ 1) ∧
+  δ > 0 ∧
+  reciprocalSum A > δ * Real.log N
+
+/-! ## Part III: Erdős's Conjecture (Solved) -/
+
+/--
+**Erdős Problem #47 (original formulation):**
+For every δ > 0, there exists N₀ such that for all N ≥ N₀,
+if A ⊆ {1, …, N} has ∑ 1/a > δ log N, then A contains a
+subset S with ∑ 1/n = 1.
+-/
+def ErdosConjecture47 : Prop :=
+  ∀ δ : ℚ, δ > 0 →
+    ∃ N₀ : ℕ,
+      ∀ N : ℕ, N ≥ N₀ →
+        ∀ A : Finset ℕ,
+          IsDenseSubset A N δ →
+          ContainsUnitFraction A
+
+/-! ## Part IV: Bloom's Theorem -/
+
+/--
+**Bloom's Theorem [Bl21]:**
+Erdős Problem #47 is true. In fact, a quantitative threshold suffices:
+if ∑ 1/a ≫ (log log log N)/(log log N) · log N, then A contains
+a unit fraction subset.
+
+We state the qualitative version as the main result.
+-/
+axiom bloom_theorem : ErdosConjecture47
+
+/--
+**Bloom's quantitative bound:**
+There exists an absolute constant C such that if A ⊆ {1, …, N}
+and ∑ 1/a ≥ C · (log log log N / log log N) · log N, then
+A contains a unit fraction subset.
+-/
+axiom bloom_quantitative :
+  ∃ C : ℚ, C > 0 ∧
+    ∀ N : ℕ, N ≥ 2 →
+      ∀ A : Finset ℕ, A ⊆ Icc1 N →
+        reciprocalSum A ≥ C * (Real.log (Real.log (Real.log N)) /
+          Real.log (Real.log N)) * Real.log N →
+        ContainsUnitFraction A
+
+/-! ## Part V: Liu–Sawhney Improvement -/
+
+/--
+**Liu–Sawhney Improvement [LiSa24]:**
+The threshold can be improved to ∑ 1/a ≫ (log N)^{4/5 + o(1)}.
+-/
+axiom liu_sawhney_improvement :
+  ∀ ε : ℚ, ε > 0 →
+    ∃ N₀ : ℕ,
+      ∀ N : ℕ, N ≥ N₀ →
+        ∀ A : Finset ℕ, A ⊆ Icc1 N →
+          reciprocalSum A ≥ (Real.log N : ℚ) ^ ((4 : ℚ) / 5 + ε) →
+          ContainsUnitFraction A
+
+/-! ## Part VI: Pomerance's Optimality -/
+
+/--
+**Pomerance's construction:**
+There exist sets A ⊆ {1, …, N} with ∑ 1/a ≫ (log log N)²
+that contain no unit fraction subset. This shows Erdős's guess
+of (log log N)² as the threshold would be essentially tight.
+-/
+axiom pomerance_lower_bound :
+  ∀ N₀ : ℕ, ∃ N : ℕ, N ≥ N₀ ∧
+    ∃ A : Finset ℕ, A ⊆ Icc1 N ∧
+      reciprocalSum A ≥ (Real.log (Real.log N) : ℚ) ^ 2 ∧
+      ¬ContainsUnitFraction A
+
+/-! ## Part VII: Summary -/
+
+/--
+**Summary:**
+Erdős Problem #47 is solved. Dense subsets of {1, …, N} (with large
+reciprocal sum) contain unit fraction subsets. Bloom proved the
+conjecture; Liu–Sawhney improved the quantitative bound.
+-/
+theorem erdos_47_summary : ErdosConjecture47 := bloom_theorem
+
+end Erdos47

--- a/src/data/proofs/erdos-47/annotations.json
+++ b/src/data/proofs/erdos-47/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "erdos-47-reciprocal",
+    "proofId": "erdos-47",
+    "type": "definition",
+    "range": { "startLine": 38, "endLine": 56 },
+    "title": "Unit Fraction Definitions",
+    "content": "reciprocalSum computes ∑ 1/a over ℚ. HasUnitFractionSum requires ∑ = 1 with all elements ≥ 1. ContainsUnitFraction asks for a nonempty subset with unit fraction sum.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-47-dense",
+    "proofId": "erdos-47",
+    "type": "definition",
+    "range": { "startLine": 60, "endLine": 72 },
+    "title": "Dense Subset Definition",
+    "content": "Icc1(N) = {1,…,N}. IsDenseSubset captures A ⊆ {1,…,N} with reciprocal sum exceeding δ · log N, the density condition in Erdős's conjecture.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-47-conjecture",
+    "proofId": "erdos-47",
+    "type": "conjecture",
+    "range": { "startLine": 76, "endLine": 88 },
+    "title": "Erdős's Conjecture (Solved)",
+    "content": "ErdosConjecture47: for every δ > 0, sufficiently large N, and A ⊆ {1,…,N} with ∑ 1/a > δ log N, there exists S ⊆ A with ∑ 1/n = 1. Now a theorem (Bloom).",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-47-bloom",
+    "proofId": "erdos-47",
+    "type": "result",
+    "range": { "startLine": 92, "endLine": 114 },
+    "title": "Bloom's Theorem",
+    "content": "Bloom [Bl21] proved the conjecture with an explicit quantitative bound: ∑ 1/a ≥ C · (log log log N / log log N) · log N suffices to guarantee a unit fraction subset.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-47-liu-sawhney",
+    "proofId": "erdos-47",
+    "type": "result",
+    "range": { "startLine": 118, "endLine": 128 },
+    "title": "Liu–Sawhney Improvement",
+    "content": "Liu and Sawhney [LiSa24] improved Bloom's threshold to (log N)^{4/5+o(1)}, a substantial polynomial improvement over the triple-logarithmic bound.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-47-pomerance",
+    "proofId": "erdos-47",
+    "type": "context",
+    "range": { "startLine": 132, "endLine": 142 },
+    "title": "Pomerance's Lower Bound",
+    "content": "Pomerance constructed sets with ∑ 1/a ≈ (log log N)² containing no unit fraction subset. This shows Erdős's conjectured threshold is essentially optimal.",
+    "significance": "supporting"
+  }
+]

--- a/src/data/proofs/erdos-47/index.ts
+++ b/src/data/proofs/erdos-47/index.ts
@@ -1,0 +1,42 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos47Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-47/meta.json
+++ b/src/data/proofs/erdos-47/meta.json
@@ -1,0 +1,95 @@
+{
+  "id": "erdos-47",
+  "title": "Erdős Problem #47: Unit Fractions from Dense Sets",
+  "slug": "erdos-47",
+  "description": "If A ⊆ {1,…,N} has ∑ 1/a > δ log N, must some S ⊆ A have ∑ 1/n = 1? Yes — proved by Bloom (2021). Liu–Sawhney improved the quantitative bound. SOLVED.",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/47",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos47Problem.lean",
+    "tags": [
+      "number-theory",
+      "unit-fractions",
+      "density",
+      "combinatorial-number-theory"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 47,
+    "erdosUrl": "https://erdosproblems.com/47",
+    "erdosProblemStatus": "solved"
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #47 asks whether dense subsets of {1, …, N} (measured by reciprocal sum) must contain a subset whose reciprocals sum to 1. Bloom [Bl21] proved this affirmatively; Liu and Sawhney [LiSa24] improved the quantitative threshold. Pomerance showed Erdős's conjectured (log log N)² bound is essentially optimal.",
+    "problemStatement": "If δ > 0 and N is large, and A ⊆ {1, …, N} has ∑ 1/a > δ log N, must there exist S ⊆ A with ∑ 1/n = 1? SOLVED: YES (Bloom).",
+    "proofStrategy": "We formalize the unit fraction problem using Finset and ℚ arithmetic. Bloom's theorem and the Liu–Sawhney improvement are stated as axioms. Pomerance's lower bound construction is also axiomatized.",
+    "keyInsights": [
+      "Bloom proved the conjecture: large reciprocal sum forces a unit fraction subset",
+      "Bloom's quantitative bound: ∑ 1/a ≫ (log log log N / log log N) · log N suffices",
+      "Liu–Sawhney improved to ∑ 1/a ≫ (log N)^{4/5 + o(1)}",
+      "Pomerance showed (log log N)² is essentially the optimal threshold",
+      "The problem is related to Egyptian fraction representations"
+    ]
+  },
+  "sections": [
+    {
+      "id": "unit-fractions",
+      "title": "Part I: Unit Fraction Subsets",
+      "startLine": 36,
+      "endLine": 56,
+      "summary": "Defines reciprocalSum, HasUnitFractionSum (∑ 1/n = 1), and ContainsUnitFraction (∃ subset summing to 1)."
+    },
+    {
+      "id": "dense-subsets",
+      "title": "Part II: Dense Subsets of {1, ..., N}",
+      "startLine": 58,
+      "endLine": 72,
+      "summary": "Defines Icc1 (the interval {1,…,N}) and IsDenseSubset (A ⊆ Icc1 N with ∑ 1/a > δ log N)."
+    },
+    {
+      "id": "conjecture",
+      "title": "Part III: Erdős's Conjecture (Solved)",
+      "startLine": 74,
+      "endLine": 88,
+      "summary": "Defines ErdosConjecture47: for all δ > 0 and large N, dense subsets contain unit fraction subsets."
+    },
+    {
+      "id": "bloom",
+      "title": "Part IV: Bloom's Theorem",
+      "startLine": 90,
+      "endLine": 114,
+      "summary": "Axiom bloom_theorem: the conjecture is true. Axiom bloom_quantitative: explicit threshold with triple-log."
+    },
+    {
+      "id": "liu-sawhney",
+      "title": "Part V: Liu–Sawhney Improvement",
+      "startLine": 116,
+      "endLine": 128,
+      "summary": "Axiom: threshold improved to (log N)^{4/5+ε} for any ε > 0."
+    },
+    {
+      "id": "pomerance",
+      "title": "Part VI: Pomerance's Optimality",
+      "startLine": 130,
+      "endLine": 142,
+      "summary": "Axiom: sets with ∑ 1/a ≈ (log log N)² exist without unit fraction subsets, showing optimality."
+    },
+    {
+      "id": "summary",
+      "title": "Part VII: Summary",
+      "startLine": 144,
+      "endLine": 154,
+      "summary": "Theorem erdos_47_summary: the conjecture equals bloom_theorem."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős Problem #47 is solved: dense subsets of {1, …, N} always contain unit fraction subsets. Bloom proved the conjecture; Liu–Sawhney improved the quantitative bound. Pomerance showed near-optimality.",
+    "implications": "The result connects additive combinatorics to Egyptian fractions. The quantitative gap between (log N)^{4/5} and (log log N)² remains open.",
+    "openQuestions": [
+      "What is the exact threshold for guaranteed unit fraction subsets?",
+      "Can the Liu–Sawhney bound be improved further toward (log log N)²?",
+      "What structural properties characterize sets avoiding unit fraction subsets?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- **Erdős Problem #47** (Unit Fractions from Dense Sets): If A ⊆ {1,…,N} has ∑ 1/a > δ log N, must some S ⊆ A have ∑ 1/n = 1? **SOLVED** by Bloom [Bl21]
- Formalized reciprocalSum, HasUnitFractionSum, ContainsUnitFraction, IsDenseSubset, ErdosConjecture47
- Bloom's theorem + quantitative bound, Liu–Sawhney improvement to (log N)^{4/5+o(1)}, Pomerance lower bound
- 154 lines, 0 sorries, 6 annotations, badge: axiom

## Test plan
- [x] `pnpm build` passes
- [x] All content files (Lean, meta.json, annotations.json, index.ts) created
- [x] listings.json updated with erdos-47 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)