### PR TITLE
fix(erdos-804): remove True := trivial placeholders, add resolution theorem

### DIFF
--- a/proofs/Proofs/Erdos804Problem.lean
+++ b/proofs/Proofs/Erdos804Problem.lean
@@ -83,28 +83,6 @@ def HasLocalIndependence (G : SimpleGraph V) (m k : ℕ) : Prop :=
   ∀ S : Finset V, S.card = m →
     ∃ I : Finset V, I ⊆ S ∧ IsIndependent G I ∧ I.card ≥ k
 
-/--
-**The f(m, n) function:**
-f(m, n) is the maximum f such that every graph on n vertices with
-(m, log n)-local independence has an independent set of size ≥ f.
-
-More precisely: if every induced subgraph on m vertices has an
-independent set of size ≥ log n, then the whole graph has an
-independent set of size ≥ f(m, n).
--/
-noncomputable def f_local_to_global (m n : ℕ) : ℕ :=
-  -- The minimum independence number over all graphs with the property
-  -- (This is a noncomputable idealization)
-  Classical.choose (⟨0, trivial⟩ : ∃ k : ℕ, True)
-
-/--
-**Key observation:**
-If every m-vertex subgraph has a large independent set, the whole graph
-might not have a proportionally large one. The question is: how large
-must it be?
--/
-theorem local_to_global_intuition : True := trivial
-
 /-
 ## Part III: Erdős-Hajnal's Conjectures
 
@@ -196,11 +174,11 @@ axiom alon_sudakov_tight_bound_2 :
             (independenceNumber G : ℝ) ≤ C * (Nat.log n) ^ 2 / Nat.log (Nat.log n))
 
 /-
-## Part V: Main Results Summary
+## Part V: Main Results
 -/
 
 /--
-**Erdős Problem #804: DISPROVED**
+**Erdős Problem #804: DISPROVED (Alon-Sudakov, 2007)**
 
 Q1: Is f((log n)², n) ≥ n^(1/2 - o(1))?
 A: NO. The true answer is Θ((log n)² / log log n).
@@ -224,103 +202,23 @@ theorem erdos_804 :
   exact ⟨erdos_hajnal_conjecture_1_false, erdos_hajnal_conjecture_2_false⟩
 
 /-
-## Part VI: Proof Intuition
-
-Why are the conjectures false?
+## Part VI: Alon-Sudakov Full Resolution
 -/
 
 /--
-**Intuition: Random Graphs**
+**Complete resolution of Problem #804:**
 
-Consider a random graph G(n, p) with edge probability p ≈ 1 - 1/log n.
+The true bounds are:
+1. f((log n)², n) = Θ((log n)² / log log n) — between lower and upper bounds
+2. f((log n)³, n) = Θ((log n)² / log log n) — tight characterization
 
-- In any m-vertex induced subgraph, there are likely ≈ m/log n vertices
-  with no edges, giving independent sets of size ≈ log n when m = (log n)².
+Both conjectures overestimated the local-to-global propagation strength.
 
-- But the global independence number is only ≈ (log n)² because the graph
-  is quite dense.
-
-Random constructions often give tight examples in extremal graph theory.
+Remarkably, increasing m from (log n)² to (log n)³ does NOT significantly
+improve the global bound — the bottleneck is elsewhere.
 -/
