### PR TITLE
enhance(erdos-616): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos616Problem.lean
+++ b/proofs/Proofs/Erdos616Problem.lean
@@ -39,9 +39,7 @@ import Mathlib.Data.Real.Basic
 
 namespace Erdos616
 
-/-!
-## Part I: Hypergraph Definitions
--/
+/- ## Part I: Hypergraph Definitions -/
 
 /--
 **r-uniform hypergraph:**
@@ -78,9 +76,7 @@ def inducedSubhypergraph {V : Type*} {r : ℕ}
     intro e he
     exact G.uniform e he.1
 
-/-!
-## Part II: The Local Condition
--/
+/- ## Part II: The Local Condition -/
 
 /--
 **Local covering condition:**
@@ -101,9 +97,7 @@ For r-uniform hypergraphs, the relevant threshold is 3r-3 vertices.
 -/
 def localThreshold (r : ℕ) : ℕ := 3 * r - 3
 
-/-!
-## Part III: The Main Question
--/
+/- ## Part III: The Main Question -/
 
 /--
 **Erdős Problem #616:**
@@ -123,9 +117,7 @@ There exists an optimal t(r) that works for all such hypergraphs.
 -/
 axiom optimalCoveringBound (r : ℕ) : ℕ
 
-/-!
-## Part IV: Known Bounds (Erdős-Hajnal-Tuza 1991)
--/
+/- ## Part IV: Known Bounds (Erdős-Hajnal-Tuza 1991) -/
 
 /--
 **Lower Bound:**
@@ -167,9 +159,7 @@ theorem coefficient_bounds :
   unfold lowerCoefficient upperCoefficient
   norm_num
 
-/-!
-## Part V: Special Cases
--/
+/- ## Part V: Special Cases -/
 
 /--
 **r = 3 case:**
@@ -194,9 +184,7 @@ The bounds give:
 The bounds become meaningful for larger r.
 -/
 
-/-!
-## Part VI: Why the Condition 3r-3?
--/
+/- ## Part VI: Why the Condition 3r-3? -/
 
 /--
 **The threshold 3r-3:**
@@ -212,9 +200,7 @@ of edges sharing a common "core", and the local condition τ ≤ 1 enforces
 sunflower-like structure locally.
 -/
 
-/-!
-## Part VII: Equivalent Formulations
--/
+/- ## Part VII: Equivalent Formulations -/
 
 /--
 **Intersection property:**
@@ -241,9 +227,7 @@ theorem tau_one_iff_kernel {V : Type*} [Fintype V] {r : ℕ}
     use v
     exact ⟨Set.mem_singleton v, hv e he⟩
 
-/-!
-## Part VIII: Fractional Relaxation
--/
+/- ## Part VIII: Fractional Relaxation -/
 
 /--
 **Fractional covering number τ*(G):**
@@ -259,9 +243,7 @@ axiom fractionalCoveringNumber : ∀ {V : Type*} [Fintype V] {r : ℕ},
 The gap between them relates to the integrality gap.
 -/
 
-/-!
-## Part IX: Summary
--/
+/- ## Part IX: Summary -/
 
 /--
 **Erdős Problem #616: OPEN**

--- a/src/data/proofs/erdos-616/meta.json
+++ b/src/data/proofs/erdos-616/meta.json
@@ -20,7 +20,25 @@
     "sorries": 0,
     "erdosNumber": 616,
     "erdosUrl": "https://erdosproblems.com/616",
-    "erdosProblemStatus": "open"
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-01-19",
+    "mathlib_version": "4.15.0",
+    "mathlibDependencies": [
+      { "theorem": "Finset", "description": "Finite sets", "module": "Mathlib.Data.Finset.Basic" },
+      { "theorem": "Nat.Basic", "description": "Natural number basics", "module": "Mathlib.Data.Nat.Basic" },
+      { "theorem": "Set.Basic", "description": "Set operations", "module": "Mathlib.Data.Set.Basic" },
+      { "theorem": "Real", "description": "Real number arithmetic", "module": "Mathlib.Data.Real.Basic" }
+    ],
+    "originalContributions": [
+      "UniformHypergraph structure for r-uniform hypergraphs",
+      "IsCoveringSet and coveringNumber definitions",
+      "inducedSubhypergraph construction",
+      "HasLocalCoveringBound predicate",
+      "ErdosProblem616 formal statement",
+      "eht_lower_bound and eht_upper_bound axioms",
+      "HasKernel definition and tau_one_iff_kernel proof",
+      "erdos_616_summary theorem combining bounds"
+    ]
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's work on extremal hypergraph theory. The covering number (or transversal number) τ(G) is a fundamental parameter measuring how many vertices are needed to 'hit' every edge. The question asks: how does local structure (small subgraphs all having τ ≤ 1, meaning a common vertex) bound global covering number? Erdős, Hajnal, and Tuza established bounds in their 1991 paper 'Local constraints ensuring small representing sets' in J. Combinatorial Theory Series A. The problem belongs to the classical tradition of inferring global structure from local constraints.",


### PR DESCRIPTION
## Summary
- Fixed all `/-!` section headers to `/-` in Lean proof file for Aristotle compatibility
- Added missing meta.json fields: dateAdded, mathlib_version, mathlibDependencies, originalContributions

## Checklist
- [x] Lean proof file uses `/-` headers (not `/-!`)
- [x] meta.json has all required fields
- [x] pnpm build succeeds

Generated by erdos-enhancer-2