### PR TITLE
Research: erdos-185 - prove f3_is_little_o from DHJ (8→7 axioms)

### DIFF
--- a/proofs/Proofs/Erdos185Problem.lean
+++ b/proofs/Proofs/Erdos185Problem.lean
@@ -299,11 +299,97 @@ axiom density_hales_jewett_k3 (δ : ℝ) (hδ : δ > 0) :
         ∃ L : CombinatorialLine n, L.points ⊆ S
 
 /--
+**Cap sets avoid combinatorial lines:**
+An arithmetic cap set (no collinear triple) also avoids combinatorial lines.
+The key insight: the three points of a combinatorial line satisfy OnLine.
+-/
+theorem isCapSet_implies_isCapSetCombinatorial {S : Finset (TernaryHypercube n)}
+    (hS : IsCapSet S) : IsCapSetCombinatorial S := by
+  intro L hL
+  -- Extract the three points on the combinatorial line
+  let p : ZMod 3 → TernaryHypercube n := fun t i => if i ∈ L.varying then t else L.fixed i
+  -- All three points are in S (since L.points ⊆ S)
+  have hp : ∀ t : ZMod 3, p t ∈ S := by
+    intro t
+    apply hL
+    simp only [CombinatorialLine.points]
+    exact Finset.mem_image_of_mem _ (Finset.mem_univ _)
+  -- The three points are collinear: p 0 + p 2 = 2 * p 1
+  have hline : OnLine (p 0) (p 1) (p 2) := by
+    intro i
+    simp only [p]
+    split_ifs with h
+    · -- Varying coordinate: 0 + 2 = 2 * 1 in ZMod 3
+      decide
+    · -- Fixed coordinate: fixed i + fixed i = 2 * fixed i
+      ring
+  -- The three points are distinct (since varying is nonempty)
+  obtain ⟨j, hj⟩ := L.nonempty
+  have h01 : p 0 ≠ p 1 := by
+    intro h
+    have := congr_fun h j
+    simp only [p, if_pos hj] at this
+    exact absurd this (by decide)
+  have h12 : p 1 ≠ p 2 := by
+    intro h
+    have := congr_fun h j
+    simp only [p, if_pos hj] at this
+    exact absurd this (by decide)
+  have h02 : p 0 ≠ p 2 := by
+    intro h
+    have := congr_fun h j
+    simp only [p, if_pos hj] at this
+    exact absurd this (by decide)
+  -- This contradicts IsCapSet
+  exact hS (p 0) (p 1) (p 2) (hp 0) (hp 1) (hp 2) h01 h12 h02 hline
+
+/--
+**Cap set density bound from DHJ:**
+For any ε > 0, for sufficiently large n, every cap set has density < ε.
+-/
+private theorem capSet_density_lt (ε : ℝ) (hε : ε > 0) :
+    ∃ n₀ : ℕ, ∀ n ≥ n₀, ∀ S : Finset (TernaryHypercube n),
+      IsCapSet S → (S.card : ℝ) < ε * 3^n := by
+  obtain ⟨n₀, hn₀⟩ := density_hales_jewett_k3 ε hε
+  exact ⟨n₀, fun n hn S hcap => by
+    by_contra h
+    push_neg at h
+    have hdensity : (S.card : ℝ) / 3^n ≥ ε := by
+      rwa [ge_iff_le, le_div_iff₀ (by positivity : (3 : ℝ)^n > 0)]
+    obtain ⟨L, hL⟩ := hn₀ n hn S hdensity
+    exact isCapSet_implies_isCapSetCombinatorial hcap L hL⟩
+
+/--
+**f₃(n) bound from DHJ:**
+For any ε > 0, for sufficiently large n, f₃(n) ≤ ε * 3^n.
+-/
+private theorem f3_eventually_le (c : ℝ) (hc : c > 0) :
+    ∀ᶠ n in atTop, (f3 n : ℝ) ≤ c * (3 : ℝ)^n := by
+  obtain ⟨n₀, hn₀⟩ := capSet_density_lt c hc
+  rw [Filter.eventually_atTop]
+  refine ⟨n₀, fun n hn => ?_⟩
+  -- f3 n is a natural sSup of a bounded nonempty set, so it is achieved
+  have hf3_mem : f3 n ∈ { m : ℕ | ∃ S : Finset (TernaryHypercube n), IsCapSet S ∧ S.card = m } := by
+    unfold f3
+    exact Nat.sSup_mem ⟨0, f3_nonempty n⟩ (f3_bddAbove n)
+  obtain ⟨S, hcap, hcard⟩ := hf3_mem
+  have hlt := hn₀ n hn S hcap
+  rw [hcard] at hlt
+  linarith
+
+/--
 **Corollary: f₃(n) = o(3^n):**
 The density Hales-Jewett theorem implies cap sets have density → 0.
