### PR TITLE
Enhance Erdős #1054: Remove trivial theorem

### DIFF
--- a/proofs/Proofs/Erdos1054Problem.lean
+++ b/proofs/Proofs/Erdos1054Problem.lean
@@ -202,7 +202,6 @@ def erdos_1054_part_iii : Prop :=
 The main Erdős Problem #1054 asks about the relationship between these questions.
 The status is OPEN - the "almost all" version remains unresolved.
 -/
-theorem erdos_1054_is_open : True := trivial
 
 /-!
 ## Tao's Partial Result


### PR DESCRIPTION
## Summary
- Removed `erdos_1054_is_open : True := trivial`

## Checklist
- [x] pnpm build succeeds
- [x] No True := trivial

🤖 Generated by enhancer-2