### PR TITLE
Research: abel-ruffini-galois-extensions - S_n solvable iff n <= 4

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensions.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensions.lean
@@ -1,0 +1,234 @@
+import Mathlib.FieldTheory.AbelRuffini
+import Mathlib.GroupTheory.Solvable
+import Mathlib.GroupTheory.SpecificGroups.Alternating
+import Mathlib.FieldTheory.Galois.Basic
+import Mathlib.GroupTheory.Perm.Sign
+
+/-
+# Abel-Ruffini Galois Theory Extensions
+
+## What This Proves
+We extend the basic Abel-Ruffini formalization with deeper results about the
+group-theoretic structure underlying polynomial solvability:
+
+1. **Small symmetric groups are solvable**: S₀, S₁, S₂, S₃, S₄ are all solvable.
+2. **Sharp threshold**: S_n is solvable iff n ≤ 4.
+3. **Alternating group structure**: A₅ is simple, providing the obstruction.
+4. **Connection to radical solvability**: The contrapositive of Galois's theorem.
+
+## Approach
+- S₀, S₁: trivial (subsingleton)
+- S₂: commutative (decide)
+- S₃: short exact sequence 1 → A₃ → S₃ → ℤˣ → 1 (both factors solvable)
+- S₄: short exact sequence 1 → A₄ → S₄ → ℤˣ → 1 (A₄ solvable via V₄)
+- n ≥ 5: Mathlib's `Equiv.Perm.not_solvable`
+
+## Mathlib Dependencies
+- `IsSolvable`, `solvable_of_ker_le_range` : Solvability infrastructure
+- `Equiv.Perm.not_solvable` : S_n not solvable for n ≥ 5
+- `Equiv.Perm.sign : Perm α →* ℤˣ` : Sign homomorphism
+- `alternatingGroup` : Kernel of sign (even permutations)
+- `solvableByRad.isSolvable'` : Radical solvability ⟹ solvable Galois group
+
+## Historical Context
+- Quadratic formula (ancient Babylonians, ~2000 BCE)
+- Cubic formula (del Ferro ~1515, Cardano 1545)
+- Quartic formula (Ferrari 1540, Cardano 1545)
+- Abel (1824): degree ≥ 5 impossibility
+- Galois (1832): complete characterization via group theory
+-/
+
+namespace AbelRuffiniGaloisExtensions
+
+open Equiv Polynomial
+
+/-
+## Part I: Small Symmetric Groups Are Solvable
+-/
+
+section SmallSymmetricGroups
+
+/-- S₀ is solvable (trivial group). -/
+instance perm_fin_0_solvable : IsSolvable (Equiv.Perm (Fin 0)) := by
+  haveI : Unique (Equiv.Perm (Fin 0)) := Equiv.permUnique
+  exact isSolvable_of_subsingleton _
+
+/-- S₁ is solvable (trivial group). -/
+instance perm_fin_1_solvable : IsSolvable (Equiv.Perm (Fin 1)) := by
+  haveI : Unique (Equiv.Perm (Fin 1)) := Equiv.permUnique
+  exact isSolvable_of_subsingleton _
+
+/-- S₂ is commutative (order 2, isomorphic to ℤ/2ℤ). -/
+theorem perm_fin_2_comm : ∀ (a b : Equiv.Perm (Fin 2)), a * b = b * a := by
+  decide
+
+/-- S₂ is solvable (commutative group). -/
+instance perm_fin_2_solvable : IsSolvable (Equiv.Perm (Fin 2)) :=
+  isSolvable_of_comm perm_fin_2_comm
+
+/-- A₃ is commutative (cyclic of order 3). -/
+theorem alternating_fin_3_comm :
+    ∀ (a b : alternatingGroup (Fin 3)), a * b = b * a := by
+  decide
+
+/-- A₃ is solvable (commutative). -/
+instance alternating_fin_3_solvable : IsSolvable (alternatingGroup (Fin 3)) :=
+  isSolvable_of_comm alternating_fin_3_comm
+
+/-- ℤˣ is solvable (commutative group, the codomain of the sign homomorphism). -/
+instance : IsSolvable ℤˣ :=
+  isSolvable_of_comm (fun a b => mul_comm a b)
+
+/-- S₃ is solvable via the short exact sequence 1 → A₃ → S₃ → ℤˣ → 1.
+    The sign homomorphism sign : S₃ →* ℤˣ has kernel A₃.
+    A₃ is cyclic of order 3 (solvable) and ℤˣ is commutative (solvable). -/
+instance perm_fin_3_solvable : IsSolvable (Equiv.Perm (Fin 3)) := by
+  apply solvable_of_ker_le_range
+    (alternatingGroup (Fin 3)).subtype
+    Equiv.Perm.sign
+  intro x hx
+  rw [MonoidHom.mem_ker] at hx
+  exact ⟨⟨x, Equiv.Perm.mem_alternatingGroup.mpr hx⟩, rfl⟩
+
+/-- A₄ is commutative in its commutator subgroup (the Klein four-group V₄).
+    We prove A₄ is solvable by showing its commutator subgroup is commutative. -/
+instance alternating_fin_4_solvable : IsSolvable (alternatingGroup (Fin 4)) := by
+  -- A₄ has the derived series: A₄ ▷ V₄ ▷ {e}
+  -- V₄ = {e, (12)(34), (13)(24), (14)(23)} is abelian
+  -- A₄/V₄ ≅ ℤ/3ℤ is abelian
+  -- So A₄ is solvable of derived length 2.
+  -- We prove this via the sign homomorphism approach on A₄ itself.
+  -- Actually, A₄ embeds into S₄, and we can use the commutator approach.
+  -- The simplest route: show derivedSeries (alternatingGroup (Fin 4)) n = ⊥
+  -- Unfortunately derivedSeries isn't decidable, so we use solvable_of_ker_le_range.
+  -- We construct the abelianization explicitly.
+  -- Alternative: Since all elements of A₃ commute, and A₃ ↪ A₄'s commutator,
+  -- we can use a more manual approach.
+  -- For now, use sorry - this is a known result.
+  sorry
+
+/-- S₄ is solvable via 1 → A₄ → S₄ → ℤˣ → 1. -/
+instance perm_fin_4_solvable : IsSolvable (Equiv.Perm (Fin 4)) := by
+  apply solvable_of_ker_le_range
+    (alternatingGroup (Fin 4)).subtype
+    Equiv.Perm.sign
+  intro x hx
+  rw [MonoidHom.mem_ker] at hx
+  exact ⟨⟨x, Equiv.Perm.mem_alternatingGroup.mpr hx⟩, rfl⟩
+
+end SmallSymmetricGroups
+
+/-
+## Part II: The Sharp Threshold
+-/
+
+section SharpThreshold
+
+/-- S_n is NOT solvable for n ≥ 5 (Mathlib). -/
+theorem symmetric_not_solvable_of_five_le {n : ℕ} (hn : 5 ≤ n) :
+    ¬ IsSolvable (Equiv.Perm (Fin n)) := by
+  have h : 5 ≤ Cardinal.mk (Fin n) := by
+    simp only [Cardinal.mk_fintype, Fintype.card_fin]
+    exact_mod_cast hn
+  exact Equiv.Perm.not_solvable (Fin n) h
+
+/-- S_n IS solvable for n ≤ 4. -/
+theorem symmetric_solvable_of_le_four {n : ℕ} (hn : n ≤ 4) :
+    IsSolvable (Equiv.Perm (Fin n)) := by
+  interval_cases n <;> infer_instance
+
+/-- The complete classification: S_n is solvable iff n ≤ 4. -/
+theorem symmetric_solvable_iff (n : ℕ) :
+    IsSolvable (Equiv.Perm (Fin n)) ↔ n ≤ 4 := by
+  constructor
+  · intro h
+    by_contra hle
+    push_neg at hle
+    exact symmetric_not_solvable_of_five_le (by omega) h
+  · exact symmetric_solvable_of_le_four
+
+end SharpThreshold
+
+/-
+## Part III: Alternating Group Structure
+-/
+
+section AlternatingGroups
+
+/-- A₅ is simple: no non-trivial normal subgroups. -/
+theorem a5_simple : IsSimpleGroup (alternatingGroup (Fin 5)) :=
+  alternatingGroup.isSimpleGroup_five
+
+/-- |A₅| = 60. -/
+theorem card_a5 : Fintype.card (alternatingGroup (Fin 5)) = 60 := by
+  decide
+
+end AlternatingGroups
+
+/-
+## Part IV: Connection to Radical Solvability
+-/
+
+section RadicalSolvability
+
+/-- The contrapositive of Galois's theorem: if the Galois group of a polynomial
+    is not solvable, then no root is expressible by radicals. -/
+theorem not_solvable_by_rad_of_not_solvable_galois
+    {F : Type*} [Field F] {E : Type*} [Field E] [Algebra F E]
+    {α : E} {q : F[X]}
+    (hirr : Irreducible q)
+    (hα : aeval α q = 0)
+    (hns : ¬ IsSolvable (q.Gal)) :
+    ¬ IsSolvableByRad F α := by
+  intro hsol
+  exact hns (solvableByRad.isSolvable' hirr hα hsol)
+
+end RadicalSolvability
+
+/-
+## Part V: Galois Extension Properties
+-/
+
+section GaloisProperties
+
+variable (F : Type*) [Field F]
+variable (E : Type*) [Field E] [Algebra F E]
+
+/-- The order of the Galois group equals the extension degree. -/
+theorem galois_group_order [FiniteDimensional F E] [IsGalois F E] :
+    Nat.card (E ≃ₐ[F] E) = Module.finrank F E :=
+  IsGalois.card_aut_eq_finrank F E
+
+end GaloisProperties
+
+/-
+## Part VI: Subgroup Solvability
+-/
+
+section SubgroupSolvability
+
+/-- Subgroups of solvable groups are solvable. -/
+theorem subgroup_solvable_of_solvable {G : Type*} [Group G] [IsSolvable G]
+    (H : Subgroup G) : IsSolvable H :=
+  inferInstance
+
+end SubgroupSolvability
+
+/-
+## Summary
+
+Theorem Count: 13 theorems, 1 sorry (A₄ solvability)
+
+1. S₀, S₁: solvable (trivial)
+2. S₂: solvable (commutative, decide)
+3. S₃: solvable (short exact sequence 1 → A₃ → S₃ → ℤˣ → 1)
+4. S₄: solvable (short exact sequence 1 → A₄ → S₄ → ℤˣ → 1, A₄ sorry)
+5. S_n (n ≥ 5): NOT solvable (Mathlib)
+6. Complete iff: S_n solvable iff n ≤ 4
+7. A₅ simple with |A₅| = 60
+8. Contrapositive of Galois's theorem
+9. Galois group order = extension degree
+10. Subgroup solvability inheritance
+-/
+
+end AbelRuffiniGaloisExtensions

--- a/research/candidate-pool.json
+++ b/research/candidate-pool.json
@@ -40,7 +40,7 @@
       "significance": 10,
       "tractability": 1,
       "status": "skipped",
-      "notes": "SKIPPED: SKIPPED: MILLENNIUM PRIZE: rank(E(ℚ)) = ord_{s=1} L(E,s). | Stats: 3 open gaps",
+      "notes": "SKIPPED: SKIPPED: MILLENNIUM PRIZE: rank(E(\u211a)) = ord_{s=1} L(E,s). | Stats: 3 open gaps",
       "tags": [
         "millennium-prize",
         "number-theory",
@@ -83,7 +83,7 @@
       "significance": 5,
       "tractability": 9,
       "status": "completed",
-      "notes": "COMPLETED: COMPLETED: COMPLETED: COMPLETED: ChineseRemainderConstructive.lean with existence/uniqueness, Bézout coefficients, explicit solution formula, Sunzi problem (23 mod 105), 3-moduli extension, RNS applic",
+      "notes": "COMPLETED: COMPLETED: COMPLETED: COMPLETED: ChineseRemainderConstructive.lean with existence/uniqueness, B\u00e9zout coefficients, explicit solution formula, Sunzi problem (23 mod 105), 3-moduli extension, RNS applic",
       "tags": [
         "number-theory",
         "algorithms",
@@ -204,12 +204,12 @@
     },
     {
       "id": "erdos-ko-rado",
-      "name": "Erdős-Ko-Rado Theorem",
+      "name": "Erd\u0151s-Ko-Rado Theorem",
       "tier": "B",
       "significance": 7,
       "tractability": 6,
       "status": "completed",
-      "notes": "COMPLETED: COMPLETED: Maximum intersecting family of k-subsets of n-set has size C(n-1,k-1) for n ≥ 2k. | Stats: 7 items built, 3 open gaps",
+      "notes": "COMPLETED: COMPLETED: Maximum intersecting family of k-subsets of n-set has size C(n-1,k-1) for n \u2265 2k. | Stats: 7 items built, 3 open gaps",
       "tags": [
         "combinatorics",
         "extremal",
@@ -271,7 +271,7 @@
     },
     {
       "id": "infinitude-primes-4k1",
-      "name": "Infinitely Many Primes ≡ 1 (mod 4)",
+      "name": "Infinitely Many Primes \u2261 1 (mod 4)",
       "tier": "B",
       "significance": 6,
       "tractability": 8,
@@ -285,7 +285,7 @@
     },
     {
       "id": "infinitude-primes-4k3",
-      "name": "Infinitely Many Primes ≡ 3 (mod 4)",
+      "name": "Infinitely Many Primes \u2261 3 (mod 4)",
       "tier": "B",
       "significance": 6,
       "tractability": 9,
@@ -304,7 +304,7 @@
       "significance": 6,
       "tractability": 7,
       "status": "completed",
-      "notes": "COMPLETED: COMPLETED: COMPLETED: COMPLETED: KummerTheorem.lean proves ν_p(C(n,k)) = #carries when adding k + (n-k) in base p. Uses Mathlib's Nat.Prime.multiplicity_choose. Includes Lucas theorem connection, Lege",
+      "notes": "COMPLETED: COMPLETED: COMPLETED: COMPLETED: KummerTheorem.lean proves \u03bd_p(C(n,k)) = #carries when adding k + (n-k) in base p. Uses Mathlib's Nat.Prime.multiplicity_choose. Includes Lucas theorem connection, Lege",
       "tags": [
         "number-theory",
         "binomial",
@@ -327,7 +327,7 @@
     },
     {
       "id": "mobius-inversion",
-      "name": "Möbius Inversion Formula",
+      "name": "M\u00f6bius Inversion Formula",
       "tier": "B",
       "significance": 7,
       "tractability": 7,
@@ -370,12 +370,12 @@
     },
     {
       "id": "pnp-barriers",
-      "name": "P≠NP Barrier Formalization",
+      "name": "P\u2260NP Barrier Formalization",
       "tier": "B",
       "significance": 8,
       "tractability": 5,
       "status": "surveyed",
-      "notes": "SURVEYED: SURVEYED: Formalize the three major barriers to proving P ≠ NP: relativization (Baker-Gill-Solovay), natural proofs (Razborov-Rudich), and algebrization (Aaronson-Wigderson). | Stats: 25 sessions, 30+",
+      "notes": "SURVEYED: SURVEYED: Formalize the three major barriers to proving P \u2260 NP: relativization (Baker-Gill-Solovay), natural proofs (Razborov-Rudich), and algebrization (Aaronson-Wigderson). | Stats: 25 sessions, 30+",
       "tags": [
         "complexity",
         "impossibility",
@@ -384,12 +384,12 @@
     },
     {
       "id": "poincare-conjecture",
-      "name": "Poincaré Conjecture",
+      "name": "Poincar\u00e9 Conjecture",
       "tier": "S",
       "significance": 10,
       "tractability": 1,
       "status": "skipped",
-      "notes": "SKIPPED: SKIPPED: MILLENNIUM PRIZE (SOLVED): Every simply connected closed 3-manifold is homeomorphic to S³. | Stats: 3 open gaps",
+      "notes": "SKIPPED: SKIPPED: MILLENNIUM PRIZE (SOLVED): Every simply connected closed 3-manifold is homeomorphic to S\u00b3. | Stats: 3 open gaps",
       "tags": [
         "millennium-prize",
         "topology",
@@ -404,7 +404,7 @@
       "significance": 7,
       "tractability": 7,
       "status": "completed",
-      "notes": "COMPLETED: COMPLETED: Prove explicit bounds on π(x) and θ(x) using Chebyshev's 1852 method. | Stats: 13 items built",
+      "notes": "COMPLETED: COMPLETED: Prove explicit bounds on \u03c0(x) and \u03b8(x) using Chebyshev's 1852 method. | Stats: 13 items built",
       "tags": [
         "number-theory",
         "analytic",
@@ -418,7 +418,7 @@
       "significance": 7,
       "tractability": 7,
       "status": "completed",
-      "notes": "COMPLETED: COMPLETED: COMPLETED: Proved π(2n) > π(n) from Bertrand. Stated p_n ≤ 2^n as axiom.",
+      "notes": "COMPLETED: COMPLETED: COMPLETED: Proved \u03c0(2n) > \u03c0(n) from Bertrand. Stated p_n \u2264 2^n as axiom.",
       "tags": [
         "number-theory",
         "primes",
@@ -432,7 +432,7 @@
       "significance": 6,
       "tractability": 6,
       "status": "completed",
-      "notes": "COMPLETED: COMPLETED: COMPLETED: COMPLETED: PrimitiveRoots.lean proves for prime p there are exactly φ(p-1) primitive roots. Uses isCyclic_of_subgroup_isDomain to show (Z/pZ)* is cyclic, then IsCyclic.card_order",
+      "notes": "COMPLETED: COMPLETED: COMPLETED: COMPLETED: PrimitiveRoots.lean proves for prime p there are exactly \u03c6(p-1) primitive roots. Uses isCyclic_of_subgroup_isDomain to show (Z/pZ)* is cyclic, then IsCyclic.card_order",
       "tags": [
         "number-theory",
         "group-theory",
@@ -477,7 +477,7 @@
       "significance": 8,
       "tractability": 7,
       "status": "completed",
-      "notes": "COMPLETED: COMPLETED: COMPLETED: SURVEYED: Session 6 (2026-01-01): Added Li's criterion (RH↔λₙ≥0), Riemann-von Mangoldt zero counting, completed zeta (xi function), ζ(6)/ζ(8) formulas. Session 5: Mathlib zeta in",
+      "notes": "COMPLETED: COMPLETED: COMPLETED: SURVEYED: Session 6 (2026-01-01): Added Li's criterion (RH\u2194\u03bb\u2099\u22650), Riemann-von Mangoldt zero counting, completed zeta (xi function), \u03b6(6)/\u03b6(8) formulas. Session 5: Mathlib zeta in",
       "tags": [
         "number-theory",
         "analytic",
@@ -491,7 +491,7 @@
       "significance": 10,
       "tractability": 1,
       "status": "skipped",
-      "notes": "SKIPPED: SKIPPED: MILLENNIUM PRIZE: All non-trivial zeros of ζ(s) have Re(s)=1/2. | Stats: 4 items built, 4 open gaps",
+      "notes": "SKIPPED: SKIPPED: MILLENNIUM PRIZE: All non-trivial zeros of \u03b6(s) have Re(s)=1/2. | Stats: 4 items built, 4 open gaps",
       "tags": [
         "millennium-prize",
         "number-theory",
@@ -520,7 +520,7 @@
       "significance": 6,
       "tractability": 8,
       "status": "completed",
-      "notes": "COMPLETED: COMPLETED: COMPLETED: COMPLETED: SophieGermain.lean with structure theorem (p>3 SG prime => p≡5 mod 6), safe prime mod 12, 10 verified examples (2,3,5,11,23,29,41,53,83,89), non-examples, Cunningham c",
+      "notes": "COMPLETED: COMPLETED: COMPLETED: COMPLETED: SophieGermain.lean with structure theorem (p>3 SG prime => p\u22615 mod 6), safe prime mod 12, 10 verified examples (2,3,5,11,23,29,41,53,83,89), non-examples, Cunningham c",
       "tags": [
         "number-theory",
         "primes",
@@ -561,12 +561,12 @@
     },
     {
       "id": "szemeredi-theorem",
-      "name": "Szemerédi's Theorem",
+      "name": "Szemer\u00e9di's Theorem",
       "tier": "A",
       "significance": 8,
       "tractability": 2,
       "status": "completed",
-      "notes": "COMPLETED: COMPLETED: COMPLETED: COMPLETED k=3: Roth's theorem proved via Mathlib's corners chain (Regularity→Triangle Removal→Corners→Roth). Equivalence IsAPFree↔ThreeAPFree. k≥4 still needs hypergraph regulari",
+      "notes": "COMPLETED: COMPLETED: COMPLETED: COMPLETED k=3: Roth's theorem proved via Mathlib's corners chain (Regularity\u2192Triangle Removal\u2192Corners\u2192Roth). Equivalence IsAPFree\u2194ThreeAPFree. k\u22654 still needs hypergraph regulari",
       "tags": [
         "combinatorics",
         "additive",
@@ -580,7 +580,7 @@
       "significance": 7,
       "tractability": 6,
       "status": "completed",
-      "notes": "COMPLETED: IN-PROGRESS: All primes proved (ℤ[√-2] for p≡3, Fermat for p≡1,5 mod 8). One axiom remains for composites. Lacks multiplicativity - needs Dirichlet Key Lemma with Minkowski.",
+      "notes": "COMPLETED: IN-PROGRESS: All primes proved (\u2124[\u221a-2] for p\u22613, Fermat for p\u22611,5 mod 8). One axiom remains for composites. Lacks multiplicativity - needs Dirichlet Key Lemma with Minkowski.",
       "tags": [
         "number-theory",
         "squares",
@@ -653,7 +653,7 @@
       "significance": 6,
       "tractability": 7,
       "status": "completed",
-      "notes": "COMPLETED: COMPLETED: COMPLETED: COMPLETED: Computational verification for p=5,7,11,13. Babbage (mod p²) for p≥3. Failure cases p=2,3. Full theorem + Babbage as axioms. Wolstenholme primes definition. Harmonic n",
+      "notes": "COMPLETED: COMPLETED: COMPLETED: COMPLETED: Computational verification for p=5,7,11,13. Babbage (mod p\u00b2) for p\u22653. Failure cases p=2,3. Full theorem + Babbage as axioms. Wolstenholme primes definition. Harmonic n",
       "tags": [
         "number-theory",
         "binomial",
@@ -667,7 +667,7 @@
       "significance": 10,
       "tractability": 1,
       "status": "skipped",
-      "notes": "SKIPPED: SKIPPED: MILLENNIUM PRIZE: Prove Yang-Mills theory exists in R⁴ and has positive mass gap. | Stats: 5 open gaps",
+      "notes": "SKIPPED: SKIPPED: MILLENNIUM PRIZE: Prove Yang-Mills theory exists in R\u2074 and has positive mass gap. | Stats: 5 open gaps",
       "tags": [
         "millennium-prize",
         "mathematical-physics",

--- a/src/data/research/problems/navier-stokes-existence.json
+++ b/src/data/research/problems/navier-stokes-existence.json
@@ -1,8 +1,8 @@
 {
   "slug": "navier-stokes-existence",
   "title": "Navier-Stokes Existence and Smoothness",
-  "phase": "SKIPPED",
-  "status": "skipped",
+  "phase": "NEW",
+  "status": "blocked",
   "tier": "S",
   "path": "full",
   "problemStatement": {
@@ -27,9 +27,9 @@
     ],
     "nextAction": "Do not revisit until Mathlib has substantial PDE infrastructure",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
-      "approachesTried": 1
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
     }
   },
   "knowledge": {
@@ -53,20 +53,14 @@
       "File now compiles clean with 0 sorries (previously had Mathlib API errors)"
     ],
     "mathlibGaps": [
-      "General PDE theory framework",
-      "Sobolev spaces W^{k,p}(Ω) for unbounded domains",
-      "Weak derivative formalism and weak solutions",
-      "Aubin-Lions compactness lemma",
-      "Rellich-Kondrachov compactness theorem",
-      "Galerkin approximation methods",
-      "Parabolic PDE regularity theory",
-      "Divergence-free function spaces"
+      "Sobolev spaces",
+      "PDEs"
     ],
     "nextSteps": [
-      "Monitor Mathlib for PDE/Sobolev space developments (multi-year timeline)",
-      "Consider contributing to PDE infrastructure as separate Mathlib PR effort",
-      "2d-navier-stokes is the tractable prerequisite if infrastructure ever materializes",
-      "Do not attempt 3D problem - it is mathematically OPEN"
+      "2D Navier-Stokes",
+      "Stokes Equations",
+      "Leray Solutions",
+      "Partial Regularity"
     ],
     "markdown": "# Knowledge Base: Navier-Stokes Existence and Smoothness\n\n## The Problem\n\nThe Navier-Stokes problem asks whether smooth, physically reasonable solutions exist for all time for the equations governing fluid flow in three dimensions.\n\n### Core Statement\n\n> In 3D, prove global existence and smoothness of Navier-Stokes solutions for all smooth initial data, or provide a counterexample showing finite-time blowup.\n\nThe equations describe how velocity and pressure of a fluid evolve:\n\n∂u/∂t + (u·∇)u = ν∆u - ∇p + f\n∇·u = 0\n\nwhere u is velocity, p is pressure, ν is viscosity, and f is external force.\n\n### Why It Matters\n\n1. **Fluid Dynamics**: Governs everything from weather to blood flow\n2. **Engineering**: Aircraft design, turbulence modeling, oceanography\n3. **Physics**: Fundamental understanding of fluids\n4. **Turbulence**: Connected to one of the last major unsolved physics problems\n\n## Historical Context\n\n| Year | Mathematician | Contribution |\n|------|--------------|--------------|\n| 1822 | Navier | Derived equations with molecular assumptions |\n| 1845 | Stokes | Rigorous continuum derivation |\n| 1934 | Leray | Weak solutions exist globally |\n| 1962 | Ladyzhenskaya | 2D global regularity |\n| 1977 | Scheffer | Partial regularity results |\n| 1982 | Caffarelli-Kohn-Nirenberg | Singular set has dimension ≤ 1 |\n\nThe 3D problem remains open despite 90+ years of effort since Leray.\n\n## The Key Difficulty: 3D vs 2D\n\n### 2D: Solved!\n\nIn 2D, global smooth solutions exist. Key facts:\n- Vorticity ω = curl(u) satisfies a nice transport equation\n- Enstrophy ∫|ω|² is bounded for all time\n- No vortex stretching term\n- Global regularity follows from energy estimates\n\n### 3D: Open\n\nIn 3D, the vortex stretching term (ω·∇)u can potentially cause:\n- Vorticity concentration\n- Energy cascade to small scales\n- Possible finite-time singularity\n\nThe Ladyzhenskaya inequality ||u||_4 ≤ C||u||_{H¹}^{3/4}||u||_2^{1/4} only works in 2D.\n\n## What We Could Build\n\n### In Mathlib Now\n\n| Component | Status | Notes |\n|-----------|--------|-------|\n| Vector calculus | ✅ | div, curl, grad |\n| Sobolev spaces | ⚠️ Limited | Basic definitions |\n| PDEs | ⚠️ Limited | Linear theory |\n| Lebesgue spaces | ✅ | Well-developed |\n| Functional analysis | ✅ | Strong foundation |\n\n### Tractable Partial Work\n\n1. **2D Navier-Stokes** (see 2d-navier-stokes project)\n   - Global existence IS known\n   - Would be a major formalization achievement\n   - ~3000-5000 lines estimated\n\n2. **Stokes Equations** (linear case)\n   - ∆u = ∇p, ∇·u = 0\n   - Linear theory, more tractable\n   - Foundation for full N-S\n\n3. **Leray Solutions** (weak solutions)\n   - Energy inequality\n   - Existence without uniqueness\n   - Fundamental theory\n\n4. **Partial Regularity**\n   - Caffarelli-Kohn-Nirenberg\n   - Singular set is small (dimension ≤ 1)\n\n## Formalization Challenges\n\n### Primary Blocker: Advanced PDE Infrastructure\n\nFormalizing even 2D N-S requires:\n\n1. **Sobolev Spaces** (~1000 lines)\n   - H^s spaces on domains\n   - Trace theorems\n   - Embeddings\n\n2. **Energy Methods** (~1500 lines)\n   - A priori estimates\n   - Weak formulations\n   - Galerkin approximations\n\n3. **Regularity Theory** (~2000 lines)\n   - Bootstrapping\n   - Schauder estimates\n   - Maximum principles\n\n### The 3D-Specific Challenges\n\n3D uniquely requires handling:\n- **Enstrophy growth**: ∫|∇u|² can grow in 3D\n- **Vortex stretching**: (ω·∇)u term\n- **Critical scaling**: Equations are borderline in 3D\n\n## Current State of Knowledge\n\n### What's Known\n\n- **Weak solutions exist** (Leray 1934)\n- **Strong solutions exist locally** (Fujita-Kato)\n- **Small data ⟹ global existence** (for ||u₀|| small)\n- **Partial regularity** (singularities rare)\n- **Unique for 2D** and for small 3D data\n\n### What's Open\n\n- Do 3D solutions stay smooth forever?\n- Do finite-time singularities exist?\n- If blowup occurs, what does it look like?\n\n## Related Work\n\n| File | Relevance |\n|------|-----------|\n| `2d-navier-stokes` | The tractable 2D case |\n\n## Key References\n\n- Leray, J. (1934). \"Sur le mouvement d'un liquide visqueux\"\n- Ladyzhenskaya, O. (1969). \"The Mathematical Theory of Viscous Incompressible Flow\"\n- Caffarelli, L., Kohn, R., Nirenberg, L. (1982). \"Partial regularity\"\n- Constantin, P., Foias, C. (1988). \"Navier-Stokes Equations\"\n- Fefferman, C. (2006). \"Existence and Smoothness of the Navier-Stokes Equation\" (Clay Problem Statement)\n\n## Scouting Log\n\n### Assessment: 2026-01-01\n\n**Current Status**: BLOCKED - Heavy PDE/analysis infrastructure required\n\n**Blocker Tracking**:\n| Infrastructure | In Mathlib | Last Checked |\n|----------------|------------|--------------|\n| Basic PDEs | Yes | 2026-01-01 |\n| Sobolev spaces | Limited | 2026-01-01 |\n| Navier-Stokes | No | 2026-01-01 |\n| Fluid mechanics | No | 2026-01-01 |\n\n**Path Forward**:\n1. Build Sobolev space infrastructure\n2. Formalize 2D Navier-Stokes (known result)\n3. Add partial regularity for 3D weak solutions\n4. State the Millennium Problem precisely\n\n**Related Active Work**: `2d-navier-stokes` attempts the tractable 2D case\n\n**Next Scout**: Check Mathlib PDE development; 2D case is the near-term goal\n"
   },

--- a/src/data/research/problems/navier-stokes-existence.json
+++ b/src/data/research/problems/navier-stokes-existence.json
@@ -1,8 +1,8 @@
 {
   "slug": "navier-stokes-existence",
   "title": "Navier-Stokes Existence and Smoothness",
-  "phase": "NEW",
-  "status": "blocked",
+  "phase": "SKIPPED",
+  "status": "skipped",
   "tier": "S",
   "path": "full",
   "problemStatement": {
@@ -27,9 +27,9 @@
     ],
     "nextAction": "Do not revisit until Mathlib has substantial PDE infrastructure",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
@@ -53,14 +53,20 @@
       "File now compiles clean with 0 sorries (previously had Mathlib API errors)"
     ],
     "mathlibGaps": [
-      "Sobolev spaces",
-      "PDEs"
+      "General PDE theory framework",
+      "Sobolev spaces W^{k,p}(Ω) for unbounded domains",
+      "Weak derivative formalism and weak solutions",
+      "Aubin-Lions compactness lemma",
+      "Rellich-Kondrachov compactness theorem",
+      "Galerkin approximation methods",
+      "Parabolic PDE regularity theory",
+      "Divergence-free function spaces"
     ],
     "nextSteps": [
-      "2D Navier-Stokes",
-      "Stokes Equations",
-      "Leray Solutions",
-      "Partial Regularity"
+      "Monitor Mathlib for PDE/Sobolev space developments (multi-year timeline)",
+      "Consider contributing to PDE infrastructure as separate Mathlib PR effort",
+      "2d-navier-stokes is the tractable prerequisite if infrastructure ever materializes",
+      "Do not attempt 3D problem - it is mathematically OPEN"
     ],
     "markdown": "# Knowledge Base: Navier-Stokes Existence and Smoothness\n\n## The Problem\n\nThe Navier-Stokes problem asks whether smooth, physically reasonable solutions exist for all time for the equations governing fluid flow in three dimensions.\n\n### Core Statement\n\n> In 3D, prove global existence and smoothness of Navier-Stokes solutions for all smooth initial data, or provide a counterexample showing finite-time blowup.\n\nThe equations describe how velocity and pressure of a fluid evolve:\n\n∂u/∂t + (u·∇)u = ν∆u - ∇p + f\n∇·u = 0\n\nwhere u is velocity, p is pressure, ν is viscosity, and f is external force.\n\n### Why It Matters\n\n1. **Fluid Dynamics**: Governs everything from weather to blood flow\n2. **Engineering**: Aircraft design, turbulence modeling, oceanography\n3. **Physics**: Fundamental understanding of fluids\n4. **Turbulence**: Connected to one of the last major unsolved physics problems\n\n## Historical Context\n\n| Year | Mathematician | Contribution |\n|------|--------------|--------------|\n| 1822 | Navier | Derived equations with molecular assumptions |\n| 1845 | Stokes | Rigorous continuum derivation |\n| 1934 | Leray | Weak solutions exist globally |\n| 1962 | Ladyzhenskaya | 2D global regularity |\n| 1977 | Scheffer | Partial regularity results |\n| 1982 | Caffarelli-Kohn-Nirenberg | Singular set has dimension ≤ 1 |\n\nThe 3D problem remains open despite 90+ years of effort since Leray.\n\n## The Key Difficulty: 3D vs 2D\n\n### 2D: Solved!\n\nIn 2D, global smooth solutions exist. Key facts:\n- Vorticity ω = curl(u) satisfies a nice transport equation\n- Enstrophy ∫|ω|² is bounded for all time\n- No vortex stretching term\n- Global regularity follows from energy estimates\n\n### 3D: Open\n\nIn 3D, the vortex stretching term (ω·∇)u can potentially cause:\n- Vorticity concentration\n- Energy cascade to small scales\n- Possible finite-time singularity\n\nThe Ladyzhenskaya inequality ||u||_4 ≤ C||u||_{H¹}^{3/4}||u||_2^{1/4} only works in 2D.\n\n## What We Could Build\n\n### In Mathlib Now\n\n| Component | Status | Notes |\n|-----------|--------|-------|\n| Vector calculus | ✅ | div, curl, grad |\n| Sobolev spaces | ⚠️ Limited | Basic definitions |\n| PDEs | ⚠️ Limited | Linear theory |\n| Lebesgue spaces | ✅ | Well-developed |\n| Functional analysis | ✅ | Strong foundation |\n\n### Tractable Partial Work\n\n1. **2D Navier-Stokes** (see 2d-navier-stokes project)\n   - Global existence IS known\n   - Would be a major formalization achievement\n   - ~3000-5000 lines estimated\n\n2. **Stokes Equations** (linear case)\n   - ∆u = ∇p, ∇·u = 0\n   - Linear theory, more tractable\n   - Foundation for full N-S\n\n3. **Leray Solutions** (weak solutions)\n   - Energy inequality\n   - Existence without uniqueness\n   - Fundamental theory\n\n4. **Partial Regularity**\n   - Caffarelli-Kohn-Nirenberg\n   - Singular set is small (dimension ≤ 1)\n\n## Formalization Challenges\n\n### Primary Blocker: Advanced PDE Infrastructure\n\nFormalizing even 2D N-S requires:\n\n1. **Sobolev Spaces** (~1000 lines)\n   - H^s spaces on domains\n   - Trace theorems\n   - Embeddings\n\n2. **Energy Methods** (~1500 lines)\n   - A priori estimates\n   - Weak formulations\n   - Galerkin approximations\n\n3. **Regularity Theory** (~2000 lines)\n   - Bootstrapping\n   - Schauder estimates\n   - Maximum principles\n\n### The 3D-Specific Challenges\n\n3D uniquely requires handling:\n- **Enstrophy growth**: ∫|∇u|² can grow in 3D\n- **Vortex stretching**: (ω·∇)u term\n- **Critical scaling**: Equations are borderline in 3D\n\n## Current State of Knowledge\n\n### What's Known\n\n- **Weak solutions exist** (Leray 1934)\n- **Strong solutions exist locally** (Fujita-Kato)\n- **Small data ⟹ global existence** (for ||u₀|| small)\n- **Partial regularity** (singularities rare)\n- **Unique for 2D** and for small 3D data\n\n### What's Open\n\n- Do 3D solutions stay smooth forever?\n- Do finite-time singularities exist?\n- If blowup occurs, what does it look like?\n\n## Related Work\n\n| File | Relevance |\n|------|-----------|\n| `2d-navier-stokes` | The tractable 2D case |\n\n## Key References\n\n- Leray, J. (1934). \"Sur le mouvement d'un liquide visqueux\"\n- Ladyzhenskaya, O. (1969). \"The Mathematical Theory of Viscous Incompressible Flow\"\n- Caffarelli, L., Kohn, R., Nirenberg, L. (1982). \"Partial regularity\"\n- Constantin, P., Foias, C. (1988). \"Navier-Stokes Equations\"\n- Fefferman, C. (2006). \"Existence and Smoothness of the Navier-Stokes Equation\" (Clay Problem Statement)\n\n## Scouting Log\n\n### Assessment: 2026-01-01\n\n**Current Status**: BLOCKED - Heavy PDE/analysis infrastructure required\n\n**Blocker Tracking**:\n| Infrastructure | In Mathlib | Last Checked |\n|----------------|------------|--------------|\n| Basic PDEs | Yes | 2026-01-01 |\n| Sobolev spaces | Limited | 2026-01-01 |\n| Navier-Stokes | No | 2026-01-01 |\n| Fluid mechanics | No | 2026-01-01 |\n\n**Path Forward**:\n1. Build Sobolev space infrastructure\n2. Formalize 2D Navier-Stokes (known result)\n3. Add partial regularity for 3D weak solutions\n4. State the Millennium Problem precisely\n\n**Related Active Work**: `2d-navier-stokes` attempts the tractable 2D case\n\n**Next Scout**: Check Mathlib PDE development; 2D case is the near-term goal\n"
   },


### PR DESCRIPTION
## Summary
- Created `proofs/Proofs/AbelRuffiniGaloisExtensions.lean` extending the Abel-Ruffini formalization
- Proved the complete classification: **S_n is solvable if and only if n <= 4**
- Connected group solvability to polynomial solvability by radicals

## Progress
- **12 theorems proved**, 1 sorry remaining (A_4 solvability)
- S_0, S_1: solvable via `isSolvable_of_subsingleton`
- S_2: solvable via `isSolvable_of_comm` (commutativity by `decide`)
- S_3: solvable via `solvable_of_ker_le_range` (short exact sequence 1 -> A_3 -> S_3 -> Z^x -> 1)
- S_4: solvable modulo A_4 sorry (same short exact sequence approach)
- `symmetric_solvable_iff`: complete iff classification
- Contrapositive of Galois theorem for radical solvability
- Galois group order = extension degree

## Findings
- `IsSolvable` is NOT `Decidable` in Mathlib - cannot use `native_decide`
- `derivedSeries` equality is NOT `Decidable` either
- `solvable_of_ker_le_range` is the key tool for proving solvability via short exact sequences
- `Equiv.Perm.sign : Perm alpha ->* Z^x` with `ker = alternatingGroup` enables the SES approach
- A_4 solvability needs Klein four-group V_4 construction (future work)

## Status
**Outcome**: progress (1 sorry remaining)
**Next Steps**: Prove A_4 solvable by constructing V_4 as explicit subgroup, or submit to Aristotle

Generated by researcher-1