+Derived from the DHJ axiom (no longer an axiom itself).
 -/
-axiom f3_is_little_o :
-    (fun n => (f3 n : ℝ)) =o[atTop] (fun n => (3 : ℝ)^n)
+theorem f3_is_little_o :
+    (fun n => (f3 n : ℝ)) =o[atTop] (fun n => (3 : ℝ)^n) := by
+  rw [isLittleO_iff]
+  intro c hc
+  filter_upwards [f3_eventually_le c hc] with n hn
+  simp only [Real.norm_of_nonneg (by positivity : (0 : ℝ) ≤ (f3 n : ℝ)),
+             Real.norm_of_nonneg (by positivity : (0 : ℝ) ≤ (3 : ℝ)^n)]
+  exact hn
 
 /--
 **Equivalent formulation:**

--- a/src/data/proofs/erdos-185/annotations.json
+++ b/src/data/proofs/erdos-185/annotations.json
@@ -140,13 +140,13 @@
   {
     "id": "ann-e185-f3-little-o",
     "proofId": "erdos-185",
-    "range": { "startLine": 166, "endLine": 171 },
-    "type": "axiom",
-    "title": "Main Result: f₃(n) = o(3^n)",
-    "content": "**f3_is_little_o:** (λ n, f₃(n)) =o[atTop] (λ n, 3^n).\n\nThis is the answer to Erdős Problem #185: **YES**.\n\nThe density Hales-Jewett theorem implies cap sets have density → 0.",
-    "mathContext": "For any ε > 0, eventually f₃(n) < ε · 3^n.",
+    "range": { "startLine": 301, "endLine": 389 },
+    "type": "theorem",
+    "title": "Main Result: f₃(n) = o(3^n) [PROVED from DHJ]",
+    "content": "**f3_is_little_o:** (λ n, f₃(n)) =o[atTop] (λ n, 3^n).\n\nThis is the answer to Erdős Problem #185: **YES**.\n\n**Now PROVED** (was previously axiomatized) via a chain:\n1. `isCapSet_implies_isCapSetCombinatorial`: cap sets avoid combinatorial lines\n2. `capSet_density_lt`: DHJ contrapositive gives density bound\n3. `f3_eventually_le`: bound lifts to f₃(n) via sSup\n4. `f3_is_little_o`: convert to asymptotic notation",
+    "mathContext": "For any ε > 0, eventually f₃(n) < ε · 3^n. Proved from density_hales_jewett_k3.",
     "significance": "critical",
-    "relatedConcepts": ["Little-o notation", "Asymptotic analysis"]
+    "relatedConcepts": ["Little-o notation", "Asymptotic analysis", "Density Hales-Jewett"]
   },
   {
     "id": "ann-e185-density-zero",

--- a/src/data/proofs/erdos-185/meta.json
+++ b/src/data/proofs/erdos-185/meta.json
@@ -52,7 +52,10 @@
       "moser_lower_bound axiom: f₃(n) ≫ 3^n/√n",
       "moserSet construction",
       "density_hales_jewett axiom",
-      "f3_is_little_o axiom: main result",
+      "f3_is_little_o THEOREM: main result proved from DHJ",
+      "isCapSet_implies_isCapSetCombinatorial: bridging lemma",
+      "capSet_density_lt: density bound from DHJ",
+      "f3_eventually_le: eventual bound on f3(n)",
       "meshulam_upper_bound axiom: f₃(n) ≤ 3^n/n",
       "ellenberg_gijswijt_2016 axiom: f₃(n) ≤ c^n with c < 3",
       "Small value axioms: f₃(1)=2, f₃(2)=4, f₃(3)=9, f₃(4)=20"

--- a/src/data/research/problems/erdos-185.json
+++ b/src/data/research/problems/erdos-185.json
@@ -31,24 +31,24 @@
     "open": [
       "f₃(3) = 9, f₃(4) = 20 (axioms - need enumeration)"
     ],
-    "goal": "All tractable sorries eliminated. 8 axioms remain (deep results)."
+    "goal": "All tractable sorries eliminated. 7 axioms remain (deep results). f3_is_little_o now proved from DHJ."
   },
   "currentState": {
     "phase": "COMPLETE",
-    "since": "2026-02-05T06:00:00Z",
-    "iteration": 6,
-    "focus": "Converted five_or_more_contains_line from axiom to theorem via native_decide",
-    "activeApproach": "Exhaustive finite verification using native_decide over all 512 subsets",
+    "since": "2026-02-06T16:30:00Z",
+    "iteration": 7,
+    "focus": "Proved f3_is_little_o from density_hales_jewett_k3 axiom (eliminated 1 axiom)",
+    "activeApproach": "Derive little-o from DHJ via cap set density bound",
     "blockers": [],
-    "nextAction": "Problem is essentially complete. Remaining 8 axioms are deep results.",
+    "nextAction": "Problem is essentially complete. Remaining 7 axioms are deep results.",
     "attemptCounts": {
-      "total": 6,
-      "currentApproach": 2,
-      "approachesTried": 2
+      "total": 7,
+      "currentApproach": 1,
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: f₃(2) = 4 fully proved. five_or_more_contains_line converted from axiom to theorem via exhaustive native_decide verification. 0 sorries, 8 axioms (all deep results not in Mathlib).",
+    "progressSummary": "COMPLETE: f3_is_little_o now PROVED from density_hales_jewett_k3 (was axiom). New bridge lemma isCapSet_implies_isCapSetCombinatorial connects collinear and combinatorial line definitions. 0 sorries, 7 axioms (all deep results not in Mathlib).",
     "builtItems": [
       "f3_0: f₃(0) = 1",
       "f3_1: f₃(1) = 2",
@@ -68,7 +68,11 @@
       "f3_ge_two: f₃(n) ≥ 2 for n ≥ 1",
       "f3_density_tends_to_zero: PROVED from f3_is_little_o",
       "isCapSet_subset: subsets of cap sets are cap sets",
-      "erdos_185_answer: ε-δ formulation"
+      "erdos_185_answer: ε-δ formulation",
+      "isCapSet_implies_isCapSetCombinatorial: bridge lemma (cap set → no combinatorial lines)",
+      "capSet_density_lt: DHJ contrapositive gives density bound for cap sets",
+      "f3_eventually_le: eventual bound on f₃(n) from density bound",
+      "f3_is_little_o: PROVED (was axiom) from density_hales_jewett_k3"
     ],
     "insights": [
       "f3_2 lower bound: construct explicit cap set {(0,0),(0,1),(1,0),(1,2)} and verify no three are collinear",
@@ -76,17 +80,20 @@
       "hasCollinearTriple Bool function + Finset.all_iff_forall bridges computation and logic",
       "native_decide can handle Finset (Finset (Fin 2 → ZMod 3)) = 2^9 = 512 elements",
       "IsLittleO.tendsto_div_nhds_zero directly gives density → 0",
-      "Mathlib.Data.Fin.VecNotation provides ![...] notation for points"
+      "Mathlib.Data.Fin.VecNotation provides ![...] notation for points",
+      "Combinatorial line points satisfy OnLine: p(0)+p(2)=2*p(1) coordinatewise in ZMod 3",
+      "Nat.sSup_mem gives: sSup of bounded nonempty ℕ set is achieved by some element",
+      "isLittleO_iff + filter_upwards pattern for proving asymptotic bounds"
     ],
     "mathlibGaps": [
       "Density Hales-Jewett not in Mathlib (only combinatorial version)"
     ],
     "nextSteps": [
       "Problem is essentially complete for formalization purposes",
-      "Remaining 8 axioms are deep results not tractable for Lean formalization",
+      "Remaining 7 axioms are deep results not tractable for Lean formalization",
       "Could attempt f3_3 = 9 via similar native_decide approach (3^27 subsets - likely too large)"
     ],
-    "markdown": "# Erdős #185: Cap Sets in {0,1,2}^n - Knowledge\n\n## Problem\nLet f₃(n) be the maximal size of a subset of {0,1,2}^n which contains no three\npoints on a line. Is it true that f₃(n) = o(3^n)?\n\n**Answer**: YES — follows from the density Hales-Jewett theorem.\n\n## Key Results\n\n### Proved Theorems (0 sorries, 8 axioms for deep results)\n\n**Core definitions:**\n1. `TernaryHypercube`: {0,1,2}^n\n2. `OnLine`: collinearity predicate (x+z=2y mod 3)\n3. `IsCapSet`: no three collinear points\n4. `f3`: maximum cap set size function\n\n**Small cases:**\n5. `f3_0`: f₃(0) = 1\n6. `f3_1`: f₃(1) = 2\n7. `f3_2`: f₃(2) = 4 (FULLY PROVED)\n\n**f₃(2) = 4 infrastructure:**\n8. `capSet4`: explicit cap set {(0,0),(0,1),(1,0),(1,2)}\n9. `capSet4_is_cap`: line-free verification\n10. `capSet4_card`: |capSet4| = 4\n11. `f3_2_ge`: f₃(2) ≥ 4 (lower bound)\n12. `hasCollinearTriple`: decidable collinearity check\n13. `five_or_more_has_line_bool`: computational verification (native_decide)\n14. `five_or_more_contains_line`: any 5+ points contain a line (THEOREM)\n15. `capSet2_card_le_4`: |S| ≤ 4 for cap sets in dim 2 (fully proved)\n\n**General bounds:**\n16. `f3_le_three_pow`: f₃(n) ≤ 3^n\n17. `f3_ge_one`: f₃(n) ≥ 1\n18. `f3_ge_two`: f₃(n) ≥ 2 for n ≥ 1\n\n**Main result:**\n19. `f3_density_tends_to_zero`: f₃(n)/3^n → 0\n20. `erdos_185`: f₃(n) = o(3^n)\n21. `erdos_185_answer`: ε-δ formulation\n\n### Iteration 6 Progress (2026-02-05, researcher-1)\n- **Converted `five_or_more_contains_line_axiom` to theorem**\n- Strategy: defined `hasCollinearTriple` Bool function, proved `five_or_more_has_line_bool` via `native_decide` over all 512 subsets\n- Bridged computation to logic via `Finset.all_iff_forall` and `Finset.any_eq_true`\n- `capSet2_card_le_4` now fully proved (0 sorries)\n- `f3_2` now fully proved (0 sorries)\n- Reduced axiom count from 9 to 8\n- Total: 1 axiom eliminated, 1 sorry eliminated\n\n## Axiom Inventory (8 axioms)\n1. `f3_geq_R3` - f₃(n) ≥ R₃(3^n) (embedding theorem)\n2. `moser_lower_bound` - f₃(n) ≫ 3^n/√n (Moser's construction)\n3. `density_hales_jewett_k3` - DHJ for k=3 (Furstenberg-Katznelson 1991)\n4. `f3_is_little_o` - f₃(n) = o(3^n) (derived from DHJ)\n5. `meshulam_upper_bound` - f₃(n) ≤ 3^n/n (Meshulam 1995)\n6. `ellenberg_gijswijt_2016` - f₃(n) ≤ c^n, c < 3 (polynomial method)\n7. `f3_3` - f₃(3) = 9 (finite computation, large)\n8. `f3_4` - f₃(4) = 20 (finite computation, very large)\n\n## Assessment\nThis problem is well-formalized. All tractable sorries and axioms have been eliminated.\nThe remaining 8 axioms are deep mathematical results beyond Mathlib.\n"
+    "markdown": "# Erdős #185: Cap Sets in {0,1,2}^n - Knowledge\n\n## Problem\nLet f₃(n) be the maximal size of a subset of {0,1,2}^n which contains no three\npoints on a line. Is it true that f₃(n) = o(3^n)?\n\n**Answer**: YES — follows from the density Hales-Jewett theorem.\n\n## Key Results\n\n### Proved Theorems (0 sorries, 8 axioms for deep results)\n\n**Core definitions:**\n1. `TernaryHypercube`: {0,1,2}^n\n2. `OnLine`: collinearity predicate (x+z=2y mod 3)\n3. `IsCapSet`: no three collinear points\n4. `f3`: maximum cap set size function\n\n**Small cases:**\n5. `f3_0`: f₃(0) = 1\n6. `f3_1`: f₃(1) = 2\n7. `f3_2`: f₃(2) = 4 (FULLY PROVED)\n\n**f₃(2) = 4 infrastructure:**\n8. `capSet4`: explicit cap set {(0,0),(0,1),(1,0),(1,2)}\n9. `capSet4_is_cap`: line-free verification\n10. `capSet4_card`: |capSet4| = 4\n11. `f3_2_ge`: f₃(2) ≥ 4 (lower bound)\n12. `hasCollinearTriple`: decidable collinearity check\n13. `five_or_more_has_line_bool`: computational verification (native_decide)\n14. `five_or_more_contains_line`: any 5+ points contain a line (THEOREM)\n15. `capSet2_card_le_4`: |S| ≤ 4 for cap sets in dim 2 (fully proved)\n\n**General bounds:**\n16. `f3_le_three_pow`: f₃(n) ≤ 3^n\n17. `f3_ge_one`: f₃(n) ≥ 1\n18. `f3_ge_two`: f₃(n) ≥ 2 for n ≥ 1\n\n**Main result:**\n19. `f3_density_tends_to_zero`: f₃(n)/3^n → 0\n20. `erdos_185`: f₃(n) = o(3^n)\n21. `erdos_185_answer`: ε-δ formulation\n\n### Iteration 6 Progress (2026-02-05, researcher-1)\n- **Converted `five_or_more_contains_line_axiom` to theorem**\n- Strategy: defined `hasCollinearTriple` Bool function, proved `five_or_more_has_line_bool` via `native_decide` over all 512 subsets\n- Bridged computation to logic via `Finset.all_iff_forall` and `Finset.any_eq_true`\n- `capSet2_card_le_4` now fully proved (0 sorries)\n- `f3_2` now fully proved (0 sorries)\n- Reduced axiom count from 9 to 8\n- Total: 1 axiom eliminated, 1 sorry eliminated\n\n## Axiom Inventory (7 axioms)\n1. `f3_geq_R3` - f₃(n) ≥ R₃(3^n) (embedding theorem)\n2. `moser_lower_bound` - f₃(n) ≫ 3^n/√n (Moser's construction)\n3. `density_hales_jewett_k3` - DHJ for k=3 (Furstenberg-Katznelson 1991)\n4. `meshulam_upper_bound` - f₃(n) ≤ 3^n/n (Meshulam 1995)\n5. `ellenberg_gijswijt_2016` - f₃(n) ≤ c^n, c < 3 (polynomial method)\n6. `f3_3` - f₃(3) = 9 (finite computation, large)\n7. `f3_4` - f₃(4) = 20 (finite computation, very large)\n\n**Eliminated axiom:** `f3_is_little_o` now PROVED from `density_hales_jewett_k3`\n\n## Assessment\nThis problem is well-formalized. All tractable sorries and axioms have been eliminated.\nThe remaining 7 axioms are deep mathematical results beyond Mathlib.\n"
   },
   "approaches": [
     {
@@ -98,6 +105,11 @@
       "name": "Axiom derivation",
       "status": "completed",
       "description": "Derive corollaries from axioms (erdos_185_answer from f3_is_little_o)"
+    },
+    {
+      "name": "f3_is_little_o derivation from DHJ",
+      "status": "completed",
+      "description": "Proved f3_is_little_o as theorem from density_hales_jewett_k3. Bridge: IsCapSet → IsCapSetCombinatorial → density bound → little-o."
     }
   ],
   "tags": [
@@ -131,7 +143,7 @@
     ]
   },
   "started": "2026-01-27T22:18:02.333Z",
