### PR TITLE
Enhance Erdős #855: Second Hardy-Littlewood Conjecture

### DIFF
--- a/proofs/Proofs/Erdos855Problem.lean
+++ b/proofs/Proofs/Erdos855Problem.lean
@@ -30,7 +30,7 @@ import Mathlib.Data.Real.Basic
 
 namespace Erdos855
 
-/-
+/-!
 ## Part I: The Prime Counting Function
 -/
 
@@ -55,7 +55,7 @@ axiom prime_number_theorem (ε : ℝ) (hε : ε > 0) :
     ∃ N₀ : ℕ, ∀ n ≥ N₀, (n : ℝ) > 0 →
       |((primePi n : ℝ) - n / Real.log n) / (n / Real.log n)| < ε
 
-/-
+/-!
 ## Part II: The Second Hardy-Littlewood Conjecture
 -/
 
@@ -70,14 +70,7 @@ def SecondHardyLittlewoodConjecture : Prop :=
   ∃ N₀ : ℕ, ∀ x y : ℕ, x ≥ N₀ → y ≥ N₀ →
     primePi (x + y) ≤ primePi x + primePi y
 
-/--
-**Status: OPEN, LIKELY FALSE**
-The conjecture remains unproved but is believed to be false
-based on its incompatibility with the prime k-tuples conjecture.
--/
-axiom conjecture_status_open : True
-
-/-
+/-!
 ## Part III: The Prime k-Tuples Conjecture
 -/
 
@@ -99,13 +92,7 @@ def PrimeKTuplesConjecture : Prop :=
   ∀ H : Finset ℕ, IsAdmissibleTuple H →
     ∀ N : ℕ, ∃ n > N, ∀ h ∈ H, (n + h).Prime
 
-/--
-**The k-Tuples Conjecture is widely believed to be true.**
-It is supported by extensive numerical evidence and heuristic arguments.
--/
-axiom k_tuples_widely_believed : True
-
-/-
+/-!
 ## Part IV: Hensley-Richards Incompatibility Theorem
 -/
 
@@ -143,7 +130,7 @@ axiom dense_admissible_tuples_exist (k : ℕ) (hk : k ≥ 2) :
     ∃ H : Finset ℕ, IsAdmissibleTuple H ∧ H.card > primePi k ∧
       ∀ h ∈ H, h < k
 
-/-
+/-!
 ## Part V: Unconditional Results
 -/
 
@@ -165,15 +152,7 @@ theorem primePi_add_ge (x y : ℕ) :
     primePi (x + y) ≥ primePi x :=
   primePi_monotone (Nat.le_add_right x y)
 
-/--
-**Best Known Asymptotic:**
-The true behavior is believed to be:
-  π(x+y) = π(x) + π(y) + O(y/(log y)²)
-with the error term sometimes positive, sometimes negative.
--/
-axiom true_asymptotic_behavior : True
-
-/-
+/-!
 ## Part VI: Related Conjectures
 -/
 
@@ -200,65 +179,22 @@ def ErdosWeakerConjecture : Prop :=
   ∃ C : ℝ, ∃ N₀ : ℕ, ∀ x y : ℕ, x ≥ N₀ → y ≥ N₀ →
     (primePi (x + y) : ℝ) ≤ primePi x + primePi y + C * y / (Real.log y)^2
 
-axiom erdos_weaker_consistent : True  -- Consistent with k-tuples
-
-/-
-## Part VII: Why This Matters
+/-!
+## Part VII: Main Results
 -/
 
-/--
-**Philosophical Point:**
-This problem illustrates a fundamental tension in number theory.
-Both conjectures (k-tuples and 2nd Hardy-Littlewood) seem natural,
-but they cannot both be true.
+/-- **Erdős Problem #855: Summary**
 
