### PR TITLE
enhance(erdos-327): Sum-Divides-Product Avoidance

### DIFF
--- a/proofs/Proofs/Erdos327Problem.lean
+++ b/proofs/Proofs/Erdos327Problem.lean
@@ -1,0 +1,89 @@
+/-!
+# Erdős Problem 327: Sum-Divides-Product Avoidance
+
+Let `A ⊆ {1, ..., N}` have the property that for all distinct `a, b ∈ A`,
+`a + b ∤ a * b`. Note that `a + b ∣ a * b` iff `1/a + 1/b` is a unit fraction.
+
+Can `A` be substantially larger than the set of odd numbers in `{1, ..., N}`?
+
+Van Doorn showed: if `|A| ≥ (25/28 + o(1)) * N`, then `A` must contain
+`a ≠ b` with `a + b ∣ a * b`.
+
+A variant asks: if `a + b ∤ 2 * a * b` for all distinct `a, b ∈ A`, must `|A| = o(N)`?
+
+*Reference:* [erdosproblems.com/327](https://www.erdosproblems.com/327)
+-/
+
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Nat.Defs
+import Mathlib.Order.Filter.Basic
+import Mathlib.Tactic
+
+open Finset
+
+/-! ## Sum-divides-product property -/
+
+/-- `SumNotDvdProd A` means for all distinct `a, b ∈ A`, `a + b ∤ a * b`. -/
+def SumNotDvdProd (A : Finset ℕ) : Prop :=
+    ∀ a ∈ A, ∀ b ∈ A, a ≠ b → ¬(a + b ∣ a * b)
+
+/-- `SumNotDvdTwoProd A` means for all distinct `a, b ∈ A`, `a + b ∤ 2 * a * b`. -/
+def SumNotDvdTwoProd (A : Finset ℕ) : Prop :=
+    ∀ a ∈ A, ∀ b ∈ A, a ≠ b → ¬(a + b ∣ 2 * a * b)
+
+/-- The maximum size of a subset of `{1, ..., N}` with `SumNotDvdProd`. -/
+noncomputable def maxAvoidSize (N : ℕ) : ℕ :=
+    ((Finset.Icc 1 N).powerset.filter SumNotDvdProd).sup Finset.card
+
+/-! ## Main conjecture -/
+
+/-- Erdős Problem 327: The maximum size of a SumNotDvdProd subset of `{1,...,N}`
+is asymptotically at most `N/2 + o(N)` (no larger than the odd numbers). -/
+def ErdosProblem327 : Prop :=
+    ∀ ε : ℝ, 0 < ε → ∃ N₀ : ℕ, ∀ N : ℕ, N₀ ≤ N →
+      (maxAvoidSize N : ℝ) ≤ (1 / 2 + ε) * N
+
+/-! ## Van Doorn's bound -/
+
+/-- Van Doorn's result: if `|A| ≥ (25/28) * N`, then `A` contains `a ≠ b`
+with `a + b ∣ a * b`. -/
+axiom vanDoorn_bound (N : ℕ) (A : Finset ℕ) :
+    A ⊆ Finset.Icc 1 N → (25 * N ≤ 28 * A.card) →
+      ∃ a ∈ A, ∃ b ∈ A, a ≠ b ∧ a + b ∣ a * b
+
+/-! ## Variant: factor-of-2 condition -/
+
+/-- Variant conjecture: if `a + b ∤ 2ab` for distinct `a, b ∈ A ⊆ {1,...,N}`,
+then `|A| = o(N)`. -/
+def ErdosProblem327_variant : Prop :=
+    ∀ ε : ℝ, 0 < ε → ∃ N₀ : ℕ, ∀ N : ℕ, N₀ ≤ N →
+      ∀ A : Finset ℕ, A ⊆ Finset.Icc 1 N → SumNotDvdTwoProd A →
+        (A.card : ℝ) ≤ ε * N
+
+/-! ## Unit fraction equivalence -/
+
+/-- `a + b ∣ a * b` iff `1/a + 1/b` is a unit fraction (i.e., `1/c` for some `c`). -/
+axiom sumDvdProd_iff_unitFraction (a b : ℕ) (ha : 0 < a) (hb : 0 < b) :
+    a + b ∣ a * b ↔ ∃ c : ℕ, 0 < c ∧ (1 : ℚ) / a + (1 : ℚ) / b = (1 : ℚ) / c
+
+/-! ## Basic properties -/
+
+/-- The empty set trivially satisfies SumNotDvdProd. -/
+theorem sumNotDvdProd_empty : SumNotDvdProd ∅ := by
+  intro a ha; exact absurd ha (Finset.not_mem_empty a)
+
+/-- A singleton trivially satisfies SumNotDvdProd. -/
+theorem sumNotDvdProd_singleton (n : ℕ) : SumNotDvdProd {n} := by
+  intro a ha b hb hab
+  rw [Finset.mem_singleton] at ha hb
+  exact absurd (ha.trans hb.symm) hab
+
+/-- If `B ⊆ A` and `A` has SumNotDvdProd, then so does `B`. -/
+theorem sumNotDvdProd_subset {A B : Finset ℕ} (h : B ⊆ A) (hA : SumNotDvdProd A) :
+    SumNotDvdProd B := fun a ha b hb => hA a (h ha) b (h hb)
+
+/-- The odd numbers in `{1,...,N}` satisfy SumNotDvdProd (since `a+b` is even
+but `a*b` is odd for odd `a, b`). -/
+axiom oddNumbers_sumNotDvdProd (N : ℕ) :
+    SumNotDvdProd ((Finset.Icc 1 N).filter (fun n => n % 2 = 1))

--- a/src/data/proofs/erdos-327/annotations.json
+++ b/src/data/proofs/erdos-327/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "erdos-327-property",
+    "proofId": "erdos-327",
+    "type": "definition",
+    "range": { "startLine": 28, "endLine": 29 },
+    "title": "SumNotDvdProd",
+    "content": "SumNotDvdProd A holds when for all distinct a,b ∈ A, a+b does not divide a*b.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-327-conjecture",
+    "proofId": "erdos-327",
+    "type": "conjecture",
+    "range": { "startLine": 43, "endLine": 45 },
+    "title": "Main Conjecture",
+    "content": "ErdosProblem327: maxAvoidSize(N) ≤ (1/2 + ε)·N for all ε > 0.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-327-vandoorn",
+    "proofId": "erdos-327",
+    "type": "result",
+    "range": { "startLine": 51, "endLine": 53 },
+    "title": "Van Doorn's Bound",
+    "content": "If |A| ≥ (25/28)·N, then A contains distinct a,b with a+b | ab.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-327-variant",
+    "proofId": "erdos-327",
+    "type": "conjecture",
+    "range": { "startLine": 59, "endLine": 62 },
+    "title": "Factor-of-2 Variant",
+    "content": "If a+b ∤ 2ab for distinct a,b ∈ A ⊆ {1,...,N}, then |A| = o(N).",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-327-unitfraction",
+    "proofId": "erdos-327",
+    "type": "result",
+    "range": { "startLine": 67, "endLine": 68 },
+    "title": "Unit Fraction Equivalence",
+    "content": "a+b | ab iff 1/a + 1/b is a unit fraction 1/c for some positive c.",
+    "significance": "essential"
+  }
+]

