### PR TITLE
Research: sum-of-kth-powers + erdos-185 improvements

### DIFF
--- a/proofs/Proofs/Erdos185Problem.lean
+++ b/proofs/Proofs/Erdos185Problem.lean
@@ -124,12 +124,81 @@ theorem isCapSet_pair (a b : TernaryHypercube n) (hab : a ≠ b) :
   rcases hx with rfl | rfl <;> rcases hy with rfl | rfl <;> rcases hz with rfl | rfl <;>
     simp_all
 
+/-- Subsets of cap sets are cap sets. -/
+theorem isCapSet_subset {S T : Finset (TernaryHypercube n)} (hST : S ⊆ T) (hT : IsCapSet T) :
+    IsCapSet S :=
+  fun x y z hx hy hz hxy hyz hxz => hT x y z (hST hx) (hST hy) (hST hz) hxy hyz hxz
+
+/-- A singleton is a cap set. -/
+theorem isCapSet_singleton (a : TernaryHypercube n) :
+    IsCapSet ({a} : Finset (TernaryHypercube n)) := by
+  intro x _ _ hx hy _
+  simp at hx hy; subst hx; subst hy; intro h; exact absurd rfl h
+
 /--
 **f₃(n):**
 The maximum size of a cap set in {0,1,2}^n.
 -/
 noncomputable def f3 (n : ℕ) : ℕ :=
   sSup { m : ℕ | ∃ S : Finset (TernaryHypercube n), IsCapSet S ∧ S.card = m }
+
+/-- The set of achievable cap set cardinalities is bounded above by 3^n. -/
+private lemma f3_bddAbove (n : ℕ) :
+    BddAbove { m : ℕ | ∃ S : Finset (TernaryHypercube n), IsCapSet S ∧ S.card = m } :=
+  ⟨3^n, fun m hm => by
+    obtain ⟨S, _, rfl⟩ := hm
+    calc S.card ≤ (Finset.univ : Finset (TernaryHypercube n)).card :=
+          Finset.card_le_card (Finset.subset_univ _)
+      _ = Fintype.card (TernaryHypercube n) := by rw [Finset.card_univ]
+      _ = 3^n := hypercube_card n⟩
+
+/-- The set of achievable cap set cardinalities is nonempty (the empty set is always a cap set). -/
+private lemma f3_nonempty (n : ℕ) :
+    (0 : ℕ) ∈ { m : ℕ | ∃ S : Finset (TernaryHypercube n), IsCapSet S ∧ S.card = m } :=
+  ⟨∅, isCapSet_empty, rfl⟩
+
+/-- f₃(0) = 1: the hypercube {0,1,2}^0 has exactly one element. -/
+theorem f3_0 : f3 0 = 1 := by
+  unfold f3
+  apply le_antisymm
+  · apply csSup_le ⟨0, f3_nonempty 0⟩
+    rintro m ⟨S, _, rfl⟩
+    calc S.card ≤ (Finset.univ : Finset (TernaryHypercube 0)).card :=
+          Finset.card_le_card (Finset.subset_univ _)
+      _ = Fintype.card (TernaryHypercube 0) := by rw [Finset.card_univ]
+      _ = 3^0 := hypercube_card 0
+      _ = 1 := by norm_num
+  · apply le_csSup (f3_bddAbove 0)
+    show ∃ S : Finset (TernaryHypercube 0), IsCapSet S ∧ S.card = 1
+    exact ⟨{fun _ => 0}, isCapSet_singleton _, by simp⟩
+
+/-- f₃(n) ≤ 3^n: a cap set cannot be larger than the entire hypercube. -/
+theorem f3_le_three_pow (n : ℕ) : f3 n ≤ 3^n := by
+  unfold f3
+  apply csSup_le ⟨0, f3_nonempty n⟩
+  rintro m ⟨S, _, rfl⟩
+  calc S.card ≤ (Finset.univ : Finset (TernaryHypercube n)).card :=
+        Finset.card_le_card (Finset.subset_univ _)
+    _ = Fintype.card (TernaryHypercube n) := by rw [Finset.card_univ]
+    _ = 3^n := hypercube_card n
+
+/-- f₃(n) ≥ 1 for all n: the singleton {0,...,0} is a cap set. -/
+theorem f3_ge_one (n : ℕ) : f3 n ≥ 1 := by
+  unfold f3
+  apply le_csSup (f3_bddAbove n)
+  show ∃ S : Finset (TernaryHypercube n), IsCapSet S ∧ S.card = 1
+  exact ⟨{fun _ => 0}, isCapSet_singleton _, by simp⟩
+
+/-- f₃(n) ≥ 2 for n ≥ 1: any two distinct points form a cap set, and they exist for n ≥ 1. -/
+theorem f3_ge_two (n : ℕ) (hn : n ≥ 1) : f3 n ≥ 2 := by
+  unfold f3
+  apply le_csSup (f3_bddAbove n)
+  show ∃ S : Finset (TernaryHypercube n), IsCapSet S ∧ S.card = 2
+  have hdist : (fun _ : Fin n => (0 : ZMod 3)) ≠ (fun _ => 1) := by
+    intro h
+    have := congr_fun h ⟨0, by omega⟩
+    simp at this
+  exact ⟨{fun _ => 0, fun _ => 1}, isCapSet_pair _ _ hdist, Finset.card_pair hdist⟩
 
 /-
 ## Part IV: Connection to Arithmetic Progressions
