### PR TITLE
Research: erdos-185, unit-distance-independence - prove theorems, add independence number

### DIFF
--- a/proofs/Proofs/Erdos185Problem.lean
+++ b/proofs/Proofs/Erdos185Problem.lean
@@ -35,7 +35,7 @@ open Asymptotics Filter
 
 namespace Erdos185
 
-/-!
+/-
 ## Part I: Basic Definitions
 -/
 
@@ -53,7 +53,7 @@ theorem hypercube_card (n : ℕ) :
     Fintype.card (TernaryHypercube n) = 3^n := by
   simp [TernaryHypercube]
 
-/-!
+/-
 ## Part II: Lines in {0,1,2}^n
 -/
 
@@ -91,7 +91,7 @@ def CombinatorialLine.points (L : CombinatorialLine n) : Finset (TernaryHypercub
   Finset.univ.image (fun t : ZMod 3 => fun i =>
     if i ∈ L.varying then t else L.fixed i)
 
-/-!
+/-
 ## Part III: Cap Sets
 -/
 
@@ -131,7 +131,7 @@ The maximum size of a cap set in {0,1,2}^n.
 noncomputable def f3 (n : ℕ) : ℕ :=
   sSup { m : ℕ | ∃ S : Finset (TernaryHypercube n), IsCapSet S ∧ S.card = m }
 
-/-!
+/-
 ## Part IV: Connection to Arithmetic Progressions
 -/
 
@@ -152,7 +152,7 @@ AP-free sets embed to cap sets (lines generalize APs).
 -/
 axiom f3_geq_R3 (n : ℕ) : f3 n ≥ R3 (3^n)
 
-/-!
+/-
 ## Part V: Known Bounds
 -/
 
@@ -178,7 +178,7 @@ def moserSet (n : ℕ) : Finset (TernaryHypercube n) :=
     It avoids combinatorial lines, which is the relevant notion for Hales-Jewett. -/
 axiom moser_set_is_cap_combinatorial (n : ℕ) : IsCapSetCombinatorial (moserSet n)
 
-/-!
+/-
 ## Part VI: The Main Result - Density Hales-Jewett
 -/
 
@@ -206,7 +206,7 @@ f₃(n) / 3^n → 0 as n → ∞.
 axiom f3_density_tends_to_zero :
     Filter.Tendsto (fun n => (f3 n : ℝ) / 3^n) atTop (nhds 0)
 
-/-!
+/-
 ## Part VII: More Recent Progress
 -/
 
@@ -233,16 +233,95 @@ The best known upper bound has base ≈ 2.756.
 -/
 noncomputable def capSetConstant : ℝ := 2.756
 
-/-!
+/-
 ## Part VIII: Examples
 -/
+
+/-- The three elements of TernaryHypercube 1. -/
+private def pt0 : TernaryHypercube 1 := fun _ => 0
+private def pt1 : TernaryHypercube 1 := fun _ => 1
+private def pt2 : TernaryHypercube 1 := fun _ => 2
+
+private theorem pt0_ne_pt1 : pt0 ≠ (pt1 : TernaryHypercube 1) := by
+  intro h; have h0 := congr_fun h ⟨0, by omega⟩; norm_num [pt0, pt1] at h0
+
+private theorem pt1_ne_pt2 : pt1 ≠ (pt2 : TernaryHypercube 1) := by
+  intro h
+  have h0 := congr_fun h ⟨0, by omega⟩
+  have h1 : (1 : ZMod 3).val = (2 : ZMod 3).val := congr_arg ZMod.val h0
+  simp +decide at h1
+
+private theorem pt0_ne_pt2 : pt0 ≠ (pt2 : TernaryHypercube 1) := by
+  intro h
+  have h0 := congr_fun h ⟨0, by omega⟩
+  have h1 : (0 : ZMod 3).val = (2 : ZMod 3).val := congr_arg ZMod.val h0
+  simp +decide at h1
+
+/-- The Finset of all elements of TernaryHypercube 1 has cardinality 3. -/
+private theorem ternary1_card : Fintype.card (TernaryHypercube 1) = 3 :=
+  hypercube_card 1
+
+/-- pt0, pt1, pt2 are on a line: pt0 + pt2 = 2 * pt1. -/
+private theorem line_012 : OnLine pt0 pt1 pt2 := by
+  intro ⟨i, hi⟩
+  have : i = 0 := by omega
+  subst this
+  simp [pt0, pt1, pt2]
+
+/-- The full set TernaryHypercube 1 is NOT a cap set. -/
+private theorem full_set_not_cap :
+    ¬IsCapSet (Finset.univ : Finset (TernaryHypercube 1)) := by
+  intro h
+  exact h pt0 pt1 pt2 (Finset.mem_univ _) (Finset.mem_univ _) (Finset.mem_univ _)
+    pt0_ne_pt1 pt1_ne_pt2 pt0_ne_pt2 line_012
+
+/-- Any cap set in TernaryHypercube 1 has at most 2 elements. -/
+private theorem capSet1_card_le_2 (S : Finset (TernaryHypercube 1)) (hS : IsCapSet S) :
+    S.card ≤ 2 := by
+  by_contra hgt
+  push_neg at hgt
+  have hcard : Fintype.card (TernaryHypercube 1) = 3 := hypercube_card 1
+  have hle : S.card ≤ 3 := by
+    calc S.card ≤ (Finset.univ : Finset (TernaryHypercube 1)).card :=
+          Finset.card_le_card (Finset.subset_univ _)
+      _ = Fintype.card (TernaryHypercube 1) := by rw [Finset.card_univ]
+      _ = 3 := hcard
+  have hS_eq : S.card = 3 := by omega
+  have huniv : S = Finset.univ :=
+    Finset.eq_univ_of_card S (hS_eq.trans hcard.symm)
+  subst huniv
+  exact full_set_not_cap hS
+
+/-- There exists a cap set of size 2 in TernaryHypercube 1. -/
+private theorem exists_capSet1_size_2 :
+    ∃ S : Finset (TernaryHypercube 1), IsCapSet S ∧ S.card = 2 := by
+  exact ⟨{pt0, pt1}, isCapSet_pair pt0 pt1 pt0_ne_pt1,
+    Finset.card_pair pt0_ne_pt1⟩
 
 /--
 **n = 1:**
 f₃(1) = 2. The points are 0, 1, 2, and any two form a cap set.
 -/
 theorem f3_1 : f3 1 = 2 := by
-  sorry
+  unfold f3
+  apply le_antisymm
+  · -- Upper bound: sSup ≤ 2
+    apply csSup_le
+    · -- Nonempty
+      exact ⟨0, ∅, isCapSet_empty, rfl⟩
+    · -- Bound
+      rintro m ⟨S, hcap, rfl⟩
+      exact capSet1_card_le_2 S hcap
+  · -- Lower bound: 2 ≤ sSup
+    apply le_csSup
+    · -- BddAbove
+      exact ⟨3, fun m hm => by
+        obtain ⟨S, _, rfl⟩ := hm
+        calc S.card ≤ (Finset.univ : Finset (TernaryHypercube 1)).card :=
+              Finset.card_le_card (Finset.subset_univ _)
+          _ = Fintype.card (TernaryHypercube 1) := by rw [Finset.card_univ]
+          _ = 3 := hypercube_card 1⟩
+    · exact exists_capSet1_size_2
 
 /--
 **n = 2:**
@@ -262,7 +341,7 @@ f₃(4) = 20.
 -/
 axiom f3_4 : f3 4 = 20
 
-/-!
+/-
 ## Part IX: Summary
 
 **Erdős Problem #185: PROVED**

--- a/proofs/Proofs/RamseyR4kExtensions.lean
+++ b/proofs/Proofs/RamseyR4kExtensions.lean
@@ -288,24 +288,91 @@ axiom r4k_lower_bound :
         ¬(∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = false))
 
 /-
