### PR TITLE
enhance(erdos-984): remove sorry, trivial True axioms, dubious defs

### DIFF
--- a/proofs/Proofs/Erdos984Problem.lean
+++ b/proofs/Proofs/Erdos984Problem.lean
@@ -70,22 +70,15 @@ def SatisfiesCondition (χ : Coloring) : Prop :=
 /-!
 ## Part 3: Van der Waerden's Theorem Connection
 
-Van der Waerden's theorem guarantees monochromatic APs exist.
+Van der Waerden's theorem guarantees monochromatic APs exist in any finite coloring.
 -/
 
-/-- Van der Waerden number W(r, k): minimum N such that any r-coloring of [1..N]
-    has a monochromatic k-AP -/
-noncomputable def vanDerWaerden (r k : ℕ) : ℕ :=
-  Classical.choose (⟨1, fun _ _ _ _ => trivial⟩ : ∃ N : ℕ, N > 0)
-
-/-- Van der Waerden's theorem -/
+/-- Van der Waerden's theorem: any r-coloring of a sufficiently long initial
+    segment of ℕ contains a monochromatic k-term AP -/
 axiom van_der_waerden_theorem (r k : ℕ) (hr : 2 ≤ r) (hk : 3 ≤ k) :
-    ∀ χ : Fin (vanDerWaerden r k) → Fin r,
-    ∃ a d : ℕ, 0 < d ∧ ∀ i < k, χ ⟨a + i * d, sorry⟩ = χ ⟨a, sorry⟩
-
-/-- The inverse of the van der Waerden function grows extremely slowly -/
-axiom inverse_vdw_grows_slowly :
-    GrowsSlowerThanAnyPower (fun N => Nat.find ⟨3, fun _ _ => rfl⟩)
+    ∃ N : ℕ, ∀ χ : Fin N → Fin r,
+    ∃ a d : ℕ, 0 < d ∧ a + (k - 1) * d < N ∧
+      ∀ i < k, χ ⟨a + i * d, by omega⟩ = χ ⟨a, by omega⟩
 
 /-!
 ## Part 4: Spencer's 3-Coloring Result
@@ -133,21 +126,11 @@ Zach Hunter proved the full result with 2 colors.
 axiom hunter_theorem :
     ∃ χ : Coloring, SatisfiesCondition χ
 
-/-- The construction is explicit (probabilistic method) -/
-axiom hunter_construction_method :
-    -- The proof uses probabilistic methods and careful analysis
-    -- of the structure of arithmetic progressions
-    True
-
 /-!
 ## Part 7: The Chromatic Number Perspective
 
 How many colors are needed for various bounds?
 -/
-
-/-- Minimum colors needed for bound k ≪ f(a) -/
-noncomputable def chromaticNumber (f : ℕ → ℕ) : ℕ :=
-  Nat.find ⟨3, fun _ _ => trivial⟩
 
 /-- For f(a) = a^ε (any ε > 0), 2 colors suffice -/
 axiom two_colors_suffice_for_power_bound :
@@ -184,19 +167,19 @@ axiom erdos_exponent_bound :
     ∃ c : ℝ, c > 0 ∧ c < 1 ∧
     ∃ χ : Coloring, ErdosWeakBound χ c 1
 
-/-- No trivial lower bound was known by Erdős -/
-axiom no_known_lower_bound :
-    -- Erdős explicitly noted he knew no non-trivial lower bound
-    -- i.e., no proof that k ≥ g(a) for any slowly growing g
-    True
-
 /-!
-## Part 9: Main Problem Statement
+## Part 9: Summary
 -/
 
-/-- Erdős Problem #984: Complete statement -/
-theorem erdos_984_statement :
-    -- 2-coloring exists with k ≪_ε a^ε bound
+/-- **Erdős Problem #984: Summary**
+
+Combines the main results:
+1. Hunter's 2-coloring with k ≪_ε a^ε (the answer is YES)
+2. Spencer's 3-coloring with slowly growing bound
+3. Erdős's partial k ≪ a^{1-c} construction
+-/
+theorem erdos_984_summary :
+    -- The problem is solved affirmatively (Hunter)
     (∃ χ : Coloring, SatisfiesCondition χ) ∧
     -- Spencer: 3 colors achieve inverse vdW bound
     (∃ χ : Coloring3, ∀ a d k : ℕ, 0 < a → 0 < d → 2 ≤ k →
@@ -204,35 +187,6 @@ theorem erdos_984_statement :
       GrowsSlowerThanAnyPower (fun _ => k)) ∧
     -- Erdős partial: k ≪ a^{1-c}
     (∃ χ : Coloring, ∃ c C : ℝ, ErdosWeakBound χ c C) := by
