### PR TITLE
enhance(erdos-967): fix /-! header for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos967Problem.lean
+++ b/proofs/Proofs/Erdos967Problem.lean
@@ -201,7 +201,7 @@ axiom sum_positive_at_zero (a : IntegerSequence) (ha : hasConvergentReciprocalSu
   -- At t = 0, all terms are positive real numbers (1/aₖ > 0)
   -- So the sum equals 1 + ∑ₖ 1/aₖ > 1, which is nonzero
 
-/-!
+/-
 **Oscillatory Behavior:**
 For large |t|, the terms 1/aₖ^(1+it) = (1/aₖ) · e^(-it·log(aₖ)) oscillate rapidly.
 This oscillation is what allows zeros to exist for appropriate sequences.


### PR DESCRIPTION
## Summary
- Replace `/-!` doc header with `/-` for Aristotle parser compatibility
- 1 header section fixed

## Test plan
- [x] `pnpm build` passes
- [x] No `/-!` headers remain in Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)