### PR TITLE
enhance(erdos-1067): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos1067Problem.lean
+++ b/proofs/Proofs/Erdos1067Problem.lean
@@ -33,9 +33,7 @@ open Cardinal SimpleGraph
 
 namespace Erdos1067
 
-/-!
-## Part I: Basic Graph Definitions
--/
+/- ## Part I: Basic Graph Definitions -/
 
 /--
 **Chromatic Number:**
@@ -52,9 +50,7 @@ A graph has chromatic number ℵ₁ (aleph-one).
 def hasAleph1ChromaticNumber (G : SimpleGraph V) : Prop :=
   chromaticNumber G = Cardinal.aleph 1
 
-/-!
-## Part II: Infinite Connectivity
--/
+/- ## Part II: Infinite Connectivity -/
 
 /--
 **Path in Graph:**
@@ -97,9 +93,7 @@ A graph where any two vertices are connected by infinitely many pairwise disjoin
 def InfinitelyConnected (G : SimpleGraph V) : Prop :=
   ∀ u v : V, u ≠ v → InfinitelyManyDisjointPaths G u v
 
-/-!
-## Part III: Edge Connectivity Variant
--/
+/- ## Part III: Edge Connectivity Variant -/
 
 /--
 **Infinitely Edge-Connected:**
@@ -109,9 +103,7 @@ def InfinitelyEdgeConnected (G : SimpleGraph V) : Prop :=
   ∀ E : Set (Sym2 V), E.Finite → ∃ u v : V, u ≠ v ∧
     (G.deleteEdges E).Connected
 
-/-!
-## Part IV: Subgraph Relations
--/
+/- ## Part IV: Subgraph Relations -/
 
 /--
 **Subgraph:**
@@ -129,9 +121,7 @@ def ErdosHajnalQuestion (G : SimpleGraph V) : Prop :=
   ∃ H : SimpleGraph V, IsSubgraph H G ∧
     InfinitelyConnected H ∧ hasAleph1ChromaticNumber H
 
-/-!
-## Part V: The Main Results - Counterexamples
--/
+/- ## Part V: The Main Results - Counterexamples -/
 
 /--
 **Komjáth's Consistency Result (2013):**
@@ -174,9 +164,7 @@ axiom thomassen_edge_counterexample_2017 :
       ∀ H : SimpleGraph V, IsSubgraph H G →
         InfinitelyEdgeConnected H → ¬hasAleph1ChromaticNumber H
 
-/-!
-## Part VI: The Variant with ℵ₁ Vertices
--/
+/- ## Part VI: The Variant with ℵ₁ Vertices -/
 
 /--
 **ℵ₁ Vertices:**
@@ -196,9 +184,7 @@ axiom komjath_aleph1_vertex_counterexample_consistent :
       ¬∃ H : SimpleGraph V, IsSubgraph H G ∧
         InfinitelyConnected H ∧ hasAleph1ChromaticNumber H
 
-/-!
-## Part VII: Key Observations
--/
+/- ## Part VII: Key Observations -/
 
 /-- **Soukup's construction principle:**
 One can build a graph from "ladder" structures of trees where
@@ -210,8 +196,7 @@ axiom soukup_construction_principle :
       ∀ H : SimpleGraph V, IsSubgraph H G →
         InfinitelyConnected H → ¬hasAleph1ChromaticNumber H
 
-/-!
-## Part IX: Summary
+/- ## Part IX: Summary
 
 **Erdős Problem #1067: DISPROVED**
 

--- a/src/data/proofs/erdos-1067/meta.json
+++ b/src/data/proofs/erdos-1067/meta.json
@@ -77,56 +77,56 @@
       "title": "Basic Graph Definitions",
       "summary": "chromaticNumber, hasAleph1ChromaticNumber",
       "startLine": 36,
-      "endLine": 53
+      "endLine": 51
     },
     {
       "id": "infinite-connectivity",
       "title": "Infinite Connectivity",
       "summary": "PathInGraph, DisjointPaths, InfinitelyConnected definitions",
-      "startLine": 55,
-      "endLine": 98
+      "startLine": 53,
+      "endLine": 94
     },
     {
       "id": "edge-connectivity",
       "title": "Edge Connectivity Variant",
       "summary": "InfinitelyEdgeConnected definition",
-      "startLine": 100,
-      "endLine": 110
+      "startLine": 96,
+      "endLine": 104
     },
     {
       "id": "subgraph",
       "title": "Subgraph Relations",
       "summary": "IsSubgraph, ErdosHajnalQuestion",
-      "startLine": 112,
-      "endLine": 130
+      "startLine": 106,
+      "endLine": 122
     },
     {
       "id": "counterexamples",
       "title": "Main Results - Counterexamples",
       "summary": "Komjáth, Soukup, Bowler-Pitz, Thomassen axioms",
-      "startLine": 132,
-      "endLine": 175
+      "startLine": 124,
+      "endLine": 165
     },
     {
       "id": "aleph1-vertices",
       "title": "Variant with ℵ₁ Vertices",
       "summary": "hasAleph1Vertices, komjath_aleph1_vertex_counterexample_consistent",
-      "startLine": 177,
-      "endLine": 197
+      "startLine": 167,
+      "endLine": 185
     },
     {
       "id": "observations",
       "title": "Key Observations",
       "summary": "soukup_construction_principle axiom",
-      "startLine": 199,
-      "endLine": 211
+      "startLine": 187,
+      "endLine": 197
     },
     {
       "id": "summary",
       "title": "Summary and Main Theorems",
       "summary": "erdos_1067, erdos_1067_elementary, erdos_1067_answer theorems",
-      "startLine": 213,
-      "endLine": 268
+      "startLine": 199,
+      "endLine": 252
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Fixed all `/-!` docstring headers to `/-` for Aristotle parser compatibility
- Updated section line numbers in meta.json to match modified Lean file

## Checklist
- [x] Lean file has no `/-!` headers
- [x] `pnpm build` succeeds
- [x] Section line numbers match Lean file

Generated by enhancer-2