### PR TITLE
Enrich annotations for 9 Erdős entries with thin coverage

### DIFF
--- a/proofs/Proofs/Erdos234Problem.lean
+++ b/proofs/Proofs/Erdos234Problem.lean
@@ -112,9 +112,33 @@ theorem density_at_zero (h : DensityExists 0) :
     exact tendsto_const_nhds
   · rfl
 
+/-- Gap proportion is non-negative. -/
+lemma gapProportion_nonneg (N : ℕ) (c : ℝ) : gapProportion N c ≥ 0 := by
+  unfold gapProportion
+  apply div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+
+/-- Gap proportion is at most 1. -/
+lemma gapProportion_le_one (N : ℕ) (c : ℝ) (hN : 0 < N) : gapProportion N c ≤ 1 := by
+  unfold gapProportion
+  rw [div_le_one (Nat.cast_pos.mpr hN)]
+  exact Nat.cast_le.mpr (Finset.card_filter_le _ _)
+
+/-- The count of small normalized gaps is monotone in the threshold c. -/
+lemma countSmallNormGaps_mono (N : ℕ) (c₁ c₂ : ℝ) (hc : c₁ ≤ c₂) :
+    countSmallNormGaps N c₁ ≤ countSmallNormGaps N c₂ := by
+  unfold countSmallNormGaps
+  apply Finset.card_le_card
+  apply Finset.filter_subset_filter
+  intro n hn
+  exact lt_of_lt_of_le hn hc
+
 /-- f(c) is non-decreasing: more integers satisfy a larger threshold. -/
-axiom density_monotone (c₁ c₂ : ℝ) (hc : c₁ ≤ c₂) :
-    ∀ N, gapProportion N c₁ ≤ gapProportion N c₂
+theorem density_monotone (c₁ c₂ : ℝ) (hc : c₁ ≤ c₂) :
+    ∀ N, gapProportion N c₁ ≤ gapProportion N c₂ := by
+  intro N
+  unfold gapProportion
+  apply div_le_div_of_nonneg_right _ (Nat.cast_nonneg N)
+  exact Nat.cast_le.mpr (countSmallNormGaps_mono N c₁ c₂ hc)
 
 /-- f(c) → 1 as c → ∞: eventually all normalized gaps are below c. -/
 axiom density_at_infinity :
@@ -134,11 +158,24 @@ lemma cramer_exp_continuous : Continuous (fun c : ℝ => 1 - Real.exp (-c)) :=
   continuous_const.sub (continuous_exp.comp continuous_neg)
 
 /-- Cramér prediction is continuous (both pieces are continuous and agree at 0). -/
-axiom cramer_continuous : Continuous cramerPrediction
+theorem cramer_continuous : Continuous cramerPrediction := by
+  unfold cramerPrediction
+  apply Continuous.if_lt continuous_id continuous_const
+  · exact continuous_const
+  · exact continuous_const.sub (continuous_exp.comp continuous_neg)
+  · intro x hx
+    simp at hx
+    rw [hx]
+    simp
 
 /-- Cramér prediction is a valid CDF: values lie in [0, 1] for c ≥ 0. -/
-axiom cramer_in_unit_interval (c : ℝ) (hc : c ≥ 0) :
-    0 ≤ cramerPrediction c ∧ cramerPrediction c ≤ 1
+theorem cramer_in_unit_interval (c : ℝ) (hc : c ≥ 0) :
+    0 ≤ cramerPrediction c ∧ cramerPrediction c ≤ 1 := by
+  unfold cramerPrediction
+  rw [if_neg (not_lt.mpr hc)]
+  constructor
+  · linarith [exp_le_one_of_nonpos (neg_nonpos.mpr hc)]
+  · linarith [exp_pos (-c)]
 
 /-
 ## Section VI: Gallagher's Conditional Result
@@ -181,3 +218,30 @@ axiom large_gaps_exist :
 /-- The average normalized gap tends to 1 by the Prime Number Theorem. -/
 axiom average_normalized_gap :
     Tendsto (fun N => (∑ n ∈ Finset.range N, normalizedGap n) / N) atTop (nhds 1)
+
+/-
+## Section VIII: Additional Properties of Cramér's Model
+-/
+
+/-- Cramér prediction at 0 is 0. -/
+theorem cramer_at_zero : cramerPrediction 0 = 0 := by
+  unfold cramerPrediction
+  simp
+
+/-- Cramér prediction is non-negative for all c ≥ 0. -/
+theorem cramer_nonneg (c : ℝ) (hc : c ≥ 0) : cramerPrediction c ≥ 0 :=
+  (cramer_in_unit_interval c hc).1
+
+/-- Cramér prediction is at most 1 for all c ≥ 0. -/
+theorem cramer_le_one (c : ℝ) (hc : c ≥ 0) : cramerPrediction c ≤ 1 :=
+  (cramer_in_unit_interval c hc).2
+
+/-- Cramér prediction is monotone: if c₁ ≤ c₂ then f(c₁) ≤ f(c₂). -/
+theorem cramer_monotone (c₁ c₂ : ℝ) (h1 : c₁ ≥ 0) (h2 : c₂ ≥ 0) (hle : c₁ ≤ c₂) :
+    cramerPrediction c₁ ≤ cramerPrediction c₂ := by
+  unfold cramerPrediction
+  rw [if_neg (not_lt.mpr h1), if_neg (not_lt.mpr h2)]
+  have : Real.exp (-c₂) ≤ Real.exp (-c₁) := by
+    apply exp_le_exp.mpr
+    linarith
+  linarith

--- a/proofs/Proofs/Erdos513Problem.lean
+++ b/proofs/Proofs/Erdos513Problem.lean
@@ -51,15 +51,13 @@ noncomputable def termModulusRatio (a : ℕ → ℂ) (r : ℝ) : ℝ :=
 def IsTranscendentalEntire (a : ℕ → ℂ) : Prop :=
   (∀ N : ℕ, ∃ n : ℕ, n > N ∧ a n ≠ 0)
 
-/- ## Known Results -/
+/- ## Known Results (Axiomatized) -/
 
 /-- μ(r) ≤ M(r) always holds, so the ratio is at most 1. -/
 axiom maxTerm_le_maxModulus (a : ℕ → ℂ) (r : ℝ) (hr : 0 ≤ r) :
   maxTerm a r ≤ maxModulus a r
 
-/-- Kövári's lower bound: for every transcendental entire function,
-    liminf_{r→∞} μ(r)/M(r) ≤ the supremum, and the supremum exceeds 1/2.
-    Axiomatized as: there exists a transcendental entire function whose
+/-- Kövári's lower bound: there exists a transcendental entire function whose
     liminf of the ratio exceeds 1/2. -/
 axiom kovari_lower_bound :
   ∃ a : ℕ → ℂ, IsTranscendentalEntire a ∧
@@ -71,6 +69,73 @@ axiom clunie_hayman_upper_bound :
   ∃ c : ℝ, 0 < c ∧
     ∀ a : ℕ → ℂ, IsTranscendentalEntire a →
       Filter.liminf (fun r => termModulusRatio a r) Filter.atTop ≤ 2 / Real.pi - c
+
+/- ## Proved Structural Theorems -/
+
+/-- The term-modulus ratio is always nonneg for r ≥ 0. -/
+theorem termModulusRatio_nonneg (a : ℕ → ℂ) (r : ℝ) (hr : 0 ≤ r) :
+    0 ≤ termModulusRatio a r := by
+  unfold termModulusRatio
+  split_ifs with h
+  · exact le_refl 0
+  · exact div_nonneg (maxTerm_nonneg a r hr)
+      (le_of_lt (lt_of_le_of_ne (maxModulus_nonneg a r hr) (Ne.symm h)))
+
+/-- The term-modulus ratio is at most 1 for r ≥ 0. -/
+theorem termModulusRatio_le_one (a : ℕ → ℂ) (r : ℝ) (hr : 0 ≤ r) :
+    termModulusRatio a r ≤ 1 := by
+  unfold termModulusRatio
+  split_ifs with h
+  · exact zero_le_one
+  · rw [div_le_one (lt_of_le_of_ne (maxModulus_nonneg a r hr) (Ne.symm h))]
+    exact maxTerm_le_maxModulus a r hr
+
+/-- The term-modulus ratio lies in [0, 1] for r ≥ 0. -/
+theorem termModulusRatio_mem_Icc (a : ℕ → ℂ) (r : ℝ) (hr : 0 ≤ r) :
+    termModulusRatio a r ∈ Set.Icc 0 1 :=
+  ⟨termModulusRatio_nonneg a r hr, termModulusRatio_le_one a r hr⟩
+
+/-- When M(r) = 0, the ratio is exactly 0 (by definition). -/
+theorem termModulusRatio_eq_zero_of_maxModulus_eq_zero (a : ℕ → ℂ) (r : ℝ)
+    (h : maxModulus a r = 0) : termModulusRatio a r = 0 := by
+  unfold termModulusRatio
+  simp [h]
+
+/-- When M(r) > 0, the ratio equals the actual quotient μ(r)/M(r). -/
+theorem termModulusRatio_eq_div (a : ℕ → ℂ) (r : ℝ)
+    (h : 0 < maxModulus a r) :
+    termModulusRatio a r = maxTerm a r / maxModulus a r := by
+  unfold termModulusRatio
+  simp [ne_of_gt h]
+
+/-- The known bounds 1/2 and 2/π are consistent: 1/2 < 2/π.
+    This ensures the interval in which the answer lies is non-empty. -/
+theorem half_lt_two_div_pi : (1 : ℝ) / 2 < 2 / Real.pi := by
+  rw [div_lt_div_iff (by norm_num : (0:ℝ) < 2)
+    (by linarith [Real.pi_gt_three] : (0:ℝ) < Real.pi)]
+  have : Real.pi < 4 := by linarith [Real.pi_lt_3141593]
+  linarith
+
+/-- The supremum of liminf ratios exceeds 1/2 (from Kövári). -/
+theorem supremum_exceeds_half :
+    ∃ a : ℕ → ℂ, IsTranscendentalEntire a ∧
+      (1 : ℝ) / 2 < Filter.liminf (fun r => termModulusRatio a r) Filter.atTop :=
+  kovari_lower_bound
+
+/-- The supremum of liminf ratios is strictly less than 2/π (from Clunie–Hayman). -/
+theorem supremum_lt_two_div_pi :
+    ∃ c : ℝ, 0 < c ∧ ∀ a : ℕ → ℂ, IsTranscendentalEntire a →
+      Filter.liminf (fun r => termModulusRatio a r) Filter.atTop < 2 / Real.pi := by
+  obtain ⟨c, hc, hbound⟩ := clunie_hayman_upper_bound
+  exact ⟨c, hc, fun a ha => lt_of_le_of_lt (hbound a ha) (by linarith)⟩
+
+/-- The Clunie–Hayman bound gives a gap: every transcendental entire function
+    has liminf ratio bounded away from 2/π by an absolute constant. -/
+theorem clunie_hayman_gap :
+    ∃ c : ℝ, 0 < c ∧ ∀ a : ℕ → ℂ, IsTranscendentalEntire a →
+      Filter.liminf (fun r => termModulusRatio a r) Filter.atTop + c ≤ 2 / Real.pi := by
+  obtain ⟨c, hc, hbound⟩ := clunie_hayman_upper_bound
+  exact ⟨c, hc, fun a ha => by linarith [hbound a ha]⟩
 
 /- ## The Open Question -/
 

--- a/proofs/Proofs/TestApi1159b.lean
+++ b/proofs/Proofs/TestApi1159b.lean
@@ -1,0 +1,31 @@
+import Mathlib
+
+open Configuration
+
+-- Check HasLines fields
+#check @HasLines.mkFinOrder
+#print HasLines
+
+-- Check HasPoints fields
+#print HasPoints
+
+-- Check if mkLine exists
+#check @HasLines.mkLine
+
+-- Check if there's a mkPoint
+#check @HasPoints.mkPoint
+
+-- Check for line intersection results (two lines in a projective plane meet)
+#check @ProjectivePlane.mkFinOrder
+
+-- Print the ProjectivePlane class
+#print ProjectivePlane
+
+-- Check Set.Nonempty
+#check @Set.Nonempty
+
+-- Check Finset.card_le_card
+#check @Finset.card_le_card
+
+-- Check Set.nontrivial
+#check @Set.nontrivial_iff_exists_ne

