### PR TITLE
Enrich erdos-579: K₂,₂,₂-Free Dense Graphs

### DIFF
--- a/src/data/proofs/erdos-579/annotations.json
+++ b/src/data/proofs/erdos-579/annotations.json
@@ -1,62 +1,137 @@
 [
   {
-    "id": "k222-def",
+    "id": "ann-e579-imports",
+    "proofId": "erdos-579",
+    "type": "import",
+    "title": "Mathlib SimpleGraph Imports",
+    "content": "Imports Mathlib's SimpleGraph, Clique, and Finset libraries for graph-theoretic definitions.",
+    "mathContext": "This formalization uses Mathlib's built-in `SimpleGraph V` type rather than a custom graph structure. The `SimpleGraph.Clique` import provides access to clique-related predicates, while `Finset` supports edge counting and vertex subsets. The `DecidableRel G.Adj` instance enables `edgeFinset.card` for edge counting.",
+    "significance": "supporting",
+    "relatedConcepts": ["SimpleGraph", "Mathlib graph theory", "DecidableRel"],
+    "prerequisites": ["SimpleGraph.Basic", "SimpleGraph.Clique", "Finset"],
+    "range": {
+      "startLine": 17,
+      "endLine": 21
+    }
+  },
+  {
+    "id": "ann-e579-containsK222",
     "proofId": "erdos-579",
     "type": "definition",
     "title": "K₂,₂,₂ Containment",
-    "content": "A graph contains K₂,₂,₂ if there exist three disjoint pairs of vertices with all 12 cross-edges present. K₂,₂,₂ is the octahedron graph.",
+    "content": "A graph contains K₂,₂,₂ if there exist six distinct vertices partitioned into three pairs with all 12 cross-edges present.",
+    "mathContext": "The complete tripartite graph $K_{2,2,2}$ (the **octahedron**) has vertex set $\\{a_1,a_2\\} \\cup \\{b_1,b_2\\} \\cup \\{c_1,c_2\\}$ with edges between all vertices in different parts. It has 6 vertices, 12 edges, and is $3$-regular. The formalization explicitly enumerates all 12 cross-edges and enforces distinctness via `Finset.card = 6`. The octahedron is self-complementary and is the dual of the cube.",
     "significance": "critical",
+    "relatedConcepts": ["complete tripartite graphs", "octahedron", "forbidden subgraphs"],
+    "prerequisites": ["SimpleGraph.Adj", "Finset.card", "DecidableEq"],
     "range": {
-      "startLine": 26,
-      "endLine": 37
+      "startLine": 30,
+      "endLine": 38
     }
   },
   {
-    "id": "independence-number",
+    "id": "ann-e579-isK222Free",
+    "proofId": "erdos-579",
+    "type": "definition",
+    "title": "K₂,₂,₂-Free Graph",
+    "content": "A graph is K₂,₂,₂-free if it does not contain the octahedron as a subgraph.",
+    "mathContext": "The $K_{2,2,2}$-free condition is a **forbidden subgraph** constraint. By the Kruskal-Katona/Turán theory, $K_{2,2,2}$-free graphs on $n$ vertices have at most $(1/8 + o(1))n^2$ edges. This is tighter than the $K_4$-free bound of $n^2/6$ but looser than the $K_3$-free (triangle-free) bound of $n^2/4$.",
+    "significance": "key",
+    "relatedConcepts": ["forbidden subgraphs", "Turán density", "extremal graph theory"],
+    "prerequisites": ["SimpleGraph.ContainsK222"],
+    "range": {
+      "startLine": 41,
+      "endLine": 42
+    }
+  },
+  {
+    "id": "ann-e579-isDense",
+    "proofId": "erdos-579",
+    "type": "definition",
+    "title": "Edge Density Predicate",
+    "content": "isDense G δ asserts that G has at least δn² edges, where n is the number of vertices.",
+    "mathContext": "The density parameter $\\delta \\in (0, 1/8]$ measures the fraction of possible edges present. For $K_{2,2,2}$-free graphs, $\\delta \\leq 1/8 + o(1)$ by the Turán bound. The EHSS result handles $\\delta > 1/8$ (super-Turán density), and the conjecture extends to all $\\delta > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["edge density", "graph density", "Turán density"],
+    "prerequisites": ["SimpleGraph", "edgeFinset", "DecidableRel"],
+    "range": {
+      "startLine": 47,
+      "endLine": 48
+    }
+  },
+  {
+    "id": "ann-e579-isIndepSet",
+    "proofId": "erdos-579",
+    "type": "definition",
+    "title": "Independent Set",
+    "content": "A set of vertices with no edges between any two members.",
+    "mathContext": "An **independent set** (or **stable set**) $S$ satisfies $\\forall u, v \\in S, u \\neq v \\implies \\neg G.\\text{Adj}(u,v)$. Finding large independent sets is dual to finding small vertex covers (by König's theorem in bipartite graphs). The Ramsey number $R(3,t) = \\Theta(t^2/\\log t)$ bounds the independence number of triangle-free graphs, but $K_{2,2,2}$-freeness is a different constraint.",
+    "significance": "critical",
+    "relatedConcepts": ["independent sets", "Ramsey numbers", "vertex covers"],
+    "prerequisites": ["SimpleGraph.Adj", "Finset membership"],
+    "range": {
+      "startLine": 51,
+      "endLine": 52
+    }
+  },
+  {
+    "id": "ann-e579-independenceNumber",
     "proofId": "erdos-579",
     "type": "definition",
     "title": "Independence Number",
-    "content": "The maximum size of a set of pairwise non-adjacent vertices. The conjecture asserts this is linear in n for K₂,₂,₂-free dense graphs.",
+    "content": "The maximum cardinality of an independent set, computed as the supremum over all independent subsets of vertices.",
+    "mathContext": "The independence number $\\alpha(G)$ is computed as $\\max\\{|S| : S \\subseteq V, G.\\text{IsIndepSet}(S)\\}$. The conjecture asserts $\\alpha(G) \\geq c(\\delta) \\cdot n$ for $K_{2,2,2}$-free graphs with density $\\delta$. The `noncomputable` annotation reflects that enumerating all subsets to find the maximum is not constructively feasible.",
     "significance": "critical",
+    "relatedConcepts": ["independence number", "optimization over subsets", "NP-hardness"],
+    "prerequisites": ["SimpleGraph.IsIndepSet", "Finset.sup"],
     "range": {
       "startLine": 55,
-      "endLine": 59
+      "endLine": 57
     }
   },
   {
-    "id": "ehss-result",
+    "id": "ann-e579-ehss",
     "proofId": "erdos-579",
-    "type": "theorem",
-    "title": "EHSS Result (δ > 1/8)",
-    "content": "For edge density δ > 1/8, Erdős–Hajnal–Sós–Szemerédi proved that K₂,₂,₂-free graphs have independent sets of size c·n. The threshold 1/8 is the Turán density of K₂,₂,₂.",
+    "type": "axiom",
+    "title": "EHSS Result for δ > 1/8",
+    "content": "Erdős, Hajnal, Sós, and Szemerédi (1983) proved that for δ > 1/8, K₂,₂,₂-free graphs with ≥ δn² edges have independence number ≥ cn.",
+    "mathContext": "The **EHSS theorem** (1983) uses the fact that for $\\delta > 1/8$, a $K_{2,2,2}$-free graph with $\\geq \\delta n^2$ edges exceeds the **Turán number** $\\text{ex}(n; K_{2,2,2})$. This 'super-Turán' density creates structural constraints exploitable by regularity methods. The formalization uses `Filter.atTop` for the 'sufficiently large $n$' quantifier, a clean alternative to explicit bounds.",
     "significance": "critical",
+    "relatedConcepts": ["EHSS theorem", "super-Turán density", "regularity method", "Filter.atTop"],
+    "prerequisites": ["SimpleGraph.IsK222Free", "isDense", "independenceNumber"],
     "range": {
       "startLine": 63,
-      "endLine": 71
+      "endLine": 69
     }
   },
   {
-    "id": "main-conjecture",
+    "id": "ann-e579-conjecture",
     "proofId": "erdos-579",
-    "type": "concept",
-    "title": "The General Conjecture",
-    "content": "For every δ > 0 (not just δ > 1/8), K₂,₂,₂-free graphs with ≥ δn² edges should have independent sets of size ≫_δ n. This extends the EHSS result below the Turán threshold.",
+    "type": "axiom",
+    "title": "Erdős Problem 579: Full Conjecture",
+    "content": "For every δ > 0, K₂,₂,₂-free graphs with ≥ δn² edges have independent sets of size ≥ c(δ)·n.",
+    "mathContext": "The conjecture extends EHSS from $\\delta > 1/8$ to all $\\delta > 0$. For $\\delta \\leq 1/8$, the graph has *fewer* edges than the Turán extremal graph, so the structural argument changes qualitatively. The problem is analogous to Problem #533 (triangle-free subsets in $K_5$-free graphs) but with $K_{2,2,2}$ replacing $K_5$ and independent sets replacing triangle-free subsets. Both ask whether a forbidden subgraph condition, combined with positive density, forces structured subgraphs of linear size.",
     "significance": "critical",
+    "relatedConcepts": ["sub-Turán density", "linear independence number", "Erdős Problem 533"],
+    "prerequisites": ["SimpleGraph.IsK222Free", "isDense", "independenceNumber"],
     "range": {
-      "startLine": 75,
-      "endLine": 83
+      "startLine": 76,
+      "endLine": 82
     }
   },
   {
-    "id": "turan-connection",
+    "id": "ann-e579-turanK222",
     "proofId": "erdos-579",
-    "type": "insight",
-    "title": "Turán Density Connection",
-    "content": "The Turán number ex(n; K₂,₂,₂) = (1/8+o(1))n². For δ > 1/8, K₂,₂,₂-free graphs are 'super-Turán dense', making the EHSS proof possible. Below 1/8, new ideas are needed.",
+    "type": "axiom",
+    "title": "Turán Number of K₂,₂,₂",
+    "content": "The Turán number ex(n; K₂,₂,₂) = (1/8 + o(1))n², establishing the maximum edge count for K₂,₂,₂-free graphs.",
+    "mathContext": "The **Turán number** $\\text{ex}(n; H)$ is the maximum number of edges in an $H$-free graph on $n$ vertices. For $K_{2,2,2}$, the extremal graph is the balanced complete $8$-partite graph $T_8(n)$ with $\\lfloor n/8 \\rfloor$-sized parts. The formalization uses a vanishing error function $f : \\mathbb{N} \\to \\mathbb{R}$ with $f(n) \\to 0$ to express the asymptotic bound. The threshold $1/8$ explains why the EHSS proof works above this density: exceeding the Turán number forces structural richness in the graph.",
     "significance": "key",
+    "relatedConcepts": ["Turán's theorem", "extremal numbers", "Turán graph T₈(n)"],
+    "prerequisites": ["SimpleGraph.IsK222Free", "edgeFinset", "Filter.atTop"],
     "range": {
-      "startLine": 87,
-      "endLine": 95
+      "startLine": 89,
+      "endLine": 94
     }
   }
 ]

