### PR TITLE
Enhance Erdős #525: Littlewood Polynomials - improve annotations

### DIFF
--- a/src/data/proofs/erdos-525/annotations.json
+++ b/src/data/proofs/erdos-525/annotations.json
@@ -1,146 +1,123 @@
 [
   {
-    "id": "header-comment",
+    "id": "ann-e525-header",
     "proofId": "erdos-525",
     "type": "concept",
-    "range": { "startLine": 1, "endLine": 29 },
+    "range": { "startLine": 1, "endLine": 30 },
     "title": "Problem Overview",
-    "content": "Erdős Problem #525 asks about the minimum modulus m(f) = min_{|z|=1} |f(z)| for Littlewood polynomials (±1 coefficients). Complete resolution: m(f) ≈ n^{-1/2} with explicit limiting distribution (Cook-Nguyen 2021).",
-    "significance": "critical"
+    "content": "Erdős Problem #525 asks about the minimum modulus m(f) = min_{|z|=1} |f(z)| for Littlewood polynomials (polynomials with ±1 coefficients). The problem has been completely resolved through a series of landmark results spanning 55 years.",
+    "mathContext": "Littlewood polynomials f(z) = Σ aₖzᵏ where each aₖ ∈ {-1, +1} are fundamental objects in harmonic analysis. The minimum modulus m(f) measures how close f gets to zero on the unit circle.",
+    "significance": "critical",
+    "relatedConcepts": ["littlewood-polynomials", "minimum-modulus", "unit-circle", "random-polynomials"]
   },
   {
-    "id": "littlewood-def",
+    "id": "ann-e525-littlewood-def",
     "proofId": "erdos-525",
     "type": "definition",
-    "range": { "startLine": 47, "endLine": 49 },
+    "range": { "startLine": 47, "endLine": 53 },
     "title": "Littlewood Polynomials",
-    "content": "A Littlewood polynomial has all coefficients in {-1, +1}. These are also called flat polynomials or Rademacher polynomials.",
-    "significance": "critical"
+    "content": "A Littlewood polynomial has all coefficients in {-1, +1}. These are also called flat polynomials or Rademacher polynomials. There are exactly 2^(n+1) such polynomials of degree n.",
+    "mathContext": "The definition IsLittlewoodPolynomial checks that every coefficient up to the degree is ±1. LittlewoodPolynomials(n) collects all degree-n Littlewood polynomials as a set.",
+    "significance": "critical",
+    "relatedConcepts": ["polynomial-coefficients", "rademacher-random-variables", "combinatorics"]
   },
   {
-    "id": "unit-circle",
+    "id": "ann-e525-min-modulus",
     "proofId": "erdos-525",
     "type": "definition",
-    "range": { "startLine": 59, "endLine": 60 },
-    "title": "Unit Circle",
-    "content": "The unit circle {z ∈ ℂ : |z| = 1} is the domain on which we study the minimum modulus.",
-    "significance": "key"
+    "range": { "startLine": 59, "endLine": 64 },
+    "title": "Unit Circle and Minimum Modulus",
+    "content": "The unit circle {z ∈ ℂ : |z| = 1} is the domain of study. The minimum modulus m(f) = inf_{|z|=1} |f(z)| measures the closest approach of f to zero on the unit circle.",
+    "mathContext": "minModulus is defined as the infimum (greatest lower bound) of |f(z)| over all z on the unit circle. Since the unit circle is compact and |f| is continuous, this infimum is attained.",
+    "significance": "critical",
+    "relatedConcepts": ["unit-circle", "infimum", "complex-analysis", "continuous-functions"]
   },
   {
-    "id": "min-modulus",
+    "id": "ann-e525-almost-all",
     "proofId": "erdos-525",
-    "type": "definition",
-    "range": { "startLine": 62, "endLine": 64 },
-    "title": "Minimum Modulus",
-    "content": "m(f) = min_{|z|=1} |f(z)| - the smallest absolute value of the polynomial on the unit circle. This is the central quantity of the problem.",
-    "significance": "critical"
-  },
-  {
-    "id": "almost-all-small",
-    "proofId": "erdos-525",
-    "type": "theorem",
-    "range": { "startLine": 78, "endLine": 82 },
+    "type": "axiom",
+    "range": { "startLine": 70, "endLine": 84 },
     "title": "Almost All Have m(f) < 1",
-    "content": "All except o(2^n) Littlewood polynomials of degree n have m(f) < 1. This answers the first question affirmatively.",
-    "significance": "key"
+    "content": "The first question is answered affirmatively: all except o(2^n) Littlewood polynomials of degree n have |f(z)| < 1 for some z on the unit circle. This means the 'exceptional' set is negligible.",
+    "mathContext": "HasSmallValue(p) means ∃ z on the unit circle with |p(z)| < 1. The axiom almost_all_small states that the count of exceptions grows slower than 2^n (the total count).",
+    "significance": "key",
+    "relatedConcepts": ["probability", "asymptotic-density", "o-notation"]
   },
   {
-    "id": "littlewood-conjecture",
+    "id": "ann-e525-kashin",
     "proofId": "erdos-525",
-    "type": "definition",
-    "range": { "startLine": 88, "endLine": 92 },
-    "title": "Littlewood's Conjecture",
-    "content": "Littlewood (1966) conjectured m(f) → 0 in probability as n → ∞. That is, for any ε > 0, almost all polynomials have m(f) < ε.",
-    "significance": "critical"
+    "type": "axiom",
+    "range": { "startLine": 86, "endLine": 97 },
+    "title": "Littlewood's Conjecture and Kashin's Theorem",
+    "content": "Littlewood (1966) conjectured that m(f) → 0 in probability as n → ∞. Kashin proved this in 1987: for any ε > 0, almost all Littlewood polynomials of large degree have m(f) < ε.",
+    "mathContext": "LittlewoodConjecture formalizes convergence in probability: for any ε, δ > 0, eventually the fraction of polynomials with m(f) > ε is less than δ. kashin_theorem asserts this holds.",
+    "significance": "critical",
+    "relatedConcepts": ["convergence-in-probability", "random-trigonometric-polynomials", "littlewood-conjecture"]
   },
   {
-    "id": "kashin-theorem",
+    "id": "ann-e525-konyagin",
     "proofId": "erdos-525",
-    "type": "theorem",
-    "range": { "startLine": 94, "endLine": 95 },
-    "title": "Kashin's Theorem",
-    "content": "Kashin (1987): Littlewood's conjecture is TRUE. The minimum modulus tends to 0 in probability.",
-    "significance": "critical"
+    "type": "axiom",
+    "range": { "startLine": 99, "endLine": 112 },
+    "title": "Konyagin's Optimal Bound",
+    "content": "Konyagin (1994) proved the sharp bound m(f) ≤ n^{-1/2+o(1)} almost surely, pinning down the correct rate of decay. The companion result shows the exponent -1/2 cannot be improved.",
+    "mathContext": "konyagin_upper_bound gives the upper bound and konyagin_exponent_tight shows it is essentially optimal. Together they establish m(f) = Θ(n^{-1/2}) in a probabilistic sense.",
+    "significance": "critical",
+    "relatedConcepts": ["sharp-bounds", "exponent-optimization", "probabilistic-method"]
   },
   {
-    "id": "konyagin-bound",
+    "id": "ann-e525-konyagin-schlag",
     "proofId": "erdos-525",
-    "type": "theorem",
-    "range": { "startLine": 101, "endLine": 105 },
-    "title": "Konyagin's Upper Bound",
-    "content": "Konyagin (1994): m(f) ≤ n^{-1/2+o(1)} almost surely. This gives the correct order of magnitude - the minimum modulus decays like 1/√n.",
-    "significance": "critical"
-  },
-  {
-    "id": "konyagin-tight",
-    "proofId": "erdos-525",
-    "type": "theorem",
-    "range": { "startLine": 107, "endLine": 110 },
-    "title": "Exponent -1/2 is Tight",
-    "content": "The exponent -1/2 cannot be improved - the minimum modulus is typically Θ(n^{-1/2}).",
-    "significance": "key"
-  },
-  {
-    "id": "konyagin-schlag",
-    "proofId": "erdos-525",
-    "type": "theorem",
-    "range": { "startLine": 116, "endLine": 120 },
+    "type": "axiom",
+    "range": { "startLine": 114, "endLine": 122 },
     "title": "Konyagin-Schlag Lower Tail",
-    "content": "Konyagin-Schlag (1999): The lower tail is thin. P(m(f) ≤ εn^{-1/2}) ≪ ε. Very few polynomials have unusually small minimum modulus.",
-    "significance": "key"
+    "content": "Konyagin-Schlag (1999) proved that the probability of m(f) being much smaller than n^{-1/2} is proportional to ε. This 'thin lower tail' result was a key step toward the exact distribution.",
+    "mathContext": "The axiom states: for any ε > 0, the fraction of polynomials with m(f) ≤ εn^{-1/2} is at most Cε for some constant C. This gives precise control over the lower tail.",
+    "significance": "key",
+    "relatedConcepts": ["tail-bounds", "probability-distribution", "small-ball-probability"]
   },
   {
-    "id": "cook-nguyen-lambda",
+    "id": "ann-e525-cook-nguyen",
+    "proofId": "erdos-525",
+    "type": "axiom",
+    "range": { "startLine": 124, "endLine": 139 },
+    "title": "Cook-Nguyen Exact Distribution",
+    "content": "Cook-Nguyen (2021) identified the exact limiting distribution: P(m(f) > εn^{-1/2}) → e^{-ελ} as n → ∞. This is a striking universality result - the distribution doesn't depend on the specific ±1 coefficient scheme.",
+    "mathContext": "cook_nguyen_lambda is an explicit constant and cook_nguyen_distribution formalizes the convergence. The exponential form e^{-ελ} is reminiscent of Gumbel-type extreme value distributions.",
+    "significance": "critical",
+    "relatedConcepts": ["universality", "extreme-value-theory", "limiting-distribution", "exponential-distribution"]
+  },
+  {
+    "id": "ann-e525-rudin-shapiro",
     "proofId": "erdos-525",
     "type": "definition",
-    "range": { "startLine": 126, "endLine": 127 },
-    "title": "Cook-Nguyen Constant λ",
-    "content": "The explicit constant λ appearing in the limiting distribution. Its value can be computed from the theory.",
-    "significance": "key"
+    "range": { "startLine": 141, "endLine": 162 },
+    "title": "Rudin-Shapiro Polynomials and All-Ones Polynomial",
+    "content": "Rudin-Shapiro polynomials are special Littlewood polynomials with a flat bound |p(z)| ≤ √(2^(n+1)) on the unit circle. The all-ones polynomial 1 + z + ... + z^n provides a concrete example with minimum modulus 1/(n+1).",
+    "mathContext": "IsRudinShapiro combines being Littlewood with degree 2^n - 1 and the flat bound. AllOnesPolynomial is the simplest Littlewood polynomial, with minimum modulus decaying as 1/n.",
+    "significance": "supporting",
+    "relatedConcepts": ["rudin-shapiro-polynomials", "flat-polynomials", "geometric-series"]
   },
   {
-    "id": "cook-nguyen-distribution",
+    "id": "ann-e525-mahler",
+    "proofId": "erdos-525",
+    "type": "definition",
+    "range": { "startLine": 164, "endLine": 180 },
+    "title": "Mahler Measure and Lehmer's Problem",
+    "content": "The Mahler measure M(p) = exp(∫ log|p(e^{2πit})| dt) is the geometric mean of |p| on the unit circle. For Littlewood polynomials, M(p) ≥ 1 implies m(p) ≤ M(p), connecting to Lehmer's famous conjecture.",
+    "mathContext": "MahlerMeasure is defined via integration of log|p| over the unit circle. Lehmer's problem asks whether there exist polynomials with M(p) arbitrarily close to 1, a major open question in number theory.",
+    "significance": "supporting",
+    "relatedConcepts": ["mahler-measure", "lehmer-conjecture", "number-theory", "algebraic-integers"]
+  },
+  {
+    "id": "ann-e525-summary",
     "proofId": "erdos-525",
     "type": "theorem",
-    "range": { "startLine": 129, "endLine": 137 },
-    "title": "Cook-Nguyen Distribution",
-    "content": "Cook-Nguyen (2021): The exact limiting distribution is lim P(m(f) > εn^{-1/2}) = e^{-ελ}. This is a remarkable universality result - the distribution is the same for any ±1 coefficient scheme.",
-    "significance": "critical"
-  },
-  {
-    "id": "rudin-shapiro",
-    "proofId": "erdos-525",
-    "type": "definition",
-    "range": { "startLine": 145, "endLine": 150 },
-    "title": "Rudin-Shapiro Polynomials",
-    "content": "Special Littlewood polynomials of degree 2^n - 1 satisfying a flat bound: |p(z)| ≤ √(2^(n+1)) on the unit circle.",
-    "significance": "supporting"
-  },
-  {
-    "id": "mahler-measure",
-    "proofId": "erdos-525",
-    "type": "definition",
-    "range": { "startLine": 167, "endLine": 170 },
-    "title": "Mahler Measure",
-    "content": "M(p) = exp(∫ log|p(e^{2πit})| dt) - the geometric mean of |p| on the unit circle. Related to m(p) and connects to Lehmer's problem.",
-    "significance": "supporting"
-  },
-  {
-    "id": "lehmer-question",
-    "proofId": "erdos-525",
-    "type": "concept",
-    "range": { "startLine": 177, "endLine": 179 },
-    "title": "Lehmer's Problem",
-    "content": "Is there a Littlewood polynomial with M(p) < 1? This is related to Lehmer's conjecture on polynomial heights.",
-    "significance": "supporting"
-  },
-  {
-    "id": "main-summary",
-    "proofId": "erdos-525",
-    "type": "theorem",
-    "range": { "startLine": 204, "endLine": 225 },
-    "title": "Complete Solution",
-    "content": "Summary theorem: Littlewood's conjecture is true (Kashin), the correct exponent is -1/2 (Konyagin), and the exact limiting distribution is e^{-ελ} (Cook-Nguyen).",
-    "significance": "critical"
+    "range": { "startLine": 182, "endLine": 226 },
+    "title": "Complete Solution Summary",
+    "content": "Three summary theorems combine the key results: (1) Littlewood's conjecture is true (Kashin), (2) the correct exponent is -1/2 (Konyagin), and (3) the exact limiting distribution is e^{-ελ} (Cook-Nguyen). This completely resolves Erdős Problem #525.",
+    "mathContext": "erdos_525_solved directly applies kashin_theorem. erdos_525_main combines Kashin and Konyagin. erdos_525_answer combines the first question answer with the Cook-Nguyen distribution.",
+    "significance": "critical",
+    "relatedConcepts": ["complete-resolution", "summary-theorems", "historical-progression"]
   }
 ]


### PR DESCRIPTION
## Summary
Annotation quality enhancement for Erdős Problem #525 (Littlewood Polynomials and Minimum Modulus).

## Changes
- Added `mathContext` and `relatedConcepts` fields to all 11 annotations
- Standardized annotation IDs to `ann-e525-*` format
- Improved content descriptions with mathematical context for each definition, axiom, and theorem

## Checklist
- [x] pnpm build succeeds
- [x] Annotations align with Lean file line numbers
- [x] Quality checks pass

Generated by enhancer-1