### PR TITLE
enrich(erdos-201): arithmetic progressions in integer sets

### DIFF
--- a/src/data/proofs/erdos-201/annotations.json
+++ b/src/data/proofs/erdos-201/annotations.json
@@ -1,65 +1,122 @@
 [
   {
-    "id": "erdos-201-arith-prog",
+    "id": "erdos-201-imports",
     "proofId": "erdos-201",
-    "type": "definition",
-    "range": { "startLine": 27, "endLine": 30 },
-    "title": "Arithmetic Progression",
-    "content": "IsArithProg defines a k-term arithmetic progression as a list of integers with constant common difference d between consecutive elements.",
-    "significance": "supporting"
+    "type": "concept",
+    "range": { "startLine": 23, "endLine": 26 },
+    "title": "Library Imports",
+    "content": "Imports Mathlib for finite sets, cardinality, integer arithmetic, and tactics. These provide Finset.Icc for the interval $\\{1, \\ldots, N\\}$, powerset for enumeration, and sup for computing maxima.",
+    "mathContext": "The formalization works over $\\mathbb{Z}$ using `Finset ℤ` for finite integer sets. `Finset.Icc 1 N` represents $\\{1, \\ldots, N\\}$ and `powerset.filter` enumerates AP-free subsets.",
+    "significance": "supporting",
+    "relatedConcepts": ["finite sets", "integer arithmetic", "powerset filtration"],
+    "prerequisites": ["Lean 4 basics", "Mathlib Finset library"]
   },
   {
     "id": "erdos-201-contains-ap",
     "proofId": "erdos-201",
     "type": "definition",
-    "range": { "startLine": 33, "endLine": 35 },
-    "title": "Contains AP of Length k",
-    "content": "ContainsAPOfLength A k holds when A contains elements a, a+d, a+2d, …, a+(k-1)d for some nonzero d. This is the standard definition of a k-term AP in a finite set.",
-    "significance": "essential"
+    "range": { "startLine": 33, "endLine": 39 },
+    "title": "AP Containment and AP-Free Sets",
+    "content": "ContainsAPOfLength$(A, k)$: $\\exists a, d \\in \\mathbb{Z}, d \\neq 0, k \\geq 1$, with $a + id \\in A$ for all $0 \\leq i < k$. IsAPFree$(A, k) = \\neg$ContainsAPOfLength$(A, k)$.",
+    "mathContext": "ContainsAPOfLength$(A, k)$: $\\exists a, d \\neq 0: \\{a, a+d, a+2d, \\ldots, a+(k-1)d\\} \\subseteq A$. This uses `Fin k` to index AP terms, giving $a + (i : \\mathbb{Z}) \\cdot d \\in A$ for each $i : \\text{Fin}\\,k$.",
+    "significance": "key",
+    "relatedConcepts": ["arithmetic progression", "AP-free sets", "Szemerédi's theorem"],
+    "prerequisites": ["Fin type", "Finset membership", "integer multiplication"]
   },
   {
-    "id": "erdos-201-ap-free",
+    "id": "erdos-201-ap-transfer",
     "proofId": "erdos-201",
-    "type": "definition",
-    "range": { "startLine": 39, "endLine": 41 },
-    "title": "AP-Free Set",
-    "content": "IsAPFree A k means A contains no k-term arithmetic progression. This is the negation of ContainsAPOfLength.",
-    "significance": "essential"
+    "type": "theorem",
+    "range": { "startLine": 42, "endLine": 57 },
+    "title": "AP Transfer and Subset Inheritance",
+    "content": "If $k \\leq l$ and $A$ contains an $l$-AP, then $A$ contains a $k$-AP (truncate). Consequently, $k$-AP-free implies $l$-AP-free for $l \\geq k$. Also, subsets of AP-free sets are AP-free. All three are proved in Lean.",
+    "mathContext": "contains_ap_of_le: truncate a $l$-AP $\\{a, a+d, \\ldots, a+(l-1)d\\}$ to its first $k$ terms via `Fin.castLE`. isAPFree_of_le and isAPFree_subset follow by contraposition. These are the basic structural lemmas for AP-free sets.",
+    "significance": "supporting",
+    "relatedConcepts": ["AP truncation", "monotonicity of AP-freeness", "subset inheritance"],
+    "prerequisites": ["ContainsAPOfLength", "IsAPFree", "Fin.castLE"]
   },
   {
     "id": "erdos-201-rk",
     "proofId": "erdos-201",
     "type": "definition",
-    "range": { "startLine": 47, "endLine": 50 },
-    "title": "R_k(N) Function",
-    "content": "R_k(N) is the maximum cardinality of a k-AP-free subset of {1,…,N}. Defined via supremum over the powerset of Finset.Icc filtered by the AP-free predicate.",
-    "significance": "essential"
+    "range": { "startLine": 64, "endLine": 67 },
+    "title": "$R_k(N)$: Maximum AP-Free Subset of $\\{1, \\ldots, N\\}$",
+    "content": "$R_k(N) = \\max\\{|A| : A \\subseteq \\{1, \\ldots, N\\}, A$ is $k$-AP-free$\\}$. Defined as the supremum of cardinality over the powerset of $\\text{Icc}\\,1\\,N$ filtered by IsAPFree.",
+    "mathContext": "rk$(k, N) = \\text{Finset.sup}((\\text{Finset.Icc}\\,1\\,N).\\text{powerset.filter}(\\lambda A, \\text{IsAPFree}\\,A\\,k))\\,\\text{Finset.card}$. This is noncomputable since it searches over exponentially many subsets, but is well-defined for finite $N$.",
+    "significance": "critical",
+    "relatedConcepts": ["extremal set theory", "Roth's theorem", "r_3(N) bounds"],
+    "prerequisites": ["IsAPFree", "Finset.Icc", "Finset.sup"]
   },
   {
     "id": "erdos-201-gk",
     "proofId": "erdos-201",
     "type": "definition",
-    "range": { "startLine": 54, "endLine": 55 },
-    "title": "G_k(N) Function",
-    "content": "G_k(N) is the minimum size of a k-AP-free subset guaranteed to exist in any N-element integer set. Axiomatised since its definition requires quantification over all N-element sets.",
-    "significance": "essential"
+    "range": { "startLine": 74, "endLine": 83 },
+    "title": "$G_k(N)$: Guaranteed AP-Free Subset Size",
+    "content": "$G_k(N) = \\min_{S : |S| = N} \\max\\{|A| : A \\subseteq S, A$ is $k$-AP-free$\\}$. The minimum is over all $N$-element integer sets $S$, so $G_k(N)$ measures the worst-case guarantee. Axiomatized since quantification over all $N$-element sets is non-computable.",
+    "mathContext": "gk is axiomatized as $\\mathbb{N} \\to \\mathbb{N} \\to \\mathbb{N}$. The Prop-level characterization gk_prop$(k, N, m)$: $\\forall S: |S| = N \\implies$ HasAPFreeSubsetOfSize$(S, k, m)$. This separates the value-level axiom from its property.",
+    "significance": "critical",
+    "relatedConcepts": ["minimax problems", "guaranteed extremal functions", "worst-case analysis"],
+    "prerequisites": ["HasAPFreeSubsetOfSize", "IsAPFree"]
+  },
+  {
+    "id": "erdos-201-basic-bounds",
+    "proofId": "erdos-201",
+    "type": "theorem",
+    "range": { "startLine": 92, "endLine": 100 },
+    "title": "Basic Bounds: $G_k(N) \\leq R_k(N)$ and Strict Examples",
+    "content": "$G_k(N) \\leq R_k(N)$ trivially since $\\{1, \\ldots, N\\}$ is a particular $N$-element set. The inequality is strict: $G_3(5) = 3 < 4 = R_3(5)$ and $G_3(14) \\leq 7 < 8 = R_3(14)$.",
+    "mathContext": "gk_le_rk: $G_k(N) \\leq R_k(N)$ for $k \\geq 3$. The strict examples show that $\\{1, \\ldots, N\\}$ is not the worst case: there exist 5-element sets where the largest 3-AP-free subset has only 3 elements (vs. 4 for $\\{1,2,3,4,5\\}$).",
+    "significance": "key",
+    "relatedConcepts": ["trivial bound", "strict inequality examples", "extremal gap"],
+    "prerequisites": ["gk", "rk"]
   },
   {
     "id": "erdos-201-kss",
     "proofId": "erdos-201",
-    "type": "result",
-    "range": { "startLine": 76, "endLine": 79 },
-    "title": "Komlós–Sulyok–Szemerédi Bound",
-    "content": "Komlós, Sulyok, and Szemerédi (1975) proved that R_k(N) ≤ C·G_k(N) for some constant C depending on k, showing the two functions have the same order of magnitude.",
-    "significance": "essential"
+    "type": "theorem",
+    "range": { "startLine": 108, "endLine": 109 },
+    "title": "Komlós–Sulyok–Szemerédi Bound (1975)",
+    "content": "Komlós, Sulyok, and Szemerédi proved that $R_k(N) \\leq C \\cdot G_k(N)$ for some constant $C = C(k) > 0$, establishing that the two functions have the same order of magnitude.",
+    "mathContext": "komlos_sulyok_szemeredi: $\\forall k \\geq 3, \\exists C > 0: \\forall N, R_k(N) \\leq C \\cdot G_k(N)$. Combined with $G_k(N) \\leq R_k(N)$, this gives $G_k(N) \\asymp R_k(N)$. The conjecture asks whether $C$ can be taken arbitrarily close to 1 for $k = 3$.",
+    "significance": "critical",
+    "relatedConcepts": ["Komlós–Sulyok–Szemerédi 1975", "order-of-magnitude equivalence", "extremal bounds"],
+    "prerequisites": ["rk", "gk", "asymptotic notation"]
   },
   {
     "id": "erdos-201-conjecture",
     "proofId": "erdos-201",
-    "type": "conjecture",
-    "range": { "startLine": 85, "endLine": 90 },
-    "title": "Erdős Problem 201",
-    "content": "The main conjecture: lim R_3(N)/G_3(N) = 1. Formalised as: for every ε > 0, there exists N₀ such that R_3(N) ≤ (1+ε)·G_3(N) for all N ≥ N₀.",
-    "significance": "essential"
+    "type": "definition",
+    "range": { "startLine": 119, "endLine": 122 },
+    "title": "Erdős Problem 201 — The Open Conjecture",
+    "content": "Is $\\lim_{N \\to \\infty} R_3(N) / G_3(N) = 1$? Formalized as: $\\forall \\varepsilon > 0, \\exists N_0: \\forall N \\geq N_0, R_3(N) \\leq (1 + \\varepsilon) \\cdot G_3(N)$. This uses rationals to avoid real-number overhead.",
+    "mathContext": "ErdosProblem201: $\\forall \\varepsilon \\in \\mathbb{Q}, \\varepsilon > 0 \\implies \\exists N_0: \\forall N \\geq N_0, (R_3(N) : \\mathbb{Q}) \\leq (1 + \\varepsilon) \\cdot (G_3(N) : \\mathbb{Q})$. The cast to $\\mathbb{Q}$ enables the multiplicative bound without real analysis.",
+    "significance": "critical",
+    "relatedConcepts": ["asymptotic ratio", "epsilon-delta formalization", "AP density functions"],
+    "prerequisites": ["rk", "gk", "rational arithmetic"]
+  },
+  {
+    "id": "erdos-201-monotonicity",
+    "proofId": "erdos-201",
+    "type": "theorem",
+    "range": { "startLine": 129, "endLine": 149 },
+    "title": "Monotonicity Properties of $R_k$",
+    "content": "$R_k$ is monotone in $N$ ($M \\leq N \\implies R_k(M) \\leq R_k(N)$) and anti-monotone in $k$ ($k \\leq l \\implies R_l(N) \\leq R_k(N)$). Both proved structurally in Lean using subset inclusion and AP transfer.",
+    "mathContext": "rk_mono: $M \\leq N \\implies$ Icc$\\,1\\,M \\subseteq$ Icc$\\,1\\,N$, so every AP-free subset of Icc$\\,1\\,M$ is also a subset of Icc$\\,1\\,N$. rk_anti_k: $k \\leq l \\implies$ every $l$-AP-free set is $k$-AP-free, so $R_l(N) \\leq R_k(N)$.",
+    "significance": "key",
+    "relatedConcepts": ["monotone functions", "Finset.Icc nesting", "AP-free hierarchy"],
+    "prerequisites": ["rk", "isAPFree_of_le", "Finset.Icc_subset_Icc_right"]
+  },
+  {
+    "id": "erdos-201-consequences",
+    "proofId": "erdos-201",
+    "type": "theorem",
+    "range": { "startLine": 156, "endLine": 197 },
+    "title": "Consequences and Summary",
+    "content": "Proves the strict inequality $G_3(5) < R_3(5)$, that the empty set and singletons are AP-free, $R_k(N) \\geq 1$ for $N \\geq 1$ and $k \\geq 2$, and a summary theorem combining the gap with the logical status of the conjecture.",
+    "mathContext": "g3_lt_r3_at_5: $3 < 4$ by rewriting with g3_5_eq and r3_5_eq. rk_pos: singleton $\\{1\\} \\in$ Icc$\\,1\\,N$ is AP-free, giving $R_k(N) \\geq 1$. erdos_201_summary: $G_3(5) < R_3(5) \\wedge ($ErdosProblem201 $\\lor \\neg$ErdosProblem201$)$ by `Classical.em`.",
+    "significance": "supporting",
+    "relatedConcepts": ["trivial AP-freeness", "base cases", "classical logic"],
+    "prerequisites": ["g3_5_eq", "r3_5_eq", "isAPFree_singleton", "Classical.em"]
   }
 ]