--- a/proofs/Proofs/TestApi234.lean
+++ b/proofs/Proofs/TestApi234.lean
@@ -1,0 +1,49 @@
+import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Real.Basic
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+import Mathlib.Tactic
+
+open Real
+
+-- Test 1: piecewise continuous with if-then-else
+noncomputable def testPiecewise (c : ℝ) : ℝ :=
+  if c < 0 then 0 else 1 - Real.exp (-c)
+
+-- Test 2: Continuous.if_le for piecewise
+theorem test_piecewise_continuous : Continuous testPiecewise := by
+  unfold testPiecewise
+  apply Continuous.if_lt continuous_id continuous_const
+  · exact continuous_const
+  · exact continuous_const.sub (continuous_exp.comp continuous_neg)
+  · intro x hx
+    simp at hx
+    rw [hx]
+    simp
+
+-- Test 3: exp bounds
+theorem test_exp_nonneg (c : ℝ) (hc : c ≥ 0) : Real.exp (-c) ≤ 1 := by
+  calc Real.exp (-c) ≤ Real.exp 0 := by
+        apply exp_le_exp.mpr; linarith
+    _ = 1 := exp_zero
+
+-- Test 4: Finset.card_le_card for monotone filter
+theorem test_filter_mono {N : ℕ} {c₁ c₂ : ℝ} (h : c₁ ≤ c₂) :
+    ((Finset.range N).filter (fun n => decide (n < 3) = true)).card ≤
+    ((Finset.range N).filter (fun n => decide (n < 5) = true)).card := by
+  apply Finset.card_le_card
+  apply Finset.filter_subset_filter
+  intro x
+  simp
+  omega
+
+-- Test 5: Finset.filter_subset_filter with general Prop
+-- This is what we need for density_monotone
+example {N : ℕ} {P Q : ℕ → Prop} [DecidablePred P] [DecidablePred Q]
+    (h : ∀ x, P x → Q x) :
+    ((Finset.range N).filter P).card ≤ ((Finset.range N).filter Q).card := by
+  apply Finset.card_le_card
+  apply Finset.filter_subset_filter
+  exact fun _ => h _

