### PR TITLE
Add validation to prevent broken research formal statements

### DIFF
--- a/scripts/erdos/generate-research.ts
+++ b/scripts/erdos/generate-research.ts
@@ -38,7 +38,7 @@ function generateProblemMd(problem: TransformedProblem): string {
     plainStatement = plainStatement.slice(0, 497) + '...'
   }
 
-  const formalStatement = problem.statement.latex || '(LaTeX not available)'
+  const formalStatement = problem.statement.latex || ''
 
   return `# Problem: Erdős #${problem.number}
 

--- a/scripts/erdos/playwright-fetch.ts
+++ b/scripts/erdos/playwright-fetch.ts
@@ -14,6 +14,20 @@ let page: Page | null = null
 const BASE_URL = 'https://erdosproblems.com'
 
 /**
+ * Validate that a LaTeX response contains actual mathematical content,
+ * not navigation junk from the website.
+ *
+ * Returns true if the content looks like valid LaTeX.
+ */
+function isValidLatexResponse(content: string): boolean {
+  if (!content || content.trim().length < 10) return false
+  if (content.startsWith('<!DOCTYPE') || content.startsWith('<html')) return false
+  if (content.includes('Forum') && content.includes('Favourites')) return false
+  if (content.includes('Random Solved') || content.includes('Random Open')) return false
+  return true
+}
+
+/**
  * Random delay between min and max milliseconds
  */
 function randomDelay(min: number, max: number): Promise<void> {
@@ -150,8 +164,9 @@ export async function fetchLatexWithPlaywright(
     // Get the page text content (LaTeX pages are plain text)
     const content = await browserPage.evaluate(() => document.body.innerText || document.body.textContent || '')
 
-    // Validate it's actually LaTeX, not HTML
-    if (content.startsWith('<!DOCTYPE') || content.startsWith('<html')) {
+    // Validate it's actual LaTeX content, not navigation junk or HTML
+    if (!isValidLatexResponse(content)) {
+      console.warn(`  Problem #${problemNumber}: Invalid LaTeX response (navigation junk or HTML detected)`)
       return null
     }
 

--- a/scripts/research/validate-data.sh
+++ b/scripts/research/validate-data.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# validate-data.sh - Check research data quality
+# Usage: ./scripts/research/validate-data.sh [--strict]
+# Exit code 0 = pass, 1 = fail (only in --strict mode)
+
+set -euo pipefail
+
+STRICT=false
+[[ "${1:-}" == "--strict" ]] && STRICT=true
+
+PROBLEMS_DIR="src/data/research/problems"
+issues=0
+
+# Check for navigation junk in formal statements
+junk_count=$(python3 -c "
+import json, glob
+count = sum(1 for f in glob.glob('${PROBLEMS_DIR}/erdos-*.json')
+            if 'Forum' in json.load(open(f)).get('problemStatement',{}).get('formal',''))
+print(count)
+")
+
+if [[ "$junk_count" -gt 0 ]]; then
+    echo "FAIL: $junk_count problems have navigation junk in formal statements"
+    ((issues++))
+else
+    echo "PASS: No navigation junk in formal statements"
+fi
+
+# Check for placeholder text
+placeholder_count=$(python3 -c "
+import json, glob
+count = sum(1 for f in glob.glob('${PROBLEMS_DIR}/erdos-*.json')
+            if json.load(open(f)).get('problemStatement',{}).get('formal','') == '(LaTeX not available)')
+print(count)
+")
+
+if [[ "$placeholder_count" -gt 0 ]]; then
+    echo "WARN: $placeholder_count problems have '(LaTeX not available)' placeholder"
+else
+    echo "PASS: No placeholder formal statements"
+fi
+
+# Check for HTML entities in plain text
+html_count=$(python3 -c "
+import json, glob
+count = sum(1 for f in glob.glob('${PROBLEMS_DIR}/erdos-*.json')
+            if '&lt;' in json.load(open(f)).get('problemStatement',{}).get('plain','')
+            or '&#x' in json.load(open(f)).get('problemStatement',{}).get('plain',''))
+print(count)
+")
+
+if [[ "$html_count" -gt 0 ]]; then
+    echo "WARN: $html_count problems have HTML entities in plain text"
+else
+    echo "PASS: No HTML entities in plain text"
+fi
+
+# Summary
+echo ""
+echo "=== Summary ==="
+echo "Navigation junk: $junk_count (FAIL if > 0)"
+echo "Placeholders: $placeholder_count (WARN)"
+echo "HTML entities: $html_count (WARN)"
+
+if [[ "$issues" -gt 0 ]] && $STRICT; then
+    echo ""
+    echo "STRICT MODE: $issues failures detected"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Add `isValidLatexResponse()` scraper validation to reject navigation junk from erdosproblems.com
- Change generator placeholder from literal `(LaTeX not available)` text to empty string
- Add standalone `scripts/research/validate-data.sh` data quality validation script

Phase 3 prevention for #1370.

## Test plan
- [ ] Scraper validation rejects strings containing 'Forum'/'Favourites'
- [ ] Generator uses empty string when LaTeX unavailable
- [ ] `./scripts/research/validate-data.sh` runs and reports current data quality
- [ ] `./scripts/research/validate-data.sh --strict` exits non-zero if junk found
- [ ] No regressions in existing scraper/generator behavior

Closes #1375

🤖 Generated with [Claude Code](https://claude.com/claude-code)