### PR TITLE
fix(erdos-426): remove True axioms and trivial theorems

### DIFF
--- a/proofs/Proofs/Erdos426Problem.lean
+++ b/proofs/Proofs/Erdos426Problem.lean
@@ -40,7 +40,7 @@ open Nat SimpleGraph
 
 namespace Erdos426
 
-/-
+/-!
 ## Part I: Basic Definitions
 -/
 
@@ -82,7 +82,7 @@ The conceptual definition is clear but the formalization is technically complex.
 axiom CountUniqueSubgraphs (G : SimpleGraph V) [Fintype V]
     [DecidableEq V] [DecidableRel G.Adj] : ℕ
 
-/-
+/-!
 ## Part II: The Counting Bounds
 -/
 
@@ -114,7 +114,7 @@ noncomputable def maxUniqueSubgraphs (n : ℕ) : ℕ :=
   sSup {k : ℕ | ∃ (G : SimpleGraph (Fin n)) [DecidableRel G.Adj],
     CountUniqueSubgraphs G = k}
 
-/-
+/-!
 ## Part III: Historical Constructions
 -/
 
@@ -134,7 +134,7 @@ axiom brouwer_1975 (n : ℕ) (hn : n ≥ 10) :
     ∃ C : ℝ, C > 0 ∧
       (maxUniqueSubgraphs n : ℝ) ≥ (2 : ℝ)^(n.choose 2 - C * n) / n.factorial
 
-/-
+/-!
 ## Part IV: The Main Conjecture and Its Resolution
 -/
 
@@ -148,24 +148,17 @@ def OriginalQuestion : Prop :=
   ∃ c : ℝ, c > 0 ∧
     ∀ n : ℕ, n ≥ 10 → (maxUniqueSubgraphs n : ℝ) ≥ c * nonIsomorphicGraphs n
 
-/--
+/-!
 **Spencer's suggestion:**
 Spencer suggested that the answer might be YES (i.e., one could achieve
-≫ 2^(n choose 2) / n! unique subgraphs).
+≫ 2^(n choose 2) / n! unique subgraphs). Erdős offered $100 for such a construction.
 
-Erdős offered $100 for such a construction.
--/
-axiom spencer_suggestion : True
-
-/--
 **Erdős's belief:**
 Erdős believed Brouwer's construction was essentially best possible.
-
 He offered $25 for a proof that no better construction exists.
 -/
-axiom erdos_belief : True
 
-/-
+/-!
 ## Part V: Bradač-Christoph Resolution (2024)
 -/
 
@@ -208,11 +201,11 @@ The answer is NO - unique subgraphs are rare.
 -/
 theorem erdos_426_resolved : ¬OriginalQuestion := original_question_false
 
-/-
+/-!
 ## Part VI: Understanding the Result
 -/
 
-/--
+/-!
 **Why unique subgraphs are rare:**
 The key insight is that most graphs have many automorphisms or structural
 regularities that create multiple copies of any subgraph.
@@ -220,10 +213,7 @@ regularities that create multiple copies of any subgraph.
 To have a unique subgraph, we need:
 1. The subgraph must embed in exactly one way
 2. This is increasingly rare as graphs become larger and more complex
--/
-axiom uniqueness_insight : True
 
-/--
 **The gap between constructions and the upper bound:**
 - Brouwer achieved 2^{(n choose 2) - O(n)} / n!
 - The upper bound is 2^(n choose 2) / n! (all non-isomorphic graphs)
@@ -231,11 +221,8 @@ axiom uniqueness_insight : True
 
 Bradač-Christoph show that even 2^{(n choose 2)} / n! is unachievable.
 -/
-theorem gap_explanation (n : ℕ) (hn : n ≥ 10) :
-    -- Brouwer's lower bound is a factor of 2^{O(n)} below the naive upper bound
-    True := trivial
 
-/-
+/-!
 ## Part VII: Related Concepts
 -/
 
@@ -255,15 +242,13 @@ Almost all graphs are asymmetric (Erdős-Rényi), which relates to uniqueness.
 def IsAsymmetric (G : SimpleGraph V) : Prop :=
   ∀ σ : V → V, HasAutomorphism G σ → σ = id
 
-/--
-**Almost all graphs are asymmetric:**
+/-!
+**Almost all graphs are asymmetric (Erdős-Rényi):**
+For any ε > 0, the fraction of graphs on n vertices that are asymmetric
+exceeds 1 - ε for all sufficiently large n.
 -/
-axiom almost_all_asymmetric :
-    ∀ ε > 0, ∃ N : ℕ, ∀ n : ℕ, n ≥ N →
-      -- Fraction of graphs on n vertices that are asymmetric > 1 - ε
-      True
 
-/-
+/-!
 ## Part VIII: Summary
 -/
 
@@ -290,13 +275,7 @@ theorem erdos_426_summary :
     (¬OriginalQuestion) ∧
     -- Brouwer's construction exists
     (∀ n : ℕ, n ≥ 10 → ∃ C : ℝ, C > 0 ∧
-      (maxUniqueSubgraphs n : ℝ) ≥ (2 : ℝ)^(n.choose 2 - C * n) / n.factorial) ∧
-    -- But it cannot reach the full bound
-    True := by
-  constructor
-  · exact original_question_false
-  constructor
-  · exact brouwer_1975
-  · trivial
+      (maxUniqueSubgraphs n : ℝ) ≥ (2 : ℝ)^(n.choose 2 - C * n) / n.factorial) :=
+  ⟨original_question_false, brouwer_1975⟩
 
 end Erdos426

