### PR TITLE
enhance(erdos-43): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos43Problem.lean
+++ b/proofs/Proofs/Erdos43Problem.lean
@@ -1,0 +1,103 @@
+/-!
+# Erdős Problem #43: Sidon Sets with Disjoint Difference Sets
+
+If A, B ⊆ {1,...,N} are Sidon sets with (A-A) ∩ (B-B) = {0},
+must C(|A|,2) + C(|B|,2) ≤ C(f(N),2) + O(1), where f(N) is
+the maximum Sidon set size in {1,...,N}?
+
+## Status: OPEN ($100 bounty)
+
+## References
+- Erdős
+- Tao (partial progress)
+- Barreto (negative answer to equal-size variant)
+-/
+
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Int.Basic
+import Mathlib.Data.Real.Basic
+import Mathlib.Data.Real.Sqrt
+import Mathlib.Tactic
+
+/-!
+## Section I: Sidon Sets
+-/
+
+/-- A Sidon set (B₂ set): all pairwise sums a + b (a ≤ b, a,b ∈ A) are distinct,
+equivalently all nonzero pairwise differences are distinct. -/
+def IsSidonSet (A : Finset ℤ) : Prop :=
+  ∀ a₁ b₁ a₂ b₂ : ℤ, a₁ ∈ A → b₁ ∈ A → a₂ ∈ A → b₂ ∈ A →
+    a₁ + b₁ = a₂ + b₂ → ({a₁, b₁} : Finset ℤ) = {a₂, b₂}
+
+/-- The difference set A - A = { a - b | a, b ∈ A }. -/
+def diffSet (A : Finset ℤ) : Finset ℤ :=
+  (A ×ˢ A).image (fun p => p.1 - p.2)
+
+/-!
+## Section II: Disjoint Differences
+-/
+
+/-- Two sets have disjoint nonzero differences: (A-A) ∩ (B-B) = {0}. -/
+def DisjointDifferences (A B : Finset ℤ) : Prop :=
+  ∀ d : ℤ, d ∈ diffSet A → d ∈ diffSet B → d = 0
+
+/-!
+## Section III: Maximum Sidon Set Size
+-/
+
+/-- f(N): the maximum cardinality of a Sidon set in {1,...,N}. -/
+axiom maxSidonSize : ℕ → ℕ
+
+/-- f(N) ~ √N: the maximum Sidon set size is asymptotically √N. -/
+axiom sidon_size_asymptotic :
+  ∀ ε : ℝ, ε > 0 → ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ →
+    |(maxSidonSize N : ℝ) - Real.sqrt N| ≤ ε * Real.sqrt N
+
+/-!
+## Section IV: The Conjecture
+-/
+
+/-- **Erdős Problem #43**: If A, B are Sidon sets in {1,...,N} with
+disjoint nonzero differences, then C(|A|,2) + C(|B|,2) ≤ C(f(N),2) + O(1). -/
+def ErdosProblem43 : Prop :=
+  ∃ C : ℕ, ∀ N : ℕ, ∀ A B : Finset ℤ,
+    IsSidonSet A → IsSidonSet B →
+    (∀ a ∈ A, 1 ≤ a ∧ a ≤ N) → (∀ b ∈ B, 1 ≤ b ∧ b ≤ N) →
+    DisjointDifferences A B →
+    A.card.choose 2 + B.card.choose 2 ≤ (maxSidonSize N).choose 2 + C
+
+/-!
+## Section V: Equal Size Variant
+-/
+
+/-- The equal-size strengthening: when |A| = |B|, can we get
+C(|A|,2) + C(|B|,2) ≤ (1 - c)·C(f(N),2) for some c > 0?
+Barreto showed this is FALSE for infinitely many N. -/
+def EqualSizeVariant : Prop :=
+  ∃ c : ℝ, c > 0 ∧ ∀ N : ℕ, ∀ A B : Finset ℤ,
+    IsSidonSet A → IsSidonSet B →
+    (∀ a ∈ A, 1 ≤ a ∧ a ≤ N) → (∀ b ∈ B, 1 ≤ b ∧ b ≤ N) →
+    DisjointDifferences A B → A.card = B.card →
+    (A.card.choose 2 + B.card.choose 2 : ℝ) ≤ (1 - c) * (maxSidonSize N).choose 2
+
+/-- Barreto's result: the equal-size variant is false. -/
+axiom barreto_counterexample : ¬EqualSizeVariant
+
+/-!
+## Section VI: Structural Bounds
+-/
+
+/-- A single Sidon set A in {1,...,N} has C(|A|,2) ≤ N. -/
+axiom sidon_pair_bound (A : Finset ℤ) (N : ℕ)
+    (hS : IsSidonSet A) (hR : ∀ a ∈ A, 1 ≤ a ∧ a ≤ N) :
+  A.card.choose 2 ≤ N
+
+/-- Disjoint differences force A ∪ B to have distinct nonzero
+differences, bounding the combined size. -/
+axiom disjoint_diff_combined_bound (A B : Finset ℤ) (N : ℕ)
+    (hA : IsSidonSet A) (hB : IsSidonSet B)
+    (hRA : ∀ a ∈ A, 1 ≤ a ∧ a ≤ N) (hRB : ∀ b ∈ B, 1 ≤ b ∧ b ≤ N)
+    (hD : DisjointDifferences A B) :
+  A.card.choose 2 + B.card.choose 2 ≤ N

