### PR TITLE
enhance(erdos-479): remove True := trivial, add summary theorem

### DIFF
--- a/proofs/Proofs/Erdos479Problem.lean
+++ b/proofs/Proofs/Erdos479Problem.lean
@@ -101,11 +101,6 @@ reduced to positive residues by taking k mod n.
 def grahams_conjecture : Prop :=
   ∀ k : ℕ, k > 1 → (SolutionSet k).Infinite
 
-/--
-The conjecture remains OPEN as of 2024.
--/
-theorem erdos_479_is_open : True := trivial
-
 /-!
 ## Computational Difficulty
 
@@ -204,10 +199,23 @@ The pattern is irregular and hard to predict.
 -/
 
 /--
-Some small k values have relatively small minimal solutions.
+**Erdős Problem #479: Summary**
+
+Combines the key results:
+1. k = 1 is impossible (no solutions for n > 1)
+2. Powers of 2 case proved (Graham-Lehmer-Lehmer)
+3. k = -1 case proved (Graham-Lehmer-Lehmer)
+4. General conjecture: SolutionSet(k) infinite for all k > 1
 -/
-axiom small_solutions_exist :
-    7 ∈ SolutionSet 5 ∧  -- 2^7 = 128 ≡ 2 mod 7... let me check
-    46 ∈ SolutionSet 7   -- Known from OEIS
+theorem erdos_479_summary :
+    -- k = 1 has only finitely many solutions
+    (SolutionSet 1).Finite ∧
+    -- Powers of 2 have infinitely many solutions
+    (∀ i : ℕ, i ≥ 1 → (SolutionSet (2 ^ i)).Infinite) ∧
+    -- k = 2 has infinitely many solutions (via Fermat)
+    (SolutionSet 2).Infinite :=
+  ⟨solution_set_one_finite,
+   powers_of_two_infinite,
+   solution_set_two_infinite⟩
 
 end Erdos479

