### PR TITLE
enhance(erdos-882): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos882Problem.lean
+++ b/proofs/Proofs/Erdos882Problem.lean
@@ -1,4 +1,4 @@
-/-!
+/-
 # Erdős Problem #882: Subset Sums Without Divisibility
 
 Source: https://erdosproblems.com/882
@@ -34,7 +34,7 @@ namespace Erdos882
 
 open Finset BigOperators
 
-/-!
+/-
 ## Part 1: Basic Definitions
 
 A ⊆ {1,...,n} and its subset sums.
@@ -59,7 +59,7 @@ def DivisibilityFree (S : Finset ℕ) : Prop :=
 def ValidSubset (n : ℕ) (A : Finset ℕ) : Prop :=
   (∀ a ∈ A, 1 ≤ a ∧ a ≤ n) ∧ DivisibilityFree (subsetSums A)
 
-/-!
+/-
 ## Part 2: The Optimization Problem
 
 Find max |A| such that ValidSubset n A holds.
@@ -73,7 +73,7 @@ noncomputable def maxValidSize (n : ℕ) : ℕ :=
     exact ⟨A.card, A, hA, rfl⟩ : ∃ k, ∃ A, ValidSubset n A ∧ A.card = k)
   else 0
 
-/-!
+/-
 ## Part 3: Lower Bounds
 
 Constructions achieving good sizes.
@@ -101,7 +101,7 @@ axiom elrss_1999 (m : ℕ) (hm : m ≥ 2) :
   let n := 2^m
   ValidSubset n (ELRSSConstruction m) ∧ (ELRSSConstruction m).card > Nat.log 2 n - 1
 
-/-!
+/-
 ## Part 4: Upper Bounds
 
 The subset sums being distinct implies constraints.
@@ -137,7 +137,7 @@ axiom upper_bound_refined (n : ℕ) (A : Finset ℕ) (hn : n ≥ 16)
 axiom conjectured_upper_bound (n : ℕ) (A : Finset ℕ) (h : ValidSubset n A) :
   ∃ C : ℕ, A.card ≤ Nat.log 2 n + C
 
-/-!
+/-
 ## Part 5: The Answer
 
 maxValidSize(n) = (1 + o(1)) log₂ n
@@ -155,7 +155,7 @@ theorem upper_bound_max (n : ℕ) (hn : n ≥ 16) :
   intro A hA
   exact upper_bound_refined n A hn hA
 
-/-!
+/-
 ## Part 6: Examples
 -/
 
@@ -168,7 +168,7 @@ axiom example_2_3 (n : ℕ) (hn : n ≥ 3) : ValidSubset n ({2, 3} : Finset ℕ)
   -- subset sums: {2}, {3}, {2,3} give 2, 3, 5
   -- Check: 2 ∤ 3, 3 ∤ 2, 2 ∤ 5, 5 ∤ 2, 3 ∤ 5, 5 ∤ 3 ✓
 
-/-!
+/-
 ## Part 7: Connection to Erdős Problem #1 and #13
 -/
 
@@ -182,7 +182,7 @@ axiom erdos_1_connection :
 axiom sidon_sets_have_distinct_pairwise_sums :
   ∀ A : Finset ℕ, DistinctSubsetSums A → DivisibilityFree (subsetSums A)
 
-/-!
+/-
 ## Part 8: Main Results
 -/
 

