### PR TITLE
Enhance Erdős #9: Odd Integers Not of the Form p + 2^k + 2^l

### DIFF
--- a/proofs/Proofs/Erdos9Problem.lean
+++ b/proofs/Proofs/Erdos9Problem.lean
@@ -172,21 +172,6 @@ theorem S_intersects_all_progressions (a d : ℕ) (hd : d ≥ 1) :
   obtain ⟨n, hn, hmod⟩ := form_in_every_arithmetic_progression a d hd
   exact ⟨n, hn, hmod⟩
 
-/--
-**Implication**: Any proof of positive density for A must use methods
-other than covering systems.
-
-Covering systems work by showing some residue class misses S.
-But Erdős's observation says every residue class meets S.
--/
-theorem covering_systems_insufficient :
-    -- Covering system proofs require an arithmetic progression disjoint from S
-    -- But no such progression exists
-    (∀ a d : ℕ, d ≥ 1 → (S ∩ { n | n ≡ a [MOD d] }).Nonempty) →
-    -- Therefore covering systems cannot prove A has positive density
-    True := by
-  intro _
-  trivial
 
 /-! ## Small Examples -/
 
@@ -239,16 +224,6 @@ theorem nine_in_S : 9 ∈ S := by
 
 /-! ## Bounds Comparison -/
 
-/-- The growth hierarchy of known bounds:
-    Crocker: ≫ log log N (very slow)
-    Pan: ≫ N^(1-ε) (almost linear)
-    Question: ≫ N (linear = positive density)?
--/
-theorem bounds_comparison :
-    -- Crocker < Pan < (potential positive density)
-    -- log log N << N^(1-ε) << N for any ε > 0
-    True := trivial
-
 /--
 **Linear Bound Implies Positive Density:**
 If one could prove countA(N) ≥ cN for some c > 0 and all large N,
@@ -260,21 +235,6 @@ arguments about limsup that are technical in Lean.
 axiom improvement_would_solve :
     (∃ c : ℝ, c > 0 ∧ ∀ᶠ N in atTop, (countA N : ℝ) ≥ c * N) →
     erdos_9_question
-
-/-! ## Related Problems -/
-
-/-- Connection to Romanoff's theorem and its variants. -/
-def romanoff_related : Prop :=
-  -- Romanoff (1934): Positive proportion of integers are p + 2^k
-  -- This problem asks about p + 2^k + 2^l for odd integers
-  True
-
-/-- Related problems on erdosproblems.com. -/
-theorem related_problems :
-    -- Problem #10: Is there an infinite set A with A - A not containing p - 2^k?
-    -- Problem #11: Similar problems about sums with prime
-    -- Problem #16: Related additive questions
-    True := trivial
 
 /-! ## Summary
 

--- a/src/data/proofs/erdos-9/annotations.json
+++ b/src/data/proofs/erdos-9/annotations.json
@@ -150,10 +150,10 @@
   {
     "id": "ann-e9-improvement",
     "proofId": "erdos-9",
-    "range": { "startLine": 248, "endLine": 254 },
-    "type": "theorem",
+    "range": { "startLine": 227, "endLine": 237 },
+    "type": "axiom",
     "title": "Linear Bound Would Solve",
-    "content": "If we could prove countA(N) ≥ cN for some c > 0, the problem would be solved.\n\nThis is equivalent to positive upper density.",
+    "content": "**improvement_would_solve** axiomatizes: if countA(N) ≥ cN for some c > 0 and all large N, then the Erdős question has a positive answer. The gap between Pan's N^{1-ε} bound and the needed linear bound N is the central difficulty. Closing this gap would resolve the problem.",
     "significance": "key"
   }
 ]

--- a/src/data/proofs/erdos-9/meta.json
+++ b/src/data/proofs/erdos-9/meta.json
@@ -69,52 +69,59 @@
   "sections": [
     {
       "id": "definitions",
-      "title": "Core Definitions",
-      "summary": "Prime + two powers form, set A, counting function",
-      "startLine": 35,
-      "endLine": 72
+      "title": "Basic Definitions",
+      "summary": "HasPrimePlusTwoPowersForm, sets S and A, special cases",
+      "startLine": 39,
+      "endLine": 73
     },
     {
       "id": "density",
       "title": "Density Definitions",
-      "summary": "Upper density and positive density",
-      "startLine": 68,
-      "endLine": 80
+      "summary": "countA, upperDensity, hasPositiveUpperDensity",
+      "startLine": 75,
+      "endLine": 88
     },
     {
-      "id": "conjecture",
+      "id": "question",
       "title": "The Erdős Question",
-      "summary": "OPEN: Does A have positive upper density?",
-      "startLine": 82,
-      "endLine": 97
+      "summary": "erdos_9_question and erdos_9_alt definitions (OPEN)",
+      "startLine": 90,
+      "endLine": 105
     },
     {
       "id": "known-results",
       "title": "Known Results",
-      "summary": "Schinzel, Crocker, and Pan bounds",
-      "startLine": 99,
-      "endLine": 145
+      "summary": "Schinzel infinite, Crocker log log N, Pan N^{1-ε} bounds",
+      "startLine": 107,
+      "endLine": 155
     },
     {
       "id": "covering",
-      "title": "Covering Systems",
-      "summary": "Why covering systems cannot resolve this",
-      "startLine": 147,
-      "endLine": 179
+      "title": "Why Covering Systems Don't Work",
+      "summary": "form_in_every_arithmetic_progression axiom and S_intersects_all_progressions theorem",
+      "startLine": 157,
+      "endLine": 173
     },
     {
       "id": "examples",
       "title": "Small Examples",
-      "summary": "1, 3 are exceptional; 5, 9 are representable",
-      "startLine": 181,
-      "endLine": 228
+      "summary": "Proved: 1, 3 are exceptional; 5, 9 are representable",
+      "startLine": 176,
+      "endLine": 223
     },
     {
-      "id": "status",
-      "title": "Problem Status",
-      "summary": "Summary and open status",
-      "startLine": 265,
-      "endLine": 292
+      "id": "bounds",
+      "title": "Bounds Comparison",
+      "summary": "improvement_would_solve axiom: linear bound implies positive density",
+      "startLine": 225,
+      "endLine": 237
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "summary": "Open problem status, known results, and key insight",
+      "startLine": 239,
+      "endLine": 267
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Removed 4 trivial True theorems (covering_systems_insufficient, bounds_comparison, romanoff_related, related_problems)
- Updated meta.json sections and annotations.json line ranges to match

## Changes
- **Lean proof**: Removed trivial True theorems. All meaningful axioms, proved theorems, and constructive examples preserved
- **meta.json**: Updated section line ranges
- **annotations.json**: Updated line range for improvement_would_solve annotation

## Checklist
- [x] Lean proof compiles (no sorry, no trivial True)
- [x] pnpm build succeeds
- [x] Annotations align with Lean file line numbers

🤖 Generated by enhancer-1