--- a/src/data/proofs/erdos-579/meta.json
+++ b/src/data/proofs/erdos-579/meta.json
@@ -10,9 +10,10 @@
     "proofRepoPath": "Proofs/Erdos579Problem.lean",
     "tags": [
       "erdos",
-      "graph theory",
-      "extremal graph theory",
-      "Turán theory"
+      "graph-theory",
+      "extremal-graph-theory",
+      "turan-theory",
+      "open"
     ],
     "badge": "formalized",
     "sorries": 0,
@@ -21,53 +22,70 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős, Hajnal, Sós, and Szemerédi studied dense graphs forbidding the octahedron (K₂,₂,₂). They proved that for edge density > 1/8, such graphs must have linear-size independent sets. The threshold 1/8 corresponds to the Turán density of K₂,₂,₂. The conjecture extends this to all positive densities.",
+    "historicalContext": "Erdős, Hajnal, Sós, and Szemerédi studied the relationship between forbidden subgraphs and independence numbers in dense graphs. The octahedron K₂,₂,₂ (complete tripartite graph with parts of size 2) has Turán density 1/8: the maximum number of edges in a K₂,₂,₂-free graph on n vertices is (1/8 + o(1))n². EHSS (1983) proved that for edge density exceeding this threshold (δ > 1/8), K₂,₂,₂-free graphs must have linear independence numbers α(G) ≥ c·n. The conjecture extends this to all δ > 0, asking whether even sub-Turán density K₂,₂,₂-free graphs are forced to have large independent sets. This parallels Problem #533 (triangle-free subsets in K₅-free graphs), forming part of a broader program in Ramsey-Turán theory that investigates how forbidden subgraph conditions interact with density to force structural properties.",
     "problemStatement": "For every δ > 0 and n sufficiently large, must every K₂,₂,₂-free graph on n vertices with at least δn² edges contain an independent set of size ≫_δ n?",
