### PR TITLE
fix(erdos-801): remove 14 True axioms, 1 True trivial, formalize tightness

### DIFF
--- a/proofs/Proofs/Erdos801Problem.lean
+++ b/proofs/Proofs/Erdos801Problem.lean
@@ -32,12 +32,13 @@ import Mathlib.Data.Real.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Order.Filter.Basic
 
 open Finset Real
 
 namespace Erdos801
 
-/-!
+/-
 ## Part 1: Basic Graph Definitions
 -/
 
@@ -56,7 +57,7 @@ def HasBoundedIndependence {n : ℕ} (G : FiniteGraph n) (k : ℕ) : Prop :=
 noncomputable def inducedEdges {n : ℕ} (G : FiniteGraph n) (S : Finset (Fin n)) : ℕ :=
   ((S ×ˢ S).filter (fun p => p.1 < p.2 ∧ G.Adj p.1 p.2)).card
 
-/-!
+/-
 ## Part 2: The Main Statement
 -/
 
@@ -76,201 +77,47 @@ axiom alon_1996 : Erdos801Statement
 /-- The main theorem: Problem #801 is solved -/
 theorem erdos_801_solved : Erdos801Statement := alon_1996
 
-/-!
-## Part 3: Why the Bound Matters
+/-
+## Part 3: Tightness and Optimality
 -/
 
-/-- The independence bound √n is critical -/
-axiom sqrt_threshold :
-  -- If α(G) ≤ √n, the graph is "dense enough" to have local density
-  -- If α(G) > √n, counterexamples exist
-  True
-
-/-- The logarithmic factor is necessary -/
+/-- The logarithmic factor in √n log n edges is necessary:
+    there exist graphs with α(G) ≤ √n where every set of ≤ √n
+    vertices has at most O(√n log n) induced edges. -/
 axiom log_factor_necessary :
-  -- One cannot replace √n log n edges with √n · ω(1) edges
-  -- for any function ω(n) growing faster than log n
-  True
+  ∀ C : ℝ, C > 0 →
+    ∀ n : ℕ, n ≥ 2 →
+      ∃ G : FiniteGraph n,
+        HasBoundedIndependence G (Nat.sqrt n) ∧
+        ∀ S : Finset (Fin n),
+          S.card ≤ Nat.sqrt n →
+          (inducedEdges G S : ℝ) ≤ C * Real.sqrt n * Real.log n
 
-/-- The vertex set size √n is optimal -/
+/-- The vertex set size √n is optimal: one cannot replace √n with o(√n). -/
 axiom vertex_set_size_optimal :
-  -- Cannot guarantee the result with o(√n) vertices
-  True
+  ∀ ε : ℝ, ε > 0 → ε < 1 →
+    ∀ᶠ n in Filter.atTop,
+      ∃ G : FiniteGraph n,
+        HasBoundedIndependence G (Nat.sqrt n) ∧
+        ∀ S : Finset (Fin n),
+          (S.card : ℝ) ≤ ε * Real.sqrt n →
+          (inducedEdges G S : ℝ) < Real.sqrt n
 
-/-!
-## Part 4: Connection to Ramsey Theory
+/-
+## Part 4: Summary
 -/
 
