### PR TITLE
enhance(erdos-56): fix /-! headers for Aristotle compatibility

### DIFF
--- a/proofs/Proofs/Erdos56Problem.lean
+++ b/proofs/Proofs/Erdos56Problem.lean
@@ -24,7 +24,7 @@ open scoped Finset
 
 namespace Erdos56
 
-/-!
+/-
 ## Definitions
 
 We formalize the notion of "k-weakly divisible" sets and the key quantities
@@ -74,7 +74,7 @@ This is Erdős's conjectured optimal set: take all multiples of p₁, p₂, ...,
 noncomputable def FirstPrimesMultiples (N k : ℕ) : Finset ℕ :=
   (Finset.Icc 1 N).filter fun i => ∃ j < k, (j.nth Nat.Prime ∣ i)
 
-/-!
+/-
 ## The Main Result
 
 Erdős conjectured that FirstPrimesMultiples is always optimal. This was
@@ -102,7 +102,7 @@ axiom erdos_56_disproved :
     ∀ N : ℕ, N ≥ (k - 1).nth Nat.Prime →
     MaxWeaklyDivisible N k = (FirstPrimesMultiples N k).card)
 
-/-!
+/-
 ## Verified Examples
 
 We verify some basic cases to build intuition.


### PR DESCRIPTION
## Summary
- Replace `/-!` section headers with `/-` for Aristotle proof search parser compatibility
- 3 section headers fixed

## Test plan
- [x] `pnpm build` passes
- [x] No `/-!` patterns remain in file

🤖 Generated with [Claude Code](https://claude.com/claude-code)