### PR TITLE
Research: erdos-681 - eliminate all axioms with 17 proved theorems

### DIFF
--- a/proofs/Proofs/Erdos681Problem.lean
+++ b/proofs/Proofs/Erdos681Problem.lean
@@ -27,9 +27,73 @@ noncomputable def leastPrimeFactor (m : ℕ) : ℕ :=
 def IsLeastPrimeFactor (p m : ℕ) : Prop :=
     p.Prime ∧ p ∣ m ∧ ∀ q : ℕ, q.Prime → q ∣ m → p ≤ q
 
+/- ## Proved infrastructure -/
+
+/-- `Nat.minFac` gives the least prime factor for `m ≥ 2`. -/
+theorem minFac_is_lpf (m : ℕ) (hm : 2 ≤ m) :
+    IsLeastPrimeFactor m.minFac m := by
+  refine ⟨Nat.minFac_prime (by omega), Nat.minFac_dvd m, ?_⟩
+  intro q hq hqd
+  exact Nat.minFac_le_of_dvd hq.two_le hqd
+
 /-- A composite number has a least prime factor that is prime. -/
-axiom composite_has_lpf (m : ℕ) (hm : ¬m.Prime) (hm2 : 2 ≤ m) :
-    ∃ p : ℕ, IsLeastPrimeFactor p m
+theorem composite_has_lpf (m : ℕ) (_hm : ¬m.Prime) (hm2 : 2 ≤ m) :
+    ∃ p : ℕ, IsLeastPrimeFactor p m :=
+  ⟨m.minFac, minFac_is_lpf m hm2⟩
+
+/-- If `n + k` is prime, it trivially has least prime factor `n + k`
+itself, which is large. The conjecture requires `n + k` composite. -/
+theorem prime_lpf_self (p : ℕ) (hp : p.Prime) :
+    IsLeastPrimeFactor p p := by
+  refine ⟨hp, dvd_refl p, ?_⟩
+  intro q hq hqd
+  have hq1 : q ≠ 1 := Nat.Prime.one_lt hq |>.ne'
+  rcases hp.eq_one_or_self_of_dvd q hqd with h | h
+  · exact absurd h hq1
+  · exact le_of_eq h.symm
+
+/-- The least prime factor of a composite `m` satisfies
+`p(m) ≤ √m`, i.e. `p(m)² ≤ m`. -/
+theorem lpf_le_sqrt (m : ℕ) (hm : ¬m.Prime) (hm2 : 2 ≤ m) :
+    ∃ p : ℕ, IsLeastPrimeFactor p m ∧ p * p ≤ m := by
+  refine ⟨m.minFac, minFac_is_lpf m hm2, ?_⟩
+  have := Nat.minFac_sq_le_self (by omega : 0 < m) hm
+  rwa [sq] at this
+
+/-- The least prime factor is unique: if both `p` and `q` are least
+prime factors of `m`, then `p = q`. -/
+theorem lpf_unique (p q m : ℕ) (hp : IsLeastPrimeFactor p m)
+    (hq : IsLeastPrimeFactor q m) : p = q := by
+  have hpq := hp.2.2 q hq.1 hq.2.1
+  have hqp := hq.2.2 p hp.1 hp.2.1
+  exact le_antisymm hpq hqp |>.symm ▸ rfl
+
+/-- `leastPrimeFactor m` equals `m.minFac` when `m ≥ 2`. -/
+theorem leastPrimeFactor_eq_minFac (m : ℕ) (hm : 2 ≤ m) :
+    leastPrimeFactor m = m.minFac := by
+  simp [leastPrimeFactor, show ¬(m ≤ 1) by omega]
+
+/-- `leastPrimeFactor m` is a least prime factor for `m ≥ 2`. -/
+theorem leastPrimeFactor_is_lpf (m : ℕ) (hm : 2 ≤ m) :
+    IsLeastPrimeFactor (leastPrimeFactor m) m := by
+  rw [leastPrimeFactor_eq_minFac m hm]
+  exact minFac_is_lpf m hm
+
+/-- For prime `p`, `leastPrimeFactor p = p`. -/
+theorem leastPrimeFactor_prime (p : ℕ) (hp : p.Prime) :
+    leastPrimeFactor p = p := by
+  rw [leastPrimeFactor_eq_minFac p hp.two_le]
+  exact hp.minFac_eq
+
+/-- The least prime factor of a composite divides it. -/
+theorem lpf_dvd (m : ℕ) (hm : 2 ≤ m) :
+    leastPrimeFactor m ∣ m := by
+  exact (leastPrimeFactor_is_lpf m hm).2.1
+
+/-- The least prime factor of a composite is prime. -/
+theorem lpf_prime (m : ℕ) (hm : 2 ≤ m) :
+    (leastPrimeFactor m).Prime := by
+  exact (leastPrimeFactor_is_lpf m hm).1
 
 /- ## The conjecture -/
 
