### PR TITLE
enhance(erdos-391): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos391Problem.lean
+++ b/proofs/Proofs/Erdos391Problem.lean
@@ -37,9 +37,7 @@ open Finset BigOperators Real
 
 namespace Erdos391
 
-/-!
-## Part I: Basic Definitions
--/
+/- ## Part I: Basic Definitions -/
 
 /--
 **Ordered Factorization:**
@@ -74,9 +72,7 @@ The key quantity to study.
 -/
 noncomputable def ratio (n : ℕ) : ℝ := (t n : ℝ) / (n : ℝ)
 
-/-!
-## Part II: Easy Upper Bound
--/
+/- ## Part II: Easy Upper Bound -/
 
 /--
 **Easy Upper Bound:**
@@ -96,9 +92,7 @@ theorem limsup_le_one_over_e :
     ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, ratio n ≤ 1 / Real.exp 1 + ε :=
   easy_upper_bound
 
-/-!
-## Part III: The Lost Proof (Erdős-Selfridge-Straus)
--/
+/- ## Part III: The Lost Proof (Erdős-Selfridge-Straus) -/
 
 /--
 **The Erdős-Selfridge-Straus Claim (Lost):**
@@ -109,9 +103,7 @@ reconstruct our proof, so our assertion now can be called only a conjecture."
 def erdosSelfridgeStrausConjecture : Prop :=
   ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, |ratio n - 1 / Real.exp 1| < ε
 
-/-!
-## Part IV: The ACRSTUV Theorem (2025)
--/
+/- ## Part IV: The ACRSTUV Theorem (2025) -/
 
 /--
 **The Constant c₀:**
@@ -144,9 +136,7 @@ axiom second_order_correction :
     ∃ (c : ℝ) (N : ℕ), c > 0 ∧ ∀ n ≥ N,
       ratio n ≤ 1 / Real.exp 1 - c / Real.log n
 
-/-!
-## Part V: Explicit Bounds
--/
+/- ## Part V: Explicit Bounds -/
 
 /--
 **Upper Bound (ACRSTUV25):**
@@ -169,9 +159,7 @@ The threshold 43632 is sharp.
 axiom threshold_43632_sharp :
     ∃ n : ℕ, n < 43632 ∧ t n < n / 3
 
-/-!
-## Part VI: Small Cases
--/
+/- ## Part VI: Small Cases -/
 
 /--
 **Small Values:**
@@ -186,9 +174,7 @@ t(4) = 3 > 4/e ≈ 1.47, so n = 4 is a genuine exception to t(n) ≤ n/e.
 -/
 axiom exception_at_4 : (t 4 : ℝ) > 4 / Real.exp 1
 
-/-!
-## Part VII: Guy-Selfridge Conjectures
--/
+/- ## Part VII: Guy-Selfridge Conjectures -/
 
 /--
 **Guy-Selfridge Conjecture 1:**
@@ -209,9 +195,7 @@ def guySelfridgeConjecture2 : Prop :=
 theorem guy_selfridge_2_proved : guySelfridgeConjecture2 :=
   lower_bound_explicit
 
-/-!
-## Part VIII: The Factorization Perspective
--/
+/- ## Part VIII: The Factorization Perspective -/
 
 /--
 **Equivalent Formulation:**
@@ -223,7 +207,7 @@ axiom balanced_factorization_view :
       ∃ f : OrderedFactorization n.factorial n,
         minFactor f = t n ∧ ∀ g : OrderedFactorization n.factorial n, minFactor g ≤ t n
 
-/-!
+/-
 ## Part IX: Summary
 
 **Erdős Problem #391: Status SOLVED** (ACRSTUV25)

