### PR TITLE
fix(erdos-1133): remove sorry/True patterns, clean up axioms

### DIFF
--- a/proofs/Proofs/Erdos1133Problem.lean
+++ b/proofs/Proofs/Erdos1133Problem.lean
@@ -1,5 +1,5 @@
-/-
-Erdős Problem #1133: Large Polynomial Interpolation Bound
+/-!
+# Erdős Problem #1133: Large Polynomial Interpolation Bound
 
 Source: https://erdosproblems.com/1133
 Status: OPEN
@@ -151,17 +151,15 @@ axiom lagrange_interpolation (n : ℕ) (x y : Fin n → ℝ)
 
 /--
 **Divergence of Lagrange Interpolation:**
-Lagrange interpolation can diverge badly for uniformly spaced points.
-The max norm can grow exponentially even for smooth functions.
+There exist continuous functions for which Lagrange interpolation
+on uniformly spaced nodes diverges.
 -/
 axiom lagrange_divergence :
     ∃ f : ℝ → ℝ, Continuous f ∧
-    ¬ Filter.Tendsto
-      (fun n => maxNormOnInterval (Classical.choose (lagrange_interpolation n
-        (fun i : Fin n => -1 + 2 * i / (n - 1))
-        (fun i => f (-1 + 2 * i / (n - 1)))
-        sorry)))
-      Filter.atTop (nhds 0)
+    ∀ M : ℝ, ∃ n : ℕ, ∀ P : Polynomial ℝ,
+      P.natDegree < n →
+      (∀ i : Fin n, P.eval (-1 + 2 * i / (n - 1)) = f (-1 + 2 * i / (n - 1))) →
+      maxNormOnInterval P > M
 
 /-!
 ## Part VI: The Chebyshev Connection
@@ -185,55 +183,8 @@ axiom chebyshev_optimal :
     maxNormOnInterval P ≤ 1
 
 /-!
-## Part VII: Why the Conjecture is Hard
+## Part VII: Summary
 -/
-
-/--
-**Key Difficulty:**
-The conjecture requires choosing yᵢ values adversarially.
-Erdős couldn't even prove the case m = n (exact interpolation).
--/
-axiom conjecture_difficulty :
-    -- Even for m = n (exact degree), the problem is open
-    True
-
-/--
-**Relationship to Approximation Theory:**
-The conjecture relates to how well polynomials can approximate
-with constraints on both sample values and degree.
--/
-axiom approximation_theory_connection :
-    True
-
-/-!
-## Part VIII: Summary
--/
-
-/--
-**Erdős Problem #1133: OPEN**
-
-CONJECTURE: For any C > 0, there exists ε > 0 such that for large n:
-Given any sample points, one can choose target values in [-1,1] that
-force any approximating polynomial (degree < (1+ε)n, matching ≥ (1-ε)n points)
-to exceed C somewhere in [-1,1].
-
-KNOWN: Erdős proved a weaker result about existence of polynomials.
-
-WHY HARD: Requires adversarial choice of target values.
--/
-theorem erdos_1133_summary :
-    -- The conjecture statement is well-defined
-    ErdosConjecture1133 = ErdosConjecture1133 ∧
-    -- The related result exists
-    True := by
-  constructor
-  · rfl
-  · trivial
-
-/--
-**Main Status: OPEN**
--/
-theorem erdos_1133 : True := trivial
 
 /--
 **The ε parameter matters:**
@@ -247,5 +198,21 @@ theorem exact_interpolation_case :
     ∃ P : Polynomial ℝ, P.natDegree < n ∧ ∀ i, P.eval (x i) = y i := by
   intro n hn x hx y
   exact Classical.choose_spec (ExistsUnique.exists (lagrange_interpolation n x y hx))
+
+/--
+**Erdős Problem #1133: Summary**
+
+Status: OPEN
+
+The conjecture ErdosConjecture1133 is formally stated.
+The related weaker result (existence of polynomial) is axiomatized.
+Lagrange interpolation provides the exact interpolation case.
+-/
+theorem erdos_1133_summary :
+    (∀ n : ℕ, n ≥ 1 →
+      ∀ x : Fin n → ℝ, Function.Injective x →
+      ∀ y : Fin n → ℝ,
+      ∃ P : Polynomial ℝ, P.natDegree < n ∧ ∀ i, P.eval (x i) = y i) :=
+  exact_interpolation_case
 
 end Erdos1133

