### PR TITLE
enhance(erdos-166): remove trivial True axioms and placeholders

### DIFF
--- a/proofs/Proofs/Erdos166Problem.lean
+++ b/proofs/Proofs/Erdos166Problem.lean
@@ -33,7 +33,7 @@ open Finset
 
 namespace Erdos166
 
-/-
+/-!
 ## Part I: Ramsey Number Definitions
 -/
 
@@ -52,7 +52,7 @@ noncomputable def RamseyNumber (s t : ℕ) : ℕ :=
 /-- Notation: R(s,t) for Ramsey numbers. -/
 notation "R(" s "," t ")" => RamseyNumber s t
 
-/-
+/-!
 ## Part II: Basic Properties
 -/
 
@@ -125,7 +125,7 @@ theorem ramsey_two_left (t : ℕ) (ht : t ≥ 2) : R(2, t) = t := by
         fun x hx => by linarith [show x.card ≤ b by
           exact le_trans (Finset.card_le_univ _) (by simpa)]⟩
 
-/-
+/-!
 ## Part III: Known Exact Values
 -/
 
@@ -159,7 +159,7 @@ axiom ramsey_3_k_bounds (k : ℕ) (hk : k ≥ 3) :
     c₁ * k^2 / Real.log k ≤ R(3, k) ∧
     (R(3, k) : ℝ) ≤ c₂ * k^2 / Real.log k
 
-/-
+/-!
 ## Part IV: Historical Lower Bounds for R(4,k)
 -/
 
@@ -174,21 +174,8 @@ axiom spencer_lower_bound :
   ∃ c : ℝ, c > 0 ∧ ∀ k : ℕ, k ≥ 3 →
     (R(4, k) : ℝ) ≥ c * (k * Real.log k)^(5/2 : ℝ)
 
-/--
-**Interpretation of Spencer's Bound:**
-Spencer's bound (k log k)^{5/2} = k^{5/2} · (log k)^{5/2}
-is far from the expected truth k³/(log k)^O(1).
--/
-axiom spencer_interpretation : True
 
-/--
-**Probabilistic Method:**
-Spencer's proof uses the probabilistic method: a random graph
-avoids K_4 with high probability while maintaining independence number.
--/
-axiom probabilistic_method : True
-
-/-
+/-!
 ## Part V: Upper Bound (Ajtai-Komlós-Szemerédi)
 -/
 
@@ -203,21 +190,8 @@ axiom aks_upper_bound :
   ∃ C : ℝ, C > 0 ∧ ∀ k : ℕ, k ≥ 3 →
     (R(4, k) : ℝ) ≤ C * k^3 / (Real.log k)^2
 
-/--
-**AKS Algorithm:**
-The Ajtai-Komlós-Szemerédi proof constructs an explicit coloring
-avoiding K_4 in red and K_k in blue on N vertices.
--/
-axiom aks_algorithm : True
 
-/--
-**The Gap (1980-2023):**
-For 43 years, the gap between Spencer's lower bound (k log k)^{5/2}
-and the AKS upper bound k³/(log k)² remained open.
--/
-axiom the_gap : True
-
-/-
+/-!
 ## Part VI: The Solution (Mattheus-Verstraete 2023)
 -/
 
@@ -232,29 +206,8 @@ axiom mattheus_verstraete :
   ∃ c : ℝ, c > 0 ∧ ∀ k : ℕ, k ≥ 3 →
     (R(4, k) : ℝ) ≥ c * k^3 / (Real.log k)^4
 
-/--
-**The Key Innovation:**
-Mattheus and Verstraete used *algebraic graph constructions*
-based on finite geometry (incidence graphs of projective planes)
-rather than purely probabilistic methods.
--/
-axiom key_innovation : True
 
