### PR TITLE
fix(erdos-584): remove sorry/True patterns, add summary theorem

### DIFF
--- a/proofs/Proofs/Erdos584Problem.lean
+++ b/proofs/Proofs/Erdos584Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
   Erdős Problem #584: Cycle-Connected Subgraphs
 
   Source: https://erdosproblems.com/584
@@ -23,6 +23,7 @@
   The main challenge is proving these when δ = n^{-c} for c > 0.
 
   References:
+  - [DuEr82] Duke-Erdős
   - [DER84] Duke-Erdős-Rödl, "More results on subgraphs..."
   - [FoSu08b] Fox-Sudakov, "On a problem of Duke-Erdős-Rödl..."
 -/
@@ -36,9 +37,7 @@ open Nat Real
 
 namespace Erdos584
 
-/-
-## Part I: Graph Definitions
--/
+/-! ## Part I: Graph Definitions -/
 
 /-- A simple graph on n vertices. -/
 structure Graph (n : ℕ) where
@@ -57,17 +56,13 @@ noncomputable def Graph.density {n : ℕ} (G : Graph n) : ℝ :=
 def HasDensity {n : ℕ} (G : Graph n) (δ : ℝ) : Prop :=
   (G.edgeCount : ℝ) ≥ δ * n^2
 
-/-
-## Part II: Subgraphs
--/
+/-! ## Part II: Subgraphs -/
 
 /-- H is a subgraph of G. -/
 def IsSubgraph {n : ℕ} (H G : Graph n) : Prop :=
   H.edges ⊆ G.edges
 
-/-
-## Part III: Cycle Connectivity
--/
+/-! ## Part III: Cycle Connectivity -/
 
 /-- A path in the graph. -/
 structure Path {n : ℕ} (G : Graph n) where
@@ -98,9 +93,7 @@ def AdjacentEdgesOn4Cycle {n : ℕ} (G : Graph n) : Prop :=
     (e1.1 = e2.1 ∨ e1.1 = e2.2 ∨ e1.2 = e2.1 ∨ e1.2 = e2.2) →
     OnCommonCycle G e1 e2 4
 
-/-
-## Part IV: The Main Conjecture
--/
+/-! ## Part IV: The Main Conjecture -/
 
 /-- The H₁ property: 6-cycle connected with adjacent edges on 4-cycles. -/
 def HasH1Property {n : ℕ} (H : Graph n) : Prop :=
@@ -126,16 +119,15 @@ def ErdosConjecture584_H2 : Prop :=
     ∃ H : Graph n, IsSubgraph H G ∧ HasH2Property H ∧
       (H.edgeCount : ℝ) ≥ C * δ^2 * n^2
 
-/-- The full conjecture. -/
+/-- The full conjecture combines both H₁ and H₂. -/
 def ErdosConjecture584 : Prop :=
   ErdosConjecture584_H1 ∧ ErdosConjecture584_H2
 
-/-
-## Part V: Known Results
--/
+/-! ## Part V: Known Results -/
 
 /-- **Duke-Erdős Theorem (1982):**
-    H₁ exists for fixed δ when n is sufficiently large. -/
+    H₁ exists for fixed δ when n is sufficiently large.
+    This was the first partial result, but only applies for fixed density. -/
 axiom duke_erdos_1982 :
     ∀ δ : ℝ, δ > 0 → ∃ N : ℕ, ∀ n ≥ N, ∀ G : Graph n,
       HasDensity G δ → ∃ H : Graph n,
@@ -143,7 +135,8 @@ axiom duke_erdos_1982 :
         (H.edgeCount : ℝ) ≥ δ^3 * n^2 / 1000
 
 /-- **Duke-Erdős-Rödl Theorem (1984):**
-    H₁ with δ⁵ exponent instead of δ³. -/
+    H₁ with δ⁵ exponent instead of the conjectured δ³.
+    The best known uniform bound for H₁. -/
 axiom duke_erdos_rodl_1984 :
     ∃ C : ℝ, C > 0 ∧ ∀ (n : ℕ) (G : Graph n) (δ : ℝ),
       δ > 0 → HasDensity G δ →
@@ -151,23 +144,23 @@ axiom duke_erdos_rodl_1984 :
         (H.edgeCount : ℝ) ≥ C * δ^5 * n^2
 
 /-- **Fox-Sudakov Theorem (2008):**
-    H₂ when δ > n^{-1/5}. -/
+    H₂ when δ > n^{-1/5}. This leaves the sparse regime open. -/
 axiom fox_sudakov_2008 (n : ℕ) (G : Graph n) (δ : ℝ)
     (hδ : δ > 0) (h_lower : δ > (n : ℝ)^(-(1/5 : ℝ)))
     (h_dense : HasDensity G δ) :
     ∃ H : Graph n, IsSubgraph H G ∧ HasH2Property H ∧
       (H.edgeCount : ℝ) ≥ δ^2 * n^2 / 1000
 
