### PR TITLE
enhance(erdos-1126): Almost Additive Functions

### DIFF
--- a/proofs/Proofs/Erdos1126Problem.lean
+++ b/proofs/Proofs/Erdos1126Problem.lean
@@ -14,8 +14,7 @@ Proved independently by de Bruijn (1966) and Jurkat (1965).
 
 Key Ideas:
 - "Almost all" means for all (x,y) except a null set in ℝ²
-- The additive function g is essentially unique (f and any
-  correction must agree a.e.)
+- The additive function g is essentially unique
 - Without continuity assumption, additive functions can be wild
 - The theorem says almost-additivity can always be "repaired"
 
@@ -23,8 +22,6 @@ References:
 - Jurkat (1965): "On Cauchy's functional equation"
 - de Bruijn (1966): "On almost additive functions"
 - Erdős (1960): Original formulation
-
-Tags: analysis, functional-equations, measure-theory, cauchy-equation
 -/
 
 import Mathlib.Data.Real.Basic
@@ -35,246 +32,105 @@ open MeasureTheory
 
 namespace Erdos1126
 
-/-!
-## Part I: Cauchy's Functional Equation
--/
+/- ## Part I: Cauchy's Functional Equation -/
 
-/--
-**Cauchy's Functional Equation:**
+/-- **Cauchy's Functional Equation:**
 f(x + y) = f(x) + f(y) for all x, y ∈ ℝ.
-Functions satisfying this are called additive.
--/
+Functions satisfying this are called additive. -/
 def IsAdditive (f : ℝ → ℝ) : Prop :=
   ∀ x y : ℝ, f (x + y) = f x + f y
 
-/--
-**Basic Additive Function:**
-The identity function f(x) = x is additive.
--/
+/-- The identity function f(x) = x is additive. -/
 theorem id_is_additive : IsAdditive id := by
   intro x y
   simp [id]
 
-/--
-**Scalar Multiples:**
-For any c ∈ ℝ, f(x) = cx is additive.
--/
+/-- For any c ∈ ℝ, f(x) = cx is additive. -/
 theorem scalar_is_additive (c : ℝ) : IsAdditive (fun x => c * x) := by
   intro x y
   ring
 
-/--
-**Continuous Additive Functions:**
-If f is additive and continuous, then f(x) = cx for some c.
-This is the classical result for "nice" additive functions.
--/
+/-- **Continuous Additive Functions:**
+If f is additive and continuous, then f(x) = cx for some c. -/
 axiom continuous_additive_is_linear :
     ∀ f : ℝ → ℝ, IsAdditive f → Continuous f →
       ∃ c : ℝ, ∀ x : ℝ, f x = c * x
 
-/-!
-## Part II: Almost Additive Functions
--/
+/- ## Part II: Almost Additive Functions -/
 
-/--
-**Almost Everywhere (a.e.):**
-A property holds a.e. if it fails only on a null set.
--/
+/-- A property holds almost everywhere if it fails only on a null set. -/
 def ae_holds (P : ℝ → Prop) : Prop :=
   ∃ N : Set ℝ, MeasureTheory.volume N = 0 ∧ ∀ x : ℝ, x ∉ N → P x
 
-/--
-**Almost All Pairs:**
-A property holds for almost all pairs (x,y) if it fails only
-on a null set in ℝ².
--/
+/-- A property holds for almost all pairs (x,y) in ℝ². -/
 def ae_pairs (P : ℝ → ℝ → Prop) : Prop :=
   ∃ N : Set (ℝ × ℝ), MeasureTheory.volume N = 0 ∧
     ∀ x y : ℝ, (x, y) ∉ N → P x y
 
-/--
-**Almost Additive Function:**
-f(x + y) = f(x) + f(y) for almost all pairs (x, y).
--/
+/-- **Almost Additive Function:**
+f(x + y) = f(x) + f(y) for almost all pairs (x, y). -/
 def IsAlmostAdditive (f : ℝ → ℝ) : Prop :=
   ae_pairs (fun x y => f (x + y) = f x + f y)
 
