### PR TITLE
enrich(erdos-125, erdos-128, erdos-14): sumsets, dense subgraphs, unique sums

### DIFF
--- a/src/data/proofs/erdos-125/annotations.json
+++ b/src/data/proofs/erdos-125/annotations.json
@@ -1,56 +1,158 @@
 [
   {
+    "id": "ann-e125-header",
+    "proofId": "erdos-125",
+    "range": { "startLine": 1, "endLine": 15 },
+    "type": "context",
+    "title": "Problem Overview and Known Results",
+    "content": "Header documenting Erdős Problem #125 on digit-restricted sumsets. The problem asks whether the sumset of numbers with only 0,1 digits in base 3 and base 4 has positive density. Burr, Erdős, Graham, and Li posed this in 1996. Melfi (2001) proved the counting function grows as $x^{0.965}$; Hasler and Melfi (2024) improved this to $x^{0.9777}$ and showed the upper density is at most 0.696.",
+    "mathContext": "Let $A = \\{\\sum \\varepsilon_k 3^k : \\varepsilon_k \\in \\{0,1\\}\\}$ and $B = \\{\\sum \\varepsilon_k 4^k : \\varepsilon_k \\in \\{0,1\\}\\}$. Does $C = A + B$ satisfy $\\underline{d}(C) = \\liminf_{x \\to \\infty} |C \\cap [1,x]|/x > 0$? Known: $|C \\cap [1,x]| \\gg x^{0.9777}$ and $\\overline{d}(C) \\leq 0.696$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "natural density",
+      "Cantor set integers",
+      "digit restrictions",
+      "additive combinatorics"
+    ],
+    "prerequisites": [
+      "asymptotic density",
+      "base representations",
+      "sumsets"
+    ]
+  },
+  {
+    "id": "ann-e125-imports",
+    "proofId": "erdos-125",
+    "range": { "startLine": 17, "endLine": 23 },
+    "type": "context",
+    "title": "Imports",
+    "content": "Imports Mathlib's digit representation (`Nat.digits`), basic natural number and real number infrastructure, `Finset` for counting, and `Filter` for asymptotic statements.",
+    "mathContext": "Uses `Nat.digits b n` which returns the list of base-$b$ digits of $n$, enabling the definition of digit-restricted sets via list membership conditions.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Nat.digits",
+      "Finset.filter"
+    ],
+    "prerequisites": [
+      "Mathlib.Data.Nat.Digits"
+    ]
+  },
+  {
     "id": "erdos-125-digits",
     "proofId": "erdos-125",
+    "range": { "startLine": 24, "endLine": 38 },
     "type": "definition",
-    "range": { "startLine": 28, "endLine": 38 },
-    "title": "Digit-Restricted Sets",
-    "content": "digitSet b is the set of natural numbers with only digits 0,1 in base b. setA = digitSet 3 and setB = digitSet 4 are the specific sets in the problem.",
-    "significance": "essential"
+    "title": "Digit-Restricted Sets (Cantor Set Integers)",
+    "content": "Defines `digitSet b` as the set of natural numbers whose base-$b$ representation uses only the digits 0 and 1. These are exactly the sums of distinct powers of $b$, forming the integer analogue of the Cantor set. `setA = digitSet 3` (Cantor set integers in base 3) and `setB = digitSet 4` (Cantor set integers in base 4) are the specific sets in the problem.",
+    "mathContext": "$\\text{digitSet}(b) = \\{n \\in \\mathbb{N} : \\text{every digit of } n \\text{ in base } b \\text{ is 0 or 1}\\} = \\{\\sum_{k} \\varepsilon_k b^k : \\varepsilon_k \\in \\{0,1\\}\\}$. The set $A = \\text{digitSet}(3)$ has counting function $|A \\cap [0,x]| \\sim x^{\\log_3 2} \\approx x^{0.631}$, and $|B \\cap [0,x]| \\sim x^{\\log_4 2} = x^{0.5}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Cantor set",
+      "base representations",
+      "sums of distinct powers",
+      "fractal dimension"
+    ],
+    "prerequisites": [
+      "Nat.digits",
+      "base-b representation"
+    ]
   },
   {
     "id": "erdos-125-sumset",
     "proofId": "erdos-125",
+    "range": { "startLine": 40, "endLine": 49 },
     "type": "definition",
-    "range": { "startLine": 44, "endLine": 49 },
-    "title": "The Sumset C = A + B",
-    "content": "setC = A + B is the sumset. countingC x = |C ∩ [0, x]| counts elements up to x.",
-    "significance": "essential"
+    "title": "The Sumset $C = A + B$",
+    "content": "Defines $C = A + B = \\{a + b : a \\in A,\\, b \\in B\\}$ as the Minkowski sum of the two digit-restricted sets. The counting function `countingC x` gives $|C \\cap [0, x]|$ using `Finset.filter`. Despite both $A$ and $B$ having density 0, their sumset $C$ could potentially have positive density because the two sets are 'independent' in a number-theoretic sense.",
+    "mathContext": "$C = A + B = \\{a + b : a \\in A,\\, b \\in B\\}$. Although $|A| \\sim x^{0.631}$ and $|B| \\sim x^{0.5}$, the number of distinct sums could be as large as $|A| \\cdot |B| \\sim x^{1.131}$, far exceeding $x$ — suggesting positive density is plausible.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Minkowski sum",
+      "sumset growth",
+      "additive combinatorics",
+      "counting function"
+    ],
+    "prerequisites": [
+      "Finset.filter",
+      "set membership"
+    ]
   },
   {
     "id": "erdos-125-conjecture",
     "proofId": "erdos-125",
-    "type": "conjecture",
-    "range": { "startLine": 55, "endLine": 60 },
-    "title": "Erdős Problem 125",
-    "content": "Does C = A + B have positive lower density? That is, is lim inf |C ∩ [1,x]|/x > 0?",
-    "significance": "essential"
+    "range": { "startLine": 51, "endLine": 60 },
+    "type": "concept",
+    "title": "Erdős Problem 125: Positive Lower Density",
+    "content": "The formal conjecture: there exists $\\delta > 0$ such that $\\liminf_{x \\to \\infty} |C \\cap [1,x]|/x \\geq \\delta$. The formalization uses an $\\varepsilon$-$\\delta$ characterization of $\\liminf > 0$: for every $\\varepsilon > 0$, the ratio $|C \\cap [1,x]|/x$ eventually exceeds $\\delta - \\varepsilon$.",
+    "mathContext": "$\\text{ErdosProblem125} \\iff \\exists \\delta > 0,\\, \\forall \\varepsilon > 0,\\, \\exists N_0,\\, \\forall x \\geq N_0,\\, |C \\cap [0,x]|/x \\geq \\delta - \\varepsilon$. This is equivalent to $\\underline{d}(C) > 0$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "lower asymptotic density",
+      "liminf",
+      "epsilon-delta characterization"
+    ],
+    "prerequisites": [
+      "asymptotic density",
+      "real analysis"
+    ]
   },
   {
     "id": "erdos-125-lower",
     "proofId": "erdos-125",
-    "type": "result",
-    "range": { "startLine": 66, "endLine": 74 },
-    "title": "Counting Lower Bounds",
-    "content": "Melfi (2001): |C ∩ [1,x]| ≫ x^{0.965}. Hasler–Melfi (2024): improved to x^{0.9777}. Nearly linear growth but not yet linear.",
-    "significance": "essential"
+    "range": { "startLine": 62, "endLine": 74 },
+    "type": "theorem",
+    "title": "Counting Lower Bounds (Melfi, Hasler-Melfi)",
+    "content": "Two progressively stronger lower bounds on $|C \\cap [1,x]|$. Melfi (2001) proved $|C \\cap [1,x]| \\geq cx^{0.965}$ for large $x$. Hasler and Melfi (2024) improved this to $cx^{0.9777}$. Both bounds are sub-linear (exponent $< 1$) so they do not directly prove positive density, but the exponent is tantalizingly close to 1.",
+    "mathContext": "Melfi: $\\exists c > 0,\\, |C \\cap [1,x]| \\geq c x^{0.965}$ for $x \\geq N_0$. Hasler-Melfi: $\\exists c > 0,\\, |C \\cap [1,x]| \\geq c x^{0.9777}$ for $x \\geq N_0$. Positive density requires exponent $= 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "counting functions",
+      "sub-linear growth",
+      "power-law bounds"
+    ],
+    "prerequisites": [
+      "asymptotic notation",
+      "Melfi 2001"
+    ]
   },
   {
     "id": "erdos-125-upper",
     "proofId": "erdos-125",
-    "type": "result",
-    "range": { "startLine": 80, "endLine": 84 },
-    "title": "Upper Density Bound",
-    "content": "Hasler–Melfi (2024): the upper density of C is at most ≈ 0.696, so C misses a positive fraction of ℕ.",
-    "significance": "essential"
+    "range": { "startLine": 76, "endLine": 84 },
+    "type": "theorem",
+    "title": "Upper Density Bound (Hasler-Melfi 2024)",
+    "content": "Hasler and Melfi (2024) showed the upper density of $C$ is at most approximately 0.696. This means $C$ must miss at least 30% of the natural numbers, even if it has positive lower density. The bound comes from analyzing the measure-theoretic properties of the digit-restricted sets.",
+    "mathContext": "$\\overline{d}(C) = \\limsup_{x \\to \\infty} |C \\cap [0,x]|/x \\leq 0.696 + \\varepsilon$ for any $\\varepsilon > 0$ and large enough $x$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "upper density",
+      "limsup density",
+      "density gap"
+    ],
+    "prerequisites": [
+      "upper asymptotic density",
+      "Hasler-Melfi 2024"
+    ]
   },
   {
     "id": "erdos-125-general",
     "proofId": "erdos-125",
-    "type": "context",
-    "range": { "startLine": 90, "endLine": 107 },
-    "title": "Generalization",
-    "content": "For bases n₁ < ⋯ < nₖ with Σ log_{nᵢ}(2) > 1, does the sumset of digit sets have positive density? For bases 3,4 the sum ≈ 1.131 > 1.",
-    "significance": "supporting"
+    "range": { "startLine": 86, "endLine": 107 },
+    "type": "concept",
+    "title": "Generalization to Multiple Bases",
+    "content": "The general question: for bases $n_1 < \\cdots < n_k$ with $\\sum_{i=1}^k \\log_{n_i}(2) > 1$, does $\\text{digitSet}(n_1) + \\cdots + \\text{digitSet}(n_k)$ have positive density? The log-sum condition ensures the combined 'fractal dimensions' exceed 1, making positive density plausible. For bases 3 and 4, $\\log_3(2) + \\log_4(2) \\approx 0.631 + 0.5 = 1.131 > 1$.",
+    "mathContext": "The condition $\\sum \\log_{n_i}(2) > 1$ means $\\sum \\dim_H(\\text{digitSet}(n_i)) > 1$, where $\\dim_H$ is the Hausdorff dimension of the corresponding Cantor set. For bases 3, 4: $\\frac{\\ln 2}{\\ln 3} + \\frac{\\ln 2}{\\ln 4} \\approx 1.131 > 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hausdorff dimension",
+      "Cantor sets",
+      "fractal dimension condition",
+      "Marstrand's theorem"
+    ],
+    "prerequisites": [
+      "Hausdorff dimension",
+      "Real.log",
+      "logarithm change of base"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -22,67 +22,83 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Burr, Erdős, Graham, and Li (1996) posed this question about digit-restricted sets. Melfi (2001) proved the counting function grows as x^{0.965}. Hasler and Melfi (2024) improved this to x^{0.9777} and showed the upper density is at most 0.696. The question of positive lower density remains open.",
-    "problemStatement": "Let A = {n ∈ ℕ : digits of n in base 3 are all 0 or 1} and B = {n ∈ ℕ : digits in base 4 are all 0 or 1}. Does A + B have positive lower density?",
-    "proofStrategy": "We define digitSet b (numbers with only 0,1 digits in base b), setA = digitSet 3, setB = digitSet 4, and setC = A + B. ErdosProblem125 asks if lim inf |C ∩ [1,x]|/x > 0. Melfi's and Hasler–Melfi's bounds are axiomatized. The generalization to multiple bases and the log-sum condition are stated.",
+    "historicalContext": "This problem originates in the study of sumsets of 'thin' structured sets. Burr, Erdős, Graham, and Li posed it in their 1996 paper 'On complete sequences of polynomial values', asking whether the sumset of integers with restricted digits in two different bases must have positive density. The sets $A = \\{\\sum \\varepsilon_k 3^k : \\varepsilon_k \\in \\{0,1\\}\\}$ and $B = \\{\\sum \\varepsilon_k 4^k : \\varepsilon_k \\in \\{0,1\\}\\}$ are 'Cantor set integers' — the integer analogues of the classical middle-thirds Cantor set and its base-4 counterpart. Each set is extremely sparse: $|A \\cap [0,x]| \\sim x^{\\log_3 2} \\approx x^{0.631}$ and $|B \\cap [0,x]| \\sim x^{\\log_4 2} = x^{0.5}$, both having density zero. Yet their arithmetic structure in different bases creates enough 'independence' that their sumset $C = A + B$ might have positive density.\n\nThe heuristic justification comes from fractal geometry: the Hausdorff dimensions satisfy $\\dim_H(A) + \\dim_H(B) = \\log_3 2 + \\log_4 2 \\approx 1.131 > 1$, and by analogy with Marstrand's projection theorem, sumsets of independent fractal sets whose dimensions exceed the ambient dimension tend to have positive measure.\n\nThe first quantitative progress came from Giuseppe Melfi in 2001, who proved $|C \\cap [1,x]| \\gg x^{0.965}$ — nearly linear growth but falling just short of establishing positive density (which requires linear growth with exponent exactly 1). Hasler and Melfi improved this in 2024 to $|C \\cap [1,x]| \\gg x^{0.9777}$, bringing the exponent tantalizingly close to 1, and also established the upper bound $\\overline{d}(C) \\leq 0.696$, showing that even if $C$ has positive density, it must miss at least 30% of the natural numbers.",
+    "problemStatement": "Let $A = \\{n \\in \\mathbb{N} : \\text{every digit of } n \\text{ in base 3 is 0 or 1}\\}$ and $B = \\{n \\in \\mathbb{N} : \\text{every digit of } n \\text{ in base 4 is 0 or 1}\\}$. Does $A + B$ have positive lower density, i.e., does $\\liminf_{x \\to \\infty} |A + B \\cap [1,x]|/x > 0$?",
+    "proofStrategy": "The formalization defines `digitSet b` via Mathlib's `Nat.digits` as the set of naturals whose base-$b$ representation uses only digits 0 and 1. Specific instances `setA = digitSet 3` and `setB = digitSet 4` are defined, along with the sumset `setC` and its counting function `countingC`. The conjecture `ErdosProblem125` uses an $\\varepsilon$-$\\delta$ formulation of $\\liminf > 0$. The known bounds (Melfi's $x^{0.965}$, Hasler-Melfi's $x^{0.9777}$, and the upper density $\\leq 0.696$) are axiomatized. The generalization to multiple bases with the log-sum condition $\\sum \\log_{n_i}(2) > 1$ is stated, along with verification that bases 3 and 4 satisfy this condition.",
     "keyInsights": [
-      "A and B are 'Cantor set integers' — sparse but structured subsets of ℕ",
-      "The counting function |C ∩ [1,x]| grows nearly linearly (exponent > 0.977)",
-      "Upper density ≤ 0.696 shows C cannot be all of ℕ even if dense",
-      "The condition log₃(2) + log₄(2) > 1 governs the generalization"
+      "The sets $A$ and $B$ are Cantor set integers — integer analogues of fractal Cantor sets. Despite both having density zero ($|A \\cap [0,x]| \\sim x^{0.631}$, $|B \\cap [0,x]| \\sim x^{0.5}$), their sumset could have positive density because the two sets are 'independent' in different bases: knowing a number's base-3 digits tells you nothing about its base-4 digits.",
+      "The fractal dimension heuristic $\\dim_H(A) + \\dim_H(B) = \\log_3 2 + \\log_4 2 \\approx 1.131 > 1$ is the key structural insight. By analogy with Marstrand's theorem — which says that projections of planar sets with dimension $> 1$ have positive Lebesgue measure — the sumset should have positive density. But making this analogy rigorous for integer sets with arithmetic structure remains open.",
+      "The gap between the best known lower bound ($x^{0.9777}$, sub-linear) and positive density ($x^1$, linear) is small but fundamental. Closing it requires understanding not just how many elements $C$ contains, but how they distribute — whether they cluster or spread uniformly across residue classes.",
+      "The upper density bound $\\overline{d}(C) \\leq 0.696$ reveals genuine number-theoretic obstructions: certain residue classes modulo powers of 3 and 4 are underrepresented in $C$. This means the density, if positive, lies strictly between 0 and 0.696.",
+      "The generalization to $k$ bases with $\\sum_{i=1}^k \\log_{n_i}(2) > 1$ connects to a broad conjecture in fractal additive combinatorics. For three or more bases exceeding the dimension threshold, the problem is wide open — even the counting function bounds have not been established."
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement and References",
+      "startLine": 1,
+      "endLine": 15,
+      "summary": "Documents the problem with references to Burr-Erdős-Graham-Li (1996), Melfi (2001), and Hasler-Melfi (2024). Records the known bounds $x^{0.9777}$ and upper density $\\leq 0.696$."
+    },
+    {
+      "id": "imports",
+      "title": "Imports",
+      "startLine": 17,
+      "endLine": 23,
+      "summary": "Imports `Nat.digits` for base representations, `Finset` for counting, `Real` for density ratios, and `Filter` for asymptotic statements."
+    },
+    {
       "id": "digit-sets",
-      "title": "Digit-Restricted Sets",
+      "title": "Digit-Restricted Sets (Cantor Set Integers)",
       "startLine": 24,
       "endLine": 38,
-      "summary": "Defines digitSet b, setA (base 3), and setB (base 4)."
+      "summary": "Defines `digitSet b` as naturals with only 0,1 digits in base $b$. Instantiates `setA = digitSet 3` (counting $\\sim x^{0.631}$) and `setB = digitSet 4` (counting $\\sim x^{0.5}$)."
     },
     {
       "id": "sumset",
-      "title": "The Sumset",
+      "title": "The Sumset $C = A + B$",
       "startLine": 40,
       "endLine": 49,
-      "summary": "Defines setC = A + B and countingC |C ∩ [1,x]|."
+      "summary": "Defines $C = A + B$ as the set of all sums $a + b$ with $a \\in A$, $b \\in B$. Provides the counting function `countingC x = |C \\cap [0,x]|$ via `Finset.filter`."
     },
     {
       "id": "conjecture",
-      "title": "The Conjecture",
+      "title": "Erdős Problem 125: Positive Lower Density",
       "startLine": 51,
       "endLine": 60,
-      "summary": "States ErdosProblem125: does C have positive lower density?"
+      "summary": "Formalizes the conjecture as $\\exists \\delta > 0$ such that $\\liminf_{x \\to \\infty} |C \\cap [1,x]|/x \\geq \\delta$, using an $\\varepsilon$-$\\delta$ characterization of positive liminf."
     },
     {
       "id": "lower-bounds",
-      "title": "Known Lower Bounds",
+      "title": "Counting Lower Bounds (Melfi, Hasler-Melfi)",
       "startLine": 62,
       "endLine": 74,
-      "summary": "Melfi (2001): ≫ x^{0.965}. Hasler–Melfi (2024): ≫ x^{0.9777}."
+      "summary": "Axiomatizes Melfi's 2001 bound $|C \\cap [1,x]| \\geq cx^{0.965}$ and the Hasler-Melfi 2024 improvement to $cx^{0.9777}$. Both are sub-linear, falling short of proving positive density."
     },
     {
       "id": "upper-density",
-      "title": "Upper Density Bound",
+      "title": "Upper Density Bound (Hasler-Melfi 2024)",
       "startLine": 76,
       "endLine": 84,
-      "summary": "Hasler–Melfi (2024): upper density ≤ 0.696."
+      "summary": "Axiomatizes $\\overline{d}(C) \\leq 0.696$: for any $\\varepsilon > 0$, eventually $|C \\cap [1,x]|/x \\leq 0.696 + \\varepsilon$. Shows $C$ cannot be 'almost all' of $\\mathbb{N}$."
     },
     {
       "id": "generalization",
-      "title": "Generalization to Other Bases",
+      "title": "Generalization to Multiple Bases",
       "startLine": 86,
       "endLine": 107,
-      "summary": "General question for multiple bases with Σ log_b(2) > 1 condition."
+      "summary": "States the general conjecture for bases $n_1, \\ldots, n_k$ with $\\sum \\log_{n_i}(2) > 1$, and verifies that bases 3 and 4 satisfy $\\log_3(2) + \\log_4(2) \\approx 1.131 > 1$ as an axiom."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 125 asks whether the sumset of base-3 and base-4 'Cantor integers' has positive density. The counting function is nearly linear but positive density is unproved.",
-    "implications": "Understanding this would connect digital properties of integers to additive structure, bridging fractal geometry and number theory.",
+    "summary": "This formalization captures Erdős Problem #125 in 107 lines of Lean 4, encoding the Cantor set integers via `Nat.digits`, the sumset and its counting function, the open conjecture on positive lower density, the best known bounds (Melfi $x^{0.965}$, Hasler-Melfi $x^{0.9777}$, upper density $\\leq 0.696$), and the generalization to multiple bases with the Hausdorff dimension condition. Zero sorries; deep results axiomatized.",
+    "implications": "Resolution would establish a deep connection between digital structure (base representations) and additive number theory (sumset density), with implications for fractal geometry. A proof would likely require new techniques bridging the Marstrand-type projection arguments from geometric measure theory with the arithmetic structure of digit-restricted sets. The techniques could extend to the general multi-base conjecture and to understanding sumsets of other fractal-like integer sequences.",
     "openQuestions": [
-      "Does A + B have positive lower density?",
-      "What is the exact lower density if it exists?",
-      "Does the generalization hold for all pairwise coprime bases satisfying the log condition?"
+      "Does $A + B$ have positive lower density? This is the central open question, with the exponent gap $0.9777 < 1$ being the remaining obstacle.",
+      "If $\\underline{d}(C) > 0$, what is its exact value? The upper density bound $\\overline{d}(C) \\leq 0.696$ constrains it, but no lower bound on the density itself is known.",
+      "Does the generalized conjecture hold for all families of pairwise coprime bases with $\\sum \\log_{n_i}(2) > 1$? Even the three-base case (e.g., bases 3, 4, 5) is open.",
+      "Can the Hasler-Melfi exponent $0.9777$ be improved further? Is there a natural barrier below exponent 1, or can sub-linear bounds be pushed arbitrarily close to linear?"
     ]
   }
 }

