### PR TITLE
Enhance erdos-854: coprime residue gap annotations

### DIFF
--- a/src/data/proofs/erdos-854/annotations.json
+++ b/src/data/proofs/erdos-854/annotations.json
@@ -1,86 +1,167 @@
 [
   {
-    "id": "primorial-def",
+    "id": "ann-e854-imports",
+    "proofId": "erdos-854",
+    "type": "import",
+    "title": "Number Theory Imports",
+    "content": "Imports Nat.Basic, Nat.Prime.Basic, Finset.Basic, Finset.Card, and tactics.",
+    "mathContext": "The formalization uses `Nat.Prime` for primality, `Nat.Coprime` for the coprimality condition, and `Finset` for the finite set of coprime residues and gap values. The `Finset.range` and `Finset.filter` combinators construct the coprime residue set computationally.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.Prime", "Nat.Coprime", "Finset.filter"],
+    "prerequisites": ["Mathlib.Data.Nat.Prime.Basic", "Mathlib.Data.Finset.Basic"],
+    "range": {
+      "startLine": 17,
+      "endLine": 21
+    }
+  },
+  {
+    "id": "ann-e854-nthPrime",
+    "proofId": "erdos-854",
+    "type": "axiom",
+    "title": "Prime Enumeration Axioms",
+    "content": "Axiomatizes the k-th prime function with primality, strict monotonicity, and initial values (2, 3, 5).",
+    "mathContext": "The **prime enumeration** $p_k$ is axiomatized rather than defined computationally, avoiding the need for a computable prime sieve in Lean. The strict monotonicity axiom `nthPrime_mono : StrictMono nthPrime` encodes the fundamental fact that primes are an infinite increasing sequence. The initial values $p_1 = 2, p_2 = 3, p_3 = 5$ are recorded for concrete computations. In Lean, `Nat.Prime (nthPrime k)` requires $k \\geq 1$ since `nthPrime 0` is left unspecified.",
+    "significance": "supporting",
+    "relatedConcepts": ["prime enumeration", "StrictMono", "Nat.Prime"],
+    "prerequisites": ["Mathlib.Data.Nat.Prime.Basic"],
+    "range": {
+      "startLine": 26,
+      "endLine": 29
+    }
+  },
+  {
+    "id": "ann-e854-primorial",
     "proofId": "erdos-854",
     "type": "definition",
     "title": "Primorial Function",
-    "content": "The k-th primorial is the product of the first k primes: nₖ = p₁ · p₂ · ⋯ · pₖ.",
+    "content": "The k-th primorial is the product of the first k primes: nₖ = p₁ · p₂ · ⋯ · pₖ, defined recursively.",
+    "mathContext": "The **primorial** $n_k = \\prod_{i=1}^k p_i$ is defined by recursion: $n_0 = 1$ and $n_{k+1} = n_k \\cdot p_{k+1}$. The first few values are $n_1 = 2$, $n_2 = 6$, $n_3 = 30$, $n_4 = 210$, $n_5 = 2310$, $n_6 = 30030$. Primorials grow faster than exponentials but slower than factorials. The coprime residues modulo $n_k$ are precisely those integers not divisible by any of the first $k$ primes—the numbers that survive sieving by the first $k$ primes. The function is marked `noncomputable` since `nthPrime` is axiomatized.",
     "significance": "critical",
+    "relatedConcepts": ["primorial", "product of primes", "Eratosthenes sieve"],
+    "prerequisites": ["nthPrime"],
     "range": {
-      "startLine": 33,
-      "endLine": 36
+      "startLine": 32,
+      "endLine": 34
     }
   },
   {
-    "id": "coprime-residues",
+    "id": "ann-e854-coprimeResidues",
     "proofId": "erdos-854",
     "type": "definition",
     "title": "Coprime Residues",
-    "content": "The coprime residues of n are the positive integers less than n that share no common factor with n.",
+    "content": "The positive integers less than n that are coprime to n, as a Finset.",
+    "mathContext": "The **coprime residues** of $n$ are $\\{a : 1 \\leq a < n, \\gcd(a, n) = 1\\}$. For $n = n_k$ (the $k$-th primorial), these are the integers not divisible by any prime $\\leq p_k$, and their count is $\\varphi(n_k) = n_k \\prod_{i=1}^k (1 - 1/p_i)$ by Euler's totient function. The definition uses `Finset.range n |>.filter (fun a => 0 < a ∧ Nat.Coprime a n)`, which is computable. The sorted sequence $1 = a_1 < a_2 < \\cdots < a_{\\varphi(n_k)} = n_k - 1$ of coprime residues is axiomatized separately via `sortedCoprimes`.",
     "significance": "critical",
+    "relatedConcepts": ["Euler totient", "coprimality", "sieve of Eratosthenes"],
+    "prerequisites": ["Nat.Coprime", "Finset.filter"],
     "range": {
-      "startLine": 38,
-      "endLine": 39
+      "startLine": 37,
+      "endLine": 38
     }
   },
   {
-    "id": "gaps-even",
+    "id": "ann-e854-sortedCoprimes",
     "proofId": "erdos-854",
-    "type": "theorem",
-    "title": "Gaps Are Even",
-    "content": "For k ≥ 2, every gap between consecutive coprime residues of the k-th primorial is even, since all coprime residues are odd.",
+    "type": "axiom",
+    "title": "Sorted Coprime Sequence",
+    "content": "Axiomatizes the sorted list of coprime residues with sortedness and membership equivalence.",
+    "mathContext": "The sorted enumeration $a_1 < a_2 < \\cdots < a_{\\varphi(n)}$ is axiomatized as a `List ℕ` with `List.Sorted (· < ·)` and membership equivalence with `coprimeResidues`. This separation between the `Finset` (for cardinality/membership) and the `List` (for ordering/consecutive gaps) reflects the fact that gap structure depends on the linear order, which `Finset` does not directly expose.",
+    "significance": "supporting",
+    "relatedConcepts": ["List.Sorted", "ordered enumeration", "Finset-to-List"],
+    "prerequisites": ["coprimeResidues", "List.Sorted"],
+    "range": {
+      "startLine": 41,
+      "endLine": 44
+    }
+  },
+  {
+    "id": "ann-e854-gapSet",
+    "proofId": "erdos-854",
+    "type": "axiom",
+    "title": "Gap Set and Evenness",
+    "content": "The set of consecutive gaps aᵢ₊₁ − aᵢ between coprime residues, with the axiom that all gaps are even for k ≥ 2.",
+    "mathContext": "The **gap set** $\\{a_{i+1} - a_i : 1 \\leq i < \\varphi(n)\\}$ is the multiset (treated as a `Finset` of distinct values) of consecutive differences. For $k \\geq 2$, the primorial $n_k$ is divisible by 2, so all coprime residues are odd, making all gaps even. This is axiomatized as `gaps_even : 2 ∣ d` for $d \\in \\text{gapSet}(n_k)$. The gap set is a fundamental object: its size (number of distinct gap values) and its maximum are the two quantities Erdős asked about.",
     "significance": "key",
+    "relatedConcepts": ["consecutive differences", "parity", "gap distribution"],
+    "prerequisites": ["coprimeResidues", "primorial"],
     "range": {
-      "startLine": 52,
-      "endLine": 54
+      "startLine": 49,
+      "endLine": 53
     }
   },
   {
-    "id": "jacobsthal-bound",
+    "id": "ann-e854-maxGap",
     "proofId": "erdos-854",
-    "type": "theorem",
-    "title": "Jacobsthal Function Bound",
-    "content": "The maximal gap between consecutive coprime residues of the k-th primorial is at most 2pₖ, where pₖ is the k-th prime.",
+    "type": "axiom",
+    "title": "Maximal Gap and Jacobsthal Bound",
+    "content": "The largest consecutive gap, axiomatized with membership in gapSet and maximality. Bounded by 2pₖ via the Jacobsthal function.",
+    "mathContext": "The **maximal gap** $g(n_k) = \\max_i (a_{i+1} - a_i)$ is the largest gap between consecutive coprime residues. The **Jacobsthal function** $j(n)$ is the largest gap between consecutive integers coprime to $n$, and the bound $g(n_k) \\leq 2p_k$ follows from sieve-theoretic arguments. More precisely, $j(n_k) \\sim c \\cdot p_k$ where the constant $c$ is related to Iwaniec's result $j(n) \\ll (\\log n)^2$. For small primorials: $g(6) = 4$, $g(30) = 6$, $g(210) = 10$, $g(2310) = 14$.",
     "significance": "key",
+    "relatedConcepts": ["Jacobsthal function", "maximal gap", "sieve bounds"],
+    "prerequisites": ["gapSet", "nthPrime"],
     "range": {
-      "startLine": 70,
-      "endLine": 72
+      "startLine": 56,
+      "endLine": 69
     }
   },
   {
-    "id": "lacampagne-selfridge",
+    "id": "ann-e854-firstMissingGap",
     "proofId": "erdos-854",
-    "type": "insight",
-    "title": "Lacampagne–Selfridge Counterexample",
-    "content": "Computations for the primorial 30030 = 2·3·5·7·11·13 showed that not all even integers up to the maximal gap appear as consecutive differences.",
+    "type": "axiom",
+    "title": "First Missing Gap",
+    "content": "The smallest even integer not appearing as a consecutive gap. Axiomatized with evenness and non-membership.",
+    "mathContext": "The **first missing gap** $f(n_k)$ is the smallest even positive integer not in the gap set. Erdős originally conjectured that all even integers up to $g(n_k)$ appear as gaps, which would mean $f(n_k) > g(n_k)$. The Lacampagne–Selfridge computation showed $f(30030) \\leq g(30030)$, disproving this. The remaining question (Part 1) asks for the growth rate of $f(n_k)$ as $k \\to \\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["missing gaps", "gap completeness", "growth rate"],
+    "prerequisites": ["gapSet", "primorial"],
+    "range": {
+      "startLine": 72,
+      "endLine": 76
+    }
+  },
+  {
+    "id": "ann-e854-lacampagne-selfridge",
+    "proofId": "erdos-854",
+    "type": "axiom",
+    "title": "Lacampagne-Selfridge Counterexample",
+    "content": "For the primorial 30030 = 2·3·5·7·11·13, not all even integers up to the maximal gap appear as consecutive differences.",
+    "mathContext": "**Lacampagne and Selfridge** computed the gap set of $n_6 = 30030$ and found even integers below $g(30030)$ that do not appear as gaps. This disproved Erdős's original strong conjecture that the gap set contains all even integers up to the maximum. The primorial $30030 = 2 \\cdot 3 \\cdot 5 \\cdot 7 \\cdot 11 \\cdot 13$ has $\\varphi(30030) = 5760$ coprime residues, making the computation feasible. The axiom existentially asserts $\\exists d, 2 \\mid d \\wedge d < g(30030) \\wedge d \\notin \\text{gapSet}(30030)$.",
     "significance": "critical",
+    "relatedConcepts": ["computational number theory", "counterexample", "Erdős conjecture disproved"],
+    "prerequisites": ["gapSet", "maxGap", "primorial"],
     "range": {
-      "startLine": 82,
-      "endLine": 84
+      "startLine": 80,
+      "endLine": 81
     }
   },
   {
-    "id": "missing-gap-growth",
+    "id": "ann-e854-conjecturePart1",
     "proofId": "erdos-854",
-    "type": "concept",
-    "title": "Missing Gap Growth",
-    "content": "Erdős asked to estimate how the smallest missing even gap grows with the primorial index k.",
-    "significance": "key",
-    "range": {
-      "startLine": 90,
-      "endLine": 92
-    }
-  },
-  {
-    "id": "proportional-gaps",
-    "proofId": "erdos-854",
-    "type": "concept",
-    "title": "Proportional Distinct Gaps",
-    "content": "The weaker conjecture asks whether the number of distinct gap values is at least a constant fraction of the maximal gap.",
+    "type": "axiom",
+    "title": "Erdős Conjecture Part 1: Missing Gap Growth",
+    "content": "The smallest even integer not representable as a gap grows without bound as the primorial index increases.",
+    "mathContext": "**Part 1** of Problem 854 asks to estimate the growth of $f(n_k)$. The axiom states $\\forall C, \\exists k, C \\leq f(n_k)$, i.e., $f(n_k) \\to \\infty$. This is a qualitative statement; the quantitative question (how fast $f$ grows relative to $g(n_k)$ or $p_k$) remains open. If $f(n_k) \\gg g(n_k)$, then almost all even integers up to the max gap eventually appear—a weakening of the disproved original conjecture.",
     "significance": "critical",
+    "relatedConcepts": ["unbounded growth", "gap completeness", "asymptotic analysis"],
+    "prerequisites": ["firstMissingGap", "primorial"],
     "range": {
-      "startLine": 95,
-      "endLine": 99
+      "startLine": 87,
+      "endLine": 88
+    }
+  },
+  {
+    "id": "ann-e854-conjecturePart2",
+    "proofId": "erdos-854",
+    "type": "axiom",
+    "title": "Erdős Conjecture Part 2: Proportionally Many Gaps",
+    "content": "The number of distinct even gap values is at least a constant fraction of the maximal gap.",
+    "mathContext": "**Part 2** of Problem 854 asks whether $|\\text{gapSet}(n_k)| \\gg g(n_k)$, i.e., whether the number of distinct gap values is proportional to the maximum gap. The axiom states $\\exists c > 0, \\forall k \\geq 2, c \\cdot g(n_k) \\leq |\\text{gapSet}(n_k)|$. Since every gap is even and lies in $\\{2, 4, \\ldots, g(n_k)\\}$, the maximum possible number of distinct gaps is $g(n_k)/2$. The conjecture asserts that the actual count is a constant fraction of this maximum—the gap set is **dense** among even integers up to the maximum gap.",
+    "significance": "critical",
+    "relatedConcepts": ["gap density", "proportional representation", "distinct-gap-counting"],
+    "prerequisites": ["distinctGapCount", "maxGap", "primorial"],
+    "range": {
+      "startLine": 92,
+      "endLine": 95
     }
   }
 ]

