### PR TITLE
enhance(erdos-291): fix /-! headers, True placeholders, definition sorry

### DIFF
--- a/proofs/Proofs/Erdos291Problem.lean
+++ b/proofs/Proofs/Erdos291Problem.lean
@@ -649,19 +649,11 @@ theorem part2_trivially_true : question_part2 := by
 ## Part XVIII: Summary
 -/
 
-/--
-**Summary of Known Results:**
--/
+/-- Summary: Part 2 (gcd > 1 infinitely often) is proved.
+    Part 1 (gcd = 1 infinitely often) remains OPEN. -/
 theorem erdos_291_summary :
-    -- Part 2: Trivially YES (Steinerberger)
-    question_part2 ∧
-    -- Part 1: OPEN (heuristically YES)
-    True ∧
-    -- Wu-Yan: Conditional on Schanuel, density of gcd > 1 is 1
-    True := by
-  constructor
-  · exact part2_trivially_true
-  · exact ⟨trivial, trivial⟩
+    question_part2 :=
+  part2_trivially_true
 
 /--
 **Erdős Problem #291: OPEN**


### PR DESCRIPTION
## Summary
- Replace all `/-!` section headers with `/-` in `Erdos291Problem.lean` (10 instances)
- Replace 6 `True` axiom placeholders with proper mathematical content:
  - `wolstenholme_implies_divisibility` - now states p | gcd(a_n, L_n)
  - `shiu_heuristic` - now states countGCDOne(x) ~ x/log(x) asymptotic
  - `density_zero_prediction` - now states density tends to 0
  - `log_prime_independence` - now states ℚ-linear independence
  - `wu_yan_conditional` - now states upper density 1 under Schanuel
  - `why_part1_hard` - now states the no-leading-digit-p-1 condition
- Replace `True := trivial` theorems with actual mathematical statements
- Fix `leadingDigit` definition sorry with proper implementation using `Nat.log`
- Rewrite `erdos_291_summary` to remove True padding

## Quality Checklist
- [x] No `/-!` docstring headers (Aristotle compatibility)
- [x] No `True := trivial` placeholders
- [x] No `True` axiom placeholders
- [x] No definition sorries
- [x] `pnpm build` succeeds

## Test Plan
- [x] Verified no remaining quality issues
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)