### PR TITLE
Research: erdos-847 - prove AP-free equivalence and subset monotonicity

### DIFF
--- a/proofs/Proofs/Erdos847Problem.lean
+++ b/proofs/Proofs/Erdos847Problem.lean
@@ -56,8 +56,25 @@ def isAPFree (S : Set ℕ) : Prop :=
 def isAPFree' (S : Set ℕ) : Prop :=
   ∀ x y z : ℕ, x ∈ S → y ∈ S → z ∈ S → x < y → y < z → 2*y ≠ x + z
 
-/-- The two definitions are equivalent. -/
-axiom apfree_equiv (S : Set ℕ) : isAPFree S ↔ isAPFree' S
+/-- Subsets of AP-free sets are AP-free. -/
+theorem isAPFree_subset {S T : Set ℕ} (hT : isAPFree T) (hST : S ⊆ T) : isAPFree S :=
+  fun a d hd ha had hz => hT a d hd (hST ha) (hST had) (hST hz)
+
+/-- The two definitions of AP-free are equivalent. -/
+theorem apfree_equiv (S : Set ℕ) : isAPFree S ↔ isAPFree' S := by
+  unfold isAPFree isAPFree'
+  constructor
+  · -- Forward: no {a, a+d, a+2d} AP → no x < y < z with 2y = x+z
+    intro h x y z hx hy hz hxy hyz heq
+    have hd_pos : y - x > 0 := Nat.sub_pos_of_lt hxy
+    have hy' : x + (y - x) ∈ S := by rwa [Nat.add_sub_cancel' (Nat.le_of_lt hxy)]
+    have hnotS := h x (y - x) hd_pos hx hy'
+    have h2d_eq : x + 2 * (y - x) = z := by omega
+    rw [h2d_eq] at hnotS
+    exact hnotS hz
+  · -- Backward: no x < y < z with 2y = x+z → no {a, a+d, a+2d} AP
+    intro h a d hd ha had hadd
+    exact h a (a + d) (a + 2 * d) ha had hadd (by omega) (by omega) (by omega)
 
 /- ## Part II: The Erdős-Nešetřil-Rödl Condition -/
 
@@ -160,8 +177,13 @@ The counterexample likely uses a construction where:
 **Finite unions are very restrictive:**
 If A = A₁ ∪ ... ∪ Aₖ with each Aᵢ AP-free, then any finite B ⊆ A
 can be covered by k AP-free sets. But the ENR condition is weaker.
+
+Proof sketch: Given B ⊆ A with |B| = n, by pigeonhole there exists
+i such that |B ∩ parts(i)| ≥ n/k. This intersection is AP-free
+(subset of AP-free set) and has the required size.
 -/
-theorem finite_union_implies_enr (A : Set ℕ) (k : ℕ) (parts : Fin k → Set ℕ)
+theorem finite_union_implies_enr (A : Set ℕ) (k : ℕ) (hk : k > 0)
+    (parts : Fin k → Set ℕ)
     (hparts : ∀ i, isAPFree (parts i))
     (hunion : A = ⋃ i, parts i) :
     hasENRCondition A (1 / k) := by

--- a/src/data/research/problems/erdos-847.json
+++ b/src/data/research/problems/erdos-847.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-847",
   "title": "Erdős #847",
-  "phase": "NEW",
+  "phase": "SURVEY",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -11,34 +11,62 @@
     "whyMatters": []
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "apfree_equiv: Two AP-free definitions are equivalent (proved)",
+      "isAPFree_subset: Subsets of AP-free sets are AP-free (proved)"
+    ],
     "open": [],
