### PR TITLE
Enhance Erdős #821: fix docstring headers

### DIFF
--- a/proofs/Proofs/Erdos821Problem.lean
+++ b/proofs/Proofs/Erdos821Problem.lean
@@ -37,7 +37,7 @@ open Nat Real Filter
 
 namespace Erdos821
 
-/-! ## Euler's Totient Function -/
+/- ## Euler's Totient Function -/
 
 /-- Euler's totient function φ(n). -/
 def phi : ℕ → ℕ := Nat.totient
@@ -55,7 +55,7 @@ noncomputable def preimageCount (n : ℕ) : ℕ :=
 /-- The preimage count is finite for each n. -/
 axiom preimageCount_finite (n : ℕ) : preimageCount n < n^2
 
-/-! ## Known Results -/
+/- ## Known Results -/
 
 /-- **Pillai's Theorem:**
     lim sup g(n) = ∞, i.e., g(n) is unbounded. -/
@@ -73,7 +73,7 @@ noncomputable def erdosConstant1935 : ℝ := 0.1 -- placeholder
 axiom erdos_explicit_bound :
   ∀ N : ℕ, ∃ n ≥ N, (preimageCount n : ℝ) > n^erdosConstant1935
 
-/-! ## Lichtman's Result (2022) -/
+/- ## Lichtman's Result (2022) -/
 
 /-- The Lichtman exponent: 0.71568... -/
 noncomputable def lichtmanExponent : ℝ := 0.71568
@@ -90,7 +90,7 @@ axiom lichtman_primes :
       ∀ q : ℕ, Nat.Prime q → q ∣ p - 1 → q ≤ ⌊x^(0.2843 : ℝ)⌋₊)
       (Finset.range (⌊x⌋₊ + 1))).card ≥ c * x / (Real.log x)^2
 
-/-! ## The Conjecture -/
+/- ## The Conjecture -/
 
 /-- **Erdős Conjecture (Problem #821):**
     For every ε > 0, there are infinitely many n with g(n) > n^{1-ε}. -/
@@ -101,7 +101,7 @@ def ErdosConjecture821 : Prop :=
 def ErdosConjecture821' : Prop :=
   ∀ α : ℝ, α < 1 → ∀ N : ℕ, ∃ n ≥ N, (preimageCount n : ℝ) > n^α
 
-/-! ## Connection to Smooth Primes -/
+/- ## Connection to Smooth Primes -/
 
 /-- A prime p has ε-smooth (p-1) if all prime factors of p-1 are < p^ε. -/
 def IsEpsilonSmooth (p : ℕ) (ε : ℝ) : Prop :=
@@ -117,7 +117,7 @@ def SmoothPrimesCondition : Prop :=
 axiom smooth_implies_conjecture :
   SmoothPrimesCondition → ErdosConjecture821
 
-/-! ## Upper Bounds -/
+/- ## Upper Bounds -/
 
 /-- Upper bound: g(n) ≤ n^(1+o(1)) trivially. -/
 axiom preimageCount_upper_bound :
@@ -128,13 +128,13 @@ axiom average_preimageCount :
   ∃ C : ℝ, C > 0 ∧ ∀ N : ℕ, N ≥ 2 →
     (∑ n in Finset.Icc 1 N, preimageCount n : ℝ) / N ≤ C * Real.log N
 
-/-! ## Examples -/
+/- ## Examples -/
 
 /-- g(1) = 2 (since φ(1) = φ(2) = 1). -/
 theorem preimage_of_1 : phi 1 = 1 ∧ phi 2 = 1 := by
   simp [phi, Nat.totient]
 
-/-! ## Summary
+/- ## Summary
 
 **Erdős Problem #821: OPEN**
 


### PR DESCRIPTION
## Summary
- Replace `/-!` docstring markers with `/-` in Erdos821Problem.lean for Aristotle parser compatibility
- 8 section headers fixed (Totient, Known Results, Lichtman, Conjecture, Smooth Primes, Upper Bounds, Examples, Summary)
- No other quality issues found (no True placeholders, no definition sorries)

## Test plan
- [x] `pnpm build` passes
- [x] No `/-!` markers remain in file
- [x] No `True := trivial` or definition sorries present

🤖 Generated with [Claude Code](https://claude.com/claude-code)