--- a/src/data/proofs/erdos-882/annotations.json
+++ b/src/data/proofs/erdos-882/annotations.json
@@ -103,7 +103,7 @@
   {
     "id": "ann-882-divimplies",
     "proofId": "erdos-882",
-    "range": { "startLine": 115, "endLine": 122 },
+    "range": { "startLine": 115, "endLine": 120 },
     "type": "theorem",
     "title": "div_free_implies_distinct",
     "content": "If subset sums are divisibility-free, they must be distinct. This connects the problem to Erdős #1.",
@@ -112,7 +112,7 @@
   {
     "id": "ann-882-sumbound",
     "proofId": "erdos-882",
-    "range": { "startLine": 128, "endLine": 132 },
+    "range": { "startLine": 125, "endLine": 129 },
     "type": "theorem",
     "title": "sum_bound",
     "content": "For A ⊆ {1,...,n}, the sum σ(A) = ∑A ≤ |A| · n. This bounds the total sum by the set size times the maximum element.",
@@ -121,7 +121,7 @@
   {
     "id": "ann-882-upperrefined",
     "proofId": "erdos-882",
-    "range": { "startLine": 134, "endLine": 137 },
+    "range": { "startLine": 131, "endLine": 134 },
     "type": "axiom",
     "title": "Refined Upper Bound",
     "content": "|A| ≤ log₂ n + ½ log₂(log n) + 3 for n ≥ 16. This follows from the distinct subset sums bound.",
@@ -130,7 +130,7 @@
   {
     "id": "ann-882-conjectured",
     "proofId": "erdos-882",
-    "range": { "startLine": 139, "endLine": 141 },
+    "range": { "startLine": 136, "endLine": 138 },
     "type": "axiom",
     "title": "Conjectured Bound",
     "content": "Conjectured: |A| ≤ log₂ n + O(1), i.e., the ½ log₂(log n) term can be removed.",
@@ -139,7 +139,7 @@
   {
     "id": "ann-882-lowermax",
     "proofId": "erdos-882",
-    "range": { "startLine": 149, "endLine": 153 },
+    "range": { "startLine": 146, "endLine": 148 },
     "type": "theorem",
     "title": "lower_bound_max",
     "content": "For n ≥ 4, there exists a valid A with |A| ≥ log₂ n - 2. Uses ELRSS or Sándor construction.",
@@ -148,7 +148,7 @@
   {
     "id": "ann-882-uppermax",
     "proofId": "erdos-882",
-    "range": { "startLine": 155, "endLine": 160 },
+    "range": { "startLine": 152, "endLine": 156 },
     "type": "theorem",
     "title": "upper_bound_max",
     "content": "For n ≥ 16, every valid A satisfies |A| ≤ log₂ n + ½ log₂(log n) + 3.",
@@ -157,7 +157,7 @@
   {
     "id": "ann-882-singleton",
     "proofId": "erdos-882",
-    "range": { "startLine": 166, "endLine": 179 },
+    "range": { "startLine": 162, "endLine": 163 },
     "type": "theorem",
     "title": "example_singleton",
     "content": "A = {1} is valid for any n ≥ 1. Its only subset sum is 1, which is trivially divisibility-free.",
@@ -166,7 +166,7 @@
   {
     "id": "ann-882-example23",
     "proofId": "erdos-882",
-    "range": { "startLine": 181, "endLine": 191 },
+    "range": { "startLine": 166, "endLine": 169 },
     "type": "theorem",
     "title": "example_2_3",
     "content": "A = {2, 3} is valid for n ≥ 3. Subset sums are {2, 3, 5}, and none of 2, 3, 5 divide each other.",
@@ -175,7 +175,7 @@
   {
     "id": "ann-882-erdos1",
     "proofId": "erdos-882",
-    "range": { "startLine": 197, "endLine": 199 },
+    "range": { "startLine": 175, "endLine": 177 },
     "type": "axiom",
     "title": "Erdős #1 Connection",
     "content": "Connection to Erdős Problem #1: ValidSubset implies DistinctSubsetSums, giving the upper bound.",
@@ -202,7 +202,7 @@
   {
     "id": "ann-882-summary",
     "proofId": "erdos-882",
-    "range": { "startLine": 200, "endLine": 215 },
+    "range": { "startLine": 200, "endLine": 214 },
     "type": "theorem",
     "title": "erdos_882_summary",
     "content": "**erdos_882_summary** combines the lower and upper bounds into a single theorem, equivalent to erdos_882_statement. The proof delegates directly to erdos_882_statement.\n\nThe answer is (1 + o(1)) log₂ n. SOLVED.",

--- a/src/data/proofs/erdos-882/meta.json
+++ b/src/data/proofs/erdos-882/meta.json
@@ -93,21 +93,21 @@
       "title": "Upper Bounds",
       "summary": "DistinctSubsetSums, div_free_implies_distinct, upper_bound_refined",
       "startLine": 104,
-      "endLine": 142
+      "endLine": 139
     },
     {
       "id": "the-answer",
       "title": "The Answer",
       "summary": "lower_bound_max, upper_bound_max theorems",
-      "startLine": 143,
-      "endLine": 161
+      "startLine": 140,
+      "endLine": 157
     },
     {
       "id": "examples",
       "title": "Examples",
       "summary": "example_singleton, example_2_3",
-      "startLine": 162,
-      "endLine": 192
+      "startLine": 158,
+      "endLine": 169
     },
     {
       "id": "connections",

--- a/src/data/proofs/erdos-882/meta.json
+++ b/src/data/proofs/erdos-882/meta.json
@@ -21,6 +21,7 @@
     "erdosNumber": 882,
     "erdosUrl": "https://erdosproblems.com/882",
     "erdosProblemStatus": "solved",
+    "dateAdded": "2025-01-15",
     "mathlib_version": "4.15.0",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Summary
- Replace 9 `/-!` docstring headers with `/-` for Aristotle parser compatibility
- Add missing `dateAdded` field to meta.json

## Test plan
- [x] `pnpm build` passes
- [ ] Judge review

🤖 Generated with [Claude Code](https://claude.com/claude-code)