### PR TITLE
Enhance Erdős #173: Monochromatic Triangles

### DIFF
--- a/proofs/Proofs/Erdos173Problem.lean
+++ b/proofs/Proofs/Erdos173Problem.lean
@@ -1,27 +1,25 @@
-/-
-Erdős Problem #173: Monochromatic Triangles in Plane Colorings
+/-!
+# Erdős Problem #173: Monochromatic Triangles in Plane Colorings
 
-Source: https://erdosproblems.com/173
-Status: OPEN (partial results known)
+**Source:** [erdosproblems.com/173](https://erdosproblems.com/173)
+**Status:** OPEN (partial results known)
 
-Statement:
-In any 2-coloring of R^2, for all but at most one triangle T, there is a
+## Statement
+
+In any 2-coloring of ℝ², for all but at most one triangle T, there is a
 monochromatic congruent copy of T.
 
-Known Results:
-- Shader [Sh76]: All right triangles are Ramsey in R^2 (i.e., every 2-coloring
-  contains a monochromatic copy of any given right triangle)
+## Background
+
+- Shader [Sh76]: All right triangles are Ramsey in ℝ²
 - The equilateral triangle is the natural candidate for the "exceptional" triangle
+- Strip coloring shows equilateral triangles cannot always be placed monochromatically
 
-Key Observation:
-Consider coloring R^2 with alternating horizontal strips of colors. An equilateral
-triangle cannot be placed monochromatically if its height equals the strip width.
-This shows that at least one triangle might need to be excluded.
+## Approach
 
-References:
-- Shader [Sh76]: "All right triangles are Ramsey in E^2!", J. Comb. Th. A (1976)
-- Erdős [Er75f, Er83c]: Original problem statements
-- Erdős-Graham [ErGr79, ErGr80]: Problem collections
+We define plane colorings, triangle congruence, and the Ramsey property. We
+axiomatize Shader's theorem for right triangles and the strip coloring
+counterexample for equilateral triangles, then combine into a summary.
 -/
 
 import Mathlib.Analysis.InnerProductSpace.EuclideanDist
@@ -33,12 +31,10 @@ open EuclideanSpace
 
 namespace Erdos173
 
-/-
-## Part I: Basic Definitions
--/
+/-! ## Part I: Basic Definitions -/
 
 /--
-A 2-coloring of the plane R^2.
+A 2-coloring of the plane ℝ².
 -/
 def PlaneColoring := EuclideanSpace ℝ (Fin 2) → Bool
 
@@ -78,9 +74,7 @@ A triangle is monochromatic under coloring c if all three vertices have the same
 def IsMonochromatic (T : Triangle) (c : PlaneColoring) : Prop :=
   c T.v1 = c T.v2 ∧ c T.v2 = c T.v3
 
-/-
-## Part II: Triangle Types
--/
+/-! ## Part II: Triangle Types -/
 
 /--
 **Equilateral Triangle:**
@@ -100,21 +94,19 @@ def IsRightTriangle (T : Triangle) : Prop :=
   a^2 + b^2 = c^2 ∨ b^2 + c^2 = a^2 ∨ a^2 + c^2 = b^2
 
 /--
-**Isoceles Triangle:**
+**Isosceles Triangle:**
 A triangle with at least two equal sides.
 -/
-def IsIsoceles (T : Triangle) : Prop :=
+def IsIsosceles (T : Triangle) : Prop :=
   sideLengths T 0 = sideLengths T 1 ∨
   sideLengths T 1 = sideLengths T 2 ∨
   sideLengths T 0 = sideLengths T 2
 
-/-
-## Part III: Ramsey Property
--/
+/-! ## Part III: Ramsey Property -/
 
 /--
-**Triangle is Ramsey in R^2:**
-A triangle (shape) T is "Ramsey" if every 2-coloring of R^2 contains a
+**Triangle is Ramsey in ℝ²:**
+A triangle (shape) T is "Ramsey" if every 2-coloring of ℝ² contains a
 monochromatic congruent copy of T.
 -/
 def IsRamseyTriangle (T : Triangle) : Prop :=
@@ -129,15 +121,13 @@ def AlmostAllTrianglesRamsey : Prop :=
     ∀ T : Triangle, (∀ T_exc : Triangle, exceptional = some T_exc → ¬Congruent T T_exc) →
     IsRamseyTriangle T
 
-/-
-## Part IV: Shader's Theorem
--/
+/-! ## Part IV: Shader's Theorem -/
 
 /--
 **Shader's Theorem (1976):**
-All right triangles are Ramsey in R^2.
+All right triangles are Ramsey in ℝ².
 
-Every 2-coloring of R^2 contains a monochromatic congruent copy of any
+Every 2-coloring of ℝ² contains a monochromatic congruent copy of any
 given right triangle.
 -/
 axiom shader_theorem :
@@ -158,13 +148,11 @@ theorem right_345_ramsey (T : Triangle)
   simp only [ha, hb, hc]
   norm_num
 
-/-
-## Part V: The Strip Coloring Example
--/
+/-! ## Part V: The Strip Coloring Example -/
 
 /--
 **Strip Coloring:**
-Color R^2 by alternating horizontal strips of width h.
+Color ℝ² by alternating horizontal strips of width h.
 A point (x, y) is colored based on floor(y/h) mod 2.
 -/
 noncomputable def stripColoring (h : ℝ) (h_pos : h > 0) : PlaneColoring :=
@@ -178,7 +166,7 @@ cannot be placed monochromatically.
 axiom equilateral_not_monochromatic_strip :
     ∀ h : ℝ, h > 0 →
     ∃ T : Triangle, IsEquilateral T ∧
-    sideLengths T 0 = 2 * h / Real.sqrt 3 ∧  -- Side length corresponding to height h
+    sideLengths T 0 = 2 * h / Real.sqrt 3 ∧
     ¬∃ T' : Triangle, Congruent T T' ∧ IsMonochromatic T' (stripColoring h ‹h > 0›)
 
 /--
@@ -187,17 +175,13 @@ This shows that if one equilateral triangle is not Ramsey, the problem's
 -/
 theorem at_most_one_is_tight :
     ∃ T : Triangle, IsEquilateral T ∧ ¬IsRamseyTriangle T := by
-  -- Use h = 1 as a specific strip width
   obtain ⟨T, hEquilateral, _, hNotMono⟩ := equilateral_not_monochromatic_strip 1 one_pos
   refine ⟨T, hEquilateral, ?_⟩
-  -- T is not Ramsey: there exists a coloring with no monochromatic congruent copy
   unfold IsRamseyTriangle
   push_neg
   exact ⟨stripColoring 1 one_pos, hNotMono⟩
 
-/-
-## Part VI: Conjectured Resolution
--/
+/-! ## Part VI: The Conjecture -/
 
 /--
 **Erdős Conjecture:**
@@ -206,32 +190,7 @@ The equilateral triangle is the natural candidate for this exception.
 -/
 axiom erdos_173_conjecture : AlmostAllTrianglesRamsey
 
-/--
-**Stronger Conjecture:**
-Perhaps even the equilateral triangle is Ramsey for "most" colorings,
-and only special colorings like the strip coloring avoid it.
--/
-axiom equilateral_conjecture :
-    ∃ c : PlaneColoring, ∀ T : Triangle, IsEquilateral T → IsRamseyTriangle T
-
-/-
-## Part VII: Related Results
--/
-
-/--
-**Finite Ramsey Statement:**
-For any triangle T and any finite 2-coloring of a sufficiently large region,
-there exists a monochromatic copy of T.
-
-This is the finite version that implies the infinite statement.
--/
-axiom finite_ramsey_triangles (T : Triangle) :
-    ∃ R : ℝ, R > 0 ∧
-    ∀ c : PlaneColoring,
-    ∃ T' : Triangle, Congruent T T' ∧ IsMonochromatic T' c ∧
-    dist T'.v1 (0 : EuclideanSpace ℝ (Fin 2)) < R ∧
-    dist T'.v2 (0 : EuclideanSpace ℝ (Fin 2)) < R ∧
-    dist T'.v3 (0 : EuclideanSpace ℝ (Fin 2)) < R
+/-! ## Part VII: Similarity Invariance -/
 
 /--
 **Similar Triangles:**
@@ -243,15 +202,14 @@ def Similar (T1 T2 : Triangle) : Prop :=
 /--
 **Similarity Class is Ramsey:**
 If one triangle in a similarity class is Ramsey, so are all triangles in that class.
+This is because ℝ² can be scaled arbitrarily, so the Ramsey property depends
+only on shape, not size.
 -/
 axiom similarity_preserves_ramsey :
     ∀ T1 T2 : Triangle, Similar T1 T2 → (IsRamseyTriangle T1 ↔ IsRamseyTriangle T2)
 
-/-
-## Part VIII: Main Results Summary
--/
+/-! ## Part VIII: Summary
 
-/--
 **Erdős Problem #173: Monochromatic Triangles**
 
 Status: OPEN (partial results)
@@ -263,6 +221,7 @@ Summary:
 
 Conjecture: All but at most one triangle is Ramsey.
 -/
+
 theorem erdos_173_summary :
     -- All right triangles are Ramsey
     (∀ T : Triangle, IsRightTriangle T → IsRamseyTriangle T) ∧
@@ -271,10 +230,5 @@ theorem erdos_173_summary :
     -- The conjecture
     AlmostAllTrianglesRamsey :=
   ⟨shader_theorem, at_most_one_is_tight, erdos_173_conjecture⟩
-
-/--
-The main theorem: partial resolution with right triangles solved.
--/
-theorem erdos_173 : True := trivial
 
 end Erdos173

--- a/src/data/proofs/erdos-173/annotations.json
+++ b/src/data/proofs/erdos-173/annotations.json
@@ -1,145 +1,86 @@
 [
   {
-    "id": "ann-e173-header",
+    "id": "ann-173-1",
     "proofId": "erdos-173",
-    "range": { "startLine": 1, "endLine": 25 },
+    "range": { "startLine": 1, "endLine": 32 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "**Erdős Problem #173: Monochromatic Triangles in Plane Colorings**\n\nThis problem belongs to Euclidean Ramsey theory, which studies whether geometric configurations must appear monochromatically in finite colorings of Euclidean space.\n\n**Key Question:**\nIn any 2-coloring of R², for all but at most one triangle T, is there a monochromatic congruent copy of T?\n\n**Known Results:**\n- Shader (1976): All right triangles are Ramsey\n- The equilateral triangle is the candidate exception\n- Strip coloring shows equilateral triangles of specific heights cannot be placed monochromatically",
-    "mathContext": "Euclidean Ramsey theory asks which geometric configurations are unavoidable in colorings. Unlike graph Ramsey theory, the continuous nature of R² requires different techniques.",
+    "content": "**Erdős Problem #173: Monochromatic Triangles in Plane Colorings**\n\nIn any 2-coloring of ℝ², for all but at most one triangle T (up to congruence), there should exist a monochromatic congruent copy of T. The formalization defines plane colorings, triangle congruence via side-length permutations, and the Ramsey property. Shader's theorem (1976) handles right triangles; the strip coloring shows equilateral triangles are problematic.",
+    "mathContext": "This is a problem in Euclidean Ramsey theory. Unlike graph Ramsey theory, the continuous nature of ℝ² introduces geometric constraints. The Ramsey property for a triangle shape means no 2-coloring can avoid monochromatic copies.",
     "significance": "critical",
-    "relatedConcepts": ["Euclidean Ramsey theory", "Plane colorings", "Congruent triangles"]
+    "relatedConcepts": ["Euclidean Ramsey theory", "Plane colorings", "Congruent triangles", "Chromatic geometry"]
   },
   {
-    "id": "ann-e173-coloring",
+    "id": "ann-173-2",
     "proofId": "erdos-173",
-    "range": { "startLine": 40, "endLine": 43 },
+    "range": { "startLine": 39, "endLine": 75 },
     "type": "definition",
-    "title": "Plane Coloring",
-    "content": "**PlaneColoring:**\n\nA 2-coloring of the Euclidean plane R².\n\n**Definition:**\n```lean\ndef PlaneColoring := EuclideanSpace ℝ (Fin 2) → Bool\n```\n\nEach point in the plane is assigned one of two colors (true or false). The challenge is to find monochromatic copies of triangles regardless of how the plane is colored.",
-    "mathContext": "Using Bool for colors is equivalent to using {0, 1} or any two-element set. The key insight is that with only 2 colors, pigeonhole-type arguments become powerful.",
-    "significance": "critical",
-    "relatedConcepts": ["2-colorings", "Euclidean space", "Chromatic problems"]
+    "title": "Core Definitions",
+    "content": "**PlaneColoring:** EuclideanSpace ℝ (Fin 2) → Bool, assigning one of two colors to each point of ℝ². **Triangle:** Three vertices in ℝ² with a nondegeneracy proof (pairwise distinct). **sideLengths:** Extracts three side lengths using Mathlib's dist. **Congruent:** Two triangles are congruent if their side lengths agree up to a permutation σ : Equiv.Perm (Fin 3), formalizing SSS congruence. **IsMonochromatic:** All three vertices share the same color.",
+    "significance": "key"
   },
   {
-    "id": "ann-e173-triangle",
+    "id": "ann-173-3",
     "proofId": "erdos-173",
-    "range": { "startLine": 45, "endLine": 56 },
-    "type": "definition",
-    "title": "Triangle Structure",
-    "content": "**Triangle:**\n\nA triangle defined by three vertices in R² with a nondegeneracy condition.\n\n**Definition:**\n```lean\nstructure Triangle where\n  v1 : EuclideanSpace ℝ (Fin 2)\n  v2 : EuclideanSpace ℝ (Fin 2)\n  v3 : EuclideanSpace ℝ (Fin 2)\n  nondegenerate : v1 ≠ v2 ∧ v2 ≠ v3 ∧ v1 ≠ v3\n```\n\nThe nondegeneracy condition ensures the three vertices are distinct (and implicitly non-collinear for a proper triangle).",
-    "mathContext": "Triangles are characterized up to congruence by their three side lengths. Two triangles with the same side lengths are congruent.",
-    "significance": "critical",
-    "relatedConcepts": ["Vertices", "Nondegeneracy", "Euclidean geometry"]
-  },
-  {
-    "id": "ann-e173-sidelengths",
-    "proofId": "erdos-173",
-    "range": { "startLine": 58, "endLine": 65 },
-    "type": "definition",
-    "title": "Side Lengths",
-    "content": "**sideLengths:**\n\nExtract the three side lengths of a triangle.\n\n**Definition:**\n```lean\nnoncomputable def sideLengths (T : Triangle) : Fin 3 → ℝ\n  | 0 => dist T.v1 T.v2\n  | 1 => dist T.v2 T.v3\n  | 2 => dist T.v1 T.v3\n```\n\nThe three side lengths uniquely determine a triangle up to congruence (SSS congruence theorem).",
-    "mathContext": "Using dist from Mathlib provides the Euclidean distance. The ordering of sides is arbitrary but fixed.",
-    "significance": "key",
-    "relatedConcepts": ["Euclidean distance", "SSS congruence", "Triangle classification"]
-  },
-  {
-    "id": "ann-e173-congruent",
-    "proofId": "erdos-173",
-    "range": { "startLine": 67, "endLine": 72 },
-    "type": "definition",
-    "title": "Congruent Triangles",
-    "content": "**Congruent:**\n\nTwo triangles are congruent if they have the same side lengths (up to permutation).\n\n**Definition:**\n```lean\ndef Congruent (T1 T2 : Triangle) : Prop :=\n  ∃ σ : Equiv.Perm (Fin 3), ∀ i, sideLengths T1 i = sideLengths T2 (σ i)\n```\n\nThe permutation σ accounts for different orderings of the vertices. This is the formal statement of SSS congruence.",
-    "mathContext": "Using Equiv.Perm from Mathlib provides a clean way to express that side lengths match up to reordering.",
-    "significance": "critical",
-    "relatedConcepts": ["SSS congruence", "Permutations", "Geometric equivalence"]
-  },
-  {
-    "id": "ann-e173-monochromatic",
-    "proofId": "erdos-173",
-    "range": { "startLine": 74, "endLine": 79 },
-    "type": "definition",
-    "title": "Monochromatic Triangle",
-    "content": "**IsMonochromatic:**\n\nA triangle is monochromatic under a coloring if all three vertices have the same color.\n\n**Definition:**\n```lean\ndef IsMonochromatic (T : Triangle) (c : PlaneColoring) : Prop :=\n  c T.v1 = c T.v2 ∧ c T.v2 = c T.v3\n```\n\nThis is the key property we seek: finding a congruent copy where all vertices share one color.",
-    "mathContext": "By transitivity of equality, this ensures c(v1) = c(v2) = c(v3), i.e., all three vertices have the same color.",
-    "significance": "critical",
-    "relatedConcepts": ["Vertex coloring", "Monochromatic configurations", "Ramsey property"]
-  },
-  {
-    "id": "ann-e173-types",
-    "proofId": "erdos-173",
-    "range": { "startLine": 81, "endLine": 109 },
+    "range": { "startLine": 83, "endLine": 103 },
     "type": "definition",
     "title": "Triangle Types",
-    "content": "**Triangle Classification:**\n\nThree important triangle types are defined:\n\n1. **IsEquilateral:** All three sides equal\n```lean\ndef IsEquilateral (T : Triangle) : Prop :=\n  sideLengths T 0 = sideLengths T 1 ∧ sideLengths T 1 = sideLengths T 2\n```\n\n2. **IsRightTriangle:** Satisfies Pythagorean theorem\n```lean\ndef IsRightTriangle (T : Triangle) : Prop :=\n  a² + b² = c² ∨ b² + c² = a² ∨ a² + c² = b²\n```\n\n3. **IsIsoceles:** At least two sides equal\n\nThese predicates help classify which triangles are Ramsey.",
-    "mathContext": "Right triangles are particularly important as Shader proved they are all Ramsey. The equilateral triangle is the candidate exception.",
-    "significance": "key",
-    "relatedConcepts": ["Triangle classification", "Pythagorean theorem", "Shader's theorem"]
+    "content": "**IsEquilateral:** All three side lengths equal. **IsRightTriangle:** The Pythagorean relation holds for some permutation of sides (a² + b² = c² ∨ b² + c² = a² ∨ a² + c² = b²). **IsIsosceles:** At least two sides equal. The right triangle predicate is critical for Shader's theorem; the equilateral predicate identifies the candidate exception.",
+    "significance": "key"
   },
   {
-    "id": "ann-e173-ramsey",
+    "id": "ann-173-4",
     "proofId": "erdos-173",
-    "range": { "startLine": 111, "endLine": 130 },
+    "range": { "startLine": 112, "endLine": 122 },
     "type": "definition",
     "title": "Ramsey Property",
-    "content": "**IsRamseyTriangle and AlmostAllTrianglesRamsey:**\n\n**IsRamseyTriangle:**\n```lean\ndef IsRamseyTriangle (T : Triangle) : Prop :=\n  ∀ c : PlaneColoring, ∃ T' : Triangle, Congruent T T' ∧ IsMonochromatic T' c\n```\nA triangle shape is Ramsey if every 2-coloring contains a monochromatic congruent copy.\n\n**AlmostAllTrianglesRamsey:**\n```lean\ndef AlmostAllTrianglesRamsey : Prop :=\n  ∃ exceptional : Option Triangle,\n    ∀ T : Triangle, (∀ T_exc, exceptional = some T_exc → ¬Congruent T T_exc) →\n    IsRamseyTriangle T\n```\nAll but at most one triangle shape is Ramsey.",
-    "mathContext": "The problem asks if AlmostAllTrianglesRamsey holds, with the equilateral triangle as the candidate exception.",
-    "significance": "critical",
-    "relatedConcepts": ["Ramsey theory", "Euclidean Ramsey", "Unavoidable configurations"]
+    "content": "**IsRamseyTriangle T:** For every PlaneColoring c, there exists a triangle T' congruent to T with all vertices monochromatic under c. This is the central notion — a triangle shape is 'Ramsey' if no 2-coloring can avoid it. **AlmostAllTrianglesRamsey:** There exists at most one exceptional triangle shape (formalized via Option Triangle) such that all non-exceptional shapes are Ramsey. The problem asks whether this holds.",
+    "significance": "critical"
   },
   {
-    "id": "ann-e173-shader",
+    "id": "ann-173-5",
     "proofId": "erdos-173",
-    "range": { "startLine": 132, "endLine": 159 },
+    "range": { "startLine": 133, "endLine": 149 },
     "type": "axiom",
-    "title": "Shader's Theorem",
-    "content": "**shader_theorem:**\n\nAll right triangles are Ramsey in R².\n\n**Statement:**\n```lean\naxiom shader_theorem :\n    ∀ T : Triangle, IsRightTriangle T → IsRamseyTriangle T\n```\n\n**Significance:** This 1976 result by Shader handles a large class of triangles. Every 2-coloring of R² contains a monochromatic congruent copy of any given right triangle.\n\n**Example:** The 3-4-5 right triangle is Ramsey (theorem right_345_ramsey).",
-    "mathContext": "Shader's proof uses clever geometric constructions to find monochromatic right triangles. The technique doesn't extend to equilateral triangles.",
-    "significance": "critical",
-    "relatedConcepts": ["Shader 1976", "Right triangles", "Euclidean Ramsey"]
+    "title": "Shader's Theorem (1976)",
+    "content": "**shader_theorem:** All right triangles are Ramsey in ℝ². For any right triangle T and any 2-coloring c, there exists a monochromatic congruent copy of T. The proof by Shader uses geometric constructions exploiting the right angle. **right_345_ramsey:** Concrete application showing the 3-4-5 right triangle is Ramsey, proved by verifying 3² + 4² = 5² via norm_num and applying shader_theorem.",
+    "mathContext": "Shader's result handles a large class of triangles. The technique does not extend to equilateral triangles, which lack the orthogonal structure.",
+    "significance": "critical"
   },
   {
-    "id": "ann-e173-strip",
+    "id": "ann-173-6",
     "proofId": "erdos-173",
-    "range": { "startLine": 161, "endLine": 190 },
+    "range": { "startLine": 158, "endLine": 182 },
     "type": "theorem",
     "title": "Strip Coloring Counterexample",
-    "content": "**stripColoring and equilateral_not_monochromatic_strip:**\n\n**Strip Coloring:**\n```lean\nnoncomputable def stripColoring (h : ℝ) (h_pos : h > 0) : PlaneColoring :=\n  fun p => (Int.floor (p 1 / h) % 2 = 0)\n```\nColor R² with alternating horizontal strips of width h.\n\n**Counterexample:**\n```lean\naxiom equilateral_not_monochromatic_strip :\n    ∀ h : ℝ, h > 0 →\n    ∃ T : Triangle, IsEquilateral T ∧\n    sideLengths T 0 = 2 * h / Real.sqrt 3 ∧\n    ¬∃ T' : Triangle, Congruent T T' ∧ IsMonochromatic T' (stripColoring h ‹h > 0›)\n```\n\nAn equilateral triangle whose height equals the strip width cannot be placed monochromatically.",
-    "mathContext": "This construction shows the equilateral triangle is problematic. If one vertex is in a strip, the other two (at height h above) straddle the strip boundary.",
-    "significance": "critical",
-    "relatedConcepts": ["Counterexamples", "Strip constructions", "Equilateral triangles"]
+    "content": "**stripColoring h h_pos:** Colors ℝ² with alternating horizontal strips of width h, using floor(y/h) mod 2. **equilateral_not_monochromatic_strip:** For any strip width h > 0, there exists an equilateral triangle (with side length 2h/√3, i.e., height exactly h) that cannot be monochromatically placed in the strip coloring. **at_most_one_is_tight:** Derives from the strip coloring with h = 1 that some equilateral triangle is NOT Ramsey, showing the 'at most one exception' bound is tight.",
+    "significance": "critical"
   },
   {
-    "id": "ann-e173-conjecture",
+    "id": "ann-173-7",
     "proofId": "erdos-173",
-    "range": { "startLine": 192, "endLine": 209 },
+    "range": { "startLine": 191, "endLine": 191 },
     "type": "axiom",
-    "title": "Conjectured Resolution",
-    "content": "**erdos_173_conjecture and equilateral_conjecture:**\n\n**Main Conjecture:**\n```lean\naxiom erdos_173_conjecture : AlmostAllTrianglesRamsey\n```\nAll triangles except possibly one (the equilateral triangle) are Ramsey.\n\n**Stronger Conjecture:**\n```lean\naxiom equilateral_conjecture :\n    ∃ c : PlaneColoring, ∀ T : Triangle, IsEquilateral T → IsRamseyTriangle T\n```\nPerhaps even the equilateral triangle is Ramsey for \"most\" colorings, with only special constructions (like strip coloring) avoiding it.",
-    "mathContext": "The problem remains open. Proving or disproving these conjectures would complete our understanding of monochromatic triangles in plane colorings.",
-    "significance": "key",
-    "relatedConcepts": ["Open problems", "Erdős conjectures", "Equilateral exception"]
+    "title": "The Conjecture",
+    "content": "**erdos_173_conjecture : AlmostAllTrianglesRamsey:** The open conjecture that all but at most one triangle shape is Ramsey in ℝ² under 2-colorings. The equilateral triangle is the natural candidate for the exception. This is axiomatized since the problem remains open.",
+    "significance": "key"
   },
   {
-    "id": "ann-e173-similar",
+    "id": "ann-173-8",
     "proofId": "erdos-173",
-    "range": { "startLine": 211, "endLine": 242 },
-    "type": "definition",
-    "title": "Similarity and Related Results",
-    "content": "**Similar and similarity_preserves_ramsey:**\n\n**Similar Triangles:**\n```lean\ndef Similar (T1 T2 : Triangle) : Prop :=\n  ∃ k : ℝ, k > 0 ∧ ∀ i, sideLengths T1 i = k * sideLengths T2 i\n```\nTwo triangles are similar if their side lengths are proportional.\n\n**Similarity Preserves Ramsey:**\n```lean\naxiom similarity_preserves_ramsey :\n    ∀ T1 T2 : Triangle, Similar T1 T2 → (IsRamseyTriangle T1 ↔ IsRamseyTriangle T2)\n```\n\nThe Ramsey property depends only on shape, not size. This is why we speak of \"triangle shapes\" being Ramsey.",
-    "mathContext": "Since R² can be scaled arbitrarily, similar triangles have identical Ramsey status. This reduces the problem to studying similarity classes.",
-    "significance": "key",
-    "relatedConcepts": ["Similarity", "Scale invariance", "Shape classification"]
+    "range": { "startLine": 199, "endLine": 209 },
+    "type": "concept",
+    "title": "Similarity Invariance",
+    "content": "**Similar T1 T2:** Side lengths are proportional (∃ k > 0, ∀ i, sideLengths T1 i = k · sideLengths T2 i). **similarity_preserves_ramsey:** The Ramsey property is invariant under similarity — if T1 is Ramsey and T2 is similar to T1, then T2 is also Ramsey (and vice versa). This holds because ℝ² can be scaled arbitrarily, so the Ramsey property depends only on triangle shape, not size.",
+    "significance": "key"
   },
   {
-    "id": "ann-e173-summary",
+    "id": "ann-173-9",
     "proofId": "erdos-173",
-    "range": { "startLine": 244, "endLine": 275 },
+    "range": { "startLine": 225, "endLine": 232 },
     "type": "theorem",
-    "title": "Main Results Summary",
-    "content": "**erdos_173_summary:**\n\nCombines all main results:\n\n```lean\ntheorem erdos_173_summary :\n    -- All right triangles are Ramsey\n    (∀ T : Triangle, IsRightTriangle T → IsRamseyTriangle T) ∧\n    -- At most one exception is tight\n    (∃ T : Triangle, IsEquilateral T ∧ ¬IsRamseyTriangle T) ∧\n    -- The conjecture\n    AlmostAllTrianglesRamsey\n```\n\n**Status:**\n1. Right triangles: All Ramsey (Shader 1976) ✓\n2. Equilateral triangle: Possibly the only exception\n3. Problem remains OPEN for complete resolution",
-    "mathContext": "This open problem connects to broader questions in Euclidean Ramsey theory about which geometric configurations are unavoidable.",
-    "significance": "critical",
-    "relatedConcepts": ["Summary theorem", "Partial resolution", "Open problem"]
+    "title": "Summary Theorem",
+    "content": "**erdos_173_summary:** Packages three results: (1) all right triangles are Ramsey (shader_theorem), (2) the 'at most one exception' bound is tight (at_most_one_is_tight shows some equilateral triangle is not Ramsey), and (3) the open conjecture (erdos_173_conjecture). The proof is a direct tuple construction.",
+    "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-173/meta.json
+++ b/src/data/proofs/erdos-173/meta.json
@@ -42,23 +42,21 @@
       }
     ],
     "originalContributions": [
-      "PlaneColoring definition for 2-colorings",
+      "PlaneColoring definition for 2-colorings of ℝ²",
       "Triangle structure with vertices and nondegeneracy",
-      "sideLengths function extracting three sides",
-      "Congruent definition via side length permutation",
-      "IsMonochromatic definition for triangles",
-      "IsEquilateral, IsRightTriangle, IsIsoceles predicates",
-      "IsRamseyTriangle definition for Ramsey property",
-      "AlmostAllTrianglesRamsey statement",
+      "sideLengths, Congruent, IsMonochromatic definitions",
+      "IsEquilateral, IsRightTriangle, IsIsosceles predicates",
+      "IsRamseyTriangle and AlmostAllTrianglesRamsey definitions",
       "shader_theorem axiom: right triangles are Ramsey",
-      "stripColoring explicit counterexample construction",
-      "equilateral_not_monochromatic_strip axiom",
-      "Similar definition and similarity_preserves_ramsey",
-      "erdos_173_summary main results"
+      "right_345_ramsey: concrete example from shader_theorem",
+      "stripColoring construction and equilateral_not_monochromatic_strip",
+      "at_most_one_is_tight theorem from strip coloring",
+      "Similar definition and similarity_preserves_ramsey axiom",
+      "erdos_173_summary combining all results"
     ]
   },
   "overview": {
-    "historicalContext": "**Erdos Problem #173: Euclidean Ramsey Theory**\n\nThis problem belongs to Euclidean Ramsey theory, which studies whether geometric configurations must appear monochromatically in finite colorings of Euclidean space.\n\n**Key History:**\n- Erdos [Er75f, Er83c]: Posed the problem about monochromatic triangles\n- Shader [Sh76]: Proved all right triangles are Ramsey in R^2\n- Erdos-Graham [ErGr79, ErGr80]: Collected and extended the problem\n\n**Mathematical Setting:**\nGiven a 2-coloring of all points in R^2, we ask whether every triangle shape has a monochromatic congruent copy somewhere in the plane. The strip coloring example shows the equilateral triangle is problematic.",
+    "historicalContext": "This problem belongs to Euclidean Ramsey theory, which studies whether geometric configurations must appear monochromatically in finite colorings of Euclidean space. Erdős posed the problem [Er75f, Er83c] asking whether, in any 2-coloring of ℝ², all but at most one triangle shape (up to congruence) must have a monochromatic congruent copy somewhere in the plane.\n\nThe most significant partial result is due to Shader [Sh76, 1976], who proved that all right triangles are Ramsey in ℝ² — that is, for any right triangle T and any 2-coloring of the plane, there exists a monochromatic congruent copy of T. The proof uses geometric constructions that exploit the right angle structure.\n\nThe equilateral triangle is the natural candidate for the exceptional triangle. A simple strip coloring — alternating horizontal bands of two colors — shows that equilateral triangles whose height matches the strip width cannot be placed monochromatically. However, this does not prove the equilateral triangle is not Ramsey (since the same triangle at a different scale might still be placeable). The problem remains open.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nIn any 2-coloring of $\\mathbb{R}^2$, for all but at most one triangle $T$, there is a monochromatic congruent copy of $T$.\n\n**Known Results:**\n- All right triangles are Ramsey (Shader 1976)\n- The equilateral triangle is the candidate exception\n\n**Counterexample Idea:**\nColor $\\mathbb{R}^2$ with alternating horizontal strips. An equilateral triangle of the right height cannot be placed monochromatically.",
     "proofStrategy": "**Formalization Approach**\n\n1. **Basic Structures:**\n   - PlaneColoring: R^2 -> Bool\n   - Triangle: Three vertices with nondegeneracy\n   - Congruent, IsMonochromatic predicates\n\n2. **Triangle Types:**\n   - IsEquilateral, IsRightTriangle, IsIsoceles\n   - sideLengths to characterize congruence classes\n\n3. **Ramsey Property:**\n   - IsRamseyTriangle: Every coloring has monochromatic copy\n   - AlmostAllTrianglesRamsey: At most one exception\n\n4. **Key Results:**\n   - shader_theorem: Right triangles are Ramsey\n   - stripColoring: Counterexample for equilateral",
     "keyInsights": [
@@ -74,57 +72,57 @@
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "summary": "PlaneColoring, Triangle, sideLengths, Congruent, IsMonochromatic",
-      "startLine": 36,
-      "endLine": 79
+      "startLine": 34,
+      "endLine": 75
     },
     {
       "id": "triangle-types",
       "title": "Triangle Types",
-      "summary": "IsEquilateral, IsRightTriangle, IsIsoceles predicates",
-      "startLine": 81,
-      "endLine": 109
+      "summary": "IsEquilateral, IsRightTriangle, IsIsosceles predicates",
+      "startLine": 77,
+      "endLine": 103
     },
     {
       "id": "ramsey-property",
       "title": "Ramsey Property",
       "summary": "IsRamseyTriangle, AlmostAllTrianglesRamsey definitions",
-      "startLine": 111,
-      "endLine": 130
+      "startLine": 105,
+      "endLine": 122
     },
     {
       "id": "shader-theorem",
       "title": "Shader's Theorem",
-      "summary": "shader_theorem axiom, right_345_ramsey example",
-      "startLine": 132,
-      "endLine": 159
+      "summary": "shader_theorem axiom and right_345_ramsey example",
+      "startLine": 124,
+      "endLine": 149
     },
     {
       "id": "strip-coloring",
       "title": "Strip Coloring Example",
-      "summary": "stripColoring, equilateral_not_monochromatic_strip",
-      "startLine": 161,
-      "endLine": 190
+      "summary": "stripColoring, equilateral counterexample, at_most_one_is_tight",
+      "startLine": 151,
+      "endLine": 182
     },
     {
       "id": "conjecture",
-      "title": "Conjectured Resolution",
-      "summary": "erdos_173_conjecture, equilateral_conjecture",
-      "startLine": 192,
+      "title": "The Conjecture",
+      "summary": "erdos_173_conjecture: AlmostAllTrianglesRamsey",
+      "startLine": 184,
+      "endLine": 191
+    },
+    {
+      "id": "similarity",
+      "title": "Similarity Invariance",
+      "summary": "Similar definition and similarity_preserves_ramsey axiom",
+      "startLine": 193,
       "endLine": 209
     },
     {
-      "id": "related",
-      "title": "Related Results",
-      "summary": "finite_ramsey_triangles, Similar, similarity_preserves_ramsey",
+      "id": "summary",
+      "title": "Summary",
+      "summary": "erdos_173_summary combining shader, strip coloring, and conjecture",
       "startLine": 211,
-      "endLine": 242
-    },
-    {
-      "id": "main-results",
-      "title": "Main Results Summary",
-      "summary": "erdos_173_summary combining all results",
-      "startLine": 244,
-      "endLine": 275
+      "endLine": 234
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove 1 `True := trivial` (erdos_173), 1 incoherent axiom (equilateral_conjecture), and 1 mathematically incorrect axiom (finite_ramsey_triangles)
- Fix section headers from `/-` to `/-!` doc comments
- Fix spelling: `IsIsoceles` → `IsIsosceles`
- Reduce Lean file from 281 to 234 lines
- Update meta.json with 3-paragraph historicalContext and corrected section line numbers
- Rewrite annotations.json with 9 substantive entries

## Quality fixes
- Removed: `erdos_173 : True := trivial` (hollow theorem)
- Removed: `equilateral_conjecture` (stated ∃ coloring making equilateral Ramsey, but IsRamseyTriangle already quantifies over all colorings — incoherent)
- Removed: `finite_ramsey_triangles` (claimed finite Ramsey for ALL triangles, contradicting the problem's equilateral exception)
- Preserved: all core definitions, shader_theorem, right_345_ramsey, stripColoring, at_most_one_is_tight, erdos_173_conjecture, similarity_preserves_ramsey, erdos_173_summary

## Test plan
- [x] `pnpm build` passes
- [x] 0 `sorry` instances
- [x] 0 `True := trivial` instances
- [x] 9 substantive annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)