### PR TITLE
Enrich erdos-5: Limit Points of Normalized Prime Gaps

### DIFF
--- a/src/data/proofs/erdos-5/annotations.json
+++ b/src/data/proofs/erdos-5/annotations.json
@@ -1,56 +1,167 @@
 [
   {
-    "id": "erdos-5-ann-1",
+    "id": "ann-e5-imports",
     "proofId": "erdos-5",
-    "range": { "startLine": 30, "endLine": 38 },
-    "type": "definition",
+    "type": "import",
+    "title": "Mathlib Foundations",
+    "content": "Imports Nat.Prime for primality, Real.Basic for ℝ and logarithm, and Topology.Basic for limit point concepts.",
+    "mathContext": "The formalization works in $\\mathbb{R}$ using Mathlib's `Real.log` for the normalization $g(n) = (p_{n+1} - p_n)/\\log p_n$. The cast from $\\mathbb{Z}$ to $\\mathbb{R}$ handles the gap $p_{n+1} - p_n$ correctly even when formalized as a difference of natural numbers.",
+    "significance": "supporting",
+    "relatedConcepts": ["real analysis", "natural number primes", "logarithm"],
+    "prerequisites": ["Mathlib.Data.Real.Basic", "Mathlib.Data.Nat.Prime.Basic"],
+    "range": {
+      "startLine": 23,
+      "endLine": 26
+    }
+  },
+  {
+    "id": "ann-e5-nthPrime",
+    "proofId": "erdos-5",
+    "type": "axiom",
     "title": "The n-th Prime Axiomatization",
-    "content": "We axiomatize nthPrime as a function ℕ → ℕ that is strictly monotone and yields primes for n ≥ 1. This avoids the computability issues of defining p_n constructively while capturing the essential properties needed for the gap analysis.",
-    "significance": "The axiomatization is standard for number-theoretic formalizations where explicit prime enumeration is unnecessary."
+    "content": "Axiomatizes nthPrime as a function ℕ → ℕ, avoiding the computability issues of constructive prime enumeration.",
+    "mathContext": "The function $p : \\mathbb{N} \\to \\mathbb{N}$ satisfying $p(1) = 2, p(2) = 3, p(3) = 5, \\ldots$ is axiomatized rather than defined, since constructive prime enumeration would require a decidable primality sieve. The axiom captures the essential properties: $p(n)$ is prime for $n \\geq 1$, and the sequence is strictly monotone. This is a standard pattern for number-theoretic formalizations in Lean.",
+    "significance": "key",
+    "relatedConcepts": ["prime enumeration", "axiomatization patterns", "constructive vs classical"],
+    "prerequisites": ["Nat.Prime"],
+    "range": {
+      "startLine": 32,
+      "endLine": 32
+    }
   },
   {
-    "id": "erdos-5-ann-2",
+    "id": "ann-e5-nthPrime-prime",
     "proofId": "erdos-5",
-    "range": { "startLine": 40, "endLine": 48 },
+    "type": "axiom",
+    "title": "Primality of nthPrime",
+    "content": "nthPrime n is prime for all n ≥ 1. The guard n ≥ 1 avoids issues with nthPrime 0.",
+    "mathContext": "The 1-indexing convention ($p_1 = 2$) matches the standard number-theoretic convention. The condition $n \\geq 1$ leaves $p(0)$ unspecified, which is harmless since all statements use $n \\geq 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.Prime", "1-indexed sequences"],
+    "prerequisites": ["nthPrime"],
+    "range": {
+      "startLine": 35,
+      "endLine": 35
+    }
+  },
+  {
+    "id": "ann-e5-strictMono",
+    "proofId": "erdos-5",
+    "type": "axiom",
+    "title": "Strict Monotonicity of nthPrime",
+    "content": "nthPrime is strictly increasing, using Mathlib's StrictMono typeclass.",
+    "mathContext": "Strict monotonicity $p(m) < p(n)$ for $m < n$ encodes that each prime is followed by a strictly larger one. Combined with primality, this fully characterizes the prime enumeration function up to the choice of $p(0)$. The `StrictMono` predicate from Mathlib provides access to useful lemmas about order-preserving maps.",
+    "significance": "key",
+    "relatedConcepts": ["StrictMono", "order theory", "prime ordering"],
+    "prerequisites": ["nthPrime", "StrictMono"],
+    "range": {
+      "startLine": 38,
+      "endLine": 38
+    }
+  },
+  {
+    "id": "ann-e5-normalizedGap",
+    "proofId": "erdos-5",
     "type": "definition",
-    "title": "Normalized Gap and Limit Point Definitions",
-    "content": "normalizedGap(n) = (p_{n+1} - p_n) / log(p_n) is the key quantity. A value C is a limit point (IsLimitPointOfGaps) if for every ε > 0 and every N, some n ≥ N has |g(n) - C| < ε. This is the standard ε-N formulation of cluster points for real sequences.",
-    "significance": "The normalization by log(p_n) is crucial: by PNT, the average gap is ~ log(p_n), so g(n) has average value 1. The question is about the full set of accumulation points."
+    "title": "Normalized Gap Ratio",
+    "content": "g(n) = (p_{n+1} − p_n) / log(p_n), the prime gap normalized by the expected gap size from the prime number theorem.",
+    "mathContext": "The **prime number theorem** (PNT) states $\\pi(x) \\sim x/\\ln x$, which implies the average gap between consecutive primes near $x$ is approximately $\\ln x$. The normalization $g(n) = (p_{n+1} - p_n)/\\log p_n$ thus scales gaps so that $g(n)$ has average value $1$. The question of whether $S = [0, \\infty)$ asks whether *every* possible fluctuation around this average occurs infinitely often. The `noncomputable` annotation reflects that `Real.log` is noncomputable in Lean.",
+    "significance": "critical",
+    "relatedConcepts": ["prime number theorem", "logarithmic normalization", "average gap"],
+    "prerequisites": ["nthPrime", "Real.log", "integer cast"],
+    "range": {
+      "startLine": 41,
+      "endLine": 42
+    }
   },
   {
-    "id": "erdos-5-ann-3",
+    "id": "ann-e5-isLimitPoint",
     "proofId": "erdos-5",
-    "range": { "startLine": 52, "endLine": 54 },
-    "type": "result",
-    "title": "Goldston–Pintz–Yıldırım: 0 ∈ S",
-    "content": "GPY (2009) proved lim inf (p_{n+1} - p_n)/log(p_n) = 0, establishing that 0 is a limit point. This breakthrough later led to Zhang (2013) and Maynard (2013) proving bounded gaps between primes.",
-    "significance": "This is one of the landmark results in analytic number theory, showing primes can be much closer together than average infinitely often."
+    "type": "definition",
+    "title": "Limit Point of Gaps",
+    "content": "C is a limit point of g(n) if for every ε > 0 and every N, there exists n ≥ N with |g(n) − C| < ε. This is the standard ε-N formulation of cluster points.",
+    "mathContext": "The set $S = \\{C \\in \\mathbb{R} : C \\text{ is a limit point of } g(n)\\}$ is the closure of $\\{g(n) : n \\in \\mathbb{N}\\}$ in the one-point compactification $[0, \\infty]$. The $\\forall \\varepsilon > 0, \\forall N, \\exists n \\geq N$ quantifier structure is the standard sequential characterization of cluster points, avoiding topological machinery. This captures \"infinitely many $n$ with $g(n) \\approx C$\" rigorously.",
+    "significance": "critical",
+    "relatedConcepts": ["cluster points", "ε-N definition", "sequential limits", "topology"],
+    "prerequisites": ["normalizedGap", "Real.abs"],
+    "range": {
+      "startLine": 46,
+      "endLine": 48
+    }
   },
   {
-    "id": "erdos-5-ann-4",
+    "id": "ann-e5-GPY",
     "proofId": "erdos-5",
-    "range": { "startLine": 56, "endLine": 65 },
-    "type": "result",
-    "title": "Unbounded Gaps and Large Limit Points",
-    "content": "Westzynthius (1931) showed lim sup (p_{n+1} - p_n)/log(p_n) = ∞. Hildebrand and Maier strengthened this to show S contains arbitrarily large finite values. The current best quantitative result on large gaps is due to Ford–Green–Konyagin–Maynard–Tao (2018).",
-    "significance": "Together with GPY, this shows S contains both 0 and ∞, but the question of whether S fills all of [0, ∞) remains elusive."
+    "type": "axiom",
+    "title": "Goldston-Pintz-Yıldırım: 0 ∈ S",
+    "content": "GPY (2009) proved lim inf g(n) = 0, establishing that 0 is a limit point of the normalized gap sequence.",
+    "mathContext": "The **GPY theorem** (2009) proved $\\liminf_{n \\to \\infty} (p_{n+1} - p_n)/\\log p_n = 0$, meaning primes can be much closer together than average infinitely often. This was the breakthrough that initiated the chain: GPY (2009) → Zhang (2013, bounded gaps) → Maynard-Tao (2013, multiple bounded gaps) → Polymath 8 (gap ≤ 246). The GPY sieve method combined the Bombieri-Vinogradov theorem with the Selberg sieve in a novel way.",
+    "significance": "critical",
+    "relatedConcepts": ["GPY theorem", "bounded gaps", "Zhang's theorem", "Maynard-Tao", "sieve methods"],
+    "prerequisites": ["IsLimitPointOfGaps", "normalizedGap"],
+    "range": {
+      "startLine": 54,
+      "endLine": 54
+    }
   },
   {
-    "id": "erdos-5-ann-5",
+    "id": "ann-e5-unbounded",
     "proofId": "erdos-5",
-    "range": { "startLine": 67, "endLine": 72 },
-    "type": "result",
-    "title": "Merikoski Density Bound",
-    "content": "Merikoski (2020) proved that at least 1/3 of [0, ∞) belongs to S (in the sense of Lebesgue density). Earlier, Erdős and Ricci had shown S has positive measure. Banks, Freiberg, and Maynard established at least 12.5% coverage.",
-    "significance": "The improving density bounds (positive measure → 12.5% → 1/3) suggest the full conjecture S = [0, ∞) may be true, but the gap from 1/3 to 1 remains substantial."
+    "type": "axiom",
+    "title": "Westzynthius: Unbounded Gaps (∞ ∈ S)",
+    "content": "Westzynthius (1931) proved that normalized gaps can be arbitrarily large: for every M, infinitely many n satisfy g(n) > M.",
+    "mathContext": "**Westzynthius** (1931) showed $\\limsup (p_{n+1} - p_n)/\\log p_n = \\infty$, proving that gaps between primes can grow much faster than $\\log p_n$ infinitely often. The best quantitative bound is due to **Ford-Green-Konyagin-Maynard-Tao** (2018): there exist gaps exceeding $c \\cdot \\log n \\cdot \\log\\log n \\cdot \\log\\log\\log\\log n / (\\log\\log\\log n)^2$. This is formalized as a universal statement: for *every* $M$, the set $\\{n : g(n) > M\\}$ is infinite.",
+    "significance": "critical",
+    "relatedConcepts": ["large gaps", "Rankin's theorem", "Ford-Green-Konyagin-Maynard-Tao"],
+    "prerequisites": ["normalizedGap"],
+    "range": {
+      "startLine": 59,
+      "endLine": 60
+    }
   },
   {
-    "id": "erdos-5-ann-6",
+    "id": "ann-e5-hildebrand-maier",
     "proofId": "erdos-5",
-    "range": { "startLine": 76, "endLine": 80 },
-    "type": "conjecture",
-    "title": "The Full Conjecture: S = [0, ∞)",
-    "content": "Erdős conjectured that every non-negative real number is a limit point of g(n). This is formalized as: ∀ C ≥ 0, IsLimitPointOfGaps C. The conjecture implies complete understanding of the fluctuations of prime gaps at the logarithmic scale.",
-    "significance": "This is one of the most fundamental open problems about the distribution of primes, connecting to the Hardy–Littlewood conjecture, sieve methods, and the statistical behavior of primes."
+    "type": "axiom",
+    "title": "Hildebrand-Maier: Large Finite Limit Points",
+    "content": "For any C > 0, infinitely many n have g(n) > C. This strengthens unbounded gaps by showing S contains arbitrarily large finite values.",
+    "mathContext": "**Hildebrand and Maier** showed that $S$ contains arbitrarily large finite numbers, not just $\\infty$. This is stronger than Westzynthius: it's not merely that gaps can be large, but that specific large values are *limit points*. Combined with GPY ($0 \\in S$), this means $S$ is unbounded from above and contains $0$, but the interior structure of $S$ between $0$ and $\\infty$ remains mysterious.",
+    "significance": "key",
+    "relatedConcepts": ["Hildebrand-Maier theorem", "finite limit points", "gap distribution"],
+    "prerequisites": ["normalizedGap", "IsLimitPointOfGaps"],
+    "range": {
+      "startLine": 64,
+      "endLine": 65
+    }
+  },
+  {
+    "id": "ann-e5-merikoski",
+    "proofId": "erdos-5",
+    "type": "axiom",
+    "title": "Merikoski: At Least 1/3 Coverage",
+    "content": "Merikoski (2020) proved that at least 1/3 of any interval [0, T] belongs to S in the sense of Lebesgue measure.",
+    "mathContext": "The sequence of density improvements for $S$: **Erdős-Ricci** (positive measure) → **Banks-Freiberg-Maynard** (≥ 12.5%) → **Merikoski** (2020, ≥ 1/3). The formalization uses a finitary approximation: a `Finset ℝ` of at least $T/3$ many limit points in $[0, T]$. This is a pragmatic compromise—the true statement involves Lebesgue measure, but Finset approximation is more tractable in Lean.",
+    "significance": "key",
+    "relatedConcepts": ["Lebesgue measure", "density bounds", "Banks-Freiberg-Maynard"],
+    "prerequisites": ["IsLimitPointOfGaps", "Finset"],
+    "range": {
+      "startLine": 70,
+      "endLine": 72
+    }
+  },
+  {
+    "id": "ann-e5-conjecture",
+    "proofId": "erdos-5",
+    "type": "axiom",
+    "title": "Erdős Problem 5: S = [0, ∞)",
+    "content": "Every non-negative real C is a limit point of g(n). This is the full conjecture: the set of limit points of normalized prime gaps is all of [0, ∞).",
+    "mathContext": "The conjecture $S = [0, \\infty)$ is formalized as $\\forall C \\geq 0, \\text{IsLimitPointOfGaps}(C)$. This would mean that for *every* target ratio $C$, there are infinitely many consecutive prime pairs with gap ratio approximately $C$. The conjecture is one of the deepest open problems about prime distribution, connecting to the **Hardy-Littlewood prime $k$-tuples conjecture**, **Cramér's model** of primes as random events with density $1/\\ln x$, and the **Elliott-Halberstam conjecture** on primes in arithmetic progressions.",
+    "significance": "critical",
+    "relatedConcepts": ["Hardy-Littlewood conjecture", "Cramér's model", "Elliott-Halberstam conjecture"],
+    "prerequisites": ["IsLimitPointOfGaps"],
+    "range": {
+      "startLine": 79,
+      "endLine": 80
+    }
   }
 ]

