### PR TITLE
enhance(erdos-861): fix quality issues in Sidon sets formalization

### DIFF
--- a/proofs/Proofs/Erdos861Problem.lean
+++ b/proofs/Proofs/Erdos861Problem.lean
@@ -227,19 +227,6 @@ axiom extend_sidon (S : Finset ℕ) (n : ℕ) :
 -/
 
 /--
-**Erdős Problem #861: SOLVED**
-
-QUESTION 1: A(N)/2^{f(N)} → ∞?
-ANSWER: YES (proved via lower bound 2^{1.16·f(N)})
-
-QUESTION 2: A(N) = 2^{(1+o(1))f(N)}?
-ANSWER: NO (bounds show exponent is strictly between 1.16 and 6.442)
-
-Current state: Best bounds are 2^{1.16·f(N)} ≤ A(N) ≤ 2^{6.442·f(N)}.
--/
-theorem erdos_861 : True := trivial
-
-/--
 **Summary of results:**
 -/
 theorem erdos_861_summary :
@@ -250,17 +237,19 @@ theorem erdos_861_summary :
   exact ⟨cameron_erdos_q1_true, cameron_erdos_q2_false⟩
 
 /--
-**The gap between bounds:**
-The exponent in A(N) ~ 2^{c·f(N)} lies in [1.16, 6.442].
-Determining the exact constant remains open.
+**Erdős Problem #861: SOLVED**
+
+QUESTION 1: A(N)/2^{f(N)} → ∞?
+ANSWER: YES (proved via lower bound 2^{1.16·f(N)})
+
+QUESTION 2: A(N) = 2^{(1+o(1))f(N)}?
+ANSWER: NO (bounds show exponent is strictly between 1.16 and 6.442)
+
+Current state: Best bounds are 2^{1.16·f(N)} ≤ A(N) ≤ 2^{6.442·f(N)}.
 -/
-theorem bounds_gap :
-    ∃ c_lower c_upper : ℝ,
-      c_lower = 1.16 ∧ c_upper = 6.442 ∧
-      c_lower < c_upper ∧
-      -- The true exponent is somewhere in between
-      True := by
-  use 1.16, 6.442
-  norm_num
+theorem erdos_861 :
+    CameronErdosQuestion1 ∧
+    ¬ CameronErdosQuestion2 :=
+  erdos_861_summary
 
 end Erdos861

--- a/src/data/proofs/erdos-861/annotations.json
+++ b/src/data/proofs/erdos-861/annotations.json
@@ -112,7 +112,7 @@
   {
     "id": "ann-e861-summary",
     "proofId": "erdos-861",
-    "range": { "startLine": 229, "endLine": 250 },
+    "range": { "startLine": 229, "endLine": 255 },
     "type": "theorem",
     "title": "Summary of Results",
     "content": "**erdos_861_summary:**\n\n- Question 1: YES (A(N)/2^{f(N)} → ∞)\n- Question 2: NO (exponent ≠ 1+o(1))\n\nThe exact constant c in A(N) ~ 2^{c·f(N)} remains open, known to be in [1.16, 6.442].",

--- a/src/data/proofs/erdos-861/meta.json
+++ b/src/data/proofs/erdos-861/meta.json
@@ -7,10 +7,10 @@
     "author": "Paul Erdős, Peter Cameron",
     "sourceUrl": "https://erdosproblems.com/861",
     "date": "",
-    "status": "verified",
+    "status": "complete",
     "proofRepoPath": "Proofs/Erdos861Problem.lean",
     "tags": ["erdos", "combinatorics", "Sidon-sets", "additive-combinatorics", "counting"],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 861,
     "erdosUrl": "https://erdosproblems.com/861",
@@ -95,7 +95,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 225,
-      "endLine": 267,
+      "endLine": 255,
       "summary": "Main results and current state of knowledge"
     }
   ],


### PR DESCRIPTION
## Summary
- Replaced `erdos_861 : True := trivial` with meaningful theorem combining Q1 (yes) and Q2 (no) answers
- Removed `bounds_gap` trivial theorem
- Fixed meta.json: badge "axiom" (was "mathlib"), status "complete" (was "verified")
- Updated section line ranges for shorter file

## Test plan
- [x] `pnpm build` passes
- [x] No `sorry` or trivial `True` constructs
- [x] meta.json and annotations.json consistent with file

🤖 Generated with [Claude Code](https://claude.com/claude-code)