--- a/src/data/proofs/erdos-854/meta.json
+++ b/src/data/proofs/erdos-854/meta.json
@@ -10,10 +10,12 @@
     "proofRepoPath": "Proofs/Erdos854Problem.lean",
     "tags": [
       "erdos",
-      "number theory",
-      "prime gaps",
+      "number-theory",
+      "prime-gaps",
       "primorials",
-      "sieve theory"
+      "sieve-theory",
+      "jacobsthal-function",
+      "coprime-residues"
     ],
     "badge": "formalized",
     "sorries": 0,
@@ -22,53 +24,97 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős posed this problem about the gap structure of coprime residues modulo primorials. He initially conjectured that all even integers up to the maximal gap would appear as consecutive differences, but computations by Lacampagne and Selfridge for the primorial 30030 cast doubt on this conjecture.",
-    "problemStatement": "Let nₖ be the k-th primorial and 1 = a₁ < a₂ < ⋯ < a_{φ(nₖ)} = nₖ−1 be the coprime residues. Estimate the smallest even integer not of the form aᵢ₊₁ − aᵢ, and determine if the number of distinct gap values is ≫ max(aᵢ₊₁ − aᵢ).",
-    "proofStrategy": "We axiomatize the primorial function, coprime residue sequences, and the gap structure. Known bounds on maximal gaps via the Jacobsthal function are recorded, along with the Lacampagne–Selfridge counterexample to the original strong conjecture.",
+    "historicalContext": "**Erdős** posed this problem about the gap structure of coprime residues modulo primorials. The sequence $1 = a_1 < a_2 < \\cdots < a_{\\varphi(n_k)} = n_k - 1$ of integers coprime to the $k$-th primorial $n_k = p_1 \\cdots p_k$ exhibits a rich gap structure. Erdős initially conjectured that **all even integers** up to the maximal gap appear as consecutive differences, but computational work by **Lacampagne and Selfridge** for $n_6 = 30030$ disproved this strong form. The problem connects to the **Jacobsthal function** $j(n)$, the maximum gap between consecutive integers coprime to $n$, studied by Jacobsthal (1960), Iwaniec (1978), and Pintz (1997). Iwaniec proved $j(n) \\ll (\\log n)^2$, giving the sharpest known upper bound. The two remaining open questions—growth rate of the smallest missing gap and proportionality of distinct gap counts—connect coprimality patterns to distribution of primes in arithmetic progressions.",
+    "problemStatement": "Let nₖ be the k-th primorial and 1 = a₁ < a₂ < ⋯ < a_{φ(nₖ)} = nₖ−1 be the coprime residues. (1) Estimate the smallest even integer not of the form aᵢ₊₁ − aᵢ. (2) Is the number of distinct gap values ≫ max(aᵢ₊₁ − aᵢ)?",
+    "proofStrategy": "The formalization axiomatizes the prime enumeration, primorial function, coprime residue sequences, and the gap structure. The coprime residue set `coprimeResidues` is defined computationally using `Finset.filter`, while the sorted enumeration and gap set are axiomatized. Known bounds (Jacobsthal function, gap evenness) and the Lacampagne-Selfridge counterexample are recorded as axioms, and both parts of the conjecture are stated.",
     "keyInsights": [
-      "For k ≥ 2, all gaps between coprime residues of the k-th primorial are even (since all coprime residues are odd)",
-      "The maximal gap is bounded by 2pₖ via the Jacobsthal function",
-      "Lacampagne and Selfridge showed not all even integers up to the max gap appear for nₖ = 30030",
-      "The weaker conjecture asks only for proportionally many distinct gaps"
+      "**All gaps are even for k ≥ 2**: since the primorial $n_k$ is divisible by 2, all coprime residues are odd, so all consecutive differences are even",
+      "**Jacobsthal function bound**: the maximal gap satisfies $g(n_k) \\leq 2p_k$, connecting to the deep sieve-theoretic bounds of Iwaniec ($j(n) \\ll (\\log n)^2$)",
+      "**Lacampagne-Selfridge disproof**: computational verification for $n_6 = 30030$ (with $\\varphi(30030) = 5760$ coprime residues) showed that not all even integers up to $g(30030)$ appear as gaps, disproving Erdős's original strong conjecture",
+      "**Two-part open problem**: Part 1 asks for the growth rate of the smallest missing gap; Part 2 asks whether the number of distinct gap values is proportional to the maximal gap",
+      "**Computable vs axiomatized**: the coprime residue set is defined computationally via `Finset.filter`, while the sorted enumeration and gap set are axiomatized to separate the combinatorial structure from computational concerns"
     ]
   },
   "sections": [
     {
-      "id": "primorial-setup",
-      "title": "Primorial and Coprime Residues",
-      "startLine": 18,
-      "endLine": 46,
-      "summary": "Defines primorials, coprime residue sets, and their sorted enumeration."
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 17,
+      "endLine": 22,
+      "summary": "Imports Nat.Basic, Nat.Prime.Basic, Finset.Basic, Finset.Card, and tactics."
+    },
+    {
+      "id": "prime-enumeration",
+      "title": "Prime Enumeration Axioms",
+      "startLine": 25,
+      "endLine": 29,
+      "summary": "Axiomatizes the k-th prime with primality, strict monotonicity, and initial values."
+    },
+    {
+      "id": "primorial",
+      "title": "Primorial Function",
+      "startLine": 31,
+      "endLine": 34,
+      "summary": "Defines the k-th primorial recursively as the product of the first k primes."
+    },
+    {
+      "id": "coprime-residues",
+      "title": "Coprime Residues",
+      "startLine": 36,
+      "endLine": 44,
+      "summary": "Defines the coprime residue set computationally and axiomatizes the sorted enumeration."
     },
     {
       "id": "gap-structure",
-      "title": "Gap Structure",
-      "startLine": 48,
-      "endLine": 66,
-      "summary": "Defines the gap set, maximal gap, and count of distinct gap values for coprime residues."
+      "title": "Gap Set and Evenness",
+      "startLine": 46,
+      "endLine": 63,
+      "summary": "Axiomatizes the gap set, gap evenness for k ≥ 2, maximal gap with membership and maximality."
     },
     {
       "id": "known-bounds",
-      "title": "Known Bounds",
-      "startLine": 68,
-      "endLine": 86,
-      "summary": "Records the Jacobsthal function bound on maximal gaps and the Lacampagne–Selfridge counterexample."
+      "title": "Jacobsthal Bound and Distinct Gap Count",
+      "startLine": 65,
+      "endLine": 69,
+      "summary": "Records the bound g(nₖ) ≤ 2pₖ and axiomatizes the distinct gap count."
     },
     {
-      "id": "conjectures",
-      "title": "The Erdős Conjectures",
-      "startLine": 88,
-      "endLine": 99,
-      "summary": "States the two main open questions: growth of the first missing gap and proportionality of distinct gap counts."
+      "id": "first-missing-gap",
+      "title": "First Missing Gap",
+      "startLine": 71,
+      "endLine": 76,
+      "summary": "Axiomatizes the smallest even integer absent from the gap set with evenness and non-membership."
+    },
+    {
+      "id": "counterexample",
+      "title": "Lacampagne-Selfridge Counterexample",
+      "startLine": 78,
+      "endLine": 81,
+      "summary": "Records the computational disproof of Erdős's strong conjecture for n₆ = 30030."
+    },
+    {
+      "id": "conjecture-part1",
+      "title": "Conjecture Part 1: Missing Gap Growth",
+      "startLine": 83,
+      "endLine": 88,
+      "summary": "States that the smallest missing gap grows without bound."
+    },
+    {
+      "id": "conjecture-part2",
+      "title": "Conjecture Part 2: Proportional Distinct Gaps",
+      "startLine": 90,
+      "endLine": 96,
+      "summary": "States that the number of distinct gap values is proportional to the maximal gap."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 854 explores the rich combinatorial structure of gaps between coprime residues of primorials. The original strong conjecture was disproved computationally, but the weaker proportionality conjecture remains open.",
-    "implications": "Understanding these gap patterns connects to Jacobsthal's function, sieve methods, and the distribution of primes in short intervals.",
+    "summary": "Erdős Problem 854 explores the rich combinatorial structure of gaps between coprime residues of primorials. The original strong conjecture (all even gaps up to the maximum) was disproved by Lacampagne and Selfridge for n₆ = 30030, but both the growth rate of the smallest missing gap and the proportionality of distinct gap counts remain open.",
+    "implications": "Understanding these gap patterns connects to the Jacobsthal function, sieve methods, and the distribution of primes in arithmetic progressions. Resolution would illuminate the fine structure of integers surviving sieving by small primes.",
     "openQuestions": [
       "How fast does the smallest missing gap grow with k?",
       "Is the number of distinct gap values truly proportional to the maximal gap?",
-      "What is the limiting distribution of gap sizes for large primorials?"
+      "What is the limiting distribution of gap sizes for large primorials?",
+      "Can the Lacampagne-Selfridge counterexample be extended to characterize which even integers are missing?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enriched `annotations.json`: 7→11 annotations with `mathContext` covering Jacobsthal function, Euler totient, Lacampagne-Selfridge computation, prime enumeration axiomatization, and both conjecture parts
- Fixed annotation types: `theorem`→`axiom` (gaps_even, Jacobsthal bound), `insight`→`axiom` (Lacampagne-Selfridge), `concept`→`axiom` (both conjectures)
- Enriched `meta.json`: deeper historicalContext (Jacobsthal 1960, Iwaniec 1978, Pintz 1997), 5 bold keyInsights, 10 sections (up from 4), 7 tags

## Test plan
- [x] JSON files parse correctly
- [x] `pnpm annotations:build` passes (no erdos-854-specific errors)
- [x] Annotation types match Lean constructs at referenced lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)