### PR TITLE
enhance(erdos-254): remove 7 True axioms, rewrite meta/annotations

### DIFF
--- a/proofs/Proofs/Erdos254Problem.lean
+++ b/proofs/Proofs/Erdos254Problem.lean
@@ -35,7 +35,9 @@ open Nat Real Set
 namespace Erdos254
 
 /-!
-## Part 1: Basic Definitions
+## Part I: Basic Definitions
+
+Distance to nearest integer and counting functions.
 -/
 
 /-- Distance to nearest integer -/
@@ -51,7 +53,10 @@ noncomputable def countTo (A : Set ℕ) (x : ℝ) : ℕ :=
   (Finset.range (Nat.floor x + 1)).filter (· ∈ A) |>.card
 
 /-!
-## Part 2: The Growth Condition
+## Part II: The Growth Condition
+
+The first hypothesis requires that the number of elements of A
+in each dyadic interval [x, 2x] tends to infinity.
 -/
 
 /-- The growth condition: |A ∩ [1,2x]| - |A ∩ [1,x]| → ∞ -/
@@ -59,14 +64,12 @@ def HasGrowthCondition (A : Set ℕ) : Prop :=
   ∀ M : ℕ, ∃ x₀ : ℝ, x₀ > 0 ∧
     ∀ x ≥ x₀, countTo A (2 * x) - countTo A x ≥ M
 
-/-- Intuition: A has infinitely many elements in each dyadic interval -/
-axiom growth_intuition :
-  -- This means A is "infinitely dense" in a specific sense
-  -- Enough elements keep appearing as we go to infinity
-  True
-
 /-!
-## Part 3: The Irrationality Condition
+## Part III: The Irrationality Condition
+
+The second hypothesis ensures that A is "uniformly distributed"
+modulo every irrational multiple θ, in the sense that the
+fractional parts θn cannot all be close to integers.
 -/
 
 /-- Sum of fractional distances Σ {θn} for n ∈ A -/
@@ -77,14 +80,8 @@ noncomputable def fracDistSum (A : Set ℕ) (θ : ℝ) : ℝ :=
 def HasIrrationalityCondition (A : Set ℕ) : Prop :=
   ∀ θ : ℝ, 0 < θ → θ < 1 → fracDistSum A θ = ⊤
 
-/-- Intuition: A is "uniformly distributed" modulo every θ -/
-axiom irrationality_intuition :
-  -- The fractional parts θn mod 1 are well-distributed
-  -- Enough of them are far from integers
-  True
-
 /-!
-## Part 4: The Conjecture
+## Part IV: Subset Sum Representation
 -/
 
 /-- Sum of distinct elements of A representation -/
@@ -95,7 +92,15 @@ def IsSubsetSum (A : Set ℕ) (n : ℕ) : Prop :=
 def RepresentsAllLarge (A : Set ℕ) : Prop :=
   ∃ N : ℕ, ∀ n ≥ N, IsSubsetSum A n
 
-/-- Erdős's Conjecture -/
+/-!
+## Part V: The Conjecture
+-/
+
+/--
+**Erdős's Conjecture (Problem #254, OPEN):**
+If A satisfies the growth and irrationality conditions,
+then every sufficiently large integer is a sum of distinct elements of A.
+-/
 def ErdosConjecture : Prop :=
   ∀ A : Set ℕ,
     HasGrowthCondition A →
@@ -103,22 +108,28 @@ def ErdosConjecture : Prop :=
     RepresentsAllLarge A
 
 /-!
-## Part 5: Cassels's Theorem (1960)
+## Part VI: Cassels's Theorem (1960)
+
+Cassels proved the conjecture under strictly stronger hypotheses.
 -/
 
-/-- Cassels's stronger growth condition -/
+/-- Cassels's stronger growth condition: growth / log log x → ∞ -/
 def HasStrongGrowthCondition (A : Set ℕ) : Prop :=
   ∀ M : ℝ, M > 0 → ∃ x₀ : ℝ, x₀ > 0 ∧
     ∀ x ≥ x₀, (countTo A (2 * x) - countTo A x : ℝ) / Real.log (Real.log x) ≥ M
 
