### PR TITLE
enhance(erdos-560): fix doc comments, duplicate axiom, trivial

### DIFF
--- a/proofs/Proofs/Erdos560Problem.lean
+++ b/proofs/Proofs/Erdos560Problem.lean
@@ -39,7 +39,7 @@ open SimpleGraph
 
 namespace Erdos560
 
-/-
+/-!
 ## Part I: Basic Definitions
 -/
 
@@ -75,7 +75,7 @@ Number of edges in K_{n,n} is n^2.
 axiom completeBipartite_edgeCount (n : ℕ) (hn : n > 0) :
     (K[n,n]).edgeFinset.card = n * n
 
-/-
+/-!
 ## Part II: Size Ramsey Numbers
 -/
 
@@ -118,7 +118,7 @@ noncomputable def sizeRamseyNumber (G : SimpleGraph W) : ℕ :=
 
 notation "R̂(" G ")" => sizeRamseyNumber G
 
-/-
+/-!
 ## Part III: Known Bounds
 -/
 
@@ -146,7 +146,7 @@ theorem size_ramsey_bounds (n : ℕ) (hn : n ≥ 6) :
   · exact erdos_rousseau_lower_bound n hn
   · exact upper_bound n (by omega)
 
-/-
+/-!
 ## Part IV: Conlon-Fox-Wigderson Results (2023)
 -/
 
@@ -180,7 +180,7 @@ axiom cfw_conjecture :
     c * (n : ℝ)^3 * (2 : ℝ)^n ≤ (R̂(K[n,n]) : ℝ) ∧
     (R̂(K[n,n]) : ℝ) ≤ C * (n : ℝ)^3 * (2 : ℝ)^n
 
-/-
+/-!
 ## Part V: Basic Properties
 -/
 
@@ -207,7 +207,7 @@ For paths P_n, the size Ramsey number is linear in n.
 axiom size_ramsey_path_linear (n : ℕ) (hn : n ≥ 2) :
     ∃ C : ℝ, C > 0 ∧ (R̂(SimpleGraph.pathGraph n) : ℝ) ≤ C * n
 
-/-
+/-!
 ## Part VI: Related Concepts
 -/
 
@@ -235,7 +235,7 @@ Classical Ramsey number for complete bipartite graphs grows doubly exponentially
 axiom classical_ramsey_bipartite (n : ℕ) (hn : n ≥ 1) :
     ∃ C : ℝ, C > 0 ∧ (R(K[n,n]) : ℝ) ≤ C * (2 : ℝ)^(2^n)
 
-/-
+/-!
 ## Part VII: Gap Between Bounds
 -/
 
@@ -265,7 +265,7 @@ axiom cfw_implies_tight_lower (n : ℕ) (hn : n ≥ 1) :
 axiom thetaNotation {α : Type*} [Preorder α] (f : α → ℝ) : α → ℝ
 notation:50 f " = Θ(" g ")" => f = thetaNotation g
 
-/-
+/-!
 ## Part VIII: Main Results Summary
 -/
 
@@ -279,8 +279,8 @@ Summary of known results:
 2. Upper bound: (3/2) * n^3 * 2^n (EFRS 1978, NR 1978)
 3. Conjectured: R_hat(K_{n,n}) ≍ n^3 * 2^n (CFW 2023)
 -/
-/-- Size Ramsey numbers are monotone: larger graphs need more edges. -/
-axiom size_ramsey_monotone (n m : ℕ) (hm : m ≤ n) : R̂(K[m,m]) ≤ R̂(K[n,n])
+/-- Size Ramsey numbers are monotone for K_{n,n}: larger n means more edges needed. -/
+axiom size_ramsey_monotone_bipartite (n m : ℕ) (hm : m ≤ n) : R̂(K[m,m]) ≤ R̂(K[n,n])
 
 theorem erdos_560_summary (n : ℕ) (hn : n ≥ 6) :
     -- Lower bound
@@ -291,11 +291,6 @@ theorem erdos_560_summary (n : ℕ) (hn : n ≥ 6) :
     (∀ m : ℕ, m ≤ n → R̂(K[m,m]) ≤ R̂(K[n,n])) :=
   ⟨erdos_rousseau_lower_bound n hn,
    upper_bound n (by omega),
-   fun m hm => size_ramsey_monotone n m hm⟩
-
-/--
-The main theorem: Erdős #560 remains open with the gap between bounds being O(n).
--/
-theorem erdos_560 : True := trivial
+   fun m hm => size_ramsey_monotone_bipartite n m hm⟩
 
 end Erdos560

--- a/src/data/proofs/erdos-560/meta.json
+++ b/src/data/proofs/erdos-560/meta.json
@@ -81,56 +81,56 @@
       "title": "Basic Definitions",
       "summary": "EdgeColoring, completeBipartiteGraph K_{n,n}",
       "startLine": 42,
-      "endLine": 76
+      "endLine": 77
     },
     {
       "id": "size-ramsey",
       "title": "Size Ramsey Numbers",
       "summary": "HasMonochromaticCopy, isSizeRamseyWitness, sizeRamseyNumber",
-      "startLine": 78,
-      "endLine": 110
+      "startLine": 79,
+      "endLine": 119
     },
     {
       "id": "known-bounds",
       "title": "Known Bounds",
       "summary": "erdos_rousseau_lower_bound, upper_bound, size_ramsey_bounds",
-      "startLine": 112,
-      "endLine": 138
+      "startLine": 122,
+      "endLine": 148
     },
     {
       "id": "cfw-results",
       "title": "Conlon-Fox-Wigderson Results",
       "summary": "cfw_general_lower, cfw_asymptotic, cfw_conjecture",
-      "startLine": 140,
-      "endLine": 172
+      "startLine": 150,
+      "endLine": 182
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
       "summary": "Monotonicity, lower bounds, K11 case, path linear bound",
-      "startLine": 174,
-      "endLine": 199
+      "startLine": 184,
+      "endLine": 209
     },
     {
       "id": "classical-ramsey",
       "title": "Classical Ramsey Relation",
       "summary": "classicalRamseyNumber, size vs classical relationship",
-      "startLine": 201,
-      "endLine": 227
+      "startLine": 211,
+      "endLine": 237
     },
     {
       "id": "bounds-gap",
       "title": "Gap Analysis",
       "summary": "bounds_gap theorem, cfw_implies_tight_lower",
-      "startLine": 229,
-      "endLine": 258
+      "startLine": 239,
+      "endLine": 267
     },
     {
       "id": "main-results",
       "title": "Main Results Summary",
       "summary": "erdos_560_summary combining all bounds",
-      "startLine": 260,
-      "endLine": 291
+      "startLine": 269,
+      "endLine": 295
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Changed all section headers from `/-` to `/-!` doc comments
- Removed `erdos_560 : True := trivial` filler
- Renamed duplicate `size_ramsey_monotone` axiom to `size_ramsey_monotone_bipartite` (was defined twice with different signatures)
- Fixed section line numbers in meta.json to match actual Lean file

## Test plan
- [x] `pnpm build` passes
- [x] No sorry or True := trivial issues remain
- [x] No duplicate axiom names
- [x] Summary theorem `erdos_560_summary` has meaningful type

🤖 Generated with [Claude Code](https://claude.com/claude-code)