### PR TITLE
enhance(erdos-976): fix docstrings, improve annotations and meta

### DIFF
--- a/proofs/Proofs/Erdos976Problem.lean
+++ b/proofs/Proofs/Erdos976Problem.lean
@@ -1,4 +1,4 @@
-/-!
+/-
 Erdős Problem #976: Greatest Prime Divisor of Polynomial Products
 
 Source: https://erdosproblems.com/976
@@ -32,7 +32,7 @@ import Mathlib.Algebra.Polynomial.Basic
 
 namespace Erdos976
 
-/-!
+/-
 ## Part I: Basic Definitions
 -/
 
@@ -66,7 +66,7 @@ def F_f (f : Polynomial ℤ) (n : ℕ) : ℕ :=
   (List.range n).map (fun m => greatestPrimeDivisor (f.eval (m + 1)).natAbs)
     |>.maximum? |>.getD 1
 
-/-!
+/-
 ## Part II: Known Lower Bounds
 -/
 
@@ -98,7 +98,7 @@ axiom tenenbaum_bound (f : Polynomial ℤ) :
     ∃ C c : ℝ, C > 0 ∧ c > 0 ∧ ∀ n : ℕ, n ≥ 2 →
       (F_f f n : ℝ) ≥ C * n * Real.exp ((Real.log n) ^ c)
 
-/-!
+/-
 ## Part III: The Main Conjectures
 -/
 
@@ -120,7 +120,7 @@ def conjecture_degree_growth (f : Polynomial ℤ) : Prop :=
   ∃ C : ℝ, C > 0 ∧ ∀ n : ℕ, n ≥ 2 →
     (F_f f n : ℝ) ≥ C * (n : ℝ) ^ (polyDegree f)
 
-/-!
+/-
 ## Part IV: Upper Bounds
 -/
 
@@ -132,7 +132,7 @@ axiom trivial_upper_bound (f : Polynomial ℤ) :
     isIrreducible f → polyDegree f ≥ 2 →
     ∃ C : ℝ, ∀ n : ℕ, (F_f f n : ℝ) ≤ C * (n : ℝ) ^ (polyDegree f)
 
-/-!
+/-
 ## Part V: Computational Examples
 -/
 
@@ -160,7 +160,7 @@ At n = 1000, for degree d = 2:
 example : (1000 : ℕ) * 7 = 7000 := by native_decide  -- ≈ n log n
 example : (1000 : ℕ) ^ 2 = 1000000 := by native_decide  -- n^d for d=2
 
-/-!
+/-
 ## Part VI: Summary
 -/
 

