### PR TITLE
Enrich 8 Wiedijk entries with keyInsights, sections, and metadata

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -1,1 +1,40 @@
-{"version": 1, "entries": {}}
+{
+  "version": 1,
+  "entries": {
+    "cauchy-schwarz": {
+      "passes": 1,
+      "lastEnriched": "2026-02-08T05:37:03Z",
+      "quality": 72
+    },
+    "cramers-rule": {
+      "passes": 1,
+      "lastEnriched": "2026-02-08T05:37:04Z",
+      "quality": 72
+    },
+    "derangements": {
+      "passes": 1,
+      "lastEnriched": "2026-02-08T05:37:05Z",
+      "quality": 72
+    },
+    "euler-totient": {
+      "passes": 1,
+      "lastEnriched": "2026-02-08T05:37:05Z",
+      "quality": 72
+    },
+    "fundamental-arithmetic": {
+      "passes": 1,
+      "lastEnriched": "2026-02-08T05:37:06Z",
+      "quality": 72
+    },
+    "herons-formula": {
+      "passes": 1,
+      "lastEnriched": "2026-02-08T05:37:06Z",
+      "quality": 72
+    },
+    "isosceles-triangle": {
+      "passes": 1,
+      "lastEnriched": "2026-02-08T05:37:07Z",
+      "quality": 72
+    }
+  }
+}

--- a/src/data/proofs/lagrange-theorem/annotations.json
+++ b/src/data/proofs/lagrange-theorem/annotations.json
@@ -3,11 +3,13 @@
     "id": "ann-intro",
     "proofId": "lagrange-theorem",
     "range": {"startLine": 8, "endLine": 55},
-    "type": "concept",
+    "type": "context",
     "title": "Lagrange's Theorem: Wiedijk #71",
-    "content": "**Lagrange's Theorem**:\n\nFor a finite group $G$ and subgroup $H \\leq G$:\n$$|H| \\text{ divides } |G|$$\n\nEquivalently:\n$$|G| = |H| \\cdot [G : H]$$\n\nwhere $[G : H]$ is the **index** (number of cosets).\n\n**Historical**: Joseph-Louis Lagrange proved this in 1771 studying permutation groups.\n\n**Significance**: One of the most important theorems in abstract algebra, constraining subgroup structure.",
+    "content": "**Lagrange's Theorem**:\n\nFor a finite group $G$ and subgroup $H \\leq G$:\n$$|H| \\mid |G|$$\n\nEquivalently: $|G| = |H| \\cdot [G : H]$ where $[G : H]$ is the **index** (number of cosets).\n\n**Historical**: Lagrange proved this in 1771 while studying permutation groups and the solvability of polynomial equations. He observed that the number of distinct values of a rational function of polynomial roots divides $n!$. The abstract group-theoretic statement emerged through Galois, Cayley, and Jordan in the 19th century. The coset-partition proof is due to Dedekind.\n\n**Significance**: Perhaps the most important single theorem in finite group theory. It constrains subgroup structure, implies Fermat's and Euler's theorems in number theory, and leads to the Sylow theorems, orbit-stabilizer theorem, and class equation.",
+    "mathContext": "$|H| \\mid |G|$; equivalently $|G| = |H| \\cdot [G:H]$",
     "significance": "critical",
