### PR TITLE
enhance(erdos-774): remove True/String placeholders, add summary theorem

### DIFF
--- a/proofs/Proofs/Erdos774Problem.lean
+++ b/proofs/Proofs/Erdos774Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
   Erdős Problem #774: Dissociated and Proportionately Dissociated Sets
 
   Source: https://erdosproblems.com/774
@@ -38,7 +38,7 @@ open Finset Set
 
 namespace Erdos774
 
-/-
+/-!
 ## Part I: Dissociated Sets
 -/
 
@@ -68,7 +68,7 @@ theorem dissociated_iff_unique_sums (A : Finset ℕ) :
   · intro h X Y hX hY hne hsum
     exact hne (h X Y hX hY hsum)
 
-/-
+/-!
 ## Part II: Examples of Dissociated Sets
 -/
 
@@ -94,7 +94,7 @@ def IsLacunary (a : ℕ → ℕ) : Prop :=
 axiom lacunary_is_dissociated (a : ℕ → ℕ) (h : IsLacunary a) (n : ℕ) :
     IsDissociated ((Finset.range n).image a)
 
-/-
+/-!
 ## Part III: Proportionately Dissociated Sets
 -/
 
@@ -121,7 +121,7 @@ theorem dissociated_is_proportionately (A : Set ℕ) :
         exact h X Y (Subset.trans hX hB) (Subset.trans hY hB) hne
       · simp
 
-/-
+/-!
 ## Part IV: Sidon Sets (Harmonic Analysis)
 -/
 
@@ -139,7 +139,7 @@ def IsSidonHarmonic (A : Set ℕ) : Prop :=
 axiom pisier_theorem (A : Set ℕ) :
     IsProportionatelyDissociated A ↔ IsSidonHarmonic A
 
-/-
+/-!
 ## Part V: Sidon Sets (Additive Combinatorics)
 -/
 
@@ -157,7 +157,7 @@ axiom sidon_implies_dissociated (A : Finset ℕ) :
 axiom dissociated_not_implies_sidon :
     ∃ A : Finset ℕ, IsDissociated A ∧ ¬IsSidonAdditive A
 
-/-
+/-!
 ## Part VI: Union Decomposition
 -/
 
@@ -170,7 +170,7 @@ def IsFiniteUnionDissociated (A : Set ℕ) : Prop :=
 axiom finite_union_is_proportionately (A : Set ℕ) :
     IsFiniteUnionDissociated A → IsProportionatelyDissociated A
 
-/-
+/-!
 ## Part VII: The Main Conjecture
 -/
 
@@ -183,10 +183,7 @@ def ErdosConjecture774 : Prop :=
 /-- Alon-Erdős (1985) conjectured the answer is NO. -/
 axiom alon_erdos_conjecture : ¬ErdosConjecture774
 
-/-- The conjecture status: OPEN. -/
-axiom conjecture_open : True -- Placeholder for open status
-
-/-
+/-!
 ## Part VIII: The Sidon Analogue
 -/
 
@@ -219,15 +216,9 @@ axiom nrs_construction :
     ∃ A : Set ℕ, A.Infinite ∧ IsProportionatelySidon A ∧
       ¬IsFiniteUnionSidon A
 
-/-
+/-!
 ## Part IX: Connections and Implications
 -/
-
-/-- The NRS result suggests the dissociated conjecture is also false. -/
-theorem nrs_suggests_no :
-    ¬SidonAnalogue → True := by  -- Heuristic connection
-  intro _
-  trivial
 
 /-- Dissociated implies Sidon (additive), so:
     proportionately Sidon ⟹ proportionately dissociated. -/
@@ -238,17 +229,8 @@ axiom prop_sidon_implies_prop_dissociated (A : Set ℕ) :
 axiom union_sidon_implies_union_dissociated (A : Set ℕ) :
     IsFiniteUnionSidon A → IsFiniteUnionDissociated A
 
-/-
-## Part X: Graph Theory Connection
--/
-
-/-- Alon-Erdős used graph theory to study these problems.
-    Dissociated sets correspond to independent sets in
-    certain hypergraphs. -/
-axiom graph_theory_connection : True
-
-/-
-## Part XI: Bounds on Dissociated Subsets
+/-!
+## Part X: Bounds on Dissociated Subsets
 -/
 
 /-- Maximum size of a dissociated subset of {1,...,n}. -/
