### PR TITLE
enhance(erdos-1110): fix sorry, align section/annotation ranges

### DIFF
--- a/proofs/Proofs/Erdos1110Problem.lean
+++ b/proofs/Proofs/Erdos1110Problem.lean
@@ -207,22 +207,11 @@ axiom yang_zhao_improved_lower :
 -/
 
 /--
-**Problem #123: Three Powers:**
-The analog with three coprime bases (p, q, r) instead of two.
+**Related Problems:**
+- Problem #123: The analog with three coprime bases (p, q, r)
+- Problem #845: Additional questions about the {2,3} representation
+- Problem #246: Representations without the non-divisibility constraint
 -/
-axiom problem_123_three_powers : True
-
-/--
-**Problem #845: More on {2,3}:**
-Additional questions about the {2,3} representation.
--/
-axiom problem_845_2_3_case : True
-
-/--
-**Problem #246: Without Non-Divisibility:**
-Representations without the constraint that no term divides another.
--/
-axiom problem_246_no_constraint : True
 
 /-
 ## Part VII: Examples

--- a/proofs/Proofs/Erdos1110Problem.lean
+++ b/proofs/Proofs/Erdos1110Problem.lean
@@ -128,8 +128,8 @@ theorem infinitely_many_non_rep (p q : ℕ) (hp : p > q) (hq : q ≥ 2)
     (hcop : Nat.Coprime p q) (hne : ¬((p = 3 ∧ q = 2) ∨ (p = 2 ∧ q = 3))) :
     Set.Infinite (NonRepresentable p q) := by
   have h := erdos_lewin_theorem p q hp hq hcop
-  rw [h] at hne
-  sorry
+  intro hfin
+  exact hne (h.mp hfin)
 
 /-
 ## Part IV: Yu-Chen Results (2022)

--- a/src/data/proofs/erdos-1110/annotations.json
+++ b/src/data/proofs/erdos-1110/annotations.json
@@ -68,7 +68,7 @@
   {
     "id": "ann-1110-erdos-lewin",
     "proofId": "erdos-1110",
-    "range": { "startLine": 114, "endLine": 120 },
+    "range": { "startLine": 115, "endLine": 121 },
     "type": "theorem",
     "title": "Erdős-Lewin Characterization",
     "content": "The fundamental characterization (1996): The set of non-representable numbers is FINITE if and only if {p,q} = {2,3}. All other coprime pairs have infinitely many non-representables.",
@@ -79,7 +79,7 @@
   {
     "id": "ann-1110-density",
     "proofId": "erdos-1110",
-    "range": { "startLine": 137, "endLine": 155 },
+    "range": { "startLine": 138, "endLine": 156 },
     "type": "definition",
     "title": "Natural Density",
     "content": "The natural density d(A) measures the 'proportion' of integers in A. Yu-Chen (2022) proved the non-representables have density ZERO in many cases: q > 3, or q = 3 and p > 6, or q = 2 and p > 10.",
@@ -90,7 +90,7 @@
   {
     "id": "ann-1110-coprime-infinite",
     "proofId": "erdos-1110",
-    "range": { "startLine": 157, "endLine": 170 },
+    "range": { "startLine": 158, "endLine": 171 },
     "type": "theorem",
     "title": "Yu-Chen Coprime Infinitude",
     "content": "Yu-Chen (2022) proved infinitely many COPRIME non-representables exist for most (p,q): q > 3, or q = 3 and p ≠ 5, or q = 2 and p ∉ {3, 5, 9}. This answers one of Erdős's main questions.",
@@ -101,7 +101,7 @@
   {
     "id": "ann-1110-min-summand",
     "proofId": "erdos-1110",
-    "range": { "startLine": 176, "endLine": 193 },
+    "range": { "startLine": 177, "endLine": 203 },
     "type": "theorem",
     "title": "Minimum Summand Bounds",
     "content": "For {2,3}, Erdős-Lewin asked: how large can all summands be? Yu-Chen proved n/(log n)^{log₂3} ≪ f(n) ≪ n/log n. Yang-Zhao (2025) improved the lower bound to f(n) ≫ n/log n, matching the upper bound.",
@@ -112,7 +112,7 @@
   {
     "id": "ann-1110-example",
     "proofId": "erdos-1110",
-    "range": { "startLine": 230, "endLine": 248 },
+    "range": { "startLine": 220, "endLine": 238 },
     "type": "theorem",
     "title": "Example: 1 is Representable",
     "content": "The simplest case: 1 = 3^0 · 2^0. A single-element 'sum' trivially satisfies the non-divisibility constraint. This gives a constructive proof that 1 ∈ Representable.",
@@ -123,7 +123,7 @@
   {
     "id": "ann-1110-summary",
     "proofId": "erdos-1110",
-    "range": { "startLine": 261, "endLine": 291 },
+    "range": { "startLine": 251, "endLine": 292 },
     "type": "theorem",
     "title": "Complete Summary",
     "content": "Erdős Problem #1110: Status OPEN (partially resolved). The {2,3} case is completely solved. For other (p,q): infinitely many non-representables exist (Erdős-Lewin), density zero in many cases (Yu-Chen), infinitely many coprime exceptions for most parameters.",

--- a/src/data/proofs/erdos-1110/meta.json
+++ b/src/data/proofs/erdos-1110/meta.json
@@ -17,7 +17,7 @@
       "density"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1110,
     "erdosUrl": "https://erdosproblems.com/1110",
     "erdosProblemStatus": "open",
@@ -78,7 +78,7 @@
       "title": "Basic Definitions",
       "summary": "Power form p^k q^l, non-divisibility, representability",
       "startLine": 42,
-      "endLine": 77
+      "endLine": 76
     },
     {
       "id": "case-2-3",
@@ -91,43 +91,43 @@
       "id": "general-case",
       "title": "General Case",
       "summary": "Erdős-Lewin theorem: finite exceptions iff {2,3}",
-      "startLine": 110,
+      "startLine": 111,
       "endLine": 132
     },
     {
       "id": "yu-chen",
       "title": "Yu-Chen Results (2022)",
       "summary": "Density zero and coprime infinitude theorems",
-      "startLine": 133,
+      "startLine": 134,
       "endLine": 171
     },
     {
       "id": "minimum-summand",
       "title": "Minimum Summand Size",
       "summary": "Bounds on f(n): how large can summands be?",
-      "startLine": 172,
+      "startLine": 173,
       "endLine": 203
     },
     {
       "id": "related",
       "title": "Related Problems",
       "summary": "Connections to Problems #123, #845, #246",
-      "startLine": 204,
-      "endLine": 225
+      "startLine": 205,
+      "endLine": 214
     },
     {
       "id": "examples",
       "title": "Examples",
       "summary": "Concrete representations for small numbers",
-      "startLine": 226,
-      "endLine": 256
+      "startLine": 216,
+      "endLine": 245
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Problem status and main results",
-      "startLine": 257,
-      "endLine": 298
+      "startLine": 247,
+      "endLine": 294
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Replace `sorry` in `infinitely_many_non_rep` theorem with proper proof derived from `erdos_lewin_theorem`
- Fix misaligned section line ranges in meta.json (8 sections corrected)
- Fix misaligned annotation line ranges in annotations.json (6 annotations corrected)
- Update sorries count from 1 to 0

## Test plan
- [x] `pnpm build` passes
- [x] No `sorry` remains (replaced with `intro hfin; exact hne (h.mp hfin)`)
- [x] Section and annotation line ranges verified against Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)