### PR TITLE
enhance(erdos-683): fix quality issues in Prime Divisors of Binomials

### DIFF
--- a/proofs/Proofs/Erdos683Problem.lean
+++ b/proofs/Proofs/Erdos683Problem.lean
@@ -150,12 +150,6 @@ def erdosConjecture683 : Prop :=
     (P n k : ℝ) ≥ min (n - k + 1 : ℝ) ((k : ℝ) ^ (1 + c))
 
 /--
-**Current Status:**
-This conjecture remains OPEN.
--/
-axiom conjecture_683_open : ¬ Decidable erdosConjecture683
-
-/--
 **Erdős (1979) Strengthening:**
 Erdős wrote it "seems certain" that for any c > 0,
   P(C(n,k)) ≫ k^{1+c}
@@ -196,17 +190,6 @@ axiom heuristic_stronger_than_conjecture (c : ℝ) (hc : c > 0) :
 /-!
 ## Part VI: The min(n-k+1, k^{1+c}) Bound
 -/
-
-/--
-**Why min(n-k+1, k^{1+c})?**
-Two regimes:
-1. k small: The product (n-k+1)···n of k terms has prime divisor > k^{1+c}
-2. k close to n/2: Use n-k+1 as the obvious bound since n-k+1 ≤ P(C(n,k))
--/
-theorem min_bound_explanation (n k : ℕ) (hk : 1 ≤ k) (hkn : k ≤ n) :
-    -- n-k+1 is the smallest factor in the numerator of C(n,k) = n!/(k!(n-k)!)
-    -- = (n-k+1)(n-k+2)···n / k!
-    True := trivial
 
 /--
 **Trivial Upper Bound:**
@@ -266,69 +249,31 @@ axiom small_k_case_2 (n : ℕ) (hn : n ≥ 4) :
     P n 2 ≥ (n - 1) / 2
 
 /-!
-## Part IX: Related Problem 961
+## Part IX: Summary
 -/
 
 /--
-**Problem 961 Equivalence:**
-Problem 683 is essentially equivalent to Problem 961.
--/
-axiom equivalent_to_961 : True
+**Erdős Problem #683: Summary**
 
-/--
-**Problem 961 Statement (for reference):**
-Similar bounds on prime divisors of binomial coefficients,
-focusing on different parameter ranges.
--/
-axiom problem_961_statement : True
-
-/-!
-## Part X: Summary
--/
-
-/--
-**Summary of Known Bounds:**
-1. Sylvester-Schur: P(C(n,k)) > k [PROVEN]
-2. Erdős 1955: P(C(n,k)) ≫ k log k [PROVEN]
-3. Erdős conjecture: P(C(n,k)) ≥ min(n-k+1, k^{1+c}) [OPEN]
-4. Heuristic: P(C(n,k)) > e^{c√k} [CONJECTURED]
--/
-theorem erdos_683_summary :
-    -- Sylvester-Schur proven
-    True ∧
-    -- Erdős 1955 proven
-    True ∧
-    -- Main conjecture open
-    True := ⟨trivial, trivial, trivial⟩
-
-/--
-**Erdős Problem #683: OPEN**
-
-**QUESTION:** For every 1 ≤ k ≤ n, is there a constant c > 0 such that
+QUESTION: For every 1 ≤ k ≤ n, is there a constant c > 0 such that
   P(C(n,k)) ≥ min(n - k + 1, k^{1+c})?
 
-**KNOWN:**
+KNOWN:
 - P(C(n,k)) > k for k ≤ n/2 (Sylvester-Schur 1892/1929)
 - P(C(n,k)) ≫ k log k (Erdős 1955)
 - For any c > 0, P(C(n,k)) > k^{1+c} with finitely many exceptions (believed)
 
-**HEURISTIC:**
+HEURISTIC:
 - P(C(n,k)) > e^{c√k} (from prime gap statistics)
 
-**KEY INSIGHT:**
-The binomial coefficient C(n,k) is divisible by primes that appear
-in the numerator (n-k+1)···n but are canceled in k!. Understanding
-the prime factorization of products of consecutive integers is key.
+STATUS: OPEN
 -/
