### PR TITLE
Enhance Erdős #395: Reverse Littlewood-Offord Problem

### DIFF
--- a/proofs/Proofs/Erdos395Problem.lean
+++ b/proofs/Proofs/Erdos395Problem.lean
@@ -99,12 +99,14 @@ def carnielli_carolino_counterexample (n : ℕ) (hn : Even n) (hn2 : n ≥ 2) :
     Fin n → ℂ :=
   fun i => if i.val = 0 then 1 else Complex.I
 
-/-- The counterexample always has |sum| ≥ √2. -/
+/-- The counterexample always has |sum| ≥ √2.
+Axiomatized because verifying this requires complex norm estimates. -/
 axiom counterexample_always_large (n : ℕ) (hn : Even n) (hn2 : n ≥ 2)
     (ε : Fin n → ℤ) (hε : isSignVector ε) :
     signedSumAbs (carnielli_carolino_counterexample n hn hn2) ε ≥ Real.sqrt 2
 
-/-- Erdős's original question is FALSE. -/
+/-- Erdős's original question is FALSE.
+Axiomatized: Carnielli-Carolino (2011) showed the counterexample works. -/
 axiom erdos_original_is_false :
   ∃ n : ℕ, n > 0 ∧ ¬erdos_original_question n
 
@@ -123,7 +125,9 @@ def erdos_395_question (n : ℕ) : Prop :=
 
 /-- He-Juškevičius-Narayanan-Spiro (2024):
     For any unit vectors z₁, ..., zₙ, the probability that
-    |ε₁z₁ + ... + εₙzₙ| ≤ √2 is at least c/n for some c > 0. -/
+    |ε₁z₁ + ... + εₙzₙ| ≤ √2 is at least c/n for some c > 0.
+    Axiomatized because the proof uses Fourier analysis on the
+    hypercube and concentration inequalities. -/
 axiom hjns_2024 :
   ∃ (c : ℝ), c > 0 ∧
   ∀ (n : ℕ), n > 0 →
@@ -144,64 +148,15 @@ theorem erdos_395_solved (n : ℕ) : erdos_395_question n := by
 def extremal_example (n : ℕ) : Fin n → ℂ :=
   fun i => if i.val < n / 2 then 1 else Complex.I
 
-/-- The extremal example has probability exactly Θ(1/n). -/
+/-- The extremal example has probability exactly Θ(1/n).
+Axiomatized because the precise computation requires CLT-type arguments. -/
 axiom extremal_example_tight (n : ℕ) (hn : n ≥ 4) :
   ∃ (c C : ℝ), c > 0 ∧ C > 0 ∧
   c / n ≤ probSmallSum (extremal_example n) ∧
   probSmallSum (extremal_example n) ≤ C / n
 
-/-- The 1/n bound is optimal (cannot be improved to 1/n^α for α < 1). -/
-theorem bound_is_optimal :
-  -- The 1/n rate is achieved by the extremal example
-  -- No faster rate (like 1/√n) is possible
-  True := trivial
-
 /-!
-## Part VI: Connection to Littlewood-Offord
--/
-
-/-- The classical Littlewood-Offord problem (1943):
-    For any unit vectors, at most (n choose ⌊n/2⌋) / 2^n sign choices
-    give any fixed value. -/
-theorem littlewood_offord_classical :
-    -- At most about 1/√n fraction of sign choices hit any fixed sum
-    True := trivial
-
-/-- The "reverse" direction:
-    At LEAST Ω(1/n) fraction hit the ball of radius √2 around 0. -/
-theorem reverse_direction :
-    -- This is what Erdős 395 asks about
-    True := trivial
-
-/-- Why √2 is the right threshold:
-    The extremal configuration has real and imaginary parts balanced,
-    so the minimum possible |sum| is √2 in the worst case. -/
-theorem why_sqrt_2 :
-    -- For z₁ = 1, zₖ = i (k ≥ 2, n even), every sum has |sum| ≥ √2
-    -- So threshold < √2 can have probability 0
-    -- Threshold √2 always has probability ≥ c/n
-    True := trivial
-
-/-!
-## Part VII: Proof Technique Context
--/
-
-/-- The HJNS proof uses probabilistic and analytic methods. -/
-theorem hjns_proof_technique :
-    -- Key ideas from the proof:
-    -- 1. Fourier analysis on the hypercube
-    -- 2. Concentration inequalities
-    -- 3. Careful analysis of the geometry of unit vector sums
-    True := trivial
-
-/-- Connection to anticoncentration inequalities. -/
-theorem anticoncentration_connection :
-    -- Littlewood-Offord is an anticoncentration result (upper bound)
-    -- Erdős 395 asks for a complementary lower bound
-    True := trivial
-
-/-!
-## Part VIII: Summary
+## Part VI: Summary
 
 **Erdős Problem #395 - SOLVED (HJNS 2024)**
 
