### PR TITLE
enhance(erdos-362): remove quality issues, clean up formalization

### DIFF
--- a/proofs/Proofs/Erdos362Problem.lean
+++ b/proofs/Proofs/Erdos362Problem.lean
@@ -1,27 +1,23 @@
 /-
-  Erdős Problem #362: Subset Sum Concentration
+Erdős Problem #362: Subset Sum Concentration
 
-  Source: https://erdosproblems.com/362
-  Status: SOLVED (Sárközy-Szemerédi 1965, Halász 1977, Stanley 1980)
+Source: https://erdosproblems.com/362
+Status: SOLVED (Sárközy-Szemerédi 1965, Halász 1977, Stanley 1980)
 
-  Statement:
-  Let A ⊆ ℕ be a finite set of size N. For any fixed target t:
-  Q1: Are there ≪ 2^N / N^(3/2) subsets S ⊆ A with sum(S) = t?
-  Q2: If we also fix |S| = l, are there ≪ 2^N / N² such subsets?
+Statement:
+Let A ⊆ ℕ be a finite set of size N. For any fixed target t:
+Q1: Are there ≪ 2^N / N^(3/2) subsets S ⊆ A with sum(S) = t?
+Q2: If we also fix |S| = l, are there ≪ 2^N / N² such subsets?
 
-  Answers: YES to both!
+Answers: YES to both!
 
-  Key Results:
-  - Erdős-Moser (1965): First bound with extra (log N)^(3/2) factor
-  - Sárközy-Szemerédi (1965): Proved Q1 affirmatively (removed log factor)
-  - Halász (1977): Proved Q2 affirmatively via multi-dimensional result
-  - Stanley (1980): Maximizing set is {-⌊(N-1)/2⌋, ..., ⌊N/2⌋}
+Key Results:
+- Erdős-Moser (1965): First bound with extra (log N)^(3/2) factor
+- Sárközy-Szemerédi (1965): Proved Q1 affirmatively (removed log factor)
+- Halász (1977): Proved Q2 affirmatively via multi-dimensional result
+- Stanley (1980): Maximizing set is {-⌊(N-1)/2⌋, ..., ⌊N/2⌋}
 
-  Background:
-  This is about the "concentration function" in additive combinatorics.
-  How concentrated can the distribution of subset sums be?
-
-  Tags: additive-combinatorics, subset-sum, concentration, counting
+Tags: additive-combinatorics, subset-sum, concentration, counting
 -/
 
 import Mathlib.Algebra.BigOperators.Group.Finset
@@ -35,7 +31,7 @@ namespace Erdos362
 
 open Finset Nat Real Filter BigOperators
 
-/-!
+/-
 ## Part 1: Subset Sum Definitions
 
 Define the number of subsets summing to a target value.
@@ -59,31 +55,33 @@ noncomputable def concentrationFunction (A : Finset ℤ) : ℕ :=
   Finset.sup (Finset.Icc (∑ x ∈ A.filter (· < 0), x) (∑ x ∈ A.filter (· ≥ 0), x))
     (fun t => countSubsetsWithSum A t)
 
-/-!
+/-
 ## Part 2: Question 1 - General Subset Sum Bound
 
 For any A of size N and any target t:
   #{S ⊆ A : sum(S) = t} ≪ 2^N / N^(3/2)
 -/
 
-/-- Erdős-Moser (1965): Weaker bound with log factor -/
+/-- Erdős-Moser (1965): Weaker bound with log factor.
+    First proved the concentration bound with an extra (log N)^(3/2) factor. -/
 axiom erdos_moser_1965_bound :
     ∃ C > 0, ∀ (A : Finset ℤ), A.card > 0 →
       ∀ t : ℤ, (countSubsetsWithSum A t : ℝ) ≤
         C * 2^(A.card) / (A.card : ℝ)^(3/2 : ℝ) * (Real.log A.card)^(3/2 : ℝ)
 
-/-- Sárközy-Szemerédi (1965): Sharp bound answering Q1 -/
+/-- Sárközy-Szemerédi (1965): Sharp bound answering Q1.
+    Removed the log factor from the Erdős-Moser bound. -/
 axiom sarkozy_szemeredi_1965 :
     ∃ C > 0, ∀ (A : Finset ℤ), A.card > 0 →
       ∀ t : ℤ, (countSubsetsWithSum A t : ℝ) ≤ C * 2^(A.card) / (A.card : ℝ)^(3/2 : ℝ)
 
-/-- The bound 2^N / N^(3/2) is tight up to constants -/
+/-- The bound 2^N / N^(3/2) is tight up to constants. -/
 axiom bound_tight_order :
     ∀ ε > 0, ∀ᶠ N : ℕ in atTop,
       ∃ (A : Finset ℤ), A.card = N ∧
         ∃ t : ℤ, (countSubsetsWithSum A t : ℝ) ≥ (1 - ε) * 2^N / (N : ℝ)^(3/2 : ℝ)
 
-/-!
+/-
 ## Part 3: Question 2 - Fixed Cardinality Bound
 
 For any A of size N, any target t, and any fixed cardinality l:
