### PR TITLE
fix(erdos-475): Enhance Graham's Rearrangement Conjecture

### DIFF
--- a/proofs/Proofs/Erdos475Problem.lean
+++ b/proofs/Proofs/Erdos475Problem.lean
@@ -42,35 +42,39 @@ namespace Erdos475
 open Finset
 
 /-!
-## Part 1: Valid Orderings
+## Part I: Valid Orderings
 -/
 
-/-- A partial sum sequence: the cumulative sums of a list -/
+/-- A partial sum sequence: the cumulative sums of a list. -/
 def partialSums {G : Type*} [AddMonoid G] (l : List G) : List G :=
   l.scanl (· + ·) 0 |>.tail
 
-/-- An ordering of a set is valid if all partial sums are distinct -/
+/-- An ordering of a set is valid if all partial sums are distinct. -/
 def IsValidOrdering {p : ℕ} [Fact (Nat.Prime p)] (A : Finset (ZMod p))
     (ordering : List (ZMod p)) : Prop :=
   ordering.toFinset = A ∧
   ordering.Nodup ∧
   (partialSums ordering).Nodup
 
-/-- Graham's conjecture: every non-zero subset has a valid ordering -/
+/-- Graham's conjecture: every non-zero subset has a valid ordering. -/
 def GrahamConjecture (p : ℕ) [Fact (Nat.Prime p)] : Prop :=
   ∀ A : Finset (ZMod p), (∀ a ∈ A, a ≠ 0) →
     ∃ ordering : List (ZMod p), IsValidOrdering A ordering
 
 /-!
-## Part 2: Small Cases
+## Part II: Small Cases (Costa-Pellegrini 2020)
 -/
 
-/-- For t ≤ 12, the conjecture holds (Costa-Pellegrini 2020) -/
+/--
+**Costa-Pellegrini (2020):**
+For t ≤ 12, the conjecture holds. Verified through a combination of
+exhaustive computation for specific primes and theoretical reductions.
+-/
 axiom costa_pellegrini_2020 (p : ℕ) [Fact (Nat.Prime p)] (hp : p > 12) :
     ∀ A : Finset (ZMod p), A.card ≤ 12 → (∀ a ∈ A, a ≠ 0) →
       ∃ ordering : List (ZMod p), IsValidOrdering A ordering
 
-/-- Explicit valid orderings exist for small sets -/
+/-- Explicit valid orderings exist for small sets. -/
 theorem small_sets_have_valid_orderings (p : ℕ) [Fact (Nat.Prime p)]
     (A : Finset (ZMod p)) (hA : A.card ≤ 12) (hnonzero : ∀ a ∈ A, a ≠ 0)
     (hp : p > 12) :
@@ -78,156 +82,140 @@ theorem small_sets_have_valid_orderings (p : ℕ) [Fact (Nat.Prime p)]
   costa_pellegrini_2020 p hp A hA hnonzero
 
 /-!
-## Part 3: Large Cases (Near p)
+## Part III: Large Cases — Near p (Hicks-Ollis-Schmitt 2019)
 -/
 
-/-- For p - 3 ≤ t ≤ p - 1, the conjecture holds (Hicks-Ollis-Schmitt 2019) -/
+/--
+**Hicks-Ollis-Schmitt (2019):**
+For p - 3 ≤ t ≤ p - 1, the conjecture holds. When the set is
+nearly the entire non-zero field, structural arguments suffice.
+-/
 axiom hicks_ollis_schmitt_2019 (p : ℕ) [Fact (Nat.Prime p)] :
     ∀ A : Finset (ZMod p), p - 3 ≤ A.card ∧ A.card ≤ p - 1 →
       (∀ a ∈ A, a ≠ 0) →
       ∃ ordering : List (ZMod p), IsValidOrdering A ordering
 
-/-- Graham's original result: t = p - 1 works -/
+/--
+**Graham's Original Result:**
+The case t = p - 1 (the full non-zero set) was solved constructively
+by Graham, providing an explicit ordering.
+-/
 axiom graham_full_set (p : ℕ) [Fact (Nat.Prime p)] :
     let A := (Finset.univ : Finset (ZMod p)).filter (· ≠ 0)
     ∃ ordering : List (ZMod p), IsValidOrdering A ordering
 
 /-!
-## Part 4: Logarithmic Range (Kravitz 2024)
+## Part IV: Logarithmic Range (Kravitz 2024)
 -/
 
-/-- For t ≤ log p / log log p, the conjecture holds (Kravitz 2024) -/
+/--
+**Kravitz (2024):**
+For t ≤ log p / log log p, the conjecture holds.
+Will Sawin independently observed this bound on MathOverflow.
+This significantly extends beyond the constant bound of 12.
+-/
 axiom kravitz_2024 (p : ℕ) [Fact (Nat.Prime p)] (hp : p > 2) :
     ∀ A : Finset (ZMod p),
       (A.card : ℝ) ≤ Real.log p / Real.log (Real.log p) →
       (∀ a ∈ A, a ≠ 0) →
       ∃ ordering : List (ZMod p), IsValidOrdering A ordering
 
