### PR TITLE
Remove placeholder True axioms from erdos-264 and erdos-599

### DIFF
--- a/proofs/Proofs/Erdos264Problem.lean
+++ b/proofs/Proofs/Erdos264Problem.lean
@@ -60,19 +60,16 @@ axiom powers_of_two_not_irrationality_seq :
 theorem erdos_264_part_i : ¬IsIrrationalitySequence (fun n => 2^n) :=
   powers_of_two_not_irrationality_seq
 
-/--
+/-
 **Open Problem**: Is aₙ = n! an irrationality sequence?
 
 This remains open. The factorial grows faster than 2ⁿ but slower than 2^(2ⁿ),
 so neither the positive nor negative criteria from Kovač-Tao apply directly.
+The Kovač-Tao negative criterion requires liminf(aₙ² · ∑_{k>n} 1/aₖ²) > 0,
+which does NOT hold for n! (the tail sum decays too fast). The positive
+criterion requires a_{n+1}/aₙ → ∞, but for n! we have (n+1)!/n! = n+1
+which grows but not fast enough.
 -/
-axiom factorial_irrationality_seq_open :
-    -- This is stated as an axiom representing the open status
-    -- The actual answer is unknown
-    True
-
-/-- Erdős Problem #264 Part (ii): n! case is OPEN -/
-theorem erdos_264_part_ii_open : True := factorial_irrationality_seq_open
 
 /- ## Known Positive Example -/
 

--- a/proofs/Proofs/Erdos599Problem.lean
+++ b/proofs/Proofs/Erdos599Problem.lean
@@ -150,14 +150,10 @@ theorem erdos_599 : ErdosMengerConjecture := aharoni_berger_theorem
 ## Part V: Key Techniques
 -/
 
-/-- The Aharoni-Berger proof uses infinite matroid theory. -/
-axiom uses_infinite_matroids : True
-
-/-- Connection to infinite combinatorics and well-quasi-ordering. -/
-axiom well_quasi_order_connection : True
-
-/-- The paper was published in Inventiones Mathematicae (2009). -/
-axiom published_inventiones : True
+/-
+The Aharoni-Berger proof uses infinite matroid theory, connecting infinite
+combinatorics and well-quasi-ordering. Published in Inventiones Mathematicae (2009).
+-/
 
 /-
 ## Part VI: Generalizations
@@ -181,28 +177,16 @@ axiom erdos_menger_implies_linkage :
 
 /-
 ## Part VII: Historical Context
+
+- Menger's theorem dates to 1927
+- Erdős asked about the infinite case in 1981
+- The conjecture remained open for almost 30 years
+- Aharoni-Berger resolved it in 2009
 -/
-
-/-- Menger's theorem dates to 1927. -/
-axiom menger_1927 : True
-
-/-- Erdős asked about the infinite case in 1981. -/
-axiom erdos_1981 : True
-
-/-- The conjecture remained open for almost 30 years. -/
-axiom open_for_decades : True
-
-/-- Aharoni-Berger resolved it in 2009. -/
-axiom resolved_2009 : True
 
 /-
 ## Part VIII: Related Concepts
 -/
-
-/-- Vertex connectivity: min size of separating set. -/
-noncomputable def vertexConnectivity {V : Type*} (G : Graph V) (A B : Set V) : ℕ :=
-  Nat.find ⟨0, fun _ => ⟨∅, fun p hp => False.elim (by trivial)⟩⟩
-  -- Placeholder definition
 
 /-- The max-flow min-cut theorem for vertex version. -/
 axiom maxflow_mincut_vertex {V : Type*} [Fintype V] (G : Graph V) (A B : Set V) :
@@ -213,26 +197,17 @@ axiom maxflow_mincut_vertex {V : Type*} [Fintype V] (G : Graph V) (A B : Set V) 
 
 /-
 ## Part IX: König-Egervary Connection
+
+Matching in bipartite graphs is a special case; König's theorem on
+bipartite matching is generalized by Menger's theorem for paths.
 -/