-/-- Cassels's stronger irrationality condition -/
+/-- Cassels's stronger irrationality condition: Σ {θn}² = ∞ -/
 noncomputable def fracDistSqSum (A : Set ℕ) (θ : ℝ) : ℝ :=
   ∑' (n : ℕ), if n ∈ A then (fracDist (θ * n))^2 else 0
 
 def HasStrongIrrationalityCondition (A : Set ℕ) : Prop :=
   ∀ θ : ℝ, 0 < θ → θ < 1 → fracDistSqSum A θ = ⊤
 
-/-- Cassels's Theorem (1960) -/
+/--
+**Cassels's Theorem (1960):**
+Under the stronger growth and irrationality conditions,
+every sufficiently large integer is a sum of distinct elements of A.
+-/
 axiom cassels_theorem :
   ∀ A : Set ℕ,
     HasStrongGrowthCondition A →
@@ -126,91 +137,49 @@ axiom cassels_theorem :
     RepresentsAllLarge A
 
 /-!
-## Part 6: The Gap
--/
-
-/-- The gap between Erdős's conditions and Cassels's -/
-axiom condition_gap :
-  -- Erdős: (count(2x) - count(x)) → ∞
-  -- Cassels: (count(2x) - count(x)) / log log x → ∞
-  -- Cassels's condition is strictly stronger (faster growth)
-  True
-
-/-- Similarly for the irrationality condition -/
-axiom irrationality_gap :
-  -- Erdős: Σ {θn} = ∞
-  -- Cassels: Σ {θn}² = ∞
-  -- {θn}² ≤ {θn} ≤ 1/2, so Σ{θn}² ≤ Σ{θn}
-  -- Cassels's condition is weaker (easier to satisfy)
-  -- But the combination with stronger growth still works
-  True
-
-/-!
-## Part 7: Examples
+## Part VII: Examples
 -/
 
 /-- The set of powers of 2: {1, 2, 4, 8, ...} -/
 def PowersOf2 : Set ℕ := {n | ∃ k, n = 2^k}
 
-/-- Powers of 2 satisfy the growth condition -/
+/-- Powers of 2 satisfy the growth condition. -/
 axiom powers_of_2_growth :
   HasGrowthCondition PowersOf2
 
-/-- Powers of 2 satisfy the irrationality condition -/
+/-- Powers of 2 satisfy the irrationality condition. -/
 axiom powers_of_2_irrationality :
   HasIrrationalityCondition PowersOf2
 
-/-- Indeed, every sufficiently large n is a sum of distinct powers of 2 -/
+/-- Every sufficiently large n is a sum of distinct powers of 2 (binary representation). -/
 axiom powers_of_2_representation :
   RepresentsAllLarge PowersOf2
 
 /-!
-## Part 8: Related Problems
+## Part VIII: Summary
 -/
 
-/-- Connection to subset sum problem -/
-axiom subset_sum_connection :
-  -- The subset sum problem asks: given A and n, is n a subset sum?
-  -- This is NP-complete in general
-  -- But with growth/irrationality conditions, the answer is "yes" for large n
-  True
+/--
+**Erdős Problem #254: Summary**
 
-/-- Connection to Sidon sets -/
-axiom sidon_connection :
-  -- Sidon sets have unique subset sums
-  -- This problem concerns existence of representations
-  True
+CONJECTURE (OPEN): If A ⊆ ℕ satisfies growth and irrationality conditions,
+then every sufficiently large integer is a subset sum of A.
 
-/-!
-## Part 9: Summary
+Combines:
+1. Cassels's theorem under stronger hypotheses
+2. Powers of 2 as a concrete example satisfying all conditions
+3. Powers of 2 represent all sufficiently large integers
 -/