-theorem random_graph_intuition : True := trivial
-
-/--
-**Intuition: Ramsey Theory Connection**
-
-The problem relates to Ramsey numbers. In Ramsey terms:
-- Local independence says small subgraphs have "controlled" structure
-- The question is how this propagates globally
-
-Erdős-Hajnal conjectured stronger propagation than actually occurs.
--/
-theorem ramsey_connection : True := trivial
-
-/-
-## Part VII: Related Results
--/
-
-/--
-**Connection to Problem #805:**
-Problem #805 asks related questions about local-to-global independence.
-The Alon-Sudakov techniques apply to both problems.
--/
-theorem related_to_805 : True := trivial
-
-/--
-**Erdős-Hajnal Conjecture (different problem):**
-The famous Erdős-Hajnal conjecture says that for any graph H,
-graphs that don't contain H as an induced subgraph have polynomial
-independence number. That is a different (and still open!) problem.
--/
-theorem erdos_hajnal_conjecture_different : True := trivial
-
-/-
-## Part VIII: Examples
--/
-
-/--
-**Example: Complete Graph**
-K_n has α(K_n) = 1 (only singletons are independent).
-Every induced subgraph on m vertices is K_m, which also has α = 1.
-This trivially satisfies the local condition with k = 1.
--/
-theorem complete_graph_example : True := trivial
-
-/--
-**Example: Empty Graph**
-The empty graph (no edges) has α = n (the whole vertex set is independent).
-Every induced subgraph on m vertices has α = m.
-This shows f(m, n) ≥ min{n, log n requirement} when conditions are met.
--/
-theorem empty_graph_example : True := trivial
-
-/--
-**Example: Paley Graphs**
-Paley graphs are quadratic residue graphs on prime fields.
-They have independence number ≈ √n and can be analyzed for local properties.
--/
-theorem paley_graph_example : True := trivial
-
-/-
-## Part IX: Summary
--/
-
-/--
-**Erdős Problem #804: DISPROVED (Alon-Sudakov, 2007)**
-
-**Original Questions:**
-1. f((log n)², n) ≥ n^(1/2 - o(1))? NO
-2. f((log n)³, n) ≫ (log n)³? NO
-
-**True Bounds:**
-1. f((log n)², n) = Θ((log n)² / log log n)
-2. f((log n)³, n) = Θ((log n)² / log log n)
-
-**Key Lesson:** Local structure doesn't imply global structure as strongly
-as intuition might suggest. The loss from local to global is significant.
--/
-theorem erdos_804_summary :
-    -- The conjectures were false
+theorem erdos_804_resolution :
+    -- Conjectures are false
     (¬(∀ ε > 0, ∀ᶠ n : ℕ in atTop,
         ∀ G : SimpleGraph (Fin n),
           HasLocalIndependence G ((Nat.log n) ^ 2) (Nat.log n) →
@@ -329,8 +227,18 @@ theorem erdos_804_summary :
         ∀ G : SimpleGraph (Fin n),
           HasLocalIndependence G ((Nat.log n) ^ 3) (Nat.log n) →
             independenceNumber G ≥ (Nat.log n) ^ 3 * Nat.log n)) ∧
-    -- But we do have bounds (existence statements from Alon-Sudakov)
-    True := by
-  exact ⟨erdos_hajnal_conjecture_1_false, erdos_hajnal_conjecture_2_false, trivial⟩
+    -- But precise bounds exist (Alon-Sudakov 2007)
+    (∃ C : ℝ, C > 0 ∧
+      ∀ᶠ n : ℕ in atTop,
+        ∃ G : SimpleGraph (Fin n),
+          HasLocalIndependence G ((Nat.log n) ^ 2) (Nat.log n) ∧
+            independenceNumber G ≤ C * (Nat.log n) ^ 2) ∧
+    (∃ c : ℝ, c > 0 ∧
+      ∀ᶠ n : ℕ in atTop,
+        ∀ G : SimpleGraph (Fin n),
+          HasLocalIndependence G ((Nat.log n) ^ 2) (Nat.log n) →
+            (independenceNumber G : ℝ) ≥ c * (Nat.log n) ^ 2 / Nat.log (Nat.log n)) :=
+  ⟨erdos_hajnal_conjecture_1_false, erdos_hajnal_conjecture_2_false,
+   alon_sudakov_upper_bound_1, alon_sudakov_lower_bound_1⟩
 
 end Erdos804

--- a/src/data/proofs/erdos-804/annotations.json
+++ b/src/data/proofs/erdos-804/annotations.json
@@ -8,7 +8,7 @@
     "content": "**Erdős Problem #804: Independent Sets in Locally Independent Graphs**\n\nThe problem asks: if EVERY small induced subgraph has a good independent set, how good must the GLOBAL independent set be?\n\nErdős and Hajnal conjectured optimistic bounds:\n- f((log n)², n) ≥ n^(1/2 - o(1))\n- f((log n)³, n) ≫ (log n)³\n\n**Both were WRONG!** Alon-Sudakov (2007) proved the true answer is only (log n)² / log log n.",
     "mathContext": "This is a local-to-global structure problem. Local guarantees (every small subgraph has large independent set) don't translate to global guarantees as strongly as expected.",
     "significance": "critical",