-/-- Will Sawin independently observed the log p / log log p bound -/
-theorem sawin_observation : True := trivial
-
 /-!
-## Part 5: Beyond the Rectification Barrier (Bedert-Kravitz 2024)
+## Part V: Beyond the Rectification Barrier (Bedert-Kravitz 2024)
+
+Previous methods hit a "rectification barrier" at log p / log log p.
+Bedert and Kravitz (2024) developed new techniques that go far beyond
+this barrier, reaching exp((log p)^{1/4}).
 -/
 
-/-- For t ≤ exp((log p)^{1/4}), the conjecture holds (Bedert-Kravitz 2024) -/
+/--
+**Bedert-Kravitz (2024):**
+For t ≤ exp((log p)^{1/4}), the conjecture holds.
+This is a major breakthrough beyond the rectification barrier.
+exp((log p)^{1/4}) ≫ log p / log log p for large p.
+-/
 axiom bedert_kravitz_2024 (p : ℕ) [Fact (Nat.Prime p)] (hp : p > 2) :
     ∀ A : Finset (ZMod p),
       (A.card : ℝ) ≤ Real.exp ((Real.log p) ^ (1/4 : ℝ)) →
       (∀ a ∈ A, a ≠ 0) →
       ∃ ordering : List (ZMod p), IsValidOrdering A ordering
 
-/-- The "rectification barrier" was a technical obstacle in earlier methods -/
-theorem rectification_barrier_explanation :
-    -- Previous methods had difficulty beyond log p / log log p
-    -- Bedert-Kravitz developed new techniques to go beyond this
-    True := trivial
-
-/-- Comparison: exp((log p)^{1/4}) >> log p / log log p -/
-theorem bedert_kravitz_improves_kravitz : True := trivial
-
 /-!
-## Part 6: Connection to Alspach's Conjecture
+## Part VI: Connection to Alspach's Conjecture
+
+Alspach generalized Graham's conjecture to arbitrary finite abelian groups.
+Graham's conjecture is precisely Alspach's conjecture for G = 𝔽ₚ.
 -/
 
-/-- Alspach's generalization to arbitrary abelian groups -/
+/-- Alspach's generalization to arbitrary abelian groups. -/
 def AlspachConjecture (G : Type*) [AddCommGroup G] [Fintype G] : Prop :=
   ∀ A : Finset G, (∀ a ∈ A, a ≠ 0) →
     ∃ ordering : List G, ordering.toFinset = A ∧ ordering.Nodup ∧
       (partialSums ordering).Nodup
 
-/-- Graham's conjecture is Alspach's conjecture for 𝔽ₚ -/
+/-- Graham's conjecture is Alspach's conjecture for 𝔽ₚ. -/
 theorem graham_is_alspach_for_prime_field (p : ℕ) [Fact (Nat.Prime p)] :
     GrahamConjecture p ↔ AlspachConjecture (ZMod p) := by
   constructor <;> intro h A hA <;> exact h A hA
 
-/-- Alspach's conjecture is open for general groups -/
-axiom alspach_open : True
-
 /-!
-## Part 7: The Case of Cyclic Groups
+## Part VII: Constructive vs Existential
+
+Some proofs provide explicit constructions of valid orderings,
+while others are purely existential.
 -/
 
-/-- For cyclic groups ℤ/nℤ, the problem is well-studied -/
-def CyclicGroupConjecture (n : ℕ) : Prop :=
-  ∀ A : Finset (ZMod n), (∀ a ∈ A, a ≠ 0) →
-    ∃ ordering : List (ZMod n), ordering.toFinset = A ∧ ordering.Nodup ∧
-      (partialSums ordering).Nodup
-
-/-- For prime n, this is Graham's conjecture -/
-theorem prime_cyclic_is_graham (p : ℕ) [Fact (Nat.Prime p)] :
-    CyclicGroupConjecture p ↔ GrahamConjecture p := by
-  sorry
-
-/-!
-## Part 8: Constructive vs Existential
--/
-
-/-- Some proofs give explicit constructions -/
+/-- Some proofs give explicit constructions. -/
 def HasExplicitValidOrdering {p : ℕ} [Fact (Nat.Prime p)]
     (A : Finset (ZMod p)) : Prop :=
   ∃ (f : Finset (ZMod p) → List (ZMod p)),
     IsValidOrdering A (f A)
 
-/-- Graham's proof for t = p - 1 was constructive -/
+/--
+**Graham's Constructive Proof:**
+Graham's proof for the full non-zero set t = p - 1 was constructive,
+giving an explicit algorithm to produce a valid ordering.
+-/
 axiom graham_constructive (p : ℕ) [Fact (Nat.Prime p)] :
     let A := (Finset.univ : Finset (ZMod p)).filter (· ≠ 0)
     HasExplicitValidOrdering A
 
-/-- Small cases are often verified by exhaustive search -/
-theorem small_cases_by_computation : True := trivial
-
 /-!
