### PR TITLE
enhance(erdos-925): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos925Problem.lean
+++ b/proofs/Proofs/Erdos925Problem.lean
@@ -1,5 +1,5 @@
-/-!
-# Erdős Problem #925: Independent Sets in Non-Ramsey Graphs
+/-
+Erdős Problem #925: Independent Sets in Non-Ramsey Graphs
 
 Source: https://erdosproblems.com/925
 Status: DISPROVED (Alon-Rödl 2005)
@@ -41,10 +41,7 @@ open SimpleGraph
 
 namespace Erdos925
 
-/-! ## Part I: Basic Definitions
-
-Graphs, colorings, and Ramsey properties.
--/
+/- ## Part I: Basic Definitions -/
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
@@ -66,10 +63,7 @@ def hasIndependentSetOfSize (G : SimpleGraph V) (k : ℕ) : Prop :=
     the graph adjacency and finiteness of the search space. -/
 axiom independenceNumber (G : SimpleGraph V) : ℕ
 
-/-! ## Part II: Ramsey Numbers
-
-The multicolor Ramsey number R(3,3,m).
--/
+/- ## Part II: Ramsey Numbers -/
 
 /-- R(3,3,m) is the minimum n such that any graph on n vertices either:
     - has a monochromatic triangle in every 2-coloring, OR
@@ -87,10 +81,7 @@ axiom trivial_independent_set_bound :
   isNotRamseyForTriangle G →
   hasIndependentSetOfSize G (n ^ (1/3 : ℝ)).toNat
 
-/-! ## Part III: The Conjecture
-
-Erdős's question: can we do better than n^(1/3)?
--/
+/- ## Part III: The Conjecture -/
 
 /-- Erdős's conjecture (later disproved):
     There exists δ > 0 such that non-Ramsey graphs on n vertices
@@ -110,10 +101,7 @@ def erdos_925_ramsey_form : Prop :=
   ∃ (c : ℝ) (C : ℝ), c > 0 ∧ C > 0 ∧
   ∀ m : ℕ, m > 0 → R_3_3 m ≤ ⌈C * (m : ℝ) ^ (3 - c)⌉.toNat
 
-/-! ## Part IV: Alon-Rödl Disproof (2005)
-
-The conjecture is FALSE.
--/
+/- ## Part IV: Alon-Rödl Disproof (2005) -/
 
 /-- Alon-Rödl (2005) lower bound:
     R(3,3,m) ≥ m³ / (log m)^(4+o(1)) -/
@@ -142,10 +130,7 @@ axiom erdos_925_disproved : ¬erdos_925_conjecture
     The Ramsey formulation of the conjecture is also false. -/
 axiom erdos_925_ramsey_disproof : ¬erdos_925_ramsey_form
 
-/-! ## Part V: Why n^(1/3) is Optimal
-
-The Alon-Rödl result shows n^(1/3) cannot be improved.
--/
+/- ## Part V: Why n^(1/3) is Optimal -/
 
 /-- The trivial bound n^(1/3) is essentially tight.
     Non-Ramsey graphs need not have independent sets larger than ~n^(1/3).
@@ -158,10 +143,7 @@ axiom n_one_third_is_optimal :
   isNotRamseyForTriangle G ∧
   independenceNumber G ≤ ⌈(n : ℝ) ^ (1/3 + ε)⌉.toNat
 
-/-! ## Part VI: The Easy Lower Bound
-
-Every non-Ramsey graph has α ≥ cn^(1/3).
--/
+/- ## Part VI: The Easy Lower Bound -/
 
 /-- The "easy" direction: every non-Ramsey graph has α ≥ cn^(1/3).
     This follows from basic counting arguments: in a 2-coloring without
@@ -176,7 +158,7 @@ axiom easy_lower_bound :
   isNotRamseyForTriangle G →
   (independenceNumber G : ℝ) ≥ c * (n : ℝ) ^ (1/3 : ℝ)
 
-/-! ## Part VII: Summary
+/- ## Part VII: Summary
 
 **Erdős Problem #925 - DISPROVED (Alon-Rödl 2005)**
 

--- a/src/data/proofs/erdos-925/meta.json
+++ b/src/data/proofs/erdos-925/meta.json
@@ -72,49 +72,49 @@
       "title": "Basic Definitions",
       "summary": "Non-Ramsey graphs, independent sets, independence number",
       "startLine": 44,
-      "endLine": 67
+      "endLine": 64
     },
     {
       "id": "ramsey",
       "title": "Ramsey Numbers",
       "summary": "R(3,3,m) definition and trivial bound",
-      "startLine": 69,
-      "endLine": 88
+      "startLine": 66,
+      "endLine": 82
     },
     {
       "id": "conjecture",
       "title": "The Conjecture",
       "summary": "Erdős's original question and Ramsey formulation",
-      "startLine": 90,
-      "endLine": 111
+      "startLine": 84,
+      "endLine": 102
     },
     {
       "id": "disproof",
       "title": "Alon-Rödl Disproof (2005)",
       "summary": "Sharp bounds on R(3,3,m) and disproof axioms",
-      "startLine": 113,
-      "endLine": 143
+      "startLine": 104,
+      "endLine": 131
     },
     {
       "id": "optimality",
       "title": "Optimality of n^(1/3)",
       "summary": "The trivial bound is essentially tight",
-      "startLine": 145,
-      "endLine": 159
+      "startLine": 133,
+      "endLine": 144
     },
     {
       "id": "easy-bound",
       "title": "The Easy Lower Bound",
       "summary": "Every non-Ramsey graph has α ≥ cn^(1/3)",
-      "startLine": 161,
-      "endLine": 177
+      "startLine": 146,
+      "endLine": 159
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Main result theorems: erdos_925 and erdos_925_summary",
-      "startLine": 179,
-      "endLine": 217
+      "startLine": 161,
+      "endLine": 199
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Fixed all `/-!` docstring headers to `/-` for Aristotle parser compatibility
- Updated section line numbers in meta.json to match modified Lean file

## Checklist
- [x] Lean file has no `/-!` headers
- [x] `pnpm build` succeeds
- [x] Section line numbers match Lean file

Generated by enhancer-2