### PR TITLE
enhance(erdos-923): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos923Problem.lean
+++ b/proofs/Proofs/Erdos923Problem.lean
@@ -1,4 +1,4 @@
-/-!
+/-
 Erdős Problem #923: Triangle-Free Subgraphs with High Chromatic Number
 
 Source: https://erdosproblems.com/923
@@ -42,7 +42,7 @@ open Nat SimpleGraph
 
 namespace Erdos923
 
-/-! ## Part I: Graph Colorings and Chromatic Number -/
+/- ## Part I: Graph Colorings and Chromatic Number -/
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
@@ -68,7 +68,7 @@ G has chromatic number at least k.
 def HasChromaticNumberAtLeast (G : SimpleGraph V) (k : ℕ) : Prop :=
   chromaticNumber G ≥ k
 
-/-! ## Part II: Triangle-Free Graphs -/
+/- ## Part II: Triangle-Free Graphs -/
 
 /--
 **Triangle:**
@@ -95,7 +95,7 @@ theorem emptyGraph_triangleFree : IsTriangleFree (⊥ : SimpleGraph V) := by
   intros a b c _ _ _
   simp [SimpleGraph.bot_adj]
 
-/-! ## Part III: Subgraphs -/
+/- ## Part III: Subgraphs -/
 
 /--
 **Spanning Subgraph:**
@@ -119,7 +119,7 @@ axiom subgraph_chromatic_le (H G : SimpleGraph V)
     (hsub : IsSpanningSubgraph H G) :
     chromaticNumber H ≤ chromaticNumber G
 
-/-! ## Part IV: Mycielski's Construction (Context) -/
+/- ## Part IV: Mycielski's Construction (Context) -/
 
 /--
 **Mycielski Graphs:**
@@ -131,7 +131,7 @@ axiom mycielski_triangle_free_high_chromatic :
     ∃ G : SimpleGraph W,
       IsTriangleFree G ∧ HasChromaticNumberAtLeast G k
 
-/-! ## Part V: The Main Problem -/
+/- ## Part V: The Main Problem -/
 
 /--
 **Rödl's Theorem (1977):**
@@ -162,7 +162,7 @@ theorem erdos_923_true :
         HasChromaticNumberAtLeast H k :=
   rodl_1977
 
-/-! ## Part VI: Tower Function Bounds -/
+/- ## Part VI: Tower Function Bounds -/
 
 /--
 **Tower Function:**
@@ -197,7 +197,7 @@ axiom rodl_bound :
         IsTriangleFree H ∧
         HasChromaticNumberAtLeast H k
 
-/-! ## Part VII: Generalizations -/
+/- ## Part VII: Generalizations -/
 
 /--
 **H-Free Version (Problem #108):**
@@ -225,7 +225,7 @@ axiom rodl_general_bipartite :
     (∃ c : Hgraph.Coloring (Fin 2), True) →
     HFreeSubgraphProblem H Hgraph
 
-/-! ## Part VIII: Summary -/
+/- ## Part VIII: Summary -/
 
 /--
 **Erdős Problem #923: Summary**

--- a/src/data/proofs/erdos-923/meta.json
+++ b/src/data/proofs/erdos-923/meta.json
@@ -19,7 +19,9 @@
     "sorries": 0,
     "erdosNumber": 923,
     "erdosUrl": "https://erdosproblems.com/923",
-    "erdosProblemStatus": "solved"
+    "erdosProblemStatus": "solved",
+    "dateAdded": "2026-01-19",
+    "mathlib_version": "4.15.0"
   },
   "overview": {
     "historicalContext": "Jan Mycielski stunned graph theorists in 1955 by constructing triangle-free graphs with arbitrarily high chromatic number. The Mycielski construction M_k satisfies χ(M_k) = k while being completely triangle-free. This shattered the intuition that high chromatic number requires dense local structure like triangles.\n\nErdős posed Problem #923 in 1969 [Er69b]: if a graph has VERY high chromatic number, must it contain a triangle-free subgraph with moderately high chromatic number? This asks whether chromatic complexity must 'spread' beyond just the triangles.\n\nVojtěch Rödl proved YES in a one-page paper in Proc. Amer. Math. Soc. (1977). The proof uses Ramsey-theoretic ideas: partition edges of the high-chromatic graph into classes, and use Ramsey bounds to find a triangle-free piece with high chromatic number. The threshold f(k) is necessarily a tower of 2s, reflecting deep connections to Ramsey numbers.",


### PR DESCRIPTION
## Summary
- Fixed all `/-!` section headers to `/-` in Lean proof file for Aristotle compatibility
- Added missing dateAdded and mathlib_version to meta.json

## Checklist
- [x] Lean proof file uses `/-` headers (not `/-!`)
- [x] pnpm build succeeds

Generated by erdos-enhancer-2