### PR TITLE
enrich(erdos-207): Steiner triple systems, high girth, KSSS

### DIFF
--- a/src/data/proofs/erdos-207/annotations.json
+++ b/src/data/proofs/erdos-207/annotations.json
@@ -1,174 +1,146 @@
 [
   {
-    "id": "ann-e207-header",
+    "id": "erdos-207-imports",
     "proofId": "erdos-207",
-    "range": { "startLine": 1, "endLine": 26 },
     "type": "concept",
-    "title": "Problem Overview",
-    "content": "**Erdős Problem #207: High-Girth Steiner Triple Systems**\n\nFor g≥2, do STS(n) with girth ≥g exist for large admissible n?\n\n**Answer:** YES (Kwan-Sah-Sawhney-Simkin 2022)\n\nA Steiner triple system is a collection of triples where each pair appears in exactly one triple. The girth condition prevents tight edge configurations.",
-    "mathContext": "Solved in 2022 using probabilistic combinatorics.",
-    "significance": "critical",
-    "relatedConcepts": ["Steiner systems", "Hypergraphs", "Design theory"]
-  },
-  {
-    "id": "ann-e207-hypergraph3",
-    "proofId": "erdos-207",
-    "range": { "startLine": 41, "endLine": 47 },
-    "type": "definition",
-    "title": "3-Uniform Hypergraph",
-    "content": "**Hypergraph3:**\n\nA collection of 3-element subsets (edges) of a vertex set.\n\n```lean\nstructure Hypergraph3 (V : Type*) [Fintype V] where\n  edges : Finset (Finset V)\n  uniform : ∀ e ∈ edges, e.card = 3\n```",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e207-sts",
-    "proofId": "erdos-207",
-    "range": { "startLine": 56, "endLine": 63 },
-    "type": "definition",
-    "title": "Steiner Triple System",
-    "content": "**IsSteinerTripleSystem:**\n\nEvery pair of distinct vertices is contained in exactly one edge.\n\n```lean\ndef IsSteinerTripleSystem {V : Type*} [Fintype V] [DecidableEq V]\n    (H : Hypergraph3 V) : Prop :=\n  ∀ a b : V, a ≠ b → ∃! e ∈ H.edges, edgeContainsPair e a b\n```",
-    "mathContext": "The defining property of Steiner triple systems.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e207-vertexspan",
-    "proofId": "erdos-207",
-    "range": { "startLine": 69, "endLine": 74 },
-    "type": "definition",
-    "title": "Vertex Span",
-    "content": "**vertexSpan:**\n\nThe number of distinct vertices in a collection of edges.\n\n```lean\ndef vertexSpan {V : Type*} [DecidableEq V] (edges : Finset (Finset V)) : ℕ :=\n  (edges.biUnion id).card\n```",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e207-girth",
-    "proofId": "erdos-207",
-    "range": { "startLine": 76, "endLine": 83 },
-    "type": "definition",
-    "title": "High-Girth Property",
-    "content": "**HasGirthAtLeast:**\n\nAny j edges (2≤j≤g) must span at least j+3 vertices.\n\n```lean\ndef HasGirthAtLeast {V : Type*} [Fintype V] [DecidableEq V]\n    (H : Hypergraph3 V) (g : ℕ) : Prop :=\n  ∀ S : Finset (Finset V), S ⊆ H.edges → 2 ≤ S.card → S.card ≤ g →\n    vertexSpan S ≥ S.card + 3\n```",
-    "mathContext": "The central girth condition in the problem.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e207-why-j3",
-    "proofId": "erdos-207",
-    "range": { "startLine": 85, "endLine": 94 },
-    "type": "definition",
-    "title": "Why j+3?",
-    "content": "**girthExplanation:**\n\n- Single edge: 3 vertices\n- Two edges share ≤1 vertex in STS → span ≥5 = 2+3\n- j+3 generalizes: prevents edges from overlapping too much\n- Ensures no \"short cycles\" in hypergraph structure",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e207-admissible",
-    "proofId": "erdos-207",
-    "range": { "startLine": 100, "endLine": 105 },
-    "type": "definition",
-    "title": "Admissible Order",
-    "content": "**IsAdmissible:**\n\nn is admissible for STS if n ≡ 1 or 3 (mod 6).\n\n```lean\ndef IsAdmissible (n : ℕ) : Prop :=\n  n % 6 = 1 ∨ n % 6 = 3\n```\n\nThis is the necessary and sufficient condition for STS existence.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e207-kirkman",
-    "proofId": "erdos-207",
-    "range": { "startLine": 107, "endLine": 114 },
-    "type": "axiom",
-    "title": "Kirkman's Theorem (1847)",
-    "content": "**kirkman_theorem:**\n\nAn STS(n) exists if and only if n ≡ 1, 3 (mod 6).\n\nThis classical result from 1847 establishes when Steiner triple systems can exist.",
-    "mathContext": "One of the oldest results in combinatorial design theory.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e207-conjecture",
-    "proofId": "erdos-207",
-    "range": { "startLine": 130, "endLine": 138 },
-    "type": "definition",
-    "title": "The Erdős Conjecture",
-    "content": "**erdos207Conjecture:**\n\nFor any g ≥ 2, there exists N(g) such that for all admissible n ≥ N(g), there exists an STS(n) with girth at least g.\n\n```lean\ndef erdos207Conjecture : Prop :=\n  ∀ g : ℕ, g ≥ 2 → ∃ N : ℕ, ∀ n : ℕ, n ≥ N → IsAdmissible n →\n    ∃ (V : Type) ... IsSteinerTripleSystem H ∧ HasGirthAtLeast H g\n```",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e207-ksss",
-    "proofId": "erdos-207",
-    "range": { "startLine": 144, "endLine": 151 },
-    "type": "axiom",
-    "title": "KSSS Theorem (2022)",
-    "content": "**kwan_sah_sawhney_simkin_2022:**\n\nThe Erdős conjecture on high-girth STS is TRUE.\n\nProved in arXiv:2201.04554 using random greedy construction with spread measure analysis.",
-    "mathContext": "The solution to Erdős Problem #207.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e207-main",
-    "proofId": "erdos-207",
-    "range": { "startLine": 153, "endLine": 157 },
-    "type": "theorem",
-    "title": "Main Theorem",
-    "content": "**erdos_207:**\n\n```lean\ntheorem erdos_207 : erdos207Conjecture :=\n  kwan_sah_sawhney_simkin_2022\n```\n\nDirect from the KSSS theorem.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e207-girth2",
-    "proofId": "erdos-207",
-    "range": { "startLine": 163, "endLine": 171 },
-    "type": "theorem",
-    "title": "Girth 2 (Trivial)",
-    "content": "**sts_has_girth_at_least_2:**\n\nAny STS has girth at least 2.\n\nTwo edges in an STS share at most 1 vertex, so they span at least 5 vertices.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-e207-pasch",
-    "proofId": "erdos-207",
-    "range": { "startLine": 173, "endLine": 182 },
-    "type": "definition",
-    "title": "Pasch Configuration",
-    "content": "**IsPaschConfiguration:**\n\n4 triples on 6 vertices forming a specific pattern:\n{abc, ade, bdf, cef}\n\nThis is the obstacle to girth 3 in STS.",
-    "mathContext": "Named after Moritz Pasch, related to projective geometry.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e207-antipasch",
-    "proofId": "erdos-207",
-    "range": { "startLine": 189, "endLine": 196 },
-    "type": "axiom",
-    "title": "Anti-Pasch STS",
-    "content": "**anti_pasch_sts_exist:**\n\nFor n ≥ 7 admissible, there exists an STS(n) avoiding Pasch configurations.\n\nAnti-Pasch STS were known before the general KSSS result.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e207-random",
-    "proofId": "erdos-207",
-    "range": { "startLine": 202, "endLine": 211 },
-    "type": "axiom",
-    "title": "Random Construction",
-    "content": "**ksss_random_construction:**\n\nThe KSSS proof method:\n1. Order pairs randomly\n2. Greedily add triples avoiding forbidden configurations\n3. Show positive probability of success\n\nKey tools: Rödl nibble method, spread measure, concentration.",
-    "mathContext": "Probabilistic combinatorics technique.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e207-resolvable",
-    "proofId": "erdos-207",
-    "range": { "startLine": 224, "endLine": 232 },
-    "type": "definition",
-    "title": "Resolvable STS",
-    "content": "**IsResolvable:**\n\nAn STS is resolvable if its triples can be partitioned into parallel classes (each class partitions the vertex set).\n\nRelated to scheduling problems.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-e207-kirkman-schoolgirl",
-    "proofId": "erdos-207",
-    "range": { "startLine": 234, "endLine": 243 },
-    "type": "definition",
-    "title": "Kirkman Schoolgirl Problem",
-    "content": "**kirkmanSchoolgirlProblem:**\n\nCan 15 schoolgirls walk in groups of 3 for 7 days without any pair together twice?\n\nYES - this requires a resolvable STS(15).",
-    "mathContext": "Classic 1850 recreational mathematics problem.",
+    "range": { "startLine": 28, "endLine": 35 },
+    "title": "Library Imports and Namespace",
+    "content": "Imports Mathlib for finite sets, cardinality, finite types, and natural numbers. Opens the `Finset` namespace and defines everything within `Erdos207`.",
+    "mathContext": "The formalization works with `Finset (Finset V)` for edge collections, `Fintype.card V` for vertex counts, and `Finset.biUnion` for vertex span computations. The namespace `Erdos207` isolates the definitions.",
     "significance": "supporting",
-    "relatedConcepts": ["Scheduling", "Resolvable designs"]
+    "relatedConcepts": ["finite sets", "finite types", "namespace isolation"],
+    "prerequisites": ["Lean 4 basics", "Mathlib Finset library"]
   },
   {
-    "id": "ann-e207-summary",
+    "id": "erdos-207-hypergraph3",
     "proofId": "erdos-207",
-    "range": { "startLine": 249, "endLine": 274 },
+    "type": "definition",
+    "range": { "startLine": 45, "endLine": 47 },
+    "title": "3-Uniform Hypergraph",
+    "content": "A `Hypergraph3 V` consists of a finite set of edges, each a 3-element subset of $V$. The uniformity condition $|e| = 3$ for all edges $e$ is enforced structurally.",
+    "mathContext": "Hypergraph3$(V)$: edges $\\in \\text{Finset}(\\text{Finset}\\,V)$ with $\\forall e \\in$ edges$, |e| = 3$. This is the standard definition of a 3-uniform hypergraph, the combinatorial object underlying Steiner triple systems.",
+    "significance": "key",
+    "relatedConcepts": ["hypergraph", "uniform hypergraph", "combinatorial design"],
+    "prerequisites": ["Fintype", "Finset", "structure types"]
+  },
+  {
+    "id": "erdos-207-sts",
+    "proofId": "erdos-207",
+    "type": "definition",
+    "range": { "startLine": 53, "endLine": 63 },
+    "title": "Steiner Triple System",
+    "content": "IsSteinerTripleSystem$(H)$: every pair of distinct vertices is contained in exactly one edge. This uses `∃!` (unique existence) to encode the \"exactly one triple\" condition.",
+    "mathContext": "IsSteinerTripleSystem$(H)$: $\\forall a \\neq b \\in V, \\exists! e \\in H.\\text{edges}: a \\in e \\wedge b \\in e$. An STS$(n)$ on $n$ vertices has exactly $n(n-1)/6$ triples and each vertex appears in $(n-1)/2$ triples.",
+    "significance": "critical",
+    "relatedConcepts": ["Steiner systems", "balanced incomplete block designs", "pairwise balanced designs"],
+    "prerequisites": ["Hypergraph3", "edgeContainsPair", "unique existence"]
+  },
+  {
+    "id": "erdos-207-girth",
+    "proofId": "erdos-207",
+    "type": "definition",
+    "range": { "startLine": 73, "endLine": 94 },
+    "title": "Vertex Span and High-Girth Property",
+    "content": "vertexSpan counts distinct vertices in an edge collection via `biUnion`. HasGirthAtLeast$(H, g)$: any $j$ edges ($2 \\leq j \\leq g$) span at least $j + 3$ vertices. The $j + 3$ threshold prevents tight configurations where edges share too many vertices.",
+    "mathContext": "HasGirthAtLeast$(H, g)$: $\\forall S \\subseteq H.\\text{edges}, 2 \\leq |S| \\leq g \\implies |\\bigcup S| \\geq |S| + 3$. For $j = 2$: two edges must span $\\geq 5$ vertices, so they share $\\leq 1$ vertex. This generalizes the cycle-free condition from graphs to 3-uniform hypergraphs.",
+    "significance": "critical",
+    "relatedConcepts": ["hypergraph girth", "sparse hypergraphs", "cycle-free designs"],
+    "prerequisites": ["Hypergraph3", "Finset.biUnion", "Finset.card"]
+  },
+  {
+    "id": "erdos-207-admissible",
+    "proofId": "erdos-207",
+    "type": "definition",
+    "range": { "startLine": 104, "endLine": 120 },
+    "title": "Admissible Order and Triple Count",
+    "content": "IsAdmissible$(n)$: $n \\equiv 1$ or $3 \\pmod{6}$, the necessary and sufficient condition for STS$(n)$ existence. The triple count formula $n(n-1)/6$ is well-defined precisely when $6 \\mid n(n-1)$.",
+    "mathContext": "IsAdmissible$(n) \\iff n \\bmod 6 \\in \\{1, 3\\}$. An STS$(n)$ has $n(n-1)/6$ triples since each of $\\binom{n}{2}$ pairs is covered by exactly one triple of size 3. The divisibility $6 \\mid n(n-1)$ holds iff $n \\equiv 1, 3 \\pmod{6}$.",
+    "significance": "key",
+    "relatedConcepts": ["modular arithmetic", "divisibility conditions", "design existence"],
+    "prerequisites": ["natural number modular arithmetic"]
+  },
+  {
+    "id": "erdos-207-kirkman",
+    "proofId": "erdos-207",
     "type": "theorem",
-    "title": "Summary Theorem",
-    "content": "**erdos_207_summary:**\n\n1. High-girth STS exist for all admissible n ≥ N(g)\n2. Proved by KSSS (2022)\n3. Method: Random greedy + spread measure\n4. Special case: Anti-Pasch (girth 3) known earlier\n5. Kirkman's condition necessary\n\nStatus: SOLVED",
-    "significance": "critical"
+    "range": { "startLine": 111, "endLine": 114 },
+    "title": "Kirkman's Theorem (1847)",
+    "content": "An STS$(n)$ exists if and only if $n \\geq 1$ and $n \\equiv 1, 3 \\pmod{6}$. This classical result from 1847 completely characterizes when Steiner triple systems can be constructed.",
+    "mathContext": "kirkman_theorem$(n)$: $(\\exists$ STS on $n$ vertices$) \\iff (n \\geq 1 \\wedge$ IsAdmissible$(n))$. The necessity follows from counting; sufficiency uses direct and recursive constructions. Thomas Kirkman proved this in 1847, predating Steiner's 1853 paper.",
+    "significance": "critical",
+    "relatedConcepts": ["Kirkman 1847", "design existence theorems", "Wilson's theorem for designs"],
+    "prerequisites": ["IsSteinerTripleSystem", "IsAdmissible", "Hypergraph3"]
+  },
+  {
+    "id": "erdos-207-conjecture",
+    "proofId": "erdos-207",
+    "type": "definition",
+    "range": { "startLine": 135, "endLine": 138 },
+    "title": "Erdős Problem 207 — The Conjecture",
+    "content": "For any girth $g \\geq 2$, there exists $N(g)$ such that for all admissible $n \\geq N(g)$, there exists an STS$(n)$ with girth at least $g$. Erdős posed this in 1976.",
+    "mathContext": "erdos207Conjecture: $\\forall g \\geq 2, \\exists N: \\forall n \\geq N,$ IsAdmissible$(n) \\implies \\exists$ STS$(n)$ with HasGirthAtLeast $g$. The quantifier structure captures the threshold phenomenon: for each girth, only finitely many admissible orders lack high-girth STS.",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős 1976", "threshold functions", "asymptotic existence"],
+    "prerequisites": ["IsSteinerTripleSystem", "HasGirthAtLeast", "IsAdmissible"]
+  },
+  {
+    "id": "erdos-207-ksss",
+    "proofId": "erdos-207",
+    "type": "theorem",
+    "range": { "startLine": 151, "endLine": 157 },
+    "title": "Kwan–Sah–Sawhney–Simkin Theorem (2022)",
+    "content": "The Erdős conjecture on high-girth STS is TRUE. Proved using a random greedy construction with the Rödl nibble method and a novel spread measure to maintain the girth property during the construction.",
+    "mathContext": "kwan_sah_sawhney_simkin_2022: erdos207Conjecture. The proof (arXiv:2201.04554) uses probabilistic combinatorics: order pairs randomly, greedily add triples avoiding forbidden configurations, and show positive probability of success using concentration inequalities and the spread measure technique.",
+    "significance": "critical",
+    "relatedConcepts": ["KSSS 2022", "random greedy algorithm", "Rödl nibble", "spread measure"],
+    "prerequisites": ["erdos207Conjecture", "probabilistic combinatorics"]
+  },
+  {
+    "id": "erdos-207-girth2",
+    "proofId": "erdos-207",
+    "type": "theorem",
+    "range": { "startLine": 168, "endLine": 171 },
+    "title": "Girth 2 Is Trivial",
+    "content": "Any STS has girth at least 2: two edges in an STS share at most 1 vertex (since sharing 2 vertices would mean the pair appears in two triples, contradicting uniqueness), so they span at least 5 vertices.",
+    "mathContext": "sts_has_girth_at_least_2: IsSteinerTripleSystem$(H) \\implies$ HasGirthAtLeast$(H, 2)$. For $|S| = 2$: if edges $e_1, e_2$ share 2 vertices $a, b$, then both contain the pair $\\{a,b\\}$, contradicting $\\exists!$. So $|e_1 \\cap e_2| \\leq 1$ and $|e_1 \\cup e_2| \\geq 5$.",
+    "significance": "supporting",
+    "relatedConcepts": ["trivial girth bound", "STS edge intersection", "unique pair coverage"],
+    "prerequisites": ["IsSteinerTripleSystem", "HasGirthAtLeast"]
+  },
+  {
+    "id": "erdos-207-pasch",
+    "proofId": "erdos-207",
+    "type": "definition",
+    "range": { "startLine": 178, "endLine": 196 },
+    "title": "Pasch Configuration and Anti-Pasch STS",
+    "content": "A Pasch configuration is 4 triples on 6 vertices: $\\{abc, ade, bdf, cef\\}$. IsPaschFree$(H)$ means no subset of edges forms a Pasch configuration. Girth $\\geq 3$ is equivalent to being Pasch-free (proved modulo sorry).",
+    "mathContext": "IsPaschConfiguration$(S)$: $|S| = 4 \\wedge |\\bigcup S| = 6$. Named after Moritz Pasch (projective geometry). Anti-Pasch STS were constructed before KSSS's general result: anti_pasch_sts_exist axiomatizes existence for admissible $n \\geq 7$.",
+    "significance": "key",
+    "relatedConcepts": ["Pasch axiom", "anti-Pasch designs", "forbidden configurations"],
+    "prerequisites": ["vertexSpan", "Hypergraph3"]
+  },
+  {
+    "id": "erdos-207-resolvable",
+    "proofId": "erdos-207",
+    "type": "definition",
+    "range": { "startLine": 227, "endLine": 241 },
+    "title": "Resolvable STS and Kirkman Schoolgirl Problem",
+    "content": "IsResolvable$(H)$: the triples can be partitioned into parallel classes (each covering all vertices). The Kirkman schoolgirl problem asks for a resolvable STS$(15)$: 15 girls walk in groups of 3 for 7 days without repeating pairs.",
+    "mathContext": "IsResolvable$(H)$: $\\exists$ classes such that each class partitions $V$ into triples from $H$.edges. kirkmanSchoolgirlProblem: $\\exists$ resolvable STS$(15)$. This classic 1850 problem was one of the first questions in combinatorial design theory.",
+    "significance": "supporting",
+    "relatedConcepts": ["resolvable designs", "parallel classes", "Kirkman 1850", "scheduling"],
+    "prerequisites": ["IsSteinerTripleSystem", "Finset partition"]
+  },
+  {
+    "id": "erdos-207-summary",
+    "proofId": "erdos-207",
+    "type": "theorem",
+    "range": { "startLine": 258, "endLine": 272 },
+    "title": "Main Results Summary",
+    "content": "Summary theorem combining: (1) erdos207Conjecture is true (from KSSS), and (2) Kirkman's condition is necessary and sufficient for STS existence. The second part is proved in Lean from the kirkman_theorem axiom.",
+    "mathContext": "erdos_207_summary: erdos207Conjecture $\\wedge \\forall n \\geq 1: (\\exists$ STS$(n)) \\iff$ IsAdmissible$(n)$. The first conjunct is the KSSS axiom; the second is proved by applying kirkman_theorem in both directions.",
+    "significance": "key",
+    "relatedConcepts": ["summary theorem", "bidirectional proof", "design existence"],
+    "prerequisites": ["kwan_sah_sawhney_simkin_2022", "kirkman_theorem"]
   }
 ]

