### PR TITLE
Fix macOS UTC timestamp parsing across remaining scripts

### DIFF
--- a/.lean/scripts/research-available.sh
+++ b/.lean/scripts/research-available.sh
@@ -99,7 +99,9 @@ for problem_id in $AVAILABLE_IN_POOL; do
             EXPIRES_AT=$(jq -r '.expires_at' "$CLAIM_FILE")
             NOW_EPOCH=$(date -u +%s)
             if [[ "$(uname)" == "Darwin" ]]; then
-                EXPIRES_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$EXPIRES_AT" +%s 2>/dev/null || echo 0)
+                # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+                clean_ts="${EXPIRES_AT%Z}"
+                EXPIRES_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" +%s 2>/dev/null || echo 0)
             else
                 EXPIRES_EPOCH=$(date -d "$EXPIRES_AT" +%s 2>/dev/null || echo 0)
             fi

--- a/.lean/scripts/research-claim.sh
+++ b/.lean/scripts/research-claim.sh
@@ -135,7 +135,9 @@ else
         # Compare timestamps
         NOW_EPOCH=$(date -u +%s)
         if [[ "$(uname)" == "Darwin" ]]; then
-            EXPIRES_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$EXISTING_EXPIRES" +%s 2>/dev/null || echo 0)
+            # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+            clean_ts="${EXISTING_EXPIRES%Z}"
+            EXPIRES_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" +%s 2>/dev/null || echo 0)
         else
             EXPIRES_EPOCH=$(date -d "$EXISTING_EXPIRES" +%s 2>/dev/null || echo 0)
         fi

