### PR TITLE
fix: walk full process subtree in find_claude_child()

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -224,6 +224,11 @@ run_claude_once() {
     # Run Claude CLI with timeout to prevent indefinite hangs.
     # The 'timeout' command sends SIGTERM after CLAUDE_TIMEOUT seconds,
     # and SIGKILL 30s later if the process hasn't exited.
+    #
+    # NOTE: 'timeout' adds an intermediate process to the tree:
+    #   shell -> claude-wrapper.sh -> timeout -> claude
+    # The health check in launch.sh (find_claude_child) walks the full
+    # process subtree, so additional nesting levels are handled correctly.
     if [[ -n "$LOG_FILE" ]]; then
         last_output=$(timeout --kill-after=30 "$CLAUDE_TIMEOUT" claude --dangerously-skip-permissions "$PROMPT" 2>&1 | tee -a "$LOG_FILE"; echo "EXIT_CODE:${PIPESTATUS[0]}")
     else


### PR DESCRIPTION
## Summary

- **Replace 2-level nested loop** with a single `ps + awk` approach that walks the entire process subtree to arbitrary depth, fixing health check misreporting agents as COMPLETED when they are actually running
- **Add maintainer comment** in `claude-wrapper.sh` noting that the `timeout` command adds an intermediate process level

Closes #1404

## Problem

The `find_claude_child()` function in `launch.sh` searched only 2 levels deep (children and grandchildren). When `claude-wrapper.sh` uses `timeout`, it creates a 3-level process tree:

```
tmux pane PID (shell)
  └── claude-wrapper.sh (bash)
      └── timeout --kill-after=30 3600
          └── claude                    ← not found (level 3)
```

This caused `/lean health` to report all agents as COMPLETED when they were actually running, and stuck agent detection also failed.

## Solution

Replaced the hand-rolled 2-level nested loops with a single `ps -eo pid,ppid,comm` call piped through `awk`. The awk script:
1. Snapshots the entire process table in one call (efficient)
2. Iteratively expands the subtree rooted at the given PID until no new descendants are found
3. Returns the first process matching `/claude/` in that subtree

This handles arbitrary nesting depth and is future-proof against additional wrapper layers.

## Test plan

- [x] Verified bash syntax (`bash -n`) passes for both changed files
- [x] Tested awk logic with mock process trees simulating the exact bug scenario (3-level nesting via timeout)
- [x] Tested edge cases: no claude in tree (empty output), direct child (level 1), deep nesting (level 4)
- [x] Tested against live process table on macOS Darwin - correctly finds running claude PID
- [ ] Manual: start agent via `./scripts/lean/launch.sh spawn erdos`, run `./scripts/lean/launch.sh health`, verify RUNNING status

🤖 Generated with [Claude Code](https://claude.com/claude-code)