+## Part V-B: Additional Structural Properties
+-/
+
+/-- R(r,s) ≥ s for r ≥ 2, s ≥ 1: the upper bound is at least s. -/
+theorem ramseyUpperBound_ge_right (r s : ℕ) (hr : r ≥ 2) (hs : s ≥ 1) :
+    ramseyUpperBound r s ≥ s := by
+  unfold ramseyUpperBound
+  simp only [show ¬(r = 0 ∨ s = 0) by omega, ↓reduceIte]
+  -- Need: C(r+s-2, r-1) ≥ s
+  -- C(r+s-2, r-1) = C(r+s-2, s-1) by symmetry
+  -- For r ≥ 2: C(r+s-2, s-1) ≥ C(s, s-1) = s by monotonicity of choose
+  have h1 : r - 1 ≤ r + s - 2 := by omega
+  calc Nat.choose (r + s - 2) (r - 1)
+      = Nat.choose (r + s - 2) ((r + s - 2) - (r - 1)) := Nat.choose_symm h1
+    _ = Nat.choose (r + s - 2) (s - 1) := by congr 1; omega
+    _ ≥ Nat.choose s (s - 1) := Nat.choose_le_choose (s - 1) (by omega)
+    _ = s := by rw [Nat.choose_symm (by omega : s - 1 ≤ s)]; simp [show s - (s - 1) = 1 from by omega]; exact Nat.choose_one_right s
+
+/-- R(r,s) ≥ r for r ≥ 1, s ≥ 2: the upper bound is at least r. -/
+theorem ramseyUpperBound_ge_left (r s : ℕ) (hr : r ≥ 1) (hs : s ≥ 2) :
+    ramseyUpperBound r s ≥ r := by
+  rw [ramseyUpperBound_symm r s hr (by omega)]
+  exact ramseyUpperBound_ge_right s r hs hr
+
+/-- More concrete bounds: R(3,6) ≤ C(7,2) = 21. -/
+theorem r3_6_upper : ramseyUpperBound 3 6 = 21 := by native_decide
+
+/-- R(3,7) ≤ C(8,2) = 28. -/
+theorem r3_7_upper : ramseyUpperBound 3 7 = 28 := by native_decide
+
+/-- R(3,8) ≤ C(9,2) = 36. -/
+theorem r3_8_upper : ramseyUpperBound 3 8 = 36 := by native_decide
+
+/-- R(3,9) ≤ C(10,2) = 45. Known exact value: R(3,9) = 36. -/
+theorem r3_9_upper : ramseyUpperBound 3 9 = 45 := by native_decide
+
+/-- R(4,6) ≤ C(8,3) = 56. -/
+theorem r4_6_upper : ramseyUpperBound 4 6 = 56 := by native_decide
+
+/-- R(4,7) ≤ C(9,3) = 84. -/
+theorem r4_7_upper : ramseyUpperBound 4 7 = 84 := by native_decide
+
+/-- R(5,6) ≤ C(9,4) = 126. -/
+theorem r5_6_upper : ramseyUpperBound 5 6 = 126 := by native_decide
+
+/-- R(6,6) ≤ C(10,5) = 252. -/
+theorem r6_6_upper : ramseyUpperBound 6 6 = 252 := by native_decide
+
+/-- Diagonal monotonicity: R(k,k) ≤ R(k+1,k+1) for k ≥ 1. -/
+theorem ramseyUpperBound_diag_mono (k : ℕ) (hk : k ≥ 1) :
+    ramseyUpperBound k k ≤ ramseyUpperBound (k + 1) (k + 1) :=
+  calc ramseyUpperBound k k
+      ≤ ramseyUpperBound (k + 1) k := ramseyUpperBound_mono_left k k hk hk
+    _ ≤ ramseyUpperBound (k + 1) (k + 1) := ramseyUpperBound_mono_right (k + 1) k (by omega) hk
+
+/-- The upper bound grows strictly: R(r, s+1) ≥ R(r, s) + 1 for r ≥ 2, s ≥ 2. -/
+theorem ramseyUpperBound_strict_mono_right (r s : ℕ) (hr : r ≥ 2) (hs : s ≥ 2) :
+    ramseyUpperBound r (s + 1) ≥ ramseyUpperBound r s + 1 := by
+  rw [ramseyUpperBound_pascal r (s + 1) hr (by omega)]
+  have : ramseyUpperBound (r - 1) (s + 1) ≥ 1 :=
+    ramseyUpperBound_pos (r - 1) (s + 1) (by omega) (by omega)
+  simp only [show s + 1 - 1 = s from by omega]
+  omega
+
+/-
 ## Summary
 
 This file formalizes:
