### PR TITLE
fix(erdos-879): remove True/trivial patterns, trim trivial axioms

### DIFF
--- a/proofs/Proofs/Erdos879Problem.lean
+++ b/proofs/Proofs/Erdos879Problem.lean
@@ -36,9 +36,7 @@ open Nat Finset BigOperators
 
 namespace Erdos879
 
-/-
-## Part I: Admissible Sets
--/
+/-! ## Part I: Admissible Sets -/
 
 /--
 **Pairwise Coprime (Admissible):**
@@ -60,9 +58,7 @@ The collection of all admissible subsets of {1, ..., n}.
 def admissibleSetsUpTo (n : ℕ) : Set (Finset ℕ) :=
   {S | S ⊆ Finset.range (n + 1) ∧ IsAdmissible S}
 
-/-
-## Part II: The Functions G(n) and H(n)
--/
+/-! ## Part II: The Functions G(n) and H(n) -/
 
 /--
 **G(n): Maximum Sum of Admissible Sets**
@@ -92,75 +88,55 @@ H(n) = Σ_{p < n} p + n · π(√n)
 noncomputable def H (n : ℕ) : ℕ :=
   sumOfPrimes n + n * primeCountingFn (Nat.sqrt n)
 
-/-
-## Part III: The Erdős-Van Lint Bounds
--/
+/-! ## Part III: The Erdős-Van Lint Bounds -/
 
 /--
-**Upper Bound:**
-G(n) < H(n) for all n.
-
-Intuition: The set of primes < n plus certain semiprimes gives a good
-admissible set, but you can't do better than H(n).
+**Upper Bound (Erdős-Van Lint):**
+G(n) < H(n) for all n ≥ 2. The set of primes plus semiprimes cannot
+exceed H(n) in total sum.
 -/
 axiom G_upper_bound (n : ℕ) (hn : n ≥ 2) :
   G n < H n
 
 /--
-**Lower Bound:**
-G(n) > H(n) - n^{3/2 - o(1)}.
-
-The gap H(n) - G(n) is at most about n^{3/2}.
+**Lower Bound (Erdős-Van Lint):**
+G(n) > H(n) - c·n^{3/2} for some constant c > 0. The gap between
+H(n) and G(n) is at most of order n^{3/2}.
 -/
 axiom G_lower_bound (n : ℕ) (hn : n ≥ 2) :
   ∃ c : ℝ, c > 0 ∧ (G n : ℝ) > (H n : ℝ) - c * (n : ℝ)^(3/2 : ℝ)
 
 /--
-**Gap Growth:**
-(H(n) - G(n))/n → ∞ as n → ∞.
-
-The gap between H(n) and G(n) grows faster than linearly.
+**Gap Growth (Erdős-Van Lint):**
+(H(n) - G(n))/n → ∞ as n → ∞. The gap grows faster than linearly,
+so G(n) is genuinely smaller than H(n) by more than O(n).
 -/
 axiom gap_grows :
   ∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, ((H n : ℝ) - (G n : ℝ)) / n > M
 
-/-
-## Part IV: Question 1 (Open)
--/
+/-! ## Part IV: Question 1 (Open) -/
 
 /--
 **Question 1: Tighter Lower Bound?**
-Is G(n) > H(n) - n^{1+o(1)}?
-
-This asks if the gap can be bounded by n^{1+ε} for any ε > 0.
+Is G(n) > H(n) - n^{1+o(1)}? This asks if the gap can be bounded
+by n^{1+ε} for any ε > 0, improving the known n^{3/2} bound.
 -/
 def Question1 : Prop :=
   ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N,
     (G n : ℝ) > (H n : ℝ) - (n : ℝ)^(1 + ε)
 
-/--
-**Conditional Result:**
-Erdős-Van Lint proved Question 1 holds under "plausible assumptions"
-about the distribution of primes (related to the twin prime conjecture).
--/
-axiom question1_conditional :
-  -- Under plausible prime distribution assumptions
-  True → Question1
-
-/-
-## Part V: Question 2 (Partially Solved)
--/
+/-! ## Part V: Question 2 (Partially Solved) -/
 
 /--
-**Number of Prime Factors:**
-The number of prime factors of n (with multiplicity).
+**Number of Distinct Prime Factors:**
+The number of distinct prime factors of n (ω(n) in standard notation).
 -/
 noncomputable def numPrimeFactors (n : ℕ) : ℕ :=
   n.factorization.support.card
 
 /--
-**Has Many Prime Factors:**
-n has at least k prime factors.
+**Has At Least k Prime Factors:**
+n has at least k distinct prime factors.
 -/
 def hasManyPrimeFactors (n k : ℕ) : Prop :=
   numPrimeFactors n ≥ k
@@ -168,7 +144,7 @@ def hasManyPrimeFactors (n k : ℕ) : Prop :=
 /--
 **Question 2: Optimal Set Contains Composite?**
 For every k ≥ 2, does the optimal admissible set for G(n) contain
