### PR TITLE
fix(erdos-288): remove True placeholder, fix headers, add erdos tag

### DIFF
--- a/proofs/Proofs/Erdos288Problem.lean
+++ b/proofs/Proofs/Erdos288Problem.lean
@@ -27,7 +27,7 @@ open Finset BigOperators
 
 namespace Erdos288
 
-/-! ## Part I: Harmonic Sums Over Intervals -/
+/- ## Part I: Harmonic Sums Over Intervals -/
 
 /-- The harmonic sum over the interval [a, b] of positive integers:
     H(a, b) = Σ_{n=a}^{b} 1/n as a rational number. -/
@@ -46,7 +46,7 @@ noncomputable def pairSum (p : IntervalPair) : ℚ :=
 def IsIntegerSum (p : IntervalPair) : Prop :=
   ∃ n : ℕ+, pairSum p = (n : ℚ)
 
-/-! ## Part II: The Main Conjecture -/
+/- ## Part II: The Main Conjecture -/
 
 /-- The set of interval pairs whose harmonic sum is a positive integer. -/
 def integerSumPairs : Set IntervalPair :=
@@ -63,7 +63,7 @@ def ErdosConjecture288 : Prop :=
 /-- The conjecture is axiomatized. -/
 axiom erdos_288 : ErdosConjecture288
 
-/-! ## Part III: The Known Example -/
+/- ## Part III: The Known Example -/
 
 /-- Example: 1/3 + 1/4 + 1/5 + 1/6 + 1/20 = 1.
     This uses intervals [3,6] and [20,20]. -/
@@ -71,7 +71,7 @@ axiom example_sum_one :
     harmonicInterval ⟨3, by omega⟩ ⟨6, by omega⟩ +
     harmonicInterval ⟨20, by omega⟩ ⟨20, by omega⟩ = 1
 
-/-! ## Part IV: Variant — Single Element I₂ -/
+/- ## Part IV: Variant — Single Element I₂ -/
 
 /-- The restricted version where I₂ has a single element. -/
 def singletonPairs : Set (ℕ+ × ℕ+ × ℕ+) :=
@@ -83,7 +83,7 @@ The conjecture is still open even when |I₂| = 1.
 -/
 axiom erdos_288_singleton : Set.Finite singletonPairs
 
-/-! ## Part V: Variant — k Intervals -/
+/- ## Part V: Variant — k Intervals -/
 
 /-- The generalization to k intervals: each interval represented
     as a pair (start, end) of positive naturals. -/
@@ -102,7 +102,7 @@ whose harmonic sums add to a positive integer.
 axiom erdos_288_k_intervals :
     ∀ k : ℕ, Set.Finite (kIntervalPairs k)
 
-/-! ## Part VI: Properties of Harmonic Sums -/
+/- ## Part VI: Properties of Harmonic Sums -/
 
 /-- The harmonic sum over [a, a] is 1/a. -/
 axiom harmonicInterval_singleton (a : ℕ+) :
@@ -121,7 +121,7 @@ axiom harmonicInterval_growth :
     ∀ ε : ℝ, ε > 0 → ∃ N : ℕ, ∀ n : ℕ, n ≥ N →
     harmonicInterval 1 ⟨n, by omega⟩ > (n : ℚ) * 0
 
-/-! ## Part VII: Summary -/
+/- ## Part VII: Summary -/
 
 /--
 **Erdős Problem #288: Summary**
@@ -141,7 +141,21 @@ theorem erdos_288_statement :
     ErdosConjecture288 ↔ Set.Finite {p : IntervalPair | IsIntegerSum p} := by
   simp only [ErdosConjecture288, integerSumPairs]
 
-/-- The problem remains OPEN. -/
-theorem erdos_288_status : True := trivial
+/--
+**Erdős Problem #288: Summary**
+
+QUESTION: Are there only finitely many pairs of intervals (I₁, I₂) with
+Σ_{I₁} 1/n + Σ_{I₂} 1/n ∈ ℕ?
+
+STATUS: OPEN
+
+KNOWN:
+- Example: [3,6] ∪ [20,20] gives 1/3 + 1/4 + 1/5 + 1/6 + 1/20 = 1
+- Open even when |I₂| = 1
+- Conjectured to hold for k intervals (any k)
+-/
+theorem erdos_288_summary :
+    ErdosConjecture288 ↔ Set.Finite {p : IntervalPair | IsIntegerSum p} :=
+  erdos_288_statement
 
 end Erdos288