@@ -172,11 +241,14 @@ Taking points with coordinates summing to 0 or 1 (mod 3) gives a large cap set.
 def moserSet (n : ℕ) : Finset (TernaryHypercube n) :=
   Finset.univ.filter (fun x => (Finset.univ.sum x) = 0 ∨ (Finset.univ.sum x) = 1)
 
-/-- The Moser set avoids combinatorial lines (not all collinear triples).
-    Note: The Moser set is NOT a cap set in the `IsCapSet` sense: e.g. for n≥1,
-    the points (0,...,0), (1,...,1), (2,...,2) are all in the Moser set and collinear.
-    It avoids combinatorial lines, which is the relevant notion for Hales-Jewett. -/
-axiom moser_set_is_cap_combinatorial (n : ℕ) : IsCapSetCombinatorial (moserSet n)
+/-
+**Moser set and combinatorial lines:**
+The Moser set does NOT avoid all combinatorial lines.
+Counterexample: for n ≡ 0 mod 3 (e.g., n=3), the diagonal line (0,...,0),(1,...,1),(2,...,2)
+has coordinate sums 0, n, 2n. When 3 | n, all sums ≡ 0, so all are in {0,1} and
+the full line lies in moserSet n. The Moser set only avoids lines where |varying| ≢ 0 (mod 3).
+(Previous axiom moser_set_is_cap_combinatorial was FALSE and has been removed.)
+-/
 
 /-
 ## Part VI: The Main Result - Density Hales-Jewett
@@ -202,9 +274,11 @@ axiom f3_is_little_o :
 /--
 **Equivalent formulation:**
 f₃(n) / 3^n → 0 as n → ∞.
+Derived from f3_is_little_o via IsLittleO.tendsto_div_nhds_zero.
 -/
-axiom f3_density_tends_to_zero :
-    Filter.Tendsto (fun n => (f3 n : ℝ) / 3^n) atTop (nhds 0)
+theorem f3_density_tends_to_zero :
+    Filter.Tendsto (fun n => (f3 n : ℝ) / 3^n) atTop (nhds 0) :=
+  f3_is_little_o.tendsto_div_nhds_zero
 
 /-
 ## Part VII: More Recent Progress

--- a/proofs/Proofs/SumOfKthPowers.lean
+++ b/proofs/Proofs/SumOfKthPowers.lean
@@ -327,7 +327,52 @@ theorem sum_fifth_powers_classical (n : ℕ) :
   have hdvd := twelve_dvd_fifth_sum n
   omega
 