@@ -52,22 +116,84 @@ def ErdosProblem681General (d : ℕ) : Prop :=
         ¬(n + k).Prime ∧ 2 ≤ n + k ∧
         ∀ p : ℕ, IsLeastPrimeFactor p (n + k) → k ^ d < p
 
-/-- The original conjecture is the `d = 2` case. -/
-axiom erdos681_is_general_d2 :
-    ErdosProblem681 ↔ ErdosProblem681General 2
+/-- The original conjecture is exactly the `d = 2` case of the
+generalisation. -/
+theorem erdos681_is_general_d2 :
+    ErdosProblem681 ↔ ErdosProblem681General 2 := by
+  rfl
 
-/- ## Basic observations -/
+/- ## Structural observations -/
 
-/-- If `n + k` is prime, it trivially has least prime factor `n + k`
-itself, which is large. The conjecture requires `n + k` composite. -/
-axiom prime_lpf_self (p : ℕ) (hp : p.Prime) :
-    IsLeastPrimeFactor p p
+/-- When n + k is prime, minFac(n+k) = n+k, which easily exceeds k² + 1
+for large n. -/
+theorem prime_offset_gives_large_lpf (n k : ℕ) (_hk : 0 < k)
+    (hp : (n + k).Prime) (hn : k ^ 2 < n + k) :
+    ∀ p : ℕ, IsLeastPrimeFactor p (n + k) → k ^ 2 < p := by
+  intro p hlpf
+  have := lpf_unique p (n + k) (n + k) hlpf (prime_lpf_self (n + k) hp)
+  rw [this]
+  exact hn
 
-/-- The least prime factor of a composite `m` satisfies
-`p(m) ≤ √m`. -/
-axiom lpf_le_sqrt (m : ℕ) (hm : ¬m.Prime) (hm2 : 2 ≤ m) :
-    ∃ p : ℕ, IsLeastPrimeFactor p m ∧ p * p ≤ m
+/-- For the conjecture, the difficulty lies in composite numbers: if `n + k`
+is composite then `p(n+k) ≤ √(n+k)`, giving the constraint
+`k² < p(n+k) ≤ √(n+k)`, i.e. `k⁴ < n + k`. -/
+theorem composite_constraint (n k : ℕ) (_hk : 0 < k) (hm : ¬(n + k).Prime)
+    (hm2 : 2 ≤ n + k)
+    (hlpf : ∀ p : ℕ, IsLeastPrimeFactor p (n + k) → k ^ 2 < p) :
+    k ^ 4 < n + k := by
+  obtain ⟨p, hp, hpsq⟩ := lpf_le_sqrt (n + k) hm hm2
+  have hk2 := hlpf p hp
+  -- k² < p and p * p ≤ n + k, so k⁴ = (k²)² < p² ≤ n + k
+  calc k ^ 4 = (k ^ 2) ^ 2 := by ring
+    _ = k ^ 2 * k ^ 2 := by ring
+    _ < p * p := by nlinarith
+    _ ≤ n + k := hpsq
 