-at least one integer with at least k prime factors (for large enough n)?
+at least one integer with at least k distinct prime factors (for large enough n)?
 -/
 def Question2 (k : ℕ) : Prop :=
   ∃ N : ℕ, ∀ n ≥ N,
@@ -177,137 +153,40 @@ def Question2 (k : ℕ) : Prop :=
       ∃ m ∈ S, hasManyPrimeFactors m k
 
 /--
-**k = 2 Case (Proved):**
+**k = 2 Case (Proved by Erdős-Van Lint):**
 The optimal admissible set contains at least one semiprime
-(product of two primes) for large enough n.
+(product of two distinct primes) for sufficiently large n.
 -/
 axiom question2_k2 : Question2 2
 
-/--
-**General k (Open):**
-Question 2 for k ≥ 3 remains open.
--/
-axiom question2_general_open :
-  -- Question2 k is open for k ≥ 3
-  True
-
-/-
-## Part VI: The Optimal Admissible Set Structure
--/
+/-! ## Part VI: The Optimal Admissible Set Structure -/
 
 /--
 **Primes are Admissible:**
-The set of all primes < n is admissible (any two primes > 1 are coprime).
+The set of all primes < n is admissible, since distinct primes are coprime.
+This provides a natural baseline admissible set whose sum is close to G(n).
 -/
 theorem primes_admissible (n : ℕ) :
     IsAdmissible (Finset.filter Nat.Prime (Finset.range n)) := by
   intro a ha b hb hab
   simp only [Finset.mem_filter] at ha hb
-  exact Nat.Prime.coprime_iff_not_dvd ha.2 |>.mpr (fun h => hab (hb.2.eq_one_or_self_of_dvd a h |>.resolve_left (by omega)))
+  exact Nat.Prime.coprime_iff_not_dvd ha.2 |>.mpr
+    (fun h => hab (hb.2.eq_one_or_self_of_dvd a h |>.resolve_left (by omega)))
 
-/--
-**Near-Optimal Strategy:**
-Include all primes < n, plus some carefully chosen semiprimes.
-The semiprimes must avoid sharing prime factors with included primes.
--/
-axiom optimal_strategy :
-  -- The optimal set is close to: primes + select semiprimes
-  True
-
-/--
-**Why Semiprimes Help:**
-A semiprime pq (with p, q > √n) can be added to {primes < n}
-if p and q are not in the set. This increases the sum.
--/
-axiom semiprime_contribution :
-  True
-
-/-
-## Part VII: Asymptotic Behavior
--/
-
-/--
-**H(n) Asymptotics:**
-H(n) ~ n²/(2 ln n) as n → ∞ (dominated by sum of primes).
--/
-axiom H_asymptotic :
-  True  -- H(n) is asymptotically n²/(2 ln n)
-
-/--
-**G(n) Asymptotics:**
-G(n) ~ H(n) as n → ∞, but with a subtractive gap.
--/
-axiom G_asymptotic :
-  True  -- G(n) is close to H(n) for large n
-
-/--
-**Gap Asymptotics:**
-H(n) - G(n) is between n^{1+o(1)} and n^{3/2-o(1)} (conjecturally closer to n^1).
--/
-axiom gap_asymptotic :
-  True  -- The exact gap exponent is unknown
-
-/-
-## Part VIII: Related Problems
--/
-
-/--
-**OEIS A186736:**
-The sequence G(n) for small n.
--/
-axiom oeis_a186736 :
-  -- G(1) = 1, G(2) = 3, G(3) = 5, ...
-  True
-
-/--
-**Problem #878:**
-A related problem about admissible sets and their properties.
--/
-axiom related_problem_878 :
-  True
-
-/--
-**Primitive Sets:**
-A related concept: a set where no element divides another.
--/
-axiom primitive_sets_connection :
-  True
-
-/-
-## Part IX: Summary
--/
+/-! ## Part VII: Summary -/
 
 /--
 **Erdős Problem #879: Summary**
 
-PROBLEM:
-1. Is G(n) > H(n) - n^{1+o(1)}?
-2. Does the optimal admissible set contain composites with many prime factors?
-
-STATUS: OPEN (Question 2 solved for k = 2)
-
-KNOWN RESULTS (Erdős-Van Lint):
-- H(n) - n^{3/2-o(1)} < G(n) < H(n)
-- (H(n) - G(n))/n → ∞
-- Question 1 holds conditionally on prime distribution
-- Question 2 holds for k = 2
-
-KEY INSIGHT: The optimal admissible set consists of primes plus
-carefully chosen composites (semiprimes, etc.) to maximize the sum.
+Combines the three main known results of Erdős-Van Lint:
+1. Upper bound: G(n) < H(n) for all n ≥ 2
+2. Lower bound: G(n) > H(n) - c·n^{3/2} for some c > 0
+3. Question 2 for k = 2: optimal sets contain semiprimes
 -/
 theorem erdos_879_summary :
-    -- Upper bound: G(n) < H(n)
     (∀ n ≥ 2, G n < H n) ∧