--- a/src/data/proofs/erdos-327/index.ts
+++ b/src/data/proofs/erdos-327/index.ts
@@ -1,0 +1,34 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos327Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-327/meta.json
+++ b/src/data/proofs/erdos-327/meta.json
@@ -1,0 +1,45 @@
+{
+  "id": "erdos-327",
+  "title": "Sum-Divides-Product Avoidance",
+  "slug": "erdos-327",
+  "description": "How large can A ⊆ {1,...,N} be if a+b ∤ ab for all distinct a,b ∈ A? Equivalently, no pair has 1/a+1/b a unit fraction. Odd numbers give N/2; van Doorn shows 25/28·N is a threshold.",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/327",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos327Problem.lean",
+    "tags": ["number-theory", "unit-fractions", "extremal-combinatorics", "divisibility"],
+    "badge": "formalized",
+    "sorries": 0,
+    "erdosNumber": 327,
+    "erdosUrl": "https://erdosproblems.com/327",
+    "erdosProblemStatus": "open"
+  },
+  "overview": {
+    "historicalContext": "Erdős asked whether a subset of {1,...,N} avoiding the condition a+b | ab (equivalently, 1/a+1/b being a unit fraction) can be substantially larger than the odd numbers. Van Doorn proved that any set of size ≥ (25/28)N must contain such a pair. A variant with 2ab replacing ab asks whether avoiding sets must have o(N) elements.",
+    "problemStatement": "Let A ⊆ {1,...,N} with a+b ∤ ab for all distinct a,b ∈ A. Can |A| > (1/2+ε)N for some ε > 0?",
+    "proofStrategy": "We define SumNotDvdProd and SumNotDvdTwoProd as avoiding conditions, maxAvoidSize as the extremal function. The main conjecture states maxAvoidSize(N) ≤ (1/2+ε)N. Van Doorn's bound and the unit-fraction equivalence are axioms. Basic monotonicity properties are proved.",
+    "keyInsights": [
+      "a+b | ab is equivalent to 1/a + 1/b being a unit fraction 1/c",
+      "Odd numbers naturally avoid the condition since a+b is even but ab is odd",
+      "Van Doorn's threshold of 25/28 is the best known density bound",
+      "The factor-of-2 variant may force o(N) size"
+    ]
+  },
+  "sections": [
+    { "id": "property", "title": "Sum-Divides-Product Property", "startLine": 25, "endLine": 37, "summary": "Defines SumNotDvdProd, SumNotDvdTwoProd, and maxAvoidSize as extremal function." },
+    { "id": "conjecture", "title": "Main Conjecture", "startLine": 39, "endLine": 45, "summary": "States ErdosProblem327: maxAvoidSize(N) ≤ (1/2+ε)N for all ε > 0." },
+    { "id": "vandoorn", "title": "Van Doorn's Bound", "startLine": 47, "endLine": 53, "summary": "Van Doorn's result: |A| ≥ 25N/28 forces a pair with a+b | ab." },
+    { "id": "variant", "title": "Factor-of-2 Variant", "startLine": 55, "endLine": 68, "summary": "Variant conjecture with 2ab and unit-fraction equivalence axiom." },
+    { "id": "basic", "title": "Basic Properties", "startLine": 70, "endLine": 89, "summary": "Proves SumNotDvdProd for empty, singleton, and subsets. States odd-numbers result." }
+  ],
+  "conclusion": {
+    "summary": "The formalization captures Erdős Problem 327 on sum-divides-product avoidance, van Doorn's density bound, the factor-of-2 variant, and the unit-fraction equivalence. 0 sorries.",
+    "implications": "Resolution would clarify the extremal theory of unit-fraction avoidance sets and connect to Problems 301 and 302.",
+    "openQuestions": [
+      "Can A be larger than (1/2+ε)N for some ε > 0?",
+      "Is the 25/28 bound sharp?",
+      "Does the factor-of-2 variant force o(N) size?"
+    ]
+  }
+}

