### PR TITLE
Enhance Erdős #597: Partition Relations for Ordinal Powers

### DIFF
--- a/src/data/proofs/erdos-597/annotations.json
+++ b/src/data/proofs/erdos-597/annotations.json
@@ -1,218 +1,101 @@
 [
   {
-    "id": "ann-597-1",
+    "id": "ann-e597-header",
     "proofId": "erdos-597",
-    "range": {
-      "startLine": 1,
-      "endLine": 26
-    },
+    "range": { "startLine": 1, "endLine": 24 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "Erdős Problem #597: Does ω₁² → (ω₁ω, G)² for K₄-free, K_{ℵ₀,ℵ₀}-free graphs G? OPEN. This is a partition calculus problem in infinite combinatorics connecting ordinals, graphs, and Ramsey theory.",
-    "significance": "critical"
+    "content": "**Erdős Problem #597** asks about partition relations for ordinal powers. Given a graph G on at most ℵ₁ vertices that is both K₄-free (no complete subgraph on 4 vertices) and K_{ℵ₀,ℵ₀}-free (no infinite complete bipartite subgraph), does ω₁² → (ω₁ω, G)² hold? This notation means: for any 2-coloring of pairs from a set of order type ω₁², either there exists a homogeneous set of type ω₁ω, or a monochromatic copy of G. The problem remains OPEN and connects partition calculus, graph Ramsey theory, and set theory.",
+    "mathContext": "The partition arrow notation was developed by Erdős and Rado as a compact way to express Ramsey-type statements for infinite structures. Problem #597 was posed by Erdős in [Er87] and appears in [Va99, 7.84]. It sits at the frontier of what is known about partition relations involving ordinal powers.",
+    "significance": "critical",
+    "relatedConcepts": ["partition-calculus", "ramsey-theory", "ordinal-arithmetic"]
   },
   {
-    "id": "ann-597-2",
+    "id": "ann-e597-ordinals",
     "proofId": "erdos-597",
-    "range": {
-      "startLine": 39,
-      "endLine": 43
-    },
+    "range": { "startLine": 32, "endLine": 56 },
     "type": "definition",
-    "title": "The Ordinal ω₁",
-    "content": "ω₁ is the first uncountable ordinal - the smallest ordinal with uncountably many predecessors. It plays a central role in set theory and partition calculus.",
-    "significance": "critical"
+    "title": "Ordinal Notation: ω₁, ω₁ω, ω₁²",
+    "content": "**The key ordinals** in this problem are: ω₁ (the first uncountable ordinal), ω (the first infinite ordinal, identified with ℕ), ω₁ω (the ordinal product of ω₁ copies of ω), and ω₁² = ω₁ · ω₁ (the ordinal square). These are axiomatized with defining equations. The ordinal ω₁² serves as the 'source' whose pairs are colored, while ω₁ω is the 'target' homogeneity type.",
+    "mathContext": "Ordinal arithmetic is non-commutative: ω · ω₁ ≠ ω₁ · ω. The product ω₁ω means ω₁ copies of ω laid end-to-end. These ordinals live in Mathlib's Ordinal type, which formalizes the von Neumann ordinal hierarchy.",
+    "significance": "critical",
+    "relatedConcepts": ["ordinal-arithmetic", "set-theory", "cardinal-numbers"]
   },
   {
-    "id": "ann-597-3",
+    "id": "ann-e597-graphs",
     "proofId": "erdos-597",
-    "range": {
-      "startLine": 51,
-      "endLine": 55
-    },
+    "range": { "startLine": 58, "endLine": 91 },
     "type": "definition",
-    "title": "Ordinal Product ω₁ω",
-    "content": "ω₁ω is the ordinal product: ω₁ copies of ω. This is an uncountable limit ordinal larger than ω₁ but smaller than ω₁². It appears as the 'target' in the partition relation.",
-    "significance": "key"
+    "title": "Graph Structures and Forbidden Subgraphs",
+    "content": "**SimpleGraph'** defines a graph as a symmetric, irreflexive adjacency relation. **containsClique** checks for complete subgraphs of size n, and **isK4Free** asserts no 4-clique exists. **containsCountableBiclique** captures K_{ℵ₀,ℵ₀}: two countably infinite disjoint vertex sets with all cross-pairs adjacent. **isKAleph0Free** negates this. **hasAtMostAleph1Vertices** bounds the vertex cardinality. These definitions formalize the hypotheses of Problem #597.",
+    "mathContext": "The definition uses Finset for cliques (finite subgraphs) and Set with Countable/Infinite predicates for infinite bipartite subgraphs. The cardinality bound uses Cardinal.mk and Cardinal.aleph 1. A custom SimpleGraph' is used rather than Mathlib's SimpleGraph to keep the formalization self-contained.",
+    "significance": "critical",
+    "relatedConcepts": ["graph-theory", "complete-graphs", "bipartite-graphs"]
   },
   {
-    "id": "ann-597-4",
+    "id": "ann-e597-partition",
     "proofId": "erdos-597",
-    "range": {
-      "startLine": 57,
-      "endLine": 61
-    },
-    "type": "definition",
-    "title": "Ordinal Square ω₁²",
-    "content": "ω₁² = ω₁ · ω₁ is the ordinal square. The partition relation asks about 2-colorings of pairs from a set of order type ω₁². This is the 'source' ordinal in the problem.",
-    "significance": "critical"
+    "range": { "startLine": 93, "endLine": 102 },
+    "type": "axiom",
+    "title": "Partition Arrow Relation",
+    "content": "**partitionArrow α β γ** axiomatizes the partition relation α → (β, γ)². The full definition would require: (1) fixing a well-ordering of type α, (2) considering all 2-colorings of unordered pairs, (3) defining 'homogeneous set of order type β', and (4) defining 'subgraph isomorphic to γ in color 1'. This infrastructure exceeds what is available in Mathlib, so the relation is taken as an axiom.",
+    "mathContext": "The partition relation is a central concept in infinite combinatorics. For finite ordinals, it reduces to classical Ramsey theory. For uncountable ordinals like ω₁², the theory becomes much richer and often depends on set-theoretic axioms.",
+    "significance": "critical",
+    "relatedConcepts": ["ramsey-theory", "2-coloring", "homogeneous-sets"]
   },
   {
-    "id": "ann-597-5",
+    "id": "ann-e597-conjecture",
     "proofId": "erdos-597",
-    "range": {
-      "startLine": 67,
-      "endLine": 74
-    },
-    "type": "definition",
-    "title": "Partition Relation",
-    "content": "α → (β, γ)² means: for any 2-coloring of pairs [α]², either there's a homogeneous set of type β in color 0, OR a copy of γ in color 1. This is the arrow notation of partition calculus.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-597-6",
-    "proofId": "erdos-597",
-    "range": {
-      "startLine": 91,
-      "endLine": 95
-    },
-    "type": "definition",
-    "title": "K_{ℵ₀,ℵ₀}",
-    "content": "The infinite complete bipartite graph with countably many vertices in each class. Baumgartner showed ω₁² ↛ (ω₁ω, K_{ℵ₀,ℵ₀})², which forced adding this exclusion to the conjecture.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-597-7",
-    "proofId": "erdos-597",
-    "range": {
-      "startLine": 101,
-      "endLine": 105
-    },
-    "type": "definition",
-    "title": "K₄-free",
-    "content": "A graph is K₄-free if it contains no complete subgraph on 4 vertices. This forbids too much 'clique structure' in G, a natural restriction in Ramsey-type problems.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-597-8",
-    "proofId": "erdos-597",
-    "range": {
-      "startLine": 107,
-      "endLine": 111
-    },
-    "type": "definition",
-    "title": "K_{ℵ₀,ℵ₀}-free",
-    "content": "A graph is K_{ℵ₀,ℵ₀}-free if it has no infinite complete bipartite subgraph. This condition was added after Baumgartner's counterexample showed it's necessary.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-597-9",
-    "proofId": "erdos-597",
-    "range": {
-      "startLine": 119,
-      "endLine": 128
-    },
+    "range": { "startLine": 104, "endLine": 123 },
     "type": "theorem",
-    "title": "Main Conjecture",
-    "content": "For G with ≤ℵ₁ vertices, no K₄, no K_{ℵ₀,ℵ₀}: does ω₁² → (ω₁ω, G)²? This is the OPEN central question. Both forbidden subgraph conditions appear essential.",
-    "significance": "critical"
+    "title": "The Main Conjecture and Finite Case",
+    "content": "**erdos597Conjecture** states the full open problem: for all graphs G with ≤ℵ₁ vertices, no K₄, and no K_{ℵ₀,ℵ₀}, the partition relation ω₁² → (ω₁ω, G)² holds. **finiteCaseConjecture** restricts to finite G (dropping the K_{ℵ₀,ℵ₀}-free condition, since finite graphs are automatically K_{ℵ₀,ℵ₀}-free). Even the finite case is open beyond the triangle.",
+    "mathContext": "The conjecture is formalized as a universally quantified Prop over all types α with a SimpleGraph' structure satisfying the three conditions. The finite case uses Lean's Fintype class to restrict to finite vertex sets.",
+    "significance": "critical",
+    "relatedConcepts": ["open-problems", "erdos-problems", "partition-calculus"]
   },
   {
-    "id": "ann-597-10",
+    "id": "ann-e597-erdos-hajnal",
     "proofId": "erdos-597",
-    "range": {
-      "startLine": 134,
-      "endLine": 140
-    },
+    "range": { "startLine": 125, "endLine": 132 },
+    "type": "axiom",
+    "title": "Erdős-Hajnal Triangle Theorem",
+    "content": "**erdosHajnalTriangle** axiomatizes the proven result ω₁² → (ω₁ω, 3)². This says: for any 2-coloring of pairs from ω₁², either there is a homogeneous set of order type ω₁ω, or there is a monochromatic triangle. This is the strongest positive result known toward Problem #597 and serves as the foundation for the conjecture.",
+    "mathContext": "The triangle (Fin 3) is the simplest non-trivial graph case. Erdős and Hajnal's proof uses ordinal partition calculus techniques including stepping-up lemmas. The result demonstrates that the partition relation can hold for small graphs.",
+    "significance": "critical",
+    "relatedConcepts": ["erdos-hajnal", "triangle", "positive-partition-relation"]
+  },
+  {
+    "id": "ann-e597-baumgartner",
+    "proofId": "erdos-597",
+    "range": { "startLine": 134, "endLine": 141 },
+    "type": "axiom",
+    "title": "Baumgartner's Counterexample",
+    "content": "**baumgartnerCounterexample** axiomatizes the negative result: there exists a type β of cardinality ℵ₀ such that ω₁² ↛ (ω₁ω, β × β)². This captures ω₁² ↛ (ω₁ω, K_{ℵ₀,ℵ₀})² — Baumgartner constructed an explicit 2-coloring witnessing the failure. Since K_{ℵ₀,ℵ₀} is bipartite (hence K₄-free), this shows the original question without the K_{ℵ₀,ℵ₀}-free condition has a negative answer.",
+    "mathContext": "The counterexample is formalized existentially: there exists a countable type whose product β × β serves as the vertex set of K_{ℵ₀,ℵ₀}. The negation of the partition relation means there exists a 2-coloring with no homogeneous ω₁ω and no monochromatic copy of the bipartite graph.",
+    "significance": "critical",
+    "relatedConcepts": ["counterexample", "baumgartner", "negative-partition-relation"]
+  },
+  {
+    "id": "ann-e597-both-conditions",
+    "proofId": "erdos-597",
+    "range": { "startLine": 143, "endLine": 154 },
+    "type": "concept",
+    "title": "Why Both Forbidden Subgraph Conditions Are Needed",
+    "content": "**The two conditions play complementary roles.** K₄-freeness forbids dense local structure (large cliques), while K_{ℵ₀,ℵ₀}-freeness forbids dense global bipartite structure. Crucially, K_{ℵ₀,ℵ₀} is itself K₄-free (bipartite graphs contain no odd cycles, let alone 4-cliques), so Baumgartner's counterexample passes the K₄-free test. This is why Erdős had to add the K_{ℵ₀,ℵ₀}-free condition to salvage the conjecture.",
+    "mathContext": "This illustrates a common pattern in infinite combinatorics: initial conjectures are refined after counterexamples reveal unexpected obstructions. The interplay between local (clique) and global (bipartite) graph structure is a recurring theme.",
+    "significance": "key",
+    "relatedConcepts": ["graph-structure", "clique-free", "bipartite-free"]
+  },
+  {
+    "id": "ann-e597-summary",
+    "proofId": "erdos-597",
+    "range": { "startLine": 173, "endLine": 189 },
     "type": "theorem",
-    "title": "Erdős-Hajnal Triangle Case",
-    "content": "ω₁² → (ω₁ω, 3)² is PROVEN. For 2-colorings of pairs from ω₁², there's either a homogeneous set of type ω₁ω or a monochromatic triangle. This is the positive foundation.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-597-11",
-    "proofId": "erdos-597",
-    "range": {
-      "startLine": 142,
-      "endLine": 148
-    },
-    "type": "theorem",
-    "title": "Baumgartner Counterexample",
-    "content": "ω₁² ↛ (ω₁ω, K_{ℵ₀,ℵ₀})². There exists a 2-coloring with no homogeneous ω₁ω and no monochromatic infinite complete bipartite graph. This forced the K_{ℵ₀,ℵ₀}-free condition.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-597-12",
-    "proofId": "erdos-597",
-    "range": {
-      "startLine": 150,
-      "endLine": 156
-    },
-    "type": "concept",
-    "title": "Why Both Conditions",
-    "content": "Erdős originally asked with only K₄-free. Baumgartner's counterexample showed this is insufficient - the infinite bipartite graph escapes the relation. Both conditions are needed for the conjecture to have a chance.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-597-13",
-    "proofId": "erdos-597",
-    "range": {
-      "startLine": 162,
-      "endLine": 168
-    },
-    "type": "theorem",
-    "title": "Finite Case",
-    "content": "Does ω₁² → (ω₁ω, G)² for all finite K₄-free G? This is a natural subproblem. The triangle case (G = K₃) is proven, but general finite K₄-free graphs remain open.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-597-14",
-    "proofId": "erdos-597",
-    "range": {
-      "startLine": 187,
-      "endLine": 192
-    },
-    "type": "concept",
-    "title": "Erdős-Rado Theorem",
-    "content": "A fundamental result in partition calculus giving bounds on partition relations for cardinals. It provides the theoretical framework for problems like this one.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-597-15",
-    "proofId": "erdos-597",
-    "range": {
-      "startLine": 201,
-      "endLine": 206
-    },
-    "type": "concept",
-    "title": "Stepping-Up Lemmas",
-    "content": "Techniques to derive partition relations for larger ordinals from known relations for smaller ones. These are key tools in establishing positive partition relations.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-597-16",
-    "proofId": "erdos-597",
-    "range": {
-      "startLine": 219,
-      "endLine": 224
-    },
-    "type": "concept",
-    "title": "ZFC Dependence",
-    "content": "Some partition relations depend on set-theoretic axioms. This problem may have different answers under different axioms like CH, Martin's Axiom, or large cardinal hypotheses.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-597-17",
-    "proofId": "erdos-597",
-    "range": {
-      "startLine": 258,
-      "endLine": 262
-    },
-    "type": "concept",
-    "title": "Graph Ramsey Connection",
-    "content": "The problem connects infinite combinatorics to graph Ramsey theory. Finite Ramsey numbers R(n, G) are related to these infinite partition relations.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-597-18",
-    "proofId": "erdos-597",
-    "range": {
-      "startLine": 290,
-      "endLine": 295
-    },
-    "type": "theorem",
-    "title": "Status Summary",
-    "content": "Erdős #597 is OPEN. Known: ω₁² → (ω₁ω, 3)² (positive), ω₁² ↛ (ω₁ω, K_{ℵ₀,ℵ₀})² (negative). The combined K₄-free AND K_{ℵ₀,ℵ₀}-free case remains the central open question.",
-    "significance": "critical"
+    "title": "Summary Theorem: Known Results Combined",
+    "content": "**erdos597_knownResults** is the only proven theorem in this formalization. It combines the two axiomatized partial results into a conjunction: (1) the Erdős-Hajnal positive result for triangles, and (2) the Baumgartner negative result for K_{ℵ₀,ℵ₀}. The proof is `⟨erdosHajnalTriangle, baumgartnerCounterexample⟩`, directly pairing the two axioms. This theorem encapsulates the current state of knowledge on Problem #597.",
+    "mathContext": "The conjunction captures the 'gap' that defines Problem #597: we know the partition relation holds for the smallest non-trivial case (triangles) and fails for the infinite bipartite case. Everything in between — finite K₄-free graphs, countable graphs, graphs on ℵ₁ vertices with both exclusions — is unknown.",
+    "significance": "critical",
+    "relatedConcepts": ["summary-theorem", "open-problem", "partial-results"]
   }
 ]

--- a/src/data/proofs/erdos-597/meta.json
+++ b/src/data/proofs/erdos-597/meta.json
@@ -2,11 +2,11 @@
   "id": "erdos-597",
   "title": "Erdős Problem #597: Partition Relations for Ordinal Powers",
   "slug": "erdos-597",
-  "description": "Does ω₁² → (ω₁ω, G)² for graphs G on ≤ℵ₁ vertices with no K₄ and no K_{ℵ₀,ℵ₀}? OPEN. Triangle case proven (Erdős-Hajnal), but K_{ℵ₀,ℵ₀} case fails (Baumgartner).",
+  "description": "Does ω₁² → (ω₁ω, G)² for graphs G on at most ℵ₁ vertices with no K₄ and no K_{ℵ₀,ℵ₀}? An open problem in infinite partition calculus connecting ordinal combinatorics with graph Ramsey theory.",
   "meta": {
     "author": "Paul Erdős, András Hajnal",
     "sourceUrl": "https://erdosproblems.com/597",
-    "date": "1969",
+    "date": "1987",
     "status": "complete",
     "proofRepoPath": "Proofs/Erdos597Problem.lean",
     "tags": [
@@ -22,87 +22,108 @@
     "sorries": 0,
     "erdosNumber": 597,
     "erdosUrl": "https://erdosproblems.com/597",
-    "erdosProblemStatus": "open"
+    "erdosProblemStatus": "open",
+    "mathlibDependencies": [
+      {
+        "theorem": "Ordinal",
+        "description": "Ordinal number type and arithmetic",
+        "module": "Mathlib.SetTheory.Ordinal.Basic"
+      },
+      {
+        "theorem": "Cardinal.aleph",
+        "description": "Aleph cardinal numbers",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Set.Countable",
+        "description": "Countability predicate for sets",
+        "module": "Mathlib.Data.Set.Basic"
+      }
+    ],
+    "originalContributions": [
+      "SimpleGraph' structure for symmetric irreflexive relations",
+      "containsClique and isK4Free definitions",
+      "containsCountableBiclique and isKAleph0Free definitions",
+      "partitionArrow axiomatized relation α → (β, γ)²",
+      "erdos597Conjecture: the full open conjecture",
+      "finiteCaseConjecture: the finite subproblem",
+      "erdosHajnalTriangle axiom: ω₁² → (ω₁ω, 3)²",
+      "baumgartnerCounterexample axiom: ω₁² ↛ (ω₁ω, K_{ℵ₀,ℵ₀})²",
+      "erdos597_knownResults theorem combining both results"
+    ]
   },
   "overview": {
-    "historicalContext": "This problem lies at the intersection of partition calculus and graph theory. Erdős originally asked with only the K₄-free condition, but Baumgartner showed this fails for K_{ℵ₀,ℵ₀}. The current formulation with both forbidden subgraph conditions remains open. Erdős and Hajnal established the triangle case ω₁² → (ω₁ω, 3)², providing a foundation for the conjecture.",
-    "problemStatement": "Let G be a graph on at most ℵ₁ vertices containing no K₄ and no K_{ℵ₀,ℵ₀} (the complete bipartite graph with ℵ₀ vertices in each class). Is it true that ω₁² → (ω₁ω, G)²? The arrow notation means: for any 2-coloring of pairs from ω₁², either there exists a homogeneous set of order type ω₁ω in color 1, or a copy of G in color 2.",
-    "proofStrategy": "The formalization captures the ordinal notation (ω₁, ω₁², ω₁ω), the partition relation α → (β, γ)², and the graph conditions. Known results are axiomatized: Erdős-Hajnal's positive result for triangles and Baumgartner's counterexample for K_{ℵ₀,ℵ₀}. The main conjecture with both conditions remains an open problem.",
+    "historicalContext": "Erdős Problem #597 originates from the study of partition calculus, a branch of infinite combinatorics developed by Erdős and Rado in the 1950s. The partition arrow notation α → (β, γ)² encodes a Ramsey-type statement: every 2-coloring of pairs from a set of order type α yields either a homogeneous set of type β or a copy of γ. This problem was posed by Erdős in [Er87] and referenced in [Va99, 7.84].\n\nErdős originally asked whether ω₁² → (ω₁ω, G)² holds for all K₄-free graphs G on at most ℵ₁ vertices. However, Baumgartner demonstrated a counterexample: the complete bipartite graph K_{ℵ₀,ℵ₀} is K₄-free (being bipartite, it is even triangle-free), yet ω₁² ↛ (ω₁ω, K_{ℵ₀,ℵ₀})². This forced a refinement of the conjecture to exclude K_{ℵ₀,ℵ₀} subgraphs.\n\nThe positive foundation comes from Erdős and Hajnal, who proved ω₁² → (ω₁ω, 3)² — the triangle case. The gap between the triangle (3 vertices) and K_{ℵ₀,ℵ₀} (infinitely many) is precisely where Problem #597 lives. The problem also asks specifically about finite K₄-free graphs G, which is a natural intermediate case. The problem may be sensitive to set-theoretic axioms beyond ZFC, as many partition relations at the level of ℵ₁ depend on assumptions like the Continuum Hypothesis or Martin's Axiom.",
+    "problemStatement": "Let $G$ be a graph on at most $\\aleph_1$ vertices containing no $K_4$ and no $K_{\\aleph_0,\\aleph_0}$ (the complete bipartite graph with $\\aleph_0$ vertices in each class). Is it true that $\\omega_1^2 \\to (\\omega_1\\omega, G)^2$? What about finite $G$? The arrow notation means: for any 2-coloring of pairs from $\\omega_1^2$, either there exists a homogeneous set of order type $\\omega_1\\omega$ in color 0, or a copy of $G$ in color 1. STATUS: OPEN.",
+    "proofStrategy": "The formalization defines the key mathematical structures from scratch: a simple graph type, clique containment, K₄-freeness, K_{ℵ₀,ℵ₀}-freeness (via countable bicliques), and a vertex cardinality bound. The partition relation α → (β, γ)² is axiomatized since its full definition requires substantial order-type and graph-embedding infrastructure. The two known partial results are stated as axioms: the Erdős-Hajnal positive result for triangles and Baumgartner's negative result for K_{ℵ₀,ℵ₀}. The summary theorem combines both via an exact proof.",
     "keyInsights": [
-      "ω₁² → (ω₁ω, 3)² is proven (Erdős-Hajnal)",
-      "ω₁² ↛ (ω₁ω, K_{ℵ₀,ℵ₀})² (Baumgartner counterexample)",
-      "Both K₄-free AND K_{ℵ₀,ℵ₀}-free conditions are needed",
-      "The finite case (finite K₄-free G) is a natural subproblem",
-      "May depend on set-theoretic axioms beyond ZFC",
-      "Connects infinite combinatorics with graph Ramsey theory"
+      "**Partition Arrow**: α → (β, γ)² means every 2-coloring of pairs from α yields homogeneous β or a copy of γ",
+      "**Erdős-Hajnal Positive Result**: ω₁² → (ω₁ω, 3)² — the triangle case is fully proven",
+      "**Baumgartner Negative Result**: ω₁² ↛ (ω₁ω, K_{ℵ₀,ℵ₀})² — the infinite bipartite case fails",
+      "**Both Conditions Essential**: K_{ℵ₀,ℵ₀} is K₄-free (bipartite), so the K_{ℵ₀,ℵ₀}-free condition is independently needed",
+      "**Finite Subproblem**: Whether the relation holds for all finite K₄-free G is itself open",
+      "**Set-Theoretic Sensitivity**: The answer may depend on axioms like CH or Martin's Axiom"
     ]
   },
   "sections": [
     {
       "id": "ordinal-notation",
       "title": "Ordinal Notation",
-      "startLine": 35,
-      "endLine": 61,
-      "summary": "ω₁, ω, ω₁ω, ω₁² definitions"
+      "startLine": 32,
+      "endLine": 56,
+      "summary": "Definitions of ω₁, ω, ω₁ω, and ω₁² as ordinals"
+    },
+    {
+      "id": "graph-structures",
+      "title": "Graph Structures",
+      "startLine": 58,
+      "endLine": 91,
+      "summary": "SimpleGraph', containsClique, isK4Free, containsCountableBiclique, isKAleph0Free, hasAtMostAleph1Vertices"
     },
     {
       "id": "partition-arrow",
       "title": "Partition Arrow Notation",
-      "startLine": 63,
-      "endLine": 95,
-      "summary": "α → (β, γ)² relation and graph structures"
+      "startLine": 93,
+      "endLine": 102,
+      "summary": "Axiomatized partition relation α → (β, γ)²"
     },
     {
-      "id": "main-question",
-      "title": "The Main Question",
-      "startLine": 97,
-      "endLine": 128,
-      "summary": "K₄-free, K_{ℵ₀,ℵ₀}-free conditions and the conjecture"
+      "id": "main-conjecture",
+      "title": "The Main Conjecture",
+      "startLine": 104,
+      "endLine": 123,
+      "summary": "erdos597Conjecture and finiteCaseConjecture definitions"
     },
     {
       "id": "known-results",
       "title": "Known Results",
-      "startLine": 130,
-      "endLine": 156,
-      "summary": "Erdős-Hajnal triangle case, Baumgartner counterexample"
+      "startLine": 125,
+      "endLine": 141,
+      "summary": "Erdős-Hajnal triangle theorem and Baumgartner counterexample"
     },
     {
-      "id": "finite-case",
-      "title": "Finite Case",
-      "startLine": 158,
-      "endLine": 181,
-      "summary": "The question restricted to finite K₄-free graphs"
-    },
-    {
-      "id": "partition-calculus",
-      "title": "Partition Calculus Background",
-      "startLine": 183,
-      "endLine": 213,
-      "summary": "Erdős-Rado theorem, stepping-up lemmas"
-    },
-    {
-      "id": "set-theory",
-      "title": "Set-Theoretic Context",
-      "startLine": 215,
-      "endLine": 238,
-      "summary": "ZFC dependence, role of ℵ₁, consistency"
+      "id": "background",
+      "title": "Background and Context",
+      "startLine": 143,
+      "endLine": 171,
+      "summary": "Why both conditions are needed, partition calculus background, set-theoretic context"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 264,
-      "endLine": 302,
-      "summary": "Open problem status and known partial results"
+      "startLine": 173,
+      "endLine": 189,
+      "summary": "erdos597_knownResults theorem combining positive and negative results"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #597 is OPEN. The question asks whether ω₁² → (ω₁ω, G)² holds for graphs G on ≤ℵ₁ vertices with no K₄ and no K_{ℵ₀,ℵ₀}. Erdős-Hajnal proved the triangle case (G = K₃), but Baumgartner showed the relation fails for G = K_{ℵ₀,ℵ₀}. The combined condition (both forbidden subgraphs) remains unresolved.",
-    "implications": "This is a fundamental problem in infinite Ramsey theory connecting partition calculus with graph theory. A positive answer would extend the Erdős-Hajnal result significantly. A negative answer would require a subtle counterexample respecting both forbidden subgraph conditions.",
+    "summary": "Erdős Problem #597 remains OPEN. The formalization captures the two known partial results: Erdős-Hajnal proved ω₁² → (ω₁ω, 3)² (triangle case positive), and Baumgartner proved ω₁² ↛ (ω₁ω, K_{ℵ₀,ℵ₀})² (infinite bipartite case negative). The main question — whether the relation holds for all K₄-free, K_{ℵ₀,ℵ₀}-free graphs on ≤ℵ₁ vertices — sits in the gap between these results.",
+    "implications": "A positive answer would significantly extend the Erdős-Hajnal result from triangles to a broad class of graphs. A negative answer would require a subtle counterexample that is both K₄-free and K_{ℵ₀,ℵ₀}-free. The problem connects partition calculus, graph Ramsey theory, and set-theoretic independence, making it a central question in infinite combinatorics.",
     "openQuestions": [
-      "Does the relation hold for all finite K₄-free graphs?",
-      "What is the role of set-theoretic axioms beyond ZFC?",
-      "Can the K₄-free condition be relaxed?",
-      "What about higher ordinal powers like ω₂²?"
+      "Does ω₁² → (ω₁ω, G)² hold for all finite K₄-free graphs G?",
+      "Is the answer to Problem #597 independent of ZFC?",
+      "Can the K₄-free condition be relaxed to K_n-free for larger n?",
+      "What about analogous questions for higher ordinal powers like ω₂²?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Rewrote Lean proof: removed all trivial `True` axioms and `True := trivial`, added substantive graph definitions (`SimpleGraph'`, `containsClique`, `containsCountableBiclique`), meaningful partition relation axiom
- Updated meta.json with 3-paragraph historicalContext, mathlibDependencies, originalContributions, and corrected section line numbers
- Rewrote annotations.json with 9 substantive annotations covering all major definitions, axioms, and the summary theorem

## Checklist
- [x] Lean proof compiles
- [x] pnpm build succeeds
- [x] Annotations align with Lean file
- [x] No `True := trivial` or trivial `axiom : True`
- [x] historicalContext has 3 substantive paragraphs
- [x] 9 annotations with correct line ranges

Generated by enhancer-2