### PR TITLE
fix(deployer): skip PRs with any loom: label in relabeling

### DIFF
--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -101,12 +101,12 @@ label_unlabeled_prs() {
     print_header "Labeling Unlabeled Erdos/Research PRs"
 
     # Find open PRs with erdos-enhancement, research, or aristotle-integration labels
-    # that are missing loom:review-requested (safety net for old worktrees or gh errors)
+    # that have no loom: labels at all (safety net for old worktrees or gh errors)
     local labeled=0
     for pr in $(gh pr list --state open --limit 100 --json number,labels \
         --jq '.[] |
             select(.labels | map(.name) | any(. == "erdos-enhancement" or . == "research" or . == "aristotle-integration")) |
-            select(.labels | map(.name) | any(. == "loom:review-requested") | not) |
+            select(.labels | map(.name) | any(startswith("loom:")) | not) |
             .number'); do
         if $DRY_RUN; then
             echo "  Would label PR #$pr with loom:review-requested"


### PR DESCRIPTION
## Summary

- Replace `loom:review-requested` exact-match check with `startswith("loom:")` prefix check in `label_unlabeled_prs()`
- PRs already managed by the loom workflow (with any `loom:` label) are now excluded from relabeling

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| PRs with any `loom:` label excluded from relabeling | ✅ | `startswith("loom:")` filter catches all loom labels |
| PRs with only erdos/research/aristotle labels still get labeled | ✅ | Filter only excludes when a `loom:` label exists |
| No change to dry-run output path | ✅ | Only the jq filter changed, dry-run logic untouched |

Closes #1788

🤖 Generated with [Claude Code](https://claude.com/claude-code)