-
-/-- Matching in bipartite graphs is a special case. -/
-axiom bipartite_matching_connection : True
-
-/-- König's theorem on bipartite matching. -/
-axiom konig_theorem : True
-
-/-- Menger generalizes König for paths. -/
-axiom menger_generalizes_konig : True
 
 /-
 ## Part X: Infinite Ramsey Theory Connection
+
+The Erdős-Menger conjecture connects to infinite Ramsey theory.
+Well-quasi-ordering plays a key role in the proof structure.
 -/
-
-/-- Connection to infinite Ramsey theory. -/
-axiom ramsey_connection : True
-
-/-- Well-quasi-ordering plays a role. -/
-axiom wqo_role : True
 
 /-
 ## Part XI: Summary

--- a/src/data/proofs/erdos-264/annotations.json
+++ b/src/data/proofs/erdos-264/annotations.json
@@ -59,9 +59,9 @@
     "proofId": "erdos-264",
     "range": {
       "startLine": 63,
-      "endLine": 75
+      "endLine": 72
     },
-    "type": "theorem",
+    "type": "concept",
     "title": "Factorial Case is OPEN",
     "content": "**Open Problem**: Is aₙ = n! an irrationality sequence? This remains unsolved despite the Kovač-Tao criteria.",
     "mathContext": "The factorial is borderline: its ratio (n+1)!/n! = n+1 grows without bound (so the negative criterion doesn't apply), but grows polynomially (so the positive criterion doesn't apply either). This makes n! genuinely difficult.",
@@ -72,8 +72,8 @@
     "id": "ann-e264-double-exp",
     "proofId": "erdos-264",
     "range": {
-      "startLine": 79,
-      "endLine": 87
+      "startLine": 76,
+      "endLine": 84
     },
     "type": "theorem",
     "title": "2^(2ⁿ) IS an Irrationality Sequence",
@@ -86,8 +86,8 @@
     "id": "ann-e264-negative-criterion",
     "proofId": "erdos-264",
     "range": {
-      "startLine": 91,
-      "endLine": 105
+      "startLine": 88,
+      "endLine": 102
     },
     "type": "theorem",
     "title": "Kovač-Tao Negative Criterion",
@@ -100,8 +100,8 @@
     "id": "ann-e264-positive-criterion",
     "proofId": "erdos-264",
     "range": {
-      "startLine": 107,
-      "endLine": 118
+      "startLine": 104,
+      "endLine": 115
     },
     "type": "theorem",
     "title": "Kovač-Tao Positive Criterion",
@@ -114,8 +114,8 @@
     "id": "ann-e264-growth-discussion",
     "proofId": "erdos-264",
     "range": {
-      "startLine": 120,
-      "endLine": 131
+      "startLine": 117,
+      "endLine": 128
     },
     "type": "concept",
     "title": "Growth Rate Boundary",
@@ -128,8 +128,8 @@
     "id": "ann-e264-power-ratio",
     "proofId": "erdos-264",
     "range": {
-      "startLine": 135,
-      "endLine": 138
+      "startLine": 132,
+      "endLine": 135
     },
     "type": "lemma",
     "title": "Powers of 2 Growth Rate",
@@ -142,8 +142,8 @@
     "id": "ann-e264-double-exp-ratio",
     "proofId": "erdos-264",
     "range": {
-      "startLine": 140,
-      "endLine": 147
+      "startLine": 137,
+      "endLine": 144
     },
     "type": "lemma",
     "title": "Double Exponential Growth Rate",
@@ -156,8 +156,8 @@
     "id": "ann-e264-factorial-ratio",
     "proofId": "erdos-264",
     "range": {
-      "startLine": 149,
-      "endLine": 153
+      "startLine": 146,
+      "endLine": 150
     },
     "type": "lemma",
     "title": "Factorial Growth Rate",

