### PR TITLE
enhance(erdos-470): remove True := trivial, add summary

### DIFF
--- a/proofs/Proofs/Erdos470Problem.lean
+++ b/proofs/Proofs/Erdos470Problem.lean
@@ -134,10 +134,6 @@ def OddWeird : Set ℕ := { n | IsWeird n ∧ Odd n }
 -/
 def erdos_470_part1 : Prop := ∃ n : ℕ, IsWeird n ∧ Odd n
 
-/--
-The question remains open as of 2024.
--/
-theorem erdos_470_part1_is_open : True := trivial
 
 /-!
 ## Computational Bounds on Odd Weird Numbers
@@ -207,10 +203,6 @@ weird numbers?
 -/
 def erdos_470_part2 : Prop := PrimitiveWeirdSet.Infinite
 
-/--
-The question remains open as of 2024.
--/
-theorem erdos_470_part2_is_open : True := trivial
 
 /-!
 ## Conditional Result: Prime Gaps
@@ -325,5 +317,30 @@ The proper divisors of 70 are {1, 2, 5, 7, 10, 14, 35}.
 -/
 axiom proper_divisors_70 :
     (70 : ℕ).properDivisors = {1, 2, 5, 7, 10, 14, 35}
+
+/-!
+## Summary
+
+**Erdős Problem #470**: Both questions remain OPEN.
+We combine the key established results:
+1. 70 is the smallest weird number
+2. 70 is primitive weird
+3. Weird numbers have positive density (Benkoski-Erdős)
+4. Melfi's conditional infinitude of primitive weirds
+-/
+
+/--
+**Complete summary of Erdős Problem #470.**
+Combines the smallest weird number result, primitive weirdness of 70,
+positive density, and Melfi's conditional result.
+-/
+theorem erdos_470 :
+    (IsWeird 70 ∧ ∀ n < 70, ¬IsWeird n) ∧
+    IsPrimitiveWeird 70 ∧
+    (∃ c > 0, ∀ᶠ N in Filter.atTop, (↑((WeirdSet ∩ {n | n ≤ N}).ncard) : ℝ) / N ≥ c) ∧
+    ((∀ᶠ n in Filter.atTop, (primeGap n : ℝ) < Real.sqrt (nthPrime n) / 10) →
+      PrimitiveWeirdSet.Infinite) :=
+  ⟨smallest_weird_is_70, seventy_is_primitive_weird,
+   benkoski_erdos_density, melfi_conditional⟩
 
 end Erdos470

--- a/src/data/proofs/erdos-470/annotations.json
+++ b/src/data/proofs/erdos-470/annotations.json
@@ -148,7 +148,7 @@
     "proofId": "erdos-470",
     "range": {
       "startLine": 120,
-      "endLine": 140
+      "endLine": 135
     },
     "type": "definition",
     "title": "Open Question 1: Odd Weird Numbers",
@@ -165,8 +165,8 @@
     "id": "ann-e470-fang",
     "proofId": "erdos-470",
     "range": {
-      "startLine": 148,
-      "endLine": 153
+      "startLine": 144,
+      "endLine": 149
     },
     "type": "axiom",
     "title": "Fang's Computational Bound",
@@ -183,8 +183,8 @@
     "id": "ann-e470-liddy-riedl",
     "proofId": "erdos-470",
     "range": {
-      "startLine": 155,
-      "endLine": 164
+      "startLine": 151,
+      "endLine": 160
     },
     "type": "axiom",
     "title": "Liddy-Riedl: Prime Divisor Bound",
@@ -201,8 +201,8 @@
     "id": "ann-e470-primitive",
     "proofId": "erdos-470",
     "range": {
-      "startLine": 166,
-      "endLine": 191
+      "startLine": 162,
+      "endLine": 186
     },
     "type": "definition",
     "title": "Primitive Weird Numbers",
@@ -219,8 +219,8 @@
     "id": "ann-e470-part2",
     "proofId": "erdos-470",
     "range": {
-      "startLine": 204,
-      "endLine": 213
+      "startLine": 195,
+      "endLine": 204
     },
     "type": "definition",
     "title": "Open Question 2: Infinitely Many Primitive Weirds",
@@ -237,8 +237,8 @@
     "id": "ann-e470-melfi",
     "proofId": "erdos-470",
     "range": {
-      "startLine": 223,
-      "endLine": 245
+      "startLine": 215,
+      "endLine": 236
     },
     "type": "axiom",
     "title": "Melfi's Conditional Infinitude Result",
@@ -255,8 +255,8 @@
     "id": "ann-e470-density",
     "proofId": "erdos-470",
     "range": {
-      "startLine": 246,
-      "endLine": 263
+      "startLine": 238,
+      "endLine": 254
     },
     "type": "axiom",
     "title": "Benkoski-Erdos: Positive Density",
