### PR TITLE
enhance(erdos-1099): fix docstrings, sorries count, annotation line ranges

### DIFF
--- a/proofs/Proofs/Erdos1099Problem.lean
+++ b/proofs/Proofs/Erdos1099Problem.lean
@@ -38,7 +38,7 @@ open Nat Finset BigOperators
 
 namespace Erdos1099
 
-/-!
+/-
 ## Part I: Divisors and Consecutive Ratios
 
 For a positive integer n, its divisors can be ordered as 1 = d₁ < d₂ < ⋯ < d_τ(n) = n.
@@ -72,7 +72,7 @@ For n ≥ 1, the last divisor is always n.
 axiom last_divisor_is_n (n : ℕ) (hn : n ≥ 1) :
     (sortedDivisors n).getLast? = some n
 
-/-!
+/-
 ## Part II: The h_α Function
 
 The key function measures how "spread out" the divisor ratios are.
@@ -104,7 +104,7 @@ theorem h_alpha_eq_sum (α : ℝ) (n : ℕ) :
     h_alpha α n = (divisorRatios n).map (fun r => ((r : ℝ) - 1) ^ α) |>.sum := by
   rfl
 
-/-!
+/-
 ## Part III: The Trivial Lower Bound
 
 The first term alone gives h_α(n) ≥ 1 for n ≥ 2.
@@ -126,7 +126,7 @@ Proof: The first term is ((d₂/1) - 1)^α ≥ (2-1)^α = 1.
 axiom h_alpha_ge_one (α : ℝ) (hα : α > 1) (n : ℕ) (hn : n ≥ 2) :
     h_alpha α n ≥ 1
 
-/-!
+/-
 ## Part IV: Special Sequences
 
 Erdős suggested that n! and lcm{1,...,n} might have bounded h_α.
@@ -145,14 +145,14 @@ lcm{1,...,n} has many small divisors as well.
 def lcmDivisors (n : ℕ) : Finset ℕ :=
   (List.range (n + 1) |>.foldl lcm 1).divisors
 
-/-!
+/-
 **Open Sub-questions:**
 - Does h_α(n!) remain bounded as n → ∞?
 - Does h_α(lcm{1,...,n}) remain bounded as n → ∞?
 These specific candidates suggested by Erdős remain unresolved.
 -/
 
-/-!
+/-
 ## Part V: Vose's Theorem (1984)
 
 Vose answered the question affirmatively by constructing a different sequence.
@@ -193,7 +193,7 @@ theorem erdos_1099 (α : ℝ) (hα : α > 1) :
     obtain ⟨n, hn_pos, hn_bound⟩ := hbound ε hε
     exact ⟨n, hn_pos, by linarith⟩
 
-/-!
+/-
 ## Part VI: The Related Sum Σ(d_{i+1}/dᵢ)
 
 Erdős also studied the unweighted sum of ratios.
@@ -222,24 +222,24 @@ Is liminf (Σᵢ (d_{i+1}/dᵢ) - τ(n) - log(n)) < ∞?
 
 This would follow from a positive answer to the main question.
 -/
-/-!
+/-
 If h_α is bounded along a subsequence, the related sum question
 Σ(d_{i+1}/dᵢ) - τ(n) - log(n) < ∞ follows along the same subsequence.
 -/
 
-/-!
+/-
 ## Part VII: Connection to Problem #673
 
 This problem resembles the function considered in Erdős Problem #673.
 -/
 
-/-!
+/-
 **Connection to Problem #673:**
 Both problems study functions of consecutive divisor ratios,
 exploring how "smooth" the divisor structure of integers can be.
 -/
 
-/-!
+/-
 ## Part VIII: Proof Strategy
 
 Vose's approach and why Erdős's candidates remain open.
@@ -262,7 +262,7 @@ lcm{1,...,n} has many prime factors, giving it many divisors.
 But proving uniform bounds on consecutive ratios is non-trivial.
 -/
 
-/-!
+/-
 ## Part IX: Examples
 -/
 
@@ -289,7 +289,7 @@ Ratios: 2/1=2, 3/2=1.5, 4/3≈1.33, 6/4=1.5, 12/6=2
 h_α(12) = 1^α + 0.5^α + 0.33^α + 0.5^α + 1^α (approximately)
 -/
 
