### PR TITLE
enhance(erdos-812): remove 17 trivial True axioms, fix headers, consolidate

### DIFF
--- a/proofs/Proofs/Erdos812Problem.lean
+++ b/proofs/Proofs/Erdos812Problem.lean
@@ -17,10 +17,6 @@ The diagonal Ramsey number R(n) is the minimum N such that any 2-coloring
 of edges of K_N contains a monochromatic K_n. This problem asks about
 the growth rate of consecutive Ramsey numbers.
 
-Historical Note:
-Determining precise growth rates of Ramsey numbers is extremely difficult.
-Even computing R(5) exactly took decades of effort.
-
 References:
 - Burr-Erdős-Faudree-Schelp [BEFS89]: Lower bound on differences
 - Erdős [Er91]: Problem statement
@@ -32,7 +28,7 @@ import Mathlib.Combinatorics.SimpleGraph.Basic
 
 namespace Erdos812
 
-/-
+/-!
 ## Part I: Ramsey Number Definitions
 -/
 
@@ -69,7 +65,7 @@ The classical bounds are:
 axiom ramsey_bounds (n : ℕ) :
     n ≥ 3 → (2 : ℝ) ^ (n / 2 : ℝ) ≤ R n ∧ (R n : ℝ) ≤ (4 : ℝ) ^ n / Real.sqrt n
 
-/-
+/-!
 ## Part II: The Main Questions
 -/
 
@@ -87,13 +83,7 @@ Is R(n+1) - R(n) ≫ n²?
 def quadratic_difference_conjecture : Prop :=
   ∃ C : ℝ, C > 0 ∧ ∃ N : ℕ, ∀ n ≥ N, (R (n + 1) - R n : ℝ) ≥ C * n^2
 
-/--
-**Both conjectures remain OPEN:**
-Neither the ratio bound nor the quadratic difference has been proven.
--/
-axiom conjectures_open : True
-
-/-
+/-!
 ## Part III: Known Results
 -/
 
@@ -106,12 +96,6 @@ axiom BEFS_theorem :
     ∀ n ≥ 2, R (n + 1) - R n ≥ 4 * n - 8
 
 /--
-**The linear bound is best known:**
-No super-linear lower bound on R(n+1) - R(n) has been proven.
--/
-axiom linear_best_known : True
-
-/--
 **Related result from Problem #165:**
 R(n+2) - R(n) ≫ n^{2-o(1)}.
 This shows the two-step difference grows almost quadratically.
@@ -120,15 +104,8 @@ axiom problem_165_bound :
     ∃ f : ℕ → ℝ, (∀ n, f n > 0) ∧ (∀ ε > 0, ∃ N, ∀ n ≥ N, f n ≤ n^ε) ∧
     ∃ C : ℝ, C > 0 ∧ ∀ n ≥ 3, (R (n + 2) - R n : ℝ) ≥ C * n^2 / f n
 
-/--
-**Gap between one-step and two-step:**
-We know R(n+2) - R(n) ≫ n^{2-o(1)}, but not R(n+1) - R(n) ≫ n^2.
-The gap suggests the growth might be irregular.
--/
-axiom gap_observation : True
-
-/-
-## Part IV: What Would Follow
+/-!
+## Part IV: Consequences
 -/
 
 /--
@@ -139,126 +116,14 @@ giving true exponential growth.
 axiom ratio_implies_exponential (c : ℝ) (hc : c > 0) :
     (∀ n ≥ 3, (R (n + 1) : ℝ) / R n ≥ 1 + c) →
     ∀ n k : ℕ, 3 ≤ k → k ≤ n → (R n : ℝ) ≥ R k * (1 + c) ^ (n - k)
-  -- Proof by induction: multiply ratios R(k+1)/R(k) · R(k+2)/R(k+1) · ... · R(n)/R(n-1)
 
-/--
-**Quadratic difference implications:**
-R(n+1) - R(n) ≫ n² would establish that Ramsey numbers grow
-faster than any polynomial in n.
+/-!
+## Part V: Computational Verifications
 -/