-1. **Proved theorems (22 total, 0 sorries)**:
+1. **Proved theorems (33 total, 0 sorries)**:
    - Concrete values: R(3,3)=6, R(3,4)=10, R(3,5)=15,
-     R(4,4)=20, R(4,5)=35, R(5,5)=70  (6 theorems)
+     R(4,4)=20, R(4,5)=35, R(5,5)=70, R(3,6)=21, R(3,7)=28,
+     R(3,8)=36, R(3,9)=45, R(4,6)=56, R(4,7)=84, R(5,6)=126,
+     R(6,6)=252  (14 concrete values)
    - ramseyUpperBound_symm: R(r,s) = R(s,r)
    - ramseyUpperBound_one_left/right: R(1,s) = R(r,1) = 1
    - ramseyUpperBound_two_left/right: R(2,s) = s, R(r,2) = r
    - ramseyUpperBound_zero_left/right: R(0,s) = R(r,0) = 0
    - ramseyUpperBound_pos: R(r,s) ≥ 1 for r,s ≥ 1
-   - ramseyUpperBound_mono_right: R(r,s) ≤ R(r,s+1)
-   - ramseyUpperBound_mono_left: R(r,s) ≤ R(r+1,s)
-   - ramseyUpperBound_pascal: R(r,s) = R(r-1,s) + R(r,s-1)  [NEW]
-   - ramseyUpperBound_pascal_check_33: R(3,3) = R(2,3) + R(3,2)  [NEW]
-   - ramseyUpperBound_pascal_check_44: R(4,4) = R(3,4) + R(4,3)  [NEW]
-   - ramseyUpperBound_ge_pred_left: R(r,s) ≥ R(r-1,s)  [NEW]
-   - ramseyUpperBound_ge_pred_right: R(r,s) ≥ R(r,s-1)  [NEW]
+   - ramseyUpperBound_mono_right/left: monotonicity
+   - ramseyUpperBound_pascal: R(r,s) = R(r-1,s) + R(r,s-1)
+   - ramseyUpperBound_pascal_check_33/44: Pascal rule verifications
+   - ramseyUpperBound_ge_pred_left/right: pred corollaries
+   - ramseyUpperBound_ge_right/left: R(r,s) ≥ s and ≥ r  [NEW]
+   - ramseyUpperBound_diag_mono: R(k,k) ≤ R(k+1,k+1)  [NEW]
+   - ramseyUpperBound_strict_mono_right: R(r,s+1) ≥ R(r,s) + 1  [NEW]
 
 2. **Axioms (5 total)**: Deep probabilistic results
    - erdos_probabilistic_lower_bound: R(k,k) > 2^(k/2)

