### PR TITLE
Enhance Erdős #861: Counting Sidon Sets

### DIFF
--- a/proofs/Proofs/Erdos861Problem.lean
+++ b/proofs/Proofs/Erdos861Problem.lean
@@ -42,7 +42,7 @@ open Finset BigOperators
 
 namespace Erdos861
 
-/-!
+/-
 ## Part I: Sidon Set Definitions
 -/
 
@@ -68,7 +68,7 @@ The equivalence of Sidon definitions.
 -/
 axiom sidon_equiv (S : Finset ℕ) : IsSidon S ↔ IsSidon' S
 
-/-!
+/-
 ## Part II: The Functions f(N) and A(N)
 -/
 
@@ -88,7 +88,7 @@ noncomputable def countSidonSets (N : ℕ) : ℕ :=
   (Finset.filter (fun S => IsSidon S)
     (Finset.powerset (Finset.range (N + 1)))).card
 
-/-!
+/-
 ## Part III: Known Asymptotic for f(N)
 -/
 
@@ -111,7 +111,7 @@ def SidonSizeConjecture : Prop :=
     ∃ C : ℝ, ∀ N : ℕ, N > 0 →
       |(maxSidonSize N : ℝ) - Real.sqrt N| ≤ C * (N : ℝ) ^ ε
 
-/-!
+/-
 ## Part IV: Cameron-Erdős Question 1
 -/
 
@@ -132,7 +132,7 @@ This follows from the lower bound A(N) ≥ 2^{1.16·f(N)}.
 -/
 axiom cameron_erdos_q1_true : CameronErdosQuestion1
 
-/-!
+/-
 ## Part V: Cameron-Erdős Question 2
 -/
 
@@ -154,7 +154,7 @@ not as simply as 2^{(1+o(1))f(N)}.
 -/
 axiom cameron_erdos_q2_false : ¬ CameronErdosQuestion2
 
-/-!
+/-
 ## Part VI: Current Best Bounds
 -/
 
@@ -194,7 +194,7 @@ theorem current_bounds :
   · exact h₁ N (le_of_max_le_left hN)
   · exact h₂ N (le_of_max_le_right hN)
 
-/-!
+/-
 ## Part VII: Basic Properties
 -/
 
@@ -222,22 +222,9 @@ axiom extend_sidon (S : Finset ℕ) (n : ℕ) :
     (∀ a : ℕ, a ∈ S → ∀ c d : ℕ, c ∈ S → d ∈ S → c ≤ d → n + a ≠ c + d) →
     IsSidon (insert n S)
 
-/-!
+/-
 ## Part VIII: Summary
 -/
-
-/--
-**Erdős Problem #861: SOLVED**
-
-QUESTION 1: A(N)/2^{f(N)} → ∞?
-ANSWER: YES (proved via lower bound 2^{1.16·f(N)})
-
-QUESTION 2: A(N) = 2^{(1+o(1))f(N)}?
-ANSWER: NO (bounds show exponent is strictly between 1.16 and 6.442)
-
-Current state: Best bounds are 2^{1.16·f(N)} ≤ A(N) ≤ 2^{6.442·f(N)}.
--/
-theorem erdos_861 : True := trivial
 
 /--
 **Summary of results:**
@@ -257,9 +244,7 @@ Determining the exact constant remains open.
 theorem bounds_gap :
     ∃ c_lower c_upper : ℝ,
       c_lower = 1.16 ∧ c_upper = 6.442 ∧
-      c_lower < c_upper ∧
-      -- The true exponent is somewhere in between
-      True := by
+      c_lower < c_upper := by
   use 1.16, 6.442
   norm_num
 

--- a/src/data/proofs/erdos-861/annotations.json
+++ b/src/data/proofs/erdos-861/annotations.json
@@ -112,7 +112,7 @@
   {
     "id": "ann-e861-summary",
     "proofId": "erdos-861",
-    "range": { "startLine": 229, "endLine": 250 },
+    "range": { "startLine": 229, "endLine": 237 },
     "type": "theorem",
     "title": "Summary of Results",
     "content": "**erdos_861_summary:**\n\n- Question 1: YES (A(N)/2^{f(N)} → ∞)\n- Question 2: NO (exponent ≠ 1+o(1))\n\nThe exact constant c in A(N) ~ 2^{c·f(N)} remains open, known to be in [1.16, 6.442].",

--- a/src/data/proofs/erdos-861/meta.json
+++ b/src/data/proofs/erdos-861/meta.json
@@ -7,10 +7,10 @@
     "author": "Paul Erdős, Peter Cameron",
     "sourceUrl": "https://erdosproblems.com/861",
     "date": "",
-    "status": "verified",
+    "status": "complete",
     "proofRepoPath": "Proofs/Erdos861Problem.lean",
     "tags": ["erdos", "combinatorics", "Sidon-sets", "additive-combinatorics", "counting"],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 861,
     "erdosUrl": "https://erdosproblems.com/861",
@@ -95,7 +95,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 225,
-      "endLine": 267,
+      "endLine": 252,
       "summary": "Main results and current state of knowledge"
     }
   ],


### PR DESCRIPTION
## Summary
- Remove `True := trivial` placeholder theorem
- Convert `/-!` section headers to `/-` for Aristotle compatibility
- Fix `bounds_gap` theorem to remove trailing `True`
- Fix meta.json badge (mathlib → axiom) and status (verified → complete)
- Update annotation line ranges to match modified Lean file

## Checklist
- [x] Lean proof compiles
- [x] pnpm build succeeds
- [x] Annotations align with Lean file
- [x] No quality issues remain

Generated by enhancer-1