### PR TITLE
enhance(erdos-992): remove True axioms, add summary theorem

### DIFF
--- a/proofs/Proofs/Erdos992Problem.lean
+++ b/proofs/Proofs/Erdos992Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
 Erdős Problem #992: Discrepancy of Sequences mod 1
 
 Source: https://erdosproblems.com/992
@@ -67,8 +67,6 @@ noncomputable def countInInterval (x : ℕ → ℕ) (α : ℝ) (N : ℕ) (a b : 
 
 /-- The discrepancy D(N) for sequence x and multiplier α -/
 noncomputable def discrepancy (x : ℕ → ℕ) (α : ℝ) (N : ℕ) : ℝ :=
-  -- D(N) = max over all intervals I ⊆ [0,1] of |count - |I|·N|
-  -- We axiomatize this supremum
   sSup { |↑(countInInterval x α N a b) - (b - a) * N| |
          (a : ℝ) (b : ℝ) (_ : 0 ≤ a) (_ : a ≤ b) (_ : b ≤ 1) }
 
@@ -79,12 +77,11 @@ noncomputable def discrepancy (x : ℕ → ℕ) (α : ℝ) (N : ℕ) : ℝ :=
 /-- Erdős-Koksma (1949) and Cassels (1950): D(N) ≪ N^{1/2}(log N)^{5/2+o(1)} -/
 axiom erdos_koksma_cassels (x : ℕ → ℕ) (hx : StrictlyIncreasingSeq x) :
     ∃ C : ℝ, C > 0 ∧
-    -- For almost all α ∈ [0,1]
     ∀ᵐ α ∂volume.restrict (Set.Icc 0 1),
       ∀ N : ℕ, N ≥ 2 →
         discrepancy x α N ≤ C * Real.sqrt N * (Real.log N) ^ (5/2 : ℝ)
 
-/-- Baker (1981): D(N) ≪ N^{1/2}(log N)^{3/2+o(1)} -/
+/-- Baker (1981): D(N) ≪ N^{1/2}(log N)^{3/2+o(1)} — current best general bound -/
 axiom baker_1981 (x : ℕ → ℕ) (hx : StrictlyIncreasingSeq x) :
     ∃ C : ℝ, C > 0 ∧
     ∀ᵐ α ∂volume.restrict (Set.Icc 0 1),
@@ -126,9 +123,6 @@ def conjecture_loglog_polynomial (x : ℕ → ℕ) : Prop :=
       ∀ N : ℕ, N ≥ 3 →
         discrepancy x α N ≤ C * Real.sqrt N * (Real.log (Real.log N)) ^ k
 
-/-- Status: Both conjectures remain OPEN for general sequences -/
-axiom conjectures_open : True
-
 /-!
 ## Part VI: Lower Bounds
 -/
@@ -140,27 +134,8 @@ axiom lower_bound_sqrt :
     ∀ α ∈ S, ∀ C > 0, ∃ N : ℕ, N ≥ 2 ∧
       discrepancy x α N ≥ C * Real.sqrt N
 
-/-- The √N factor is unavoidable - question is about the logarithmic factor -/
-axiom sqrt_is_correct_order : True
-
 /-!
-## Part VII: Connection to Uniform Distribution
--/
-
-/-- Weyl's criterion: αxₙ is equidistributed mod 1 iff exponential sums vanish -/
-axiom weyl_criterion (x : ℕ → ℕ) (α : ℝ) :
-    -- Sequence is equidistributed mod 1 iff for all h ≠ 0:
-    -- lim_{N→∞} (1/N) Σₙ≤N exp(2πi h α xₙ) = 0
-    True
-
-/-- Erdős-Turán inequality relates discrepancy to exponential sums -/
-axiom erdos_turan_inequality : True
-
-/-- Van der Corput's difference theorem for exponential sums -/
-axiom van_der_corput : True
-
-/-!
-## Part VIII: Examples
+## Part VII: Examples
 -/
 
 /-- Example: x_n = n (natural numbers) -/
@@ -180,81 +155,25 @@ axiom powers_of_two_bound :
       ∀ N : ℕ, N ≥ 3 →
         discrepancy powersOfTwo α N ≤ C * Real.sqrt N * (Real.log (Real.log N)) ^ k
 
-/-- Numerical example: At N = 1000000, √N = 1000, log N ≈ 13.8, (log N)^{3/2} ≈ 51 -/
-example : (1000000 : ℕ).sqrt = 1000 := by native_decide
-
 /-!
-## Part IX: The Gap in Bounds
+## Part VIII: Summary
 -/
 
-/-- Current best: (log N)^{3/2+o(1)}
-    Conjecture: (log N)^{o(1)} or (log log N)^{O(1)}
-    Gap: From polynomial in log N to subpolynomial -/
-axiom gap_analysis : True
-
-/-- At N = 10^6: (log N)^{3/2} ≈ 51, (log log N) ≈ 2.6
-    The difference is significant for understanding fine structure -/
-axiom numerical_gap_illustration : True
-
-/-!
-## Part X: Techniques
--/
-
-/-- Probabilistic method for almost all α -/
-axiom probabilistic_method : True
-
-/-- Metric number theory techniques -/
-axiom metric_number_theory : True
-
-/-- Connection to Diophantine approximation -/
-axiom diophantine_approximation : True
-
-/-!
-## Part XI: Summary
--/
-
-/--
-**Erdős Problem #992: Summary**
-
-**Question:** For integer sequence x₁ < x₂ < ⋯ and almost all α ∈ [0,1],
-what is the optimal bound for discrepancy D(N)?
-
-**Known Bounds:**
-- Erdős-Koksma & Cassels (1949-50): D(N) ≪ √N · (log N)^{5/2}
-- Baker (1981): D(N) ≪ √N · (log N)^{3/2}
-- Erdős-Gál (lacunary case): D(N) ≪ √N · (log log N)^{O(1)}
-
-**Conjectures:**
-1. D(N) ≪ √N · (log N)^{o(1)} (subpolynomial in log)
-2. D(N) ≪ √N · (log log N)^{O(1)} (polynomial in log log)
-
-**Status:** OPEN for general sequences
-The √N factor is optimal; the question is the logarithmic correction.
-
-**Key Insight:** The discrepancy measures how uniformly {αxₙ} is distributed.
-For lacunary sequences the stronger bound is known, suggesting the conjecture
-may be true in general.
--/
-theorem erdos_992_statement :
-    -- Baker's bound holds for all sequences
+/-- **Summary of Erdős Problem #992:**
+    Combines the two main known results:
+    1. Baker's bound (1981): D(N) ≪ √N · (log N)^{3/2} for all sequences (current best)
+    2. Erdős-Gál: D(N) ≪ √N · (log log N)^{O(1)} for lacunary sequences -/
+theorem erdos_992_summary :
     (∀ x : ℕ → ℕ, StrictlyIncreasingSeq x →
       ∃ C : ℝ, C > 0 ∧
       ∀ᵐ α ∂volume.restrict (Set.Icc 0 1),
         ∀ N : ℕ, N ≥ 2 →
           discrepancy x α N ≤ C * Real.sqrt N * (Real.log N) ^ (3/2 : ℝ)) ∧
-    -- Stronger bound for lacunary sequences
     (∀ x : ℕ → ℕ, ∀ λ : ℝ, Lacunary x λ →
       ∃ C k : ℝ, C > 0 ∧ k > 0 ∧
       ∀ᵐ α ∂volume.restrict (Set.Icc 0 1),
         ∀ N : ℕ, N ≥ 3 →
-          discrepancy x α N ≤ C * Real.sqrt N * (Real.log (Real.log N)) ^ k) ∧
-    -- Problem remains open
-    True := by
-  refine ⟨?_, ?_, trivial⟩
-  · intro x hx; exact baker_1981 x hx
-  · intro x λ hλ; exact erdos_gal_lacunary x λ hλ
-
-/-- Erdős Problem #992 is OPEN -/
-theorem erdos_992_open : True := trivial
+          discrepancy x α N ≤ C * Real.sqrt N * (Real.log (Real.log N)) ^ k) :=
+  ⟨fun x hx => baker_1981 x hx, fun x λ hλ => erdos_gal_lacunary x λ hλ⟩
 
 end Erdos992

