### PR TITLE
Enhance erdos-1174: fix True placeholders, rewrite gallery content

### DIFF
--- a/proofs/Proofs/Erdos1174Problem.lean
+++ b/proofs/Proofs/Erdos1174Problem.lean
@@ -200,54 +200,26 @@ axiom nesetril_rodl_context :
 ## Part VI: Shelah's Consistency Results
 -/
 
-/--
-**Shelah's Consistency Result (Finite):**
-It is consistent with ZFC that there exists a graph G satisfying
-the Erdős-Hajnal finite property. This means we cannot disprove
-existence in ZFC alone.
--/
-axiom shelah_consistency_finite :
-  -- Con(ZFC + ∃G : ErdosHajnalFiniteProperty G)
-  True
-
-/--
-**Shelah's Consistency Result (Infinite):**
-It is consistent with ZFC that there exists a graph G satisfying
-the Erdős-Hajnal infinite property.
--/
-axiom shelah_consistency_infinite :
-  -- Con(ZFC + ∃G : ErdosHajnalInfiniteProperty G)
-  True
+/- Shelah's consistency results:
+Shelah showed that it is consistent with ZFC that graphs satisfying
+either the finite property (part a) or the infinite property (part b)
+exist. This means we cannot disprove existence in ZFC alone.
+However, whether such graphs provably exist in ZFC remains open. -/
 
 /-
 ## Part VII: Structural Observations
 -/
 
-/--
-**K₄-free graphs can be triangle-rich:**
-There exist K₄-free graphs with many triangles. For example,
-balanced complete tripartite graphs K_{n,n,n} are K₄-free
-but contain n³ triangles. The Ramsey question asks if
-such triangle-richness can force monochromatic triangles.
--/
-theorem k4free_can_have_triangles :
-    -- The complete tripartite graph K_{1,1,1} = K₃ is K₄-free
-    -- and is itself a triangle
-    True := by
-  trivial
+/- K₄-free graphs can be triangle-rich:
+Balanced complete tripartite graphs K_{n,n,n} are K₄-free
+but contain n³ triangles. The Ramsey question asks whether
+such triangle-richness can force monochromatic triangles
+under countable edge colorings.
 
-/--
-**Relation between parts (a) and (b):**
+Relation between parts (a) and (b):
 Part (b) is a natural infinite generalization of part (a).
-If G witnesses part (b), then any countable subgraph that
-is an infinite clique under some coloring also witnesses
-a monochromatic triangle, giving a connection to part (a).
--/
-theorem parts_related :
-    -- A positive answer to (b) would imply structural results
-    -- about the forcing power of K_{ℵ₁}-free graphs
-    True := by
-  trivial
+A positive answer to (b) would yield structural results about
+the Ramsey-theoretic forcing power of K_{ℵ₁}-free graphs. -/
 
 /-
 ## Part VIII: Open Status and Summary

--- a/src/data/proofs/erdos-1174/annotations.json
+++ b/src/data/proofs/erdos-1174/annotations.json
@@ -2,234 +2,172 @@
   {
     "id": "ann-e1174-header",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 1,
-      "endLine": 27
-    },
+    "range": { "startLine": 1, "endLine": 27 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "Header documentation for Erdős Problem #1174, providing mathematical context and problem statement.",
-    "mathContext": "Erdős Problem #1174: Monochromatic Cliques from Edge Colorings\n\nSource: https://erdosproblems.com/1174\nStatus: OPEN (set-theoretic independence)\nReference: [Va99, 7.91]\n\nStatement:\n(a) Does there exist a graph G with no K₄ such that every edge colouring of G\n    with countably many colours contains a monochromatic triangle (K₃)?\n\n(b) Does there exist a graph G with no K_{ℵ₁} such that every edge colouring of G\n    with countably many colours contains a monochromatic K_{ℵ₀}?\n\nKey Results:\n- This ",
+    "content": "**Erdős Problem #1174** asks whether restricting a host graph can still force monochromatic structures under countable edge colorings. The classical Ramsey theorem says that any 2-coloring of the complete graph K_ω produces a monochromatic infinite clique. But what if we forbid large cliques in the host graph and allow countably many colors instead of just two? Part (a) asks for a K₄-free graph forcing monochromatic triangles; part (b) lifts this to infinite cardinals.",
+    "mathContext": "The problem was posed by Erdős and Hajnal. Shelah proved consistency results showing ZFC cannot rule out such graphs, but whether they provably exist in ZFC is open. Reference: [Va99, 7.91].",
     "significance": "critical",
-    "relatedConcepts": [
-      "Erdős problems",
-      "Number theory"
-    ]
+    "relatedConcepts": ["Ramsey theory", "set-theoretic independence", "partition calculus"]
   },
   {
-    "id": "ann-e1174-IsClique",
+    "id": "ann-e1174-clique",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 45,
-      "endLine": 46
-    },
+    "range": { "startLine": 41, "endLine": 46 },
     "type": "definition",