-    -- Lower bound: G(n) > H(n) - n^{3/2}
     (∀ n ≥ 2, ∃ c : ℝ, c > 0 ∧ (G n : ℝ) > (H n : ℝ) - c * (n : ℝ)^(3/2 : ℝ)) ∧
-    -- k = 2 case is solved
-    Question2 2 := by
-  refine ⟨G_upper_bound, fun n hn => G_lower_bound n hn, question2_k2⟩
-
-/--
-**Erdős Problem #879: OPEN**
-Both main questions remain partially open.
--/
-theorem erdos_879 : True := trivial
+    Question2 2 :=
+  ⟨G_upper_bound, fun n hn => G_lower_bound n hn, question2_k2⟩
 
 end Erdos879

--- a/src/data/proofs/erdos-879/annotations.json
+++ b/src/data/proofs/erdos-879/annotations.json
@@ -1,182 +1,90 @@
 [
   {
-    "id": "ann-879-1",
+    "id": "ann-e879-header",
     "proofId": "erdos-879",
     "range": { "startLine": 1, "endLine": 28 },
-    "type": "context",
+    "type": "concept",
     "title": "Problem Overview",
-    "content": "Erdos Problem #879 studies the maximum sum G(n) of pairwise coprime (admissible) subsets of {1,...,n}. Two key questions: (1) Is G(n) > H(n) - n^{1+o(1)}? (2) Does the optimal set contain integers with many prime factors? Known bounds: H(n) - n^{3/2-o(1)} < G(n) < H(n).",
-    "significance": "high"
+    "content": "**Erdős Problem #879** studies the maximum sum achievable by a pairwise coprime subset of {1,...,n}. A set is called *admissible* if every pair of its elements is coprime (their GCD is 1). The function G(n) denotes this maximum sum, and H(n) = Σ_{p<n} p + n·π(√n) is a natural comparison function based on sums of primes. Erdős and Van Lint established tight bounds showing G(n) is close to H(n), but the exact gap remains unknown. Two key questions are posed: whether the gap is at most n^{1+o(1)}, and whether optimal admissible sets must contain composites with many prime factors.",
+    "mathContext": "The problem combines additive combinatorics with analytic number theory. The comparison function H(n) arises from considering the sum of all primes below n plus a correction for semiprimes pq where p, q > √n. By the prime number theorem, H(n) ~ n²/(2 ln n).",
+    "significance": "critical",
+    "relatedConcepts": ["pairwise coprime", "admissible sets", "prime sums", "additive combinatorics"]
   },
   {
-    "id": "ann-879-2",
+    "id": "ann-e879-admissible",
     "proofId": "erdos-879",
-    "range": { "startLine": 47, "endLine": 48 },
+    "range": { "startLine": 41, "endLine": 59 },
     "type": "definition",
-    "title": "Admissible Set",
-    "content": "IsAdmissible S means gcd(a,b) = 1 for all distinct a, b in S. Such sets are called 'pairwise coprime'. The primes form a canonical admissible set, but optimal sets also include carefully chosen composites.",
-    "significance": "high"
+    "title": "Admissible Sets and Their Sums",
+    "content": "**IsAdmissible** formalizes the key property: a finite set S of natural numbers is admissible if gcd(a,b) = 1 for every pair of distinct elements a, b ∈ S. This uses Lean's `Nat.Coprime` from Mathlib. The function **setSum** computes Σ_{a ∈ S} a using Finset.sum, and **admissibleSetsUpTo** collects all admissible subsets of {1,...,n} as a Set of Finsets. The optimization problem asks: among all such admissible subsets, which one has the largest sum?",
+    "mathContext": "Pairwise coprimality is a strong condition that forces elements to have disjoint prime factorizations. The primes themselves trivially satisfy this, making them a natural starting point for constructing large-sum admissible sets.",
+    "significance": "critical",
+    "relatedConcepts": ["Nat.Coprime", "Finset", "pairwise coprime", "optimization"]
   },
   {
-    "id": "ann-879-3",
+    "id": "ann-e879-functions",
     "proofId": "erdos-879",
-    "range": { "startLine": 54, "endLine": 54 },
+    "range": { "startLine": 63, "endLine": 89 },
     "type": "definition",
-    "title": "Set Sum",
-    "content": "setSum S = sum of all elements in S. The goal is to maximize this over all admissible subsets of {1,...,n}.",
-    "significance": "medium"
+    "title": "The Functions G(n) and H(n)",
+    "content": "**G(n)** is defined as the supremum of setSum over all admissible subsets of {1,...,n}. Since the search space is finite, this supremum is achieved. The **comparison function H(n)** equals the sum of all primes below n, plus n times the number of primes up to √n. The term n·π(√n) accounts for the contribution of semiprimes pq with p, q > √n that can augment the prime set. The definitions use **primeCountingFn** (π(x) = |{p ≤ x : p prime}|) and **sumOfPrimes** (Σ_{p<n} p), both defined constructively using Finset.filter.",
+    "mathContext": "The definition of G uses sSup on a set of natural numbers, which is noncomputable. H(n) is also noncomputable due to primality testing in the filter. Both are well-defined since the underlying sets are finite.",
+    "significance": "critical",
+    "relatedConcepts": ["sSup", "prime counting function", "sum of primes", "noncomputable"]
   },
   {
-    "id": "ann-879-4",
+    "id": "ann-e879-bounds",
     "proofId": "erdos-879",
-    "range": { "startLine": 60, "endLine": 61 },
-    "type": "definition",
-    "title": "Admissible Sets Up To n",
-    "content": "admissibleSetsUpTo n collects all admissible subsets of {1,...,n}. This is the search space for maximizing the sum.",
-    "significance": "medium"
+    "range": { "startLine": 91, "endLine": 115 },
+    "type": "axiom",
+    "title": "Erdős-Van Lint Bounds",
+    "content": "The three core results of Erdős and Van Lint are axiomatized here. **G_upper_bound** states G(n) < H(n) for n ≥ 2: no admissible set can beat the primes-plus-semiprimes benchmark. **G_lower_bound** states G(n) > H(n) - c·n^{3/2} for some positive constant c, establishing that the gap is at most O(n^{3/2}). **gap_grows** captures the divergence (H(n) - G(n))/n → ∞, showing the gap is superlinear even though it's subquadratic. Together, these pin down G(n) as asymptotically close to H(n) with a gap between n^{1+o(1)} and n^{3/2-o(1)}.",
+    "mathContext": "These results require deep estimates from analytic number theory involving sieve methods and prime distribution, placing them well beyond current Mathlib capabilities. The lower bound proof constructs explicit large admissible sets using primes and carefully chosen semiprimes.",
+    "significance": "critical",
+    "relatedConcepts": ["asymptotic bounds", "sieve methods", "analytic number theory"]
   },
   {
-    "id": "ann-879-5",
+    "id": "ann-e879-question1",
     "proofId": "erdos-879",
-    "range": { "startLine": 71, "endLine": 72 },
-    "type": "definition",
-    "title": "G(n) - Maximum Sum",
-    "content": "G(n) = max{sum(S) : S is admissible in {1,...,n}}. This is the main function of interest. Computing G(n) exactly is difficult; the problem asks about its asymptotic behavior relative to H(n).",
-    "significance": "high"
+    "range": { "startLine": 117, "endLine": 126 },
+    "type": "concept",
+    "title": "Question 1: Tighter Gap Bound",
+    "content": "**Question1** formalizes the open conjecture: for every ε > 0, does G(n) > H(n) - n^{1+ε} hold for all sufficiently large n? This would improve the known n^{3/2} gap to n^{1+o(1)}. Erdős and Van Lint showed this holds under plausible assumptions about prime distribution (related to prime gaps and the twin prime conjecture), but an unconditional proof remains elusive. The formalization expresses this as a ∀-∃ statement over reals and naturals.",
+    "mathContext": "The connection to prime gaps arises because the gap H(n) - G(n) depends on how many semiprimes pq with p, q > √n can be added to the prime set. Tighter prime gap results would allow more such semiprimes to be included.",
+    "significance": "key",
+    "relatedConcepts": ["prime gaps", "twin prime conjecture", "little-o notation"]
   },
   {
-    "id": "ann-879-6",
+    "id": "ann-e879-question2",
     "proofId": "erdos-879",
-    "range": { "startLine": 78, "endLine": 79 },
-    "type": "definition",
-    "title": "Prime Counting Function",
-    "content": "primeCountingFn(x) = pi(x) = number of primes <= x. This classical function appears in the definition of H(n) and in asymptotic analysis.",
-    "significance": "medium"
+    "range": { "startLine": 128, "endLine": 160 },
+    "type": "concept",
+    "title": "Question 2: Composites in Optimal Sets",
+    "content": "**Question2(k)** asks whether, for sufficiently large n, every optimal admissible set must contain at least one integer with k or more distinct prime factors. The formalization defines **numPrimeFactors** as the cardinality of the support of the prime factorization (counting distinct primes, i.e., ω(n)), and **hasManyPrimeFactors** as the predicate numPrimeFactors(n) ≥ k. The axiom **question2_k2** asserts the k=2 case: optimal sets contain semiprimes for large n. This is the only solved case; k ≥ 3 remains open.",
+    "mathContext": "The k=2 result shows that an optimal admissible set cannot consist solely of primes and 1. Some product of two large primes must be included to achieve the maximum sum. The proof constructs semiprimes pq with p, q > √n that beat replacing them with smaller primes.",
+    "significance": "key",
+    "relatedConcepts": ["prime factorization", "omega function", "semiprimes", "extremal sets"]
   },
   {
-    "id": "ann-879-7",
+    "id": "ann-e879-primes",
     "proofId": "erdos-879",
-    "range": { "startLine": 85, "endLine": 86 },
-    "type": "definition",
-    "title": "Sum of Primes",
-    "content": "sumOfPrimes(n) = sum of all primes p < n. Asymptotically, this is about n^2/(2 ln n) by the prime number theorem. This dominates H(n).",
-    "significance": "medium"
-  },
-  {
-    "id": "ann-879-8",
-    "proofId": "erdos-879",
-    "range": { "startLine": 92, "endLine": 93 },
-    "type": "definition",
-    "title": "H(n) - Comparison Function",
-    "content": "H(n) = sum of primes < n + n * pi(sqrt(n)). This serves as a comparison target for G(n). The second term accounts for semiprimes that can be added to the primes.",
-    "significance": "high"
-  },
-  {
-    "id": "ann-879-9",
-    "proofId": "erdos-879",
-    "range": { "startLine": 106, "endLine": 107 },
-    "type": "theorem",
-    "title": "Upper Bound",
-    "content": "G_upper_bound: G(n) < H(n) for n >= 2. You cannot do better than H(n). This is the easy direction of the Erdos-Van Lint bounds.",
-    "significance": "high"
-  },
-  {
-    "id": "ann-879-10",
-    "proofId": "erdos-879",
-    "range": { "startLine": 115, "endLine": 116 },
-    "type": "theorem",
-    "title": "Lower Bound",
-    "content": "G_lower_bound: G(n) > H(n) - c*n^{3/2} for some c > 0. The gap between G(n) and H(n) is at most O(n^{3/2}). This is the harder direction.",
-    "significance": "high"
-  },
-  {
-    "id": "ann-879-11",
-    "proofId": "erdos-879",
-    "range": { "startLine": 124, "endLine": 125 },
-    "type": "theorem",
-    "title": "Gap Growth",
-    "content": "gap_grows: (H(n) - G(n))/n tends to infinity. The gap grows faster than linearly, so G(n) is genuinely smaller than H(n) by more than O(n).",
-    "significance": "medium"
-  },
-  {
-    "id": "ann-879-12",
-    "proofId": "erdos-879",
-    "range": { "startLine": 137, "endLine": 139 },
-    "type": "definition",
-    "title": "Question 1",
-    "content": "Question1: Is G(n) > H(n) - n^{1+epsilon} for all epsilon > 0 and large n? This asks if the gap can be bounded by n^{1+o(1)}, improving the known n^{3/2} bound.",
-    "significance": "high"
-  },
-  {
-    "id": "ann-879-13",
-    "proofId": "erdos-879",
-    "range": { "startLine": 146, "endLine": 148 },
-    "type": "insight",
-    "title": "Conditional Result",
-    "content": "question1_conditional: Erdos-Van Lint proved Question 1 holds under plausible assumptions about prime distribution, related to twin prime-type conjectures.",
-    "significance": "medium"
-  },
-  {
-    "id": "ann-879-14",
-    "proofId": "erdos-879",
-    "range": { "startLine": 158, "endLine": 159 },
-    "type": "definition",
-    "title": "Number of Prime Factors",
-    "content": "numPrimeFactors(n) = number of distinct primes dividing n. This uses the support of the factorization function from Mathlib.",
-    "significance": "medium"
-  },
-  {
-    "id": "ann-879-15",
-    "proofId": "erdos-879",
-    "range": { "startLine": 173, "endLine": 177 },
-    "type": "definition",
-    "title": "Question 2",
-    "content": "Question2(k): For large n, does the optimal admissible set contain an integer with >= k distinct prime factors? This asks whether optimal sets must include 'complicated' composites.",
-    "significance": "high"
-  },
-  {
-    "id": "ann-879-16",
-    "proofId": "erdos-879",
-    "range": { "startLine": 184, "endLine": 184 },
-    "type": "theorem",
-    "title": "k=2 Case Solved",
-    "content": "question2_k2: Question 2 holds for k=2. Optimal sets contain semiprimes (products of two distinct primes) for large n. This is proved by Erdos-Van Lint.",
-    "significance": "high"
-  },
-  {
-    "id": "ann-879-17",
-    "proofId": "erdos-879",
-    "range": { "startLine": 202, "endLine": 206 },
+    "range": { "startLine": 162, "endLine": 174 },
     "type": "theorem",
     "title": "Primes are Admissible",
-    "content": "primes_admissible: The set of all primes < n is admissible. This is because distinct primes are coprime. This provides a baseline admissible set.",
-    "significance": "medium"
+    "content": "**primes_admissible** is the main constructive result: the set of all primes below n is admissible. The proof is direct — given two distinct primes a and b in the filtered set, their coprimality follows from Prime.coprime_iff_not_dvd: prime a is coprime to b unless a divides b, but a prime b can only be divided by 1 or itself, so a = b, contradicting distinctness. This theorem establishes the baseline for the optimization: G(n) is at least as large as the sum of primes below n.",
+    "mathContext": "The proof uses Nat.Prime.coprime_iff_not_dvd and Nat.Prime.eq_one_or_self_of_dvd from Mathlib. The omega tactic handles the arithmetic contradiction. This is a clean example of using Mathlib's prime API for a concrete combinatorial argument.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.Prime.coprime_iff_not_dvd", "Finset.filter", "constructive proof"]
   },
   {
-    "id": "ann-879-18",
+    "id": "ann-e879-summary",
     "proofId": "erdos-879",
-    "range": { "startLine": 219, "endLine": 222 },
-    "type": "insight",
-    "title": "Why Semiprimes Help",
-    "content": "A semiprime pq with p, q > sqrt(n) can be added to the primes < n if p, q are not already in the set. This increases the sum without breaking coprimality.",
-    "significance": "medium"
-  },
-  {
-    "id": "ann-879-19",
-    "proofId": "erdos-879",
-    "range": { "startLine": 298, "endLine": 305 },
+    "range": { "startLine": 176, "endLine": 192 },
     "type": "theorem",
     "title": "Summary Theorem",
-    "content": "erdos_879_summary: Combines the upper bound G(n) < H(n), the lower bound G(n) > H(n) - cn^{3/2}, and the solved k=2 case. This captures the main known results.",
-    "significance": "high"
-  },
-  {
-    "id": "ann-879-20",
-    "proofId": "erdos-879",
-    "range": { "startLine": 311, "endLine": 311 },
-    "type": "theorem",
-    "title": "Erdos 879 Status",
-    "content": "erdos_879: The problem remains OPEN. Question 1 (tighter gap bound) is open unconditionally. Question 2 is open for k >= 3.",
-    "significance": "high"
+    "content": "**erdos_879_summary** combines the three main known results into a single conjunction: (1) the upper bound G(n) < H(n), (2) the lower bound G(n) > H(n) - c·n^{3/2}, and (3) the solved k=2 case of Question 2. The proof is constructive, using `exact ⟨G_upper_bound, fun n hn => G_lower_bound n hn, question2_k2⟩` to assemble the three axioms. This captures the complete state of knowledge for this open problem: tight asymptotic bounds on G(n) and partial structural information about optimal sets.",
+    "mathContext": "The anonymous constructor ⟨...⟩ builds the conjunction directly from the axioms. The lambda `fun n hn => G_lower_bound n hn` wraps the universally quantified lower bound to match the conjunction's expected type.",
+    "significance": "critical",
+    "relatedConcepts": ["conjunction", "anonymous constructor", "axiom composition"]
   }
 ]