--- a/proofs/Proofs/UnitDistanceIndependence.lean
+++ b/proofs/Proofs/UnitDistanceIndependence.lean
@@ -10,11 +10,13 @@ the independence number α(S) = max |I| where I ⊆ S has no two points at dista
 
 **Key Results Formalized**:
 - Independent sets in simple graphs: definition and properties
+- Independence number: formal definition and bounds
 - Connection between colorings and independent sets
+- α(G) · k ≥ |V| for any proper k-coloring
+- Independence-clique duality: independent in G ↔ clique in Gᶜ
 - Hadwiger-Nelson bounds: 5 ≤ χ(R^2) ≤ 7
-- Basic structural theorems about independence
 
-**Status**: BUILD
+**Status**: DEEP DIVE
 Tags: combinatorial-geometry, graph-theory, independence-number, unit-distance
 -/
 
@@ -72,6 +74,12 @@ theorem isIndepFinset_subset {V : Type*} (G : SimpleGraph V) {S T : Finset V}
 theorem isIndepFinset_iff {V : Type*} (G : SimpleGraph V) (S : Finset V) :
     IsIndepFinset G S ↔ ∀ u ∈ S, ∀ v ∈ S, u ≠ v → ¬ G.Adj u v :=
   Iff.rfl
+
+/-- A graph with no edges has all sets independent. -/
+theorem isIndepFinset_of_bot {V : Type*} (S : Finset V) :
+    IsIndepFinset (⊥ : SimpleGraph V) S := by
+  intro u _ v _ _ hadj
+  exact hadj
 
 /-
 ## Part III: Coloring and Independence Relationship
@@ -151,39 +159,77 @@ theorem exists_nonempty_indep {V : Type*} [DecidableEq V] [Nonempty V]
 
 /-- Independent sets have at most |V| elements. -/
 theorem indep_card_le_univ {V : Type*} [Fintype V] (G : SimpleGraph V)
-    (S : Finset V) (hS : IsIndepFinset G S) :
+    (S : Finset V) (_hS : IsIndepFinset G S) :
     S.card ≤ Fintype.card V :=
   Finset.card_le_card (Finset.subset_univ S)
 
 /-
-## Part VI: Unit Distance Graph Specific Results
+## Part VI: Independence Number
 -/
 
-/-- Points at distance ≠ 1 can both be in an independent set (trivial). -/
-theorem not_unit_dist_independent (p q : Plane) (h : dist p q ≠ 1) :
-    -- p and q are "compatible" for independence
-    True := trivial
+/-- The independence number of a finite graph: the maximum size of an independent set. -/
+noncomputable def indepNumber {V : Type*} [Fintype V] (G : SimpleGraph V) : ℕ :=
+  sSup {n : ℕ | ∃ S : Finset V, IsIndepFinset G S ∧ S.card = n}
 
-/-- A point set where all pairwise distances ≠ 1 is independent in
-    the unit distance graph (by definition). -/
-theorem all_diff_dist_independent (S : Finset Plane)
-    (h : ∀ p ∈ S, ∀ q ∈ S, p ≠ q → dist p q ≠ 1) :
-    ∀ p ∈ S, ∀ q ∈ S, p ≠ q → dist p q ≠ 1 := h
+/-- Every independent set has cardinality at most the independence number. -/
+theorem indep_card_le_indepNumber {V : Type*} [Fintype V] (G : SimpleGraph V)
+    (S : Finset V) (hS : IsIndepFinset G S) :
+    S.card ≤ indepNumber G := by
+  apply le_csSup
+  · exact ⟨Fintype.card V, fun m hm => by
+      obtain ⟨T, _, rfl⟩ := hm
+      exact Finset.card_le_card (Finset.subset_univ T)⟩
+  · exact ⟨S, hS, rfl⟩
+
+/-- The independence number is at least 1 for nonempty graphs. -/
+theorem indepNumber_pos {V : Type*} [Fintype V] [DecidableEq V] [Nonempty V]
+    (G : SimpleGraph V) : 0 < indepNumber G := by
+  obtain ⟨v⟩ := ‹Nonempty V›
+  have h1 : ({v} : Finset V).card ≤ indepNumber G :=
+    indep_card_le_indepNumber G {v} (isIndepFinset_singleton G v)
+  simp at h1
+  omega
+
+/-- The independence number is at most |V|. -/
+theorem indepNumber_le_card {V : Type*} [Fintype V] (G : SimpleGraph V) :
+    indepNumber G ≤ Fintype.card V := by
+  apply csSup_le
+  · exact ⟨0, ∅, isIndepFinset_empty G, by simp⟩
+  · rintro m ⟨S, _, rfl⟩
+    exact Finset.card_le_card (Finset.subset_univ S)
+
+/-- The independence number of the empty graph equals |V|. -/
+theorem indepNumber_bot {V : Type*} [Fintype V] (G : SimpleGraph V) (hG : G = ⊥) :
+    indepNumber G = Fintype.card V := by
+  apply le_antisymm (indepNumber_le_card G)
+  have hIndep : IsIndepFinset G (Finset.univ : Finset V) := by
+    subst hG; exact isIndepFinset_of_bot Finset.univ
+  have hcard : (Finset.univ : Finset V).card = Fintype.card V := Finset.card_univ
+  calc Fintype.card V = (Finset.univ : Finset V).card := hcard.symm
+    _ ≤ indepNumber G := indep_card_le_indepNumber G Finset.univ hIndep
 
 /-
 ## Part VII: Independence and Clique Duality
 -/
 