--- a/src/data/proofs/erdos-201/meta.json
+++ b/src/data/proofs/erdos-201/meta.json
@@ -21,67 +21,97 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "First investigated by Riddell (1969), this problem connects two natural measures of arithmetic-progression-free subsets. Erdős asked whether the extremal function R_k(N) for {1,…,N} and the guaranteed function G_k(N) for arbitrary N-element integer sets are asymptotically equal for k=3.",
-    "problemStatement": "Let G_k(N) denote the minimum size of a k-AP-free subset guaranteed in any set of N integers, and R_k(N) the maximum size of a k-AP-free subset of {1,…,N}. Is lim_{N→∞} R_3(N)/G_3(N) = 1?",
-    "proofStrategy": "The formalization defines k-term arithmetic progressions, AP-free sets, R_k(N) via powerset filtration, and G_k(N) axiomatically. The conjecture is stated as: for every ε > 0, R_3(N) ≤ (1+ε) G_3(N) for large N.",
+    "historicalContext": "Riddell (1969) first investigated the function $G_k(N)$ — the guaranteed size of a $k$-AP-free subset in any $N$-element integer set. The natural comparison with $R_k(N)$ (the maximum AP-free subset of $\\{1, \\ldots, N\\}$, studied by Roth and later Szemerédi) reveals a subtle gap: $\\{1, \\ldots, N\\}$ is not always the worst case for AP avoidance. Komlós, Sulyok, and Szemerédi (1975) proved the fundamental result that $R_k(N) \\asymp G_k(N)$, showing the two functions have the same order of magnitude. Erdős then asked the sharper question: does the ratio $R_3(N)/G_3(N)$ tend to 1? This connects to the broader program of understanding how the structure of the ambient set affects AP density, a theme central to Szemerédi's theorem (1975) and the subsequent work of Gowers, Green–Tao, and Kelley–Meka on quantitative bounds for $R_3(N)$.",
+    "problemStatement": "Let $G_k(N)$ denote the minimum size of a $k$-AP-free subset guaranteed in any set of $N$ integers, and $R_k(N)$ the maximum size of a $k$-AP-free subset of $\\{1, \\ldots, N\\}$. Is $\\lim_{N \\to \\infty} R_3(N)/G_3(N) = 1$?",
+    "proofStrategy": "The formalization defines $k$-term APs via `Fin k`-indexed arithmetic sequences, AP-free sets, $R_k(N)$ as a computable supremum over the powerset of Icc$\\,1\\,N$, and $G_k(N)$ axiomatically. Structural lemmas (AP transfer, subset inheritance) are proved. The KSS bound, concrete examples ($G_3(5) = 3 < 4 = R_3(5)$), monotonicity properties, and the main conjecture in $\\varepsilon$-$N_0$ form are all formalized.",
     "keyInsights": [
-      "G_k(N) ≤ R_k(N) trivially since {1,…,N} is an N-element set",
-      "Strict inequality: G_3(5) = 3 while R_3(5) = 4",
-      "Komlós–Sulyok–Szemerédi (1975) proved R_k(N) ≪_k G_k(N), establishing the same order of magnitude",
-      "The conjecture asks whether the constant in the KSS bound approaches 1 for k=3"
+      "**Trivial bound with strict gap**: $G_k(N) \\leq R_k(N)$ always, but $G_3(5) = 3 < 4 = R_3(5)$ shows $\\{1, \\ldots, N\\}$ is not the worst case for 3-AP avoidance",
+      "**Komlós–Sulyok–Szemerédi (1975)**: $R_k(N) \\leq C(k) \\cdot G_k(N)$, establishing order-of-magnitude equivalence. The conjecture asks whether $C(3) \\to 1$",
+      "**Connection to Roth/Szemerédi bounds**: $R_3(N) = o(N)$ (Roth 1953) and recent Kelley–Meka improvements give $R_3(N) \\leq N/\\exp(c(\\log N)^{1/12})$, but these bounds on $R_3$ don't directly determine the ratio $R_3/G_3$",
+      "**Proved monotonicity**: $R_k(N)$ is monotone in $N$ (larger interval has more AP-free subsets) and anti-monotone in $k$ ($l$-AP-free implies $k$-AP-free for $k \\leq l$), both verified in Lean",
+      "**$\\varepsilon$-$N_0$ formalization**: The conjecture uses $\\mathbb{Q}$ for the $(1 + \\varepsilon)$ bound, avoiding real analysis while precisely capturing the asymptotic ratio"
     ]
   },
   "sections": [
     {
-      "id": "arithmetic-progressions",
-      "title": "Arithmetic Progressions",
-      "startLine": 24,
-      "endLine": 42,
-      "summary": "Definitions of k-term arithmetic progressions in integer sets and AP-free sets."
+      "id": "imports",
+      "title": "Library Imports",
+      "startLine": 23,
+      "endLine": 26,
+      "summary": "Imports Mathlib for `Finset`, cardinality, $\\mathbb{Z}$-arithmetic, and tactics."
     },
     {
-      "id": "rk-gk",
-      "title": "The Functions G_k and R_k",
-      "startLine": 44,
-      "endLine": 56,
-      "summary": "R_k(N) as the maximum AP-free subset of {1,…,N}; G_k(N) as the guaranteed AP-free subset in arbitrary N-element sets."
+      "id": "ap-definitions",
+      "title": "Arithmetic Progressions and AP-Free Sets",
+      "startLine": 33,
+      "endLine": 39,
+      "summary": "Defines ContainsAPOfLength$(A, k)$ via $\\exists a, d \\neq 0: \\{a, a+d, \\ldots\\} \\subseteq A$ and IsAPFree as its negation."
+    },
+    {
+      "id": "structural-lemmas",
+      "title": "Structural Lemmas (Proved)",
+      "startLine": 42,
+      "endLine": 57,
+      "summary": "AP transfer ($k \\leq l$ AP containment), AP-freeness inheritance ($k$-free $\\implies$ $l$-free), and subset closure — all proved in Lean."
+    },
+    {
+      "id": "rk-definition",
+      "title": "$R_k(N)$ Definition",
+      "startLine": 64,
+      "endLine": 67,
+      "summary": "$R_k(N) = \\sup\\{|A| : A \\subseteq \\text{Icc}\\,1\\,N, \\text{IsAPFree}\\,A\\,k\\}$ via powerset filtration."
+    },
+    {
+      "id": "gk-definition",
+      "title": "$G_k(N)$ Definition and Properties",
+      "startLine": 74,
+      "endLine": 83,
+      "summary": "$G_k(N)$ axiomatized with Prop-level characterization gk_prop$(k, N, m)$. Quantification over all $N$-element sets makes this non-computable."
     },
     {
       "id": "basic-bounds",
-      "title": "Basic Bounds",
-      "startLine": 58,
-      "endLine": 72,
-      "summary": "Trivial bound G_k(N) ≤ R_k(N) and concrete examples showing strict inequality."
+      "title": "Basic Bounds and Examples",
+      "startLine": 89,
+      "endLine": 100,
+      "summary": "$G_k(N) \\leq R_k(N)$ (trivial) with strict examples: $G_3(5) = 3 < 4 = R_3(5)$ and $G_3(14) \\leq 7 < 8 = R_3(14)$."
     },
     {
       "id": "kss-bound",
       "title": "Komlós–Sulyok–Szemerédi Bound",
-      "startLine": 74,
-      "endLine": 80,
-      "summary": "R_k(N) and G_k(N) have the same order of magnitude (1975 result)."
+      "startLine": 108,
+      "endLine": 109,
+      "summary": "$\\exists C > 0: R_k(N) \\leq C \\cdot G_k(N)$ for all $N$, establishing $R_k \\asymp G_k$ (1975)."
     },
     {
       "id": "main-conjecture",
-      "title": "Main Conjecture",
-      "startLine": 82,
-      "endLine": 91,
-      "summary": "Erdős Problem 201: the ratio R_3(N)/G_3(N) tends to 1."
+      "title": "The Open Conjecture",
+      "startLine": 119,
+      "endLine": 122,
+      "summary": "ErdosProblem201: $\\forall \\varepsilon > 0, \\exists N_0: \\forall N \\geq N_0, R_3(N) \\leq (1 + \\varepsilon) \\cdot G_3(N)$."
     },
     {
       "id": "monotonicity",
-      "title": "Monotonicity",
-      "startLine": 93,
-      "endLine": 100,
-      "summary": "R_k is monotone in N and anti-monotone in k."
+      "title": "Monotonicity Properties (Proved)",
+      "startLine": 129,
+      "endLine": 149,
+      "summary": "$R_k$ monotone in $N$ and anti-monotone in $k$, both proved structurally using Icc nesting and AP transfer."
+    },
+    {
+      "id": "consequences",
+      "title": "Consequences and Base Cases",
+      "startLine": 156,
+      "endLine": 197,
+      "summary": "Proved: $G_3(5) < R_3(5)$, empty/singleton AP-freeness, $R_k(N) \\geq 1$, and a summary theorem via `Classical.em`."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 201 on the asymptotic equality of R_3(N) and G_3(N), with the Komlós–Sulyok–Szemerédi bound and concrete examples as supporting results.",
-    "implications": "A positive answer would show that arbitrary N-element integer sets behave like {1,…,N} with respect to 3-AP-free subsets, unifying two fundamental measures in additive combinatorics.",
+    "summary": "Erdős Problem #201 asks whether the ratio $R_3(N)/G_3(N)$ tends to 1 — whether the interval $\\{1, \\ldots, N\\}$ is asymptotically the worst case for 3-AP-free subsets among all $N$-element integer sets. The KSS bound (1975) establishes order-of-magnitude equivalence, and the formalization includes several proved structural results (AP transfer, monotonicity, base cases).",
+    "implications": "A positive answer would unify two fundamental measures in additive combinatorics, showing that the extremal behavior of AP-free sets is asymptotically determined by the simplest ambient set $\\{1, \\ldots, N\\}$. This would have implications for transfer principles in extremal combinatorics.",
     "openQuestions": [
-      "Is lim R_3(N)/G_3(N) = 1?",
-      "What is the precise growth rate of G_k(N) for general k?",
-      "Can the KSS bound constant be made explicit?"
+      "Is $\\lim_{N \\to \\infty} R_3(N)/G_3(N) = 1$?",
+      "What is the best explicit constant $C$ in the KSS bound $R_3(N) \\leq C \\cdot G_3(N)$?",
+      "Does the analogous ratio converge to 1 for $k \\geq 4$?",
+      "Can the Kelley–Meka bounds on $R_3(N)$ be transferred to bounds on $G_3(N)$?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Add mathContext, relatedConcepts, and prerequisites to all 10 annotations (up from 7)
- Fix invalid types (conjecture→definition, result→theorem) and significance (essential→critical/key/supporting)
- Deepen historicalContext with Riddell 1969, KSS 1975, Roth 1953, Kelley–Meka connections (~800 chars)
- Add 5 bold-formatted keyInsights: trivial bound gap, KSS equivalence, Roth/Szemerédi connection, proved monotonicity, epsilon-N0 formalization
- Expand from 6 to 10 sections with LaTeX in summaries

## Test plan
- [x] `pnpm annotations:build` passes with no erdos-201 errors (type warnings are non-strict per design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)