### PR TITLE
Enhance Erdős #1128: Monochromatic Cubes in Cardinal Products

### DIFF
--- a/proofs/Proofs/Erdos1128Problem.lean
+++ b/proofs/Proofs/Erdos1128Problem.lean
@@ -1,291 +1,177 @@
-/-
-Erdős Problem #1128: Monochromatic Cubes in Cardinal Products
+/-!
+# Erdős Problem #1128: Monochromatic Cubes in Cardinal Products
 
-Source: https://erdosproblems.com/1128
-Status: DISPROVED (Prikry-Mills 1978)
-Prize: $50
+**Source:** [erdosproblems.com/1128](https://erdosproblems.com/1128)
+**Status:** DISPROVED (Prikry-Mills, 1978)
+**Prize:** $50
 
-Statement:
+**Statement:**
 Let A, B, C be three sets of cardinality ℵ₁. Is it true that
 in any 2-coloring of A × B × C, there must exist A₁ ⊂ A, B₁ ⊂ B,
 C₁ ⊂ C, all of cardinality ℵ₀, such that A₁ × B₁ × C₁ is monochromatic?
 
-Answer: NO. Prikry and Mills disproved this in 1978.
+**Answer:** NO — disproved by Prikry and Mills (1978)
 
-Historical Note:
-A problem of Erdős and Hajnal. The disproof remained unpublished but
-was later documented by Todorčević [To94] and Komjáth [Ko25b].
+**History:**
+- Erdős-Hajnal [Er81b]: Posed the conjecture
+- Prikry-Mills (1978): Disproved via counterexample (unpublished)
+- Todorčević [To94]: Documented the disproof
+- Komjáth [Ko25b]: Included in the Erdős-Hajnal Problem List
 
-Context:
-This is a partition problem in set theory, asking whether the
-cardinal Ramsey property ℵ₁³ → (ℵ₀)³₂ holds.
+**Notation:** In partition calculus, this asks whether ℵ₁³ → (ℵ₀)³₂ holds.
+The answer is ℵ₁³ ↛ (ℵ₀)³₂.
 
-References:
-- Erdős-Hajnal [Er81b]: Original problem
-- Prikry-Mills (1978): Disproof (unpublished)
-- Todorčević [To94]: Documentation
-- Komjáth [Ko25b]: Erdős-Hajnal Problem List
+**Reference:** https://erdosproblems.com/1128
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Set.Basic
 import Mathlib.SetTheory.Cardinal.Basic
+import Mathlib.SetTheory.Cardinal.Ordinal
+import Mathlib.Data.Set.Basic
 
 namespace Erdos1128
 
-/-
-## Part I: Cardinal Definitions
--/
+/-! ## Part I: Cardinal Setup -/
 
 /--
-**The cardinal ℵ₁:**
-The first uncountable cardinal. |A| = ℵ₁ means A has the same
-cardinality as the first uncountable ordinal ω₁.
+**ℵ₁ (aleph-one):** The first uncountable cardinal.
+A set has cardinality ℵ₁ if it bijects with the first uncountable ordinal ω₁.
 -/
-axiom aleph_1 : Cardinal
+noncomputable def aleph1 : Cardinal := Cardinal.aleph 1
 
 /--
-**The cardinal ℵ₀:**
-The cardinality of countable infinity. |A| = ℵ₀ means A is
-countably infinite.
+**ℵ₀ (aleph-naught):** The cardinality of countable infinity.
+Equals `Cardinal.aleph0`, the cardinality of ℕ.
 -/
-def aleph_0 : Cardinal := Cardinal.omega
+noncomputable def aleph0 : Cardinal := Cardinal.aleph0
 
 /--
-**Sets of cardinality ℵ₁:**
-A, B, C each have cardinality ℵ₁.
+The three sets A, B, C are types with cardinality ℵ₁.
+We axiomatize types of the correct cardinality.
 -/
 axiom A : Type*
 axiom B : Type*
 axiom C : Type*
-axiom card_A : Cardinal.mk A = aleph_1
-axiom card_B : Cardinal.mk B = aleph_1
-axiom card_C : Cardinal.mk C = aleph_1
+axiom card_A : Cardinal.mk A = Cardinal.aleph 1
+axiom card_B : Cardinal.mk B = Cardinal.aleph 1
+axiom card_C : Cardinal.mk C = Cardinal.aleph 1
 
-/-
-## Part II: The Coloring Problem
--/
+/-! ## Part II: Colorings and Monochromatic Cubes -/
 
 /--
-**2-coloring of the product:**
-A function χ: A × B × C → {0, 1} (or equivalently → Bool).
+**2-coloring of a product:**
+A function χ : A × B × C → Bool assigns each triple a color (true or false).
 -/
-def TwoColoring (A B C : Type*) := A × B × C → Bool
+def TwoColoring (X Y Z : Type*) := X × Y × Z → Bool
 
 /--
 **Monochromatic cube:**
-A₁ × B₁ × C₁ is monochromatic for coloring χ if χ is constant
-on the cube: all triples get the same color.
+A₁ × B₁ × C₁ is monochromatic under coloring χ if χ is constant
+on all triples from the cube — every element gets the same color.
 -/
-def isMonochromatic {A B C : Type*} (χ : TwoColoring A B C)
-    (A₁ : Set A) (B₁ : Set B) (C₁ : Set C) : Prop :=
-  (∀ a₁ a₂ ∈ A₁, ∀ b₁ b₂ ∈ B₁, ∀ c₁ c₂ ∈ C₁,
-    χ (a₁, b₁, c₁) = χ (a₂, b₂, c₂))
+def isMonochromatic {X Y Z : Type*} (χ : TwoColoring X Y Z)
+    (A₁ : Set X) (B₁ : Set Y) (C₁ : Set Z) : Prop :=
+  ∀ a₁ ∈ A₁, ∀ a₂ ∈ A₁, ∀ b₁ ∈ B₁, ∀ b₂ ∈ B₁, ∀ c₁ ∈ C₁, ∀ c₂ ∈ C₁,
+    χ (a₁, b₁, c₁) = χ (a₂, b₂, c₂)
 
 /--
 **Countably infinite subset:**
-A subset A₁ ⊂ A has cardinality ℵ₀.
+A subset S has cardinality ℵ₀ (is countably infinite).
 -/
-def hasCardinalityAleph0 {X : Type*} (S : Set X) : Prop :=
-  Cardinal.mk S = aleph_0
+def hasCardAleph0 {X : Type*} (S : Set X) : Prop :=
+  Cardinal.mk S = Cardinal.aleph0
 
-/-
-## Part III: The Conjecture (Disproved)
--/
+/-! ## Part III: The Erdős-Hajnal Conjecture -/
 
 /--
-**The Erdős-Hajnal Conjecture (for ℵ₁³ → (ℵ₀)³):**
-For any 2-coloring χ of A × B × C (with |A| = |B| = |C| = ℵ₁),
-there exist countably infinite A₁, B₁, C₁ such that
-A₁ × B₁ × C₁ is monochromatic.
+**The Erdős-Hajnal Conjecture (ℵ₁³ → (ℵ₀)³₂):**
+For any 2-coloring χ of A × B × C (where |A| = |B| = |C| = ℵ₁),
+there exist countably infinite subsets A₁ ⊂ A, B₁ ⊂ B, C₁ ⊂ C
+such that the sub-cube A₁ × B₁ × C₁ is monochromatic.
 -/
 def erdos_hajnal_conjecture : Prop :=
   ∀ χ : TwoColoring A B C,
-  ∃ A₁ : Set A, ∃ B₁ : Set B, ∃ C₁ : Set C,
-    hasCardinalityAleph0 A₁ ∧
-    hasCardinalityAleph0 B₁ ∧
-    hasCardinalityAleph0 C₁ ∧
+  ∃ (A₁ : Set A) (B₁ : Set B) (C₁ : Set C),
+    hasCardAleph0 A₁ ∧ hasCardAleph0 B₁ ∧ hasCardAleph0 C₁ ∧
     isMonochromatic χ A₁ B₁ C₁
 
+/-! ## Part IV: Prikry-Mills Disproof (1978) -/
+
 /--
-**The conjecture is FALSE:**
-Prikry and Mills disproved this in 1978.
+**Prikry-Mills Disproof (1978):**
+The conjecture is FALSE. Prikry and Mills constructed a counterexample
+showing that ℵ₁³ ↛ (ℵ₀)³₂. Their proof uses the ordinal structure
+of ω₁ to define a coloring that defeats all countably infinite cubes.
+
+Axiomatized because the construction requires ordinal combinatorics
+beyond current Mathlib capabilities.
 -/
 axiom prikry_mills_disproof : ¬erdos_hajnal_conjecture
 
-/-
-## Part IV: The Counterexample
--/
-
 /--
 **Existence of a bad coloring:**
-There exists a 2-coloring of ℵ₁ × ℵ₁ × ℵ₁ such that NO
-countably infinite monochromatic cube exists.
+Equivalently, there exists a 2-coloring of A × B × C such that
+NO countably infinite sub-cube A₁ × B₁ × C₁ is monochromatic.
 -/
 theorem exists_bad_coloring :
     ∃ χ : TwoColoring A B C,
-    ∀ A₁ : Set A, ∀ B₁ : Set B, ∀ C₁ : Set C,
-      hasCardinalityAleph0 A₁ → hasCardinalityAleph0 B₁ → hasCardinalityAleph0 C₁ →
+    ∀ (A₁ : Set A) (B₁ : Set B) (C₁ : Set C),
+      hasCardAleph0 A₁ → hasCardAleph0 B₁ → hasCardAleph0 C₁ →
       ¬isMonochromatic χ A₁ B₁ C₁ := by
   by_contra h
   push_neg at h
   exact prikry_mills_disproof h
 
-/--
-**Construction sketch:**
-The counterexample uses a coloring based on ordinal arithmetic.
-By carefully interleaving colors, one can ensure that any
-countably infinite cube contains both colors.
--/
-axiom counterexample_construction : True
+/-! ## Part V: The Two-Dimensional Analogue -/
 
 /--
-**Key idea:**
-The coloring exploits the uncountability of ℵ₁ to encode enough
-information that any ℵ₀ × ℵ₀ × ℵ₀ cube must have mixed colors.
+**Two-dimensional analogue:**
+Even the 2D version ℵ₁² → (ℵ₀)²₂ is false.
+There exists a 2-coloring of ℵ₁ × ℵ₁ with no countably infinite
+monochromatic rectangle. The proof method is different from the 3D case.
+Axiomatized as the construction uses ordinal stepping-up techniques.
 -/
-axiom key_idea : True
+axiom two_dim_negative :
+    ∃ (χ : A × B → Bool),
+    ∀ (A₁ : Set A) (B₁ : Set B),
+      hasCardAleph0 A₁ → hasCardAleph0 B₁ →
+      ¬(∀ a₁ ∈ A₁, ∀ a₂ ∈ A₁, ∀ b₁ ∈ B₁, ∀ b₂ ∈ B₁,
+        χ (a₁, b₁) = χ (a₂, b₂))
 
-/-
-## Part V: Context in Partition Calculus
--/
+/-! ## Part VI: Main Theorem -/
 
 /--
-**Partition arrow notation:**
-κ → (λ)ⁿ means: for any 2-coloring of [κ]ⁿ (n-element subsets),
-there exists a homogeneous set of size λ.
+**Main Theorem (Answer to Erdős #1128):**
+The partition property ℵ₁³ → (ℵ₀)³₂ fails. The Erdős-Hajnal
+conjecture on monochromatic cubes in cardinal products is false.
 -/
-axiom partition_arrow_notation : True
+theorem erdos_1128 : ¬erdos_hajnal_conjecture :=
+  prikry_mills_disproof
+
+/-! ## Part VII: Summary -/
 
 /--
-**Product version:**
-ℵ₁³ → (ℵ₀)³₂ asks about colorings of the 3-dimensional product.
-This is related to but different from the ordinary partition arrow.
+**Erdős Problem #1128: DISPROVED**
+
+**QUESTION:** Must every 2-coloring of ℵ₁ × ℵ₁ × ℵ₁ contain
+a countably infinite monochromatic cube?
+
+**ANSWER:** NO (Prikry-Mills, 1978)
+
+**KEY RESULTS:**
+1. Prikry-Mills (1978): Constructed a bad coloring — no ℵ₀³ mono cube
+2. The 2D analogue ℵ₁² ↛ (ℵ₀)²₂ also fails
+3. Finite Ramsey theory analogues DO hold — infiniteness is key
+
+**PRIZE:** $50 (for a negative answer)
 -/
-axiom product_version : True
-
-/--
-**The problem in notation:**
-Is ℵ₁ × ℵ₁ × ℵ₁ → (ℵ₀)³₂ true?
-Answer: NO (Prikry-Mills).
--/
-axiom problem_in_notation : True
-
-/--
-**Two-dimensional case:**
-For comparison, ℵ₁ × ℵ₁ → (ℵ₀)²₂ is also false,
-but the proof is different.
--/
-axiom two_dimensional_case : True
-
-/-
-## Part VI: Positive Results
--/
-
-/--
-**Finite case works:**
-For finite cardinals, the analogous statements are true.
-This is classical Ramsey theory.
--/
-axiom finite_case_true : True
-
-/--
-**Countable case:**
-ℵ₀ × ℵ₀ × ℵ₀ → (n)³₂ is true for any finite n.
-But not for n = ℵ₀.
--/
-axiom countable_case : True
-
-/--
-**With larger cardinals:**
-Under certain set-theoretic axioms, some infinite-dimensional
-Ramsey results can be recovered.
--/
-axiom larger_cardinal_case : True
-
-/-
-## Part VII: Related Problems
--/
-
-/--
-**Erdős-Rado theorem:**
-Gives positive results for certain partition relations
-involving cardinals.
--/
-axiom erdos_rado : True
-
-/--
-**Negative partition relations:**
-Many infinite-dimensional partition relations fail.
-Problem #1128 is one such example.
--/
-axiom negative_partition_relations : True
-
-/--
-**Todorčević's work:**
-Todorčević [To94] systematically studied partitions of
-three-dimensional combinatorial cubes.
--/
-axiom todorcevic_1994 : True
-
-/-
-## Part VIII: Historical Context
--/
-
-/--
-**Erdős-Hajnal collaboration:**
-Erdős and Hajnal posed many problems in infinite combinatorics
-and partition calculus. This is one from their joint work.
--/
-axiom erdos_hajnal_collaboration : True
-
-/--
-**The unpublished proof:**
-Prikry and Mills found the counterexample in 1978 but
-never formally published it. It was later recorded by others.
--/
-axiom unpublished_history : True
-
-/--
-**The $50 prize:**
-Erdős offered $50 for the resolution, which was negative.
--/
-axiom prize_history : True
-
-/-
-## Part IX: Summary
--/
-
-/--
-**Summary of Erdős Problem #1128:**
-
-PROBLEM: Let A, B, C have cardinality ℵ₁. In any 2-coloring
-of A × B × C, must there exist countably infinite A₁, B₁, C₁
-such that A₁ × B₁ × C₁ is monochromatic?
-
-STATUS: DISPROVED by Prikry-Mills (1978)
-Prize: $50
-
-ANSWER: NO. There exists a 2-coloring of ℵ₁ × ℵ₁ × ℵ₁ with
-no countably infinite monochromatic cube.
-
-KEY INSIGHTS:
-1. The uncountability of ℵ₁ allows "bad" colorings
-2. The counterexample uses ordinal structure
-3. In notation: ℵ₁³ ↛ (ℵ₀)³₂
-4. Contrast with finite Ramsey theory where analogues hold
-
-A negative result in infinite-dimensional Ramsey theory.
--/
-theorem erdos_1128_status :
+theorem erdos_1128_summary :
     -- The conjecture is false
-    ¬erdos_hajnal_conjecture := by
-  exact prikry_mills_disproof
-
-/--
-**Problem resolved:**
-Erdős Problem #1128 was disproved by Prikry-Mills in 1978.
--/
-theorem erdos_1128_disproved : True := trivial
+    ¬erdos_hajnal_conjecture ∧
+    -- A bad coloring exists
+    (∃ χ : TwoColoring A B C,
+     ∀ (A₁ : Set A) (B₁ : Set B) (C₁ : Set C),
+       hasCardAleph0 A₁ → hasCardAleph0 B₁ → hasCardAleph0 C₁ →
+       ¬isMonochromatic χ A₁ B₁ C₁) :=
+  ⟨prikry_mills_disproof, exists_bad_coloring⟩
 
 end Erdos1128

--- a/src/data/proofs/erdos-1128/annotations.json
+++ b/src/data/proofs/erdos-1128/annotations.json
@@ -1,218 +1,79 @@
 [
   {
-    "id": "ann-1128-1",
+    "id": "ann-e1128-header",
     "proofId": "erdos-1128",
-    "range": {
-      "startLine": 1,
-      "endLine": 28
-    },
+    "range": { "startLine": 1, "endLine": 25 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "Erdős Problem #1128: Must any 2-coloring of ℵ₁ × ℵ₁ × ℵ₁ contain a countably infinite monochromatic cube? DISPROVED by Prikry-Mills (1978): NO, bad colorings exist. Prize: $50.",
-    "significance": "critical"
+    "content": "**Erdős Problem #1128: Monochromatic Cubes in Cardinal Products**\n\nLet A, B, C be three sets of cardinality ℵ₁ (first uncountable cardinal). Must every 2-coloring of A × B × C contain a countably infinite monochromatic sub-cube?\n\n**Answer:** NO — disproved by Prikry and Mills (1978)\n\nThis is a question in partition calculus, the branch of combinatorics that studies which partition properties hold for infinite cardinals. In compact notation, it asks whether ℵ₁³ → (ℵ₀)³₂ holds. Prikry and Mills showed it does not: there exists a 'bad' coloring where every countably infinite cube contains both colors.",
+    "mathContext": "The partition arrow notation κ → (λ)ⁿ_r means: for every r-coloring of n-dimensional products of sets of size κ, there is a monochromatic sub-product of size λ. The negative arrow ↛ means this fails. Problem #1128 asks about the specific case ℵ₁³ → (ℵ₀)³₂.",
+    "significance": "critical",
+    "relatedConcepts": ["partition calculus", "Ramsey theory", "cardinal arithmetic"]
   },
   {
-    "id": "ann-1128-2",
+    "id": "ann-e1128-cardinals",
     "proofId": "erdos-1128",
-    "range": {
-      "startLine": 40,
-      "endLine": 45
-    },
+    "range": { "startLine": 33, "endLine": 56 },
     "type": "definition",
-    "title": "The Cardinal ℵ₁",
-    "content": "ℵ₁ (aleph-one) is the first uncountable cardinal. A set has cardinality ℵ₁ if it has the same size as the first uncountable ordinal ω₁. Key fact: ℵ₁ > ℵ₀ but we can't 'count' to ℵ₁.",
-    "significance": "critical"
+    "title": "Cardinal Setup",
+    "content": "**Cardinal definitions and the type setup:**\n\n**aleph1:** Defined as Cardinal.aleph 1, the first uncountable cardinal ℵ₁. A set of size ℵ₁ cannot be listed as a sequence — it's 'bigger' than the natural numbers.\n\n**aleph0:** Defined as Cardinal.aleph0, the cardinality of ℕ (countable infinity).\n\n**Types A, B, C:** Axiomatized as types whose cardinality equals Cardinal.aleph 1. These represent the three 'axes' of the product space to be colored.\n\nUsing Mathlib's Cardinal.aleph function gives a clean connection to ordinal-indexed cardinals rather than an ad hoc axiom.",
+    "mathContext": "Cardinal.aleph maps ordinals to infinite cardinals: aleph 0 = ℵ₀, aleph 1 = ℵ₁, etc. The cardinality of a type X is Cardinal.mk X. The axioms card_A/B/C establish that our types have the correct size.",
+    "significance": "critical",
+    "relatedConcepts": ["Cardinal.aleph", "Cardinal.mk", "uncountable sets"]
   },
   {
-    "id": "ann-1128-3",
+    "id": "ann-e1128-coloring",
     "proofId": "erdos-1128",
-    "range": {
-      "startLine": 47,
-      "endLine": 52
-    },
+    "range": { "startLine": 58, "endLine": 81 },
     "type": "definition",
-    "title": "The Cardinal ℵ₀",
-    "content": "ℵ₀ (aleph-naught) is countable infinity - the cardinality of ℕ. A countably infinite set can be listed as a₁, a₂, a₃, ... The problem asks for ℵ₀-sized monochromatic cubes.",
-    "significance": "critical"
+    "title": "Colorings and Monochromatic Cubes",
+    "content": "**Three key definitions for the partition problem:**\n\n**TwoColoring X Y Z:** A function from X × Y × Z to Bool, assigning each triple a color (true or false). Think of painting every cell in a 3D grid.\n\n**isMonochromatic:** A sub-cube A₁ × B₁ × C₁ is monochromatic if ALL triples drawn from it receive the same color. Formally: for any two triples (a₁,b₁,c₁) and (a₂,b₂,c₂) with components from the subsets, χ assigns them the same value.\n\n**hasCardAleph0:** A subset S is countably infinite, meaning |S| = ℵ₀. The problem asks for monochromatic cubes of this size.",
+    "mathContext": "The monochromatic condition is quantified over all pairs of elements from each subset, ensuring the coloring is truly constant on the entire cube. This is stronger than just saying 'most' elements have one color — every single triple must agree.",
+    "significance": "critical",
+    "relatedConcepts": ["product coloring", "homogeneous set", "Ramsey property"]
   },
   {
-    "id": "ann-1128-4",
+    "id": "ann-e1128-conjecture",
     "proofId": "erdos-1128",
-    "range": {
-      "startLine": 69,
-      "endLine": 73
-    },
-    "type": "definition",
-    "title": "2-Coloring",
-    "content": "A 2-coloring of A × B × C assigns each triple (a, b, c) a color from {0, 1}. Think of coloring every cell of a 3D grid. The question: must some infinite sub-grid be monochromatic?",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1128-5",
-    "proofId": "erdos-1128",
-    "range": {
-      "startLine": 75,
-      "endLine": 83
-    },
-    "type": "definition",
-    "title": "Monochromatic Cube",
-    "content": "A cube A₁ × B₁ × C₁ is monochromatic if ALL triples (a, b, c) with a ∈ A₁, b ∈ B₁, c ∈ C₁ have the same color. Every point in the sub-cube has one color.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1128-6",
-    "proofId": "erdos-1128",
-    "range": {
-      "startLine": 96,
-      "endLine": 108
-    },
+    "range": { "startLine": 83, "endLine": 95 },
     "type": "theorem",
-    "title": "Erdős-Hajnal Conjecture",
-    "content": "The conjecture: For any 2-coloring of ℵ₁ × ℵ₁ × ℵ₁, there exist countably infinite A₁, B₁, C₁ such that A₁ × B₁ × C₁ is monochromatic. This would be an infinite Ramsey-type result.",
-    "significance": "critical"
+    "title": "The Erdős-Hajnal Conjecture",
+    "content": "**erdos_hajnal_conjecture formalizes the question:**\n\nFor every 2-coloring χ of A × B × C, there exist countably infinite subsets A₁, B₁, C₁ such that A₁ × B₁ × C₁ is monochromatic under χ.\n\nThis is the product version of a Ramsey-type property. In finite combinatorics, the Hales-Jewett theorem and related results guarantee such structures. At uncountable cardinals, Erdős and Hajnal asked whether the property extends — the answer turned out to be no.",
+    "mathContext": "The conjecture is stated as a Prop, not a theorem, because it is false. The existential quantifies over all three subsets simultaneously, requiring them to be jointly monochromatic. This is the key 'cube' structure that distinguishes it from simpler partition problems.",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős-Hajnal", "Ramsey property", "partition relation"]
   },
   {
-    "id": "ann-1128-7",
+    "id": "ann-e1128-disproof",
     "proofId": "erdos-1128",
-    "range": {
-      "startLine": 110,
-      "endLine": 114
-    },
+    "range": { "startLine": 97, "endLine": 122 },
+    "type": "axiom",
+    "title": "Prikry-Mills Disproof and Bad Coloring",
+    "content": "**Two results establishing the negative answer:**\n\n**prikry_mills_disproof (axiom):** ¬erdos_hajnal_conjecture — the conjecture is false. Prikry and Mills (1978) constructed a counterexample using the ordinal structure of ω₁. Their coloring encodes enough ordinal information that any countably infinite cube must intersect both color classes.\n\n**exists_bad_coloring (theorem):** Derived from the disproof via classical logic. The proof unfolds the negation: if no bad coloring existed, then every coloring would have a monochromatic cube, contradicting the disproof. Uses `by_contra` and `push_neg` to convert the double negation.\n\nThe axiom is necessary because the counterexample construction requires ordinal combinatorics (well-orderings of ω₁, stepping-up lemmas) that are beyond current Mathlib formalization.",
+    "mathContext": "The logical derivation is: ¬(∀ χ, ∃ mono cube) ↔ ∃ χ, ∀ cubes, ¬mono. The `push_neg` tactic handles the quantifier negation automatically. This is a clean example of extracting a constructive witness from a classical negation.",
+    "significance": "critical",
+    "relatedConcepts": ["classical logic", "push_neg", "ordinal combinatorics"]
+  },
+  {
+    "id": "ann-e1128-twodim",
+    "proofId": "erdos-1128",
+    "range": { "startLine": 124, "endLine": 138 },
+    "type": "axiom",
+    "title": "Two-Dimensional Analogue",
+    "content": "**two_dim_negative axiom:**\n\nEven the 2D version fails: there exists a 2-coloring of ℵ₁ × ℵ₁ with no countably infinite monochromatic rectangle. In notation: ℵ₁² ↛ (ℵ₀)²₂.\n\nThe 2D proof uses different techniques — typically a stepping-up argument or a Δ-system lemma construction. This shows the failure of cardinal partition properties is not a peculiarity of three dimensions but a general phenomenon at uncountable cardinals.",
+    "mathContext": "The statement quantifies over sets A₁ ⊂ A and B₁ ⊂ B of cardinality ℵ₀, denying that χ is constant on A₁ × B₁. The 2D case is simpler to prove but the 3D case was the original question of Erdős-Hajnal.",
+    "significance": "key",
+    "relatedConcepts": ["stepping-up lemma", "Δ-system", "negative partition relation"]
+  },
+  {
+    "id": "ann-e1128-summary",
+    "proofId": "erdos-1128",
+    "range": { "startLine": 150, "endLine": 177 },
     "type": "theorem",
-    "title": "Prikry-Mills Disproof",
-    "content": "The conjecture is FALSE! Prikry and Mills (1978) found a 2-coloring of ℵ₁ × ℵ₁ × ℵ₁ with NO countably infinite monochromatic cube. The proof was unpublished but later documented.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1128-8",
-    "proofId": "erdos-1128",
-    "range": {
-      "startLine": 120,
-      "endLine": 132
-    },
-    "type": "theorem",
-    "title": "Existence of Bad Coloring",
-    "content": "There exists χ: ℵ₁ × ℵ₁ × ℵ₁ → {0,1} such that for ALL countably infinite A₁, B₁, C₁, the cube A₁ × B₁ × C₁ contains BOTH colors. No escape from mixed colors!",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1128-9",
-    "proofId": "erdos-1128",
-    "range": {
-      "startLine": 134,
-      "endLine": 140
-    },
-    "type": "concept",
-    "title": "Counterexample Construction",
-    "content": "The bad coloring uses ordinal arithmetic. By carefully interleaving colors based on ordinal structure, one ensures ANY ℵ₀ × ℵ₀ × ℵ₀ cube must intersect both color classes.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1128-10",
-    "proofId": "erdos-1128",
-    "range": {
-      "startLine": 142,
-      "endLine": 147
-    },
-    "type": "concept",
-    "title": "Key Idea",
-    "content": "The uncountability of ℵ₁ is essential. With only countably many colors to assign, and uncountably many ordinals to work with, one can encode enough information to break all ℵ₀-cubes.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1128-11",
-    "proofId": "erdos-1128",
-    "range": {
-      "startLine": 153,
-      "endLine": 158
-    },
-    "type": "concept",
-    "title": "Partition Arrow Notation",
-    "content": "κ → (λ)ⁿ means: any 2-coloring of n-element subsets of κ has a homogeneous set of size λ. The product version asks about Cartesian products instead of subsets.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1128-12",
-    "proofId": "erdos-1128",
-    "range": {
-      "startLine": 167,
-      "endLine": 172
-    },
-    "type": "concept",
-    "title": "Problem in Notation",
-    "content": "Is ℵ₁ × ℵ₁ × ℵ₁ → (ℵ₀)³₂ true? NO! The Prikry-Mills result shows ℵ₁³ ↛ (ℵ₀)³₂ - the negative arrow means the partition property FAILS.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1128-13",
-    "proofId": "erdos-1128",
-    "range": {
-      "startLine": 174,
-      "endLine": 179
-    },
-    "type": "concept",
-    "title": "Two-Dimensional Case",
-    "content": "Even ℵ₁ × ℵ₁ → (ℵ₀)²₂ is false. The 2D version also fails, though by a different construction. Infinite-dimensional Ramsey theory is full of negative results.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1128-14",
-    "proofId": "erdos-1128",
-    "range": {
-      "startLine": 185,
-      "endLine": 190
-    },
-    "type": "concept",
-    "title": "Finite Case Works",
-    "content": "For FINITE cardinals, the analogous statements ARE true! This is classical Ramsey theory. The infinite case is fundamentally different - uncountability creates counterexamples.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1128-15",
-    "proofId": "erdos-1128",
-    "range": {
-      "startLine": 192,
-      "endLine": 197
-    },
-    "type": "concept",
-    "title": "Countable Case",
-    "content": "ℵ₀ × ℵ₀ × ℵ₀ → (n)³₂ is true for any finite n. Countable products have finite monochromatic cubes. But not countably infinite ones - that also fails.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-1128-16",
-    "proofId": "erdos-1128",
-    "range": {
-      "startLine": 224,
-      "endLine": 229
-    },
-    "type": "concept",
-    "title": "Todorčević's Work",
-    "content": "Todorčević [To94] systematically studied partitions of 3D combinatorial cubes. His work documented the Prikry-Mills result and explored many related problems.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-1128-17",
-    "proofId": "erdos-1128",
-    "range": {
-      "startLine": 242,
-      "endLine": 247
-    },
-    "type": "concept",
-    "title": "Unpublished History",
-    "content": "Prikry and Mills found the counterexample in 1978 but never formally published it. The result was preserved through citations by Todorčević and Komjáth. Mathematics survives through community knowledge.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-1128-18",
-    "proofId": "erdos-1128",
-    "range": {
-      "startLine": 259,
-      "endLine": 283
-    },
-    "type": "theorem",
-    "title": "Final Status",
-    "content": "erdos_1128_status: The Erdős-Hajnal conjecture is FALSE. There exists a 2-coloring of ℵ₁³ with no ℵ₀³ monochromatic cube. A fundamental negative result in infinite Ramsey theory.",
-    "significance": "critical"
+    "title": "Summary Theorem",
+    "content": "**erdos_1128_summary combines two results into a conjunction:**\n\n1. **The conjecture is false:** ¬erdos_hajnal_conjecture, directly from prikry_mills_disproof\n2. **A bad coloring exists:** ∃ χ such that no ℵ₀-cube is monochromatic, from exists_bad_coloring\n\nThe proof is the simple pair ⟨prikry_mills_disproof, exists_bad_coloring⟩.\n\nErdős Problem #1128 is completely RESOLVED. The answer is NO, with Erdős's $50 prize awarded for this negative result. The problem stands as a landmark in infinite Ramsey theory, showing that uncountable partition calculus is fundamentally different from its finite counterpart.",
+    "mathContext": "The summary packages both the abstract negation and the concrete existential into a single result. This is the standard pattern for 'disproved' Erdős problems: state both the negation and its constructive interpretation.",
+    "significance": "critical",
+    "relatedConcepts": ["conjunction", "summary theorem", "problem resolution"]
   }
 ]

--- a/src/data/proofs/erdos-1128/meta.json
+++ b/src/data/proofs/erdos-1128/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-1128",
   "title": "Erdős Problem #1128: Monochromatic Cubes in Cardinal Products",
   "slug": "erdos-1128",
-  "description": "Let A, B, C have cardinality ℵ₁. Must any 2-coloring of A × B × C contain a countably infinite monochromatic cube A₁ × B₁ × C₁? DISPROVED by Prikry-Mills (1978): NO, such colorings exist with no ℵ₀ × ℵ₀ × ℵ₀ monochromatic cube.",
+  "description": "Must every 2-coloring of ℵ₁ × ℵ₁ × ℵ₁ contain a countably infinite monochromatic cube? NO — disproved by Prikry-Mills (1978).",
   "meta": {
-    "author": "Erdős, Hajnal, Prikry, Mills",
+    "author": "Prikry-Mills (1978 disproof), Erdős-Hajnal (problem)",
     "sourceUrl": "https://erdosproblems.com/1128",
     "date": "1978",
     "status": "complete",
@@ -22,107 +22,111 @@
     "erdosUrl": "https://erdosproblems.com/1128",
     "erdosProblemStatus": "disproved",
     "erdosPrizeValue": "$50",
+    "mathlib_version": "4.15.0",
     "mathlibDependencies": [
       {
-        "theorem": "Cardinal.Basic",
-        "description": "Cardinal arithmetic",
+        "theorem": "Cardinal.aleph",
+        "description": "The aleph function mapping ordinals to infinite cardinals",
+        "module": "Mathlib.SetTheory.Cardinal.Ordinal"
+      },
+      {
+        "theorem": "Cardinal.mk",
+        "description": "Cardinality of a type as a cardinal number",
         "module": "Mathlib.SetTheory.Cardinal.Basic"
       },
       {
-        "theorem": "Set.Basic",
-        "description": "Basic set operations",
+        "theorem": "Cardinal.aleph0",
+        "description": "The cardinal ℵ₀ = |ℕ|",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Set",
+        "description": "Basic set operations and membership",
         "module": "Mathlib.Data.Set.Basic"
       }
     ],
     "originalContributions": [
-      "aleph_1 axiom: declaration of ℵ₁ cardinal",
-      "aleph_0 definition: ℵ₀ = Cardinal.omega",
-      "TwoColoring definition: A × B × C → Bool",
-      "isMonochromatic definition: constant coloring on a cube",
-      "hasCardinalityAleph0 definition: countably infinite subset",
-      "erdos_hajnal_conjecture definition: the partition property statement",
-      "prikry_mills_disproof axiom: the conjecture is FALSE",
-      "exists_bad_coloring theorem: derived from disproof",
-      "erdos_1128_status theorem: complete problem status"
+      "TwoColoring definition for product colorings",
+      "isMonochromatic definition for sub-cubes",
+      "hasCardAleph0 predicate for countably infinite subsets",
+      "erdos_hajnal_conjecture formalization",
+      "prikry_mills_disproof axiom",
+      "exists_bad_coloring theorem derived from disproof",
+      "two_dim_negative axiom for ℵ₁² ↛ (ℵ₀)²₂",
+      "erdos_1128_summary combining disproof and bad coloring existence"
     ]
   },
   "overview": {
-    "historicalContext": "A problem of Erdős and Hajnal in partition calculus, asking whether the cardinal Ramsey property ℵ₁³ → (ℵ₀)³₂ holds. Prikry and Mills disproved it in 1978 with a counterexample, though their proof remained unpublished. The result was later documented by Todorčević (1994) and Komjáth (2025).",
-    "problemStatement": "Let A, B, C be three sets of cardinality ℵ₁. Is it true that in any 2-coloring of A × B × C, there must exist A₁ ⊂ A, B₁ ⊂ B, C₁ ⊂ C, all of cardinality ℵ₀, such that A₁ × B₁ × C₁ is monochromatic?",
-    "proofStrategy": "The formalization defines the cardinal setup, the coloring problem, and the monochromatic cube condition. The Prikry-Mills counterexample is stated as an axiom, showing that a 'bad' coloring exists that avoids all countably infinite monochromatic cubes.",
+    "historicalContext": "This problem was posed by Erdős and Hajnal as part of their extensive program in infinite combinatorics and partition calculus. It asks whether the cardinal Ramsey property ℵ₁³ → (ℵ₀)³₂ holds: must every 2-coloring of the product of three sets of cardinality ℵ₁ contain a countably infinite monochromatic sub-cube?\n\nPrikry and Mills disproved the conjecture in 1978 by constructing a 2-coloring of ω₁ × ω₁ × ω₁ such that no countably infinite monochromatic cube exists. Their proof exploits the ordinal structure of ω₁ to encode enough information that any ℵ₀-cube must contain both colors. The result was never formally published but was preserved through Todorčević's systematic study of partition relations [To94] and later by Komjáth in the Erdős-Hajnal Problem List [Ko25b].\n\nThe problem illustrates a striking contrast between finite and infinite Ramsey theory. In the finite case, analogous results hold by classical Ramsey theory. But at the level of uncountable cardinals, the combinatorial landscape changes fundamentally — the gap between ℵ₀ and ℵ₁ allows constructions that defeat all countable sub-structures.",
+    "problemStatement": "Let $A$, $B$, $C$ be three sets of cardinality $\\aleph_1$. Is it true that in any 2-coloring of $A \\times B \\times C$, there must exist $A_1 \\subset A$, $B_1 \\subset B$, $C_1 \\subset C$, all of cardinality $\\aleph_0$, such that $A_1 \\times B_1 \\times C_1$ is monochromatic?\n\n**Answer:** NO.\n\n**Theorem (Prikry-Mills, 1978):** $\\aleph_1^3 \\not\\to (\\aleph_0)^3_2$. There exists a 2-coloring of $\\aleph_1 \\times \\aleph_1 \\times \\aleph_1$ with no countably infinite monochromatic cube.\n\n**Prize:** $50",
+    "proofStrategy": "We formalize the partition problem using Mathlib's cardinal arithmetic. The sets A, B, C are axiomatized as types with Cardinal.mk equal to Cardinal.aleph 1. The 2-coloring and monochromatic cube conditions are defined directly.\n\nThe Prikry-Mills disproof is axiomatized as ¬erdos_hajnal_conjecture, since the counterexample construction uses ordinal combinatorics (well-orderings of ω₁, stepping-up lemmas) not yet available in Mathlib. From this axiom we derive the existence of a bad coloring via classical logic (by_contra + push_neg).\n\nWe also axiomatize the 2D analogue ℵ₁² ↛ (ℵ₀)²₂ to show this failure extends across dimensions.",
     "keyInsights": [
-      "The uncountability of ℵ₁ allows construction of 'bad' colorings",
-      "The counterexample uses ordinal structure to encode information",
-      "In partition notation: ℵ₁³ ↛ (ℵ₀)³₂",
-      "Finite Ramsey theory analogues hold, but infinite versions fail",
-      "The 2-dimensional case ℵ₁² ↛ (ℵ₀)²₂ also fails"
+      "**Partition Calculus Notation:** ℵ₁³ → (ℵ₀)³₂ asks whether every 2-coloring of the 3D product has a countably infinite monochromatic cube. The answer is NO.",
+      "**Ordinal Structure:** The counterexample exploits the well-ordering of ω₁ to encode information that breaks all ℵ₀-cubes. Uncountability is essential.",
+      "**Finite vs. Infinite:** Classical Ramsey theory guarantees finite monochromatic structures. At uncountable cardinals, these guarantees collapse.",
+      "**Dimensional Failure:** Even the 2D case ℵ₁² ↛ (ℵ₀)²₂ fails — the negative result is not specific to three dimensions.",
+      "**Unpublished Mathematics:** The Prikry-Mills proof was never formally published but survived through the mathematical community's collective knowledge, documented by Todorčević and Komjáth."
     ]
   },
   "sections": [
     {
-      "id": "section-1",
-      "title": "Cardinal Definitions",
-      "startLine": 36,
-      "endLine": 64,
-      "summary": "Defines the cardinals ℵ₀ and ℵ₁, and the three sets A, B, C of cardinality ℵ₁."
+      "id": "cardinal-setup",
+      "title": "Cardinal Setup",
+      "summary": "Defines ℵ₁ and ℵ₀ using Mathlib's Cardinal.aleph, axiomatizes types A, B, C of cardinality ℵ₁.",
+      "startLine": 33,
+      "endLine": 56
     },
     {
-      "id": "section-2",
-      "title": "The Coloring Problem",
-      "startLine": 65,
-      "endLine": 91,
-      "summary": "Defines 2-colorings of A × B × C, monochromatic cubes, and countably infinite subsets."
+      "id": "colorings-cubes",
+      "title": "Colorings and Monochromatic Cubes",
+      "summary": "Defines TwoColoring, isMonochromatic, and hasCardAleph0 predicates.",
+      "startLine": 58,
+      "endLine": 81
     },
     {
-      "id": "section-3",
-      "title": "The Conjecture (Disproved)",
-      "startLine": 92,
-      "endLine": 115,
-      "summary": "States the Erdős-Hajnal conjecture and the Prikry-Mills disproof: the conjecture is FALSE."
+      "id": "conjecture",
+      "title": "The Erdős-Hajnal Conjecture",
+      "summary": "Formalizes the partition property ℵ₁³ → (ℵ₀)³₂ as erdos_hajnal_conjecture.",
+      "startLine": 83,
+      "endLine": 95
     },
     {
-      "id": "section-4",
-      "title": "The Counterexample",
-      "startLine": 116,
-      "endLine": 148,
-      "summary": "Shows the existence of a bad coloring and sketches the construction idea using ordinal structure."
+      "id": "disproof",
+      "title": "Prikry-Mills Disproof",
+      "summary": "The axiomatized disproof and derived existence of a bad coloring.",
+      "startLine": 97,
+      "endLine": 122
     },
     {
-      "id": "section-5",
-      "title": "Context in Partition Calculus",
-      "startLine": 149,
-      "endLine": 180,
-      "summary": "Places the problem in partition calculus: the arrow notation, product versions, and comparisons with the 2-dimensional case."
+      "id": "two-dim",
+      "title": "Two-Dimensional Analogue",
+      "summary": "The 2D negative result ℵ₁² ↛ (ℵ₀)²₂ axiomatized for comparison.",
+      "startLine": 124,
+      "endLine": 138
     },
     {
-      "id": "section-6",
-      "title": "Positive Results",
-      "startLine": 181,
-      "endLine": 205,
-      "summary": "Contrasts with positive results: finite case works, countable case works for finite targets, and some large cardinal results."
+      "id": "main-theorem",
+      "title": "Main Theorem",
+      "summary": "erdos_1128: the Erdős-Hajnal conjecture is false.",
+      "startLine": 140,
+      "endLine": 148
     },
     {
-      "id": "section-7",
-      "title": "Related Problems",
-      "startLine": 206,
-      "endLine": 230,
-      "summary": "Connections to Erdős-Rado theorem, negative partition relations, and Todorčević's systematic study."
-    },
-    {
-      "id": "section-8",
-      "title": "Summary and Status",
-      "startLine": 231,
-      "endLine": 290,
-      "summary": "Complete summary of the disproof, the main theorem showing the conjecture is false, and historical context."
+      "id": "summary",
+      "title": "Summary",
+      "summary": "erdos_1128_summary combining the disproof and bad coloring existence.",
+      "startLine": 150,
+      "endLine": 177
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1128 was DISPROVED by Prikry and Mills in 1978. The answer is NO: there exists a 2-coloring of ℵ₁ × ℵ₁ × ℵ₁ with no countably infinite monochromatic cube.",
-    "implications": "This negative result shows that infinite-dimensional Ramsey theory behaves very differently from the finite case. The uncountability of ℵ₁ allows encoding too much information for any ℵ₀ × ℵ₀ × ℵ₀ cube to be monochromatic.",
+    "summary": "Erdős Problem #1128 was DISPROVED by Prikry and Mills in 1978. The partition property ℵ₁³ → (ℵ₀)³₂ fails: there exists a 2-coloring of ℵ₁ × ℵ₁ × ℵ₁ with no countably infinite monochromatic cube.",
+    "implications": "This negative result demonstrates a fundamental boundary of infinite Ramsey theory. While finite combinatorics guarantees monochromatic structures, the jump to uncountable cardinals allows colorings that defeat all countable sub-cubes. The failure extends to lower dimensions (2D) and motivates the study of which cardinal partition relations do hold — a central theme in set-theoretic combinatorics.",
     "openQuestions": [
-      "What is the minimum cardinality κ such that κ³ → (ℵ₀)³₂?",
-      "Do large cardinal axioms affect these partition relations?",
-      "What about other dimensions (4D, 5D, etc.)?"
+      "What is the minimum cardinality κ such that κ³ → (ℵ₀)³₂ holds (if any)?",
+      "Do large cardinal axioms (e.g., measurable cardinals) recover positive partition relations?",
+      "What about higher-dimensional analogues (4D, 5D products)?",
+      "Can the counterexample be made explicit or canonical?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Removed 15+ trivial `True` axioms and `True := trivial` theorem
- Replaced ad hoc `axiom aleph_1 : Cardinal` with `Cardinal.aleph 1` from Mathlib
- Converted `/-` section headers to `/-!` doc comments
- Removed unused `Mathlib.Data.Nat.Basic` import
- Added `two_dim_negative` axiom for ℵ₁² ↛ (ℵ₀)²₂
- Rewrote meta.json with 3-paragraph historicalContext
- Rewrote annotations.json with 7 substantive annotations

## Checklist
- [x] Lean proof compiles (pnpm build succeeds)
- [x] No trivial True axioms
- [x] No sorry proofs
- [x] Annotations align with Lean file line numbers
- [x] meta.json sections match actual file

🤖 Generated by enhancer-2