### PR TITLE
enhance(erdos-429): Sparse Admissible Sets

### DIFF
--- a/proofs/Proofs/Erdos429Problem.lean
+++ b/proofs/Proofs/Erdos429Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
 Erdős Problem #429: Sparse Admissible Sets and Prime Shifts
 
 Source: https://erdosproblems.com/429
@@ -41,45 +41,31 @@ open Nat Set
 
 namespace Erdos429
 
-/-!
-## Part I: Basic Definitions
+/-! ## Part I: Basic Definitions -/
 
-Residue classes, admissibility, and prime shifts.
--/
-
-/--
-**Residue Class Coverage:**
-A set A covers residue class r mod m if some a ∈ A satisfies a ≡ r (mod m).
--/
+/-- **Residue Class Coverage:**
+A set A covers residue class r mod m if some a ∈ A satisfies a ≡ r (mod m). -/
 def CoversResidue (A : Set ℕ) (m : ℕ) (r : ℕ) : Prop :=
   ∃ a ∈ A, a % m = r
 
-/--
-**Covers All Residue Classes:**
-A set A covers all residue classes mod m if for every r < m, some a ∈ A ≡ r (mod m).
--/
+/-- **Covers All Residue Classes:**
+A set A covers all residue classes mod m if for every r < m, some a ∈ A ≡ r (mod m). -/
 def CoversAllResidues (A : Set ℕ) (m : ℕ) : Prop :=
   ∀ r < m, CoversResidue A m r
 
-/--
-**Admissible Set:**
+/-- **Admissible Set:**
 A ⊆ ℕ is admissible if it does NOT cover all residue classes mod p for any prime p.
-Equivalently, for each prime p, there exists a residue class mod p avoided by A.
--/
+Equivalently, for each prime p, there exists a residue class mod p avoided by A. -/
 def IsAdmissible (A : Set ℕ) : Prop :=
   ∀ p : ℕ, Nat.Prime p → ¬CoversAllResidues A p
 
-/--
-**Avoided Residue:**
-If A is admissible, for each prime p there exists r such that no a ∈ A ≡ r (mod p).
--/
+/-- **Avoided Residue:**
+If A is admissible, for each prime p there exists r such that no a ∈ A ≡ r (mod p). -/
 def AvoidedResidue (A : Set ℕ) (p : ℕ) (r : ℕ) : Prop :=
   r < p ∧ ∀ a ∈ A, a % p ≠ r
 
-/--
-**Admissibility Characterization:**
-A is admissible iff every prime has an avoided residue.
--/
+/-- **Admissibility Characterization:**
+A is admissible iff every prime has an avoided residue. -/
 theorem admissible_iff_avoided (A : Set ℕ) :
     IsAdmissible A ↔ ∀ p, Nat.Prime p → ∃ r, AvoidedResidue A p r := by
   constructor
@@ -92,240 +78,76 @@ theorem admissible_iff_avoided (A : Set ℕ) :
     obtain ⟨r, hr, havoid⟩ := hA p hp
     exact havoid _ (hcov r hr).choose_spec.1 (hcov r hr).choose_spec.2
 
-/-!
-## Part II: Prime Shifts and the Conjecture
+/-! ## Part II: Prime Shifts and the Conjecture -/
 
-The n-shift of A and when all shifts are prime.
--/
-
-/--
-**Integer Shift:**
-The n-shift of A is {n + a : a ∈ A}.
--/
-def IntShift (A : Set ℕ) (n : ℤ) : Set ℤ :=
-  {x | ∃ a ∈ A, x = n + (a : ℤ)}
-
-/--
-**Natural Shift:**
-The n-shift where n ≥ max(A), ensuring all elements are positive.
--/
-def NatShift (A : Finset ℕ) (n : ℕ) : Finset ℕ :=
-  A.image (· + n)
-
-/--
-**All Primes in Shift:**
-All elements of n + A are prime.
--/
+/-- **All Primes in Shift:**
+All elements of n + A are prime. -/
 def AllPrimesInShift (A : Set ℕ) (n : ℕ) : Prop :=
   ∀ a ∈ A, Nat.Prime (n + a)
 
