### PR TITLE
enhance(erdos-436): replace placeholder with summary theorem

### DIFF
--- a/proofs/Proofs/Erdos436Problem.lean
+++ b/proofs/Proofs/Erdos436Problem.lean
@@ -393,7 +393,14 @@ theorem erdos_436_summary :
 but m = 3 exhibits a parity dichotomy (finite for k=3, ∞ for even k,
 unknown for odd k ≥ 5), and m ≥ 4 is always infinite (Graham).
 -/
-theorem erdos_436 : True := trivial
+theorem erdos_436_partially_solved :
+    -- Q1 SOLVED: Λ(k,2) finite for all k
+    (∀ k : ℕ, k ≥ 2 → LambdaFinite k 2) ∧
+    -- Λ(k,m) = ∞ for m ≥ 4
+    (∀ k m : ℕ, k ≥ 2 → m ≥ 4 → ¬LambdaFinite k m) ∧
+    -- Λ(k,3) = ∞ for even k
+    (∀ k : ℕ, k ≥ 2 → 2 ∣ k → ¬LambdaFinite k 3) :=
+  erdos_436_summary
 
 /-- The parity dichotomy: for even k, m=3 is infinite. -/
 theorem even_k_m3_infinite (k : ℕ) (hk : k ≥ 2) (heven : Even k) :

--- a/src/data/proofs/erdos-436/annotations.json
+++ b/src/data/proofs/erdos-436/annotations.json
@@ -25,57 +25,65 @@
   },
   {
     "id": "ann-4",
-    "range": { "startLine": 115, "endLine": 121 },
+    "range": { "startLine": 105, "endLine": 119 },
+    "type": "definition",
+    "title": "Lambda(k,m) Axiomatized",
+    "content": "The Λ(k,m) function is axiomatized with two properties: lambda_is_bound (it bounds r(k,m,p) for large primes) and lambda_is_minimal (no smaller value suffices). This avoids sorry in the definition.",
+    "significance": "essential"
+  },
+  {
+    "id": "ann-5",
+    "range": { "startLine": 125, "endLine": 131 },
     "type": "theorem",
     "title": "Λ(2,2) = 9",
     "content": "The first pair of consecutive quadratic residues is always ≤ 9. Elegant proof: 9=3² is always QR. If 10 isn't QR, then since 10=2·5 and product of two non-QRs is QR, one of 2,5 must be QR, giving pair {1,2} or {4,5}.",
     "significance": "essential"
   },
   {
-    "id": "ann-5",
-    "range": { "startLine": 157, "endLine": 165 },
+    "id": "ann-6",
+    "range": { "startLine": 167, "endLine": 175 },
     "type": "theorem",
     "title": "Hildebrand's Theorem (1991)",
     "content": "Λ(k,2) is finite for ALL k ≥ 2. This resolves Question 1 completely. The proof uses sophisticated character sum estimates and the large sieve inequality from analytic number theory.",
     "significance": "essential"
   },
   {
-    "id": "ann-6",
-    "range": { "startLine": 184, "endLine": 191 },
+    "id": "ann-7",
+    "range": { "startLine": 194, "endLine": 201 },
     "type": "theorem",
     "title": "Λ(k,3) = ∞ for Even k",
     "content": "For even k, no uniform bound exists for 3 consecutive kth power residues. This creates a parity dichotomy: m=3 case is finite for k=3 but infinite for even k, with odd k ≥ 5 unknown.",
     "significance": "essential"
   },
   {
-    "id": "ann-7",
-    "range": { "startLine": 211, "endLine": 219 },
+    "id": "ann-8",
+    "range": { "startLine": 221, "endLine": 229 },
     "type": "theorem",
     "title": "Graham's Theorem (1964)",
     "content": "Λ(k,m) = ∞ for ALL k ≥ 2 and m ≥ 4. No matter how large the prime, there's no universal bound for finding 4+ consecutive kth power residues. This makes m ≤ 3 the only interesting cases.",
     "significance": "essential"
   },
   {
-    "id": "ann-8",
-    "range": { "startLine": 127, "endLine": 151 },
+    "id": "ann-9",
+    "range": { "startLine": 137, "endLine": 161 },
     "type": "insight",
     "title": "Known Exact Values",
     "content": "Machine computations found: Λ(2,2)=9, Λ(3,2)=77, Λ(4,2)=1224, Λ(5,2)=7888, Λ(6,2)=202124, Λ(7,2)=1649375. These grow rapidly - ratio between consecutive values is irregular but increasing.",
     "significance": "important"
   },
   {
-    "id": "ann-9",
-    "range": { "startLine": 198, "endLine": 199 },
+    "id": "ann-10",
+    "range": { "startLine": 208, "endLine": 209 },
     "type": "conjecture",
     "title": "Question 2: OPEN",
     "content": "Is Λ(k,3) finite for all ODD k ≥ 5? Only Λ(3,3)=23532 is known to be finite. Values like Λ(5,3), Λ(7,3) are completely unknown - we don't even know if they're finite!",
     "significance": "important"
   },
   {
-    "id": "ann-10",
-    "range": { "startLine": 302, "endLine": 320 },
+    "id": "ann-11",
+    "range": { "startLine": 317, "endLine": 339 },
     "type": "summary",
-    "title": "Main Result: erdos_436",
+    "title": "Main Result: erdos_436_partially_solved",
     "content": "PARTIALLY SOLVED: Q1 (Λ(k,2) finite) resolved by Hildebrand. Q2 (Λ(k,3) for odd k) OPEN for k ≥ 5. Q3 (growth rate) partially known. The m=3 parity dichotomy is the key remaining mystery.",
     "significance": "essential"
   }