-axiom quadratic_difference_implications : True
-
-/--
-**Connection to Ramsey number bounds:**
-Proving either conjecture would improve our understanding of
-the exact growth rate of R(n) between the known exponential bounds.
--/
-axiom connection_to_bounds : True
-
-/-
-## Part V: Why These Questions Are Hard
--/
-
-/--
-**Difficulty of Ramsey numbers:**
-Even computing R(5) exactly is unknown (43 ≤ R(5) ≤ 48).
-Growth rates are even harder than exact values.
--/
-axiom ramsey_difficulty : True
-
-/--
-**Irregular behavior:**
-The sequence R(n) may have irregular jumps, making ratio bounds
-difficult to establish uniformly.
--/
-axiom irregular_behavior : True
-
-/--
-**Probabilistic lower bounds:**
-The best lower bounds come from probabilistic arguments that
-don't give information about consecutive differences.
--/
-axiom probabilistic_limitations : True
-
-/--
-**Computational barriers:**
-Cannot be resolved through finite computation alone -
-would require asymptotic arguments.
--/
-axiom computational_barriers : True
-
-/-
-## Part VI: Related Problems
--/
-
-/--
-**Problem 165: Ramsey lower bounds:**
-Asks about improved lower bounds for R(n), connected via
-the R(n+2) - R(n) estimate.
--/
-axiom related_problem_165 : True
-
-/--
-**Off-diagonal Ramsey numbers:**
-R(s,t) for s ≠ t has similar open questions about growth rates.
--/
-axiom off_diagonal_ramsey : True
-
-/--
-**Hypergraph Ramsey:**
-Ramsey numbers for hypergraphs have even wilder growth rates
-(tower functions).
--/
-axiom hypergraph_ramsey : True
-
-/-
-## Part VII: Historical Context
--/
-
-/--
-**Ramsey's theorem (1930):**
-Frank Ramsey proved the existence of R(n) in his 1930 paper.
-Exact growth rates remain mysterious almost a century later.
--/
-axiom ramsey_1930 : True
-
-/--
-**Erdős-Szekeres (1935):**
-Established the upper bound R(n) ≤ C(2n-2, n-1) < 4^n.
--/
-axiom erdos_szekeres_1935 : True
-
-/--
-**Erdős probabilistic method (1947):**
-Established R(n) > 2^{n/2} using random graphs.
-This was a founding application of the probabilistic method.
--/
-axiom erdos_probabilistic_1947 : True
-
-/--
-**Erdős's quote on R(5):**
-"Suppose aliens invade the earth and threaten to obliterate it
-in a year's time unless human beings can find R(5). We could
-marshal the world's best minds and computers... But if they
-asked for R(6), we should have to just surrender."
--/
-axiom erdos_aliens_quote : True
-
-/-
-## Part VIII: Known Values and Bounds
--/
-
-/--
-**Table of known Ramsey numbers:**
-R(1) = 1, R(2) = 2, R(3) = 6, R(4) = 18.
-R(5) is unknown: 43 ≤ R(5) ≤ 48.
--/
-axiom known_ramsey_table : True
 
 /--
 **Growth of known values:**
 R(3)/R(2) = 3, R(4)/R(3) = 3.
-The ratio 3 suggests c ≈ 2 might work, but this is only 2 data points.
 -/
 example : (6 : ℚ) / 2 = 3 := by norm_num
 example : (18 : ℚ) / 6 = 3 := by norm_num
@@ -266,31 +131,21 @@ example : (18 : ℚ) / 6 = 3 := by norm_num
 /--
 **Consecutive differences:**
 R(3) - R(2) = 4, R(4) - R(3) = 12.
-Both exceed the 4n - 8 bound: 4 ≥ 0 and 12 ≥ 4.
 -/
 example : 6 - 2 = 4 := by norm_num
 example : 18 - 6 = 12 := by norm_num
 
 /--
 **Verification of BEFS bound for small n:**
-The bound 4n - 8 gives: n=2 → 0, n=3 → 4, n=4 → 8.
-Actual differences: R(3)-R(2)=4 ≥ 0 ✓, R(4)-R(3)=12 ≥ 4 ✓.
+4n - 8 gives: n=2 → 0, n=3 → 4, n=4 → 8.
+Actual differences exceed these bounds.
 -/
 example : 4 * 2 - 8 = 0 := by norm_num
 example : 4 * 3 - 8 = 4 := by norm_num
 example : 4 * 4 - 8 = 8 := by norm_num
 