+/- ## Sum of Sixth Powers
+
+The formula ∑i⁶ = n(n+1)(2n+1)(3n⁴+6n³-3n+1)/42
+
+To avoid natural number subtraction, we use:
+  42 * ∑i⁶ + 3n²(n+1)(2n+1) = n(n+1)(2n+1)(3n⁴ + 6n³ + 1)
+-/
+
+/-- **Sum of sixth powers times 42 (rearranged)**
+
+    42 * ∑_{i=0}^{n} i⁶ + 3n²(n+1)(2n+1) = n(n+1)(2n+1)(3n⁴ + 6n³ + 1)
+
+    Rearranged to avoid natural number subtraction. This is equivalent to
+    42 * ∑i⁶ = n(n+1)(2n+1)(3n⁴ + 6n³ - 3n + 1). -/
+theorem sum_sixth_powers_mul_fortytwo (n : ℕ) :
+    42 * ∑ i ∈ range (n + 1), i ^ 6 + 3 * n ^ 2 * (n + 1) * (2 * n + 1) =
+    n * (n + 1) * (2 * n + 1) * (3 * n ^ 4 + 6 * n ^ 3 + 1) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [sum_range_succ, Nat.mul_add]
+    nlinarith [ih]
+
+/-- Helper: 42 divides the RHS minus LHS constant term. -/
+private lemma fortytwo_dvd_sixth_sum (n : ℕ) :
+    42 ∣ (n * (n + 1) * (2 * n + 1) * (3 * n ^ 4 + 6 * n ^ 3 + 1)
+         - 3 * n ^ 2 * (n + 1) * (2 * n + 1)) := by
+  have h := sum_sixth_powers_mul_fortytwo n
+  use ∑ i ∈ range (n + 1), i ^ 6
+  omega
+
+/-- **Sum of sixth powers formula (classical version)**
+
+    ∑_{i=0}^{n} i⁶ = (n(n+1)(2n+1)(3n⁴+6n³+1) - 3n²(n+1)(2n+1)) / 42 -/
+theorem sum_sixth_powers_classical (n : ℕ) :
+    ∑ i ∈ range (n + 1), i ^ 6 =
+    (n * (n + 1) * (2 * n + 1) * (3 * n ^ 4 + 6 * n ^ 3 + 1)
+     - 3 * n ^ 2 * (n + 1) * (2 * n + 1)) / 42 := by
+  have h := sum_sixth_powers_mul_fortytwo n
+  have hdvd := fortytwo_dvd_sixth_sum n
+  omega
+
 /- ## Verification Examples -/
+
+/-- Sum of sixth powers from 0 to 10 -/
+theorem sum_sixth_powers_10 : ∑ i ∈ range 11, i ^ 6 = 1978405 := by native_decide
 
 /-- Sum of squares from 0 to 10: 0² + 1² + ... + 10² = 385 -/
 theorem sum_squares_10 : ∑ i ∈ range 11, i ^ 2 = 385 := by native_decide

