### PR TITLE
fix: include Lean project files in Aristotle preprocessing temp dirs

### DIFF
--- a/scripts/aristotle/preprocess-for-aristotle.sh
+++ b/scripts/aristotle/preprocess-for-aristotle.sh
@@ -22,6 +22,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
 if [[ $# -lt 1 ]]; then
     echo "Usage: $0 <lean-file>" >&2
     exit 1
@@ -63,6 +66,10 @@ fi
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/aristotle-preprocess-XXXXXX")
 tmp_file="$tmp_dir/$(basename "$INPUT_FILE")"
 cp "$INPUT_FILE" "$tmp_file"
+
+# Copy Lean project files so aristotlelib recognizes it as a valid project
+cp "$PROJECT_ROOT/proofs/lakefile.toml" "$tmp_dir/"
+cp "$PROJECT_ROOT/proofs/lean-toolchain" "$tmp_dir/"
 
 changes_made=0
 


### PR DESCRIPTION
## Summary

- Copies `lakefile.toml` and `lean-toolchain` into the temp directory created by `preprocess-for-aristotle.sh`, so aristotlelib recognizes it as a valid Lean project
- Derives `PROJECT_ROOT` from the script's location, consistent with `submit-batch.sh`

Closes #2393

## Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Preprocessed files include lakefile.toml and lean-toolchain | Verified | `ls` of temp dir shows both files alongside .lean |
| Files needing no preprocessing still work | Verified | Tested with Erdos1005ProblemProvable.lean |
| Definition sorry rejection still works | Verified | Synthetic test file correctly rejected |
| Temp directory cleanup still works | Verified | `submit-batch.sh` uses `rm -rf "$(dirname ...)"` which removes entire temp dir |

## Test plan

- [x] Run preprocessing on axiom-heavy file (Erdos1001Problem.lean) - temp dir contains lakefile.toml and lean-toolchain
- [x] Regression: file with no axioms (Erdos1005ProblemProvable.lean) still works and includes project files
- [x] Rejection: file with definition sorries still correctly rejected
- [x] Bash syntax validation passes (`bash -n`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)