-    "relatedConcepts": ["subgroup", "index", "cosets", "finite groups"]
+    "relatedConcepts": ["subgroup", "index", "cosets", "finite groups", "Galois"],
+    "prerequisites": ["group theory basics", "finite sets", "divisibility"]
   },
   {
     "id": "ann-main-theorem",
@@ -15,84 +17,82 @@
     "range": {"startLine": 59, "endLine": 80},
     "type": "theorem",
     "title": "Main Theorem",
-    "content": "**Lagrange's Theorem (Wiedijk #71)**:\n\n$$|H| \\mid |G|$$\n\n**Lean Statement**:\n```lean\ntheorem card_subgroup_dvd_card (G : Type*) [Group G] [Fintype G]\n    (H : Subgroup G) [Fintype H] : \n    Fintype.card H ∣ Fintype.card G\n```\n\n**Proof idea**: Partition $G$ into left cosets of $H$:\n- Each coset $gH$ has size $|H|$ (via bijection $h \\mapsto gh$)\n- Cosets are disjoint\n- $G = \\bigsqcup gH$\n\nSo $|G| = (\\text{# cosets}) \\times |H|$.",
-    "mathContext": "|H| divides |G|",
+    "content": "**Lagrange's Theorem (Wiedijk #71)**:\n\n$$|H| \\mid |G|$$\n\n```lean\ntheorem card_subgroup_dvd_card (G : Type*) [Group G] [Fintype G]\n    (H : Subgroup G) [Fintype H] : Fintype.card H ∣ Fintype.card G\n```\n\n**Proof**: Delegates to Mathlib's `Subgroup.card_subgroup_dvd_card` after converting between `Fintype.card` and `Nat.card`. The underlying Mathlib proof partitions $G$ into left cosets of $H$:\n- Each coset $gH$ has size $|H|$ (via the bijection $h \\mapsto gh$)\n- Cosets are disjoint (if $g_1H \\cap g_2H \\neq \\emptyset$ then $g_1H = g_2H$)\n- $G = \\bigsqcup gH$ (every element belongs to some coset)\n\nSo $|G| = (\\text{\\# cosets}) \\times |H|$, proving $|H| \\mid |G|$.\n\nTwo formulations are provided: `card_subgroup_dvd_card` with explicit `G` parameter and `lagrange` as an alias.",
+    "mathContext": "$|H| \\mid |G|$ via coset partition $G = \\bigsqcup gH$",
     "significance": "critical",
-    "relatedConcepts": ["Subgroup.card_subgroup_dvd_card", "coset partition"]
+    "relatedConcepts": ["Subgroup.card_subgroup_dvd_card", "coset partition", "Nat.card_eq_fintype_card"],
+    "prerequisites": ["group theory", "finite type cardinality", "divisibility"]
   },
   {
     "id": "ann-index-formula",
     "proofId": "lagrange-theorem",
-    "range": {"startLine": 81, "endLine": 91},
+    "range": {"startLine": 81, "endLine": 106},
     "type": "theorem",
-    "title": "Product Formula",
-    "content": "**Quantitative Lagrange**:\n\n$$|G| = |H| \\times [G : H]$$\n\nwhere $[G : H]$ = index = number of distinct cosets.\n\n**Lean**:\n```lean\ntheorem card_eq_card_mul_index :\n    Fintype.card G = Fintype.card H * H.index\n```\n\n**The index counts cosets**:\n- Trivial subgroup: index = $|G|$\n- Whole group: index = 1",
-    "mathContext": "|G| = |H| × [G:H]",
+    "title": "Product Formula and Cosets",
+    "content": "**Quantitative Lagrange**:\n\n$$|G| = |H| \\times [G : H]$$\n\n```lean\ntheorem card_eq_card_mul_index (G : Type*) [Group G] [Fintype G]\n    (H : Subgroup G) [Fintype H] : Fintype.card G = Fintype.card H * H.index\n```\n\nThis is the 'with witnesses' version: not just that $|H|$ divides $|G|$, but the explicit quotient $[G:H]$ is the number of left cosets.\n\n**Coset partition table**: The documentation includes a table showing four key properties — every element is in some coset, cosets are equal or disjoint, each has size $|H|$, and $G$ is their disjoint union. These are proved as separate lemmas in Mathlib's `GroupTheory.Coset`.\n\n**Boundary cases**: $[G : \\{1\\}] = |G|$ (trivial subgroup splits into singletons) and $[G : G] = 1$ (the whole group is one coset).",
+    "mathContext": "$|G| = |H| \\cdot [G:H]$; index = number of left cosets",
     "significance": "major",
-    "relatedConcepts": ["index", "Subgroup.card_mul_index", "quotient"]
-  },
-  {
-    "id": "ann-cosets",
-    "proofId": "lagrange-theorem",
-    "range": {"startLine": 92, "endLine": 106},
-    "type": "concept",
-    "title": "Coset Partition",
-    "content": "**The Key Insight**:\n\nLeft cosets $gH = \\{gh : h \\in H\\}$ partition $G$:\n\n| Property | Why |\n|----------|-----|\n| $g \\in gH$ | $g = g \\cdot e$ and $e \\in H$ |\n| Cosets equal or disjoint | If $g_1H \\cap g_2H \\neq \\emptyset$ then $g_1H = g_2H$ |\n| $|gH| = |H|$ | $h \\mapsto gh$ is a bijection |\n| $G = \\bigsqcup gH$ | Every element in some coset |\n\n**Conclusion**:\n$$|G| = (\\text{# cosets}) \\times |H| = [G:H] \\times |H|$$",
-    "significance": "major",
-    "relatedConcepts": ["partition", "bijection", "equivalence classes"]
+    "relatedConcepts": ["index", "Subgroup.card_mul_index", "quotient", "coset partition"],
+    "prerequisites": ["coset definition", "bijection between cosets", "finite cardinality"]
   },
   {
     "id": "ann-element-order",
     "proofId": "lagrange-theorem",
     "range": {"startLine": 108, "endLine": 129},
     "type": "theorem",
-    "title": "Corollary: Element Orders",
-    "content": "**Order of Element Divides Group Order**:\n\nFor any $g \\in G$:\n$$\\text{ord}(g) \\mid |G|$$\n\n**Proof**: Apply Lagrange to cyclic subgroup $\\langle g \\rangle$.\n\n**Power by Group Order**:\n$$g^{|G|} = 1$$\n\nSince $\\text{ord}(g) \\mid |G|$, we have $g^{|G|} = (g^{\\text{ord}(g)})^{|G|/\\text{ord}(g)} = 1$.\n\n**Mathlib**: `orderOf_dvd_card`, `pow_card_eq_one`",
-    "mathContext": "ord(g) | |G| ⟹ g^|G| = 1",
+    "title": "Element Order Corollaries",
+    "content": "**Order of Element Divides Group Order**:\n\nFor any $g \\in G$: $\\text{ord}(g) \\mid |G|$\n\n**Proof**: Apply Lagrange to the cyclic subgroup $\\langle g \\rangle$, which has order $\\text{ord}(g)$.\n\n**Power by Group Order**: $g^{|G|} = 1$\n\nSince $\\text{ord}(g) \\mid |G|$, write $|G| = \\text{ord}(g) \\cdot k$, then $g^{|G|} = (g^{\\text{ord}(g)})^k = 1^k = 1$.\n\nThree formulations:\n- `orderOf_dvd_card'` — ord(g) | card G\n- `order_divides_card` — same statement, alternative name\n- `pow_card_eq_one'` — g^(card G) = 1\n\nAll delegate to Mathlib's `orderOf_dvd_card` and `pow_card_eq_one`.",
+    "mathContext": "$\\text{ord}(g) \\mid |G|$, hence $g^{|G|} = 1$",
     "significance": "major",
-    "relatedConcepts": ["orderOf", "cyclic subgroup", "pow_card_eq_one"]
+    "relatedConcepts": ["orderOf", "cyclic subgroup", "pow_card_eq_one", "orderOf_dvd_card"],
+    "prerequisites": ["element order", "cyclic subgroups", "exponentiation in groups"]
   },
   {
     "id": "ann-fermat",
     "proofId": "lagrange-theorem",
     "range": {"startLine": 130, "endLine": 153},
     "type": "theorem",
-    "title": "Fermat's Little Theorem",
-    "content": "**Fermat from Lagrange**:\n\nApply to $(\\mathbb{Z}/p\\mathbb{Z})^\\times$:\n\n1. For prime $p$: $|(\\mathbb{Z}/p\\mathbb{Z})^\\times| = p - 1 = \\phi(p)$\n2. By Lagrange: $\\text{ord}(a) \\mid p - 1$\n3. Therefore: $a^{p-1} \\equiv 1 \\pmod{p}$\n\n**Lean**:\n```lean\ntheorem fermat_little_from_lagrange (a : (ZMod p)ˣ) : \n    a ^ (p - 1) = 1\n```\n\nThis is the **group-theoretic** proof of Fermat's little theorem!",
-    "mathContext": "a^(p-1) ≡ 1 (mod p)",
+    "title": "Fermat's Little Theorem from Lagrange",
+    "content": "**Fermat from Lagrange**:\n\nApply Lagrange to $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ (units of $\\mathbb{Z}/p\\mathbb{Z}$):\n\n1. $|(\\mathbb{Z}/p\\mathbb{Z})^\\times| = \\phi(p) = p - 1$ for prime $p$\n2. By Lagrange: $\\text{ord}(a) \\mid p - 1$\n3. By power corollary: $a^{p-1} = 1$ in $(\\mathbb{Z}/p\\mathbb{Z})^\\times$\n\n```lean\ntheorem fermat_little_from_lagrange {p : ℕ} [hp : Fact (Nat.Prime p)]\n    (a : (ZMod p)ˣ) : a ^ (p - 1) = 1\n```\n\nThe proof chains: $a^{p-1} = a^{\\phi(p)} = a^{|\\text{units}|} = 1$, using `Nat.totient_prime` and `ZMod.card_units_eq_totient` to connect the exponents, then `pow_card_eq_one` for the final step.\n\n**This is the group-theoretic proof of Fermat's little theorem** — arguably the 'right' proof, as it reveals why Fermat's theorem is true: it's a special case of the general fact that element orders divide group orders.",
+    "mathContext": "$a^{p-1} \\equiv 1 \\pmod{p}$ as a corollary of Lagrange applied to $(\\mathbb{Z}/p\\mathbb{Z})^\\times$",
     "significance": "major",
-    "relatedConcepts": ["Fermat's little theorem", "ZMod", "units group"]
+    "relatedConcepts": ["Fermat's little theorem", "ZMod", "units group", "totient", "pow_card_eq_one"],
+    "prerequisites": ["modular arithmetic", "units of Z/pZ", "Euler's totient function"]
   },
   {
     "id": "ann-index-properties",
     "proofId": "lagrange-theorem",
-    "range": {"startLine": 154, "endLine": 168},
+    "range": {"startLine": 154, "endLine": 181},
     "type": "theorem",
     "title": "Index Properties",
-    "content": "**Index = Coset Count**:\n\n$$[G : H] = |G/H| = \\text{# of left cosets}$$\n\n**Index Divides Group Order**:\n$$[G : H] \\mid |G|$$\n\n**Boundary Cases**:\n- $[G : \\{1\\}] = |G|$ (trivial subgroup)\n- $[G : G] = 1$ (whole group)\n\n**Lean**: `Subgroup.index_eq_card`, `Subgroup.index_bot`, `Subgroup.index_top`",
-    "mathContext": "[G:H] = |G/H|",
-    "significance": "minor",
-    "relatedConcepts": ["index", "quotient group", "boundary cases"]
+    "content": "**Index = Coset Count**:\n\n$$[G : H] = |G/H| = \\text{\\# of left cosets}$$\n\n```lean\ntheorem index_eq_card_quotient : H.index = Fintype.card (G ⧸ H)\n```\n\n**Index Divides Group Order**: $[G : H] \\mid |G|$, proved by rewriting via the product formula.\n\n**Boundary Cases**:\n- $[G : \\{1\\}] = |G|$ — the trivial subgroup has $|G|$ singleton cosets\n- $[G : G] = 1$ — the whole group is a single coset\n\nThese boundary cases verify the formula at its extremes. The quotient notation $G ⧸ H$ denotes the set of left cosets (which is a group iff $H$ is normal).",
+    "mathContext": "$[G:H] = |G/H|$; $[G:\\{1\\}] = |G|$; $[G:G] = 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["index", "quotient", "Subgroup.index_bot", "Subgroup.index_top"],
+    "prerequisites": ["quotient types", "left cosets", "boundary analysis"]
   },
   {
     "id": "ann-prime-order",
     "proofId": "lagrange-theorem",
-    "range": {"startLine": 182, "endLine": 212},
+    "range": {"startLine": 182, "endLine": 198},
     "type": "theorem",
     "title": "Prime Order Groups",
-    "content": "**Consequence for Prime Order**:\n\nIf $|G| = p$ (prime), then $G$ has **no non-trivial proper subgroups**.\n\n**Proof**: By Lagrange, $|H| \\mid p$, so $|H| \\in \\{1, p\\}$.\n\n**Groups of Prime Order are Cyclic**:\nEvery element (except identity) generates $G$.\n\n**Converse Fails**: $n \\mid |G|$ does NOT guarantee a subgroup of order $n$.\n\n**Counterexample**: $A_4$ has order 12 but NO subgroup of order 6.\n\nThis motivates Sylow theorems (partial converse).",
-    "mathContext": "|G| prime ⟹ G cyclic",
+    "content": "**Consequence for Prime Order**:\n\nIf $|G| = p$ (prime), then $G$ has **no non-trivial proper subgroups**.\n\n```lean\ntheorem prime_order_simple (H : Subgroup G) [Fintype H]\n    (hp : Nat.Prime (Fintype.card G)) :\n    Fintype.card H = 1 ∨ Fintype.card H = Fintype.card G\n```\n\n**Proof**: By Lagrange, $|H| \\mid p$. Since $p$ is prime, $|H| \\in \\{1, p\\}$ — the subgroup is trivial or the whole group. Uses `Nat.Prime.eq_one_or_self_of_dvd`.\n\n**Groups of Prime Order are Cyclic**: Any non-identity element $g$ has $\\text{ord}(g) | p$ and $\\text{ord}(g) > 1$, so $\\text{ord}(g) = p$ and $\\langle g \\rangle = G$. Formalized via `isCyclic_of_prime_card`.\n\n**Converse is FALSE**: Having $n \\mid |G|$ does NOT guarantee a subgroup of order $n$. The alternating group $A_4$ has order 12 but NO subgroup of order 6. This motivates the Sylow theorems (partial converse for prime powers).",
+    "mathContext": "$|G| = p$ prime $\\Rightarrow$ $G$ cyclic; converse of Lagrange fails ($A_4$)",
     "significance": "major",
-    "relatedConcepts": ["prime order", "cyclic groups", "Sylow theorems"]
+    "relatedConcepts": ["prime order", "cyclic groups", "Sylow theorems", "A₄ counterexample", "isCyclic_of_prime_card"],
+    "prerequisites": ["prime numbers", "cyclic group definition", "divisor properties"]
   },
   {
     "id": "ann-significance",
     "proofId": "lagrange-theorem",
-    "range": {"startLine": 200, "endLine": 212},
-    "type": "concept",
-    "title": "Why Lagrange Matters",
-    "content": "**Fundamental Because**:\n\n1. **Structure constraints**: Limits possible subgroup orders\n2. **Element orders**: Via cyclic subgroups\n3. **Counting**: Enables group classification\n4. **Number theory**: Implies Fermat, Euler theorems\n5. **Generalizations**: Orbit-stabilizer, class equation\n\n**Important Non-Result**:\nConverse is FALSE! Having $n \\mid |G|$ doesn't guarantee a subgroup of order $n$.\n\n$A_4$ (order 12) has no subgroup of order 6 - motivates Sylow theorems.",
-    "significance": "major",
-    "relatedConcepts": ["orbit-stabilizer", "class equation", "Sylow"]
+    "range": {"startLine": 200, "endLine": 222},
+    "type": "context",
+    "title": "Significance and Verification",
+    "content": "**Why Lagrange's Theorem Matters**:\n\n1. **Structure constraints**: Limits possible subgroup orders to divisors of $|G|$\n2. **Element orders**: Via cyclic subgroups, constrains orders of individual elements\n3. **Counting arguments**: Enables group counting and classification (e.g., groups of order $\\leq 15$)\n4. **Number theory**: Implies Fermat's little theorem and Euler's theorem\n5. **Extensions**: Generalizes to orbit-stabilizer ($|G| = |\\text{Orb}(x)| \\cdot |\\text{Stab}(x)|$) and the class equation\n\n**The false converse**: $n | |G|$ does NOT imply existence of a subgroup of order $n$. The alternating group $A_4$ (order 12) has no subgroup of order 6, despite $6 | 12$. This is because a subgroup of order 6 would be normal (index 2) and isomorphic to $S_3$, but $A_4$'s structure (Klein four-group plus 3-cycles) doesn't permit this.\n\nThe `#check` statements verify all seven exported theorems are well-typed.",
+    "mathContext": "Five applications: structure, elements, counting, number theory, orbit-stabilizer",
+    "significance": "supporting",
+    "relatedConcepts": ["orbit-stabilizer", "class equation", "Sylow theorems", "group classification"],
+    "prerequisites": ["group theory overview", "alternating groups", "normal subgroups"]
   }
 ]

