### PR TITLE
Add strict quality gate to claim-stub.sh complete

### DIFF
--- a/.lean/roles/erdos-enhancer.md
+++ b/.lean/roles/erdos-enhancer.md
@@ -346,8 +346,21 @@ EOF
 ## Step 9: Mark Complete
 
 ```bash
-$REPO_ROOT/scripts/erdos/claim-stub.sh complete {NUMBER}
+# Strict quality gate: fails if quality issues remain
+if ! $REPO_ROOT/scripts/erdos/claim-stub.sh complete {NUMBER}; then
+    echo "Completion rejected - quality issues remain for erdos-{NUMBER}"
+
+    # Re-run quality check to see specific issues
+    $REPO_ROOT/scripts/erdos/has-quality-issues.sh {NUMBER} || true
+
+    # Release claim so other agents can attempt this problem
+    $REPO_ROOT/scripts/erdos/claim-stub.sh release {NUMBER}
+
+    # Move to next problem (skip to Step 10)
+fi
 ```
+
+**Note:** Completion now enforces a strict quality gate. If quality issues remain, you must either fix them and retry, or release the claim and move on. Use `--force` only for genuinely unfixable cases.
 
 ## Step 10: Clean Up and Loop
 

--- a/scripts/erdos/parallel-enhance.sh
+++ b/scripts/erdos/parallel-enhance.sh
@@ -384,7 +384,7 @@ You are working in an isolated git worktree with your own branch.
 6. Commit: \`git add src/data/proofs/erdos-N/ proofs/Proofs/ErdosNProblem.lean && git commit -m "Enhance Erdős #N: Title"\`
 7. Push: \`git push -u origin feature/enhancer-$i\`
 8. Create PR: \`gh pr create --title "Enhance Erdős #N" --body "Stub enhancement" --label erdos-enhancement\`
-9. Mark complete: \`\$REPO_ROOT/scripts/erdos/claim-stub.sh complete N\`
+9. Mark complete: \`\$REPO_ROOT/scripts/erdos/claim-stub.sh complete N\` (fails if quality issues remain; use --force to override)
 10. Reset for next: \`git checkout main && git pull && git checkout -B feature/enhancer-$i main\`
 11. Repeat from step 2
 


### PR DESCRIPTION
## Summary

- Upgrade `complete_stub()` from soft warning to hard quality gate that fails with exit code 1 when quality issues remain
- Add `--force` flag to override the gate for genuinely unfixable entries
- List specific quality issues (placeholder proofs, missing/sparse annotations, scraping garbage) in error output
- Update erdos-enhancer role instructions to handle completion rejection (release claim and move on)
- Update parallel-enhance.sh prompt to document the new behavior

## Test plan

- [ ] `claim-stub.sh complete <N>` fails with exit 1 on entry with quality issues
- [ ] Error output lists specific issues detected
- [ ] `claim-stub.sh complete <N> --force` succeeds with `needs-work` status
- [ ] `claim-stub.sh complete <N>` succeeds normally on quality entries

Closes #1433

🤖 Generated with [Claude Code](https://claude.com/claude-code)