### PR TITLE
Fix research pages: hide broken formal statements, render plain text LaTeX

### DIFF
--- a/src/pages/ResearchProblemPage.tsx
+++ b/src/pages/ResearchProblemPage.tsx
@@ -22,6 +22,17 @@ import {
   Archive
 } from 'lucide-react'
 
+function isValidFormalStatement(formal: string | undefined): boolean {
+  if (!formal || !formal.trim()) return false
+  // Navigation junk from scraper
+  if (formal.includes('Forum') || formal.includes('Favourites') || formal.includes('Random Solved')) return false
+  // Placeholder text
+  if (formal === '(LaTeX not available)') return false
+  // Another placeholder variant
+  if (formal.includes('\\text{(formal')) return false
+  return true
+}
+
 export function ResearchProblemPage() {
   const { slug } = useParams<{ slug: string }>()
   const [problem, setProblem] = useState<ResearchProblem | null>(null)
@@ -211,7 +222,7 @@ export function ResearchProblemPage() {
                     <FileText className="h-5 w-5 text-annotation" />
                     Problem Statement
                   </h2>
-                  {problem.problemStatement.formal && (
+                  {isValidFormalStatement(problem.problemStatement.formal) && (
                     <div className="bg-card border border-border rounded-lg p-4 mb-4">
                       <p className="text-xs text-muted-foreground mb-2 uppercase tracking-wide">Formal</p>
                       <div className="text-lg">
@@ -219,9 +230,9 @@ export function ResearchProblemPage() {
                       </div>
                     </div>
                   )}
-                  <p className="text-muted-foreground">
-                    {problem.problemStatement.plain}
-                  </p>
+                  <div className="text-muted-foreground">
+                    <MarkdownMath>{problem.problemStatement.plain}</MarkdownMath>
+                  </div>
                   {problem.problemStatement.whyMatters.length > 0 && (
                     <div className="mt-4">
                       <p className="text-sm font-medium mb-2">Why This Matters:</p>


### PR DESCRIPTION
## Summary
- Add `isValidFormalStatement()` helper to detect navigation junk, placeholder text, and other known-bad formal statement patterns
- Hide FORMAL section when content is invalid (affects 315/320 Erdős problems — 98.4%)
- Render plain text with `<MarkdownMath>` so inline LaTeX (`$...$`) renders properly
- Change plain text container from `<p>` to `<div>` for block-level math support

Phase 1 frontend resilience fix for #1370. Data cleanup (Phase 2) is separate.

## Test plan
- [ ] `/research/erdos-40` — no more "(LaTeXnotavailable)" in FORMAL box
- [ ] `/research/erdos-1013` — no more navigation junk in FORMAL box
- [ ] `/research/erdos-40` — plain text renders inline LaTeX properly
- [ ] `/research/erdos-12` — valid formal statement still displays correctly
- [ ] `pnpm build` passes

Closes #1370

🤖 Generated with [Claude Code](https://claude.com/claude-code)