### PR TITLE
Enrich erdos-396: Descending Factorials Dividing Central Binomials

### DIFF
--- a/src/data/proofs/erdos-396/annotations.json
+++ b/src/data/proofs/erdos-396/annotations.json
@@ -1,74 +1,110 @@
 [
   {
-    "id": "catalan-divisibility",
+    "id": "ann-e396-imports",
     "proofId": "erdos-396",
-    "type": "theorem",
+    "range": { "startLine": 20, "endLine": 25 },
+    "type": "context",
+    "title": "Imports and Setup",
+    "content": "Imports Mathlib modules for natural number arithmetic, central binomial coefficients (`Nat.centralBinom`), and factorial operations (`Nat.descFactorial`). The `Nat.centralBinom n` computes $\\binom{2n}{n}$ directly, while `Nat.descFactorial n k` computes the descending factorial $n(n-1)\\cdots(n-k+1)$.",
+    "mathContext": "`Nat.centralBinom n` $= \\binom{2n}{n}$, `Nat.descFactorial n k` $= n^{\\underline{k}} = \\frac{n!}{(n-k)!}$",
+    "significance": "technical",
+    "relatedConcepts": ["Mathlib", "central binomial coefficient", "descending factorial"],
+    "prerequisites": ["Lean 4", "Mathlib combinatorics modules"]
+  },
+  {
+    "id": "ann-e396-catalan",
+    "proofId": "erdos-396",
+    "range": { "startLine": 38, "endLine": 39 },
+    "type": "axiom",
     "title": "Catalan Divisibility",
-    "content": "n+1 always divides C(2n,n), giving the n-th Catalan number C(2n,n)/(n+1). This is the base case for the descending factorial question.",
+    "content": "The foundational fact: $(n+1) \\mid \\binom{2n}{n}$ for all $n$, giving the Catalan number $C_n = \\binom{2n}{n}/(n+1)$. This is the 'zeroth case' of the descending factorial question — the factor immediately above $n$ always divides. The proof follows from the identity $\\binom{2n}{n} = \\frac{(2n)!}{(n!)^2}$ and the fact that $\\binom{2n}{n}/(n+1) = \\binom{2n}{n+1} \\in \\mathbb{Z}$.",
+    "mathContext": "$(n+1) \\mid \\binom{2n}{n}$ for all $n \\geq 0$, so $C_n = \\frac{1}{n+1}\\binom{2n}{n} \\in \\mathbb{Z}$",
     "significance": "key",
-    "range": {
-      "startLine": 34,
-      "endLine": 36
-    }
+    "relatedConcepts": ["Catalan numbers", "ballot problem", "Bertrand ballot problem"],
+    "prerequisites": ["binomial coefficients", "divisibility"]
   },
   {
-    "id": "pomerance-single",
+    "id": "ann-e396-n-rarely",
     "proofId": "erdos-396",
-    "type": "theorem",
-    "title": "Pomerance Single Factor",
-    "content": "For any k ≥ 0, infinitely many n satisfy (n−k) | C(2n,n), though this set has upper density less than 1/3.",
-    "significance": "critical",
-    "range": {
-      "startLine": 45,
-      "endLine": 48
-    }
-  },
-  {
-    "id": "pomerance-ascending",
-    "proofId": "erdos-396",
-    "type": "theorem",
-    "title": "Ascending Factorial Density",
-    "content": "The set of n where the ascending product (n+1)(n+2)⋯(n+k) divides C(2n,n) has asymptotic density 1.",
-    "significance": "key",
-    "range": {
-      "startLine": 54,
-      "endLine": 57
-    }
-  },
-  {
-    "id": "main-conjecture",
-    "proofId": "erdos-396",
-    "type": "concept",
-    "title": "Main Conjecture",
-    "content": "For every k, there exists n such that the descending factorial n(n−1)⋯(n−k) divides the central binomial coefficient C(2n,n).",
-    "significance": "critical",
-    "range": {
-      "startLine": 62,
-      "endLine": 64
-    }
-  },
-  {
-    "id": "computational-evidence",
-    "proofId": "erdos-396",
-    "type": "insight",
-    "title": "Computational Evidence",
-    "content": "The OEIS sequence A375077 records the smallest witness n for each k. Finding these witnesses computationally is non-trivial.",
+    "range": { "startLine": 42, "endLine": 45 },
+    "type": "axiom",
+    "title": "Rarity of $n \\mid \\binom{2n}{n}$",
+    "content": "While $n+1$ always divides $\\binom{2n}{n}$, the factor $n$ itself divides only for specific values. By Kummer's theorem, $n \\mid \\binom{2n}{n}$ iff there is no carry when adding $n$ to itself in every prime base dividing $n$. This makes divisibility by $n$ a delicate arithmetic condition, and most $n$ fail it.",
+    "mathContext": "By Kummer's theorem: $\\nu_p(\\binom{2n}{n})$ equals the number of carries when adding $n$ to $n$ in base $p$.",
     "significance": "supporting",
-    "range": {
-      "startLine": 68,
-      "endLine": 72
-    }
+    "relatedConcepts": ["Kummer's theorem", "p-adic valuation", "carries in addition"],
+    "prerequisites": ["prime factorization", "Kummer's theorem"]
   },
   {
-    "id": "infinitely-many",
+    "id": "ann-e396-pomerance-single",
     "proofId": "erdos-396",
-    "type": "concept",
-    "title": "Infinitely Many Witnesses",
-    "content": "A strengthening of the conjecture: for each k, there are infinitely many n with descFactorial(n, k+1) | centralBinom(n).",
+    "range": { "startLine": 50, "endLine": 51 },
+    "type": "axiom",
+    "title": "Pomerance: Single Factor Divisibility",
+    "content": "Pomerance's 2014 result: for any fixed $k \\geq 0$, infinitely many $n$ satisfy $(n-k) \\mid \\binom{2n}{n}$. This handles each individual factor in the descending product separately, but does not address simultaneous divisibility by all factors $n, n-1, \\ldots, n-k$. The gap between single-factor and full-product divisibility is the core difficulty of Problem #396.",
+    "mathContext": "$\\forall k \\geq 0, \\forall N, \\exists n \\geq N: (n-k) \\mid \\binom{2n}{n}$",
     "significance": "key",
-    "range": {
-      "startLine": 76,
-      "endLine": 78
-    }
+    "relatedConcepts": ["Pomerance 2014", "single factor divisibility", "infinitely-often results"],
+    "prerequisites": ["analytic number theory", "sieve methods"]
+  },
+  {
+    "id": "ann-e396-pomerance-density",
+    "proofId": "erdos-396",
+    "range": { "startLine": 54, "endLine": 56 },
+    "type": "axiom",
+    "title": "Pomerance: Upper Density Bound",
+    "content": "The set of $n$ for which $(n-k) \\mid \\binom{2n}{n}$ has upper density strictly less than $1/3$. This quantitative bound shows that while single-factor divisibility happens infinitely often, it is far from typical — most $n$ fail even single-factor divisibility.",
+    "mathContext": "$\\overline{d}(\\{n : (n-k) \\mid \\binom{2n}{n}\\}) < \\frac{1}{3}$",
+    "significance": "supporting",
+    "relatedConcepts": ["upper density", "natural density", "arithmetic sets"],
+    "prerequisites": ["asymptotic density", "analytic number theory"]
+  },
+  {
+    "id": "ann-e396-pomerance-ascending",
+    "proofId": "erdos-396",
+    "range": { "startLine": 59, "endLine": 61 },
+    "type": "axiom",
+    "title": "Pomerance: Ascending Factorial Density 1",
+    "content": "A striking contrast: the ascending product $(n+1)(n+2)\\cdots(n+k)$ divides $\\binom{2n}{n}$ for a set of $n$ with asymptotic density 1. This follows because $(n+1)(n+2)\\cdots(n+k)$ divides $\\frac{(2n)!}{n!}$ which is closely related to $\\binom{2n}{n} \\cdot n!$. The descending case is much harder because the factors $n, n-1, \\ldots$ interact with the denominator $(n!)^2$.",
+    "mathContext": "$d(\\{n : (n+1)(n+2)\\cdots(n+k) \\mid \\binom{2n}{n}\\}) = 1$",
+    "significance": "key",
+    "relatedConcepts": ["ascending factorial", "Pochhammer symbol", "density-1 sets"],
+    "prerequisites": ["asymptotic density", "factorial divisibility"]
+  },
+  {
+    "id": "ann-e396-main-conjecture",
+    "proofId": "erdos-396",
+    "range": { "startLine": 67, "endLine": 68 },
+    "type": "axiom",
+    "title": "Main Conjecture: Erdős Problem #396",
+    "content": "The central open question: for every $k$, does there exist $n$ such that the full descending factorial $n^{\\underline{k+1}} = n(n-1)\\cdots(n-k)$ divides $\\binom{2n}{n}$? This requires simultaneous divisibility by all factors, which is much stronger than Pomerance's single-factor result. The conjecture is supported by computational evidence (OEIS A375077) but remains unproved.",
+    "mathContext": "$\\forall k \\in \\mathbb{N}, \\exists n \\in \\mathbb{N}: n^{\\underline{k+1}} \\mid \\binom{2n}{n}$",
+    "significance": "key",
+    "relatedConcepts": ["simultaneous divisibility", "Chinese Remainder Theorem obstacles", "open problems"],
+    "prerequisites": ["descending factorials", "central binomial coefficients"]
+  },
+  {
+    "id": "ann-e396-computational",
+    "proofId": "erdos-396",
+    "range": { "startLine": 77, "endLine": 79 },
+    "type": "axiom",
+    "title": "Smallest Witnesses and Computational Evidence",
+    "content": "Axiomatizes a function giving the smallest witness $n$ for each $k$, along with a validity axiom. The OEIS sequence A375077 catalogues these values. Finding witnesses is computationally intensive because the descending factorial grows rapidly and the divisibility condition is arithmetically delicate.",
+    "mathContext": "$w(k) = \\min\\{n : n^{\\underline{k+1}} \\mid \\binom{2n}{n}\\}$, catalogued in OEIS A375077",
+    "significance": "supporting",
+    "relatedConcepts": ["OEIS A375077", "computational number theory", "witness functions"],
+    "prerequisites": ["computational search", "divisibility testing"]
+  },
+  {
+    "id": "ann-e396-infinitely-many",
+    "proofId": "erdos-396",
+    "range": { "startLine": 82, "endLine": 83 },
+    "type": "axiom",
+    "title": "Infinitely Many Witnesses Strengthening",
+    "content": "A natural strengthening of the main conjecture: for each $k$, there are infinitely many $n$ with $n^{\\underline{k+1}} \\mid \\binom{2n}{n}$. This parallels Pomerance's single-factor result (infinitely many $n$ for each individual factor) but demands simultaneous divisibility. If the main conjecture holds, this strengthening is a natural next question.",
+    "mathContext": "$\\forall k, \\forall N, \\exists n \\geq N: n^{\\underline{k+1}} \\mid \\binom{2n}{n}$",
+    "significance": "key",
+    "relatedConcepts": ["infinitely-often results", "density questions", "strengthenings"],
+    "prerequisites": ["Erdős Problem #396", "descending factorial divisibility"]
   }
 ]

