### PR TITLE
feat: reallocate agent pool from Erdos to Research after campaign completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,11 +57,11 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 ## Quick Start
 
 ```bash
-# Start with defaults (2 erdos, 1 aristotle, 1 researcher, 1 seeker, 1 deployer)
+# Start with defaults (0 erdos, 1 aristotle, 2 researcher, 1 seeker, 1 deployer)
 /lean
 
 # Start with custom pool sizes
-/lean start --erdos 3 --researcher 2
+/lean start --researcher 3
 
 # Check status
 /lean status
@@ -88,9 +88,9 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 
 | Agent | Default | Max |
 |-------|---------|-----|
-| Erdős Enhancer | 2 | 5 |
+| Erdős Enhancer | 0 | 5 |
 | Aristotle | 1 | 2 |
-| Researcher | 1 | 3 |
+| Researcher | 2 | 5 |
 | Seeker | 1 | 1 |
 | Deployer | 1 | 1 |
 
@@ -102,17 +102,17 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 ./scripts/lean/status.sh --json
 
 # Launch/stop (also works outside /lean skill)
-./scripts/lean/launch.sh start --erdos 2
+./scripts/lean/launch.sh start --researcher 3
 ./scripts/lean/launch.sh stop                # Graceful (signal files)
 ./scripts/lean/launch.sh stop --force        # Force (kill sessions)
 ./scripts/lean/launch.sh health              # Check agent health
-./scripts/lean/launch.sh spawn erdos
+./scripts/lean/launch.sh spawn researcher
 ./scripts/lean/launch.sh spawn seeker
-./scripts/lean/launch.sh scale erdos 3
+./scripts/lean/launch.sh scale researcher 4
 
 # Continuous daemon (monitors and respawns agents)
 ./scripts/lean/launch.sh daemon                             # Default 60s interval
-./scripts/lean/launch.sh daemon --interval 30 --erdos 3     # Custom settings
+./scripts/lean/launch.sh daemon --interval 30 --researcher 3  # Custom settings
 ./scripts/lean/launch.sh daemon &                           # Run in background
 ```
 

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -39,17 +39,17 @@ STUCK_CPU_THRESHOLD="0.5"
 DEFAULT_DAEMON_INTERVAL=60
 RESPAWN_COOLDOWN_SECONDS=300  # 5 minutes between respawns of same agent
 
-# Default pool sizes
-DEFAULT_ERDOS=2
+# Default pool sizes (Erdos enhancement campaign completed 2026-01-27)
+DEFAULT_ERDOS=0
 DEFAULT_ARISTOTLE=1
-DEFAULT_RESEARCHER=1
+DEFAULT_RESEARCHER=2
 DEFAULT_SEEKER=1
 DEFAULT_DEPLOYER=1
 
 # Max pool sizes
 MAX_ERDOS=5
 MAX_ARISTOTLE=2
-MAX_RESEARCHER=3
+MAX_RESEARCHER=5
 MAX_SEEKER=1
 MAX_DEPLOYER=1
 
@@ -94,16 +94,16 @@ Agent Types:
 
 Examples:
   $0 start                              # Start with defaults
-  $0 start --erdos 3 --researcher 2     # Custom pool sizes
-  $0 start --seeker 1 --researcher 2    # Research team with seeker
-  $0 spawn erdos                        # Add one Erdős enhancer
+  $0 start --researcher 3               # Custom pool sizes
+  $0 start --erdos 2 --researcher 1     # Include Erdős enhancers
+  $0 spawn researcher                   # Add one Researcher
   $0 spawn seeker                       # Add seeker agent
-  $0 scale erdos 4                      # Scale to 4 enhancers
+  $0 scale researcher 4                 # Scale to 4 Researchers
   $0 stop                               # Graceful stop (signal files)
   $0 stop --force                       # Force stop (kill sessions)
   $0 health                             # Check agent health
   $0 daemon                             # Run daemon with defaults
-  $0 daemon --interval 30 --erdos 3     # Custom interval and pool
+  $0 daemon --interval 30 --researcher 3  # Custom interval and pool
   $0 daemon &                           # Run daemon in background
 EOF
 }