--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -4,8 +4,10 @@
   "slug": "erdos-5",
   "description": "Is the set S of limit points of (p_{n+1} - p_n)/log(p_n) equal to [0, ∞)? Known: 0 ∈ S (GPY), ∞ ∈ S (Westzynthius), S has positive measure (Erdős–Ricci), at least 1/3 coverage (Merikoski). Open.",
   "meta": {
-    "erdosNumber": 5,
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/5",
     "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos5Problem.lean",
     "tags": [
       "erdos",
       "number-theory",
@@ -13,62 +15,94 @@
       "analytic-number-theory",
       "open"
     ],
+    "badge": "formalized",
+    "sorries": 0,
+    "erdosNumber": 5,
+    "erdosUrl": "https://erdosproblems.com/5",
+    "erdosProblemStatus": "open",
     "references": [
       "Goldston–Pintz–Yıldırım: 0 ∈ S (2009)",
       "Westzynthius: ∞ ∈ S (1931)",
       "Erdős–Ricci: S has positive Lebesgue measure",
       "Hildebrand–Maier: arbitrarily large finite limit points",
       "Merikoski: at least 1/3 of [0,∞) in S (2020)",
-      "https://erdosproblems.com/5"
-    ],
-    "leanFile": "Proofs/Erdos5Problem.lean",
-    "sorries": 0,
-    "sourceUrl": "https://erdosproblems.com/5",
-    "erdosUrl": "https://erdosproblems.com/5"
+      "Ford–Green–Konyagin–Maynard–Tao: improved large gap bounds (2018)",
+      "Zhang: bounded gaps between primes (2013)",
+      "Maynard–Tao: multiple bounded gaps (2013)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős studied the distribution of prime gaps normalized by log(p_n) throughout his career, building on the prime number theorem's prediction that the average gap is ~log(p_n). The question of which values arise as limit points of g(n) = (p_{n+1} − p_n)/log(p_n) captures the full range of prime gap fluctuations. Westzynthius (1931) first showed the gaps can be arbitrarily large (∞ ∈ S). The landmark GPY theorem (2009) proved lim inf g(n) = 0, establishing 0 ∈ S and initiating the chain of breakthroughs: Zhang (2013, first finite bound on gap), Maynard-Tao (2013, gap ≤ 600), Polymath 8 (gap ≤ 246). For the interior of S, Erdős and Ricci showed S has positive Lebesgue measure, Banks-Freiberg-Maynard improved this to ≥ 12.5%, and Merikoski (2020) reached ≥ 1/3 of [0, ∞). The conjecture S = [0, ∞) remains one of the most fundamental open problems about prime distribution, closely related to the Hardy-Littlewood prime k-tuples conjecture and Cramér's probabilistic model of primes.",
+    "problemStatement": "Is the set S of all limit points of (p_{n+1} - p_n)/log(p_n) equal to [0, ∞)? Equivalently, for every C ≥ 0, does there exist an infinite sequence of indices n_i with g(n_i) → C?",
+    "proofStrategy": "The formalization axiomatizes nthPrime with strict monotonicity and primality, defines normalizedGap as the real-valued ratio, and specifies IsLimitPointOfGaps via the standard ε-N formulation. Known partial results are recorded as axioms: GPY for 0 ∈ S, Westzynthius for ∞ ∈ S, Hildebrand-Maier for large finite limit points, and Merikoski's 1/3 density bound (approximated via Finset). The full conjecture is stated as a universal quantification over all C ≥ 0.",
+    "keyInsights": [
+      "**PNT normalization**: Dividing by log(p_n) gives average value 1 by the prime number theorem, so the question is about the full fluctuation spectrum",
+      "**GPY breakthrough**: The proof that 0 ∈ S (2009) used a novel combination of Bombieri-Vinogradov and Selberg sieve, later leading to bounded gaps proofs",
+      "**Asymmetric progress**: The extremes 0 and ∞ are well-understood, but filling in the interior of S is much harder—requiring simultaneous control of both small and large gaps",
+      "**Density approach**: The improving density bounds (positive measure → 12.5% → 1/3) suggest S might be dense, but the jump from 1/3 to full coverage requires fundamentally new ideas",
+      "**Cramér's model predicts S = [0, ∞)**: Under the probabilistic model where primes behave like random integers with density 1/ln(x), all gap ratios would occur as limit points"
+    ]
   },
   "sections": [
     {
-      "id": "definitions",
-      "title": "Definitions",
-      "startLine": 28,
-      "endLine": 48,
-      "summary": "nthPrime, normalizedGap g(n), IsLimitPointOfGaps."
+      "id": "imports",
+      "title": "Mathlib Imports",
+      "startLine": 23,
+      "endLine": 26,
+      "summary": "Imports Nat.Prime, Real.Basic (for logarithm), and Topology.Basic from Mathlib."
     },
     {
-      "id": "known-results",
-      "title": "Known Results",
+      "id": "prime-axioms",
+      "title": "Prime Enumeration Axioms",
+      "startLine": 28,
+      "endLine": 38,
+      "summary": "Axiomatizes nthPrime with primality for n ≥ 1 and strict monotonicity."
+    },
+    {
+      "id": "gap-definitions",
+      "title": "Gap and Limit Point Definitions",
+      "startLine": 40,
+      "endLine": 48,
+      "summary": "Defines normalizedGap g(n) = (p_{n+1} − p_n)/log(p_n) and IsLimitPointOfGaps via ε-N formulation."
+    },
+    {
+      "id": "GPY-result",
+      "title": "GPY: 0 ∈ S",
       "startLine": 50,
+      "endLine": 54,
+      "summary": "Records Goldston-Pintz-Yıldırım's 2009 proof that 0 is a limit point."
+    },
+    {
+      "id": "large-gaps",
+      "title": "Large Gaps and Unboundedness",
+      "startLine": 56,
+      "endLine": 65,
+      "summary": "Records Westzynthius (∞ ∈ S) and Hildebrand-Maier (arbitrarily large finite limit points)."
+    },
+    {
+      "id": "density-bound",
+      "title": "Merikoski Density Bound",
+      "startLine": 67,
       "endLine": 72,
-      "summary": "0 ∈ S, ∞ ∈ S, Hildebrand–Maier, Merikoski 1/3 density."
+      "summary": "Records Merikoski's 2020 result that at least 1/3 of [0, T] belongs to S."
     },
     {
       "id": "conjecture",
-      "title": "The Conjecture",
+      "title": "The Full Conjecture",
       "startLine": 74,
-      "endLine": 80,
-      "summary": "S = [0, ∞): every C ≥ 0 is a limit point."
+      "endLine": 81,
+      "summary": "States Erdős Problem 5: S = [0, ∞), i.e., every C ≥ 0 is a limit point of g(n)."
     }
   ],
