### PR TITLE
fix(erdos-134): remove True placeholders, fix header

### DIFF
--- a/proofs/Proofs/Erdos134Problem.lean
+++ b/proofs/Proofs/Erdos134Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
 Erdős Problem #134: Triangle-Free Graphs with Diameter 2
 
 Source: https://erdosproblems.com/134
@@ -214,26 +214,15 @@ axiom alon_implies_conjecture : erdosGyarfasConjecture
 
 /-!
 ## Part VI: The Role of the Exponent
--/
 
-/--
-**Critical Exponent 1/2:**
 The exponent 1/2 is critical:
 - Below 1/2 - ε: Extension possible with o(n²) edges (Alon)
 - At 1/2 (with large constant): Extension may need Ω(n²) edges (Simonovits)
 
 The ε "gap" below 1/2 is essential for the positive result.
+Triangle-free graphs with max degree constraints relate to Turán's theorem,
+Ramsey theory, and spectral graph theory.
 -/
-theorem critical_exponent_half : True := trivial
-
-/--
-**Connection to Extremal Graph Theory:**
-Triangle-free graphs with max degree constraints are related to:
-- Turán's theorem: max edges in triangle-free graphs
-- Ramsey theory: unavoidable structures
-- Spectral graph theory: eigenvalue bounds
--/
-theorem extremal_connection : True := trivial
 
 /-!
 ## Part VII: Related Concepts
@@ -256,25 +245,13 @@ axiom diameter2_equiv (G : SimpleGraph V) (hConn : G.Connected) :
     hasDiameter2 G ↔ commonNeighborProperty G
 
 /-!
-## Part VIII: Open Refinements
--/
+## Part VIII: Summary
 
-/--
-**Open Question: Tight Bound on Edges**
-What is the minimum number of edges needed in the worst case?
-Alon shows O(n^{2-ε}), but is this tight?
--/
-def openQuestion_tightBound : Prop := True
-
-/--
-**Open Question: Explicit Constructions**
-Can we explicitly construct the diameter-2 extension, or is the proof
-non-constructive (using probabilistic methods)?
--/
-def openQuestion_explicit : Prop := True
-
-/-!
-## Part IX: Summary
+**Open Refinements:**
+- Is the O(n^{2-ε}) bound tight?
+- Can the extension be constructed explicitly (vs. probabilistic methods)?
+- What about diameter k > 2?
+- Extensions to K_r-free graphs for r > 3?
 -/
 
 /--

--- a/src/data/proofs/erdos-134/annotations.json
+++ b/src/data/proofs/erdos-134/annotations.json
@@ -102,27 +102,30 @@
     "id": "critical-exponent",
     "proofId": "erdos-134",
     "type": "concept",
-    "range": { "startLine": 219, "endLine": 227 },
+    "range": { "startLine": 215, "endLine": 225 },
     "title": "Critical Exponent 1/2",
-    "content": "The exponent 1/2 is critical: below 1/2-ε extension is possible with o(n²) edges (Alon), but at 1/2 with large constant, extension may need Ω(n²) edges (Simonovits).",
+    "content": "The exponent 1/2 is critical: below 1/2-ε extension is possible with o(n²) edges (Alon), but at 1/2 with large constant, extension may need Ω(n²) edges (Simonovits). The ε gap below 1/2 is essential. Triangle-free graphs with degree constraints relate to Turán's theorem, Ramsey theory, and spectral graph theory.",
+    "mathContext": "This phase transition at degree n^{1/2} is reminiscent of other thresholds in extremal graph theory where polynomial bounds shift from possible to impossible.",
     "significance": "key"
   },
   {
     "id": "common-neighbor",
     "proofId": "erdos-134",
     "type": "definition",
-    "range": { "startLine": 242, "endLine": 249 },
+    "range": { "startLine": 231, "endLine": 245 },
     "title": "Common Neighbor Property",
-    "content": "A graph has the common neighbor property if every pair of non-adjacent vertices has a common neighbor. For connected graphs, this is equivalent to diameter 2.",
+    "content": "**commonNeighborProperty(G)**: every pair of non-adjacent vertices has a common neighbor. For connected graphs, this is equivalent to diameter 2 (axiom diameter2_equiv). This characterization is useful because it converts a global property (diameter) into a local condition (common neighbors).",
+    "mathContext": "The equivalence between diameter 2 and the common neighbor property is standard in graph theory. It provides an alternative way to verify diameter-2 extensions.",
     "significance": "supporting"
   },
   {
     "id": "main-theorem",
     "proofId": "erdos-134",
     "type": "theorem",
-    "range": { "startLine": 280, "endLine": 316 },
-    "title": "Main Result",
-    "content": "erdos_134_main: The Erdős-Gyárfás conjecture is true (from Alon's theorem), with the stronger quantitative bound O(n^{2-ε}) edges.",
+    "range": { "startLine": 257, "endLine": 295 },
+    "title": "Main Results: erdos_134_solved and erdos_134_main",
+    "content": "**erdos_134_solved** (PROVED): derives erdosGyarfasConjecture directly from alon_implies_conjecture.\n\n**erdos_134_main** (PROVED): Combines two results:\n1. The conjecture is true (from Alon)\n2. The stronger O(n^{2-ε}) bound (from alon_theorem)\n\nProof uses `exact ⟨alon_implies_conjecture, ...⟩` with `obtain` to extract constants from alon_theorem.",
+    "mathContext": "The summary theorem packages both the qualitative result (the conjecture holds) and the quantitative improvement (O(n^{2-ε}) vs δn²) into a single statement.",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-134/meta.json
+++ b/src/data/proofs/erdos-134/meta.json
@@ -111,24 +111,24 @@
     },
     {
       "id": "critical-exponent",
-      "title": "The Critical Exponent",
-      "summary": "Why 1/2 is the threshold",
+      "title": "The Role of the Exponent",
+      "summary": "Why 1/2 is the critical threshold between positive and negative results",
       "startLine": 215,
-      "endLine": 236
+      "endLine": 225
     },
     {
       "id": "related-concepts",
       "title": "Related Concepts",
-      "summary": "commonNeighborProperty, diameter2_equiv",
-      "startLine": 238,
-      "endLine": 256
+      "summary": "commonNeighborProperty, diameter2_equiv equivalence",
+      "startLine": 227,
+      "endLine": 245
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_134_solved, erdos_134_main theorems",
-      "startLine": 276,
-      "endLine": 317
+      "summary": "erdos_134_solved, erdos_134_main theorems combining conjecture with Alon's bound",
+      "startLine": 247,
+      "endLine": 295
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Fixed `/-` to `/-!` on file header
- Removed 4 True placeholders: `critical_exponent_half`, `extremal_connection`, `openQuestion_tightBound`, `openQuestion_explicit`
- Converted removed content to `/-!` doc comments
- Updated section line numbers in meta.json
- Updated annotation line ranges and added mathContext fields

## Test plan
- [x] `pnpm build` succeeds
- [x] No `sorry`, `True := trivial`, or `Prop := True` remain
- [x] All section line ranges match actual Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)