### PR TITLE
fix(erdos-1078): remove True trivials, dubious axiom, fix summary

### DIFF
--- a/proofs/Proofs/Erdos1078Problem.lean
+++ b/proofs/Proofs/Erdos1078Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
 Erdős Problem #1078: Minimum Degree for K_r in r-Partite Graphs
 
 Source: https://erdosproblems.com/1078
@@ -14,16 +14,6 @@ Background:
 - Bollobás-Erdős-Szemerédi (1975): Conjectured, showed r-3/2 is best possible
 - Haxell (2001): Proved the conjecture
 - Haxell-Szabó (2006): Sharp threshold (r-1)n - ⌈sn/(2s-1)⌉ where s = ⌊r/2⌋
-
-Key Results:
-- The threshold r-3/2 is tight
-- Sharp formula involves floor and ceiling functions
-- Connected to transversal theory
-
-References:
-- Bollobás-Erdős-Szemerédi (1975): "On complete subgraphs of r-chromatic graphs"
-- Haxell (2001): "A note on vertex list colouring"
-- Haxell-Szabó (2006): "Odd independent transversals are odd"
 
 Tags: extremal-graph-theory, multipartite-graphs, minimum-degree, cliques
 -/
@@ -191,9 +181,6 @@ example : sharpThreshold 4 3 = 3 * 3 - (2 * 3 + 2) / 3 := by
 The sharp threshold (r-1)n - ⌈sn/(2s-1)⌉ ≈ (r - 3/2)n asymptotically.
 
 For large n: ⌈sn/(2s-1)⌉ ≈ n/2 + O(1), so threshold ≈ (r - 3/2)n.
-
-Axiomatized because the proof involves careful asymptotic analysis of ceiling
-functions and showing that sn/(2s-1) → n/2 as n → ∞.
 -/
 axiom asymptotic_agreement (r : ℕ) (hr : r ≥ 2) :
     ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N,
@@ -214,35 +201,6 @@ def IsIndependentTransversal (G : RPartiteGraph r n)
   (∀ i j : Fin r, i ≠ j → ¬G.edges.Adj (T i) (T j))
 
 /--
-**Complement View:**
-K_r exists iff the complement has no independent transversal.
-
-This is a conceptual equivalence: a complete r-clique in G corresponds to
-r vertices (one per part) with all edges between them, which is exactly
-the negation of an independent transversal in the complement graph.
-
-Axiomatized because the proof requires:
-1. Constructing the complement graph as an RPartiteGraph
-2. Showing the bijection between K_r and independent transversals
--/
-axiom kr_iff_no_ind_transversal (G : RPartiteGraph r n) :
-    ContainsKr G ↔ ¬(∃ T, IsIndependentTransversal G T)
-
-/-!
-## Part VIII: Why the Threshold is r - 3/2
--/
-
-/--
-**Intuition:**
-- Need edges to all r-1 other parts
-- Minimum degree (r-1)n would force complete multipartite
-- But we can save roughly n/2 per part using parity tricks
-- Net savings: (r-1) × (1/2)n = (r/2 - 1/2)n
-- So threshold ≈ (r-1)n - n/2 = (r - 3/2)n
--/
-theorem intuition : True := trivial
-
-/--
 **Extremal Example:**
 The construction showing r - 3/2 is tight uses parity.
 -/
@@ -252,47 +210,21 @@ axiom extremal_construction (r n : ℕ) :
       ¬ContainsKr G
 
 /-!
-## Part IX: Summary
+## Part VIII: Summary
 -/
-
-/--
-**Summary of Results:**
--/
-theorem erdos_1078_summary :
-    -- The BES conjecture is true (Haxell)
-    BESConjecture ∧
-    -- The threshold r - 3/2 is best possible
-    True ∧
-    -- Sharp threshold known (Haxell-Szabó)
-    True := by
-  constructor
-  · exact haxell_theorem
-  · exact ⟨trivial, trivial⟩
 
 /--
 **Erdős Problem #1078: SOLVED**
