### PR TITLE
enhance(erdos-594): remove sorry and True := trivial

### DIFF
--- a/proofs/Proofs/Erdos594Problem.lean
+++ b/proofs/Proofs/Erdos594Problem.lean
@@ -218,14 +218,13 @@ axiom mycielski_type_construction :
     ∀ κ : Cardinal, ∃ (V : Type*) (G : SimpleGraph V),
       isTriangleFree G ∧ hasLargeChromaticNumber G κ
 
-/-- The smallest odd cycle that MUST appear is length 3 only if
-    the graph has finite girth. -/
-def girth (G : SimpleGraph V) : ℕ := sorry -- Minimum cycle length
-
-/-- Graphs with high girth can still have high chromatic number. -/
+/-- Graphs with high girth can still have high chromatic number.
+    (Girth is the minimum cycle length; here we express the property
+    directly: no cycles of length < g exist, yet χ ≥ κ.) -/
 axiom high_girth_high_chromatic :
     ∀ g : ℕ, ∀ κ : Cardinal, ∃ (V : Type*) (G : SimpleGraph V),
-      girth G ≥ g ∧ hasLargeChromaticNumber G κ
+      (∀ n, 3 ≤ n → n < g → ¬hasCycleOfLength G n) ∧
+      hasLargeChromaticNumber G κ
 
 /-! ## Explicit Bounds -/
 
@@ -267,8 +266,5 @@ theorem erdos_594_summary (V : Type*) (G : SimpleGraph V)
   constructor
   · exact erdos_594 V G h
   · exact contains_all_finite_bipartite V G h
-
-/-- Problem status. -/
-theorem erdos_594_status : True := trivial
 
 end Erdos594

--- a/src/data/proofs/erdos-594/annotations.json
+++ b/src/data/proofs/erdos-594/annotations.json
@@ -123,7 +123,7 @@
   {
     "id": "ann-e594-summary",
     "proofId": "erdos-594",
-    "range": {"startLine": 239, "endLine": 272},
+    "range": {"startLine": 238, "endLine": 270},
     "type": "theorem",
     "title": "Summary",
     "content": "**Erdős Problem #594: Complete Summary**\n\n```lean\ntheorem erdos_594_summary (V : Type*) (G : SimpleGraph V)\n    (h : hasLargeChromaticNumber G aleph1) :\n    containsAllLargeOddCycles G ∧\n    (∀ (W : Type*) [Fintype W] (H : SimpleGraph W), H.IsBipartite →\n      ∃ f : W → V, ∀ v w : W, H.Adj v w → G.Adj (f v) (f w))\n```\n\n**STATUS: SOLVED (1974)**\n\n**Question:** χ(G) ≥ ℵ₁ ⟹ all large odd cycles?\n**Answer:** YES\n\n**Key Results:**\n1. Erdős-Hajnal: Proved for ℵ₂\n2. Erdős-Hajnal-Shelah: Proved for ℵ₁ (optimal)\n3. Thomassen: Cycles pass through any given edge",

--- a/src/data/proofs/erdos-594/meta.json
+++ b/src/data/proofs/erdos-594/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 594,
     "erdosUrl": "https://erdosproblems.com/594",
     "erdosProblemStatus": "solved",
@@ -121,9 +121,9 @@
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_594_summary, final status",
-      "startLine": 239,
-      "endLine": 272
+      "summary": "erdos_594_summary theorem combining main results",
+      "startLine": 238,
+      "endLine": 270
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Removed `sorry` in `girth` function definition (axiomatized `high_girth_high_chromatic` directly)
- Removed `erdos_594_status : True := trivial` placeholder
- Updated meta.json (sorries: 0) and annotations line numbers

## Checklist
- [x] No sorry proofs
- [x] No True := trivial
- [x] pnpm build succeeds
- [x] Annotations aligned with Lean file

🤖 Generated by enhancer-1