--- a/src/data/proofs/erdos-288/annotations.json
+++ b/src/data/proofs/erdos-288/annotations.json
@@ -2,12 +2,12 @@
   {
     "id": "erdos-288-header",
     "proofId": "erdos-288",
-    "type": "context",
+    "type": "concept",
     "range": { "startLine": 1, "endLine": 16 },
     "title": "Problem Overview",
     "content": "Erdős Problem #288: Are there only finitely many pairs of intervals (I₁, I₂) whose harmonic sums add to a positive integer? Example: 1/3+1/4+1/5+1/6+1/20 = 1. OPEN.",
     "mathContext": "Harmonic sums over intervals [a,b] are Σ_{n=a}^{b} 1/n ∈ ℚ. The question is finiteness of interval pairs achieving integer totals.",
-    "significance": "essential",
+    "significance": "critical",
     "relatedConcepts": ["harmonic sums", "unit fractions", "Egyptian fractions"]
   },
   {
@@ -18,25 +18,25 @@
     "title": "Harmonic Sums and Interval Pairs",
     "content": "harmonicInterval(a,b): sum of 1/n for n in [a,b] over ℚ. IntervalPair: (a₁, b₁, a₂, b₂). pairSum: combined harmonic sum. IsIntegerSum: pairSum equals a positive integer.",
     "mathContext": "All sums are computed exactly in ℚ to avoid rounding issues.",
-    "significance": "essential",
+    "significance": "critical",
     "relatedConcepts": ["ℚ arithmetic", "Finset.sum", "PNat"]
   },
   {
     "id": "erdos-288-conjecture",
     "proofId": "erdos-288",
-    "type": "conjecture",
-    "range": { "startLine": 49, "endLine": 62 },
+    "type": "definition",
+    "range": { "startLine": 49, "endLine": 64 },
     "title": "Main Conjecture (OPEN)",
     "content": "ErdosConjecture288: Set.Finite integerSumPairs. The set of interval pairs with integer harmonic sum is finite. erdos_288 (axiom).",
     "mathContext": "Finiteness of a set defined by a Diophantine-type condition on harmonic sums.",
-    "significance": "essential",
+    "significance": "critical",
     "relatedConcepts": ["Set.Finite", "Diophantine equations"]
   },
   {
     "id": "erdos-288-example",
     "proofId": "erdos-288",
-    "type": "result",
-    "range": { "startLine": 64, "endLine": 69 },
+    "type": "axiom",
+    "range": { "startLine": 66, "endLine": 72 },
     "title": "Known Example",
     "content": "example_sum_one (axiom): H(3,6) + H(20,20) = 1. That is, 1/3+1/4+1/5+1/6+1/20 = 1.",
     "mathContext": "The decomposition 1 = 1/3+1/4+1/5+1/6+1/20 uses intervals [3,6] and [20,20].",
@@ -46,23 +46,23 @@
   {
     "id": "erdos-288-variants",
     "proofId": "erdos-288",
-    "type": "conjecture",
-    "range": { "startLine": 71, "endLine": 102 },
+    "type": "definition",
+    "range": { "startLine": 74, "endLine": 103 },
     "title": "Variants: Singleton and k-Interval",
     "content": "singletonPairs: restricted to |I₂|=1. erdos_288_singleton (axiom): still open. kIntervalSum, kIntervalPairs: generalization to k intervals. erdos_288_k_intervals (axiom): conjectured for all k.",
     "mathContext": "The problem is open even in the restricted singleton case. The k-interval generalization is a natural strengthening.",
-    "significance": "essential",
+    "significance": "critical",
     "relatedConcepts": ["generalizations", "singleton intervals"]
   },
   {
     "id": "erdos-288-summary",
     "proofId": "erdos-288",
-    "type": "result",
-    "range": { "startLine": 122, "endLine": 148 },
-    "title": "Summary: OPEN",
-    "content": "erdos_288_statement (proved): equivalence by simp. erdos_288_status (proved): True. Problem remains OPEN with variants also open.",
+    "type": "theorem",
+    "range": { "startLine": 124, "endLine": 161 },
+    "title": "Summary",
+    "content": "erdos_288_statement (proved by simp): equivalence unfolding. erdos_288_summary: the conjecture is equivalent to finiteness of integer-sum interval pairs. Problem remains OPEN.",
     "mathContext": "The statement unfolds to Set.Finite of interval pairs with integer harmonic sum.",
-    "significance": "essential",
+    "significance": "critical",
     "relatedConcepts": ["open problem", "summary"]
   }
 ]

--- a/src/data/proofs/erdos-288/meta.json
+++ b/src/data/proofs/erdos-288/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos288Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "harmonic-sums",
       "unit-fractions",
@@ -79,9 +80,9 @@
     {
       "id": "summary",
       "title": "Part VII: Summary",
-      "startLine": 122,
-      "endLine": 148,
-      "summary": "Proved: erdos_288_statement (simp), erdos_288_status (trivial). Problem remains OPEN."
+      "startLine": 124,
+      "endLine": 161,
+      "summary": "Proved: erdos_288_statement (simp), erdos_288_summary. Problem remains OPEN."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove `erdos_288_status : True := trivial` placeholder, replace with proved `erdos_288_summary` theorem
- Fix all `/-!` doc sections → `/-` for Aristotle compatibility
- Add missing `erdos` tag to meta.json
- Update annotations.json with correct types and line ranges

## Changes
- **Lean file**: Remove True placeholder, add proved summary theorem, fix 7 `/-!` headers
- **meta.json**: Add `erdos` tag, update summary section line range
- **annotations.json**: Fix annotation types to valid values, update line ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)