### PR TITLE
fix(erdos-149): remove True axioms, sorry, True trivials

### DIFF
--- a/proofs/Proofs/Erdos149Problem.lean
+++ b/proofs/Proofs/Erdos149Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
   Erdős Problem #149: Strong Chromatic Index Conjecture
 
   Source: https://erdosproblems.com/149
@@ -15,13 +15,6 @@
   - Strong edge coloring: edges at distance ≤ 2 get different colors
   - The conjecture would be tight: blow-up of C₅ achieves (5/4)Δ²
   - Progress: 2Δ² → 1.998Δ² → 1.93Δ² → 1.835Δ² → 1.772Δ²
-
-  Key References:
-  - Erdős-Nešetřil (1985): Original conjecture
-  - Molloy-Reed (1997): 1.998Δ²
-  - Bruhn-Joos (2018): 1.93Δ²
-  - Bonamy-Perrett-Postle (2022): 1.835Δ²
-  - Hurley-de Joannis de Verclos-Kang (2022): 1.772Δ²
 
   Tags: graph-theory, edge-coloring, chromatic-index, combinatorics
 -/
@@ -65,23 +58,7 @@ noncomputable def strongChromaticIndex (G : SimpleGraph V) : ℕ :=
 notation "χ'_s" => strongChromaticIndex
 
 /-!
-## Part 2: Line Graph and Its Square
-
-The strong chromatic index equals χ(L(G)²) where L(G) is the line graph.
--/
-
-/-- The line graph L(G) has edges of G as vertices, adjacent when they share an endpoint. -/
-axiom lineGraph (G : SimpleGraph V) : SimpleGraph G.edgeSet
-
-/-- The square of a graph: G² has edge (u,v) if dist(u,v) ≤ 2 in G. -/
-axiom graphSquare (G : SimpleGraph V) : SimpleGraph V
-
-/-- Key equivalence: χ'_s(G) = χ(L(G)²). -/
-axiom strong_chromatic_eq_line_square (G : SimpleGraph V) :
-    χ'_s G = sorry  -- Would need chromatic number of L(G)²
-
-/-!
-## Part 3: The Erdős-Nešetřil Conjecture (1985)
+## Part 2: The Erdős-Nešetřil Conjecture (1985)
 
 The conjectured bound is (5/4)Δ², which would be best possible.
 -/
