### PR TITLE
enhance(erdos-1091): Odd Cycles with Diagonals in K₄-Free Graphs

### DIFF
--- a/proofs/Proofs/Erdos1091Problem.lean
+++ b/proofs/Proofs/Erdos1091Problem.lean
@@ -1,25 +1,20 @@
 /-
 Erdős Problem #1091: Odd Cycles with Diagonals in K₄-Free Graphs
 
-Source: https://erdosproblems.com/1091
-Status: PARTIALLY SOLVED / OPEN
+Must a K₄-free graph with χ(G) = 4 contain an odd cycle with at least two diagonals?
 
-Statement:
-Let G be a K₄-free graph with chromatic number 4. Must G contain an odd cycle
-with at least two diagonals?
+**Answer**: YES - proved by Voss (1982), building on Larson (1979).
 
-More generally, is there some f(r)→∞ such that every graph with chromatic number 4,
-in which every subgraph on ≤r vertices has chromatic number ≤3, contains an odd
-cycle with at least f(r) diagonals?
+More generally, is there some f(r)→∞ such that every graph with χ ≥ 4,
+in which every subgraph on ≤r vertices has χ ≤ 3, contains an odd
+cycle with at least f(r) diagonals? This remains OPEN.
 
 History:
-- Erdős originally asked about existence of just one diagonal (simpler question)
 - Larson (1979): Proved one diagonal exists; proved Bollobás-Erdős conjecture
-- Voss (1982): Proved two diagonals are guaranteed (first question SOLVED)
+- Voss (1982): Proved two diagonals are guaranteed
 - Pentagonal wheel shows three diagonals cannot be guaranteed
-- General f(r) question remains OPEN
 
-Tags: graph-theory, chromatic-number, odd-cycles, K4-free
+Reference: https://erdosproblems.com/1091
 -/
 
 import Mathlib.Combinatorics.SimpleGraph.Basic
@@ -29,11 +24,9 @@ import Mathlib.Data.Finset.Basic
 
 namespace Erdos1091
 
-/-!
-## Part 1: Basic Definitions
+/- ## Part 1: Basic Definitions
 
-Graphs, cycles, diagonals, and chromatic number.
--/
+Graphs, cycles, diagonals, and chromatic number. -/
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
@@ -74,11 +67,9 @@ def IsK4Free (G : SimpleGraph V) : Prop :=
 noncomputable def chromaticNumber (G : SimpleGraph V) : ℕ :=
   sSup { k : ℕ | ∃ (c : G.Coloring (Fin k)), True }
 
-/-!
-## Part 2: Larson's Theorem (1979)
+/- ## Part 2: Larson's Theorem (1979)
 
-One diagonal is guaranteed.
--/
+One diagonal is guaranteed. -/
 
 /-- Larson's Theorem (1979): Every K₄-free graph with χ(G) ≥ 4 has an odd cycle
     with at least one diagonal -/
@@ -102,11 +93,9 @@ axiom bollobas_erdos_conjecture (G : SimpleGraph V)
     let alt := BollobasErdosAlternative G
     alt.isBipartite ∨ alt.hasCutVertex ∨ alt.hasDegree2Vertex
 
-/-!
-## Part 3: Voss's Theorem (1982)
+/- ## Part 3: Voss's Theorem (1982)
 
-Two diagonals are guaranteed - answers the first question.
--/
+Two diagonals are guaranteed - answers the first question. -/
 
 /-- Voss's Theorem (1982): Every K₄-free graph with χ(G) ≥ 4 has an odd cycle
     with at least two diagonals -/
@@ -121,11 +110,9 @@ theorem voss_implies_larson (G : SimpleGraph V)
   obtain ⟨c, hOdd, hDiag⟩ := voss_two_diagonals G hK4 hChi
   exact ⟨c, hOdd, Nat.le_of_succ_le hDiag⟩
 
-/-!
-## Part 4: Counterexample for Three Diagonals
+/- ## Part 4: Counterexample for Three Diagonals
 
-The pentagonal wheel shows 3 diagonals cannot be guaranteed.
--/
+The pentagonal wheel shows 3 diagonals cannot be guaranteed. -/
 
 /-- The pentagonal wheel: a 5-cycle with a central vertex connected to all -/
 def PentagonalWheel : SimpleGraph (Fin 6) where
@@ -169,11 +156,9 @@ theorem three_diagonals_not_guaranteed :
   have hMax := pentagonal_wheel_max_2_diagonals c hOdd
   omega
 
