### PR TITLE
Research: erdos-1109 - prove distinct_primes_squarefree, element squarefreeness

### DIFF
--- a/proofs/Proofs/Erdos1109Problem.lean
+++ b/proofs/Proofs/Erdos1109Problem.lean
@@ -39,6 +39,7 @@ import Mathlib.Data.Nat.Squarefree
 import Mathlib.Data.Real.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Data.List.Prime
 
 open Nat Finset Real
 
@@ -78,8 +79,30 @@ theorem prime_squarefree (p : ℕ) (hp : p.Prime) : isSquarefree p := by
   exact hp.squarefree
 
 /-- Products of distinct primes are squarefree. -/
-axiom distinct_primes_squarefree (ps : List ℕ) (hps : ∀ p ∈ ps, Nat.Prime p)
-    (hdist : ps.Nodup) : isSquarefree ps.prod
+theorem distinct_primes_squarefree (ps : List ℕ) (hps : ∀ p ∈ ps, Nat.Prime p)
+    (hdist : ps.Nodup) : isSquarefree ps.prod := by
+  simp only [isSquarefree]
+  induction ps with
+  | nil => simp
+  | cons p ps ih =>
+    have hp := hps p (by simp)
+    have hps_tail : ∀ q ∈ ps, Nat.Prime q := fun q hq => hps q (by simp [hq])
+    have hdist_tail : ps.Nodup := (List.nodup_cons.mp hdist).2
+    have hp_notin : p ∉ ps := (List.nodup_cons.mp hdist).1
+    have ih_result := ih hps_tail hdist_tail
+    simp only [List.prod_cons]
+    rw [Nat.squarefree_mul_iff]
+    refine ⟨?_, hp.squarefree, ih_result⟩
+    -- Show p.Coprime ps.prod
+    -- p is prime and doesn't divide any element of ps (since p ∉ ps and all are prime)
+    rw [hp.coprime_iff_not_dvd]
+    intro hp_dvd_prod
+    rw [Prime.dvd_prod_iff hp.prime] at hp_dvd_prod
+    obtain ⟨q, hq_mem, hp_dvd_q⟩ := hp_dvd_prod
+    have hq_prime := hps_tail q hq_mem
+    rcases hq_prime.eq_one_or_self_of_dvd p hp_dvd_q with h | h
+    · exact absurd h hp.one_lt.ne'
+    · exact hp_notin (h ▸ hq_mem)
 
 /-
 ## Part II: The Sumset
@@ -269,6 +292,43 @@ theorem prime_sq_avoidance (A : Finset ℕ) (h : hasSquarefreeSumset A)
   have hunit := hsf p hdvd
   rw [Nat.isUnit_iff] at hunit
   exact absurd hunit hp.one_lt.ne'
+
+/--
+**Diagonal squarefreeness:**
+For any element a in a squarefree-sumset set, 2a must be squarefree.
+This follows directly from a + a = 2a being in the sumset.
+-/
+theorem double_squarefree (A : Finset ℕ) (h : hasSquarefreeSumset A) (a : ℕ) (ha : a ∈ A) :
+    isSquarefree (a + a) := by
+  exact h (a + a) (by
+    simp only [sumset, Finset.mem_image, Finset.mem_product]
+    exact ⟨(a, a), ⟨ha, ha⟩, rfl⟩)
+
+/--
+**No element divisible by p²:**
+For any prime p and any a ∈ A (with squarefree sumset),
+p² does not divide a. Equivalently, each element of A is squarefree.
+
+Proof: If p² | a, then p² | 2a = a + a, contradicting prime_sq_avoidance.
+-/
+theorem element_not_div_prime_sq (A : Finset ℕ) (h : hasSquarefreeSumset A)
+    (p : ℕ) (hp : p.Prime) (a : ℕ) (ha : a ∈ A) : ¬(p * p ∣ a) := by
+  intro hdvd
+  have h2a : p * p ∣ (a + a) := by
+    obtain ⟨k, hk⟩ := hdvd
+    exact ⟨2 * k, by rw [hk]; ring⟩
+  exact prime_sq_avoidance A h p hp a a ha ha h2a
+
+/--
+**Elements of squarefree-sumset sets are themselves squarefree (when positive).**
+
+Each element must be squarefree because if p² | a for some prime p,
+then p² | 2a, but 2a ∈ A + A must be squarefree.
+-/
+theorem element_squarefree (A : Finset ℕ) (h : hasSquarefreeSumset A)
+    (a : ℕ) (ha : a ∈ A) (ha_pos : a ≥ 1) : isSquarefree a := by
+  rw [squarefree_iff_no_prime_sq a ha_pos]
+  exact fun p hp => element_not_div_prime_sq A h p hp a ha
 
 /-
 ## Part X: Main Results