-/--
-**Almost Everywhere Equal:**
-f = g almost everywhere.
--/
+/-- f = g almost everywhere. -/
 def ae_eq (f g : ℝ → ℝ) : Prop :=
   ae_holds (fun x => f x = g x)
 
-/-!
-## Part III: The Main Theorem
--/
+/- ## Part III: The Main Theorem (de Bruijn-Jurkat) -/
 
-/--
-**Erdős Problem #1126: The de Bruijn-Jurkat Theorem**
+/-- **Erdős Problem #1126: The de Bruijn-Jurkat Theorem**
 
 If f is almost additive, then there exists a truly additive g
 such that f = g almost everywhere.
 
 This is remarkable: the "defects" in almost-additivity can always
-be repaired by changing f on a null set to get a truly additive g.
--/
+be repaired by changing f on a null set to get a truly additive g. -/
 axiom de_bruijn_jurkat_theorem :
     ∀ f : ℝ → ℝ, IsAlmostAdditive f →
       ∃ g : ℝ → ℝ, IsAdditive g ∧ ae_eq f g
 
-/--
-**Alternative Statement:**
-Every almost additive function agrees a.e. with some additive function.
--/
+/-- Alternative statement of the main result. -/
 theorem erdos_1126_main :
     ∀ f : ℝ → ℝ, IsAlmostAdditive f →
       ∃ g : ℝ → ℝ, IsAdditive g ∧ ae_eq f g :=
   de_bruijn_jurkat_theorem
 
-/-!
-## Part IV: Uniqueness
--/
+/- ## Part IV: Uniqueness -/
 
-/--
-**Uniqueness up to a.e. Equality:**
-If g₁ and g₂ are both additive and agree with f a.e., then g₁ = g₂.
--/
+/-- **Uniqueness up to a.e. equality:**
+If g₁ and g₂ are both additive and agree a.e., then g₁ = g₂. -/
 axiom additive_ae_unique :
     ∀ g₁ g₂ : ℝ → ℝ, IsAdditive g₁ → IsAdditive g₂ →
       ae_eq g₁ g₂ → g₁ = g₂
 
-/--
-**Key Lemma:**
-An additive function that is 0 a.e. is identically 0.
--/
+/-- An additive function that is 0 a.e. is identically 0. -/
 axiom additive_zero_ae :
     ∀ g : ℝ → ℝ, IsAdditive g → ae_eq g 0 → g = 0
 
-/-!
-## Part V: Construction of g
--/
+/- ## Part V: Wild Additive Functions and Regularity -/
 
-/--
-**Sketch of Proof:**
-For almost additive f, define g by:
-  g(x) = lim_{n→∞} f(nx)/n (when this limit exists)
-
-For almost all x, this limit equals f(x), and g is additive.
--/
-axiom proof_sketch_limit_construction : True
-
-/--
-**Alternative Approach (de Bruijn):**
-Use the fact that the set of "good" points
-  G = {x : f(x+y) = f(x) + f(y) for a.e. y}
-has full measure, and show f restricted to G extends uniquely.
--/
-axiom proof_sketch_good_points : True
-
-/-!
-## Part VI: Wild Additive Functions
--/
-
-/--
-**Existence of Wild Additive Functions:**
+/-- **Existence of wild additive functions:**
 Using the Axiom of Choice, there exist additive functions that
-are discontinuous everywhere and unbounded on every interval.
-These are called "wild" additive functions.
--/
+are discontinuous everywhere and unbounded on every interval. -/
 axiom wild_additive_exist :
     ∃ f : ℝ → ℝ, IsAdditive f ∧ ¬Continuous f
 