--- a/src/data/proofs/erdos-479/annotations.json
+++ b/src/data/proofs/erdos-479/annotations.json
@@ -18,23 +18,6 @@
     ]
   },
   {
-    "id": "ann-e479-imports",
-    "proofId": "erdos-479",
-    "range": {
-      "startLine": 19,
-      "endLine": 24
-    },
-    "type": "concept",
-    "title": "Mathlib Imports",
-    "content": "We import:\n- **Nat.Basic**: Fundamental natural number operations\n- **Nat.Prime.Basic**: Primality predicate for stating Fermat's Little Theorem\n- **Int.ModEq**: Modular equivalence for integers (the ZMOD notation)\n- **Set.Finite.Basic**: Predicates for finite and infinite sets",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "Mathlib",
-      "modular equivalence",
-      "infinite sets"
-    ]
-  },
-  {
     "id": "ann-e479-solution-set",
     "proofId": "erdos-479",
     "range": {
@@ -57,11 +40,11 @@
     "proofId": "erdos-479",
     "range": {
       "startLine": 45,
-      "endLine": 61
+      "endLine": 66
     },
     "type": "axiom",
     "title": "Why k = 1 is Impossible",
-    "content": "**Theorem**: For n > 1, we have 2^n ≢ 1 (mod n).\n\nThis explains why Graham's conjecture requires k ≠ 1.\n\n**Proof sketch**:\n- **Case n even**: 2^n ≡ 0 (mod 2), but 1 ≢ 0 (mod 2). Since n is even, n ≡ 0 (mod 2), so if 2^n ≡ 1 (mod n), we'd need 1 ≡ 0 (mod 2). Contradiction.\n- **Case n odd > 1**: More subtle number-theoretic arguments show 2^n ≢ 1 (mod n).",
+    "content": "**Axiom**: For n > 1, we have 2^n ≢ 1 (mod n).\n\nThis explains why Graham's conjecture requires k ≠ 1.\n\n**Proof sketch**:\n- **Case n even**: 2^n ≡ 0 (mod 2), but 1 ≢ 0 (mod 2). Since 2 | n, if 2^n ≡ 1 (mod n), we'd need 1 ≡ 0 (mod 2). Contradiction.\n- **Case n odd > 1**: More subtle number-theoretic arguments show 2^n ≢ 1 (mod n).\n\nConsequence: SolutionSet(1) is finite.",
     "mathContext": "This result is elementary but requires careful case analysis. The key insight is that 2^n shares factors with n in ways that prevent the remainder from being 1.",
     "significance": "key",
     "relatedConcepts": [
@@ -93,7 +76,7 @@
     "proofId": "erdos-479",
     "range": {
       "startLine": 88,
-      "endLine": 107
+      "endLine": 102
     },
     "type": "definition",
     "title": "Graham's Conjecture",
@@ -110,12 +93,12 @@
     "id": "ann-e479-k3-difficulty",
     "proofId": "erdos-479",
     "range": {
-      "startLine": 109,
-      "endLine": 133
+      "startLine": 104,
+      "endLine": 128
     },
     "type": "axiom",
     "title": "The k = 3 Computational Challenge",
-    "content": "**Remarkable fact**: For k = 3, the smallest n with 2^n ≡ 3 (mod n) is:\n\n**n = 4,700,063,497** (a 10-digit number!)\n\nThis illustrates the extreme computational difficulty of the problem. Despite k = 3 being small, solutions are incredibly sparse.\n\nThe same value n = 4700063497 also works for k = 5, showing that certain n satisfy multiple congruences.",
+    "content": "**Remarkable fact**: For k = 3, the smallest n with 2^n ≡ 3 (mod n) is:\n\n**n = 4,700,063,497** (a 10-digit number!)\n\nThis illustrates the extreme computational difficulty of the problem. Despite k = 3 being small, solutions are incredibly sparse.\n\nAlso axiomatized: all n < 4700063497 fail for k = 3, confirming minimality.",
     "mathContext": "The OEIS sequence A036236 catalogs minimal n for each k. The values are highly irregular: A036236(2) = 3, A036236(3) = 4700063497, A036236(4) = 6. This irregularity suggests deep arithmetic structure.",
     "significance": "key",
     "relatedConcepts": [
@@ -128,8 +111,8 @@
     "id": "ann-e479-fermat",
     "proofId": "erdos-479",
     "range": {
-      "startLine": 135,
-      "endLine": 162
+      "startLine": 130,
+      "endLine": 157
     },
     "type": "axiom",
     "title": "Fermat's Little Theorem Connection",
@@ -143,33 +126,15 @@
     ]
   },
   {
-    "id": "ann-e479-euler",
-    "proofId": "erdos-479",
-    "range": {
-      "startLine": 143,
-      "endLine": 148
-    },
-    "type": "concept",
-    "title": "Why Euler's Theorem Doesn't Help",
-    "content": "**Euler's Theorem** states: 2^φ(n) ≡ 1 (mod n) when gcd(2,n) = 1.\n\nBut this doesn't directly help because:\n- We need 2^n ≡ k (mod n), not 2^φ(n) ≡ 1\n- The exponent n and the totient φ(n) don't align in general\n- The constraint that modulus = exponent creates unique difficulties",
-    "mathContext": "Euler's theorem gives information about 2^(φ(n)) mod n, but our problem asks about 2^n mod n. Since n ≠ φ(n) in general, we can't directly apply Euler's theorem.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "Euler's totient function",
-      "Euler's theorem",
-      "multiplicative order"
-    ]
-  },
-  {
     "id": "ann-e479-examples",
     "proofId": "erdos-479",
     "range": {
-      "startLine": 164,
-      "endLine": 188
+      "startLine": 159,
+      "endLine": 199
     },
     "type": "lemma",
-    "title": "Verified Examples",
-    "content": "The Lean `decide` tactic can verify small instances:\n\n| Computation | Verification |\n|-------------|-------------|\n| 2^3 = 8 ≡ 2 (mod 3) | `by decide` |\n| 2^6 = 64 ≡ 4 (mod 6) | `by decide` |\n| 2^4 = 16 ≡ 0 (mod 4) | `by decide` |\n\nThese confirm the OEIS data: A036236(2) = 3, A036236(4) = 6, A036236(0) = 4.",
+    "title": "Verified Examples and OEIS Data",
+    "content": "The Lean `decide` tactic can verify small instances:\n\n| Computation | Verification |\n|-------------|-------------|\n| 2^3 = 8 ≡ 2 (mod 3) | `by decide` |\n| 2^6 = 64 ≡ 4 (mod 6) | `by decide` |\n| 2^4 = 16 ≡ 0 (mod 4) | `by decide` |\n\nThese confirm the OEIS data: A036236(2) = 3, A036236(4) = 6, A036236(0) = 4.\n\nThe OEIS pattern is highly irregular: k = 3 needs n = 4700063497, but k = 4 only needs n = 6.",
     "mathContext": "Decidable propositions about finite computations can be verified automatically by Lean's kernel. This provides machine-checked confirmation of the small cases.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -179,56 +144,15 @@
     ]
   },
   {
-    "id": "ann-e479-oeis",
+    "id": "ann-e479-summary",
     "proofId": "erdos-479",
     "range": {
-      "startLine": 190,
-      "endLine": 204
+      "startLine": 201,
+      "endLine": 221
     },
-    "type": "concept",
-    "title": "OEIS A036236",
-    "content": "The **OEIS sequence A036236** gives the smallest n for each k:\n\n| k | A036236(k) | Verification |\n|---|------------|-------------|\n| 0 | 4 | 2^4 = 16 ≡ 0 (mod 4) |\n| 2 | 3 | 2^3 = 8 ≡ 2 (mod 3) |\n| 3 | 4700063497 | Enormous! |\n| 4 | 6 | 2^6 = 64 ≡ 4 (mod 6) |\n| 5 | 4700063497 | Same as k=3 |\n| 6 | 903 | 2^903 ≡ 6 (mod 903) |\n| 7 | 46 | 2^46 ≡ 7 (mod 46) |\n\nThe pattern is highly irregular and unpredictable.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "OEIS",
-      "minimal solutions",
-      "pattern irregularity"
-    ]
-  },
-  {
-    "id": "ann-e479-crt",
-    "proofId": "erdos-479",
-    "range": {
-      "startLine": 147,
-      "endLine": 148
-    },
-    "type": "concept",
-    "title": "Chinese Remainder Theorem Approach",
-    "content": "The **Chinese Remainder Theorem** suggests analyzing 2^n ≡ k (mod n) by factoring n into prime powers.\n\nFor n = p₁^{a₁} · p₂^{a₂} · ... · pₘ^{aₘ}, the congruence 2^n ≡ k (mod n) holds iff:\n- 2^n ≡ k (mod p₁^{a₁})\n- 2^n ≡ k (mod p₂^{a₂})\n- ...\n\nBut the constraints from different prime powers **interact in complex ways** because n appears in the exponent too.",
-    "mathContext": "This prime-by-prime analysis is the standard approach, but the fact that n determines both the exponent and the modulus creates feedback loops that make the analysis extremely difficult.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "Chinese Remainder Theorem",
-      "prime factorization",
-      "system of congruences"
-    ]
-  },
-  {
-    "id": "ann-e479-carmichael",
-    "proofId": "erdos-479",
-    "range": {
-      "startLine": 143,
-      "endLine": 148
-    },
-    "type": "concept",
-    "title": "Carmichael Function Connection",
-    "content": "The **Carmichael function λ(n)** gives the smallest positive integer m such that a^m ≡ 1 (mod n) for all a coprime to n.\n\nThe multiplicative order of 2 modulo n divides λ(n). However, the constraint that the exponent equals the modulus (2^n mod n) creates unique difficulties:\n\n- We need information about 2^n, not 2^λ(n)\n- The relationship between n and λ(n) is complicated\n- For n with small prime factors, λ(n) is much smaller than n",
-    "mathContext": "Carmichael's theorem gives 2^λ(n) ≡ 1 (mod n) when gcd(2,n) = 1. But since λ(n) ≤ φ(n) < n for n > 1, we can't directly use this to determine 2^n mod n.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "Carmichael function",
-      "multiplicative order",
-      "Euler's totient"
-    ]
+    "type": "theorem",
+    "title": "Summary Theorem",
+    "content": "**erdos_479_summary (proved from axioms):**\n\nCombines three key results:\n1. SolutionSet(1) is finite (k = 1 impossible)\n2. SolutionSet(2^i) is infinite for all i ≥ 1 (powers of 2)\n3. SolutionSet(2) is infinite (via Fermat's Little Theorem)\n\nProved by: `⟨solution_set_one_finite, powers_of_two_infinite, solution_set_two_infinite⟩`",
+    "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-479/meta.json
+++ b/src/data/proofs/erdos-479/meta.json
@@ -74,7 +74,7 @@
     {
       "id": "solution-set",
       "title": "The Solution Set",
-      "startLine": 38,
+      "startLine": 28,
       "endLine": 66,
       "summary": "Definition of SolutionSet(k) and why k = 1 is impossible."
     },
