### PR TITLE
enhance(erdos-425): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos425Problem.lean
+++ b/proofs/Proofs/Erdos425Problem.lean
@@ -36,7 +36,7 @@ import Mathlib.Data.Real.Basic
 
 namespace Erdos425
 
-/-!
+/-
 ## Part I: Basic Definitions
 -/
 
@@ -74,7 +74,7 @@ def IsMultiplicativeSidon' (A : Finset ℕ) : Prop :=
   ((A.product A).filter (fun p => p.1 < p.2)).card =
     ((A.product A).filter (fun p => p.1 < p.2) |>.image (fun p => p.1 * p.2)).card
 
-/-!
+/-
 ## Part II: The Function F(n)
 -/
 
@@ -107,7 +107,7 @@ The primes ≤ n form a multiplicative Sidon set of size π(n).
 axiom F_ge_prime_count (n : ℕ) (hn : n ≥ 2) :
     F n ≥ (Finset.range (n + 1)).filter Nat.Prime |>.card
 
-/-!
+/-
 ## Part III: Erdős's Bounds
 -/
 
@@ -133,7 +133,7 @@ def MainQuestion : Prop :=
     let extra := (n : ℝ)^(3/4 : ℝ) * (Real.log n)^(-(3/2) : ℝ)
     |(F n : ℝ) - (π_n + c * extra)| ≤ ε * extra
 
-/-!
+/-
 ## Part IV: The r-Product Generalization
 -/
 
@@ -160,7 +160,7 @@ def RProductConjecture : Prop :=
         (A.card : ℝ) ≤ ((Finset.range (n + 1)).filter Nat.Prime).card +
           C * (n : ℝ)^((r + 1 : ℝ) / (2 * r))
 
-/-!
+/-
 ## Part V: The Real Number Version
 -/
 
@@ -197,7 +197,7 @@ axiom alexander_construction :
       ∃ A : Finset ℝ, (∀ a ∈ A, 1 ≤ a ∧ a ≤ x) ∧ RealMultSidon A ∧
         (A.card : ℝ) ≥ c * x
 
-/-!
+/-
 ## Part VI: Connection to Additive Sidon Sets
 -/
 
@@ -231,7 +231,7 @@ axiom sidon_bound :
     ∀ n : ℕ, ∀ S : Finset ℕ, (∀ s ∈ S, s ≤ n) → IsSidonSet S →
       (S.card : ℝ) ≤ Real.sqrt n + Real.sqrt (Real.sqrt n)
 
-/-!
+/-
 ## Part VII: Examples
 -/
 
@@ -246,7 +246,7 @@ example : ¬IsMultiplicativeSidon {1, 2, 3, 6} := by
     (by norm_num) (by norm_num) this
   simp at this
 
-/-!
+/-
 ## Part VIII: Summary
 -/
 


### PR DESCRIPTION
## Summary
- Convert 8 `/-!` section headers to `/-` in Erdős #425 (Multiplicative Sidon Sets)
- Prevents Aristotle parser errors

## Checklist
- [x] pnpm build succeeds
- [x] No remaining `/-!` headers

🤖 Generated by enhancer-1