### PR TITLE
enhance(erdos-251): remove trivial True theorem, fix line numbers

### DIFF
--- a/proofs/Proofs/Erdos251Problem.lean
+++ b/proofs/Proofs/Erdos251Problem.lean
@@ -158,13 +158,6 @@ The key challenges are:
    rational approximations, which depends on the arithmetic of primes.
 -/
 
-/-- Comparison with known irrationals:
-- e = Σ 1/n! is irrational (Euler)
-- π is irrational (Lambert/Hermite)
-- e + π is unknown (!)
-- Σ pₙ/2ⁿ is unknown (this problem) -/
-theorem comparison_context : True := trivial
-
 /-!
 ## Generalized Conjecture
 

--- a/src/data/proofs/erdos-251/annotations.json
+++ b/src/data/proofs/erdos-251/annotations.json
@@ -130,7 +130,7 @@
     "proofId": "erdos-251",
     "range": {
       "startLine": 148,
-      "endLine": 166
+      "endLine": 159
     },
     "type": "concept",
     "title": "Why This Is Hard",
@@ -143,8 +143,8 @@
     "id": "ann-e251-oeis",
     "proofId": "erdos-251",
     "range": {
-      "startLine": 191,
-      "endLine": 195
+      "startLine": 184,
+      "endLine": 188
     },
     "type": "axiom",
     "title": "OEIS Bounds",
@@ -157,8 +157,8 @@
     "id": "ann-e251-explicit",
     "proofId": "erdos-251",
     "range": {
-      "startLine": 203,
-      "endLine": 216
+      "startLine": 196,
+      "endLine": 209
     },
     "type": "theorem",
     "title": "Explicit Partial Sums",

--- a/src/data/proofs/erdos-251/meta.json
+++ b/src/data/proofs/erdos-251/meta.json
@@ -107,28 +107,28 @@
       "id": "difficulty",
       "title": "Why This Is Hard",
       "startLine": 148,
-      "endLine": 166,
+      "endLine": 159,
       "summary": "Discussion of the challenges in proving irrationality of explicit series."
     },
     {
       "id": "general-conjecture",
       "title": "Generalized Conjecture",
-      "startLine": 168,
-      "endLine": 182,
+      "startLine": 161,
+      "endLine": 175,
       "summary": "Erdős's general conjecture about products of slowly-growing sequences."
     },
     {
       "id": "oeis",
       "title": "The OEIS Constant",
-      "startLine": 184,
-      "endLine": 195,
+      "startLine": 177,
+      "endLine": 188,
       "summary": "Bounds on erdosSum: between 3 and 4, approximately 3.5968."
     },
     {
       "id": "explicit-sums",
       "title": "Explicit Partial Sums",
-      "startLine": 197,
-      "endLine": 218,
+      "startLine": 190,
+      "endLine": 211,
       "summary": "Verified theorems for first 1, 2, 3, 4, 5 terms."
     }
   ],


### PR DESCRIPTION
## Summary
- Removed `comparison_context : True := trivial` theorem from Lean file
- Updated section line numbers in meta.json to match corrected file
- Updated annotation ranges in annotations.json (oeis, explicit-sums)

## Test plan
- [x] `pnpm build` succeeds
- [x] No `sorry` or `True := trivial` in Lean file
- [x] Section and annotation line numbers match actual Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)