### PR TITLE
fix(erdos-419): remove True axioms, invalid syntax, True := trivial

### DIFF
--- a/proofs/Proofs/Erdos419Problem.lean
+++ b/proofs/Proofs/Erdos419Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
   Erdős Problem #419: Limit Points of τ((n+1)!)/τ(n!)
 
   Source: https://erdosproblems.com/419
@@ -123,13 +123,6 @@ axiom large_prime_valuation (p n : ℕ) (hp : p.Prime) (hdiv : p ∣ n + 1)
     (hlarge : (p : ℝ) > n^(2/3 : ℝ)) :
     padicValNat p (n + 1) = 1
 
-/-- Large prime p > n^(2/3) dividing n+1 = pk contributes (1 + 1/k) -/
-axiom large_prime_contribution (p n : ℕ) (hp : p.Prime) (hdiv : p ∣ n + 1)
-    (hlarge : (p : ℝ) > n^(2/3 : ℝ)) :
-    let k := (n + 1) / p
-    (1 + (padicValNat p (n + 1) : ℚ) / (padicValNat p n.factorial + 1)) =
-      (1 : ℚ) + 1 / k + o(1)  -- Informal; actual statement uses limits
-
 /-- When n+1 is prime, the ratio is approximately 2 -/
 axiom prime_case (n : ℕ) (hp : (n + 1).Prime) (hn : n ≥ 4) :
     |factorialDivisorRatio n - 2| < 1 / n
@@ -164,7 +157,7 @@ axiom only_these_limit_points (x : ℚ) :
     x ∈ limitPointSet
 
 /-!
-## Part 7: Examples
+## Part 7: Examples and Concrete Cases
 
 Concrete cases illustrating the phenomenon.
 -/
@@ -187,9 +180,9 @@ axiom example_highly_composite :
       |factorialDivisorRatio n - 1| < ε
 
 /-!
-## Part 8: The Proof Structure
+## Part 8: The Proof Structure and Main Theorem
 
-Outline of the complete argument.
+The ratio decomposition and Sawhney's characterization.
 -/
 
 /-- Main decomposition: ratio = (small prime contribution) × (large prime contribution) -/
@@ -231,48 +224,8 @@ axiom tau_factorial_log_asymptotic :
     ∀ ε > 0, ∃ N, ∀ n ≥ N,
       |Real.log (tau n.factorial) - n * Real.log n / Real.log (Real.log n)| / n < ε
 
-/-- The number of divisors of n! is related to the primorial -/
-axiom tau_factorial_primorial_relation :
-    True  -- Connection to product of (1 + vₚ(n!))
-
 /-!
-## Part 10: Generalizations
-
-Extensions of the result.
--/
-
-/-- Could study τ((n+k)!)/τ(n!) for fixed k -/
-axiom generalization_fixed_k (k : ℕ) (hk : k ≥ 1) :
-    True  -- Similar analysis possible
-
-/-- Could study σ((n+1)!)/σ(n!) for sum-of-divisors function -/
-axiom sum_of_divisors_analog :
-    True  -- Different behavior
-
-/-- Could study d(n!^2)/d(n!)^2 -/
-axiom square_analog :
-    True  -- Related problem
-
-/-!
-## Part 11: Historical Context
-
-The problem and its resolution.
--/
-
-/-- Erdős-Graham asked this in 1980 -/
-axiom erdos_graham_1980 :
-    True  -- Original source
-
-/-- Erdős-Graham-Ivić-Pomerance proved it in 1996 -/
-axiom egip_1996 :
-    True  -- Complete solution
-
-/-- Sawhney independently rediscovered the argument -/
-axiom sawhney_rediscovery :
-    True  -- Simple and elegant reproof
-
-/-!
-## Part 12: Summary
+## Part 10: Summary
 
 The limit points are exactly {1, 2, 3/2, 4/3, 5/4, ...}.
 -/