--- a/proofs/Proofs/Erdos43Problem.lean
+++ b/proofs/Proofs/Erdos43Problem.lean
@@ -1,4 +1,4 @@
-/-!
+/-
 # Erdős Problem #43: Sidon Sets with Disjoint Difference Sets
 
 If A, B ⊆ {1,...,N} are Sidon sets with (A-A) ∩ (B-B) = {0},
@@ -21,7 +21,7 @@ import Mathlib.Data.Real.Basic
 import Mathlib.Data.Real.Sqrt
 import Mathlib.Tactic
 
-/-!
+/-
 ## Section I: Sidon Sets
 -/
 
@@ -35,7 +35,7 @@ def IsSidonSet (A : Finset ℤ) : Prop :=
 def diffSet (A : Finset ℤ) : Finset ℤ :=
   (A ×ˢ A).image (fun p => p.1 - p.2)
 
-/-!
+/-
 ## Section II: Disjoint Differences
 -/
 
@@ -43,7 +43,7 @@ def diffSet (A : Finset ℤ) : Finset ℤ :=
 def DisjointDifferences (A B : Finset ℤ) : Prop :=
   ∀ d : ℤ, d ∈ diffSet A → d ∈ diffSet B → d = 0
 
-/-!
+/-
 ## Section III: Maximum Sidon Set Size
 -/
 
@@ -55,7 +55,7 @@ axiom sidon_size_asymptotic :
   ∀ ε : ℝ, ε > 0 → ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ →
     |(maxSidonSize N : ℝ) - Real.sqrt N| ≤ ε * Real.sqrt N
 
-/-!
+/-
 ## Section IV: The Conjecture
 -/
 
@@ -68,7 +68,7 @@ def ErdosProblem43 : Prop :=
     DisjointDifferences A B →
     A.card.choose 2 + B.card.choose 2 ≤ (maxSidonSize N).choose 2 + C
 
-/-!
+/-
 ## Section V: Equal Size Variant
 -/
 
@@ -85,7 +85,7 @@ def EqualSizeVariant : Prop :=
 /-- Barreto's result: the equal-size variant is false. -/
 axiom barreto_counterexample : ¬EqualSizeVariant
 
-/-!
+/-
 ## Section VI: Structural Bounds
 -/
 

--- a/src/data/proofs/erdos-43/annotations.json
+++ b/src/data/proofs/erdos-43/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "erdos-43-sidon",
+    "proofId": "erdos-43",
+    "type": "definition",
+    "range": { "startLine": 27, "endLine": 35 },
+    "title": "Sidon Sets and Difference Sets",
+    "content": "IsSidonSet requires distinct pairwise sums. diffSet A computes {a - b | a,b ∈ A}.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-43-disjoint",
+    "proofId": "erdos-43",
+    "type": "definition",
+    "range": { "startLine": 41, "endLine": 43 },
+    "title": "Disjoint Differences",
+    "content": "DisjointDifferences A B holds when the nonzero elements of A-A and B-B are disjoint.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-43-conjecture",
+    "proofId": "erdos-43",
+    "type": "conjecture",
+    "range": { "startLine": 63, "endLine": 70 },
+    "title": "Erdős Problem 43",
+    "content": "Must C(|A|,2) + C(|B|,2) ≤ C(f(N),2) + O(1) for Sidon sets with disjoint differences? $100 bounty.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-43-equal",
+    "proofId": "erdos-43",
+    "type": "result",
+    "range": { "startLine": 79, "endLine": 87 },
+    "title": "Equal Size Variant Disproved",
+    "content": "The strengthening with |A| = |B| and constant improvement factor (1-c) is false. Barreto provided counterexamples.",
+    "significance": "essential"
+  },
+  {
+    "id": "erdos-43-asymptotic",
+    "proofId": "erdos-43",
+    "type": "result",
+    "range": { "startLine": 54, "endLine": 57 },
+    "title": "f(N) ~ √N",
+    "content": "The maximum Sidon set size in {1,...,N} is asymptotically √N.",
+    "significance": "supporting"
+  },
+  {
+    "id": "erdos-43-pairbound",
+    "proofId": "erdos-43",
+    "type": "result",
+    "range": { "startLine": 93, "endLine": 104 },
+    "title": "Pair Count Bounds",
+    "content": "Each Sidon set has C(|A|,2) ≤ N; disjoint differences give C(|A|,2) + C(|B|,2) ≤ N.",
+    "significance": "supporting"
+  }
+]

