### PR TITLE
Enhance erdos-532: fix headers, remove True placeholder

### DIFF
--- a/proofs/Proofs/Erdos532Problem.lean
+++ b/proofs/Proofs/Erdos532Problem.lean
@@ -1,4 +1,4 @@
-/-!
+/-
 Erdős Problem #532: Hindman's Theorem (IP Sets)
 
 Source: https://erdosproblems.com/532
@@ -48,7 +48,7 @@ open Finset BigOperators
 
 namespace Erdos532
 
-/-!
+/-
 ## Part I: Finite Colorings
 -/
 
@@ -65,7 +65,7 @@ A set S ⊆ ℕ is monochromatic under coloring c if all elements have the same 
 def IsMonochromatic {k : ℕ} (c : Coloring k) (S : Set ℕ) : Prop :=
   ∃ color : Fin k, ∀ n ∈ S, c n = color
 
-/-!
+/-
 ## Part II: Finite Subset Sums
 -/
 
@@ -83,7 +83,7 @@ This is the set { Σ_{n ∈ S} n | S ⊆ A, S finite and non-empty }.
 def FiniteSums (A : Set ℕ) : Set ℕ :=
   { n : ℕ | ∃ S : Finset ℕ, S.Nonempty ∧ (↑S : Set ℕ) ⊆ A ∧ finsetSum S = n }
 
-/-!
+/-
 ## Part III: IP Sets
 -/
 
@@ -102,7 +102,7 @@ A set is IP* if it intersects every IP set (the dual notion).
 def IsIPStarSet (S : Set ℕ) : Prop :=
   ∀ T : Set ℕ, IsIPSet T → (S ∩ T).Nonempty
 
-/-!
+/-
 ## Part IV: Hindman's Theorem
 -/
 
@@ -147,7 +147,7 @@ theorem erdos_532_two_colors :
   intro c
   exact hindman_color_class 2 (by norm_num) c
 
-/-!
+/-
 ## Part V: Basic Properties of IP Sets
 -/
 
@@ -199,7 +199,7 @@ theorem finite_sums_add_disjoint {A : Set ℕ} {S T : Finset ℕ}
   · unfold finsetSum
     rw [sum_union hST]
 
-/-!
+/-
 ## Part VI: Ultrafilter Proof (Modern Approach)
 -/
 
@@ -246,22 +246,8 @@ axiom ultrafilter_implies_hindman :
     ∀ c : Coloring k,
       ∃ A : Set ℕ, A.Infinite ∧ IsMonochromatic c (FiniteSums A)
 
-/-!
-## Part VII: Milliken-Taylor Theorem
--/
-
-/--
-**Milliken-Taylor Theorem:**
-A strengthening of Hindman's theorem. For any finite coloring of FS_k
-(k-tuples of sums from an infinite sequence), there exists a monochromatic
-structure.
--/
-axiom milliken_taylor_theorem :
-  ∀ k r : ℕ, k ≥ 1 → r ≥ 1 →
-    True  -- Statement requires more elaborate types
-
-/-!
-## Part VIII: Hales-Jewett Connection
+/-
+## Part VII: Hales-Jewett Connection
 -/
 
 /--
@@ -278,8 +264,8 @@ axiom hales_jewett_implies_hindman :
     ∀ c : Coloring k,
       ∃ A : Set ℕ, A.Infinite ∧ IsMonochromatic c (FiniteSums A)
 
-/-!
-## Part IX: Computational Aspects
+/-
+## Part VIII: Computational Aspects
 -/
 
 /--
@@ -306,8 +292,8 @@ all the same color.
 noncomputable def hindmanNumber (k : ℕ) : ℕ :=
   Nat.find (hindman_finite_exists k)
 
-/-!
-## Part X: Summary
+/-
+## Part IX: Summary
 -/
 
 /--