@@ -297,7 +250,14 @@ theorem limit_set_properties :
       have : (k : ℚ) ≥ 1 := by exact Nat.one_le_cast.mpr hk_pos
       linarith [this, one_div_pos.mpr (by linarith : (k : ℚ) > 0)]
 
-/-- Erdős Problem #419: SOLVED -/
-theorem erdos_419 : True := trivial
+/-- Erdős Problem #419: SOLVED
+    The limit points of τ((n+1)!)/τ(n!) are exactly {1} ∪ {1+1/k : k ≥ 1}.
+    Combines: characterization theorem, limit point existence, and uniqueness. -/
+theorem erdos_419_summary :
+    (∀ x : ℚ, (∀ ε > 0, ∃ᶠ n in Filter.atTop, |factorialDivisorRatio n - x| < ε) ↔
+      x ∈ limitPointSet) ∧
+    (∀ ε > 0, ∃ᶠ n in Filter.atTop, |factorialDivisorRatio n - 1| < ε) ∧
+    (∀ k : ℕ, k ≥ 1 → ∀ ε > 0, ∃ᶠ n in Filter.atTop, |factorialDivisorRatio n - (1 + 1/k)| < ε) :=
+  ⟨sawhney_characterization, one_is_limit_point, one_plus_reciprocal_is_limit_point⟩
 
 end Erdos419