-
-/-- The problem remains open in its original form -/
-axiom erdos_254_open :
-  -- Erdős's original conjecture (with weaker conditions) is OPEN
-  -- Cassels proved a related result with stronger hypotheses
-  True
-
-/-- **Erdős Problem #254: OPEN**
-
-CONJECTURE: If A ⊆ ℕ satisfies:
-1. |A ∩ [1,2x]| - |A ∩ [1,x]| → ∞
-2. Σ {θn} = ∞ for all θ ∈ (0,1)
-
-Then every sufficiently large integer is a sum of distinct elements of A.
-
-STATUS: OPEN
-
-KNOWN: Cassels (1960) proved under stronger conditions:
-- Growth: (count(2x) - count(x)) / log log x → ∞
-- Irrationality: Σ {θn}² = ∞
-
-The gap between Erdős's conditions and Cassels's remains to be closed.
--/
-theorem erdos_254_status : True := trivial
-
-/-- Problem status -/
-def erdos_254_status_str : String :=
-  "OPEN - Cassels proved related result, original conjecture open"
+theorem erdos_254_summary :
+    -- Cassels's theorem holds under stronger conditions
+    (∀ A : Set ℕ, HasStrongGrowthCondition A →
+      HasStrongIrrationalityCondition A → RepresentsAllLarge A) ∧
+    -- Powers of 2 satisfy both conditions
+    (HasGrowthCondition PowersOf2 ∧ HasIrrationalityCondition PowersOf2) ∧
+    -- Powers of 2 represent all large integers
+    RepresentsAllLarge PowersOf2 :=
+  ⟨cassels_theorem,
+   ⟨powers_of_2_growth, powers_of_2_irrationality⟩,
+   powers_of_2_representation⟩
 
 end Erdos254

