### PR TITLE
Enhance erdos-81: fix header, remove problematic axioms

### DIFF
--- a/proofs/Proofs/Erdos81Problem.lean
+++ b/proofs/Proofs/Erdos81Problem.lean
@@ -1,5 +1,5 @@
-/-
-Erdős Problem #81: Clique Partitions of Chordal Graphs
+/-!
+# Erdős Problem #81: Clique Partitions of Chordal Graphs
 
 Source: https://erdosproblems.com/81
 Status: OPEN
@@ -180,17 +180,6 @@ def erdos_81_conjecture : Prop :=
     @IsChordal V hV _ G →
     @cliquePartitionNumber V hV _ G ≤ (Fintype.card V)^2 / 6 + Fintype.card V
 
-/--
-**Status: OPEN**
-The conjecture remains unresolved. There is a gap between:
-- Lower bound: n²/6 (extremal construction)
-- Upper bound: (1/4 - ε)n² (Erdős-Ordman-Zalcstein)
-The gap factor is 1/4 ÷ 1/6 = 3/2.
--/
-axiom erdos_81_gap_open :
-    (1 : ℚ) / 4 > 1 / 6 ∧
-    ¬erdos_81_conjecture
-
 /-!
 ## Part VI: Gap Analysis
 -/
@@ -204,16 +193,6 @@ The multiplicative gap is about 1.5×.
 -/
 theorem gap_analysis :
     (1 : ℚ) / 4 > 1 / 6 := by norm_num
-
-/--
-**If the conjecture is true:**
-Then split graphs are the "hardest" case for clique partitions.
--/
-axiom split_graphs_extremal :
-    erdos_81_conjecture →
-    (∀ (V : Type) [Fintype V] [DecidableEq V] (G : SimpleGraph V),
-      @IsChordal V _ _ G → @IsSplitGraph V _ _ G →
-      @cliquePartitionNumber V _ _ G ≤ (Fintype.card V)^2 / 6 + Fintype.card V)
 
 /-!
 ## Part VII: Perfect Elimination Ordering