-/-- This is a "Ramsey-type" problem -/
-axiom ramsey_connection :
-  -- The structure of graphs avoiding large independent sets
-  -- relates to Ramsey theory via the complementary view:
-  -- small independence ↔ large cliques or specific structure
-  True
-
-/-- Connection to R(k,k) -/
-axiom ramsey_number_connection :
-  -- If α(G) ≤ √n, then the complement has clique number ≥ n/√n = √n
-  -- This relates to off-diagonal Ramsey numbers
-  True
-
-/-- Local-global phenomenon -/
-axiom local_global :
-  -- Global constraint (bounded α) implies local structure (dense subset)
-  -- This is a common theme in extremal graph theory
-  True
-
-/-!
-## Part 5: Proof Techniques
--/
-
-/-- Alon's proof uses probabilistic methods -/
-axiom probabilistic_method :
-  -- Key step: sample a random subset of appropriate size
-  -- Show expected number of edges is large
-  -- Derandomization gives the deterministic result
-  True
-
-/-- Connection to dependent random choice -/
-axiom dependent_random_choice :
-  -- The technique of dependent random choice
-  -- (sample neighborhood iteratively) is relevant
-  True
-
-/-- Concentration inequalities -/
-axiom concentration_inequalities :
-  -- Alon's proof uses concentration bounds to show
-  -- a random sample has the required properties w.h.p.
-  True
-
-/-!
-## Part 6: Consequences and Applications
--/
-
-/-- Application: Locally sparse graphs have large independence number -/
-theorem locally_sparse_has_large_independence :
-    -- Contrapositive of Problem #801
-    -- If every small set has few edges, then α(G) > √n
-    True := trivial
-
-/-- Connection to regularity lemma -/
-axiom regularity_connection :
-  -- Szemerédi's regularity lemma also finds "structured" subgraphs
-  -- This result is more elementary but captures a similar spirit
-  True
-
-/-- Applications in algorithm design -/
-axiom algorithm_applications :
-  -- Finding dense subgraphs has applications in:
-  -- - Community detection
-  -- - Dense subgraph algorithms
-  -- - Approximation algorithms
-  True
-
-/-!
-## Part 7: Quantitative Bounds
--/
-
-/-- The constant c in Alon's bound -/
-axiom alon_constant :
-  -- The constant c in the theorem can be made explicit
-  -- though the exact value depends on the proof
-  True
-
-/-- Tight bounds -/
-def TightBound : Prop :=
-  -- The bound c · √n · log n edges is tight up to constants
-  ∃ c₁ c₂ : ℝ, c₁ > 0 ∧ c₂ > 0 ∧
-    -- Lower bound: there exist graphs requiring c₁ · √n · log n edges
-    -- Upper bound: can always find set with c₂ · √n · log n edges
-    True
-
-/-- Alon's result is essentially tight -/
-axiom bound_is_tight : TightBound
-
-/-!
-## Part 8: Related Problems
--/
-
-/-- Problem #802: Related independence questions -/
-axiom problem_802_relation :
-  -- Other Erdős problems study the relationship between
-  -- independence number and local structure
-  True
-
-/-- Turán-type connection -/
-axiom turan_connection :
-  -- Turán's theorem gives edge count for K_r-free graphs
-  -- This problem asks about induced density in α-bounded graphs
-  True
-
-/-- Zarankiewicz-type questions -/
-axiom zarankiewicz_connection :
-  -- Related to bipartite density questions
-  True
-
-/-!
-## Part 9: Extremal Examples
--/
-
-/-- Kneser graphs provide relevant examples -/
-axiom kneser_examples :
-  -- Kneser graphs K(n,k) have known independence numbers
-  -- and can be analyzed for local density
-  True
-
-/-- Paley graphs -/
-axiom paley_examples :
-  -- Paley graphs have α ≈ √n and specific local structure
-  -- They are candidate extremal examples
-  True
-
-/-- Random graphs -/
-axiom random_graph_examples :
-  -- G(n, 1/2) typically has α ≈ 2 log n
-  -- Much smaller than √n, so has very dense local structure
-  True
-
-/-!
-## Part 10: Summary
--/
-
-/-- Erdős Problem #801 is SOLVED -/
-theorem erdos_801_status : Erdos801Statement := alon_1996
-
-/-- **Erdős Problem #801: SOLVED (Alon, 1996)**
-
-PROBLEM: If G has n vertices and α(G) ≤ √n, prove that some
-set of ≤ √n vertices contains ≫ √n log n edges.
-
-ANSWER: YES
-
-PROVED BY: Noga Alon (1996)
-
-KEY INSIGHT: Small independence number forces high local edge density.
-The logarithmic factor √n log n cannot be improved to √n · ω(n)
-for any faster-growing function ω.
-
-TECHNIQUE: Probabilistic method with concentration inequalities.
-Sample random subsets and show expected edge count is large.
-
-APPLICATIONS:
-- Community detection in graphs
-- Dense subgraph algorithms
-- Ramsey-type structural theorems
-
-The result captures a local-global phenomenon: a global constraint
-(bounded independence) implies local structure (dense subset).
--/
+/-- **Erdős Problem #801: SOLVED by Alon (1996)**
+    Combines: (1) Alon's theorem, (2) necessity of the log factor. -/
 theorem erdos_801_summary :
-    -- The problem is solved
     Erdos801Statement ∧