-    "goal": ""
+    "goal": "Complete formalization of disproved conjecture with proved helper lemmas"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-15T10:25:45.155Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "SURVEY",
+    "since": "2026-02-08T03:00:00Z",
+    "iteration": 2,
+    "focus": "Proved apfree_equiv equivalence and isAPFree_subset; finite_union_implies_enr still needs pigeonhole formalization",
+    "blockers": [
+      "Docker not available for build verification",
+      "finite_union_implies_enr requires pigeonhole principle with decidability workaround"
+    ],
+    "nextAction": "Build-verify apfree_equiv proof, then tackle finite_union_implies_enr pigeonhole argument with classical decidability",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Replaced axiom apfree_equiv with proved theorem. Added isAPFree_subset lemma. Fixed finite_union_implies_enr to require k>0. 1 axiom eliminated, 2 new theorems proved.",
+    "builtItems": [
+      "theorem apfree_equiv: isAPFree S <-> isAPFree' S (proved, replaced axiom)",
+      "theorem isAPFree_subset: AP-free is monotone under subsets (proved)",
+      "Fixed finite_union_implies_enr to require k > 0 hypothesis"
+    ],
+    "insights": [
+      "Forward direction of apfree_equiv: use d = y-x, rwa with Nat.add_sub_cancel', then omega for 2*(y-x) = z",
+      "Backward direction: direct application with omega for arithmetic",
+      "finite_union_implies_enr is FALSE when k=0 since 1/0 = 0 in Lean's reals",
+      "Pigeonhole for finite_union_implies_enr needs classical decidability for Set membership filtering"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #847 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A\\subset \\mathbb{N}$ be an infinite set for which there exists some $\\epsilon>0$ such that in any subset of $A$ of size $n$ there is a subset of size at least $\\epsilon n$ which contains no three-term arithmetic progression.\n\nIs it true that $A$ is the union of a finite number of sets which contain no three-term arithmetic progression?\n\n\n\nA problem of Erd\\H{o}s, Ne\\v{s}et\\v{r}il, and R\\\"{o}dl.\n\nSee also [774] and [846].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #774\n- Problem #846\n- Problem #848\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er92b\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "nextSteps": [
+      "Build-verify the proof (Docker was unavailable)",
+      "Prove finite_union_implies_enr using classical pigeonhole",
+      "Consider submitting provable sorries to Aristotle"
+    ],
+    "markdown": "# Erdős #847 - Knowledge Base\n\n## Status: DISPROVED\n\n## Research Session 1 (2026-02-08)\n\n### Accomplished\n- Proved `apfree_equiv`: equivalence of two AP-free definitions (eliminated axiom)\n- Proved `isAPFree_subset`: subsets of AP-free sets are AP-free\n- Fixed `finite_union_implies_enr` to require k > 0\n\n### Remaining Sorries\n- `finite_union_implies_enr`: needs pigeonhole principle formalization\n\n---\n\n*Updated by researcher-1 on 2026-02-08*\n"
   },
-  "approaches": [],
+  "approaches": [
+    {
+      "name": "Direct proof of helper lemmas",
+      "description": "Prove apfree_equiv and isAPFree_subset directly using omega for ℕ arithmetic.",
+      "status": "completed",
+      "outcome": "2 theorems proved, 1 axiom eliminated"
+    }
+  ],
   "tags": [
-    "erdos"
+    "erdos",
+    "combinatorics",
+    "arithmetic-progressions"
   ],
   "relatedProofs": [],
   "references": {


### PR DESCRIPTION
## Summary
- Replace `axiom apfree_equiv` with a proved `theorem` establishing equivalence of two AP-free definitions (common difference form vs triple form)
- Add `theorem isAPFree_subset`: subsets of AP-free sets are AP-free (monotonicity)
- Fix `finite_union_implies_enr` to require `k > 0` (the original statement was false when k = 0 since 1/0 = 0 in Lean's reals)

## Progress
- **1 axiom eliminated** (apfree_equiv → proved theorem)
- **2 new theorems proved** (apfree_equiv, isAPFree_subset)
- **1 sorry remains** (finite_union_implies_enr - pigeonhole argument, documented proof sketch added)

## Proof Techniques
- Forward direction: set d = y - x, use `Nat.add_sub_cancel'` and `omega` for ℕ arithmetic
- Backward direction: direct instantiation with `omega` for all three arithmetic goals
- Subset monotonicity: term-mode proof via function composition

## Status
**Outcome**: progress
**Next Steps**: Build-verify proofs (Docker unavailable during session), prove finite_union_implies_enr via classical pigeonhole

Generated by researcher-1