### PR TITLE
Add Aristotle candidate counting and dynamic spawning

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -2684,8 +2684,8 @@
       "path": "fast",
       "started": "2026-01-27T22:18:02.333Z",
       "status": "graduated",
-      "lastUpdate": "2026-02-08T06:47:46.587Z",
-      "completed": "2026-02-08T06:47:46.587Z"
+      "lastUpdate": "2026-02-08T06:49:51.839Z",
+      "completed": "2026-02-08T06:49:51.839Z"
     },
     {
       "slug": "erdos-285",
@@ -2819,11 +2819,12 @@
     },
     {
       "slug": "borsuk-ulam-oq-01",
-      "phase": "NEW",
+      "phase": "BREAKTHROUGH",
       "path": "full",
       "started": "2026-02-08T06:11:43.709Z",
-      "status": "active",
-      "lastUpdate": "2026-02-08T06:11:43.709Z"
+      "status": "graduated",
+      "lastUpdate": "2026-02-08T06:49:51.838Z",
+      "completed": "2026-02-08T06:49:51.837Z"
     },
     {
       "slug": "brouwer-fixed-point-oq-03",

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -951,10 +951,16 @@ get_work_queue_stats() {
         aristotle_jobs=$(jq '[.jobs[] | select(.status == "submitted")] | length' "research/aristotle-jobs.json" 2>/dev/null || echo "0")
     fi
 
+    # Aristotle candidates (files with sorries eligible for submission)
+    local aristotle_candidates="0"
+    if [[ -x "scripts/aristotle/find-candidates.sh" ]]; then
+        aristotle_candidates=$(timeout 10 ./scripts/aristotle/find-candidates.sh --count 2>/dev/null || echo "0")
+    fi
+
     # PRs ready to merge
     ready_prs=$(timeout 10 gh pr list --label "loom:pr" --json number 2>/dev/null | jq 'length' 2>/dev/null || echo "0")
 
-    echo "$enrichment_targets $candidates $aristotle_jobs $ready_prs"
+    echo "$enrichment_targets $candidates $aristotle_jobs $aristotle_candidates $ready_prs"
 }
 
 # Helper: Write daemon state to state file
@@ -1269,14 +1275,23 @@ cmd_daemon() {
         # 3. Work queue assessment (with timeout protection)
         local queue_stats
         queue_stats=$(get_work_queue_stats)
-        local enrichment_targets candidates aristotle_jobs ready_prs
-        read -r enrichment_targets candidates aristotle_jobs ready_prs <<< "$queue_stats"
+        local enrichment_targets candidates aristotle_jobs aristotle_candidates ready_prs
+        read -r enrichment_targets candidates aristotle_jobs aristotle_candidates ready_prs <<< "$queue_stats"
 
         # 4. Process completion signals and update session stats
         process_completion_signals
 
+        # 4b. Dynamic Aristotle: spawn when candidates or jobs exist but no agent running
+        if [[ $aristotle_active -eq 0 ]] && [[ "$aristotle_jobs" -gt 0 || "$aristotle_candidates" -gt 0 ]]; then
+            if is_cooldown_elapsed "aristotle-agent"; then
+                daemon_log "INFO" "Auto-spawning Aristotle: $aristotle_jobs pending jobs, $aristotle_candidates candidates"
+                respawn_agent "aristotle-agent"
+                total_respawns=$((total_respawns + 1))
+            fi
+        fi
+
         # 5. Log cycle summary
-        daemon_log "INFO" "Cycle $cycle_count: running=$running_count, idle=$idle_count, completed=$completed_count, stuck=$stuck_count, respawned=$cycle_respawns | queues: enrichment=$enrichment_targets, candidates=$candidates, aristotle=$aristotle_jobs, prs=$ready_prs"
+        daemon_log "INFO" "Cycle $cycle_count: running=$running_count, idle=$idle_count, completed=$completed_count, stuck=$stuck_count, respawned=$cycle_respawns | queues: enrichment=$enrichment_targets, candidates=$candidates, aristotle_jobs=$aristotle_jobs, aristotle_candidates=$aristotle_candidates, prs=$ready_prs"
 
         # 6. Update state file with daemon stats
         update_daemon_state "$cycle_count" "$total_respawns"

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -83,6 +83,15 @@ count_aristotle_jobs() {
     fi
 }
 
+# Helper: Count Aristotle candidates (files eligible for submission)
+count_aristotle_candidates() {
+    if [[ -x "scripts/aristotle/find-candidates.sh" ]]; then
+        timeout 10 ./scripts/aristotle/find-candidates.sh --count 2>/dev/null || echo "0"
+    else
+        echo "0"
+    fi
+}
+
 # Helper: Count available research problems
 count_research_problems() {
     if [[ -f "$CANDIDATE_POOL" ]]; then
@@ -162,11 +171,13 @@ gather_status() {
     # Work queue counts
     local enrichment_count
     local aristotle_jobs
+    local aristotle_candidates
     local research_problems
     local ready_prs
 
     enrichment_count=$(count_enrichment_targets)
     aristotle_jobs=$(count_aristotle_jobs)
+    aristotle_candidates=$(count_aristotle_candidates)
     research_problems=$(count_research_problems)
     ready_prs=$(count_ready_prs)
 
@@ -197,6 +208,7 @@ gather_status() {
   "work_queue": {
     "proofs_needing_enrichment": "$enrichment_count",
     "aristotle_pending": $aristotle_jobs,
+    "aristotle_candidates": $aristotle_candidates,
     "research_available": $research_problems,
     "prs_ready": $ready_prs
   },
@@ -250,6 +262,7 @@ EOF
         echo -e "  ${CYAN}Work Queue:${NC}"
         echo "    Proofs needing enrichment: $enrichment_count"
         echo "    Aristotle jobs pending: $aristotle_jobs"
+        echo "    Aristotle candidates: $aristotle_candidates"
         echo "    Research problems available: $research_problems"
         echo "    PRs ready to merge: $ready_prs"
         echo ""


### PR DESCRIPTION
## Summary

- **Adds Aristotle candidate counting** to `get_work_queue_stats()` in `launch.sh` — calls `find-candidates.sh --count` with a 10s timeout to count proof files eligible for Aristotle submission
- **Adds dynamic Aristotle spawning** in the daemon loop — auto-spawns an Aristotle agent when candidates or pending jobs exist but no agent is running (even with `--aristotle 0`), respecting the 5-minute cooldown
- **Updates status output** in `status.sh` — shows Aristotle candidate count in both JSON and human-readable output

Closes #1852

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|-------------|
| Candidate counting in work queue stats | Done | `get_work_queue_stats()` calls `find-candidates.sh --count` with 10s timeout |
| Dynamic Aristotle spawning | Done | Step 4b in daemon loop checks `aristotle_active == 0 && (jobs > 0 \|\| candidates > 0)` |
| Cooldown respected | Done | Uses existing `is_cooldown_elapsed` function |
| Status display updated | Done | Both JSON (`aristotle_candidates`) and human-readable output include candidate count |
| Daemon log includes candidate count | Done | Cycle summary now shows `aristotle_jobs` and `aristotle_candidates` separately |
| Timeout protection | Done | 10s timeout on `find-candidates.sh` prevents daemon loop blocking |

## Test plan

- [ ] Start daemon with `--aristotle 0`, confirm Aristotle auto-spawns when `find-candidates.sh --count` returns > 0
- [ ] Start daemon with `--aristotle 0` and no candidates/jobs, confirm Aristotle does NOT spawn
- [ ] Run `./scripts/lean/status.sh` and confirm Aristotle candidate count appears in output
- [ ] Run `./scripts/lean/status.sh --json` and confirm `aristotle_candidates` field in JSON
- [ ] Check daemon log output includes candidate count in cycle summary line
- [ ] Verify `find-candidates.sh --count` timeout doesn't block daemon loop
- [ ] Verify cooldown is respected (Aristotle not respawned within 5min window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)