### PR TITLE
feat: implement continuous daemon loop in launch.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 | `/lean stop` | Graceful shutdown of all agents (creates signal files) |
 | `/lean stop --force` | Force stop all agents (kills tmux sessions immediately) |
 | `/lean health` | Show agent process health and detect stuck agents |
+| `/lean daemon [options]` | Run continuous monitoring daemon (respawns completed/stuck agents) |
 
 ## Pool Limits
 
@@ -108,6 +109,11 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 ./scripts/lean/launch.sh spawn erdos
 ./scripts/lean/launch.sh spawn seeker
 ./scripts/lean/launch.sh scale erdos 3
+
+# Continuous daemon (monitors and respawns agents)
+./scripts/lean/launch.sh daemon                             # Default 60s interval
+./scripts/lean/launch.sh daemon --interval 30 --erdos 3     # Custom settings
+./scripts/lean/launch.sh daemon &                           # Run in background
 ```
 
 ---


### PR DESCRIPTION
## Summary

Implements a continuous daemon monitoring loop (`launch.sh daemon`) that automatically respawns completed and stuck agents, enabling true autonomous operation without requiring a persistent Claude Code session for supervision.

## Changes

- **New `daemon` subcommand**: Runs a continuous health-check loop (configurable interval, default 60s) that detects completed/stuck agents and respawns them automatically
- **Respawn infrastructure**: `respawn_agent()`, `kill_and_respawn()`, `get_agent_type()` helpers for restarting agents by session name
- **Cooldown tracking**: 5-minute cooldown per agent session to prevent rapid respawn thrashing (supports both bash 3 and 4+)
- **Daemon lifecycle management**: PID file (`research/lean-daemon.pid`) prevents double-starting; SIGTERM/SIGINT handlers for clean shutdown; EXIT trap cleans up PID file
- **Work queue logging**: Each cycle logs stubs, research candidates, Aristotle jobs, and ready PRs (with 10s timeout protection)
- **State persistence**: Daemon cycle count and total respawns written to state file each cycle
- **Stop integration**: `cmd_stop --force` now also kills the daemon process and cleans up PID file; graceful stop creates signal file that daemon detects on next cycle
- **Updated documentation**: CLAUDE.md commands table and helper scripts section now include daemon references
- **Updated usage**: Help text includes Daemon Options section with all flags

## Test Plan

- [ ] `./scripts/lean/launch.sh daemon --help` shows daemon options
- [ ] `./scripts/lean/launch.sh daemon` starts agents and enters monitoring loop
- [ ] Daemon detects `research/lean-stop-daemon` signal file and exits cleanly
- [ ] Daemon respawns COMPLETED agents (shell at prompt, no claude process)
- [ ] Daemon kills and respawns STUCK agents (>30min, <0.5% CPU, no network)
- [ ] Cooldown prevents respawning same agent within 5 minutes
- [ ] Second `daemon` invocation blocked when PID file exists with running process
- [ ] `./scripts/lean/launch.sh stop --force` kills daemon process
- [ ] SIGTERM/SIGINT cause clean daemon exit with PID file cleanup
- [ ] Work queue stats appear in daemon log output each cycle
- [ ] State file updated with `daemon_cycles` and `daemon_respawns` fields
- [ ] `bash -n scripts/lean/launch.sh` passes (syntax valid)

Closes #1407