### PR TITLE
Fix metadata quality: add erdos tags, sourceUrls, and author

### DIFF
--- a/src/data/proofs/erdos-10/meta.json
+++ b/src/data/proofs/erdos-10/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos10Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "additive combinatorics",
       "primes",

--- a/src/data/proofs/erdos-101/meta.json
+++ b/src/data/proofs/erdos-101/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/101"
     ],
     "leanFile": "Proofs/Erdos101Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/101",
+    "erdosUrl": "https://erdosproblems.com/101"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1013/meta.json
+++ b/src/data/proofs/erdos-1013/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1013Problem.lean",
     "tags": [
+      "erdos",
       "graph theory",
       "chromatic number",
       "triangle-free graphs",

--- a/src/data/proofs/erdos-1014/meta.json
+++ b/src/data/proofs/erdos-1014/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/1014"
     ],
     "leanFile": "Proofs/Erdos1014Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1014",
+    "erdosUrl": "https://erdosproblems.com/1014"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1016/meta.json
+++ b/src/data/proofs/erdos-1016/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1016Problem.lean",
     "tags": [
+      "erdos",
       "graph theory",
       "pancyclic graphs",
       "cycles",

--- a/src/data/proofs/erdos-102/meta.json
+++ b/src/data/proofs/erdos-102/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos102Problem.lean",
     "tags": [
+      "erdos",
       "combinatorial-geometry",
       "incidence-geometry",
       "collinearity",

--- a/src/data/proofs/erdos-1032/meta.json
+++ b/src/data/proofs/erdos-1032/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/1032",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1032Problem.lean",
-    "tags": ["graph-theory", "chromatic-number", "critical-graphs", "minimum-degree"],
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "chromatic-number",
+      "critical-graphs",
+      "minimum-degree"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 1032,

--- a/src/data/proofs/erdos-1035/meta.json
+++ b/src/data/proofs/erdos-1035/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/1035",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1035Problem.lean",
-    "tags": ["graph-theory", "hypercube", "extremal-graph-theory", "minimum-degree"],
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "hypercube",
+      "extremal-graph-theory",
+      "minimum-degree"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 1035,
@@ -27,11 +33,41 @@
     ]
   },
   "sections": [
-    { "id": "hypercube", "title": "Hypercube Graph", "startLine": 23, "endLine": 38, "summary": "Defines hypercubeAdj via XOR and constructs hypercubeGraph as a SimpleGraph with symmetry and irreflexivity proofs." },
-    { "id": "degree", "title": "Minimum Degree", "startLine": 40, "endLine": 45, "summary": "Defines HasMinDegree as all vertices having at least d neighbours." },
-    { "id": "containment", "title": "Subgraph Containment", "startLine": 47, "endLine": 53, "summary": "Defines ContainsAsSubgraph via injective adjacency-preserving maps." },
-    { "id": "conjecture", "title": "Main Conjecture", "startLine": 55, "endLine": 63, "summary": "States ErdosProblem1035: existence of c > 0 for hypercube embedding under min degree condition." },
-    { "id": "alternatives", "title": "Alternative Questions and Basic Properties", "startLine": 65, "endLine": 99, "summary": "Two alternative formulations (larger host, exact threshold) and basic axioms on self-containment and completeness." }
+    {
+      "id": "hypercube",
+      "title": "Hypercube Graph",
+      "startLine": 23,
+      "endLine": 38,
+      "summary": "Defines hypercubeAdj via XOR and constructs hypercubeGraph as a SimpleGraph with symmetry and irreflexivity proofs."
+    },
+    {
+      "id": "degree",
+      "title": "Minimum Degree",
+      "startLine": 40,
+      "endLine": 45,
+      "summary": "Defines HasMinDegree as all vertices having at least d neighbours."
+    },
+    {
+      "id": "containment",
+      "title": "Subgraph Containment",
+      "startLine": 47,
+      "endLine": 53,
+      "summary": "Defines ContainsAsSubgraph via injective adjacency-preserving maps."
+    },
+    {
+      "id": "conjecture",
+      "title": "Main Conjecture",
+      "startLine": 55,
+      "endLine": 63,
+      "summary": "States ErdosProblem1035: existence of c > 0 for hypercube embedding under min degree condition."
+    },
+    {
+      "id": "alternatives",
+      "title": "Alternative Questions and Basic Properties",
+      "startLine": 65,
+      "endLine": 99,
+      "summary": "Two alternative formulations (larger host, exact threshold) and basic axioms on self-containment and completeness."
+    }
   ],
   "conclusion": {
     "summary": "The formalization captures Erdős Problem 1035 on hypercube embedding in dense graphs, with XOR-based Q_n construction, the main conjecture, and two alternative formulations. 0 sorries.",

--- a/src/data/proofs/erdos-1051/meta.json
+++ b/src/data/proofs/erdos-1051/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/1051",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1051Problem.lean",
-    "tags": ["number-theory", "irrationality", "series", "transcendence-theory"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "irrationality",
+      "series",
+      "transcendence-theory"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1051,

--- a/src/data/proofs/erdos-1053/meta.json
+++ b/src/data/proofs/erdos-1053/meta.json
@@ -23,7 +23,9 @@
       "https://erdosproblems.com/1053"
     ],
     "leanFile": "Proofs/Erdos1053Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1053",
+    "erdosUrl": "https://erdosproblems.com/1053"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1055/meta.json
+++ b/src/data/proofs/erdos-1055/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/1055"
     ],
     "leanFile": "Proofs/Erdos1055Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1055",
+    "erdosUrl": "https://erdosproblems.com/1055"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1056/meta.json
+++ b/src/data/proofs/erdos-1056/meta.json
@@ -23,7 +23,9 @@
       "https://erdosproblems.com/1056"
     ],
     "leanFile": "Proofs/Erdos1056Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1056",
+    "erdosUrl": "https://erdosproblems.com/1056"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1059/meta.json
+++ b/src/data/proofs/erdos-1059/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/1059"
     ],
     "leanFile": "Proofs/Erdos1059Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1059",
+    "erdosUrl": "https://erdosproblems.com/1059"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1062/meta.json
+++ b/src/data/proofs/erdos-1062/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/1062",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1062Problem.lean",
-    "tags": ["number-theory", "extremal-combinatorics", "divisibility"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "extremal-combinatorics",
+      "divisibility"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1062,

--- a/src/data/proofs/erdos-1065/meta.json
+++ b/src/data/proofs/erdos-1065/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/1065"
     ],
     "leanFile": "Proofs/Erdos1065Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1065",
+    "erdosUrl": "https://erdosproblems.com/1065"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1068/meta.json
+++ b/src/data/proofs/erdos-1068/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/1068"
     ],
     "leanFile": "Proofs/Erdos1068Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1068",
+    "erdosUrl": "https://erdosproblems.com/1068"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1071/meta.json
+++ b/src/data/proofs/erdos-1071/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/1071",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1071Problem.lean",
-    "tags": ["geometry", "combinatorial-geometry", "packing"],
+    "tags": [
+      "erdos",
+      "geometry",
+      "combinatorial-geometry",
+      "packing"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 1071,

--- a/src/data/proofs/erdos-1072/meta.json
+++ b/src/data/proofs/erdos-1072/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/1072"
     ],
     "leanFile": "Proofs/Erdos1072Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1072",
+    "erdosUrl": "https://erdosproblems.com/1072"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1073/meta.json
+++ b/src/data/proofs/erdos-1073/meta.json
@@ -8,7 +8,14 @@
     "sourceUrl": "https://erdosproblems.com/1073",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1073Problem.lean",
-    "tags": ["number-theory", "factorial", "composites", "divisibility", "wilson-theorem"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "factorial",
+      "composites",
+      "divisibility",
+      "wilson-theorem"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 1073,
@@ -27,11 +34,41 @@
     ]
   },
   "sections": [
-    { "id": "divisibility", "title": "Factorial Divisibility", "startLine": 21, "endLine": 33, "summary": "Defines DividesFactorialPlusOne, compositeFactorialSet, and factorialCompositeCount." },
-    { "id": "conjecture", "title": "Main Conjecture", "startLine": 35, "endLine": 42, "summary": "States ErdosProblem1073: A(x) ≤ x^ε for every ε > 0 and large x." },
-    { "id": "wilson", "title": "Wilson's Theorem Connection", "startLine": 44, "endLine": 52, "summary": "Wilson's theorem and its consequence for primes." },
-    { "id": "composites", "title": "Known Composites", "startLine": 54, "endLine": 64, "summary": "Proves 25 | 4!+1. States 121, 169 as axioms." },
-    { "id": "basic", "title": "Basic Properties", "startLine": 66, "endLine": 80, "summary": "Proves 1 divides all n!+1, divisibility transitivity, and states monotonicity." }
+    {
+      "id": "divisibility",
+      "title": "Factorial Divisibility",
+      "startLine": 21,
+      "endLine": 33,
+      "summary": "Defines DividesFactorialPlusOne, compositeFactorialSet, and factorialCompositeCount."
+    },
+    {
+      "id": "conjecture",
+      "title": "Main Conjecture",
+      "startLine": 35,
+      "endLine": 42,
+      "summary": "States ErdosProblem1073: A(x) ≤ x^ε for every ε > 0 and large x."
+    },
+    {
+      "id": "wilson",
+      "title": "Wilson's Theorem Connection",
+      "startLine": 44,
+      "endLine": 52,
+      "summary": "Wilson's theorem and its consequence for primes."
+    },
+    {
+      "id": "composites",
+      "title": "Known Composites",
+      "startLine": 54,
+      "endLine": 64,
+      "summary": "Proves 25 | 4!+1. States 121, 169 as axioms."
+    },
+    {
+      "id": "basic",
+      "title": "Basic Properties",
+      "startLine": 66,
+      "endLine": 80,
+      "summary": "Proves 1 divides all n!+1, divisibility transitivity, and states monotonicity."
+    }
   ],
   "conclusion": {
     "summary": "The formalization captures Erdős Problem 1073 on composites dividing factorial plus one, Wilson's theorem connection, known examples, and the subpolynomial growth conjecture. 0 sorries.",

--- a/src/data/proofs/erdos-1084/meta.json
+++ b/src/data/proofs/erdos-1084/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/1084"
     ],
     "leanFile": "Proofs/Erdos1084Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1084",
+    "erdosUrl": "https://erdosproblems.com/1084"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/1092"
     ],
     "leanFile": "Proofs/Erdos1092Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1092",
+    "erdosUrl": "https://erdosproblems.com/1092"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1093/meta.json
+++ b/src/data/proofs/erdos-1093/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/1093",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1093Problem.lean",
-    "tags": ["number-theory", "binomial-coefficients", "smooth-numbers"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "binomial-coefficients",
+      "smooth-numbers"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1093,

--- a/src/data/proofs/erdos-1094/meta.json
+++ b/src/data/proofs/erdos-1094/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/1094",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1094Problem.lean",
-    "tags": ["number-theory", "binomial-coefficients", "prime-factorization"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "binomial-coefficients",
+      "prime-factorization"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1094,

--- a/src/data/proofs/erdos-1097/meta.json
+++ b/src/data/proofs/erdos-1097/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1097Problem.lean",
     "tags": [
+      "erdos",
       "additive combinatorics",
       "arithmetic progressions",
       "Kakeya conjecture",

--- a/src/data/proofs/erdos-1103/meta.json
+++ b/src/data/proofs/erdos-1103/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/1103",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1103Problem.lean",
-    "tags": ["number-theory", "squarefree", "sumsets", "growth-rates"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "squarefree",
+      "sumsets",
+      "growth-rates"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 1103,
@@ -27,10 +33,34 @@
     ]
   },
   "sections": [
-    { "id": "definitions", "title": "Definitions", "startLine": 28, "endLine": 41, "summary": "Defines SquarefreeSumset and axiomatizes enumSet as the increasing enumeration of A." },
-    { "id": "conjecture", "title": "Main Conjecture", "startLine": 43, "endLine": 51, "summary": "ErdosProblem1103: every infinite squarefree-sumset sequence grows at least exponentially." },
-    { "id": "bounds", "title": "Known Bounds", "startLine": 53, "endLine": 73, "summary": "States van Doorn–Tao upper/lower bounds and Konyagin's finite-set bound." },
-    { "id": "basic", "title": "Basic Properties", "startLine": 75, "endLine": 95, "summary": "Singleton characterization, empty set, subset monotonicity, and squarefree_one." }
+    {
+      "id": "definitions",
+      "title": "Definitions",
+      "startLine": 28,
+      "endLine": 41,
+      "summary": "Defines SquarefreeSumset and axiomatizes enumSet as the increasing enumeration of A."
+    },
+    {
+      "id": "conjecture",
+      "title": "Main Conjecture",
+      "startLine": 43,
+      "endLine": 51,
+      "summary": "ErdosProblem1103: every infinite squarefree-sumset sequence grows at least exponentially."
+    },
+    {
+      "id": "bounds",
+      "title": "Known Bounds",
+      "startLine": 53,
+      "endLine": 73,
+      "summary": "States van Doorn–Tao upper/lower bounds and Konyagin's finite-set bound."
+    },
+    {
+      "id": "basic",
+      "title": "Basic Properties",
+      "startLine": 75,
+      "endLine": 95,
+      "summary": "Singleton characterization, empty set, subset monotonicity, and squarefree_one."
+    }
   ],
   "conclusion": {
     "summary": "The formalization captures Erdős Problem 1103 on squarefree sumsets with the main conjecture and known bounds by van Doorn–Tao and Konyagin. 0 sorries.",

--- a/src/data/proofs/erdos-1104/meta.json
+++ b/src/data/proofs/erdos-1104/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/1104"
     ],
     "leanFile": "Proofs/Erdos1104Problem.lean",
-    "sorries": 1
+    "sorries": 1,
+    "sourceUrl": "https://erdosproblems.com/1104",
+    "erdosUrl": "https://erdosproblems.com/1104"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1117/meta.json
+++ b/src/data/proofs/erdos-1117/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/1117"
     ],
     "leanFile": "Proofs/Erdos1117Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1117",
+    "erdosUrl": "https://erdosproblems.com/1117"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-112/meta.json
+++ b/src/data/proofs/erdos-112/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/112"
     ],
     "leanFile": "Proofs/Erdos112Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/112",
+    "erdosUrl": "https://erdosproblems.com/112"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1120/meta.json
+++ b/src/data/proofs/erdos-1120/meta.json
@@ -9,6 +9,7 @@
     "status": "enhanced",
     "proofRepoPath": "Proofs/Erdos1120Problem.lean",
     "tags": [
+      "erdos",
       "complex-analysis",
       "polynomials",
       "lemniscates",

--- a/src/data/proofs/erdos-1130/meta.json
+++ b/src/data/proofs/erdos-1130/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/1130",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1130Problem.lean",
-    "tags": ["approximation theory", "interpolation", "analysis"],
+    "tags": [
+      "erdos",
+      "approximation theory",
+      "interpolation",
+      "analysis"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 1130,

--- a/src/data/proofs/erdos-1135/meta.json
+++ b/src/data/proofs/erdos-1135/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/1135"
     ],
     "leanFile": "Proofs/Erdos1135Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1135",
+    "erdosUrl": "https://erdosproblems.com/1135"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-114/meta.json
+++ b/src/data/proofs/erdos-114/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/114"
     ],
     "leanFile": "Proofs/Erdos114Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/114",