-/-- `Nat.minFac` gives the least prime factor for `m ≥ 2`. -/
-axiom minFac_is_lpf (m : ℕ) (hm : 2 ≤ m) :
-    IsLeastPrimeFactor m.minFac m
+/-- When `d = 1`, the conjecture asks for `p(n+k) > k`. For k = 1, this
+means `p(n+1) > 1`, which holds for all `n ≥ 1` (since `p(m) ≥ 2`
+for `m ≥ 2`). -/
+theorem d1_k1_trivial (n : ℕ) (_hn : 1 ≤ n) (_hc : ¬(n + 1).Prime) (_hn2 : 2 ≤ n + 1) :
+    ∀ p : ℕ, IsLeastPrimeFactor p (n + 1) → 1 ^ 1 < p := by
+  intro p ⟨hp, _, _⟩
+  simp
+  exact hp.one_lt
+
+/-- The `d = 0` case of the generalisation is trivially true:
+we need `p(n+k) > k⁰ = 1`, which holds since all prime factors
+are `≥ 2`. We pick k = n to get n + k = 2n which is composite
+for n ≥ 2. -/
+theorem general_d0_trivial :
+    ErdosProblem681General 0 := by
+  refine ⟨2, fun n hn => ⟨n, by omega, ?_, ?_, ?_⟩⟩
+  · -- ¬(n + n).Prime: 2n is even and ≥ 4
+    intro hp
+    have h2 : 2 ∣ (n + n) := ⟨n, by ring⟩
+    have := hp.eq_one_or_self_of_dvd 2 h2
+    rcases this with h | h <;> omega
+  · omega
+  · intro p ⟨hp, _, _⟩
+    simp
+    exact hp.one_lt
+
+/-- For `d ≥ 1`, the generalised conjecture implies the original. -/
+theorem general_monotone (d₁ d₂ : ℕ) (hd : d₁ ≤ d₂)
+    (h : ErdosProblem681General d₂) : ErdosProblem681General d₁ := by
+  obtain ⟨N₀, hN⟩ := h
+  refine ⟨N₀, fun n hn => ?_⟩
+  obtain ⟨k, hk, hc, hm2, hlpf⟩ := hN n hn
+  exact ⟨k, hk, hc, hm2, fun p hp => lt_of_le_of_lt (Nat.pow_le_pow_right (by omega) hd) (hlpf p hp)⟩
+
+/- ## Connection to Erdős 680 -/
+
+/-- The formulations of #680 and #681 are closely related. Problem 680
+uses `minFac` directly, while 681 uses the `IsLeastPrimeFactor` predicate.
+This shows equivalence of the core condition. -/
+theorem lpf_condition_equiv (m k : ℕ) (hm : 2 ≤ m) :
+    (∀ p : ℕ, IsLeastPrimeFactor p m → k < p) ↔ k < m.minFac := by
+  constructor
+  · intro h
+    exact h m.minFac (minFac_is_lpf m hm)
+  · intro h p hp
+    have := lpf_unique p m.minFac m hp (minFac_is_lpf m hm)
+    rw [this]
+    exact h

--- a/src/data/research/problems/erdos-681.json
+++ b/src/data/research/problems/erdos-681.json
@@ -16,25 +16,54 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "INFRASTRUCTURE",
     "since": "2026-01-14T19:46:33.193Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Infrastructure complete. Main conjecture is OPEN.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Main conjecture is OPEN - no further proof progress possible without new mathematical insights.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: All 5 axioms eliminated and replaced with 17 proved theorems. Infrastructure includes lpf existence, uniqueness, sqrt bound, minFac connection, and structural analysis of the conjecture.",
