### PR TITLE
enhance(erdos-800): fix quality issues in Linear Ramsey Numbers

### DIFF
--- a/proofs/Proofs/Erdos800Problem.lean
+++ b/proofs/Proofs/Erdos800Problem.lean
@@ -44,7 +44,7 @@ open SimpleGraph
 
 namespace Erdos800
 
-/-
+/-!
 ## Part I: Basic Definitions
 -/
 
@@ -72,7 +72,7 @@ This is the key structural property in Erdős Problem #800.
 def noAdjacentHighDegree (G : SimpleGraph V) : Prop :=
   ∀ u v : V, G.Adj u v → ¬(isHighDegree G u ∧ isHighDegree G v)
 
-/-
+/-!
 ## Part II: Subdivisions
 -/
 
@@ -104,7 +104,7 @@ theorem subdivision_implies_no_adjacent_high_degree (G : SimpleGraph V)
   have : vertexDegree G v ≤ 2 := h u (hu3) v huv
   omega
 
-/-
+/-!
 ## Part III: Ramsey Numbers
 -/
 
@@ -139,16 +139,20 @@ def containsMonochromaticCopy (N : ℕ) (c : edgeColoring N) (G : SimpleGraph V)
   ∃ f : V → Fin N, Function.Injective f ∧ isMonochromatic N c f G
 
 /--
-**Ramsey Number:**
+**Ramsey Number (axiomatized):**
 R(G) is the minimum N such that every 2-coloring of K_N contains
-a monochromatic copy of G.
+a monochromatic copy of G. Axiomatized since formalizing the existence
+via the finite Ramsey theorem requires substantial infrastructure.
 -/
-noncomputable def ramseyNumber (G : SimpleGraph V) : ℕ :=
-  Nat.find (ramsey_exists G)
-where
-  ramsey_exists (G : SimpleGraph V) : ∃ N : ℕ, ∀ (c : edgeColoring N),
-    containsMonochromaticCopy N c G := by
-    sorry -- Follows from finite Ramsey theorem
+axiom ramseyNumber (G : SimpleGraph V) : ℕ
+
+/--
+**Ramsey property:**
+For any 2-coloring of K_{R(G)}, there exists a monochromatic copy of G.
+-/
+axiom ramseyNumber_spec (G : SimpleGraph V) :
+    ∀ (c : edgeColoring (ramseyNumber G)),
+      containsMonochromaticCopy (ramseyNumber G) c G
 
 /--
 **Linear Ramsey Number:**
@@ -157,7 +161,7 @@ A graph G has linear Ramsey number if R(G) = O(n) where n = |V(G)|.
 def hasLinearRamseyNumber (G : SimpleGraph V) (C : ℝ) : Prop :=
   (ramseyNumber G : ℝ) ≤ C * (Fintype.card V : ℝ)
 
-/-
+/-!
 ## Part IV: The Main Theorem
 -/
 
@@ -182,7 +186,7 @@ theorem subdivided_graphs_linear_ramsey (G : SimpleGraph V)
   unfold hasLinearRamseyNumber
   exact alon_theorem G (subdivision_implies_no_adjacent_high_degree G h)
 
-/-
+/-!
 ## Part V: Degeneracy and the Burr-Erdős Conjecture
 -/
 
@@ -197,11 +201,10 @@ def isDegenerateAt (G : SimpleGraph V) (p : ℕ) : Prop :=
 /--
 **Key Observation:**
 Graphs with no adjacent high-degree vertices are 2-degenerate.
-(Every subgraph has a vertex of degree ≤ 2.)
+Axiomatized since the proof requires careful induction on subgraph structure.
 -/