-
-**CONJECTURE:** In r-partite graphs with n vertices per part,
-min degree ≥ (r - 3/2 - o(1))n implies K_r exists.
-
-**ANSWER:** YES (Haxell 2001)
-
-**SHARP THRESHOLD:** (r-1)n - ⌈sn/(2s-1)⌉ where s = ⌊r/2⌋ (Haxell-Szabó 2006)
-
-**BEST POSSIBLE:** r - 3/2 cannot be improved (BES 1975)
-
-**KEY INSIGHT:** The threshold involves subtle parity considerations.
-The r - 3/2 factor reflects that we can save approximately n/2 from
-each of the r-1 other parts through careful construction.
--/
-theorem erdos_1078 : BESConjecture := haxell_theorem
-
-/--
-**Historical Note:**
-This problem connects minimum degree conditions to transversal theory.
-The solution by Haxell used connections to list coloring, while the
-sharp result by Haxell-Szabó used structural graph theory techniques.
--/
-theorem historical_note : True := trivial
+Combines: (1) Haxell's proof of the BES conjecture, (2) tightness of r-3/2,
+(3) Haxell-Szabó sharp threshold, (4) sharpness of the exact threshold. -/
+theorem erdos_1078_summary :
+    BESConjecture ∧
+    (∀ (r : ℕ) (hr : r ≥ 2), ∃ (n : ℕ) (G : RPartiteGraph r n),
+      (minDegree G.edges : ℝ) ≥ (r - 3/2 : ℝ) * n - n ∧ ¬ContainsKr G) ∧
+    (∀ (r n : ℕ) (hr : r ≥ 2) (hn : n ≥ 1) (G : RPartiteGraph r n),
+      minDegree G.edges ≥ sharpThreshold r n + 1 → ContainsKr G) ∧
+    (∀ (r n : ℕ) (hr : r ≥ 2) (hn : n ≥ 1),
+      ∃ G : RPartiteGraph r n, minDegree G.edges = sharpThreshold r n ∧ ¬ContainsKr G) :=
+  ⟨haxell_theorem, threshold_tight, haxell_szabo_theorem, threshold_sharp⟩
 
 end Erdos1078