--- a/src/data/proofs/erdos-1133/annotations.json
+++ b/src/data/proofs/erdos-1133/annotations.json
@@ -5,10 +5,9 @@
     "range": { "startLine": 1, "endLine": 33 },
     "type": "concept",
     "title": "Problem Overview: Polynomial Interpolation Bound",
-    "content": "**Erdos Problem #1133: OPEN**\n\nCan one always choose target values y_i for polynomial interpolation such that ANY approximating polynomial must become large somewhere in [-1,1]?\n\n**The setup:**\n- Given sample points x_1,...,x_n in [-1,1]\n- Choose target values y_1,...,y_n in [-1,1]\n- Consider polynomials P of degree < (1+epsilon)n matching >= (1-epsilon)n points\n\n**The question:** Can we force max |P(x)| > C for any such P?",
+    "content": "**Erdős Problem #1133: OPEN**\n\nCan one always choose target values y_i for polynomial interpolation such that ANY approximating polynomial must become large somewhere in [-1,1]?\n\n**The setup:**\n- Given sample points x_1,...,x_n in [-1,1]\n- Choose target values y_1,...,y_n in [-1,1]\n- Consider polynomials P of degree < (1+epsilon)n matching >= (1-epsilon)n points\n\n**The question:** Can we force max |P(x)| > C for any such P?",
     "mathContext": "This is about adversarial function approximation. The conjecture asks if we can always 'win' against any polynomial approximation scheme by clever choice of target values.",
