### PR TITLE
enhance(erdos-810): fix quality issues in rainbow C4 formalization

### DIFF
--- a/proofs/Proofs/Erdos810Problem.lean
+++ b/proofs/Proofs/Erdos810Problem.lean
@@ -1,21 +1,41 @@
-/-!
-# Erdős Problem #810 — Rainbow C₄ in Edge-Colored Dense Graphs
+/-
+Erdős Problem #810: Rainbow C₄ in Edge-Colored Dense Graphs
+
+Source: https://erdosproblems.com/810
+Status: OPEN (Burr, Erdős, Graham, Sós)
+
+## Statement
 
 Does there exist ε > 0 such that for all sufficiently large n, there exists
 a graph G on n vertices with at least εn² edges whose edges can be colored
 with n colors so that every C₄ receives 4 distinct colors?
 
-A problem of Burr, Erdős, Graham, and Sós [Er91].
+## Background
 
-Reference: https://erdosproblems.com/810
+A problem of Burr, Erdős, Graham, and Sós [Er91]. See also Problem #809.
+The Kővári-Sós-Turán theorem gives ex(n; C₄) = O(n^{3/2}), so C₄-free
+graphs (which vacuously satisfy the rainbow condition) are too sparse.
+Any positive answer must involve graphs with many C₄s, all of which
+are rainbow — a delicate balance between density and structure.
+
+## Approach
+
+We formalize edge colorings, the C₄ structure, and the rainbow property.
+The main conjecture is stated as a Prop definition (not an axiom, since it is OPEN).
+The Kővári-Sós-Turán sparsity bound for C₄-free graphs is axiomatized.
 -/
 
 import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Combinatorics.SimpleGraph.Finite
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Card
 import Mathlib.Tactic
 
-/-! ## Edge Colorings and Rainbow Subgraphs -/
+namespace Erdos810
+
+variable {n : ℕ}
+
+-- ## Part I: Edge Colorings and Rainbow Subgraphs
 
 /-- An edge coloring of a graph on Fin n using n colors.
     Assigns a color in Fin n to each edge (unordered pair). -/
@@ -35,51 +55,67 @@ structure CycleFour (G : SimpleGraph (Fin n)) where
   edge34 : G.Adj v₃ v₄
   edge41 : G.Adj v₄ v₁
 
-/-- A C₄ is rainbow under a coloring if all 4 edges have distinct colors -/
-def CycleFour.isRainbow (C : CycleFour G) (χ : EdgeColoringN G) : Prop :=
+/-- A C₄ is rainbow under a coloring if all 4 edges have distinct colors. -/
+def CycleFour.isRainbow {G : SimpleGraph (Fin n)} (C : CycleFour G)
+    (χ : EdgeColoringN G) : Prop :=
   let c₁ := χ C.v₁ C.v₂ C.edge12
   let c₂ := χ C.v₂ C.v₃ C.edge23
   let c₃ := χ C.v₃ C.v₄ C.edge34
   let c₄ := χ C.v₄ C.v₁ C.edge41
   ({c₁, c₂, c₃, c₄} : Finset (Fin n)).card = 4
 
-/-- An edge coloring is rainbow-C₄ if every C₄ in G is rainbow -/
+/-- An edge coloring is rainbow-C₄ if every C₄ in G is rainbow. -/
 def IsRainbowC4Coloring (G : SimpleGraph (Fin n)) (χ : EdgeColoringN G) : Prop :=
   ∀ C : CycleFour G, C.isRainbow χ
 
-/-! ## Dense Graphs with Rainbow-C₄ Colorings -/
+-- ## Part II: Dense Graphs with Rainbow-C₄ Colorings
 
-/-- A graph on n vertices has a rainbow-C₄ n-coloring and ≥ εn² edges -/
+/-- A graph on n vertices has a rainbow-C₄ n-coloring and at least εn² edges. -/
 def HasDenseRainbowC4 (n : ℕ) (ε : ℝ) : Prop :=
   ∃ (G : SimpleGraph (Fin n)) (_ : DecidableRel G.Adj),
     ε * (n : ℝ) ^ 2 ≤ (G.edgeFinset.card : ℝ) ∧
     ∃ χ : EdgeColoringN G, IsRainbowC4Coloring G χ
 
-/-! ## The Burr–Erdős–Graham–Sós Problem -/
+-- ## Part III: The Burr-Erdős-Graham-Sós Conjecture (OPEN)
 
-/-- Erdős Problem 810 (Burr–Erdős–Graham–Sós): Does there exist ε > 0
-    such that for all sufficiently large n, there is a graph on n vertices
-    with ≥ εn² edges admitting an n-coloring where every C₄ is rainbow? -/
-axiom ErdosProblem810 :
+/-- **Erdős Problem 810** (Burr-Erdős-Graham-Sós conjecture):
+    Does there exist ε > 0 such that for all sufficiently large n,
+    there is a graph on n vertices with at least εn² edges admitting
+    an n-coloring where every C₄ is rainbow?
+
+    This is an OPEN problem — stated as a Prop, not asserted as true. -/
+def ErdosProblem810 : Prop :=
   ∃ ε : ℝ, ε > 0 ∧
     ∀ᶠ n in Filter.atTop, HasDenseRainbowC4 n ε
 
-/-! ## Trivial Observations -/
+-- ## Part IV: Known Results (Axioms)
 