-/-- In a simple graph, the complement of a clique is related to independence. -/
-theorem indep_compl_clique {V : Type*} [DecidableEq V] (G : SimpleGraph V) (S : Finset V) :
-    IsIndepFinset G S ↔ IsIndepFinset G S :=
-  Iff.rfl
+/-- **Independence-Clique Duality**: An independent set in G is exactly a set where
+    all distinct pairs are non-adjacent, which is the same as a clique in the complement.
+    We state this as: S independent in G implies the set-version is a clique in Gᶜ. -/
+theorem indepSet_iff_compl_clique {V : Type*} (G : SimpleGraph V) (S : Set V) :
+    IsIndepSet G S ↔ (Gᶜ).IsClique S := by
+  constructor
+  · intro hI u hu v hv huv
+    -- Gᶜ.Adj u v means ⟨u ≠ v, ¬G.Adj u v⟩
+    exact ⟨huv, hI u hu v hv huv⟩
+  · intro hC u hu v hv huv hadj
+    have hcadj := hC hu hv huv
+    exact hcadj.2 hadj
 
-/-- A graph with no edges has all sets independent. -/
-theorem isIndepFinset_of_bot {V : Type*} (S : Finset V) :
-    IsIndepFinset (⊥ : SimpleGraph V) S := by
-  intro u _ v _ _ hadj
-  exact hadj
+/-- The Finset version: S independent in G iff the corresponding set is a clique in Gᶜ. -/
+theorem indepFinset_iff_compl_clique {V : Type*} (G : SimpleGraph V) (S : Finset V) :
+    IsIndepFinset G S ↔ (Gᶜ).IsClique (S : Set V) := by
+  rw [← indepSet_iff_compl_clique]
+  rfl
 
 /-- A complete graph (on ≥ 2 vertices) has independence number 1. -/
 theorem indep_top_singleton {V : Type*} [DecidableEq V] (G : SimpleGraph V)
@@ -218,41 +264,81 @@ theorem proper_coloring_gives_independent_partition {V : Type*} [Fintype V] [Dec
   intro v hv
   exact (Finset.mem_filter.mp hv).2
 
+/-- **Independence number lower bound from coloring**:
+    If a graph has a proper k-coloring, then α(G) · k ≥ |V|.
+    This follows from: each color class is independent with size ≤ α(G),
+    and the color classes partition V, so |V| = Σ|Cᵢ| ≤ k · α(G). -/
+theorem indep_times_colors_ge_card {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) {k : ℕ} (_hk : k > 0) (c : V → Fin k)
+    (hc : IsProperColoring G c) :
+    indepNumber G * k ≥ Fintype.card V := by
+  -- Each color class is independent, and their sizes sum to |V|
+  have hsum : Fintype.card V =
+      (Finset.univ : Finset (Fin k)).sum
+        (fun i => (Finset.univ.filter (fun v => c v = i)).card) := by
+    rw [← Finset.card_univ (α := V)]
+    rw [← Finset.card_biUnion]
+    · congr 1
+      ext v; simp
+    · intro i _ j _ hij
+      apply Finset.disjoint_filter.mpr
+      intro x _ hxi hxj
+      exact hij (hxi.symm.trans hxj)
+  -- Each color class has size ≤ α(G)
+  have hle : ∀ i : Fin k,
+      (Finset.univ.filter (fun v => c v = i)).card ≤ indepNumber G := by
+    intro i
+    exact indep_card_le_indepNumber G _
+      (proper_coloring_gives_independent_partition G c hc i)
+  -- Sum of k things each ≤ α is ≤ k·α
+  have hbound : (Finset.univ : Finset (Fin k)).sum
+      (fun i => (Finset.univ.filter (fun v => c v = i)).card) ≤
+      (Finset.univ : Finset (Fin k)).sum (fun _ => indepNumber G) := by
+    apply Finset.sum_le_sum
+    intro i _
+    exact hle i
+  rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul] at hbound
+  linarith [mul_comm (indepNumber G) k]
+
 /-
 ## Part IX: Summary
 
 This file establishes:
 1. **Independent sets**: Definition and basic properties (empty, singleton, subset, insert)