@@ -98,127 +96,42 @@ def subsetsWithSumAndCard (A : Finset ℤ) (t : ℤ) (l : ℕ) : Finset (Finset 
 def countSubsetsWithSumAndCard (A : Finset ℤ) (t : ℤ) (l : ℕ) : ℕ :=
   (subsetsWithSumAndCard A t l).card
 
-/-- Halász (1977): Sharp bound answering Q2 -/
+/-- Halász (1977): Sharp bound answering Q2.
+    With fixed cardinality constraint, the bound improves to 2^N / N². -/
 axiom halasz_1977 :
     ∃ C > 0, ∀ (A : Finset ℤ), A.card > 0 →
       ∀ t : ℤ, ∀ l : ℕ,
         (countSubsetsWithSumAndCard A t l : ℝ) ≤ C * 2^(A.card) / (A.card : ℝ)^2
 
-/-- Halász's result is dimension-independent -/
-axiom halasz_multidimensional :
-    ∀ d : ℕ, ∃ C > 0, ∀ (A : Finset (Fin d → ℤ)), A.card > 0 →
-      ∀ t : Fin d → ℤ, ∀ l : ℕ,
-        -- Count of subsets with vector sum t and cardinality l
-        True  -- The actual bound involves A.card and dimension d
-
-/-!
+/-
 ## Part 4: Stanley's Extremal Result
 
 The symmetric set {-⌊(N-1)/2⌋, ..., ⌊N/2⌋} maximizes concentration.
+Stanley's proof uses the hard Lefschetz theorem from algebraic geometry
+to establish the Sperner property for certain posets.
 -/
 
 /-- The symmetric set centered at 0 -/
 def symmetricSet (N : ℕ) : Finset ℤ :=
   Finset.Icc (-(N - 1 : ℕ) / 2 : ℤ) ((N : ℕ) / 2 : ℤ)
 
-/-- Stanley (1980): Symmetric set maximizes concentration -/
+/-- Stanley (1980): Symmetric set maximizes concentration.
+    Uses the hard Lefschetz theorem from algebraic geometry. -/
 axiom stanley_1980_extremal :
     ∀ (A : Finset ℤ), ∀ t : ℤ,
       countSubsetsWithSum A t ≤
         countSubsetsWithSum (symmetricSet A.card) 0
 
-/-- For the symmetric set, t = 0 achieves maximum -/
+/-- For the symmetric set, t = 0 achieves maximum concentration. -/
 axiom symmetric_max_at_zero (N : ℕ) :
     ∀ t : ℤ, countSubsetsWithSum (symmetricSet N) t ≤
       countSubsetsWithSum (symmetricSet N) 0
 
-/-- Stanley's theorem uses the hard Lefschetz theorem -/
-theorem stanley_uses_hard_lefschetz :
-    -- Stanley's proof uses algebraic geometry (hard Lefschetz)
-    -- to show the Sperner property for certain posets
-    True := trivial
+/-
+## Part 5: Multi-dimensional Generalization
 
-/-!
-## Part 5: The Central Limit Perspective
-
-The distribution of subset sums approaches a Gaussian.
--/
-
-/-- Mean of subset sums -/
-noncomputable def meanSum (A : Finset ℤ) : ℝ :=
-  (∑ x ∈ A, (x : ℝ)) / 2
-
-/-- Variance of subset sums -/
-noncomputable def varianceSum (A : Finset ℤ) : ℝ :=
-  (∑ x ∈ A, (x : ℝ)^2) / 4
-
-/-- Local CLT: Distribution of subset sums is approximately Gaussian -/
-axiom local_clt_subset_sums (A : Finset ℤ) (hA : A.card > 0) :
-    let μ := meanSum A
-    let σ² := varianceSum A
-    ∀ t : ℤ, σ² > 0 →
-      (countSubsetsWithSum A t : ℝ) ≈
-        2^(A.card) / Real.sqrt (2 * Real.pi * σ²) *
-          Real.exp (-(t - μ)^2 / (2 * σ²))
-  where
-    -- "≈" means asymptotic equality for large |A|
-    a ≈ b := True  -- Placeholder for asymptotic relation
-
-/-- For symmetric set, σ² ≈ N³/12 -/
-axiom symmetric_variance (N : ℕ) (hN : N > 0) :
-    varianceSum (symmetricSet N) ≈ (N : ℝ)^3 / 12
-  where
-    a ≈ b := True
-
-/-!
-## Part 6: Connection to Littlewood-Offord
-
-The classical Littlewood-Offord problem is related.
--/
-
-/-- Littlewood-Offord problem: signs of fixed sequence -/
-def littlewoodOffordCount (v : Fin n → ℝ) (I : Set ℝ) : ℕ :=
-  -- Count of sign choices ε ∈ {±1}^n such that ∑ εᵢvᵢ ∈ I
-  0  -- Placeholder
-
-/-- Erdős's Littlewood-Offord theorem (1945) -/
-axiom erdos_littlewood_offord :
-    ∀ (n : ℕ) (v : Fin n → ℝ) (hv : ∀ i, |v i| ≥ 1),
-      littlewoodOffordCount v (Set.Icc (-1 : ℝ) 1) ≤ Nat.choose n (n / 2)
-
-/-- The Erdős bound is ≈ 2^n / √n by Stirling -/
-theorem erdos_lo_asymptotic (n : ℕ) (hn : n > 0) :
-    (Nat.choose n (n / 2) : ℝ) ≈ 2^n / Real.sqrt ((Real.pi / 2) * n) := by
-  -- Stirling's approximation
-  sorry
-  where a ≈ b := True
-
-/-!
-## Part 7: Proof Sketch for Sárközy-Szemerédi
-
-The key is Fourier analysis on ℤ/Mℤ.
--/
-
-/-- The generating function for subset sums -/
-noncomputable def subsetSumGF (A : Finset ℤ) (z : ℂ) : ℂ :=
-  ∏ a ∈ A, (1 + z^(a.toNat))
-
-/-- Fourier coefficient extraction -/
-axiom fourier_extraction (A : Finset ℤ) (t : ℤ) :
-    (countSubsetsWithSum A t : ℂ) =
-      (1 : ℂ) / (2 * Real.pi) * ∫ θ in Set.Icc 0 (2 * Real.pi),
-        subsetSumGF A (Complex.exp (Complex.I * θ)) * Complex.exp (-Complex.I * t * θ)
-
-/-- The 2^N / N^(3/2) bound comes from saddle point analysis -/
-theorem saddle_point_explanation :
-    -- The generating function has a saddle point
-    -- whose contribution gives the N^(-3/2) factor
-    True := trivial
-
-/-!
-## Part 8: Multi-dimensional Generalization
-
-Halász's theorem generalizes to vector sums.
+Halász's theorem generalizes to vector sums in d dimensions,
+giving a bound of 2^N / N^((d+1)/2).
 -/
 
 /-- Vector-valued subset sum -/
@@ -230,153 +143,45 @@ def countVectorSubsetsWithSum {d : ℕ} (A : Finset (Fin d → ℤ))
     (t : Fin d → ℤ) : ℕ :=
   (A.powerset.filter (fun S => vectorSetSum S = t)).card
 
-/-- Halász multi-dimensional bound -/
+/-- Halász multi-dimensional bound: generalizes to d dimensions.
+    The exponent (d+1)/2 specializes to 3/2 for d=2 and 2 for d=3. -/
 axiom halasz_multi_dim (d : ℕ) :
     ∃ C > 0, ∀ (A : Finset (Fin d → ℤ)), A.card > 0 →
       ∀ t : Fin d → ℤ,
         (countVectorSubsetsWithSum A t : ℝ) ≤
           C * 2^(A.card) / (A.card : ℝ)^((d + 1 : ℕ) / 2 : ℝ)
 
-/-!
-## Part 9: Algorithmic Perspective
+/-
+## Part 6: Generating Function Approach
 
-Counting subset sums is related to the subset sum problem.
+The Sárközy-Szemerédi proof uses Fourier analysis / generating functions.
+The generating function for subset sums factors as a product, and
+the concentration bound follows from saddle point analysis.
 -/
 
-/-- The subset sum decision problem is NP-complete -/
-axiom subset_sum_np_complete :
-    -- Given A and t, deciding if there exists S ⊆ A with sum(S) = t
-    -- is NP-complete
-    True
+/-- The generating function for subset sums.
+    The coefficient of z^t in this product equals countSubsetsWithSum A t. -/
+noncomputable def subsetSumGF (A : Finset ℤ) (z : ℂ) : ℂ :=
+  ∏ a ∈ A, (1 + z^(a.toNat))
 
-/-- Dynamic programming counts in pseudo-polynomial time -/
-axiom dp_counting :
-    -- Count of subsets summing to t can be computed in O(N · M) time
-    -- where M is the sum of |elements|
-    True
+/-- Fourier coefficient extraction: countSubsetsWithSum equals
+    the integral of the generating function against an exponential. -/
+axiom fourier_extraction (A : Finset ℤ) (t : ℤ) :
+    (countSubsetsWithSum A t : ℂ) =
+      (1 : ℂ) / (2 * Real.pi) * ∫ θ in Set.Icc 0 (2 * Real.pi),
+        subsetSumGF A (Complex.exp (Complex.I * θ)) * Complex.exp (-Complex.I * t * θ)
 
-/-- The concentration bound helps with approximate counting -/
-theorem concentration_helps_approximation :
-    -- Knowing the max concentration is 2^N / N^(3/2) helps
-    -- design approximate counting algorithms
-    True := trivial
-
-/-!
-## Part 10: Random Subsets
-
-For a random subset, the sum is approximately Gaussian.
--/
-
-/-- Each element included independently with probability 1/2 -/
-axiom random_subset_sum_clt (A : Finset ℤ) (hA : A.card > 0) :
-    -- The sum of a random subset (each element included w.p. 1/2)
-    -- converges to Gaussian as |A| → ∞
-    let σ² := varianceSum A
-    -- Distribution of sum converges to N(μ, σ²)
-    True
-
-/-- Most subset sums are near the mean -/
-axiom most_sums_near_mean (A : Finset ℤ) :
-    -- #{S : |sum(S) - μ| ≤ c·σ} ≥ (1 - 1/c²) · 2^|A|
-    -- by Chebyshev
-    True
-
-/-!
-## Part 11: Extremal Sets Beyond Symmetric
-
-What other sets achieve near-optimal concentration?
--/
-
-/-- Arithmetic progressions have good concentration -/
-axiom ap_concentration (a d : ℤ) (N : ℕ) (hd : d ≠ 0) :
-    let A := Finset.image (fun i : Fin N => a + d * i) Finset.univ
-    ∃ t, (countSubsetsWithSum A t : ℝ) ≥ (1 - o(1)) * 2^N / (N : ℝ)^(3/2 : ℝ)
-  where
-    o(x : ℝ) := 0  -- Placeholder for little-o notation
-
-/-- Geometric progressions have different behavior -/
-axiom geometric_different (r : ℤ) (N : ℕ) (hr : r > 1) :
-    let A := Finset.image (fun i : Fin N => r^(i : ℕ)) Finset.univ
-    -- Geometric progressions have much lower concentration
-    -- because sums are more spread out
-    True
-
-/-!
-## Part 12: Inverse Problems
-
-Given concentration bounds, what can we deduce about the set?
--/
-
-/-- High concentration implies structure -/
-axiom inverse_concentration :
-    ∀ (A : Finset ℤ), A.card > 0 →
-      (∃ t, (countSubsetsWithSum A t : ℝ) ≥ 2^(A.card) / (A.card : ℝ)^(3/2 : ℝ)) →
-        -- A has arithmetic structure (close to AP)
-        True
-
-/-- Freiman-type theorem for concentration -/
-axiom freiman_type_concentration :
-    -- If concentration is within constant factor of optimal,
-    -- then A has small doubling constant
-    True
-
-/-!
-## Part 13: Explicit Examples
-
-Small cases to build intuition.
--/
-
-/-- For A = {1, 2, 3}, count subsets summing to each target -/
-example : countSubsetsWithSum ({1, 2, 3} : Finset ℤ) 0 = 1 := by
-  -- Only the empty set sums to 0
-  sorry
-
-example : countSubsetsWithSum ({1, 2, 3} : Finset ℤ) 3 = 2 := by
-  -- {3} and {1, 2} both sum to 3
-  sorry
-
-example : countSubsetsWithSum ({1, 2, 3} : Finset ℤ) 6 = 1 := by
-  -- Only {1, 2, 3} sums to 6
-  sorry
-
-/-- The maximum for {1,2,3} is 2, achieved at t = 3 -/
-theorem max_concentration_123 :
-    concentrationFunction ({1, 2, 3} : Finset ℤ) = 2 := by
-  sorry
-
-/-!
-## Part 14: Comparison of Exponents
-
-Q1 gives N^(-3/2), Q2 gives N^(-2). Why the difference?
--/
-
-/-- The extra N^(1/2) factor comes from summing over cardinalities -/
-theorem exponent_comparison :
-    -- #{S : sum(S) = t} = Σₗ #{S : sum(S) = t, |S| = l}
-    -- Sum of N terms, each ≤ C · 2^N / N²
-    -- gives ≤ C · 2^N / N (which is worse than N^(-3/2))
-    -- But we get N^(-3/2) because most l contribute little
-    True := trivial
-
-/-- Only l ≈ N/2 ± √N contribute significantly -/
-axiom central_l_dominate :
-    ∀ (A : Finset ℤ), A.card > 0 → ∀ t : ℤ,
-      -- Most of countSubsetsWithSum A t comes from
-      -- |l - N/2| ≤ c√N for some constant c
-      True
-
-/-!
-## Part 15: Summary
+/-
+## Part 7: Summary
 
 Erdős Problem #362 asks about concentration of subset sums.
 Both questions were answered affirmatively.
 -/
 
-/-- Main summary of Erdős Problem #362 -/
+/-- Main summary of Erdős Problem #362.
+    Q1: #{S ⊆ A : sum(S) = t} ≪ 2^N / N^(3/2) (Sárközy-Szemerédi 1965)
+    Q2: #{S ⊆ A : sum(S) = t, |S| = l} ≪ 2^N / N² (Halász 1977) -/
 theorem erdos_362_summary :
-    -- Q1: #{S ⊆ A : sum(S) = t} ≪ 2^N / N^(3/2) ✓ (Sárközy-Szemerédi 1965)
-    -- Q2: #{S ⊆ A : sum(S) = t, |S| = l} ≪ 2^N / N² ✓ (Halász 1977)
-    -- Extremal: Symmetric set maximizes (Stanley 1980)
     (∃ C > 0, ∀ (A : Finset ℤ), A.card > 0 →
       ∀ t : ℤ, (countSubsetsWithSum A t : ℝ) ≤
         C * 2^(A.card) / (A.card : ℝ)^(3/2 : ℝ)) ∧
@@ -384,8 +189,5 @@ theorem erdos_362_summary :
       ∀ t : ℤ, ∀ l : ℕ, (countSubsetsWithSumAndCard A t l : ℝ) ≤
         C * 2^(A.card) / (A.card : ℝ)^2) := by
   exact ⟨sarkozy_szemeredi_1965, halasz_1977⟩
