### PR TITLE
Enhance erdos-875: admissible sequences annotations

### DIFF
--- a/src/data/proofs/erdos-875/annotations.json
+++ b/src/data/proofs/erdos-875/annotations.json
@@ -1,74 +1,227 @@
 [
   {
-    "id": "erdos-875-ann-rFold",
+    "id": "ann-e875-imports",
     "proofId": "erdos-875",
-    "range": { "startLine": 33, "endLine": 34 },
+    "type": "import",
+    "title": "Combinatorics and Bitwise Imports",
+    "content": "Imports tactics, Finset.Basic, Finset.Powerset for subset enumeration, and Nat.Bitwise for popcount.",
+    "mathContext": "The formalization uses `Finset.powersetCard r` to enumerate all $r$-element subsets (for the $r$-fold sumset), `Finset.image` and `Finset.sum` for computing sumset elements, and `Nat.popcount` (from `Nat.Bitwise`) for the binary argument that powers of 2 are admissible. The `Filter.atTop` filter is used implicitly through `HasPolynomialGaps` and `HasRatioOne`.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.powersetCard", "Nat.popcount", "Filter.atTop"],
+    "prerequisites": ["Mathlib.Data.Finset.Powerset", "Mathlib.Data.Nat.Bitwise"],
+    "range": {
+      "startLine": 20,
+      "endLine": 25
+    }
+  },
+  {
+    "id": "ann-e875-rFoldSumset",
+    "proofId": "erdos-875",
     "type": "definition",
-    "title": "rFoldSumset",
-    "content": "The r-fold sumset of A: all sums of r distinct elements from A. Computed as the image of r-element subsets under summation.",
-    "significance": "critical"
+    "title": "r-Fold Sumset",
+    "content": "The r-fold sumset of A: all sums of r distinct elements. Computed as the image of r-element subsets under summation.",
+    "mathContext": "The **$r$-fold sumset** $S_r(A) = \\{a_{i_1} + \\cdots + a_{i_r} : i_1 < \\cdots < i_r, a_i \\in A\\}$ consists of all sums of $r$ distinct elements from $A$. The formalization computes this as `(A.powersetCard r).image (fun S => S.sum id)`, leveraging `powersetCard` to enumerate all $r$-element subsets and `sum id` to compute their element sums. This is computationally expensive (exponential in $r$) but provides a clean specification.",
+    "significance": "critical",
+    "relatedConcepts": ["sumset", "powerset", "subset sum"],
+    "prerequisites": ["Finset.powersetCard", "Finset.image"],
+    "range": {
+      "startLine": 30,
+      "endLine": 31
+    }
   },
   {
-    "id": "erdos-875-ann-disjoint",
+    "id": "ann-e875-strictlyIncreasing",
     "proofId": "erdos-875",
-    "range": { "startLine": 46, "endLine": 48 },
     "type": "definition",
-    "title": "DisjointSumsets",
-    "content": "The r-fold and s-fold sumsets of the first N terms are disjoint for all r ≠ s and all N. This is the key structural condition.",
-    "significance": "critical"
+    "title": "Strictly Increasing Sequence",
+    "content": "A sequence a : ℕ → ℕ with a(n) < a(n+1) for all n.",
+    "mathContext": "The **strictly increasing** condition $a(n) < a(n+1)$ is separate from Mathlib's `StrictMono` for clarity. It implies $a(n) \\geq a(0) + n$, so the sequence grows at least linearly. Combined with the disjoint sumsets condition, much faster growth is forced.",
+    "significance": "supporting",
+    "relatedConcepts": ["StrictMono", "monotone sequence", "growth rate"],
+    "prerequisites": [],
+    "range": {
+      "startLine": 34,
+      "endLine": 35
+    }
   },
   {
-    "id": "erdos-875-ann-admissible",
+    "id": "ann-e875-seqRSumset",
     "proofId": "erdos-875",
-    "range": { "startLine": 52, "endLine": 53 },
     "type": "definition",
-    "title": "IsAdmissible",
-    "content": "A sequence is admissible if it is strictly increasing and has pairwise disjoint r-fold sumsets.",
-    "significance": "critical"
+    "title": "Sequence r-Fold Sumset",
+    "content": "The r-fold sumset of the first N elements of a sequence: rFoldSumset applied to {a(0), ..., a(N-1)}.",
+    "mathContext": "For an infinite sequence $a$, the $r$-fold sumset is defined relative to the first $N$ terms: $S_r^{(N)}(a) = S_r(\\{a(0), \\ldots, a(N-1)\\})$. This finitization is necessary because `Finset` operations require finite sets. The disjointness condition then quantifies over all $N$, ensuring the property holds for every finite initial segment.",
+    "significance": "key",
+    "relatedConcepts": ["initial segment", "finitization", "sequence indexing"],
+    "prerequisites": ["rFoldSumset"],
+    "range": {
+      "startLine": 39,
+      "endLine": 40
+    }
   },
   {
-    "id": "erdos-875-ann-gap",
+    "id": "ann-e875-disjointSumsets",
     "proofId": "erdos-875",
-    "range": { "startLine": 62, "endLine": 65 },
+    "type": "definition",
+    "title": "Disjoint Sumsets Property",
+    "content": "For any N, the r-fold and s-fold sumsets (r ≠ s, both ≥ 1, both ≤ N) of the first N terms are disjoint.",
+    "mathContext": "The **disjoint sumsets** condition states that for all $N$ and all $1 \\leq r \\neq s \\leq N$, the $r$-fold and $s$-fold sumsets $S_r^{(N)}(a)$ and $S_s^{(N)}(a)$ are disjoint as `Finset`s. This is a strong condition: knowing that $a_{i_1} + \\cdots + a_{i_r} = a_{j_1} + \\cdots + a_{j_s}$ forces $r = s$. For the powers-of-2 sequence, this follows from binary representation (popcount determines $r$).",
+    "significance": "critical",
+    "relatedConcepts": ["Disjoint", "Finset.Disjoint", "subset sum uniqueness"],
+    "prerequisites": ["seqRSumset"],
+    "range": {
+      "startLine": 44,
+      "endLine": 46
+    }
+  },
+  {
+    "id": "ann-e875-isAdmissible",
+    "proofId": "erdos-875",
+    "type": "definition",
+    "title": "Admissible Sequence",
+    "content": "Strictly increasing with pairwise disjoint r-fold sumsets for all r ≥ 1.",
+    "mathContext": "An **admissible sequence** combines strict increase with the disjoint sumsets property. The term comes from Deshouillers and Erdős, who studied the finite version (Problem #874) and the infinite variant here. Admissibility is a strong structural condition: it forces rapid growth because slow growth would create sumset collisions. The simplest example is $a(n) = 2^n$.",
+    "significance": "critical",
+    "relatedConcepts": ["admissible set", "Deshouillers-Erdős", "sumset disjointness"],
+    "prerequisites": ["StrictlyIncreasing", "DisjointSumsets"],
+    "range": {
+      "startLine": 50,
+      "endLine": 51
+    }
+  },
+  {
+    "id": "ann-e875-hasPolynomialGaps",
+    "proofId": "erdos-875",
+    "type": "definition",
+    "title": "Polynomial Gaps Property",
+    "content": "a(n+1) − a(n) ≤ n^c for all sufficiently large n, using Filter.atTop.",
+    "mathContext": "The **polynomial gaps** condition $a(n+1) - a(n) \\leq n^c$ (eventually) asks whether the consecutive differences can be bounded by a polynomial in $n$. Since $a(n) \\leq a(0) + \\sum_{k=0}^{n-1} k^c \\sim n^{c+1}/(c+1)$, this bounds the overall growth rate. The critical exponent $c_0$ marks the transition: for $c < c_0$ no admissible sequence achieves polynomial gaps $n^c$, and for $c > c_0$ one does. The formalization uses `Filter.atTop` for the 'eventually' quantifier.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial growth", "Filter.atTop", "eventually"],
+    "prerequisites": ["Filter.atTop"],
+    "range": {
+      "startLine": 57,
+      "endLine": 59
+    }
+  },
+  {
+    "id": "ann-e875-gapThreshold",
+    "proofId": "erdos-875",
+    "type": "axiom",
+    "title": "Gap Threshold Conjecture (OPEN)",
+    "content": "There exists a critical exponent c₀ such that polynomial gaps n^c are achievable for c > c₀ but not for c < c₀.",
+    "mathContext": "The **gap threshold** axiom asserts the existence of a critical exponent $c_0 > 0$ with a sharp transition: no admissible sequence has gaps $\\leq n^c$ for $c < c_0$, but admissible sequences with gaps $\\leq n^c$ exist for $c > c_0$. This is the central quantitative question of Problem 875. The axiom's form—existential over $c_0$ with both impossibility below and existence above—encodes a sharp phase transition in the space of admissible sequences.",
+    "significance": "critical",
+    "relatedConcepts": ["phase transition", "critical exponent", "gap growth"],
+    "prerequisites": ["IsAdmissible", "HasPolynomialGaps"],
+    "range": {
+      "startLine": 64,
+      "endLine": 67
+    }
+  },
+  {
+    "id": "ann-e875-hasRatioOne",
+    "proofId": "erdos-875",
+    "type": "definition",
+    "title": "Ratio-One Property",
+    "content": "a(n+1)/a(n) → 1 as n → ∞, meaning the sequence grows subexponentially.",
+    "mathContext": "The **ratio-one** property $a(n+1)/a(n) \\to 1$ means the sequence grows subexponentially: for any $\\varepsilon > 0$, eventually $a(n+1) < (1+\\varepsilon) \\cdot a(n)$. This is formalized using `Filter.Tendsto ... Filter.atTop (nhds 1)`. Powers of 2 have ratio 2 (not ratio 1), so the question asks whether a much more slowly growing admissible sequence exists. Erdős noted this is 'not completely trivial.'",
+    "significance": "key",
+    "relatedConcepts": ["subexponential growth", "Filter.Tendsto", "nhds"],
+    "prerequisites": ["Filter.Tendsto", "Filter.atTop"],
+    "range": {
+      "startLine": 71,
+      "endLine": 72
+    }
+  },
+  {
+    "id": "ann-e875-ratioOneAxiom",
+    "proofId": "erdos-875",
+    "type": "axiom",
+    "title": "Ratio-One Existence (Erdős Claim)",
+    "content": "There exists an admissible sequence with a(n+1)/a(n) → 1.",
+    "mathContext": "Erdős claimed that an admissible sequence with $a(n+1)/a(n) \\to 1$ exists, describing this as 'not completely trivial.' This is axiomatized rather than proved. A construction might use highly lacunary sequences that are 'almost' geometric with ratio tending to 1, carefully avoiding sumset collisions. The axiom is $\\exists a, \\text{IsAdmissible}(a) \\wedge \\text{HasRatioOne}(a)$.",
+    "significance": "key",
+    "relatedConcepts": ["existence claim", "constructive vs non-constructive", "Erdős quotation"],
+    "prerequisites": ["IsAdmissible", "HasRatioOne"],
+    "range": {
+      "startLine": 74,
+      "endLine": 75
+    }
+  },
+  {
+    "id": "ann-e875-pow2Increasing",
+    "proofId": "erdos-875",
     "type": "theorem",
-    "title": "Gap Threshold",
-    "content": "There exists a critical exponent c₀ such that polynomial gaps n^c are achievable for c > c₀ but not for c < c₀. The value of c₀ is unknown.",
-    "significance": "critical"
+    "title": "Powers of 2 Strictly Increasing (Fully Proved)",
+    "content": "2^n < 2^(n+1) for all n, proved by Nat.pow_lt_pow_right.",
+    "mathContext": "The **fully proved** lemma that $2^n < 2^{n+1}$ establishes `StrictlyIncreasing (fun n => 2^n)`. The proof uses `Nat.pow_lt_pow_right` with base $\\geq 2$ and exponent increase. This is the first half of showing powers of 2 are admissible.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.pow_lt_pow_right", "exponential growth"],
+    "prerequisites": [],
+    "range": {
+      "startLine": 80,
+      "endLine": 82
+    }
   },
   {
-    "id": "erdos-875-ann-ratio",
+    "id": "ann-e875-popcountAxiom",
     "proofId": "erdos-875",
-    "range": { "startLine": 73, "endLine": 74 },
+    "type": "axiom",
+    "title": "Popcount of Sum of Distinct Powers of 2",
+    "content": "The popcount (number of 1-bits) of a sum of distinct powers of 2 equals the number of terms.",
+    "mathContext": "The **popcount lemma** states that if $S$ is a set of distinct natural numbers, then $\\text{popcount}(\\sum_{i \\in S} 2^i) = |S|$. This is because distinct powers of 2 have disjoint binary representations, so their sum has exactly $|S|$ bits set. This is the key technical fact for proving powers of 2 are admissible: if $\\sum_{i \\in S} 2^i = \\sum_{j \\in T} 2^j$, then $|S| = |T|$ by popcount, establishing sumset disjointness across different $r$-values.",
+    "significance": "key",
+    "relatedConcepts": ["popcount", "binary representation", "disjoint bit patterns"],
+    "prerequisites": ["Nat.popcount"],
+    "range": {
+      "startLine": 90,
+      "endLine": 91
+    }
+  },
+  {
+    "id": "ann-e875-pow2Admissible",
+    "proofId": "erdos-875",
     "type": "theorem",
-    "title": "Ratio One Existence",
-    "content": "There exists an admissible sequence with a(n+1)/a(n) → 1. Erdős described this as 'not completely trivial.'",
-    "significance": "key"
+    "title": "Powers of 2 Admissible (Partially Proved)",
+    "content": "a(n) = 2^n is admissible. Strict increase is proved; disjoint sumsets part uses sorry (relies on popcount argument).",
+    "mathContext": "The theorem that $a(n) = 2^n$ is admissible is **partially proved**: the `StrictlyIncreasing` half is established via `pow2_strictly_increasing`, but the `DisjointSumsets` half is left as `sorry`. The full proof would use the popcount axiom: if a sum $\\sum 2^{i_j}$ with $r$ terms equals a sum $\\sum 2^{i'_j}$ with $s$ terms, then popcount gives $r = s$, so sumsets of different sizes are disjoint.",
+    "significance": "key",
+    "relatedConcepts": ["admissible example", "binary encoding", "partial proof"],
+    "prerequisites": ["pow2_strictly_increasing", "popcount_sum_distinct_pow2"],
+    "range": {
+      "startLine": 99,
+      "endLine": 103
+    }
   },
   {
-    "id": "erdos-875-ann-powers",
+    "id": "ann-e875-growthLower",
     "proofId": "erdos-875",
-    "range": { "startLine": 80, "endLine": 81 },
-    "type": "insight",
-    "title": "Powers of 2 Example",
-    "content": "a(n) = 2^n is admissible: binary representations uniquely encode which elements are summed, ensuring disjoint sumsets.",
-    "significance": "key"
-  },
-  {
-    "id": "erdos-875-ann-reciprocal",
-    "proofId": "erdos-875",
-    "range": { "startLine": 86, "endLine": 87 },
     "type": "theorem",
-    "title": "Reciprocal Sum Converges",
-    "content": "For any admissible sequence, ∑ 1/a(n) converges. This implies the sequence must grow at least as fast as any polynomial.",
-    "significance": "key"
+    "title": "Growth Lower Bound a(n) ≥ n+1 (Fully Proved)",
+    "content": "Every admissible sequence with a(0) ≥ 1 satisfies a(n) ≥ n+1, proved by induction using strict increase.",
+    "mathContext": "A **fully proved** growth lower bound: if $a(0) \\geq 1$ and $a$ is admissible (hence strictly increasing), then $a(n) \\geq n+1$ for all $n$. The proof is by induction: base case $a(0) \\geq 1$, and if $a(n) \\geq n+1$ then $a(n+1) > a(n) \\geq n+1$ so $a(n+1) \\geq n+2$. The `omega` tactic handles the final inequality. This is a crude bound; the disjoint sumsets condition forces much faster growth.",
+    "significance": "supporting",
+    "relatedConcepts": ["induction", "omega tactic", "linear lower bound"],
+    "prerequisites": ["IsAdmissible", "StrictlyIncreasing"],
+    "range": {
+      "startLine": 109,
+      "endLine": 115
+    }
   },
   {
-    "id": "erdos-875-ann-growth",
+    "id": "ann-e875-finiteConnection",
     "proofId": "erdos-875",
-    "range": { "startLine": 92, "endLine": 93 },
-    "type": "concept",
-    "title": "Growth Lower Bound",
-    "content": "Admissible sequences satisfy a(n) ≥ n + 1, a minimal lower bound from the strictly increasing and disjointness conditions.",
-    "significance": "supporting"
+    "type": "axiom",
+    "title": "Connection to Problem #874 (Finite Version)",
+    "content": "For any n, there is a maximum size f(n) for a subset of {1,...,n} with pairwise disjoint r-fold sumsets.",
+    "mathContext": "Problem #874 (Deshouillers-Erdős) is the **finite version**: what is the maximum size of $A \\subseteq \\{1, \\ldots, n\\}$ with pairwise disjoint $r$-fold sumsets? The axiom asserts this maximum $f(n)$ exists. The infinite Problem 875 asks about the growth rate of infinite admissible sequences, which corresponds to understanding how $f(n)$ grows. If $f(n) \\sim n^\\alpha$, then admissible sequences can grow like $n^{1/\\alpha}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["finite version", "Problem 874", "extremal combinatorics"],
+    "prerequisites": ["rFoldSumset", "Disjoint"],
+    "range": {
+      "startLine": 130,
+      "endLine": 135
+    }
   }
 ]

