### PR TITLE
Add IDLE status for polling agents to prevent false STUCK detection

### DIFF
--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -35,6 +35,8 @@ DAEMON_LOG_FILE="research/lean-daemon.log"
 # Health check thresholds
 STUCK_THRESHOLD_MINUTES=30
 STUCK_CPU_THRESHOLD="0.5"
+# Agent statuses: RUNNING, COMPLETED, STUCK, IDLE, UNKNOWN
+# IDLE = polling agent (deployer/seeker) that is healthy but waiting between cycles
 
 # Daemon defaults
 DEFAULT_DAEMON_INTERVAL=60
@@ -505,8 +507,18 @@ is_script_based_agent() {
     [[ "$agent_type" == "aristotle" ]]
 }
 
+# Helper: Check if an agent is a polling agent that legitimately idles between cycles
+# Polling agents (deployer, seeker) sleep between work cycles, so low CPU + no network
+# is normal behavior, not a stuck state.
+is_polling_agent() {
+    local session="$1"
+    local agent_type
+    agent_type=$(get_agent_type "$session")
+    [[ "$agent_type" == "deployer" || "$agent_type" == "seeker" ]]
+}
+
 # Helper: Determine agent health status
-# Returns: RUNNING, COMPLETED, STUCK, or UNKNOWN
+# Returns: RUNNING, COMPLETED, STUCK, IDLE, or UNKNOWN
 get_agent_status() {
     local session="$1"
     local pane_pid
@@ -563,7 +575,12 @@ get_agent_status() {
         local is_low_cpu
         is_low_cpu=$(awk "BEGIN { print ($cpu < $STUCK_CPU_THRESHOLD) ? 1 : 0 }")
         if [[ "$is_low_cpu" -eq 1 ]] && ! has_network "$claude_pid"; then
-            echo "STUCK"
+            # Polling agents (deployer, seeker) legitimately idle between cycles
+            if is_polling_agent "$session"; then
+                echo "IDLE"
+            else
+                echo "STUCK"
+            fi
             return
         fi
     fi
@@ -591,6 +608,7 @@ cmd_health() {
     local stuck_count=0
     local running_count=0
     local completed_count=0
+    local idle_count=0
 
     while IFS= read -r session; do
         [[ -z "$session" ]] && continue
@@ -660,6 +678,10 @@ cmd_health() {
                     status_display="${RED}STUCK${NC}"
                     stuck_count=$((stuck_count + 1))
                     ;;
+                IDLE)
+                    status_display="${BLUE}IDLE${NC}"
+                    idle_count=$((idle_count + 1))
+                    ;;
                 RUNNING)
                     status_display="${GREEN}RUNNING${NC}"
                     running_count=$((running_count + 1))
@@ -675,7 +697,12 @@ cmd_health() {
     done <<< "$sessions"
 
     echo ""
-    echo -e "Summary: ${GREEN}$running_count running${NC}, ${completed_count} completed, ${RED}$stuck_count stuck${NC}"
+    local summary="Summary: ${GREEN}$running_count running${NC}, ${completed_count} completed"
+    if [[ $idle_count -gt 0 ]]; then
+        summary+=", ${BLUE}$idle_count idle${NC}"
+    fi
+    summary+=", ${RED}$stuck_count stuck${NC}"
+    echo -e "$summary"
 
     if [[ $stuck_count -gt 0 ]]; then
         echo ""
@@ -1129,6 +1156,7 @@ cmd_daemon() {
         local running_count=0
         local completed_count=0
         local stuck_count=0
+        local idle_count=0
 
         while IFS= read -r session; do
             [[ -z "$session" ]] && continue
@@ -1139,6 +1167,10 @@ cmd_daemon() {
             case "$status" in
                 RUNNING)
                     running_count=$((running_count + 1))
+                    ;;
+                IDLE)
+                    # Polling agents (deployer, seeker) are healthy but waiting between cycles
+                    idle_count=$((idle_count + 1))
                     ;;
                 COMPLETED)
                     completed_count=$((completed_count + 1))
@@ -1248,7 +1280,7 @@ cmd_daemon() {
         process_completion_signals
 
         # 5. Log cycle summary
-        daemon_log "INFO" "Cycle $cycle_count: running=$running_count, completed=$completed_count, stuck=$stuck_count, respawned=$cycle_respawns | queues: stubs=$stubs, candidates=$candidates, aristotle=$aristotle_jobs, prs=$ready_prs"
+        daemon_log "INFO" "Cycle $cycle_count: running=$running_count, idle=$idle_count, completed=$completed_count, stuck=$stuck_count, respawned=$cycle_respawns | queues: stubs=$stubs, candidates=$candidates, aristotle=$aristotle_jobs, prs=$ready_prs"
 
         # 6. Update state file with daemon stats
         update_daemon_state "$cycle_count" "$total_respawns"


### PR DESCRIPTION
## Summary

- Adds `IDLE` health status for polling agents (deployer, seeker) that legitimately idle between work cycles with no CPU or network activity
- Prevents the daemon from incorrectly marking these agents as `STUCK` and kill-and-respawning them
- Displays IDLE agents in blue in `health` output and includes them in cycle summaries

## Changes

All changes in `scripts/lean/launch.sh`:

| Change | Location | Description |
|--------|----------|-------------|
| Status enum comment | Lines 38-39 | Document IDLE in status enum |
| `is_polling_agent()` | After line 508 | New helper identifying deployer/seeker as polling agents |
| `get_agent_status()` | Line ~575 | Return IDLE instead of STUCK for polling agents |
| `cmd_health()` | Lines ~608-705 | Display IDLE in blue, count separately, show in summary |
| Daemon loop | Lines ~1156-1283 | Treat IDLE same as RUNNING (no respawn), log idle count |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Polling agents return IDLE instead of STUCK | Done | `get_agent_status()` checks `is_polling_agent()` before returning STUCK |
| IDLE displayed in blue (not red) in health output | Done | Uses `${BLUE}IDLE${NC}` in `cmd_health()` |
| IDLE agents not counted as stuck in exit code | Done | Only `stuck_count` is returned, IDLE has separate counter |
| Daemon does not kill-and-respawn IDLE agents | Done | IDLE case in daemon loop only increments counter |
| Non-polling agents still show STUCK normally | Done | `is_polling_agent()` only matches deployer/seeker |
| `check_for_stuck_agents()` excludes IDLE | Done | Only checks `status == "STUCK"`, IDLE returns different string |

## Test plan

- [ ] Start daemon with deployer and seeker, wait >30min, run `./scripts/lean/launch.sh health` — deployer/seeker should show `IDLE` (not `STUCK`)
- [ ] `health` should return exit code 0 when only deployer/seeker are idle
- [ ] If erdos-enhancer or researcher has 0% CPU + no network for 30min+, it should still show `STUCK`
- [ ] Daemon loop does NOT kill-and-respawn IDLE agents
- [ ] `bash -n scripts/lean/launch.sh` passes (verified)
- [ ] `shellcheck` shows no new warnings (verified — only pre-existing SC2034)

Closes #1815

🤖 Generated with [Claude Code](https://claude.com/claude-code)