-/--
-**Has Prime Shift:**
-There exists n such that all elements of n + A are prime.
--/
+/-- **Has Prime Shift:**
+There exists n such that all elements of n + A are prime. -/
 def HasPrimeShift (A : Set ℕ) : Prop :=
   ∃ n : ℕ, AllPrimesInShift A n
 
-/-!
-## Part III: Sparsity Conditions
+/-! ## Part III: Sparsity Conditions -/
 
-Different notions of when a set is "sparse."
--/
-
-/--
-**Density Function:**
-For finite A ⊆ [1, N], the density is |A|/N.
--/
-noncomputable def Density (A : Finset ℕ) (N : ℕ) : ℝ :=
-  (A.filter (· ≤ N)).card / N
-
-/--
-**Zero Density:**
-A has density 0 if |A ∩ [1,N]|/N → 0 as N → ∞.
--/
+/-- **Zero Density:**
+A has density 0 if |A ∩ [1,N]|/N → 0 as N → ∞. -/
 def HasZeroDensity (A : Set ℕ) : Prop :=
   ∀ ε > 0, ∃ N₀ : ℕ, ∀ N ≥ N₀,
     ({n ∈ A | n ≤ N} : Set ℕ).ncard < ε * N
 
-/--
-**Arbitrarily Sparse:**
-A can be made arbitrarily sparse while maintaining the property.
--/
-def ArbitrarilySparse (P : Set ℕ → Prop) : Prop :=
-  ∀ f : ℕ → ℕ, (∀ᶠ n in Filter.atTop, f n > n) →
-    ∃ A : Set ℕ, P A ∧ ∀ a ∈ A, a > f a
-
-/--
-**Lacunary:**
-A is lacunary if a_{n+1}/a_n → ∞.
--/
+/-- **Lacunary:**
+A is lacunary if a_{n+1}/a_n → ∞. -/
 def IsLacunary (A : List ℕ) (hA : A.Sorted (· < ·)) : Prop :=
   ∀ c : ℕ, ∃ N : ℕ, ∀ i, i + 1 < A.length → i ≥ N →
     A.get ⟨i + 1, by omega⟩ > c * A.get ⟨i, by omega⟩
 
-/-!
-## Part IV: The Erdős Conjecture and Its Refutation
+/-! ## Part IV: The Erdős Conjecture and Its Refutation -/
 
-The original question and Weisenberg's counterexample.
--/
-
-/--
-**The Erdős Conjecture (Disproved):**
-If A is sparse enough and admissible, then A has a prime shift.
--/
+/-- **The Erdős Conjecture (Disproved):**
+If A is sparse enough and admissible, then A has a prime shift. -/
 def ErdosConjecture429 : Prop :=
   ∀ A : Set ℕ, HasZeroDensity A → IsAdmissible A → HasPrimeShift A
 
-/--
-**Weisenberg's Theorem (2024):**
+/-- **Weisenberg's Theorem (2024):**
 The Erdős conjecture is FALSE. There exist arbitrarily sparse admissible sets
-with no prime shift.
--/
+with no prime shift. -/
 axiom weisenberg_theorem :
   ∃ A : Set ℕ, HasZeroDensity A ∧ IsAdmissible A ∧ ¬HasPrimeShift A
 
-/--
-**Stronger Result:**
-Even lacunary admissible sets may fail to have prime shifts.
--/
+/-- **Stronger Result:**
+Even lacunary admissible sets may fail to have prime shifts. -/
 axiom weisenberg_lacunary :
   ∃ (A : List ℕ) (hA : A.Sorted (· < ·)),
     IsLacunary A hA ∧
     IsAdmissible (A.toFinset : Set ℕ) ∧
     ¬HasPrimeShift (A.toFinset : Set ℕ)
 
-/--
-**The Conjecture is FALSE:**
--/
+/-- **The Conjecture is FALSE:** -/
 theorem erdos_429_disproved : ¬ErdosConjecture429 := by
   intro hconj
   obtain ⟨A, hdens, hadm, hno⟩ := weisenberg_theorem
   exact hno (hconj A hdens hadm)
 
-/-!
-## Part V: Weisenberg's Construction
+/-! ## Part V: Covering Systems -/
 