--- a/src/data/proofs/erdos-1078/annotations.json
+++ b/src/data/proofs/erdos-1078/annotations.json
@@ -1,94 +1,65 @@
 [
   {
-    "id": "ann-1078-1",
+    "id": "erdos-1078-intro",
     "proofId": "erdos-1078",
-    "range": { "startLine": 1, "endLine": 29 },
-    "type": "concept",
-    "title": "Problem Overview",
-    "content": "**Erdős Problem #1078: Minimum Degree for K_r in r-Partite Graphs**\n\n**Setup:** r-partite graph with n vertices in each of r parts.\n\n**Question:** If min degree ≥ (r - 3/2 - o(1))n, must G contain K_r?\n\n**Answer:** YES (Haxell 2001)\n\n**Sharp:** (r-1)n - ⌈sn/(2s-1)⌉ where s = ⌊r/2⌋ (Haxell-Szabó 2006)",
-    "mathContext": "This connects minimum degree conditions to forcing complete subgraphs in multipartite graphs.",
-    "significance": "critical",
-    "relatedConcepts": ["Minimum degree", "Multipartite graphs", "Transversals", "Extremal graph theory"]
-  },
-  {
-    "id": "ann-1078-2",
-    "proofId": "erdos-1078",
-    "range": { "startLine": 46, "endLine": 58 },
-    "type": "definition",
-    "title": "r-Partite Graph",
-    "content": "**RPartiteGraph:**\n\nA structure with:\n- r parts, each a Finset of size n\n- Parts are disjoint and cover all vertices\n- Edges only between different parts\n\n**Key property:** No edges within a part (each part is independent).",
+    "type": "context",
+    "range": { "startLine": 1, "endLine": 19 },
+    "title": "Problem Introduction",
+    "content": "Erdős Problem #1078 asks whether minimum degree ≥ (r - 3/2 - o(1))n forces K_r in balanced r-partite graphs. Bollobás-Erdős-Szemerédi conjectured YES in 1975 and showed the constant r - 3/2 is best possible. Haxell proved the conjecture in 2001 via list coloring. Haxell-Szabó gave the exact sharp threshold in 2006.",
     "significance": "critical"
   },
   {
-    "id": "ann-1078-3",
+    "id": "erdos-1078-rpartite",
     "proofId": "erdos-1078",
-    "range": { "startLine": 66, "endLine": 74 },
     "type": "definition",
-    "title": "Contains K_r",
-    "content": "**ContainsKr:**\n\nThe graph contains K_r = complete graph on r vertices, with exactly one vertex from each part.\n\nFormally: ∃ f : Fin r → vertices such that:\n- f(i) ∈ part i for all i\n- f(i) and f(j) are adjacent for all i ≠ j",
+    "range": { "startLine": 40, "endLine": 63 },
+    "title": "r-Partite Graph and K_r",
+    "content": "RPartiteGraph is a structure with r parts, each a Finset of n vertices, that are disjoint and cover all vertices, with edges only between different parts. ContainsKr asks for a function f : Fin r → vertices selecting one vertex per part with all pairs adjacent — a complete r-clique.",
     "significance": "critical"
   },
   {
-    "id": "ann-1078-4",
+    "id": "erdos-1078-bes",
     "proofId": "erdos-1078",
-    "range": { "startLine": 79, "endLine": 87 },
     "type": "definition",
-    "title": "BES Conjecture",
-    "content": "**Bollobás-Erdős-Szemerédi Conjecture (1975):**\n\nIf min degree ≥ (r - 3/2)n - O(1), then G contains K_r.\n\n**Key insight:** The threshold (r - 3/2) involves a half-integer, suggesting parity plays a role.",
+    "range": { "startLine": 73, "endLine": 86 },
+    "title": "The BES Conjecture",
+    "content": "BESConjecture formalizes: for all r ≥ 2, n ≥ 1, and r-partite G with min degree ≥ (r - 3/2)n - 1, G contains K_r. The threshold r - 3/2 involves a half-integer, hinting at parity's role. threshold_tight axiomatizes that this constant cannot be improved.",
     "significance": "critical"
   },
   {
-    "id": "ann-1078-5",
+    "id": "erdos-1078-haxell",
     "proofId": "erdos-1078",
-    "range": { "startLine": 102, "endLine": 110 },
     "type": "axiom",
+    "range": { "startLine": 99, "endLine": 113 },
     "title": "Haxell's Theorem (2001)",
-    "content": "**Haxell's Proof:**\n\nThe BES conjecture is TRUE.\n\n**Method:** Used connections to list coloring (vertex coloring from lists).\n\n**Significance:** Resolved a 25+ year old conjecture.",
+    "content": "haxell_theorem : BESConjecture axiomatizes Haxell's 2001 proof of the BES conjecture using list coloring. The proved corollary asymptotic_threshold gives an explicit constant C = 1: for all n ≥ 1, min degree ≥ (r - 3/2)n - 1 suffices for K_r.",
     "significance": "critical"
   },
   {
-    "id": "ann-1078-6",
+    "id": "erdos-1078-sharp",
     "proofId": "erdos-1078",
-    "range": { "startLine": 129, "endLine": 146 },
     "type": "definition",
-    "title": "Sharp Threshold Formula",
-    "content": "**sharpThreshold (Haxell-Szabó 2006):**\n\n(r-1)n - ⌈sn/(2s-1)⌉ where s = ⌊r/2⌋\n\n**Meaning:**\n- s = ⌊r/2⌋ captures parity of r\n- Ceiling function gives exact discrete threshold\n- Asymptotically ≈ (r - 3/2)n",
+    "range": { "startLine": 123, "endLine": 143 },
+    "title": "Sharp Threshold (Haxell-Szabó 2006)",
+    "content": "sharpThreshold(r, n) = (r-1)n - ⌈sn/(2s-1)⌉ where s = ⌊r/2⌋. The Haxell-Szabó theorem says min degree ≥ sharpThreshold + 1 forces K_r, while threshold_sharp guarantees counterexamples exist at exactly the threshold. The formula captures parity: s = ⌊r/2⌋ distinguishes even and odd r.",
     "significance": "critical"
   },
   {
-    "id": "ann-1078-7",
+    "id": "erdos-1078-special",
     "proofId": "erdos-1078",
-    "range": { "startLine": 159, "endLine": 184 },
     "type": "theorem",
-    "title": "Special Cases",
-    "content": "**Computing sharpThreshold for small r:**\n\n- **r = 2:** Threshold ≈ 0 (any edge is K_2)\n- **r = 3:** Threshold = n (need edges to both other parts)\n- **r = 4:** Threshold = 3n - ⌈2n/3⌉\n\nThese match the (r - 3/2)n asymptotic up to O(1).",
+    "range": { "startLine": 154, "endLine": 173 },
+    "title": "Special Cases r = 2, 3, 4",
+    "content": "For r = 2 (bipartite): threshold = 0 (any edge is K_2). For r = 3: threshold = n. For r = 4: threshold = 3n - ⌈2n/3⌉. These concrete values are proved by simp and ring, verifying the general formula. All match (r - 3/2)n up to O(1).",
     "significance": "key"
   },
   {
-    "id": "ann-1078-8",
+    "id": "erdos-1078-summary",
     "proofId": "erdos-1078",
-    "range": { "startLine": 207, "endLine": 216 },
-    "type": "definition",
-    "title": "Independent Transversal",
-    "content": "**IsIndependentTransversal:**\n\nA selection T = {t_1, ..., t_r} with one vertex from each part, such that no two selected vertices are adjacent.\n\n**Connection:** K_r exists iff the complement has no independent transversal.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1078-9",
-    "proofId": "erdos-1078",
-    "range": { "startLine": 236, "endLine": 254 },
     "type": "theorem",
-    "title": "Why r - 3/2",
-    "content": "**Intuition for the Threshold:**\n\n- Need edges to all r-1 other parts\n- Naive threshold: (r-1)n\n- Parity trick saves ~n/2 per part\n- Net: (r-1)n - n/2 = (r - 3/2)n\n\nThe extremal construction uses subtle parity arguments.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1078-10",
-    "proofId": "erdos-1078",
-    "range": { "startLine": 273, "endLine": 299 },
-    "type": "theorem",
-    "title": "Summary: SOLVED",
-    "content": "**Erdős Problem #1078:**\n\n**STATUS:** SOLVED\n\n**Conjecture:** min degree (r-3/2-o(1))n ⇒ K_r exists\n\n**Proof:** Haxell (2001)\n\n**Sharp:** (r-1)n - ⌈sn/(2s-1)⌉ (Haxell-Szabó 2006)\n\n**Best Possible:** BES showed r-3/2 is tight\n\n**Key Insight:** Parity and transversal theory are essential.",
+    "range": { "startLine": 220, "endLine": 228 },
+    "title": "Summary Theorem",
+    "content": "erdos_1078_summary combines four results: (1) haxell_theorem — BES conjecture is true, (2) threshold_tight — r - 3/2 is best possible, (3) haxell_szabo_theorem — exact threshold suffices, (4) threshold_sharp — counterexamples exist at the threshold. Proved by exact ⟨haxell_theorem, threshold_tight, haxell_szabo_theorem, threshold_sharp⟩.",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-1078/meta.json
+++ b/src/data/proofs/erdos-1078/meta.json
@@ -15,7 +15,6 @@
     "erdosNumber": 1078,
     "erdosUrl": "https://erdosproblems.com/1078",
     "erdosProblemStatus": "solved",
-    "mathlib_version": "4.15.0",
     "mathlibDependencies": [
       { "theorem": "SimpleGraph", "description": "Basic graph structure", "module": "Mathlib.Combinatorics.SimpleGraph.Basic" },
       { "theorem": "Finset.card", "description": "Cardinality of finite sets", "module": "Mathlib.Data.Finset.Card" },
@@ -26,95 +25,86 @@
       "minDegree: minimum degree definition",
       "ContainsKr: complete r-clique with one vertex per part",
       "BESConjecture: (r-3/2)n threshold conjecture",
-      "haxell_theorem: proof of the conjecture",
+      "haxell_theorem: proof of the conjecture (axiom)",
       "sharpThreshold: (r-1)n - ⌈sn/(2s-1)⌉ formula",
-      "haxell_szabo_theorem: sharp threshold result",
-      "IsIndependentTransversal: transversal connection",
-      "asymptotic_threshold: O(1) error term corollary"
+      "haxell_szabo_theorem and threshold_sharp: exact threshold",
+      "asymptotic_threshold: proved corollary with explicit constant",
+      "erdos_1078_summary combining all four main results"
     ],
     "dateAdded": "2026-01-19"
   },
   "overview": {
-    "historicalContext": "Bollobás, Erdős, and Szemerédi (1975) conjectured that in r-partite graphs with n vertices per part, minimum degree ≥ (r-3/2-o(1))n forces a K_r. They also showed this threshold is best possible. Haxell (2001) proved the conjecture using connections to list coloring. Haxell and Szabó (2006) determined the exact sharp threshold: (r-1)n - ⌈sn/(2s-1)⌉ where s = ⌊r/2⌋.",
-    "problemStatement": "**Problem Statement (SOLVED)**\n\nLet G be an r-partite graph with n vertices in each part.\n\n**Question:** If G has minimum degree ≥ (r - 3/2 - o(1))n, must G contain K_r?\n\n**Answer:** YES (Haxell 2001)\n\n**Sharp Threshold:** (r-1)n - ⌈sn/(2s-1)⌉ where s = ⌊r/2⌋ (Haxell-Szabó 2006)\n\n**Best Possible:** r - 3/2 cannot be improved (BES 1975)",
-    "proofStrategy": "The formalization defines r-partite graphs as structures with r parts of equal size. The BES conjecture is stated precisely, and Haxell's theorem is axiomatized as its proof. The Haxell-Szabó sharp threshold is formalized. Special cases (r=2,3,4) are computed, and the connection to independent transversals is explored.",
+    "historicalContext": "Bollobás, Erdős, and Szemerédi conjectured in 1975 that in balanced r-partite graphs, minimum degree at least (r - 3/2 - o(1))n forces a complete r-clique K_r. They also constructed examples showing the constant r - 3/2 is best possible, with extremal graphs avoiding K_r via subtle parity arguments.\n\nHaxell proved the conjecture in 2001 using connections to list coloring theory. Her proof showed that the minimum degree condition forces a rainbow clique through a reduction to vertex list coloring problems, resolving the question after 25 years.\n\nHaxell and Szabó determined the exact sharp threshold in 2006: (r-1)n - ⌈sn/(2s-1)⌉ where s = ⌊r/2⌋. This precise formula reveals the role of parity in the problem — the floor of r/2 appears because the extremal constructions depend on whether r is even or odd. Asymptotically, ⌈sn/(2s-1)⌉ ≈ n/2, recovering the (r - 3/2)n threshold.",
+    "problemStatement": "Let G be an r-partite graph with n vertices in each part. If G has minimum degree ≥ (r - 3/2 - o(1))n, must G contain K_r? Answer: YES (Haxell 2001). Sharp threshold: (r-1)n - ⌈sn/(2s-1)⌉ where s = ⌊r/2⌋ (Haxell-Szabó 2006).",
+    "proofStrategy": "The formalization defines r-partite graphs as structures with r equal-size parts and edges only between parts. The BES conjecture is stated as a Prop, and Haxell's theorem is axiomatized. The Haxell-Szabó sharp threshold is formalized with both the sufficiency theorem and sharpness (counterexamples exist at the threshold). Special cases for r = 2, 3, 4 are computed. The summary theorem combines all four main results.",
     "keyInsights": [
-      "**r-Partite Graph:** Vertices split into r independent parts of size n",
-      "**K_r:** Complete subgraph with one vertex from each part",
-      "**BES Threshold:** (r - 3/2)n is the asymptotic threshold",
-      "**Haxell (2001):** Proved the conjecture via list coloring",
-      "**Sharp Formula:** (r-1)n - ⌈sn/(2s-1)⌉ where s = ⌊r/2⌋",
-      "**Transversal Connection:** K_r ↔ no independent transversal in complement",
-      "**Parity Trick:** Savings of n/2 per part via parity arguments"
+      "The threshold (r - 3/2)n involves a half-integer, suggesting parity plays a role",
+      "Haxell's proof uses connections to list coloring",
+      "The sharp formula (r-1)n - ⌈sn/(2s-1)⌉ with s = ⌊r/2⌋ captures parity exactly",
+      "Asymptotically ⌈sn/(2s-1)⌉ ≈ n/2, giving the (r - 3/2)n threshold",
+      "The savings of n/2 per part come from parity-based extremal constructions"
     ]
   },
   "sections": [
     {
       "id": "definitions",
-      "title": "Basic Definitions",
-      "startLine": 40,
-      "endLine": 74,
-      "summary": "RPartiteGraph structure, minDegree, ContainsKr"
+      "title": "Part I: Basic Definitions",
+      "startLine": 30,
+      "endLine": 63,
+      "summary": "RPartiteGraph structure, minDegree, ContainsKr."
     },
     {
       "id": "bes-conjecture",
-      "title": "The BES Conjecture",
-      "startLine": 75,
-      "endLine": 97,
-      "summary": "Original conjecture and threshold tightness"
+      "title": "Part II: The BES Conjecture",
+      "startLine": 65,
+      "endLine": 86,
+      "summary": "BESConjecture definition and threshold_tight axiom."
     },
     {
       "id": "haxell",
-      "title": "Haxell's Theorem (2001)",
-      "startLine": 98,
-      "endLine": 124,
-      "summary": "Proof of BES conjecture"
+      "title": "Part III: Haxell's Theorem (2001)",
+      "startLine": 88,
+      "endLine": 113,
+      "summary": "haxell_theorem axiom and asymptotic_threshold proved corollary."
     },
     {
       "id": "sharp-threshold",
-      "title": "Sharp Threshold (Haxell-Szabó 2006)",
-      "startLine": 125,
-      "endLine": 154,
-      "summary": "(r-1)n - ⌈sn/(2s-1)⌉ exact threshold"
+      "title": "Part IV: Sharp Threshold (Haxell-Szabó 2006)",
+      "startLine": 115,
+      "endLine": 143,
+      "summary": "sharpThreshold formula, haxell_szabo_theorem, threshold_sharp."
     },
     {
       "id": "special-cases",
-      "title": "Special Cases",
-      "startLine": 155,
-      "endLine": 184,
-      "summary": "r = 2, 3, 4 cases computed"
+      "title": "Part V: Special Cases",
+      "startLine": 145,
+      "endLine": 173,
+      "summary": "Computed thresholds for r = 2, 3, 4."
     },
     {
       "id": "comparison",
-      "title": "Asymptotic Agreement",
-      "startLine": 185,
-      "endLine": 202,
-      "summary": "Sharp threshold ≈ (r-3/2)n asymptotically"
+      "title": "Part VI: Comparison with BES Threshold",
+      "startLine": 175,
+      "endLine": 187,
+      "summary": "asymptotic_agreement: sharp threshold ≈ (r-3/2)n."
     },
     {
       "id": "transversals",
-      "title": "Connection to Transversals",
-      "startLine": 203,
-      "endLine": 231,
-      "summary": "K_r ↔ no independent transversal in complement"
-    },
-    {
-      "id": "intuition",
-      "title": "Why r - 3/2",
-      "startLine": 232,
-      "endLine": 254,
-      "summary": "Parity savings explanation"
+      "title": "Part VII: Connection to Transversals",
+      "startLine": 189,
+      "endLine": 210,
+      "summary": "IsIndependentTransversal definition and extremal_construction."
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "startLine": 255,
-      "endLine": 299,
-      "summary": "Main theorem and historical note"
+      "title": "Part VIII: Summary",
+      "startLine": 212,
+      "endLine": 230,
+      "summary": "erdos_1078_summary combining haxell_theorem, threshold_tight, haxell_szabo_theorem, threshold_sharp."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1078 is SOLVED. The BES conjecture that min degree (r-3/2-o(1))n forces K_r in r-partite graphs was proved by Haxell (2001). Haxell-Szabó (2006) gave the exact sharp threshold: (r-1)n - ⌈sn/(2s-1)⌉ where s = ⌊r/2⌋. The threshold r-3/2 is best possible.",
+    "summary": "Erdős Problem #1078 is SOLVED. The BES conjecture that min degree (r-3/2-o(1))n forces K_r in r-partite graphs was proved by Haxell (2001). Haxell-Szabó (2006) gave the exact sharp threshold: (r-1)n - ⌈sn/(2s-1)⌉ where s = ⌊r/2⌋.",
     "implications": "This result connects minimum degree conditions to transversal theory and list coloring. The sharp formula involving floor and ceiling functions reveals the importance of parity in extremal problems.",
     "openQuestions": [
       "What about non-balanced r-partite graphs (different part sizes)?",


### PR DESCRIPTION
## Summary
- Removed `intuition : True := trivial` and `historical_note : True := trivial`
- Removed dubious `kr_iff_no_ind_transversal` axiom
- Replaced `True ∧ True` in `erdos_1078_summary` with meaningful conjunction of `haxell_theorem`, `threshold_tight`, `haxell_szabo_theorem`, `threshold_sharp`
- Fixed doc header `/-` → `/-!`
- Consolidated from 9 to 8 parts (299→231 lines)
- Updated meta.json with 3-paragraph historicalContext and correct sections
- Rewrote annotations.json with 7 substantive annotations

## Test plan
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)