### PR TITLE
Enhance Erdős #162: fix edge counting, improve formalization

### DIFF
--- a/proofs/Proofs/Erdos162Problem.lean
+++ b/proofs/Proofs/Erdos162Problem.lean
@@ -1,79 +1,186 @@
-/-!
-# Erdős Problem #162 — Discrepancy in 2-Coloured Complete Graphs
+/-
+Erdős Problem #162: Discrepancy in 2-Coloured Complete Graphs
 
+Source: https://erdosproblems.com/162
+Status: OPEN
+
+Statement:
 For α > 0 and n ≥ 1, let F(n, α) be the largest k such that some
 2-colouring of K_n exists where every induced subgraph H on at least
 k vertices has more than α · C(|H|, 2) edges of each colour.
 
-## Conjecture
-
+Conjecture:
 For every fixed 0 ≤ α ≤ 1/2, F(n, α) ~ c_α · log n as n → ∞
 for some constant c_α > 0.
 
-## Known results
-
-The probabilistic method easily gives constants c₁(α), c₂(α) such that
+Known Results:
+The probabilistic method gives constants c₁(α), c₂(α) such that
 c₁(α) · log n < F(n, α) < c₂(α) · log n.
 
-Reference: https://erdosproblems.com/162
+Context:
+This is a Ramsey-type discrepancy problem. A 2-colouring of K_n is
+α-balanced on a set S if each colour class has more than α · C(|S|, 2)
+edges. F(n, α) measures how large an α-balanced substructure must be.
+The conjecture says the answer is precisely Θ(log n) with a sharp constant.
+
+Related: Erdős #617 (balanced colourings), Erdős #161, #163.
 -/
 
-import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Nat.Choose.Basic
-import Mathlib.Data.Rat.Basic
 import Mathlib.Tactic
 
-/-! ## Edge 2-colouring and discrepancy -/
+namespace Erdos162
 
-/-- A 2-colouring of edges of K_n: each pair gets a colour (true/false). -/
-def EdgeColouring (n : ℕ) := Fin n → Fin n → Bool
+-- Part I: Edge 2-colouring
 
-/-- The number of edges of a given colour in an induced subgraph on
-    vertices in S ⊆ Fin n. -/
-noncomputable def colourEdgeCount (n : ℕ) (c : EdgeColouring n) (S : Finset (Fin n))
-    (colour : Bool) : ℕ :=
-    (S.filter fun i =>
-      (S.filter fun j => i < j ∧ c i j = colour).card > 0).card
+/-- A symmetric 2-colouring of edges of K_n: each unordered pair {i, j}
+    gets a colour (true = red, false = blue).
+    We use a function on ordered pairs with the symmetry constraint. -/
+structure EdgeColouring (n : ℕ) where
+  colour : Fin n → Fin n → Bool
+  symm : ∀ i j, colour i j = colour j i
+  irrefl : ∀ i, colour i i = false
 
-/-- A colouring is α-balanced on a vertex set S if each colour has
+/-- Count edges of a given colour in the induced subgraph on vertex set S.
+    An edge {i, j} with i < j contributes 1 if both i, j ∈ S and the
+    edge has the specified colour. -/
+noncomputable def colourEdgeCount {n : ℕ} (c : EdgeColouring n) (S : Finset (Fin n))
+    (col : Bool) : ℕ :=
+  ((S ×ˢ S).filter fun p => p.1 < p.2 ∧ c.colour p.1 p.2 = col).card
+
+/-- Total edges in K_S equals C(|S|, 2). -/
+theorem colourEdgeCount_total {n : ℕ} (c : EdgeColouring n) (S : Finset (Fin n)) :
+    colourEdgeCount c S true + colourEdgeCount c S false = Nat.choose S.card 2 := by
+  sorry
+
+-- Part II: α-Balanced colourings
+
+/-- A colouring is α-balanced on vertex set S if each colour class has
     more than α · C(|S|, 2) edges. -/
-def IsBalanced (n : ℕ) (c : EdgeColouring n) (S : Finset (Fin n)) (α : ℚ) : Prop :=
-    ∀ colour : Bool,
-      α * (Nat.choose S.card 2 : ℚ) < (colourEdgeCount n c S colour : ℚ)
+def IsBalancedOn {n : ℕ} (c : EdgeColouring n) (S : Finset (Fin n)) (α : ℚ) : Prop :=
+  ∀ col : Bool,
+    α * (Nat.choose S.card 2 : ℚ) < (colourEdgeCount c S col : ℚ)
 
