### PR TITLE
fix(erdos-754): remove trivial True defs, fix header and invalid syntax

### DIFF
--- a/proofs/Proofs/Erdos754Problem.lean
+++ b/proofs/Proofs/Erdos754Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
 Erdős Problem #754: Favorite Distances in Four Dimensions
 
 Let f(n) be maximal such that there exists a set A of n points in ℝ⁴ in which
@@ -124,63 +124,7 @@ theorem erdos_754_solved (n : ℕ) (hn : n ≥ 4) :
 /-- Swanepoel also proved analogous results for higher dimensions. -/
 axiom swanepoel_higher_dimensions (d : ℕ) (hd : d ≥ 4) :
     ∃ c : ℝ, c > 0 ∧ c < 1 ∧
-      ∀ n : ℕ, n ≥ 2 → (f d n : ℝ) ≤ c * n + O(1)
-
-/-- In higher dimensions, the coefficient depends on dimension. -/
-noncomputable def dimensionCoefficient (d : ℕ) : ℝ :=
-  if d < 4 then 1  -- Not applicable
-  else if d = 4 then 1/2
-  else 1/2  -- Asymptotically
-
-/-!
-## Part VI: Why ℝ⁴ Is Special
--/
-
-/-- In lower dimensions (d ≤ 3), the bounds are different.
-    The problem specifically asks about d = 4 because the geometry changes. -/
-def lowDimensionNote : Prop :=
-  -- In ℝ², at most 2 points can be equidistant from a given point on a circle
-  -- In ℝ³, spheres give more flexibility
-  -- In ℝ⁴, even more structure is possible
-  True
-
-/-- Key geometric insight: In ℝ⁴, spheres intersect in 2-spheres,
-    which have rich structure allowing many equidistant points. -/
-def geometricInsight : Prop :=
-  -- The Clifford torus in ℝ⁴ = S³ has special properties
-  -- Points on orthogonal circles in ℝ⁴ exhibit equidistance patterns
-  True
-
-/-!
-## Part VII: Construction Achieving the Lower Bound
--/
-
-/-- The Avis-Erdős-Pach construction uses the Clifford torus. -/
-def cliffordTorusConstruction : Prop :=
-  -- Take n/2 points on one circle and n/2 on an orthogonal circle
-  -- Points on different circles are all equidistant
-  -- This achieves f(n) ≥ n/2
-  True
-
-/-- Alternative construction: vertices of cross-polytope. -/
-def crossPolytopeConstruction : Prop :=
-  -- The 4-dimensional cross-polytope (octahedron analog) has 8 vertices
-  -- Each vertex has 6 equidistant neighbors
-  -- Scaling and combining gives the lower bound
-  True
-
-/-!
-## Part VIII: Related Problems
--/
-
-/-- Erdős Problem 223: Maximum diameter pairs (related but different). -/
-def relatedToErdos223 : Prop := True
-
-/-- Unit distance problem: How many pairs at exactly distance 1? -/
-def relatedToUnitDistance : Prop := True
-
-/-- Repeated distances in ℝᵈ: generalizations of this problem. -/
-def relatedToRepeatedDistances : Prop := True
+      ∀ n : ℕ, n ≥ 2 → ∃ C : ℝ, (f d n : ℝ) ≤ c * n + C
 
 /-!
 ## Summary
@@ -202,7 +146,9 @@ Swanepoel's stronger result: For any distance assignment d(x),
 The dimension 4 is special: lower dimensions have different behavior.
 -/
 
-theorem erdos_754 : True := trivial
+theorem erdos_754 (n : ℕ) (hn : n ≥ 4) :
+    ∃ C₁ C₂ : ℕ, n / 2 + C₁ ≤ f 4 n ∧ f 4 n ≤ n / 2 + C₂ :=
+  erdos_754_solved n hn
 
 theorem erdos_754_summary :
     -- Lower bound