--- a/src/data/proofs/erdos-992/annotations.json
+++ b/src/data/proofs/erdos-992/annotations.json
@@ -1,137 +1,79 @@
 [
   {
-    "id": "ann-992-seq",
+    "id": "ann-992-header",
     "proofId": "erdos-992",
-    "range": { "startLine": 45, "endLine": 47 },
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #992: Discrepancy of Sequences mod 1**\n\nFor an integer sequence x₁ < x₂ < ⋯ and almost all α ∈ [0,1], how large can the discrepancy D(N) be?\n\nD(N) = max_{I ⊆ [0,1]} |#{n ≤ N : {αxₙ} ∈ I} - |I|·N|\n\n**Status:** OPEN\n\n**Known:** D(N) ≪ √N·(log N)^{3/2} (Baker 1981)\n**Conjectured:** D(N) ≪ √N·(log N)^{o(1)} or even √N·(log log N)^{O(1)}\n\nThe gap between (log N)^{3/2} and o(1) is substantial. For lacunary sequences, the stronger bound is known (Erdős-Gál).",
+    "mathContext": "Discrepancy measures deviation from uniform distribution. The 'almost all α' means the result holds for Lebesgue-a.e. α ∈ [0,1].",
+    "significance": "critical",
+    "relatedConcepts": ["Discrepancy theory", "Uniform distribution mod 1", "Metric number theory"]
+  },
+  {
+    "id": "ann-992-definitions",
+    "proofId": "erdos-992",
+    "range": { "startLine": 39, "endLine": 71 },
     "type": "definition",
-    "title": "StrictlyIncreasingSeq",
-    "content": "Infinite sequence with x(n) < x(n+1) for all n.",
-    "significance": "critical"
+    "title": "Core Definitions",
+    "content": "**StrictlyIncreasingSeq(x)** — x(n) < x(n+1) for all n.\n\n**frac(t)** = t - ⌊t⌋ — the fractional part, always in [0,1).\n\n**countInInterval(x, α, N, a, b)** — count of n ≤ N with {αxₙ} ∈ [a,b). Uses Finset.filter on Finset.range N.\n\n**discrepancy(x, α, N)** = sup over intervals I ⊆ [0,1] of |count - |I|·N|. Defined via sSup over the set of deviations for all valid intervals [a,b) ⊆ [0,1].\n\nThe discrepancy captures the worst-case deviation from uniform distribution across all intervals.",
+    "mathContext": "The supremum definition matches the classical definition of star discrepancy D*(N). The 'almost all α' statements use MeasureTheory.ae (∀ᵐ α ∂volume.restrict [0,1]).",
+    "significance": "critical",
+    "relatedConcepts": ["Star discrepancy", "Finset.filter", "sSup"]
   },
   {
-    "id": "ann-992-frac",
+    "id": "ann-992-bounds",
     "proofId": "erdos-992",
-    "range": { "startLine": 49, "endLine": 53 },
-    "type": "definition",
-    "title": "Fractional Part",
-    "content": "frac(t) = t - floor(t), always in [0,1).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-992-count",
-    "proofId": "erdos-992",
-    "range": { "startLine": 61, "endLine": 66 },
-    "type": "definition",
-    "title": "countInInterval",
-    "content": "Count n <= N with {alpha*x_n} in [a,b).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-992-discrepancy",
-    "proofId": "erdos-992",
-    "range": { "startLine": 68, "endLine": 73 },
-    "type": "definition",
-    "title": "Discrepancy",
-    "content": "D(N) = max over I of |count - |I|*N|.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-992-koksma",
-    "proofId": "erdos-992",
-    "range": { "startLine": 79, "endLine": 85 },
-    "type": "theorem",
-    "title": "Erdos-Koksma-Cassels",
-    "content": "D(N) << sqrt(N)*(log N)^{5/2} for almost all alpha (1949-50).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-992-baker",
-    "proofId": "erdos-992",
-    "range": { "startLine": 87, "endLine": 92 },
-    "type": "theorem",
-    "title": "Baker 1981",
-    "content": "D(N) << sqrt(N)*(log N)^{3/2} for almost all alpha.",
-    "significance": "critical"
+    "range": { "startLine": 73, "endLine": 89 },
+    "type": "axiom",
+    "title": "Known Upper Bounds",
+    "content": "**erdos_koksma_cassels** (1949-50): D(N) ≤ C·√N·(log N)^{5/2} for a.e. α. The first metric result on discrepancy of lacunary-like sequences.\n\n**baker_1981**: D(N) ≤ C·√N·(log N)^{3/2} for a.e. α. The current best general bound, improving the exponent from 5/2 to 3/2.\n\nBoth use the ∀ᵐ quantifier from Mathlib's measure theory library to express 'for almost all α ∈ [0,1]'.\n\nBaker's improvement used refined estimates on exponential sums and the Erdős-Turán inequality.",
+    "mathContext": "The improvement from (log N)^{5/2} to (log N)^{3/2} was substantial but still far from the conjectured o(1). No further improvement has been made since 1981.",
+    "significance": "critical",
+    "relatedConcepts": ["Baker's method", "Exponential sums", "Erdős-Turán inequality"]
   },
   {
     "id": "ann-992-lacunary",
     "proofId": "erdos-992",
-    "range": { "startLine": 98, "endLine": 107 },
-    "type": "theorem",
-    "title": "Lacunary Bound",
-    "content": "For lacunary x_n, D(N) << sqrt(N)*(log log N)^k (Erdos-Gal).",
-    "significance": "critical"
+    "range": { "startLine": 91, "endLine": 104 },
+    "type": "axiom",
+    "title": "Lacunary Sequences",
+    "content": "**Lacunary(x, λ):** x(n+1)/x(n) > λ > 1 for all n — the sequence grows at least geometrically.\n\n**erdos_gal_lacunary:** For lacunary sequences, D(N) ≤ C·√N·(log log N)^k for a.e. α.\n\nThis is much stronger than Baker's general bound: (log log N)^k versus (log N)^{3/2}. For example, at N = 10^6: (log N)^{3/2} ≈ 51, but log log N ≈ 2.6.\n\nThe Erdős-Gál result supports the conjecture that the general bound should also be subpolynomial in log N.",
+    "mathContext": "Lacunary sequences have strong independence properties that make exponential sum estimates much easier. The question is whether these estimates can be extended to all sequences.",
+    "significance": "critical",
+    "relatedConcepts": ["Lacunary sequences", "Independence", "Exponential sums"]
   },
   {
-    "id": "ann-992-conj1",
+    "id": "ann-992-conjectures",
     "proofId": "erdos-992",
-    "range": { "startLine": 113, "endLine": 119 },
+    "range": { "startLine": 106, "endLine": 124 },
     "type": "definition",
-    "title": "Subpolynomial Conjecture",
-    "content": "D(N) << sqrt(N)*(log N)^{o(1)} for all sequences.",
-    "significance": "key"
+    "title": "The Main Conjectures",
+    "content": "**conjecture_log_subpolynomial:** For all ε > 0, D(N) ≤ C_ε·√N·(log N)^ε for a.e. α. This says (log N)^{o(1)} — any power of log N, no matter how small.\n\n**conjecture_loglog_polynomial:** D(N) ≤ C·√N·(log log N)^k for a.e. α. This is stronger — polynomial in log log N rather than subpolynomial in log N.\n\nBoth conjectures are defined as Prop (not asserted as axioms) since they remain OPEN. The second conjecture matches the known lacunary case.",
+    "mathContext": "The hierarchy of conjectured bounds: (log N)^{3/2} (known) > (log N)^{o(1)} (weak conjecture) > (log log N)^{O(1)} (strong conjecture).",
+    "significance": "critical",
+    "relatedConcepts": ["Open conjectures", "Asymptotic bounds", "Subpolynomial growth"]
   },
   {
-    "id": "ann-992-conj2",
+    "id": "ann-992-examples",
     "proofId": "erdos-992",
-    "range": { "startLine": 121, "endLine": 127 },
+    "range": { "startLine": 137, "endLine": 156 },
     "type": "definition",
-    "title": "Loglog Conjecture",
-    "content": "D(N) << sqrt(N)*(log log N)^{O(1)} for all sequences.",
-    "significance": "key"
+    "title": "Examples",
+    "content": "**naturalSeq** = id — the sequence 1, 2, 3, ... The simplest strictly increasing sequence.\n\n**powersOfTwo(n)** = 2^n — lacunary with λ = 2. Since it's lacunary, the stronger loglog bound applies.\n\n**powers_of_two_bound:** D(N) ≤ C·√N·(log log N)^k for powers of 2 and a.e. α.\n\nThese examples illustrate the gap: for x_n = n (not lacunary), only Baker's (log N)^{3/2} is known. For x_n = 2^n (lacunary), the much stronger (log log N)^k applies.",
+    "mathContext": "The contrast between general and lacunary sequences is the central tension of Problem #992.",
+    "significance": "key",
+    "relatedConcepts": ["Examples", "Gap between bounds"]
   },
   {
-    "id": "ann-992-lower",
+    "id": "ann-992-summary",
     "proofId": "erdos-992",
-    "range": { "startLine": 136, "endLine": 141 },
+    "range": { "startLine": 158, "endLine": 179 },
     "type": "theorem",
-    "title": "Lower Bound",
-    "content": "sqrt(N) is necessary - cannot do better.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-992-weyl",
-    "proofId": "erdos-992",
-    "range": { "startLine": 150, "endLine": 160 },
-    "type": "definition",
-    "title": "Weyl Criterion",
-    "content": "Equidistribution iff exponential sums vanish.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-992-natural",
-    "proofId": "erdos-992",
-    "range": { "startLine": 166, "endLine": 169 },
-    "type": "example",
-    "title": "Natural Numbers",
-    "content": "x_n = n, strictly increasing sequence.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-992-powers",
-    "proofId": "erdos-992",
-    "range": { "startLine": 171, "endLine": 181 },
-    "type": "example",
-    "title": "Powers of 2",
-    "content": "x_n = 2^n, lacunary with lambda = 2.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-992-sqrt",
-    "proofId": "erdos-992",
-    "range": { "startLine": 183, "endLine": 184 },
-    "type": "example",
-    "title": "Numerical Example",
-    "content": "sqrt(1000000) = 1000 for bound scale.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-992-main",
-    "proofId": "erdos-992",
-    "range": { "startLine": 238, "endLine": 255 },
-    "type": "theorem",
-    "title": "Main Statement",
-    "content": "Baker bound + lacunary bound + open status.",
-    "significance": "critical"
+    "title": "Summary Theorem",
+    "content": "**erdos_992_summary** (PROVED): Combines two key results:\n1. Baker's bound: D(N) ≪ √N·(log N)^{3/2} for all sequences and a.e. α\n2. Erdős-Gál: D(N) ≪ √N·(log log N)^k for lacunary sequences and a.e. α\n\nProof: ⟨baker_1981, erdos_gal_lacunary⟩\n\nThe summary captures the complete picture: the best general bound and the special lacunary bound. The conjectures ask whether the lacunary bound extends to all sequences.",
+    "mathContext": "Both conjuncts are instantiated from the axiomatized results. The summary theorem is proved, not axiomatized.",
+    "significance": "critical",
+    "relatedConcepts": ["Summary theorems", "Known results", "Open problem formalization"]
   }
 ]