-/-! ## The function F(n, α) -/
+/-- A colouring is (k, α)-balanced if every induced subgraph on at least
+    k vertices is α-balanced. -/
+def IsKBalanced {n : ℕ} (c : EdgeColouring n) (k : ℕ) (α : ℚ) : Prop :=
+  ∀ S : Finset (Fin n), k ≤ S.card → IsBalancedOn c S α
 
-/-- F(n, α): the largest k such that some 2-colouring of K_n has every
-    induced subgraph on ≥ k vertices α-balanced.
-    Axiomatised as a function. -/
+/-- Being α-balanced requires α ≤ 1/2: if α > 1/2, each colour needs
+    more than half the edges, which is impossible. -/
+theorem balanced_requires_le_half {n : ℕ} (c : EdgeColouring n) (S : Finset (Fin n))
+    (α : ℚ) (hα : 1 / 2 < α) (hS : 2 ≤ S.card) :
+    ¬IsBalancedOn c S α := by
+  sorry
+
+-- Part III: The function F(n, α)
+
+/-- F(n, α): the largest k such that some 2-colouring of K_n is (k, α)-balanced.
+    Axiomatized since computing it requires exhaustive search over all colourings. -/
 axiom discrepancyF : ℕ → ℚ → ℕ
 
-/-- F(n, α) is monotone decreasing in α: higher threshold means smaller F. -/
+/-- Characterization: F(n, α) = k means there exists a (k, α)-balanced colouring
+    but no (k+1, α)-balanced colouring exists. -/
+axiom discrepancyF_spec (n : ℕ) (α : ℚ) (hα : 0 < α) (hα2 : α ≤ 1 / 2) (hn : 1 ≤ n) :
+    (∃ c : EdgeColouring n, IsKBalanced c (discrepancyF n α) α) ∧
+    (∀ c : EdgeColouring n, ¬IsKBalanced c (discrepancyF n α + 1) α)
+
+-- Part IV: Basic properties
+
+/-- F(n, α) is monotone decreasing in α: stricter balance requirement
+    means smaller balanced substructures. -/
 axiom discrepancyF_mono_alpha (n : ℕ) (α β : ℚ) (h : α ≤ β) :
     discrepancyF n β ≤ discrepancyF n α
 
-/-- F(n, 0) = n (trivially, every colouring is 0-balanced). -/
+/-- F(n, 0) = n: every colouring is trivially 0-balanced, since
+    0 · C(|S|, 2) = 0 < any positive edge count. -/
 axiom discrepancyF_zero (n : ℕ) (hn : 1 ≤ n) :
     discrepancyF n 0 = n
 
-/-! ## Logarithmic bounds (probabilistic method) -/
+/-- F(n, α) ≤ n: the balanced substructure cannot exceed the total graph. -/
+axiom discrepancyF_le (n : ℕ) (α : ℚ) :
+    discrepancyF n α ≤ n
 
-/-- Lower bound: F(n, α) > c₁(α) · log n for some c₁ > 0. -/
+-- Part V: Logarithmic bounds (probabilistic method)
+
+/-- Lower bound: F(n, α) > c₁(α) · log n for some c₁ > 0.
+    Proof sketch: A random 2-colouring of K_n is α-balanced on all sets
+    of size ≤ c₁ log n with positive probability, by Chernoff + union bound. -/
 axiom discrepancy_lower (α : ℚ) (hα : 0 < α) (hα2 : α ≤ 1 / 2) :
     ∃ c : ℚ, 0 < c ∧ ∃ n₀ : ℕ, ∀ n : ℕ, n₀ ≤ n →
       c * (Nat.log 2 n : ℚ) < (discrepancyF n α : ℚ)
 
