### PR TITLE
enhance(erdos-525): replace True placeholder in IsRudinShapiro definition

### DIFF
--- a/proofs/Proofs/Erdos525Problem.lean
+++ b/proofs/Proofs/Erdos525Problem.lean
@@ -142,11 +142,12 @@ axiom cook_nguyen_distribution :
 ## Part VII: Special Cases and Examples
 -/
 
-/-- The Rudin-Shapiro polynomials have particularly nice behavior -/
+/-- The Rudin-Shapiro polynomials have particularly nice behavior.
+    They are Littlewood polynomials of degree 2^n - 1 satisfying a flat bound
+    on the unit circle: |p(z)| ≤ √(2^(n+1)) for all |z| = 1. -/
 def IsRudinShapiro (p : Polynomial ℂ) (n : ℕ) : Prop :=
   p.natDegree = 2^n - 1 ∧ IsLittlewoodPolynomial p ∧
-  -- The defining recurrence relation
-  True  -- Simplified
+  ∀ z ∈ UnitCircle, abs (p.eval z) ≤ Real.sqrt (2^(n+1))
 
 /-- Rudin-Shapiro polynomials satisfy |p(z)| ≤ √(2n) on the unit circle -/
 axiom rudin_shapiro_bound (p : Polynomial ℂ) (n : ℕ) (z : ℂ) :

--- a/research/candidate-pool.json
+++ b/research/candidate-pool.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "last_updated": "2026-02-07T15:04:11.779Z",
+  "last_updated": "2026-02-07T18:05:46.961Z",
   "source": "auto-generated from research/db/knowledge.db",
   "candidates": [
     {

--- a/src/data/proofs/erdos-525/annotations.json
+++ b/src/data/proofs/erdos-525/annotations.json
@@ -111,16 +111,16 @@
     "id": "rudin-shapiro",
     "proofId": "erdos-525",
     "type": "definition",
-    "range": { "startLine": 143, "endLine": 151 },
+    "range": { "startLine": 145, "endLine": 150 },
     "title": "Rudin-Shapiro Polynomials",
-    "content": "Special Littlewood polynomials defined by a recurrence. They have flat modulus - |p(z)| ≤ √(2n) on the unit circle.",
+    "content": "Special Littlewood polynomials of degree 2^n - 1 satisfying a flat bound: |p(z)| ≤ √(2^(n+1)) on the unit circle.",
     "significance": "supporting"
   },
   {
     "id": "mahler-measure",
     "proofId": "erdos-525",
     "type": "definition",
-    "range": { "startLine": 165, "endLine": 168 },
+    "range": { "startLine": 167, "endLine": 170 },
     "title": "Mahler Measure",
     "content": "M(p) = exp(∫ log|p(e^{2πit})| dt) - the geometric mean of |p| on the unit circle. Related to m(p) and connects to Lehmer's problem.",
     "significance": "supporting"
@@ -129,7 +129,7 @@
     "id": "lehmer-question",
     "proofId": "erdos-525",
     "type": "concept",
-    "range": { "startLine": 175, "endLine": 177 },
+    "range": { "startLine": 177, "endLine": 179 },
     "title": "Lehmer's Problem",
     "content": "Is there a Littlewood polynomial with M(p) < 1? This is related to Lehmer's conjecture on polynomial heights.",
     "significance": "supporting"
@@ -138,7 +138,7 @@
     "id": "main-summary",
     "proofId": "erdos-525",
     "type": "theorem",
-    "range": { "startLine": 202, "endLine": 220 },
+    "range": { "startLine": 204, "endLine": 225 },
     "title": "Complete Solution",
     "content": "Summary theorem: Littlewood's conjecture is true (Kashin), the correct exponent is -1/2 (Konyagin), and the exact limiting distribution is e^{-ελ} (Cook-Nguyen).",
     "significance": "critical"

--- a/src/data/proofs/erdos-525/meta.json
+++ b/src/data/proofs/erdos-525/meta.json
@@ -132,21 +132,21 @@
       "title": "Special Cases and Examples",
       "summary": "IsRudinShapiro, AllOnesPolynomial, rudin_shapiro_bound",
       "startLine": 139,
-      "endLine": 159
+      "endLine": 161
     },
     {
       "id": "connections",
       "title": "Connection to Other Problems",
       "summary": "MahlerMeasure, LehmerQuestion definitions",
-      "startLine": 161,
-      "endLine": 177
+      "startLine": 163,
+      "endLine": 179
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_525_main, erdos_525_answer theorems",
-      "startLine": 179,
-      "endLine": 220
+      "startLine": 181,
+      "endLine": 227
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Replace `True -- Simplified` placeholder in `IsRudinShapiro` definition with the actual flat bound property: `∀ z ∈ UnitCircle, abs (p.eval z) ≤ Real.sqrt (2^(n+1))`
- Update annotation and section line ranges in meta.json and annotations.json

## Test plan
- [x] `pnpm build` passes
- [x] No remaining quality issues (`True`, `/-!`, `sorry` placeholders)