### PR TITLE
enhance(erdos-902): fix quality issues in tournament domination formalization

### DIFF
--- a/proofs/Proofs/Erdos902Problem.lean
+++ b/proofs/Proofs/Erdos902Problem.lean
@@ -35,7 +35,7 @@ open Finset
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
-/- ## Part I: Tournament Definitions -/
+/-! ## Part I: Tournament Definitions -/
 
 /-- A tournament is a complete directed graph (orientation of complete graph). -/
 structure Tournament (V : Type*) [Fintype V] where
@@ -47,7 +47,7 @@ structure Tournament (V : Type*) [Fintype V] where
 /-- Number of vertices in a tournament. -/
 def Tournament.order (T : Tournament V) : ℕ := Fintype.card V
 
-/- ## Part II: Domination -/
+/-! ## Part II: Domination -/
 
 /-- A vertex v dominates a set S if v → s for all s ∈ S. -/
 def dominates (T : Tournament V) (v : V) (S : Finset V) : Prop :=
@@ -61,7 +61,7 @@ def isDominated (T : Tournament V) (S : Finset V) : Prop :=
 def isNDominating (T : Tournament V) (n : ℕ) : Prop :=
   ∀ S : Finset V, S.card = n → isDominated T S
 
-/- ## Part III: The Function f(n) -/
+/-! ## Part III: The Function f(n) -/
 
 /-- Existence of n-dominating tournaments for all n. -/
 axiom exists_n_dominating : ∀ n, ∃ k, ∃ (V : Type) (_ : Fintype V) (_ : DecidableEq V)
@@ -78,7 +78,7 @@ axiom f_is_minimum (n : ℕ) :
     (∀ (W : Type) [Fintype W] [DecidableEq W] (S : Tournament W),
       isNDominating S n → Fintype.card W ≥ f n)
 
-/- ## Part IV: Known Values -/
+/-! ## Part IV: Known Values -/
 
 /-- f(1) = 3: The rock-paper-scissors tournament. -/
 axiom f_1 : f 1 = 3
@@ -109,7 +109,7 @@ axiom exists_19_is_3_dominating :
 axiom no_18_is_3_dominating :
     ∀ (T : Tournament (Fin 18)), ¬isNDominating T 3
 
-/- ## Part V: Lower Bound -/
+/-! ## Part V: Lower Bound -/
 
 /-- Szekeres & Szekeres (1965): f(n) ≥ c · n · 2^n for some constant c > 0. -/
 axiom szekeres_lower_bound :
@@ -124,7 +124,7 @@ axiom domination_count_bound (k n : ℕ) (T : Tournament (Fin k)) :
     ∀ v : Fin k, (Finset.univ.filter (fun S : Finset (Fin k) =>
       S.card = n ∧ dominates T v S)).card ≤ Nat.choose (k - 1) n
 
-/- ## Part VI: Upper Bound -/
+/-! ## Part VI: Upper Bound -/
 
 /-- Erdős (1963): f(n) ≤ C · n² · 2^n for some constant C. -/
 axiom erdos_upper_bound :
@@ -135,7 +135,7 @@ axiom probabilistic_upper_bound (n : ℕ) (hn : n ≥ 1) :
     ∃ k : ℕ, k ≤ 4 * n^2 * 2^n ∧
     ∃ (T : Tournament (Fin k)), isNDominating T n
 
-/- ## Part VII: Asymptotic Behavior -/
+/-! ## Part VII: Asymptotic Behavior -/
 
 /-- The main open question: What is f(n) / (n · 2^n) as n → ∞? -/
 def asymptoticRatio (n : ℕ) : ℝ := (f n : ℝ) / (n * 2^n)
@@ -164,22 +164,17 @@ theorem asymptotic_gap :
   · intro n hn
     exact ⟨hc_bound n hn, hC_bound n hn⟩
 
-/- ## Part VIII: Paley Tournament -/
+/-! ## Part VIII: Paley Tournament -/
 
 /-- Paley tournament: edge p → q iff q - p is a quadratic residue (mod prime). -/
 def isPaleyEdge (p : ℕ) [Fact (Nat.Prime p)] (hp : p % 4 = 3) (u v : ZMod p) : Prop :=
   ∃ x : ZMod p, x ≠ 0 ∧ v - u = x^2
 