--- a/src/data/proofs/erdos-419/annotations.json
+++ b/src/data/proofs/erdos-419/annotations.json
@@ -1,123 +1,65 @@
 [
   {
-    "id": "ann-e419-overview",
+    "id": "erdos-419-intro",
     "proofId": "erdos-419",
-    "range": { "startLine": 1, "endLine": 20 },
-    "type": "concept",
-    "title": "Problem Overview",
-    "content": "**Erdős Problem #419: Limit Points of τ((n+1)!)/τ(n!)**\n\nWhat is the set of limit points of the ratio τ((n+1)!)/τ(n!)?\n\n**Status:** SOLVED (1996)\n**Answer:** {1} ∪ {1 + 1/k : k ≥ 1} = {1, 2, 3/2, 4/3, 5/4, ...}",
-    "mathContext": "τ(n) = divisor function = number of positive divisors of n.",
-    "significance": "critical",
-    "relatedConcepts": ["Divisor function", "Factorial", "Limit points", "p-adic valuation"]
+    "type": "context",
+    "range": { "startLine": 1, "endLine": 21 },
+    "title": "Problem Introduction",
+    "content": "Erdős Problem #419 asks: what is the set of limit points of τ((n+1)!)/τ(n!), where τ is the divisor function? Erdős-Graham-Ivić-Pomerance proved in 1996 that the answer is {1} ∪ {1 + 1/k : k ≥ 1} = {1, 2, 3/2, 4/3, ...}. When n+1 = pk for a large prime p, the ratio is approximately 1 + 1/k.",
+    "significance": "critical"
   },
   {
-    "id": "ann-e419-tau",
+    "id": "erdos-419-ratio-formula",
     "proofId": "erdos-419",
-    "range": { "startLine": 39, "endLine": 44 },
-    "type": "definition",
-    "title": "Divisor Function τ",
-    "content": "**tau n:** The divisor function τ(n) counts the number of positive divisors of n.\n\nτ(n) = |{d : d | n}|\n\nFor example: τ(12) = 6 since 12 has divisors 1, 2, 3, 4, 6, 12.",
-    "significance": "key",
-    "leanSymbol": "tau"
-  },
-  {
-    "id": "ann-e419-ratio",
-    "proofId": "erdos-419",
-    "range": { "startLine": 46, "endLine": 50 },
-    "type": "definition",
-    "title": "The Factorial Divisor Ratio",
-    "content": "**factorialDivisorRatio n:** The ratio τ((n+1)!)/τ(n!).\n\nThis measures how much the divisor count of n! increases when we multiply by n+1.",
-    "significance": "critical",
-    "leanSymbol": "factorialDivisorRatio"
-  },
-  {
-    "id": "ann-e419-legendre",
-    "proofId": "erdos-419",
-    "range": { "startLine": 62, "endLine": 68 },
     "type": "axiom",
-    "title": "Legendre's Formula",
-    "content": "**legendre_formula:** vₚ(n!) = ∑_{i≥1} ⌊n/p^i⌋\n\nThe p-adic valuation of n! (highest power of p dividing n!) is the sum of floor(n/p^i) for all i.\n\nThis gives vₚ(n!) ≈ n/(p-1), so large primes divide n! with small exponent.",
-    "significance": "key",
-    "leanSymbol": "legendre_formula"
-  },
-  {
-    "id": "ann-e419-ratio-formula",
-    "proofId": "erdos-419",
     "range": { "startLine": 70, "endLine": 74 },
-    "type": "axiom",
     "title": "The Ratio Product Formula",
-    "content": "**ratio_product_formula:** τ((n+1)!)/τ(n!) = ∏_{p|n+1} (1 + vₚ(n+1)/(vₚ(n!)+1))\n\nThe ratio is a product over primes dividing n+1. Each factor measures how much the exponent of p increases.",
-    "significance": "critical",
-    "leanSymbol": "ratio_product_formula"
+    "content": "The key identity: τ((n+1)!)/τ(n!) = ∏_{p|n+1} (1 + vₚ(n+1)/(vₚ(n!)+1)). Using the multiplicativity τ(n) = ∏ₚ(vₚ(n)+1), the factorial ratio telescopes to a product over primes dividing n+1. Each factor measures how the exponent of p in the factorial increases.",
+    "significance": "critical"
   },
   {
-    "id": "ann-e419-large-prime",
+    "id": "erdos-419-small-primes",
     "proofId": "erdos-419",
-    "range": { "startLine": 90, "endLine": 92 },
     "type": "axiom",
-    "title": "At Most One Large Prime",
-    "content": "**at_most_one_large_prime:** At most one prime p | n+1 satisfies p > n^(2/3).\n\nIf n+1 = pk with p > n^(2/3), then k < n^(1/3) so k is 'small'. This prime dominates the ratio.",
-    "significance": "key",
-    "leanSymbol": "at_most_one_large_prime"
-  },
-  {
-    "id": "ann-e419-small-primes",
-    "proofId": "erdos-419",
     "range": { "startLine": 100, "endLine": 113 },
-    "type": "axiom",
     "title": "Small Primes Contribute ≈ 1",
-    "content": "**small_primes_contribution:** Primes p ≤ n^(2/3) contribute (1 + o(1)) to the ratio.\n\nFor small primes, vₚ(n!) is large (≈ n/p), so vₚ(n+1)/(vₚ(n!)+1) is small.\n\nThe product over all small primes is close to 1.",
-    "significance": "key",
-    "leanSymbol": "small_primes_contribution"
+    "content": "For primes p ≤ n^(2/3), the p-adic valuation vₚ(n!) is large (≈ n/p by Legendre's formula), so vₚ(n+1)/(vₚ(n!)+1) is small. The product over all small primes satisfies 1 ≤ contribution ≤ 1 + (log n)²/n^(1/3), which tends to 1 as n → ∞.",
+    "significance": "key"
   },
   {
-    "id": "ann-e419-large-contribution",
+    "id": "erdos-419-large-prime",
     "proofId": "erdos-419",
-    "range": { "startLine": 126, "endLine": 131 },
     "type": "axiom",
-    "title": "Large Prime Contributes 1 + 1/k",
-    "content": "**large_prime_contribution:** If p > n^(2/3) divides n+1 = pk, the contribution is ≈ 1 + 1/k.\n\nFor large primes, vₚ(n+1) = 1 (since p² > n+1), and the contribution simplifies to 1 + 1/(vₚ(n!)+1) ≈ 1 + 1/k.",
-    "significance": "critical",
-    "leanSymbol": "large_prime_contribution"
+    "range": { "startLine": 121, "endLine": 128 },
+    "title": "Large Prime Contribution",
+    "content": "If p > n^(2/3) divides n+1, then p² > n+1 so vₚ(n+1) = 1. At most one such prime exists (since p > n^(2/3) means n+1/p < n^(1/3)). When n+1 = pk for large prime p, this prime's contribution dominates, giving ratio ≈ 1 + 1/k. When n+1 is prime (k=1), the ratio ≈ 2.",
+    "significance": "critical"
   },
   {
-    "id": "ann-e419-limitset",
+    "id": "erdos-419-limit-set",
     "proofId": "erdos-419",
-    "range": { "startLine": 143, "endLine": 145 },
     "type": "definition",
-    "title": "The Limit Point Set",
-    "content": "**limitPointSet:** {1} ∪ {1 + 1/k : k ≥ 1}\n\nThis is the complete set of limit points: 1, 2, 3/2, 4/3, 5/4, 6/5, ...\n\nThe sequence 1 + 1/k converges to 1, which is also a limit point.",
-    "significance": "critical",
-    "leanSymbol": "limitPointSet"
+    "range": { "startLine": 136, "endLine": 157 },
+    "title": "The Limit Point Set and Characterization",
+    "content": "limitPointSet := {1} ∪ {1 + 1/k : k ≥ 1}. Three axioms establish the characterization: one_is_limit_point (1 is achieved by highly composite n+1), one_plus_reciprocal_is_limit_point (each 1+1/k is achieved by n+1 = pk), and only_these_limit_points (no other limit points exist). The sequence 1+1/k converges to 1, which is itself a limit point.",
+    "significance": "critical"
   },
   {
-    "id": "ann-e419-examples",
+    "id": "erdos-419-sawhney",
     "proofId": "erdos-419",
-    "range": { "startLine": 172, "endLine": 187 },
     "type": "theorem",
-    "title": "Concrete Examples",
-    "content": "**Examples of each limit point:**\n\n- **Ratio ≈ 2:** When n+1 is prime (n+1 = p×1), ratio ≈ 1 + 1/1 = 2\n- **Ratio ≈ 3/2:** When n+1 = 2p for large prime p, ratio ≈ 1 + 1/2\n- **Ratio ≈ 4/3:** When n+1 = 3p for large prime p, ratio ≈ 1 + 1/3\n- **Ratio ≈ 1:** When n+1 is highly composite (many small primes)",
-    "significance": "supporting",
-    "leanSymbol": "example_prime"
+    "range": { "startLine": 196, "endLine": 210 },
+    "title": "Sawhney's Characterization (Proved)",
+    "content": "sawhney_characterization is a proved theorem giving the full iff: x is a limit point of factorialDivisorRatio ⟺ x ∈ limitPointSet. The forward direction uses only_these_limit_points; the reverse splits into the case x = 1 (using one_is_limit_point) and x = 1 + 1/k (using one_plus_reciprocal_is_limit_point).",
+    "significance": "critical"
   },
   {
-    "id": "ann-e419-sawhney",
+    "id": "erdos-419-summary",
     "proofId": "erdos-419",
-    "range": { "startLine": 202, "endLine": 217 },
     "type": "theorem",
-    "title": "Sawhney's Characterization",
-    "content": "**sawhney_characterization:** The limit points are EXACTLY limitPointSet.\n\nThis is an if-and-only-if statement: x is a limit point ⟺ x ∈ {1} ∪ {1 + 1/k : k ≥ 1}.\n\nThe proof combines small/large prime analysis with density arguments.",
-    "significance": "critical",
-    "leanSymbol": "sawhney_characterization"
-  },
-  {
-    "id": "ann-e419-summary",
-    "proofId": "erdos-419",
-    "range": { "startLine": 280, "endLine": 301 },
-    "type": "theorem",
-    "title": "Summary and Main Result",
-    "content": "**erdos_419:** SOLVED\n\nThe limit points of τ((n+1)!)/τ(n!) are exactly {1, 2, 3/2, 4/3, 5/4, ...}.\n\nProved by Erdős-Graham-Ivić-Pomerance (1996), independently rediscovered by Sawhney.",
-    "significance": "critical",
-    "leanSymbol": "erdos_419"
+    "range": { "startLine": 253, "endLine": 261 },
+    "title": "Summary Theorem",
+    "content": "erdos_419_summary combines three results into one: (1) sawhney_characterization — the complete iff characterization, (2) one_is_limit_point — 1 is a limit point, (3) one_plus_reciprocal_is_limit_point — each 1+1/k is a limit point. Proved by exact ⟨sawhney_characterization, one_is_limit_point, one_plus_reciprocal_is_limit_point⟩.",
+    "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-419/meta.json
+++ b/src/data/proofs/erdos-419/meta.json
@@ -23,7 +23,6 @@
     "erdosUrl": "https://erdosproblems.com/419",
     "erdosProblemStatus": "solved",
     "dateAdded": "2026-01-22",
-    "mathlib_version": "4.15.0",
     "mathlibDependencies": [
       {
         "theorem": "Nat.divisors",
@@ -52,99 +51,99 @@
       "padicValFactorial for Legendre's formula",
       "limitPointSet definition: {1} ∪ {1 + 1/k : k ≥ 1}",
       "ratio_product_formula axiom",
-      "small_primes_contribution and large_prime_contribution analysis",
-      "sawhney_characterization theorem",
-      "Concrete examples: prime, twice-prime, thrice-prime cases"
+      "small_primes_contribution and large_prime_valuation analysis",
+      "sawhney_characterization proved theorem (iff characterization)",
+      "limit_set_properties proved theorem",
+      "erdos_419_summary combining characterization, existence, and uniqueness"
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #419** asks about the limit points of the ratio τ((n+1)!)/τ(n!), where τ is the divisor function.\n\n**Historical Development:**\n- **1980:** Erdős and Graham pose the problem, noting 1 + 1/k are limit points\n- **1996:** Erdős-Graham-Ivić-Pomerance prove these are the ONLY limit points\n- **Later:** Mehtaab Sawhney independently rediscovers the elegant argument\n\n**Key Insight:** The ratio depends on the prime factorization of n+1. If n+1 = pk where p is a large prime, the ratio is approximately 1 + 1/k.",
-    "problemStatement": "**Problem Statement**\n\nIf $\\tau(n)$ counts the number of divisors of $n$, what is the set of limit points of\n$$\\frac{\\tau((n+1)!)}{\\tau(n!)}?$$\n\n**Answer:** The limit points are exactly $\\{1\\} \\cup \\{1 + 1/k : k \\geq 1\\}$\n\nThis equals $\\{1, 2, 3/2, 4/3, 5/4, 6/5, \\ldots\\}$.\n\n**Status:** SOLVED (Erdős-Graham-Ivić-Pomerance 1996)",
-    "proofStrategy": "**Proof Strategy (Sawhney's Argument)**\n\n1. **Ratio Formula:** τ((n+1)!)/τ(n!) = ∏_{p|n+1} (1 + vₚ(n+1)/(vₚ(n!)+1))\n\n2. **Small Primes:** For p ≤ n^(2/3), the contribution is ≈ 1 since vₚ(n!) is large\n\n3. **Large Primes:** At most one prime p | n+1 with p > n^(2/3). If n+1 = pk, this contributes 1 + 1/k\n\n4. **Dichotomy:** The ratio is either ≈ 1 or ≈ 1 + 1/k for some k\n\n5. **Limit Points:** Both cases occur infinitely often, giving exactly the stated set",
+    "historicalContext": "Erdős Problem #419 asks about the limit points of the ratio τ((n+1)!)/τ(n!), where τ(n) counts the positive divisors of n. The factorial n! has a very regular prime factorization given by Legendre's formula, so the ratio is controlled by the prime factorization of n+1.\n\nErdős and Graham posed this problem in 1980, conjecturing that the values 1 + 1/k for k ≥ 1 should be limit points. In 1996, Erdős, Graham, Ivić, and Pomerance proved the complete characterization: the limit points are exactly {1} ∪ {1 + 1/k : k ≥ 1}. The key insight is that the ratio decomposes into a product over primes dividing n+1, where small primes contribute ≈ 1 and at most one large prime p > n^(2/3) determines the dominant term.\n\nMehtaab Sawhney later independently rediscovered the argument, presenting an elegant version of the proof. When n+1 = pk for a large prime p, the ratio is approximately 1 + 1/k. When n+1 has only small prime factors (highly composite), the ratio approaches 1. These are the only possibilities, yielding the stated set of limit points.",
+    "problemStatement": "If τ(n) counts the number of divisors of n, what is the set of limit points of τ((n+1)!)/τ(n!)? Answer: The limit points are exactly {1} ∪ {1 + 1/k : k ≥ 1} = {1, 2, 3/2, 4/3, 5/4, ...}.",
+    "proofStrategy": "The proof uses the multiplicative formula τ(n) = ∏ₚ (vₚ(n) + 1) to express the ratio as a product over primes dividing n+1. Small primes (p ≤ n^(2/3)) contribute negligibly since vₚ(n!) is large by Legendre's formula. At most one large prime p > n^(2/3) can divide n+1; if n+1 = pk, this contributes 1 + 1/k. The ratio decomposition into small and large prime contributions yields the complete characterization.",
     "keyInsights": [
-      "**Multiplicativity:** τ(n) = ∏ₚ (vₚ(n) + 1), so the ratio is a product over primes dividing n+1.",
-      "**Legendre's Formula:** vₚ(n!) ≈ n/p, making small prime contributions negligible.",
-      "**Large Prime Dominance:** If p > n^(2/3) divides n+1, it appears with exponent 1 and dominates the ratio.",
-      "**n+1 = pk Pattern:** When n+1 = pk for large prime p, the ratio is approximately 1 + 1/k.",
-      "**Highly Composite Numbers:** When n+1 has only small prime factors, the ratio is close to 1.",
-      "**Elegant Resolution:** The same simple argument was discovered independently by Sawhney decades after the original proof."
+      "τ(n) = ∏ₚ (vₚ(n) + 1), so the ratio is a product over primes dividing n+1",
+      "Legendre's formula gives vₚ(n!) ≈ n/p, making small prime contributions negligible",
+      "At most one prime p > n^(2/3) can divide n+1, and it dominates the ratio",
+      "When n+1 = pk for large prime p, the ratio is approximately 1 + 1/k",
+      "When n+1 is highly composite, the ratio approaches 1"
     ]
   },
   "sections": [
     {
       "id": "definitions",
-      "title": "Basic Definitions",
-      "summary": "tau, factorialDivisorRatio",
+      "title": "Part 1: Basic Definitions",
+      "summary": "tau, factorialDivisorRatio definitions.",
       "startLine": 33,
       "endLine": 50
     },
     {
       "id": "ratio-formula",
-      "title": "The Ratio Formula",
-      "summary": "Legendre's formula, product over prime factors",
+      "title": "Part 2: The Ratio Formula",
+      "summary": "Legendre's formula, product formula for the ratio.",
       "startLine": 52,
       "endLine": 74
     },
     {
       "id": "prime-bounds",
-      "title": "Prime Factorization Bounds",
-      "summary": "Number of prime divisors, p-adic valuation bounds",
+      "title": "Part 3: Prime Factorization Bounds",
+      "summary": "Bounds on number of prime divisors and p-adic valuations.",
       "startLine": 76,
       "endLine": 92
     },
     {
       "id": "small-primes",
-      "title": "Small Primes Contribution",
-      "summary": "Primes p ≤ n^(2/3) contribute ≈ 1",
+      "title": "Part 4: Small Primes Contribution",
+      "summary": "Primes p ≤ n^(2/3) contribute ≈ 1 to the ratio.",
       "startLine": 94,
       "endLine": 113
     },
     {
       "id": "large-primes",
-      "title": "Large Prime Contribution",
-      "summary": "n+1 = pk gives contribution 1 + 1/k",
+      "title": "Part 5: Large Prime Contribution",
+      "summary": "Large prime valuation and prime case approximation.",
       "startLine": 115,
-      "endLine": 135
+      "endLine": 128
     },
     {
       "id": "limit-points",
-      "title": "The Set of Limit Points",
-      "summary": "limitPointSet = {1} ∪ {1 + 1/k : k ≥ 1}",
-      "startLine": 137,
-      "endLine": 164
+      "title": "Part 6: The Set of Limit Points",
+      "summary": "limitPointSet = {1} ∪ {1 + 1/k : k ≥ 1}, existence and uniqueness axioms.",
+      "startLine": 130,
+      "endLine": 157
     },
     {
       "id": "examples",
-      "title": "Examples",
-      "summary": "Prime, twice-prime, thrice-prime, highly composite cases",
-      "startLine": 166,
-      "endLine": 187
+      "title": "Part 7: Examples and Concrete Cases",
+      "summary": "Prime, twice-prime, thrice-prime, highly composite cases.",
+      "startLine": 159,
+      "endLine": 180
     },
     {
       "id": "proof-structure",
-      "title": "The Proof Structure",
-      "summary": "ratio_decomposition, sawhney_characterization",
-      "startLine": 189,
-      "endLine": 217
+      "title": "Part 8: The Proof Structure and Main Theorem",
+      "summary": "ratio_decomposition axiom and sawhney_characterization proved theorem.",
+      "startLine": 182,
+      "endLine": 210
     },
     {
       "id": "asymptotics",
-      "title": "Asymptotics of τ(n!)",
-      "summary": "Growth rate, log asymptotic",
-      "startLine": 219,
-      "endLine": 236
+      "title": "Part 9: Asymptotics of τ(n!)",
+      "summary": "Growth rate and log-asymptotic for τ(n!).",
+      "startLine": 212,
+      "endLine": 225
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "summary": "Problem status: SOLVED",
-      "startLine": 274,
-      "endLine": 303
+      "title": "Part 10: Summary",
+      "summary": "limit_set_properties and erdos_419_summary theorems.",
+      "startLine": 227,
+      "endLine": 263
     }
   ],
   "conclusion": {
     "summary": "Erdős Problem #419 asks for the limit points of τ((n+1)!)/τ(n!). The answer, proved by Erdős-Graham-Ivić-Pomerance (1996), is that the limit points are exactly {1} ∪ {1 + 1/k : k ≥ 1}. This follows from the observation that the ratio is dominated by large prime factors of n+1.",
-    "implications": "**Implications for Number Theory**\n\n1. **Divisor Function:** Reveals subtle structure in how τ(n!) grows with n.\n\n2. **Prime Distribution:** Connected to primes in arithmetic progressions and the form pk.\n\n3. **Factorial Arithmetic:** Part of a broader study of arithmetic properties of factorials.\n\n4. **Analytic Number Theory:** Uses p-adic valuations and asymptotic analysis.",
+    "implications": "The result reveals subtle structure in how τ(n!) grows with n, connecting divisor function asymptotics to prime distribution. It is part of a broader study of arithmetic properties of factorials in analytic number theory.",
     "openQuestions": [
       "What are the limit points of τ((n+k)!)/τ(n!) for fixed k > 1?",
       "What about σ((n+1)!)/σ(n!) for the sum-of-divisors function?",


### PR DESCRIPTION
## Summary
- Removed 7 trivial `True` axioms (tau_factorial_primorial_relation, generalization_fixed_k, sum_of_divisors_analog, square_analog, erdos_graham_1980, egip_1996, sawhney_rediscovery)
- Removed `large_prime_contribution` which had invalid `o(1)` syntax
- Replaced `erdos_419 : True := trivial` with `erdos_419_summary` combining sawhney_characterization, one_is_limit_point, and one_plus_reciprocal_is_limit_point
- Consolidated from 12 to 10 parts (304→264 lines)
- Updated meta.json with correct sections/line numbers and 3-paragraph historicalContext
- Rewrote annotations.json with 7 substantive annotations

## Test plan
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)