### PR TITLE
enhance(erdos-887): convert summary axiom to theorem

### DIFF
--- a/proofs/Proofs/Erdos887Problem.lean
+++ b/proofs/Proofs/Erdos887Problem.lean
@@ -169,12 +169,13 @@ known results into a single summary statement.
     • For exponent α > 1/2, no bound exists
     • For exponent α < 1/4, the bound is 2
     • The general case at exponent 1/4 is OPEN -/
-axiom erdos_887_summary :
+theorem erdos_887_summary :
   (∀ C : ℝ, C ≥ 1 → Set.Infinite { n : ℕ | divisorsNearSqrt n C = 4 }) ∧
   (∀ n : ℕ, isPerfectSquare n → ∀ c : ℝ, c > 0 →
     divisorsSymmetricInterval n c ≤ 5) ∧
   (∀ α : ℝ, α > 1/2 → ∀ K : ℕ, ∃ n : ℕ, n ≥ 1 ∧ divisorsNearSqrtAlpha n 1 α > K) ∧
-  (∀ α : ℝ, 0 < α → α < 1/4 → ∃ N₀ : ℕ, ∀ n : ℕ, n ≥ N₀ → divisorsNearSqrtAlpha n 1 α ≤ 2)
+  (∀ α : ℝ, 0 < α → α < 1/4 → ∃ N₀ : ℕ, ∀ n : ℕ, n ≥ N₀ → divisorsNearSqrtAlpha n 1 α ≤ 2) :=
+  ⟨erdos_rosenfeld_four_divisors, chan_perfect_square_bound, no_bound_for_large_alpha, bound_for_small_alpha⟩
 
 /-- Erdős Problem #887: Main entry point.
     The conjecture is stated as a Prop; its truth value is unknown. -/

--- a/src/data/proofs/erdos-887/meta.json
+++ b/src/data/proofs/erdos-887/meta.json
@@ -49,7 +49,7 @@
       "divisor_bound_epsilon axiom: τ(n) ≪ n^ε",
       "no_bound_for_large_alpha axiom: no bound for α > 1/2",
       "bound_for_small_alpha axiom: ≤ 2 divisors for α < 1/4",
-      "erdos_887_summary axiom: conjunction of all known results",
+      "erdos_887_summary theorem: conjunction of all known results (proved)",
       "erdos_887 theorem: unfolding of the conjecture definition"
     ]
   },


### PR DESCRIPTION
## Summary
- Converted `erdos_887_summary` from axiom to proved theorem using `⟨erdos_rosenfeld_four_divisors, chan_perfect_square_bound, no_bound_for_large_alpha, bound_for_small_alpha⟩`
- Updated meta.json to reflect the change

## Test plan
- [x] `pnpm build` passes
- [ ] Verify proof page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)