### PR TITLE
enhance(erdos-110): remove sorry, True trivial, String defs

### DIFF
--- a/proofs/Proofs/Erdos110Problem.lean
+++ b/proofs/Proofs/Erdos110Problem.lean
@@ -1,25 +1,25 @@
-/-
-  Erdős Problem #110: Chromatic Number Growth in Uncountable Graphs
+/-!
+Erdős Problem #110: Chromatic Number Growth in Uncountable Graphs
 
-  Source: https://erdosproblems.com/110
-  Status: DISPROVED (Lambie-Hanson 2020, ZFC)
+Source: https://erdosproblems.com/110
+Status: DISPROVED (Lambie-Hanson 2020, ZFC)
 
-  Conjecture (Erdős-Hajnal-Szemerédi 1982):
-  Is there F(n) such that every graph with chromatic number ℵ₁ has,
-  for all large n, a subgraph with chromatic number n on at most F(n) vertices?
+Conjecture (Erdős-Hajnal-Szemerédi 1982):
+Is there F(n) such that every graph with chromatic number ℵ₁ has,
+for all large n, a subgraph with chromatic number n on at most F(n) vertices?
 
-  Answer: NO. Disproved by Lambie-Hanson (2020) in ZFC.
+Answer: NO. Disproved by Lambie-Hanson (2020) in ZFC.
 
-  History:
-  - de Bruijn-Erdős (1951): Infinite χ implies finite n-chromatic subgraphs exist
-  - Erdős-Hajnal-Szemerédi (1982): Conjectured uniform bound F(n) exists for ℵ₁
-  - Shelah (2005): Showed negative answer is consistent with ZFC
-  - Lambie-Hanson (2020): Constructed ZFC counterexample - no such F exists!
+History:
+- de Bruijn-Erdős (1951): Infinite χ implies finite n-chromatic subgraphs exist
+- Erdős-Hajnal-Szemerédi (1982): Conjectured uniform bound F(n) exists for ℵ₁
+- Shelah (2005): Showed negative answer is consistent with ZFC
+- Lambie-Hanson (2020): Constructed ZFC counterexample - no such F exists!
 
-  Key insight: The conjecture fails for χ = ℵ₀ but was hoped to hold for χ = ℵ₁.
-  Lambie-Hanson showed it fails for ℵ₁ too, in every model of ZFC.
+Key insight: The conjecture fails for χ = ℵ₀ but was hoped to hold for χ = ℵ₁.
+Lambie-Hanson showed it fails for ℵ₁ too, in every model of ZFC.
 
-  Tags: graph-theory, chromatic-number, infinite-graphs, set-theory, counterexample
+Tags: graph-theory, chromatic-number, infinite-graphs, set-theory, counterexample
 -/
 
 import Mathlib
@@ -28,8 +28,7 @@ namespace Erdos110
 
 open Cardinal Set
 
-/-!
-## Part I: Basic Graph Theory
+/-! ## Part I: Basic Graph Theory
 
 Chromatic numbers and graph colorings.
 -/
@@ -50,8 +49,7 @@ def IsKColorable (G : SimpleGraph V) (k : ℕ) : Prop :=
 noncomputable def chromaticNumber (G : SimpleGraph V) : ℕ∞ :=
   ⨅ k : ℕ, if IsKColorable G k then (k : ℕ∞) else ⊤
 
-/-!
-## Part II: Subgraphs and Induced Subgraphs
+/-! ## Part II: Subgraphs and Induced Subgraphs
 
 For studying finite subgraphs of infinite graphs.
 -/
@@ -70,8 +68,7 @@ noncomputable def subgraphChromaticNumber (G : SimpleGraph V) (S : Set V) : ℕ�
 def HasFiniteNChromaticSubgraph (G : SimpleGraph V) (n : ℕ) (bound : ℕ) : Prop :=
   ∃ S : Finset V, S.card ≤ bound ∧ subgraphChromaticNumber G S ≥ n
 
-/-!
-## Part III: Cardinals and Infinite Chromatic Numbers
+/-! ## Part III: Cardinals and Infinite Chromatic Numbers
 
 Using Mathlib's cardinal arithmetic.
 -/
@@ -99,8 +96,7 @@ def HasChromaticNumber (G : SimpleGraph V) (κ : Cardinal) : Prop :=
   HasChromaticNumberAtLeast G κ ∧
   (κ.toNat > 0 → IsKColorable G κ.toNat)
 