--- a/src/data/proofs/erdos-207/meta.json
+++ b/src/data/proofs/erdos-207/meta.json
@@ -55,91 +55,98 @@
     ]
   },
   "overview": {
-    "historicalContext": "**Steiner Triple Systems and High Girth**\n\nA Steiner triple system (STS) of order n is a collection of 3-element subsets (triples) of an n-set such that every pair of elements appears in exactly one triple. These fundamental combinatorial structures were first studied by Kirkman in 1847, who proved they exist if and only if n ≡ 1 or 3 (mod 6).\n\n**The Girth Question**\n\nErdős asked in 1976 whether STS with arbitrarily high girth exist. The girth condition requires that any j edges (2 ≤ j ≤ g) span at least j+3 vertices, preventing \"tight\" configurations where edges overlap heavily.\n\n**The Resolution (2022)**\n\nKwan, Sah, Sawhney, and Simkin resolved this in 2022 using a sophisticated random greedy construction. Their proof employs the Rödl nibble method and introduces a \"spread measure\" to control the girth property during construction.\n\n**Special Case: Pasch-Free STS**\n\nThe girth-3 case corresponds to avoiding the Pasch configuration (4 triples on 6 vertices). Anti-Pasch STS were known to exist before KSSS's general result.",
+    "historicalContext": "**Steiner Triple Systems and High Girth**\n\nA Steiner triple system STS$(n)$ is a collection of 3-element subsets (triples) of an $n$-set such that every pair of elements appears in exactly one triple. These fundamental structures were first studied by **Thomas Kirkman** in 1847, who proved STS$(n)$ exists iff $n \\equiv 1, 3 \\pmod{6}$, predating **Jakob Steiner**'s 1853 formulation.\n\n**The Girth Question**\n\nErdős posed this problem in 1976, asking whether STS with arbitrarily high girth exist for all large admissible orders. The girth condition (any $j$ edges span $\\geq j+3$ vertices) prevents 'tight' configurations. The special case $g = 3$ (Pasch-free STS) was resolved earlier by **Grannell, Griggs, and Whitehead** (2000) and independently by others.\n\n**The Resolution (2022)**\n\n**Matthew Kwan, Ashwin Sah, Mehtaab Sawhney, and Michael Simkin** (arXiv:2201.04554) resolved this completely using a random greedy construction. Their proof combines the **Rödl nibble method** with a novel **spread measure** to control the girth property throughout the construction process, employing concentration inequalities from probabilistic combinatorics.\n\n**The Kirkman Schoolgirl Problem**\n\nThe formalization also includes the 1850 Kirkman schoolgirl problem—the first question in design theory—asking for a resolvable STS$(15)$ where 15 girls walk in groups of 3 for 7 days without repeating companions.",
     "problemStatement": "**Problem Statement (SOLVED)**\n\nFor any $g \\geq 2$, if $n$ is sufficiently large and $n \\equiv 1, 3 \\pmod{6}$, does there exist a 3-uniform hypergraph on $n$ vertices such that:\n1. Every pair of vertices is contained in exactly one edge (Steiner triple system)\n2. For any $2 \\leq j \\leq g$, any collection of $j$ edges contains at least $j+3$ vertices\n\n**Answer: YES**\n\nKwan, Sah, Sawhney, and Simkin (2022) proved that high-girth Steiner triple systems exist for all admissible orders.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Hypergraphs:** Define Hypergraph3 structure for 3-uniform hypergraphs.\n\n2. **STS Property:** Formalize IsSteinerTripleSystem requiring each pair in exactly one edge.\n\n3. **Girth:** Define HasGirthAtLeast requiring j edges span ≥ j+3 vertices.\n\n4. **Admissibility:** Define IsAdmissible for n ≡ 1, 3 (mod 6).\n\n5. **Main Result:** Axiomatize Kirkman's theorem and KSSS theorem.\n\n6. **Special Cases:** Define Pasch configurations and anti-Pasch STS.\n\n7. **Related:** Include resolvable STS and Kirkman schoolgirl problem.\n\n**Why Axiomatization?** The KSSS proof is highly technical, using probabilistic combinatorics (Rödl nibble, concentration inequalities) far beyond Mathlib.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Hypergraphs:** Define `Hypergraph3 V` as a structure with edges $\\in \\text{Finset}(\\text{Finset}\\,V)$ satisfying $|e| = 3$.\n\n2. **STS Property:** Formalize `IsSteinerTripleSystem` via $\\forall a \\neq b, \\exists! e \\in H.\\text{edges}: a \\in e \\wedge b \\in e$.\n\n3. **Girth:** Define `HasGirthAtLeast` requiring $|S| \\leq g \\implies |\\bigcup S| \\geq |S| + 3$.\n\n4. **Admissibility:** Define `IsAdmissible` for $n \\bmod 6 \\in \\{1, 3\\}$.\n\n5. **Main Result:** Axiomatize Kirkman's theorem and the KSSS theorem.\n\n6. **Special Cases:** Define Pasch configurations ($|S| = 4, |\\bigcup S| = 6$) and anti-Pasch STS.\n\n7. **Related:** Include resolvable STS and the Kirkman schoolgirl problem.\n\n**Why Axiomatization?** The KSSS proof uses probabilistic combinatorics (Rödl nibble, concentration inequalities, spread measure) far beyond current Mathlib.",
     "keyInsights": [
-      "**Kirkman's Condition:** STS(n) exists iff n ≡ 1, 3 (mod 6). This is necessary for the girth question to make sense.",
-      "**Why j+3?:** Two edges share at most 1 vertex in an STS, so 2 edges span ≥ 5 = 2+3 vertices. The condition generalizes this.",
-      "**Pasch Configuration:** The obstacle to girth 3 - four triples {abc, ade, bdf, cef} on 6 vertices.",
-      "**Random Greedy Works:** Surprisingly, a careful random construction achieves arbitrary girth.",
-      "**Spread Measure:** The key technical innovation in KSSS - measures how uniformly distributed a partial STS is."
+      "**Kirkman's Condition:** STS$(n)$ exists iff $n \\equiv 1, 3 \\pmod{6}$. This 1847 result is the necessary foundation for the girth question.",
+      "**Why $j+3$?** Two edges in an STS share at most 1 vertex (by unique pair coverage), so 2 edges span $\\geq 5 = 2+3$ vertices. The girth condition generalizes this to $j$ edges.",
+      "**Pasch Configuration:** The minimal obstruction to girth 3 — four triples $\\{abc, ade, bdf, cef\\}$ on exactly 6 vertices, forming the smallest 'tight' hypergraph cycle.",
+      "**Random Greedy Construction:** The KSSS proof shows that a careful random greedy process achieves arbitrary girth with positive probability, despite the global nature of the constraint.",
+      "**Spread Measure Innovation:** The key technical tool in KSSS measures how uniformly distributed a partial STS is, preventing concentration that would create forbidden configurations."
     ]
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Namespace",
+      "summary": "Imports Mathlib modules for `Finset`, `Fintype.card`, `Finset.biUnion`, and natural number arithmetic. Opens `Finset` namespace within `Erdos207`.",
+      "startLine": 28,
+      "endLine": 36
+    },
+    {
       "id": "hypergraphs",
-      "title": "Hypergraphs and STS",
-      "summary": "Hypergraph3, edgeContainsPair, IsSteinerTripleSystem definitions",
+      "title": "3-Uniform Hypergraphs and STS",
+      "summary": "Defines `Hypergraph3 V` (edges $\\in \\text{Finset}(\\text{Finset}\\,V)$ with $|e| = 3$), `edgeContainsPair`, and `IsSteinerTripleSystem` via $\\exists!$ unique pair coverage.",
       "startLine": 37,
       "endLine": 64
     },
     {
       "id": "girth",
-      "title": "Girth Conditions",
-      "summary": "vertexSpan, HasGirthAtLeast, girthExplanation",
+      "title": "Vertex Span and Girth Conditions",
+      "summary": "Defines `vertexSpan` via `Finset.biUnion` and `HasGirthAtLeast(H, g)$: $\\forall S \\subseteq H.\\text{edges}, 2 \\leq |S| \\leq g \\implies |\\bigcup S| \\geq |S| + 3$.",
       "startLine": 65,
       "endLine": 95
     },
     {
       "id": "admissibility",
-      "title": "The Admissibility Condition",
-      "summary": "IsAdmissible, kirkman_theorem, stsTripleCount",
+      "title": "Admissibility and Triple Count",
+      "summary": "Defines `IsAdmissible(n)$: $n \\bmod 6 \\in \\{1,3\\}$ and `stsTripleCount $= n(n-1)/6$. Axiomatizes Kirkman's 1847 theorem characterizing STS existence.",
       "startLine": 96,
       "endLine": 125
     },
     {
       "id": "conjecture",
       "title": "The Erdős Conjecture",
-      "summary": "erdos207Conjecture definition",
+      "summary": "Formalizes erdos207Conjecture: $\\forall g \\geq 2, \\exists N: \\forall n \\geq N$, IsAdmissible$(n) \\implies \\exists$ STS$(n)$ with girth $\\geq g$.",
       "startLine": 126,
       "endLine": 139
     },
     {
       "id": "solution",
-      "title": "The Solution",
-      "summary": "kwan_sah_sawhney_simkin_2022, erdos_207 theorem",
+      "title": "The KSSS Solution",
+      "summary": "Axiomatizes `kwan_sah_sawhney_simkin_2022 : erdos207Conjecture` and derives `erdos_207 : erdos207Conjecture` as the main result of the formalization.",
       "startLine": 140,
       "endLine": 158
     },
     {
       "id": "special-cases",
-      "title": "Special Cases",
-      "summary": "Girth 2, Pasch configurations, anti-Pasch STS",
+      "title": "Girth 2, Pasch, and Anti-Pasch",
+      "summary": "Proves `sts_has_girth_at_least_2` (trivial from unique pair coverage). Defines `IsPaschConfiguration` ($|S|=4, |\\bigcup S|=6$) and states `girth_3_iff_pasch_free`.",
       "startLine": 159,
       "endLine": 197
     },
     {
       "id": "techniques",
       "title": "Proof Techniques",
-      "summary": "Random construction, spread measure",
+      "summary": "Documents the random greedy construction, Rödl nibble method, and spread measure technique used in the KSSS proof, formalized as descriptive comments.",
       "startLine": 198,
       "endLine": 219
     },
     {
       "id": "related",
-      "title": "Related Problems",
-      "summary": "IsResolvable, kirkmanSchoolgirlProblem",
+      "title": "Resolvable STS and Kirkman Schoolgirl",
+      "summary": "Defines `IsResolvable(H)$: edges partition into parallel classes covering all vertices. States `kirkmanSchoolgirlProblem`: $\\exists$ resolvable STS$(15)$.",
       "startLine": 220,
       "endLine": 244
     },
     {
       "id": "summary",
       "title": "Main Results Summary",
-      "summary": "erdos_207_summary theorem",
+      "summary": "Proves `erdos_207_summary`: erdos207Conjecture $\\wedge$ ($\\forall n \\geq 1$, $\\exists$ STS$(n) \\iff$ IsAdmissible$(n)$). Second conjunct proved from `kirkman_theorem` axiom.",
       "startLine": 245,
       "endLine": 282
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #207 asked whether high-girth Steiner triple systems exist for all admissible orders. Kwan, Sah, Sawhney, and Simkin (2022) proved YES using a random greedy construction with spread measure analysis. The result generalizes earlier work on Pasch-free (girth ≥ 3) STS to arbitrary girth.",
-    "implications": "**Implications in Design Theory**\n\n1. **Arbitrary Girth:** Any forbidden configuration can be avoided in large STS.\n\n2. **Random Methods Work:** Even for highly structured objects like STS, probabilistic constructions succeed.\n\n3. **Spread Measure Technique:** A new tool applicable to other design construction problems.\n\n4. **Hypergraph Regularity:** Connects to Szemerédi-type regularity for hypergraphs.\n\n5. **Coding Theory:** High-girth STS relate to error-correcting codes with specific distance properties.",
+    "summary": "Erdős Problem #207 asked whether high-girth Steiner triple systems exist for all sufficiently large admissible orders. Kwan, Sah, Sawhney, and Simkin (2022) proved YES using a random greedy construction with spread measure analysis. The formalization captures the full problem structure: 3-uniform hypergraphs, the STS property, the girth condition, Kirkman's 1847 existence theorem, and the 2022 resolution, plus special cases (Pasch configurations) and related problems (resolvable STS, Kirkman schoolgirl problem).",
+    "implications": "**Implications in Design Theory**\n\n1. **Arbitrary Girth:** Any forbidden configuration can be avoided in large STS, settling a fundamental question about the structure of Steiner systems.\n\n2. **Random Methods Work:** Even for highly structured combinatorial objects like STS, probabilistic constructions achieve optimal results.\n\n3. **Spread Measure Technique:** A new tool in probabilistic combinatorics applicable to other design construction problems.\n\n4. **Hypergraph Regularity:** Connects to Szemerédi-type regularity for hypergraphs and the broader program of understanding quasirandom designs.\n\n5. **Coding Theory:** High-girth STS relate to error-correcting codes with specific minimum distance properties.",
     "openQuestions": [
-      "Explicit constructions (non-random) for high-girth STS",
-      "Optimal threshold N(g) for existence",
-      "High-girth Steiner systems with other block sizes",
-      "Counting high-girth STS of order n",
-      "Resolvable high-girth STS"
+      "Can explicit (deterministic) constructions achieve high-girth STS, or is randomness inherent?",
+      "What is the optimal threshold $N(g)$ as a function of girth $g$?",
+      "Do high-girth Steiner systems $S(t, k, n)$ exist for block sizes $k > 3$?",
+      "How many non-isomorphic high-girth STS$(n)$ exist for large $n$?",
+      "Can resolvable high-girth STS be constructed for admissible orders $n \\equiv 3 \\pmod{6}$?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enriched annotations.json: 12 annotations with mathContext, relatedConcepts, prerequisites on all; fixed types (axiom→theorem for Kirkman/KSSS axiom lines)
- Enriched meta.json: deepened historicalContext (Kirkman 1847, Grannell-Griggs-Whitehead 2000, KSSS 2022 full names), LaTeX in section summaries, expanded to 10 sections, enriched openQuestions with specific mathematical detail
- Covers: 3-uniform hypergraphs, STS, vertex span/girth, admissibility, Erdős conjecture, KSSS solution, Pasch configurations, resolvable STS, Kirkman schoolgirl problem

## Test plan
- [x] `pnpm annotations:build` passes (non-strict)
- [x] No erdos-207 warnings in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)