--- a/src/data/proofs/erdos-128/annotations.json
+++ b/src/data/proofs/erdos-128/annotations.json
@@ -1,56 +1,198 @@
 [
   {
+    "id": "ann-e128-header",
+    "proofId": "erdos-128",
+    "range": { "startLine": 1, "endLine": 18 },
+    "type": "context",
+    "title": "Problem Overview and Known Results",
+    "content": "Header documenting Erdős Problem #128: a local-to-global triangle forcing conjecture. If every induced subgraph on at least $\\lfloor n/2 \\rfloor$ vertices has more than $n^2/50$ edges, must $G$ contain a triangle? The problem was posed by Erdős and Rousseau with a $250 prize. The constant $1/50$ is conjectured optimal, witnessed by blow-ups of $C_5$ and the Petersen graph.",
+    "mathContext": "The conjecture asks: $\\forall G$ on $n$ vertices, if $\\forall S \\subseteq V(G)$ with $|S| \\geq \\lfloor n/2 \\rfloor$, $e(G[S]) > n^2/50$, then $G$ contains $K_3$. Known partial results replace $1/50$ by $1/16$ (EFRS), $27/1024$ (Razborov), or change the subgraph size threshold from $n/2$ to $3n/5$ (Krivelevich).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "extremal graph theory",
+      "triangle forcing",
+      "local density conditions",
+      "Turán-type problems"
+    ],
+    "prerequisites": [
+      "induced subgraphs",
+      "edge density",
+      "triangle-free graphs"
+    ]
+  },
+  {
+    "id": "ann-e128-imports",
+    "proofId": "erdos-128",
+    "range": { "startLine": 20, "endLine": 24 },
+    "type": "context",
+    "title": "Imports",
+    "content": "Imports Mathlib's basic tactics, natural number and finset infrastructure, and `SimpleGraph.Basic` for the foundational graph theory API. The file defines its own `Graph` structure rather than using Mathlib's `SimpleGraph` directly, bundling adjacency with symmetry and irreflexivity proofs.",
+    "mathContext": "Uses `Finset.univ.product` and `Finset.filter` for edge counting, and `Fin n` for vertex indexing. The custom `Graph n` structure packages a decidable adjacency relation on `Fin n`.",
+    "significance": "context",
+    "relatedConcepts": [
+      "SimpleGraph",
+      "Finset.filter",
+      "Fin type"
+    ],
+    "prerequisites": [
+      "Mathlib.Combinatorics.SimpleGraph.Basic"
+    ]
+  },
+  {
+    "id": "ann-e128-graph-defs",
+    "proofId": "erdos-128",
+    "range": { "startLine": 25, "endLine": 47 },
+    "type": "definition",
+    "title": "Graph Infrastructure",
+    "content": "Defines the core graph-theoretic objects: `Graph n` (a simple graph on $n$ vertices with symmetric, irreflexive adjacency), `edgeCount` (number of edges via filtering ordered pairs), `induce` (induced subgraph on a vertex subset), and `hasTriangle` (existence of three mutually adjacent vertices).",
+    "mathContext": "The edge count is $e(G) = |\\{(u,v) : u < v,\\, G.\\text{adj}(u,v)\\}|$. The induced subgraph $G[S]$ restricts adjacency to $S$: $G[S].\\text{adj}(u,v) \\iff u \\in S \\wedge v \\in S \\wedge G.\\text{adj}(u,v)$. A triangle is $\\exists u,v,w$ distinct with $uv, vw, uw \\in E(G)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "simple graphs",
+      "induced subgraphs",
+      "edge counting",
+      "clique number"
+    ],
+    "prerequisites": [
+      "Fin type",
+      "Finset.product",
+      "graph theory basics"
+    ]
+  },
+  {
     "id": "dense-subgraphs",
     "proofId": "erdos-128",
-    "range": { "startLine": 48, "endLine": 52 },
+    "range": { "startLine": 48, "endLine": 57 },
     "type": "definition",
-    "title": "Dense Subgraphs Condition",
-    "content": "Every induced subgraph on at least ⌊n/2⌋ vertices has more than n²/50 edges. This is a 'local density' condition — it doesn't require the whole graph to be dense, just every large enough subgraph.",
-    "significance": "high"
+    "title": "Dense Subgraphs Condition and Triangle-Freeness",
+    "content": "Defines `denseSubgraphs`: every induced subgraph on at least $\\lfloor n/2 \\rfloor$ vertices has more than $n^2/50$ edges. Also defines `triangleFree` as the negation of `hasTriangle`. The density threshold $n^2/50$ corresponds to edge density $2/50 = 1/25$ in the half-sized subgraph, which is exactly the Turán density for triangle-free graphs on 5-chromatic blow-ups.",
+    "mathContext": "The condition is: $\\forall S \\subseteq V(G),\\, |S| \\geq \\lfloor n/2 \\rfloor \\implies e(G[S]) > n^2/50$. For a balanced $C_5$ blow-up, each half-sized subgraph has approximately $2 \\cdot (n/5)^2 = 2n^2/25$ edges from 2 of the 5 bipartite pairs, yielding $\\approx n^2/50$ after normalization — exactly the threshold.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "local density",
+      "Turán density",
+      "edge density threshold",
+      "C₅ blow-up"
+    ],
+    "prerequisites": [
+      "induced subgraph edge count",
+      "integer division"
+    ]
   },
   {
     "id": "c5-blowup",
     "proofId": "erdos-128",
-    "range": { "startLine": 56, "endLine": 60 },
+    "range": { "startLine": 58, "endLine": 67 },
     "type": "example",
-    "title": "C₅ Blow-up Extremal Example",
-    "content": "Partition n vertices into 5 equal parts, connect parts i and i+1 (mod 5). This is triangle-free (C₅ has no odd cycle of length 3) with subgraph density approaching n²/50 in half-sized subgraphs, showing 1/50 is optimal.",
-    "significance": "high"
+    "title": "C₅ Blow-up: Extremal Example",
+    "content": "The balanced blow-up of $C_5$ partitions $n$ vertices into 5 parts of size $\\sim n/5$ and connects parts $i$ and $i+1 \\pmod{5}$. This graph is triangle-free (since $C_5$ has no $K_3$) and achieves subgraph edge density approaching $n^2/50$ in half-sized subgraphs, showing the constant $1/50$ in the conjecture cannot be improved. The axiom states the subgraph density is at most $n^2/50 + n$ (with a linear error term).",
+    "mathContext": "The $C_5$ blow-up $G$ has $5 \\cdot (n/5)^2 = n^2/5$ total edges. For $S \\subseteq V$ with $|S| = n/2$, one can show $e(G[S]) \\leq n^2/50 + O(n)$. The Petersen graph (vertex-transitive, 3-regular, triangle-free) is the $n = 10$ case.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "graph blow-ups",
+      "Petersen graph",
+      "extremal examples",
+      "tightness of constants"
+    ],
+    "prerequisites": [
+      "C₅ structure",
+      "bipartite subgraphs"
+    ]
   },
   {
     "id": "efrs",
     "proofId": "erdos-128",
-    "range": { "startLine": 64, "endLine": 69 },
+    "range": { "startLine": 68, "endLine": 77 },
     "type": "theorem",
-    "title": "EFRS Theorem",
-    "content": "Erdős–Faudree–Rousseau–Schelp proved the conjecture with 50 replaced by 16. If every subgraph on ≥ n/2 vertices has > n²/16 edges, then G contains a triangle.",
-    "significance": "high"
+    "title": "EFRS Theorem: Constant 16",
+    "content": "Erdős, Faudree, Rousseau, and Schelp (1994) proved the conjecture with $50$ replaced by $16$: if every induced subgraph on $\\geq n/2$ vertices has $> n^2/16$ edges, then $G$ contains a triangle. More generally, for any $0 < \\alpha < 1$, if every set of $\\geq \\alpha n$ vertices induces $> \\alpha^3 n^2/2$ edges, then $G$ contains a triangle.",
+    "mathContext": "$\\forall n,\\, \\forall G$ on $n$ vertices: $(\\forall S,\\, |S| \\geq n/2 \\implies e(G[S]) > n^2/16) \\implies K_3 \\subseteq G$. The general form replaces $1/16$ by $\\alpha^3/2$ for threshold $\\alpha n$, recovering $1/16 = (1/2)^3/2$ at $\\alpha = 1/2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdős-Faudree-Rousseau-Schelp",
+      "local-to-global forcing",
+      "generalized density conditions"
+    ],
+    "prerequisites": [
+      "Turán's theorem",
+      "graph regularity"
+    ]
+  },
+  {
+    "id": "krivelevich",
+    "proofId": "erdos-128",
+    "range": { "startLine": 78, "endLine": 83 },
+    "type": "theorem",
+    "title": "Krivelevich's Theorem: Subgraph Size 3n/5",
+    "content": "Krivelevich (1995) proved a variant: if every induced subgraph on $\\geq 3n/5$ vertices has $> n^2/25$ edges, then $G$ contains a triangle. This trades a larger subgraph size threshold ($3n/5$ vs $n/2$) for a better constant ($25$ vs $50$), reflecting a different point on the trade-off curve between local density and subgraph size.",
+    "mathContext": "$\\forall n,\\, \\forall G$ on $n$ vertices: $(\\forall S,\\, |S| \\geq 3n/5 \\implies e(G[S]) > n^2/25) \\implies K_3 \\subseteq G$. Note $1/25 > 1/50$, so the density requirement is weaker, but more vertices are required.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Krivelevich's method",
+      "subgraph size vs density trade-off"
+    ],
+    "prerequisites": [
+      "extremal graph theory",
+      "edge density"
+    ]
   },
   {
     "id": "razborov",
     "proofId": "erdos-128",
-    "range": { "startLine": 77, "endLine": 82 },
+    "range": { "startLine": 84, "endLine": 91 },
     "type": "theorem",
-    "title": "Razborov's Flag Algebra Result",
-    "content": "Razborov improved the constant to 27/1024 ≈ 0.0264 using flag algebra methods. Compare with the target 1/50 = 0.02. The gap is now quite small but closing it remains an open challenge.",
-    "significance": "high"
+    "title": "Razborov's Flag Algebra Result: Constant 27/1024",
+    "content": "Razborov (2022) improved the EFRS constant from $1/16$ to $27/1024 \\approx 0.0264$ using the flag algebra method. This is much closer to the conjectured $1/50 = 0.02$, narrowing the gap to a factor of $\\approx 1.32$. Flag algebras provide a systematic framework for proving graph density inequalities via semidefinite programming relaxations of counting constraints.",
+    "mathContext": "$\\forall n,\\, \\forall G$ on $n$ vertices: $(\\forall S,\\, |S| \\geq n/2 \\implies e(G[S]) > 27n^2/1024) \\implies K_3 \\subseteq G$. Comparison: $27/1024 \\approx 0.02637$ vs $1/50 = 0.02$. The multiplicative gap is $27/1024 \\cdot 50 = 1350/1024 \\approx 1.318$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "flag algebras",
+      "semidefinite programming",
+      "graph density inequalities",
+      "Razborov's method"
+    ],
+    "prerequisites": [
+      "graph homomorphism densities",
+      "flag algebra framework"
+    ]
   },
   {
     "id": "norin-yepremyan",
     "proofId": "erdos-128",
-    "range": { "startLine": 84, "endLine": 90 },
+    "range": { "startLine": 92, "endLine": 98 },
     "type": "theorem",
-    "title": "Norin–Yepremyan for Dense Graphs",
-    "content": "For graphs with total edge count ≥ (1/5 − c)n² (close to the Turán density for triangle-free graphs), the conjecture holds. The remaining hard cases are graphs that are globally sparse but locally dense.",
-    "significance": "medium"
+    "title": "Norin-Yepremyan: Dense Graphs Case",
+    "content": "Norin and Yepremyan (2015) proved the conjecture for graphs with at least $(1/5 - c)n^2$ edges for some constant $c > 0$. Since the Turán number $\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$ and the $C_5$ blow-up has $n^2/5$ edges, this handles the case where the graph has nearly as many edges as the extremal triangle-free graph. The remaining hard cases are globally sparse graphs that are locally dense.",
+    "mathContext": "$\\exists c > 0,\\, \\forall n,\\, \\forall G$ on $n$ vertices: $e(G) \\geq (1/5 - c)n^2 \\wedge G.\\text{denseSubgraphs} \\implies K_3 \\subseteq G$. Note that $1/5 < 1/4 = \\text{ex}(n,K_3)/n^2$, so this condition is weaker than Turán-dense.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Turán number",
+      "global vs local density",
+      "Mantel's theorem"
+    ],
+    "prerequisites": [
+      "Turán's theorem",
+      "edge density"
+    ]
   },
   {
     "id": "main-conjecture",
     "proofId": "erdos-128",
-    "range": { "startLine": 94, "endLine": 96 },
-    "type": "conjecture",
-    "title": "Main Conjecture ($250)",
-    "content": "If every induced subgraph on ≥ ⌊n/2⌋ vertices has > n²/50 edges, then G contains a triangle. The $250 prize reflects that this is a concrete, falsifiable question — a single counterexample would disprove it.",
-    "significance": "high"
+    "range": { "startLine": 99, "endLine": 105 },
+    "type": "concept",
+    "title": "Erdős Problem 128: The Full Conjecture ($250)",
+    "content": "The formal statement of the conjecture: for all graphs $G$ on $n$ vertices, if `G.denseSubgraphs` holds (every induced subgraph on $\\geq \\lfloor n/2 \\rfloor$ vertices has $> n^2/50$ edges), then $G$ contains a triangle. Stated as an axiom since the problem is open. Erdős offered $250 for a resolution.",
+    "mathContext": "$\\text{ErdosProblem128}: \\forall n \\in \\mathbb{N},\\, \\forall G \\text{ on } n \\text{ vertices},\\, G.\\text{denseSubgraphs} \\implies G.\\text{hasTriangle}$. Equivalently: every triangle-free graph on $n$ vertices has an induced subgraph on $\\geq \\lfloor n/2 \\rfloor$ vertices with $\\leq n^2/50$ edges.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Erdős prizes",
+      "open conjectures",
+      "extremal graph theory",
+      "triangle detection"
+    ],
+    "prerequisites": [
+      "denseSubgraphs definition",
+      "hasTriangle definition"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-128/meta.json
+++ b/src/data/proofs/erdos-128/meta.json
@@ -15,67 +15,97 @@
     ],
     "references": [
       "Erdős–Rousseau [Er93, p.344]",
-      "Erdős–Faudree–Rousseau–Schelp: 50 → 16",
-      "Krivelevich: n/2 → 3n/5, 50 → 25",
-      "Razborov: flag algebras, 50 → 1024/27",
-      "Norin–Yepremyan: graphs with ≥ (1/5-c)n² edges",
+      "Erdős–Faudree–Rousseau–Schelp [EFRS94]",
+      "Krivelevich [Kr95]",
+      "Keevash–Sudakov [KeSu06]",
+      "Norin–Yepremyan [NoYe15]",
+      "Razborov [Ra22]",
       "https://erdosproblems.com/128"
     ],
     "leanFile": "Proofs/Erdos128Problem.lean",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/128",
