### PR TITLE
Enrich erdos-1141, 1157, 1144: depth pass

### DIFF
--- a/src/data/proofs/erdos-1157/annotations.json
+++ b/src/data/proofs/erdos-1157/annotations.json
@@ -1,247 +1,134 @@
 [
   {
-    "id": "ann-e1157-header",
+    "id": "erdos-1157-imports",
     "proofId": "erdos-1157",
-    "range": {
-      "startLine": 1,
-      "endLine": 23
-    },
-    "type": "concept",
-    "title": "Problem Overview",
-    "content": "Header documentation for Erdős Problem #1157, providing mathematical context and problem statement.",
-    "mathContext": "Erdős Problem #1157: General Extremal Numbers for r-Uniform Hypergraphs\n\nSource: https://erdosproblems.com/1157\nStatus: OPEN (partial results known)\n\nStatement:\nDetermine the extremal number ex_r(n, F) where F is the family of all r-uniform\nhypergraphs with k vertices and s edges.\n\nThe Brown-Erdős-Sós conjecture asserts: for r > t ≥ 2 and s ≥ 3,\n  ex_t(n, F) = o(n^t) whenever k ≥ (r-t)s + t + 1.\n\nKnown Results:\n- Brown-Erdős-Sós (1973): Lower bound ex_r(n, F) ≫ n^{(rs-k)/(s-1)} for k > r, s > 1\n",
-    "significance": "critical",
-    "relatedConcepts": [
-      "Erdős problems",
-      "Number theory"
-    ]
+    "type": "context",
+    "range": { "startLine": 1, "endLine": 28 },
+    "title": "Problem Context and Imports",
+    "content": "Header documenting Erdős Problem #1157 on general extremal numbers for r-uniform hypergraphs. The Brown-Erdős-Sós (BES) conjecture asks: for r > t >= 2 and s >= 3, is ex_t(n, F) = o(n^t) whenever k >= (r-t)s + t + 1? Known partial results include the (6,3)-case (Ruzsa-Szemerédi 1978), (7,4)-case (Glock 2019), and the full 3-uniform case (Delcourt-Postle 2024). Imports Nat.Basic for natural number arithmetic, Real.Basic for the real-valued exponent computations, and SpecialFunctions.Pow.Real for real powers n^α used in asymptotic bounds.",
+    "mathContext": "The extremal number $f^{(r)}(n; k, s)$ is the maximum edges in an $r$-uniform hypergraph on $n$ vertices with no $s$ edges spanning $\\leq k$ vertices. The BES conjecture asserts $f^{(t)}(n; k, s) = o(n^t)$ when $k \\geq (r-t)s + t + 1$.",
+    "significance": "technical",
+    "relatedConcepts": ["Real.rpow", "Nat.Basic", "Asymptotics.IsLittleO"],
+    "prerequisites": ["Lean 4 basics", "Mathlib real analysis", "hypergraph extremal theory"]
   },
   {
-    "id": "ann-e1157-extremalNumber",
+    "id": "erdos-1157-extremal-number",
     "proofId": "erdos-1157",
-    "range": {
-      "startLine": 42,
-      "endLine": 42
-    },
-    "type": "axiom",
-    "title": "Extremalnumber",
-    "content": "axiom extremalNumber",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1157-extremalNumber_mono_k",
-    "proofId": "erdos-1157",
-    "range": {
-      "startLine": 46,
-      "endLine": 47
-    },
-    "type": "axiom",
-    "title": "Extremalnumber Mono K",
-    "content": "axiom extremalNumber_mono_k",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1157-extremalNumber_mono_s",
-    "proofId": "erdos-1157",
-    "range": {
-      "startLine": 51,
-      "endLine": 52
-    },
-    "type": "axiom",
-    "title": "Extremalnumber Mono S",
-    "content": "axiom extremalNumber_mono_s",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1157-besExponent",
-    "proofId": "erdos-1157",
-    "range": {
-      "startLine": 65,
-      "endLine": 66
-    },
     "type": "definition",
-    "title": "Besexponent",
-    "content": "noncomputable def besExponent",
-    "significance": "supporting"
+    "range": { "startLine": 31, "endLine": 42 },
+    "title": "General Extremal Number",
+    "content": "The extremal number f^(r)(n; k, s) is axiomatized as extremalNumber : ℕ⁴ → ℕ. It counts the maximum edges in an r-uniform hypergraph on n vertices containing no s edges that jointly span at most k vertices. This generalizes the classical Turán number ex(n; K_t) (which is the s=1 case) and the Zarankiewicz number (bipartite case).",
+    "mathContext": "$$f^{(r)}(n; k, s) = \\max\\{|E(H)| : H \\text{ is } r\\text{-uniform on } n \\text{ vertices, no } s \\text{ edges span } \\leq k \\text{ vertices}\\}$$",
+    "significance": "key",
+    "relatedConcepts": ["Turán number", "Zarankiewicz number", "r-uniform hypergraph", "forbidden configuration"],
+    "prerequisites": ["hypergraph basics", "extremal graph theory"]
   },
   {
-    "id": "ann-e1157-besExponent_pos",
+    "id": "erdos-1157-monotonicity",
     "proofId": "erdos-1157",
-    "range": {
-      "startLine": 69,
-      "endLine": 76
-    },
-    "type": "theorem",
-    "title": "Besexponent Pos",
-    "content": "/-- The BES lower bound exponent is positive when rs > k and s ≥ 2. -/",
-    "significance": "key"
+    "type": "result",
+    "range": { "startLine": 44, "endLine": 52 },
+    "title": "Monotonicity Properties",
+    "content": "Two monotonicity axioms: (1) extremalNumber is non-decreasing in k—allowing more vertices in forbidden configurations is a weaker constraint, so more edges are permitted. (2) extremalNumber is non-decreasing in s—requiring more forbidden edges is harder to violate. These are fundamental structural properties that allow transferring results between parameter regimes.",
+    "mathContext": "$k_1 \\leq k_2 \\implies f^{(r)}(n; k_1, s) \\leq f^{(r)}(n; k_2, s)$ and $s_1 \\leq s_2 \\implies f^{(r)}(n; k, s_1) \\leq f^{(r)}(n; k, s_2)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["monotone function", "extremal number properties", "supersaturation"],
+    "prerequisites": ["order theory", "extremal graph theory basics"]
   },
   {
-    "id": "ann-e1157-brown_erdos_sos_lower_bound",
+    "id": "erdos-1157-bes-exponent",
     "proofId": "erdos-1157",
-    "range": {
-      "startLine": 81,
-      "endLine": 83
-    },
-    "type": "axiom",
-    "title": "Brown Erdos Sos Lower Bound",
-    "content": "axiom brown_erdos_sos_lower_bound",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e1157-IsLittleO",
-    "proofId": "erdos-1157",
-    "range": {
-      "startLine": 92,
-      "endLine": 93
-    },
     "type": "definition",
-    "title": "Islittleo",
-    "content": "/-- Little-o notation for sequences: f(n) = o(g(n)) as n → ∞. -/",
-    "significance": "supporting"
+    "range": { "startLine": 54, "endLine": 76 },
+    "title": "BES Exponent and Positivity",
+    "content": "The BES exponent α = (rs − k)/(s − 1) governs the polynomial growth rate of the lower bound. When rs > k and s >= 2, α > 0, ensuring the lower bound n^α grows polynomially. The proof of positivity uses basic real division: the numerator rs − k > 0 and denominator s − 1 > 0 from the hypotheses. The exponent captures the 'dimension' of the extremal problem: larger α means the extremal number grows faster, so the problem is harder.",
+    "mathContext": "$$\\alpha(r,k,s) = \\frac{rs - k}{s - 1}, \\qquad \\alpha > 0 \\iff rs > k \\text{ and } s \\geq 2$$",
+    "significance": "key",
+    "relatedConcepts": ["polynomial growth", "real division", "exponent analysis"],
+    "prerequisites": ["real analysis basics", "asymptotic notation"]
   },
   {
-    "id": "ann-e1157-BESConjecture",
+    "id": "erdos-1157-bes-lower-bound",
     "proofId": "erdos-1157",
-    "range": {
-      "startLine": 98,
-      "endLine": 100
-    },
-    "type": "definition",
-    "title": "Besconjecture",
-    "content": "def BESConjecture",
-    "significance": "supporting"
+    "type": "result",
+    "range": { "startLine": 78, "endLine": 83 },
+    "title": "Brown-Erdős-Sós Lower Bound (1973)",
+    "content": "The foundational lower bound: for k > r >= 2 and s >= 2, there exist c > 0 and N₀ such that f^(r)(n; k, s) >= c · n^α for all n >= N₀. This was proved by Brown, Erdős, and Sós in 1973 using probabilistic and algebraic constructions. The lower bound shows that the extremal number grows at least polynomially with exponent α = (rs−k)/(s−1). The construction uses random hypergraphs and norm-graph-type algebraic constructions over finite fields.",
+    "mathContext": "$$\\forall\\, k > r \\geq 2,\\; s \\geq 2: \\quad f^{(r)}(n; k, s) \\geq c \\cdot n^{(rs-k)/(s-1)} \\quad \\text{for } n \\geq N_0$$",
+    "significance": "key",
+    "relatedConcepts": ["probabilistic method", "algebraic construction", "norm graphs", "finite field construction"],
+    "prerequisites": ["probabilistic combinatorics", "algebraic graph theory"]
   },
   {
-    "id": "ann-e1157-erdos716_parameter_check",
+    "id": "erdos-1157-bes-conjecture",
     "proofId": "erdos-1157",
-    "range": {
-      "startLine": 111,
-      "endLine": 111
-    },
-    "type": "theorem",
-    "title": "Erdos716 Parameter Check",
-    "content": "theorem erdos716_parameter_check",
-    "significance": "critical"
+    "type": "conjecture",
+    "range": { "startLine": 85, "endLine": 100 },
+    "title": "The Brown-Erdős-Sós Conjecture",
+    "content": "The central conjecture: for r > t >= 2 and s >= 3, if k >= (r−t)s + t + 1, then f^(t)(n; k, s) = o(n^t). The little-o notation is formalized as IsLittleO: for every ε > 0, eventually |f(n)| <= ε|g(n)|. The threshold k = (r−t)s + t + 1 is sharp: below it, the lower bound gives polynomial growth ≥ n^α with α > 0, so o(n^t) would be impossible. The conjecture asserts a phase transition at this threshold.",
+    "mathContext": "$$\\text{BES Conjecture: } r > t \\geq 2,\\; s \\geq 3,\\; k \\geq (r-t)s + t + 1 \\implies f^{(t)}(n; k, s) = o(n^t)$$\nThe threshold is tight: for $k = (r-t)s + t$, the BES lower bound gives $f^{(t)}(n; k, s) \\geq c \\cdot n^t$.",
+    "significance": "key",
+    "relatedConcepts": ["little-o notation", "phase transition", "extremal threshold", "sublinear growth"],
+    "prerequisites": ["asymptotic analysis", "extremal combinatorics"]
   },
   {
-    "id": "ann-e1157-erdos1076_beyond_bes",
+    "id": "erdos-1157-special-cases",
     "proofId": "erdos-1157",
-    "range": {
-      "startLine": 117,
-      "endLine": 118
-    },
-    "type": "theorem",
-    "title": "Erdos1076 Beyond Bes",
-    "content": "theorem erdos1076_beyond_bes",
-    "significance": "critical"
+    "type": "insight",
+    "range": { "startLine": 102, "endLine": 118 },
+    "title": "Connections to Other Erdős Problems",
+    "content": "Problem #1157 unifies several major Erdős problems. The (6,3)-case (t=2, r=3, s=3, k=6) is exactly Problem #716, the Ruzsa-Szemerédi theorem. The parameter check (3−2)·3 + 2 + 1 = 6 shows this is tight. Problem #1076 (r=3, k=s+2) lies beyond the BES threshold since s+2 < s+3 = (3−2)s + 2 + 1, meaning #1076's results are stronger than what BES alone predicts. This reveals that specific structural properties (Steiner systems, regularity) can beat the generic BES bound.",
+    "mathContext": "Problem \\#716: $t=2, r=s=3, k=6$ gives $(3-2) \\cdot 3 + 2 + 1 = 6$, tight.\\\\Problem \\#1076: $k = s+2 < s+3 = (r-t)s + t + 1$, so \\#1076 is \\emph{beyond} BES.",
+    "significance": "key",
+    "relatedConcepts": ["Ruzsa-Szemerédi theorem", "Steiner triple system", "triangle removal lemma"],
+    "prerequisites": ["Erdős Problem #716", "Erdős Problem #1076"]
   },
   {
-    "id": "ann-e1157-ruzsa_szemeredi_bes",
+    "id": "erdos-1157-partial-results",
     "proofId": "erdos-1157",
-    "range": {
-      "startLine": 126,
-      "endLine": 127
-    },
-    "type": "axiom",
-    "title": "Ruzsa Szemeredi Bes",
-    "content": "axiom ruzsa_szemeredi_bes",
-    "significance": "key"
+    "type": "result",
+    "range": { "startLine": 120, "endLine": 136 },
+    "title": "Known Partial Results",
+    "content": "Three landmark results are axiomatized: (1) Ruzsa-Szemerédi (1978): the (6,3)-case via the Triangle Removal Lemma (itself a consequence of Szemerédi's regularity lemma). (2) Glock (2019): the (7,4)-case, extending to 4 edges. (3) Delcourt-Postle (2024): the full 3-uniform BES conjecture for all s >= 3 and k >= s+3. The Delcourt-Postle result was a major breakthrough, resolving the t=2 case completely after over 50 years.",
+    "mathContext": "Ruzsa-Szemerédi: $f^{(3)}(n; 6, 3) = o(n^2)$.\\\\Glock: $f^{(3)}(n; 7, 4) = o(n^2)$.\\\\Delcourt-Postle: $\\forall\\, s \\geq 3,\\; k \\geq s+3: f^{(3)}(n; k, s) = o(n^2)$.",
+    "significance": "key",
+    "relatedConcepts": ["Triangle Removal Lemma", "Szemerédi regularity", "Delcourt-Postle theorem", "3-uniform hypergraph"],
+    "prerequisites": ["regularity lemma", "graph removal lemma"]
   },
   {
-    "id": "ann-e1157-glock_bes_k4",
+    "id": "erdos-1157-exponent-structure",
     "proofId": "erdos-1157",
-    "range": {
-      "startLine": 130,
-      "endLine": 131
-    },
-    "type": "axiom",
-    "title": "Glock Bes K4",
-    "content": "/-- **Glock (2019):** The (7,4)-case. -/",
-    "significance": "key"
+    "type": "result",
+    "range": { "startLine": 138, "endLine": 180 },
+    "title": "Structural Properties of the BES Exponent",
+    "content": "Several structural theorems about the BES exponent α = (rs−k)/(s−1): (1) α decreases as k increases—more vertices in the forbidden configuration yields a weaker lower bound. (2) α = 0 when k = rs—at this boundary the lower bound is trivial. (3) Specific values: α(3,6,3) = 3/2 and α(3,7,4) = 5/3. (4) At the BES threshold k = (r−2)s + 3, the exponent α ≤ 1, confirming compatibility with the o(n²) conjecture. All proofs use basic real arithmetic (unfold, norm_num, nlinarith).",
+    "mathContext": "$\\alpha(r,k_2,s) < \\alpha(r,k_1,s)$ for $k_1 < k_2$. $\\alpha(r, rs, s) = 0$. $\\alpha(3,6,3) = \\tfrac{3}{2}$. $\\alpha(3,7,4) = \\tfrac{5}{3}$. At threshold: $\\alpha \\leq 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["real arithmetic", "exponent analysis", "threshold behavior"],
+    "prerequisites": ["real division", "basic inequalities"]
   },
   {
-    "id": "ann-e1157-delcourt_postle_theorem",
+    "id": "erdos-1157-proved-theorems",
     "proofId": "erdos-1157",
-    "range": {
-      "startLine": 135,
-      "endLine": 136
-    },
-    "type": "axiom",
-    "title": "Delcourt Postle Theorem",
-    "content": "axiom delcourt_postle_theorem",
-    "significance": "key"
+    "type": "result",
+    "range": { "startLine": 182, "endLine": 210 },
+    "title": "Proved Theorems and Monotonicity Transfer",
+    "content": "Three theorems are fully proved (no sorry): (1) The 3-uniform case follows directly from Delcourt-Postle. (2) The (6,3) case follows from Ruzsa-Szemerédi. (3) A monotonicity transfer: if f^(3)(n; k₁, s) = o(n²) and k₁ ≤ k₂, then f^(3)(n; k₂, s) = o(n²). The monotonicity proof uses the extremalNumber_mono_k axiom and careful manipulation of absolute values. This transfer principle means proving BES for the smallest k in each parameter family suffices.",
+    "mathContext": "Monotonicity transfer: $f^{(3)}(n; k_1, s) = o(n^2) \\wedge k_1 \\leq k_2 \\implies f^{(3)}(n; k_2, s) = o(n^2)$, since $f^{(3)}(n; k_2, s) \\leq f^{(3)}(n; k_1, s)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["monotonicity", "absolute value", "little-o transfer"],
+    "prerequisites": ["real analysis", "monotone properties"]
   },
   {
-    "id": "ann-e1157-besExponent_decreasing",
+    "id": "erdos-1157-main-statement",
     "proofId": "erdos-1157",
-    "range": {
-      "startLine": 143,
-      "endLine": 150
-    },
-    "type": "theorem",
-    "title": "Besexponent Decreasing",
-    "content": "/-- The BES exponent decreases as k increases. -/",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1157-besExponent_zero_at_rs",
-    "proofId": "erdos-1157",
-    "range": {
-      "startLine": 153,
-      "endLine": 156
-    },
-    "type": "theorem",
-    "title": "Besexponent Zero At Rs",
-    "content": "/-- When k = rs, the BES exponent is 0. -/",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1157-besExponent_6_3",
-    "proofId": "erdos-1157",
-    "range": {
-      "startLine": 159,
-      "endLine": 161
-    },
-    "type": "theorem",
-    "title": "Besexponent 6 3",
-    "content": "/-- The BES exponent for the (6,3) case is 3/2. -/",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1157-besExponent_7_4",
-    "proofId": "erdos-1157",
-    "range": {
-      "startLine": 164,
-      "endLine": 166
-    },
-    "type": "theorem",
-    "title": "Besexponent 7 4",
-    "content": "/-- The BES exponent for the (7,4) case (Glock 2019). -/",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1157-besExponent_le_one_at_bes_thre",
-    "proofId": "erdos-1157",
-    "range": {
-      "startLine": 171,
-      "endLine": 180
-    },
-    "type": "theorem",
-    "title": "Besexponent Le One At Bes Threshold",
-    "content": "theorem besExponent_le_one_at_bes_threshold",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1157-erdos_1157_3uniform_resolved",
-    "proofId": "erdos-1157",
-    "range": {
-      "startLine": 187,
-      "endLine": 189
-    },
-    "type": "theorem",
-    "title": "Erdos 1157 3Uniform Resolved",
-    "content": "/-- The 3-uniform case of the BES conjecture is fully resolved. -/",
-    "significance": "critical"
+    "type": "conjecture",
+    "range": { "startLine": 212, "endLine": 235 },
+    "title": "Problem Statement and Summary",
+    "content": "The full Problem #1157 is stated as: for all t, r, s, k, BESConjecture t r s k holds. The summary theorem combines four known results into a single conjunction: the Delcourt-Postle 3-uniform resolution, the Ruzsa-Szemerédi (6,3) case, and the computed BES exponents for (6,3) and (7,4). The problem remains OPEN for uniformities r >= 4 (equivalently t >= 3), where no general sublinear bound is known.",
+    "mathContext": "$$\\text{Problem \\#1157: } \\forall\\, t, r, s, k,\\; \\text{BESConjecture}(t, r, s, k)$$\nResolved for $t = 2$ (3-uniform). Open for $t \\geq 3$.",
+    "significance": "key",
+    "relatedConcepts": ["open problem", "BES conjecture", "higher uniformity", "summary theorem"],
+    "prerequisites": ["all preceding results"]
   }
 ]