--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-875",
-  "title": "Admissible Sequences with Disjoint Sumsets",
+  "title": "Erdős Problem #875: Admissible Sequences with Disjoint Sumsets",
   "slug": "erdos-875",
   "description": "Let A = {a₁ < a₂ < ...} with r-fold sumsets Sᵣ pairwise disjoint for all r. How fast must A grow? For which c is a_{n+1} − aₙ ≤ n^c possible? Can a_{n+1}/aₙ → 1? Erdős noted the ratio-1 case is 'not completely trivial.'",
   "meta": {
@@ -10,10 +10,12 @@
     "proofRepoPath": "Proofs/Erdos875Problem.lean",
     "tags": [
       "erdos",
-      "additive combinatorics",
+      "additive-combinatorics",
       "sumsets",
-      "growth rates",
-      "sequences"
+      "growth-rates",
+      "sequences",
+      "binary-representation",
+      "popcount"
     ],
     "badge": "formalized",
     "sorries": 2,
@@ -22,47 +24,97 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Deshouillers and Erdős posed this as an infinite variant of Problem #874. An admissible sequence has pairwise disjoint r-fold sumsets. Powers of 2 trivially satisfy this (binary encoding), but the question asks how slowly such sequences can grow.",
-    "problemStatement": "For an infinite admissible sequence A with pairwise disjoint r-fold sumsets, how fast must A grow? For which c can a_{n+1} − aₙ ≤ n^c?",
-    "proofStrategy": "We formalize the r-fold sumset, the admissibility condition, polynomial gap and ratio-one properties, and structural observations including the powers-of-2 example and reciprocal convergence.",
+    "historicalContext": "**Deshouillers and Erdős** posed this as an infinite variant of Problem #874. An **admissible sequence** $a_1 < a_2 < \\cdots$ has the property that the $r$-fold sumsets $S_r = \\{a_{i_1} + \\cdots + a_{i_r} : i_1 < \\cdots < i_r\\}$ are pairwise disjoint for distinct $r \\geq 1$. The simplest example is powers of 2 ($a_n = 2^n$), where binary representation ensures disjointness via popcount. The central question is **how slowly** an admissible sequence can grow. Erdős noted that the ratio-one property $a_{n+1}/a_n \\to 1$ (subexponential growth) is achievable but 'not completely trivial.' The problem connects to **Sidon sets** (where sumsets of different sizes are automatically separated by parity of the number of terms) and to the **subset sum problem** in computational complexity.",
+    "problemStatement": "For an infinite admissible sequence A with pairwise disjoint r-fold sumsets: (1) How fast must A grow? (2) For which c can a_{n+1} − aₙ ≤ n^c? (3) Can a_{n+1}/aₙ → 1?",
+    "proofStrategy": "The formalization defines the r-fold sumset via `Finset.powersetCard` and `Finset.image`, the admissibility condition combining strict increase with sumset disjointness, and the polynomial gap and ratio-one properties using `Filter.atTop`. It proves two results: `pow2_strictly_increasing` (powers of 2 are strictly increasing) and `admissible_growth_lower` (a(n) ≥ n+1 by induction). The powers-of-2 admissibility is partially proved (strict increase done, disjoint sumsets via sorry). The gap threshold and ratio-one existence are stated as axioms.",
     "keyInsights": [
-      "Powers of 2 form an admissible sequence (binary encoding of subsets)",
-      "Admissible sequences must grow fast enough that ∑ 1/aₙ converges",
-      "Erdős noted a_{n+1}/aₙ → 1 is possible but 'not completely trivial'",
-      "The critical exponent c for polynomial gaps is unknown",
-      "Infinite variant of Problem #874 (Deshouillers–Erdős)"
+      "**Powers of 2 are admissible**: binary encoding uniquely determines which elements are summed, and popcount (number of 1-bits) equals the number of terms, ensuring different $r$-fold sumsets are disjoint",
+      "**Critical exponent for polynomial gaps**: there exists a threshold $c_0$ such that admissible sequences with gaps $\\leq n^c$ exist for $c > c_0$ but not for $c < c_0$—the value of $c_0$ is unknown",
+      "**Ratio-one is achievable**: Erdős claimed an admissible sequence with $a_{n+1}/a_n \\to 1$ exists, meaning subexponential growth suffices for admissibility",
+      "**Proved growth lower bound**: by induction on strict increase, every admissible sequence satisfies $a(n) \\geq n+1$—a crude linear bound, with the disjoint sumsets condition forcing much faster growth",
+      "**Finite-infinite connection**: the finite Problem #874 asks for the maximum size of an admissible subset of $\\{1, \\ldots, n\\}$, whose growth rate determines the optimal growth of infinite admissible sequences"
     ]
   },
   "sections": [
     {
-      "id": "definitions",
-      "title": "Core Definitions",
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 20,
+      "endLine": 25,
+      "summary": "Imports tactics, Finset.Basic, Finset.Powerset, and Nat.Bitwise for popcount."
+    },
+    {
+      "id": "r-fold-sumset",
+      "title": "r-Fold Sumset Definition",
       "startLine": 27,
-      "endLine": 52,
-      "summary": "Defines r-fold sumsets, strictly increasing sequences, disjoint sumsets property, and admissible sequences."
+      "endLine": 31,
+      "summary": "Defines rFoldSumset as the image of r-element subsets under summation."
     },
     {
-      "id": "questions",
-      "title": "Main Questions",
-      "startLine": 54,
+      "id": "sequence-defs",
+      "title": "Sequence Properties",
+      "startLine": 33,
+      "endLine": 51,
+      "summary": "Defines StrictlyIncreasing, seqRSumset, DisjointSumsets, and IsAdmissible."
+    },
+    {
+      "id": "main-questions",
+      "title": "Main Questions (OPEN)",
+      "startLine": 53,
       "endLine": 75,
-      "summary": "Formalizes the polynomial gap threshold question and the ratio-one question."
+      "summary": "Defines HasPolynomialGaps, HasRatioOne, and states the gap threshold and ratio-one axioms."
     },
     {
-      "id": "structural",
-      "title": "Structural Observations",
+      "id": "pow2-increasing",
+      "title": "Powers of 2 Strictly Increasing (Fully Proved)",
       "startLine": 77,
-      "endLine": 96,
-      "summary": "Powers of 2 are admissible; reciprocal sum converges; crude growth lower bound."
+      "endLine": 82,
+      "summary": "Proves 2^n < 2^(n+1) using Nat.pow_lt_pow_right."
+    },
+    {
+      "id": "popcount",
+      "title": "Popcount Lemma (Axiomatized)",
+      "startLine": 84,
+      "endLine": 91,
+      "summary": "Axiomatizes that the popcount of a sum of distinct powers of 2 equals the number of terms."
+    },
+    {
+      "id": "pow2-admissible",
+      "title": "Powers of 2 Admissible (Partially Proved)",
+      "startLine": 93,
+      "endLine": 103,
+      "summary": "Strict increase proved; disjoint sumsets uses sorry (depends on popcount argument)."
+    },
+    {
+      "id": "growth-lower",
+      "title": "Growth Lower Bound (Fully Proved)",
+      "startLine": 105,
+      "endLine": 115,
+      "summary": "Proves a(n) ≥ n+1 for admissible sequences by induction."
+    },
+    {
+      "id": "small-examples",
+      "title": "Small Examples",
+      "startLine": 117,
+      "endLine": 123,
+      "summary": "The set {1, 2, 4} has disjoint 1-fold and 2-fold sumsets (sorry)."
+    },
+    {
+      "id": "finite-connection",
+      "title": "Connection to Problem #874",
+      "startLine": 125,
+      "endLine": 136,
+      "summary": "Axiomatizes the finite version: maximum admissible subset size of {1,...,n}."
     }
   ],
   "conclusion": {
-    "summary": "Formalizes Erdős Problem #875 on admissible sequences with disjoint r-fold sumsets, including growth rate questions, the polynomial gap threshold, and structural properties.",
-    "implications": "Understanding admissible sequences connects to Sidon set theory, additive bases, and the combinatorics of subset sums.",
+    "summary": "The formalization captures Erdős Problem #875 on admissible sequences with three proved results (powers of 2 strictly increasing, growth lower bound a(n) ≥ n+1, partial powers-of-2 admissibility). The gap threshold and ratio-one questions remain open, with the popcount argument for full powers-of-2 admissibility axiomatized.",
+    "implications": "Understanding admissible sequences connects to Sidon set theory, the subset sum problem, additive bases, and binary coding theory. The critical exponent c₀ would quantify how efficiently the disjoint sumsets condition constrains growth.",
     "openQuestions": [
-      "What is the critical exponent c for polynomial gaps?",
-      "Can an admissible sequence have a_{n+1}/aₙ → 1?",
-      "What is the optimal growth rate for admissible sequences?"
+      "What is the critical exponent c₀ for polynomial gaps in admissible sequences?",
+      "Can an admissible sequence have a_{n+1}/aₙ → 1 (Erdős's 'not completely trivial' claim)?",
+      "What is the optimal growth rate for admissible sequences?",
+      "How does the maximum admissible subset size of {1,...,n} grow with n?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enriched `annotations.json`: 8→15 annotations with `mathContext` covering r-fold sumsets via powersetCard, binary/popcount argument for powers-of-2, Filter.atTop for asymptotic conditions, phase transition in critical exponent, Deshouillers-Erdős connection to Problem #874
- Fixed annotation types: `theorem`→`axiom` (gap threshold, ratio-one axioms), `insight`→`theorem` (pow2 increasing), `concept`→`theorem` (growth lower bound); fixed misaligned line ranges
- Enriched `meta.json`: deeper historicalContext (Sidon sets, subset sum, binary coding), 5 bold keyInsights, 10 sections (up from 3), 7 tags

## Test plan
- [x] JSON files parse correctly
- [x] `pnpm annotations:build` passes (no erdos-875-specific errors)
- [x] Annotation types match Lean constructs at referenced lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)