-The key ideas in the counterexample.
--/
-
-/--
-**The Construction Idea:**
-Weisenberg builds A by carefully choosing elements that:
-1. Avoid one residue class mod p for each prime p (admissibility)
-2. Are arbitrarily spread out (sparsity)
-3. Yet for every n, some n + a is composite
--/
-axiom weisenberg_construction_idea :
-  -- The construction uses covering systems
-  -- For each potential shift n, identify a prime p_n
-  -- and ensure some a ∈ A satisfies n + a ≡ 0 (mod p_n)
-  True
-
-/--
-**Covering System Connection:**
-The construction relates to covering systems of congruences.
-A covering system {(a_i, m_i)} covers all integers if every n ≡ a_i (mod m_i) for some i.
--/
+/-- **Covering System:**
+A covering system {(aᵢ, mᵢ)} covers all integers if every n ≡ aᵢ (mod mᵢ) for some i.
+Weisenberg's construction uses covering systems to ensure every shift n
+has some a ∈ A with n + a composite. -/
 def IsCoveringSystem (covers : List (ℕ × ℕ)) : Prop :=
   ∀ n : ℤ, ∃ ⟨a, m⟩ ∈ covers, n % m = a
 
-/--
-**Key Insight:**
-The construction ensures that the set of "bad" residue classes forms a covering system.
--/
-axiom key_covering_insight :
-  -- For each prime p in A's construction:
-  -- The "forcing" residue (where A has an element)
-  -- combined across all primes covers all possible shifts n
-  True
+/-- **Admissibility is necessary for prime shifts:**
+If A has a prime shift, then A must be admissible. -/
+axiom admissibility_necessary (A : Set ℕ) (hne : A.Nonempty) :
+    HasPrimeShift A → IsAdmissible A
 
-/-!
-## Part VI: Why Admissibility Isn't Enough
+/-! ## Part VI: Summary -/
 
-The gap between admissibility and having prime shifts.
--/
-
-/--
-**Admissibility is Necessary but Not Sufficient:**
-While non-admissible sets clearly have no prime shift (mod p rules out some n),
-admissibility alone doesn't guarantee existence.
--/
-theorem admissibility_necessary (A : Set ℕ) (hne : A.Nonempty) :
-    HasPrimeShift A → IsAdmissible A := by
-  intro ⟨n, hprime⟩
-  intro p hp
-  simp only [CoversAllResidues, CoversResidue, not_forall, not_exists]
-  -- If A covers all residues mod p, some n+a ≡ 0 (mod p)
-  -- so n+a = p (only prime ≡ 0 mod p) or n+a > p composite
-  use 0
-  constructor
-  · exact hp.pos
-  · intro a ha heq
-    have h := hprime a ha
-    -- n + a ≡ 0 (mod p) means p | (n + a)
-    -- Prime n + a with p | (n + a) means n + a = p
-    sorry -- Technical: use that n + a is prime and divisible by p
-
-/--
-**Dense Finite Admissible Sets:**
-The prime tuples conjecture says dense finite admissible sets have infinitely many prime shifts.
--/
-axiom prime_tuples_conjecture (A : Finset ℕ) :
-    IsAdmissible (A : Set ℕ) →
-    -- Conjecturally: infinitely many n with all n + a prime
-    True
-
-/--
-**The Gap:**
-Sparsity changes the picture: even admissible infinite sparse sets may have no prime shift.
--/
-theorem sparsity_changes_picture :
-    (∀ A : Finset ℕ, IsAdmissible (A : Set ℕ) → True) ∧
-    (∃ A : Set ℕ, A.Infinite ∧ HasZeroDensity A ∧ IsAdmissible A ∧ ¬HasPrimeShift A) := by
-  constructor
-  · intro _ _; trivial
-  · obtain ⟨A, hdens, hadm, hno⟩ := weisenberg_theorem
-    exact ⟨A, sorry, hdens, hadm, hno⟩
-
-/-!
-## Part VII: Related Problems and Context
-
-Connections to other problems in additive combinatorics.
--/
-
-/--
-**Erdős-Graham Problem:**
-This problem was posed jointly with Graham.
--/
-axiom erdos_graham_origin :
-  -- The problem appears in the Erdős-Graham book on combinatorial number theory
-  True
-
-/--
-**Covering Congruences:**
-Erdős was deeply interested in covering systems, which play a key role here.
--/
-axiom covering_congruences_connection :
-  -- Covering systems: {(a_i, m_i)} where every integer is in some a_i (mod m_i)
-  -- Used in the construction of counterexample sets
-  True
-
-/--
-**Green-Tao Connection:**
-Green-Tao proved primes contain arbitrary arithmetic progressions.
-This shows primes are "large" in some sense, but doesn't help here.
--/
-axiom green_tao_context :
-  -- Green-Tao theorem concerns structure IN the primes
-  -- This problem concerns translating sets TO the primes
-  True
-
-/-!
-## Part VIII: Summary
--/
-
-/--
-**Erdős Problem #429: Summary**
+/-- **Summary of Erdős Problem #429:**
 
 PROBLEM: If A ⊆ ℕ is sparse and admissible (avoids one residue class mod p
 for each prime p), must there exist n with all n + a prime?