--- a/src/data/proofs/erdos-254/annotations.json
+++ b/src/data/proofs/erdos-254/annotations.json
@@ -1,1 +1,73 @@
-[]
+[
+  {
+    "id": "ann-e254-overview",
+    "proofId": "erdos-254",
+    "range": { "startLine": 1, "endLine": 25 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #254** asks: if A ⊆ ℕ satisfies a growth condition and an irrationality condition, must every sufficiently large integer be a sum of distinct elements of A?\n\n**Status**: OPEN. Cassels (1960) proved a related result under stronger hypotheses.\n\nThe two conditions are:\n1. Growth: |A ∩ [1,2x]| - |A ∩ [1,x]| → ∞ (enough elements in each dyadic interval)\n2. Irrationality: Σ_{n ∈ A} {θn} = ∞ for all θ ∈ (0,1) (A well-distributed mod θ)",
+    "significance": "critical",
+    "relatedConcepts": ["subset sums", "additive number theory", "Cassels theorem"]
+  },
+  {
+    "id": "ann-e254-fracdist",
+    "proofId": "erdos-254",
+    "range": { "startLine": 43, "endLine": 53 },
+    "type": "definition",
+    "title": "Fractional Distance and Counting",
+    "content": "**fracDist(x)** = |x - round(x)|: distance from x to the nearest integer. Values in [0, 1/2].\n\n**fracDist'(x)** = min(x - ⌊x⌋, ⌈x⌉ - x): equivalent alternative definition.\n\n**countTo(A, x)**: number of elements of A in {1, 2, ..., ⌊x⌋}. Used to express growth conditions.",
+    "mathContext": "The fractional distance {x} measures how far x is from being an integer. When θ is irrational, the sequence {θn} is equidistributed by Weyl's theorem, so Σ {θn} = ∞ for any infinite set A. The interesting constraint is for rational θ.",
+    "significance": "key",
+    "relatedConcepts": ["fractional part", "Weyl's theorem", "equidistribution"]
+  },
+  {
+    "id": "ann-e254-conditions",
+    "proofId": "erdos-254",
+    "range": { "startLine": 55, "endLine": 81 },
+    "type": "definition",
+    "title": "Growth and Irrationality Conditions",
+    "content": "**HasGrowthCondition(A)**: For every M, eventually countTo(A, 2x) - countTo(A, x) ≥ M. This means A has arbitrarily many elements in each dyadic interval.\n\n**HasIrrationalityCondition(A)**: For every θ ∈ (0,1), the sum Σ_{n ∈ A} fracDist(θn) diverges. This prevents A from being too structured (e.g., all elements ≡ 0 mod some q).\n\nTogether these two conditions should force A to be 'rich enough' for complete representation.",
+    "significance": "critical",
+    "relatedConcepts": ["dyadic intervals", "divergent series", "additive structure"]
+  },
+  {
+    "id": "ann-e254-conjecture",
+    "proofId": "erdos-254",
+    "range": { "startLine": 95, "endLine": 108 },
+    "type": "definition",
+    "title": "The Erdős Conjecture",
+    "content": "**ErdosConjecture**: If A has growth + irrationality, then RepresentsAllLarge(A).\n\n**RepresentsAllLarge(A)**: ∃ N, ∀ n ≥ N, n is a sum of distinct elements of A.\n\n**IsSubsetSum(A, n)**: ∃ S ⊆ A (finite, distinct), Σ S = n.\n\nThe conjecture remains OPEN in its original form.",
+    "significance": "critical",
+    "relatedConcepts": ["complete sequences", "representation problems", "open conjecture"]
+  },
+  {
+    "id": "ann-e254-cassels",
+    "proofId": "erdos-254",
+    "range": { "startLine": 110, "endLine": 137 },
+    "type": "axiom",
+    "title": "Cassels's Theorem (1960)",
+    "content": "**cassels_theorem (axiom):** Under strictly stronger hypotheses, every large integer is a subset sum.\n\n**HasStrongGrowthCondition**: (count(2x) - count(x)) / log log x → ∞. Strictly stronger than Erdős's condition.\n\n**HasStrongIrrationalityCondition**: Σ {θn}² = ∞. Strictly weaker than Erdős's Σ {θn} = ∞ (since {θn}² ≤ {θn}).\n\nThe 'paradox': Cassels weakens one condition but strengthens the other, and the combination works. The gap between Erdős's and Cassels's conditions is the open question.",
+    "mathContext": "The growth strengthening (dividing by log log x) is substantial — Erdős only requires divergence to ∞, while Cassels requires divergence faster than log log x.",
+    "significance": "critical",
+    "relatedConcepts": ["Cassels 1960", "stronger hypotheses", "log log growth"]
+  },
+  {
+    "id": "ann-e254-examples",
+    "proofId": "erdos-254",
+    "range": { "startLine": 139, "endLine": 156 },
+    "type": "axiom",
+    "title": "Powers of 2 Example",
+    "content": "**PowersOf2** = {1, 2, 4, 8, 16, ...} satisfies both conditions:\n\n1. **Growth**: Each dyadic interval [2^k, 2^{k+1}] contains exactly one power of 2, so the count grows.\n2. **Irrationality**: For irrational θ, {θ · 2^k} is equidistributed; for rational θ = p/q, eventually 2^k mod q cycles through residues.\n3. **Representation**: Every n ∈ ℕ has a unique binary representation as a sum of distinct powers of 2.\n\nThis is the canonical example confirming the conjecture's conclusion is reasonable.",
+    "significance": "key",
+    "relatedConcepts": ["binary representation", "equidistribution", "concrete example"]
+  },
+  {
+    "id": "ann-e254-summary",
+    "proofId": "erdos-254",
+    "range": { "startLine": 158, "endLine": 185 },
+    "type": "theorem",
+    "title": "Summary Theorem",
+    "content": "**erdos_254_summary (proved from axioms):**\n\nCombines three results:\n1. Cassels's theorem: representation under strong conditions\n2. Powers of 2 satisfy growth + irrationality conditions\n3. Powers of 2 represent all large integers\n\nProved by: `⟨cassels_theorem, ⟨powers_of_2_growth, powers_of_2_irrationality⟩, powers_of_2_representation⟩`",
+    "significance": "critical"
+  }
+]


### PR DESCRIPTION
## Summary
- Removed 7 trivial `True` axioms (growth_intuition, irrationality_intuition, condition_gap, irrationality_gap, subset_sum_connection, sidon_connection, erdos_254_open)
- Removed `erdos_254_status : True := trivial` and `erdos_254_status_str : String`
- Added proper `erdos_254_summary` theorem combining Cassels theorem + powers of 2 example
- Rewrote meta.json from scraped HTML garbage to proper content with 3-paragraph historicalContext
- Rewrote annotations.json from empty `[]` to 7 substantive annotations
- 217→185 lines

## Test plan
- [x] `pnpm build` succeeds
- [x] No `True := trivial` remaining
- [x] No trivial `True` axioms remaining
- [x] No `String` defs remaining
- [x] Summary theorem proves from axioms

🤖 Generated with [Claude Code](https://claude.com/claude-code)