--- a/src/data/proofs/erdos-391/annotations.json
+++ b/src/data/proofs/erdos-391/annotations.json
@@ -24,7 +24,7 @@
   {
     "id": "ann-e391-upper-bound",
     "proofId": "erdos-391",
-    "range": { "startLine": 77, "endLine": 97 },
+    "range": { "startLine": 75, "endLine": 93 },
     "type": "axiom",
     "title": "Easy Upper Bound: lim sup t(n)/n ≤ 1/e",
     "content": "**The easy direction** of the problem is showing that t(n)/n cannot be much larger than 1/e. The intuition comes from Stirling's formula: if all n factors in n! = a₁ · ... · aₙ were equal to some value a, then aⁿ = n! ≈ (n/e)ⁿ, giving a ≈ n/e. Since the minimum factor a₁ ≤ a (the average), we get a₁ ≤ n/e asymptotically.\n\nMore precisely, if a₁ = t(n), then a₁ⁿ ≤ a₁ · a₂ · ... · aₙ = n! (since all factors are at least a₁), giving t(n) ≤ (n!)^{1/n} ≈ n/e.",
@@ -35,7 +35,7 @@
   {
     "id": "ann-e391-lost-proof",
     "proofId": "erdos-391",
-    "range": { "startLine": 99, "endLine": 110 },
+    "range": { "startLine": 95, "endLine": 104 },
     "type": "concept",
     "title": "The Lost Proof of Erdős-Selfridge-Straus",
     "content": "**One of the most famous lost proofs in mathematics.** Erdős, Selfridge, and Straus claimed to have proved that lim t(n)/n = 1/e (the matching lower bound to the easy upper bound). Ernst Straus was supposed to write up the proof, but he died suddenly in 1983. No notes were ever found, and Erdős and Selfridge could never reconstruct the argument.\n\nErdős himself described the situation: 'we never could reconstruct our proof, so our assertion now can be called only a conjecture.' This anecdote illustrates the importance of writing up proofs promptly — and the value of formal verification systems like Lean that preserve mathematical knowledge permanently.",
@@ -46,7 +46,7 @@
   {
     "id": "ann-e391-acrstuv",
     "proofId": "erdos-391",
-    "range": { "startLine": 112, "endLine": 145 },
+    "range": { "startLine": 106, "endLine": 137 },
     "type": "theorem",
     "title": "The ACRSTUV Theorem: Complete Resolution (2025)",
     "content": "**The main result** of Alexeev, Conway, Rosenfeld, Sutherland, Tao, Uhr, and Ventullo (2025) resolves both of Erdős's questions simultaneously. They proved the precise asymptotic formula: t(n)/n = 1/e - c₀/log(n) + O(1/(log n)^{1+c}), where c₀ ≈ 0.3044 is an explicit constant and c > 0.\n\nThis formula tells us three things at once: (1) the limit exists and equals 1/e (answering Question 1), (2) the approach to 1/e is from below with rate c₀/log(n) (answering Question 2, and showing it holds for ALL large n, not just infinitely many), and (3) the error beyond the second-order term decays as a power of 1/log(n).",
@@ -57,7 +57,7 @@
   {
     "id": "ann-e391-explicit-bounds",
     "proofId": "erdos-391",
-    "range": { "startLine": 147, "endLine": 170 },
+    "range": { "startLine": 139, "endLine": 160 },
     "type": "axiom",
     "title": "Explicit Bounds and the Sharp Threshold 43632",
     "content": "**Beyond asymptotics**, ACRSTUV also proved remarkably precise explicit bounds. The upper bound t(n) ≤ n/e holds for ALL n except the three exceptions n = 1, 2, and 4. The lower bound t(n) ≥ n/3 holds for all n ≥ 43632, and this threshold is sharp: there exists some n < 43632 for which t(n) < n/3.\n\nThese explicit bounds were conjectured by Guy and Selfridge in 1998 and had remained unproved for nearly three decades. The precision of the threshold 43632 is striking — it was found through extensive computation and then proved to be optimal.",
@@ -68,7 +68,7 @@
   {
     "id": "ann-e391-guy-selfridge",
     "proofId": "erdos-391",
-    "range": { "startLine": 189, "endLine": 210 },
+    "range": { "startLine": 177, "endLine": 196 },
     "type": "theorem",
     "title": "Guy-Selfridge Conjectures: Verified",
     "content": "**Guy and Selfridge** formulated two precise conjectures about t(n) in their 1998 paper 'Factoring Factorial n' in the American Mathematical Monthly. Conjecture 1: t(n) ≤ n/e for all n ≠ 1, 2, 4. Conjecture 2: t(n) ≥ n/3 for all n ≥ 43632. Both were proved by ACRSTUV in 2025.\n\nThe formalization defines these as Lean propositions (guySelfridgeConjecture1, guySelfridgeConjecture2) and provides their proofs: Conjecture 1 via the axiom guy_selfridge_1_proved, and Conjecture 2 as a direct consequence of lower_bound_explicit.",
@@ -79,7 +79,7 @@
   {
     "id": "ann-e391-summary",
     "proofId": "erdos-391",
-    "range": { "startLine": 226, "endLine": 263 },
+    "range": { "startLine": 210, "endLine": 247 },
     "type": "theorem",
     "title": "Summary Theorem: All Main Results Combined",
     "content": "**The summary theorem** erdos_391_summary packages all four main results into a single Lean statement: (1) lim t(n)/n = 1/e, (2) the second-order correction t(n)/n ≤ 1/e - c/log(n) for large n, (3) the explicit upper bound t(n) ≤ ⌊n/e⌋ for n ≥ 3, n ≠ 4, and (4) the lower bound t(n) ≥ n/3 for n ≥ 43632.\n\nThis is a proved theorem (not an axiom), constructed from the individual axioms using Lean's refine tactic. It demonstrates that the axioms are coherent and combine to give a comprehensive picture of the problem's resolution.",

--- a/src/data/proofs/erdos-391/meta.json
+++ b/src/data/proofs/erdos-391/meta.json
@@ -78,63 +78,63 @@
       "title": "Basic Definitions",
       "summary": "OrderedFactorization structure, minFactor, t(n), and ratio definitions",
       "startLine": 40,
-      "endLine": 75
+      "endLine": 73
     },
     {
       "id": "easy-upper-bound",
       "title": "Easy Upper Bound",
       "summary": "lim sup t(n)/n ≤ 1/e via Stirling-type argument",
-      "startLine": 77,
-      "endLine": 97
+      "startLine": 75,
+      "endLine": 93
     },
     {
       "id": "lost-proof",
       "title": "The Lost Proof",
       "summary": "Erdős-Selfridge-Straus conjecture definition",
-      "startLine": 99,
-      "endLine": 110
+      "startLine": 95,
+      "endLine": 104
     },
     {
       "id": "acrstuv-theorem",
       "title": "The ACRSTUV Theorem (2025)",
       "summary": "Main asymptotic formula and corollaries: limit equals 1/e, second-order correction",
-      "startLine": 112,
-      "endLine": 145
+      "startLine": 106,
+      "endLine": 137
     },
     {
       "id": "explicit-bounds",
       "title": "Explicit Bounds",
       "summary": "t(n) ≤ n/e for n ≠ 1,2,4; t(n) ≥ n/3 for n ≥ 43632; sharpness of 43632",
-      "startLine": 147,
-      "endLine": 170
+      "startLine": 139,
+      "endLine": 160
     },
     {
       "id": "small-cases",
       "title": "Small Cases",
       "summary": "Explicit values t(1)=1, t(2)=2, t(3)=2, t(4)=3; exception at n=4",
-      "startLine": 172,
-      "endLine": 187
+      "startLine": 162,
+      "endLine": 175
     },
     {
       "id": "guy-selfridge",
       "title": "Guy-Selfridge Conjectures",
       "summary": "Definitions and proofs of both Guy-Selfridge conjectures",
-      "startLine": 189,
-      "endLine": 210
+      "startLine": 177,
+      "endLine": 196
     },
     {
       "id": "factorization-perspective",
       "title": "The Factorization Perspective",
       "summary": "Balanced factorization view — optimal factorization always exists",
-      "startLine": 212,
-      "endLine": 224
+      "startLine": 198,
+      "endLine": 208
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_391_summary theorem assembling all four main results",
-      "startLine": 226,
-      "endLine": 263
+      "startLine": 210,
+      "endLine": 247
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Convert all `/-!` docstring headers to `/-` in `Erdos391Problem.lean` for Aristotle proof search parser compatibility
- Update section line numbers in `meta.json` to match updated file (250→247 lines)
- Update annotation line ranges in `annotations.json` to match

## Test plan
- [x] `pnpm build` passes
- [x] No `/-!` headers remain in Lean file
- [x] Section/annotation line numbers verified against actual file content

🤖 Generated with [Claude Code](https://claude.com/claude-code)