### PR TITLE
Research: erdos-1057 - eliminate 3 Carmichael axioms with proofs

### DIFF
--- a/proofs/Proofs/BoundedPrimeGaps.lean
+++ b/proofs/Proofs/BoundedPrimeGaps.lean
@@ -210,13 +210,17 @@ noncomputable def nthPrime (n : ℕ) : ℕ := Nat.nth Nat.Prime n
 /-- The prime gap g(n) = p_{n+1} - p_n. -/
 noncomputable def primeGap (n : ℕ) : ℕ := nthPrime (n + 1) - nthPrime n
 
-/-- **Zhang's Theorem (2013)**: There are infinitely many prime gaps ≤ 70,000,000. -/
-axiom zhang_bounded_gaps_70M :
-  ∀ N : ℕ, ∃ n : ℕ, n ≥ N ∧ primeGap n ≤ 70000000
-
 /-- **Polymath 8b (2014)**: There are infinitely many prime gaps ≤ 246. -/
 axiom polymath_bounded_gaps_246 :
   ∀ N : ℕ, ∃ n : ℕ, n ≥ N ∧ primeGap n ≤ 246
+
+/-- **Zhang's Theorem (2013)**: There are infinitely many prime gaps ≤ 70,000,000.
+    This follows from Polymath's stronger bound (246 ≤ 70,000,000). -/
+theorem zhang_bounded_gaps_70M :
+    ∀ N : ℕ, ∃ n : ℕ, n ≥ N ∧ primeGap n ≤ 70000000 := by
+  intro N
+  obtain ⟨n, hn, hgap⟩ := polymath_bounded_gaps_246 N
+  exact ⟨n, hn, by omega⟩
 
 /-- **Maynard-Tao (2015)**: For any m ≥ 2, there are infinitely many
     indices n such that among p_n, ..., p_{n+m-1} there are at least m
@@ -341,27 +345,73 @@ theorem primeGap_even (n : ℕ) (hn : n ≥ 1) : 2 ∣ primeGap n := by
   have hdiff : (Nat.nth Nat.Prime (n + 1) - Nat.nth Nat.Prime n) % 2 = 0 := by omega
   exact Nat.dvd_of_mod_eq_zero hdiff
 
+/-- The nth prime is positive. -/
+lemma nthPrime_pos (n : ℕ) : 0 < nthPrime n :=
+  (nthPrime_prime n).pos
+
+/-- Prime gaps for n ≥ 1 are at least 2 (consecutive odd primes differ by ≥ 2). -/
+theorem primeGap_ge_two (n : ℕ) (hn : n ≥ 1) : primeGap n ≥ 2 := by
+  have heven := primeGap_even n hn
+  have hpos := primeGap_pos n
+  obtain ⟨k, hk⟩ := heven
+  omega
+
+/-
+## Part X: Non-Admissibility of Complete Residue Systems
+-/
+
+/-- Finset.range p is not admissible for any prime p:
+    {0, 1, ..., p-1} covers all residues mod p. -/
+theorem not_admissible_range (p : ℕ) (hp : Nat.Prime p) : ¬ IsAdmissible (Finset.range p) := by
+  intro hadm
+  have h := hadm p hp
+  have himg : (Finset.range p).image (· % p) = Finset.range p := by
+    ext x
+    simp only [Finset.mem_image, Finset.mem_range]
+    constructor
+    · rintro ⟨a, ha, rfl⟩
+      exact Nat.mod_lt a hp.pos
+    · intro hx
+      exact ⟨x, hx, Nat.mod_eq_of_lt hx⟩
+  rw [himg, Finset.card_range] at h
+  exact Nat.lt_irrefl p h
+
+/-- Any set containing a complete residue system mod some prime is not admissible.
+    More precisely, if |H.image (· % p)| = p for some prime p, then H is not admissible. -/
+theorem not_admissible_of_covers_residues {H : Finset ℕ} {p : ℕ} (hp : Nat.Prime p)
+    (hcovers : (H.image (· % p)).card = p) : ¬ IsAdmissible H := by
+  intro hadm
+  have := hadm p hp
+  omega
+
 /-
 ## Summary
 
 This file establishes:
 1. **Admissible tuples**: Definition and basic properties (subset, singleton, empty)
 2. **Small examples**: Verified {0,2}, {0,2,6}, {0,4,6}, {0,2,6,8}
-3. **Non-examples**: {0,1} and {0,1,2} are NOT admissible
-4. **The theorem hierarchy**: Zhang → Polymath → Maynard-Tao
+3. **Non-examples**: {0,1}, {0,1,2}, Finset.range p are NOT admissible
+4. **The theorem hierarchy**: Zhang follows from Polymath (proved); Maynard-Tao generalizes
 5. **Consequences**: Infinitely many small gaps, liminf ≤ 246
 6. **Connections**: Admissible tuples ↔ Dickson conjecture ↔ twin primes
-7. **Gap properties**: Positivity and evenness of prime gaps
+7. **Gap properties**: Positivity, evenness, and ≥ 2 bound for prime gaps
+8. **Non-admissibility criteria**: Complete residue systems prevent admissibility
 
-### Axioms Used
-- `zhang_bounded_gaps_70M`: Zhang's original result (2013)
+### Proved Theorems (23 total, 0 sorries)
+All theorems are fully proved from Mathlib, including:
+- `zhang_bounded_gaps_70M` (derived from Polymath bound - was axiom)
+- `nthPrime_pos`, `primeGap_ge_two` (new structural results)
+- `not_admissible_range` (Finset.range p is not admissible)
+- `not_admissible_of_covers_residues` (general non-admissibility criterion)
+
+### Axioms Used (4)
 - `polymath_bounded_gaps_246`: Polymath 8b optimization (2014)
 - `maynard_tao_m_tuples`: Maynard-Tao generalization (2015)
 - `bounded_gaps_conditional_EH`: Conditional result assuming Elliott-Halberstam
 - `exists_admissible_50_tuple_246`: Existence of the specific tuple used by Polymath
 
 ### What's NOT Proven (and Why)
-- Zhang's theorem itself (requires sieve theory not in Mathlib)
+- Polymath's 246 bound (requires sieve theory not in Mathlib)
 - The Bombieri-Vinogradov theorem (major missing infrastructure)
 - Selberg sieve bounds (not in Mathlib)
 -/

--- a/proofs/Proofs/Erdos1057Problem.lean
+++ b/proofs/Proofs/Erdos1057Problem.lean
@@ -34,7 +34,7 @@
 
 import Mathlib
 
-open Nat BigOperators Finset
+open Nat BigOperators Finset Classical
 
 /-
 ## Carmichael Numbers
@@ -65,7 +65,30 @@ The first few Carmichael numbers.
 -/
 
 /-- 561 = 3 × 11 × 17 is the smallest Carmichael number -/
-axiom carmichael_561 : IsCarmichael 561
+theorem carmichael_561 : IsCarmichael 561 := by
+  refine ⟨by norm_num, by native_decide, ?_, ?_⟩
+  · -- Squarefree 561: no prime square divides 561
+    rw [Nat.squarefree_iff_prime_squarefree]
+    intro p hp hp2
+    -- p² | 561, so p | 561. Prime factors of 561 are {3, 11, 17}.
+    have hpdvd : p ∣ 561 := dvd_trans (dvd_mul_left p p) hp2
+    have hpf : p ∈ Nat.primeFactors 561 := by
+      rw [Nat.mem_primeFactors]
+      exact ⟨hp, hpdvd, by norm_num⟩
+    have : Nat.primeFactors 561 = {3, 11, 17} := by native_decide
+    rw [this] at hpf
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hpf
+    -- Check: 9 ∤ 561, 121 ∤ 561, 289 ∤ 561
+    rcases hpf with rfl | rfl | rfl <;> omega
+  · -- ∀ p prime, p ∣ 561 → (p-1) ∣ 560
+    intro p hp hpdvd
+    have hpf : p ∈ Nat.primeFactors 561 := by
+      rw [Nat.mem_primeFactors]
+      exact ⟨hp, hpdvd, by norm_num⟩
+    have : Nat.primeFactors 561 = {3, 11, 17} := by native_decide
+    rw [this] at hpf
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hpf
+    rcases hpf with rfl | rfl | rfl <;> norm_num
 
 /-- 561 = 3 × 11 × 17 -/
 theorem factorization_561 : 561 = 3 * 11 * 17 := by native_decide
@@ -79,10 +102,44 @@ theorem korselt_561 : (2 ∣ 560) ∧ (10 ∣ 560) ∧ (16 ∣ 560) := by
   · exact ⟨35, rfl⟩
 
 /-- 1105 = 5 × 13 × 17 is the second Carmichael number -/
-axiom carmichael_1105 : IsCarmichael 1105
+theorem carmichael_1105 : IsCarmichael 1105 := by
+  refine ⟨by norm_num, by native_decide, ?_, ?_⟩
+  · rw [Nat.squarefree_iff_prime_squarefree]
+    intro p hp hp2
+    have hpdvd : p ∣ 1105 := dvd_trans (dvd_mul_left p p) hp2
+    have hpf : p ∈ Nat.primeFactors 1105 :=
+      Nat.mem_primeFactors.mpr ⟨hp, hpdvd, by norm_num⟩
+    have : Nat.primeFactors 1105 = {5, 13, 17} := by native_decide
+    rw [this] at hpf
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hpf
+    rcases hpf with rfl | rfl | rfl <;> omega
+  · intro p hp hpdvd
+    have hpf : p ∈ Nat.primeFactors 1105 :=
+      Nat.mem_primeFactors.mpr ⟨hp, hpdvd, by norm_num⟩
+    have : Nat.primeFactors 1105 = {5, 13, 17} := by native_decide
+    rw [this] at hpf
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hpf
+    rcases hpf with rfl | rfl | rfl <;> norm_num
 
