### PR TITLE
enhance(erdos-736): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos736Problem.lean
+++ b/proofs/Proofs/Erdos736Problem.lean
@@ -42,9 +42,7 @@ open Cardinal SimpleGraph
 
 namespace Erdos736
 
-/-!
-## Part I: Basic Definitions
--/
+/- ## Part I: Basic Definitions -/
 
 /--
 **Chromatic number of a simple graph:**
@@ -77,9 +75,7 @@ def finiteSubgraphClass {V : Type*} (G : SimpleGraph V) :
   { ⟨n, H⟩ | ∃ (S : Finset V) (e : S ≃ Fin n),
     ∀ i j : Fin n, H.Adj i j ↔ G.Adj (e.symm i) (e.symm j) }
 
-/-!
-## Part II: The Taylor Conjecture
--/
+/- ## Part II: The Taylor Conjecture -/
 
 /--
 **Walter Taylor's Conjecture:**
@@ -109,9 +105,7 @@ def GeneralizedTaylorConjecture : Prop :=
           ∀ (n : ℕ) (F : SimpleGraph (Fin n)),
             isSubgraphOf F H → isSubgraphOf F G
 
-/-!
-## Part III: Erdős's General Question
--/
+/- ## Part III: Erdős's General Question -/
 
 /--
 **Family of finite graphs:**
@@ -137,9 +131,7 @@ def ErdosGeneralQuestion : Prop :=
   ∃ (characterization : FiniteGraphFamily → Ordinal → Prop),
     ∀ F α, characterization F α ↔ realizableAt F α
 
-/-!
-## Part IV: The Komjáth-Shelah Consistency Result
--/
+/- ## Part IV: The Komjáth-Shelah Consistency Result -/
 
 /--
 **Komjáth-Shelah (2005):**
@@ -164,9 +156,7 @@ axiom taylor_conjecture_independent :
     -- The statement is independent of ZFC
     True
 
-/-!
-## Part V: Related Concepts
--/
+/- ## Part V: Related Concepts -/
 
 /--
 **De Bruijn-Erdős theorem (finite version):**
@@ -195,9 +185,7 @@ axiom chromatic_cardinal_interaction :
     ∀ κ : Cardinal, κ.IsRegular → κ ≥ aleph 0 →
       ∃ (V : Type*) (G : SimpleGraph V), chromaticNumber V G = κ
 
-/-!
-## Part VI: Special Cases
--/
+/- ## Part VI: Special Cases -/
 
 /--
 **Countable chromatic number:**
@@ -225,9 +213,7 @@ theorem finite_case (V : Type*) (G : SimpleGraph V) (k : ℕ) :
   intro _ _ _
   sorry
 
-/-!
-## Part VII: Summary
--/
+/- ## Part VII: Summary -/
 
 /--
 **Erdős Problem #736: OPEN (independence known)**

--- a/src/data/proofs/erdos-736/meta.json
+++ b/src/data/proofs/erdos-736/meta.json
@@ -15,7 +15,7 @@
     "erdosNumber": 736,
     "erdosUrl": "https://erdosproblems.com/736",
     "erdosProblemStatus": "open",
-    "mathlib_version": "v4.x",
+    "mathlib_version": "4.15.0",
     "mathlibDependencies": [
       { "theorem": "SimpleGraph", "description": "Simple graphs in combinatorics", "module": "Mathlib.Combinatorics.SimpleGraph.Basic" },
       { "theorem": "SimpleGraph.Subgraph", "description": "Subgraphs of simple graphs", "module": "Mathlib.Combinatorics.SimpleGraph.Subgraph" },
@@ -48,49 +48,49 @@
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "startLine": 45,
-      "endLine": 79,
+      "endLine": 77,
       "summary": "Chromatic number, finite subgraphs, and subgraph embeddings"
     },
     {
       "id": "taylor-conjecture",
       "title": "The Taylor Conjecture",
-      "startLine": 80,
-      "endLine": 111,
+      "startLine": 78,
+      "endLine": 107,
       "summary": "Walter Taylor's original conjecture and its generalization"
     },
     {
       "id": "general-question",
       "title": "Erdős's General Question",
-      "startLine": 112,
-      "endLine": 139,
+      "startLine": 108,
+      "endLine": 133,
       "summary": "Characterizing realizable families of finite graphs"
     },
     {
       "id": "consistency-result",
       "title": "Komjáth-Shelah Consistency",
-      "startLine": 140,
-      "endLine": 166,
+      "startLine": 134,
+      "endLine": 158,
       "summary": "Independence from ZFC and the ℵ₂ bound"
     },
     {
       "id": "related-concepts",
       "title": "Related Concepts",
-      "startLine": 167,
-      "endLine": 197,
+      "startLine": 159,
+      "endLine": 187,
       "summary": "De Bruijn-Erdős theorem and chromatic compactness"
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "startLine": 198,
-      "endLine": 227,
+      "startLine": 188,
+      "endLine": 215,
       "summary": "Countable and finite chromatic number cases"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 228,
-      "endLine": 267,
+      "startLine": 216,
+      "endLine": 253,
       "summary": "Main theorem statements and key insight"
     }
   ],


### PR DESCRIPTION
## Summary
- Convert 7 `/-!` section headers to `/-` for Aristotle proof search parser compatibility
- Fix `mathlib_version` from `"v4.x"` to `"4.15.0"`
- Update all section line numbers in meta.json after header changes

## Test plan
- [x] `pnpm build` succeeds
- [x] No `/-!` headers remain in Lean file
- [x] Section line numbers match actual file positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)