### PR TITLE
enhance(erdos-1032): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos1032Problem.lean
+++ b/proofs/Proofs/Erdos1032Problem.lean
@@ -1,4 +1,4 @@
-/-!
+/-
 # Erdős Problem #1032 — 4-Chromatic Critical Graphs with High Minimum Degree
 
 Do there exist 4-chromatic critical graphs on n vertices with minimum
@@ -24,7 +24,7 @@ import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Rat.Basic
 import Mathlib.Tactic
 
-/-! ## Graph properties (axiomatised) -/
+/- ## Graph properties (axiomatised) -/
 
 /-- The number of vertices of a graph. -/
 axiom vertexCount : Type → ℕ
@@ -45,7 +45,7 @@ def IsKChromaticCritical (G : Type) (k : ℕ) : Prop :=
     ∀ e : ℕ, e < edgeCount G →
       chromaticNumber G - 1 ≤ k - 1
 
-/-! ## Known constructions -/
+/- ## Known constructions -/
 
 /-- Dirac: there exist 6-chromatic critical graphs with δ > n/2. -/
 axiom dirac_6_critical :
@@ -60,7 +60,7 @@ axiom simonovits_toft_4_critical :
       vertexCount G = N ∧ IsKChromaticCritical G 4 ∧
       c * (N : ℚ) ^ ((1 : ℚ) / 3) ≤ (minDegree G : ℚ)
 
-/-! ## Toft's conjecture -/
+/- ## Toft's conjecture -/
 
 /-- Toft: every 4-chromatic critical graph on n vertices has
     ≥ (5/3 + o(1))n edges. -/
@@ -69,7 +69,7 @@ def ToftConjecture : Prop :=
       n₀ ≤ vertexCount G → IsKChromaticCritical G 4 →
         (5 / 3 - ε) * (vertexCount G : ℚ) ≤ (edgeCount G : ℚ)
 
-/-! ## Main conjecture -/
+/- ## Main conjecture -/
 
 /-- Erdős Problem 1032: there exist 4-chromatic critical graphs on
     n vertices with minimum degree linear in n.


### PR DESCRIPTION
## Summary
- Fixed `/-!` docstring headers to `/-` for Aristotle compatibility

## Checklist
- [x] pnpm build succeeds
- [x] No quality issues remain

🤖 Generated by enhancer-3