### PR TITLE
enhance(erdos-1016): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos1016Problem.lean
+++ b/proofs/Proofs/Erdos1016Problem.lean
@@ -1,4 +1,4 @@
-/-!
+/-
 # Erdős Problem #1016: Pancyclic Excess Edges
 
 Let h(n) be the minimum number of edges beyond n needed for an n-vertex
@@ -26,7 +26,7 @@ import Mathlib.Data.Nat.Log
 import Mathlib.Data.Real.Basic
 import Mathlib.Tactic
 
-/-! ## Core Definitions -/
+/- ## Core Definitions -/
 
 /-- A simple graph G on n vertices is pancyclic if it contains cycles
     of every length k for 3 ≤ k ≤ n. -/
@@ -47,7 +47,7 @@ noncomputable def iteratedLog : ℕ → ℕ
   | 1 => 0
   | (n + 2) => 1 + iteratedLog (Nat.log 2 (n + 2))
 
-/-! ## Main Conjecture -/
+/- ## Main Conjecture -/
 
 /-- **Erdős's Conjecture**: h(n) ≥ log₂ n + log* n − O(1).
     The pancyclic excess requires not just logarithmically many extra edges,
@@ -62,7 +62,7 @@ axiom excess_beyond_log :
   ∀ M : ℕ, ∃ N : ℕ, ∀ n : ℕ, n ≥ N →
     pancyclicExcess n ≥ Nat.log 2 n + M
 
-/-! ## Known Bounds -/
+/- ## Known Bounds -/
 
 /-- **Bondy's lower bound** (Griffin 2013): h(n) ≥ ⌊log₂(n−1)⌋ − 1.
     Any pancyclic graph on n vertices has at least n + ⌊log₂(n−1)⌋ − 1 edges. -/
@@ -77,7 +77,7 @@ axiom gkw_upper_bound :
   ∃ C : ℕ, ∀ n : ℕ, n ≥ 3 →
     pancyclicExcess n ≤ Nat.log 2 n + iteratedLog n + C
 
-/-! ## Structural Properties -/
+/- ## Structural Properties -/
 
 /-- A Hamiltonian graph (cycle of length n) has exactly n edges.
     Pancyclicity requires additional edges for shorter cycles. -/


### PR DESCRIPTION
## Summary
- Fixed `/-!` docstring headers to `/-` for Aristotle compatibility

## Checklist
- [x] pnpm build succeeds
- [x] No quality issues remain

🤖 Generated by enhancer-3