-## Part 9: What Makes This Hard?
+## Part VIII: Summary
+
+Graham's conjecture (Erdős Problem #475) has been proven for:
+- Small t (≤ 12): Costa-Pellegrini 2020
+- Large t (≥ p - 3): Hicks-Ollis-Schmitt 2019
+- Medium t (≤ exp((log p)^{1/4})): Bedert-Kravitz 2024
+
+The general case remains OPEN.
 -/
 
-/-- The number of possible orderings is t! -/
-theorem factorial_orderings (t : ℕ) :
-    -- There are t! orderings to check
-    -- But we need just ONE to work
-    True := trivial
+/--
+**Erdős Problem #475: Summary**
 
-/-- Partial sums must avoid p - 1 collisions in 𝔽ₚ -/
-theorem collision_avoidance :
-    -- In 𝔽ₚ, there are p possible sum values
-    -- We need t distinct values among 0, 1, ..., p-1
-    -- This is possible when t ≤ p, but finding the ordering is hard
-    True := trivial
-
-/-- The conjecture is about existence, not counting -/
-theorem existence_not_counting :
-    -- We don't ask how many valid orderings exist
-    -- Just whether at least one exists
-    True := trivial
-
-/-!
-## Part 10: Summary
+Combines the key axiomatized results:
+1. Small case: t ≤ 12 (Costa-Pellegrini)
+2. Large case: p - 3 ≤ t ≤ p - 1 (Hicks-Ollis-Schmitt)
+3. Medium case: t ≤ exp((log p)^{1/4}) (Bedert-Kravitz)
+4. Graham's original: t = p - 1 (constructive)
+5. Alspach equivalence: GrahamConjecture p ↔ AlspachConjecture (ZMod p)
 -/
-
-/-- Main theorem: Status of Graham's Conjecture (Problem #475) -/
-theorem erdos_475 :
-    -- Small cases: t ≤ 12 (Costa-Pellegrini)
-    -- Large cases: p - 3 ≤ t ≤ p - 1 (Hicks-Ollis-Schmitt)
-    -- Logarithmic: t ≤ log p / log log p (Kravitz)
-    -- Beyond barrier: t ≤ exp((log p)^{1/4}) (Bedert-Kravitz)
-    -- General: OPEN
-    True := trivial
-
-/-- The conjecture remains open in general -/
-def ConjectureStatus : Prop :=
-  -- Proven for:
-  -- 1. t ≤ 12 (any prime)
-  -- 2. t ≥ p - 3 (large sets)
-  -- 3. t ≤ exp((log p)^{1/4}) (medium sets)
-  -- Open for: general t
-  True
-
-/-- Summary of known ranges -/
-theorem erdos_475_summary :
-    -- The problem exhibits interesting behavior at different scales
-    -- Small t: direct computation
-    -- Medium t: advanced techniques (rectification barrier)
-    -- Large t (near p): structural arguments
-    True := trivial
+theorem erdos_475_summary (p : ℕ) [Fact (Nat.Prime p)] (hp12 : p > 12) (hp2 : p > 2) :
+    -- Small cases verified
+    (∀ A : Finset (ZMod p), A.card ≤ 12 → (∀ a ∈ A, a ≠ 0) →
+      ∃ ordering : List (ZMod p), IsValidOrdering A ordering) ∧
+    -- Large cases verified
+    (∀ A : Finset (ZMod p), p - 3 ≤ A.card ∧ A.card ≤ p - 1 →
+      (∀ a ∈ A, a ≠ 0) →
+      ∃ ordering : List (ZMod p), IsValidOrdering A ordering) ∧
+    -- Bedert-Kravitz breakthrough
+    (∀ A : Finset (ZMod p),
+      (A.card : ℝ) ≤ Real.exp ((Real.log p) ^ (1/4 : ℝ)) →
+      (∀ a ∈ A, a ≠ 0) →
+      ∃ ordering : List (ZMod p), IsValidOrdering A ordering) :=
+  ⟨costa_pellegrini_2020 p hp12,
+   hicks_ollis_schmitt_2019 p,
+   bedert_kravitz_2024 p hp2⟩
 
 end Erdos475

