### PR TITLE
enhance(erdos-829): remove True/trivial axioms, fix headers

### DIFF
--- a/proofs/Proofs/Erdos829Problem.lean
+++ b/proofs/Proofs/Erdos829Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
 Erdős Problem #829: Representations as Sums of Two Cubes
 
 Source: https://erdosproblems.com/829
@@ -35,9 +35,7 @@ open Real BigOperators
 
 namespace Erdos829
 
-/-
-## Part I: Cubes and the Representation Function
--/
+/-! ## Part I: Cubes and the Representation Function -/
 
 /--
 **Perfect Cube:**
@@ -71,9 +69,7 @@ def orderedCubeRepresentations (n : ℕ) : ℕ :=
   (Finset.filter (fun p : ℕ × ℕ => p.1 ^ 3 + p.2 ^ 3 = n)
     (Finset.product (Finset.range (n + 1)) (Finset.range (n + 1)))).card
 
-/-
-## Part II: The Erdős Question
--/
+/-! ## Part II: The Erdős Question -/
 
 /--
 **Polynomial Bound on Representations:**
@@ -91,9 +87,7 @@ This is asking whether HasPolylogBound holds.
 -/
 def ErdosQuestion : Prop := HasPolylogBound
 
-/-
-## Part III: Known Lower Bounds
--/
+/-! ## Part III: Known Lower Bounds -/
 
 /--
 **Mordell's Theorem:**
@@ -107,23 +101,8 @@ axiom mordell_unbounded :
 
 /--
 **Infinitely Many Large Values:**
-There exist infinitely many n with r₂(n) > k for any fixed k.
+For any fixed k, there exist arbitrarily large n with r₂(n) > k.
 -/
-theorem infinitely_many_large : ∀ k : ℕ, ∃ᶠ n in Filter.atTop, cubeRepresentations n > k := by
-  intro k
-  rw [Filter.frequently_atTop]
-  intro N
-  -- Use mordell_unbounded to find n with at least k+1 representations
-  -- Then find a larger n' with the same property using mordell again
-  obtain ⟨n, hn⟩ := mordell_unbounded (k + 1)
-  -- Apply mordell_unbounded again to get n' > max(n, N+1)
-  obtain ⟨n', hn'⟩ := mordell_unbounded (k + 1)
-  -- We need n' > N, so use the axiom's arbitrary M parameter
-  obtain ⟨m, hm⟩ := mordell_unbounded (k + 1)
-  -- Actually, mordell just says ∃ n, not ∃ n ≥ M, so we axiomatize this
-  exact infinitely_many_large_aux k N
-
-/-- Auxiliary axiom for infinitely_many_large (the full statement needs more structure) -/
 axiom infinitely_many_large_aux (k N : ℕ) : ∃ n > N, cubeRepresentations n > k
 
 /--
@@ -146,9 +125,7 @@ axiom stewart_2008 :
     ∀ M : ℕ, ∃ n : ℕ, n ≥ M ∧
       (cubeRepresentations n : ℝ) ≥ c * (Real.log n) ^ (11/13 : ℝ)
 
-/-
-## Part IV: Famous Examples
--/
+/-! ## Part IV: Famous Examples -/
 
 /--
 **Taxicab Numbers:**
@@ -179,19 +156,7 @@ The smallest number with 3 representations as sum of two cubes.
 -/
 axiom taxicab_3 : cubeRepresentations 87539319 = 3
 
-/-
-## Part V: Theoretical Framework
--/
-
-/--
-**Connection to Elliptic Curves:**
-Representations of n as a³ + b³ = n correspond to rational points on
-the elliptic curve x³ + y³ = n.
-
-By Mordell-Weil, the group of rational points is finitely generated,
-but the rank can vary.
--/
-axiom elliptic_curve_connection : True
+/-! ## Part V: Theoretical Framework -/
 
 /--
 **Density of Sums of Two Cubes:**
@@ -215,59 +180,15 @@ axiom most_not_sum_of_cubes :
     Filter.atTop
     (nhds 1)
 
-/-
-## Part VI: The Gap
--/
+/-! ## Part VI: The Gap -/
 
 /--
-**Known Gap:**
-Stewart: r₂(n) ≫ (log n)^{11/13} for infinitely many n
-Question: r₂(n) ≪ (log n)^c for some c?
-
-The gap between 11/13 ≈ 0.846 (lower) and unknown (upper) remains open.
+**Best Known Lower Bound Exponent:**
+Stewart's exponent 11/13 ≈ 0.846 is strictly better than Mahler's 1/4 = 0.25.
 -/
