### PR TITLE
fix: prevent Claude CLI suspension in tmux

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -221,24 +221,25 @@ run_claude_once() {
 
     log_info "Claude CLI timeout set to ${CLAUDE_TIMEOUT}s"
 
-    # Run Claude CLI with timeout to prevent indefinite hangs.
-    # The 'timeout' command sends SIGTERM after CLAUDE_TIMEOUT seconds,
-    # and SIGKILL 30s later if the process hasn't exited.
-    #
-    # NOTE: 'timeout' adds an intermediate process to the tree:
-    #   shell -> claude-wrapper.sh -> timeout -> claude
-    # The health check in launch.sh (find_claude_child) walks the full
-    # process subtree, so additional nesting levels are handled correctly.
+    # IMPORTANT: We write to a temp file and redirect stdin from /dev/null.
+    # Claude CLI tries to set up terminal access during initialization.
+    # When run inside $() command substitution or pipelines in tmux, this
+    # causes SIGTTIN/SIGTTOU signals that suspend the process (state T).
+    # Redirecting stdin from /dev/null and stdout to a file avoids all
+    # TTY interaction issues.
+    local tmpfile
+    tmpfile=$(mktemp)
+
+    timeout --kill-after=30 "$CLAUDE_TIMEOUT" claude -p --dangerously-skip-permissions "$PROMPT" < /dev/null > "$tmpfile" 2>&1
+    exit_code=$?
+
+    # Append to log file if configured
     if [[ -n "$LOG_FILE" ]]; then
-        last_output=$(timeout --kill-after=30 "$CLAUDE_TIMEOUT" claude --dangerously-skip-permissions "$PROMPT" 2>&1 | tee -a "$LOG_FILE"; echo "EXIT_CODE:${PIPESTATUS[0]}")
-    else
-        last_output=$(timeout --kill-after=30 "$CLAUDE_TIMEOUT" claude --dangerously-skip-permissions "$PROMPT" 2>&1; echo "EXIT_CODE:$?")
+        cat "$tmpfile" >> "$LOG_FILE"
     fi
 
-    # Extract exit code from output
-    exit_code=$(echo "$last_output" | grep -o 'EXIT_CODE:[0-9]*' | cut -d: -f2)
-    exit_code="${exit_code:-1}"
-    last_output=$(echo "$last_output" | sed '/EXIT_CODE:[0-9]*/d')
+    last_output=$(cat "$tmpfile")
+    rm -f "$tmpfile"
 
     # Check for timeout (exit code 124 = SIGTERM, 137 = SIGKILL)
     if [[ "$exit_code" -eq 124 ]]; then


### PR DESCRIPTION
## Summary
- Claude CLI processes were getting suspended (state `T`) when run by `claude-wrapper.sh` in tmux sessions
- Root cause: `$()` command substitution + pipe to `tee` caused SIGTTIN/SIGTTOU signals when claude tried terminal access
- Fix: use `-p` (print) mode, redirect stdin from `/dev/null`, write output to temp file instead of `$()` capture

## Test plan
- [x] Tested manually: `timeout --kill-after=5 30 claude -p --dangerously-skip-permissions "Say WORKING" < /dev/null > /tmp/test 2>&1` returns successfully
- [x] Verified all 7 agent processes running in state `S` (not `T`) after restart
- [x] Confirmed agents show real CPU usage (3-8%) instead of 0%

🤖 Generated with [Claude Code](https://claude.com/claude-code)