-theorem no_adjacent_high_degree_is_2_degenerate (G : SimpleGraph V)
-    (h : noAdjacentHighDegree G) : isDegenerateAt G 2 := by
-  sorry -- Technical proof using the structure of no adjacent high-degree
+axiom no_adjacent_high_degree_is_2_degenerate (G : SimpleGraph V)
+    (h : noAdjacentHighDegree G) : isDegenerateAt G 2
 
 /--
 **Burr-Erdős Conjecture (Problem #163, now theorem):**
@@ -228,131 +231,8 @@ theorem erdos_800_special_case_of_163 (G : SimpleGraph V)
   unfold hasLinearRamseyNumber
   exact hc_bound V G (no_adjacent_high_degree_is_2_degenerate G h)
 
-/-
-## Part VI: Proof Sketch
--/
-
-/--
-**Alon's Proof Technique:**
-The proof uses the following key ideas:
-
-1. **Partition by Degree**: Separate vertices into high-degree (≥ 3) and
-   low-degree (≤ 2) vertices. Call them H and L.
-
-2. **Independence of H**: Since no two high-degree vertices are adjacent,
-   H is an independent set in G.
-
-3. **Paths Through L**: Each edge from a high-degree vertex goes to L.
-   The structure of L (degree ≤ 2) means it consists of paths and cycles.
-
-4. **Embedding Strategy**: Use probabilistic method: randomly embed
-   the high-degree vertices, then deterministically extend along paths.
-
-5. **Counting Argument**: The bound 12n comes from careful analysis of
-   conflicts in the random embedding.
--/
-axiom alon_proof_technique : True
-
-/--
-**Why the Constant 12?**
-Alon's proof gives R(G) ≤ 12n. This comes from:
-- Factor 2 for the two colors (red/blue)
-- Factor 6 from the probabilistic embedding analysis
-The constant has been improved in subsequent work.
--/
-axiom constant_12_explanation : True
-
-/-
-## Part VII: Examples
--/
-
-/--
-**Example 1: Path P_n**
-A path on n vertices has all vertices of degree ≤ 2, so no adjacent
-high-degree vertices. R(P_n) ≤ 12n (actually R(P_n) = n).
--/
-axiom path_ramsey : True
-
-/--
-**Example 2: Cycle C_n**
-A cycle on n vertices has all vertices of degree 2.
-R(C_n) ≤ 12n (actually R(C_n) ~ 2n for odd n, 1.5n for even n).
--/
-axiom cycle_ramsey : True
-
-/--
-**Example 3: Subdivided K_n**
-Take K_n and subdivide each edge once. The resulting graph has
-n high-degree vertices (none adjacent) and n(n-1)/2 degree-2 vertices.
-Total: n + n(n-1)/2 = n(n+1)/2 vertices.
-R(subdivided K_n) ≤ 12 · n(n+1)/2 = 6n(n+1).
--/
-axiom subdivided_complete_ramsey : True
-
-/--
-**Example 4: Stars K_{1,t}**
-A star has one vertex of degree t and t vertices of degree 1.
-R(K_{1,t}) = 2t - 1 (exact), satisfying R(K_{1,t}) ≤ 12(t+1).
--/
-axiom star_ramsey : True
-
-/-
-## Part VIII: Connections
--/
-
-/--
-**Connection to Graph Colorings:**
-The Ramsey number R(G) is related to graph colorings: it asks for
-the size needed to guarantee a monochromatic copy, which connects to
-the chromatic number of certain derived graphs.
--/
-axiom coloring_connection : True
-
-/--
-**Connection to Turán Theory:**
-The extremal number ex(n; G) and Ramsey number R(G) are related:
-- Sparse graphs (small ex) tend to have small Ramsey numbers
-- Turán density and Ramsey growth rate are connected
--/
-axiom turan_connection : True
-
-/--
-**Ramsey Theory Applications:**
-Linear Ramsey numbers are important in:
-- Algorithm design (finding structures in large networks)
-- Property testing
-- Combinatorial geometry
--/
-axiom ramsey_applications : True
-
-/-
-## Part IX: Later Developments
--/
-
-/--
-**Lee's Theorem (2016):**
-Choongbum Lee proved the full Burr-Erdős conjecture:
-For any p-degenerate n-vertex graph G, R(G) ≤ 2^{2^{O(p)}} · n.
--/
-axiom lee_theorem : True
-
-/--
-**Improved Bounds:**
-Subsequent work improved the constants:
-- Fox-Sudakov: Better bounds for specific graph classes
-- Conlon et al.: Polynomial dependence on degeneracy for some families
--/
-axiom improved_bounds : True
-
-/--
-**Ramsey Numbers of Random Graphs:**
-Fox-Sudakov showed that for fixed d, a.a.s. the random graph G(n, d/n)
-has Ramsey number linear in n.
--/
-axiom random_graph_ramsey : True
-
-/-
-## Part X: Summary
+/-!
+## Part VI: Summary
 -/
 
 /--
@@ -376,18 +256,18 @@ theorem erdos_800 : erdos800Problem := by
   exact alon_theorem G h
 
 /--
-**Summary:**
-Erdős Problem #800 asked whether graphs without adjacent high-degree
-vertices have linear Ramsey numbers. Alon (1994) proved R(G) ≤ 12n
-for such graphs, which includes all subdivided graphs (each edge
-subdivided at least once). This was a special case of the Burr-Erdős
-conjecture, later fully resolved by Lee (2016).
+**Erdős Problem #800: Summary**
 
-Status: SOLVED (Alon, 1994)
-Bound: R(G) ≤ 12n
-Method: Probabilistic method with careful embedding analysis
-Generalization: Burr-Erdős conjecture (Problem #163, Lee 2016)
+Alon (1994) proved R(G) ≤ 12n for graphs with no adjacent high-degree vertices.
+This includes all subdivided graphs. The result is a special case of the
+Burr-Erdős conjecture (Problem #163), fully resolved by Lee (2016).
 -/
-theorem erdos_800_solved : True := trivial
+theorem erdos_800_summary :
+    -- Alon's explicit bound
+    (∀ (V : Type*) [Fintype V] [DecidableEq V] (G : SimpleGraph V),
+      noAdjacentHighDegree G → (ramseyNumber G : ℝ) ≤ 12 * (Fintype.card V : ℝ)) ∧
+    -- General existence of linear bound
+    erdos800Problem :=
+  ⟨fun V _ _ G h => alon_theorem G h, erdos_800⟩
 
 end Erdos800

--- a/src/data/proofs/erdos-800/annotations.json
+++ b/src/data/proofs/erdos-800/annotations.json
@@ -1,189 +1,74 @@
 [
   {
-    "id": "ann-800-1",
+    "id": "ann-800-overview",
     "proofId": "erdos-800",
-    "range": { "startLine": 57, "endLine": 58 },
-    "type": "definition",
-    "title": "Vertex Degree",
-    "content": "**vertexDegree G v** counts edges incident to vertex v. In a simple graph, this equals |N(v)|, the size of the neighborhood. Degree is fundamental to the structural condition in this problem.",
-    "significance": "critical",
-    "relatedConcepts": ["Neighborhood", "Adjacency", "Graph structure"]
+    "range": { "startLine": 1, "endLine": 34 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #800: Linear Ramsey Numbers**\n\nIf G has no two adjacent vertices of degree ≥ 3, then R(G) ≪ n.\n\n**Solution (Alon, 1994):** R(G) ≤ 12n using the probabilistic method.\n\nThis includes all subdivided graphs. The result is a special case of the Burr-Erdős conjecture (Problem #163), fully resolved by Lee (2016).",
+    "significance": "critical"
   },
   {
-    "id": "ann-800-2",
+    "id": "ann-800-structural",
     "proofId": "erdos-800",
-    "range": { "startLine": 64, "endLine": 65 },
+    "range": { "startLine": 57, "endLine": 73 },
     "type": "definition",
-    "title": "High-Degree Vertex",
-    "content": "**isHighDegree G v** means deg(v) ≥ 3 in graph G. The threshold 3 is crucial: degree-2 vertices are 'subdivision vertices' that can be inserted to separate high-degree vertices.",
-    "significance": "critical",
-    "relatedConcepts": ["Subdivision", "Degree constraints", "Graph structure"]
+    "title": "The Structural Condition",
+    "content": "**vertexDegree, isHighDegree, noAdjacentHighDegree:**\n\nThe key condition is `noAdjacentHighDegree G`: no edge connects two vertices of degree ≥ 3. This means the high-degree vertices form an independent set.\n\nWhy degree 3? Degree-2 vertices are 'subdivision vertices' that can be inserted along edges to separate high-degree vertices. This captures exactly the class of subdivided graphs.",
+    "significance": "critical"
   },
   {
-    "id": "ann-800-3",
-    "proofId": "erdos-800",
-    "range": { "startLine": 72, "endLine": 73 },
-    "type": "definition",
-    "title": "No Adjacent High-Degree",
-    "content": "**noAdjacentHighDegree G** is the central structural condition: no edge connects two vertices of degree ≥ 3. This ensures high-degree vertices form an independent set, enabling probabilistic embedding.",
-    "significance": "critical",
-    "relatedConcepts": ["Independent set", "Subdivided graphs", "Structural restriction"]
-  },
-  {
-    "id": "ann-800-4",
-    "proofId": "erdos-800",
-    "range": { "startLine": 84, "endLine": 85 },
-    "type": "definition",
-    "title": "Subdivision Vertex",
-    "content": "**isSubdivisionVertex G v** means deg(v) = 2. When a graph is subdivided, new degree-2 vertices are inserted along each edge, separating the original high-degree vertices.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-800-5",
+    "id": "ann-800-subdivision",
     "proofId": "erdos-800",
     "range": { "startLine": 100, "endLine": 105 },
     "type": "theorem",
-    "title": "Subdivision Implies Condition",
-    "content": "**subdivision_implies_no_adjacent_high_degree** shows that if all neighbors of high-degree vertices have degree ≤ 2, then no two high-degree vertices are adjacent. This captures the essence of subdivided graphs.",
+    "title": "Subdivision Implies Condition (Proved)",
+    "content": "**subdivision_implies_no_adjacent_high_degree (proved in Lean):**\n\nIf every neighbor of a high-degree vertex has degree ≤ 2, then no two high-degree vertices are adjacent. Proved by contradiction using `omega`.\n\nThis verified theorem establishes that subdivided graphs satisfy the structural condition required for Alon's theorem.",
     "significance": "critical"
   },
   {
-    "id": "ann-800-6",
+    "id": "ann-800-ramsey",
     "proofId": "erdos-800",
-    "range": { "startLine": 115, "endLine": 118 },
+    "range": { "startLine": 115, "endLine": 162 },
     "type": "definition",
-    "title": "Complete Graph",
-    "content": "**completeGraph N** is K_N where every pair of distinct vertices is adjacent. The Ramsey number R(G) asks: how large must N be so that any 2-coloring of K_N contains monochromatic G?",
-    "significance": "critical",
-    "relatedConcepts": ["Ramsey theory", "Edge coloring", "Monochromatic subgraph"]
-  },
-  {
-    "id": "ann-800-7",
-    "proofId": "erdos-800",
-    "range": { "startLine": 124, "endLine": 124 },
-    "type": "definition",
-    "title": "Edge Coloring",
-    "content": "**edgeColoring N** assigns a color (true/false for red/blue) to each pair of vertices in K_N. Ramsey theory studies when monochromatic structures must appear regardless of the coloring.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-800-8",
-    "proofId": "erdos-800",
-    "range": { "startLine": 130, "endLine": 132 },
-    "type": "definition",
-    "title": "Monochromatic Copy",
-    "content": "**isMonochromatic N c f G** means all edges of G (under embedding f) have the same color in coloring c. Either all red or all blue - this is what Ramsey numbers guarantee must exist.",
+    "title": "Ramsey Number Infrastructure",
+    "content": "**completeGraph, edgeColoring, isMonochromatic, containsMonochromaticCopy, ramseyNumber:**\n\nR(G) = minimum N such that every 2-coloring of K_N contains a monochromatic copy of G. The Ramsey number is axiomatized along with its specification (ramseyNumber_spec), since formalizing existence via the finite Ramsey theorem requires substantial infrastructure.\n\n**hasLinearRamseyNumber G C** means R(G) ≤ C·n — the best possible growth rate for graphs with Ω(n) edges.",
     "significance": "critical"
   },
   {
-    "id": "ann-800-9",
+    "id": "ann-800-alon",
     "proofId": "erdos-800",
-    "range": { "startLine": 146, "endLine": 151 },
-    "type": "definition",
-    "title": "Ramsey Number",
-    "content": "**ramseyNumber G** = R(G) is the minimum N such that every 2-coloring of K_N contains a monochromatic copy of G. Computing R(G) exactly is notoriously difficult; even R(K_5) is unknown!",
-    "significance": "critical",
-    "relatedConcepts": ["Ramsey theory", "Extremal combinatorics", "Complete graphs"]
-  },
-  {
-    "id": "ann-800-10",
-    "proofId": "erdos-800",
-    "range": { "startLine": 157, "endLine": 158 },
-    "type": "definition",
-    "title": "Linear Ramsey Number",
-    "content": "**hasLinearRamseyNumber G C** means R(G) ≤ C·n where n = |V(G)|. Linear growth is the best possible for graphs with Ω(n) edges. Many natural sparse graphs have linear Ramsey numbers.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-800-11",
-    "proofId": "erdos-800",
-    "range": { "startLine": 172, "endLine": 173 },
+    "range": { "startLine": 176, "endLine": 187 },
     "type": "axiom",
-    "title": "Alon's Theorem",
-    "content": "**alon_theorem** (1994): If G has no adjacent high-degree vertices, then R(G) ≤ 12n. This is the main result solving Erdős Problem #800. The explicit constant 12 comes from probabilistic analysis.",
+    "title": "Alon's Theorem (1994)",
+    "content": "**alon_theorem (axiom):**\n\nIf G has no adjacent high-degree vertices, then R(G) ≤ 12n.\n\nThe proof uses the probabilistic method:\n1. High-degree vertices form an independent set H\n2. Randomly embed H into K_N\n3. Deterministically extend along paths of degree-2 vertices\n4. The constant 12 = 2 (colors) × 6 (probabilistic counting)\n\n**subdivided_graphs_linear_ramsey (proved):** Corollary applying this to subdivided graphs.",
     "significance": "critical"
   },
   {
-    "id": "ann-800-12",
+    "id": "ann-800-degeneracy",
     "proofId": "erdos-800",
-    "range": { "startLine": 179, "endLine": 183 },
-    "type": "theorem",
-    "title": "Subdivided Graphs Corollary",
-    "content": "**subdivided_graphs_linear_ramsey** shows any subdivided graph has linear Ramsey number. Subdividing each edge once ensures no adjacent high-degree vertices, so Alon's theorem applies.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-800-13",
-    "proofId": "erdos-800",
-    "range": { "startLine": 193, "endLine": 195 },
+    "range": { "startLine": 197, "endLine": 232 },
     "type": "definition",
-    "title": "Graph Degeneracy",
-    "content": "**isDegenerateAt G p** means G is p-degenerate: every induced subgraph has a vertex of degree ≤ p. Equivalently, vertices can be ordered so each has ≤ p later neighbors. Trees are 1-degenerate.",
-    "significance": "critical",
-    "relatedConcepts": ["Sparse graphs", "Ordering", "Burr-Erdős conjecture"]
+    "title": "Degeneracy and Burr-Erdős",
+    "content": "**isDegenerateAt G p:** Every subgraph has a vertex of degree ≤ p.\n\n**no_adjacent_high_degree_is_2_degenerate (axiom):** Graphs satisfying the structural condition are 2-degenerate.\n\n**burr_erdos_theorem (axiom, Lee 2016):** Every p-degenerate n-vertex graph has R(G) ≤ c_p · n.\n\n**erdos_800_special_case_of_163 (proved):** Problem #800 follows as the p=2 case of Burr-Erdős.",
+    "significance": "key"
   },
   {
-    "id": "ann-800-14",
+    "id": "ann-800-solution",
     "proofId": "erdos-800",
-    "range": { "startLine": 202, "endLine": 204 },
+    "range": { "startLine": 243, "endLine": 256 },
     "type": "theorem",
-    "title": "2-Degeneracy",
-    "content": "**no_adjacent_high_degree_is_2_degenerate** shows graphs with no adjacent high-degree vertices are 2-degenerate. This connects Problem #800 to the broader Burr-Erdős conjecture.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-800-15",
-    "proofId": "erdos-800",
-    "range": { "startLine": 213, "endLine": 216 },
-    "type": "axiom",
-    "title": "Burr-Erdős Theorem",
-    "content": "**burr_erdos_theorem** (Lee, 2016): Every p-degenerate n-vertex graph has R(G) ≤ c_p · n. This fully resolves the Burr-Erdős conjecture from 1975. Problem #800 is the p=2 case.",
-    "significance": "critical",
-    "relatedConcepts": ["Problem #163", "Degeneracy", "Linear Ramsey numbers"]
-  },
-  {
-    "id": "ann-800-16",
-    "proofId": "erdos-800",
-    "range": { "startLine": 223, "endLine": 229 },
-    "type": "theorem",
-    "title": "Special Case of #163",
-    "content": "**erdos_800_special_case_of_163** shows Problem #800 follows from the Burr-Erdős conjecture: graphs with no adjacent high-degree vertices are 2-degenerate, so Lee's theorem gives linear R(G).",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-800-17",
-    "proofId": "erdos-800",
-    "range": { "startLine": 235, "endLine": 253 },
-    "type": "concept",
-    "title": "Alon's Proof Technique",
-    "content": "**alon_proof_technique** outlines the proof: partition vertices into high-degree (H) and low-degree (L). H is independent, so use probabilistic embedding. L consists of paths/cycles for deterministic extension.",
+    "title": "Problem Statement and Solution",
+    "content": "**erdos800Problem:** Formalizes the problem as ∀ G with noAdjacentHighDegree, ∃ C, R(G) ≤ C·n.\n\n**erdos_800 (proved):** Solves the problem by invoking alon_theorem with constant 12. This is a fully verified proof modulo the axiomatized Ramsey number and Alon's bound.",
     "significance": "critical"
   },
   {
-    "id": "ann-800-18",
+    "id": "ann-800-summary",
     "proofId": "erdos-800",
-    "range": { "startLine": 256, "endLine": 263 },
-    "type": "concept",
-    "title": "The Constant 12",
-    "content": "**constant_12_explanation** explains the bound R(G) ≤ 12n: factor 2 for two colors times factor 6 from the probabilistic counting argument. The exact optimal constant remains unknown.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-800-19",
-    "proofId": "erdos-800",
-    "range": { "startLine": 363, "endLine": 366 },
-    "type": "definition",
-    "title": "Problem Statement",
-    "content": "**erdos800Problem** formalizes: for all graphs G with no adjacent high-degree vertices, R(G) grows linearly in n. This is the precise mathematical formulation of Erdős Problem #800.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-800-20",
-    "proofId": "erdos-800",
-    "range": { "startLine": 372, "endLine": 376 },
+    "range": { "startLine": 265, "endLine": 271 },
     "type": "theorem",
-    "title": "Solution",
-    "content": "**erdos_800** proves the problem: invoke Alon's theorem with constant 12. The result shows R(G) ≤ 12n for all graphs satisfying the structural condition, fully resolving the problem.",
+    "title": "Summary Theorem",
+    "content": "**erdos_800_summary (proved from axioms):**\n\nCombines:\n1. **Alon's explicit bound:** R(G) ≤ 12n for all G with no adjacent high-degree vertices\n2. **General existence:** erdos800Problem — every such graph has linear Ramsey number\n\nProved by: `⟨fun V _ _ G h => alon_theorem G h, erdos_800⟩`",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-800/meta.json
+++ b/src/data/proofs/erdos-800/meta.json
@@ -17,52 +17,84 @@
       "degeneracy",
       "probabilistic-method"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 800,
     "erdosUrl": "https://erdosproblems.com/800",
-    "erdosProblemStatus": "solved"
+    "erdosProblemStatus": "solved",
+    "mathlib_version": "4.15.0",
+    "dateAdded": "2026-01-19",
+    "mathlibDependencies": [
+      { "theorem": "SimpleGraph", "description": "Simple graph type and adjacency", "module": "Mathlib.Combinatorics.SimpleGraph.Basic" },
+      { "theorem": "SimpleGraph.neighborFinset", "description": "Finite neighborhood sets", "module": "Mathlib.Combinatorics.SimpleGraph.Basic" },
+      { "theorem": "Fintype", "description": "Finite types for vertex sets", "module": "Mathlib.Data.Fintype.Basic" },
+      { "theorem": "Real", "description": "Real numbers for Ramsey bounds", "module": "Mathlib.Data.Real.Basic" }
+    ],
+    "originalContributions": [
+      "vertexDegree, isHighDegree, noAdjacentHighDegree predicates",
+      "isSubdivisionVertex, isOriginalVertex definitions",
+      "subdivision_implies_no_adjacent_high_degree (proved)",
+      "Ramsey number infrastructure: completeGraph, edgeColoring, isMonochromatic, containsMonochromaticCopy",
+      "ramseyNumber and ramseyNumber_spec axioms",
+      "alon_theorem axiom with explicit bound R(G) ≤ 12n",
+      "isDegenerateAt and connection to Burr-Erdős conjecture",
+      "erdos_800 theorem and erdos_800_summary"
+    ]
   },
   "overview": {
-    "historicalContext": "This problem was posed by Burr and Erdős in 1975 as part of their broader conjecture about Ramsey numbers of sparse graphs. It asks whether graphs with a specific structural restriction—no two adjacent vertices of high degree—have Ramsey numbers growing linearly in the number of vertices. This is a special case of the Burr-Erdős conjecture (Problem #163), which concerns p-degenerate graphs.",
+    "historicalContext": "This problem was posed by Burr and Erdős in 1975 as part of their broader conjecture about Ramsey numbers of sparse graphs. The Ramsey number R(G) is the minimum N such that any 2-coloring of the edges of K_N contains a monochromatic copy of G. Burr and Erdős conjectured that p-degenerate graphs have linear Ramsey numbers.\n\nNoga Alon solved Problem #800 in 1994, proving that graphs with no two adjacent vertices of degree ≥ 3 satisfy R(G) ≤ 12n. His proof uses the probabilistic method: since the high-degree vertices form an independent set, they can be randomly embedded into a large complete graph, with paths of low-degree vertices extended deterministically. The constant 12 arises from a factor of 2 (for the two colors) times 6 (from the probabilistic counting).\n\nThis result is a special case of the Burr-Erdős conjecture (Problem #163), which was fully resolved by Choongbum Lee in 2016. Lee proved that every p-degenerate n-vertex graph has Ramsey number at most 2^{2^{O(p)}} · n, confirming the linear growth in n that Burr and Erdős predicted.",
     "problemStatement": "If G is a graph on n vertices which has no two adjacent vertices of degree ≥ 3, then R(G) ≪ n, where R(G) is the Ramsey number (minimum N such that any 2-coloring of K_N contains a monochromatic copy of G) and the implied constant is absolute.",
-    "proofStrategy": "Alon's proof uses the probabilistic method. The key observation is that high-degree vertices form an independent set. Randomly embed these vertices into the complete graph, then deterministically extend along paths of low-degree vertices. Careful counting yields the bound R(G) ≤ 12n.",
+    "proofStrategy": "Alon's proof uses the probabilistic method. The key observation is that high-degree vertices form an independent set. Randomly embed these vertices into the complete graph, then deterministically extend along paths of low-degree vertices. Careful counting yields the bound R(G) ≤ 12n. The formalization axiomatizes the Ramsey number and Alon's bound, while proving the connection between subdivisions and the structural condition, and the relationship to the Burr-Erdős conjecture.",
     "keyInsights": [
-      "Graphs with no adjacent high-degree vertices include all subdivided graphs (where each edge is subdivided at least once)",
-      "The high-degree vertices (degree ≥ 3) form an independent set due to the structural constraint",
+      "Graphs with no adjacent high-degree vertices include all subdivided graphs",
+      "The high-degree vertices form an independent set, enabling probabilistic embedding",
       "Such graphs are 2-degenerate, connecting to the broader Burr-Erdős conjecture",
-      "The probabilistic embedding of the independent set of high-degree vertices is the key technique",
-      "The constant 12 comes from a factor of 2 (two colors) times 6 (from the probabilistic analysis)"
+      "The constant 12 comes from factor 2 (colors) × 6 (probabilistic analysis)",
+      "Lee (2016) fully resolved the general Burr-Erdős conjecture (Problem #163)"
     ]
   },
   "sections": [
     {
-      "id": "ramsey-background",
-      "title": "Background: Ramsey Numbers",
-      "summary": "Definition and significance of Ramsey numbers in graph theory",
+      "id": "basic-definitions",
+      "title": "Basic Definitions",
+      "startLine": 47,
+      "endLine": 73,
+      "summary": "vertexDegree, isHighDegree, noAdjacentHighDegree"
+    },
+    {
+      "id": "subdivisions",
+      "title": "Subdivisions",
+      "startLine": 75,
+      "endLine": 105,
+      "summary": "isSubdivisionVertex, isOriginalVertex, subdivision_implies_no_adjacent_high_degree (proved)"
+    },
+    {
+      "id": "ramsey-numbers",
+      "title": "Ramsey Numbers",
       "startLine": 107,
-      "endLine": 159
+      "endLine": 162,
+      "summary": "completeGraph, edgeColoring, isMonochromatic, ramseyNumber axiom, hasLinearRamseyNumber"
     },
     {
-      "id": "structural-condition",
-      "title": "The Structural Condition",
-      "summary": "No adjacent vertices of degree ≥ 3 captures subdivided graphs",
-      "startLine": 67,
-      "endLine": 105
+      "id": "main-theorem",
+      "title": "The Main Theorem",
+      "startLine": 164,
+      "endLine": 187,
+      "summary": "alon_theorem axiom (R(G) ≤ 12n), subdivided_graphs_linear_ramsey corollary"
     },
     {
-      "id": "alon-solution",
-      "title": "Alon's Theorem (1994)",
-      "summary": "Main result: R(G) ≤ 12n using probabilistic embedding",
-      "startLine": 160,
-      "endLine": 183
+      "id": "degeneracy",
+      "title": "Degeneracy and Burr-Erdős Conjecture",
+      "startLine": 189,
+      "endLine": 232,
+      "summary": "isDegenerateAt, 2-degeneracy, burr_erdos_theorem, erdos_800_special_case_of_163"
     },
     {
-      "id": "burr-erdos",
-      "title": "Connection to Burr-Erdős Conjecture",
-      "summary": "Problem #800 as a special case of the broader conjecture on degenerate graphs",
-      "startLine": 185,
-      "endLine": 229
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 234,
+      "endLine": 273,
+      "summary": "erdos800Problem, erdos_800, erdos_800_summary combining Alon bound with general result"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove 14 trivial `True` axioms (proof techniques, examples, connections, later developments)
- Remove `True := trivial` theorem (`erdos_800_solved`)
- Convert `ramseyNumber` from `Nat.find` with `sorry` to axiom + `ramseyNumber_spec`
- Convert `no_adjacent_high_degree_is_2_degenerate` from `sorry` proof to axiom
- Fix all `/-` section headers to `/-!` doc comments
- Add proper summary theorem combining Alon's bound with general existence
- Update meta.json: `badge` → `axiom`, 3-paragraph historicalContext, correct section line ranges
- Update annotations.json with 8 aligned, substantive annotations

## Test plan
- [x] `pnpm build` succeeds with no errors
- [x] No `sorry` in Lean file
- [x] No trivial `True` axioms or `True := trivial`
- [x] All annotation and section line ranges match actual Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)