--- a/src/data/proofs/erdos-976/annotations.json
+++ b/src/data/proofs/erdos-976/annotations.json
@@ -1,146 +1,123 @@
 [
   {
-    "id": "ann-976-1",
+    "id": "ann-e976-header",
     "proofId": "erdos-976",
-    "range": {
-      "startLine": 1,
-      "endLine": 26
-    },
+    "range": { "startLine": 1, "endLine": 26 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "Erdős Problem #976: For irreducible f ∈ ℤ[x] of degree d ≥ 2, let F_f(n) = greatest prime dividing ∏_{m=1}^n f(m). Is F_f(n) ≫ n^{1+c} or even n^d? The main conjectures remain OPEN. Best known: F_f(n) ≫ n·exp((log n)^c) by Tenenbaum (1990).",
-    "significance": "critical"
+    "content": "**Erdős Problem #976**: For irreducible f ∈ ℤ[x] of degree d ≥ 2, let F_f(n) = greatest prime dividing ∏_{m=1}^n f(m). Is F_f(n) ≫ n^{1+c} or even n^d?\n\nThe main conjectures remain OPEN. Best known: F_f(n) ≫ n·exp((log n)^c) by Tenenbaum (1990).\n\nThe progression of bounds from n log n (1922) to n·exp((log n)^c) (1990) spans nearly 70 years, yet the gap to the conjectured polynomial growth remains enormous.",
+    "mathContext": "This problem connects prime factorization theory to polynomial evaluation. The key difficulty is that while individual values f(m) can be smooth, the product ∏f(m) must contain increasingly large prime factors as m grows.",
+    "significance": "critical",
+    "relatedConcepts": ["Irreducible polynomials", "Prime divisors", "Sieve methods", "Analytic number theory"]
   },
   {
-    "id": "ann-976-2",
+    "id": "ann-e976-irreducible",
     "proofId": "erdos-976",
-    "range": {
-      "startLine": 39,
-      "endLine": 44
-    },
+    "range": { "startLine": 39, "endLine": 44 },
     "type": "definition",
     "title": "Irreducible Polynomial",
-    "content": "A polynomial f ∈ ℤ[x] is irreducible if it has degree ≥ 1 and cannot be factored into polynomials of smaller degree over ℤ. Examples: x² + 1, x² - 2, x³ - 2. This is analogous to prime numbers among integers.",
-    "significance": "critical"
+    "content": "**isIrreducible f** — A polynomial f ∈ ℤ[x] is irreducible if it has degree ≥ 1 and cannot be factored into polynomials of smaller degree over ℤ.\n\n**Examples:** x² + 1, x² - 2, x³ - 2\n\nThis is analogous to prime numbers among integers. Irreducibility ensures the polynomial doesn't decompose into simpler factors that could be analyzed separately.",
+    "mathContext": "The irreducibility condition is essential. For reducible f = g·h, the problem reduces to analyzing F_g(n) and F_h(n) separately, making the combinatorics much simpler.",
+    "significance": "critical",
+    "relatedConcepts": ["Irreducibility", "Polynomial factorization", "Algebraic number theory"]
   },
   {
-    "id": "ann-976-3",
+    "id": "ann-e976-gpd",
     "proofId": "erdos-976",
-    "range": {
-      "startLine": 52,
-      "endLine": 58
-    },
+    "range": { "startLine": 52, "endLine": 58 },
     "type": "definition",
     "title": "Greatest Prime Divisor",
-    "content": "P(n) = max{p prime : p | n}. For example, P(60) = 5 since 60 = 2² · 3 · 5. By convention P(1) = 1. Computed via Nat.factors and maximum?. This function measures the 'smoothness' of an integer — smooth numbers have small P(n).",
-    "significance": "critical"
+    "content": "**P(n) = max{p prime : p | n}**, with P(1) = 1 by convention.\n\n**Examples:** P(60) = 5 since 60 = 2² · 3 · 5; P(210) = 7 since 210 = 2 · 3 · 5 · 7.\n\nComputed via Nat.factors and maximum?. This function measures the 'smoothness' of an integer — smooth numbers have small P(n), and the problem asks how non-smooth polynomial values must be.",
+    "mathContext": "The study of P(n) connects to smooth number theory. An integer n is y-smooth if P(n) ≤ y. The Dickman function ρ(u) gives the density of n ≤ x that are x^{1/u}-smooth.",
+    "significance": "critical",
+    "relatedConcepts": ["Smooth numbers", "Dickman function", "Prime factorization"]
   },
   {
-    "id": "ann-976-4",
+    "id": "ann-e976-ff",
     "proofId": "erdos-976",
-    "range": {
-      "startLine": 60,
-      "endLine": 67
-    },
+    "range": { "startLine": 60, "endLine": 67 },
     "type": "definition",
     "title": "The Function F_f(n)",
-    "content": "F_f(n) = greatest prime dividing f(m) for any 1 ≤ m ≤ n. Computed by mapping greatestPrimeDivisor over polynomial evaluations at 1,...,n and taking the maximum. This captures the largest prime factor appearing in the first n polynomial values.",
-    "significance": "critical"
+    "content": "**F_f(n)** = greatest prime dividing f(m) for any 1 ≤ m ≤ n.\n\nComputed by mapping greatestPrimeDivisor over polynomial evaluations at 1,...,n and taking the maximum. Equivalently, F_f(n) = P(∏_{m=1}^n f(m)).\n\nThis captures the largest prime factor appearing in the first n polynomial values.",
+    "mathContext": "The max-over-evaluations formulation is equivalent to P of the product because the greatest prime factor of a product equals the maximum of the greatest prime factors of the terms.",
+    "significance": "critical",
+    "relatedConcepts": ["Extremal functions", "Polynomial evaluation", "Maximum over sequences"]
   },
   {
-    "id": "ann-976-5",
+    "id": "ann-e976-nagell-ricci",
     "proofId": "erdos-976",
-    "range": {
-      "startLine": 77,
-      "endLine": 79
-    },
-    "type": "theorem",
+    "range": { "startLine": 73, "endLine": 79 },
+    "type": "axiom",
     "title": "Nagell-Ricci Bound (1922)",
-    "content": "F_f(n) ≫ n log n for any irreducible f of degree ≥ 2. This was the first non-trivial lower bound, establishing that F_f(n) grows faster than linear. The proof uses elementary number theory and counting arguments.",
-    "significance": "critical"
+    "content": "**F_f(n) ≫ n log n** for any irreducible f of degree ≥ 2.\n\nThis was the first non-trivial lower bound, establishing that F_f(n) grows faster than linear. The proof uses elementary number theory and counting arguments about prime factors.\n\nFor n = 1000: bound gives ≈ 6908.",
+    "mathContext": "The n log n bound is only slightly super-linear. Compare: the prime number theorem gives π(x) ~ x/log x, so there are roughly n/log n primes up to n. The bound says F_f(n) grows like n times this inverse density.",
+    "significance": "key",
+    "relatedConcepts": ["Prime number theorem", "Elementary bounds", "Counting arguments"]
   },
   {
-    "id": "ann-976-6",
+    "id": "ann-e976-erdos-1952",
     "proofId": "erdos-976",
-    "range": {
-      "startLine": 86,
-      "endLine": 89
-    },
-    "type": "theorem",
+    "range": { "startLine": 81, "endLine": 89 },
+    "type": "axiom",
     "title": "Erdős Bound (1952)",
-    "content": "F_f(n) ≫ n(log n)^{log log log n}. Erdős improved Nagell-Ricci using sieve methods to count integers with large prime factors. The iterated logarithm exponent shows slow but unbounded growth beyond n log n.",
-    "significance": "critical"
+    "content": "**F_f(n) ≫ n(log n)^{log log log n}**\n\nErdős improved Nagell-Ricci using sieve methods to count integers with large prime factors. The triply-iterated logarithm exponent shows slow but unbounded growth beyond n log n.\n\n**Scale:** log log log n grows incredibly slowly: for n = 10^{10}, log log log n ≈ 3.0",
+    "mathContext": "The iterated logarithm bound is characteristic of sieve methods, which often produce bounds involving iterated logs. The improvement over n log n is real but tiny in practice.",
+    "significance": "key",
+    "relatedConcepts": ["Sieve methods", "Iterated logarithms", "Erdős sieve"]
   },
   {
-    "id": "ann-976-7",
+    "id": "ann-e976-tenenbaum",
     "proofId": "erdos-976",
-    "range": {
-      "startLine": 96,
-      "endLine": 99
-    },
-    "type": "theorem",
+    "range": { "startLine": 91, "endLine": 99 },
+    "type": "axiom",
     "title": "Tenenbaum Bound (1990)",
-    "content": "F_f(n) ≫ n·exp((log n)^c) for some c > 0. Currently the best rigorous bound. The exp((log n)^c) factor grows faster than any power of log but slower than any power of n — a 'sub-polynomial' improvement over linearity.",
-    "significance": "critical"
+    "content": "**F_f(n) ≫ n·exp((log n)^c)** for some c > 0.\n\nCurrently the best rigorous bound. The exp((log n)^c) factor grows faster than any power of log n but slower than any power of n — a 'sub-polynomial' improvement over linearity.\n\nTenenbaum used large sieve inequalities to prove this. Erdős had claimed this bound in 1965 but never published a valid proof.",
+    "mathContext": "Functions of the form exp((log x)^c) for 0 < c < 1 are called 'sub-exponential' in the exponent. They appear naturally in many number-theoretic contexts, including integer factoring algorithms.",
+    "significance": "critical",
+    "relatedConcepts": ["Large sieve inequality", "Sub-exponential functions", "Tenenbaum"]
   },
   {
-    "id": "ann-976-8",
+    "id": "ann-e976-conjectures",
     "proofId": "erdos-976",
-    "range": {
-      "startLine": 109,
-      "endLine": 112
-    },
-    "type": "theorem",
-    "title": "Polynomial Growth Conjecture",
-    "content": "Conjecture: F_f(n) ≫ n^{1+c} for some c > 0. This would establish true polynomial growth, vastly stronger than current bounds. The gap between n·exp((log n)^c) and n^{1+c} is enormous — the conjecture remains OPEN.",
-    "significance": "critical"
+    "range": { "startLine": 101, "endLine": 121 },
+    "type": "definition",
+    "title": "The Main Conjectures",
+    "content": "**conjecture_polynomial_growth:** F_f(n) ≫ n^{1+c} for some c > 0. This would be a true polynomial-scale improvement.\n\n**conjecture_degree_growth:** F_f(n) ≫ n^d where d = deg(f). The stronger form says the polynomial's degree controls the growth exponent.\n\nBoth remain OPEN. The gap between the known n·exp((log n)^c) and the conjectured n^{1+c} is enormous — for any fixed c > 0, n^{1+c} eventually dwarfs n·exp((log n)^{0.99}).",
+    "mathContext": "If the degree growth conjecture holds, then combined with the trivial upper bound F_f(n) ≤ C·n^d, we'd have F_f(n) = Θ(n^d), completely determining the growth rate.",
+    "significance": "critical",
+    "relatedConcepts": ["Polynomial growth", "Open conjectures", "Growth rate classification"]
   },
   {
-    "id": "ann-976-9",
+    "id": "ann-e976-upper",
     "proofId": "erdos-976",
-    "range": {
-      "startLine": 118,
-      "endLine": 121
-    },
-    "type": "theorem",
-    "title": "Degree Growth Conjecture",
-    "content": "Stronger conjecture: F_f(n) ≫ n^d where d = deg(f). This says the degree of the polynomial controls the growth exponent. Would imply quadratics give n², cubics give n³, etc. Also OPEN.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-976-10",
-    "proofId": "erdos-976",
-    "range": {
-      "startLine": 131,
-      "endLine": 133
-    },
-    "type": "theorem",
+    "range": { "startLine": 123, "endLine": 133 },
+    "type": "axiom",
     "title": "Trivial Upper Bound",
-    "content": "F_f(n) ≤ C·n^d since |f(m)| ≤ C·m^d, so all prime factors of f(m) are at most C·n^d. Combined with the degree growth conjecture, this would make F_f(n) = Θ(n^d), showing the upper bound is essentially tight if the conjecture holds.",
-    "significance": "key"
+    "content": "**F_f(n) ≤ C·n^d** since |f(m)| ≤ C·m^d for a degree-d polynomial, so all prime factors of f(m) are at most C·n^d.\n\nCombined with the degree growth conjecture, this would make F_f(n) = Θ(n^d), showing the upper bound is essentially tight if the conjecture holds.",
+    "mathContext": "The upper bound comes from the simple fact that the greatest prime factor of an integer cannot exceed the integer itself. Since f(m) is a degree-d polynomial, |f(m)| = O(m^d).",
+    "significance": "key",
+    "relatedConcepts": ["Upper bounds", "Polynomial growth", "Theta notation"]
   },
   {
-    "id": "ann-976-11",
+    "id": "ann-e976-examples",
     "proofId": "erdos-976",
-    "range": {
-      "startLine": 146,
-      "endLine": 152
-    },
+    "range": { "startLine": 135, "endLine": 161 },
     "type": "theorem",
-    "title": "Greatest Prime Divisor Examples",
-    "content": "Computational verification of P(n) using native_decide: P(1) = 1, P(2) = 2, P(6) = 3, P(30) = 5, P(60) = 5, P(210) = 7, P(100) = 5. These demonstrate the function extracts the largest prime factor from integer factorizations.",
-    "significance": "supporting"
+    "title": "Computational Examples",
+    "content": "**Greatest prime divisor examples** verified via native_decide:\n\n| n | P(n) | Factorization |\n|---|------|---------------|\n| 1 | 1 | (convention) |\n| 2 | 2 | 2 |\n| 6 | 3 | 2 · 3 |\n| 30 | 5 | 2 · 3 · 5 |\n| 60 | 5 | 2² · 3 · 5 |\n| 210 | 7 | 2 · 3 · 5 · 7 |\n| 100 | 5 | 2² · 5² |\n\nAlso: numerical comparison at n = 1000 showing the gap between n log n ≈ 7000 and n² = 1,000,000.",
+    "mathContext": "The primorial numbers (2, 6, 30, 210, 2310, ...) are products of the first k primes. Their greatest prime factors are exactly the k-th prime, making them good test cases.",
+    "significance": "supporting",
+    "relatedConcepts": ["native_decide", "Primorial numbers", "Computational verification"]
   },
   {
-    "id": "ann-976-12",
+    "id": "ann-e976-summary",
     "proofId": "erdos-976",
-    "range": {
-      "startLine": 181,
-      "endLine": 186
-    },
+    "range": { "startLine": 163, "endLine": 188 },
     "type": "theorem",
     "title": "Summary Theorem",
-    "content": "erdos_976_status is a proved theorem establishing the current best bound: for all irreducible f of degree ≥ 2, F_f(n) ≫ n·exp((log n)^c). Proof: direct application of tenenbaum_bound axiom. This captures the state of the art for Erdős Problem #976.",
-    "significance": "critical"
+    "content": "**erdos_976_status** is a proved theorem establishing the current best bound: for all irreducible f of degree ≥ 2, F_f(n) ≫ n·exp((log n)^c).\n\nProof: direct application of tenenbaum_bound axiom via `exact tenenbaum_bound f h_irred h_deg`.\n\nThis captures the state of the art for Erdős Problem #976, packaging the Tenenbaum result into a clean theorem statement.",
+    "mathContext": "Summary theorems are valuable for formalizations of open problems — they document what is currently known in a single, citable result.",
+    "significance": "critical",
+    "relatedConcepts": ["Summary theorems", "Tenenbaum bound", "State of the art"]
   }
 ]

--- a/src/data/proofs/erdos-976/meta.json
+++ b/src/data/proofs/erdos-976/meta.json
@@ -61,11 +61,11 @@
     "problemStatement": "Let f ∈ ℤ[x] be an irreducible polynomial of degree d ≥ 2. Define F_f(n) = max{p prime : p | f(m) for some 1 ≤ m ≤ n}, equivalently the greatest prime divisor of ∏_{m=1}^n f(m). Question: Is F_f(n) ≫ n^{1+c} for some constant c > 0? Or even ≫ n^d?",
     "proofStrategy": "The formalization defines F_f computationally via Nat.factors and presents the three known lower bounds (Nagell-Ricci, Erdős, Tenenbaum) as axioms with precise type signatures. The two open conjectures are formalized as Prop definitions. The summary theorem erdos_976_status is proved by applying the tenenbaum_bound axiom, establishing the current best known result. Computational examples verify greatestPrimeDivisor via native_decide.",
     "keyInsights": [
-      "The degree d of the polynomial should control the growth rate of F_f(n)",
-      "Current best bound n·exp((log n)^c) is sub-polynomial but super-linear",
-      "The gap between known bounds and conjectures is enormous",
-      "Prime distribution in polynomial values connects to algebraic number theory",
-      "Sieve methods and large sieve inequalities are the key analytic tools"
+      "**Degree Controls Growth:** The degree d of the polynomial should control the growth rate of F_f(n), with the strongest conjecture predicting F_f(n) ~ n^d",
+      "**Sub-Polynomial Gap:** Current best bound n·exp((log n)^c) is sub-polynomial but super-linear — enormously weaker than the conjectured n^{1+c}",
+      "**Three Eras of Progress:** Nagell-Ricci (1922) → n log n; Erdős (1952) → n(log n)^{log log log n}; Tenenbaum (1990) → n·exp((log n)^c)",
+      "**Smoothness Connection:** P(n) = greatest prime factor measures how 'smooth' a number is; this problem asks how non-smooth polynomial values must be",
+      "**Sieve Methods:** Large sieve inequalities and multiplicative number theory are the key analytic tools for these bounds"
     ]
   },
   "sections": [


### PR DESCRIPTION
## Summary
Quality rework for Erdős Problem #976 (Greatest Prime Divisor of Polynomial Products).

## Changes
- Converted all `/-!` docstrings to `/-` for Aristotle parser compatibility
- Added bold headers to keyInsights in meta.json
- Rewrote all 11 annotations with mathContext, relatedConcepts, and richer educational content
- Improved annotation IDs to follow exemplar naming convention (ann-e976-*)

## Checklist
- [x] Lean proof compiles (structure unchanged)
- [x] pnpm build succeeds
- [x] Annotations align with Lean file line numbers
- [x] No scraping garbage in meta.json
- [x] keyInsights use bold header format

🤖 Generated by enhancer-1