@@ -333,27 +155,17 @@ for each prime p), must there exist n with all n + a prime?
 ANSWER: NO (Weisenberg 2024)
 
 KEY RESULT: Weisenberg constructed arbitrarily sparse admissible sets
-with no prime shift at all.
+with no prime shift at all, even lacunary ones.
 
 TECHNIQUE: Uses ideas from covering congruences to ensure every potential
-shift n has some a ∈ A with n + a composite.
-
-SIGNIFICANCE: Resolves a question of Erdős and Graham about the relationship
-between sparsity, admissibility, and prime shifts.
--/
+shift n has some a ∈ A with n + a composite. -/
 theorem erdos_429_summary :
-    -- The conjecture is disproved
     ¬ErdosConjecture429 ∧
-    -- There exist arbitrarily sparse counterexamples
     (∃ A : Set ℕ, HasZeroDensity A ∧ IsAdmissible A ∧ ¬HasPrimeShift A) ∧
-    -- Admissibility is necessary but not sufficient
-    True := by
-  refine ⟨erdos_429_disproved, weisenberg_theorem, trivial⟩
-
-/--
-**Erdős Problem #429: SOLVED**
-Answer: NO (Weisenberg 2024)
--/
-theorem erdos_429 : True := trivial
+    (∃ (A : List ℕ) (hA : A.Sorted (· < ·)),
+      IsLacunary A hA ∧
+      IsAdmissible (A.toFinset : Set ℕ) ∧
+      ¬HasPrimeShift (A.toFinset : Set ℕ)) :=
+  ⟨erdos_429_disproved, weisenberg_theorem, weisenberg_lacunary⟩
 
 end Erdos429

