### PR TITLE
Enhance erdos-846: non-trilinear subsets annotations

### DIFF
--- a/src/data/proofs/erdos-846/annotations.json
+++ b/src/data/proofs/erdos-846/annotations.json
@@ -1,74 +1,152 @@
 [
   {
-    "id": "collinear-def",
+    "id": "ann-e846-imports",
     "proofId": "erdos-846",
-    "type": "definition",
-    "title": "Collinearity",
-    "content": "Three points p, q, r in ℝ² are collinear if the cross product (q-p)×(r-p) = 0, i.e. (q₀-p₀)(r₁-p₁) = (r₀-p₀)(q₁-p₁).",
+    "type": "import",
+    "title": "Euclidean Geometry Imports",
+    "content": "Imports InnerProductSpace for ℝ², Finset for combinatorics, and tactics.",
+    "mathContext": "The formalization represents points in $\\mathbb{R}^2$ as `Fin 2 → ℝ` (the coordinate representation) rather than `EuclideanSpace ℝ (Fin 2)`, avoiding the metric space infrastructure in favor of direct coordinate access for the collinearity cross-product formula. The `Finset` imports support the finite subset quantification in the $\\varepsilon$-non-trilinear property.",
     "significance": "supporting",
+    "relatedConcepts": ["Fin 2 → ℝ", "coordinate representation", "Finset"],
+    "prerequisites": ["Mathlib.Analysis.InnerProductSpace.Basic", "Mathlib.Data.Finset.Basic"],
     "range": {
-      "startLine": 23,
-      "endLine": 25
+      "startLine": 15,
+      "endLine": 20
     }
   },
   {
-    "id": "non-trilinear",
+    "id": "ann-e846-areCollinear",
     "proofId": "erdos-846",
     "type": "definition",
-    "title": "Non-Trilinear Set",
-    "content": "A set is non-trilinear if no three distinct points are collinear. This is the 'general position' condition for points in the plane.",
-    "significance": "critical",
+    "title": "Collinearity via Cross Product",
+    "content": "Three points p, q, r are collinear iff (q₀-p₀)(r₁-p₁) = (r₀-p₀)(q₁-p₁), the vanishing of the 2D cross product.",
+    "mathContext": "The **collinearity test** uses the $2 \\times 2$ determinant: points $p, q, r$ are collinear iff $\\det \\begin{pmatrix} q_0 - p_0 & r_0 - p_0 \\\\ q_1 - p_1 & r_1 - p_1 \\end{pmatrix} = 0$. This is equivalent to the cross product $(q-p) \\times (r-p) = 0$, which says the vectors $q-p$ and $r-p$ are parallel. The algebraic formulation avoids the need for affine geometry infrastructure and is directly computable in Lean's `ℝ` arithmetic.",
+    "significance": "key",
+    "relatedConcepts": ["cross product", "determinant", "affine dependence"],
+    "prerequisites": ["Fin 2 → ℝ"],
     "range": {
-      "startLine": 28,
-      "endLine": 30
+      "startLine": 26,
+      "endLine": 27
     }
   },
   {
-    "id": "eps-non-trilinear",
+    "id": "ann-e846-nonTrilinear",
     "proofId": "erdos-846",
     "type": "definition",
-    "title": "ε-Non-Trilinear Property",
-    "content": "A set A is ε-non-trilinear if every finite subset B ⊆ A of size n contains a non-collinear subset of size at least εn. This is a density condition.",
+    "title": "Non-Trilinear Set (General Position)",
+    "content": "A set is non-trilinear if no three distinct points are collinear. This is the 'points in general position' condition.",
+    "mathContext": "A set $S \\subseteq \\mathbb{R}^2$ is **non-trilinear** (or 'in general position') if no three distinct points are collinear. Equivalently, no line contains three or more points of $S$. The Sylvester-Gallai theorem states that any finite set of points not all collinear determines a line through exactly two points, showing that non-trilinearity is a strong structural constraint. The formalization quantifies over all triples with the three distinctness conditions $p \\neq q$, $q \\neq r$, $p \\neq r$.",
     "significance": "critical",
+    "relatedConcepts": ["general position", "Sylvester-Gallai theorem", "collinearity"],
+    "prerequisites": ["AreCollinear"],
     "range": {
-      "startLine": 36,
-      "endLine": 39
+      "startLine": 30,
+      "endLine": 32
     }
   },
   {
-    "id": "weakly-non-trilinear",
+    "id": "ann-e846-epsNonTrilinear",
     "proofId": "erdos-846",
     "type": "definition",
-    "title": "Weakly Non-Trilinear",
-    "content": "A set is weakly non-trilinear if it is a finite union of non-trilinear sets. This is a structural decomposition condition.",
+    "title": "ε-Non-Trilinear Property (Density Condition)",
+    "content": "Every finite B ⊆ A contains a non-collinear subset C with |C| ≥ ε|B|. A density version of general position.",
+    "mathContext": "The **$\\varepsilon$-non-trilinear property** is a density condition: a constant fraction $\\varepsilon$ of any finite subset can be found in general position. This is a Ramsey-theoretic condition—it says that even in the worst case, a positive density of points avoids collinear triples. The formalization uses Finset coercions to move between `Finset` and `Set` worlds, with the non-trilinearity of $C$ checked as a `Set` predicate via `(↑C : Set (Fin 2 → ℝ))`.",
     "significance": "critical",
+    "relatedConcepts": ["density Ramsey theory", "general position subsets", "ε-density"],
+    "prerequisites": ["NonTrilinear", "Finset"],
     "range": {
-      "startLine": 43,
-      "endLine": 46
+      "startLine": 38,
+      "endLine": 41
     }
   },
   {
-    "id": "easy-direction",
+    "id": "ann-e846-weaklyNonTrilinear",
+    "proofId": "erdos-846",
+    "type": "definition",
+    "title": "Weakly Non-Trilinear (Structural Decomposition)",
+    "content": "A is a finite union of non-trilinear sets: A ⊆ ⋃ᵢ Sᵢ with each Sᵢ non-trilinear.",
+    "mathContext": "The **weakly non-trilinear** condition is a structural decomposition: $A = S_1 \\cup \\ldots \\cup S_k$ where each $S_i$ is in general position. This is analogous to Ramsey-type partition results: the chromatic number of the collinearity hypergraph is finite. The formalization uses `Fin n → Set (Fin 2 → ℝ)` for the partition and `⋃ i, S i` for the union. The key question (Problem 846) is whether the density condition ($\\varepsilon$-non-trilinear) implies this structural condition.",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey partition", "chromatic number of hypergraphs", "structural decomposition"],
+    "prerequisites": ["NonTrilinear", "Set.iUnion"],
+    "range": {
+      "startLine": 45,
+      "endLine": 48
+    }
+  },
+  {
+    "id": "ann-e846-basicProperties",
     "proofId": "erdos-846",
     "type": "theorem",
-    "title": "Easy Direction",
-    "content": "A finite union of k non-trilinear sets is ε-non-trilinear with ε = 1/k, by the pigeonhole principle: in any n-element subset, one of the k parts contains ≥ n/k points.",
-    "significance": "key",
+    "title": "Basic Properties of Non-Trilinear Sets (Fully Proved)",
+    "content": "Four proved lemmas: monotonicity (subsets preserve non-trilinearity), empty set, singleton, and collinearity symmetry.",
+    "mathContext": "Four **fully proved** structural lemmas: (1) `nonTrilinear_mono`: non-trilinearity is hereditary—subsets of non-trilinear sets are non-trilinear; (2) `nonTrilinear_empty`: $\\emptyset$ is non-trilinear (vacuously); (3) `nonTrilinear_singleton`: any singleton $\\{p\\}$ is non-trilinear (no three distinct points exist); (4) `areCollinear_symm12`: collinearity is symmetric in the first two arguments, proved by `linarith`. These form the foundation for the pigeonhole argument.",
+    "significance": "supporting",
+    "relatedConcepts": ["hereditary property", "vacuous truth", "symmetry of collinearity"],
+    "prerequisites": ["NonTrilinear", "AreCollinear"],
     "range": {
-      "startLine": 56,
-      "endLine": 68
+      "startLine": 53,
+      "endLine": 73
     }
   },
   {
-    "id": "main-conjecture",
+    "id": "ann-e846-epsOneAndMono",
     "proofId": "erdos-846",
-    "type": "concept",
-    "title": "Erdős–Nešetřil–Rödl Conjecture",
-    "content": "Every infinite ε-non-trilinear set in ℝ² is weakly non-trilinear: density of points in general position implies a finite structural decomposition. Open since [Er92b].",
-    "significance": "critical",
+    "type": "theorem",
+    "title": "ε-Non-Trilinear: Trivial Case and Monotonicity (Fully Proved)",
+    "content": "Non-trilinear sets are ε-non-trilinear with ε=1 (take C=B). If ε' ≤ ε, then ε-non-trilinear implies ε'-non-trilinear.",
+    "mathContext": "Two **fully proved** results about the $\\varepsilon$-non-trilinear property: (1) `nonTrilinear_is_eps_one`: any non-trilinear set $A$ is $1$-non-trilinear (take $C = B$, since $B \\subseteq A$ is non-trilinear by monotonicity); (2) `isEpsNonTrilinear_mono`: if $A$ is $\\varepsilon$-non-trilinear and $\\varepsilon' \\leq \\varepsilon$, then $A$ is $\\varepsilon'$-non-trilinear (the same $C$ works since $\\varepsilon' |B| \\leq \\varepsilon |B| \\leq |C|$). The monotonicity proof uses `mul_le_mul_of_nonneg_right`.",
+    "significance": "key",
+    "relatedConcepts": ["monotonicity in ε", "trivial bound", "parameter weakening"],
+    "prerequisites": ["IsEpsNonTrilinear", "NonTrilinear", "nonTrilinear_mono"],
     "range": {
-      "startLine": 72,
-      "endLine": 78
+      "startLine": 80,
+      "endLine": 97
+    }
+  },
+  {
+    "id": "ann-e846-pigeonhole",
+    "proofId": "erdos-846",
+    "type": "theorem",
+    "title": "Finitary Pigeonhole Principle (Fully Proved)",
+    "content": "For any function f : B → Fin k, some fiber has |fiber| ≥ |B|/k. Proved by contradiction using Finset.sum and Finset.card_biUnion.",
+    "mathContext": "The **finitary pigeonhole principle** is a substantial standalone Lean proof (~20 lines). The proof proceeds by contradiction: if every fiber has $< |B|/k$ elements, then $\\sum_i k \\cdot |\\text{fiber}_i| < k \\cdot |B|$. But $\\sum_i |\\text{fiber}_i| = |B|$ (by `Finset.card_biUnion`, since fibers partition $B$), giving $k \\cdot |B| < k \\cdot |B|$, contradiction via `omega`. The disjointness of fibers requires showing that if $f(x) = i$ and $f(x) = j$ with $i \\neq j$, we get a contradiction via `Fin.ext`. This lemma is used in the main theorem to find a large partition class.",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "Finset.card_biUnion", "fiber decomposition"],
+    "prerequisites": ["Finset", "Fin", "Finset.card_biUnion"],
+    "range": {
+      "startLine": 104,
+      "endLine": 121
+    }
+  },
+  {
+    "id": "ann-e846-easyDirection",
+    "proofId": "erdos-846",
+    "type": "theorem",
+    "title": "Easy Direction: Weakly Non-Trilinear → ε-Non-Trilinear (Fully Proved)",
+    "content": "If A = S₁ ∪ ... ∪ Sₖ with each Sᵢ non-trilinear, then A is (1/k)-non-trilinear. The main proved result of the file.",
+    "mathContext": "This is the **main proved theorem** of the file (~45 lines). The proof: given $A \\subseteq \\bigcup_{i=1}^k S_i$ with each $S_i$ non-trilinear, and a finite $B \\subseteq A$, assign each $x \\in B$ to some $S_i$ containing it (using `choice` for the assignment function). By the pigeonhole lemma, some fiber $C = \\{x \\in B : \\text{assign}(x) = i\\}$ has $|C| \\geq |B|/k$. Since $C \\subseteq S_i$ and $S_i$ is non-trilinear, $C$ is also non-trilinear by monotonicity. Thus $\\varepsilon = 1/k$ works. The proof handles the edge case $k = 0$ separately (where $A \\subseteq \\emptyset$, so all finite subsets are empty). The `classical` tactic is needed for the non-constructive choice of assignment function.",
+    "significance": "critical",
+    "relatedConcepts": ["pigeonhole principle", "partition argument", "choice function"],
+    "prerequisites": ["IsWeaklyNonTrilinear", "IsEpsNonTrilinear", "finset_pigeonhole_exists", "nonTrilinear_mono"],
+    "range": {
+      "startLine": 131,
+      "endLine": 177
+    }
+  },
+  {
+    "id": "ann-e846-conjecture",
+    "proofId": "erdos-846",
+    "type": "theorem",
+    "title": "Erdős Problem 846: The Hard Direction (OPEN)",
+    "content": "Every infinite ε-non-trilinear set in ℝ² is weakly non-trilinear. This is the open problem, marked with sorry.",
+    "mathContext": "The **hard direction** of the Erdős-Nešetřil-Rödl conjecture: if $A$ is infinite and $\\varepsilon$-non-trilinear for some $\\varepsilon > 0$, then $A$ is a finite union of non-trilinear sets. This is formalized as a `theorem` with `sorry`, making the open status explicit. The difficulty is that the density condition provides *existence* of a large non-collinear subset in every finite piece, but does not directly yield a *global decomposition* into finitely many non-collinear parts. The contrapositive formulation is also provided, derived from the main conjecture by pure logic (`intro` + `exact`).",
+    "significance": "critical",
+    "relatedConcepts": ["density-to-structure", "Ramsey-type decomposition", "open problem"],
+    "prerequisites": ["IsEpsNonTrilinear", "IsWeaklyNonTrilinear", "Set.Infinite"],
+    "range": {
+      "startLine": 187,
+      "endLine": 199
     }
   }
 ]