--- a/src/data/proofs/erdos-599/annotations.json
+++ b/src/data/proofs/erdos-599/annotations.json
@@ -1,155 +1,140 @@
 [
   {
-    "id": "ann-599-graph",
+    "id": "ann-599-header",
     "proofId": "erdos-599",
-    "range": { "startLine": 41, "endLine": 45 },
-    "type": "definition",
-    "title": "Graph",
-    "content": "Graph structure supporting infinite vertex sets with symmetric adjacency and no loops.",
-    "significance": "critical"
+    "range": { "startLine": 1, "endLine": 25 },
+    "type": "concept",
+    "title": "Problem Overview",
+    "content": "**Erdős Problem #599** asks whether Menger's theorem for finite graphs extends to infinite graphs. Menger's theorem (1927) states that the maximum number of vertex-disjoint paths equals the minimum separator size. Erdős conjectured in 1981 that this holds for infinite graphs too.",
+    "mathContext": "The conjecture was open for 28 years before being resolved by Aharoni and Berger in 2009.",
+    "significance": "critical",
+    "relatedConcepts": ["erdos", "menger-theorem", "infinite-graphs"]
   },
   {
-    "id": "ann-599-independent",
+    "id": "ann-599-graph",
     "proofId": "erdos-599",
-    "range": { "startLine": 47, "endLine": 49 },
+    "range": { "startLine": 41, "endLine": 49 },
     "type": "definition",
-    "title": "IsIndependent",
-    "content": "A set S is independent if no two vertices in S are adjacent.",
-    "significance": "critical"
+    "title": "Graph and Independent Set",
+    "content": "**Graph** structure supporting infinite vertex sets with symmetric adjacency and no self-loops. An **independent set** S has no two vertices adjacent — this ensures A and B don't trivially share edges.",
+    "mathContext": "Unlike Mathlib's SimpleGraph, this custom Graph type avoids decidability assumptions needed for infinite vertex sets.",
+    "significance": "critical",
+    "relatedConcepts": ["graph-theory", "independent-set"]
   },
   {
     "id": "ann-599-path",
     "proofId": "erdos-599",
-    "range": { "startLine": 51, "endLine": 56 },
+    "range": { "startLine": 51, "endLine": 75 },
     "type": "definition",
-    "title": "Path",
-    "content": "A path as a nonempty list of vertices with consecutive adjacency.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-599-pathbetween",
-    "proofId": "erdos-599",
-    "range": { "startLine": 69, "endLine": 71 },
-    "type": "definition",
-    "title": "IsPathBetween",
-    "content": "A path goes from A to B: first vertex in A, last vertex in B.",
-    "significance": "key"
+    "title": "Paths and Path Properties",
+    "content": "A **Path** is a nonempty list of vertices with consecutive adjacency. Key operations: **first** (start vertex), **last** (end vertex), **vertexSet** (all vertices on the path). A path goes **from A to B** if its first vertex is in A and last is in B.",
+    "mathContext": "List-based representation allows clean formalization of path operations without requiring decidable equality on the vertex type.",
+    "significance": "critical",
+    "relatedConcepts": ["path", "connectivity"]
   },
   {
     "id": "ann-599-disjoint",
     "proofId": "erdos-599",
     "range": { "startLine": 77, "endLine": 85 },
     "type": "definition",
-    "title": "AreInternallyDisjoint",
-    "content": "Two paths are internally vertex-disjoint: share vertices only at endpoints.",
-    "significance": "key"
+    "title": "Path Disjointness",
+    "content": "Two notions of disjointness: **AreDisjoint** allows shared endpoints only, while **AreInternallyDisjoint** is the weaker condition used in the conjecture — paths may share endpoints but not internal vertices.",
+    "mathContext": "Internal disjointness is the standard notion for Menger-type theorems, as paths between A and B naturally share membership in those sets.",
+    "significance": "key",
+    "relatedConcepts": ["vertex-disjoint", "path-separation"]
   },
   {
     "id": "ann-599-pathfamily",
     "proofId": "erdos-599",
     "range": { "startLine": 91, "endLine": 99 },
     "type": "definition",
-    "title": "PathFamily",
-    "content": "A family of paths between sets A and B, with pairwise disjointness property.",
-    "significance": "critical"
+    "title": "Path Families",
+    "content": "A **PathFamily** is a set of paths all going from A to B, with a **pairwiseDisjoint** property requiring all pairs to be internally vertex-disjoint.",
+    "significance": "critical",
+    "relatedConcepts": ["path-family", "disjoint-paths"]
   },
   {
-    "id": "ann-599-transversal",
+    "id": "ann-599-transversal-separator",
     "proofId": "erdos-599",
-    "range": { "startLine": 101, "endLine": 104 },
+    "range": { "startLine": 101, "endLine": 108 },
     "type": "definition",
-    "title": "IsTransversal",
-    "content": "Set S is a transversal: exactly one vertex from each path in the family.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-599-separator",
-    "proofId": "erdos-599",
-    "range": { "startLine": 106, "endLine": 108 },
-    "type": "definition",
-    "title": "IsSeparator",
-    "content": "Set S is a separator: every A-B path contains a vertex from S.",
-    "significance": "critical"
+    "title": "Transversal and Separator",
+    "content": "The two key properties of the set S in the conjecture: **IsTransversal** means S hits each path exactly once. **IsSeparator** means every A-B path passes through S. Together, these capture the max-flow min-cut duality.",
+    "mathContext": "A set that is both a transversal and separator witnesses the equality of maximum flow and minimum cut.",
+    "significance": "critical",
+    "relatedConcepts": ["transversal", "separator", "max-flow-min-cut"]
   },
   {
     "id": "ann-599-conjecture",
     "proofId": "erdos-599",
     "range": { "startLine": 110, "endLine": 118 },
     "type": "definition",
-    "title": "ErdosMengerConjecture",
-    "content": "∃ vertex-disjoint A-B paths P and set S: S is transversal of P AND S is separator.",
-    "significance": "critical"
+    "title": "The Erdős-Menger Conjecture",
+    "content": "**The formal statement**: For any graph G with disjoint independent sets A, B, there exist vertex-disjoint A-B paths P and a set S that is both a transversal of P and a separator for all A-B paths. This is the central object of the formalization.",
+    "significance": "critical",
+    "relatedConcepts": ["erdos", "menger-theorem", "conjecture"]
   },
   {
     "id": "ann-599-menger",
     "proofId": "erdos-599",
     "range": { "startLine": 124, "endLine": 135 },
     "type": "theorem",
-    "title": "MengersTheorem",
-    "content": "Menger (1927): For finite graphs, max disjoint paths = min separator size.",
-    "significance": "critical"
+    "title": "Menger's Theorem (Finite Case)",
+    "content": "**Menger (1927)**: For finite graphs, max vertex-disjoint A-B paths equals min A-B separator size. This classical result is the finite case of the Erdős-Menger conjecture.",
+    "mathContext": "Stated as an axiom since the full proof requires significant finite graph theory infrastructure not built here.",
+    "significance": "critical",
+    "relatedConcepts": ["menger-theorem", "finite-graphs"]
   },
   {
     "id": "ann-599-aharoniberger",
     "proofId": "erdos-599",
     "range": { "startLine": 141, "endLine": 147 },
     "type": "theorem",
-    "title": "aharoni_berger_theorem",
-    "content": "Aharoni-Berger (2009): The Erdős-Menger conjecture holds for ALL graphs.",
-    "significance": "critical"
+    "title": "Aharoni-Berger Theorem (2009)",
+    "content": "**The main result**: Aharoni and Berger proved the Erdős-Menger conjecture holds for ALL graphs, including infinite ones. Published in Inventiones Mathematicae, this resolved a 28-year-old conjecture using infinite matroid theory.",
+    "mathContext": "The proof technique involves infinite matroid intersection, a deep result in combinatorial optimization that extends finite matroid theory.",
+    "significance": "critical",
+    "relatedConcepts": ["aharoni-berger", "infinite-matroid"]
   },
   {
-    "id": "ann-599-matroids",
+    "id": "ann-599-techniques",
     "proofId": "erdos-599",
-    "range": { "startLine": 153, "endLine": 154 },
+    "range": { "startLine": 149, "endLine": 156 },
     "type": "concept",
-    "title": "Infinite Matroids",
-    "content": "The proof uses infinite matroid theory - sophisticated combinatorial structures.",
-    "significance": "key"
+    "title": "Proof Techniques",
+    "content": "The Aharoni-Berger proof uses **infinite matroid theory** — a generalization of finite matroids to infinite ground sets. The connection to well-quasi-ordering provides the compactness arguments needed for the infinite case.",
+    "significance": "key",
+    "relatedConcepts": ["matroid-theory", "well-quasi-ordering"]
   },
   {
     "id": "ann-599-klinked",
     "proofId": "erdos-599",
-    "range": { "startLine": 166, "endLine": 173 },
+    "range": { "startLine": 162, "endLine": 176 },
     "type": "definition",
-    "title": "IsKLinked",
-    "content": "k-linked: any k sources can be connected to k targets by disjoint paths.",
-    "significance": "key"
+    "title": "k-Linkage Generalization",
+    "content": "**IsKLinked**: A graph is k-linked if any k source-target pairs can be connected by disjoint paths. The Erdős-Menger result implies k-linkage for sufficiently connected graphs.",
+    "mathContext": "k-linkage is a natural strengthening that asks for multiple independent path connections simultaneously.",
+    "significance": "key",
+    "relatedConcepts": ["k-linkage", "connectivity"]
   },
   {
-    "id": "ann-599-history",
+    "id": "ann-599-maxflow",
     "proofId": "erdos-599",
-    "range": { "startLine": 186, "endLine": 196 },
-    "type": "concept",
-    "title": "Historical Timeline",
-    "content": "Menger 1927 (finite) → Erdős 1981 (infinite conjecture) → Aharoni-Berger 2009 (proof).",
-    "significance": "key"
-  },
-  {
-    "id": "ann-599-connectivity",
-    "proofId": "erdos-599",
-    "range": { "startLine": 202, "endLine": 212 },
-    "type": "definition",
-    "title": "vertexConnectivity",
-    "content": "Vertex connectivity: minimum size of separating set.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-599-konig",
-    "proofId": "erdos-599",
-    "range": { "startLine": 218, "endLine": 225 },
-    "type": "concept",
-    "title": "König Connection",
-    "content": "Menger's theorem generalizes König's theorem on bipartite matching.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-599-solved",
-    "proofId": "erdos-599",
-    "range": { "startLine": 264, "endLine": 268 },
+    "range": { "startLine": 191, "endLine": 196 },
     "type": "theorem",
-    "title": "erdos_599_solved",
-    "content": "Problem #599 is SOLVED: YES, Menger's theorem extends to infinite graphs.",
-    "significance": "critical"
+    "title": "Max-Flow Min-Cut (Vertex Version)",
+    "content": "The vertex version of max-flow min-cut: the maximum number of vertex-disjoint A-B paths equals the minimum vertex separator size. This is the quantitative form of Menger's theorem.",
+    "significance": "key",
+    "relatedConcepts": ["max-flow-min-cut", "vertex-separator"]
+  },
+  {
+    "id": "ann-599-summary",
+    "proofId": "erdos-599",
+    "range": { "startLine": 216, "endLine": 245 },
+    "type": "theorem",
+    "title": "Summary and Status",
+    "content": "**Problem #599 is SOLVED**: YES, Menger's theorem extends to infinite graphs. The timeline spans from Menger (1927) through Erdős (1981) to Aharoni-Berger (2009). This is a major result in infinite combinatorics.",
+    "significance": "critical",
+    "relatedConcepts": ["erdos", "solved", "infinite-combinatorics"]
   }
 ]