--- a/research/problems/erdos-1109/knowledge.md
+++ b/research/problems/erdos-1109/knowledge.md
@@ -1,50 +1,67 @@
-# Erdős #1109: Squarefree Sumsets - Knowledge
+# Erdos #1109: Squarefree Sumsets - Knowledge
 
 ## Problem
 Let f(N) be the max size of A ⊆ {1,...,N} with A+A squarefree. Estimate f(N).
 
 ## Key Results
 
-### Proved Theorems (0 sorries)
-1. `all_odd`: All elements in a squarefree-sumset set must be odd (even elements create 4 | a+a)
-2. `prime_sq_avoidance`: For any prime p, no two elements sum to a multiple of p²
-3. `squarefree_iff_no_prime_sq`: Squarefree ↔ no prime square divides
-4. `one_squarefree`, `prime_squarefree`: Basic squarefree facts
-5. `current_bounds`, `erdos_1109_summary`: Bound statements using axioms
+### Proved Theorems (11 theorems, 0 sorries)
+1. `squarefree_iff_no_prime_sq`: Squarefree iff no prime square divides
+2. `one_squarefree`: 1 is squarefree
+3. `prime_squarefree`: Primes are squarefree
+4. `distinct_primes_squarefree`: Products of distinct primes are squarefree (**PROVED**, was axiom)
+5. `all_odd`: All elements in a squarefree-sumset set must be odd
+6. `prime_sq_avoidance`: For any prime p, no two elements sum to a multiple of p^2
+7. `double_squarefree`: For any a in A, 2a is squarefree
+8. `element_not_div_prime_sq`: No element is divisible by p^2 for any prime p
+9. `element_squarefree`: All positive elements of A are themselves squarefree
+10. `current_bounds`: Combined Konyagin 2004 bounds (from axioms)
+11. `erdos_1109_summary`: Full bound summary theorem (from axioms)
 
-### Compilation Fixes
+### Iteration 2 Progress (2026-02-03)
+- **Converted `distinct_primes_squarefree` from axiom to theorem**
+  - Proof by induction on the list of distinct primes
+  - Key Mathlib lemmas: `Nat.squarefree_mul_iff`, `Prime.dvd_prod_iff`, `Nat.Prime.coprime_iff_not_dvd`
+  - Strategy: In the inductive step, show p is coprime to ps.prod because
+    p is prime, all elements of ps are prime, and p not in ps (Nodup). If p | q for
+    some q in ps, then since q is prime, p = q, contradicting Nodup.
+- **Added `double_squarefree`**: 2a is squarefree for all a in A
+- **Added `element_not_div_prime_sq`**: No element divisible by p^2 (follows from diagonal of prime_sq_avoidance)
+- **Added `element_squarefree`**: All positive elements are squarefree (uses squarefree_iff_no_prime_sq + element_not_div_prime_sq)
+- Added `import Mathlib.Data.List.Prime` for `Prime.dvd_prod_iff`
+
+### Structural Constraint Hierarchy
+The theorems form a logical hierarchy:
+1. `prime_sq_avoidance` (most general): for all a, b in A and prime p, p^2 does not divide a+b
+2. `element_not_div_prime_sq` (diagonal case): setting a = b, p^2 does not divide 2a, hence p^2 does not divide a
+3. `element_squarefree` (aggregated): combining over all primes, elements are squarefree
+4. `all_odd` (p=2 special case): the simplest constraint, elements must be odd
+
+### Iteration 1 Progress (2026-01-28)
+- Fixed compilation (missing imports, wrong sSup syntax)
+- Changed /-! to /- for Aristotle compatibility
+- Proved `all_odd` and `prime_sq_avoidance`
+- File now compiles cleanly
+
+### Compilation Fixes (Iteration 1)
 - Changed all `/-!` docstrings to `/-` (Aristotle compatibility)
