### PR TITLE
enhance(erdos-865): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos865Problem.lean
+++ b/proofs/Proofs/Erdos865Problem.lean
@@ -30,11 +30,7 @@ open Finset Nat
 
 namespace Erdos865
 
-/-!
-## Part I: Basic Definitions
-
-Pairwise sums and the main predicate.
--/
+/- ## Part I: Basic Definitions -/
 
 /-- **Interval Set:** {1, 2, ..., N} as a finite set. -/
 def intervalSet (N : ℕ) : Finset ℕ := Finset.range N |>.map ⟨(· + 1), fun _ _ h => by omega⟩
@@ -57,11 +53,7 @@ def HasKPairwiseSums (A : Finset ℕ) (k : ℕ) : Prop :=
   ∃ S : Finset ℕ, S ⊆ A ∧ S.card = k ∧
     ∀ a b : ℕ, a ∈ S → b ∈ S → a ≠ b → a + b ∈ A
 
-/-!
-## Part II: Threshold Functions
-
-The minimum density needed to guarantee pairwise sums.
--/
+/- ## Part II: Threshold Functions -/
 
 /-- **Threshold Function f_k(N):**
 The minimum size of A ⊆ {1,...,N} needed to guarantee k elements
@@ -78,11 +70,7 @@ noncomputable def conjecturedThreshold (k N : ℕ) : ℚ :=
 axiom k3_conjectured_threshold (N : ℕ) :
     conjecturedThreshold 3 N = (5/8 : ℚ) * N
 
-/-!
-## Part III: The k=2 Case
-
-Classical folklore result.
--/
+/- ## Part III: The k=2 Case -/
 
 /-- **Classical k=2 Result:**
 If A ⊆ {1,...,2N} has |A| ≥ N+2, then ∃ distinct a,b ∈ A with a+b ∈ A. -/
@@ -94,11 +82,7 @@ axiom classical_k2_result (N : ℕ) (A : Finset ℕ)
 /-- **k=2 Threshold:** f_2(N) = N + 2 (asymptotically N/2 of the interval {1,...,2N}). -/
 axiom k2_threshold : ∀ N : ℕ, threshold 2 (2 * N) ≤ N + 2
 
-/-!
-## Part IV: The k=3 Case
-
-The main content of Problem #865.
--/
+/- ## Part IV: The k=3 Case -/
 
 /-- **The 5/8 Conjecture (k=3):**
 If A ⊆ {1,...,N} has |A| ≥ (5/8)N + C for some constant C,
@@ -130,11 +114,7 @@ axiom k3_optimal_threshold :
     ∀ ε : ℚ, ε > 0 → ∃ N₀ : ℕ, ∀ N ≥ N₀,
     |((threshold 3 N : ℚ) / N) - 5/8| < ε
 
-/-!
-## Part V: The General Conjecture
-
-Erdős-Sós conjecture for all k.
--/
+/- ## Part V: The General Conjecture -/
 
 /-- **Erdős-Sós Conjecture:**
 f_k(N) ~ (1/2)(1 + Σ_{r=1}^{k-2} 1/4^r) N
@@ -158,11 +138,7 @@ axiom threshold_converges_to_two_thirds :
     ∀ ε : ℚ, ε > 0 → ∃ K : ℕ, ∀ k ≥ K,
     |conjecturedThreshold k 1 - 2/3| < ε
 
-/-!
-## Part VI: Choi-Erdős-Szemerédi Result
-
-Proven upper bound for all k ≥ 3.
--/
+/- ## Part VI: Choi-Erdős-Szemerédi Result -/
 
 /-- **CES Upper Bound (1975):**
 For all k ≥ 3, there exists ε_k > 0 such that
@@ -177,11 +153,7 @@ Note: The conjecture says f_3(N) ≈ (5/8)N < (2/3)N, so CES is weaker. -/
 theorem ces_weaker_than_conjecture :
     (5 : ℚ) / 8 < 2 / 3 := by norm_num
 
-/-!
-## Part VII: Why 5/8?
-
-The geometric reasoning behind the threshold.
--/
+/- ## Part VII: Why 5/8? -/
 
 /-- **Lower Bound Intuition:**
 Taking A = [N/8, N/4] ∪ [N/2, N]:
@@ -195,11 +167,7 @@ axiom lower_bound_cross_sums (N : ℕ) (hN : N ≥ 8) :
               a ≤ N / 4 ∧ b ≥ N / 2 ∧
               N / 2 < a + b ∧ a + b < N
 