--- a/src/data/proofs/listings.json
+++ b/src/data/proofs/listings.json
@@ -2460,6 +2460,27 @@
     "annotationCount": 12
   },
   {
+    "id": "erdos-1105",
+    "title": "Erdős Problem #1105: Anti-Ramsey Numbers for Cycles and Paths",
+    "slug": "erdos-1105",
+    "description": "Determine exact formulas for the anti-Ramsey numbers AR(n, C_k) and AR(n, P_k), where AR(n,G) is the maximum number of colors in a rainbow-G-free edge-coloring of K_n.",
+    "status": "complete",
+    "badge": "axiom",
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "ramsey-theory",
+      "anti-ramsey",
+      "combinatorics",
+      "coloring",
+      "open"
+    ],
+    "erdosNumber": 1105,
+    "mathlibCount": 3,
+    "sorries": 1,
+    "annotationCount": 12
+  },
+  {
     "id": "erdos-1106",
     "title": "Erdős #1106: Prime Factors of Partition Products",
     "slug": "erdos-1106",
@@ -6671,6 +6692,23 @@
     "annotationCount": 8
   },
   {
+    "id": "erdos-327",
+    "title": "Sum-Divides-Product Avoidance",
+    "slug": "erdos-327",
+    "description": "How large can A ⊆ {1,...,N} be if a+b ∤ ab for all distinct a,b ∈ A? Equivalently, no pair has 1/a+1/b a unit fraction. Odd numbers give N/2; van Doorn shows 25/28·N is a threshold.",
+    "status": "formalized",
+    "badge": "formalized",
+    "tags": [
+      "number-theory",
+      "unit-fractions",
+      "extremal-combinatorics",
+      "divisibility"
+    ],
+    "erdosNumber": 327,
+    "sorries": 0,
+    "annotationCount": 5
+  },
+  {
     "id": "erdos-328",
     "title": "Erdős Problem #328: Partitioning Sets with Bounded Representation Function",
     "slug": "erdos-328",
@@ -8001,6 +8039,26 @@
     "annotationCount": 11
   },
   {
+    "id": "erdos-410",
+    "title": "Erdős Problem #410: Iterated Sum of Divisors Growth",
+    "slug": "erdos-410",
+    "description": "Does lim_{k → ∞} σₖ(n)^{1/k} = ∞ for all n ≥ 2, where σₖ is the k-th iterate of the sum of divisors function?",
+    "status": "complete",
+    "badge": "axiom",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "iterated-functions",
+      "sum-of-divisors",
+      "arithmetic-functions",
+      "open"
+    ],
+    "erdosNumber": 410,
+    "mathlibCount": 3,
+    "sorries": 10,
+    "annotationCount": 11
+  },
+  {
     "id": "erdos-412",
     "title": "Erdos Problem #412: Iterated Sum of Divisors Convergence",
     "slug": "erdos-412",
@@ -8151,6 +8209,27 @@
     "mathlibCount": 4,
     "sorries": 0,
     "annotationCount": 15
+  },
+  {
+    "id": "erdos-421",
+    "title": "Erdős Problem #421: Distinct Products in Dense Sequences",
+    "slug": "erdos-421",
+    "description": "Is there a strictly increasing sequence d₁ < d₂ < ... with density 1 such that all interval products ∏_{u ≤ i ≤ v} d_i are distinct?",
+    "status": "complete",
+    "badge": "axiom",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "sequences",
+      "products",
+      "density",
+      "distinct-products",
+      "open"
+    ],
+    "erdosNumber": 421,
+    "mathlibCount": 4,
+    "sorries": 0,
+    "annotationCount": 11
   },
   {
     "id": "erdos-425",
@@ -12139,6 +12218,26 @@
     "annotationCount": 15
   },
   {
+    "id": "erdos-684",
+    "title": "Erdős Problem #684: Smooth Parts of Binomial Coefficients",
+    "slug": "erdos-684",
+    "description": "Find bounds on f(n) = smallest k such that the k-smooth part of C(n,k) exceeds n².",
+    "status": "complete",
+    "badge": "axiom",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "primes",
+      "binomial-coefficients",
+      "smooth-numbers",
+      "open"
+    ],
+    "erdosNumber": 684,
+    "mathlibCount": 3,
+    "sorries": 5,
+    "annotationCount": 13
+  },
+  {
     "id": "erdos-69",
     "title": "Erdős Problem #69: Irrationality of Sum of Omega over Powers of 2",
     "slug": "erdos-69",
@@ -13851,6 +13950,27 @@
     "mathlibCount": 2,
     "sorries": 4,
     "annotationCount": 18
+  },
+  {
+    "id": "erdos-782",
+    "title": "Erdős Problem #782: Quasi-Progressions and Cubes in the Squares",
+    "slug": "erdos-782",
+    "description": "Two questions about structure in perfect squares: (1) Do squares contain arbitrarily long quasi-progressions with uniform bound C? (2) Do squares contain arbitrarily large combinatorial cubes?",
+    "status": "complete",
+    "badge": "axiom",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "additive-combinatorics",
+      "squares",
+      "progressions",
+      "combinatorial-cubes",
+      "open"
+    ],
+    "erdosNumber": 782,
+    "mathlibCount": 3,
+    "sorries": 0,
+    "annotationCount": 12
   },
   {
     "id": "erdos-784",


### PR DESCRIPTION
## Summary
- Formalize Erdős Problem 327 on sets avoiding a+b | ab (unit fraction pairs)
- Define `SumNotDvdProd`, `SumNotDvdTwoProd`, `maxAvoidSize` as extremal function
- State main conjecture, factor-of-2 variant, van Doorn's 25/28 bound, and unit-fraction equivalence
- Prove `sumNotDvdProd_empty` (absurd), `sumNotDvdProd_singleton` (mem_singleton), `sumNotDvdProd_subset` (fun application)
- 0 sorries, 5 annotations, 5 sections

## Test plan
- [x] `pnpm build` passes
- [x] Listings.json updated with correct lexicographic ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)