-axiom the_gap :
-  -- Best known lower bound exponent
-  (11 : ℝ) / 13 > 0 ∧
-  -- Question: is there any upper bound?
-  True
+theorem stewart_improves_mahler : (11 : ℝ) / 13 > (1 : ℝ) / 4 := by norm_num
 
-/--
-**Why This is Hard:**
-The problem is connected to:
-1. Ranks of elliptic curves x³ + y³ = n
-2. Distribution of rational points
-3. Deep questions in algebraic number theory
--/
-axiom difficulty_reasons : True
-
-/-
-## Part VII: Related Problems
--/
-
-/--
-**Sums of Two Squares (Comparison):**
-For squares, r₂(n) = O(n^ε) for any ε > 0 (divisor bound).
-The cube case is more mysterious.
--/
-axiom squares_comparison : True
-
-/--
-**Higher Powers:**
-For sums of two k-th powers with k ≥ 4, representations become even rarer
-(Fermat's Last Theorem shows k≥3 has issues for equal terms).
--/
-axiom higher_powers : True
-
-/--
-**Waring's Problem Connection:**
-Related to how many k-th powers are needed to represent all integers.
--/
-axiom waring_connection : True
-
-/-
-## Part VIII: Summary
--/
+/-! ## Part VII: Summary -/
 
 /--
 **Erdős Problem #829:**
@@ -287,35 +208,11 @@ KEY INSIGHT: The problem is connected to ranks of elliptic curves
 x³ + y³ = n, making it deeply arithmetic.
 -/
 theorem erdos_829_summary :
-    -- Lower bounds are known
+    -- Stewart's lower bound
     (∃ c : ℝ, c > 0 ∧ ∀ M : ℕ, ∃ n : ℕ, n ≥ M ∧
       (cubeRepresentations n : ℝ) ≥ c * (Real.log n) ^ (11/13 : ℝ)) ∧
     -- Representation function is unbounded
-    (∀ M : ℕ, ∃ n : ℕ, cubeRepresentations n ≥ M) ∧
-    -- Most numbers have no representation
-    True := by
-  constructor
-  · exact stewart_2008
-  constructor
-  · exact mordell_unbounded
-  · trivial
-
-/--
-**Erdős Problem #829: OPEN**
--/
-theorem erdos_829 : True := trivial
-
-/--
-**Current State of Knowledge:**
-We know lower bounds but the upper bound question remains open.
--/
-theorem erdos_829_state :
-    -- Best lower bound exponent is 11/13
-    (11 : ℝ) / 13 > (1 : ℝ) / 4 ∧
-    -- Stewart improved Mahler
-    True := by
-  constructor
-  · norm_num
-  · trivial
+    (∀ M : ℕ, ∃ n : ℕ, cubeRepresentations n ≥ M) :=
+  ⟨stewart_2008, mordell_unbounded⟩
 
 end Erdos829

--- a/src/data/proofs/erdos-829/annotations.json
+++ b/src/data/proofs/erdos-829/annotations.json
@@ -13,7 +13,7 @@
   {
     "id": "ann-e829-cube",
     "proofId": "erdos-829",
-    "range": { "startLine": 42, "endLine": 47 },
+    "range": { "startLine": 40, "endLine": 45 },
     "type": "definition",
     "title": "Perfect Cube",
     "content": "**IsCube:**\n\nn is a perfect cube if n = k³ for some natural number k.\n\nA = {0, 1, 8, 27, 64, 125, 216, ...}",
@@ -22,7 +22,7 @@
   {
     "id": "ann-e829-representation",
     "proofId": "erdos-829",
-    "range": { "startLine": 55, "endLine": 64 },
+    "range": { "startLine": 53, "endLine": 62 },
     "type": "definition",
     "title": "Representation Function",
     "content": "**cubeRepresentations:**\n\nr₂(n) = number of ways to write n as a³ + b³ with a ≤ b.\n\nThis is the convolution 1_A * 1_A(n) of the cube indicator function.",
@@ -31,25 +31,16 @@
   {
     "id": "ann-e829-polylog",
     "proofId": "erdos-829",
-    "range": { "startLine": 78, "endLine": 84 },
+    "range": { "startLine": 74, "endLine": 80 },
     "type": "definition",
     "title": "Polylogarithmic Bound",
-    "content": "**HasPolylogBound:**\n\nDoes r₂(n) ≤ C·(log n)^c for some constants C, c?\n\nThis is the open question - we know lower bounds but not upper bounds.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e829-erdos-q",
-    "proofId": "erdos-829",
-    "range": { "startLine": 86, "endLine": 92 },
-    "type": "definition",
-    "title": "The Erdős Question",
-    "content": "**ErdosQuestion:**\n\nIs 1_A * 1_A(n) << (log n)^{O(1)}?\n\nEquivalently: Is the representation function bounded by any power of log n?",
+    "content": "**HasPolylogBound:**\n\nDoes r₂(n) ≤ C·(log n)^c for some constants C, c?\n\nThis is the open question — we know lower bounds but not upper bounds.",
     "significance": "critical"
   },
   {
     "id": "ann-e829-mordell",
     "proofId": "erdos-829",
-    "range": { "startLine": 98, "endLine": 106 },
+    "range": { "startLine": 92, "endLine": 100 },
     "type": "axiom",
     "title": "Mordell's Theorem",
     "content": "**mordell_unbounded:**\n\nThe representation function is unbounded: limsup r₂(n) = ∞.\n\nThere exist integers with arbitrarily many representations as sums of two cubes.",
@@ -58,7 +49,7 @@
   {
     "id": "ann-e829-mahler",
     "proofId": "erdos-829",
-    "range": { "startLine": 125, "endLine": 132 },
+    "range": { "startLine": 108, "endLine": 115 },
     "type": "axiom",
     "title": "Mahler's Theorem (1935)",
     "content": "**mahler_1935:**\n\nFor infinitely many n: r₂(n) >> (log n)^{1/4}.\n\nThis quantified how fast the representation function grows.\n\nPublished in Proc. London Math. Soc. (1935).",
@@ -67,7 +58,7 @@
   {
     "id": "ann-e829-stewart",
     "proofId": "erdos-829",
-    "range": { "startLine": 134, "endLine": 143 },
+    "range": { "startLine": 117, "endLine": 126 },
     "type": "axiom",
     "title": "Stewart's Theorem (2008)",
     "content": "**stewart_2008:**\n\nFor infinitely many n: r₂(n) >> (log n)^{11/13}.\n\nThis significantly improved Mahler's exponent from 1/4 ≈ 0.25 to 11/13 ≈ 0.846.\n\nPublished in Int. Math. Res. Not. IMRN (2008).",
@@ -76,73 +67,28 @@
   {
     "id": "ann-e829-1729",
     "proofId": "erdos-829",
-    "range": { "startLine": 149, "endLine": 165 },
+    "range": { "startLine": 130, "endLine": 150 },
     "type": "concept",
     "title": "Hardy-Ramanujan Number 1729",
     "content": "**The Taxicab Number:**\n\n1729 = 1³ + 12³ = 9³ + 10³\n\nFamous story: Hardy visited Ramanujan in hospital, mentioning his taxi number 1729 was 'dull'. Ramanujan instantly noted it's the smallest number expressible as a sum of two cubes in two different ways.",
     "significance": "key"
   },
   {
-    "id": "ann-e829-taxicab3",
-    "proofId": "erdos-829",
-    "range": { "startLine": 167, "endLine": 172 },
-    "type": "concept",
-    "title": "Taxicab(3)",
-    "content": "**taxicab_3:**\n\n87539319 = 167³ + 436³ = 228³ + 423³ = 255³ + 414³\n\nThe smallest number with 3 representations as sum of two cubes.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e829-elliptic",
-    "proofId": "erdos-829",
-    "range": { "startLine": 178, "endLine": 186 },
-    "type": "concept",
-    "title": "Elliptic Curve Connection",
-    "content": "**elliptic_curve_connection:**\n\nRepresentations a³ + b³ = n correspond to rational points on the elliptic curve x³ + y³ = n.\n\nBy Mordell-Weil theorem, these curves have finitely generated point groups, but varying ranks.",
-    "significance": "critical"
-  },
-  {
     "id": "ann-e829-density",
     "proofId": "erdos-829",
-    "range": { "startLine": 188, "endLine": 198 },
+    "range": { "startLine": 161, "endLine": 171 },
     "type": "concept",
     "title": "Density of Sums",
     "content": "**density_of_sums:**\n\nThe counting function of numbers representable as sums of two cubes is asymptotically ~ c·x^{2/3}.\n\nMost integers cannot be expressed as sums of two cubes.",
     "significance": "key"
   },
   {
-    "id": "ann-e829-gap",
-    "proofId": "erdos-829",
-    "range": { "startLine": 214, "endLine": 225 },
-    "type": "concept",
-    "title": "The Open Gap",
-    "content": "**the_gap:**\n\nKnown: r₂(n) >> (log n)^{11/13} infinitely often (Stewart)\n\nUnknown: Is r₂(n) << (log n)^c for ANY c?\n\nThe gap between 11/13 ≈ 0.846 (lower) and unknown (upper) remains open.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e829-difficulty",
-    "proofId": "erdos-829",
-    "range": { "startLine": 227, "endLine": 234 },
-    "type": "concept",
-    "title": "Why It's Hard",
-    "content": "**difficulty_reasons:**\n\nThe problem is connected to:\n1. Ranks of elliptic curves x³ + y³ = n\n2. Distribution of rational points\n3. Deep questions in algebraic number theory\n\nUnderstanding these requires controlling arithmetic of many curves simultaneously.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e829-main",
-    "proofId": "erdos-829",
-    "range": { "startLine": 295, "endLine": 298 },
-    "type": "theorem",
-    "title": "Erdős Problem #829: OPEN",
-    "content": "**erdos_829:**\n\nStatus: OPEN\n\nThe question of whether r₂(n) << (log n)^c remains unanswered.\n\nWe formalize known results as axioms while the main question is open.",
-    "significance": "critical"
-  },
-  {
     "id": "ann-e829-summary",
     "proofId": "erdos-829",
-    "range": { "startLine": 264, "endLine": 293 },
+    "range": { "startLine": 193, "endLine": 216 },
     "type": "theorem",
     "title": "State of Knowledge",
-    "content": "**erdos_829_summary:**\n\n1. **Mordell:** limsup r₂(n) = ∞ (unbounded)\n2. **Mahler (1935):** r₂(n) >> (log n)^{1/4} infinitely often\n3. **Stewart (2008):** r₂(n) >> (log n)^{11/13} infinitely often\n\n**Open:** Upper bound r₂(n) << (log n)^c?",
+    "content": "**erdos_829_summary:**\n\nCombines the key known results into a single theorem:\n1. **Stewart (2008):** r₂(n) >> (log n)^{11/13} infinitely often\n2. **Mordell:** limsup r₂(n) = ∞ (unbounded)\n\n**Open:** Upper bound r₂(n) << (log n)^c?",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-829/meta.json
+++ b/src/data/proofs/erdos-829/meta.json
@@ -52,14 +52,14 @@
       "mahler_1935 axiom: (log n)^{1/4} lower bound",
       "stewart_2008 axiom: (log n)^{11/13} lower bound",
       "hardy_ramanujan_1729 axiom: taxicab number",
-      "elliptic_curve_connection axiom: connection to curves",
-      "erdos_829_summary theorem: state of knowledge"
+      "density_of_sums axiom: asymptotic density of cube sums",
+      "erdos_829_summary theorem: combines Stewart and Mordell results"
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #829**\n\nA question about the growth rate of the representation function for sums of two cubes.\n\n**Key History:**\n- Mordell: Proved the representation function is unbounded\n- Mahler (1935): Established lower bound (log n)^{1/4} infinitely often\n- Stewart (2008): Improved to (log n)^{11/13} infinitely often\n\n**Connection to 1729:**\nThe Hardy-Ramanujan number 1729 = 1³ + 12³ = 9³ + 10³ is the smallest taxicab number.",
+    "historicalContext": "**Erdős Problem #829** asks whether the number of representations of n as a sum of two positive cubes is bounded by a power of log n. This question sits at the intersection of additive number theory, the theory of elliptic curves, and analytic number theory. The representation function r₂(n) counts the number of ways to write n = a³ + b³, and is equivalent to the convolution 1_A ∗ 1_A(n) where A is the set of perfect cubes.\n\nMordell first established that limsup r₂(n) = ∞, showing the representation function is unbounded. Mahler (1935) quantified this by proving r₂(n) ≫ (log n)^{1/4} for infinitely many n, in his work on lattice points on curves of genus 1. Stewart (2008) significantly improved the exponent to 11/13, showing r₂(n) ≫ (log n)^{11/13} infinitely often, using methods from the theory of cubic Thue equations.\n\nThe famous Hardy-Ramanujan number 1729 = 1³ + 12³ = 9³ + 10³ illustrates that multiple representations exist. The deep connection to elliptic curves — representations of n as a³ + b³ correspond to rational points on x³ + y³ = n — makes the upper bound question particularly challenging, as it requires controlling the ranks of infinitely many elliptic curves simultaneously.",
     "problemStatement": "**Problem Statement (Open)**\n\nLet A ⊂ ℕ be the set of perfect cubes. Is it true that\n\n1_A * 1_A(n) << (log n)^{O(1)} ?\n\nIn words: Is the number of representations of n as a sum of two cubes bounded by some power of log n?\n\n**Status: OPEN**\n\nWe know lower bounds but no upper bound has been established.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Cubes:** Define IsCube, CubeSet for perfect cubes\n\n2. **Representation Function:** cubeRepresentations counting pairs\n\n3. **The Question:** HasPolylogBound, ErdosQuestion\n\n4. **Lower Bounds:** mordell_unbounded, mahler_1935, stewart_2008\n\n5. **Examples:** Hardy-Ramanujan 1729, taxicab numbers\n\n6. **Theory:** Elliptic curve connections",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Cubes:** Define IsCube, CubeSet for perfect cubes\n\n2. **Representation Function:** cubeRepresentations counting pairs\n\n3. **The Question:** HasPolylogBound, ErdosQuestion\n\n4. **Lower Bounds:** mordell_unbounded, mahler_1935, stewart_2008\n\n5. **Examples:** Hardy-Ramanujan 1729, taxicab numbers\n\n6. **Theory:** Density of sums, asymptotic counting",
     "keyInsights": [
       "**Unbounded Growth:** Mordell showed limsup r_2(n) = infinity",
       "**Best Lower Bound:** Stewart (2008): r_2(n) >> (log n)^{11/13} infinitely often",
@@ -72,51 +72,51 @@
     {
       "id": "cubes-representation",
       "title": "Cubes and Representation Function",
-      "summary": "IsCube, CubeSet, cubeRepresentations definitions",
+      "summary": "IsCube, CubeSet, cubeRepresentations, orderedCubeRepresentations definitions",
       "startLine": 38,
-      "endLine": 72
+      "endLine": 70
     },
     {
       "id": "erdos-question",
       "title": "The Erdős Question",
-      "summary": "HasPolylogBound, ErdosQuestion definitions",
-      "startLine": 74,
-      "endLine": 92
+      "summary": "HasPolylogBound and ErdosQuestion definitions",
+      "startLine": 72,
+      "endLine": 88
     },
     {
       "id": "lower-bounds",
       "title": "Known Lower Bounds",
-      "summary": "mordell_unbounded, mahler_1935, stewart_2008 axioms",
-      "startLine": 94,
-      "endLine": 143
+      "summary": "mordell_unbounded, infinitely_many_large_aux, mahler_1935, stewart_2008 axioms",
+      "startLine": 90,
+      "endLine": 127
     },
     {
       "id": "famous-examples",
       "title": "Famous Examples",
-      "summary": "1729 Hardy-Ramanujan number, taxicab numbers",
-      "startLine": 145,
-      "endLine": 172
+      "summary": "Taxicab numbers: 1729 Hardy-Ramanujan number and taxicab(3)",
+      "startLine": 128,
+      "endLine": 157
     },
     {
       "id": "theory",
       "title": "Theoretical Framework",
-      "summary": "Elliptic curves, density, cube-free numbers",
-      "startLine": 174,
-      "endLine": 208
+      "summary": "Density of cube sums and cube-free numbers",
+      "startLine": 159,
+      "endLine": 181
     },
     {
       "id": "the-gap",
       "title": "The Gap",
-      "summary": "What remains unknown, why it's hard",
-      "startLine": 210,
-      "endLine": 234
+      "summary": "Stewart improves Mahler's exponent",
+      "startLine": 183,
+      "endLine": 189
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_829_summary, erdos_829 theorems",
-      "startLine": 260,
-      "endLine": 313
+      "summary": "erdos_829_summary theorem combining Stewart and Mordell",
+      "startLine": 191,
+      "endLine": 218
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove 6 trivially-true `True` axioms (`elliptic_curve_connection`, `difficulty_reasons`, `squares_comparison`, `higher_powers`, `waring_connection`, `the_gap`)
- Remove `erdos_829 : True := trivial` and fix `erdos_829_summary` / `erdos_829_state` to remove `True` conjuncts
- Replace `infinitely_many_large` sorry theorem with `infinitely_many_large_aux` axiom
- Fix all `/-` section headers to `/-!` doc comments
- Add `stewart_improves_mahler` theorem proving 11/13 > 1/4
- Update meta.json and annotations.json with correct line ranges

## Test plan
- [x] `pnpm build` passes
- [x] No `sorry` in Lean file
- [x] No `True := trivial` patterns
- [x] No trivially-true axioms
- [x] All section headers use `/-!`
- [x] meta.json sorries = 0
- [x] 10 annotations with correct line ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)