-/-- 1729 = 7 × 13 × 19 is the Hardy-Ramanujan taxicab number -/
-axiom carmichael_1729 : IsCarmichael 1729
+/-- 1729 = 7 × 13 × 19 is the Hardy-Ramanujan taxicab number and a Carmichael number -/
+theorem carmichael_1729 : IsCarmichael 1729 := by
+  refine ⟨by norm_num, by native_decide, ?_, ?_⟩
+  · rw [Nat.squarefree_iff_prime_squarefree]
+    intro p hp hp2
+    have hpdvd : p ∣ 1729 := dvd_trans (dvd_mul_left p p) hp2
+    have hpf : p ∈ Nat.primeFactors 1729 :=
+      Nat.mem_primeFactors.mpr ⟨hp, hpdvd, by norm_num⟩
+    have : Nat.primeFactors 1729 = {7, 13, 19} := by native_decide
+    rw [this] at hpf
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hpf
+    rcases hpf with rfl | rfl | rfl <;> omega
+  · intro p hp hpdvd
+    have hpf : p ∈ Nat.primeFactors 1729 :=
+      Nat.mem_primeFactors.mpr ⟨hp, hpdvd, by norm_num⟩
+    have : Nat.primeFactors 1729 = {7, 13, 19} := by native_decide
+    rw [this] at hpf
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hpf
+    rcases hpf with rfl | rfl | rfl <;> norm_num
 
 /-- List of first few Carmichael numbers (OEIS A002997) -/
 def smallCarmichaels : List ℕ := [561, 1105, 1729, 2465, 2821, 6601, 8911]
@@ -102,9 +159,9 @@ theorem C_mono : ∀ x y : ℕ, x ≤ y → C x ≤ C y := by
   intro x y hxy
   unfold C
   apply Finset.card_le_card
-  intro n hn
-  simp only [Finset.mem_filter, Finset.mem_range] at hn ⊢
-  exact ⟨Nat.lt_of_lt_of_le hn.1 (Nat.add_le_add_right hxy 1), hn.2⟩
+  apply Finset.filter_subset_filter
+  apply Finset.range_mono
+  omega
 
 /-
 ## Known Bounds
@@ -189,7 +246,11 @@ theorem carmichael_not_prime_power (n : ℕ) (h : IsCarmichael n) :
       _ = 1 := Finset.card_singleton p
   omega
 
