### PR TITLE
enhance(erdos-1096): fix doc comment headers

### DIFF
--- a/proofs/Proofs/Erdos1096Problem.lean
+++ b/proofs/Proofs/Erdos1096Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
 Erdős Problem #1096: Gap Convergence in q-Expansions
 
 Source: https://erdosproblems.com/1096
@@ -36,7 +36,7 @@ open Set Nat Real
 
 namespace Erdos1096
 
-/-
+/-!
 ## Part I: q-Expansions
 
 Numbers that can be written as finite sums of powers of q.
@@ -69,7 +69,7 @@ theorem q_q_representable (q : ℝ) : q ∈ QRepresentable q := by
   use {1}
   simp
 
-/-
+/-!
 ## Part II: The Ordered Sequence
 
 The q-representable numbers form a countable set that can be enumerated
@@ -88,7 +88,7 @@ axiom qSequence_initial (q : ℝ) (hq : 1 < q) (hq2 : q < 2) :
 /-- The gap between consecutive terms: x_{k+1} - x_k -/
 def gap (q : ℝ) (k : ℕ) : ℝ := qSequence q (k + 1) - qSequence q k
 
-/-
+/-!
 ## Part III: Pisot-Vijayaraghavan Numbers
 
 Special algebraic integers with important properties.
@@ -116,7 +116,7 @@ noncomputable def goldenRatio : ℝ := (1 + Real.sqrt 5) / 2
 
 axiom goldenRatio_is_pisot : IsPisot goldenRatio
 
-/-
+/-!
 ## Part IV: The Erdős-Joó-Komornik Results (1990)
 -/
 
@@ -133,7 +133,7 @@ axiom pisot_no_gap_property (q : ℝ) (hPisot : IsPisot q) :
 axiom gap_universal_bound (q : ℝ) (hq1 : 1 < q) (hq2 : q ≤ 2) :
     ∀ k : ℕ, gap q k ≤ 1
 
-/-
+/-!
 ## Part V: The Main Conjecture
 -/
 
@@ -150,7 +150,7 @@ def ErdosJooConjecture : Prop :=
 theorem conjecture_second_part : ¬HasGapProperty smallestPisot :=
   pisot_no_gap_property smallestPisot smallestPisot_is_pisot
 
-/-
+/-!
 ## Part VI: Characterization via m-Digit Expansions
 
 Bugeaud and others characterized Pisot numbers using generalized expansions.
@@ -178,7 +178,7 @@ axiom bugeaud_characterization (q : ℝ) (hq1 : 1 < q) (hq2 : q ≤ 2) :
 axiom ejs_refinement (q : ℝ) (hq1 : 1 < q) (hq2 : q < goldenRatio) :
     IsPisot q ↔ ∃ δ : ℝ, δ > 0 ∧ ∀ᶠ k in Filter.atTop, gapM q 2 k ≥ δ
 
-/-
+/-!
 ## Part VII: Density Result
 -/
 
@@ -189,7 +189,7 @@ axiom density_near_one :
       ∃ q : ℝ, 1 < q ∧ q < 1 + ε ∧
         ∀ x ∈ Set.Icc 0 N, ∃ y ∈ QRepresentable q, |x - y| < ε
 
-/-
+/-!
 ## Part VIII: Summary
 -/
 


### PR DESCRIPTION
## Summary
- Fix file header from `/-` to `/-!` doc comment
- Fix all 8 section headers from `/-` to `/-!` doc comments

## Test plan
- [x] `pnpm build` passes
- [x] No `sorry` remaining
- [x] No `True := trivial` remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)