### PR TITLE
Research: erdos-483 - define schurNumber, prove S(1)=2 and S(2)=5

### DIFF
--- a/proofs/Proofs/Erdos483Problem.lean
+++ b/proofs/Proofs/Erdos483Problem.lean
@@ -1,3 +1,9 @@
+import Mathlib.Tactic
+import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Real.Basic
+import Mathlib.Data.Finset.Basic
+import Proofs.SchursTheorem
+
 /-
 # Erdős Problem #483: Growth Rate of Schur Numbers
 
@@ -17,62 +23,173 @@ Status: OPEN.
 Reference: https://erdosproblems.com/483
 -/
 
-import Mathlib.Tactic
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Real.Basic
-import Mathlib.Data.Finset.Basic
+open SchursTheorem
 
-/- ## Definitions -/
+-- ## Defining the Schur Number
 
-/-- A k-coloring of {1, ..., N}. -/
-def Coloring (N k : ℕ) := Fin N → Fin k
+/-- The Schur property: N is large enough that every k-coloring of {1,...,N}
+    contains a monochromatic solution to x + y = z. -/
+def SchurProp (N k : ℕ) : Prop :=
+  ∀ (c : IntegerColoring N k), HasMonochromaticSchurTriple c
 
-/-- A coloring has a monochromatic sum-free triple a + b = c if
-    there exist a, b, c in {1,...,N} with the same color and a + b = c. -/
-def HasMonochromaticSum {N k : ℕ} (χ : Coloring N k) : Prop :=
-  ∃ (a b : Fin N), a.val + 1 + (b.val + 1) ≤ N ∧
-    χ a = χ b ∧
-    ∃ c : Fin N, c.val + 1 = (a.val + 1) + (b.val + 1) ∧ χ a = χ c
+/-- For any k ≥ 1, there exists an N with the Schur property. -/
+theorem schurProp_exists (k : ℕ) (hk : k ≥ 1) : ∃ N, SchurProp N k := by
+  obtain ⟨S, _, hS⟩ := schur_theorem_existence k hk
+  exact ⟨S, hS⟩
 
-/-- The Schur number f(k): smallest N such that every k-coloring of {1,...,N}
-    has a monochromatic solution to a + b = c. Axiomatized. -/
-axiom schurNumber (k : ℕ) : ℕ
+/-- If SchurProp N k holds, then SchurProp M k holds for any M ≥ N. -/
+theorem schurProp_mono {N M k : ℕ} (hNM : N ≤ M) (hN : SchurProp N k) : SchurProp M k := by
+  intro c
+  let c' : IntegerColoring N k := fun i => c ⟨i.val, Nat.lt_of_lt_of_le i.isLt hNM⟩
+  obtain ⟨i, j, kk, hsum, hci, hcj⟩ := hN c'
+  exact ⟨⟨i.val, Nat.lt_of_lt_of_le i.isLt hNM⟩,
+         ⟨j.val, Nat.lt_of_lt_of_le j.isLt hNM⟩,
+         ⟨kk.val, Nat.lt_of_lt_of_le kk.isLt hNM⟩,
+         hsum, hci, hcj⟩
 
-/-- schurNumber k is positive for k ≥ 1. -/
-axiom schurNumber_pos (k : ℕ) (hk : 1 ≤ k) : 1 ≤ schurNumber k
+-- ## The Schur Number as a Proper Definition
 
-/- ## Known Values -/
+open Classical in
+/-- The Schur number S(k) is the smallest N such that every k-coloring
+    of {1,...,N} has a monochromatic solution to x + y = z. -/
+noncomputable def schurNumber (k : ℕ) : ℕ :=
+  if hk : k ≥ 1 then Nat.find (schurProp_exists k hk)
+  else 0
 
