### PR TITLE
Enrich area-of-circle: deepen Wiedijk #9 annotations

### DIFF
--- a/src/data/proofs/area-of-circle/annotations.json
+++ b/src/data/proofs/area-of-circle/annotations.json
@@ -2,43 +2,61 @@
   {
     "id": "ann-intro",
     "proofId": "area-of-circle",
-    "range": {"startLine": 4, "endLine": 50},
+    "range": {"startLine": 1, "endLine": 50},
     "type": "concept",
-    "title": "Area of a Circle",
-    "content": "The most fundamental formula in geometry:\n\n$$A = \\pi r^2$$\n\n**Wiedijk #9** on the list of 100 famous theorems.\n\n**Historical note**: Archimedes proved this around 250 BCE using the **method of exhaustion** — an ancient precursor to calculus.",
+    "title": "Introduction: Area of a Circle (Wiedijk #9)",
+    "content": "The file opens with imports of `Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls` (providing `Complex.volume_ball`) and `Mathlib.Tactic`. The extensive doc comment establishes this as Wiedijk #9 — one of the 100 most famous theorems. It explains the measure-theoretic approach: area is formalized as Lebesgue measure in $\\mathbb{R}^2$, modeled via $\\mathbb{C}$. The historical note credits Archimedes (c. 287–212 BCE) with the first rigorous proof using the method of exhaustion, where he showed the area equals that of a right triangle with base = circumference and height = radius.",
+    "mathContext": "The method of exhaustion, formalized by Eudoxus of Cnidus and perfected by Archimedes, proves equalities by showing that the difference between two quantities can be made smaller than any given positive value — essentially the $\\varepsilon$-$\\delta$ definition of a limit. Archimedes inscribed $n$-gons with area $\\frac{n}{2}r^2 \\sin(2\\pi/n) \\to \\pi r^2$ as $n \\to \\infty$.",
     "significance": "critical",
-    "relatedConcepts": ["pi", "Archimedes", "Lebesgue measure"]
+    "relatedConcepts": ["Lebesgue measure", "Archimedes", "Wiedijk 100 theorems", "method of exhaustion"],
+    "prerequisites": ["measure theory basics", "complex plane as ℝ²", "Mathlib library structure"]
   },
   {
     "id": "ann-main-theorem",
     "proofId": "area-of-circle",
-    "range": {"startLine": 63, "endLine": 76},
+    "range": {"startLine": 52, "endLine": 84},
     "type": "theorem",
-    "title": "Main Theorem",
-    "content": "**Area of a Circle (Wiedijk #9)**:\n\n$$\\text{volume}(\\text{ball}(c, r)) = \\pi r^2$$\n\nThe proof is a **one-liner** — just applying Mathlib's `Complex.volume_ball`! This shows the power of building on a library.",
-    "mathContext": "$A = \\pi r^2$",
+    "title": "Main Theorems: Open and Closed Disk Area = πr²",
+    "content": "The core results. `area_of_circle` proves that the Lebesgue measure of an open ball in $\\mathbb{C}$ with center $c$ and radius $r$ equals $r^2 \\cdot \\pi$, expressed as `ENNReal.ofReal r ^ 2 * ↑NNReal.pi`. The proof is a single line: `Complex.volume_ball center r`. Similarly, `area_of_closed_disk` proves the same for closed balls via `Complex.volume_closedBall`. The equality of open and closed disk areas reflects the measure-theoretic fact that the boundary circle (a 1-dimensional manifold) has 2-dimensional Lebesgue measure zero.",
+    "mathContext": "The result is stated using `ENNReal` (extended non-negative reals $[0, \\infty]$) because Lebesgue measure takes values in $\\overline{\\mathbb{R}_{\\geq 0}}$. The `ENNReal.ofReal r` coercion maps negative $r$ to 0, handling the edge case of negative radius. `NNReal.pi` is $\\pi$ as a non-negative real. The `open MeasureTheory Metric` command brings `volume` and `ball`/`closedBall` into scope.",
     "significance": "critical",
-    "relatedConcepts": ["Mathlib", "Complex.volume_ball"]
+    "relatedConcepts": ["Complex.volume_ball", "Complex.volume_closedBall", "ENNReal", "NNReal.pi", "MeasureTheory.volume"],
+    "prerequisites": ["Lebesgue measure", "metric balls in ℂ", "ENNReal coercions"]
   },
   {
-    "id": "ann-unit-disk",
+    "id": "ann-special-cases",
     "proofId": "area-of-circle",
-    "range": {"startLine": 88, "endLine": 115},
+    "range": {"startLine": 86, "endLine": 115},
     "type": "theorem",
-    "title": "Special Cases",
-    "content": "**Special cases**:\n\n- **Unit disk** (r = 1): Area = π\n- **Zero radius**: Area = 0 (empty ball)\n- **Closed vs open disk**: Same area — the boundary (circle) has measure 0\n- **Negative radius**: Empty set, area = 0",
-    "significance": "minor",
-    "relatedConcepts": ["unit disk", "measure zero", "edge cases"]
+    "title": "Special Cases: Unit Disk, Zero Radius, Negative Radius",
+    "content": "Five corollaries exercise the main theorem at boundary values. `area_unit_disk` and `area_unit_closed_disk`: setting $r = 1$ gives area $\\pi$, proved by rewriting with `area_of_circle` and simplifying $1^2 = 1$. `area_zero_radius` and `area_zero_radius_closed`: $r = 0$ gives area 0 — the open ball is empty, the closed ball is a single point, both with measure 0. `area_negative_radius`: $r < 0$ gives area 0 since `ball_eq_empty` shows the ball is empty when $r \\leq 0$.",
+    "mathContext": "The `simp` tactic with `ENNReal.ofReal_one` simplifies $\\text{ofReal}(1)^2 \\cdot \\pi = \\pi$. The `ball_zero` lemma states $B(c, 0) = \\emptyset$ (strict inequality $|x - c| < 0$ is impossible). The `closedBall_zero` states $\\overline{B}(c, 0) = \\{c\\}$ (a singleton has measure 0 in $\\mathbb{R}^2$). These edge cases demonstrate the robustness of the measure-theoretic formulation.",
+    "significance": "supporting",
+    "relatedConcepts": ["ENNReal.ofReal_one", "ball_zero", "closedBall_zero", "ball_eq_empty"],
+    "prerequisites": ["ENNReal arithmetic", "metric ball edge cases", "measure of singletons"]
+  },
+  {
+    "id": "ann-significance",
+    "proofId": "area-of-circle",
+    "range": {"startLine": 117, "endLine": 136},
+    "type": "concept",
+    "title": "Why This Matters: Cross-Disciplinary Significance",
+    "content": "A doc section explaining the ubiquity of $A = \\pi r^2$. In **geometry**, it underpins circle, sphere, and curved surface theory. In **calculus**, it is the canonical polar coordinate integral $\\int_0^{2\\pi} \\int_0^r \\rho\\, d\\rho\\, d\\theta = \\pi r^2$. In **physics**, it governs intensity through circular apertures. In **probability**, the Gaussian integral $\\iint e^{-x^2-y^2}\\, dA = \\pi$ depends on it. In **engineering**, it appears in calculations for pipes, gears, and wheels. The appearance of $\\pi$ reflects the deep connection between circles and the circumference-to-diameter ratio.",
+    "mathContext": "The Gaussian integral connection is particularly deep: $\\int_{-\\infty}^{\\infty} e^{-x^2}\\, dx = \\sqrt{\\pi}$ is proved by squaring and converting to polar coordinates, where $A = \\pi r^2$ provides the area element $r\\, dr\\, d\\theta$. This is one of the most elegant applications of the circle area formula.",
+    "significance": "key",
+    "relatedConcepts": ["polar coordinates", "Gaussian integral", "circumference"],
+    "prerequisites": ["multivariable calculus", "change of variables", "probability theory"]
   },
   {
     "id": "ann-archimedes",
     "proofId": "area-of-circle",
-    "range": {"startLine": 138, "endLine": 148},
+    "range": {"startLine": 138, "endLine": 155},
     "type": "concept",
-    "title": "Archimedes' Insight",
-    "content": "Archimedes imagined the disk as **concentric thin rings**:\n\n$$dA = 2\\pi\\rho\\, d\\rho$$\n\nIntegrating:\n$$A = \\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$$\n\nThis is calculus **2000 years** before Newton and Leibniz!",
-    "mathContext": "$\\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$",
-    "significance": "major",
-    "relatedConcepts": ["Archimedes", "integration", "circumference"]
+    "title": "Archimedes' Insight: Concentric Ring Integration",
+    "content": "The final doc section connects the area formula to the circumference $C = 2\\pi r$ via the annular ring argument. Imagining the disk as concentric thin rings of radius $\\rho$ and width $d\\rho$: each ring has area $dA = 2\\pi\\rho\\, d\\rho$ (circumference times thickness). Integrating: $A = \\int_0^r 2\\pi\\rho\\, d\\rho = \\pi\\rho^2\\big|_0^r = \\pi r^2$. This is how Archimedes conceptualized the proof, viewing the disk as composed of infinitely many concentric circular strips — calculus 2000 years before Newton and Leibniz. The file ends with `#check` commands verifying the main theorems are accessible.",
+    "mathContext": "The annular ring argument is equivalent to computing $A(r) = \\int_0^r C(\\rho)\\, d\\rho = \\int_0^r 2\\pi\\rho\\, d\\rho$, giving the relationship $A'(r) = C(r) = 2\\pi r$. This derivative relationship — the circumference is the derivative of the area with respect to radius — generalizes to all dimensions: the surface area of an $n$-ball is the derivative of its volume with respect to radius.",
+    "significance": "key",
+    "relatedConcepts": ["circumference", "integration", "method of exhaustion", "fundamental theorem of calculus"],
+    "prerequisites": ["single-variable integration", "circumference formula", "Archimedes' method"]
   }
 ]