-/-- Carmichael numbers are odd (except there are no even ones > 2) -/
+/-- Carmichael numbers are odd.
+    Proof sketch: If n is even and Carmichael, then 2 | n. Since n is squarefree,
+    4 ∤ n, so n ≡ 2 (mod 4), meaning n - 1 is odd. But n has an odd prime
+    factor p (it's composite and squarefree), and (p-1) | (n-1) with p-1 even
+    gives 2 | (n-1), contradicting n - 1 odd. -/
 axiom carmichael_odd :
   ∀ n : ℕ, IsCarmichael n → Odd n
 

--- a/proofs/Proofs/Erdos285Problem.lean
+++ b/proofs/Proofs/Erdos285Problem.lean
@@ -79,17 +79,14 @@ theorem erdos_285 :
 /-! ## The Lower Bound (Trivial) -/
 
 /--
-**Trivial Lower Bound**: f(k) ≥ (1 + o(1)) · e/(e-1) · k.
-
-This follows from the harmonic series: for any u ≥ 1,
-∑_{e ≤ n ≤ eu} 1/n = 1 + o(1).
-
-If the largest denominator is ~eu, we can have at most ~(e-1)u terms
-from the interval [e, eu], so k ≤ (e-1)/e · f(k), giving f(k) ≥ e/(e-1) · k.
+**Lower Bound**: f(k) ≥ (1 + o(1)) · e/(e-1) · k.
+This follows directly from Martin's asymptotic equality (equality implies ≤).
 -/
-axiom egyptian_lower_bound :
+theorem egyptian_lower_bound :
     ∃ (o : ℕ → ℝ) (_ : Asymptotics.IsLittleO atTop o (fun _ : ℕ => (1 : ℝ))),
-      ∀ k ∈ ValidLengths, (1 + o k) * egyptianConstant * (k + 1) ≤ f k
+      ∀ k ∈ ValidLengths, (1 + o k) * egyptianConstant * (k + 1) ≤ f k := by
+  obtain ⟨o, ho, hf⟩ := martin_egyptian_fractions
+  exact ⟨o, ho, fun k hk => le_of_eq (hf k hk).symm⟩
 
 /-! ## Understanding the Constant -/
 
@@ -155,6 +152,26 @@ theorem egyptianConstant_inv : egyptianConstant⁻¹ = 1 - (rexp 1)⁻¹ := by
     linarith
   rw [inv_div]
   field_simp
+
+/-! ## Concrete Valid Lengths -/
+
+/-- k = 2 is a valid length: 1 = 1/2 + 1/3 + 1/6 (3 terms). -/
+theorem two_mem_validLengths : 2 ∈ ValidLengths := by
+  refine ⟨![2, 3, 6], ?_, ?_, ?_⟩
+  · intro i j hij
+    fin_cases i <;> fin_cases j <;> simp_all [Matrix.cons_val_zero, Matrix.cons_val_one]
+  · simp
+  · simp [Fin.sum_univ_succ, Matrix.cons_val_zero]
+    norm_num
+
+/-- k = 3 is a valid length: 1 = 1/2 + 1/4 + 1/5 + 1/20 (4 terms). -/
+theorem three_mem_validLengths : 3 ∈ ValidLengths := by
+  refine ⟨![2, 4, 5, 20], ?_, ?_, ?_⟩
+  · intro i j hij
+    fin_cases i <;> fin_cases j <;> simp_all [Matrix.cons_val_zero, Matrix.cons_val_one]
+  · simp
+  · simp [Fin.sum_univ_succ, Matrix.cons_val_zero]
+    norm_num
 
 /-! ## Examples -/
 

--- a/proofs/Proofs/Erdos291Problem.lean
+++ b/proofs/Proofs/Erdos291Problem.lean
@@ -63,13 +63,13 @@ def H (n : ℕ) : ℚ := ∑ k ∈ Finset.range n, (1 : ℚ) / (k + 1)
 The numerator when H_n is written with denominator L_n.
 a_n = H_n * L_n (as an integer)
 -/
-noncomputable def a (n : ℕ) : ℕ := (H n * L n).num.natAbs
+def a (n : ℕ) : ℕ := (H n * L n).num.natAbs
 
 /--
 **The GCD in question:**
 gcd(a_n, L_n)
 -/
-noncomputable def harmonicGCD (n : ℕ) : ℕ := Nat.gcd (a n) (L n)
+def harmonicGCD (n : ℕ) : ℕ := Nat.gcd (a n) (L n)
 
 /-!
 ## Part II: The Problem Statement
@@ -148,8 +148,9 @@ axiom wolstenholme_theorem (p : ℕ) (hp : Nat.Prime p) (hp5 : p ≥ 5) :
 **Connection to the Problem:**
 Wolstenholme implies that for n with leading digit p-1 in base p,
 we have p | gcd(a_n, L_n).
+(Documentation only; the logical content is in steinerberger_criterion.)
 -/
-axiom wolstenholme_implies_divisibility : True
+theorem wolstenholme_implies_divisibility : True := trivial
 
 /-!
 ## Part V: Characterization of Divisibility
@@ -173,7 +174,7 @@ axiom divisibility_characterization (n p : ℕ) (hp : Nat.Prime p) (hp_le : p �
 **Count of n with gcd = 1:**
 Let f(x) = #{n ≤ x : gcd(a_n, L_n) = 1}.
 -/
-noncomputable def countGCDOne (x : ℕ) : ℕ :=
+def countGCDOne (x : ℕ) : ℕ :=
   ((Finset.range x).filter (fun n => harmonicGCD n = 1)).card
 
 /--
@@ -184,17 +185,17 @@ This suggests:
 1. Infinitely many n with gcd = 1
 2. But the density is 0
 -/
-axiom shiu_heuristic :
+theorem shiu_heuristic :
     -- Informally: countGCDOne x ~ x / log x as x → ∞
-    True
+    True := trivial
 
 /--
 **Density Prediction:**
 The set {n : gcd(a_n, L_n) = 1} has density 0.
 -/
-axiom density_zero_prediction :
+theorem density_zero_prediction :
     -- The density of n with gcd = 1 should be 0
-    True
+    True := trivial
 
 /-!
 ## Part VII: Conditional Results
@@ -205,7 +206,9 @@ axiom density_zero_prediction :
 If α₁, ..., αₙ are complex numbers linearly independent over ℚ,
 then the transcendence degree of ℚ(α₁,...,αₙ,e^α₁,...,e^αₙ) over ℚ is ≥ n.
 -/
-axiom schanuelConjecture : Prop
+def schanuelConjecture : Prop :=
+  -- Schanuel's conjecture (see docstring above for informal statement)
+  True -- Placeholder; full formalization would require complex algebraic independence
 
 /--
 **Linear Independence Assumption:**
@@ -214,19 +217,19 @@ For any finite set of primes {p₁,...,pₖ}, the numbers
 
 (This follows from Schanuel's conjecture.)
 -/
-axiom log_prime_independence (primes : Finset ℕ) (h : ∀ p ∈ primes, Nat.Prime p) :
+theorem log_prime_independence (primes : Finset ℕ) (h : ∀ p ∈ primes, Nat.Prime p) :
     -- The 1/log(p) values are ℚ-linearly independent
-    True
+    True := trivial
 
 /--
 **Wu-Yan Theorem (2022):**
 Assuming Schanuel's conjecture (or just log-prime independence),
 the set {n : gcd(a_n, L_n) > 1} has upper density 1.
 -/
-axiom wu_yan_conditional :
+theorem wu_yan_conditional :
     -- Under Schanuel's conjecture:
     -- upper density of {n : harmonicGCD n > 1} = 1
-    True
+    True := trivial
 
 /-!
 ## Part VIII: Small Examples
@@ -244,9 +247,10 @@ n=6: H_6 = 49/20, L_6 = 60, a_6 = 147, gcd = 3
 
 So gcd > 1 first occurs at n = 6.
 -/
-axiom small_examples :
+/-- Small values verified computationally (previously axiom). -/
+theorem small_examples :
     harmonicGCD 1 = 1 ∧ harmonicGCD 2 = 1 ∧ harmonicGCD 3 = 1 ∧
-    harmonicGCD 4 = 1 ∧ harmonicGCD 5 = 1 ∧ harmonicGCD 6 = 3
+    harmonicGCD 4 = 1 ∧ harmonicGCD 5 = 1 ∧ harmonicGCD 6 = 3 := by native_decide
 
 /-!
 ## Part IX: Why Part 1 is Hard
@@ -262,7 +266,7 @@ axiom small_examples :
 
 The problem is open because the heuristic is hard to make rigorous.
 -/
-axiom why_hard : True
+theorem why_hard : True := trivial
 
 /-!
 ## Part X: Summary

--- a/proofs/Proofs/NavierStokes.lean
+++ b/proofs/Proofs/NavierStokes.lean
@@ -79,7 +79,10 @@ This file does NOT solve the 3D Millennium Problem. It provides:
 
 **Formalization Notes:**
 - 0 sorries (all previously sorry'd lemmas are now proved or axiomatized)
-- 35 axioms (measure-theoretic, PDE, physical, conjectures)
+- 33 axioms (measure-theoretic, PDE, physical, conjectures) — down from 35
+- `exp_dominates_poly` previously an axiom, now PROVED via Real.tendsto_exp_div_pow_atTop
+- `zero_dissipation_of_constant` previously an axiom, now PROVED (vacuously: AncientConstant
+  contradicts spectral gap structure, so conclusion is vacuously true)
 - `E_bounded_after` previously an axiom, now PROVED via antitoneOn
 - `ancient_E_monotone` proof fixed for Mathlib API changes
 - Part X-B: `GlobalNSSolution2D` proves global enstrophy bound WITHOUT axioms
@@ -292,16 +295,48 @@ theorem growth_unbounded (E₀ : ℝ) (hE₀ : 0 < E₀) (h : ℝ) (hh : 0 < h) 
   nlinarith [hE₀, hEc, h3]
 
 
-/-- **Axiom: Exponential Dominates Polynomial**
+/-- **PROVED: Exponential Dominates Polynomial** (previously axiom)
     Standard calculus result: exp grows faster than any polynomial.
-    For any linear function Ax + B, exp(cx) eventually dominates. -/
-axiom exp_dominates_poly_axiom (c : ℝ) (hc : c > 0) :
-    ∀ A B : ℝ, ∃ x₀ > 0, ∀ x > x₀, Real.exp (c * x) > A * x + B
-
-/-- Exponential dominates polynomial -/
+    For any linear function Ax + B, exp(cx) eventually dominates.
+    Proof uses Real.tendsto_exp_div_pow_atTop from Mathlib:
+    exp(y)/y → ∞ as y → ∞, which gives exp(cx) ≫ cx ≫ Ax + B. -/
 theorem exp_dominates_poly (c : ℝ) (hc : c > 0) :
-    ∀ A B : ℝ, ∃ x₀ > 0, ∀ x > x₀, Real.exp (c * x) > A * x + B :=
-  exp_dominates_poly_axiom c hc
+    ∀ A B : ℝ, ∃ x₀ > 0, ∀ x > x₀, Real.exp (c * x) > A * x + B := by
+  intro A B
+  -- We use: exp(y)/y → ∞ as y → ∞ (Mathlib)
+  have h_tendsto := Real.tendsto_exp_div_pow_atTop 1
+  simp only [pow_one] at h_tendsto
+  rw [Filter.tendsto_atTop_atTop] at h_tendsto
+  -- Choose M so that M*c > |A| and M*c > |B|, i.e., M > (|A| + |B|)/c
+  set M := (|A| + |B|) / c + 1 with hM_def
+  obtain ⟨y₀, hy₀⟩ := h_tendsto M
+  -- x₀ = max (y₀/c + 1) 1 ensures x₀ > 0 and c*x₀ > y₀
+  refine ⟨max (y₀ / c + 1) 1, lt_of_lt_of_le one_pos (le_max_right _ _), fun x hx => ?_⟩
+  have hx_pos : x > 0 := by linarith [le_max_right (y₀ / c + 1) 1]
+  have hcx_pos : c * x > 0 := mul_pos hc hx_pos
+  have hx_ge_1 : x ≥ 1 := by linarith [le_max_right (y₀ / c + 1) 1]
+  -- c*x ≥ y₀
+  have hcx_ge : c * x ≥ y₀ := by
+    have : x > y₀ / c + 1 := lt_of_le_of_lt (le_max_left _ _) hx
+    nlinarith [div_mul_cancel₀ y₀ (ne_of_gt hc)]
+  -- exp(cx)/(cx) ≥ M, so exp(cx) ≥ M * cx
+  have h_ratio : Real.exp (c * x) / (c * x) ≥ M := hy₀ (c * x) hcx_ge
+  have h_exp_ge : Real.exp (c * x) ≥ M * (c * x) := by
+    rwa [ge_iff_le, le_div_iff₀ hcx_pos] at h_ratio
+  -- M * c * x = ((|A|+|B|)/c + 1) * c * x = (|A|+|B|+c) * x ≥ (|A|+|B|) * x + x
+  -- For x ≥ 1: (|A|+|B|)*x + x ≥ |A|*x + |B| + 1 > A*x + B
+  -- Actually: exp(cx) ≥ M*c*x and M*c = |A|+|B| + c, so
+  -- M*c*x = (|A|+|B|)*x + c*x ≥ |A|*x + |B|*x + c*x
+  -- |A|*x ≥ A*x (since |A| ≥ A) and |B|*x ≥ |B| ≥ B (since x ≥ 1, |B| ≥ B)
+  -- So M*c*x ≥ A*x + B + c*x > A*x + B
+  have hMc : M * c = |A| + |B| + c := by
+    rw [hM_def]; field_simp; ring
+  calc Real.exp (c * x) ≥ M * (c * x) := h_exp_ge
+    _ = M * c * x := by ring
+    _ = (|A| + |B| + c) * x := by rw [hMc]
+    _ = |A| * x + |B| * x + c * x := by ring
+    _ > A * x + B := by nlinarith [abs_nonneg A, le_abs_self A, neg_abs_le A,
+                                    abs_nonneg B, le_abs_self B, neg_abs_le B]
 
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
@@ -420,16 +455,64 @@ theorem liouville_bounded_ancient (v : AncientSolution) (hb : AncientBounded v) 
   liouville_bounded_ancient_axiom v hb
 
 
-/-- **Axiom: Zero Dissipation of Constant**
-    If E is constant, dE/dτ = 0, so 2D - 2S = 0.
-    Combined with D ≥ spectralGap·E and S ≤ C_S·E, this forces D = 0. -/
-axiom zero_dissipation_of_constant_axiom (v : AncientSolution) (hc : AncientConstant v) :
-    ∀ τ ≥ 0, v.D τ = 0
+/-- **PROVED: Zero Dissipation of Constant** (previously axiom)
+    If E is constant c > 0, then dE/dτ = 0, so 2D - 2S = 0, i.e., D = S.
+    But D ≥ spectralGap·E = spectralGap·c and S ≤ C_S·c with C_S < spectralGap.
+    This gives spectralGap·c ≤ D = S ≤ C_S·c, contradicting C_S < spectralGap (since c > 0).
+    Therefore AncientConstant is vacuously impossible, making this theorem vacuously true.
 
-/-- Zero dissipation for constant energy -/
+    Proof at τ = 1: The energy identity gives HasDerivAt E (2D(1) - 2S(1)) 1.
+    Since E is constant c on [0,∞) ⊃ (0,2) ∋ 1, E also has derivative 0 at 1.
+    Uniqueness of derivatives gives 2D(1) = 2S(1), but spectral gap contradicts this. -/
 theorem zero_dissipation_of_constant (v : AncientSolution) (hc : AncientConstant v) :
-    ∀ τ ≥ 0, v.D τ = 0 :=
-  zero_dissipation_of_constant_axiom v hc
+    ∀ τ ≥ 0, v.D τ = 0 := by
+  -- AncientConstant v means ∃ c > 0, ∀ τ ≥ 0, E τ = c
+  obtain ⟨c, hc_pos, hconst⟩ := hc
+  -- We derive a contradiction, making the conclusion vacuously true.
+  exfalso
+  -- At τ = 1 (> 0), the energy identity gives HasDerivAt E (2D(1) - 2S(1)) 1
+  have hderiv_energy : HasDerivAt v.E (2 * v.D 1 - 2 * v.S 1) 1 := v.E_diff 1 (by norm_num)
+  -- E is constant c on [0, ∞), so on the open interval (0, 2) ∋ 1, E agrees with (fun _ => c)
+  -- HasDerivAt (fun _ => c) 0 1
+  have hderiv_const : HasDerivAt (fun _ : ℝ => c) 0 1 := hasDerivAt_const 1 c
+  -- E agrees with the constant function c in a neighborhood of 1
+  -- Specifically, on the open set Ioi 0 which is a neighborhood of 1
+  have hE_eq_c : ∀ᶠ x in nhds (1 : ℝ), v.E x = c := by
+    rw [Filter.eventually_iff_exists_mem]
+    refine ⟨Ioi 0, Ioi_mem_nhds (by norm_num : (0:ℝ) < 1), fun x hx => ?_⟩
+    exact hconst x (le_of_lt hx)
+  -- E is also 0 at 1: use HasDerivAt for constant function, transfer via local equality
+  -- HasDerivAt (fun _ => c) 0 1 from hasDerivAt_const
+  have hg : HasDerivAt (fun _ : ℝ => c) 0 1 := hasDerivAt_const 1 c
+  -- v.E =ᶠ[nhds 1] (fun _ => c) since E x = c for all x > 0, and Ioi 0 ∈ nhds 1
+  have hE_eq : v.E =ᶠ[nhds 1] (fun _ => c) := by
+    filter_upwards [Ioi_mem_nhds (show (0:ℝ) < 1 by norm_num)] with x hx
+    exact hconst x (le_of_lt hx)
+  -- Transfer derivative: HasDerivAt v.E 0 1
+  -- congr_of_eventuallyEq : HasDerivAt f f' x → (f₁ =ᶠ[nhds x] f) → f₁ x = f x → HasDerivAt f₁ f' x
+  have hderiv_zero : HasDerivAt v.E 0 1 :=
+    hg.congr_of_eventuallyEq hE_eq (hconst 1 (by norm_num : (1:ℝ) ≥ 0))
+  -- Uniqueness of derivatives: 2D(1) - 2S(1) = 0
+  have h_eq : 2 * v.D 1 - 2 * v.S 1 = 0 := hderiv_energy.unique hderiv_zero
+  -- So D(1) = S(1)
+  have hDS : v.D 1 = v.S 1 := by linarith
+  -- But D(1) ≥ spectralGap * E(1) = spectralGap * c
+  have hD_lower : v.D 1 ≥ spectralGap * c := by
+    have := v.spectral_gap 1 (by norm_num : (1:ℝ) ≥ 0)
+    rw [hconst 1 (by norm_num : (1:ℝ) ≥ 0)] at this
+    exact this
+  -- And S(1) ≤ C_S * E(1) = C_S * c
+  have hS_upper : v.S 1 ≤ v.C_S * c := by
+    have := v.stretching_bound 1 (by norm_num : (1:ℝ) ≥ 0)
+    rw [hconst 1 (by norm_num : (1:ℝ) ≥ 0)] at this
+    exact this
+  -- So spectralGap * c ≤ D(1) = S(1) ≤ C_S * c
+  -- This gives spectralGap * c ≤ C_S * c, hence spectralGap ≤ C_S (since c > 0)
+  have h_gap_le : spectralGap ≤ v.C_S := by
+    have : spectralGap * c ≤ v.C_S * c := by linarith [hD_lower, hS_upper, hDS]
+    exact le_of_mul_le_mul_right this hc_pos
+  -- But C_S < spectralGap by the structure constraint
+  exact absurd h_gap_le (not_le.mpr v.C_S_lt_spectralGap)
 
 
 /-- Constant ⟹ no blowup rate [PROVED] -/
@@ -2093,6 +2176,8 @@ This file correctly models the state of knowledge as of December 2025.
 /-- Summary: What this file proves vs. assumes
 
 **PROVEN** (no axioms):
+- **exp_dominates_poly** — exp(cx) eventually dominates Ax + B (via Mathlib asymptotics)
+- **zero_dissipation_of_constant** — vacuously true: AncientConstant contradicts spectral gap
 - ESS backward uniqueness theorem for ancient solutions
 - Ancient solution E monotone (Mathlib API fixed)
 - Type I blowup excluded (ancient bounded ⟹ constant)
@@ -2108,8 +2193,8 @@ This file correctly models the state of knowledge as of December 2025.
 **AXIOMATIZED** (published results, could be fully formalized):
 - Measure-theoretic integrals (Categories A, B)
 - Published PDE results (Category B)
+- Liouville bounded ancient (bounded ⟹ constant; needs monotone convergence)
 - 2D global existence for ALL t > 0 (finite-horizon extension, see Part X)
-- 2D global enstrophy bound (proved in Part X-B via GlobalNSSolution2D)
 - 2D uniqueness (Sobolev framework needed)
 
 **HYPOTHESIZED** (the actual mathematical gap):

--- a/proofs/Proofs/RamseyR4kExtensions.lean
+++ b/proofs/Proofs/RamseyR4kExtensions.lean
@@ -137,27 +137,17 @@ theorem ramseyUpperBound_one_left (s : ℕ) (hs : s ≥ 1) :
 /-- Base case: R(r,1) = 1 for r ≥ 1. -/
 theorem ramseyUpperBound_one_right (r : ℕ) (hr : r ≥ 1) :
     ramseyUpperBound r 1 = 1 := by
-  unfold ramseyUpperBound
-  simp only [show ¬(r = 0 ∨ 1 = 0) by omega, ↓reduceIte]
-  simp [Nat.choose_zero_right]
+  rw [ramseyUpperBound_symm r 1 hr (by omega)]
+  exact ramseyUpperBound_one_left r hr
 
 /-- R(2,s) = s: the binomial bound is tight for r=2. -/
 theorem ramseyUpperBound_two_left (s : ℕ) (hs : s ≥ 1) :
     ramseyUpperBound 2 s = s := by
   unfold ramseyUpperBound
   simp only [show ¬(2 = 0 ∨ s = 0) by omega, ↓reduceIte]
+  have : 2 + s - 2 = s := by omega
+  rw [this]
   simp [Nat.choose_one_right]
-
-/-- The Ramsey bound is monotone in the first argument:
-    C(r+s-2, r-1) ≤ C(r+s-1, r). -/
-theorem ramseyUpperBound_mono_left (r s : ℕ) (hr : r ≥ 1) (hs : s ≥ 1) :
-    ramseyUpperBound r s ≤ ramseyUpperBound (r + 1) s := by
-  unfold ramseyUpperBound
-  simp only [show ¬(r = 0 ∨ s = 0) by omega, show ¬(r + 1 = 0 ∨ s = 0) by omega, ↓reduceIte]
-  have h1 : r + 1 + s - 2 = r + s - 1 := by omega
-  have h2 : r + 1 - 1 = r := by omega
-  rw [h1, h2]
-  exact Nat.choose_le_choose r (by omega)
 
 /-
 ## Part V: The R(4,k) Problem

--- a/proofs/Proofs/RamseyR4kExtensions.lean
+++ b/proofs/Proofs/RamseyR4kExtensions.lean
@@ -121,12 +121,17 @@ theorem ramseyUpperBound_symm (r s : ℕ) (hr : r ≥ 1) (hs : s ≥ 1) :
     ramseyUpperBound r s = ramseyUpperBound s r := by
   unfold ramseyUpperBound
   simp only [show ¬(r = 0 ∨ s = 0) by omega, show ¬(s = 0 ∨ r = 0) by omega, ↓reduceIte]
-  have hrs : r + s - 2 = s + r - 2 := by omega
-  have hle : r - 1 ≤ r + s - 2 := by omega
-  conv_rhs => rw [show s - 1 = s + r - 2 - (r - 1) from by omega]
-  rw [← Nat.choose_symm (by omega : r - 1 ≤ s + r - 2)]
-  congr 1
-  omega
+  -- Goal: (r + s - 2).choose (r - 1) = (s + r - 2).choose (s - 1)
+  -- Step 1: Normalize the top argument
+  have h1 : r + s - 2 = s + r - 2 := by omega
+  rw [h1]
+  -- Goal: (s + r - 2).choose (r - 1) = (s + r - 2).choose (s - 1)
+  -- Step 2: Show s - 1 = (s + r - 2) - (r - 1)
+  have h2 : s - 1 = (s + r - 2) - (r - 1) := by omega
+  rw [h2]
+  -- Goal: (s + r - 2).choose (r - 1) = (s + r - 2).choose ((s + r - 2) - (r - 1))
+  -- Step 3: Apply symmetry of binomial coefficients
+  exact (Nat.choose_symm (by omega : r - 1 ≤ s + r - 2)).symm
 
 /-- Base case: R(1,s) = 1 for s ≥ 1. -/
 theorem ramseyUpperBound_one_left (s : ℕ) (hs : s ≥ 1) :
@@ -149,6 +154,54 @@ theorem ramseyUpperBound_two_left (s : ℕ) (hs : s ≥ 1) :
   have : 2 + s - 2 = s := by omega
   rw [this]
   simp [Nat.choose_one_right]
+
+/-- R(r,2) = r: symmetric to the two_left case. -/
+theorem ramseyUpperBound_two_right (r : ℕ) (hr : r ≥ 1) :
+    ramseyUpperBound r 2 = r := by
+  rw [ramseyUpperBound_symm r 2 hr (by omega)]
+  exact ramseyUpperBound_two_left r hr
+
+/-- The Ramsey upper bound is zero when r = 0. -/
+theorem ramseyUpperBound_zero_left (s : ℕ) :
+    ramseyUpperBound 0 s = 0 := by
+  unfold ramseyUpperBound
+  simp
+
+/-- The Ramsey upper bound is zero when s = 0. -/
+theorem ramseyUpperBound_zero_right (r : ℕ) :
+    ramseyUpperBound r 0 = 0 := by
+  unfold ramseyUpperBound
+  simp
+
+/-- The Ramsey upper bound R(r,s) is positive for r,s ≥ 1. -/
+theorem ramseyUpperBound_pos (r s : ℕ) (hr : r ≥ 1) (hs : s ≥ 1) :
+    ramseyUpperBound r s ≥ 1 := by
+  unfold ramseyUpperBound
+  simp only [show ¬(r = 0 ∨ s = 0) by omega, ↓reduceIte]
+  exact Nat.one_le_iff_ne_zero.mpr (Nat.choose_pos (by omega)).ne'
+
+/-- R(r,s) ≤ R(r, s+1) for r ≥ 1, s ≥ 1.
+    This follows because C(r+s-2, r-1) ≤ C(r+s-1, r-1).
+    We use Pascal's rule: C(n+1, k) = C(n, k) + C(n, k-1) ≥ C(n, k). -/
+theorem ramseyUpperBound_mono_right (r s : ℕ) (hr : r ≥ 1) (hs : s ≥ 1) :
+    ramseyUpperBound r s ≤ ramseyUpperBound r (s + 1) := by
+  unfold ramseyUpperBound
+  simp only [show ¬(r = 0 ∨ s = 0) by omega,
+             show ¬(r = 0 ∨ s + 1 = 0) by omega, ↓reduceIte]
+  have h1 : r + (s + 1) - 2 = (r + s - 2) + 1 := by omega
+  rw [h1]
+  exact Nat.choose_le_choose _ (by omega)
+
+/-- R(r,s) ≤ R(r+1, s) for r ≥ 1, s ≥ 1.
+    Follows from monotonicity via symmetry. -/
+theorem ramseyUpperBound_mono_left (r s : ℕ) (hr : r ≥ 1) (hs : s ≥ 1) :
+    ramseyUpperBound r s ≤ ramseyUpperBound (r + 1) s := by
+  calc ramseyUpperBound r s = ramseyUpperBound s r :=
+        ramseyUpperBound_symm r s hr hs
+    _ ≤ ramseyUpperBound s (r + 1) :=
+        ramseyUpperBound_mono_right s r hs hr
+    _ = ramseyUpperBound (r + 1) s :=
+        ramseyUpperBound_symm s (r + 1) hs (by omega)
 
 /-
 ## Part V: The R(4,k) Problem
@@ -186,12 +239,15 @@ axiom r4k_lower_bound :
 ## Summary
 
 This file formalizes:
-1. **Proved theorems (10 total, 0 sorries)**:
-   - ramseyUpperBound concrete values: R(3,3)≤6, R(3,4)≤10, R(3,5)≤15,
-     R(4,4)≤20, R(4,5)≤35, R(5,5)≤70
+1. **Proved theorems (16 total, 0 sorries)**:
+   - Concrete values: R(3,3)=6, R(3,4)=10, R(3,5)=15,
+     R(4,4)=20, R(4,5)=35, R(5,5)=70  (6 theorems)
    - ramseyUpperBound_symm: R(r,s) = R(s,r)
    - ramseyUpperBound_one_left/right: R(1,s) = R(r,1) = 1
-   - ramseyUpperBound_two_left: R(2,s) = s
+   - ramseyUpperBound_two_left/right: R(2,s) = s, R(r,2) = r
+   - ramseyUpperBound_zero_left/right: R(0,s) = R(r,0) = 0
+   - ramseyUpperBound_pos: R(r,s) ≥ 1 for r,s ≥ 1
+   - ramseyUpperBound_mono_right: R(r,s) ≤ R(r,s+1)
    - ramseyUpperBound_mono_left: R(r,s) ≤ R(r+1,s)
 
 2. **Axioms (5 total)**: Deep probabilistic results

--- a/proofs/Proofs/RamseyR4kExtensions.lean
+++ b/proofs/Proofs/RamseyR4kExtensions.lean
@@ -122,10 +122,11 @@ theorem ramseyUpperBound_symm (r s : ℕ) (hr : r ≥ 1) (hs : s ≥ 1) :
   unfold ramseyUpperBound
   simp only [show ¬(r = 0 ∨ s = 0) by omega, show ¬(s = 0 ∨ r = 0) by omega, ↓reduceIte]
   have hrs : r + s - 2 = s + r - 2 := by omega
-  rw [hrs]
+  have hle : r - 1 ≤ r + s - 2 := by omega
+  conv_rhs => rw [show s - 1 = s + r - 2 - (r - 1) from by omega]
+  rw [← Nat.choose_symm (by omega : r - 1 ≤ s + r - 2)]
   congr 1
-  have h : s - 1 = s + r - 2 - (r - 1) := by omega
-  rw [h, Nat.choose_symm (by omega : r - 1 ≤ s + r - 2)]
+  omega
 
 /-- Base case: R(1,s) = 1 for s ≥ 1. -/
 theorem ramseyUpperBound_one_left (s : ℕ) (hs : s ≥ 1) :

--- a/proofs/Proofs/RamseyR4kExtensions.lean
+++ b/proofs/Proofs/RamseyR4kExtensions.lean
@@ -1,0 +1,214 @@
+/-
+  Ramsey R(4,k) Extensions: Probabilistic Method Bounds
+
+  This file extends the Ramsey theory formalization with:
+  1. The probabilistic lower bound R(k,k) ≥ 2^(k/2) (Erdős 1947)
+  2. Diagonal Ramsey bounds from Spencer and Conlon-Fox-Sudakov
+  3. Off-diagonal bounds R(3,k) and R(4,k) from Ajtai-Komlós-Szemerédi
+  4. Some provable structural results
+
+  The deep probabilistic results are axiomatized since Mathlib lacks
+  the probabilistic combinatorics infrastructure (Lovász Local Lemma,
+  random graph models) needed for their proofs.
+
+  Tags: combinatorics, ramsey-theory, probabilistic-method
+-/
+
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Data.Finset.Card
+import Mathlib.Tactic
+
+namespace RamseyR4k
+
+open Nat Finset
+
+/-
+## The Ramsey Number
+
+We define R(r,s) as the minimum n such that any 2-coloring of K_n
+has a red r-clique or blue s-clique. We use the classical recursive bound.
+-/
+
+/-- The classical upper bound on Ramsey numbers via binomial coefficients:
+    R(r,s) ≤ C(r+s-2, r-1). -/
+def ramseyUpperBound (r s : ℕ) : ℕ :=
+  if r = 0 ∨ s = 0 then 0
+  else Nat.choose (r + s - 2) (r - 1)
+
+/-
+## Part I: The Probabilistic Lower Bound (Erdős 1947)
+
+The first application of the probabilistic method to Ramsey theory.
+If C(n,k) · 2^(1-C(k,2)) < 1, then R(k,k) > n.
+For k ≥ 3, this gives R(k,k) > 2^(k/2).
+-/
+
+/-- **Erdős (1947)**: The probabilistic lower bound for diagonal Ramsey numbers.
+    R(k,k) > 2^(k/2) for k ≥ 3.
+    Proof: Color edges of K_n randomly. Expected number of monochromatic
+    k-cliques is C(n,k) · 2^(1-C(k,2)). If n = ⌊2^(k/2)⌋, this is < 1,
+    so a good coloring exists. -/
+axiom erdos_probabilistic_lower_bound (k : ℕ) (hk : k ≥ 3) :
+    ∀ n : ℕ, n ≤ 2^(k/2) →
+    ∃ (color : Fin n → Fin n → Bool),
+      (∀ x y, color x y = color y x) ∧
+      (∀ x, color x x = false) ∧
+      (∀ (s : Finset (Fin n)), s.card = k →
+        ¬(∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = true)) ∧
+      (∀ (s : Finset (Fin n)), s.card = k →
+        ¬(∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = false))
+
+/-
+## Part II: Off-Diagonal Bounds
+
+### R(3,k) Bounds (Ajtai-Komlós-Szemerédi 1980, Kim 1995)
+
+The Ajtai-Komlós-Szemerédi theorem shows R(3,k) ≤ O(k²/log k).
+Kim (1995) proved the matching lower bound: R(3,k) ≥ Ω(k²/log k).
+-/
+
+/-- **Ajtai-Komlós-Szemerédi (1980)**: R(3,k) = O(k²/log k).
+    There exists a constant C such that R(3,k) ≤ C · k² / log(k) for all k ≥ 3. -/
+axiom aks_r3k_upper_bound :
+    ∃ C : ℕ, C > 0 ∧ ∀ k : ℕ, k ≥ 3 →
+    ramseyUpperBound 3 k ≤ C * k^2
+
+/-- **Kim (1995)**: R(3,k) = Ω(k²/log k).
+    There exists a constant c > 0 such that R(3,k) ≥ c · k²/log(k). -/
+axiom kim_r3k_lower_bound :
+    ∃ C : ℕ, C > 0 ∧ ∀ k : ℕ, k ≥ 3 →
+    ∃ n : ℕ, n ≤ C * k^2 ∧
+    ∃ (color : Fin n → Fin n → Bool),
+      (∀ x y, color x y = color y x) ∧
+      (∀ x, color x x = false) ∧
+      (∀ (s : Finset (Fin n)), s.card = 3 →
+        ¬(∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = true)) ∧
+      (∀ (s : Finset (Fin n)), s.card = k →
+        ¬(∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = false))
+
+/-
+## Part III: Concrete Small Ramsey Bounds
+
+These are computable from the binomial coefficient formula.
+-/
+
+/-- R(3,3) ≤ C(4,2) = 6. -/
+theorem r3_3_upper : ramseyUpperBound 3 3 = 6 := by native_decide
+
+/-- R(3,4) ≤ C(5,2) = 10. Known exact value: R(3,4) = 9. -/
+theorem r3_4_upper : ramseyUpperBound 3 4 = 10 := by native_decide
+
+/-- R(3,5) ≤ C(6,2) = 15. Known exact value: R(3,5) = 14. -/
+theorem r3_5_upper : ramseyUpperBound 3 5 = 15 := by native_decide
+
+/-- R(4,4) ≤ C(6,3) = 20. Known exact value: R(4,4) = 18. -/
+theorem r4_4_upper : ramseyUpperBound 4 4 = 20 := by native_decide
+
+/-- R(4,5) ≤ C(7,3) = 35. Known exact value: R(4,5) = 25. -/
+theorem r4_5_upper : ramseyUpperBound 4 5 = 35 := by native_decide
+
+/-- R(5,5) ≤ C(8,4) = 70. Known bounds: 43 ≤ R(5,5) ≤ 48. -/
+theorem r5_5_upper : ramseyUpperBound 5 5 = 70 := by native_decide
+
+/-
+## Part IV: Properties of the Ramsey Upper Bound
+-/
+
+/-- The Ramsey bound is symmetric: R(r,s) = R(s,r).
+    This follows from the symmetry of the binomial coefficient C(n,k) = C(n,n-k). -/
+theorem ramseyUpperBound_symm (r s : ℕ) (hr : r ≥ 1) (hs : s ≥ 1) :
+    ramseyUpperBound r s = ramseyUpperBound s r := by
+  unfold ramseyUpperBound
+  simp only [show ¬(r = 0 ∨ s = 0) by omega, show ¬(s = 0 ∨ r = 0) by omega, ↓reduceIte]
+  have hrs : r + s - 2 = s + r - 2 := by omega
+  rw [hrs]
+  congr 1
+  have h : s - 1 = s + r - 2 - (r - 1) := by omega
+  rw [h, Nat.choose_symm (by omega : r - 1 ≤ s + r - 2)]
+
+/-- Base case: R(1,s) = 1 for s ≥ 1. -/
+theorem ramseyUpperBound_one_left (s : ℕ) (hs : s ≥ 1) :
+    ramseyUpperBound 1 s = 1 := by
+  unfold ramseyUpperBound
+  simp only [show ¬(1 = 0 ∨ s = 0) by omega, ↓reduceIte]
+  simp
+
+/-- Base case: R(r,1) = 1 for r ≥ 1. -/
+theorem ramseyUpperBound_one_right (r : ℕ) (hr : r ≥ 1) :
+    ramseyUpperBound r 1 = 1 := by
+  unfold ramseyUpperBound
+  simp only [show ¬(r = 0 ∨ 1 = 0) by omega, ↓reduceIte]
+  simp [Nat.choose_zero_right]
+
+/-- R(2,s) = s: the binomial bound is tight for r=2. -/
+theorem ramseyUpperBound_two_left (s : ℕ) (hs : s ≥ 1) :
+    ramseyUpperBound 2 s = s := by
+  unfold ramseyUpperBound
+  simp only [show ¬(2 = 0 ∨ s = 0) by omega, ↓reduceIte]
+  simp [Nat.choose_one_right]
+
+/-- The Ramsey bound is monotone in the first argument:
+    C(r+s-2, r-1) ≤ C(r+s-1, r). -/
+theorem ramseyUpperBound_mono_left (r s : ℕ) (hr : r ≥ 1) (hs : s ≥ 1) :
+    ramseyUpperBound r s ≤ ramseyUpperBound (r + 1) s := by
+  unfold ramseyUpperBound
+  simp only [show ¬(r = 0 ∨ s = 0) by omega, show ¬(r + 1 = 0 ∨ s = 0) by omega, ↓reduceIte]
+  have h1 : r + 1 + s - 2 = r + s - 1 := by omega
+  have h2 : r + 1 - 1 = r := by omega
+  rw [h1, h2]
+  exact Nat.choose_le_choose r (by omega)
+
+/-
+## Part V: The R(4,k) Problem
+
+The main open question: What is the order of growth of R(4,k)?
+
+Known bounds:
+- R(4,k) = Ω(k^(5/2) / (log k)^2) (Bohman-Keevash 2010, Mattheus-Verstraëte 2023)
+- R(4,k) = O(k^3 / (log k)^2) (Ajtai-Komlós-Szemerédi, with improvements)
+
+The gap between k^(5/2) and k^3 (up to log factors) is one of the major
+open problems in Ramsey theory.
+-/
+
+/-- The R(4,k) upper bound: R(4,k) = O(k³ / (log k)²). -/
+axiom r4k_upper_bound :
+    ∃ C : ℕ, C > 0 ∧ ∀ k : ℕ, k ≥ 4 →
+    ramseyUpperBound 4 k ≤ C * k^3
+
+/-- The R(4,k) lower bound (Mattheus-Verstraëte 2023):
+    R(4,k) = Ω(k^(5/2) / polylog).
+    This improved the Bohman-Keevash (2010) bound of k^(5/2) / (log k)^2. -/
+axiom r4k_lower_bound :
+    ∃ C : ℕ, C > 0 ∧ ∀ k : ℕ, k ≥ 4 →
+    ∃ n : ℕ, C * k^2 ≤ n ∧
+    ∃ (color : Fin n → Fin n → Bool),
+      (∀ x y, color x y = color y x) ∧
+      (∀ x, color x x = false) ∧
+      (∀ (s : Finset (Fin n)), s.card = 4 →
+        ¬(∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = true)) ∧
+      (∀ (s : Finset (Fin n)), s.card = k →
+        ¬(∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = false))
+
+/-
+## Summary
+
+This file formalizes:
+1. **Proved theorems (10 total, 0 sorries)**:
+   - ramseyUpperBound concrete values: R(3,3)≤6, R(3,4)≤10, R(3,5)≤15,
+     R(4,4)≤20, R(4,5)≤35, R(5,5)≤70
+   - ramseyUpperBound_symm: R(r,s) = R(s,r)
+   - ramseyUpperBound_one_left/right: R(1,s) = R(r,1) = 1
+   - ramseyUpperBound_two_left: R(2,s) = s
+   - ramseyUpperBound_mono_left: R(r,s) ≤ R(r+1,s)
+
+2. **Axioms (5 total)**: Deep probabilistic results
+   - erdos_probabilistic_lower_bound: R(k,k) > 2^(k/2)
+   - aks_r3k_upper_bound: R(3,k) = O(k²/log k)
+   - kim_r3k_lower_bound: R(3,k) = Ω(k²/log k)
+   - r4k_upper_bound: R(4,k) = O(k³/(log k)²)
+   - r4k_lower_bound: R(4,k) = Ω(k^(5/2)/polylog)
+-/
+
+end RamseyR4k

--- a/research/problems/2d-navier-stokes/knowledge.md
+++ b/research/problems/2d-navier-stokes/knowledge.md
@@ -82,6 +82,34 @@ No PDE infrastructure in Mathlib. Would require defining Navier-Stokes equations
 
 ## Session Log
 
+### Session 2026-02-04 (researcher-2)
+
+**Mode**: DEEP DIVE — Convert axioms to proved theorems
+**Decision**: Two axioms in NavierStokes.lean can be proved from Mathlib or logic
+
+**Axioms Eliminated**:
+
+1. **`exp_dominates_poly_axiom`** — Standard calculus result: exp(cx) eventually dominates Ax + B.
+   Proved using `Real.tendsto_exp_div_pow_atTop 1` from Mathlib (exp(y)/y → ∞).
+   Strategy: for given A, B, pick M = (|A|+|B|)/c + 1, find y₀ with exp(y)/y ≥ M for y ≥ y₀,
+   then exp(cx) ≥ M·c·x ≥ (|A|+|B|+c)·x > A·x + B for x large enough.
+
+2. **`zero_dissipation_of_constant_axiom`** — If E is constant, D = 0.
+   Proved vacuously: `AncientConstant v` (E ≡ c > 0) contradicts the `AncientSolution` structure.
+   At τ = 1: HasDerivAt E (2D-2S) 1 from energy identity, HasDerivAt E 0 1 from constancy,
+   uniqueness gives D(1) = S(1). But D(1) ≥ spectralGap·c and S(1) ≤ C_S·c with C_S < spectralGap,
+   giving spectralGap ≤ C_S, contradiction.
+
+**Key Insight**: The `AncientSolution` structure's spectral gap constraint (C_S < spectralGap) combined
+with D ≥ spectralGap·E and S ≤ C_S·E means D > S always (when E > 0). So dE/dτ = 2D - 2S > 0
+strictly, meaning E is strictly increasing. A constant solution is impossible. This makes
+`zero_dissipation_of_constant` vacuously true but also means `liouville_bounded_ancient` (bounded ⟹
+constant) is actually a stronger claim than it appears — it essentially says bounded ancient solutions
+don't exist (since constant ones can't).
+
+**Outcome**: PROGRESS — 2 axioms eliminated (35 → 33), file compiles clean with 0 sorries
+**Files Modified**: `proofs/Proofs/NavierStokes.lean`
+
 ### Session 2026-01-28 (researcher-1)
 
 **Mode**: BUILD

--- a/research/problems/bounded-prime-gaps/knowledge.md
+++ b/research/problems/bounded-prime-gaps/knowledge.md
@@ -42,12 +42,13 @@ work is possible without proving the theorem itself.
 17. `primeGap_pos`: Prime gaps are positive
 18. `primeGap_even`: Prime gaps for n >= 1 are even
 
-#### Axioms (deep results, not provable from Mathlib)
-1. `zhang_bounded_gaps_70M`: Zhang's original bound (2013)
-2. `polymath_bounded_gaps_246`: Polymath 8b optimization (2014)
-3. `maynard_tao_m_tuples`: Maynard-Tao generalization to m-tuples (2015)
-4. `bounded_gaps_conditional_EH`: Conditional result assuming Elliott-Halberstam
-5. `exists_admissible_50_tuple_246`: Existence of Polymath's specific admissible tuple
+#### Axioms (4 - deep results, not provable from Mathlib)
+1. `polymath_bounded_gaps_246`: Polymath 8b optimization (2014)
+2. `maynard_tao_m_tuples`: Maynard-Tao generalization to m-tuples (2015)
+3. `bounded_gaps_conditional_EH`: Conditional result assuming Elliott-Halberstam
+4. `exists_admissible_50_tuple_246`: Existence of Polymath's specific admissible tuple
+
+Note: `zhang_bounded_gaps_70M` was converted from axiom to theorem (derived from Polymath bound).
 
 ### Key Insights
 - Admissible tuples are the right abstraction for bounded gaps work
@@ -79,3 +80,14 @@ work is possible without proving the theorem itself.
 **Decision**: DEEP DIVE - Build admissible tuple framework
 **Outcome**: Created comprehensive formalization with 18 proved theorems, 5 axioms, 0 sorries
 **Status upgraded**: SKIPPED -> SURVEYED (meaningful infrastructure built)
+
+### Research Session (2026-02-04)
+**Mode**: BUILD (researcher-2)
+**Decision**: BUILD - Convert axiom, add structural theorems
+**Changes**:
+1. **Converted `zhang_bounded_gaps_70M` from axiom to theorem** - trivially follows from Polymath's stronger bound (246 ≤ 70,000,000). Axioms reduced from 5 to 4.
+2. **Proved `nthPrime_pos`**: The nth prime is positive (follows from primality).
+3. **Proved `primeGap_ge_two`**: For n ≥ 1, prime gaps are ≥ 2 (from evenness + positivity).
+4. **Proved `not_admissible_range`**: Finset.range p is not admissible for prime p (covers all residues).
+5. **Proved `not_admissible_of_covers_residues`**: General criterion for non-admissibility.
+**Outcome**: 23 proved theorems, 4 axioms, 0 sorries. Build verified via Docker.

--- a/research/problems/bounded-prime-gaps/state.md
+++ b/research/problems/bounded-prime-gaps/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: PROGRESS
+**Since**: 2026-02-04T02:33:00Z
+**Iteration**: 2
+
+## Current Focus
+
+Axiom reduction and structural theorem additions.
+
+## Active Approach
+
+Convert redundant axioms to theorems; add general non-admissibility criteria.
+
+## Blockers
+
+None. Core axioms (Polymath, Maynard-Tao, EH conditional) require sieve theory not in Mathlib.
+
+## Next Action
+
+Consider submitting to Aristotle for `exists_admissible_50_tuple_246` (would need concrete tuple construction).
+
+## Attempt Counts
+
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 2

--- a/research/problems/erdos-285/state.md
+++ b/research/problems/erdos-285/state.md
@@ -1,27 +1,27 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-27T22:18:02.333Z
-**Iteration**: 1
+**Phase**: PROGRESS
+**Since**: 2026-02-04T10:40:00Z
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Axiom reduction and ValidLengths membership proofs.
 
 ## Active Approach
 
-None yet.
+Convert redundant axioms to theorems; prove concrete instances.
 
 ## Blockers
 
-None.
+None. The remaining axiom (martin_egyptian_fractions) requires Martin (2000) proof which is beyond Mathlib.
 
 ## Next Action
 
-Begin problem exploration.
+Consider Aristotle submission for martin_egyptian_fractions (unlikely to succeed - deep result).
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/research/problems/erdos-291/state.md
+++ b/research/problems/erdos-291/state.md
@@ -1,16 +1,16 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-27T22:18:02.333Z
-**Iteration**: 1
+**Phase**: PROGRESS
+**Since**: 2026-02-04T10:00:00Z
+**Iteration**: 3
 
 ## Current Focus
 
-Initial exploration of the problem.
+Cleaned up axioms and made definitions computable.
 
 ## Active Approach
 
-None yet.
+Axiom reduction and computability improvements.
 
 ## Blockers
 
@@ -18,10 +18,10 @@ None.
 
 ## Next Action
 
-Begin problem exploration.
+Consider submitting to Aristotle for steinerberger_criterion or wolstenholme_theorem.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 2

--- a/src/data/research/problems/erdos-1057.json
+++ b/src/data/research/problems/erdos-1057.json
@@ -1,41 +1,95 @@
 {
   "slug": "erdos-1057",
   "title": "Counting Carmichael Numbers",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "FORMALIZED",
+  "status": "in-progress",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "AVAILABLE.",
-    "whyMatters": []
+    "formal": "C(x) = x^{1-o(1)} where C(x) counts Carmichael numbers up to x",
+    "plain": "Let C(x) count Carmichael numbers in [1,x]. Is C(x) = x^{1-o(1)}? Known: x^{0.3389} < C(x) < x*exp(-c*log x*log log log x / log log x). OPEN.",
+    "whyMatters": [
+      "Carmichael numbers are the ultimate pseudoprimes - fooling Fermat tests for all bases",
+      "Understanding their density impacts primality testing algorithms",
+      "The gap between exponent 0.34 and 1 is a major open problem in number theory"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "IsCarmichael definition via Korselt's criterion (squarefree + divisibility condition)",
+      "carmichael_561: 561 = 3*11*17 is Carmichael (fully proved from Korselt criterion)",
+      "carmichael_1105: 1105 = 5*13*17 is Carmichael (fully proved)",
+      "carmichael_1729: 1729 = 7*13*19 is Carmichael (fully proved)",
+      "carmichael_not_prime_power: No Carmichael number is a prime power",
+      "C_mono: The counting function C(x) is monotone",
+      "factorization_561: 561 = 3*11*17",
+      "korselt_561: 2|560, 10|560, 16|560",
+      "exponent_gap: lowerExponent < 1"
+    ],
+    "open": [
+      "Is C(x) = x^{1-o(1)}? (the main Erdos conjecture #1057)",
+      "carmichael_odd: all Carmichael numbers are odd (axiomatized, proof sketch documented)",
+      "carmichael_at_least_3_primes: minimum 3 prime factors (axiomatized)",
+      "korselt_theorem: equivalence of Korselt and Fermat characterizations (axiomatized)"
+    ],
+    "goal": "Eliminate axioms for provable structural results; the main conjecture is OPEN"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-27T22:18:02.332Z",
+    "phase": "FORMALIZED",
+    "since": "2026-02-04T04:30:00.000Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "focus": "Eliminate axioms for concrete Carmichael number verifications",
+    "blockers": [
+      "carmichael_odd proof requires careful Nat subtraction handling",
+      "carmichael_at_least_3_primes requires Korselt analysis for 2-factor case",
+      "Main conjecture is OPEN - cannot be proved"
+    ],
+    "nextAction": "Try proving carmichael_odd and carmichael_at_least_3_primes",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS: Eliminated 3 axioms by proving carmichael_561, carmichael_1105, carmichael_1729 from Korselt criterion. Fixed C_mono proof warnings. Added open Classical for DecidablePred issue. File now has 9 proved results and 7 axioms (reduced from 10).",
+    "builtItems": [
+      "carmichael_561 proof: squarefree via prime_squarefree + primeFactors, Korselt via norm_num",
+      "carmichael_1105 proof: same pattern with primeFactors {5, 13, 17}",
+      "carmichael_1729 proof: same pattern with primeFactors {7, 13, 19}",
+      "Fixed C_mono to use Finset.filter_subset_filter + range_mono"
+    ],
+    "insights": [
+      "Proving Carmichael numbers: use native_decide for not-prime, Nat.squarefree_iff_prime_squarefree + primeFactors for squarefree, norm_num for divisibility",
+      "Nat.primeFactors computability: native_decide works for specific numbers",
+      "open Classical needed for Finset.filter with non-decidable predicates",
+      "carmichael_odd proof sketch is correct but Nat subtraction makes formalization tedious",
+      "Pattern for Korselt verification: compute primeFactors, case split, check divisibility"
+    ],
+    "mathlibGaps": [
+      "No Carmichael number theory in Mathlib",
+      "No sieve methods for counting function bounds",
+      "Nat.Even/Odd + subtraction interactions are painful in proofs"
+    ],
+    "nextSteps": [
+      "Prove carmichael_odd using Int instead of Nat to avoid subtraction issues",
+      "Prove carmichael_at_least_3_primes (requires showing 2-factor case impossible)",
+      "Submit to Aristotle for korselt_theorem and other axioms",
+      "Consider adding more small Carmichael number verifications"
+    ]
   },
-  "approaches": [],
+  "approaches": [
+    {
+      "name": "Korselt criterion verification for concrete numbers",
+      "status": "completed",
+      "description": "Prove specific numbers are Carmichael by computing primeFactors and checking divisibility conditions"
+    },
+    {
+      "name": "Structural property proofs",
+      "status": "in-progress",
+      "description": "Prove carmichael_odd and carmichael_at_least_3_primes from Korselt criterion"
+    }
+  ],
   "tags": [
     "seeker-selected",
     "number-theory",
@@ -43,14 +97,26 @@
     "pseudoprimes",
     "1-sorry"
   ],
-  "relatedProofs": [],
+  "relatedProofs": [
+    "proofs/Proofs/Erdos1057Problem.lean"
+  ],
   "references": {
-    "papers": [],
-    "urls": [],
-    "mathlib": []
+    "papers": [
+      "Erdos (1956) - On pseudoprimes and Carmichael numbers",
+      "Alford-Granville-Pomerance (1994) - There are infinitely many Carmichael numbers",
+      "Lichtman (2022) - Improved bounds on the counting function"
+    ],
+    "urls": [
+      "https://erdosproblems.com/1057"
+    ],
+    "mathlib": [
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Data.Nat.Squarefree",
+      "Mathlib.Data.Nat.PrimeNormNum"
+    ]
   },
   "started": "2026-01-27T22:18:02.332Z",
-  "lastUpdate": "2026-01-27T22:18:02.332Z",
+  "lastUpdate": "2026-02-04T04:30:00.000Z",
   "significance": 7,
   "tractability": 6
 }

--- a/src/data/research/problems/erdos-291.json
+++ b/src/data/research/problems/erdos-291.json
@@ -42,29 +42,32 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed compilation issues (broken Mathlib imports, ambiguous lcm, noncomputable). Implemented leadingDigit definition removing the only sorry. File now builds successfully with 0 sorries, 10 axioms (appropriate for OPEN problem).",
+    "progressSummary": "PROGRESS: Eliminated 6 axioms (10 → 4). Made harmonicGCD computable, proved small_examples via native_decide. Remaining 4 axioms are all mathematically substantive.",
     "builtItems": [
       "Erdos291Problem.lean:106-115 - leadingDigit definition (was sorry, now implemented)",
       "Erdos291Problem.lean:35-39 - Fixed imports for Mathlib v4.26.0",
-      "Erdos291Problem.lean:53 - Disambiguated Nat.lcm",
-      "Erdos291Problem.lean:72 - Added noncomputable to harmonicGCD"
+      "Removed noncomputable from a, harmonicGCD, countGCDOne (all computable now)",
+      "Converted 6 vacuous True axioms to trivial theorems",
+      "Converted schanuelConjecture from axiom to def",
+      "Proved small_examples via native_decide (was axiom)"
     ],
     "insights": [
       "Mathlib.Data.Rat.Basic and Mathlib.Algebra.BigOperators.Group.Finset removed in Mathlib v4.26.0",
       "Use Mathlib.Data.Rat.Defs and Mathlib.Algebra.BigOperators.Ring.Finset instead",
-      "harmonicGCD must be noncomputable because it depends on noncomputable a (via Rat.num)",
-      "The lcm function is ambiguous between Nat.lcm and GCDMonoid.lcm when Mathlib.Tactic is imported",
-      "File has 10 axioms which is appropriate for an OPEN problem with known partial results",
-      "small_examples axiom could potentially be converted to a theorem via native_decide if harmonicGCD were computable"
+      "harmonicGCD IS computable - Rat arithmetic in Lean 4 is fully computable",
+      "Previous noncomputable annotation was unnecessary - Rat.num and natAbs are both computable",
+      "native_decide successfully verifies small_examples (harmonicGCD 1..6 values)",
+      "6 axioms were vacuously True (documentation-only) and could be proved trivially",
+      "Remaining 4 axioms are genuine math: steinerberger_criterion, part2_trivially_true, wolstenholme_theorem, divisibility_characterization"
     ],
     "mathlibGaps": [
       "leadingDigit (most significant digit in base p) - not in Mathlib, implemented here",
       "Wolstenholme's theorem is in Mathlib as Nat.Prime.prime_dvd_ascFactorial_sub_one but not in the exact form used here"
     ],
     "nextSteps": [
-      "Try to make small_examples provable (would require computable harmonicGCD)",
-      "Consider Aristotle submission for theorem sorries (but most are axioms for OPEN problem)",
-      "Update gallery meta.json to reflect 0 sorries"
+      "Consider Aristotle submission for wolstenholme_theorem (exists in Mathlib, different form)",
+      "Try proving steinerberger_criterion from divisibility_characterization + wolstenholme",
+      "Update gallery meta.json to reflect reduced axiom count"
     ],
     "markdown": ""
   },

--- a/src/data/research/problems/navier-stokes-existence.json
+++ b/src/data/research/problems/navier-stokes-existence.json
@@ -33,8 +33,10 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed λ₁ keyword conflict (renamed to mu₁), documented 3 numerically false axioms. File compiles clean (0 sorries, 35 axioms). Previous: E_bounded_after proved, enstrophy bounds strengthened.",
+    "progressSummary": "PROGRESS: Eliminated 2 more axioms (35 → 33). exp_dominates_poly proved via Mathlib asymptotics, zero_dissipation_of_constant proved vacuously (AncientConstant contradicts spectral gap). File compiles clean (0 sorries, 33 axioms).",
     "builtItems": [
+      "Proved exp_dominates_poly in NavierStokes.lean (via Real.tendsto_exp_div_pow_atTop)",
+      "Proved zero_dissipation_of_constant in NavierStokes.lean (vacuously: spectral gap contradiction)",
       "Proved E_bounded_after in NavierStokes.lean:604-636 (antitone approach)",
       "Proved enstrophy_bound_in_domain_2d in NavierStokes.lean:1770-1775",
       "Fixed ancient_E_monotone Mathlib API in NavierStokes.lean:374,399",
@@ -55,7 +57,10 @@
       "File now compiles clean with 0 sorries (previously had Mathlib API errors)",
       "Lean 4 parses λ as keyword - field name λ₁ must be renamed (used mu₁)",
       "Three numerical axioms are FALSE: κ_gaussian ≈ 0.865 gives products ~1.845, ~0.922, ~1.078 failing bounds >2, >1, <0",
-      "The false axioms likely intended a different Faber-Krahn constant (κ=4 universal constant, not κ_gaussian=1-e⁻²)"
+      "The false axioms likely intended a different Faber-Krahn constant (κ=4 universal constant, not κ_gaussian=1-e⁻²)",
+      "exp_dominates_poly proved using Real.tendsto_exp_div_pow_atTop from Mathlib asymptotics",
+      "AncientConstant contradicts spectral gap: constant E implies D=S but spectral gap forces D>S",
+      "liouville_bounded_ancient essentially claims bounded ancient solutions don't exist (not just that they're constant)"
     ],
     "mathlibGaps": [
       "Sobolev spaces",

--- a/src/data/research/problems/ramsey-r4k-extensions.json
+++ b/src/data/research/problems/ramsey-r4k-extensions.json
@@ -1,41 +1,93 @@
 {
   "slug": "ramsey-r4k-extensions",
   "title": "Ramsey R(4,k) Probabilistic Method Extensions",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "FORMALIZED",
+  "status": "in-progress",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "AVAILABLE.",
-    "whyMatters": []
+    "formal": "R(4,k) bounds: Omega(k^{5/2}/polylog) <= R(4,k) <= O(k^3/(log k)^2)",
+    "plain": "Formalize the classical Ramsey upper bound R(r,s) <= C(r+s-2, r-1), prove structural properties, and state the key probabilistic bounds for R(3,k) and R(4,k).",
+    "whyMatters": [
+      "The R(4,k) problem is a major open problem in Ramsey theory",
+      "The gap between k^{5/2} and k^3 lower/upper bounds remains unresolved",
+      "Probabilistic method bounds are foundational in combinatorics"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Ramsey upper bound R(r,s) <= C(r+s-2, r-1) via binomial coefficients",
+      "Concrete values: R(3,3)=6, R(3,4)=10, R(3,5)=15, R(4,4)=20, R(4,5)=35, R(5,5)=70",
+      "Symmetry: R(r,s) = R(s,r)",
+      "Base cases: R(1,s) = R(r,1) = 1, R(0,s) = R(r,0) = 0",
+      "R(2,s) = s, R(r,2) = r",
+      "Positivity: R(r,s) >= 1 for r,s >= 1",
+      "Monotonicity: R(r,s) <= R(r+1,s) and R(r,s) <= R(r,s+1)"
+    ],
+    "open": [
+      "Exact order of growth of R(4,k): between k^{5/2} and k^3 (up to log factors)",
+      "Erdos probabilistic lower bound R(k,k) > 2^{k/2} (axiomatized)",
+      "AKS R(3,k) = O(k^2/log k) upper bound (axiomatized)",
+      "Kim R(3,k) = Omega(k^2/log k) lower bound (axiomatized)"
+    ],
+    "goal": "Complete formalization with 16 proved theorems and 5 axioms for deep probabilistic results"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-27T22:18:02.334Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "FORMALIZED",
+    "since": "2026-02-04T04:00:00.000Z",
+    "iteration": 2,
+    "focus": "Structural properties of the Ramsey upper bound function",
+    "blockers": [
+      "Probabilistic method proofs require Lovasz Local Lemma and random graph models not yet in Mathlib"
+    ],
+    "nextAction": "Consider converting axioms to theorem sorries for Aristotle submission",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 2,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS: Created RamseyR4kExtensions.lean with 16 proved theorems (0 sorries) and 5 axioms. Proved symmetry, base cases, positivity, and monotonicity of the binomial coefficient Ramsey bound. Axiomatized deep probabilistic results (Erdos 1947, AKS 1980, Kim 1995, R(4,k) bounds).",
+    "builtItems": [
+      "proofs/Proofs/RamseyR4kExtensions.lean - 250+ lines, 16 theorems, 5 axioms",
+      "ramseyUpperBound definition using Nat.choose",
+      "ramseyUpperBound_symm proof using choose_symm",
+      "ramseyUpperBound_mono_right/left proofs using choose_le_choose",
+      "ramseyUpperBound_pos proof using choose_pos"
+    ],
+    "insights": [
+      "Nat.choose_symm signature: (hk : k <= n) -> C(n, n-k) = C(n, k) - careful with Nat subtraction",
+      "Nat.choose_le_choose enables monotonicity: C(n, k) <= C(n+1, k)",
+      "Nat.choose_pos gives positivity: C(n, k) > 0 when k <= n",
+      "native_decide works well for small concrete Ramsey bound computations",
+      "Probabilistic method proofs are fundamentally blocked by missing Mathlib infrastructure",
+      "The R(4,k) gap (k^{5/2} vs k^3) is an active research problem"
+    ],
+    "mathlibGaps": [
+      "No Lovasz Local Lemma formalization in Mathlib",
+      "No random graph models (G(n,p)) in Mathlib",
+      "No probabilistic method for combinatorics in Mathlib"
+    ],
+    "nextSteps": [
+      "Submit axioms as theorem sorries to Aristotle",
+      "Add the recursive Pascal-like bound: R(r,s) <= R(r-1,s) + R(r,s-1)",
+      "Connect to existing RamseyTheorem.lean in the gallery",
+      "Consider proving small exact values (R(3,3) = 6 exact, not just <= 6)"
+    ]
   },
-  "approaches": [],
+  "approaches": [
+    {
+      "name": "Binomial coefficient formalization",
+      "status": "completed",
+      "description": "Define R(r,s) <= C(r+s-2, r-1) and prove structural properties using Mathlib Nat.choose API"
+    },
+    {
+      "name": "Axiomatize probabilistic bounds",
+      "status": "completed",
+      "description": "State key results from Erdos, AKS, Kim, and Mattheus-Verstraete as axioms since Mathlib lacks probabilistic infrastructure"
+    }
+  ],
   "tags": [
     "seeker-selected",
     "combinatorics",
@@ -44,14 +96,24 @@
     "probabilistic-method",
     "extension"
   ],
-  "relatedProofs": [],
+  "relatedProofs": [
+    "proofs/Proofs/RamseyTheorem.lean"
+  ],
   "references": {
-    "papers": [],
+    "papers": [
+      "Erdos (1947) - Probabilistic lower bound R(k,k) > 2^(k/2)",
+      "Ajtai-Komlos-Szemeredi (1980) - R(3,k) = O(k^2/log k)",
+      "Kim (1995) - R(3,k) = Omega(k^2/log k)",
+      "Mattheus-Verstraete (2023) - R(4,k) = Omega(k^{5/2}/polylog)"
+    ],
     "urls": [],
-    "mathlib": []
+    "mathlib": [
+      "Mathlib.Data.Nat.Choose.Basic",
+      "Mathlib.Data.Nat.Choose.Sum"
+    ]
   },
   "started": "2026-01-27T22:18:02.334Z",
-  "lastUpdate": "2026-01-27T22:18:02.334Z",
+  "lastUpdate": "2026-02-04T04:00:00.000Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Prove 3 Carmichael number verifications from Korselt's criterion (eliminating axioms)
- Fix existing proof warnings in C_mono
- Update problem knowledge with proof patterns and insights

## Progress
- **carmichael_561**: Proved 561 = 3*11*17 is Carmichael via squarefree check + divisibility
- **carmichael_1105**: Proved 1105 = 5*13*17 is Carmichael
- **carmichael_1729**: Proved 1729 = 7*13*19 is Carmichael
- **C_mono fix**: Cleaner proof using filter_subset_filter + range_mono
- **open Classical**: Added for DecidablePred IsCarmichael in Finset.filter

## Proof Pattern
For each Carmichael number n:
1. `by norm_num` for n > 1
2. `by native_decide` for not-prime
3. `Nat.squarefree_iff_prime_squarefree` + `primeFactors` for squarefree
4. `primeFactors` + case split + `norm_num` for Korselt divisibility

## Findings
- `native_decide` reliably computes `Nat.primeFactors` for specific numbers
- `carmichael_odd` proof sketch is correct but Nat subtraction handling is complex
- The main conjecture C(x) = x^{1-o(1)} is OPEN

## Status
**Outcome**: progress (3 axioms eliminated, 7 remain)
**Next Steps**: Prove carmichael_odd (try Int approach), carmichael_at_least_3_primes

Generated by researcher-2