@@ -262,34 +244,17 @@ axiom max_dissociated_log_bound :
       c * Real.log n ≤ maxDissociatedSize n ∧
       maxDissociatedSize n ≤ C * Real.log n
 
-/-
-## Part XII: Summary
+/-!
+## Part XI: Summary
 -/
 
 /-- **Summary of Erdős Problem #774:**
-
-PROBLEM: Is every proportionately dissociated set a finite
-         union of dissociated sets?
-
-STATUS: OPEN (conjectured NO)
-
-KEY RESULTS:
-1. Pisier (1983): Proportionately dissociated ⟺ Sidon (harmonic)
-2. Alon-Erdős (1985): Introduced the problem, conjectured NO
-3. Nešetřil-Rödl-Sales (2024): The Sidon analogue is FALSE
-
-CONNECTIONS:
-- Graph theory (hypergraph independent sets)
-- Harmonic analysis (Sidon sets)
-- Additive combinatorics
-- Probabilistic method (NRS construction)
-
-The NRS result provides strong evidence against the conjecture.
--/
-theorem erdos_774_open : True := trivial
-
-/-- The problem remains open. -/
-def erdos_774_status : String :=
-  "OPEN - Conjectured NO (Alon-Erdős 1985), supported by NRS 2024"
+    Combines key established results:
+    1. Finite union of dissociated ⟹ proportionately dissociated (converse direction)
+    2. The Sidon analogue is FALSE (NRS 2024), providing evidence for #774 -/
+theorem erdos_774_summary :
+    (∀ A : Set ℕ, IsFiniteUnionDissociated A → IsProportionatelyDissociated A) ∧
+    ¬SidonAnalogue :=
+  ⟨finite_union_is_proportionately, nesetril_rodl_sales_theorem⟩
 
 end Erdos774

