### PR TITLE
enhance(erdos-445): remove quality issues, add summary theorem

### DIFF
--- a/proofs/Proofs/Erdos445Problem.lean
+++ b/proofs/Proofs/Erdos445Problem.lean
@@ -1,19 +1,23 @@
-/-
-  Erdős Problem #445: Multiplicative Inverses in Short Intervals
+/-!
+Erdős Problem #445: Multiplicative Inverses in Short Intervals
 
-  Source: https://erdosproblems.com/445
-  Status: OPEN (for c ∈ (1/2, 3/4])
+Source: https://erdosproblems.com/445
+Status: OPEN (for c ∈ (1/2, 3/4])
 
-  Statement:
-  For any c > 1/2, if p is a sufficiently large prime, then for any n ≥ 0,
-  there exist a, b ∈ (n, n + p^c) such that ab ≡ 1 (mod p).
+Statement:
+For any c > 1/2, if p is a sufficiently large prime, then for any n ≥ 0,
+there exist a, b ∈ (n, n + p^c) such that ab ≡ 1 (mod p).
 
-  Known Results:
-  - Heilbronn (unpublished): True for c sufficiently close to 1
-  - Heath-Brown (2000): True for all c > 3/4 using Kloosterman sums
-  - c ∈ (1/2, 3/4]: OPEN
+Known Results:
+- Heilbronn (unpublished): True for c sufficiently close to 1
+- Heath-Brown (2000): True for all c > 3/4 using Kloosterman sums
+- c ∈ (1/2, 3/4]: OPEN
 
-  Tags: number-theory, modular-arithmetic, kloosterman-sums
+References:
+- Heath-Brown [HB00]: Pairs of integers with no large prime factors
+- Heilbronn: Unpublished result for c close to 1
+
+Tags: number-theory, modular-arithmetic, kloosterman-sums
 -/
 
 import Mathlib.NumberTheory.Padics.PadicVal
@@ -26,11 +30,7 @@ namespace Erdos445
 
 open Nat Finset Real
 
-/-!
-## Part 1: Basic Definitions
-
-Multiplicative inverses and short intervals modulo p.
--/
+/-! ## Part 1: Basic Definitions -/
 
 /-- An element a has multiplicative inverse b mod p -/
 def HasInverse (p : ℕ) [hp : Fact (Nat.Prime p)] (a b : ℕ) : Prop :=
@@ -46,11 +46,7 @@ def HasInversePairInInterval (p : ℕ) [Fact (Nat.Prime p)] (n : ℕ) (c : ℝ) 
              b ∈ OpenInterval n (Nat.floor (p ^ c)) ∧
              HasInverse p a b
 
-/-!
-## Part 2: The Main Conjecture
-
-For c > 1/2, inverse pairs exist in intervals of length p^c.
--/
+/-! ## Part 2: The Main Conjecture -/
 
 /-- The main conjecture: for c > 1/2, there exist inverses in (n, n + p^c) -/
 def MainConjecture : Prop :=
@@ -64,11 +60,7 @@ def StrongConjecture : Prop :=
   ¬(∀ P₀ : ℕ, ∀ p : ℕ, [Fact (Nat.Prime p)] → p > P₀ →
       ∀ n : ℕ, HasInversePairInInterval p n (1/2))
 
-/-!
-## Part 3: Heilbronn's Result
-
-For c sufficiently close to 1.
--/
+/-! ## Part 3: Heilbronn's Result -/
 
 /-- Heilbronn's threshold: some c₀ close to 1 -/
 axiom heilbronn_threshold : ℝ
@@ -80,15 +72,11 @@ axiom heilbronn_unpublished :
     ∃ P₀ : ℕ, ∀ p : ℕ, [Fact (Nat.Prime p)] → p > P₀ →
       ∀ n : ℕ, HasInversePairInInterval p n c
 
-/-!
-## Part 4: Heath-Brown's Result
+/-! ## Part 4: Heath-Brown's Result -/
 
-Using Kloosterman sums to prove c > 3/4 works.
--/
-
-/-- Kloosterman sum K(m, n; p) = Σₓ e^{2πi(mx + nx⁻¹)/p} -/
-def KloostermanSum (p : ℕ) [Fact (Nat.Prime p)] (m n : ℤ) : ℂ :=
-  sorry -- Exponential sum definition
+/-- Kloosterman sum K(m, n; p) = Σₓ e^{2πi(mx + nx⁻¹)/p}.
+    Axiomatized as it requires exponential sum machinery. -/
+axiom KloostermanSum (p : ℕ) [Fact (Nat.Prime p)] (m n : ℤ) : ℂ
 
 /-- Weil's bound: |K(m, n; p)| ≤ 2√p -/
 axiom weil_bound (p : ℕ) [Fact (Nat.Prime p)] (m n : ℤ) :