-/--
-**Quadratic vs linear comparison:**
-At n = 10: linear bound gives 4·10 - 8 = 32.
-Quadratic would give n² = 100 (if the conjecture holds).
-Gap ratio is about 3x at n=10, grows linearly.
--/
-example : 4 * 10 - 8 = 32 := by norm_num
-example : (10 : ℕ)^2 = 100 := by norm_num
-
-/-
-## Part IX: Summary
+/-!
+## Part VI: Summary
 -/
 
 /--
@@ -306,28 +161,13 @@ KNOWN RESULTS:
 1. R(n+1) - R(n) ≥ 4n - 8 (Burr-Erdős-Faudree-Schelp 1989)
 2. R(n+2) - R(n) ≫ n^{2-o(1)} (from Problem #165)
 3. Overall bounds: 2^{n/2} ≤ R(n) ≤ 4^n / √n
-
-KEY INSIGHTS:
-1. Linear lower bound on differences is best known
-2. Two-step differences are almost quadratic
-3. Cannot be resolved computationally - needs asymptotic arguments
-4. Even R(5) is not known exactly
-
-A fundamental open problem in Ramsey theory.
 -/
-theorem erdos_812_status :
+theorem erdos_812_summary :
     -- The BEFS bound is established
     (∀ n ≥ 2, R (n + 1) - R n ≥ 4 * n - 8) ∧
-    -- But the main conjectures remain OPEN
-    True := by
-  constructor
-  · exact BEFS_theorem
-  · trivial
-
-/--
-**Problem status:**
-Erdős Problem #812 remains OPEN.
--/
-theorem erdos_812_open : True := trivial
+    -- The two-step bound from Problem #165
+    (∃ f : ℕ → ℝ, (∀ n, f n > 0) ∧ (∀ ε > 0, ∃ N, ∀ n ≥ N, f n ≤ n^ε) ∧
+      ∃ C : ℝ, C > 0 ∧ ∀ n ≥ 3, (R (n + 2) - R n : ℝ) ≥ C * n^2 / f n) :=
+  ⟨BEFS_theorem, problem_165_bound⟩
 
 end Erdos812

--- a/src/data/proofs/erdos-812/annotations.json
+++ b/src/data/proofs/erdos-812/annotations.json
@@ -1,242 +1,74 @@
 [
   {
-    "id": "ann-812-1",
+    "id": "ann-812-overview",
     "proofId": "erdos-812",
-    "range": {
-      "startLine": 1,
-      "endLine": 27
-    },
+    "range": { "startLine": 1, "endLine": 23 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "Erdős Problem #812 asks two questions about Ramsey number growth: (1) Is R(n+1)/R(n) ≥ 1+c for some c > 0? (2) Is R(n+1) - R(n) ≫ n²? Both remain OPEN. Best known: R(n+1) - R(n) ≥ 4n - 8.",
+    "content": "Erdős Problem #812 asks two questions about Ramsey number growth: (1) Is R(n+1)/R(n) ≥ 1+c for some c > 0? (2) Is R(n+1) - R(n) ≫ n²? Both remain OPEN. Best known: R(n+1) - R(n) ≥ 4n - 8 (BEFS 1989). The two-step difference R(n+2) - R(n) is almost quadratic.",
     "significance": "critical"
   },
   {
-    "id": "ann-812-2",
+    "id": "ann-812-ramsey",
     "proofId": "erdos-812",
-    "range": {
-      "startLine": 39,
-      "endLine": 44
-    },
+    "range": { "startLine": 35, "endLine": 66 },
     "type": "definition",
-    "title": "Diagonal Ramsey Number",
-    "content": "R(n) is the minimum N such that any 2-coloring of edges of K_N contains a monochromatic K_n. This is THE fundamental object in Ramsey theory, and determining its exact growth is one of the biggest open problems in combinatorics.",
+    "title": "Diagonal Ramsey Number and Bounds",
+    "content": "R(n) is axiomatized as the minimum N guaranteeing a monochromatic K_n in any 2-coloring of K_N. Basic properties: R(1)=1, R(2)=2, strictly increasing. Known values: R(3)=6, R(4)=18. Classical bounds: 2^{n/2} ≤ R(n) ≤ 4^n/√n, from Erdős's probabilistic method (1947) and Erdős-Szekeres (1935).",
     "significance": "critical"
   },
   {
-    "id": "ann-812-3",
+    "id": "ann-812-conjectures",
     "proofId": "erdos-812",
-    "range": {
-      "startLine": 46,
-      "endLine": 53
-    },
-    "type": "theorem",
-    "title": "Basic Properties",
-    "content": "R(1) = 1, R(2) = 2, and R is strictly increasing. These are the trivial values - the interesting behavior begins with R(3) = 6 and R(4) = 18.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-812-4",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 63,
-      "endLine": 70
-    },
-    "type": "theorem",
-    "title": "Classical Bounds",
-    "content": "2^{n/2} ≤ R(n) ≤ 4^n/√n. The lower bound uses the probabilistic method (Erdős 1947), the upper bound comes from Erdős-Szekeres (1935). The gap between these is HUGE and has barely narrowed in 80+ years.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-812-5",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 76,
-      "endLine": 81
-    },
+    "range": { "startLine": 68, "endLine": 84 },
     "type": "definition",
-    "title": "Ratio Conjecture",
-    "content": "First question: Is R(n+1)/R(n) ≥ 1 + c for some c > 0? This would establish that consecutive Ramsey numbers grow by at least a constant multiplicative factor - true exponential growth.",
+    "title": "The Two Main Conjectures",
+    "content": "ratio_conjecture: ∃ c > 0, ∃ N, ∀ n ≥ N, R(n+1)/R(n) ≥ 1+c. This would establish true exponential growth. quadratic_difference_conjecture: ∃ C > 0, ∃ N, ∀ n ≥ N, R(n+1) - R(n) ≥ C·n². This is much stronger than the known linear bound. Both remain completely open.",
     "significance": "critical"
   },
   {
-    "id": "ann-812-6",
+    "id": "ann-812-befs",
     "proofId": "erdos-812",
-    "range": {
-      "startLine": 83,
-      "endLine": 88
-    },
-    "type": "definition",
-    "title": "Quadratic Difference Conjecture",
-    "content": "Second question: Is R(n+1) - R(n) ≫ n²? This asks if the additive difference between consecutive Ramsey numbers is at least quadratic, which is much stronger than the known linear bound.",
+    "range": { "startLine": 86, "endLine": 96 },
+    "type": "axiom",
+    "title": "BEFS Theorem (1989)",
+    "content": "Burr-Erdős-Faudree-Schelp: R(n+1) - R(n) ≥ 4n - 8 for all n ≥ 2. This linear lower bound is the best known result on consecutive Ramsey number differences. The gap between this and the conjectured quadratic growth is enormous.",
     "significance": "critical"
   },
   {
-    "id": "ann-812-7",
+    "id": "ann-812-twostep",
     "proofId": "erdos-812",
-    "range": {
-      "startLine": 100,
-      "endLine": 106
-    },
+    "range": { "startLine": 98, "endLine": 105 },
+    "type": "axiom",
+    "title": "Two-Step Bound from Problem #165",
+    "content": "R(n+2) - R(n) ≫ n^{2-o(1)}: the TWO-step difference is almost quadratic. Formalized using a subpolynomial correction factor f(n) → 0. This tantalizing result shows that stepping by 2 instead of 1 dramatically changes the picture.",
+    "significance": "critical"
+  },
+  {
+    "id": "ann-812-exponential",
+    "proofId": "erdos-812",
+    "range": { "startLine": 107, "endLine": 118 },
+    "type": "axiom",
+    "title": "Ratio Implies Exponential Growth",
+    "content": "If R(n+1)/R(n) ≥ 1+c for all n ≥ 3, then by multiplying consecutive ratios: R(n) ≥ R(k)·(1+c)^{n-k}. This would pin down the exponential base of Ramsey number growth, currently only known to lie between √2 and 4.",
+    "significance": "key"
+  },
+  {
+    "id": "ann-812-computations",
+    "proofId": "erdos-812",
+    "range": { "startLine": 120, "endLine": 145 },
     "type": "theorem",
-    "title": "BEFS Theorem",
-    "content": "Burr-Erdős-Faudree-Schelp (1989): R(n+1) - R(n) ≥ 4n - 8 for all n ≥ 2. This linear lower bound is the best known result on consecutive differences. The gap to quadratic is enormous.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-812-8",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 114,
-      "endLine": 121
-    },
-    "type": "theorem",
-    "title": "Two-Step Bound",
-    "content": "From Problem #165: R(n+2) - R(n) ≫ n^{2-o(1)}. The TWO-step difference is almost quadratic! This suggests the one-step conjecture might be true but is much harder to prove.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-812-9",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 123,
-      "endLine": 128
-    },
-    "type": "concept",
-    "title": "Gap Observation",
-    "content": "We know R(n+2) - R(n) ≫ n^{2-o(1)} but only R(n+1) - R(n) ≥ 4n - 8. The factor of 2 in the step size makes a huge difference. This suggests growth may be irregular.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-812-10",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 134,
-      "endLine": 143
-    },
-    "type": "theorem",
-    "title": "Ratio Implies Exponential",
-    "content": "If R(n+1)/R(n) ≥ 1 + c, then R(n) ≥ R(k) · (1+c)^{n-k}, giving true exponential growth. This would narrow the gap between known bounds significantly.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-812-11",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 163,
-      "endLine": 168
-    },
-    "type": "concept",
-    "title": "Ramsey Difficulty",
-    "content": "Even R(5) is unknown! We only know 43 ≤ R(5) ≤ 48. Erdős famously said about R(6): 'we should have to just surrender' if aliens demanded it. Growth rates are even harder than exact values.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-812-12",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 170,
-      "endLine": 175
-    },
-    "type": "concept",
-    "title": "Irregular Behavior",
-    "content": "The sequence R(n) may have irregular jumps. Some consecutive pairs might grow by more, others by less. Uniform bounds like R(n+1)/R(n) ≥ 1 + c are hard to establish.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-812-13",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 177,
-      "endLine": 182
-    },
-    "type": "concept",
-    "title": "Probabilistic Limitations",
-    "content": "The probabilistic method gives excellent OVERALL bounds (2^{n/2} ≤ R(n)) but says nothing about consecutive differences. Different techniques are needed for difference questions.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-812-14",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 184,
-      "endLine": 189
-    },
-    "type": "concept",
-    "title": "Computational Barriers",
-    "content": "Cannot be resolved through finite computation alone. Even if we computed R(5), R(6), ..., R(100), that wouldn't prove asymptotic statements. Need theoretical arguments.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-812-15",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 219,
-      "endLine": 224
-    },
-    "type": "concept",
-    "title": "Ramsey's Theorem (1930)",
-    "content": "Frank Ramsey proved the existence of R(n) in his foundational 1930 paper. Nearly a century later, we still don't know the exact growth rate! A testament to the problem's difficulty.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-812-16",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 232,
-      "endLine": 237
-    },
-    "type": "concept",
-    "title": "Erdős Probabilistic Method",
-    "content": "In 1947, Erdős proved R(n) > 2^{n/2} using random graphs - a founding application of the probabilistic method. This lower bound has only been improved by factors of √2, not exponentially.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-812-17",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 259,
-      "endLine": 273
-    },
-    "type": "concept",
-    "title": "Known Values",
-    "content": "R(3)/R(2) = 6/2 = 3, R(4)/R(3) = 18/6 = 3. Both ratios are 3, suggesting c ≈ 2 might work. But with only 2 data points, this is speculative. R(4) - R(3) = 12 ≫ 4·3 - 8 = 4.",
+    "title": "Computational Verifications",
+    "content": "Verified by norm_num: R(3)/R(2) = 6/2 = 3, R(4)/R(3) = 18/6 = 3 (both ratios are 3, suggesting c ≈ 2). Differences: R(3)-R(2) = 4, R(4)-R(3) = 12. BEFS bound check: 4n-8 gives 0, 4, 8 for n = 2, 3, 4 — all satisfied with room to spare.",
     "significance": "supporting"
   },
   {
-    "id": "ann-812-18",
+    "id": "ann-812-summary",
     "proofId": "erdos-812",
-    "range": {
-      "startLine": 274,
-      "endLine": 277
-    },
-    "type": "concept",
-    "title": "BEFS Bound Verification",
-    "content": "Computational verification of BEFS bound 4n-8 for small n: n=2 → 0, n=3 → 4, n=4 → 8. Actual differences (4, 12) exceed these bounds, showing BEFS is satisfied with room to spare.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-812-19",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 279,
-      "endLine": 287
-    },
-    "type": "concept",
-    "title": "Quadratic vs Linear Gap",
-    "content": "At n=10: linear BEFS bound gives 32, quadratic would give 100. The gap ratio is about 3x at n=10 and grows linearly in n. This highlights the enormous distance between what we know and what we suspect.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-812-20",
-    "proofId": "erdos-812",
-    "range": {
-      "startLine": 296,
-      "endLine": 325
-    },
+    "range": { "startLine": 147, "endLine": 173 },
     "type": "theorem",
