### PR TITLE
enhance(erdos-872): fix section doc comments

### DIFF
--- a/proofs/Proofs/Erdos872Problem.lean
+++ b/proofs/Proofs/Erdos872Problem.lean
@@ -43,7 +43,7 @@ open Nat Finset Set
 
 namespace Erdos872
 
-/-
+/-!
 ## Part I: Antichain Definition
 
 An antichain under divisibility is a set where no element divides another.
@@ -76,7 +76,7 @@ theorem antichain_iff_primitive (A : Set ℕ) :
     by_contra hab
     exact h a b ha hb hab hdiv
 
-/-
+/-!
 ## Part II: The Game Board
 -/
 
@@ -108,7 +108,7 @@ Axiomatized: the biconditional requires careful set manipulation.
 axiom legal_move_iff (A : Set ℕ) (k : ℕ) (hA : IsDivisibilityAntichain A) :
     IsLegalMove A k ↔ k ∉ A ∧ (∀ a ∈ A, ¬(k ∣ a)) ∧ (∀ a ∈ A, ¬(a ∣ k))
 
-/-
+/-!
 ## Part III: Game State and Termination
 -/
 
@@ -129,7 +129,7 @@ axiom game_terminates (n : ℕ) (hn : n ≥ 2) :
     A.Finite →
     ∃ B : Set ℕ, A ⊆ B ∧ IsMaximalAntichain B (gameBoard n)
 
-/-
+/-!
 ## Part IV: Bounds on Game Length
 -/
 
@@ -152,7 +152,7 @@ axiom prime_antichain_bound (n : ℕ) (hn : n ≥ 10) :
     ∃ P : Set ℕ, P ⊆ gameBoard n ∧ IsDivisibilityAntichain P ∧
     (∀ p ∈ P, p.Prime) ∧ P.ncard ≥ n / (4 * Nat.log n + 1)
 
-/-
+/-!
 ## Part V: Erdős's Questions
 -/
 
@@ -188,7 +188,7 @@ axiom erdos_872_open_status :
       -- This axiom asserts we cannot currently determine the game's behavior
       gameLastsLinear gameLength ∧ gameLastsNearOptimal gameLength)
 
-/-
+/-!
 ## Part VI: Related Results
 -/
 
@@ -208,7 +208,7 @@ axiom biro_horn_wildstrom_bound (n : ℕ) (hn : n ≥ 10) :
     ∃ moves : ℕ, ∀ triangle_free_game_length : ℕ,
       (triangle_free_game_length : ℚ) ≤ (27 : ℚ) / 121 * n ^ 2
 
-/-
+/-!
 ## Part VII: Special Cases and Examples
 -/
 
@@ -252,7 +252,7 @@ def firstPlayerAdvantage : Prop :=
     and {2,3,5} is maximal with 3 elements. -/
 axiom first_player_advantage_exists : firstPlayerAdvantage
 
-/-
+/-!
 ## Part VIII: Game-Theoretic Formulation
 -/
 
@@ -275,7 +275,7 @@ axiom erdos_872_conjecture :
     (∃ c : ℚ, c > 0 ∧ ∀ n ≥ 10, gameValue n ≥ (c * n).floor) ∨
     (∀ ε : ℚ, ε > 0 → ∃ N : ℕ, ∀ n ≥ N, gameValue n ≤ (ε * n).ceil)
 
-/-
+/-!
 ## Part IX: Summary
 -/
 


### PR DESCRIPTION
## Summary
- Convert `/-` section headers to `/-!` doc comments in Erdős Problem #872 (Antichain Saturation Game)
- No other quality issues found (no sorry, no True := trivial, meta.json already correct)

## Test plan
- [x] `pnpm build` passes in worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)