-    "title": "Isclique",
-    "content": "def IsClique",
-    "significance": "supporting"
+    "title": "Clique Definition",
+    "content": "A **clique** in a graph G is a set S of vertices where every two distinct vertices are adjacent. This is the standard graph-theoretic notion: a clique of size k is a complete subgraph K_k. The definition quantifies over all pairs in S, requiring G.Adj v w whenever v ≠ w.",
+    "mathContext": "This is equivalent to saying the induced subgraph G[S] is complete. In Ramsey theory, finding monochromatic cliques is a central goal.",
+    "significance": "key",
+    "relatedConcepts": ["complete graph", "Ramsey theory", "induced subgraph"]
   },
   {
-    "id": "ann-e1174-IsK4Free",
+    "id": "ann-e1174-k4free",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 52,
-      "endLine": 54
-    },
+    "range": { "startLine": 48, "endLine": 54 },
     "type": "definition",
-    "title": "Isk4Free",
-    "content": "def IsK4Free",
-    "significance": "supporting"
+    "title": "K₄-free Graph",
+    "content": "A graph is **K₄-free** if no four vertices form a complete subgraph. The definition explicitly enumerates all 6 edges among 4 vertices and asserts their conjunction is impossible. This is the key constraint in part (a): we want a graph rich enough to force monochromatic triangles under any coloring, yet sparse enough to avoid K₄.",
+    "mathContext": "K₄-free graphs include important families like triangle-free graphs, planar graphs, and complete tripartite graphs. The Turán graph T(n,3) maximizes edges while being K₄-free.",
+    "significance": "critical",
+    "relatedConcepts": ["Turán's theorem", "graph density", "forbidden subgraph"]
   },
   {
-    "id": "ann-e1174-IsCliqueFreeCardinal",
+    "id": "ann-e1174-cardinal-clique",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 61,
-      "endLine": 62
-    },
+    "range": { "startLine": 56, "endLine": 62 },
     "type": "definition",
-    "title": "Iscliquefreecardinal",
-    "content": "def IsCliqueFreeCardinal",
-    "significance": "supporting"
+    "title": "Cardinal Clique-freeness",
+    "content": "**IsCliqueFreeCardinal G κ** says that every clique in G has cardinality strictly less than κ. For part (b), we use κ = ℵ₁ (the first uncountable cardinal), meaning G has no uncountable clique. This generalizes finite clique-freeness to the transfinite setting.",
+    "mathContext": "The cardinality #S uses Mathlib's Cardinal type. Cardinal.aleph 1 = ℵ₁ is the smallest cardinal greater than ℵ₀ = |ℕ|. Under GCH, ℵ₁ = 2^{ℵ₀}, but this is independent of ZFC.",
+    "significance": "key",
+    "relatedConcepts": ["aleph numbers", "cardinal arithmetic", "set theory"]
   },
   {
-    "id": "ann-e1174-HasMonochromaticTriangle",
+    "id": "ann-e1174-symmetric-coloring",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 81,
-      "endLine": 85
-    },
+    "range": { "startLine": 64, "endLine": 70 },
     "type": "definition",