-    -- The bound is tight
-    TightBound := by
-  exact ⟨alon_1996, bound_is_tight⟩
-
-/-- Problem status -/
-def erdos_801_status_str : String :=
-  "SOLVED (Alon 1996) - α(G) ≤ √n implies ∃ S with |S| ≤ √n and e(S) ≫ √n log n"
+    (∀ C : ℝ, C > 0 →
+      ∀ n : ℕ, n ≥ 2 →
+        ∃ G : FiniteGraph n,
+          HasBoundedIndependence G (Nat.sqrt n) ∧
+          ∀ S : Finset (Fin n),
+            S.card ≤ Nat.sqrt n →
+            (inducedEdges G S : ℝ) ≤ C * Real.sqrt n * Real.log n) :=
+  ⟨alon_1996, log_factor_necessary⟩
 
 end Erdos801

--- a/src/data/proofs/erdos-801/annotations.json
+++ b/src/data/proofs/erdos-801/annotations.json
@@ -13,7 +13,7 @@
   {
     "id": "ann-801-independence",
     "proofId": "erdos-801",
-    "range": { "startLine": 47, "endLine": 53 },
+    "range": { "startLine": 48, "endLine": 54 },
     "type": "definition",
     "title": "Independence Number α(G)",
     "content": "**α(G) = max{|S| : S is an independent set in G}**\n\nAn independent set has no edges between its vertices. The problem constrains α(G) ≤ √n.",
@@ -22,7 +22,7 @@
   {
     "id": "ann-801-induced-edges",
     "proofId": "erdos-801",
-    "range": { "startLine": 55, "endLine": 57 },
+    "range": { "startLine": 56, "endLine": 58 },
     "type": "definition",
     "title": "Induced Edges",
     "content": "**e(S) = number of edges in the subgraph induced by S**\n\nCount edges with both endpoints in S. The problem asks for S with |S| ≤ √n but e(S) ≫ √n log n.",
@@ -31,7 +31,7 @@
   {
     "id": "ann-801-statement",
     "proofId": "erdos-801",
-    "range": { "startLine": 63, "endLine": 71 },
+    "range": { "startLine": 64, "endLine": 72 },
     "type": "definition",
     "title": "Erdos801Statement",
     "content": "**Main Statement:**\n\n∃ c > 0 such that for all n ≥ 2, for all G with n vertices:\n\nIf α(G) ≤ √n, then ∃ S with |S| ≤ √n and e(S) ≥ c · √n · log n",
@@ -40,55 +40,37 @@
   {
     "id": "ann-801-alon",
     "proofId": "erdos-801",
-    "range": { "startLine": 73, "endLine": 74 },
+    "range": { "startLine": 74, "endLine": 78 },
     "type": "axiom",
     "title": "Alon's Theorem (1996)",
-    "content": "**Alon's Theorem:**\n\nThe statement Erdos801Statement is true.\n\nProved using probabilistic methods and concentration inequalities.",
+    "content": "**alon_1996** axiomatizes Alon's proof that Erdos801Statement holds. The theorem erdos_801_solved directly references this axiom.\n\nProved using probabilistic methods and concentration inequalities.",
     "significance": "critical"
   },
   {
     "id": "ann-801-log-necessary",
     "proofId": "erdos-801",
-    "range": { "startLine": 89, "endLine": 93 },
-    "type": "insight",
-    "title": "Logarithmic Factor is Necessary",
-    "content": "**The log n factor cannot be removed:**\n\nOne cannot replace √n log n with √n · ω(n) for any faster-growing function ω.\n\nThe bound is tight up to the constant.",
+    "range": { "startLine": 83, "endLine": 94 },
+    "type": "axiom",
+    "title": "Log Factor is Necessary",
+    "content": "**log_factor_necessary** formalizes that the √n log n bound is tight: for any constant C, there exist graphs with α(G) ≤ √n where every ≤ √n vertex set has at most C · √n · log n induced edges. The bound cannot be asymptotically improved.",
     "significance": "key"
   },
   {
-    "id": "ann-801-ramsey",
+    "id": "ann-801-vertex-optimal",
     "proofId": "erdos-801",
-    "range": { "startLine": 104, "endLine": 109 },
-    "type": "insight",
-    "title": "Ramsey Connection",
-    "content": "**Connection to Ramsey Theory:**\n\nSmall independence ↔ complementary clique structure.\n\nIf α(G) ≤ √n, the complement G' has ω(G') ≥ n/α(G) ≥ √n.\n\nThis connects to off-diagonal Ramsey numbers.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-801-probabilistic",
-    "proofId": "erdos-801",
-    "range": { "startLine": 127, "endLine": 132 },
-    "type": "insight",
-    "title": "Probabilistic Method",
-    "content": "**Alon's Proof Technique:**\n\n1. Sample a random subset S of size ~√n\n2. Compute expected induced edges E[e(S)]\n3. Show E[e(S)] ≈ √n log n\n4. Derandomize to get deterministic result",
-    "significance": "key"
-  },
-  {
-    "id": "ann-801-contrapositive",
-    "proofId": "erdos-801",
-    "range": { "startLine": 150, "endLine": 154 },
-    "type": "theorem",
-    "title": "Contrapositive Form",
-    "content": "**Locally Sparse ⟹ Large Independence:**\n\nIf every set of ≤ √n vertices has o(√n log n) edges, then α(G) > √n.\n\nLocal sparsity implies the existence of large independent sets.",
+    "range": { "startLine": 96, "endLine": 104 },
+    "type": "axiom",
+    "title": "Vertex Set Size Optimal",
+    "content": "**vertex_set_size_optimal** formalizes that the set size √n cannot be reduced: for any ε < 1, eventually there exist graphs where sets of size ε√n have fewer than √n induced edges.",
     "significance": "key"
   },
   {
     "id": "ann-801-summary",
     "proofId": "erdos-801",
-    "range": { "startLine": 241, "endLine": 270 },
+    "range": { "startLine": 109, "endLine": 121 },
     "type": "theorem",
-    "title": "Summary",
-    "content": "**Erdős Problem #801: SOLVED (Alon, 1996)**\n\n**Problem:** α(G) ≤ √n ⟹ ∃ small dense subset\n\n**Answer:** YES - some ≤ √n vertices induce ≫ √n log n edges\n\n**Key insight:** Bounded independence forces local density\n\n**Applications:** Community detection, dense subgraph algorithms, Ramsey-type theorems",
+    "title": "erdos_801_summary",
+    "content": "**erdos_801_summary** combines two results:\n1. **alon_1996** — Erdős Problem #801 is solved: bounded independence forces dense local subsets\n2. **log_factor_necessary** — the √n log n edge count is tight up to constants\n\nProved by exact ⟨alon_1996, log_factor_necessary⟩.",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-801/meta.json
+++ b/src/data/proofs/erdos-801/meta.json
@@ -16,7 +16,7 @@
       "extremal-combinatorics",
       "probabilistic-method"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 801,
     "erdosUrl": "https://erdosproblems.com/801",
@@ -33,7 +33,36 @@
       "Probabilistic sampling techniques are essential"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Basic Graph Definitions",
+      "startLine": 40,
+      "endLine": 58,
+      "summary": "FiniteGraph, independenceNumber, HasBoundedIndependence, inducedEdges."
+    },
+    {
+      "id": "main-statement",
+      "title": "The Main Statement",
+      "startLine": 60,
+      "endLine": 78,
+      "summary": "Erdos801Statement definition and Alon's theorem (1996)."
+    },
+    {
+      "id": "tightness",
+      "title": "Tightness and Optimality",
+      "startLine": 79,
+      "endLine": 104,
+      "summary": "Log factor is necessary, vertex set size √n is optimal."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 105,
+      "endLine": 123,
+      "summary": "erdos_801_summary combining Alon's theorem and tightness."
+    }
+  ],
   "conclusion": {
     "summary": "Alon (1996) proved that graphs with independence number at most √n must contain a small dense subgraph. Specifically, there exists a set of ≤ √n vertices inducing ≫ √n log n edges. The bound is tight up to constants.",
     "implications": "The result demonstrates a local-global principle: global sparsity constraints (bounded independence) imply local density. Applications include community detection algorithms, dense subgraph discovery, and Ramsey-type structural theorems.",


### PR DESCRIPTION
## Summary
- Remove 14 `True` axioms and 1 `True := trivial` theorem (Parts 3-9 were all filler)
- Remove `TightBound` definition with `True`, `bound_is_tight`, `erdos_801_status_str`
- Add formalized `log_factor_necessary` axiom (√n log n bound is tight)
- Add formalized `vertex_set_size_optimal` axiom (√n set size cannot be reduced)
- Replace summary with real `erdos_801_summary` combining `alon_1996` and `log_factor_necessary`
- Fix all `/-!` to `/-` for Aristotle compatibility
- Update meta.json (badge: axiom, add sections) and annotations.json (8 annotations)

File reduced from 277 to 123 lines while improving mathematical content.

## Test plan
- [x] `pnpm build` passes
- [ ] Lean file compiles (docker build)
- [ ] Gallery renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)