### PR TITLE
fix(erdos-1114): remove 4 True trivials, 7 True axioms, formalize Lorch generalization

### DIFF
--- a/proofs/Proofs/Erdos1114Problem.lean
+++ b/proofs/Proofs/Erdos1114Problem.lean
@@ -138,133 +138,56 @@ axiom balint_symmetric (n : ℕ) (hn : n ≥ 3) (c : Fin n → ℝ)
     Gap c ⟨0, by omega⟩ ≥ Gap c ⟨n / 2 - 1, by omega⟩
 
 /-
-## Part V: Special Cases
+## Part V: Quartic Case
 -/
 
-/--
-**n = 2 case (quadratic):**
-f has 3 roots: a, a+d, a+2d
-f' is linear with one root (the vertex), no gap comparison needed.
--/
-theorem quadratic_trivial : True := trivial
-
-/--
-**n = 3 case (cubic):**
-f has 4 roots: a, a+d, a+2d, a+3d
-f' is quadratic with 2 roots c₁ < c₂
-There's one gap g = c₂ - c₁.
--/
-theorem cubic_one_gap : True := trivial
-
-/--
-**n = 4 case (quartic):**
-f has 5 roots: a, a+d, a+2d, a+3d, a+4d
-f' has 4 roots c₁ < c₂ < c₃ < c₄
-Gaps: g₁ = c₂-c₁, g₂ = c₃-c₂, g₃ = c₄-c₃
-Theorem says: g₁ > g₂, g₃ > g₂ (outer gaps larger than middle)
--/
+/-- **n = 4 case (quartic):**
+    f has 5 roots, f' has 4 critical points c₁ < c₂ < c₃ < c₄.
+    Gaps: g₁ = c₂-c₁, g₂ = c₃-c₂, g₃ = c₄-c₃.
+    Result: g₁ > g₂ and g₃ > g₂ (outer gaps larger than middle). -/
 axiom quartic_gap_property (c : Fin 4 → ℝ)
     (hc : ∀ i j : Fin 4, i < j → c i < c j) :
     Gap c ⟨0, by omega⟩ > Gap c ⟨1, by omega⟩ ∧
     Gap c ⟨2, by omega⟩ > Gap c ⟨1, by omega⟩
 
 /-
-## Part VI: Proof Ideas
+## Part VI: Lorch's Generalizations (1976)
 -/
 
-/--
-**Symmetry observation:**
-The polynomial with AP roots has symmetric properties.
-f(a₀ + t) = (-1)ⁿ⁺¹ f(aₙ - t) up to scaling.
--/
-axiom symmetry_of_ap_polynomial :
-  -- The polynomial with evenly spaced roots is symmetric about its center
-  True
-
-/--
-**Derivative structure:**
-f'(x) also has special structure when f has AP roots.
-The critical points are NOT evenly spaced, but have predictable pattern.
--/
-axiom derivative_structure :
-  -- f' has roots that cluster toward the center
-  -- Gaps are larger near the endpoints
-  True
-
-/--
-**Convexity argument:**
-The key insight is that certain auxiliary functions are convex,
-which implies the monotonicity of gaps.
--/
-axiom convexity_argument : True
+/-- Lorch (1976) extended Bálint's result to higher derivatives:
+    for f⁽ᵏ⁾ with k < n, the gaps between consecutive zeros also
+    exhibit monotonicity from the midpoint outward. -/
+axiom lorch_higher_derivatives {f : Polynomial ℝ} {n : ℕ} {a₀ d : ℝ}
+    (hf : HasAPRoots f (n + 1) a₀ d) (k : ℕ) (hk : k < n) :
+    ∃ c : Fin (n - k) → ℝ,
+      (∀ i j : Fin (n - k), i < j → c i < c j) ∧
+      ∀ i j : Fin (n - k - 1),
+        DistFromMidpoint c a₀ d (n - k) ⟨i.val, by omega⟩ <
+        DistFromMidpoint c a₀ d (n - k) ⟨j.val, by omega⟩ →
+        Gap c i < Gap c j
 
 /-
