### PR TITLE
fix: Seeker writes to database before initializing workspaces

### DIFF
--- a/.claude/commands/seeker.md
+++ b/.claude/commands/seeker.md
@@ -73,12 +73,48 @@ npx tsx .lean/scripts/extract-problems.ts --json
 
 ## Mode: INIT
 
-Initialize a specific problem for research.
+Initialize a specific problem for research using the **database-first** workflow.
+
+**CRITICAL**: You MUST register the problem in the database before initializing the
+workspace. Without this, `candidate-pool.json` will not include the problem, and
+Researchers will not be able to discover or claim it.
 
 ```bash
 PROBLEM_ID="$2"  # from --init <id>
 
-# Initialize the research workspace
+# Step 1: Ensure the database exists
+if [ ! -f research/db/knowledge.db ]; then
+    python3 research/db/migrate.py
+fi
+
+# Step 2: Check if problem already exists in the database
+EXISTS=$(sqlite3 research/db/knowledge.db "SELECT COUNT(*) FROM problems WHERE slug = '$PROBLEM_ID'")
+
+if [ "$EXISTS" -eq 0 ]; then
+    # Insert the new problem (Seeker should determine tier/significance/tractability)
+    sqlite3 research/db/knowledge.db <<SQL
+INSERT INTO problems (slug, title, status, tier, significance, tractability, tags, last_updated)
+VALUES ('$PROBLEM_ID', '$PROBLEM_ID', 'available', 'B', 5, 5, '["seeker-selected"]', datetime('now'));
+SQL
+    echo "Registered '$PROBLEM_ID' in database with status 'available'"
+else
+    # Update status to available if it was previously skipped/blocked
+    sqlite3 research/db/knowledge.db <<SQL
+UPDATE problems SET status = 'available', last_updated = datetime('now')
+WHERE slug = '$PROBLEM_ID' AND status NOT IN ('in-progress', 'completed', 'graduated');
+SQL
+    echo "Updated '$PROBLEM_ID' status to 'available' in database"
+fi
+
+# Step 3: Regenerate candidate-pool.json from database
+python3 research/db/sync_pool.py
+
+# Step 4: Verify the problem appears in the pool with status 'available'
+jq -e ".candidates[] | select(.id == \"$PROBLEM_ID\" and .status == \"available\")" research/candidate-pool.json > /dev/null \
+    && echo "Verified: '$PROBLEM_ID' is available in candidate-pool.json" \
+    || echo "WARNING: '$PROBLEM_ID' not found as available in candidate-pool.json"
+
+# Step 5: Initialize the research workspace
 ./.lean/scripts/research.sh init "$PROBLEM_ID"
 
 # Report what was initialized
@@ -184,16 +220,21 @@ function select_problem():
   return ranked[0]
 ```
 
-### Step 5: Validate Selection
+### Step 5: Validate and Register Selection
 
-Before finalizing, verify:
+Before finalizing, verify the problem is valid and register it in the database:
 
 1. **Not currently claimed**: Check `research/claims/<id>.lock` does not exist