+    "erdosUrl": "https://erdosproblems.com/114"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-115/meta.json
+++ b/src/data/proofs/erdos-115/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/115",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos115Problem.lean",
-    "tags": ["analysis", "polynomials", "complex analysis"],
+    "tags": [
+      "erdos",
+      "analysis",
+      "polynomials",
+      "complex analysis"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 115,

--- a/src/data/proofs/erdos-116/meta.json
+++ b/src/data/proofs/erdos-116/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/116",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos116Problem.lean",
-    "tags": ["complex analysis", "polynomial theory", "measure theory"],
+    "tags": [
+      "erdos",
+      "complex analysis",
+      "polynomial theory",
+      "measure theory"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 116,

--- a/src/data/proofs/erdos-117/meta.json
+++ b/src/data/proofs/erdos-117/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos117Problem.lean",
     "tags": [
+      "erdos",
       "group-theory",
       "abelian-subgroups",
       "covering-number",

--- a/src/data/proofs/erdos-118/meta.json
+++ b/src/data/proofs/erdos-118/meta.json
@@ -23,7 +23,9 @@
       "https://erdosproblems.com/118"
     ],
     "leanFile": "Proofs/Erdos118Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/118",
+    "erdosUrl": "https://erdosproblems.com/118"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-119/meta.json
+++ b/src/data/proofs/erdos-119/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/119",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos119Problem.lean",
-    "tags": ["complex-analysis", "polynomials", "unit-circle", "extremal-problems"],
+    "tags": [
+      "erdos",
+      "complex-analysis",
+      "polynomials",
+      "unit-circle",
+      "extremal-problems"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 119,
@@ -27,11 +33,41 @@
     ]
   },
   "sections": [
-    { "id": "definitions", "title": "Polynomial Product and Maximum Modulus", "startLine": 31, "endLine": 41, "summary": "Defines unitCirclePoly as ∏_{i<n}(w - z_i) and maxModulus as the sup of its norm over the unit circle." },
-    { "id": "part1", "title": "Part 1: limsup M_n = ∞ (Wagner 1980)", "startLine": 43, "endLine": 54, "summary": "States that limsup M_n = ⊤ in EReal for any unit circle sequence. Solved by Wagner." },
-    { "id": "part2", "title": "Part 2: M_n > n^c Infinitely Often (Beck 1991)", "startLine": 56, "endLine": 68, "summary": "States existence of c > 0 with max_{n≤N} M_n > N^c. Solved by Beck." },
-    { "id": "part3", "title": "Part 3: Partial Sum Growth (Open)", "startLine": 70, "endLine": 80, "summary": "ErdosProblem119: ∃ c > 0 such that ∑_{k<n} M_k > n^{1+c} eventually. Open with $100 prize." },
-    { "id": "basic", "title": "Basic Properties and Implications", "startLine": 82, "endLine": 115, "summary": "Proves unitCirclePoly_one and unitCirclePoly_zero. States M_n ≥ 1, nonnegativity, and the implication chain part3 ⟹ part2 ⟹ part1." }
+    {
+      "id": "definitions",
+      "title": "Polynomial Product and Maximum Modulus",
+      "startLine": 31,
+      "endLine": 41,
+      "summary": "Defines unitCirclePoly as ∏_{i<n}(w - z_i) and maxModulus as the sup of its norm over the unit circle."
+    },
+    {
+      "id": "part1",
+      "title": "Part 1: limsup M_n = ∞ (Wagner 1980)",
+      "startLine": 43,
+      "endLine": 54,
+      "summary": "States that limsup M_n = ⊤ in EReal for any unit circle sequence. Solved by Wagner."
+    },
+    {
+      "id": "part2",
+      "title": "Part 2: M_n > n^c Infinitely Often (Beck 1991)",
+      "startLine": 56,
+      "endLine": 68,
+      "summary": "States existence of c > 0 with max_{n≤N} M_n > N^c. Solved by Beck."
+    },
+    {
+      "id": "part3",
+      "title": "Part 3: Partial Sum Growth (Open)",
+      "startLine": 70,
+      "endLine": 80,
+      "summary": "ErdosProblem119: ∃ c > 0 such that ∑_{k<n} M_k > n^{1+c} eventually. Open with $100 prize."
+    },
+    {
+      "id": "basic",
+      "title": "Basic Properties and Implications",
+      "startLine": 82,
+      "endLine": 115,
+      "summary": "Proves unitCirclePoly_one and unitCirclePoly_zero. States M_n ≥ 1, nonnegativity, and the implication chain part3 ⟹ part2 ⟹ part1."
+    }
   ],
   "conclusion": {
     "summary": "The formalization captures all three parts of Erdős Problem 119 on maximum modulus of unit-circle polynomials. Parts 1-2 (solved by Wagner and Beck) are stated as axioms. Part 3 remains open. 0 sorries.",

--- a/src/data/proofs/erdos-120/meta.json
+++ b/src/data/proofs/erdos-120/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/120",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos120Problem.lean",
-    "tags": ["measure theory", "similarity", "real analysis", "geometric measure theory"],
+    "tags": [
+      "erdos",
+      "measure theory",
+      "similarity",
+      "real analysis",
+      "geometric measure theory"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 120,

--- a/src/data/proofs/erdos-121/meta.json
+++ b/src/data/proofs/erdos-121/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/121",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos121Problem.lean",
-    "tags": ["number theory", "squares", "multiplicative number theory", "extremal"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "squares",
+      "multiplicative number theory",
+      "extremal"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 121,

--- a/src/data/proofs/erdos-122/meta.json
+++ b/src/data/proofs/erdos-122/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos122Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "arithmetic-functions",
       "distribution",

--- a/src/data/proofs/erdos-124/meta.json
+++ b/src/data/proofs/erdos-124/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/124",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos124Problem.lean",
-    "tags": ["number theory", "base representations", "additive combinatorics"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "base representations",
+      "additive combinatorics"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 124,

--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/125",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos125Problem.lean",
-    "tags": ["number-theory", "base-representations", "density", "additive-combinatorics"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "base-representations",
+      "density",
+      "additive-combinatorics"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 125,

--- a/src/data/proofs/erdos-127/meta.json
+++ b/src/data/proofs/erdos-127/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/127",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos127Problem.lean",
-    "tags": ["graph-theory", "bipartite-graphs", "extremal-graph-theory"],
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "bipartite-graphs",
+      "extremal-graph-theory"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 127,

--- a/src/data/proofs/erdos-128/meta.json
+++ b/src/data/proofs/erdos-128/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/128"
     ],
     "leanFile": "Proofs/Erdos128Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/128",
+    "erdosUrl": "https://erdosproblems.com/128"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-129/meta.json
+++ b/src/data/proofs/erdos-129/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/129",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos129Problem.lean",
-    "tags": ["graph-theory", "ramsey-theory", "combinatorics", "edge-coloring"],
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "ramsey-theory",
+      "combinatorics",
+      "edge-coloring"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 129,
@@ -27,10 +33,34 @@
     ]
   },
   "sections": [
-    { "id": "coloring", "title": "Edge Coloring and Clique Avoidance", "startLine": 23, "endLine": 46, "summary": "Defines EdgeColoring, AvoidsMono, NoMonoClique, and HasRamseyAvoid for r-colored complete graphs." },
-    { "id": "conjecture", "title": "Main Conjecture: Exponential Bounds", "startLine": 48, "endLine": 65, "summary": "States the Erdős–Gyárfás conjecture for general k and the specialized k=3 upper bound conjecture." },
-    { "id": "known", "title": "Known Results", "startLine": 67, "endLine": 73, "summary": "States the Erdős–Gyárfás lower bound R(n;3,r) > C^{√n} as an axiom." },
-    { "id": "basic", "title": "Basic Properties", "startLine": 75, "endLine": 97, "summary": "Monotonicity in N, anti-monotonicity in colors, small-k vacuity, singleton and zero cases." }
+    {
+      "id": "coloring",
+      "title": "Edge Coloring and Clique Avoidance",
+      "startLine": 23,
+      "endLine": 46,
+      "summary": "Defines EdgeColoring, AvoidsMono, NoMonoClique, and HasRamseyAvoid for r-colored complete graphs."
+    },
+    {
+      "id": "conjecture",
+      "title": "Main Conjecture: Exponential Bounds",
+      "startLine": 48,
+      "endLine": 65,
+      "summary": "States the Erdős–Gyárfás conjecture for general k and the specialized k=3 upper bound conjecture."
+    },
+    {
+      "id": "known",
+      "title": "Known Results",
+      "startLine": 67,
+      "endLine": 73,
+      "summary": "States the Erdős–Gyárfás lower bound R(n;3,r) > C^{√n} as an axiom."
+    },
+    {
+      "id": "basic",
+      "title": "Basic Properties",
+      "startLine": 75,
+      "endLine": 97,
+      "summary": "Monotonicity in N, anti-monotonicity in colors, small-k vacuity, singleton and zero cases."
+    }
   ],
   "conclusion": {
     "summary": "The formalization captures Erdős Problem 129 on Ramsey numbers R(n;k,r) avoiding monochromatic cliques, including the Erdős–Gyárfás conjecture and the known lower bound. 0 sorries.",

--- a/src/data/proofs/erdos-130/meta.json
+++ b/src/data/proofs/erdos-130/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/130"
     ],
     "leanFile": "Proofs/Erdos130Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/130",
+    "erdosUrl": "https://erdosproblems.com/130"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos14Problem.lean",
     "tags": [
+      "erdos",
       "additive combinatorics",
       "unique representation",
       "sumsets",

--- a/src/data/proofs/erdos-142/meta.json
+++ b/src/data/proofs/erdos-142/meta.json
@@ -23,7 +23,9 @@
       "https://erdosproblems.com/142"
     ],
     "leanFile": "Proofs/Erdos142Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/142",
+    "erdosUrl": "https://erdosproblems.com/142"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-151/meta.json
+++ b/src/data/proofs/erdos-151/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/151",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos151Problem.lean",
-    "tags": ["graph theory", "clique transversal", "independence number", "Ramsey theory"],
+    "tags": [
+      "erdos",
+      "graph theory",
+      "clique transversal",
+      "independence number",
+      "Ramsey theory"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 151,

--- a/src/data/proofs/erdos-152/meta.json
+++ b/src/data/proofs/erdos-152/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/152",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos152Problem.lean",
-    "tags": ["additive-combinatorics", "sidon-sets", "sumsets"],
+    "tags": [
+      "erdos",
+      "additive-combinatorics",
+      "sidon-sets",
+      "sumsets"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 152,

--- a/src/data/proofs/erdos-153/meta.json
+++ b/src/data/proofs/erdos-153/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/153",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos153Problem.lean",
-    "tags": ["combinatorics", "sidon-sets", "additive-combinatorics", "sumsets"],
+    "tags": [
+      "erdos",
+      "combinatorics",
+      "sidon-sets",
+      "additive-combinatorics",
+      "sumsets"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 153,

--- a/src/data/proofs/erdos-155/meta.json
+++ b/src/data/proofs/erdos-155/meta.json
@@ -23,7 +23,9 @@
       "https://erdosproblems.com/155"
     ],
     "leanFile": "Proofs/Erdos155Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/155",
+    "erdosUrl": "https://erdosproblems.com/155"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -13,6 +13,7 @@
     "status": "axiom",
     "proofRepoPath": "Proofs/Erdos156Problem.lean",
     "tags": [
+      "erdos",
       "sidon-sets",
       "additive-combinatorics",
       "extremal-combinatorics"
@@ -22,8 +23,12 @@
     "erdosNumber": 156,
     "erdosUrl": "https://erdosproblems.com/156",
     "erdosProblemStatus": "open",
-    "relatedProblems": [340],
-    "oeis": ["A382397"],
+    "relatedProblems": [
+      340
+    ],
+    "oeis": [
+      "A382397"
+    ],
     "references": [
       {
         "key": "ESS94",
@@ -39,11 +44,31 @@
       }
     ],
     "mathlibDependencies": [
-      {"theorem": "Set.Finite", "description": "Predicate for finite sets", "module": "Mathlib.Data.Set.Finite"},
-      {"theorem": "Nat.find", "description": "Finds smallest natural number satisfying a predicate", "module": "Mathlib.Data.Nat.Find"},
-      {"theorem": "Real.sqrt", "description": "Real square root function", "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"},
-      {"theorem": "Filter.Tendsto", "description": "Tendsto for filter limits", "module": "Mathlib.Order.Filter.Basic"},
-      {"theorem": "iInf", "description": "Infimum over indexed family", "module": "Mathlib.Order.CompleteLattice"}
+      {
+        "theorem": "Set.Finite",
+        "description": "Predicate for finite sets",
+        "module": "Mathlib.Data.Set.Finite"
+      },
+      {
+        "theorem": "Nat.find",
+        "description": "Finds smallest natural number satisfying a predicate",
+        "module": "Mathlib.Data.Nat.Find"
+      },
+      {
+        "theorem": "Real.sqrt",
+        "description": "Real square root function",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Filter.Tendsto",
+        "description": "Tendsto for filter limits",
+        "module": "Mathlib.Order.Filter.Basic"
+      },
+      {
+        "theorem": "iInf",
+        "description": "Infimum over indexed family",
+        "module": "Mathlib.Order.CompleteLattice"
+      }
     ],
     "originalContributions": [
       "Two equivalent formal definitions of Sidon sets with proved equivalence theorem",
@@ -70,16 +95,76 @@
     ]
   },
   "sections": [
-    {"id": "header-docstring", "title": "Module Docstring", "startLine": 1, "endLine": 18, "summary": "Problem statement, definition of Sidon sets and maximality, references to Erdős-Sárközy-Sós [ESS94] and Ruzsa [Ru98b]."},
-    {"id": "sidon-definitions", "title": "Sidon Set Definitions", "startLine": 19, "endLine": 81, "summary": "Two definitions of Sidon sets (IsSidonSet with ≤, IsSidonSetAlt with <) and a detailed equivalence proof via case analysis on orderings. The proof handles all four combinations of a ≤ b vs a > b and c ≤ d vs c > d."},
-    {"id": "maximal-sidon", "title": "Maximal Sidon Sets", "startLine": 82, "endLine": 100, "summary": "Defines Interval(N) = {1,...,N}, IsMaximalSidonSet (subset of interval + Sidon + non-extendable), and the size function for finite sets using Set.Finite.toFinset.card."},
-    {"id": "greedy-construction", "title": "Greedy Sidon Construction", "startLine": 101, "endLine": 131, "summary": "Recursive greedy algorithm: greedySidon(n+1) adds n+1 if it preserves Sidon-ness. Proved to always produce Sidon sets by induction (greedySidon_is_sidon). Maximality theorem stated with sorry."},
-    {"id": "known-bounds", "title": "Classical Bounds", "startLine": 132, "endLine": 148, "summary": "Two axioms: sidon_upper_bound (|A| ≤ √N + C for Sidon A ⊆ {1,...,N}) and greedy_lower_bound (|greedy(N)| ≥ c√N). These establish that greedy Sidon sets have size Θ(√N)."},
-    {"id": "ruzsa-construction", "title": "Ruzsa's Small Maximal Sidon Sets", "startLine": 149, "endLine": 161, "summary": "Axiom ruzsa_small_maximal: for any ε > 0, there exist maximal Sidon sets of size ≤ N^{1/3+ε}. This is the key breakthrough result that motivates the conjecture."},
-    {"id": "main-conjecture", "title": "Main Conjecture", "startLine": 162, "endLine": 183, "summary": "The central axiom erdos_156_conjecture: either ∃ C > 0 with maximal Sidon sets of size ≤ C·N^{1/3} for all N, or ∀ C > 0 the bound C·N^{1/3} is eventually exceeded."},
-    {"id": "gap-and-minimum", "title": "Gap Analysis and Minimum Size", "startLine": 184, "endLine": 203, "summary": "Defines minMaximalSidonSize via Nat.find and states the growth exponent conjecture: ∃ α ∈ [1/3, 1/2] such that log(minMaximalSidonSize N)/log N → α."},
-    {"id": "additive-combinatorics", "title": "Connection to Additive Combinatorics", "startLine": 204, "endLine": 238, "summary": "Sumset definition, |A + A| = |A|(|A|+1)/2 for Sidon sets (with sorry), IsB2Set alias, and a placeholder axiom for random Sidon barriers."},
-    {"id": "infimum-formulation", "title": "Infimum Formulation and Precise Problem", "startLine": 239, "endLine": 261, "summary": "Defines infMaximalSidonSize via iInf over all maximal Sidon sets. Final axiom erdos_156_precise: either the infimum is O(N^{1/3}) or it diverges relative to N^{1/3}."}
+    {
+      "id": "header-docstring",
+      "title": "Module Docstring",
+      "startLine": 1,
+      "endLine": 18,
+      "summary": "Problem statement, definition of Sidon sets and maximality, references to Erdős-Sárközy-Sós [ESS94] and Ruzsa [Ru98b]."
+    },
+    {
+      "id": "sidon-definitions",
+      "title": "Sidon Set Definitions",
+      "startLine": 19,
+      "endLine": 81,
+      "summary": "Two definitions of Sidon sets (IsSidonSet with ≤, IsSidonSetAlt with <) and a detailed equivalence proof via case analysis on orderings. The proof handles all four combinations of a ≤ b vs a > b and c ≤ d vs c > d."
+    },
+    {
+      "id": "maximal-sidon",
+      "title": "Maximal Sidon Sets",
+      "startLine": 82,
+      "endLine": 100,
+      "summary": "Defines Interval(N) = {1,...,N}, IsMaximalSidonSet (subset of interval + Sidon + non-extendable), and the size function for finite sets using Set.Finite.toFinset.card."
+    },
+    {
+      "id": "greedy-construction",
+      "title": "Greedy Sidon Construction",
+      "startLine": 101,
+      "endLine": 131,
+      "summary": "Recursive greedy algorithm: greedySidon(n+1) adds n+1 if it preserves Sidon-ness. Proved to always produce Sidon sets by induction (greedySidon_is_sidon). Maximality theorem stated with sorry."
+    },
+    {
+      "id": "known-bounds",
+      "title": "Classical Bounds",
+      "startLine": 132,
+      "endLine": 148,
+      "summary": "Two axioms: sidon_upper_bound (|A| ≤ √N + C for Sidon A ⊆ {1,...,N}) and greedy_lower_bound (|greedy(N)| ≥ c√N). These establish that greedy Sidon sets have size Θ(√N)."
+    },
+    {
+      "id": "ruzsa-construction",
+      "title": "Ruzsa's Small Maximal Sidon Sets",
+      "startLine": 149,
+      "endLine": 161,
+      "summary": "Axiom ruzsa_small_maximal: for any ε > 0, there exist maximal Sidon sets of size ≤ N^{1/3+ε}. This is the key breakthrough result that motivates the conjecture."
+    },
+    {
+      "id": "main-conjecture",
+      "title": "Main Conjecture",
+      "startLine": 162,
+      "endLine": 183,
+      "summary": "The central axiom erdos_156_conjecture: either ∃ C > 0 with maximal Sidon sets of size ≤ C·N^{1/3} for all N, or ∀ C > 0 the bound C·N^{1/3} is eventually exceeded."
+    },
+    {
+      "id": "gap-and-minimum",
+      "title": "Gap Analysis and Minimum Size",
+      "startLine": 184,
+      "endLine": 203,
+      "summary": "Defines minMaximalSidonSize via Nat.find and states the growth exponent conjecture: ∃ α ∈ [1/3, 1/2] such that log(minMaximalSidonSize N)/log N → α."
+    },
+    {
+      "id": "additive-combinatorics",
+      "title": "Connection to Additive Combinatorics",
+      "startLine": 204,
+      "endLine": 238,
+      "summary": "Sumset definition, |A + A| = |A|(|A|+1)/2 for Sidon sets (with sorry), IsB2Set alias, and a placeholder axiom for random Sidon barriers."
+    },
+    {
+      "id": "infimum-formulation",
+      "title": "Infimum Formulation and Precise Problem",
+      "startLine": 239,
+      "endLine": 261,
+      "summary": "Defines infMaximalSidonSize via iInf over all maximal Sidon sets. Final axiom erdos_156_precise: either the infimum is O(N^{1/3}) or it diverges relative to N^{1/3}."
+    }
   ],
   "conclusion": {
     "summary": "This 261-line formalization of Erdős Problem #156 defines Sidon sets with two equivalent characterizations (proved equivalent via detailed case analysis), constructs greedy Sidon sets with an inductive Sidon-ness proof, and states the main conjecture about minimal maximal Sidon sets. Classical bounds (Erdős-Turán, greedy), Ruzsa's N^{1/3+ε} breakthrough, and two equivalent formulations of the open problem (via constants and via infimum) provide a complete formal framework. Three sorries remain in structural proofs.",

--- a/src/data/proofs/erdos-159/meta.json
+++ b/src/data/proofs/erdos-159/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/159",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos159Problem.lean",
-    "tags": ["graph-theory", "ramsey-theory", "extremal-graph-theory"],
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "ramsey-theory",
+      "extremal-graph-theory"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 159,

--- a/src/data/proofs/erdos-160/meta.json
+++ b/src/data/proofs/erdos-160/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/160"
     ],
     "leanFile": "Proofs/Erdos160Problem.lean",
-    "sorries": 3
+    "sorries": 3,
+    "sourceUrl": "https://erdosproblems.com/160",
+    "erdosUrl": "https://erdosproblems.com/160"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-162/meta.json
+++ b/src/data/proofs/erdos-162/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos162Problem.lean",
     "tags": [
+      "erdos",
       "combinatorics",
       "ramsey-theory",
       "discrepancy",

--- a/src/data/proofs/erdos-17/meta.json
+++ b/src/data/proofs/erdos-17/meta.json
@@ -4,7 +4,7 @@
   "slug": "erdos-17",
   "description": "Are there infinitely many cluster primes? A prime p is a cluster prime if every even n ≤ p-3 can be expressed as a difference of primes ≤ p. First non-cluster prime: 97.",
   "meta": {
-    "author": "Unknown",
+    "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/17",
     "date": "",
     "status": "complete",

--- a/src/data/proofs/erdos-181/meta.json
+++ b/src/data/proofs/erdos-181/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/181",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos181Problem.lean",
-    "tags": ["graph-theory", "ramsey-theory", "hypercube"],
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "ramsey-theory",
+      "hypercube"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 181,

--- a/src/data/proofs/erdos-187/meta.json
+++ b/src/data/proofs/erdos-187/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/187"
     ],
     "leanFile": "Proofs/Erdos187Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/187",
+    "erdosUrl": "https://erdosproblems.com/187"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-190/meta.json
+++ b/src/data/proofs/erdos-190/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/190",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos190Problem.lean",
-    "tags": ["additive-combinatorics", "arithmetic-progressions", "ramsey-theory", "canonical-ramsey"],
+    "tags": [
+      "erdos",
+      "additive-combinatorics",
+      "arithmetic-progressions",
+      "ramsey-theory",
+      "canonical-ramsey"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 190,

--- a/src/data/proofs/erdos-193/meta.json
+++ b/src/data/proofs/erdos-193/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/193",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos193Problem.lean",
-    "tags": ["geometry", "combinatorics", "lattice walks", "collinearity"],
+    "tags": [
+      "erdos",
+      "geometry",
+      "combinatorics",
+      "lattice walks",
+      "collinearity"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 193,

--- a/src/data/proofs/erdos-196/meta.json
+++ b/src/data/proofs/erdos-196/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos196Problem.lean",
     "tags": [
+      "erdos",
       "combinatorics",
       "permutations",
       "arithmetic progressions",

--- a/src/data/proofs/erdos-200/meta.json
+++ b/src/data/proofs/erdos-200/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/200"
     ],
     "leanFile": "Proofs/Erdos200Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/200",
+    "erdosUrl": "https://erdosproblems.com/200"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-201/meta.json
+++ b/src/data/proofs/erdos-201/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/201",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos201Problem.lean",
-    "tags": ["additive combinatorics", "arithmetic progressions", "Szemerédi"],
+    "tags": [
+      "erdos",
+      "additive combinatorics",
+      "arithmetic progressions",
+      "Szemerédi"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 201,

--- a/src/data/proofs/erdos-218/meta.json
+++ b/src/data/proofs/erdos-218/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos218Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "prime-gaps",
       "natural-density",

--- a/src/data/proofs/erdos-234/meta.json
+++ b/src/data/proofs/erdos-234/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/234",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos234Problem.lean",
-    "tags": ["number-theory", "prime-gaps", "density-functions", "distribution"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "prime-gaps",
+      "density-functions",
+      "distribution"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 234,

--- a/src/data/proofs/erdos-238/meta.json
+++ b/src/data/proofs/erdos-238/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/238",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos238Problem.lean",
-    "tags": ["prime-numbers", "prime-gaps", "consecutive-primes", "number-theory"],
+    "tags": [
+      "erdos",
+      "prime-numbers",
+      "prime-gaps",
+      "consecutive-primes",
+      "number-theory"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 238,

--- a/src/data/proofs/erdos-241/meta.json
+++ b/src/data/proofs/erdos-241/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/241",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos241Problem.lean",
-    "tags": ["additive-combinatorics", "sidon-sets", "b3-sets"],
+    "tags": [
+      "erdos",
+      "additive-combinatorics",
+      "sidon-sets",
+      "b3-sets"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 241,

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/25",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos25Problem.lean",
-    "tags": ["number-theory", "density", "sieve-theory", "modular-arithmetic"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "density",
+      "sieve-theory",
+      "modular-arithmetic"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 25,

--- a/src/data/proofs/erdos-260/meta.json
+++ b/src/data/proofs/erdos-260/meta.json
@@ -9,6 +9,7 @@
     "status": "enhanced",
     "proofRepoPath": "Proofs/Erdos260Problem.lean",
     "tags": [
+      "erdos",
       "analysis",
       "irrationality",
       "series",

--- a/src/data/proofs/erdos-261/meta.json
+++ b/src/data/proofs/erdos-261/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/261",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos261Problem.lean",
-    "tags": ["number theory", "combinatorics", "representations"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "combinatorics",
+      "representations"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 261,

--- a/src/data/proofs/erdos-265/meta.json
+++ b/src/data/proofs/erdos-265/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/265",
     "status": "axiom",
     "proofRepoPath": "Proofs/Erdos265Problem.lean",
-    "tags": ["number-theory", "irrationality", "sequences"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "irrationality",
+      "sequences"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 265,
@@ -21,8 +26,16 @@
       }
     ],
     "mathlibDependencies": [
-      {"theorem": "Filter.Tendsto", "description": "Tendsto for filter limits", "module": "Mathlib.Order.Filter.Basic"},
-      {"theorem": "tsum", "description": "Infinite summation over ℕ", "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"}
+      {
+        "theorem": "Filter.Tendsto",
+        "description": "Tendsto for filter limits",
+        "module": "Mathlib.Order.Filter.Basic"
+      },
+      {
+        "theorem": "tsum",
+        "description": "Infinite summation over ℕ",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      }
     ],
     "originalContributions": [
       "Formal definitions of valid sequences with dual rational sum constraints",
@@ -44,15 +57,69 @@
     ]
   },
   "sections": [
-    {"id": "header-imports", "title": "Header and Imports", "startLine": 1, "endLine": 20, "summary": "Module documentation describing the problem, Cantor's example, Erdős's conjectures, Kovač-Tao result, and the remaining open question. Imports Mathlib."},
-    {"id": "valid-sequences", "title": "Sequences with Rational Sums", "startLine": 22, "endLine": 46, "summary": "Core definitions: positive integer sequences, strict monotonicity, reciprocal sum ∑ 1/aₙ, shifted reciprocal sum ∑ 1/(aₙ-1), and the combined rationality predicate hasBothRationalSums."},
-    {"id": "cantor-example", "title": "Cantor's Example", "startLine": 48, "endLine": 70, "summary": "Defines Cantor's sequence (triangular numbers n(n+1)/2), proves strict monotonicity, and states rationality of both sums as axioms."},
-    {"id": "growth-rates", "title": "Growth Rate Measures", "startLine": 72, "endLine": 89, "summary": "Three growth measures: singleExpGrowth (aₙ^(1/n)), doubleExpGrowth (aₙ^(1/2ⁿ)), and genExpGrowth (aₙ^(1/βⁿ)) for parameterized β > 1."},
-    {"id": "erdos-conjectures", "title": "Erdős's Conjectures", "startLine": 91, "endLine": 109, "summary": "Two conjectures: (1) aₙ^(1/n) → ∞ is achievable (proved by Kovač-Tao), (2) aₙ^(1/2ⁿ) → 1 is necessary (still open)."},
-    {"id": "kovac-tao", "title": "Kovač-Tao Result and Open Question", "startLine": 111, "endLine": 131, "summary": "Kovač-Tao theorem: ∃ β > 1 with aₙ^(1/βⁿ) → ∞ achievable. The remaining open question: can β = 2 work?"},
-    {"id": "irrationality", "title": "Irrationality Threshold", "startLine": 133, "endLine": 144, "summary": "Folklore result: if aₙ^(1/2ⁿ) → c > 1, then ∑ 1/aₙ is irrational. This explains why β = 2 might be the natural barrier."},
-    {"id": "valid-set-poly", "title": "Valid Set and Polynomial Examples", "startLine": 146, "endLine": 172, "summary": "Defines the set of valid sequences and states that higher-degree polynomial families (e.g., n³+6n²+5n with shift 12) can satisfy the constraint."},
-    {"id": "main-open", "title": "Main Open Problem", "startLine": 174, "endLine": 205, "summary": "The formal statement of Erdős #265 as a disjunction: either ∃ valid sequence with limsup aₙ^(1/2ⁿ) > 1, or all valid sequences have limsup ≤ 1."}
+    {
+      "id": "header-imports",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 20,
+      "summary": "Module documentation describing the problem, Cantor's example, Erdős's conjectures, Kovač-Tao result, and the remaining open question. Imports Mathlib."
+    },
+    {
+      "id": "valid-sequences",
+      "title": "Sequences with Rational Sums",
+      "startLine": 22,
+      "endLine": 46,
+      "summary": "Core definitions: positive integer sequences, strict monotonicity, reciprocal sum ∑ 1/aₙ, shifted reciprocal sum ∑ 1/(aₙ-1), and the combined rationality predicate hasBothRationalSums."
+    },
+    {
+      "id": "cantor-example",
+      "title": "Cantor's Example",
+      "startLine": 48,
+      "endLine": 70,
+      "summary": "Defines Cantor's sequence (triangular numbers n(n+1)/2), proves strict monotonicity, and states rationality of both sums as axioms."
+    },
+    {
+      "id": "growth-rates",
+      "title": "Growth Rate Measures",
+      "startLine": 72,
+      "endLine": 89,
+      "summary": "Three growth measures: singleExpGrowth (aₙ^(1/n)), doubleExpGrowth (aₙ^(1/2ⁿ)), and genExpGrowth (aₙ^(1/βⁿ)) for parameterized β > 1."
+    },
+    {
+      "id": "erdos-conjectures",
+      "title": "Erdős's Conjectures",
+      "startLine": 91,
+      "endLine": 109,
+      "summary": "Two conjectures: (1) aₙ^(1/n) → ∞ is achievable (proved by Kovač-Tao), (2) aₙ^(1/2ⁿ) → 1 is necessary (still open)."
+    },
+    {
+      "id": "kovac-tao",
+      "title": "Kovač-Tao Result and Open Question",
+      "startLine": 111,
+      "endLine": 131,
+      "summary": "Kovač-Tao theorem: ∃ β > 1 with aₙ^(1/βⁿ) → ∞ achievable. The remaining open question: can β = 2 work?"
+    },
+    {
+      "id": "irrationality",
+      "title": "Irrationality Threshold",
+      "startLine": 133,
+      "endLine": 144,
+      "summary": "Folklore result: if aₙ^(1/2ⁿ) → c > 1, then ∑ 1/aₙ is irrational. This explains why β = 2 might be the natural barrier."
+    },
+    {
+      "id": "valid-set-poly",
+      "title": "Valid Set and Polynomial Examples",
+      "startLine": 146,
+      "endLine": 172,
+      "summary": "Defines the set of valid sequences and states that higher-degree polynomial families (e.g., n³+6n²+5n with shift 12) can satisfy the constraint."
+    },
+    {
+      "id": "main-open",
+      "title": "Main Open Problem",
+      "startLine": 174,
+      "endLine": 205,
+      "summary": "The formal statement of Erdős #265 as a disjunction: either ∃ valid sequence with limsup aₙ^(1/2ⁿ) > 1, or all valid sequences have limsup ≤ 1."
+    }
   ],
   "conclusion": {
     "summary": "Erdős Problem #265 concerns the maximum growth rate of sequences with two rational reciprocal sums. Cantor's triangular numbers give polynomial growth. Kovač and Tao (2024) achieved doubly exponential growth for some β > 1, confirming Erdős's first conjecture. The question of whether β = 2 is achievable remains the key open problem, formalized as a disjunction in Lean.",

--- a/src/data/proofs/erdos-273/meta.json
+++ b/src/data/proofs/erdos-273/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/273",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos273Problem.lean",
-    "tags": ["number-theory", "covering-systems", "primes"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "covering-systems",
+      "primes"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 273,

--- a/src/data/proofs/erdos-276/meta.json
+++ b/src/data/proofs/erdos-276/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/276"
     ],
     "leanFile": "Proofs/Erdos276Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/276",
+    "erdosUrl": "https://erdosproblems.com/276"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/278"
     ],
     "leanFile": "Proofs/Erdos278Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/278",
+    "erdosUrl": "https://erdosproblems.com/278"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-279/meta.json
+++ b/src/data/proofs/erdos-279/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/279",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos279Problem.lean",
-    "tags": ["number theory", "covering systems", "primes"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "covering systems",
+      "primes"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 279,

--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/28"
     ],
     "leanFile": "Proofs/Erdos28Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/28",
+    "erdosUrl": "https://erdosproblems.com/28"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-281/meta.json
+++ b/src/data/proofs/erdos-281/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/281",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos281Problem.lean",
-    "tags": ["number theory", "covering systems", "density", "congruences"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "covering systems",
+      "density",
+      "congruences"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 281,

--- a/src/data/proofs/erdos-282/meta.json
+++ b/src/data/proofs/erdos-282/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/282"
     ],
     "leanFile": "Proofs/Erdos282Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/282",
+    "erdosUrl": "https://erdosproblems.com/282"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-286/meta.json
+++ b/src/data/proofs/erdos-286/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos286Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "unit-fractions",
       "egyptian-fractions",

--- a/src/data/proofs/erdos-289/meta.json
+++ b/src/data/proofs/erdos-289/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos289Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "unit fractions",
       "intervals",

--- a/src/data/proofs/erdos-301/meta.json
+++ b/src/data/proofs/erdos-301/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/301",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos301Problem.lean",
-    "tags": ["number-theory", "unit-fractions", "extremal-combinatorics", "egyptian-fractions"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "unit-fractions",
+      "extremal-combinatorics",
+      "egyptian-fractions"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 301,
@@ -27,11 +33,41 @@
     ]
   },
   "sections": [
-    { "id": "avoidance", "title": "Egyptian Fraction Avoidance", "startLine": 22, "endLine": 37, "summary": "Defines HasEgyptianDecomp, EgyptFractionFree, and maxEgyptFree." },
-    { "id": "conjecture", "title": "Main Conjecture", "startLine": 39, "endLine": 45, "summary": "States ErdosProblem301: f(N) = (1/2+o(1))N." },
-    { "id": "lower", "title": "Lower Bound", "startLine": 47, "endLine": 55, "summary": "Half-interval (N/2, N] is EgyptFractionFree, giving f(N) ≥ N/2." },
-    { "id": "upper", "title": "Upper Bound (van Doorn)", "startLine": 57, "endLine": 61, "summary": "Van Doorn's bound f(N) ≤ (25/28+o(1))N." },
-    { "id": "basic", "title": "Basic Properties", "startLine": 63, "endLine": 78, "summary": "Proves empty and subset properties. States singleton axiom." }
+    {
+      "id": "avoidance",
+      "title": "Egyptian Fraction Avoidance",
+      "startLine": 22,
+      "endLine": 37,
+      "summary": "Defines HasEgyptianDecomp, EgyptFractionFree, and maxEgyptFree."
+    },
+    {
+      "id": "conjecture",
+      "title": "Main Conjecture",
+      "startLine": 39,
+      "endLine": 45,
+      "summary": "States ErdosProblem301: f(N) = (1/2+o(1))N."
+    },
+    {
+      "id": "lower",
+      "title": "Lower Bound",
+      "startLine": 47,
+      "endLine": 55,
+      "summary": "Half-interval (N/2, N] is EgyptFractionFree, giving f(N) ≥ N/2."
+    },
+    {
+      "id": "upper",
+      "title": "Upper Bound (van Doorn)",
+      "startLine": 57,
+      "endLine": 61,
+      "summary": "Van Doorn's bound f(N) ≤ (25/28+o(1))N."
+    },
+    {
+      "id": "basic",
+      "title": "Basic Properties",
+      "startLine": 63,
+      "endLine": 78,
+      "summary": "Proves empty and subset properties. States singleton axiom."
+    }
   ],
   "conclusion": {
     "summary": "The formalization captures Erdős Problem 301 on Egyptian fraction avoidance sets, with lower bound N/2, upper bound 25/28·N, and the conjecture f(N) ~ N/2. 0 sorries.",

--- a/src/data/proofs/erdos-311/meta.json
+++ b/src/data/proofs/erdos-311/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/311"
     ],
     "leanFile": "Proofs/Erdos311Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/311",
+    "erdosUrl": "https://erdosproblems.com/311"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-313/meta.json
+++ b/src/data/proofs/erdos-313/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos313Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "unit fractions",
       "Egyptian fractions",

--- a/src/data/proofs/erdos-319/meta.json
+++ b/src/data/proofs/erdos-319/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos319Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "unit-fractions",
       "combinatorics",

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/321"
     ],
     "leanFile": "Proofs/Erdos321Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/321",
+    "erdosUrl": "https://erdosproblems.com/321"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-323/meta.json
+++ b/src/data/proofs/erdos-323/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/323",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos323Problem.lean",
-    "tags": ["number theory", "Waring problem", "sums of powers", "counting functions"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "Waring problem",
+      "sums of powers",
+      "counting functions"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 323,

--- a/src/data/proofs/erdos-324/meta.json
+++ b/src/data/proofs/erdos-324/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/324",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos324Problem.lean",
-    "tags": ["number-theory", "polynomial", "additive-combinatorics"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "polynomial",
+      "additive-combinatorics"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 324,

--- a/src/data/proofs/erdos-327/meta.json
+++ b/src/data/proofs/erdos-327/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/327",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos327Problem.lean",
-    "tags": ["number-theory", "unit-fractions", "extremal-combinatorics", "divisibility"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "unit-fractions",
+      "extremal-combinatorics",
+      "divisibility"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 327,
@@ -27,11 +33,41 @@
     ]
   },
   "sections": [
-    { "id": "property", "title": "Sum-Divides-Product Property", "startLine": 25, "endLine": 37, "summary": "Defines SumNotDvdProd, SumNotDvdTwoProd, and maxAvoidSize as extremal function." },
-    { "id": "conjecture", "title": "Main Conjecture", "startLine": 39, "endLine": 45, "summary": "States ErdosProblem327: maxAvoidSize(N) ≤ (1/2+ε)N for all ε > 0." },
-    { "id": "vandoorn", "title": "Van Doorn's Bound", "startLine": 47, "endLine": 53, "summary": "Van Doorn's result: |A| ≥ 25N/28 forces a pair with a+b | ab." },
-    { "id": "variant", "title": "Factor-of-2 Variant", "startLine": 55, "endLine": 68, "summary": "Variant conjecture with 2ab and unit-fraction equivalence axiom." },
-    { "id": "basic", "title": "Basic Properties", "startLine": 70, "endLine": 89, "summary": "Proves SumNotDvdProd for empty, singleton, and subsets. States odd-numbers result." }
+    {
+      "id": "property",
+      "title": "Sum-Divides-Product Property",
+      "startLine": 25,
+      "endLine": 37,
+      "summary": "Defines SumNotDvdProd, SumNotDvdTwoProd, and maxAvoidSize as extremal function."
+    },
+    {
+      "id": "conjecture",
+      "title": "Main Conjecture",
+      "startLine": 39,
+      "endLine": 45,
+      "summary": "States ErdosProblem327: maxAvoidSize(N) ≤ (1/2+ε)N for all ε > 0."
+    },
+    {
+      "id": "vandoorn",
+      "title": "Van Doorn's Bound",
+      "startLine": 47,
+      "endLine": 53,
+      "summary": "Van Doorn's result: |A| ≥ 25N/28 forces a pair with a+b | ab."
+    },
+    {
+      "id": "variant",
+      "title": "Factor-of-2 Variant",
+      "startLine": 55,
+      "endLine": 68,
+      "summary": "Variant conjecture with 2ab and unit-fraction equivalence axiom."
+    },
+    {
+      "id": "basic",
+      "title": "Basic Properties",
+      "startLine": 70,
+      "endLine": 89,
+      "summary": "Proves SumNotDvdProd for empty, singleton, and subsets. States odd-numbers result."
+    }
   ],
   "conclusion": {
     "summary": "The formalization captures Erdős Problem 327 on sum-divides-product avoidance, van Doorn's density bound, the factor-of-2 variant, and the unit-fraction equivalence. 0 sorries.",

--- a/src/data/proofs/erdos-330/meta.json
+++ b/src/data/proofs/erdos-330/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/330"
     ],
     "leanFile": "Proofs/Erdos330Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/330",
+    "erdosUrl": "https://erdosproblems.com/330"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-332/meta.json
+++ b/src/data/proofs/erdos-332/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/332",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos332Problem.lean",
-    "tags": ["number theory", "additive combinatorics", "difference sets", "density"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "additive combinatorics",
+      "difference sets",
+      "density"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 332,

--- a/src/data/proofs/erdos-335/meta.json
+++ b/src/data/proofs/erdos-335/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos335Problem.lean",
     "tags": [
+      "erdos",
       "additive combinatorics",
       "density",
       "sumsets",

--- a/src/data/proofs/erdos-340/meta.json
+++ b/src/data/proofs/erdos-340/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/340"
     ],
     "leanFile": "Proofs/Erdos340Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/340",
+    "erdosUrl": "https://erdosproblems.com/340"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-341/meta.json
+++ b/src/data/proofs/erdos-341/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos341Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "sequences",
       "sum-free sets",

--- a/src/data/proofs/erdos-342/meta.json
+++ b/src/data/proofs/erdos-342/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos342Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "sequences",
       "additive-combinatorics",

--- a/src/data/proofs/erdos-345/meta.json
+++ b/src/data/proofs/erdos-345/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/345",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos345Problem.lean",
-    "tags": ["number theory", "complete sequences", "subset sums", "Waring problem"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "complete sequences",
+      "subset sums",
+      "Waring problem"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 345,

--- a/src/data/proofs/erdos-346/meta.json
+++ b/src/data/proofs/erdos-346/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/346",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos346Problem.lean",
-    "tags": ["number theory", "complete sequences", "golden ratio", "Fibonacci numbers"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "complete sequences",
+      "golden ratio",
+      "Fibonacci numbers"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 346,

--- a/src/data/proofs/erdos-347/meta.json
+++ b/src/data/proofs/erdos-347/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/347",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos347Problem.lean",
-    "tags": ["number theory", "complete sequences", "subset sums", "density"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "complete sequences",
+      "subset sums",
+      "density"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 347,

--- a/src/data/proofs/erdos-348/meta.json
+++ b/src/data/proofs/erdos-348/meta.json
@@ -10,6 +10,7 @@
     "status": "axiom",
     "proofRepoPath": "Proofs/Erdos348Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "complete-sequences",
       "additive-combinatorics"

--- a/src/data/proofs/erdos-349/meta.json
+++ b/src/data/proofs/erdos-349/meta.json
@@ -19,7 +19,9 @@
       "https://erdosproblems.com/349"
     ],
     "leanFile": "Proofs/Erdos349Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/349",
+    "erdosUrl": "https://erdosproblems.com/349"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/36"
     ],
     "leanFile": "Proofs/Erdos36Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/36",
+    "erdosUrl": "https://erdosproblems.com/36"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-361/meta.json
+++ b/src/data/proofs/erdos-361/meta.json
@@ -9,6 +9,7 @@
     "status": "enhanced",
     "proofRepoPath": "Proofs/Erdos361Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "subset-sums",
       "combinatorics",

--- a/src/data/proofs/erdos-367/meta.json
+++ b/src/data/proofs/erdos-367/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/367",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos367Problem.lean",
-    "tags": ["number-theory", "powerful-numbers", "consecutive-integers", "squarefree"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "powerful-numbers",
+      "consecutive-integers",
+      "squarefree"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 367,

--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -9,6 +9,7 @@
     "status": "complete",
     "proofRepoPath": "Proofs/Erdos369Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "smooth-numbers",
       "consecutive-integers",

--- a/src/data/proofs/erdos-374/meta.json
+++ b/src/data/proofs/erdos-374/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/374"
     ],
     "leanFile": "Proofs/Erdos374Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/374",
+    "erdosUrl": "https://erdosproblems.com/374"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-380/meta.json
+++ b/src/data/proofs/erdos-380/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/380",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos380Problem.lean",
-    "tags": ["number theory", "prime factors", "intervals", "products"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "prime factors",
+      "intervals",
+      "products"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 380,

--- a/src/data/proofs/erdos-384/meta.json
+++ b/src/data/proofs/erdos-384/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/384",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos384Problem.lean",
-    "tags": ["number-theory", "binomial-coefficients", "prime-divisors", "solved"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "binomial-coefficients",
+      "prime-divisors",
+      "solved"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 384,

--- a/src/data/proofs/erdos-386/meta.json
+++ b/src/data/proofs/erdos-386/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/386",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos386Problem.lean",
-    "tags": ["number-theory", "binomial-coefficients", "prime-numbers", "combinatorics"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "binomial-coefficients",
+      "prime-numbers",
+      "combinatorics"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 386,

--- a/src/data/proofs/erdos-388/meta.json
+++ b/src/data/proofs/erdos-388/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos388Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "diophantine equations",
       "consecutive integers",

--- a/src/data/proofs/erdos-389/meta.json
+++ b/src/data/proofs/erdos-389/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos389Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "divisibility",
       "consecutive integers",

--- a/src/data/proofs/erdos-390/meta.json
+++ b/src/data/proofs/erdos-390/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/390",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos390Problem.lean",
-    "tags": ["number-theory", "factorials", "asymptotics"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "factorials",
+      "asymptotics"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 390,

--- a/src/data/proofs/erdos-396/meta.json
+++ b/src/data/proofs/erdos-396/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/396",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos396Problem.lean",
-    "tags": ["number theory", "binomial coefficients", "divisibility"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "binomial coefficients",
+      "divisibility"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 396,

--- a/src/data/proofs/erdos-40/meta.json
+++ b/src/data/proofs/erdos-40/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/40"
     ],
     "leanFile": "Proofs/Erdos40Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/40",
+    "erdosUrl": "https://erdosproblems.com/40"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-400/meta.json
+++ b/src/data/proofs/erdos-400/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/400",
     "status": "enhanced",
     "proofRepoPath": "Proofs/Erdos400Problem.lean",
-    "tags": ["number-theory", "factorials", "asymptotics", "combinatorics"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "factorials",
+      "asymptotics",
+      "combinatorics"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 400,

--- a/src/data/proofs/erdos-406/meta.json
+++ b/src/data/proofs/erdos-406/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/406",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos406Problem.lean",
-    "tags": ["number theory", "base representations", "powers of 2", "digit problems"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "base representations",
+      "powers of 2",
+      "digit problems"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 406,

--- a/src/data/proofs/erdos-409/meta.json
+++ b/src/data/proofs/erdos-409/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos409Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "Euler totient",
       "iteration",

--- a/src/data/proofs/erdos-411/meta.json
+++ b/src/data/proofs/erdos-411/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/411",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos411Problem.lean",
-    "tags": ["number-theory", "iterated-functions", "totient", "arithmetic-dynamics"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "iterated-functions",
+      "totient",
+      "arithmetic-dynamics"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 411,

--- a/src/data/proofs/erdos-413/meta.json
+++ b/src/data/proofs/erdos-413/meta.json
@@ -9,6 +9,7 @@
     "status": "axiom",
     "proofRepoPath": "Proofs/Erdos413Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "arithmetic-functions",
       "iterated-functions",
@@ -19,8 +20,13 @@
     "erdosNumber": 413,
     "erdosUrl": "https://erdosproblems.com/413",
     "erdosProblemStatus": "open",
-    "relatedProblems": [412, 414],
-    "oeis": ["A005236"],
+    "relatedProblems": [
+      412,
+      414
+    ],
+    "oeis": [
+      "A005236"
+    ],
     "references": [
       {
         "key": "Er79d",
@@ -36,10 +42,26 @@
       }
     ],
     "mathlibDependencies": [
-      {"theorem": "Nat.primeFactors", "description": "Set of distinct prime factors of a natural number", "module": "Mathlib.Data.Nat.PrimeFin"},
-      {"theorem": "Nat.totient", "description": "Euler's totient function", "module": "Mathlib.Data.Nat.Totient"},
-      {"theorem": "Nat.divisors", "description": "Finset of divisors", "module": "Mathlib.NumberTheory.Divisors"},
-      {"theorem": "Squarefree", "description": "Squarefree predicate", "module": "Mathlib.Data.Nat.Squarefree"}
+      {
+        "theorem": "Nat.primeFactors",
+        "description": "Set of distinct prime factors of a natural number",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "Nat.totient",
+        "description": "Euler's totient function",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.divisors",
+        "description": "Finset of divisors",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "Squarefree",
+        "description": "Squarefree predicate",
+        "module": "Mathlib.Data.Nat.Squarefree"
+      }
     ],
     "originalContributions": [
       "Barrier definition and basic structural theorems for general arithmetic functions",
@@ -67,20 +89,104 @@
     ]
   },
   "sections": [
-    {"id": "header-imports", "title": "Header and Imports", "startLine": 1, "endLine": 21, "summary": "Module docstring describing barriers for ω, Erdős's conjecture, known results (expProd density, Selfridge's computation, OEIS A005236), and Mathlib import."},
-    {"id": "arithmetic-functions", "title": "Arithmetic Functions", "startLine": 23, "endLine": 40, "summary": "Defines three noncomputable arithmetic functions: ω(n) = number of distinct prime divisors, Ω(n) = prime factors with multiplicity, and expProd(n) = product of prime exponents."},
-    {"id": "barrier-definitions", "title": "Barrier Definitions", "startLine": 42, "endLine": 61, "summary": "Defines IsBarrier for ℕ → ℕ functions, IsBarrierReal for ℝ-valued functions (ε-variant), and the set of barriers."},
-    {"id": "basic-properties", "title": "Basic Barrier Properties", "startLine": 63, "endLine": 100, "summary": "Proves 0 and 1 are always barriers, characterizes when 2 is a barrier, and shows barrier monotonicity in the function argument."},
-    {"id": "omega-values-bounds", "title": "ω Values and Upper Bound", "startLine": 101, "endLine": 159, "summary": "Computes ω for small inputs, proves ω(p) = 1 for primes, and establishes the key bound 2^ω(n) ≤ n (equivalently ω(n) ≤ log₂ n) via prime factorization."},
-    {"id": "phi-sigma-no-barriers", "title": "φ and σ₁ Have No Barriers", "startLine": 160, "endLine": 218, "summary": "Proves φ has no barriers beyond 3 (since φ(n) ≥ 2 for n ≥ 3) and σ₁ has no barriers beyond 2 (since σ₁(n) ≥ n+1 for n ≥ 2). Also proves ω ≤ Ω."},
-    {"id": "decidable-omega-barriers", "title": "Machine-Verified ω-Barriers", "startLine": 244, "endLine": 401, "summary": "Computable barrier checking via isBarrierBool with soundness/completeness proofs. Machine-verifies ω-barriers at 0-128 and non-barriers at 3,5,7-10,15,16,20 via native_decide. Counts barriers at thresholds."},
-    {"id": "structural-theorems", "title": "Barrier Structural Theorems", "startLine": 403, "endLine": 480, "summary": "Not-barrier witness extraction, proof that barrier predecessors are prime powers, barrier spacing (gap-two, consecutive barriers, offset bounds), and barrier downward closure."},
-    {"id": "general-barrier-theory", "title": "General Barrier Theory", "startLine": 519, "endLine": 584, "summary": "Barriers for zero function = all of ℕ, constant function characterization, bounded-by-one implies universal barrier, barrier sum decomposition, and inter-barrier witness theorem."},
-    {"id": "iterated-dynamics", "title": "Iterated Dynamics", "startLine": 605, "endLine": 709, "summary": "Defines iterOmega, iterOmegaPow, eventuallyMeet, and orbit. Proves orbits are strictly increasing for n ≥ 2, barriers trap orbits, and orbits respect barrier ordering."},
-    {"id": "decidable-bigomega-expprod", "title": "Verified Ω and expProd Barriers", "startLine": 710, "endLine": 855, "summary": "Computable Ω and expProd, machine-verified barriers for each, barrier counts, and computational comparison hierarchy: F >> ω >> Ω."},
-    {"id": "omega-multiplicativity", "title": "ω Multiplicativity and Subadditivity", "startLine": 1025, "endLine": 1077, "summary": "Proves ω(mn) = ω(m) + ω(n) for coprime m,n, derives ω(6) = 2 and ω(30) = 3, and proves the subadditive bound ω(mn) ≤ ω(m) + ω(n) for general products."},
-    {"id": "main-conjectures", "title": "Main Conjectures and Open Problem", "startLine": 974, "endLine": 1024, "summary": "States the main conjecture (ω-barriers infinite), ε-variant, trajectory merging conjecture (related to #412), Erdős's expProd density result, Selfridge's computation, and the combined open problem."},
-    {"id": "strong-prime-power", "title": "Strong Prime Power Predecessor", "startLine": 1078, "endLine": 1102, "summary": "Proves the strong form: at any barrier n ≥ 3, n-1 is necessarily a prime power p^k with k ≥ 1, using the fact that ω(n-1) = 1 for n ≥ 3 at a barrier."}
+    {
+      "id": "header-imports",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 21,
+      "summary": "Module docstring describing barriers for ω, Erdős's conjecture, known results (expProd density, Selfridge's computation, OEIS A005236), and Mathlib import."
+    },
+    {
+      "id": "arithmetic-functions",
+      "title": "Arithmetic Functions",
+      "startLine": 23,
+      "endLine": 40,
+      "summary": "Defines three noncomputable arithmetic functions: ω(n) = number of distinct prime divisors, Ω(n) = prime factors with multiplicity, and expProd(n) = product of prime exponents."
+    },
+    {
+      "id": "barrier-definitions",
+      "title": "Barrier Definitions",
+      "startLine": 42,
+      "endLine": 61,
+      "summary": "Defines IsBarrier for ℕ → ℕ functions, IsBarrierReal for ℝ-valued functions (ε-variant), and the set of barriers."
+    },
+    {
+      "id": "basic-properties",
+      "title": "Basic Barrier Properties",
+      "startLine": 63,
+      "endLine": 100,
+      "summary": "Proves 0 and 1 are always barriers, characterizes when 2 is a barrier, and shows barrier monotonicity in the function argument."
+    },
+    {
+      "id": "omega-values-bounds",
+      "title": "ω Values and Upper Bound",
+      "startLine": 101,
+      "endLine": 159,
+      "summary": "Computes ω for small inputs, proves ω(p) = 1 for primes, and establishes the key bound 2^ω(n) ≤ n (equivalently ω(n) ≤ log₂ n) via prime factorization."
+    },
+    {
+      "id": "phi-sigma-no-barriers",
+      "title": "φ and σ₁ Have No Barriers",
+      "startLine": 160,
+      "endLine": 218,
+      "summary": "Proves φ has no barriers beyond 3 (since φ(n) ≥ 2 for n ≥ 3) and σ₁ has no barriers beyond 2 (since σ₁(n) ≥ n+1 for n ≥ 2). Also proves ω ≤ Ω."
+    },
+    {
+      "id": "decidable-omega-barriers",
+      "title": "Machine-Verified ω-Barriers",
+      "startLine": 244,
+      "endLine": 401,
+      "summary": "Computable barrier checking via isBarrierBool with soundness/completeness proofs. Machine-verifies ω-barriers at 0-128 and non-barriers at 3,5,7-10,15,16,20 via native_decide. Counts barriers at thresholds."
+    },
+    {
+      "id": "structural-theorems",
+      "title": "Barrier Structural Theorems",
+      "startLine": 403,
+      "endLine": 480,
+      "summary": "Not-barrier witness extraction, proof that barrier predecessors are prime powers, barrier spacing (gap-two, consecutive barriers, offset bounds), and barrier downward closure."
+    },
+    {
+      "id": "general-barrier-theory",
+      "title": "General Barrier Theory",
+      "startLine": 519,
+      "endLine": 584,
+      "summary": "Barriers for zero function = all of ℕ, constant function characterization, bounded-by-one implies universal barrier, barrier sum decomposition, and inter-barrier witness theorem."
+    },
+    {
+      "id": "iterated-dynamics",
+      "title": "Iterated Dynamics",
+      "startLine": 605,
+      "endLine": 709,
+      "summary": "Defines iterOmega, iterOmegaPow, eventuallyMeet, and orbit. Proves orbits are strictly increasing for n ≥ 2, barriers trap orbits, and orbits respect barrier ordering."
+    },
+    {
+      "id": "decidable-bigomega-expprod",
+      "title": "Verified Ω and expProd Barriers",
+      "startLine": 710,
+      "endLine": 855,
+      "summary": "Computable Ω and expProd, machine-verified barriers for each, barrier counts, and computational comparison hierarchy: F >> ω >> Ω."
+    },
+    {
+      "id": "omega-multiplicativity",
+      "title": "ω Multiplicativity and Subadditivity",
+      "startLine": 1025,
+      "endLine": 1077,
+      "summary": "Proves ω(mn) = ω(m) + ω(n) for coprime m,n, derives ω(6) = 2 and ω(30) = 3, and proves the subadditive bound ω(mn) ≤ ω(m) + ω(n) for general products."
+    },
+    {
+      "id": "main-conjectures",
+      "title": "Main Conjectures and Open Problem",
+      "startLine": 974,
+      "endLine": 1024,
+      "summary": "States the main conjecture (ω-barriers infinite), ε-variant, trajectory merging conjecture (related to #412), Erdős's expProd density result, Selfridge's computation, and the combined open problem."
+    },
+    {
+      "id": "strong-prime-power",
+      "title": "Strong Prime Power Predecessor",
+      "startLine": 1078,
+      "endLine": 1102,
+      "summary": "Proves the strong form: at any barrier n ≥ 3, n-1 is necessarily a prime power p^k with k ≥ 1, using the fact that ω(n-1) = 1 for n ≥ 3 at a barrier."
+    }
   ],
   "conclusion": {
     "summary": "This formalization provides a comprehensive treatment of Erdős Problem #413 on barriers for the ω function. It defines barriers for general arithmetic functions, proves structural constraints (predecessors must be prime powers, φ and σ₁ cannot have large barriers), machine-verifies specific barriers up to 128, establishes a barrier hierarchy F >> ω >> Ω, and connects barriers to the iterated dynamics of n ↦ n + ω(n). The 1100-line file includes 50+ theorems, a decidable barrier-checking framework, and extensive computational verification.",

--- a/src/data/proofs/erdos-414/meta.json
+++ b/src/data/proofs/erdos-414/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/414"
     ],
     "leanFile": "Proofs/Erdos414Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/414",
+    "erdosUrl": "https://erdosproblems.com/414"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-417/meta.json
+++ b/src/data/proofs/erdos-417/meta.json
@@ -9,6 +9,7 @@
     "status": "enhanced",
     "proofRepoPath": "Proofs/Erdos417Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "totient-function",
       "counting-functions",

--- a/src/data/proofs/erdos-42/meta.json
+++ b/src/data/proofs/erdos-42/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/42",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos42Problem.lean",
-    "tags": ["number theory", "Sidon sets", "additive combinatorics"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "Sidon sets",
+      "additive combinatorics"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 42,

--- a/src/data/proofs/erdos-422/meta.json
+++ b/src/data/proofs/erdos-422/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos422Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "sequences",
       "recursion",

--- a/src/data/proofs/erdos-423/meta.json
+++ b/src/data/proofs/erdos-423/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos423Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "sequences",
       "additive-combinatorics",

--- a/src/data/proofs/erdos-424/meta.json
+++ b/src/data/proofs/erdos-424/meta.json
@@ -9,6 +9,7 @@
     "status": "enhanced",
     "proofRepoPath": "Proofs/Erdos424Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "sequences",
       "density",

--- a/src/data/proofs/erdos-428/meta.json
+++ b/src/data/proofs/erdos-428/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/428",
     "status": "enhanced",
     "proofRepoPath": "Proofs/Erdos428Problem.lean",
-    "tags": ["number-theory", "prime-numbers", "density", "k-tuple-conjecture"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "prime-numbers",
+      "density",
+      "k-tuple-conjecture"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 428,

--- a/src/data/proofs/erdos-43/meta.json
+++ b/src/data/proofs/erdos-43/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos43Problem.lean",
     "tags": [
+      "erdos",
       "additive-combinatorics",
       "sidon-sets",
       "number-theory"

--- a/src/data/proofs/erdos-430/meta.json
+++ b/src/data/proofs/erdos-430/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/430"
     ],
     "leanFile": "Proofs/Erdos430Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/430",
+    "erdosUrl": "https://erdosproblems.com/430"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-432/meta.json
+++ b/src/data/proofs/erdos-432/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos432Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "additive-combinatorics",
       "coprimality",

--- a/src/data/proofs/erdos-450/meta.json
+++ b/src/data/proofs/erdos-450/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos450Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "divisors",
       "density",

--- a/src/data/proofs/erdos-451/meta.json
+++ b/src/data/proofs/erdos-451/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos451Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "prime-factors",
       "bertrand-postulate",

--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos456Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "primes",
       "totient-function",

--- a/src/data/proofs/erdos-46/meta.json
+++ b/src/data/proofs/erdos-46/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/46",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos46Problem.lean",
-    "tags": ["number-theory", "unit-fractions", "ramsey-theory", "colouring"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "unit-fractions",
+      "ramsey-theory",
+      "colouring"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 46,
@@ -27,11 +33,41 @@
     ]
   },
   "sections": [
-    { "id": "unit-fraction", "title": "Unit Fraction Representations", "startLine": 21, "endLine": 30, "summary": "Defines IsUnitFractionRepr and IsRatFractionRepr for Egyptian fraction sums over Finsets." },
-    { "id": "colourings", "title": "Colourings", "startLine": 32, "endLine": 40, "summary": "Defines FiniteColouring as ℕ → Fin r and IsMonochromatic for uniform colour." },
-    { "id": "main", "title": "Main Theorem", "startLine": 42, "endLine": 54, "summary": "States ErdosProblem46 and the stronger infinitely-many disjoint solutions variant." },
-    { "id": "rational", "title": "Rational Generalization", "startLine": 56, "endLine": 66, "summary": "States Erdős–Graham generalization to arbitrary positive rationals." },
-    { "id": "basic", "title": "Basic Properties", "startLine": 68, "endLine": 91, "summary": "Proves empty set and 1-colouring results. States singleton non-representation and cardinality bound." }
+    {
+      "id": "unit-fraction",
+      "title": "Unit Fraction Representations",
+      "startLine": 21,
+      "endLine": 30,
+      "summary": "Defines IsUnitFractionRepr and IsRatFractionRepr for Egyptian fraction sums over Finsets."
+    },
+    {
+      "id": "colourings",
+      "title": "Colourings",
+      "startLine": 32,
+      "endLine": 40,
+      "summary": "Defines FiniteColouring as ℕ → Fin r and IsMonochromatic for uniform colour."
+    },
+    {
+      "id": "main",
+      "title": "Main Theorem",
+      "startLine": 42,
+      "endLine": 54,
+      "summary": "States ErdosProblem46 and the stronger infinitely-many disjoint solutions variant."
+    },
+    {
+      "id": "rational",
+      "title": "Rational Generalization",
+      "startLine": 56,
+      "endLine": 66,
+      "summary": "States Erdős–Graham generalization to arbitrary positive rationals."
+    },
+    {
+      "id": "basic",
+      "title": "Basic Properties",
+      "startLine": 68,
+      "endLine": 91,
+      "summary": "Proves empty set and 1-colouring results. States singleton non-representation and cardinality bound."
+    }
   ],
   "conclusion": {
     "summary": "The formalization captures Erdős Problem 46 on monochromatic unit fraction representations, Croot's infinitely-many result, and the Erdős–Graham rational generalization. 0 sorries.",

--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/460",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos460Problem.lean",
-    "tags": ["number-theory", "sieve-methods", "reciprocal-sums", "coprimality"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "sieve-methods",
+      "reciprocal-sums",
+      "coprimality"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 460,

--- a/src/data/proofs/erdos-461/meta.json
+++ b/src/data/proofs/erdos-461/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/461",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos461Problem.lean",
-    "tags": ["number theory", "primes", "smooth numbers", "short intervals"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "primes",
+      "smooth numbers",
+      "short intervals"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 461,

--- a/src/data/proofs/erdos-462/meta.json
+++ b/src/data/proofs/erdos-462/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/462",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos462Problem.lean",
-    "tags": ["number theory", "primes", "least prime factor", "short intervals"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "primes",
+      "least prime factor",
+      "short intervals"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 462,

--- a/src/data/proofs/erdos-463/meta.json
+++ b/src/data/proofs/erdos-463/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos463Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "prime factors",
       "composites",

--- a/src/data/proofs/erdos-466/meta.json
+++ b/src/data/proofs/erdos-466/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos466Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "discrete geometry",
       "diophantine approximation",

--- a/src/data/proofs/erdos-467/meta.json
+++ b/src/data/proofs/erdos-467/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos467Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "covering congruences",
       "prime residues",

--- a/src/data/proofs/erdos-468/meta.json
+++ b/src/data/proofs/erdos-468/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos468Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "divisors",
       "partial-sums",

--- a/src/data/proofs/erdos-469/meta.json
+++ b/src/data/proofs/erdos-469/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/469"
     ],
     "leanFile": "Proofs/Erdos469Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/469",
+    "erdosUrl": "https://erdosproblems.com/469"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-47/meta.json
+++ b/src/data/proofs/erdos-47/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos47Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "unit-fractions",
       "density",

--- a/src/data/proofs/erdos-472/meta.json
+++ b/src/data/proofs/erdos-472/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/472",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos472Problem.lean",
-    "tags": ["number theory", "primes", "sequences", "Ulam"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "primes",
+      "sequences",
+      "Ulam"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 472,

--- a/src/data/proofs/erdos-477/meta.json
+++ b/src/data/proofs/erdos-477/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/477"
     ],
     "leanFile": "Proofs/Erdos477Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/477",
+    "erdosUrl": "https://erdosproblems.com/477"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-478/meta.json
+++ b/src/data/proofs/erdos-478/meta.json
@@ -23,7 +23,9 @@
       "https://erdosproblems.com/478"
     ],
     "leanFile": "Proofs/Erdos478Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/478",
+    "erdosUrl": "https://erdosproblems.com/478"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-483/meta.json
+++ b/src/data/proofs/erdos-483/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/483"
     ],
     "leanFile": "Proofs/Erdos483Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/483",
+    "erdosUrl": "https://erdosproblems.com/483"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-488/meta.json
+++ b/src/data/proofs/erdos-488/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/488",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos488Problem.lean",
-    "tags": ["number theory", "divisibility", "density", "inclusion-exclusion"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "divisibility",
+      "density",
+      "inclusion-exclusion"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 488,

--- a/src/data/proofs/erdos-49/meta.json
+++ b/src/data/proofs/erdos-49/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/49",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos49Problem.lean",
-    "tags": ["number theory", "primes", "euler totient", "analytic number theory"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "primes",
+      "euler totient",
+      "analytic number theory"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 49,

--- a/src/data/proofs/erdos-493/meta.json
+++ b/src/data/proofs/erdos-493/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos493Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "representation",
       "constructive-proof",

--- a/src/data/proofs/erdos-496/meta.json
+++ b/src/data/proofs/erdos-496/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos496Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "Diophantine approximation",
       "quadratic forms",

--- a/src/data/proofs/erdos-497/meta.json
+++ b/src/data/proofs/erdos-497/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/497",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos497Problem.lean",
-    "tags": ["combinatorics", "antichains", "Sperner theory", "Dedekind numbers"],
+    "tags": [
+      "erdos",
+      "combinatorics",
+      "antichains",
+      "Sperner theory",
+      "Dedekind numbers"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 497,

--- a/src/data/proofs/erdos-498/meta.json
+++ b/src/data/proofs/erdos-498/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/498"
     ],
     "leanFile": "Proofs/Erdos498Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/498",
+    "erdosUrl": "https://erdosproblems.com/498"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/5"
     ],
     "leanFile": "Proofs/Erdos5Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/5",
+    "erdosUrl": "https://erdosproblems.com/5"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-50/meta.json
+++ b/src/data/proofs/erdos-50/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos50Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "Euler totient",
       "distribution functions",

--- a/src/data/proofs/erdos-500/meta.json
+++ b/src/data/proofs/erdos-500/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/500"
     ],
     "leanFile": "Proofs/Erdos500Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/500",
+    "erdosUrl": "https://erdosproblems.com/500"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-502/meta.json
+++ b/src/data/proofs/erdos-502/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/502"
     ],
     "leanFile": "Proofs/Erdos502Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/502",
+    "erdosUrl": "https://erdosproblems.com/502"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-503/meta.json
+++ b/src/data/proofs/erdos-503/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos503Problem.lean",
     "tags": [
+      "erdos",
       "combinatorial-geometry",
       "distances",
       "isosceles",

--- a/src/data/proofs/erdos-505/meta.json
+++ b/src/data/proofs/erdos-505/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/505"
     ],
     "leanFile": "Proofs/Erdos505Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/505",
+    "erdosUrl": "https://erdosproblems.com/505"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-506/meta.json
+++ b/src/data/proofs/erdos-506/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/506"
     ],
     "leanFile": "Proofs/Erdos506Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/506",
+    "erdosUrl": "https://erdosproblems.com/506"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-507/meta.json
+++ b/src/data/proofs/erdos-507/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/507"
     ],
     "leanFile": "Proofs/Erdos507Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/507",
+    "erdosUrl": "https://erdosproblems.com/507"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-508/meta.json
+++ b/src/data/proofs/erdos-508/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/508",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos508Problem.lean",
-    "tags": ["combinatorial-geometry", "graph-coloring", "chromatic-number", "unit-distance"],
+    "tags": [
+      "erdos",
+      "combinatorial-geometry",
+      "graph-coloring",
+      "chromatic-number",
+      "unit-distance"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 508,

--- a/src/data/proofs/erdos-51/meta.json
+++ b/src/data/proofs/erdos-51/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos51Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "Euler totient",
       "inverse totient",

--- a/src/data/proofs/erdos-510/meta.json
+++ b/src/data/proofs/erdos-510/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/510"
     ],
     "leanFile": "Proofs/Erdos510Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/510",
+    "erdosUrl": "https://erdosproblems.com/510"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-513/meta.json
+++ b/src/data/proofs/erdos-513/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/513"
     ],
     "leanFile": "Proofs/Erdos513Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/513",
+    "erdosUrl": "https://erdosproblems.com/513"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-52/meta.json
+++ b/src/data/proofs/erdos-52/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/52",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos52Problem.lean",
-    "tags": ["additive-combinatorics", "sum-product", "number-theory"],
+    "tags": [
+      "erdos",
+      "additive-combinatorics",
+      "sum-product",
+      "number-theory"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 52,

--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/524"
     ],
     "leanFile": "Proofs/Erdos524Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/524",
+    "erdosUrl": "https://erdosproblems.com/524"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-526/meta.json
+++ b/src/data/proofs/erdos-526/meta.json
@@ -11,6 +11,7 @@
     "dateAdded": "2026-01-23",
     "proofRepoPath": "Proofs/Erdos526Problem.lean",
     "tags": [
+      "erdos",
       "probability",
       "random-covering",
       "geometric-probability",

--- a/src/data/proofs/erdos-53/meta.json
+++ b/src/data/proofs/erdos-53/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/53",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos53Problem.lean",
-    "tags": ["number-theory", "additive-combinatorics", "sum-product"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "additive-combinatorics",
+      "sum-product"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 53,

--- a/src/data/proofs/erdos-530/meta.json
+++ b/src/data/proofs/erdos-530/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/530",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos530Problem.lean",
-    "tags": ["number-theory", "sidon-sets", "additive-combinatorics", "extremal-combinatorics"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "sidon-sets",
+      "additive-combinatorics",
+      "extremal-combinatorics"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 530,

--- a/src/data/proofs/erdos-533/meta.json
+++ b/src/data/proofs/erdos-533/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/533"
     ],
     "leanFile": "Proofs/Erdos533Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/533",
+    "erdosUrl": "https://erdosproblems.com/533"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-536/meta.json
+++ b/src/data/proofs/erdos-536/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos536Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "lcm",
       "density",

--- a/src/data/proofs/erdos-538/meta.json
+++ b/src/data/proofs/erdos-538/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos538Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "prime-factors",
       "reciprocal-sums",

--- a/src/data/proofs/erdos-54/meta.json
+++ b/src/data/proofs/erdos-54/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/54",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos54Problem.lean",
-    "tags": ["number theory", "Ramsey theory", "complete sequences", "additive combinatorics"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "Ramsey theory",
+      "complete sequences",
+      "additive combinatorics"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 54,

--- a/src/data/proofs/erdos-542/meta.json
+++ b/src/data/proofs/erdos-542/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/542",
     "status": "enhanced",
     "proofRepoPath": "Proofs/Erdos542Problem.lean",
-    "tags": ["number-theory", "lcm", "reciprocal-sums", "extremal-combinatorics"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "lcm",
+      "reciprocal-sums",
+      "extremal-combinatorics"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 542,

--- a/src/data/proofs/erdos-544/meta.json
+++ b/src/data/proofs/erdos-544/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/544",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos544Problem.lean",
-    "tags": ["graph theory", "Ramsey theory", "Ramsey numbers"],
+    "tags": [
+      "erdos",
+      "graph theory",
+      "Ramsey theory",
+      "Ramsey numbers"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 544,

--- a/src/data/proofs/erdos-555/meta.json
+++ b/src/data/proofs/erdos-555/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos555Problem.lean",
     "tags": [
+      "erdos",
       "Ramsey theory",
       "graph theory",
       "extremal combinatorics"

--- a/src/data/proofs/erdos-557/meta.json
+++ b/src/data/proofs/erdos-557/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/557"
     ],
     "leanFile": "Proofs/Erdos557Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/557",
+    "erdosUrl": "https://erdosproblems.com/557"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-562/meta.json
+++ b/src/data/proofs/erdos-562/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/562"
     ],
     "leanFile": "Proofs/Erdos562Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/562",
+    "erdosUrl": "https://erdosproblems.com/562"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-563/meta.json
+++ b/src/data/proofs/erdos-563/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos563Problem.lean",
     "tags": [
+      "erdos",
       "graph theory",
       "Ramsey theory",
       "probabilistic method",

--- a/src/data/proofs/erdos-566/meta.json
+++ b/src/data/proofs/erdos-566/meta.json
@@ -19,7 +19,9 @@
       "https://erdosproblems.com/566"
     ],
     "leanFile": "Proofs/Erdos566Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/566",
+    "erdosUrl": "https://erdosproblems.com/566"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-567/meta.json
+++ b/src/data/proofs/erdos-567/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/567"
     ],
     "leanFile": "Proofs/Erdos567Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/567",
+    "erdosUrl": "https://erdosproblems.com/567"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-568/meta.json
+++ b/src/data/proofs/erdos-568/meta.json
@@ -19,7 +19,9 @@
       "https://erdosproblems.com/568"
     ],
     "leanFile": "Proofs/Erdos568Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/568",
+    "erdosUrl": "https://erdosproblems.com/568"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-574/meta.json
+++ b/src/data/proofs/erdos-574/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/574"
     ],
     "leanFile": "Proofs/Erdos574Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/574",
+    "erdosUrl": "https://erdosproblems.com/574"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-575/meta.json
+++ b/src/data/proofs/erdos-575/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos575Problem.lean",
     "tags": [
+      "erdos",
       "extremal graph theory",
       "Turán numbers",
       "bipartite graphs",

--- a/src/data/proofs/erdos-579/meta.json
+++ b/src/data/proofs/erdos-579/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/579",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos579Problem.lean",
-    "tags": ["graph theory", "extremal graph theory", "Turán theory"],
+    "tags": [
+      "erdos",
+      "graph theory",
+      "extremal graph theory",
+      "Turán theory"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 579,

--- a/src/data/proofs/erdos-585/meta.json
+++ b/src/data/proofs/erdos-585/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/585",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos585Problem.lean",
-    "tags": ["graph theory", "extremal graph theory", "cycles"],
+    "tags": [
+      "erdos",
+      "graph theory",
+      "extremal graph theory",
+      "cycles"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 585,

--- a/src/data/proofs/erdos-592/meta.json
+++ b/src/data/proofs/erdos-592/meta.json
@@ -23,7 +23,9 @@
       "https://erdosproblems.com/592"
     ],
     "leanFile": "Proofs/Erdos592Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/592",
+    "erdosUrl": "https://erdosproblems.com/592"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-593/meta.json
+++ b/src/data/proofs/erdos-593/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/593",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos593Problem.lean",
-    "tags": ["set-theory", "hypergraphs", "chromatic-number", "graph-theory"],
+    "tags": [
+      "erdos",
+      "set-theory",
+      "hypergraphs",
+      "chromatic-number",
+      "graph-theory"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 593,

--- a/src/data/proofs/erdos-598/meta.json
+++ b/src/data/proofs/erdos-598/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/598",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos598Problem.lean",
-    "tags": ["set-theory", "ramsey-theory", "cardinal-arithmetic"],
+    "tags": [
+      "erdos",
+      "set-theory",
+      "ramsey-theory",
+      "cardinal-arithmetic"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 598,

--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/638",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos638Problem.lean",
-    "tags": ["graph theory", "ramsey theory", "infinite combinatorics", "cardinals"],
+    "tags": [
+      "erdos",
+      "graph theory",
+      "ramsey theory",
+      "infinite combinatorics",
+      "cardinals"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 638,

--- a/src/data/proofs/erdos-640/meta.json
+++ b/src/data/proofs/erdos-640/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos640Problem.lean",
     "tags": [
+      "erdos",
       "graph-theory",
       "chromatic-number",
       "odd-cycles",

--- a/src/data/proofs/erdos-654/meta.json
+++ b/src/data/proofs/erdos-654/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/654"
     ],
     "leanFile": "Proofs/Erdos654Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/654",
+    "erdosUrl": "https://erdosproblems.com/654"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-655/meta.json
+++ b/src/data/proofs/erdos-655/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/655",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos655Problem.lean",
-    "tags": ["combinatorial geometry", "distinct distances", "concyclicity"],
+    "tags": [
+      "erdos",
+      "combinatorial geometry",
+      "distinct distances",
+      "concyclicity"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 655,

--- a/src/data/proofs/erdos-661/meta.json
+++ b/src/data/proofs/erdos-661/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/661"
     ],
     "leanFile": "Proofs/Erdos661Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/661",
+    "erdosUrl": "https://erdosproblems.com/661"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -19,7 +19,9 @@
       "https://erdosproblems.com/662"
     ],
     "leanFile": "Proofs/Erdos662Problem.lean",
-    "sorries": 4
+    "sorries": 4,
+    "sourceUrl": "https://erdosproblems.com/662",
+    "erdosUrl": "https://erdosproblems.com/662"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-663/meta.json
+++ b/src/data/proofs/erdos-663/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/663",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos663Problem.lean",
-    "tags": ["number-theory", "prime-numbers", "consecutive-products", "asymptotic-bounds"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "prime-numbers",
+      "consecutive-products",
+      "asymptotic-bounds"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 663,
@@ -27,11 +33,41 @@
     ]
   },
   "sections": [
-    { "id": "definitions", "title": "Consecutive Products and Smallest Missing Prime", "startLine": 24, "endLine": 44, "summary": "Defines consecutiveProduct and axiomatizes q(n,k) with its key properties: primality, non-divisibility, and minimality." },
-    { "id": "conjecture", "title": "Main Conjecture", "startLine": 46, "endLine": 54, "summary": "States Erdős Problem 663: q(n,k) < (1+o(1)) log n as an ε-N formulation." },
-    { "id": "weak-bound", "title": "Weak Bound", "startLine": 56, "endLine": 77, "summary": "States the weak bound q(n,k) < (1+o(1))k·log n and proves it coincides with the conjecture for k=1." },
-    { "id": "related", "title": "Related Results", "startLine": 79, "endLine": 110, "summary": "Proves consecutiveProduct properties, states the connection to Problem 457, and establishes q(n,k) > k." },
-    { "id": "monotonicity", "title": "Monotonicity Properties", "startLine": 112, "endLine": 128, "summary": "States monotonicity of q in k and proves the main conjecture implies the weak bound." }
+    {
+      "id": "definitions",
+      "title": "Consecutive Products and Smallest Missing Prime",
+      "startLine": 24,
+      "endLine": 44,
+      "summary": "Defines consecutiveProduct and axiomatizes q(n,k) with its key properties: primality, non-divisibility, and minimality."
+    },
+    {
+      "id": "conjecture",
+      "title": "Main Conjecture",
+      "startLine": 46,
+      "endLine": 54,
+      "summary": "States Erdős Problem 663: q(n,k) < (1+o(1)) log n as an ε-N formulation."
+    },
+    {
+      "id": "weak-bound",
+      "title": "Weak Bound",
+      "startLine": 56,
+      "endLine": 77,
+      "summary": "States the weak bound q(n,k) < (1+o(1))k·log n and proves it coincides with the conjecture for k=1."
+    },
+    {
+      "id": "related",
+      "title": "Related Results",
+      "startLine": 79,
+      "endLine": 110,
+      "summary": "Proves consecutiveProduct properties, states the connection to Problem 457, and establishes q(n,k) > k."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Monotonicity Properties",
+      "startLine": 112,
+      "endLine": 128,
+      "summary": "States monotonicity of q in k and proves the main conjecture implies the weak bound."
+    }
   ],
   "conclusion": {
     "summary": "The formalization captures Erdős Problem 663 on the asymptotic behavior of the smallest prime not dividing consecutive products. The main conjecture, weak bound, and several structural properties are formalized with 0 sorries.",

--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/667",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos667Problem.lean",
-    "tags": ["graph theory", "Ramsey theory", "extremal graph theory", "clique numbers"],
+    "tags": [
+      "erdos",
+      "graph theory",
+      "Ramsey theory",
+      "extremal graph theory",
+      "clique numbers"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 667,

--- a/src/data/proofs/erdos-675/meta.json
+++ b/src/data/proofs/erdos-675/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/675",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos675Problem.lean",
-    "tags": ["number theory", "sieve theory", "combinatorics"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "sieve theory",
+      "combinatorics"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 675,

--- a/src/data/proofs/erdos-677/meta.json
+++ b/src/data/proofs/erdos-677/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/677",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos677Problem.lean",
-    "tags": ["number-theory", "lcm", "consecutive-integers", "prime-factors"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "lcm",
+      "consecutive-integers",
+      "prime-factors"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 677,
@@ -27,11 +33,41 @@
     ]
   },
   "sections": [
-    { "id": "lcm", "title": "LCM of Consecutive Integers", "startLine": 30, "endLine": 35, "summary": "Defines lcmInterval n k as the fold of Nat.lcm over range k." },
-    { "id": "conjecture", "title": "Main Conjecture", "startLine": 37, "endLine": 41, "summary": "ErdosProblem677: M(m,k) ≠ M(n,k) for all m ≥ n+k." },
-    { "id": "examples", "title": "Known Examples", "startLine": 43, "endLine": 48, "summary": "The two known cross-parameter equalities: M(4,3) = M(13,2) and M(3,4) = M(19,2)." },
-    { "id": "strong", "title": "Stronger Conjecture and Thue–Siegel", "startLine": 50, "endLine": 72, "summary": "Stronger prime-factor conjecture and Thue–Siegel finiteness theorem." },
-    { "id": "basic", "title": "Basic Properties", "startLine": 74, "endLine": 97, "summary": "Proves lcmInterval_zero/one, consecutiveProduct_zero/one. States divisibility and positivity." }
+    {
+      "id": "lcm",
+      "title": "LCM of Consecutive Integers",
+      "startLine": 30,
+      "endLine": 35,
+      "summary": "Defines lcmInterval n k as the fold of Nat.lcm over range k."
+    },
+    {
+      "id": "conjecture",
+      "title": "Main Conjecture",
+      "startLine": 37,
+      "endLine": 41,
+      "summary": "ErdosProblem677: M(m,k) ≠ M(n,k) for all m ≥ n+k."
+    },
+    {
+      "id": "examples",
+      "title": "Known Examples",
+      "startLine": 43,
+      "endLine": 48,
+      "summary": "The two known cross-parameter equalities: M(4,3) = M(13,2) and M(3,4) = M(19,2)."
+    },
+    {
+      "id": "strong",
+      "title": "Stronger Conjecture and Thue–Siegel",
+      "startLine": 50,
+      "endLine": 72,
+      "summary": "Stronger prime-factor conjecture and Thue–Siegel finiteness theorem."
+    },
+    {
+      "id": "basic",
+      "title": "Basic Properties",
+      "startLine": 74,
+      "endLine": 97,
+      "summary": "Proves lcmInterval_zero/one, consecutiveProduct_zero/one. States divisibility and positivity."
+    }
   ],
   "conclusion": {
     "summary": "The formalization captures Erdős Problem 677 on distinctness of LCM of consecutive integers, the stronger prime-factor conjecture, and Thue–Siegel finiteness. 0 sorries.",

--- a/src/data/proofs/erdos-680/meta.json
+++ b/src/data/proofs/erdos-680/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/680",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos680Problem.lean",
-    "tags": ["number-theory", "prime-numbers", "prime-gaps", "least-prime-factor"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "prime-numbers",
+      "prime-gaps",
+      "least-prime-factor"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 680,

--- a/src/data/proofs/erdos-681/meta.json
+++ b/src/data/proofs/erdos-681/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/681",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos681Problem.lean",
-    "tags": ["number-theory", "primes", "least-prime-factor", "composites"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "primes",
+      "least-prime-factor",
+      "composites"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 681,

--- a/src/data/proofs/erdos-685/meta.json
+++ b/src/data/proofs/erdos-685/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/685",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos685Problem.lean",
-    "tags": ["number-theory", "primes", "binomial-coefficients", "prime-factors"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "primes",
+      "binomial-coefficients",
+      "prime-factors"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 685,

--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos687Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "covering systems",
       "Jacobsthal function",

--- a/src/data/proofs/erdos-688/meta.json
+++ b/src/data/proofs/erdos-688/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos688Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "covering systems",
       "prime numbers",

--- a/src/data/proofs/erdos-689/meta.json
+++ b/src/data/proofs/erdos-689/meta.json
@@ -19,7 +19,9 @@
       "https://erdosproblems.com/689"
     ],
     "leanFile": "Proofs/Erdos689Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/689",
+    "erdosUrl": "https://erdosproblems.com/689"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-690/meta.json
+++ b/src/data/proofs/erdos-690/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos690Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "prime factors",
       "density",

--- a/src/data/proofs/erdos-691/meta.json
+++ b/src/data/proofs/erdos-691/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/691",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos691Problem.lean",
-    "tags": ["number theory", "density", "multiplicative number theory"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "density",
+      "multiplicative number theory"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 691,

--- a/src/data/proofs/erdos-693/meta.json
+++ b/src/data/proofs/erdos-693/meta.json
@@ -9,6 +9,7 @@
     "status": "complete",
     "proofRepoPath": "Proofs/Erdos693Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "divisors",
       "gaps",

--- a/src/data/proofs/erdos-700/meta.json
+++ b/src/data/proofs/erdos-700/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/700"
     ],
     "leanFile": "Proofs/Erdos700Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/700",
+    "erdosUrl": "https://erdosproblems.com/700"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-706/meta.json
+++ b/src/data/proofs/erdos-706/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/706"
     ],
     "leanFile": "Proofs/Erdos706Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/706",
+    "erdosUrl": "https://erdosproblems.com/706"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-719/meta.json
+++ b/src/data/proofs/erdos-719/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos719Problem.lean",
     "tags": [
+      "erdos",
       "graph-theory",
       "hypergraphs",
       "turan-theory",

--- a/src/data/proofs/erdos-726/meta.json
+++ b/src/data/proofs/erdos-726/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/726"
     ],
     "leanFile": "Proofs/Erdos726Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/726",
+    "erdosUrl": "https://erdosproblems.com/726"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-730/meta.json
+++ b/src/data/proofs/erdos-730/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos730Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "binomial coefficients",
       "prime divisors",

--- a/src/data/proofs/erdos-731/meta.json
+++ b/src/data/proofs/erdos-731/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos731Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "binomial coefficients",
       "divisibility",

--- a/src/data/proofs/erdos-738/meta.json
+++ b/src/data/proofs/erdos-738/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos738Problem.lean",
     "tags": [
+      "erdos",
       "graph theory",
       "chromatic number",
       "triangle-free",

--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/741",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos741Problem.lean",
-    "tags": ["additive-combinatorics", "density", "sumsets", "basis"],
+    "tags": [
+      "erdos",
+      "additive-combinatorics",
+      "density",
+      "sumsets",
+      "basis"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 741,

--- a/src/data/proofs/erdos-749/meta.json
+++ b/src/data/proofs/erdos-749/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/749"
     ],
     "leanFile": "Proofs/Erdos749Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/749",
+    "erdosUrl": "https://erdosproblems.com/749"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-75/meta.json
+++ b/src/data/proofs/erdos-75/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/75",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos75Problem.lean",
-    "tags": ["graph theory", "chromatic number", "independence number", "infinite combinatorics"],
+    "tags": [
+      "erdos",
+      "graph theory",
+      "chromatic number",
+      "independence number",
+      "infinite combinatorics"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 75,

--- a/src/data/proofs/erdos-750/meta.json
+++ b/src/data/proofs/erdos-750/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/750"
     ],
     "leanFile": "Proofs/Erdos750Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/750",
+    "erdosUrl": "https://erdosproblems.com/750"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/761"
     ],
     "leanFile": "Proofs/Erdos761Problem.lean",
-    "sorries": 1
+    "sorries": 1,
+    "sourceUrl": "https://erdosproblems.com/761",
+    "erdosUrl": "https://erdosproblems.com/761"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-768/meta.json
+++ b/src/data/proofs/erdos-768/meta.json
@@ -8,13 +8,22 @@
     "sourceUrl": "https://erdosproblems.com/768",
     "status": "axiom",
     "proofRepoPath": "Proofs/Erdos768Problem.lean",
-    "tags": ["number-theory", "divisibility", "asymptotics", "group-theory"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "divisibility",
+      "asymptotics",
+      "group-theory"
+    ],
     "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 768,
     "erdosUrl": "https://erdosproblems.com/768",
     "erdosProblemStatus": "open",
-    "oeis": ["A001034", "A352287"],
+    "oeis": [
+      "A001034",
+      "A352287"
+    ],
     "references": [
       {
         "key": "Er",
@@ -22,10 +31,26 @@
       }
     ],
     "mathlibDependencies": [
-      {"theorem": "Nat.primeFactors", "description": "Set of distinct prime factors", "module": "Mathlib.Data.Nat.PrimeFin"},
-      {"theorem": "Nat.divisors", "description": "Finset of divisors of a natural number", "module": "Mathlib.NumberTheory.Divisors"},
-      {"theorem": "IsSimpleGroup", "description": "Predicate for simple groups", "module": "Mathlib.GroupTheory.SpecificGroups.Basic"},
-      {"theorem": "Real.sqrt", "description": "Real square root function", "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"}
+      {
+        "theorem": "Nat.primeFactors",
+        "description": "Set of distinct prime factors",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "Nat.divisors",
+        "description": "Finset of divisors of a natural number",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "IsSimpleGroup",
+        "description": "Predicate for simple groups",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Basic"
+      },
+      {
+        "theorem": "Real.sqrt",
+        "description": "Real square root function",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
     ],
     "originalContributions": [
       "Formal definition of the witness divisor property and set A",
@@ -50,15 +75,69 @@
     ]
   },
   "sections": [
-    {"id": "header-imports", "title": "Header and Imports", "startLine": 1, "endLine": 20, "summary": "Module docstring describing set A, Erdős's bounds, connection to simple group orders. Imports Mathlib."},
-    {"id": "set-a-definition", "title": "The Set A", "startLine": 22, "endLine": 42, "summary": "Defines hasWitnessDivisor, inSetA, setA, and the alternative definition inSetA' using primeFactors and divisors."},
-    {"id": "basic-properties", "title": "Basic Membership Properties", "startLine": 44, "endLine": 75, "summary": "Proves 1 ∈ A (vacuously), prime powers ∉ A (partial, with sorry), and states a criterion for products of special primes."},
-    {"id": "counting-density", "title": "Counting Function and Density", "startLine": 77, "endLine": 100, "summary": "Defines countA via Finset.filter, densityA as the ratio, and exponentFunc = √(log N)·log log N."},
-    {"id": "erdos-bounds", "title": "Erdős's Density Bounds", "startLine": 102, "endLine": 127, "summary": "States Erdős's lower bound (density ≥ exp(-c·f(N))) and upper bound (density ≤ exp(-(1+o(1))√(log N·log log N))) as axioms. Main conjecture as a disjunction."},
-    {"id": "simple-groups", "title": "Connection to Simple Groups", "startLine": 128, "endLine": 147, "summary": "Defines isSimpleGroupOrder and isNonCyclicSimpleGroupOrder using Mathlib's IsSimpleGroup and IsCyclic. States that non-cyclic simple group orders are in A."},
-    {"id": "structural-properties", "title": "Structural Properties", "startLine": 149, "endLine": 165, "summary": "Squarefree part structure theorem (sorry) and existence of smallest non-trivial element of A."},
-    {"id": "asymptotic-analysis", "title": "Asymptotic Analysis and OEIS", "startLine": 167, "endLine": 205, "summary": "Log-log density definition, scaling axiom, small elements from OEIS A352287, and proof that 6 ∈ A via interval_cases."},
-    {"id": "main-problem", "title": "Main Open Problem", "startLine": 207, "endLine": 231, "summary": "Formal statement: there exist c₁ ≤ c₂ bounding the density between exp(-c₂·f(N)) and exp(-c₁·f(N)) for all N ≥ 10."}
+    {
+      "id": "header-imports",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 20,
+      "summary": "Module docstring describing set A, Erdős's bounds, connection to simple group orders. Imports Mathlib."
+    },
+    {
+      "id": "set-a-definition",
+      "title": "The Set A",
+      "startLine": 22,
+      "endLine": 42,
+      "summary": "Defines hasWitnessDivisor, inSetA, setA, and the alternative definition inSetA' using primeFactors and divisors."
+    },
+    {
+      "id": "basic-properties",
+      "title": "Basic Membership Properties",
+      "startLine": 44,
+      "endLine": 75,
+      "summary": "Proves 1 ∈ A (vacuously), prime powers ∉ A (partial, with sorry), and states a criterion for products of special primes."
+    },
+    {
+      "id": "counting-density",
+      "title": "Counting Function and Density",
+      "startLine": 77,
+      "endLine": 100,
+      "summary": "Defines countA via Finset.filter, densityA as the ratio, and exponentFunc = √(log N)·log log N."
+    },
+    {
+      "id": "erdos-bounds",
+      "title": "Erdős's Density Bounds",
+      "startLine": 102,
+      "endLine": 127,
+      "summary": "States Erdős's lower bound (density ≥ exp(-c·f(N))) and upper bound (density ≤ exp(-(1+o(1))√(log N·log log N))) as axioms. Main conjecture as a disjunction."
+    },
+    {
+      "id": "simple-groups",
+      "title": "Connection to Simple Groups",
+      "startLine": 128,
+      "endLine": 147,
+      "summary": "Defines isSimpleGroupOrder and isNonCyclicSimpleGroupOrder using Mathlib's IsSimpleGroup and IsCyclic. States that non-cyclic simple group orders are in A."
+    },
+    {
+      "id": "structural-properties",
+      "title": "Structural Properties",
+      "startLine": 149,
+      "endLine": 165,
+      "summary": "Squarefree part structure theorem (sorry) and existence of smallest non-trivial element of A."
+    },
+    {
+      "id": "asymptotic-analysis",
+      "title": "Asymptotic Analysis and OEIS",
+      "startLine": 167,
+      "endLine": 205,
+      "summary": "Log-log density definition, scaling axiom, small elements from OEIS A352287, and proof that 6 ∈ A via interval_cases."
+    },
+    {
+      "id": "main-problem",
+      "title": "Main Open Problem",
+      "startLine": 207,
+      "endLine": 231,
+      "summary": "Formal statement: there exist c₁ ≤ c₂ bounding the density between exp(-c₂·f(N)) and exp(-c₁·f(N)) for all N ≥ 10."
+    }
   ],
   "conclusion": {
     "summary": "This formalization introduces the witness divisor set A, proves basic membership (1 ∈ A, 6 ∈ A, prime powers ∉ A), connects to simple group orders via Sylow theory, and states Erdős's two-sided density bounds. The 231-line file formalizes the main conjecture as whether the ratio -log(density)/f(N) converges, with 3 sorries remaining in structural proofs.",

--- a/src/data/proofs/erdos-770/meta.json
+++ b/src/data/proofs/erdos-770/meta.json
@@ -19,7 +19,9 @@
       "https://erdosproblems.com/770"
     ],
     "leanFile": "Proofs/Erdos770Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/770",
+    "erdosUrl": "https://erdosproblems.com/770"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-776/meta.json
+++ b/src/data/proofs/erdos-776/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos776Problem.lean",
     "tags": [
+      "erdos",
       "combinatorics",
       "extremal set theory",
       "antichains",

--- a/src/data/proofs/erdos-78/meta.json
+++ b/src/data/proofs/erdos-78/meta.json
@@ -22,7 +22,9 @@
       "https://erdosproblems.com/78"
     ],
     "leanFile": "Proofs/Erdos78Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/78",
+    "erdosUrl": "https://erdosproblems.com/78"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-783/meta.json
+++ b/src/data/proofs/erdos-783/meta.json
@@ -19,7 +19,9 @@
       "https://erdosproblems.com/783"
     ],
     "leanFile": "Proofs/Erdos783Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/783",
+    "erdosUrl": "https://erdosproblems.com/783"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-810/meta.json
+++ b/src/data/proofs/erdos-810/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/810",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos810Problem.lean",
-    "tags": ["graph-theory", "ramsey-theory", "edge-coloring"],
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "ramsey-theory",
+      "edge-coloring"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 810,

--- a/src/data/proofs/erdos-82/meta.json
+++ b/src/data/proofs/erdos-82/meta.json
@@ -8,7 +8,15 @@
     "sourceUrl": "https://erdosproblems.com/82",
     "status": "complete",
     "proofRepoPath": "Proofs/Erdos82Problem.lean",
-    "tags": ["graph-theory", "ramsey-theory", "regular-graphs", "extremal-graph-theory", "induced-subgraphs", "open"],
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "ramsey-theory",
+      "regular-graphs",
+      "extremal-graph-theory",
+      "induced-subgraphs",
+      "open"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 82,
@@ -17,10 +25,26 @@
     "dateAdded": "2026-01-19",
     "mathlib_version": "4.15.0",
     "mathlibDependencies": [
-      { "theorem": "SimpleGraph", "description": "Simple graph structure", "module": "Mathlib.Combinatorics.SimpleGraph.Basic" },
-      { "theorem": "SimpleGraph.Subgraph", "description": "Subgraph operations", "module": "Mathlib.Combinatorics.SimpleGraph.Subgraph" },
-      { "theorem": "Nat.log", "description": "Natural number logarithm", "module": "Mathlib.Data.Nat.Log" },
-      { "theorem": "Filter.Tendsto", "description": "Filter-based limits", "module": "Mathlib.Order.Filter.Basic" }
+      {
+        "theorem": "SimpleGraph",
+        "description": "Simple graph structure",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+      },
+      {
+        "theorem": "SimpleGraph.Subgraph",
+        "description": "Subgraph operations",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Subgraph"
+      },
+      {
+        "theorem": "Nat.log",
+        "description": "Natural number logarithm",
+        "module": "Mathlib.Data.Nat.Log"
+      },
+      {
+        "theorem": "Filter.Tendsto",
+        "description": "Filter-based limits",
+        "module": "Mathlib.Order.Filter.Basic"
+      }
     ],
     "originalContributions": [
       "IsRegular and IsRegularGraph definitions using SimpleGraph.degree",

--- a/src/data/proofs/erdos-823/meta.json
+++ b/src/data/proofs/erdos-823/meta.json
@@ -10,6 +10,7 @@
     "status": "solved",
     "proofRepoPath": "Proofs/Erdos823Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "sum-of-divisors",
       "sequences",

--- a/src/data/proofs/erdos-825/meta.json
+++ b/src/data/proofs/erdos-825/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/825",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos825Problem.lean",
-    "tags": ["number theory", "divisor functions", "weird numbers", "semiperfect numbers"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "divisor functions",
+      "weird numbers",
+      "semiperfect numbers"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 825,

--- a/src/data/proofs/erdos-827/meta.json
+++ b/src/data/proofs/erdos-827/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/827",
     "status": "enhanced",
     "proofRepoPath": "Proofs/Erdos827Problem.lean",
-    "tags": ["geometry", "discrete-geometry", "circumradii", "ramsey-type"],
+    "tags": [
+      "erdos",
+      "geometry",
+      "discrete-geometry",
+      "circumradii",
+      "ramsey-type"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 827,

--- a/src/data/proofs/erdos-837/meta.json
+++ b/src/data/proofs/erdos-837/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/837"
     ],
     "leanFile": "Proofs/Erdos837Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/837",
+    "erdosUrl": "https://erdosproblems.com/837"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-839/meta.json
+++ b/src/data/proofs/erdos-839/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/839"
     ],
     "leanFile": "Proofs/Erdos839Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/839",
+    "erdosUrl": "https://erdosproblems.com/839"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-846/meta.json
+++ b/src/data/proofs/erdos-846/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos846Problem.lean",
     "tags": [
+      "erdos",
       "combinatorial geometry",
       "collinearity",
       "Ramsey theory"

--- a/src/data/proofs/erdos-848/meta.json
+++ b/src/data/proofs/erdos-848/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/848"
     ],
     "leanFile": "Proofs/Erdos848Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/848",
+    "erdosUrl": "https://erdosproblems.com/848"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-850/meta.json
+++ b/src/data/proofs/erdos-850/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/850",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos850Problem.lean",
-    "tags": ["number-theory", "prime-factors", "abc-conjecture", "erdos-woods"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "prime-factors",
+      "abc-conjecture",
+      "erdos-woods"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 850,

--- a/src/data/proofs/erdos-852/meta.json
+++ b/src/data/proofs/erdos-852/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/852",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos852Problem.lean",
-    "tags": ["number theory", "prime gaps", "sieve theory"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "prime gaps",
+      "sieve theory"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 852,

--- a/src/data/proofs/erdos-853/meta.json
+++ b/src/data/proofs/erdos-853/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos853Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "primes",
       "prime-gaps",

--- a/src/data/proofs/erdos-854/meta.json
+++ b/src/data/proofs/erdos-854/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/854",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos854Problem.lean",
-    "tags": ["number theory", "prime gaps", "primorials", "sieve theory"],
+    "tags": [
+      "erdos",
+      "number theory",
+      "prime gaps",
+      "primorials",
+      "sieve theory"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 854,

--- a/src/data/proofs/erdos-863/meta.json
+++ b/src/data/proofs/erdos-863/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/863",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos863Problem.lean",
-    "tags": ["additive-combinatorics", "sidon-sets", "number-theory"],
+    "tags": [
+      "erdos",
+      "additive-combinatorics",
+      "sidon-sets",
+      "number-theory"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 863,

--- a/src/data/proofs/erdos-864/meta.json
+++ b/src/data/proofs/erdos-864/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos864Problem.lean",
     "tags": [
+      "erdos",
       "additive combinatorics",
       "Sidon sets",
       "sum representations",

--- a/src/data/proofs/erdos-87/meta.json
+++ b/src/data/proofs/erdos-87/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/87",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos87Problem.lean",
-    "tags": ["graph theory", "ramsey theory", "chromatic number"],
+    "tags": [
+      "erdos",
+      "graph theory",
+      "ramsey theory",
+      "chromatic number"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 87,

--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos875Problem.lean",
     "tags": [
+      "erdos",
       "additive combinatorics",
       "sumsets",
       "growth rates",

--- a/src/data/proofs/erdos-883/meta.json
+++ b/src/data/proofs/erdos-883/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos883Problem.lean",
     "tags": [
+      "erdos",
       "graph-theory",
       "number-theory",
       "coprime-graph",

--- a/src/data/proofs/erdos-889/meta.json
+++ b/src/data/proofs/erdos-889/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/889",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos889Problem.lean",
-    "tags": ["number-theory", "prime-factors", "consecutive-integers", "arithmetic-functions"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "prime-factors",
+      "consecutive-integers",
+      "arithmetic-functions"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 889,

--- a/src/data/proofs/erdos-890/meta.json
+++ b/src/data/proofs/erdos-890/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos890Problem.lean",
     "tags": [
+      "erdos",
       "number-theory",
       "prime-factors",
       "consecutive-integers",

--- a/src/data/proofs/erdos-892/meta.json
+++ b/src/data/proofs/erdos-892/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/892",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos892Problem.lean",
-    "tags": ["number-theory", "primitive-sets", "divisibility", "sequences"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "primitive-sets",
+      "divisibility",
+      "sequences"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 892,

--- a/src/data/proofs/erdos-893/meta.json
+++ b/src/data/proofs/erdos-893/meta.json
@@ -20,7 +20,9 @@
       "https://erdosproblems.com/893"
     ],
     "leanFile": "Proofs/Erdos893Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/893",
+    "erdosUrl": "https://erdosproblems.com/893"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-896/meta.json
+++ b/src/data/proofs/erdos-896/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/896",
     "status": "enhanced",
     "proofRepoPath": "Proofs/Erdos896Problem.lean",
-    "tags": ["number-theory", "multiplicative-combinatorics", "product-sets", "asymptotic-bounds"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "multiplicative-combinatorics",
+      "product-sets",
+      "asymptotic-bounds"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 896,

--- a/src/data/proofs/erdos-90/meta.json
+++ b/src/data/proofs/erdos-90/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/90",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos90Problem.lean",
-    "tags": ["combinatorial geometry", "unit distance", "incidence geometry"],
+    "tags": [
+      "erdos",
+      "combinatorial geometry",
+      "unit distance",
+      "incidence geometry"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 90,

--- a/src/data/proofs/erdos-905/meta.json
+++ b/src/data/proofs/erdos-905/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos905Problem.lean",
     "tags": [
+      "erdos",
       "graph-theory",
       "extremal-graph-theory",
       "triangles",

--- a/src/data/proofs/erdos-913/meta.json
+++ b/src/data/proofs/erdos-913/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/913",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos913Problem.lean",
-    "tags": ["number-theory", "prime-factorization", "consecutive-integers"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "prime-factorization",
+      "consecutive-integers"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 913,

--- a/src/data/proofs/erdos-929/meta.json
+++ b/src/data/proofs/erdos-929/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos929Problem.lean",
     "tags": [
+      "erdos",
       "number theory",
       "smooth numbers",
       "sieve methods",

--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/931",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos931Problem.lean",
-    "tags": ["number-theory", "prime-factorization", "consecutive-integers"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "prime-factorization",
+      "consecutive-integers"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 931,

--- a/src/data/proofs/erdos-935/meta.json
+++ b/src/data/proofs/erdos-935/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/935",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos935Problem.lean",
-    "tags": ["number-theory", "powerful-numbers", "consecutive-products"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "powerful-numbers",
+      "consecutive-products"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 935,

--- a/src/data/proofs/erdos-943/meta.json
+++ b/src/data/proofs/erdos-943/meta.json
@@ -18,7 +18,9 @@
       "https://erdosproblems.com/943"
     ],
     "leanFile": "Proofs/Erdos943Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/943",
+    "erdosUrl": "https://erdosproblems.com/943"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-949/meta.json
+++ b/src/data/proofs/erdos-949/meta.json
@@ -8,7 +8,13 @@
     "sourceUrl": "https://erdosproblems.com/949",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos949Problem.lean",
-    "tags": ["set-theory", "additive-combinatorics", "sum-free-sets", "cardinal-arithmetic"],
+    "tags": [
+      "erdos",
+      "set-theory",
+      "additive-combinatorics",
+      "sum-free-sets",
+      "cardinal-arithmetic"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 949,

--- a/src/data/proofs/erdos-950/meta.json
+++ b/src/data/proofs/erdos-950/meta.json
@@ -8,7 +8,14 @@
     "sourceUrl": "https://erdosproblems.com/950",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos950Problem.lean",
-    "tags": ["number-theory", "prime-numbers", "prime-gaps", "analytic-number-theory", "open-problem"],
+    "tags": [
+      "erdos",
+      "number-theory",
+      "prime-numbers",
+      "prime-gaps",
+      "analytic-number-theory",
+      "open-problem"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 950,

--- a/src/data/proofs/erdos-954/meta.json
+++ b/src/data/proofs/erdos-954/meta.json
@@ -21,7 +21,9 @@
       "https://erdosproblems.com/954"
     ],
     "leanFile": "Proofs/Erdos954Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/954",
+    "erdosUrl": "https://erdosproblems.com/954"
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-958/meta.json
+++ b/src/data/proofs/erdos-958/meta.json
@@ -9,6 +9,7 @@
     "status": "complete",
     "proofRepoPath": "Proofs/Erdos958Problem.lean",
     "tags": [
+      "erdos",
       "geometry",
       "distances",
       "point-configurations",

--- a/src/data/proofs/erdos-959/meta.json
+++ b/src/data/proofs/erdos-959/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos959Problem.lean",
     "tags": [
+      "erdos",
       "combinatorial-geometry",
       "distances",
       "frequency",

--- a/src/data/proofs/erdos-963/meta.json
+++ b/src/data/proofs/erdos-963/meta.json
@@ -9,6 +9,7 @@
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos963Problem.lean",
     "tags": [
+      "erdos",
       "additive combinatorics",
       "dissociated sets",
       "subset sums",

--- a/src/data/proofs/erdos-98/meta.json
+++ b/src/data/proofs/erdos-98/meta.json
@@ -8,7 +8,12 @@
     "sourceUrl": "https://erdosproblems.com/98",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos98Problem.lean",
-    "tags": ["combinatorial-geometry", "distinct-distances", "incidence-geometry"],
+    "tags": [
+      "erdos",
+      "combinatorial-geometry",
+      "distinct-distances",
+      "incidence-geometry"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 98,

--- a/src/data/proofs/erdos-szekeres/meta.json
+++ b/src/data/proofs/erdos-szekeres/meta.json
@@ -10,6 +10,7 @@
     "status": "verified",
     "proofRepoPath": "Proofs/ErdosSzekeres.lean",
     "tags": [
+      "erdos",
       "combinatorics",
       "ramsey-theory",
       "sequences",


### PR DESCRIPTION
## Summary

- Add missing `erdos` tag to 182 gallery entries
- Add missing `sourceUrl` to 79 entries (erdosproblems.com/N)  
- Fix erdos-17 author from 'Unknown' to 'Erdős'
- Normalize meta fields across 275+ Erdős entries (from previous work)

All 1140 gallery entries now pass comprehensive quality audit across tags, URLs, and author fields.

## Test plan
- [x] `pnpm build` succeeds
- [x] Quality audit shows 0 remaining issues
- [x] All meta.json files are valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)