--- a/.lean/scripts/research-cleanup.sh
+++ b/.lean/scripts/research-cleanup.sh
@@ -90,7 +90,9 @@ for claim_file in "$CLAIMS_DIR"/*.json; do
 
     # Parse expiry time
     if [[ "$(uname)" == "Darwin" ]]; then
-        EXPIRES_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$expires_at" +%s 2>/dev/null || echo 0)
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        clean_ts="${expires_at%Z}"
+        EXPIRES_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" +%s 2>/dev/null || echo 0)
     else
         EXPIRES_EPOCH=$(date -d "$expires_at" +%s 2>/dev/null || echo 0)
     fi

--- a/.loom/scripts/check-completions.sh
+++ b/.loom/scripts/check-completions.sh
@@ -1,0 +1,503 @@
+#!/usr/bin/env bash
+# check-completions.sh - Check task completions and detect silent failures
+#
+# This script polls all active task IDs from daemon-state.json and checks if
+# their output files indicate completion. It detects silent failures where
+# tasks have exited but issues are still in loom:building state.
+#
+# Usage:
+#   ./check-completions.sh                # Check all active tasks
+#   ./check-completions.sh --json         # Output JSON for programmatic use
+#   ./check-completions.sh --recover      # Auto-recover silently failed tasks
+#   ./check-completions.sh --verbose      # Show detailed progress
+#
+# Exit codes:
+#   0 - All tasks healthy (or recovered with --recover)
+#   1 - Silent failures detected
+#   2 - State file not found
+#
+# Checks:
+#   - Shepherd task output files for completion/error markers
+#   - Support role task output files
+#   - Progress files for heartbeat staleness
+#   - GitHub label state vs daemon state consistency
+#
+# Detects:
+#   - completed: Task completed successfully
+#   - errored: Task exited with error
+#   - stale: No heartbeat for extended period
+#   - orphaned: Issue in loom:building but no active task
+#   - missing_output: Output file doesn't exist
+
+set -euo pipefail
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Staleness thresholds (in seconds)
+HEARTBEAT_STALE_THRESHOLD="${LOOM_HEARTBEAT_STALE_THRESHOLD:-300}"  # 5 minutes
+OUTPUT_STALE_THRESHOLD="${LOOM_OUTPUT_STALE_THRESHOLD:-600}"        # 10 minutes
+
+# Find the repository root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository" >&2
+    return 1
+}
+
+REPO_ROOT=$(find_repo_root)
+STATE_FILE="$REPO_ROOT/.loom/daemon-state.json"
+PROGRESS_DIR="$REPO_ROOT/.loom/progress"
+
+# Parse arguments
+JSON_OUTPUT=false
+RECOVER=false
+VERBOSE=false
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --json)
+            JSON_OUTPUT=true
+            shift
+            ;;
+        --recover)
+            RECOVER=true
+            shift
+            ;;
+        --verbose|-v)
+            VERBOSE=true
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --help|-h)
+            cat <<EOF
+Usage: $0 [OPTIONS]
+
+Check task completions and detect silent failures.
+
+Options:
+  --json        Output JSON for programmatic use
+  --recover     Auto-recover silently failed tasks (revert labels)
+  --verbose     Show detailed progress
+  --dry-run     Show what would be recovered without making changes
+  --help        Show this help message
+
+Exit codes:
+  0 - All tasks healthy (or recovered with --recover)
+  1 - Silent failures detected
+  2 - State file not found
+
+Environment variables:
+  LOOM_HEARTBEAT_STALE_THRESHOLD   Seconds before heartbeat is stale (default: 300)
+  LOOM_OUTPUT_STALE_THRESHOLD      Seconds before output is stale (default: 600)
+
+Task states detected:
+  completed        Task completed successfully
+  errored          Task exited with error
+  stale            No heartbeat for extended period
+  orphaned         Issue in loom:building but no active task
+  missing_output   Output file doesn't exist
+  running          Task is still active
+
+Examples:
+  $0                     # Check all tasks
+  $0 --json              # Machine-readable output
+  $0 --recover --verbose # Recover and show details
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Logging helpers
+log_info() {
+    if [[ "$JSON_OUTPUT" != "true" ]]; then
+        echo -e "${BLUE}[INFO]${NC} $*" >&2
+    fi
+}
+
+log_verbose() {
+    if [[ "$VERBOSE" == "true" && "$JSON_OUTPUT" != "true" ]]; then
+        echo -e "${BLUE}[DEBUG]${NC} $*" >&2
+    fi
+}
+
+log_success() {
+    if [[ "$JSON_OUTPUT" != "true" ]]; then
+        echo -e "${GREEN}[OK]${NC} $*" >&2
+    fi
+}
+
+log_warn() {
+    if [[ "$JSON_OUTPUT" != "true" ]]; then
+        echo -e "${YELLOW}[WARN]${NC} $*" >&2
+    fi
+}
+
+log_error() {
+    if [[ "$JSON_OUTPUT" != "true" ]]; then
+        echo -e "${RED}[ERROR]${NC} $*" >&2
+    fi
+}
+
+# Check if state file exists
+if [[ ! -f "$STATE_FILE" ]]; then
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        echo '{"error": "state_file_not_found", "file": "'"$STATE_FILE"'"}'
+    else
+        log_error "State file not found: $STATE_FILE"
+    fi
+    exit 2
+fi
+
+# Load state
+STATE=$(cat "$STATE_FILE")
+
+# Results tracking
+declare -a COMPLETED=()
+declare -a ERRORED=()
+declare -a STALE=()
+declare -a ORPHANED=()
+declare -a RUNNING=()
+declare -a RECOVERIES=()
+
+# Get current timestamp in seconds since epoch
+get_epoch() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        date +%s
+    else
+        date +%s
+    fi
+}
+
+# Convert ISO timestamp to epoch
+iso_to_epoch() {
+    local iso="$1"
+    if [[ "$(uname)" == "Darwin" ]]; then
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        local clean_ts="${iso%Z}"
+        TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0"
+    else
+        # GNU date
+        date -d "$iso" "+%s" 2>/dev/null || echo "0"
+    fi
+}
+
+NOW_EPOCH=$(get_epoch)
+
+# Check shepherd tasks
+log_info "Checking shepherd tasks..."
+
+SHEPHERDS=$(echo "$STATE" | jq -c '.shepherds // {} | to_entries[]' 2>/dev/null || true)
+
+while IFS= read -r shepherd_entry; do
+    [[ -z "$shepherd_entry" ]] && continue
+
+    shepherd_id=$(echo "$shepherd_entry" | jq -r '.key')
+    shepherd_data=$(echo "$shepherd_entry" | jq -r '.value')
+    status=$(echo "$shepherd_data" | jq -r '.status // "unknown"')
+    issue=$(echo "$shepherd_data" | jq -r '.issue // empty')
+    task_id=$(echo "$shepherd_data" | jq -r '.task_id // empty')
+    output_file=$(echo "$shepherd_data" | jq -r '.output_file // empty')
+    execution_mode=$(echo "$shepherd_data" | jq -r '.execution_mode // "direct"')
+
+    log_verbose "Checking shepherd $shepherd_id: status=$status, issue=$issue, task_id=$task_id"
+
+    # Skip idle shepherds
+    if [[ "$status" == "idle" ]]; then
+        log_verbose "  Skipping (idle)"
+        continue
+    fi
+
+    # For working shepherds, check task status
+    if [[ "$status" == "working" ]]; then
+        # Check progress file for heartbeat
+        if [[ -n "$task_id" && -d "$PROGRESS_DIR" ]]; then
+            progress_file="$PROGRESS_DIR/shepherd-${task_id}.json"
+            if [[ -f "$progress_file" ]]; then
+                last_heartbeat=$(jq -r '.last_heartbeat // empty' "$progress_file" 2>/dev/null || true)
+                if [[ -n "$last_heartbeat" ]]; then
+                    heartbeat_epoch=$(iso_to_epoch "$last_heartbeat")
+                    heartbeat_age=$((NOW_EPOCH - heartbeat_epoch))
+                    log_verbose "  Heartbeat age: ${heartbeat_age}s"
+
+                    if [[ $heartbeat_age -gt $HEARTBEAT_STALE_THRESHOLD ]]; then
+                        STALE+=("$shepherd_id:$issue:$task_id:heartbeat_stale:${heartbeat_age}s")
+                        log_warn "Shepherd $shepherd_id has stale heartbeat (${heartbeat_age}s)"
+                        continue
+                    fi
+                fi
+
+                # Check progress file status
+                progress_status=$(jq -r '.status // "working"' "$progress_file" 2>/dev/null || echo "working")
+                if [[ "$progress_status" == "completed" ]]; then
+                    COMPLETED+=("$shepherd_id:$issue:$task_id")
+                    log_success "Shepherd $shepherd_id completed (issue #$issue)"
+                    continue
+                elif [[ "$progress_status" == "error" ]]; then
+                    ERRORED+=("$shepherd_id:$issue:$task_id:progress_error")
+                    log_error "Shepherd $shepherd_id errored (issue #$issue)"
+                    continue
+                fi
+            fi
+        fi
+
+        # Check output file for direct mode tasks
+        if [[ "$execution_mode" == "direct" && -n "$output_file" ]]; then
+            if [[ ! -f "$output_file" ]]; then
+                # Output file missing - task may have never started or crashed
+                ERRORED+=("$shepherd_id:$issue:$task_id:missing_output")
+                log_warn "Shepherd $shepherd_id output file missing: $output_file"
+                continue
+            fi
+
+            # Check output file modification time
+            if [[ "$(uname)" == "Darwin" ]]; then
+                output_mtime=$(stat -f %m "$output_file" 2>/dev/null || echo "0")
+            else
+                output_mtime=$(stat -c %Y "$output_file" 2>/dev/null || echo "0")
+            fi
+            output_age=$((NOW_EPOCH - output_mtime))
+
+            if [[ $output_age -gt $OUTPUT_STALE_THRESHOLD ]]; then
+                STALE+=("$shepherd_id:$issue:$task_id:output_stale:${output_age}s")
+                log_warn "Shepherd $shepherd_id has stale output (${output_age}s)"
+                continue
+            fi
+
+            # Check output for completion/error markers
+            if grep -q "AGENT_EXIT_CODE=0" "$output_file" 2>/dev/null; then
+                COMPLETED+=("$shepherd_id:$issue:$task_id")
+                log_success "Shepherd $shepherd_id completed (issue #$issue)"
+                continue
+            elif grep -q "AGENT_EXIT_CODE=" "$output_file" 2>/dev/null; then
+                ERRORED+=("$shepherd_id:$issue:$task_id:exit_error")
+                log_error "Shepherd $shepherd_id exited with error (issue #$issue)"
+                continue
+            fi
+        fi
+
+        # Still running
+        RUNNING+=("$shepherd_id:$issue:$task_id")
+        log_verbose "  Still running"
+    fi
+done < <(echo "$SHEPHERDS")
+
+# Check support role tasks
+log_info "Checking support role tasks..."
+
+SUPPORT_ROLES=$(echo "$STATE" | jq -c '.support_roles // {} | to_entries[]' 2>/dev/null || true)
+
+while IFS= read -r role_entry; do
+    [[ -z "$role_entry" ]] && continue
+
+    role_name=$(echo "$role_entry" | jq -r '.key')
+    role_data=$(echo "$role_entry" | jq -r '.value')
+    status=$(echo "$role_data" | jq -r '.status // "unknown"')
+    task_id=$(echo "$role_data" | jq -r '.task_id // empty')
+    output_file=$(echo "$role_data" | jq -r '.output_file // empty')
+
+    log_verbose "Checking support role $role_name: status=$status, task_id=$task_id"
+
+    # Skip idle roles
+    if [[ "$status" == "idle" ]]; then
+        log_verbose "  Skipping (idle)"
+        continue
+    fi
+
+    # For running roles, check task status
+    if [[ "$status" == "running" && -n "$output_file" ]]; then
+        if [[ ! -f "$output_file" ]]; then
+            ERRORED+=("support:$role_name:$task_id:missing_output")
+            log_warn "Support role $role_name output file missing"
+            continue
+        fi
+
+        # Check output file modification time
+        if [[ "$(uname)" == "Darwin" ]]; then
+            output_mtime=$(stat -f %m "$output_file" 2>/dev/null || echo "0")
+        else
+            output_mtime=$(stat -c %Y "$output_file" 2>/dev/null || echo "0")
+        fi
+        output_age=$((NOW_EPOCH - output_mtime))
+
+        if [[ $output_age -gt $OUTPUT_STALE_THRESHOLD ]]; then
+            STALE+=("support:$role_name:$task_id:output_stale:${output_age}s")
+            log_warn "Support role $role_name has stale output (${output_age}s)"
+            continue
+        fi
+
+        # Check output for completion/error markers
+        if grep -q "AGENT_EXIT_CODE=0" "$output_file" 2>/dev/null; then
+            COMPLETED+=("support:$role_name:$task_id")
+            log_success "Support role $role_name completed"
+        elif grep -q "AGENT_EXIT_CODE=" "$output_file" 2>/dev/null; then
+            ERRORED+=("support:$role_name:$task_id:exit_error")
+            log_error "Support role $role_name exited with error"
+        else
+            RUNNING+=("support:$role_name:$task_id")
+            log_verbose "  Still running"
+        fi
+    fi
+done < <(echo "$SUPPORT_ROLES")
+
+# Check for orphaned issues (loom:building but no active shepherd)
+log_info "Checking for orphaned issues..."
+
+BUILDING_ISSUES=$(gh issue list --label "loom:building" --state open --json number --jq '.[].number' 2>/dev/null || true)
+
+for issue_num in $BUILDING_ISSUES; do
+    # Check if this issue is tracked by any shepherd
+    tracked=false
+    while IFS= read -r shepherd_entry; do
+        [[ -z "$shepherd_entry" ]] && continue
+        shepherd_issue=$(echo "$shepherd_entry" | jq -r '.value.issue // empty')
+        if [[ "$shepherd_issue" == "$issue_num" ]]; then
+            tracked=true
+            break
+        fi
+    done < <(echo "$STATE" | jq -c '.shepherds // {} | to_entries[]' 2>/dev/null || true)
+
+    if [[ "$tracked" == "false" ]]; then
+        ORPHANED+=("issue:$issue_num")
+        log_warn "Issue #$issue_num is in loom:building but not tracked by any shepherd"
+    fi
+done
+
+# Recovery actions
+if [[ "$RECOVER" == "true" ]]; then
+    log_info "Performing recovery actions..."
+
+    # Recover errored shepherds
+    for error_entry in "${ERRORED[@]}"; do
+        shepherd_part=$(echo "$error_entry" | cut -d: -f1)
+        issue=$(echo "$error_entry" | cut -d: -f2)
+
+        # Only recover shepherd issues (not support roles)
+        if [[ "$shepherd_part" != "support" && -n "$issue" ]]; then
+            if [[ "$DRY_RUN" == "true" ]]; then
+                log_info "  Would revert issue #$issue from loom:building to loom:issue"
+            else
+                if gh issue edit "$issue" --remove-label "loom:building" --add-label "loom:issue" 2>/dev/null; then
+                    log_success "  Reverted issue #$issue to loom:issue"
+                    RECOVERIES+=("revert:$issue")
+
+                    # Add recovery comment
+                    gh issue comment "$issue" --body "**Silent Failure Recovery**
+
+This issue was automatically recovered after a silent task failure.
+
+**What happened**:
+- The shepherd task exited without completing
+- The issue was left in \`loom:building\` state
+
+**Action taken**:
+- Returned to \`loom:issue\` state for re-processing
+
+---
+*Recovered by check-completions.sh at $(date -u +%Y-%m-%dT%H:%M:%SZ)*" 2>/dev/null || true
+                else
+                    log_error "  Failed to revert issue #$issue"
+                fi
+            fi
+        fi
+    done
+
+    # Recover orphaned issues
+    for orphan_entry in "${ORPHANED[@]}"; do
+        issue=$(echo "$orphan_entry" | cut -d: -f2)
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log_info "  Would revert orphaned issue #$issue from loom:building to loom:issue"
+        else
+            if gh issue edit "$issue" --remove-label "loom:building" --add-label "loom:issue" 2>/dev/null; then
+                log_success "  Reverted orphaned issue #$issue to loom:issue"
+                RECOVERIES+=("revert_orphan:$issue")
+            else
+                log_error "  Failed to revert orphaned issue #$issue"
+            fi
+        fi
+    done
+fi
+
+# Generate output
+if [[ "$JSON_OUTPUT" == "true" ]]; then
+    # Build arrays
+    completed_json=$(printf '%s\n' "${COMPLETED[@]}" 2>/dev/null | jq -R . | jq -s . || echo "[]")
+    errored_json=$(printf '%s\n' "${ERRORED[@]}" 2>/dev/null | jq -R . | jq -s . || echo "[]")
+    stale_json=$(printf '%s\n' "${STALE[@]}" 2>/dev/null | jq -R . | jq -s . || echo "[]")
+    orphaned_json=$(printf '%s\n' "${ORPHANED[@]}" 2>/dev/null | jq -R . | jq -s . || echo "[]")
+    running_json=$(printf '%s\n' "${RUNNING[@]}" 2>/dev/null | jq -R . | jq -s . || echo "[]")
+    recoveries_json=$(printf '%s\n' "${RECOVERIES[@]}" 2>/dev/null | jq -R . | jq -s . || echo "[]")
+
+    has_failures="false"
+    if [[ ${#ERRORED[@]} -gt 0 || ${#ORPHANED[@]} -gt 0 ]]; then
+        has_failures="true"
+    fi
+
+    jq -n \
+        --argjson completed "$completed_json" \
+        --argjson errored "$errored_json" \
+        --argjson stale "$stale_json" \
+        --argjson orphaned "$orphaned_json" \
+        --argjson running "$running_json" \
+        --argjson recoveries "$recoveries_json" \
+        --argjson has_failures "$has_failures" \
+        '{
+            completed: $completed,
+            errored: $errored,
+            stale: $stale,
+            orphaned: $orphaned,
+            running: $running,
+            recoveries: $recoveries,
+            summary: {
+                completed_count: ($completed | length),
+                errored_count: ($errored | length),
+                stale_count: ($stale | length),
+                orphaned_count: ($orphaned | length),
+                running_count: ($running | length),
+                recovery_count: ($recoveries | length),
+                has_failures: $has_failures
+            }
+        }'
+else
+    # Human-readable summary
+    echo ""
+    log_info "=== Task Completion Summary ==="
+    echo "  Running:   ${#RUNNING[@]}"
+    echo "  Completed: ${#COMPLETED[@]}"
+    echo "  Errored:   ${#ERRORED[@]}"
+    echo "  Stale:     ${#STALE[@]}"
+    echo "  Orphaned:  ${#ORPHANED[@]}"
+    if [[ ${#RECOVERIES[@]} -gt 0 ]]; then
+        echo "  Recovered: ${#RECOVERIES[@]}"
+    fi
+fi
+
+# Exit code
+if [[ ${#ERRORED[@]} -gt 0 || ${#ORPHANED[@]} -gt 0 ]]; then
+    if [[ "$RECOVER" == "true" && ${#RECOVERIES[@]} -gt 0 ]]; then
+        exit 0  # Issues detected but recovered
+    fi
+    exit 1  # Silent failures detected
+fi
+
+exit 0

--- a/.loom/scripts/clean.sh
+++ b/.loom/scripts/clean.sh
@@ -200,8 +200,9 @@ check_grace_period() {
   # Parse merged_at timestamp
   local merged_ts
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    # macOS
-    merged_ts=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$merged_at" +%s 2>/dev/null || echo "0")
+    # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+    local clean_ts="${merged_at%Z}"
+    merged_ts=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" +%s 2>/dev/null || echo "0")
   else
     # Linux
     merged_ts=$(date -d "$merged_at" +%s 2>/dev/null || echo "0")

--- a/.loom/scripts/daemon-cleanup.sh
+++ b/.loom/scripts/daemon-cleanup.sh
@@ -289,7 +289,9 @@ cleanup_stale_progress_files() {
         if [[ -n "$last_heartbeat" && "$last_heartbeat" != "null" ]]; then
           local hb_epoch
           if [[ "$(uname)" == "Darwin" ]]; then
-            hb_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_heartbeat" "+%s" 2>/dev/null || echo "0")
+            # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+            local clean_ts="${last_heartbeat%Z}"
+            hb_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
           else
             hb_epoch=$(date -d "$last_heartbeat" "+%s" 2>/dev/null || echo "0")
           fi

--- a/.loom/scripts/daemon-health.sh
+++ b/.loom/scripts/daemon-health.sh
@@ -1,0 +1,920 @@
+#!/usr/bin/env bash
+# daemon-health.sh - Diagnostic health check for Loom daemon
+#
+# Usage:
+#   daemon-health.sh              Display health report
+#   daemon-health.sh --json       Output health report as JSON
+#   daemon-health.sh --help       Show help
+#
+# This script consolidates daemon diagnostics into a single report:
+# - Validates daemon state file structure and integrity
+# - Checks shepherd task ID format (7-char hex)
+# - Queries GitHub for pipeline state (label counts)
+# - Detects orphaned loom:building issues (no shepherd entry)
+# - Detects stale loom:building issues (no PR after threshold)
+# - Reports support role spawn times vs expected intervals
+# - Works when daemon is NOT running (reads last state snapshot)
+#
+# Exit codes:
+#   0 - Healthy (no warnings or critical issues)
+#   1 - Warnings detected (degraded but functional)
+#   2 - Critical issues (state corruption, orphaned work)
+
+set -euo pipefail
+
+# Colors for output (disabled if stdout is not a terminal)
+# shellcheck disable=SC2034  # Color palette - not all colors used in every script
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    CYAN='\033[0;36m'
+    GRAY='\033[0;90m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    CYAN=''
+    GRAY=''
+    BOLD=''
+    NC=''
+fi
+
+# Find the repository root (works from any subdirectory)
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            if [[ -f "$dir/.git" ]]; then
+                local gitdir
+                gitdir=$(sed 's/^gitdir: //' "$dir/.git")
+                local main_repo
+                main_repo=$(dirname "$(dirname "$(dirname "$gitdir")")")
+                if [[ -d "$main_repo/.loom" ]]; then
+                    echo "$main_repo"
+                    return 0
+                fi
+            fi
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository" >&2
+    return 1
+}
+
+REPO_ROOT=$(find_repo_root)
+DAEMON_STATE_FILE="$REPO_ROOT/.loom/daemon-state.json"
+
+# Stale threshold in minutes for loom:building issues without a PR
+STALE_BUILDING_MINUTES="${LOOM_STALE_BUILDING_MINUTES:-15}"
+
+# Support role expected intervals (seconds)
+GUIDE_INTERVAL="${LOOM_GUIDE_INTERVAL:-900}"        # 15 minutes
+CHAMPION_INTERVAL="${LOOM_CHAMPION_INTERVAL:-600}"  # 10 minutes
+DOCTOR_INTERVAL="${LOOM_DOCTOR_INTERVAL:-300}"      # 5 minutes
+AUDITOR_INTERVAL="${LOOM_AUDITOR_INTERVAL:-600}"    # 10 minutes
+JUDGE_INTERVAL="${LOOM_JUDGE_INTERVAL:-300}"        # 5 minutes
+
+show_help() {
+    cat <<EOF
+${BOLD}daemon-health.sh - Diagnostic Health Check for Loom Daemon${NC}
+
+${YELLOW}USAGE:${NC}
+    daemon-health.sh              Display health report
+    daemon-health.sh --json       Output health report as JSON
+    daemon-health.sh --help       Show this help message
+
+${YELLOW}DESCRIPTION:${NC}
+    Provides a consolidated diagnostic view of daemon health by:
+
+    - Validating state file JSON structure and required fields
+    - Checking shepherd task ID format (7-char hex)
+    - Querying GitHub for pipeline state (label counts)
+    - Detecting orphaned loom:building issues (no shepherd entry)
+    - Detecting stale loom:building issues (no PR after threshold)
+    - Reporting support role spawn times vs expected intervals
+    - Working when daemon is NOT running (reads last state snapshot)
+
+${YELLOW}EXIT CODES:${NC}
+    0   Healthy - no warnings or critical issues
+    1   Warnings detected - degraded but functional
+    2   Critical issues - state corruption, orphaned work
+
+${YELLOW}ENVIRONMENT VARIABLES:${NC}
+    LOOM_STALE_BUILDING_MINUTES    Minutes before flagging stale building (default: 15)
+    LOOM_GUIDE_INTERVAL            Guide expected interval in seconds (default: 900)
+    LOOM_CHAMPION_INTERVAL         Champion expected interval in seconds (default: 600)
+    LOOM_DOCTOR_INTERVAL           Doctor expected interval in seconds (default: 300)
+    LOOM_AUDITOR_INTERVAL          Auditor expected interval in seconds (default: 600)
+    LOOM_JUDGE_INTERVAL            Judge expected interval in seconds (default: 300)
+
+${YELLOW}EXAMPLES:${NC}
+    # Quick diagnostic check
+    daemon-health.sh
+
+    # Machine-readable output
+    daemon-health.sh --json
+
+    # Use in scripts
+    if ! daemon-health.sh >/dev/null 2>&1; then
+        echo "Daemon health check failed"
+    fi
+
+${YELLOW}RELATED SCRIPTS:${NC}
+    daemon-snapshot.sh             Real-time state snapshot (JSON)
+    stale-building-check.sh        Detect stuck issues
+    recover-orphaned-shepherds.sh  Clean up after crashes
+    health-check.sh                Proactive health monitoring and alerting
+EOF
+}
+
+# Parse arguments
+JSON_OUTPUT=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --json)
+            JSON_OUTPUT=true
+            shift
+            ;;
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Error: Unknown option '$1'${NC}" >&2
+            echo "Run 'daemon-health.sh --help' for usage" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ---- Tracking ----
+WARNINGS=0
+CRITICALS=0
+WARNING_MESSAGES=()
+CRITICAL_MESSAGES=()
+RECOMMENDATION_MESSAGES=()
+
+add_warning() {
+    WARNINGS=$((WARNINGS + 1))
+    WARNING_MESSAGES+=("$1")
+}
+
+add_critical() {
+    CRITICALS=$((CRITICALS + 1))
+    CRITICAL_MESSAGES+=("$1")
+}
+
+add_recommendation() {
+    RECOMMENDATION_MESSAGES+=("$1")
+}
+
+# ---- Timestamp helpers ----
+
+now_epoch() {
+    date +%s
+}
+
+# Convert ISO timestamp to epoch seconds (macOS/Linux compatible)
+timestamp_to_epoch() {
+    local ts="$1"
+    if [[ -z "$ts" ]] || [[ "$ts" == "null" ]]; then
+        echo "0"
+        return
+    fi
+    if [[ "$(uname)" == "Darwin" ]]; then
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        local clean_ts="${ts%Z}"
+        TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0"
+    else
+        date -d "$ts" "+%s" 2>/dev/null || echo "0"
+    fi
+}
+
+# Format seconds into human-readable duration
+format_duration() {
+    local seconds="$1"
+    if [[ "$seconds" -lt 0 ]]; then
+        echo "unknown"
+        return
+    fi
+    if [[ $seconds -lt 60 ]]; then
+        echo "${seconds} sec"
+    elif [[ $seconds -lt 3600 ]]; then
+        echo "$((seconds / 60)) min"
+    elif [[ $seconds -lt 86400 ]]; then
+        local hours=$((seconds / 3600))
+        local mins=$(((seconds % 3600) / 60))
+        echo "${hours}h ${mins}m"
+    else
+        local days=$((seconds / 86400))
+        local hours=$(((seconds % 86400) / 3600))
+        echo "${days}d ${hours}h"
+    fi
+}
+
+# Format epoch diff as "N min ago" style string
+time_ago() {
+    local ts="$1"
+    local epoch
+    epoch=$(timestamp_to_epoch "$ts")
+    if [[ "$epoch" == "0" ]]; then
+        echo "never"
+        return
+    fi
+    local diff=$(( $(now_epoch) - epoch ))
+    echo "$(format_duration "$diff") ago"
+}
+
+# ---- Helper: read JSON file with safe fallback ----
+read_json_safe() {
+    local f="$1"
+    if [[ -f "$f" ]] && [[ -s "$f" ]]; then
+        cat "$f"
+    else
+        echo "[]"
+    fi
+}
+
+# ---- State file validation ----
+# Returns exit code:
+#   0 = valid
+#   1 = file missing
+#   2 = invalid JSON
+#   3 = missing fields (writes field names to VALIDATE_MISSING_FIELDS)
+VALIDATE_MISSING_FIELDS=""
+
+validate_state_file() {
+    VALIDATE_MISSING_FIELDS=""
+
+    if [[ ! -f "$DAEMON_STATE_FILE" ]]; then
+        return 1
+    fi
+
+    # Check if valid JSON
+    if ! jq -e . "$DAEMON_STATE_FILE" >/dev/null 2>&1; then
+        return 2
+    fi
+
+    # Check required top-level fields
+    # Use 'has()' instead of '-e' because '-e' treats false/null as failure
+    local missing=()
+    for field in started_at running iteration shepherds; do
+        if ! jq -e "has(\"$field\")" "$DAEMON_STATE_FILE" >/dev/null 2>&1; then
+            missing+=("$field")
+        fi
+    done
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        VALIDATE_MISSING_FIELDS="${missing[*]}"
+        return 3
+    fi
+
+    return 0
+}
+
+# ---- Task ID validation ----
+# Valid task IDs are 7-character hex strings (e.g., "a1b2c3d")
+validate_task_id() {
+    local task_id="$1"
+    if [[ -z "$task_id" ]] || [[ "$task_id" == "null" ]]; then
+        # null task_id is fine for idle shepherds
+        return 0
+    fi
+    if [[ "$task_id" =~ ^[0-9a-f]{7}$ ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# ---- Pipeline state from GitHub ----
+
+# Global pipeline variables set by get_pipeline_state
+PIPELINE_READY="[]"
+PIPELINE_BUILDING="[]"
+PIPELINE_REVIEW="[]"
+PIPELINE_MERGE="[]"
+PIPELINE_BLOCKED="[]"
+PIPELINE_READY_COUNT=0
+PIPELINE_BUILDING_COUNT=0
+PIPELINE_REVIEW_COUNT=0
+PIPELINE_MERGE_COUNT=0
+PIPELINE_BLOCKED_COUNT=0
+
+get_pipeline_state() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    # Clean up temp dir on function exit
+    trap 'rm -rf "$tmpdir"' RETURN
+
+    # Run all queries in parallel
+    gh issue list --label "loom:issue" --state open --json number,title \
+        > "$tmpdir/ready" 2>/dev/null &
+    local pid_ready=$!
+
+    gh issue list --label "loom:building" --state open --json number,title,createdAt,updatedAt \
+        > "$tmpdir/building" 2>/dev/null &
+    local pid_building=$!
+
+    gh pr list --label "loom:review-requested" --state open --json number,title \
+        > "$tmpdir/review" 2>/dev/null &
+    local pid_review=$!
+
+    gh pr list --label "loom:pr" --state open --json number,title \
+        > "$tmpdir/merge" 2>/dev/null &
+    local pid_merge=$!
+
+    gh issue list --label "loom:blocked" --state open --json number,title \
+        > "$tmpdir/blocked" 2>/dev/null &
+    local pid_blocked=$!
+
+    # Wait for all queries
+    wait $pid_ready $pid_building $pid_review $pid_merge $pid_blocked 2>/dev/null || true
+
+    PIPELINE_READY=$(read_json_safe "$tmpdir/ready")
+    PIPELINE_BUILDING=$(read_json_safe "$tmpdir/building")
+    PIPELINE_REVIEW=$(read_json_safe "$tmpdir/review")
+    PIPELINE_MERGE=$(read_json_safe "$tmpdir/merge")
+    PIPELINE_BLOCKED=$(read_json_safe "$tmpdir/blocked")
+
+    PIPELINE_READY_COUNT=$(echo "$PIPELINE_READY" | jq 'length')
+    PIPELINE_BUILDING_COUNT=$(echo "$PIPELINE_BUILDING" | jq 'length')
+    PIPELINE_REVIEW_COUNT=$(echo "$PIPELINE_REVIEW" | jq 'length')
+    PIPELINE_MERGE_COUNT=$(echo "$PIPELINE_MERGE" | jq 'length')
+    PIPELINE_BLOCKED_COUNT=$(echo "$PIPELINE_BLOCKED" | jq 'length')
+}
+
+# ---- Check orphaned loom:building (labeled but no shepherd entry) ----
+
+ORPHANED_BUILDING=()
+
+check_orphaned_building() {
+    local building_numbers
+    building_numbers=$(echo "$PIPELINE_BUILDING" | jq -r '.[].number' 2>/dev/null)
+
+    ORPHANED_BUILDING=()
+
+    if [[ -z "$building_numbers" ]]; then
+        return
+    fi
+
+    # Get tracked issues from daemon-state shepherds
+    local tracked_issues="[]"
+    if [[ -f "$DAEMON_STATE_FILE" ]]; then
+        tracked_issues=$(jq '[.shepherds // {} | to_entries[] | select(.value.status == "working") | .value.issue] | map(select(. != null))' "$DAEMON_STATE_FILE" 2>/dev/null || echo "[]")
+    fi
+
+    for num in $building_numbers; do
+        [[ -z "$num" ]] && continue
+        local is_tracked
+        is_tracked=$(echo "$tracked_issues" | jq --argjson n "$num" 'any(. == $n)')
+        if [[ "$is_tracked" == "false" ]]; then
+            ORPHANED_BUILDING+=("$num")
+        fi
+    done
+}
+
+# ---- Check stale loom:building (no PR after threshold) ----
+
+STALE_BUILDING=()
+
+check_stale_building() {
+    STALE_BUILDING=()
+    local threshold_secs=$((STALE_BUILDING_MINUTES * 60))
+    local now
+    now=$(now_epoch)
+
+    # Get all open PRs once for matching
+    local open_prs
+    open_prs=$(gh pr list --state open --json number,headRefName,body 2>/dev/null || echo "[]")
+
+    local count
+    count=$(echo "$PIPELINE_BUILDING" | jq 'length')
+
+    local i
+    for i in $(seq 0 $((count - 1))); do
+        local issue
+        issue=$(echo "$PIPELINE_BUILDING" | jq -c ".[$i]")
+        local num
+        num=$(echo "$issue" | jq -r '.number')
+        local updated_at
+        updated_at=$(echo "$issue" | jq -r '.updatedAt // .createdAt')
+
+        local updated_epoch
+        updated_epoch=$(timestamp_to_epoch "$updated_at")
+        if [[ "$updated_epoch" == "0" ]]; then
+            continue
+        fi
+
+        local age_secs=$((now - updated_epoch))
+        if [[ $age_secs -lt $threshold_secs ]]; then
+            continue
+        fi
+
+        # Check if a PR exists for this issue
+        local has_pr
+        has_pr=$(echo "$open_prs" | jq --arg n "$num" \
+            '[.[] | select(
+                (.body // "" | test("(Closes|Fixes|Resolves) #" + $n + "\\b"; "i")) or
+                (.headRefName | test("issue-" + $n + "\\b"))
+            )] | length > 0')
+
+        if [[ "$has_pr" == "false" ]]; then
+            local age_min=$((age_secs / 60))
+            STALE_BUILDING+=("${num}:${age_min}")
+        fi
+    done
+}
+
+# ---- Check support role spawn times ----
+
+SUPPORT_ROLE_STATUS=()
+
+check_support_roles() {
+    SUPPORT_ROLE_STATUS=()
+    local now
+    now=$(now_epoch)
+
+    local roles=("guide" "judge" "champion" "doctor" "auditor")
+    local intervals=("$GUIDE_INTERVAL" "$JUDGE_INTERVAL" "$CHAMPION_INTERVAL" "$DOCTOR_INTERVAL" "$AUDITOR_INTERVAL")
+    local interval_display=("15 min" "5 min" "10 min" "5 min" "10 min")
+
+    local idx
+    for idx in "${!roles[@]}"; do
+        local role="${roles[$idx]}"
+        local expected_interval="${intervals[$idx]}"
+        local interval_str="${interval_display[$idx]}"
+
+        local last_completed=""
+        local status="unknown"
+
+        if [[ -f "$DAEMON_STATE_FILE" ]]; then
+            last_completed=$(jq -r ".support_roles.${role}.last_completed // \"\"" "$DAEMON_STATE_FILE" 2>/dev/null || echo "")
+            status=$(jq -r ".support_roles.${role}.status // \"idle\"" "$DAEMON_STATE_FILE" 2>/dev/null || echo "idle")
+        fi
+
+        local display_name
+        display_name="$(echo "${role:0:1}" | tr '[:lower:]' '[:upper:]')${role:1}"
+
+        if [[ -z "$last_completed" ]] || [[ "$last_completed" == "null" ]] || [[ "$last_completed" == "" ]]; then
+            SUPPORT_ROLE_STATUS+=("${display_name}:NEVER_SPAWNED:${interval_str}:${status}")
+            if [[ "$status" != "running" ]]; then
+                add_warning "$display_name has NEVER SPAWNED (should spawn every $interval_str)"
+            fi
+        else
+            local lc_epoch
+            lc_epoch=$(timestamp_to_epoch "$last_completed")
+            if [[ "$lc_epoch" == "0" ]]; then
+                SUPPORT_ROLE_STATUS+=("${display_name}:UNKNOWN:${interval_str}:${status}")
+                continue
+            fi
+            local elapsed=$((now - lc_epoch))
+            local elapsed_str
+            elapsed_str=$(format_duration "$elapsed")
+            SUPPORT_ROLE_STATUS+=("${display_name}:${elapsed_str}:${interval_str}:${status}")
+
+            # Check if overdue (only warn if not currently running)
+            if [[ "$status" != "running" ]] && [[ $elapsed -gt $((expected_interval * 2)) ]]; then
+                add_warning "$display_name last completed $elapsed_str ago (expected every $interval_str)"
+            fi
+        fi
+    done
+}
+
+# Format issue/PR number lists from JSON array
+format_numbers() {
+    local json_array="$1"
+    local count
+    count=$(echo "$json_array" | jq 'length')
+    if [[ "$count" -eq 0 ]]; then
+        echo ""
+        return
+    fi
+    echo "$json_array" | jq -r '[.[].number] | map("#" + tostring) | join(", ")' 2>/dev/null
+}
+
+# ============================
+# MAIN EXECUTION
+# ============================
+
+# ---- 1. Validate state file ----
+STATE_FILE_STATUS="ok"
+STATE_FILE_DETAILS=""
+DAEMON_RUNNING="false"
+DAEMON_ITERATION=0
+DAEMON_STARTED_AT=""
+DAEMON_FORCE_MODE="false"
+
+if validate_state_file; then
+    STATE_FILE_STATUS="ok"
+    DAEMON_RUNNING=$(jq -r '.running // false' "$DAEMON_STATE_FILE")
+    DAEMON_ITERATION=$(jq -r '.iteration // 0' "$DAEMON_STATE_FILE")
+    DAEMON_STARTED_AT=$(jq -r '.started_at // ""' "$DAEMON_STATE_FILE")
+    DAEMON_FORCE_MODE=$(jq -r '.force_mode // false' "$DAEMON_STATE_FILE")
+else
+    validate_exit=$?
+    case $validate_exit in
+        1)
+            STATE_FILE_STATUS="missing"
+            STATE_FILE_DETAILS="No daemon state file found at $DAEMON_STATE_FILE"
+            add_critical "Daemon state file not found"
+            add_recommendation "Start the daemon with /loom or /loom --force"
+            ;;
+        2)
+            STATE_FILE_STATUS="corrupt"
+            STATE_FILE_DETAILS="State file contains invalid JSON"
+            add_critical "Daemon state file is corrupt (invalid JSON)"
+            add_recommendation "Fix state corruption: delete .loom/daemon-state.json and restart daemon"
+            ;;
+        3)
+            STATE_FILE_STATUS="incomplete"
+            STATE_FILE_DETAILS="Missing required fields: $VALIDATE_MISSING_FIELDS"
+            add_critical "Daemon state file missing required fields: $VALIDATE_MISSING_FIELDS"
+            add_recommendation "State file may be partially written; restart daemon to regenerate"
+            ;;
+    esac
+fi
+
+# ---- 2. Validate shepherd task IDs ----
+SHEPHERD_DETAILS=()
+INVALID_TASK_IDS=0
+TOTAL_SHEPHERDS=0
+
+if [[ "$STATE_FILE_STATUS" == "ok" ]]; then
+    shepherd_keys=$(jq -r '.shepherds // {} | keys[]' "$DAEMON_STATE_FILE" 2>/dev/null || true)
+
+    for shepherd_key in $shepherd_keys; do
+        TOTAL_SHEPHERDS=$((TOTAL_SHEPHERDS + 1))
+        task_id=$(jq -r ".shepherds[\"$shepherd_key\"].task_id // null" "$DAEMON_STATE_FILE")
+        status=$(jq -r ".shepherds[\"$shepherd_key\"].status // \"unknown\"" "$DAEMON_STATE_FILE")
+        issue=$(jq -r ".shepherds[\"$shepherd_key\"].issue // null" "$DAEMON_STATE_FILE")
+
+        task_id_valid="true"
+        if [[ "$task_id" != "null" ]] && [[ -n "$task_id" ]]; then
+            if ! validate_task_id "$task_id"; then
+                task_id_valid="false"
+                INVALID_TASK_IDS=$((INVALID_TASK_IDS + 1))
+            fi
+        fi
+
+        SHEPHERD_DETAILS+=("${shepherd_key}:${task_id}:${status}:${issue}:${task_id_valid}")
+    done
+
+    if [[ $INVALID_TASK_IDS -gt 0 ]]; then
+        add_critical "$INVALID_TASK_IDS/$TOTAL_SHEPHERDS shepherds have invalid task IDs -- completion tracking broken"
+        add_recommendation "Fix shepherd task IDs (state corruption)"
+    fi
+fi
+
+# ---- 3. Get pipeline state from GitHub ----
+get_pipeline_state
+
+# ---- 4. Check orphaned building issues ----
+check_orphaned_building
+
+if [[ ${#ORPHANED_BUILDING[@]} -gt 0 ]]; then
+    orphan_list=$(printf "#%s, " "${ORPHANED_BUILDING[@]}")
+    orphan_list="${orphan_list%, }"
+    add_warning "Orphaned loom:building issues (labeled but no shepherd): $orphan_list"
+    add_recommendation "Check orphaned issues with: ./.loom/scripts/stale-building-check.sh --recover"
+fi
+
+# ---- 5. Check stale building issues ----
+check_stale_building
+
+if [[ ${#STALE_BUILDING[@]} -gt 0 ]]; then
+    for entry in "${STALE_BUILDING[@]}"; do
+        num="${entry%%:*}"
+        age="${entry##*:}"
+        add_warning "#$num in loom:building for ${age} min with no PR"
+    done
+    add_recommendation "Check stale loom:building issues (>${STALE_BUILDING_MINUTES} min without PR)"
+fi
+
+# ---- 6. Check support roles ----
+check_support_roles
+
+# Count how many support roles have never spawned
+NEVER_SPAWNED_COUNT=0
+for entry in "${SUPPORT_ROLE_STATUS[@]}"; do
+    spawned_status="${entry#*:}"
+    spawned_status="${spawned_status%%:*}"
+    if [[ "$spawned_status" == "NEVER_SPAWNED" ]]; then
+        NEVER_SPAWNED_COUNT=$((NEVER_SPAWNED_COUNT + 1))
+    fi
+done
+
+if [[ $NEVER_SPAWNED_COUNT -eq ${#SUPPORT_ROLE_STATUS[@]} ]] && [[ $NEVER_SPAWNED_COUNT -gt 0 ]]; then
+    add_warning "No support roles have run this session"
+    add_recommendation "Spawn Guide for triage"
+fi
+
+# ---- Determine final exit code ----
+EXIT_CODE=0
+if [[ $CRITICALS -gt 0 ]]; then
+    EXIT_CODE=2
+elif [[ $WARNINGS -gt 0 ]]; then
+    EXIT_CODE=1
+fi
+
+# ============================
+# OUTPUT
+# ============================
+
+if [[ "$JSON_OUTPUT" == "true" ]]; then
+    # Build JSON arrays for warnings and criticals
+    warnings_json="[]"
+    for msg in "${WARNING_MESSAGES[@]+"${WARNING_MESSAGES[@]}"}"; do
+        warnings_json=$(echo "$warnings_json" | jq --arg m "$msg" '. + [$m]')
+    done
+
+    criticals_json="[]"
+    for msg in "${CRITICAL_MESSAGES[@]+"${CRITICAL_MESSAGES[@]}"}"; do
+        criticals_json=$(echo "$criticals_json" | jq --arg m "$msg" '. + [$m]')
+    done
+
+    recommendations_json="[]"
+    for msg in "${RECOMMENDATION_MESSAGES[@]+"${RECOMMENDATION_MESSAGES[@]}"}"; do
+        recommendations_json=$(echo "$recommendations_json" | jq --arg m "$msg" '. + [$m]')
+    done
+
+    # Build shepherd details JSON
+    shepherds_json="[]"
+    for entry in "${SHEPHERD_DETAILS[@]+"${SHEPHERD_DETAILS[@]}"}"; do
+        IFS=':' read -r s_key s_task_id s_status s_issue s_valid <<< "$entry"
+        shepherds_json=$(echo "$shepherds_json" | jq \
+            --arg key "$s_key" \
+            --arg task_id "$s_task_id" \
+            --arg status "$s_status" \
+            --arg issue "$s_issue" \
+            --arg valid "$s_valid" \
+            '. + [{key: $key, task_id: $task_id, status: $status, issue: (if $issue == "null" then null else ($issue | tonumber? // $issue) end), task_id_valid: ($valid == "true")}]')
+    done
+
+    # Build support roles JSON
+    support_json="[]"
+    for entry in "${SUPPORT_ROLE_STATUS[@]+"${SUPPORT_ROLE_STATUS[@]}"}"; do
+        IFS=':' read -r sr_name sr_elapsed sr_interval sr_status <<< "$entry"
+        support_json=$(echo "$support_json" | jq \
+            --arg name "$sr_name" \
+            --arg elapsed "$sr_elapsed" \
+            --arg interval "$sr_interval" \
+            --arg status "$sr_status" \
+            '. + [{name: $name, last_completed_ago: $elapsed, expected_interval: $interval, current_status: $status}]')
+    done
+
+    # Build orphaned and stale arrays
+    orphaned_json="[]"
+    for num in "${ORPHANED_BUILDING[@]+"${ORPHANED_BUILDING[@]}"}"; do
+        orphaned_json=$(echo "$orphaned_json" | jq --argjson n "$num" '. + [$n]')
+    done
+
+    stale_json="[]"
+    for entry in "${STALE_BUILDING[@]+"${STALE_BUILDING[@]}"}"; do
+        s_num="${entry%%:*}"
+        s_age="${entry##*:}"
+        stale_json=$(echo "$stale_json" | jq --argjson n "$s_num" --argjson a "$s_age" '. + [{issue: $n, age_minutes: $a}]')
+    done
+
+    # Build the full JSON output
+    jq -n \
+        --arg state_file "$DAEMON_STATE_FILE" \
+        --arg state_status "$STATE_FILE_STATUS" \
+        --argjson running "$DAEMON_RUNNING" \
+        --argjson iteration "$DAEMON_ITERATION" \
+        --arg started_at "$DAEMON_STARTED_AT" \
+        --argjson force_mode "$DAEMON_FORCE_MODE" \
+        --argjson shepherds "$shepherds_json" \
+        --argjson invalid_task_ids "$INVALID_TASK_IDS" \
+        --argjson total_shepherds "$TOTAL_SHEPHERDS" \
+        --argjson pipeline_ready "$PIPELINE_READY_COUNT" \
+        --argjson pipeline_building "$PIPELINE_BUILDING_COUNT" \
+        --argjson pipeline_review "$PIPELINE_REVIEW_COUNT" \
+        --argjson pipeline_merge "$PIPELINE_MERGE_COUNT" \
+        --argjson pipeline_blocked "$PIPELINE_BLOCKED_COUNT" \
+        --argjson ready_issues "$PIPELINE_READY" \
+        --argjson building_issues "$PIPELINE_BUILDING" \
+        --argjson review_prs "$PIPELINE_REVIEW" \
+        --argjson merge_prs "$PIPELINE_MERGE" \
+        --argjson blocked_issues "$PIPELINE_BLOCKED" \
+        --argjson orphaned_building "$orphaned_json" \
+        --argjson stale_building "$stale_json" \
+        --argjson support_roles "$support_json" \
+        --argjson warnings_list "$warnings_json" \
+        --argjson criticals_list "$criticals_json" \
+        --argjson recommendations "$recommendations_json" \
+        --argjson warning_count "$WARNINGS" \
+        --argjson critical_count "$CRITICALS" \
+        --argjson exit_code "$EXIT_CODE" \
+        '{
+            state_file: {
+                path: $state_file,
+                status: $state_status
+            },
+            daemon: {
+                running: $running,
+                iteration: $iteration,
+                started_at: $started_at,
+                force_mode: $force_mode
+            },
+            shepherds: {
+                entries: $shepherds,
+                invalid_task_ids: $invalid_task_ids,
+                total: $total_shepherds
+            },
+            pipeline: {
+                ready: { count: $pipeline_ready, issues: $ready_issues },
+                building: { count: $pipeline_building, issues: $building_issues },
+                review_requested: { count: $pipeline_review, prs: $review_prs },
+                ready_to_merge: { count: $pipeline_merge, prs: $merge_prs },
+                blocked: { count: $pipeline_blocked, issues: $blocked_issues }
+            },
+            consistency: {
+                orphaned_building: $orphaned_building,
+                stale_building: $stale_building
+            },
+            support_roles: $support_roles,
+            diagnostics: {
+                warnings: $warnings_list,
+                criticals: $criticals_list,
+                recommendations: $recommendations,
+                warning_count: $warning_count,
+                critical_count: $critical_count,
+                exit_code: $exit_code
+            }
+        }'
+
+    exit "$EXIT_CODE"
+fi
+
+# ---- Human-readable output ----
+
+echo ""
+echo -e "${BOLD}LOOM DAEMON HEALTH CHECK${NC}"
+echo "========================"
+echo ""
+
+# State File section
+echo -e "${BOLD}State File:${NC} $DAEMON_STATE_FILE"
+
+if [[ "$STATE_FILE_STATUS" == "ok" ]]; then
+    status_label="running"
+    if [[ "$DAEMON_RUNNING" == "false" ]]; then
+        status_label="stopped"
+    fi
+    echo -e "  Status: ${BOLD}$status_label${NC} (iteration $DAEMON_ITERATION)"
+
+    if [[ -n "$DAEMON_STARTED_AT" ]] && [[ "$DAEMON_STARTED_AT" != "null" ]]; then
+        echo -e "  Started: $DAEMON_STARTED_AT ($(time_ago "$DAEMON_STARTED_AT"))"
+    fi
+
+    if [[ "$DAEMON_FORCE_MODE" == "true" ]]; then
+        echo -e "  Force mode: ${YELLOW}enabled${NC}"
+    else
+        echo -e "  Force mode: disabled"
+    fi
+
+    if [[ "$DAEMON_RUNNING" == "false" ]]; then
+        echo -e "  ${GRAY}(showing last known state)${NC}"
+    fi
+elif [[ "$STATE_FILE_STATUS" == "missing" ]]; then
+    echo -e "  ${RED}CRITICAL: State file not found${NC}"
+    echo -e "  ${GRAY}Daemon may have never started. Run /loom or /loom --force${NC}"
+elif [[ "$STATE_FILE_STATUS" == "corrupt" ]]; then
+    echo -e "  ${RED}CRITICAL: State file contains invalid JSON${NC}"
+    echo -e "  ${GRAY}Delete .loom/daemon-state.json and restart daemon${NC}"
+elif [[ "$STATE_FILE_STATUS" == "incomplete" ]]; then
+    echo -e "  ${RED}CRITICAL: State file missing required fields${NC}"
+    echo -e "  ${GRAY}$STATE_FILE_DETAILS${NC}"
+fi
+echo ""
+
+# Shepherd State Integrity
+echo -e "${BOLD}Shepherd State Integrity:${NC}"
+if [[ ${#SHEPHERD_DETAILS[@]} -eq 0 ]]; then
+    echo -e "  ${GRAY}No shepherd data available${NC}"
+else
+    for entry in "${SHEPHERD_DETAILS[@]}"; do
+        IFS=':' read -r s_key s_task_id s_status s_issue s_valid <<< "$entry"
+
+        if [[ "$s_task_id" == "null" ]] || [[ -z "$s_task_id" ]]; then
+            echo -e "  ${GRAY}$s_key: idle (no task)${NC}"
+        elif [[ "$s_valid" == "true" ]]; then
+            issue_display=""
+            if [[ "$s_issue" != "null" ]] && [[ -n "$s_issue" ]]; then
+                issue_display=" issue=#$s_issue"
+            fi
+            echo -e "  ${GREEN}$s_key: task_id=\"$s_task_id\" $s_status$issue_display${NC}"
+        else
+            echo -e "  ${RED}$s_key: task_id=\"$s_task_id\" <- INVALID (not 7-char hex)${NC}"
+        fi
+    done
+
+    if [[ $INVALID_TASK_IDS -gt 0 ]]; then
+        echo -e "  ${RED}WARNING: $INVALID_TASK_IDS/$TOTAL_SHEPHERDS shepherds have invalid task IDs -- completion tracking broken${NC}"
+    fi
+fi
+echo ""
+
+# Pipeline Consistency
+echo -e "${BOLD}Pipeline Consistency:${NC}"
+
+ready_nums=$(format_numbers "$PIPELINE_READY")
+building_nums=$(format_numbers "$PIPELINE_BUILDING")
+review_nums=$(format_numbers "$PIPELINE_REVIEW")
+merge_nums=$(format_numbers "$PIPELINE_MERGE")
+blocked_nums=$(format_numbers "$PIPELINE_BLOCKED")
+
+printf "  %-27s %d issues" "loom:issue (ready):" "$PIPELINE_READY_COUNT"
+[[ -n "$ready_nums" ]] && printf " (%s)" "$ready_nums"
+echo ""
+
+printf "  %-27s %d issues" "loom:building:" "$PIPELINE_BUILDING_COUNT"
+[[ -n "$building_nums" ]] && printf " (%s)" "$building_nums"
+echo ""
+
+printf "  %-27s %d PRs" "loom:review-requested:" "$PIPELINE_REVIEW_COUNT"
+[[ -n "$review_nums" ]] && printf " (%s)" "$review_nums"
+echo ""
+
+printf "  %-27s %d PRs" "loom:pr (ready merge):" "$PIPELINE_MERGE_COUNT"
+[[ -n "$merge_nums" ]] && printf " (%s)" "$merge_nums"
+echo ""
+
+printf "  %-27s %d issues" "loom:blocked:" "$PIPELINE_BLOCKED_COUNT"
+[[ -n "$blocked_nums" ]] && printf " (%s)" "$blocked_nums"
+echo ""
+echo ""
+
+# Orphaned/stale building
+if [[ ${#ORPHANED_BUILDING[@]} -eq 0 ]]; then
+    echo -e "  Orphaned loom:building: ${GREEN}NONE${NC} (all have shepherd entries)"
+else
+    echo -e "  Orphaned loom:building: ${RED}${#ORPHANED_BUILDING[@]} issue(s)${NC}"
+    for num in "${ORPHANED_BUILDING[@]}"; do
+        echo -e "    ${YELLOW}#$num (labeled but no active shepherd)${NC}"
+    done
+fi
+
+if [[ ${#STALE_BUILDING[@]} -eq 0 ]]; then
+    echo -e "  Stale loom:building:    ${GREEN}NONE${NC}"
+else
+    echo -e "  Stale loom:building:    ${YELLOW}${#STALE_BUILDING[@]} issue(s)${NC}"
+    for entry in "${STALE_BUILDING[@]}"; do
+        s_num="${entry%%:*}"
+        s_age="${entry##*:}"
+        echo -e "    ${YELLOW}#$s_num (${s_age} min, no PR yet)${NC}"
+    done
+fi
+echo ""
+
+# Support Roles
+echo -e "${BOLD}Support Roles:${NC}"
+for entry in "${SUPPORT_ROLE_STATUS[@]+"${SUPPORT_ROLE_STATUS[@]}"}"; do
+    IFS=':' read -r sr_name sr_elapsed sr_interval sr_status <<< "$entry"
+
+    if [[ "$sr_status" == "running" ]]; then
+        printf "  %-12s ${GREEN}RUNNING${NC} (interval: every %s)\n" "$sr_name:" "$sr_interval"
+    elif [[ "$sr_elapsed" == "NEVER_SPAWNED" ]]; then
+        printf "  %-12s ${RED}NEVER SPAWNED${NC} (should spawn every %s)\n" "$sr_name:" "$sr_interval"
+    elif [[ "$sr_elapsed" == "UNKNOWN" ]]; then
+        printf "  %-12s ${GRAY}unknown${NC} (interval: every %s)\n" "$sr_name:" "$sr_interval"
+    else
+        printf "  %-12s %s ago (interval: every %s)\n" "$sr_name:" "$sr_elapsed" "$sr_interval"
+    fi
+done
+
+# Check if any never spawned
+if [[ $NEVER_SPAWNED_COUNT -eq ${#SUPPORT_ROLE_STATUS[@]} ]] && [[ $NEVER_SPAWNED_COUNT -gt 0 ]]; then
+    echo -e "  ${YELLOW}WARNING: No support roles have run this session${NC}"
+fi
+echo ""
+
+# Recommendations
+if [[ ${#RECOMMENDATION_MESSAGES[@]} -gt 0 ]]; then
+    echo -e "${BOLD}Recommendations:${NC}"
+    rec_num=1
+    for msg in "${RECOMMENDATION_MESSAGES[@]}"; do
+        echo -e "  $rec_num. $msg"
+        rec_num=$((rec_num + 1))
+    done
+    echo ""
+fi
+
+# Summary
+if [[ $EXIT_CODE -eq 0 ]]; then
+    echo -e "${GREEN}${BOLD}Health: OK${NC} - No issues detected"
+elif [[ $EXIT_CODE -eq 1 ]]; then
+    echo -e "${YELLOW}${BOLD}Health: WARNINGS${NC} - $WARNINGS warning(s) detected"
+else
+    echo -e "${RED}${BOLD}Health: CRITICAL${NC} - $CRITICALS critical issue(s), $WARNINGS warning(s)"
+fi
+echo ""
+
+exit "$EXIT_CODE"

--- a/.loom/scripts/daemon-snapshot.sh
+++ b/.loom/scripts/daemon-snapshot.sh
@@ -383,7 +383,9 @@ HERMIT_COOLDOWN_OK="false"
 if [[ -n "$LAST_ARCHITECT_TRIGGER" ]]; then
     # Convert ISO timestamp to epoch
     if [[ "$(uname)" == "Darwin" ]]; then
-        ARCH_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$LAST_ARCHITECT_TRIGGER" "+%s" 2>/dev/null || echo "0")
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        clean_ts="${LAST_ARCHITECT_TRIGGER%Z}"
+        ARCH_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
     else
         ARCH_EPOCH=$(date -d "$LAST_ARCHITECT_TRIGGER" "+%s" 2>/dev/null || echo "0")
     fi
@@ -397,7 +399,9 @@ fi
 
 if [[ -n "$LAST_HERMIT_TRIGGER" ]]; then
     if [[ "$(uname)" == "Darwin" ]]; then
-        HERMIT_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$LAST_HERMIT_TRIGGER" "+%s" 2>/dev/null || echo "0")
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        clean_ts="${LAST_HERMIT_TRIGGER%Z}"
+        HERMIT_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
     else
         HERMIT_EPOCH=$(date -d "$LAST_HERMIT_TRIGGER" "+%s" 2>/dev/null || echo "0")
     fi
@@ -414,7 +418,9 @@ GUIDE_IDLE_SECONDS=0
 GUIDE_NEEDS_TRIGGER="false"
 if [[ -n "$GUIDE_LAST_COMPLETED" && "$GUIDE_LAST_COMPLETED" != "null" ]]; then
     if [[ "$(uname)" == "Darwin" ]]; then
-        GUIDE_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$GUIDE_LAST_COMPLETED" "+%s" 2>/dev/null || echo "0")
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        clean_ts="${GUIDE_LAST_COMPLETED%Z}"
+        GUIDE_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
     else
         GUIDE_EPOCH=$(date -d "$GUIDE_LAST_COMPLETED" "+%s" 2>/dev/null || echo "0")
     fi
@@ -434,7 +440,9 @@ CHAMPION_IDLE_SECONDS=0
 CHAMPION_NEEDS_TRIGGER="false"
 if [[ -n "$CHAMPION_LAST_COMPLETED" && "$CHAMPION_LAST_COMPLETED" != "null" ]]; then
     if [[ "$(uname)" == "Darwin" ]]; then
-        CHAMPION_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$CHAMPION_LAST_COMPLETED" "+%s" 2>/dev/null || echo "0")
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        clean_ts="${CHAMPION_LAST_COMPLETED%Z}"
+        CHAMPION_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
     else
         CHAMPION_EPOCH=$(date -d "$CHAMPION_LAST_COMPLETED" "+%s" 2>/dev/null || echo "0")
     fi
@@ -452,7 +460,9 @@ DOCTOR_IDLE_SECONDS=0
 DOCTOR_NEEDS_TRIGGER="false"
 if [[ -n "$DOCTOR_LAST_COMPLETED" && "$DOCTOR_LAST_COMPLETED" != "null" ]]; then
     if [[ "$(uname)" == "Darwin" ]]; then
-        DOCTOR_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$DOCTOR_LAST_COMPLETED" "+%s" 2>/dev/null || echo "0")
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        clean_ts="${DOCTOR_LAST_COMPLETED%Z}"
+        DOCTOR_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
     else
         DOCTOR_EPOCH=$(date -d "$DOCTOR_LAST_COMPLETED" "+%s" 2>/dev/null || echo "0")
     fi
@@ -470,7 +480,9 @@ AUDITOR_IDLE_SECONDS=0
 AUDITOR_NEEDS_TRIGGER="false"
 if [[ -n "$AUDITOR_LAST_COMPLETED" && "$AUDITOR_LAST_COMPLETED" != "null" ]]; then
     if [[ "$(uname)" == "Darwin" ]]; then
-        AUDITOR_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$AUDITOR_LAST_COMPLETED" "+%s" 2>/dev/null || echo "0")
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        clean_ts="${AUDITOR_LAST_COMPLETED%Z}"
+        AUDITOR_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
     else
         AUDITOR_EPOCH=$(date -d "$AUDITOR_LAST_COMPLETED" "+%s" 2>/dev/null || echo "0")
     fi
@@ -488,7 +500,9 @@ JUDGE_IDLE_SECONDS=0
 JUDGE_NEEDS_TRIGGER="false"
 if [[ -n "$JUDGE_LAST_COMPLETED" && "$JUDGE_LAST_COMPLETED" != "null" ]]; then
     if [[ "$(uname)" == "Darwin" ]]; then
-        JUDGE_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$JUDGE_LAST_COMPLETED" "+%s" 2>/dev/null || echo "0")
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        clean_ts="${JUDGE_LAST_COMPLETED%Z}"
+        JUDGE_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
     else
         JUDGE_EPOCH=$(date -d "$JUDGE_LAST_COMPLETED" "+%s" 2>/dev/null || echo "0")
     fi
@@ -616,7 +630,9 @@ read_shepherd_progress() {
                     if [[ -n "$last_heartbeat" && "$last_heartbeat" != "null" ]]; then
                         local hb_epoch
                         if [[ "$(uname)" == "Darwin" ]]; then
-                            hb_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_heartbeat" "+%s" 2>/dev/null || echo "0")
+                            # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+                            local clean_ts="${last_heartbeat%Z}"
+                            hb_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
                         else
                             hb_epoch=$(date -d "$last_heartbeat" "+%s" 2>/dev/null || echo "0")
                         fi

--- a/.loom/scripts/health-check.sh
+++ b/.loom/scripts/health-check.sh
@@ -171,7 +171,9 @@ timestamp_to_epoch() {
         return
     fi
     if [[ "$(uname)" == "Darwin" ]]; then
-        date -j -f "%Y-%m-%dT%H:%M:%SZ" "$timestamp" "+%s" 2>/dev/null || echo "0"
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        local clean_ts="${timestamp%Z}"
+        TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0"
     else
         date -d "$timestamp" "+%s" 2>/dev/null || echo "0"
     fi

--- a/.loom/scripts/loom-status.sh
+++ b/.loom/scripts/loom-status.sh
@@ -132,8 +132,9 @@ time_ago() {
 
     # Parse ISO timestamp
     if [[ "$(uname)" == "Darwin" ]]; then
-        # macOS
-        then_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$timestamp" "+%s" 2>/dev/null || echo "0")
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        local clean_ts="${timestamp%Z}"
+        then_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
     else
         # Linux
         then_epoch=$(date -d "$timestamp" "+%s" 2>/dev/null || echo "0")
@@ -176,7 +177,9 @@ format_uptime() {
     now_epoch=$(date +%s)
 
     if [[ "$(uname)" == "Darwin" ]]; then
-        then_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$timestamp" "+%s" 2>/dev/null || echo "0")
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        local clean_ts="${timestamp%Z}"
+        then_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
     else
         then_epoch=$(date -d "$timestamp" "+%s" 2>/dev/null || echo "0")
     fi

--- a/.loom/scripts/recover-orphaned-shepherds.sh
+++ b/.loom/scripts/recover-orphaned-shepherds.sh
@@ -453,7 +453,9 @@ check_stale_progress() {
         if [[ -n "$last_heartbeat" && "$last_heartbeat" != "null" ]]; then
             local hb_epoch
             if [[ "$(uname)" == "Darwin" ]]; then
-                hb_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_heartbeat" "+%s" 2>/dev/null || echo "0")
+                # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+                local clean_ts="${last_heartbeat%Z}"
+                hb_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
             else
                 hb_epoch=$(date -d "$last_heartbeat" "+%s" 2>/dev/null || echo "0")
             fi

--- a/.loom/scripts/session-reflection.sh
+++ b/.loom/scripts/session-reflection.sh
@@ -174,9 +174,11 @@ calculate_duration() {
     start_epoch=$(date -d "$started_at" +%s 2>/dev/null || echo "0")
     end_epoch=$(date -d "$end_time" +%s 2>/dev/null || echo "0")
   else
-    # BSD date (macOS)
-    start_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$started_at" +%s 2>/dev/null || echo "0")
-    end_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$end_time" +%s 2>/dev/null || echo "0")
+    # BSD date (macOS) - Strip Z suffix and parse as UTC
+    local clean_start="${started_at%Z}"
+    local clean_end="${end_time%Z}"
+    start_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_start" +%s 2>/dev/null || echo "0")
+    end_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_end" +%s 2>/dev/null || echo "0")
   fi
 
   echo $((end_epoch - start_epoch))

--- a/.loom/scripts/spawn-support-role.sh
+++ b/.loom/scripts/spawn-support-role.sh
@@ -1,0 +1,516 @@
+#!/bin/bash
+# spawn-support-role.sh - Deterministic support role spawn logic
+#
+# This script encapsulates the decision logic for spawning support roles
+# (Guide, Champion, Doctor, Auditor, Judge) in the daemon. It replaces
+# LLM-interpreted pseudocode with deterministic bash logic.
+#
+# The script does NOT spawn roles itself - it evaluates whether a role
+# should be spawned and updates daemon-state.json accordingly. The actual
+# spawning (Task subagent, tmux session, or MCP) is handled by the caller
+# (the iteration subagent or daemon-loop.sh).
+#
+# Usage:
+#   spawn-support-role.sh <role> [--demand] [--check-only] [--json]
+#   spawn-support-role.sh --check-all [--json]
+#   spawn-support-role.sh --mark-running <role> --task-id <id>
+#   spawn-support-role.sh --mark-completed <role>
+#   spawn-support-role.sh --help
+#
+# Options:
+#   <role>            Role name: guide, champion, doctor, auditor, judge
+#   --demand          Demand-based spawn (skip interval check)
+#   --check-only      Only check if spawn is needed, don't modify state
+#   --check-all       Check all support roles and output combined result
+#   --mark-running    Mark a role as running with the given task_id
+#   --mark-completed  Mark a role as completed (transition to idle)
+#   --json            Output JSON instead of human-readable text
+#   --help            Show this help message
+#
+# Exit Codes:
+#   0 - Role should be spawned (or state updated successfully)
+#   1 - Role should NOT be spawned (already running, interval not elapsed)
+#   2 - Error (invalid role, missing state file, etc.)
+#
+# Environment Variables:
+#   LOOM_GUIDE_INTERVAL      Guide re-trigger interval in seconds (default: 900)
+#   LOOM_CHAMPION_INTERVAL   Champion re-trigger interval in seconds (default: 600)
+#   LOOM_DOCTOR_INTERVAL     Doctor re-trigger interval in seconds (default: 300)
+#   LOOM_AUDITOR_INTERVAL    Auditor re-trigger interval in seconds (default: 600)
+#   LOOM_JUDGE_INTERVAL      Judge re-trigger interval in seconds (default: 300)
+#
+# Examples:
+#   # Check if Guide should be spawned (interval-based)
+#   spawn-support-role.sh guide
+#
+#   # Check if Champion should be spawned on-demand
+#   spawn-support-role.sh champion --demand
+#
+#   # Check all roles and get JSON output
+#   spawn-support-role.sh --check-all --json
+#
+#   # Mark role as running after successful Task spawn
+#   spawn-support-role.sh --mark-running champion --task-id a7dc1e0
+#
+#   # Mark role as completed
+#   spawn-support-role.sh --mark-completed champion
+
+set -euo pipefail
+
+# Find the repository root (works from any subdirectory)
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository" >&2
+    return 1
+}
+
+REPO_ROOT=$(find_repo_root)
+STATE_FILE="$REPO_ROOT/.loom/daemon-state.json"
+
+# Default intervals (in seconds)
+GUIDE_INTERVAL="${LOOM_GUIDE_INTERVAL:-900}"        # 15 minutes
+CHAMPION_INTERVAL="${LOOM_CHAMPION_INTERVAL:-600}"  # 10 minutes
+DOCTOR_INTERVAL="${LOOM_DOCTOR_INTERVAL:-300}"      # 5 minutes
+AUDITOR_INTERVAL="${LOOM_AUDITOR_INTERVAL:-600}"    # 10 minutes
+JUDGE_INTERVAL="${LOOM_JUDGE_INTERVAL:-300}"        # 5 minutes
+
+# Valid roles
+VALID_ROLES=("guide" "champion" "doctor" "auditor" "judge")
+
+show_help() {
+    cat <<'EOF'
+spawn-support-role.sh - Deterministic support role spawn logic
+
+USAGE:
+    spawn-support-role.sh <role> [--demand] [--check-only] [--json]
+    spawn-support-role.sh --check-all [--json]
+    spawn-support-role.sh --mark-running <role> --task-id <id>
+    spawn-support-role.sh --mark-completed <role>
+    spawn-support-role.sh --help
+
+ROLES:
+    guide       Backlog triage (interval: 15 min)
+    champion    PR merging and proposal evaluation (interval: 10 min)
+    doctor      PR conflict resolution (interval: 5 min)
+    auditor     Main branch validation (interval: 10 min)
+    judge       PR review (interval: 5 min)
+
+OPTIONS:
+    --demand        Demand-based spawn (skip interval check)
+    --check-only    Only check if spawn is needed, don't modify state
+    --check-all     Check all roles and output combined result
+    --mark-running  Mark a role as running with a task_id
+    --mark-completed Mark a role as completed (transition to idle)
+    --json          Output JSON format
+    --help          Show this help message
+
+EXIT CODES:
+    0 - Role should be spawned (or state updated)
+    1 - Role should NOT be spawned
+    2 - Error
+
+ENVIRONMENT VARIABLES:
+    LOOM_GUIDE_INTERVAL      (default: 900)
+    LOOM_CHAMPION_INTERVAL   (default: 600)
+    LOOM_DOCTOR_INTERVAL     (default: 300)
+    LOOM_AUDITOR_INTERVAL    (default: 600)
+    LOOM_JUDGE_INTERVAL      (default: 300)
+EOF
+}
+
+# Get the interval for a role
+get_interval() {
+    local role="$1"
+    case "$role" in
+        guide)    echo "$GUIDE_INTERVAL" ;;
+        champion) echo "$CHAMPION_INTERVAL" ;;
+        doctor)   echo "$DOCTOR_INTERVAL" ;;
+        auditor)  echo "$AUDITOR_INTERVAL" ;;
+        judge)    echo "$JUDGE_INTERVAL" ;;
+        *)        echo "0" ;;
+    esac
+}
+
+# Validate role name
+validate_role() {
+    local role="$1"
+    for valid in "${VALID_ROLES[@]}"; do
+        if [[ "$role" == "$valid" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Validate task_id format (7-char hex)
+validate_task_id() {
+    local task_id="$1"
+    if [[ -z "$task_id" ]]; then
+        return 1
+    fi
+    # Real Task tool IDs are 7-char lowercase hex strings
+    if [[ "$task_id" =~ ^[a-f0-9]{7}$ ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# Convert ISO timestamp (UTC) to epoch seconds (cross-platform)
+iso_to_epoch() {
+    local timestamp="$1"
+    if [[ -z "$timestamp" || "$timestamp" == "null" ]]; then
+        echo "0"
+        return
+    fi
+    if [[ "$(uname)" == "Darwin" ]]; then
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        local clean_ts="${timestamp%Z}"
+        TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0"
+    else
+        # Linux: date -d handles ISO 8601 with timezone suffix natively
+        date -d "$timestamp" "+%s" 2>/dev/null || echo "0"
+    fi
+}
+
+# Check if a role should be spawned
+# Returns: JSON object with decision and reason
+check_role() {
+    local role="$1"
+    local demand_mode="${2:-false}"
+    local now_epoch
+    now_epoch=$(date +%s)
+
+    # Ensure state file exists
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo '{"should_spawn":true,"reason":"no_state_file","role":"'"$role"'"}'
+        return 0
+    fi
+
+    # Read role status from state
+    local status
+    status=$(jq -r ".support_roles.${role}.status // \"idle\"" "$STATE_FILE" 2>/dev/null || echo "idle")
+
+    # Check if already running - never spawn duplicates
+    if [[ "$status" == "running" ]]; then
+        local task_id
+        task_id=$(jq -r ".support_roles.${role}.task_id // \"\"" "$STATE_FILE" 2>/dev/null || echo "")
+
+        # Validate the task_id - if fabricated, treat as idle
+        if [[ -n "$task_id" && "$task_id" != "null" ]]; then
+            if validate_task_id "$task_id"; then
+                echo '{"should_spawn":false,"reason":"already_running","role":"'"$role"'","task_id":"'"$task_id"'"}'
+                return 1
+            else
+                # Fabricated task_id - treat as idle
+                echo '{"should_spawn":true,"reason":"fabricated_task_id","role":"'"$role"'","stale_task_id":"'"$task_id"'"}'
+                return 0
+            fi
+        fi
+        # Running but no task_id - something is wrong, allow spawn
+        echo '{"should_spawn":true,"reason":"running_no_task_id","role":"'"$role"'"}'
+        return 0
+    fi
+
+    # In demand mode, skip interval check
+    if [[ "$demand_mode" == "true" ]]; then
+        echo '{"should_spawn":true,"reason":"demand","role":"'"$role"'"}'
+        return 0
+    fi
+
+    # Check interval
+    local interval
+    interval=$(get_interval "$role")
+
+    local last_completed
+    last_completed=$(jq -r ".support_roles.${role}.last_completed // \"\"" "$STATE_FILE" 2>/dev/null || echo "")
+
+    if [[ -z "$last_completed" || "$last_completed" == "null" ]]; then
+        # Never completed - needs trigger
+        echo '{"should_spawn":true,"reason":"never_run","role":"'"$role"'"}'
+        return 0
+    fi
+
+    local last_epoch
+    last_epoch=$(iso_to_epoch "$last_completed")
+
+    if [[ "$last_epoch" == "0" ]]; then
+        # Invalid timestamp - needs trigger
+        echo '{"should_spawn":true,"reason":"invalid_timestamp","role":"'"$role"'"}'
+        return 0
+    fi
+
+    local elapsed=$((now_epoch - last_epoch))
+
+    if [[ $elapsed -gt $interval ]]; then
+        echo '{"should_spawn":true,"reason":"interval_elapsed","role":"'"$role"'","elapsed_seconds":'"$elapsed"',"interval_seconds":'"$interval"'}'
+        return 0
+    fi
+
+    local remaining=$((interval - elapsed))
+    echo '{"should_spawn":false,"reason":"interval_not_elapsed","role":"'"$role"'","elapsed_seconds":'"$elapsed"',"interval_seconds":'"$interval"',"remaining_seconds":'"$remaining"'}'
+    return 1
+}
+
+# Check all roles and output combined result
+check_all_roles() {
+    local json_output="${1:-false}"
+    local results="[]"
+    local any_should_spawn=false
+
+    for role in "${VALID_ROLES[@]}"; do
+        local result
+        result=$(check_role "$role" "false") && true || true
+
+        local should_spawn
+        should_spawn=$(echo "$result" | jq -r '.should_spawn')
+
+        if [[ "$should_spawn" == "true" ]]; then
+            any_should_spawn=true
+        fi
+
+        results=$(echo "$results" | jq --argjson entry "$result" '. + [$entry]')
+    done
+
+    if [[ "$json_output" == "true" ]]; then
+        jq -n \
+            --argjson results "$results" \
+            --argjson any_should_spawn "$any_should_spawn" \
+            '{roles: $results, any_should_spawn: $any_should_spawn}'
+    else
+        for role in "${VALID_ROLES[@]}"; do
+            local entry
+            entry=$(echo "$results" | jq -r ".[] | select(.role == \"$role\")")
+            local should_spawn reason
+            should_spawn=$(echo "$entry" | jq -r '.should_spawn')
+            reason=$(echo "$entry" | jq -r '.reason')
+
+            if [[ "$should_spawn" == "true" ]]; then
+                echo "  $role: SPAWN ($reason)"
+            else
+                local remaining
+                remaining=$(echo "$entry" | jq -r '.remaining_seconds // "n/a"')
+                echo "  $role: SKIP ($reason, ${remaining}s remaining)"
+            fi
+        done
+    fi
+
+    if [[ "$any_should_spawn" == "true" ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# Mark a role as running in daemon-state.json
+mark_running() {
+    local role="$1"
+    local task_id="$2"
+    local now_iso
+    now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+    # Validate task_id format
+    if ! validate_task_id "$task_id"; then
+        echo "Error: Invalid task_id format: '$task_id' (expected 7-char hex like 'a7dc1e0')" >&2
+        return 2
+    fi
+
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo "Error: State file not found: $STATE_FILE" >&2
+        return 2
+    fi
+
+    # Atomic update using temp file
+    local temp_file
+    temp_file=$(mktemp)
+    if jq --arg role "$role" \
+          --arg task_id "$task_id" \
+          --arg started_at "$now_iso" \
+          '.support_roles[$role] = (.support_roles[$role] // {}) + {
+              status: "running",
+              task_id: $task_id,
+              started_at: $started_at
+          }' "$STATE_FILE" > "$temp_file" 2>/dev/null; then
+        mv "$temp_file" "$STATE_FILE"
+        echo "Marked $role as running (task_id=$task_id)"
+        return 0
+    else
+        rm -f "$temp_file"
+        echo "Error: Failed to update state file" >&2
+        return 2
+    fi
+}
+
+# Mark a role as completed in daemon-state.json
+mark_completed() {
+    local role="$1"
+    local now_iso
+    now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo "Error: State file not found: $STATE_FILE" >&2
+        return 2
+    fi
+
+    # Atomic update using temp file
+    local temp_file
+    temp_file=$(mktemp)
+    if jq --arg role "$role" \
+          --arg last_completed "$now_iso" \
+          '.support_roles[$role] = (.support_roles[$role] // {}) + {
+              status: "idle",
+              task_id: null,
+              output_file: null,
+              last_completed: $last_completed
+          }' "$STATE_FILE" > "$temp_file" 2>/dev/null; then
+        mv "$temp_file" "$STATE_FILE"
+        echo "Marked $role as completed"
+        return 0
+    else
+        rm -f "$temp_file"
+        echo "Error: Failed to update state file" >&2
+        return 2
+    fi
+}
+
+# Main entry point
+main() {
+    local role=""
+    local demand_mode=false
+    # shellcheck disable=SC2034  # Parsed from --check-only flag, reserved for future use
+    local check_only=false
+    local check_all=false
+    local json_output=false
+    local mark_running_mode=false
+    local mark_completed_mode=false
+    local task_id=""
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --demand)
+                demand_mode=true
+                shift
+                ;;
+            --check-only)
+                # shellcheck disable=SC2034  # Reserved for future use
+                check_only=true
+                shift
+                ;;
+            --check-all)
+                check_all=true
+                shift
+                ;;
+            --json)
+                json_output=true
+                shift
+                ;;
+            --mark-running)
+                mark_running_mode=true
+                role="$2"
+                shift 2
+                ;;
+            --mark-completed)
+                mark_completed_mode=true
+                role="$2"
+                shift 2
+                ;;
+            --task-id)
+                task_id="$2"
+                shift 2
+                ;;
+            --help|-h)
+                show_help
+                exit 0
+                ;;
+            -*)
+                echo "Unknown option: $1" >&2
+                exit 2
+                ;;
+            *)
+                if [[ -z "$role" ]]; then
+                    role="$1"
+                else
+                    echo "Unexpected argument: $1" >&2
+                    exit 2
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    # Handle --check-all
+    if [[ "$check_all" == "true" ]]; then
+        check_all_roles "$json_output" && exit 0 || exit $?
+    fi
+
+    # Handle --mark-running
+    if [[ "$mark_running_mode" == "true" ]]; then
+        if [[ -z "$role" ]]; then
+            echo "Error: --mark-running requires a role name" >&2
+            exit 2
+        fi
+        if ! validate_role "$role"; then
+            echo "Error: Invalid role: $role" >&2
+            exit 2
+        fi
+        if [[ -z "$task_id" ]]; then
+            echo "Error: --mark-running requires --task-id" >&2
+            exit 2
+        fi
+        mark_running "$role" "$task_id"
+        exit $?
+    fi
+
+    # Handle --mark-completed
+    if [[ "$mark_completed_mode" == "true" ]]; then
+        if [[ -z "$role" ]]; then
+            echo "Error: --mark-completed requires a role name" >&2
+            exit 2
+        fi
+        if ! validate_role "$role"; then
+            echo "Error: Invalid role: $role" >&2
+            exit 2
+        fi
+        mark_completed "$role"
+        exit $?
+    fi
+
+    # Handle role check (default mode)
+    if [[ -z "$role" ]]; then
+        echo "Error: No role specified" >&2
+        echo "Usage: spawn-support-role.sh <role> [--demand] [--check-only] [--json]" >&2
+        exit 2
+    fi
+
+    if ! validate_role "$role"; then
+        echo "Error: Invalid role: $role (valid: ${VALID_ROLES[*]})" >&2
+        exit 2
+    fi
+
+    local result exit_code
+    result=$(check_role "$role" "$demand_mode") && exit_code=0 || exit_code=$?
+
+    if [[ "$json_output" == "true" ]]; then
+        echo "$result"
+    else
+        local should_spawn reason
+        should_spawn=$(echo "$result" | jq -r '.should_spawn')
+        reason=$(echo "$result" | jq -r '.reason')
+
+        if [[ "$should_spawn" == "true" ]]; then
+            echo "SPAWN $role ($reason)"
+        else
+            echo "SKIP $role ($reason)"
+        fi
+    fi
+
+    exit $exit_code
+}
+
+main "$@"

--- a/.loom/scripts/stale-building-check.sh
+++ b/.loom/scripts/stale-building-check.sh
@@ -162,9 +162,9 @@ for i in $(seq 0 $((ISSUE_COUNT - 1))); do
   # Without this, macOS date interprets the time as local timezone, causing
   # negative ages for users west of UTC (e.g., PST shows times as "in the future")
   if [[ "$(uname)" == "Darwin" ]]; then
-    # macOS: Handle different timestamp formats with UTC timezone
-    UPDATED_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED_AT" +%s 2>/dev/null || \
-                    TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "${UPDATED_AT%Z}" +%s 2>/dev/null || echo "0")
+    # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+    clean_ts="${UPDATED_AT%Z}"
+    UPDATED_EPOCH=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" +%s 2>/dev/null || echo "0")
   else
     # Linux
     UPDATED_EPOCH=$(date -d "$UPDATED_AT" +%s 2>/dev/null || echo "0")

--- a/.loom/scripts/status.sh
+++ b/.loom/scripts/status.sh
@@ -255,8 +255,9 @@ check_stale() {
     # Convert ISO timestamp to epoch
     local updated_epoch
     if [[ "$(uname)" == "Darwin" ]]; then
-        # macOS
-        updated_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$updated_at" "+%s" 2>/dev/null || echo "0")
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        local clean_ts="${updated_at%Z}"
+        updated_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
     else
         # Linux
         updated_epoch=$(date -d "$updated_at" "+%s" 2>/dev/null || echo "0")

--- a/.loom/scripts/stuck-detection.sh
+++ b/.loom/scripts/stuck-detection.sh
@@ -255,7 +255,9 @@ get_working_seconds() {
     now_epoch=$(date +%s)
 
     if [[ "$(uname)" == "Darwin" ]]; then
-        started_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$started" "+%s" 2>/dev/null || echo "0")
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        local clean_ts="${started%Z}"
+        started_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
     else
         started_epoch=$(date -d "$started" "+%s" 2>/dev/null || echo "0")
     fi
@@ -364,7 +366,9 @@ get_heartbeat_age() {
     now_epoch=$(date +%s)
 
     if [[ "$(uname)" == "Darwin" ]]; then
-        hb_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_heartbeat" "+%s" 2>/dev/null || echo "0")
+        # Strip Z suffix and parse as UTC - macOS date -j doesn't respect Z timezone suffix
+        local clean_ts="${last_heartbeat%Z}"
+        hb_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_ts" "+%s" 2>/dev/null || echo "0")
     else
         hb_epoch=$(date -d "$last_heartbeat" "+%s" 2>/dev/null || echo "0")
     fi


### PR DESCRIPTION
## Summary

- Apply the UTC timestamp parsing fix from PR #1466 to 16 remaining script files
- Fix timestamps being interpreted as local time instead of UTC on macOS
- Prevents incorrect time calculations in agent monitoring, health checks, and cleanup operations

**Key changes:**
1. Strip `Z` suffix from ISO timestamps before parsing: `clean_ts="${timestamp%Z}"`
2. Set `TZ=UTC` environment variable for macOS date commands
3. Update format string from `"%Y-%m-%dT%H:%M:%SZ"` to `"%Y-%m-%dT%H:%M:%S"`
4. Add explanatory comments for maintainability

**Affected files (16 total):**
- `.lean/scripts/research-available.sh`
- `.lean/scripts/research-claim.sh`
- `.lean/scripts/research-cleanup.sh`
- `.loom/scripts/check-completions.sh` (new file)
- `.loom/scripts/clean.sh`
- `.loom/scripts/daemon-cleanup.sh`
- `.loom/scripts/daemon-health.sh` (new file)
- `.loom/scripts/daemon-snapshot.sh` (8 instances)
- `.loom/scripts/health-check.sh`
- `.loom/scripts/loom-status.sh` (2 instances)
- `.loom/scripts/recover-orphaned-shepherds.sh`
- `.loom/scripts/session-reflection.sh` (2 instances)
- `.loom/scripts/spawn-support-role.sh` (new file)
- `.loom/scripts/stale-building-check.sh`
- `.loom/scripts/status.sh`
- `.loom/scripts/stuck-detection.sh` (2 instances)

## Test plan

- [x] All scripts pass bash syntax check (`bash -n`)
- [x] Verified UTC timestamp parsing produces correct epoch values
- [x] No shellcheck SC2168 errors (proper `local` usage)
- [ ] Test `.loom/scripts/loom-status.sh` shows correct agent durations on macOS
- [ ] Test `.loom/scripts/health-check.sh` doesn't show false "stuck" agents
- [ ] Verify `.lean/scripts/research-claim.sh` handles claim timestamps correctly

Closes #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)