### PR TITLE
Fix Aristotle pipeline: add preprocessing and feedback loop

### DIFF
--- a/scripts/aristotle/check-jobs.sh
+++ b/scripts/aristotle/check-jobs.sh
@@ -127,6 +127,50 @@ run_check() {
     uvx --from aristotlelib python3 -c "$PYTHON_CHECK" "$JOBS_FILE" 2>&1
 }
 
+# Categorize failure based on job outcome text and file content
+categorize_failure() {
+    local pid="$1"
+
+    # Get outcome text from jobs file
+    local outcome
+    outcome=$(jq -r --arg pid "$pid" '.jobs[] | select(.project_id == $pid) | .outcome // ""' "$JOBS_FILE" 2>/dev/null)
+    local file
+    file=$(jq -r --arg pid "$pid" '.jobs[] | select(.project_id == $pid) | .file // ""' "$JOBS_FILE" 2>/dev/null)
+
+    # Pattern match on outcome text
+    case "$outcome" in
+        *"parse"*|*"unexpected token"*|*"syntax"*)
+            echo "parse_error" ;;
+        *"failed to load"*|*"import"*|*"not found"*)
+            echo "load_error" ;;
+        *"def.*sorry"*|*"definition sorry"*)
+            echo "def_sorry" ;;
+        *"placeholder"*|*"True"*)
+            echo "placeholder" ;;
+        *"axiom"*|*"nothing to prove"*)
+            echo "axiom_only" ;;
+        *"OPEN"*|*"conjecture"*|*"open problem"*)
+            echo "open_problem" ;;
+        *"no improvement"*|*"0 theorems"*|*"no progress"*)
+            echo "no_improvement" ;;
+        *)
+            echo "unknown" ;;
+    esac
+}
+
+# Count how many times a file has been submitted
+count_file_submissions() {
+    local pid="$1"
+    local file
+    file=$(jq -r --arg pid "$pid" '.jobs[] | select(.project_id == $pid) | .file // ""' "$JOBS_FILE" 2>/dev/null)
+
+    if [[ -n "$file" ]]; then
+        jq --arg file "$file" '[.jobs[] | select(.file == $file)] | length' "$JOBS_FILE" 2>/dev/null
+    else
+        echo 1
+    fi
+}
+
 # Update jobs.json with new statuses
 update_jobs_file() {
     local results="$1"
@@ -143,13 +187,35 @@ update_jobs_file() {
             *) continue ;;  # Don't update in-progress jobs
         esac
 
-        # Update in jobs file
-        local tmp_file=$(mktemp)
-        jq --arg pid "$pid" --arg status "$new_status" '
-            .jobs |= map(if .project_id == $pid then .status = $status else . end)
-        ' "$JOBS_FILE" > "$tmp_file" && mv "$tmp_file" "$JOBS_FILE"
+        # For failed/expired jobs, categorize the failure and count submissions
+        local extra_fields=""
+        if [[ "$new_status" == "failed" || "$new_status" == "expired" ]]; then
+            local category
+            category=$(categorize_failure "$pid")
+            local sub_count
+            sub_count=$(count_file_submissions "$pid")
 
-        echo -e "  Updated $pid -> $new_status"
+            # Update with failure metadata
+            local tmp_file=$(mktemp)
+            jq --arg pid "$pid" --arg status "$new_status" \
+               --arg category "$category" --argjson count "$sub_count" '
+                .jobs |= map(if .project_id == $pid then
+                    .status = $status |
+                    .failure_category = $category |
+                    .submission_count = $count
+                else . end)
+            ' "$JOBS_FILE" > "$tmp_file" && mv "$tmp_file" "$JOBS_FILE"
+
+            echo -e "  Updated $pid -> $new_status (category: $category, submissions: $sub_count)"
+        else
+            # Update status only
+            local tmp_file=$(mktemp)
+            jq --arg pid "$pid" --arg status "$new_status" '
+                .jobs |= map(if .project_id == $pid then .status = $status else . end)
+            ' "$JOBS_FILE" > "$tmp_file" && mv "$tmp_file" "$JOBS_FILE"
+
+            echo -e "  Updated $pid -> $new_status"
+        fi
     done
 }
 

--- a/scripts/aristotle/find-candidates.sh
+++ b/scripts/aristotle/find-candidates.sh
@@ -10,8 +10,9 @@
 #
 # Candidates are files that:
 #   - Have theorem/lemma sorries (something to prove)