--- a/src/data/research/problems/erdos-185.json
+++ b/src/data/research/problems/erdos-185.json
@@ -1,57 +1,114 @@
 {
   "slug": "erdos-185",
   "title": "Cap Sets in {0,1,2}^n",
-  "phase": "NEW",
+  "phase": "PROGRESS",
   "status": "active",
   "tier": "A",
   "path": "fast",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "AVAILABLE.",
-    "whyMatters": []
+    "formal": "f₃(n) = o(3^n) where f₃(n) = max cap set size in {0,1,2}^n",
+    "plain": "Is f₃(n) = o(3^n)? YES - proved via density Hales-Jewett theorem.",
+    "whyMatters": [
+      "Central problem in additive combinatorics (cap set problem)",
+      "Connected to sunflower conjecture, matrix multiplication exponents",
+      "Breakthrough by Ellenberg-Gijswijt (2016) using polynomial method"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "f₃(0) = 1 (proved directly via sSup)",
+      "f₃(1) = 2 (proved: upper bound from pigeonhole, lower bound from pair)",
+      "f₃(n) ≤ 3^n (trivial upper bound)",
+      "f₃(n) ≥ 1 for all n (singleton cap set)",
+      "f₃(n) ≥ 2 for n ≥ 1 (pair cap set)",
+      "f₃(n)/3^n → 0 (derived from f₃ = o(3^n))",
+      "Subsets of cap sets are cap sets",
+      "Full set of {0,1,2}^1 is not a cap set"
+    ],
+    "open": [
+      "f₃(2) = 4, f₃(3) = 9, f₃(4) = 20 (axioms - need enumeration)"
+    ],
+    "goal": "Eliminate remaining axioms where possible; currently 9 axioms, 25 theorems, 0 sorries"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-27T22:18:02.333Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "PROGRESS",
+    "since": "2026-02-04T19:59:00Z",
+    "iteration": 2,
+    "focus": "Converted f3_density_tends_to_zero from axiom to theorem, removed false moser_set_is_cap_combinatorial axiom, added structural theorems.",
+    "activeApproach": "Structural theorem proving with sSup manipulation.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Try proving f3_2 = 4 via enumeration of TernaryHypercube 2 (9 elements). Explore Mathlib for decidable cap set checking.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "25 theorems, 9 axioms, 0 sorries, clean build. Proved f₃(0)=1, f₃(1)=2, structural bounds, derived density convergence from little-o. Identified and removed false Moser axiom.",
+    "builtItems": [
+      "f3_0: f₃(0) = 1",
+      "f3_1: f₃(1) = 2",
+      "f3_le_three_pow: f₃(n) ≤ 3^n",
+      "f3_ge_one: f₃(n) ≥ 1",
+      "f3_ge_two: f₃(n) ≥ 2 for n ≥ 1",
+      "f3_density_tends_to_zero: PROVED from f3_is_little_o via tendsto_div_nhds_zero",
+      "isCapSet_subset: subsets of cap sets are cap sets",
+      "isCapSet_singleton: singletons are cap sets",
+      "hypercube_card: |{0,1,2}^n| = 3^n",
+      "onLine_symm: collinearity symmetric in outer args",
+      "full_set_not_cap: {0,1,2}^1 not a cap set",
+      "capSet1_card_le_2: upper bound for n=1",
+      "erdos_185_answer: ε-δ formulation from little-o"
+    ],
+    "insights": [
+      "IsLittleO.tendsto_div_nhds_zero directly gives Tendsto (f/g) nhds 0 from f =o g",
+      "The Moser set does NOT avoid all combinatorial lines (counterexample: n=3, diagonal line has all sums ≡ 0 mod 3)",
+      "f3 is noncomputable (sSup over Finset cardinalities) so native_decide cannot evaluate f3(n) directly",
+      "For sSup proofs, extract BddAbove and nonempty as helper lemmas to avoid universe issues",
+      "csSup_le needs (Set.Nonempty) as first arg, le_csSup needs (BddAbove) as first arg"
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Prove f3_2 = 4 by explicit enumeration of TernaryHypercube 2",
+      "Try to derive f3_is_little_o from density_hales_jewett_k3 (chain derivation)",
+      "Explore if Ellenberg-Gijswijt bound can be made more precise"
+    ]
   },
