### PR TITLE
fix(erdos-355): remove True := trivial placeholder

### DIFF
--- a/proofs/Proofs/Erdos355Problem.lean
+++ b/proofs/Proofs/Erdos355Problem.lean
@@ -370,7 +370,6 @@ theorem fibLikeSeq_pos : ∀ n, fibLikeSeq n > 0 := by
     rationals in some interval.
 
     The van Doorn-Kovač proof constructs explicit sequences achieving this. -/
-theorem intuition_explained : True := trivial
 
 /-- Summary: Erdős Problem #355 (SOLVED - YES)
 

--- a/src/data/proofs/erdos-355/annotations.json
+++ b/src/data/proofs/erdos-355/annotations.json
@@ -112,8 +112,8 @@
   {
     "id": "ann-e355-intuition",
     "proofId": "erdos-355",
-    "range": { "startLine": 363, "endLine": 373 },
-    "type": "lemma",
+    "range": { "startLine": 363, "endLine": 372 },
+    "type": "concept",
     "title": "Intuition: Why λ < 2 Works",
     "content": "**The key intuition**: For λ = 2, reciprocal sums are exactly dyadic rationals - a discrete, nowhere-dense set. For λ < 2, the 'overlap' between consecutive levels of the sequence allows reciprocal sums to become dense, eventually covering all rationals in some interval.",
     "mathContext": "When λ < 2, we have a_{n+1} < 2a_n, so the intervals [1/a_{n+1}, 1/a_n] overlap in a way that allows filling gaps. The construction is delicate and requires careful analysis.",
@@ -123,7 +123,7 @@
   {
     "id": "ann-e355-summary",
     "proofId": "erdos-355",
-    "range": { "startLine": 375, "endLine": 386 },
+    "range": { "startLine": 374, "endLine": 385 },
     "type": "theorem",
     "title": "Summary of Results",
     "content": "**erdos_355_summary** packages the main results: (1) existence of lacunary sequences covering intervals, (2) powers of 2 form a lacunary sequence with λ = 2, (3) 3/2 is in the valid range (1, 2).",

--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -17,7 +17,7 @@
       "reciprocal-sums"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 355,
     "erdosUrl": "https://erdosproblems.com/355",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Summary
- Remove `intuition_explained : True := trivial` placeholder theorem
- Fix `sorries` count in meta.json from 3 to 0 (file has axioms, not sorries)
- Update annotation line ranges for removed line

## Test plan
- [x] `pnpm build` succeeds
- [x] Only erdos-355 files modified (3 files, net -1 line)
- [x] Quality check passes after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)