-    "relatedConcepts": ["Independent sets", "Local-global propagation", "Ramsey theory"]
+    "relatedConcepts": ["independent sets", "local-global propagation", "Ramsey theory"]
   },
   {
     "id": "ann-e804-independent",
@@ -17,8 +17,9 @@
     "type": "definition",
     "title": "Independent Set Definition",
     "content": "**IsIndependent G S:**\n\nA set S of vertices is independent (or stable) if no two vertices in S are adjacent:\n$$\\forall u, v \\in S, u \\neq v \\implies \\neg G.\\text{Adj}(u, v)$$\n\n**Examples:**\n- In any graph, {v} (singleton) is independent\n- In K_n (complete graph), only singletons are independent\n- In empty graph, any set is independent",
+    "mathContext": "Independent sets are dual to cliques. The complement of an independent set in the complement graph is a clique. Computing the maximum independent set is NP-hard.",
     "significance": "critical",
-    "relatedConcepts": ["Stable sets", "Vertex covers", "Graph coloring"]
+    "relatedConcepts": ["stable sets", "vertex covers", "graph coloring"]
   },
   {
     "id": "ann-e804-alpha",
@@ -27,8 +28,20 @@
     "type": "definition",
     "title": "Independence Number α(G)",
     "content": "**independenceNumber G:**\n\nα(G) = maximum size of an independent set in G.\n\n**Examples:**\n- α(K_n) = 1 (only singletons work)\n- α(empty graph on n vertices) = n\n- α(cycle C_n) = ⌊n/2⌋\n\nComputing α(G) is NP-hard in general.",
+    "mathContext": "Defined as the supremum of Finset.card over all subsets in the powerset that satisfy IsIndependent. This is noncomputable due to the search over all subsets.",
     "significance": "critical",
-    "relatedConcepts": ["Clique number", "Chromatic number", "NP-completeness"]
+    "relatedConcepts": ["clique number", "chromatic number", "NP-completeness"]
+  },
+  {
+    "id": "ann-e804-empty-independent",
+    "proofId": "erdos-804",
+    "range": { "startLine": 64, "endLine": 69 },
+    "type": "theorem",
+    "title": "Empty Set is Independent",
+    "content": "**empty_is_independent:**\n\nThe empty set ∅ is independent in any graph G. This is vacuously true: the quantifier \"for all u ∈ ∅\" is vacuously satisfied.\n\nThe proof uses absurd to derive a contradiction from the assumption that u ∈ ∅.",
+    "mathContext": "This is the base case for inductive arguments about independent sets. It establishes that the IsIndependent predicate is non-vacuous.",
+    "significance": "supporting",
+    "relatedConcepts": ["vacuous truth", "base case", "Finset.not_mem_empty"]
   },
   {
     "id": "ann-e804-local-independence",
@@ -36,110 +49,86 @@
     "range": { "startLine": 77, "endLine": 84 },
     "type": "definition",
     "title": "Local Independence Property",
-    "content": "**HasLocalIndependence G m k:**\n\nA graph has the (m, k)-local independence property if EVERY induced subgraph on m vertices contains an independent set of size ≥ k.\n\n**Interpretation:** This is a very strong condition! It says that no matter which m vertices you pick, you can find k non-adjacent ones among them.\n\nThe question: does this local guarantee force a large global independent set?",
+    "content": "**HasLocalIndependence G m k:**\n\nA graph has the (m, k)-local independence property if EVERY induced subgraph on m vertices contains an independent set of size ≥ k.\n\n**Interpretation:** This is a very strong condition! It says that no matter which m vertices you pick, you can find k non-adjacent ones among them.\n\nThe central question of Problem #804: does this local guarantee force a large global independent set?",
+    "mathContext": "This definition quantifies over all m-element subsets of V. For m = (log n)² and k = log n, this says every polylogarithmic-sized subgraph has a logarithmic independent set.",
     "significance": "critical",
-    "relatedConcepts": ["Local properties", "Induced subgraphs"]
+    "relatedConcepts": ["local properties", "induced subgraphs", "Ramsey-type conditions"]
   },
   {
     "id": "ann-e804-conjecture-1",
     "proofId": "erdos-804",
-    "range": { "startLine": 114, "endLine": 127 },
+    "range": { "startLine": 92, "endLine": 105 },
     "type": "axiom",
     "title": "Conjecture 1 (Disproved)",
     "content": "**erdos_hajnal_conjecture_1_false:**\n\nErdős-Hajnal conjectured: f((log n)², n) ≥ n^(1/2 - o(1))\n\nThis would mean: if every (log n)²-vertex subgraph has α ≥ log n, then the whole graph has α almost √n.\n\n**DISPROVED!** The true bound is only Θ((log n)² / log log n), which is MUCH smaller than √n.\n\nThe conjecture was off by an exponential factor!",
+    "mathContext": "The negation ¬(∀ ε > 0, ...) means there exists ε > 0 for which the bound fails for infinitely many n. The gap between polylogarithmic truth and polynomial conjecture shows a fundamental misunderstanding of propagation strength.",
     "significance": "critical",
-    "relatedConcepts": ["False conjectures", "Tight bounds"]
+    "relatedConcepts": ["false conjectures", "tight bounds", "polynomial vs polylogarithmic"]
   },
   {
     "id": "ann-e804-conjecture-2",
     "proofId": "erdos-804",
-    "range": { "startLine": 129, "endLine": 142 },
+    "range": { "startLine": 107, "endLine": 120 },
     "type": "axiom",
     "title": "Conjecture 2 (Disproved)",
     "content": "**erdos_hajnal_conjecture_2_false:**\n\nErdős-Hajnal conjectured: f((log n)³, n) ≫ (log n)³\n\nThis would mean: if every (log n)³-vertex subgraph has α ≥ log n, then the whole graph has α much larger than (log n)³.\n\n**DISPROVED!** The true bound is only Θ((log n)² / log log n), which is smaller than (log n)³.\n\nRemarkably, increasing m from (log n)² to (log n)³ doesn't significantly improve the global bound!",
+    "mathContext": "This reveals a saturation effect: beyond a threshold, increasing the local window size m doesn't help. The bottleneck for global independence is not local structure but rather global density properties.",
     "significance": "critical",
-    "relatedConcepts": ["False conjectures", "Saturation effects"]
+    "relatedConcepts": ["saturation effects", "false conjectures", "diminishing returns"]
   },
   {
     "id": "ann-e804-upper-bound",
     "proofId": "erdos-804",
-    "range": { "startLine": 150, "endLine": 162 },
+    "range": { "startLine": 128, "endLine": 140 },
     "type": "axiom",
     "title": "Alon-Sudakov Upper Bound",
     "content": "**alon_sudakov_upper_bound_1:**\n\nThere exist graphs where:\n- Every (log n)²-vertex subgraph has α ≥ log n\n- But the global α is only O((log n)²)\n\n**Construction idea:** Dense random graphs G(n, p) with p ≈ 1 - 1/log n have this property. They're dense enough that global α is small, but sparse enough locally to have good local independent sets.",
+    "mathContext": "The existential quantifier (∃ G) combined with the eventually-for-all (∀ᶠ n) shows that counterexamples exist for all sufficiently large n. The constant C in the O((log n)²) bound comes from the probabilistic analysis.",
     "significance": "key",
-    "relatedConcepts": ["Random graphs", "Probabilistic method"]
+    "relatedConcepts": ["random graphs", "probabilistic method", "G(n,p)"]
   },
   {
     "id": "ann-e804-lower-bound",
     "proofId": "erdos-804",
-    "range": { "startLine": 164, "endLine": 176 },
+    "range": { "startLine": 142, "endLine": 154 },
     "type": "axiom",
     "title": "Alon-Sudakov Lower Bound",
     "content": "**alon_sudakov_lower_bound_1:**\n\nAny graph where every (log n)²-vertex subgraph has α ≥ log n must have:\n$$\\alpha(G) \\geq c \\cdot \\frac{(\\log n)^2}{\\log \\log n}$$\n\n**The log log n factor is crucial!** It appears mysteriously in many extremal combinatorics bounds.\n\nCombined with the upper bound, this gives the tight characterization.",
+    "mathContext": "This is a universal statement (∀ G): every graph with the local property must have a global independent set of this size. The cast to ℝ allows the division by log log n.",
     "significance": "key",
-    "relatedConcepts": ["Lower bounds", "Tight bounds", "Log log factors"]
+    "relatedConcepts": ["lower bounds", "tight bounds", "log log factors"]
   },
   {
     "id": "ann-e804-tight-bound-2",
     "proofId": "erdos-804",
-    "range": { "startLine": 178, "endLine": 196 },
+    "range": { "startLine": 156, "endLine": 174 },
     "type": "axiom",
     "title": "Tight Bound for (log n)³",
     "content": "**alon_sudakov_tight_bound_2:**\n\n$$f((\\log n)^3, n) \\asymp \\frac{(\\log n)^2}{\\log \\log n}$$\n\n**Surprising fact:** The answer for m = (log n)³ is THE SAME as for m = (log n)² (up to constants)!\n\nIncreasing the local window size by a factor of log n doesn't help the global bound. The bottleneck is elsewhere.",
-    "mathContext": "This shows a saturation effect: beyond a certain point, stronger local conditions don't improve global outcomes.",
+    "mathContext": "This axiom combines both lower and upper bounds into a single statement, showing the asymptotic equivalence. The conjunction captures both directions of the ≍ relation.",
     "significance": "critical",
-    "relatedConcepts": ["Saturation", "Asymptotic equivalence"]
+    "relatedConcepts": ["saturation", "asymptotic equivalence", "tight characterization"]
   },
   {
     "id": "ann-e804-main-theorem",
     "proofId": "erdos-804",
-    "range": { "startLine": 202, "endLine": 224 },
+    "range": { "startLine": 180, "endLine": 202 },
     "type": "theorem",
-    "title": "Main Theorem",
-    "content": "**erdos_804:**\n\nBoth original Erdős-Hajnal conjectures are FALSE:\n\n1. f((log n)², n) ≱ n^(1/2 - o(1)) ✗\n2. f((log n)³, n) ≯ (log n)³ ✗\n\nThe true answer in both cases is Θ((log n)² / log log n).\n\nThis completely resolves Erdős Problem #804 in the negative.",
+    "title": "Main Theorem — Both Conjectures False",
+    "content": "**erdos_804:**\n\nBoth original Erdős-Hajnal conjectures are FALSE:\n\n1. f((log n)², n) ≱ n^(1/2 - o(1))\n2. f((log n)³, n) ≯ (log n)³\n\nProved by exact ⟨conjecture_1_false, conjecture_2_false⟩ — a direct conjunction of the two disproof axioms.",
+    "mathContext": "This is a fully proved Lean theorem, combining the two axioms via an anonymous constructor. The proof term is a pair of the two axiom applications.",
     "significance": "critical",
-    "relatedConcepts": ["Erdős Problem #804", "Disproof"]
+    "relatedConcepts": ["Erdős Problem #804", "disproof", "conjunction"]
   },
   {
-    "id": "ann-e804-random-graphs",
+    "id": "ann-e804-resolution",
     "proofId": "erdos-804",
-    "range": { "startLine": 232, "endLine": 245 },
-    "type": "concept",
-    "title": "Random Graph Intuition",
-    "content": "**random_graph_intuition:**\n\nRandom graphs G(n, p) with p ≈ 1 - 1/log n provide counterexamples:\n\n1. **Local structure:** In m-vertex induced subgraphs, ≈ m/log n vertices are expected to form an independent set (due to low local density).\n\n2. **Global structure:** But globally, α(G) ≈ (log n)² because the overall edge density is high.\n\nRandom constructions often give optimal or near-optimal examples in extremal graph theory.",
-    "mathContext": "The probabilistic method is a powerful tool: showing random objects have certain properties proves existence.",
-    "significance": "key",
-    "relatedConcepts": ["Probabilistic method", "Random graphs", "G(n,p)"]
-  },
-  {
-    "id": "ann-e804-ramsey",
-    "proofId": "erdos-804",
-    "range": { "startLine": 247, "endLine": 256 },
-    "type": "concept",
-    "title": "Ramsey Theory Connection",
-    "content": "**ramsey_connection:**\n\nThe problem connects to Ramsey theory:\n- Local independence = controlling structure of small induced subgraphs\n- Global independence = large-scale structure\n\nRamsey theory studies how local constraints force global patterns. Here, Erdős-Hajnal overestimated the forcing strength.\n\nNote: This is DIFFERENT from the famous Erdős-Hajnal conjecture about forbidden induced subgraphs (which remains open).",
-    "significance": "key",
-    "relatedConcepts": ["Ramsey numbers", "Regularity lemma", "Erdős-Hajnal conjecture"]
-  },
-  {
-    "id": "ann-e804-problem-805",
-    "proofId": "erdos-804",
-    "range": { "startLine": 262, "endLine": 267 },
-    "type": "concept",
-    "title": "Connection to Problem #805",
-    "content": "**related_to_805:**\n\nErdős Problem #805 asks closely related questions about local-to-global independence.\n\nThe Alon-Sudakov paper [AlSu07] resolves BOTH problems using similar techniques. If you understand #804, you understand the essence of #805 as well.",
-    "significance": "key",
-    "relatedConcepts": ["Problem #805", "Related problems"]
-  },
-  {
-    "id": "ann-e804-summary",
-    "proofId": "erdos-804",
-    "range": { "startLine": 308, "endLine": 334 },
+    "range": { "startLine": 208, "endLine": 242 },
     "type": "theorem",
-    "title": "Summary",
-    "content": "**erdos_804_summary:**\n\n**Erdős Problem #804: DISPROVED (Alon-Sudakov, 2007)**\n\n**Original Questions:**\n1. f((log n)², n) ≥ n^(1/2 - o(1))? **NO**\n2. f((log n)³, n) ≫ (log n)³? **NO**\n\n**True Bounds:**\n1. f((log n)², n) = Θ((log n)² / log log n)\n2. f((log n)³, n) = Θ((log n)² / log log n)\n\n**Key Lesson:** Local structure → global structure is weaker than intuition suggests. The loss is measured by the mysterious log log n factor.",
+    "title": "Full Resolution with Bounds",
+    "content": "**erdos_804_resolution:**\n\nCombines the complete picture:\n1. Both conjectures are false (disproof)\n2. Upper bound: f((log n)², n) ≤ C(log n)² (counterexample exists)\n3. Lower bound: f((log n)², n) ≥ c(log n)²/log log n (universal guarantee)\n\nThis proved theorem packages all four results into a single 4-fold conjunction, giving the definitive answer to Problem #804.",
+    "mathContext": "The proof applies all four axioms: erdos_hajnal_conjecture_1_false, erdos_hajnal_conjecture_2_false, alon_sudakov_upper_bound_1, alon_sudakov_lower_bound_1.",
     "significance": "critical",
-    "relatedConcepts": ["Main result", "Disproof", "Tight bounds"]
+    "relatedConcepts": ["complete resolution", "summary theorem", "Alon-Sudakov 2007"]
   }
 ]