-## Part VII: Lorch's Generalizations (1976)
+## Part VII: Summary
 -/
 
-/--
-**Generalization 1:**
-The result extends to higher derivatives.
--/
-axiom lorch_higher_derivatives :
-  -- For f⁽ᵏ⁾, similar monotonicity properties hold
-  True
-
-/--
-**Generalization 2:**
-Related monotonicity properties for other polynomial families.
--/
-axiom lorch_extensions : True
-
-/-
-## Part VIII: Explicit Examples
--/
-
-/--
-**Example: f(x) = (x-1)(x-2)(x-3)(x-4)**
-Roots: 1, 2, 3, 4 (AP with d = 1)
-f(x) = x⁴ - 10x³ + 35x² - 50x + 24
-f'(x) = 4x³ - 30x² + 70x - 50
-
-Critical points: approximately 1.38, 2.5, 3.62
-Gaps: g₁ ≈ 1.12, g₂ ≈ 1.12 (actually symmetric for n=4)
--/
-axiom example_quartic : True
-
-/--
-**Example: f(x) = (x-1)(x-2)(x-3)(x-4)(x-5)**
-Roots: 1, 2, 3, 4, 5 (AP with d = 1)
-f' has 4 critical points.
-Outer gaps > inner gaps.
--/
-axiom example_quintic : True
-
-/-
-## Part IX: Summary
--/
-
-/--
-**Erdős Problem #1114: SOLVED**
-
-**STATEMENT:** For a polynomial f with n+1 real roots in arithmetic progression,
-the gaps between consecutive critical points of f' increase outward from
-the midpoint.
-
-**PROOF:** Bálint (1960)
-
-**GENERALIZATIONS:** Lorch (1976)
-
-**KEY INSIGHT:** The symmetry of AP roots induces structure on f',
-and convexity arguments establish the monotonicity of gaps.
--/
+/-- **Erdős Problem #1114: SOLVED by Bálint (1960)**
+    Combines Bálint's main theorem with the quartic special case. -/
 theorem erdos_1114_summary :
-    -- The main theorem is true (axiomatized)
-    True := trivial
-
-/--
-**Problem status:**
-Erdős Problem #1114 is SOLVED.
--/
-theorem erdos_1114_status : True := trivial
+    -- Main theorem: gaps increase outward
+    (∀ n : ℕ, n ≥ 2 → ∀ a₀ d : ℝ, d > 0 →
+      ∀ c : Fin n → ℝ,
+      (∀ i j : Fin n, i < j → c i < c j) →
+      (∀ i : Fin n, a₀ + i * d < c i ∧ c i < a₀ + (i + 1) * d) →
+      ∀ i j : Fin (n - 1),
+        DistFromMidpoint c a₀ d n ⟨i.val, by omega⟩ <
+        DistFromMidpoint c a₀ d n ⟨j.val, by omega⟩ →
+        Gap c i < Gap c j) ∧
+    -- Quartic case: outer gaps > middle gap
+    (∀ c : Fin 4 → ℝ,
+      (∀ i j : Fin 4, i < j → c i < c j) →
+      Gap c ⟨0, by omega⟩ > Gap c ⟨1, by omega⟩ ∧
+      Gap c ⟨2, by omega⟩ > Gap c ⟨1, by omega⟩) :=
+  ⟨fun n hn a₀ d hd c hc hcb => balint_theorem hn hd c hc hcb,
+   fun c hc => quartic_gap_property c hc⟩
 
 end Erdos1114

--- a/src/data/proofs/erdos-1114/annotations.json
+++ b/src/data/proofs/erdos-1114/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-1114-overview",
     "proofId": "erdos-1114",
