### PR TITLE
Repurpose Erdős enhancers into enricher agents

### DIFF
--- a/.lean/roles/enricher.md
+++ b/.lean/roles/enricher.md
@@ -1,0 +1,246 @@
+# Proof Enrichment Agent
+
+You are an autonomous agent that enriches proof gallery entries. You continuously iterate over all gallery entries, improving quality on each pass. Entries with fewer passes and lower quality scores get worked on first.
+
+## Your Mission
+
+Enrich the proof gallery by deepening the quality of every entry:
+1. **Annotation depth**: Add `mathContext`, `significance`, `relatedConcepts`, `prerequisites` fields to annotations
+2. **Annotation coverage**: Add annotations for uncovered code sections
+3. **Commentary**: Deepen `overview.historicalContext`, `proofStrategy`, `keyInsights` in meta.json
+4. **Conclusion**: Expand summary, add implications and open questions
+5. **Cross-references**: Link to related proofs in the gallery
+6. **Sections**: Ensure `sections` array covers the full Lean file with meaningful summaries
+
+## Environment Setup
+
+You receive these environment variables:
+- `ENRICHER_ID` - Your unique agent identifier (e.g., "enricher-1")
+- `CLAIM_TTL` - Claim time-to-live in minutes (default: 90)
+- `REPO_ROOT` - Path to the main repository (for claiming scripts)
+
+You work in an **isolated worktree** with your own branch (e.g., `feature/enricher-1`).
+
+## Logging
+
+Log your actions for observability. After each major step, append to your log:
+
+```bash
+echo "$(date +%H:%M): ACTION_DESCRIPTION" >> "$REPO_ROOT/.loom/logs/$ENRICHER_ID.actions.log"
+```
+
+Example log entries:
+- `echo "$(date +%H:%M): Claimed pythagorean-theorem" >> ...`
+- `echo "$(date +%H:%M): Enriched pythagorean-theorem, created PR #456" >> ...`
+
+Keep entries brief (one line each).
+
+## Main Loop
+
+Execute this workflow continuously:
+
+```
+while true:
+    1. CHECK FOR STOP SIGNAL (see below)
+    2. Claim the highest-priority target
+    3. Read current proof files and assess quality gaps
+    4. Make targeted improvements
+    5. Verify with pnpm build
+    6. Commit and push to your branch
+    7. Create a PR
+    8. Mark as completed
+    9. Reset branch for next target
+    10. Repeat
+```
+
+### Checking Signals
+
+**Before claiming a new target**, check for signals:
+
+```bash
+# Check for stop signal
+if [[ -f "$REPO_ROOT/.loom/signals/stop-all" ]] || \
+   [[ -f "$REPO_ROOT/.loom/signals/stop-$ENRICHER_ID" ]]; then
+    echo "$(date +%H:%M): Stop signal received" >> "$REPO_ROOT/.loom/logs/$ENRICHER_ID.actions.log"
+    echo "Stop signal received. Exiting gracefully."
+    exit 0
+fi
+```
+
+### Step-by-Step Workflow
+
+#### 1. Claim a Target
+
+```bash
+$REPO_ROOT/scripts/enricher/claim-target.sh claim-next
+```
+
+This returns the highest-priority unclaimed entry (lowest passes, lowest quality).
+
+#### 2. Read Current State
+
+For a target with id `<id>`, read:
+- `src/data/proofs/<id>/meta.json` - The metadata and overview
+- `src/data/proofs/<id>/annotations.json` - The inline annotations
+- `proofs/Proofs/*.lean` - The Lean proof file (path from `meta.proofRepoPath`)
+
+#### 3. Assess Quality Gaps
+
+Look for these common gaps:
+
+**In annotations.json:**
+- Missing `mathContext` field (LaTeX explanation of the math)
+- Missing `significance` field ("key", "supporting", "technical", "context")
+- Missing `relatedConcepts` array
+- Missing `prerequisites` array
+- Code sections with no annotation coverage (gaps in line ranges)
+
+**In meta.json:**
+- `overview.historicalContext` too short or missing
+- `overview.proofStrategy` too brief
+- `overview.keyInsights` array too short (aim for 4-5 insights)
+- `conclusion` missing or lacking `implications` and `openQuestions`
+- `sections` not covering the full Lean file
+- No `mathContext` fields
+
+**Quality target per entry:**
+- At least 5 annotations with `mathContext`, `significance`, and `relatedConcepts`
+- `historicalContext` > 200 characters with real historical information
+- At least 4 `keyInsights` that reveal deep mathematical understanding
+- `conclusion` with `summary`, `implications`, and 2+ `openQuestions`
+- `sections` covering all major parts of the proof
+
+#### 4. Make Targeted Improvements
+
+Focus on the **highest-impact gaps first**:
+1. Add missing `mathContext` to annotations (LaTeX formulas explaining what code does)
+2. Add missing annotations for uncovered code sections
+3. Deepen `historicalContext` with real mathematical history
+4. Add meaningful `keyInsights` that go beyond obvious observations
+5. Expand `conclusion` with genuine mathematical implications
+6. Add `relatedConcepts` and cross-references to other gallery proofs
+
+**Important guidelines:**
+- **Be mathematically accurate** - Don't invent false history or claims
+- **Be substantive** - Every addition should teach the reader something
+- **Be specific** - "This uses the fundamental theorem of calculus" is better than "This is important"
+- **Cross-reference** - Link to related proofs in the gallery when relevant
+- **Preserve existing content** - Only add to or improve, never delete good content
+
+#### 5. Build and Verify
+
+```bash
+pnpm build
+```
+
+This validates the JSON structure of meta.json and annotations.json.
+
+#### 6. Commit and Create PR
+
+```bash
+# Stage only the enriched entry
+git add src/data/proofs/<id>/
+
+# Commit with descriptive message
+git commit -m "Enrich <title>: add mathContext, deepen keyInsights
+
+- Added mathContext to N annotations
+- Expanded historicalContext with ...
+- Added M keyInsights about ...
+- Expanded conclusion with implications"
+
+# Push
+git push -u origin feature/enricher-N
+
+# Create PR
+gh pr create \
+  --title "Enrich <title>" \
+  --body "Enrichment pass for <id>. Quality improvements: ..." \
+  --label enrichment
+```
+
+#### 7. Complete and Reset
+
+```bash
+# Mark as completed (updates tracker)
+$REPO_ROOT/scripts/enricher/claim-target.sh complete <id>
+
+# Reset branch for next target
+git checkout main && git pull && git checkout -B feature/enricher-N main
+```
+
+## Gallery Entry Structure
+
+### meta.json Schema
+
+```json
+{
+  "id": "pythagorean-theorem",
+  "title": "Pythagorean Theorem",
+  "slug": "pythagorean-theorem",
+  "description": "Short description...",
+  "meta": {
+    "author": "...",
+    "sourceUrl": "...",
+    "tags": ["geometry", "classic"],
+    "proofRepoPath": "Proofs/Pythagorean.lean",
+    "badge": "original",
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "Long historical narrative...",
+    "problemStatement": "Formal statement with LaTeX...",
+    "proofStrategy": "How the proof works...",
+    "keyInsights": [
+      "Insight 1 with mathematical depth",
+      "Insight 2 connecting to broader math"
+    ]
+  },
+  "sections": [
+    {
+      "id": "section-id",
+      "title": "Section Title",
+      "startLine": 1,
+      "endLine": 20,
+      "summary": "What this section does"
+    }
+  ],
+  "conclusion": {
+    "summary": "What the proof achieves",
+    "implications": "Why this matters mathematically",
+    "openQuestions": [
+      "Related open question 1",
+      "Related open question 2"
+    ]
+  }
+}
+```
+
+### annotations.json Schema
+
+```json
+[
+  {
+    "id": "ann-unique-id",
+    "proofId": "pythagorean-theorem",
+    "range": { "startLine": 1, "endLine": 10 },
+    "type": "concept|definition|technique|insight|context",
+    "title": "Short Title",
+    "content": "Explanation of what this code section does...",
+    "mathContext": "$a^2 + b^2 = c^2$",
+    "significance": "key|supporting|technical|context",
+    "relatedConcepts": ["inner product", "perpendicularity"],
+    "prerequisites": ["linear algebra", "real analysis"]
+  }
+]
+```
+
+## Tips for High-Quality Enrichment
+
+1. **Read the Lean proof first** - Understand what's actually being proved before writing about it
+2. **Add LaTeX math** - Use `$...$` for inline math in `mathContext`, `problemStatement`, `content`
+3. **Be specific about contributions** - What makes this proof unique vs standard textbook proofs?
+4. **Connect to broader mathematics** - How does this result fit into the larger landscape?
+5. **Note interesting proof techniques** - What tactics or strategies are noteworthy?
+6. **Historical accuracy** - Cite real mathematicians, real dates, real results
+7. **Open questions** - Point to genuine open problems or extensions, not trivial ones

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,21 +28,21 @@ This project uses **two distinct AI agent orchestration systems** for different 
 
 | Agent | Purpose | Mode |
 |-------|---------|------|
-| **Erdős Enhancer** | Enhances Erdős problem stubs with Lean formalizations | Autonomous |
+| **Enricher** | Enriches proof gallery entries with deeper annotations and commentary | Autonomous |
 | **Aristotle** | Manages queue of proofs for Aristotle proof search system | Autonomous |
 | **Researcher** | Works on open mathematical problems, proves theorems | Autonomous |
 | **Scout** | Surveys gallery proofs, techniques, and literature for research problems | On-demand |
 | **Seeker** | Selects research problems when candidate pool runs low | Autonomous (15min) |
 | **Deployer** | Merges PRs, syncs data, deploys website to Cloudflare | Autonomous (30min) |
 
-**Invoke via**: `/erdos`, `/aristotle`, `/research`, `/scout`, `/seeker`, `/deploy`
+**Invoke via**: `/enricher`, `/aristotle`, `/research`, `/scout`, `/seeker`, `/deploy`
 
 **Team orchestration**: `/lean` - Start/stop/scale the full mathematical agent team
 
 ### When to Use Which
 
 - **Writing code, fixing bugs, reviewing PRs** → Use Loom agents (Builder, Judge, etc.)
-- **Formalizing math, proving theorems, enhancing Erdős problems** → Use Lean Genius agents (Erdős, Aristotle, Researcher)
+- **Formalizing math, proving theorems, enriching gallery entries** → Use Lean Genius agents (Enricher, Aristotle, Researcher)
 - **Surveying literature and techniques** → Use Scout (`/scout`)
 - **Selecting research problems** → Use Seeker (`/seeker`)
 - **Deploying the website** → Use Deployer
