### PR TITLE
fix: handle expired Aristotle jobs and allow resubmission

### DIFF
--- a/scripts/aristotle/aristotle-agent.sh
+++ b/scripts/aristotle/aristotle-agent.sh
@@ -6,7 +6,7 @@
 #   ./aristotle-agent.sh              # Run one cycle
 #   ./aristotle-agent.sh --loop       # Run continuously
 #   ./aristotle-agent.sh --interval N # Loop interval in minutes (default: 30)
-#   ./aristotle-agent.sh --target N   # Target active jobs (default: 20)
+#   ./aristotle-agent.sh --target N   # Target active jobs (default: 10)
 #   ./aristotle-agent.sh --status     # Show current status
 #
 # This agent:
@@ -32,7 +32,7 @@ NC='\033[0m'
 # Defaults
 LOOP_MODE=false
 INTERVAL_MINUTES="${ARISTOTLE_INTERVAL:-30}"
-TARGET_ACTIVE="${ARISTOTLE_TARGET:-20}"
+TARGET_ACTIVE="${ARISTOTLE_TARGET:-10}"
 SHOW_STATUS=false
 
 while [[ $# -gt 0 ]]; do
@@ -47,7 +47,7 @@ while [[ $# -gt 0 ]]; do
             echo "Options:"
             echo "  --loop        Run continuously"
             echo "  --interval N  Loop interval in minutes (default: 30)"
-            echo "  --target N    Target active jobs (default: 20)"
+            echo "  --target N    Target active jobs (default: 10)"
             echo "  --status      Show current status and exit"
             exit 0
             ;;
@@ -70,6 +70,7 @@ show_status() {
     local completed=$(jq '[.jobs[] | select(.status == "completed")] | length' "$JOBS_FILE")
     local integrated=$(jq '[.jobs[] | select(.status == "integrated")] | length' "$JOBS_FILE")
     local failed=$(jq '[.jobs[] | select(.status == "failed" or .status == "build_failed")] | length' "$JOBS_FILE")
+    local expired=$(jq '[.jobs[] | select(.status == "expired")] | length' "$JOBS_FILE")
 
     echo "Total jobs: $total"
     echo ""
@@ -77,6 +78,7 @@ show_status() {
     echo "  Completed (pending integration): $completed"
     echo "  Integrated: $integrated"
     echo "  Failed: $failed"
+    echo "  Expired: $expired"
     echo ""
     echo "Target active: $TARGET_ACTIVE"
 

--- a/scripts/aristotle/check-jobs.sh
+++ b/scripts/aristotle/check-jobs.sh
@@ -115,6 +115,7 @@ update_jobs_file() {
         case "$status" in
             COMPLETE) new_status="completed" ;;
             FAILED) new_status="failed" ;;
+            NOT_FOUND) new_status="expired" ;;
             *) continue ;;  # Don't update in-progress jobs
         esac
 
@@ -162,12 +163,14 @@ main() {
         local completed=$(jq '[.jobs[] | select(.status == "completed")] | length' "$JOBS_FILE")
         local integrated=$(jq '[.jobs[] | select(.status == "integrated")] | length' "$JOBS_FILE")
         local failed=$(jq '[.jobs[] | select(.status == "failed")] | length' "$JOBS_FILE")
+        local expired=$(jq '[.jobs[] | select(.status == "expired")] | length' "$JOBS_FILE")
 
         echo ""
         echo "Summary:"
         echo "  Completed: $completed"
         echo "  Integrated: $integrated"
         echo "  Failed: $failed"
+        echo "  Expired: $expired"
         exit 0
     fi
 

--- a/scripts/aristotle/find-candidates.sh
+++ b/scripts/aristotle/find-candidates.sh
@@ -38,7 +38,9 @@ done
 # Get list of already-submitted files
 get_submitted_files() {
     if [[ -f "$JOBS_FILE" ]]; then
-        jq -r '.jobs[].file' "$JOBS_FILE" 2>/dev/null | xargs -I{} basename {} .lean | sort -u
+        # Only exclude files with active or successful jobs
+        # Expired and failed files are eligible for resubmission
+        jq -r '.jobs[] | select(.status == "submitted" or .status == "completed" or .status == "integrated") | .file' "$JOBS_FILE" 2>/dev/null | xargs -I{} basename {} .lean | sort -u
     fi
 }
 

--- a/scripts/aristotle/submit-batch.sh
+++ b/scripts/aristotle/submit-batch.sh
@@ -3,14 +3,14 @@
 # submit-batch.sh - Submit a batch of files to Aristotle
 #
 # Usage:
-#   ./submit-batch.sh                    # Submit up to TARGET (default 20) total active
+#   ./submit-batch.sh                    # Submit up to TARGET (default 10) total active
 #   ./submit-batch.sh --count N          # Submit exactly N files
 #   ./submit-batch.sh --dry-run          # Show what would be submitted
-#   ./submit-batch.sh --target N         # Maintain N active jobs (default 20)
+#   ./submit-batch.sh --target N         # Maintain N active jobs (default 10)
 #
 # Environment:
 #   ARISTOTLE_API_KEY - Required for submission
-#   ARISTOTLE_TARGET  - Target number of active jobs (default 20)
+#   ARISTOTLE_TARGET  - Target number of active jobs (default 10)
 #
 
 set -euo pipefail
@@ -28,7 +28,7 @@ BLUE='\033[0;34m'
 NC='\033[0m'
 
 # Defaults
-TARGET_ACTIVE="${ARISTOTLE_TARGET:-20}"
+TARGET_ACTIVE="${ARISTOTLE_TARGET:-10}"
 SUBMIT_COUNT=0
 DRY_RUN=false
 
@@ -43,7 +43,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --count N    Submit exactly N files"
-            echo "  --target N   Maintain N active jobs (default: 20)"
+            echo "  --target N   Maintain N active jobs (default: 10)"
             echo "  --dry-run    Show what would be submitted"
             exit 0
             ;;


### PR DESCRIPTION
## Summary

- **Map NOT_FOUND → expired** in `check-jobs.sh` so stale "submitted" entries no longer inflate the active job count or block resubmission
- **Allow expired/failed file resubmission** in `find-candidates.sh` by only excluding files with active (`submitted`) or successful (`completed`, `integrated`) jobs
- **Lower default ARISTOTLE_TARGET from 20 to 10** across `submit-batch.sh` and `aristotle-agent.sh` to match observed throughput and reduce waste from server-side expiry
- **Display expired count** in status outputs for both `check-jobs.sh` and `aristotle-agent.sh`

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| NOT_FOUND jobs marked "expired" in aristotle-jobs.json | ✅ | `check-jobs.sh:117` maps `NOT_FOUND` → `expired` |
| Expired/failed files eligible for resubmission | ✅ | `find-candidates.sh:41-43` only excludes `submitted`/`completed`/`integrated` |
| Default ARISTOTLE_TARGET tuned to 10 | ✅ | Both `submit-batch.sh:31` and `aristotle-agent.sh:35` default to 10 |
| Agent loop correctly counts only truly active jobs | ✅ | `count_active_jobs()` in submit-batch.sh already filters `status == "submitted"` only — expired entries excluded automatically |
| Existing integrated/completed jobs remain unaffected | ✅ | No changes to completed/integrated handling logic |

## Test plan

- [ ] Verify `bash -n` passes for all 4 modified scripts (confirmed locally)
- [ ] Manual: Submit a file, wait for expiry, run `check-jobs.sh --update` → status becomes "expired"
- [ ] Manual: After marking expired, run `find-candidates.sh` → file reappears as candidate
- [ ] Manual: Run `submit-batch.sh --dry-run` → expired jobs not counted as active
- [ ] Edge case: File submitted twice (first expired, second completed) — second entry keeps file excluded

Closes #1525

🤖 Generated with [Claude Code](https://claude.com/claude-code)