### PR TITLE
Fix phantom stop signal killing lean daemon within 67s of launch

### DIFF
--- a/.claude/commands/lean.md
+++ b/.claude/commands/lean.md
@@ -98,7 +98,7 @@ The daemon runs **continuously** until cancelled:
 
 ```
 while not cancelled:
-    1. Check for shutdown signal (research/lean-stop-daemon)
+    1. Check for shutdown signal (.loom/signals/stop-lean-daemon)
     2. Assess work queues (stubs, proofs, research problems, PRs)
     3. Check agent completions (tmux session status)
     4. Spawn/scale agents based on work availability
@@ -211,7 +211,7 @@ State tracked in `.loom/lean-daemon-state.json`:
 
 ```bash
 # Option 1: Create stop signal
-touch research/lean-stop-daemon
+touch .loom/signals/stop-lean-daemon
 
 # Option 2: Use command
 /lean stop


### PR DESCRIPTION
## Summary

- Moves the daemon stop signal file from `research/lean-stop-daemon` to `.loom/signals/stop-lean-daemon` to prevent git worktree creation from copying the stop signal into the main repo's working directory
- Adds diagnostic logging (file stat details) when the stop signal is detected, for debugging future occurrences
- Updates documentation in `.claude/commands/lean.md` to reference the new path

## Root cause

When `git worktree add` runs during agent startup, it copies tracked/untracked files from the main repo's working directory. The `research/` directory is not in `.gitignore`, so any `research/lean-stop-daemon` file gets copied into worktrees and can appear in the main repo context. The `.loom/signals/` directory is already in `.gitignore`, making it immune to this race condition.

## Test plan

- [ ] Verify `STOP_SIGNAL_FILE` uses `.loom/signals/stop-lean-daemon` path
- [ ] Verify no remaining references to `research/lean-stop-daemon` in codebase
- [ ] Verify `mkdir -p` ensures signals directory exists before `touch` in force-stop path
- [ ] Verify diagnostic logging captures `ls -la` and `stat` output before acting on signal
- [ ] Documentation in `.claude/commands/lean.md` updated in both locations (continuous loop description and graceful shutdown example)

Closes #1442

🤖 Generated with [Claude Code](https://claude.com/claude-code)