### PR TITLE
fix: add --throttle flag to check-usage.sh and fix --human references

### DIFF
--- a/.lean/roles/aristotle-agent.md
+++ b/.lean/roles/aristotle-agent.md
@@ -61,7 +61,7 @@ fi
 # Check session usage limits
 throttle=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --throttle 2>/dev/null || echo "4")
 if [[ "$throttle" -ge 3 ]]; then
-    usage_info=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --human 2>/dev/null || echo "Unknown")
+    usage_info=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --status 2>/dev/null || echo "Unknown")
     echo "$(date +%H:%M): Throttled (level $throttle) - $usage_info" >> "$REPO_ROOT/.loom/logs/aristotle.actions.log"
     echo "Session usage high (throttle level $throttle). Pausing until reset."
     exit 0

--- a/.lean/roles/erdos-enhancer.md
+++ b/.lean/roles/erdos-enhancer.md
@@ -67,7 +67,7 @@ fi
 # Check session usage limits
 throttle=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --throttle 2>/dev/null || echo "4")
 if [[ "$throttle" -ge 3 ]]; then
-    usage_info=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --human 2>/dev/null || echo "Unknown")
+    usage_info=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --status 2>/dev/null || echo "Unknown")
     echo "$(date +%H:%M): Throttled (level $throttle) - $usage_info" >> "$REPO_ROOT/.loom/logs/$ENHANCER_ID.actions.log"
     echo "Session usage high (throttle level $throttle). Pausing until reset."
     exit 0

--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -62,7 +62,7 @@ fi
 # Check session usage limits
 throttle=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --throttle 2>/dev/null || echo "4")
 if [[ "$throttle" -ge 3 ]]; then
-    usage_info=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --human 2>/dev/null || echo "Unknown")
+    usage_info=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --status 2>/dev/null || echo "Unknown")
     echo "$(date +%H:%M): Throttled (level $throttle) - $usage_info" >> "$REPO_ROOT/.loom/logs/$RESEARCHER_ID.actions.log"
     echo "Session usage high (throttle level $throttle). Pausing until reset."
     exit 0

--- a/.loom/scripts/check-usage.sh
+++ b/.loom/scripts/check-usage.sh
@@ -2,11 +2,19 @@
 # check-usage.sh - Query claude-monitor database for session usage
 #
 # Usage:
-#   ./.loom/scripts/check-usage.sh           # Returns JSON with usage data
-#   ./.loom/scripts/check-usage.sh --status  # Human-readable status
+#   ./.loom/scripts/check-usage.sh             # Returns JSON with usage data
+#   ./.loom/scripts/check-usage.sh --status    # Human-readable status
+#   ./.loom/scripts/check-usage.sh --throttle  # Numeric throttle level (0-4)
+#
+# Throttle levels (--throttle):
+#   0 - Normal (session < 70%)
+#   1 - Low (session >= 70%) - informational
+#   2 - Moderate (session >= 80%) - warning
+#   3 - High (session >= 90%) - spawn delays recommended
+#   4 - Critical (session >= 97%) - pause all operations
 #
 # Exit codes:
-#   0 - Data returned successfully
+#   0 - Data returned successfully (--throttle always exits 0)
 #   1 - Database not found or query failed
 #
 # This script queries the claude-monitor SQLite database to get current
@@ -21,7 +29,10 @@ DB_PATH="$HOME/.claude-monitor/usage.db"
 
 # Check if database exists
 if [ ! -f "$DB_PATH" ]; then
-    if [ "$1" = "--status" ]; then
+    if [ "$1" = "--throttle" ]; then
+        echo "0"
+        exit 0
+    elif [ "$1" = "--status" ]; then
         echo "NO_DATABASE: claude-monitor not installed"
         echo ""
         echo "For multi-day autonomous operation, install claude-monitor:"
@@ -34,7 +45,10 @@ fi
 
 # Check if sqlite3 is available
 if ! command -v sqlite3 &> /dev/null; then
-    if [ "$1" = "--status" ]; then
+    if [ "$1" = "--throttle" ]; then
+        echo "0"
+        exit 0
+    elif [ "$1" = "--status" ]; then
         echo "ERROR: sqlite3 not found"
     else
         echo '{"error": "NO_SQLITE3", "message": "sqlite3 command not found"}'