-  constructor
-  · exact hunter_theorem
-  constructor
-  · exact spencer_1975
-  · exact erdos_partial_construction
-
-/-!
-## Part 10: Summary
--/
-
-/-- Summary of Erdős Problem #984 -/
-theorem erdos_984_summary :
-    -- The problem is solved affirmatively
-    (∃ χ : Coloring, SatisfiesCondition χ) ∧
-    -- 2 colors suffice (Hunter)
-    (∀ ε : ℝ, 0 < ε →
-      ∃ χ : Coloring, ∀ a d k : ℕ, 0 < a → 0 < d → 2 ≤ k →
-        MonochromaticAP χ a d k →
-        ∃ C : ℝ, C > 0 ∧ (k : ℝ) ≤ C * (a : ℝ) ^ ε) ∧
-    -- 1 color is insufficient
-    (¬∃ χ : ℕ → Fin 1, ∀ k : ℕ, 3 ≤ k →
-      ¬∃ a d : ℕ, 0 < d ∧ ∀ i < k, χ (a + i * d) = χ a) := by
-  constructor
-  · exact hunter_theorem
-  constructor
-  · exact two_colors_suffice_for_power_bound
-  · exact one_color_insufficient
-
-/-- The answer to Erdős Problem #984: SOLVED (YES) -/
-theorem erdos_984_answer : True := trivial
+  exact ⟨hunter_theorem, spencer_1975, erdos_partial_construction⟩
 
 end Erdos984

--- a/src/data/proofs/erdos-984/annotations.json
+++ b/src/data/proofs/erdos-984/annotations.json
@@ -5,34 +5,16 @@
     "type": "context",
     "range": { "startLine": 1, "endLine": 21 },
     "title": "Problem Introduction",
