### PR TITLE
Add worktree isolation for deployer/seeker and pool locking

### DIFF
--- a/scripts/deploy/launch-agent.sh
+++ b/scripts/deploy/launch-agent.sh
@@ -44,9 +44,12 @@ GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
+YELLOW='\033[1;33m'
+
 print_error() { echo -e "${RED}✗ $1${NC}"; }
 print_success() { echo -e "${GREEN}✓ $1${NC}"; }
 print_info() { echo -e "${BLUE}ℹ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}! $1${NC}"; }
 
 # Check dependencies
 check_deps() {


### PR DESCRIPTION
## Summary

- Add flock-based file locking for `candidate-pool.json` to prevent race conditions when multiple agents update problem status concurrently
- Create dedicated worktrees for deployer (`.loom/worktrees/deployer`) and seeker (`.loom/worktrees/seeker`) agents
- Update launch scripts to create/sync worktrees before starting agents, matching the pattern used by enhancers and researchers

## Implementation Details

### File Locking (Phase 1 from issue)

Added to `scripts/research/claim-problem.sh`:
- `acquire_pool_lock()` - Uses `flock` on Linux, falls back to `mkdir`-based locking on macOS
- `release_pool_lock()` - Releases the lock
- `with_pool_lock()` - Wrapper to run commands with locking
- 30 second timeout to prevent deadlocks
- Lock file: `.loom/locks/candidate-pool.lock`

### Worktree Isolation (Phase 2 from issue)

Updated `scripts/deploy/launch-agent.sh`:
- Creates worktree at `.loom/worktrees/deployer`
- Syncs with `origin/main` on restart
- Links `.lake` for Lean builds
- Runs tmux session in worktree

Updated `scripts/research/launch-seeker.sh`:
- Creates worktree at `.loom/worktrees/seeker`
- Rebases on `origin/main` on restart
- Links `.lake` for Lean builds
- Runs tmux session in worktree

## Test plan

- [x] All scripts pass `bash -n` syntax check
- [x] All scripts pass `shellcheck` (deployer/seeker clean, claim-problem has pre-existing minor warnings)
- [x] `--help` commands work correctly for all modified scripts
- [x] `--status` commands work correctly and show worktree paths
- [ ] Manual testing: Start deployer and verify it runs in worktree
- [ ] Manual testing: Start seeker and verify it runs in worktree
- [ ] Manual testing: Run concurrent `claim-problem.sh update` commands to verify locking

Closes #1464

:robot: Generated with [Claude Code](https://claude.com/claude-code)