### PR TITLE
Document tw-animate-css as intentional dependency

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,7 @@
 @import "tailwindcss";
+/* tw-animate-css provides enter/exit animation utilities (animate-in, animate-out,
+   fade-in/out, zoom-in/out, slide-in/out) used by shadcn/ui components: dialog, tooltip, sheet.
+   depcheck flags this as unused because it tracks JS imports, not CSS @import. See #1421. */
 @import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));


### PR DESCRIPTION
## Summary

- Adds CSS comment explaining why `tw-animate-css` is imported and why depcheck falsely flags it as unused
- The package provides enter/exit animation utilities used by shadcn/ui components (dialog, tooltip, sheet)
- depcheck cannot detect CSS `@import` usage, only JS imports

Closes #1421

## Test plan

- [ ] Verify `pnpm build` succeeds
- [ ] Verify dialog/tooltip/sheet animations still work in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)