### PR TITLE
erdos-974: Remove sorry proofs, True junk, fix header

### DIFF
--- a/proofs/Proofs/Erdos974Problem.lean
+++ b/proofs/Proofs/Erdos974Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
 Erdős Problem #974: Power Sums and Roots of Unity
 
 Let z₁, ..., zₙ ∈ ℂ with z₁ = 1. Define power sums:
@@ -162,55 +162,29 @@ theorem erdos_974_solved (n : ℕ) (hn : n ≥ 2) (z : Configuration n)
 -/
 
 /-- The nth roots of unity DO have the zero-tuple property when n > 1. -/
-theorem roots_of_unity_have_zero_tuples (n : ℕ) (hn : n ≥ 2) :
-    hasInfinitelyManyZeroTuples (standardRootsOfUnity n) := by
-  intro N
-  -- For any N, we can find k > N such that (sₖ, ..., sₖ₊ₙ₋₂) are all 0
-  -- Choose k = N + 1 (if n ∤ (N+1), ..., n ∤ (N+n-1))
-  use N + 1
-  constructor
-  · omega
-  · intro j
-    -- Power sum is 0 when n doesn't divide the exponent
-    sorry
+axiom roots_of_unity_have_zero_tuples (n : ℕ) (hn : n ≥ 2) :
+    hasInfinitelyManyZeroTuples (standardRootsOfUnity n)
 
 /-!
 ## Part VII: Connection to Newton's Identities
+
+Newton's identities connect power sums to elementary symmetric polynomials:
+k·eₖ = Σⱼ₌₁ᵏ (-1)^(j-1) eₖ₋ⱼ pⱼ. This algebraic relationship underlies Tijdeman's proof.
+If z₁, ..., zₙ are roots of P(x) = xⁿ + a₁xⁿ⁻¹ + ... + aₙ, then the power sums sₖ
+are determined by the aᵢ. If n-1 consecutive sums vanish, the polynomial is severely
+constrained.
 -/
-
-/-- Newton's identities connect power sums to elementary symmetric polynomials.
-    This algebraic relationship underlies the result. -/
-def relatedToNewtonIdentities : Prop :=
-  -- If e₁, ..., eₙ are elementary symmetric polynomials and p₁, ..., pₙ are power sums,
-  -- then k·eₖ = Σⱼ₌₁ᵏ (-1)^(j-1) eₖ₋ⱼ pⱼ (Newton's formula)
-  True
-
-/-- Connection to characteristic polynomials:
-    z₁, ..., zₙ are roots of some monic polynomial P(x) = xⁿ + a₁xⁿ⁻¹ + ... + aₙ.
-    The power sums sₖ are determined by the aᵢ via Newton's identities. -/
-def relatedToCharacteristicPolynomials : Prop :=
-  -- If n-1 consecutive power sums vanish, this constrains the polynomial severely
-  True
 
 /-!
 ## Part VIII: The "Essentially" Qualification
 -/
 
-/-- What does "essentially" mean? It allows:
-    1. Permutation of the roots (order doesn't matter for power sums)
-    2. For even n, a rotation/reflection symmetry (two (n/2)-gons)
-
-    The power sums are symmetric functions, so permutations are invisible.
--/
-theorem essentially_means_up_to_permutation (n : ℕ) (hn : n > 0)
+/-- Power sums are invariant under permutation of the configuration. -/
+axiom essentially_means_up_to_permutation (n : ℕ) (hn : n > 0)
     (z₁ z₂ : Configuration n)
-    (σ : Fin n ≃ Fin n)  -- A permutation
+    (σ : Fin n ≃ Fin n)
     (hperm : ∀ i, z₁ i = z₂ (σ i)) :
-    ∀ k, powerSum z₁ k = powerSum z₂ k := by
-  intro k
-  simp only [powerSum]
-  -- Sum is invariant under reindexing
-  sorry
+    ∀ k, powerSum z₁ k = powerSum z₂ k
 
 /-!
 ## Summary
@@ -229,8 +203,6 @@ sₖ = Σ zᵢᵏ vanish, then the zᵢ must be (essentially) nth roots of unity
 **Key insight:** The vanishing of n-1 consecutive power sums severely constrains
 the underlying polynomial whose roots are the zᵢ, via Newton's identities.
 -/
-
-theorem erdos_974 : True := trivial
 
 theorem erdos_974_summary :
     -- The main theorem (Turán's conjecture)

--- a/src/data/proofs/erdos-974/annotations.json
+++ b/src/data/proofs/erdos-974/annotations.json
@@ -185,8 +185,8 @@
     "id": "ann-974-newton",
     "proofId": "erdos-974",
     "range": {
-      "startLine": 181,
-      "endLine": 186
+      "startLine": 168,
+      "endLine": 176
     },
     "type": "concept",
     "title": "Newton's Identities Connection",
@@ -199,8 +199,8 @@
     "id": "ann-974-summary",
     "proofId": "erdos-974",
     "range": {
-      "startLine": 235,
-      "endLine": 249
+      "startLine": 207,
+      "endLine": 221
     },
     "type": "theorem",
     "title": "Summary Theorem",

--- a/src/data/proofs/erdos-974/meta.json
+++ b/src/data/proofs/erdos-974/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 974,
     "erdosUrl": "https://erdosproblems.com/974",
     "erdosProblemStatus": "solved",
@@ -118,21 +118,28 @@
       "title": "Converse Direction",
       "summary": "Roots of unity DO have the zero-tuple property",
       "startLine": 160,
-      "endLine": 175
+      "endLine": 166
     },
     {
       "id": "newton",
       "title": "Connection to Newton's Identities",
       "summary": "Algebraic foundation of the result",
-      "startLine": 177,
-      "endLine": 193
+      "startLine": 168,
+      "endLine": 176
+    },
+    {
+      "id": "essentially",
+      "title": "The 'Essentially' Qualification",
+      "summary": "Power sum permutation invariance",
+      "startLine": 178,
+      "endLine": 187
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Final results and erdos_974_summary",
-      "startLine": 215,
-      "endLine": 250
+      "startLine": 189,
+      "endLine": 222
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Converted 2 sorry proofs to axioms (`roots_of_unity_have_zero_tuples`, `essentially_means_up_to_permutation`)
- Removed `erdos_974 : True := trivial`
- Removed 2 `True` definitions (`relatedToNewtonIdentities`, `relatedToCharacteristicPolynomials`), replaced with doc comment
- Fixed header from `/-` to `/-!`
- Updated meta.json (sorries 2→0, section line numbers)
- Updated annotations.json line numbers

## Test plan
- [x] `pnpm build` passes
- [ ] Visual inspection of proof page

🤖 Generated with [Claude Code](https://claude.com/claude-code)