--- a/src/data/proofs/erdos-992/meta.json
+++ b/src/data/proofs/erdos-992/meta.json
@@ -81,65 +81,58 @@
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "summary": "Sequences and fractional parts",
+      "summary": "StrictlyIncreasingSeq, frac, frac_in_unit_interval",
       "startLine": 39,
       "endLine": 53
     },
     {
       "id": "discrepancy",
       "title": "Discrepancy Definition",
-      "summary": "D(N) via supremum over intervals",
+      "summary": "countInInterval, discrepancy D(N) via supremum",
       "startLine": 55,
-      "endLine": 73
+      "endLine": 71
     },
     {
       "id": "known-bounds",
       "title": "Known Bounds",
-      "summary": "Erdős-Koksma, Cassels, Baker",
-      "startLine": 75,
-      "endLine": 92
+      "summary": "erdos_koksma_cassels, baker_1981 axioms",
+      "startLine": 73,
+      "endLine": 89
     },
     {
       "id": "lacunary",
       "title": "Lacunary Sequences",
-      "summary": "Erdős-Gál stronger bound",
-      "startLine": 94,
-      "endLine": 107
+      "summary": "Lacunary definition, erdos_gal_lacunary axiom",
+      "startLine": 91,
+      "endLine": 104
     },
     {
       "id": "conjectures",
       "title": "Main Conjectures",
-      "summary": "Subpolynomial and loglog conjectures",
-      "startLine": 109,
-      "endLine": 130
+      "summary": "conjecture_log_subpolynomial, conjecture_loglog_polynomial",
+      "startLine": 106,
+      "endLine": 124
     },
     {
       "id": "lower-bounds",
       "title": "Lower Bounds",
-      "summary": "√N is necessary",
-      "startLine": 132,
-      "endLine": 144
-    },
-    {
-      "id": "connections",
-      "title": "Uniform Distribution",
-      "summary": "Weyl, Erdős-Turán, Van der Corput",
-      "startLine": 146,
-      "endLine": 160
+      "summary": "lower_bound_sqrt: √N is necessary",
+      "startLine": 126,
+      "endLine": 135
     },
     {
       "id": "examples",
       "title": "Examples",
-      "summary": "Natural numbers and powers of 2",
-      "startLine": 162,
-      "endLine": 184
+      "summary": "naturalSeq, powersOfTwo, powers_of_two_bound",
+      "startLine": 137,
+      "endLine": 156
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Main theorem and status",
-      "startLine": 212,
-      "endLine": 258
+      "summary": "erdos_992_summary combining Baker and Erdős-Gál",
+      "startLine": 158,
+      "endLine": 179
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove 10 trivial `True` axioms and placeholders (conjectures_open, sqrt_is_correct_order, weyl_criterion, erdos_turan_inequality, van_der_corput, gap_analysis, numerical_gap_illustration, probabilistic_method, metric_number_theory, diophantine_approximation)
- Remove `erdos_992_open : True := trivial` and numerical example using `native_decide`
- Add `erdos_992_summary` proved theorem combining `baker_1981` and `erdos_gal_lacunary`
- Reduce 261→180 lines
- Rewrite meta.json sections and annotations.json with substantive mathematical content

## Test plan
- [x] `pnpm build` passes
- [x] No `sorry`, no `True := trivial`, no trivial `True` axioms remain
- [x] Summary theorem proves using `exact ⟨..⟩`
- [x] Annotations ≥ 5 entries with correct line ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)