### PR TITLE
Enrich erdos-127: bipartite subgraphs beyond Edwards' bound

### DIFF
--- a/src/data/proofs/erdos-127/annotations.json
+++ b/src/data/proofs/erdos-127/annotations.json
@@ -1,56 +1,98 @@
 [
   {
+    "id": "erdos-127-bipartite",
+    "proofId": "erdos-127",
+    "type": "definition",
+    "range": { "startLine": 28, "endLine": 30 },
+    "title": "Maximum Bipartite Subgraph",
+    "content": "Axiomatizes `maxBipartiteEdges`, the maximum number of edges in a bipartite subgraph of a simple graph. This is the key quantity that Edwards' bound lower-bounds.",
+    "mathContext": "Finding the maximum bipartite subgraph (MAX-CUT) is NP-hard in general. Edwards' result gives a deterministic lower bound that beats the trivial $m/2$ by a term of order $\\sqrt{m}$. The probabilistic argument (random partition) gives $m/2$ in expectation, but Edwards' greedy algorithm does better.",
+    "significance": "critical",
+    "relatedConcepts": ["MAX-CUT", "bipartite graphs", "graph partitioning", "NP-hardness"],
+    "prerequisites": ["SimpleGraph", "Fintype", "bipartite graph definition"]
+  },
+  {
     "id": "erdos-127-edwards",
     "proofId": "erdos-127",
     "type": "definition",
     "range": { "startLine": 32, "endLine": 34 },
     "title": "Edwards' Bound",
-    "content": "edwardsBound(m) = m/2 + (√(8m+1) - 1)/8. Every graph with m edges has a bipartite subgraph with at least this many edges (Edwards 1973).",
-    "significance": "essential"
+    "content": "The Edwards bound formula: $\\text{edwardsBound}(m) = m/2 + (\\sqrt{8m+1} - 1)/8$. Every graph with $m$ edges has a bipartite subgraph with at least this many edges.",
+    "mathContext": "Edwards' 1973 proof uses a greedy vertex-by-vertex algorithm: at each step, place the next vertex on the side that maximizes the cut. This yields the $m/2 + \\Theta(\\sqrt{m})$ bound. The exact formula $m/2 + (\\sqrt{8m+1}-1)/8$ is tight for complete graphs $K_n$ where $m = \\binom{n}{2}$ and the maximum cut has $\\lfloor n^2/4 \\rfloor$ edges.",
+    "significance": "critical",
+    "relatedConcepts": ["greedy algorithms", "graph cuts", "extremal graph theory"],
+    "prerequisites": ["Real.sqrt", "graph edge counting"]
   },
   {
     "id": "erdos-127-excess",
     "proofId": "erdos-127",
     "type": "definition",
     "range": { "startLine": 40, "endLine": 45 },
-    "title": "Excess Function f(m)",
-    "content": "excessF(m) measures how much better than Edwards' bound one can guarantee. f(m) ≥ 0 always holds.",
-    "significance": "essential"
+    "title": "Excess Function $f(m)$",
+    "content": "The excess function $f(m) \\ge 0$ measures the improvement over Edwards' bound: every graph with $m$ edges has a bipartite subgraph with at least $\\text{edwardsBound}(m) + f(m)$ edges. Axiomatized with nonnegativity.",
+    "mathContext": "The function $f(m)$ captures how far Edwards' bound is from optimal for a given $m$. Since complete graphs achieve the bound exactly, $f(\\binom{n}{2}) = 0$ for all $n$. The interesting question is whether $f$ can grow without bound between these zeros — i.e., whether non-complete graphs systematically admit larger cuts than Edwards predicts.",
+    "significance": "critical",
+    "relatedConcepts": ["extremal functions", "graph theory excess", "optimization gap"],
+    "prerequisites": ["Edwards' bound", "bipartite subgraph guarantees"]
   },
   {
     "id": "erdos-127-tight",
     "proofId": "erdos-127",
-    "type": "result",
+    "type": "insight",
     "range": { "startLine": 51, "endLine": 54 },
     "title": "Tightness at Complete Graphs",
-    "content": "f(C(n,2)) = 0: complete graphs show Edwards' bound is tight at triangular numbers.",
-    "significance": "supporting"
+    "content": "For complete graphs $K_n$ with $m = \\binom{n}{2}$ edges, Edwards' bound is exactly tight: $f(\\binom{n}{2}) = 0$. The maximum cut of $K_n$ is $\\lfloor n^2/4 \\rfloor = \\text{edwardsBound}(\\binom{n}{2})$.",
+    "mathContext": "The maximum cut of $K_n$ places $\\lfloor n/2 \\rfloor$ and $\\lceil n/2 \\rceil$ vertices on each side, giving $\\lfloor n/2 \\rfloor \\cdot \\lceil n/2 \\rceil = \\lfloor n^2/4 \\rfloor$ edges. Substituting $m = n(n-1)/2$ into Edwards' formula gives exactly $\\lfloor n^2/4 \\rfloor$, proving tightness. The zeros of $f$ at triangular numbers $\\binom{n}{2}$ constrain $f$'s growth.",
+    "significance": "key",
+    "relatedConcepts": ["complete graphs", "maximum cut", "extremal examples", "Turán's theorem"],
+    "prerequisites": ["Nat.choose", "graph cuts of complete graphs"]
   },
   {
     "id": "erdos-127-conjecture",
     "proofId": "erdos-127",
     "type": "conjecture",
     "range": { "startLine": 60, "endLine": 64 },
-    "title": "Erdős Problem 127",
-    "content": "Is there an infinite sequence mᵢ with f(mᵢ) → ∞? Solved affirmatively by Alon (1996).",
-    "significance": "essential"
+    "title": "Erdős Problem 127 (Solved)",
+    "content": "Is there an infinite strictly monotone sequence $m_i$ with $f(m_i) \\to \\infty$? Formalized using `StrictMono` and `Filter.Tendsto` to $\\top$. Solved: YES by Alon (1996).",
+    "mathContext": "Since $f(\\binom{n}{2}) = 0$ for all $n$, the excess function has infinitely many zeros. The question asks whether it also has arbitrarily large values. This is equivalent to asking: is Edwards' bound asymptotically suboptimal for 'generic' edge counts, even though it is tight at triangular numbers?",
+    "significance": "critical",
+    "relatedConcepts": ["StrictMono", "Filter.Tendsto", "divergent sequences"],
+    "prerequisites": ["filter theory", "sequences", "convergence"]
   },
   {
     "id": "erdos-127-alon-lower",
     "proofId": "erdos-127",
-    "type": "result",
-    "range": { "startLine": 66, "endLine": 69 },
+    "type": "technique",
+    "range": { "startLine": 66, "endLine": 73 },
     "title": "Alon's Lower Bound",
-    "content": "Alon (1996) proved f(n²/2) ≫ n^{1/2}, establishing that the excess grows at least like √n along the sequence m = n²/2.",
-    "significance": "essential"
+    "content": "Alon (1996) proved $f(n^2/2) \\ge c\\sqrt{n}$ for an absolute constant $c > 0$. Taking $m_i = i^2/2$ gives a sequence with $f(m_i) \\to \\infty$, solving the conjecture.",
+    "mathContext": "Alon's proof uses the probabilistic method and semidefinite programming relaxations. The key insight is that at $m = n^2/2$ (midway between consecutive triangular numbers $\\binom{n}{2}$ and $\\binom{n+1}{2}$), graphs are far from complete, and one can exploit this structural gap to find larger cuts. The $\\sqrt{n}$ growth matches the spacing between triangular numbers.",
+    "significance": "critical",
+    "relatedConcepts": ["probabilistic method", "semidefinite programming", "random graphs"],
+    "prerequisites": ["probabilistic combinatorics", "algebraic graph theory"]
   },
   {
     "id": "erdos-127-alon-upper",
     "proofId": "erdos-127",
-    "type": "result",
-    "range": { "startLine": 79, "endLine": 82 },
-    "title": "Alon's Upper Bound",
-    "content": "f(m) ≪ m^{1/4} for all m. The optimal constant remains unknown.",
-    "significance": "supporting"
+    "type": "technique",
+    "range": { "startLine": 79, "endLine": 88 },
+    "title": "Alon's Upper Bound and Optimal Constant",
+    "content": "Alon also proved $f(m) \\le C \\cdot m^{1/4}$ for all $m$, and `OptimalConstantQuestion` asks for the exact value of the optimal $C$. This constrains $f$'s growth to be at most $m^{1/4}$.",
+    "mathContext": "The upper bound $f(m) = O(m^{1/4})$ means the excess is always subpolynomial relative to $m$. At $m = n^2/2$, the bounds give $c\\sqrt{n} \\le f(m) \\le C \\cdot (n^2/2)^{1/4} \\approx C' \\cdot \\sqrt{n}$, so both bounds are $\\Theta(\\sqrt{n})$ — Alon's result is essentially sharp at these values.",
+    "significance": "key",
+    "relatedConcepts": ["upper bounds", "optimal constants", "extremal graph theory"],
+    "prerequisites": ["asymptotic analysis", "polynomial growth rates"]
+  },
+  {
+    "id": "erdos-127-structural",
+    "proofId": "erdos-127",
+    "type": "context",
+    "range": { "startLine": 94, "endLine": 102 },
+    "title": "Structural Properties",
+    "content": "Two structural facts: (1) bounded variation — $f(m_2) \\le f(m_1) + (m_2 - m_1)$ for $m_1 \\le m_2$, and (2) proximity to complete graphs — every $m$ is within $\\sqrt{m}$ of some $\\binom{n}{2}$ where $f = 0$. Together these constrain $f$'s oscillation between its zeros.",
+    "mathContext": "The bounded variation property follows because adding one edge to a graph can increase the maximum cut by at most 1. The proximity result uses $\\binom{n}{2} \\approx n^2/2$, so consecutive triangular numbers differ by $n$, and every $m$ is within $n/2 \\le \\sqrt{m}$ of one. Combined with $f = 0$ at triangular numbers, this gives $f(m) \\le \\sqrt{m}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["bounded variation", "triangular numbers", "Lipschitz functions"],
+    "prerequisites": ["Nat.choose", "integer approximation"]
   }
 ]