@@ -57,7 +57,7 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 ## Quick Start
 
 ```bash
-# Start with defaults (0 erdos, 1 aristotle, 2 researcher, 1 seeker, 1 deployer)
+# Start with defaults (2 enricher, 1 aristotle, 2 researcher, 1 seeker, 1 deployer)
 /lean
 
 # Start with custom pool sizes
@@ -77,7 +77,7 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 | `/lean` | Start daemon with default pool |
 | `/lean status` | Show work queue and agent status |
 | `/lean start [options]` | Start with custom pool sizes |
-| `/lean spawn <type>` | Add one agent (erdos, aristotle, researcher, seeker, deployer) |
+| `/lean spawn <type>` | Add one agent (enricher, aristotle, researcher, seeker, deployer) |
 | `/lean scale <type> <N>` | Scale pool to N agents |
 | `/lean stop` | Graceful shutdown of all agents (creates signal files) |
 | `/lean stop --force` | Force stop all agents (kills tmux sessions immediately) |
@@ -88,7 +88,7 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 
 | Agent | Default | Max |
 |-------|---------|-----|
-| Erdős Enhancer | 0 | 5 |
+| Enricher | 2 | 5 |
 | Aristotle | 1 | 2 |
 | Researcher | 2 | 5 |
 | Seeker | 1 | 1 |

--- a/research/candidate-pool.json
+++ b/research/candidate-pool.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "last_updated": "2026-02-08T03:05:53.676Z",
+  "last_updated": "2026-02-08T03:37:13.346Z",
   "source": "auto-generated from research/db/knowledge.db",
   "candidates": [
     {

--- a/scripts/enricher/claim-target.sh
+++ b/scripts/enricher/claim-target.sh
@@ -1,0 +1,408 @@
+#!/bin/bash
+#
+# claim-target.sh - Claim a proof gallery entry for exclusive enrichment work
+#
+# Usage:
+#   ./claim-target.sh claim-next            # Claim the highest-priority unclaimed target
+#   ./claim-target.sh claim <id>            # Claim a specific entry
+#   ./claim-target.sh complete <id>         # Mark as completed and release
+#   ./claim-target.sh release <id>          # Release a claimed entry
+#   ./claim-target.sh status                # Show all claims
+#   ./claim-target.sh cleanup               # Remove stale claims
+#
+# Environment:
+#   ENRICHER_ID - Agent identifier (default: enricher-PID)
+#   CLAIM_TTL   - Claim time-to-live in minutes (default: 90)
+
+set -euo pipefail
+shopt -s nullglob
+
+# Find repo root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository" >&2
+    return 1
+}
+
+REPO_ROOT="$(find_repo_root)"
+CLAIMS_DIR="$REPO_ROOT/research/enrichment-claims"
+TRACKER_FILE="$REPO_ROOT/src/data/proofs/enrichment-tracker.json"
+FIND_TARGETS="$REPO_ROOT/scripts/enricher/find-targets.ts"
+COMPLETIONS_DIR="$REPO_ROOT/.loom/signals/completions"
+
+# Defaults
+TTL_MINUTES="${CLAIM_TTL:-90}"
+AGENT_ID="${ENRICHER_ID:-enricher-$$}"
+
+# Ensure claims directory exists
+mkdir -p "$CLAIMS_DIR"
+
+# Initialize tracker if missing
+if [[ ! -f "$TRACKER_FILE" ]]; then
+    echo '{"version": 1, "entries": {}}' > "$TRACKER_FILE"
+fi
+
+# Calculate timestamps
+get_timestamps() {
+    CLAIMED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    if [[ "$(uname)" == "Darwin" ]]; then
+        EXPIRES_AT=$(date -u -v+${TTL_MINUTES}M +"%Y-%m-%dT%H:%M:%SZ")
+    else
+        EXPIRES_AT=$(date -u -d "+${TTL_MINUTES} minutes" +"%Y-%m-%dT%H:%M:%SZ")
+    fi
+}
+
+# Check if claim is expired
+is_claim_expired() {
+    local claim_file="$1"
+    if [[ ! -f "$claim_file" ]]; then
+        return 0
+    fi
+
+    local expires_at
+    expires_at=$(jq -r '.expires_at' "$claim_file")
+
+    local now_epoch expires_epoch
+    now_epoch=$(date -u +%s)
+
+    if [[ "$(uname)" == "Darwin" ]]; then
+        local stripped="${expires_at%Z}"
+        expires_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$stripped" +%s 2>/dev/null || echo 0)
+    else
+        expires_epoch=$(date -d "$expires_at" +%s 2>/dev/null || echo 0)
+    fi
+
+    [[ $now_epoch -gt $expires_epoch ]]
+}
+
+# Claim a specific entry
+claim_target() {
+    local target_id="$1"
+    local lock_dir="$CLAIMS_DIR/$target_id.lock"
+    local claim_file="$CLAIMS_DIR/$target_id.json"
+
+    get_timestamps
+
+    # Try atomic claim with mkdir
+    if mkdir "$lock_dir" 2>/dev/null; then
+        cat > "$claim_file" << EOF
+{
+  "target_id": "$target_id",
+  "agent_id": "$AGENT_ID",
+  "claimed_at": "$CLAIMED_AT",
+  "expires_at": "$EXPIRES_AT",
+  "ttl_minutes": $TTL_MINUTES,
+  "status": "in_progress"
+}
+EOF
+        echo "Claimed $target_id by $AGENT_ID (expires: $EXPIRES_AT)"
+        return 0
+    else
+        # Lock exists - check if stale
+        if is_claim_expired "$claim_file"; then
+            echo "Stale claim detected, reclaiming..."
+            rm -rf "$lock_dir"
+            rm -f "$claim_file"
+
+            if mkdir "$lock_dir" 2>/dev/null; then
+                cat > "$claim_file" << EOF
+{
+  "target_id": "$target_id",
+  "agent_id": "$AGENT_ID",
+  "claimed_at": "$CLAIMED_AT",
+  "expires_at": "$EXPIRES_AT",
+  "ttl_minutes": $TTL_MINUTES,
+  "status": "in_progress"
+}
+EOF
+                echo "Claimed $target_id by $AGENT_ID (expires: $EXPIRES_AT)"
+                return 0
+            fi
+        fi
+
+        local existing_agent
+        existing_agent=$(jq -r '.agent_id' "$claim_file" 2>/dev/null || echo "unknown")
+        echo "Error: $target_id already claimed by $existing_agent" >&2
+        return 1
+    fi
+}
+
+# Claim the highest-priority unclaimed target
+claim_next() {
+    # Get sorted targets
+    local targets_json
+    targets_json=$(npx tsx "$FIND_TARGETS" --json 2>/dev/null)
+
+    if [[ -z "$targets_json" ]]; then
+        echo "Error: Could not find enrichment targets" >&2
+        return 1
+    fi
+
+    # Iterate through targets in priority order
+    local count
+    count=$(echo "$targets_json" | jq 'length')
+
+    for i in $(seq 0 $((count - 1))); do
+        local target_id
+        target_id=$(echo "$targets_json" | jq -r ".[$i].id")
+
+        # Skip if currently claimed (and not expired)
+        local claim_file="$CLAIMS_DIR/$target_id.json"
+        if [[ -d "$CLAIMS_DIR/$target_id.lock" ]] && ! is_claim_expired "$claim_file"; then
+            continue
+        fi
+
+        # Try to claim it
+        if claim_target "$target_id"; then
+            local quality passes priority
+            quality=$(echo "$targets_json" | jq ".[$i].quality")
+            passes=$(echo "$targets_json" | jq ".[$i].passes")
+            priority=$(echo "$targets_json" | jq ".[$i].priority")
+            echo "Target: $target_id (quality: $quality, passes: $passes, priority: $priority)"
+            return 0
+        fi
+    done
+
+    echo "No unclaimed targets available" >&2
+    return 1
+}
+
+# Release a claim
+release_target() {
+    local target_id="$1"
+    local lock_dir="$CLAIMS_DIR/$target_id.lock"
+    local claim_file="$CLAIMS_DIR/$target_id.json"
+
+    if [[ -d "$lock_dir" ]]; then
+        rm -rf "$lock_dir"
+        rm -f "$claim_file"
+        echo "Released $target_id"
+    else
+        echo "Warning: No claim found for $target_id" >&2
+    fi
+}
+
+# Mark as completed, update tracker, and release
+complete_target() {
+    local target_id="$1"
+
+    get_timestamps
+
+    # Update enrichment tracker
+    local tmp_file
+    tmp_file=$(mktemp)
+
+    if jq -e ".entries[\"$target_id\"]" "$TRACKER_FILE" > /dev/null 2>&1; then
+        # Existing entry: increment passes and update quality
+        local quality
+        quality=$(npx tsx "$FIND_TARGETS" --json 2>/dev/null | jq "[.[] | select(.id == \"$target_id\")] | .[0].quality // 0")
+        jq --arg id "$target_id" \
+           --arg ts "$CLAIMED_AT" \
+           --argjson quality "$quality" \
+           '.entries[$id].passes += 1 |
+            .entries[$id].lastEnriched = $ts |
+            .entries[$id].quality = $quality' \
+           "$TRACKER_FILE" > "$tmp_file"
+    else
+        # New entry
+        local quality
+        quality=$(npx tsx "$FIND_TARGETS" --json 2>/dev/null | jq "[.[] | select(.id == \"$target_id\")] | .[0].quality // 0")
+        jq --arg id "$target_id" \
+           --arg ts "$CLAIMED_AT" \
+           --argjson quality "$quality" \
+           '.entries[$id] = {
+               "passes": 1,
+               "lastEnriched": $ts,
+               "quality": ($quality // 0)
+           }' \
+           "$TRACKER_FILE" > "$tmp_file"
+    fi
+
+    mv "$tmp_file" "$TRACKER_FILE"
+
+    # Release the claim
+    release_target "$target_id"
+
+    # Create completion signal for daemon stats tracking
+    mkdir -p "$COMPLETIONS_DIR"
+    touch "$COMPLETIONS_DIR/enrichment-completed-$target_id-$(date +%s)"
+
+    echo "Marked $target_id as enriched (pass $(jq -r ".entries[\"$target_id\"].passes" "$TRACKER_FILE"))"
+}
+
+# Show status
+show_status() {
+    echo "=== Enrichment Claims ==="
+    echo ""
+
+    local active_count=0
+    local stale_count=0
+
+    for lock_dir in "$CLAIMS_DIR"/*.lock; do
+        [[ ! -d "$lock_dir" ]] && continue
+
+        local target_id
+        target_id=$(basename "$lock_dir" .lock)
+        local claim_file="$CLAIMS_DIR/$target_id.json"
+
+        if [[ -f "$claim_file" ]]; then
+            local agent expires status
+            agent=$(jq -r '.agent_id' "$claim_file")
+            expires=$(jq -r '.expires_at' "$claim_file")
+
+            if is_claim_expired "$claim_file"; then
+                status="STALE"
+                ((stale_count++))
+            else
+                status="active"
+                ((active_count++))
+            fi
+
+            echo "  $target_id: $agent ($status, expires: $expires)"
+        fi
+    done
+
+    if [[ $active_count -eq 0 && $stale_count -eq 0 ]]; then
+        echo "  (no active claims)"
+    fi
+
+    echo ""
+
+    # Show tracker stats
+    if [[ -f "$TRACKER_FILE" ]]; then
+        local total_entries enriched_entries avg_quality
+        total_entries=$(jq '.entries | length' "$TRACKER_FILE" 2>/dev/null || echo 0)
+        avg_quality=$(jq '[.entries[] | .quality] | if length > 0 then add / length else 0 end' "$TRACKER_FILE" 2>/dev/null || echo 0)
+
+        echo "Tracker: $total_entries entries enriched"
+        echo "Average quality: $avg_quality"
+    fi
+
+    echo "Active claims: $active_count"
+    echo "Stale claims: $stale_count"
+}
+
+# Cleanup stale claims
+cleanup_claims() {
+    local cleaned=0
+
+    for lock_dir in "$CLAIMS_DIR"/*.lock; do
+        [[ ! -d "$lock_dir" ]] && continue
+
+        local target_id
+        target_id=$(basename "$lock_dir" .lock)
+        local claim_file="$CLAIMS_DIR/$target_id.json"
+
+        if is_claim_expired "$claim_file"; then
+            rm -rf "$lock_dir"
+            rm -f "$claim_file"
+            echo "Cleaned up stale claim: $target_id"
+            ((cleaned++))
+        fi
+    done
+
+    if [[ $cleaned -eq 0 ]]; then
+        echo "No stale claims to clean up"
+    else
+        echo "Cleaned up $cleaned stale claims"
+    fi
+}
+
+# Extend a claim (renew TTL)
+extend_claim() {
+    local target_id="$1"
+    local claim_file="$CLAIMS_DIR/$target_id.json"
+
+    if [[ ! -f "$claim_file" ]]; then
+        echo "Error: No claim found for $target_id" >&2
+        return 1
+    fi
+
+    get_timestamps
+
+    local tmp_file
+    tmp_file=$(mktemp)
+    jq ".expires_at = \"$EXPIRES_AT\"" "$claim_file" > "$tmp_file"
+    mv "$tmp_file" "$claim_file"
+
+    echo "Extended claim for $target_id (new expires: $EXPIRES_AT)"
+}
+
+# Main command dispatch
+case "${1:-help}" in
+    claim-next)
+        claim_next
+        ;;
+    claim)
+        if [[ -z "${2:-}" ]]; then
+            echo "Usage: $0 claim <target-id>" >&2
+            exit 1
+        fi
+        claim_target "$2"
+        ;;
+    release)
+        if [[ -z "${2:-}" ]]; then
+            echo "Usage: $0 release <target-id>" >&2
+            exit 1
+        fi
+        release_target "$2"
+        ;;
+    complete)
+        if [[ -z "${2:-}" ]]; then
+            echo "Usage: $0 complete <target-id>" >&2
+            exit 1
+        fi
+        complete_target "$2"
+        ;;
+    extend)
+        if [[ -z "${2:-}" ]]; then
+            echo "Usage: $0 extend <target-id>" >&2
+            exit 1
+        fi
+        extend_claim "$2"
+        ;;
+    status)
+        show_status
+        ;;
+    cleanup)
+        cleanup_claims
+        ;;
+    help|--help|-h)
+        cat << EOF
+Enrichment Target Claiming System
+
+Provides atomic claiming for parallel proof enrichment.
+
+Commands:
+  claim-next              Claim the highest-priority unclaimed target
+  claim <target-id>       Claim a specific entry
+  release <target-id>     Release a claimed entry
+  complete <target-id>    Mark as enriched, update tracker, release
+  extend <target-id>      Extend claim TTL
+  status                  Show all claims and tracker stats
+  cleanup                 Remove stale claims
+  help                    Show this help
+
+Environment Variables:
+  ENRICHER_ID   Agent identifier (default: enricher-PID)
+  CLAIM_TTL     Claim time-to-live in minutes (default: 90)
+
+Examples:
+  ENRICHER_ID=enricher-1 ./claim-target.sh claim-next
+  ENRICHER_ID=enricher-1 ./claim-target.sh complete pythagorean-theorem
+  ./claim-target.sh status
+EOF
+        ;;
+    *)
+        echo "Unknown command: $1" >&2
+        echo "Run '$0 help' for usage" >&2
+        exit 1
+        ;;
+esac

--- a/scripts/enricher/find-targets.ts
+++ b/scripts/enricher/find-targets.ts
@@ -1,0 +1,254 @@
+#!/usr/bin/env npx tsx
+/**
+ * Find proof gallery entries that need enrichment
+ *
+ * Reads all proof directories, joins with enrichment tracker,
+ * computes quality score, and returns priority-sorted list.
+ *
+ * Quality score heuristic:
+ * - Annotation count (0-25 points)
+ * - Presence of mathContext in annotations (0-10 points)
+ * - Presence of significance in annotations (0-10 points)
+ * - overview.historicalContext length (0-10 points)
+ * - overview.keyInsights count (0-10 points)
+ * - conclusion presence and depth (0-15 points)
+ * - sections count (0-10 points)
+ * - cross-references / relatedConcepts (0-10 points)
+ *
+ * Priority: (1 / (passes + 1)) * (100 - quality)
+ *
+ * Usage:
+ *   npx tsx scripts/enricher/find-targets.ts           # Show top 10 targets
+ *   npx tsx scripts/enricher/find-targets.ts --all     # Show all targets
+ *   npx tsx scripts/enricher/find-targets.ts --json    # Output as JSON
+ *   npx tsx scripts/enricher/find-targets.ts --stats   # Show statistics only
+ *   npx tsx scripts/enricher/find-targets.ts --next    # Show single highest-priority target
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+const GALLERY_DIR = 'src/data/proofs'
+const TRACKER_FILE = 'src/data/proofs/enrichment-tracker.json'
+
+interface TrackerEntry {
+  passes: number
+  lastEnriched: string | null
+  quality: number
+}
+
+interface Tracker {
+  version: number
+  entries: Record<string, TrackerEntry>
+}
+
+interface TargetInfo {
+  id: string
+  galleryPath: string
+  quality: number
+  passes: number
+  lastEnriched: string | null
+  priority: number
+  qualityBreakdown: {
+    annotations: number
+    mathContext: number
+    significance: number
+    historicalContext: number
+    keyInsights: number
+    conclusion: number
+    sections: number
+    crossRefs: number
+  }
+}
+
+function loadTracker(): Tracker {
+  if (fs.existsSync(TRACKER_FILE)) {
+    try {
+      return JSON.parse(fs.readFileSync(TRACKER_FILE, 'utf-8'))
+    } catch {
+      // Corrupted file, start fresh
+    }
+  }
+  return { version: 1, entries: {} }
+}
+
+function computeQuality(galleryPath: string): { score: number; breakdown: TargetInfo['qualityBreakdown'] } {
+  const breakdown = {
+    annotations: 0,
+    mathContext: 0,
+    significance: 0,
+    historicalContext: 0,
+    keyInsights: 0,
+    conclusion: 0,
+    sections: 0,
+    crossRefs: 0,
+  }
+
+  // Read meta.json
+  const metaPath = path.join(galleryPath, 'meta.json')
+  let meta: any = null
+  if (fs.existsSync(metaPath)) {
+    try {
+      meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'))
+    } catch { /* skip */ }
+  }
+
+  // Read annotations.json
+  const annotationsPath = path.join(galleryPath, 'annotations.json')
+  let annotations: any[] = []
+  if (fs.existsSync(annotationsPath)) {
+    try {
+      annotations = JSON.parse(fs.readFileSync(annotationsPath, 'utf-8'))
+    } catch { /* skip */ }
+  }
+
+  // Annotation count (0-25 points, 5 per annotation up to 5)
+  breakdown.annotations = Math.min(25, annotations.length * 5)
+
+  // mathContext presence in annotations (0-10 points)
+  const withMathContext = annotations.filter((a: any) => a.mathContext && a.mathContext.length > 0)
+  breakdown.mathContext = Math.min(10, withMathContext.length * 3)
+
+  // significance presence in annotations (0-10 points)
+  const withSignificance = annotations.filter((a: any) => a.significance && a.significance.length > 0)
+  breakdown.significance = Math.min(10, withSignificance.length * 3)
+
+  if (meta) {
+    // historicalContext length (0-10 points)
+    const hc = meta.overview?.historicalContext || ''
+    if (hc.length > 500) breakdown.historicalContext = 10
+    else if (hc.length > 200) breakdown.historicalContext = 7
+    else if (hc.length > 50) breakdown.historicalContext = 4
+    else if (hc.length > 0) breakdown.historicalContext = 2
+
+    // keyInsights count (0-10 points, 2 per insight up to 5)
+    const insights = meta.overview?.keyInsights || []
+    breakdown.keyInsights = Math.min(10, insights.length * 2)
+
+    // conclusion presence and depth (0-15 points)
+    const conclusion = meta.conclusion
+    if (conclusion) {
+      if (conclusion.summary) breakdown.conclusion += 5
+      if (conclusion.implications) breakdown.conclusion += 5
+      if (conclusion.openQuestions && conclusion.openQuestions.length > 0) breakdown.conclusion += 5
+    }
+
+    // sections count (0-10 points, 2 per section up to 5)
+    const sections = meta.sections || []
+    breakdown.sections = Math.min(10, sections.length * 2)
+  }
+
+  // Cross-references / relatedConcepts (0-10 points)
+  const withRelated = annotations.filter((a: any) => a.relatedConcepts && a.relatedConcepts.length > 0)
+  breakdown.crossRefs = Math.min(10, withRelated.length * 3)
+
+  const score = Object.values(breakdown).reduce((sum, v) => sum + v, 0)
+  return { score: Math.min(100, score), breakdown }
+}
+
+function findTargets(): TargetInfo[] {
+  const tracker = loadTracker()
+  const targets: TargetInfo[] = []
+
+  if (!fs.existsSync(GALLERY_DIR)) {
+    console.error(`Gallery directory not found: ${GALLERY_DIR}`)
+    process.exit(1)
+  }
+
+  const entries = fs.readdirSync(GALLERY_DIR, { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .map(d => d.name)
+
+  for (const id of entries) {
+    const galleryPath = path.join(GALLERY_DIR, id)
+    const metaPath = path.join(galleryPath, 'meta.json')
+
+    // Must have meta.json to be a valid entry
+    if (!fs.existsSync(metaPath)) continue
+
+    const { score, breakdown } = computeQuality(galleryPath)
+    const trackerEntry = tracker.entries[id]
+    const passes = trackerEntry?.passes ?? 0
+    const lastEnriched = trackerEntry?.lastEnriched ?? null
+
+    // Priority: (1 / (passes + 1)) * (100 - quality)
+    const priority = (1 / (passes + 1)) * (100 - score)
+
+    targets.push({
+      id,
+      galleryPath,
+      quality: score,
+      passes,
+      lastEnriched,
+      priority,
+      qualityBreakdown: breakdown,
+    })
+  }
+
+  // Sort by priority descending (highest priority first)
+  targets.sort((a, b) => b.priority - a.priority)
+
+  return targets
+}
+
+function printStats(targets: TargetInfo[]): void {
+  const total = targets.length
+  const avgQuality = targets.reduce((sum, t) => sum + t.quality, 0) / total
+  const passDistribution: Record<number, number> = {}
+  for (const t of targets) {
+    passDistribution[t.passes] = (passDistribution[t.passes] || 0) + 1
+  }
+
+  const qualityBuckets = {
+    '0-20 (needs work)': targets.filter(t => t.quality <= 20).length,
+    '21-40 (basic)': targets.filter(t => t.quality > 20 && t.quality <= 40).length,
+    '41-60 (decent)': targets.filter(t => t.quality > 40 && t.quality <= 60).length,
+    '61-80 (good)': targets.filter(t => t.quality > 60 && t.quality <= 80).length,
+    '81-100 (excellent)': targets.filter(t => t.quality > 80).length,
+  }
+
+  console.log(`Enrichment Target Statistics`)
+  console.log(`============================`)
+  console.log(`Total gallery entries: ${total}`)
+  console.log(`Average quality score: ${avgQuality.toFixed(1)}`)
+  console.log(``)
+  console.log(`Quality distribution:`)
+  for (const [bucket, count] of Object.entries(qualityBuckets)) {
+    const bar = '#'.repeat(Math.ceil(count / 20))
+    console.log(`  ${bucket.padEnd(24)} ${String(count).padStart(5)} ${bar}`)
+  }
+  console.log(``)
+  console.log(`Pass distribution:`)
+  for (const [passes, count] of Object.entries(passDistribution).sort(([a], [b]) => Number(a) - Number(b))) {
+    console.log(`  ${passes} passes: ${count} entries`)
+  }
+  console.log(``)
+  console.log(`Entries needing enrichment: ${targets.filter(t => t.quality < 80).length}`)
+}
+
+// Main
+const args = process.argv.slice(2)
+const targets = findTargets()
+
+if (args.includes('--stats')) {
+  printStats(targets)
+} else if (args.includes('--json')) {
+  console.log(JSON.stringify(targets, null, 2))
+} else if (args.includes('--next')) {
+  if (targets.length > 0) {
+    const t = targets[0]
+    console.log(`${t.id} (quality: ${t.quality}, passes: ${t.passes}, priority: ${t.priority.toFixed(1)})`)
+  } else {
+    console.log('No targets found')
+  }
+} else {
+  const count = args.includes('--all') ? targets.length : 10
+  const shown = targets.slice(0, count)
+
+  console.log(`Top ${shown.length} enrichment targets (of ${targets.length}):`)
+  console.log(`${'ID'.padEnd(40)} ${'Quality'.padStart(7)} ${'Passes'.padStart(6)} ${'Priority'.padStart(8)}`)
+  console.log(`${'─'.repeat(40)} ${'─'.repeat(7)} ${'─'.repeat(6)} ${'─'.repeat(8)}`)
+  for (const t of shown) {
+    console.log(`${t.id.padEnd(40)} ${String(t.quality).padStart(7)} ${String(t.passes).padStart(6)} ${t.priority.toFixed(1).padStart(8)}`)
+  }
+}

--- a/scripts/enricher/parallel-enrich.sh
+++ b/scripts/enricher/parallel-enrich.sh
@@ -1,0 +1,455 @@
+#!/bin/bash
+#
+# parallel-enrich.sh - Launch multiple proof enrichment agents in isolated worktrees
+#
+# Usage:
+#   ./parallel-enrich.sh                    # Launch 2 agents (default)
+#   ./parallel-enrich.sh 3                  # Launch 3 agents
+#   ./parallel-enrich.sh --status           # Show agent status
+#   ./parallel-enrich.sh --stop             # Stop all agents
+#   ./parallel-enrich.sh --logs <N>         # Tail logs for agent N
+#   ./parallel-enrich.sh --cleanup          # Remove all enricher worktrees
+#
+# Each agent runs in its own git worktree with a dedicated branch.
+# Agents work autonomously: claim target → enrich → commit → push → create PR → repeat.
+
+set -euo pipefail
+
+# Configuration
+DEFAULT_AGENTS=2
+MAX_AGENTS=5
+SESSION_PREFIX="enricher"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORKTREES_DIR="$REPO_ROOT/.loom/worktrees"
+ROLE_FILE="$REPO_ROOT/.lean/roles/enricher.md"
+LOGS_DIR="$REPO_ROOT/.loom/logs"
+SIGNALS_DIR="$REPO_ROOT/.loom/signals"
+CLAIM_TTL=90  # Minutes
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+print_info() { echo -e "${BLUE}i $1${NC}"; }
+print_success() { echo -e "${GREEN}✓ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}! $1${NC}"; }
+print_error() { echo -e "${RED}x $1${NC}" >&2; }
+
+# Check dependencies
+check_deps() {
+    local missing=()
+
+    if ! command -v tmux &> /dev/null; then
+        missing+=("tmux")
+    fi
+
+    if ! command -v claude &> /dev/null; then
+        missing+=("claude (Claude Code CLI)")
+    fi
+
+    if ! command -v gh &> /dev/null; then
+        missing+=("gh (GitHub CLI)")
+    fi
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        print_error "Missing dependencies: ${missing[*]}"
+        echo "Please install the missing dependencies and try again."
+        exit 1
+    fi
+}
+
+# Get list of running agent sessions
+get_running_agents() {
+    tmux list-sessions 2>/dev/null | grep "^$SESSION_PREFIX" | cut -d: -f1 || true
+}
+
+# Create worktree for an agent
+create_agent_worktree() {
+    local agent_num="$1"
+    local worktree_path="$WORKTREES_DIR/enricher-$agent_num"
+    local branch_name="feature/enricher-$agent_num"
+
+    # Remove existing worktree if it exists
+    if [[ -d "$worktree_path" ]]; then
+        print_info "Removing existing worktree for agent $agent_num..."
+        git worktree remove "$worktree_path" --force 2>/dev/null || rm -rf "$worktree_path"
+    fi
+
+    # Delete existing branch if it exists (force fresh start)
+    git branch -D "$branch_name" 2>/dev/null || true
+
+    # Create fresh worktree with new branch from main
+    print_info "Creating worktree for agent $agent_num..."
+    git worktree add "$worktree_path" -b "$branch_name" main
+
+    # Initialize submodules if needed
+    if [[ -f "$worktree_path/.gitmodules" ]]; then
+        (cd "$worktree_path" && git submodule update --init --recursive 2>/dev/null) || true
+    fi
+
+    echo "$worktree_path"
+}
+
+# Show status of all agents
+show_status() {
+    echo "=== Proof Enrichment Agents ==="
+    echo ""
+
+    local running
+    running=$(get_running_agents)
+
+    if [[ -z "$running" ]]; then
+        echo "No agents currently running."
+        echo ""
+        echo "Start agents with: $0 [count]"
+    else
+        echo "Running agents:"
+        while IFS= read -r session; do
+            local agent_num="${session#$SESSION_PREFIX-}"
+            local worktree_path="$WORKTREES_DIR/enricher-$agent_num"
+            local branch=""
+
+            if [[ -d "$worktree_path" ]]; then
+                branch=$(cd "$worktree_path" && git branch --show-current 2>/dev/null || echo "unknown")
+            fi
+
+            echo "  $session: worktree=$worktree_path branch=$branch"
+        done <<< "$running"
+    fi
+
+    echo ""
+
+    # Show claim status
+    echo "=== Enrichment Claims ==="
+    "$REPO_ROOT/scripts/enricher/claim-target.sh" status 2>/dev/null || echo "  (claim system not initialized)"
+
+    echo ""
+
+    # Show worktrees
+    echo "=== Worktrees ==="
+    git worktree list | grep enricher || echo "  (no enricher worktrees)"
+
+    # Show stop signal status
+    echo ""
+    echo "=== Stop Signals ==="
+    if [[ -f "$SIGNALS_DIR/stop-all" ]]; then
+        print_warning "STOP-ALL signal pending - agents will stop after current work"
+    else
+        local has_individual=false
+        for sig in "$SIGNALS_DIR"/stop-enricher-*; do
+            if [[ -f "$sig" ]]; then
+                has_individual=true
+                local agent_num=$(basename "$sig" | sed 's/stop-enricher-//')
+                print_warning "STOP signal pending for enricher-$agent_num"
+            fi
+        done
+        if [[ "$has_individual" == "false" ]]; then
+            echo "  (no stop signals pending)"
+        fi
+    fi
+}
+
+# Signal agents to stop gracefully
+signal_graceful_stop() {
+    local agent_num="${1:-all}"
+
+    mkdir -p "$SIGNALS_DIR"
+
+    if [[ "$agent_num" == "all" ]]; then
+        touch "$SIGNALS_DIR/stop-all"
+        print_success "Signaled all agents to stop after completing current work"
+    else
+        touch "$SIGNALS_DIR/stop-enricher-$agent_num"
+        print_success "Signaled enricher-$agent_num to stop after completing current work"
+    fi
+}
+
+# Clear stop signals
+clear_stop_signals() {
+    rm -f "$SIGNALS_DIR/stop-all" 2>/dev/null || true
+    rm -f "$SIGNALS_DIR/stop-enricher-"* 2>/dev/null || true
+}
+
+# Stop all agents (force)
+stop_agents() {
+    local running
+    running=$(get_running_agents)
+
+    if [[ -z "$running" ]]; then
+        print_info "No agents running"
+        return 0
+    fi
+
+    echo "Stopping agents..."
+    while IFS= read -r session; do
+        tmux kill-session -t "$session" 2>/dev/null && \
+            print_success "Stopped $session" || \
+            print_warning "Failed to stop $session"
+    done <<< "$running"
+
+    # Clear any stop signals
+    clear_stop_signals
+
+    # Cleanup stale claims
+    print_info "Cleaning up claims..."
+    "$REPO_ROOT/scripts/enricher/claim-target.sh" cleanup 2>/dev/null || true
+}
+
+# Cleanup all enricher worktrees
+cleanup_worktrees() {
+    echo "Cleaning up enricher worktrees..."
+
+    # First stop any running agents
+    stop_agents
+
+    # Remove worktrees
+    for i in $(seq 1 $MAX_AGENTS); do
+        local worktree_path="$WORKTREES_DIR/enricher-$i"
+        local branch_name="feature/enricher-$i"
+
+        if [[ -d "$worktree_path" ]]; then
+            print_info "Removing worktree: $worktree_path"
+            git worktree remove "$worktree_path" --force 2>/dev/null || rm -rf "$worktree_path"
+        fi
+
+        # Delete branch
+        git branch -D "$branch_name" 2>/dev/null && \
+            print_info "Deleted branch: $branch_name" || true
+    done
+
+    # Prune worktree references
+    git worktree prune
+
+    print_success "Cleanup complete"
+}
+
+# Tail logs for a specific agent
+tail_logs() {
+    local agent_num="$1"
+    local log_file="$LOGS_DIR/$SESSION_PREFIX-$agent_num.log"
+
+    if [[ ! -f "$log_file" ]]; then
+        print_error "Log file not found: $log_file"
+        exit 1
+    fi
+
+    print_info "Tailing logs for agent $agent_num (Ctrl+C to stop)"
+    tail -f "$log_file"
+}
+
+# Attach to agent session
+attach_agent() {
+    local agent_num="$1"
+    local session="$SESSION_PREFIX-$agent_num"
+
+    if ! tmux has-session -t "$session" 2>/dev/null; then
+        print_error "Agent $agent_num is not running"
+        exit 1
+    fi
+
+    print_info "Attaching to $session (Ctrl+B D to detach)"
+    tmux attach -t "$session"
+}
+
+# Launch agents
+launch_agents() {
+    local count="${1:-$DEFAULT_AGENTS}"
+
+    if [[ $count -gt $MAX_AGENTS ]]; then
+        print_warning "Limiting to $MAX_AGENTS agents (requested $count)"
+        count=$MAX_AGENTS
+    fi
+
+    # Check existing agents
+    local running
+    running=$(get_running_agents | wc -l | tr -d ' ')
+
+    if [[ $running -gt 0 ]]; then
+        print_warning "$running agent(s) already running"
+        echo "Use '$0 --stop' to stop them first, or '$0 --status' to view"
+        exit 1
+    fi
+
+    # Create directories
+    mkdir -p "$LOGS_DIR"
+    mkdir -p "$WORKTREES_DIR"
+    mkdir -p "$SIGNALS_DIR"
+
+    # Clear any old stop signals
+    clear_stop_signals
+
+    # Ensure claim system is initialized
+    mkdir -p "$REPO_ROOT/research/enrichment-claims"
+
+    # Ensure tracker exists
+    if [[ ! -f "$REPO_ROOT/src/data/proofs/enrichment-tracker.json" ]]; then
+        echo '{"version": 1, "entries": {}}' > "$REPO_ROOT/src/data/proofs/enrichment-tracker.json"
+    fi
+
+    # Ensure we're on main and up to date
+    print_info "Updating main branch..."
+    git checkout main 2>/dev/null || true
+    git pull origin main 2>/dev/null || true
+
+    print_info "Launching $count enrichment agents with isolated worktrees..."
+    echo ""
+
+    for i in $(seq 1 "$count"); do
+        local session="$SESSION_PREFIX-$i"
+        local log_file="$LOGS_DIR/$session.log"
+        local enricher_id="enricher-$i"
+
+        # Create isolated worktree for this agent
+        local worktree_path
+        worktree_path=$(create_agent_worktree "$i")
+
+        # Create tmux session starting in the worktree
+        tmux new-session -d -s "$session" -c "$worktree_path"
+
+        # Set environment variables
+        tmux send-keys -t "$session" "export ENRICHER_ID='$enricher_id'" Enter
+        tmux send-keys -t "$session" "export CLAIM_TTL='$CLAIM_TTL'" Enter
+        tmux send-keys -t "$session" "export REPO_ROOT='$REPO_ROOT'" Enter
+
+        # Write prompt to file (avoids tmux multiline issues)
+        local prompt_file="$LOGS_DIR/$session-prompt.md"
+        cat > "$prompt_file" << PROMPT_EOF
+# Proof Enrichment Agent $enricher_id
+
+You are working in an isolated git worktree with your own branch.
+
+**Your worktree:** $worktree_path
+**Your branch:** feature/enricher-$i
+**Claim script:** \$REPO_ROOT/scripts/enricher/claim-target.sh
+
+## Quick Start
+
+1. Read the full instructions: \`cat .lean/roles/enricher.md\`
+2. **Check for stop signal before each iteration:**
+   \`[[ -f \$REPO_ROOT/.loom/signals/stop-all ]] && echo "Stopping" && exit 0\`
+3. Claim a target: \`\$REPO_ROOT/scripts/enricher/claim-target.sh claim-next\`
+4. Enrich it (improve meta.json, annotations.json - add depth, cross-refs, context)
+5. Build: \`pnpm build\`
+6. Commit: \`git add src/data/proofs/<id>/ && git commit -m "Enrich <title>: add depth"\`
+7. Push: \`git push -u origin feature/enricher-$i\`
+8. Create PR: \`gh pr create --title "Enrich <title>" --body "Enrichment pass" --label enrichment\`
+9. Mark complete: \`\$REPO_ROOT/scripts/enricher/claim-target.sh complete <id>\`
+10. Reset for next: \`git checkout main && git pull && git checkout -B feature/enricher-$i main\`
+11. Repeat from step 2
+
+Start now by running step 1 to read the full instructions, then claim and enrich a target.
+PROMPT_EOF
+
+        # Start Claude Code with simple prompt pointing to instructions
+        local simple_prompt="You are $enricher_id. Read $prompt_file for your instructions, then start the enrichment workflow."
+        local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
+        tmux send-keys -t "$session" "$wrapper_script --prompt '$simple_prompt' --log '$log_file' --max-retries 5" Enter
+
+        print_success "Launched $session (worktree: $worktree_path)"
+    done
+
+    echo ""
+    print_success "All agents launched in isolated worktrees!"
+    echo ""
+    echo "Each agent has:"
+    echo "  - Its own worktree in .loom/worktrees/enricher-N"
+    echo "  - Its own branch: feature/enricher-N"
+    echo "  - Creates PRs instead of committing to main"
+    echo ""
+    echo "Commands:"
+    echo "  $0 --status        Show agent status and worktrees"
+    echo "  $0 --attach N      Attach to agent N's tmux session"
+    echo "  $0 --stop          Stop all agents"
+    echo "  $0 --cleanup       Remove all enricher worktrees"
+}
+
+# Main command dispatch
+case "${1:-}" in
+    --status|-s)
+        show_status
+        ;;
+    --stop)
+        stop_agents
+        ;;
+    --graceful-stop|-g)
+        signal_graceful_stop "${2:-all}"
+        ;;
+    --cleanup)
+        cleanup_worktrees
+        ;;
+    --logs|-l)
+        if [[ -z "${2:-}" ]]; then
+            print_error "Usage: $0 --logs <agent-number>"
+            exit 1
+        fi
+        tail_logs "$2"
+        ;;
+    --attach|-a)
+        if [[ -z "${2:-}" ]]; then
+            print_error "Usage: $0 --attach <agent-number>"
+            exit 1
+        fi
+        attach_agent "$2"
+        ;;
+    --help|-h)
+        cat << EOF
+Parallel Proof Enrichment (with Worktree Isolation)
+
+Launch multiple Claude Code agents to enrich gallery proofs concurrently.
+Each agent works in its own git worktree with a dedicated branch.
+
+Usage:
+  $0 [count]            Launch N agents (default: $DEFAULT_AGENTS, max: $MAX_AGENTS)
+  $0 --status           Show running agents, worktrees, and claims
+  $0 --graceful-stop    Signal agents to stop after current work
+  $0 --graceful-stop N  Signal agent N to stop after current work
+  $0 --stop             Force stop all agents immediately
+  $0 --cleanup          Stop agents and remove all enricher worktrees
+  $0 --attach N         Attach to agent N's tmux session
+  $0 --help             Show this help
+
+How it works:
+  1. Each agent gets its own worktree: .loom/worktrees/enricher-N
+  2. Each agent works on its own branch: feature/enricher-N
+  3. Agents claim targets atomically (no duplicates)
+  4. Each agent: claim → enrich → commit → push → create PR → repeat
+  5. Entries with fewer passes get prioritized
+  6. PRs can be reviewed and merged independently
+
+Examples:
+  $0                    # Launch 2 agents
+  $0 3                  # Launch 3 agents
+  $0 --status           # Check progress
+  $0 --attach 2         # Interact with agent 2
+  $0 --cleanup          # Clean up everything
+
+Requirements:
+  - tmux
+  - claude (Claude Code CLI)
+  - gh (GitHub CLI)
+  - Node.js (for find-targets.ts)
+
+Notes:
+  - Agents create PRs instead of committing to main
+  - Use --cleanup to remove worktrees when done
+  - Stale claims auto-expire after $CLAIM_TTL minutes
+EOF
+        ;;
+    "")
+        check_deps
+        launch_agents "$DEFAULT_AGENTS"
+        ;;
+    *)
+        if [[ "$1" =~ ^[0-9]+$ ]]; then
+            check_deps
+            launch_agents "$1"
+        else
+            print_error "Unknown command: $1"
+            echo "Run '$0 --help' for usage"
+            exit 1
+        fi
+        ;;
+esac

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -3,13 +3,13 @@
 # Lean Genius Launch - Start/stop/scale the mathematical agent team
 #
 # Usage:
-#   ./scripts/lean/launch.sh start [--erdos N] [--aristotle N] [--researcher N] [--seeker N] [--deployer N]
+#   ./scripts/lean/launch.sh start [--enricher N] [--aristotle N] [--researcher N] [--seeker N] [--deployer N]
 #   ./scripts/lean/launch.sh stop [--force]
 #   ./scripts/lean/launch.sh health
-#   ./scripts/lean/launch.sh spawn erdos|aristotle|researcher|seeker|deployer
-#   ./scripts/lean/launch.sh scale erdos|researcher|seeker N
+#   ./scripts/lean/launch.sh spawn enricher|aristotle|researcher|seeker|deployer
+#   ./scripts/lean/launch.sh scale enricher|researcher|seeker N
 #   ./scripts/lean/launch.sh status
-#   ./scripts/lean/launch.sh daemon [--interval N] [--erdos N] [--researcher N] [...]
+#   ./scripts/lean/launch.sh daemon [--interval N] [--enricher N] [--researcher N] [...]
 #
 
 set -euo pipefail
@@ -42,15 +42,15 @@ STUCK_CPU_THRESHOLD="0.5"
 DEFAULT_DAEMON_INTERVAL=60
 RESPAWN_COOLDOWN_SECONDS=300  # 5 minutes between respawns of same agent
 
-# Default pool sizes (Erdos quality repair campaign resumed 2026-01-27)
-DEFAULT_ERDOS=2
+# Default pool sizes
+DEFAULT_ENRICHER=2
 DEFAULT_ARISTOTLE=1
 DEFAULT_RESEARCHER=2
 DEFAULT_SEEKER=1
 DEFAULT_DEPLOYER=1
 
 # Max pool sizes
-MAX_ERDOS=5
+MAX_ENRICHER=5
 MAX_ARISTOTLE=2
 MAX_RESEARCHER=5
 MAX_SEEKER=1
@@ -71,7 +71,7 @@ Usage:
   $0 daemon [options]    Run continuous monitoring daemon
 
 Start Options:
-  --erdos N              Number of Erdős enhancers (default: $DEFAULT_ERDOS, max: $MAX_ERDOS)
+  --enricher N           Number of Enrichers (default: $DEFAULT_ENRICHER, max: $MAX_ENRICHER)
   --aristotle N          Number of Aristotle agents (default: $DEFAULT_ARISTOTLE, max: $MAX_ARISTOTLE)
   --researcher N         Number of Researchers (default: $DEFAULT_RESEARCHER, max: $MAX_RESEARCHER)
   --seeker N             Number of Seeker agents (default: $DEFAULT_SEEKER, max: $MAX_SEEKER)
@@ -82,14 +82,14 @@ Stop Options:
 
 Daemon Options:
   --interval N           Seconds between health check cycles (default: $DEFAULT_DAEMON_INTERVAL)
-  --erdos N              Initial Erdős enhancer count (default: $DEFAULT_ERDOS, max: $MAX_ERDOS)
+  --enricher N           Initial Enricher count (default: $DEFAULT_ENRICHER, max: $MAX_ENRICHER)
   --aristotle N          Initial Aristotle agent count (default: $DEFAULT_ARISTOTLE, max: $MAX_ARISTOTLE)
   --researcher N         Initial Researcher count (default: $DEFAULT_RESEARCHER, max: $MAX_RESEARCHER)
   --seeker N             Initial Seeker agent count (default: $DEFAULT_SEEKER, max: $MAX_SEEKER)
   --deployer N           Initial Deployer count (default: $DEFAULT_DEPLOYER, max: $MAX_DEPLOYER)
 
 Agent Types:
-  erdos       Enhances Erdős problem stubs with Lean formalizations
+  enricher    Enriches proof gallery entries with deeper annotations and commentary
   aristotle   Manages proof search queue for Aristotle system
   researcher  Works on open mathematical problems
   seeker      Selects research problems when candidate pool runs low
@@ -98,7 +98,7 @@ Agent Types:
 Examples:
   $0 start                              # Start with defaults
   $0 start --researcher 3               # Custom pool sizes
-  $0 start --erdos 2 --researcher 1     # Include Erdős enhancers
+  $0 start --enricher 2 --researcher 1  # Include Enrichers
   $0 spawn researcher                   # Add one Researcher
   $0 spawn seeker                       # Add seeker agent
   $0 scale researcher 4                 # Scale to 4 Researchers
@@ -123,7 +123,7 @@ migrate_state_file() {
 # Helper: Initialize state file
 # Preserves session_stats and stopped_at from previous state across daemon restarts
 init_state() {
-    local erdos="${1:-$DEFAULT_ERDOS}"
+    local enricher="${1:-$DEFAULT_ENRICHER}"
     local aristotle="${2:-$DEFAULT_ARISTOTLE}"
     local researcher="${3:-$DEFAULT_RESEARCHER}"
     local seeker="${4:-$DEFAULT_SEEKER}"
@@ -143,7 +143,7 @@ init_state() {
     local new_state
     new_state=$(jq -n \
         --arg started_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-        --argjson erdos "$erdos" \
+        --argjson enricher "$enricher" \
         --argjson aristotle "$aristotle" \
         --argjson researcher "$researcher" \
         --argjson seeker "$seeker" \
@@ -153,7 +153,7 @@ init_state() {
             started_at: $started_at,
             running: true,
             config: {
-                erdos: $erdos,
+                enricher: $enricher,
                 aristotle: $aristotle,
                 researcher: $researcher,
                 seeker: $seeker,
@@ -163,7 +163,7 @@ init_state() {
             session_stats: (
                 if ($prev_stats | length) > 0 then $prev_stats
                 else {
-                    stubs_enhanced: 0,
+                    entries_enriched: 0,
                     proofs_submitted: 0,
                     proofs_integrated: 0,
                     problems_selected: 0,
@@ -204,7 +204,7 @@ check_script() {
 
 # Command: start
 cmd_start() {
-    local erdos=$DEFAULT_ERDOS
+    local enricher=$DEFAULT_ENRICHER
     local aristotle=$DEFAULT_ARISTOTLE
     local researcher=$DEFAULT_RESEARCHER
     local seeker=$DEFAULT_SEEKER
@@ -213,8 +213,8 @@ cmd_start() {
     # Parse options
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --erdos)
-                erdos="$2"
+            --enricher)
+                enricher="$2"
                 shift 2
                 ;;
             --aristotle)
@@ -242,9 +242,9 @@ cmd_start() {
     done
 
     # Validate counts
-    if [[ $erdos -gt $MAX_ERDOS ]]; then
-        echo -e "${YELLOW}Warning: Erdős count $erdos exceeds max $MAX_ERDOS, using $MAX_ERDOS${NC}"
-        erdos=$MAX_ERDOS
+    if [[ $enricher -gt $MAX_ENRICHER ]]; then
+        echo -e "${YELLOW}Warning: Enricher count $enricher exceeds max $MAX_ENRICHER, using $MAX_ENRICHER${NC}"
+        enricher=$MAX_ENRICHER
     fi
     if [[ $aristotle -gt $MAX_ARISTOTLE ]]; then
         echo -e "${YELLOW}Warning: Aristotle count $aristotle exceeds max $MAX_ARISTOTLE, using $MAX_ARISTOTLE${NC}"
@@ -266,7 +266,7 @@ cmd_start() {
     echo -e "${BOLD}Starting Lean Genius Mathematical Orchestration${NC}"
     echo ""
     echo -e "Configuration:"
-    echo "  Erdős Enhancers: $erdos"
+    echo "  Enrichers: $enricher"
     echo "  Aristotle Agents: $aristotle"
     echo "  Researchers: $researcher"
     echo "  Seekers: $seeker"
@@ -277,18 +277,18 @@ cmd_start() {
     migrate_state_file
 
     # Initialize state
-    init_state "$erdos" "$aristotle" "$researcher" "$seeker" "$deployer"
+    init_state "$enricher" "$aristotle" "$researcher" "$seeker" "$deployer"
 
     # Start agents
     local started=0
 
-    # Erdős enhancers
-    if [[ $erdos -gt 0 ]]; then
-        echo -e "${BLUE}Starting $erdos Erdős enhancer(s)...${NC}"
-        if check_script "./scripts/erdos/parallel-enhance.sh"; then
-            ./scripts/erdos/parallel-enhance.sh "$erdos" &
+    # Enrichers
+    if [[ $enricher -gt 0 ]]; then
+        echo -e "${BLUE}Starting $enricher Enricher(s)...${NC}"
+        if check_script "./scripts/enricher/parallel-enrich.sh"; then
+            ./scripts/enricher/parallel-enrich.sh "$enricher" &
             sleep 2
-            echo -e "${GREEN}✓ Erdős enhancers launched${NC}"
+            echo -e "${GREEN}✓ Enrichers launched${NC}"
             started=$((started + 1))
         fi
     fi
@@ -353,10 +353,10 @@ cmd_start() {
 # Helper: Get all known agent tmux session names
 get_all_agent_sessions() {
     local sessions=()
-    # Erdős enhancers
+    # Enrichers
     for i in 1 2 3 4 5; do
-        if tmux has-session -t "erdos-enhancer-$i" 2>/dev/null; then
-            sessions+=("erdos-enhancer-$i")
+        if tmux has-session -t "enricher-$i" 2>/dev/null; then
+            sessions+=("enricher-$i")
         fi
     done
     # Aristotle
@@ -800,7 +800,7 @@ daemon_log() {
 get_agent_type() {
     local session="$1"
     case "$session" in
-        erdos-enhancer-*) echo "erdos" ;;
+        enricher-*) echo "enricher" ;;
         aristotle-agent)  echo "aristotle" ;;
         researcher-*)     echo "researcher" ;;
         seeker-agent)     echo "seeker" ;;
@@ -823,13 +823,13 @@ respawn_agent() {
     sleep 1
 
     case "$agent_type" in
-        erdos)
-            # Spawn a specific enhancer slot directly (parallel-enhance.sh refuses
-            # to start if any enhancer is already running, so we inline the logic)
+        enricher)
+            # Spawn a specific enricher slot directly (parallel-enrich.sh refuses
+            # to start if any enricher is already running, so we inline the logic)
             local agent_num="${session##*-}"
-            local worktree_dir=".loom/worktrees/enhancer-$agent_num"
-            local branch="feature/enhancer-$agent_num"
-            local enhancer_id="enhancer-$agent_num"
+            local worktree_dir=".loom/worktrees/enricher-$agent_num"
+            local branch="feature/enricher-$agent_num"
+            local enricher_id="enricher-$agent_num"
             local log_file=".loom/logs/$session.log"
             local prompt_file=".loom/logs/$session-prompt.md"
             local repo_root
@@ -847,23 +847,19 @@ respawn_agent() {
             if [[ -f "$worktree_dir/.gitmodules" ]]; then
                 (cd "$worktree_dir" && git submodule update --init --recursive 2>/dev/null) || true
             fi
-            if [[ -d "proofs/.lake" ]] && [[ -d "$worktree_dir/proofs" ]]; then
-                rm -rf "$worktree_dir/proofs/.lake"
-                ln -s "$repo_root/proofs/.lake" "$worktree_dir/proofs/.lake"
-            fi
 
             # Create tmux session and launch Claude
             tmux new-session -d -s "$session" -c "$repo_root/$worktree_dir"
             sleep 0.3
-            tmux send-keys -t "$session" "export ENHANCER_ID='$enhancer_id'" Enter
+            tmux send-keys -t "$session" "export ENRICHER_ID='$enricher_id'" Enter
             sleep 0.2
             tmux send-keys -t "$session" "export REPO_ROOT='$repo_root'" Enter
             sleep 0.2
-            local prompt="You are $enhancer_id. Read $repo_root/$prompt_file for your instructions, then start the enhancement workflow."
+            local prompt="You are $enricher_id. Read $repo_root/$prompt_file for your instructions, then start the enrichment workflow."
             local wrapper_script="$repo_root/scripts/agents/claude-wrapper.sh"
             tmux send-keys -t "$session" "$wrapper_script --prompt '$prompt' --log '$repo_root/$log_file' --max-retries 5" Enter
             sleep 1
-            daemon_log "INFO" "Erdos enhancer $agent_num respawned (session: $session)"
+            daemon_log "INFO" "Enricher $agent_num respawned (session: $session)"
             ;;
         aristotle)
             if check_script "./scripts/aristotle/launch-agent.sh" 2>/dev/null; then
@@ -935,14 +931,14 @@ is_cooldown_elapsed() {
 
 # Helper: Get work queue stats (with timeout protection)
 get_work_queue_stats() {
-    local stubs="?"
+    local enrichment_targets="?"
     local candidates="0"
     local aristotle_jobs="0"
     local ready_prs="0"
 
-    # Stubs count (with 10s timeout)
-    if command -v npx &>/dev/null && [[ -f "scripts/erdos/find-stubs.ts" ]]; then
-        stubs=$(timeout 10 npx tsx scripts/erdos/find-stubs.ts --stats 2>/dev/null | grep -oE "Stubs needing enhancement: +[0-9]+" | grep -oE "[0-9]+" || echo "?")
+    # Enrichment targets count (with 10s timeout)
+    if command -v npx &>/dev/null && [[ -f "scripts/enricher/find-targets.ts" ]]; then
+        enrichment_targets=$(timeout 10 npx tsx scripts/enricher/find-targets.ts --stats 2>/dev/null | grep -oE "Entries needing enrichment: +[0-9]+" | grep -oE "[0-9]+" || echo "?")
     fi
 
     # Research candidates
@@ -958,7 +954,7 @@ get_work_queue_stats() {
     # PRs ready to merge
     ready_prs=$(timeout 10 gh pr list --label "loom:pr" --json number 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
 
-    echo "$stubs $candidates $aristotle_jobs $ready_prs"
+    echo "$enrichment_targets $candidates $aristotle_jobs $ready_prs"
 }
 
 # Helper: Write daemon state to state file
@@ -984,7 +980,7 @@ process_completion_signals() {
     # Ensure completions directory exists
     mkdir -p "$COMPLETIONS_DIR/archive"
 
-    local stubs=0
+    local enriched=0
     local proofs=0
     local integrated=0
     local selected=0
@@ -992,14 +988,14 @@ process_completion_signals() {
     local researched=0
 
     # Count signals by type (use find to avoid glob expansion issues)
-    stubs=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'stub-enhanced-*' -type f 2>/dev/null | wc -l | tr -d ' ')
+    enriched=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'enrichment-completed-*' -type f 2>/dev/null | wc -l | tr -d ' ')
     proofs=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'proof-submitted-*' -type f 2>/dev/null | wc -l | tr -d ' ')
     integrated=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'proof-integrated-*' -type f 2>/dev/null | wc -l | tr -d ' ')
     selected=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'problem-selected-*' -type f 2>/dev/null | wc -l | tr -d ' ')
     deploys=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'deployment-*' -type f 2>/dev/null | wc -l | tr -d ' ')
     researched=$(find "$COMPLETIONS_DIR" -maxdepth 1 -name 'research-completed-*' -type f 2>/dev/null | wc -l | tr -d ' ')
 
-    local total=$((stubs + proofs + integrated + selected + deploys + researched))
+    local total=$((enriched + proofs + integrated + selected + deploys + researched))
 
     # Update state file if any completions
     if [[ $total -gt 0 ]]; then
@@ -1007,13 +1003,13 @@ process_completion_signals() {
             local tmp
             tmp=$(mktemp)
             jq \
-                --argjson stubs "$stubs" \
+                --argjson enriched "$enriched" \
                 --argjson proofs "$proofs" \
                 --argjson integrated "$integrated" \
                 --argjson selected "$selected" \
                 --argjson deploys "$deploys" \
                 --argjson researched "$researched" \
-                '.session_stats.stubs_enhanced += $stubs |
+                '.session_stats.entries_enriched += $enriched |
                  .session_stats.proofs_submitted += $proofs |
                  .session_stats.proofs_integrated += $integrated |
                  .session_stats.problems_selected += $selected |
@@ -1022,10 +1018,10 @@ process_completion_signals() {
                 "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
         fi
 
-        daemon_log "INFO" "Stats updated: +$stubs stubs, +$proofs proofs, +$integrated integrated, +$selected selected, +$deploys deploys, +$researched researched"
+        daemon_log "INFO" "Stats updated: +$enriched enriched, +$proofs proofs, +$integrated integrated, +$selected selected, +$deploys deploys, +$researched researched"
 
         # Archive signals (preserve for debugging but don't recount)
-        find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'stub-enhanced-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
+        find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'enrichment-completed-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
         find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'proof-submitted-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
         find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'proof-integrated-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
         find "$COMPLETIONS_DIR" -maxdepth 1 -type f -name 'problem-selected-*' -exec mv {} "$COMPLETIONS_DIR/archive/" \; 2>/dev/null || true
@@ -1046,7 +1042,7 @@ daemon_cleanup() {
 # Command: daemon - Continuous monitoring loop
 cmd_daemon() {
     local interval=$DEFAULT_DAEMON_INTERVAL
-    local erdos=$DEFAULT_ERDOS
+    local enricher=$DEFAULT_ENRICHER
     local aristotle=$DEFAULT_ARISTOTLE
     local researcher=$DEFAULT_RESEARCHER
     local seeker=$DEFAULT_SEEKER
@@ -1059,8 +1055,8 @@ cmd_daemon() {
                 interval="$2"
                 shift 2
                 ;;
-            --erdos)
-                erdos="$2"
+            --enricher)
+                enricher="$2"
                 shift 2
                 ;;
             --aristotle)
@@ -1117,10 +1113,10 @@ cmd_daemon() {
     trap 'daemon_log "INFO" "Received SIGINT"; exit 0' INT
 
     daemon_log "INFO" "Starting daemon (PID $$, interval ${interval}s)"
-    daemon_log "INFO" "Pool config: erdos=$erdos, aristotle=$aristotle, researcher=$researcher, seeker=$seeker, deployer=$deployer"
+    daemon_log "INFO" "Pool config: enricher=$enricher, aristotle=$aristotle, researcher=$researcher, seeker=$seeker, deployer=$deployer"
 
     # Start initial agents via cmd_start
-    cmd_start --erdos "$erdos" --aristotle "$aristotle" --researcher "$researcher" --seeker "$seeker" --deployer "$deployer"
+    cmd_start --enricher "$enricher" --aristotle "$aristotle" --researcher "$researcher" --seeker "$seeker" --deployer "$deployer"
 
     local cycle_count=0
     local total_respawns=0
@@ -1213,25 +1209,25 @@ cmd_daemon() {
         # 2b. Pool gap detection: spawn missing agents whose sessions vanished
         # (get_all_agent_sessions only returns existing sessions, so if a session
         # exits entirely, the health check above never sees it)
-        local erdos_active=0 researcher_active=0 aristotle_active=0 seeker_active=0 deployer_active=0
+        local enricher_active=0 researcher_active=0 aristotle_active=0 seeker_active=0 deployer_active=0
         for i in 1 2 3 4 5; do
-            tmux has-session -t "erdos-enhancer-$i" 2>/dev/null && erdos_active=$((erdos_active + 1))
+            tmux has-session -t "enricher-$i" 2>/dev/null && enricher_active=$((enricher_active + 1))
             tmux has-session -t "researcher-$i" 2>/dev/null && researcher_active=$((researcher_active + 1))
         done
         tmux has-session -t "aristotle-agent" 2>/dev/null && aristotle_active=1
         tmux has-session -t "seeker-agent" 2>/dev/null && seeker_active=1
         tmux has-session -t "deployer" 2>/dev/null && deployer_active=1
 
-        if [[ $erdos_active -lt $erdos ]]; then
-            local missing_erdos=$((erdos - erdos_active))
-            daemon_log "INFO" "Pool gap: erdos has $erdos_active/$erdos, spawning $missing_erdos"
+        if [[ $enricher_active -lt $enricher ]]; then
+            local missing_enricher=$((enricher - enricher_active))
+            daemon_log "INFO" "Pool gap: enricher has $enricher_active/$enricher, spawning $missing_enricher"
             for i in $(seq 1 5); do
-                [[ $missing_erdos -le 0 ]] && break
-                if ! tmux has-session -t "erdos-enhancer-$i" 2>/dev/null; then
-                    if is_cooldown_elapsed "erdos-enhancer-$i"; then
-                        respawn_agent "erdos-enhancer-$i"
+                [[ $missing_enricher -le 0 ]] && break
+                if ! tmux has-session -t "enricher-$i" 2>/dev/null; then
+                    if is_cooldown_elapsed "enricher-$i"; then
+                        respawn_agent "enricher-$i"
                         total_respawns=$((total_respawns + 1))
-                        missing_erdos=$((missing_erdos - 1))
+                        missing_enricher=$((missing_enricher - 1))
                     fi
                 fi
             done
@@ -1273,14 +1269,14 @@ cmd_daemon() {
         # 3. Work queue assessment (with timeout protection)
         local queue_stats
         queue_stats=$(get_work_queue_stats)
-        local stubs candidates aristotle_jobs ready_prs
-        read -r stubs candidates aristotle_jobs ready_prs <<< "$queue_stats"
+        local enrichment_targets candidates aristotle_jobs ready_prs
+        read -r enrichment_targets candidates aristotle_jobs ready_prs <<< "$queue_stats"
 
         # 4. Process completion signals and update session stats
         process_completion_signals
 
         # 5. Log cycle summary
-        daemon_log "INFO" "Cycle $cycle_count: running=$running_count, idle=$idle_count, completed=$completed_count, stuck=$stuck_count, respawned=$cycle_respawns | queues: stubs=$stubs, candidates=$candidates, aristotle=$aristotle_jobs, prs=$ready_prs"
+        daemon_log "INFO" "Cycle $cycle_count: running=$running_count, idle=$idle_count, completed=$completed_count, stuck=$stuck_count, respawned=$cycle_respawns | queues: enrichment=$enrichment_targets, candidates=$candidates, aristotle=$aristotle_jobs, prs=$ready_prs"
 
         # 6. Update state file with daemon stats
         update_daemon_state "$cycle_count" "$total_respawns"
@@ -1324,9 +1320,9 @@ cmd_stop() {
         local stopped=0
 
         # Force stop: kill tmux sessions directly
-        echo -e "${BLUE}Killing Erdős enhancer sessions...${NC}"
-        if [[ -x "./scripts/erdos/parallel-enhance.sh" ]]; then
-            ./scripts/erdos/parallel-enhance.sh --stop 2>/dev/null || true
+        echo -e "${BLUE}Killing Enricher sessions...${NC}"
+        if [[ -x "./scripts/enricher/parallel-enrich.sh" ]]; then
+            ./scripts/enricher/parallel-enrich.sh --stop 2>/dev/null || true
             stopped=$((stopped + 1))
         fi
 
@@ -1357,7 +1353,7 @@ cmd_stop() {
         # Safety net: kill any remaining agent sessions
         echo -e "${BLUE}Catch-all: cleaning remaining agent sessions...${NC}"
         local remaining_sessions
-        remaining_sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E '^(erdos-enhancer-|researcher-|aristotle-agent$|seeker-agent$|deployer$)' || true)
+        remaining_sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E '^(enricher-|researcher-|aristotle-agent$|seeker-agent$|deployer$)' || true)
         if [[ -n "$remaining_sessions" ]]; then
             while IFS= read -r session; do
                 echo -e "  Killing stale session: $session"
@@ -1395,9 +1391,9 @@ cmd_stop() {
         echo -e "${GREEN}Created stop-all signal file${NC}"
 
         # Also signal each agent type through their own mechanisms
-        echo -e "${BLUE}Signaling Erdős enhancers...${NC}"
-        if [[ -x "./scripts/erdos/parallel-enhance.sh" ]]; then
-            ./scripts/erdos/parallel-enhance.sh --graceful-stop 2>/dev/null || true
+        echo -e "${BLUE}Signaling Enrichers...${NC}"
+        if [[ -x "./scripts/enricher/parallel-enrich.sh" ]]; then
+            ./scripts/enricher/parallel-enrich.sh --graceful-stop 2>/dev/null || true
         fi
 
         echo -e "${BLUE}Signaling Aristotle agent...${NC}"
@@ -1442,24 +1438,24 @@ cmd_spawn() {
     local agent_type="${1:-}"
 
     if [[ -z "$agent_type" ]]; then
-        echo -e "${RED}Error: Must specify agent type (erdos, aristotle, researcher, deployer)${NC}" >&2
+        echo -e "${RED}Error: Must specify agent type (enricher, aristotle, researcher, deployer)${NC}" >&2
         exit 1
     fi
 
     case "$agent_type" in
-        erdos)
-            echo -e "${BLUE}Spawning additional Erdős enhancer...${NC}"
+        enricher)
+            echo -e "${BLUE}Spawning additional Enricher...${NC}"
             # Find next available slot
             for i in 1 2 3 4 5; do
-                if ! tmux has-session -t "erdos-enhancer-$i" 2>/dev/null; then
-                    # Spawn single enhancer
-                    ./scripts/erdos/parallel-enhance.sh 1 &
+                if ! tmux has-session -t "enricher-$i" 2>/dev/null; then
+                    # Spawn single enricher
+                    ./scripts/enricher/parallel-enrich.sh 1 &
                     sleep 2
-                    echo -e "${GREEN}✓ Erdős enhancer spawned${NC}"
+                    echo -e "${GREEN}✓ Enricher spawned${NC}"
                     exit 0
                 fi
             done
-            echo -e "${YELLOW}All Erdős slots are full (max: $MAX_ERDOS)${NC}"
+            echo -e "${YELLOW}All Enricher slots are full (max: $MAX_ENRICHER)${NC}"
             ;;
         aristotle)
             echo -e "${BLUE}Spawning Aristotle agent...${NC}"
@@ -1505,7 +1501,7 @@ cmd_spawn() {
             ;;
         *)
             echo -e "${RED}Unknown agent type: $agent_type${NC}" >&2
-            echo "Valid types: erdos, aristotle, researcher, seeker, deployer"
+            echo "Valid types: enricher, aristotle, researcher, seeker, deployer"
             exit 1
             ;;
     esac
@@ -1518,36 +1514,36 @@ cmd_scale() {
 
     if [[ -z "$agent_type" || -z "$count" ]]; then
         echo -e "${RED}Error: Must specify agent type and count${NC}" >&2
-        echo "Usage: $0 scale <erdos|researcher> <count>"
+        echo "Usage: $0 scale <enricher|researcher> <count>"
         exit 1
     fi
 
     case "$agent_type" in
-        erdos)
-            if [[ $count -gt $MAX_ERDOS ]]; then
-                echo -e "${YELLOW}Count $count exceeds max $MAX_ERDOS, using $MAX_ERDOS${NC}"
-                count=$MAX_ERDOS
+        enricher)
+            if [[ $count -gt $MAX_ENRICHER ]]; then
+                echo -e "${YELLOW}Count $count exceeds max $MAX_ENRICHER, using $MAX_ENRICHER${NC}"
+                count=$MAX_ENRICHER
             fi
 
             # Count current
             local current=0
             for i in 1 2 3 4 5; do
-                if tmux has-session -t "erdos-enhancer-$i" 2>/dev/null; then
+                if tmux has-session -t "enricher-$i" 2>/dev/null; then
                     current=$((current + 1))
                 fi
             done
 
             if [[ $count -gt $current ]]; then
                 local to_add=$((count - current))
-                echo -e "${BLUE}Scaling Erdős enhancers from $current to $count (adding $to_add)...${NC}"
-                ./scripts/erdos/parallel-enhance.sh "$to_add" &
+                echo -e "${BLUE}Scaling Enrichers from $current to $count (adding $to_add)...${NC}"
+                ./scripts/enricher/parallel-enrich.sh "$to_add" &
                 sleep 2
-                echo -e "${GREEN}✓ Scaled to $count Erdős enhancers${NC}"
+                echo -e "${GREEN}✓ Scaled to $count Enrichers${NC}"
             elif [[ $count -lt $current ]]; then
                 echo -e "${YELLOW}Scale down not implemented - stop agents manually${NC}"
                 echo "Current: $current, Requested: $count"
             else
-                echo -e "${GREEN}Already at $count Erdős enhancers${NC}"
+                echo -e "${GREEN}Already at $count Enrichers${NC}"
             fi
             ;;
         researcher)
@@ -1582,7 +1578,7 @@ cmd_scale() {
             ;;
         *)
             echo -e "${RED}Unknown agent type: $agent_type${NC}" >&2
-            echo "Scalable types: erdos, researcher"
+            echo "Scalable types: enricher, researcher"
             exit 1
             ;;
     esac

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -65,10 +65,10 @@ get_session_uptime() {
     fi
 }
 
-# Helper: Count stubs needing enhancement
-count_stubs() {
-    if command -v npx &>/dev/null && [[ -f "scripts/erdos/find-stubs.ts" ]]; then
-        npx tsx scripts/erdos/find-stubs.ts --stats 2>/dev/null | grep -oE "Stubs needing enhancement: +[0-9]+" | grep -oE "[0-9]+" || echo "?"
+# Helper: Count proofs needing enrichment
+count_enrichment_targets() {
+    if command -v npx &>/dev/null && [[ -f "scripts/enricher/find-targets.ts" ]]; then
+        npx tsx scripts/enricher/find-targets.ts --stats 2>/dev/null | grep -oE "Entries needing enrichment: +[0-9]+" | grep -oE "[0-9]+" || echo "?"
     else
         echo "?"
     fi
@@ -124,16 +124,16 @@ gather_status() {
     fi
 
     # Check tmux sessions
-    local erdos_sessions=()
+    local enricher_sessions=()
     local aristotle_status="stopped"
     local researcher_sessions=()
     local seeker_status="stopped"
     local deployer_status="stopped"
 
-    # Erdős enhancers
+    # Enrichers
     for i in 1 2 3 4 5; do
-        if session_exists "erdos-enhancer-$i"; then
-            erdos_sessions+=("erdos-enhancer-$i:$(get_session_uptime "erdos-enhancer-$i")")
+        if session_exists "enricher-$i"; then
+            enricher_sessions+=("enricher-$i:$(get_session_uptime "enricher-$i")")
         fi
     done
 
@@ -160,25 +160,25 @@ gather_status() {
     fi
 
     # Work queue counts
-    local stubs_count
+    local enrichment_count
     local aristotle_jobs
     local research_problems
     local ready_prs
 
-    stubs_count=$(count_stubs)
+    enrichment_count=$(count_enrichment_targets)
     aristotle_jobs=$(count_aristotle_jobs)
     research_problems=$(count_research_problems)
     ready_prs=$(count_ready_prs)
 
     # Session stats from state file
-    local stubs_enhanced=0
+    local entries_enriched=0
     local proofs_submitted=0
     local problems_selected=0
     local deployments=0
     local research_completed=0
 
     if [[ -f "$STATE_FILE" ]]; then
-        stubs_enhanced=$(jq -r '.session_stats.stubs_enhanced // 0' "$STATE_FILE")
+        entries_enriched=$(jq -r '.session_stats.entries_enriched // 0' "$STATE_FILE")
         proofs_submitted=$(jq -r '.session_stats.proofs_submitted // 0' "$STATE_FILE")
         problems_selected=$(jq -r '.session_stats.problems_selected // 0' "$STATE_FILE")
         deployments=$(jq -r '.session_stats.deployments // 0' "$STATE_FILE")
@@ -195,15 +195,15 @@ gather_status() {
     "started_at": "$started_at"
   },
   "work_queue": {
-    "stubs_needing_enhancement": "$stubs_count",
+    "proofs_needing_enrichment": "$enrichment_count",
     "aristotle_pending": $aristotle_jobs,
     "research_available": $research_problems,
     "prs_ready": $ready_prs
   },
   "agents": {
-    "erdos": {
-      "count": ${#erdos_sessions[@]},
-      "sessions": $(printf '%s\n' "${erdos_sessions[@]:-}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+    "enricher": {
+      "count": ${#enricher_sessions[@]},
+      "sessions": $(printf '%s\n' "${enricher_sessions[@]:-}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
     },
     "aristotle": {
       "status": "${aristotle_status%%:*}",
@@ -223,7 +223,7 @@ gather_status() {
     }
   },
   "session_stats": {
-    "stubs_enhanced": $stubs_enhanced,
+    "entries_enriched": $entries_enriched,
     "proofs_submitted": $proofs_submitted,
     "problems_selected": $problems_selected,
     "deployments": $deployments,
@@ -248,9 +248,7 @@ EOF
 
         # Work Queue
         echo -e "  ${CYAN}Work Queue:${NC}"
-        if [[ "$stubs_count" != "0" ]]; then
-            echo "    Stubs needing enhancement: $stubs_count"
-        fi
+        echo "    Proofs needing enrichment: $enrichment_count"
         echo "    Aristotle jobs pending: $aristotle_jobs"
         echo "    Research problems available: $research_problems"
         echo "    PRs ready to merge: $ready_prs"
@@ -259,15 +257,17 @@ EOF
         # Agent Pool
         echo -e "  ${CYAN}Agent Pool:${NC}"
 
-        # Erdős (only shown when active, since enhancement campaign is complete)
-        local erdos_count=${#erdos_sessions[@]}
-        if [[ $erdos_count -gt 0 ]]; then
-            echo -e "    ${BOLD}Erdős Enhancers:${NC} ${GREEN}$erdos_count active${NC}"
-            for session in "${erdos_sessions[@]}"; do
+        # Enrichers
+        local enricher_count=${#enricher_sessions[@]}
+        if [[ $enricher_count -gt 0 ]]; then
+            echo -e "    ${BOLD}Enrichers:${NC} ${GREEN}$enricher_count active${NC}"
+            for session in "${enricher_sessions[@]}"; do
                 local name="${session%%:*}"
                 local uptime="${session#*:}"
                 echo "      $name: Running ($uptime)"
             done
+        else
+            echo -e "    ${BOLD}Enrichers:${NC} ${YELLOW}0 active${NC}"
         fi
 
         # Aristotle
@@ -310,7 +310,7 @@ EOF
 
         # Session Stats
         echo -e "  ${CYAN}Session Stats:${NC}"
-        echo "    Stubs enhanced: $stubs_enhanced"
+        echo "    Entries enriched: $entries_enriched"
         echo "    Proofs submitted: $proofs_submitted"
         echo "    Research completed: $research_completed"
         echo "    Problems selected: $problems_selected"

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -1,0 +1,1 @@
+{"version": 1, "entries": {}}


### PR DESCRIPTION
## Summary
- All 1,764 Erdős stubs are enhanced — enhancer agents now complete instantly with no work
- Repurposes them into **enricher agents** that continuously iterate over all 1,291 proof gallery entries, improving quality on each pass
- Entries with fewer passes and lower quality scores are prioritized via `(1 / (passes + 1)) * (100 - quality)`

## Changes
- **New**: `scripts/enricher/` — `find-targets.ts`, `claim-target.sh`, `parallel-enrich.sh`
- **New**: `.lean/roles/enricher.md` — agent role with enrichment instructions
- **New**: `src/data/proofs/enrichment-tracker.json` — pass tracking (initialized empty)
- **Modified**: `scripts/lean/launch.sh` — replaced erdos → enricher throughout (defaults, options, spawn, scale, daemon)
- **Modified**: `scripts/lean/status.sh` — renamed display, updated work queue
- **Modified**: `CLAUDE.md` — updated agent table and pool config

## Test plan
- [x] `npx tsx scripts/enricher/find-targets.ts --stats` → shows 321 entries needing enrichment
- [x] `./scripts/enricher/claim-target.sh status` → works, shows empty claims
- [x] `./scripts/lean/launch.sh --help` → shows enricher in all options
- [x] `./scripts/lean/status.sh` → displays "Enrichers" and "Proofs needing enrichment: 321"
- [ ] `./scripts/lean/launch.sh spawn enricher` → spawns agent successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)