--- a/src/data/proofs/erdos-532/annotations.json
+++ b/src/data/proofs/erdos-532/annotations.json
@@ -145,7 +145,7 @@
   {
     "id": "ann-e532-hales-jewett",
     "proofId": "erdos-532",
-    "range": { "startLine": 267, "endLine": 279 },
+    "range": { "startLine": 253, "endLine": 265 },
     "type": "axiom",
     "title": "Hales-Jewett Connection",
     "content": "Hindman's theorem can also be derived from the **Hales-Jewett theorem**, which guarantees combinatorial lines in high-dimensional cubes under finite colorings. This shows the deep interconnections within Ramsey theory: Hales-Jewett implies Van der Waerden, Hindman, and many other partition regularity results.\n\nAxiomatized because the Hales-Jewett theorem itself is not in Mathlib.",
@@ -156,7 +156,7 @@
   {
     "id": "ann-e532-hindman-numbers",
     "proofId": "erdos-532",
-    "range": { "startLine": 286, "endLine": 308 },
+    "range": { "startLine": 272, "endLine": 294 },
     "type": "definition",
     "title": "Hindman Numbers",
     "content": "**Hindman numbers** HJ(k) give the finite version: the smallest N such that any k-coloring of {1,...,N} has a monochromatic triple {a, b, a+b}. The existence is axiomatized (follows from compactness), and the Hindman number is defined as the least such N via Nat.find. Known: HJ(2) = 5 since any 2-coloring of {1,...,5} must have a monochromatic Schur triple.",
@@ -167,7 +167,7 @@
   {
     "id": "ann-e532-summary",
     "proofId": "erdos-532",
-    "range": { "startLine": 313, "endLine": 340 },
+    "range": { "startLine": 299, "endLine": 326 },
     "type": "theorem",
     "title": "Summary: Problem Solved",
     "content": "The **summary theorem** combines the key results: (1) for any 2-coloring, some color class is an IP set (answering the original question), and (2) for any k-coloring (k ≥ 1), there exists an infinite set A with monochromatic finite sums (the full Hindman theorem). Proved by combining `erdos_532_two_colors` and `hindman_theorem`.",

--- a/src/data/proofs/erdos-532/meta.json
+++ b/src/data/proofs/erdos-532/meta.json
@@ -56,8 +56,7 @@
       "Idempotent ultrafilter existence axiom with IP-set property",
       "Ultrafilter implies Hindman axiom (modern proof path)",
       "Hales-Jewett implies Hindman axiom (alternative proof path)",
-      "Finite Hindman theorem axiom and Hindman numbers definition",
-      "Milliken-Taylor theorem statement (generalization)"
+      "Finite Hindman theorem axiom and Hindman numbers definition"
     ]
   },
   "overview": {
@@ -118,32 +117,25 @@
       "endLine": 248
     },
     {
-      "id": "milliken-taylor",
-      "title": "Milliken-Taylor Theorem",
-      "summary": "Strengthening of Hindman's theorem for k-tuples",
-      "startLine": 249,
-      "endLine": 262
-    },
-    {
       "id": "hales-jewett",
       "title": "Hales-Jewett Connection",
       "summary": "Deriving Hindman from Hales-Jewett theorem",
-      "startLine": 263,
-      "endLine": 280
+      "startLine": 249,
+      "endLine": 265
     },
     {
       "id": "computational",
       "title": "Computational Aspects",
       "summary": "Hindman numbers and the finite version",
-      "startLine": 281,
-      "endLine": 308
+      "startLine": 267,
+      "endLine": 294
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Problem status, combined results, and impact",
-      "startLine": 309,
-      "endLine": 343
+      "startLine": 295,
+      "endLine": 329
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Convert 11 `/-!` section headers to `/-` for Aristotle compatibility
- Remove `milliken_taylor_theorem` True placeholder axiom
- Renumber sections, update meta.json and annotations.json

## Test plan
- [x] `pnpm build` passes
- [ ] Gallery renders erdos-532 correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)