### PR TITLE
Fix sync-data.ts pool path after state directory migration

### DIFF
--- a/scripts/research/sync-data.ts
+++ b/scripts/research/sync-data.ts
@@ -22,7 +22,8 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 const RESEARCH_DIR = path.join(__dirname, '../../research')
-const POOL_FILE = path.join(RESEARCH_DIR, 'candidate-pool.json')
+const STATE_DIR = path.join(__dirname, '../../.lean/state')
+const POOL_FILE = path.join(STATE_DIR, 'candidate-pool.json')
 const REGISTRY_FILE = path.join(RESEARCH_DIR, 'registry.json')
 const PROBLEMS_DIR = path.join(RESEARCH_DIR, 'problems')
 


### PR DESCRIPTION
## Summary
- PR #2301 moved `candidate-pool.json` to `.lean/state/` but missed updating the path in `scripts/research/sync-data.ts`
- This caused `pnpm build` to fail with "Error: candidate-pool.json not found"
- Updates `POOL_FILE` to point to `.lean/state/candidate-pool.json`

## Test plan
- [x] `pnpm build` succeeds
- [x] Deployed to Cloudflare Pages successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)