### PR TITLE
fix(erdos-967): remove True := trivial theorem

### DIFF
--- a/proofs/Proofs/Erdos967Problem.lean
+++ b/proofs/Proofs/Erdos967Problem.lean
@@ -201,12 +201,11 @@ axiom sum_positive_at_zero (a : IntegerSequence) (ha : hasConvergentReciprocalSu
   -- At t = 0, all terms are positive real numbers (1/aₖ > 0)
   -- So the sum equals 1 + ∑ₖ 1/aₖ > 1, which is nonzero
 
-/--
+/-!
 **Oscillatory Behavior:**
 For large |t|, the terms 1/aₖ^(1+it) = (1/aₖ) · e^(-it·log(aₖ)) oscillate rapidly.
 This oscillation is what allows zeros to exist for appropriate sequences.
 -/
-theorem oscillatory_behavior : True := trivial
 
 /--
 **Example: The Geometric Sequence {2^n}:**

--- a/src/data/proofs/erdos-967/annotations.json
+++ b/src/data/proofs/erdos-967/annotations.json
@@ -174,7 +174,7 @@
   {
     "id": "ann-e967-oscillation",
     "proofId": "erdos-967",
-    "range": { "startLine": 204, "endLine": 209 },
+    "range": { "startLine": 204, "endLine": 208 },
     "type": "concept",
     "title": "Oscillatory Behavior",
     "content": "**Oscillation for t ≠ 0:**\n\nThe terms 1/aₖ^(1+it) = (1/aₖ)·e^(-it·log(aₖ)) rotate around the origin.\n\nBy choosing aₖ carefully, these oscillating terms can sum to exactly -1, giving a zero.",
@@ -185,7 +185,7 @@
   {
     "id": "ann-e967-geometric",
     "proofId": "erdos-967",
-    "range": { "startLine": 211, "endLine": 226 },
+    "range": { "startLine": 210, "endLine": 225 },
     "type": "definition",
     "title": "Geometric Sequence Example",
     "content": "**geometricSequence = {2, 4, 8, 16, ...}:**\n\nA concrete IntegerSequence where seq(n) = 2^(n+1).\n\nThis sequence has convergent reciprocal sum: ∑(1/2^n) = 1 < ∞.",
@@ -195,7 +195,7 @@
   {
     "id": "ann-e967-pow2-convergent",
     "proofId": "erdos-967",
-    "range": { "startLine": 228, "endLine": 233 },
+    "range": { "startLine": 227, "endLine": 232 },
     "type": "theorem",
     "title": "Powers of 2 Convergent",
     "content": "**Theorem powers_of_2_convergent:**\n\nhasConvergentReciprocalSum geometricSequence\n\nVerifies that {2, 4, 8, ...} satisfies the convergence condition required by the problem.",
@@ -204,7 +204,7 @@
   {
     "id": "ann-e967-summary",
     "proofId": "erdos-967",
-    "range": { "startLine": 246, "endLine": 253 },
+    "range": { "startLine": 245, "endLine": 252 },
     "type": "theorem",
     "title": "Summary Theorem",
     "content": "**Theorem erdos_967_summary:**\n\n1. The Erdős-Ingham conjecture (1964) is FALSE for infinite sequences\n2. Yip (2025) provided counterexamples for every nonzero t\n3. The finite sequence case remains OPEN\n4. The {2,3,5} case connects to the Four Exponentials conjecture",

--- a/src/data/proofs/erdos-967/meta.json
+++ b/src/data/proofs/erdos-967/meta.json
@@ -135,15 +135,15 @@
       "id": "properties",
       "title": "Properties of the Sum",
       "startLine": 190,
-      "endLine": 233,
+      "endLine": 232,
       "summary": "Special case t = 0, oscillatory behavior, and concrete examples.",
       "description": "At t = 0, the sum is real and positive. Includes geometricSequence example {2^n} with proven convergence."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 235,
-      "endLine": 255,
+      "startLine": 234,
+      "endLine": 254,
       "summary": "Main results: conjecture disproved, finite case open.",
       "description": "The 60-year-old conjecture was disproved in 2025. Key questions about finite sequences remain."
     }


### PR DESCRIPTION
## Summary
- Removed `oscillatory_behavior : True := trivial`, replaced with `/-!` doc comment
- Updated meta.json and annotations.json line numbers

## Test plan
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)