### PR TITLE
fix: preserve daemon state on stop and move state file to .loom/

### DIFF
--- a/.claude/commands/lean.md
+++ b/.claude/commands/lean.md
@@ -5,7 +5,7 @@ Assume the Lean Daemon role and run the **continuous** mathematical orchestratio
 ## Process
 
 1. **Parse arguments**: Extract command and options
-2. **Initialize state**: Load or create `research/lean-daemon-state.json`
+2. **Initialize state**: Load or create `.loom/lean-daemon-state.json`
 3. **Run continuous loop**: Spawn mathematical agents, monitor progress, scale pools
 4. **Run until cancelled**: Continue until Ctrl+C or stop signal
 
@@ -20,7 +20,7 @@ As the **Lean Daemon**, you **continuously** orchestrate the mathematical agent 
 - **Spawn Deployers** to merge PRs and deploy the website
 - **Monitor progress** by checking tmux sessions and work queues
 - **Scale pools** based on available work
-- **Track state** in `research/lean-daemon-state.json` for crash recovery
+- **Track state** in `.loom/lean-daemon-state.json` for crash recovery
 
 You don't do the mathematical work yourself - you spawn worker agents to do the work in parallel.
 
@@ -176,7 +176,7 @@ The daemon monitors these tmux sessions to track agent status.
 
 ## State Persistence
 
-State tracked in `research/lean-daemon-state.json`:
+State tracked in `.loom/lean-daemon-state.json`:
 
 ```json
 {

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ aristotle-results/
 .loom/worktrees/
 .loom/*.log
 .loom/*.sock
+.loom/*.json

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -19,9 +19,15 @@ BOLD='\033[1m'
 NC='\033[0m' # No Color
 
 # Config
-STATE_FILE="research/lean-daemon-state.json"
+STATE_FILE=".loom/lean-daemon-state.json"
+OLD_STATE_FILE="research/lean-daemon-state.json"
 ARISTOTLE_JOBS="research/aristotle-jobs.json"
 CANDIDATE_POOL="research/candidate-pool.json"
+
+# Fall back to old location if new state file doesn't exist
+if [[ ! -f "$STATE_FILE" && -f "$OLD_STATE_FILE" ]]; then
+    STATE_FILE="$OLD_STATE_FILE"
+fi
 
 # Parse arguments
 JSON_OUTPUT=false


### PR DESCRIPTION
## Summary

- Move `lean-daemon-state.json` from `research/` to `.loom/` to prevent git worktree conflicts and follow Loom conventions for runtime state files
- Replace `set_running()` with `set_stopped()` that preserves all existing state (agents, session_stats) and adds a `stopped_at` timestamp instead of only toggling the running flag
- Add migration logic so existing state files are automatically moved on first run
- Add `.loom/*.json` to `.gitignore` so daemon state is never git-tracked

## Test plan

- [ ] Fresh start with no existing state file creates `.loom/lean-daemon-state.json`
- [ ] Migration moves `research/lean-daemon-state.json` to `.loom/` on first run
- [ ] `launch.sh stop --force` preserves agent list and session_stats (only sets `running=false` and `stopped_at`)
- [ ] `launch.sh stop` (graceful) adds stopped_at without data loss
- [ ] `status.sh` reads from new location, falls back to old location
- [ ] Multiple start/stop cycles maintain cumulative session_stats

Closes #1406

🤖 Generated with [Claude Code](https://claude.com/claude-code)