-/-- C₄-free graphs trivially satisfy the rainbow condition (vacuously).
-    The Kővári–Sós–Turán theorem gives ex(n; C₄) = O(n^{3/2}),
-    so C₄-free graphs have too few edges (o(n²)). -/
-axiom c4_free_too_sparse :
+/-- **Kővári-Sós-Turán bound for C₄:**
+    C₄-free graphs on n vertices have O(n^{3/2}) edges.
+    This means C₄-free graphs (which vacuously satisfy the rainbow condition)
+    have too few edges to achieve the quadratic density εn². -/
+axiom kovari_sos_turan_C4 :
   ∃ C : ℝ, C > 0 ∧
     ∀ (n : ℕ) (hn : 1 ≤ n)
       (G : SimpleGraph (Fin n)) [DecidableRel G.Adj],
       (∀ C4 : CycleFour G, False) →
         (G.edgeFinset.card : ℝ) ≤ C * (n : ℝ) ^ (3 / 2 : ℝ)
 
-/-- If the conjecture is true, the graph must contain many C₄'s
-    but all of them must be rainbow — a delicate balance between
-    density and structure. -/
-axiom rainbow_requires_many_C4 (n : ℕ) (hn : 2 ≤ n) (ε : ℝ) (hε : ε > 0)
+/-- **Dense graphs contain C₄s:**
+    Any graph with Ω(n²) edges must contain at least one C₄.
+    This is a consequence of Kővári-Sós-Turán. -/
+axiom dense_graph_has_C4 (n : ℕ) (hn : 2 ≤ n) (ε : ℝ) (hε : ε > 0)
     (G : SimpleGraph (Fin n)) [DecidableRel G.Adj]
     (hd : ε * (n : ℝ) ^ 2 ≤ (G.edgeFinset.card : ℝ)) :
   ∃ C4 : CycleFour G, True
+
+-- ## Part V: Structural Observations
+
+/-- C₄-free graphs vacuously satisfy the rainbow condition. -/
+theorem c4_free_vacuously_rainbow
+    (G : SimpleGraph (Fin n)) (χ : EdgeColoringN G)
+    (hfree : ∀ C4 : CycleFour G, False) :
+    IsRainbowC4Coloring G χ :=
+  fun C => False.elim (hfree C)
+
+end Erdos810

--- a/src/data/research/problems/erdos-810.json
+++ b/src/data/research/problems/erdos-810.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-810",
   "title": "Erdős #810",
-  "phase": "NEW",
+  "phase": "SURVEYED",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,24 +16,40 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "SURVEYED",
     "since": "2026-01-15T09:32:29.766Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Enhanced formalization with quality fixes",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Explore connections to Problem 809",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "ENHANCED: Fixed quality issues - removed docstring section headers for Aristotle, changed open conjecture from axiom to Prop def, added namespace, fixed edgeFinset import, proved vacuous rainbow theorem, renamed axioms for clarity.",
+    "builtItems": [
+      "EdgeColoringN, CycleFour, isRainbow in namespace Erdos810",
+      "ErdosProblem810 as Prop def (not axiom) in Erdos810Problem.lean",
+      "kovari_sos_turan_C4 axiom (renamed from c4_free_too_sparse)",
+      "dense_graph_has_C4 axiom (renamed from rainbow_requires_many_C4)",
+      "c4_free_vacuously_rainbow theorem (proved) in Erdos810Problem.lean"
+    ],
+    "insights": [
+      "Problem is OPEN - main conjecture should NOT be axiom (was wrongly asserted as true)",
+      "C4-free graphs vacuously satisfy rainbow condition - key structural observation",
+      "Kovari-Sos-Turan gives ex(n;C4) = O(n^{3/2}) so C4-free graphs too sparse for epsilon n^2",
+      "Any positive answer must have many C4s, all rainbow - delicate density/structure balance",
+      "SimpleGraph.edgeFinset requires import Mathlib.Combinatorics.SimpleGraph.Finite",
+      "Using namespace and variable {n} resolves implicit variable scope issues for CycleFour.isRainbow"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Could explore connections to rainbow Ramsey theory",
+      "Could formalize the relationship to Problem 809"
+    ],
     "markdown": "# Erdős #810 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nDoes there exist some $\\epsilon>0$ such that, for all sufficiently large $n$, there exists a graph $G$ on $n$ vertices with at least $\\epsilon n^2$ many edges such that the edges can be coloured with $n$ colours so that every $C_4$ receives $4$ distinct colours?\n\n\n\nA problem of Burr, Erd\\H{o}s, Graham, and S\\'{o}s.\n\nSee also [809].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #809\n- Problem #811\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er91\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "approaches": [],
@@ -44,7 +60,10 @@
   "references": {
     "papers": [],
     "urls": [],
-    "mathlib": []
+    "mathlib": [
+      "Mathlib.Combinatorics.SimpleGraph.Basic",
+      "Mathlib.Combinatorics.SimpleGraph.Finite"
+    ]
   },
   "started": "2026-01-15T09:32:29.767Z",
   "significance": 7,


### PR DESCRIPTION
## Summary
- Fix docstring section headers for Aristotle parsing compatibility
- Change `ErdosProblem810` from `axiom` to `def ... : Prop` (OPEN conjecture should not be asserted true)
- Add namespace `Erdos810` and `variable {n}` for proper implicit variable scoping
- Add `import Mathlib.Combinatorics.SimpleGraph.Finite` for `edgeFinset` API
- Rename axioms for mathematical clarity (`kovari_sos_turan_C4`, `dense_graph_has_C4`)
- Prove `c4_free_vacuously_rainbow` theorem (C₄-free graphs trivially satisfy rainbow condition)
- Fix `CycleFour.isRainbow` implicit variable resolution

## Test plan
- [x] Docker build verified clean (only minor unused variable warnings in axiom signatures)

🤖 Generated by researcher-1