-- Added `import Mathlib.Data.Real.Basic` for ℝ type
+- Added `import Mathlib.Data.Real.Basic` for R type
 - Added `import Mathlib.Analysis.SpecialFunctions.Log.Basic` for `Real.log`
-- Added `import Mathlib.Analysis.SpecialFunctions.Pow.Real` for `ℝ^ℝ` power
-- Fixed `sSup` set builder syntax from `{ A.card | A : Finset ℕ // ... }` to `{ m : ℕ | ∃ A ... }`
-- Fixed axiom quantifier patterns (`∃ C > 0` → `∃ C : ℝ, C > 0 ∧ ...`)
-- Removed `squarefree_density` axiom (required `DecidablePred` for filtering, and `Real.pi` - not essential)
-- Removed trivial `erdos_1109_open : True` and `mod4_constraint : True` theorems
-- File now compiles cleanly (was previously broken)
+- Added `import Mathlib.Analysis.SpecialFunctions.Pow.Real` for R^R power
+- Fixed `sSup` set builder syntax
+- Fixed axiom quantifier patterns
 
-### Mathematical Insight
-The `all_odd` theorem is the simplest structural constraint on squarefree-sumset sets:
-- If a is even, a + a = 2a. Since a = 2k, we get a + a = 4k.
-- 4k is divisible by 4 = 2², so not squarefree (when k > 0).
-- When k = 0, a + a = 0, which is also not squarefree.
-- Therefore every element must be odd.
-
-This generalizes: for prime p, elements must avoid residue classes modulo p²
-that would make any pair sum to 0 mod p². The `prime_sq_avoidance` theorem
-captures this general constraint.
-
-## Axiom Inventory (8 axioms)
-1. `distinct_primes_squarefree` - Products of distinct primes are squarefree (provable, needs Mathlib API work)
-2. `erdos_sarkozy_lower_1987` - f(N) ≫ log N
-3. `erdos_sarkozy_upper_1987` - f(N) ≪ N^{3/4} log N
-4. `konyagin_lower_2004` - f(N) ≫ (log log N)(log N)²
-5. `konyagin_upper_2004` - f(N) ≪ N^{11/15+o(1)}
+## Axiom Inventory (7 axioms, down from 8)
+1. ~~`distinct_primes_squarefree`~~ **PROVED** (was axiom)
+2. `erdos_sarkozy_lower_1987` - f(N) >> log N
+3. `erdos_sarkozy_upper_1987` - f(N) << N^{3/4} log N
+4. `konyagin_lower_2004` - f(N) >> (log log N)(log N)^2
+5. `konyagin_upper_2004` - f(N) << N^{11/15+o(1)}
 6. `erdos_sarkozy_conjecture` - f(N) = (log N)^{O(1)}
-7. `connection_to_1103` - Finite bounds → infinite sequence growth
+7. `connection_to_1103` - Finite bounds -> infinite sequence growth
 8. `sarkozy_k_power_free` - k-power-free generalization bounds
 
 ## Next Steps
-- Prove `distinct_primes_squarefree` (needs exploration of Mathlib list/product API)
-- Consider Aristotle submission for the axiom (after converting to theorem sorry)
-- Could strengthen `all_odd` to show specific residue class constraints mod p² for small primes
+- Submit remaining axioms to Aristotle (bound axioms are from published papers, may not be in Mathlib)
+- Explore density bounds via counting forbidden residue classes mod p^2
+- Consider CRT approach for simultaneous mod p^2 constraints

