### PR TITLE
Enhance Erdős #1111: Anticomplete High-Chromatic Subgraphs

### DIFF
--- a/proofs/Proofs/Erdos1111Problem.lean
+++ b/proofs/Proofs/Erdos1111Problem.lean
@@ -187,39 +187,24 @@ axiom nguyen_scott_seymour_2024 :
 
 /--
 **Ramsey connection:**
-The problem relates to Ramsey-type questions about graph structure.
+The problem relates to Ramsey-type questions. High chromatic number with
+bounded clique number forces rich graph structure, analogous to how
+large Ramsey numbers force monochromatic cliques.
 -/
 axiom ramsey_connection :
-  -- High chromatic number with bounded clique forces structure
-  True
+    ∀ t : ℕ, t ≥ 2 → ∃ d : ℕ, HasElZaharErdosProperty t 2 d
 
 /--
 **χ-boundedness connection:**
 Graphs with ω(G) < t and χ(G) large have special structure.
+The problem asks specifically what anticomplete substructure must appear.
 -/
-axiom chi_boundedness_connection :
-  -- This problem studies what structure high-χ, low-ω graphs must have
-  True
-
-/-
-## Part VIII: Why It's Hard
--/
-
-/--
-**Difficulty:**
-The problem asks for EXACT values of d(t, c), not just existence.
--/
-axiom difficulty_exact_values :
-  -- Upper bounds are known, but determining exact d(t, c) is hard
-  True
-
-/--
-**Cannot be computed:**
-For large t, c, determining d(t, c) requires infinite analysis.
--/
-axiom cannot_compute :
-  -- Noted on erdosproblems.com: cannot be resolved by finite computation
-  True
+axiom chi_boundedness :
+    ∀ t c : ℕ, t ≥ 1 → c ≥ 1 →
+    ∀ (V : Type*) [Fintype V] [DecidableEq V] (G : SimpleGraph V),
+    G.chromaticNumber ≥ d_func t c → cliqueNumber G < t →
+    ∃ A B : Finset V, IsAnticomplete G A B ∧
+      inducedChromaticNumber G A ≥ c ∧ inducedChromaticNumber G B ≥ c
 
 /-
 ## Part IX: Summary
@@ -240,33 +225,21 @@ sets A, B with χ(A) ≥ χ(B) ≥ c.
 
 **Open:** Determine exact values of d(t, c) for general t, c.
 -/
-theorem erdos_1111_open :
-    -- Some exact values known
-    (d_func 2 2 = 2 ∧ d_func 3 2 = 4 ∧ d_func 4 2 = 5) →
-    -- Upper bounds exist
-    (∀ t : ℕ, t ≥ 2 → d_func t 2 ≤ Nat.choose t 2 + 1) →
-    -- Problem remains open for general d(t, c)
-    True := by
-  intro _ _
-  trivial
+theorem erdos_1111_known_values :
+    d_func 2 2 = 2 ∧ d_func 3 2 = 4 ∧ d_func 4 2 = 5 :=
+  ⟨d_2_2, d_3_2, d_4_2⟩
 
 /--
-**Summary theorem:**
+**Summary of known bounds:**
+Wagon's bound, El Zahar-Erdős bound, and NSS existence.
 -/
 theorem erdos_1111_summary :
-    -- Small cases
-    True ∧
-    -- Wagon's bound
-    True ∧
-    -- El Zahar-Erdős results
-    True ∧
-    -- NSS strengthening
-    True ∧
-    -- Problem is OPEN
-    True := ⟨trivial, trivial, trivial, trivial, trivial⟩
-
-/-- Problem status -/
-def erdos_1111_status : String :=
-    "OPEN - Exact values of d(t, c) unknown for general t, c"
+    -- Wagon's bound holds for c = 2
+    (∀ t : ℕ, t ≥ 2 → d_func t 2 ≤ Nat.choose t 2 + 1) ∧
+    -- d(3, 3) ≤ 8
+    (d_func 3 3 ≤ 8) ∧
+    -- NSS strengthening exists
+    (∀ t c : ℕ, t ≥ 1 → c ≥ 1 → ∃ d : ℕ, HasNSSProperty t c d) := by
+  exact ⟨wagon_1980, d_3_3_bound, nguyen_scott_seymour_2024⟩
 
 end Erdos1111

