### PR TITLE
feat: track session statistics during daemon operation

### DIFF
--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -165,7 +165,8 @@ init_state() {
                     proofs_submitted: 0,
                     proofs_integrated: 0,
                     problems_selected: 0,
-                    deployments: 0
+                    deployments: 0,
+                    research_completed: 0
                 }
                 end
             )
@@ -875,6 +876,7 @@ process_completion_signals() {
     local integrated=0
     local selected=0
     local deploys=0
+    local researched=0
 
     # Count signals by type (use find to avoid glob expansion issues)
     stubs=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'stub-enhanced-*' -type f 2>/dev/null | wc -l | tr -d ' ')
@@ -882,8 +884,9 @@ process_completion_signals() {
     integrated=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'proof-integrated-*' -type f 2>/dev/null | wc -l | tr -d ' ')
     selected=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'problem-selected-*' -type f 2>/dev/null | wc -l | tr -d ' ')
     deploys=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'deployment-*' -type f 2>/dev/null | wc -l | tr -d ' ')
+    researched=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'research-completed-*' -type f 2>/dev/null | wc -l | tr -d ' ')
 
-    local total=$((stubs + proofs + integrated + selected + deploys))
+    local total=$((stubs + proofs + integrated + selected + deploys + researched))
 
     # Update state file if any completions
     if [[ $total -gt 0 ]]; then