-    "title": "Hasmonochromatictriangle",
-    "content": "def HasMonochromaticTriangle",
-    "significance": "supporting"
+    "title": "Symmetric Coloring Structure",
+    "content": "A **symmetric coloring** packages a color function f : V → V → C with a proof that f(v,w) = f(w,v). This reflects the fact that edge colorings assign a single color to each unordered edge {v,w}. The structure ensures well-definedness without needing to work with unordered pairs directly.",
+    "significance": "supporting",
+    "relatedConcepts": ["edge coloring", "graph homomorphism"]
   },
   {
-    "id": "ann-e1174-ErdosHajnalFiniteProperty",
+    "id": "ann-e1174-mono-triangle",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 94,
-      "endLine": 97
-    },
+    "range": { "startLine": 76, "endLine": 85 },
     "type": "definition",
-    "title": "Erdoshajnalfiniteproperty",
-    "content": "def ErdosHajnalFiniteProperty",
-    "significance": "critical"
+    "title": "Monochromatic Triangle",
+    "content": "**HasMonochromaticTriangle G f** asserts there exist three mutually adjacent vertices whose three edge colors under f all agree. This is the Ramsey-theoretic target for part (a): we want to find three vertices a, b, c forming a triangle in G with f(a,b) = f(a,c) = f(b,c). The coloring uses ℕ as the color set, representing countably many colors.",
+    "mathContext": "With only 2 colors and 6 vertices, Ramsey's theorem R(3,3) = 6 guarantees a monochromatic triangle. With countably many colors, no finite bound suffices, making the problem fundamentally harder.",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey number R(3,3)", "monochromatic subgraph", "countable coloring"]
   },
   {
-    "id": "ann-e1174-erdos_1174a",
+    "id": "ann-e1174-eh-finite",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 104,
-      "endLine": 105
-    },
+    "range": { "startLine": 87, "endLine": 97 },
     "type": "definition",
-    "title": "Erdos 1174A",
-    "content": "def erdos_1174a",
-    "significance": "critical"
+    "title": "Erdős-Hajnal Finite Property",
+    "content": "The **Erdős-Hajnal finite property** combines two conditions: (1) G is K₄-free, and (2) every symmetric edge coloring of G with countably many colors contains a monochromatic triangle. A graph satisfying both conditions would answer part (a) affirmatively. The tension is that K₄-freeness limits graph density, while the coloring property demands enough structure to force monochromatic triangles.",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős-Hajnal conjecture", "partition property", "Ramsey forcing"]
   },
   {
-    "id": "ann-e1174-HasMonochromaticAleph0Clique",
+    "id": "ann-e1174-part-a",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 116,
-      "endLine": 121
-    },
+    "range": { "startLine": 99, "endLine": 105 },
     "type": "definition",
-    "title": "Hasmonochromaticaleph0Clique",
-    "content": "def HasMonochromaticAleph0Clique",
-    "significance": "supporting"
+    "title": "Problem 1174 Part (a)",
+    "content": "**erdos_1174a** is the formal statement of part (a): there exists some type V and some simple graph G on V satisfying the Erdős-Hajnal finite property. The existential quantification over the vertex type V means we are not restricted to graphs on ℕ or any fixed set—the graph could have any cardinality.",
+    "significance": "critical",
+    "relatedConcepts": ["existential statement", "graph construction", "Type*"]
   },
   {
-    "id": "ann-e1174-ErdosHajnalInfiniteProperty",
+    "id": "ann-e1174-mono-aleph0",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 130,
-      "endLine": 133
-    },
+    "range": { "startLine": 111, "endLine": 121 },
     "type": "definition",