-/-!
-## Part 5: The General Question (OPEN)
+/- ## Part 5: The General Question (OPEN)
 
-Is there f(r)→∞ such that locally 3-colorable graphs have f(r) diagonals?
--/
+Is there f(r)→∞ such that locally 3-colorable graphs have f(r) diagonals? -/
 
 /-- A graph is locally k-colorable up to size r if all subgraphs
     on ≤r vertices have chromatic number ≤k -/
@@ -189,14 +174,7 @@ def GeneralQuestion : Prop :=
       ∀ r : ℕ, IsLocallyColorable G r 3 →
         ∃ c : Cycle G, c.isOdd ∧ c.diagonalCount ≥ f r
 
-/-- The general question remains OPEN -/
-axiom general_question_open : True  -- Status unknown
-
-/-!
-## Part 6: Relationship to Other Problems
-
-This connects to Erdős's work on graph coloring and structural graph theory.
--/
+/- ## Part 6: Related Results -/
 
 /-- Key insight: K₄-free graphs can still have high chromatic number -/
 theorem K4_free_high_chi_possible :
@@ -210,35 +188,22 @@ theorem K4_free_high_chi_possible :
 axiom mycielski_construction : ∀ k : ℕ, ∃ (V : Type*) [Fintype V]
     (G : SimpleGraph V), G.CliqueFree 3 ∧ chromaticNumber G ≥ k
 
-/-!
-## Part 7: Main Results Summary
--/
+/- ## Part 7: Summary -/
 
-/-- First question (two diagonals): SOLVED by Voss (1982) -/
-theorem erdos_1091_first_question_solved :
-    ∀ (V : Type*) [Fintype V] [DecidableEq V] (G : SimpleGraph V),
+/-- **Erdős Problem #1091 Summary**:
+    - First question (≥2 diagonals): SOLVED by Voss (1982)
+    - Upper bound (not ≥3): Shown via pentagonal wheel counterexample
+    - General f(r) question: OPEN -/
+theorem erdos_1091_summary :
+    -- Two diagonals guaranteed (Voss)
+    (∀ (V : Type*) [Fintype V] [DecidableEq V] (G : SimpleGraph V),
       IsK4Free G → chromaticNumber G ≥ 4 →
-      ∃ c : Cycle G, c.isOdd ∧ c.diagonalCount ≥ 2 :=
-  fun _ _ _ G hK4 hChi => voss_two_diagonals G hK4 hChi
-
-/-- Upper bound: 3 diagonals cannot be guaranteed -/
-theorem erdos_1091_upper_bound :
+      ∃ c : Cycle G, c.isOdd ∧ c.diagonalCount ≥ 2) ∧
+    -- Three diagonals NOT guaranteed
     ¬ (∀ (V : Type*) [Fintype V] [DecidableEq V] (G : SimpleGraph V),
       IsK4Free G → chromaticNumber G ≥ 4 →
       ∃ c : Cycle G, c.isOdd ∧ c.diagonalCount ≥ 3) :=
-  three_diagonals_not_guaranteed
-
-/-- Second question (general f(r)): OPEN -/
-theorem erdos_1091_second_question_open :
-    -- General f(r)→∞ question status unknown
-    True := trivial
-
-/-- Complete summary -/
-theorem erdos_1091_summary :
-    -- Original question (one diagonal): SOLVED by Larson (1979)
-    -- First question (two diagonals): SOLVED by Voss (1982)
-    -- Upper bound: Pentagonal wheel shows ≤2 diagonals sometimes
-    -- General question (f(r)→∞): OPEN
-    True := trivial
+  ⟨fun _ _ _ G hK4 hChi => voss_two_diagonals G hK4 hChi,
+   three_diagonals_not_guaranteed⟩
 
 end Erdos1091

--- a/src/data/proofs/erdos-1091/annotations.json
+++ b/src/data/proofs/erdos-1091/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-1091-header",
     "proofId": "erdos-1091",
-    "range": { "startLine": 1, "endLine": 23 },
+    "range": { "startLine": 1, "endLine": 18 },
     "type": "concept",
     "title": "Problem Overview",
     "content": "**Erdős Problem #1091** asks: Must a K₄-free graph with χ(G) = 4 contain an odd cycle with at least two diagonals? The first question is SOLVED (Voss 1982). The general f(r) question remains OPEN.",