-theorem erdos_683 : True := trivial
-
-/--
-**Historical Note:**
-This problem connects number theory (prime distribution) with
-combinatorics (binomial coefficients). The Sylvester-Schur theorem
-from 1892/1929 was a starting point, improved by Erdős over decades.
-The full conjecture remains elusive despite much progress.
--/
-theorem historical_note : True := trivial
+theorem erdos_683_summary :
+    -- Sylvester-Schur: P(C(n,k)) > k
+    (∀ n k : ℕ, 1 ≤ k → 2 * k ≤ n → P n k > k) ∧
+    -- Erdős 1955: P(C(n,k)) ≫ k log k
+    (∃ c : ℝ, c > 0 ∧ ∀ n k : ℕ, 1 ≤ k → 2 * k ≤ n →
+      (P n k : ℝ) ≥ c * k * Real.log k) :=
+  ⟨fun n k hk hn => sylvester_schur hk hn, erdos_1955_bound⟩
 
 end Erdos683

--- a/src/data/proofs/erdos-683/annotations.json
+++ b/src/data/proofs/erdos-683/annotations.json
@@ -1,137 +1,83 @@
 [
   {
-    "id": "largest-prime-divisor",
+    "id": "ann-683-overview",
     "proofId": "erdos-683",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #683: Largest Prime Divisor of C(n,k)**\n\nIs P(C(n,k)) ≥ min(n-k+1, k^{1+c}) for some c > 0?\n\n**Known:** P(C(n,k)) > k (Sylvester-Schur) and P(C(n,k)) ≫ k log k (Erdős 1955).\n**Believed:** P(C(n,k)) > k^{1+c} with finitely many exceptions for any c > 0.\n**Heuristic:** P(C(n,k)) > e^{c√k} from prime gap statistics.\n\n**STATUS: OPEN.** Related to Problem #961 (essentially equivalent).",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-683-largest-prime",
+    "proofId": "erdos-683",
+    "range": { "startLine": 49, "endLine": 78 },
     "type": "definition",
-    "range": { "startLine": 49, "endLine": 53 },
     "title": "Largest Prime Divisor P(n)",
-    "content": "P(n) is the largest prime dividing n. For example, P(30) = 5 since 30 = 2·3·5. This is the central object of study - we want to understand how large P(C(n,k)) can be.",
+    "content": "**largestPrimeDivisor and P(C(n,k)):**\n\nP(n) = largest prime dividing n (1 if n ≤ 1). Three key properties axiomatized:\n- P_is_prime: P(n) is prime when n > 1\n- P_divides: P(n) divides n\n- P_largest: P(n) is maximal among prime divisors\n\nP(n,k) = P(C(n,k)) = largest prime divisor of the binomial coefficient.",
     "significance": "critical"
   },
   {
-    "id": "p-binom",
+    "id": "ann-683-sylvester-schur",
     "proofId": "erdos-683",
-    "type": "definition",
-    "range": { "startLine": 58, "endLine": 59 },
-    "title": "P(C(n,k)) for Binomials",
-    "content": "The largest prime divisor of the binomial coefficient C(n,k) = n!/(k!(n-k)!). The question asks: how large must this prime be in terms of n and k?",
-    "significance": "critical"
-  },
-  {
-    "id": "sylvester-schur",
-    "proofId": "erdos-683",
+    "range": { "startLine": 93, "endLine": 113 },
     "type": "theorem",
-    "range": { "startLine": 93, "endLine": 98 },
     "title": "Sylvester-Schur Theorem",
-    "content": "For k ≤ n/2, P(C(n,k)) > k. This foundational result from 1892/1929 says the binomial coefficient always has a 'large' prime divisor exceeding k. The proof uses properties of products of consecutive integers.",
+    "content": "**sylvester_schur (axiom):** P(C(n,k)) > k for k ≤ n/2.\n\nThe product (n-k+1)···n of k consecutive integers > k must contain a prime > k. This foundational result from 1892/1929 is the starting point.\n\n**binom_has_large_prime (proved):** Derives the existential form ∃ p, p.Prime ∧ p ∣ C(n,k) ∧ p > k from the Sylvester-Schur axiom.",
     "significance": "critical"
   },
   {
-    "id": "choose-gt-one",
+    "id": "ann-683-erdos-1955",
     "proofId": "erdos-683",
+    "range": { "startLine": 126, "endLine": 137 },
     "type": "theorem",
-    "range": { "startLine": 100, "endLine": 105 },
-    "title": "Binomial Coefficient > 1",
-    "content": "For 1 ≤ k ≤ n/2, the binomial coefficient C(n,k) is at least 2. This ensures that P(C(n,k)) is well-defined as a prime.",
-    "significance": "supporting"
-  },
-  {
-    "id": "erdos-1955",
-    "proofId": "erdos-683",
-    "type": "theorem",
-    "range": { "startLine": 125, "endLine": 134 },
-    "title": "Erdős 1955 Improvement",
-    "content": "P(C(n,k)) ≫ k log k for k ≤ n/2. This is a significant strengthening of Sylvester-Schur - the prime divisor exceeds not just k, but c·k·log k for some constant c > 0.",
+    "title": "Erdős 1955: P ≫ k log k",
+    "content": "**erdos_1955_bound (axiom):** ∃ c > 0 such that P(C(n,k)) ≥ c·k·log k for k ≤ n/2.\n\nA significant improvement over Sylvester-Schur — the prime divisor exceeds not just k, but c·k·log k.\n\n**erdos_1955_asymptotic (proved):** Instantiates the bound for specific n, k from the existential axiom.",
     "significance": "critical"
   },
   {
-    "id": "main-conjecture",
+    "id": "ann-683-conjecture",
     "proofId": "erdos-683",
+    "range": { "startLine": 148, "endLine": 161 },
     "type": "concept",
-    "range": { "startLine": 149, "endLine": 156 },
     "title": "The Main Conjecture (OPEN)",
-    "content": "Erdős conjectured P(C(n,k)) ≥ min(n-k+1, k^{1+c}) for some c > 0. The minimum captures two regimes: near k=n/2 use n-k+1, for small k use k^{1+c}. This remains OPEN.",
+    "content": "**erdosConjecture683:** ∃ c > 0, ∀ n k, P(C(n,k)) ≥ min(n-k+1, k^{1+c}).\n\nThe minimum captures two regimes:\n- k small relative to n: the product has k terms, expect a prime > k^{1+c}\n- k close to n/2: use n-k+1 as a natural bound\n\n**erdos_1979_belief:** For ANY c > 0, the bound k^{1+c} holds with finitely many exceptions. This is even stronger than the main conjecture.",
     "significance": "critical"
   },
   {
-    "id": "erdos-1979",
+    "id": "ann-683-heuristic",
     "proofId": "erdos-683",
-    "type": "theorem",
-    "range": { "startLine": 165, "endLine": 173 },
-    "title": "Erdős 1979 Belief",
-    "content": "Erdős wrote it 'seems certain' that for ANY c > 0, we have P(C(n,k)) > k^{1+c} with only finitely many exceptions (depending on c). This is even stronger than the main conjecture.",
-    "significance": "key"
-  },
-  {
-    "id": "prime-gap-heuristic",
-    "proofId": "erdos-683",
-    "type": "concept",
-    "range": { "startLine": 179, "endLine": 190 },
+    "range": { "startLine": 175, "endLine": 188 },
+    "type": "axiom",
     "title": "Prime Gap Heuristic",
-    "content": "Standard prime gap heuristics suggest P(C(n,k)) > e^{c√k}, which is much stronger than k^{1+c}. This 'stretched exponential' growth would far exceed polynomial bounds.",
+    "content": "**prime_gap_heuristic:** P(C(n,k)) > e^{c√k} for some c > 0, eventually.\n\nThis stretched exponential bound is far stronger than polynomial k^{1+c}.\n\n**heuristic_stronger_than_conjecture:** Proves e^{c√k} > k^{1+c} eventually — the heuristic dominates the conjecture for large k.",
     "significance": "key"
   },
   {
-    "id": "heuristic-comparison",
+    "id": "ann-683-consecutive",
     "proofId": "erdos-683",
-    "type": "theorem",
-    "range": { "startLine": 192, "endLine": 200 },
-    "title": "Heuristic vs Conjecture Comparison",
-    "content": "e^{c√k} grows much faster than k^{1+c}. The stretched exponential eventually dominates any polynomial growth, showing the heuristic bound is much stronger.",
-    "significance": "supporting"
-  },
-  {
-    "id": "consecutive-product",
-    "proofId": "erdos-683",
+    "range": { "startLine": 210, "endLine": 227 },
     "type": "definition",
-    "range": { "startLine": 233, "endLine": 234 },
-    "title": "Consecutive Products",
-    "content": "The numerator of C(n,k) = (n-k+1)(n-k+2)···n / k! is a product of k consecutive integers. Understanding prime factors of such products is key to the problem.",
+    "title": "Consecutive Products and Bertrand",
+    "content": "**consecutiveProduct m k:** The product (m)(m+1)···(m+k-1) of k consecutive integers.\n\nC(n,k) = (n-k+1)···n / k! — the numerator is such a product.\n\n**bertrand_for_central:** P(C(2n,n)) > n, from Bertrand's postulate (there's always a prime between n and 2n).\n\n**consecutive_has_large_prime:** Among k consecutive integers starting at m > k, at least one has a prime divisor > k.",
     "significance": "key"
   },
   {
-    "id": "bertrand",
+    "id": "ann-683-specific",
     "proofId": "erdos-683",
-    "type": "theorem",
-    "range": { "startLine": 236, "endLine": 242 },
-    "title": "Bertrand's Postulate Connection",
-    "content": "Bertrand's postulate (Chebyshev's theorem) says there's a prime between n and 2n. This implies P(C(2n,n)) > n for the central binomial coefficient - a special case of Sylvester-Schur.",
+    "range": { "startLine": 238, "endLine": 249 },
+    "type": "axiom",
+    "title": "Specific Cases",
+    "content": "**central_binom_bound:** P(C(2k,k)) > (4/3)k for large k. The central binomial coefficient has particularly large prime divisors.\n\n**small_k_case_2:** P(C(n,2)) ≥ (n-1)/2 for n ≥ 4. Since C(n,2) = n(n-1)/2, one of n or n-1 has a large prime factor.",
     "significance": "supporting"
   },
   {
-    "id": "central-binom",
+    "id": "ann-683-summary",
     "proofId": "erdos-683",
+    "range": { "startLine": 271, "endLine": 277 },
     "type": "theorem",
-    "range": { "startLine": 260, "endLine": 263 },
-    "title": "Central Binomial Bound",
-    "content": "Erdős proved P(C(2k,k)) > (4/3)k for large k. The central binomial coefficient has particularly large prime divisors.",
-    "significance": "key"
-  },
-  {
-    "id": "small-k-case",
-    "proofId": "erdos-683",
-    "type": "theorem",
-    "range": { "startLine": 265, "endLine": 272 },
-    "title": "Small k Case (k=2)",
-    "content": "For k=2: P(C(n,2)) = P(n(n-1)/2) ≥ (n-1)/2. Since either n or n-1 has a prime factor of this size.",
-    "significance": "supporting"
-  },
-  {
-    "id": "related-961",
-    "proofId": "erdos-683",
-    "type": "concept",
-    "range": { "startLine": 278, "endLine": 289 },
-    "title": "Equivalence to Problem 961",
-    "content": "Problems 683 and 961 are essentially equivalent, asking about prime divisors of binomial coefficients from different perspectives.",
-    "significance": "supporting"
-  },
-  {
-    "id": "main-summary",
-    "proofId": "erdos-683",
-    "type": "theorem",
-    "range": { "startLine": 310, "endLine": 329 },
-    "title": "Main Result: erdos_683",
-    "content": "Summary: Sylvester-Schur gives P(C(n,k)) > k (proven), Erdős improved to ≫ k log k (proven), the conjecture min(n-k+1, k^{1+c}) remains OPEN. Problem 961 is equivalent.",
+    "title": "Summary Theorem",
+    "content": "**erdos_683_summary (proved from axioms):**\n\nCombines the two proven bounds:\n1. **Sylvester-Schur:** ∀ n k, 1 ≤ k → 2k ≤ n → P(C(n,k)) > k\n2. **Erdős 1955:** ∃ c > 0, ∀ n k, P(C(n,k)) ≥ c·k·log k\n\nProved by: `⟨fun n k hk hn => sylvester_schur hk hn, erdos_1955_bound⟩`",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-683/meta.json
+++ b/src/data/proofs/erdos-683/meta.json
@@ -15,33 +15,31 @@
     "erdosNumber": 683,
     "erdosUrl": "https://erdosproblems.com/683",
     "erdosProblemStatus": "open",
-    "mathlib_version": "4.26.0",
-    "dateAdded": "2026-01-22",
+    "mathlib_version": "4.15.0",
+    "dateAdded": "2026-01-19",
     "mathlibDependencies": [
       { "theorem": "Nat.choose", "description": "Binomial coefficients", "module": "Mathlib.Data.Nat.Choose.Basic" },
       { "theorem": "Nat.Prime", "description": "Prime numbers", "module": "Mathlib.Data.Nat.Prime.Basic" },
       { "theorem": "Real.log", "description": "Natural logarithm", "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic" },
-      { "theorem": "Real.rpow", "description": "Real exponentiation", "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real" },
-      { "theorem": "Finset.prod", "description": "Finite products", "module": "Mathlib.Algebra.BigOperators.Group.Finset" }
+      { "theorem": "Real.rpow", "description": "Real exponentiation", "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real" }
     ],
     "originalContributions": [
-      "largestPrimeDivisor: P(n) is the largest prime dividing n",
-      "P: Largest prime divisor of C(n,k)",
-      "sylvester_schur: P(C(n,k)) > k for k ≤ n/2",
-      "erdos_1955_bound: P(C(n,k)) ≥ c·k·log k",
-      "erdosConjecture683: The main open conjecture",
-      "erdos_1979_belief: k^{1+c} bound with finite exceptions",
-      "prime_gap_heuristic: e^{c√k} heuristic bound",
-      "consecutiveProduct: Product of k consecutive integers",
-      "bertrand_for_central: P(C(2n,n)) > n",
-      "central_binom_bound: P(C(2k,k)) > (4/3)k"
-    ],
-    "dateAdded": "2026-01-19"
+      "largestPrimeDivisor with P_is_prime, P_divides, P_largest axioms",
+      "P(C(n,k)) applied to binomial coefficients",
+      "sylvester_schur axiom: P(C(n,k)) > k",
+      "erdos_1955_bound axiom: P(C(n,k)) ≥ c·k·log k",
+      "erdosConjecture683: the main open conjecture formalized",
+      "erdos_1979_belief: k^{1+c} with finite exceptions",
+      "prime_gap_heuristic and heuristic_stronger_than_conjecture",
+      "consecutiveProduct, bertrand_for_central, consecutive_has_large_prime",
+      "central_binom_bound and small_k_case_2",
+      "erdos_683_summary combining proven bounds"
+    ]
   },
   "overview": {
-    "historicalContext": "Sylvester (1892) and Schur (1929) proved that for k ≤ n/2, the binomial coefficient C(n,k) has a prime divisor exceeding k. Erdős improved this in 1934 and 1955, showing P(C(n,k)) ≫ k log k. In 1979, Erdős conjectured the stronger bound P(C(n,k)) ≥ min(n-k+1, k^{1+c}), which remains open.",
+    "historicalContext": "Sylvester (1892) proved that the product of k consecutive integers greater than k contains a prime factor exceeding k. Schur (1929) refined this to show that the binomial coefficient C(n,k) itself has such a large prime divisor. This foundational result — P(C(n,k)) > k for k ≤ n/2 — became the starting point for deeper investigations.\n\nErdős made this problem his own over several decades. In 1934 he gave a new proof of the Sylvester-Schur theorem. In 1955, he significantly improved the bound to P(C(n,k)) ≫ k log k. By 1979, he conjectured the much stronger bound P(C(n,k)) ≥ min(n-k+1, k^{1+c}) for some absolute constant c > 0, and wrote that it 'seems certain' that P(C(n,k)) > k^{1+c} holds with only finitely many exceptions for any c > 0.\n\nThe problem remains open despite substantial progress. Standard heuristics based on prime gap statistics suggest the even stronger bound P(C(n,k)) > e^{c√k}, a stretched exponential that far exceeds any polynomial growth. The problem connects number theory (prime distribution in consecutive products) with combinatorics (binomial coefficients), and is essentially equivalent to Problem #961.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nFor every 1 ≤ k ≤ n, is there a constant c > 0 such that:\n  P(C(n,k)) ≥ min(n - k + 1, k^{1+c})\n\nwhere P(m) denotes the largest prime divisor of m?\n\n**Known:**\n- P(C(n,k)) > k for k ≤ n/2 (Sylvester-Schur)\n- P(C(n,k)) ≫ k log k (Erdős 1955)\n\n**Believed:**\n- For any c > 0, P(C(n,k)) > k^{1+c} with finitely many exceptions",
-    "proofStrategy": "The formalization defines the largest prime divisor function P and applies it to binomial coefficients. The Sylvester-Schur theorem and Erdős's 1955 improvement are axiomatized. The main conjecture is stated but marked as open. Connections to products of consecutive integers and Bertrand's postulate are explored.",
+    "proofStrategy": "The formalization defines the largest prime divisor function P and applies it to binomial coefficients. The Sylvester-Schur theorem and Erdős's 1955 improvement are axiomatized with proper type signatures. The main conjecture is stated as a definition. Connections to products of consecutive integers, Bertrand's postulate, and specific cases (central binomial, k=2) are explored. The summary theorem combines the two proven bounds.",
     "keyInsights": [
       "**Sylvester-Schur:** P(C(n,k)) > k is the foundation",
       "**Erdős 1955:** P(C(n,k)) ≫ k log k is a significant improvement",
@@ -57,70 +55,63 @@
       "title": "Basic Definitions",
       "startLine": 41,
       "endLine": 78,
-      "summary": "Largest prime divisor P(n), P(C(n,k)) for binomials"
+      "summary": "largestPrimeDivisor, P(C(n,k)), P_is_prime, P_divides, P_largest"
     },
     {
       "id": "sylvester-schur",
       "title": "Sylvester-Schur Theorem",
       "startLine": 80,
-      "endLine": 110,
-      "summary": "P(C(n,k)) > k for k ≤ n/2"
+      "endLine": 113,
+      "summary": "sylvester_schur axiom, choose_gt_one, binom_has_large_prime (proved)"
     },
     {
       "id": "erdos-1955",
       "title": "Erdős's 1955 Improvement",
-      "startLine": 112,
-      "endLine": 134,
-      "summary": "P(C(n,k)) ≫ k log k"
+      "startLine": 115,
+      "endLine": 137,
+      "summary": "erdos_1955_bound axiom, erdos_1955_asymptotic (proved)"
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
-      "startLine": 136,
-      "endLine": 164,
-      "summary": "erdosConjecture683: min(n-k+1, k^{1+c}) bound (OPEN)"
+      "startLine": 139,
+      "endLine": 161,
+      "summary": "erdosConjecture683 (OPEN), erdos_1979_belief"
     },
     {
       "id": "heuristics",
       "title": "Heuristic Bounds",
-      "startLine": 166,
-      "endLine": 191,
-      "summary": "Prime gap heuristic: e^{c√k}"
+      "startLine": 163,
+      "endLine": 188,
+      "summary": "prime_gap_heuristic, heuristic_stronger_than_conjecture"
     },
     {
       "id": "min-bound",
       "title": "The min(n-k+1, k^{1+c}) Bound",
-      "startLine": 193,
-      "endLine": 213,
-      "summary": "Why the minimum of two terms"
+      "startLine": 190,
+      "endLine": 199,
+      "summary": "P_upper_bound axiom"
     },
     {
       "id": "consecutive",
       "title": "Products of Consecutive Integers",
-      "startLine": 215,
-      "endLine": 241,
-      "summary": "Connection to C(n,k) numerator, Bertrand's postulate"
+      "startLine": 201,
+      "endLine": 227,
+      "summary": "consecutiveProduct, bertrand_for_central, consecutive_has_large_prime"
     },
     {
       "id": "specific-cases",
       "title": "Specific Cases",
-      "startLine": 243,
-      "endLine": 263,
-      "summary": "Central binomial, small k cases"
-    },
-    {
-      "id": "related-961",
-      "title": "Related Problem 961",
-      "startLine": 265,
-      "endLine": 280,
-      "summary": "Equivalence to Problem 961"
+      "startLine": 229,
+      "endLine": 249,
+      "summary": "central_binom_bound, small_k_case_2"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 282,
-      "endLine": 331,
-      "summary": "Main theorem and historical note"
+      "startLine": 251,
+      "endLine": 279,
+      "summary": "erdos_683_summary combining sylvester_schur and erdos_1955_bound"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove nonsensical `conjecture_683_open : ¬ Decidable erdosConjecture683` axiom
- Remove 2 trivial `True` axioms (`equivalent_to_961`, `problem_961_statement`)
- Remove 3 `True := trivial` theorems (`min_bound_explanation`, `erdos_683`, `historical_note`)
- Replace `True ∧ True ∧ True` summary with proper theorem combining `sylvester_schur` and `erdos_1955_bound`
- Fix duplicate `dateAdded` in meta.json, update `mathlib_version` to 4.15.0
- Update meta.json: 3-paragraph historicalContext, correct section line ranges (9 sections)
- Update annotations.json with 9 aligned, substantive annotations

## Test plan
- [x] `pnpm build` succeeds with no errors
- [x] No `sorry` in Lean file
- [x] No trivial `True` axioms or `True := trivial`
- [x] All annotation and section line ranges match actual Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)