--- a/src/data/proofs/erdos-879/meta.json
+++ b/src/data/proofs/erdos-879/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-879",
   "title": "Erdős Problem #879: Maximum Sum of Pairwise Coprime Sets",
   "slug": "erdos-879",
-  "description": "For admissible (pairwise coprime) sets S ⊆ {1,...,n}, is G(n) = max Σa close to H(n) = Σp + n·π(√n)? OPEN: Is G(n) > H(n) - n^{1+o(1)}? Known bounds: H(n) - n^{3/2} < G(n) < H(n).",
+  "description": "For admissible (pairwise coprime) sets S ⊆ {1,...,n}, what is the maximum sum G(n)? Erdős-Van Lint proved H(n) - n^{3/2} < G(n) < H(n) where H(n) = Σp + n·π(√n). Open: Is G(n) > H(n) - n^{1+o(1)}?",
   "meta": {
     "author": "Erdős-Van Lint",
     "sourceUrl": "https://erdosproblems.com/879",
@@ -52,24 +52,24 @@
       "setSum, admissibleSetsUpTo definitions",
       "G function: maximum sum of admissible sets",
       "primeCountingFn, sumOfPrimes, H function",
-      "G_upper_bound, G_lower_bound axioms",
+      "G_upper_bound, G_lower_bound axioms (Erdős-Van Lint bounds)",
       "gap_grows axiom: (H-G)/n → ∞",
-      "Question1 definition: tighter lower bound",
-      "Question2 definition: composites in optimal set",
-      "question2_k2 axiom: k=2 case solved",
-      "primes_admissible theorem"
+      "Question1 definition: tighter lower bound conjecture",
+      "Question2 definition and question2_k2 axiom (k=2 solved)",
+      "primes_admissible theorem: constructive proof",
+      "erdos_879_summary: combines all known results"
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #879: Maximum Sum of Pairwise Coprime Sets**\n\nThis problem studies the optimization of sums over admissible (pairwise coprime) subsets of {1,...,n}.\n\n**Key History:**\n- Erdős and Van Lint established bounds on G(n) relative to H(n)\n- They proved H(n) - n^{3/2-o(1)} < G(n) < H(n)\n- Question 1 holds conditionally on prime distribution assumptions\n- Question 2 (k=2 case) is proved; k≥3 remains open\n\n**Mathematical Setting:**\nThe comparison function H(n) = Σ_{p<n} p + n·π(√n) arises naturally as the sum of primes plus a correction term involving small prime counts.",
+    "historicalContext": "Erdős Problem #879, posed by Paul Erdős in collaboration with J.H. van Lint, investigates the maximum sum achievable by a pairwise coprime subset of {1,...,n}. The problem first appeared in [Er84e] and was revisited in [Er98]. It sits at the intersection of additive combinatorics and analytic number theory, connecting the structure of coprime sets to the distribution of primes.\n\nErdős and Van Lint defined the comparison function H(n) = Σ_{p<n} p + n·π(√n), which represents the sum one would obtain by taking all primes below n plus a correction term for semiprimes involving small primes. They proved the bounds H(n) - n^{3/2-o(1)} < G(n) < H(n), showing that the primes-plus-semiprimes strategy is nearly optimal. They also showed that (H(n) - G(n))/n → ∞, meaning the gap grows faster than linearly.\n\nThe problem poses two open questions. Question 1 asks whether the gap can be tightened to n^{1+o(1)}, which Erdős and Van Lint showed holds under plausible (but unproven) assumptions about prime distribution related to the twin prime conjecture. Question 2 asks whether optimal admissible sets must contain integers with arbitrarily many prime factors; the k=2 case (semiprimes) is proved, but k ≥ 3 remains open. The problem is closely related to Problem #878 and connects to OEIS sequence A186736.",
     "problemStatement": "**Problem Statement (Open)**\n\nCall $S \\subseteq \\{1,\\ldots,n\\}$ **admissible** if $(a,b)=1$ for all distinct $a,b \\in S$. Define:\n$$G(n) = \\max_S \\sum_{a \\in S} a, \\quad H(n) = \\sum_{p<n} p + n\\pi(\\sqrt{n})$$\n\n**Questions:**\n1. Is $G(n) > H(n) - n^{1+o(1)}$?\n2. For every $k \\geq 2$, does the optimal set contain an integer with $\\geq k$ prime factors?\n\n**Known Bounds (Erdős-Van Lint):**\n$$H(n) - n^{3/2-o(1)} < G(n) < H(n)$$\n$$(H(n) - G(n))/n \\to \\infty$$",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Admissibility:** Define IsAdmissible as pairwise coprimality using Nat.Coprime.\n\n2. **Optimization:** G(n) is the supremum of sums over admissible subsets.\n\n3. **Comparison Function:** H(n) uses sumOfPrimes and primeCountingFn.\n\n4. **Bounds:** Axiomatize Erdős-Van Lint bounds as G_upper_bound, G_lower_bound.\n\n5. **Questions:** Formalize Question1 (gap bound) and Question2 (composites in optimal set).\n\n6. **Partial Results:** question2_k2 asserts the k=2 case is proved.",
+    "proofStrategy": "**Formalization Approach**\n\nThe formalization defines the core objects constructively where possible: IsAdmissible captures pairwise coprimality using Nat.Coprime, G(n) is defined as the supremum over sums of admissible sets, and H(n) is built from sumOfPrimes and primeCountingFn.\n\nThe three main results of Erdős-Van Lint are axiomatized since they require deep analytic number theory beyond Mathlib: the upper bound G(n) < H(n), the lower bound G(n) > H(n) - c·n^{3/2}, and the gap growth (H(n)-G(n))/n → ∞. The k=2 case of Question 2 is similarly axiomatized.\n\nThe key constructive result is primes_admissible, which directly proves that the set of primes below n forms an admissible set. The summary theorem erdos_879_summary ties together the three axiomatized bounds with a constructive proof using exact ⟨...⟩.",
     "keyInsights": [
-      "**Primes are Optimal:** The set of all primes < n is admissible with large sum",
-      "**Adding Semiprimes:** Composites pq with p,q > √n can be added for extra sum",
-      "**Gap Growth:** The gap H(n) - G(n) grows faster than linearly but slower than n^{3/2}",
-      "**Conditional Result:** Question 1 holds under assumptions about prime distribution",
-      "**Structural Question:** Question 2 asks about the structure of optimal sets"
+      "**Primes Form an Admissible Set:** Any two distinct primes are coprime, so all primes below n form a natural admissible set whose sum is close to G(n)",
+      "**Semiprimes Boost the Sum:** A semiprime pq with p, q > √n can be added to the prime set without breaking coprimality, increasing the total sum beyond Σp",
+      "**Gap Between G and H:** The gap H(n) - G(n) lies between n^{1+o(1)} (conjectured) and n^{3/2-o(1)} (proved), with the exact exponent unknown",
+      "**Connection to Prime Distribution:** Question 1 holds under assumptions about prime gaps related to the twin prime conjecture",
+      "**Structural Complexity of Optimal Sets:** As n grows, optimal admissible sets must include composites with increasingly many prime factors (proved for k=2, open for k≥3)"
     ]
   },
   "sections": [
@@ -78,74 +78,59 @@
       "title": "Admissible Sets",
       "summary": "IsAdmissible, setSum, admissibleSetsUpTo definitions",
       "startLine": 39,
-      "endLine": 62
+      "endLine": 59
     },
     {
       "id": "functions",
       "title": "The Functions G(n) and H(n)",
       "summary": "G, primeCountingFn, sumOfPrimes, H definitions",
-      "startLine": 63,
-      "endLine": 94
+      "startLine": 61,
+      "endLine": 89
     },
     {
       "id": "bounds",
       "title": "The Erdős-Van Lint Bounds",
       "summary": "G_upper_bound, G_lower_bound, gap_grows axioms",
-      "startLine": 95,
-      "endLine": 126
+      "startLine": 91,
+      "endLine": 115
     },
     {
       "id": "question1",
       "title": "Question 1 (Open)",
-      "summary": "Question1 definition, question1_conditional",
-      "startLine": 127,
-      "endLine": 149
+      "summary": "Question1 definition: tighter lower bound conjecture",
+      "startLine": 117,
+      "endLine": 126
     },
     {
       "id": "question2",
       "title": "Question 2 (Partially Solved)",
-      "summary": "numPrimeFactors, Question2, question2_k2",
-      "startLine": 150,
-      "endLine": 193
+      "summary": "numPrimeFactors, hasManyPrimeFactors, Question2, question2_k2",
+      "startLine": 128,
+      "endLine": 160
     },
     {
       "id": "optimal-structure",
       "title": "Optimal Admissible Set Structure",
-      "summary": "primes_admissible, optimal_strategy",
-      "startLine": 194,
-      "endLine": 224
-    },
-    {
-      "id": "asymptotics",
-      "title": "Asymptotic Behavior",
-      "summary": "H_asymptotic, G_asymptotic, gap_asymptotic",
-      "startLine": 225,
-      "endLine": 249
-    },
-    {
-      "id": "related",
-      "title": "Related Problems",
-      "summary": "oeis_a186736, related_problem_878",
-      "startLine": 250,
-      "endLine": 275
+      "summary": "primes_admissible theorem: constructive proof",
+      "startLine": 162,
+      "endLine": 174
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_879_summary, erdos_879 theorems",
-      "startLine": 276,
-      "endLine": 313
+      "summary": "erdos_879_summary: combines all known results",
+      "startLine": 176,
+      "endLine": 192
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #879 asks about the maximum sum G(n) of pairwise coprime subsets of {1,...,n}. Erdős-Van Lint proved H(n) - n^{3/2} < G(n) < H(n). The main open question is whether G(n) > H(n) - n^{1+o(1)}. For the second question about composites in optimal sets, the k=2 case is solved.",
-    "implications": "**Number Theory Connections**\n\n1. **Prime Distribution:** Question 1 relates to assumptions about twin primes\n\n2. **Additive Combinatorics:** Optimization over structured sets\n\n3. **OEIS A186736:** The sequence G(n) is catalogued\n\n4. **Primitive Sets:** Related to sets with no divisibility relations",
+    "summary": "Erdős Problem #879 asks about the maximum sum G(n) of pairwise coprime subsets of {1,...,n}. Erdős-Van Lint proved the bounds H(n) - n^{3/2} < G(n) < H(n) and that the gap grows superlinearly. The formalization axiomatizes these bounds and the solved k=2 case of Question 2, while constructively proving that the set of primes is admissible.",
+    "implications": "**Number Theory Connections**\n\n1. **Prime Distribution:** Question 1 connects to assumptions about prime gaps and the twin prime conjecture\n\n2. **Additive Combinatorics:** The optimization problem over coprime sets bridges number theory and extremal combinatorics\n\n3. **Structure of Extremal Sets:** Question 2 reveals that optimal coprime sets have rich composite structure, not just primes\n\n4. **Asymptotic Analysis:** H(n) ~ n²/(2 ln n) by the prime number theorem, placing G(n) in the same asymptotic regime",
     "openQuestions": [
-      "Is G(n) > H(n) - n^{1+o(1)}?",
-      "Does the optimal set contain integers with k ≥ 3 prime factors?",
-      "What is the exact gap exponent in H(n) - G(n)?",
-      "Can the gap be computed exactly for small n?",
-      "Connection to the twin prime conjecture?"
+      "Is G(n) > H(n) - n^{1+o(1)}? (Question 1, open)",
+      "Does the optimal set contain integers with k ≥ 3 prime factors? (Question 2 for k ≥ 3, open)",
+      "What is the exact exponent in the gap H(n) - G(n)?",
+      "Can the conditional proof of Question 1 be made unconditional?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Removed `theorem erdos_879 : True := trivial` placeholder
- Removed 9 trivial `True` axioms that added no mathematical content
- Removed `True →` pattern from `question1_conditional`
- Changed section headers from `/-` to `/-!` doc comments
- Rewrote annotations.json with 8 substantive annotations (was 20 with many low-quality ones)
- Updated meta.json with corrected line ranges and improved historicalContext

## Checklist
- [x] Lean proof compiles
- [x] pnpm build succeeds
- [x] No `True := trivial` patterns
- [x] No trivial `True` axioms
- [x] Annotations align with Lean file

Generated by enhancer-4