### PR TITLE
Fix stubs count grep pattern to match find-stubs.ts output

### DIFF
--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -827,7 +827,7 @@ get_work_queue_stats() {
 
     # Stubs count (with 10s timeout)
     if command -v npx &>/dev/null && [[ -f "scripts/erdos/find-stubs.ts" ]]; then
-        stubs=$(timeout 10 npx tsx scripts/erdos/find-stubs.ts --stats 2>/dev/null | grep -oE "with sources: [0-9]+" | grep -oE "[0-9]+" || echo "?")
+        stubs=$(timeout 10 npx tsx scripts/erdos/find-stubs.ts --stats 2>/dev/null | grep -oE "Stubs needing enhancement: +[0-9]+" | grep -oE "[0-9]+" || echo "?")
     fi
 
     # Research candidates

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -68,7 +68,7 @@ get_session_uptime() {
 # Helper: Count stubs needing enhancement
 count_stubs() {
     if command -v npx &>/dev/null && [[ -f "scripts/erdos/find-stubs.ts" ]]; then
-        npx tsx scripts/erdos/find-stubs.ts --stats 2>/dev/null | grep -oE "with sources: [0-9]+" | grep -oE "[0-9]+" || echo "?"
+        npx tsx scripts/erdos/find-stubs.ts --stats 2>/dev/null | grep -oE "Stubs needing enhancement: +[0-9]+" | grep -oE "[0-9]+" || echo "?"
     else
         echo "?"
     fi
@@ -193,7 +193,7 @@ gather_status() {
     "started_at": "$started_at"
   },
   "work_queue": {
-    "stubs_with_sources": "$stubs_count",
+    "stubs_needing_enhancement": "$stubs_count",
     "aristotle_pending": $aristotle_jobs,
     "research_available": $research_problems,
     "prs_ready": $ready_prs
@@ -246,7 +246,7 @@ EOF
         # Work Queue
         echo -e "  ${CYAN}Work Queue:${NC}"
         if [[ "$stubs_count" != "0" ]]; then
-            echo "    Stubs needing enhancement: $stubs_count (with sources)"
+            echo "    Stubs needing enhancement: $stubs_count"
         fi
         echo "    Aristotle jobs pending: $aristotle_jobs"
         echo "    Research problems available: $research_problems"


### PR DESCRIPTION
## Summary

- Fixed grep pattern in `status.sh` and `launch.sh` that was searching for a non-existent output format
- The pattern `"with sources: [0-9]+"` never matched because `find-stubs.ts --stats` outputs `"Stubs needing enhancement: 361 (31.7%)"`
- Updated to match actual format: `"Stubs needing enhancement: +[0-9]+"`
- Also cleaned up misleading display text and JSON field name

## Test plan

- [x] `./scripts/lean/status.sh` now shows actual stub count (361) instead of "?"
- [x] `./scripts/lean/status.sh --json` has correct field name `stubs_needing_enhancement`
- [x] Grep pattern correctly extracts the number from find-stubs.ts output

Closes #1461

Generated with [Claude Code](https://claude.com/claude-code)