-/-!
-## Part IV: de Bruijn-Erdős Theorem
+/-! ## Part IV: de Bruijn-Erdős Theorem
 
 Foundation: infinite chromatic number implies finite n-chromatic subgraphs exist.
 -/
@@ -114,13 +110,11 @@ axiom de_bruijn_erdos (G : SimpleGraph V) (hχ : HasChromaticNumberAtLeast G ale
     ∀ n : ℕ, ∃ S : Finset V, subgraphChromaticNumber G S ≥ n
 
 /-- de Bruijn-Erdős is a compactness result for colorings. -/
-theorem de_bruijn_erdos_compactness (G : SimpleGraph V)
+axiom de_bruijn_erdos_compactness (G : SimpleGraph V)
     (h : ∀ S : Finset V, ∃ k : ℕ, k > 0 ∧ IsKColorable (inducedSubgraph G S) k) :
-    ∃ k : ℕ, k > 0 ∧ IsKColorable G k := by
-  sorry  -- The compactness argument
+    ∃ k : ℕ, k > 0 ∧ IsKColorable G k
 
-/-!
-## Part V: The Erdős-Hajnal-Szemerédi Conjecture
+/-! ## Part V: The Erdős-Hajnal-Szemerédi Conjecture
 
 The conjecture that was disproved.
 -/
@@ -144,8 +138,7 @@ axiom conjecture_fails_aleph0 :
       HasChromaticNumberAtLeast G aleph0 ∧
       ¬∃ (F : ℕ → ℕ) (N₀ : ℕ), ∀ n ≥ N₀, HasFiniteNChromaticSubgraph G n (F n)
 
-/-!
-## Part VI: Shelah's Consistency Result (2005)
+/-! ## Part VI: Shelah's Consistency Result (2005)
 
 Shelah showed the negative answer is consistent with ZFC.
 -/
@@ -155,18 +148,11 @@ Shelah showed the negative answer is consistent with ZFC.
 
     This means: there exists a model of ZFC where no such F exists. -/
 axiom shelah_consistency :
-    -- In some model of ZFC:
     ∃ (V : Type*) (G : SimpleGraph V),
       HasChromaticNumber G aleph1 ∧
       ¬∃ (F : ℕ → ℕ) (N₀ : ℕ), ∀ n ≥ N₀, HasFiniteNChromaticSubgraph G n (F n)
 
-/-- Shelah's result left open: is this provable in ZFC, or just consistent? -/
-def ShelahOpenQuestion : Prop :=
-  -- Is ¬ErdosHajnalSzemerediConjecture provable in ZFC?
-  True  -- Lambie-Hanson answered: YES
-
-/-!
-## Part VII: Lambie-Hanson's ZFC Disproof (2020)
+/-! ## Part VII: Lambie-Hanson's ZFC Disproof (2020)
 
 The definitive resolution: the conjecture is FALSE in ZFC.
 -/
@@ -191,18 +177,10 @@ theorem erdos_110_disproved : ¬ErdosHajnalSzemerediConjecture := by
   obtain ⟨n, hn, hNotBound⟩ := hBad F N₀
   exact hNotBound (hF n hn)
 
-/-!
-## Part VIII: Erdős's Growth Rate Expectations
+/-! ## Part VIII: Erdős's Growth Rate Expectations
 
 Erdős expected F would need to grow extremely fast.
 -/
-
-/-- Erdős conjectured: if F exists, it must grow faster than any
-    k-fold iterated exponential. -/
-def FastGrowthExpectation : Prop :=
-  ∀ F : ℕ → ℕ, (∀ k : ℕ, ∃ n₀, ∀ n ≥ n₀, F n > Nat.iterate (2 ^ ·) k n) →
-    -- F grows faster than tower(k, n) for all k
-    True  -- Moot point since F doesn't exist!
 
 /-- The tower function: 2^2^...^n with k iterations. -/
 def tower (k n : ℕ) : ℕ := Nat.iterate (2 ^ ·) k n
@@ -218,8 +196,7 @@ theorem erdos_growth_expectation_moot : ¬∃ F : ℕ → ℕ,
   obtain ⟨n, hn, hNotBound⟩ := hBad F N₀
   exact hNotBound (hN₀ n hn)
 
-/-!
-## Part IX: Connection to Compactness
+/-! ## Part IX: Connection to Compactness
 
 Why compactness doesn't help here.
 -/
@@ -228,14 +205,7 @@ Why compactness doesn't help here.
 axiom graph_compactness (G : SimpleGraph V) :
     (∀ S : Finset V, IsKColorable (inducedSubgraph G S) k) → IsKColorable G k
 
-/-- Compactness gives existence, not uniform bounds. -/
-theorem compactness_no_bound :
-    -- Compactness says: if every finite subgraph is k-colorable, so is G
-    -- But it says nothing about chromatic subgraph sizes!
-    True := by trivial
-
-/-!
-## Part X: Properties of the Counterexample
+/-! ## Part X: Properties of the Counterexample
 
 What we know about Lambie-Hanson's graph.
 -/
@@ -263,8 +233,7 @@ theorem lambie_hanson_graph_exists :
   · intro n
     exact de_bruijn_erdos G (hχ.1) n
 
-/-!
-## Part XI: Main Result
+/-! ## Part XI: Summary
 
 Erdős Problem #110 is DISPROVED.
 -/
@@ -283,15 +252,10 @@ Erdős Problem #110 is DISPROVED.
 theorem erdos_110 : ¬ErdosHajnalSzemerediConjecture :=
   erdos_110_disproved
 
-/-- The answer to Erdős Problem #110. -/
-def erdos_110_answer : String :=
-  "NO: Disproved by Lambie-Hanson (2020) in ZFC"
-
-/-- The conjecture was disproved, not proved. -/
-def erdos_110_status : String := "DISPROVED"
-
-#check erdos_110
-#check lambie_hanson_counterexample
-#check de_bruijn_erdos
+/-- Summary: the counterexample exists and the conjecture is false -/
+theorem erdos_110_summary :
+    ¬ErdosHajnalSzemerediConjecture ∧
+    (∃ (V : Type*) (G : SimpleGraph V), LambieHansonGraph V G) :=
+  ⟨erdos_110_disproved, lambie_hanson_graph_exists⟩
 
 end Erdos110

--- a/src/data/proofs/erdos-110/annotations.json
+++ b/src/data/proofs/erdos-110/annotations.json
@@ -5,178 +5,81 @@
     "range": { "startLine": 1, "endLine": 23 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "**Erdős Problem #110: Chromatic Number Growth in Uncountable Graphs**\n\nConjecture: For ℵ₁-chromatic graphs, there exists F(n) bounding the size of n-chromatic subgraphs.\n\n**Answer**: NO - DISPROVED by Lambie-Hanson (2020) in ZFC.\n\nKey result: No such function F exists, even for uncountable chromatic number.",
+    "content": "**Erdős Problem #110: Chromatic Number Growth in Uncountable Graphs**\n\nConjecture: For ℵ₁-chromatic graphs, there exists F(n) bounding the size of n-chromatic subgraphs.\n\n**Answer**: NO - DISPROVED by Lambie-Hanson (2020) in ZFC.\n\nKey history: de Bruijn-Erdős (1951) → Erdős-Hajnal-Szemerédi conjecture (1982) → Shelah consistency (2005) → Lambie-Hanson ZFC disproof (2020).",
+    "mathContext": "This problem sits at the intersection of infinite graph theory and set theory, connecting chromatic numbers to cardinal arithmetic.",
+    "significance": "critical",
+    "relatedConcepts": ["Chromatic number", "Cardinals", "Compactness", "ZFC"]
+  },
+  {
+    "id": "ann-110-definitions",
+    "proofId": "erdos-110",
+    "range": { "startLine": 31, "endLine": 69 },
+    "type": "definition",
+    "title": "Graph Coloring Definitions",
+    "content": "**IsProperColoring:** Adjacent vertices get different colors.\n\n**IsKColorable:** Admits a proper k-coloring.\n\n**chromaticNumber:** Minimum k for k-colorability (as ℕ∞).\n\n**inducedSubgraph:** Restriction of G to vertex subset S.\n\n**HasFiniteNChromaticSubgraph(G, n, bound):** G has an n-chromatic subgraph on ≤ bound vertices.",
+    "mathContext": "These definitions set up the framework for studying chromatic properties of finite subgraphs of infinite graphs.",
     "significance": "critical"
   },
   {
-    "id": "ann-110-graph",
+    "id": "ann-110-cardinals",
     "proofId": "erdos-110",
-    "range": { "startLine": 37, "endLine": 38 },
+    "range": { "startLine": 71, "endLine": 97 },
     "type": "definition",
-    "title": "Graph",
-    "content": "A **simple graph** on vertex type V is a symmetric, irreflexive adjacency relation.\n\nThis is Mathlib's `SimpleGraph V` type.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-110-coloring",
-    "proofId": "erdos-110",
-    "range": { "startLine": 40, "endLine": 43 },
-    "type": "definition",
-    "title": "Proper Coloring",
-    "content": "A **proper k-coloring** assigns colors 1..k to vertices so adjacent vertices have different colors.\n\nFormally: c : V → Fin k with G.Adj v w → c v ≠ c w.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-110-kcolorable",
-    "proofId": "erdos-110",
-    "range": { "startLine": 45, "endLine": 47 },
-    "type": "definition",
-    "title": "k-Colorable",
-    "content": "A graph is **k-colorable** if it admits a proper k-coloring.\n\nThis is the fundamental concept in chromatic graph theory.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-110-chromatic",
-    "proofId": "erdos-110",
-    "range": { "startLine": 49, "endLine": 51 },
-    "type": "definition",
-    "title": "Chromatic Number",
-    "content": "The **chromatic number** χ(G) is the minimum k for which G is k-colorable.\n\nFor infinite graphs, this can be an infinite cardinal (ℵ₀, ℵ₁, ...).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-110-induced",
-    "proofId": "erdos-110",
-    "range": { "startLine": 59, "endLine": 63 },
-    "type": "definition",
-    "title": "Induced Subgraph",
-    "content": "The **induced subgraph** on S ⊆ V contains all edges of G between vertices in S.\n\nThis is the natural restriction of G to a subset of vertices.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-110-finite-subgraph",
-    "proofId": "erdos-110",
-    "range": { "startLine": 69, "endLine": 71 },
-    "type": "definition",
-    "title": "Finite n-Chromatic Subgraph",
-    "content": "**HasFiniteNChromaticSubgraph(G, n, bound)**: G has an n-chromatic subgraph on at most `bound` vertices.\n\nThe conjecture asks if `bound = F(n)` exists uniformly.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-110-aleph0",
-    "proofId": "erdos-110",
-    "range": { "startLine": 82, "endLine": 83 },
-    "type": "definition",
-    "title": "Aleph-0 (ℵ₀)",
-    "content": "**ℵ₀** (aleph-null) is the cardinality of the natural numbers.\n\nIt's the smallest infinite cardinal.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-110-aleph1",
-    "proofId": "erdos-110",
-    "range": { "startLine": 85, "endLine": 86 },
-    "type": "definition",
-    "title": "Aleph-1 (ℵ₁)",
-    "content": "**ℵ₁** (aleph-one) is the first uncountable cardinal.\n\nℵ₁ = succ(ℵ₀), the successor of aleph-null.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-110-cardinal-chromatic",
-    "proofId": "erdos-110",
-    "range": { "startLine": 93, "endLine": 100 },
-    "type": "definition",
-    "title": "Cardinal Chromatic Number",
-    "content": "**HasChromaticNumber(G, κ)**: G has chromatic number exactly the cardinal κ.\n\nFor ℵ₁: not k-colorable for any finite k, but 'ℵ₁-colorable' in a suitable sense.",
-    "significance": "critical"
+    "title": "Cardinals and Infinite Chromatic Numbers",
+    "content": "**aleph0, aleph1:** ℵ₀ (countable infinity) and ℵ₁ (first uncountable cardinal).\n\n**HasChromaticNumberAtLeast(G, κ):** Not k-colorable for any k < κ.\n\n**HasChromaticNumber(G, κ):** Chromatic number is exactly κ.\n\nThe conjecture specifically targets ℵ₁-chromatic graphs.",
+    "mathContext": "ℵ₁ = succ(ℵ₀) is the first uncountable cardinal. The conjecture's failure for ℵ₀ was already known.",
+    "significance": "critical",
+    "relatedConcepts": ["Aleph numbers", "Successor cardinals", "Uncountability"]
   },
   {
     "id": "ann-110-debruijn",
     "proofId": "erdos-110",
-    "range": { "startLine": 108, "endLine": 114 },
+    "range": { "startLine": 99, "endLine": 115 },
     "type": "axiom",
     "title": "de Bruijn-Erdős Theorem",
-    "content": "**de Bruijn-Erdős Theorem (1951)**:\n\nIf χ(G) = ∞, then for every n, G contains a finite n-chromatic subgraph.\n\n**Crucial limitation**: This says nothing about the SIZE of such subgraphs!",
+    "content": "**de_bruijn_erdos (1951):** If χ(G) ≥ ℵ₀, then for every n, G contains a finite n-chromatic subgraph.\n\n**de_bruijn_erdos_compactness:** The compactness formulation—if every finite subgraph is k-colorable, so is G.\n\n**Crucial limitation:** These say nothing about the SIZE of n-chromatic subgraphs!",
+    "mathContext": "The de Bruijn-Erdős theorem is a compactness result. It guarantees existence but not uniform bounds, which is exactly the gap the conjecture tried to fill.",
     "significance": "critical"
   },
   {
     "id": "ann-110-conjecture",
     "proofId": "erdos-110",
-    "range": { "startLine": 128, "endLine": 138 },
+    "range": { "startLine": 117, "endLine": 139 },
     "type": "definition",
-    "title": "Erdős-Hajnal-Szemerédi Conjecture",
-    "content": "**Conjecture (1982)**: For ℵ₁-chromatic graphs, there exists F : ℕ → ℕ such that for large n, an n-chromatic subgraph exists on ≤ F(n) vertices.\n\n**Status**: DISPROVED by Lambie-Hanson (2020).",
+    "title": "The Erdős-Hajnal-Szemerédi Conjecture",
+    "content": "**ErdosHajnalSzemerediConjecture (1982):** For ℵ₁-chromatic graphs, there exists F : ℕ → ℕ such that for large n, an n-chromatic subgraph exists on ≤ F(n) vertices.\n\n**conjecture_fails_aleph0:** Already known to fail for ℵ₀-chromatic graphs.\n\nThe conjecture tried to leverage ℵ₁ > ℵ₀ to obtain uniform bounds.",
+    "mathContext": "The hope was that uncountable chromatic number would be 'strong enough' to guarantee efficient finite approximations.",
     "significance": "critical"
   },
   {
-    "id": "ann-110-aleph0-fails",
+    "id": "ann-110-disproof",
     "proofId": "erdos-110",
-    "range": { "startLine": 140, "endLine": 145 },
-    "type": "axiom",
-    "title": "Conjecture Fails for ℵ₀",
-    "content": "The conjecture **already fails for ℵ₀-chromatic graphs**.\n\nThis was known before Erdős-Hajnal-Szemerédi conjectured it might hold for ℵ₁.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-110-shelah",
-    "proofId": "erdos-110",
-    "range": { "startLine": 153, "endLine": 161 },
-    "type": "axiom",
-    "title": "Shelah's Consistency Result",
-    "content": "**Shelah's Theorem (2005)**:\n\nIt is **consistent with ZFC** that no such F exists.\n\nThis left open: is it provable in ZFC, or just consistent?",
-    "significance": "key"
-  },
-  {
-    "id": "ann-110-lambie-hanson",
-    "proofId": "erdos-110",
-    "range": { "startLine": 174, "endLine": 181 },
-    "type": "axiom",
-    "title": "Lambie-Hanson's ZFC Disproof",
-    "content": "**Lambie-Hanson Theorem (2020)**:\n\nThe conjecture is FALSE **in ZFC** (no extra assumptions).\n\nConstructed an ℵ₁-chromatic graph defeating every proposed F.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-110-disproved",
-    "proofId": "erdos-110",
-    "range": { "startLine": 183, "endLine": 192 },
+    "range": { "startLine": 141, "endLine": 178 },
     "type": "theorem",
-    "title": "Conjecture Disproved",
-    "content": "**Theorem**: ¬ErdosHajnalSzemerediConjecture\n\nThe conjecture is FALSE. Proof: apply Lambie-Hanson's counterexample.",
-    "significance": "critical"
+    "title": "Shelah's Consistency and Lambie-Hanson's ZFC Disproof",
+    "content": "**shelah_consistency (2005):** Consistent with ZFC that no F exists.\n\n**lambie_hanson_counterexample (2020):** Proved in ZFC—no extra assumptions. Constructed an ℵ₁-chromatic graph defeating every proposed bound F.\n\n**erdos_110_disproved:** Direct proof that ¬ErdosHajnalSzemerediConjecture by extracting the counterexample and deriving contradiction.",
+    "mathContext": "Shelah's consistency result left open whether this was a ZFC theorem. Lambie-Hanson's construction settled this definitively.",
+    "significance": "critical",
+    "relatedConcepts": ["ZFC", "Consistency", "Counterexample construction"]
   },
   {
-    "id": "ann-110-tower",
+    "id": "ann-110-counterexample",
     "proofId": "erdos-110",
-    "range": { "startLine": 207, "endLine": 208 },
-    "type": "definition",
-    "title": "Tower Function",
-    "content": "**tower(k, n)** = 2^2^...^n with k iterations.\n\nErdős expected F would grow faster than any tower function. Moot: F doesn't exist!",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-110-counterexample-struct",
-    "proofId": "erdos-110",
-    "range": { "startLine": 243, "endLine": 252 },
+    "range": { "startLine": 208, "endLine": 234 },
     "type": "definition",
     "title": "Lambie-Hanson Graph Structure",
-    "content": "**LambieHansonGraph** structure:\n\n1. χ(G) = ℵ₁ exactly\n2. Defeats all proposed bounds F\n3. Still has n-chromatic subgraphs (de Bruijn-Erdős)\n\nThe graph exists by Lambie-Hanson's construction.",
+    "content": "**LambieHansonGraph:** A structure capturing the three key properties:\n1. χ(G) = ℵ₁ exactly\n2. Defeats all proposed bounds F\n3. Still has n-chromatic subgraphs (by de Bruijn-Erdős)\n\n**lambie_hanson_graph_exists:** Proved from the counterexample axiom and de Bruijn-Erdős.",
+    "mathContext": "The existence proof combines Lambie-Hanson's counterexample with de Bruijn-Erdős to show all three properties hold simultaneously.",
     "significance": "key"
   },
   {
-    "id": "ann-110-main",
+    "id": "ann-110-summary",
     "proofId": "erdos-110",
-    "range": { "startLine": 272, "endLine": 284 },
+    "range": { "startLine": 236, "endLine": 261 },
     "type": "theorem",
-    "title": "Main Result",
-    "content": "**Erdős Problem #110: DISPROVED**\n\nThe Erdős-Hajnal-Szemerédi conjecture is FALSE.\n\n- Shelah (2005): Consistent with ZFC that no F exists\n- Lambie-Hanson (2020): Proved in ZFC that no F exists\n\nde Bruijn-Erdős guarantees existence but not uniform bounds.",
+    "title": "Summary",
+    "content": "**erdos_110:** ¬ErdosHajnalSzemerediConjecture (the conjecture is FALSE).\n\n**erdos_110_summary:** Combines the disproof with the existence of the counterexample graph:\n```lean\n⟨erdos_110_disproved, lambie_hanson_graph_exists⟩\n```\n\nThe answer to Problem #110 is NO: no uniform bound F(n) exists.",
+    "mathContext": "A complete resolution via counterexample, answering a question that stood open for nearly 40 years (1982-2020).",
     "significance": "critical"
-  },
-  {
-    "id": "ann-110-answer",
-    "proofId": "erdos-110",
-    "range": { "startLine": 286, "endLine": 291 },
-    "type": "definition",
-    "title": "The Answer",
-    "content": "**Answer**: NO\n\nDisproved by Lambie-Hanson (2020) in ZFC.\n\nNo uniform bound F(n) exists for ℵ₁-chromatic graphs.",
-    "significance": "supporting"
   }
 ]

