### PR TITLE
Fix daemon_cleanup to call set_stopped instead of nonexistent set_running

### DIFF
--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -869,7 +869,7 @@ daemon_cleanup() {
     rm -f "$DAEMON_PID_FILE"
     # Clean up temp respawn cache files
     rm -f /tmp/lean-daemon-respawn-* 2>/dev/null || true
-    set_running false
+    set_stopped
 }
 
 # Command: daemon - Continuous monitoring loop


### PR DESCRIPTION
## Summary

- Fixes `daemon_cleanup()` function in `scripts/lean/launch.sh` which was calling the nonexistent `set_running false` function
- Changes to call `set_stopped` which correctly updates `state.json` with `running=false` and `stopped_at` timestamp

## Problem

The `daemon_cleanup()` function at line 872 was calling `set_running false`, but this function does not exist in the script. This caused a visible error on every daemon shutdown:

```
./scripts/lean/launch.sh: line 872: set_running: command not found
```

## Solution

Replaced `set_running false` with `set_stopped`, which is the existing function designed for this purpose. The `set_stopped` function properly updates the state file with `running=false` and a `stopped_at` timestamp.

## Test plan

- [x] Verified bash syntax with `bash -n scripts/lean/launch.sh`
- [x] Confirmed `set_stopped` function exists at line 182
- [x] Single-line change with clear intent

Closes #1459

🤖 Generated with [Claude Code](https://claude.com/claude-code)