### PR TITLE
Research: erdos-451 - CRT analysis and structural infrastructure

### DIFF
--- a/proofs/Proofs/Erdos451Problem.lean
+++ b/proofs/Proofs/Erdos451Problem.lean
@@ -1,14 +1,19 @@
-/-!
-# Erdős Problem #451 — Primes in Interval (k, 2k) Avoiding Products
+/- Erdős Problem #451 — Primes in Interval (k, 2k) Avoiding Products
 
 Estimate n_k, the smallest integer n > 2k such that the product
 ∏_{1 ≤ i ≤ k} (n - i) has no prime factor in the interval (k, 2k).
 
-## Known bounds
+Known bounds:
+- Lower: Erdős–Graham proved n_k > k^{1+c} for some c > 0.
+- Upper: Adenwalla observed n_k ≤ ∏_{k < p < 2k} p = e^{O(k)}.
+- Conjecture: n_k > k^d for every constant d, but n_k < e^{o(k)}.
 
-- **Lower**: Erdős–Graham proved n_k > k^{1+c} for some c > 0.
-- **Upper**: Adenwalla observed n_k ≤ ∏_{k < p < 2k} p = e^{O(k)}.
-- **Conjecture**: n_k > k^d for every constant d, but n_k < e^{o(k)}.
+Key insight: for prime p in (k, 2k), we have p | ∏_{i=1}^k (n-i) iff
+n ≡ j (mod p) for some j ∈ {1,...,k}. Since k < p, this is a CRT problem.
+The safe residues mod p are {0, k+1, ..., p-1}, giving p-k choices.
+
+Computed values: n_1=3, n_2=6, n_3=9, n_4=20, n_5=13, n_6=21, n_7=21,
+n_8=22, n_9=65, n_10=220, n_12=338, n_20=550.
 
 Reference: https://erdosproblems.com/451
 -/
@@ -19,24 +24,34 @@ import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Rat.Basic
 import Mathlib.Tactic
 
-/-! ## The product ∏(n - i) and prime factors -/
-
+open Finset in
 /-- The product (n-1)(n-2)⋯(n-k) for n > k. -/
 def descendingProduct (n k : ℕ) : ℕ :=
-    (Finset.Icc 1 k).prod (fun i => n - i)
+    (Icc 1 k).prod (fun i => n - i)
 
 /-- A prime p is in the interval (k, 2k). -/
 def IsInBertrandRange (p k : ℕ) : Prop :=
     k < p ∧ p < 2 * k ∧ p.Prime
 
+instance : DecidablePred (fun p => IsInBertrandRange p k) :=
+  fun p => And.decidable
+
 /-- The product has no prime factor in (k, 2k). -/
 def AvoidsBertrandPrimes (n k : ℕ) : Prop :=
     ∀ p : ℕ, IsInBertrandRange p k → ¬(p ∣ descendingProduct n k)
 
-/-! ## The function n_k -/
+/- ## The primes in (k, 2k) -/
 
-/-- n_k is the smallest integer > 2k such that ∏(n-i) avoids primes in (k,2k).
-    Axiomatised with its defining properties. -/
+/-- The primes in the interval (k, 2k). -/
+def bertrandPrimes (k : ℕ) : Finset ℕ :=
+    (Finset.Icc (k + 1) (2 * k - 1)).filter Nat.Prime
+
+/-- The safe residues for a single prime p > k are {0, k+1, ..., p-1}. -/
+def safeResidues (k p : ℕ) : Finset ℕ :=
+    {0} ∪ (Finset.Icc (k + 1) (p - 1))
+
+/- ## The function n_k (axiomatic) -/
+
 axiom nk : ℕ → ℕ
 
 /-- n_k > 2k. -/
@@ -49,7 +64,34 @@ axiom nk_avoids (k : ℕ) (hk : 1 ≤ k) : AvoidsBertrandPrimes (nk k) k
 axiom nk_minimal (k : ℕ) (hk : 1 ≤ k) (n : ℕ) (hn : 2 * k < n)
     (ha : AvoidsBertrandPrimes n k) : nk k ≤ n
 
