### PR TITLE
Remove 228 placeholder axiom True from 87 Erdős Lean files

### DIFF
--- a/proofs/Proofs/Erdos1100Problem.lean
+++ b/proofs/Proofs/Erdos1100Problem.lean
@@ -101,10 +101,9 @@ def question1_almost_all_growth : Prop :=
         (fun n => (tauPerp n : ℝ) / (omega n) < M ∧ omega n > 0)
         (Finset.range x)).card / (x : ℝ) < ε
 
-/--
+/-
 **Status of Question 1: OPEN**
 -/
-axiom question1_open : True
 
 /-
 ## Part IV: Question 2 - Upper Bound
@@ -129,10 +128,9 @@ axiom erdos_hall_max_lower_bound :
   ∀ ε > 0, ∃ X : ℕ, ∀ x : ℕ, x ≥ X →
     ∃ n : ℕ, n < x ∧ (tauPerp n : ℝ) > exp ((log (log x))^(2 - ε))
 
-/--
+/-
 **Status of Question 2: OPEN**
 -/
-axiom question2_open : True
 
 /-
 ## Part V: Question 3 - Growth of g(k)
@@ -208,7 +206,7 @@ example : omega 12 = 2 := by native_decide
 ## Part VII: Why This Problem Is Hard
 -/
 
-/--
+/-
 **Structural Insight:**
 The coprime consecutive divisors depend delicately on the factorization of n.
 For n = p₁^a₁ · ... · p_k^a_k:
@@ -218,7 +216,6 @@ For n = p₁^a₁ · ... · p_k^a_k:
 
 The exponential bounds on g(k) show the structure is neither trivial nor chaotic.
 -/
-axiom structural_insight : True
 
 /-
 ## Part VIII: Summary

--- a/proofs/Proofs/Erdos111Problem.lean
+++ b/proofs/Proofs/Erdos111Problem.lean
@@ -262,12 +262,11 @@ def erdos111_question : Prop :=
     hasAleph1ChromaticNumber G →
     ∀ M : ℕ, ∃ N : ℕ, ∀ n ≥ N, edgeDeletionFunction G n > M * n
 
-/--
+/-
 **Erdős Problem #111: OPEN**
 
 The status of the main question remains unknown.
 -/
-axiom erdos_111_status : True  -- Problem is open; we cannot assert either direction
 
 /-
 ## Part X: Related Results

--- a/proofs/Proofs/Erdos113Problem.lean
+++ b/proofs/Proofs/Erdos113Problem.lean
@@ -266,7 +266,6 @@ theorem erdos_113_forward (g : ℕ) :
     (fun n => (extremalNumber n g : ℝ)) ≪ (fun n => (n : ℝ).rpow (3/2)) :=
   forward_direction g
 
-/-- The $500 prize was claimed by Janzer for the counterexample. -/
-axiom prize_claimed : True  -- Janzer 2023
+/- The $500 prize was claimed by Janzer for the counterexample. -/
 
 end Erdos113

--- a/proofs/Proofs/Erdos1159Problem.lean
+++ b/proofs/Proofs/Erdos1159Problem.lean
@@ -106,13 +106,12 @@ axiom ess_log_blocking_set :
 
 -- ## Part V: The Open Problem (Erdős #1159)
 
-/-- **Erdős Problem #1159** (Open):
+/- **Erdős Problem #1159** (Open):
     Does there exist an absolute constant C such that every finite projective
     plane has a C-bounded blocking set?
 
     The ESS result gives O(log n), but the question is whether this can be
     improved to an absolute constant independent of n. -/
-axiom erdos_1159_open : True
 
 /-- The formal statement of Erdős Problem #1159: there exists an absolute
     constant C such that every finite projective plane admits a blocking set
@@ -139,8 +138,7 @@ theorem ess_implies_per_order_bound :
 
 -- ## Part VI: Related Problems
 
-/-- Problem #664 asks the stronger question for all pairwise balanced
+/- Problem #664 asks the stronger question for all pairwise balanced
     block designs, not just projective planes. -/
-axiom erdos_664_stronger : True
 
 end Erdos1159

--- a/proofs/Proofs/Erdos117Problem.lean
+++ b/proofs/Proofs/Erdos117Problem.lean
@@ -71,11 +71,9 @@ axiom isaacs_lower :
     Then h(1) = 1. -/
 axiom trivial_case : abelianCoverNumber 1 = 1
 
-/-- **Connection to Ramsey Theory**: the n-commuting property is a Ramsey-type
+/- **Connection to Ramsey Theory**: the n-commuting property is a Ramsey-type
     condition on the group. The covering number h(n) measures how far the group
     is from being globally Abelian. -/
-axiom ramsey_connection : True
 
-/-- **Open**: determine the exact base of the exponential growth. Is there
+/- **Open**: determine the exact base of the exponential growth. Is there
     a single constant c > 1 with h(n) = Θ(c^n)? -/
-axiom exact_base_open : True

--- a/proofs/Proofs/Erdos130Problem.lean
+++ b/proofs/Proofs/Erdos130Problem.lean
@@ -120,11 +120,9 @@ axiom erdos_anning_diameter_bound :
 
 /- ## Observations -/
 
-/-- **Chromatic vs Clique gap**: Even though the clique number is finite,
+/- **Chromatic vs Clique gap**: Even though the clique number is finite,
     the chromatic number could potentially be infinite — there is no
     general relationship forcing χ ≤ f(ω) for geometric distance graphs. -/
-axiom chromatic_clique_gap : True
 
-/-- **Related Problem #213**: Concerns integer distance sets without
+/- **Related Problem #213**: Concerns integer distance sets without
     the cocircularity restriction. -/
-axiom related_problem_213 : True

--- a/proofs/Proofs/Erdos163Problem.lean
+++ b/proofs/Proofs/Erdos163Problem.lean
@@ -75,11 +75,9 @@ axiom trees_are_1_degenerate :
   -- (every subtree has a leaf)
   True
 
-/-- Forests (disjoint unions of trees) are 1-degenerate -/
-axiom forests_are_1_degenerate : True
+/- Forests (disjoint unions of trees) are 1-degenerate -/
 
-/-- Planar graphs are 5-degenerate -/
-axiom planar_5_degenerate : True
+/- Planar graphs are 5-degenerate -/
 
 /-
 ## Part 2: Ramsey Numbers

--- a/proofs/Proofs/Erdos165Problem.lean
+++ b/proofs/Proofs/Erdos165Problem.lean
@@ -297,7 +297,6 @@ theorem erdos_165 : ∃ c₁ c₂ : ℝ, c₁ > 0 ∧ c₂ > 0 ∧
   · exact hk₁ k (le_of_max_le_left hk)
   · exact hk₂ k (le_of_max_le_right hk)
 
-/-- The prize ($250) was claimed for establishing the asymptotic order. -/
-axiom prize_claimed : True  -- Kim's 1995 result established the order
+/- The prize ($250) was claimed for establishing the asymptotic order. -/
 
 end Erdos165

--- a/proofs/Proofs/Erdos171Problem.lean
+++ b/proofs/Proofs/Erdos171Problem.lean
@@ -135,9 +135,8 @@ theorem current_bounds : 5 ≤ chromaticNumberPlane ∧ chromaticNumberPlane ≤
 
 /- ## Related Results -/
 
-/-- The fractional chromatic number of the plane is known exactly: 4.
+/- The fractional chromatic number of the plane is known exactly: 4.
     (It equals the supremum of fractional chromatic numbers of finite unit distance graphs.) -/
-axiom fractional_chromatic : True
 
 -- χ_f(ℝ²) = 4
 

--- a/proofs/Proofs/Erdos182Problem.lean
+++ b/proofs/Proofs/Erdos182Problem.lean
@@ -145,9 +145,8 @@ axiom k_equals_2_is_forest (G : SimpleGraph V) :
 axiom forest_edge_bound (G : SimpleGraph V) [DecidableRel G.Adj] (h : G.IsAcyclic) :
     G.edgeFinset.card ≤ Fintype.card V - 1
 
-/-- For k = 1, a 1-regular graph is a perfect matching.
+/- For k = 1, a 1-regular graph is a perfect matching.
 Every graph with ≥ n/2 edges in each component contains a perfect matching. -/
-axiom k_equals_1_matching : True  -- Placeholder for matching theory
 
 /-
 ## Connected Variant

