### PR TITLE
Enhance Erdős #998: Kesten's Equidistribution Characterization

### DIFF
--- a/proofs/Proofs/Erdos998Problem.lean
+++ b/proofs/Proofs/Erdos998Problem.lean
@@ -40,7 +40,7 @@ open Set
 
 namespace Erdos998
 
-/-
+/-!
 ## Part I: Basic Definitions
 -/
 
@@ -68,7 +68,7 @@ theorem frac_lt_one (x : ℝ) : frac x < 1 := by
 -/
 def Irrational (α : ℝ) : Prop := ¬∃ (p q : ℤ), q ≠ 0 ∧ α = p / q
 
-/-
+/-!
 ## Part II: Counting Function
 -/
 
@@ -86,7 +86,7 @@ noncomputable def countingFunction (α : ℝ) (u v : ℝ) (n : ℕ) : ℕ :=
 def countSet (α : ℝ) (u v : ℝ) (n : ℕ) : Set ℕ :=
   {m : ℕ | 1 ≤ m ∧ m ≤ n ∧ u ≤ frac (α * m) ∧ frac (α * m) < v}
 
-/-
+/-!
 ## Part III: O(1) Discrepancy Property
 -/
 
@@ -106,7 +106,7 @@ axiom weyl_generic_bound (α : ℝ) (hα : Irrational α) (u v : ℝ) :
     ∃ C : ℝ, C > 0 ∧ ∀ n : ℕ, n ≥ 1 →
       |((countingFunction α u v n : ℝ) - n * (v - u))| ≤ C * Real.sqrt n
 
-/-
+/-!
 ## Part IV: The Characterization
 -/
 
@@ -145,7 +145,7 @@ theorem erdos_szusz_characterization (α : ℝ) (hα : Irrational α) (u v : ℝ
   · exact kesten_theorem α hα u v hu hv huv
   · exact hecke_ostrowski α hα u v
 
-/-
+/-!
 ## Part V: Three-Distance Theorem Connection
 -/
 
@@ -160,7 +160,7 @@ axiom three_distance_theorem (α : ℝ) (hα : Irrational α) (n : ℕ) (hn : n 
       L₃ = L₁ + L₂ ∧
       n * L₁ + (n + 1 - n) * L₂ = 1
 
-/-
+/-!
 ## Part VI: Weyl's Equidistribution
 -/
 
@@ -171,7 +171,7 @@ axiom weyl_equidistribution (α : ℝ) (hα : Irrational α) (u v : ℝ)
     ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N,
       |(countingFunction α u v n : ℝ) / n - (v - u)| < ε
 
-/-
+/-!
 ## Part VII: Summary
 -/
 

--- a/src/data/proofs/erdos-998/meta.json
+++ b/src/data/proofs/erdos-998/meta.json
@@ -16,8 +16,37 @@
     "erdosUrl": "https://erdosproblems.com/998",
     "erdosProblemStatus": "proved",
     "mathlib_version": "4.15.0",
-    "mathlibDependencies": [],
-    "originalContributions": []
+    "mathlibDependencies": [
+      {
+        "theorem": "Int.floor",
+        "description": "Floor function on real numbers",
+        "module": "Mathlib.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "Finset.card",
+        "description": "Cardinality of finite sets",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Real.sqrt",
+        "description": "Real square root function",
+        "module": "Mathlib.Analysis.SpecialFunctions.Integrals"
+      }
+    ],
+    "originalContributions": [
+      "frac definition: fractional part {x} = x - ⌊x⌋",
+      "frac_nonneg theorem: 0 ≤ {x} (proved)",
+      "frac_lt_one theorem: {x} < 1 (proved)",
+      "countingFunction definition: counts {αm} ∈ [u,v) for m = 1..n",
+      "hasBoundedDiscrepancy definition: O(1) discrepancy property",
+      "endpointsFromOrbit definition: u,v are fractional parts of α-multiples",
+      "hecke_ostrowski axiom: orbit endpoints imply bounded discrepancy",
+      "kesten_theorem axiom: bounded discrepancy implies orbit endpoints",
+      "erdos_szusz_characterization theorem: complete iff characterization (proved)",
+      "three_distance_theorem axiom: at most 3 gap lengths",
+      "weyl_equidistribution axiom: equidistribution for irrational rotations",
+      "erdos_998_summary theorem: restates full characterization (proved)"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős Problem #998 was posed by Erdős and Szüsz, asking for a characterization of intervals with minimal discrepancy for irrational rotations. The sequence of fractional parts {αm} for irrational α is equidistributed in [0,1) by Weyl's theorem, meaning the count of points in any interval is approximately proportional to its length.\n\nHecke (1922) and Ostrowski (1927, 1930) proved that if u = {αk} and v = {αℓ} for integers k, ℓ, then the interval [u,v) has O(1) discrepancy—the count differs from the expected value by at most a constant. Erdős and Szüsz asked the converse: are these the only such intervals?\n\nKesten (1966) proved yes, completing the characterization. This connects equidistribution theory to the orbit structure of irrational rotations, with deep connections to continued fractions and the three-distance theorem.",


### PR DESCRIPTION
## Summary
- Fixed section headers from `/- ` to `/-!` doc comments throughout Lean file
- Added mathlibDependencies and originalContributions to meta.json
- Existing content (annotations, historicalContext, key insights) was already high quality

## Changes
- **Lean proof**: 7 section headers converted to proper doc comments
- **meta.json**: Added 3 mathlibDependencies and 12 originalContributions

## Checklist
- [x] Lean proof compiles (no sorry, no trivial True axioms)
- [x] pnpm build succeeds
- [x] Annotations align with Lean file line numbers
- [x] meta.json has clean description and 3-paragraph historicalContext

🤖 Generated by enhancer-1