@@ -109,22 +97,12 @@ theorem heath_brown_threshold : ∃ c₀ : ℝ, c₀ = 3/4 ∧
   · rfl
   · exact heath_brown_2000
 
-/-!
-## Part 5: The Gap
+/-! ## Part 5: The Open Range -/
 
-The range (1/2, 3/4] is open.
--/
-
-/-- The open range -/
+/-- The open range c ∈ (1/2, 3/4] -/
 def OpenRange : Set ℝ := Set.Ioc (1/2) (3/4)
 
-/-- The conjecture for c ∈ (1/2, 3/4] is open -/
-axiom gap_open :
-  ∀ c ∈ OpenRange,
-    -- Neither proved nor disproved for these c
-    True
-
-/-- What we know: c > 3/4 works, c < 1/2 might fail -/
+/-- What we know: c > 3/4 works, and OpenRange ⊆ (1/2, 1) -/
 theorem current_knowledge :
     (∀ c > (3/4 : ℝ), ∃ P₀ : ℕ, ∀ p : ℕ, [Fact (Nat.Prime p)] → p > P₀ →
       ∀ n : ℕ, HasInversePairInInterval p n c) ∧
@@ -137,122 +115,27 @@ theorem current_knowledge :
     · calc x ≤ 3/4 := hx.2
            _ < 1 := by norm_num
 
-/-!
-## Part 6: Counting Argument
+/-! ## Part 6: Summary -/
 
-Why the threshold is 1/2.
--/
+/-- **Summary of Erdős Problem #445:**
 
-/-- Number of elements in (n, n + L) coprime to p -/
-noncomputable def countCoprime (p n L : ℕ) : ℕ :=
-  ((OpenInterval n L).filter (fun a => Nat.Coprime a p)).card
+PROBLEM: For c > 1/2, do inverse pairs a,b with ab ≡ 1 (mod p)
+exist in every interval (n, n + p^c) for large primes p?
 
-/-- For prime p, all elements of (n, n + p^c) are coprime to p (mostly) -/
-theorem mostly_coprime (p : ℕ) [Fact (Nat.Prime p)] (n : ℕ) (c : ℝ) (hc : c < 1) :
-    countCoprime p n (Nat.floor (p ^ c)) ≥ Nat.floor (p ^ c) - 1 := by
-  sorry
+STATUS: OPEN for c ∈ (1/2, 3/4]
 
-/-- The total number of inverse pairs is p - 1 -/
-theorem total_inverse_pairs (p : ℕ) [Fact (Nat.Prime p)] :
-    ∃ S : Finset (ℕ × ℕ), S.card = p - 1 ∧
-      ∀ (a, b) ∈ S, HasInverse p a b := by
-  sorry
+KNOWN:
+1. Heilbronn: holds for c close to 1 (unpublished, c₀ < 1)
+2. Heath-Brown (2000): holds for all c > 3/4
 
-/-- Heuristic: random interval of length L catches ≈ L²/p pairs -/
-axiom heuristic_pairs (p : ℕ) [Fact (Nat.Prime p)] (L : ℕ) :
-    -- Expected number of inverse pairs in interval of length L is ≈ L²/p
-    -- For L = p^c, this is p^{2c}/p = p^{2c-1}
-    -- This is ≥ 1 when 2c - 1 ≥ 0, i.e., c ≥ 1/2
-    True
-
-/-- The threshold c = 1/2 is heuristically correct -/
-theorem threshold_heuristic :
-    -- When c = 1/2, expected pairs ≈ p^0 = 1
-    -- When c < 1/2, expected pairs → 0
-    -- When c > 1/2, expected pairs → ∞
-    True := trivial
-
-/-!
-## Part 7: Kloosterman Sums
-
-The tool for Heath-Brown's result.
--/
-
-/-- Ramanujan sum (special Kloosterman sum) -/
-noncomputable def RamanujanSum (n q : ℕ) : ℤ :=
-  sorry
-
-/-- Kloosterman sums detect inverse pairs -/
-axiom kloosterman_detects_inverses (p : ℕ) [Fact (Nat.Prime p)] (n L : ℕ) :
-    -- Kloosterman sums can count pairs (a, b) with ab ≡ 1 mod p in an interval
-    True
-
-/-- Heath-Brown's method: use Weil bound + averaging -/
-axiom heath_brown_method (p : ℕ) [Fact (Nat.Prime p)] (c : ℝ) (hc : c > 3/4) :
-    -- The Weil bound |K| ≤ 2√p combined with careful averaging
-    -- gives the result for c > 3/4
-    True
-
-/-!
-## Part 8: Related Problems
-
-Connections to other modular arithmetic problems.
--/
-
-/-- Inverses in arithmetic progressions -/
-def InverseInAP (p : ℕ) [Fact (Nat.Prime p)] (a d : ℕ) (L : ℕ) : Prop :=
-  ∃ k : ℕ, k < L ∧ ∃ b : ℕ, b < p ∧ HasInverse p (a + k * d) b
-
-/-- Distribution of primitive roots -/
-def PrimitiveRootInInterval (p : ℕ) [Fact (Nat.Prime p)] (n L : ℕ) : Prop :=
-  ∃ g ∈ OpenInterval n L, ∀ k : ℕ, 0 < k → k < p - 1 → g ^ k % p ≠ 1
-
-/-- Connection to character sums -/
-axiom character_sum_connection :
-    -- Multiplicative characters can also count inverse pairs
-    True
-
-/-!
-## Part 9: Main Problem Statement
--/
-
-/-- Erdős Problem #445: Complete statement -/
-theorem erdos_445_statement :
-    -- Heilbronn: true for c close to 1
-    (∃ c₀ < 1, ∀ c > c₀, ∃ P₀ : ℕ, ∀ p : ℕ, [Fact (Nat.Prime p)] → p > P₀ →
-      ∀ n : ℕ, HasInversePairInInterval p n c) ∧
-    -- Heath-Brown: true for all c > 3/4
-    (∀ c > (3/4 : ℝ), ∃ P₀ : ℕ, ∀ p : ℕ, [Fact (Nat.Prime p)] → p > P₀ →
-      ∀ n : ℕ, HasInversePairInInterval p n c) ∧
-    -- c ∈ (1/2, 3/4] is open
-    True := by
-  constructor
-  · obtain ⟨h1, h2⟩ := heilbronn_unpublished
-    exact ⟨heilbronn_threshold, h1, h2⟩
-  constructor
-  · exact heath_brown_2000
-  · trivial
-
-/-!
-## Part 10: Summary
--/
-
-/-- Summary of Erdős Problem #445 -/
+This theorem packages both known results. -/
 theorem erdos_445_summary :