--- a/src/data/proofs/erdos-804/meta.json
+++ b/src/data/proofs/erdos-804/meta.json
@@ -45,23 +45,25 @@
       "IsIndependent definition: no adjacent pairs in vertex set",
       "independenceNumber definition: α(G) as maximum independent set",
       "HasLocalIndependence definition: (m,k)-local independence property",
+      "empty_is_independent theorem: basic proof that ∅ is independent",
       "erdos_hajnal_conjecture_1_false axiom: f((log n)², n) ≱ n^(1/2-o(1))",
       "erdos_hajnal_conjecture_2_false axiom: f((log n)³, n) ≯ (log n)³",
       "alon_sudakov_upper_bound_1 axiom: upper bound for (log n)² case",
       "alon_sudakov_lower_bound_1 axiom: lower bound with log log n factor",
       "alon_sudakov_tight_bound_2 axiom: tight bounds for (log n)³ case",
-      "erdos_804 theorem: main disproof result"
+      "erdos_804 theorem: main disproof combining both conjectures",
+      "erdos_804_resolution theorem: full resolution with Alon-Sudakov bounds"
     ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #804** was posed by Erdős and Hajnal as part of their study of local-to-global structure in graphs. The question asks: if every small induced subgraph has a good independent set, how good must the global independent set be?\n\n**Historical Development:**\n- **1991 (Erdős [Er91]):** Posed the problem with conjectured bounds.\n- **2007 (Alon-Sudakov [AlSu07]):** Completely resolved both questions in the NEGATIVE. The conjectured bounds were far too optimistic.\n\n**Key Insight:** Local independent set structure does NOT propagate as strongly to global structure as Erdős and Hajnal expected. The true bounds involve an extra log log n factor in the denominator.",
     "problemStatement": "**Problem Statement (Disproved)**\n\nLet $f(m, n)$ be maximal such that any graph on $n$ vertices in which every induced subgraph on $m$ vertices has an independent set of size $\\geq \\log n$ must contain an independent set of size $\\geq f(n)$.\n\n**Questions:**\n1. Is $f((\\log n)^2, n) \\geq n^{1/2 - o(1)}$?\n2. Is $f((\\log n)^3, n) \\gg (\\log n)^3$?\n\n**Answers: BOTH NO!** (Alon-Sudakov, 2007)\n\n**True Bounds:**\n$$\\frac{(\\log n)^2}{\\log \\log n} \\ll f((\\log n)^2, n) \\ll (\\log n)^2$$\n$$f((\\log n)^3, n) \\asymp \\frac{(\\log n)^2}{\\log \\log n}$$",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Definitions:** Define independent sets, independence number α(G), and local independence property.\n\n2. **False Conjectures:** Axiomatize that both Erdős-Hajnal conjectures are false.\n\n3. **True Bounds:** Axiomatize Alon-Sudakov's upper and lower bounds showing the correct answer involves (log n)² / log log n.\n\n4. **Intuition:** Explain why random graphs provide counterexamples.\n\n5. **Related Results:** Connection to Problem #805 and the different Erdős-Hajnal conjecture.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Definitions:** Define independent sets, independence number α(G), and local independence property.\n\n2. **False Conjectures:** Axiomatize that both Erdős-Hajnal conjectures are false.\n\n3. **True Bounds:** Axiomatize Alon-Sudakov's upper and lower bounds showing the correct answer involves (log n)² / log log n.\n\n4. **Main Theorems:** Combine the disproof and resolution into proved summary theorems.",
     "keyInsights": [
       "**Local vs Global:** Having large independent sets in ALL small subgraphs doesn't force a proportionally large global independent set.",
       "**Conjecture 1 Failed:** f((log n)², n) ≈ (log n)² / log log n, NOT n^(1/2-o(1)). The true bound is polylogarithmic, not polynomial!",
       "**Conjecture 2 Failed:** f((log n)³, n) ≈ (log n)² / log log n, NOT (log n)³. Going from m = (log n)² to m = (log n)³ doesn't help much.",
-      "**Random Graphs:** Dense random graphs provide counterexamples - they have good local structure but limited global independent sets.",
+      "**Random Graphs:** Dense random graphs provide counterexamples — they have good local structure but limited global independent sets.",
       "**Log Log Factor:** The mysterious log log n divisor appears in both tight bounds, reflecting subtle structure.",
       "**Related Problem #805:** Similar questions answered by the same Alon-Sudakov techniques."
     ]