-  "lastUpdate": "2026-02-05T06:00:00Z",
+  "lastUpdate": "2026-02-06T16:30:00Z",
   "significance": 7,
   "tractability": 7,
   "knowledgeScore": 3


### PR DESCRIPTION
## Summary
- **Prove** `f3_is_little_o` as a theorem derived from `density_hales_jewett_k3` axiom (previously axiomatized separately)
- **Reduce axiom count** from 8 to 7 for Erdős #185 (Cap Sets in {0,1,2}^n)
- **Add 3 new lemmas** bridging the gap between DHJ and the asymptotic result

## Key Proof
The main result `f₃(n) = o(3^n)` is now **derived** from the density Hales-Jewett axiom via:

1. `isCapSet_implies_isCapSetCombinatorial` — Combinatorial line points satisfy `OnLine` (collinearity), so arithmetic cap sets avoid combinatorial lines
2. `capSet_density_lt` — DHJ contrapositive: cap sets have density < ε for large n
3. `f3_eventually_le` — Bound lifts to f₃(n) via `Nat.sSup_mem` (sSup is achieved in ℕ)
4. `f3_is_little_o` — Convert to `IsLittleO` via `isLittleO_iff` + `filter_upwards`

## Files Modified
- `proofs/Proofs/Erdos185Problem.lean` — Main proof changes (+92 lines)
- `src/data/proofs/erdos-185/annotations.json` — Update annotation type axiom→theorem
- `src/data/proofs/erdos-185/meta.json` — Add new contributions
- `src/data/research/problems/erdos-185.json` — Update knowledge and status

## Test plan
- [x] Docker build passes (`./proofs/scripts/docker-build.sh Proofs.Erdos185Problem`)
- [x] 0 sorries, 7 axioms (down from 8)
- [x] All dependent theorems (`f3_density_tends_to_zero`, `erdos_185`, `erdos_185_answer`) still compile

Generated by researcher-1