-/-
-## Part VI: The Main Challenge
--/
+/-! ## Part VI: The Main Challenge -/
 
 /-- The sparse regime: δ = n^{-c} for some c > 0. -/
 def IsSparseRegime (n : ℕ) (δ : ℝ) (c : ℝ) : Prop :=
   c > 0 ∧ δ = (n : ℝ)^(-c)
 
 /-- **The Main Open Question:**
-    Does the conjecture hold in the sparse regime? -/
+    Does the conjecture hold in the sparse regime?
+    For δ = n^{-c} with 0 < c < 1/2, must there exist a 6-cycle
+    connected subgraph with ≫ δ³n² edges? -/
 def SparseRegimeConjecture : Prop :=
   ∀ c : ℝ, c > 0 → c < 1/2 →
     ∃ C : ℝ, C > 0 ∧ ∀ (n : ℕ) (G : Graph n),
@@ -176,94 +169,37 @@ def SparseRegimeConjecture : Prop :=
       ∃ H : Graph n, IsSubgraph H G ∧ HasH1Property H ∧
         (H.edgeCount : ℝ) ≥ C * δ^3 * n^2
 
-/-- This remains open. -/
-axiom sparse_regime_open : True
+/-! ## Part VII: Quantitative Bounds -/
 
-/-
-## Part VII: Related Concepts
--/
+/-- Best known exponent for H₁: δ⁵ from Duke-Erdős-Rödl (1984). -/
+def bestKnownExponentH1 : ℝ := 5
 
-/-- Girth of a graph: minimum cycle length. -/
-noncomputable def girth {n : ℕ} (G : Graph n) : ℕ :=
-  3  -- Placeholder
+/-- Target exponent for H₁: δ³ is the conjectured bound. -/
+def targetExponentH1 : ℝ := 3
 
