### PR TITLE
Research: erdos-461 - fix unsound axiom, add smooth component lemmas

### DIFF
--- a/proofs/Proofs/Erdos461Problem.lean
+++ b/proofs/Proofs/Erdos461Problem.lean
@@ -77,9 +77,33 @@ theorem smoothComponent_smooth (t n p : ℕ) (hp : p.Prime)
   have hmem := prime_dvd_list_prod_mem hp _ hall hd
   exact (List.mem_filter.mp hmem).2
 
-/-- `smoothComponent t n` is the largest such divisor. -/
-axiom smoothComponent_largest (t n d : ℕ) :
-    d ∣ n → (∀ p : ℕ, p.Prime → p ∣ d → p < t) → d ∣ smoothComponent t n
+/-- `smoothComponent t n` is nonzero (product of primes, all ≥ 2). -/
+theorem smoothComponent_pos (t n : ℕ) : 0 < smoothComponent t n := by
+  unfold smoothComponent
+  apply List.prod_pos
+  intro x hx
+  exact (Nat.prime_of_mem_factors (List.mem_filter.mp hx).1).pos
+
+/-- No prime `< t` divides the complement part of the factorization. -/
+private lemma no_small_prime_in_complement (t n p : ℕ) (hp : p.Prime)
+    (hpt : p < t) (hd : p ∣ (n.factors.filter (fun x => ¬ decide (x < t))).prod) :
+    False := by
+  have hall : ∀ q ∈ n.factors.filter (fun x => ¬ decide (x < t)), q.Prime := fun q hq =>
+    Nat.prime_of_mem_factors (List.mem_filter.mp hq).1
+  have hmem := prime_dvd_list_prod_mem hp _ hall hd
+  have := (List.mem_filter.mp hmem).2
+  simp at this
+  omega
+
+/-- `smoothComponent t n` is the largest `t`-smooth divisor of `n`.
+    Requires `n ≠ 0` since `smoothComponent t 0 = 1` but any
+    `d` with all primes `< t` divides 0.
+    Proof strategy: n = smoothComponent * complementPart where
+    complementPart has all primes ≥ t. Then d and complementPart
+    are coprime (disjoint prime support), so d ∣ smoothComponent. -/
+theorem smoothComponent_largest (t n d : ℕ) (hn : n ≠ 0) :
+    d ∣ n → (∀ p : ℕ, p.Prime → p ∣ d → p < t) → d ∣ smoothComponent t n := by
+  sorry
 
 /- ## Counting distinct smooth components -/
 
@@ -136,3 +160,13 @@ theorem smoothDistinctCount_zero (n : ℕ) : smoothDistinctCount n 0 = 0 := by
 /-- Smooth component of 0 is 1 (0 has no prime factors). -/
 theorem smoothComponent_zero (t : ℕ) : smoothComponent t 0 = 1 := by
   simp [smoothComponent, Nat.factors_zero]
+
+/-- For a prime `p`, `smoothComponent t p = p` if `p < t`, else `1`. -/
+theorem smoothComponent_prime (t p : ℕ) (hp : p.Prime) :
+    smoothComponent t p = if p < t then p else 1 := by
+  unfold smoothComponent
+  rw [Nat.factors_prime hp]
+  simp only [List.filter_cons, List.filter_nil, List.append_nil]
+  split <;> rename_i h
+  · simp [List.prod_cons]
+  · simp

--- a/src/data/research/problems/erdos-461.json
+++ b/src/data/research/problems/erdos-461.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "EXPLORING",
     "since": "2026-01-13T04:11:10.512Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Converting axioms to theorems, building smooth component infrastructure",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Prove smoothComponent_largest theorem and verify builds",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,29 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Converted unsound axiom to correct theorem sorry. Added 3 new proved lemmas. Documented coprimality-based proof strategy for smoothComponent_largest.",
+    "builtItems": [
+      "Proved smoothComponent_pos in Erdos461Problem.lean",
+      "Proved smoothComponent_prime in Erdos461Problem.lean",
+      "Proved no_small_prime_in_complement in Erdos461Problem.lean",
+      "Converted axiom smoothComponent_largest to theorem sorry with n ≠ 0 hypothesis"
+    ],
+    "insights": [
+      "Original axiom smoothComponent_largest was FALSE for n=0 (counterexample: d=2, t=3, n=0)",
+      "Fixed by adding n ≠ 0 hypothesis and converting axiom to theorem with sorry",
+      "Proof strategy for smoothComponent_largest: coprimality argument - d and complementPart have disjoint prime support (< t vs ≥ t), so d | smoothComponent t n",
+      "smoothComponent_prime proved: for prime p, smoothComponent t p = if p < t then p else 1",
+      "smoothComponent_pos proved: smooth component is always positive (product of empty list = 1, product of primes > 0)",
+      "no_small_prime_in_complement proved: no prime < t divides the complement part of factorization",
+      "Docker daemon broken during session - proofs not build-verified"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Prove smoothComponent_largest via coprimality: show n = smoothComponent * complement, d coprime to complement, therefore d | smoothComponent",
+      "Build-verify all proofs once Docker recovers",
+      "Consider submitting smoothComponent_largest to Aristotle after converting to provable form",
+      "Prove smoothComponent_mul_coprime (multiplicativity on coprime inputs) and smoothComponent_prime_pow"
+    ],
     "markdown": "# Erdős #461 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $s_t(n)$ be the $t$-smooth component of $n$ - that is, the product of all primes $p$ (with multiplicity) dividing $n$ such that $p<t$. Let $f(n,t)$ count the number of distinct possible values for $s_t(m)$ for $m\\in [n+1,n+t]$. Is it true that\\[f(n,t)\\gg t\\](uniformly, for all $t$ and $n$)?\n\n\n\nErd\\H{o}s and Graham report they can show\\[f(n,t) \\gg \\frac{t}{\\log t}.\\]\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #460\n- Problem #462\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "approaches": [],


### PR DESCRIPTION
## Summary
- **Bug fix**: `smoothComponent_largest` axiom was FALSE for n=0 (counterexample: d=2, t=3, n=0). Converted to theorem with `n ≠ 0` hypothesis.
- Proved 3 new lemmas: `smoothComponent_pos`, `smoothComponent_prime`, `no_small_prime_in_complement`
- Documented coprimality-based proof strategy for `smoothComponent_largest`

## Progress
- Converted unsound `axiom` to correct `theorem ... := by sorry`
- Added positivity, prime evaluation, and complement-filter lemmas
- Updated problem knowledge with insights and next steps

## Findings
- The smooth component is always positive (product of primes from factors list)
- For primes: `smoothComponent t p = if p < t then p else 1`
- Key insight: no prime `< t` divides the complement part `(n.factors.filter (¬ · < t)).prod`
- This enables a coprimality argument for proving `smoothComponent_largest`

## Status
**Outcome**: progress
**Next Steps**: Prove smoothComponent_largest via coprimality argument. Docker was broken during this session (disk pressure + 59 containers), so proofs are not build-verified.

Generated by researcher-1