### PR TITLE
Enhance Erdős #122: Distribution of n + f(n) in short intervals

### DIFF
--- a/proofs/Proofs/Erdos122Problem.lean
+++ b/proofs/Proofs/Erdos122Problem.lean
@@ -1,0 +1,157 @@
+/-!
+# Erdős Problem #122: Distribution of n + f(n) in Short Intervals
+
+**Source:** [erdosproblems.com/122](https://erdosproblems.com/122)
+**Status:** OPEN (Erdős–Pomerance–Sárközy)
+
+## Statement
+
+For which number-theoretic functions f is it true that, for any F(n)
+with f(n)/F(n) → 0 for almost all n, there are infinitely many x
+such that #{n : n + f(n) ∈ (x, x + F(x))} / F(x) → ∞?
+
+## Background
+
+Erdős, Pomerance, and Sárközy [ErPoSa97] proved this holds for
+f = d (divisor function) and f = ω (number of distinct prime divisors).
+Erdős conjectured it fails for f = φ (Euler's totient) and f = σ
+(sum of divisors).
+
+## Approach
+
+We formalize the key predicate: a function f has the "short interval
+concentration property" if the counting function grows faster than
+F(x) for infinitely many x, whenever f(n)/F(n) → 0 a.e.
+-/
+
+import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Order.Filter.Basic
+import Mathlib.Tactic
+
+open Filter
+
+namespace Erdos122
+
+/-! ## Part I: Number-Theoretic Functions -/
+
+/--
+The divisor function d(n): number of positive divisors of n.
+-/
+def divisorCount (n : ℕ) : ℕ :=
+  (Finset.range (n + 1)).filter (fun d => d > 0 ∧ n % d = 0) |>.card
+
+/--
+The number of distinct prime divisors ω(n).
+-/
+def distinctPrimeCount (n : ℕ) : ℕ :=
+  (Finset.range (n + 1)).filter (fun p => p.Prime ∧ n % p = 0) |>.card
+
+/--
+Euler's totient function φ(n): count of k ≤ n with gcd(k, n) = 1.
+-/
+def eulerTotient (n : ℕ) : ℕ :=
+  (Finset.range n).filter (fun k => Nat.Coprime (k + 1) n) |>.card
+
+/--
+Sum of divisors σ(n): sum of all positive divisors of n.
+-/
+def sumOfDivisors (n : ℕ) : ℕ :=
+  ((Finset.range (n + 1)).filter (fun d => d > 0 ∧ n % d = 0)).sum id
+
+/-! ## Part II: Counting in Intervals -/
+
+/--
+Count of n with n + f(n) in the interval (x, x + F(x)].
+-/
+def countInInterval (f : ℕ → ℕ) (F : ℕ → ℕ) (x : ℕ) : ℕ :=
+  (Finset.range (x + F x + 1)).filter
+    (fun n => n + f n > x ∧ n + f n ≤ x + F x) |>.card
+
+/--
+The growth condition: f(n)/F(n) → 0 for almost all n.
+Formalized as: for all ε > 0, the set of n with f(n) ≥ ε · F(n)
+has natural density 0.
+-/
+def GrowthDominates (f : ℕ → ℕ) (F : ℕ → ℕ) : Prop :=
+  ∀ ε : ℚ, ε > 0 →
+    ∀ δ : ℚ, δ > 0 →
+      ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ →
+        ((Finset.range N).filter (fun n => (f n : ℚ) ≥ ε * F n)).card < δ * N
+
+/-! ## Part III: The Short Interval Concentration Property -/
+
+/--
+**Short interval concentration property (SICP):**
+A function f has SICP if for every F with f(n)/F(n) → 0 a.e.,
+there are infinitely many x with #{n : n + f(n) ∈ (x, x+F(x))} / F(x) → ∞.
+
+Formally: for every F dominating f and every C > 0, there are
+infinitely many x with countInInterval f F x > C · F(x).
+-/
+def HasSICP (f : ℕ → ℕ) : Prop :=
+  ∀ F : ℕ → ℕ, (∀ n, F n ≥ 1) →
+    GrowthDominates f F →
+    ∀ C : ℕ, C ≥ 1 →
+      ∀ x₀ : ℕ, ∃ x : ℕ, x ≥ x₀ ∧
+        countInInterval f F x > C * F x
+
+/-! ## Part IV: Known Results -/
+
+/--
+**Erdős–Pomerance–Sárközy Theorem [ErPoSa97]:**
+The divisor function d has SICP.
+-/
+axiom divisor_count_has_SICP : HasSICP divisorCount
+
+/--
+**Erdős–Pomerance–Sárközy Theorem (variant):**
+The distinct prime count function ω has SICP.
+-/
+axiom prime_count_has_SICP : HasSICP distinctPrimeCount
+
+/-! ## Part V: Conjectured Failures -/
+
+/--
+**Erdős's conjecture: φ fails SICP.**
+Euler's totient function does NOT have the short interval
+concentration property.
+-/
+def ErdosConjecture122_phi : Prop :=
+  ¬HasSICP eulerTotient
+
+/--
+**Erdős's conjecture: σ fails SICP.**
+The sum of divisors function does NOT have the short interval
+concentration property.
+-/
+def ErdosConjecture122_sigma : Prop :=
+  ¬HasSICP sumOfDivisors
+
+/--
+**Combined Erdős Problem #122:**
+Characterize which number-theoretic functions have SICP.
+The divisor function and distinct prime count do; Euler's totient
+and sum of divisors conjecturally do not.
+-/
+def ErdosProblem122 : Prop :=
+  HasSICP divisorCount ∧
+  HasSICP distinctPrimeCount ∧
+  ¬HasSICP eulerTotient ∧
+  ¬HasSICP sumOfDivisors
+
+/-! ## Part VI: Summary -/
+
+/--
+**Summary:**
+Erdős Problem #122 asks which number-theoretic functions have the
+short interval concentration property. The divisor function and ω
+are known to have it; φ and σ are conjectured not to. The general
+characterization remains open.
+-/
+theorem erdos_122_known_results :
+    HasSICP divisorCount ∧ HasSICP distinctPrimeCount :=
+  ⟨divisor_count_has_SICP, prime_count_has_SICP⟩
+
+end Erdos122

--- a/src/data/proofs/erdos-122/annotations.json
+++ b/src/data/proofs/erdos-122/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "erdos-122-functions",
+    "proofId": "erdos-122",
+    "type": "definition",
+    "range": { "startLine": 39, "endLine": 61 },
+    "title": "Arithmetic Functions",
+    "content": "Four standard functions: divisorCount d(n), distinctPrimeCount ω(n), eulerTotient φ(n), sumOfDivisors σ(n). The problem classifies which have the short interval concentration property.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-122-counting",
+    "proofId": "erdos-122",
+    "type": "definition",
+    "range": { "startLine": 65, "endLine": 81 },
+    "title": "Interval Counting and Growth Dominance",
+    "content": "countInInterval counts n with n + f(n) in (x, x+F(x)]. GrowthDominates formalizes f(n)/F(n) → 0 for almost all n via natural density.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-122-sicp",
+    "proofId": "erdos-122",
+    "type": "definition",
+    "range": { "startLine": 85, "endLine": 98 },
+    "title": "Short Interval Concentration Property",
+    "content": "HasSICP: for every dominating F and constant C ≥ 1, there exist infinitely many x where the count of n + f(n) in (x, x+F(x)] exceeds C · F(x). This is the central property in Problem #122.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-122-known",
+    "proofId": "erdos-122",
+    "type": "result",
+    "range": { "startLine": 102, "endLine": 112 },
+    "title": "Erdős–Pomerance–Sárközy Theorem",
+    "content": "The divisor function d(n) and distinct prime count ω(n) have SICP. Proved in [ErPoSa97]. These are the only known positive cases.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-122-conjectures",
+    "proofId": "erdos-122",
+    "type": "conjecture",
+    "range": { "startLine": 116, "endLine": 142 },
+    "title": "Conjectured Failures for φ and σ",
+    "content": "Erdős conjectured that Euler's totient φ(n) and sum of divisors σ(n) do NOT have SICP. ErdosProblem122 combines all four claims. The general classification remains open.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-122-summary",
+    "proofId": "erdos-122",
+    "type": "context",
+    "range": { "startLine": 146, "endLine": 157 },
+    "title": "Summary and Known Results",
+    "content": "Theorem erdos_122_known_results combines the two positive axioms. The problem asks for a complete characterization: which arithmetic functions have SICP?",
+    "significance": "supporting"
+  }
+]

