### PR TITLE
fix: deployer labels unlabeled erdos/research PRs

### DIFF
--- a/.lean/roles/deployer.md
+++ b/.lean/roles/deployer.md
@@ -4,11 +4,12 @@ You are the **Deployer** agent. Your mission is to keep the website current by p
 
 ## Your Responsibilities
 
-1. **Merge Pull Requests** - Merge all ready PRs, aggressively resolve conflicts
-2. **Sync Data Files** - Update research-listings.json with actual iteration counts
-3. **Build Website** - Compile the site and catch any errors
-4. **Deploy to Cloudflare** - Push the built site to production
-5. **Commit Changes** - Push any data sync changes back to main
+1. **Label Unlabeled PRs** - Add `loom:review-requested` to erdos/research PRs missing it
+2. **Merge Pull Requests** - Merge all ready PRs, aggressively resolve conflicts
+3. **Sync Data Files** - Update research-listings.json with actual iteration counts
+4. **Build Website** - Compile the site and catch any errors
+5. **Deploy to Cloudflare** - Push the built site to production
+6. **Commit Changes** - Push any data sync changes back to main
 
 ## Workflow
 

--- a/research/candidate-pool.json
+++ b/research/candidate-pool.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "last_updated": "2026-02-06T17:01:39.520Z",
+  "last_updated": "2026-02-06T17:51:58.032Z",
   "source": "auto-generated from research/db/knowledge.db",
   "candidates": [
     {

--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -95,6 +95,40 @@ if $ONLY_DEPLOY; then run_merge=false; run_sync=false; run_build=false; fi
 [[ "${SKIP_DEPLOY:-}" == "1" ]] && run_deploy=false
 
 # ============================================================================
+# Step 0: Label unlabeled erdos/research PRs
+# ============================================================================
+label_unlabeled_prs() {
+    print_header "Labeling Unlabeled Erdos/Research PRs"
+
+    # Find open PRs with erdos-enhancement, research, or aristotle-integration labels
+    # that are missing loom:review-requested (safety net for old worktrees or gh errors)
+    local labeled=0
+    for pr in $(gh pr list --state open --limit 100 --json number,labels \
+        --jq '.[] |
+            select(.labels | map(.name) | any(. == "erdos-enhancement" or . == "research" or . == "aristotle-integration")) |
+            select(.labels | map(.name) | any(. == "loom:review-requested") | not) |
+            .number'); do
+        if $DRY_RUN; then
+            echo "  Would label PR #$pr with loom:review-requested"
+        else
+            echo -n "  #$pr: "
+            if gh pr edit "$pr" --add-label "loom:review-requested" 2>/dev/null; then
+                echo "labeled"
+            else
+                echo "failed to label"
+            fi
+        fi
+        ((labeled++)) || true
+    done
+
+    if [[ $labeled -eq 0 ]]; then
+        print_info "No unlabeled erdos/research PRs found"
+    else
+        print_success "Labeled $labeled PR(s) with loom:review-requested"
+    fi
+}
+
+# ============================================================================
 # Step 1: Merge PRs
 # ============================================================================
 merge_prs() {
@@ -603,6 +637,7 @@ main() {
     echo "  Deploy:    $run_deploy"
     echo "  Dry Run:   $DRY_RUN"
 
+    $run_merge && label_unlabeled_prs
     $run_merge && merge_prs
     $run_sync && sync_data
     $run_build && build_website


### PR DESCRIPTION
## Summary

- Adds `label_unlabeled_prs()` step to `sync-and-deploy.sh` that runs before PR merging
- Scans for open PRs with `erdos-enhancement`, `research`, or `aristotle-integration` labels missing `loom:review-requested`
- Automatically adds the missing label so PRs enter the Judge/Deployer pipeline
- Updates deployer role documentation to list the new responsibility

Closes #1703

## Test plan

- [ ] Run `./scripts/deploy/sync-and-deploy.sh --merge --dry-run` to verify the new step runs
- [ ] Create a test PR with `erdos-enhancement` label but no `loom:review-requested` and verify it gets labeled
- [ ] Verify existing labeled PRs are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)