-
-/-- Erdős Problem #362: SOLVED -/
-theorem erdos_362 : True := trivial
 
 end Erdos362

--- a/src/data/proofs/erdos-362/annotations.json
+++ b/src/data/proofs/erdos-362/annotations.json
@@ -2,229 +2,83 @@
   {
     "id": "ann-e362-overview",
     "proofId": "erdos-362",
-    "range": { "startLine": 1, "endLine": 25 },
+    "range": { "startLine": 1, "endLine": 21 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "**Erdős Problem #362: Subset Sum Concentration**\n\nFor a finite set A of size N and target t:\n- Q1: #{S ⊆ A : sum(S) = t} ≪ 2^N / N^(3/2)? YES\n- Q2: With |S| = l fixed: ≪ 2^N / N²? YES\n\nSolved by Sárközy-Szemerédi (1965) and Halász (1977).",
+    "content": "**Erdős Problem #362: Subset Sum Concentration**\n\nFor a finite set A of size N and target t:\n- Q1: #{S ⊆ A : sum(S) = t} ≪ 2^N / N^(3/2)? YES\n- Q2: With |S| = l fixed: ≪ 2^N / N²? YES\n\nSolved by Sárközy-Szemerédi (1965) and Halász (1977). Stanley (1980) found the extremal set.",
     "mathContext": "Additive combinatorics: concentration functions, subset sums, and Fourier analysis on finite groups.",
     "significance": "critical",
-    "relatedConcepts": ["Littlewood-Offord", "Concentration inequalities", "Subset sum"]
+    "relatedConcepts": ["Concentration inequalities", "Subset sum", "Fourier analysis"]
   },
   {
-    "id": "ann-e362-setsum",
+    "id": "ann-e362-definitions",
     "proofId": "erdos-362",
-    "range": { "startLine": 46, "endLine": 47 },
+    "range": { "startLine": 42, "endLine": 56 },
     "type": "definition",
-    "title": "Set Sum",
-    "content": "**setSum A:** The sum of all elements in a finite set A.\n\nsetSum {1, 2, 3} = 6\nsetSum {} = 0",
-    "significance": "key",
-    "leanSymbol": "setSum"
-  },
-  {
-    "id": "ann-e362-subsetswithsum",
-    "proofId": "erdos-362",
-    "range": { "startLine": 49, "endLine": 55 },
-    "type": "definition",
-    "title": "Subsets With Sum",
-    "content": "**subsetsWithSum A t:** All subsets S ⊆ A with sum(S) = t.\n\n**countSubsetsWithSum A t:** The cardinality |{S ⊆ A : sum(S) = t}|.\n\nThis is the central quantity of interest in the problem.",
+    "title": "Core Definitions",
+    "content": "**setSum A:** Sum of all elements in a finite set.\n**subsetsWithSum A t:** All subsets S ⊆ A with sum(S) = t.\n**countSubsetsWithSum A t:** The count |{S ⊆ A : sum(S) = t}|.\n**concentrationFunction A:** max_t countSubsetsWithSum(A, t).\n\nThese are the central quantities: how many subsets sum to a given target, and what's the maximum over all targets?",
     "significance": "critical",
-    "leanSymbol": "subsetsWithSum"
-  },
-  {
-    "id": "ann-e362-concentration",
-    "proofId": "erdos-362",
-    "range": { "startLine": 57, "endLine": 60 },
-    "type": "definition",
-    "title": "Concentration Function",
-    "content": "**concentrationFunction A:** max_t countSubsetsWithSum(A, t)\n\nThe maximum over all possible targets. This measures how 'peaked' the distribution of subset sums can be.",
-    "significance": "critical",
-    "leanSymbol": "concentrationFunction"
-  },
-  {
-    "id": "ann-e362-erdosmoser",
-    "proofId": "erdos-362",
-    "range": { "startLine": 69, "endLine": 73 },
-    "type": "axiom",
-    "title": "Erdős-Moser (1965)",
-    "content": "**erdos_moser_1965_bound:**\n\ncountSubsetsWithSum(A, t) ≤ C · 2^N / N^(3/2) · (log N)^(3/2)\n\nThe first bound, with an extra logarithmic factor that was later removed.",
-    "significance": "key",
-    "leanSymbol": "erdos_moser_1965_bound"
+    "relatedConcepts": ["Finset.powerset", "BigOperators"]
   },
   {
     "id": "ann-e362-sarkozy",
     "proofId": "erdos-362",
-    "range": { "startLine": 75, "endLine": 78 },
+    "range": { "startLine": 72, "endLine": 76 },
     "type": "axiom",
     "title": "Sárközy-Szemerédi (1965)",
-    "content": "**sarkozy_szemeredi_1965:**\n\ncountSubsetsWithSum(A, t) ≤ C · 2^N / N^(3/2)\n\nThe sharp bound answering Question 1 affirmatively. The log factor was removed using more refined Fourier analysis.",
+    "content": "**sarkozy_szemeredi_1965:**\n\ncountSubsetsWithSum(A, t) ≤ C · 2^N / N^(3/2)\n\nThe sharp bound answering Question 1 affirmatively. Removed the (log N)^(3/2) factor from the earlier Erdős-Moser bound using refined Fourier analysis.",
     "significance": "critical",
-    "leanSymbol": "sarkozy_szemeredi_1965"
-  },
-  {
-    "id": "ann-e362-tight",
-    "proofId": "erdos-362",
-    "range": { "startLine": 80, "endLine": 84 },
-    "type": "axiom",
-    "title": "Bound is Tight",
-    "content": "**bound_tight_order:**\n\nThe 2^N / N^(3/2) bound is tight up to constants. There exist sets achieving this concentration.",
-    "significance": "key",
-    "leanSymbol": "bound_tight_order"
-  },
-  {
-    "id": "ann-e362-fixedcard",
-    "proofId": "erdos-362",
-    "range": { "startLine": 93, "endLine": 99 },
-    "type": "definition",
-    "title": "Fixed Cardinality",
-    "content": "**subsetsWithSumAndCard A t l:** Subsets S ⊆ A with sum(S) = t AND |S| = l.\n\nAdding the cardinality constraint gives a stronger bound.",
-    "significance": "key",
-    "leanSymbol": "subsetsWithSumAndCard"
+    "relatedConcepts": ["Fourier analysis", "Saddle point method"]
   },
   {
     "id": "ann-e362-halasz",
     "proofId": "erdos-362",
-    "range": { "startLine": 101, "endLine": 105 },
+    "range": { "startLine": 99, "endLine": 104 },
     "type": "axiom",
     "title": "Halász (1977)",
-    "content": "**halasz_1977:**\n\ncountSubsetsWithSumAndCard(A, t, l) ≤ C · 2^N / N²\n\nWith fixed cardinality, the exponent improves from 3/2 to 2. The constant C is independent of l and t.",
+    "content": "**halasz_1977:**\n\ncountSubsetsWithSumAndCard(A, t, l) ≤ C · 2^N / N²\n\nWith fixed cardinality |S| = l, the exponent improves from 3/2 to 2. The constant C is independent of both l and t.",
     "significance": "critical",
-    "leanSymbol": "halasz_1977"
-  },
-  {
-    "id": "ann-e362-symmetric",
-    "proofId": "erdos-362",
-    "range": { "startLine": 120, "endLine": 122 },
-    "type": "definition",
-    "title": "Symmetric Set",
-    "content": "**symmetricSet N:** {-⌊(N-1)/2⌋, ..., ⌊N/2⌋}\n\nThe set of N consecutive integers centered at 0. For N=5: {-2, -1, 0, 1, 2}.",
-    "significance": "key",
-    "leanSymbol": "symmetricSet"
+    "relatedConcepts": ["Fixed cardinality constraint", "Additive combinatorics"]
   },
   {
     "id": "ann-e362-stanley",
     "proofId": "erdos-362",
-    "range": { "startLine": 124, "endLine": 128 },
+    "range": { "startLine": 118, "endLine": 128 },
     "type": "axiom",
     "title": "Stanley's Extremal Result (1980)",
-    "content": "**stanley_1980_extremal:**\n\nFor any set A and target t:\ncountSubsetsWithSum(A, t) ≤ countSubsetsWithSum(symmetricSet(|A|), 0)\n\nThe symmetric set centered at 0 maximizes concentration, achieved at target 0.",
+    "content": "**stanley_1980_extremal:**\n\nFor any set A and target t:\ncountSubsetsWithSum(A, t) ≤ countSubsetsWithSum(symmetricSet(|A|), 0)\n\nThe symmetric set {-⌊(N-1)/2⌋, ..., ⌊N/2⌋} maximizes concentration, with maximum at target 0. Stanley's proof uses the hard Lefschetz theorem from algebraic geometry.",
     "significance": "critical",
-    "leanSymbol": "stanley_1980_extremal"
-  },
-  {
-    "id": "ann-e362-lefschetz",
-    "proofId": "erdos-362",
-    "range": { "startLine": 135, "endLine": 139 },
-    "type": "theorem",
-    "title": "Hard Lefschetz Connection",
-    "content": "**stanley_uses_hard_lefschetz:**\n\nStanley's proof uses the hard Lefschetz theorem from algebraic geometry to establish the Sperner property for certain posets, which implies the extremal result.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e362-mean",
-    "proofId": "erdos-362",
-    "range": { "startLine": 147, "endLine": 153 },
-    "type": "definition",
-    "title": "Mean and Variance",
-    "content": "**meanSum A:** (Σ_{x∈A} x) / 2\n**varianceSum A:** (Σ_{x∈A} x²) / 4\n\nFor random subsets (each element included w.p. 1/2), these are the mean and variance of the sum.",
-    "significance": "key",
-    "leanSymbol": "meanSum"
-  },
-  {
-    "id": "ann-e362-clt",
-    "proofId": "erdos-362",
-    "range": { "startLine": 155, "endLine": 165 },
-    "type": "axiom",
-    "title": "Local CLT",
-    "content": "**local_clt_subset_sums:**\n\nFor large |A|, the distribution of subset sums is approximately Gaussian:\n\ncountSubsetsWithSum(A, t) ≈ 2^|A| / √(2πσ²) · exp(-(t-μ)²/(2σ²))\n\nThis explains the N^(3/2) factor: the peak height is ~2^N / √σ², and σ² ~ N.",
-    "significance": "critical",
-    "leanSymbol": "local_clt_subset_sums"
-  },
-  {
-    "id": "ann-e362-lo",
-    "proofId": "erdos-362",
-    "range": { "startLine": 184, "endLine": 187 },
-    "type": "axiom",
-    "title": "Littlewood-Offord Theorem",
-    "content": "**erdos_littlewood_offord:**\n\nFor vectors v₁, ..., vₙ with |vᵢ| ≥ 1:\n#{ε ∈ {±1}ⁿ : |Σ εᵢvᵢ| ≤ 1} ≤ C(n, n/2) ≈ 2ⁿ/√n\n\nThis is the classical result on signed sums, related to subset sum concentration.",
-    "significance": "key",
-    "leanSymbol": "erdos_littlewood_offord"
-  },
-  {
-    "id": "ann-e362-gf",
-    "proofId": "erdos-362",
-    "range": { "startLine": 202, "endLine": 204 },
-    "type": "definition",
-    "title": "Generating Function",
-    "content": "**subsetSumGF A z:** ∏_{a∈A} (1 + z^a)\n\nThe coefficient of z^t gives countSubsetsWithSum(A, t). Fourier analysis on this generating function proves the concentration bounds.",
-    "significance": "key",
-    "leanSymbol": "subsetSumGF"
-  },
-  {
-    "id": "ann-e362-fourier",
-    "proofId": "erdos-362",
-    "range": { "startLine": 206, "endLine": 210 },
-    "type": "axiom",
-    "title": "Fourier Extraction",
-    "content": "**fourier_extraction:**\n\ncountSubsetsWithSum(A, t) = (1/2π) ∫₀^{2π} GF(e^{iθ}) · e^{-itθ} dθ\n\nThe count is extracted as a Fourier coefficient. Saddle point analysis gives the N^(-3/2) bound.",
-    "significance": "key",
-    "leanSymbol": "fourier_extraction"
+    "relatedConcepts": ["Hard Lefschetz theorem", "Sperner property", "Algebraic geometry"]
   },
   {
     "id": "ann-e362-multidim",
     "proofId": "erdos-362",
-    "range": { "startLine": 233, "endLine": 238 },
+    "range": { "startLine": 146, "endLine": 152 },
     "type": "axiom",
     "title": "Multi-dimensional Bound",
-    "content": "**halasz_multi_dim:**\n\nFor d-dimensional vectors:\ncountVectorSubsetsWithSum(A, t) ≤ C · 2^|A| / |A|^{(d+1)/2}\n\nThe exponent grows with dimension: 3/2 for d=1, 2 for d=2, etc.",
+    "content": "**halasz_multi_dim:**\n\nFor d-dimensional integer vectors:\ncountVectorSubsetsWithSum(A, t) ≤ C · 2^|A| / |A|^{(d+1)/2}\n\nThe exponent grows with dimension: 3/2 for d=2, 2 for d=3, etc. This generalizes both the Q1 and Q2 bounds.",
     "significance": "key",
-    "leanSymbol": "halasz_multi_dim"
+    "relatedConcepts": ["Vector sums", "Multi-dimensional concentration"]
   },
   {
-    "id": "ann-e362-np",
+    "id": "ann-e362-gf",
     "proofId": "erdos-362",
-    "range": { "startLine": 246, "endLine": 250 },
-    "type": "axiom",
-    "title": "NP-Completeness",
-    "content": "**subset_sum_np_complete:**\n\nThe subset sum decision problem is NP-complete: given A and t, is there S ⊆ A with sum(S) = t?\n\nThe counting version can be done in pseudo-polynomial time via DP.",
-    "significance": "supporting",
-    "leanSymbol": "subset_sum_np_complete"
-  },
-  {
-    "id": "ann-e362-examples",
-    "proofId": "erdos-362",
-    "range": { "startLine": 329, "endLine": 340 },
-    "type": "theorem",
-    "title": "Small Examples",
-    "content": "**Examples for A = {1, 2, 3}:**\n\n- countSubsetsWithSum({1,2,3}, 0) = 1 (empty set)\n- countSubsetsWithSum({1,2,3}, 3) = 2 ({3} and {1,2})\n- countSubsetsWithSum({1,2,3}, 6) = 1 ({1,2,3})\n\nMaximum concentration is 2, achieved at t = 3.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-e362-exponents",
-    "proofId": "erdos-362",
-    "range": { "startLine": 353, "endLine": 359 },
-    "type": "theorem",
-    "title": "Exponent Comparison",
-    "content": "**exponent_comparison:**\n\nQ1: 2^N / N^(3/2) - sum over all cardinalities\nQ2: 2^N / N² - fixed cardinality\n\nThe N^(1/2) difference: summing N terms each bounded by 2^N/N² would give 2^N/N, but most l contribute little, so we get N^(3/2).",
-    "significance": "key"
+    "range": { "startLine": 162, "endLine": 172 },
+    "type": "concept",
+    "title": "Generating Function and Fourier Analysis",
+    "content": "**subsetSumGF A z:** ∏_{a∈A} (1 + z^a)\n\nThe coefficient of z^t gives countSubsetsWithSum(A, t). The Sárközy-Szemerédi proof extracts this coefficient via a contour integral (Fourier analysis). Saddle point analysis of the integral yields the N^(-3/2) factor.",
+    "mathContext": "This connects combinatorial counting to complex analysis. The generating function factors as a product, making Fourier analysis tractable.",
+    "significance": "key",
+    "relatedConcepts": ["Generating functions", "Fourier analysis", "Saddle point method"]
   },
   {
     "id": "ann-e362-summary",
     "proofId": "erdos-362",
-    "range": { "startLine": 375, "endLine": 386 },
+    "range": { "startLine": 181, "endLine": 191 },
     "type": "theorem",
     "title": "Main Summary",
-    "content": "**erdos_362_summary:**\n\n- Q1: countSubsetsWithSum(A, t) ≤ C · 2^N / N^(3/2) ✓\n- Q2: countSubsetsWithSumAndCard(A, t, l) ≤ C · 2^N / N² ✓\n\nBoth questions answered affirmatively.",
+    "content": "**erdos_362_summary:**\n\nCombines both main results into a single theorem:\n- Q1: countSubsetsWithSum(A, t) ≤ C · 2^N / N^(3/2) (Sárközy-Szemerédi)\n- Q2: countSubsetsWithSumAndCard(A, t, l) ≤ C · 2^N / N² (Halász)\n\nProved directly from the axiomatized bounds. Both questions answered affirmatively.",
     "significance": "critical",
-    "leanSymbol": "erdos_362_summary"
-  },
-  {
-    "id": "ann-e362-main",
-    "proofId": "erdos-362",
-    "range": { "startLine": 388, "endLine": 389 },
-    "type": "theorem",
-    "title": "Main Theorem",
-    "content": "**erdos_362:**\n\nErdős Problem #362 is SOLVED.\n\nBoth concentration bounds were established by 1977.",
-    "significance": "critical",
-    "leanSymbol": "erdos_362"
+    "relatedConcepts": ["Concentration bounds", "Subset sum problem"]
   }
 ]

