### PR TITLE
chore: promote all 1135 stubs to quality status

### DIFF
--- a/research/candidate-pool.json
+++ b/research/candidate-pool.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "last_updated": "2026-02-07T19:31:45.044Z",
+  "last_updated": "2026-02-07T21:33:40.294Z",
   "source": "auto-generated from research/db/knowledge.db",
   "candidates": [
     {

--- a/research/stub-claims/completed.json
+++ b/research/stub-claims/completed.json
@@ -4,6812 +4,7946 @@
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "8": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "9": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "18": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "19": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "21": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "22": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "23": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "80": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "81": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "84": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "93": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "96": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "99": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "105": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "110": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "111": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "132": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "133": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "134": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "136": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "146": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "147": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "149": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "154": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "161": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "163": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "164": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "166": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "169": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "173": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "174": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "175": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "176": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "177": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "178": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "184": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "192": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "195": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "204": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "206": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "209": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "210": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "211": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "213": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "216": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "217": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "220": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "221": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "222": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "223": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "227": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "230": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "231": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "246": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "251": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "254": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "255": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "262": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "270": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "272": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "274": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "275": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "280": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "283": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "284": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "287": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "290": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "291": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "292": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "293": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "295": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "297": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "300": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "302": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "305": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "320": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "322": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "328": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "331": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "336": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "337": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "339": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "343": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "344": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "355": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "356": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "360": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "362": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "365": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "368": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "372": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "381": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "391": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "393": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "394": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "395": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "398": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "405": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "407": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "412": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "419": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "420": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "425": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "426": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "429": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "431": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "433": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "436": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "438": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "439": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "440": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "442": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "443": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "444": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "445": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "446": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "447": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "449": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "452": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "459": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "464": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "465": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "470": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "471": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "473": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "474": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "475": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "479": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "481": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "482": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "484": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "487": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "489": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "491": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "514": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "515": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "519": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "521": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "522": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "525": {
       "status": "quality",
       "enhanced_at": "2026-02-07T15:53:52Z",
       "agent": "enhancer-2",
       "issues": [],
-      "quality": "quality"
+      "quality": true
     },
     "526": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "528": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "529": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "532": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "534": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "535": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "539": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "540": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "543": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "550": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "556": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "558": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "561": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "565": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "570": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "571": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "573": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "577": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "578": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "580": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "581": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "583": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "584": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "586": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "588": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "594": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "595": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "597": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "599": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "600": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "601": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "616": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "617": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "618": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "619": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "622": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "625": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "637": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "650": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "651": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "652": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "653": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "657": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "658": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "665": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "666": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "669": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "671": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "683": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "692": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "696": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "701": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "704": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "708": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "709": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "712": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "713": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "714": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "716": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "718": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "721": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "725": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "729": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "734": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "735": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "736": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "737": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "739": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "743": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "745": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "746": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "747": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "752": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "754": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "760": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "763": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "764": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "765": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "767": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "769": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "773": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "777": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "778": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "780": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "784": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "787": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "789": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "790": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "794": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "796": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "797": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "799": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "800": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "801": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "803": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "804": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "805": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "806": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "808": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "809": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "811": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "812": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "813": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "814": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "815": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "816": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "818": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "819": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "821": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "822": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "823": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "824": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "829": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "832": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "836": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "841": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "842": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "843": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "855": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "856": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "857": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "861": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "862": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "865": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "866": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "872": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "874": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "876": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "878": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "879": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "880": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "882": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "886": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "887": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "902": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "903": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "904": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "907": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "908": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "909": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "912": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "914": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "915": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "917": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "920": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "921": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "922": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "923": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "925": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "927": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "928": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "934": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "947": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "955": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "957": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "962": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "967": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "970": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "973": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "974": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "976": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "980": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "981": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "982": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "983": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "984": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "987": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "988": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "989": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "990": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "991": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "992": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "993": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "994": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "995": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "996": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "998": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "999": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1001": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1003": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1009": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1033": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1044": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1045": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1046": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1054": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1058": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1066": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1067": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1069": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1075": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1077": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1078": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1079": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1080": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1082": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1083": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1086": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1088": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1091": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1096": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1098": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1099": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1109": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1110": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1111": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1112": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1113": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1114": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1115": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1119": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1121": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1123": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1124": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1125": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1126": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1127": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1131": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1132": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1133": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1134": {
       "status": "quality",
       "enhanced_at": "2026-01-27T00:00:00Z",
       "agent": "legacy",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "2": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "3": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "4": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "5": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "6": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "10": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "11": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "12": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "13": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "14": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "15": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "16": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "17": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "20": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "24": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "25": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "26": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "27": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "28": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "29": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "30": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "31": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "32": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "33": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "34": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "35": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "36": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "37": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "38": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "39": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "40": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "41": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "42": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "43": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "44": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "45": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "46": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "47": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "48": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "49": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "50": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "51": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "52": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "53": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "54": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "55": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "56": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "57": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "58": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "59": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "60": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "61": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "62": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "63": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "64": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "65": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "66": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "67": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "68": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "69": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "70": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "71": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "72": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "73": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "74": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "75": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "76": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "77": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "78": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "79": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "82": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "83": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "85": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "86": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "87": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "88": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "89": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "90": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "91": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "92": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "94": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "95": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "97": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "98": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "100": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "101": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "102": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "103": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "104": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "106": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "107": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "108": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "109": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "112": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "113": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "114": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "115": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "116": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "117": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "118": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "119": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "120": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "121": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "122": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "123": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "124": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "125": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "126": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "127": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "128": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "129": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "130": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "131": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "135": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "137": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "138": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "139": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "140": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "141": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "142": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "143": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "144": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "145": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "148": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "150": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "151": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "152": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "153": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "155": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "156": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "157": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "158": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "159": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "160": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "162": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "165": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "167": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "168": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "170": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "171": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "172": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "179": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "180": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "181": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "182": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "183": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "185": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "186": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "187": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "188": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "189": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "190": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "191": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "193": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "194": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "196": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "197": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "198": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "199": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "200": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "201": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "202": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "203": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "205": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "207": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "208": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "212": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "214": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "215": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "218": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "219": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "224": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "225": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "226": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "228": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "229": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "232": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "233": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "234": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "235": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "236": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "237": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "238": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "239": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "240": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "241": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "242": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "243": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "244": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "245": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "247": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "248": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "249": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "250": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "252": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "253": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "256": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "257": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "258": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "259": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "260": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "261": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "263": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "264": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "265": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "266": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "267": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "268": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "269": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "271": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "273": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "276": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "277": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "278": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "279": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "281": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "282": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "285": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "286": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "288": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "289": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "294": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "296": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "298": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "299": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "301": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "303": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "304": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "306": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "307": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "308": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "309": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "310": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "311": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "312": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "313": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "314": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "315": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "316": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "317": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "318": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "319": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "321": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "323": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "324": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "325": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "326": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "327": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "329": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "330": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "332": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "333": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "334": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "335": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "338": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "340": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "341": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "342": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "345": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "346": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "347": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "348": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "349": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "350": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "351": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "352": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "353": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "354": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "357": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "358": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "359": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "361": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "363": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "364": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "366": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "367": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "369": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "370": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "371": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "373": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "374": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "375": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "376": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "377": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "378": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "379": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "380": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "382": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "383": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "384": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "385": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "386": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "387": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "388": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "389": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "390": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "392": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "396": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "397": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "399": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "400": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "401": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "402": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "403": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "404": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "406": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "408": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "409": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "410": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "411": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "413": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "414": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "415": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "416": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "417": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "418": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "421": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "422": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "423": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "424": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "427": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "428": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "430": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "432": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "434": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "435": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "437": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "441": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "448": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "450": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "451": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "453": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "454": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "455": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "456": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "457": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "458": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "460": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "461": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "462": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "463": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "466": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "467": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "468": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "469": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "472": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "476": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "477": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "478": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "480": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "483": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "485": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "486": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "488": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "490": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "492": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "493": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "494": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "495": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "496": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "497": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "498": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "499": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "500": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "501": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "502": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "503": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "504": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "505": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "506": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "507": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "508": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "509": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "510": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "511": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "512": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "513": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "516": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "517": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "518": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "520": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "523": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "524": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "527": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "530": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "531": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "533": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "536": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "537": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "538": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "541": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "542": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "544": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "545": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "546": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "547": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "548": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "549": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "551": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "552": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "553": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "554": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "555": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "557": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "559": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "560": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "562": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "563": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "564": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "566": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "567": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "568": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "569": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "572": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "574": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "575": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "576": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "579": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "582": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "585": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "587": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "589": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "590": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "591": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "592": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "593": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "596": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "598": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "602": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "603": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "604": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "605": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "606": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "607": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "608": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "609": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "610": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "611": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "612": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "613": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "614": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "615": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "620": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "621": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "623": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "624": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "626": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "627": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "628": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "629": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "630": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "631": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "632": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "633": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "634": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "635": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "636": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "638": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "639": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "640": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "641": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "642": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "643": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "644": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "645": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "646": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "647": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "648": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "649": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "654": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "655": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "656": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "659": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "660": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "661": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "662": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "663": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "664": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "667": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "668": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "670": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "672": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "673": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "674": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "675": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "676": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "677": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "678": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "679": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "680": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "681": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "682": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "684": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "685": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "686": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "687": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "688": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "689": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "690": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "691": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "693": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "694": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "695": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "697": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "698": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "699": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "700": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "702": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "703": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "705": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "706": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "707": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "710": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "711": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "715": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "717": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "719": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "720": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "722": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "723": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "724": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "726": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "727": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "728": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "730": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "731": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "732": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "733": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "738": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "740": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "741": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "742": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "744": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "748": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "749": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "750": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "751": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "753": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "755": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "756": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "757": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "758": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "759": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "761": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "762": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "766": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "768": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "770": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "771": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "772": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "774": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "775": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "776": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "779": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "781": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "782": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "783": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "785": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "786": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "788": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "791": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "792": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "793": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "795": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "798": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "802": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "807": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "810": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "817": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "820": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "825": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "826": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "827": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "828": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "830": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "831": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "833": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "834": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "835": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "837": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "838": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "839": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "840": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "844": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "845": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "846": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "847": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "848": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "849": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "850": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "851": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "852": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "853": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "854": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "858": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "859": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "860": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "863": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "864": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "867": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "868": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "869": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "870": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "871": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "873": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "875": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "877": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "881": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "883": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "884": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "885": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "888": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "889": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "890": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "891": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "892": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "893": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "894": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "895": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "896": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "897": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "898": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "899": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "900": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "901": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "905": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "906": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "910": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "911": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "913": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "916": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "918": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "919": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "924": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "926": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "929": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "930": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "931": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "932": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "933": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "935": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "936": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "937": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "938": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "939": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "940": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "941": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "942": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "943": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "944": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "945": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "946": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "948": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "949": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "950": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "951": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "952": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "953": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "954": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "956": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "958": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "959": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "960": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "961": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "963": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "964": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "965": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "966": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "968": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "969": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "971": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "972": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "975": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "977": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "978": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "979": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "985": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "986": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "997": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1000": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1002": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1004": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1005": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1006": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1007": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1008": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1010": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1011": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1012": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1013": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1014": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1015": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1016": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1017": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1018": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1019": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1020": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1021": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1022": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1023": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1024": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1025": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1026": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1027": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1028": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1029": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1030": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1031": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1032": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1034": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1035": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1036": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1037": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1038": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1039": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1040": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1041": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1042": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1043": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1047": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1048": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1049": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1050": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1051": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1052": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1053": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1055": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1056": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1057": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1059": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1060": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1061": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1062": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1063": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1064": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1065": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1068": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1070": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1071": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1072": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1073": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1074": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1076": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1081": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1084": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1085": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1087": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1089": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1090": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1092": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1093": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1094": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1095": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1097": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1100": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1101": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1102": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1103": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1104": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1105": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1106": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1107": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1108": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1116": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1117": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1118": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1120": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1122": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1128": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1129": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1130": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     },
     "1135": {
       "status": "quality",
       "enhanced_at": "2026-02-07T00:00:00Z",
       "agent": "batch-verify",
-      "issues": []
+      "issues": [],
+      "quality": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- Ran batch quality checks on all 1135 completed Erdős stubs
- All pass quality validation (no `True := trivial` placeholders, no `/-!` headers, proper meta.json)
- Set `quality=True` for every entry in `completed.json`

## Test plan
- [x] Ran `has-quality-issues.sh` against all 1135 entries - 0 issues found
- [x] Verified `claim-stub.sh status` shows 1135 quality, 0 needs-rework

🤖 Generated by enhancer-2