-/-- Paley tournaments are highly symmetric. -/
-theorem paley_symmetric (p : ℕ) [hp : Fact (Nat.Prime p)] (h4 : p % 4 = 3) :
-    True := by  -- The automorphism group has order p(p-1)/2
-  trivial
-
 /-- Paley tournament of order p is ((p-1)/2 - 1)-dominating. -/
-theorem paley_domination (p : ℕ) [Fact (Nat.Prime p)] (h4 : p % 4 = 3) :
-    True := trivial  -- Bound on domination number, details axiomatized
+axiom paley_domination_bound (p : ℕ) [Fact (Nat.Prime p)] (h4 : p % 4 = 3) :
+    ∃ (T : Tournament (ZMod p)), isNDominating T ((p - 1) / 2 - 1)
 
-/- ## Part IX: Quadratic Residues -/
+/-! ## Part IX: Quadratic Residues -/
 
 /-- Quadratic residue characterization for Paley construction. -/
 def isQuadraticResidue (p : ℕ) (a : ZMod p) : Prop :=
@@ -189,7 +184,7 @@ def isQuadraticResidue (p : ℕ) (a : ZMod p) : Prop :=
 axiom half_are_residues (p : ℕ) [Fact (Nat.Prime p)] (hp : p > 2) :
     (Finset.univ.filter (isQuadraticResidue p)).card = (p - 1) / 2
 
-/- ## Part X: Generalizations -/
+/-! ## Part X: Generalizations -/
 
 /-- Existence of non-dominating level for any tournament. -/
 axiom exists_non_dominating (T : Tournament V) : ∃ n, ¬isNDominating T (n + 1)
@@ -202,7 +197,7 @@ noncomputable def dominationNumber (T : Tournament V) : ℕ :=
 axiom domination_characterization (T : Tournament V) :
     ∀ n : ℕ, n < dominationNumber T → isNDominating T n
 
-/- ## Part XI: Probabilistic Method -/
+/-! ## Part XI: Probabilistic Method -/
 
 /-- Random tournament: Each edge direction chosen uniformly at random. -/
 def randomTournamentProb (k n : ℕ) : ℝ :=
@@ -217,43 +212,26 @@ axiom random_tournament_works (n : ℕ) (hn : n ≥ 1) :
 axiom probabilistic_existence (n : ℕ) (hn : n ≥ 1) :
     ∃ k : ℕ, ∃ (T : Tournament (Fin k)), isNDominating T n
 
-/- ## Part XII: Connection to Coding Theory -/
+/-! ## Part XII: Summary -/
 
-/-- Covering codes relate to dominating tournaments.
-    coveringRadius n k = minimum r such that k codewords cover all n-bit strings within Hamming distance r. -/
-noncomputable def coveringRadius (n k : ℕ) : ℕ :=
-  -- This would require formalizing coding theory; we use a placeholder
-  n -- Trivial upper bound: any single codeword covers within distance n
+/-- **Erdős Problem #902: OPEN**
 
-/-- Tournament domination connects to covering codes. -/
-theorem tournament_covering_connection :
-    True := by  -- Deep connection to coding theory
-  trivial
+PROBLEM: Let f(n) be minimal such that there is a tournament on f(n) vertices
+where every set of n vertices is dominated by at least one other vertex.
+Estimate f(n).
+
+KNOWN:
+- f(1) = 3, f(2) = 7, f(3) = 19
+- Lower: c·n·2^n ≤ f(n) (Szekeres & Szekeres 1965)
+- Upper: f(n) ≤ C·n²·2^n (Erdős 1963, probabilistic method)
+
+OPEN: Close the gap between n·2^n and n²·2^n.
+-/
+theorem erdos_902 :
+    -- Lower bound
+    (∃ c : ℝ, c > 0 ∧ ∀ n : ℕ, n ≥ 1 → (f n : ℝ) ≥ c * n * 2^n) ∧
+    -- Upper bound
+    (∃ C : ℝ, C > 0 ∧ ∀ n : ℕ, n ≥ 1 → (f n : ℝ) ≤ C * n^2 * 2^n) :=
+  ⟨szekeres_lower_bound, erdos_upper_bound⟩
 
 end Erdos902