--- a/src/data/research/problems/erdos-1109.json
+++ b/src/data/research/problems/erdos-1109.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1109",
   "title": "Squarefree Sumsets",
-  "phase": "SURVEYED",
+  "phase": "PROGRESS",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,9 +16,15 @@
   },
   "knownResults": {
     "proven": [
+      "squarefree_iff_no_prime_sq: Squarefree characterization via prime squares",
+      "one_squarefree: 1 is squarefree",
+      "prime_squarefree: Primes are squarefree",
+      "distinct_primes_squarefree: Products of distinct primes are squarefree (PROVED, was axiom)",
       "all_odd: All elements of a squarefree-sumset set must be odd",
       "prime_sq_avoidance: No two elements sum to a multiple of p² for any prime p",
-      "squarefree_iff_no_prime_sq: Squarefree characterization via prime squares",
+      "double_squarefree: For any element a in A, 2a is squarefree",
+      "element_not_div_prime_sq: No element is divisible by p² for any prime p",
+      "element_squarefree: All positive elements of A are themselves squarefree",
       "current_bounds: Combined Konyagin 2004 bounds",
       "erdos_1109_summary: Full summary theorem"
     ],
@@ -30,43 +36,45 @@
     "goal": "Improve bounds or prove structural constraints on optimal sets"
   },
   "currentState": {
-    "phase": "SURVEYED",
-    "since": "2026-01-28T04:49:00.000Z",
-    "iteration": 1,
-    "focus": "Fix compilation, prove structural constraints, Aristotle-ready format",
-    "blockers": [
-      "distinct_primes_squarefree remains an axiom (needs Mathlib list/product API)"
-    ],
-    "nextAction": "Submit to Aristotle for distinct_primes_squarefree, explore mod p² constraints for small primes",
+    "phase": "PROGRESS",
+    "since": "2026-02-03T08:00:00.000Z",
+    "iteration": 2,
+    "focus": "Proved distinct_primes_squarefree (was axiom), added element squarefreeness chain",
+    "blockers": [],
+    "nextAction": "Submit remaining 7 axioms to Aristotle, explore upper bound improvements via sieve methods",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 2,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed compilation (was broken), proved 2 new structural theorems (all_odd, prime_sq_avoidance), fixed /-! to /- for Aristotle, fixed type issues with Real.log/Real.pow imports, 0 sorries, 8 axioms for deep results",
+    "progressSummary": "PROGRESS: Converted distinct_primes_squarefree from axiom to proved theorem using Nat.squarefree_mul_iff + Prime.dvd_prod_iff by induction. Added 3 new structural theorems: double_squarefree, element_not_div_prime_sq, element_squarefree. Now 11 proved theorems, 7 axioms (down from 8), 0 sorries.",
     "builtItems": [
-      "all_odd theorem in Erdos1109Problem.lean:237 - all elements must be odd",
-      "prime_sq_avoidance theorem in Erdos1109Problem.lean:261 - no pair sums to p²-multiple",
-      "Fixed f(N) definition using proper sSup set builder syntax",
-      "Added Real.log, Real.pow imports for compilation",
+      "distinct_primes_squarefree theorem (proved, was axiom) - induction on list using Nat.squarefree_mul_iff",
+      "double_squarefree theorem - 2a is squarefree for a ∈ A",
+      "element_not_div_prime_sq theorem - no element divisible by p²",
+      "element_squarefree theorem - all positive elements are squarefree",
+      "Added import Mathlib.Data.List.Prime for Prime.dvd_prod_iff",
+      "all_odd theorem in Erdos1109Problem.lean - all elements must be odd",
+      "prime_sq_avoidance theorem in Erdos1109Problem.lean - no pair sums to p²-multiple",
       "Knowledge entry at research/problems/erdos-1109/knowledge.md"
     ],
     "insights": [
-      "Original file did not compile - missing Real.log, Real.pow imports and wrong sSup syntax",
-      "/-! docstrings break Aristotle parser - must use /-",
+      "distinct_primes_squarefree is provable by induction using Nat.squarefree_mul_iff and Prime.dvd_prod_iff",
+      "Key step: prime p coprime to product of other distinct primes because p ∤ any q in list (all prime, distinct)",
+      "Elements of squarefree-sumset sets are themselves squarefree: if p² | a then p² | 2a = a+a",
+      "Squarefreeness of elements is a stronger constraint than just oddness",
+      "The hierarchy: all_odd (p=2 case) → prime_sq_avoidance (general) → element_not_div_prime_sq (diagonal) → element_squarefree",
       "Even elements are impossible: a even → a+a = 4k → divisible by 2², not squarefree",
-      "The all_odd constraint is the p=2 special case of general mod p² avoidance",
-      "Axiom quantifier patterns need explicit types for Lean 4 (∃ C : ℝ, C > 0 ∧ ... not ∃ C > 0, ...)"
+      "Axiom quantifier patterns need explicit types for Lean 4"
     ],
-    "mathlibGaps": [
-      "No direct squarefree product theorem for lists of distinct primes"
-    ],
+    "mathlibGaps": [],
     "nextSteps": [
-      "Attempt proof of distinct_primes_squarefree using Mathlib coprimality API",
-      "Submit to Aristotle for automated proof search on axioms",
-      "Explore residue class constraints for p=3 (mod 9 avoidance)"
+      "Submit remaining 7 axioms to Aristotle (bound axioms likely unprovable from Mathlib)",
+      "Prove that elements must avoid residue 0 mod p² for all primes p (follows from element_squarefree)",
+      "Explore density bounds: count forbidden residue classes mod p² to derive upper bounds",
+      "Consider Chinese Remainder Theorem approach for simultaneous mod p² constraints"
     ]
   },
   "approaches": [
@@ -74,7 +82,7 @@
       "name": "Structural constraints",
       "description": "Prove necessary conditions on elements of squarefree-sumset sets via modular arithmetic",
       "status": "progress",
-      "results": "Proved all_odd and prime_sq_avoidance theorems"
+      "results": "Proved all_odd, prime_sq_avoidance, distinct_primes_squarefree (was axiom), double_squarefree, element_not_div_prime_sq, element_squarefree. Full chain of structural constraints established."
     }
   ],
   "tags": [
@@ -100,12 +108,13 @@
     ],
     "mathlib": [
       "Mathlib.Data.Nat.Squarefree",
+      "Mathlib.Data.List.Prime",
       "Mathlib.Analysis.SpecialFunctions.Log.Basic",
       "Mathlib.Analysis.SpecialFunctions.Pow.Real"
     ]
   },
   "started": "2026-01-27T22:18:02.332Z",