-2. **Coloring connection**: Color classes are independent sets
-3. **Pigeonhole**: Large color class from k-coloring of n vertices
-4. **Hadwiger-Nelson**: Formal statement of 5 ≤ χ(R²) ≤ 7
-5. **Edge-independence duality**: Edges force vertices out of independent sets
-6. **Extremal cases**: No-edge graph (all independent), complete graph (α = 1)
-7. **Structural**: Independent set cardinality bounded by |V|
+2. **Independence number**: Formal definition as sSup + basic bounds
+3. **Coloring connection**: Color classes are independent sets
+4. **α·k ≥ n**: Independence number times chromatic number covers all vertices
+5. **Independence-clique duality**: Independent in G ↔ clique in Gᶜ
+6. **Hadwiger-Nelson**: Formal statement of 5 ≤ χ(R²) ≤ 7
+7. **Edge-independence duality**: Edges force vertices out of independent sets
+8. **Extremal cases**: Empty graph (α = n), complete graph (α = 1)
 
-### Proved Theorems (15 total, 0 sorries)
+### Proved Theorems (0 sorries)
 - `isIndepFinset_empty`: ∅ is independent
 - `isIndepFinset_singleton`: {v} is independent
 - `isIndepFinset_subset`: Subsets preserve independence
 - `isIndepFinset_iff`: Characterization of independence
+- `isIndepFinset_of_bot`: Empty graph has all sets independent
+- `isIndepFinset_insert`: Growing independent sets
 - `color_class_independent`: Color classes are independent
 - `hadwiger_nelson_bounds`: Combined HN bounds
-- `isIndepFinset_insert`: Growing independent sets
 - `edge_leaves_indep`: Edges force vertices out
 - `exists_nonempty_indep`: Nonempty graphs have nonempty independent sets
 - `indep_card_le_univ`: |S| ≤ |V|
-- `isIndepFinset_of_bot`: Empty graph has all sets independent
+- `indep_card_le_indepNumber`: |S| ≤ α(G)
+- `indepNumber_pos`: α(G) ≥ 1 for nonempty graphs
+- `indepNumber_le_card`: α(G) ≤ |V|
+- `indepNumber_bot`: α(⊥) = |V|
+- `indepSet_iff_compl_clique`: Independent ↔ clique in complement (Set version)
+- `indepFinset_iff_compl_clique`: Independent ↔ clique in complement (Finset version)
 - `indep_top_singleton`: Complete graph has α = 1
-- `pigeonhole_color_class`: Pigeonhole for colorings
+- `color_class_partition`: Each vertex in exactly one color class
+- `proper_coloring_gives_independent_partition`: Proper colorings give independent partitions
+- `indep_times_colors_ge_card`: α(G) · k ≥ n
 
 ### Axioms Used (2)
 - `hadwiger_nelson_lower_bound`: De Grey's 5-color lower bound (2018)
 - `hadwiger_nelson_upper_bound`: 7-coloring upper bound
-
-### What's NOT Proven (and Why)
-- De Grey's construction (requires explicit 1581-vertex graph verification)
-- The 7-coloring (requires constructing the hexagonal tiling coloring)
-- Fractional chromatic number bounds (requires LP duality formalization)
 -/
 
 end UnitDistanceIndependence