-    "erdosUrl": "https://erdosproblems.com/128"
+    "erdosUrl": "https://erdosproblems.com/128",
+    "erdosProblemStatus": "open"
+  },
+  "overview": {
+    "historicalContext": "This problem was posed by Erdős and Rousseau, appearing in Erdős's 1993 paper [Er93, p.344] and also in the Erdős-Rousseau paper [ErRo93]. It asks whether a local density condition — every large induced subgraph being dense — forces a global structure (a triangle). The problem sits at the intersection of extremal graph theory and Ramsey-type forcing, asking for the precise threshold at which local density guarantees global substructure.\n\nThe constant $1/50$ is motivated by the balanced blow-up of the 5-cycle $C_5$: partition $n$ vertices into 5 equal parts and connect parts $i$ and $i+1 \\pmod{5}$. This graph is triangle-free (since $C_5$ contains no $K_3$), has $n^2/5$ total edges, and any induced subgraph on $\\geq n/2$ vertices has at most $\\approx n^2/50$ edges. The Petersen graph (the $n=10$ case) is the smallest such extremal example.\n\nThe first major result was by Erdős, Faudree, Rousseau, and Schelp (1994), who proved the conjecture with $50$ replaced by $16$. They also proved a generalized form: for any $0 < \\alpha < 1$, if every set of $\\geq \\alpha n$ vertices induces $> \\alpha^3 n^2/2$ edges, then the graph contains a triangle. Krivelevich (1995) obtained a different trade-off, proving the result with the subgraph size increased to $3n/5$ but the constant improved to $25$. Keevash and Sudakov (2006) proved the conjecture under additional structural assumptions: either when the total edge count is $\\leq n^2/12$ or $\\geq n^2/5$. Norin and Yepremyan (2015) extended this to graphs with $\\geq (1/5 - c)n^2$ edges for some $c > 0$. The current best result is by Razborov (2022), who used his flag algebra method to improve the constant to $27/1024 \\approx 0.0264$, narrowing the gap with $1/50 = 0.02$ to a factor of $\\approx 1.32$. Erdős offered $250 for the resolution.",
+    "problemStatement": "Let $G$ be a graph with $n$ vertices such that every induced subgraph on $\\geq \\lfloor n/2 \\rfloor$ vertices has more than $n^2/50$ edges. Must $G$ contain a triangle?",
+    "proofStrategy": "The formalization defines a custom `Graph n` structure with symmetric, irreflexive adjacency on `Fin n`, along with `edgeCount`, `induce` (induced subgraph), `hasTriangle`, and `triangleFree`. The key definition `denseSubgraphs` captures the local density condition. The extremal $C_5$ blow-up is axiomatized, as are four partial results: EFRS (constant 16), Krivelevich (threshold $3n/5$, constant 25), Razborov (constant $27/1024$), and Norin-Yepremyan (dense graphs). The main conjecture `erdos_128_conjecture` is stated as an axiom. Zero sorries.",
+    "keyInsights": [
+      "The $C_5$ blow-up is the conjectured unique extremal example: it is triangle-free and saturates the $n^2/50$ bound in half-sized subgraphs. Its 5-part structure means any subset of $n/2$ vertices intersects at most 2 'edge-classes' heavily, yielding edge density $\\approx 2 \\cdot (n/5)^2 / \\binom{n/2}{2} \\approx 2/25$.",
+      "The progression of constants — EFRS $1/16$, Razborov $27/1024 \\approx 0.0264$, conjectured $1/50 = 0.02$ — shows the problem is 'almost solved' quantitatively but the final gap is structurally hard. The remaining factor $\\approx 1.32$ likely requires understanding the exact extremal structure, not just density inequalities.",
+      "The EFRS generalization reveals a continuous trade-off: for subgraph threshold $\\alpha n$, the critical density is $\\alpha^3/2$. At $\\alpha = 1/2$ this gives $1/16$; the conjecture asserts the true threshold is $(2/5)^2 / 2 = 2/25$ (from the $C_5$ blow-up), which is much smaller than the EFRS prediction.",
+      "Norin-Yepremyan's result identifies the hard case: globally sparse graphs that are locally dense. The $C_5$ blow-up has edge density $1/5$, well below the Turán density $1/4$ for triangle-free graphs. The conjecture is about these 'moderately sparse' graphs where triangle-freeness barely survives.",
+      "Flag algebras (Razborov's framework) reduce the problem to a semidefinite program over graph homomorphism densities. The current SDP relaxation yields $27/1024$; closing the gap to $1/50$ may require additional structural constraints or a different decomposition of the flag algebra certificate."
+    ]
   },
   "sections": [
     {
-      "id": "definitions",
-      "title": "Definitions",
+      "id": "header",
+      "title": "Problem Statement and References",
+      "startLine": 1,
+      "endLine": 18,
+      "summary": "Documents the problem origin (Erdős-Rousseau 1993), the $250 prize, known partial results (EFRS, Krivelevich, Norin-Yepremyan, Razborov), and the extremal $C_5$ blow-up."
+    },
+    {
+      "id": "imports",
+      "title": "Imports",
       "startLine": 20,
-      "endLine": 52,
-      "summary": "Graph, edge count, induced subgraph, triangle, dense subgraphs condition."
+      "endLine": 24,
+      "summary": "Imports Mathlib tactics, natural number/finset basics, and `SimpleGraph.Basic`. The file uses a custom `Graph` structure."
+    },
+    {
+      "id": "definitions",
+      "title": "Graph Definitions",
+      "startLine": 25,
+      "endLine": 51,
+      "summary": "Defines `Graph n` (symmetric, irreflexive adjacency on `Fin n`), `edgeCount` (ordered pair filtering), `induce` (induced subgraph), `hasTriangle`, and `triangleFree`."
+    },
+    {
+      "id": "dense-condition",
+      "title": "Dense Subgraphs Condition",
+      "startLine": 53,
+      "endLine": 57,
+      "summary": "Defines `denseSubgraphs`: $\\forall S$ with $|S| \\geq n/2$, $e(G[S]) > n^2/50$. The threshold matches the $C_5$ blow-up edge density."
     },
     {
       "id": "extremal",
-      "title": "Extremal Examples",
-      "startLine": 54,
-      "endLine": 60,
-      "summary": "C₅ blow-up: triangle-free with subgraph density near n²/50."
+      "title": "Extremal Example: $C_5$ Blow-up",
+      "startLine": 58,
+      "endLine": 67,
+      "summary": "Axiomatizes the $C_5$ blow-up: triangle-free with $e(G[S]) \\leq n^2/50 + n$ for all $|S| \\geq n/2$. Shows tightness of the constant $1/50$."
     },
     {
-      "id": "partial-results",
-      "title": "Partial Results",
-      "startLine": 62,
-      "endLine": 90,
-      "summary": "EFRS, Krivelevich, Razborov, and Norin–Yepremyan theorems."
+      "id": "efrs-krivelevich",
+      "title": "EFRS and Krivelevich Theorems",
+      "startLine": 68,
+      "endLine": 83,
+      "summary": "EFRS (1994): constant 16. Krivelevich (1995): threshold $3n/5$, constant 25. Two different trade-offs between subgraph size and density."
+    },
+    {
+      "id": "razborov-norin",
+      "title": "Razborov and Norin-Yepremyan",
+      "startLine": 84,
+      "endLine": 98,
+      "summary": "Razborov (2022): flag algebras improve constant to $27/1024$. Norin-Yepremyan (2015): handle graphs with $\\geq (1/5-c)n^2$ edges."
     },
     {
       "id": "main-conjecture",
-      "title": "Main Conjecture",
-      "startLine": 92,
-      "endLine": 96,
-      "summary": "The full conjecture with constant 1/50."
+      "title": "Main Conjecture ($250 Prize)",
+      "startLine": 99,
+      "endLine": 105,
+      "summary": "States the full conjecture: `denseSubgraphs → hasTriangle` for all graphs. Open with $250 Erdős prize."
     }
   ],