-/-!
+/-
 ## Part X: Summary
 -/
 

--- a/src/data/proofs/erdos-1099/annotations.json
+++ b/src/data/proofs/erdos-1099/annotations.json
@@ -33,7 +33,7 @@
   {
     "id": "ann-e1099-divisor-ratios",
     "proofId": "erdos-1099",
-    "range": { "startLine": 84, "endLine": 90 },
+    "range": { "startLine": 81, "endLine": 87 },
     "type": "definition",
     "title": "Consecutive Divisor Ratios",
     "content": "**divisorRatios (n):**\n\nThe list of ratios d_{i+1}/dᵢ for consecutive divisors.\n\n**Example for n = 12:**\nDivisors: [1, 2, 3, 4, 6, 12]\nRatios: [2/1, 3/2, 4/3, 6/4, 12/6] = [2, 1.5, 1.33, 1.5, 2]\n\n**Key observation:** The product of all ratios equals n (telescoping product).",
@@ -43,7 +43,7 @@
   {
     "id": "ann-e1099-h-alpha",
     "proofId": "erdos-1099",
-    "range": { "startLine": 92, "endLine": 100 },
+    "range": { "startLine": 89, "endLine": 97 },
     "type": "definition",
     "title": "The h_α Function",
     "content": "**h_alpha (α) (n):**\n\n$$h_\\alpha(n) = \\sum_i \\left(\\frac{d_{i+1}}{d_i} - 1\\right)^\\alpha$$\n\nThis measures the total \"gap irregularity\" of divisors:\n- Each term (ratio - 1)^α is 0 when ratio = 1 (adjacent divisors)\n- Larger ratios contribute more, especially for large α\n- Small h_α means ALL ratios are close to 1\n\n**Key:** The α > 1 constraint makes this non-linear, penalizing large gaps.",
@@ -54,7 +54,7 @@
   {
     "id": "ann-e1099-lower-bound",
     "proofId": "erdos-1099",
-    "range": { "startLine": 124, "endLine": 132 },
+    "range": { "startLine": 120, "endLine": 127 },
     "type": "theorem",
     "title": "Trivial Lower Bound",
     "content": "**h_alpha_ge_one:**\n\n```lean\ntheorem h_alpha_ge_one (α : ℝ) (hα : α > 1) (n : ℕ) (hn : n ≥ 2) :\n    h_alpha α n ≥ 1\n```\n\n**Why?** For any n ≥ 2:\n- The first divisor is 1\n- The second divisor d₂ ≥ 2 (smallest prime factor)\n- So the first ratio d₂/1 ≥ 2\n- Therefore (d₂ - 1)^α ≥ (2-1)^α = 1\n\nThis shows liminf h_α(n) ≥ 1 trivially.",
@@ -64,7 +64,7 @@
   {
     "id": "ann-e1099-factorial",
     "proofId": "erdos-1099",
-    "range": { "startLine": 146, "endLine": 150 },
+    "range": { "startLine": 135, "endLine": 139 },
     "type": "definition",
     "title": "Factorial Divisors",
     "content": "**factorialDivisors (n):**\n\nThe divisors of n!. Factorials have MANY divisors because they contain every prime up to n.\n\n**Example:** 5! = 120 = 2³ · 3 · 5\nτ(120) = 4 · 2 · 2 = 16 divisors\n\n**Erdős's Question:** Does h_α(n!) remain bounded? STILL OPEN!",
@@ -75,7 +75,7 @@
   {
     "id": "ann-e1099-lcm",
     "proofId": "erdos-1099",
-    "range": { "startLine": 152, "endLine": 157 },
+    "range": { "startLine": 141, "endLine": 146 },
     "type": "definition",
     "title": "LCM Divisors",
     "content": "**lcmDivisors (n):**\n\nThe divisors of lcm{1, 2, ..., n}. This number has each prime p ≤ n appearing exactly once with maximal power p^⌊log_p(n)⌋.\n\n**Example:** lcm{1,...,6} = 60 = 2² · 3 · 5\n\n**Erdős's Question:** Does h_α(lcm{1,...,n}) remain bounded? STILL OPEN!",
@@ -86,7 +86,7 @@
   {
     "id": "ann-e1099-vose-sequence",
     "proofId": "erdos-1099",
-    "range": { "startLine": 177, "endLine": 187 },
+    "range": { "startLine": 161, "endLine": 171 },
     "type": "axiom",
     "title": "Vose's Bounded Sequence",
     "content": "**vose_bounded_sequence:**\n\nFor any α > 1, there exists a bound C and a sequence (nₖ) such that h_α(nₖ) ≤ C for all k.\n\n**Key insight:** Vose constructed numbers whose divisors are very evenly spaced:\n- If all τ ratios are approximately 1 + c/τ\n- Then h_α ≈ τ · (c/τ)^α = c^α · τ^(1-α) → 0\n\nThe construction is specific and doesn't use n! or lcm.",
@@ -97,7 +97,7 @@
   {
     "id": "ann-e1099-vose-theorem",
     "proofId": "erdos-1099",
-    "range": { "startLine": 189, "endLine": 197 },
+    "range": { "startLine": 173, "endLine": 181 },
     "type": "axiom",
     "title": "Vose's Theorem (1984)",
     "content": "**vose_liminf_bounded:**\n\nFor any α > 1, liminf_{n→∞} h_α(n) is finite.\n\n**This resolves Erdős Problem #1099!**\n\nThe answer is YES: there exist integers with arbitrarily small h_α values (approaching some finite limit inferior).",
@@ -108,7 +108,7 @@
   {
     "id": "ann-e1099-main-theorem",
     "proofId": "erdos-1099",
-    "range": { "startLine": 199, "endLine": 210 },
+    "range": { "startLine": 183, "endLine": 194 },
     "type": "theorem",
     "title": "Main Theorem",
     "content": "**erdos_1099:**\n\n```lean\ntheorem erdos_1099 (α : ℝ) (hα : α > 1) :\n    ∃ C : ℝ, C > 0 ∧ ∀ ε > 0, ∃ n : ℕ, n > 0 ∧ h_alpha α n < C + ε\n```\n\nThis formalizes the answer to Erdős's question: YES, the liminf is bounded.\n\nThe proof extracts a bound from Vose's axiom.",
@@ -118,7 +118,7 @@
   {
     "id": "ann-e1099-sum-ratio-bound",
     "proofId": "erdos-1099",
-    "range": { "startLine": 225, "endLine": 233 },
+    "range": { "startLine": 209, "endLine": 217 },
     "type": "axiom",
     "title": "Sum of Ratios Lower Bound",
     "content": "**sum_divisor_ratios_lower_bound:**\n\n$$\\sum_i \\frac{d_{i+1}}{d_i} > \\tau(n) + \\log(n)$$\n\n**Why?** \n- There are τ(n) - 1 ratios, each ≥ 1\n- The product of ratios is n (telescoping)\n- By AM-GM, the sum exceeds what we'd expect from uniform ratios\n\n**Related question:** Is liminf(Σ ratios - τ - log n) < ∞? This follows from the main result.",
@@ -128,7 +128,7 @@
   {
     "id": "ann-e1099-prime-example",
     "proofId": "erdos-1099",
-    "range": { "startLine": 293, "endLine": 300 },
+    "range": { "startLine": 269, "endLine": 275 },
     "type": "theorem",
     "title": "Example: Primes",
     "content": "**prime_h_alpha_unbounded:**\n\nFor a prime p, divisors are just {1, p}, with single ratio p.\n\nh_α(p) = (p - 1)^α → ∞ as p → ∞\n\n**Lesson:** Primes are the WORST case for divisor regularity. They have only one gap, and it's maximal.\n\nThis shows we need composite numbers with many divisors to achieve bounded h_α.",
@@ -138,7 +138,7 @@
   {
     "id": "ann-e1099-power-two",
     "proofId": "erdos-1099",
-    "range": { "startLine": 302, "endLine": 309 },
+    "range": { "startLine": 277, "endLine": 283 },
     "type": "theorem",
     "title": "Example: Powers of 2",
     "content": "**power_of_two_h_alpha:**\n\nFor n = 2^k, divisors are {1, 2, 4, ..., 2^k}, with k ratios all equal to 2.\n\nh_α(2^k) = k · (2-1)^α = k · 1 = k\n\n**Lesson:** Even with many divisors, if ratios are uniform but not close to 1, h_α still grows.\n\nPowers of 2 grow linearly in h_α, which is better than primes but still unbounded.",
@@ -148,7 +148,7 @@
   {
     "id": "ann-e1099-summary",
     "proofId": "erdos-1099",
-    "range": { "startLine": 323, "endLine": 345 },
+    "range": { "startLine": 296, "endLine": 319 },
     "type": "theorem",
     "title": "Summary",
     "content": "**erdos_1099_summary:**\n\n**Q:** For α > 1, is liminf h_α(n) bounded?\n\n**A:** YES (Vose, 1984)\n\n**Key points:**\n1. Trivial lower bound: liminf ≥ 1\n2. Primes are terrible: h_α(p) = (p-1)^α → ∞\n3. Powers of 2 grow linearly: h_α(2^k) = k\n4. Vose constructed good examples with bounded h_α\n5. Whether n! or lcm{1,...,n} work remains OPEN\n\nThis resolves a question about divisor structure from 1981.",

--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 0,
     "erdosNumber": 1099,
     "erdosUrl": "https://erdosproblems.com/1099",
     "erdosProblemStatus": "solved",
@@ -79,70 +79,70 @@
       "title": "Divisors and Consecutive Ratios",
       "summary": "Definition of τ(n), sorted divisors, and the divisor ratio list",
       "startLine": 41,
-      "endLine": 76
+      "endLine": 73
     },
     {
       "id": "h-alpha-function",
       "title": "The h_α Function",
       "summary": "Main function measuring divisor gap regularity",
-      "startLine": 78,
-      "endLine": 108
+      "startLine": 75,
+      "endLine": 105
     },
     {
       "id": "lower-bound",
       "title": "The Trivial Lower Bound",
       "summary": "h_α(n) ≥ 1 for n ≥ 2",
-      "startLine": 110,
-      "endLine": 132
+      "startLine": 107,
+      "endLine": 127
     },
     {
       "id": "special-sequences",
       "title": "Special Sequences",
       "summary": "Factorial and lcm divisors, Erdős's open conjectures",
-      "startLine": 134,
-      "endLine": 169
+      "startLine": 129,
+      "endLine": 153
     },
     {
       "id": "vose-theorem",
       "title": "Vose's Theorem (1984)",
       "summary": "The main resolution: bounded liminf exists",
-      "startLine": 171,
-      "endLine": 210
+      "startLine": 155,
+      "endLine": 194
     },
     {
       "id": "related-sum",
       "title": "The Related Sum",
       "summary": "The sum Σ(d_{i+1}/dᵢ) and its lower bound",
-      "startLine": 212,
-      "endLine": 243
+      "startLine": 196,
+      "endLine": 228
     },
     {
       "id": "problem-673",
       "title": "Connection to Problem #673",
       "summary": "Related problem on divisor ratio functions",
-      "startLine": 245,
-      "endLine": 256
+      "startLine": 230,
+      "endLine": 240
     },
     {
       "id": "proof-strategy",
       "title": "Proof Strategy",
       "summary": "Vose's approach and why natural candidates remain open",
-      "startLine": 258,
-      "endLine": 287
+      "startLine": 242,
+      "endLine": 263
     },
     {
       "id": "examples",
       "title": "Examples",
       "summary": "Primes, powers of 2, and highly composite numbers",
-      "startLine": 289,
-      "endLine": 317
+      "startLine": 265,
+      "endLine": 291
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Main theorem and key takeaways",
-      "startLine": 319,
-      "endLine": 347
+      "startLine": 292,
+      "endLine": 321
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Replace all `/-!` docstrings with `/-` for Aristotle compatibility (13 instances)
- Fix `sorries` count in meta.json from 6 to 0 (file uses axioms, not sorries; `erdos_1099` and `erdos_1099_summary` are fully proved)
- Update all section line ranges in meta.json and annotation line ranges in annotations.json to match actual Lean file positions

## Test plan
- [x] `pnpm build` succeeds
- [x] Only erdos-1099 files modified
- [x] Lean file syntax preserved (only `/-!` → `/-` changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)