### PR TITLE
enhance(erdos-1067): remove True axioms/defs, fix quality

### DIFF
--- a/proofs/Proofs/Erdos1067Problem.lean
+++ b/proofs/Proofs/Erdos1067Problem.lean
@@ -185,65 +185,30 @@ The graph has exactly ℵ₁ many vertices.
 def hasAleph1Vertices (V : Type*) : Prop :=
   Cardinal.mk V = Cardinal.aleph 1
 
-/--
-**Komjáth's Independence Result:**
-For graphs with ℵ₁ vertices, the answer is independent of ZFC.
--/
-axiom komjath_independence_aleph1_vertices :
-    -- The statement "all such graphs have the property" is independent of ZFC
-    -- meaning neither it nor its negation can be proved from ZFC alone
-    True  -- We state the independence informally
+/-- **Komjáth's Independence Result:**
+For graphs with exactly ℵ₁ vertices, the Erdős-Hajnal question is
+independent of ZFC: counterexamples exist in some models but not others.
+We axiomatize one direction (consistency of counterexample). -/
+axiom komjath_aleph1_vertex_counterexample_consistent :
+    -- In some models of ZFC with ℵ₁-vertex graphs:
+    ∃ V : Type*, ∃ G : SimpleGraph V,
+      hasAleph1Vertices V ∧ hasAleph1ChromaticNumber G ∧
+      ¬∃ H : SimpleGraph V, IsSubgraph H G ∧
+        InfinitelyConnected H ∧ hasAleph1ChromaticNumber H
 
 /-!
 ## Part VII: Key Observations
 -/
 
-/--
-**Why counterexamples exist:**
-The key insight is that high chromatic number doesn't force high connectivity.
-
-One can construct graphs where:
-1. χ(G) = ℵ₁ (uncountable chromatic number)
-2. Any infinitely connected subgraph has χ ≤ ℵ₀ (countable chromatic number)
--/
-theorem counterexample_insight :
-    -- Chromatic number and connectivity are somewhat independent
-    True := trivial
-
-/--
-**Soukup's construction idea:**
-Build a "ladder" structure where:
-- The overall graph needs ℵ₁ colors
-- But any infinitely connected piece can be colored with fewer colors
--/
+/-- **Soukup's construction principle:**
+One can build a graph from "ladder" structures of trees where
+the overall graph needs ℵ₁ colors but any infinitely connected
+piece can be colored with fewer colors. -/
 axiom soukup_construction_principle :
     ∃ V : Type*, ∃ G : SimpleGraph V,
-      -- G is built from "trees" arranged so connectivity forces separation
-      hasAleph1ChromaticNumber G
-
-/--
-**Bowler-Pitz simplification:**
-Their example is more elementary and avoids sophisticated set-theoretic machinery.
--/
-axiom bowler_pitz_elementary :
-    -- The construction is "elementary" - uses basic graph theory only
-    True
-
-/-!
-## Part VIII: Related Results
--/
-
-/--
-**Connection to Problem #1068:**
-Related question about similar connectivity vs chromatic number issues.
--/
-def related_1068 : Prop := True
-
-/--
-**Erdős-Hajnal Original (1966):**
-The question originated in their paper on chromatic numbers and set systems.
--/
-def original_erdos_hajnal_1966 : Prop := True
+      hasAleph1ChromaticNumber G ∧
+      ∀ H : SimpleGraph V, IsSubgraph H G →
+        InfinitelyConnected H → ¬hasAleph1ChromaticNumber H
 
 /-!
 ## Part IX: Summary

