### PR TITLE
fix(daemon): prevent Aristotle from being falsely detected as COMPLETED

### DIFF
--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -491,6 +491,20 @@ get_pane_command() {
     tmux display-message -t "$session" -p '#{pane_current_command}' 2>/dev/null || echo "unknown"
 }
 
+# Helper: Check if a process has any child processes
+has_child_processes() {
+    local pid="$1"
+    pgrep -P "$pid" > /dev/null 2>&1
+}
+
+# Helper: Check if an agent is a script-based (non-Claude) agent
+is_script_based_agent() {
+    local session="$1"
+    local agent_type
+    agent_type=$(get_agent_type "$session")
+    [[ "$agent_type" == "aristotle" ]]
+}
+
 # Helper: Determine agent health status
 # Returns: RUNNING, COMPLETED, STUCK, or UNKNOWN
 get_agent_status() {
@@ -507,7 +521,23 @@ get_agent_status() {
     local pane_cmd
     pane_cmd=$(get_pane_command "$session")
 
-    # Find claude child process
+    # Script-based agents (e.g., Aristotle) don't use Claude.
+    # Check if the shell has any child processes still running.
+    if is_script_based_agent "$session"; then
+        if [[ "$pane_cmd" == "zsh" || "$pane_cmd" == "bash" || "$pane_cmd" == "sh" ]]; then
+            if has_child_processes "$pane_pid"; then
+                echo "RUNNING"
+            else
+                echo "COMPLETED"
+            fi
+            return
+        fi
+        # pane_cmd is something other than a shell - script is actively executing
+        echo "RUNNING"
+        return
+    fi
+
+    # Claude-based agents: find claude child process
     local claude_pid
     claude_pid=$(find_claude_child "$pane_pid" | head -1)
 
@@ -573,12 +603,35 @@ cmd_health() {
             continue
         fi
 
-        # Find claude child
-        local claude_pid
-        claude_pid=$(find_claude_child "$pane_pid" | head -1)
-
         local status
         status=$(get_agent_status "$session")
+
+        # Script-based agents (e.g., Aristotle): show pane process info
+        if is_script_based_agent "$session"; then
+            local status_display
+            case "$status" in
+                RUNNING)
+                    status_display="${GREEN}RUNNING${NC}"
+                    running_count=$((running_count + 1))
+                    ;;
+                COMPLETED)
+                    status_display="${GREEN}COMPLETED${NC}"
+                    completed_count=$((completed_count + 1))
+                    ;;
+                *)
+                    status_display="${YELLOW}$status${NC}"
+                    ;;
+            esac
+            local elapsed_human
+            elapsed_human=$(get_elapsed_human "$pane_pid")
+            printf "%-22s %-8s %-10s %-7s %-5s " "$session" "$pane_pid" "$elapsed_human" "-" "-"
+            echo -e "$status_display (script)"
+            continue
+        fi
+
+        # Claude-based agents: find claude child process
+        local claude_pid
+        claude_pid=$(find_claude_child "$pane_pid" | head -1)
 
         if [[ -z "$claude_pid" ]]; then
             # No claude process


### PR DESCRIPTION
## Summary

- Fixes daemon incorrectly detecting Aristotle (a script-based agent) as COMPLETED every 60s, causing constant kill/respawn cycles
- Adds agent-type-aware status detection: script-based agents check for child processes via `pgrep -P` instead of looking for a `claude` process
- Updates `cmd_health()` display to show script agent info (pane PID, elapsed time) with "(script)" indicator

## Changes

**`scripts/lean/launch.sh`**:
- Added `has_child_processes()` helper — checks if a PID has any child processes
- Added `is_script_based_agent()` helper — identifies non-Claude agents (currently Aristotle)
- Modified `get_agent_status()` — early-returns for script-based agents using child process check instead of Claude process search
- Modified `cmd_health()` — displays script-based agent info properly with running/completed status

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Aristotle shows RUNNING when script has children | Done | `has_child_processes()` checks `pgrep -P $pane_pid`; while sleeping/curling/tee-ing, children exist |
| Aristotle shows COMPLETED when script exits | Done | No children under shell PID = COMPLETED |
| Claude-based agents unchanged | Done | `is_script_based_agent()` returns false for all non-aristotle agents; existing Claude logic untouched |
| Health display shows script agent info | Done | Shows pane PID, elapsed time, and "(script)" suffix |

## Test plan

- [ ] Start daemon with `--aristotle 1`, run `./scripts/lean/launch.sh health` multiple times over 5+ minutes — Aristotle should show `RUNNING` consistently
- [ ] Run daemon for 30+ minutes, verify no "Respawning aristotle" messages in daemon log
- [ ] Verify Claude-based agents (Erdős/Researcher/Seeker/Deployer) still show correct COMPLETED/RUNNING/STUCK status
- [ ] While Aristotle is in sleep phase between cycles, health check should still report RUNNING
- [ ] When `aristotle-agent.sh` actually exits (stop signal), health check should report COMPLETED

Closes #1700

🤖 Generated with [Claude Code](https://claude.com/claude-code)