-/--
-**Pseudo-random Constructions:**
-The construction creates graphs that are "pseudo-random" enough
-to have small clique number while maintaining large independence number.
--/
-axiom pseudorandom_constructions : True
-
-/--
-**Finite Geometry Connection:**
-The proof exploits properties of incidence structures in
-projective planes over finite fields.
--/
-axiom finite_geometry_connection : True
-
-/-
+/-!
 ## Part VII: Erdős's Conjecture (SOLVED)
 -/
 
@@ -292,115 +245,8 @@ theorem current_bounds :
   obtain ⟨C, hC, hC_bound⟩ := aks_upper_bound
   exact ⟨c, C, hc, hC, fun k hk => ⟨hc_bound k hk, hC_bound k hk⟩⟩
 
-/-
-## Part VIII: Related Problems and Generalizations
--/
-
-/--
-**General R(s,k) Problem (Problem #986):**
-Determine the growth rate of R(s,k) for fixed s ≥ 3.
-The Mattheus-Verstraete result specifically handles s = 4.
--/
-axiom general_ramsey_problem : True
-
-/--
-**Ramsey Multiplicity:**
-How many monochromatic copies of K_s appear in any 2-coloring?
-Related to density versions of Ramsey problems.
--/
-axiom ramsey_multiplicity : True
-
-/--
-**Hypergraph Ramsey Numbers:**
-Extensions to hypergraphs where we color r-subsets.
-Growth rates are much faster than graph Ramsey numbers.
--/
-axiom hypergraph_ramsey : True
-
-/--
-**Multicolor Ramsey Numbers:**
-R(k₁,...,kᵣ) for r ≥ 3 colors. Much less is known
-about these compared to 2-color Ramsey numbers.
--/
-axiom multicolor_ramsey : True
-
-/-
-## Part IX: Techniques in Ramsey Theory
--/
-
-/--
-**Probabilistic Method:**
-A random 2-coloring often avoids monochromatic K_s in
-graphs of size much smaller than R(s,k).
--/
-axiom probabilistic_method_general : True
-
-/--
-**Algebraic Constructions:**
-Explicit constructions using algebraic structures
-(Paley graphs, incidence graphs) often achieve better bounds.
--/
-axiom algebraic_constructions : True
-
-/--
-**Stepping Up Lemma:**
-R(s+1, t+1) ≤ R(R(s,t+1), R(s+1,t)) + 1
-allows recursive bounds on Ramsey numbers.
--/
-axiom stepping_up_lemma : True
-
-/--
-**Turán's Theorem Connection:**
-The Turán number ex(n, K_s) relates to Ramsey theory
-through the relationship between cliques and independence.
--/
-axiom turan_connection : True
-
-/-
-## Part X: The Prize Story
--/
-
-/--
-**$250 Erdős Prize:**
-This was one of the problems Erdős offered money for.
-The solution by Mattheus-Verstraete earned the $250 prize.
--/
-axiom erdos_prize : True
-
-/--
-**Prize Collection:**
-Ron Graham managed Erdős's prize fund after Erdős's death (1996).
-The fund continues to pay for solutions to Erdős problems.
--/
-axiom prize_collection : True
-
-/-
-## Part XI: Open Questions
--/
-
-/--
-**Exact Exponent:**
-What is the exact exponent of log k in the lower bound?
-Currently we have (log k)⁴ but (log k)² might be achievable.
--/
-axiom exact_exponent : True
-
-/--
-**General s ≥ 5:**
-For s ≥ 5, what is R(s,k)? The asymptotics are unknown.
-Mattheus-Verstraete techniques may extend partially.
--/
-axiom general_s : True
-
-/--
-**Explicit Constructions:**
-Can we give fully explicit constructions matching
-the probabilistic lower bounds?
--/
-axiom explicit_constructions : True
-
-/-
-## Part XII: Summary
+/-!
+## Part VIII: Summary
 -/
 
 /--
@@ -432,12 +278,6 @@ A breakthrough result bridging 43 years of effort in Ramsey theory.
 theorem erdos_166_status :
     -- Erdős Problem #166 is solved
     Erdos166Statement := erdos_166_solved
-
-/--
-**Problem solved:**
-Erdős Problem #166 was completely solved by Mattheus and Verstraete in 2023.
--/
-theorem erdos_166_complete : True := trivial
 
 /--
 **The bounds match up to logarithmic factors:**

--- a/src/data/proofs/erdos-166/annotations.json
+++ b/src/data/proofs/erdos-166/annotations.json
@@ -36,18 +36,6 @@
     "significance": "key"
   },
   {
-    "id": "ann-166-4",
-    "proofId": "erdos-166",
-    "range": {
-      "startLine": 70,
-      "endLine": 86
-    },
-    "type": "theorem",
-    "title": "R(1,t) = 1",
-    "content": "R(1, t) = 1 for all t ≥ 1. Any single vertex trivially forms a monochromatic K_1, regardless of the edge coloring. This is the base case for Ramsey number recursions.",
-    "significance": "supporting"
-  },
-  {
     "id": "ann-166-5",
     "proofId": "erdos-166",
     "range": {
@@ -72,119 +60,59 @@
     "significance": "key"
   },
   {
-    "id": "ann-166-7",
-    "proofId": "erdos-166",
-    "range": {
-      "startLine": 152,
-      "endLine": 160
-    },
-    "type": "concept",
-    "title": "R(3,k) Bounds",
-    "content": "The best known bounds for R(3,k) are c₁·k²/log k ≤ R(3,k) ≤ c₂·k²/log k. This tight asymptotic result shows R(3,k) ~ k²/log k, a major achievement in Ramsey theory.",
-    "significance": "supporting"
-  },
-  {
     "id": "ann-166-8",
     "proofId": "erdos-166",
     "range": {
       "startLine": 166,
       "endLine": 175
     },
-    "type": "theorem",
+    "type": "axiom",
     "title": "Spencer's Lower Bound (1977)",
     "content": "Spencer proved R(4,k) ≥ c·(k log k)^{5/2} using probabilistic methods. This was the best lower bound for over 40 years, but fell far short of the expected k³/(log k)^O(1).",
     "significance": "key"
   },
   {
-    "id": "ann-166-9",
-    "proofId": "erdos-166",
-    "range": {
-      "startLine": 184,
-      "endLine": 189
-    },
-    "type": "concept",
-    "title": "Probabilistic Method",
-    "content": "Spencer's proof uses the probabilistic method: a randomly constructed graph avoids K_4 with high probability while maintaining a small independence number. This technique revolutionized combinatorics but has limits.",
-    "significance": "supporting"
-  },
-  {
     "id": "ann-166-10",
     "proofId": "erdos-166",
     "range": {
-      "startLine": 195,
-      "endLine": 204
+      "startLine": 182,
+      "endLine": 191
     },
-    "type": "theorem",
+    "type": "axiom",
     "title": "AKS Upper Bound (1980)",
-    "content": "Ajtai-Komlós-Szemerédi proved R(4,k) ≤ C·k³/(log k)² using a clever greedy coloring algorithm. This established that R(4,k) grows like k³ up to polylogarithmic factors.",
+    "content": "Ajtai-Komlós-Szemerédi proved R(4,k) ≤ C·k³/(log k)² using a clever greedy coloring algorithm. This established that R(4,k) grows like k³ up to polylogarithmic factors, creating the benchmark upper bound.",
     "significance": "critical"
-  },
-  {
-    "id": "ann-166-11",
-    "proofId": "erdos-166",
-    "range": {
-      "startLine": 213,
-      "endLine": 218
-    },
-    "type": "concept",
-    "title": "The 43-Year Gap",
-    "content": "From 1980 to 2023, the gap between Spencer's lower bound (k log k)^{5/2} and the AKS upper bound k³/(log k)² remained open. Erdős offered $250 for resolving this fundamental question in Ramsey theory.",
-    "significance": "key"
   },
   {
     "id": "ann-166-12",
     "proofId": "erdos-166",
     "range": {
-      "startLine": 224,
-      "endLine": 233
+      "startLine": 198,
+      "endLine": 207
     },
-    "type": "theorem",
+    "type": "axiom",
     "title": "Mattheus-Verstraete (2023)",
-    "content": "R(4,k) ≥ c·k³/(log k)⁴ for some constant c > 0. This SOLVED Erdős Problem #166, earning the $250 prize. The proof uses algebraic graph constructions from finite geometry rather than probabilistic methods.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-166-13",
-    "proofId": "erdos-166",
-    "range": {
-      "startLine": 235,
-      "endLine": 255
-    },
-    "type": "concept",
-    "title": "Algebraic Constructions",
-    "content": "Mattheus and Verstraete used incidence graphs of projective planes over finite fields to construct 'pseudo-random' graphs with small clique number but large independence number. This algebraic approach succeeded where probabilistic methods failed.",
+    "content": "R(4,k) ≥ c·k³/(log k)⁴ for some constant c > 0. This SOLVED Erdős Problem #166, earning the $250 prize. The proof uses algebraic graph constructions from finite geometry (incidence graphs of projective planes) rather than probabilistic methods.",
     "significance": "critical"
   },
   {
     "id": "ann-166-14",
     "proofId": "erdos-166",
     "range": {
-      "startLine": 261,
-      "endLine": 271
+      "startLine": 222,
+      "endLine": 232
     },
     "type": "definition",
     "title": "Erdős Problem #166 Statement",
-    "content": "There exist constants c > 0 and A > 0 such that R(4,k) ≥ c·k³/(log k)^A for all sufficiently large k. This asks for the lower bound to match the upper bound up to polylogarithmic factors.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-166-15",
-    "proofId": "erdos-166",
-    "range": {
-      "startLine": 273,
-      "endLine": 279
-    },
-    "type": "theorem",
-    "title": "Problem SOLVED",
-    "content": "erdos_166_solved: The Mattheus-Verstraete theorem with A = 4 proves Erdős Problem #166. The lower bound now matches the upper bound up to the exponent of log k.",
+    "content": "There exist constants c > 0 and A > 0 such that R(4,k) ≥ c·k³/(log k)^A for all sufficiently large k. The Mattheus-Verstraete theorem with A = 4 proves this statement.",
     "significance": "critical"
   },
   {
     "id": "ann-166-16",
     "proofId": "erdos-166",
     "range": {
-      "startLine": 287,
-      "endLine": 293
+      "startLine": 240,
+      "endLine": 246
     },
     "type": "theorem",
     "title": "Current Best Bounds",
@@ -192,27 +120,15 @@
     "significance": "key"
   },
   {
-    "id": "ann-166-17",
-    "proofId": "erdos-166",
-    "range": {
-      "startLine": 363,
-      "endLine": 375
-    },
-    "type": "concept",
-    "title": "The $250 Prize",
-    "content": "Erdős offered monetary prizes for solutions to problems he considered important. The $250 prize for Problem #166 was collected by Mattheus and Verstraete after their 2023 breakthrough. Ron Graham's estate manages the prize fund.",
-    "significance": "supporting"
-  },
-  {
     "id": "ann-166-18",
     "proofId": "erdos-166",
     "range": {
-      "startLine": 406,
-      "endLine": 434
+      "startLine": 283,
+      "endLine": 302
     },
     "type": "theorem",
-    "title": "Final Status",
-    "content": "erdos_166_status: Erdős Problem #166 is SOLVED. R(4,k) >> k³/(log k)⁴, resolving a 43-year-old question. The algebraic construction breakthrough opens new directions in extremal combinatorics and Ramsey theory.",
+    "title": "Summary and Logarithmic Gap",
+    "content": "erdos_166_status confirms the problem is solved. logarithmic_gap formalizes that the exponent of log k lies between 2 and 4: both lower and upper bounds are Θ(k³/(log k)^α), resolving Erdős's question about the cubic growth of R(4,k).",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-166/meta.json
+++ b/src/data/proofs/erdos-166/meta.json
@@ -16,7 +16,7 @@
       "graph-theory",
       "probabilistic-method"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 166,
     "erdosUrl": "https://erdosproblems.com/166",
@@ -82,63 +82,35 @@
       "id": "section-4",
       "title": "Historical Lower Bounds",
       "startLine": 162,
-      "endLine": 190,
+      "endLine": 176,
       "summary": "Spencer's 1977 lower bound R(4,k) >> (k log k)^{5/2} using probabilistic methods."
     },
     {
       "id": "section-5",
       "title": "Upper Bound (AKS)",
-      "startLine": 191,
-      "endLine": 219,
+      "startLine": 178,
+      "endLine": 192,
       "summary": "Ajtai-Komlós-Szemerédi 1980 upper bound R(4,k) << k³/(log k)² using greedy coloring."
     },
     {
       "id": "section-6",
       "title": "The Solution (2023)",
-      "startLine": 220,
-      "endLine": 256,
-      "summary": "Mattheus-Verstraete breakthrough: R(4,k) >> k³/(log k)⁴ using finite geometry constructions."
+      "startLine": 194,
+      "endLine": 208,
+      "summary": "Mattheus-Verstraete breakthrough: R(4,k) >> k³/(log k)⁴ using finite geometry."
     },
     {
       "id": "section-7",
       "title": "Erdős's Conjecture (SOLVED)",
-      "startLine": 257,
-      "endLine": 294,
-      "summary": "Formalizes Erdős166Statement, proves erdos_166_solved, establishes current_bounds."
+      "startLine": 210,
+      "endLine": 247,
+      "summary": "Erdős166Statement, erdos_166_solved, current_bounds theorems."
     },
     {
       "id": "section-8",
-      "title": "Related Problems and Generalizations",
-      "startLine": 295,
-      "endLine": 326,
-      "summary": "General R(s,k), Ramsey multiplicity, hypergraph and multicolor Ramsey numbers."
-    },
-    {
-      "id": "section-9",
-      "title": "Techniques in Ramsey Theory",
-      "startLine": 327,
-      "endLine": 358,
-      "summary": "Probabilistic method, algebraic constructions, stepping-up lemma, Turán connection."
-    },
-    {
-      "id": "section-10",
-      "title": "The Prize Story",
-      "startLine": 359,
-      "endLine": 376,
-      "summary": "The $250 Erdős prize and how it was collected by Mattheus-Verstraete."
-    },
-    {
-      "id": "section-11",
-      "title": "Open Questions",
-      "startLine": 377,
-      "endLine": 401,
-      "summary": "Exact exponent, general s ≥ 5, explicit constructions."
-    },
-    {
-      "id": "section-12",
       "title": "Summary",
-      "startLine": 402,
-      "endLine": 461,
+      "startLine": 248,
+      "endLine": 302,
       "summary": "Complete summary with erdos_166_status and logarithmic_gap theorems."
     }
   ],


### PR DESCRIPTION
## Summary
- Removed 16+ trivial `axiom foo : True` placeholders (spencer_interpretation, probabilistic_method, aks_algorithm, the_gap, key_innovation, pseudorandom_constructions, finite_geometry_connection, general_ramsey_problem, ramsey_multiplicity, hypergraph_ramsey, multicolor_ramsey, probabilistic_method_general, algebraic_constructions, stepping_up_lemma, turan_connection, erdos_prize, prize_collection, exact_exponent, general_s, explicit_constructions)
- Removed `erdos_166_complete : True := trivial`
- Fixed `/-` section headers to `/-!` doc comments
- Consolidated empty sections
- Updated meta.json (badge: axiom) and annotations.json

## Checklist
- [x] No sorry proofs
- [x] No True := trivial
- [x] No trivial True axioms
- [x] pnpm build succeeds
- [x] 11 annotations with correct line numbers

🤖 Generated by enhancer-1