### PR TITLE
enhance(erdos-821): fix quality issues

### DIFF
--- a/proofs/Proofs/Erdos821Problem.lean
+++ b/proofs/Proofs/Erdos821Problem.lean
@@ -37,9 +37,7 @@ open Nat Real Filter
 
 namespace Erdos821
 
-/-
-## Part I: Euler's Totient Function
--/
+/-! ## Euler's Totient Function -/
 
 /-- Euler's totient function φ(n). -/
 def phi : ℕ → ℕ := Nat.totient
@@ -57,9 +55,7 @@ noncomputable def preimageCount (n : ℕ) : ℕ :=
 /-- The preimage count is finite for each n. -/
 axiom preimageCount_finite (n : ℕ) : preimageCount n < n^2
 
-/-
-## Part II: Known Results
--/
+/-! ## Known Results -/
 
 /-- **Pillai's Theorem:**
     lim sup g(n) = ∞, i.e., g(n) is unbounded. -/
@@ -77,9 +73,7 @@ noncomputable def erdosConstant1935 : ℝ := 0.1 -- placeholder
 axiom erdos_explicit_bound :
   ∀ N : ℕ, ∃ n ≥ N, (preimageCount n : ℝ) > n^erdosConstant1935
 
-/-
-## Part III: Lichtman's Result (2022)
--/
+/-! ## Lichtman's Result (2022) -/
 
 /-- The Lichtman exponent: 0.71568... -/
 noncomputable def lichtmanExponent : ℝ := 0.71568
@@ -96,9 +90,7 @@ axiom lichtman_primes :
       ∀ q : ℕ, Nat.Prime q → q ∣ p - 1 → q ≤ ⌊x^(0.2843 : ℝ)⌋₊)
       (Finset.range (⌊x⌋₊ + 1))).card ≥ c * x / (Real.log x)^2
 