-  "overview": {
-    "historicalContext": "This problem was posed by Erdős and Rousseau, appearing in Erdős's 1993 paper [Er93, p.344]. It asks whether a local density condition on all large subgraphs forces a triangle. The constant 1/50 is motivated by the C₅ blow-up (or Petersen graph blow-up), which is triangle-free and achieves subgraph edge density near n²/50.",
-    "problemStatement": "Let G be a graph with n vertices such that every induced subgraph on ≥ ⌊n/2⌋ vertices has more than n²/50 edges. Must G contain a triangle?",
-    "proofStrategy": "We define graphs, induced subgraphs, the dense subgraphs condition, and state the conjecture. We record the C₅ blow-up extremal example, partial results by EFRS (constant 16), Krivelevich (subgraph size 3n/5), Razborov (flag algebras), and Norin–Yepremyan (high overall edge count).",
-    "keyInsights": [
-      "The C₅ blow-up is triangle-free and achieves subgraph density ≈ n²/50, so the constant is tight",
-      "EFRS proved the result with 50 replaced by 16, leaving a factor ~3 gap",
-      "Razborov's flag algebra method improves the constant to 27/1024 ≈ 0.0264 vs 1/50 = 0.02",
-      "Krivelevich trades subgraph size (3n/5 instead of n/2) for a better constant (25)",
-      "Norin–Yepremyan handle graphs with many total edges, leaving sparse graphs as the hard case"
-    ]
-  },
   "conclusion": {
-    "summary": "Erdős Problem #128 remains open despite significant partial progress. The gap between the best constant achieved (27/1024 by Razborov) and the conjectured 1/50 is narrow, suggesting the problem may be within reach of current flag algebra or regularity methods.",
-    "implications": "Resolution would advance extremal graph theory, connecting local density conditions to global substructure. The C₅ blow-up extremality would establish a precise Turán-type threshold for local-to-global triangle forcing.",
+    "summary": "This formalization captures Erdős Problem #128 in 105 lines of Lean 4, encoding the local-to-global triangle forcing conjecture with its extremal $C_5$ blow-up example, four major partial results (EFRS, Krivelevich, Razborov, Norin-Yepremyan), and the open $250 conjecture. Zero sorries; all deep results axiomatized.",
+    "implications": "Resolution would establish a precise Turán-type threshold for local-to-global triangle forcing: the $C_5$ blow-up would be the unique extremal configuration, connecting the problem to the classical Turán theory and to the broader program of characterizing which local conditions force global substructures. The flag algebra approach of Razborov suggests that computational methods (semidefinite programming certificates) may be sufficient, potentially yielding a computer-assisted proof.",
     "openQuestions": [
-      "Can flag algebras close the gap from 27/1024 to 1/50?",
-      "Is the C₅ blow-up the unique extremal example?",
-      "What happens for K₄ instead of triangles?",
-      "Can the subgraph size threshold n/2 be reduced below 3n/5?"
+      "Can flag algebras close the remaining gap from $27/1024 \\approx 0.0264$ to $1/50 = 0.02$? The gap factor is $\\approx 1.32$.",
+      "Is the balanced $C_5$ blow-up the unique extremal example, or are there other triangle-free graphs achieving subgraph density $\\approx n^2/50$? The Petersen graph blow-up is one such example — are there others?",
+      "What is the analogous conjecture for $K_4$ instead of triangles? The extremal graph would likely involve blow-ups of triangle-free graphs with higher chromatic number.",
+      "Can the subgraph size threshold $n/2$ be reduced? Krivelevich showed $3n/5$ works with constant $25$; is there a version with threshold $\\alpha n$ for all $\\alpha > 0$?"
     ]
   }
 }