-Most experts believe k-tuples, so the 2nd Hardy-Littlewood conjecture
-is likely false - but no explicit counterexample is known!
--/
-axiom philosophical_significance : True
-
-/--
-**Computational Note:**
-No explicit counterexample has been found despite extensive computation.
-The first potential counterexample is expected to be astronomically large.
--/
-axiom no_known_counterexample : True
-
-/-
-## Part VIII: Main Results
--/
-
-/--
-**Erdős Problem #855: LIKELY FALSE**
-
-**Conjecture:** π(x+y) ≤ π(x) + π(y) for large x, y.
-
-**Status:** Open, but likely FALSE
-
-**Why:** Hensley-Richards (1973) proved this is incompatible with
-the prime k-tuples conjecture. Since k-tuples is widely believed,
-this conjecture is likely wrong.
-
-**Unconditional:** Montgomery-Vaughan proved π(x+y) ≤ π(x) + 2y/log(y).
--/
-theorem erdos_855 : True := trivial
-
-/--
-**Summary:**
-The Second Hardy-Littlewood Conjecture (Erdős #855) asserts
-π(x+y) ≤ π(x) + π(y) for large x, y. This is likely false:
-- Hensley-Richards showed incompatibility with k-tuples conjecture
-- The k-tuples conjecture is widely believed
-- No counterexample found despite computation
-
-The tension between these conjectures is a fascinating open problem
-in analytic number theory.
--/
-theorem erdos_855_summary :
-    -- The conjecture is open but likely false
-    True ∧
-    -- It contradicts k-tuples
-    (PrimeKTuplesConjecture → ¬SecondHardyLittlewoodConjecture) := by
-  exact ⟨trivial, hensley_richards_incompatibility⟩
+The Second Hardy-Littlewood Conjecture asserts π(x+y) ≤ π(x) + π(y)
+for large x, y. This is open but LIKELY FALSE:
+- Hensley-Richards (1973) proved incompatibility with k-tuples conjecture
+- Montgomery-Vaughan proved π(x+y) ≤ π(x) + 2y/log(y) unconditionally
+- Straus's variant is also incompatible with k-tuples -/
+theorem erdos_855 :
+    -- k-tuples contradicts the Second Hardy-Littlewood Conjecture
+    (PrimeKTuplesConjecture → ¬SecondHardyLittlewoodConjecture) ∧
+    -- k-tuples also contradicts Straus's modification
+    (PrimeKTuplesConjecture → ¬StrausConjecture) := by
+  exact ⟨hensley_richards_incompatibility, straus_also_incompatible⟩
 
 end Erdos855

--- a/src/data/proofs/erdos-855/annotations.json
+++ b/src/data/proofs/erdos-855/annotations.json
@@ -1,146 +1,90 @@
 [
   {
-    "id": "prime-pi",
+    "id": "ann-e855-header",
     "proofId": "erdos-855",
-    "range": { "startLine": 37, "endLine": 42 },
+    "range": { "startLine": 1, "endLine": 25 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #855: The Second Hardy-Littlewood Conjecture**\n\nIs π(x+y) ≤ π(x) + π(y) for large x and y? Erdős described this as 'an old conjecture of mine which was probably already stated by Hardy and Littlewood.' The conjecture is likely FALSE based on its incompatibility with the prime k-tuples conjecture (Hensley-Richards, 1973).",
+    "mathContext": "The conjecture asserts asymptotic subadditivity of the prime counting function. If true, it would mean that the primes in [1, x+y] are never more numerous than those in [1, x] and [1, y] combined.",
+    "significance": "critical",
+    "relatedConcepts": ["prime-counting-function", "hardy-littlewood-conjectures", "prime-k-tuples"]
+  },
+  {
+    "id": "ann-e855-primepi",
+    "proofId": "erdos-855",
+    "range": { "startLine": 37, "endLine": 56 },
     "type": "definition",
     "title": "Prime Counting Function π(n)",
-    "content": "The prime counting function π(n) counts the number of primes in [1,n]. This is the fundamental object in the conjecture.",
-    "significance": "critical"
+    "content": "**primePi(n)** counts the number of primes p with 1 ≤ p ≤ n. This is the fundamental object in the conjecture.\n\nKey properties axiomatized:\n- **Monotonicity**: primePi is monotone increasing\n- **Prime Number Theorem**: π(n) ~ n/log(n) as n → ∞",
+    "mathContext": "Defined as the cardinality of {p ∈ [1,n] : p prime} using Finset.filter and Finset.Icc.",
+    "significance": "critical",
+    "relatedConcepts": ["prime-number-theorem", "analytic-number-theory"]
   },
   {
-    "id": "prime-number-theorem",
-    "proofId": "erdos-855",
-    "range": { "startLine": 50, "endLine": 56 },
-    "type": "axiom",
-    "title": "Prime Number Theorem",
-    "content": "The fundamental asymptotic π(n) ~ n/log(n). This gives the basic growth rate of the prime counting function.",
-    "significance": "high"
-  },
-  {
-    "id": "second-hl-conjecture",
+    "id": "ann-e855-conjecture",
     "proofId": "erdos-855",
     "range": { "startLine": 62, "endLine": 71 },
     "type": "definition",
-    "title": "Second Hardy-Littlewood Conjecture",
-    "content": "The conjecture that π(x+y) ≤ π(x) + π(y) for all sufficiently large x and y. This asserts subadditivity of the prime counting function.",
-    "significance": "critical"
+    "title": "The Second Hardy-Littlewood Conjecture",
+    "content": "**SecondHardyLittlewoodConjecture**: For all sufficiently large x and y, π(x+y) ≤ π(x) + π(y).\n\nThis asserts that the prime counting function is 'subadditive' for large arguments. Intuitively, the interval [1, x+y] should never have more primes than [1, x] and [1, y] combined.",
+    "mathContext": "Formalized as: ∃ N₀, ∀ x y ≥ N₀, primePi(x+y) ≤ primePi(x) + primePi(y).",
+    "significance": "critical",
+    "relatedConcepts": ["subadditivity", "prime-distribution"]
   },
   {
-    "id": "admissible-tuple",
+    "id": "ann-e855-admissible",
     "proofId": "erdos-855",
-    "range": { "startLine": 84, "endLine": 91 },
+    "range": { "startLine": 77, "endLine": 93 },
     "type": "definition",
-    "title": "Admissible Tuple",
-    "content": "A k-tuple H is admissible if the residues don't cover all classes mod p for any prime p. This is the sieving condition for prime k-tuples.",
-    "significance": "high"
+    "title": "Admissible Tuples and k-Tuples Conjecture",
+    "content": "**IsAdmissibleTuple(H)**: A finite set H of natural numbers is admissible if for every prime p, the residues of H mod p do not cover all residue classes.\n\n**PrimeKTuplesConjecture**: For any admissible tuple H, there are infinitely many n such that n + h is prime for all h ∈ H. This is widely believed to be true and is the key conjecture that conflicts with the Second Hardy-Littlewood.",
+    "mathContext": "The admissibility condition prevents trivial obstructions: if H covered all residues mod p, then some n + h would always be divisible by p.",
+    "significance": "critical",
+    "relatedConcepts": ["sieve-theory", "prime-patterns", "twin-prime-conjecture"]
   },
   {
-    "id": "k-tuples-conjecture",
+    "id": "ann-e855-incompatibility",
     "proofId": "erdos-855",
-    "range": { "startLine": 93, "endLine": 100 },
+    "range": { "startLine": 95, "endLine": 131 },
+    "type": "axiom",
+    "title": "Hensley-Richards Incompatibility (1973)",
+    "content": "**hensley_richards_incompatibility**: The k-tuples conjecture implies ¬SecondHardyLittlewoodConjecture.\n\nThe key insight is that admissible tuples can be denser than the primes: **dense_admissible_tuples_exist** shows that for large k, there exist admissible k-tuples in [0,k) with more than π(k) elements.\n\nThe **quantitative version** shows the violation can be substantial: under k-tuples, π(x+y) > π(x) + π(y) + (log 2/2) · y/(log y)² for infinitely many x.",
+    "mathContext": "If an admissible H ⊂ [0,k) has |H| > π(k) elements, and k-tuples guarantees n where all n+h are prime, then π(n+k) ≥ π(n) + |H| > π(n) + π(k).",
+    "significance": "critical",
+    "relatedConcepts": ["sieve-theory", "prime-gaps", "extremal-combinatorics"]
+  },
+  {
+    "id": "ann-e855-unconditional",
+    "proofId": "erdos-855",
+    "range": { "startLine": 133, "endLine": 153 },
+    "type": "axiom",
+    "title": "Unconditional Results",
+    "content": "**montgomery_vaughan_bound**: Unconditionally, π(x+y) ≤ π(x) + 2y/log(y). This is weaker than the conjecture's π(x) + π(y) but requires no unproved hypothesis.\n\n**primePi_add_ge**: The trivial lower bound π(x+y) ≥ π(x) holds by monotonicity. This is the only fully proved result in the file (using primePi_monotone).",
+    "mathContext": "The Montgomery-Vaughan bound uses the large sieve inequality. The factor of 2 is the best known constant.",
+    "significance": "key",
+    "relatedConcepts": ["large-sieve", "brun-titchmarsh"]
+  },
+  {
+    "id": "ann-e855-related",
+    "proofId": "erdos-855",
+    "range": { "startLine": 155, "endLine": 180 },
     "type": "definition",
-    "title": "Prime k-Tuples Conjecture",
-    "content": "For any admissible tuple H, there are infinitely many n where all n + h are prime. This is the widely-believed conjecture that conflicts with the Second Hardy-Littlewood.",
-    "significance": "critical"
+    "title": "Related Conjectures",
+    "content": "**StrausConjecture**: π(x+y) ≤ π(x) + 2π(y/2). Straus suggested this as a potential 'correct' formulation, but it is also incompatible with k-tuples.\n\n**ErdosWeakerConjecture**: π(x+y) ≤ π(x) + π(y) + O(y/(log y)²). This weaker form allows an error term and may be consistent with k-tuples. If true, the Second Hardy-Littlewood fails by at most O(y/(log y)²).",
+    "mathContext": "The weaker conjecture suggests that even if π is not subadditive, the violation is bounded by a secondary term from the prime number theorem.",
+    "significance": "key",
+    "relatedConcepts": ["error-terms", "prime-number-theorem"]
   },
   {
-    "id": "hensley-richards",
+    "id": "ann-e855-summary",
     "proofId": "erdos-855",
-    "range": { "startLine": 112, "endLine": 122 },
-    "type": "axiom",
-    "title": "Hensley-Richards Incompatibility",
-    "content": "Hensley and Richards (1973) proved that the k-tuples conjecture implies the negation of the Second Hardy-Littlewood Conjecture. These two natural conjectures cannot both be true!",
-    "significance": "critical"
-  },
-  {
-    "id": "quantitative-version",
-    "proofId": "erdos-855",
-    "range": { "startLine": 124, "endLine": 133 },
-    "type": "axiom",
-    "title": "Quantitative Incompatibility",
-    "content": "Under k-tuples, for every large y and infinitely many x: π(x+y) > π(x) + π(y) + (log 2 - o(1))·y/(log y)². The violation can be substantial.",
-    "significance": "high"
-  },
-  {
-    "id": "dense-tuples",
-    "proofId": "erdos-855",
-    "range": { "startLine": 135, "endLine": 144 },
-    "type": "axiom",
-    "title": "Dense Admissible Tuples",
-    "content": "Hensley-Richards showed that admissible k-tuples can have more than π(k) elements in [0,k). This is the key to the incompatibility.",
-    "significance": "high"
-  },
-  {
-    "id": "montgomery-vaughan",
-    "proofId": "erdos-855",
-    "range": { "startLine": 150, "endLine": 158 },
-    "type": "axiom",
-    "title": "Montgomery-Vaughan Bound",
-    "content": "Unconditionally: π(x+y) ≤ π(x) + 2y/log(y). This is weaker than π(x) + π(y) but requires no unproved conjecture.",
-    "significance": "high"
-  },
-  {
-    "id": "trivial-bound",
-    "proofId": "erdos-855",
-    "range": { "startLine": 160, "endLine": 166 },
+    "range": { "startLine": 186, "endLine": 198 },
     "type": "theorem",
-    "title": "Trivial Lower Bound",
-    "content": "π(x+y) ≥ π(x) always holds by monotonicity. Adding y to the counting interval can only increase the prime count.",
-    "significance": "medium"
-  },
-  {
-    "id": "straus-conjecture",
-    "proofId": "erdos-855",
-    "range": { "startLine": 180, "endLine": 191 },
-    "type": "definition",
-    "title": "Straus's Modification",
-    "content": "Straus suggested π(x+y) ≤ π(x) + 2π(y/2) as the 'correct' formulation. This is also incompatible with k-tuples.",
-    "significance": "medium"
-  },
-  {
-    "id": "erdos-weaker",
-    "proofId": "erdos-855",
-    "range": { "startLine": 193, "endLine": 203 },
-    "type": "definition",
-    "title": "Erdős's Weaker Conjecture",
-    "content": "Erdős conjectured π(x+y) ≤ π(x) + π(y) + O(y/(log y)²). This weaker form may be true and is consistent with k-tuples.",
-    "significance": "medium"
-  },
-  {
-    "id": "philosophical",
-    "proofId": "erdos-855",
-    "range": { "startLine": 209, "endLine": 218 },
-    "type": "insight",
-    "title": "Philosophical Significance",
-    "content": "This illustrates a fundamental tension: two natural conjectures in number theory can be mutually exclusive. Most experts believe k-tuples, so the Second Hardy-Littlewood is likely false.",
-    "significance": "high"
-  },
-  {
-    "id": "no-counterexample",
-    "proofId": "erdos-855",
-    "range": { "startLine": 220, "endLine": 225 },
-    "type": "insight",
-    "title": "No Known Counterexample",
-    "content": "Despite extensive computation, no explicit values x, y with π(x+y) > π(x) + π(y) have been found. The first counterexample is expected to be astronomically large.",
-    "significance": "medium"
-  },
-  {
-    "id": "main-result",
-    "proofId": "erdos-855",
-    "range": { "startLine": 231, "endLine": 244 },
-    "type": "theorem",
-    "title": "Erdős Problem #855: LIKELY FALSE",
-    "content": "The Second Hardy-Littlewood Conjecture is open but likely false due to incompatibility with the k-tuples conjecture. The best unconditional bound is Montgomery-Vaughan's 2y/log(y).",
-    "significance": "critical"
-  },
-  {
-    "id": "summary",
-    "proofId": "erdos-855",
-    "range": { "startLine": 246, "endLine": 262 },
-    "type": "theorem",
-    "title": "Summary Theorem",
-    "content": "Combines the status (open, likely false) with the key result: if k-tuples holds, then the Second Hardy-Littlewood Conjecture fails.",
-    "significance": "high"
+    "title": "Main Result: erdos_855",
+    "content": "**erdos_855** combines the two incompatibility results:\n1. k-tuples → ¬SecondHardyLittlewoodConjecture\n2. k-tuples → ¬StrausConjecture\n\nProved via `exact ⟨hensley_richards_incompatibility, straus_also_incompatible⟩`. This captures the essence of the problem: if the widely-believed k-tuples conjecture is true, then both the original and Straus's variant are false.",
+    "mathContext": "The theorem is a clean conjunction of the two incompatibility axioms, demonstrating that one natural conjecture (k-tuples) refutes two others.",
+    "significance": "critical",
+    "relatedConcepts": ["incompatibility", "conditional-disproof"]
   }
 ]

--- a/src/data/proofs/erdos-855/meta.json
+++ b/src/data/proofs/erdos-855/meta.json
@@ -56,7 +56,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #855: The Second Hardy-Littlewood Conjecture**\n\nThis problem concerns a fundamental inequality in the distribution of primes.\n\n**Key History:**\n- Hardy-Littlewood: Original conjecture π(x+y) ≤ π(x) + π(y)\n- Erdős (1985): Described it as 'an old conjecture of mine which was probably already stated by Hardy and Littlewood'\n- Hensley-Richards (1973): Proved incompatibility with the prime k-tuples conjecture\n- Montgomery-Vaughan (1973): Proved π(x+y) ≤ π(x) + 2y/log(y) unconditionally\n\n**The Tension:** This conjecture and the prime k-tuples conjecture cannot both be true!",
+    "historicalContext": "The Second Hardy-Littlewood Conjecture asserts that π(x+y) ≤ π(x) + π(y) for all sufficiently large x and y, where π denotes the prime counting function. Erdős described it as 'an old conjecture of mine which was probably already stated by Hardy and Littlewood.' The conjecture suggests that the interval [1, x+y] can never contain more primes than the intervals [1, x] and [1, y] combined.\n\nThe major development came in 1973 when Hensley and Richards proved that this conjecture is incompatible with the prime k-tuples conjecture, which asserts that any admissible pattern of primes occurs infinitely often. Their proof showed that admissible tuples can be denser than the primes themselves: for large k, there exist admissible k-tuples in [0,k) with more than π(k) elements. If k-tuples holds, placing these dense tuples at the right position would violate π(x+y) ≤ π(x) + π(y).\n\nSince most number theorists believe the k-tuples conjecture is true (it is supported by extensive numerical evidence and heuristic arguments), the Second Hardy-Littlewood Conjecture is considered likely false. However, no explicit counterexample has been found despite extensive computation. Montgomery and Vaughan proved the unconditional bound π(x+y) ≤ π(x) + 2y/log(y), which is weaker but does not require any unproved hypothesis.",
     "problemStatement": "**Problem Statement (Open, Likely False)**\n\nIf $\\pi(x)$ counts the number of primes in $[1,x]$, is it true that for all sufficiently large $x$ and $y$:\n$$\\pi(x+y) \\leq \\pi(x) + \\pi(y)$$?\n\n**Status:** OPEN but LIKELY FALSE\n\n**Key Result:** Hensley and Richards (1973) proved this is **incompatible** with the prime k-tuples conjecture. Under k-tuples:\n$$\\pi(x+y) > \\pi(x) + \\pi(y) + (\\log 2 - o(1))\\frac{y}{(\\log y)^2}$$\nfor infinitely many x.\n\nSince the k-tuples conjecture is widely believed, this conjecture is likely false.",
     "proofStrategy": "**Formalization Approach**\n\n1. **Prime Counting Function:** Define π(n) as the count of primes ≤ n.\n\n2. **Main Conjecture:** Formalize the Second Hardy-Littlewood Conjecture.\n\n3. **k-Tuples Conjecture:** Define admissible tuples and the prime k-tuples conjecture.\n\n4. **Incompatibility:** State Hensley-Richards theorem showing the two conjectures conflict.\n\n5. **Unconditional Bounds:** Include Montgomery-Vaughan's π(x+y) ≤ π(x) + 2y/log(y).\n\n6. **Related Variants:** Straus's modification and Erdős's weaker conjecture.",
     "keyInsights": [
@@ -78,51 +78,44 @@
     {
       "id": "second-hl",
       "title": "The Second Hardy-Littlewood Conjecture",
-      "summary": "SecondHardyLittlewoodConjecture definition and status",
+      "summary": "SecondHardyLittlewoodConjecture definition",
       "startLine": 58,
-      "endLine": 78
+      "endLine": 71
     },
     {
       "id": "k-tuples",
       "title": "The Prime k-Tuples Conjecture",
       "summary": "IsAdmissibleTuple, PrimeKTuplesConjecture definitions",
-      "startLine": 80,
-      "endLine": 106
+      "startLine": 73,
+      "endLine": 93
     },
     {
       "id": "hensley-richards",
       "title": "Hensley-Richards Incompatibility",
       "summary": "hensley_richards_incompatibility, quantitative version, dense tuples",
-      "startLine": 108,
-      "endLine": 144
+      "startLine": 95,
+      "endLine": 131
     },
     {
       "id": "unconditional",
       "title": "Unconditional Results",
       "summary": "montgomery_vaughan_bound, primePi_add_ge theorem",
-      "startLine": 146,
-      "endLine": 174
+      "startLine": 133,
+      "endLine": 153
     },
     {
       "id": "related",
       "title": "Related Conjectures",
       "summary": "StrausConjecture, ErdosWeakerConjecture definitions",
-      "startLine": 176,
-      "endLine": 203
-    },
-    {
-      "id": "significance",
-      "title": "Why This Matters",
-      "summary": "Philosophical and computational notes",
-      "startLine": 205,
-      "endLine": 225
+      "startLine": 155,
+      "endLine": 180
     },
     {
       "id": "main-results",
       "title": "Main Results",
-      "summary": "erdos_855 and erdos_855_summary theorems",
-      "startLine": 227,
-      "endLine": 264
+      "summary": "erdos_855 summary theorem",
+      "startLine": 182,
+      "endLine": 200
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Enhanced Second Hardy-Littlewood Conjecture (Erdős #855)
- Removed 6 trivial True axioms and True := trivial placeholder
- Summary theorem now combines two incompatibility results

## Changes
- Lean: removed trivial axioms, replaced placeholder with meaningful `erdos_855` theorem using `exact ⟨hensley_richards_incompatibility, straus_also_incompatible⟩`
- Fixed `/-` section headers to `/-!` doc comments
- meta.json: proper 3-paragraph historicalContext
- annotations.json: 8 substantive annotations with correct line numbers

## Checklist
- [x] No sorry or True := trivial
- [x] pnpm build succeeds
- [x] Annotations align with Lean file
- [x] No scraping garbage

Generated by enhancer-1