-2. **Research workspace ready**: Check if `research/problems/<id>/` exists
-3. **Gallery proof accessible**: Verify the source proof exists
+2. **Register in database**: Ensure the problem is in `research/db/knowledge.db` with status `'available'`
+3. **Regenerate pool JSON**: Run `python3 research/db/sync_pool.py`
+4. **Research workspace ready**: Initialize if `research/problems/<id>/` does not exist
 
 ```bash
 SELECTED_ID="<selected>"
+SELECTED_TITLE="<title>"
+SELECTED_TIER="<tier>"       # S, A, B, or C
+SELECTED_SIG=<significance>  # 1-10
+SELECTED_TRACT=<tractability> # 1-10
 
 # Check not claimed
 if [ -d "research/claims/${SELECTED_ID}.lock" ]; then
@@ -201,7 +242,36 @@ if [ -d "research/claims/${SELECTED_ID}.lock" ]; then
   # Select next in ranking
 fi
 
-# Check if research directory exists
+# CRITICAL: Register in database (database-first workflow)
+# Ensure database exists
+if [ ! -f research/db/knowledge.db ]; then
+  python3 research/db/migrate.py
+fi
+
+# Upsert the selected problem into the database
+sqlite3 research/db/knowledge.db <<SQL
+INSERT INTO problems (slug, title, tier, significance, tractability, status, tags, last_updated)
+VALUES ('$SELECTED_ID', '$SELECTED_TITLE', '$SELECTED_TIER', $SELECTED_SIG, $SELECTED_TRACT, 'available', '["seeker-selected"]', datetime('now'))
+ON CONFLICT(slug) DO UPDATE SET
+  status = CASE
+    WHEN excluded.status IN ('in-progress', 'completed', 'graduated') THEN problems.status
+    ELSE 'available'
+  END,
+  tier = excluded.tier,
+  significance = excluded.significance,
+  tractability = excluded.tractability,
+  last_updated = datetime('now');
+SQL
+
+# Regenerate candidate-pool.json from database
+python3 research/db/sync_pool.py
+
+# Verify the problem appears in the pool
+jq -e ".candidates[] | select(.id == \"$SELECTED_ID\")" research/candidate-pool.json > /dev/null \
+  && echo "Verified: $SELECTED_ID registered in candidate pool" \
+  || echo "ERROR: $SELECTED_ID not found in candidate pool after sync"
+
+# Initialize workspace if it doesn't exist
 if [ ! -d "research/problems/${SELECTED_ID}" ]; then
   echo "Initializing research workspace..."
   ./.lean/scripts/research.sh init "$SELECTED_ID"
@@ -316,8 +386,13 @@ When the available pool runs low (< 5 available problems):
 
 1. **Refresh from gallery**: `npx tsx .lean/scripts/extract-problems.ts --json`
 2. **Cross-reference**: Check which gallery problems are NOT yet in the candidate pool
-3. **Add new candidates**: Add tractable problems to the pool
-4. **Report**: List newly added problems
+3. **Add new candidates to the database**: Insert into `research/db/knowledge.db`
+4. **Regenerate pool JSON**: Run `python3 research/db/sync_pool.py`
+5. **Report**: List newly added problems
+
+**IMPORTANT**: `candidate-pool.json` is auto-generated from the database. Do NOT
+edit it directly. All new problems must be added to the database first, then the
+pool JSON is regenerated via `sync_pool.py`.
 
 ```bash
 # Check pool depth