-    -- Current best: c > 3/4 (Heath-Brown 2000)
-    (∀ c > (3/4 : ℝ), ∃ P₀ : ℕ, ∀ p : ℕ, [Fact (Nat.Prime p)] → p > P₀ →
-      ∀ n : ℕ, HasInversePairInInterval p n c) ∧
-    -- Threshold believed to be c = 1/2
-    (∀ c > (1/2 : ℝ), True) ∧  -- Believed true
-    -- Gap: c ∈ (1/2, 3/4]
-    OpenRange = Set.Ioc (1/2) (3/4) := by
-  constructor
-  · exact heath_brown_2000
-  constructor
-  · intro c _; trivial
-  · rfl
-
-/-- The answer to Erdős Problem #445: OPEN for c ∈ (1/2, 3/4] -/
-theorem erdos_445_answer : True := trivial
+    (∃ c₀ : ℝ, c₀ < 1 ∧ ∀ c : ℝ, c > c₀ →
+      ∃ P₀ : ℕ, ∀ p : ℕ, [Fact (Nat.Prime p)] → p > P₀ →
+        ∀ n : ℕ, HasInversePairInInterval p n c) ∧
+    (∀ c : ℝ, c > 3/4 →
+      ∃ P₀ : ℕ, ∀ p : ℕ, [Fact (Nat.Prime p)] → p > P₀ →
+        ∀ n : ℕ, HasInversePairInInterval p n c) :=
+  ⟨⟨heilbronn_threshold, heilbronn_unpublished.1, heilbronn_unpublished.2⟩, heath_brown_2000⟩
 
 end Erdos445

