### PR TITLE
enhance(erdos-10): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos10Problem.lean
+++ b/proofs/Proofs/Erdos10Problem.lean
@@ -1,4 +1,4 @@
-/-!
+/-
 # Erdős Problem #10 — Sums of a Prime and Powers of 2
 
 Is there some k such that every sufficiently large integer is the sum of
@@ -32,7 +32,7 @@ import Mathlib.Order.Filter.AtTopBot.Group
 
 open Set Filter
 
-/-! ## Core Definitions -/
+/- ## Core Definitions -/
 
 /-- The set of natural numbers that can be written as a sum of a prime
 and at most `k` powers of 2. We represent the powers-of-2 component
@@ -47,7 +47,7 @@ noncomputable def Set.lowerDensity (S : Set ℕ) : ℝ :=
   Filter.liminf (fun n => (↑(Finset.card (Finset.filter (· ∈ S) (Finset.range (n + 1)))) : ℝ)
     / (↑(n + 1) : ℝ)) atTop
 
-/-! ## Main Conjecture -/
+/- ## Main Conjecture -/
 
 /-- **Erdős Problem #10 (Open).**
 Is there some k such that every integer > 1 is the sum of a prime and
@@ -58,7 +58,7 @@ arbitrarily large integers not so representable. -/
 axiom erdos_10_conjecture :
   ¬ ∃ k : ℕ, {n : ℕ | 1 < n} ⊆ sumPrimeAndTwoPows k
 
-/-! ## Gallagher's Density Theorem -/
+/- ## Gallagher's Density Theorem -/
 
 /-- **Gallagher (1975).** For any ε > 0 there exists k(ε) such that the
 set of integers representable as a prime plus at most k(ε) powers of 2
@@ -66,7 +66,7 @@ has lower density at least 1 − ε. -/
 axiom gallagher_density (ε : ℝ) (hε : 0 < ε) :
   ∃ k : ℕ, 1 - ε ≤ (sumPrimeAndTwoPows k).lowerDensity
 
-/-! ## Granville–Soundararajan Conjecture -/
+/- ## Granville–Soundararajan Conjecture -/
 
 /-- **Granville–Soundararajan (1998) — Odd Part.**
 Every odd integer > 1 is the sum of a prime and at most 3 powers of 2. -/
@@ -78,21 +78,21 @@ Every even integer ≥ 2 is the sum of a prime and at most 4 powers of 2. -/
 axiom granville_soundararajan_even :
   {n : ℕ | Even n ∧ n ≠ 0} ⊆ sumPrimeAndTwoPows 4
 
-/-! ## Counterexample to k = 3 for Even Integers -/
+/- ## Counterexample to k = 3 for Even Integers -/
 
 /-- **Grechuk's observation.** The number 1117175146 is not the sum of
 a prime and at most 3 powers of 2. This shows that the Granville–
 Soundararajan conjecture cannot be extended to all integers with k = 3. -/
 axiom grechuk_counterexample : 1117175146 ∉ sumPrimeAndTwoPows 3
 
-/-! ## Infinitely Many Exceptions for k = 2 -/
+/- ## Infinitely Many Exceptions for k = 2 -/
 
 /-- There are infinitely many even integers that are not the sum of a
 prime and 2 powers of 2. This follows from covering congruence arguments. -/
 axiom infinitely_many_exceptions_k2 :
   Set.Infinite ({n : ℕ | Even n} \ sumPrimeAndTwoPows 2)
 
-/-! ## Conjectured Infinitely Many Exceptions for k = 3 -/
+/- ## Conjectured Infinitely Many Exceptions for k = 3 -/
 
 /-- It is conjectured (following Grechuk's observation and parity arguments)
 that there are infinitely many even integers not the sum of a prime and
@@ -100,7 +100,7 @@ at most 3 powers of 2. -/
 axiom infinitely_many_exceptions_k3 :
   Set.Infinite ({n : ℕ | Even n} \ sumPrimeAndTwoPows 3)
 
-/-! ## Romanoff's Theorem -/
+/- ## Romanoff's Theorem -/
 
 /-- **Romanoff (1934).** A positive proportion of integers are the sum of
 a prime and a power of 2 (i.e., the k = 1 case already has positive


### PR DESCRIPTION
## Summary
- Fixed `/-!` section headers to `/-` for Aristotle parser compatibility

## Checklist
- [x] pnpm build succeeds
- [x] No `/-!` headers remain

Generated by enhancer-3