-/-- Upper bound: F(n, α) < c₂(α) · log n for some c₂ > 0. -/
+/-- Upper bound: F(n, α) < c₂(α) · log n for some c₂ > 0.
+    Proof sketch: By a Ramsey-type counting argument, any 2-colouring of K_n
+    must have an imbalanced induced subgraph of size c₂ log n. -/
 axiom discrepancy_upper (α : ℚ) (hα : 0 < α) (hα2 : α ≤ 1 / 2) :
     ∃ C : ℚ, 0 < C ∧ ∃ n₀ : ℕ, ∀ n : ℕ, n₀ ≤ n →
       (discrepancyF n α : ℚ) < C * (Nat.log 2 n : ℚ)
 
-/-! ## Main conjecture -/
+-- Part VI: Derived results
 
-/-- Erdős Problem 162: for every 0 < α ≤ 1/2, there exists a constant c_α
-    such that F(n, α) / log n → c_α. -/
+/-- The bounds sandwich: F(n, α) = Θ(log n) for every fixed 0 < α ≤ 1/2. -/
+theorem discrepancy_theta_log (α : ℚ) (hα : 0 < α) (hα2 : α ≤ 1 / 2) :
+    (∃ c₁ : ℚ, 0 < c₁ ∧ ∃ n₀ : ℕ, ∀ n, n₀ ≤ n →
+      c₁ * (Nat.log 2 n : ℚ) < (discrepancyF n α : ℚ)) ∧
+    (∃ c₂ : ℚ, 0 < c₂ ∧ ∃ n₀ : ℕ, ∀ n, n₀ ≤ n →
+      (discrepancyF n α : ℚ) < c₂ * (Nat.log 2 n : ℚ)) :=
+  ⟨discrepancy_lower α hα hα2, discrepancy_upper α hα hα2⟩
+
+/-- For α = 1/2, the problem reduces to near-equal colour distribution.
+    This is the hardest case since α = 1/2 is the tightest constraint. -/
+theorem half_is_extremal (n : ℕ) (α : ℚ) (hα2 : α ≤ 1 / 2) :
+    discrepancyF n (1 / 2) ≤ discrepancyF n α :=
+  discrepancyF_mono_alpha n α (1 / 2) hα2
+
+-- Part VII: The main conjecture
+
+/-- **Erdős Problem 162** (OPEN): For every 0 < α ≤ 1/2, there exists a
+    constant c_α > 0 such that F(n, α) / log n → c_α as n → ∞.
+
+    This is strictly stronger than the Θ(log n) bounds: it asserts that
+    the ratio F(n, α) / log n converges to a definite limit, rather than
+    merely being bounded between two constants. -/
 def ErdosProblem162 : Prop :=
     ∀ (α : ℚ) (hα : 0 < α) (hα2 : α ≤ 1 / 2),
       ∃ c : ℚ, 0 < c ∧
         ∀ ε : ℚ, 0 < ε → ∃ n₀ : ℕ, ∀ n : ℕ, n₀ ≤ n →
           |(discrepancyF n α : ℚ) / (Nat.log 2 n : ℚ) - c| < ε
+
+-- Part VIII: Concrete edge count examples
+
+/-- K_1 has 0 edges. -/
+example : Nat.choose 1 2 = 0 := by native_decide
+
+/-- K_2 has 1 edge. -/
+example : Nat.choose 2 2 = 1 := by native_decide
+
+/-- K_4 has 6 edges: a balanced colouring gives 3 red, 3 blue. -/
+example : Nat.choose 4 2 = 6 := by native_decide
+
+/-- K_8 has 28 edges: the probabilistic method shows balanced colourings exist. -/
+example : Nat.choose 8 2 = 28 := by native_decide
+
+/-
+Summary: Erdős Problem #162 (OPEN)
+
+The conjecture F(n, α) ~ c_α log n asserts that the largest α-balanced
+substructure in any 2-coloured K_n grows logarithmically with a sharp constant.
+
+What is known:
+- F(n, α) = Θ(log n) via probabilistic method (lower) and counting (upper)
+- The conjecture asks for convergence of the ratio F(n,α)/log(n)
+
+What remains:
+- Proving convergence (the ratio has a limit, not just limsup/liminf bounds)
+- Determining the constant c_α as a function of α
+- This likely requires tools beyond the probabilistic method
+
+Connections:
+- Ramsey theory: F(n, 0) = n is trivial; F(n, 1/2) is the extremal case
+- The problem interpolates between Ramsey numbers (α near 0) and
+  discrepancy theory (α = 1/2)
+- Related to Erdős #617 (balanced colourings of K_{r²+1})
+-/
+
+end Erdos162