--- a/src/data/proofs/erdos-426/annotations.json
+++ b/src/data/proofs/erdos-426/annotations.json
@@ -96,7 +96,7 @@
   {
     "id": "ann-e426-prizes",
     "proofId": "erdos-426",
-    "range": { "startLine": 146, "endLine": 161 },
+    "range": { "startLine": 146, "endLine": 159 },
     "type": "concept",
     "title": "Prize Structure",
     "content": "**The Erdős Prizes:**\n\n- $100 for a construction achieving ≫ 2^(n choose 2)/n! (Spencer's belief)\n- $25 for proving no such construction exists (Erdős's belief)\n\nErdős believed Brouwer was optimal; Spencer disagreed.",
@@ -107,7 +107,7 @@
   {
     "id": "ann-e426-bradac",
     "proofId": "erdos-426",
-    "range": { "startLine": 167, "endLine": 176 },
+    "range": { "startLine": 163, "endLine": 172 },
     "type": "axiom",
     "title": "Bradač-Christoph (2024)",
     "content": "**bradac_christoph_2024:**\n\nThe answer is NO: f(n) = o(2^(n choose 2)/n!)\n\nFor any ε > 0, eventually f(n) < ε · nonIsomorphicGraphs(n).\n\nThis resolves Erdős Problem #426 negatively.",
@@ -118,7 +118,7 @@
   {
     "id": "ann-e426-quantitative",
     "proofId": "erdos-426",
-    "range": { "startLine": 178, "endLine": 185 },
+    "range": { "startLine": 174, "endLine": 181 },
     "type": "axiom",
     "title": "Quantitative Bound",
     "content": "**bradac_christoph_quantitative:**\n\nThe o(1) factor is explicitly O(log log log n / log log n).\n\nThis is a very slowly decreasing function, showing uniqueness decays gradually.",
@@ -128,7 +128,7 @@
   {
     "id": "ann-e426-resolved",
     "proofId": "erdos-426",
-    "range": { "startLine": 187, "endLine": 202 },
+    "range": { "startLine": 183, "endLine": 202 },
     "type": "theorem",
     "title": "Problem Resolved",
     "content": "**original_question_false, erdos_426_resolved:**\n\n¬OriginalQuestion\n\nThe answer to Erdős's question is NO. Unique subgraphs are rare - they cannot approach the total count of non-isomorphic graphs.",
@@ -138,7 +138,7 @@
   {
     "id": "ann-e426-insight",
     "proofId": "erdos-426",
-    "range": { "startLine": 208, "endLine": 229 },
+    "range": { "startLine": 204, "endLine": 223 },
     "type": "concept",
     "title": "Why Unique Subgraphs Are Rare",
     "content": "**Key Insights:**\n\n1. **Automorphisms:** Graphs with symmetries create multiple embeddings\n2. **Structural regularity:** Repeated patterns prevent uniqueness\n3. **The gap:** Brouwer loses 2^{O(n)} from the naive bound\n4. **Unavoidable:** Even the naive bound is unreachable\n\nUniqueness requires that every embedding produces a distinct 'fingerprint'.",
@@ -148,7 +148,7 @@
   {
     "id": "ann-e426-automorphism",
     "proofId": "erdos-426",
-    "range": { "startLine": 235, "endLine": 257 },
+    "range": { "startLine": 228, "endLine": 249 },
     "type": "definition",
     "title": "Automorphisms and Asymmetry",
     "content": "**HasAutomorphism, IsAsymmetric:**\n\nAn automorphism is a bijection σ : V → V preserving adjacency.\n\nA graph is asymmetric if its only automorphism is the identity.\n\n**Key fact:** Almost all graphs are asymmetric (Erdős-Rényi), yet unique subgraphs are still rare - the obstacle is deeper than just symmetry.",
@@ -158,7 +158,7 @@
   {
     "id": "ann-e426-summary",
     "proofId": "erdos-426",
-    "range": { "startLine": 263, "endLine": 293 },
+    "range": { "startLine": 255, "endLine": 281 },
     "type": "theorem",
     "title": "Problem Summary",
     "content": "**erdos_426_summary:**\n\n| Aspect | Result |\n|--------|--------|\n| Question | Can f(n) = Ω(2^(n choose 2)/n!)? |\n| Answer | NO (Bradač-Christoph 2024) |\n| Upper bound | f(n) = o(2^(n choose 2)/n!) |\n| Best construction | 2^{(n choose 2) - O(n)}/n! (Brouwer) |\n| Prize | $25 for impossibility proof |",


### PR DESCRIPTION
## Summary
- Removed 3 `axiom foo : True` (spencer_suggestion, erdos_belief, uniqueness_insight)
- Removed 1 `True := trivial` theorem (gap_explanation)
- Removed 1 `→ True` axiom (almost_all_asymmetric)
- Fixed `erdos_426_summary` to remove `∧ True`, now uses `⟨original_question_false, brouwer_1975⟩`
- Converted `/- ##` section headers to `/-! ##`
- Updated annotations.json line numbers

## Test plan
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)