--- a/src/data/proofs/erdos-1067/annotations.json
+++ b/src/data/proofs/erdos-1067/annotations.json
@@ -1,177 +1,50 @@
 [
   {
-    "id": "ann-e1067-header",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 1, "endLine": 26 },
-    "type": "concept",
-    "title": "Problem Overview",
-    "content": "**Erdos Problem #1067: Infinitely Connected Subgraphs**\n\n**Question:** Does every graph with chromatic number aleph_1 contain an infinitely connected subgraph with chromatic number aleph_1?\n\n**Answer: NO** (Counterexamples exist)\n\n**Key results:**\n- Komjath (2013): Consistency of counterexample\n- Soukup (2015): Counterexample in ZFC\n- Bowler-Pitz (2024): Simpler elementary counterexample\n- Thomassen (2017): Edge-connectivity variant also false",
-    "mathContext": "A graph is infinitely connected if any two vertices are connected by infinitely many pairwise disjoint paths.",
-    "significance": "critical",
-    "relatedConcepts": ["Chromatic number", "Infinite graphs", "Connectivity"]
-  },
-  {
     "id": "ann-e1067-chromatic",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 40, "endLine": 46 },
+    "range": { "startLine": 40, "endLine": 53 },
     "type": "definition",
-    "title": "Chromatic Number",
-    "content": "**chromaticNumber(G):**\n\nThe minimum number of colors needed to properly color a graph.\n\nFor infinite graphs, this is a cardinal number.\n\n**Proper coloring:** Adjacent vertices have different colors.",
-    "significance": "critical",
-    "relatedConcepts": ["Graph coloring", "Cardinals"]
+    "title": "Chromatic Number for Infinite Graphs",
+    "content": "The chromatic number χ(G) is defined as the infimum of cardinals κ for which G is κ-colorable. For finite graphs this is the familiar minimum number of colors for a proper coloring. For infinite graphs it becomes a cardinal: χ(G) = ℵ₁ means G cannot be properly colored with countably many colors but can be colored with ℵ₁ colors. The predicate hasAleph1ChromaticNumber captures graphs at this specific level of 'coloring complexity'.",
+    "significance": "essential"
   },
   {
-    "id": "ann-e1067-aleph1",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 48, "endLine": 53 },
+    "id": "ann-e1067-connectivity",
+    "range": { "startLine": 55, "endLine": 98 },
     "type": "definition",
-    "title": "Chromatic Number aleph_1",
-    "content": "**hasAleph1ChromaticNumber(G):**\n\nThe graph G has chromatic number aleph_1 (the first uncountable cardinal).\n\nThis means:\n- G cannot be colored with countably many colors\n- G can be colored with aleph_1 many colors",
-    "mathContext": "aleph_1 is the cardinality of the set of countable ordinals.",
-    "significance": "critical",
-    "relatedConcepts": ["Aleph numbers", "Uncountable sets"]
+    "title": "Infinite Connectivity via Disjoint Paths",
+    "content": "A graph is infinitely connected if any two distinct vertices are joined by infinitely many pairwise internally-disjoint paths. This is formalized through PathInGraph (a sequence of adjacent vertices), DisjointPaths (no shared internal vertices), and InfinitelyManyDisjointPaths (an infinite set of pairwise disjoint paths with given endpoints). By Menger's theorem, this is equivalent to having infinite vertex connectivity — no finite vertex cut separates any two vertices.",
+    "significance": "essential"
   },
   {
-    "id": "ann-e1067-path",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 59, "endLine": 66 },
+    "id": "ann-e1067-question",
+    "range": { "startLine": 112, "endLine": 130 },
     "type": "definition",