-    "content": "Erdős Problem #984 asks whether ℕ can be 2-colored such that monochromatic k-term arithmetic progressions starting at a satisfy k ≪_ε a^ε. Zach Hunter proved this is achievable.",
+    "content": "Erdős Problem #984 asks whether ℕ can be 2-colored such that monochromatic k-term arithmetic progressions starting at a satisfy k ≪_ε a^ε for all ε > 0. Zach Hunter proved YES, improving on Spencer's 3-color result and Erdős's partial bound k ≪ a^{1-c}.",
     "significance": "critical"
   },
   {
-    "id": "erdos-984-coloring",
+    "id": "erdos-984-coloring-defs",
     "proofId": "erdos-984",
     "type": "definition",
-    "range": { "startLine": 39, "endLine": 40 },
-    "title": "2-Coloring Definition",
-    "content": "A 2-coloring is a function χ: ℕ → Bool assigning each natural number one of two colors (true or false).",
-    "significance": "key"
-  },
-  {
-    "id": "erdos-984-arith-prog",
-    "proofId": "erdos-984",
-    "type": "definition",
-    "range": { "startLine": 42, "endLine": 44 },
-    "title": "Arithmetic Progression",
-    "content": "ArithProg a d k represents the k-term arithmetic progression {a, a+d, a+2d, ..., a+(k-1)d} as a finite set.",
-    "significance": "key"
-  },
-  {
-    "id": "erdos-984-monochromatic",
-    "proofId": "erdos-984",
-    "type": "definition",
-    "range": { "startLine": 46, "endLine": 52 },
-    "title": "Monochromatic Sets",
-    "content": "A set is monochromatic under coloring χ if all its elements share the same color. MonochromaticAP checks this for arithmetic progressions.",
+    "range": { "startLine": 39, "endLine": 52 },
+    "title": "Colorings and Arithmetic Progressions",
+    "content": "Coloring := ℕ → Bool assigns each natural number one of two colors. ArithProg a d k represents {a, a+d, ..., a+(k-1)d} as a Finset. IsMonochromatic checks if all elements share the same color. MonochromaticAP combines these for arithmetic progressions.",
     "significance": "key"
   },
   {
@@ -40,98 +22,54 @@
     "proofId": "erdos-984",
     "type": "definition",
     "range": { "startLine": 60, "endLine": 68 },
-    "title": "Growth Condition",
-    "content": "GrowsSlowerThanAnyPower formalizes k ≪_ε a^ε: for all ε > 0, there exists C > 0 such that k ≤ C·a^ε. SatisfiesCondition requires all monochromatic APs to satisfy this bound.",
+    "title": "Growth Condition k ≪_ε a^ε",
+    "content": "GrowsSlowerThanAnyPower formalizes the condition that for all ε > 0, there exists C > 0 such that f(a) ≤ C·a^ε. SatisfiesCondition requires that for every monochromatic AP with parameters (a, d, k), the length k satisfies this subpolynomial growth bound relative to the starting point a.",
+    "mathContext": "This is the formal statement of 'k ≪_ε a^ε': k grows slower than any positive power of a.",
     "significance": "critical"
   },
   {
     "id": "erdos-984-van-der-waerden",
     "proofId": "erdos-984",
     "type": "axiom",
-    "range": { "startLine": 76, "endLine": 84 },
+    "range": { "startLine": 76, "endLine": 81 },
     "title": "Van der Waerden's Theorem",
-    "content": "For any r-coloring and k ≥ 3, there exists N = W(r,k) such that any r-coloring of [1..N] contains a monochromatic k-term AP. This fundamental theorem forces monochromatic progressions.",
+    "content": "For any r-coloring (r ≥ 2) and k ≥ 3, there exists N such that any r-coloring of {0, ..., N-1} contains a monochromatic k-term arithmetic progression. This fundamental Ramsey-theoretic result guarantees that monochromatic APs are unavoidable; the question is only how long they must be.",
     "significance": "critical"
-  },
-  {
-    "id": "erdos-984-inverse-vdw",
-    "proofId": "erdos-984",
-    "type": "axiom",
-    "range": { "startLine": 86, "endLine": 88 },
-    "title": "Inverse Van der Waerden",
-    "content": "The inverse of the van der Waerden function grows extremely slowly—slower than any fixed power a^ε. This was the bound Spencer achieved with 3 colors.",
-    "significance": "key"
   },
   {
     "id": "erdos-984-spencer",
     "proofId": "erdos-984",
     "type": "axiom",
-    "range": { "startLine": 103, "endLine": 107 },
-    "title": "Spencer's 3-Coloring",
-    "content": "Spencer (1975) proved that with 3 colors, one can achieve the bound k ≪ h(a) where h is related to the inverse van der Waerden function, which grows slower than any power.",
-    "significance": "key"
-  },
-  {
-    "id": "erdos-984-erdos-weak",
-    "proofId": "erdos-984",
-    "type": "definition",
-    "range": { "startLine": 115, "endLine": 124 },
-    "title": "Erdős's Weaker Bound",
-    "content": "Erdős claimed a 2-coloring achieving k ≪ a^{1-c} for some absolute constant c > 0, which is weaker than the full k ≪_ε a^ε requirement.",
+    "range": { "startLine": 96, "endLine": 100 },
+    "title": "Spencer's 3-Coloring (1975)",
+    "content": "Spencer proved that with 3 colors, one can achieve the bound k ≪ h(a) where h is related to the inverse van der Waerden function, which grows slower than any power a^ε. This was the first result of its kind, showing the growth condition is achievable but requiring more colors than the 2 asked for in Problem #984.",
     "significance": "key"
   },
   {
     "id": "erdos-984-hunter",
     "proofId": "erdos-984",
     "type": "axiom",
-    "range": { "startLine": 132, "endLine": 134 },
-    "title": "Hunter's Theorem",
-    "content": "Zach Hunter proved there exists a 2-coloring satisfying k ≪_ε a^ε for all ε > 0, resolving the problem completely. This is the key external result axiomatized here.",
+    "range": { "startLine": 125, "endLine": 127 },
+    "title": "Hunter's Theorem (Solution)",
+    "content": "Zach Hunter proved there exists a 2-coloring χ such that SatisfiesCondition χ holds, i.e., all monochromatic APs starting at a with k terms satisfy k ≪_ε a^ε. This resolves Erdős Problem #984 affirmatively. The proof uses probabilistic methods.",
     "significance": "critical"
-  },
-  {
-    "id": "erdos-984-two-colors",
-    "proofId": "erdos-984",
-    "type": "axiom",
-    "range": { "startLine": 152, "endLine": 157 },
-    "title": "Two Colors Suffice",
-    "content": "For any fixed ε > 0, there exists a 2-coloring such that all monochromatic APs starting at a with k terms satisfy k ≤ C·a^ε for some constant C.",
-    "significance": "key"
   },
   {
     "id": "erdos-984-one-color",
     "proofId": "erdos-984",
     "type": "theorem",
-    "range": { "startLine": 159, "endLine": 174 },
-    "title": "One Color Insufficient",
-    "content": "With only 1 color, every set is trivially monochromatic, so arbitrarily long APs exist starting at any position. This proves 2 is the minimum number of colors needed.",
+    "range": { "startLine": 142, "endLine": 157 },
+    "title": "One Color is Insufficient",
+    "content": "With only 1 color, every subset of ℕ is trivially monochromatic, so arbitrarily long monochromatic APs exist starting at any position. The proof uses Fin.eq_zero to show all values in Fin 1 are equal. This establishes that 2 is the optimal number of colors for the growth condition.",
     "significance": "key"
-  },
-  {
-    "id": "erdos-984-erdos-exponent",
-    "proofId": "erdos-984",
-    "type": "axiom",
-    "range": { "startLine": 182, "endLine": 185 },
-    "title": "Erdős's Exponent",
-    "content": "The optimal constant c in Erdős's k ≪ a^{1-c} construction satisfies 0 < c < 1. The exact value remains unspecified.",
-    "significance": "key"
-  },
-  {
-    "id": "erdos-984-main-statement",
-    "proofId": "erdos-984",
-    "type": "theorem",
-    "range": { "startLine": 197, "endLine": 211 },
-    "title": "Main Problem Statement",
-    "content": "The complete formalization combines: Hunter's 2-coloring with k ≪_ε a^ε bound, Spencer's 3-coloring result, and Erdős's partial k ≪ a^{1-c} construction.",
-    "significance": "critical"
   },
   {
     "id": "erdos-984-summary",
     "proofId": "erdos-984",
     "type": "theorem",
-    "range": { "startLine": 217, "endLine": 233 },
+    "range": { "startLine": 174, "endLine": 192 },
     "title": "Summary Theorem",
-    "content": "Summary establishes: (1) The problem is solved affirmatively, (2) 2 colors suffice for any power bound, (3) 1 color is insufficient due to van der Waerden.",
+    "content": "erdos_984_summary combines three results: (1) Hunter's theorem — 2-coloring with k ≪_ε a^ε exists, (2) Spencer's theorem — 3-coloring with subpolynomial growth exists, (3) Erdős's partial construction — 2-coloring with k ≪ a^{1-c} exists. Proved by exact ⟨hunter_theorem, spencer_1975, erdos_partial_construction⟩.",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-984/meta.json
+++ b/src/data/proofs/erdos-984/meta.json
@@ -17,7 +17,7 @@
       "van-der-waerden"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 984,
     "erdosUrl": "https://erdosproblems.com/984",
     "erdosProblemStatus": "solved",
@@ -46,86 +46,80 @@
     ]
   },
   "overview": {
-    "historicalContext": "This problem, posed by Spencer, asks whether the natural numbers can be 2-colored such that monochromatic arithmetic progressions have controlled length. Spencer (1975) showed 3 colors suffice with bound related to the inverse van der Waerden function. Erdős claimed a 2-coloring with k ≪ a^{1-c} but noted no non-trivial lower bound was known. Zach Hunter resolved the full question affirmatively.",
+    "historicalContext": "Erdős Problem #984 asks whether the natural numbers can be 2-colored such that monochromatic arithmetic progressions have controlled length relative to their starting point. Specifically, if {a, a+d, ..., a+(k-1)d} is monochromatic, must k ≪_ε a^ε for all ε > 0?\n\nSpencer (1975) showed this is achievable with 3 colors using a bound related to the inverse van der Waerden function. Erdős himself claimed a 2-coloring achieving the weaker bound k ≪ a^{1-c} for some absolute constant c > 0, but noted he knew no non-trivial lower bound on progression lengths.\n\nZach Hunter resolved the problem completely, proving that 2 colors suffice for the full k ≪_ε a^ε bound. His proof uses probabilistic methods and careful analysis of the structure of arithmetic progressions. Combined with the trivial observation that 1 color fails (via van der Waerden's theorem), this shows 2 is the optimal number of colors.",
     "problemStatement": "Can ℕ be 2-colored such that if {a, a+d, ..., a+(k-1)d} is a k-term monochromatic arithmetic progression, then k ≪_ε a^ε for all ε > 0?",
     "proofStrategy": "The proof uses: (1) Definition of colorings and monochromatic arithmetic progressions, (2) Formalization of the growth condition k ≪_ε a^ε, (3) Connection to van der Waerden's theorem which forces monochromatic APs, (4) Axiomatization of Hunter's probabilistic construction, and (5) Proof that 1 color is trivially insufficient.",
     "keyInsights": [
       "Van der Waerden's theorem guarantees monochromatic APs exist in any finite coloring",
       "The question is about controlling how long these progressions can be relative to their starting point",
       "With 3 colors, Spencer achieved a bound via the inverse van der Waerden function",
-      "Hunter's breakthrough shows 2 colors suffice for the k ≪_ε a^ε bound"
+      "Hunter's breakthrough shows 2 colors suffice for the k ≪_ε a^ε bound",
+      "1 color trivially fails since all sets are monochromatic, making 2 optimal"
     ]
   },
   "sections": [
     {
       "id": "basic-definitions",
-      "title": "Basic Definitions",
+      "title": "Part 1: Basic Definitions",
       "startLine": 33,
       "endLine": 52,
       "summary": "Definitions of colorings, arithmetic progressions, and monochromaticity."
     },
     {
       "id": "growth-condition",
-      "title": "The Growth Condition",
+      "title": "Part 2: The Growth Condition",
       "startLine": 54,
       "endLine": 68,
       "summary": "Formalization of k ≪_ε a^ε using GrowsSlowerThanAnyPower predicate."
     },
     {
       "id": "van-der-waerden",
-      "title": "Van der Waerden Connection",
+      "title": "Part 3: Van der Waerden Connection",
       "startLine": 70,
-      "endLine": 88,
-      "summary": "Van der Waerden's theorem and its inverse function."
+      "endLine": 81,
+      "summary": "Van der Waerden's theorem axiomatized."
     },
     {
       "id": "spencer-result",
-      "title": "Spencer's 3-Coloring",
-      "startLine": 90,
-      "endLine": 107,
+      "title": "Part 4: Spencer's 3-Coloring",
+      "startLine": 83,
+      "endLine": 100,
       "summary": "Spencer's 1975 result achieving the bound with 3 colors."
     },
     {
       "id": "erdos-partial",
-      "title": "Erdős's Partial Result",
-      "startLine": 109,
-      "endLine": 124,
+      "title": "Part 5: Erdős's Partial Result",
+      "startLine": 102,
+      "endLine": 117,
       "summary": "Erdős's weaker bound k ≪ a^{1-c} for some c > 0."
     },
     {
       "id": "hunter-solution",
-      "title": "Hunter's Complete Solution",
-      "startLine": 126,
-      "endLine": 140,
+      "title": "Part 6: Hunter's Complete Solution",
+      "startLine": 119,
+      "endLine": 127,
       "summary": "Hunter's theorem resolving the problem for 2 colors."
     },
     {
       "id": "chromatic-number",
-      "title": "Chromatic Number Perspective",
-      "startLine": 142,
-      "endLine": 174,
-      "summary": "Analysis of minimum colors needed for various growth bounds."
+      "title": "Part 7: Chromatic Number Perspective",
+      "startLine": 129,
+      "endLine": 157,
+      "summary": "Two colors suffice, one color insufficient (proved)."
     },
     {
       "id": "explicit-bounds",
-      "title": "Explicit Bounds",
-      "startLine": 176,
-      "endLine": 191,
-      "summary": "Known bounds on constants and open questions about lower bounds."
-    },
-    {
-      "id": "main-statement",
-      "title": "Main Problem Statement",
-      "startLine": 193,
-      "endLine": 211,
-      "summary": "Complete formalization combining Hunter, Spencer, and Erdős results."
+      "title": "Part 8: Explicit Bounds",
+      "startLine": 159,
+      "endLine": 168,
+      "summary": "Erdős's exponent bound 0 < c < 1."
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "startLine": 213,
-      "endLine": 236,
-      "summary": "Summary theorem with the affirmative answer and chromatic bounds."
+      "title": "Part 9: Summary",
+      "startLine": 170,
+      "endLine": 192,
+      "summary": "Summary theorem combining Hunter, Spencer, and Erdős results."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove 2 `sorry` in `van_der_waerden_theorem` — rewritten as clean axiom
- Remove 2 trivial `True` axioms (`hunter_construction_method`, `no_known_lower_bound`)
- Remove `erdos_984_answer : True := trivial`
- Remove dubious `chromaticNumber` def and `inverse_vdw_grows_slowly` axiom (both used `Nat.find` with trivial existence proofs)
- Remove redundant `erdos_984_statement` (covered by `erdos_984_summary`)
- Consolidate from 10 parts to 9 parts
- Update meta.json: sorries 2→0, 3-paragraph historicalContext, sections match new line numbers
- Rewrite annotations.json with 8 substantive annotations

## Test plan
- [x] `pnpm build` succeeds
- [ ] Verify no `sorry`, no `True := trivial`, no trivial `True` axioms
- [ ] Verify meta.json section line numbers match actual file
- [ ] Verify annotations.json line ranges are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)