@@ -42,7 +56,45 @@ if ! command -v sqlite3 &> /dev/null; then
     exit 1
 fi
 
-if [ "$1" = "--status" ]; then
+# Helper: compute throttle level from session percentage
+compute_throttle_level() {
+    local session_pct="$1"
+    local pct="${session_pct%.*}"  # Remove decimal part
+
+    if [ -z "$pct" ] || [ "$pct" -le 0 ] 2>/dev/null; then
+        echo "0"
+    elif [ "$pct" -ge 97 ]; then
+        echo "4"
+    elif [ "$pct" -ge 90 ]; then
+        echo "3"
+    elif [ "$pct" -ge 80 ]; then
+        echo "2"
+    elif [ "$pct" -ge 70 ]; then
+        echo "1"
+    else
+        echo "0"
+    fi
+}
+
+if [ "$1" = "--throttle" ]; then
+    # Return numeric throttle level (0-4) for programmatic use
+    result=$(sqlite3 "$DB_PATH" "
+        SELECT session_percent
+        FROM usage_history
+        WHERE is_synthetic = 0
+        ORDER BY timestamp DESC
+        LIMIT 1
+    " 2>/dev/null)
+
+    if [ -z "$result" ]; then
+        echo "0"
+        exit 0
+    fi
+
+    compute_throttle_level "$result"
+    exit 0
+
+elif [ "$1" = "--status" ]; then
     # Human-readable format
     result=$(sqlite3 "$DB_PATH" "
         SELECT
@@ -75,14 +127,20 @@ if [ "$1" = "--status" ]; then
     echo "  Resets:    $weekly_reset"
     echo ""
 
-    # Provide recommendation
-    if [ "${session_pct%.*}" -ge 97 ]; then
-        echo "⚠️  RECOMMENDATION: Pause operations until session resets"
-    elif [ "${session_pct%.*}" -ge 80 ]; then
-        echo "⚠️  WARNING: Approaching session limit"
-    else
-        echo "✓ Session usage is healthy"
-    fi
+    # Compute and display throttle level
+    throttle_level=$(compute_throttle_level "$session_pct")
+
+    echo "Throttle:    Level $throttle_level/4"
+    echo ""
+
+    # Provide recommendation based on throttle level
+    case "$throttle_level" in
+        4) echo "RECOMMENDATION: Pause all operations until session resets" ;;
+        3) echo "WARNING: High usage - spawn delays recommended" ;;
+        2) echo "WARNING: Approaching session limit" ;;
+        1) echo "NOTE: Usage rising, monitoring recommended" ;;
+        *) echo "Session usage is healthy" ;;
+    esac
 else
     # JSON format for programmatic use
     sqlite3 "$DB_PATH" "

--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -118,7 +118,7 @@ check_usage_limits() {
 
         if [[ "$throttle" -ge 3 ]]; then
             local usage_info
-            usage_info=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --human 2>/dev/null || echo "High usage")
+            usage_info=$("$REPO_ROOT/.loom/scripts/check-usage.sh" --status 2>/dev/null || echo "High usage")
             log_warn "Usage limit reached (throttle level $throttle): $usage_info"
             return 1
         fi


### PR DESCRIPTION
## Summary

- Adds `--throttle` flag to `check-usage.sh` that returns a numeric throttle level (0-4) based on session usage percentage, fixing the broken integer comparison in `claude-wrapper.sh` that disabled rate limiting for all agents
- Fixes references to the non-existent `--human` flag (should be `--status`) in `claude-wrapper.sh` and three agent role definitions
- Adds throttle level display to `--status` output via a shared `compute_throttle_level()` helper function

## Test plan

- [ ] Run `check-usage.sh --throttle` and verify it returns a single digit (0-4)
- [ ] Run `check-usage.sh` (no args) and verify JSON output is unchanged
- [ ] Run `check-usage.sh --status` and verify it now includes "Throttle: Level N/4" line
- [ ] Verify `bash -n` passes on both `check-usage.sh` and `claude-wrapper.sh`
- [ ] Verify agent launch scripts no longer produce bash syntax errors from integer comparison

Closes #1405

🤖 Generated with [Claude Code](https://claude.com/claude-code)