### PR TITLE
enhance(erdos-54): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos54Problem.lean
+++ b/proofs/Proofs/Erdos54Problem.lean
@@ -1,4 +1,4 @@
-/-!
+/-
 # Erdős Problem 54: Ramsey 2-Complete Sets
 
 A set `A ⊆ ℕ` is **Ramsey 2-complete** if for every 2-colouring of `A`,
@@ -22,7 +22,7 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Data.Set.Basic
 import Mathlib.Tactic
 
-/-! ## Monochromatic subset sums -/
+/- ## Monochromatic subset sums -/
 
 /-- A 2-colouring of a set `A`. -/
 def Colouring2 (A : Set ℕ) := { n : ℕ // n ∈ A } → Bool
@@ -33,7 +33,7 @@ def monoSubsetSums (A : Set ℕ) (c : Colouring2 A) (colour : Bool) : Set ℕ :=
       (∀ n ∈ S, n ∈ A ∧ c ⟨n, ‹_›⟩ = colour) ∧
       S.sum id = s }
 
-/-! ## Ramsey 2-completeness -/
+/- ## Ramsey 2-completeness -/
 
 /-- `A` is Ramsey 2-complete if for every 2-colouring, all large
 integers are monochromatic subset sums. -/
@@ -43,13 +43,13 @@ def IsRamsey2Complete (A : Set ℕ) : Prop :=
         ∃ m : ℕ, ∀ n : ℕ, m ≤ n →
           n ∈ monoSubsetSums A c colour
 
-/-! ## Counting function -/
+/- ## Counting function -/
 
 /-- `|A ∩ {1,…,N}|`. -/
 noncomputable def countingFn (A : Set ℕ) (N : ℕ) : ℕ :=
     ((Finset.Icc 1 N).filter (· ∈ A)).card
 
-/-! ## Burr–Erdős lower bound -/
+/- ## Burr–Erdős lower bound -/
 
 /-- Burr–Erdős (1985): No Ramsey 2-complete set can be too sparse.
 There exists `c > 0` such that no Ramsey 2-complete `A` has
@@ -60,7 +60,7 @@ axiom burr_erdos_lower :
         ∀ N₀ : ℕ, ∃ N : ℕ, N₀ ≤ N ∧
           c * ((Nat.log 2 N : ℚ)) ^ 2 ≤ (countingFn A N : ℚ)
 
-/-! ## Conlon–Fox–Pham upper bound -/
+/- ## Conlon–Fox–Pham upper bound -/
 
 /-- Conlon–Fox–Pham (2021): There exists a Ramsey 2-complete set
 with `|A ∩ [1,N]| ≪ (log N)²`. -/
@@ -70,7 +70,7 @@ axiom conlon_fox_pham :
         ∃ N₀ : ℕ, ∀ N : ℕ, N₀ ≤ N →
           (countingFn A N : ℚ) ≤ C * ((Nat.log 2 N : ℚ)) ^ 2
 
-/-! ## Main problem (solved) -/
+/- ## Main problem (solved) -/
 
 /-- Erdős Problem 54 (solved): The minimum growth rate of a Ramsey
 2-complete set is `Θ((log N)²)`. -/
@@ -84,7 +84,7 @@ def ErdosProblem54 : Prop :=
         ∃ N₀ : ℕ, ∀ N : ℕ, N₀ ≤ N →
           (countingFn A N : ℚ) ≤ C * ((Nat.log 2 N : ℚ)) ^ 2)
 
-/-! ## Earlier upper bound -/
+/- ## Earlier upper bound -/
 
 /-- Burr–Erdős (1985): There exists a Ramsey 2-complete set with
 `|A ∩ [1,N]| < (2 log₂ N)³`. This was improved by Conlon–Fox–Pham. -/


### PR DESCRIPTION
## Summary
- Replace `/-!` section headers with `/-` for Aristotle proof search parser compatibility
- 8 headers fixed (1 title + 7 section headers)

## Test plan
- [x] `pnpm build` passes
- [x] No `/-!` patterns remain in file

🤖 Generated with [Claude Code](https://claude.com/claude-code)