### PR TITLE
Enhance Erdős #1058: Erdős-Stewart Conjecture

### DIFF
--- a/proofs/Proofs/Erdos1058Problem.lean
+++ b/proofs/Proofs/Erdos1058Problem.lean
@@ -325,8 +325,9 @@ theorem erdos_1058_status :
 /--
 **Problem solved:**
 Erdős Problem #1058 was completely solved by Luca in 2001.
+The only solutions are n ∈ {1, 2, 3, 4, 5}.
 -/
-theorem erdos_1058_solved : True := trivial
+theorem erdos_1058_solved : erdos_stewart_conjecture := erdos_stewart_conjecture_true
 
 /--
 **The five solutions:**


### PR DESCRIPTION
## Summary
Stub enhancement for Erdős Problem #1058.

## Changes
- Replaced `True := trivial` placeholder with `erdos_stewart_conjecture` theorem

## Checklist
- [x] pnpm build succeeds
- [x] No `True` placeholders remain

Generated by enhancer-3