-    "title": "Path in Graph",
-    "content": "**PathInGraph:**\n\nA finite sequence of vertices where consecutive vertices are adjacent.\n\n```lean\nstructure PathInGraph (G : SimpleGraph V) where\n  vertices : List V\n  isPath : forall i, G.Adj vertices[i] vertices[i+1]\n```",
-    "significance": "key",
-    "relatedConcepts": ["Graph walks", "Connectivity"]
+    "title": "The Erdős-Hajnal Question (1966)",
+    "content": "ErdosHajnalQuestion formalizes the original 1966 conjecture: if χ(G) = ℵ₁, must G contain an infinitely connected subgraph H with χ(H) = ℵ₁? The intuition was that high chromatic number might force rich connectivity structure. The answer turned out to be NO — one can build graphs where the chromatic 'bottleneck' lives in thin regions that cannot support infinite connectivity.",
+    "significance": "essential"
   },
   {
-    "id": "ann-e1067-disjoint",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 68, "endLine": 82 },
-    "type": "definition",
-    "title": "Disjoint Paths",
-    "content": "**DisjointPaths(p1, p2):**\n\nTwo paths are disjoint if they share no internal vertices.\n\n**PairwiseDisjoint(paths):**\nA collection of paths is pairwise disjoint.\n\nEndpoints may be shared (for paths between same vertices), but no internal vertices overlap.",
-    "significance": "key",
-    "relatedConcepts": ["Menger's theorem", "Path systems"]
-  },
-  {
-    "id": "ann-e1067-infinitely-many",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 84, "endLine": 91 },
-    "type": "definition",
-    "title": "Infinitely Many Disjoint Paths",
-    "content": "**InfinitelyManyDisjointPaths(G, u, v):**\n\nThere exist infinitely many pairwise disjoint paths from u to v in G.\n\nThis is a very strong connectivity requirement - not just one path, but infinitely many that don't share internal vertices.",
-    "significance": "key",
-    "relatedConcepts": ["Path multiplicity", "Strong connectivity"]
-  },
-  {
-    "id": "ann-e1067-infinitely-connected",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 93, "endLine": 98 },
-    "type": "definition",
-    "title": "Infinitely Connected",
-    "content": "**InfinitelyConnected(G):**\n\nA graph is infinitely connected if ANY two vertices are connected by infinitely many pairwise disjoint paths.\n\n```lean\ndef InfinitelyConnected (G : SimpleGraph V) : Prop :=\n  forall u v, u != v -> InfinitelyManyDisjointPaths G u v\n```\n\nThis is the key property in the Erdos-Hajnal question.",
-    "mathContext": "By Menger's theorem, this is related to having infinite vertex connectivity.",
-    "significance": "critical",
-    "relatedConcepts": ["Menger's theorem", "Vertex connectivity"]
-  },
-  {
-    "id": "ann-e1067-edge-connected",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 104, "endLine": 110 },
-    "type": "definition",
-    "title": "Infinitely Edge-Connected",
-    "content": "**InfinitelyEdgeConnected(G):**\n\nTo disconnect the graph requires deleting infinitely many edges.\n\nThis is a weaker notion than infinitely connected (vertex version).\n\nThomassen (2017) constructed a counterexample for this variant too.",
-    "significance": "key",
-    "relatedConcepts": ["Edge connectivity", "Thomassen's result"]
-  },
-  {
-    "id": "ann-e1067-erdos-hajnal",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 123, "endLine": 130 },
-    "type": "definition",
-    "title": "The Erdos-Hajnal Question",
-    "content": "**ErdosHajnalQuestion(G):**\n\nDoes G with chi(G) = aleph_1 contain an infinitely connected subgraph H with chi(H) = aleph_1?\n\nThis formalizes the original 1966 question.\n\n**The answer is NO** - counterexamples exist.",
-    "significance": "critical",
-    "relatedConcepts": ["Original question", "1966"]
-  },
-  {
-    "id": "ann-e1067-komjath",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 136, "endLine": 145 },
-    "type": "axiom",
-    "title": "Komjath's Consistency Result (2013)",
-    "content": "**komjath_consistency_2013:**\n\nIt is consistent with ZFC that a counterexample exists.\n\nThis was the first breakthrough - showing the answer isn't necessarily YES.\n\nFor the variant with aleph_1 vertices, Komjath proved independence from ZFC.",
-    "significance": "key",
-    "relatedConcepts": ["ZFC consistency", "Independence results"]
-  },
-  {
-    "id": "ann-e1067-soukup",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 147, "endLine": 155 },
-    "type": "axiom",
-    "title": "Soukup's Counterexample (2015)",
-    "content": "**soukup_counterexample_2015:**\n\nA counterexample exists in ZFC without extra assumptions.\n\nSoukup constructed a graph G with:\n- chi(G) = aleph_1\n- Every infinitely connected subgraph H has chi(H) < aleph_1\n\n**This definitively answers the question: NO**",
-    "mathContext": "The construction uses 'ladders' of trees that force chromatic separation.",
-    "significance": "critical",
-    "relatedConcepts": ["Main result", "ZFC counterexample"]
-  },
-  {
-    "id": "ann-e1067-bowler-pitz",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 157, "endLine": 165 },
-    "type": "axiom",
-    "title": "Bowler-Pitz Simpler Counterexample (2024)",
-    "content": "**bowler_pitz_counterexample_2024:**\n\nAn elementary counterexample, simpler than Soukup's construction.\n\nTheir 2024 paper (arXiv:2402.05984) provides a more accessible construction using only basic graph theory.\n\nThis makes the result easier to understand and verify.",
-    "significance": "key",
-    "relatedConcepts": ["Elementary proof", "2024"]
-  },
-  {
-    "id": "ann-e1067-thomassen",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 167, "endLine": 175 },
-    "type": "axiom",
-    "title": "Thomassen's Edge-Connectivity Counterexample (2017)",
-    "content": "**thomassen_edge_counterexample_2017:**\n\nFor the edge-connectivity variant, a counterexample also exists.\n\nEven the weaker requirement of 'infinitely edge-connected' (needing infinitely many edge deletions to disconnect) doesn't suffice.\n\nThis shows the phenomenon is robust across different connectivity notions.",
-    "significance": "key",
-    "relatedConcepts": ["Edge connectivity", "Robustness"]
-  },
-  {
-    "id": "ann-e1067-aleph1-vertices",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 181, "endLine": 195 },
-    "type": "axiom",
-    "title": "Variant: aleph_1 Vertices",
-    "content": "**hasAleph1Vertices(V) and komjath_independence:**\n\nFor graphs with exactly aleph_1 many vertices, Komjath proved the answer is INDEPENDENT of ZFC.\n\nThis means:\n- Some models of ZFC have counterexamples\n- Other models have the property hold\n- Neither can be proved from ZFC alone",
-    "mathContext": "This is a striking example of set-theoretic independence in combinatorics.",
-    "significance": "key",
-    "relatedConcepts": ["ZFC independence", "Set theory"]
-  },
-  {
-    "id": "ann-e1067-insight",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 201, "endLine": 211 },
+    "id": "ann-e1067-counterexamples",
+    "range": { "startLine": 132, "endLine": 175 },
     "type": "theorem",