-  "approaches": [],
+  "approaches": [
+    {
+      "name": "Structural theorem proving",
+      "status": "active",
+      "description": "Prove concrete values, structural properties, derive corollaries from axioms"
+    }
+  ],
   "tags": [
     "seeker-selected",
     "combinatorics",
     "additive-combinatorics",
     "cap-sets",
-    "1-sorry",
+    "0-sorry",
     "solved"
   ],
   "relatedProofs": [],
   "references": {
-    "papers": [],
-    "urls": [],
-    "mathlib": []
+    "papers": [
+      "Furstenberg-Katznelson (1991): Density Hales-Jewett theorem",
+      "Meshulam (1995): f₃(n) ≤ 3^n/n",
+      "Ellenberg-Gijswijt (2016): f₃(n) ≤ c^n for c < 3"
+    ],
+    "urls": [
+      "https://erdosproblems.com/185"
+    ],
+    "mathlib": [
+      "Mathlib.Data.Fintype.Card",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Analysis.Asymptotics.Defs",
+      "Mathlib.Analysis.Asymptotics.Lemmas"
+    ]
   },
   "started": "2026-01-27T22:18:02.333Z",
-  "lastUpdate": "2026-01-27T22:18:02.333Z",
+  "lastUpdate": "2026-02-04T19:59:00Z",
   "significance": 7,
   "tractability": 7
 }

--- a/src/data/research/problems/sum-of-kth-powers.json
+++ b/src/data/research/problems/sum-of-kth-powers.json
@@ -6,30 +6,42 @@
   "tier": "B",
   "path": "fast",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "AVAILABLE.",
-    "whyMatters": []
+    "formal": "∑_{i=0}^{n} i^k for k=1..6 with closed-form Faulhaber formulas",
+    "plain": "Prove closed-form Faulhaber formulas for sums of consecutive kth powers (k=1 through 6), plus Nicomachus' identity.",
+    "whyMatters": [
+      "Wiedijk's 100 Theorems #77",
+      "Foundation for Bernoulli number theory and Euler-Maclaurin formula"
+    ]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "Sum of 1st powers (Gauss formula): n(n+1)/2",
+      "Sum of squares: n(n+1)(2n+1)/6",
+      "Sum of cubes: [n(n+1)/2]^2 = (sum of 1st powers)^2",
+      "Sum of 4th powers: n(n+1)(2n+1)(3n^2+3n-1)/30",
+      "Sum of 5th powers: n^2(n+1)^2(2n^2+2n-1)/12",
+      "Sum of 6th powers: n(n+1)(2n+1)(3n^4+6n^3-3n+1)/42",
+      "Nicomachus identity: sum of cubes = square of sum"
+    ],
     "open": [],