-    "title": "Erdoshajnalinfiniteproperty",
-    "content": "def ErdosHajnalInfiniteProperty",
-    "significance": "critical"
+    "title": "Monochromatic ℵ₀-Clique",
+    "content": "**HasMonochromaticAleph0Clique G f** asks for a set S of cardinality exactly ℵ₀ (countably infinite) that forms a clique in G with all edges the same color c. This is the infinite analog of a monochromatic triangle: instead of 3 vertices forming K₃, we need countably many vertices forming K_{ℵ₀}.",
+    "mathContext": "The cardinality condition #S = Cardinal.aleph 0 ensures S is countably infinite, not merely finite. The universal quantification over pairs in S with the same color c gives a monochromatic infinite complete subgraph.",
+    "significance": "key",
+    "relatedConcepts": ["countably infinite set", "aleph-0", "infinite Ramsey theory"]
   },
   {
-    "id": "ann-e1174-erdos_1174b",
+    "id": "ann-e1174-eh-infinite",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 140,
-      "endLine": 141
-    },
+    "range": { "startLine": 123, "endLine": 141 },
     "type": "definition",
-    "title": "Erdos 1174B",
-    "content": "def erdos_1174b",
-    "significance": "critical"
+    "title": "Erdős-Hajnal Infinite Property and Part (b)",
+    "content": "The **Erdős-Hajnal infinite property** requires: (1) G has no clique of cardinality ℵ₁, and (2) every countable coloring yields a monochromatic K_{ℵ₀}. This is the transfinite analog of the finite property, replacing K₄-free with K_{ℵ₁}-free and monochromatic K₃ with monochromatic K_{ℵ₀}. The formal statement **erdos_1174b** asserts the existence of such a graph.",
+    "significance": "critical",
+    "relatedConcepts": ["infinite combinatorics", "transfinite Ramsey theory", "uncountable cardinals"]
   },
   {
-    "id": "ann-e1174-infinite_ramsey_2color",
+    "id": "ann-e1174-ramsey",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 153,
-      "endLine": 157
-    },
+    "range": { "startLine": 147, "endLine": 157 },
     "type": "axiom",
-    "title": "Infinite Ramsey 2Color",
-    "content": "axiom infinite_ramsey_2color",
-    "significance": "key"
+    "title": "Infinite Ramsey Theorem (2 Colors)",
+    "content": "The **infinite Ramsey theorem** for 2 colors states that any symmetric 2-coloring of edges of the complete graph on ℕ yields a monochromatic countably infinite clique. This is axiomatized because the full proof requires König's lemma or an equivalent. It provides crucial context: the complete graph K_ω trivially has the coloring property, but it is not K₄-free.",
+    "mathContext": "This is the infinite version of R(ω,ω) = ω in partition calculus notation. The theorem extends to any finite number of colors, but Problem 1174 asks about countably many colors on restricted graphs.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey's theorem", "König's lemma", "infinite combinatorics"]
   },
   {
-    "id": "ann-e1174-complete_graph_not_k4free",
+    "id": "ann-e1174-complete-not-k4free",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 165,
-      "endLine": 171
-    },
+    "range": { "startLine": 159, "endLine": 171 },
     "type": "theorem",
-    "title": "Complete Graph Not K4Free",
-    "content": "theorem complete_graph_not_k4free",
-    "significance": "key"
+    "title": "Complete Graph is Not K₄-free",
+    "content": "This **constructive proof** shows the complete graph on ℕ is not K₄-free by exhibiting the 4-clique {0, 1, 2, 3}. The proof is by contradiction: assume K₄-freeness, instantiate with vertices 0-3, show all 6 edges exist (via `SimpleGraph.top_adj`), and derive a contradiction. This demonstrates that the K₄-freeness constraint in part (a) is essential—without it, the coloring property holds trivially via Ramsey.",
+    "mathContext": "The tactic `simp [SimpleGraph.top_adj]` resolves all adjacency goals in the complete graph ⊤, and `omega` handles the distinctness conditions.",
+    "significance": "key",
+    "relatedConcepts": ["complete graph", "proof by contradiction", "constructive mathematics"]
   },
   {
-    "id": "ann-e1174-partitionProperty",
+    "id": "ann-e1174-partition",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 182,
-      "endLine": 187
-    },
+    "range": { "startLine": 177, "endLine": 187 },
     "type": "definition",
