### PR TITLE
fix(erdos-991): remove True := trivial, update annotations

### DIFF
--- a/proofs/Proofs/Erdos991Problem.lean
+++ b/proofs/Proofs/Erdos991Problem.lean
@@ -356,9 +356,4 @@ theorem erdos_991_summary :
         normalizedCapArea cosAngle * points.card| ≤ C * (points.card : ℝ)^(2/3 : ℝ)) :=
   ⟨erdos_991, marzo_mas_bound⟩
 
-/--
-The answer to Erdős Problem #991 is YES.
--/
-theorem erdos_991_answer : True := trivial
-
 end Erdos991

--- a/src/data/proofs/erdos-991/annotations.json
+++ b/src/data/proofs/erdos-991/annotations.json
@@ -171,19 +171,10 @@
   {
     "id": "ann-e991-summary",
     "proofId": "erdos-991",
-    "range": { "startLine": 337, "endLine": 358 },
+    "range": { "startLine": 337, "endLine": 359 },
     "type": "theorem",
-    "title": "Summary Theorem",
-    "content": "**erdos_991_summary:**\n\nCombines the main results:\n```lean\ntheorem erdos_991_summary :\n  (∀ points, IsOptimalConfig points → HasSmallDiscrepancy points) ∧\n  (∀ points, IsOptimalConfig points →\n   ∃ C > 0, ∀ cap, discrepancy ≤ C · n^(2/3))\n```\n\n**What we proved:**\n1. Qualitative: optimal points have o(n) discrepancy\n2. Quantitative: the bound is O(n^{2/3})\n3. Follows from classical potential theory with modern improvements",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e991-answer",
-    "proofId": "erdos-991",
-    "range": { "startLine": 359, "endLine": 364 },
-    "type": "theorem",
-    "title": "The Answer",
-    "content": "**erdos_991_answer:**\n\nThe answer to Erdős Problem #991 is **YES**.\n\nOptimal logarithmic energy point configurations on S² have small spherical cap discrepancy. They distribute uniformly in the limit, with quantitative bounds of O(n^{2/3}).",
+    "title": "Summary: Erdős #991 SOLVED",
+    "content": "**erdos_991_summary:**\n\nCombines the main results into one theorem:\n1. Qualitative: optimal points have o(n) discrepancy (erdos_991)\n2. Quantitative: the bound is O(n^{2/3}) (marzo_mas_bound)\n\nThe answer to Erdős Problem #991 is **YES**: optimal logarithmic energy point configurations on S² distribute uniformly in the limit, with quantitative bounds of O(n^{2/3}).",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-991/meta.json
+++ b/src/data/proofs/erdos-991/meta.json
@@ -152,9 +152,9 @@
     {
       "id": "main-results",
       "title": "Main Results",
-      "summary": "erdos_991_summary, erdos_991_answer",
+      "summary": "erdos_991_summary combining qualitative and quantitative results.",
       "startLine": 333,
-      "endLine": 364
+      "endLine": 359
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Removed `erdos_991_answer : True := trivial` placeholder
- Merged summary and answer annotations into one comprehensive entry
- Updated meta.json section line numbers to match

## Checklist
- [x] No True := trivial placeholders
- [x] No /-! docstring sections
- [x] pnpm build succeeds
- [x] Annotations align with Lean file line numbers

🤖 Generated by enhancer-2