### PR TITLE
enrich(erdos-234): deepen annotations with Cramér, Gallagher, GPY context

### DIFF
--- a/src/data/proofs/erdos-234/annotations.json
+++ b/src/data/proofs/erdos-234/annotations.json
@@ -1,56 +1,110 @@
 [
   {
-    "id": "erdos-234-gap-defs",
+    "id": "erdos-234-imports",
+    "proofId": "erdos-234",
+    "type": "concept",
+    "range": { "startLine": 15, "endLine": 30 },
+    "title": "Library Imports and Namespace",
+    "content": "Imports Mathlib for prime enumeration (`Nat.Nth`), finite sets, real analysis (`Log.Basic`, `ExpDeriv`), topology (`nhds`, `Filter.atTop`), and the Riemann Hypothesis axiom from `Proofs.RiemannHypothesis`. Opens `Nat`, `Filter`, `Real`, `Set` namespaces.",
+    "mathContext": "The formalization uses `Nat.nth Nat.Prime` to enumerate primes, `Real.log` and `Real.exp` for the normalized gap and Cramér prediction, `Filter.Tendsto` with `atTop` for limits $\\lim_{N \\to \\infty}$, and `nhds` for topological convergence. The `RiemannHypothesis` import provides the axiom needed for Gallagher's conditional result.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.nth", "Filter.Tendsto", "Real.log", "Real.exp", "RiemannHypothesis"],
+    "prerequisites": ["Lean 4 basics", "Mathlib analysis library", "filter theory"]
+  },
+  {
+    "id": "erdos-234-prime-defs",
     "proofId": "erdos-234",
     "type": "definition",
-    "range": { "startLine": 32, "endLine": 56 },
-    "title": "Prime Gap and Density Definitions",
-    "content": "nthPrime uses Nat.nth to enumerate primes. primeGap computes p_{n+1}-p_n. normalizedGap divides by log n. countSmallNormGaps and gapProportion measure the proportion below a threshold c.",
-    "significance": "essential"
+    "range": { "startLine": 37, "endLine": 44 },
+    "title": "Prime Gaps and Normalized Gaps",
+    "content": "Defines `nthPrime` via `Nat.nth Nat.Prime`, `primeGap` as $p_{n+1} - p_n$, and `normalizedGap` as $g_n / \\log n$ (with $0$ for $n \\leq 1$). The normalization by $\\log n$ is motivated by the Prime Number Theorem: the average gap near $p_n$ is approximately $\\log p_n \\approx \\log n$.",
+    "mathContext": "nthPrime$(n) = p_n$ via `Nat.nth`. primeGap$(n) = p_{n+1} - p_n$. normalizedGap$(n) = g_n / \\log n$ for $n > 1$, else $0$. By PNT, $p_n \\sim n \\log n$, so consecutive gaps average $\\log p_n$. The normalization makes the gap distribution scale-free.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.nth", "prime number theorem", "prime gaps", "normalization"],
+    "prerequisites": ["Nat.Prime", "Real.log", "natural number subtraction"]
+  },
+  {
+    "id": "erdos-234-counting",
+    "proofId": "erdos-234",
+    "type": "definition",
+    "range": { "startLine": 51, "endLine": 56 },
+    "title": "Counting Functions for Gap Distribution",
+    "content": "Defines `countSmallNormGaps` as $\\#\\{n < N : g_n/\\log n < c\\}$ via `Finset.filter` on `Finset.range N`, and `gapProportion` as this count divided by $N$. These are the finite approximations to the density $f(c)$.",
+    "mathContext": "countSmallNormGaps$(N, c) = |\\{n < N : \\text{normalizedGap}(n) < c\\}|$ via `Finset.range.filter`. gapProportion$(N, c) = \\text{countSmallNormGaps}(N, c) / N$. The conjecture asks whether $\\lim_{N \\to \\infty} \\text{gapProportion}(N, c)$ exists.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.filter", "empirical distribution function", "natural density"],
+    "prerequisites": ["Finset.range", "Finset.card", "real division"]
   },
   {
     "id": "erdos-234-conjecture",
     "proofId": "erdos-234",
-    "type": "conjecture",
-    "range": { "startLine": 62, "endLine": 76 },
-    "title": "Erdős Problem 234",
-    "content": "For every c ≥ 0, the density f(c) = lim #{n ≤ N : g_n/log n < c}/N exists and defines a continuous function. This combines existence of the limit with continuity of the resulting function.",
-    "significance": "essential"
+    "type": "definition",
+    "range": { "startLine": 63, "endLine": 76 },
+    "title": "Erdős Problem 234 — The Conjecture",
+    "content": "States `ErdosProblem234` as two conditions: (1) for every $c \\geq 0$, the limit $f(c) = \\lim_{N \\to \\infty} \\text{gapProportion}(N, c)$ exists, and (2) there exists a continuous function $f : \\mathbb{R} \\to \\mathbb{R}$ that equals this limit for all $c \\geq 0$. The conjecture is OPEN.",
+    "mathContext": "ErdosProblem234: $(\\forall c \\geq 0, \\exists f_c: \\text{Tendsto}(\\text{gapProportion}(\\cdot, c), \\text{atTop}, \\text{nhds}(f_c))) \\wedge (\\exists f \\in C(\\mathbb{R}): \\forall c \\geq 0, \\text{Tendsto}(\\text{gapProportion}(\\cdot, c), \\text{atTop}, \\text{nhds}(f(c))))$. The second conjunct is strictly stronger: it requires the pointwise limits to assemble into a continuous function.",
+    "significance": "critical",
+    "relatedConcepts": ["natural density", "continuous distribution function", "Erdős 1935"],
+    "prerequisites": ["DensityExists", "Tendsto", "Continuous", "nhds"]
   },
   {
     "id": "erdos-234-basic-props",
     "proofId": "erdos-234",
-    "type": "result",
-    "range": { "startLine": 82, "endLine": 121 },
+    "type": "theorem",
+    "range": { "startLine": 83, "endLine": 141 },
     "title": "Basic Properties of the Density",
-    "content": "normalizedGap_nonneg proves gaps are non-negative. countSmallNormGaps_zero and gapProportion_zero prove no gaps lie below 0. density_at_zero shows f(0)=0. Monotonicity and convergence to 1 are axiomatized.",
-    "significance": "essential"
+    "content": "Proves in Lean: `normalizedGap_nonneg` ($g_n/\\log n \\geq 0$), `countSmallNormGaps_zero` (no gaps below $0$), `gapProportion_zero` ($f_N(0) = 0$), `density_at_zero` ($f(0) = 0$), `gapProportion_nonneg` ($f_N(c) \\geq 0$), `gapProportion_le_one` ($f_N(c) \\leq 1$), `countSmallNormGaps_mono` and `density_monotone` ($c_1 \\leq c_2 \\implies f_N(c_1) \\leq f_N(c_2)$). Axiomatizes `density_at_infinity` ($f(c) \\to 1$ as $c \\to \\infty$).",
+    "mathContext": "The proved properties establish that the finite approximations $f_N(c)$ form a family of non-decreasing functions from $[0,1]$ into $[0,1]$ with $f_N(0) = 0$. The axiom density_at_infinity captures that eventually all normalized gaps lie below any threshold, a consequence of the prime number theorem and Bertrand's postulate.",
+    "significance": "key",
+    "relatedConcepts": ["distribution function properties", "monotonicity", "Bertrand's postulate", "PNT"],
+    "prerequisites": ["normalizedGap", "gapProportion", "div_nonneg", "Finset.card_filter_le"]
   },
   {
     "id": "erdos-234-cramer",
     "proofId": "erdos-234",
     "type": "definition",
-    "range": { "startLine": 128, "endLine": 141 },
+    "range": { "startLine": 153, "endLine": 178 },
     "title": "Cramér's Exponential Model",
-    "content": "cramerPrediction defines f(c) = 1 - e^{-c} for c ≥ 0, following Cramér's 1936 probabilistic model for prime gaps. Continuity of the exponential part is proved; full continuity of the piecewise function is axiomatized.",
-    "significance": "essential"
+    "content": "Defines `cramerPrediction` as $f(c) = 1 - e^{-c}$ for $c \\geq 0$ (and $0$ for $c < 0$), following **Cramér's 1936 probabilistic model** where each integer $n$ is independently prime with probability $1/\\log n$. Proves `cramer_continuous` (continuity of the piecewise function) and `cramer_in_unit_interval` ($0 \\leq f(c) \\leq 1$ for $c \\geq 0$).",
+    "mathContext": "cramerPrediction$(c) = \\begin{cases} 0 & c < 0 \\\\ 1 - e^{-c} & c \\geq 0 \\end{cases}$. Cramér's model treats primes as a Poisson process with rate $1/\\log n$, giving exponential gaps. The CDF of $\\text{Exp}(1)$ is $1 - e^{-c}$. The continuity proof uses `Continuous.if_lt` to join the two pieces at $c = 0$.",
+    "significance": "critical",
+    "relatedConcepts": ["Cramér model", "Poisson process", "exponential distribution", "CDF"],
+    "prerequisites": ["Real.exp", "Continuous.if_lt", "exp_le_one_of_nonpos"]
   },
   {
     "id": "erdos-234-gallagher",
     "proofId": "erdos-234",
-    "type": "result",
-    "range": { "startLine": 149, "endLine": 165 },
-    "title": "Gallagher's Conditional Result",
-    "content": "Gallagher (1976) showed that under the Riemann Hypothesis, normalized prime gaps follow the exponential distribution. gallagher_implies_conjecture proves this implies the full ErdosProblem234.",
-    "significance": "essential"
+    "type": "theorem",
+    "range": { "startLine": 187, "endLine": 202 },
+    "title": "Gallagher's Conditional Result (1976)",
+    "content": "Axiomatizes **Gallagher's theorem**: assuming the Riemann Hypothesis, $\\lim_{N \\to \\infty} \\text{gapProportion}(N, c) = 1 - e^{-c}$ for all $c \\geq 0$. Then proves `gallagher_implies_conjecture`: RH implies `ErdosProblem234`, since Cramér's prediction is continuous and matches the limit.",
+    "mathContext": "gallagher_conditional: RH $\\implies \\forall c \\geq 0, \\text{Tendsto}(\\text{gapProportion}(\\cdot, c), \\text{atTop}, \\text{nhds}(\\text{cramerPrediction}(c)))$. gallagher_implies_conjecture: RH $\\implies$ ErdosProblem234. Proof: the first conjunct uses `gallagher_conditional` to witness the limit; the second uses `cramerPrediction` as the continuous function (via `cramer_continuous`).",
+    "significance": "critical",
+    "relatedConcepts": ["Gallagher 1976", "Riemann Hypothesis", "conditional results", "short intervals"],
+    "prerequisites": ["gallagher_conditional", "cramer_continuous", "ErdosProblem234"]
   },
   {
     "id": "erdos-234-partial",
     "proofId": "erdos-234",
-    "type": "result",
-    "range": { "startLine": 172, "endLine": 183 },
-    "title": "Partial Results on Gap Distribution",
-    "content": "Three axiomatized results: small_gaps_exist (infinitely many gaps below (1+ε)log p), large_gaps_exist (unbounded normalized gaps, by Rankin–Maynard), and average_normalized_gap tending to 1 by PNT.",
-    "significance": "supporting"
+    "type": "theorem",
+    "range": { "startLine": 210, "endLine": 220 },
+    "title": "Partial Results: Small Gaps, Large Gaps, Average",
+    "content": "Three axiomatized results: (1) `small_gaps_exist`: for any $\\varepsilon > 0$, infinitely many primes have $g_n < (1 + \\varepsilon) \\log p_n$ (Goldston–Pintz–Yıldırım, Maynard–Tao); (2) `large_gaps_exist`: normalized gaps are unbounded (Rankin 1938, improved by Ford–Green–Konyagin–Tao 2016, Maynard 2016); (3) `average_normalized_gap` tends to $1$ by PNT.",
+    "mathContext": "small_gaps_exist: $\\{n : g_n < (1+\\varepsilon)\\log p_n\\}$ is infinite. GPY (2009) showed $\\liminf g_n/\\log p_n = 0$; Maynard–Tao (2014) showed bounded gaps. large_gaps_exist: $\\forall M > 0, \\exists n: g_n/\\log n > M$. The best bound is $g_n \\gg \\log n \\cdot \\log\\log n \\cdot \\log\\log\\log\\log n / (\\log\\log\\log n)^2$ (FGKT). average_normalized_gap: $\\frac{1}{N}\\sum_{n<N} g_n/\\log n \\to 1$ by PNT.",
+    "significance": "key",
+    "relatedConcepts": ["GPY theorem", "Maynard–Tao", "Rankin's theorem", "Ford–Green–Konyagin–Tao", "PNT"],
+    "prerequisites": ["primeGap", "normalizedGap", "Set.Infinite", "Tendsto"]
+  },
+  {
+    "id": "erdos-234-cramer-props",
+    "proofId": "erdos-234",
+    "type": "theorem",
+    "range": { "startLine": 227, "endLine": 248 },
+    "title": "Additional Cramér Model Properties",
+    "content": "Proves `cramer_at_zero` ($f(0) = 0$, by `simp`), `cramer_nonneg` ($f(c) \\geq 0$), `cramer_le_one` ($f(c) \\leq 1$), and `cramer_monotone` ($c_1 \\leq c_2 \\implies f(c_1) \\leq f(c_2)$, using $e^{-c_2} \\leq e^{-c_1}$ from `exp_le_exp`).",
+    "mathContext": "cramer_monotone uses the fact that $e^{-x}$ is decreasing: $c_1 \\leq c_2 \\implies -c_2 \\leq -c_1 \\implies e^{-c_2} \\leq e^{-c_1} \\implies 1 - e^{-c_1} \\leq 1 - e^{-c_2}$. All properties mirror the standard CDF axioms: $F(0) = 0$, $0 \\leq F \\leq 1$, $F$ non-decreasing.",
+    "significance": "supporting",
+    "relatedConcepts": ["CDF axioms", "exponential monotonicity", "exp_le_exp"],
+    "prerequisites": ["cramerPrediction", "cramer_in_unit_interval", "Real.exp"]
   }
 ]