@@ -219,7 +174,8 @@ ANSWER: YES (He-Juškevičius-Narayanan-Spiro 2024)
 3. This is a "reverse Littlewood-Offord" problem
 -/
 
-/-- Summary: Erdős #395 was solved affirmatively. -/
+/-- Summary: Erdős #395 was solved affirmatively.
+Combines the HJNS theorem giving the c/n lower bound. -/
 theorem erdos_395_summary :
     ∃ (c : ℝ), c > 0 ∧
     ∀ (n : ℕ), n > 0 →
@@ -227,7 +183,13 @@ theorem erdos_395_summary :
     probSmallSum z ≥ c / n :=
   hjns_2024
 
-/-- The problem was completely resolved. -/
-theorem erdos_395_resolved : True := trivial
+/-- Complete resolution: the original question is false but the revised is true. -/
+theorem erdos_395 :
+    (∃ n : ℕ, n > 0 ∧ ¬erdos_original_question n) ∧
+    (∃ (c : ℝ), c > 0 ∧
+      ∀ (n : ℕ), n > 0 →
+      ∀ (z : Fin n → ℂ), isUnitVector z →
+      probSmallSum z ≥ c / n) :=
+  ⟨erdos_original_is_false, hjns_2024⟩
 
 end Erdos395

--- a/src/data/proofs/erdos-395/annotations.json
+++ b/src/data/proofs/erdos-395/annotations.json
@@ -5,204 +5,72 @@
     "range": { "startLine": 1, "endLine": 37 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "**Erdős Problem #395**\n\nFor unit complex vectors, is P(|ε₁z₁ + ... + εₙzₙ| ≤ √2) ≥ c/n?\n\n**Status:** SOLVED (HJNS 2024)\n\nThe answer is YES, and the 1/n rate is optimal.",
-    "mathContext": "This is the 'reverse Littlewood-Offord' problem.",
+    "content": "Erdős Problem #395 is the 'reverse Littlewood-Offord problem.' For unit complex vectors z₁, ..., zₙ, is the probability that |ε₁z₁ + ... + εₙzₙ| ≤ √2 (with random signs) at least c/n? Erdős originally asked with threshold 1, but Carnielli-Carolino (2011) showed this fails. The revised question with threshold √2 was proved by He-Juškevičius-Narayanan-Spiro (2024).",
+    "mathContext": "The 'reverse' direction of Littlewood-Offord: a lower bound on concentration near zero, complementing the classical upper bound.",
     "significance": "critical",
-    "relatedConcepts": ["Littlewood-Offord", "Random signs", "Unit vectors"]
+    "relatedConcepts": ["Littlewood-Offord", "Random signs", "Unit vectors", "Anticoncentration"]
   },
   {
-    "id": "ann-395-unitvec",
+    "id": "ann-395-definitions",
     "proofId": "erdos-395",
-    "range": { "startLine": 54, "endLine": 56 },
+    "range": { "startLine": 48, "endLine": 68 },
     "type": "definition",
-    "title": "Unit Vector",
-    "content": "**isUnitVector z:**\n\n∀i: |zᵢ| = 1.\n\nThe vectors lie on the complex unit circle.",
-    "significance": "key",
-    "relatedConcepts": ["Unit circle", "Complex numbers"]
-  },
-  {
-    "id": "ann-395-signvec",
-    "proofId": "erdos-395",
-    "range": { "startLine": 58, "endLine": 60 },
-    "type": "definition",
-    "title": "Sign Vector",
-    "content": "**isSignVector ε:**\n\n∀i: εᵢ ∈ {-1, 1}.\n\nThese are the random choices (uniformly distributed).",
-    "significance": "key",
-    "relatedConcepts": ["Rademacher", "Random sign", "Hypercube"]
-  },
-  {
-    "id": "ann-395-signedsum",
-    "proofId": "erdos-395",
-    "range": { "startLine": 62, "endLine": 64 },
-    "type": "definition",
-    "title": "Signed Sum",
-    "content": "**signedSum z ε:**\n\nε₁z₁ + ... + εₙzₙ.\n\nThe sum of unit vectors with random signs.",
+    "title": "Core Definitions: Unit Vectors, Signs, and Sums",
+    "content": "isUnitVector z: all components lie on the complex unit circle (|zᵢ| = 1). isSignVector ε: each εᵢ ∈ {-1, 1}, representing random Rademacher variables. signedSum z ε = Σ εᵢzᵢ: the random signed combination. signedSumAbs: the magnitude |Σ εᵢzᵢ|, measuring distance from the origin.",
     "significance": "critical",
-    "relatedConcepts": ["Random walk", "Sum of vectors"]
+    "relatedConcepts": ["Unit circle", "Rademacher distribution", "Random walk"]
   },
   {
-    "id": "ann-395-abs",
+    "id": "ann-395-probability",
     "proofId": "erdos-395",
-    "range": { "startLine": 66, "endLine": 68 },
+    "range": { "startLine": 70, "endLine": 82 },
     "type": "definition",
-    "title": "Signed Sum Absolute Value",
-    "content": "**signedSumAbs z ε:**\n\n|ε₁z₁ + ... + εₙzₙ|.\n\nThe magnitude of the random walk endpoint.",
-    "significance": "key",
-    "relatedConcepts": ["Absolute value", "Distance from origin"]
-  },
-  {
-    "id": "ann-395-count",
-    "proofId": "erdos-395",
-    "range": { "startLine": 76, "endLine": 78 },
-    "type": "definition",
-    "title": "Count Small Sums",
-    "content": "**countSmallSums z:**\n\nThe number of sign vectors ε such that |signedSum z ε| ≤ √2.\n\nOut of 2^n total sign choices.",
-    "significance": "key",
-    "relatedConcepts": ["Counting", "Threshold √2"]
-  },
-  {
-    "id": "ann-395-prob",
-    "proofId": "erdos-395",
-    "range": { "startLine": 80, "endLine": 82 },
-    "type": "definition",
-    "title": "Probability",
-    "content": "**probSmallSum z:**\n\nP(|signedSum| ≤ √2) = countSmallSums / 2^n.\n\nThe main quantity of interest.",
+    "title": "Probability of Small Sums",
+    "content": "countSmallSums z: the number of sign vectors ε with |Σ εᵢzᵢ| ≤ √2, out of 2ⁿ total. probSmallSum z = countSmallSums / 2ⁿ: the probability under uniform random signs. The central question is whether this probability is always at least c/n for unit vectors.",
     "significance": "critical",
-    "relatedConcepts": ["Probability", "Uniform distribution"]
+    "relatedConcepts": ["Probability", "Uniform distribution", "Counting"]
   },
   {
-    "id": "ann-395-original",
+    "id": "ann-395-counterexample",
     "proofId": "erdos-395",
-    "range": { "startLine": 88, "endLine": 94 },
-    "type": "definition",
-    "title": "Original Question (FALSE)",
-    "content": "**erdos_original_question:**\n\nIs P(|sum| ≤ 1) ≥ c/n for unit vectors?\n\nThis was Erdős's original question, but it's FALSE.",
-    "mathContext": "Carnielli-Carolino (2011) found a counterexample.",
-    "significance": "key",
-    "relatedConcepts": ["Original formulation", "Threshold 1"]
-  },
-  {
-    "id": "ann-395-counterex",
-    "proofId": "erdos-395",
-    "range": { "startLine": 96, "endLine": 105 },
+    "range": { "startLine": 84, "endLine": 111 },
     "type": "axiom",
-    "title": "Counterexample",
-    "content": "**carnielli_carolino_counterexample, counterexample_always_large:**\n\nTake z₁ = 1, zₖ = i for k ≥ 2 (n even).\n\nEvery signed sum has |sum| ≥ √2.\n\nSo P(|sum| ≤ 1) = 0.",
-    "mathContext": "This disproves the original threshold-1 question.",
+    "title": "Original Question is FALSE (Carnielli-Carolino 2011)",
+    "content": "erdos_original_question: Erdős's original formulation with threshold 1 instead of √2. carnielli_carolino_counterexample: z₁ = 1, zₖ = i for k ≥ 2 (n even). counterexample_always_large: for this configuration, |sum| ≥ √2 always — the real and imaginary parts each contribute at least 1, so the total magnitude is at least √2. erdos_original_is_false: the original threshold-1 question has a negative answer.",
+    "mathContext": "The counterexample splits into independent real and imaginary parts: the real part is ±1 (from z₁) and the imaginary part sums n-1 copies of ±i, but the total is always at least √(1² + 1²) = √2.",
     "significance": "critical",
-    "relatedConcepts": ["Counterexample", "Real-imaginary split"]
-  },
-  {
-    "id": "ann-395-false",
-    "proofId": "erdos-395",
-    "range": { "startLine": 107, "endLine": 109 },
-    "type": "axiom",
-    "title": "Original is False",
-    "content": "**erdos_original_is_false:**\n\nThe original question (threshold 1) is FALSE.\n\nThis led to the revised question with threshold √2.",
-    "significance": "key",
-    "relatedConcepts": ["Disproof", "Revision"]
-  },
-  {
-    "id": "ann-395-revised",
-    "proofId": "erdos-395",
-    "range": { "startLine": 117, "endLine": 122 },
-    "type": "definition",
-    "title": "Revised Question (TRUE)",
-    "content": "**erdos_395_question:**\n\nIs P(|sum| ≤ √2) ≥ c/n for unit vectors?\n\nThis is the correct formulation, and the answer is YES.",
-    "significance": "critical",
-    "relatedConcepts": ["Revised question", "Threshold √2"]
+    "relatedConcepts": ["Counterexample", "Complex geometry", "Threshold"]
   },
   {
     "id": "ann-395-hjns",
     "proofId": "erdos-395",
-    "range": { "startLine": 124, "endLine": 131 },
+    "range": { "startLine": 113, "endLine": 141 },
     "type": "axiom",
-    "title": "HJNS 2024 Theorem",
-    "content": "**hjns_2024:**\n\n∃c > 0: ∀n, ∀ unit vectors z₁,...,zₙ:\n\nP(|ε₁z₁ + ... + εₙzₙ| ≤ √2) ≥ c/n.\n\nThis is the main result resolving Erdős #395.",
-    "mathContext": "He-Juškevičius-Narayanan-Spiro, arXiv:2408.11034 (2024).",
+    "title": "HJNS 2024: Revised Question is TRUE",
+    "content": "erdos_395_question: the revised formulation with threshold √2. hjns_2024 (axiom): ∃ c > 0 such that for all n > 0 and all unit vectors z, probSmallSum z ≥ c/n. This is the main result of He-Juškevičius-Narayanan-Spiro (2024), axiomatized because the proof requires Fourier analysis on the Boolean hypercube and concentration inequalities. erdos_395_solved: derives the answer for each fixed n from the universal axiom.",
+    "mathContext": "arXiv:2408.11034. The proof technique uses Fourier analysis on {-1,1}ⁿ to analyze the distribution of signed sums.",
     "significance": "critical",
-    "relatedConcepts": ["HJNS 2024", "Main theorem"]
+    "relatedConcepts": ["HJNS 2024", "Fourier analysis", "Concentration inequalities"]
   },
   {
-    "id": "ann-395-solved",
+    "id": "ann-395-optimality",
     "proofId": "erdos-395",
-    "range": { "startLine": 133, "endLine": 137 },
-    "type": "theorem",
-    "title": "Problem Solved",
-    "content": "**erdos_395_solved:**\n\nThe revised question is TRUE.\n\nFollows directly from hjns_2024.",
-    "significance": "key",
-    "relatedConcepts": ["Solved", "Affirmative"]
-  },
-  {
-    "id": "ann-395-extremal",
-    "proofId": "erdos-395",
-    "range": { "startLine": 143, "endLine": 151 },
+    "range": { "startLine": 143, "endLine": 156 },
     "type": "axiom",
-    "title": "Extremal Example",
-    "content": "**extremal_example, extremal_example_tight:**\n\nzₖ = 1 for k ≤ n/2, zₖ = i otherwise.\n\nThis achieves probability exactly Θ(1/n).\n\nShows the 1/n rate is optimal.",
-    "mathContext": "Half real, half imaginary is the worst case.",
+    "title": "Optimality: 1/n Rate is Tight",
+    "content": "extremal_example: zₖ = 1 for k ≤ n/2, zₖ = i for k > n/2. This splits the sum into independent real and imaginary parts, each a sum of ±1 with ~n/2 terms. extremal_example_tight (axiom): ∃ c, C > 0 with c/n ≤ probSmallSum ≤ C/n. By CLT, each part is approximately Gaussian with standard deviation ~√(n/2), and landing in a √2-ball requires both parts to be O(1), giving probability Θ(1/n).",
+    "mathContext": "The CLT gives each coordinate as approximately N(0, n/2), so the joint probability of both being O(1) is Θ(1/√n · 1/√n) = Θ(1/n).",
     "significance": "key",
-    "relatedConcepts": ["Extremal", "Optimality", "Tight bound"]
-  },
-  {
-    "id": "ann-395-optimal",
-    "proofId": "erdos-395",
-    "range": { "startLine": 153, "endLine": 157 },
-    "type": "theorem",
-    "title": "Optimality",
-    "content": "**bound_is_optimal:**\n\nThe 1/n rate cannot be improved to 1/n^α for any α < 1.\n\nThe extremal example proves this.",
-    "significance": "key",
-    "relatedConcepts": ["Optimal rate", "Lower bound"]
-  },
-  {
-    "id": "ann-395-lo",
-    "proofId": "erdos-395",
-    "range": { "startLine": 163, "endLine": 168 },
-    "type": "theorem",
-    "title": "Classical Littlewood-Offord",
-    "content": "**littlewood_offord_classical:**\n\nAt most ~1/√n fraction of sign choices hit any fixed point.\n\nThis is an UPPER bound (anticoncentration).",
-    "mathContext": "Littlewood-Offord (1943) - the original direction.",
-    "significance": "supporting",
-    "relatedConcepts": ["Littlewood-Offord", "Anticoncentration"]
-  },
-  {
-    "id": "ann-395-reverse",
-    "proofId": "erdos-395",
-    "range": { "startLine": 170, "endLine": 174 },
-    "type": "theorem",
-    "title": "Reverse Direction",
-    "content": "**reverse_direction:**\n\nAt LEAST Ω(1/n) fraction hit the ball of radius √2 around 0.\n\nThis is a LOWER bound - the 'reverse' direction.",
-    "significance": "key",
-    "relatedConcepts": ["Reverse", "Lower bound", "Ball"]
-  },
-  {
-    "id": "ann-395-why-sqrt2",
-    "proofId": "erdos-395",
-    "range": { "startLine": 176, "endLine": 183 },
-    "type": "theorem",
-    "title": "Why √2",
-    "content": "**why_sqrt_2:**\n\nThe counterexample shows: for z₁=1, zₖ=i (k≥2), |sum| ≥ √2 always.\n\nSo threshold < √2 can have probability 0.\n\n√2 is the critical threshold.",
-    "significance": "key",
-    "relatedConcepts": ["Threshold", "Critical value"]
+    "relatedConcepts": ["Extremal example", "Central Limit Theorem", "Tight bound"]
   },
   {
     "id": "ann-395-summary",
     "proofId": "erdos-395",
-    "range": { "startLine": 222, "endLine": 228 },
+    "range": { "startLine": 158, "endLine": 195 },
     "type": "theorem",
-    "title": "Summary Theorem",
-    "content": "**erdos_395_summary:**\n\n∃c > 0: P(|signedSum| ≤ √2) ≥ c/n for all unit vectors.\n\nThis is the main result of HJNS 2024.",
+    "title": "Complete Resolution of Erdős #395",
+    "content": "erdos_395_summary: restates hjns_2024 directly. erdos_395 (main theorem): combines both directions — erdos_original_is_false (threshold 1 fails) and hjns_2024 (threshold √2 works) — into a single conjunction. This gives the complete picture: the original formulation is false, but the natural revised formulation with the sharp threshold √2 is true with optimal rate 1/n.",
     "significance": "critical",
-    "relatedConcepts": ["Main result", "Summary"]
-  },
-  {
-    "id": "ann-395-resolved",
-    "proofId": "erdos-395",
-    "range": { "startLine": 230, "endLine": 231 },
-    "type": "theorem",
-    "title": "Problem Resolved",
-    "content": "**erdos_395_resolved:**\n\nErdős Problem #395 was completely resolved by HJNS in 2024.",
-    "significance": "supporting",
-    "relatedConcepts": ["Resolved", "2024"]
+    "relatedConcepts": ["Summary", "Complete resolution", "Sharp threshold"]
   }
 ]