@@ -70,69 +72,48 @@
     {
       "id": "independent-sets",
       "title": "Independent Sets in Graphs",
-      "summary": "Definition of independent sets and independence number α(G)",
+      "summary": "Definition of independent sets and independence number α(G).",
       "startLine": 42,
       "endLine": 69
     },
     {
       "id": "f-function",
       "title": "The Function f(m, n)",
-      "summary": "Local independence property and the f(m,n) function",
+      "summary": "Local independence property definition capturing the core question.",
       "startLine": 71,
-      "endLine": 106
+      "endLine": 84
     },
     {
       "id": "conjectures",
       "title": "Erdős-Hajnal's Conjectures",
-      "summary": "The two conjectured bounds, both disproved",
-      "startLine": 108,
-      "endLine": 142
+      "summary": "The two conjectured bounds, both disproved by Alon-Sudakov.",
+      "startLine": 86,
+      "endLine": 120
     },
     {
       "id": "alon-sudakov",
       "title": "Alon-Sudakov's Resolution (2007)",
-      "summary": "The true bounds establishing the disproof",
-      "startLine": 144,
-      "endLine": 196
+      "summary": "Upper and lower bounds establishing the true answer: Θ((log n)² / log log n).",
+      "startLine": 122,
+      "endLine": 174
     },
     {
       "id": "main-results",
-      "title": "Main Results Summary",
-      "summary": "The main theorem showing both conjectures false",
-      "startLine": 198,
-      "endLine": 224
+      "title": "Main Results",
+      "summary": "erdos_804 theorem showing both conjectures false.",
+      "startLine": 176,
+      "endLine": 202
     },
     {
-      "id": "intuition",
-      "title": "Proof Intuition",
-      "summary": "Random graphs and Ramsey theory connections",
-      "startLine": 226,
-      "endLine": 256
-    },
-    {
-      "id": "related",
-      "title": "Related Results",
-      "summary": "Connection to Problem #805 and Erdős-Hajnal conjecture",
-      "startLine": 258,
-      "endLine": 275
-    },
-    {
-      "id": "examples",
-      "title": "Examples",
-      "summary": "Complete graphs, empty graphs, and Paley graphs",
-      "startLine": 277,
-      "endLine": 302
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "Main theorem and final answer",
-      "startLine": 304,
-      "endLine": 337
+      "id": "resolution",
+      "title": "Full Resolution",
+      "summary": "erdos_804_resolution combining disproof with precise Alon-Sudakov bounds.",
+      "startLine": 204,
+      "endLine": 244
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #804 asked two questions about how local independent set structure propagates globally. Both conjectures were DISPROVED by Alon and Sudakov (2007). The true bounds are (log n)² / log log n, far smaller than the conjectured n^(1/2-o(1)) and (log n)³. This demonstrates that local structure doesn't force global structure as strongly as intuition might suggest.",
+    "summary": "Erdős Problem #804 asked two questions about how local independent set structure propagates globally. Both conjectures were DISPROVED by Alon and Sudakov (2007). The true bounds are (log n)² / log log n, far smaller than the conjectured n^(1/2-o(1)) and (log n)³. This demonstrates that local structure doesn't force global structure as strongly as intuition suggests.",
     "implications": "**Implications for Extremal Graph Theory**\n\n1. **Local-Global Gap:** The gap between local and global independent set structure is larger than expected.\n\n2. **Polylogarithmic vs Polynomial:** The true answer is polylogarithmic, not polynomial in n.\n\n3. **Log Log Factor:** The mysterious log log n appears in tight bounds, a common phenomenon in extremal combinatorics.\n\n4. **Random Constructions:** Random graphs continue to provide extremal examples.",
     "openQuestions": [
       "What is the exact leading constant in f((log n)², n)?",


### PR DESCRIPTION
## Summary
- Removed 8 placeholder theorems (True := trivial) from Lean file
- Removed meaningless `f_local_to_global` definition using `Classical.choose`
- Added `erdos_804_resolution` theorem combining disproof with Alon-Sudakov bounds
- Updated annotations.json line ranges to match rewritten Lean file
- Updated meta.json originalContributions

## Checklist
- [x] No True := trivial placeholders remain
- [x] pnpm build succeeds
- [x] Quality check passes (has-quality-issues.sh returns clean)
- [x] Annotations align with Lean file line numbers

Generated by enhancer-2