--- a/src/data/proofs/erdos-234/meta.json
+++ b/src/data/proofs/erdos-234/meta.json
@@ -22,74 +22,90 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős asked whether the density of integers n with normalized prime gap (p_{n+1}-p_n)/log n < c exists and is continuous. Cramér's 1936 probabilistic model predicts an exponential distribution f(c) = 1 - e^{-c}. Gallagher (1976) proved this holds conditional on the Riemann Hypothesis. The unconditional question remains open. Related to Problem 233 (sum of squared gaps) and Problem 5 (large prime gaps).",
-    "problemStatement": "For every c ≥ 0, does the density f(c) = lim_{N→∞} #{n ≤ N : (p_{n+1}-p_n)/log n < c}/N exist, and is f continuous?",
-    "proofStrategy": "We define nthPrime, primeGap, normalizedGap, and gapProportion. The conjecture ErdosProblem234 asserts both existence and continuity. We prove basic properties (f(0)=0, non-negativity) and define Cramér's exponential prediction. Gallagher's conditional result is axiomatized, and we prove it implies the full conjecture. Partial results on small gaps, large gaps, and average gap are stated.",
+    "historicalContext": "**From Cramér's Model to the Distribution of Prime Gaps**\n\n**Harald Cramér** introduced his groundbreaking probabilistic model in 1936, treating each integer $n$ as independently prime with probability $1/\\log n$. Under this model, normalized prime gaps $g_n / \\log p_n$ follow an **exponential distribution** with CDF $f(c) = 1 - e^{-c}$. Cramér's model has been remarkably successful at predicting prime gap statistics, though it is known to fail for some finer questions (Maier's theorem, 1985).\n\n**Erdős** asked in the 1930s–1940s whether the **natural density** $f(c) = \\lim_{N \\to \\infty} \\#\\{n \\leq N : g_n/\\log n < c\\}/N$ exists for all $c \\geq 0$ and defines a continuous function. This combines an existence question (does the proportion converge?) with a regularity question (is the limit continuous in $c$?).\n\n**Patrick Gallagher** (1976) proved the exponential distribution conjecture conditional on the **Riemann Hypothesis**, using the Hardy–Littlewood prime $k$-tuples conjecture structure. His result shows that if RH holds, then $f(c) = 1 - e^{-c}$ exactly.\n\nPartial unconditional progress includes: **Goldston–Pintz–Yıldırım** (2009) proved $\\liminf g_n/\\log p_n = 0$; **Maynard** and **Tao** (2014) proved bounded gaps $\\liminf g_n \\leq 246$; **Ford–Green–Konyagin–Tao** (2016) and **Maynard** (2016) improved Rankin's large gap bound. Related problems include Erdős #233 (sum of squared gaps) and #5 (large prime gaps).",
+    "problemStatement": "**Erdős Problem 234**\n\nFor every $c \\geq 0$, does the density\n$$f(c) = \\lim_{N \\to \\infty} \\frac{\\#\\{n \\leq N : (p_{n+1} - p_n)/\\log n < c\\}}{N}$$\nexist, and is $f$ a continuous function of $c$?\n\nCramér's model predicts $f(c) = 1 - e^{-c}$, the CDF of the standard exponential distribution.",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Prime gap infrastructure:** Define `nthPrime` via `Nat.nth`, `primeGap`, and `normalizedGap` with $\\log n$ normalization.\n2. **Counting functions:** Define `countSmallNormGaps` and `gapProportion` as the finite approximations to $f(c)$.\n3. **Conjecture statement:** `ErdosProblem234` asserts both existence of the limit and continuity of the resulting function, using `Filter.Tendsto` and `Continuous`.\n4. **Basic properties:** Prove $f(0) = 0$, monotonicity, non-negativity, and boundedness by $1$ — all in Lean.\n5. **Cramér model:** Define $1 - e^{-c}$ piecewise, prove continuity via `Continuous.if_lt`, and verify CDF axioms.\n6. **Gallagher's theorem:** Axiomatize the conditional result and prove it implies the full conjecture.\n7. **Partial results:** Axiomatize small gaps (GPY/Maynard–Tao), large gaps (FGKT/Maynard), and average gap (PNT).",
     "keyInsights": [
-      "Cramér's model predicts exponential distribution f(c) = 1 - e^{-c} for normalized prime gaps",
-      "Gallagher (1976) proved the conjecture conditional on the Riemann Hypothesis",
-      "Basic properties f(0)=0, monotonicity, and f→1 as c→∞ are formalized",
-      "The unconditional existence of the density remains the key open question"
+      "**Cramér's Exponential Model:** The probabilistic model treats primes as a Poisson process with rate $1/\\log n$, predicting normalized gaps follow $\\text{Exp}(1)$ with CDF $f(c) = 1 - e^{-c}$.",
+      "**Two-Part Conjecture:** The problem separates into (i) existence of the density $f(c)$ for each $c$ and (ii) continuity of $f$ as a function of $c$ — the second is strictly stronger than the first.",
+      "**Gallagher's Conditional Bridge:** Under RH, Gallagher proves $f(c) = 1 - e^{-c}$ exactly, resolving both parts simultaneously. The Lean proof of RH $\\implies$ ErdosProblem234 is just 8 lines.",
+      "**Rich Lean Proofs:** Many properties (monotonicity, boundedness, $f(0) = 0$, Cramér continuity and monotonicity) are fully proved in Lean, not axiomatized — demonstrating real formal reasoning about prime gap distributions.",
+      "**Small and Large Gap Extremes:** The axiomatized partial results capture the state of the art: GPY/Maynard–Tao for small gaps ($\\liminf g_n/\\log p_n = 0$) and FGKT/Maynard for large gaps ($\\limsup g_n/\\log n = \\infty$), bounding the distribution from both sides."
     ]
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Namespace",
+      "startLine": 15,
+      "endLine": 30,
+      "summary": "Imports Mathlib for `Nat.Nth` (prime enumeration), `Real.log`/`Real.exp` (analysis), `Filter.Tendsto` (limits), and `Proofs.RiemannHypothesis`. Opens `Nat`, `Filter`, `Real`, `Set`."
+    },
+    {
       "id": "basic-definitions",
-      "title": "Basic Definitions",
-      "startLine": 32,
+      "title": "Prime Gap Definitions",
+      "startLine": 37,
       "endLine": 44,
-      "summary": "Defines nthPrime via Nat.nth, primeGap as the difference of consecutive primes, and normalizedGap as g_n/log n."
+      "summary": "Defines nthPrime$(n) = p_n$ via `Nat.nth`, primeGap$(n) = p_{n+1} - p_n$, and normalizedGap$(n) = g_n / \\log n$ (with $0$ for $n \\leq 1$)."
     },
     {
       "id": "counting-functions",
       "title": "Counting Functions",
-      "startLine": 46,
+      "startLine": 51,
       "endLine": 56,
-      "summary": "Defines countSmallNormGaps and gapProportion to compute the proportion of integers with normalized gap below a threshold."
+      "summary": "Defines countSmallNormGaps$(N, c) = |\\{n < N : g_n/\\log n < c\\}|$ via `Finset.filter` and gapProportion as the count divided by $N$."
     },
     {
       "id": "conjecture",
       "title": "The Conjecture",
-      "startLine": 58,
+      "startLine": 63,
       "endLine": 76,
-      "summary": "States ErdosProblem234: for all c ≥ 0 the density limit exists, and the resulting function is continuous."
+      "summary": "States ErdosProblem234: $\\forall c \\geq 0$, the density $f(c) = \\lim_{N} \\text{gapProportion}(N, c)$ exists and $f$ is continuous. Uses `Tendsto` with `atTop` and `nhds`."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "startLine": 78,
-      "endLine": 121,
-      "summary": "Proves f(0)=0 via non-negativity of normalized gaps. Axiomatizes monotonicity and convergence to 1 at infinity."
+      "startLine": 83,
+      "endLine": 145,
+      "summary": "Proves $f_N(0) = 0$, $0 \\leq f_N(c) \\leq 1$, monotonicity $c_1 \\leq c_2 \\implies f_N(c_1) \\leq f_N(c_2)$, and $f(0) = 0$. Axiomatizes $f(c) \\to 1$ as $c \\to \\infty$."
     },
     {
       "id": "cramer-model",
-      "title": "Cramér's Model",
-      "startLine": 123,
-      "endLine": 141,
-      "summary": "Defines Cramér's exponential prediction f(c) = 1 - e^{-c}, proves continuity of the exponential part, and axiomatizes full continuity and CDF validity."
+      "title": "Cramér's Exponential Model",
+      "startLine": 153,
+      "endLine": 178,
+      "summary": "Defines cramerPrediction$(c) = 1 - e^{-c}$ for $c \\geq 0$. Proves continuity via `Continuous.if_lt` and validates CDF bounds $0 \\leq f(c) \\leq 1$."
     },
     {
       "id": "gallagher-result",
       "title": "Gallagher's Conditional Result",
-      "startLine": 143,
-      "endLine": 165,
-      "summary": "Axiomatizes Gallagher's 1976 theorem and proves that RH implies the full ErdosProblem234 conjecture."
+      "startLine": 187,
+      "endLine": 202,
+      "summary": "Axiomatizes Gallagher (1976): RH $\\implies \\text{gapProportion}(N, c) \\to 1 - e^{-c}$. Proves gallagher_implies_conjecture: RH $\\implies$ ErdosProblem234."
     },
     {
       "id": "partial-results",
       "title": "Partial Results on Gap Distribution",
-      "startLine": 167,
-      "endLine": 183,
-      "summary": "Axiomatizes existence of small gaps (ε-close to log p), large gaps (unbounded normalized gaps), and the average normalized gap tending to 1."
+      "startLine": 210,
+      "endLine": 220,
+      "summary": "Axiomatizes: (1) small_gaps_exist (GPY/Maynard–Tao: infinitely many $g_n < (1+\\varepsilon)\\log p_n$), (2) large_gaps_exist (FGKT: unbounded $g_n/\\log n$), (3) average $g_n/\\log n \\to 1$ by PNT."
+    },
+    {
+      "id": "cramer-properties",
+      "title": "Cramér Model Properties",
+      "startLine": 227,
+      "endLine": 248,
+      "summary": "Proves $f(0) = 0$, $f(c) \\geq 0$, $f(c) \\leq 1$, and monotonicity $c_1 \\leq c_2 \\implies f(c_1) \\leq f(c_2)$ using $e^{-c_2} \\leq e^{-c_1}$."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 234 asks whether the density of normalized prime gaps exists and is continuous. Cramér's model predicts exponential distribution, and Gallagher proved this conditional on RH. The unconditional problem remains open.",
-    "implications": "Resolution would connect prime gap distribution theory to classical analytic number theory and clarify whether the Cramér model correctly describes prime gap statistics.",
+    "summary": "The formalization of Erdős Problem 234 captures the open question of whether normalized prime gaps $g_n/\\log n$ have a well-defined continuous density function. Cramér's exponential model $f(c) = 1 - e^{-c}$ is defined with full continuity and CDF properties proved in Lean. Gallagher's conditional result (RH $\\implies$ ErdosProblem234) is proved in 8 lines from the axiomatized conditional. Basic properties — $f(0) = 0$, monotonicity, boundedness — are all formally verified, with partial results from GPY, Maynard–Tao, and Ford–Green–Konyagin–Tao axiomatized.",
+    "implications": "**Implications and Connections**\n\n1. **Prime Number Distribution:** Resolution would establish the precise statistical law governing consecutive prime spacings, settling a fundamental question about the fine structure of the primes.\n\n2. **Cramér's Conjecture:** If $f(c) = 1 - e^{-c}$, this strongly supports Cramér's broader conjecture that $\\max_{p_n \\leq x} g_n = O((\\log x)^2)$, though Granville's refinement suggests $\\limsup g_n/(\\log p_n)^2 \\geq 2e^{-\\gamma}$.\n\n3. **Riemann Hypothesis Connection:** Gallagher's result creates a bridge: proving the density exists and is exponential would provide evidence for (or against) RH, since RH implies the exponential law.\n\n4. **Sieve Methods and $k$-Tuples:** The proof techniques connect to the Hardy–Littlewood prime $k$-tuples conjecture, as Gallagher's approach uses moment calculations from prime $k$-tuple counts.\n\n5. **Computational Evidence:** Numerical data strongly supports $f(c) = 1 - e^{-c}$ for the first $10^{18}$ primes, but unconditional analytic proof remains elusive.",
     "openQuestions": [
-      "Does the density f(c) exist unconditionally for all c ≥ 0?",
-      "Is f(c) = 1 - e^{-c} the true density (matching Cramér's prediction)?",
-      "Can the Gallagher conditional result be made unconditional?"
+      "Does the density $f(c)$ exist unconditionally for all $c \\geq 0$, without assuming RH?",
+      "Is $f(c) = 1 - e^{-c}$ the true density, or could the Cramér model fail (as Maier's theorem suggests for short intervals)?",
+      "Can Gallagher's conditional result be strengthened to require weaker assumptions than full RH (e.g., density hypothesis or quasi-RH)?",
+      "What is the rate of convergence: how fast does $\\text{gapProportion}(N, c)$ approach $f(c)$, and does this depend on $c$?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Expanded annotations from 6 to 9 with deep mathContext (Cramér model, Gallagher conditional, GPY/Maynard-Tao/FGKT)
- Fixed invalid types (conjecture → definition, result → theorem) and significance (essential → critical/key/supporting)
- Added mathContext, relatedConcepts, prerequisites to all annotations
- Enriched historicalContext: Cramér 1936, Gallagher 1976, GPY 2009, Maynard-Tao 2014, FGKT 2016
- Added 5 bold keyInsights with LaTeX, expanded from 7 to 9 sections with LaTeX summaries
- Rich conclusion with Cramér conjecture/RH/sieve method implications and specific openQuestions

## Test plan
- [x] `pnpm annotations:build` passes (non-strict warnings only: axiom→theorem, lemma→theorem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)