--- a/src/data/proofs/erdos-1111/annotations.json
+++ b/src/data/proofs/erdos-1111/annotations.json
@@ -34,30 +34,19 @@
   {
     "id": "ann-e1111-property",
     "proofId": "erdos-1111",
-    "range": { "startLine": 70, "endLine": 79 },
+    "range": { "startLine": 70, "endLine": 93 },
     "type": "definition",
     "title": "The El Zahar-Erdos Property",
-    "content": "**HasElZaharErdosProperty t c d:**\n\nA graph G has the (t, c, d) property if:\n- chi(G) >= d and omega(G) < t implies\n- There exist anticomplete A, B with chi(A) >= c and chi(B) >= c\n\nThe conjecture asserts this property holds for all t, c >= 1 with some d.",
+    "content": "**HasElZaharErdosProperty t c d:**\n\nA graph G has the (t, c, d) property if:\n- chi(G) >= d and omega(G) < t implies\n- There exist anticomplete A, B with chi(A) >= c and chi(B) >= c\n\n**d_func t c:** The minimal such d.\n\n**ElZaharErdosConjecture:** d(t, c) exists for all t, c >= 1.",
     "mathContext": "This defines when a chromatic threshold d is sufficient to guarantee anticomplete high-chromatic substructures given clique bound t and chromatic target c.",
     "significance": "critical",
-    "relatedConcepts": ["Graph property", "Chromatic threshold"]
-  },
-  {
-    "id": "ann-e1111-d-func",
-    "proofId": "erdos-1111",
-    "range": { "startLine": 81, "endLine": 93 },
-    "type": "definition",
-    "title": "The Function d(t, c)",
-    "content": "**d_func t c = d(t, c):**\n\nThe minimal d such that HasElZaharErdosProperty t c d holds.\n\n**ElZaharErdosConjecture:**\nFor all t, c >= 1, d(t, c) exists (is finite).\n\nDetermining the exact function d(t, c) is the open problem.",
-    "mathContext": "The existence of d(t, c) follows from various results, but computing exact values is hard. Only small cases are known precisely.",
-    "significance": "critical",
-    "relatedConcepts": ["Extremal function", "Minimality"]
+    "relatedConcepts": ["Graph property", "Chromatic threshold", "Extremal function"]
   },
   {
     "id": "ann-e1111-small-cases",
     "proofId": "erdos-1111",
     "range": { "startLine": 95, "endLine": 115 },
-    "type": "theorem",
+    "type": "axiom",
     "title": "Known Small Cases",
     "content": "**Exact values:**\n- d(2, 2) = 2: Triangle-free graphs with chi >= 2 work\n- d(3, 2) = 4: K3-free graphs need chi >= 4\n- d(4, 2) = 5: K4-free graphs need chi >= 5\n\nThese are the only exactly determined values of d(t, c).",
     "mathContext": "Small cases can be verified by case analysis. The jump from d(3,2)=4 to d(4,2)=5 shows the function is not simply linear in t.",
@@ -78,24 +67,13 @@
   {
     "id": "ann-e1111-reduction",
     "proofId": "erdos-1111",
-    "range": { "startLine": 139, "endLine": 145 },
+    "range": { "startLine": 139, "endLine": 159 },
     "type": "axiom",
-    "title": "Reduction to t <= c",
-    "content": "**reduction_to_t_le_c:**\n\nEl Zahar and Erdos showed: To prove the conjecture for all t, c, it suffices to prove it when t <= c.\n\nThis reduces the infinite problem to a more tractable family of cases.",
-    "mathContext": "When t > c, one can use the result for (c, c) and deduce the general case. This is a standard reduction technique in extremal combinatorics.",
-    "significance": "key",
-    "relatedConcepts": ["Problem reduction", "Sufficient condition"]
-  },
-  {
-    "id": "ann-e1111-c3-bounds",
-    "proofId": "erdos-1111",
-    "range": { "startLine": 147, "endLine": 159 },
-    "type": "axiom",
-    "title": "Bounds for c = 3",
-    "content": "**d_3_3_bound:** d(3, 3) <= 8\n\n**el_zahar_erdos_c3_bound:**\nFor t > 3: d(t, 3) <= 2*C(t-1, 3) + 7*C(t-1, 2) + t\n\nThe c = 3 case is the next frontier after c = 2.",
+    "title": "El Zahar-Erdos Results (1985)",
+    "content": "**reduction_to_t_le_c:** To prove the conjecture for all t, c, it suffices to prove it when t <= c.\n\n**d_3_3_bound:** d(3, 3) <= 8\n\n**el_zahar_erdos_c3_bound:** For t > 3: d(t, 3) <= 2*C(t-1, 3) + 7*C(t-1, 2) + t\n\nThe c = 3 case is the next frontier after c = 2.",
     "mathContext": "El Zahar and Erdos (1985) established these bounds. The exact value of d(3, 3) is unknown - could be anywhere from 5 to 8.",
     "significance": "key",
-    "relatedConcepts": ["Cubic bound", "Polynomial growth"]
+    "relatedConcepts": ["Problem reduction", "Cubic bound"]
   },
   {
     "id": "ann-e1111-nss",
@@ -109,13 +87,24 @@
     "relatedConcepts": ["Minimum degree", "Structural strengthening", "2024 result"]
   },
   {
+    "id": "ann-e1111-connections",
+    "proofId": "erdos-1111",
+    "range": { "startLine": 184, "endLine": 207 },
+    "type": "axiom",
+    "title": "Connections to Ramsey Theory and chi-Boundedness",
+    "content": "**ramsey_connection:** For all t >= 2, there exists d such that the (t, 2, d) property holds. High chromatic number with bounded clique forces rich structure.\n\n**chi_boundedness:** Graphs with omega(G) < t and chi(G) >= d(t,c) contain anticomplete sets with high chromatic number. This connects to the broader theory of chi-bounded graph classes.",
+    "mathContext": "The problem sits at the intersection of Ramsey theory (forced substructures) and chi-boundedness (relating clique and chromatic numbers).",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey theory", "Chi-boundedness", "Graph structure"]
+  },
+  {
     "id": "ann-e1111-summary",
     "proofId": "erdos-1111",
-    "range": { "startLine": 224, "endLine": 272 },
+    "range": { "startLine": 209, "endLine": 245 },
     "type": "theorem",
     "title": "Problem Summary",
-    "content": "**Erdos Problem #1111: OPEN**\n\n**Known:**\n- Exact values: d(2,2)=2, d(3,2)=4, d(4,2)=5\n- Upper bounds: d(t,2) <= C(t,2)+1, d(3,3) <= 8\n- Existence: NSS 2024 proves existence with degree constraint\n\n**Open:** Determine d(t, c) for general t, c.\n\n**Note:** Cannot be resolved by finite computation - requires infinite analysis.",
-    "mathContext": "The problem sits at the intersection of chromatic number theory, Ramsey theory, and chi-boundedness. Progress requires new structural insights.",
+    "content": "**Erdos Problem #1111: OPEN**\n\n**Known:**\n- Exact values: d(2,2)=2, d(3,2)=4, d(4,2)=5 (erdos_1111_known_values)\n- Upper bounds: d(t,2) <= C(t,2)+1, d(3,3) <= 8\n- Existence: NSS 2024 proves existence with degree constraint (erdos_1111_summary)\n\n**Open:** Determine d(t, c) for general t, c.\n\nThe summary theorem combines Wagon's bound, El Zahar-Erdos bound, and NSS existence.",
+    "mathContext": "The problem requires new structural insights to determine exact values. Progress requires infinite analysis, not finite computation.",
     "significance": "critical"
   }
 ]

