### PR TITLE
Fix macOS UTC timestamp parsing in date commands

### DIFF
--- a/scripts/erdos/clean-enhancers.sh
+++ b/scripts/erdos/clean-enhancers.sh
@@ -149,7 +149,9 @@ is_claim_expired() {
     now_epoch=$(date -u +%s)
 
     if [[ "$(uname)" == "Darwin" ]]; then
-        expires_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$expires_at" +%s 2>/dev/null || echo 0)
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        local clean_ts="${expires_at%Z}"
+        expires_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" +%s 2>/dev/null || echo 0)
     else
         expires_epoch=$(date -d "$expires_at" +%s 2>/dev/null || echo 0)
     fi

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -109,7 +109,9 @@ gather_status() {
         started_at=$(jq -r '.started_at // ""' "$STATE_FILE")
         if [[ -n "$started_at" && "$daemon_running" == "true" ]]; then
             local start_epoch
-            start_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$started_at" +%s 2>/dev/null || date -d "$started_at" +%s 2>/dev/null || echo "0")
+            # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+            local clean_ts="${started_at%Z}"
+            start_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" +%s 2>/dev/null || date -d "$started_at" +%s 2>/dev/null || echo "0")
             if [[ "$start_epoch" != "0" ]]; then
                 local now
                 now=$(date +%s)

--- a/scripts/research/claim-problem.sh
+++ b/scripts/research/claim-problem.sh
@@ -69,7 +69,9 @@ is_claim_expired() {
     now_epoch=$(date -u +%s)
 
     if [[ "$(uname)" == "Darwin" ]]; then
-        expires_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$expires_at" +%s 2>/dev/null || echo 0)
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        local clean_ts="${expires_at%Z}"
+        expires_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" +%s 2>/dev/null || echo 0)
     else
         expires_epoch=$(date -d "$expires_at" +%s 2>/dev/null || echo 0)
     fi

--- a/scripts/research/clean-research.sh
+++ b/scripts/research/clean-research.sh
@@ -149,7 +149,9 @@ is_claim_expired() {
     now_epoch=$(date -u +%s)
 
     if [[ "$(uname)" == "Darwin" ]]; then
-        expires_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$expires_at" +%s 2>/dev/null || echo 0)
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        local clean_ts="${expires_at%Z}"
+        expires_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" +%s 2>/dev/null || echo 0)
     else
         expires_epoch=$(date -d "$expires_at" +%s 2>/dev/null || echo 0)
     fi


### PR DESCRIPTION
## Summary

- Fix macOS `date -j -f` misinterpreting UTC timestamps as local time
- Apply consistent fix pattern across 4 affected scripts
- Resolves negative uptime display and incorrect claim expiry calculations

## Details

macOS's `date -j -f` command interprets timestamps as **local time** even when the format string includes the `Z` (UTC) suffix. This caused:
- Negative uptime values in daemon status (e.g., `-7h -55m`)
- Incorrect claim expiry checks (claims appearing expired/not-expired at wrong times)

### Files Fixed

1. `scripts/lean/status.sh` - Daemon uptime calculation
2. `scripts/erdos/clean-enhancers.sh` - Claim expiry checking
3. `scripts/research/clean-research.sh` - Claim expiry checking
4. `scripts/research/claim-problem.sh` - Claim expiry checking

### The Fix

```bash
# BEFORE (broken - interprets as local time):
start_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$started_at" +%s)

# AFTER (correct - parses as UTC):
local clean_ts="${started_at%Z}"
start_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" +%s)
```

The fix:
1. Strips the `Z` suffix from the timestamp (since it's ignored anyway)
2. Explicitly sets `TZ=UTC` for the `date` command
3. Uses format string without `Z` suffix

### Testing

Verified on macOS (Darwin):
```
Input timestamp: 2026-01-27T12:00:00Z
Old approach epoch: 1769544000 (wrong - 8 hours off)
New approach epoch: 1769515200 (correct)
```

The reference implementation in `scripts/erdos/claim-stub.sh` (which already worked correctly) was used as the pattern.

## Test plan

- [x] All 4 scripts pass `bash -n` syntax validation
- [x] `./scripts/lean/status.sh` runs without errors
- [x] UTC timestamp parsing test shows correct behavior
- [ ] Manual test: Start daemon, verify positive uptime displays

Closes #1460

Generated with [Claude Code](https://claude.com/claude-code)