--- a/src/data/proofs/erdos-599/meta.json
+++ b/src/data/proofs/erdos-599/meta.json
@@ -52,8 +52,7 @@
       "ErdosMengerConjecture: formal statement",
       "MengersTheorem: finite case statement",
       "aharoni_berger_theorem: main result axiom",
-      "IsKLinked: k-linkage definition",
-      "vertexConnectivity: connectivity definition"
+      "IsKLinked: k-linkage definition"
     ]
   },
   "overview": {
@@ -68,7 +67,57 @@
       "**28 Years Open:** Conjecture remained open from 1981 to 2009"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Problem Overview",
+      "startLine": 1,
+      "endLine": 25,
+      "summary": "Problem statement, history, and references"
+    },
+    {
+      "id": "graph-defs",
+      "title": "Graph Definitions",
+      "startLine": 37,
+      "endLine": 85,
+      "summary": "Graph, independent set, path, disjointness definitions"
+    },
+    {
+      "id": "conjecture",
+      "title": "The Erdős-Menger Conjecture",
+      "startLine": 87,
+      "endLine": 118,
+      "summary": "Path family, transversal, separator, and the formal conjecture statement"
+    },
+    {
+      "id": "finite-case",
+      "title": "Menger's Theorem (Finite Case)",
+      "startLine": 120,
+      "endLine": 135,
+      "summary": "Classical finite Menger's theorem statement"
+    },
+    {
+      "id": "main-result",
+      "title": "Aharoni-Berger Theorem",
+      "startLine": 137,
+      "endLine": 156,
+      "summary": "The main result: infinite Erdős-Menger conjecture proved"
+    },
+    {
+      "id": "generalizations",
+      "title": "Generalizations and Related Results",
+      "startLine": 158,
+      "endLine": 210,
+      "summary": "k-linkage, max-flow min-cut, König connection, Ramsey theory"
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 212,
+      "endLine": 245,
+      "summary": "Final theorem and problem status"
+    }
+  ],
   "conclusion": {
     "summary": "Erdős Problem #599 (the Erdős-Menger Conjecture) asks whether Menger's theorem extends to infinite graphs. Aharoni and Berger proved the answer is YES in 2009, using infinite matroid theory. This resolved a conjecture that had been open for almost 30 years and represents a major advance in infinite combinatorics.",
     "implications": "**Connections**\n\n1. **Menger's Theorem:** Direct generalization to infinite graphs\n\n2. **Max-Flow Min-Cut:** Extends the duality to infinite setting\n\n3. **Infinite Matroid Theory:** Proof technique with broader applications\n\n4. **König's Theorem:** Menger generalizes König for paths",

--- a/src/data/research/problems/erdos-100.json
+++ b/src/data/research/problems/erdos-100.json
@@ -42,9 +42,7 @@
     "distinct-distances",
     "open"
   ],
-  "relatedProofs": [
-    "Relevance"
-  ],
+  "relatedProofs": [],
   "references": {
     "papers": [],
     "urls": [],


### PR DESCRIPTION
## Summary
- **erdos-599**: Remove 12 `axiom X : True` placeholder declarations (historical dates, technique notes, König connection, Ramsey connection) and replace with doc comments. Remove placeholder `vertexConnectivity` definition. Add sections to meta.json. Rewrite annotations with correct line numbers and richer content (13 annotations).
- **erdos-264**: Remove `factorial_irrationality_seq_open : True` axiom and associated `erdos_264_part_ii_open : True` theorem. Replace with expanded doc comment explaining why the factorial case is genuinely open (neither Kovač-Tao criterion applies). Update annotation line numbers.
- **erdos-100**: Remove "Relevance" scraping artifact from research file's `relatedProofs` array.

All substantive mathematical axioms and theorems are preserved. Only non-mathematical `True` placeholders were removed.

## Test plan
- [x] `pnpm build` succeeds
- [x] No `: True` patterns remain in erdos-264 or erdos-599 Lean files
- [x] Quality audit relevance-artifact issue resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)