### PR TITLE
enhance(erdos-754): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos754Problem.lean
+++ b/proofs/Proofs/Erdos754Problem.lean
@@ -1,4 +1,4 @@
-/-!
+/-
 Erdős Problem #754: Favorite Distances in Four Dimensions
 
 Let f(n) be maximal such that there exists a set A of n points in ℝ⁴ in which
@@ -27,8 +27,7 @@ open Finset
 
 namespace Erdos754
 
-/-!
-## Overview
+/- ## Overview
 
 This problem asks about "favorite distances" in ℝ⁴: how many points can share
 the same distance from a given point? In high dimensions, the geometry allows
@@ -37,9 +36,7 @@ for many equidistant points, but there are still limits.
 The answer: roughly n/2 points can be equidistant from each point, but not more.
 -/
 
-/-!
-## Part I: Basic Definitions
--/
+/- ## Part I: Basic Definitions -/
 
 /-- A point configuration in d-dimensional Euclidean space. -/
 def PointConfig (d n : ℕ) := Fin n → EuclideanSpace ℝ (Fin d)
@@ -61,9 +58,7 @@ noncomputable def favoriteDistance {d n : ℕ} (A : PointConfig d n) (x : Fin n)
 noncomputable def favoriteCount {d n : ℕ} (A : PointConfig d n) (x : Fin n) : ℕ :=
   ⨆ r : ℝ, (equidistantSet A x r).card
 
-/-!
-## Part II: The Function f(n)
--/
+/- ## Part II: The Function f(n) -/
 
 /-- f_d(n): the maximum k such that every point has at least k equidistant points. -/
 noncomputable def f (d n : ℕ) : ℕ :=
@@ -73,9 +68,7 @@ noncomputable def f (d n : ℕ) : ℕ :=
 noncomputable def minFavoriteCount {d n : ℕ} (A : PointConfig d n) : ℕ :=
   ⨅ x : Fin n, favoriteCount A x
 
-/-!
-## Part III: The Four-Dimensional Case
--/
+/- ## Part III: The Four-Dimensional Case -/
 
 /-- Avis-Erdős-Pach (1988) lower bound: f(n) ≥ n/2 + 2. -/
 axiom avis_erdos_pach_lower_bound (n : ℕ) (hn : n ≥ 4) :
@@ -85,9 +78,7 @@ axiom avis_erdos_pach_lower_bound (n : ℕ) (hn : n ≥ 4) :
 axiom avis_erdos_pach_upper_bound (n : ℕ) (hn : n ≥ 4) :
     ∀ ε > 0, ∃ N : ℕ, ∀ m ≥ N, (f 4 m : ℝ) ≤ (1 + ε) * m / 2
 
-/-!
-## Part IV: Swanepoel's Theorem (2013)
--/
+/- ## Part IV: Swanepoel's Theorem (2013) -/
 
 /-- A distance assignment: for each point, a "favorite" distance. -/
 def DistanceAssignment (n : ℕ) := Fin n → ℝ
@@ -117,17 +108,14 @@ theorem erdos_754_solved (n : ℕ) (hn : n ≥ 4) :
   use C₂
   exact ⟨avis_erdos_pach_lower_bound n hn, hC₂⟩
 
-/-!
-## Part V: Higher Dimensions
--/
+/- ## Part V: Higher Dimensions -/
 
 /-- Swanepoel also proved analogous results for higher dimensions. -/
 axiom swanepoel_higher_dimensions (d : ℕ) (hd : d ≥ 4) :
     ∃ c : ℝ, c > 0 ∧ c < 1 ∧
       ∀ n : ℕ, n ≥ 2 → ∃ C : ℝ, (f d n : ℝ) ≤ c * n + C
 
-/-!
-## Summary
+/- ## Summary
 
 **Erdős Problem #754: SOLVED (YES)**
 

--- a/src/data/proofs/erdos-754/annotations.json
+++ b/src/data/proofs/erdos-754/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-e754-header",
     "proofId": "erdos-754",
-    "range": { "startLine": 1, "endLine": 17 },
+    "range": { "startLine": 1, "endLine": 18 },
     "type": "concept",
     "title": "Problem Overview",
     "content": "**Erdős Problem #754: Favorite Distances in ℝ⁴**\n\nFor n points in ℝ⁴, what's the maximum k such that EVERY point has at least k equidistant neighbors?\n\n**Question:** Is f(n) ≤ n/2 + O(1)?\n\n**Answer: YES** - Swanepoel (2013)\n\nSwanepoel's stronger result: Σ 1_{|x-y|=d(x)} ≤ (1/2)n² + O(n) for any distance assignment d(x).",