@@ -896,15 +899,17 @@ process_completion_signals() {
                 --argjson integrated "$integrated" \
                 --argjson selected "$selected" \
                 --argjson deploys "$deploys" \
+                --argjson researched "$researched" \
                 '.session_stats.stubs_enhanced += $stubs |
                  .session_stats.proofs_submitted += $proofs |
                  .session_stats.proofs_integrated += $integrated |
                  .session_stats.problems_selected += $selected |
-                 .session_stats.deployments += $deploys' \
+                 .session_stats.deployments += $deploys |
+                 .session_stats.research_completed += $researched' \
                 "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
         fi
 
-        daemon_log "INFO" "Stats updated: +$stubs stubs, +$proofs proofs, +$integrated integrated, +$selected selected, +$deploys deploys"
+        daemon_log "INFO" "Stats updated: +$stubs stubs, +$proofs proofs, +$integrated integrated, +$selected selected, +$deploys deploys, +$researched researched"
 
         # Archive signals (preserve for debugging but don't recount)
         find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'stub-enhanced-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
@@ -912,6 +917,7 @@ process_completion_signals() {
         find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'proof-integrated-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
         find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'problem-selected-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
         find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'deployment-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
+        find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'research-completed-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
     fi
 }
 

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -175,12 +175,14 @@ gather_status() {
     local proofs_submitted=0
     local problems_selected=0
     local deployments=0
+    local research_completed=0
 
     if [[ -f "$STATE_FILE" ]]; then
         stubs_enhanced=$(jq -r '.session_stats.stubs_enhanced // 0' "$STATE_FILE")
         proofs_submitted=$(jq -r '.session_stats.proofs_submitted // 0' "$STATE_FILE")
         problems_selected=$(jq -r '.session_stats.problems_selected // 0' "$STATE_FILE")
         deployments=$(jq -r '.session_stats.deployments // 0' "$STATE_FILE")
+        research_completed=$(jq -r '.session_stats.research_completed // 0' "$STATE_FILE")
     fi
 
     if $JSON_OUTPUT; then
@@ -224,7 +226,8 @@ gather_status() {
     "stubs_enhanced": $stubs_enhanced,
     "proofs_submitted": $proofs_submitted,
     "problems_selected": $problems_selected,
-    "deployments": $deployments
+    "deployments": $deployments,
+    "research_completed": $research_completed
   }
 }
 EOF
@@ -309,6 +312,7 @@ EOF
         echo -e "  ${CYAN}Session Stats:${NC}"
         echo "    Stubs enhanced: $stubs_enhanced"
         echo "    Proofs submitted: $proofs_submitted"
+        echo "    Research completed: $research_completed"
         echo "    Problems selected: $problems_selected"
         echo "    Deployments: $deployments"
 

--- a/scripts/lean/update-stats.sh
+++ b/scripts/lean/update-stats.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# update-stats.sh - Create completion signal files for daemon stats tracking
+#
+# Agents call this script after completing significant work. The daemon
+# polls for these signal files and aggregates them into session_stats.
+#
+# Usage:
+#   ./scripts/lean/update-stats.sh <stat_name> [identifier]
+#
+# Signal types:
+#   stub-enhanced <erdos-number>    Erdős stub was enhanced
+#   proof-submitted <problem-id>    Proof submitted to Aristotle
+#   proof-integrated <problem-id>   Aristotle proof integrated
+#   research-completed <problem-id> Research problem completed
+#   problem-selected [identifier]   New problem selected by seeker
+#   deployment [identifier]         Deployment completed
+#
+# Examples:
+#   ./scripts/lean/update-stats.sh stub-enhanced 42
+#   ./scripts/lean/update-stats.sh proof-submitted erdos-728
+#   ./scripts/lean/update-stats.sh research-completed bounded-prime-gaps
+#   ./scripts/lean/update-stats.sh problem-selected
+#   ./scripts/lean/update-stats.sh deployment
+#
+
+set -euo pipefail
+
+# Find repo root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository" >&2
+    return 1
+}
+
+REPO_ROOT="$(find_repo_root)"
+COMPLETIONS_DIR="$REPO_ROOT/.loom/signals/completions"
+
+usage() {
+    cat <<EOF
+Usage: $0 <stat_name> [identifier]
+
+Create a completion signal file for daemon stats tracking.
+
+Signal types:
+  stub-enhanced <erdos-number>     Erdős stub was enhanced
+  proof-submitted <problem-id>     Proof submitted to Aristotle
+  proof-integrated <problem-id>    Aristotle proof integrated
+  research-completed <problem-id>  Research problem completed
+  problem-selected [identifier]    New problem selected by seeker
+  deployment [identifier]          Deployment completed
+
+Examples:
+  $0 stub-enhanced 42
+  $0 proof-submitted erdos-728
+  $0 research-completed bounded-prime-gaps
+  $0 problem-selected
+  $0 deployment
+EOF
+}
+
+# Validate signal type
+validate_signal_type() {
+    local signal_type="$1"
+    case "$signal_type" in
+        stub-enhanced|proof-submitted|proof-integrated|research-completed|problem-selected|deployment)
+            return 0
+            ;;
+        *)
+            echo "Error: Unknown signal type '$signal_type'" >&2
+            echo "Valid types: stub-enhanced, proof-submitted, proof-integrated, research-completed, problem-selected, deployment" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Main
+if [[ $# -lt 1 ]] || [[ "${1:-}" == "--help" ]] || [[ "${1:-}" == "-h" ]]; then
+    usage
+    exit 1
+fi
+
+signal_type="$1"
+identifier="${2:-}"
+
+validate_signal_type "$signal_type"
+
+# Build signal filename
+mkdir -p "$COMPLETIONS_DIR"
+timestamp=$(date +%s)
+
+if [[ -n "$identifier" ]]; then
+    signal_file="$COMPLETIONS_DIR/${signal_type}-${identifier}-${timestamp}"
+else
+    signal_file="$COMPLETIONS_DIR/${signal_type}-${timestamp}"
+fi
+
+touch "$signal_file"
+echo "Signal created: $(basename "$signal_file")"

--- a/scripts/research/claim-problem.sh
+++ b/scripts/research/claim-problem.sh
@@ -351,6 +351,13 @@ update_problem_status() {
     }
 
     with_pool_lock _update_problem_status_inner
+
+    # Create completion signal when problem is marked completed
+    if [[ "$new_status" == "completed" ]]; then
+        local completions_dir="$REPO_ROOT/.loom/signals/completions"
+        mkdir -p "$completions_dir"
+        touch "$completions_dir/research-completed-$problem_id-$(date +%s)"
+    fi
 }
 
 # Show status

--- a/scripts/research/launch-seeker.sh
+++ b/scripts/research/launch-seeker.sh
@@ -170,6 +170,10 @@ You are the **seeker** agent. Your mission is to keep the research pipeline fed 
      c. Regenerate pool JSON: \`python3 research/db/sync_pool.py\`
      d. Then initialize workspace: \`./.lean/scripts/research.sh init <slug>\`
    - Without steps (a-c), Researchers will NOT see the new problems in candidate-pool.json
+   - **After each problem is selected**, create a completion signal for stats tracking:
+     \`\`\`bash
+     $REPO_ROOT/scripts/lean/update-stats.sh problem-selected
+     \`\`\`
 
 4. **If pool is adequate, report status and wait**
    - Run: \`/seeker --status\` to generate a status report

--- a/scripts/research/parallel-research.sh
+++ b/scripts/research/parallel-research.sh
@@ -161,7 +161,7 @@ sleep ${wait_interval}m
 1. Run one research iteration following the research methodology
 2. Commit and push your progress
 3. Create/update a PR with your findings
-4. Update problem status and release claim
+4. Update problem status and release claim (stats signal is created automatically when status is set to "completed")
 
 ### Step 5: Repeat from Step 1
 


### PR DESCRIPTION
## Summary

- Adds `scripts/lean/update-stats.sh` helper script for agents to create completion signal files
- Adds `research-completed` signal creation to `claim-problem.sh` when researcher marks a problem as completed
- Adds `problem-selected` signal instructions to seeker agent prompt
- Updates daemon's `process_completion_signals()` to count and aggregate `research-completed` signals
- Updates `init_state()` default stats to include `research_completed: 0`
- Updates `status.sh` to read and display `research_completed` in both JSON and human-readable output

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Helper script exists | Done | `scripts/lean/update-stats.sh` created with validation and all signal types |
| Researcher stats tracked | Done | `claim-problem.sh` creates `research-completed` signal on `update <id> completed` |
| Seeker stats tracked | Done | Seeker prompt instructs agent to call `update-stats.sh problem-selected` |
| Daemon processes new signal | Done | `process_completion_signals()` counts `research-completed-*` files |
| Status displays new metric | Done | `status.sh` shows `research_completed` in both JSON and formatted output |
| Existing signals unaffected | Done | All existing signal types (stub-enhanced, proof-submitted, proof-integrated, problem-selected, deployment) unchanged |

## Test plan

- [x] All modified shell scripts pass `bash -n` syntax validation
- [x] `update-stats.sh` --help shows usage correctly
- [x] `update-stats.sh` rejects invalid signal types
- [x] `update-stats.sh research-completed test-id` creates signal file in correct directory
- [x] `pnpm build` succeeds (no web app breakage)

Closes #1524

🤖 Generated with [Claude Code](https://claude.com/claude-code)