--- a/src/data/proofs/erdos-436/meta.json
+++ b/src/data/proofs/erdos-436/meta.json
@@ -28,7 +28,7 @@
       "AreConsecutiveKthResidues: m consecutive residues",
       "minConsecKthResidues: r(k,m,p) function",
       "LambdaFinite: Finiteness of Λ(k,m)",
-      "Lambda: The Λ(k,m) value",
+      "Lambda: The Λ(k,m) value (axiomatized)",
       "hildebrand_theorem: Λ(k,2) finite for all k",
       "graham_theorem: Λ(k,m) = ∞ for m ≥ 4",
       "lambda_even_3_infinite: Λ(k,3) = ∞ for even k",
@@ -42,7 +42,7 @@
   "overview": {
     "historicalContext": "D.H. Lehmer and Emma Lehmer initiated this problem in 1962 with their paper 'On runs of residues'. They showed Λ(2,2)=9 with an elegant argument. Extensive computations in the 1960s by Dunton, Bierstedt, Mills, Brillhart, and Selfridge found exact values through k=7. Hildebrand's 1991 theorem using character sums and the large sieve resolved Question 1. Graham (1964) proved the m≥4 case is always infinite.",
     "problemStatement": "**Problem Statement (PARTIALLY SOLVED)**\n\nFor prime p and k, m ≥ 2, let r(k,m,p) = min{r : r,...,r+m-1 are kth power residues mod p}.\nDefine Λ(k,m) = lim sup_{p→∞} r(k,m,p).\n\n**Questions:**\n1. Is Λ(k,2) finite for all k? [SOLVED: YES - Hildebrand 1991]\n2. Is Λ(k,3) finite for all odd k? [OPEN]\n3. What is the growth rate of Λ(k,m)? [PARTIAL]",
-    "proofStrategy": "The formalization defines kth power residues and consecutive runs. The Λ(k,m) function captures lim sup behavior. Hildebrand's theorem, Graham's theorem, and the Lehmer-Lehmer parity result for m=3 are axiomatized. Exact computed values are recorded.",
+    "proofStrategy": "The formalization defines kth power residues and consecutive runs. The Λ(k,m) function captures lim sup behavior via axiomatized Lambda with bound and minimality properties. Hildebrand's theorem, Graham's theorem, and the Lehmer-Lehmer parity result for m=3 are axiomatized. Exact computed values are recorded.",
     "keyInsights": [
       "**Λ(2,2)=9:** Elegant proof using 9=3² always QR and 10=2·5 structure",
       "**Hildebrand 1991:** Λ(k,2) finite for all k using analytic methods",
@@ -71,57 +71,57 @@
       "id": "lambda-function",
       "title": "The Λ(k,m) Function",
       "startLine": 89,
-      "endLine": 109,
-      "summary": "LambdaFinite, Lambda definitions"
+      "endLine": 119,
+      "summary": "LambdaFinite, Lambda axiom with bound and minimality"
     },
     {
       "id": "known-values",
       "title": "Known Exact Values",
-      "startLine": 111,
-      "endLine": 151,
+      "startLine": 121,
+      "endLine": 161,
       "summary": "Λ(2,2)=9 through Λ(7,2)=1649375"
     },
     {
       "id": "hildebrand",
       "title": "Hildebrand's Theorem",
-      "startLine": 153,
-      "endLine": 171,
+      "startLine": 163,
+      "endLine": 181,
       "summary": "Λ(k,2) finite for all k (1991)"
     },
     {
       "id": "m3-case",
       "title": "The m = 3 Case",
-      "startLine": 173,
-      "endLine": 205,
+      "startLine": 183,
+      "endLine": 215,
       "summary": "Λ(3,3)=23532, parity dichotomy, open question"
     },
     {
       "id": "graham",
       "title": "Graham's Theorem",
-      "startLine": 207,
-      "endLine": 230,
+      "startLine": 217,
+      "endLine": 240,
       "summary": "Λ(k,m) = ∞ for m ≥ 4"
     },
     {
       "id": "quadratic",
       "title": "Quadratic Residue Case",
-      "startLine": 232,
-      "endLine": 254,
+      "startLine": 242,
+      "endLine": 264,
       "summary": "Elegant proof of Λ(2,2) ≤ 9"
     },
     {
       "id": "growth",
       "title": "Growth Rate Questions",
-      "startLine": 256,
-      "endLine": 280,
-      "summary": "Super-polynomial growth conjectured"
+      "startLine": 266,
+      "endLine": 295,
+      "summary": "Super-polynomial growth, increasing ratios"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 282,
-      "endLine": 331,
-      "summary": "Main theorems and historical note"
+      "startLine": 297,
+      "endLine": 341,
+      "summary": "Main theorems and partially solved status"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Replace `True := trivial` placeholder with meaningful `erdos_436_partially_solved` theorem
- Summary theorem references actual Hildebrand, Graham, and Lehmer-Lehmer results

## Checklist
- [x] pnpm build succeeds
- [x] Quality check passes
- [x] No placeholder proofs remain

🤖 Generated by enhancer-2

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>