@@ -325,8 +400,18 @@ AVAILABLE=$(jq '[.candidates[] | select(.status == "available")] | length' resea
 THRESHOLD=5
 
 if [ "$AVAILABLE" -lt "$THRESHOLD" ]; then
-  echo "Pool running low ($AVAILABLE available). Consider refreshing."
-  echo "Run: /seeker --refresh"
+  echo "Pool running low ($AVAILABLE available). Replenishing..."
+
+  # Ensure database exists
+  if [ ! -f research/db/knowledge.db ]; then
+    python3 research/db/migrate.py
+  fi
+
+  # After selecting new problems, insert each into the database:
+  # sqlite3 research/db/knowledge.db "INSERT INTO problems (slug, title, tier, significance, tractability, status, tags, last_updated) VALUES (...) ON CONFLICT(slug) DO UPDATE SET status='available', last_updated=datetime('now');"
+
+  # Then regenerate the pool JSON:
+  # python3 research/db/sync_pool.py
 fi
 ```
 

--- a/.claude/commands/seeker.md
+++ b/.claude/commands/seeker.md
@@ -254,7 +254,7 @@ INSERT INTO problems (slug, title, tier, significance, tractability, status, tag
 VALUES ('$SELECTED_ID', '$SELECTED_TITLE', '$SELECTED_TIER', $SELECTED_SIG, $SELECTED_TRACT, 'available', '["seeker-selected"]', datetime('now'))
 ON CONFLICT(slug) DO UPDATE SET
   status = CASE
-    WHEN excluded.status IN ('in-progress', 'completed', 'graduated') THEN problems.status
+    WHEN problems.status IN ('in-progress', 'completed', 'graduated') THEN problems.status
     ELSE 'available'
   END,
   tier = excluded.tier,

--- a/.lean/roles/seeker.md
+++ b/.lean/roles/seeker.md
@@ -99,17 +99,53 @@ For each candidate, ask:
 3. **Clear first step?** Can we at least start exploring?
 4. **Learning potential?** Even if we fail, will we learn something?
 
-### Step 4: Select and Initialize
+### Step 4: Select and Register in Database
+
+**CRITICAL**: You MUST write the selected problem to the database before initializing
+the workspace. This ensures `candidate-pool.json` stays in sync and Researchers can
+discover the problem.
 
 ```bash
 # Pick a problem
 PROBLEM_ID="sqrt2-irrational-oq-01"
+PROBLEM_TITLE="Square Root of 2 Irrationality Extensions"
+TIER="B"
+SIGNIFICANCE=6
+TRACTABILITY=7
 
-# Initialize research workspace
+# Step 4a: Ensure the database exists (build from SQL data files if needed)
+if [ ! -f research/db/knowledge.db ]; then
+    python3 research/db/migrate.py
+fi
+
+# Step 4b: Insert into database (upsert - update if exists)
+sqlite3 research/db/knowledge.db <<SQL
+INSERT INTO problems (slug, title, tier, significance, tractability, status, tags, last_updated)
+VALUES ('$PROBLEM_ID', '$PROBLEM_TITLE', '$TIER', $SIGNIFICANCE, $TRACTABILITY, 'available', '["seeker-selected"]', datetime('now'))
+ON CONFLICT(slug) DO UPDATE SET
+  status = 'available',
+  tier = excluded.tier,
+  significance = excluded.significance,
+  tractability = excluded.tractability,
+  last_updated = datetime('now');
+SQL
+
+# Step 4c: Regenerate candidate-pool.json from database
+python3 research/db/sync_pool.py
+
+# Step 4d: Verify the problem appears in the pool
+jq -e ".candidates[] | select(.id == \"$PROBLEM_ID\")" research/candidate-pool.json > /dev/null
+
+# Step 4e: Initialize research workspace
 ./.lean/scripts/research.sh init $(echo $PROBLEM_ID | sed 's/-oq-[0-9]*$//')
 
 # Update problem.md with the specific question
 ```
+
+> **Why database-first?** The database (`research/db/knowledge.db`) is the single
+> source of truth. `candidate-pool.json` is auto-generated from it via `sync_pool.py`.
+> If you only create workspace directories, Researchers cannot discover the problem
+> because they query the pool JSON, not the filesystem.
 
 ## Selection Algorithm
 
@@ -195,12 +231,18 @@ When you select a problem:
 
 ## Integration with Researcher
 
-After selecting a problem:
+After selecting a problem, follow this **database-first** sequence:
 
-1. **Create workspace**: `./.lean/scripts/research.sh init [slug]`
-2. **Populate problem.md**: Copy the problem description and context
-3. **Set initial state**: OBSERVE phase
-4. **Hand off**: The Researcher takes over from here
+1. **Register in database**: Insert into `research/db/knowledge.db` with status `'available'`
+2. **Regenerate pool JSON**: Run `python3 research/db/sync_pool.py`
+3. **Verify pool entry**: Confirm the problem appears in `research/candidate-pool.json`
+4. **Create workspace**: `./.lean/scripts/research.sh init [slug]`
+5. **Populate problem.md**: Copy the problem description and context
+6. **Set initial state**: OBSERVE phase
+7. **Hand off**: The Researcher takes over from here
+
+> **Important**: Steps 1-3 are required for Researchers to discover the problem.
+> Skipping them causes the pool to show 0 available problems even though workspaces exist.
 
 ## Autonomous Operation
 

--- a/.lean/roles/seeker.md
+++ b/.lean/roles/seeker.md
@@ -123,7 +123,10 @@ sqlite3 research/db/knowledge.db <<SQL
 INSERT INTO problems (slug, title, tier, significance, tractability, status, tags, last_updated)
 VALUES ('$PROBLEM_ID', '$PROBLEM_TITLE', '$TIER', $SIGNIFICANCE, $TRACTABILITY, 'available', '["seeker-selected"]', datetime('now'))
 ON CONFLICT(slug) DO UPDATE SET
-  status = 'available',
+  status = CASE
+    WHEN problems.status IN ('in-progress', 'completed', 'graduated') THEN problems.status
+    ELSE 'available'
+  END,
   tier = excluded.tier,
   significance = excluded.significance,
   tractability = excluded.tractability,

--- a/scripts/research/launch-seeker.sh
+++ b/scripts/research/launch-seeker.sh
@@ -113,6 +113,12 @@ You are the **seeker** agent. Your mission is to keep the research pipeline fed 
    - Use the /seeker skill to select and initialize new problems
    - Run: \`/seeker --refresh\` to extract new problems from gallery
    - Or run: \`/seeker\` to select from existing pool
+   - **CRITICAL - Database-first workflow**: When adding new problems, you MUST:
+     a. Ensure database exists: \`if [ ! -f research/db/knowledge.db ]; then python3 research/db/migrate.py; fi\`
+     b. Insert into database: \`sqlite3 research/db/knowledge.db "INSERT INTO problems ..."\`
+     c. Regenerate pool JSON: \`python3 research/db/sync_pool.py\`
+     d. Then initialize workspace: \`./.lean/scripts/research.sh init <slug>\`
+   - Without steps (a-c), Researchers will NOT see the new problems in candidate-pool.json
 
 4. **If pool is adequate, report status and wait**
    - Run: \`/seeker --status\` to generate a status report


### PR DESCRIPTION
## Summary

- Updates the Seeker agent's workflow to use a **database-first approach** when selecting new research problems
- Previously, the Seeker created workspace directories (`research/problems/<slug>/`) but never updated `research/db/knowledge.db` or `research/candidate-pool.json`, causing Researchers to see 0 available problems
- Now the Seeker inserts selected problems into the SQLite database, regenerates `candidate-pool.json` via `sync_pool.py`, and then initializes the workspace

## Changes

Three files updated to enforce the database-first workflow:

1. **`.lean/roles/seeker.md`** - Step 4 "Select and Initialize" replaced with "Select and Register in Database" including sqlite3 upsert, sync_pool.py regeneration, and verification. Integration with Researcher section updated with 7-step database-first sequence.

2. **`.claude/commands/seeker.md`** - INIT mode now includes full database registration before workspace init. Step 5 "Validate Selection" replaced with "Validate and Register Selection" including database upsert and pool regeneration. Pool Replenishment section updated with database-first instructions and DO NOT EDIT warning for candidate-pool.json.

3. **`scripts/research/launch-seeker.sh`** - Prompt template updated with CRITICAL database-first workflow instructions in Step 3.

## Test plan

- [ ] Verify the Seeker agent reads the updated role definition and follows database-first workflow
- [ ] After Seeker selects a problem, verify it appears in `candidate-pool.json` with status `"available"`
- [ ] Verify `jq '[.candidates[] | select(.status == "available")] | length' research/candidate-pool.json` returns accurate count
- [ ] Verify Researcher can discover and claim the newly selected problem via `research-available.sh`
- [ ] Verify upsert behavior: re-selecting an existing problem updates metadata without duplicating

Closes #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)