### PR TITLE
enhance(erdos-1014): fix /-! headers, remove True placeholder

### DIFF
--- a/proofs/Proofs/Erdos1014Problem.lean
+++ b/proofs/Proofs/Erdos1014Problem.lean
@@ -1,4 +1,4 @@
-/-!
+/-
 # Erdős Problem #1014: Ramsey Number Ratio Convergence
 
 For fixed k ≥ 3, prove that R(k, l+1) / R(k, l) → 1 as l → ∞,
@@ -22,7 +22,7 @@ import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Tactic
 
-/-! ## Core Definitions -/
+/- ## Core Definitions -/
 
 /-- The Ramsey number R(k, l): minimum n such that every 2-coloring of
     edges of K_n contains a red K_k or a blue K_l. -/
@@ -35,7 +35,7 @@ axiom ramsey_pos (k l : ℕ) (hk : k ≥ 1) (hl : l ≥ 1) :
 /-- Symmetry: R(k, l) = R(l, k). -/
 axiom ramsey_symm (k l : ℕ) : ramseyNumber k l = ramseyNumber l k
 
-/-! ## Classical Bounds -/
+/- ## Classical Bounds -/
 
 /-- Erdős–Szekeres upper bound: R(k, l) ≤ C(k+l-2, k-1). -/
 axiom ramsey_upper_erdos_szekeres (k l : ℕ) (hk : k ≥ 2) (hl : l ≥ 2) :
@@ -49,7 +49,7 @@ axiom ramsey_monotone_right (k l : ℕ) :
 axiom ramsey_recurrence (k l : ℕ) (hk : k ≥ 2) (hl : l ≥ 1) :
   ramseyNumber k (l + 1) ≤ ramseyNumber k l + ramseyNumber (k - 1) (l + 1)
 
-/-! ## R(3, l) Bounds -/
+/- ## R(3, l) Bounds -/
 
 /-- Shearer (1983) / Kim (1995): R(3, l) ≥ c · l² / log l. -/
 axiom R3_lower (c : ℝ) (hc : c > 0) :
@@ -61,7 +61,7 @@ axiom R3_upper :
   ∃ C : ℝ, C > 0 ∧ ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
     (ramseyNumber 3 l : ℝ) ≤ C * (l : ℝ) ^ 2 / Real.log l
 
-/-! ## Main Conjecture -/
+/- ## Main Conjecture -/
 
 /-- **Erdős Problem #1014** (OPEN): For fixed k ≥ 3,
     R(k, l+1) / R(k, l) → 1 as l → ∞. -/
@@ -69,7 +69,7 @@ axiom erdos_1014_conjecture (k : ℕ) (hk : k ≥ 3) :
   ∀ ε : ℝ, ε > 0 → ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
     |(ramseyNumber k (l + 1) : ℝ) / (ramseyNumber k l : ℝ) - 1| < ε
 
-/-! ## Consequences and Implications -/
+/- ## Consequences and Implications -/
 
 /-- If R(k, l) ~ c_k · l^(k-1) / (log l)^(k-2) (conjectured asymptotics),
     then R(k, l+1)/R(k, l) = ((l+1)/l)^(k-1) · (log l / log(l+1))^(k-2) → 1. -/
@@ -87,7 +87,7 @@ axiom ratio_equiv_difference (k : ℕ) (hk : k ≥ 3) :
     ((ramseyNumber k (l + 1) : ℝ) - (ramseyNumber k l : ℝ)) /
     (ramseyNumber k l : ℝ) < ε)
 
-/-! ## Special Cases -/
+/- ## Special Cases -/
 
 /-- For k = 2: R(2, l) = l, so R(2, l+1)/R(2, l) = (l+1)/l → 1.
     This is trivial (k = 2 case). -/
@@ -98,6 +98,7 @@ axiom R33 : ramseyNumber 3 3 = 6
 axiom R34 : ramseyNumber 3 4 = 9
 axiom R35 : ramseyNumber 3 5 = 14
 
-/-- For the diagonal case k = l, see Erdős Problem #1030. -/
-axiom diagonal_ramsey_related :
-  True  -- R(k,k) asymptotics is a separate major open problem
+/-- For the diagonal case k = l, Erdős–Szekeres gives R(k,k) ≤ C(2k-2,k-1).
+    See Problem #1030 for the full diagonal Ramsey asymptotics question. -/
+axiom diagonal_ramsey_upper (k : ℕ) (hk : k ≥ 2) :
+  ramseyNumber k k ≤ Nat.choose (2 * k - 2) (k - 1)


### PR DESCRIPTION
## Summary
- Fixed `/-!` docstring headers to `/-` for Aristotle compatibility
- Replaced `True` placeholder for diagonal Ramsey with Erdős–Szekeres upper bound

## Checklist
- [x] pnpm build succeeds
- [x] No quality issues remain

🤖 Generated by enhancer-3