--- a/src/data/proofs/lagrange-theorem/meta.json
+++ b/src/data/proofs/lagrange-theorem/meta.json
@@ -20,11 +20,34 @@
     "wiedijkNumber": 71
   },
   "overview": {
-    "historicalContext": "Lagrange proved this in 1771 while studying permutation groups. One of the first major results in group theory.",
-    "problemStatement": "**Lagrange's Theorem**:\n\n$$|H| \\text{ divides } |G|$$\n\nfor any subgroup H of finite group G.",
-    "proofStrategy": "Partition G into cosets of H. Each coset has size |H|, so |G| = |H| × [G:H].",
-    "keyInsights": ["Cosets partition the group", "Each coset has the same size", "Index [G:H] = |G|/|H|"]
+    "historicalContext": "Joseph-Louis Lagrange proved this theorem in 1771 in his *Reflexions sur la resolution algebrique des equations*, while studying permutation groups in connection with the solvability of polynomial equations by radicals. Lagrange observed that the number of 'values' (arrangements) of a rational function of the roots always divides $n!$, which is essentially the statement that subgroup orders divide the group order for symmetric groups. The theorem was not stated in the language of abstract groups (which didn't exist until the 1830s with Galois and later Cayley); Lagrange worked entirely with permutations. The abstract formulation emerged through the work of Galois (1832), Cayley (1854), and Jordan (1870). The coset-based proof — partitioning $G$ into translates $gH$ — is due to Dedekind. The theorem's converse is famously false: $A_4$ (order 12) has no subgroup of order 6, despite $6 | 12$. The Sylow theorems (1872) provide the best partial converse: subgroups of prime-power order $p^k | |G|$ always exist.",
+    "problemStatement": "**Lagrange's Theorem**:\n\nFor a finite group $G$ and subgroup $H \\leq G$:\n$$|H| \\mid |G|$$\n\nEquivalently: $|G| = |H| \\cdot [G:H]$ where $[G:H]$ is the index (number of left cosets).",
+    "proofStrategy": "The formalization delegates the core divisibility result to Mathlib's `Subgroup.card_subgroup_dvd_card`, which uses the coset partition argument. The product formula $|G| = |H| \\cdot [G:H]$ is derived from `Subgroup.card_mul_index`. Corollaries include: element order divides group order (via cyclic subgroups), the power-by-group-order identity $g^{|G|} = 1$, Fermat's little theorem as a special case for $(\\mathbb{Z}/p\\mathbb{Z})^\\times$, and the classification of prime-order groups as cyclic.",
+    "keyInsights": [
+      "The proof relies on a single elegant idea: left cosets $gH = \\{gh : h \\in H\\}$ partition $G$ into pieces of equal size $|H|$. The translation map $h \\mapsto gh$ is a bijection from $H$ to $gH$, and cosets are either identical or disjoint (they are equivalence classes of the relation $a \\sim b \\iff a^{-1}b \\in H$).",
+      "Lagrange's theorem implies every element's order divides the group order. Applied to the cyclic subgroup $\\langle g \\rangle$, we get $\\text{ord}(g) | |G|$, hence $g^{|G|} = 1$. This single corollary yields both Fermat's little theorem ($a^{p-1} \\equiv 1 \\pmod{p}$) and Euler's theorem ($a^{\\phi(n)} \\equiv 1 \\pmod{n}$).",
+      "The converse is spectacularly false: $n | |G|$ does not guarantee a subgroup of order $n$. The alternating group $A_4$ has order 12 but no subgroup of order 6. This failure motivates the Sylow theorems, which guarantee subgroups of prime-power order, and Hall's theorem for solvable groups.",
+      "For groups of prime order $p$, Lagrange immediately implies the group is cyclic: any non-identity element $g$ generates a subgroup $\\langle g \\rangle$ of order dividing $p$, and since $\\text{ord}(g) > 1$, we must have $\\text{ord}(g) = p$, so $\\langle g \\rangle = G$.",
+      "The index $[G:H]$ counts the number of distinct cosets and satisfies the tower law: for $K \\leq H \\leq G$, we have $[G:K] = [G:H] \\cdot [H:K]$. This multiplicativity of the index is the algebraic backbone of the orbit-stabilizer theorem and the class equation."
+    ]
   },