-/-- f(1) = 2: any 1-coloring of {1, 2} has 1 + 1 = 2. -/
-axiom schur_1 : schurNumber 1 = 2
+open Classical in
+/-- The Schur number satisfies its defining property. -/
+theorem schurNumber_spec (k : ℕ) (hk : k ≥ 1) :
+    SchurProp (schurNumber k) k := by
+  have : schurNumber k = Nat.find (schurProp_exists k hk) := by
+    unfold schurNumber
+    rw [dif_pos hk]
+  rw [this]
+  exact Nat.find_spec (schurProp_exists k hk)
 
-/-- f(2) = 5. -/
-axiom schur_2 : schurNumber 2 = 5
+open Classical in
+/-- The Schur number is minimal. -/
+theorem schurNumber_min (k : ℕ) (hk : k ≥ 1) (N : ℕ) (hN : N < schurNumber k) :
+    ¬SchurProp N k := by
+  have : N < Nat.find (schurProp_exists k hk) := by
+    unfold schurNumber at hN
+    rwa [dif_pos hk] at hN
+  exact Nat.find_min (schurProp_exists k hk) this
+
+-- ## Proved: S(1) = 2
+
+/-- S(1) ≤ 2: any 1-coloring of {1,2} has a monochromatic Schur triple. -/
+theorem schurProp_2_1 : SchurProp 2 1 := schur_1
+
+/-- S(1) > 1: {1} alone has no Schur triple. -/
+theorem not_schurProp_1_1 : ¬SchurProp 1 1 := by
+  intro h
+  obtain ⟨i, j, k, hsum, _, _⟩ := h (fun _ => (0 : Fin 1))
+  have hi : i.val = 0 := Nat.lt_one_iff.mp i.isLt
+  have hj : j.val = 0 := Nat.lt_one_iff.mp j.isLt
+  have hk : k.val = 0 := Nat.lt_one_iff.mp k.isLt
+  omega
+
+/-- S(1) = 2. -/
+theorem schurNumber_1 : schurNumber 1 = 2 := by
+  have hspec := schurNumber_spec 1 (by omega)
+  have hmin := schurNumber_min 1 (by omega)
+  have h_le : schurNumber 1 ≤ 2 := by
+    by_contra h
+    push_neg at h
+    exact hmin 2 (by omega) schurProp_2_1
+  have h_ge : schurNumber 1 ≥ 2 := by
+    by_contra h
+    push_neg at h
+    have h1 : SchurProp 1 1 := schurProp_mono (by omega) hspec
+    exact not_schurProp_1_1 h1
+  omega
+
+-- ## Proved: S(2) = 5
+
+/-- S(2) ≤ 5. -/
+theorem schurProp_5_2 : SchurProp 5 2 := schur_2_upper
+
+/-- S(2) > 4. -/
+theorem not_schurProp_4_2 : ¬SchurProp 4 2 := by
+  intro h
+  obtain ⟨c, hc⟩ := schur_2_lower
+  exact hc (h c)
+
+/-- S(2) = 5. -/
+theorem schurNumber_2 : schurNumber 2 = 5 := by
+  have hspec := schurNumber_spec 2 (by omega)
+  have hmin := schurNumber_min 2 (by omega)
+  have h_le : schurNumber 2 ≤ 5 := by
+    by_contra h
+    push_neg at h
+    exact hmin 5 (by omega) schurProp_5_2
+  have h_ge : schurNumber 2 ≥ 5 := by
+    by_contra h
+    push_neg at h
+    have h4 : SchurProp 4 2 := schurProp_mono (by omega) hspec
+    exact not_schurProp_4_2 h4
+  omega
+
+-- ## Structural Properties
+
+/-- Schur numbers are positive for k ≥ 1. -/
+theorem schurNumber_pos (k : ℕ) (hk : k ≥ 1) : schurNumber k ≥ 1 := by
+  by_contra h
+  push_neg at h
+  have h0 : schurNumber k = 0 := by omega
+  have hspec := schurNumber_spec k hk
+  rw [h0] at hspec
+  obtain ⟨i, _, _, _, _, _⟩ := hspec Fin.elim0
+  exact Fin.elim0 i
+
+/-- Schur numbers are non-decreasing: S(k₁) ≤ S(k₂) when k₁ ≤ k₂. -/
+theorem schurNumber_nondecreasing {k₁ k₂ : ℕ} (hk1 : k₁ ≥ 1) (hle : k₁ ≤ k₂) :
+    schurNumber k₁ ≤ schurNumber k₂ := by
+  have hk2 : k₂ ≥ 1 := by omega
+  by_contra h
+  push_neg at h
+  have hno := schurNumber_min k₁ hk1 (schurNumber k₂) h
+  apply hno
+  intro c
+  let c' : IntegerColoring (schurNumber k₂) k₂ := fun i =>
+    ⟨(c i).val, Nat.lt_of_lt_of_le (c i).isLt hle⟩
+  obtain ⟨i, j, kk, hsum, hci, hcj⟩ := schurNumber_spec k₂ hk2 c'
+  refine ⟨i, j, kk, hsum, ?_, ?_⟩
+  · have hval : (c i).val = (c j).val := by
+      have := congr_arg Fin.val hci
+      simp only [c'] at this
+      exact this
+    exact Fin.ext hval
+  · have hval : (c j).val = (c kk).val := by
+      have := congr_arg Fin.val hcj
+      simp only [c'] at this
+      exact this
+    exact Fin.ext hval
+
+-- ## Known Values (larger cases - axiomatized)
 
 /-- f(3) = 14. -/
-axiom schur_3 : schurNumber 3 = 14
+axiom schurNumber_3 : schurNumber 3 = 14
 
 /-- f(4) = 45. -/
-axiom schur_4 : schurNumber 4 = 45
+axiom schurNumber_4 : schurNumber 4 = 45
 
-/-- f(5) = 161. -/
-axiom schur_5 : schurNumber 5 = 161
+/-- f(5) = 161 (Heule, 2017). -/
+axiom schurNumber_5 : schurNumber 5 = 161
 
-/- ## Bounds -/
+-- ## Bounds
 
-/-- Lower bound: f(k) ≥ 380^{k/5} - O(1).
-    Simplified: f(k) grows at least exponentially. -/
+/-- Lower bound: f(k) grows at least exponentially. -/
 axiom schur_lower_bound :
   ∃ C : ℝ, 1 < C ∧ ∀ k : ℕ, 1 ≤ k →
     C ^ k ≤ (schurNumber k : ℝ)
 
-/-- Upper bound: f(k) ≤ ⌊(e - 1/24)k!⌋ - 1 (Whitehead 1973).
-    Simplified: f(k) ≤ C · k! for some constant C. -/
+/-- Upper bound: f(k) ≤ C * k! for some constant C (Whitehead 1973). -/
 axiom schur_upper_bound :
   ∃ C : ℝ, 0 < C ∧ ∀ k : ℕ, 1 ≤ k →
     (schurNumber k : ℝ) ≤ C * (Nat.factorial k : ℝ)
 
-/- ## The Conjecture -/
+-- ## The Conjecture
 
 /-- Erdős Problem #483: Is f(k) < c^k for some constant c > 0?
     That is, are Schur numbers bounded by a simple exponential? -/

--- a/src/data/proofs/erdos-483/annotations.json
+++ b/src/data/proofs/erdos-483/annotations.json
@@ -2,46 +2,46 @@
   {
     "id": "erdos-483-ann-1",
     "proofId": "erdos-483",
-    "range": { "startLine": 27, "endLine": 42 },
+    "range": { "startLine": 28, "endLine": 57 },
     "type": "definition",
-    "title": "Colorings and Schur Numbers",
-    "content": "A k-Coloring assigns colors from Fin k to elements of {1,...,N}. HasMonochromaticSum detects monochromatic a+b=c triples. schurNumber k is axiomatized as the threshold for forced monochromatic sums.",
-    "significance": "The Schur number is the central object. Axiomatization avoids the need for a constructive minimum, while HasMonochromaticSum captures the combinatorial condition."
+    "title": "Schur Property and Schur Number",
+    "content": "SchurProp N k says every k-coloring of {1,...,N} has a monochromatic Schur triple. schurNumber k is defined via Nat.find as the minimal such N, building on the finiteness result from SchursTheorem.",
+    "significance": "The Schur number is now a proper definition (not an axiom), with proved minimality and specification theorems."
   },
   {
     "id": "erdos-483-ann-2",
     "proofId": "erdos-483",
-    "range": { "startLine": 46, "endLine": 59 },
+    "range": { "startLine": 78, "endLine": 105 },
     "type": "result",
-    "title": "Exact Schur Numbers for k ≤ 5",
-    "content": "f(1)=2, f(2)=5, f(3)=14, f(4)=45, f(5)=161 are all known. The value f(5)=161 was determined computationally by Fredricksen and Sweet (1986). No exact values beyond k=5 are known.",
-    "significance": "The growth rate f(1), f(2), ..., f(5) is roughly 2, 5, 14, 45, 161 — each roughly 3× the previous, suggesting exponential growth around 3^k."
+    "title": "S(1) = 2 (Proved)",
+    "content": "S(1) = 2 is fully proved: any 1-coloring of {1,2} has 1+1=2 (upper bound), and {1} alone has no Schur triple (lower bound). Combined via Nat.find characterization.",
+    "significance": "First exact Schur number, proved computationally rather than axiomatized."
   },
   {
     "id": "erdos-483-ann-3",
     "proofId": "erdos-483",
-    "range": { "startLine": 63, "endLine": 67 },
+    "range": { "startLine": 107, "endLine": 131 },
     "type": "result",
-    "title": "Exponential Lower Bound",
-    "content": "f(k) ≥ 380^{k/5} - O(1) by Ageron et al., showing Schur numbers grow at least exponentially with base ≈ 380^{1/5} ≈ 3.27.",
-    "significance": "The exponential lower bound confirms that f(k) cannot grow polynomially. The question is whether the growth is exactly exponential or faster."
+    "title": "S(2) = 5 (Proved)",
+    "content": "S(2) = 5 is fully proved by reusing the exhaustive case analysis from SchursTheorem (upper bound) and the sum-free partition {1,4},{2,3} (lower bound).",
+    "significance": "The first non-trivial Schur number, proved via Ramsey-theoretic case analysis."
   },
   {
     "id": "erdos-483-ann-4",
     "proofId": "erdos-483",
-    "range": { "startLine": 69, "endLine": 73 },
+    "range": { "startLine": 133, "endLine": 167 },
     "type": "result",
-    "title": "Factorial Upper Bound (Whitehead 1973)",
-    "content": "f(k) ≤ ⌊(e - 1/24)k!⌋ - 1, so f(k) = O(k!). This follows from a probabilistic/counting argument. The gap between exponential and factorial is enormous.",
-    "significance": "Closing this gap — from O(k!) to O(c^k) — is the content of Problem #483."
+    "title": "Structural Properties",
+    "content": "Proved: Schur numbers are positive (S(k) ≥ 1 for k ≥ 1) and non-decreasing (S(k₁) ≤ S(k₂) when k₁ ≤ k₂). Monotonicity uses color embedding: any k₁-coloring extends to a k₂-coloring.",
+    "significance": "Structural theorems about the Schur number sequence, proved from the Nat.find definition."
   },
   {
     "id": "erdos-483-ann-5",
     "proofId": "erdos-483",
-    "range": { "startLine": 77, "endLine": 81 },
+    "range": { "startLine": 169, "endLine": 199 },
     "type": "conjecture",
-    "title": "Exponential Bound Conjecture",
-    "content": "Erdős asked whether f(k) < c^k for some constant c. This would mean Schur numbers grow at most exponentially, matching the exponential lower bound up to the base.",
-    "significance": "If true, Schur numbers would be Θ(c^k) for some c, giving a complete asymptotic picture. This connects to similar questions for Ramsey numbers."
+    "title": "Known Values, Bounds, and the Conjecture",
+    "content": "S(3)=14, S(4)=45, S(5)=161 axiomatized (too large for computation). Exponential lower bound and factorial upper bound stated. Erdős #483 asks if f(k) < c^k for some c.",
+    "significance": "The gap between exponential lower bound and factorial upper bound is the core open question."
   }
 ]

--- a/src/data/proofs/erdos-483/meta.json
+++ b/src/data/proofs/erdos-483/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-483",
   "title": "Erdős Problem #483: Growth Rate of Schur Numbers",
   "slug": "erdos-483",
-  "description": "Is f(k) < c^k for some c, where f(k) is the Schur number (min N forcing monochromatic a+b=c in k-coloring)? Known: f(1)=2, f(2)=5, ..., f(5)=161. Lower: 380^{k/5}. Upper: ≈ek!. Open.",
+  "description": "Is f(k) < c^k for some c, where f(k) is the Schur number (min N forcing monochromatic a+b=c in k-coloring)? S(1)=2 and S(2)=5 proved from SchursTheorem. S(k) defined via Nat.find with monotonicity. Open.",
   "meta": {
     "erdosNumber": 483,
     "status": "formalized",
@@ -25,48 +25,55 @@
   "sections": [
     {
       "id": "definitions",
-      "title": "Definitions",
-      "startLine": 25,
-      "endLine": 42,
-      "summary": "Coloring, HasMonochromaticSum, schurNumber (axiom)."
+      "title": "Schur Property and Schur Number",
+      "startLine": 28,
+      "endLine": 57,
+      "summary": "SchurProp, schurNumber via Nat.find, schurProp_mono."
     },
     {
-      "id": "known-values",
-      "title": "Known Values",
-      "startLine": 44,
-      "endLine": 59,
-      "summary": "f(1)=2, f(2)=5, f(3)=14, f(4)=45, f(5)=161."
+      "id": "s1-proof",
+      "title": "S(1) = 2 (Proved)",
+      "startLine": 78,
+      "endLine": 105,
+      "summary": "Full proof of S(1) = 2 from upper/lower bounds."
     },
     {
-      "id": "bounds",
-      "title": "Bounds",
-      "startLine": 61,
-      "endLine": 73,
-      "summary": "Exponential lower bound, factorial upper bound."
+      "id": "s2-proof",
+      "title": "S(2) = 5 (Proved)",
+      "startLine": 107,
+      "endLine": 131,
+      "summary": "Full proof of S(2) = 5 reusing SchursTheorem."
     },
     {
-      "id": "conjecture",
-      "title": "The Conjecture",
-      "startLine": 75,
-      "endLine": 81,
-      "summary": "Is f(k) < c^k for some constant c?"
+      "id": "structural",
+      "title": "Structural Properties",
+      "startLine": 133,
+      "endLine": 167,
+      "summary": "Positivity and monotonicity of Schur numbers."
+    },
+    {
+      "id": "bounds-conjecture",
+      "title": "Bounds and Conjecture",
+      "startLine": 169,
+      "endLine": 199,
+      "summary": "S(3)-S(5) axiomatized, bounds stated, Erdős #483 conjecture."
     }
   ],
   "overview": {
     "historicalContext": "Schur (1916) proved that for every k, any k-coloring of {1,...,N} must contain a monochromatic solution to a+b=c if N is large enough. The Schur number f(k) is this threshold. The question of whether f(k) grows at most exponentially connects to Ramsey theory and additive combinatorics.",
     "problemStatement": "Is f(k) < c^k for some constant c > 0? That is, are the Schur numbers bounded by a simple exponential in the number of colors?",
-    "proofStrategy": "We axiomatize the Schur number, record exact values for k ≤ 5, state the exponential lower bound and factorial upper bound, and formalize the conjecture that f(k) is at most exponential.",
+    "proofStrategy": "We define schurNumber via Nat.find (not axiom), prove S(1)=2 and S(2)=5 from SchursTheorem, prove monotonicity, and axiomatize deep results (S(3)-S(5), bounds, conjecture).",
     "keyInsights": [
-      "The known values f(1)=2, f(2)=5, f(3)=14, f(4)=45, f(5)=161 grow rapidly but sub-factorially",
-      "The lower bound 380^{k/5} shows f(k) is at least exponential",
-      "The upper bound ≈ e·k! leaves a huge gap: exponential vs factorial",
-      "The conjecture asks whether the factorial upper bound can be improved to exponential",
+      "schurNumber is properly defined via Nat.find, not axiomatized",
+      "S(1)=2 and S(2)=5 are fully proved using SchursTheorem infrastructure",
+      "Schur numbers are non-decreasing via color embedding argument",
+      "The exponential lower bound ≈ 3.28^k vs factorial upper bound ≈ e·k! is the core gap",
       "Schur numbers are closely related to Ramsey numbers R(3,...,3) with k arguments"
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #483 asks whether Schur numbers grow at most exponentially. The current bounds range from exponential (lower) to factorial (upper), leaving a large gap.",
-    "implications": "Resolution would clarify the complexity of sum-free colorings, with connections to Ramsey theory, the Rado–Folkman theorem, and additive number theory.",
+    "summary": "Erdős Problem #483 asks whether Schur numbers grow at most exponentially. S(1)=2 and S(2)=5 are fully proved, monotonicity established, with deep bounds and open conjecture axiomatized.",
+    "implications": "Resolution would clarify the complexity of sum-free colorings, with connections to Ramsey theory, the Rado-Folkman theorem, and additive number theory.",
     "openQuestions": [
       "Is f(k) < c^k for some constant c?",
       "What is f(6)?",

--- a/src/data/research/problems/erdos-483.json
+++ b/src/data/research/problems/erdos-483.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-483",
   "title": "Erdős #483",
-  "phase": "NEW",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-01-13T03:37:39.479Z",
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
@@ -29,11 +29,31 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Defined schurNumber via Nat.find, proved S(1)=2 and S(2)=5, proved monotonicity and positivity. Reduced axioms from 9 to 6.",
+    "builtItems": [
+      "schurNumber via Nat.find (proofs/Proofs/Erdos483Problem.lean)",
+      "schurNumber_spec (specification theorem)",
+      "schurNumber_min (minimality theorem)",
+      "schurNumber_1: S(1) = 2 (proved)",
+      "schurNumber_2: S(2) = 5 (proved)",
+      "schurNumber_pos: S(k) >= 1 (proved)",
+      "schurNumber_nondecreasing: monotonicity (proved)",
+      "schurProp_mono: monotonicity of SchurProp (proved)"
+    ],
+    "insights": [
+      "schurNumber defined via Nat.find using schur_theorem_existence",
+      "S(1)=2 proved via upper (schur_1) + lower (no triple in Fin 1)",
+      "S(2)=5 proved via upper (schur_2_upper) + lower (schur_2_lower)",
+      "Monotonicity: color embedding Fin k1 -> Fin k2 preserves triples",
+      "SchurProp monotonic: more elements => more triples possible",
+      "S(3)=14, S(4)=45, S(5)=161 too large for computation - axiomatized"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove S(3)=14 computationally (requires larger enumeration)",
+      "Prove Ramsey connection S(k) <= R_k(3,...,3) - 1 formally",
+      "Build Schur triple decidability for native_decide proofs"
+    ],
     "markdown": "# Erdős #483 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $f(k)$ be the minimal $N$ such that if $\\{1,\\ldots,N\\}$ is $k$-coloured then there is a monochromatic solution to $a+b=c$. Estimate $f(k)$. In particular, is it true that $f(k) < c^k$ for some constant $c>0$?\n\n\n\nThe values of $f(k)$ are known as Schur numbers. The best-known bounds for large $k$ are\\[(380)^{k/5}-O(1)\\leq f(k) \\leq \\lfloor(e-\\tfrac{1}{24}) k!\\rfloor-1.\\]The lower bound is due to Ageron, Casteras, Pellerin, Portella, Rimmel, and Tomasik \\cite{ACPPRT21} (improving previous bounds of Exoo \\cite{Ex94} and Fredricksen and Sweet \\cite{FrSw00}) and the upper bound is due to Whitehead \\cite{Wh73}. Note that $380^{1/5}\\approx 3.2806$.\n\nThe known values of $f$ are $f(1)=2$, $f(2)=5$, $f(3)=14$, $f(4)=45$, and $f(5)=161$ (see A030126). (The equality $f(5)=161$ was established by Heule \\cite{He17}).\n\nSee also [183] (in particular a folklore observation gives $f(k)\\leq R(3;k)-1$).\n\n\n\n\nReferences\n\n\n[ACPPRT21] R. Ageron, P. Casteras, T. Pellerin, Y. Portella, A. Rimmel, and J. Tomasik, New lower bounds for Schur and weak Schur numbers. arXiv:2112.03175 (2021).\n\n[Ex94] Exoo, G., A lower bound for Schur numbers and multicolor Ramsey numbers. Electronic J. of Combinatorics (1994).\n\n[FrSw00] Fredricksen, Harold and Sweet, Melvin M., Symmetric sum-free partitions and lower bounds for {S}chur\nnumbers. Electron. J. Combin. (2000), Research Paper 32, 9.\n\n[He17] M. Heuele, Schur Number Five. arXiv:1711.08076 (2017).\n\n[Wh73] Whitehead, Jr., Earl Glen, The {R}amsey number {$N(3,\\,3,\\,3,\\,3;\\,2)$}. Discrete Math. (1973), 389--396.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #5\n- Problem #183\n- Problem #482\n- Problem #484\n- Problem #2\n- Problem #39\n- Problem #1\n- Problem #20\n\n## References\n\n- ACPPRT21\n- Ex94\n- FrSw00\n- Wh73\n- He17\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "approaches": [],


### PR DESCRIPTION
## Summary
- Define `schurNumber` via `Nat.find` instead of axiom (proper definition with minimality)
- Prove `S(1) = 2` and `S(2) = 5` by reusing `SchursTheorem` infrastructure
- Prove monotonicity and positivity of Schur numbers
- Reduce axiom count from 9 to 6

## Progress
- **schurNumber**: Properly defined via `Nat.find` with `schurNumber_spec` and `schurNumber_min`
- **schurNumber_1**: `S(1) = 2` fully proved
- **schurNumber_2**: `S(2) = 5` fully proved (reuses exhaustive case analysis)
- **schurNumber_pos**: `S(k) ≥ 1` for `k ≥ 1`
- **schurNumber_nondecreasing**: `S(k₁) ≤ S(k₂)` when `k₁ ≤ k₂` (color embedding)
- **schurProp_mono**: monotonicity of SchurProp (restriction preserves triples)

## Remaining Axioms (6)
- `schurNumber_3`, `schurNumber_4`, `schurNumber_5` (too large for computation)
- `schur_lower_bound`, `schur_upper_bound` (deep analytic/combinatorial results)
- `erdos_483_conjecture` (OPEN problem)

## Test plan
- [x] Docker build passes (`./proofs/scripts/docker-build.sh Proofs.Erdos483Problem`)
- [x] Gallery metadata updated

🤖 Generated by researcher-1