@@ -13,7 +13,7 @@
   {
     "id": "ann-e754-point-config",
     "proofId": "erdos-754",
-    "range": { "startLine": 44, "endLine": 45 },
+    "range": { "startLine": 41, "endLine": 42 },
     "type": "definition",
     "title": "Point Configuration",
     "content": "**PointConfig d n:**\n\nA configuration of n points in d-dimensional Euclidean space: Fin n → EuclideanSpace ℝ (Fin d).\n\nThis represents any arrangement of n labeled points in ℝᵈ.",
@@ -23,7 +23,7 @@
   {
     "id": "ann-e754-equidistant",
     "proofId": "erdos-754",
-    "range": { "startLine": 51, "endLine": 53 },
+    "range": { "startLine": 48, "endLine": 50 },
     "type": "definition",
     "title": "Equidistant Set",
     "content": "**equidistantSet A x r:**\n\nThe set of points y ≠ x with |A(x) - A(y)| = r.\n\nThis captures 'all points at distance r from x' in the configuration.",
@@ -33,7 +33,7 @@
   {
     "id": "ann-e754-favorite-count",
     "proofId": "erdos-754",
-    "range": { "startLine": 60, "endLine": 62 },
+    "range": { "startLine": 57, "endLine": 59 },
     "type": "definition",
     "title": "Favorite Count",
     "content": "**favoriteCount A x:**\n\nThe maximum over all distances r of |equidistantSet A x r|.\n\nThis is the largest number of points equidistant from x at any single distance - the 'favorite distance' achieves this count.",
@@ -43,7 +43,7 @@
   {
     "id": "ann-e754-function-f",
     "proofId": "erdos-754",
-    "range": { "startLine": 68, "endLine": 70 },
+    "range": { "startLine": 63, "endLine": 65 },
     "type": "definition",
     "title": "The Function f(n)",
     "content": "**f d n:**\n\nThe maximum over all n-point configurations A in ℝᵈ of (minimum over x of favoriteCount A x).\n\nIn words: f(n) is the largest k such that some configuration has EVERY point with at least k equidistant neighbors.",
@@ -53,7 +53,7 @@
   {
     "id": "ann-e754-aep-lower",
     "proofId": "erdos-754",
-    "range": { "startLine": 80, "endLine": 82 },
+    "range": { "startLine": 73, "endLine": 75 },
     "type": "axiom",
     "title": "Avis-Erdős-Pach Lower Bound",
     "content": "**avis_erdos_pach_lower_bound:**\n\nf(n) ≥ n/2 + 2 for n ≥ 4 in ℝ⁴.\n\n**Construction:** Use the Clifford torus - place n/2 points on each of two orthogonal circles. Points on different circles are all equidistant!",
@@ -64,7 +64,7 @@
   {
     "id": "ann-e754-distance-assign",
     "proofId": "erdos-754",
-    "range": { "startLine": 92, "endLine": 93 },
+    "range": { "startLine": 83, "endLine": 84 },
     "type": "definition",
     "title": "Distance Assignment",
     "content": "**DistanceAssignment n:**\n\nA function Fin n → ℝ assigning a 'favorite distance' d(x) to each point x.\n\nSwanepoel's result is stronger because it applies to ANY such assignment, not just the optimal one.",
@@ -74,7 +74,7 @@
   {
     "id": "ann-e754-swanepoel-main",
     "proofId": "erdos-754",
-    "range": { "startLine": 101, "endLine": 106 },
+    "range": { "startLine": 92, "endLine": 97 },
     "type": "axiom",
     "title": "Swanepoel's Main Theorem",
     "content": "**swanepoel_2013:**\n\nFor any configuration A and distance assignment d:\n\nΣ_{x,y} 1_{|x-y|=d(x)} ≤ (1/2)n² + O(n)\n\nThe total count of 'favorite distance pairs' is at most quadratic with leading coefficient 1/2.",
@@ -85,7 +85,7 @@
   {
     "id": "ann-e754-swanepoel-answer",
     "proofId": "erdos-754",
-    "range": { "startLine": 108, "endLine": 110 },
+    "range": { "startLine": 99, "endLine": 101 },
     "type": "axiom",
     "title": "Swanepoel Solves Erdős 754",
     "content": "**swanepoel_erdos_754:**\n\nf(n) ≤ n/2 + O(1) for ℝ⁴.\n\nThis answers Erdős's question affirmatively. Combined with the lower bound, we get f(n) = n/2 + Θ(1).",
@@ -95,7 +95,7 @@
   {
     "id": "ann-e754-solved",
     "proofId": "erdos-754",
-    "range": { "startLine": 112, "endLine": 118 },
+    "range": { "startLine": 103, "endLine": 109 },
     "type": "theorem",
     "title": "Problem Solved",
     "content": "**erdos_754_solved:**\n\nCombines the bounds: ∃ C₁ C₂, n/2 + C₁ ≤ f(n) ≤ n/2 + C₂.\n\n**Proof:** Uses avis_erdos_pach_lower_bound (C₁ = 2) and swanepoel_erdos_754 (get C₂).\n\nThe answer is f(n) = n/2 + Θ(1) - determined up to an additive constant.",
@@ -105,7 +105,7 @@
   {
     "id": "ann-e754-higher-dim",
     "proofId": "erdos-754",
-    "range": { "startLine": 124, "endLine": 127 },
+    "range": { "startLine": 113, "endLine": 116 },
     "type": "axiom",
     "title": "Higher Dimensions",
     "content": "**swanepoel_higher_dimensions:**\n\nSwanepoel proved analogous results for all d ≥ 4: there exists c ∈ (0,1) depending on d such that f_d(n) ≤ c·n + O(1). In dimension 4, c = 1/2. The Clifford torus construction (S¹ × S¹ ⊂ ℝ⁴) achieves the lower bound: n/2 points on each of two orthogonal circles gives f(n) ≥ n/2.",
@@ -115,7 +115,7 @@
   {
     "id": "ann-e754-summary",
     "proofId": "erdos-754",
-    "range": { "startLine": 149, "endLine": 163 },
+    "range": { "startLine": 137, "endLine": 151 },
     "type": "theorem",
     "title": "Summary Theorems",
     "content": "**erdos_754** and **erdos_754_summary:**\n\n`erdos_754` is a genuine theorem: ∃ C₁ C₂, n/2 + C₁ ≤ f(n) ≤ n/2 + C₂, proved via `erdos_754_solved`.\n\n`erdos_754_summary` combines:\n1. Lower bound: ∀ n ≥ 4, f(n) ≥ n/2 + 2 (Avis-Erdős-Pach)\n2. Upper bound: ∀ n ≥ 4, ∃ C, f(n) ≤ n/2 + C (Swanepoel)\n\nThe function f(n) for 'favorite distances' in ℝ⁴ grows exactly as n/2 + O(1).",

--- a/src/data/proofs/erdos-754/meta.json
+++ b/src/data/proofs/erdos-754/meta.json
@@ -70,49 +70,49 @@
       "title": "Overview",
       "summary": "Favorite distances problem setup",
       "startLine": 30,
-      "endLine": 38
+      "endLine": 37
     },
     {
       "id": "definitions",
       "title": "Basic Definitions",
       "summary": "PointConfig, equidistantSet, favoriteCount",
-      "startLine": 40,
-      "endLine": 62
+      "startLine": 39,
+      "endLine": 59
     },
     {
       "id": "function-f",
       "title": "The Function f(n)",
       "summary": "f_d(n) definition, minFavoriteCount",
-      "startLine": 64,
-      "endLine": 74
+      "startLine": 61,
+      "endLine": 69
     },
     {
       "id": "four-dim",
       "title": "Four-Dimensional Case",
       "summary": "Avis-Erdős-Pach bounds (1988)",
-      "startLine": 76,
-      "endLine": 86
+      "startLine": 71,
+      "endLine": 79
     },
     {
       "id": "swanepoel",
       "title": "Swanepoel's Theorem",
       "summary": "2013 solution, favorite distance pairs, erdos_754_solved",
-      "startLine": 88,
-      "endLine": 118
+      "startLine": 81,
+      "endLine": 109
     },
     {
       "id": "higher-dim",
       "title": "Higher Dimensions",
       "summary": "swanepoel_higher_dimensions for d ≥ 4",
-      "startLine": 120,
-      "endLine": 127
+      "startLine": 111,
+      "endLine": 116
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_754, erdos_754_summary",
-      "startLine": 129,
-      "endLine": 164
+      "startLine": 118,
+      "endLine": 152
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Convert all `/-!` docstring headers to `/-` comments for Aristotle parser compatibility
- Update section line numbers in meta.json to match revised Lean file
- Update annotation line ranges in annotations.json

## Checklist
- [x] Lean proof structure preserved
- [x] pnpm build succeeds
- [x] Annotations align with Lean file

🤖 Generated by enhancer-1