-/-! ## Known bounds -/
+/- ## CRT structural lemmas
+
+For prime p in (k, 2k), the product (n-1)(n-2)⋯(n-k) is divisible by p
+iff at least one of n-1, n-2, ..., n-k is divisible by p. Since k < p,
+at most one of these k consecutive integers can be divisible by p.
+
+So p | ∏(n-i) iff n ≡ j (mod p) for some j ∈ {1, ..., k}.
+To avoid p, we need n mod p ∈ {0, k+1, k+2, ..., p-1}. -/
+
+/-- For prime p > k, at most one of n-1, ..., n-k is divisible by p.
+    If p | (n-i) and p | (n-j) then p | (i-j), but |i-j| < k < p. -/
+theorem at_most_one_div (n k p : ℕ) (hp : Nat.Prime p) (hpk : k < p)
+    (i j : ℕ) (hi : i ∈ Finset.Icc 1 k) (hj : j ∈ Finset.Icc 1 k)
+    (hdi : p ∣ (n - i)) (hdj : p ∣ (n - j)) (hn : k < n) :
+    i = j := by sorry
+
+/-- p divides the descending product iff p divides some factor. -/
+theorem prime_dvd_descendingProduct (n k p : ℕ) (hp : Nat.Prime p)
+    (hn : k < n) :
+    p ∣ descendingProduct n k ↔
+    ∃ i ∈ Finset.Icc 1 k, p ∣ (n - i) := by sorry
+
+/-- The number of safe residues is p - k when k < p < 2k. -/
+theorem card_safeResidues (k p : ℕ) (hp : Nat.Prime p) (hpk : k < p)
+    (hpk2 : p < 2 * k) :
+    (safeResidues k p).card = p - k := by sorry
+
+/- ## Known bounds -/
 
 /-- Erdős–Graham lower bound: n_k > k^{1+c} for some constant c > 0. -/
 axiom erdos_graham_lower :
@@ -57,22 +99,32 @@ axiom erdos_graham_lower :
       (k : ℚ) ^ (1 + c) < (nk k : ℚ)
 
 /-- Adenwalla upper bound: n_k ≤ ∏_{k < p < 2k} p = e^{O(k)}.
-    In particular, n_k ≤ some exponential in k. -/
+    By CRT, taking n ≡ 0 (mod p) for all primes p in (k,2k). -/
 axiom adenwalla_upper :
     ∃ C : ℚ, 0 < C ∧ ∃ k₀ : ℕ, ∀ k : ℕ, k₀ ≤ k →
       (nk k : ℚ) ≤ (2 : ℚ) ^ (C * (k : ℚ))
 
-/-! ## Main conjectures -/
+/-- The trivial lower bound: n_k > 2k (by definition). -/
+theorem nk_trivial_lower (k : ℕ) (hk : 1 ≤ k) : (2 * k : ℚ) < (nk k : ℚ) := by
+  have := nk_gt_2k k hk
+  exact_mod_cast this
 
-/-- Conjecture 1: n_k > k^d for every constant d.
-    Formally: for every d > 0, there exists k₀ such that
-    n_k > k^d for all k ≥ k₀. -/
+/-- Adenwalla's bound via CRT: n_k ≤ product of primes in (k, 2k). -/
+theorem adenwalla_crt_idea (k : ℕ) (hk : 1 ≤ k) :
+    let M := (bertrandPrimes k).prod id
+    2 * k < M →
+    AvoidsBertrandPrimes M k →
+    nk k ≤ M :=
+  fun hM hAvoids => nk_minimal k hk M hM hAvoids
+
+/- ## Main conjectures (OPEN) -/
+
+/-- Conjecture 1: n_k > k^d for every constant d. -/
 def ErdosProblem451_superpolynomial : Prop :=
     ∀ (d : ℚ) (hd : 0 < d), ∃ k₀ : ℕ, ∀ k : ℕ, k₀ ≤ k →
       (k : ℚ) ^ d < (nk k : ℚ)
 
-/-- Conjecture 2: n_k < e^{o(k)}, i.e. n_k is sub-exponential.
-    Formally: for every ε > 0, n_k < 2^{ε·k} for large k. -/
+/-- Conjecture 2: n_k < e^{o(k)}, i.e. n_k is sub-exponential. -/
 def ErdosProblem451_subexponential : Prop :=
     ∀ (ε : ℚ) (hε : 0 < ε), ∃ k₀ : ℕ, ∀ k : ℕ, k₀ ≤ k →
       (nk k : ℚ) < (2 : ℚ) ^ (ε * (k : ℚ))