-/--
-**Hamel Basis:**
-Every additive function can be written as f(x) = Σᵢ cᵢ ρᵢ(x)
-where {ρᵢ} is a Hamel basis of ℝ over ℚ and cᵢ ∈ ℝ.
-Wild functions arise when the cᵢ are chosen inconsistently.
--/
-axiom hamel_basis_characterization : True
-
-/--
-**Measurable Additive Functions:**
+/-- **Measurable additive functions are linear:**
 If f is additive and Lebesgue measurable, then f(x) = cx.
-Non-linear additive functions are necessarily non-measurable.
--/
+Non-linear additive functions are necessarily non-measurable. -/
 axiom measurable_additive_is_linear :
     ∀ f : ℝ → ℝ, IsAdditive f → Measurable f →
       ∃ c : ℝ, ∀ x : ℝ, f x = c * x
 
-/-!
-## Part VII: Generalizations
--/
+/- ## Part VI: Summary -/
 
-/--
-**Higher Dimensions:**
-The theorem extends to ℝⁿ: almost additive functions on ℝⁿ
-agree a.e. with truly additive functions.
--/
-axiom higher_dimensional_version : True
+/-- **Erdős Problem #1126: SOLVED**
 
-/--
-**Other Groups:**
-The result holds for locally compact abelian groups with
-Haar measure replacing Lebesgue measure.
--/
-axiom general_group_version : True
-
-/--
-**Stability:**
-This is an instance of "stability" in functional equations:
-approximate solutions are close to exact solutions.
--/
-axiom stability_interpretation : True
-
-/-!
-## Part VIII: Applications
--/
-
-/--
-**Application to Probability:**
-If X + Y has the same distribution as X' + Y' for independent
-copies almost surely, similar stability results apply.
--/
-axiom probability_application : True
-
-/--
-**Application to Harmonic Analysis:**
-Connects to the study of characters on groups and their
-almost-everywhere versions.
--/
-axiom harmonic_analysis_connection : True
-
-/-!
-## Part IX: Historical Context
--/
-
-/--
-**Cauchy (1821):**
-Original study of functional equations; showed continuous
-additive functions are linear.
--/
-axiom cauchy_1821 : True
-
-/--
-**Hamel (1905):**
-Constructed wild additive functions using a basis for ℝ/ℚ.
--/
-axiom hamel_1905 : True
-
-/--
-**Erdős (1960):**
-Posed the question about almost additive functions.
--/
-axiom erdos_1960 : True
-
-/-!
-## Part X: Summary
--/
-
-/--
-**Summary of Results:**
--/
+Summary of results:
+1. Almost additive → agrees a.e. with truly additive (de Bruijn-Jurkat)
+2. The correction is unique among additive functions
+3. Wild additive functions exist (AC) but are non-measurable
+4. Measurable additive functions must be linear -/
 theorem erdos_1126_summary :
     -- Main theorem (de Bruijn-Jurkat)
     (∀ f : ℝ → ℝ, IsAlmostAdditive f →
@@ -283,35 +139,5 @@ theorem erdos_1126_summary :
     (∀ g₁ g₂ : ℝ → ℝ, IsAdditive g₁ → IsAdditive g₂ →
       ae_eq g₁ g₂ → g₁ = g₂) :=
   ⟨de_bruijn_jurkat_theorem, additive_ae_unique⟩
-
-/--
-**Erdős Problem #1126: SOLVED**
-
-**THEOREM:** If f(x+y) = f(x) + f(y) for almost all x,y ∈ ℝ,
-then there exists g with g(x+y) = g(x) + g(y) for ALL x,y ∈ ℝ
-such that f(x) = g(x) for almost all x.
-
-**PROVED BY:**
-- de Bruijn (1966): "On almost additive functions"
-- Jurkat (1965): "On Cauchy's functional equation"
-
-**KEY INSIGHT:** Almost-additivity can always be "repaired" by
-modifying the function on a null set. The repair g is unique
-among additive functions.
-
-**SIGNIFICANCE:** This is a stability result for Cauchy's equation:
-if a function nearly satisfies the equation (in measure), it can
-be corrected to exactly satisfy it.
--/
-theorem erdos_1126 : True := trivial
-
-/--
-**Historical Note:**
-This problem connects to deep questions in analysis about when
-approximate solutions to functional equations can be corrected
-to exact solutions. The measure-theoretic perspective, where
-"approximate" means "a.e.", is particularly elegant.
--/
-theorem historical_note : True := trivial
 
 end Erdos1126

--- a/src/data/proofs/erdos-1126/annotations.json
+++ b/src/data/proofs/erdos-1126/annotations.json
@@ -1,82 +1,73 @@
 [
   {
-    "id": "ann-1",
-    "range": { "startLine": 47, "endLine": 48 },
+    "id": "ann-e1126-overview",
+    "proofId": "erdos-1126",
+    "range": { "startLine": 1, "endLine": 25 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #1126: Almost Additive Functions**\n\nIf f(x+y) = f(x) + f(y) for almost all pairs (x,y), can f be 'repaired' to satisfy the equation for ALL pairs?\n\n**Answer: YES** — proved by de Bruijn (1966) and Jurkat (1965) independently.\n\nThe repaired function g agrees with f almost everywhere and is unique among additive functions.",
+    "mathContext": "Connects Cauchy's functional equation with measure theory.",
+    "significance": "critical",
+    "relatedConcepts": ["Cauchy equation", "Measure theory", "Functional equations"]
+  },
+  {
+    "id": "ann-e1126-additive",
+    "proofId": "erdos-1126",
+    "range": { "startLine": 37, "endLine": 57 },
     "type": "definition",
     "title": "Cauchy's Functional Equation",
-    "content": "The equation f(x+y) = f(x) + f(y) for all x,y ∈ ℝ. Functions satisfying this are called 'additive'. The simplest examples are f(x) = cx for any constant c.",
-    "significance": "essential"
+    "content": "**IsAdditive f:** f(x+y) = f(x) + f(y) for all x,y ∈ ℝ.\n\nThe simplest examples are f(x) = cx for any constant c. If f is also continuous, then f(x) = cx is the only possibility (Cauchy's classical result). Without continuity, wild solutions exist via the Axiom of Choice.",
+    "significance": "critical",
+    "leanSymbol": "IsAdditive"
   },
   {
-    "id": "ann-2",
-    "range": { "startLine": 99, "endLine": 100 },
+    "id": "ann-e1126-almost-additive",
+    "proofId": "erdos-1126",
+    "range": { "startLine": 61, "endLine": 77 },
     "type": "definition",
-    "title": "Almost Additive Function",
-    "content": "A function f is almost additive if f(x+y) = f(x) + f(y) for almost all pairs (x,y) ∈ ℝ², meaning the equation fails only on a null set in ℝ² (Lebesgue measure zero).",
-    "significance": "essential"
+    "title": "Almost Additive Functions",
+    "content": "**IsAlmostAdditive f:** f(x+y) = f(x) + f(y) for almost all pairs (x,y) ∈ ℝ².\n\n'Almost all' means the equation fails only on a null set in ℝ² (Lebesgue measure zero). Also defines ae_holds (a.e. for single variable), ae_pairs (a.e. for pairs), and ae_eq (equal a.e.).",
+    "significance": "critical",
+    "leanSymbol": "IsAlmostAdditive"
   },
   {
-    "id": "ann-3",
-    "range": { "startLine": 122, "endLine": 124 },
-    "type": "theorem",
+    "id": "ann-e1126-main",
+    "proofId": "erdos-1126",
+    "range": { "startLine": 81, "endLine": 96 },
+    "type": "axiom",
     "title": "de Bruijn-Jurkat Theorem",
-    "content": "The main result: If f is almost additive, there exists a truly additive g with f = g almost everywhere. The 'defects' in almost-additivity can always be repaired by changing f on a null set!",
-    "significance": "essential"
+    "content": "**de_bruijn_jurkat_theorem:** If f is almost additive, there exists a truly additive g with f = g almost everywhere.\n\nThe 'defects' in almost-additivity can always be repaired by changing f on a null set! This is the main result of Erdős Problem #1126.",
+    "significance": "critical",
+    "leanSymbol": "de_bruijn_jurkat_theorem"
   },
   {
-    "id": "ann-4",
-    "range": { "startLine": 143, "endLine": 145 },
-    "type": "theorem",
+    "id": "ann-e1126-uniqueness",
+    "proofId": "erdos-1126",
+    "range": { "startLine": 98, "endLine": 108 },
+    "type": "axiom",
     "title": "Uniqueness of Correction",
-    "content": "If g₁ and g₂ are both additive and equal a.e., then g₁ = g₂ everywhere. This follows from: an additive function that is zero a.e. must be identically zero.",
-    "significance": "essential"
+    "content": "**additive_ae_unique:** If g₁ and g₂ are both additive and equal a.e., then g₁ = g₂ everywhere.\n\nThis follows from the key lemma: an additive function that is zero a.e. must be identically zero. So the repair g in the main theorem is unique.",
+    "significance": "critical",
+    "leanSymbol": "additive_ae_unique"
   },
   {
-    "id": "ann-5",
-    "range": { "startLine": 66, "endLine": 73 },
+    "id": "ann-e1126-wild",
+    "proofId": "erdos-1126",
+    "range": { "startLine": 110, "endLine": 123 },
+    "type": "axiom",
+    "title": "Wild Functions and Regularity",
+    "content": "**wild_additive_exist:** Discontinuous additive functions exist (using AC).\n\n**measurable_additive_is_linear:** If f is additive and Lebesgue measurable, then f(x) = cx.\n\nWild additive functions are necessarily non-measurable. This context shows why the almost-additivity question is subtle.",
+    "significance": "key",
+    "leanSymbol": "wild_additive_exist"
+  },
+  {
+    "id": "ann-e1126-summary",
+    "proofId": "erdos-1126",
+    "range": { "startLine": 127, "endLine": 143 },
     "type": "theorem",
-    "title": "Continuous Additive ⟹ Linear",
-    "content": "Cauchy's classical result (1821): If f is additive AND continuous, then f(x) = cx for some constant c. Without continuity, additive functions can be extremely pathological.",
-    "significance": "essential"
-  },
-  {
-    "id": "ann-6",
-    "range": { "startLine": 185, "endLine": 186 },
-    "type": "insight",
-    "title": "Wild Additive Functions",
-    "content": "Using the Axiom of Choice, one can construct additive functions that are discontinuous everywhere, unbounded on every interval, and whose graph is dense in ℝ². These 'wild' functions use Hamel bases.",
-    "significance": "important"
-  },
-  {
-    "id": "ann-7",
-    "range": { "startLine": 201, "endLine": 203 },
-    "type": "theorem",
-    "title": "Measurable Additive ⟹ Linear",
-    "content": "If f is additive and Lebesgue measurable, then f(x) = cx. Wild additive functions are necessarily non-measurable. This is why measurability/continuity assumptions are often needed.",
-    "significance": "important"
-  },
-  {
-    "id": "ann-8",
-    "range": { "startLine": 223, "endLine": 228 },
-    "type": "insight",
-    "title": "Stability Interpretation",
-    "content": "This theorem is a 'stability' result: approximate solutions (in the measure-theoretic sense) to Cauchy's equation can be corrected to exact solutions. Similar stability questions arise throughout functional equations.",
-    "significance": "important"
-  },
-  {
-    "id": "ann-9",
-    "range": { "startLine": 259, "endLine": 263 },
-    "type": "insight",
-    "title": "Hamel (1905)",
-    "content": "Hamel constructed discontinuous additive functions using a 'Hamel basis' - a basis for ℝ as a vector space over ℚ. Any additive function is determined by its values on such a basis, allowing pathological choices.",
-    "significance": "helpful"
-  },
-  {
-    "id": "ann-10",
-    "range": { "startLine": 287, "endLine": 305 },
-    "type": "summary",
-    "title": "Main Result: erdos_1126",
-    "content": "SOLVED by de Bruijn (1966) and Jurkat (1965) independently. Almost-additive functions can always be corrected to truly additive ones a.e. The correction is unique. This is a foundational result in functional equation stability.",
-    "significance": "essential"
+    "title": "Summary Theorem",
+    "content": "**erdos_1126_summary:** Combines the main theorem (de Bruijn-Jurkat) with uniqueness into a single result.\n\nProved directly from the axiomatized results.\n\n**SOLVED** by de Bruijn (1966) and Jurkat (1965).",
+    "significance": "critical",
+    "leanSymbol": "erdos_1126_summary"
   }
 ]

--- a/src/data/proofs/erdos-1126/meta.json
+++ b/src/data/proofs/erdos-1126/meta.json
@@ -53,72 +53,44 @@
     {
       "id": "cauchy",
       "title": "Cauchy's Functional Equation",
-      "startLine": 38,
-      "endLine": 73,
+      "startLine": 35,
+      "endLine": 57,
       "summary": "IsAdditive, basic properties, continuous case"
     },
     {
       "id": "almost-additive",
       "title": "Almost Additive Functions",
-      "startLine": 75,
-      "endLine": 107,
+      "startLine": 59,
+      "endLine": 77,
       "summary": "ae_holds, ae_pairs, IsAlmostAdditive, ae_eq"
     },
     {
       "id": "main-theorem",
       "title": "The Main Theorem",
-      "startLine": 109,
-      "endLine": 133,
-      "summary": "de_bruijn_jurkat_theorem"
+      "startLine": 79,
+      "endLine": 96,
+      "summary": "de_bruijn_jurkat_theorem, erdos_1126_main"
     },
     {
       "id": "uniqueness",
       "title": "Uniqueness",
-      "startLine": 135,
-      "endLine": 152,
+      "startLine": 98,
+      "endLine": 108,
       "summary": "additive_ae_unique, additive_zero_ae"
     },
     {
-      "id": "construction",
-      "title": "Construction of g",
-      "startLine": 154,
-      "endLine": 173,
-      "summary": "Limit construction, good points approach"
-    },
-    {
       "id": "wild",
-      "title": "Wild Additive Functions",
-      "startLine": 175,
-      "endLine": 203,
-      "summary": "Existence via AC, Hamel basis, measurability"
-    },
-    {
-      "id": "generalizations",
-      "title": "Generalizations",
-      "startLine": 205,
-      "endLine": 228,
-      "summary": "Higher dimensions, general groups, stability"
-    },
-    {
-      "id": "applications",
-      "title": "Applications",
-      "startLine": 230,
-      "endLine": 246,
-      "summary": "Probability, harmonic analysis"
-    },
-    {
-      "id": "history",
-      "title": "Historical Context",
-      "startLine": 248,
-      "endLine": 269,
-      "summary": "Cauchy, Hamel, Erdős timeline"
+      "title": "Wild Additive Functions and Regularity",
+      "startLine": 110,
+      "endLine": 123,
+      "summary": "wild_additive_exist, measurable_additive_is_linear"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 271,
-      "endLine": 317,
-      "summary": "Main theorem and historical note"
+      "startLine": 125,
+      "endLine": 143,
+      "summary": "erdos_1126_summary theorem with proof"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Enhancement for Erdős Problem #1126: Almost Additive Functions (SOLVED).

## Changes
- Removed 11 placeholder `True` axioms/theorems
- Removed all `/-!` docstrings (Aristotle parser incompatible)
- Streamlined from 318 to 143 lines, keeping core mathematical content
- Updated annotations.json with 7 aligned annotations
- Updated meta.json sections for new file structure

## Checklist
- [x] No `sorry` in Lean file
- [x] No placeholder `True` theorems
- [x] No `/-!` docstrings
- [x] `pnpm build` succeeds
- [x] Annotations align with Lean file line numbers

🤖 Generated by enhancer-1