### PR TITLE
Enhance Erdős #534: Maximum GCD-Intersecting Sets

### DIFF
--- a/proofs/Proofs/Erdos534Problem.lean
+++ b/proofs/Proofs/Erdos534Problem.lean
@@ -1,29 +1,25 @@
-/-
-Erdős Problem #534: Maximum GCD-Intersecting Sets Containing N
+/-!
+# Erdős Problem #534: Maximum GCD-Intersecting Sets Containing N
 
-Source: https://erdosproblems.com/534
-Status: SOLVED (Ahlswede-Khachatrian 1996)
+**Source:** [erdosproblems.com/534](https://erdosproblems.com/534)
+**Status:** SOLVED (Ahlswede-Khachatrian, 1996)
 
-Statement:
+## Statement
+
 What is the largest subset A ⊆ {1,...,N} containing N such that
 gcd(a,b) > 1 for all distinct a, b ∈ A?
 
-Answer:
-For N = q₁^k₁ ⋯ qᵣ^kᵣ (distinct primes), the maximum is achieved by
-integers in [1,N] that are multiples of at least one element from
-{2q₁,...,2qⱼ, q₁⋯qⱼ} for some 1 ≤ j ≤ r.
+## Background
 
-History:
 - Original Erdős-Graham conjecture: max is N/p or #{2t : t ≤ N/2, gcd(2t,N) > 1}
 - Ahlswede-Khachatrian (1992): Found counterexample
 - Ahlswede-Khachatrian (1996): Proved the refined characterization
 
-References:
-- Erdős [Er73]
-- Ahlswede-Khachatrian [AhKh96]
-- Related: Problem 56, OEIS A387543, A387698
+## Approach
 
-Tags: number-theory, gcd, intersecting-families, solved
+We define GCD-intersecting sets, state the original (false) conjecture,
+define the optimal family construction, and axiomatize the
+Ahlswede-Khachatrian theorem with special cases.
 -/
 
 import Mathlib.Data.Nat.GCD.Basic
@@ -36,9 +32,7 @@ open Nat Finset
 
 namespace Erdos534
 
-/-!
-## Part 1: Basic Definitions
--/
+/-! ## Part 1: Basic Definitions -/
 
 /-- The interval {1, ..., N} -/
 def interval (N : ℕ) : Finset ℕ := (Finset.range N).map ⟨(· + 1), fun _ _ h => by omega⟩
@@ -55,9 +49,7 @@ noncomputable def maxGCDIntersecting (N : ℕ) : ℕ :=
   sSup {k : ℕ | ∃ A : Finset ℕ, A ⊆ interval N ∧ ContainsN A N ∧
         IsGCDIntersecting A ∧ A.card = k}
 
-/-!
-## Part 2: Simple Upper Bounds
--/
+/-! ## Part 2: Simple Constructions -/
 
 /-- All multiples of smallest prime factor p -/
 def multiplesOfSmallestPrime (N : ℕ) : Finset ℕ :=
@@ -72,10 +64,6 @@ axiom multiples_of_p_size :
 axiom multiples_of_p_intersecting :
   ∀ N : ℕ, N > 1 → IsGCDIntersecting (multiplesOfSmallestPrime N)
 
-/-!
-## Part 3: The Even Multiples Construction
--/
-
 /-- Even numbers that share a factor with N -/
 def evenMultiplesSharing (N : ℕ) : Finset ℕ :=
   (interval N).filter (fun n => 2 ∣ n ∧ Nat.gcd n N > 1)
@@ -84,9 +72,7 @@ def evenMultiplesSharing (N : ℕ) : Finset ℕ :=
 axiom even_multiples_intersecting :
   ∀ N : ℕ, N > 1 → IsGCDIntersecting (evenMultiplesSharing N)
 
-/-!
-## Part 4: The Original Conjecture (WRONG)
--/
+/-! ## Part 3: The Original Conjecture (WRONG) -/
 
 /-- Erdős-Graham original conjecture -/
 def OriginalConjecture : Prop :=
@@ -97,141 +83,68 @@ def OriginalConjecture : Prop :=
 axiom original_conjecture_false :
   ¬OriginalConjecture
 
-/-- Example counterexample -/
+/-- There exists a specific N where the maximum exceeds both candidates -/
 axiom counterexample_exists :
   ∃ N : ℕ, N > 1 ∧
     maxGCDIntersecting N > max (N / N.minFac) (evenMultiplesSharing N).card
 
-/-!
-## Part 5: The Correct Characterization
--/
+/-! ## Part 4: The Correct Characterization -/
 
-/-- The optimal construction family for N = q₁^k₁ ⋯ qᵣ^kᵣ -/
+/-- The optimal construction family for N = q₁^k₁ ⋯ qᵣ^kᵣ.
+    Integers in [1,N] that are multiples of at least one of:
+    2q₁, 2q₂, ..., 2qⱼ, or q₁·q₂·...·qⱼ -/
 def optimalFamily (N : ℕ) (j : ℕ) (primes : List ℕ) : Finset ℕ :=
-  -- Integers in [1,N] that are multiples of at least one of:
-  -- 2q₁, 2q₂, ..., 2qⱼ, or q₁·q₂·...·qⱼ
   let firstJ := primes.take j
-  let twoTimesPrimes := firstJ.map (2 * ·)  -- {2q₁, ..., 2qⱼ}
-  let productOfFirstJ := firstJ.foldl (· * ·) 1  -- q₁·q₂·...·qⱼ
+  let twoTimesPrimes := firstJ.map (2 * ·)
+  let productOfFirstJ := firstJ.foldl (· * ·) 1
   (interval N).filter fun n =>
     (twoTimesPrimes.any (· ∣ n)) ∨ (productOfFirstJ ∣ n)
 
-/-- The maximum is achieved by one of these families -/
+/-- The maximum is achieved by one of these families (Ahlswede-Khachatrian 1996) -/
 axiom ahlswede_khachatrian_theorem :
   ∀ N : ℕ, N > 1 →
     ∃ j : ℕ, ∃ primes : List ℕ,
-      -- primes are the distinct prime factors of N
       (∀ p ∈ primes, p.Prime ∧ p ∣ N) ∧
       maxGCDIntersecting N = (optimalFamily N j primes).card
 
-/-- The optimal j depends on the structure of N -/
-axiom optimal_j_choice :
-  -- For each N, there's an optimal j ∈ {1, ..., ω(N)}
-  -- where ω(N) is the number of distinct prime factors
-  True
+/-! ## Part 5: Special Cases -/
 
-/-!
-## Part 6: Special Cases
--/
-
-/-- When N is a prime power p^k -/
+/-- When N is a prime power p^k, the maximum is p^(k-1) -/
 axiom prime_power_case :
   ∀ p k : ℕ, p.Prime → k ≥ 1 →
     maxGCDIntersecting (p^k) = p^(k-1)
 
-/-- When N = 2p for odd prime p -/
+/-- When N = 2p for odd prime p, the maximum is 2 -/
 axiom two_times_prime_case :
   ∀ p : ℕ, p.Prime → p > 2 →
     maxGCDIntersecting (2 * p) = 2
 
-/-- When N is squarefree -/
-axiom squarefree_case :
-  ∀ N : ℕ, Squarefree N →
-    -- The structure simplifies
-    True
+/-! ## Part 6: Summary
 
-/-!
-## Part 7: Structure of Optimal Sets
--/
+**Erdős Problem #534: SOLVED** (Ahlswede-Khachatrian 1996)
 
-/-- All optimal sets contain all multiples of the product q₁⋯qⱼ -/
-axiom optimal_contains_multiples :
-  -- The product of the first j primes divides every element
-  -- or is 2 times a factor
-  True
-
-/-- The trade-off between j values -/
-axiom j_tradeoff :
-  -- Larger j: more elements via 2qᵢ terms
-  -- Smaller j: more elements via q₁⋯qⱼ multiples
-  -- Optimal j balances these
-  True
-
-/-!
-## Part 8: Connection to Intersecting Families
--/
-
-/-- Relation to Erdős-Ko-Rado type problems -/
-axiom ekr_connection :
-  -- GCD > 1 is analogous to "shares an element" in set systems
-  -- This is an arithmetic version of intersecting family problems
-  True
-
-/-- Relation to Problem 56 -/
-axiom problem_56_relation :
-  -- Problem 56 asks about similar questions
-  True
-
-/-!
-## Part 9: Computational Aspects
--/
-
-/-- OEIS A387543: Related sequence -/
-axiom oeis_a387543 :
-  -- Sequence of maxGCDIntersecting(N) for various N
-  True
-
-/-- Computing the optimal family -/
-axiom computation :
-  -- Given N and its factorization, can compute optimal j efficiently
-  True
-
-/-!
-## Part 10: Summary
--/
-
-/-- The complete characterization -/
-theorem erdos_534_characterization :
-    -- Original conjecture is false
-    ¬OriginalConjecture ∧
-    -- Correct answer involves choosing optimal j
-    (∀ N : ℕ, N > 1 → ∃ j primes, True) ∧
-    -- Proven by Ahlswede-Khachatrian
-    True := by
-  constructor
-  · exact original_conjecture_false
-  · exact ⟨fun _ _ => ⟨1, [], trivial⟩, trivial⟩
-
-/-- **Erdős Problem #534: SOLVED**
-
-PROBLEM: What is the largest A ⊆ {1,...,N} containing N with gcd(a,b) > 1
+**Question:** What is the largest A ⊆ {1,...,N} containing N with gcd(a,b) > 1
 for all distinct a, b ∈ A?
 
-ANSWER: For N = q₁^k₁ ⋯ qᵣ^kᵣ, the maximum is achieved by integers
+**Answer:** For N = q₁^k₁ ⋯ qᵣ^kᵣ, the maximum is achieved by integers
 that are multiples of elements from {2q₁,...,2qⱼ, q₁⋯qⱼ} for optimal j.
 
-HISTORY:
+**History:**
 - Original Erdős-Graham conjecture was wrong
 - Ahlswede-Khachatrian (1992) found counterexample
 - Ahlswede-Khachatrian (1996) proved correct characterization
-
-KEY INSIGHT: The optimal construction balances between using
-"2 times prime" factors and the product of several primes.
 -/
-theorem erdos_534_solved : True := trivial
 
-/-- Problem status -/
-def erdos_534_status : String :=
-  "SOLVED - Ahlswede-Khachatrian (1996), original conjecture was wrong"
+theorem erdos_534_summary :
+    -- Original conjecture is false
+    ¬OriginalConjecture ∧
+    -- A counterexample exists
+    (∃ N : ℕ, N > 1 ∧
+      maxGCDIntersecting N > max (N / N.minFac) (evenMultiplesSharing N).card) ∧
+    -- Correct characterization exists for all N > 1
+    (∀ N : ℕ, N > 1 → ∃ j primes,
+      (∀ p ∈ primes, p.Prime ∧ p ∣ N) ∧
+      maxGCDIntersecting N = (optimalFamily N j primes).card) := by
+  exact ⟨original_conjecture_false, counterexample_exists, ahlswede_khachatrian_theorem⟩
 
 end Erdos534

--- a/src/data/proofs/erdos-534/annotations.json
+++ b/src/data/proofs/erdos-534/annotations.json
@@ -1,90 +1,68 @@
 [
   {
-    "id": "ann-e534-header",
+    "id": "ann-534-1",
     "proofId": "erdos-534",
-    "range": { "startLine": 1, "endLine": 27 },
+    "range": { "startLine": 1, "endLine": 33 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "**Erdős Problem #534: Maximum GCD-Intersecting Sets**\n\nWhat is the largest subset A ⊆ {1,...,N} containing N such that gcd(a,b) > 1 for all distinct a,b ∈ A?\n\n**Status:** SOLVED (Ahlswede-Khachatrian 1996)\n\n**Key Result:** The original Erdős-Graham conjecture was WRONG. The correct answer uses multiples of {2q₁,...,2qⱼ, q₁⋯qⱼ}.",
-    "mathContext": "This is an arithmetic version of intersecting families, where gcd > 1 plays the role of 'shares an element'.",
+    "content": "**Erdős Problem #534: Maximum GCD-Intersecting Sets**\n\nWhat is the largest A ⊆ {1,...,N} containing N with gcd(a,b) > 1 for all distinct a,b ∈ A? The original Erdős-Graham conjecture was WRONG — Ahlswede-Khachatrian found a counterexample (1992) and proved the correct characterization (1996) using optimal families based on prime factorization of N.",
+    "mathContext": "This is an arithmetic version of intersecting family problems (Erdős-Ko-Rado type), where gcd > 1 replaces 'shares an element'. The optimization is over subsets of {1,...,N} containing N.",
     "significance": "critical",
-    "relatedConcepts": ["GCD", "Intersecting families", "Number theory"]
+    "relatedConcepts": ["GCD", "Intersecting families", "Erdős-Ko-Rado", "Number theory"]
   },
   {
-    "id": "ann-e534-definitions",
+    "id": "ann-534-2",
     "proofId": "erdos-534",
-    "range": { "startLine": 39, "endLine": 56 },
+    "range": { "startLine": 37, "endLine": 50 },
     "type": "definition",
-    "title": "Basic Definitions",
-    "content": "**interval N:** The set {1, ..., N}.\n\n**IsGCDIntersecting A:** For all distinct a,b ∈ A, gcd(a,b) > 1.\n\n**ContainsN A N:** N ∈ A.\n\n**maxGCDIntersecting N:** The supremum of sizes of valid sets.",
-    "mathContext": "These definitions set up the optimization problem: maximize |A| subject to A ⊆ {1,...,N}, N ∈ A, and pairwise gcd > 1.",
-    "significance": "critical",
-    "relatedConcepts": ["GCD", "Finset", "Optimization"]
+    "title": "Core Definitions",
+    "content": "**interval N:** {1,...,N} as a Finset via range.map with +1 shift. **IsGCDIntersecting A:** For all distinct a,b ∈ A, Nat.gcd a b > 1 — every pair shares a common factor. **ContainsN A N:** N ∈ A. **maxGCDIntersecting N:** The supremum of {|A| : A ⊆ interval N, N ∈ A, A is GCD-intersecting}, using sSup on the set of achievable cardinalities.",
+    "significance": "key"
   },
   {
-    "id": "ann-e534-multiples-p",
+    "id": "ann-534-3",
     "proofId": "erdos-534",
-    "range": { "startLine": 58, "endLine": 73 },
+    "range": { "startLine": 54, "endLine": 73 },
     "type": "definition",
-    "title": "Multiples of Smallest Prime",
-    "content": "**multiplesOfSmallestPrime N:**\n\nAll multiples of p = minFac(N) in {1,...,N}.\n\nThis gives a GCD-intersecting set of size N/p.\n\n**Example:** For N = 12, p = 2, giving {2,4,6,8,10,12} with 6 elements.",
-    "mathContext": "All elements share the factor p, so any pair has gcd ≥ p > 1.",
-    "significance": "key",
-    "relatedConcepts": ["Prime factors", "Divisibility"]
+    "title": "Simple Constructions",
+    "content": "**multiplesOfSmallestPrime N:** All multiples of p = minFac(N) in {1,...,N}. This set has size N/p and is GCD-intersecting since all elements share factor p. **evenMultiplesSharing N:** Even numbers in {1,...,N} that also share a factor with N. All pairs have gcd ≥ 2 (both even). These two constructions represent the two candidates from the original (incorrect) conjecture.",
+    "significance": "key"
   },
   {
-    "id": "ann-e534-even-multiples",
+    "id": "ann-534-4",
     "proofId": "erdos-534",
-    "range": { "startLine": 75, "endLine": 85 },
-    "type": "definition",
-    "title": "Even Multiples Sharing Factor",
-    "content": "**evenMultiplesSharing N:**\n\nEven numbers in {1,...,N} that share a factor with N.\n\nAll elements are even (gcd ≥ 2) and share factor with N.\n\nThis was part of the original (incorrect) conjecture.",
-    "mathContext": "This construction ensures pairwise gcd > 1 via the factor 2.",
-    "significance": "key",
-    "relatedConcepts": ["Even numbers", "GCD structure"]
-  },
-  {
-    "id": "ann-e534-wrong-conjecture",
-    "proofId": "erdos-534",
-    "range": { "startLine": 87, "endLine": 103 },
+    "range": { "startLine": 78, "endLine": 89 },
     "type": "axiom",
     "title": "Original Conjecture (WRONG)",
-    "content": "**OriginalConjecture:**\n\nErdős-Graham conjectured max = max(N/p, |evenMultiplesSharing(N)|).\n\n**original_conjecture_false:** This is FALSE!\n\n**counterexample_exists:** Ahlswede-Khachatrian (1992) found counterexamples.\n\nThe maximum can exceed both N/p and the even multiples count.",
-    "mathContext": "Finding the counterexample required careful analysis of specific N values.",
-    "significance": "critical",
-    "relatedConcepts": ["Counterexamples", "Failed conjectures"]
+    "content": "**OriginalConjecture:** Erdős-Graham conjectured max = max(N/p, |evenMultiplesSharing(N)|). **original_conjecture_false:** This is FALSE — Ahlswede-Khachatrian (1992) found counterexamples where the maximum exceeds both candidates. **counterexample_exists:** Witnesses a specific N > 1 where maxGCDIntersecting(N) > max(N/p, |evenMultiplesSharing(N)|). The failure of this conjecture motivated the correct, more complex characterization.",
+    "significance": "critical"
   },
   {
-    "id": "ann-e534-optimal-family",
+    "id": "ann-534-5",
     "proofId": "erdos-534",
-    "range": { "startLine": 105, "endLine": 127 },
-    "type": "definition",
-    "title": "Optimal Family Construction",
-    "content": "**optimalFamily N j primes:**\n\nIntegers in {1,...,N} that are multiples of at least one of:\n- 2q₁, 2q₂, ..., 2qⱼ (two times the first j primes of N)\n- q₁·q₂·...·qⱼ (product of first j primes)\n\n**ahlswede_khachatrian_theorem:**\nFor some optimal j, this family achieves the maximum.",
-    "mathContext": "The key insight is balancing between 2qᵢ terms (many divisors) and the product term (fewer but larger divisors).",
-    "significance": "critical",
-    "relatedConcepts": ["Optimal construction", "Prime products"]
+    "range": { "startLine": 96, "endLine": 108 },
+    "type": "axiom",
+    "title": "Ahlswede-Khachatrian Theorem (1996)",
+    "content": "**optimalFamily N j primes:** Integers in {1,...,N} divisible by at least one of 2q₁,...,2qⱼ or by q₁·q₂·...·qⱼ, where q₁,...,qⱼ are the first j prime factors of N. The construction balances between '2 times prime' factors (capturing many multiples of even numbers) and the product term (capturing a different set of multiples). **ahlswede_khachatrian_theorem:** For every N > 1, there exists an optimal j and a list of prime factors such that maxGCDIntersecting(N) equals the size of this optimal family.",
+    "mathContext": "The optimal j depends on the arithmetic structure of N. Larger j captures more via 2qᵢ terms but makes the product q₁⋯qⱼ larger (fewer multiples). The balance point varies with N.",
+    "significance": "critical"
   },
   {
-    "id": "ann-e534-special-cases",
+    "id": "ann-534-6",
     "proofId": "erdos-534",
-    "range": { "startLine": 129, "endLine": 147 },
-    "type": "theorem",
+    "range": { "startLine": 113, "endLine": 120 },
+    "type": "axiom",
     "title": "Special Cases",
-    "content": "**prime_power_case:** For N = p^k, max = p^(k-1).\n\n**two_times_prime_case:** For N = 2p (odd prime p), max = 2.\n\n**squarefree_case:** Simplified structure when N is squarefree.",
-    "mathContext": "Special cases provide insight and are easier to compute.",
-    "significance": "key",
-    "relatedConcepts": ["Prime powers", "Squarefree numbers"]
+    "content": "**prime_power_case:** For N = p^k (prime power), maxGCDIntersecting(p^k) = p^(k-1). All elements must be divisible by p, giving exactly the multiples of p in {1,...,p^k}. **two_times_prime_case:** For N = 2p (odd prime p), maxGCDIntersecting(2p) = 2. The only valid set is {N, 2p} since elements must share a factor with both 2 and p, but the only common multiples are 2p itself and one partner.",
+    "significance": "key"
   },
   {
-    "id": "ann-e534-summary",
+    "id": "ann-534-7",
     "proofId": "erdos-534",
-    "range": { "startLine": 195, "endLine": 237 },
+    "range": { "startLine": 138, "endLine": 148 },
     "type": "theorem",
-    "title": "Summary",
-    "content": "**erdos_534_characterization:**\n\n1. Original conjecture is FALSE\n2. Correct answer uses optimal j from {1,...,ω(N)}\n3. Proven by Ahlswede-Khachatrian (1996)\n\n**erdos_534_solved:** Problem is SOLVED.\n\n**erdos_534_status:** \"SOLVED - original conjecture was wrong\"",
-    "mathContext": "This was a case where the intuitive conjecture failed and a more sophisticated construction was needed.",
-    "significance": "critical",
-    "relatedConcepts": ["Summary", "Solved problems"]
+    "title": "Summary Theorem",
+    "content": "**erdos_534_summary:** Combines three results: (1) the original Erdős-Graham conjecture is false (original_conjecture_false), (2) a concrete counterexample exists (counterexample_exists), and (3) the correct Ahlswede-Khachatrian characterization holds for all N > 1. The proof directly packages the three axioms.",
+    "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-534/meta.json
+++ b/src/data/proofs/erdos-534/meta.json
@@ -46,19 +46,19 @@
       }
     ],
     "originalContributions": [
-      "interval definition: {1,...,N}",
-      "IsGCDIntersecting definition: gcd(a,b) > 1 for all pairs",
-      "maxGCDIntersecting definition: supremum of valid set sizes",
-      "multiplesOfSmallestPrime construction",
-      "evenMultiplesSharing construction",
-      "OriginalConjecture statement (proved false)",
+      "interval, IsGCDIntersecting, ContainsN, maxGCDIntersecting definitions",
+      "multiplesOfSmallestPrime construction with size and intersecting axioms",
+      "evenMultiplesSharing construction with intersecting axiom",
+      "OriginalConjecture statement and original_conjecture_false axiom",
+      "counterexample_exists axiom",
       "optimalFamily definition with 2qᵢ and product terms",
-      "ahlswede_khachatrian_theorem axiom",
-      "prime_power_case and two_times_prime_case special cases"
+      "ahlswede_khachatrian_theorem axiom: correct characterization",
+      "prime_power_case and two_times_prime_case special cases",
+      "erdos_534_summary combining all main results"
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #534: Maximum GCD-Intersecting Sets**\n\nThis problem asks for the largest subset of {1,...,N} containing N where every pair shares a common factor > 1.\n\n**Key History:**\n- Erdős-Graham: Original conjecture (max is N/p or even multiples sharing factor with N)\n- Ahlswede-Khachatrian (1992): Found counterexample\n- Ahlswede-Khachatrian (1996): Proved correct characterization\n\n**Mathematical Setting:**\nThe problem is an arithmetic analog of intersecting families, where gcd > 1 plays the role of 'shares an element'.",
+    "historicalContext": "This problem asks for the largest subset A ⊆ {1,...,N} containing N where every pair of distinct elements shares a common factor greater than 1. Erdős posed this as an arithmetic analog of intersecting family problems, where gcd(a,b) > 1 plays the role of 'shares an element' in classical Erdős-Ko-Rado theory.\n\nErdős and Graham conjectured that the maximum is either N/p (where p is the smallest prime factor of N, achieved by taking all multiples of p) or the number of even integers in {1,...,N} sharing a factor with N. However, Ahlswede and Khachatrian found a counterexample in 1992, showing that the maximum can exceed both these candidates for certain values of N.\n\nAhlswede and Khachatrian proved the correct characterization in 1996. For N = q₁^k₁ ⋯ qᵣ^kᵣ (with distinct primes q₁ < ⋯ < qᵣ), the maximum is achieved by integers that are multiples of at least one element from {2q₁,...,2qⱼ, q₁⋯qⱼ} for some optimal j ∈ {1,...,r}. The optimal j balances between using '2 times prime' divisors (which capture many multiples) and the product of several primes (which gives fewer but structurally richer divisors).",
     "problemStatement": "**Problem Statement (SOLVED)**\n\nWhat is the largest $A \\subseteq \\{1, \\ldots, N\\}$ containing $N$ such that $\\gcd(a, b) > 1$ for all distinct $a, b \\in A$?\n\n**Answer:** For $N = q_1^{k_1} \\cdots q_r^{k_r}$ (distinct primes $q_1 < \\cdots < q_r$), the maximum is achieved by integers that are multiples of at least one of $\\{2q_1, \\ldots, 2q_j, q_1 \\cdots q_j\\}$ for some optimal $1 \\leq j \\leq r$.\n\n**Note:** The original Erdős-Graham conjecture was wrong!",
     "proofStrategy": "**Formalization Approach**\n\n1. **Basic Structures:**\n   - interval: {1,...,N}\n   - IsGCDIntersecting: pairwise gcd > 1\n   - maxGCDIntersecting: supremum of valid set sizes\n\n2. **Constructions:**\n   - multiplesOfSmallestPrime: size N/p\n   - evenMultiplesSharing: even numbers sharing factor with N\n   - optimalFamily: the Ahlswede-Khachatrian construction\n\n3. **Main Results:**\n   - original_conjecture_false: the counterexample exists\n   - ahlswede_khachatrian_theorem: correct characterization",
     "keyInsights": [
@@ -74,50 +74,43 @@
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "summary": "interval, IsGCDIntersecting, ContainsN, maxGCDIntersecting",
-      "startLine": 39,
-      "endLine": 56
+      "startLine": 35,
+      "endLine": 50
     },
     {
-      "id": "simple-bounds",
-      "title": "Simple Upper Bounds",
-      "summary": "multiplesOfSmallestPrime construction and size N/p",
-      "startLine": 58,
+      "id": "simple-constructions",
+      "title": "Simple Constructions",
+      "summary": "multiplesOfSmallestPrime and evenMultiplesSharing with axioms",
+      "startLine": 52,
       "endLine": 73
-    },
-    {
-      "id": "even-multiples",
-      "title": "Even Multiples Construction",
-      "summary": "evenMultiplesSharing: even numbers sharing factor with N",
-      "startLine": 75,
-      "endLine": 85
     },
     {
       "id": "original-conjecture",
       "title": "Original Conjecture (WRONG)",
       "summary": "OriginalConjecture, original_conjecture_false, counterexample_exists",
-      "startLine": 87,
-      "endLine": 103
+      "startLine": 75,
+      "endLine": 89
     },
     {
       "id": "correct-characterization",
       "title": "Correct Characterization",
-      "summary": "optimalFamily, ahlswede_khachatrian_theorem",
-      "startLine": 105,
-      "endLine": 127
+      "summary": "optimalFamily definition and ahlswede_khachatrian_theorem",
+      "startLine": 91,
+      "endLine": 108
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "summary": "prime_power_case, two_times_prime_case, squarefree_case",
-      "startLine": 129,
-      "endLine": 147
+      "summary": "prime_power_case and two_times_prime_case",
+      "startLine": 110,
+      "endLine": 120
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_534_characterization, erdos_534_solved",
-      "startLine": 195,
-      "endLine": 232
+      "summary": "erdos_534_summary combining all main results",
+      "startLine": 122,
+      "endLine": 150
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove 8 trivial `True` axioms, 1 `True := trivial`, trivial `erdos_534_characterization`, and `erdos_534_status` String def
- Reduce Lean file from 238 to 150 lines while preserving all substantive mathematical content
- Add `erdos_534_summary` theorem combining three key results
- Update meta.json with 3-paragraph historicalContext and corrected sections
- Rewrite annotations.json with 7 substantive entries

## Quality fixes
- Removed: `optimal_j_choice`, `squarefree_case`, `optimal_contains_multiples`, `j_tradeoff`, `ekr_connection`, `problem_56_relation`, `oeis_a387543`, `computation` (all trivial `True` axioms)
- Removed: `erdos_534_solved : True := trivial`
- Removed: `erdos_534_characterization` (contained `True` in type, trivial proof)
- Removed: `erdos_534_status : String` (not meaningful Lean content)
- Preserved: all definitions, constructions, OriginalConjecture, original_conjecture_false, counterexample_exists, optimalFamily, ahlswede_khachatrian_theorem, prime_power_case, two_times_prime_case

## Test plan
- [x] `pnpm build` passes
- [x] 0 `sorry` instances
- [x] 0 `True := trivial` instances
- [x] 7 substantive annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)