### PR TITLE
Integrate Aristotle proof: Erdős #824 h_upper_bound

### DIFF
--- a/proofs/Proofs/Erdos824Problem.lean
+++ b/proofs/Proofs/Erdos824Problem.lean
@@ -166,7 +166,9 @@ Trivially h(x) ≤ x², since there are at most x² pairs (a, b) with a, b < x.
 -/
 theorem h_upper_bound (x : ℕ) : h x ≤ x ^ 2 := by
   -- h(x) counts pairs in a set of size at most x²
-  sorry
+  -- Proved by Aristotle (Harmonic)
+  refine le_trans (Finset.card_filter_le _ _) ?_
+  simpa using by nlinarith
 
 /--
 **Gap Between Known and Conjectured:**

--- a/proofs/Proofs/Erdos824ProblemProvable.lean
+++ b/proofs/Proofs/Erdos824ProblemProvable.lean
@@ -166,7 +166,9 @@ Trivially h(x) ≤ x², since there are at most x² pairs (a, b) with a, b < x.
 -/
 theorem h_upper_bound (x : ℕ) : h x ≤ x ^ 2 := by
   -- h(x) counts pairs in a set of size at most x²
-  sorry
+  -- Proved by Aristotle (Harmonic)
+  refine le_trans (Finset.card_filter_le _ _) ?_
+  simpa using by nlinarith
 
 /--
 **Gap Between Known and Conjectured:**

--- a/src/data/proofs/erdos-824/meta.json
+++ b/src/data/proofs/erdos-824/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 824,
     "erdosUrl": "https://erdosproblems.com/824",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Summary
- Aristotle proved `h_upper_bound` theorem in Erdős #824 (coprime pairs with equal sum of divisors)
- Sorry count reduced: 2 → 1 in main file, 4 → 3 in provable variant
- Proof uses `Finset.card_filter_le` and `nlinarith`

## Aristotle Findings
- **Proved**: `h_upper_bound (x : ℕ) : h x ≤ x ^ 2` - trivial upper bound from pair counting
- **Negated**: `erdos_1974_limsup` and `pollack_pomerance_2016` - suggests the formalization of h(x) may not correctly capture the intended mathematical function (worth investigating)

## Files Changed
- `proofs/Proofs/Erdos824Problem.lean` - h_upper_bound sorry replaced with proof
- `proofs/Proofs/Erdos824ProblemProvable.lean` - same fix
- `src/data/proofs/erdos-824/meta.json` - updated sorry count

## Verification
- `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>