+    "builtItems": [
+      "theorem minFac_is_lpf: minFac gives least prime factor (Erdos681Problem.lean)",
+      "theorem composite_has_lpf: composite numbers have lpf (Erdos681Problem.lean)",
+      "theorem prime_lpf_self: primes are their own lpf (Erdos681Problem.lean)",
+      "theorem lpf_le_sqrt: lpf of composite ≤ √m (Erdos681Problem.lean)",
+      "theorem lpf_unique: uniqueness of lpf (Erdos681Problem.lean)",
+      "theorem leastPrimeFactor_eq_minFac: connects def to minFac (Erdos681Problem.lean)",
+      "theorem leastPrimeFactor_is_lpf: def satisfies IsLeastPrimeFactor (Erdos681Problem.lean)",
+      "theorem leastPrimeFactor_prime: lpf of prime = itself (Erdos681Problem.lean)",
+      "theorem lpf_dvd: lpf divides the number (Erdos681Problem.lean)",
+      "theorem lpf_prime: lpf is prime (Erdos681Problem.lean)",
+      "theorem erdos681_is_general_d2: problem 681 ↔ general d=2 (Erdos681Problem.lean)",
+      "theorem prime_offset_gives_large_lpf: prime case analysis (Erdos681Problem.lean)",
+      "theorem composite_constraint: k⁴ < n+k necessary (Erdos681Problem.lean)",
+      "theorem d1_k1_trivial: d=1, k=1 trivial case (Erdos681Problem.lean)",
+      "theorem general_d0_trivial: d=0 case fully proved (Erdos681Problem.lean)",
+      "theorem general_monotone: higher d implies lower d (Erdos681Problem.lean)",
+      "theorem lpf_condition_equiv: connects to problem 680 formulation (Erdos681Problem.lean)"
+    ],
+    "insights": [
+      "All axioms from original file are provable from Mathlib minFac API",
+      "The d=0 generalisation is trivially true (pick k=n, 2n is composite for n≥2)",
+      "Key structural constraint: for composite n+k satisfying conjecture, k⁴ < n+k",
+      "IsLeastPrimeFactor predicate equivalent to minFac comparison (lpf_condition_equiv)",
+      "Problem 681 is definitionally equal to ErdosProblem681General 2",
+      "Higher d cases imply lower d cases (general_monotone)"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #681 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs it true that for all large $n$ there exists $k$ such that $n+k$ is composite and\\[p(n+k)>k^2,\\]where $p(m)$ is the least prime factor of $m$?\n\n\n\nRelated to questions of Erd\\H{o}s, Eggleton, and Selfridge. This may be true with $k^2$ replaced by $k^d$ for any $d$.\n\nSee also [680] and [682].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #680\n- Problem #682\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er7d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
+    "nextSteps": [
+      "Main conjecture is OPEN - cannot prove ErdosProblem681 itself",
+      "Consider computational verification for small n",
+      "Connect to smooth number distribution theory for asymptotic arguments"
+    ],
+    "markdown": "# Erdős #681 - Knowledge Base\n\n## Research Completed\n\nAll 5 axioms from the original formalization eliminated. 17 proved theorems now provide\ncomplete infrastructure for the least prime factor framework.\n\n## Key Results\n- IsLeastPrimeFactor predicate fully connected to Nat.minFac\n- d=0 case of generalisation proved (trivially true)\n- Structural constraint: composite case requires k⁴ < n+k\n- Monotonicity: higher d implies lower d\n\n## Status: OPEN (main conjecture)\nThe main conjecture remains open. Our infrastructure provides the framework but\nthe actual existential proof requires deep number-theoretic arguments."
   },
   "approaches": [],
   "tags": [


### PR DESCRIPTION
## Summary
- Eliminated all 5 axioms from Erdős #681 formalization, replacing with 17 proved theorems
- Complete infrastructure for least prime factor framework using Mathlib's `Nat.minFac` API
- Proved the d=0 case of the generalised conjecture (trivially true)

## Progress
- **Axioms eliminated**: `composite_has_lpf`, `prime_lpf_self`, `lpf_le_sqrt`, `minFac_is_lpf`, `erdos681_is_general_d2` (5 → 0)
- **New theorems proved**: 17 including uniqueness, sqrt bound, minFac connection, structural constraints, monotonicity, and cross-problem equivalence
- **Key structural result**: `composite_constraint` shows k⁴ < n+k is necessary for the conjecture
- **Generalisation**: `general_d0_trivial` proves the d=0 case; `general_monotone` shows higher d implies lower d

## Findings
- All original axioms provable from Mathlib `Nat.minFac_prime`, `Nat.minFac_dvd`, `Nat.minFac_le_of_dvd`, `Nat.minFac_sq_le_self`
- `ErdosProblem681 ↔ ErdosProblem681General 2` is definitional equality (proved by `rfl`)
- Connection to problem #680 via `lpf_condition_equiv`: IsLeastPrimeFactor predicate equivalent to minFac comparison

## Status
**Outcome**: completed
**Next Steps**: Main conjecture is OPEN - no further proof progress possible without new mathematical insights

## Test plan
- [x] Docker build passes (`./proofs/scripts/docker-build.sh Proofs.Erdos681Problem`)
- [x] No axioms remain (all converted to theorems)
- [x] Only minor linter warnings (unused variables, fixed with `_` prefix)

Generated by researcher-1