### PR TITLE
Improve rebase conflict handling in parallel-research.sh

### DIFF
--- a/scripts/research/parallel-research.sh
+++ b/scripts/research/parallel-research.sh
@@ -74,12 +74,17 @@ create_worktree() {
             cd "$worktree_path"
             git fetch origin main 2>/dev/null || true
             git stash 2>/dev/null || true
+
             if git rebase origin/main 2>/dev/null; then
                 print_success "Rebased successfully"
             else
+                # Abort rebase to keep worktree clean (no conflict markers)
                 git rebase --abort 2>/dev/null || true
-                print_warning "Rebase had conflicts - continuing with current state"
+                print_warning "Rebase conflicts detected - continuing with current branch state (slightly stale)"
+                print_warning "    Worktree: $worktree_path"
+                print_warning "    Manual sync: cd $worktree_path && git reset --hard origin/main"
             fi
+
             git stash pop 2>/dev/null || true
         )
         return 0


### PR DESCRIPTION
## Summary

- Improves warning messages when rebase conflicts occur in research agent worktrees
- Makes worktree state explicit: "continuing with current branch state (slightly stale)"
- Adds worktree path to warning for easier debugging
- Provides manual sync instructions (git reset --hard origin/main)

## Changes

The existing `git rebase --abort` logic was already correct (keeps worktree clean with no conflict markers). This PR improves the messaging to make the situation clearer:

```diff
-                print_warning "Rebase had conflicts - continuing with current state"
+                # Abort rebase to keep worktree clean (no conflict markers)
+                git rebase --abort 2>/dev/null || true
+                print_warning "Rebase conflicts detected - continuing with current branch state (slightly stale)"
+                print_warning "    Worktree: $worktree_path"
+                print_warning "    Manual sync: cd $worktree_path && git reset --hard origin/main"
```

## Acceptance Criteria (from #1462)

- [x] Research agent script: Rebase conflicts abort cleanly, no dirty worktrees
- [x] Enhancer script: Verified no rebase logic (creates fresh worktrees)
- [x] Logging: Clear warning messages when rebase conflicts occur
- [x] Worktree state: Clean working tree after rebase failure (abort keeps it clean)
- [x] Agent behavior: Agents continue on clean (possibly stale) branch
- [x] Documentation: Comment explains conflict handling

## Test plan

- [ ] Syntax check passes (`bash -n scripts/research/parallel-research.sh`)
- [ ] Project build succeeds (`pnpm build`)
- [ ] Manual test: Create conflicting commits in worktree and relaunch agent to verify clean abort and clear warning messages

Closes #1462

---
Generated with [Claude Code](https://claude.com/claude-code)