-    "proofStrategy": "Defines K₂,₂,₂ containment, dense graphs, independent sets, and the independence number. States the EHSS result for δ > 1/8, the main conjecture, and the connection to Turán theory.",
+    "proofStrategy": "The formalization uses Mathlib's SimpleGraph type with K₂,₂,₂ containment defined by enumerating all 12 cross-edges between three vertex pairs. Edge density, independent sets, and the independence number are defined as standard predicates. The EHSS result (δ > 1/8), the full conjecture (all δ > 0), and the Turán bound ex(n; K₂,₂,₂) = (1/8+o(1))n² are axiomatized. The Filter.atTop mechanism elegantly handles 'sufficiently large n' quantification.",
     "keyInsights": [
-      "K₂,₂,₂ is the octahedron graph — the Turán density is 1/8",
-      "For δ > 1/8, the EHSS proof uses the structure of dense K₂,₂,₂-free graphs",
-      "Below the Turán threshold, K₂,₂,₂-free graphs can have many edges and the conjecture becomes harder",
-      "The linear independence number is a strong structural conclusion from a density assumption"
+      "**Turán threshold 1/8**: K₂,₂,₂-free graphs have at most (1/8+o(1))n² edges; above this density, the EHSS proof exploits structural constraints from exceeding the extremal bound",
+      "**Sub-Turán mystery**: For δ ≤ 1/8, the graph is within the Turán limit, and the EHSS argument breaks down—new techniques are needed to establish linear independence numbers",
+      "**Octahedron geometry**: K₂,₂,₂ is the octahedron (6 vertices, 12 edges, 3-regular), a highly symmetric graph whose absence restricts local edge density in a specific pattern",
+      "**Parallel to Problem 533**: Both problems ask whether forbidden subgraph + positive density forces structured subsets of linear size, with K₅ (Problem 533) and K₂,₂,₂ (Problem 579) as the forbidden graphs",
+      "**Filter.atTop formalization**: Using Mathlib's Filter.atTop for 'sufficiently large n' avoids explicit bounds and keeps the statement clean"
     ]
   },
   "sections": [
     {
-      "id": "k222-free",
-      "title": "K₂,₂,₂-Free Graphs",
-      "startLine": 20,
-      "endLine": 41,
-      "summary": "Defines K₂,₂,₂ containment and K₂,₂,₂-free graphs."
+      "id": "imports",
+      "title": "Mathlib SimpleGraph Imports",
+      "startLine": 17,
+      "endLine": 21,
+      "summary": "Imports SimpleGraph, Clique, Finset, and tactics from Mathlib."
     },
     {
-      "id": "dense-indep",
-      "title": "Dense Graphs and Independent Sets",
-      "startLine": 45,
-      "endLine": 59,
-      "summary": "Defines edge density, independent sets, and the independence number."
+      "id": "k222-containment",
+      "title": "K₂,₂,₂ Definition and Freeness",
+      "startLine": 23,
+      "endLine": 42,
+      "summary": "Defines K₂,₂,₂ containment via 6 distinct vertices with 12 cross-edges, and the K₂,₂,₂-free predicate."
     },
     {
-      "id": "ehss",
-      "title": "EHSS Result",
-      "startLine": 63,
-      "endLine": 71,
-      "summary": "States the result for δ > 1/8 by Erdős–Hajnal–Sós–Szemerédi."
+      "id": "density-independence",
+      "title": "Density and Independence",
+      "startLine": 44,
+      "endLine": 57,
+      "summary": "Defines isDense (edge count ≥ δn²), IsIndepSet (pairwise non-adjacent), and independenceNumber (maximum |S|)."
     },
     {
-      "id": "conjecture",
-      "title": "The Main Conjecture and Turán Connection",
-      "startLine": 75,
+      "id": "ehss-result",
+      "title": "EHSS Result for δ > 1/8",
+      "startLine": 59,
+      "endLine": 69,
+      "summary": "Records the 1983 result: K₂,₂,₂-free graphs above Turán density have linear independence number."
+    },
+    {
+      "id": "main-conjecture",
+      "title": "The Full Conjecture",
+      "startLine": 71,
+      "endLine": 82,
+      "summary": "States Problem 579: for all δ > 0, K₂,₂,₂-free dense graphs have α(G) ≥ cn."
+    },
+    {
+      "id": "turan-connection",
+      "title": "Turán Number of K₂,₂,₂",
+      "startLine": 84,
       "endLine": 95,
-      "summary": "States the conjecture for all δ > 0 and the Turán number of K₂,₂,₂."
+      "summary": "Records ex(n; K₂,₂,₂) = (1/8+o(1))n², explaining the EHSS threshold."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 579 asks whether K₂,₂,₂-free dense graphs always have linear independence numbers. The EHSS result handles densities above the Turán threshold 1/8, but the general case remains open.",
-    "implications": "Resolution would connect forbidden subgraph theory with Ramsey-type independence guarantees, advancing extremal graph theory.",
+    "summary": "Erdős Problem 579 asks whether K₂,₂,₂-free dense graphs always have linear-size independent sets. The EHSS result handles densities above the Turán threshold 1/8, but extending to all positive densities requires fundamentally new methods that work in the sub-Turán regime.",
+    "implications": "Resolution would advance Ramsey-Turán theory by clarifying how forbidden tripartite subgraphs force independence structure. It connects to the broader program of Erdős-Hajnal type conjectures about structured subgraphs in forbidden-subgraph families.",
     "openQuestions": [
-      "Does the conjecture hold for all δ > 0?",
-      "What is the optimal constant c(δ) in the linear bound?",
-      "Are there analogous results for K_{t,t,t}-free graphs for t ≥ 3?"
+      "Does the conjecture hold for all δ > 0, especially δ ≤ 1/8?",
+      "What is the optimal dependence of c(δ) on δ as δ → 0?",
+      "Are there analogous results for K_{t,t,t}-free graphs for t ≥ 3?",
+      "Does the Szemerédi regularity lemma yield any results below the Turán threshold?",
+      "Is there a connection to the Erdős-Hajnal conjecture for K₂,₂,₂-free graphs?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Deepen annotations (5→9) with mathContext covering octahedron geometry, Turán density 1/8, super-Turán vs sub-Turán regimes, and Filter.atTop formalization
- Enrich meta.json with historicalContext (EHSS 1983, Ramsey-Turán theory), bold keyInsights, and parallel to Problem #533
- Build verified clean (`pnpm annotations:build` passes)

## Test plan
- [x] `pnpm annotations:build` passes with no erdos-579 warnings
- [ ] Visual review of gallery entry rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)