### PR TITLE
fix: remove null wiedijkNumber causing build failure

### DIFF
--- a/src/data/proofs/nth-root-irrational/meta.json
+++ b/src/data/proofs/nth-root-irrational/meta.json
@@ -44,8 +44,7 @@
       "Converse characterization: perfect powers give integer roots",
       "15 concrete corollaries spanning square, cube, fourth, and fifth roots"
     ],
-    "dateAdded": "02/06/26",
-    "wiedijkNumber": null
+    "dateAdded": "02/06/26"
   },
   "overview": {
     "historicalContext": "The irrationality of $\\sqrt{2}$ is one of the oldest results in mathematics, attributed to the Pythagoreans around 500 BCE. The classical proof uses a parity argument specific to square roots. The natural question is: does the same hold for cube roots, fourth roots, and beyond? The answer is yes, and the proof generalizes beautifully using the rational root theorem and algebraic number theory. This formalization captures the complete generalization in a single theorem.",


### PR DESCRIPTION
## Summary
- The `nth-root-irrational` proof's meta.json had `"wiedijkNumber": null` which is incompatible with the TypeScript type `number | undefined`
- This caused the website build to fail after PR #1757 was merged
- Fix: remove the null field entirely (optional fields default to undefined)

## Test plan
- [x] `pnpm build` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)