-    "significance": "critical",
-    "relatedConcepts": ["polynomial-interpolation", "approximation-theory", "Lagrange", "Chebyshev"]
+    "significance": "critical"
   },
   {
     "id": "ann-e1133-definitions",
@@ -17,9 +16,7 @@
     "type": "definition",
     "title": "Basic Definitions",
     "content": "**polyEval P x:** P.eval x - polynomial evaluation\n\n**maxNormOnInterval P:** sup_{x in [-1,1]} |P(x)| - the maximum norm on the interval\n\n**SamplePoints n:** Functions from Fin n to [-1,1] representing sample x values\n\n**TargetValues n:** Functions from Fin n to [-1,1] representing target y values",
-    "mathContext": "The maximum norm on [-1,1] is the key quantity. The conjecture asks if we can force this to exceed any constant C.",
-    "significance": "key",
-    "relatedConcepts": ["polynomial-evaluation", "supremum", "interval"]
+    "significance": "key"
   },
   {
     "id": "ann-e1133-interpolation",
@@ -27,75 +24,52 @@
     "range": { "startLine": 75, "endLine": 93 },
     "type": "definition",
     "title": "Interpolation Conditions",
-    "content": "**ApproximatelyInterpolates P x y epsilon:**\nP passes through at least (1-epsilon)n of the points (x_i, y_i)\n\nAllows some slack - not all points need to be matched exactly.\n\n**HasBoundedDegree P n epsilon:**\ndeg(P) < (1+epsilon)n\n\nThe polynomial has degree slightly less than (1+epsilon)n.",
-    "mathContext": "The epsilon parameter controls both the degree bound and the matching requirement. For epsilon = 0, this is exact Lagrange interpolation.",
-    "significance": "critical",
-    "relatedConcepts": ["approximate-interpolation", "degree-bound", "epsilon-slack"]
+    "content": "**ApproximatelyInterpolates P x y epsilon:** P passes through at least (1-epsilon)n of the points (x_i, y_i). Allows slack.\n\n**HasBoundedDegree P n epsilon:** deg(P) < (1+epsilon)n. The polynomial has degree slightly less than (1+epsilon)n.\n\nFor epsilon = 0, this is exact Lagrange interpolation.",
+    "significance": "critical"
   },
   {
     "id": "ann-e1133-conjecture",
     "proofId": "erdos-1133",
     "range": { "startLine": 95, "endLine": 115 },
     "type": "definition",
-    "title": "The Erdos Conjecture",
-    "content": "**ErdosConjecture1133:**\n\nFor all C > 0, there exists epsilon > 0 such that for large n:\nFor all sample points x_i in [-1,1],\nthere exist target values y_i in [-1,1] such that:\nfor all polynomials P with bounded degree and approximate interpolation,\nmax_{[-1,1]} |P| > C.\n\nThis is the formal statement with all quantifiers in the correct order.",
-    "mathContext": "The quantifier order matters: we get to CHOOSE y_i after seeing x_i, but before seeing P. This is an adversarial game.",
-    "significance": "critical",
-    "relatedConcepts": ["formal-statement", "quantifier-order", "adversarial"]
+    "title": "The Erdős Conjecture",
+    "content": "**ErdosConjecture1133:** For all C > 0, there exists epsilon > 0 such that for large n: for all sample points x_i in [-1,1], there exist target values y_i in [-1,1] such that for all polynomials P with bounded degree and approximate interpolation, max_{[-1,1]} |P| > C.\n\nThe quantifier order matters: we choose y_i after seeing x_i, but before seeing P. This is an adversarial game.",
+    "significance": "critical"
   },
   {
     "id": "ann-e1133-related",
     "proofId": "erdos-1133",
-    "range": { "startLine": 117, "endLine": 137 },
+    "range": { "startLine": 129, "endLine": 137 },
     "type": "axiom",
-    "title": "Erdos's Related Result (Known)",
-    "content": "**erdos_related_result:**\n\nFor any C > 0, there exists epsilon > 0 such that for large n:\nGiven any m = floor((1+epsilon)n) sample points x_i,\nthere EXISTS a polynomial P of degree n with:\n- |P(x_i)| <= 1 for all i\n- max |P(x)| > C\n\nThis is WEAKER: it asks for existence of P, not choice of y_i.",
-    "mathContext": "Erdos proved this weaker result. The conjecture reverses the quantifiers: instead of finding P, we need to choose y_i that work against all P.",
-    "significance": "critical",
-    "relatedConcepts": ["existence-result", "weaker-statement", "Erdos-1967"]
+    "title": "Erdős's Related Result (Known)",
+    "content": "**erdos_related_result:** For any C > 0, there exists epsilon > 0 such that for large n and m = floor((1+epsilon)n) sample points, there EXISTS a polynomial P of degree n with |P(x_i)| <= 1 for all i, yet max |P(x)| > C.\n\nThis is WEAKER: it asks for existence of P, not choice of y_i.",
+    "significance": "critical"
   },
   {
     "id": "ann-e1133-lagrange",
     "proofId": "erdos-1133",
-    "range": { "startLine": 139, "endLine": 164 },
+    "range": { "startLine": 148, "endLine": 162 },
     "type": "axiom",
     "title": "Lagrange Interpolation",
-    "content": "**lagrange_interpolation:**\nGiven n distinct points, there is a unique polynomial of degree < n passing through all.\n\n**lagrange_divergence:**\nLagrange interpolation can diverge badly for uniformly spaced points.\nThe max norm can grow exponentially even for smooth functions (Runge's phenomenon).",
-    "mathContext": "Lagrange interpolation is the classical case (epsilon = 0). The divergence phenomenon motivates using better node distributions like Chebyshev nodes.",
-    "significance": "key",
-    "relatedConcepts": ["Lagrange-polynomial", "uniqueness", "Runge-phenomenon"]
+    "content": "**lagrange_interpolation:** Given n distinct points, there is a unique polynomial of degree < n passing through all.\n\n**lagrange_divergence:** There exist continuous functions for which Lagrange interpolation on uniformly spaced nodes diverges (Runge's phenomenon).",
+    "significance": "key"
   },
   {
     "id": "ann-e1133-chebyshev",
     "proofId": "erdos-1133",
-    "range": { "startLine": 166, "endLine": 185 },
-    "type": "definition",
-    "title": "Chebyshev Nodes",
-    "content": "**chebyshevNodes n k:**\nx_k = cos(pi(2k+1)/(2n))\n\nThese are the optimal nodes for polynomial interpolation.\n\n**chebyshev_optimal:**\nIf P has degree n and |P(x_k)| <= 1 at all Chebyshev nodes, then max |P| <= 1.\n\nChebyshev nodes give the best possible control on the max norm.",
-    "mathContext": "Chebyshev nodes cluster near the endpoints of [-1,1]. They minimize the maximum interpolation error (Lebesgue constant).",
-    "significance": "key",
-    "relatedConcepts": ["Chebyshev-nodes", "optimal-nodes", "Lebesgue-constant"]
-  },
-  {
-    "id": "ann-e1133-difficulty",
-    "proofId": "erdos-1133",
-    "range": { "startLine": 187, "endLine": 206 },
-    "type": "concept",
-    "title": "Why the Conjecture is Hard",
-    "content": "**Key Difficulty:**\n\n1. We must choose y_i values that work against ALL possible polynomials P\n\n2. Erdos couldn't prove this even for m = n (exact interpolation)\n\n3. The adversarial nature makes the problem fundamentally different from existence results\n\n4. Connection to approximation theory and game-theoretic complexity",
-    "mathContext": "The difficulty is the universal quantifier over P. We need y_i that force ANY approximating polynomial to be large.",
-    "significance": "key",
-    "relatedConcepts": ["adversarial", "universal-quantifier", "approximation-complexity"]
+    "range": { "startLine": 172, "endLine": 183 },
+    "type": "axiom",
+    "title": "Chebyshev Nodes and Optimality",
+    "content": "**chebyshevNodes n k:** x_k = cos(pi(2k+1)/(2n)), the optimal nodes for polynomial interpolation.\n\n**chebyshev_optimal:** If P has degree n and |P(x_k)| <= 1 at all Chebyshev nodes, then max |P| <= 1. These nodes minimize the Lebesgue constant.",
+    "significance": "key"
   },
   {
     "id": "ann-e1133-summary",
     "proofId": "erdos-1133",
-    "range": { "startLine": 208, "endLine": 251 },
+    "range": { "startLine": 194, "endLine": 218 },
     "type": "theorem",
     "title": "Summary and Main Results",
-    "content": "**erdos_1133_summary:**\n- The conjecture is well-formed\n- The related existence result is known\n\n**erdos_1133:** True (placeholder for open problem)\n\n**exact_interpolation_case:**\nFor epsilon = 0 (exact interpolation), Lagrange gives the unique polynomial of degree < n through all n points.\n\n**Status: OPEN**",
-    "mathContext": "The problem connects Lagrange interpolation, approximation theory, and game-theoretic aspects of function approximation.",
-    "significance": "critical",
-    "relatedConcepts": ["open-problem", "approximation-theory", "interpolation"]
+    "content": "**exact_interpolation_case:** For epsilon = 0 (exact interpolation), Lagrange gives the unique polynomial of degree < n through all n points. Proved from lagrange_interpolation axiom.\n\n**erdos_1133_summary:** Wraps exact_interpolation_case as the main proved result. The conjecture ErdosConjecture1133 remains OPEN.",
+    "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-1133/meta.json
+++ b/src/data/proofs/erdos-1133/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1133",
-  "title": "Erdos Problem #1133: Large Polynomial Interpolation Bound",
+  "title": "Erdős Problem #1133: Large Polynomial Interpolation Bound",
   "slug": "erdos-1133",
   "description": "For any C > 0, can one always choose target values y_i in [-1,1] for sample points x_i such that any low-degree polynomial approximating most points must exceed C somewhere in [-1,1]? OPEN.",
   "meta": {
-    "author": "Erdos (1967)",
+    "author": "Erdős (1967)",
     "sourceUrl": "https://erdosproblems.com/1133",
     "date": "1967",
     "status": "complete",
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1133,
     "erdosUrl": "https://erdosproblems.com/1133",
     "erdosProblemStatus": "open",
@@ -53,25 +53,26 @@
       "ApproximatelyInterpolates definition: P passes through >= (1-epsilon)n points",
       "HasBoundedDegree definition: deg(P) < (1+epsilon)n",
       "ErdosConjecture1133 formal statement",
-      "erdos_related_result axiom: Erdos's weaker result about polynomial existence",
+      "erdos_related_result axiom: Erdős's weaker result about polynomial existence",
       "lagrange_interpolation axiom: existence and uniqueness",
       "lagrange_divergence axiom: divergence for uniform nodes",
       "chebyshevNodes definition: cos(pi(2k+1)/(2n))",
       "chebyshev_optimal axiom: Chebyshev nodes are optimal",
-      "exact_interpolation_case theorem"
+      "exact_interpolation_case theorem",
+      "erdos_1133_summary theorem"
     ]
   },
   "overview": {
-    "historicalContext": "This problem was posed by Erdos in 1967 in his paper 'Problems and results on the convergence and divergence properties of Lagrange interpolation polynomials'. It concerns the behavior of polynomial interpolation on [-1,1]. Lagrange showed that given n distinct points, there is a unique polynomial of degree < n passing through them. However, this polynomial can behave badly between the sample points, leading to Runge's phenomenon and related issues.\n\nErdos proved a weaker result: for any bound C, one can find polynomials that stay small at many sample points but become large in [-1,1]. The conjecture asks the converse: can one always CHOOSE the target values to force this behavior for ANY approximating polynomial?",
-    "problemStatement": "**Conjecture:** For any C > 0, there exists epsilon > 0 such that for sufficiently large n: Given any x_1,...,x_n in [-1,1], one can choose y_1,...,y_n in [-1,1] such that if P is a polynomial of degree < (1+epsilon)n passing through at least (1-epsilon)n of the points (x_i, y_i), then max_{x in [-1,1]} |P(x)| > C.\n\n**Status: OPEN**\n\nErdos could not prove this even for the case m = n (exact interpolation).",
-    "proofStrategy": "We formalize:\n\n1. **Basic setup:** Polynomial evaluation, max norm on [-1,1], sample/target points\n\n2. **Interpolation conditions:** ApproximatelyInterpolates (>= (1-epsilon)n matches), HasBoundedDegree (< (1+epsilon)n)\n\n3. **The conjecture:** ErdosConjecture1133 - formal statement with all quantifiers\n\n4. **Related result:** Erdos's weaker existence theorem (axiomatized)\n\n5. **Lagrange theory:** Uniqueness, divergence for uniform nodes\n\n6. **Chebyshev connection:** Optimal node placement",
+    "historicalContext": "This problem was posed by Erdős in 1967 in his paper on convergence and divergence of Lagrange interpolation polynomials. It concerns the behavior of polynomial interpolation on [-1,1]. Lagrange showed that given n distinct points, there is a unique polynomial of degree < n passing through them. However, this polynomial can behave badly between the sample points, leading to Runge's phenomenon and related divergence issues.\n\nErdős proved a weaker result: for any bound C, one can find polynomials that stay small at many sample points but become large in [-1,1]. The conjecture asks the converse: can one always CHOOSE the target values to force this behavior for ANY approximating polynomial? The adversarial nature of this quantifier reversal makes the conjecture fundamentally harder.\n\nThe problem connects to the Chebyshev theory of optimal node placement. Chebyshev nodes give the best possible interpolation behavior, but even their properties do not resolve the conjecture. Erdős noted that he could not prove the conjecture even in the case of exact interpolation (ε = 0), making this a challenging open problem in approximation theory.",
+    "problemStatement": "**Conjecture:** For any C > 0, there exists epsilon > 0 such that for sufficiently large n: Given any x_1,...,x_n in [-1,1], one can choose y_1,...,y_n in [-1,1] such that if P is a polynomial of degree < (1+epsilon)n passing through at least (1-epsilon)n of the points (x_i, y_i), then max_{x in [-1,1]} |P(x)| > C.\n\n**Status: OPEN**",
+    "proofStrategy": "We formalize:\n\n1. **Basic setup:** Polynomial evaluation, max norm on [-1,1], sample/target points\n\n2. **Interpolation conditions:** ApproximatelyInterpolates (>= (1-epsilon)n matches), HasBoundedDegree (< (1+epsilon)n)\n\n3. **The conjecture:** ErdosConjecture1133 - formal statement with all quantifiers\n\n4. **Related result:** Erdős's weaker existence theorem (axiomatized)\n\n5. **Lagrange theory:** Uniqueness, divergence for uniform nodes\n\n6. **Chebyshev connection:** Optimal node placement",
     "keyInsights": [
       "**Adversarial choice:** The conjecture requires choosing y_i values that work against ALL polynomials",
       "**Degree flexibility:** The (1+epsilon)n degree bound allows slightly more than n degrees of freedom",
       "**Approximate matching:** Only (1-epsilon)n points need to match, giving some slack",
       "**Lagrange connection:** For exact interpolation (epsilon=0), this is about Lagrange polynomials",
       "**Chebyshev nodes:** These give optimal interpolation behavior, but don't resolve the conjecture",
-      "**Erdos's weaker result:** Existence is proven; universal choice of y_i is open"
+      "**Erdős's weaker result:** Existence is proven; universal choice of y_i is open"
     ]
   },
   "sections": [
@@ -91,7 +92,7 @@
     },
     {
       "id": "conjecture",
-      "title": "The Erdos Conjecture",
+      "title": "The Erdős Conjecture",
       "summary": "ErdosConjecture1133 formal statement",
       "startLine": 95,
       "endLine": 115
@@ -108,39 +109,31 @@
       "title": "Lagrange Interpolation",
       "summary": "lagrange_interpolation, lagrange_divergence",
       "startLine": 139,
-      "endLine": 164
+      "endLine": 162
     },
     {
       "id": "chebyshev",
       "title": "Chebyshev Connection",
       "summary": "chebyshevNodes, chebyshev_optimal",
-      "startLine": 166,
-      "endLine": 185
-    },
-    {
-      "id": "difficulty",
-      "title": "Why the Conjecture is Hard",
-      "summary": "conjecture_difficulty, approximation_theory_connection",
-      "startLine": 187,
-      "endLine": 206
+      "startLine": 164,
+      "endLine": 183
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_1133_summary, erdos_1133, exact_interpolation_case",
-      "startLine": 208,
-      "endLine": 251
+      "summary": "exact_interpolation_case, erdos_1133_summary",
+      "startLine": 185,
+      "endLine": 218
     }
   ],
   "conclusion": {
-    "summary": "Erdos Problem #1133 asks whether one can always choose target values for polynomial interpolation that force any approximating polynomial to be large somewhere in [-1,1]. The problem remains OPEN. Erdos proved a weaker existence result but could not prove the conjectured universal choice property.",
-    "implications": "**Approximation Theory Impact:**\n\n1. **Interpolation limits:** Shows fundamental limits on controlling polynomial behavior through interpolation\n\n2. **Adversarial approximation:** Connects to game-theoretic aspects of function approximation\n\n3. **Chebyshev theory:** The role of optimal node placement in polynomial approximation\n\n4. **Computational complexity:** Potential connections to hardness of approximation",
+    "summary": "Erdős Problem #1133 asks whether one can always choose target values for polynomial interpolation that force any approximating polynomial to be large somewhere in [-1,1]. The problem remains OPEN. Erdős proved a weaker existence result but could not prove the conjectured universal choice property.",
+    "implications": "**Approximation Theory Impact:**\n\n1. **Interpolation limits:** Shows fundamental limits on controlling polynomial behavior through interpolation\n\n2. **Adversarial approximation:** Connects to game-theoretic aspects of function approximation\n\n3. **Chebyshev theory:** The role of optimal node placement in polynomial approximation",
     "openQuestions": [
       "Is the conjecture true for epsilon = 0 (exact interpolation)?",
       "What is the optimal epsilon(C) if the conjecture is true?",
       "Are there special node configurations where the conjecture fails?",
-      "What happens in higher dimensions or for other domains?",
-      "Is there a constructive way to choose the y_i values?"
+      "What happens in higher dimensions or for other domains?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Remove sorry in `lagrange_divergence` (rewrote axiom without sorry)
- Remove `conjecture_difficulty` (`: True`), `approximation_theory_connection` (`: True`)
- Remove `erdos_1133` (`True := trivial`)
- Rewrite `erdos_1133_summary` with meaningful type (wraps `exact_interpolation_case`)
- Change `/-` header to `/-!` doc comment
- Update meta.json (sorries=0, 3-paragraph historicalContext)

## Test plan
- [x] `pnpm build` passes
- [x] No `sorry` remaining
- [x] No `True := trivial` patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)