--- a/src/data/proofs/erdos-846/meta.json
+++ b/src/data/proofs/erdos-846/meta.json
@@ -10,9 +10,12 @@
     "proofRepoPath": "Proofs/Erdos846Problem.lean",
     "tags": [
       "erdos",
-      "combinatorial geometry",
+      "combinatorial-geometry",
       "collinearity",
-      "Ramsey theory"
+      "ramsey-theory",
+      "general-position",
+      "pigeonhole-principle",
+      "density-to-structure"
     ],
     "badge": "formalized",
     "sorries": 1,
@@ -21,53 +24,97 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "This problem was posed by Erdős, Nešetřil, and Rödl in [Er92b]. It asks whether the density characterization of non-collinearity (every large subset contains proportionally many points in general position) implies a structural characterization (finite union of non-collinear sets). This is analogous to Ramsey-theoretic partition problems.",
-    "problemStatement": "Let A ⊂ ℝ² be infinite with some ε > 0 such that every finite B ⊆ A has a non-collinear subset of size ≥ ε|B|. Is A a finite union of sets with no three points collinear?",
-    "proofStrategy": "Full rewrite from formal-conjectures. Defines collinearity via the cross product criterion, non-trilinear sets, the ε-non-trilinear property, and weakly non-trilinear sets. States both directions of the basic implication and the main conjecture with its contrapositive.",
+    "historicalContext": "**Erdős, Nešetřil, and Rödl** posed this problem in [Er92b], asking whether a density condition on non-collinearity implies a structural decomposition. The question belongs to the broader programme of **density-to-structure implications** in combinatorics: when does a quantitative property (every large piece has a proportional substructure) force a qualitative partition (the whole set splits into finitely many well-structured pieces)? Analogous questions appear throughout Ramsey theory—for instance, Szemerédi's regularity lemma converts density conditions on graphs into structural partitions. In the geometric setting, **Sylvester–Gallai** (1893/1944) showed that any finite set of points not all collinear determines a line through exactly two points, constraining the collinearity hypergraph. The Hales–Jewett density theorem and the density Hales–Jewett theorem provide further parallels. Problem 846 is closely related to Erdős Problems 774 and 847, which concern similar density-vs-structure questions for collinearity in the plane. The problem remains **open** as of 2026.",
+    "problemStatement": "Let A ⊂ ℝ² be an infinite set such that for some ε > 0, every finite subset B ⊆ A contains a non-collinear subset of size ≥ ε|B|. Must A be a finite union of sets, each with no three points collinear?",
+    "proofStrategy": "The formalization represents points as `Fin 2 → ℝ` and defines collinearity via the vanishing of the 2D cross product (equivalently, the 2×2 determinant). It builds up from basic structural lemmas (monotonicity, empty set, singleton, symmetry) through a fully proved finitary pigeonhole principle to the complete proof of the **easy direction**: every weakly non-trilinear set is ε-non-trilinear with ε = 1/k. The hard direction (the actual conjecture) is stated with `sorry`.",
     "keyInsights": [
-      "ε-non-trilinear is a density condition: large subsets contain proportionally many points in general position",
-      "Weakly non-trilinear is a structural condition: the set decomposes into finitely many non-collinear parts",
-      "The easy direction (structure → density) follows from the pigeonhole principle with ε = 1/k",
-      "The hard direction (density → structure) is the open problem"
+      "**Collinearity via cross product**: three points $p, q, r \\in \\mathbb{R}^2$ are collinear iff $(q_0 - p_0)(r_1 - p_1) = (r_0 - p_0)(q_1 - p_1)$, the vanishing of the 2D cross product, avoiding affine geometry infrastructure",
+      "**Density vs structure paradigm**: the $\\varepsilon$-non-trilinear condition is a density guarantee (a constant fraction of any finite piece is in general position), while weak non-trilinearity is a structural partition into finitely many non-collinear parts",
+      "**Full pigeonhole proof**: the formalization includes a standalone ~20-line proof of the finitary pigeonhole principle via contradiction, using `Finset.card_biUnion` for fiber decomposition and `omega` for the final inequality",
+      "**Easy direction fully proved**: a ~45-line proof that $A \\subseteq \\bigcup_{i=1}^k S_i$ with each $S_i$ non-collinear implies $A$ is $(1/k)$-non-trilinear, using `classical` choice for the assignment function and pigeonhole for fiber selection",
+      "**The hard direction is the open problem**: going from density ($\\varepsilon$-non-trilinear) to structure (finite union of non-collinear sets) requires fundamentally different techniques—the density condition provides local existence but not a global decomposition"
     ]
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 15,
+      "endLine": 20,
+      "summary": "Imports InnerProductSpace for ℝ², Finset for combinatorics, and standard tactics."
+    },
+    {
       "id": "collinearity",
-      "title": "Collinearity and Non-Trilinear Sets",
-      "startLine": 18,
-      "endLine": 30,
-      "summary": "Defines collinearity via the cross product and non-trilinear sets."
+      "title": "Collinearity via Cross Product",
+      "startLine": 22,
+      "endLine": 27,
+      "summary": "Defines AreCollinear using the vanishing of the 2D cross product determinant."
+    },
+    {
+      "id": "non-trilinear",
+      "title": "Non-Trilinear Sets",
+      "startLine": 29,
+      "endLine": 32,
+      "summary": "Defines NonTrilinear: no three distinct points in the set are collinear (general position)."
     },
     {
       "id": "eps-property",
-      "title": "The ε-Non-Trilinear Property",
+      "title": "ε-Non-Trilinear Property",
       "startLine": 34,
+      "endLine": 41,
+      "summary": "Defines the density condition: every finite subset B has a non-collinear subset C with |C| ≥ ε|B|."
+    },
+    {
+      "id": "weakly-non-trilinear",
+      "title": "Weakly Non-Trilinear Sets",
+      "startLine": 43,
       "endLine": 48,
-      "summary": "Defines the density and structural characterizations of non-collinearity."
+      "summary": "Defines the structural condition: A is a finite union of non-trilinear sets."
     },
     {
-      "id": "observations",
-      "title": "Basic Observations",
-      "startLine": 52,
-      "endLine": 68,
-      "summary": "States the easy implication: weakly non-trilinear implies ε-non-trilinear."
+      "id": "basic-properties",
+      "title": "Basic Properties (Fully Proved)",
+      "startLine": 50,
+      "endLine": 73,
+      "summary": "Four proved lemmas: monotonicity, empty set, singleton non-trilinearity, and collinearity symmetry."
     },
     {
-      "id": "main-problem",
-      "title": "The Erdős–Nešetřil–Rödl Problem",
-      "startLine": 72,
-      "endLine": 86,
-      "summary": "States the main conjecture and its contrapositive formulation."
+      "id": "eps-results",
+      "title": "ε-Non-Trilinear Results (Fully Proved)",
+      "startLine": 75,
+      "endLine": 97,
+      "summary": "Proves non-trilinear sets are 1-non-trilinear and that ε-non-trilinearity is monotone in ε."
+    },
+    {
+      "id": "pigeonhole",
+      "title": "Finitary Pigeonhole Principle (Fully Proved)",
+      "startLine": 99,
+      "endLine": 121,
+      "summary": "A standalone proof that some fiber of f : B → Fin k has |fiber| ≥ |B|/k, by contradiction."
+    },
+    {
+      "id": "easy-direction",
+      "title": "Easy Direction: Structure → Density (Fully Proved)",
+      "startLine": 123,
+      "endLine": 177,
+      "summary": "The main proved theorem: if A ⊆ ⋃ᵢ Sᵢ with each Sᵢ non-trilinear, then A is (1/k)-non-trilinear."
+    },
+    {
+      "id": "conjecture",
+      "title": "The Erdős–Nešetřil–Rödl Conjecture (OPEN)",
+      "startLine": 179,
+      "endLine": 200,
+      "summary": "States the open problem (density → structure) and its logically equivalent contrapositive."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 846 asks whether a density condition for non-collinearity (every large subset has proportionally many points in general position) implies a structural decomposition (finite union of non-collinear sets). Open since 1992.",
-    "implications": "Resolution would connect density and structural descriptions of geometric configurations, with implications for discrete geometry and Ramsey theory.",
+    "summary": "This formalization achieves a complete proof of the easy direction of Erdős Problem 846 (weakly non-trilinear → ε-non-trilinear with ε = 1/k), including a standalone finitary pigeonhole principle. The hard direction—whether every infinite ε-non-trilinear set is a finite union of non-collinear sets—remains open since 1992.",
+    "implications": "Resolution would establish a fundamental connection between density and structural descriptions of geometric configurations. The density-to-structure paradigm appears throughout combinatorics (Szemerédi regularity, Ramsey theory), and a positive answer would add a geometric instance to this pattern.",
     "openQuestions": [
-      "Does the conjecture hold even for sets on algebraic curves?",
+      "Does the conjecture hold even for sets lying on algebraic curves?",
       "What is the minimum number of non-collinear sets needed in the decomposition as a function of ε?",
-      "Does an analogous result hold in higher dimensions (no four coplanar)?"
+      "Does an analogous result hold in higher dimensions (no d+1 points on a hyperplane)?",
+      "Can the contrapositive be leveraged: if A is not weakly non-trilinear, can one construct finite subsets with few points in general position?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enriched `annotations.json`: 6→10 annotations with detailed `mathContext` covering cross product collinearity, Sylvester-Gallai, density Ramsey theory, fiber decomposition pigeonhole proof, and partition argument with choice function
- Enriched `meta.json`: deeper historicalContext (density-to-structure programme, Szemerédi regularity analogy), 5 bold keyInsights, 10 sections (up from 4), 7 tags

## Test plan
- [x] JSON files parse correctly
- [x] `pnpm annotations:build` passes (no erdos-846-specific errors)
- [x] Annotation types match Lean constructs at referenced lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)