### PR TITLE
Enhance erdos-125: Positive Density of Digit-Restricted Sumsets

### DIFF
--- a/proofs/Proofs/Erdos125Problem.lean
+++ b/proofs/Proofs/Erdos125Problem.lean
@@ -1,0 +1,106 @@
+/-!
+# Erdős Problem #125: Positive Density of Digit-Restricted Sumsets
+
+Let A = {Σ εₖ3ᵏ : εₖ ∈ {0,1}} (integers with digits 0,1 in base 3)
+and B = {Σ εₖ4ᵏ : εₖ ∈ {0,1}} (digits 0,1 in base 4). Does A + B
+have positive density?
+
+## Status: OPEN
+
+## References
+- Burr–Erdős–Graham–Li (1996)
+- Erdős (1997)
+- Melfi (2001): |C∩[1,x]| ≫ x^{0.965}
+- Hasler–Melfi (2024): improved to x^{0.9777}, upper density ≤ 0.696
+-/
+
+import Mathlib.Data.Nat.Digits
+import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Real.Basic
+import Mathlib.Order.Filter.Basic
+import Mathlib.Tactic
+
+/-!
+## Section I: Digit-Restricted Sets
+-/
+
+/-- The set of natural numbers whose base-b digits are all 0 or 1.
+These are sums of distinct powers of b. -/
+def digitSet (b : ℕ) : Set ℕ :=
+  { n : ℕ | ∀ d ∈ Nat.digits b n, d = 0 ∨ d = 1 }
+
+/-- A = digitSet 3: numbers with only digits 0, 1 in base 3.
+Also known as the "Cantor set integers". -/
+def setA : Set ℕ := digitSet 3
+
+/-- B = digitSet 4: numbers with only digits 0, 1 in base 4. -/
+def setB : Set ℕ := digitSet 4
+
+/-!
+## Section II: The Sumset
+-/
+
+/-- The sumset C = A + B = { a + b : a ∈ A, b ∈ B }. -/
+def setC : Set ℕ := { n : ℕ | ∃ a ∈ setA, ∃ b ∈ setB, n = a + b }
+
+/-- The counting function: |C ∩ [1, x]|. -/
+noncomputable def countingC (x : ℕ) : ℕ :=
+  (Finset.range (x + 1)).filter (· ∈ setC) |>.card
+
+/-!
+## Section III: The Conjecture
+-/
+
+/-- **Erdős Problem #125**: Does C = A + B have positive lower density?
+That is, does lim inf |C ∩ [1,x]| / x > 0? -/
+def ErdosProblem125 : Prop :=
+  ∃ δ : ℝ, δ > 0 ∧
+    ∀ ε : ℝ, ε > 0 → ∃ N₀ : ℕ,
+      ∀ x : ℕ, x ≥ N₀ → (countingC x : ℝ) / x ≥ δ - ε
+
+/-!
+## Section IV: Known Lower Bounds
+-/
+
+/-- Melfi (2001): |C ∩ [1,x]| ≫ x^{0.965}. -/
+axiom melfi_lower_bound :
+  ∃ c : ℝ, c > 0 ∧ ∃ N₀ : ℕ,
+    ∀ x : ℕ, x ≥ N₀ → (countingC x : ℝ) ≥ c * (x : ℝ) ^ (0.965 : ℝ)
+
+/-- Hasler–Melfi (2024): improved to |C ∩ [1,x]| ≫ x^{0.9777}. -/
+axiom hasler_melfi_lower_bound :
+  ∃ c : ℝ, c > 0 ∧ ∃ N₀ : ℕ,
+    ∀ x : ℕ, x ≥ N₀ → (countingC x : ℝ) ≥ c * (x : ℝ) ^ (0.9777 : ℝ)
+
+/-!
+## Section V: Upper Density Bound
+-/
+
+/-- Hasler–Melfi (2024): the upper density of C is at most ≈ 0.696.
+So even if C has positive density, it cannot fill more than 70% of ℕ. -/
+axiom upper_density_bound :
+  ∀ ε : ℝ, ε > 0 → ∃ N₀ : ℕ, ∀ x : ℕ, x ≥ N₀ →
+    (countingC x : ℝ) / x ≤ 0.696 + ε
+
+/-!
+## Section VI: Generalization to Other Bases
+-/
+
+/-- The general problem: for bases n₁ < ⋯ < nₖ, does
+digitSet(n₁) + ⋯ + digitSet(nₖ) have positive density when
+Σ log_{nₖ}(2) > 1? This condition ensures the sumset is
+large enough to potentially have positive density. -/
+def GeneralizedDensityQuestion (bases : List ℕ) : Prop :=
+  (∀ b ∈ bases, b ≥ 2) →
+    (bases.map (fun b => Real.log 2 / Real.log b)).sum > 1 →
+      ∃ δ : ℝ, δ > 0 ∧
+        ∀ ε : ℝ, ε > 0 → ∃ N₀ : ℕ,
+          ∀ x : ℕ, x ≥ N₀ →
+            (countingC x : ℝ) / x ≥ δ - ε
+
+/-- For bases 3 and 4: log₄(2) + log₄(2)/log₄(3) =
+log(2)/log(3) + log(2)/log(4) ≈ 0.631 + 0.5 = 1.131 > 1,
+satisfying the condition. -/
+axiom base_3_4_satisfies_condition :
+  Real.log 2 / Real.log 3 + Real.log 2 / Real.log 4 > 1