-    "goal": ""
+    "goal": "Complete Faulhaber formulas for k=1..6 (DONE), potential extension to k=7+"
   },
   "currentState": {
     "phase": "PROGRESS",
-    "since": "2026-02-04T10:30:00.000Z",
-    "iteration": 2,
-    "focus": "Fixed Aristotle compatibility, added structural properties",
+    "since": "2026-02-04T19:50:00Z",
+    "iteration": 3,
+    "focus": "Added sum of 6th powers formula, extending Faulhaber coverage to k=1..6.",
+    "activeApproach": "Inductive proofs with nlinarith for polynomial algebra.",
     "blockers": [],
-    "nextAction": "Add sum of 6th powers or Bernoulli number connection",
+    "nextAction": "Connect to Bernoulli numbers via Mathlib. Consider marking as completed.",
     "attemptCounts": {
-      "total": 2,
+      "total": 3,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: ~30 theorems, 0 axioms, 0 sorries. Complete Faulhaber formulas for powers 1-5, Nicomachus identity, structural properties (monotonicity, bounds, telescoping).",
+    "progressSummary": "40 theorems, 0 axioms, 0 sorries, clean build. Complete Faulhaber formulas for powers 1-6, Nicomachus identity, structural properties, verification examples up to n=100.",
     "builtItems": [
       "sum_first_powers/classical: Gauss formula",
       "sum_squares/classical: n(n+1)(2n+1)/6",
@@ -37,6 +49,7 @@
       "sum_cubes_eq_sum_squared: Nicomachus identity",
       "sum_fourth_powers_classical: n(n+1)(2n+1)(3n^2+3n-1)/30",
       "sum_fifth_powers_classical: n^2(n+1)^2(2n^2+2n-1)/12",
+      "sum_sixth_powers_classical: n(n+1)(2n+1)(3n^4+6n^3-3n+1)/42 [NEW]",
       "sum_pow_le_succ: monotonicity in range",
       "sum_pow_le_mul: upper bound (n+1)*n^k",
       "sum_pow_ge_last: lower bound n^k",
@@ -44,19 +57,26 @@
       "sum_pow_succ_sub: telescoping difference"
     ],
     "insights": [
-      "Avoiding ℕ subtraction by rearranging formulas (e.g., 30*sum + correction = product)",
+      "Avoiding ℕ subtraction by rearranging formulas (e.g., 42*sum + correction = product)",
       "nlinarith handles polynomial induction steps after sum_range_succ expansion",
       "omega resolves final division from multiplied form + divisibility lemma",
-      "All docstrings converted from /-! to /- for Aristotle compatibility"
+      "All docstrings converted from /-! to /- for Aristotle compatibility",
+      "Pattern: for k-th powers, multiply by denominator, rearrange subtraction to addition, prove by induction+nlinarith, derive division form via omega"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Add sum of 6th powers formula",
       "Connect to Bernoulli numbers via Mathlib",
-      "Formalize general Faulhaber polynomial structure"
+      "Formalize general Faulhaber polynomial structure",
+      "Consider extending to 7th powers (denominator 24)"
     ]
   },
-  "approaches": [],
+  "approaches": [
+    {
+      "name": "Inductive Faulhaber formulas",
+      "status": "active",
+      "description": "Prove each power sum by induction with nlinarith, avoiding subtraction via rearrangement"
+    }
+  ],
   "tags": [
     "seeker-selected",
     "number-theory",
@@ -64,16 +84,20 @@
     "series",
     "faulhaber",
     "bernoulli-numbers",
-    "extension"
+    "extension",
+    "0-sorry"
   ],
   "relatedProofs": [],
   "references": {
     "papers": [],
     "urls": [],
-    "mathlib": []
+    "mathlib": [
+      "Mathlib.Algebra.BigOperators.Intervals",
+      "Mathlib.Algebra.BigOperators.Ring.Finset"
+    ]
   },
   "started": "2026-01-27T22:18:02.334Z",
-  "lastUpdate": "2026-02-04T10:30:00.000Z",
+  "lastUpdate": "2026-02-04T19:50:00Z",
   "significance": 6,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary
- **sum-of-kth-powers**: Added sum of 6th powers Faulhaber formula (4 new theorems, 36→40 total)
- **erdos-185**: Eliminated 2 axioms, added 6 theorems, removed false Moser axiom (19→25 theorems, 11→9 axioms)

### sum-of-kth-powers details
- `sum_sixth_powers_mul_fortytwo`, `fortytwo_dvd_sixth_sum`, `sum_sixth_powers_classical`, `sum_sixth_powers_10`
- Pattern: multiply by denominator (42), prove by induction+nlinarith, derive division form via omega

### erdos-185 details
- **Axiom→Theorem**: `f3_density_tends_to_zero` proved via `IsLittleO.tendsto_div_nhds_zero`
- **False axiom removed**: `moser_set_is_cap_combinatorial` is false for n≡0 mod 3 (counterexample: n=3 diagonal line)
- **New theorems**: `f3_0`, `f3_le_three_pow`, `f3_ge_one`, `f3_ge_two`, `isCapSet_subset`, `isCapSet_singleton`

## Test plan
- [x] Docker build succeeded for SumOfKthPowers.lean (0 errors, 0 warnings)
- [x] Docker build succeeded for Erdos185Problem.lean (0 errors, 0 warnings)
- [x] Verification: `sum_sixth_powers_10` confirms ∑i⁶ for i=0..10 = 1978405 via native_decide

🤖 Generated with [Claude Code](https://claude.com/claude-code)