-    "title": "Problem Status",
-    "content": "Erdős #812 remains OPEN for both questions. Known: BEFS linear bound and Problem #165's two-step bound. Unknown: whether one-step growth is at least quadratic or whether ratios have a constant lower bound.",
+    "title": "Summary: OPEN",
+    "content": "erdos_812_summary combines the BEFS linear bound and Problem #165 two-step bound: (∀ n ≥ 2, R(n+1) - R(n) ≥ 4n - 8) ∧ (∃ f subpolynomial, ∃ C > 0, ∀ n ≥ 3, R(n+2) - R(n) ≥ Cn²/f(n)). Both main conjectures remain open. Proved by exact ⟨BEFS_theorem, problem_165_bound⟩.",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-812/meta.json
+++ b/src/data/proofs/erdos-812/meta.json
@@ -15,118 +15,81 @@
       "ramsey-theory",
       "graph-theory"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "mathlib_version": "4.15.0",
+    "erdosNumber": 812,
+    "erdosUrl": "https://erdosproblems.com/812",
+    "erdosProblemStatus": "open",
     "mathlibDependencies": [
-      {
-        "theorem": "Nat.Basic",
-        "description": "Natural number operations",
-        "module": "Mathlib.Data.Nat.Basic"
-      },
-      {
-        "theorem": "Real.Basic",
-        "description": "Real number operations for bounds",
-        "module": "Mathlib.Data.Real.Basic"
-      },
-      {
-        "theorem": "SimpleGraph.Basic",
-        "description": "Graph definitions for Ramsey context",
-        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
-      }
+      { "theorem": "Nat.Basic", "description": "Natural number operations", "module": "Mathlib.Data.Nat.Basic" },
+      { "theorem": "Real.Basic", "description": "Real number operations for bounds", "module": "Mathlib.Data.Real.Basic" }
     ],
     "originalContributions": [
       "R axiom: the diagonal Ramsey number",
       "R_basic: R(1)=1, R(2)=2, strict increasing",
       "R_known_values: R(3)=6, R(4)=18",
       "ramsey_bounds axiom: 2^{n/2} ≤ R(n) ≤ 4^n/√n",
-      "ratio_conjecture definition: R(n+1)/R(n) ≥ 1+c question",
-      "quadratic_difference_conjecture definition: R(n+1)-R(n) ≫ n² question",
+      "ratio_conjecture and quadratic_difference_conjecture definitions",
       "BEFS_theorem axiom: R(n+1) - R(n) ≥ 4n - 8",
       "problem_165_bound axiom: two-step almost-quadratic bound",
       "ratio_implies_exponential: logical consequence",
-      "Computational verifications: ratios and BEFS bounds for small n",
-      "erdos_812_status theorem: captures known state"
-    ],
-    "erdosNumber": 812,
-    "erdosUrl": "https://erdosproblems.com/812",
-    "erdosProblemStatus": "open"
+      "Computational verifications for small n"
+    ]
   },
   "overview": {
-    "historicalContext": "**The Birth of Ramsey Theory (1930)**\n\nFrank Ramsey proved his fundamental theorem in 1930, establishing that R(n) exists for all n. This was the beginning of an entire field, but exact growth rates remained mysterious.\n\n**The Classical Bounds (1935-1947)**\n\nErdős and Szekeres (1935) proved R(n) ≤ C(2n-2, n-1) < 4^n/√n, a remarkably simple bound. In 1947, Erdős revolutionized combinatorics by proving R(n) > 2^{n/2} using the probabilistic method - showing that random 2-colorings work with positive probability. Despite 80+ years of effort, these bounds have only been improved by polynomial factors!\n\n**The BEFS Linear Bound (1989)**\n\nBurr, Erdős, Faudree, and Schelp proved R(n+1) - R(n) ≥ 4n - 8, the best known bound on consecutive differences. This linear bound stands in stark contrast to the suspected quadratic truth. The related Problem #165 shows R(n+2) - R(n) ≫ n^{2-o(1)}, tantalizingly close to quadratic for two-step differences.\n\n**Erdős's Famous Quote**\n\nErdős illustrated the difficulty with his 'aliens' thought experiment: if aliens demanded R(5) or R(6), 'We could marshal the world's best minds and computers' for R(5), 'But if they asked for R(6), we should have to just surrender.' We still don't know R(5) exactly (43 ≤ R(5) ≤ 48).",
+    "historicalContext": "Erdős Problem #812 asks two fundamental questions about how fast consecutive Ramsey numbers grow. The diagonal Ramsey number R(n) — the minimum N guaranteeing a monochromatic K_n in any 2-coloring of K_N — is known to satisfy 2^{n/2} ≤ R(n) ≤ 4^n/√n, but the exact growth rate remains one of the biggest mysteries in combinatorics.\n\nBurr, Erdős, Faudree, and Schelp proved in 1989 that R(n+1) - R(n) ≥ 4n - 8, giving a linear lower bound on consecutive differences. This is the best known result. Tantalizingly, the related Problem #165 shows that the TWO-step difference R(n+2) - R(n) is almost quadratic (≫ n^{2-o(1)}), but the one-step gap remains wide.\n\nErdős illustrated the difficulty of Ramsey numbers with his famous aliens thought experiment: 'if aliens demanded R(5), we could marshal the world's best minds... but if they asked for R(6), we should have to just surrender.' We still don't know R(5) exactly (43 ≤ R(5) ≤ 48). Both questions in Problem #812 remain completely open.",
     "problemStatement": "Is it true that R(n+1)/R(n) ≥ 1 + c for some constant c > 0 and all large n? Is it true that R(n+1) - R(n) ≫ n²?",
-    "proofStrategy": "The formalization defines the Ramsey function R(n), states the two main conjectures, and presents the known results. The BEFS theorem gives a linear lower bound on differences. The connection to Problem #165 shows that two-step differences are almost quadratic. The gap between one-step and two-step bounds is highlighted.",
+    "proofStrategy": "The formalization defines the Ramsey function R(n), states the two main conjectures, and presents the known results. The BEFS theorem gives a linear lower bound on differences. The connection to Problem #165 shows that two-step differences are almost quadratic. Computational verifications for small n are included.",
     "keyInsights": [
       "The linear bound R(n+1) - R(n) ≥ 4n - 8 is best known",
       "Two-step differences R(n+2) - R(n) ≫ n^{2-o(1)} are much larger",
-      "Cannot be resolved by finite computation - needs asymptotic arguments",
       "Ramsey numbers have mysterious growth between 2^{n/2} and 4^n",
-      "The sequence R(n) may have irregular jumps"
+      "The ratio conjecture would imply true exponential growth",
+      "Even R(5) is not known exactly"
     ]
   },
   "sections": [
     {
-      "id": "section-1",
-      "title": "Ramsey Number Definitions",
-      "startLine": 35,
-      "endLine": 71,
-      "summary": "Defines the diagonal Ramsey number R(n), basic properties (R(1)=1, R(2)=2, monotonicity), known values (R(3)=6, R(4)=18), and the classical bounds 2^{n/2} ≤ R(n) ≤ 4^n/√n."
+      "id": "ramsey-defs",
+      "title": "Part I: Ramsey Number Definitions",
+      "startLine": 31,
+      "endLine": 66,
+      "summary": "R(n) axiom, basic properties, known values, classical bounds."
     },
     {
-      "id": "section-2",
-      "title": "Main Questions",
-      "startLine": 72,
-      "endLine": 95,
-      "summary": "Formalizes the two main conjectures: the ratio conjecture (R(n+1)/R(n) ≥ 1+c) and the quadratic difference conjecture (R(n+1) - R(n) ≫ n²)."
+      "id": "main-questions",
+      "title": "Part II: The Main Questions",
+      "startLine": 68,
+      "endLine": 84,
+      "summary": "ratio_conjecture and quadratic_difference_conjecture definitions."
     },
     {
-      "id": "section-3",
-      "title": "Known Results",
-      "startLine": 96,
-      "endLine": 129,
-      "summary": "States the BEFS theorem (R(n+1) - R(n) ≥ 4n - 8), notes this linear bound is best known, and presents the related result from Problem #165 about two-step differences."
+      "id": "known-results",
+      "title": "Part III: Known Results",
+      "startLine": 86,
+      "endLine": 105,
+      "summary": "BEFS theorem and Problem #165 two-step bound."
     },
     {
-      "id": "section-4",
-      "title": "Implications",
-      "startLine": 130,
-      "endLine": 158,
-      "summary": "Shows what would follow from the conjectures: ratio bound implies exponential growth, quadratic differences imply super-polynomial growth."
+      "id": "consequences",
+      "title": "Part IV: Consequences",
+      "startLine": 107,
+      "endLine": 118,
+      "summary": "Ratio bound implies exponential growth."
     },
     {
-      "id": "section-5",
-      "title": "Why Questions Are Hard",
-      "startLine": 159,
-      "endLine": 190,
-      "summary": "Explains difficulties: even R(5) is unknown, irregular behavior, probabilistic methods don't give consecutive differences, and computational barriers."
+      "id": "computations",
+      "title": "Part V: Computational Verifications",
+      "startLine": 120,
+      "endLine": 145,
+      "summary": "Verified ratios and BEFS bound for small n."
     },
     {
-      "id": "section-6",
-      "title": "Related Problems",
-      "startLine": 191,
-      "endLine": 214,
-      "summary": "Connections to Problem #165 (Ramsey lower bounds), off-diagonal Ramsey numbers R(s,t), and hypergraph Ramsey numbers."
-    },
-    {
-      "id": "section-7",
-      "title": "Historical Context",
-      "startLine": 215,
-      "endLine": 247,
-      "summary": "History from Ramsey (1930) through Erdős-Szekeres (1935) to Erdős's probabilistic method (1947). Includes the famous 'aliens' quote about R(5) and R(6)."
-    },
-    {
-      "id": "section-8",
-      "title": "Known Values and Computational Verification",
-      "startLine": 248,
-      "endLine": 290,
-      "summary": "Known Ramsey values, computed ratios R(3)/R(2)=3, R(4)/R(3)=3, BEFS bound verification for small n, and quadratic vs linear comparison."
-    },
-    {
-      "id": "section-9",
-      "title": "Summary and Status",
-      "startLine": 291,
-      "endLine": 333,
-      "summary": "Complete summary with main status theorem capturing the BEFS bound and open status."
+      "id": "summary",
+      "title": "Part VI: Summary",
+      "startLine": 147,
+      "endLine": 173,
+      "summary": "erdos_812_summary combining BEFS and Problem #165 bounds."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove **17** trivial `True` axioms (commentary about difficulty, history, etc.)
- Remove `erdos_812_open : True := trivial`
- Replace `erdos_812_status` (which had `∧ True`) with meaningful `erdos_812_summary` combining BEFS and Problem #165 bounds
- Fix all 9 section headers from `/-` to `/-!`
- Consolidate from 9 parts to 6 parts
- Update meta.json: badge "mathlib" → "axiom", sections match new line numbers, 3-paragraph historicalContext
- Rewrite annotations.json with 8 substantive annotations

## Test plan
- [x] `pnpm build` succeeds
- [ ] Verify no `True := trivial`, no trivial `True` axioms
- [ ] Verify meta.json section line numbers match actual file
- [ ] Verify annotations.json line ranges are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)