### PR TITLE
Research: friendship-theorem-oq-02 - remove 2 axioms

### DIFF
--- a/proofs/Proofs/FriendshipTheorem.lean
+++ b/proofs/Proofs/FriendshipTheorem.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Combinatorics.SimpleGraph.Clique
+import Mathlib.Combinatorics.SimpleGraph.DegreeSum
 import Mathlib.Combinatorics.SimpleGraph.Finite
 import Mathlib.Data.Fintype.Card
 import Mathlib.Algebra.BigOperators.Ring.Finset
@@ -126,18 +127,69 @@ lemma friendship_positive_degree (hF : IsFriendshipGraph G) (h : Fintype.card V 
   simp only [degree, Finset.card_pos, Finset.Nonempty]
   exact ⟨w, (G.mem_neighborFinset v w).mpr hw_mem.1⟩
 
-/-- **Axiom: In a friendship graph, the number of vertices is odd.**
+/-- In a friendship graph with universal vertex c, every non-center vertex
+    has exactly two neighbors: c and its unique partner. -/
+lemma friendship_noncentral_degree (hF : IsFriendshipGraph G)
+    (c : V) (hc : IsUniversalVertex G c) (u : V) (hu : u ≠ c) :
+    G.degree u = 2 := by
+  have h1 := hF u c hu
+  rw [Set.ncard_eq_one] at h1
+  obtain ⟨w, hw⟩ := h1
+  have hw_mem : w ∈ G.commonNeighbors u c := hw ▸ Set.mem_singleton w
+  rw [mem_commonNeighbors] at hw_mem
+  have hwu : w ≠ u := fun heq => G.loopless u (heq ▸ hw_mem.1)
+  have hwc : w ≠ c := fun heq => G.loopless c (G.symm (heq ▸ hw_mem.2))
+  have hneighbors : G.neighborFinset u = {c, w} := by
+    ext v
+    simp only [SimpleGraph.mem_neighborFinset, Finset.mem_insert, Finset.mem_singleton]
+    constructor
+    · intro hadj
+      by_cases hvc : v = c
+      · left; exact hvc
+      · right
+        have hcv : G.Adj c v := hc v hvc
+        have : v ∈ G.commonNeighbors u c := mem_commonNeighbors.mpr ⟨hadj, G.symm hcv⟩
+        exact Set.mem_singleton_iff.mp (hw ▸ this)
+    · intro hv
+      rcases hv with rfl | rfl
+      · exact G.symm (hc u hu)
+      · exact hw_mem.1
+  rw [SimpleGraph.degree, hneighbors, Finset.card_pair (Ne.symm hwc)]
 
-    The proof uses counting: for a windmill with n triangles sharing a center,
-    there are 2n + 1 vertices. The friendship property forces this structure,
-    so the number of vertices is always 2n + 1 for some n ≥ 1. -/
-axiom friendship_card_odd_axiom (hF : IsFriendshipGraph G) (h : Fintype.card V ≥ 3) :
-    Odd (Fintype.card V)
+/-- The degree of a universal vertex equals n - 1. -/
+lemma universal_degree (c : V) (hc : IsUniversalVertex G c) :
+    G.degree c = Fintype.card V - 1 := by
+  rw [SimpleGraph.degree]
+  have hneigh : G.neighborFinset c = Finset.univ.erase c := by
+    ext v
+    simp only [SimpleGraph.mem_neighborFinset, Finset.mem_erase, Finset.mem_univ, and_true]
+    exact ⟨fun hadj hvc => G.loopless c (hvc ▸ hadj), fun hne => hc v hne⟩
+  rw [hneigh, Finset.card_erase_of_mem (Finset.mem_univ c), Finset.card_univ]
 
-/-- In a friendship graph, the number of vertices is odd. -/
+/-- In a friendship graph, the number of vertices is odd.
+
+    Proof: By the handshaking lemma, 2|E| = Σ deg(v). With universal vertex c,
+    deg(c) = n-1 and deg(u) = 2 for u ≠ c, giving 2|E| = 3(n-1).
+    Since gcd(2,3) = 1, we get 2 | (n-1), so n is odd. -/
 lemma friendship_card_odd (hF : IsFriendshipGraph G) (h : Fintype.card V ≥ 3) :
-    Odd (Fintype.card V) :=
-  friendship_card_odd_axiom G hF h
+    Odd (Fintype.card V) := by
+  obtain ⟨c, hc⟩ := friendship_theorem G hF h
+  have hdeg_c := universal_degree G c hc
+  have hdeg_u : ∀ v : V, v ≠ c → G.degree v = 2 :=
+    fun v hv => friendship_noncentral_degree G hF c hc v hv
+  have hsum : ∑ v : V, G.degree v = 3 * (Fintype.card V - 1) := by
+    rw [← Finset.add_sum_erase _ _ (Finset.mem_univ c), hdeg_c]
+    have : ∀ v ∈ Finset.univ.erase c, G.degree v = 2 :=
+      fun v hv => hdeg_u v (Finset.ne_of_mem_erase hv)
+    rw [Finset.sum_congr rfl this, Finset.sum_const, Finset.card_erase_of_mem (Finset.mem_univ c),
+        Finset.card_univ, smul_eq_mul]
+    omega
+  have hhand := G.sum_degrees_eq_twice_card_edges
+  rw [hsum] at hhand
+  have hdvd : 2 ∣ (Fintype.card V - 1) :=
+    Nat.Coprime.dvd_of_dvd_mul_left _ _ _ (by norm_num) ⟨G.edgeFinset.card, by omega⟩
+  obtain ⟨k, hk⟩ := hdvd
+  exact ⟨k, by omega⟩
 
 /-- **Axiom: A friendship graph is either has a universal vertex or is regular.**
 

--- a/src/data/research/problems/friendship-theorem-oq-02.json
+++ b/src/data/research/problems/friendship-theorem-oq-02.json
@@ -1,0 +1,79 @@
+{
+  "slug": "friendship-theorem-oq-02",
+  "title": "Friendship theorem generalizations to directed graphs and hypergraphs",
+  "phase": "FORMALIZED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "theorem friendship_theorem (hF : IsFriendshipGraph G) (h : Fintype.card V >= 3) : exists c, IsUniversalVertex G c",
+    "plain": "In any finite simple graph where every pair of distinct vertices has exactly one common neighbor, there exists a vertex adjacent to all other vertices (the 'politician').",
+    "whyMatters": [
+      "Classic result by Erdos, Renyi, and Sos (1966)",
+      "Connects spectral graph theory to combinatorial structure",
+      "Foundation for studying friendship-type properties in directed graphs and hypergraphs",
+      "One of the most elegant applications of eigenvalue methods in combinatorics"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Friendship property definition (every pair has exactly one common neighbor)",
+      "Windmill graph structure characterization (proved from friendship theorem)",
+      "Odd vertex count (proved via handshaking lemma and degree analysis)",
+      "Non-center vertex degree = 2 in windmill (proved)",
+      "Universal vertex degree = n-1 (proved)",
+      "Main theorem: friendship implies universal vertex (proved modulo 2 spectral axioms)",
+      "W2 windmill example: friendship property verification via finite case analysis"
+    ],
+    "open": [
+      "friendship_has_universal_or_regular: no universal vertex implies regularity",
+      "friendship_regular_implies_universal: regular friendship graph has universal vertex (spectral argument)"
+    ],
+    "goal": "Complete formalization of friendship theorem, potentially extend to directed/hypergraph cases"
+  },
+  "currentState": {
+    "phase": "FORMALIZED",
+    "since": "2026-02-10T00:00:00Z",
+    "iteration": 1,
+    "focus": "Removed 2 of 4 axioms; 2 spectral axioms remain",
+    "blockers": [
+      "friendship_has_universal_or_regular requires counting argument showing adjacent vertices have equal degree",
+      "friendship_regular_implies_universal requires spectral graph theory (eigenvalue analysis of adjacency matrix)"
+    ],
+    "nextAction": "Prove friendship_has_universal_or_regular via counting argument, or submit to Aristotle",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: Removed 2 of 4 axioms. Proved friendship_graph_is_windmill directly from friendship_theorem. Proved friendship_card_odd via handshaking lemma + degree analysis (3 helper lemmas). 2 spectral axioms remain: universal-or-regular and regular-implies-universal.",
+    "builtItems": [
+      "friendship_noncentral_degree: non-center vertices have degree 2 (20 lines)",
+      "universal_degree: universal vertex has degree n-1 (8 lines)",
+      "friendship_card_odd: odd vertex count via handshaking lemma (20 lines)",
+      "friendship_graph_is_windmill: windmill structure from friendship theorem (18 lines)"
+    ],
+    "insights": [
+      "The windmill characterization follows directly from the friendship theorem + friendship property (no extra axioms needed)",
+      "Odd cardinality follows from handshaking: sum of degrees = 3(n-1) must be even, so 2|(n-1)",
+      "Non-center vertices have exactly 2 neighbors: the center c and a unique partner w",
+      "The partner w is the unique common neighbor of u and c (from friendship property)",
+      "SimpleGraph.sum_degrees_eq_twice_card_edges available via Mathlib.Combinatorics.SimpleGraph.DegreeSum",
+      "The spectral argument (regular implies universal) requires eigenvalue analysis not readily available in Mathlib",
+      "The counting argument (no universal implies regular) requires showing adjacent vertices have equal degree via injection on private neighborhoods",
+      "Nat.Coprime.dvd_of_dvd_mul_left works for the gcd(2,3)=1 divisibility step"
+    ],
+    "mathlibGaps": [
+      "No built-in 'fixed-point-free involution implies even cardinality' lemma",
+      "Graph adjacency matrix eigenvalue analysis for spectral proofs",
+      "No ready-made 'adjacent vertices in friendship graph have equal degree' infrastructure"
+    ],
+    "nextSteps": [
+      "Prove friendship_has_universal_or_regular via counting: adjacent vertices have equal degree when no universal vertex exists",
+      "Consider submitting file to Aristotle for the remaining 2 axioms",
+      "The spectral argument may require custom eigenvalue infrastructure (~500+ lines)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Proved `friendship_graph_is_windmill` directly from `friendship_theorem` (removed axiom)
- Proved `friendship_card_odd` via handshaking lemma + degree analysis (removed axiom)
- Added 3 helper lemmas: `friendship_noncentral_degree`, `universal_degree`, `friendship_card_odd`
- Reduced axiom count from 4 to 2

## Key Insights
- Windmill structure follows directly: given universal vertex c, non-adjacent pairs share only c as common neighbor
- Non-center vertices have degree exactly 2 (c and unique partner)
- Odd cardinality via handshaking: sum of degrees = 3(n-1), must be even, so 2|(n-1)

## Remaining Axioms
- `friendship_has_universal_or_regular`: needs counting argument (adjacent vertices have equal degree when no universal vertex)
- `friendship_regular_implies_universal`: needs spectral graph theory (eigenvalue analysis)

## Test plan
- [x] Docker build passes
- [x] No errors (only linter warnings on pre-existing example code)

🤖 Generated by researcher-1