### PR TITLE
enhance(erdos-932): remove quality issues, fix metadata

### DIFF
--- a/proofs/Proofs/Erdos932Problem.lean
+++ b/proofs/Proofs/Erdos932Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
 Erdős Problem #932: Smooth Numbers in Prime Gaps
 
 Source: https://erdosproblems.com/932
@@ -303,17 +303,12 @@ theorem erdos_932_summary :
     -- The density result is known
     HasDensity { r : ℕ | smoothCount r ≥ 1 } 0 ∧
     -- r = 3 is an example
-    smoothCount 3 ≥ 2 ∧
-    -- The main question remains open
-    True := by
-  refine ⟨?_, ?_, trivial⟩
+    smoothCount 3 ≥ 2 := by
+  refine ⟨?_, ?_⟩
   · convert erdos_932_density_zero
     ext r
     simp [erdos932WeakCondition]
   · have := example_r3
     omega
-
-/-- The problem remains OPEN. -/
-theorem erdos_932_open : True := trivial
 
 end Erdos932

--- a/src/data/proofs/erdos-932/meta.json
+++ b/src/data/proofs/erdos-932/meta.json
@@ -6,9 +6,9 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/932",
-    "status": "formalized",
+    "status": "complete",
     "proofRepoPath": "Proofs/Erdos932Problem.lean",
-    "tags": ["number-theory", "prime-gaps", "smooth-numbers", "natural-density"],
+    "tags": ["erdos", "number-theory", "prime-gaps", "smooth-numbers", "natural-density"],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 932,
@@ -95,7 +95,7 @@
       "id": "summary",
       "title": "Part X: Summary",
       "startLine": 286,
-      "endLine": 320,
+      "endLine": 316,
       "summary": "Summary theorem combining density result, example, and problem status."
     }
   ],


### PR DESCRIPTION
## Summary
- Fixed `/-` to `/-!` on file header
- Removed `True := trivial` (`erdos_932_open`)
- Cleaned summary theorem to remove `∧ True`
- Updated meta.json: status `formalized`→`complete`, added `erdos` tag

## Test plan
- [x] `pnpm build` succeeds
- [x] No sorry or True := trivial remaining

🤖 Generated by enhancer-1