--- a/src/data/proofs/erdos-1157/meta.json
+++ b/src/data/proofs/erdos-1157/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-1157",
   "title": "Erdős Problem #1157: General Extremal Numbers for r-Uniform Hypergraphs",
   "slug": "erdos-1157",
-  "description": "Determine the extremal number ex_r(n, F) where F is the family of all r-uniform",
+  "description": "Determine the extremal number f^(r)(n; k, s) for r-uniform hypergraphs. The Brown-Erdős-Sós conjecture asserts f^(t)(n; k, s) = o(n^t) when k >= (r-t)s + t + 1. Resolved for 3-uniform (Delcourt-Postle 2024). Open for r >= 4.",
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1157",
@@ -18,71 +18,132 @@
     "sorries": 0,
     "erdosNumber": 1157,
     "erdosUrl": "https://erdosproblems.com/1157",
-    "erdosProblemStatus": "open",
-    "mathlib_version": "4.15.0",
-    "mathlibDependencies": [
-      {
-        "theorem": "Basic",
-        "description": "From Mathlib.Data.Nat.Basic",
-        "module": "Mathlib.Data.Nat.Basic"
-      },
-      {
-        "theorem": "Basic",
-        "description": "From Mathlib.Data.Real.Basic",
-        "module": "Mathlib.Data.Real.Basic"
-      },
-      {
-        "theorem": "Real",
-        "description": "From Mathlib.Analysis.SpecialFunctions.Pow.Real",
-        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
-      }
-    ],
-    "originalContributions": [
-      "extremalNumber",
-      "extremalNumber_mono_k",
-      "extremalNumber_mono_s",
-      "besExponent",
-      "besExponent_pos",
-      "brown_erdos_sos_lower_bound",
-      "IsLittleO",
-      "BESConjecture",
-      "erdos716_parameter_check",
-      "erdos1076_beyond_bes",
-      "ruzsa_szemeredi_bes",
-      "glock_bes_k4",
-      "delcourt_postle_theorem",
-      "besExponent_decreasing",
-      "besExponent_zero_at_rs"
-    ]
+    "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős Problem #1157 concerns general extremal numbers for r-uniform hypergraphs. This problem remains OPEN.\n\nKnown results include: - Brown-Erdős-Sós (1973): Lower bound ex_r(n, F) ≫ n^{(rs-k)/(s-1)} for k > r, s > 1 - The case r = s = 3, k = 6 is Problem #716 (Ruzsa-Szemerédi theorem) - The case r = 3, k = s + 2 is Problem #1076 (solved by Bohman-Warnke 2019) - The case t = 2 is Problem #1178\n\nThis problem is catalogued at erdosproblems.com/1157.",
-    "problemStatement": "Determine the extremal number ex_r(n, F) where F is the family of all r-uniform",
-    "proofStrategy": "The formalization is structured in 238 lines of Lean 4 code. It uses 7 axioms for results that require external references or deep mathematical arguments beyond Mathlib. The main conjecture is stated as an axiom since it is an open problem.",
+    "historicalContext": "Brown, Erdős, and Sós introduced the general extremal number $f^{(r)}(n; k, s)$ in 1973, proving the foundational lower bound $f^{(r)}(n; k, s) \\gg n^{(rs-k)/(s-1)}$ for $k > r$ and $s > 1$ using probabilistic and algebraic constructions over finite fields. The BES conjecture—that $f^{(t)}(n; k, s) = o(n^t)$ when $k \\geq (r-t)s + t + 1$—predicts a sharp phase transition in the growth rate. The first case resolved was the $(6,3)$-problem by Ruzsa and Szemerédi (1978), who established $f^{(3)}(n; 6, 3) = o(n^2)$ via the Triangle Removal Lemma (a consequence of Szemerédi's regularity lemma). This special case is independently famous as Erdős Problem #716 and connects to Roth's theorem on 3-term arithmetic progressions. Glock (2019) resolved the $(7,4)$-case. The breakthrough came from Delcourt and Postle (2024), who proved the full 3-uniform BES conjecture: $f^{(3)}(n; k, s) = o(n^2)$ for all $s \\geq 3$ and $k \\geq s + 3$. Problem #1076 (the $k = s + 2$ case) was solved separately by Bohman-Warnke (2019), lying beyond the BES threshold. The conjecture remains wide open for uniformities $t \\geq 3$.",
+    "problemStatement": "Determine the extremal number $f^{(r)}(n; k, s)$, the maximum edges in an $r$-uniform hypergraph on $n$ vertices with no $s$ edges spanning at most $k$ vertices. Prove the Brown-Erdős-Sós conjecture: for $r > t \\geq 2$ and $s \\geq 3$, $f^{(t)}(n; k, s) = o(n^t)$ when $k \\geq (r-t)s + t + 1$.",
+    "proofStrategy": "The formalization axiomatizes the extremal number as a function $\\mathbb{N}^4 \\to \\mathbb{N}$ with monotonicity in $k$ and $s$. The BES exponent $\\alpha = (rs-k)/(s-1)$ is defined over $\\mathbb{R}$ and shown positive under the natural conditions. The BES conjecture is formalized using a custom IsLittleO definition. Three axioms encode the landmark results (Ruzsa-Szemerédi, Glock, Delcourt-Postle). Structural properties of the exponent are proved via real arithmetic: monotonicity in $k$, vanishing at $k = rs$, specific values for $(6,3)$ and $(7,4)$, and compatibility with the $o(n^2)$ conjecture at the BES threshold. A monotonicity transfer theorem allows deducing BES for larger $k$ from smaller $k$.",
     "keyInsights": [
-      "**The general extremal number f^(r)(n; k, s)**: The general extremal number f^(r)(n; k, s):",
-      "**Monotonicity in k**: Monotonicity in k: allowing more vertices in forbidden configurations",
-      "**Monotonicity in s**: Monotonicity in s: requiring more forbidden edges makes it harder",
-      "**The BES lower bound exponent**: The BES lower bound exponent: α = (rs - k) / (s - 1).",
-      "**The BES lower bound exponent is positive when rs > k and s ≥ 2.**: The BES lower bound exponent is positive when rs > k and s ≥ 2."
+      "The BES exponent $\\alpha = (rs-k)/(s-1)$ governs a sharp phase transition: for $\\alpha \\geq t$ the extremal number grows as $\\Omega(n^t)$, while the conjecture predicts $o(n^t)$ just above this threshold at $k = (r-t)s + t + 1$",
+      "The (6,3)-case is equivalent to the Ruzsa-Szemerédi theorem and connects to Roth's theorem on arithmetic progressions via the Triangle Removal Lemma, illustrating how hypergraph extremal theory interacts with additive combinatorics",
+      "Delcourt-Postle's 2024 resolution of the full 3-uniform case was achieved over 50 years after the conjecture, showing that the $t = 2$ barrier was the most fundamental—but $t \\geq 3$ remains completely open",
+      "Problem #1076 ($k = s + 2$) is beyond the BES threshold ($k \\geq s + 3$), yet was also resolved (Bohman-Warnke 2019), suggesting the true extremal landscape is richer than BES alone predicts",
+      "Monotonicity in $k$ enables a transfer principle: proving BES for the smallest valid $k$ in each parameter family automatically implies it for all larger $k$, reducing the conjecture to boundary cases"
     ]
   },
   "sections": [
     {
-      "id": "formalization",
-      "title": "Formalization",
-      "summary": "Complete formalization of Erdős Problem #1157",
+      "id": "imports-setup",
+      "title": "Problem Context and Imports",
       "startLine": 1,
-      "endLine": 238
+      "endLine": 28,
+      "summary": "Header documentation with problem statement, known results (BES 1973, Ruzsa-Szemerédi 1978, Glock 2019, Delcourt-Postle 2024), and Mathlib imports for natural numbers, real numbers, and real powers."
+    },
+    {
+      "id": "extremal-number",
+      "title": "General Extremal Number",
+      "startLine": 31,
+      "endLine": 52,
+      "summary": "Axiomatizes f^(r)(n; k, s) as extremalNumber : ℕ⁴ → ℕ with monotonicity axioms in k and s."
+    },
+    {
+      "id": "bes-exponent",
+      "title": "BES Exponent",
+      "startLine": 54,
+      "endLine": 76,
+      "summary": "Defines besExponent α = (rs−k)/(s−1) over ℝ and proves positivity when rs > k and s ≥ 2."
+    },
+    {
+      "id": "bes-lower-bound",
+      "title": "Brown-Erdős-Sós Lower Bound",
+      "startLine": 78,
+      "endLine": 83,
+      "summary": "Axiomatizes the 1973 lower bound: f^(r)(n; k, s) ≥ c·n^α for k > r ≥ 2, s ≥ 2."
+    },
+    {
+      "id": "bes-conjecture",
+      "title": "The BES Conjecture",
+      "startLine": 85,
+      "endLine": 100,
+      "summary": "Formalizes IsLittleO and the BES conjecture: f^(t)(n; k, s) = o(n^t) when k ≥ (r−t)s + t + 1."
+    },
+    {
+      "id": "special-cases",
+      "title": "Connections to Other Problems",
+      "startLine": 102,
+      "endLine": 118,
+      "summary": "Parameter checks connecting to Problem #716 (tight at k=6) and Problem #1076 (beyond BES threshold)."
+    },
+    {
+      "id": "partial-results",
+      "title": "Known Partial Results",
+      "startLine": 120,
+      "endLine": 136,
+      "summary": "Axiomatizes Ruzsa-Szemerédi (6,3), Glock (7,4), and Delcourt-Postle (full 3-uniform) results."
+    },
+    {
+      "id": "exponent-structure",
+      "title": "Exponent Structural Properties",
+      "startLine": 138,
+      "endLine": 180,
+      "summary": "Proves exponent is decreasing in k, zero at k=rs, computes α(3,6,3)=3/2 and α(3,7,4)=5/3, and shows α≤1 at BES threshold."
+    },
+    {
+      "id": "proved-theorems",
+      "title": "Proved Theorems",
+      "startLine": 182,
+      "endLine": 210,
+      "summary": "Three fully proved theorems: 3-uniform resolution, (6,3) case, and monotonicity transfer principle for little-o bounds."
+    },
+    {
+      "id": "main-statement",
+      "title": "Problem Statement and Summary",
+      "startLine": 212,
+      "endLine": 237,
+      "summary": "States full Problem #1157 as universal BES conjecture. Summary theorem combines Delcourt-Postle, Ruzsa-Szemerédi, and computed exponents."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1157 (General Extremal Numbers for r-Uniform Hypergraphs) in Lean 4, including core definitions, key structural results, and the open conjecture stated as an axiom.",
-    "implications": "The formalization demonstrates how open problems in combinatorics and number theory can be rigorously expressed in Lean 4.",
+    "summary": "This formalization captures the full landscape of Erdős Problem #1157: the general extremal number $f^{(r)}(n; k, s)$ is axiomatized with monotonicity properties, the BES exponent $\\alpha = (rs-k)/(s-1)$ is analyzed in detail, the 1973 lower bound and the BES conjecture are formalized, three landmark partial results are encoded, and structural properties of the exponent are proved. The 3-uniform case ($t = 2$) is fully resolved; the problem remains open for higher uniformities.",
+    "implications": "The BES conjecture is one of the central problems in extremal hypergraph theory. Its resolution for $t \\geq 3$ would require fundamentally new techniques beyond regularity-based methods, which lose effectiveness for higher uniformities. The phase transition at $k = (r-t)s + t + 1$ governs the complexity of forbidden configuration problems in combinatorics, with connections to additive number theory (via the Ruzsa-Szemerédi/Roth link), design theory (via Steiner systems), and the probabilistic method.",
     "openQuestions": [
-      "Resolve the conjecture",
-      "Fill in sorry placeholders with complete proofs",
-      "Strengthen connections to other Erdős problems"
+      "Can the BES conjecture be proved for any $t \\geq 3$? Even the case $t = 3$ (4-uniform hypergraphs) remains completely open",
+      "What is the correct exponent in the BES lower bound? Is $f^{(r)}(n; k, s) = \\Theta(n^{(rs-k)/(s-1)})$ below the BES threshold, or can the lower bound be improved?",
+      "Can quantitative bounds on the $o(n^t)$ term be established? The regularity-based proofs give only tower-type bounds",
+      "Is there a unified approach to the BES conjecture that avoids case-by-case analysis of uniformity?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-716",
+      "relationship": "specializes",
+      "description": "Problem #716 (Ruzsa-Szemerédi (6,3)-problem) is the t=2, r=s=3, k=6 case of the BES conjecture, resolved in 1978 via the Triangle Removal Lemma"
+    },
+    {
+      "targetId": "erdos-1076",
+      "relationship": "related",
+      "description": "Problem #1076 (3-uniform extremal for k=s+2) lies beyond the BES threshold, solved by Bohman-Warnke (2019) using Steiner system constructions"
+    },
+    {
+      "targetId": "erdos-714",
+      "relationship": "related",
+      "description": "Problem #714 (Zarankiewicz for K_{r,r}) is a related bipartite extremal problem; the K_{2,2} case connects to hypergraph extremal theory via incidence geometry"
+    },
+    {
+      "targetId": "erdos-1075",
+      "relationship": "related",
+      "description": "Problem #1075 (dense subgraphs in r-uniform hypergraphs) studies the density constant c_r, complementing the extremal number bounds in #1157"
+    },
+    {
+      "targetId": "erdos-1155",
+      "relationship": "technique",
+      "description": "Problem #1155 (triangle removal process) involves the Triangle Removal Lemma, which is the key technique for the (6,3)-case of the BES conjecture"
+    },
+    {
+      "targetId": "erdos-1078",
+      "relationship": "related",
+      "description": "Problem #1078 (minimum degree for K_r in r-partite graphs) studies BES-type thresholds in the multipartite setting, solved by Haxell (2001)"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1159/annotations.json
+++ b/src/data/proofs/erdos-1159/annotations.json
@@ -1,139 +1,174 @@
 [
   {
-    "id": "ann-e1159-header",
+    "id": "erdos-1159-imports",
     "proofId": "erdos-1159",
+    "type": "context",
     "range": {
-      "startLine": 1,
-      "endLine": 32
+      "startLine": 34,
+      "endLine": 38
     },
-    "type": "concept",
-    "title": "Problem Overview",
-    "content": "Header documentation for Erdős Problem #1159, providing mathematical context and problem statement.",
-    "mathContext": "Erdős Problem #1159: Bounded Blocking Sets in Projective Planes\n\nSource: https://erdosproblems.com/1159\nStatus: OPEN\n\nStatement:\nDoes there exist a constant C > 1 such that for any finite projective plane P,\none can find a set of points S where each line ℓ intersects S in at least 1\nbut at most C points?\n\nSuch a set S is called a \"C-bounded blocking set\" — it blocks every line\n(meets it in ≥1 point) while keeping the intersection with any line at most C.\n\nBackground:\nA blocking set in a projecti",
-    "significance": "critical",
+    "title": "Imports and Namespace",
+    "content": "Imports the full Mathlib library and opens the Configuration namespace, which provides ProjectivePlane, pointCount, lineCount, and the order function. The Configuration module formalizes incidence geometry structures where points and lines interact via a Membership instance.",
+    "mathContext": "The formalization uses Mathlib's $\\texttt{Configuration.ProjectivePlane}$ typeclass, which encodes the axioms: any two distinct points determine a unique line, any two distinct lines meet in a unique point, and there exist four points in general position.",
+    "significance": "technical",
     "relatedConcepts": [
-      "Erdős problems",
-      "Number theory"
+      "Configuration.ProjectivePlane",
+      "Membership",
+      "incidence geometry"
+    ],
+    "prerequisites": [
+      "Lean 4 basics",
+      "Mathlib incidence geometry"
     ]
   },
   {
-    "id": "ann-e1159-IsBlockingSet",
+    "id": "erdos-1159-blocking-set-def",
     "proofId": "erdos-1159",
+    "type": "definition",
     "range": {
-      "startLine": 43,
+      "startLine": 42,
       "endLine": 44
     },
-    "type": "definition",
-    "title": "Isblockingset",
-    "content": "/-- A set of points S is a blocking set if every line contains at least one point of S. -/",
-    "significance": "supporting"
+    "title": "Blocking Set Definition",
+    "content": "Defines IsBlockingSet S as the property that every line contains at least one point of S. This is the fundamental concept in finite geometry: a blocking set blocks every line from being disjoint from S. The definition is generic over any incidence structure.",
+    "mathContext": "$$\\text{IsBlockingSet}(S) \\;:\\Leftrightarrow\\; \\forall\\, \\ell \\in \\mathcal{L},\\; S \\cap \\ell \\neq \\emptyset$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "blocking set",
+      "covering design",
+      "transversal"
+    ],
+    "prerequisites": [
+      "incidence geometry",
+      "set intersection"
+    ]
   },
   {
-    "id": "ann-e1159-blocking_set_mono",
+    "id": "erdos-1159-basic-properties",
     "proofId": "erdos-1159",
+    "type": "result",
     "range": {
-      "startLine": 49,
-      "endLine": 53
-    },
-    "type": "theorem",
-    "title": "Blocking Set Mono",
-    "content": "/-- If S is a blocking set and S ⊆ T, then T is also a blocking set. -/",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1159-empty_not_blocking_set",
-    "proofId": "erdos-1159",
-    "range": {
-      "startLine": 56,
+      "startLine": 48,
       "endLine": 61
     },
-    "type": "theorem",
-    "title": "Empty Not Blocking Set",
-    "content": "/-- The empty set is not a blocking set in any nontrivial configuration. -/",
-    "significance": "key"
+    "title": "Basic Properties of Blocking Sets",
+    "content": "Monotonicity: supersets of blocking sets are blocking. Non-triviality: the empty set is never a blocking set. These establish that blocking sets form an upper set in the power set lattice.",
+    "mathContext": "$S \\subseteq T \\land \\text{IsBlockingSet}(S) \\implies \\text{IsBlockingSet}(T)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monotone property",
+      "upper set",
+      "trivial blocking sets"
+    ],
+    "prerequisites": [
+      "set inclusion",
+      "basic logic"
+    ]
   },
   {
-    "id": "ann-e1159-pointCount_eq'",
+    "id": "erdos-1159-projective-plane-props",
     "proofId": "erdos-1159",
+    "type": "result",
     "range": {
-      "startLine": 66,
-      "endLine": 69
-    },
-    "type": "theorem",
-    "title": "Pointcount Eq'",
-    "content": "/-- In a projective plane, every line has exactly order + 1 points. -/",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1159-lineCount_eq'",
-    "proofId": "erdos-1159",
-    "range": {
-      "startLine": 72,
-      "endLine": 75
-    },
-    "type": "theorem",
-    "title": "Linecount Eq'",
-    "content": "/-- In a projective plane, every point lies on exactly order + 1 lines. -/",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1159-card_points'",
-    "proofId": "erdos-1159",
-    "range": {
-      "startLine": 78,
-      "endLine": 81
-    },
-    "type": "theorem",
-    "title": "Card Points'",
-    "content": "/-- A projective plane of order n has n² + n + 1 points. -/",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1159-card_lines'",
-    "proofId": "erdos-1159",
-    "range": {
-      "startLine": 84,
+      "startLine": 63,
       "endLine": 87
     },
-    "type": "theorem",
-    "title": "Card Lines'",
-    "content": "/-- A projective plane of order n has n² + n + 1 lines. -/",
-    "significance": "key"
+    "title": "Projective Plane Structure",
+    "content": "Four classical counting results: n+1 points per line, n+1 lines per point, n^2+n+1 total points and lines. Point-line duality is reflected in |P| = |L|.",
+    "mathContext": "Order $n$: $|\\ell| = n+1$, $n+1$ lines per point, $|\\mathcal{P}| = |\\mathcal{L}| = n^2+n+1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "projective plane order",
+      "point-line duality",
+      "Fano plane"
+    ],
+    "prerequisites": [
+      "finite projective planes",
+      "combinatorial counting"
+    ]
   },
   {
-    "id": "ann-e1159-ess_log_blocking_set",
+    "id": "erdos-1159-ess-result",
     "proofId": "erdos-1159",
+    "type": "result",
     "range": {
-      "startLine": 99,
+      "startLine": 89,
       "endLine": 105
     },
-    "type": "axiom",
-    "title": "Ess Log Blocking Set",
-    "content": "axiom ess_log_blocking_set",
-    "significance": "key"
+    "title": "Erdos-Silverman-Stein Theorem (1983)",
+    "content": "Axiomatizes: every plane of order n has a blocking set meeting each line in at most 3(log_2(n)+1) points. The probabilistic proof includes each point with probability c*log(n)/n.",
+    "mathContext": "ESS: $\\exists\\, S$ blocking with $|S \\cap \\ell| \\leq 3(\\log_2 n + 1)$ for all $\\ell$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "probabilistic method",
+      "random blocking sets"
+    ],
+    "prerequisites": [
+      "probabilistic combinatorics",
+      "projective plane structure"
+    ]
   },
   {
-    "id": "ann-e1159-BoundedBlockingSetConjecture",
+    "id": "erdos-1159-conjecture",
     "proofId": "erdos-1159",
+    "type": "conjecture",
     "range": {
-      "startLine": 119,
+      "startLine": 107,
       "endLine": 124
     },
-    "type": "definition",
-    "title": "Boundedblockingsetconjecture",
-    "content": "def BoundedBlockingSetConjecture",
-    "significance": "supporting"
+    "title": "The Bounded Blocking Set Conjecture",
+    "content": "The main open problem: exists absolute C such that every plane has a C-bounded blocking set. ESS gives C(n)=O(log n); the conjecture asks for C(n)=O(1).",
+    "mathContext": "$$\\exists\\, C :\\; \\forall\\text{ planes } \\Pi,\\; \\exists\\, S : \\text{IsBlockingSet}(S) \\land \\forall\\,\\ell,\\; |S \\cap \\ell| \\leq C$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "uniform bound",
+      "derandomization"
+    ],
+    "prerequisites": [
+      "blocking sets",
+      "projective planes",
+      "ESS theorem"
+    ]
   },
   {
-    "id": "ann-e1159-ess_implies_per_order_bound",
+    "id": "erdos-1159-implication",
     "proofId": "erdos-1159",
+    "type": "result",
     "range": {
-      "startLine": 129,
+      "startLine": 126,
       "endLine": 137
     },
-    "type": "theorem",
-    "title": "Ess Implies Per Order Bound",
-    "content": "theorem ess_implies_per_order_bound",
-    "significance": "key"
+    "title": "ESS Implies Per-Order Bound",
+    "content": "Proves ESS implies per-order bounds: for each plane, exists C(n) and a C(n)-bounded blocking set. The open question is uniformity across all n.",
+    "mathContext": "ESS $\\implies$ per-order $C(n) = 3(\\log_2 n + 1)$. Conjecture: $C$ independent of $n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "uniform vs non-uniform bounds",
+      "quantifier order"
+    ],
+    "prerequisites": [
+      "ESS theorem"
+    ]
+  },
+  {
+    "id": "erdos-1159-related",
+    "proofId": "erdos-1159",
+    "type": "context",
+    "range": {
+      "startLine": 139,
+      "endLine": 145
+    },
+    "title": "Related Problems",
+    "content": "Problem 664 extends this to all pairwise balanced block designs. Projective planes are (n^2+n+1, n+1, 1)-designs; the general case is less regular.",
+    "mathContext": "Projective planes are $(n^2+n+1, n+1, 1)$-designs. Problem 664: bounded blocking in general $(v, k, \\lambda)$-designs.",
+    "significance": "context",
+    "relatedConcepts": [
+      "block designs",
+      "Steiner systems",
+      "Erdos Problem 664"
+    ],
+    "prerequisites": [
+      "combinatorial design theory"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-1159/meta.json
+++ b/src/data/proofs/erdos-1159/meta.json
@@ -1,70 +1,122 @@
 {
   "id": "erdos-1159",
-  "title": "Erdős Problem #1159: Bounded Blocking Sets in Projective Planes",
+  "title": "Erdos Problem #1159: Bounded Blocking Sets in Projective Planes",
   "slug": "erdos-1159",
-  "description": "Does there exist a constant C > 1 such that for any finite projective plane P,",
+  "description": "Does there exist an absolute constant C such that every finite projective plane has a blocking set meeting every line in at most C points?",
   "meta": {
-    "author": "Erdős",
+    "author": "Erdos",
     "sourceUrl": "https://erdosproblems.com/1159",
-    "status": "complete",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1159Problem.lean",
     "tags": [
       "erdos",
       "combinatorics",
-      "graph-theory",
-      "probability",
-      "geometry",
-      "hypergraph",
+      "finite-geometry",
+      "projective-planes",
+      "blocking-sets",
       "open"
     ],
     "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1159,
     "erdosUrl": "https://erdosproblems.com/1159",
-    "erdosProblemStatus": "open",
-    "mathlib_version": "4.15.0",
-    "mathlibDependencies": [],
-    "originalContributions": [
-      "IsBlockingSet",
-      "blocking_set_mono",
-      "empty_not_blocking_set",
-      "pointCount_eq",
-      "lineCount_eq",
-      "card_points",
-      "card_lines",
-      "ess_log_blocking_set",
-      "BoundedBlockingSetConjecture",
-      "ess_implies_per_order_bound"
-    ]
+    "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős Problem #1159 concerns bounded blocking sets in projective planes. This problem remains OPEN.\n\nKnown results include: - Erdős, Silverman, and Stein (1983) proved there exists a blocking set S - The open question is whether O(log n) can be replaced by an absolute - Erdős (1981), original formulation - Erdős, Silverman, and Stein (1983)\n\nThis problem is catalogued at erdosproblems.com/1159.",
-    "problemStatement": "Does there exist a constant C > 1 such that for any finite projective plane P,",
-    "proofStrategy": "The formalization is structured in 145 lines of Lean 4 code. It uses 1 axiom for results that require external references or deep mathematical arguments beyond Mathlib. The main conjecture is stated as an axiom since it is an open problem.",
+    "historicalContext": "This problem was formulated by Erdos in 1981 and connects to fundamental questions in finite geometry. A blocking set in a projective plane is a set of points that intersects every line. Trivially, any line is a blocking set, but with n+1 points per line intersection. The question is whether one can find blocking sets with uniformly bounded line intersections. Erdos, Silverman, and Stein (1983) proved that every projective plane of order n admits a blocking set meeting each line in at most O(log n) points, using the probabilistic method: include each point independently with probability c*log(n)/n. The open question is whether the logarithmic dependence on n can be eliminated entirely, replaced by an absolute constant C independent of the plane's order. This connects to deep questions about the structure of non-Desarguesian planes and whether 'exotic' projective planes might force large intersections. Problem 664 extends this to general block designs.",
+    "problemStatement": "Does there exist a constant $C > 1$ such that for any finite projective plane $\\Pi$ of order $n$, one can find a set of points $S$ where each line $\\ell$ intersects $S$ in at least 1 but at most $C$ points?",
+    "proofStrategy": "The formalization defines IsBlockingSet generically for any incidence structure, proves monotonicity and non-triviality, then specializes to projective planes using Mathlib's ProjectivePlane typeclass. The ESS theorem (O(log n) bounded blocking sets exist) is axiomatized. The main conjecture BoundedBlockingSetConjecture asks for the quantifier order swap: existence of a universal C before quantifying over all planes. The theorem ess_implies_per_order_bound demonstrates the logical gap between the known result and the conjecture.",
     "keyInsights": [
-      "**A set of points S is a blocking set if every line contains at least one point of S.**: A set of points S is a blocking set if every line contains at least one point of S.",
-      "**If S is a blocking set and S ⊆ T, then T is also a blocking set.**: If S is a blocking set and S ⊆ T, then T is also a blocking set.",
-      "**The empty set is not a blocking set in any nontrivial configuration.**: The empty set is not a blocking set in any nontrivial configuration.",
-      "**In a projective plane, every line has exactly order + 1 points.**: In a projective plane, every line has exactly order + 1 points.",
-      "**In a projective plane, every point lies on exactly order + 1 lines.**: In a projective plane, every point lies on exactly order + 1 lines."
+      "The conjecture reduces to a quantifier order question: ESS gives 'for all n, exists C(n)' while the conjecture asks 'exists C, for all n' -- the difference between non-uniform and uniform bounds",
+      "The probabilistic method gives O(log n) because the union bound over n^2+n+1 lines introduces a log factor; eliminating this would require structural arguments beyond probabilistic methods",
+      "Blocking sets in projective planes have a beautiful duality with external sets (sets missing every line), and the minimum blocking set size is known to be n+1 (a line) but the bounded intersection constraint is orthogonal to minimality",
+      "The Fano plane (order 2) trivially has bounded blocking sets since every line has only 3 points, so any blocking set meets each line in at most 3 points -- the difficulty arises for large orders",
+      "Non-Desarguesian planes (which exist for all prime-power orders > 8) might behave differently from Desarguesian planes PG(2,q), making the 'for all planes' quantifier essential"
     ]
   },
   "sections": [
     {
-      "id": "formalization",
-      "title": "Formalization",
-      "summary": "Complete formalization of Erdős Problem #1159",
+      "id": "imports",
+      "title": "Imports and Setup",
       "startLine": 1,
-      "endLine": 145
+      "endLine": 38,
+      "summary": "Header documentation with problem statement, ESS background, and references. Imports Mathlib and opens Configuration namespace for ProjectivePlane."
+    },
+    {
+      "id": "blocking-set-def",
+      "title": "Blocking Set Definition",
+      "startLine": 40,
+      "endLine": 44,
+      "summary": "Defines IsBlockingSet S as the property that every line contains at least one point of S, generic over any incidence structure."
+    },
+    {
+      "id": "basic-properties",
+      "title": "Basic Properties",
+      "startLine": 46,
+      "endLine": 61,
+      "summary": "Proves monotonicity (supersets of blocking sets are blocking) and non-triviality (empty set is never blocking)."
+    },
+    {
+      "id": "projective-plane",
+      "title": "Projective Plane Structure",
+      "startLine": 63,
+      "endLine": 87,
+      "summary": "Extracts n+1 points per line, n+1 lines per point, and n^2+n+1 total points/lines from Mathlib's ProjectivePlane."
+    },
+    {
+      "id": "ess-theorem",
+      "title": "ESS Theorem (1983)",
+      "startLine": 89,
+      "endLine": 105,
+      "summary": "Axiomatizes the Erdos-Silverman-Stein result: O(log n)-bounded blocking sets exist in any plane of order n."
+    },
+    {
+      "id": "main-conjecture",
+      "title": "The Open Conjecture",
+      "startLine": 107,
+      "endLine": 124,
+      "summary": "Defines BoundedBlockingSetConjecture: exists an absolute constant C such that every plane has a C-bounded blocking set."
+    },
+    {
+      "id": "implication",
+      "title": "ESS Implication",
+      "startLine": 126,
+      "endLine": 137,
+      "summary": "Proves ESS implies per-order bounds, highlighting the gap between non-uniform (known) and uniform (conjectured) bounds."
+    },
+    {
+      "id": "related",
+      "title": "Related Problems",
+      "startLine": 139,
+      "endLine": 145,
+      "summary": "Notes connection to Problem 664 (bounded blocking sets in general block designs)."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1159 (Bounded Blocking Sets in Projective Planes) in Lean 4, including core definitions, key structural results, and the open conjecture stated as an axiom.",
-    "implications": "The formalization demonstrates how open problems in combinatorics and number theory can be rigorously expressed in Lean 4.",
+    "summary": "This formalization captures Erdos Problem 1159 using Mathlib's ProjectivePlane typeclass: the blocking set definition, its basic lattice properties, the projective plane counting results, the ESS O(log n) theorem, and the main conjecture asking for a uniform constant. The logical gap between the known non-uniform bound and the conjectured uniform bound is made explicit.",
+    "implications": "A positive resolution would reveal deep structural uniformity in projective planes -- that despite the diversity of plane constructions (Desarguesian, Hall, Hughes, and other exotic types), they all admit bounded blocking sets. A negative resolution would identify a family of planes where large-order structure forces growing intersection sizes, with implications for combinatorial design theory and coding theory.",
     "openQuestions": [
-      "Resolve the conjecture",
-      "Fill in sorry placeholders with complete proofs",
-      "Strengthen connections to other Erdős problems"
+      "Does there exist an absolute constant C such that every projective plane has a C-bounded blocking set?",
+      "Can the ESS O(log n) bound be improved for Desarguesian planes PG(2,q)? The algebraic structure might allow better constructions",
+      "What is the relationship between the minimum blocking set size (n + sqrt(n) + 1 for PG(2,q)) and the bounded intersection property?",
+      "Does the answer change for non-Desarguesian planes? Exotic planes might have structural obstructions to bounded blocking sets"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-664",
+      "relationship": "strengthens",
+      "description": "Problem 664 generalizes to all pairwise balanced block designs, not just projective planes"
+    },
+    {
+      "targetId": "erdos-1104",
+      "relationship": "related",
+      "description": "Both use the probabilistic method as the primary tool and ask whether probabilistic bounds can be improved to constants"
+    },
+    {
+      "targetId": "fano-plane",
+      "relationship": "foundation",
+      "description": "The Fano plane (order 2, the smallest projective plane) is a trivial case where C = 3 suffices"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Enriched erdos-1141 meta.json with deeper historicalContext, keyInsights, expanded sections, cross-references
- Enriched erdos-1157 annotations.json (17→11) and meta.json: BES conjecture context, 10 sections, 6 cross-references
- Enriched erdos-1144 annotations.json (14→7) and meta.json: random multiplicative functions, Atherfold bound, 7 sections, 5 cross-references

## Test plan
- [x] JSON validation passed
- [x] Commits verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)