-  "lastUpdate": "2026-01-28T04:49:00.000Z",
+  "lastUpdate": "2026-02-03T08:00:00.000Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Converted `distinct_primes_squarefree` from axiom to proved theorem using `Nat.squarefree_mul_iff` + `Prime.dvd_prod_iff` by induction on the list of distinct primes
- Added 3 new structural constraint theorems: `double_squarefree`, `element_not_div_prime_sq`, `element_squarefree`
- Now 11 proved theorems, 7 axioms (down from 8), 0 sorries
- Added `import Mathlib.Data.List.Prime`

## Progress
- **Axiom removed**: `distinct_primes_squarefree` - products of distinct primes are squarefree
- **New theorem chain**: Elements of squarefree-sumset sets are themselves squarefree
  - `double_squarefree`: 2a is squarefree for any a in A
  - `element_not_div_prime_sq`: no element divisible by p^2 for any prime p
  - `element_squarefree`: all positive elements are squarefree

## Findings
- `distinct_primes_squarefree` provable by induction: show head prime is coprime to tail product (since it can't divide any other distinct prime), then apply `Nat.squarefree_mul_iff`
- Element squarefreeness follows from the diagonal case of `prime_sq_avoidance`: if p^2 | a then p^2 | 2a = a+a

## Status
**Outcome**: progress
**Next Steps**: Submit remaining 7 axioms to Aristotle, explore density bounds via residue class counting

Generated by researcher-2