-    "range": { "startLine": 1, "endLine": 30 },
+    "range": { "startLine": 1, "endLine": 31 },
     "type": "concept",
     "title": "Problem Overview",
     "content": "**Erdős Problem #1114:**\n\nFor a polynomial f with roots in arithmetic progression, the gaps between consecutive critical points of f' increase outward from the midpoint.\n\n**Setup:**\n- f has roots a₀, a₀+d, a₀+2d, ..., a₀+nd\n- By Rolle, f' has n critical points\n- Gaps gᵢ = cᵢ₊₁ - cᵢ\n\n**Result:** Gaps increase as we move from center to endpoints.\n\n**Status:** SOLVED by Bálint (1960)",
@@ -47,10 +47,10 @@
   {
     "id": "ann-1114-midpoint",
     "proofId": "erdos-1114",
-    "range": { "startLine": 93, "endLine": 98 },
+    "range": { "startLine": 93, "endLine": 105 },
     "type": "definition",
-    "title": "Midpoint",
-    "content": "**Midpoint of Root Interval:**\n\nm = a₀ + nd/2\n\nThe center of the interval containing all roots.",
+    "title": "Midpoint and Distance",
+    "content": "**Midpoint of Root Interval:**\n\nm = a₀ + nd/2\n\nThe center of the interval containing all roots.\n\n**DistFromMidpoint** measures how far each critical point is from m.",
     "significance": "key"
   },
   {
@@ -58,7 +58,7 @@
     "proofId": "erdos-1114",
     "range": { "startLine": 111, "endLine": 128 },
     "type": "axiom",
-    "title": "Bálint's Theorem",
+    "title": "Bálint's Theorem (1960)",
     "content": "**Main Theorem (Bálint 1960):**\n\nIf |cᵢ - m| < |cⱼ - m| (cᵢ is closer to midpoint), then gᵢ < gⱼ.\n\nThe gaps increase as we move outward from the center.\n\nThis is the core result of Problem #1114.",
     "significance": "critical"
   },