-/-
-## Part IV: The Conjecture
--/
+/-! ## The Conjecture -/
 
 /-- **Erdős Conjecture (Problem #821):**
     For every ε > 0, there are infinitely many n with g(n) > n^{1-ε}. -/
@@ -109,9 +101,7 @@ def ErdosConjecture821 : Prop :=
 def ErdosConjecture821' : Prop :=
   ∀ α : ℝ, α < 1 → ∀ N : ℕ, ∃ n ≥ N, (preimageCount n : ℝ) > n^α
 
-/-
-## Part V: Connection to Smooth Primes
--/
+/-! ## Connection to Smooth Primes -/
 
 /-- A prime p has ε-smooth (p-1) if all prime factors of p-1 are < p^ε. -/
 def IsEpsilonSmooth (p : ℕ) (ε : ℝ) : Prop :=
@@ -127,9 +117,7 @@ def SmoothPrimesCondition : Prop :=
 axiom smooth_implies_conjecture :
   SmoothPrimesCondition → ErdosConjecture821
 
-/-
-## Part VI: Upper Bounds
--/
+/-! ## Upper Bounds -/
 
 /-- Upper bound: g(n) ≤ n^(1+o(1)) trivially. -/
 axiom preimageCount_upper_bound :
@@ -140,59 +128,15 @@ axiom average_preimageCount :
   ∃ C : ℝ, C > 0 ∧ ∀ N : ℕ, N ≥ 2 →
     (∑ n in Finset.Icc 1 N, preimageCount n : ℝ) / N ≤ C * Real.log N
 
-/-
-## Part VII: Examples
--/
+/-! ## Examples -/
 
 /-- g(1) = 2 (since φ(1) = φ(2) = 1). -/
 theorem preimage_of_1 : phi 1 = 1 ∧ phi 2 = 1 := by
   simp [phi, Nat.totient]
 
-/-- Values n = 2^k · 3^j · ... with many representations. -/
-def highlyCompositePreimage : Prop :=
-  -- Numbers of the form n = 2^k · ∏ (p_i - 1) have many preimages
-  -- since m = ∏ p_i^{a_i} all give φ(m) = n
-  True
+/-! ## Summary
 
-/-
-## Part VIII: Progress Summary
--/
-
-/-- The current state of knowledge. -/
-def currentKnowledge : Prop :=
-  -- Proven: g(n) > n^{0.71568} infinitely often (Lichtman 2022)
-  -- Conjectured: g(n) > n^{1-ε} for all ε > 0 infinitely often
-  -- Gap: exponent 0.71568 vs target 1
-  True
-
-/-- The exponent has improved over time. -/
-def exponentProgress : Prop :=
-  -- Erdős 1935: some c > 0
-  -- Various improvements
-  -- Baker-Harman 1998: improved bounds
-  -- Lichtman 2022: 0.71568
-  True
-
-/-
-## Part IX: Related Problems
--/
-
-/-- Related to Carmichael's conjecture (always g(n) ≥ 2 or g(n) = 0). -/
-def carmichaelConnection : Prop :=
-  -- Carmichael conjectured: if g(n) ≥ 1 then g(n) ≥ 2
-  -- i.e., no unique preimage
-  True
-
-/-- Connection to Problem #416. -/
-def problem416Connection : Prop :=
-  -- Problem #416 concerns related questions about shifted primes
-  True
-
-/-
-## Part X: Summary
--/
-
-/-- **Erdős Problem #821: OPEN**
+**Erdős Problem #821: OPEN**
 
 Question: For every ε > 0, are there infinitely many n with g(n) > n^{1-ε}?
 
@@ -205,19 +149,14 @@ Status: OPEN (partial results)
 The conjecture would follow from sufficient density of primes p
 with smooth p-1.
 -/
-theorem erdos_821_partial : ∀ N : ℕ, ∃ n ≥ N,
-    (preimageCount n : ℝ) > n^lichtmanExponent :=
-  lichtman_theorem
 
-/-- The full conjecture remains open. -/
-def erdos_821_open : Prop := ErdosConjecture821
-
-/-- Known: the Lichtman bound. -/
-theorem erdos_821_best_known : ∀ N : ℕ, ∃ n ≥ N,
-    (preimageCount n : ℝ) > n^(0.71568 : ℝ) := by
-  exact lichtman_theorem
-
-/-- Placeholder for the full conjecture (unproven). -/
-theorem erdos_821 : True := trivial
+/-- **Complete summary of Erdős Problem #821.**
+Combines Lichtman's best known bound with Erdős's original result
+and the smooth primes reduction. -/
+theorem erdos_821 :
+    (∀ N : ℕ, ∃ n ≥ N, (preimageCount n : ℝ) > n^lichtmanExponent) ∧
+    (∃ c : ℝ, c > 0 ∧ ∀ N : ℕ, ∃ n ≥ N, (preimageCount n : ℝ) > n^c) ∧
+    (SmoothPrimesCondition → ErdosConjecture821) :=
+  ⟨lichtman_theorem, erdos_1935, smooth_implies_conjecture⟩
 
 end Erdos821

--- a/src/data/proofs/erdos-821/annotations.json
+++ b/src/data/proofs/erdos-821/annotations.json
@@ -1,137 +1,76 @@
 [
   {
-    "id": "ann-821-phi",
+    "id": "ann-821-header",
     "proofId": "erdos-821",
-    "range": { "startLine": 44, "endLine": 45 },
-    "type": "definition",
-    "title": "phi",
-    "content": "Euler's totient function φ(n).",
-    "significance": "key"
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "Erdős Problem #821 asks: for every ε > 0, are there infinitely many n with g(n) > n^{1-ε}, where g(n) = |{m : φ(m) = n}| counts preimages of n under Euler's totient? The problem is OPEN. Best known: g(n) > n^{0.71568} infinitely often (Lichtman 2022). The conjecture would follow from sufficient density of primes with smooth p-1.",
+    "mathContext": "The preimage counting function g(n) connects multiplicative number theory (Euler's totient) with smooth numbers and prime distribution.",
+    "significance": "critical",
+    "relatedConcepts": ["Euler's totient", "Preimage counting", "Smooth primes"]
   },
   {
-    "id": "ann-821-preimagecount",
+    "id": "ann-821-definitions",
     "proofId": "erdos-821",
-    "range": { "startLine": 53, "endLine": 55 },
+    "range": { "startLine": 40, "endLine": 56 },
     "type": "definition",
-    "title": "preimageCount",
-    "content": "g(n) = |{m : φ(m) = n}|.",
-    "significance": "critical"
+    "title": "Totient and Preimage Count",
+    "content": "phi: Euler's totient φ(n), defined as Nat.totient. g(n): a partial preimage count using Finset.filter (lower bound). preimageCount(n) = Nat.card {m : φ(m) = n}: the full preimage count. preimageCount_finite (axiom): g(n) < n² for all n, ensuring the count is bounded.",
+    "significance": "critical",
+    "relatedConcepts": ["Nat.totient", "Nat.card", "Preimage"]
   },
   {
-    "id": "ann-821-pillai",
+    "id": "ann-821-known",
     "proofId": "erdos-821",
-    "range": { "startLine": 64, "endLine": 66 },
+    "range": { "startLine": 58, "endLine": 74 },
     "type": "theorem",
-    "title": "pillai_theorem",
-    "content": "lim sup g(n) = ∞.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-821-erdos1935",
-    "proofId": "erdos-821",
-    "range": { "startLine": 68, "endLine": 71 },
-    "type": "theorem",
-    "title": "erdos_1935",
-    "content": "∃ c > 0 with g(n) > n^c infinitely often.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-821-lichtmanexp",
-    "proofId": "erdos-821",
-    "range": { "startLine": 84, "endLine": 85 },
-    "type": "definition",
-    "title": "lichtmanExponent",
-    "content": "0.71568... the current best exponent.",
-    "significance": "critical"
+    "title": "Classical Results: Pillai and Erdős",
+    "content": "pillai_theorem (axiom): for any M, there exists n with g(n) > M, i.e., g(n) is unbounded. erdos_1935 (axiom): there exists c > 0 with g(n) > n^c infinitely often — the first power-law bound. erdos_explicit_bound: the same with a specific (placeholder) constant 0.1.",
+    "mathContext": "Pillai's result was qualitative; Erdős's 1935 paper was the breakthrough showing quantitative power-law growth.",
+    "significance": "key",
+    "relatedConcepts": ["Pillai", "Erdős 1935", "Power-law growth"]
   },
   {
     "id": "ann-821-lichtman",
     "proofId": "erdos-821",
-    "range": { "startLine": 87, "endLine": 90 },
+    "range": { "startLine": 76, "endLine": 91 },
     "type": "theorem",
-    "title": "lichtman_theorem",
-    "content": "Lichtman 2022: g(n) > n^{0.71568} infinitely.",
-    "significance": "critical"
+    "title": "Lichtman's Theorem (2022): Current Best",
+    "content": "lichtmanExponent = 0.71568: the current best exponent. lichtman_theorem (axiom): g(n) > n^{0.71568} infinitely often. lichtman_primes (axiom): there are ≥ cx/(log x)² primes p ≤ x with all prime factors of p-1 at most x^{0.2843}. This is the technical ingredient behind the improved exponent.",
+    "mathContext": "Lichtman's 2022 result improved on Baker-Harman (1998) and represents the state of the art.",
+    "significance": "critical",
+    "relatedConcepts": ["Lichtman 2022", "Best known bound", "Smooth primes density"]
   },
   {
     "id": "ann-821-conjecture",
     "proofId": "erdos-821",
-    "range": { "startLine": 103, "endLine": 106 },
+    "range": { "startLine": 93, "endLine": 118 },
     "type": "definition",
-    "title": "ErdosConjecture821",
-    "content": "∀ ε > 0, g(n) > n^{1-ε} infinitely.",
-    "significance": "critical"
+    "title": "The Conjecture and Smooth Primes Connection",
+    "content": "ErdosConjecture821: ∀ ε > 0, g(n) > n^{1-ε} infinitely often. ErdosConjecture821': equivalent formulation with α < 1. IsEpsilonSmooth p ε: all prime factors of p-1 are < p^ε. SmoothPrimesCondition: for every ε > 0, there are ≫ x/log x primes p < x with ε-smooth p-1. smooth_implies_conjecture (axiom): the smooth primes condition implies the full conjecture.",
+    "mathContext": "The reduction to smooth primes shows that the number-theoretic conjecture is equivalent to a question about prime distribution.",
+    "significance": "critical",
+    "relatedConcepts": ["Conjecture", "Smooth numbers", "Sufficient condition"]
   },
   {
-    "id": "ann-821-smooth",
+    "id": "ann-821-bounds",
     "proofId": "erdos-821",
-    "range": { "startLine": 116, "endLine": 118 },
-    "type": "definition",
-    "title": "IsEpsilonSmooth",
-    "content": "Prime p has ε-smooth p-1.",
-    "significance": "key"
+    "range": { "startLine": 120, "endLine": 135 },
+    "type": "axiom",
+    "title": "Upper Bounds and Examples",
+    "content": "preimageCount_upper_bound (axiom): g(n) ≤ C · n^{1.01} for all n ≥ 2. average_preimageCount (axiom): the average of g(n) over [1,N] is O(log N). preimage_of_1 (theorem): φ(1) = φ(2) = 1, so g(1) ≥ 2. The upper bound shows the conjecture asks for near-maximal behavior.",
+    "significance": "supporting",
+    "relatedConcepts": ["Upper bound", "Average order", "Base case"]
   },
   {
-    "id": "ann-821-smoothcond",
+    "id": "ann-821-summary",
     "proofId": "erdos-821",
-    "range": { "startLine": 120, "endLine": 124 },
-    "type": "definition",
-    "title": "SmoothPrimesCondition",
-    "content": "Sufficient smooth primes condition.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-821-reduction",
-    "proofId": "erdos-821",
-    "range": { "startLine": 126, "endLine": 128 },
+    "range": { "startLine": 137, "endLine": 163 },
     "type": "theorem",
-    "title": "smooth_implies_conjecture",
-    "content": "Smooth primes ⟹ conjecture.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-821-upper",
-    "proofId": "erdos-821",
-    "range": { "startLine": 134, "endLine": 136 },
-    "type": "theorem",
-    "title": "preimageCount_upper_bound",
-    "content": "Upper bound g(n) ≤ n^{1+o(1)}.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-821-average",
-    "proofId": "erdos-821",
-    "range": { "startLine": 138, "endLine": 141 },
-    "type": "theorem",
-    "title": "average_preimageCount",
-    "content": "Average g(n) ≤ C log N.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-821-partial",
-    "proofId": "erdos-821",
-    "range": { "startLine": 208, "endLine": 210 },
-    "type": "theorem",
-    "title": "erdos_821_partial",
-    "content": "Partial result: Lichtman bound.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-821-open",
-    "proofId": "erdos-821",
-    "range": { "startLine": 212, "endLine": 213 },
-    "type": "definition",
-    "title": "erdos_821_open",
-    "content": "Full conjecture remains OPEN.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-821-best",
-    "proofId": "erdos-821",
-    "range": { "startLine": 215, "endLine": 218 },
-    "type": "theorem",
-    "title": "erdos_821_best_known",
-    "content": "Best known: g(n) > n^{0.71568}.",
-    "significance": "critical"
+    "title": "Summary Theorem",
+    "content": "erdos_821 combines three partial results: (1) Lichtman's best known bound g(n) > n^{0.71568} infinitely often, (2) Erdős's 1935 power-law growth for some c > 0, and (3) the reduction showing the smooth primes condition implies the full conjecture. Proved by exact ⟨lichtman_theorem, erdos_1935, smooth_implies_conjecture⟩.",
+    "significance": "critical",
+    "relatedConcepts": ["Summary", "Partial results", "OPEN problem"]
   }
 ]

--- a/src/data/proofs/erdos-821/meta.json
+++ b/src/data/proofs/erdos-821/meta.json
@@ -54,7 +54,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #821 (Euler Phi Preimage Function)**\n\n**Origin:**\nLet g(n) count the number of m such that φ(m) = n. Erdős asked whether g(n) > n^{1-ε} for infinitely many n, for every ε > 0.\n\n**Progress:**\n- Pillai: Proved lim sup g(n) = ∞\n- Erdős (1935): Showed g(n) > n^c for some c > 0 infinitely often\n- Baker-Harman (1998): Improved bounds\n- Lichtman (2022): Current best: g(n) > n^{0.71568...} infinitely often\n\n**Connection:**\nThe conjecture would follow if there are ≫ x/log x primes p < x with all prime factors of p-1 less than p^ε (smooth shifted primes).\n\n**Status:**\nThe full conjecture remains OPEN. The gap between the best known exponent 0.71568 and the target 1 is significant.",
+    "historicalContext": "Erdős Problem #821 asks about the preimage counting function g(n) = |{m : φ(m) = n}| for Euler's totient. The question is whether for every ε > 0, there are infinitely many n with g(n) > n^{1-ε}. This would mean the preimage count can be almost as large as n itself, infinitely often.\n\nPillai first showed g(n) is unbounded. Erdős (1935) strengthened this to g(n) > n^c for some c > 0 infinitely often, establishing power-law growth. Baker and Harman (1998) improved the constant, and Lichtman (2022) achieved the current best: g(n) > n^{0.71568} infinitely often. The gap between the exponent 0.71568 and the target of 1 remains significant.\n\nThe conjecture has a beautiful connection to smooth numbers: it would follow if for every ε > 0, there are sufficiently many primes p < x with all prime factors of p-1 less than p^ε. This reduction shows that the problem is intimately connected to the distribution of primes with smooth shifted values, a central topic in analytic number theory.",
     "problemStatement": "**Problem Statement (Open)**\n\nLet g(n) = |{m : φ(m) = n}| count preimages of n under Euler's totient.\n\n**Question:** For every ε > 0, are there infinitely many n with g(n) > n^{1-ε}?\n\n**Status: OPEN**\n\n- Known: g(n) > n^{0.71568} infinitely often (Lichtman 2022)\n- Conjectured: g(n) > n^{1-ε} for all ε > 0\n- Gap: exponent 0.71568 vs target 1",
     "proofStrategy": "**Formalization Approach**\n\n1. **Basic Definitions:** phi (Euler totient), preimageCount (g(n))\n\n2. **Known Results:** pillai_theorem, erdos_1935, lichtman_theorem\n\n3. **Main Conjecture:** ErdosConjecture821 formal statement\n\n4. **Smooth Primes:** IsEpsilonSmooth, SmoothPrimesCondition\n\n5. **Reduction:** smooth_implies_conjecture showing the connection\n\n6. **Bounds:** Upper and average bounds on g(n)\n\n7. **Partial Results:** erdos_821_partial, erdos_821_best_known",
     "keyInsights": [
@@ -65,7 +65,57 @@
       "**Related #416:** Connected to shifted primes problems"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "totient",
+      "title": "Euler's Totient Function",
+      "summary": "phi, g, preimageCount definitions",
+      "startLine": 40,
+      "endLine": 56
+    },
+    {
+      "id": "known-results",
+      "title": "Known Results",
+      "summary": "pillai_theorem, erdos_1935, erdos_explicit_bound",
+      "startLine": 58,
+      "endLine": 74
+    },
+    {
+      "id": "lichtman",
+      "title": "Lichtman's Result (2022)",
+      "summary": "lichtmanExponent, lichtman_theorem, lichtman_primes",
+      "startLine": 76,
+      "endLine": 91
+    },
+    {
+      "id": "conjecture",
+      "title": "The Conjecture",
+      "summary": "ErdosConjecture821 formal statement and alternative form",
+      "startLine": 93,
+      "endLine": 102
+    },
+    {
+      "id": "smooth-primes",
+      "title": "Connection to Smooth Primes",
+      "summary": "IsEpsilonSmooth, SmoothPrimesCondition, smooth_implies_conjecture",
+      "startLine": 104,
+      "endLine": 118
+    },
+    {
+      "id": "upper-bounds",
+      "title": "Upper Bounds",
+      "summary": "preimageCount_upper_bound, average_preimageCount",
+      "startLine": 120,
+      "endLine": 129
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "summary": "erdos_821 main theorem combining partial results",
+      "startLine": 137,
+      "endLine": 163
+    }
+  ],
   "conclusion": {
     "summary": "Erdős Problem #821 asks whether g(n) > n^{1-ε} for infinitely many n, where g(n) counts preimages of n under Euler's totient. The problem is OPEN. Lichtman (2022) proved the best known bound g(n) > n^{0.71568} infinitely often. The conjecture would follow from sufficient density of primes with smooth p-1.",
     "implications": "**Connections**\n\n1. **Euler's Totient:** Deep properties of φ preimages\n\n2. **Smooth Numbers:** Primes p with smooth p-1 are key\n\n3. **Carmichael's Conjecture:** Related: no unique preimages of φ\n\n4. **Problem #416:** Connected shifted primes questions",


### PR DESCRIPTION
## Summary
- Removed 5 trivial `True` defs (`highlyCompositePreimage`, `currentKnowledge`, `exponentProgress`, `carmichaelConnection`, `problem416Connection`)
- Fixed `/-` → `/-!` section headers throughout
- Replaced `erdos_821 : True := trivial` with proper summary theorem using `exact ⟨lichtman_theorem, erdos_1935, smooth_implies_conjecture⟩`
- Removed redundant `erdos_821_partial`, `erdos_821_open`, `erdos_821_best_known`
- Updated meta.json: 3-paragraph historicalContext, added sections (was empty)
- Rewrote annotations.json: 7 annotations with correct line numbers

## Test plan
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)