### PR TITLE
fix: update D1 database ID in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,7 +7,7 @@ pages_build_output_dir = "dist"
 [[d1_databases]]
 binding = "DB"
 database_name = "lean-genius-db"
-database_id = "2830c709-96a0-47d5-a5f6-b72fdf314a8a"
+database_id = "ea0c4f06-f29c-4fd4-9814-72c064252f2e"
 migrations_dir = "drizzle"
 
 # Environment variables


### PR DESCRIPTION
## Summary
- Updated the D1 database_id in wrangler.toml to match the newly created lean-genius-db database in the current Cloudflare account
- Old ID was from a different/deleted database, causing deployment failures

## Test plan
- [x] Verified deployment succeeds with new database ID
- [x] Migrations applied successfully to new database

🤖 Generated with [Claude Code](https://claude.com/claude-code)