--- a/proofs/Proofs/TestApi321.lean
+++ b/proofs/Proofs/TestApi321.lean
@@ -1,0 +1,56 @@
+import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Rat.Basic
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Powerset
+
+-- Test: Finset.sum over rationals
+#check @Finset.sum ℕ ℚ _ -- should give Finset ℕ → (ℕ → ℚ) → ℚ
+
+-- Test: subset monotonicity type
+example (A : Finset ℕ) (S T : Finset ℕ) (hS : S ⊆ A) (hT : T ⊆ A) :
+    S ⊆ A := hS
+
+-- Test: Finset.sum_empty
+#check @Finset.sum_empty ℕ ℚ _
+
+-- Test: Finset.sum_singleton
+#check @Finset.sum_singleton
+
+-- Test: Rat division
+example : (1 : ℚ) / 2 ≠ (1 : ℚ) / 3 := by norm_num
+
+-- Test: Finset.subset_refl
+#check @Finset.Subset.refl
+
+-- Test: empty finset
+#check (∅ : Finset ℕ)
+
+-- Test: singleton finset
+#check ({3} : Finset ℕ)
+
+-- Test: Finset.card
+#check @Finset.card ℕ
+
+-- Test: powerset
+#check @Finset.powerset ℕ
+
+-- Test: mem_powerset
+#check @Finset.mem_powerset ℕ
+
+-- Test: Rat.div_ne_zero or similar
+example (n : ℕ) (hn : n ≠ 0) : (n : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr hn
+
+-- Test: 1/a ≠ 1/b for distinct positive nats
+example : (1 : ℚ) / 1 ≠ (1 : ℚ) / 2 := by norm_num
+example : (1 : ℚ) / 2 ≠ (1 : ℚ) / 3 := by norm_num
+
+-- Test: sum of singleton
+example : Finset.sum {(2 : ℕ)} (fun n => (1 : ℚ) / n) = 1/2 := by simp
+
+-- Test: Finset.filter
+#check @Finset.filter
+
+-- Test: Finset.sup for ℕ
+#check @Finset.sup ℕ ℕ _

--- a/proofs/Proofs/TestApi385.lean
+++ b/proofs/Proofs/TestApi385.lean
@@ -1,10 +1,24 @@
--- Test API availability for erdos-385 (part 2 - minimal filter)
-import Mathlib.Order.Filter.AtTopBot
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Order.Filter.Basic
+import Mathlib.Data.Set.Finite.Basic
 
--- Filter APIs
-#check Filter.Eventually
-#check Filter.Eventually.mono
-#check Filter.Tendsto
-#check Filter.atTop
+-- Test: minFac APIs
+#check Nat.minFac_sq_le_self
+#check Nat.minFac_prime
+#check Nat.minFac_dvd
+
+-- Test: minFac_sq_le_self
+example (n : ℕ) (hn : n > 1) : n.minFac ^ 2 ≤ n := by
+  exact Nat.minFac_sq_le_self (by omega)
+
+-- Test: le_sqrt API name
+#check @Nat.le_sqrt'
+
+-- Test: eventually_atTop
 #check Filter.eventually_atTop
-#check @Filter.tendsto_atTop
+#check @Filter.Tendsto
+
+-- Test: Set.Finite
+#check Set.Finite
+#check Set.Finite.subset

--- a/proofs/Proofs/TestApi417.lean
+++ b/proofs/Proofs/TestApi417.lean
@@ -1,0 +1,30 @@
+import Mathlib.Data.Nat.Totient
+import Mathlib.Data.Finset.Basic
+
+open Nat Finset
+
+-- Check key APIs
+#check Nat.totient_le  -- totient m ≤ m
+#check Nat.totient_prime
+#check Nat.totient_prime_pow
+#check @Nat.totient_even
+
+-- Small computations
+#eval Nat.totient 3  -- expect 2
+
+-- Test: Finset.card_le_card for V' ≤ V
+#check @Finset.card_le_card
+
+-- Test key proof idea: image ⊆ filter
+example : (Finset.image Nat.totient (Finset.range 4)) ⊆
+    (Finset.filter (fun n => ∃ m, Nat.totient m = n) (Finset.range 4)) := by
+  intro n hn
+  simp only [mem_image, mem_range] at hn
+  obtain ⟨m, hm, rfl⟩ := hn
+  simp only [mem_filter, mem_range]
+  exact ⟨Nat.lt_of_lt_of_le hm (Nat.totient_le m) |>.trans_le (by omega), ⟨m, rfl⟩⟩
+
+-- Wait, totient_le gives totient m ≤ m, not totient m < m. Let me adjust.
+-- Actually we need totient m ∈ range (x+1), i.e. totient m ≤ x
+-- Since m ∈ range (x+1), we have m ≤ x, and totient m ≤ m ≤ x
+-- So totient m ∈ range (x+1)

--- a/proofs/Proofs/TestApi472.lean
+++ b/proofs/Proofs/TestApi472.lean
@@ -1,0 +1,27 @@
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.List.Basic
+import Mathlib.Tactic
+import Mathlib.Data.Nat.Parity
+
+-- Test basic decidability for small prime checks
+example : (3 : ℕ).Prime := by decide
+example : (5 : ℕ).Prime := by decide
+
+-- Test list membership
+example : (3 : ℕ) ∈ [3, 5] := by decide
+example : ∀ p ∈ [3, 5], (p : ℕ).Prime := by decide
+
+-- Test Even/Odd
+#check Nat.Even
+#check Nat.even_add
+#check Nat.Odd
+#check Nat.Prime.eq_two_or_odd
+
+-- Test natural number subtraction behavior
+-- q + q - 1 where q ≥ 2: is 2q - 1 odd?
+example : ¬ Even (3 + 3 - 1) := by decide
+example : ¬ Even (5 + 5 - 1) := by decide
+
+-- Test decidability for small Finset/List computations
+#check List.ofFn
+#check Nat.minFac

--- a/proofs/Proofs/TestApi513.lean
+++ b/proofs/Proofs/TestApi513.lean
@@ -1,0 +1,24 @@
+import Mathlib.Tactic
+import Mathlib.Analysis.Complex.Basic
+import Mathlib.Order.LiminfLimsup
+
+-- Test: division lemmas for ratio proofs
+example (a b : ℝ) (ha : 0 ≤ a) (hb : 0 < b) (hab : a ≤ b) : a / b ≤ 1 := by
+  rw [div_le_one hb]
+  exact hab
+
+example (a b : ℝ) (ha : 0 ≤ a) (hb : 0 < b) : 0 ≤ a / b :=
+  div_nonneg ha (le_of_lt hb)
+
+-- Test: 1/2 < 2/π
+example : (1 : ℝ) / 2 < 2 / Real.pi := by
+  have hpi : Real.pi > 3 := Real.pi_gt_three
+  have hpi_pos : (0 : ℝ) < Real.pi := by linarith
+  rw [div_lt_div_iff (by norm_num : (0:ℝ) < 2) hpi_pos]
+  -- Need: 1 * π < 2 * 2 = 4, i.e., π < 4
+  have : Real.pi < 4 := by linarith [Real.pi_lt_3141593]
+  linarith
+
+-- Test: if_neg simplification
+example (h : ¬ (3 : ℝ) = 0) : (if (3 : ℝ) = 0 then 0 else 5 / 3) = 5 / 3 := by
+  simp [h]

--- a/proofs/Proofs/TestApi826.lean
+++ b/proofs/Proofs/TestApi826.lean
@@ -1,0 +1,22 @@
+import Mathlib.NumberTheory.ArithmeticFunction
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic
+
+open scoped ArithmeticFunction
+open Nat
+
+-- Check: σ 0 for specific values
+example : σ 0 1 = 1 := by native_decide
+example : σ 0 2 = 2 := by native_decide
+example : σ 0 6 = 4 := by native_decide
+example : σ 0 12 = 6 := by native_decide
+
+-- Check sigma_apply exists
+#check ArithmeticFunction.sigma_apply
+#check Nat.divisors
+#check Nat.primeFactors
+
+-- Simple individual checks
+example : σ 0 (0 + 1) ≤ 2 * 1 := by native_decide
+example : σ 0 (0 + 2) ≤ 2 * 2 := by native_decide
+example : σ 0 (0 + 6) ≤ 2 * 6 := by native_decide

--- a/proofs/Proofs/TestApi828.lean
+++ b/proofs/Proofs/TestApi828.lean
@@ -1,0 +1,7 @@
+import Mathlib.Data.Nat.Totient
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic
+
+#check Nat.totient_prime
+#check Nat.totient_prime_pow_succ
+#check @Nat.totient_even

--- a/research/candidate-pool.json
+++ b/research/candidate-pool.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "last_updated": "2026-02-07T21:33:40.294Z",
+  "last_updated": "2026-02-07T23:33:31.681Z",
   "source": "auto-generated from research/db/knowledge.db",
   "candidates": [
     {

--- a/src/data/proofs/erdos-1032/annotations.json
+++ b/src/data/proofs/erdos-1032/annotations.json
@@ -1,38 +1,78 @@
 [
   {
-    "id": "erdos-1032-critical",
+    "id": "ann-e1032-header",
     "proofId": "erdos-1032",
+    "range": { "startLine": 1, "endLine": 20 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #1032** (OPEN):\n\nDo there exist 4-chromatic critical graphs on n vertices with minimum degree linear in n (i.e., δ(G) ≥ cn for some constant c > 0)?\n\nA graph G is k-chromatic critical if χ(G) = k and removing any edge reduces the chromatic number to k − 1. The question asks whether criticality is compatible with high minimum degree for k = 4.",
+    "mathContext": "Critical graphs are 'tightly chromatic' — every edge is essential. For k = 6, Dirac showed linear minimum degree is achievable. For k = 4, the best known is δ ≫ n^{1/3} (Simonovits–Toft).",
+    "significance": "critical",
+    "relatedConcepts": ["chromatic number", "critical graphs", "minimum degree"]
+  },
+  {
+    "id": "ann-e1032-axioms",
+    "proofId": "erdos-1032",
+    "range": { "startLine": 22, "endLine": 39 },
+    "type": "concept",
+    "title": "Graph Properties (Axiomatised)",
+    "content": "**Axiomatised functions:**\n\n- `vertexCount G` — number of vertices\n- `minDegree G` — minimum degree δ(G)\n- `chromaticNumber G` — chromatic number χ(G)\n- `edgeCount G` — number of edges\n\nThese are axiomatised because Lean 4's Mathlib does not have a built-in chromatic number for general graphs parametrised over Type.",
+    "significance": "supporting",
+    "relatedConcepts": ["axiom", "graph theory", "Mathlib"]
+  },
+  {
+    "id": "ann-e1032-critical",
+    "proofId": "erdos-1032",
+    "range": { "startLine": 41, "endLine": 46 },
     "type": "definition",
-    "range": { "startLine": 39, "endLine": 43 },
     "title": "k-Chromatic Critical Graph",
-    "content": "IsKChromaticCritical G k means χ(G) = k and removing any edge reduces the chromatic number. This is the central structural condition.",
-    "significance": "essential"
+    "content": "**IsKChromaticCritical G k:**\n\nG is k-chromatic critical if:\n1. χ(G) = k, and\n2. Removing any edge reduces the chromatic number\n\n**Examples:**\n- Complete graph K_k is k-critical\n- Odd cycles C_{2m+1} are 3-critical\n- Petersen graph is 3-critical\n\nCritical graphs are the 'minimal' graphs achieving a given chromatic number.",
+    "mathContext": "The study of critical graphs dates to Dirac (1952). A k-critical graph on n vertices must have δ(G) ≥ k−1 (otherwise a vertex of degree < k−1 could be coloured greedily).",
+    "significance": "essential",
+    "relatedConcepts": ["chromatic number", "graph colouring", "Dirac's theorem"]
   },
   {
-    "id": "erdos-1032-dirac",
+    "id": "ann-e1032-dirac",
     "proofId": "erdos-1032",
+    "range": { "startLine": 48, "endLine": 54 },
     "type": "result",
-    "range": { "startLine": 47, "endLine": 51 },
     "title": "Dirac's 6-Chromatic Construction",
-    "content": "Dirac constructed 6-chromatic critical graphs with δ > n/2. This shows linear minimum degree is achievable for χ = 6.",
-    "significance": "supporting"
+    "content": "**dirac_6_critical:**\n\nDirac constructed 6-chromatic critical graphs with δ > n/2. This shows that linear minimum degree is achievable for k = 6.\n\nThe gap: for k = 6, we can achieve δ(G) = Θ(n). For k = 4, the best known is δ(G) = Θ(n^{1/3}). Problem #1032 asks whether the k = 4 case can also achieve δ(G) = Θ(n).",
+    "mathContext": "Dirac's construction uses iterated Mycielski-type operations. The key difficulty for k = 4 is that 4-critical graphs have more structural constraints.",
+    "significance": "key",
+    "relatedConcepts": ["Dirac", "Mycielski construction", "dense graphs"]
   },
   {
-    "id": "erdos-1032-simonovits-toft",
+    "id": "ann-e1032-simonovits-toft",
     "proofId": "erdos-1032",
+    "range": { "startLine": 56, "endLine": 61 },
     "type": "result",
-    "range": { "startLine": 53, "endLine": 58 },
     "title": "Simonovits–Toft Construction",
-    "content": "4-chromatic critical graphs with δ ≫ n^{1/3}. This is the best known lower bound on minimum degree for 4-chromatic critical graphs.",
-    "significance": "essential"
+    "content": "**simonovits_toft_4_critical:**\n\nSimonovits and Toft constructed 4-chromatic critical graphs with δ ≫ n^{1/3}.\n\nFormally: there exists c > 0 such that for every N, a 4-critical graph on N vertices exists with δ(G) ≥ c · N^{1/3}.\n\nThis is the best known lower bound on minimum degree for 4-chromatic critical graphs.",
+    "mathContext": "The cube-root barrier n^{1/3} arises from the construction technique. Breaking through to linear minimum degree would require fundamentally new ideas.",
+    "significance": "essential",
+    "relatedConcepts": ["construction", "cube-root barrier", "extremal graph theory"]
   },
   {
-    "id": "erdos-1032-conjecture",
+    "id": "ann-e1032-toft",
     "proofId": "erdos-1032",
+    "range": { "startLine": 63, "endLine": 70 },
     "type": "conjecture",
-    "range": { "startLine": 72, "endLine": 77 },
-    "title": "Erdős Problem 1032",
-    "content": "There exist 4-chromatic critical graphs with minimum degree linear in n. This would close the gap from n^{1/3} to n.",
-    "significance": "essential"
+    "title": "Toft's Edge Conjecture",
+    "content": "**ToftConjecture:**\n\nEvery 4-chromatic critical graph on n vertices has at least (5/3 + o(1))n edges.\n\nFormally: for every ε > 0 and sufficiently large n, every 4-critical graph G on n vertices satisfies |E(G)| ≥ (5/3 − ε)n.\n\nThis is a companion conjecture to Problem #1032, bounding edge density rather than minimum degree.",
+    "mathContext": "The 5/3 constant is sharp for certain known constructions. This conjecture and Problem #1032 are related but neither implies the other.",
+    "significance": "key",
+    "relatedConcepts": ["edge density", "Toft's conjecture", "extremal graph theory"]
+  },
+  {
+    "id": "ann-e1032-conjecture",
+    "proofId": "erdos-1032",
+    "range": { "startLine": 72, "endLine": 81 },
+    "type": "conjecture",
+    "title": "Erdős Problem #1032 (OPEN)",
+    "content": "**ErdosProblem1032:**\n\nThere exist 4-chromatic critical graphs on n vertices with δ(G) ≥ c·n for some constant c > 0.\n\nThis would close the gap from n^{1/3} (Simonovits–Toft) to linear n. The question is whether 4-criticality is compatible with dense graphs.\n\n**ErdosProblem1032_k5** extends the question to 5-chromatic critical graphs.",
+    "mathContext": "The progression is: k=3 (odd cycles, δ=2), k=4 (unknown if δ can be linear), k=5 (unknown), k=6 (Dirac: δ > n/2). The jump from k=5 to k=6 is where linear degree becomes achievable.",
+    "significance": "critical",
+    "relatedConcepts": ["minimum degree", "chromatic number", "open problem"]
   }
 ]

--- a/src/data/proofs/erdos-151/annotations.json
+++ b/src/data/proofs/erdos-151/annotations.json
@@ -1,38 +1,89 @@
 [
   {
-    "id": "erdos-151-transversal",
+    "id": "ann-e151-header",
     "proofId": "erdos-151",
-    "type": "definition",
-    "range": { "startLine": 46, "endLine": 48 },
-    "title": "Clique Transversal",
-    "content": "IsCliqueTransversal G T means T intersects every maximal clique of size ≥ 2. The clique transversal number τ(G) minimises |T|.",
-    "significance": "essential"
+    "range": { "startLine": 1, "endLine": 22 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #151** (Erdős–Gallai, OPEN):\n\nFor a graph G on n vertices, is τ(G) ≤ n − H(n), where τ(G) is the clique transversal number and H(n) is the maximum independent set size guaranteed in every triangle-free graph on n vertices?\n\n**Known:** τ(G) ≤ n − √n (easy), and H(n) ≥ √n by Ramsey theory. Even the K₄-free case is open.",
+    "mathContext": "Erdős called this conjecture 'perhaps completely wrongheaded,' indicating uncertainty about its truth. The problem connects clique covering, Ramsey theory, and independent sets.",
+    "significance": "critical",
+    "relatedConcepts": ["clique transversal", "Ramsey theory", "independent set"]
   },
   {
-    "id": "erdos-151-H",
+    "id": "ann-e151-axioms",
     "proofId": "erdos-151",
+    "range": { "startLine": 24, "endLine": 49 },
+    "type": "concept",
+    "title": "Graph Properties (Axiomatised)",
+    "content": "**Axiomatised predicates:**\n\n- `vertexCount G` — number of vertices\n- `IsClique G C` / `IsMaximalClique G C` — clique and maximality predicates\n- `IsIndependent G I` — independent set predicate\n- `IsTriangleFree G` / `IsK4Free G` — graph structure constraints\n\nThese are axiomatised since the Lean formalization works with abstract graph types rather than Mathlib's SimpleGraph.",
+    "significance": "supporting",
+    "relatedConcepts": ["axiom", "graph theory", "Mathlib"]
+  },
+  {
+    "id": "ann-e151-transversal",
+    "proofId": "erdos-151",
+    "range": { "startLine": 51, "endLine": 68 },
     "type": "definition",
-    "range": { "startLine": 57, "endLine": 59 },
+    "title": "Clique Transversal Number τ(G)",
+    "content": "**IsCliqueTransversal G T:** T intersects every maximal clique of size ≥ 2.\n\n**cliqueTransversal G = τ(G):** the minimum size of such a transversal.\n\nTwo axioms establish that τ(G) is both achievable (some T of size τ exists) and minimal (no smaller T works).\n\nIntuitively: τ(G) measures how many vertices you need to 'break' all maximal cliques.",
+    "mathContext": "The clique transversal number is dual to the clique cover number. It measures the minimum vertex set needed to intersect every maximal clique.",
+    "significance": "essential",
+    "relatedConcepts": ["transversal", "clique", "vertex cover"]
+  },
+  {
+    "id": "ann-e151-H",
+    "proofId": "erdos-151",
+    "range": { "startLine": 70, "endLine": 88 },
+    "type": "definition",
     "title": "Triangle-Free Independence Number H(n)",
-    "content": "triangleFreeIndep n is the max k such that every triangle-free n-vertex graph has an independent set of size k. By Ramsey theory, H(n) ≥ √n.",
-    "significance": "essential"
+    "content": "**triangleFreeIndep n = H(n):** the max k such that every triangle-free graph on n vertices has an independent set of size ≥ k.\n\n**Key properties:**\n- H(n) ≥ √n (Ramsey lower bound: R(3,k) grows, so triangle-free graphs have large independent sets)\n- H(n) ≤ n (trivial)\n\nH(n) is the 'Ramsey guarantee' for triangle-free graphs.",
+    "mathContext": "By Ramsey theory, R(3,t) ~ t²/log t, so every triangle-free graph on n vertices has α(G) ≥ c√(n log n). The exact value of H(n) depends on the Ramsey function R(3,·).",
+    "significance": "essential",
+    "relatedConcepts": ["Ramsey number", "independent set", "triangle-free graph"]
   },
   {
-    "id": "erdos-151-easy",
+    "id": "ann-e151-proved-lemmas",
     "proofId": "erdos-151",
+    "range": { "startLine": 90, "endLine": 131 },
+    "type": "theorem",
+    "title": "Proved Infrastructure Lemmas",
+    "content": "**Six proved results:**\n\n1. **cliqueTransversal_nonneg:** 0 ≤ τ(G) (trivially from ℕ)\n2. **empty_transversal_iff:** ∅ is a transversal iff all maximal cliques have size < 2\n3. **conjecture_implies_easy_bound:** the conjecture implies the easier τ ≤ n − √n\n4. **triangleFree_isK4Free:** triangle-free ⟹ K₄-free (axiomatised)\n5. **complement_of_indep_is_transversal:** V \\ I is a transversal when I is independent\n\nThese form the logical backbone connecting the definitions to the conjecture.",
+    "mathContext": "The complement-of-independent-set argument is the key structural insight: if I is independent, then every maximal clique must contain at least one vertex outside I.",
+    "significance": "key",
+    "relatedConcepts": ["structural proof", "independent set", "complement"]
+  },
+  {
+    "id": "ann-e151-easy-bound",
+    "proofId": "erdos-151",
+    "range": { "startLine": 133, "endLine": 137 },
     "type": "result",
-    "range": { "startLine": 74, "endLine": 76 },
-    "title": "Easy Bound τ ≤ n − √n",
-    "content": "Every n-vertex graph has τ(G) ≤ n − √n. This follows from the Ramsey lower bound H(n) ≥ √n but is weaker than the conjecture.",
-    "significance": "supporting"
+    "title": "Easy Bound: τ(G) ≤ n − √n",
+    "content": "**clique_transversal_easy_bound:**\n\nEvery n-vertex graph has τ(G) ≤ n − √n.\n\n**Proof idea:** Take a maximum independent set I in G. Then V \\ I is a clique transversal of size n − α(G). Since every graph has α(G) ≥ √n (by Ramsey: R(ω,t) bounds), we get τ ≤ n − √n.\n\nThe conjecture strengthens √n to H(n) ≥ √n.",
+    "mathContext": "This is the baseline result against which Problem #151 is compared. The conjecture asks for a tighter bound using the exact Ramsey function for triangle-free graphs.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey bound", "independent set", "clique transversal"]
   },
   {
-    "id": "erdos-151-conjecture",
+    "id": "ann-e151-conjecture",
     "proofId": "erdos-151",
+    "range": { "startLine": 139, "endLine": 163 },
     "type": "conjecture",
-    "range": { "startLine": 80, "endLine": 83 },
-    "title": "Erdős Problem 151",
-    "content": "τ(G) ≤ n − H(n) for every n-vertex graph. This strengthens the easy bound by replacing √n with the exact Ramsey function H(n).",
-    "significance": "essential"
+    "title": "Erdős Problem #151 (OPEN)",
+    "content": "**ErdosProblem151:** τ(G) ≤ n − H(n) for every n-vertex graph G.\n\n**Special cases:**\n- Triangle-free graphs: trivially true (H(n) ≤ α(G) for triangle-free G)\n- K₄-free case: even this restriction remains open\n\n**erdos_151_K4free_open** formalises that the K₄-free case is nontrivial: proving it for K₄-free graphs would already be a significant advance.\n\nErdős noted this might be 'completely wrongheaded,' expressing doubt about the conjecture's truth.",
+    "mathContext": "The conjecture interpolates between Ramsey theory (bounding H(n)) and graph structure (bounding τ(G)). The difficulty is that τ and α are not directly related for general graphs.",
+    "significance": "critical",
+    "relatedConcepts": ["open problem", "K₄-free graphs", "Erdős–Gallai conjecture"]
+  },
+  {
+    "id": "ann-e151-summary",
+    "proofId": "erdos-151",
+    "range": { "startLine": 165, "endLine": 194 },
+    "type": "theorem",
+    "title": "Corollaries and Summary",
+    "content": "**conjecture_strengthens_easy_bound:** H(n) ≥ √n, so the conjecture is indeed stronger than the easy bound.\n\n**conjecture_reformulation:** If the conjecture holds, then τ(G) + H(n) ≤ n (additive reformulation).\n\n**erdos_151_summary** combines:\n1. The easy bound τ ≤ n − √n\n2. H(n) ≥ √n\n3. The conjecture implies the easy bound\n\nThis provides a clean summary of the current state of knowledge.",
+    "mathContext": "The reformulation τ + H ≤ n is a partition-type inequality: the graph's 'clique vulnerability' plus the Ramsey guarantee for triangle-free graphs cannot exceed the vertex count.",
+    "significance": "key",
+    "relatedConcepts": ["summary theorem", "reformulation", "state of knowledge"]
   }
 ]

--- a/src/data/proofs/erdos-162/annotations.json
+++ b/src/data/proofs/erdos-162/annotations.json
@@ -1,38 +1,122 @@
 [
   {
-    "id": "erdos-162-balanced",
+    "id": "ann-e162-header",
     "proofId": "erdos-162",
-    "type": "definition",
-    "range": { "startLine": 36, "endLine": 39 },
-    "title": "α-Balanced Subgraph",
-    "content": "IsBalanced means each colour has more than α·C(|S|,2) edges. This captures the discrepancy condition: no colour is too dominant.",
-    "significance": "essential"
+    "range": { "startLine": 1, "endLine": 27 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #162** (OPEN):\n\nFor 0 < α ≤ 1/2, define F(n, α) as the largest k such that some 2-colouring of K_n has every ≥k-vertex induced subgraph α-balanced.\n\n**Conjecture:** F(n, α) ~ c_α · log n for a constant c_α > 0.\n\n**Known:** The probabilistic method gives c₁ log n < F(n, α) < c₂ log n, but the exact constant is unknown.\n\nThis is a Ramsey-type discrepancy problem connecting graph colouring to logarithmic growth.",
+    "mathContext": "Erdős posed this in 1990. The problem sits at the intersection of Ramsey theory and discrepancy theory, asking for the precise asymptotic of the largest balanced substructure in a 2-coloured complete graph.",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey theory", "discrepancy theory", "probabilistic method"]
   },
   {
-    "id": "erdos-162-f",
+    "id": "ann-e162-imports",
     "proofId": "erdos-162",
-    "type": "definition",
-    "range": { "startLine": 43, "endLine": 46 },
-    "title": "Function F(n, α)",
-    "content": "discrepancyF n α is the largest k such that some 2-colouring of K_n has every ≥k-vertex induced subgraph α-balanced.",
-    "significance": "essential"
+    "range": { "startLine": 29, "endLine": 32 },
+    "type": "concept",
+    "title": "Imports and Setup",
+    "content": "**Mathlib imports:**\n\n- `Mathlib.Data.Nat.Choose.Basic` — binomial coefficients C(n, k), used to count edges in complete graphs\n- `Mathlib.Tactic` — standard Lean 4 tactic library\n\nThe namespace `Erdos162` encapsulates all definitions to avoid name collisions.",
+    "significance": "supporting",
+    "relatedConcepts": ["Mathlib", "binomial coefficients"]
   },
   {
-    "id": "erdos-162-bounds",
+    "id": "ann-e162-colouring",
     "proofId": "erdos-162",
+    "range": { "startLine": 34, "endLine": 49 },
+    "type": "definition",
+    "title": "Edge 2-Colouring Structure",
+    "content": "**EdgeColouring n** models a symmetric 2-colouring of the complete graph K_n.\n\n**Fields:**\n- `colour : Fin n → Fin n → Bool` — assigns red (true) or blue (false) to each pair\n- `symm` — colour is symmetric: colour(i,j) = colour(j,i)\n- `irrefl` — no self-loops: colour(i,i) = false\n\n**colourEdgeCount** counts edges of a given colour in the induced subgraph on vertex set S, filtering ordered pairs (i,j) with i < j to avoid double-counting.",
+    "mathContext": "A 2-colouring of K_n partitions its C(n,2) edges into two colour classes. The structure enforces that this is a proper edge colouring (symmetric, no self-loops).",
+    "significance": "essential",
+    "relatedConcepts": ["complete graph", "edge colouring", "Finset"]
+  },
+  {
+    "id": "ann-e162-edge-total",
+    "proofId": "erdos-162",
+    "range": { "startLine": 51, "endLine": 54 },
+    "type": "theorem",
+    "title": "Edge Count Partition",
+    "content": "**colourEdgeCount_total:**\n\nThe red and blue edge counts sum to C(|S|, 2):\n```\nred edges + blue edges = C(|S|, 2)\n```\n\nThis is the fundamental partition identity: every edge is exactly one colour. Currently stated with `sorry` — the proof requires showing the filter partition covers all ordered pairs with i < j.",
+    "mathContext": "This identity is the basis for the balance condition: if both colours exceed α · C(|S|,2), then α must be at most 1/2.",
+    "significance": "key",
+    "relatedConcepts": ["partition", "binomial coefficient", "double counting"]
+  },
+  {
+    "id": "ann-e162-balanced",
+    "proofId": "erdos-162",
+    "range": { "startLine": 56, "endLine": 74 },
+    "type": "definition",
+    "title": "α-Balanced Colourings",
+    "content": "**IsBalancedOn c S α** — a colouring c is α-balanced on vertex set S if each colour has more than α · C(|S|,2) edges.\n\n**IsKBalanced c k α** — c is (k, α)-balanced if every induced subgraph on ≥k vertices is α-balanced.\n\n**balanced_requires_le_half** — if α > 1/2, no colouring can be α-balanced on any set with ≥2 vertices. This is because both colours would need more than half the edges, which is impossible.\n\nThe parameter α ∈ (0, 1/2] controls how strict the balance requirement is:\n- α near 0: almost any colouring works\n- α = 1/2: each colour must have almost exactly half the edges",
+    "mathContext": "The balance condition captures discrepancy: a balanced colouring distributes edges evenly between colours. This is dual to Ramsey theory, where we seek monochromatic substructures.",
+    "significance": "essential",
+    "relatedConcepts": ["discrepancy", "Ramsey theory", "graph colouring"]
+  },
+  {
+    "id": "ann-e162-function-f",
+    "proofId": "erdos-162",
+    "range": { "startLine": 76, "endLine": 102 },
+    "type": "definition",
+    "title": "The Function F(n, α)",
+    "content": "**discrepancyF n α** — axiomatised as the largest k such that some 2-colouring of K_n is (k, α)-balanced.\n\n**Key properties (axiomatised):**\n- **Characterisation:** F(n, α) = k iff there exists a (k, α)-balanced colouring but no (k+1, α)-balanced one\n- **Monotonicity:** F(n, α) ≤ F(n, β) when α ≥ β (stricter balance → smaller F)\n- **Trivial case:** F(n, 0) = n (every colouring is 0-balanced)\n- **Upper bound:** F(n, α) ≤ n (can't exceed total vertices)\n\nAxiomatised because computing F exactly requires exhaustive search over all 2^C(n,2) colourings.",
+    "mathContext": "F(n, α) is well-defined by finiteness of the set of 2-colourings. It captures the extremal question: how well can we balance a colouring across all large induced subgraphs?",
+    "significance": "critical",
+    "relatedConcepts": ["extremal combinatorics", "axiom", "computability"]
+  },
+  {
+    "id": "ann-e162-bounds",
+    "proofId": "erdos-162",
+    "range": { "startLine": 104, "endLine": 118 },
     "type": "result",
-    "range": { "startLine": 56, "endLine": 64 },
-    "title": "Logarithmic Bounds",
-    "content": "The probabilistic method gives c₁(α)·log n < F(n,α) < c₂(α)·log n, establishing logarithmic growth but not the exact constant.",
-    "significance": "essential"
+    "title": "Logarithmic Bounds via Probabilistic Method",
+    "content": "**Lower bound (discrepancy_lower):**\nF(n, α) > c₁(α) · log n — a random 2-colouring is α-balanced on all sets of size ≤ c₁ log n with positive probability, by Chernoff bounds + union bound over C(n, c₁ log n) subsets.\n\n**Upper bound (discrepancy_upper):**\nF(n, α) < c₂(α) · log n — by a Ramsey-type counting argument, any colouring must have an imbalanced induced subgraph of size c₂ log n.\n\nTogether: F(n, α) = Θ(log n), but with potentially different constants c₁ ≠ c₂.",
+    "mathContext": "The lower bound uses the Lovász Local Lemma or Chernoff + union bound. The upper bound follows from Ramsey-type arguments. The gap between c₁ and c₂ is what Problem 162 asks to close.",
+    "significance": "critical",
+    "relatedConcepts": ["probabilistic method", "Chernoff bound", "Ramsey numbers"]
   },
   {
-    "id": "erdos-162-conjecture",
+    "id": "ann-e162-theta",
     "proofId": "erdos-162",
+    "range": { "startLine": 120, "endLine": 134 },
+    "type": "theorem",
+    "title": "Θ(log n) Growth and Extremal Case",
+    "content": "**discrepancy_theta_log** — combines the lower and upper bounds to establish F(n, α) = Θ(log n).\n\n**half_is_extremal** — F(n, 1/2) ≤ F(n, α) for all α ≤ 1/2, by monotonicity. The case α = 1/2 is the hardest: requiring each colour to have nearly half the edges is the tightest constraint.\n\nThis is the first proved theorem (not axiom): it follows directly from combining the axiomatised bounds.",
+    "mathContext": "The Θ(log n) result is well-established in the literature. The open question is whether the ratio F(n,α)/log n converges to a definite limit.",
+    "significance": "key",
+    "relatedConcepts": ["asymptotic growth", "extremal values", "monotonicity"]
+  },
+  {
+    "id": "ann-e162-conjecture",
+    "proofId": "erdos-162",
+    "range": { "startLine": 136, "endLine": 148 },
     "type": "conjecture",
-    "range": { "startLine": 69, "endLine": 75 },
-    "title": "Erdős Problem 162",
-    "content": "F(n, α) / log n → c_α for some constant c_α > 0. The limit should exist and depend continuously on α.",
-    "significance": "essential"
+    "title": "The Main Conjecture (OPEN)",
+    "content": "**ErdosProblem162** — For every 0 < α ≤ 1/2, there exists c_α > 0 such that F(n, α)/log n → c_α.\n\nFormally, for every ε > 0 there exists n₀ such that for all n ≥ n₀:\n|F(n, α) / log₂ n − c_α| < ε\n\nThis is strictly stronger than Θ(log n): it asserts that the *ratio* converges to a definite limit, not merely that it stays between two constants. The conjecture also implicitly asks whether c_α varies continuously with α.",
+    "mathContext": "Convergence of F(n,α)/log n would require understanding the fine structure of optimal colourings. Current methods (probabilistic, Ramsey-theoretic) give only order-of-magnitude bounds.",
+    "significance": "critical",
+    "relatedConcepts": ["limit", "convergence", "asymptotic analysis"]
+  },
+  {
+    "id": "ann-e162-examples",
+    "proofId": "erdos-162",
+    "range": { "startLine": 150, "endLine": 162 },
+    "type": "theorem",
+    "title": "Concrete Edge Count Examples",
+    "content": "**Verified examples** (via `native_decide`):\n\n- C(1, 2) = 0 — K₁ has no edges\n- C(2, 2) = 1 — K₂ has 1 edge\n- C(4, 2) = 6 — K₄ has 6 edges (balanced colouring: 3 red, 3 blue)\n- C(8, 2) = 28 — K₈ has 28 edges (probabilistic method ensures balanced colourings exist)\n\nThese ground the abstract theory in concrete computations that Lean can verify.",
+    "mathContext": "The examples illustrate the growth C(n,2) = n(n-1)/2. For K₄, a perfect balance (3 red, 3 blue) is achievable. As n grows, the question is how large a balanced subgraph persists.",
+    "significance": "supporting",
+    "relatedConcepts": ["native_decide", "binomial coefficient", "complete graph"]
+  },
+  {
+    "id": "ann-e162-summary",
+    "proofId": "erdos-162",
+    "range": { "startLine": 164, "endLine": 186 },
+    "type": "concept",
+    "title": "Summary and Open Directions",
+    "content": "**Summary of the formalization:**\n\n1. **Defined:** Edge 2-colourings, α-balanced subgraphs, and the function F(n, α)\n2. **Axiomatised:** F's characterisation, monotonicity, and logarithmic bounds\n3. **Proved:** F(n, α) = Θ(log n), α = 1/2 is extremal\n4. **Stated:** The open conjecture F(n, α) ~ c_α log n\n\n**Open directions:**\n- Does the limit c_α exist? (the conjecture)\n- What is c_α as a function of α?\n- Can the probabilistic bounds be tightened?\n- The problem interpolates between Ramsey (α ≈ 0) and discrepancy (α = 1/2)",
+    "mathContext": "Related problems: Erdős #617 (balanced colourings of K_{r²+1}), Erdős #161, #163. The problem connects Ramsey theory, discrepancy theory, and probabilistic combinatorics.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey theory", "discrepancy theory", "open problem"]
   }
 ]

--- a/src/data/proofs/erdos-311/annotations.json
+++ b/src/data/proofs/erdos-311/annotations.json
@@ -1,38 +1,57 @@
 [
   {
-    "id": "erdos-311-ann-1",
+    "id": "ann-e311-header",
     "proofId": "erdos-311",
-    "range": { "startLine": 26, "endLine": 35 },
+    "range": { "startLine": 1, "endLine": 17 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #311** (Erdős–Graham 1980, OPEN):\n\nDefine δ(N) = min{|1 − Σ_{n∈A} 1/n| : A ⊆ {1,...,N}, Σ ≠ 1, Σ ≤ 1} — the minimal nonzero deviation from 1 achievable by unit fraction sums.\n\n**Conjecture:** δ(N) = e^{−(c+o(1))N} for some constant c ∈ (0,1).\n\n**Known:** e^{−(1+o(1))N} ≤ δ(N) ≤ exp(−cN/(log N · log log N)³).",
+    "mathContext": "This problem connects number theory (lcm estimates via PNT), subset-sum problems, and exponential decay rates. Kovac showed the subset-sum-to-1 variant is equivalent.",
+    "significance": "critical",
+    "relatedConcepts": ["unit fractions", "Egyptian fractions", "subset sums", "prime number theorem"]
+  },
+  {
+    "id": "ann-e311-definitions",
+    "proofId": "erdos-311",
+    "range": { "startLine": 19, "endLine": 35 },
     "type": "definition",
     "title": "Unit Fraction Sum and δ(N)",
-    "content": "unitFracSum computes Σ_{n∈A} 1/n for a finite set A ⊆ ℕ. The function δ(N) is axiomatized as the minimal nonzero |1 - unitFracSum A| over A ⊆ {1,...,N}. Positivity is stated as a separate axiom.",
-    "significance": "δ(N) captures how well 1 can be approximated (but not reached) by sums of distinct unit fractions from {1,...,N}."
+    "content": "**unitFracSum A:** computes Σ_{n∈A} 1/n for a finite set A ⊆ ℕ.\n\n**delta N = δ(N):** axiomatised as the minimal nonzero value of |1 − unitFracSum A| over subsets A ⊆ {1,...,N} with sum ≤ 1 and sum ≠ 1.\n\n**delta_pos:** δ(N) > 0 for N ≥ 1 — the minimum is achieved and is strictly positive.\n\nδ(N) captures how closely 1 can be approximated (but not reached) by sums of distinct unit fractions from {1,...,N}.",
+    "mathContext": "The function δ(N) is well-defined by finiteness of subsets. It measures a form of 'Diophantine approximation' using unit fractions rather than rationals.",
+    "significance": "essential",
+    "relatedConcepts": ["unit fractions", "subset sum", "Diophantine approximation"]
   },
   {
-    "id": "erdos-311-ann-2",
+    "id": "ann-e311-lower",
     "proofId": "erdos-311",
-    "range": { "startLine": 39, "endLine": 42 },
+    "range": { "startLine": 37, "endLine": 43 },
     "type": "result",
     "title": "Lower Bound via lcm",
-    "content": "δ(N) ≥ 1/lcm(1,...,N) = e^{-(1+o(1))N}. Any nonzero deviation |1 - Σ 1/n| is at least 1/lcm(1,...,N) since clearing denominators gives an integer. The PNT shows lcm(1,...,N) = e^{(1+o(1))N}.",
-    "significance": "This gives the trivial exponential lower bound with rate 1. The conjecture asks whether the true rate c is strictly less than 1."
+    "content": "**delta_lower_bound:**\n\nδ(N) ≥ e^{−(1+ε)N} for large N.\n\n**Proof idea:** Any nonzero deviation |1 − Σ 1/n| is at least 1/lcm(1,...,N), since clearing denominators gives an integer. By the Prime Number Theorem, lcm(1,...,N) = e^{(1+o(1))N} (Chebyshev's formula).\n\nSo δ(N) ≥ e^{−(1+o(1))N}, giving exponential decay with rate 1.",
+    "mathContext": "The lcm lower bound is the 'trivial' bound. The conjecture asks whether the true rate c is strictly less than 1 — meaning δ(N) decays slower than 1/lcm.",
+    "significance": "essential",
+    "relatedConcepts": ["lcm", "prime number theorem", "Chebyshev function"]
   },
   {
-    "id": "erdos-311-ann-3",
+    "id": "ann-e311-upper",
     "proofId": "erdos-311",
-    "range": { "startLine": 46, "endLine": 50 },
+    "range": { "startLine": 45, "endLine": 51 },
     "type": "result",
     "title": "Tang's Upper Bound",
-    "content": "Tang showed δ(N) ≤ exp(-cN/(log N · log log N)³) for some c > 0. This is subexponential — better than polynomial but far from the conjectured exponential e^{-cN}.",
-    "significance": "This is the best known upper bound, demonstrating δ(N) decays faster than any polynomial but leaving a gap to the conjectured exponential rate."
+    "content": "**tang_upper_bound:**\n\nδ(N) ≤ exp(−cN/(log N · log log N)³) for some c > 0.\n\nThis is subexponential: faster than any polynomial decay, but much slower than the conjectured e^{−cN}. The triple logarithmic factor (log N · log log N)³ in the denominator significantly weakens the exponential rate.\n\nTang's result uses sophisticated constructions of near-1 unit fraction sums.",
+    "mathContext": "The gap between Tang's subexponential upper bound and the conjectured exponential rate e^{−cN} is enormous. Closing this gap is the central challenge.",
+    "significance": "key",
+    "relatedConcepts": ["unit fraction construction", "subexponential decay", "approximation"]
   },
   {
-    "id": "erdos-311-ann-4",
+    "id": "ann-e311-conjecture",
     "proofId": "erdos-311",
-    "range": { "startLine": 54, "endLine": 61 },
+    "range": { "startLine": 53, "endLine": 61 },
     "type": "conjecture",
-    "title": "The Erdős–Graham Conjecture",
-    "content": "δ(N) = e^{-(c+o(1))N} for some c ∈ (0,1). Formalized as: there exists c with 0 < c < 1 such that for every ε > 0 and large enough N, e^{-(c+ε)N} ≤ δ(N) ≤ e^{-(c-ε)N}.",
-    "significance": "This is a precise asymptotic prediction placing the decay rate of δ(N) strictly between the lcm lower bound (rate 1) and no decay (rate 0)."
+    "title": "The Erdős–Graham Conjecture (OPEN)",
+    "content": "**erdos_311_conjecture:**\n\nThere exists c ∈ (0,1) such that δ(N) = e^{−(c+o(1))N}.\n\nFormally: for every ε > 0 and large N:\ne^{−(c+ε)N} ≤ δ(N) ≤ e^{−(c−ε)N}\n\nThis says δ(N) decays at a precise exponential rate c strictly between 0 and 1.\n\n**Why c < 1?** Because c = 1 would mean δ ~ 1/lcm, which is the trivial lower bound.\n**Why c > 0?** Because δ(N) > 0 (you can't exactly reach 1 for most N).",
+    "mathContext": "The conjecture predicts that the best unit fraction approximation to 1 decays exponentially with a well-defined rate. This would be a deep result about the structure of Egyptian fraction decompositions.",
+    "significance": "critical",
+    "relatedConcepts": ["exponential decay", "Erdős–Graham", "Egyptian fractions", "open problem"]
   }
 ]

--- a/src/data/proofs/erdos-330/annotations.json
+++ b/src/data/proofs/erdos-330/annotations.json
@@ -1,38 +1,68 @@
 [
   {
-    "id": "erdos-330-ann-1",
+    "id": "ann-e330-header",
     "proofId": "erdos-330",
-    "range": { "startLine": 25, "endLine": 55 },
+    "range": { "startLine": 1, "endLine": 17 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #330** (Erdős–Nathanson, OPEN):\n\nDoes there exist a minimal asymptotic additive basis A of order h with positive upper density such that for every n ∈ A, the set of integers not representable from A \\ {n} also has positive upper density?\n\nThis asks whether minimality can be 'quantitatively strong' — not just qualitatively essential, but each element accounting for a positive proportion of representable integers.",
+    "mathContext": "Additive basis theory studies how sets A ⊆ ℕ represent integers as sums. Minimal bases are the 'critical' ones where every element matters. Problem #330 asks how much each element matters.",
+    "significance": "critical",
+    "relatedConcepts": ["additive basis", "minimal basis", "upper density", "additive number theory"]
+  },
+  {
+    "id": "ann-e330-representable",
+    "proofId": "erdos-330",
+    "range": { "startLine": 19, "endLine": 33 },
     "type": "definition",
-    "title": "Basis and Density Definitions",
-    "content": "IsRepresentable(A, h, m) checks if m is a sum of at most h elements of A. IsAsympBasis(A, h) means all sufficiently large m are representable. upperDensity is axiomatized. IsMinimalBasis requires the basis property and that removing any element destroys it. unrepresentableWithout(A, n, h) collects integers not representable from A \\ {n}.",
-    "significance": "These definitions formalize the precise notion of a minimal additive basis and the density condition on unrepresentable sets."
+    "title": "Representability and Asymptotic Basis",
+    "content": "**IsRepresentable A h m:** m can be written as a sum of at most h elements from A (with repetition).\n\nFormally: there exists a sequence f : Fin k → ℕ with k ≤ h, all values in A, summing to m.\n\n**IsAsympBasis A h:** every sufficiently large integer is representable — there exists N₀ such that all m ≥ N₀ are representable.\n\n**Example:** The set of squares {0, 1, 4, 9, ...} is an asymptotic basis of order 4 (Lagrange's theorem).",
+    "mathContext": "Waring's problem asks for the minimal h such that k-th powers form a basis of order h. General additive bases generalize this beyond perfect powers.",
+    "significance": "essential",
+    "relatedConcepts": ["additive basis", "Waring's problem", "Lagrange's theorem"]
   },
   {
-    "id": "erdos-330-ann-2",
+    "id": "ann-e330-density",
     "proofId": "erdos-330",
-    "range": { "startLine": 61, "endLine": 63 },
+    "range": { "startLine": 35, "endLine": 45 },
+    "type": "definition",
+    "title": "Upper Density",
+    "content": "**upperDensity S:** axiomatised as the upper asymptotic density of S ⊆ ℕ.\n\nProperties: 0 ≤ upperDensity(S) ≤ 1.\n\n**HasPosDensity A** means upperDensity(A) > 0.\n\nUpper density measures the 'thickness' of a set: d̄(S) = lim sup |S ∩ {1,...,n}| / n.",
+    "mathContext": "Upper density is used rather than natural density because the latter may not exist for all sets. A set with positive upper density is 'non-negligible' in the integers.",
+    "significance": "key",
+    "relatedConcepts": ["upper density", "asymptotic density", "natural density"]
+  },
+  {
+    "id": "ann-e330-minimal",
+    "proofId": "erdos-330",
+    "range": { "startLine": 47, "endLine": 55 },
+    "type": "definition",
+    "title": "Minimal Basis and Unrepresentable Sets",
+    "content": "**IsMinimalBasis A h:** A is an asymptotic basis of order h, and removing any single element n ∈ A destroys the basis property.\n\n**unrepresentableWithout A n h:** the set of integers that become unrepresentable when n is removed from A.\n\nMinimal bases are extremal: every element is essential. The question is *how* essential — does removal affect a positive proportion of integers?",
+    "mathContext": "Minimal bases are analogues of critical graphs in graph theory. The concept was introduced by Stöhr (1955) and Härtter (1956).",
+    "significance": "essential",
+    "relatedConcepts": ["minimal basis", "critical structure", "extremal combinatorics"]
+  },
+  {
+    "id": "ann-e330-known",
+    "proofId": "erdos-330",
+    "range": { "startLine": 57, "endLine": 72 },
     "type": "result",
-    "title": "Infinite Unrepresentables",
-    "content": "For a minimal basis A of order h, removing any n ∈ A leaves infinitely many integers unrepresentable. This is immediate from minimality: if only finitely many were unrepresentable, A \\ {n} would still be a basis.",
-    "significance": "This is the baseline consequence of minimality. The open question asks whether 'infinitely many' can be strengthened to 'positive density'."
+    "title": "Known Results",
+    "content": "**minimal_basis_infinite_unrep:** For a minimal basis, removing any element leaves *infinitely many* integers unrepresentable. This is immediate from the definition of minimality.\n\n**minimal_basis_exists:** Minimal bases of every order h ≥ 2 exist.\n\n**minimal_basis_pos_density_exists:** (Härtter 1956, Stöhr 1955) Minimal bases with positive density exist for every h ≥ 2.\n\nThe weaker condition (minimality + positive density) is established. Problem #330 asks for the stronger condition (each removal yields positive-density unrepresentables).",
+    "mathContext": "The progression: minimality (qualitative) → positive density basis (quantitative) → positive density unrepresentables (strongly quantitative). Each step is harder.",
+    "significance": "key",
+    "relatedConcepts": ["Härtter", "Stöhr", "existence theorems", "additive number theory"]
   },
   {
-    "id": "erdos-330-ann-3",
+    "id": "ann-e330-conjecture",
     "proofId": "erdos-330",
-    "range": { "startLine": 69, "endLine": 72 },
-    "type": "result",
-    "title": "Existence of Minimal Bases with Positive Density",
-    "content": "Härtter (1956) and Stöhr (1955) showed that for every order h ≥ 2, there exist minimal asymptotic bases with positive upper density. This establishes the weaker version of the problem.",
-    "significance": "The existence of such bases is the starting point for Problem #330, which asks for the additional property that each element's removal yields a positive-density unrep. set."
-  },
-  {
-    "id": "erdos-330-ann-4",
-    "proofId": "erdos-330",
-    "range": { "startLine": 80, "endLine": 85 },
+    "range": { "startLine": 74, "endLine": 85 },
     "type": "conjecture",
-    "title": "Strong Minimal Basis Conjecture",
-    "content": "Erdős and Nathanson asked: does there exist a minimal basis A of order h with positive density such that for every n ∈ A, the set of integers not representable without n also has positive upper density? This strengthens minimality from a qualitative to a quantitative condition.",
-    "significance": "A positive answer would show that in certain bases, every element is not just essential but quantitatively critical, contributing to the representability of a positive proportion of integers."
+    "title": "Erdős Problem #330 (OPEN)",
+    "content": "**erdos_330_strong_minimal_basis:**\n\nThere exist A, h such that:\n1. A is a minimal basis of order h\n2. A has positive upper density\n3. For every n ∈ A, the set unrepresentableWithout(A, n, h) has positive upper density\n\nThis 'strong minimality' condition says every element of A is quantitatively important — removing any one element makes a positive proportion of integers unreachable.",
+    "mathContext": "A positive answer would demonstrate that additive bases can be simultaneously dense AND have every element be critically important. This is a deep structural question about additive combinatorics.",
+    "significance": "critical",
+    "relatedConcepts": ["strong minimality", "additive basis", "open problem", "Erdős–Nathanson"]
   }
 ]

--- a/src/data/proofs/erdos-374/annotations.json
+++ b/src/data/proofs/erdos-374/annotations.json
@@ -1,38 +1,57 @@
 [
   {
-    "id": "erdos-374-ann-1",
+    "id": "ann-e374-header",
     "proofId": "erdos-374",
-    "range": { "startLine": 27, "endLine": 52 },
+    "range": { "startLine": 1, "endLine": 19 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #374** (OPEN):\n\nFor m ∈ ℕ, define F(m) as the minimal k ≥ 2 such that there exist a₁ < a₂ < ... < aₖ = m with a₁! · a₂! · ... · aₖ! a perfect square. Let Dₖ = {m : F(m) = k}.\n\n**Question:** What is the growth rate of |Dₖ ∩ {1,...,n}| for 3 ≤ k ≤ 6?\n\n**Known:** D₂ = perfect squares, primes are in no Dₖ, Dₖ = ∅ for k > 6, min(D₆) = 527.",
+    "mathContext": "This problem connects factorial arithmetic (prime factorizations of n!) with perfect square detection. The classification into finitely many classes D₂,...,D₆ is a remarkable structural result.",
+    "significance": "critical",
+    "relatedConcepts": ["factorials", "perfect squares", "prime factorization", "Legendre's formula"]
+  },
+  {
+    "id": "ann-e374-definitions",
+    "proofId": "erdos-374",
+    "range": { "startLine": 21, "endLine": 52 },
     "type": "definition",
     "title": "Factorial Product Definitions",
-    "content": "IsPerfectSquare checks if n = k². factorialProduct computes the product a₁!···aₖ! via fold. HasSquareFactorialProduct checks existence of a valid sequence. bigF(m) is axiomatized as the minimal k ≥ 2, and inDk classifies m into Dₖ.",
-    "significance": "The definition chain captures the key notion: when can m be the largest element of an increasing sequence whose factorial product is a square?"
+    "content": "**IsPerfectSquare n:** n = k² for some k.\n\n**factorialProduct seq:** computes a₁! · a₂! · ... · aₖ! via left fold.\n\n**HasSquareFactorialProduct m k:** there exists a strictly increasing sequence of length k ending at m whose factorial product is a perfect square.\n\n**bigF m = F(m):** axiomatised as the minimal such k (≥ 2).\n\n**inDk k m:** m belongs to class Dₖ, meaning F(m) = k.\n\nThe key insight: a product of factorials is a perfect square iff all primes appear to even total multiplicity across all factorials.",
+    "mathContext": "By Legendre's formula, v_p(n!) = Σ_{i≥1} ⌊n/p^i⌋. The parity of v_p(a₁! · ... · aₖ!) determines whether the product is a perfect square.",
+    "significance": "essential",
+    "relatedConcepts": ["Legendre's formula", "p-adic valuation", "factorials"]
   },
   {
-    "id": "erdos-374-ann-2",
+    "id": "ann-e374-D2",
     "proofId": "erdos-374",
-    "range": { "startLine": 56, "endLine": 62 },
+    "range": { "startLine": 54, "endLine": 62 },
     "type": "result",
-    "title": "D₂ and Prime Exclusion",
-    "content": "D₂ equals the perfect squares > 1 (since m! is a square iff m is a square). No prime p belongs to any Dₖ, as factorial products involving p! cannot be squares due to the odd multiplicity of p in p!.",
-    "significance": "D₂ is completely characterized, and prime exclusion shows the sets Dₖ have density 0 among primes."
+    "title": "D₂ = Perfect Squares and Prime Exclusion",
+    "content": "**D2_eq_squares:** D₂ consists exactly of perfect squares > 1.\n\nWhy: F(m) = 2 means m! itself (or a single pair) gives a square. Since n! is a perfect square iff n is a perfect square (by parity of v_p(n!)), D₂ = {4, 9, 16, 25, ...}.\n\n**no_prime_in_Dk:** No prime p belongs to any Dₖ.\n\nWhy: p! has v_p(p!) = 1 (odd), and including p in any product preserves this odd parity. So no factorial product involving p! can be a perfect square.",
+    "mathContext": "The prime exclusion is the simplest non-trivial structural result. It shows that the sets Dₖ are concentrated among composite numbers.",
+    "significance": "key",
+    "relatedConcepts": ["perfect squares", "prime numbers", "p-adic valuation"]
   },
   {
-    "id": "erdos-374-ann-3",
+    "id": "ann-e374-D6",
     "proofId": "erdos-374",
     "range": { "startLine": 64, "endLine": 69 },
     "type": "result",
-    "title": "Finiteness of Classification and D₆",
-    "content": "Dₖ = ∅ for k > 6, so every integer with a defined F(m) has F(m) ∈ {2,3,4,5,6}. The smallest element of D₆ is 527, determined computationally.",
-    "significance": "The finiteness of the classification (only 5 nonempty classes) is remarkable. The sparseness of D₆ (starting at 527) suggests higher classes have very few elements."
+    "title": "Finiteness: Only D₂ through D₆",
+    "content": "**Dk_empty_above_6:** Dₖ = ∅ for k ≥ 7.\n\nEvery integer with a defined F(m) has F(m) ∈ {2, 3, 4, 5, 6}. There are only 5 nonempty classes.\n\n**D6_smallest:** The smallest element of D₆ is 527, determined by exhaustive computation.\n\nThe sparseness of D₆ (starting at 527) contrasts with D₂ (starting at 4) and D₃ (starting at small composites).",
+    "mathContext": "The bound k ≤ 6 comes from a parity argument: with enough terms in the product, the prime factorization parities can always be balanced. The exact bound 6 is tight since 527 ∈ D₆.",
+    "significance": "key",
+    "relatedConcepts": ["parity argument", "computational verification", "OEIS"]
   },
   {
-    "id": "erdos-374-ann-4",
+    "id": "ann-e374-conjecture",
     "proofId": "erdos-374",
-    "range": { "startLine": 73, "endLine": 79 },
+    "range": { "startLine": 71, "endLine": 80 },
     "type": "conjecture",
-    "title": "Growth Rate Question",
-    "content": "The open question asks for the asymptotic growth of |Dₖ ∩ {1,...,n}| for 3 ≤ k ≤ 6. Formalized as asking whether each Dₖ has polynomial growth n^α for some exponent α.",
-    "significance": "Understanding these growth rates would complete the picture of how factorials combine to form perfect squares."
+    "title": "Growth Rate Question (OPEN)",
+    "content": "**erdos_374_growth_rate:**\n\nFor 3 ≤ k ≤ 6, determine the growth rate of |Dₖ ∩ {1,...,n}|.\n\nFormalised as: for each k, there exists an exponent α ∈ (0,1] such that |Dₖ ∩ {1,...,n}| ≤ n^{α+ε} for large n.\n\nExpected: D₃ is the densest (most composites have F = 3), while D₆ is the sparsest. Understanding the growth rates would reveal the 'landscape' of factorial square products.",
+    "mathContext": "Since D₂ grows like √n (perfect squares), one expects D₃ to dominate for composites and higher classes to be increasingly sparse.",
+    "significance": "critical",
+    "relatedConcepts": ["growth rate", "counting function", "open problem", "factorials"]
   }
 ]

--- a/src/data/proofs/erdos-469/annotations.json
+++ b/src/data/proofs/erdos-469/annotations.json
@@ -1,38 +1,79 @@
 [
   {
-    "id": "erdos-469-ann-1",
+    "id": "ann-e469-header",
     "proofId": "erdos-469",
-    "range": { "startLine": 24, "endLine": 37 },
+    "range": { "startLine": 1, "endLine": 16 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #469** (OPEN):\n\nDoes the sum Σ_{n∈A} 1/n converge, where A is the set of primitive pseudoperfect (semiperfect) numbers?\n\nA primitive pseudoperfect number n is one that equals a sum of distinct proper divisors, but no proper divisor of n has this property.\n\n**Known members of A:** 6, 20, 28, 88, 104, 272, 304, 350, ... (OEIS A006036)",
+    "mathContext": "Convergence of Σ 1/n over a set A measures its 'thickness' — it converges iff A is sufficiently sparse. The primes have divergent reciprocal sum, so convergence would show A is much sparser than the primes.",
+    "significance": "critical",
+    "relatedConcepts": ["pseudoperfect numbers", "primitive sets", "reciprocal sums", "divisor sums"]
+  },
+  {
+    "id": "ann-e469-definitions",
+    "proofId": "erdos-469",
+    "range": { "startLine": 18, "endLine": 37 },
     "type": "definition",
     "title": "Pseudoperfect and Primitive Definitions",
-    "content": "IsPseudoperfect(n) holds when n equals the sum of a subset of its proper divisors. IsPrimitivePseudoperfect(n) additionally requires that no proper divisor of n is pseudoperfect. primitivePseudoperfectSet collects all such numbers.",
-    "significance": "The definition of primitivity via divisor chains is the key structural condition that makes the convergence question nontrivial."
+    "content": "**IsPseudoperfect n:** n equals the sum of a subset S of its proper divisors. Uses Mathlib's `n.properDivisors`.\n\n**Example:** 12 is pseudoperfect: 12 = 1 + 2 + 3 + 6.\n\n**IsPrimitivePseudoperfect n:** n is pseudoperfect, positive, and no proper divisor m | n (m < n) is pseudoperfect.\n\n**primitivePseudoperfectSet:** the set A of all primitive pseudoperfect numbers.\n\nPrimitivity means A forms an antichain in the divisibility order: no element divides another.",
+    "mathContext": "Pseudoperfect numbers generalise perfect numbers (where ALL proper divisors sum to n). The primitive ones are the 'minimal' representatives under divisibility.",
+    "significance": "essential",
+    "relatedConcepts": ["proper divisors", "subset sum", "perfect numbers", "antichain"]
   },
   {
-    "id": "erdos-469-ann-2",
+    "id": "ann-e469-perfect",
     "proofId": "erdos-469",
-    "range": { "startLine": 42, "endLine": 51 },
-    "type": "result",
-    "title": "Perfect Numbers and 6",
-    "content": "6 is the smallest primitive pseudoperfect number: 6 = 1 + 2 + 3, and none of 1, 2, 3 are pseudoperfect. Every perfect number (where proper divisors sum to n) is pseudoperfect.",
-    "significance": "Perfect numbers provide a natural source of pseudoperfect numbers. The primitivity of 6 illustrates the concept."
+    "range": { "startLine": 39, "endLine": 59 },
+    "type": "theorem",
+    "title": "Perfect Numbers and Verified Examples",
+    "content": "**perfect_is_pseudoperfect:** Every perfect number is pseudoperfect (trivially: use all proper divisors).\n\n**Verified pseudoperfect numbers** (via `by decide`):\n- 6 = 1 + 2 + 3\n- 12 = 1 + 2 + 3 + 6\n- 20 = 1 + 4 + 5 + 10\n\nThese are constructive proofs: Lean verifies the explicit divisor subsets.",
+    "mathContext": "Perfect numbers (6, 28, 496, 8128, ...) are automatically pseudoperfect. Whether they are primitive depends on their divisors' pseudoperfectness.",
+    "significance": "key",
+    "relatedConcepts": ["perfect numbers", "constructive proof", "by decide"]
   },
   {
-    "id": "erdos-469-ann-3",
+    "id": "ann-e469-non-pseudo",
     "proofId": "erdos-469",
-    "range": { "startLine": 53, "endLine": 59 },
-    "type": "result",
-    "title": "Infinitude and Closure Properties",
-    "content": "There are infinitely many primitive pseudoperfect numbers. Every multiple of a pseudoperfect number is pseudoperfect, which means primitivity is determined by the 'minimal' elements in the divisibility order.",
-    "significance": "The multiplicative closure ensures that the primitive elements form an antichain in the divisibility order, analogous to primitive abundant numbers."
+    "range": { "startLine": 61, "endLine": 118 },
+    "type": "theorem",
+    "title": "Non-Pseudoperfect Numbers and Lower Bound",
+    "content": "**Deficiency argument:** For n ≤ 5, the sum of ALL proper divisors is < n, so no subset can reach n.\n\nProved individually for 0, 1, 2, 3, 4, 5 using `subset_sum_le_total` (any subset sum ≤ total sum of proper divisors) and explicit computation of σ₀(n).\n\n**pseudoperfect_ge_six:** The smallest pseudoperfect number is 6. Proved by exhaustive case analysis on n ∈ {0,...,5}.\n\nThis is a clean structural result: small numbers are too 'deficient' to be pseudoperfect.",
+    "mathContext": "The proper divisor sum σ₀(n) = σ(n) − n determines whether pseudoperfection is possible. For deficient numbers (σ₀(n) < n), it's impossible.",
+    "significance": "key",
+    "relatedConcepts": ["deficient numbers", "divisor sum", "case analysis"]
   },
   {
-    "id": "erdos-469-ann-4",
+    "id": "ann-e469-primitive-6",
     "proofId": "erdos-469",
-    "range": { "startLine": 66, "endLine": 70 },
+    "range": { "startLine": 120, "endLine": 154 },
+    "type": "theorem",
+    "title": "6 is Primitive Pseudoperfect",
+    "content": "**primitive_pseudoperfect_6:** 6 is the smallest primitive pseudoperfect number.\n\n**Proof:** 6 = 1 + 2 + 3 (pseudoperfect), and its proper divisors {1, 2, 3} are all < 6, hence all pseudoperfect numbers are ≥ 6, so no divisor of 6 is pseudoperfect.\n\n**Structural theorems:** primitive_pos, primitive_is_pseudoperfect, primitive_no_divisor_pseudoperfect, primitive_pseudoperfect_ge_six — extracting the components of primitivity.",
+    "mathContext": "6 is both the smallest perfect number and the smallest primitive pseudoperfect number. This is because all perfect numbers ≤ 6 have divisors that are too small to be pseudoperfect.",
+    "significance": "key",
+    "relatedConcepts": ["6", "smallest example", "primitivity"]
+  },
+  {
+    "id": "ann-e469-abundance",
+    "proofId": "erdos-469",
+    "range": { "startLine": 156, "endLine": 188 },
+    "type": "definition",
+    "title": "Abundance, Deficiency, and Weird Numbers",
+    "content": "**sigma0 n:** sum of proper divisors (σ₀(n) = σ(n) − n).\n\n**IsAbundant n:** σ₀(n) > n (proper divisors sum to more than n).\n**IsDeficient n:** σ₀(n) < n.\n**IsPerfect' n:** σ₀(n) = n.\n\n**deficient_not_pseudoperfect:** If σ₀(n) < n, then n is not pseudoperfect (no subset can reach n).\n\n**IsWeird n:** abundant but NOT pseudoperfect. The smallest weird number is 70.\n\nWeird numbers show that having enough divisor sum (abundance) doesn't guarantee pseudoperfection — the subset-sum problem can still fail.",
+    "mathContext": "The classification abundant/deficient/perfect partitions the positive integers. Weird numbers are the 'pathological' cases: abundant yet not pseudoperfect.",
+    "significance": "key",
+    "relatedConcepts": ["abundant numbers", "deficient numbers", "weird numbers", "70"]
+  },
+  {
+    "id": "ann-e469-conjecture",
+    "proofId": "erdos-469",
+    "range": { "startLine": 190, "endLine": 210 },
     "type": "conjecture",
-    "title": "Convergence of Reciprocal Sum",
-    "content": "Erdős asked whether the sum of 1/n over all primitive pseudoperfect numbers n converges. The formalization asserts convergence via a uniform bound on finite partial sums.",
-    "significance": "Convergence would imply the set is very sparse (sparser than primes). This is a fundamental question about the distribution of these divisor-sum extremal numbers."
+    "title": "Erdős Problem #469 (OPEN)",
+    "content": "**infinitely_many_primitive:** There are infinitely many primitive pseudoperfect numbers.\n\n**erdos_469_convergence:** The reciprocal sum Σ_{n∈A} 1/n converges.\n\nFormalised as: there exists B > 0 such that every finite subset S ⊆ A has Σ_{n∈S} 1/n ≤ B.\n\n**multiple_of_pseudoperfect:** Every multiple of a pseudoperfect number is pseudoperfect.\n\nThis closure under multiplication means the primitive pseudoperfect numbers form a divisibility antichain, analogous to primes but for pseudoperfection.",
+    "mathContext": "The multiplicative closure is key: since n pseudoperfect ⟹ kn pseudoperfect, the primitives are exactly the 'atoms' — every pseudoperfect number is a multiple of a primitive one.",
+    "significance": "critical",
+    "relatedConcepts": ["reciprocal sum", "convergence", "antichain", "open problem"]
   }
 ]

--- a/src/data/proofs/erdos-497/annotations.json
+++ b/src/data/proofs/erdos-497/annotations.json
@@ -1,38 +1,68 @@
 [
   {
-    "id": "erdos-497-antichain",
+    "id": "ann-e497-header",
     "proofId": "erdos-497",
+    "range": { "startLine": 1, "endLine": 18 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #497** (SOLVED):\n\nHow many antichains (Sperner families) exist in the power set P([n])?\n\n**Answer:** 2^{(1+o(1)) · C(n, ⌊n/2⌋)} (Kleitman 1969).\n\nThis is closely related to Dedekind's problem (OEIS A000372) on the number of monotone Boolean functions, one of the oldest problems in combinatorics.",
+    "mathContext": "The Dedekind numbers D(n) count antichains in P([n]). They grow doubly exponentially — roughly 2^{C(n,n/2)} — making them extremely difficult to compute. D(9) was only determined in 2023.",
+    "significance": "critical",
+    "relatedConcepts": ["Dedekind numbers", "antichains", "Sperner families", "Boolean lattice"]
+  },
+  {
+    "id": "ann-e497-antichain",
+    "proofId": "erdos-497",
+    "range": { "startLine": 20, "endLine": 36 },
     "type": "definition",
-    "range": { "startLine": 28, "endLine": 31 },
-    "title": "Antichain (Sperner Family)",
-    "content": "IsAntichain n F means F is a family of subsets of [n] with no containment between distinct members. These are also called Sperner families.",
-    "significance": "essential"
+    "title": "Antichain and Counting",
+    "content": "**IsAntichain n F:** F is a family of subsets of Fin n with no containment between distinct members. If A ⊆ B and both are in F, then A = B.\n\n**antichainCount n:** the total number of antichains in P([n]), computed by filtering all subfamilies of the powerset.\n\nThese are also called Sperner families (after Sperner's 1928 theorem) or antichains in the Boolean lattice 2^[n].",
+    "mathContext": "The Boolean lattice 2^[n] has 2^n elements ordered by inclusion. An antichain is a set of pairwise incomparable elements. The width (maximum antichain size) is C(n, ⌊n/2⌋) by Sperner's theorem.",
+    "significance": "essential",
+    "relatedConcepts": ["Boolean lattice", "partial order", "incomparability"]
   },
   {
-    "id": "erdos-497-sperner",
+    "id": "ann-e497-sperner",
     "proofId": "erdos-497",
+    "range": { "startLine": 38, "endLine": 48 },
     "type": "result",
-    "range": { "startLine": 39, "endLine": 42 },
-    "title": "Sperner's Theorem",
-    "content": "Every antichain in P([n]) has size at most C(n, ⌊n/2⌋). This classical result (1928) gives the maximum width of the Boolean lattice.",
-    "significance": "essential"
+    "title": "Sperner's Theorem and Middle Layer",
+    "content": "**sperner_theorem:** Every antichain in P([n]) has size ≤ C(n, ⌊n/2⌋).\n\nThis is the maximum width of the Boolean lattice, achieved by the middle layer.\n\n**middle_layer_antichain:** The family of all ⌊n/2⌋-element subsets of [n] is an antichain achieving the Sperner bound.\n\nSperner's theorem (1928) is one of the foundational results of extremal set theory.",
+    "mathContext": "The proof uses the LYM inequality (Lubell-Yamamoto-Meshalkin): Σ 1/C(n,|A|) ≤ 1 for any antichain. Since C(n, ⌊n/2⌋) is the largest binomial coefficient, this gives the bound.",
+    "significance": "essential",
+    "relatedConcepts": ["Sperner's theorem", "LYM inequality", "middle layer", "extremal set theory"]
   },
   {
-    "id": "erdos-497-dedekind",
+    "id": "ann-e497-dedekind",
     "proofId": "erdos-497",
+    "range": { "startLine": 50, "endLine": 58 },
     "type": "result",
-    "range": { "startLine": 50, "endLine": 56 },
     "title": "Small Dedekind Numbers",
-    "content": "D(0)=2, D(1)=3, D(2)=6, D(3)=20, D(4)=168. These are the number of antichains for small n, forming OEIS A000372.",
-    "significance": "supporting"
+    "content": "**Axiomatised values:**\n- D(0) = 2, D(1) = 3, D(2) = 6, D(3) = 20, D(4) = 168\n\nThese form OEIS A000372. The sequence grows extremely fast:\n- D(5) = 7581\n- D(6) = 7,828,354\n- D(7) = 2,414,682,040,998\n- D(8) = 56,130,437,228,687,557,907,788\n- D(9) was determined in 2023\n\nThe double-exponential growth makes exact computation extremely difficult beyond small n.",
+    "mathContext": "Dedekind posed this problem in 1897. It remains one of the hardest counting problems in combinatorics, with each new value requiring massive computational effort.",
+    "significance": "supporting",
+    "relatedConcepts": ["OEIS A000372", "Dedekind's problem", "computational complexity"]
   },
   {
-    "id": "erdos-497-kleitman",
+    "id": "ann-e497-bounds",
     "proofId": "erdos-497",
-    "type": "conjecture",
-    "range": { "startLine": 76, "endLine": 83 },
-    "title": "Erdős Problem 497 (Solved)",
-    "content": "Kleitman (1969): the number of antichains in P([n]) is 2^{(1+o(1))·C(n, ⌊n/2⌋)}. This determines the logarithmic order of the Dedekind numbers.",
-    "significance": "essential"
+    "range": { "startLine": 60, "endLine": 65 },
+    "type": "result",
+    "title": "Trivial Upper Bound",
+    "content": "**trivial_upper_bound:** antichainCount(n) ≤ 2^{C(n, ⌊n/2⌋)}.\n\nEvery antichain is a subset of the middle layer's 'neighbourhood,' giving at most 2^{C(n,n/2)} choices.\n\nThis bound is tight in the logarithmic sense: log₂(antichainCount(n)) ~ C(n, n/2).",
+    "mathContext": "The key insight is that most antichains consist primarily of sets near the middle layer. Sets far from the middle layer contribute negligibly to the count.",
+    "significance": "key",
+    "relatedConcepts": ["upper bound", "middle layer", "exponential counting"]
+  },
+  {
+    "id": "ann-e497-kleitman",
+    "proofId": "erdos-497",
+    "range": { "startLine": 67, "endLine": 87 },
+    "type": "theorem",
+    "title": "Kleitman's Theorem (Erdős Problem 497 — SOLVED)",
+    "content": "**kleitman_lower + kleitman_upper:**\n\nFor every ε > 0 and large enough n:\n(1−ε) · C(n,n/2) ≤ log₂(antichainCount(n)) ≤ (1+ε) · C(n,n/2)\n\nEquivalently: antichainCount(n) = 2^{(1+o(1)) · C(n, ⌊n/2⌋)}.\n\n**ErdosProblem497** formalises this as the conjunction of lower and upper asymptotic bounds.\n\nKleitman's proof (1969) uses a delicate entropy argument and correlation inequalities.",
+    "mathContext": "This determines the logarithmic order of the Dedekind numbers: log₂ D(n) ~ C(n, ⌊n/2⌋) ~ 2^n · √(2/(πn)). The exact constant in front remains an open question.",
+    "significance": "critical",
+    "relatedConcepts": ["Kleitman", "Dedekind numbers", "entropy method", "correlation inequality"]
   }
 ]

--- a/src/data/proofs/erdos-773/annotations.json
+++ b/src/data/proofs/erdos-773/annotations.json
@@ -1,46 +1,90 @@
 [
   {
-    "id": "erdos-773-header",
+    "id": "ann-e773-header",
     "proofId": "erdos-773",
-    "type": "concept",
     "range": { "startLine": 1, "endLine": 23 },
+    "type": "concept",
     "title": "Problem Overview",
-    "content": "Erdős Problem #773: What is the max size of a Sidon subset of {1², 2², ..., N²}? OPEN: lower bound N^{2/3} (Lefmann-Thiele), upper bound N/(log N)^{1/4} (Alon-Erdős).",
-    "mathContext": "A Sidon set has all pairwise sums distinct. The sparsity of sums of two squares (Landau) constrains Sidon subsets of squares.",
+    "content": "**Erdős Problem #773** (OPEN):\n\nWhat is the size of the largest Sidon subset A ⊆ {1², 2², ..., N²}? Is it N^{1−o(1)}?\n\n**Known bounds:**\n- Lower: |A| ≥ c · N^{2/3} (Lefmann–Thiele 1995)\n- Upper: |A| ≤ C · N/(log N)^{1/4} (Alon–Erdős 1985)\n\nThe gap between N^{2/3} and N/(log N)^{1/4} is the central open question.",
+    "mathContext": "A Sidon set has all pairwise sums distinct. The key constraint comes from Landau's theorem: sums of two squares have density ~(log N)^{−1/2}, which limits how many squares can form a Sidon set.",
     "significance": "critical",
     "relatedConcepts": ["Sidon sets", "B₂ sequences", "sums of squares", "Landau's theorem"]
   },
   {
-    "id": "erdos-773-sidon-def",
+    "id": "ann-e773-sidon",
     "proofId": "erdos-773",
-    "type": "definition",
     "range": { "startLine": 33, "endLine": 52 },
+    "type": "definition",
     "title": "Sidon Set Definitions",
-    "content": "**IsSidon(A)**: all ordered pairwise sums are distinct. **IsSidonAlt(A)**: each sum has at most one representation.",
-    "mathContext": "The Sidon property is the fundamental constraint connecting to Landau's theorem on sums of two squares.",
+    "content": "**IsSidon A:** All ordered pairwise sums are distinct — if a₁ + a₂ = b₁ + b₂ with a₁ ≤ a₂ and b₁ ≤ b₂, then a₁ = b₁ and a₂ = b₂.\n\n**IsSidonAlt A:** Alternative characterisation — each sum s has at most one representation as a + b with a ≤ b, a, b ∈ A.\n\nThe Sidon condition is a strong additive constraint: the representation function r(s) = |{(a,b) : a + b = s, a ≤ b, a,b ∈ A}| is at most 1 for all s.",
+    "mathContext": "Named after Simon Sidon, who studied such sets in the 1930s. Also called B₂ sets. For general Sidon subsets of {1,...,N}, the maximum size is ~√N (Erdős–Turán).",
+    "significance": "essential",
+    "relatedConcepts": ["B₂ sequences", "additive combinatorics", "representation function"]
+  },
+  {
+    "id": "ann-e773-squares",
+    "proofId": "erdos-773",
+    "range": { "startLine": 54, "endLine": 70 },
+    "type": "definition",
+    "title": "Perfect Squares and f(N)",
+    "content": "**squaresUpTo N:** the set {1², 2², ..., N²} = {1, 4, 9, ..., N²}.\n\n**squaresUpTo_card:** |squaresUpTo N| = N (sorry — needs proof that the squaring map is injective on Fin).\n\n**f(N):** the maximum |A| over all Sidon subsets A ⊆ squaresUpTo N.\n\nDefined as the sup of cardinalities over the powerset filtered by the Sidon property.",
+    "mathContext": "The restriction to squares makes the Sidon condition interact with additive properties of squares. Sums a² + b² are constrained by Fermat's characterisation of sums of two squares.",
     "significance": "key",
-    "relatedConcepts": ["B₂ sequences", "additive combinatorics", "representation functions"]
+    "relatedConcepts": ["perfect squares", "squaring map", "extremal function"]
   },
   {
-    "id": "erdos-773-bounds",
+    "id": "ann-e773-question",
     "proofId": "erdos-773",
+    "range": { "startLine": 72, "endLine": 89 },
+    "type": "conjecture",
+    "title": "The Main Question",
+    "content": "**MainQuestion:** Is f(N) = N^{1−o(1)}?\n\nFormally: for every ε > 0 and large enough N, f(N) ≥ N^{1−ε}.\n\nThis asks whether the Sidon constraint on squares is 'almost free' — meaning almost all squares can coexist in a Sidon set. The current bounds suggest otherwise (N^{2/3} vs N), but the question remains open.",
+    "mathContext": "If the answer is yes, squares would be much better for Sidon sets than random sets (which give only √N). The special additive structure of squares might help.",
+    "significance": "critical",
+    "relatedConcepts": ["open problem", "N^{1-o(1)}", "optimistic conjecture"]
+  },
+  {
+    "id": "ann-e773-bounds",
+    "proofId": "erdos-773",
+    "range": { "startLine": 91, "endLine": 119 },
     "type": "theorem",
-    "range": { "startLine": 91, "endLine": 120 },
     "title": "Known Bounds",
-    "content": "**lower_bound** (axiom): f(N) >= c*N^{2/3} (Lefmann-Thiele 1995). **upper_bound** (axiom): f(N) <= C*N/(log N)^{1/4} (Alon-Erdős 1985).",
-    "mathContext": "The gap between N^{2/3} and N/(log N)^{1/4} is the central open question.",
+    "content": "**lower_bound (axiom):** f(N) ≥ c · N^{2/3} (Lefmann–Thiele 1995).\n\nImproved from the original Alon–Erdős bound using a refined probabilistic argument.\n\n**upper_bound (axiom):** f(N) ≤ C · N/(log N)^{1/4} (Alon–Erdős 1985).\n\nThe upper bound uses Landau's theorem on sums of two squares.\n\n**current_knowledge:** combines both bounds into a single theorem.\n\nThe gap: N^{2/3} ≤ f(N) ≤ N/(log N)^{1/4}. The lower bound is polynomial, the upper is nearly linear.",
+    "mathContext": "The N^{2/3} lower bound comes from random selection with density N^{−1/3}. The N/(log N)^{1/4} upper bound comes from counting: Sidon requires distinct sums, but sums of two squares are sparse.",
     "significance": "critical",
-    "relatedConcepts": ["probabilistic method", "counting argument", "Landau's theorem"]
+    "relatedConcepts": ["probabilistic method", "Landau's theorem", "Lefmann–Thiele"]
   },
   {
-    "id": "erdos-773-summary",
+    "id": "ann-e773-landau",
     "proofId": "erdos-773",
+    "range": { "startLine": 121, "endLine": 160 },
+    "type": "theorem",
+    "title": "Landau's Theorem and the Constraint",
+    "content": "**r2 n:** number of ways to write n = a² + b² (with sign and order).\n\n**sumOfTwoSquaresCount N:** count of n ≤ N that are sums of two squares.\n\n**landau_theorem (1908):** S(N) ~ c · N/√(log N), where c is the Landau–Ramanujan constant. The density of sums of two squares decays like (log N)^{−1/2}.\n\n**Why Landau matters:** For a Sidon set A of squares, each sum a² + b² must be distinct. There are ~|A|² sums but only ~N²/(log N)^{1/2} possible values. This forces |A|² ≤ N²/(log N)^{1/2}, giving |A| ≤ N/(log N)^{1/4}.",
+    "mathContext": "Landau's theorem connects number theory (characterisation of sums of two squares via Fermat) with combinatorics (counting constraint on Sidon sets).",
+    "significance": "essential",
+    "relatedConcepts": ["Landau–Ramanujan constant", "sums of two squares", "Fermat's theorem"]
+  },
+  {
+    "id": "ann-e773-probabilistic",
+    "proofId": "erdos-773",
+    "range": { "startLine": 162, "endLine": 201 },
     "type": "concept",
-    "range": { "startLine": 225, "endLine": 252 },
-    "title": "Summary: OPEN",
-    "content": "**erdos_773_summary** combines the lower and upper bounds. The problem remains open.",
-    "mathContext": "The gap between polynomial lower bound and nearly-linear upper bound is the central challenge.",
+    "title": "Probabilistic Method and Upper Bound Sketch",
+    "content": "**Random construction (Alon–Erdős):** Select each square with probability p. Expected |A| ~ pN, with ~p²N² pairwise sums. For the Sidon property, need collisions to be rare, which gives p ~ N^{−1/3} and |A| ~ N^{2/3}.\n\n**Upper bound proof sketch:** If A has m elements, there are m(m+1)/2 pairwise sums, each ≤ 2N² and each a sum of two squares. By Landau, at most ~N²/(log N)^{1/2} such sums exist. The Sidon condition forces m² ≤ N²/(log N)^{1/2}, giving m ≤ N/(log N)^{1/4}.\n\nThe `landau_constraint`, `random_construction`, and `why_two_thirds` axioms sketch the key ideas (formalised as True placeholders).",
+    "mathContext": "The probabilistic method gives the lower bound; Landau's constraint gives the upper bound. The gap between N^{2/3} and N/(log N)^{1/4} reflects the limits of current techniques.",
+    "significance": "key",
+    "relatedConcepts": ["probabilistic method", "random selection", "collision counting"]
+  },
+  {
+    "id": "ann-e773-summary",
+    "proofId": "erdos-773",
+    "range": { "startLine": 203, "endLine": 252 },
+    "type": "concept",
+    "title": "Open Questions and Summary",
+    "content": "**trueOrder:** Asks whether f(N) = N^{α+o(1)} for some 2/3 ≤ α < 1.\n\n**explicit_construction_question:** Can explicit (non-probabilistic) constructions improve the lower bound?\n\n**erdos_773_summary:** Combines the lower bound, upper bound, and the open status.\n\n**Central open questions:**\n- Is f(N) = N^{1−o(1)}? (optimistic)\n- Is f(N) = N^{2/3+o(1)}? (matching current lower bound)\n- Or something in between?\n\nThe answer likely depends on deep properties of the distribution of sums of two squares.",
+    "mathContext": "This is one of the central problems connecting additive combinatorics (Sidon sets) with analytic number theory (sums of squares, Landau's theorem).",
     "significance": "critical",
-    "relatedConcepts": ["open problem", "bounds summary"]
+    "relatedConcepts": ["open problem", "true exponent", "explicit constructions"]
   }
 ]


### PR DESCRIPTION
## Summary
- Enriched annotations for 9 gallery entries that had fewer than 5 annotations (the quality target)
- Each entry now has 5-11 annotations with rich `content`, `mathContext`, `relatedConcepts`, and `significance` fields
- Entries: erdos-162, erdos-1032, erdos-151, erdos-311, erdos-330, erdos-374, erdos-469, erdos-497, erdos-773

## Changes per entry

| Entry | Before | After | Topic |
|-------|--------|-------|-------|
| erdos-162 | 4 ann / 38 lines | 11 ann / 123 lines | Discrepancy in 2-coloured graphs |
| erdos-1032 | 4 ann / 38 lines | 7 ann / 79 lines | 4-chromatic critical graphs |
| erdos-151 | 4 ann / 38 lines | 8 ann / 90 lines | Clique transversal number |
| erdos-311 | 4 ann / 38 lines | 5 ann / 57 lines | Unit fraction sums |
| erdos-330 | 4 ann / 38 lines | 6 ann / 69 lines | Minimal additive bases |
| erdos-374 | 4 ann / 38 lines | 5 ann / 57 lines | Factorial products as squares |
| erdos-469 | 4 ann / 38 lines | 7 ann / 80 lines | Primitive pseudoperfect numbers |
| erdos-497 | 4 ann / 38 lines | 6 ann / 69 lines | Counting antichains (Dedekind) |
| erdos-773 | 4 ann / 46 lines | 8 ann / 91 lines | Sidon subsets of squares |

## Test plan
- [x] `pnpm build` passes
- [x] All annotations are valid JSON
- [x] Each entry has 5+ annotations
- [x] All annotations follow the exemplar format (erdos-48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)