@@ -273,8 +273,8 @@
     "id": "ann-e470-abundancy",
     "proofId": "erdos-470",
     "range": {
-      "startLine": 264,
-      "endLine": 282
+      "startLine": 256,
+      "endLine": 273
     },
     "type": "concept",
     "title": "Abundancy Index Connection",
@@ -291,8 +291,8 @@
     "id": "ann-e470-why-70",
     "proofId": "erdos-470",
     "range": {
-      "startLine": 302,
-      "endLine": 328
+      "startLine": 294,
+      "endLine": 319
     },
     "type": "concept",
     "title": "Why 70 is Weird: Detailed Analysis",
@@ -303,6 +303,23 @@
       "case analysis",
       "subset sum",
       "verification"
+    ]
+  },
+  {
+    "id": "ann-e470-summary",
+    "proofId": "erdos-470",
+    "range": {
+      "startLine": 321,
+      "endLine": 344
+    },
+    "type": "theorem",
+    "title": "Summary Theorem",
+    "content": "erdos_470 combines four key established results: (1) 70 is the smallest weird number, (2) 70 is primitive weird, (3) weird numbers have positive density (Benkoski-Erdős), and (4) Melfi's conditional result on infinitely many primitive weirds. Proved by exact ⟨smallest_weird_is_70, seventy_is_primitive_weird, benkoski_erdos_density, melfi_conditional⟩. The main questions — existence of odd weird numbers and infinitude of primitive weirds — remain OPEN.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Summary",
+      "Partial results",
+      "Open problem"
     ]
   }
 ]

--- a/src/data/proofs/erdos-470/meta.json
+++ b/src/data/proofs/erdos-470/meta.json
@@ -54,7 +54,8 @@
       "Axiomatization of Fang's computational bound (no odd weird below 10^21)",
       "Axiomatization of Liddy-Riedl result (odd weird has ≥6 prime divisors)",
       "Axiomatization of Melfi's conditional infinitude result",
-      "Theorem: 70 is the smallest weird number"
+      "Theorem: 70 is the smallest weird number",
+      "erdos_470 summary theorem combining key results"
     ]
   },
   "overview": {
@@ -82,50 +83,57 @@
       "id": "smallest-weird",
       "title": "The Smallest Weird Number: 70",
       "startLine": 70,
-      "endLine": 100,
+      "endLine": 99,
       "summary": "Axioms establishing 70 as abundant, not pseudoperfect, and the smallest weird."
     },
     {
       "id": "oeis-sequence",
       "title": "The Weird Number Sequence",
       "startLine": 101,
-      "endLine": 119,
+      "endLine": 118,
       "summary": "OEIS A006037 values: 70, 836, 4030, 5830, 7192, 7912, 9272, ..."
     },
     {
       "id": "odd-weird",
       "title": "Open Question 1: Odd Weird Numbers",
       "startLine": 120,
-      "endLine": 165,
+      "endLine": 160,
       "summary": "Formal statement of the odd weird question with Fang and Liddy-Riedl bounds."
     },
     {
       "id": "primitive-weird",
       "title": "Primitive Weird Numbers",
-      "startLine": 166,
-      "endLine": 213,
-      "summary": "Definition of IsPrimitiveWeird and Open Question 2."
+      "startLine": 162,
+      "endLine": 204,
+      "summary": "Definition of IsPrimitiveWeird, Open Question 2, and seventy_is_primitive_weird proof."
     },
     {
       "id": "conditional-results",
       "title": "Conditional Results: Prime Gaps",
-      "startLine": 214,
-      "endLine": 245,
+      "startLine": 207,
+      "endLine": 236,
       "summary": "Melfi's conditional infinitude result based on prime gap hypothesis."
     },
     {
       "id": "density",
       "title": "Positive Density of Weird Numbers",
-      "startLine": 246,
-      "endLine": 263,
+      "startLine": 238,
+      "endLine": 254,
       "summary": "Benkoski-Erdős theorem: weird numbers have positive asymptotic density."
     },
     {
       "id": "detailed-analysis",
       "title": "Why 70 is Weird: Detailed Analysis",
-      "startLine": 302,
-      "endLine": 328,
+      "startLine": 294,
+      "endLine": 319,
       "summary": "Complete analysis of why no subset of 70's proper divisors sums to 70."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 321,
+      "endLine": 344,
+      "summary": "erdos_470 summary theorem combining key established results."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove 2 `True := trivial` placeholder theorems (`erdos_470_part1_is_open`, `erdos_470_part2_is_open`)
- Add `erdos_470` summary theorem combining `smallest_weird_is_70`, `seventy_is_primitive_weird`, `benkoski_erdos_density`, `melfi_conditional`
- Update meta.json section line numbers and add summary section
- Update annotations.json line numbers and add summary annotation

## Test plan
- [x] `pnpm build` passes
- [ ] Verify Lean file has no `sorry` or `True := trivial`
- [ ] Verify annotation line numbers match Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)