-
-/-
-  ## Summary
-
-  This file formalizes Erdős Problem #902 on tournament domination.
-
-  **Status**: OPEN
-
-  **The Question**: What is f(n), the minimum tournament order such that
-  every n-set of vertices is dominated by some other vertex?
-
-  **Known Values**:
-  - f(1) = 3 (rock-paper-scissors)
-  - f(2) = 7 (Paley tournament)
-  - f(3) = 19
-
-  **Bounds**:
-  - Lower: n · 2^n ≪ f(n) (Szekeres & Szekeres 1965)
-  - Upper: f(n) ≪ n² · 2^n (Erdős 1963)
-
-  **Key sorries**:
-  - `f_1`, `f_2`, `f_3`: Known exact values
-  - `szekeres_lower_bound`: The counting argument
-  - `erdos_upper_bound`: Probabilistic construction
-  - `asymptotic_gap`: The main open gap
--/

--- a/src/data/proofs/erdos-902/annotations.json
+++ b/src/data/proofs/erdos-902/annotations.json
@@ -1,146 +1,79 @@
 [
   {
-    "id": "ann-902-tournament",
+    "id": "ann-902-header",
     "proofId": "erdos-902",
-    "range": { "startLine": 40, "endLine": 45 },
+    "range": { "startLine": 1, "endLine": 25 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #902: Tournament Domination**\n\nLet f(n) be minimal such that there is a tournament on f(n) vertices where every set of n vertices is dominated by at least one other vertex.\n\n**Known values**: f(1) = 3, f(2) = 7, f(3) = 19\n**Bounds**: n·2^n ≪ f(n) ≪ n²·2^n\n**Status**: OPEN",
+    "mathContext": "The gap between n·2^n and n²·2^n is a factor of n. Closing this gap requires understanding the extremal structure of tournaments.",
+    "significance": "critical",
+    "relatedConcepts": ["Tournaments", "Domination", "Probabilistic method"]
+  },
+  {
+    "id": "ann-902-defs",
+    "proofId": "erdos-902",
+    "range": { "startLine": 38, "endLine": 62 },
     "type": "definition",
-    "title": "Tournament",
-    "content": "A complete directed graph: for any two vertices, exactly one edge exists.",
-    "significance": "critical"
+    "title": "Tournament and Domination Definitions",
+    "content": "**Tournament(V)**: Complete directed graph — irreflexive, complete (u≠v implies edge), antisymmetric.\n\n**dominates(T, v, S)**: Vertex v beats all vertices in set S (and v ∉ S).\n\n**isDominated(T, S)**: Some vertex dominates S.\n\n**isNDominating(T, n)**: Every n-subset of vertices is dominated.",
+    "mathContext": "These definitions capture the precise notion of 'every small set has a common dominator'. The condition v ∉ S ensures the dominator is external.",
+    "significance": "critical",
+    "relatedConcepts": ["Directed graphs", "Domination", "Complete tournaments"]
   },
   {
-    "id": "ann-902-dominates",
+    "id": "ann-902-f-values",
     "proofId": "erdos-902",
-    "range": { "startLine": 52, "endLine": 54 },
-    "type": "definition",
-    "title": "Dominates",
-    "content": "Vertex v dominates set S if v beats all vertices in S.",
-    "significance": "critical"
+    "range": { "startLine": 64, "endLine": 110 },
+    "type": "axiom",
+    "title": "The Function f(n) and Known Values",
+    "content": "**f(n)**: Defined via Nat.find as the minimum order of an n-dominating tournament.\n\n**f(1) = 3**: Rock-paper-scissors (cyclic tournament on 3 vertices).\n**f(2) = 7**: Paley tournament of order 7.\n**f(3) = 19**: Verified computationally.\n\nFor each value, we axiomatize both existence of the optimal tournament and non-existence at one less.",
+    "mathContext": "The jump from f(1)=3 to f(2)=7 to f(3)=19 illustrates the exponential growth. Paley tournaments (from quadratic residues) provide key constructions.",
+    "significance": "critical",
+    "relatedConcepts": ["Paley tournament", "Computational verification"]
   },
   {
-    "id": "ann-902-ndom",
+    "id": "ann-902-bounds",
     "proofId": "erdos-902",
-    "range": { "startLine": 60, "endLine": 62 },
-    "type": "definition",
-    "title": "n-Dominating",
-    "content": "Tournament where every n-set is dominated by some vertex.",
-    "significance": "critical"
+    "range": { "startLine": 112, "endLine": 136 },
+    "type": "axiom",
+    "title": "Lower and Upper Bounds",
+    "content": "**szekeres_lower_bound**: f(n) ≥ c·n·2^n (Szekeres & Szekeres, 1965).\nFrom a counting argument: each vertex can dominate at most C(k-1,n) sets of size n.\n\n**erdos_upper_bound**: f(n) ≤ C·n²·2^n (Erdős, 1963).\nFrom the probabilistic method: a random tournament of order O(n²·2^n) is n-dominating with positive probability.",
+    "mathContext": "The lower bound uses double counting. The upper bound is a landmark application of the probabilistic method — one of Erdős's key contributions to combinatorics.",
+    "significance": "critical",
+    "relatedConcepts": ["Counting argument", "Probabilistic method", "Szekeres"]
   },
   {
-    "id": "ann-902-f",
+    "id": "ann-902-asymptotic",
     "proofId": "erdos-902",
-    "range": { "startLine": 66, "endLine": 72 },
-    "type": "definition",
-    "title": "f(n)",
-    "content": "Minimum tournament order where every n-set is dominated.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-902-f1",
-    "proofId": "erdos-902",
-    "range": { "startLine": 84, "endLine": 86 },
-    "type": "theorem",
-    "title": "f(1) = 3",
-    "content": "Rock-paper-scissors: the minimal 1-dominating tournament.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-902-f2",
-    "proofId": "erdos-902",
-    "range": { "startLine": 93, "endLine": 95 },
-    "type": "theorem",
-    "title": "f(2) = 7",
-    "content": "Paley tournament of order 7 achieves this bound.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-902-f3",
-    "proofId": "erdos-902",
-    "range": { "startLine": 107, "endLine": 109 },
-    "type": "theorem",
-    "title": "f(3) = 19",
-    "content": "Computationally determined exact value.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-902-lower",
-    "proofId": "erdos-902",
-    "range": { "startLine": 123, "endLine": 126 },
-    "type": "theorem",
-    "title": "Szekeres Lower Bound",
-    "content": "f(n) >= c * n * 2^n for some c > 0 (1965).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-902-upper",
-    "proofId": "erdos-902",
-    "range": { "startLine": 141, "endLine": 144 },
-    "type": "theorem",
-    "title": "Erdos Upper Bound",
-    "content": "f(n) <= C * n^2 * 2^n via probabilistic method (1963).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-902-ratio",
-    "proofId": "erdos-902",
-    "range": { "startLine": 154, "endLine": 155 },
-    "type": "definition",
-    "title": "Asymptotic Ratio",
-    "content": "f(n) / (n * 2^n): the key quantity to estimate.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-902-gap",
-    "proofId": "erdos-902",
-    "range": { "startLine": 167, "endLine": 171 },
+    "range": { "startLine": 138, "endLine": 165 },
     "type": "theorem",
     "title": "Asymptotic Gap",
-    "content": "c <= f(n)/(n*2^n) <= C*n. The gap remains open.",
-    "significance": "critical"
+    "content": "**asymptoticRatio(n)** = f(n)/(n·2^n): The key quantity.\n\n**asymptotic_lower/upper**: c ≤ asymptoticRatio(n) ≤ C·n.\n\n**asymptotic_gap** (theorem): Combines both bounds, with C > 0 derived from the ratio being positive. The gap of a factor of n is the central open question.",
+    "mathContext": "Whether the ratio is bounded (f(n) = Θ(n·2^n)) or grows (f(n) = Θ(n²·2^n)) is unknown. This determines whether the lower or upper bound is closer to truth.",
+    "significance": "critical",
+    "relatedConcepts": ["Asymptotic analysis", "Open problem"]
   },
   {
     "id": "ann-902-paley",
     "proofId": "erdos-902",
-    "range": { "startLine": 175, "endLine": 177 },
+    "range": { "startLine": 167, "endLine": 186 },
     "type": "definition",
-    "title": "Paley Edge",
-    "content": "Edge u->v iff v-u is a quadratic residue mod prime p.",
-    "significance": "key"
+    "title": "Paley Tournaments and Quadratic Residues",
+    "content": "**isPaleyEdge(p, u, v)**: Edge u → v iff v - u is a quadratic residue mod p (for p ≡ 3 mod 4).\n\n**paley_domination_bound**: Paley tournament of order p is ((p-1)/2-1)-dominating.\n\n**isQuadraticResidue(p, a)**: a ≠ 0 and a = x² for some x.\n**half_are_residues**: Exactly (p-1)/2 nonzero elements are quadratic residues.",
+    "mathContext": "Paley tournaments are highly structured: their automorphism group acts transitively. For primes p ≡ 3 mod 4, they provide optimal or near-optimal dominating tournaments.",
+    "significance": "key",
+    "relatedConcepts": ["Quadratic residues", "Finite fields", "Paley construction"]
   },
   {
-    "id": "ann-902-residue",
+    "id": "ann-902-summary",
     "proofId": "erdos-902",
-    "range": { "startLine": 191, "endLine": 193 },
-    "type": "definition",
-    "title": "Quadratic Residue",
-    "content": "a is a QR if a = x^2 for some nonzero x.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-902-domnum",
-    "proofId": "erdos-902",
-    "range": { "startLine": 202, "endLine": 207 },
-    "type": "definition",
-    "title": "Domination Number",
-    "content": "Maximum n such that tournament is n-dominating.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-902-random",
-    "proofId": "erdos-902",
-    "range": { "startLine": 216, "endLine": 219 },
-    "type": "definition",
-    "title": "Random Tournament",
-    "content": "Probability that random k-tournament is n-dominating.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-902-prob",
-    "proofId": "erdos-902",
-    "range": { "startLine": 226, "endLine": 229 },
+    "range": { "startLine": 217, "endLine": 237 },
     "type": "theorem",
-    "title": "Probabilistic Existence",
-    "content": "For any n, an n-dominating tournament exists.",
-    "significance": "key"
+    "title": "Summary",
+    "content": "**erdos_902**: Combines the Szekeres lower bound and Erdős upper bound:\n- ∃ c > 0: f(n) ≥ c·n·2^n\n- ∃ C > 0: f(n) ≤ C·n²·2^n\n\nProved by ⟨szekeres_lower_bound, erdos_upper_bound⟩.\n\nThe gap of a factor of n between bounds remains OPEN.",
+    "mathContext": "The problem is to close the gap between n·2^n and n²·2^n. Neither bound has been improved since the 1960s.",
+    "significance": "critical",
+    "relatedConcepts": ["Summary", "Open problem"]
   }
 ]

--- a/src/data/proofs/erdos-902/meta.json
+++ b/src/data/proofs/erdos-902/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, György Szekeres, Esther Szekeres",
     "sourceUrl": "https://erdosproblems.com/902",
     "date": "1963",
-    "status": "formalized",
+    "status": "complete",
     "proofRepoPath": "Proofs/Erdos902Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "tournaments",
       "domination"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 902,
     "erdosUrl": "https://erdosproblems.com/902",
@@ -86,37 +86,37 @@
     {
       "id": "paley",
       "title": "Paley Tournament",
-      "summary": "Quadratic residue construction",
-      "startLine": 173,
-      "endLine": 187
+      "summary": "Quadratic residue construction and domination bound",
+      "startLine": 167,
+      "endLine": 175
     },
     {
       "id": "quadratic-residues",
       "title": "Quadratic Residues",
       "summary": "Half of nonzero elements are residues",
-      "startLine": 189,
-      "endLine": 198
+      "startLine": 177,
+      "endLine": 186
     },
     {
       "id": "generalizations",
       "title": "Generalizations",
       "summary": "Domination number of a tournament",
-      "startLine": 200,
-      "endLine": 212
+      "startLine": 188,
+      "endLine": 200
     },
     {
       "id": "probabilistic",
       "title": "Probabilistic Method",
       "summary": "Random tournaments and existence proofs",
-      "startLine": 214,
-      "endLine": 229
+      "startLine": 202,
+      "endLine": 215
     },
     {
-      "id": "coding-theory",
-      "title": "Coding Theory Connection",
-      "summary": "Covering codes and dominating tournaments",
-      "startLine": 231,
-      "endLine": 241
+      "id": "summary",
+      "title": "Summary",
+      "summary": "erdos_902: combining Szekeres lower and Erdős upper bounds",
+      "startLine": 217,
+      "endLine": 237
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Replaced 3 `True` theorems with meaningful axiom (`paley_domination_bound`)
- Removed trivial `coveringRadius` placeholder and `tournament_covering_connection`
- Added meaningful `erdos_902` summary theorem combining Szekeres lower + Erdős upper bounds
- Fixed `/-` section headers to `/-!` doc comments throughout
- Fixed meta.json: badge "axiom" (was "wip"), status "complete" (was "formalized")
- Updated sections and annotations for new 237-line structure

## Test plan
- [x] `pnpm build` passes
- [x] No `sorry` or trivial `True` constructs
- [x] meta.json and annotations consistent with file

🤖 Generated with [Claude Code](https://claude.com/claude-code)