-    "title": "Key Insight",
-    "content": "**counterexample_insight:**\n\nChromatic number and infinite connectivity are somewhat independent properties.\n\nOne can construct graphs where:\n1. chi(G) = aleph_1 (uncountable chromatic number)\n2. Any infinitely connected subgraph has chi <= aleph_0\n\nThe 'bottleneck' for chromatic number is in parts that can't support infinite connectivity.",
-    "significance": "key",
-    "relatedConcepts": ["Independence of properties"]
+    "title": "Three Counterexamples and an Edge Variant",
+    "content": "Four axioms record the disproof timeline: Komjáth (2013) showed consistency of a counterexample; Soukup (2015) constructed one in ZFC without extra assumptions; Bowler-Pitz (2024) gave a simpler elementary construction. Thomassen (2017) extended the negative answer to edge-connectivity: even requiring infinitely many edge-disjoint paths doesn't force high chromatic number in subgraphs. Each axiom asserts existence of a graph G with χ = ℵ₁ where every infinitely connected subgraph has χ < ℵ₁.",
+    "significance": "essential"
+  },
+  {
+    "id": "ann-e1067-independence",
+    "range": { "startLine": 177, "endLine": 197 },
+    "type": "insight",
+    "title": "ZFC Independence for ℵ₁-Vertex Graphs",
+    "content": "When restricted to graphs with exactly ℵ₁ vertices, Komjáth proved the answer is independent of ZFC: some models have counterexamples, others do not. This is a striking example of set-theoretic independence in combinatorics — the truth of a purely graph-theoretic statement depends on which axioms of set theory one adopts. The axiom komjath_aleph1_vertex_counterexample_consistent captures one direction.",
+    "significance": "important"
   },
   {
     "id": "ann-e1067-main",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 270, "endLine": 278 },