--- a/src/data/proofs/erdos-429/annotations.json
+++ b/src/data/proofs/erdos-429/annotations.json
@@ -1,164 +1,68 @@
 [
   {
-    "id": "ann-429-1",
+    "id": "ann-e429-header",
     "proofId": "erdos-429",
-    "range": { "startLine": 1, "endLine": 33 },
-    "type": "context",
+    "range": { "startLine": 1, "endLine": 42 },
+    "type": "concept",
     "title": "Problem Overview",
-    "content": "Erdos Problem #429 asks whether sparse admissible sets must have a prime shift. Answer: NO (Weisenberg 2024). Even arbitrarily sparse sets avoiding one residue class mod p for each prime can fail to have any n with all n+a prime.",
-    "significance": "high"
+    "content": "**Erdős Problem #429** asks whether sparse admissible sets must have prime shifts. An admissible set avoids one residue class mod p for every prime p, so simple sieve arguments cannot rule out a prime shift. Erdős and Graham conjectured that adding sparsity (zero density) should guarantee existence of n with all n + a prime. Weisenberg (2024) proved the answer is NO: even lacunary admissible sets can fail to have any prime shift.",
+    "mathContext": "The problem sits at the intersection of sieve theory and combinatorial number theory. Admissibility is the standard necessary condition for prime tuples — the Hardy-Littlewood conjecture predicts finite admissible tuples have infinitely many prime shifts. The surprise is that for infinite sparse sets, this local-to-global principle fails: passing mod-p tests everywhere does not guarantee a global prime shift.",
+    "significance": "critical",
+    "relatedConcepts": ["admissible sets", "prime tuples conjecture", "covering congruences"]
   },
   {
-    "id": "ann-429-2",
+    "id": "ann-e429-admissibility",
     "proofId": "erdos-429",
-    "range": { "startLine": 54, "endLine": 55 },
+    "range": { "startLine": 44, "endLine": 79 },
     "type": "definition",
-    "title": "Covers Residue",
-    "content": "CoversResidue A m r means some element a in A satisfies a mod m = r. This is the basic building block for admissibility.",
-    "significance": "medium"
+    "title": "Admissibility Framework",
+    "content": "**CoversResidue A m r** checks if some a ∈ A satisfies a ≡ r (mod m). **CoversAllResidues A m** means A hits every residue class mod m. **IsAdmissible A** requires that for every prime p, A does NOT cover all residue classes. **AvoidedResidue A p r** says no element of A is congruent to r mod p. **admissible_iff_avoided** (proved): these two formulations are equivalent — A is admissible iff every prime has an avoided residue.",
+    "mathContext": "The proof of the equivalence uses classical logic: ¬∀r<p, ∃a∈A, a%p=r is equivalent to ∃r<p, ∀a∈A, a%p≠r. This characterization is useful because avoided residues provide the 'free' residue class that could accommodate a prime shift: if n ≡ -r (mod p) for the avoided residue r, then no n + a is divisible by p.",
+    "significance": "critical",
+    "relatedConcepts": ["residue classes", "sieve of Eratosthenes", "modular arithmetic"]
   },
   {
-    "id": "ann-429-3",
+    "id": "ann-e429-prime-shifts",
     "proofId": "erdos-429",
-    "range": { "startLine": 61, "endLine": 62 },
+    "range": { "startLine": 81, "endLine": 105 },
     "type": "definition",
-    "title": "Covers All Residues",
-    "content": "CoversAllResidues A m means A has elements in every residue class mod m. Non-admissible sets cover all residues for some prime.",
-    "significance": "medium"
+    "title": "Prime Shifts and Sparsity",
+    "content": "**AllPrimesInShift A n** requires Nat.Prime (n + a) for all a ∈ A. **HasPrimeShift A** existentially quantifies over n. **HasZeroDensity A** says |A ∩ [1,N]|/N → 0 — the set is sparse. **IsLacunary** is even stronger: consecutive term ratios a_{n+1}/a_n → ∞, meaning gaps grow faster than any linear function.",
+    "mathContext": "Zero density is a weak sparsity condition — the primes themselves have zero density (by the prime number theorem, π(N)/N → 0). Lacunary sets are much sparser: examples include {2^n} or {n!}. The strength of Weisenberg's result is that even this extreme sparsity is insufficient.",
+    "significance": "key",
+    "relatedConcepts": ["asymptotic density", "lacunary sequences", "prime number theorem"]
   },
   {
-    "id": "ann-429-4",
+    "id": "ann-e429-weisenberg",
     "proofId": "erdos-429",
-    "range": { "startLine": 69, "endLine": 70 },
-    "type": "definition",
-    "title": "Admissible Set",
-    "content": "IsAdmissible A means for every prime p, A avoids at least one residue class mod p. Such sets cannot be ruled out from prime shifts by simple mod p arguments.",
-    "significance": "high"
-  },
-  {
-    "id": "ann-429-5",
-    "proofId": "erdos-429",
-    "range": { "startLine": 76, "endLine": 77 },
-    "type": "definition",
-    "title": "Avoided Residue",
-    "content": "AvoidedResidue A p r means no element of A is congruent to r mod p. Admissible sets have at least one avoided residue for each prime.",
-    "significance": "medium"
-  },
-  {
-    "id": "ann-429-6",
-    "proofId": "erdos-429",
-    "range": { "startLine": 119, "endLine": 120 },
-    "type": "definition",
-    "title": "All Primes in Shift",
-    "content": "AllPrimesInShift A n means for all a in A, n+a is prime. This is what we want for a 'prime shift'.",
-    "significance": "high"
-  },
-  {
-    "id": "ann-429-7",
-    "proofId": "erdos-429",
-    "range": { "startLine": 126, "endLine": 127 },
-    "type": "definition",
-    "title": "Has Prime Shift",
-    "content": "HasPrimeShift A means there exists n such that all n+a are prime. The main question is whether sparse admissible sets have this property.",
-    "significance": "high"
-  },
-  {
-    "id": "ann-429-8",
-    "proofId": "erdos-429",
-    "range": { "startLine": 146, "endLine": 148 },
-    "type": "definition",
-    "title": "Zero Density",
-    "content": "HasZeroDensity A means |A cap [1,N]|/N tends to 0 as N tends to infinity. This captures 'sparse enough' in the problem statement.",
-    "significance": "medium"
-  },
-  {
-    "id": "ann-429-9",
-    "proofId": "erdos-429",
-    "range": { "startLine": 162, "endLine": 164 },
-    "type": "definition",
-    "title": "Lacunary Set",
-    "content": "IsLacunary means consecutive terms ratio grows without bound. This is an extremely strong sparsity condition.",
-    "significance": "medium"
-  },
-  {
-    "id": "ann-429-10",
-    "proofId": "erdos-429",
-    "range": { "startLine": 176, "endLine": 177 },
-    "type": "definition",
-    "title": "Erdos Conjecture 429",
-    "content": "ErdosConjecture429: sparse + admissible implies has prime shift. This is the statement that Weisenberg disproved.",
-    "significance": "high"
-  },
-  {
-    "id": "ann-429-11",
-    "proofId": "erdos-429",
-    "range": { "startLine": 184, "endLine": 185 },
+    "range": { "startLine": 107, "endLine": 132 },
     "type": "theorem",
-    "title": "Weisenberg's Theorem",
-    "content": "weisenberg_theorem: There exist zero-density admissible sets with no prime shift. This is the main counterexample result.",
-    "significance": "high"
+    "title": "Weisenberg's Theorem and the Disproof",
+    "content": "**ErdosConjecture429** states: zero density + admissible ⟹ has prime shift. **weisenberg_theorem** (axiom): there exists A with zero density, admissible, and NO prime shift. **weisenberg_lacunary** (axiom): even lacunary admissible sets can fail. **erdos_429_disproved** (proved): ¬ErdosConjecture429, derived by contradiction from weisenberg_theorem — if the conjecture held, the counterexample A would have a prime shift, contradicting ¬HasPrimeShift A.",
+    "mathContext": "The disproof is a clean application of modus tollens: assume the conjecture, apply it to Weisenberg's counterexample A (which satisfies both hypotheses), obtain HasPrimeShift A, contradicting the third property. The lacunary strengthening shows the failure is not about density but about the infinite nature of A.",
+    "significance": "critical",
+    "relatedConcepts": ["proof by contradiction", "counterexample", "modus tollens"]
   },
   {
-    "id": "ann-429-12",
+    "id": "ann-e429-covering",
     "proofId": "erdos-429",
-    "range": { "startLine": 191, "endLine": 195 },
-    "type": "theorem",
-    "title": "Lacunary Counterexample",
-    "content": "weisenberg_lacunary: Even lacunary (extremely sparse) admissible sets can fail to have prime shifts. This strengthens the main result.",
-    "significance": "high"
+    "range": { "startLine": 134, "endLine": 146 },
+    "type": "axiom",
+    "title": "Covering Systems and Necessity",
+    "content": "**IsCoveringSystem** formalizes a covering system: a list of pairs (aᵢ, mᵢ) such that every integer n satisfies n ≡ aᵢ (mod mᵢ) for some i. Weisenberg's construction builds A so that the 'blocking' congruences form a covering system over all potential shifts. **admissibility_necessary** (axiom): if A has a prime shift, A must be admissible — this is the easy direction, showing admissibility is a necessary condition.",
+    "mathContext": "Covering systems were introduced by Erdős himself in the 1950s and play a central role in many number-theoretic constructions. The idea: assign to each element aₖ ∈ A a prime pₖ such that n + aₖ ≡ 0 (mod pₖ) for 'many' values of n. If the congruences {n : pₖ | n + aₖ} collectively cover all integers, then every shift n has some composite element. The challenge is doing this while maintaining admissibility.",
+    "significance": "key",
+    "relatedConcepts": ["covering systems", "Erdős covering conjecture", "Chinese remainder theorem"]
   },
   {
-    "id": "ann-429-13",
+    "id": "ann-e429-summary",
     "proofId": "erdos-429",
-    "range": { "startLine": 200, "endLine": 203 },
-    "type": "theorem",
-    "title": "Conjecture Disproved",
-    "content": "erdos_429_disproved: The Erdos conjecture is false. Derives this from weisenberg_theorem.",
-    "significance": "high"
-  },
-  {
-    "id": "ann-429-14",
-    "proofId": "erdos-429",
-    "range": { "startLine": 229, "endLine": 230 },
-    "type": "definition",
-    "title": "Covering System",
-    "content": "IsCoveringSystem: A set of congruences that covers all integers. Key technique in Weisenberg's construction.",
-    "significance": "medium"
-  },
-  {
-    "id": "ann-429-15",
-    "proofId": "erdos-429",
-    "range": { "startLine": 253, "endLine": 267 },
-    "type": "theorem",
-    "title": "Admissibility Necessary",
-    "content": "admissibility_necessary: If A has a prime shift, then A is admissible. This shows admissibility is a necessary condition.",
-    "significance": "medium"
-  },
-  {
-    "id": "ann-429-16",
-    "proofId": "erdos-429",
-    "range": { "startLine": 273, "endLine": 276 },
-    "type": "insight",
-    "title": "Prime Tuples Conjecture",
-    "content": "prime_tuples_conjecture: For finite admissible sets, conjecturally there are infinitely many prime shifts. Contrast with the infinite sparse case.",
-    "significance": "medium"
-  },
-  {
-    "id": "ann-429-17",
-    "proofId": "erdos-429",
-    "range": { "startLine": 344, "endLine": 351 },
+    "range": { "startLine": 148, "endLine": 171 },
     "type": "theorem",
     "title": "Summary Theorem",
-    "content": "erdos_429_summary: Combines the disproof, existence of counterexamples, and necessity of admissibility into a single statement.",
-    "significance": "high"
-  },
-  {
-    "id": "ann-429-18",
-    "proofId": "erdos-429",
-    "range": { "startLine": 357, "endLine": 357 },
-    "type": "theorem",
-    "title": "Erdos 429 Status",
-    "content": "erdos_429: SOLVED with answer NO. Weisenberg (2024) disproved the conjecture by constructing counterexamples.",
-    "significance": "high"
+    "content": "**erdos_429_summary** packages three results: (1) ¬ErdosConjecture429 — the conjecture is false, (2) existence of a zero-density admissible counterexample, (3) existence of a lacunary admissible counterexample. The proof is ⟨erdos_429_disproved, weisenberg_theorem, weisenberg_lacunary⟩. The three parts capture increasing strength: the conjecture fails, it fails for zero-density sets, and it fails even for lacunary sets.",
+    "mathContext": "The three-part conjunction progresses from the qualitative (conjecture is false) through the quantitative (zero density suffices for counterexample) to the structural (even the strongest reasonable sparsity condition fails). This organization reflects how Weisenberg's paper strengthens the basic result in stages.",
+    "significance": "critical",
+    "relatedConcepts": ["conjunction", "complete resolution", "counterexample hierarchy"]
   }
 ]