--- a/src/data/proofs/erdos-14/annotations.json
+++ b/src/data/proofs/erdos-14/annotations.json
@@ -1,74 +1,211 @@
 [
   {
+    "id": "ann-e14-header",
+    "proofId": "erdos-14",
+    "range": { "startLine": 1, "endLine": 22 },
+    "type": "context",
+    "title": "Problem Overview and References",
+    "content": "Header documenting Erdős Problem #14 on unique representation of sums. Given $A \\subseteq \\mathbb{N}$, let $B$ be the set of integers representable in exactly one way as $a + b$ with $a \\leq b$, $a, b \\in A$. The two-part question asks about the growth rate of $|\\{1, \\ldots, N\\} \\setminus B|$: (a) must it be at least $N^{1/2-\\varepsilon}$? (b) can it be $o(\\sqrt{N})$?",
+    "mathContext": "For $A \\subseteq \\mathbb{N}$, define $B = \\{n : |\\{(a,b) \\in A \\times A : a \\leq b,\\, a+b=n\\}| = 1\\}$. Question (a): $\\forall A,\\, \\forall \\varepsilon > 0,\\, |\\{1,\\ldots,N\\} \\setminus B| \\gg_{\\varepsilon} N^{1/2-\\varepsilon}$? Question (b): $\\exists A$ with $|\\{1,\\ldots,N\\} \\setminus B| = o(N^{1/2})$?",
+    "significance": "critical",
+    "relatedConcepts": [
+      "additive combinatorics",
+      "unique representation",
+      "sumsets",
+      "Sidon sets"
+    ],
+    "prerequisites": [
+      "representation functions",
+      "asymptotic notation"
+    ]
+  },
+  {
+    "id": "ann-e14-imports",
+    "proofId": "erdos-14",
+    "range": { "startLine": 23, "endLine": 28 },
+    "type": "context",
+    "title": "Imports and Setup",
+    "content": "Imports Mathlib's asymptotic analysis (`Asymptotics`), `Finset.Basic` for finite set operations, and general tactics. Opens `Finset`, `Filter`, and `Asymptotics` namespaces for convenient access to `atTop`, `∀ᶠ`, `∃ᶠ`, and finset operations.",
+    "mathContext": "Uses `Filter.atTop` for $N \\to \\infty$, `∀ᶠ N in atTop` for 'for all sufficiently large $N$', and `∃ᶠ N in atTop` for 'for infinitely many $N$'. These are Lean's clean formalization of asymptotic quantifiers.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Filter.atTop",
+      "Asymptotics",
+      "Finset operations"
+    ],
+    "prerequisites": [
+      "Mathlib.Analysis.Asymptotics.Asymptotics",
+      "filter library"
+    ]
+  },
+  {
     "id": "erdos-14-ann-unique",
     "proofId": "erdos-14",
-    "range": { "startLine": 28, "endLine": 33 },
+    "range": { "startLine": 30, "endLine": 38 },
     "type": "definition",
-    "title": "Unique Sums",
-    "content": "The set of integers with exactly one ordered representation a+b (a≤b) from A. The central object of the problem.",
-    "significance": "critical"
+    "title": "Unique Sums (Finite Version)",
+    "content": "Defines `uniqueSums A` for a finite set $A$: the set of integers $n$ such that $n = a + b$ with $a \\leq b$, $a, b \\in A$, and this representation is unique (exactly one such pair $(a,b)$). Computed by filtering ordered pairs, taking sums, then filtering for uniqueness via `.card = 1`.",
+    "mathContext": "$\\text{uniqueSums}(A) = \\{n \\in \\mathbb{N} : |\\{(a,b) \\in A \\times A : a \\leq b,\\, a+b=n\\}| = 1\\}$. For a Sidon set $A$, every sum has a unique representation, so $\\text{uniqueSums}(A) = A + A$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "representation function",
+      "Sidon sets",
+      "sumset structure"
+    ],
+    "prerequisites": [
+      "Finset.filter",
+      "Finset.image"
+    ]
   },
   {
     "id": "erdos-14-ann-count",
     "proofId": "erdos-14",
-    "range": { "startLine": 36, "endLine": 38 },
+    "range": { "startLine": 40, "endLine": 50 },
     "type": "definition",
-    "title": "Non-Unique Sum Count",
-    "content": "Count of integers in {1,...,N} not representable in exactly one way. This measures how far the sumset is from perfect unique coverage.",
-    "significance": "critical"
+    "title": "Non-Unique Sum Count (Finite and Infinite)",
+    "content": "Defines the non-unique sum count: the number of integers in $\\{1, \\ldots, N\\}$ not in `uniqueSums A`. The finite version `nonUniqueSumCount` works with `Finset`, while `nonUniqueSumCountInf` uses `Set.ncard` for infinite sets. This is the quantity whose growth rate is the subject of the problem.",
+    "mathContext": "$f_A(N) = |\\{1, \\ldots, N\\} \\setminus B| = |\\{n \\leq N : n \\text{ has } \\neq 1 \\text{ representation as } a+b\\}|$. Integers not in $B$ either have 0 representations (not in the sumset) or $\\geq 2$ representations (non-unique).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "counting functions",
+      "Set.ncard",
+      "set difference"
+    ],
+    "prerequisites": [
+      "Finset.Icc",
+      "Set.ncard"
+    ]
   },
   {
     "id": "erdos-14-ann-14a",
     "proofId": "erdos-14",
-    "range": { "startLine": 49, "endLine": 53 },
-    "type": "theorem",
-    "title": "Conjecture 14a: Lower Bound",
-    "content": "For every A and ε > 0, |{1,...,N}\\B| ≫ N^{1/2−ε}. The non-unique count cannot be much smaller than √N.",
-    "significance": "critical"
+    "range": { "startLine": 52, "endLine": 59 },
+    "type": "concept",
+    "title": "Conjecture 14a: Lower Bound $\\gg N^{1/2-\\varepsilon}$",
+    "content": "The first open question: for every $A \\subseteq \\mathbb{N}$ and every $\\varepsilon > 0$, is the non-unique count at least $C_{\\varepsilon} N^{1/2 - \\varepsilon}$ for all sufficiently large $N$? This would mean that no set $A$ can make the unique sums cover almost all of $\\{1, \\ldots, N\\}$ — there must be at least $\\sim \\sqrt{N}$ 'failures'. Formalized using `∀ᶠ N in atTop`.",
+    "mathContext": "$\\forall A \\subseteq \\mathbb{N},\\, \\forall \\varepsilon > 0,\\, \\exists C > 0,\\, \\forall^{\\infty} N,\\, f_A(N) \\geq C N^{1/2 - \\varepsilon}$. The best known lower bound is $f_A(N) \\gg N^{1/3 - \\varepsilon}$ infinitely often (ESS), far from the conjectured $N^{1/2 - \\varepsilon}$ for all large $N$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "lower bounds",
+      "Filter.Eventually",
+      "polynomial growth"
+    ],
+    "prerequisites": [
+      "asymptotic analysis",
+      "Filter.atTop"
+    ]
   },
   {
     "id": "erdos-14-ann-14b",
     "proofId": "erdos-14",
-    "range": { "startLine": 56, "endLine": 58 },
-    "type": "theorem",
-    "title": "Conjecture 14b: o(√N) Possible?",
-    "content": "Can the non-unique count be o(√N)? If yes, question (a) would be answered negatively.",
-    "significance": "critical"
+    "range": { "startLine": 61, "endLine": 65 },
+    "type": "concept",
+    "title": "Conjecture 14b: Is $o(\\sqrt{N})$ Possible?",
+    "content": "The second open question: does there exist $A \\subseteq \\mathbb{N}$ with $f_A(N) = o(\\sqrt{N})$? A positive answer would contradict (a), since $o(\\sqrt{N})$ is smaller than $N^{1/2-\\varepsilon}$ for any fixed $\\varepsilon$. The ESS construction achieves $O(N^{1/2+\\varepsilon})$ but not $o(\\sqrt{N})$, so this asks whether the extra $N^{\\varepsilon}$ factor can be eliminated.",
+    "mathContext": "$\\exists A \\subseteq \\mathbb{N},\\, \\forall \\varepsilon > 0,\\, \\forall^{\\infty} N,\\, f_A(N) \\leq \\varepsilon \\sqrt{N}$. This is equivalent to: $\\exists A$ with $f_A(N) / \\sqrt{N} \\to 0$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "little-o notation",
+      "optimality questions",
+      "Filter.Eventually"
+    ],
+    "prerequisites": [
+      "asymptotic notation",
+      "Filter.atTop"
+    ]
   },
   {
     "id": "erdos-14-ann-ess-upper",
     "proofId": "erdos-14",
-    "range": { "startLine": 62, "endLine": 67 },
+    "range": { "startLine": 67, "endLine": 74 },
     "type": "theorem",
-    "title": "ESS Upper Bound",
-    "content": "Erdős–Sárközy–Szemerédi: there exists A with non-unique count ≪ N^{1/2+ε}. Close to √N from above.",
-    "significance": "key"
+    "title": "ESS Upper Bound: $O(N^{1/2+\\varepsilon})$ Achievable",
+    "content": "Erdős, Sárközy, and Szemerédi showed there exists $A \\subseteq \\mathbb{N}$ with $f_A(N) \\ll_{\\varepsilon} N^{1/2+\\varepsilon}$ for every $\\varepsilon > 0$. This means the non-unique count can be brought very close to $\\sqrt{N}$ — but the extra $N^{\\varepsilon}$ factor cannot be removed by their construction.",
+    "mathContext": "$\\exists A \\subseteq \\mathbb{N},\\, \\forall \\varepsilon > 0,\\, \\exists C > 0,\\, \\forall^{\\infty} N,\\, f_A(N) \\leq C N^{1/2 + \\varepsilon}$. The construction uses a probabilistic argument with careful adjustments to reduce collisions.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdős-Sárközy-Szemerédi",
+      "probabilistic construction",
+      "upper bounds"
+    ],
+    "prerequisites": [
+      "probabilistic method",
+      "representation function"
+    ]
   },
   {
     "id": "erdos-14-ann-ess-lower",
     "proofId": "erdos-14",
-    "range": { "startLine": 70, "endLine": 75 },
+    "range": { "startLine": 76, "endLine": 81 },
     "type": "theorem",
-    "title": "ESS Lower Bound",
-    "content": "The same ESS set has non-unique count ≫ N^{1/3−ε} for infinitely many N. The gap 1/3 to 1/2 is open.",
-    "significance": "key"
+    "title": "ESS Lower Bound: $\\Omega(N^{1/3-\\varepsilon})$ Infinitely Often",
+    "content": "The same ESS construction has $f_A(N) \\gg_{\\varepsilon} N^{1/3-\\varepsilon}$ for infinitely many $N$. This is the best known lower bound and uses the `∃ᶠ` (frequently) quantifier in Lean. The gap between the exponents $1/3$ and $1/2$ is the open territory of the problem.",
+    "mathContext": "$\\exists A \\subseteq \\mathbb{N},\\, \\forall \\varepsilon > 0,\\, \\exists C > 0,\\, \\exists^{\\infty} N,\\, f_A(N) \\geq C N^{1/3 - \\varepsilon}$. Note the weaker quantifier: this holds for infinitely many $N$ (not eventually all $N$), unlike conjecture (a).",
+    "significance": "key",
+    "relatedConcepts": [
+      "frequently quantifier",
+      "infinitely often bounds",
+      "exponent gap"
+    ],
+    "prerequisites": [
+      "Filter.Frequently",
+      "asymptotic lower bounds"
+    ]
   },
   {
     "id": "erdos-14-ann-ef",
     "proofId": "erdos-14",
-    "range": { "startLine": 78, "endLine": 82 },
+    "range": { "startLine": 83, "endLine": 88 },
     "type": "theorem",
-    "title": "Erdős–Freud Finite Analogue",
-    "content": "For finite A ⊆ {1,...,N}, the non-unique count is < 2^{3/2}·√N. The constant may be optimal.",
-    "significance": "key"
+    "title": "Erdős-Freud Finite Analogue",
+    "content": "For the finite version (restricting $A \\subseteq \\{1, \\ldots, N\\}$), Erdős and Freud showed there exists $A$ with non-unique count less than $2^{3/2} \\sqrt{N} \\approx 2.83 \\sqrt{N}$. The constant $2^{3/2}$ may be optimal. This gives a concrete bound rather than an asymptotic one.",
+    "mathContext": "$\\forall N \\geq 1,\\, \\exists A \\subseteq \\{1, \\ldots, N\\},\\, |\\{1, \\ldots, N\\} \\setminus \\text{uniqueSums}(A)| < 2^{3/2} \\sqrt{N}$. The constant $2^{3/2} = 2\\sqrt{2}$ arises from optimizing the finite construction.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdős-Freud",
+      "finite analogues",
+      "explicit constants"
+    ],
+    "prerequisites": [
+      "finite combinatorics",
+      "Finset.Icc"
+    ]
   },
   {
     "id": "erdos-14-ann-sidon",
     "proofId": "erdos-14",
-    "range": { "startLine": 89, "endLine": 94 },
+    "range": { "startLine": 90, "endLine": 99 },
     "type": "theorem",
-    "title": "Sidon Set Structure",
-    "content": "Sidon sets give perfect uniqueness but are too sparse: |A∩{1,...,N}| ≤ √N + O(N^{1/4}), leaving ~N unrepresented integers.",
-    "significance": "supporting"
+    "title": "Sidon Set Analysis",
+    "content": "Sidon sets (sets where all pairwise sums are distinct) give perfect uniqueness — every sum has exactly one representation. But Sidon sets are too sparse: $|A \\cap \\{1, \\ldots, N\\}| \\leq \\sqrt{N} + O(N^{1/4})$. This means the sumset $A + A$ has at most $\\sim N$ elements, missing about half of $\\{1, \\ldots, N\\}$. So Sidon sets solve the uniqueness problem but fail the coverage problem.",
+    "mathContext": "If $A$ is Sidon (i.e., $a+b = c+d,\\, a \\leq b,\\, c \\leq d \\implies a=c \\wedge b=d$), then $\\text{uniqueSums}(A) = A + A$, so $f_A(N) = N - |A + A \\cap [1,N]|$. Since $|A \\cap [1,N]| \\leq \\sqrt{N} + O(N^{1/4})$, we get $|A+A| \\leq N + O(N^{3/4})$, hence $f_A(N) \\geq N/2$ eventually.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Sidon sets",
+      "B₂ sequences",
+      "sumset size bounds"
+    ],
+    "prerequisites": [
+      "Sidon set density bounds",
+      "sumset cardinality"
+    ]
+  },
+  {
+    "id": "ann-e14-monotone",
+    "proofId": "erdos-14",
+    "range": { "startLine": 101, "endLine": 103 },
+    "type": "technique",
+    "title": "Monotonicity of Non-Unique Count",
+    "content": "The non-unique count $f_A(N) = |\\{1, \\ldots, N\\} \\setminus B|$ is monotonically non-decreasing in $N$: adding more integers to the range can only increase the count of non-uniquely represented ones. This simple observation is useful for converting 'infinitely often' bounds to 'eventually' bounds.",
+    "mathContext": "$M \\leq N \\implies f_A(M) \\leq f_A(N)$. This follows because $\\{1, \\ldots, M\\} \\setminus B \\subseteq \\{1, \\ldots, N\\} \\setminus B$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monotone functions",
+      "counting function properties"
+    ],
+    "prerequisites": [
+      "set inclusion",
+      "cardinality monotonicity"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -10,10 +10,10 @@
     "proofRepoPath": "Proofs/Erdos14Problem.lean",
     "tags": [
       "erdos",
-      "additive combinatorics",
-      "unique representation",
+      "additive-combinatorics",
+      "unique-representation",
       "sumsets",
-      "Sidon sets"
+      "sidon-sets"
     ],
     "badge": "formalized",
     "sorries": 0,
@@ -22,54 +22,83 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős asked about the minimum non-unique sum count for subsets of ℕ. Erdős–Sárközy–Szemerédi showed O(N^{1/2+ε}) is achievable but Ω(N^{1/3−ε}) occurs infinitely often. Erdős–Freud gave the finite analogue with constant 2^{3/2}. The exact exponent in the lower bound remains open.",
-    "problemStatement": "(a) Must |{1,...,N}\\B| ≫ N^{1/2−ε} for all A and ε > 0? (b) Can |{1,...,N}\\B| = o(√N)?",
-    "proofStrategy": "We formalize unique sums, non-unique count for both finite and infinite sets, the two open questions, the ESS upper/lower bounds, the Erdős–Freud finite result, and structural observations about Sidon sets.",
+    "historicalContext": "This problem was originally considered by Erdős and Nathanson, and later attributed by Erdős to joint work with Sárközy and Szemerédi (references [Er92c], [Er97], [Er97e]). It asks a fundamental question about the trade-off between uniqueness and coverage in additive representation: given $A \\subseteq \\mathbb{N}$, the set $B$ of integers with exactly one representation as $a + b$ ($a \\leq b$, $a, b \\in A$) captures the 'well-represented' sums. The complementary set $\\{1, \\ldots, N\\} \\setminus B$ consists of integers that are either unrepresented or multiply represented.\n\nThe key tension is that making $A$ larger increases coverage (fewer unrepresented integers) but also increases collisions (more multiply represented integers). Sidon sets, where all sums are distinct, achieve perfect uniqueness but are too sparse ($|A| \\leq \\sqrt{N} + O(N^{1/4})$) to cover even half of $\\{1, \\ldots, N\\}$. At the other extreme, dense sets cover everything but have massive collision counts.\n\nThe main quantitative results are by Erdős, Sárközy, and Szemerédi: they constructed $A \\subseteq \\mathbb{N}$ achieving $f_A(N) = O_{\\varepsilon}(N^{1/2+\\varepsilon})$ for all $\\varepsilon > 0$, showing the non-unique count can be brought very close to $\\sqrt{N}$ from above. However, they also proved that for this same set, $f_A(N) \\gg_{\\varepsilon} N^{1/3-\\varepsilon}$ for infinitely many $N$. Erdős and Freud (1991) proved a finite analogue: for $A \\subseteq \\{1, \\ldots, N\\}$, there exists a choice with non-unique count $< 2^{3/2}\\sqrt{N}$, and the constant $2^{3/2}$ may be optimal.",
+    "problemStatement": "(a) Must $|\\{1, \\ldots, N\\} \\setminus B| \\gg_{\\varepsilon} N^{1/2-\\varepsilon}$ for all $A \\subseteq \\mathbb{N}$ and $\\varepsilon > 0$? (b) Can $|\\{1, \\ldots, N\\} \\setminus B| = o(\\sqrt{N})$ for some $A$?",
+    "proofStrategy": "The formalization defines `uniqueSums` for finite sets (filtering for representation count $= 1$), `uniqueSumsInf` for infinite sets (using `∃!` for unique existence), and `nonUniqueSumCount`/`nonUniqueSumCountInf` as the complementary counting functions. Both conjectures are stated using Lean's `Filter.atTop` for asymptotic quantifiers. The ESS bounds use `∀ᶠ` (eventually) and `∃ᶠ` (frequently) to distinguish 'for all large $N$' from 'for infinitely many $N$'. Structural results about Sidon sets and monotonicity are included.",
     "keyInsights": [
-      "Unique representation sums form a sparse subset of all sums",
-      "ESS construction achieves O(N^{1/2+ε}) but not O(√N)",
-      "The gap between N^{1/3} and N^{1/2} lower bounds is the open territory",
-      "Sidon sets give perfect uniqueness but miss too many integers",
-      "Erdős–Freud: finite analogue with optimal constant 2^{3/2}"
+      "The problem encodes a fundamental uniqueness-coverage trade-off: Sidon sets give perfect uniqueness ($B = A+A$) but miss $\\sim N/2$ integers, while dense sets cover everything but have $\\sim N$ collisions. The question is whether any intermediate construction can reduce the non-unique count below $\\sqrt{N}$.",
+      "The ESS exponent gap $1/3 < ? < 1/2$ is the open territory. The upper bound $O(N^{1/2+\\varepsilon})$ and the lower bound $\\Omega(N^{1/3-\\varepsilon})$ leave a wide range for the true threshold. Conjecture (a) predicts the answer is $\\sim N^{1/2}$, matching the Sidon set barrier.",
+      "The distinction between `∀ᶠ` (eventually: for all $N \\geq N_0$) and `∃ᶠ` (frequently: for infinitely many $N$) is mathematically crucial. The ESS lower bound $N^{1/3-\\varepsilon}$ holds only frequently, while conjecture (a) requires an eventual lower bound — a much stronger statement.",
+      "The Erdős-Freud constant $2^{3/2} = 2\\sqrt{2} \\approx 2.83$ in the finite analogue provides a concrete target. If it is optimal, it suggests that the non-unique count cannot be made smaller than $\\sim \\sqrt{N}$ even with the best finite constructions.",
+      "The problem cannot be resolved by finite computation (as noted on erdosproblems.com), since it asks about the behavior of $f_A(N)$ as $N \\to \\infty$ for all infinite sets $A$. This is fundamentally an asymptotic question requiring analytical or structural methods."
     ]
   },
   "sections": [
     {
-      "id": "definitions",
-      "title": "Core Definitions",
-      "startLine": 22,
-      "endLine": 46,
-      "summary": "Defines unique sums, non-unique sum count for finite and infinite sets."
+      "id": "header",
+      "title": "Problem Statement and References",
+      "startLine": 1,
+      "endLine": 22,
+      "summary": "Documents the two-part problem, references to Erdős [Er92c, Er97, Er97e], Erdős-Freud [ErFr91], and OEIS A143824."
+    },
+    {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 23,
+      "endLine": 28,
+      "summary": "Imports Mathlib's asymptotics library and finset basics. Opens `Finset`, `Filter`, `Asymptotics` for `atTop`, `∀ᶠ`, `∃ᶠ`."
+    },
+    {
+      "id": "unique-sums",
+      "title": "Unique Sums Definition",
+      "startLine": 30,
+      "endLine": 38,
+      "summary": "Defines `uniqueSums A` for finite $A$: integers with exactly one representation as $a+b$ ($a \\leq b$). Uses `Finset.filter` with `.card = 1`."
+    },
+    {
+      "id": "counting",
+      "title": "Non-Unique Sum Counting Functions",
+      "startLine": 40,
+      "endLine": 50,
+      "summary": "Defines `nonUniqueSumCount` (finite) and `nonUniqueSumCountInf` (infinite via `Set.ncard`) — the quantity $f_A(N) = |\\{1,\\ldots,N\\} \\setminus B|$."
     },
     {
       "id": "conjectures",
-      "title": "Main Conjectures",
-      "startLine": 48,
-      "endLine": 58,
-      "summary": "States the two open questions: lower bound ≫ N^{1/2−ε} and possibility of o(√N)."
+      "title": "Main Conjectures (14a and 14b)",
+      "startLine": 52,
+      "endLine": 65,
+      "summary": "States (a) $f_A(N) \\gg N^{1/2-\\varepsilon}$ eventually and (b) $\\exists A$ with $f_A(N) = o(\\sqrt{N})$, using `∀ᶠ` and filter quantifiers."
     },
     {
-      "id": "known",
-      "title": "Known Results",
-      "startLine": 60,
-      "endLine": 85,
-      "summary": "ESS upper and lower bounds, Erdős–Freud finite analogue with constant 2^{3/2}."
+      "id": "ess-bounds",
+      "title": "Erdős-Sárközy-Szemerédi Bounds",
+      "startLine": 67,
+      "endLine": 81,
+      "summary": "Upper: $\\exists A$ with $f_A(N) \\leq CN^{1/2+\\varepsilon}$ eventually. Lower: same $A$ has $f_A(N) \\geq CN^{1/3-\\varepsilon}$ frequently."
+    },
+    {
+      "id": "erdos-freud",
+      "title": "Erdős-Freud Finite Analogue",
+      "startLine": 83,
+      "endLine": 88,
+      "summary": "For $A \\subseteq \\{1,\\ldots,N\\}$, $\\exists A$ with $f_A(N) < 2^{3/2}\\sqrt{N}$. The constant $2\\sqrt{2}$ may be optimal."
     },
     {
       "id": "structural",
       "title": "Structural Observations",
-      "startLine": 87,
-      "endLine": 106,
-      "summary": "Sidon set analysis, random heuristic, monotonicity of non-unique count."
+      "startLine": 90,
+      "endLine": 103,
+      "summary": "Sidon sets give $f_A(N) \\geq N/2$ (perfect uniqueness, poor coverage). Monotonicity: $M \\leq N \\implies f_A(M) \\leq f_A(N)$."
     }
   ],
   "conclusion": {
-    "summary": "Formalizes Erdős Problem #14 on unique-sum representation. The non-unique count lies between N^{1/3} and N^{1/2+ε}; the exact threshold remains open. Both questions (a) and (b) are unresolved.",
-    "implications": "A resolution would clarify the structure of sumsets with unique representations, connecting to additive combinatorics and probabilistic number theory.",
+    "summary": "This formalization captures Erdős Problem #14 in 104 lines of Lean 4, encoding the unique-sum representation problem with both finite and infinite versions, the two open conjectures, ESS bounds ($O(N^{1/2+\\varepsilon})$ eventually, $\\Omega(N^{1/3-\\varepsilon})$ frequently), the Erdős-Freud finite analogue, and structural observations about Sidon sets. Zero sorries; all deep results axiomatized.",
+    "implications": "Resolution would clarify the fundamental limits of unique representation in additive combinatorics. If conjecture (a) holds, it establishes $\\sqrt{N}$ as a universal barrier — no set can achieve better than $\\sim \\sqrt{N}$ non-unique sums. This connects to the broader theory of additive bases, Sidon sets, and the probabilistic method in combinatorial number theory.",
     "openQuestions": [
-      "Is |{1,...,N}\\B| ≫ N^{1/2−ε} for all A?",
-      "Can |{1,...,N}\\B| = o(√N)?",
-      "What is the optimal exponent in the lower bound?"
+      "Is $f_A(N) \\gg N^{1/2-\\varepsilon}$ for all $A$ and all large $N$? This is conjecture (a), the main open question.",
+      "Can $f_A(N) = o(\\sqrt{N})$ for some $A$? This is conjecture (b), which if true would refute (a).",
+      "What is the true exponent in the lower bound? The gap between the ESS bounds ($1/3$ from below, $1/2$ from above) leaves room for the answer to lie anywhere in $(1/3, 1/2]$.",
+      "Is the Erdős-Freud constant $2^{3/2}$ optimal for the finite analogue? What is the extremal set achieving this bound?"
     ]
   }
 }