--- a/proofs/Proofs/Erdos207Problem.lean
+++ b/proofs/Proofs/Erdos207Problem.lean
@@ -199,7 +199,7 @@ axiom anti_pasch_sts_exist (n : ℕ) (hn : IsAdmissible n) (hn' : n ≥ 7) :
 ## Part VII: Proof Techniques
 -/
 
-/--
+/-
 **Random Construction:**
 The KSSS proof uses a random greedy algorithm:
 1. Order pairs randomly
@@ -208,14 +208,12 @@ The KSSS proof uses a random greedy algorithm:
 
 Key tools: Rödl nibble method, spread measure, concentration inequalities.
 -/
-axiom ksss_random_construction : True
 
-/--
+/-
 **The Spread Measure:**
 A key technical tool measuring how "spread out" a partial STS is,
 ensuring the greedy process maintains the high-girth property.
 -/
-axiom spread_measure_technique : True
 
 /-
 ## Part VIII: Related Problems
@@ -273,10 +271,9 @@ theorem erdos_207_summary :
     · intro hadm
       exact h.mpr ⟨hn, hadm⟩
 
-/--
+/-
 **Problem Status:**
 Solved by Kwan, Sah, Sawhney, and Simkin in 2022.
 -/
-axiom erdos_207_status : True
 
 end Erdos207

--- a/proofs/Proofs/Erdos213Problem.lean
+++ b/proofs/Proofs/Erdos213Problem.lean
@@ -84,11 +84,10 @@ arbitrarily large ones exist.
 -/
 def Erdos213Question : Prop := ∀ n : ℕ, n ≥ 4 → ExistsIntDistSetGP n
 
-/--
+/-
 The status of Erdős #213 is OPEN. We state this as an axiom placeholder
 since neither proof nor disproof is known.
 -/
-axiom erdos_213_status_open : True -- Placeholder: question is open
 
 /- ## Known Constructions -/
 

--- a/proofs/Proofs/Erdos214Problem.lean
+++ b/proofs/Proofs/Erdos214Problem.lean
@@ -119,8 +119,7 @@ def HoldsFor5Points : Prop :=
   ∀ S : Set Plane, IsUnitDistanceFree S →
     ∀ P : PointSet 5, ContainsCongruentCopy Sᶜ P
 
-/-- The 5-point case is open -/
-axiom five_points_open : True -- Status of HoldsFor5Points is unknown
+/- The 5-point case is open -/
 
 /-
 ## Part 5: Connection to Unit Distance Graphs

--- a/proofs/Proofs/Erdos224Problem.lean
+++ b/proofs/Proofs/Erdos224Problem.lean
@@ -107,13 +107,12 @@ Any 9 points in ℝ³ contain an obtuse triple.
 -/
 axiom case_d3 : ErdosObtuseConjecture 3
 
-/--
+/-
 **Why d = 2 is Trivial:**
 In the plane, 5 points must either have 4 in convex position
 (forming an obtuse angle in the quadrilateral) or 3+ collinear
 (where middle points see 180° angles, which are obtuse).
 -/
-axiom d2_explanation : True
 
 /-
 ## Part IV: The Extremal Configuration
@@ -168,12 +167,11 @@ axiom hypercube_angle_classification (d : ℕ) (A B C : EuclideanPoint d)
     (hdist : A ≠ B ∧ B ≠ C ∧ A ≠ C) :
     angle A B C ≤ Real.pi / 2
 
-/--
+/-
 **Orthogonal Directions:**
 The hypercube has 2d orthogonal directions from each vertex.
 This geometric structure prevents obtuse angles.
 -/
-axiom hypercube_orthogonal_structure : True
 
 /-
 ## Part VI: Why More Than 2ᵈ Forces Obtuse
@@ -188,44 +186,39 @@ axiom pigeonhole_orthants (d : ℕ) (P : Finset (EuclideanPoint d))
     (hcard : P.card = 2^d + 1) :
     ∃ (orthant : Finset (EuclideanPoint d)), orthant ⊆ P ∧ orthant.card ≥ 2
 
-/--
+/-
 **Two Points in Same Orthant:**
 If two points are in the same orthant relative to a third,
 they can form obtuse angles more easily.
 -/
-axiom same_orthant_obstruction : True
 
-/--
+/-
 **The Danzer-Grünbaum Argument:**
 Uses a careful analysis of the hypercube structure and
 how additional points must create obtuse configurations.
 -/
-axiom danzer_grunbaum_proof_idea : True
 
 /-
 ## Part VII: Related Results
 -/
 
-/--
+/-
 **Maximum Acute Sets:**
 Sets where all angles are acute have been studied.
 The maximum size is related to spherical codes.
 -/
-axiom acute_sets_bound : True
 
-/--
+/-
 **Spherical Codes:**
 Points on the unit sphere with minimum angle constraints.
 Related to error-correcting codes.
 -/
-axiom spherical_codes_connection : True
 
-/--
+/-
 **Higher Dimensional Geometry:**
 The problem illustrates how geometry behaves differently
 in high dimensions.
 -/
-axiom high_dim_geometry : True
 
 /-
 ## Part VIII: Main Results

--- a/proofs/Proofs/Erdos237Problem.lean
+++ b/proofs/Proofs/Erdos237Problem.lean
@@ -144,27 +144,24 @@ theorem erdos_conjecture_true : ErdosConjecture := by
 ## Part V: Understanding the Proof Strategy
 -/
 
-/--
+/-
 **Why Infinite Sets Suffice:**
 The key insight is that as n → ∞, the number of primes p < n
 grows like n/log(n) by the Prime Number Theorem. If A is infinite,
 eventually many elements of A will have prime complements.
 -/
-axiom infinite_set_insight : True
 
-/--
+/-
 **Prime Number Theorem Connection:**
 π(n) ~ n/log(n) means primes are plentiful enough that
 infinite sets A will intersect {n - p : p prime} infinitely often.
 -/
-axiom pnt_connection : True
 
-/--
+/-
 **Density vs Cardinality:**
 Erdős asked about logarithmic density, but Chen-Ding showed
 that even much sparser sets (just infinite) work.
 -/
-axiom density_not_needed : True
 
 /-
 ## Part VI: Examples and Special Cases
@@ -188,31 +185,28 @@ def primePowers : Set ℕ := {n | ∃ (p k : ℕ), p.Prime ∧ k ≥ 1 ∧ n = p
 axiom prime_powers_unbounded_limsup :
     HasUnboundedLimsup (representationCount primePowers)
 
-/--
+/-
 **Highly Composite Numbers:**
 Even very sparse sequences like highly composite numbers
 satisfy the theorem.
 -/
-axiom highly_composite_example : True
 
 /-
 ## Part VII: Relation to Goldbach-type Problems
 -/
 
-/--
+/-
 **Goldbach Connection:**
 This problem is related to Goldbach's conjecture.
 If A = {2}, then f(n) counts primes p with n - 2 = p,
 i.e., twin primes shifted by 2.
 -/
-axiom goldbach_connection : True
 
-/--
+/-
 **Binary Additive Problems:**
 Problems of the form n = p + a for structured sets A
 are central to additive number theory.
 -/
-axiom binary_additive_context : True
 
 /-
 ## Part VIII: Main Results

--- a/proofs/Proofs/Erdos240Problem.lean
+++ b/proofs/Proofs/Erdos240Problem.lean
@@ -199,7 +199,7 @@ theorem erdos240_answer : erdos240Question := by
 ## Part VII: Construction Ideas
 -/
 
-/--
+/-
 **Tijdeman's Construction:**
 The infinite set P is constructed so that the primes are
 sufficiently "sparse" - they grow fast enough that consecutive
@@ -209,7 +209,6 @@ Key insight: If P contains all primes up to some bound,
 P-smooth numbers are dense. But if P is sparse (like powers
 of 2, or primes along a fast-growing sequence), gaps grow.
 -/
-axiom tijdeman_construction : True
 
 /--
 **Example: Powers of 2**
@@ -239,20 +238,18 @@ This is another consequence of Pólya-type results.
 axiom stormer_theorem (P : Finset ℕ) (hP : ∀ p ∈ P, Nat.Prime p) :
   ∃ N : ℕ, ∀ n > N, ¬(isPSmooth (↑P : Set ℕ) n ∧ isPSmooth (↑P : Set ℕ) (n + 1))
 
-/--
+/-
 **Connection to ABC Conjecture:**
 Better bounds on gaps would follow from the ABC conjecture.
 The ABC conjecture implies: for coprime a, b, c with a + b = c,
 c < rad(abc)^{1+ε} where rad is the radical (product of distinct primes).
 -/
-axiom abc_connection : True
 
-/--
+/-
 **Smooth numbers in arithmetic progressions:**
 How are P-smooth numbers distributed in arithmetic progressions?
 This is related to Linnik-type problems.
 -/
-axiom smooth_in_progressions : True
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/Erdos276Problem.lean
+++ b/proofs/Proofs/Erdos276Problem.lean
@@ -78,12 +78,10 @@ axiom covering_system_mechanism :
 
 /- ## Further Results -/
 
-/-- **Smaller starting values**: Vsemirnov (2004) found a primefree
+/- **Smaller starting values**: Vsemirnov (2004) found a primefree
     Lucas sequence with a₀ = 106276436867, a₁ = 35256392432,
     much smaller than Graham's original starting values. -/
-axiom vsemirnov_small_start : True
 
-/-- **Open Question**: Is every primefree Lucas sequence with coprime
+/- **Open Question**: Is every primefree Lucas sequence with coprime
     initial terms explained by a covering system? Or can such sequences
     exist for fundamentally different reasons? -/
-axiom covering_necessary_open : True

--- a/proofs/Proofs/Erdos294Problem.lean
+++ b/proofs/Proofs/Erdos294Problem.lean
@@ -281,11 +281,10 @@ def greedyRelation (t N : ℕ) : Prop :=
 ## Part IX: Computational Aspects
 -/
 
-/--
+/-
 **Computing t(N) is hard:**
 There's no known efficient algorithm for computing t(N) exactly.
 -/
-axiom t_computation_hard : True
 
 /--
 **Small computed values:**
@@ -315,19 +314,17 @@ theorem erdos_294_summary :
     liuSawhneyLowerBound := by
   exact liu_sawhney_2024
 
-/--
+/-
 **Key insight:**
 The density of "bad" starting points is about log(N)/N,
 so they form a sparse set.
 -/
-axiom key_insight : True
 
-/--
+/-
 **Problem Status:**
 - Upper bound: PROVED (Erdős-Graham 1980)
 - Lower bound: PROVED (Liu-Sawhney 2024)
 - Full asymptotic: SOLVED up to (log log N)^O(1) factors
 -/
-axiom erdos_294_status : True
 
 end Erdos294

--- a/proofs/Proofs/Erdos298Problem.lean
+++ b/proofs/Proofs/Erdos298Problem.lean
@@ -218,8 +218,7 @@ The formalization is ~10,000 lines of Lean code and covers:
 3. The main theorem and its corollaries
 -/
 
-/-- The existence of a complete Lean 3 formalization. -/
-axiom formalization_exists : True
+/- The existence of a complete Lean 3 formalization. -/
 
 /-
 ## Related Problems
@@ -233,11 +232,10 @@ Erdős posed several related problems about unit fractions.
 Answer: Yes for n ≥ 5 (various authors). -/
 axiom erdos_46_related : ∀ n ≥ 5, ∃ S : Finset ℕ, (∀ a ∈ S, 0 < a ∧ a ≤ n) ∧ SumsToOne S
 
-/-- **Erdős Problem #47**: Bounds on representing 1 as sum of unit fractions
+/- **Erdős Problem #47**: Bounds on representing 1 as sum of unit fractions
 with denominators from an interval.
 
 Related to #298 by considering density in intervals. -/
-axiom erdos_47_related : True
 
 /-
 ## Summary

--- a/proofs/Proofs/Erdos307Problem.lean
+++ b/proofs/Proofs/Erdos307Problem.lean
@@ -69,8 +69,7 @@ def ErdosProblem307 : Prop :=
   ∃ P Q : Finset ℕ, IsSetOfPrimes P ∧ IsSetOfPrimes Q ∧
     reciprocalProduct P Q = 1
 
-/-- The open status is a placeholder. -/
-axiom erdos_307_open : True
+/- The open status is a placeholder. -/
 
 /- ## Part III: The Solved Coprime Version -/
 
@@ -154,8 +153,7 @@ def ErdosProblem307CoprimeStrengthened : Prop :=
     IsPairwiseCoprime P ∧ IsPairwiseCoprime Q ∧
     reciprocalProduct P Q = 1
 
-/-- Status: The strengthened coprime version remains OPEN. -/
-axiom erdos_307_coprime_strengthened_open : True
+/- Status: The strengthened coprime version remains OPEN. -/
 
 /- ## Part V: Constraints on Prime Solutions -/
 

--- a/proofs/Proofs/Erdos319Problem.lean
+++ b/proofs/Proofs/Erdos319Problem.lean
@@ -84,7 +84,6 @@ axiom small_example :
   ∃ A : Finset ℕ, ∃ δ : ℕ → Int,
     A ⊆ Finset.Icc 1 6 ∧ IsIrreducibleZeroSum A δ
 
-/-- **Connection to Unit Fractions**: the problem is closely related to
+/- **Connection to Unit Fractions**: the problem is closely related to
     Egyptian fraction representations and signed unit-fraction decompositions.
     Erdős and Graham (1980) posed this in their monograph on such problems. -/
-axiom unit_fraction_connection : True

--- a/proofs/Proofs/Erdos321Problem.lean
+++ b/proofs/Proofs/Erdos321Problem.lean
@@ -75,17 +75,14 @@ axiom main_term_n_over_log_n :
 
 /- ## Observations -/
 
-/-- **Egyptian fraction connection**: The problem relates to
+/- **Egyptian fraction connection**: The problem relates to
     representations of rationals as sums of distinct unit fractions.
     R(N) measures how many denominators from {1,...,N} can be used
     while keeping all partial sums distinguishable. -/
-axiom egyptian_fraction_connection : True
 
-/-- **Greedy construction**: A natural construction takes all n
+/- **Greedy construction**: A natural construction takes all n
     with certain divisibility properties, ensuring subset sums
     separate. The challenge is optimizing the selection criterion. -/
-axiom greedy_construction : True
 
-/-- **OEIS sequences**: Related sequences A384927 and A391592
+/- **OEIS sequences**: Related sequences A384927 and A391592
     track computed values of R(N) for small N. -/
-axiom oeis_sequences : True

--- a/proofs/Proofs/Erdos337Problem.lean
+++ b/proofs/Proofs/Erdos337Problem.lean
@@ -219,12 +219,11 @@ axiom construction_insight :
     -- the sumset has many collisions, limiting its growth
     True
 
-/--
+/-
 **The Role of Sparsity:**
 Being sparse (o(N) elements) is not enough to guarantee
 unbounded sumset-to-set ratio.
 -/
-axiom sparsity_not_enough : True
 
 /-
 ## Part VIII: Comparison with Plünnecke-Ruzsa
@@ -241,12 +240,11 @@ axiom plunnecke_ruzsa (A : Finset ℕ) (h : ℕ) (hh : h ≥ 1) :
     (hFoldSumset h (A : Set ℕ) ∩ {n | ∃ a ∈ A, ∃ b ∈ A, n ≤ a + b}).ncard
       ≤ A.card ^ h
 
-/--
+/-
 **Lower bounds are harder:**
 There's no general lower bound for |A+A| in terms of |A|
 for infinite sets.
 -/
-axiom no_general_lower_bound : True
 
 /-
 ## Part IX: Examples

--- a/proofs/Proofs/Erdos349Problem.lean
+++ b/proofs/Proofs/Erdos349Problem.lean
@@ -78,13 +78,11 @@ axiom floor_3_2_even_infinitely :
 
 /- ## Observations -/
 
-/-- **Waring-Type Connection**: Completeness of ⌊tα^n⌋ relates to
+/- **Waring-Type Connection**: Completeness of ⌊tα^n⌋ relates to
     representation problems in additive number theory, similar in
     spirit to Waring's problem for exponential bases. -/
-axiom waring_connection : True
 
-/-- **Fibonacci Threshold**: The golden ratio (1+√5)/2 is the
+/- **Fibonacci Threshold**: The golden ratio (1+√5)/2 is the
     growth rate of the Fibonacci sequence, which is known to be
     a complete sequence. The conjecture suggests completeness
     persists for slightly faster growth rates. -/
-axiom fibonacci_threshold : True

--- a/proofs/Proofs/Erdos353Problem.lean
+++ b/proofs/Proofs/Erdos353Problem.lean
@@ -285,12 +285,11 @@ axiom finite_measure_counterexample :
       MeasurableSet A ∧ volume A < ⊤ ∧
       ¬HasTriangleWithArea A 1
 
-/--
+/-
 **Density Argument:**
 The proofs use the fact that infinite measure sets must have positive
 density in many regions, ensuring enough points to form configurations.
 -/
-axiom density_argument : True
 
 /-
 ## Part VIII: Scaling Properties
@@ -321,19 +320,17 @@ theorem all_areas_isosceles (A : Set (EuclideanSpace ℝ (Fin 2)))
 ## Part IX: Connections to Other Problems
 -/
 
-/--
+/-
 **Connection to Erdős Distance Problem:**
 The study of configurations in point sets relates to the Erdős distinct
 distances problem and unit distance problems.
 -/
-axiom erdos_distance_connection : True
 
-/--
+/-
 **Connection to Ramsey Theory:**
 Finding configurations in large sets has Ramsey-theoretic flavor:
 large enough sets must contain desired structures.
 -/
-axiom ramsey_connection : True
 
 /-
 ## Part X: Summary

--- a/proofs/Proofs/Erdos36Problem.lean
+++ b/proofs/Proofs/Erdos36Problem.lean
@@ -79,16 +79,13 @@ axiom small_values :
 
 /- ## Observations -/
 
-/-- **Erdős' Original Conjecture**: Erdős initially conjectured c = 1/2,
+/- **Erdős' Original Conjecture**: Erdős initially conjectured c = 1/2,
     but this was disproved. The true value is near 0.38. -/
-axiom erdos_original_conjecture_disproved : True
 
-/-- **Fourier Analytic Approach**: White's method translates the
+/- **Fourier Analytic Approach**: White's method translates the
     combinatorial problem into a convex optimization program
     using elementary Fourier analysis on ℤ. -/
-axiom fourier_approach : True
 
-/-- **Connection to Additive Combinatorics**: The minimum overlap
+/- **Connection to Additive Combinatorics**: The minimum overlap
     problem is a fundamental question about the structure of
     equal partitions and difference sets. -/
-axiom additive_combinatorics_connection : True

--- a/proofs/Proofs/Erdos384Problem.lean
+++ b/proofs/Proofs/Erdos384Problem.lean
@@ -119,8 +119,7 @@ def ecklundStrongConjecture : Prop :=
   ∀ n k : ℕ, 1 < k → k < n - 1 → n > k^2 →
     hasSmallPrimeDivisor (Nat.choose n k) (n / k + 1)
 
-/-- This stronger conjecture is still open -/
-axiom ecklund_strong_open : True  -- Placeholder; actual status unknown
+/- This stronger conjecture is still open -/
 
 /-- Known partial result: p ≪ n/k^c for some c > 0 -/
 axiom partial_bound_known (n k : ℕ) (hk : 1 < k) (hn : k < n - 1) :

--- a/proofs/Proofs/Erdos418Problem.lean
+++ b/proofs/Proofs/Erdos418Problem.lean
@@ -189,11 +189,10 @@ def HasPositiveDensity (S : Set ℕ) : Prop :=
   ∃ δ > 0, ∀ᶠ n in Filter.atTop,
     (S ∩ Finset.range (n + 1)).toFinite.toFinset.card ≥ δ * n
 
-/-- **Open Question**: Do non-cototients have positive density?
+/- **Open Question**: Do non-cototients have positive density?
 
     This is mentioned as open in the literature. The Browkin-Schinzel
     construction gives a sparse set (2^k · 509203), not positive density. -/
-axiom density_open : True  -- Placeholder for open status
 
 /-
 ## Part VIII: Related Function σ(n) - n

--- a/proofs/Proofs/Erdos422Problem.lean
+++ b/proofs/Proofs/Erdos422Problem.lean
@@ -67,14 +67,11 @@ axiom initial_values :
 
 /- ## Observations -/
 
-/-- **Hofstadter Origin**: the sequence was proposed by Hofstadter and
+/- **Hofstadter Origin**: the sequence was proposed by Hofstadter and
     communicated to Erdős. It appears in Erdős–Graham (1980). -/
-axiom hofstadter_origin : True
 
-/-- **Self-Referential Recursion**: f(n) depends on f at points
+/- **Self-Referential Recursion**: f(n) depends on f at points
     determined by earlier values of f itself. This self-referential
     nature makes analysis extremely difficult. -/
-axiom self_referential : True
 
-/-- **Eventually Constant?**: it is open whether f becomes constant. -/
-axiom eventually_constant_open : True
+/- **Eventually Constant?**: it is open whether f becomes constant. -/

--- a/proofs/Proofs/Erdos424Problem.lean
+++ b/proofs/Proofs/Erdos424Problem.lean
@@ -80,6 +80,5 @@ axiom generated_closed :
   ∀ x y, x ∈ generatedSet → y ∈ generatedSet → x ≠ y → x * y ≥ 2 →
     x * y - 1 ∈ generatedSet
 
-/-- **Guy E31**: this problem appears as E31 in Guy's 'Unsolved Problems
+/- **Guy E31**: this problem appears as E31 in Guy's 'Unsolved Problems
     in Number Theory' and as Problem 63 on Green's open problems list. -/
-axiom guy_e31_reference : True

--- a/proofs/Proofs/Erdos433Problem.lean
+++ b/proofs/Proofs/Erdos433Problem.lean
@@ -227,12 +227,11 @@ axiom extremal_set_structure (k n : ℕ) (hk : 2 ≤ k) (hkn : k < n) :
     ∃ A : Finset ℕ, A ⊆ Finset.Icc (n - k + 1) n ∧ A.card = k ∧
       IsCoprime A ∧ G(A) = g k n
 
-/--
+/-
 **Why Large Elements Maximize G(A):**
 If all elements of A are near n, then their linear combinations
 leave more gaps, maximizing the Frobenius number.
 -/
-axiom large_elements_maximize : True
 
 /-
 ## Part VIII: Connection to Classical Frobenius Problem
@@ -257,12 +256,11 @@ theorem schur_bound (a b : ℕ) (ha : a ≥ 1) (hb : b ≥ 1) (hcop : Nat.Coprim
   rw [sylvester_frobenius a b ha hb hcop]
   omega
 
-/--
+/-
 **Frobenius for 3 generators:**
 No closed formula exists for G({a, b, c}), but bounds are known.
 Ramirez Alfonsin showed the problem is NP-hard in general.
 -/
-axiom three_generators_np_hard : True
 
 /-
 ## Part IX: Counting Gaps

--- a/proofs/Proofs/Erdos435Problem.lean
+++ b/proofs/Proofs/Erdos435Problem.lean
@@ -137,11 +137,10 @@ example : ¬IsPrimePower 6 := by
 -/
 axiom frobenius_6 : frobeniusBinomial 6 = 49
 
-/--
+/-
 **n = 10 Example:**
 10 = 2 · 5, so contributions from p=2 and p=5.
 -/
-axiom frobenius_10 : True  -- Computed value from OEIS A389479
 
 /-
 ## Part V: Why Prime Powers are Special
@@ -155,12 +154,11 @@ making the representation problem degenerate.
 axiom prime_power_degenerate (n : ℕ) (hPP : IsPrimePower n) :
     True  -- The formula doesn't apply to prime powers
 
-/--
+/-
 **Lucas' Theorem Connection:**
 The divisibility of binomial coefficients by primes (Lucas' theorem)
 is key to understanding which numbers are representable.
 -/
-axiom lucas_connection : True
 
 /-
 ## Part VI: Structure of Representable Set
@@ -197,17 +195,15 @@ This is the 2-generator case.
 axiom classical_frobenius (a b : ℕ) (ha : a > 0) (hb : b > 0) (hcop : Nat.Coprime a b) :
     True  -- Sylvester-Frobenius formula
 
-/--
+/-
 **Sylvester-Denumerant:**
 The number of representations is related to denumerants (partition counting).
 -/
-axiom sylvester_connection : True
 
-/--
+/-
 **OEIS A389479:**
 The sequence of Frobenius numbers for this problem is catalogued.
 -/
-axiom oeis_sequence : True
 
 /-
 ## Part VIII: Main Results

--- a/proofs/Proofs/Erdos448Problem.lean
+++ b/proofs/Proofs/Erdos448Problem.lean
@@ -275,12 +275,11 @@ axiom problem_446_connection :
       (τ⁺(n) : ℝ) / τ(n) ≤ 1 ∧  -- trivially bounded above by 1
       True  -- connection to #446
 
-/--
+/-
 **Connection to Problem #449:**
 Problem #449 asks about divisors in short intervals [y, 2y).
 The dyadic structure in τ⁺ is related to this setting.
 -/
-axiom problem_449_connection : True  -- placeholder for relationship
 
 /-
 ## Part VIII: Summary

--- a/proofs/Proofs/Erdos468Problem.lean
+++ b/proofs/Proofs/Erdos468Problem.lean
@@ -91,5 +91,4 @@ axiom smallest_partial_sum (n : ℕ) (hn : 2 ≤ n) :
 axiom largest_partial_sum (n : ℕ) (hn : 2 ≤ n) :
     (n.divisors.sum id - 1) ∈ partialDivisorSums n
 
-/-- OEIS A167485 relates to the sequence of partial sums of divisors. -/
-axiom oeis_context : True
+/- OEIS A167485 relates to the sequence of partial sums of divisors. -/

--- a/proofs/Proofs/Erdos498Problem.lean
+++ b/proofs/Proofs/Erdos498Problem.lean
@@ -76,17 +76,14 @@ axiom erdos_complex_weak (n : ℕ) (hn : n ≥ 1)
 
 /- ## Generalizations -/
 
-/-- **Kleitman (1970)**: The result extends to arbitrary Hilbert
+/- **Kleitman (1970)**: The result extends to arbitrary Hilbert
     spaces: for vectors v₁,...,vₙ in a Hilbert space with
     ‖vᵢ‖ ≥ 1, at most C(n, ⌊n/2⌋) signed sums fall in any
     ball of radius 1. -/
-axiom kleitman_hilbert_space : True
 
-/-- **Sperner connection**: The bound C(n, ⌊n/2⌋) is tight and
+/- **Sperner connection**: The bound C(n, ⌊n/2⌋) is tight and
     equals the size of the largest antichain in the power set
     of {1,...,n}. Kleitman's proof uses antichain arguments. -/
-axiom sperner_connection : True
 
-/-- **Related Problem #395**: Further variants of the
+/- **Related Problem #395**: Further variants of the
     Littlewood–Offord problem. -/
-axiom related_395 : True

--- a/proofs/Proofs/Erdos510Problem.lean
+++ b/proofs/Proofs/Erdos510Problem.lean
@@ -49,13 +49,11 @@ axiom bedert_bound :
     ∀ (A : Finset ℕ), (∀ a ∈ A, a > 0) → A.card > 0 →
       ∃ θ : ℝ, cosineSum A θ < -c * (A.card : ℝ) ^ (1 / 7 : ℝ)
 
-/-- **Ruzsa (2004)**: Improved Bourgain's (1986) bound. The minimum
+/- **Ruzsa (2004)**: Improved Bourgain's (1986) bound. The minimum
     cosine sum is at most −exp(O(√(log N))). -/
-axiom ruzsa_bound : True
 
-/-- **Bourgain (1986)**: First non-trivial bound for the cosine
+/- **Bourgain (1986)**: First non-trivial bound for the cosine
     problem, later improved by Ruzsa. -/
-axiom bourgain_bound : True
 
 /- ## Optimality -/
 
@@ -69,16 +67,13 @@ axiom sidon_optimality :
 
 /- ## Observations -/
 
-/-- **Connection to Additive Combinatorics**: The cosine problem is
+/- **Connection to Additive Combinatorics**: The cosine problem is
     intimately related to the structure of difference sets and
     exponential sums in additive number theory. -/
-axiom additive_combinatorics : True
 
-/-- **Green's Problem 81**: This appears as Problem 81 on Ben Green's
+/- **Green's Problem 81**: This appears as Problem 81 on Ben Green's
     list of open problems in additive combinatorics. -/
-axiom greens_list : True
 
-/-- **Polynomial Progress (2025)**: Both Bedert and Jin–Milojević–
+/- **Polynomial Progress (2025)**: Both Bedert and Jin–Milojević–
     Tomon–Zhang independently achieved polynomial bounds,
     representing major progress toward the √N conjecture. -/
-axiom polynomial_progress : True

--- a/proofs/Proofs/Erdos515Problem.lean
+++ b/proofs/Proofs/Erdos515Problem.lean
@@ -191,53 +191,47 @@ axiom lrw_subharmonic_version :
 ## Part VII: Why This is Surprising
 -/
 
-/--
+/-
 **Key Insight 1: Growth of Entire Functions:**
 Entire functions can grow arbitrarily fast (faster than any polynomial).
 Yet a path can be found where the inverse power is integrable.
 -/
-axiom growth_insight : True
 
-/--
+/-
 **Key Insight 2: Uniformity in λ:**
 The same path works for ALL λ > 0. This is much stronger than
 Huber's result where the path depends on λ.
 -/
-axiom uniformity_insight : True
 
-/--
+/-
 **Key Insight 3: Subharmonic Functions:**
 The proof works for subharmonic functions, which is more general
 than log|f| for entire f. This suggests the result is about
 growth rates rather than complex analysis specifically.
 -/
-axiom subharmonic_insight : True
 
 /-
 ## Part VIII: Construction Ideas
 -/
 
-/--
+/-
 **The Path Construction:**
 The path is constructed to avoid regions where f is small.
 Since f is transcendental, it takes small values, but these
 regions can be avoided by a clever path.
 -/
-axiom path_construction : True
 
-/--
+/-
 **Avoiding Zeros:**
 If f has zeros, the path must avoid them. The density of zeros
 of transcendental functions allows this.
 -/
-axiom avoiding_zeros : True
 
-/--
+/-
 **Growth Along Rays:**
 Entire functions grow rapidly along most rays. The path
 exploits this to keep |f| large (hence |f|^{-λ} small).
 -/
-axiom growth_along_rays : True
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/Erdos519Problem.lean
+++ b/proofs/Proofs/Erdos519Problem.lean
@@ -172,11 +172,10 @@ theorem why_first_one_matters :
     ∀ k : ℕ, powerSum z k = 1 + ∑ i : {j : Fin n | j.val > 0}, (z i)^k := by
   sorry
 
-/--
+/-
 **Cancellation Challenge:**
 The other terms can cancel the 1, but not too much if we choose k wisely.
 -/
-axiom cancellation_bounds : True
 
 /-
 ## Part VI: Special Cases
@@ -196,12 +195,11 @@ def nthRootsOfUnity (n : ℕ) : Fin n → ℂ :=
 axiom roots_of_unity_sum (n : ℕ) (hn : n ≥ 1) (k : ℕ) :
   powerSum (nthRootsOfUnity n) k = if n ∣ k then n else 0
 
-/--
+/-
 **Implication for the Problem:**
 Roots of unity don't satisfy z₁ = 1 in general (unless n-th root = 1).
 The problem is more about arbitrary configurations.
 -/
-axiom roots_of_unity_note : True
 
 /-
 ## Part VII: Related Problem
@@ -215,12 +213,11 @@ def relatedProblem973 : Prop :=
   -- See Problem #973 for related questions
   True
 
-/--
+/-
 **Connection:**
 Both problems explore how power sums of complex numbers behave
 under various constraints.
 -/
-axiom problem_connection : True
 
 /-
 ## Part VIII: The Optimal Constant
@@ -244,11 +241,10 @@ axiom computational_evidence :
   -- Experiments suggest the true optimal c ≈ 0.7
   True
 
-/--
+/-
 **Gap:**
 The gap between c > 1/2 (proved) and c ≈ 0.7 (conjectured) remains.
 -/
-axiom gap_note : True
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/Erdos536Problem.lean
+++ b/proofs/Proofs/Erdos536Problem.lean
@@ -83,6 +83,5 @@ axiom lcm_structure (a b c L : ℕ) :
   HasEqualPairwiseLCM a b c → a.lcm b = L →
     a ∣ L ∧ b ∣ L ∧ c ∣ L
 
-/-- **Related Problems**: #535, #537, #856, #857 concern similar questions
+/- **Related Problems**: #535, #537, #856, #857 concern similar questions
     about GCD/LCM patterns in dense sets. -/
-axiom related_problems : True

--- a/proofs/Proofs/Erdos537Problem.lean
+++ b/proofs/Proofs/Erdos537Problem.lean
@@ -201,48 +201,43 @@ theorem erdos_537_disproved : ¬Erdos537Conjecture := by
 ## Part VI: Understanding Ruzsa's Construction
 -/
 
-/--
+/-
 **Why Lacunary?**
 The large gaps (pᵢ₊₁ > 2pᵢ) ensure that if pq | a for a in the set,
 then q/p > 2. This is incompatible with a₂/a₃ < 2.
 -/
-axiom lacunary_explanation : True
 
-/--
+/-
 **The Prime Ratio Argument:**
 If a₁p₁ = a₂p₂ = a₃p₃ and a₂ > a₃ (WLOG), then p₂ < p₃.
 Since p₂p₃ | a₁, the gap property gives p₃/p₂ > 2.
 But p₃/p₂ = a₂/a₃ < 2. Contradiction.
 -/
-axiom prime_ratio_argument : True
 
-/--
+/-
 **Density Estimate:**
 The lacunary squarefree numbers have positive density.
 This uses a counting argument on the number of ways to
 choose primes with the gap property.
 -/
-axiom density_estimate : True
 
 /-
 ## Part VII: Connection to Related Problems
 -/
 
-/--
+/-
 **Connection to Erdős #536:**
 Problem #536 asks a similar question with weaker conditions.
 A positive answer to #537 would imply a positive answer to #536.
 Since #537 is false, this implication gives no information about #536.
 -/
-axiom connection_536 : True
 
-/--
+/-
 **Multiplicative Structure:**
 This problem relates to the multiplicative structure of dense sets.
 Ruzsa's construction shows that density alone doesn't force
 multiplicative coincidences.
 -/
-axiom multiplicative_structure : True
 
 /-
 ## Part VIII: Main Results

--- a/proofs/Proofs/Erdos564Problem.lean
+++ b/proofs/Proofs/Erdos564Problem.lean
@@ -111,8 +111,7 @@ This would close the gap in tower height between upper and lower bounds.
 def erdos_564_conjecture : Prop :=
   ∃ c : ℝ, c > 0 ∧ ∀ᶠ n : ℕ in atTop, (R 3 n : ℝ) ≥ (2 : ℝ)^((2 : ℝ)^(c * n))
 
-/-- The problem remains open. -/
-axiom erdos_564_is_open : True
+/- The problem remains open. -/
 
 /-
 ## Tower Functions

--- a/proofs/Proofs/Erdos566Problem.lean
+++ b/proofs/Proofs/Erdos566Problem.lean
@@ -96,6 +96,5 @@ axiom trees_ramsey_size_linear :
       ∀ (q : ℕ) (H : Graph q), NoIsolated H →
         (sizeRamsey G H : ℝ) ≤ c * (edgeCount H : ℝ)
 
-/-- **Implies Problem #567**: A positive answer to #566 would
+/- **Implies Problem #567**: A positive answer to #566 would
     resolve #567 as well. -/
-axiom implies_567 : True

--- a/proofs/Proofs/Erdos574Problem.lean
+++ b/proofs/Proofs/Erdos574Problem.lean
@@ -85,13 +85,11 @@ axiom case_k_2 :
 
 /- ## Observations -/
 
-/-- **The conjecture says forbidding C_{2k−1} is "free"**: since
+/- **The conjecture says forbidding C_{2k−1} is "free"**: since
     ex(n; C_{2k}) already has the conjectured form, additionally
     forbidding C_{2k−1} should not change the asymptotics. -/
-axiom odd_cycle_free_observation : True
 
-/-- **Algebraic constructions**: For k = 2, 3, 5, algebraic
+/- **Algebraic constructions**: For k = 2, 3, 5, algebraic
     constructions (e.g., incidence graphs of projective planes)
     provide C_{2k}-free graphs with ~(n/2)^{1+1/k} edges that
     also happen to avoid C_{2k−1}. -/
-axiom algebraic_constructions : True

--- a/proofs/Proofs/Erdos577Problem.lean
+++ b/proofs/Proofs/Erdos577Problem.lean
@@ -142,25 +142,22 @@ axiom degree_bound_sharp :
 ## Part V: Related Results
 -/
 
-/-- **Connection to Hamiltonian cycles:**
+/- **Connection to Hamiltonian cycles:**
     A graph on n vertices with minimum degree ≥ n/2 is Hamiltonian
     (Dirac's theorem). Wang's result can be seen as a "partition"
     version of this classical theorem. -/
-axiom dirac_connection : True
 
-/-- **El-Zahar's Conjecture (1984):**
+/- **El-Zahar's Conjecture (1984):**
     If G has n₁ + n₂ + ... + nₖ vertices and minimum degree ≥ ⌈nᵢ/2⌉
     for all i, then G contains vertex-disjoint cycles of lengths n₁, ..., nₖ.
 
     Wang's theorem is the special case where all nᵢ = 4. -/
-axiom elzahar_conjecture : True
 
-/-- **Corrádi-Hajnal Theorem:**
+/- **Corrádi-Hajnal Theorem:**
     If G has 3k vertices and minimum degree ≥ 2k,
     then G contains k vertex-disjoint triangles.
 
     This is analogous to Wang's theorem but for 3-cycles. -/
-axiom corradi_hajnal : True
 
 /-
 ## Part VI: Proof Techniques
@@ -177,10 +174,9 @@ axiom wang_proof_technique :
     -- 4. Derive contradiction
     True
 
-/-- **Algorithmic aspect:**
+/- **Algorithmic aspect:**
     Wang's proof is constructive in the sense that it provides
     a polynomial-time algorithm to find the k disjoint 4-cycles. -/
-axiom algorithmic_aspect : True
 
 /-
 ## Part VII: Summary

--- a/proofs/Proofs/Erdos589Problem.lean
+++ b/proofs/Proofs/Erdos589Problem.lean
@@ -228,7 +228,7 @@ axiom balogh_solymosi_2018 :
   ∀ ε > 0, ∃ N : ℕ, ∀ n : ℕ, n ≥ N →
     (g n : ℝ) ≤ (n : ℝ)^((5:ℝ)/6 + ε)
 
-/--
+/-
 **The container method:**
 Balogh and Solymosi used the container method (Saxton-Thomason,
 Balogh-Morris-Samotij) - this was the first application of the
@@ -238,7 +238,6 @@ They showed: a random n-element subset of a large 3D grid, projected
 to 2D, has no 4 collinear points but at most n^(5/6+o(1)) points in
 general position with high probability.
 -/
-axiom container_method_application : True
 
 /--
 **Current best bounds:**

--- a/proofs/Proofs/Erdos661Problem.lean
+++ b/proofs/Proofs/Erdos661Problem.lean
@@ -71,17 +71,14 @@ axiom lattice_upper :
 
 /- ## Higher Dimensions -/
 
-/-- **Lenz Construction (ℝ⁴)**: In ℝ⁴, place x₁,...,xₙ on one
+/- **Lenz Construction (ℝ⁴)**: In ℝ⁴, place x₁,...,xₙ on one
     circle and y₁,...,yₙ on an orthogonal circle. Then
     d(xᵢ,yⱼ) = √2 for all i,j: only one bipartite distance. -/
-axiom lenz_construction : True
 
 /- ## Observations -/
 
-/-- **Connection to Problem #89**: The Erdős distinct distances
+/- **Connection to Problem #89**: The Erdős distinct distances
     problem (general case) is Problem #89. This bipartite variant
     asks whether the bipartite structure provides additional savings. -/
-axiom erdos_89_connection : True
 
-/-- **$50 Reward**: Erdős offered $50 for resolving this problem. -/
-axiom reward : True
+/- **$50 Reward**: Erdős offered $50 for resolving this problem. -/

--- a/proofs/Proofs/Erdos664Problem.lean
+++ b/proofs/Proofs/Erdos664Problem.lean
@@ -180,11 +180,9 @@ def ErdosQuestion664_Original : Prop :=
       ∃ B : Finset (Fin n), ∃ k : ℕ,
         IsBlocker A B ∧ HasBoundedIntersection A B k
 
-/-- The original version remains OPEN but is conjectured false. -/
-axiom original_version_open : True
+/- The original version remains OPEN but is conjectured false. -/
 
-/-- Alon conjectures the original is also false. -/
-axiom alon_conjecture_original_false : True
+/- Alon conjectures the original is also false. -/
 
 /-
 ## Part VII: Finite Geometry Interpretation

--- a/proofs/Proofs/Erdos666Problem.lean
+++ b/proofs/Proofs/Erdos666Problem.lean
@@ -247,10 +247,9 @@ def GeneralizedConjecture : Prop :=
           (H.edgeFinset.card : ℝ) ≥ c * (n : ℝ)^aₖ * 2^n →
           HasC2k H k
 
-/--
+/-
 **This generalization remains open:**
 -/
-axiom generalized_conjecture_open : True
 
 /-
 ## Part IX: Related Results

--- a/proofs/Proofs/Erdos672Problem.lean
+++ b/proofs/Proofs/Erdos672Problem.lean
@@ -226,8 +226,7 @@ The probability that a "random" product of k near-coprime factors
 is a perfect l-th power is extremely small, heuristically ~ 1/P^(1-1/l).
 -/
 
-/-- Heuristic: Products of k ≥ 4 terms in AP are generically not perfect powers. -/
-axiom heuristic_argument : True
+/- Heuristic: Products of k ≥ 4 terms in AP are generically not perfect powers. -/
 
 /-
 ## Summary

--- a/proofs/Proofs/Erdos676Problem.lean
+++ b/proofs/Proofs/Erdos676Problem.lean
@@ -192,7 +192,6 @@ The problem remains OPEN. Erdős doubted a positive answer.
 def erdos_676_status : String := "OPEN"
 
 -- Erdős's skepticism
-axiom erdos_skeptical : True  -- Erdős believed positive answer "rather unlikely"
 
 -- The main statement
 theorem erdos_676_statement :

--- a/proofs/Proofs/Erdos682Problem.lean
+++ b/proofs/Proofs/Erdos682Problem.lean
@@ -290,31 +290,27 @@ theorem most_gaps_have_rough :
 ## Part IX: Related Results
 -/
 
-/--
+/-
 **Connection to Problem #680:**
 Problem 680 asks about the maximum gap among p_n ≤ X without rough numbers.
 -/
-axiom problem_680_connection : True
 
-/--
+/-
 **Connection to Problem #681:**
 Problem 681 concerns a similar question with a different gap condition.
 -/
-axiom problem_681_connection : True
 
-/--
+/-
 **Smooth vs Rough Numbers:**
 k-smooth numbers (all prime factors ≤ k) are the complement of k-rough.
 The distribution of smooth numbers is well-understood (de Bruijn).
 -/
-axiom smooth_number_theory : True
 
-/--
+/-
 **Bertrand's Postulate Connection:**
 Bertrand: there exists a prime in (n, 2n).
 This problem asks about composite numbers with large least prime factors.
 -/
-axiom bertrand_connection : True
 
 /-
 ## Part X: Summary

--- a/proofs/Proofs/Erdos696Problem.lean
+++ b/proofs/Proofs/Erdos696Problem.lean
@@ -243,12 +243,11 @@ For n with many divisors, H(n) >> h(n).
 axiom H_much_larger_example :
   ∃ n : ℕ, H n ≥ 2 * h n
 
-/--
+/-
 **Why composites help:**
 If d | n and d' | n with d' ≡ 1 (mod d), we can include both.
 Composites give more flexibility in finding such pairs.
 -/
-axiom composites_give_flexibility : True
 
 /--
 **Highly composite numbers:**

--- a/proofs/Proofs/Erdos697Problem.lean
+++ b/proofs/Proofs/Erdos697Problem.lean
@@ -100,8 +100,7 @@ axiom trivial_bound_proof :
 axiom erdos_alpha_one :
   Filter.Tendsto (fun m => delta m 1) Filter.atTop (nhds 0)
 
-/-- Erdős claimed this in [Er79e] but didn't publish a full proof -/
-axiom erdos_claim_source : True
+/- Erdős claimed this in [Er79e] but didn't publish a full proof -/
 
 /-
 ## Part 5: Hall's Theorem (1992)
@@ -132,7 +131,7 @@ theorem threshold_is_one_over_log_two :
 ## Part 6: Why 1/log 2?
 -/
 
-/-- Intuition: The number of d ≡ 1 (mod m) with d < x is about x/m.
+/- Intuition: The number of d ≡ 1 (mod m) with d < x is about x/m.
     For x = exp(m^α), this is exp(m^α)/m.
 
     For this to "cover" most integers, we need:
@@ -140,7 +139,6 @@ theorem threshold_is_one_over_log_two :
 
     The threshold comes from the sieve-theoretic analysis of when
     enough divisors exist to cover a positive density of integers. -/
-axiom intuition_for_threshold : True
 
 /-- The value 1/log 2 arises from the multiplicative structure of divisors -/
 axiom why_one_over_log_two :
@@ -167,12 +165,10 @@ axiom at_threshold_open :
 ## Part 8: Connection to Problem #696
 -/
 
-/-- Problem #696 is related (similar divisibility questions) -/
-axiom related_problem_696 : True
+/- Problem #696 is related (similar divisibility questions) -/
 
-/-- The problems share the theme of understanding when divisors d ≡ 1 (mod m)
+/- The problems share the theme of understanding when divisors d ≡ 1 (mod m)
     sufficiently cover integers -/
-axiom shared_theme : True
 
 /-
 ## Part 9: Examples
@@ -183,24 +179,20 @@ axiom shared_theme : True
     So δ(2, α) = 1 for all α > 0. -/
 axiom example_m_2 : ∀ α : ℝ, α > 0 → delta 2 α = 1
 
-/-- For m = p (large prime): d ≡ 1 (mod p) means d = 1 + kp.
+/- For m = p (large prime): d ≡ 1 (mod p) means d = 1 + kp.
     The smallest such d > 1 is 1 + p.
     The density depends on how many integers are divisible by such d. -/
-axiom example_m_prime : True
 
 /-
 ## Part 10: Historical Context
 -/
 
-/-- The problem appeared in Erdős's 1979 paper in Astérisque -/
-axiom erdos_1979_source : True
+/- The problem appeared in Erdős's 1979 paper in Astérisque -/
 
-/-- "Some unconventional problems in number theory" contained several
+/- "Some unconventional problems in number theory" contained several
     related problems about divisibility and density -/
-axiom unconventional_problems : True
 
-/-- Hall's 1992 paper resolved this and related questions -/
-axiom hall_1992_paper : True
+/- Hall's 1992 paper resolved this and related questions -/
 
 /-
 ## Part 11: Main Results

--- a/proofs/Proofs/Erdos698Problem.lean
+++ b/proofs/Proofs/Erdos698Problem.lean
@@ -198,37 +198,33 @@ theorem erdos698_answer : erdos698Question := by
 ## Part VII: Implications and Generalizations
 -/
 
-/--
+/-
 **Divisibility Observation:**
 The fact that gcd(C(n,i), C(n,j)) > 1 for all valid pairs
 shows that the middle binomial coefficients share common factors.
 This is related to the arithmetic structure of Pascal's triangle.
 -/
-axiom divisibility_structure : True
 
-/--
+/-
 **Pascal's Triangle Primes:**
 The only primes in Pascal's triangle (besides the edges) are
 the entries C(p, k) where p is prime and 0 < k < p.
 These are all equal to p · (p-1)! / (k! (p-k)!) which is divisible by p.
 -/
-axiom pascal_primes : True
 
-/--
+/-
 **Multinomial Generalization:**
 Bergman actually proved a more general result about
 common divisors of multinomial coefficients.
 -/
-axiom multinomial_generalization : True
 
-/--
+/-
 **Connection to Number Theory:**
 The GCD of binomial coefficients relates to:
 1. p-adic valuations of factorials (Kummer's theorem)
 2. Lucas' theorem on binomial coefficients mod p
 3. Distribution of prime factors in products
 -/
-axiom number_theory_connections : True
 
 /-
 ## Part VIII: Kummer's Theorem Connection

--- a/proofs/Proofs/Erdos699Problem.lean
+++ b/proofs/Proofs/Erdos699Problem.lean
@@ -74,8 +74,7 @@ def HasCommonStrictlyLargePrime (n i j : ℕ) : Prop :=
 def erdos_699_statement : Prop :=
   ∀ n i j : ℕ, 1 ≤ i → i < j → j ≤ n / 2 → HasCommonLargePrime n i j
 
-/-- The problem is open - we don't know whether it's true or false. -/
-axiom erdos_699_open : True
+/- The problem is open - we don't know whether it's true or false. -/
 
 /-
 ## The Erdős-Szekeres Strengthening (OPEN)

--- a/proofs/Proofs/Erdos701Problem.lean
+++ b/proofs/Proofs/Erdos701Problem.lean
@@ -213,7 +213,6 @@ def WeightedChvatalConjecture {α : Type*} [Fintype α]
     ∃ x : α, ∀ F' : Set (Set α), F' ⊆ F → IsIntersecting F' →
       ∑' A : F', w A ≤ ∑' A : Star F x, w A
 
-axiom borg_2011_partial : True  -- Partial results under assumptions
 
 /-
 ## Part VI: Connection to Erdős-Ko-Rado

--- a/proofs/Proofs/Erdos702Problem.lean
+++ b/proofs/Proofs/Erdos702Problem.lean
@@ -78,10 +78,9 @@ axiom extremal_construction :
       F.card = Nat.choose (n - 2) (k - 2) ∧
       AvoidsSingletonIntersections F
 
-/-- **Why C(n-2, k-2)?**
+/- **Why C(n-2, k-2)?**
     If all sets contain {x, y}, then any two sets A, B satisfy
     |A ∩ B| ≥ 2 (they share at least x and y), so |A ∩ B| ≠ 1. -/
-axiom why_n_minus_2_choose_k_minus_2 : True
 
 /-
 ## Part IV: Frankl's Theorem (1977)
@@ -133,13 +132,11 @@ axiom k3_fails :
 ## Part VI: Proof Technique
 -/
 
-/-- **Frankl's proof approach:**
+/- **Frankl's proof approach:**
     Uses the shifting technique and careful case analysis. -/
-axiom shifting_technique : True
 
-/-- **Connection to Problem #703:**
+/- **Connection to Problem #703:**
     Related problem about intersecting families. -/
-axiom related_to_703 : True
 
 /-
 ## Part VII: Summary

--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -164,12 +164,11 @@ is exponentially bounded away from 2^n.
 -/
 axiom frankl_rodl_1987 : mainQuestion
 
-/--
+/-
 **The Middle Range:**
 When r is a constant fraction of n (not too small, not too close to n/2),
 the forbidden intersection constraint becomes very powerful.
 -/
-axiom middle_range_intuition : True
 
 /-
 ## Part VI: Connection to Chromatic Numbers
@@ -229,12 +228,11 @@ axiom frankl_wilson_theorem :
 ## Part VIII: Related Problem #702
 -/
 
-/--
+/-
 **Problem #702 - The k-uniform case:**
 What is the maximum size of a k-uniform family (all sets have size k)
 avoiding r-intersection?
 -/
-axiom erdos_702_connection : True
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/Erdos706Problem.lean
+++ b/proofs/Proofs/Erdos706Problem.lean
@@ -68,15 +68,12 @@ axiom erdos_706_exponential_upper :
 
 /- ## Observations -/
 
-/-- **Hadwiger–Nelson Connection**: the r = 1 case is exactly
+/- **Hadwiger–Nelson Connection**: the r = 1 case is exactly
     the Hadwiger–Nelson problem (Erdős Problem #508). -/
-axiom hadwiger_nelson_connection : True
 
-/-- **Higher-Dimensional Analogue**: Erdős Problem #704 asks
+/- **Higher-Dimensional Analogue**: Erdős Problem #704 asks
     about the chromatic number of unit-distance graphs in ℝⁿ,
     where Frankl–Wilson gives exponential lower bounds. -/
-axiom higher_dim_analogue : True
 
-/-- **Girth Variant**: Erdős Problem #705 asks whether large girth
+/- **Girth Variant**: Erdős Problem #705 asks whether large girth
     forces the chromatic number of unit-distance graphs down to 3. -/
-axiom girth_variant : True

--- a/proofs/Proofs/Erdos714Problem.lean
+++ b/proofs/Proofs/Erdos714Problem.lean
@@ -204,19 +204,17 @@ axiom projective_plane_construction :
     ∃ (G : SimpleGraph (Fin (q^2 + q + 1))) [DecidableRel G.Adj],
       isKrrFree G 2 ∧ edgeCount G = (q + 1) * (q^2 + q + 1)
 
-/--
+/-
 **Generalized Polygons:**
 For r = 3, constructions use generalized hexagons (girth 12 cages).
 These algebraic constructions give K_{3,3}-free graphs with n^{5/3} edges.
 -/
-axiom generalized_hexagon_construction : True
 
-/--
+/-
 **Norm Graphs (Kollár-Rónyai-Szabó):**
 Algebraic constructions using norms over finite fields give
 improvements for some values of r, but still don't achieve the conjectured bound.
 -/
-axiom norm_graph_construction : True
 
 /-
 ## Part VII: Connection to Other Problems
@@ -232,19 +230,17 @@ theorem k22_equals_c4 :
   intro G _
   constructor <;> intro _ <;> trivial
 
-/--
+/-
 **Problem #147: Related Turán problem**
 Problem #147 asks about degenerate Turán numbers.
 -/
-axiom related_problem_147 : True
 
-/--
+/-
 **Zarankiewicz Problem z(m,n;r,s):**
 The full Zarankiewicz problem asks for the maximum number of 1s
 in an m×n 0-1 matrix with no all-1s r×s submatrix.
 ex(n; K_{r,r}) = z(n,n;r,r)/2 (approximately).
 -/
-axiom zarankiewicz_matrix_formulation : True
 
 /-
 ## Part VIII: Main Results Summary

--- a/proofs/Proofs/Erdos719Problem.lean
+++ b/proofs/Proofs/Erdos719Problem.lean
@@ -165,7 +165,7 @@ theorem trivial_decomp_exists (n r : ℕ) (H : RUniformHypergraph (Fin n) r) :
 
 -- ## Relationship to Other Problems
 
-/-- The Erdős–Sauer conjecture relates to Turán-type extremal hypergraph
+/- The Erdős–Sauer conjecture relates to Turán-type extremal hypergraph
     theory. The graph case (r=2) connects to Erdős' result on edge-disjoint
     triangle decompositions.
 
@@ -173,4 +173,3 @@ theorem trivial_decomp_exists (n r : ℕ) (H : RUniformHypergraph (Fin n) r) :
     - #718: Lower bounds on Turán numbers for hypergraphs
     - #720: Turán densities for higher uniformity
     - #83: Triangle decomposition problems for dense graphs -/
-axiom related_problems : True

--- a/proofs/Proofs/Erdos722Problem.lean
+++ b/proofs/Proofs/Erdos722Problem.lean
@@ -214,7 +214,7 @@ theorem erdos_722_solved (r k : ℕ) (hr : r ≥ 1) (hk : k > r) :
 ## Part VI: Keevash's Method
 -/
 
-/--
+/-
 **Randomized Algebraic Construction:**
 Keevash's proof uses a sophisticated combination of:
 1. Random greedy algorithms
@@ -224,14 +224,12 @@ Keevash's proof uses a sophisticated combination of:
 The key innovation was the "randomized algebraic construction" that handles
 the general case.
 -/
-axiom keevash_method_insight : True
 
-/--
+/-
 **Absorbing Method:**
 A key technique: first construct a "robustly spread" partial design,
 then complete it using algebraic absorption.
 -/
-axiom absorbing_method : True
 
 /-
 ## Part VII: Small Examples

--- a/proofs/Proofs/Erdos723Problem.lean
+++ b/proofs/Proofs/Erdos723Problem.lean
@@ -37,7 +37,7 @@ The Mathlib type `Configuration.ProjectivePlane P L` captures these axioms.
 
 /- ## The Main Conjecture (Open) -/
 
-/--
+/-
 **Erdős Problem #723** (The Prime Power Conjecture):
 
 If there exists a finite projective plane of order n, must n be a prime power?
@@ -49,7 +49,6 @@ been found.
 We state this as an open problem (axiom for True, indicating we don't know
 whether the answer is yes or no).
 -/
-axiom erdos_723_open : True  -- The general conjecture remains open
 
 /--
 The formal statement of the Prime Power Conjecture: every finite projective
@@ -120,13 +119,12 @@ axiom lam_order_10 :
 
 /- ## Order 12 Remains Open -/
 
-/--
+/-
 It is an open problem whether a projective plane of order 12 exists.
 
 Note that 12 ≡ 0 (mod 4), so Bruck-Ryser doesn't apply. No computer search
 has been successful for order 12, and no theoretical obstruction is known.
 -/
-axiom order_12_open : True  -- Existence of order 12 plane is open
 
 /- ## Basic Properties -/
 

--- a/proofs/Proofs/Erdos732Problem.lean
+++ b/proofs/Proofs/Erdos732Problem.lean
@@ -271,18 +271,16 @@ example : PairCountCondition [3, 3, 3, 3, 3] 6 := by
 ## Part VIII: Related Problems
 -/
 
-/--
+/-
 **Problem #733:**
 A related problem about block designs.
 -/
-axiom problem_733_related : True
 
-/--
+/-
 **Connection to Steiner systems:**
 A Steiner system S(2, k, n) is a PBD where all blocks have size k.
 These are very constrained.
 -/
-axiom steiner_systems_special_case : True
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/Erdos747Problem.lean
+++ b/proofs/Proofs/Erdos747Problem.lean
@@ -217,14 +217,13 @@ axiom above_threshold_succeeds :
   ∀ ε > 0, AlmostSurely (fun n =>
     ShamirProperty n (Nat.ceil ((1 + ε) * n * Real.log n)))
 
-/--
+/-
 **Probabilistic Method:**
 The proof uses sophisticated probabilistic techniques including:
 1. Second moment method
 2. Nibble method
 3. Regularity-type arguments
 -/
-axiom proof_techniques : True
 
 /-
 ## Part VIII: Comparison with Graphs
@@ -241,37 +240,33 @@ axiom graph_matching_threshold :
       c * n * Real.log n ≤ shamirThreshold n ∧
       shamirThreshold n ≤ C * n * Real.log n
 
-/--
+/-
 **The Surprise:**
 The same threshold n log n works for ALL uniformities r ≥ 2.
 This was not obvious - Erdős expected the hypergraph case to be different.
 -/
-axiom uniformity_independence : True
 
 /-
 ## Part IX: Historical Notes
 -/
 
-/--
+/-
 **Erdős's Comment:**
 "Many of the problems on random hypergraphs can be settled by the same
 methods as used for ordinary graphs and usually one can guess the answer
 almost immediately. Here we have no idea of the answer."
 -/
-axiom erdos_comment : True
 
-/--
+/-
 **Shamir's Original Question (1979):**
 Shamir asked about the r = 3 case specifically.
 -/
-axiom shamir_1979 : True
 
-/--
+/-
 **Connection to Factor Problems:**
 This is related to the general "factor" problem in random graphs:
 when does G(n, p) contain a given subgraph?
 -/
-axiom factor_problems : True
 
 /-
 ## Part X: Summary

--- a/proofs/Proofs/Erdos759Problem.lean
+++ b/proofs/Proofs/Erdos759Problem.lean
@@ -263,14 +263,13 @@ axiom high_girth_cochromatic :
 ## Part IX: Connection to Graph Structure
 -/
 
-/--
+/-
 **Why √n / log n?**
 - √n relates to the number of vertices in dense surface graphs
 - log n factor comes from girth considerations
 - High-girth graphs contribute to the lower bound
 - The upper bound uses structural properties of surface embeddings
 -/
-axiom growth_rate_intuition : True
 
 /--
 **Planar Case (n = 0):**

--- a/proofs/Proofs/Erdos770Problem.lean
+++ b/proofs/Proofs/Erdos770Problem.lean
@@ -74,10 +74,8 @@ axiom h_equals_3_infinitely :
 
 /- ## Observations -/
 
-/-- **Fermat Connection**: gcd(a^n − 1, b^n − 1) = a^{gcd(n,n)} − 1 = a^n − 1
+/- **Fermat Connection**: gcd(a^n − 1, b^n − 1) = a^{gcd(n,n)} − 1 = a^n − 1
     is related to the factoring of Mersenne-type numbers. When p − 1 | n,
     p divides a^n − 1 for all a coprime to p, creating shared factors. -/
-axiom fermat_connection : True
 
-/-- **OEIS A263647**: The sequence h(n) appears in the OEIS. -/
-axiom oeis_connection : True
+/- **OEIS A263647**: The sequence h(n) appears in the OEIS. -/

--- a/proofs/Proofs/Erdos773Problem.lean
+++ b/proofs/Proofs/Erdos773Problem.lean
@@ -174,7 +174,7 @@ axiom random_construction :
     -- This gives |A| ~ N^{1/3+ε}, but refined analysis gives N^{2/3-o(1)}
     True
 
-/--
+/-
 **Why N^{2/3}?**
 Balancing: want many elements (N^α) but few collisions.
 Collisions occur when a₁² + a₂² = b₁² + b₂².
@@ -182,7 +182,6 @@ With N^α elements, expect N^{2α} sums, but only N/(log N)^{1/2} targets.
 Need N^{2α} ≤ N/(log N)^{1/2}, giving α ≤ 1/2 + o(1).
 Refined counting gives α = 2/3.
 -/
-axiom why_two_thirds : True
 
 /-
 ## Part VII: Upper Bound Analysis
@@ -215,12 +214,11 @@ def trueOrder : Prop :=
     ∀ ε > 0, ∀ᶠ N in Filter.atTop,
       (N : ℝ)^(α - ε) ≤ (f N : ℝ) ∧ (f N : ℝ) ≤ (N : ℝ)^(α + ε)
 
-/--
+/-
 **Can the lower bound be improved?**
 The current N^{2/3} comes from probabilistic existence.
 An explicit construction might do better.
 -/
-axiom explicit_construction_question : True
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/Erdos775Problem.lean
+++ b/proofs/Proofs/Erdos775Problem.lean
@@ -262,12 +262,11 @@ theorem graphs_vs_hypergraphs :
 ## Part X: Related Problems
 -/
 
-/--
+/-
 **Connection to Erdős Problem #927:**
 Problem #927 asks related questions about clique structures in hypergraphs.
 Both problems explore the combinatorial limitations of hypergraph cliques.
 -/
-axiom erdos_927_related : True  -- Placeholder for the connection
 
 /--
 **Summary Theorem:**

--- a/proofs/Proofs/Erdos789Problem.lean
+++ b/proofs/Proofs/Erdos789Problem.lean
@@ -128,21 +128,18 @@ theorem combined_bounds :
       (h n : ℝ) ≤ C * Real.sqrt n) := by
   exact ⟨erdos_choi_1974_lower, straus_1966_upper⟩
 
-/-- The gap between bounds: exponents 1/3 and 1/2 -/
-axiom gap_between_bounds : True
+/- The gap between bounds: exponents 1/3 and 1/2 -/
 
 /-
 ## Part VI: Erdős's Construction
 -/
 
-/-- Erdős's probabilistic construction for lower bound:
+/- Erdős's probabilistic construction for lower bound:
     For random α ∈ [0,1], take
     B = {a ∈ A : {αa} ∈ n^{-1/3} + ½(-n^{-2/3}, n^{-2/3})}
     Expected |B| ≈ n^{1/3} and likely sum-length-free -/
-axiom erdos_construction : True
 
-/-- Choi's improvement using more careful analysis -/
-axiom choi_improvement : True
+/- Choi's improvement using more careful analysis -/
 
 /-
 ## Part VII: Connection to Sidon Sets
@@ -166,11 +163,9 @@ axiom sidon_bound : ∀ n : ℕ, ∃ C : ℝ, C > 0 ∧
 ## Part VIII: Related Problems
 -/
 
-/-- Connection to Problem 186 (sum-free sets) -/
-axiom problem_186_related : True
+/- Connection to Problem 186 (sum-free sets) -/
 
-/-- Connection to Problem 874 -/
-axiom problem_874_related : True
+/- Connection to Problem 874 -/
 
 /-
 ## Part IX: Special Cases
@@ -179,18 +174,16 @@ axiom problem_874_related : True
 /-- For n = 1: h(1) = 1 trivially -/
 axiom h_one : h 1 = 1
 
-/-- For small sets, explicit bounds can be computed -/
-axiom h_small_values : True
+/- For small sets, explicit bounds can be computed -/
 
 /-
 ## Part X: Examples
 -/
 
-/-- Example: {1, 2, 3} - is {1, 3} sum-length-free?
+/- Example: {1, 2, 3} - is {1, 3} sum-length-free?
     1 + 1 = 2 (length 2), but 2 ∉ B
     1 + 3 = 4 (length 2), 3 + 1 = 4 (length 2) ✓
     So {1, 3} is sum-length-free -/
-axiom example_1_3 : True
 
 /-- Numerical bounds:
     At n = 1000:
@@ -215,21 +208,17 @@ example : (1000000 : ℕ).sqrt = 1000 := by native_decide
     3. h(n) ~ (n log n)^{1/3} · (log n)^β for some β > 0 -/
 def possible_growth_rates : Prop := True
 
-/-- The problem is to determine the correct exponent -/
-axiom correct_exponent_unknown : True
+/- The problem is to determine the correct exponent -/
 
 /-
 ## Part XII: Proof Techniques
 -/
 
-/-- Upper bound uses counting argument on sum representations -/
-axiom upper_bound_technique : True
+/- Upper bound uses counting argument on sum representations -/
 
-/-- Lower bound uses probabilistic method with fractional parts -/
-axiom lower_bound_technique : True
+/- Lower bound uses probabilistic method with fractional parts -/
 
-/-- Diophantine approximation is key to construction -/
-axiom diophantine_approximation : True
+/- Diophantine approximation is key to construction -/
 
 /-
 ## Part XIII: Summary

--- a/proofs/Proofs/Erdos833Problem.lean
+++ b/proofs/Proofs/Erdos833Problem.lean
@@ -122,8 +122,7 @@ axiom f_2 : f 2 = 2
 /-- Known: f(3) = 3 -/
 axiom f_3 : f 3 = 3
 
-/-- Erdős did not know f(4) -/
-axiom f_4_unknown : True
+/- Erdős did not know f(4) -/
 
 /-
 ## Part IV: The Exponential Question
@@ -209,10 +208,9 @@ axiom fano_plane_example :
 ## Part VIII: Proof Technique
 -/
 
-/-- The proof uses probabilistic methods and the Lovász Local Lemma.
+/- The proof uses probabilistic methods and the Lovász Local Lemma.
     The key insight: if all degrees are small, a random 2-coloring
     works with positive probability, contradicting χ(H) = 3. -/
-axiom lovasz_local_lemma_application : True
 
 /-- Contrapositive: χ(H) = 3 implies some vertex has high degree.
     This is the contrapositive of erdos_lovasz_bound: if all vertices have

--- a/proofs/Proofs/Erdos837Problem.lean
+++ b/proofs/Proofs/Erdos837Problem.lean
@@ -72,18 +72,15 @@ axiom zero_is_jump_3uniform :
 
 /- ## Observations -/
 
-/-- **Hypergraph Turán problem**: For k ≥ 3, even the Turán
+/- **Hypergraph Turán problem**: For k ≥ 3, even the Turán
     density π(K_{k+1}^{(k)}) is unknown. The tetrahedron
     conjecture: π(K_4^{(3)}) = 5/9. -/
-axiom turan_hypergraph_open : True
 
-/-- **Frankl–Rödl (1984)**: The Ramsey multiplicity approach
+/- **Frankl–Rödl (1984)**: The Ramsey multiplicity approach
     shows that certain hypergraph densities force denser
     subhypergraphs, but a complete characterization of A_3
     remains far from reach. -/
-axiom frankl_rodl : True
 
-/-- **Razborov flag algebras**: Flag algebra methods can
+/- **Razborov flag algebras**: Flag algebra methods can
     determine some jump values computationally, but the
     general structure of A_3 is unknown. -/
-axiom flag_algebras : True

--- a/proofs/Proofs/Erdos83Problem.lean
+++ b/proofs/Proofs/Erdos83Problem.lean
@@ -236,29 +236,25 @@ axiom erdos83_bound_asymptotic (n : ℕ) (hn : n ≥ 10) :
 ## Part IX: Implications and Generalizations
 -/
 
-/--
+/-
 **Phase Transitions:**
 The structure of optimal t-intersecting families changes at critical values of r.
 -/
-axiom phase_transition_structure : True
 
-/--
+/-
 **Coding Theory Connection:**
 t-intersecting families relate to error-correcting codes with minimum distance.
 -/
-axiom coding_theory_connection : True
 
-/--
+/-
 **Probabilistic Extension:**
 Random k-subsets have specific intersection properties.
 -/
-axiom random_family_properties : True
 
-/--
+/-
 **Multipartite Extension:**
 The theorem extends to families of multipartite sets.
 -/
-axiom multipartite_extension : True
 
 /-
 ## Part X: Summary

--- a/proofs/Proofs/Erdos847Problem.lean
+++ b/proofs/Proofs/Erdos847Problem.lean
@@ -144,7 +144,7 @@ axiom apfree_zero_density : ∀ A : Set ℕ, isAPFree A →
 
 /- ## Part VI: Why the Conjecture Fails -/
 
-/--
+/-
 **Key insight:**
 The ENR condition only requires *some* large AP-free subset of each
 finite piece. It doesn't require the pieces to come from a single
@@ -155,7 +155,6 @@ The counterexample likely uses a construction where:
 2. But different subsets require different AP-free decompositions
 3. No single finite collection works for all subsets
 -/
-axiom key_insight : True
 
 /--
 **Finite unions are very restrictive:**
@@ -170,17 +169,15 @@ theorem finite_union_implies_enr (A : Set ℕ) (k : ℕ) (parts : Fin k → Set 
 
 /- ## Part VII: Related Problems -/
 
-/--
+/-
 **Problem #774:**
 Related to structure of sets avoiding APs.
 -/
-axiom problem_774_related : True
 
-/--
+/-
 **Problem #846:**
 Adjacent problem in the Erdős collection on AP-free sets.
 -/
-axiom problem_846_related : True
 
 /- ## Part VIII: Roth's Theorem and Bounds -/
 

--- a/proofs/Proofs/Erdos859Problem.lean
+++ b/proofs/Proofs/Erdos859Problem.lean
@@ -154,8 +154,7 @@ def ErdosProblem859 : Prop :=
     ∃ d : ℕ → ℝ, (∀ t > 0, HasNaturalDensity (DivisorSumSet t) (d t)) ∧
       (fun t : ℕ => d t) ~[atTop] (fun t => c₁ / (log t)^c₂)
 
-/-- The status: OPEN. We don't know if precise asymptotics exist. -/
-axiom erdos_859_open : True  -- Placeholder for open status
+/- The status: OPEN. We don't know if precise asymptotics exist. -/
 
 /- ## Part VI: The Divisor Function -/
 

--- a/proofs/Proofs/Erdos860Problem.lean
+++ b/proofs/Proofs/Erdos860Problem.lean
@@ -130,45 +130,39 @@ theorem subquadratic_upper_bound :
   intro c hc
   filter_upwards with n using by sorry  -- From erdos_pomerance
 
-/-- **The Open Problem:**
+/- **The Open Problem:**
     The exact growth rate of h(n) is unknown.
     Is h(n) = Θ(n^α) for some 1 < α < 3/2?
     Is h(n) = n · ω(n) for some slowly growing ω? -/
-axiom exact_growth_unknown : True
 
 /-
 ## Part V: Connection to Other Problems
 -/
 
-/-- **Relation to Erdős #375:**
+/- **Relation to Erdős #375:**
     Problem 375 asks a related covering question. -/
-axiom related_to_erdos_375 : True
 
-/-- **Guy's Problem B32:**
+/- **Guy's Problem B32:**
     This problem appears as B32 in Guy's "Unsolved Problems in
     Number Theory". -/
-axiom guys_problem_B32 : True
 
-/-- **Greedy Algorithm:**
+/- **Greedy Algorithm:**
     A natural approach is greedy: for each prime p_i, pick the
     smallest available multiple. Analysis of this algorithm gives
     bounds. -/
-axiom greedy_approach : True
 
 /-
 ## Part VI: Reformulation
 -/
 
-/-- **Equivalent formulation:**
+/- **Equivalent formulation:**
     h(n) is the least L such that for all m, the bipartite graph
     G with vertices {1,...,π(n)} and {m+1,...,m+L} where i ~ j iff
     p_i | j has a perfect matching on the prime side. -/
-axiom bipartite_matching_formulation : True
 
-/-- **Hall's condition:**
+/- **Hall's condition:**
     By Hall's theorem, we need: for all S ⊆ {1,...,π(n)},
     |N(S) ∩ (m, m+L]| ≥ |S| where N(S) is the neighbor set. -/
-axiom halls_condition : True
 
 /-
 ## Part VII: Summary

--- a/proofs/Proofs/Erdos876Problem.lean
+++ b/proofs/Proofs/Erdos876Problem.lean
@@ -240,28 +240,25 @@ theorem powers_of_two_sumfree :
   -- 2^n can only be written as sum of distinct 2^k in one way (itself)
   sorry
 
-/--
+/-
 **Powers of 3 that are 1 mod 3:**
 Another classical example of a sum-free set.
 -/
-axiom one_mod_three_example : True
 
 /-
 ## Part VIII: Connection to Sidon Sets
 -/
 
-/--
+/-
 **Sidon Set Connection:**
 Sum-free sets are related to (but different from) Sidon sets
 where all pairwise sums are distinct.
 -/
-axiom sidon_connection : True
 
-/--
+/-
 **B_h Sequences:**
 Sum-free sets are a type of B_h sequence for h = infinity.
 -/
-axiom bh_sequence_connection : True
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/Erdos877Problem.lean
+++ b/proofs/Proofs/Erdos877Problem.lean
@@ -175,13 +175,12 @@ theorem main_question_resolved :
     ∃ c : ℚ, c < 1/2 ∧ ∀ n : ℕ, n ≥ 1 → (f_m n : ℚ) < 2 ^ (c * n) :=
   luczak_schoen_theorem
 
-/--
+/-
 **Corollary: f_m(n) = o(f(n)):**
 Cameron-Erdős also asked if f_m(n) = o(f(n)).
 Since f(n) ≥ 2^{cn} for some c close to 1/2 (the odds alone give ~2^{n/2}),
 and f_m(n) < 2^{c'n} for c' < 1/2, this is also resolved.
 -/
-axiom f_m_little_o_f : True  -- f_m(n) = o(f(n))
 
 /-
 ## Part VI: The BLST Sharp Bounds (2015, 2018)
@@ -222,41 +221,37 @@ axiom C_n_values : ∃ c0 c1 c2 c3 : ℚ,
 ## Part VII: Structure of Maximal Sum-Free Sets
 -/
 
-/--
+/-
 **The three canonical constructions:**
 Most maximal sum-free sets fall into one of three types:
 1. Subsets of odd numbers
 2. Subsets of {n/3+1, ..., n}
 3. Hybrid constructions
 -/
-axiom three_canonical_types : True
 
-/--
+/-
 **Why 1/4?**
 The exponent 1/4 arises because:
 - The odds give ~n/2 elements, but maximal subsets are constrained
 - Only ~n/4 elements can be chosen freely in typical maximal sets
 -/
-axiom why_quarter_exponent : True
 
-/--
+/-
 **Container method:**
 The BLST proof uses the container method: maximal sum-free sets
 are contained in a small number of "containers", each with
 limited freedom for element choices.
 -/
-axiom container_method : True
 
 /-
 ## Part VIII: Relationship to Erdős #748
 -/
 
-/--
+/-
 **Erdős #748: All sum-free sets:**
 Related problem asks about f(n), the count of all sum-free sets.
 Cameron-Erdős conjectured f(n) = Θ(2^{n/2}).
 -/
-axiom erdos_748_connection : True
 
 /--
 **Comparison:**

--- a/proofs/Proofs/Erdos91Problem.lean
+++ b/proofs/Proofs/Erdos91Problem.lean
@@ -179,11 +179,10 @@ def erdos_91_strong_conjecture : Prop :=
       (∀ A ∈ configs, A.card = n ∧ IsOptimal A) ∧
       (∀ A B, A ∈ configs → B ∈ configs → A ≠ B → AreNonSimilar A B)
 
-/--
+/-
 **Status: OPEN**
 The conjecture is not proven.
 -/
-axiom erdos_91_open : True  -- Placeholder for the open status
 
 /-
 ## Part VI: Partial Evidence
@@ -210,12 +209,11 @@ theorem known_cases :
   · exact n4_two_optima
   · exact kovacs_2024_n5_unique
 
-/--
+/-
 **The n = 5 case was mysterious:**
 Erdős attributed the proof to "a colleague from Zagreb" whose letter he lost.
 Kovács (2024) finally published a complete proof.
 -/
-axiom zagreb_mystery_resolved : True
 
 /-
 ## Part VII: Connection to Distinct Distances Problem

--- a/proofs/Proofs/Erdos924Problem.lean
+++ b/proofs/Proofs/Erdos924Problem.lean
@@ -223,26 +223,23 @@ axiom folkman_vs_ramsey :
 ## Part VIII: Proof Techniques
 -/
 
-/--
+/-
 **The Hales-Jewett Theorem Connection:**
 The Nešetřil-Rödl proof uses the Hales-Jewett theorem and
 product constructions.
 -/
-axiom hales_jewett_method : True
 
-/--
+/-
 **Partite Construction:**
 A key technique is to build Folkman graphs from partite graphs
 where cliques are controlled by the partition structure.
 -/
-axiom partite_construction : True
 
-/--
+/-
 **Shift Graphs:**
 Folkman's original construction used "shift graphs" - graphs where
 vertices are sets and adjacency is determined by containment relations.
 -/
-axiom shift_graph_construction : True
 
 /-
 ## Part IX: Extensions
@@ -259,11 +256,10 @@ def GeneralizedFolkmanNumber (ls : List ℕ) (r : ℕ) : Prop :=
     ∀ χ : EdgeColoring G ls.length,
       ∃ i : Fin ls.length, ContainsClique (MonochromaticSubgraph G χ i) (ls.get i)
 
-/--
+/-
 **Hypergraph Generalization:**
 The result extends to r-uniform hypergraphs as well.
 -/
-axiom hypergraph_folkman : True
 
 /-
 ## Part X: Summary

--- a/proofs/Proofs/Erdos927Problem.lean
+++ b/proofs/Proofs/Erdos927Problem.lean
@@ -196,35 +196,31 @@ def CorrectAsymptotic : Prop :=
 ## Part VII: Proof Ideas
 -/
 
-/--
+/-
 **Moon-Moser construction:**
 To achieve many clique sizes, use a graph that avoids "gaps" in clique sizes.
 -/
-axiom moon_moser_construction : True
 
-/--
+/-
 **Ramsey connection:**
 The upper bound relates to Ramsey numbers - if g(n) > n - k, then there's
 a graph avoiding k consecutive clique sizes.
 -/
-axiom ramsey_connection : True
 
-/--
+/-
 **Spencer's key insight:**
 By carefully constructing graphs, one can avoid the log*(n) loss.
 The construction is probabilistic/explicit.
 -/
-axiom spencer_construction : True
 
 /-
 ## Part VIII: Related Problem
 -/
 
-/--
+/-
 **Problem 775:**
 A related problem about clique numbers and graph structure.
 -/
-axiom problem_775_related : True
 
 /-
 ## Part IX: Examples

--- a/proofs/Proofs/Erdos942Problem.lean
+++ b/proofs/Proofs/Erdos942Problem.lean
@@ -72,9 +72,8 @@ axiom squareIntervalSet_spec (n m : ℕ) : m ∈ squareIntervalSet n ↔ n^2 ≤
 /-- h(n) = count of powerful integers in [n², (n+1)²). -/
 axiom h : ℕ → ℕ
 
-/-- h(n) counts exactly the powerful numbers in the interval [n², (n+1)²).
+/- h(n) counts exactly the powerful numbers in the interval [n², (n+1)²).
 This is characterized by the fact that m is counted iff n² <= m < (n+1)² and Powerful m. -/
-axiom h_spec : True
 
 /-
 ## Examples of Powerful Numbers

--- a/proofs/Proofs/Erdos943Problem.lean
+++ b/proofs/Proofs/Erdos943Problem.lean
@@ -72,19 +72,16 @@ axiom powerful_structure :
 
 /- ## Observations -/
 
-/-- **Average order**: On average over n ≤ x, the sum
+/- **Average order**: On average over n ≤ x, the sum
     Σ_{n≤x} r(n) ∼ c²x (since there are ~c√x powerful numbers
     up to x). The question is about pointwise bounds. -/
-axiom average_order : True
 
-/-- **Connection to squares**: Perfect squares form a subset of
+/- **Connection to squares**: Perfect squares form a subset of
     powerful numbers. Representations as sums of two squares
     are well-understood (Jacobi's formula), but the powerful
     number case is harder due to the irregular structure. -/
-axiom squares_connection : True
 
-/-- **Diophantine constraints**: For n = a²b³ + c²d³, the
+/- **Diophantine constraints**: For n = a²b³ + c²d³, the
     equation constrains a,b,c,d in ways that should limit
     the number of solutions, but making this rigorous is
     the core difficulty. -/
-axiom diophantine_constraints : True

--- a/proofs/Proofs/Erdos957Problem.lean
+++ b/proofs/Proofs/Erdos957Problem.lean
@@ -194,10 +194,9 @@ axiom sum_inequality :
     (distanceFrequency A (minDistance A) : ℝ) +
     (distanceFrequency A (maxDistance A)) ≤ 3 * n - c * Real.sqrt n
 
-/--
+/-
 **Open: What is the best constant c?**
 -/
-axiom best_constant_c_open : True
 
 /-
 ## Part VII: Convex Hull Variant
@@ -243,35 +242,31 @@ axiom regular_polygon_all_frequent (n : ℕ) (hn : Odd n) (hn3 : n ≥ 3) :
   let A := regularPolygon n hn
   ∀ d ∈ pairwiseDistances A, distanceFrequency A d ≥ n
 
-/--
+/-
 **Intuition:**
 In an odd regular polygon, each distance appears many times
 due to rotational symmetry. This shows f(d) ≥ n is achievable
 for all distances, not just extremes.
 -/
-axiom regular_polygon_intuition : True
 
 /-
 ## Part IX: Related Problems
 -/
 
-/--
+/-
 **Problem #132:**
 Related problem about repeated distances.
 -/
-axiom related_132 : True
 
-/--
+/-
 **Problem #756:**
 Another related problem about distances in point sets.
 -/
-axiom related_756 : True
 
-/--
+/-
 **Connection to unit distance problem:**
 How many pairs can achieve the same distance?
 -/
-axiom unit_distance_connection : True
 
 /-
 ## Part X: Summary

--- a/proofs/Proofs/Erdos95Problem.lean
+++ b/proofs/Proofs/Erdos95Problem.lean
@@ -115,25 +115,21 @@ theorem erdos_conjecture_proved : ErdosConjecture := by
 ## Part V: The Polynomial Method
 -/
 
-/-- **Point-Line Duality:**
+/- **Point-Line Duality:**
     Distances in 2D correspond to incidences in 3D.
     This transformation is key to the Guth-Katz approach. -/
-axiom point_line_duality : True
 
-/-- **Polynomial Partitioning:**
+/- **Polynomial Partitioning:**
     Partition R³ using algebraic surfaces to control incidences.
     A technique that revolutionized combinatorial geometry. -/
-axiom polynomial_partitioning : True
 
-/-- **Ruled Surface Structure:**
+/- **Ruled Surface Structure:**
     Lines at distance d from a point form a ruled quadric surface.
     Many incidences force lines to lie on common surfaces. -/
-axiom ruled_surface_structure : True
 
-/-- **Incidence Bound:**
+/- **Incidence Bound:**
     n points and n lines in R³ have O(n^{3/2}) incidences
     unless many lines lie on a ruled surface. -/
-axiom incidence_bound_3d : True
 
 /-
 ## Part VI: Special Cases
@@ -147,9 +143,8 @@ axiom convex_polygon_case :
     True →
     ∃ C > 0, (sumSquaredMultiplicities P : ℝ) ≤ C * (P.points.card : ℝ)^3
 
-/-- **Lattice Points:**
+/- **Lattice Points:**
     For √n × √n grid, ∑f(uᵢ)² achieves near-maximum. -/
-axiom lattice_near_extremal : True
 
 /-
 ## Part VII: Summary

--- a/proofs/Proofs/Erdos965Problem.lean
+++ b/proofs/Proofs/Erdos965Problem.lean
@@ -183,12 +183,11 @@ theorem countable_vs_uncountable :
 ## Part VI: Connection to Erdős-Hajnal-Rado
 -/
 
-/--
+/-
 **Erdős-Hajnal-Rado methods:**
 The original proof by Erdős used partition calculus techniques
 developed with Hajnal and Rado in their work on infinite combinatorics.
 -/
-axiom erdos_hajnal_rado_methods : True
 
 /--
 **Partition calculus:**

--- a/proofs/Proofs/Erdos996Problem.lean
+++ b/proofs/Proofs/Erdos996Problem.lean
@@ -181,9 +181,8 @@ def ErdosProblem996 : Prop :=
     (∀ k : ℕ, k ≥ 16 → fourierError f k ≤ 1 / (Real.log (Real.log (Real.log k)))^C) →
     StrongLawHoldsAE f n
 
-/-- The status of Problem #996: OPEN.
+/- The status of Problem #996: OPEN.
     We don't know if log log log decay suffices. -/
-axiom erdos_996_open : True  -- Placeholder indicating open status
 
 /- ## Part VII: Related Questions -/
 


### PR DESCRIPTION
## Summary
- Remove 228 `axiom X : True` placeholder declarations across 87 Erdős Lean files
- Convert docstrings (`/-- ... -/`) to regular comments (`/- ... -/`) when present
- Delete axiom lines that had no mathematical content (historical notes, technique markers, related concept placeholders)
- All substantive mathematical axioms (with real type signatures) are preserved unchanged

These placeholders were originally generated as stand-ins for concepts that didn't need formal Lean declarations. Removing them reduces noise and improves Aristotle compatibility.

**Excluded**: erdos-264 and erdos-599 are handled separately in PR #2269 with additional annotation/meta.json improvements.

## Test plan
- [x] `pnpm build` succeeds
- [x] Zero `axiom X : True` remain in modified files
- [x] No orphaned docstrings introduced
- [x] Substantive axioms (real types) untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)