--- a/src/data/proofs/erdos-395/meta.json
+++ b/src/data/proofs/erdos-395/meta.json
@@ -55,7 +55,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #395**\n\nThis is the \"reverse Littlewood-Offord problem.\"\n\n**History:**\n- Erdős originally asked with threshold 1 instead of √2\n- Carnielli and Carolino (2011) found a counterexample showing threshold 1 fails\n- The revised problem (threshold √2) became the true question\n- He, Juškevičius, Narayanan, and Spiro (2024) proved YES\n\n**Context:**\n- Classical Littlewood-Offord (1943): upper bound on how often sums hit a point\n- This problem asks for a lower bound on how often sums stay near 0\n- The bound 1/n is optimal",
+    "historicalContext": "Erdős Problem #395 concerns the 'reverse Littlewood-Offord problem.' The classical Littlewood-Offord theorem (1943) provides an upper bound on the probability that a random signed sum of vectors lands near any particular target. Erdős turned this around and asked: must a random signed sum of unit complex vectors land near zero with probability at least c/n? He originally posed the question with threshold 1, but Carnielli and Carolino (2011) found a counterexample — taking z₁ = 1 and zₖ = i for k ≥ 2 forces every signed sum to have magnitude at least √2, so no sign choice gives |sum| ≤ 1.\n\nThe revised question, with threshold √2 instead of 1, became the true open problem. He, Juškevičius, Narayanan, and Spiro resolved it affirmatively in 2024, proving that for any unit complex vectors z₁, ..., zₙ, the probability that |ε₁z₁ + ... + εₙzₙ| ≤ √2 (with random signs εᵢ ∈ {-1,1}) is at least c/n for some absolute constant c > 0. Their proof uses Fourier analysis on the Boolean hypercube and concentration inequalities.\n\nThe 1/n bound is optimal: taking half the vectors equal to 1 and half equal to i achieves probability exactly Θ(1/n). The threshold √2 is sharp in the sense that any smaller threshold can yield probability zero. This result completes the picture of Littlewood-Offord type problems by providing the 'reverse' direction — a lower bound on how many sign choices must produce a small sum.",
     "problemStatement": "**Problem Statement (Solved)**\n\nIf z₁, ..., zₙ ∈ ℂ with |zᵢ| = 1, is the probability that\n\n|ε₁z₁ + ... + εₙzₙ| ≤ √2\n\n(where εᵢ ∈ {-1, 1} uniformly at random) at least c/n for some absolute constant c > 0?\n\n**Original (Erdős):** Threshold 1 — FALSE (Carnielli-Carolino 2011)\n\n**Revised:** Threshold √2 — TRUE (HJNS 2024)\n\nThe bound 1/n is optimal.",
     "proofStrategy": "**Formalization Approach**\n\n1. **Complex Vectors:** Use Fin n → ℂ for vectors\n\n2. **Key Definitions:**\n   - isUnitVector: |zᵢ| = 1\n   - signedSum: ε₁z₁ + ... + εₙzₙ\n   - probSmallSum: P(|sum| ≤ √2)\n\n3. **Counterexample:**\n   - carnielli_carolino_counterexample: shows threshold 1 fails\n   - For z₁ = 1, zₖ = i, every sum has |sum| ≥ √2\n\n4. **Main Results:**\n   - hjns_2024: P(|sum| ≤ √2) ≥ c/n for all unit vectors\n   - extremal_example_tight: 1/n rate is optimal\n\n**Why Axioms:** The HJNS proof uses Fourier analysis and concentration inequalities.",
     "keyInsights": [
@@ -70,51 +70,44 @@
     {
       "id": "definitions",
       "title": "Basic Definitions",
-      "summary": "Unit vectors and sign sums",
+      "summary": "Unit vectors, sign vectors, and signed sums",
       "startLine": 48,
       "endLine": 68
     },
     {
       "id": "probability",
-      "title": "Probability Question",
-      "summary": "Counting small sums",
+      "title": "The Probability Question",
+      "summary": "Counting and probability of small sums",
       "startLine": 70,
       "endLine": 82
     },
     {
       "id": "original-false",
       "title": "Original Question (False)",
-      "summary": "Threshold 1 counterexample",
+      "summary": "Carnielli-Carolino counterexample refuting threshold 1",
       "startLine": 84,
-      "endLine": 109
+      "endLine": 111
     },
     {
       "id": "revised-true",
       "title": "Revised Question (True)",
-      "summary": "HJNS 2024 theorem",
-      "startLine": 111,
-      "endLine": 137
+      "summary": "HJNS 2024 theorem with threshold √2",
+      "startLine": 113,
+      "endLine": 141
     },
     {
       "id": "optimality",
-      "title": "Optimality",
-      "summary": "1/n rate is tight",
-      "startLine": 139,
-      "endLine": 157
-    },
-    {
-      "id": "littlewood-offord",
-      "title": "Littlewood-Offord Connection",
-      "summary": "Classical vs reverse",
-      "startLine": 159,
-      "endLine": 201
+      "title": "Optimality of 1/n Bound",
+      "summary": "Extremal example achieving Θ(1/n)",
+      "startLine": 143,
+      "endLine": 156
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Main result and resolution",
-      "startLine": 203,
-      "endLine": 231
+      "summary": "Combined resolution: original false, revised true",
+      "startLine": 158,
+      "endLine": 195
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Removed 7 `True := trivial` theorems from Lean file (quality issues)
- Added proper `erdos_395` summary theorem using `exact ⟨erdos_original_is_false, hjns_2024⟩`
- Updated meta.json with 3-paragraph historicalContext and correct section line numbers
- Rewrote annotations.json with 7 substantive annotations matching rewritten Lean file (196 lines)

## Test plan
- [x] `pnpm build` passes
- [x] No `sorry` or `True := trivial` remaining
- [x] Annotations align with Lean file line numbers
- [x] meta.json sections match actual file structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)