-#   - Have NOT been submitted to Aristotle yet
-#   - Preferably have no definition sorries (Aristotle skips these)
+#   - Have NOT been submitted to Aristotle yet (or were modified since last failure)
+#   - Have no definition sorries (hard reject - Aristotle skips these)
+#   - Are not all-True placeholder theorems (hard reject - no value)
 #
 
 set -euo pipefail
@@ -35,38 +36,93 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Get list of already-submitted files
+# Helper: count grep matches safely (grep -c exits 1 on 0 matches)
+count_matches() {
+    grep -cE "$1" "$2" 2>/dev/null || true
+}
+
+# Get list of already-submitted files (active or successful jobs)
 get_submitted_files() {
     if [[ -f "$JOBS_FILE" ]]; then
         # Only exclude files with active or successful jobs
-        # Expired and failed files are eligible for resubmission
+        # Expired and failed files are eligible for resubmission (handled by blocked check)
         jq -r '.jobs[] | select(.status == "submitted" or .status == "completed" or .status == "integrated") | .file' "$JOBS_FILE" 2>/dev/null | xargs -I{} basename {} .lean | sort -u
     fi
 }
 
-# Analyze a single file
+# Get files blocked from resubmission (2+ failures, not modified since last attempt)
+get_blocked_files() {
+    if [[ ! -f "$JOBS_FILE" ]]; then
+        return
+    fi
+
+    # Find files with 2+ failed/expired jobs where no theorems were proven
+    jq -r '
+        [.jobs[] | select(.status == "failed" or .status == "expired")]
+        | group_by(.file)
+        | map(select(length >= 2))
+        | map({
+            file: .[0].file,
+            count: length,
+            last_submitted: (map(.submitted) | sort | last)
+          })
+        | .[]
+        | "\(.file)|\(.last_submitted)"
+    ' "$JOBS_FILE" 2>/dev/null | while IFS='|' read -r file last_submitted; do
+        [[ -z "$file" ]] && continue
+
+        # Resolve to absolute path
+        local abs_file="$PROJECT_ROOT/$file"
+        [[ -f "$abs_file" ]] || continue
+
+        # Check if file was modified since last submission
+        local file_mtime
+        file_mtime=$(stat -f '%m' "$abs_file" 2>/dev/null || stat -c '%Y' "$abs_file" 2>/dev/null || echo 0)
+
+        local submit_epoch
+        submit_epoch=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$last_submitted" '+%s' 2>/dev/null || \
+                       date -d "$last_submitted" '+%s' 2>/dev/null || echo 0)
+
+        # If file hasn't been modified since last submission, block it
+        if [[ "$file_mtime" -le "$submit_epoch" ]]; then
+            basename "$abs_file" .lean
+        fi
+    done | sort -u
+}
+
+# Analyze a single file. Returns score -1 for hard rejects.
 analyze_file() {
     local file="$1"
     local basename=$(basename "$file" .lean)
 
-    # Count different types of sorries (tr -d to remove any whitespace/newlines)
-    local total_sorry=$(grep -c "sorry" "$file" 2>/dev/null | tr -d '[:space:]' || echo 0)
-    local def_sorry=$(grep -cE "^def.*:=.*sorry|^def.*sorry$" "$file" 2>/dev/null | tr -d '[:space:]' || echo 0)
-    local axiom_count=$(grep -c "^axiom " "$file" 2>/dev/null | tr -d '[:space:]' || echo 0)
+    # Count different types of sorries
+    local total_sorry=$(count_matches "sorry" "$file")
+    local def_sorry=$(count_matches "^(noncomputable )?def[[:space:]].*(:=.*sorry|sorry$)" "$file")
+    local axiom_count=$(count_matches "^axiom " "$file")
 
-    # Ensure we have numbers
-    [[ -z "$total_sorry" ]] && total_sorry=0
-    [[ -z "$def_sorry" ]] && def_sorry=0
-    [[ -z "$axiom_count" ]] && axiom_count=0
+    # Hard reject: files with definition sorries
+    if [[ "$def_sorry" -gt 0 ]]; then
+        echo "$basename|$total_sorry|$def_sorry|$axiom_count|0|-1"
+        return
+    fi
+
+    # Check for all-True placeholder theorems
+    local thm_sorry_count=$(count_matches "^(theorem|lemma)[[:space:]].*sorry" "$file")
+    local true_thm_count=$(count_matches "^(theorem|lemma)[[:space:]].*:[[:space:]]*True[[:space:]]*:=" "$file")
+
+    # Hard reject: all theorem sorries are True placeholders
+    if [[ "$thm_sorry_count" -gt 0 && "$thm_sorry_count" -eq "$true_thm_count" ]]; then
+        echo "$basename|$total_sorry|$def_sorry|$axiom_count|0|-1"
+        return
+    fi
 
     # Theorem sorries = total - definition sorries (approximate)
     local thm_sorry=$((total_sorry - def_sorry))
 
     # Score: lower is better
-    # - Files with def sorries are penalized heavily (Aristotle skips them)
-    # - Files with axioms need conversion (medium penalty)
+    # - Axioms get small penalty (auto-converted by preprocessing now, but still slightly harder)
     # - Fewer sorries = easier to prove
-    local score=$((thm_sorry + def_sorry * 100 + axiom_count * 10))
+    local score=$((thm_sorry + axiom_count * 2))
 
     echo "$basename|$total_sorry|$def_sorry|$axiom_count|$thm_sorry|$score"
 }