--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -7,28 +7,82 @@
     "author": "Archimedes (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Area_of_a_circle",
     "date": "~250 BCE",
-    "status": "verified",
+    "status": "complete",
     "tags": ["geometry", "measure-theory", "classic", "beginner"],
     "proofRepoPath": "Proofs/AreaOfCircle.lean",
     "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
-      {"theorem": "Complex.volume_ball", "description": "Volume of open ball in the complex plane", "module": "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls"},
-      {"theorem": "Complex.volume_closedBall", "description": "Volume of closed ball in the complex plane", "module": "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls"}
+      {"theorem": "Complex.volume_ball", "description": "Lebesgue measure of open ball in ℂ equals πr²", "module": "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls"},
+      {"theorem": "Complex.volume_closedBall", "description": "Lebesgue measure of closed ball in ℂ equals πr²", "module": "Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls"},
+      {"theorem": "MeasureTheory.volume", "description": "Lebesgue measure on measurable spaces", "module": "Mathlib.MeasureTheory.Measure.MeasureSpace"},
+      {"theorem": "NNReal.pi", "description": "π as a non-negative real number", "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"}
     ],
-    "originalContributions": ["Complete formalization using Lebesgue measure", "Pedagogical documentation of measure-theoretic approach"],
+    "originalContributions": [
+      "Complete formalization of A = πr² using Lebesgue measure in ℂ ≅ ℝ²",
+      "Proof that open and closed disks have equal area (boundary has measure zero)",
+      "Special cases: unit disk (area π), zero radius (area 0), negative radius (empty)",
+      "Pedagogical documentation connecting to Archimedes' method of exhaustion"
+    ],
     "dateAdded": "12/26/25",
     "wiedijkNumber": 9
   },
   "overview": {
-    "historicalContext": "The formula A = πr² was known to ancient civilizations, but Archimedes of Syracuse (c. 287-212 BCE) gave the first rigorous proof using the method of exhaustion—an ancient precursor to integral calculus.",
-    "problemStatement": "**Area of a Circle**:\n\nFor a disk D = {p ∈ ℝ² : |p - center| ≤ r} with radius r ≥ 0:\n$$\\text{Area}(D) = \\pi r^2$$",
-    "proofStrategy": "We use measure theory: the area is the Lebesgue measure of the 2-dimensional disk. Using the complex plane ℂ ≅ ℝ², we apply Mathlib's volume_ball theorem.",
-    "keyInsights": ["Area is formalized as Lebesgue measure in ℝ²", "The complex plane provides an elegant framework", "The formula generalizes to n-dimensional balls using the gamma function"]
+    "historicalContext": "The formula $A = \\pi r^2$ was known empirically to ancient Babylonians and Egyptians (the Rhind Papyrus, c. 1650 BCE, approximates $\\pi \\approx 256/81$). Archimedes of Syracuse (c. 287–212 BCE) gave the first rigorous proof using the **method of exhaustion**: he inscribed and circumscribed regular polygons with increasing numbers of sides, proving that the area of a circle equals that of a right triangle with legs equal to the circumference and radius. This argument anticipated integral calculus by nearly two millennia. In modern mathematics, the area is formalized as the Lebesgue measure of the 2-dimensional disk. The formula is #9 on Freek Wiedijk's list of 100 famous theorems formalized in proof assistants. The Lean 4 proof leverages Mathlib's `Complex.volume_ball`, which computes the volume of balls in $\\mathbb{C} \\cong \\mathbb{R}^2$ using the general $n$-dimensional volume formula involving the gamma function.",
+    "problemStatement": "**Area of a Circle (Wiedijk #9)**:\n\nFor a disk $D = \\{p \\in \\mathbb{R}^2 : |p - \\text{center}| \\leq r\\}$ with radius $r \\geq 0$:\n$$\\text{Area}(D) = \\pi r^2$$",
+    "proofStrategy": "The proof uses measure theory, identifying area with Lebesgue measure in 2 dimensions. By modeling $\\mathbb{R}^2$ as the complex plane $\\mathbb{C}$ (which Mathlib equips with a Lebesgue measure via its real inner product space structure), the main theorem reduces to a direct application of `Complex.volume_ball`. The key insight is that $\\mathbb{C}$ and $\\mathbb{R}^2$ are isomorphic as real inner product spaces, so the Lebesgue measure on $\\mathbb{C}$ agrees with the 2D Lebesgue measure. Special cases (unit disk, zero radius, negative radius, closed vs open) are derived as corollaries.",
+    "keyInsights": [
+      "Area is formalized as Lebesgue measure in $\\mathbb{R}^2$, connecting the ancient geometric concept to modern measure theory — the 'area' of a set is its $\\lambda^2$-measure",
+      "Using $\\mathbb{C} \\cong \\mathbb{R}^2$ as the ambient space gives the cleanest formulation: `Complex.volume_ball` directly yields $\\pi r^2$ without coordinate transformations",
+      "Open and closed disks have the same area because the boundary circle has Lebesgue measure zero — a fundamental property of lower-dimensional manifolds in measure theory",
+      "The general $n$-dimensional ball volume formula $V_n(r) = \\pi^{n/2} r^n / \\Gamma(n/2 + 1)$ specializes to $\\pi r^2$ for $n = 2$ via $\\Gamma(2) = 1$",
+      "Archimedes' method of exhaustion — approximating the disk by inscribed/circumscribed polygons — is the historical precursor to the Riemann integral, which in turn is subsumed by the Lebesgue integral used in this formalization"
+    ]
   },
   "sections": [
-    {"id": "header", "title": "Introduction", "startLine": 1, "endLine": 50, "summary": "Overview and historical context."},
-    {"id": "main-theorem", "title": "Main Theorem", "startLine": 52, "endLine": 80, "summary": "The area formula for open and closed disks."}
+    {
+      "id": "header-docs",
+      "title": "Introduction and Historical Context",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Imports `VolumeOfBalls` and `Tactic`, extensive doc comment covering what is proved ($A = \\pi r^2$), the Wiedijk #9 reference, the mathematical statement, the measure-theoretic approach via $\\mathbb{C} \\cong \\mathbb{R}^2$, proof status, Mathlib dependencies, and historical note on Archimedes."
+    },
+    {
+      "id": "main-theorems",
+      "title": "Main Theorems: Open and Closed Disk Area",
+      "startLine": 52,
+      "endLine": 84,
+      "summary": "Opens namespace and `MeasureTheory Metric`. Proves `area_of_circle`: volume of open ball in $\\mathbb{C}$ equals $r^2 \\cdot \\pi$ via `Complex.volume_ball`. Proves `area_of_closed_disk`: closed ball has the same measure via `Complex.volume_closedBall`."
+    },
+    {
+      "id": "special-cases",
+      "title": "Properties and Corollaries",
+      "startLine": 86,
+      "endLine": 115,
+      "summary": "Derives special cases: unit disk area is $\\pi$ (both open and closed), zero radius gives area 0 (point has measure zero), negative radius gives area 0 (empty ball). Uses `simp` with `ENNReal.ofReal_one`, `ball_zero`, `closedBall_zero`, and `ball_eq_empty`."
+    },
+    {
+      "id": "significance",
+      "title": "Why This Matters: Applications and Connections",
+      "startLine": 117,
+      "endLine": 136,
+      "summary": "Doc section explaining the significance of $A = \\pi r^2$ across mathematics and science: foundational for geometry, the first polar coordinate integral in calculus, essential in physics (optics, mechanics), probability (Gaussian integral), and engineering."
+    },
+    {
+      "id": "circumference-connection",
+      "title": "Connection to Circumference and Archimedes",
+      "startLine": 138,
+      "endLine": 155,
+      "summary": "Doc section explaining how $A = \\pi r^2$ relates to circumference $C = 2\\pi r$ via integration of annular rings: $dA = 2\\pi\\rho\\, d\\rho$, giving $A = \\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$. References Archimedes' conceptualization of the disk as concentric circular strips. Ends with `#check` commands and namespace closing."
+    }
   ],