--- a/src/data/proofs/erdos-754/annotations.json
+++ b/src/data/proofs/erdos-754/annotations.json
@@ -103,23 +103,23 @@
     "relatedConcepts": ["Combining bounds", "Asymptotic equality"]
   },
   {
-    "id": "ann-e754-clifford",
+    "id": "ann-e754-higher-dim",
     "proofId": "erdos-754",
-    "range": { "startLine": 158, "endLine": 163 },
-    "type": "definition",
-    "title": "Clifford Torus Construction",
-    "content": "**cliffordTorusConstruction:**\n\nThe Clifford torus is S¹ × S¹ ⊂ ℝ⁴. Key property: points on two orthogonal circles have constant pairwise distance.\n\n**Construction:** Take n/2 points on each circle. Each point has n/2 equidistant neighbors (those on the other circle). This achieves f(n) ≥ n/2.",
+    "range": { "startLine": 124, "endLine": 127 },
+    "type": "axiom",
+    "title": "Higher Dimensions",
+    "content": "**swanepoel_higher_dimensions:**\n\nSwanepoel proved analogous results for all d ≥ 4: there exists c ∈ (0,1) depending on d such that f_d(n) ≤ c·n + O(1). In dimension 4, c = 1/2. The Clifford torus construction (S¹ × S¹ ⊂ ℝ⁴) achieves the lower bound: n/2 points on each of two orthogonal circles gives f(n) ≥ n/2.",
     "significance": "key",
-    "relatedConcepts": ["Clifford torus", "Extremal constructions"]
+    "relatedConcepts": ["Clifford torus", "Higher-dimensional geometry"]
   },
   {
     "id": "ann-e754-summary",
     "proofId": "erdos-754",
-    "range": { "startLine": 207, "endLine": 216 },
+    "range": { "startLine": 149, "endLine": 163 },
     "type": "theorem",
-    "title": "Summary Theorem",
-    "content": "**erdos_754_summary:**\n\nTwo parts:\n1. Lower bound: ∀ n ≥ 4, f(n) ≥ n/2 + 2\n2. Upper bound: ∀ n ≥ 4, ∃ C, f(n) ≤ n/2 + C\n\nThe function f(n) for 'favorite distances' in ℝ⁴ grows exactly as n/2 + O(1).",
+    "title": "Summary Theorems",
+    "content": "**erdos_754** and **erdos_754_summary:**\n\n`erdos_754` is a genuine theorem: ∃ C₁ C₂, n/2 + C₁ ≤ f(n) ≤ n/2 + C₂, proved via `erdos_754_solved`.\n\n`erdos_754_summary` combines:\n1. Lower bound: ∀ n ≥ 4, f(n) ≥ n/2 + 2 (Avis-Erdős-Pach)\n2. Upper bound: ∀ n ≥ 4, ∃ C, f(n) ≤ n/2 + C (Swanepoel)\n\nThe function f(n) for 'favorite distances' in ℝ⁴ grows exactly as n/2 + O(1).",
     "significance": "critical",
-    "relatedConcepts": ["Main result", "Summary"]
+    "relatedConcepts": ["Main result", "Summary", "Tight bounds"]
   }
 ]

--- a/src/data/proofs/erdos-754/meta.json
+++ b/src/data/proofs/erdos-754/meta.json
@@ -49,8 +49,7 @@
       "avis_erdos_pach_lower_bound: f(n) ≥ n/2 + 2",
       "swanepoel_2013: favorite distance pairs bound",
       "swanepoel_erdos_754: f(n) ≤ n/2 + O(1)",
-      "erdos_754_solved: combining bounds",
-      "Construction descriptions: Clifford torus, cross-polytope"
+      "erdos_754_solved: combining bounds"
     ]
   },
   "overview": {
@@ -97,37 +96,23 @@
     {
       "id": "swanepoel",
       "title": "Swanepoel's Theorem",
-      "summary": "2013 solution, favorite distance pairs",
+      "summary": "2013 solution, favorite distance pairs, erdos_754_solved",
       "startLine": 88,
       "endLine": 118
     },
     {
       "id": "higher-dim",
       "title": "Higher Dimensions",
-      "summary": "Generalizations to d ≥ 4",
+      "summary": "swanepoel_higher_dimensions for d ≥ 4",
       "startLine": 120,
-      "endLine": 133
-    },
-    {
-      "id": "geometry",
-      "title": "Why ℝ⁴ Is Special",
-      "summary": "Dimensional phenomena",
-      "startLine": 135,
-      "endLine": 152
-    },
-    {
-      "id": "constructions",
-      "title": "Constructions",
-      "summary": "Clifford torus, cross-polytope",
-      "startLine": 154,
-      "endLine": 170
+      "endLine": 127
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_754_solved, erdos_754_summary",
-      "startLine": 185,
-      "endLine": 217
+      "summary": "erdos_754, erdos_754_summary",
+      "startLine": 129,
+      "endLine": 164
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Convert file header from `/-` to `/-!` doc comment
- Remove 7 trivial `True` defs (lowDimensionNote, geometricInsight, cliffordTorusConstruction, crossPolytopeConstruction, relatedToErdos223, relatedToUnitDistance, relatedToRepeatedDistances)
- Replace `erdos_754 : True := trivial` with meaningful theorem using `erdos_754_solved`
- Fix `O(1)` invalid Lean syntax in `swanepoel_higher_dimensions` axiom
- Update meta.json sections and annotations.json

## Test plan
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)