-  "sections": [{"id": "header", "title": "Introduction", "startLine": 1, "endLine": 55, "summary": "Overview."}],
-  "conclusion": {"summary": "Lagrange's theorem is verified with corollaries about element orders."}
+  "sections": [
+    {"id": "header", "title": "Module Header and Imports", "startLine": 1, "endLine": 55, "summary": "Documentation header explaining Lagrange's Theorem as Wiedijk #71, with historical notes on Lagrange (1771) and permutation groups, proof strategy via coset partition, and Mathlib dependencies."},
+    {"id": "main-theorem", "title": "Main Theorem", "startLine": 57, "endLine": 80, "summary": "Two formulations of Lagrange's theorem: card_subgroup_dvd_card and lagrange, both proving |H| divides |G| via Subgroup.card_subgroup_dvd_card."},
+    {"id": "index-formula", "title": "Product Formula and Cosets", "startLine": 81, "endLine": 106, "summary": "The quantitative version |G| = |H| × [G:H] via card_mul_index, plus intuitive explanation of how cosets partition G into equal-sized pieces."},
+    {"id": "corollaries", "title": "Element Order Corollaries", "startLine": 108, "endLine": 129, "summary": "Three corollaries: ord(g) divides |G| (orderOf_dvd_card), alternative statement, and g^|G| = 1 (pow_card_eq_one)."},
+    {"id": "fermat", "title": "Fermat's Little Theorem", "startLine": 130, "endLine": 153, "summary": "Derives a^(p-1) ≡ 1 (mod p) from Lagrange applied to (Z/pZ)×, connecting group theory to number theory via ZMod.card_units_eq_totient."},
+    {"id": "index-properties", "title": "Index Properties", "startLine": 154, "endLine": 181, "summary": "Properties of the subgroup index: equals card of quotient, divides group order, boundary cases (trivial subgroup has index |G|, whole group has index 1)."},
+    {"id": "prime-order", "title": "Prime Order Groups", "startLine": 182, "endLine": 198, "summary": "Groups of prime order have no non-trivial proper subgroups (prime_order_simple) and are cyclic (prime_order_cyclic via isCyclic_of_prime_card)."},
+    {"id": "significance", "title": "Significance and Verification", "startLine": 200, "endLine": 222, "summary": "Discussion of why Lagrange matters (structure constraints, counting, number theory, extensions), the false converse (A₄ counterexample), and type-checking of all exported theorems."}
+  ],
+  "conclusion": {
+    "summary": "This formalization verifies Lagrange's Theorem (Wiedijk #71) with the core divisibility result, the product formula, and six corollaries: element order divides group order, power-by-group-order, Fermat's little theorem, index properties, prime-order simplicity, and prime-order cyclicity.",
+    "implications": "Lagrange's theorem is the starting point for the structural theory of finite groups. It leads directly to the Sylow theorems (existence of p-subgroups), the orbit-stabilizer theorem (|G| = |Orb(x)| × |Stab(x)|), and the class equation. In number theory, it yields Fermat's little theorem, Euler's theorem, and Wilson's theorem. In cryptography, the relationship between element orders and group orders underpins the security of RSA, Diffie-Hellman, and elliptic curve cryptography.",
+    "openQuestions": [
+      "Can the Sylow theorems (partial converse of Lagrange) be formalized, showing that subgroups of order p^k exist for every prime power p^k dividing |G|?",
+      "Can the orbit-stabilizer theorem be formalized as a generalization of Lagrange's theorem, with Lagrange recovered as the special case of the action of G on cosets of H?",
+      "Can Hall's theorem be formalized: for solvable groups, the full converse of Lagrange holds — subgroups of order n exist for every n dividing |G|?"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Enriched **cramers-rule** (Wiedijk #97): expanded historicalContext, 5 keyInsights, 8 sections, full conclusion
- Enriched **derangements** (Wiedijk #88): Montmort/Euler/Whitworth history, 5 keyInsights, 10 sections
- Enriched **euler-totient** (Wiedijk #10): Euler/Fermat/Gauss/RSA history, 5 keyInsights, 5 sections
- Enriched **fundamental-arithmetic** (Wiedijk #80): Euclid/Gauss/Kummer history, 5 keyInsights, 9 sections
- Enriched **herons-formula** (Wiedijk #57): Hero/Archimedes/Brahmagupta history, 5 keyInsights, 7 sections
- Enriched **cauchy-schwarz** (Wiedijk #78): Cauchy/Bunyakovsky/Schwarz history, Lagrange identity, 5 keyInsights, 8 sections
- Enriched **isosceles-triangle** (Wiedijk #65): Pappus/Proclus history, non-degeneracy analysis, 5 keyInsights, 6 sections
- Enriched **lagrange-theorem** (Wiedijk #71): Lagrange/Galois/Dedekind history, Sylow/orbit-stabilizer, 5 keyInsights, 8 sections

## Test plan
- [x] `pnpm build` passes after each enrichment
- [x] All meta.json and annotations.json files are valid JSON
- [x] All entries have expanded historicalContext, keyInsights, sections, and conclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)