--- a/src/data/proofs/erdos-81/annotations.json
+++ b/src/data/proofs/erdos-81/annotations.json
@@ -110,20 +110,9 @@
     "significance": "critical"
   },
   {
-    "id": "ann-81-gap-open",
-    "proofId": "erdos-81",
-    "range": { "startLine": 190, "endLine": 192 },
-    "type": "axiom",
-    "title": "Gap Status: OPEN",
-    "content": "`erdos_81_gap_open` asserts two facts: (1) the rational inequality $1/4 > 1/6$ (the gap exists), and (2) the conjecture `erdos_81_conjecture` is false (i.e., the problem remains unresolved — no proof of the conjecture exists).",
-    "mathContext": "This axiom encodes the current state of knowledge. The first conjunct is a trivial arithmetic fact. The second conjunct, $\\neg$`erdos_81_conjecture`, is a modeling choice: since the conjecture is open, we cannot assume it true. In a formal sense, axiomatizing its negation prevents the proof from being trivialized. If the conjecture is eventually proved, this axiom would need to be removed.",
-    "relatedConcepts": ["erdos_81_conjecture", "Rational arithmetic", "open problem status"],
-    "significance": "key"
-  },
-  {
     "id": "ann-81-gap-analysis",
     "proofId": "erdos-81",
-    "range": { "startLine": 205, "endLine": 206 },
+    "range": { "startLine": 194, "endLine": 195 },
     "type": "theorem",
     "title": "Gap Analysis",
     "content": "`gap_analysis`: The rational inequality $(1 : \\mathbb{Q})/4 > 1/6$, proved by `norm_num`. This quantifies the gap between the upper bound coefficient $1/4$ and the conjectured coefficient $1/6$.",
@@ -132,20 +121,9 @@
     "significance": "supporting"
   },
   {
-    "id": "ann-81-split-extremal",
-    "proofId": "erdos-81",
-    "range": { "startLine": 212, "endLine": 216 },
-    "type": "axiom",
-    "title": "Split Graphs as Extremal Case",
-    "content": "`split_graphs_extremal`: If the conjecture is true, then split graphs also satisfy the $n^2/6 + O(n)$ bound. This is a logical consequence — split graphs are chordal, so the conjecture implies the bound for them.",
-    "mathContext": "This axiom is logically redundant (it follows from the conjecture and `split_is_chordal`), but it highlights the structural insight: the extremal construction is a split graph, and split graphs may be the 'hardest' case. If a proof of the conjecture proceeds by first handling split graphs, this would be a natural intermediate step.",
-    "relatedConcepts": ["erdos_81_conjecture", "IsSplitGraph", "IsChordal"],
-    "significance": "supporting"
-  },
-  {
     "id": "ann-81-simplicial",
     "proofId": "erdos-81",
-    "range": { "startLine": 229, "endLine": 230 },
+    "range": { "startLine": 208, "endLine": 209 },
     "type": "definition",
     "title": "Simplicial Vertex",
     "content": "`IsSimplicial G v` states that for vertex $v$, all pairs of neighbors are adjacent — i.e., the neighborhood $N(v)$ forms a clique.",
@@ -156,7 +134,7 @@
   {
     "id": "ann-81-peo",
     "proofId": "erdos-81",
-    "range": { "startLine": 237, "endLine": 247 },
+    "range": { "startLine": 216, "endLine": 226 },
     "type": "definition",
     "title": "Perfect Elimination Ordering and Characterization",
     "content": "`HasPerfectEliminationOrdering G` states that there exists a bijection $\\sigma : \\text{Fin}\\,|V| \\to V$ such that each $\\sigma(i)$ is simplicial in the subgraph induced by $\\{\\sigma(j) : j \\geq i\\}$.\n\n`chordal_iff_peo` (line 246): A graph is chordal if and only if it has a PEO. This is the Fulkerson-Gross theorem (1965).",
@@ -167,7 +145,7 @@
   {
     "id": "ann-81-peo-partition",
     "proofId": "erdos-81",
-    "range": { "startLine": 259, "endLine": 261 },
+    "range": { "startLine": 238, "endLine": 240 },
     "type": "axiom",
     "title": "PEO-Based 2-Approximation",
     "content": "`peo_gives_clique_partition`: For a chordal graph, the PEO-based greedy algorithm produces a clique partition with $\\leq 2 \\cdot \\overline{\\chi}(G)$ cliques, where $\\overline{\\chi}(G)$ is the optimal clique partition number.",
@@ -178,7 +156,7 @@
   {
     "id": "ann-81-optimal-partition",
     "proofId": "erdos-81",
-    "range": { "startLine": 269, "endLine": 272 },
+    "range": { "startLine": 248, "endLine": 251 },
     "type": "axiom",
     "title": "Existence of Optimal Partition",
     "content": "`optimal_partition_open`: For every chordal graph, there exists a clique partition achieving the minimum size. This is the existence assertion for the optimization problem.",
@@ -189,7 +167,7 @@
   {
     "id": "ann-81-intersection",
     "proofId": "erdos-81",
-    "range": { "startLine": 283, "endLine": 296 },
+    "range": { "startLine": 262, "endLine": 275 },
     "type": "definition",
     "title": "Intersection Number and Relation",
     "content": "`intersectionNumber G` is the minimum number of cliques whose edges cover all of $G$'s edges (cliques may overlap). `partition_geq_intersection` (line 295): the clique partition number $\\geq$ the intersection number, since partition is more restrictive than cover.",
@@ -200,7 +178,7 @@
   {
     "id": "ann-81-summary",
     "proofId": "erdos-81",
-    "range": { "startLine": 309, "endLine": 317 },
+    "range": { "startLine": 288, "endLine": 296 },
     "type": "theorem",
     "title": "Summary Theorem",
     "content": "`erdos_81_summary` is a **genuine theorem** for $n \\geq 3$: combines (1) the lower bound — some chordal graph on $n$ vertices needs $\\geq n^2/6$ cliques — with (2) the gap $1/4 > 1/6$. The proof applies `lower_bound` and `norm_num`.",
@@ -211,7 +189,7 @@
   {
     "id": "ann-81-main",
     "proofId": "erdos-81",
-    "range": { "startLine": 325, "endLine": 333 },
+    "range": { "startLine": 304, "endLine": 312 },
     "type": "theorem",
     "title": "Main Theorem",
     "content": "`erdos_81` is a **genuine theorem**: for any chordal graph $G$, combines (1) the Erdős-Ordman-Zalcstein upper bound $(1/4 - \\varepsilon)n^2$ with (2) the PEO-based 2-approximation. The proof directly applies both axiomatized results.",

--- a/src/data/proofs/erdos-81/meta.json
+++ b/src/data/proofs/erdos-81/meta.json
@@ -52,7 +52,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "**Partitioning Edges into Cliques**\n\nA chordal graph is one with no induced cycles of length greater than 3 — equivalently, every cycle of length ≥ 4 has a 'chord' (edge connecting non-adjacent cycle vertices). These graphs arise naturally in sparse matrix computations (Gaussian elimination), database theory (acyclic schemas), and phylogenetics (perfect phylogeny).\n\n**The Question**: How efficiently can we partition the edges of a chordal graph into cliques? The trivial upper bound assigns each edge its own clique, giving O(n²). Can we always achieve n²/6 + O(n)?\n\n**The Extremal Example**: Take K_{n/3} (complete graph on n/3 vertices) and 2n/3 isolated vertices. Connect every K_{n/3} vertex to every isolated vertex. This split graph has (n/3 choose 2) + (n/3)(2n/3) ≈ n²/6 + 2n²/9 edges. The bipartite edges between K_{n/3} and the isolated vertices cannot be efficiently grouped, requiring ≈ n²/6 cliques.\n\n**Known Bounds**: Erdős, Ordman, and Zalcstein (1993) proved (1/4 − ε)n² suffices for some small ε > 0. Chen, Erdős, and Ordman (1994) improved this to 3n²/16 + O(n) for the special case of split graphs. The gap between 1/6 ≈ 0.167 and 1/4 ≈ 0.25 remains open.\n\n**Structural Insight**: Chordal graphs are characterized by having a perfect elimination ordering (Dirac 1961, Fulkerson-Gross 1965) — vertices can be removed one at a time such that each removed vertex's remaining neighbors form a clique. This gives a polynomial-time recognition algorithm and a greedy clique partition, but the greedy approach is only a 2-approximation.",
+    "historicalContext": "A chordal graph is one with no induced cycles of length greater than 3, equivalently every cycle of length 4 or more has a chord. These graphs arise naturally in sparse matrix computations, database theory, and phylogenetics. Erdős, Ordman, and Zalcstein asked in 1993 how efficiently the edges of a chordal graph on n vertices can be partitioned into cliques, conjecturing that n²/6 + O(n) cliques always suffice.\n\nThe lower bound comes from an explicit extremal construction: take K_{n/3} and 2n/3 isolated vertices, connecting every K_{n/3} vertex to every isolated vertex. This split graph requires approximately n²/6 cliques because the bipartite edges between the clique and independent set cannot be efficiently grouped. Erdős, Ordman, and Zalcstein proved the upper bound that (1/4 - ε)n² cliques always suffice for some small ε > 0. Chen, Erdős, and Ordman (1994) improved this to 3n²/16 + O(n) for the special case of split graphs.\n\nThe gap between the upper bound coefficient 1/4 and the conjectured coefficient 1/6 (a factor of approximately 1.5) remains open. Chordal graphs are characterized by having a perfect elimination ordering (Dirac 1961, Fulkerson-Gross 1965), which gives a polynomial-time recognition algorithm and a greedy clique partition that is a 2-approximation, but the optimal coefficient for clique partitions remains unknown.",
     "problemStatement": "**Problem Statement**\n\nLet G be a chordal graph on n vertices (no induced cycles of length > 3). Can the edges of G be partitioned into n²/6 + O(n) many cliques?\n\n**Key Definitions**:\n- **Chordal graph**: Every cycle of length ≥ 4 has a chord\n- **Clique partition**: Partition of edges into complete subgraphs\n- **Split graph**: Vertices partition into a clique and independent set (special case of chordal)\n\n**Known Results**:\n- Lower bound: n²/6 + O(n) is sometimes necessary (extremal construction)\n- Upper bound: (1/4 − ε)n² cliques suffice (Erdős-Ordman-Zalcstein)\n- Split graphs: 3n²/16 + O(n) cliques suffice (Chen-Erdős-Ordman)\n\n**Status**: OPEN",
     "proofStrategy": "**Approach and Known Techniques**\n\n**Upper Bound Strategy** (lines 153–167):\n1. Use the perfect elimination ordering (chordal ↔ PEO, line 246)\n2. The PEO-based greedy algorithm gives a 2-approximation (line 259)\n3. The Erdős-Ordman-Zalcstein bound of (1/4 − ε)n² (line 158) uses structural analysis beyond greedy\n\n**Lower Bound Construction** (lines 129–147):\n1. Take K_{n/3} (complete graph on n/3 vertices)\n2. Add 2n/3 isolated vertices and connect all K_{n/3} vertices to all isolated vertices\n3. This split graph (line 132) requires ≈ n²/6 cliques\n4. The `lower_bound` theorem (line 140) derives the chordal lower bound from the split graph construction via `split_is_chordal`\n\n**The Gap** (lines 190–206):\nCurrent upper bound coefficient 1/4 vs conjectured 1/6, a factor of 3/2. Closing this requires either:\n- Better structural analysis of chordal clique partitions, or\n- A counterexample exceeding n²/6 + O(n)\n\n**Main Theorems** (lines 309–333):\n- `erdos_81_summary`: combines the lower bound and gap analysis\n- `erdos_81`: combines the upper bound and PEO 2-approximation for any chordal graph",
     "keyInsights": [
@@ -97,35 +97,35 @@
       "id": "conjecture",
       "title": "The Main Conjecture and Gap",
       "startLine": 169,
-      "endLine": 216,
-      "summary": "The open conjecture (n²/6 + O(n)), gap analysis, and split graphs as potential extremal case"
+      "endLine": 195,
+      "summary": "The open conjecture (n²/6 + O(n)) and gap analysis"
     },
     {
       "id": "peo",
       "title": "Perfect Elimination Ordering",
-      "startLine": 218,
-      "endLine": 247,
+      "startLine": 197,
+      "endLine": 226,
       "summary": "Simplicial vertices, PEO definition, and the chordal ↔ PEO characterization"
     },
     {
       "id": "computational",
       "title": "Computational Aspects",
-      "startLine": 249,
-      "endLine": 272,
+      "startLine": 228,
+      "endLine": 251,
       "summary": "PEO-based 2-approximation algorithm and the open algorithmic question"
     },
     {
       "id": "related",
       "title": "Related Problems",
-      "startLine": 274,
-      "endLine": 296,
+      "startLine": 253,
+      "endLine": 275,
       "summary": "Intersection number (clique cover) and its relation to clique partition number"
     },
     {
       "id": "summary",
       "title": "Summary and Main Theorems",
-      "startLine": 298,
-      "endLine": 335,
+      "startLine": 277,
+      "endLine": 314,
       "summary": "Summary theorem combining lower bound and gap; main theorem combining upper bound and PEO approximation"
     }
   ],


### PR DESCRIPTION
## Summary
- Change `/-` header to `/-!` doc comment
- Remove `erdos_81_gap_open` axiom (incorrectly asserts negation of an open conjecture)
- Remove `split_graphs_extremal` axiom (logically redundant)
- Rewrite historicalContext as 3 clean prose paragraphs
- Update section line numbers and annotation ranges

## Test plan
- [x] `pnpm build` passes
- [ ] Verify Lean file uses `/-!` header
- [ ] Verify no axiom asserts negation of open conjecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)