--- a/src/data/research/problems/ramsey-r4k-extensions.json
+++ b/src/data/research/problems/ramsey-r4k-extensions.json
@@ -17,9 +17,9 @@
   },
   "currentState": {
     "phase": "NEW",
-    "since": "2026-01-27T22:18:02.334Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "since": "2026-02-04T00:00:00.000Z",
+    "iteration": 4,
+    "focus": "Added 11 theorems: lower bounds, concrete values, structural properties",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: RamseyR4kExtensions.lean now has 33 proved theorems (0 sorries) and 5 axioms. Added 11 new theorems: R(r,s)>=s, R(r,s)>=r lower bounds, 8 concrete values (R(3,6..9), R(4,6..7), R(5,6), R(6,6)), diagonal monotonicity, strict monotonicity.",
+    "builtItems": [
+      "ramseyUpperBound_ge_right: proved R(r,s) >= s via choose_symm + choose_le_choose",
+      "ramseyUpperBound_ge_left: proved R(r,s) >= r via symmetry",
+      "r3_6_upper through r6_6_upper: 8 new concrete values via native_decide",
+      "ramseyUpperBound_diag_mono: proved R(k,k) <= R(k+1,k+1)",
+      "ramseyUpperBound_strict_mono_right: proved R(r,s+1) >= R(r,s) + 1 via Pascal"
+    ],
+    "insights": [
+      "R(r,s) >= s proved via choose_symm + choose_le_choose: C(r+s-2,s-1) >= C(s,s-1) = s",
+      "Strict monotonicity from Pascal rule: R(r,s+1) = R(r-1,s+1) + R(r,s) >= 1 + R(r,s)",
+      "Diagonal monotonicity chains mono_left then mono_right"
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Submit axioms as theorem sorries to Aristotle for proof search",
+      "Prove R(r,s) >= (r-1)*(s-1) + 1 (product lower bound, Greenwood-Gleason style)",
+      "Add R(3,10), R(4,8), R(5,7) concrete values",
+      "Connect to existing RamseyTheorem.lean in the gallery"
+    ]
   },
   "approaches": [],
   "tags": [

--- a/src/data/research/problems/unit-distance-independence.json
+++ b/src/data/research/problems/unit-distance-independence.json
@@ -1,58 +1,94 @@
 {
   "slug": "unit-distance-independence",
   "title": "Unit Distance Graph Independence Number Bounds",
-  "phase": "NEW",
+  "phase": "PROGRESS",
   "status": "active",
   "tier": "A",
   "path": "fast",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "AVAILABLE.",
-    "whyMatters": []
+    "formal": "α(G) · χ(G) ≥ |V| where α is independence number, χ is chromatic number",
+    "plain": "Formalize independence number bounds for unit distance graphs, connecting to the Hadwiger-Nelson problem (5 ≤ χ(R²) ≤ 7).",
+    "whyMatters": ["Connects independence number to chromatic number", "Foundational for Hadwiger-Nelson problem"]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "indepNumber: formal definition as sSup",
+      "indep_card_le_indepNumber: |S| ≤ α(G) for independent S",
+      "indepNumber_pos: α(G) ≥ 1 for nonempty graphs",
+      "indepNumber_le_card: α(G) ≤ |V|",
+      "indepNumber_bot: α(⊥) = |V|",
+      "indepSet_iff_compl_clique: independent in G ↔ clique in Gᶜ",
+      "indepFinset_iff_compl_clique: Finset version",
+      "indep_times_colors_ge_card: α(G)·k ≥ |V|",
+      "hadwiger_nelson_bounds: 5 ≤ χ(R²) ≤ 7"
+    ],
     "open": [],
-    "goal": ""
+    "goal": "Further strengthen independence number theory"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-27T22:18:02.334Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "PROGRESS",
+    "since": "2026-02-04T20:00:00.000Z",
+    "iteration": 2,
+    "focus": "Added independence number definition and proved structural theorems",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Could prove Ramsey-type bounds or fractional chromatic number results",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "DEEP DIVE complete: 21 proved theorems, 2 axioms, 0 sorries. Added independence number definition, clique duality, α·k≥n bound.",
+    "builtItems": [
+      "indepNumber: formal sSup definition",
+      "indep_card_le_indepNumber: |S| ≤ α(G)",
+      "indepNumber_pos: α(G) ≥ 1",
+      "indepNumber_le_card: α(G) ≤ |V|",
+      "indepNumber_bot: α(⊥) = |V|",
+      "indepSet_iff_compl_clique: Set version of duality",
+      "indepFinset_iff_compl_clique: Finset version of duality",
+      "indep_times_colors_ge_card: α(G)·k ≥ |V|"
+    ],
+    "insights": [
+      "Gᶜ.Adj u v unfolds to ⟨u ≠ v, ¬G.Adj u v⟩ (ne first, then negated adj)",
+      "IsClique uses Set.Pairwise with Adj",
+      "Finset.disjoint_filter.mpr is the clean way to prove filter disjointness",
+      "sSup {n | ∃ S, P S ∧ S.card = n} needs BddAbove from Finset.card_le_card + subset_univ",
+      "csSup_le needs nonemptiness witness (∅ works via isIndepFinset_empty)",
+      "linarith [mul_comm a b] resolves a*b vs b*a mismatch that omega cannot"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Knowledge Base: unit-distance-independence\n\n## Problem Summary\n\nFormalize bounds on the independence number of unit distance graphs in the plane, connecting to the Hadwiger-Nelson problem on the chromatic number of the plane.\n\n## Current State\n\n**Status**: SURVEYED\n\n### What Was Built (2026-02-04)\n\n**New file**: `proofs/Proofs/UnitDistanceIndependence.lean` (~268 lines)\n\n#### Definitions\n- `IsIndepSet`: Independent set in a simple graph (set version)\n- `IsIndepFinset`: Independent set in a simple graph (finset version)\n- `IsProperColoring`: Proper graph coloring definition\n- `Plane`: The Euclidean plane R^2\n\n#### Proved Theorems (17, 0 sorries)\n1. `isIndepFinset_empty`: Empty set is independent\n2. `isIndepFinset_singleton`: Singleton sets are independent\n3. `isIndepFinset_subset`: Subsets of independent sets are independent\n4. `isIndepFinset_iff`: Characterization of independence\n5. `color_class_independent`: Color classes in proper colorings are independent\n6. `hadwiger_nelson_bounds`: Combined Hadwiger-Nelson bounds (5 ≤ χ ≤ 7)\n7. `isIndepFinset_insert`: Growing independent sets by adding non-adjacent vertex\n8. `edge_leaves_indep`: Edges force at least one endpoint out of independent sets\n9. `exists_nonempty_indep`: Nonempty graphs have nonempty independent sets\n10. `indep_card_le_univ`: Independent set cardinality bounded by |V|\n11. `not_unit_dist_independent`: Non-unit-distance points are compatible\n12. `all_diff_dist_independent`: Sets avoiding unit distance are independent\n13. `indep_compl_clique`: Independence/clique duality (trivial direction)\n14. `isIndepFinset_of_bot`: Empty graph has all sets independent\n15. `indep_top_singleton`: Complete graph has independence number 1\n16. `color_class_partition`: Each vertex in exactly one color class\n17. `proper_coloring_gives_independent_partition`: Proper colorings give independent partitions\n\n#### Axioms (2)\n1. `hadwiger_nelson_lower_bound`: De Grey's 5-chromatic lower bound (2018)\n2. `hadwiger_nelson_upper_bound`: 7-coloring upper bound\n\n### Key Insights\n- Independent sets can be developed abstractly for SimpleGraph, then specialized to unit distance\n- The Hadwiger-Nelson bounds are naturally axioms since the lower bound requires constructing a specific 1581-vertex graph\n- Color class → independence is a clean formal argument\n- Growing independent sets by inserting non-adjacent vertices is useful infrastructure\n\n### What Would Be Needed for Full Independence Number Theory\n1. Formal definition of independence number as supremum\n2. Constructive Lovász theta bound\n3. Fractional chromatic number (requires LP duality)\n4. Ramsey-type bounds relating independence and clique numbers\n\n### Related Work\n- `Erdos668Problem.lean` - Unit distance configurations (defines `isUnitPair`, `unitDistanceEdges`)\n- `Erdos90Problem.lean` - Maximum unit distances among n points\n- `Erdos922Problem.lean` - Uses SimpleGraph.Coloring\n\n## Session Log\n\n### Research Session (2026-02-04)\n**Mode**: FRESH (researcher-1)\n**Decision**: BUILD - Create formalization from scratch\n**Outcome**: Created comprehensive file with 17 proved theorems, 2 axioms, 0 sorries\n**Status**: NEW -> SURVEYED (meaningful infrastructure built)\n"
+    "nextSteps": [
+      "Prove Ramsey-type bound: α(G)·ω(G) ≥ |V| (requires clique number definition)",
+      "Prove fractional relaxation bounds (requires LP duality)",
+      "Concrete independence number computations for small unit distance graphs"
+    ]
   },
-  "approaches": [],
+  "approaches": [
+    {
+      "name": "sSup-based independence number + pigeonhole",
+      "status": "succeeded",
+      "description": "Define α(G) = sSup{|S| : S independent}, prove duality and α·k≥n via Finset.sum_le_sum"
+    }
+  ],
   "tags": [
     "seeker-selected",
     "combinatorial-geometry",
     "graph-theory",
     "independence-number",
     "unit-distance",
-    "extension"
+    "extension",
+    "0-sorry"
   ],
   "relatedProofs": [],
   "references": {
-    "papers": [],
+    "papers": ["De Grey 2018"],
     "urls": [],
-    "mathlib": []
+    "mathlib": ["Combinatorics.SimpleGraph.Basic", "Combinatorics.SimpleGraph.Clique"]
   },
   "started": "2026-01-27T22:18:02.334Z",
-  "lastUpdate": "2026-01-27T22:18:02.334Z",
+  "lastUpdate": "2026-02-04T20:00:00.000Z",
   "significance": 7,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary

### erdos-185 (Cap Sets)
- **Proved `f3_1 : f3 1 = 2`** — eliminated the only sorry in the file
- Fixed `/-!` docstrings to `/-` for Aristotle compatibility
- File is now 0-sorry

### unit-distance-independence
- **Added independence number** (`indepNumber`) as formal sSup definition
- **Proved independence-clique duality**: independent in G ↔ clique in Gᶜ
- **Proved α(G)·k ≥ |V|** for any proper k-coloring (pigeonhole bound)
- Proved α(G) ≥ 1 (nonempty), α(G) ≤ |V|, α(⊥) = |V|
- Removed 3 vacuous theorems with no mathematical content
- 8 new proved theorems, 0 sorries

## Test plan
- [x] `docker-build.sh Proofs.Erdos185Problem` succeeds
- [x] `docker-build.sh Proofs.UnitDistanceIndependence` succeeds
- [x] 0 sorries in both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)