### PR TITLE
fix(erdos-970): fix section headers to /-!

### DIFF
--- a/proofs/Proofs/Erdos970Problem.lean
+++ b/proofs/Proofs/Erdos970Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
 Erdős Problem #970: Jacobsthal's Function
 
 Source: https://erdosproblems.com/970
@@ -37,7 +37,7 @@ open Real Nat
 
 namespace Erdos970
 
-/-
+/-!
 ## Part 1: Basic Definitions
 -/
 
@@ -55,7 +55,7 @@ def consecutiveInterval (a m : ℕ) : Finset ℕ :=
 def hasCoprimeElement (n a m : ℕ) : Prop :=
   ∃ x ∈ consecutiveInterval a m, Nat.Coprime x n
 
-/-
+/-!
 ## Part 2: Jacobsthal's Function
 
 The function h(k) is axiomatized since computing it requires deep number-theoretic
@@ -78,7 +78,7 @@ axiom h_spec : ∀ k : ℕ, k ≥ 1 →
 axiom h_minimal : ∀ k : ℕ, k ≥ 1 →
     ∀ m < h k, ∃ n : ℕ, hasAtMostKPrimes n k ∧ ∃ a : ℕ, ¬hasCoprimeElement n a m
 
-/-
+/-!
 ## Part 3: Jacobsthal's Conjecture (the main question)
 -/
 
@@ -86,7 +86,7 @@ axiom h_minimal : ∀ k : ℕ, k ≥ 1 →
 def jacobsthalConjecture : Prop :=
   ∃ C : ℝ, C > 0 ∧ ∀ k : ℕ, k ≥ 1 → (h k : ℝ) ≤ C * k^2
 
-/-
+/-!
 ## Part 4: Known Upper Bounds
 -/
 
@@ -107,7 +107,7 @@ theorem iwaniec_bound_form :
   ring_nf at this ⊢
   exact this
 
-/-
+/-!
 ## Part 5: Known Lower Bounds
 -/
 
@@ -124,7 +124,7 @@ axiom fgkmt_lower_bound :
     (h k : ℝ) ≥ c * k * (Real.log k) * (Real.log (Real.log (Real.log k))) /
                     (Real.log (Real.log k))^2
 
-/-
+/-!
 ## Part 6: Known Small Values
 -/
 
@@ -150,7 +150,7 @@ axiom jacobsthal_extremal_at_primorial :
     ∀ n : ℕ, hasAtMostKPrimes n k →
       ∃ m, hasCoprimeElement n 0 m ∧ m ≤ h k
 
-/-
+/-!
 ## Part 7: The conjecture h(k) ≪ k² is OPEN
 -/
 


### PR DESCRIPTION
## Summary
- Fixed 8 section headers from `/-` to `/-!` (file header + 7 part headers)

## Test plan
- [x] `pnpm build` succeeds
- [x] No bare `/-` section headers remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)