--- a/src/data/proofs/erdos-362/meta.json
+++ b/src/data/proofs/erdos-362/meta.json
@@ -18,7 +18,7 @@
       "fourier-analysis"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 0,
     "erdosNumber": 362,
     "erdosUrl": "https://erdosproblems.com/362",
     "erdosProblemStatus": "solved",
@@ -47,17 +47,18 @@
       }
     ],
     "originalContributions": [
-      "setSum definition: sum of elements in a finite set",
-      "subsetsWithSum definition: subsets summing to target t",
-      "countSubsetsWithSum definition: count of such subsets",
-      "concentrationFunction definition: max over all targets",
-      "subsetsWithSumAndCard definition: fixed cardinality variant",
+      "setSum, subsetsWithSum, countSubsetsWithSum definitions",
+      "concentrationFunction: max concentration over all targets",
+      "subsetsWithSumAndCard: fixed cardinality variant",
       "symmetricSet definition: {-⌊(N-1)/2⌋, ..., ⌊N/2⌋}",
+      "vectorSetSum, countVectorSubsetsWithSum: d-dimensional variants",
+      "subsetSumGF: generating function for subset sums",
       "erdos_moser_1965_bound axiom: original bound with log factor",
       "sarkozy_szemeredi_1965 axiom: sharp 2^N/N^(3/2) bound",
       "halasz_1977 axiom: 2^N/N² bound with fixed cardinality",
       "stanley_1980_extremal axiom: symmetric set maximizes",
-      "halasz_multi_dim axiom: d-dimensional generalization",
+      "halasz_multi_dim axiom: d-dimensional bound 2^N/N^((d+1)/2)",
+      "fourier_extraction axiom: generating function integral formula",
       "erdos_362_summary theorem: main results combined"
     ]
   },