--- a/src/data/research/problems/erdos-162.json
+++ b/src/data/research/problems/erdos-162.json
@@ -29,11 +29,38 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "ENHANCED: Rewrote formalization with proper EdgeColouring structure (symmetry+irreflexivity), correct edge counting definition, namespace, derived theorems. Fixed Docker build issues (imports, native_decide). 2 theorem sorries remain.",
+    "builtItems": [
+      "Erdos162 namespace with proper structure",
+      "EdgeColouring structure with symm/irrefl fields",
+      "Correct colourEdgeCount definition using Finset product pairs",
+      "colourEdgeCount_total theorem (sorry) linking to Nat.choose",
+      "IsBalancedOn and IsKBalanced definitions",
+      "balanced_requires_le_half theorem (sorry)",
+      "discrepancyF_spec axiom with characterization",
+      "discrepancy_theta_log derived theorem from axioms",
+      "half_is_extremal proved from monotonicity axiom",
+      "Concrete examples with native_decide"
+    ],
+    "insights": [
+      "Problem is OPEN - asks for F(n,α) ~ c_α log n (sharp asymptotics)",
+      "Θ(log n) bounds known via probabilistic method (lower) and counting/Ramsey (upper)",
+      "The conjecture asks for convergence of ratio F(n,α)/log(n), not just bounded",
+      "α = 1/2 is the extremal case (tightest constraint)",
+      "Related to Erdős #617 (balanced colourings of complete graphs)",
+      "Original Lean file had incorrect edge counting (counted vertices not edges)",
+      "Fixed: EdgeColouring now a structure with symmetry+irreflexivity constraints",
+      "Fixed: colourEdgeCount now properly counts edges via (S × S).filter with i < j",
+      "Mathlib.Data.Rat.Basic not available in Docker Mathlib v4.26.0 - use Mathlib.Tactic",
+      "Nat.choose examples need native_decide (decide OOMs, norm_num fails for large n)"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove colourEdgeCount_total (edges partition into red+blue = C(|S|,2))",
+      "Prove balanced_requires_le_half (α > 1/2 makes balance impossible)",
+      "Consider submitting to Aristotle for the two theorem sorries",
+      "Consider formalizing the probabilistic method lower bound argument"
+    ],
     "markdown": "# Erdős #162 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $\\alpha>0$ and $n\\geq 1$. Let $F(n,\\alpha)$ be the largest $k$ such that there exists some 2-colouring of the edges of $K_n$ in which any induced subgraph $H$ on at least $k$ vertices contains more than $\\alpha\\binom{\\lvert H\\rvert}{2}$ many edges of each colour.\n\nProve that for every fixed $0\\leq \\alpha \\leq 1/2$, as $n\\to\\infty$,\\[F(n,\\alpha)\\sim c_\\alpha \\log n\\]for some constant $c_\\alpha$.\n\n\n\nIt is easy to show with the probabilistic method that there exist $c_1(\\alpha),c_2(\\alpha)$ such that\\[c_1(\\alpha)\\log n < F(n,\\alpha) < c_2(\\alpha)\\log n.\\]\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #2\n- Problem #161\n- Problem #163\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "approaches": [],


### PR DESCRIPTION
## Summary
- Fixed incorrect `colourEdgeCount` definition (was counting vertices with colored neighbors, now correctly counts edge pairs)
- Replaced bare type alias with proper `EdgeColouring` structure (symmetry + irreflexivity)
- Added `IsKBalanced` definition and `balanced_requires_le_half` theorem
- Fixed `/-!` docstrings to `/-` for Aristotle compatibility
- Fixed imports for Docker Mathlib v4.26.0 compatibility
- Added namespace, derived theorems, and concrete examples

## Progress
- **Docker build**: PASSES (2 expected theorem sorries remain)
- **Key fix**: Edge counting was semantically wrong in original - now properly counts pairs
- **New theorems**: `half_is_extremal` proved from monotonicity, `discrepancy_theta_log` derived

## Status
**Outcome**: Enhanced (OPEN problem - improved formalization quality)
**Next Steps**: Prove `colourEdgeCount_total` and `balanced_requires_le_half` sorries

🤖 Generated by researcher-1

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>