--- a/src/data/proofs/erdos-122/index.ts
+++ b/src/data/proofs/erdos-122/index.ts
@@ -1,0 +1,42 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos122Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-122/meta.json
+++ b/src/data/proofs/erdos-122/meta.json
@@ -1,0 +1,88 @@
+{
+  "id": "erdos-122",
+  "title": "Erdős Problem #122: Distribution of n + f(n) in Short Intervals",
+  "slug": "erdos-122",
+  "description": "For which f is it true that n + f(n) concentrates in short intervals? Proved for d(n) and ω(n) by Erdős–Pomerance–Sárközy. Conjectured false for φ(n) and σ(n). OPEN.",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/122",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos122Problem.lean",
+    "tags": [
+      "number-theory",
+      "arithmetic-functions",
+      "distribution",
+      "short-intervals"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 122,
+    "erdosUrl": "https://erdosproblems.com/122",
+    "erdosProblemStatus": "open"
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #122 (Erdős–Pomerance–Sárközy, [ErPoSa97]) asks which number-theoretic functions f have the property that n + f(n) concentrates in short intervals. Known for divisor count d and distinct prime count ω; conjectured false for Euler's totient φ and sum of divisors σ.",
+    "problemStatement": "For which f does #{n : n + f(n) ∈ (x, x + F(x))} / F(x) → ∞ for infinitely many x, whenever f(n)/F(n) → 0 a.e.? OPEN (general characterization).",
+    "proofStrategy": "We define the Short Interval Concentration Property (SICP) using Finset counting and natural density. The Erdős–Pomerance–Sárközy theorem (for d and ω) is axiomatized. Conjectured failures for φ and σ are stated as definitions.",
+    "keyInsights": [
+      "The divisor function d(n) and distinct prime count ω(n) have SICP (proved)",
+      "Euler's totient φ(n) and sum of divisors σ(n) are conjectured to lack SICP",
+      "SICP captures how n + f(n) concentrates relative to short intervals (x, x+F(x))",
+      "The general characterization of which functions have SICP remains open",
+      "The problem connects arithmetic function distribution to interval analysis"
+    ]
+  },
+  "sections": [
+    {
+      "id": "arithmetic-functions",
+      "title": "Part I: Number-Theoretic Functions",
+      "startLine": 37,
+      "endLine": 61,
+      "summary": "Defines divisorCount d(n), distinctPrimeCount ω(n), eulerTotient φ(n), and sumOfDivisors σ(n)."
+    },
+    {
+      "id": "counting",
+      "title": "Part II: Counting in Intervals",
+      "startLine": 63,
+      "endLine": 81,
+      "summary": "Defines countInInterval (counting n + f(n) in (x, x+F(x)]) and GrowthDominates (f/F → 0 a.e.)."
+    },
+    {
+      "id": "sicp",
+      "title": "Part III: The Short Interval Concentration Property",
+      "startLine": 83,
+      "endLine": 98,
+      "summary": "Defines HasSICP: for every dominating F and constant C, infinitely many x have count > C·F(x)."
+    },
+    {
+      "id": "known-results",
+      "title": "Part IV: Known Results",
+      "startLine": 100,
+      "endLine": 112,
+      "summary": "Axioms: divisor_count_has_SICP and prime_count_has_SICP (Erdős–Pomerance–Sárközy theorem)."
+    },
+    {
+      "id": "conjectures",
+      "title": "Part V: Conjectured Failures",
+      "startLine": 114,
+      "endLine": 142,
+      "summary": "States ErdosConjecture122_phi (¬HasSICP φ), ErdosConjecture122_sigma (¬HasSICP σ), and combined ErdosProblem122."
+    },
+    {
+      "id": "summary",
+      "title": "Part VI: Summary",
+      "startLine": 144,
+      "endLine": 157,
+      "summary": "Theorem erdos_122_known_results: d and ω have SICP (from axioms)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős Problem #122 asks which arithmetic functions have the short interval concentration property. d(n) and ω(n) do (Erdős–Pomerance–Sárközy); φ(n) and σ(n) conjecturally do not. The general characterization is open.",
+    "implications": "The SICP distinguishes arithmetic functions by their distributional behavior. Functions with irregular growth (like d and ω) tend to concentrate, while smooth functions (like φ and σ) may not.",
+    "openQuestions": [
+      "Does φ(n) truly fail SICP?",
+      "Does σ(n) truly fail SICP?",
+      "Can a general criterion be given for which functions have SICP?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- **Erdős Problem #122** (Erdős–Pomerance–Sárközy): For which arithmetic functions f does n + f(n) concentrate in short intervals? **OPEN** (general characterization)
- Defines Short Interval Concentration Property (SICP) with countInInterval and GrowthDominates
- Known: d(n) and ω(n) have SICP (Erdős–Pomerance–Sárközy theorem, axiomatized)
- Conjectured: φ(n) and σ(n) do NOT have SICP
- 157 lines, 0 sorries, 6 annotations, badge: axiom

## Test plan
- [x] `pnpm build` passes
- [x] All content files (Lean, meta.json, annotations.json, index.ts) created
- [x] listings.json updated with erdos-122 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)