### PR TITLE
fix(erdos-487): remove True := trivial placeholders

### DIFF
--- a/proofs/Proofs/Erdos487Problem.lean
+++ b/proofs/Proofs/Erdos487Problem.lean
@@ -107,8 +107,6 @@ def factorizationSet (n : ℕ) : Set (ℕ × ℕ) :=
 lcm(a, b) = c iff factorizationSet(a) ∪ factorizationSet(b) = factorizationSet(c)
 (under the max operation on exponents).
 -/
-theorem lcm_union_correspondence : True := trivial  -- Structural correspondence
-
 /-
 ## Part III: Davenport-Erdős Theorem (1936)
 -/
@@ -333,7 +331,6 @@ theorem even_numbers_example : IsLCMTriple 4 6 12 := by
 
 7. Contradiction: δN ≤ o(N) fails for large N.
 -/
-theorem proof_outline : True := trivial
 
 /-
 ## Part VIII: Summary

--- a/src/data/proofs/erdos-487/annotations.json
+++ b/src/data/proofs/erdos-487/annotations.json
@@ -54,7 +54,7 @@
   {
     "id": "ann-e487-factorization",
     "proofId": "erdos-487",
-    "range": { "startLine": 96, "endLine": 111 },
+    "range": { "startLine": 96, "endLine": 103 },
     "type": "definition",
     "title": "Prime Factorization Bijection",
     "content": "**factorizationSet n:** The set of (prime, exponent) pairs in n's factorization.\n\nThis creates a bijection ℕ⁺ → P(ℙ × ℕ). Under this map:\n- lcm(a, b) corresponds to union (taking max exponents)\n- gcd(a, b) corresponds to intersection (taking min exponents)",
@@ -65,7 +65,7 @@
   {
     "id": "ann-e487-davenport",
     "proofId": "erdos-487",
-    "range": { "startLine": 113, "endLine": 158 },
+    "range": { "startLine": 110, "endLine": 156 },
     "type": "axiom",
     "title": "Davenport-Erdős 1936",
     "content": "**davenport_erdos_1936:**\n\nIf A ⊆ ℕ has positive upper density, then A contains an infinite divisibility chain a₁ | a₂ | a₃ | ...\n\n**coprime_multipliers_lcm_triple:**\n\nIf gcd(k, m) = 1 with k > 1, m > 1, then (a*k, a*m, a*k*m) is an LCM triple.\n\nThis is proved directly using Nat.Coprime.lcm_eq_mul.",
@@ -76,7 +76,7 @@
   {
     "id": "ann-e487-kleitman",
     "proofId": "erdos-487",
-    "range": { "startLine": 161, "endLine": 223 },
+    "range": { "startLine": 158, "endLine": 221 },
     "type": "axiom",
     "title": "Kleitman's Theorem 1971",
     "content": "**kleitman_1971:**\n\nUnion-free collections F ⊆ P([n]) satisfy:\n|F| ≤ (1 + o(1)) · C(n, ⌊n/2⌋)\n\nThis is exponentially smaller than 2^n (since C(n,n/2) ≈ 2^n/√n).\n\n**union_free_is_little_o:**\n\nThe corollary that |F| / 2^n < ε for large n. Proved using Kleitman's bound and the asymptotics of C(n, n/2).",
@@ -87,7 +87,7 @@
   {
     "id": "ann-e487-main",
     "proofId": "erdos-487",
-    "range": { "startLine": 226, "endLine": 246 },
+    "range": { "startLine": 223, "endLine": 243 },
     "type": "theorem",
     "title": "Main Theorem",
     "content": "**lcm_triple_in_dense_set:**\n\nIf A ⊆ ℕ has positive upper density, then A contains distinct a, b, c with lcm(a,b) = c.\n\n**infinitely_many_lcm_triples:**\n\nIn fact, there are infinitely many such triples.\n\nThese are the main results resolving Erdős Problem #487.",
@@ -97,7 +97,7 @@
   {
     "id": "ann-e487-example-6",
     "proofId": "erdos-487",
-    "range": { "startLine": 248, "endLine": 272 },
+    "range": { "startLine": 245, "endLine": 264 },
     "type": "theorem",
     "title": "Example: Multiples of 6",
     "content": "**multiples_of_6_example:** IsLCMTriple 12 18 36\n\nA = {6, 12, 18, 24, ...} has density 1/6.\n\nlcm(12, 18) = 36 ∈ A gives an explicit LCM triple.\n\nVerified computationally with native_decide.",
@@ -107,7 +107,7 @@
   {
     "id": "ann-e487-example-pow2",
     "proofId": "erdos-487",
-    "range": { "startLine": 273, "endLine": 302 },
+    "range": { "startLine": 266, "endLine": 295 },
     "type": "theorem",
     "title": "Counterexample: Powers of 2",
     "content": "**powers_of_2_no_lcm_triple:**\n\nA = {1, 2, 4, 8, 16, ...} has NO LCM triples.\n\nlcm(2^i, 2^j) = 2^(max i j), which equals either a or b.\n\nProved using Nat.Prime.pow_max_lcm and case analysis on max.\n\nBut this set has density 0, so the theorem doesn't apply.",
@@ -118,7 +118,7 @@
   {
     "id": "ann-e487-example-even",
     "proofId": "erdos-487",
-    "range": { "startLine": 303, "endLine": 313 },
+    "range": { "startLine": 296, "endLine": 310 },
     "type": "theorem",
     "title": "Example: Even Numbers",
     "content": "**even_numbers_example:** IsLCMTriple 4 6 12\n\nA = {2, 4, 6, 8, ...} has density 1/2.\n\nlcm(4, 6) = 12 ∈ A gives an explicit LCM triple.\n\nThe even numbers have many LCM triples due to their density.",
@@ -128,7 +128,7 @@
   {
     "id": "ann-e487-proof-outline",
     "proofId": "erdos-487",
-    "range": { "startLine": 315, "endLine": 337 },
+    "range": { "startLine": 312, "endLine": 334 },
     "type": "concept",
     "title": "Proof Outline",
     "content": "**Proof by contradiction:**\n\n1. Assume A has density δ > 0 but no LCM triples.\n2. Map A via prime factorization to a collection F of sets.\n3. F is union-free (since LCM ↔ union).\n4. By Kleitman: |F| = o(2^(log N)) = o(N).\n5. But |A ∩ [1,N]| ≥ δN for large N.\n6. Contradiction: δN ≤ o(N) fails.",
@@ -139,7 +139,7 @@
   {
     "id": "ann-e487-summary",
     "proofId": "erdos-487",
-    "range": { "startLine": 339, "endLine": 371 },
+    "range": { "startLine": 335, "endLine": 368 },
     "type": "theorem",
     "title": "Summary Theorem",
     "content": "**erdos_487_summary:**\n\nCombines both main results:\n\n1. Dense sets contain LCM triples (main result)\n2. Kleitman's bound on union-free collections (the tool)\n\n**Conclusion:** Erdős Problem #487 is SOLVED affirmatively.",

--- a/src/data/proofs/erdos-487/meta.json
+++ b/src/data/proofs/erdos-487/meta.json
@@ -44,32 +44,38 @@
     {
       "id": "union-free",
       "startLine": 83,
-      "endLine": 111,
+      "endLine": 109,
       "summary": "Definition of union-free collections and the prime factorization bijection connecting LCM to set union."
     },
     {
       "id": "davenport-erdos",
-      "startLine": 112,
-      "endLine": 149,
-      "summary": "The 1936 result that sets with positive density contain infinite divisibility chains."
+      "startLine": 110,
+      "endLine": 156,
+      "summary": "The 1936 Davenport-Erdős result and the coprime multipliers LCM triple construction."
     },
     {
       "id": "kleitman",
-      "startLine": 150,
-      "endLine": 187,
-      "summary": "The 1971 theorem bounding union-free collections to (1+o(1))·C(n, ⌊n/2⌋), which resolves Problem #487."
+      "startLine": 158,
+      "endLine": 221,
+      "summary": "Kleitman's 1971 theorem bounding union-free collections, plus the o(2^n) corollary."
     },
     {
       "id": "main-result",
-      "startLine": 188,
-      "endLine": 209,
+      "startLine": 223,
+      "endLine": 243,
       "summary": "The main theorem: dense sets contain LCM triples, plus infinitely many such triples."
     },
     {
       "id": "examples",
-      "startLine": 210,
-      "endLine": 259,
+      "startLine": 245,
+      "endLine": 310,
       "summary": "Concrete examples including multiples of 6 (LCM triples exist) and powers of 2 (no LCM triples, but density 0)."
+    },
+    {
+      "id": "summary",
+      "startLine": 335,
+      "endLine": 368,
+      "summary": "Summary combining LCM triple existence and Kleitman's theorem."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove `lcm_union_correspondence : True := trivial` placeholder (line 110)
- Remove `proof_outline : True := trivial` placeholder (line 336)
- Update all section and annotation line ranges for removed lines
- Add summary section to meta.json

## Test plan
- [x] `pnpm build` succeeds
- [x] Only erdos-487 files modified
- [x] Lean file compiles (placeholders removed, substantive theorems preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)