--- a/src/data/proofs/erdos-774/annotations.json
+++ b/src/data/proofs/erdos-774/annotations.json
@@ -200,7 +200,7 @@
   {
     "id": "ann-774-implications",
     "proofId": "erdos-774",
-    "range": { "startLine": 233, "endLine": 239 },
+    "range": { "startLine": 223, "endLine": 230 },
     "type": "theorem",
     "title": "Implications Between Notions",
     "content": "**Key Implications:**\n\n1. Proportionately Sidon ⟹ Proportionately Dissociated\n   (Sidon subsets are dissociated subsets)\n\n2. Finite union of Sidon ⟹ Finite union of Dissociated\n   (Each Sidon piece is dissociated)\n\n```lean\naxiom prop_sidon_implies_prop_dissociated (A : Set ℕ) :\n    IsProportionatelySidon A → IsProportionatelyDissociated A\n\naxiom union_sidon_implies_union_dissociated (A : Set ℕ) :\n    IsFiniteUnionSidon A → IsFiniteUnionDissociated A\n```",
@@ -211,7 +211,7 @@
   {
     "id": "ann-774-maxsize",
     "proofId": "erdos-774",
-    "range": { "startLine": 254, "endLine": 263 },
+    "range": { "startLine": 236, "endLine": 245 },
     "type": "theorem",
     "title": "max_dissociated_log_bound",
     "content": "**Maximum Dissociated Subset Size:**\n\nThe maximum size of a dissociated subset of {1, 2, ..., n} is Θ(log n).\n\n```lean\naxiom max_dissociated_log_bound :\n    ∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∀ n : ℕ, n ≥ 2 →\n      c * Real.log n ≤ maxDissociatedSize n ∧\n      maxDissociatedSize n ≤ C * Real.log n\n```\n\n**Upper bound:** Subset sums range in [0, n(n+1)/2], so at most O(n²) possible sums. Dissociated sets have 2^|A| distinct sums, giving |A| ≤ O(log n²) = O(log n).\n\n**Lower bound:** Powers of 2 up to n give log₂(n) elements.",
@@ -222,12 +222,12 @@
   {
     "id": "ann-774-summary",
     "proofId": "erdos-774",
-    "range": { "startLine": 269, "endLine": 293 },
-    "type": "concept",
-    "title": "Summary and Status",
-    "content": "**Summary of Erdős Problem #774:**\n\n**Problem:** Is every proportionately dissociated set a finite union of dissociated sets?\n\n**Status:** OPEN (conjectured NO)\n\n**Key Results:**\n1. Pisier (1983): Proportionately dissociated ⟺ Sidon (harmonic)\n2. Alon-Erdős (1985): Introduced the problem, conjectured NO\n3. Nešetřil-Rödl-Sales (2024): The Sidon analogue is FALSE\n\n**Connections:**\n- Harmonic analysis (Sidon sets)\n- Additive combinatorics\n- Graph theory (hypergraph independent sets)\n- Probabilistic method\n\nThe NRS result provides strong evidence that #774 also has a negative answer.",
-    "mathContext": "This problem sits at the intersection of multiple mathematical areas, making it a rich example of how different fields inform each other.",
+    "range": { "startLine": 247, "endLine": 260 },
+    "type": "theorem",
+    "title": "Summary Theorem",
+    "content": "**erdos_774_summary** (PROVED): Combines two key established results:\n1. Finite union of dissociated ⟹ proportionately dissociated (the easy direction)\n2. The Sidon analogue is FALSE (NRS 2024)\n\nProof: `⟨finite_union_is_proportionately, nesetril_rodl_sales_theorem⟩`\n\nThis captures the known mathematical landscape: the converse direction of Problem #774 holds trivially, and the closely related Sidon analogue has been resolved negatively, providing strong evidence that #774 also has a negative answer.",
+    "mathContext": "The summary theorem packages the two main established results without claiming resolution of the open problem. The NRS result on Sidon sets provides the strongest available evidence.",
     "significance": "critical",
-    "relatedConcepts": ["Open problems", "Interdisciplinary mathematics"]
+    "relatedConcepts": ["Summary theorems", "Known results", "Open problem formalization"]
   }
 ]

--- a/src/data/proofs/erdos-774/meta.json
+++ b/src/data/proofs/erdos-774/meta.json
@@ -116,35 +116,35 @@
       "title": "The Main Conjecture",
       "summary": "ErdosConjecture774 formal statement, Alon-Erdős conjecture",
       "startLine": 173,
-      "endLine": 187
+      "endLine": 184
     },
     {
       "id": "sidon-analogue",
       "title": "The Sidon Analogue",
-      "summary": "IsProportionatelySidon, SidonAnalogue, Nešetřil-Rödl-Sales theorem",
-      "startLine": 189,
-      "endLine": 220
+      "summary": "IsProportionatelySidon, SidonAnalogue, Nešetřil-Rödl-Sales theorem, NRS construction",
+      "startLine": 186,
+      "endLine": 217
     },
     {
       "id": "connections",
       "title": "Connections and Implications",
-      "summary": "NRS suggests NO, implications between Sidon and dissociated",
-      "startLine": 222,
-      "endLine": 249
+      "summary": "Implications between Sidon and dissociated notions",
+      "startLine": 219,
+      "endLine": 230
     },
     {
       "id": "bounds",
       "title": "Bounds on Dissociated Subsets",
       "summary": "maxDissociatedSize, Θ(log n) bound",
-      "startLine": 251,
-      "endLine": 263
+      "startLine": 232,
+      "endLine": 245
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Problem statement, status, key results, erdos_774_open",
-      "startLine": 265,
-      "endLine": 295
+      "summary": "erdos_774_summary theorem combining finite_union_is_proportionately and NRS",
+      "startLine": 247,
+      "endLine": 260
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Removed 3 trivial `True` axioms/theorems (`conjecture_open`, `graph_theory_connection`, `nrs_suggests_no`)
- Removed `erdos_774_open : True := trivial` placeholder
- Removed `erdos_774_status : String` definition
- Added meaningful `erdos_774_summary` theorem combining `finite_union_is_proportionately` and `nesetril_rodl_sales_theorem`
- Fixed all 12 section headers from `/-` to `/-!`
- Updated meta.json sections and annotations.json line ranges

## Test plan
- [x] `pnpm build` succeeds
- [x] No sorry, no True := trivial, no String defs remain
- [x] Summary theorem is proved (not axiomatized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)