--- a/src/data/proofs/erdos-43/index.ts
+++ b/src/data/proofs/erdos-43/index.ts
@@ -1,0 +1,28 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+const meta = metaJson as {
+  id: string; title: string; slug: string; description: string
+  meta: ProofMeta; sections: ProofSection[]
+  overview?: ProofOverview; conclusion?: ProofConclusion
+}
+
+const leanSource = () => import('../../../../proofs/Proofs/Erdos43Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id, title: meta.title, slug: meta.slug,
+  description: meta.description, meta: meta.meta,
+  sections: meta.sections, source: '',
+  overview: meta.overview, conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+export const proofData: ProofData = { proof, annotations }
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-43/meta.json
+++ b/src/data/proofs/erdos-43/meta.json
@@ -1,0 +1,82 @@
+{
+  "id": "erdos-43",
+  "title": "Erdős Problem #43: Sidon Sets with Disjoint Difference Sets",
+  "slug": "erdos-43",
+  "description": "If A, B are Sidon sets in {1,...,N} with (A-A) ∩ (B-B) = {0}, must C(|A|,2) + C(|B|,2) ≤ C(f(N),2) + O(1)? OPEN ($100).",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/43",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos43Problem.lean",
+    "tags": ["number-theory", "additive-combinatorics", "sidon-sets"],
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 43,
+    "erdosUrl": "https://erdosproblems.com/43",
+    "erdosProblemStatus": "open"
+  },
+  "overview": {
+    "historicalContext": "Erdős posed this question about Sidon sets with disjoint difference sets, offering a $100 bounty. Tao proved partial results for the equal-size case, and Barreto showed the equal-size strengthening with a constant improvement factor is false.",
+    "problemStatement": "If A, B ⊆ {1,...,N} are Sidon sets with (A-A) ∩ (B-B) = {0}, must C(|A|,2) + C(|B|,2) ≤ C(f(N),2) + O(1), where f(N) ~ √N is the maximum Sidon set size?",
+    "proofStrategy": "We define IsSidonSet, diffSet, DisjointDifferences, and axiomatize maxSidonSize with the asymptotic f(N) ~ √N. ErdosProblem43 states the main bound. The EqualSizeVariant (with constant improvement) is stated and shown false by Barreto. Combined pair bounds are axiomatized.",
+    "keyInsights": [
+      "Disjoint nonzero differences force the difference sets to partition available residues",
+      "f(N) ~ √N is the asymptotic maximum Sidon set size in {1,...,N}",
+      "The equal-size variant with constant factor improvement is false (Barreto)",
+      "Each Sidon set satisfies C(|A|,2) ≤ N from distinct differences"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sidon-sets",
+      "title": "Sidon Sets",
+      "startLine": 23,
+      "endLine": 35,
+      "summary": "Defines IsSidonSet (distinct pairwise sums) and diffSet (difference set A - A)."
+    },
+    {
+      "id": "disjoint-diff",
+      "title": "Disjoint Differences",
+      "startLine": 37,
+      "endLine": 43,
+      "summary": "Defines DisjointDifferences: nonzero elements of A-A and B-B are disjoint."
+    },
+    {
+      "id": "max-sidon",
+      "title": "Maximum Sidon Set Size",
+      "startLine": 45,
+      "endLine": 57,
+      "summary": "Axiomatizes maxSidonSize and the asymptotic f(N) ~ √N."
+    },
+    {
+      "id": "conjecture",
+      "title": "The Conjecture",
+      "startLine": 59,
+      "endLine": 70,
+      "summary": "States ErdosProblem43: the sum of pair counts is bounded by C(f(N),2) + O(1)."
+    },
+    {
+      "id": "equal-size",
+      "title": "Equal Size Variant",
+      "startLine": 72,
+      "endLine": 87,
+      "summary": "The equal-size strengthening with constant factor is false (Barreto)."
+    },
+    {
+      "id": "bounds",
+      "title": "Structural Bounds",
+      "startLine": 89,
+      "endLine": 104,
+      "summary": "Sidon pair bound C(|A|,2) ≤ N and combined bound under disjoint differences."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős Problem 43 asks whether two Sidon sets with disjoint nonzero differences satisfy a combined pair count bound of C(f(N),2) + O(1). The equal-size improvement variant was disproved by Barreto. The main conjecture remains open with a $100 bounty.",
+    "implications": "Resolution would clarify the structure theory of Sidon sets and the extent to which disjoint difference constraints limit combined sizes.",
+    "openQuestions": [
+      "Does C(|A|,2) + C(|B|,2) ≤ C(f(N),2) + O(1) hold?",
+      "What is the tightest constant in the O(1) term?",
+      "Can Tao's partial results be extended to the full conjecture?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Replace `/-!` section headers with `/-` for Aristotle proof search parser compatibility
- 7 headers fixed (1 title + 6 section headers)

## Test plan
- [x] `pnpm build` passes
- [x] No `/-!` patterns remain in file

🤖 Generated with [Claude Code](https://claude.com/claude-code)