### PR TITLE
feat: add force-stop and health monitoring to launch.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,9 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 | `/lean start [options]` | Start with custom pool sizes |
 | `/lean spawn <type>` | Add one agent (erdos, aristotle, researcher, deployer) |
 | `/lean scale <type> <N>` | Scale pool to N agents |
-| `/lean stop` | Graceful shutdown of all agents |
+| `/lean stop` | Graceful shutdown of all agents (creates signal files) |
+| `/lean stop --force` | Force stop all agents (kills tmux sessions immediately) |
+| `/lean health` | Show agent process health and detect stuck agents |
 
 ## Pool Limits
 
@@ -95,7 +97,9 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 
 # Launch/stop (also works outside /lean skill)
 ./scripts/lean/launch.sh start --erdos 2
-./scripts/lean/launch.sh stop
+./scripts/lean/launch.sh stop                # Graceful (signal files)
+./scripts/lean/launch.sh stop --force        # Force (kill sessions)
+./scripts/lean/launch.sh health              # Check agent health
 ./scripts/lean/launch.sh spawn erdos
 ./scripts/lean/launch.sh scale erdos 3
 ```


### PR DESCRIPTION
## Summary

- Add `--force` flag to `launch.sh stop` that kills tmux sessions immediately instead of relying on signal files
- Add `launch.sh health` command that displays a per-agent health table (PID, elapsed time, CPU%, network, status)
- Graceful `stop` (default) now detects stuck agents and warns the user to use `--force`
- Fixed all `((var++))` arithmetic patterns to use `$((var + 1))` for `set -e` safety

Closes #1381

## Test plan

- [x] `launch.sh help` shows updated usage with `stop [--force]` and `health` commands
- [x] `launch.sh health` with no running sessions shows "No agent tmux sessions found."
- [x] `launch.sh health` with running sessions shows per-agent table with correct status detection
- [x] `launch.sh stop` (graceful) creates signal files and warns about stuck agents
- [x] `launch.sh stop --force` kills all tmux sessions immediately
- [x] Bash syntax check passes (`bash -n`)
- [x] CLAUDE.md updated with new commands in the /lean reference table

🤖 Generated with [Claude Code](https://claude.com/claude-code)