### PR TITLE
fix: write wrapper status messages to log file

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -49,10 +49,18 @@ GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-log_info() { echo -e "${BLUE}[wrapper]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[wrapper]${NC} $1"; }
-log_error() { echo -e "${RED}[wrapper]${NC} $1" >&2; }
-log_success() { echo -e "${GREEN}[wrapper]${NC} $1"; }
+log_to_file() {
+    if [[ -n "$LOG_FILE" ]]; then
+        local timestamp
+        timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        echo "[$timestamp] [wrapper] $1" >> "$LOG_FILE"
+    fi
+}
+
+log_info() { echo -e "${BLUE}[wrapper]${NC} $1"; log_to_file "$1"; }
+log_warn() { echo -e "${YELLOW}[wrapper]${NC} $1"; log_to_file "WARN: $1"; }
+log_error() { echo -e "${RED}[wrapper]${NC} $1" >&2; log_to_file "ERROR: $1"; }
+log_success() { echo -e "${GREEN}[wrapper]${NC} $1"; log_to_file "$1"; }
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Summary

- Adds `log_to_file()` helper function that writes timestamped, plain-text messages to `$LOG_FILE` when set
- Updates all four log functions (`log_info`, `log_warn`, `log_error`, `log_success`) to call `log_to_file()` alongside their terminal output
- Wrapper status messages (retry attempts, backoff timers, daemon cycles, usage warnings, stop signals, error classification) are now captured in the agent log file for post-mortem debugging

## Design

The `log_to_file()` helper:
- Checks `LOG_FILE` is non-empty before writing (safe when no log file specified)
- Uses ISO 8601 timestamps matching the existing `write_cycle_separator()` convention
- Writes plain text only (no ANSI color codes) for clean log parsing
- Adds `WARN:` / `ERROR:` severity prefixes for `log_warn` and `log_error`

## Test Plan

- [ ] Run wrapper with `--log` flag: verify log file contains `[wrapper]` messages
- [ ] Verify timestamps are ISO 8601 format
- [ ] Verify no ANSI escape codes in log file output
- [ ] Run wrapper without `--log` flag: verify no errors (graceful skip)
- [ ] Run in daemon mode: verify cycle messages appear in log

Closes #1380