--- a/src/data/proofs/erdos-429/meta.json
+++ b/src/data/proofs/erdos-429/meta.json
@@ -16,16 +16,16 @@
       "admissible-sets",
       "covering-systems"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 429,
     "erdosUrl": "https://erdosproblems.com/429",
     "erdosProblemStatus": "solved"
   },
   "overview": {
-    "historicalContext": "This problem was posed by Erdős and Graham and concerns the relationship between sparsity, admissibility, and prime shifts. An admissible set is one that avoids at least one residue class mod p for every prime p - such sets cannot be ruled out from having prime shifts by simple modular arguments. The Hardy-Littlewood prime tuples conjecture suggests dense finite admissible sets should have infinitely many prime shifts. Weisenberg (2024) resolved this problem negatively.",
+    "historicalContext": "Erdős and Graham asked whether sparsity combined with admissibility is sufficient to guarantee a prime shift. An admissible set A avoids at least one residue class mod p for every prime p, which means simple mod-p arguments cannot rule out the existence of n with all n + a prime. The Hardy-Littlewood prime tuples conjecture predicts that finite admissible sets should have infinitely many prime shifts.\n\nThe question was whether this extends to infinite but sparse sets: if A ⊆ ℕ has zero density and is admissible, must some shift n + A consist entirely of primes? This combines two conditions that each seem favorable: admissibility removes the obvious obstruction, and sparsity means fewer simultaneous primality constraints.\n\nWeisenberg (2024) resolved this decisively: NO. He constructed arbitrarily sparse admissible sets — even lacunary ones where consecutive term ratios grow without bound — for which no prime shift exists. The construction uses covering congruences: for each potential shift n, some element a ∈ A forces n + a to be divisible by a specific prime, and these primes collectively cover all possible shifts. This reveals a fundamental gap between the finite and infinite cases of the admissibility condition.",
     "problemStatement": "Is it true that if A ⊆ ℕ is sparse enough and does not cover all residue classes modulo p for any prime p, then there exists some n such that n + a is prime for all a ∈ A?",
-    "proofStrategy": "Weisenberg constructed arbitrarily sparse admissible sets A such that for every potential shift n, some element a ∈ A satisfies n + a is composite. The construction uses ideas from covering systems of congruences to ensure all shifts are 'blocked'.",
+    "proofStrategy": "The formalization defines admissibility via residue class avoidance, proves the equivalence between admissibility and having avoided residues for each prime, and records Weisenberg's counterexample results as axioms. The disproof erdos_429_disproved is derived from weisenberg_theorem by contradiction. The summary packages the disproof, basic counterexample, and lacunary strengthening.",
     "keyInsights": [
       "Admissibility is necessary but not sufficient for prime shifts",
       "Even lacunary (extremely sparse) admissible sets can fail",
@@ -33,10 +33,53 @@
       "Contrast with prime tuples conjecture for finite sets"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Basic Definitions",
+      "startLine": 44,
+      "endLine": 79,
+      "summary": "Residue coverage, admissibility, and the proved equivalence with avoided residues"
+    },
+    {
+      "id": "prime-shifts",
+      "title": "Prime Shifts and the Conjecture",
+      "startLine": 81,
+      "endLine": 91,
+      "summary": "AllPrimesInShift, HasPrimeShift definitions"
+    },
+    {
+      "id": "sparsity",
+      "title": "Sparsity Conditions",
+      "startLine": 93,
+      "endLine": 105,
+      "summary": "Zero density and lacunary conditions"
+    },
+    {
+      "id": "refutation",
+      "title": "The Erdős Conjecture and Its Refutation",
+      "startLine": 107,
+      "endLine": 132,
+      "summary": "ErdosConjecture429, Weisenberg's theorem, and the proved disproof"
+    },
+    {
+      "id": "covering",
+      "title": "Covering Systems",
+      "startLine": 134,
+      "endLine": 146,
+      "summary": "Covering system definition and admissibility necessity"
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 148,
+      "endLine": 171,
+      "summary": "Three-part conjunction: disproof, counterexample, lacunary strengthening"
+    }
+  ],
   "conclusion": {
     "summary": "Erdős Problem #429 is SOLVED with answer NO. Weisenberg (2024) proved that even arbitrarily sparse admissible sets can fail to have any prime shift, by constructing explicit counterexamples using covering system techniques.",
-    "implications": "The result shows that admissibility (avoiding one residue class mod p for each prime) combined with arbitrarily strong sparsity conditions is still not sufficient to guarantee the existence of a prime shift. This contrasts with the conjectured behavior for dense finite admissible sets.",
+    "implications": "The result shows that admissibility combined with arbitrarily strong sparsity conditions is still not sufficient to guarantee the existence of a prime shift. This contrasts with the conjectured behavior for dense finite admissible sets.",
     "openQuestions": [
       "What additional conditions beyond admissibility guarantee a prime shift?",
       "Is the prime tuples conjecture true for finite admissible sets?",


### PR DESCRIPTION
## Summary
- Remove 6 True axioms and 1 True := trivial
- Remove 2 sorry proofs → axiomatize admissibility_necessary, remove sparsity_changes_picture
- Remove unused definitions (IntShift, NatShift, Density, ArbitrarilySparse)
- Fix summary theorem to three-part conjunction: ⟨erdos_429_disproved, weisenberg_theorem, weisenberg_lacunary⟩
- Preserve proved theorems: admissible_iff_avoided, erdos_429_disproved
- Update meta.json: badge→axiom, add 6 sections
- Rewrite annotations.json with 6 substantive annotations
- Reduce from 360 to 172 lines

## Test plan
- [x] `pnpm build` passes
- [ ] Verify Lean file compiles with Mathlib imports
- [ ] Review annotations line ranges match actual file

🤖 Generated with [Claude Code](https://claude.com/claude-code)