### PR TITLE
fix(erdos-920): remove 7 True axioms, 3 True trivials, formalize Ramsey connection

### DIFF
--- a/proofs/Proofs/Erdos920Problem.lean
+++ b/proofs/Proofs/Erdos920Problem.lean
@@ -176,11 +176,16 @@ def RamseyNumber (k m : ℕ) : ℕ := sorry
 
 /--
 **Ramsey-Chromatic Connection:**
-If R(k,m) ≥ m^α / (log m)^β, then
-g_k(n) ≥ n^{1-1/α} / (log n)^{β/α}.
--/
+If R(k,m) ≥ c · m^α / (log m)^β, then
+g_k(n) ≥ c' · n^{1-1/α} / (log n)^{β/α}.
+This is the key bridge between Ramsey theory and chromatic numbers. -/
 axiom ramsey_chromatic_connection :
-  True
+  ∀ k : ℕ, k ≥ 3 →
+  ∀ α β : ℝ, α > 1 → β ≥ 0 →
+    (∃ c : ℝ, c > 0 ∧ ∀ m : ℕ, m ≥ 2 →
+      (RamseyNumber k m : ℝ) ≥ c * (m : ℝ) ^ α / (Real.log m) ^ β) →
+    ∃ c' : ℝ, c' > 0 ∧ ∀ n : ℕ, n ≥ 2 →
+      (maxChromaticKFree k n : ℝ) ≥ c' * (n : ℝ) ^ (1 - 1/α) / (Real.log n) ^ (β/α)
 
 /--
 **Erdős Ramsey Bound (1959):**
@@ -202,119 +207,31 @@ axiom mattheus_verstraete_ramsey :
       (RamseyNumber 4 m : ℝ) ≥ c * (m : ℝ) ^ 3 / (Real.log m) ^ 4
 
 /-
-## Part VI: Special Cases
+## Part VI: Summary
 -/
 
 /--
-**Triangle-Free Graphs (k=3):**
-For k=3, the situation is well-understood.
-See Erdős Problem #1013.
--/
-axiom triangle_free_case :
-  True  -- See Problem #1013
-
-/--
-**K_4-Free Graphs (k=4):**
-The Mattheus-Verstraete result (2023) gives the best known bound.
--/
-axiom k4_free_case :
-  True
-
-/--
-**Large k:**
-For large k, the gap between known and conjectured bounds grows.
--/
-axiom large_k_case :
-  True
-
-/-
-## Part VII: Probabilistic Methods
--/
-
-/--
-**Random Graphs:**
-Probabilistic constructions give lower bounds for g_k(n).
--/
-axiom random_graph_method :
-  True
-
-/--
-**First Moment Method:**
-Basic probabilistic technique for existence proofs.
--/
-axiom first_moment :
-  True
-
-/--
-**Lovász Local Lemma:**
-Advanced technique for dependent random variables.
--/
-axiom local_lemma :
-  True
-
-/-
-## Part VIII: Summary
--/
-
-/--
-**Erdős Problem #920:**
+**Erdős Problem #920: OPEN**
 
 PROBLEM: For k ≥ 4, is g_k(n) ≫ n^{1-1/(k-1)} / (log n)^c for some c?
 
-STATUS: OPEN
-
-KNOWN BOUNDS:
+KNOWN:
 - Upper: g_k(n) ≪ (n · log log n / log n)^{1-1/(k-1)} [Graver-Yackel]
 - Lower: g_k(n) ≫ n^{1-2/(k+1)} / (log n)^{c_k} [general]
 - k=3: g_3(n) ≈ (n/log n)^{1/2} [well-understood]
 - k=4: g_4(n) ≫ n^{2/3} / (log n)^{4/3} [Mattheus-Verstraete 2023]
 
-CONJECTURE: The exponent should be 1-1/(k-1), not 1-2/(k+1).
--/
+GAP: The exponent should be 1-1/(k-1), not 1-2/(k+1), for k ≥ 5. -/
 theorem erdos_920_summary :
     -- General lower bound is known
     (∀ k : ℕ, k ≥ 3 → ∃ c : ℝ, c > 0 ∧
       ∀ n : ℕ, n ≥ 2 →
         (maxChromaticKFree k n : ℝ) ≥
           c * (n : ℝ) ^ (1 - 2 / (k + 1 : ℝ)) / (Real.log n) ^ c) ∧
-    -- Upper bound is known
-    True ∧
-    -- Gap exists
-    True := by
-  constructor
-  · exact general_lower_bound
-  constructor <;> trivial
-
-/--
-**Erdős Problem #920: OPEN**
--/
-theorem erdos_920 : True := trivial
-
-/--
-**Known Exponents:**
-k=3: lower ≈ 1/2, conjectured 1/2 ✓ (resolved)
-k=4: lower = 2/3, conjectured 2/3 ✓ (Mattheus-Verstraete!)
-k=5: lower = 2/3, conjectured 3/4 (gap)
--/
-theorem erdos_920_exponents :
-    -- k=3 is resolved
-    True ∧
-    -- k=4 was resolved by Mattheus-Verstraete 2023
-    True ∧
-    -- k≥5 has a gap
-    True := by
-  constructor <;> trivial
-
-/--
-**Recent Progress:**
-The 2023 result of Mattheus-Verstraete was a major breakthrough,
-resolving the k=4 case with the optimal exponent 2/3.
--/
-theorem mattheus_verstraete_breakthrough :
-    -- They proved R(4,m) ≫ m^3/(log m)^4
-    True ∧
-    -- This implies g_4(n) ≫ n^{2/3}/(log n)^{4/3}
-    True := by
-  constructor <;> trivial
+    -- k=4 breakthrough by Mattheus-Verstraete (2023)
+    (∃ c : ℝ, c > 0 ∧
+      ∀ n : ℕ, n ≥ 2 →
+        (maxChromaticKFree 4 n : ℝ) ≥ c * (n : ℝ) ^ (2/3 : ℝ) / (Real.log n) ^ (4/3 : ℝ)) :=
+  ⟨general_lower_bound, mattheus_verstraete_2023⟩
 
 end Erdos920