@@ -76,7 +132,9 @@ main() {
     local submitted_files
     submitted_files=$(get_submitted_files)
 
-    local candidates=()
+    local blocked_files
+    blocked_files=$(get_blocked_files)
+
     local candidate_data=()
 
     for file in "$PROOFS_DIR"/Erdos*Problem.lean; do
@@ -84,25 +142,50 @@ main() {
 
         local basename=$(basename "$file" .lean)
 
-        # Skip if already submitted
+        # Skip if already submitted (active/successful)
         if echo "$submitted_files" | grep -q "^${basename}$"; then
+            continue
+        fi
+
+        # Skip if blocked (repeatedly failed, not modified)
+        if echo "$blocked_files" | grep -q "^${basename}$"; then
             continue
         fi
 
         # Analyze file
         local analysis=$(analyze_file "$file")
         local total_sorry=$(echo "$analysis" | cut -d'|' -f2)
+        local score=$(echo "$analysis" | cut -d'|' -f6)
 
         # Skip files with no sorries (nothing to prove)
         if [[ "$total_sorry" -eq 0 ]]; then
             continue
         fi
 
+        # Skip hard rejects (score -1)
+        if [[ "$score" -eq -1 ]]; then
+            continue
+        fi
+
         candidate_data+=("$analysis")
     done
 
+    if [[ ${#candidate_data[@]} -eq 0 ]]; then
+        if [[ "$COUNT_ONLY" == true ]]; then
+            echo 0
+        elif [[ "$JSON_OUTPUT" == true ]]; then
+            echo "[]"
+        else
+            echo "=== Aristotle Candidates ==="
+            echo ""
+            echo "No candidates found"
+        fi
+        return
+    fi
+
     # Sort by score (lower is better)
-    local sorted_data=$(printf '%s\n' "${candidate_data[@]}" | sort -t'|' -k6 -n)
+    local sorted_data
+    sorted_data=$(printf '%s\n' "${candidate_data[@]}" | sort -t'|' -k6 -n)
 
     if [[ "$COUNT_ONLY" == true ]]; then
         echo "$sorted_data" | wc -l | tr -d ' '

--- a/scripts/aristotle/preprocess-for-aristotle.sh
+++ b/scripts/aristotle/preprocess-for-aristotle.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+#
+# preprocess-for-aristotle.sh - Preprocess a Lean file for Aristotle submission
+#
+# Takes a Lean file, creates a preprocessed temp copy with:
+#   - /-! docstrings converted to /- (Aristotle parser compat)
+#   - axiom declarations converted to theorem ... := by sorry
+#
+# Rejects (exit 1):
+#   - Files with definition sorries (unfixable, blocks dependent theorems)
+#   - Files where ALL sorries are placeholder "True" theorems (no value)
+#   - Files with zero sorries after preprocessing (nothing to prove)
+#
+# Output:
+#   Last line of stdout = path to preprocessed temp file
+#   Stderr = log of changes made
+#
+# Usage:
+#   ./preprocess-for-aristotle.sh path/to/file.lean
+#   preprocessed_file=$(./preprocess-for-aristotle.sh path/to/file.lean | tail -1)
+#
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <lean-file>" >&2
+    exit 1
+fi
+
+INPUT_FILE="$1"
+
+if [[ ! -f "$INPUT_FILE" ]]; then
+    echo "ERROR: File not found: $INPUT_FILE" >&2
+    exit 1
+fi
+
+# Helper: count grep matches safely (grep -c exits 1 on 0 matches)
+count_matches() {
+    grep -cE "$1" "$2" 2>/dev/null || true
+}
+
+# --- Pre-rejection checks (on original file) ---
+
+# Check for definition sorries
+def_sorry_count=$(count_matches "^(noncomputable )?def[[:space:]].*(:=.*sorry|sorry$)" "$INPUT_FILE")
+if [[ "$def_sorry_count" -gt 0 ]]; then
+    echo "REJECT: File has $def_sorry_count definition sorries (Aristotle cannot handle these)" >&2
+    grep -nE "^(noncomputable )?def[[:space:]].*(:=.*sorry|sorry$)" "$INPUT_FILE" >&2 || true
+    exit 1
+fi
+
+# Check if ALL theorem/lemma sorries are placeholder "True" theorems
+total_thm_sorry=$(count_matches "^(theorem|lemma)[[:space:]].*sorry" "$INPUT_FILE")
+true_thm_sorry=$(count_matches "^(theorem|lemma)[[:space:]].*:[[:space:]]*True[[:space:]]*:=" "$INPUT_FILE")
+
+if [[ "$total_thm_sorry" -gt 0 && "$total_thm_sorry" -eq "$true_thm_sorry" ]]; then
+    echo "REJECT: All $total_thm_sorry theorem sorries are placeholder 'True' theorems (no value)" >&2
+    exit 1
+fi
+
+# --- Create preprocessed copy ---
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/aristotle-preprocess-XXXXXX")
+tmp_file="$tmp_dir/$(basename "$INPUT_FILE")"
+cp "$INPUT_FILE" "$tmp_file"
+
+changes_made=0
+
+# Transform 1: Convert /-! docstrings to /- (Aristotle parser compat)
+docstring_count=$(count_matches '/-!' "$tmp_file")
+if [[ "$docstring_count" -gt 0 ]]; then
+    sed -i '' 's|/-!|/-|g' "$tmp_file"
+    echo "PREPROCESS: Converted $docstring_count /-! docstrings to /-" >&2
+    changes_made=$((changes_made + docstring_count))
+fi
+
+# Transform 2: Convert axiom declarations to theorem ... := by sorry
+# Handles multi-line axioms where the type signature spans multiple lines.
+# An axiom block starts with "^axiom " and continues on indented lines.
+axiom_count=$(count_matches "^axiom " "$tmp_file")
+if [[ "$axiom_count" -gt 0 ]]; then
+    awk '
+    BEGIN { in_axiom = 0; buf = "" }
+
+    /^axiom / {
+        # Flush any pending axiom
+        if (in_axiom && buf != "") {
+            print buf " := by sorry"
+            buf = ""
+        }
+        in_axiom = 1
+        sub(/^axiom /, "theorem ")
+        buf = $0
+        next
+    }
+
+    in_axiom && /^[[:space:]]+/ {
+        # Continuation of axiom (indented line)
+        buf = buf "\n" $0
+        next
+    }
+
+    in_axiom {
+        # End of axiom block (hit non-indented line)
+        if (buf != "") {
+            print buf " := by sorry"
+            buf = ""
+        }
+        in_axiom = 0
+        print $0
+        next
+    }
+
+    { print }
+
+    END {
+        # Flush final axiom if file ends with one
+        if (in_axiom && buf != "") {
+            print buf " := by sorry"
+        }
+    }
+    ' "$tmp_file" > "${tmp_file}.awk"
+
+    mv "${tmp_file}.awk" "$tmp_file"
+    echo "PREPROCESS: Converted $axiom_count axiom declarations to theorem sorries" >&2
+    changes_made=$((changes_made + axiom_count))
+fi
+
+# --- Post-preprocessing validation ---
+
+# Count sorries in preprocessed file
+post_sorry_count=$(count_matches "sorry" "$tmp_file")
+
+if [[ "$post_sorry_count" -eq 0 ]]; then
+    echo "REJECT: Zero sorries after preprocessing (nothing for Aristotle to prove)" >&2
+    rm -f "$tmp_file"
+    exit 1
+fi
+
+# Re-check: all True placeholders after preprocessing?
+post_thm_sorry=$(count_matches "^(theorem|lemma)[[:space:]].*sorry" "$tmp_file")
+post_true_sorry=$(count_matches "^(theorem|lemma)[[:space:]].*:[[:space:]]*True[[:space:]]*:=" "$tmp_file")
+
+if [[ "$post_thm_sorry" -gt 0 && "$post_thm_sorry" -eq "$post_true_sorry" ]]; then
+    echo "REJECT: After preprocessing, all $post_thm_sorry theorem sorries are placeholder 'True' theorems" >&2
+    rm -f "$tmp_file"
+    exit 1
+fi
+
+# --- Output ---
+
+if [[ "$changes_made" -eq 0 ]]; then
+    echo "PREPROCESS: No changes needed (file already compatible)" >&2
+fi
+
+echo "PREPROCESS: Result has $post_sorry_count sorries to attempt" >&2
+
+# Last line = path to preprocessed file (caller captures this)
+echo "$tmp_file"

--- a/scripts/aristotle/submit-batch.sh
+++ b/scripts/aristotle/submit-batch.sh
@@ -19,12 +19,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 JOBS_FILE="$PROJECT_ROOT/research/aristotle-jobs.json"
 FIND_CANDIDATES="$SCRIPT_DIR/find-candidates.sh"
+PREPROCESS="$SCRIPT_DIR/preprocess-for-aristotle.sh"
 
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
+CYAN='\033[0;36m'
 NC='\033[0m'
 
 # Defaults
@@ -151,21 +153,51 @@ check_server_capacity() {
 }
 
 # Submit a single file to Aristotle
-# Returns: 0=success, 1=error, 2=rate-limited (caller should stop submitting)
+# Returns: 0=success, 1=error, 2=rate-limited (caller should stop submitting), 3=rejected by preprocessing
 submit_file() {
     local file="$1"
     local problem_id=$(basename "$file" .lean | sed 's/Problem$//' | tr '[:upper:]' '[:lower:]' | sed 's/erdos/erdos-/')
 
     echo -e "${BLUE}Submitting:${NC} $file"
 
+    # Preprocess the file (convert axioms, fix docstrings, reject unsuitable files)
+    local preprocess_log=""
+    local submit_file="$file"
+    local preprocessed_tmp=""
+
+    if [[ -x "$PREPROCESS" ]]; then
+        local preprocess_output
+        preprocess_output=$("$PREPROCESS" "$file" 2>&1) || {
+            local reject_reason
+            reject_reason=$(echo "$preprocess_output" | grep "^REJECT:" | head -1)
+            echo -e "  ${YELLOW}Skipped (preprocessing):${NC} ${reject_reason:-rejected}"
+            return 3
+        }
+
+        # Last line = temp file path, preceding lines = log
+        preprocessed_tmp=$(echo "$preprocess_output" | tail -1)
+        preprocess_log=$(echo "$preprocess_output" | grep "^PREPROCESS:" | grep -v "^PREPROCESS: Result has\|^PREPROCESS: No changes needed" | sed 's/^PREPROCESS: //' | paste -sd '; ' -)
+
+        if [[ -n "$preprocessed_tmp" && -f "$preprocessed_tmp" ]]; then
+            submit_file="$preprocessed_tmp"
+            if [[ -n "$preprocess_log" ]]; then
+                echo -e "  ${CYAN}Preprocessed:${NC} $preprocess_log"
+            fi
+        fi
+    fi
+
     if [[ "$DRY_RUN" == true ]]; then
         echo -e "  ${YELLOW}[DRY RUN]${NC} Would submit $problem_id"
+        [[ -n "$preprocessed_tmp" && -f "$preprocessed_tmp" ]] && rm -rf "$(dirname "$preprocessed_tmp")"
         return 0
     fi
 
     # Use aristotlelib to submit (prove-from-file is the new command)
     local output
-    output=$(uvx --from aristotlelib aristotle prove-from-file "$file" --no-wait 2>&1) || {
+    output=$(uvx --from aristotlelib aristotle prove-from-file "$submit_file" --no-wait 2>&1) || {
+        # Clean up temp file
+        [[ -n "$preprocessed_tmp" && -f "$preprocessed_tmp" ]] && rm -rf "$(dirname "$preprocessed_tmp")"
+
         # Check for rate limiting (429) - stop batch immediately
         if echo "$output" | grep -qi "429\|rate.limit\|too many\|already have.*projects"; then
             echo -e "  ${YELLOW}Rate limited:${NC} $output"
@@ -175,6 +207,9 @@ submit_file() {
         echo -e "  ${RED}Failed:${NC} $output"
         return 1
     }
+
+    # Clean up temp file after submission
+    [[ -n "$preprocessed_tmp" && -f "$preprocessed_tmp" ]] && rm -rf "$(dirname "$preprocessed_tmp")"
 
     # Extract project ID from output
     local project_id=$(echo "$output" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
@@ -187,20 +222,26 @@ submit_file() {
 
     echo -e "  ${GREEN}Submitted:${NC} $project_id"
 
-    # Log to jobs file
+    # Log to jobs file (include preprocessing metadata)
     local now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
     local tmp_file=$(mktemp)
+    local preprocessed_flag="false"
+    [[ -n "$preprocess_log" ]] && preprocessed_flag="true"
 
     jq --arg pid "$project_id" \
        --arg file "$file" \
        --arg prob "$problem_id" \
        --arg now "$now" \
+       --argjson preprocessed "$preprocessed_flag" \
+       --arg preprocess_log "${preprocess_log:-}" \
        '.jobs += [{
          project_id: $pid,
          file: $file,
          problem_id: $prob,
          submitted: $now,
          status: "submitted",
+         preprocessed: $preprocessed,
+         preprocessing_log: (if $preprocess_log != "" then $preprocess_log else null end),
          notes: "Batch submission"
        }]' "$JOBS_FILE" > "$tmp_file" && mv "$tmp_file" "$JOBS_FILE"
 
@@ -275,6 +316,7 @@ main() {
     # Submit each candidate
     local submitted=0
     local failed=0
+    local skipped=0
     local rate_limited=false
 
     while IFS= read -r file; do
@@ -289,16 +331,24 @@ main() {
             # Rate limited - stop batch immediately
             rate_limited=true
             break
+        elif [[ $rc -eq 3 ]]; then
+            # Rejected by preprocessing - skip but don't count as failure
+            ((skipped++))
         else
             ((failed++))
         fi
 
         # Delay between submissions to avoid rate limits
-        sleep 3
+        if [[ $rc -eq 0 ]]; then
+            sleep 3
+        fi
     done < <(echo "$candidates" | jq -r '.[].file')
 
     echo ""
     echo -e "${GREEN}Submitted: $submitted${NC}"
+    if [[ "$skipped" -gt 0 ]]; then
+        echo -e "${YELLOW}Skipped (preprocessing): $skipped${NC}"
+    fi
     if [[ "$failed" -gt 0 ]]; then
         echo -e "${RED}Failed: $failed${NC}"
     fi


### PR DESCRIPTION
## Summary

- **New `preprocess-for-aristotle.sh`**: Converts axiom declarations to theorem sorries and fixes `/-!` docstrings before submission. Rejects files with definition sorries, all-True placeholders, or zero provable sorries.
- **Improved `find-candidates.sh`**: Hard-rejects unsuitable files (def sorries, True placeholders), blocks repeatedly-failed unmodified files from resubmission, reduces axiom scoring penalty (auto-converted now).
- **Enhanced `check-jobs.sh`**: Categorizes failures (`parse_error`, `load_error`, `axiom_only`, `open_problem`, etc.) and tracks submission counts for analysis.
- **Updated `submit-batch.sh`**: Integrates preprocessing pipeline, submits preprocessed copies, logs preprocessing metadata to jobs.json, handles rejections gracefully.

## Test plan

- [x] `preprocess-for-aristotle.sh` converts multi-line axioms correctly (tested on Erdos1030Problem.lean with 16 axioms)
- [x] `find-candidates.sh --best 5` returns scored candidates without rejected files
- [x] `find-candidates.sh --json` produces valid JSON
- [x] `submit-batch.sh --dry-run --count 5` shows preprocessing actions in output
- [x] All four scripts pass `bash -n` syntax validation
- [ ] Live submission test (next Aristotle batch cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)