@@ -13,61 +13,34 @@
   {
     "id": "ann-1091-cycle",
     "proofId": "erdos-1091",
-    "range": { "startLine": 40, "endLine": 48 },
+    "range": { "startLine": 33, "endLine": 41 },
     "type": "definition",
     "title": "Cycle",
     "content": "A cycle is formalized as a list of distinct vertices where consecutive vertices are adjacent, plus a closing edge from last to first vertex. Length must be ≥ 3.",
     "significance": "critical"
   },
   {
-    "id": "ann-1091-isodd",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 50, "endLine": 51 },
-    "type": "definition",
-    "title": "Cycle.isOdd",
-    "content": "A cycle is odd if its length (number of vertices) is odd. Odd cycles are significant because they prevent bipartiteness.",
-    "significance": "key"
-  },
-  {
     "id": "ann-1091-diagonal",
     "proofId": "erdos-1091",
-    "range": { "startLine": 53, "endLine": 61 },
+    "range": { "startLine": 46, "endLine": 54 },
     "type": "definition",
     "title": "Cycle.isDiagonal",
     "content": "A diagonal of a cycle is an edge between two non-consecutive vertices. The definition checks that the vertices are in the cycle but not adjacent in the cyclic order.",
     "significance": "critical"
   },
   {
-    "id": "ann-1091-count",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 63, "endLine": 67 },
-    "type": "definition",
-    "title": "Cycle.diagonalCount",
-    "content": "Counts the number of diagonals by filtering all pairs (u,v) with u < v that satisfy isDiagonal. The ordering prevents double counting.",
-    "significance": "key"
-  },
-  {
     "id": "ann-1091-k4free",
     "proofId": "erdos-1091",
-    "range": { "startLine": 69, "endLine": 71 },
+    "range": { "startLine": 62, "endLine": 64 },
     "type": "definition",
     "title": "IsK4Free",
     "content": "A graph is K₄-free if it contains no clique of size 4, i.e., no 4 vertices that are all pairwise adjacent.",
     "significance": "critical"
   },
   {
-    "id": "ann-1091-chi",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 73, "endLine": 75 },
-    "type": "definition",
-    "title": "chromaticNumber",
-    "content": "The chromatic number χ(G) is the minimum number of colors needed to properly color the vertices (adjacent vertices get different colors).",
-    "significance": "critical"
-  },
-  {
     "id": "ann-1091-larson",
     "proofId": "erdos-1091",
-    "range": { "startLine": 83, "endLine": 87 },
+    "range": { "startLine": 74, "endLine": 78 },
     "type": "axiom",
     "title": "Larson's Theorem (1979)",
     "content": "Every K₄-free graph with χ(G) ≥ 4 contains an odd cycle with at least one diagonal. This was the first major result on this problem.",
@@ -76,154 +49,73 @@
   {
     "id": "ann-1091-bollobas",
     "proofId": "erdos-1091",
-    "range": { "startLine": 89, "endLine": 96 },
-    "type": "definition",
-    "title": "BollobasErdosAlternative",
-    "content": "The Bollobás-Erdős alternatives: if G is K₄-free with no odd cycle having a diagonal, then G is bipartite, has a cut vertex, or has a vertex of degree ≤ 2.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1091-beproof",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 98, "endLine": 103 },
+    "range": { "startLine": 80, "endLine": 94 },
     "type": "axiom",
-    "title": "bollobas_erdos_conjecture",
-    "content": "Larson (1979) proved this stronger conjecture of Bollobás and Erdős, characterizing K₄-free graphs without odd cycles having diagonals.",
+    "title": "Bollobás-Erdős Conjecture",
+    "content": "The Bollobás-Erdős alternatives (proved by Larson 1979): if G is K₄-free with no odd cycle having a diagonal, then G is bipartite, has a cut vertex, or has a vertex of degree ≤ 2.",
     "significance": "key"
   },
   {
     "id": "ann-1091-voss",
     "proofId": "erdos-1091",
-    "range": { "startLine": 111, "endLine": 115 },
+    "range": { "startLine": 100, "endLine": 104 },
     "type": "axiom",
     "title": "Voss's Theorem (1982)",
-    "content": "Every K₄-free graph with χ(G) ≥ 4 contains an odd cycle with at least TWO diagonals. This is a significant strengthening of Larson's result.",
+    "content": "Every K₄-free graph with χ(G) ≥ 4 contains an odd cycle with at least TWO diagonals. This is a significant strengthening of Larson's result and solves the first question.",
     "significance": "critical"
   },
   {
     "id": "ann-1091-implies",
     "proofId": "erdos-1091",
-    "range": { "startLine": 117, "endLine": 122 },
+    "range": { "startLine": 106, "endLine": 111 },
     "type": "theorem",
     "title": "voss_implies_larson",
-    "content": "Voss's theorem (≥2 diagonals) immediately implies Larson's theorem (≥1 diagonal). This is trivial since 2 ≥ 1.",
+    "content": "Voss's theorem (≥2 diagonals) immediately implies Larson's theorem (≥1 diagonal). Fully proved.",
     "significance": "supporting"
   },
   {
     "id": "ann-1091-wheel",
     "proofId": "erdos-1091",
-    "range": { "startLine": 130, "endLine": 148 },
+    "range": { "startLine": 117, "endLine": 135 },
     "type": "definition",
     "title": "PentagonalWheel",
     "content": "The pentagonal wheel: vertices 0-4 form a 5-cycle, vertex 5 is the center connected to all of 0-4. This graph is K₄-free with χ = 4 but every odd cycle has ≤ 2 diagonals.",
     "significance": "critical"
   },
   {
-    "id": "ann-1091-wheelk4",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 150, "endLine": 151 },
-    "type": "axiom",
-    "title": "pentagonal_wheel_K4_free",
-    "content": "The pentagonal wheel contains no K₄: no 4 vertices are mutually adjacent. The center is adjacent to all outer vertices, but outer vertices only form a 5-cycle.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1091-wheelchi",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 153, "endLine": 154 },
-    "type": "axiom",
-    "title": "pentagonal_wheel_chi_4",
-    "content": "The pentagonal wheel has χ = 4: the outer 5-cycle needs 3 colors (odd cycle), and the center needs a 4th color since it's adjacent to all.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1091-wheelmax",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 156, "endLine": 158 },
-    "type": "axiom",
-    "title": "pentagonal_wheel_max_2_diagonals",
-    "content": "In the pentagonal wheel, every odd cycle has at most 2 diagonals. This provides an upper bound on what can be guaranteed.",
-    "significance": "critical"
-  },
-  {
     "id": "ann-1091-not3",
     "proofId": "erdos-1091",
-    "range": { "startLine": 160, "endLine": 170 },
+    "range": { "startLine": 147, "endLine": 157 },
     "type": "theorem",
     "title": "three_diagonals_not_guaranteed",
-    "content": "Proof that 3 diagonals cannot be universally guaranteed: the pentagonal wheel is a counterexample satisfying all hypotheses but having ≤ 2 diagonals in every odd cycle.",
+    "content": "Proof that 3 diagonals cannot be universally guaranteed: the pentagonal wheel is a counterexample satisfying all hypotheses but having ≤ 2 diagonals in every odd cycle. Fully proved from axioms about the wheel.",
     "significance": "critical"
-  },
-  {
-    "id": "ann-1091-local",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 178, "endLine": 182 },
-    "type": "definition",
-    "title": "IsLocallyColorable",
-    "content": "A graph is locally k-colorable up to size r if every induced subgraph on ≤ r vertices has χ ≤ k. This weakens the K₄-free condition.",
-    "significance": "key"
   },
   {
     "id": "ann-1091-general",
     "proofId": "erdos-1091",
-    "range": { "startLine": 184, "endLine": 190 },
+    "range": { "startLine": 169, "endLine": 175 },
     "type": "definition",
-    "title": "GeneralQuestion",
-    "content": "The OPEN general question: Does there exist f(r) → ∞ such that locally 3-colorable graphs with χ ≥ 4 have odd cycles with ≥ f(r) diagonals?",
+    "title": "GeneralQuestion (OPEN)",
+    "content": "The OPEN general question: Does there exist f(r) → ∞ such that locally 3-colorable graphs with χ ≥ 4 have odd cycles with ≥ f(r) diagonals? This is the main unsolved part of Problem #1091.",
     "significance": "critical"
-  },
-  {
-    "id": "ann-1091-open",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 192, "endLine": 193 },
-    "type": "axiom",
-    "title": "general_question_open",
-    "content": "The general f(r) question remains OPEN. This is the main unsolved part of Problem #1091.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1091-highchi",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 201, "endLine": 206 },
-    "type": "theorem",
-    "title": "K4_free_high_chi_possible",
-    "content": "K₄-free graphs CAN have high chromatic number. The pentagonal wheel witnesses K₄-free with χ = 4. This is non-trivial since one might expect small cliques to imply low χ.",
-    "significance": "key"
   },
   {
     "id": "ann-1091-mycielski",
     "proofId": "erdos-1091",
-    "range": { "startLine": 208, "endLine": 211 },
+    "range": { "startLine": 186, "endLine": 189 },
     "type": "axiom",
     "title": "mycielski_construction",
     "content": "The Mycielski construction shows triangle-free graphs can have arbitrarily high χ. This contextualizes why K₄-free high-χ graphs exist.",
     "significance": "supporting"
   },
   {
-    "id": "ann-1091-solved",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 217, "endLine": 222 },
-    "type": "theorem",
-    "title": "erdos_1091_first_question_solved",
-    "content": "Main result: The first question is SOLVED - every K₄-free graph with χ ≥ 4 has an odd cycle with at least 2 diagonals (Voss 1982).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1091-upper",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 224, "endLine": 229 },
-    "type": "theorem",
-    "title": "erdos_1091_upper_bound",
-    "content": "Upper bound: 3 diagonals CANNOT be universally guaranteed. The bound of 2 diagonals (Voss) is tight.",
-    "significance": "critical"
-  },
-  {
     "id": "ann-1091-summary",
     "proofId": "erdos-1091",
-    "range": { "startLine": 236, "endLine": 242 },
+    "range": { "startLine": 193, "endLine": 207 },
     "type": "theorem",
     "title": "erdos_1091_summary",
-    "content": "Summary: Original (1 diagonal) by Larson 1979, first question (2 diagonals) by Voss 1982, upper bound (not 3) by pentagonal wheel, general f(r) question OPEN.",
+    "content": "Summary theorem combining the two main results: (1) Two diagonals guaranteed (Voss), and (2) three diagonals NOT guaranteed (pentagonal wheel). Fully proved from axioms.",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -74,50 +74,50 @@
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "summary": "Cycle, isOdd, isDiagonal, diagonalCount, IsK4Free, chromaticNumber",
-      "startLine": 32,
-      "endLine": 75
+      "startLine": 27,
+      "endLine": 68
     },
     {
       "id": "larson-theorem",
       "title": "Larson's Theorem (1979)",
       "summary": "larson_one_diagonal, BollobasErdosAlternative, bollobas_erdos_conjecture",
-      "startLine": 77,
-      "endLine": 103
+      "startLine": 70,
+      "endLine": 94
     },
     {
       "id": "voss-theorem",
       "title": "Voss's Theorem (1982)",
       "summary": "voss_two_diagonals, voss_implies_larson",
-      "startLine": 105,
-      "endLine": 122
+      "startLine": 96,
+      "endLine": 111
     },
     {
       "id": "counterexample",
       "title": "Counterexample for Three Diagonals",
-      "summary": "PentagonalWheel, pentagonal_wheel_K4_free, pentagonal_wheel_chi_4, three_diagonals_not_guaranteed",
-      "startLine": 124,
-      "endLine": 170
+      "summary": "PentagonalWheel construction, three_diagonals_not_guaranteed",
+      "startLine": 113,
+      "endLine": 157
     },
     {
       "id": "general-question",
       "title": "The General Question (OPEN)",
-      "summary": "IsLocallyColorable, GeneralQuestion, general_question_open",
-      "startLine": 172,
-      "endLine": 193
+      "summary": "IsLocallyColorable, GeneralQuestion",
+      "startLine": 159,
+      "endLine": 175
     },
     {
-      "id": "related-problems",
-      "title": "Related Problems",
+      "id": "related-results",
+      "title": "Related Results",
       "summary": "K4_free_high_chi_possible, mycielski_construction",
-      "startLine": 195,
-      "endLine": 211
+      "startLine": 177,
+      "endLine": 189
     },
     {
-      "id": "main-results",
-      "title": "Main Results Summary",
-      "summary": "erdos_1091_first_question_solved, erdos_1091_upper_bound, erdos_1091_summary",
-      "startLine": 213,
-      "endLine": 244
+      "id": "summary",
+      "title": "Summary",
+      "summary": "erdos_1091_summary combining Voss + counterexample",
+      "startLine": 191,
+      "endLine": 209
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Fix quality issues for Erdős Problem #1091 - odd cycles with diagonals in K₄-free graphs.

## Changes
- Removed `True := trivial` placeholder theorems
- Removed `general_question_open : True` axiom
- Replaced `/-!` docstrings with `/-` for compatibility
- Added proper summary theorem combining Voss's result + pentagonal wheel counterexample
- Updated meta.json sections and annotations with correct line numbers

## Checklist
- [x] No `True := trivial` placeholders
- [x] No `/-!` docstring sections
- [x] pnpm build succeeds
- [x] Annotations align with Lean file line numbers
- [x] Summary theorem has real mathematical content

🤖 Generated by erdos-enhancer-2