### PR TITLE
fix: add catch-all safety net to force-stop in launch.sh

### DIFF
--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -1322,6 +1322,17 @@ cmd_stop() {
             stopped=$((stopped + 1))
         fi
 
+        # Safety net: kill any remaining agent sessions
+        echo -e "${BLUE}Catch-all: cleaning remaining agent sessions...${NC}"
+        local remaining_sessions
+        remaining_sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E '^(erdos-enhancer-|researcher-|aristotle-agent$|seeker-agent$|deployer$)' || true)
+        if [[ -n "$remaining_sessions" ]]; then
+            while IFS= read -r session; do
+                echo -e "  Killing stale session: $session"
+                tmux kill-session -t "$session" 2>/dev/null || true
+            done <<< "$remaining_sessions"
+        fi
+
         # Update state (preserves agents, session_stats, etc.)
         set_stopped
 


### PR DESCRIPTION
## Summary

- Adds a catch-all cleanup step to `cmd_stop --force` in `scripts/lean/launch.sh` that scans for and kills any remaining agent tmux sessions after per-agent stop scripts have run
- Prevents stale sessions from surviving when individual stop scripts error silently

## Changes

Inserts a safety-net block between the per-agent stops and `set_stopped` that:
1. Lists all tmux sessions matching known agent name patterns (`erdos-enhancer-*`, `researcher-*`, `aristotle-agent`, `seeker-agent`, `deployer`)
2. Kills any that survived the per-agent stop attempts
3. Uses `|| true` guards to handle cases where no sessions exist or tmux isn't running

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| Catch-all runs after per-agent stops | Inserted between line 1323 and `set_stopped` |
| Matches all known session patterns | Uses regex from `get_all_agent_sessions()` |
| No errors when no sessions exist | `grep || true` prevents exit code 1 |
| `set_stopped` still called after catch-all | Verified in code |
| Script syntax valid | `bash -n` passes |

## Test plan

- [ ] Start agents, run `stop --force`, verify no agent sessions remain
- [ ] Create fake stale session (`tmux new-session -d -s researcher-1`), run `stop --force`, verify catch-all cleans it
- [ ] Run `stop --force` with no agents running — completes without errors

Closes #1702

🤖 Generated with [Claude Code](https://claude.com/claude-code)