### PR TITLE
enhance(erdos-230): remove True placeholder axioms

### DIFF
--- a/proofs/Proofs/Erdos230Problem.lean
+++ b/proofs/Proofs/Erdos230Problem.lean
@@ -291,6 +291,5 @@ Erdős and Newman conjectured (1+c)√n in 1957/1961.
 The problem appeared as Problem 4.31 in Halberstam (1974).
 Kahane's 1980 disproof via ultraflat polynomials was surprising.
 -/
-theorem erdos_230_status : True := trivial
 
 end Erdos230

--- a/proofs/Proofs/Erdos230Problem.lean
+++ b/proofs/Proofs/Erdos230Problem.lean
@@ -198,15 +198,6 @@ def bombieriBorgainExponent : ℚ := 7 / 18
 -/
 
 /--
-**Random unimodular polynomial:**
-If coefficients are chosen uniformly on the unit circle,
-what is the expected behavior of |P(z)|?
--/
-axiom random_polynomial_behavior :
-  -- Heuristically, random P has |P(z)| ≈ √n with fluctuations O(√(log n))
-  True
-
-/--
 **Rudin-Shapiro polynomials:**
 A deterministic family of unimodular polynomials with |P(z)| ≤ 2√n.
 Not ultraflat (lower bound can be small).
@@ -216,45 +207,7 @@ axiom rudin_shapiro :
     supNormOnCircle P ≤ 2 * Real.sqrt (2^n)
 
 /-
-## Part VIII: Why "Ultraflat"?
--/
-
-/--
-**Flatness interpretation:**
-A polynomial P is "flat" if |P(z)| is nearly constant on |z| = 1.
-"Ultra" flat means the ratio max/min approaches 1 as n → ∞.
-
-For perfect flatness, we'd need |P(z)| = √n for all |z| = 1,
-which is impossible (P would be constant, contradicting degree n).
--/
-axiom flatness_explanation : True
-
-/--
-**Equidistribution connection:**
-Ultraflat polynomials relate to equidistribution of polynomial values
-on the unit circle - a topic in harmonic analysis.
--/
-axiom equidistribution_connection : True
-
-/-
-## Part IX: Related Results
--/
-
-/--
-**Problem #228 connection:**
-Related to Problem #228 about coefficients and polynomial behavior.
--/
-axiom problem_228_connection : True
-
-/--
-**Littlewood conjecture:**
-A related conjecture asked about |P(z)| for polynomials with
-coefficients ±1. This is also studied extensively.
--/
-axiom littlewood_polynomials : True
-
-/-
-## Part X: Summary
+## Part VIII: Summary
 -/
 
 /--

--- a/src/data/proofs/erdos-230/annotations.json
+++ b/src/data/proofs/erdos-230/annotations.json
@@ -123,8 +123,8 @@
     "id": "ann-230-11",
     "proofId": "erdos-230",
     "range": {
-      "startLine": 209,
-      "endLine": 216
+      "startLine": 200,
+      "endLine": 207
     },
     "type": "axiom",
     "title": "Rudin-Shapiro Polynomials",
@@ -135,8 +135,8 @@
     "id": "ann-230-12",
     "proofId": "erdos-230",
     "range": {
-      "startLine": 260,
-      "endLine": 286
+      "startLine": 213,
+      "endLine": 239
     },
     "type": "theorem",
     "title": "Summary: DISPROVED",

--- a/src/data/proofs/erdos-230/meta.json
+++ b/src/data/proofs/erdos-230/meta.json
@@ -74,8 +74,8 @@
       "id": "summary",
       "title": "Summary",
       "summary": "Main results: conjecture disproved",
-      "startLine": 256,
-      "endLine": 294
+      "startLine": 209,
+      "endLine": 249
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Remove 5 `True` placeholder axioms (`random_polynomial_behavior`, `flatness_explanation`, `equidistribution_connection`, `problem_228_connection`, `littlewood_polynomials`)
- Update annotations.json and meta.json line numbers

## Test plan
- [x] `pnpm build` passes
- [x] No `True` placeholder axioms remain