@@ -74,46 +74,28 @@
   {
     "id": "ann-1114-quartic",
     "proofId": "erdos-1114",
-    "range": { "startLine": 159, "endLine": 169 },
+    "range": { "startLine": 144, "endLine": 151 },
     "type": "axiom",
     "title": "Quartic Case",
     "content": "**n = 4 Example:**\n\nf has 5 roots, f' has 4 critical points.\n\nGaps: g₁, g₂, g₃\n\nResult: g₁ > g₂ and g₃ > g₂ (outer > middle).",
     "significance": "supporting"
   },
   {
-    "id": "ann-1114-symmetry",
-    "proofId": "erdos-1114",
-    "range": { "startLine": 175, "endLine": 182 },
-    "type": "axiom",
-    "title": "Symmetry Property",
-    "content": "**Symmetry of AP Polynomial:**\n\nf(a₀ + t) = (-1)^{n+1} f(aₙ - t) (up to scaling).\n\nThe polynomial is symmetric about its center, which induces structure on f'.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1114-convexity",
-    "proofId": "erdos-1114",
-    "range": { "startLine": 194, "endLine": 199 },
-    "type": "axiom",
-    "title": "Convexity Argument",
-    "content": "**Key Proof Technique:**\n\nCertain auxiliary functions are convex, which implies the monotonicity of gaps.\n\nThis is the technical core of Bálint's proof.",
-    "significance": "key"
-  },
-  {
     "id": "ann-1114-lorch",
     "proofId": "erdos-1114",
-    "range": { "startLine": 205, "endLine": 217 },
+    "range": { "startLine": 157, "endLine": 167 },
     "type": "axiom",
-    "title": "Lorch's Generalizations",
-    "content": "**Extensions (Lorch 1976):**\n\n1. Higher derivatives f⁽ᵏ⁾ have analogous properties\n2. Related monotonicity for other polynomial families\n\nThe original result extends broadly.",
-    "significance": "supporting"
+    "title": "Lorch's Generalization (1976)",
+    "content": "**lorch_higher_derivatives** formalizes Lorch's extension to higher derivatives: for f⁽ᵏ⁾ with k < n, the gaps between consecutive zeros also exhibit monotonicity from the midpoint outward. The axiom states existence of ordered critical points with the same gap-monotonicity property.",
+    "significance": "key"
   },
   {
     "id": "ann-1114-summary",
     "proofId": "erdos-1114",
-    "range": { "startLine": 246, "endLine": 262 },
+    "range": { "startLine": 173, "endLine": 191 },
     "type": "theorem",
     "title": "erdos_1114_summary",
-    "content": "**Complete Summary:**\n\nErdős Problem #1114 is **SOLVED**.\n\n**STATEMENT:** Critical point gaps increase outward from midpoint for AP-root polynomials.\n\n**PROOF:** Bálint (1960)\n\n**KEY INSIGHT:** Symmetry + convexity establish monotonicity.",
+    "content": "**erdos_1114_summary** combines two results:\n1. **balint_theorem** — gaps between consecutive critical points increase outward from the midpoint for any polynomial with AP roots\n2. **quartic_gap_property** — the quartic case explicitly: outer gaps > middle gap\n\nProved by exact ⟨balint_theorem, quartic_gap_property⟩.",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-1114/meta.json
+++ b/src/data/proofs/erdos-1114/meta.json
@@ -15,7 +15,7 @@
       "analysis",
       "critical-points"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1114,
     "erdosUrl": "https://erdosproblems.com/1114",
@@ -59,42 +59,28 @@
       "title": "The Main Theorem",
       "startLine": 107,
       "endLine": 138,
-      "summary": "Bálint's theorem: gaps increase outward from midpoint."
+      "summary": "Bálint's theorem and symmetric formulation: gaps increase outward from midpoint."
     },
     {
-      "id": "special-cases",
-      "title": "Special Cases",
+      "id": "quartic-case",
+      "title": "Quartic Case",
       "startLine": 140,
-      "endLine": 169,
-      "summary": "Cases n = 2, 3, 4 with explicit gap properties."
-    },
-    {
-      "id": "proof-ideas",
-      "title": "Proof Ideas",
-      "startLine": 171,
-      "endLine": 199,
-      "summary": "Symmetry, derivative structure, and convexity arguments."
+      "endLine": 151,
+      "summary": "Explicit quartic case: outer gaps larger than middle gap."
     },
     {
       "id": "generalizations",
-      "title": "Lorch's Generalizations",
-      "startLine": 201,
-      "endLine": 217,
-      "summary": "Extensions to higher derivatives and related polynomials."
-    },
-    {
-      "id": "examples",
-      "title": "Explicit Examples",
-      "startLine": 219,
-      "endLine": 240,
-      "summary": "Concrete examples with quartic and quintic polynomials."
+      "title": "Lorch's Generalizations (1976)",
+      "startLine": 153,
+      "endLine": 167,
+      "summary": "Extension to higher derivatives with formalized axiom."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 242,
-      "endLine": 270,
-      "summary": "Complete summary of the SOLVED problem."
+      "startLine": 169,
+      "endLine": 193,
+      "summary": "erdos_1114_summary combining Bálint's theorem and quartic case."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove 4 `True := trivial` theorems: `quadratic_trivial`, `cubic_one_gap`, `erdos_1114_summary`, `erdos_1114_status`
- Remove 7 `True` axioms: `symmetry_of_ap_polynomial`, `derivative_structure`, `convexity_argument`, `lorch_higher_derivatives`, `lorch_extensions`, `example_quartic`, `example_quintic`
- Replace with formalized `lorch_higher_derivatives` axiom (proper type signature for gap monotonicity in higher derivatives)
- Replace summary with real `erdos_1114_summary` combining `balint_theorem` and `quartic_gap_property`
- Update meta.json (badge: axiom, updated sections) and annotations.json

## Test plan
- [x] `pnpm build` passes
- [ ] Lean file compiles (docker build)
- [ ] Gallery renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)