-/-!
-## Part VIII: Related Problems
-
-Connections to other Erdős problems.
--/
+/- ## Part VIII: Related Problems -/
 
 /-- **Sum-Free Sets:**
 A is sum-free if no a+b = c with a, b, c ∈ A.
@@ -216,11 +184,7 @@ axiom max_sum_free_size (N : ℕ) : ∃ A : Finset ℕ,
 k-colored without monochromatic x + y = z. Known: S(1)=1, S(2)=4, S(3)=13, S(4)=44. -/
 axiom schurNumber (k : ℕ) : ℕ
 
-/-!
-## Part IX: Main Results
-
-Summary of Erdős Problem #865.
--/
+/- ## Part IX: Main Results -/
 
 /-- **Erdős Problem #865: Summary**
 

--- a/research/candidate-pool.json
+++ b/research/candidate-pool.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "last_updated": "2026-02-07T11:22:00.680Z",
+  "last_updated": "2026-02-07T15:04:11.779Z",
   "source": "auto-generated from research/db/knowledge.db",
   "candidates": [
     {

--- a/src/data/proofs/erdos-865/annotations.json
+++ b/src/data/proofs/erdos-865/annotations.json
@@ -13,7 +13,7 @@
   {
     "id": "ann-e865-predicates",
     "proofId": "erdos-865",
-    "range": { "startLine": 39, "endLine": 58 },
+    "range": { "startLine": 35, "endLine": 54 },
     "type": "definition",
     "title": "Core Predicates",
     "content": "Three predicates formalize the problem:\n\n**HasPairwiseSumTriple(A)**: ∃ distinct a, b, c ∈ A with a+b, a+c, b+c all in A. This is the k=3 case of the general problem.\n\n**HasSumPair(A)**: ∃ distinct a, b ∈ A with a+b ∈ A. The k=2 case, solved classically.\n\n**HasKPairwiseSums(A, k)**: ∃ k distinct elements in A with all C(k,2) pairwise sums in A. The general case for the Erdős-Sós conjecture.",
@@ -24,7 +24,7 @@
   {
     "id": "ann-e865-threshold",
     "proofId": "erdos-865",
-    "range": { "startLine": 66, "endLine": 79 },
+    "range": { "startLine": 58, "endLine": 71 },
     "type": "definition",
     "title": "Threshold Functions and Erdős-Sós Formula",
     "content": "**threshold(k, N)** is axiomatized as the minimum subset size guaranteeing k elements with all pairwise sums in A. This is axiomatized rather than computed because decidability of HasKPairwiseSums is unavailable.\n\n**conjecturedThreshold(k, N)** = (1/2)(1 + Σ_{r=1}^{k-2} 1/4^r) · N is the Erdős-Sós formula. For k=3, this gives (1/2)(1 + 1/4) · N = **(5/8)N**.",
@@ -35,7 +35,7 @@
   {
     "id": "ann-e865-k3",
     "proofId": "erdos-865",
-    "range": { "startLine": 97, "endLine": 131 },
+    "range": { "startLine": 85, "endLine": 115 },
     "type": "axiom",
     "title": "The k=3 Case: 5/8 Conjecture and Lower Bound",
     "content": "**k3_conjecture** states the main conjecture: ∃ C such that |A| ≥ (5/8)N + C forces a pairwise sum triple.\n\n**lowerBoundConstruction(N)** = [N/8, N/4] ∪ [N/2, N] is the extremal example showing 5/8 is best possible. **lower_bound_no_triple** axiomatizes that this construction has no triple. **lower_bound_size** axiomatizes that its size is approximately 5N/8.\n\n**k3_optimal_threshold** asserts f_3(N)/N → 5/8, combining the upper and lower bounds.",
@@ -46,7 +46,7 @@
   {
     "id": "ann-e865-general",
     "proofId": "erdos-865",
-    "range": { "startLine": 133, "endLine": 159 },
+    "range": { "startLine": 117, "endLine": 139 },
     "type": "axiom",
     "title": "Erdős-Sós Conjecture and Limiting Behavior",
     "content": "**erdos_sos_conjecture** states that f_k(N) ~ conjecturedThreshold(k, N) for all k ≥ 2. The specific threshold values are: k=2: 1/2, k=3: 5/8, k=4: 21/32, k=5: 85/128.\n\n**threshold_converges_to_two_thirds** captures the limiting behavior: as k → ∞, the Erdős-Sós threshold approaches 2/3. This follows from the geometric series Σ 1/4^r = 1/3, giving (1/2)(1 + 1/3) = 2/3.",
@@ -57,7 +57,7 @@
   {
     "id": "ann-e865-ces",
     "proofId": "erdos-865",
-    "range": { "startLine": 161, "endLine": 178 },
+    "range": { "startLine": 141, "endLine": 154 },
     "type": "axiom",
     "title": "Choi-Erdős-Szemerédi Upper Bound (1975)",
     "content": "**choi_erdos_szemeredi_bound** is the strongest proven result: for each k ≥ 3, there exists ε_k > 0 such that f_k(N) ≤ (2/3 - ε_k)N for large N. This is weaker than the conjectured 5/8 for k=3.\n\n**ces_weaker_than_conjecture** verifies 5/8 < 2/3 by norm_num, confirming the CES bound doesn't resolve the sharp threshold.",
@@ -68,7 +68,7 @@
   {
     "id": "ann-e865-main",
     "proofId": "erdos-865",
-    "range": { "startLine": 219, "endLine": 249 },
+    "range": { "startLine": 187, "endLine": 213 },
     "type": "theorem",
     "title": "Main Results Summary",
     "content": "**erdos_865_summary** packages the known results into a conjunction: (1) the lower bound construction has no pairwise sum triple, and (2) the CES upper bound f_3(N) ≤ (2/3 - ε)N holds.\n\n**erdos_865** is the main entry-point theorem, proved directly from the summary axiom using `exact erdos_865_summary`. It captures everything that is currently **known** about the problem, while the sharp 5/8 threshold remains **open**.",

--- a/src/data/proofs/erdos-865/meta.json
+++ b/src/data/proofs/erdos-865/meta.json
@@ -73,63 +73,63 @@
       "title": "Basic Definitions",
       "summary": "intervalSet, HasPairwiseSumTriple, HasSumPair, HasKPairwiseSums",
       "startLine": 33,
-      "endLine": 58
+      "endLine": 54
     },
     {
       "id": "threshold-functions",
       "title": "Threshold Functions",
       "summary": "threshold (axiom), conjecturedThreshold, k=3 value",
-      "startLine": 60,
-      "endLine": 79
+      "startLine": 56,
+      "endLine": 71
     },
     {
       "id": "k2-case",
       "title": "The k=2 Case",
       "summary": "Classical folklore result, k2_threshold axiom",
-      "startLine": 81,
-      "endLine": 95
+      "startLine": 73,
+      "endLine": 83
     },
     {
       "id": "k3-case",
       "title": "The k=3 Case",
       "summary": "5/8 conjecture, lower bound construction, optimality",
-      "startLine": 97,
-      "endLine": 131
+      "startLine": 85,
+      "endLine": 115
     },
     {
       "id": "general-conjecture",
       "title": "General Conjecture",
       "summary": "Erdős-Sós conjecture for all k, threshold convergence to 2/3",
-      "startLine": 133,
-      "endLine": 159
+      "startLine": 117,
+      "endLine": 139
     },
     {
       "id": "ces-bound",
       "title": "CES Upper Bound",
       "summary": "Choi-Erdős-Szemerédi (2/3 - ε)N bound, comparison with 5/8",
-      "startLine": 161,
-      "endLine": 178
+      "startLine": 141,
+      "endLine": 154
     },
     {
       "id": "why-5-8",
       "title": "Why 5/8?",
       "summary": "Cross-sum gap argument for the lower bound construction",
-      "startLine": 180,
-      "endLine": 196
+      "startLine": 156,
+      "endLine": 168
     },
     {
       "id": "related-problems",
       "title": "Related Problems",
       "summary": "Sum-free sets, max sum-free size, Schur numbers",
-      "startLine": 198,
-      "endLine": 217
+      "startLine": 170,
+      "endLine": 185
     },
     {
       "id": "main-results",
       "title": "Main Results",
       "summary": "erdos_865_summary axiom, erdos_865 theorem",
-      "startLine": 219,
-      "endLine": 249
+      "startLine": 187,
+      "endLine": 213
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Convert 9 `/-!` docstring headers to `/-` for Aristotle parser compatibility
- Update section line ranges in meta.json (9 sections adjusted)
- Update annotation line ranges in annotations.json (6 annotations adjusted)
- File reduced from 250 to 213 lines

## Test plan
- [x] `pnpm build` passes
- [x] No `/-!` headers remain in Lean file
- [x] Section and annotation line ranges match actual file content

🤖 Generated with [Claude Code](https://claude.com/claude-code)