--- a/src/data/proofs/erdos-125/annotations.json
+++ b/src/data/proofs/erdos-125/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "erdos-125-digits",
+    "proofId": "erdos-125",
+    "type": "definition",
+    "range": { "startLine": 28, "endLine": 38 },
+    "title": "Digit-Restricted Sets",
+    "content": "digitSet b is the set of natural numbers with only digits 0,1 in base b. setA = digitSet 3 and setB = digitSet 4 are the specific sets in the problem.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-125-sumset",
+    "proofId": "erdos-125",
+    "type": "definition",
+    "range": { "startLine": 44, "endLine": 49 },
+    "title": "The Sumset C = A + B",
+    "content": "setC = A + B is the sumset. countingC x = |C ∩ [0, x]| counts elements up to x.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-125-conjecture",
+    "proofId": "erdos-125",
+    "type": "conjecture",
+    "range": { "startLine": 55, "endLine": 60 },
+    "title": "Erdős Problem 125",
+    "content": "Does C = A + B have positive lower density? That is, is lim inf |C ∩ [1,x]|/x > 0?",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-125-lower",
+    "proofId": "erdos-125",
+    "type": "result",
+    "range": { "startLine": 66, "endLine": 74 },
+    "title": "Counting Lower Bounds",
+    "content": "Melfi (2001): |C ∩ [1,x]| ≫ x^{0.965}. Hasler–Melfi (2024): improved to x^{0.9777}. Nearly linear growth but not yet linear.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-125-upper",
+    "proofId": "erdos-125",
+    "type": "result",
+    "range": { "startLine": 80, "endLine": 84 },
+    "title": "Upper Density Bound",
+    "content": "Hasler–Melfi (2024): the upper density of C is at most ≈ 0.696, so C misses a positive fraction of ℕ.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-125-general",
+    "proofId": "erdos-125",
+    "type": "context",
+    "range": { "startLine": 90, "endLine": 107 },
+    "title": "Generalization",
+    "content": "For bases n₁ < ⋯ < nₖ with Σ log_{nᵢ}(2) > 1, does the sumset of digit sets have positive density? For bases 3,4 the sum ≈ 1.131 > 1.",
+    "significance": "supporting"
+  }
+]