+    "range": { "startLine": 238, "endLine": 265 },
     "type": "theorem",
-    "title": "Main Result: erdos_1067",
-    "content": "**erdos_1067:**\n\nThere exists a graph G with chi(G) = aleph_1 such that every infinitely connected subgraph H has chi(H) < aleph_1.\n\n```lean\ntheorem erdos_1067 : exists G, hasAleph1ChromaticNumber G and\n  forall H, IsSubgraph H G -> InfinitelyConnected H ->\n    not(hasAleph1ChromaticNumber H)\n```\n\n**This DISPROVES the Erdos-Hajnal conjecture.**",
-    "significance": "critical",
-    "relatedConcepts": ["Main theorem", "Disproof"]
-  },
-  {
-    "id": "ann-e1067-answer",
-    "proofId": "erdos-1067",
-    "range": { "startLine": 290, "endLine": 300 },
-    "type": "theorem",
-    "title": "The Answer: NO",
-    "content": "**erdos_1067_answer:**\n\nExplicitly states the conjecture is FALSE.\n\n```lean\ntheorem erdos_1067_answer :\n    not(forall G, hasAleph1ChromaticNumber G ->\n      exists H, IsSubgraph H G and InfinitelyConnected H and\n        hasAleph1ChromaticNumber H)\n```\n\nThe Erdos-Hajnal question from 1966 is definitively answered in the negative.",
-    "significance": "critical",
-    "relatedConcepts": ["Final answer", "Disproof"]
+    "title": "Main Theorems: DISPROVED",
+    "content": "Three theorems capture the complete answer. erdos_1067 directly witnesses the counterexample (proved from Soukup's axiom). erdos_1067_elementary gives the same via Bowler-Pitz. erdos_1067_answer explicitly negates the universal statement, using push_neg to convert the counterexample into a refutation. The proof of erdos_1067_answer is genuine Lean tactic proof, not just an axiom application.",
+    "significance": "essential"
   }
 ]

--- a/src/data/proofs/erdos-1067/meta.json
+++ b/src/data/proofs/erdos-1067/meta.json
@@ -110,30 +110,23 @@
     {
       "id": "aleph1-vertices",
       "title": "Variant with ℵ₁ Vertices",
-      "summary": "hasAleph1Vertices, independence result",
+      "summary": "hasAleph1Vertices, komjath_aleph1_vertex_counterexample_consistent",
       "startLine": 177,
-      "endLine": 195
+      "endLine": 197
     },
     {
       "id": "observations",
       "title": "Key Observations",
-      "summary": "Why counterexamples exist, construction ideas",
-      "startLine": 197,
-      "endLine": 230
-    },
-    {
-      "id": "related",
-      "title": "Related Results",
-      "summary": "Connection to Problem #1068, Erdős-Hajnal original",
-      "startLine": 232,
-      "endLine": 246
+      "summary": "soukup_construction_principle axiom",
+      "startLine": 199,
+      "endLine": 211
     },
     {
       "id": "summary",
-      "title": "Summary",
+      "title": "Summary and Main Theorems",
       "summary": "erdos_1067, erdos_1067_elementary, erdos_1067_answer theorems",
-      "startLine": 248,
-      "endLine": 302
+      "startLine": 213,
+      "endLine": 268
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Removed trivial `True` axiom (`komjath_independence`), replaced with properly typed axiom
- Removed `counterexample_insight : True := trivial` theorem
- Removed `bowler_pitz_elementary : True` axiom
- Removed `True` placeholder defs (`related_1068`, `original_erdos_hajnal_1966`)
- Gave `soukup_construction_principle` a proper type instead of just `hasAleph1ChromaticNumber`
- Updated meta.json section line numbers for 268-line file
- Rewrote annotations.json with 6 substantive entries

## Test plan
- [x] `pnpm build` passes
- [x] No `True` axioms/defs remaining
- [x] No `True := trivial` theorems
- [x] Section line numbers match actual Lean file
- [x] Genuine proved theorems (erdos_1067_answer) preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)