### PR TITLE
Enhance erdos-1003: Remove True := trivial, fix header

### DIFF
--- a/proofs/Proofs/Erdos1003Problem.lean
+++ b/proofs/Proofs/Erdos1003Problem.lean
@@ -1,5 +1,5 @@
-/-
-Erdős Problem #1003: Consecutive Equal Totients
+/-!
+  Erdős Problem #1003: Consecutive Equal Totients
 
 Are there infinitely many solutions to φ(n) = φ(n+1), where φ is the Euler
 totient function?
@@ -73,11 +73,6 @@ def ConsecutiveEqualTotients : Set ℕ :=
 This is the main open question. The conjecture is that the answer is yes.
 -/
 def erdos_1003_conjecture : Prop := ConsecutiveEqualTotients.Infinite
-
-/--
-The problem remains open as of 2024.
--/
-theorem erdos_1003_is_open : True := trivial
 
 /-!
 ## Verified Examples

--- a/research/candidate-pool.json
+++ b/research/candidate-pool.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "last_updated": "2026-02-06T16:45:02.279Z",
+  "last_updated": "2026-02-06T17:01:39.520Z",
   "source": "auto-generated from research/db/knowledge.db",
   "candidates": [
     {

--- a/src/data/proofs/erdos-1003/meta.json
+++ b/src/data/proofs/erdos-1003/meta.json
@@ -82,49 +82,49 @@
       "id": "main-conjecture",
       "title": "The Main Conjecture",
       "startLine": 57,
-      "endLine": 79,
+      "endLine": 74,
       "summary": "Definition of ConsecutiveEqualTotients and the open conjecture."
     },
     {
       "id": "examples",
       "title": "Verified Examples",
-      "startLine": 80,
-      "endLine": 116,
+      "startLine": 75,
+      "endLine": 111,
       "summary": "Small cases verified with native_decide: n = 1, 3, 15, 104."
     },
     {
       "id": "k-consecutive",
       "title": "Consecutive k Equal Values",
-      "startLine": 117,
-      "endLine": 136,
+      "startLine": 113,
+      "endLine": 131,
       "summary": "The stronger conjecture about k consecutive equal totients."
     },
     {
       "id": "eps-bound",
       "title": "EPS Upper Bound",
-      "startLine": 137,
-      "endLine": 163,
+      "startLine": 133,
+      "endLine": 157,
       "summary": "The Erdős-Pomerance-Sárközy sparsity result."
     },
     {
       "id": "examples-detail",
       "title": "Understanding the Examples",
-      "startLine": 202,
-      "endLine": 237,
+      "startLine": 197,
+      "endLine": 232,
       "summary": "Why φ(15) = φ(16) and φ(104) = φ(105)."
     },
     {
       "id": "triple",
       "title": "The Consecutive Triple",
-      "startLine": 238,
-      "endLine": 260,
+      "startLine": 233,
+      "endLine": 255,
       "summary": "Three consecutive integers 5186, 5187, 5188 with equal totient."
     },
     {
       "id": "flp-bound",
       "title": "FLP Lower Bound",
-      "startLine": 261,
-      "endLine": 280,
+      "startLine": 256,
+      "endLine": 276,
       "summary": "Ford-Luca-Pomerance result suggesting infinitude."
     }
   ],


### PR DESCRIPTION
## Summary
- Removed `erdos_1003_is_open : True := trivial`
- Fixed `/-` header to `/-!` doc comment
- Updated meta.json section line numbers to match
- 282→276 lines

## Test plan
- [x] `pnpm build` succeeds
- [x] No `True := trivial` remaining
- [x] No `sorry` remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)