--- a/src/data/proofs/erdos-475/annotations.json
+++ b/src/data/proofs/erdos-475/annotations.json
@@ -1,134 +1,83 @@
 [
   {
-    "id": "erdos-475-intro",
+    "id": "ann-475-overview",
     "proofId": "erdos-475",
-    "type": "context",
     "range": { "startLine": 1, "endLine": 31 },
-    "title": "Problem Introduction",
+    "type": "concept",
+    "title": "Problem Overview",
     "content": "**Erdős Problem #475: Graham's Rearrangement Conjecture**\n\nGiven a non-zero subset A of 𝔽ₚ, can we always arrange it as a₁, ..., aₜ so all partial sums are distinct?\n\n**Status:** OPEN in general; proven for various ranges of t.\n\nThis is a fundamental problem in additive combinatorics, connecting prime fields, sequencing, and partial sums.",
-    "mathContext": "The problem asks about the existence of special orderings. Among t! possible orderings, we need just one where no two partial sums coincide.",
-    "significance": "critical",
-    "relatedConcepts": ["Partial sums", "Prime fields", "Valid orderings", "Additive combinatorics"]
+    "significance": "critical"
   },
   {
-    "id": "erdos-475-partial-sums",
+    "id": "ann-475-partial-sums",
     "proofId": "erdos-475",
+    "range": { "startLine": 48, "endLine": 57 },
     "type": "definition",
-    "range": { "startLine": 48, "endLine": 50 },
-    "title": "Partial Sums",
-    "content": "**partialSums l:**\n\nThe sequence of cumulative sums of a list l.\n\nFor l = [a₁, a₂, ..., aₜ], the partial sums are:\n- a₁\n- a₁ + a₂\n- a₁ + a₂ + a₃\n- ...\n- a₁ + ... + aₜ\n\nWe need all t of these to be distinct.",
-    "mathContext": "Implemented using List.scanl for accumulation, then dropping the initial 0.",
-    "significance": "key",
-    "relatedConcepts": ["Cumulative sums", "Prefix sums", "Running totals"]
+    "title": "Partial Sums and Valid Orderings",
+    "content": "**partialSums l:** The sequence of cumulative sums of a list l, computed via List.scanl.\n\n**IsValidOrdering A ordering:** An ordering of A is valid if:\n1. The ordering contains exactly the elements of A (no duplicates, same set)\n2. All partial sums are distinct (no collisions in 𝔽ₚ)\n\n**GrahamConjecture p:** For prime p, every non-zero subset of 𝔽ₚ has a valid ordering.",
+    "significance": "critical"
   },
   {
-    "id": "erdos-475-valid-ordering",
+    "id": "ann-475-small-cases",
     "proofId": "erdos-475",
-    "type": "definition",
-    "range": { "startLine": 52, "endLine": 57 },
-    "title": "Valid Ordering",
-    "content": "**IsValidOrdering A ordering:**\n\nAn ordering of set A is valid if:\n1. The ordering contains exactly the elements of A (no duplicates, same set)\n2. All partial sums of the ordering are distinct\n\nThis is the central property we seek to guarantee.",
-    "mathContext": "Valid orderings are also called 'sequencings' in the literature on cyclic groups.",
-    "significance": "critical",
-    "relatedConcepts": ["Sequencing", "Distinct sums", "Permutations"]
-  },
-  {
-    "id": "erdos-475-conjecture",
-    "proofId": "erdos-475",
-    "type": "definition",
-    "range": { "startLine": 59, "endLine": 62 },
-    "title": "Graham's Conjecture",
-    "content": "**GrahamConjecture p:**\n\nFor prime p, every finite subset A ⊆ 𝔽ₚ \\ {0} has a valid ordering.\n\nThe non-zero condition is essential: if 0 ∈ A, any partial sum containing 0 could cause collisions.",
-    "mathContext": "The conjecture is strongest when A is large (near p elements) since there are fewer possible sum values.",
-    "significance": "critical",
-    "relatedConcepts": ["Existence conjectures", "Prime field structure", "Non-zero elements"]
-  },
-  {
-    "id": "erdos-475-small-cases",
-    "proofId": "erdos-475",
+    "range": { "startLine": 68, "endLine": 82 },
     "type": "axiom",
-    "range": { "startLine": 68, "endLine": 78 },
-    "title": "Small Cases: t ≤ 12",
-    "content": "**costa_pellegrini_2020:**\n\nFor |A| ≤ 12, valid orderings exist.\n\nThis was verified through a combination of:\n- Exhaustive computation for specific primes\n- Theoretical arguments reducing to manageable cases\n\nCosta and Pellegrini (2020) established this systematically.",
-    "mathContext": "Small cases often require checking t! orderings, but structure can reduce this.",
-    "significance": "key",
-    "relatedConcepts": ["Computational verification", "Small case analysis", "Exhaustive search"]
+    "title": "Small Cases: t ≤ 12 (Costa-Pellegrini 2020)",
+    "content": "**costa_pellegrini_2020 (axiom):** For |A| ≤ 12, valid orderings exist.\n\nVerified through a combination of exhaustive computation and theoretical reductions. Costa and Pellegrini (2020) established this systematically.\n\n**small_sets_have_valid_orderings (proved):** Derives the result by instantiating the axiom.",
+    "significance": "key"
   },
   {
-    "id": "erdos-475-large-cases",
+    "id": "ann-475-large-cases",
     "proofId": "erdos-475",
+    "range": { "startLine": 88, "endLine": 105 },
     "type": "axiom",
-    "range": { "startLine": 84, "endLine": 93 },
     "title": "Large Cases: t ≥ p - 3",
-    "content": "**hicks_ollis_schmitt_2019 and graham_full_set:**\n\nFor sets of size p - 3, p - 2, or p - 1 (near-complete sets), valid orderings exist.\n\nGraham originally proved t = p - 1. Hicks-Ollis-Schmitt extended this to p - 3.\n\n**Intuition:** When A is almost all of 𝔽ₚ \\ {0}, there's enough structure to guarantee valid orderings.",
-    "mathContext": "Large sets have limited missing elements, constraining the problem sufficiently.",
-    "significance": "key",
-    "relatedConcepts": ["Near-complete sets", "Structural arguments", "Graham's original proof"]
+    "content": "**hicks_ollis_schmitt_2019 (axiom):** For sets of size p - 3, p - 2, or p - 1, valid orderings exist. When A is almost all of 𝔽ₚ \\ {0}, structural arguments suffice.\n\n**graham_full_set (axiom):** Graham originally proved the t = p - 1 case constructively, providing an explicit algorithm to produce a valid ordering.",
+    "significance": "key"
   },
   {
-    "id": "erdos-475-logarithmic",
+    "id": "ann-475-kravitz",
     "proofId": "erdos-475",
+    "range": { "startLine": 111, "endLine": 121 },
     "type": "axiom",
-    "range": { "startLine": 99, "endLine": 107 },
-    "title": "Logarithmic Range: t ≤ log p / log log p",
-    "content": "**kravitz_2024:**\n\nFor |A| ≤ log p / log log p, valid orderings exist.\n\nThis was proven by Kravitz in 2024 (and independently observed by Will Sawin on MathOverflow).\n\nThis significantly extends beyond the constant bound of 12.",
-    "mathContext": "The log p / log log p bound grows slowly but unboundedly with p.",
-    "significance": "key",
-    "relatedConcepts": ["Logarithmic bounds", "Slow-growing functions", "Independent discoveries"]
+    "title": "Logarithmic Range (Kravitz 2024)",
+    "content": "**kravitz_2024 (axiom):** For |A| ≤ log p / log log p, valid orderings exist.\n\nKravitz (2024) proved this, and Will Sawin independently observed the same bound on MathOverflow. This significantly extends beyond the constant bound of 12, though log p / log log p grows slowly.",
+    "significance": "key"
   },
   {
-    "id": "erdos-475-rectification",
+    "id": "ann-475-rectification",
     "proofId": "erdos-475",
+    "range": { "startLine": 131, "endLine": 141 },
     "type": "axiom",
-    "range": { "startLine": 113, "endLine": 127 },
-    "title": "Beyond the Rectification Barrier",
-    "content": "**bedert_kravitz_2024:**\n\nFor |A| ≤ exp((log p)^{1/4}), valid orderings exist.\n\nThis is a major breakthrough! The 'rectification barrier' at log p / log log p was a technical obstacle that previous methods couldn't overcome.\n\nBedert and Kravitz (2024) developed new techniques to go far beyond this barrier.",
-    "mathContext": "exp((log p)^{1/4}) grows much faster than log p / log log p, representing a substantial improvement.",
-    "significance": "critical",
-    "relatedConcepts": ["Technical barriers", "New techniques", "Major improvements"]
+    "title": "Beyond the Rectification Barrier (Bedert-Kravitz 2024)",
+    "content": "**bedert_kravitz_2024 (axiom):** For |A| ≤ exp((log p)^{1/4}), valid orderings exist.\n\nThis is a major breakthrough. The 'rectification barrier' at log p / log log p was a technical obstacle that limited all previous methods. Bedert and Kravitz (2024) developed fundamentally new techniques to go far beyond.\n\nexp((log p)^{1/4}) grows much faster than log p / log log p, representing a substantial improvement.",
+    "significance": "critical"
   },
   {
-    "id": "erdos-475-alspach",
+    "id": "ann-475-alspach",
     "proofId": "erdos-475",
-    "type": "definition",
-    "range": { "startLine": 133, "endLine": 145 },
-    "title": "Alspach's Conjecture",
-    "content": "**AlspachConjecture G:**\n\nFor ANY finite abelian group G, every non-zero subset has a valid ordering.\n\nThis generalizes Graham's conjecture from 𝔽ₚ to all abelian groups.\n\n**graham_is_alspach_for_prime_field:** Graham's conjecture is exactly Alspach's for G = 𝔽ₚ.",
-    "mathContext": "Alspach's more general conjecture remains open even for cyclic groups ℤ/nℤ with composite n.",
-    "significance": "key",
-    "relatedConcepts": ["Generalization", "Abelian groups", "Cyclic groups"]
-  },
-  {
-    "id": "erdos-475-constructive",
-    "proofId": "erdos-475",
-    "type": "context",
-    "range": { "startLine": 162, "endLine": 178 },
-    "title": "Constructive vs Existential",
-    "content": "**HasExplicitValidOrdering:**\n\nSome proofs are constructive (giving explicit orderings), others are existential.\n\n- Graham's original proof for t = p - 1 was constructive\n- Small cases can be verified by explicit computation\n- Some proofs use probabilistic or counting arguments (non-constructive)",
-    "mathContext": "Constructive proofs are algorithmically useful; existential proofs establish truth without explicit examples.",
-    "significance": "key",
-    "relatedConcepts": ["Constructive proofs", "Existential proofs", "Algorithms"]
-  },
-  {
-    "id": "erdos-475-difficulty",
-    "proofId": "erdos-475",
-    "type": "context",
-    "range": { "startLine": 180, "endLine": 201 },
-    "title": "Why This Problem is Hard",
-    "content": "**Challenge Analysis:**\n\n1. **Factorial Search Space:** There are t! orderings to potentially check.\n\n2. **Collision Avoidance:** We need t distinct values among p possible sums.\n\n3. **Non-Local Constraint:** Whether partial sums collide depends on the full ordering.\n\n4. **General vs Specific:** We need it to work for ALL non-zero subsets A.",
-    "mathContext": "The problem combines combinatorial explosion with global constraints, making brute force infeasible for large t.",
-    "significance": "key",
-    "relatedConcepts": ["Computational complexity", "Global constraints", "Search space"]
-  },
-  {
-    "id": "erdos-475-summary",
-    "proofId": "erdos-475",
+    "range": { "startLine": 150, "endLine": 159 },
     "type": "theorem",
-    "range": { "startLine": 207, "endLine": 231 },
-    "title": "Main Theorem Summary",
-    "content": "**erdos_475:**\n\nStatus of Graham's Conjecture:\n\n**Proven for:**\n- t ≤ 12 (Costa-Pellegrini)\n- t ≥ p - 3 (Hicks-Ollis-Schmitt)\n- t ≤ exp((log p)^{1/4}) (Bedert-Kravitz)\n\n**Open:** The general case, especially the 'gap' between exp((log p)^{1/4}) and p - 3.\n\nThe conjecture is expected to be true for all t.",
-    "mathContext": "Progress has accelerated recently, with Bedert-Kravitz (2024) making a major breakthrough.",
-    "significance": "critical",
-    "relatedConcepts": ["Problem status", "Known results", "Open gaps"]
+    "title": "Alspach's Conjecture and Equivalence",
+    "content": "**AlspachConjecture G:** For any finite abelian group G, every non-zero subset has a valid ordering. This generalizes Graham's conjecture from 𝔽ₚ to all abelian groups.\n\n**graham_is_alspach_for_prime_field (proved):** Graham's conjecture is exactly Alspach's conjecture for G = 𝔽ₚ. The proof is by direct unfolding of definitions.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-475-constructive",
+    "proofId": "erdos-475",
+    "range": { "startLine": 168, "endLine": 181 },
+    "type": "definition",
+    "title": "Constructive vs Existential Proofs",
+    "content": "**HasExplicitValidOrdering A:** There exists a function that computes a valid ordering for A.\n\n**graham_constructive (axiom):** Graham's proof for the full non-zero set was constructive, giving an explicit algorithm.\n\nSome proofs are constructive (giving explicit orderings), others are existential (proving one exists without constructing it).",
+    "significance": "key"
+  },
+  {
+    "id": "ann-475-summary",
+    "proofId": "erdos-475",
+    "range": { "startLine": 204, "endLine": 219 },
+    "type": "theorem",
+    "title": "Summary Theorem",
+    "content": "**erdos_475_summary (proved from axioms):**\n\nCombines the three main verified ranges:\n1. **Small t ≤ 12:** Costa-Pellegrini 2020\n2. **Large t ≥ p - 3:** Hicks-Ollis-Schmitt 2019\n3. **Medium t ≤ exp((log p)^{1/4}):** Bedert-Kravitz 2024\n\nProved by: `⟨costa_pellegrini_2020 p hp12, hicks_ollis_schmitt_2019 p, bedert_kravitz_2024 p hp2⟩`\n\nThe general conjecture for arbitrary t remains OPEN.",
+    "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-475/meta.json
+++ b/src/data/proofs/erdos-475/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 475,
     "erdosUrl": "https://erdosproblems.com/475",
     "erdosProblemStatus": "open",
@@ -51,105 +51,89 @@
       "kravitz_2024 axiom: t ≤ log p / log log p case",
       "bedert_kravitz_2024 axiom: t ≤ exp((log p)^{1/4}) case",
       "AlspachConjecture definition: generalization to abelian groups",
-      "CyclicGroupConjecture definition: for general cyclic groups",
-      "HasExplicitValidOrdering definition: constructive solutions",
-      "graham_is_alspach_for_prime_field theorem: equivalence"
+      "graham_is_alspach_for_prime_field theorem: equivalence proved",
+      "erdos_475_summary theorem: combines small, large, and medium cases"
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #475** is Graham's Rearrangement Conjecture, a beautiful problem in additive combinatorics.\n\n**Historical Development:**\n- **Graham (original):** Proved the conjecture for t = p - 1 (the full non-zero set).\n- **Costa-Pellegrini (2020):** Verified for t ≤ 12 via computation/theory.\n- **Hicks-Ollis-Schmitt (2019):** Proved for large sets (p - 3 ≤ t ≤ p - 1).\n- **Kravitz (2024):** Extended to t ≤ log p / log log p.\n- **Bedert-Kravitz (2024):** Broke the 'rectification barrier' to reach t ≤ exp((log p)^{1/4}).\n\nAlspach conjectured the same holds for arbitrary abelian groups.",
+    "historicalContext": "Graham's Rearrangement Conjecture asks whether every non-zero subset of a prime field 𝔽ₚ can be ordered so that all partial sums are distinct. Graham himself proved the case where A is the entire non-zero set (t = p - 1), providing a constructive ordering. Alspach later generalized the question to arbitrary finite abelian groups.\n\nProgress came in waves. Costa and Pellegrini (2020) verified the conjecture for sets of size at most 12 through computation and theory. Hicks, Ollis, and Schmitt (2019) handled the opposite extreme: sets of size at least p - 3. Kravitz (2024) made a breakthrough for medium-sized sets, proving the conjecture for t ≤ log p / log log p, and Will Sawin independently observed the same bound.\n\nThe most dramatic advance came from Bedert and Kravitz (2024), who broke through the 'rectification barrier' — a technical obstacle that had limited all previous methods to at most log p / log log p. Their new techniques pushed the verified range to t ≤ exp((log p)^{1/4}), a vastly larger bound. Despite this progress, the general conjecture for arbitrary t remains open.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nLet $p$ be a prime. Given any finite set $A \\subseteq \\mathbb{F}_p \\setminus \\{0\\}$, is there always a rearrangement $A = \\{a_1, \\ldots, a_t\\}$ such that all partial sums $\\sum_{k=1}^{m} a_k$ are distinct for all $1 \\leq m \\leq t$?\n\n**Known Results:**\n- $t \\leq 12$: YES (Costa-Pellegrini 2020)\n- $t \\geq p - 3$: YES (Hicks-Ollis-Schmitt 2019)\n- $t \\leq \\exp((\\log p)^{1/4})$: YES (Bedert-Kravitz 2024)\n\n**Open:** General $t$ (the gap in the middle).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Valid Orderings:** Define partial sums and what makes an ordering valid.\n\n2. **Graham's Conjecture:** State the existence of valid orderings.\n\n3. **Known Ranges:** Axiomatize results for small t, large t, and medium t.\n\n4. **Alspach Generalization:** Connect to the broader conjecture for abelian groups.\n\n5. **Technical Barriers:** Explain the rectification barrier overcome in 2024.",
+    "proofStrategy": "The formalization defines partial sums and valid orderings, then states Graham's conjecture. Each known range is axiomatized as a separate result: Costa-Pellegrini for small sets, Hicks-Ollis-Schmitt for large sets, Kravitz for the logarithmic range, and Bedert-Kravitz for the rectification barrier breakthrough. Alspach's generalization to abelian groups is defined and shown equivalent to Graham's conjecture for prime fields. The summary theorem combines the three main verified ranges.",
     "keyInsights": [
-      "**Partial Sums:** We track cumulative sums a₁, a₁+a₂, ..., requiring all to be distinct.",
-      "**Valid Orderings:** Among t! orderings, we need at least one with distinct partial sums.",
-      "**Collision Avoidance:** In 𝔽ₚ there are p possible sum values; we need t to be distinct.",
-      "**Small vs Large:** Small t is verified computationally; large t (near p) uses structure.",
-      "**Rectification Barrier:** Previous methods hit log p / log log p; Bedert-Kravitz broke through.",
-      "**Alspach Generalization:** The same question for all abelian groups remains open."
+      "**Partial Sums:** We track cumulative sums a₁, a₁+a₂, ..., requiring all to be distinct in 𝔽ₚ.",
+      "**Valid Orderings:** Among t! orderings, we need just one with distinct partial sums.",
+      "**Small vs Large:** Small t verified computationally; large t (near p) uses structural arguments.",
+      "**Rectification Barrier:** Previous methods hit log p / log log p; Bedert-Kravitz broke through to exp((log p)^{1/4}).",
+      "**Alspach Generalization:** The same question for all finite abelian groups remains open.",
+      "**Constructive Proofs:** Graham's original proof gave explicit orderings; others are existential."
     ]
   },
   "sections": [
     {
       "id": "valid-orderings",
       "title": "Valid Orderings",
-      "summary": "Definitions of partial sums and valid orderings",
+      "summary": "partialSums, IsValidOrdering, GrahamConjecture definitions",
       "startLine": 44,
       "endLine": 62
     },
     {
       "id": "small-cases",
-      "title": "Small Cases",
-      "summary": "t ≤ 12 verified by Costa-Pellegrini",
+      "title": "Small Cases (Costa-Pellegrini 2020)",
+      "summary": "costa_pellegrini_2020 axiom, small_sets_have_valid_orderings theorem",
       "startLine": 64,
-      "endLine": 78
+      "endLine": 82
     },
     {
       "id": "large-cases",
-      "title": "Large Cases (Near p)",
-      "summary": "p - 3 ≤ t ≤ p - 1 by Hicks-Ollis-Schmitt",
-      "startLine": 80,
-      "endLine": 93
+      "title": "Large Cases — Near p (Hicks-Ollis-Schmitt 2019)",
+      "summary": "hicks_ollis_schmitt_2019 axiom, graham_full_set axiom",
+      "startLine": 84,
+      "endLine": 105
     },
     {
       "id": "logarithmic",
-      "title": "Logarithmic Range",
-      "summary": "t ≤ log p / log log p by Kravitz",
-      "startLine": 95,
-      "endLine": 107
+      "title": "Logarithmic Range (Kravitz 2024)",
+      "summary": "kravitz_2024 axiom: t ≤ log p / log log p",
+      "startLine": 107,
+      "endLine": 121
     },
     {
       "id": "rectification-barrier",
-      "title": "Beyond the Rectification Barrier",
-      "summary": "t ≤ exp((log p)^{1/4}) by Bedert-Kravitz",
-      "startLine": 109,
-      "endLine": 127
+      "title": "Beyond the Rectification Barrier (Bedert-Kravitz 2024)",
+      "summary": "bedert_kravitz_2024 axiom: t ≤ exp((log p)^{1/4})",
+      "startLine": 123,
+      "endLine": 141
     },
     {
       "id": "alspach",
       "title": "Alspach's Conjecture",
-      "summary": "Generalization to abelian groups",
-      "startLine": 129,
-      "endLine": 145
-    },
-    {
-      "id": "cyclic-groups",
-      "title": "Cyclic Groups",
-      "summary": "The case of ℤ/nℤ",
-      "startLine": 147,
-      "endLine": 160
+      "summary": "AlspachConjecture definition, graham_is_alspach_for_prime_field (proved)",
+      "startLine": 143,
+      "endLine": 159
     },
     {
       "id": "constructive",
       "title": "Constructive vs Existential",
-      "summary": "Some proofs are explicit, some existential",
-      "startLine": 162,
-      "endLine": 178
-    },
-    {
-      "id": "difficulty",
-      "title": "What Makes This Hard?",
-      "summary": "Why finding valid orderings is difficult",
-      "startLine": 180,
-      "endLine": 201
+      "summary": "HasExplicitValidOrdering, graham_constructive axiom",
+      "startLine": 161,
+      "endLine": 181
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Current status of Graham's Conjecture",
-      "startLine": 203,
-      "endLine": 234
+      "summary": "erdos_475_summary combining small, large, and medium verified ranges",
+      "startLine": 183,
+      "endLine": 221
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #475 (Graham's Conjecture) asks if every non-zero subset of 𝔽ₚ has an ordering with distinct partial sums. Proven for t ≤ 12 (computation), t ≥ p - 3 (structure), and t ≤ exp((log p)^{1/4}) (rectification breakthrough). The general case remains open.",
-    "implications": "**Implications for Combinatorics**\n\n1. **Additive Combinatorics:** Reveals structure of sumsets in prime fields.\n\n2. **Abelian Groups:** Connects to Alspach's broader conjecture.\n\n3. **Algorithmic:** Finding valid orderings has computational aspects.\n\n4. **Technique Development:** Breaking the rectification barrier required new methods.",
+    "summary": "Erdős Problem #475 (Graham's Conjecture) asks if every non-zero subset of 𝔽ₚ has an ordering with distinct partial sums. Proven for t ≤ 12 (Costa-Pellegrini), t ≥ p - 3 (Hicks-Ollis-Schmitt), and t ≤ exp((log p)^{1/4}) (Bedert-Kravitz). The general case remains open.",
+    "implications": "This problem connects additive combinatorics, prime field structure, and algorithmic questions about finding valid orderings. The breakthrough beyond the rectification barrier suggests new techniques may eventually close the gap.",
     "openQuestions": [
       "Does Graham's conjecture hold for all t?",
       "Can the gap between exp((log p)^{1/4}) and p-3 be closed?",
       "Does Alspach's conjecture hold for general abelian groups?",
-      "Is there an efficient algorithm to find valid orderings?",
-      "What is the structure of sets without valid orderings (if any exist)?"
+      "Is there an efficient algorithm to find valid orderings?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Removed 12 trivial `True := trivial` items and 1 sorry proof
- Removed junk: `sawin_observation`, `rectification_barrier_explanation`, `bedert_kravitz_improves_kravitz`, `alspach_open`, `small_cases_by_computation`, `factorial_orderings`, `collision_avoidance`, `existence_not_counting`, `ConjectureStatus`, summary theorems
- Converted `prime_cyclic_is_graham` sorry → removed (redundant with equivalence theorem)
- Added proper `erdos_475_summary` theorem combining three verified ranges via `⟨costa_pellegrini_2020, hicks_ollis_schmitt_2019, bedert_kravitz_2024⟩`
- Updated meta.json (sorries 1→0, correct sections/line numbers)
- Updated annotations.json (9 substantive annotations with correct line ranges)
- 234→222 lines

## Test plan
- [x] `pnpm build` succeeds
- [ ] Visual review of proof page

🤖 Generated with [Claude Code](https://claude.com/claude-code)