--- a/src/data/proofs/erdos-1111/meta.json
+++ b/src/data/proofs/erdos-1111/meta.json
@@ -119,24 +119,17 @@
     },
     {
       "id": "connections",
-      "title": "Connections",
-      "summary": "Ramsey theory, χ-boundedness",
+      "title": "Connections to Ramsey Theory",
+      "summary": "Ramsey connection and chi-boundedness axioms",
       "startLine": 184,
-      "endLine": 202
-    },
-    {
-      "id": "difficulty",
-      "title": "Why It's Hard",
-      "summary": "Exact values vs existence, cannot compute",
-      "startLine": 204,
-      "endLine": 222
+      "endLine": 207
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Main theorems and problem status",
-      "startLine": 224,
-      "endLine": 272
+      "summary": "Known values and bounds combined in summary theorems",
+      "startLine": 209,
+      "endLine": 245
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Stub enhancement for Erdős Problem #1111 (Anticomplete High-Chromatic Subgraphs).

## Changes
- Fixed all `/-!` docstrings to `/-` (9 occurrences)
- Removed 4 `True` placeholder axioms, replaced with real mathematical statements
- Replaced `True`-conjunction summary with theorem using actual axioms
- Added `ramsey_connection` and `chi_boundedness` with meaningful types
- Fixed erdos-177 `proofRepoPath` (was `proofs/Proofs` → `Proofs`)
- Updated annotations and meta.json sections

## Checklist
- [x] No sorry, True placeholders, or /-! docstrings
- [x] pnpm build succeeds
- [x] Annotations align with Lean file

🤖 Generated by enhancer-1