--- a/src/data/proofs/erdos-125/index.ts
+++ b/src/data/proofs/erdos-125/index.ts
@@ -1,0 +1,28 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos125Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id, title: meta.title, slug: meta.slug,
+  description: meta.description, meta: meta.meta,
+  sections: meta.sections, source: '',
+  overview: meta.overview, conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -1,0 +1,82 @@
+{
+  "id": "erdos-125",
+  "title": "Erdős Problem #125: Positive Density of Digit-Restricted Sumsets",
+  "slug": "erdos-125",
+  "description": "Let A = {digits 0,1 in base 3}, B = {digits 0,1 in base 4}. Does A + B have positive density? Known: |A+B ∩ [1,x]| ≫ x^{0.9777}, upper density ≤ 0.696. OPEN.",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/125",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos125Problem.lean",
+    "tags": ["number-theory", "base-representations", "density", "additive-combinatorics"],
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 125,
+    "erdosUrl": "https://erdosproblems.com/125",
+    "erdosProblemStatus": "open"
+  },
+  "overview": {
+    "historicalContext": "Burr, Erdős, Graham, and Li (1996) posed this question about digit-restricted sets. Melfi (2001) proved the counting function grows as x^{0.965}. Hasler and Melfi (2024) improved this to x^{0.9777} and showed the upper density is at most 0.696. The question of positive lower density remains open.",
+    "problemStatement": "Let A = {n ∈ ℕ : digits of n in base 3 are all 0 or 1} and B = {n ∈ ℕ : digits in base 4 are all 0 or 1}. Does A + B have positive lower density?",
+    "proofStrategy": "We define digitSet b (numbers with only 0,1 digits in base b), setA = digitSet 3, setB = digitSet 4, and setC = A + B. ErdosProblem125 asks if lim inf |C ∩ [1,x]|/x > 0. Melfi's and Hasler–Melfi's bounds are axiomatized. The generalization to multiple bases and the log-sum condition are stated.",
+    "keyInsights": [
+      "A and B are 'Cantor set integers' — sparse but structured subsets of ℕ",
+      "The counting function |C ∩ [1,x]| grows nearly linearly (exponent > 0.977)",
+      "Upper density ≤ 0.696 shows C cannot be all of ℕ even if dense",
+      "The condition log₃(2) + log₄(2) > 1 governs the generalization"
+    ]
+  },
+  "sections": [
+    {
+      "id": "digit-sets",
+      "title": "Digit-Restricted Sets",
+      "startLine": 24,
+      "endLine": 38,
+      "summary": "Defines digitSet b, setA (base 3), and setB (base 4)."
+    },
+    {
+      "id": "sumset",
+      "title": "The Sumset",
+      "startLine": 40,
+      "endLine": 49,
+      "summary": "Defines setC = A + B and countingC |C ∩ [1,x]|."
+    },
+    {
+      "id": "conjecture",
+      "title": "The Conjecture",
+      "startLine": 51,
+      "endLine": 60,
+      "summary": "States ErdosProblem125: does C have positive lower density?"
+    },
+    {
+      "id": "lower-bounds",
+      "title": "Known Lower Bounds",
+      "startLine": 62,
+      "endLine": 74,
+      "summary": "Melfi (2001): ≫ x^{0.965}. Hasler–Melfi (2024): ≫ x^{0.9777}."
+    },
+    {
+      "id": "upper-density",
+      "title": "Upper Density Bound",
+      "startLine": 76,
+      "endLine": 84,
+      "summary": "Hasler–Melfi (2024): upper density ≤ 0.696."
+    },
+    {
+      "id": "generalization",
+      "title": "Generalization to Other Bases",
+      "startLine": 86,
+      "endLine": 107,
+      "summary": "General question for multiple bases with Σ log_b(2) > 1 condition."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős Problem 125 asks whether the sumset of base-3 and base-4 'Cantor integers' has positive density. The counting function is nearly linear but positive density is unproved.",
+    "implications": "Understanding this would connect digital properties of integers to additive structure, bridging fractal geometry and number theory.",
+    "openQuestions": [
+      "Does A + B have positive lower density?",
+      "What is the exact lower density if it exists?",
+      "Does the generalization hold for all pairwise coprime bases satisfying the log condition?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Full rewrite from formal-conjectures: Erdős Problem #125 on digit-restricted sumsets
- Defines `digitSet`, `setA` (base 3), `setB` (base 4), `setC` = A + B, `countingC`
- States `ErdosProblem125`: does A + B have positive lower density? (OPEN)
- Axiomatizes Melfi (2001) x^{0.965} bound, Hasler–Melfi (2024) x^{0.9777} improvement
- Upper density bound ≤ 0.696 and generalization to multiple bases
- 107 lines Lean, 0 sorries, 6 sections, 6 annotations

## Test plan
- [x] `pnpm build` passes
- [x] 0 sorries in Lean source
- [x] All gallery files valid JSON/TypeScript

🤖 Generated with [Claude Code](https://claude.com/claude-code)