@@ -82,36 +82,43 @@
       "id": "partial-results",
       "title": "Known Partial Results",
       "startLine": 68,
-      "endLine": 87,
+      "endLine": 86,
       "summary": "Powers of 2 and k = -1 cases proved by Graham, Lehmer, and Lehmer."
     },
     {
       "id": "conjecture",
       "title": "Graham's Conjecture",
       "startLine": 88,
-      "endLine": 108,
+      "endLine": 102,
       "summary": "Statement of the main open conjecture."
     },
     {
       "id": "computational",
       "title": "Computational Difficulty",
-      "startLine": 109,
-      "endLine": 134,
+      "startLine": 104,
+      "endLine": 128,
       "summary": "The k = 3 case with smallest n = 4700063497."
     },
     {
       "id": "structure",
       "title": "Understanding the Structure",
-      "startLine": 135,
-      "endLine": 163,
+      "startLine": 130,
+      "endLine": 157,
       "summary": "Fermat's Little Theorem and the infinitude of SolutionSet(2)."
     },
     {
       "id": "examples",
-      "title": "Verified Examples",
-      "startLine": 164,
-      "endLine": 214,
-      "summary": "Concrete verifications using decide tactic."
+      "title": "Verified Examples and OEIS",
+      "startLine": 159,
+      "endLine": 199,
+      "summary": "Concrete verifications using decide tactic and OEIS connection."
+    },
+    {
+      "id": "summary",
+      "title": "Summary Theorem",
+      "startLine": 201,
+      "endLine": 221,
+      "summary": "Summary combining key results: k=1 impossible, powers of 2 infinite, k=2 infinite."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Removed `erdos_479_is_open : True := trivial` placeholder
- Removed `small_solutions_exist` axiom (mathematically dubious — comment says "let me check")
- Added proper `erdos_479_summary` theorem combining `solution_set_one_finite`, `powers_of_two_infinite`, `solution_set_two_infinite`
- Updated section line numbers and annotations to match 222-line file

## Test plan
- [x] `pnpm build` succeeds
- [x] No `True := trivial` remaining
- [x] No `sorry` remaining
- [x] Summary theorem proves from axioms

🤖 Generated with [Claude Code](https://claude.com/claude-code)