--- a/src/data/proofs/erdos-152/annotations.json
+++ b/src/data/proofs/erdos-152/annotations.json
@@ -1,56 +1,172 @@
 [
   {
+    "id": "ann-e152-header",
+    "proofId": "erdos-152",
+    "range": { "startLine": 1, "endLine": 13 },
+    "type": "context",
+    "title": "Problem Overview",
+    "content": "Header documenting Erdős Problem #152 on isolated elements in Sidon sumsets. For large finite Sidon sets $A$, the sumset $A + A$ is known to have $n(n+1)/2$ elements (where $n = |A|$), fitting inside an interval of length $\\sim 2n^2$. The question is whether many elements of $A + A$ are isolated — having no neighbors in the sumset. The stronger form conjectures $\\gg n^2$ isolated elements.",
+    "mathContext": "For a Sidon set $A$ with $|A| = n$, the sumset $A + A \\subseteq [2\\min A, 2\\max A]$ has exactly $\\binom{n+1}{2}$ elements in an interval of length $\\sim 2n^2$. The density is $\\binom{n+1}{2} / (2n^2) \\approx 1/4$, so roughly 3/4 of the interval is not covered. The conjecture asks how many covered points are completely surrounded by gaps.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Sidon sets",
+      "B₂ sequences",
+      "sumset structure",
+      "gap distribution"
+    ],
+    "prerequisites": [
+      "Sidon set definition",
+      "sumset notation"
+    ]
+  },
+  {
+    "id": "ann-e152-imports",
+    "proofId": "erdos-152",
+    "range": { "startLine": 15, "endLine": 22 },
+    "type": "context",
+    "title": "Imports",
+    "content": "Imports Mathlib's Sidon set library (`Combinatorics.Additive.Sidon`), pointwise finset operations for $A + A$, and filter basics for the infinite version. Opens `Pointwise` for the `+` notation on finsets.",
+    "mathContext": "Uses `Finset.Pointwise` for $A + A = \\{a + b : a \\in A,\\, b \\in A\\}$. The Sidon property from Mathlib states that the sumset map $(a,b) \\mapsto a+b$ is injective on unordered pairs.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Mathlib.Combinatorics.Additive.Sidon",
+      "Finset.Pointwise"
+    ],
+    "prerequisites": [
+      "Finset pointwise operations"
+    ]
+  },
+  {
     "id": "erdos-152-sidon",
     "proofId": "erdos-152",
     "type": "definition",
-    "range": { "startLine": 28, "endLine": 35 },
+    "range": { "startLine": 24, "endLine": 35 },
     "title": "Sidon Sets and Sumsets",
-    "content": "IsSidonFinset A requires all pairwise sums to be distinct. sumsetFinset computes A + A via pointwise addition.",
-    "significance": "essential"
+    "content": "Defines `IsSidonFinset A`: all pairwise sums are distinct, i.e., $a_1 + b_1 = a_2 + b_2$ implies $\\{a_1, b_1\\} = \\{a_2, b_2\\}$. Also defines `sumsetFinset A = A + A` using Mathlib's pointwise addition. The Sidon property ensures $|A + A| = \\binom{n+1}{2}$ (every unordered pair gives a distinct sum).",
+    "mathContext": "$A$ is Sidon $\\iff \\forall a_1, b_1, a_2, b_2 \\in A,\\, a_1 + b_1 = a_2 + b_2 \\implies \\{a_1, b_1\\} = \\{a_2, b_2\\}$. Equivalently, the representation function $r(n) = |\\{(a,b) : a \\leq b,\\, a+b = n,\\, a,b \\in A\\}|$ satisfies $r(n) \\leq 1$ for all $n$. The sumset $A + A = \\{a + b : a, b \\in A\\}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "B₂ sequences",
+      "representation function",
+      "distinct pairwise sums"
+    ],
+    "prerequisites": [
+      "Finset operations",
+      "set equality"
+    ]
   },
   {
     "id": "erdos-152-isolated",
     "proofId": "erdos-152",
     "type": "definition",
-    "range": { "startLine": 41, "endLine": 49 },
-    "title": "Isolated Elements",
-    "content": "An element s ∈ A + A is isolated if neither s-1 nor s+1 belongs to A + A. isolatedCount measures how many such elements exist.",
-    "significance": "essential"
+    "range": { "startLine": 37, "endLine": 49 },
+    "title": "Isolated Elements and Their Count",
+    "content": "An element $s \\in A + A$ is isolated if $s - 1 \\notin A + A$ and $s + 1 \\notin A + A$ — it has no sumset neighbors. `isolatedCount A` counts these elements via `Finset.filter`. Isolated elements represent the most extreme form of sparsity in the sumset: not just gaps, but completely surrounded by gaps.",
+    "mathContext": "$\\text{IsIsolated}(A, s) \\iff s \\in A + A \\wedge (s-1) \\notin A + A \\wedge (s+1) \\notin A + A$. The isolated count is $I(A) = |\\{s \\in A + A : s \\pm 1 \\notin A + A\\}|$. For $A = \\{0, 1, 3, 5, 11\\}$ (a Sidon set), $A + A = \\{0,1,2,3,4,6,8,12,14,16,22\\}$ and the isolated elements are $\\{8, 22\\}$ (for example).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "gap structure",
+      "isolated points in sets",
+      "discrete topology"
+    ],
+    "prerequisites": [
+      "Finset.filter",
+      "membership testing"
+    ]
   },
   {
     "id": "erdos-152-conjecture",
     "proofId": "erdos-152",
-    "type": "conjecture",
-    "range": { "startLine": 55, "endLine": 60 },
-    "title": "Erdős Problem 152",
-    "content": "For any M, sufficiently large Sidon sets A have at least M isolated elements in A + A. The number of isolated elements grows without bound.",
-    "significance": "essential"
+    "type": "concept",
+    "range": { "startLine": 51, "endLine": 60 },
+    "title": "Erdős Problem 152: Weak Form",
+    "content": "The weak form of the conjecture: for any $M \\geq 1$, all sufficiently large Sidon sets have at least $M$ isolated elements. This says the isolated count grows without bound as the Sidon set grows. Formalized with a $\\forall M,\\, \\exists N_0$ quantifier structure — the threshold $N_0$ depends on $M$.",
+    "mathContext": "$\\text{ErdosProblem152}: \\forall M \\in \\mathbb{N},\\, \\exists N_0,\\, \\forall A$ Sidon with $|A| \\geq N_0,\\, I(A) \\geq M$. This is equivalent to: $\\lim_{n \\to \\infty} \\inf\\{I(A) : A \\text{ Sidon},\\, |A| = n\\} = \\infty$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "divergence conditions",
+      "extremal Sidon sets",
+      "sumset gap growth"
+    ],
+    "prerequisites": [
+      "quantifier structure",
+      "Sidon set growth"
+    ]
   },
   {
     "id": "erdos-152-strong",
     "proofId": "erdos-152",
-    "type": "conjecture",
-    "range": { "startLine": 66, "endLine": 72 },
-    "title": "Strong Form: ≫ |A|²",
-    "content": "The stronger conjecture: isolatedCount ≥ c·|A|² for some absolute constant c > 0, meaning a positive fraction of the sumset is isolated.",
-    "significance": "essential"
+    "type": "concept",
+    "range": { "startLine": 62, "endLine": 72 },
+    "title": "Strong Form: $\\gg |A|^2$ Isolated Elements",
+    "content": "The stronger conjecture: $I(A) \\geq c \\cdot |A|^2$ for some absolute constant $c > 0$. Since $|A + A| = \\binom{|A|+1}{2} \\sim |A|^2/2$, this says a positive fraction of the sumset is isolated. This is a much stronger statement than the weak form — it gives the exact growth rate rather than just divergence.",
+    "mathContext": "$\\exists c > 0,\\, \\forall A$ Sidon: $I(A) \\geq c \\cdot |A|^2$. Since $|A + A| = |A|(|A|+1)/2$, this means $I(A)/|A+A| \\geq 2c/(1 + 1/|A|) \\to 2c$, i.e., at least a fraction $2c$ of all sumset elements are isolated.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "linear proportion",
+      "sumset density",
+      "quadratic growth"
+    ],
+    "prerequisites": [
+      "Sidon sumset size",
+      "asymptotic analysis"
+    ]
   },
   {
     "id": "erdos-152-sumset-size",
     "proofId": "erdos-152",
-    "type": "result",
-    "range": { "startLine": 78, "endLine": 88 },
-    "title": "Sumset Size Bounds",
-    "content": "For Sidon sets of size n: |A + A| = n(n+1)/2 and max element ≥ n² - n + 1. These bounds constrain the sumset structure.",
-    "significance": "essential"
+    "type": "theorem",
+    "range": { "startLine": 74, "endLine": 88 },
+    "title": "Sumset Size and Range Bounds",
+    "content": "Two fundamental facts about Sidon sumsets: (1) $|A + A| = n(n+1)/2$ since the Sidon property ensures all sums are distinct, and (2) $\\max A \\geq n^2 - n + 1$ since the elements must be spread out enough to avoid sum collisions. Together, these show the sumset has $\\sim n^2/2$ elements in an interval of length $\\sim 2n^2$, giving density $\\sim 1/4$.",
+    "mathContext": "If $A$ is Sidon with $|A| = n$: $|A + A| = \\binom{n+1}{2} = n(n+1)/2$. Also $\\max A \\geq n^2 - n + 1$ (since $A \\subseteq \\{0, \\ldots, N\\}$ requires $N \\geq n^2 - n$ for the Sidon property). The sumset density in $[2\\min A, 2\\max A]$ is $\\frac{n(n+1)/2}{2(\\max A - \\min A)} \\approx \\frac{1}{4}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Sidon set counting",
+      "combinatorial identity",
+      "minimum range bounds"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "Sidon set density bounds"
+    ]
+  },
+  {
+    "id": "erdos-152-pigeonhole",
+    "proofId": "erdos-152",
+    "type": "theorem",
+    "range": { "startLine": 90, "endLine": 99 },
+    "title": "Pigeonhole Gap Existence",
+    "content": "A basic result: for Sidon sets of size $\\geq 5$, there is at least one isolated element. This follows from the pigeonhole principle: $n(n+1)/2$ sumset elements in an interval of length $\\sim 2n^2$ cannot all be consecutive, so gaps must exist, and some sumset elements must be isolated. This is the starting point — the conjecture asks for much more.",
+    "mathContext": "The sumset $A + A$ has $n(n+1)/2$ elements in $[2\\min A, 2\\max A]$, an interval of length $\\leq 2(n^2 - n)$. Since $n(n+1)/2 < 2(n^2 - n)$ for $n \\geq 5$, there are at least $2(n^2-n) - n(n+1)/2 = (3n^2 - 5n)/2$ gaps. Not all gaps create isolated elements, but at least one does.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "gap counting",
+      "existence proofs"
+    ],
+    "prerequisites": [
+      "pigeonhole principle",
+      "interval counting"
+    ]
   },
   {
     "id": "erdos-152-infinite",
     "proofId": "erdos-152",
-    "type": "context",
+    "type": "concept",
     "range": { "startLine": 101, "endLine": 109 },
     "title": "Infinite Sidon Set Version",
-    "content": "The analogous question for infinite Sidon sets: do truncations A ∩ [1,N] produce unboundedly many isolated elements as N → ∞?",
-    "significance": "supporting"
+    "content": "The analogous question for infinite Sidon sets: if $A \\subset \\mathbb{N}$ is an infinite Sidon set and $A_N = A \\cap [1, N]$, does the isolated count of $A_N + A_N$ tend to infinity as $N \\to \\infty$? This is potentially easier than the finite version since infinite Sidon sets have additional structural constraints (e.g., $|A \\cap [1,N]| \\leq \\sqrt{N} + O(N^{1/4})$).",
+    "mathContext": "$\\text{ErdosProblem152Infinite}: \\forall A \\subset \\mathbb{N}$ infinite Sidon, $\\forall M,\\, \\exists N_0,\\, I(A \\cap [1,N_0]) \\geq M$. The truncation $A_N$ is itself a finite Sidon set of growing size, so the finite conjecture would imply this.",
+    "significance": "key",
+    "relatedConcepts": [
+      "infinite Sidon sets",
+      "truncation arguments",
+      "asymptotic behavior"
+    ],
+    "prerequisites": [
+      "infinite set truncation",
+      "Filter.atTop"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-152/meta.json
+++ b/src/data/proofs/erdos-152/meta.json
@@ -21,67 +21,83 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős, Sárközy, and Sós (1994) studied the structure of sumsets A + A when A is a Sidon set. They asked whether large Sidon sets always produce many isolated elements in A + A — elements with no neighbors in the sumset. The stronger form conjectures ≫ |A|² such elements.",
-    "problemStatement": "For any M ≥ 1, if A ⊂ ℕ is a sufficiently large finite Sidon set, do there exist at least M elements a ∈ A + A such that a - 1, a + 1 ∉ A + A?",
-    "proofStrategy": "We define IsSidonFinset (distinct pairwise sums), sumsetFinset (A + A), IsIsolated and isolatedCount. ErdosProblem152 states the weak version (unbounded count). ErdosProblem152Strong states the ≫ |A|² version. Sumset size and range bounds for Sidon sets are axiomatized. The infinite version is also stated.",
+    "historicalContext": "This problem was posed by Erdős, Sárközy, and Sós in their 1994 paper 'On Sum Sets of Sidon Sets, I' in the Journal of Number Theory (pp. 329-347). They initiated a systematic study of the additive structure of Sidon sumsets, asking not just about the size of $A + A$ (which is exactly $\\binom{n+1}{2}$ for a Sidon set of size $n$) but about its fine structure — how the elements are distributed within their range.\n\nA Sidon set (also called a $B_2$ sequence) is a set where all pairwise sums are distinct: $a_1 + b_1 = a_2 + b_2$ implies $\\{a_1, b_1\\} = \\{a_2, b_2\\}$. Classical results show that a Sidon subset of $\\{1, \\ldots, N\\}$ has at most $\\sqrt{N} + O(N^{1/4})$ elements, so the sumset $A + A$ contains $\\sim N/2$ elements in an interval of length $\\sim 2N$ — density roughly $1/4$. This means roughly 3/4 of the interval is 'gaps', and the question is how many sumset elements are completely surrounded by these gaps.\n\nThe problem has a weak form (the isolated count grows without bound) and a strong form ($\\gg |A|^2$ isolated elements, meaning a positive fraction of the sumset is isolated). Neither version has been resolved. The pigeonhole principle gives at least one isolated element for $|A| \\geq 5$, but going from one to unboundedly many requires understanding the global distribution of sums, not just local density.",
+    "problemStatement": "For any $M \\geq 1$, if $A \\subset \\mathbb{N}$ is a sufficiently large finite Sidon set, do there exist at least $M$ elements $s \\in A + A$ such that $s - 1, s + 1 \\notin A + A$?",
+    "proofStrategy": "The formalization defines `IsSidonFinset` (distinct pairwise sums via multiset equality), `sumsetFinset` ($A + A$ via pointwise addition), `IsIsolated` (no sumset neighbors), and `isolatedCount`. The weak conjecture `ErdosProblem152` uses a $\\forall M, \\exists N_0$ structure. The strong conjecture `ErdosProblem152Strong` asserts $I(A) \\geq c|A|^2$. Supporting axioms give the exact sumset size ($n(n+1)/2$), the minimum range bound ($\\max A \\geq n^2 - n + 1$), and a pigeonhole existence result. The infinite version `ErdosProblem152Infinite` is also stated.",
     "keyInsights": [
-      "Sidon sets have |A + A| = n(n+1)/2, nearly half of all possible sums",
-      "The sumset fits in an interval of length ≤ 2·max A, creating many gaps",
-      "Isolated elements are those with no sumset neighbors, measuring sparsity",
-      "The conjectured ≫ |A|² count says a positive fraction of the sumset is isolated"
+      "For a Sidon set of size $n$, the sumset $A + A$ has exactly $n(n+1)/2$ elements (all unordered-pair sums distinct) in an interval of length $\\sim 2n^2$. The sumset density is $\\sim 1/4$, meaning the sumset is a sparse subset of its range with many gaps. The conjecture asks about the *fine structure* of these gaps.",
+      "The strong conjecture ($\\gg n^2$ isolated elements) says that a positive fraction of the sumset elements are isolated. Since $|A + A| \\sim n^2/2$, this would mean $\\sim cn^2$ out of $\\sim n^2/2$ elements have no neighbors — a constant fraction. This is a statement about the 'lacunarity' of Sidon sumsets.",
+      "The difficulty lies in controlling the *local* structure of the sumset. Pigeonhole arguments show that gaps exist and are numerous ($\\sim 3n^2/2$ total gaps), but converting gaps into isolated elements requires that gaps are not all clustered together — they must be well-distributed throughout the sumset.",
+      "The problem connects to deeper questions about the additive energy of Sidon sets and the distribution of gaps in sumsets. Random Sidon-like sets would have isolated elements in proportion to $n^2$, suggesting the conjecture is true, but deterministic Sidon sets could potentially have more structured gap patterns.",
+      "The infinite version is related but distinct: for infinite Sidon sets $A \\subset \\mathbb{N}$, the truncations $A \\cap [1,N]$ are finite Sidon sets of growing size ($\\sim \\sqrt{N}$), so the finite conjecture would imply unbounded isolated counts for truncations. However, the infinite version might be provable with weaker methods."
     ]
   },
   "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and References",
+      "startLine": 1,
+      "endLine": 13,
+      "summary": "Documents the problem from Erdős-Sárközy-Sós (1994), J. Number Theory. States both the weak (unbounded) and strong ($\\gg |A|^2$) forms."
+    },
+    {
+      "id": "imports",
+      "title": "Imports",
+      "startLine": 15,
+      "endLine": 22,
+      "summary": "Imports Mathlib Sidon set library, pointwise finset operations, and filter basics. Opens `Pointwise` scope."
+    },
     {
       "id": "sidon-sumsets",
       "title": "Sidon Sets and Sumsets",
       "startLine": 24,
       "endLine": 35,
-      "summary": "Defines IsSidonFinset (distinct pairwise sums) and sumsetFinset (A + A)."
+      "summary": "Defines `IsSidonFinset` (distinct pairwise sums) and `sumsetFinset A = A + A`. The Sidon property gives $|A+A| = \\binom{n+1}{2}$."
     },
     {
       "id": "isolated-elements",
       "title": "Isolated Elements",
       "startLine": 37,
       "endLine": 49,
-      "summary": "Defines IsIsolated (no sumset neighbors) and isolatedCount."
+      "summary": "Defines `IsIsolated` ($s \\pm 1 \\notin A+A$) and `isolatedCount` via `Finset.filter`. The central counting function of the problem."
     },
     {
-      "id": "conjecture",
-      "title": "The Conjecture",
+      "id": "weak-conjecture",
+      "title": "Weak Conjecture: Unbounded Isolated Count",
       "startLine": 51,
       "endLine": 60,
-      "summary": "States ErdosProblem152: isolatedCount → ∞ as |A| → ∞ over Sidon sets."
+      "summary": "States `ErdosProblem152`: $\\forall M, \\exists N_0, \\forall$ Sidon $A$ with $|A| \\geq N_0$, $I(A) \\geq M$."
     },
     {
       "id": "strong-conjecture",
-      "title": "The Stronger Conjecture",
+      "title": "Strong Conjecture: $\\gg |A|^2$ Isolated Elements",
       "startLine": 62,
       "endLine": 72,
-      "summary": "ErdosProblem152Strong: isolatedCount ≥ c·|A|² for some c > 0."
+      "summary": "States `ErdosProblem152Strong`: $\\exists c > 0$ with $I(A) \\geq c|A|^2$ for all Sidon $A$. A constant fraction of the sumset is isolated."
     },
     {
-      "id": "sumset-size",
-      "title": "Sumset Size for Sidon Sets",
+      "id": "sumset-bounds",
+      "title": "Sumset Size and Range Bounds",
       "startLine": 74,
       "endLine": 88,
-      "summary": "|A + A| = n(n+1)/2 and Sidon sets need max element ≥ n² - n + 1."
+      "summary": "Axiomatizes $|A+A| = n(n+1)/2$ and $\\max A \\geq n^2 - n + 1$ for Sidon sets of size $n$."
     },
     {
-      "id": "related-results",
-      "title": "Related Results",
+      "id": "related",
+      "title": "Pigeonhole and Infinite Version",
       "startLine": 90,
       "endLine": 109,
-      "summary": "Pigeonhole gap existence and the infinite Sidon set version."
+      "summary": "Pigeonhole: $I(A) \\geq 1$ for $|A| \\geq 5$. Infinite version: does $I(A \\cap [1,N]) \\to \\infty$ for infinite Sidon $A$?"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 152 asks whether large Sidon sets always produce many isolated elements in their sumsets. The weak version (unbounded count) and strong version (≫ |A|²) are both open.",
-    "implications": "Understanding the gap structure of Sidon sumsets connects to additive combinatorics and the inverse sumset problem.",
+    "summary": "This formalization captures Erdős Problem #152 in 109 lines of Lean 4, encoding the isolated element counting problem for Sidon sumsets with both weak (unbounded) and strong ($\\gg |A|^2$) forms, the exact sumset size identity, range bounds, pigeonhole existence, and the infinite version. Zero sorries; structural results axiomatized.",
+    "implications": "Resolution would reveal the fine structure of Sidon sumsets beyond mere counting. The strong form would establish that Sidon sumsets are inherently 'lacunary' — not just sparse on average, but with many isolated points. This connects to the theory of $B_2$ sequences, additive energy bounds, and the broader question of how arithmetic structure (the Sidon property) constrains the distribution of sums.",
     "openQuestions": [
-      "Does isolatedCount → ∞ for large Sidon sets?",
-      "Is isolatedCount ≥ c·|A|² for some absolute constant c?",
-      "Does the analogous result hold for infinite Sidon sets?"
+      "Does $I(A) \\to \\infty$ as $|A| \\to \\infty$ over Sidon sets? This is the weak form, still open.",
+      "Is $I(A) \\geq c|A|^2$ for some absolute $c > 0$? This is the strong form. What is the optimal constant $c$?",
+      "Does the infinite version hold: for infinite Sidon $A \\subset \\mathbb{N}$, does $I(A \\cap [1,N]) \\to \\infty$?",
+      "What is the minimum isolated count among all Sidon sets of size $n$? Computational evidence for small $n$ could guide the conjecture."
     ]
   }
 }


### PR DESCRIPTION
## Summary
- **erdos-125**: Enriched annotations (8 with mathContext/LaTeX) and meta.json (Burr-Erdős-Graham-Li 1996, Marstrand heuristic, fractal dimension; 5 keyInsights; 8 sections)
- **erdos-128**: Enriched annotations (10 with mathContext/LaTeX) and meta.json (EFRS 1994, Keevash-Sudakov 2006, Razborov 2022 flag algebras; 5 keyInsights; 8 sections)
- **erdos-14**: Enriched annotations (11 with mathContext/LaTeX, added header/imports/monotonicity) and meta.json (Erdős-Nathanson-Sárközy-Szemerédi history, uniqueness-coverage trade-off; 5 keyInsights; 8 sections)

## Test plan
- [ ] Verify JSON validity
- [ ] Check gallery renders correctly
- [ ] Verify LaTeX renders in annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)