--- a/src/data/proofs/erdos-396/meta.json
+++ b/src/data/proofs/erdos-396/meta.json
@@ -10,9 +10,10 @@
     "proofRepoPath": "Proofs/Erdos396Problem.lean",
     "tags": [
       "erdos",
-      "number theory",
-      "binomial coefficients",
-      "divisibility"
+      "number-theory",
+      "binomial-coefficients",
+      "divisibility",
+      "open"
     ],
     "badge": "formalized",
     "sorries": 0,
@@ -21,53 +22,76 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős and Graham posed this problem in 1980 about the divisibility of central binomial coefficients by descending factorial products. The connection to Catalan numbers (where n+1 always divides C(2n,n)) motivates the question of how deep divisibility by n and its predecessors can go. Pomerance (2014) made significant progress on related questions.",
-    "problemStatement": "For every positive integer k, does there exist n such that n(n−1)(n−2)⋯(n−k) divides C(2n,n)?",
-    "proofStrategy": "We use Mathlib's descFactorial and centralBinom. The Catalan divisibility is recorded, along with Pomerance's results on single factors and ascending factorials. The main conjecture and an infinitely-many strengthening are stated as axioms.",
+    "historicalContext": "Erdős and Graham posed Problem #396 in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory,' asking about the divisibility of central binomial coefficients $\\binom{2n}{n}$ by descending factorial products. The question is motivated by the classical fact that $n+1$ always divides $\\binom{2n}{n}$ (giving the Catalan numbers $C_n = \\binom{2n}{n}/(n+1)$), but $n$ itself rarely divides $\\binom{2n}{n}$. The problem asks how far 'downward' from $n$ one can push simultaneous divisibility.\n\nCarl Pomerance made the most significant progress in 2014. He showed that for any fixed $k$, each individual factor $(n-k)$ divides $\\binom{2n}{n}$ for infinitely many $n$, but the set of such $n$ has upper density less than $1/3$. In contrast, the ascending product $(n+1)(n+2)\\cdots(n+k)$ divides $\\binom{2n}{n}$ with asymptotic density 1 — a striking asymmetry between descending and ascending factorials. The key difficulty lies in the $p$-adic structure: by Kummer's theorem, $\\nu_p(\\binom{2n}{n})$ equals the number of carries when adding $n$ to $n$ in base $p$, and simultaneous divisibility by $n(n-1)\\cdots(n-k)$ places correlated constraints across multiple primes.\n\nThe OEIS sequence A375077 catalogues the smallest witness $n$ for each $k$. The problem remains open: even the existence of a single $n$ for each $k$ is unproved, let alone the natural strengthening that infinitely many witnesses exist.",
+    "problemStatement": "For every positive integer $k$, does there exist $n$ such that $n(n-1)(n-2)\\cdots(n-k) \\mid \\binom{2n}{n}$? Equivalently, does $n^{\\underline{k+1}} \\mid \\binom{2n}{n}$ for some $n$?",
+    "proofStrategy": "The formalization uses Mathlib's `Nat.descFactorial` and `Nat.centralBinom` to express the problem cleanly. The Catalan divisibility $(n+1) \\mid \\binom{2n}{n}$ is axiomatized as the base case. Pomerance's results are captured as three axioms: single-factor divisibility (infinitely many $n$), the $1/3$ density bound, and the density-1 result for ascending factorials. The main conjecture and its infinitely-many strengthening are stated as axioms. A smallest-witness function is axiomatized with a validity property for computational verification.",
     "keyInsights": [
-      "n+1 always divides C(2n,n), yielding Catalan numbers, but n itself rarely divides C(2n,n)",
-      "Pomerance showed each individual factor (n−k) divides C(2n,n) for infinitely many n",
-      "The ascending product ∏(n+i) divides C(2n,n) with density 1, contrasting the descending case",
-      "The OEIS sequence A375077 catalogues smallest witnesses for each k"
+      "**Ascending vs descending asymmetry**: The ascending product $(n+1)\\cdots(n+k)$ divides $\\binom{2n}{n}$ with density 1, but the descending product $n(n-1)\\cdots(n-k)$ divides only rarely. This reflects the different interactions with the denominator $(n!)^2$ in the formula $\\binom{2n}{n} = (2n)!/(n!)^2$.",
+      "**Kummer's theorem is the key tool**: The $p$-adic valuation $\\nu_p(\\binom{2n}{n})$ equals the number of carries when adding $n+n$ in base $p$. Simultaneous divisibility by $n, n-1, \\ldots, n-k$ constrains the base-$p$ digits of $n$ for each prime $p \\leq n$, creating a complex system of correlated conditions.",
+      "Pomerance's density bound of $1/3$ shows that **even single-factor divisibility is rare**: the set $\\{n : (n-k) \\mid \\binom{2n}{n}\\}$ has upper density $< 1/3$, far from the density-1 behavior of the ascending case.",
+      "The **Catalan number connection** provides the starting point: $C_n = \\binom{2n}{n}/(n+1)$ is always an integer, but the sequence $\\binom{2n}{n}/[n(n-1)\\cdots(n-k)]$ need not be, making the divisibility condition genuinely non-trivial.",
+      "The problem sits in the tradition of **Erdős divisibility questions** about binomial coefficients, connecting to the Erdős–Kac theorem, Granville's work on binomial coefficients modulo primes, and the general study of the prime factorization of $\\binom{2n}{n}$."
     ]
   },
   "sections": [
     {
-      "id": "definitions",
+      "id": "header-and-imports",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 25,
+      "summary": "Documents the problem, known results (Catalan divisibility, Pomerance 2014), and imports Mathlib modules for natural numbers, central binomial coefficients, and factorials."
+    },
+    {
+      "id": "core-definitions",
       "title": "Core Definitions",
-      "startLine": 21,
-      "endLine": 30,
-      "summary": "Uses Mathlib's descFactorial and centralBinom for the key objects."
+      "startLine": 27,
+      "endLine": 33,
+      "summary": "References Mathlib's `Nat.descFactorial` for descending factorials and `Nat.centralBinom` for central binomial coefficients."
     },
     {
       "id": "basic-divisibility",
       "title": "Basic Divisibility Results",
-      "startLine": 32,
-      "endLine": 41,
-      "summary": "Records that n+1 always divides C(2n,n) and that n rarely does."
+      "startLine": 35,
+      "endLine": 45,
+      "summary": "Axiomatizes Catalan divisibility $(n+1) \\mid \\binom{2n}{n}$ and the rarity of $n \\mid \\binom{2n}{n}$."
     },
     {
-      "id": "pomerance",
-      "title": "Pomerance's Results",
-      "startLine": 43,
-      "endLine": 58,
-      "summary": "Axiomatizes Pomerance's 2014 results on single factor divisibility and ascending factorial density."
+      "id": "pomerance-results",
+      "title": "Pomerance's Results (2014)",
+      "startLine": 47,
+      "endLine": 61,
+      "summary": "Three results: single-factor divisibility for infinitely many $n$, upper density $< 1/3$ for single factors, and density 1 for ascending factorials."
     },
     {
-      "id": "conjecture",
+      "id": "main-conjecture",
       "title": "The Erdős–Graham Conjecture",
-      "startLine": 60,
+      "startLine": 63,
+      "endLine": 68,
+      "summary": "States the main open conjecture: $\\forall k, \\exists n: n^{\\underline{k+1}} \\mid \\binom{2n}{n}$."
+    },
+    {
+      "id": "computational-evidence",
+      "title": "Computational Evidence",
+      "startLine": 70,
       "endLine": 79,
-      "summary": "States the main conjecture and its infinitely-many strengthening."
+      "summary": "Axiomatizes a smallest-witness function with validity, referencing OEIS A375077."
+    },
+    {
+      "id": "strengthening",
+      "title": "Infinitely Many Witnesses",
+      "startLine": 81,
+      "endLine": 84,
+      "summary": "States the natural strengthening: for each $k$, infinitely many $n$ satisfy the full descending factorial divisibility."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 396 asks whether descending factorial products can always divide central binomial coefficients. Pomerance's results handle individual factors and ascending products, but the full descending product conjecture remains open.",
-    "implications": "Resolution would deepen understanding of the prime factorization structure of central binomial coefficients, with connections to p-adic valuations and Kummer's theorem.",
+    "summary": "This formalization captures Erdős Problem #396 on descending factorial divisibility of central binomial coefficients. It includes the Catalan base case, Pomerance's 2014 partial results (single-factor, density bounds, ascending contrast), the open conjecture, computational evidence via OEIS, and the infinitely-many strengthening.",
+    "implications": "Resolution would deepen understanding of the $p$-adic structure of central binomial coefficients and the interplay between Kummer's theorem carries and factorial divisibility. The ascending-vs-descending asymmetry highlights fundamental differences in how the numerator and denominator of $\\binom{2n}{n}$ interact with shifted factorial products.",
     "openQuestions": [
-      "For every k, does n(n−1)⋯(n−k) divide C(2n,n) for some n?",
-      "How fast does the smallest witness n(k) grow with k?",
-      "What is the density of n for which the full product divides C(2n,n)?"
+      "For every $k$, does $n^{\\underline{k+1}} \\mid \\binom{2n}{n}$ hold for some $n$?",
+      "How fast does the smallest witness $w(k) = \\min\\{n : n^{\\underline{k+1}} \\mid \\binom{2n}{n}\\}$ grow with $k$?",
+      "What is the density (if it exists) of $\\{n : n^{\\underline{k+1}} \\mid \\binom{2n}{n}\\}$ for fixed $k \\geq 1$?",
+      "Can the Catalan divisibility axiom be proved from Mathlib's existing `Nat.centralBinom` API rather than axiomatized?"
     ]
   }
 }


### PR DESCRIPTION
## Enrichment Pass: erdos-396

Deep enrichment of the Erdős Problem #396 gallery entry (Descending Factorials Dividing Central Binomials).

### Changes
- **Annotations**: Rewrote 9 annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Fixed types to match Lean constructs.
- **Historical Context**: Rich narrative covering Erdős–Graham 1980 monograph, Pomerance 2014, Kummer's theorem and $p$-adic structure, ascending vs descending asymmetry, OEIS A375077.
- **Key Insights**: 5 substantive insights about ascending/descending asymmetry, Kummer's theorem, Pomerance density bounds, Catalan connection, and Erdős divisibility tradition.
- **Sections**: Expanded from 4 to 7 sections.
- **Conclusion**: 4 specific open questions about witness growth, density, and Mathlib formalization.
- **Tags**: Fixed to hyphenated format (`number-theory`, `binomial-coefficients`, `divisibility`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)