-    "title": "Partitionproperty",
-    "content": "def partitionProperty",
-    "significance": "supporting"
+    "title": "Partition Property",
+    "content": "**partitionProperty G k numColors** formalizes the arrow notation G → (k)²_{numColors}: for every coloring of G's edges with numColors colors, there exists a monochromatic clique of size k. This is the language of partition calculus, originally developed by Erdős, Hajnal, and Rado to systematically study Ramsey-type phenomena.",
+    "mathContext": "The notation G → (k)²_c is standard in infinite combinatorics. The superscript 2 indicates we color edges (2-element subsets). Problem 1174(a) effectively asks for G → (3)²_ω with G being K₄-free.",
+    "significance": "key",
+    "relatedConcepts": ["partition calculus", "Erdős-Rado theorem", "arrow notation"]
   },
   {
-    "id": "ann-e1174-nesetril_rodl_context",
+    "id": "ann-e1174-nesetril-rodl",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 195,
-      "endLine": 197
-    },
+    "range": { "startLine": 189, "endLine": 197 },
     "type": "axiom",
-    "title": "Nesetril Rodl Context",
-    "content": "axiom nesetril_rodl_context",
-    "significance": "key"
+    "title": "Nešetřil-Rödl Theorem",
+    "content": "The **Nešetřil-Rödl theorem** is axiomatized here as context: for each finite number k of colors, there exists a K₄-free graph G with G → (3)²_{k+1}. This means the finite-color version of part (a) is achievable. The deep challenge in Problem 1174 is whether these finite-color solutions can be unified into a single graph that works for all countably many colors simultaneously.",
+    "mathContext": "Nešetřil and Rödl proved this using the amalgamation technique for sparse Ramsey classes. Their result is constructive for fixed k but does not yield a single graph for all k.",
+    "significance": "key",
+    "relatedConcepts": ["structural Ramsey theory", "Hales-Jewett theorem", "amalgamation"]
   },
   {
-    "id": "ann-e1174-shelah_consistency_finite",
+    "id": "ann-e1174-shelah",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 209,
-      "endLine": 209
-    },
-    "type": "axiom",
-    "title": "Shelah Consistency Finite",
-    "content": "axiom shelah_consistency_finite",
-    "significance": "key"
+    "range": { "startLine": 199, "endLine": 207 },
+    "type": "concept",
+    "title": "Shelah's Consistency Results",
+    "content": "Shelah showed that it is **consistent with ZFC** that graphs satisfying either the finite or infinite Erdős-Hajnal property exist. This is expressed as a comment rather than a formal axiom because consistency statements are meta-mathematical (they concern models of ZFC, not objects within ZFC). The upshot: we know ZFC cannot disprove existence, but it remains open whether ZFC can prove it.",
+    "mathContext": "Consistency proofs typically use forcing: Shelah constructs a model of ZFC (extending a ground model) in which the desired graph exists. This does not establish the graph exists in all models.",
+    "significance": "key",
+    "relatedConcepts": ["forcing", "consistency", "set-theoretic independence"]
   },
   {
-    "id": "ann-e1174-shelah_consistency_infinite",
+    "id": "ann-e1174-summary",
     "proofId": "erdos-1174",
-    "range": {
-      "startLine": 218,
-      "endLine": 218
-    },
-    "type": "axiom",
-    "title": "Shelah Consistency Infinite",
-    "content": "axiom shelah_consistency_infinite",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1174-k4free_can_have_triangles",
-    "proofId": "erdos-1174",
-    "range": {
-      "startLine": 233,
-      "endLine": 233
-    },
-    "type": "theorem",
-    "title": "K4Free Can Have Triangles",
-    "content": "theorem k4free_can_have_triangles",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1174-parts_related",
-    "proofId": "erdos-1174",
-    "range": {
-      "startLine": 246,
-      "endLine": 246
-    },
-    "type": "theorem",
-    "title": "Parts Related",
-    "content": "theorem parts_related",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1174-erdos_1174_open",
-    "proofId": "erdos-1174",
-    "range": {
-      "startLine": 268,
-      "endLine": 268
-    },
-    "type": "axiom",
-    "title": "Erdos 1174 Open",
-    "content": "axiom erdos_1174_open",
-    "significance": "critical"
+    "range": { "startLine": 224, "endLine": 243 },
+    "type": "concept",
+    "title": "Open Status Summary",
+    "content": "Both parts of Problem 1174 remain **open in ZFC**. The known landscape: (1) Nešetřil-Rödl handles finitely many colors, (2) Shelah shows consistency, (3) no ZFC proof or refutation is known. The problem connects three major areas: finite Ramsey theory (partition properties of sparse graphs), infinite combinatorics (transfinite generalizations), and set-theoretic independence (forcing and consistency).",
+    "significance": "critical",
+    "relatedConcepts": ["open problem", "ZFC independence", "Ramsey theory"]
   }
 ]