@@ -360,7 +360,7 @@ get_all_agent_sessions() {
         sessions+=("aristotle-agent")
     fi
     # Researchers
-    for i in 1 2 3; do
+    for i in 1 2 3 4 5; do
         if tmux has-session -t "researcher-$i" 2>/dev/null; then
             sessions+=("researcher-$i")
         fi
@@ -1215,7 +1215,7 @@ cmd_spawn() {
             ;;
         researcher)
             echo -e "${BLUE}Spawning additional Researcher...${NC}"
-            for i in 1 2 3; do
+            for i in 1 2 3 4 5; do
                 if ! tmux has-session -t "researcher-$i" 2>/dev/null; then
                     ./scripts/research/parallel-research.sh 1 &
                     sleep 2
@@ -1299,7 +1299,7 @@ cmd_scale() {
             fi
 
             local current=0
-            for i in 1 2 3; do
+            for i in 1 2 3 4 5; do
                 if tmux has-session -t "researcher-$i" 2>/dev/null; then
                     current=$((current + 1))
                 fi

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -141,7 +141,7 @@ gather_status() {
     fi
 
     # Researchers
-    for i in 1 2 3; do
+    for i in 1 2 3 4 5; do
         if session_exists "researcher-$i"; then
             researcher_sessions+=("researcher-$i:$(get_session_uptime "researcher-$i")")
         fi
@@ -243,7 +243,9 @@ EOF
 
         # Work Queue
         echo -e "  ${CYAN}Work Queue:${NC}"
-        echo "    Stubs needing enhancement: $stubs_count (with sources)"
+        if [[ "$stubs_count" != "0" ]]; then
+            echo "    Stubs needing enhancement: $stubs_count (with sources)"
+        fi
         echo "    Aristotle jobs pending: $aristotle_jobs"
         echo "    Research problems available: $research_problems"
         echo "    PRs ready to merge: $ready_prs"
@@ -252,7 +254,7 @@ EOF
         # Agent Pool
         echo -e "  ${CYAN}Agent Pool:${NC}"
 
-        # Erdős
+        # Erdős (only shown when active, since enhancement campaign is complete)
         local erdos_count=${#erdos_sessions[@]}
         if [[ $erdos_count -gt 0 ]]; then
             echo -e "    ${BOLD}Erdős Enhancers:${NC} ${GREEN}$erdos_count active${NC}"
@@ -261,8 +263,6 @@ EOF
                 local uptime="${session#*:}"
                 echo "      $name: Running ($uptime)"
             done
-        else
-            echo -e "    ${BOLD}Erdős Enhancers:${NC} ${YELLOW}0 active${NC}"
         fi
 
         # Aristotle
@@ -315,10 +315,10 @@ EOF
 
         # Commands hint
         echo -e "  ${BLUE}Commands:${NC}"
-        echo "    /lean start --erdos 2 --researcher 1    Start agents"
-        echo "    /lean spawn erdos                       Add one Erdős enhancer"
+        echo "    /lean start --researcher 3              Start agents"
+        echo "    /lean spawn researcher                  Add one Researcher"
         echo "    /lean spawn seeker                      Add seeker agent"
-        echo "    /lean scale erdos 3                     Scale to 3 enhancers"
+        echo "    /lean scale researcher 4                Scale to 4 Researchers"
         echo "    /lean stop                              Stop all agents"
         echo ""
     fi


### PR DESCRIPTION
## Summary

- Shifts default pool allocation from 2 Erdos + 1 Researcher to 0 Erdos + 2 Researchers, reflecting the completed Erdos enhancement campaign (1,149 stubs enhanced, 0 remaining)
- Increases max Researcher pool from 3 to 5 to utilize freed capacity
- Updates status display to hide Erdos section when no enhancers are active, and hides "Stubs needing enhancement" when count is 0
- Updates all session loops (health check, spawn, scale) to support up to 5 researcher slots
- Synchronizes documentation in CLAUDE.md with new pool defaults and examples

Closes #1409

## Test plan

- [ ] Run `./scripts/lean/launch.sh start` and verify 0 Erdos, 2 Researcher agents start
- [ ] Run `./scripts/lean/launch.sh spawn erdos` and verify Erdos enhancer can still be spawned manually
- [ ] Run `./scripts/lean/launch.sh scale researcher 5` and verify scaling to 5 works
- [ ] Run `./scripts/lean/status.sh` and verify Erdos section is hidden when no enhancers active
- [ ] Verify bash syntax with `bash -n scripts/lean/launch.sh` and `bash -n scripts/lean/status.sh`
- [ ] Verify CLAUDE.md pool limits table matches constants in launch.sh

Generated with [Claude Code](https://claude.com/claude-code)