--- a/src/data/proofs/erdos-110/meta.json
+++ b/src/data/proofs/erdos-110/meta.json
@@ -18,8 +18,8 @@
       "counterexample",
       "disproved"
     ],
-    "badge": "disproved",
-    "sorries": 2,
+    "badge": "axiom",
+    "sorries": 0,
     "erdosNumber": 110,
     "erdosUrl": "https://erdosproblems.com/110",
     "erdosProblemStatus": "solved",
@@ -69,21 +69,20 @@
       "Statement of the Erdős-Hajnal-Szemerédi conjecture",
       "Axiomatization of de Bruijn-Erdős theorem",
       "Formalization of Lambie-Hanson's counterexample structure",
-      "Proof that the conjecture is disproved"
+      "Proof that the conjecture is disproved",
+      "erdos_110_summary combining disproof and counterexample existence"
     ],
     "relatedProblems": []
   },
   "overview": {
-    "historicalContext": "**Finite Subgraphs of Infinite Chromatic Graphs**\n\nThe de Bruijn-Erdős theorem (1951) states that a graph with infinite chromatic number contains finite subgraphs of every finite chromatic number. But how efficiently? This problem asks whether there's a universal bound F(n) on the size needed to achieve chromatic number n.\n\n**The Conjecture (Erdős-Hajnal-Szemerédi 1982)**: For graphs with chromatic number ℵ₁ (the first uncountable cardinal), there should exist F(n) such that an n-chromatic subgraph exists on at most F(n) vertices.\n\n**Important**: This fails for ℵ₀-chromatic graphs! The uncountability is essential.\n\n**Erdős's Expectation**: If F exists, it must grow faster than any k-fold iterated exponential.\n\n**The Disproof**:\n- Shelah (2005): Showed it's consistent with ZFC that no such F exists\n- Lambie-Hanson (2020): Constructed an actual ZFC counterexample - no set-theoretic assumptions needed!",
+    "historicalContext": "**Finite Subgraphs of Infinite Chromatic Graphs**\n\nThe de Bruijn-Erdős theorem (1951) states that a graph with infinite chromatic number contains finite subgraphs of every finite chromatic number. But how efficiently? This problem asks whether there's a universal bound F(n) on the size needed to achieve chromatic number n.\n\n**The Conjecture (Erdős-Hajnal-Szemerédi 1982)**: For graphs with chromatic number ℵ₁ (the first uncountable cardinal), there should exist F(n) such that an n-chromatic subgraph exists on at most F(n) vertices. This was already known to fail for ℵ₀-chromatic graphs.\n\n**The Disproof**: Shelah (2005) showed the negative answer is consistent with ZFC. Lambie-Hanson (2020) then constructed an actual ZFC counterexample—no set-theoretic assumptions needed! This completely resolves the problem.",
     "problemStatement": "**Problem Statement**\n\nIs there a function F: ℕ → ℕ such that every graph G with chromatic number ℵ₁ has, for all sufficiently large n, a subgraph with chromatic number n on at most F(n) vertices?\n\n**Answer**: NO (DISPROVED in ZFC)\n\n**Lambie-Hanson (2020)**: Constructed a graph with chromatic number ℵ₁ such that no such function F exists.\n\n**Note**: The conjecture specifically requires χ(G) = ℵ₁. For χ(G) = ℵ₀, counterexamples were already known.",
-    "proofStrategy": "**The Formalization**\n\n1. Defines chromatic number and k-colorability\n2. Defines induced subgraphs and chromatic subgraph bounds\n3. Introduces cardinals ℵ₀ and ℵ₁ from Mathlib\n4. States the de Bruijn-Erdős theorem (existence without bounds)\n5. States the Erdős-Hajnal-Szemerédi conjecture\n6. Axiomatizes Shelah's consistency result\n7. Axiomatizes Lambie-Hanson's ZFC counterexample\n8. Proves the conjecture is FALSE\n9. Characterizes the counterexample graph structure",
+    "proofStrategy": "**The Formalization**\n\n1. Defines chromatic number and k-colorability\n2. Defines induced subgraphs and chromatic subgraph bounds\n3. Introduces cardinals ℵ₀ and ℵ₁ from Mathlib\n4. States the de Bruijn-Erdős theorem (existence without bounds)\n5. States the Erdős-Hajnal-Szemerédi conjecture\n6. Axiomatizes Shelah's consistency result and Lambie-Hanson's ZFC counterexample\n7. Proves the conjecture is FALSE via direct contradiction\n8. Characterizes the counterexample graph structure",
     "keyInsights": [
       "DISPROVED in ZFC by Lambie-Hanson (2020) - no set-theoretic assumptions needed",
       "Shelah (2005) had earlier shown consistency of negative answer",
       "The conjecture was specifically for ℵ₁-chromatic graphs - it fails for ℵ₀",
       "de Bruijn-Erdős theorem guarantees existence but not bounded size",
-      "Erdős expected F would need to grow faster than any iterated exponential",
-      "The problem connects graph theory to set theory and infinite combinatorics",
       "Shows that uncountable chromatic number doesn't imply 'efficient' finite approximations"
     ]
   },