@@ -80,85 +81,50 @@
       "id": "definitions",
       "title": "Subset Sum Definitions",
       "summary": "setSum, subsetsWithSum, countSubsetsWithSum, concentrationFunction",
-      "startLine": 38,
-      "endLine": 60
+      "startLine": 34,
+      "endLine": 56
     },
     {
       "id": "question1",
       "title": "Question 1: General Bound",
-      "summary": "Sárközy-Szemerédi's 2^N / N^(3/2) bound",
-      "startLine": 62,
-      "endLine": 84
+      "summary": "Erdős-Moser weak bound and Sárközy-Szemerédi sharp 2^N / N^(3/2) bound",
+      "startLine": 58,
+      "endLine": 82
     },
     {
       "id": "question2",
       "title": "Question 2: Fixed Cardinality",
       "summary": "Halász's 2^N / N² bound with fixed |S| = l",
-      "startLine": 86,
-      "endLine": 112
+      "startLine": 84,
+      "endLine": 104
     },
     {
       "id": "stanley",
       "title": "Stanley's Extremal Result",
       "summary": "Symmetric set maximizes concentration via hard Lefschetz",
-      "startLine": 114,
-      "endLine": 139
-    },
-    {
-      "id": "clt",
-      "title": "Central Limit Perspective",
-      "summary": "Gaussian approximation explains the bounds",
-      "startLine": 141,
-      "endLine": 171
-    },
-    {
-      "id": "littlewood-offord",
-      "title": "Littlewood-Offord Connection",
-      "summary": "Related problem on signed sums",
-      "startLine": 173,
-      "endLine": 194
-    },
-    {
-      "id": "proof-sketch",
-      "title": "Proof Sketch",
-      "summary": "Fourier analysis and generating functions",
-      "startLine": 196,
-      "endLine": 216
+      "startLine": 106,
+      "endLine": 128
     },
     {
       "id": "multidim",
       "title": "Multi-dimensional Generalization",
-      "summary": "Halász's theorem for vector sums",
-      "startLine": 218,
-      "endLine": 238
+      "summary": "Halász's theorem for vector sums with bound 2^N / N^((d+1)/2)",
+      "startLine": 130,
+      "endLine": 152
     },
     {
-      "id": "algorithmic",
-      "title": "Algorithmic Perspective",
-      "summary": "Connection to NP-complete subset sum problem",
-      "startLine": 240,
-      "endLine": 262
-    },
-    {
-      "id": "examples",
-      "title": "Explicit Examples",
-      "summary": "Small cases like {1, 2, 3}",
-      "startLine": 323,
-      "endLine": 345
-    },
-    {
-      "id": "exponents",
-      "title": "Comparison of Exponents",
-      "summary": "Why Q1 gives N^(-3/2) and Q2 gives N^(-2)",
-      "startLine": 347,
-      "endLine": 366
+      "id": "generating-function",
+      "title": "Generating Function Approach",
+      "summary": "Fourier analysis and generating function for the proof",
+      "startLine": 154,
+      "endLine": 172
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Main theorem combining both answers",
-      "startLine": 368,
-      "endLine": 389
+      "summary": "Main theorem combining both answers from axioms",
+      "startLine": 174,
+      "endLine": 193
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove all `/-!` docstrings, sorry proofs, `True := trivial` placeholders
- Remove True axioms and placeholder definitions
- Strip bloated sections (CLT placeholders, Littlewood-Offord stubs, algorithmic stubs, sorry examples)
- Keep core mathematical content: definitions, Q1/Q2 bounds, Stanley extremal, multi-dim, Fourier
- Update meta.json and annotations.json to match cleaned file

## Changes
- Lean file: 392 → 193 lines (removed ~200 lines of junk)
- 0 sorries, 0 True := trivial, 0 /-! docstrings
- 8 quality annotations aligned with new file

## Checklist
- [x] No `/-!` docstrings
- [x] No sorry proofs
- [x] No True/trivial placeholders
- [x] No True axioms
- [x] pnpm build succeeds
- [x] Annotations align with Lean file

🤖 Generated by enhancer-4