### PR TITLE
enhance(erdos-404): Prime Power Divisibility of Factorial Sums (OPEN)

### DIFF
--- a/src/data/proofs/erdos-404/index.ts
+++ b/src/data/proofs/erdos-404/index.ts
@@ -1,0 +1,34 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos404Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData


### PR DESCRIPTION
## Summary
- **Erdős Problem #404**: For which (a, p) is f(a, p) finite, where f(a, p) = sup{k : p^k | Σ aᵢ!}?
- Pre-enhanced Lean formalization with StrictIncSeq, factorialSum, f(a,p), Lin's bound f(2,2) ≤ 254
- Added missing `index.ts`, fixed listings.json (badge: open, mathlibCount: 7, sorries: 0, annotationCount: 9)
- 7 Mathlib imports, 0 sorries, 9 annotations, 8 sections
- **Status: OPEN**

## Test plan
- [x] `pnpm build` passes
- [x] All content files present (Lean, meta.json, annotations.json, index.ts)
- [x] listings.json entry correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)