-  "conclusion": {"summary": "The area of a circle is verified using modern measure theory, connecting ancient geometry to contemporary mathematics."}
+  "conclusion": {
+    "summary": "The area of a circle is verified using modern measure theory in Lean 4, connecting Archimedes' 2300-year-old result to contemporary Lebesgue integration. The proof is a one-liner — `Complex.volume_ball` — demonstrating the power of building on Mathlib's library of formalized mathematics. Both open and closed disk variants are proved, along with special cases for unit disk, zero radius, and negative radius.",
+    "implications": "This formalization demonstrates how measure theory subsumes classical geometry. The same framework that proves $A = \\pi r^2$ extends to higher-dimensional ball volumes ($V_n(r) = \\pi^{n/2} r^n / \\Gamma(n/2+1)$), surface areas, and general Riemannian volume computations. The Wiedijk #9 formalization contributes to the broader project of formalizing the 100 most famous theorems.",
+    "openQuestions": [
+      "Can the formalization be extended to prove the circumference formula C = 2πr via differentiation of the area?",
+      "How does the n-dimensional ball volume formula in Mathlib generalize this result?",
+      "Can the method of exhaustion (Archimedes' original proof) be formalized directly, without measure theory?"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Enriched `area-of-circle` meta.json: expanded from 2 to 5 sections covering all 155 lines, expanded `historicalContext` (Rhind Papyrus, Archimedes, method of exhaustion, gamma function), 5 `keyInsights`, added `openQuestions` and `implications`, expanded `mathlibDependencies`
- Enriched `area-of-circle` annotations.json: added `mathContext` and `prerequisites` to all annotations, fixed `significance` values, expanded content depth
- Fixed status from "verified" to "complete"

## Test plan
- [x] `pnpm build` passes successfully
- [x] All 5 annotations reference correct line ranges matching 155-line Lean file
- [x] All annotations have required enrichment fields
- [x] 5 sections cover full file with proper startLine/endLine

🤖 Generated with [Claude Code](https://claude.com/claude-code)