--- a/src/data/proofs/erdos-920/annotations.json
+++ b/src/data/proofs/erdos-920/annotations.json
@@ -94,37 +94,28 @@
   {
     "id": "ann-e920-ramsey",
     "proofId": "erdos-920",
-    "range": { "startLine": 170, "endLine": 184 },
+    "range": { "startLine": 170, "endLine": 193 },
     "type": "concept",
     "title": "Ramsey-Chromatic Connection",
-    "content": "**ramsey_chromatic_connection:**\n\nIf R(k,m) ≥ m^α / (log m)^β\n⟹ g_k(n) ≥ n^{1-1/α} / (log n)^{β/α}\n\nBetter Ramsey bounds give better chromatic bounds!",
+    "content": "**ramsey_chromatic_connection** formalizes the key bridge: if R(k,m) ≥ c·m^α/(log m)^β, then g_k(n) ≥ c'·n^{1-1/α}/(log n)^{β/α}. Better Ramsey bounds directly give better chromatic bounds! The Erdős R(3,m) bound and Mattheus-Verstraete R(4,m) bound are axiomatized separately.",
     "significance": "critical"
   },
   {
     "id": "ann-e920-ramsey-k4",
     "proofId": "erdos-920",
-    "range": { "startLine": 194, "endLine": 203 },
+    "range": { "startLine": 199, "endLine": 207 },
     "type": "axiom",
     "title": "Mattheus-Verstraete Ramsey Bound",
-    "content": "**mattheus_verstraete_ramsey:**\n\nR(4,m) ≫ m³ / (log m)⁴\n\nThis was THE breakthrough of 2023!\nα=3, β=4 ⟹ g_4(n) exponent = 1-1/3 = 2/3 ✓",
+    "content": "**mattheus_verstraete_ramsey:** R(4,m) ≫ m³/(log m)⁴. This was the breakthrough of 2023! With α=3, β=4, the Ramsey-chromatic connection gives g_4(n) exponent = 1-1/3 = 2/3, matching the conjecture for k=4.",
     "significance": "critical"
   },
   {
     "id": "ann-e920-summary",
     "proofId": "erdos-920",
-    "range": { "startLine": 259, "endLine": 287 },
+    "range": { "startLine": 213, "endLine": 237 },
     "type": "theorem",
-    "title": "State of Knowledge",
-    "content": "**erdos_920_summary:**\n\n**Resolved:**\n- k=3: g_3(n) ≈ (n/log n)^{1/2}\n- k=4: g_4(n) ≫ n^{2/3}/(log n)^{4/3} [MV 2023]\n\n**Open:**\n- k≥5: gap between 1-2/(k+1) and 1-1/(k-1)",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e920-main",
-    "proofId": "erdos-920",
-    "range": { "startLine": 288, "endLine": 292 },
-    "type": "theorem",
-    "title": "Erdős Problem #920: OPEN",
-    "content": "**erdos_920:**\n\nStatus: OPEN for k ≥ 5\n\nThe general conjecture remains unresolved.",
+    "title": "Summary: Erdős #920 OPEN",
+    "content": "**erdos_920_summary** combines the general lower bound with the k=4 breakthrough:\n1. General: g_k(n) ≫ n^{1-2/(k+1)}/(log n)^c for all k ≥ 3\n2. k=4: g_4(n) ≫ n^{2/3}/(log n)^{4/3} [Mattheus-Verstraete 2023]\n\nThe conjecture (exponent 1-1/(k-1)) remains OPEN for k ≥ 5.",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-920/meta.json
+++ b/src/data/proofs/erdos-920/meta.json
@@ -70,14 +70,14 @@
       "title": "Connection to Ramsey Numbers",
       "summary": "How Ramsey bounds translate to chromatic bounds",
       "startLine": 166,
-      "endLine": 203
+      "endLine": 207
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "State of knowledge and recent progress",
-      "startLine": 255,
-      "endLine": 319
+      "summary": "erdos_920_summary combining general lower bound and k=4 breakthrough.",
+      "startLine": 209,
+      "endLine": 237
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Replace `ramsey_chromatic_connection : True` with proper formalized axiom connecting Ramsey bounds R(k,m) to chromatic bounds g_k(n)
- Remove Part VI (Special Cases): 3 True axioms (triangle-free, K4-free, large-k)
- Remove Part VII (Probabilistic Methods): 3 True axioms (random graph, first moment, LLL)
- Remove 3 True := trivial theorems: `erdos_920`, `erdos_920_exponents`, `mattheus_verstraete_breakthrough`
- Replace summary with proper `erdos_920_summary` combining `general_lower_bound` and `mattheus_verstraete_2023`
- Update meta.json sections and annotations.json to match new line numbers

## Test plan
- [x] `pnpm build` passes
- [ ] Lean file compiles (docker build)
- [ ] Gallery renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)