@@ -107,7 +84,7 @@ axiom c5_blowup_construction (Δ : ℕ) (hΔ : Even Δ) :
       (χ'_s G : ℚ) = (5/4 : ℚ) * Δ^2
 
 /-!
-## Part 4: Upper Bounds - Progress History
+## Part 3: Upper Bounds - Progress History
 
 The conjecture remains open, but bounds have improved steadily.
 -/
@@ -148,7 +125,7 @@ theorem current_gap :
     (1.772 : ℚ) - (5/4 : ℚ) = 0.522 := by norm_num
 
 /-!
-## Part 5: Special Graph Classes
+## Part 4: Special Graph Classes
 
 Better bounds are known for restricted graph classes.
 -/
@@ -171,7 +148,7 @@ axiom bipartite_bound :
       (χ'_s G : ℝ) ≤ c * (maxDegree G)^2
 
 /-!
-## Part 6: The Clique Number of L(G)²
+## Part 5: The Clique Number of L(G)²
 
 A related but weaker question: is ω(L(G)²) ≤ (5/4)Δ²?
 -/
@@ -193,18 +170,8 @@ axiom sleszynska_nowak_2015 (G : SimpleGraph V) (Δ : ℕ) (hΔ : maxDegree G �
 axiom faron_postle_2019 (G : SimpleGraph V) (Δ : ℕ) (hΔ : maxDegree G ≤ Δ) :
     (ω_L² G : ℚ) ≤ (4/3 : ℚ) * Δ^2
 
-/-- Cames van Batenburg-Kang-Pirot (2020): ω(L(G)²) ≤ (5/4)Δ² if G is triangle-free. -/
-axiom batenburg_kang_pirot_2020_trianglefree (G : SimpleGraph V) (Δ : ℕ)
-    (hΔ : maxDegree G ≤ Δ) (hTriFree : True) :  -- G is triangle-free
-    (ω_L² G : ℚ) ≤ (5/4 : ℚ) * Δ^2
-
-/-- Same paper: ω(L(G)²) ≤ Δ² if G is C₅-free. -/
-axiom batenburg_kang_pirot_2020_c5free (G : SimpleGraph V) (Δ : ℕ)
-    (hΔ : maxDegree G ≤ Δ) (hC5Free : True) :  -- G is C₅-free
-    (ω_L² G : ℚ) ≤ Δ^2
-
 /-!
-## Part 7: Related Problem - Strongly Independent Edge Pairs
+## Part 6: Strongly Independent Edge Pairs
 
 Erdős-Nešetřil also asked an easier problem about pairs of strongly independent edges.
 -/
@@ -222,7 +189,7 @@ axiom chung_gyarfas_tuza_trotter_1990 (G : SimpleGraph V) (Δ : ℕ)
     ∃ e₁ e₂ : G.edgeSet, StronglyIndependentEdges G e₁ e₂
 
 /-!
-## Part 8: Induced Matchings
+## Part 7: Induced Matchings
 
 Strong edge colorings partition edges into "induced matchings."
 -/
@@ -239,75 +206,20 @@ axiom strong_chromatic_eq_induced_matchings (G : SimpleGraph V) :
       (∀ e : G.edgeSet, ∃ i, e ∈ partition i)}
 
 /-!
-## Part 9: Small Cases and Exact Values
-
-For specific graphs, χ'_s is known exactly.
--/
-
-/-- For the complete graph K_n, χ'_s(K_n) = n(n-1)/2 when n ≥ 4. -/
-axiom strong_chromatic_complete (n : ℕ) (hn : n ≥ 4) :
-    True  -- Exact formula involves n
-
-/-- For paths P_n, χ'_s(P_n) = 3 for n ≥ 4. -/
-axiom strong_chromatic_path (n : ℕ) (hn : n ≥ 4) :
-    True  -- χ'_s = 3
-
-/-- For cycles C_n, χ'_s(C_n) depends on n mod 3. -/
-axiom strong_chromatic_cycle (n : ℕ) (hn : n ≥ 3) :
-    True  -- Formula based on n mod 3
-
-/-!
-## Part 10: Probabilistic Method Approach
-
-The best bounds use the probabilistic method and local lemma.
--/
-
-/-- The Lovász Local Lemma is key to proving upper bounds. -/
-axiom lovasz_local_lemma_application :
-    True  -- The technique behind Molloy-Reed and subsequent improvements
-
-/-- Entropy compression is used in recent improvements. -/
-axiom entropy_compression_technique :
-    True  -- Used by Hurley-de Joannis de Verclos-Kang
-
-/-!
-## Part 11: Algorithmic Aspects
-
-Finding optimal strong edge colorings is computationally hard.
--/
-
-/-- Computing χ'_s(G) is NP-hard. -/
-axiom strong_chromatic_np_hard :
-    True  -- Deciding if χ'_s(G) ≤ k is NP-complete for k ≥ 4
-
-/-- There exist polynomial-time approximation algorithms. -/
-axiom approximation_algorithms :
-    True  -- O(Δ²) coloring can be found efficiently
-
-/-!
-## Part 12: Summary
+## Part 8: Summary
 
 Erdős Problem #149 remains OPEN. Best bound is 1.772Δ², conjecture is (5/4)Δ².
 -/
 
-/-- Summary of known bounds on the strong chromatic index. -/
-theorem strong_chromatic_bounds_summary :
-    -- Trivial: ≤ 2Δ² (roughly)
-    -- Molloy-Reed (1997): ≤ 1.998Δ²
-    -- Bruhn-Joos (2018): ≤ 1.93Δ²
-    -- Bonamy-Perrett-Postle (2022): ≤ 1.835Δ²
-    -- Hurley-de Joannis de Verclos-Kang (2022): ≤ 1.772Δ²
-    -- Conjecture: ≤ (5/4)Δ² = 1.25Δ²
-    -- Lower bound (C₅ blow-up): ≥ (5/4)Δ² achievable
-    True := trivial
-
-/-- The conjecture status. -/
-theorem erdos_149_status :
-    -- OPEN: Gap between 1.772 and 1.25 remains
-    -- The clique number conjecture (weaker) is also open for general graphs
-    True := trivial
-
-/-- Erdős Problem #149: Strong Chromatic Index Conjecture - OPEN -/
-theorem erdos_149 : True := trivial
+/-- Erdős Problem #149: Strong Chromatic Index Conjecture (OPEN)
+    Combines: (1) current best upper bound 1.772Δ², (2) tightness of (5/4)Δ². -/
+theorem erdos_149_summary :
+    (∃ Δ₀ : ℕ, ∀ V : Type*, ∀ _ : Fintype V, ∀ _ : DecidableEq V,
+      ∀ G : SimpleGraph V, maxDegree G ≥ Δ₀ →
+        (χ'_s G : ℚ) ≤ 1.772 * (maxDegree G)^2) ∧
+    (∀ Δ : ℕ, Δ ≥ 2 →
+      ∃ V : Type*, ∃ _ : Fintype V, ∃ _ : DecidableEq V,
+      ∃ G : SimpleGraph V, maxDegree G = Δ ∧ (χ'_s G : ℚ) = (5/4 : ℚ) * Δ^2) :=
+  ⟨hurley_joannis_kang_2022, conjecture_is_tight⟩
 
 end Erdos149

--- a/src/data/proofs/erdos-149/annotations.json
+++ b/src/data/proofs/erdos-149/annotations.json
@@ -1,203 +1,65 @@
 [
   {
-    "id": "ann-e149-overview",
+    "id": "erdos-149-intro",
     "proofId": "erdos-149",
-    "range": { "startLine": 1, "endLine": 27 },
-    "type": "concept",
-    "title": "Problem Overview",
-    "content": "**Erdős Problem #149: Strong Chromatic Index Conjecture**\n\nIs χ'_s(G) ≤ (5/4)Δ² for all graphs G with max degree Δ?\n\n**Status:** OPEN\n**Best bound:** 1.772Δ² (Hurley-de Joannis de Verclos-Kang 2022)\n**Conjectured:** (5/4)Δ² = 1.25Δ²\n**Gap:** 0.522Δ²",
-    "mathContext": "Strong edge coloring: edges at distance ≤ 2 get different colors. χ'_s(G) = χ(L(G)²).",
-    "significance": "critical",
-    "relatedConcepts": ["Strong chromatic index", "Line graph", "Edge coloring", "Lovász Local Lemma"]
+    "type": "context",
+    "range": { "startLine": 1, "endLine": 20 },
+    "title": "Problem Introduction",
+    "content": "Erdős Problem #149 is the Erdős-Nešetřil conjecture (1985): is χ'_s(G) ≤ (5/4)Δ² for all graphs with maximum degree Δ? The strong chromatic index χ'_s counts the minimum colors needed so edges at distance ≤ 2 get different colors. The C₅ blow-up achieves (5/4)Δ², making the conjecture tight if true. Best known bound: 1.772Δ² (Hurley et al. 2022).",
+    "significance": "critical"
   },
   {
-    "id": "ann-e149-maxdegree",
+    "id": "erdos-149-defs",
     "proofId": "erdos-149",
-    "range": { "startLine": 47, "endLine": 49 },
     "type": "definition",
-    "title": "Maximum Degree",
-    "content": "**maxDegree G:** The maximum degree Δ of any vertex in G.\n\nmaxDegree G = sup_{v ∈ V} deg(v)\n\nThe conjecture bounds χ'_s in terms of Δ².",
-    "significance": "key",
-    "leanSymbol": "maxDegree"
-  },
-  {
-    "id": "ann-e149-distance2",
-    "proofId": "erdos-149",
-    "range": { "startLine": 51, "endLine": 54 },
-    "type": "definition",
-    "title": "Edges at Distance 2",
-    "content": "**edgesAtDistance2 G e₁ e₂:** Two edges are at distance ≤ 2 if:\n- They share a vertex, OR\n- Both touch a common third vertex\n\nThis defines which edge pairs must get different colors in strong coloring.",
-    "significance": "critical",
-    "leanSymbol": "edgesAtDistance2"
-  },
-  {
-    "id": "ann-e149-strongcoloring",
-    "proofId": "erdos-149",
-    "range": { "startLine": 56, "endLine": 59 },
-    "type": "definition",
-    "title": "Strong Edge Coloring",
-    "content": "**StrongEdgeColoring G:** A coloring of edges where edges at distance ≤ 2 get different colors.\n\nThis is more restrictive than ordinary edge coloring (where only adjacent edges must differ).",
-    "significance": "critical",
-    "leanSymbol": "StrongEdgeColoring"
-  },
-  {
-    "id": "ann-e149-strongindex",
-    "proofId": "erdos-149",
-    "range": { "startLine": 61, "endLine": 65 },
-    "type": "definition",
+    "range": { "startLine": 40, "endLine": 58 },
     "title": "Strong Chromatic Index",
-    "content": "**strongChromaticIndex G (χ'_s):** Minimum colors needed for a strong edge coloring.\n\nχ'_s(G) = min{k : G has a strong k-edge-coloring}\n\nThis equals χ(L(G)²), the chromatic number of the square of the line graph.",
-    "significance": "critical",
-    "leanSymbol": "strongChromaticIndex"
+    "content": "maxDegree uses Finset.sup over all vertex degrees. edgesAtDistance2 captures when two edges share a vertex or both touch a common vertex. StrongEdgeColoring requires distinct colors for edges at distance ≤ 2. strongChromaticIndex is defined as the infimum of the number of colors used.",
+    "significance": "critical"
   },
   {
-    "id": "ann-e149-linegraph",
+    "id": "erdos-149-conjecture",
     "proofId": "erdos-149",
-    "range": { "startLine": 73, "endLine": 74 },
-    "type": "axiom",
-    "title": "Line Graph",
-    "content": "**lineGraph G:** The line graph L(G) has:\n- Vertices = edges of G\n- Two vertices adjacent iff the corresponding edges share an endpoint\n\nStrong edge coloring of G = proper vertex coloring of L(G)².",
-    "significance": "key",
-    "leanSymbol": "lineGraph"
-  },
-  {
-    "id": "ann-e149-conjecture",
-    "proofId": "erdos-149",
-    "range": { "startLine": 89, "endLine": 94 },
     "type": "definition",
-    "title": "Erdős-Nešetřil Conjecture (1985)",
-    "content": "**ErdosNesetrilConjecture:**\n\nFor all graphs G with max degree Δ: χ'_s(G) ≤ (5/4)Δ²\n\nThis is the main open problem. If true, it would be tight (achieved by C₅ blow-up).",
-    "significance": "critical",
-    "leanSymbol": "ErdosNesetrilConjecture"
+    "range": { "startLine": 68, "endLine": 84 },
+    "title": "The Conjecture and Tightness",
+    "content": "ErdosNesetrilConjecture states χ'_s(G) ≤ (5/4)Δ² for all graphs. conjecture_is_tight axiomatizes that for every Δ ≥ 2, a graph exists achieving exactly (5/4)Δ². The c5_blowup_construction axiom gives the specific construction: replace each vertex of C₅ with Δ/2 copies.",
+    "significance": "critical"
   },
   {
-    "id": "ann-e149-tight",
+    "id": "erdos-149-bounds",
     "proofId": "erdos-149",
-    "range": { "startLine": 96, "endLine": 107 },
     "type": "axiom",
-    "title": "Tightness: C₅ Blow-up",
-    "content": "**conjecture_is_tight:**\n\nThe C₅ blow-up (replace each vertex of C₅ with Δ/2 vertices) achieves exactly (5/4)Δ².\n\nThis shows if the conjecture is true, the bound cannot be improved.",
-    "significance": "critical",
-    "leanSymbol": "conjecture_is_tight"
+    "range": { "startLine": 92, "endLine": 125 },
+    "title": "Progress History of Upper Bounds",
+    "content": "The timeline of improving bounds: trivial_bound gives 2Δ² - 2Δ + 1. Molloy-Reed (1997) first broke factor-2 with 1.998Δ². Bruhn-Joos (2018): 1.93Δ². Bonamy-Perrett-Postle (2022): 1.835Δ². Hurley-de Joannis de Verclos-Kang (2022): 1.772Δ² (current best). The proved theorem current_gap shows 1.772 - 5/4 = 0.522.",
+    "significance": "critical"
   },
   {
-    "id": "ann-e149-trivial",
+    "id": "erdos-149-clique",
     "proofId": "erdos-149",
-    "range": { "startLine": 115, "endLine": 118 },
     "type": "axiom",
-    "title": "Trivial Bound",
-    "content": "**trivial_bound:**\n\nχ'_s(G) ≤ 2Δ² - 2Δ + 1 ≈ 2Δ²\n\nEach edge has at most 2(Δ-1) neighbors at distance 1 from each endpoint. Greedy coloring gives this bound.",
-    "significance": "supporting",
-    "leanSymbol": "trivial_bound"
-  },
-  {
-    "id": "ann-e149-molloy",
-    "proofId": "erdos-149",
-    "range": { "startLine": 120, "endLine": 125 },
-    "type": "axiom",
-    "title": "Molloy-Reed (1997)",
-    "content": "**molloy_reed_1997:**\n\nχ'_s(G) ≤ 1.998Δ² for large Δ.\n\nFirst to break the factor-2 barrier! Uses the probabilistic method with Lovász Local Lemma.",
-    "significance": "key",
-    "leanSymbol": "molloy_reed_1997"
-  },
-  {
-    "id": "ann-e149-bruhn",
-    "proofId": "erdos-149",
-    "range": { "startLine": 127, "endLine": 131 },
-    "type": "axiom",
-    "title": "Bruhn-Joos (2018)",
-    "content": "**bruhn_joos_2018:**\n\nχ'_s(G) ≤ 1.93Δ² for large Δ.\n\nImproved the constant using refined probabilistic techniques.",
-    "significance": "key",
-    "leanSymbol": "bruhn_joos_2018"
-  },
-  {
-    "id": "ann-e149-bonamy",
-    "proofId": "erdos-149",
-    "range": { "startLine": 133, "endLine": 137 },
-    "type": "axiom",
-    "title": "Bonamy-Perrett-Postle (2022)",
-    "content": "**bonamy_perrett_postle_2022:**\n\nχ'_s(G) ≤ 1.835Δ² for large Δ.\n\nUsed new techniques for coloring graphs with sparse neighborhoods.",
-    "significance": "key",
-    "leanSymbol": "bonamy_perrett_postle_2022"
-  },
-  {
-    "id": "ann-e149-hurley",
-    "proofId": "erdos-149",
-    "range": { "startLine": 139, "endLine": 144 },
-    "type": "axiom",
-    "title": "Hurley-de Joannis de Verclos-Kang (2022)",
-    "content": "**hurley_joannis_kang_2022:**\n\nχ'_s(G) ≤ 1.772Δ² for large Δ.\n\n**Current best bound!** Uses entropy compression and improved local density analysis.",
-    "significance": "critical",
-    "leanSymbol": "hurley_joannis_kang_2022"
-  },
-  {
-    "id": "ann-e149-gap",
-    "proofId": "erdos-149",
-    "range": { "startLine": 146, "endLine": 148 },
-    "type": "theorem",
-    "title": "The Remaining Gap",
-    "content": "**current_gap:**\n\n1.772 - 1.25 = 0.522\n\nThe gap between best known bound and conjecture is still significant (about 42% of the conjectured bound).",
-    "significance": "key",
-    "leanSymbol": "current_gap"
-  },
-  {
-    "id": "ann-e149-c4free",
-    "proofId": "erdos-149",
-    "range": { "startLine": 156, "endLine": 163 },
-    "type": "axiom",
-    "title": "C₄-free Graphs (Mahdian)",
-    "content": "**mahdian_c4_free:**\n\nFor C₄-free graphs: χ'_s(G) ≤ (2+o(1))Δ²/log Δ\n\nMuch better than general graphs! The absence of 4-cycles allows significant improvement.",
-    "significance": "key",
-    "leanSymbol": "mahdian_c4_free"
-  },
-  {
-    "id": "ann-e149-clique",
-    "proofId": "erdos-149",
-    "range": { "startLine": 179, "endLine": 186 },
-    "type": "axiom",
+    "range": { "startLine": 156, "endLine": 171 },
     "title": "Clique Number of L(G)²",
-    "content": "**cliqueNumber_LineSquare:**\n\nω(L(G)²) = largest clique in the square of the line graph.\n\nSince χ(H) ≥ ω(H), bounding ω(L(G)²) is a weaker problem than the full conjecture.\n\nEven ω(L(G)²) ≤ (5/4)Δ² is open for general graphs!",
-    "significance": "key",
-    "leanSymbol": "cliqueNumber_LineSquare"
+    "content": "The clique number ω(L(G)²) gives a lower bound since χ(H) ≥ ω(H). Bounding ω(L(G)²) is a weaker problem than the full conjecture. Śleszyńska-Nowak (2015): ≤ (3/2)Δ². Faron-Postle (2019): ≤ (4/3)Δ². The (5/4)Δ² bound for ω is known only for triangle-free graphs.",
+    "significance": "key"
   },
   {
-    "id": "ann-e149-cgtt",
+    "id": "erdos-149-matchings",
     "proofId": "erdos-149",
-    "range": { "startLine": 217, "endLine": 222 },
-    "type": "axiom",
-    "title": "Chung-Gyárfás-Tuza-Trotter (1990)",
-    "content": "**chung_gyarfas_tuza_trotter_1990:**\n\nIf |E(G)| ≥ (5/4)Δ², then G has two strongly independent edges.\n\nThis is the 'easier' version of the problem that Erdős-Nešetřil also asked. It was solved in 1990.",
-    "significance": "key",
-    "leanSymbol": "chung_gyarfas_tuza_trotter_1990"
-  },
-  {
-    "id": "ann-e149-induced",
-    "proofId": "erdos-149",
-    "range": { "startLine": 230, "endLine": 233 },
     "type": "definition",
-    "title": "Induced Matching",
-    "content": "**IsInducedMatching G M:**\n\nA set M of edges is an induced matching if all pairs are strongly independent (no two edges at distance ≤ 2).\n\nχ'_s(G) = minimum number of induced matchings partitioning E(G).",
-    "significance": "key",
-    "leanSymbol": "IsInducedMatching"
+    "range": { "startLine": 197, "endLine": 206 },
+    "title": "Induced Matchings Characterization",
+    "content": "An induced matching M has all pairs of edges strongly independent (no shared vertices and no edges between their endpoints). strong_chromatic_eq_induced_matchings axiomatizes that χ'_s(G) equals the minimum number of induced matchings partitioning E(G). This gives an equivalent combinatorial formulation of the conjecture.",
+    "significance": "key"
   },
   {
-    "id": "ann-e149-summary",
+    "id": "erdos-149-summary",
     "proofId": "erdos-149",
-    "range": { "startLine": 293, "endLine": 308 },
     "type": "theorem",
-    "title": "Summary",
-    "content": "**strong_chromatic_bounds_summary:**\n\nProgress timeline:\n- Trivial: ≤ 2Δ²\n- Molloy-Reed (1997): ≤ 1.998Δ²\n- Bruhn-Joos (2018): ≤ 1.93Δ²\n- Bonamy-Perrett-Postle (2022): ≤ 1.835Δ²\n- Hurley et al. (2022): ≤ 1.772Δ²\n- Conjecture: ≤ 1.25Δ²\n- Lower bound: (5/4)Δ² achievable",
-    "significance": "critical",
-    "leanSymbol": "strong_chromatic_bounds_summary"
-  },
-  {
-    "id": "ann-e149-main",
-    "proofId": "erdos-149",
-    "range": { "startLine": 310, "endLine": 311 },
-    "type": "theorem",
-    "title": "Main Status",
-    "content": "**erdos_149:**\n\nErdős Problem #149: Strong Chromatic Index Conjecture - OPEN\n\nThe gap between 1.772Δ² and (5/4)Δ² remains one of the major open problems in graph coloring theory.",
-    "significance": "critical",
-    "leanSymbol": "erdos_149"
+    "range": { "startLine": 216, "endLine": 223 },
+    "title": "Summary Theorem",
+    "content": "erdos_149_summary combines two results: (1) hurley_joannis_kang_2022 — the current best bound χ'_s(G) ≤ 1.772Δ² for large Δ, and (2) conjecture_is_tight — graphs achieving exactly (5/4)Δ² exist for every Δ ≥ 2. Proved by exact ⟨hurley_joannis_kang_2022, conjecture_is_tight⟩.",
+    "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-149/meta.json
+++ b/src/data/proofs/erdos-149/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Nešetřil (1985), many contributors",
     "sourceUrl": "https://erdosproblems.com/149",
     "date": "1985-2022",
-    "status": "pending",
+    "status": "complete",
     "proofRepoPath": "Proofs/Erdos149Problem.lean",
     "tags": [
       "erdos",
@@ -18,12 +18,10 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 149,
     "erdosUrl": "https://erdosproblems.com/149",
     "erdosProblemStatus": "open",
-    "dateAdded": "2026-01-22",
-    "mathlib_version": "4.15.0",
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Basic",
@@ -43,125 +41,93 @@
     ],
     "originalContributions": [
       "maxDegree definition for SimpleGraph",
-      "edgesAtDistance2 definition: edges at distance ≤ 2",
-      "StrongEdgeColoring structure",
-      "strongChromaticIndex definition",
+      "edgesAtDistance2, StrongEdgeColoring, strongChromaticIndex definitions",
       "ErdosNesetrilConjecture definition",
       "Progress timeline: trivial → Molloy-Reed → Bruhn-Joos → Bonamy-Perrett-Postle → Hurley et al.",
-      "conjecture_is_tight axiom: C₅ blow-up achieves (5/4)Δ²",
-      "cliqueNumber_LineSquare axiom and related bounds",
-      "StronglyIndependentEdges definition",
-      "IsInducedMatching definition",
-      "current_gap theorem: 1.772 - 1.25 = 0.522"
+      "conjecture_is_tight and c5_blowup_construction axioms",
+      "cliqueNumber_LineSquare axiom and clique number bounds",
+      "StronglyIndependentEdges and IsInducedMatching definitions",
+      "current_gap theorem: 1.772 - 1.25 = 0.522",
+      "erdos_149_summary combining best bound and tightness"
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #149** is the Erdős-Nešetřil conjecture on strong edge coloring, posed in 1985.\n\n**Historical Development:**\n- **1985:** Erdős and Nešetřil conjecture χ'_s(G) ≤ (5/4)Δ²\n- **1990:** Chung-Gyárfás-Tuza-Trotter prove the easier 'two edge' version\n- **1997:** Molloy-Reed break the factor-2 barrier with 1.998Δ²\n- **2018:** Bruhn-Joos improve to 1.93Δ²\n- **2022:** Bonamy-Perrett-Postle achieve 1.835Δ²\n- **2022:** Hurley-de Joannis de Verclos-Kang prove current best 1.772Δ²\n\n**Tightness:** The blow-up of C₅ achieves exactly (5/4)Δ², so if true, the conjecture is best possible.\n\n**Related Problems:** The clique number conjecture ω(L(G)²) ≤ (5/4)Δ² is weaker and also open for general graphs.",
-    "problemStatement": "**Problem Statement**\n\nLet $G$ be a graph with maximum degree $\\Delta$. Is $G$ the union of at most $(5/4)\\Delta^2$ sets of **strongly independent edges** (sets such that the induced subgraph is the union of vertex-disjoint edges)?\n\n**Equivalent Formulations:**\n1. Is the **strong chromatic index** $\\chi'_s(G) \\leq (5/4)\\Delta^2$?\n2. Is the chromatic number of $L(G)^2$ (square of the line graph) at most $(5/4)\\Delta^2$?\n\n**Status:** OPEN\n\n**Best Known Bounds:**\n- Upper: $\\chi'_s(G) \\leq 1.772\\Delta^2$ (Hurley-de Joannis de Verclos-Kang 2022)\n- Lower: $(5/4)\\Delta^2$ is achievable (blow-up of $C_5$)",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Definitions:** maxDegree, edgesAtDistance2, StrongEdgeColoring, strongChromaticIndex\n\n2. **The Conjecture:** ErdosNesetrilConjecture as χ'_s(G) ≤ (5/4)Δ²\n\n3. **Progress Timeline:** Axiomatize the sequence of improving bounds\n\n4. **Tightness:** C₅ blow-up construction achieves the conjectured bound\n\n5. **Related Problems:** Clique number of L(G)², strongly independent edge pairs\n\n6. **Special Cases:** Results for C₄-free, triangle-free, bipartite graphs",
+    "historicalContext": "Erdős and Nešetřil conjectured in 1985 that the strong chromatic index of any graph with maximum degree Δ is at most (5/4)Δ². A strong edge coloring assigns colors to edges so that edges at distance at most 2 receive different colors. The blow-up of C₅ (replacing each vertex with Δ/2 copies) achieves exactly (5/4)Δ², so the conjecture is tight if true.\n\nThe trivial upper bound is roughly 2Δ². Molloy and Reed (1997) first broke the factor-2 barrier with 1.998Δ², using the Lovász Local Lemma. Subsequent improvements by Bruhn-Joos (2018, 1.93Δ²), Bonamy-Perrett-Postle (2022, 1.835Δ²), and Hurley-de Joannis de Verclos-Kang (2022, 1.772Δ²) have steadily reduced the constant, but a significant gap of 0.522Δ² remains.\n\nThe conjecture is also studied through the lens of the clique number of L(G)² (the square of the line graph). Since χ(H) ≥ ω(H), bounding ω(L(G)²) is a weaker problem. Faron-Postle proved ω(L(G)²) ≤ (4/3)Δ², but the (5/4)Δ² bound remains open even for the clique number in the general case.",
+    "problemStatement": "Let G be a graph with maximum degree Δ. Is χ'_s(G) ≤ (5/4)Δ², where χ'_s is the strong chromatic index? Status: OPEN. Best bound: 1.772Δ² (Hurley et al. 2022). Tight if true: C₅ blow-up achieves (5/4)Δ².",
+    "proofStrategy": "The formalization defines the strong chromatic index via StrongEdgeColoring structures and sInf. The ErdosNesetrilConjecture is stated as a Prop. The progression of upper bounds from 2Δ² to 1.772Δ² is axiomatized. Tightness is captured via the C₅ blow-up construction. Related results on the clique number of L(G)² and strongly independent edge pairs are also formalized.",
     "keyInsights": [
-      "**Strong Edge Coloring:** Two edges need different colors if they share a vertex OR both touch a common third vertex. This is much more restrictive than ordinary edge coloring.",
-      "**Line Graph Square:** χ'_s(G) = χ(L(G)²). The strong chromatic index is the chromatic number of the square of the line graph.",
-      "**The C₅ Blow-up:** Replace each vertex of C₅ with Δ/2 vertices to get a graph achieving exactly (5/4)Δ². This shows the conjecture, if true, is tight.",
-      "**Steady Progress:** The bound has improved from 2Δ² to 1.772Δ² over 25 years, but a significant gap to 1.25Δ² remains.",
-      "**Probabilistic Methods:** Best bounds use Lovász Local Lemma and entropy compression techniques.",
-      "**Special Classes:** Better bounds are known for C₄-free graphs ((2+o(1))Δ²/log Δ) and triangle-free graphs (clique number ≤ (5/4)Δ²)."
+      "Strong edge coloring: two edges need different colors if they share a vertex or both touch a common third vertex",
+      "The C₅ blow-up achieves exactly (5/4)Δ², showing the conjecture is tight if true",
+      "Best bounds have improved steadily: 2Δ² → 1.998Δ² → 1.93Δ² → 1.835Δ² → 1.772Δ²",
+      "The clique number conjecture ω(L(G)²) ≤ (5/4)Δ² is weaker and also open",
+      "Special classes admit better bounds: C₄-free graphs achieve O(Δ²/log Δ)"
     ]
   },
   "sections": [
     {
       "id": "definitions",
-      "title": "Basic Definitions",
-      "summary": "maxDegree, edgesAtDistance2, StrongEdgeColoring, strongChromaticIndex",
-      "startLine": 38,
-      "endLine": 65
-    },
-    {
-      "id": "line-graph",
-      "title": "Line Graph and Its Square",
-      "summary": "lineGraph, graphSquare, χ'_s = χ(L(G)²)",
-      "startLine": 67,
-      "endLine": 81
+      "title": "Part 1: Basic Definitions",
+      "summary": "maxDegree, edgesAtDistance2, StrongEdgeColoring, strongChromaticIndex.",
+      "startLine": 31,
+      "endLine": 58
     },
     {
       "id": "conjecture",
-      "title": "The Erdős-Nešetřil Conjecture (1985)",
-      "summary": "ErdosNesetrilConjecture, tightness via C₅ blow-up",
-      "startLine": 83,
-      "endLine": 107
+      "title": "Part 2: The Erdős-Nešetřil Conjecture (1985)",
+      "summary": "ErdosNesetrilConjecture, tightness via C₅ blow-up.",
+      "startLine": 60,
+      "endLine": 84
     },
     {
       "id": "bounds",
-      "title": "Upper Bounds - Progress History",
-      "summary": "Timeline from 2Δ² to 1.772Δ²",
-      "startLine": 109,
-      "endLine": 148
+      "title": "Part 3: Upper Bounds - Progress History",
+      "summary": "Timeline from trivial 2Δ² to best known 1.772Δ².",
+      "startLine": 86,
+      "endLine": 125
     },
     {
       "id": "special",
-      "title": "Special Graph Classes",
-      "summary": "C₄-free (Mahdian), bipartite bounds",
+      "title": "Part 4: Special Graph Classes",
+      "summary": "C₄-free (Mahdian), bipartite bounds.",
+      "startLine": 127,
+      "endLine": 148
+    },
+    {
+      "id": "clique",
+      "title": "Part 5: Clique Number of L(G)²",
+      "summary": "cliqueNumber_LineSquare, bounds: (3/2)Δ² → (4/3)Δ².",
       "startLine": 150,
       "endLine": 171
     },
     {
-      "id": "clique",
-      "title": "Clique Number of L(G)²",
-      "summary": "ω(L(G)²) bounds: 3/2 → 4/3, triangle-free case",
-      "startLine": 173,
-      "endLine": 204
-    },
-    {
       "id": "pairs",
-      "title": "Strongly Independent Edge Pairs",
-      "summary": "Chung-Gyárfás-Tuza-Trotter 1990",
-      "startLine": 206,
-      "endLine": 222
+      "title": "Part 6: Strongly Independent Edge Pairs",
+      "summary": "StronglyIndependentEdges, Chung-Gyárfás-Tuza-Trotter 1990.",
+      "startLine": 173,
+      "endLine": 189
     },
     {
       "id": "matchings",
-      "title": "Induced Matchings",
-      "summary": "IsInducedMatching, partition characterization",
-      "startLine": 224,
-      "endLine": 239
-    },
-    {
-      "id": "small",
-      "title": "Small Cases and Exact Values",
-      "summary": "Complete graphs, paths, cycles",
-      "startLine": 241,
-      "endLine": 257
-    },
-    {
-      "id": "probabilistic",
-      "title": "Probabilistic Method Approach",
-      "summary": "Lovász Local Lemma, entropy compression",
-      "startLine": 259,
-      "endLine": 271
-    },
-    {
-      "id": "algorithmic",
-      "title": "Algorithmic Aspects",
-      "summary": "NP-hardness, approximation algorithms",
-      "startLine": 273,
-      "endLine": 285
+      "title": "Part 7: Induced Matchings",
+      "summary": "IsInducedMatching, partition characterization of χ'_s.",
+      "startLine": 191,
+      "endLine": 206
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "summary": "Problem status OPEN, gap 1.772 vs 1.25",
-      "startLine": 287,
-      "endLine": 313
+      "title": "Part 8: Summary",
+      "summary": "erdos_149_summary combining best bound and tightness.",
+      "startLine": 208,
+      "endLine": 225
     }
   ],
   "conclusion": {
     "summary": "Erdős Problem #149 (Erdős-Nešetřil Conjecture) asks whether every graph with max degree Δ has strong chromatic index at most (5/4)Δ². The conjecture remains OPEN. Best upper bound is 1.772Δ² (Hurley et al. 2022). The C₅ blow-up achieves the conjectured bound, showing it would be tight if true.",
-    "implications": "**Implications for Graph Theory**\n\n1. **Edge Coloring Theory:** Strong edge coloring is a natural generalization connecting ordinary edge coloring to distance-2 coloring.\n\n2. **Structural Graph Theory:** Understanding χ'_s reveals information about local graph structure around edges.\n\n3. **Probabilistic Combinatorics:** The problem has driven development of Local Lemma and entropy compression techniques.\n\n4. **Algorithmic Complexity:** While computing χ'_s is NP-hard, the bounds give efficient approximation algorithms.",
+    "implications": "This problem connects edge coloring theory to local graph structure, and has driven development of probabilistic methods including the Lovász Local Lemma and entropy compression techniques.",
     "openQuestions": [
       "Is χ'_s(G) ≤ (5/4)Δ² for all graphs G? (The main conjecture)",
       "Is ω(L(G)²) ≤ (5/4)Δ² for all graphs G? (The weaker clique version)",
       "Can the bound be improved below 1.772Δ² with current techniques?",
-      "What is χ'_s for specific graph families (planar, bounded treewidth)?",
       "Can the conjecture be proved for bipartite graphs?"
     ]
   }


### PR DESCRIPTION
## Summary
- Removed 8 trivial `True` axioms (strong_chromatic_complete, strong_chromatic_path, strong_chromatic_cycle, lovasz_local_lemma_application, entropy_compression_technique, strong_chromatic_np_hard, approximation_algorithms, and 2 with `(hTriFree : True)` params)
- Removed 1 `sorry` (strong_chromatic_eq_line_square)
- Removed 3 `True := trivial` (strong_chromatic_bounds_summary, erdos_149_status, erdos_149)
- Replaced with `erdos_149_summary` combining `hurley_joannis_kang_2022` and `conjecture_is_tight`
- Fixed doc header `/-` → `/-!`
- Fixed meta.json: status pending→complete, sorries 1→0
- Consolidated from 12 to 8 parts (314→226 lines)
- Updated meta.json and annotations.json with correct sections

## Test plan
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)