--- a/src/data/proofs/erdos-1174/meta.json
+++ b/src/data/proofs/erdos-1174/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-1174",
   "title": "Erdős Problem #1174: Monochromatic Cliques from Edge Colorings",
   "slug": "erdos-1174",
-  "description": "with countably many colours contains a monochromatic triangle (K₃)?",
+  "description": "Does there exist a K₄-free graph such that every countable edge coloring contains a monochromatic triangle, and does the analogous infinite generalization hold?",
   "meta": {
-    "author": "Erdős",
+    "author": "Erdős & Hajnal",
     "sourceUrl": "https://erdosproblems.com/1174",
     "status": "complete",
     "proofRepoPath": "Proofs/Erdos1174Problem.lean",
@@ -24,18 +24,18 @@
     "mathlib_version": "4.15.0",
     "mathlibDependencies": [
       {
-        "theorem": "Basic",
-        "description": "From Mathlib.Combinatorics.SimpleGraph.Basic",
+        "theorem": "SimpleGraph.Basic",
+        "description": "Graph adjacency, complete graph (⊤), and basic operations",
         "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
       },
       {
-        "theorem": "Basic",
-        "description": "From Mathlib.SetTheory.Cardinal.Basic",
+        "theorem": "Cardinal.Basic",
+        "description": "Cardinal arithmetic and cardinality of sets (#S)",
         "module": "Mathlib.SetTheory.Cardinal.Basic"
       },
       {
-        "theorem": "Ordinal",
-        "description": "From Mathlib.SetTheory.Cardinal.Ordinal",
+        "theorem": "Cardinal.Ordinal",
+        "description": "Aleph numbers (ℵ₀, ℵ₁) for infinite cardinalities",
         "module": "Mathlib.SetTheory.Cardinal.Ordinal"
       }
     ],
@@ -43,47 +43,94 @@
       "IsClique",
       "IsK4Free",
       "IsCliqueFreeCardinal",
+      "SymmetricColoring",
       "HasMonochromaticTriangle",
       "ErdosHajnalFiniteProperty",
       "erdos_1174a",
       "HasMonochromaticAleph0Clique",
       "ErdosHajnalInfiniteProperty",
       "erdos_1174b",
-      "infinite_ramsey_2color",
-      "complete_graph_not_k4free",
       "partitionProperty",
-      "nesetril_rodl_context",
-      "shelah_consistency_finite",
-      "shelah_consistency_infinite"
+      "complete_graph_not_k4free"
     ]
   },
   "overview": {
-    "historicalContext": "Erdős Problem #1174 concerns monochromatic cliques from edge colorings. This problem remains OPEN.\n\nKnown results include: - This is a problem of Erdős and Hajnal - Shelah showed that a graph possessing either property can consistently exist - The problem asks whether such graphs exist in ZFC outright - We restrict the host graph (no K₄, or no K_{ℵ₁})\n\nThis problem is catalogued at erdosproblems.com/1174.",
-    "problemStatement": "with countably many colours contains a monochromatic triangle (K₃)?",
-    "proofStrategy": "The formalization is structured in 271 lines of Lean 4 code. It uses 5 axioms for results that require external references or deep mathematical arguments beyond Mathlib. The main conjecture is stated as an axiom since it is an open problem.",
+    "historicalContext": "Erdős Problem #1174 was posed by Erdős and Hajnal and sits at the intersection of Ramsey theory and set theory. The classical Ramsey theorem guarantees that any 2-coloring of the complete graph K_ω yields a monochromatic infinite clique. Problem 1174 asks what happens when we restrict the host graph—forbidding K₄ or K_{ℵ₁}—while allowing countably many colors rather than just two.\n\nThe problem has two parts: (a) asks for a K₄-free graph where every countable coloring forces a monochromatic triangle, and (b) asks for a K_{ℵ₁}-free graph where every countable coloring forces a monochromatic K_{ℵ₀}. The Nešetřil-Rödl theorem shows that for any fixed finite number k of colors, there exist K₄-free graphs with the partition property G → (3)²_k. The challenge in part (a) is extending this from finitely many to countably many colors simultaneously.\n\nShelah showed that graphs satisfying either property can consistently exist in certain models of ZFC. This means ZFC cannot disprove their existence, but whether ZFC can prove their existence remains open. The problem thus has a set-theoretic independence flavor, connecting combinatorial Ramsey theory with forcing and consistency results.",
+    "problemStatement": "Two related open questions: (a) Does there exist a K₄-free graph $G$ such that every edge coloring of $G$ with countably many colors contains a monochromatic triangle? (b) Does there exist a graph $G$ with no clique of cardinality $\\aleph_1$ such that every edge coloring with countably many colors contains a monochromatic clique of cardinality $\\aleph_0$?",
+    "proofStrategy": "The formalization defines the core graph-theoretic and set-theoretic concepts needed to state both parts precisely. Cliques, K₄-freeness, and cardinal-bounded clique-freeness are defined from first principles. The Erdős-Hajnal properties for both parts are captured as predicates on graphs. The Nešetřil-Rödl theorem (finite-color partition property for K₄-free graphs) and the infinite Ramsey theorem for 2 colors are axiomatized as context. A constructive proof shows the complete graph on ℕ is not K₄-free, demonstrating why the clique-freeness constraint is essential.",
     "keyInsights": [
-      "****Clique in a Graph**: **Clique in a Graph:**",
-      "****Clique-free for Cardinal κ**: **Clique-free for Cardinal κ:**",
-      "****Symmetric Coloring**: **Symmetric Coloring:**",
-      "****Monochromatic Triangle**: **Monochromatic Triangle:**"
+      "**Finite vs. countable colors**: The Nešetřil-Rödl theorem handles any fixed number of colors, but the jump to countably many colors is a fundamentally different challenge. No finite compactness argument bridges this gap.",
+      "**Set-theoretic independence**: Shelah's consistency results show this problem cannot be resolved by a finite computation or a standard ZFC argument alone—the answer may depend on the set-theoretic universe.",
+      "**Partition calculus notation**: The arrow notation G → (k)²_c encodes the partition property: every c-coloring of edges of G contains a monochromatic k-clique. Problem 1174(a) asks for G → (3)²_ω with G being K₄-free.",
+      "**Why K₄-free matters**: K₄-free graphs can still be very triangle-rich (e.g., complete tripartite graphs K_{n,n,n}), but whether this local triangle density can be made globally Ramsey-forcing is the crux of the problem.",
+      "**Infinite generalization**: Part (b) lifts the question to infinite cardinals: replacing triangles with K_{ℵ₀} and K₄-freeness with K_{ℵ₁}-freeness yields a natural transfinite analog."
     ]
   },
   "sections": [
     {
-      "id": "formalization",
-      "title": "Formalization",
-      "summary": "Complete formalization of Erdős Problem #1174",
+      "id": "header",
+      "title": "Problem Overview",
+      "summary": "Problem statement, context, and known results for both parts of Problem 1174",
       "startLine": 1,
-      "endLine": 271
+      "endLine": 27
+    },
+    {
+      "id": "definitions",
+      "title": "Clique and Coloring Definitions",
+      "summary": "Definitions of cliques, K₄-freeness, cardinal clique-freeness, and symmetric coloring",
+      "startLine": 37,
+      "endLine": 70
+    },
+    {
+      "id": "part-a",
+      "title": "The Finite Question (Part a)",
+      "summary": "Monochromatic triangle, Erdős-Hajnal finite property, and the formal statement of part (a)",
+      "startLine": 72,
+      "endLine": 105
+    },
+    {
+      "id": "part-b",
+      "title": "The Infinite Question (Part b)",
+      "summary": "Monochromatic ℵ₀-clique, Erdős-Hajnal infinite property, and the formal statement of part (b)",
+      "startLine": 107,
+      "endLine": 141
+    },
+    {
+      "id": "ramsey-context",
+      "title": "Ramsey Theory Context",
+      "summary": "Infinite Ramsey theorem for 2 colors and proof that the complete graph is not K₄-free",
+      "startLine": 143,
+      "endLine": 171
+    },
+    {
+      "id": "partition-calculus",
+      "title": "Partition Calculus Framework",
+      "summary": "Partition property definition and the Nešetřil-Rödl theorem for finite colors",
+      "startLine": 173,
+      "endLine": 197
+    },
+    {
+      "id": "consistency-observations",
+      "title": "Consistency Results and Structural Observations",
+      "summary": "Shelah's consistency results and observations about triangle-rich K₄-free graphs",
+      "startLine": 199,
+      "endLine": 222
+    },
+    {
+      "id": "open-status",
+      "title": "Open Status and Summary",
+      "summary": "Summary of known results and the open status of both parts in ZFC",
+      "startLine": 224,
+      "endLine": 243
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1174 (Monochromatic Cliques from Edge Colorings) in Lean 4, including core definitions, key structural results, and the open conjecture stated as an axiom.",
-    "implications": "The formalization demonstrates how open problems in combinatorics and number theory can be rigorously expressed in Lean 4.",
+    "summary": "This formalization captures both parts of Erdős Problem #1174 in Lean 4, providing rigorous definitions for K₄-freeness, cardinal clique-freeness, and the Erdős-Hajnal partition properties. The Nešetřil-Rödl theorem and infinite Ramsey theorem provide context showing why the problem is nontrivial.",
+    "implications": "The problem reveals a deep connection between finite Ramsey theory (where partition properties for K₄-free graphs are well understood for fixed numbers of colors) and set-theoretic independence (where extending to countably many colors touches on forcing and consistency). Resolution would advance understanding of the boundary between combinatorics and set theory.",
     "openQuestions": [
-      "Resolve the conjecture",
-      "Fill in sorry placeholders with complete proofs",
-      "Strengthen connections to other Erdős problems"
+      "Does ZFC prove the existence of a K₄-free graph where every countable edge coloring contains a monochromatic triangle?",
+      "Is the answer to part (a) or (b) independent of ZFC, or can a constructive example be given?",
+      "What is the relationship between the finite-color partition strength of K₄-free graphs and the countable-color question?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Removed 4 `True` placeholder declarations from Lean file (2 axioms, 2 theorems)
- Converted placeholder axioms/theorems to substantive mathematical comments
- Rewrote meta.json with proper description, keyInsights, 8 sections, and open questions
- Rewrote annotations.json with 16 educational annotations covering all definitions, axioms, and proofs

## Changes
- `proofs/Proofs/Erdos1174Problem.lean`: Removed `shelah_consistency_finite : True`, `shelah_consistency_infinite : True`, `k4free_can_have_triangles : True := by trivial`, `parts_related : True := by trivial`
- `src/data/proofs/erdos-1174/meta.json`: Fixed garbage description and keyInsights, added proper sections matching file structure
- `src/data/proofs/erdos-1174/annotations.json`: Full rewrite with educational content for each definition and theorem

## Checklist
- [x] pnpm build succeeds
- [x] Annotations align with Lean file line numbers
- [x] No True placeholders remain
- [x] 0 sorries in Lean file

🤖 Generated by enhancer-2