### PR TITLE
enhance(erdos-857): fix header and forward reference

### DIFF
--- a/proofs/Proofs/Erdos857Problem.lean
+++ b/proofs/Proofs/Erdos857Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
 Erdős Problem #857: The Weak Sunflower Problem
 
 Source: https://erdosproblems.com/857
@@ -89,13 +89,6 @@ theorem sunflower_petals_disjoint {α : Type*} [DecidableEq α]
 /-! ## Part II: The Sunflower Function m(n, k) -/
 
 /--
-**m(n, k):**
-The minimal m such that any family of m subsets of {1,...,n} contains a k-sunflower.
--/
-noncomputable def sunflowerNumber (n k : ℕ) : ℕ :=
-  Nat.find (sunflower_number_exists n k)
-
-/--
 **Existence of m(n, k):**
 For any n and k ≥ 2, there exists an m such that any family of m subsets
 of {1,...,n} must contain a k-sunflower.
@@ -105,6 +98,13 @@ This follows from the pigeonhole principle: at most 2^n subsets exist.
 axiom sunflower_number_exists (n k : ℕ) :
     ∃ m : ℕ, ∀ family : Finset (Finset (Fin n)),
       family.card ≥ m → ContainsSunflower family k
+
+/--
+**m(n, k):**
+The minimal m such that any family of m subsets of {1,...,n} contains a k-sunflower.
+-/
+noncomputable def sunflowerNumber (n k : ℕ) : ℕ :=
+  Nat.find (sunflower_number_exists n k)
 
 /-! ## Part III: Classical Sunflower Lemma (Erdős-Ko-Rado) -/
 

--- a/src/data/proofs/erdos-857/annotations.json
+++ b/src/data/proofs/erdos-857/annotations.json
@@ -32,7 +32,7 @@
     "range": { "startLine": 91, "endLine": 107 },
     "type": "definition",
     "title": "The Sunflower Function m(n,k)",
-    "content": "sunflowerNumber n k: The minimal m such that any family of m subsets of {1,...,n} contains a k-sunflower. Defined via Nat.find from the existence axiom. Well-defined since at most 2^n subsets exist.",
+    "content": "sunflower_number_exists axiom: For any n and k, there exists m such that any family of m subsets of {1,...,n} contains a k-sunflower. sunflowerNumber n k: Defined as the minimal such m via Nat.find. Well-defined since at most 2^n subsets exist.",
     "significance": "critical"
   },
   {


### PR DESCRIPTION
## Summary
- Fix file header from `/-` to `/-!` doc comment
- Reorder `sunflower_number_exists` axiom before `sunflowerNumber` definition to resolve forward reference (`Nat.find` requires the existence proof to be declared first)
- Update annotation content for reordered section

## Test plan
- [x] `pnpm build` passes
- [x] No `sorry` remaining
- [x] No `True := trivial` remaining
- [x] Forward reference resolved (axiom before definition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)