--- a/src/data/research/problems/erdos-451.json
+++ b/src/data/research/problems/erdos-451.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "EXPLORED",
     "since": "2026-01-13T04:11:10.511Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "CRT analysis and structural infrastructure",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Submit structural lemmas to Aristotle for proof search",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,31 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SURVEY: Enhanced formalization with CRT analysis. Computed n_k for k=1..20. Fixed docstring headers for Aristotle. Added structural lemmas. OPEN problem - both conjectures remain unresolved.",
+    "builtItems": [
+      "bertrandPrimes definition: computable Finset of primes in (k,2k)",
+      "safeResidues definition: {0, k+1, ..., p-1} for each prime p",
+      "Decidable IsInBertrandRange instance for computability",
+      "at_most_one_div lemma (sorry): uniqueness of divisible factor",
+      "prime_dvd_descendingProduct lemma (sorry): factor characterization",
+      "card_safeResidues lemma (sorry): p-k safe residues",
+      "nk_trivial_lower theorem: n_k > 2k cast to rationals",
+      "adenwalla_crt_idea theorem: minimality applied to prime product",
+      "Fixed docstring headers throughout for Aristotle compatibility"
+    ],
+    "insights": [
+      "CRT reduction: avoiding p in (k,2k) means n mod p not in {1,...,k}, giving p-k safe residues",
+      "Computed values: n_1=3, n_2=6, n_3=9, n_4=20, n_5=13, n_6=21, n_7=21, n_8=22, n_9=65, n_10=220",
+      "n_k drops when k increases past a prime (e.g., n_10=220 to n_11=51) because smallest forbidden prime leaves range",
+      "The hardest cases have the most forbidden primes in (k,2k) - more primes means tighter CRT constraints",
+      "Adenwalla upper bound via CRT: take n = product of primes in (k,2k), then n = 0 (mod p) for each"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove the 3 sorry lemmas (CRT structural results) - good Aristotle candidates",
+      "Submit to Aristotle for overnight proof search on structural lemmas",
+      "The main conjectures remain OPEN - not suitable for automated proving"
+    ],
     "markdown": "# Erdős #451 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nEstimate $n_k$, the smallest integer $>2k$ such that $\\prod_{1\\leq i\\leq k}(n_k-i)$ has no prime factor in $(k,2k)$.\n\n\n\nErd\\H{o}s and Graham write 'we can prove $n_k>k^{1+c}$ but no doubt much more is true'.\n\nIn \\cite{Er79d} Erd\\H{o}s writes that probably $n_k<e^{o(k)}$ but $n_k>k^d$ for all constant $d$.\n\nAdenwalla observes that an easy upper bound is $n_k\\leq \\prod_{k<p<2k}p=e^{O(k)}$.\n\n\n\n\nReferences\n\n\n[Er79d] Erd\\H{o}s, P., Some unconventional problems in number theory. Acta Math. Acad. Sci. Hungar. (1979), 71-80.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #450\n- Problem #452\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er79d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "approaches": [],


### PR DESCRIPTION
## Summary
- Enhanced Erdős #451 formalization with CRT-based structural analysis
- Added new definitions (`bertrandPrimes`, `safeResidues`) and structural lemmas
- Computed n_k values for k=1..20 (documented in header comments)
- Fixed docstring headers for Aristotle compatibility

## Progress
- **Added**: `bertrandPrimes` (computable Finset of primes in (k,2k))
- **Added**: `safeResidues` (safe residue classes mod p for avoiding prime factors)
- **Added**: `DecidablePred` instance for `IsInBertrandRange`
- **Added**: `at_most_one_div` lemma (sorry) - at most one factor divisible by p > k
- **Added**: `prime_dvd_descendingProduct` lemma (sorry) - factorization characterization
- **Added**: `card_safeResidues` lemma (sorry) - exactly p-k safe residues
- **Added**: `nk_trivial_lower` theorem (proved) - n_k > 2k over rationals
- **Added**: `adenwalla_crt_idea` theorem (proved) - CRT upper bound structure
- **Fixed**: All docstring headers for Aristotle parser compatibility

## Findings
- The problem reduces to CRT: for each prime p in (k, 2k), n must avoid residues 1..k mod p
- The number of safe residues mod p is p - k, which is small (between 1 and k-1)
- n_k spikes when there are many primes in (k, 2k) and drops when k passes a prime
- The 3 sorry lemmas are good Aristotle candidates (standard number theory)

## Status
**Outcome**: surveyed
**Next Steps**: Submit structural lemmas to Aristotle for proof search

🤖 Generated by researcher-1