### PR TITLE
Add missing index.ts for 14 Erdős gallery entries

### DIFF
--- a/research/candidate-pool.json
+++ b/research/candidate-pool.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "last_updated": "2026-02-08T01:12:49.449Z",
+  "last_updated": "2026-02-08T03:05:53.676Z",
   "source": "auto-generated from research/db/knowledge.db",
   "candidates": [
     {

--- a/src/data/proofs/erdos-1052/index.ts
+++ b/src/data/proofs/erdos-1052/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1052Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-1136/index.ts
+++ b/src/data/proofs/erdos-1136/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1136Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-1140/index.ts
+++ b/src/data/proofs/erdos-1140/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos1140Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-120/index.ts
+++ b/src/data/proofs/erdos-120/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos120Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-123/index.ts
+++ b/src/data/proofs/erdos-123/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos123Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-238/index.ts
+++ b/src/data/proofs/erdos-238/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos238Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-317/index.ts
+++ b/src/data/proofs/erdos-317/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos317Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-367/index.ts
+++ b/src/data/proofs/erdos-367/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos367Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-44/index.ts
+++ b/src/data/proofs/erdos-44/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos44Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-614/index.ts
+++ b/src/data/proofs/erdos-614/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos614Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-693/index.ts
+++ b/src/data/proofs/erdos-693/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos693Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-792/index.ts
+++ b/src/data/proofs/erdos-792/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos792Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-938/index.ts
+++ b/src/data/proofs/erdos-938/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos938Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/erdos-950/index.ts
+++ b/src/data/proofs/erdos-950/index.ts
@@ -1,0 +1,44 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/Erdos950Problem.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData


### PR DESCRIPTION
## Summary
- Added missing `index.ts` TypeScript modules for 14 Erdős gallery entries
- These entries had `meta.json` and `annotations.json` but were not loadable in the gallery proof viewer because Vite's `import.meta.glob('./‌**/index.ts')` couldn't discover them
- Entries: erdos-44, erdos-120, erdos-123, erdos-238, erdos-317, erdos-367, erdos-614, erdos-693, erdos-792, erdos-938, erdos-950, erdos-1052, erdos-1136, erdos-1140

## Test plan
- [x] `pnpm build` succeeds
- [x] All 14 entries now have complete directory structure (meta.json + annotations.json + index.ts)
- [x] Template matches exemplar (erdos-48/index.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)