@@ -93,81 +92,80 @@
       "title": "Basic Graph Theory",
       "summary": "Chromatic numbers and colorings",
       "startLine": 31,
-      "endLine": 51
+      "endLine": 50
     },
     {
       "id": "subgraphs",
       "title": "Subgraphs and Induced Subgraphs",
       "summary": "Finite chromatic subgraph definitions",
-      "startLine": 53,
-      "endLine": 71
+      "startLine": 52,
+      "endLine": 69
     },
     {
       "id": "cardinals",
       "title": "Cardinals and Infinite Chromatic Numbers",
       "summary": "ℵ₀, ℵ₁, and infinite chromatic numbers",
-      "startLine": 73,
-      "endLine": 100
+      "startLine": 71,
+      "endLine": 97
     },
     {
       "id": "de-bruijn-erdos",
       "title": "de Bruijn-Erdős Theorem",
       "summary": "Foundation: existence of finite chromatic subgraphs",
-      "startLine": 102,
-      "endLine": 120
+      "startLine": 99,
+      "endLine": 115
     },
     {
       "id": "conjecture",
       "title": "The Erdős-Hajnal-Szemerédi Conjecture",
       "summary": "The conjecture that was disproved",
-      "startLine": 122,
-      "endLine": 145
+      "startLine": 117,
+      "endLine": 139
     },
     {
       "id": "shelah",
       "title": "Shelah's Consistency Result",
       "summary": "2005: Consistent that no F exists",
-      "startLine": 147,
-      "endLine": 166
+      "startLine": 141,
+      "endLine": 153
     },
     {
       "id": "lambie-hanson",
       "title": "Lambie-Hanson's ZFC Disproof",
-      "summary": "2020: Definitive ZFC counterexample",
-      "startLine": 168,
-      "endLine": 192
+      "summary": "2020: Definitive ZFC counterexample and disproof theorem",
+      "startLine": 155,
+      "endLine": 178
     },
     {
       "id": "growth-rate",
-      "title": "Erdős's Growth Rate Expectations",
-      "summary": "Faster than any tower function",
-      "startLine": 194,
-      "endLine": 219
+      "title": "Growth Rate and Compactness",
+      "summary": "Tower function, growth expectation moot, graph compactness",
+      "startLine": 180,
+      "endLine": 206
     },
     {
       "id": "counterexample",
       "title": "Properties of the Counterexample",
-      "summary": "Lambie-Hanson's graph structure",
-      "startLine": 237,
-      "endLine": 264
+      "summary": "LambieHansonGraph structure and existence",
+      "startLine": 208,
+      "endLine": 234
     },
     {
-      "id": "main-result",
-      "title": "Main Result",
-      "summary": "Erdős Problem #110 is DISPROVED",
-      "startLine": 266,
-      "endLine": 297
+      "id": "summary",
+      "title": "Summary",
+      "summary": "erdos_110 and erdos_110_summary theorems",
+      "startLine": 236,
+      "endLine": 261
     }
   ],
   "conclusion": {
     "summary": "Erdős Problem #110 asked whether ℵ₁-chromatic graphs have uniformly bounded n-chromatic subgraphs. DISPROVED by Lambie-Hanson (2020) in ZFC, building on Shelah's 2005 consistency result. The counterexample shows uncountable chromatic number doesn't guarantee efficient finite chromatic subgraphs.",
-    "implications": "**Theoretical Significance**\n\n1. **Set Theory Meets Graph Theory**: Resolved a question at the intersection of infinite combinatorics and chromatic theory\n\n2. **de Bruijn-Erdős Limitations**: Shows the theorem's existence guarantee can't be made uniform\n\n3. **Uncountable Cardinals**: Reveals surprising behavior at ℵ₁ - the first uncountable level\n\n4. **ZFC vs Consistency**: Lambie-Hanson's ZFC proof strengthened Shelah's consistency result\n\n5. **Compactness Failures**: Another example where infinite structures resist finite approximation bounds",
+    "implications": "**Theoretical Significance**\n\n1. **Set Theory Meets Graph Theory**: Resolved a question at the intersection of infinite combinatorics and chromatic theory\n\n2. **de Bruijn-Erdős Limitations**: Shows the theorem's existence guarantee can't be made uniform\n\n3. **Uncountable Cardinals**: Reveals surprising behavior at ℵ₁ - the first uncountable level\n\n4. **ZFC vs Consistency**: Lambie-Hanson's ZFC proof strengthened Shelah's consistency result",
     "openQuestions": [
       "What is the structure of Lambie-Hanson's counterexample graph?",
       "Are there natural graph classes where uniform bounds do exist?",
       "What happens at higher cardinals (ℵ₂, ℵ₃, ...)?",
-      "Can the counterexample be made explicit/constructive?",
-      "Formalize the ZFC counterexample in Lean (requires substantial set theory)"
+      "Can the counterexample be made explicit/constructive?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Convert `de_bruijn_erdos_compactness` sorry proof to axiom
- Remove `ShelahOpenQuestion` (Prop := True), `FastGrowthExpectation` (→ True), `compactness_no_bound` (True := by trivial)
- Remove `erdos_110_answer` and `erdos_110_status` String defs
- Remove `#check` statements
- Fix header `/-` → `/-!`
- Add `erdos_110_summary` theorem combining disproof + counterexample
- Update meta.json (badge: axiom, sorries: 0, section line ranges)
- Update annotations.json (8 annotations with correct line ranges)
- 298 → 262 lines

## Test plan
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)