-  "overview": {
-    "historicalContext": "Erdős studied the distribution of gaps between consecutive primes normalized by the logarithm. The sequence g(n) = (p_{n+1} - p_n)/log(p_n) has average value 1 by the prime number theorem, but its set of limit points S remains mysterious. The conjecture that S = [0, ∞) emerged from Erdős's deep investigations into prime gap irregularities.",
-    "problemStatement": "Is the set S of all limit points of (p_{n+1} - p_n)/log(p_n) equal to [0, ∞)? Equivalently, for every C ≥ 0, does there exist an infinite sequence of indices n_i with g(n_i) → C?",
-    "proofStrategy": "We axiomatize nthPrime and normalizedGap, define IsLimitPointOfGaps via the ε-N formulation, record known partial results (GPY, Westzynthius, Hildebrand–Maier, Merikoski), and state the full conjecture.",
-    "keyInsights": [
-      "GPY (2009) proved lim inf g(n) = 0, establishing 0 ∈ S and opening the way to bounded gaps",
-      "Westzynthius (1931) showed gaps can grow arbitrarily relative to log(p_n), so ∞ ∈ S",
-      "Erdős–Ricci proved S has positive Lebesgue measure, showing the conjecture holds for 'many' values",
-      "Merikoski (2020) improved the density bound to at least 1/3 of [0, ∞)",
-      "The prime number theorem gives average gap ~ log(p_n), so g(n) has average 1, but its fluctuations are poorly understood"
-    ]
-  },
   "conclusion": {
-    "summary": "Erdős Problem #5 conjectures that every non-negative real number is a limit point of the normalized prime gap sequence. Despite major progress — 0 and ∞ are known to be in S, and at least 1/3 of [0, ∞) is covered — the full conjecture remains open.",
-    "implications": "Resolution would provide a complete picture of prime gap fluctuations, connecting to the Hardy–Littlewood prime tuple conjecture, the distribution of primes in short intervals, and sieve methods.",
+    "summary": "Erdős Problem #5 asks whether every non-negative real number is a limit point of normalized prime gaps. The extremes are settled: 0 ∈ S (GPY) and ∞ ∈ S (Westzynthius). The interior has seen steady progress from positive measure (Erdős-Ricci) through 12.5% (Banks-Freiberg-Maynard) to 1/3 (Merikoski 2020), but the full conjecture S = [0, ∞) remains wide open.",
+    "implications": "Resolution would provide a complete understanding of prime gap fluctuations at the logarithmic scale, confirming the prediction of Cramér's probabilistic model. It connects to the Hardy-Littlewood prime k-tuples conjecture (which would imply S = [0, ∞)), sieve methods (the GPY-Maynard-Tao framework), and the distribution of primes in short intervals.",
     "openQuestions": [
       "Is every C ≥ 0 a limit point of (p_{n+1} - p_n)/log(p_n)?",
       "Is the set S connected (i.e., is S an interval)?",
       "Can the Merikoski 1/3 density bound be improved toward full coverage?",
-      "What is the Hausdorff dimension of the complement [0,∞) \\ S?"
+      "What is the Hausdorff dimension of the complement [0,∞) \\ S?",
+      "Does the Elliott-Halberstam conjecture imply S = [0, ∞)?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Deep enrichment of **erdos-5** (Limit Points of Normalized Prime Gaps)
- Annotations: 6 → 11 with full mathContext covering GPY, Westzynthius, Cramér's model, Hardy-Littlewood
- Fixed annotation types from invalid `result`/`conjecture` to `axiom`/`definition`
- Meta: comprehensive historicalContext (GPY→Zhang→Maynard-Tao chain, density bounds), bold keyInsights, 7 sections
- Added `proofRepoPath`, `badge`, `erdosProblemStatus`, `author` fields
- Expanded references with Ford-Green-Konyagin-Maynard-Tao, Zhang, Maynard-Tao

## Test plan
- [x] `pnpm annotations:build` passes (no erdos-5 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)