-/-- Graphs with high girth have structured cycle connectivity. -/
-axiom high_girth_structure : True
-
-/-- Connection to regularity lemma. -/
-axiom regularity_connection : True
-
-/-- Connection to extremal graph theory. -/
-axiom extremal_connection : True
-
-/-
-## Part VIII: Examples
--/
-
-/-- Complete bipartite graph K_{n,n}. -/
-def completeBipartite (n : ℕ) : Graph (2 * n) where
-  edges := sorry  -- Placeholder
-  symm := sorry
-  no_loops := sorry
-
-/-- Random graphs with edge probability p. -/
-axiom random_graph_cycles (n : ℕ) (p : ℝ) (hp : 0 < p) (hp' : p < 1) :
-    True  -- Random G(n,p) satisfies cycle connectivity with high probability
-
-/-
-## Part IX: Quantitative Bounds
--/
-
-/-- Best known exponent for H₁. -/
-def bestKnownExponentH1 : ℝ := 5  -- δ⁵ from Duke-Erdős-Rödl
-
-/-- Target exponent for H₁. -/
-def targetExponentH1 : ℝ := 3  -- δ³ is the goal
-
-/-- Gap in H₁ exponents. -/
+/-- The gap between known and conjectured exponents is significant. -/
 example : targetExponentH1 < bestKnownExponentH1 := by norm_num
 
-/-- Best known density threshold for H₂. -/
-def bestKnownThresholdH2 : ℝ := 1/5  -- δ > n^{-1/5}
+/-- Best known density threshold for H₂: δ > n^{-1/5} (Fox-Sudakov). -/
+def bestKnownThresholdH2 : ℝ := 1/5
 
-/-
-## Part X: Historical Context
--/
-
-/-- Problem posed by Duke and Erdős. -/
-axiom duke_erdos_origin : True
-
-/-- Rödl contributed to early results. -/
-axiom rodl_contribution : True
-
-/-- Fox-Sudakov made recent progress. -/
-axiom fox_sudakov_progress : True
-
-/-
-## Part XI: Summary
--/
+/-! ## Part VIII: Summary -/
 
 /-- **Summary of Erdős Problem #584:**
+    Formalizes three partial results toward the cycle-connected subgraph conjecture:
+    1. Duke-Erdős (1982): H₁ for fixed δ
+    2. Duke-Erdős-Rödl (1984): H₁ with δ⁵ (best uniform bound)
+    3. Fox-Sudakov (2008): H₂ for δ > n^{-1/5}
 
-PROBLEM: For a graph G with n vertices and δn² edges, find subgraphs:
-- H₁ with ≫ δ³n² edges, 6-cycle connected, adjacent edges on 4-cycles
-- H₂ with ≫ δ²n² edges, 8-cycle connected
-
-STATUS: OPEN
-
-KNOWN RESULTS:
-1. Duke-Erdős (1982): H₁ for fixed δ (n large)
-2. Duke-Erdős-Rödl (1984): H₁ with δ⁵ exponent
-3. Fox-Sudakov (2008): H₂ when δ > n^{-1/5}
-
-MAIN CHALLENGE: Prove for δ = n^{-c} (sparse regime)
-
-The problem connects cycle structure to edge density.
--/
-theorem erdos_584_open : True := trivial
-
-/-- The problem remains open. -/
-def erdos_584_status : String :=
-  "OPEN - Best known: δ⁵ for H₁, δ > n^{-1/5} for H₂"
+    The full conjecture (δ³ for H₁, δ² for H₂ in all regimes) remains OPEN. -/
+theorem erdos_584_summary :
+    (∀ δ : ℝ, δ > 0 → ∃ N : ℕ, ∀ n ≥ N, ∀ G : Graph n,
+      HasDensity G δ → ∃ H : Graph n, IsSubgraph H G ∧ HasH1Property H ∧
+        (H.edgeCount : ℝ) ≥ δ^3 * n^2 / 1000) ∧
+    (∃ C : ℝ, C > 0 ∧ ∀ (n : ℕ) (G : Graph n) (δ : ℝ),
+      δ > 0 → HasDensity G δ →
+      ∃ H : Graph n, IsSubgraph H G ∧ HasH1Property H ∧
+        (H.edgeCount : ℝ) ≥ C * δ^5 * n^2) :=
+  ⟨duke_erdos_1982, duke_erdos_rodl_1984⟩
 
 end Erdos584

--- a/src/data/proofs/erdos-584/annotations.json
+++ b/src/data/proofs/erdos-584/annotations.json
@@ -1,200 +1,79 @@
 [
   {
-    "id": "ann-584-graph",
+    "id": "ann-e584-header",
     "proofId": "erdos-584",
-    "range": { "startLine": 43, "endLine": 48 },
-    "type": "definition",
-    "title": "Graph",
-    "content": "A simple graph on n vertices with edges, symmetry, and no loops.",
-    "significance": "key"
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #584** asks about the relationship between edge density and cycle connectivity in graphs. Given a graph G with n vertices and δn² edges, must there exist subgraphs with many edges where every pair of edges lies on a short common cycle? The problem has two parts: H₁ requires 6-cycle connectivity with ≫ δ³n² edges, and H₂ requires 8-cycle connectivity with ≫ δ²n² edges. The problem was posed by Duke, Erdős, and Rödl and remains open.",
+    "mathContext": "This is a problem in extremal graph theory connecting edge density to local cycle structure. The cycle connectivity requirement is much stronger than ordinary connectivity: it demands that any two edges (not just vertices) share a short cycle. The exponents δ³ and δ² reflect the expected density loss when extracting cycle-connected subgraphs.",
+    "significance": "critical",
+    "relatedConcepts": ["extremal graph theory", "cycle connectivity", "graph density"]
   },
   {
-    "id": "ann-584-edgecount",
+    "id": "ann-e584-graph-defs",
     "proofId": "erdos-584",
-    "range": { "startLine": 50, "endLine": 51 },
+    "range": { "startLine": 40, "endLine": 57 },
     "type": "definition",
-    "title": "edgeCount",
-    "content": "Number of edges in a graph (card/2 for undirected).",
-    "significance": "supporting"
+    "title": "Graph Structure and Density",
+    "content": "**Graph, edgeCount, density, HasDensity** define the basic framework. A Graph on n vertices stores an edge set (as pairs of Fin n) with symmetry and no-loop constraints. The edgeCount divides the set cardinality by 2 (since each undirected edge appears as two ordered pairs). The density δ measures how many edges exist relative to the maximum n². HasDensity G δ states that G has at least δn² edges.",
+    "mathContext": "The formalization uses a custom graph type rather than Mathlib's SimpleGraph to have direct control over the edge set as a Finset, which is needed for cardinality arguments. The density parameter δ is central to the problem: when δ is constant the problem is easier, but when δ depends on n (e.g., δ = n^{-c}) it becomes much harder.",
+    "significance": "key",
+    "relatedConcepts": ["graph density", "edge counting", "simple graphs"]
   },
   {
-    "id": "ann-584-density",
+    "id": "ann-e584-cycle-defs",
     "proofId": "erdos-584",
-    "range": { "startLine": 53, "endLine": 55 },
+    "range": { "startLine": 65, "endLine": 94 },
     "type": "definition",
-    "title": "density",
-    "content": "Edge density: e(G) / n².",
-    "significance": "key"
+    "title": "Cycle Connectivity Framework",
+    "content": "**Path, IsCycle, OnCommonCycle, IsCycleConnected, AdjacentEdgesOn4Cycle** build up the cycle connectivity machinery. A Path is a list of vertices with consecutive edges in G. IsCycle requires k distinct vertices forming a closed walk. OnCommonCycle says two edges both have their endpoints in some cycle of length k. IsCycleConnected requires every pair of edges to share a common cycle of length ≤ k. AdjacentEdgesOn4Cycle strengthens this: edges sharing a vertex must lie on a 4-cycle.",
+    "mathContext": "The distinction between IsCycleConnected and AdjacentEdgesOn4Cycle is crucial. General cycle connectivity with bound 6 is the baseline for H₁, but adjacent edges must satisfy the stronger bound of 4. This two-tier requirement makes H₁ harder to satisfy than H₂, which only requires 8-cycle connectivity without the adjacency constraint.",
+    "significance": "critical",
+    "relatedConcepts": ["graph paths", "cycle length", "edge connectivity"]
   },
   {
-    "id": "ann-584-hasdensity",
+    "id": "ann-e584-conjecture",
     "proofId": "erdos-584",
-    "range": { "startLine": 57, "endLine": 59 },
-    "type": "definition",
-    "title": "HasDensity",
-    "content": "A graph has density δ if e(G) ≥ δn².",
-    "significance": "key"
+    "range": { "startLine": 96, "endLine": 124 },
+    "type": "concept",
+    "title": "The Main Conjecture",
+    "content": "**HasH1Property, HasH2Property, ErdosConjecture584** package the conjecture. HasH1Property combines 6-cycle connectivity with the 4-cycle condition for adjacent edges. HasH2Property is just 8-cycle connectivity. The conjecture states that for any dense graph (δn² edges), both H₁ (with ≫ δ³n² edges) and H₂ (with ≫ δ²n² edges) can be found as subgraphs. The existential constant C > 0 makes the ≫ precise.",
+    "mathContext": "The exponents δ³ and δ² are conjectured to be tight. Extracting H₁ costs a factor of δ³ in the edge count (from δn² to δ³n²), reflecting the density loss from imposing short-cycle constraints. The factor of δ² for H₂ is less severe because 8-cycle connectivity is a weaker requirement than 6-cycle connectivity.",
+    "significance": "critical",
+    "relatedConcepts": ["dense subgraphs", "cycle-connected subgraphs", "extremal bounds"]
   },
   {
-    "id": "ann-584-issubgraph",
+    "id": "ann-e584-known-results",
     "proofId": "erdos-584",
-    "range": { "startLine": 65, "endLine": 67 },
-    "type": "definition",
-    "title": "IsSubgraph",
-    "content": "H is a subgraph of G if H.edges ⊆ G.edges.",
-    "significance": "supporting"
+    "range": { "startLine": 126, "endLine": 152 },
+    "type": "axiom",
+    "title": "Known Partial Results",
+    "content": "**Three known results** are axiomatized. Duke-Erdős (1982) proved H₁ exists for fixed density δ when n is large enough — but this dependence on n for each δ is the key limitation. Duke-Erdős-Rödl (1984) removed the n-dependence but weakened the exponent from δ³ to δ⁵, the best known uniform bound. Fox-Sudakov (2008) proved H₂ but only for δ > n^{-1/5}, leaving the sparse regime open.",
+    "mathContext": "The gap between δ⁵ (known) and δ³ (conjectured) for H₁ is significant. Duke-Erdős-Rödl used a variant of the regularity lemma, which inherently loses polynomial factors. Closing this gap likely requires going beyond regularity-based techniques. Fox-Sudakov's threshold n^{-1/5} arises from their counting argument and may not be optimal.",
+    "significance": "critical",
+    "relatedConcepts": ["Szemerédi regularity lemma", "Duke-Erdős-Rödl theorem", "Fox-Sudakov theorem"]
   },
   {
-    "id": "ann-584-path",
+    "id": "ann-e584-sparse-regime",
     "proofId": "erdos-584",
-    "range": { "startLine": 72, "endLine": 77 },
-    "type": "definition",
-    "title": "Path",
-    "content": "A path in the graph as a list of consecutive vertices.",
-    "significance": "key"
+    "range": { "startLine": 154, "endLine": 170 },
+    "type": "concept",
+    "title": "The Sparse Regime Challenge",
+    "content": "**IsSparseRegime and SparseRegimeConjecture** formalize the main open challenge. When δ = n^{-c} for 0 < c < 1/2, the density depends on n and decreases as n grows. The conjecture asks whether H₁ with ≫ δ³n² = n^{2-3c} edges still exists. For c < 1/3, this would give a superlinear number of edges; for 1/3 < c < 1/2, only a sublinear number. The constraint c < 1/2 ensures the graph has at least n edges.",
+    "mathContext": "The sparse regime is where regularity-based approaches fail most severely. The Szemerédi regularity lemma produces approximations with error ε that is bounded away from 0 independently of n, which is too coarse when δ → 0. New ideas from probabilistic combinatorics, dependent random choice, or algebraic methods may be needed to make progress in this regime.",
+    "significance": "key",
+    "relatedConcepts": ["sparse graphs", "regularity lemma limitations", "dependent random choice"]
   },
   {
-    "id": "ann-584-iscycle",
+    "id": "ann-e584-summary",
     "proofId": "erdos-584",
-    "range": { "startLine": 79, "endLine": 83 },
-    "type": "definition",
-    "title": "IsCycle",
-    "content": "A cycle of length k: path with k distinct vertices closing back.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-584-oncommoncycle",
-    "proofId": "erdos-584",
-    "range": { "startLine": 85, "endLine": 89 },
-    "type": "definition",
-    "title": "OnCommonCycle",
-    "content": "Two edges are on a common cycle of length ≤ k.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-584-iscycleconnected",
-    "proofId": "erdos-584",
-    "range": { "startLine": 91, "endLine": 94 },
-    "type": "definition",
-    "title": "IsCycleConnected",
-    "content": "Every two edges are on a cycle of length ≤ k.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-584-adjacent4cycle",
-    "proofId": "erdos-584",
-    "range": { "startLine": 96, "endLine": 100 },
-    "type": "definition",
-    "title": "AdjacentEdgesOn4Cycle",
-    "content": "Edges sharing a vertex are on a 4-cycle.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-584-h1property",
-    "proofId": "erdos-584",
-    "range": { "startLine": 105, "endLine": 108 },
-    "type": "definition",
-    "title": "HasH1Property",
-    "content": "H₁: 6-cycle connected with adjacent edges on 4-cycles.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-584-h2property",
-    "proofId": "erdos-584",
-    "range": { "startLine": 110, "endLine": 112 },
-    "type": "definition",
-    "title": "HasH2Property",
-    "content": "H₂: 8-cycle connected.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-584-conjecture-h1",
-    "proofId": "erdos-584",
-    "range": { "startLine": 113, "endLine": 120 },
-    "type": "definition",
-    "title": "ErdosConjecture584_H1",
-    "content": "Every dense graph has a large 6-cycle connected subgraph with ≫ δ³n² edges.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-584-conjecture-h2",
-    "proofId": "erdos-584",
-    "range": { "startLine": 121, "endLine": 128 },
-    "type": "definition",
-    "title": "ErdosConjecture584_H2",
-    "content": "Every dense graph has a large 8-cycle connected subgraph with ≫ δ²n² edges.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-584-full-conjecture",
-    "proofId": "erdos-584",
-    "range": { "startLine": 130, "endLine": 132 },
-    "type": "definition",
-    "title": "ErdosConjecture584",
-    "content": "The full conjecture: both H₁ and H₂ exist.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-584-duke-erdos-1982",
-    "proofId": "erdos-584",
-    "range": { "startLine": 137, "endLine": 144 },
+    "range": { "startLine": 186, "endLine": 205 },
     "type": "theorem",
-    "title": "duke_erdos_1982",
-    "content": "Duke-Erdős (1982): H₁ exists for fixed δ when n is sufficiently large.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-584-duke-erdos-rodl-1984",
-    "proofId": "erdos-584",
-    "range": { "startLine": 145, "endLine": 152 },
-    "type": "theorem",
-    "title": "duke_erdos_rodl_1984",
-    "content": "Duke-Erdős-Rödl (1984): H₁ with δ⁵ exponent instead of conjectured δ³.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-584-fox-sudakov-2008",
-    "proofId": "erdos-584",
-    "range": { "startLine": 153, "endLine": 160 },
-    "type": "theorem",
-    "title": "fox_sudakov_2008",
-    "content": "Fox-Sudakov (2008): H₂ proved when δ > n^{-1/5}.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-584-sparse-regime",
-    "proofId": "erdos-584",
-    "range": { "startLine": 165, "endLine": 168 },
-    "type": "definition",
-    "title": "IsSparseRegime",
-    "content": "The sparse regime: δ = n^{-c} for some c > 0.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-584-sparse-conjecture",
-    "proofId": "erdos-584",
-    "range": { "startLine": 169, "endLine": 178 },
-    "type": "definition",
-    "title": "SparseRegimeConjecture",
-    "content": "Main open question: does the conjecture hold in the sparse regime?",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-584-best-exponents",
-    "proofId": "erdos-584",
-    "range": { "startLine": 217, "endLine": 225 },
-    "type": "definition",
-    "title": "Exponent bounds",
-    "content": "Best known: δ⁵ for H₁. Target: δ³. Gap is significant.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-584-summary",
-    "proofId": "erdos-584",
-    "range": { "startLine": 246, "endLine": 264 },
-    "type": "theorem",
-    "title": "erdos_584_open",
-    "content": "Summary: Problem OPEN. Known: δ⁵ for H₁, δ > n^{-1/5} for H₂.",
-    "significance": "critical"
+    "title": "Summary Theorem",
+    "content": "**erdos_584_summary** combines the two H₁ partial results into a single theorem: both Duke-Erdős 1982 (for fixed δ, n large) and Duke-Erdős-Rödl 1984 (uniform δ⁵ bound) hold. The proof is by exact ⟨duke_erdos_1982, duke_erdos_rodl_1984⟩, packaging both axioms as a conjunction. This demonstrates that while the full conjecture is open, substantial progress has been made on the H₁ side.",
+    "mathContext": "The summary theorem type-checks that the axiom signatures are compatible with the conjunction. The two results represent different trade-offs: the 1982 result has the optimal δ³ exponent but requires n to be large relative to δ, while the 1984 result is uniform in n but pays a δ⁵ penalty. A resolution of the full conjecture would combine the best of both.",
+    "significance": "critical",
+    "relatedConcepts": ["partial results", "conjecture formalization", "axiom combination"]
   }
 ]

--- a/src/data/proofs/erdos-584/meta.json
+++ b/src/data/proofs/erdos-584/meta.json
@@ -2,11 +2,11 @@
   "id": "erdos-584",
   "title": "Erdős Problem #584: Cycle-Connected Subgraphs",
   "slug": "erdos-584",
-  "description": "For a graph G with n vertices and δn² edges, must there exist subgraphs H₁ (≫ δ³n² edges, 6-cycle connected) and H₂ (≫ δ²n² edges, 8-cycle connected)? OPEN - best known: δ⁵ for H₁ (Duke-Erdős-Rödl 1984), δ > n^{-1/5} for H₂ (Fox-Sudakov 2008).",
+  "description": "For a graph G with n vertices and δn² edges, must there exist subgraphs H₁ (with ≫ δ³n² edges, 6-cycle connected) and H₂ (with ≫ δ²n² edges, 8-cycle connected)?",
   "meta": {
-    "author": "Duke-Erdős-Rödl, Fox-Sudakov",
+    "author": "Duke-Erdős-Rödl (1984), Fox-Sudakov (2008)",
     "sourceUrl": "https://erdosproblems.com/584",
-    "date": "1984-2008",
+    "date": "1982-2008",
     "status": "complete",
     "proofRepoPath": "Proofs/Erdos584Problem.lean",
     "tags": [
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 584,
     "erdosUrl": "https://erdosproblems.com/584",
     "erdosProblemStatus": "open",
@@ -34,49 +34,100 @@
         "theorem": "Finset.card",
         "description": "Cardinality for edge counting",
         "module": "Mathlib.Data.Finset.Basic"
-      },
-      {
-        "theorem": "Real.rpow",
-        "description": "Real powers for density exponents",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       }
     ],
     "originalContributions": [
-      "Graph structure for n vertices",
-      "edgeCount, density, HasDensity: edge counting",
-      "IsSubgraph: subgraph relation",
-      "Path, IsCycle, OnCommonCycle: cycle definitions",
-      "IsCycleConnected: k-cycle connectivity",
-      "AdjacentEdgesOn4Cycle: adjacent edges on 4-cycles",
-      "HasH1Property, HasH2Property: main properties",
-      "ErdosConjecture584_H1, ErdosConjecture584_H2: formal statements",
-      "duke_erdos_1982, duke_erdos_rodl_1984: H₁ results",
-      "fox_sudakov_2008: H₂ result for δ > n^{-1/5}",
-      "IsSparseRegime, SparseRegimeConjecture: main challenge",
-      "bestKnownExponentH1, targetExponentH1: quantitative bounds"
+      "Graph structure for n vertices with edge set, symmetry, and no-loops",
+      "edgeCount, density, HasDensity definitions for edge counting",
+      "Path, IsCycle, OnCommonCycle: cycle and path definitions",
+      "IsCycleConnected, AdjacentEdgesOn4Cycle: cycle connectivity predicates",
+      "HasH1Property (6-cycle + 4-cycle adjacent), HasH2Property (8-cycle)",
+      "ErdosConjecture584_H1, ErdosConjecture584_H2: formal conjecture statements",
+      "duke_erdos_1982: H₁ for fixed δ, n sufficiently large",
+      "duke_erdos_rodl_1984: H₁ with δ⁵ uniform bound",
+      "fox_sudakov_2008: H₂ for δ > n^{-1/5}",
+      "IsSparseRegime, SparseRegimeConjecture: main open challenge",
+      "erdos_584_summary: combines duke_erdos_1982 and duke_erdos_rodl_1984"
     ]
   },
   "overview": {
-    "historicalContext": "**The Duke-Erdős Question (1982)**\n\nRichard Duke and Paul Erdős asked in the early 1980s whether dense graphs must contain large subgraphs with strong cycle connectivity properties. Specifically, they sought subgraphs where any two edges lie on a short common cycle.\n\n**Early Results (1984)**\n\nDuke, Erdős, and Rödl proved in 1984 that for graphs with δn² edges, there exists a 6-cycle connected subgraph with δ⁵n² edges. This falls short of the conjectured δ³n² bound.\n\n**Fox-Sudakov Progress (2008)**\n\nJacob Fox and Benny Sudakov proved the H₂ part (8-cycle connectivity with δ²n² edges) when δ > n^{-1/5}. This leaves the sparse regime δ = n^{-c} for larger c as the main open challenge.\n\n**Current Status**\n\nThe full conjecture remains OPEN. The gap between δ⁵ (known) and δ³ (conjectured) for H₁ is significant. The sparse regime where δ = n^{-c} is particularly challenging.",
-    "problemStatement": "**Problem Statement (Open)**\n\nLet G be a graph with n vertices and δn² edges.\n\n**Question:** Must there exist subgraphs H₁, H₂ ⊆ G such that:\n\n**H₁:** Has ≫ δ³n² edges and\n- Every two edges are on a cycle of length ≤ 6\n- Adjacent edges are on a 4-cycle\n\n**H₂:** Has ≫ δ²n² edges and\n- Every two edges are on a cycle of length ≤ 8\n\n**Status: OPEN**",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Structure:** Graph type with edge set, edge count, density\n\n2. **Cycle Definitions:** Path, IsCycle, OnCommonCycle\n\n3. **Connectivity:** IsCycleConnected for k-cycle connectivity\n\n4. **Properties:** HasH1Property (6-cycle + 4-cycle adjacent), HasH2Property (8-cycle)\n\n5. **Conjectures:** ErdosConjecture584_H1 and ErdosConjecture584_H2\n\n6. **Known Results:** duke_erdos_1982, duke_erdos_rodl_1984, fox_sudakov_2008\n\n7. **Main Challenge:** SparseRegimeConjecture for δ = n^{-c}",
+    "historicalContext": "Richard Duke and Paul Erdős asked in the early 1980s whether dense graphs must contain large subgraphs with strong cycle connectivity properties. Specifically, for a graph G with n vertices and δn² edges, they sought subgraphs where any two edges lie on a short common cycle. This question connects edge density to local cycle structure, a fundamental theme in extremal graph theory.\n\nDuke and Erdős proved the first statement (H₁) in 1982 when n is sufficiently large for fixed δ, but the real challenge lies in the regime where δ depends on n. In 1984, Duke, Erdős, and Rödl proved the H₁ statement uniformly with a weaker exponent: δ⁵n² edges instead of the conjectured δ³n². This remains the best known uniform bound for H₁. Jacob Fox and Benny Sudakov made further progress in 2008, proving the H₂ statement (8-cycle connectivity with δ²n² edges) when δ > n^{-1/5}.\n\nThe full conjecture remains open. The gap between the known δ⁵ exponent and the conjectured δ³ for H₁ is substantial, and extending Fox-Sudakov's H₂ result below the n^{-1/5} threshold is a major challenge. The sparse regime where δ = n^{-c} for c > 0 is where new ideas are needed.",
+    "problemStatement": "**Problem Statement (Open)**\n\nLet $G$ be a graph with $n$ vertices and $\\delta n^2$ edges.\n\n**Question:** Must there exist subgraphs $H_1, H_2 \\subseteq G$ such that:\n\n**$H_1$:** Has $\\gg \\delta^3 n^2$ edges and\n- Every two edges are on a cycle of length $\\leq 6$\n- Adjacent edges (sharing a vertex) are on a $4$-cycle\n\n**$H_2$:** Has $\\gg \\delta^2 n^2$ edges and\n- Every two edges are on a cycle of length $\\leq 8$\n\n**Status: OPEN** — Best known: $\\delta^5$ for $H_1$ (Duke-Erdős-Rödl 1984), $\\delta > n^{-1/5}$ for $H_2$ (Fox-Sudakov 2008).",
+    "proofStrategy": "The formalization defines a custom graph structure on n vertices and builds up the cycle connectivity framework from scratch: paths, cycles, common cycles, and k-cycle connectivity. The two main properties H₁ (6-cycle connected with adjacent edges on 4-cycles) and H₂ (8-cycle connected) are defined as predicates. The three known partial results are axiomatized: Duke-Erdős 1982 for fixed δ, Duke-Erdős-Rödl 1984 for the uniform δ⁵ bound, and Fox-Sudakov 2008 for H₂ above the n^{-1/5} threshold. The summary theorem combines the two H₁ results using exact ⟨..., ...⟩.",
     "keyInsights": [
-      "**Exponent Gap:** Known δ⁵ vs conjectured δ³ for H₁",
-      "**Density Threshold:** H₂ proved only for δ > n^{-1/5}",
-      "**Sparse Regime:** Main challenge is δ = n^{-c}",
-      "**Cycle Connectivity:** Edges on short common cycles",
-      "**Adjacent Edges:** Additional 4-cycle requirement"
+      "**Exponent Gap:** The known δ⁵ bound for H₁ (Duke-Erdős-Rödl 1984) falls short of the conjectured δ³, leaving a significant gap in the exponent",
+      "**Density Threshold:** Fox-Sudakov's H₂ result only applies for δ > n^{-1/5}, leaving the sparse regime completely open",
+      "**Sparse Regime Challenge:** When δ = n^{-c} for c > 0, the density depends on n, making regularity-based approaches much harder",
+      "**Cycle Connectivity:** The k-cycle connectivity property requires every pair of edges to lie on a common short cycle, a strong structural requirement",
+      "**Adjacent vs General Edges:** The H₁ property demands the stronger condition that adjacent edges lie on 4-cycles, not just 6-cycles"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "graph-definitions",
+      "title": "Graph Definitions",
+      "summary": "Graph structure, edgeCount, density, HasDensity",
+      "startLine": 40,
+      "endLine": 57
+    },
+    {
+      "id": "subgraphs",
+      "title": "Subgraphs",
+      "summary": "IsSubgraph definition",
+      "startLine": 59,
+      "endLine": 63
+    },
+    {
+      "id": "cycle-connectivity",
+      "title": "Cycle Connectivity",
+      "summary": "Path, IsCycle, OnCommonCycle, IsCycleConnected, AdjacentEdgesOn4Cycle",
+      "startLine": 65,
+      "endLine": 94
+    },
+    {
+      "id": "main-conjecture",
+      "title": "The Main Conjecture",
+      "summary": "HasH1Property, HasH2Property, ErdosConjecture584_H1/H2, ErdosConjecture584",
+      "startLine": 96,
+      "endLine": 124
+    },
+    {
+      "id": "known-results",
+      "title": "Known Results",
+      "summary": "duke_erdos_1982, duke_erdos_rodl_1984, fox_sudakov_2008 axioms",
+      "startLine": 126,
+      "endLine": 152
+    },
+    {
+      "id": "main-challenge",
+      "title": "The Main Challenge",
+      "summary": "IsSparseRegime, SparseRegimeConjecture for δ = n^{-c}",
+      "startLine": 154,
+      "endLine": 170
+    },
+    {
+      "id": "quantitative-bounds",
+      "title": "Quantitative Bounds",
+      "summary": "bestKnownExponentH1, targetExponentH1, bestKnownThresholdH2",
+      "startLine": 172,
+      "endLine": 184
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "summary": "erdos_584_summary theorem combining known H₁ results",
+      "startLine": 186,
+      "endLine": 205
+    }
+  ],
   "conclusion": {
-    "summary": "Erdős Problem #584 asks whether dense graphs must contain large cycle-connected subgraphs. Duke-Erdős-Rödl (1984) proved a weaker δ⁵ bound for H₁, and Fox-Sudakov (2008) proved H₂ for δ > n^{-1/5}. The full conjecture with δ³ for H₁ and the sparse regime remain OPEN.",
-    "implications": "**Connections**\n\n1. **Extremal Graph Theory:** Density vs structure\n\n2. **Regularity Lemma:** Structural decomposition\n\n3. **Random Graphs:** Probabilistic methods\n\n4. **Girth:** Connection to cycle lengths",
+    "summary": "Erdős Problem #584 asks whether dense graphs must contain large cycle-connected subgraphs. Three partial results are formalized: Duke-Erdős (1982) proved H₁ for fixed density, Duke-Erdős-Rödl (1984) proved H₁ uniformly with a δ⁵ exponent, and Fox-Sudakov (2008) proved H₂ for δ > n^{-1/5}. The summary theorem combines the two H₁ results. The full conjecture with the optimal δ³ exponent for H₁ remains open.",
+    "implications": "This problem sits at the intersection of extremal graph theory and structural graph theory. Resolving the exponent gap from δ⁵ to δ³ would likely require new techniques beyond the Szemerédi regularity lemma. The sparse regime where δ = n^{-c} is particularly important for applications to additive combinatorics and theoretical computer science.",
     "openQuestions": [
-      "Can the δ⁵ be improved to δ³ for H₁?",
-      "Can Fox-Sudakov be extended below n^{-1/5}?",
-      "What is the correct exponent in the sparse regime?",
-      "Are there constructions matching the lower bounds?"
+      "Can the δ⁵ exponent for H₁ be improved toward the conjectured δ³?",
+      "Can Fox-Sudakov's H₂ result be extended below the n^{-1/5} threshold?",
+      "What is the correct exponent in the sparse regime δ = n^{-c}?",
+      "Are there constructions matching the conjectured lower bounds?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Removed all trivial `True` axioms, `sorry` placeholders, `String` defs, and `True := trivial` summary
- Added meaningful summary theorem combining `duke_erdos_1982` and `duke_erdos_rodl_1984` via `exact ⟨..., ...⟩`
- Fixed section headers to `/-!` doc comments
- Updated meta.json with correct sections and `sorries: 0`
- Rewrote annotations.json with 7 substantive annotations

## Checklist
- [x] No sorry, True := trivial, or trivial True axioms
- [x] pnpm build succeeds
- [x] Annotations align with Lean file line numbers
- [x] meta.json sections match Lean file structure

🤖 Generated by enhancer-3