--- a/src/data/proofs/erdos-127/meta.json
+++ b/src/data/proofs/erdos-127/meta.json
@@ -21,67 +21,76 @@
     "erdosProblemStatus": "proved"
   },
   "overview": {
-    "historicalContext": "Edwards (1973) proved that every graph with m edges contains a bipartite subgraph with at least m/2 + (√(8m+1) - 1)/8 edges, and that this is tight for complete graphs. Erdős, Kohayakawa, and Gyárfás asked whether the excess f(m) beyond this bound tends to infinity along some subsequence. Alon (1996) solved this affirmatively.",
-    "problemStatement": "Let f(m) be the maximum value such that every graph with m edges contains a bipartite subgraph with at least m/2 + (√(8m+1) - 1)/8 + f(m) edges. Is there an infinite sequence mᵢ with f(mᵢ) → ∞?",
-    "proofStrategy": "We axiomatize maxBipartiteEdges and excessF, define edwardsBound as the Edwards formula. ErdosProblem127 asks for a subsequence with divergent excess. Alon's lower bound f(n²/2) ≫ √n and upper bound f(m) ≪ m^{1/4} are both axiomatized. Complete graph tightness f(C(n,2)) = 0 is included.",
+    "historicalContext": "Edwards (1973) proved a foundational result in extremal graph theory: every graph with $m$ edges contains a bipartite subgraph with at least $m/2 + (\\sqrt{8m+1} - 1)/8$ edges. His proof uses a simple but elegant greedy algorithm — assign each vertex to the side that maximizes the cut. The bound beats the trivial $m/2$ (from random partition) by $\\Theta(\\sqrt{m})$, and is tight for complete graphs $K_n$.\n\nErdős, Kohayakawa, and Gyárfás then asked a subtle question: is the Edwards bound tight for *all* values of $m$, or only at the triangular numbers $\\binom{n}{2}$? Formally, if $f(m)$ denotes the excess above Edwards' bound, is $f$ bounded or can it grow without limit?\n\nAlon (1996) resolved this by proving $f(n^2/2) \\ge c\\sqrt{n}$, showing that midway between consecutive triangular numbers, Edwards' bound can be substantially improved. He also proved $f(m) \\le C \\cdot m^{1/4}$, establishing that the excess grows at most like $m^{1/4}$. At $m = n^2/2$, both bounds give $\\Theta(\\sqrt{n})$, so the result is essentially sharp.",
+    "problemStatement": "Let $f(m)$ be the maximum value such that every graph with $m$ edges contains a bipartite subgraph with at least $m/2 + (\\sqrt{8m+1} - 1)/8 + f(m)$ edges. Is there an infinite sequence $m_i$ with $f(m_i) \\to \\infty$?",
+    "proofStrategy": "The formalization axiomatizes `maxBipartiteEdges` and `excessF`, defines `edwardsBound` as the explicit formula $m/2 + (\\sqrt{8m+1}-1)/8$, and states the conjecture `ErdosProblem127` using `StrictMono` and `Filter.Tendsto`. Alon's lower bound $f(n^2/2) \\ge c\\sqrt{n}$, his upper bound $f(m) \\le C \\cdot m^{1/4}$, and the complete graph tightness $f(\\binom{n}{2}) = 0$ are all axiomatized. Structural properties (bounded variation, proximity to complete graph numbers) are included.",
     "keyInsights": [
-      "Edwards' bound m/2 + (√(8m+1)-1)/8 is the baseline for bipartite subgraph guarantees",
-      "Complete graphs K_n show tightness: f(C(n,2)) = 0",
-      "Alon proved f(n²/2) ≫ n^{1/2}, answering the conjecture affirmatively",
-      "The upper bound f(m) ≪ m^{1/4} constrains how fast f can grow"
+      "Edwards' bound $m/2 + \\Theta(\\sqrt{m})$ is tight at triangular numbers $\\binom{n}{2}$ (complete graphs), where the maximum cut of $K_n$ is exactly $\\lfloor n^2/4 \\rfloor$",
+      "Alon's $f(n^2/2) \\ge c\\sqrt{n}$ shows that midway between triangular numbers, graphs admit significantly larger cuts than Edwards predicts",
+      "The upper bound $f(m) = O(m^{1/4})$ and lower bound $f(n^2/2) = \\Omega(\\sqrt{n})$ match at $m = n^2/2$, giving $f = \\Theta(\\sqrt{n})$ there",
+      "The excess function $f$ oscillates: it equals 0 at triangular numbers and grows to $\\Theta(\\sqrt{n})$ between them, constrained by 1-Lipschitz behavior (adding one edge changes the cut by at most 1)",
+      "Alon's proof uses the probabilistic method and connections to semidefinite programming — the same tools that later led to the Goemans–Williamson MAX-CUT algorithm"
     ]
   },
   "sections": [
+    {
+      "id": "imports",
+      "title": "Imports",
+      "startLine": 16,
+      "endLine": 22,
+      "summary": "Imports SimpleGraph, Real, Sqrt, Filter, and Tactic from Mathlib."
+    },
     {
       "id": "bipartite-size",
       "title": "Bipartite Subgraph Size",
       "startLine": 24,
       "endLine": 34,
-      "summary": "Axiomatizes maxBipartiteEdges and defines the Edwards bound formula."
+      "summary": "Axiomatizes `maxBipartiteEdges` and defines the Edwards bound formula."
     },
     {
       "id": "excess-function",
       "title": "The Excess Function",
       "startLine": 36,
       "endLine": 45,
-      "summary": "Axiomatizes excessF and the Edwards bound validity (f(m) ≥ 0)."
+      "summary": "Axiomatizes `excessF` and the Edwards bound validity ($f(m) \\ge 0$)."
     },
     {
       "id": "complete-graph",
       "title": "Complete Graph Tightness",
       "startLine": 47,
       "endLine": 54,
-      "summary": "For complete graphs K_n, the Edwards bound is tight: f(C(n,2)) = 0."
+      "summary": "For complete graphs $K_n$, the Edwards bound is tight: $f(\\binom{n}{2}) = 0$."
     },
     {
       "id": "conjecture",
-      "title": "The Conjecture (Solved)",
+      "title": "The Conjecture and Alon's Solution",
       "startLine": 56,
       "endLine": 73,
-      "summary": "States ErdosProblem127 and Alon's affirmative solution with f(n²/2) ≫ √n."
+      "summary": "States `ErdosProblem127` and Alon's affirmative solution via $f(n^2/2) \\ge c\\sqrt{n}$."
     },
     {
       "id": "upper-bound",
-      "title": "Upper Bound",
+      "title": "Upper Bound and Optimal Constant",
       "startLine": 75,
       "endLine": 88,
-      "summary": "Alon's upper bound f(m) ≪ m^{1/4} and the open question of the optimal constant."
+      "summary": "Alon's upper bound $f(m) \\le C \\cdot m^{1/4}$ and the question of optimal $C$."
     },
     {
       "id": "structural",
       "title": "Structural Properties",
       "startLine": 90,
       "endLine": 102,
-      "summary": "Bounded variation of f and proximity of every m to a complete graph number."
+      "summary": "Bounded variation of $f$ and proximity of every $m$ to a triangular number."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 127 asked whether the excess f(m) beyond Edwards' bipartite subgraph bound diverges along a subsequence. Alon (1996) proved f(n²/2) ≫ √n, resolving the conjecture affirmatively. The upper bound f(m) ≪ m^{1/4} is also established.",
-    "implications": "The result shows Edwards' bound is not universally tight, with systematic improvements possible for non-complete-graph edge counts.",
+    "summary": "Erdős Problem 127 is SOLVED: the excess $f(m)$ beyond Edwards' bipartite subgraph bound diverges along the sequence $m = n^2/2$, where $f \\ge c\\sqrt{n}$ (Alon 1996). The upper bound $f(m) = O(m^{1/4})$ shows the excess grows slowly. The formalization captures both bounds, the complete graph tightness, and structural properties of $f$.",
+    "implications": "The result reveals that Edwards' bound, while tight for complete graphs, is systematically suboptimal for other graph densities. This connects to the broader MAX-CUT problem in computer science: Alon's probabilistic methods prefigured the semidefinite programming approach of Goemans and Williamson (1995), which achieves a 0.878-approximation for MAX-CUT. Understanding the excess function helps quantify the gap between extremal bounds and algorithmic guarantees.",
     "openQuestions": [
-      "What is the optimal constant C in f(m) ≤ C·m^{1/4}?",
-      "Can the lower bound f(n²/2) ≫ √n be improved?",
-      "What is the exact growth rate of max_m≤M f(m)?"
+      "What is the optimal constant $C$ in $f(m) \\le C \\cdot m^{1/4}$?",
+      "Can the lower bound $f(n^2/2) \\ge c\\sqrt{n}$ be improved, or is it tight?",
+      "What is the exact growth rate of $\\max_{m \\le M} f(m)$ as $M \\to \\infty$?",
+      "For which graph families (beyond complete graphs) is Edwards' bound tight?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Added `mathContext`, `relatedConcepts`, and `prerequisites` to all 8 annotations
- Added 2 new annotations for `maxBipartiteEdges` and structural properties
- Fixed non-standard significance values
- Expanded `historicalContext` to 3 paragraphs: Edwards (1973), Erdős question, Alon (1996)
- Deepened `keyInsights` to 5 entries including MAX-CUT/Goemans-Williamson connections
- Expanded `conclusion` with algorithmic implications and 4 open questions
- 7 sections covering the full 102-line Lean file

## Test plan
- [x] `pnpm build` passes (no erdos-127 errors)
- [x] JSON validates correctly
- [x] All annotation line ranges match actual Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)