### PR TITLE
fix(erdos-561): header to doc comment, summary axiom to theorem

### DIFF
--- a/proofs/Proofs/Erdos561Problem.lean
+++ b/proofs/Proofs/Erdos561Problem.lean
@@ -1,4 +1,4 @@
-/-
+/-!
 Erdős Problem #561: Size Ramsey Numbers for Unions of Stars
 
 Source: https://erdosproblems.com/561
@@ -216,12 +216,13 @@ axiom size_vs_classical (F₁ F₂ : StarUnion) :
 /-- **Erdős Problem #561 Summary:**
 - The conjectured formula for R̂(F₁, F₂) is proven for uniform stars
 - The general case remains OPEN -/
-axiom erdos_561_summary :
+theorem erdos_561_summary :
     (-- BEFRS78 proves uniform case
      ∀ F₁ F₂ : StarUnion, F₁.isUniform → F₂.isUniform →
        sizeRamseyNumber F₁ F₂ = conjecturedFormula F₁ F₂) ∧
     (-- Lower bound
-     ∀ F₁ F₂, sizeRamseyNumber F₁ F₂ ≥ max F₁.totalEdges F₂.totalEdges)
+     ∀ F₁ F₂, sizeRamseyNumber F₁ F₂ ≥ max F₁.totalEdges F₂.totalEdges) :=
+  ⟨befrs78_theorem, sizeRamsey_lower_bound⟩
 
 /-- **Main Theorem:**
 The uniform case of Erdős #561 is SOLVED. -/

--- a/src/data/proofs/erdos-561/annotations.json
+++ b/src/data/proofs/erdos-561/annotations.json
@@ -68,7 +68,7 @@
   {
     "id": "ann-e561-main",
     "proofId": "erdos-561",
-    "range": { "startLine": 212, "endLine": 236 },
+    "range": { "startLine": 212, "endLine": 237 },
     "type": "theorem",
     "title": "Summary and Main Theorem",
     "content": "**erdos_561_summary** packages two results: (1) BEFRS78 proves the uniform case, and (2) the lower bound R̂ ≥ max edges holds universally.\n\n**erdos_561** is the main entry-point theorem: for all uniform star unions, the size Ramsey number equals the conjectured formula. Proved directly via `befrs78_theorem`.\n\n**openQuestion** captures the remaining challenge: does the formula hold for ALL star unions, including non-uniform ones?",

--- a/src/data/proofs/erdos-561/meta.json
+++ b/src/data/proofs/erdos-561/meta.json
@@ -139,7 +139,7 @@
       "id": "summary-main",
       "title": "Summary and Main Results",
       "startLine": 212,
-      "endLine": 236,
+      "endLine": 237,
       "summary": "Consolidates the main theorem (uniform case proven) and states the open question for general star unions.",
       "description": "The erdos_561 theorem confirms the uniform case via BEFRS78. The openQuestion definition captures that the general conjecture remains unsolved."
     }


### PR DESCRIPTION
## Summary
- Convert file header from `/-` to `/-!` for proper Lean 4 doc comment syntax
- Convert `erdos_561_summary` from axiom to theorem with proof `⟨befrs78_theorem, sizeRamsey_lower_bound⟩`
- Update section/annotation line ranges

## Test plan
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)