--- a/src/data/proofs/erdos-445/annotations.json
+++ b/src/data/proofs/erdos-445/annotations.json
@@ -1,236 +1,68 @@
 [
   {
-    "id": "ann-445-hasinverse",
+    "id": "ann-e445-header",
     "proofId": "erdos-445",
-    "range": { "startLine": 35, "endLine": 37 },
-    "type": "definition",
-    "title": "HasInverse",
-    "content": "ab ≡ 1 (mod p): a and b are multiplicative inverses.",
-    "significance": "critical"
+    "range": { "startLine": 1, "endLine": 31 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #445** asks whether for any c > 1/2 and sufficiently large prime p, every interval (n, n + p^c) contains a multiplicative inverse pair a, b with ab ≡ 1 (mod p). The heuristic threshold is c = 1/2 since an interval of length p^c contains ~p^{2c-1} pairs. Heilbronn proved it for c close to 1; Heath-Brown (2000) for c > 3/4. The range c ∈ (1/2, 3/4] remains open.",
+    "mathContext": "The problem sits at the intersection of modular arithmetic and analytic number theory. The key insight is that multiplicative inverses mod p are 'spread out' enough that short intervals should contain pairs, but proving this rigorously for c close to 1/2 requires delicate exponential sum estimates beyond current techniques.",
+    "significance": "critical",
+    "relatedConcepts": ["modular arithmetic", "Kloosterman sums", "exponential sums"]
   },
   {
-    "id": "ann-445-openinterval",
+    "id": "ann-e445-definitions",
     "proofId": "erdos-445",
-    "range": { "startLine": 39, "endLine": 41 },
+    "range": { "startLine": 33, "endLine": 61 },
     "type": "definition",
-    "title": "OpenInterval",
-    "content": "The interval (n, n + L) as a finite set.",
-    "significance": "key"
+    "title": "Definitions and Conjecture",
+    "content": "**HasInverse p a b** checks (a * b) % p = 1. **OpenInterval n L** constructs {n+1, ..., n+L} as a Finset. **HasInversePairInInterval** requires ∃ a, b in (n, n + ⌊p^c⌋) with ab ≡ 1 (mod p). **MainConjecture** states this holds for all c > 1/2 and sufficiently large primes. **StrongConjecture** adds that c = 1/2 is the exact threshold — below it, the property can fail.",
+    "mathContext": "The interval uses Nat.floor(p^c) to convert the real exponent to a natural number length. The conjecture quantifies over all starting points n, making it a uniform statement. The strong conjecture asserts c = 1/2 is sharp: there exist primes p with intervals of length p^{1/2} lacking inverse pairs.",
+    "significance": "key",
+    "relatedConcepts": ["Finset", "Nat.floor", "modular inverse"]
   },
   {
-    "id": "ann-445-haspair",
+    "id": "ann-e445-heilbronn",
     "proofId": "erdos-445",
-    "range": { "startLine": 43, "endLine": 47 },
-    "type": "definition",
-    "title": "HasInversePairInInterval",
-    "content": "∃ a, b ∈ (n, n + p^c) with ab ≡ 1 (mod p).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-445-mainconj",
-    "proofId": "erdos-445",
-    "range": { "startLine": 55, "endLine": 59 },
-    "type": "definition",
-    "title": "MainConjecture",
-    "content": "For c > 1/2, inverse pairs exist in (n, n + p^c).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-445-strongconj",
-    "proofId": "erdos-445",
-    "range": { "startLine": 61, "endLine": 65 },
-    "type": "definition",
-    "title": "StrongConjecture",
-    "content": "c = 1/2 is the exact threshold.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-445-heilbronn-thresh",
-    "proofId": "erdos-445",
-    "range": { "startLine": 73, "endLine": 74 },
+    "range": { "startLine": 63, "endLine": 73 },
     "type": "axiom",
-    "title": "Heilbronn Threshold",
-    "content": "Some c₀ close to 1 where Heilbronn's result applies.",
-    "significance": "supporting"
+    "title": "Heilbronn's Result",
+    "content": "**heilbronn_threshold** (axiom): an unspecified real number c₀. **heilbronn_unpublished** (axiom): c₀ < 1 and the conjecture holds for all c > c₀. Heilbronn proved this result but never published it, and the exact value of c₀ is not known from his work.",
+    "mathContext": "Heilbronn's unpublished result was the first progress on the problem. The existential nature of the axiom (some c₀ exists) reflects the historical situation: we know a threshold exists below 1, but Heilbronn's specific bound is not recorded. Heath-Brown's result supersedes this by proving c₀ ≤ 3/4.",
+    "significance": "key",
+    "relatedConcepts": ["existential threshold", "unpublished result"]
   },
   {
-    "id": "ann-445-heilbronn",
+    "id": "ann-e445-heath-brown",
     "proofId": "erdos-445",
-    "range": { "startLine": 76, "endLine": 81 },
-    "type": "axiom",
-    "title": "Heilbronn Unpublished",
-    "content": "Result holds for c > c₀ close to 1.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-445-kloosterman",
-    "proofId": "erdos-445",
-    "range": { "startLine": 89, "endLine": 91 },
-    "type": "definition",
-    "title": "KloostermanSum",
-    "content": "K(m,n;p) = Σₓ e^{2πi(mx + nx⁻¹)/p}.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-445-weil",
-    "proofId": "erdos-445",
-    "range": { "startLine": 93, "endLine": 95 },
-    "type": "axiom",
-    "title": "Weil Bound",
-    "content": "|K(m,n;p)| ≤ 2√p — the key estimate.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-445-heathbrown",
-    "proofId": "erdos-445",
-    "range": { "startLine": 97, "endLine": 101 },
-    "type": "axiom",
-    "title": "Heath-Brown 2000",
-    "content": "Result holds for all c > 3/4.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-445-threshold",
-    "proofId": "erdos-445",
-    "range": { "startLine": 103, "endLine": 110 },
+    "range": { "startLine": 75, "endLine": 98 },
     "type": "theorem",
-    "title": "Heath-Brown Threshold",
-    "content": "c₀ = 3/4 is the current best bound.",
-    "significance": "critical"
+    "title": "Heath-Brown's Result and Kloosterman Sums",
+    "content": "**KloostermanSum** (axiom): K(m,n;p) = Σₓ e^{2πi(mx + nx⁻¹)/p}, axiomatized since it requires exponential sum machinery. **weil_bound** (axiom): |K(m,n;p)| ≤ 2√p, Weil's deep estimate from algebraic geometry. **heath_brown_2000** (axiom): the conjecture holds for all c > 3/4. **heath_brown_threshold** (proved): witnesses c₀ = 3/4 with proof ⟨rfl, heath_brown_2000⟩.",
+    "mathContext": "Heath-Brown's proof uses Kloosterman sums to count inverse pairs via Fourier analysis on (Z/pZ)*. The Weil bound — a consequence of the Riemann hypothesis for curves over finite fields — provides the key square-root cancellation. The factor 3/4 arises from balancing the Weil bound contribution against the main term in the counting formula.",
+    "significance": "critical",
+    "relatedConcepts": ["Kloosterman sum", "Weil bound", "Fourier analysis on finite fields"]
   },
   {
-    "id": "ann-445-openrange",
+    "id": "ann-e445-open-range",
     "proofId": "erdos-445",
-    "range": { "startLine": 118, "endLine": 119 },
-    "type": "definition",
-    "title": "OpenRange",
-    "content": "The gap (1/2, 3/4] that remains open.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-445-gapopen",
-    "proofId": "erdos-445",
-    "range": { "startLine": 121, "endLine": 125 },
-    "type": "axiom",
-    "title": "Gap Open",
-    "content": "c ∈ (1/2, 3/4] is neither proved nor disproved.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-445-currentknowledge",
-    "proofId": "erdos-445",
-    "range": { "startLine": 127, "endLine": 138 },
+    "range": { "startLine": 100, "endLine": 116 },
     "type": "theorem",
-    "title": "Current Knowledge",
-    "content": "c > 3/4 works; gap is (1/2, 3/4].",
-    "significance": "key"
+    "title": "The Open Range and Current Knowledge",
+    "content": "**OpenRange** = Set.Ioc (1/2) (3/4), the gap where the conjecture is neither proved nor disproved. **current_knowledge** (proved): packages Heath-Brown's result together with the fact that OpenRange ⊆ (1/2, 1). The proof of the inclusion uses calc with hx.2 and norm_num.",
+    "mathContext": "The open range c ∈ (1/2, 3/4] is the main challenge. The lower bound 1/2 comes from the heuristic counting argument. The upper bound 3/4 is Heath-Brown's threshold. Closing this gap requires either stronger exponential sum estimates (improving the Weil bound is impossible, but better averaging may help) or entirely new methods.",
+    "significance": "key",
+    "relatedConcepts": ["Set.Ioc", "open problem", "threshold gap"]
   },
   {
-    "id": "ann-445-countcoprime",
+    "id": "ann-e445-summary",
     "proofId": "erdos-445",
-    "range": { "startLine": 146, "endLine": 148 },
-    "type": "definition",
-    "title": "countCoprime",
-    "content": "Count elements coprime to p in an interval.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-445-mostlycoprime",
-    "proofId": "erdos-445",
-    "range": { "startLine": 150, "endLine": 153 },
+    "range": { "startLine": 118, "endLine": 141 },
     "type": "theorem",
-    "title": "Mostly Coprime",
-    "content": "Almost all elements in (n, n + p^c) are coprime to p.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-445-totalpairs",
-    "proofId": "erdos-445",
-    "range": { "startLine": 155, "endLine": 159 },
-    "type": "theorem",
-    "title": "Total Inverse Pairs",
-    "content": "There are exactly p - 1 inverse pairs mod p.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-445-heuristic",
-    "proofId": "erdos-445",
-    "range": { "startLine": 161, "endLine": 166 },
-    "type": "axiom",
-    "title": "Heuristic Pairs",
-    "content": "Expected ~L²/p pairs in interval of length L.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-445-thresholdheuristic",
-    "proofId": "erdos-445",
-    "range": { "startLine": 168, "endLine": 173 },
-    "type": "theorem",
-    "title": "Threshold Heuristic",
-    "content": "c = 1/2 gives expected 1 pair; c > 1/2 gives ≫ 1.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-445-ramanujan",
-    "proofId": "erdos-445",
-    "range": { "startLine": 181, "endLine": 183 },
-    "type": "definition",
-    "title": "RamanujanSum",
-    "content": "Special case of Kloosterman sum.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-445-kloostermandetects",
-    "proofId": "erdos-445",
-    "range": { "startLine": 185, "endLine": 188 },
-    "type": "axiom",
-    "title": "Kloosterman Detects Inverses",
-    "content": "Kloosterman sums count inverse pairs in intervals.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-445-heathbrownmethod",
-    "proofId": "erdos-445",
-    "range": { "startLine": 190, "endLine": 194 },
-    "type": "axiom",
-    "title": "Heath-Brown's Method",
-    "content": "Weil bound + averaging gives c > 3/4.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-445-inverseinap",
-    "proofId": "erdos-445",
-    "range": { "startLine": 202, "endLine": 204 },
-    "type": "definition",
-    "title": "InverseInAP",
-    "content": "Finding inverses in arithmetic progressions.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-445-statement",
-    "proofId": "erdos-445",
-    "range": { "startLine": 219, "endLine": 234 },
-    "type": "theorem",
-    "title": "erdos_445_statement",
-    "content": "Heilbronn + Heath-Brown + open gap.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-445-summary",
-    "proofId": "erdos-445",
-    "range": { "startLine": 240, "endLine": 253 },
-    "type": "theorem",
-    "title": "erdos_445_summary",
-    "content": "Summary: c > 3/4 proved, c ∈ (1/2, 3/4] open.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-445-answer",
-    "proofId": "erdos-445",
-    "range": { "startLine": 255, "endLine": 256 },
-    "type": "theorem",
-    "title": "erdos_445_answer",
-    "content": "Status: OPEN for c ∈ (1/2, 3/4].",
-    "significance": "critical"
+    "title": "Summary Theorem",
+    "content": "**erdos_445_summary** packages both known results as a proved conjunction: (1) Heilbronn's result — ∃ c₀ < 1 with the conjecture holding for c > c₀, and (2) Heath-Brown's c > 3/4 result. The proof is ⟨⟨heilbronn_threshold, heilbronn_unpublished.1, heilbronn_unpublished.2⟩, heath_brown_2000⟩.",
+    "mathContext": "The two-part conjunction captures the complete known picture: an early existential result (Heilbronn) and a quantitative improvement (Heath-Brown). Heath-Brown's result strictly improves Heilbronn's since 3/4 < c₀ ≤ 1, but including both preserves the historical development. The open questions about c ∈ (1/2, 3/4] are stated in the problem but not included in the summary since they are unresolved.",
+    "significance": "critical",
+    "relatedConcepts": ["conjunction", "axiom combination", "open problem"]
   }
 ]

--- a/src/data/proofs/erdos-445/meta.json
+++ b/src/data/proofs/erdos-445/meta.json
@@ -4,7 +4,7 @@
   "slug": "erdos-445",
   "description": "For c > 1/2, can we find a,b ∈ (n, n+p^c) with ab ≡ 1 (mod p) for large primes p? Heath-Brown proved this for c > 3/4 using Kloosterman sums. The range c ∈ (1/2, 3/4] remains OPEN.",
   "meta": {
-    "author": "Heath-Brown (2000)",
+    "author": "Heath-Brown (2000), Heilbronn",
     "sourceUrl": "https://erdosproblems.com/445",
     "date": "2000",
     "status": "complete",
@@ -14,13 +14,14 @@
       "number-theory",
       "modular-arithmetic",
       "kloosterman-sums",
-      "exponential-sums"
+      "open"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 0,
     "erdosNumber": 445,
     "erdosUrl": "https://erdosproblems.com/445",
     "erdosProblemStatus": "open",
+    "dateAdded": "2026-01-19",
     "mathlib_version": "4.15.0",
     "mathlibDependencies": [
       {
@@ -34,41 +35,31 @@
         "module": "Mathlib.Data.ZMod.Basic"
       },
       {
-        "theorem": "Nat.Coprime",
-        "description": "Coprimality of natural numbers",
-        "module": "Mathlib.Data.Nat.GCD.Basic"
-      },
-      {
         "theorem": "Complex.abs",
         "description": "Complex absolute value for Kloosterman bounds",
         "module": "Mathlib.Analysis.Complex.Basic"
       }
     ],
     "originalContributions": [
-      "HasInverse: Definition of multiplicative inverse pairs mod p",
-      "HasInversePairInInterval: Inverse pairs in short intervals (n, n+p^c)",
-      "MainConjecture: Statement for all c > 1/2",
-      "StrongConjecture: c = 1/2 is the exact threshold",
-      "heilbronn_unpublished: Axiom for c close to 1",
-      "KloostermanSum: Definition K(m,n;p) = Σₓ e^{2πi(mx + nx⁻¹)/p}",
-      "weil_bound: Axiom |K(m,n;p)| ≤ 2√p",
-      "heath_brown_2000: Axiom for c > 3/4",
-      "heath_brown_threshold: Theorem establishing c₀ = 3/4",
-      "heuristic_pairs: Expected L²/p pairs in length-L interval",
-      "erdos_445_statement: Combined Heilbronn + Heath-Brown + gap"
-    ],
-    "dateAdded": "2026-01-19"
+      "HasInverse, OpenInterval, HasInversePairInInterval definitions",
+      "MainConjecture and StrongConjecture formal statements",
+      "heilbronn_threshold and heilbronn_unpublished axioms",
+      "KloostermanSum axiom and weil_bound",
+      "heath_brown_2000 axiom: c > 3/4 result",
+      "heath_brown_threshold and current_knowledge proved theorems",
+      "erdos_445_summary: two-part conjunction of known results"
+    ]
   },
   "overview": {
-    "historicalContext": "This problem concerns finding multiplicative inverse pairs (a, b with ab ≡ 1 mod p) within short intervals. The question is: how short can the interval (n, n + p^c) be while still guaranteeing such a pair exists?\n\nHeilbronn proved the result for c sufficiently close to 1 (unpublished). The breakthrough came from Heath-Brown (2000), who used Kloosterman sums and the Weil bound |K(m,n;p)| ≤ 2√p to prove the result for all c > 3/4.\n\nThe heuristic argument suggests c = 1/2 is the true threshold: an interval of length L contains roughly L²/p inverse pairs, so L = p^{1/2} gives ~1 pair on average.",
-    "problemStatement": "For any $c > 1/2$, if $p$ is a sufficiently large prime, then for any $n \\geq 0$, there exist $a, b \\in (n, n + p^c)$ such that $ab \\equiv 1 \\pmod{p}$.\n\n**Known Results**:\n- **Heilbronn** (unpublished): True for $c$ sufficiently close to 1\n- **Heath-Brown** (2000): True for all $c > 3/4$\n- **Gap**: $c \\in (1/2, 3/4]$ remains OPEN\n\n**Status**: OPEN",
-    "proofStrategy": "The formalization defines HasInverse (ab ≡ 1 mod p) and HasInversePairInInterval. The main conjecture states that for c > 1/2, inverse pairs exist in intervals of length p^c. Heilbronn's result and Heath-Brown (2000) are axiomatized. Kloosterman sums are defined, and the Weil bound is stated. The heuristic counting argument explains why c = 1/2 is believed to be the threshold.",
+    "historicalContext": "Erdős asked whether for any c > 1/2, a sufficiently large prime p guarantees that every interval (n, n + p^c) contains a pair a, b with ab ≡ 1 (mod p). The heuristic reasoning is compelling: an interval of length L = p^c contains roughly L²/p = p^{2c-1} inverse pairs, which exceeds 1 exactly when c > 1/2.\n\nHeilbronn proved this for c sufficiently close to 1 in an unpublished result, establishing that the conjecture holds above some threshold c₀ < 1. The breakthrough came from Heath-Brown in 2000, who used Kloosterman sum estimates — particularly the Weil bound |K(m,n;p)| ≤ 2√p — combined with careful averaging arguments to push the threshold down to c > 3/4.\n\nThe gap c ∈ (1/2, 3/4] remains completely open. Closing this gap would likely require new estimates for exponential sums or entirely different counting methods. The problem connects to the broader theme of how multiplicative structure modulo primes distributes across short intervals, a central question in analytic number theory.",
+    "problemStatement": "**Problem Statement (Open)**\n\nFor any $c > 1/2$, if $p$ is a sufficiently large prime, then for any $n \\geq 0$, there exist $a, b \\in (n, n + p^c)$ such that $ab \\equiv 1 \\pmod{p}$.\n\n**Known Results:**\n- **Heilbronn** (unpublished): True for $c$ sufficiently close to 1\n- **Heath-Brown** (2000): True for all $c > 3/4$\n\n**Status: OPEN** for $c \\in (1/2, 3/4]$.",
+    "proofStrategy": "The formalization defines HasInverse (ab ≡ 1 mod p) and HasInversePairInInterval for intervals of length p^c. The main conjecture and a stronger version (c = 1/2 exact threshold) are stated as Prop definitions. Heilbronn's result is axiomatized with an existential threshold, and Heath-Brown's c > 3/4 result is a separate axiom. Kloosterman sums are axiomatized with the Weil bound. Two theorems are proved: heath_brown_threshold (c₀ = 3/4) and current_knowledge (Heath-Brown + range inclusion). The summary combines both known results.",
     "keyInsights": [
-      "**Heuristic threshold**: An interval of length L contains ~L²/p inverse pairs. For L = p^c, this is p^{2c-1}, which is ≥ 1 when c ≥ 1/2.",
-      "**Kloosterman sums are key**: Heath-Brown's c > 3/4 result uses K(m,n;p) = Σₓ e^{2πi(mx + nx⁻¹)/p} and the Weil bound.",
-      "**Gap remains**: The range c ∈ (1/2, 3/4] is neither proved nor disproved.",
-      "**Connection to exponential sums**: This is part of a broader theme connecting arithmetic questions to bounds on exponential sums.",
-      "**Uniformity in n**: The result must hold for ALL starting points n, not just typical ones."
+      "**Heuristic threshold at c = 1/2:** An interval of length p^c contains ~p^{2c-1} inverse pairs, exceeding 1 when c > 1/2",
+      "**Kloosterman sums are the key tool:** K(m,n;p) = Σₓ e^{2πi(mx+nx⁻¹)/p} detects inverse pairs in intervals",
+      "**Weil bound |K| ≤ 2√p:** This deep algebraic geometry result (proved via the Riemann hypothesis for curves) is the main input",
+      "**Heath-Brown (2000):** Combined Weil bound with averaging to prove c > 3/4, the current best result",
+      "**Gap c ∈ (1/2, 3/4] remains open:** New exponential sum techniques needed to close the gap"
     ]
   },
   "sections": [
@@ -76,80 +67,51 @@
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "summary": "HasInverse, OpenInterval, HasInversePairInInterval",
-      "startLine": 29,
-      "endLine": 48
+      "startLine": 33,
+      "endLine": 47
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
       "summary": "MainConjecture, StrongConjecture",
       "startLine": 49,
-      "endLine": 66
+      "endLine": 61
     },
     {
       "id": "heilbronn",
       "title": "Heilbronn's Result",
-      "summary": "heilbronn_threshold, heilbronn_unpublished",
-      "startLine": 67,
-      "endLine": 82
+      "summary": "heilbronn_threshold, heilbronn_unpublished axioms",
+      "startLine": 63,
+      "endLine": 73
     },
     {
       "id": "heath-brown",
       "title": "Heath-Brown's Result",
-      "summary": "KloostermanSum, weil_bound, heath_brown_2000",
-      "startLine": 83,
-      "endLine": 111
+      "summary": "KloostermanSum, weil_bound, heath_brown_2000, heath_brown_threshold",
+      "startLine": 75,
+      "endLine": 98
     },
     {
-      "id": "gap",
-      "title": "The Gap",
-      "summary": "OpenRange, gap_open, current_knowledge",
-      "startLine": 112,
-      "endLine": 139
-    },
-    {
-      "id": "counting",
-      "title": "Counting Argument",
-      "summary": "countCoprime, total_inverse_pairs, heuristic_pairs",
-      "startLine": 140,
-      "endLine": 174
-    },
-    {
-      "id": "kloosterman",
-      "title": "Kloosterman Sums",
-      "summary": "RamanujanSum, kloosterman_detects_inverses, heath_brown_method",
-      "startLine": 175,
-      "endLine": 195
-    },
-    {
-      "id": "related",
-      "title": "Related Problems",
-      "summary": "InverseInAP, PrimitiveRootInInterval",
-      "startLine": 196,
-      "endLine": 214
-    },
-    {
-      "id": "main-statement",
-      "title": "Main Problem Statement",
-      "summary": "erdos_445_statement",
-      "startLine": 215,
-      "endLine": 235
+      "id": "open-range",
+      "title": "The Open Range",
+      "summary": "OpenRange definition, current_knowledge theorem",
+      "startLine": 100,
+      "endLine": 116
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_445_summary, erdos_445_answer",
-      "startLine": 236,
-      "endLine": 259
+      "summary": "erdos_445_summary: two-part conjunction of Heilbronn and Heath-Brown",
+      "startLine": 118,
+      "endLine": 141
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #445 asks whether multiplicative inverse pairs exist in intervals of length p^c for c > 1/2. Heath-Brown (2000) proved this for c > 3/4 using Kloosterman sums. The range c ∈ (1/2, 3/4] remains open, with c = 1/2 believed to be the true threshold.",
-    "implications": "A resolution would advance our understanding of the distribution of multiplicative structure mod p. The problem connects to deep tools in analytic number theory, particularly exponential sum estimates.",
+    "summary": "Erdős Problem #445 is OPEN for c ∈ (1/2, 3/4]. It asks whether multiplicative inverse pairs exist in intervals of length p^c for c > 1/2. Heilbronn proved this for c close to 1, and Heath-Brown (2000) proved it for c > 3/4 using Kloosterman sums. The summary theorem combines both known results.",
+    "implications": "A resolution would advance our understanding of multiplicative structure mod p in short intervals, connecting to exponential sum estimates and the distribution of inverses. The problem is representative of the broader challenge of converting heuristic counting arguments into rigorous proofs.",
     "openQuestions": [
-      "Does the conjecture hold for c = 0.6? c = 0.7?",
-      "What are the best techniques for c ∈ (1/2, 3/4]?",
-      "Is c = 1/2 actually the threshold, or could it be lower?",
+      "Does the conjecture hold for c ∈ (1/2, 3/4]?",
+      "Is c = 1/2 the exact threshold?",
       "Can character sum methods improve on Kloosterman approaches?"
     ]
   }


### PR DESCRIPTION
## Summary
- Remove `True := trivial` (2), True axioms (5), sorry defs/proofs (4)
- Axiomatize `KloostermanSum` (was defined with sorry body)
- Add `erdos_445_summary` two-part conjunction (Heilbronn + Heath-Brown)
- Preserve proved `heath_brown_threshold` and `current_knowledge` theorems
- Update meta.json (sorries=0, badge=axiom, 6 sections) and annotations.json (6 annotations with mathContext)
- Reduced from 259 to 142 lines

## Test plan
- [x] `pnpm build` passes
- [ ] Review Lean file for mathematical correctness
- [ ] Verify annotation line ranges match Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)