### PR TITLE
Research: erdos-1109 - f(N)>=6 and CRT density product

### DIFF
--- a/proofs/Proofs/Erdos1109Problem.lean
+++ b/proofs/Proofs/Erdos1109Problem.lean
@@ -1876,4 +1876,249 @@ theorem general_residue_image_le (A : Finset ℕ) (h : hasSquarefreeSumset A)
     _ ≤ (Finset.range ((pp - 1) / 2 + 1) \ ({0} : Finset ℕ)).card := Finset.card_le_card himg_sub
     _ = (pp - 1) / 2 := hcard_target
 
+/-
+## Part XXIII: f(N) ≥ 6
+
+The set {1, 5, 21, 37, 41, 65} witnesses f(N) ≥ 6 for N ≥ 65.
+All 21 distinct sums (from 36 ordered pairs) are squarefree:
+2, 6, 10, 22, 26, 38, 42, 46, 58, 62, 66, 70, 74, 78, 82, 86, 102, 106, 130.
+-/
+
+-- Squarefree witnesses for new sums from adding 65
+private theorem squarefree_66 : Squarefree (66 : ℕ) := by
+  rw [show (66 : ℕ) = 2 * 33 from by norm_num]
+  have h33 : Squarefree (33 : ℕ) := by
+    rw [show (33 : ℕ) = 3 * 11 from by norm_num]
+    have : Nat.Prime 11 := by native_decide
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, three_prime.squarefree, this.squarefree⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h33⟩)
+
+private theorem squarefree_70 : Squarefree (70 : ℕ) := by
+  rw [show (70 : ℕ) = 2 * 35 from by norm_num]
+  have h35 : Squarefree (35 : ℕ) := by
+    rw [show (35 : ℕ) = 5 * 7 from by norm_num]
+    have h5 : Nat.Prime 5 := by native_decide
+    have h7 : Nat.Prime 7 := by native_decide
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, h5.squarefree, h7.squarefree⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h35⟩)
+
+private theorem squarefree_86 : Squarefree (86 : ℕ) := by
+  rw [show (86 : ℕ) = 2 * 43 from by norm_num]
+  have : Nat.Prime 43 := by native_decide
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, this.squarefree⟩)
+
+private theorem squarefree_102 : Squarefree (102 : ℕ) := by
+  rw [show (102 : ℕ) = 2 * 51 from by norm_num]
+  have h51 : Squarefree (51 : ℕ) := by
+    rw [show (51 : ℕ) = 3 * 17 from by norm_num]
+    have : Nat.Prime 17 := by native_decide
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, three_prime.squarefree, this.squarefree⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h51⟩)
+
+private theorem squarefree_106 : Squarefree (106 : ℕ) := by
+  rw [show (106 : ℕ) = 2 * 53 from by norm_num]
+  have : Nat.Prime 53 := by native_decide
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, this.squarefree⟩)
+
+private theorem squarefree_130 : Squarefree (130 : ℕ) := by
+  rw [show (130 : ℕ) = 2 * 65 from by norm_num]
+  have h65 : Squarefree (65 : ℕ) := by
+    rw [show (65 : ℕ) = 5 * 13 from by norm_num]
+    have h5 : Nat.Prime 5 := by native_decide
+    have h13 : Nat.Prime 13 := by native_decide
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, h5.squarefree, h13.squarefree⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h65⟩)
+
+/--
+**{1, 5, 21, 37, 41, 65} has a squarefree sumset.**
+All 36 ordered pair sums are squarefree. This extends the 5-element set
+{1, 5, 21, 37, 41} by adding 65, introducing 6 new distinct sums:
+66=2·3·11, 70=2·5·7, 86=2·43, 102=2·3·17, 106=2·53, 130=2·5·13.
+-/
+theorem sext_1_5_21_37_41_65_squarefree_sumset :
+    hasSquarefreeSumset ({1, 5, 21, 37, 41, 65} : Finset ℕ) := by
+  intro s hs
+  simp only [sumset, Finset.mem_image, Finset.mem_product, Finset.mem_insert,
+    Finset.mem_singleton] at hs
+  obtain ⟨⟨a, b⟩, ⟨ha, hb⟩, hab⟩ := hs
+  simp only [isSquarefree]
+  rcases ha with rfl | rfl | rfl | rfl | rfl | rfl <;>
+    rcases hb with rfl | rfl | rfl | rfl | rfl | rfl <;>
+    simp at hab <;> rw [← hab]
+  -- Row a=1: 2, 6, 22, 38, 42, 66
+  · exact squarefree_2
+  · exact squarefree_6
+  · exact squarefree_22
+  · exact squarefree_38
+  · exact squarefree_42
+  · exact squarefree_66
+  -- Row a=5: 6, 10, 26, 42, 46, 70
+  · exact squarefree_6
+  · exact squarefree_10
+  · exact squarefree_26
+  · exact squarefree_42
+  · exact squarefree_46
+  · exact squarefree_70
+  -- Row a=21: 22, 26, 42, 58, 62, 86
+  · exact squarefree_22
+  · exact squarefree_26
+  · exact squarefree_42
+  · exact squarefree_58
+  · exact squarefree_62
+  · exact squarefree_86
+  -- Row a=37: 38, 42, 58, 74, 78, 102
+  · exact squarefree_38
+  · exact squarefree_42
+  · exact squarefree_58
+  · exact squarefree_74
+  · exact squarefree_78
+  · exact squarefree_102
+  -- Row a=41: 42, 46, 62, 78, 82, 106
+  · exact squarefree_42
+  · exact squarefree_46
+  · exact squarefree_62
+  · exact squarefree_78
+  · exact squarefree_82
+  · exact squarefree_106
+  -- Row a=65: 66, 70, 86, 102, 106, 130
+  · exact squarefree_66
+  · exact squarefree_70
+  · exact squarefree_86
+  · exact squarefree_102
+  · exact squarefree_106
+  · exact squarefree_130
+
+/--
+**f(N) ≥ 6 for N ≥ 65:**
+The set {1, 5, 21, 37, 41, 65} ⊆ {1,...,N} has squarefree sumset, giving f(N) ≥ 6.
+-/
+theorem f_ge_six (N : ℕ) (hN : N ≥ 65) : f N ≥ 6 := by
+  unfold f
+  have h6 : (6 : ℕ) ∈ {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
+    simp only [Set.mem_setOf_eq]
+    refine ⟨{1, 5, 21, 37, 41, 65}, ?_, sext_1_5_21_37_41_65_squarefree_sumset, ?_⟩
+    · intro x hx
+      simp [Finset.mem_insert, Finset.mem_singleton] at hx
+      simp [Finset.mem_range]
+      rcases hx with rfl | rfl | rfl | rfl | rfl | rfl <;> omega
+    · simp [Finset.card_insert_of_not_mem, Finset.mem_insert, Finset.mem_singleton]
+      native_decide
+  have hbdd : BddAbove {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
+    use N + 1
+    intro m hm
+    simp only [Set.mem_setOf_eq] at hm
+    obtain ⟨A, hA_sub, _, hA_card⟩ := hm
+    rw [← hA_card]
+    exact le_trans (Finset.card_le_card hA_sub) (by simp [Finset.card_range])
+  exact le_csSup hbdd h6
+
+/-
+## Part XXIV: Coprime Moduli and CRT
+
+When combining constraints from different primes p and q, the Chinese Remainder
+Theorem tells us the constraints are independent. This section formalizes the
+key structural result: if p ≠ q are primes, then p² and q² are coprime,
+and the residue constraints modulo p² and q² combine multiplicatively.
+-/
+
+/--
+**Coprimality of distinct prime squares:**
+For distinct primes p and q, p² and q² are coprime.
+-/
+theorem coprime_prime_sq (p q : ℕ) (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q) :
+    Nat.Coprime (p * p) (q * q) := by
+  have hcop : Nat.Coprime p q := hp.coprime_iff_not_dvd.mpr (fun h =>
+    hpq (hq.eq_one_or_self_of_dvd p h |>.resolve_left hp.one_lt.ne'))
+  have h1 : Nat.Coprime p (q * q) := hcop.mul_right hcop
+  exact h1.mul_left h1
+
+/--
+**CRT injectivity for residues mod p²q²:**
+For distinct primes p, q: if a, b < p²q² have the same residues mod p² and mod q²,
+then a = b. This is the uniqueness part of the Chinese Remainder Theorem.
+-/
+theorem crt_residue_injective (p q : ℕ) (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q)
+    (a b : ℕ) (ha : a < p * p * (q * q)) (hb : b < p * p * (q * q))
+    (h1 : a % (p * p) = b % (p * p)) (h2 : a % (q * q) = b % (q * q)) :
+    a = b := by
+  have hcop := coprime_prime_sq p q hp hq hpq
+  by_cases hab : a ≥ b
+  · have hpp_dvd : (p * p) ∣ (a - b) := by omega
+    have hqq_dvd : (q * q) ∣ (a - b) := by omega
+    have hdvd : (p * p) * (q * q) ∣ (a - b) :=
+      Nat.Coprime.mul_dvd_of_dvd_of_dvd hcop hpp_dvd hqq_dvd
+    have hlt : a - b < p * p * (q * q) := by omega
+    have h0 : a - b = 0 := by
+      rcases Nat.eq_zero_or_pos (a - b) with h | h
+      · exact h
+      · exact absurd (Nat.le_of_dvd h hdvd) (by omega)
+    omega
+  · push_neg at hab
+    have hpp_dvd : (p * p) ∣ (b - a) := by omega
+    have hqq_dvd : (q * q) ∣ (b - a) := by omega
+    have hdvd : (p * p) * (q * q) ∣ (b - a) :=
+      Nat.Coprime.mul_dvd_of_dvd_of_dvd hcop hpp_dvd hqq_dvd
+    have hlt : b - a < p * p * (q * q) := by omega
+    have h0 : b - a = 0 := by
+      rcases Nat.eq_zero_or_pos (b - a) with h | h
+      · exact h
+      · exact absurd (Nat.le_of_dvd h hdvd) (by omega)
+    omega
+
+/--
+**Combined density bound for two primes:**
+For distinct primes p and q, the number of residue classes of A modulo p²q²
+is at most ((p²-1)/2) * ((q²-1)/2).
+
+The CRT decomposition r ↦ (r % p², r % q²) injects the residue image mod p²q²
+into the product of residue images mod p² and mod q², each bounded by
+general_residue_image_le.
+-/
+theorem combined_residue_bound (A : Finset ℕ) (h : hasSquarefreeSumset A)
+    (p q : ℕ) (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q) :
+    (A.image (· % (p * p * (q * q)))).card ≤ ((p * p - 1) / 2) * ((q * q - 1) / 2) := by
+  set pp := p * p with hpp_def
+  set qq := q * q with hqq_def
+  set Spp := A.image (· % pp)
+  set Sqq := A.image (· % qq)
+  -- Step 1: |image mod ppqq| ≤ |image mod pp| × |image mod qq| via CRT injection
+  have hstep1 : (A.image (· % (pp * qq))).card ≤ Spp.card * Sqq.card := by
+    have hpp_pos : pp > 0 := Nat.mul_pos hp.pos hp.pos
+    have hqq_pos : qq > 0 := Nat.mul_pos hq.pos hq.pos
+    -- r ↦ (r % pp, r % qq) is injective on A.image (mod ppqq) by CRT
+    have hinj : Set.InjOn (fun r => (r % pp, r % qq)) ((A.image (· % (pp * qq))) : Set ℕ) := by
+      intro r hr s hs heq
+      simp only [Finset.mem_coe, Finset.mem_image] at hr hs
+      obtain ⟨a, _, rfl⟩ := hr
+      obtain ⟨b, _, rfl⟩ := hs
+      have hr_lt : a % (pp * qq) < pp * qq := Nat.mod_lt a (Nat.mul_pos hpp_pos hqq_pos)
+      have hs_lt : b % (pp * qq) < pp * qq := Nat.mod_lt b (Nat.mul_pos hpp_pos hqq_pos)
+      have h1 : a % (pp * qq) % pp = b % (pp * qq) % pp := congr_arg Prod.fst heq
+      have h2 : a % (pp * qq) % qq = b % (pp * qq) % qq := congr_arg Prod.snd heq
+      exact crt_residue_injective p q hp hq hpq _ _ hr_lt hs_lt h1 h2
+    -- The image maps into Spp ×ˢ Sqq
+    have himg : (A.image (· % (pp * qq))).image (fun r => (r % pp, r % qq)) ⊆ Spp ×ˢ Sqq := by
+      intro ⟨x, y⟩ hxy
+      simp only [Finset.mem_image, Finset.mem_product] at hxy ⊢
+      obtain ⟨r, hr, heq⟩ := hxy
+      simp only [Finset.mem_image] at hr
+      obtain ⟨a, ha, rfl⟩ := hr
+      constructor
+      · simp only [Finset.mem_image]
+        have : a % (pp * qq) % pp = a % pp := Nat.mod_mod_of_dvd a (dvd_mul_right pp qq)
+        exact ⟨a, ha, by rw [← congr_arg Prod.fst heq, this]⟩
+      · simp only [Finset.mem_image]
+        have : a % (pp * qq) % qq = a % qq := Nat.mod_mod_of_dvd a (dvd_mul_left qq pp)
+        exact ⟨a, ha, by rw [← congr_arg Prod.snd heq, this]⟩
+    calc (A.image (· % (pp * qq))).card
+        = ((A.image (· % (pp * qq))).image (fun r => (r % pp, r % qq))).card :=
+          (Finset.card_image_of_injOn hinj).symm
+      _ ≤ (Spp ×ˢ Sqq).card := Finset.card_le_card himg
+      _ = Spp.card * Sqq.card := Finset.card_product Spp Sqq
+  -- Step 2: Apply per-prime bounds
+  calc (A.image (· % (pp * qq))).card
+      ≤ Spp.card * Sqq.card := hstep1
+    _ ≤ ((pp - 1) / 2) * ((qq - 1) / 2) :=
+        Nat.mul_le_mul (general_residue_image_le A h p hp) (general_residue_image_le A h q hq)
+
 end Erdos1109

--- a/proofs/Proofs/WilsonsTheoremOQ01.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ01.lean
@@ -1,0 +1,646 @@
+import Mathlib.NumberTheory.Wilson
+import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.RingTheory.ZMod.UnitsCyclic
+import Mathlib.GroupTheory.SpecificGroups.Cyclic
+import Mathlib.Tactic
+
+/-
+# Generalizations of Wilson's Theorem to Non-Prime Moduli
+
+## What This Proves
+
+Wilson's theorem states that (p-1)! ≡ -1 (mod p) iff p is prime.
+This file explores what happens for non-prime (composite) moduli:
+
+1. Composite factorial vanishing: For composite n > 4, n divides (n-1)!,
+   so (n-1)! ≡ 0 (mod n).
+
+2. The special case n = 4: 3! = 6 ≡ 2 (mod 4), the only composite
+   number where (n-1)! is neither 0 nor -1 mod n.
+
+3. Complete classification: For n ≥ 2, exactly one of three cases holds:
+   - n is prime and (n-1)! ≡ -1 (mod n)
+   - n = 4 and (n-1)! ≡ 2 (mod n)
+   - n is composite, n > 4, and (n-1)! ≡ 0 (mod n)
+
+4. Wilson quotient: For a prime p, the Wilson quotient is
+   W_p = ((p-1)! + 1) / p. This is always an integer.
+
+5. Wilson primes: A prime p is a Wilson prime if p² | (p-1)! + 1.
+   The only known Wilson primes are 5, 13, and 563.
+
+6. Gauss generalization: The product of all units mod n satisfies
+   ∏ (units) ≡ -1 (mod n) iff n ∈ {1, 2, 4, p^k, 2p^k}.
+
+## Status
+- [x] Composite factorial theorem (n > 4) - full proof
+- [x] Special case n = 4 verified
+- [x] Complete classification theorem - full proof
+- [x] Wilson quotient definition and properties
+- [x] Wilson prime verification for 5, 13
+- [x] Gauss generalization verified computationally for n ≤ 50
+- [x] Gauss-Wilson classification via Mathlib's ZMod.isCyclic_units_iff
+- [ ] Bridge: unitsProduct ↔ IsCyclic (1 sorry, computationally verified ≤200)
+-/
+
+namespace WilsonsTheoremGeneralization
+
+open Nat
+
+/-
+## Infrastructure: Factorial as Finset Product
+-/
+
+-- Express n! as a product over Finset.Icc 1 n
+lemma factorial_eq_Icc_prod (n : ℕ) : n.factorial = (Finset.Icc 1 n).prod id := by
+  induction n with
+  | zero => simp [Nat.factorial]
+  | succ n ih =>
+    rw [Nat.factorial_succ, ih]
+    have hmem : n + 1 ∉ Finset.Icc 1 n := by simp
+    have hinsert : Finset.Icc 1 (n + 1) = insert (n + 1) (Finset.Icc 1 n) := by
+      ext x; simp [Finset.mem_Icc, Finset.mem_insert]; omega
+    rw [hinsert, Finset.prod_insert hmem, id, mul_comm]
+
+-- If a, b are distinct elements of {1,...,n}, then a*b | n!
+lemma distinct_factors_dvd_factorial {a b n : ℕ}
+    (ha : 1 ≤ a) (ha' : a ≤ n) (hb : 1 ≤ b) (hb' : b ≤ n) (hab : a ≠ b) :
+    a * b ∣ n.factorial := by
+  rw [factorial_eq_Icc_prod]
+  have hpair : ({a, b} : Finset ℕ).prod id = a * b := by
+    rw [Finset.prod_pair hab]; rfl
+  rw [← hpair]
+  apply Finset.prod_dvd_prod_of_subset
+  intro x hx
+  simp at hx
+  simp [Finset.mem_Icc]
+  rcases hx with rfl | rfl <;> omega
+
+/-
+## Part 1: Composite Factorial Vanishing
+
+For any composite number n > 4, we have n | (n-1)!.
+-/
+
+theorem composite_factorial_dvd {n : ℕ} (hn_comp : ¬Nat.Prime n) (hn_gt : n > 4) :
+    n ∣ (n - 1).factorial := by
+  have hn_pos : 0 < n := by omega
+  have hn_ne_one : n ≠ 1 := by omega
+  set p := n.minFac with hp_def
+  have hp_prime : Nat.Prime p := Nat.minFac_prime hn_ne_one
+  have hp_dvd : p ∣ n := Nat.minFac_dvd n
+  have hp_gt_one : 1 < p := hp_prime.one_lt
+  set q := n / p with hq_def
+  have hpq : p * q = n := Nat.mul_div_cancel' hp_dvd
+  have hp_sq_le : p ^ 2 ≤ n := Nat.minFac_sq_le_self hn_pos hn_comp
+  have hq_ge_p : p ≤ q := by
+    by_contra h
+    push_neg at h
+    have h1 : p * q < p * p := by nlinarith
+    nlinarith
+  have hq_gt_one : 1 < q := by linarith
+  have hp_lt_n : p < n := by nlinarith
+  have hq_lt_n : q < n := by nlinarith
+  by_cases hpq_eq : p = q
+  · -- Case: n = p² (p = q), so p ≥ 3
+    have hn_eq : n = p * p := by rw [← hpq, hpq_eq]
+    have hp_ge_3 : p ≥ 3 := by
+      by_contra h
+      push_neg at h
+      have hp2 : p = 2 := by omega
+      rw [hp2] at hn_eq; omega
+    have h2p_lt : 2 * p < p * p := by nlinarith
+    have h2p_le : 2 * p ≤ n - 1 := by omega
+    have hp_ne_2p : p ≠ 2 * p := by omega
+    have h_prod_dvd : p * (2 * p) ∣ (n - 1).factorial :=
+      distinct_factors_dvd_factorial (by omega) (by omega) (by omega) h2p_le hp_ne_2p
+    have h_pp_dvd : p * p ∣ p * (2 * p) := ⟨2, by ring⟩
+    have h_goal : p * p ∣ (n - 1).factorial := dvd_trans h_pp_dvd h_prod_dvd
+    exact hn_eq ▸ h_goal
+  · -- Case: p ≠ q, both in {1,...,n-1}
+    rw [← hpq]
+    exact distinct_factors_dvd_factorial (by omega) (by omega) (by omega) (by omega) hpq_eq
+
+-- Equivalent ZMod formulation
+theorem composite_factorial_zero {n : ℕ} (hn_comp : ¬Nat.Prime n) (hn_gt : n > 4) :
+    (↑(n - 1).factorial : ZMod n) = 0 := by
+  rw [ZMod.natCast_eq_zero_iff]
+  exact composite_factorial_dvd hn_comp hn_gt
+
+/-
+## Part 2: Special Cases and Complete Classification
+-/
+
+-- n = 4 is the unique anomaly: 3! = 6 ≡ 2 (mod 4)
+theorem factorial_mod_four : (↑(4 - 1).factorial : ZMod 4) = 2 := by native_decide
+theorem factorial_mod_four_not_zero : (↑(4 - 1).factorial : ZMod 4) ≠ 0 := by native_decide
+theorem factorial_mod_four_not_neg_one : (↑(4 - 1).factorial : ZMod 4) ≠ -1 := by native_decide
+
+-- Small prime verifications of Wilson's theorem
+example : (↑(2 - 1).factorial : ZMod 2) = -1 := by native_decide
+example : (↑(3 - 1).factorial : ZMod 3) = -1 := by native_decide
+example : (↑(5 - 1).factorial : ZMod 5) = -1 := by native_decide
+example : (↑(7 - 1).factorial : ZMod 7) = -1 := by native_decide
+example : (↑(11 - 1).factorial : ZMod 11) = -1 := by native_decide
+example : (↑(13 - 1).factorial : ZMod 13) = -1 := by native_decide
+
+-- Small composite verifications (all ≡ 0 mod n for n > 4)
+example : (↑(6 - 1).factorial : ZMod 6) = 0 := by native_decide
+example : (↑(8 - 1).factorial : ZMod 8) = 0 := by native_decide
+example : (↑(9 - 1).factorial : ZMod 9) = 0 := by native_decide
+example : (↑(10 - 1).factorial : ZMod 10) = 0 := by native_decide
+example : (↑(12 - 1).factorial : ZMod 12) = 0 := by native_decide
+example : (↑(15 - 1).factorial : ZMod 15) = 0 := by native_decide
+example : (↑(16 - 1).factorial : ZMod 16) = 0 := by native_decide
+example : (↑(20 - 1).factorial : ZMod 20) = 0 := by native_decide
+example : (↑(25 - 1).factorial : ZMod 25) = 0 := by native_decide
+
+-- For n ≥ 2, the factorial residue determines primality
+theorem wilson_complete_classification {n : ℕ} (hn : n ≥ 2) :
+    (Nat.Prime n ∧ (↑(n - 1).factorial : ZMod n) = -1) ∨
+    (n = 4 ∧ (↑(n - 1).factorial : ZMod n) = 2) ∨
+    (¬Nat.Prime n ∧ n ≠ 4 ∧ (↑(n - 1).factorial : ZMod n) = 0) := by
+  by_cases hp : Nat.Prime n
+  · left
+    exact ⟨hp, (Nat.prime_iff_fac_equiv_neg_one (by omega : n ≠ 1)).mp hp⟩
+  · right
+    by_cases h4 : n = 4
+    · left
+      exact ⟨h4, by subst h4; native_decide⟩
+    · right
+      refine ⟨hp, h4, ?_⟩
+      have hgt4 : n > 4 := by
+        by_contra h_le
+        push_neg at h_le
+        interval_cases n
+        · exact hp Nat.prime_two
+        · exact hp Nat.prime_three
+        · exact h4 rfl
+      exact composite_factorial_zero hp hgt4
+
+-- Primality test via factorial (biconditional from Mathlib)
+theorem prime_iff_factorial_neg_one {n : ℕ} (hn : n ≥ 2) :
+    Nat.Prime n ↔ (↑(n - 1).factorial : ZMod n) = -1 :=
+  Nat.prime_iff_fac_equiv_neg_one (by omega)
+
+/-
+## Part 3: Wilson Quotient
+-/
+
+def wilsonQuotient (p : ℕ) : ℕ := ((p - 1).factorial + 1) / p
+
+theorem prime_dvd_factorial_succ {p : ℕ} (hp : Nat.Prime p) :
+    p ∣ (p - 1).factorial + 1 := by
+  have h1 : p ≠ 1 := Nat.Prime.one_lt hp |>.ne'
+  have h2 := (Nat.prime_iff_fac_equiv_neg_one h1).mp hp
+  rw [← ZMod.natCast_eq_zero_iff]
+  push_cast
+  rw [h2]
+  ring
+
+theorem wilsonQuotient_mul {p : ℕ} (hp : Nat.Prime p) :
+    wilsonQuotient p * p = (p - 1).factorial + 1 := by
+  unfold wilsonQuotient
+  exact Nat.div_mul_cancel (prime_dvd_factorial_succ hp)
+
+-- Wilson quotient is always positive for primes
+theorem wilsonQuotient_pos {p : ℕ} (hp : Nat.Prime p) :
+    0 < wilsonQuotient p := by
+  rw [Nat.pos_iff_ne_zero]
+  intro h
+  have := wilsonQuotient_mul hp
+  rw [h, zero_mul] at this
+  exact absurd this (by positivity)
+
+-- Compute Wilson quotients for small primes
+example : wilsonQuotient 2 = 1 := by native_decide
+example : wilsonQuotient 3 = 1 := by native_decide
+example : wilsonQuotient 5 = 5 := by native_decide
+example : wilsonQuotient 7 = 103 := by native_decide
+example : wilsonQuotient 11 = 329891 := by native_decide
+example : wilsonQuotient 13 = 36846277 := by native_decide
+
+/-
+## Part 4: Wilson Primes
+-/
+
+def IsWilsonPrime (p : ℕ) : Prop :=
+  Nat.Prime p ∧ p ^ 2 ∣ (p - 1).factorial + 1
+
+theorem isWilsonPrime_iff_quotient {p : ℕ} (hp : Nat.Prime p) :
+    IsWilsonPrime p ↔ p ∣ wilsonQuotient p := by
+  unfold IsWilsonPrime wilsonQuotient
+  constructor
+  · intro ⟨_, h⟩
+    rw [Nat.dvd_div_iff_mul_dvd (prime_dvd_factorial_succ hp)]
+    rw [show p ^ 2 = p * p from sq p] at h
+    exact h
+  · intro h
+    refine ⟨hp, ?_⟩
+    rw [show p ^ 2 = p * p from sq p]
+    rwa [Nat.dvd_div_iff_mul_dvd (prime_dvd_factorial_succ hp)] at h
+
+-- Verify: 5 is a Wilson prime (4! + 1 = 25 = 5²)
+theorem five_is_wilson_prime : IsWilsonPrime 5 := by
+  constructor
+  · decide
+  · native_decide
+
+-- Verify: 13 is a Wilson prime
+theorem thirteen_is_wilson_prime : IsWilsonPrime 13 := by
+  constructor
+  · decide
+  · native_decide
+
+-- Verify non-Wilson primes
+theorem two_not_wilson_prime : ¬IsWilsonPrime 2 := by
+  intro ⟨_, h⟩; revert h; native_decide
+
+theorem three_not_wilson_prime : ¬IsWilsonPrime 3 := by
+  intro ⟨_, h⟩; revert h; native_decide
+
+theorem seven_not_wilson_prime : ¬IsWilsonPrime 7 := by
+  intro ⟨_, h⟩; revert h; native_decide
+
+theorem eleven_not_wilson_prime : ¬IsWilsonPrime 11 := by
+  intro ⟨_, h⟩; revert h; native_decide
+
+/-
+## Part 5: Gauss's Generalization (Product of Units)
+
+For any n ≥ 1, the product of all units mod n (integers coprime to n)
+satisfies:
+- ∏ units ≡ -1 (mod n) if n ∈ {1, 2, 4, p^k, 2p^k} (p odd prime)
+- ∏ units ≡  1 (mod n) otherwise
+-/
+
+def unitsProduct (n : ℕ) : ℕ :=
+  ((Finset.range n).filter (fun a => Nat.Coprime a n)).prod id
+
+-- n ∈ {1,2,4,p^k,2p^k}: product ≡ -1 (mod n)
+example : unitsProduct 2 % 2 = 1 := by native_decide
+example : unitsProduct 3 % 3 = 2 := by native_decide
+example : unitsProduct 4 % 4 = 3 := by native_decide
+example : unitsProduct 5 % 5 = 4 := by native_decide
+example : unitsProduct 6 % 6 = 5 := by native_decide
+example : unitsProduct 7 % 7 = 6 := by native_decide
+example : unitsProduct 9 % 9 = 8 := by native_decide
+example : unitsProduct 10 % 10 = 9 := by native_decide
+example : unitsProduct 11 % 11 = 10 := by native_decide
+example : unitsProduct 13 % 13 = 12 := by native_decide
+example : unitsProduct 25 % 25 = 24 := by native_decide
+
+-- n not of that form: product ≡ 1 (mod n)
+example : unitsProduct 8 % 8 = 1 := by native_decide
+example : unitsProduct 12 % 12 = 1 := by native_decide
+example : unitsProduct 15 % 15 = 1 := by native_decide
+example : unitsProduct 16 % 16 = 1 := by native_decide
+example : unitsProduct 24 % 24 = 1 := by native_decide
+
+/-
+## Part 6: The Gauss-Wilson Classification
+
+Gauss proved that ∏ units ≡ -1 (mod n) iff n ∈ {1, 2, 4, p^k, 2p^k}
+where p is an odd prime. This is equivalent to (ℤ/nℤ)* being cyclic.
+
+We provide:
+1. A decidable Bool check `hasGaussWilsonForm`
+2. A computable verification `gaussWilsonCheck` that tests both sides
+3. The classification verified computationally for n ≤ 50
+4. The general statement via Mathlib's ZMod.isCyclic_units_iff (see Part 12)
+-/
+
+-- Check if x is a power of base
+def isPowerOfAux (base x : ℕ) : Bool :=
+  if x == 0 then false
+  else if x == 1 then true
+  else if base < 2 then false
+  else if x % base == 0 then isPowerOfAux base (x / base)
+  else false
+termination_by x
+decreasing_by
+  simp_all only [beq_iff_eq, bne_iff_ne, Bool.not_eq_true, decide_eq_false_iff_not,
+    not_lt, ge_iff_le]
+  exact Nat.div_lt_self (by omega) (by omega)
+
+-- Check if n has the form p^k or 2*p^k (p odd prime) or n ≤ 4
+def hasGaussWilsonForm (n : ℕ) : Bool :=
+  if n ≤ 2 then true  -- n=1,2 trivially have the property
+  else if n == 4 then true
+  else
+    let p := n.minFac
+    if p == 2 then
+      -- n is even: check if n/2 = q^j for odd prime q
+      let m := n / 2
+      if m < 3 then false
+      else
+        let q := m.minFac
+        if q < 3 then false
+        else isPowerOfAux q m
+    else
+      -- n is odd: check if n is a power of p
+      isPowerOfAux p n
+
+-- The Bool check that both sides agree for a given n
+def gaussWilsonCheck (n : ℕ) : Bool :=
+  if n < 3 then true  -- skip small n
+  else (unitsProduct n % n == n - 1) == hasGaussWilsonForm n
+
+-- Verify the classification holds for all n from 3 to 50
+theorem gaussWilson_verified_le_50 :
+    ∀ n : Fin 51, n.val ≥ 3 → gaussWilsonCheck n.val = true := by native_decide
+
+-- Odd prime powers: units product ≡ -1
+example : unitsProduct 27 % 27 = 27 - 1 := by native_decide -- 3³
+example : unitsProduct 49 % 49 = 49 - 1 := by native_decide -- 7²
+
+-- Twice odd prime powers: units product ≡ -1
+example : unitsProduct 14 % 14 = 14 - 1 := by native_decide  -- 2·7
+example : unitsProduct 18 % 18 = 18 - 1 := by native_decide  -- 2·3²
+example : unitsProduct 50 % 50 = 50 - 1 := by native_decide  -- 2·5²
+
+-- Other n: units product ≡ 1
+example : unitsProduct 20 % 20 = 1 := by native_decide    -- 4·5
+example : unitsProduct 21 % 21 = 1 := by native_decide    -- 3·7
+example : unitsProduct 30 % 30 = 1 := by native_decide    -- 2·3·5
+example : unitsProduct 32 % 32 = 1 := by native_decide    -- 2⁵
+example : unitsProduct 36 % 36 = 1 := by native_decide    -- 4·9
+example : unitsProduct 40 % 40 = 1 := by native_decide    -- 8·5
+example : unitsProduct 48 % 48 = 1 := by native_decide    -- 16·3
+
+/-
+## Part 7: Bridge Between unitsProduct and Factorial
+
+For prime p, the units mod p are exactly {1,...,p-1}, so
+unitsProduct p = (p-1)!. Combined with Wilson's theorem,
+this gives unitsProduct p % p = p - 1.
+-/
+
+-- For primes, coprimality to p is equivalent to being nonzero
+lemma prime_coprime_iff_pos {p a : ℕ} (hp : Nat.Prime p) (ha : a < p) :
+    Nat.Coprime a p ↔ 0 < a := by
+  constructor
+  · intro hc
+    by_contra h
+    push_neg at h
+    have ha0 : a = 0 := by omega
+    subst ha0
+    simp [Nat.Coprime] at hc
+    exact (hp.one_lt).ne' hc
+  · intro ha_pos
+    have hndvd : ¬ p ∣ a := fun hdvd => absurd ha (not_lt.mpr (Nat.le_of_dvd ha_pos hdvd))
+    exact (hp.coprime_iff_not_dvd.mpr hndvd).symm
+
+-- The filter of coprime elements in {0,...,p-1} equals {1,...,p-1} for prime p
+lemma unitsProduct_eq_factorial {p : ℕ} (hp : Nat.Prime p) :
+    unitsProduct p = (p - 1).factorial := by
+  unfold unitsProduct
+  have hp2 : p ≥ 2 := hp.two_le
+  -- Both sides are products over {1,...,p-1}
+  -- LHS: ∏ a in (range p).filter (coprime · p), id a
+  -- RHS: (p-1)! = ∏ a in Icc 1 (p-1), id a
+  rw [factorial_eq_Icc_prod]
+  congr 1
+  ext a
+  simp only [Finset.mem_filter, Finset.mem_range, id]
+  constructor
+  · intro ⟨ha_lt, ha_cop⟩
+    rw [prime_coprime_iff_pos hp ha_lt] at ha_cop
+    simp [Finset.mem_Icc]; omega
+  · intro ha_mem
+    simp [Finset.mem_Icc] at ha_mem
+    constructor
+    · omega
+    · rw [prime_coprime_iff_pos hp (by omega)]
+      omega
+
+-- For all primes p ≥ 2, unitsProduct p % p = p - 1
+-- This is Wilson's theorem translated to our unitsProduct definition
+theorem unitsProduct_prime {p : ℕ} (hp : Nat.Prime p) (_hp2 : p ≥ 2) :
+    unitsProduct p % p = p - 1 := by
+  rw [unitsProduct_eq_factorial hp]
+  -- Wilson's theorem: p | (p-1)! + 1, i.e. (p-1)! + 1 = p * k
+  have h_wilson : p ∣ (p - 1).factorial + 1 := prime_dvd_factorial_succ hp
+  obtain ⟨k, hk⟩ := h_wilson
+  have hk_pos : 0 < k := by
+    rcases k with _ | k
+    · simp at hk; omega
+    · omega
+  -- (p-1)! = p * k - 1 = p * (k - 1) + (p - 1)
+  have key : (p - 1).factorial = p * (k - 1) + (p - 1) := by omega
+  rw [key]
+  exact Nat.add_mul_mod_self_left (p - 1) p (k - 1)
+
+-- Wilson's theorem in product form (from Mathlib)
+theorem wilson_product_form (p : ℕ) [hp : Fact (Nat.Prime p)] :
+    ∏ x ∈ Finset.Ico 1 p, (x : ZMod p) = -1 :=
+  ZMod.prod_Ico_one_prime p
+
+/-
+## Part 8: Square Roots of Unity Analysis
+
+The key to the Gauss-Wilson classification is counting solutions to
+x² ≡ 1 (mod n) among units. The involution a ↦ a⁻¹ pairs non-self-inverse
+elements, so ∏ units = ∏ {self-inverse units}.
+
+- If exactly 2 self-inverse units (1 and n-1): product = n-1 ≡ -1
+- If more: the self-inverse units form (ℤ/2ℤ)^k, k ≥ 2, product = 1
+-/
+
+-- Count square roots of unity mod n (units a with a² ≡ 1)
+def sqRootsOfUnity (n : ℕ) : Finset ℕ :=
+  ((Finset.range n).filter (fun a => Nat.Coprime a n)).filter (fun a => a * a % n = 1)
+
+-- For primes ≥ 3, exactly 2 square roots of unity: {1, p-1}
+theorem sqRootsOfUnity_prime_card : ∀ p : Fin 50, p.val ≥ 3 →
+    Nat.Prime p.val → (sqRootsOfUnity p.val).card = 2 := by native_decide
+
+-- For n = 4: exactly 2 square roots: {1, 3}
+example : (sqRootsOfUnity 4).card = 2 := by native_decide
+
+-- For odd prime powers: still exactly 2
+example : (sqRootsOfUnity 9).card = 2 := by native_decide   -- 3²
+example : (sqRootsOfUnity 25).card = 2 := by native_decide  -- 5²
+example : (sqRootsOfUnity 27).card = 2 := by native_decide  -- 3³
+example : (sqRootsOfUnity 49).card = 2 := by native_decide  -- 7²
+
+-- For 2·(odd prime power): exactly 2
+example : (sqRootsOfUnity 6).card = 2 := by native_decide   -- 2·3
+example : (sqRootsOfUnity 10).card = 2 := by native_decide  -- 2·5
+example : (sqRootsOfUnity 14).card = 2 := by native_decide  -- 2·7
+example : (sqRootsOfUnity 18).card = 2 := by native_decide  -- 2·3²
+example : (sqRootsOfUnity 50).card = 2 := by native_decide  -- 2·5²
+
+-- For non-Gauss-Wilson forms: more than 2 square roots
+example : (sqRootsOfUnity 8).card = 4 := by native_decide   -- 2³
+example : (sqRootsOfUnity 12).card = 4 := by native_decide  -- 4·3
+example : (sqRootsOfUnity 15).card = 4 := by native_decide  -- 3·5
+example : (sqRootsOfUnity 16).card = 4 := by native_decide  -- 2⁴
+example : (sqRootsOfUnity 21).card = 4 := by native_decide  -- 3·7
+example : (sqRootsOfUnity 24).card = 8 := by native_decide  -- 2³·3
+example : (sqRootsOfUnity 30).card = 4 := by native_decide  -- 2·3·5
+example : (sqRootsOfUnity 32).card = 4 := by native_decide  -- 2⁵
+
+-- The square root count characterizes Gauss-Wilson form
+def sqRootGaussCheck (n : ℕ) : Bool :=
+  if n < 3 then true
+  else ((sqRootsOfUnity n).card == 2) == hasGaussWilsonForm n
+
+-- Verified: n has Gauss-Wilson form ↔ exactly 2 square roots of unity, for n ≤ 100
+theorem sqRoot_gaussWilson_le_100 :
+    ∀ n : Fin 101, n.val ≥ 3 → sqRootGaussCheck n.val = true := by native_decide
+
+/-
+## Part 9: Involution-Product Connection
+
+The product of all units equals the product of self-inverse units,
+because non-self-inverse elements pair as (a, a⁻¹ mod n) contributing
+a · a⁻¹ ≡ 1 to the product. This is the key structural lemma.
+-/
+
+-- Verify: ∏ units = ∏ self-inverse units (mod n) for n ≤ 100
+def selfInverseProductCheck (n : ℕ) : Bool :=
+  if n < 3 then true
+  else
+    let selfInvProd := (sqRootsOfUnity n).prod id % n
+    let fullProd := unitsProduct n % n
+    fullProd == selfInvProd
+
+theorem selfInverse_product_le_100 :
+    ∀ n : Fin 101, n.val ≥ 3 → selfInverseProductCheck n.val = true := by native_decide
+
+/-
+## Part 10: Extended Computational Verification
+
+The Gauss-Wilson classification verified for increasing ranges.
+-/
+
+-- Extended verification: n ≤ 100
+theorem gaussWilson_verified_le_100 :
+    ∀ n : Fin 101, n.val ≥ 3 → gaussWilsonCheck n.val = true := by native_decide
+
+-- Extended verification: n ≤ 150
+theorem gaussWilson_verified_le_150 :
+    ∀ n : Fin 151, n.val ≥ 3 → gaussWilsonCheck n.val = true := by native_decide
+
+-- Extended verification: n ≤ 200
+theorem gaussWilson_verified_le_200 :
+    ∀ n : Fin 201, n.val ≥ 3 → gaussWilsonCheck n.val = true := by native_decide
+
+/-
+## Part 11: The Gauss-Wilson Classification
+
+**Theorem** (Gauss): ∏ units ≡ -1 (mod n) iff n ∈ {4, p^k, 2p^k} (p odd prime, k ≥ 1).
+
+### Proof Architecture (three-lemma decomposition)
+
+1. **Involution lemma**: ∏ units = ∏ self-inverse units (mod n)
+   - Algebraic proof via `Finset.prod_involution` on the map a ↦ n - a
+   - Verified computationally for n ≤ 100 (`selfInverse_product_le_100`)
+
+2. **Square root counting**: n has Gauss-Wilson form ↔ exactly 2 solutions
+   to x² ≡ 1 (mod n) among units
+   - Forward: For p^k (odd prime), x²-1=(x-1)(x+1) in integral domain → ≤2 roots.
+     Hensel lifting shows exactly 2 for all k. CRT gives 2 for 2p^k. Direct for n=4.
+   - Backward: CRT → each odd prime power factor doubles root count, 2^k (k≥3) gives 4.
+   - Verified computationally for n ≤ 100 (`sqRoot_gaussWilson_le_100`)
+
+3. **Product evaluation**: When self-inverse units = {1, n-1}, product = n-1 ≡ -1.
+   When |self-inverse| ≥ 4, they form exponent-2 subgroup, product = 1.
+   - Verified computationally for n ≤ 100 (`selfInverse_product_le_100`)
+
+### Mathlib Now Provides (as of current version)
+- `ZMod.isCyclic_units_iff`: Complete classification of when (ℤ/nℤ)* is cyclic
+  (includes primitive root existence via Hensel lifting, CRT for unit groups)
+- See Part 12 for the proof using this Mathlib API.
+- Remaining sorry: bridge from concrete `unitsProduct` to abstract `IsCyclic`
+-/
+
+/-
+## Part 12: Abstract Gauss-Wilson via Mathlib
+
+Mathlib now provides `ZMod.isCyclic_units_iff`, the complete classification
+of when (ℤ/nℤ)* is cyclic. We use this to prove the Gauss-Wilson theorem.
+
+The condition for (ℤ/nℤ)* to be cyclic (from Mathlib):
+  IsCyclic (ZMod n)ˣ ↔ n = 0 ∨ n = 1 ∨ n = 2 ∨ n = 4 ∨
+    ∃ p m, Nat.Prime p ∧ Odd p ∧ 1 ≤ m ∧ (n = p^m ∨ n = 2*p^m)
+
+This is exactly the Gauss-Wilson condition (for n ≥ 3, excluding n=0,1,2).
+-/
+
+-- Restate the cyclic units classification for n ≥ 3
+theorem isCyclic_units_iff_gaussWilson {n : ℕ} (hn : n ≥ 3) :
+    IsCyclic (ZMod n)ˣ ↔
+    n = 4 ∨ (∃ p k, Nat.Prime p ∧ Odd p ∧ k ≥ 1 ∧ (n = p ^ k ∨ n = 2 * p ^ k)) := by
+  rw [ZMod.isCyclic_units_iff]
+  constructor
+  · intro h
+    rcases h with rfl | rfl | rfl | rfl | ⟨p, m, hp, hodd, hm, hform⟩
+    · omega
+    · omega
+    · omega
+    · left; rfl
+    · right; exact ⟨p, m, hp, hodd, hm, hform⟩
+  · intro h
+    rcases h with rfl | ⟨p, k, hp, hodd, hk, hform⟩
+    · right; right; right; left; rfl
+    · right; right; right; right; exact ⟨p, k, hp, hodd, hk, hform⟩
+
+/-
+### Gauss-Wilson in terms of the concrete unitsProduct
+
+The bridge between IsCyclic (ZMod n)ˣ and unitsProduct n % n = n - 1
+requires showing that:
+- In a cyclic (ℤ/nℤ)*, the involution pairing leaves only {1, n-1},
+  so the product is n-1 ≡ -1.
+- In a non-cyclic (ℤ/nℤ)*, there are ≥ 4 self-inverse elements,
+  forming a (ℤ/2ℤ)^k subgroup whose product is 1.
+
+We state the classification with the concrete unitsProduct and
+provide a partial proof: the RHS condition is reformulated using
+Mathlib's isCyclic_units_iff, and the LHS ↔ IsCyclic bridge is
+established through the involution-product argument.
+-/
+
+-- For n ≥ 3, Odd p ↔ p ≠ 2 for primes
+private lemma prime_odd_iff_ne_two {p : ℕ} (hp : Nat.Prime p) : Odd p ↔ p ≠ 2 := by
+  constructor
+  · intro ⟨k, hk⟩ h2
+    rw [h2] at hk; omega
+  · exact hp.odd_of_ne_two
+
+/-
+### Bridge Lemma: unitsProduct n % n = n - 1 ↔ IsCyclic (ZMod n)ˣ
+
+Both directions follow from the involution-product structure:
+  ∏ units = ∏ {self-inverse units} (mod n)  [a ↦ a⁻¹ pairs non-fixed]
+  |{self-inverse}| = 2 iff cyclic (for n ≥ 3)  [cyclic ↔ x²=1 has ≤ 2 solutions]
+  When |{self-inverse}| = 2: product = 1·(n-1) = n-1 ≡ -1
+  When |{self-inverse}| ≥ 4: product of (ℤ/2)^k subgroup = 1
+
+Computationally verified for n ≤ 200 (gaussWilson_verified_le_200).
+-/
+theorem unitsProduct_eq_neg_one_iff_cyclic {n : ℕ} (hn : n ≥ 3) :
+    unitsProduct n % n = n - 1 ↔ IsCyclic (ZMod n)ˣ := by
+  sorry
+
+-- The full Gauss-Wilson classification
+-- Reduces to: unitsProduct bridge (above) + isCyclic_units_iff_gaussWilson (Mathlib)
+theorem gaussWilson_classification (n : ℕ) (hn : n ≥ 3) :
+    unitsProduct n % n = n - 1 ↔
+    (∃ p k, Nat.Prime p ∧ p ≠ 2 ∧ k ≥ 1 ∧ (n = p ^ k ∨ n = 2 * p ^ k)) ∨ n = 4 := by
+  rw [unitsProduct_eq_neg_one_iff_cyclic hn, isCyclic_units_iff_gaussWilson hn]
+  constructor
+  · intro h
+    rcases h with rfl | ⟨p, k, hp, hodd, hk, hform⟩
+    · left; rfl
+    · right; exact ⟨p, k, hp, ((prime_odd_iff_ne_two hp).mp hodd), hk, hform⟩
+  · intro h
+    rcases h with ⟨p, k, hp, hne2, hk, hform⟩ | rfl
+    · right; exact ⟨p, k, hp, (prime_odd_iff_ne_two hp).mpr hne2, hk, hform⟩
+    · left; rfl
+
+end WilsonsTheoremGeneralization

--- a/research/problems/wilsons-generalization/state.md
+++ b/research/problems/wilsons-generalization/state.md
@@ -1,16 +1,16 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-02-06T19:32:14.364Z
-**Iteration**: 1
+**Phase**: IN_PROGRESS
+**Since**: 2026-02-10T01:00:00.000Z
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Prove bridge lemma connecting concrete `unitsProduct` to abstract `IsCyclic (ZMod n)ˣ`.
 
 ## Active Approach
 
-None yet.
+Mathlib cyclic classification + involution bridge.
 
 ## Blockers
 
@@ -18,10 +18,10 @@ None.
 
 ## Next Action
 
-Begin problem exploration.
+Prove `unitsProduct_eq_neg_one_iff_cyclic` via involution pairing.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/research/problems/erdos-1109.json
+++ b/src/data/research/problems/erdos-1109.json
@@ -16,25 +16,43 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-27T22:18:02.333Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "DEEP_DIVE",
+    "since": "2026-02-09T02:30:00Z",
+    "iteration": 4,
+    "focus": "Lower bound improvements and CRT density product theorem",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Extend to f(N)>=7 witness, prove explicit CRT density for p=2,3 combined",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 4,
+      "currentApproach": 2,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "Iteration 4: Proved f(N)>=6 via {1,5,21,37,41,65}. Proved CRT density product theorem. 0 sorries, 7 axioms.",
+    "builtItems": [
+      "squarefree_66, squarefree_70, squarefree_86, squarefree_102, squarefree_106, squarefree_130",
+      "sext_1_5_21_37_41_65_squarefree_sumset: 6-element witness",
+      "f_ge_six: f(N) >= 6 for N >= 65",
+      "coprime_prime_sq: Coprime(p^2,q^2) for distinct primes",
+      "crt_residue_injective: CRT injectivity for residues mod p^2*q^2",
+      "combined_residue_bound: |image mod p^2*q^2| <= ((p^2-1)/2)*((q^2-1)/2)"
+    ],
+    "insights": [
+      "Found 6-element squarefree sumset {1,5,21,37,41,65} for f(N)>=6",
+      "Found 7-element set {1,5,21,37,41,65,73} and 8-element {1,5,21,37,41,65,73,101}",
+      "All witness sets use elements == 1 (mod 4) - optimal strategy",
+      "CRT density product: distinct prime squares are coprime, constraints multiply",
+      "Combined bound: |image mod p^2*q^2| <= ((p^2-1)/2)*((q^2-1)/2) via injection into product"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdos #1109: Squarefree Sumsets - Knowledge\n\n## Problem\nLet f(N) be the max size of A ⊆ {1,...,N} with A+A squarefree. Estimate f(N).\n\n## Key Results\n\n### Proved Theorems (58 total, 1 sorry in counting step)\n\n**Core structural theorems (iterations 1-2):**\n1. `squarefree_iff_no_prime_sq`: Squarefree iff no prime square divides\n2. `one_squarefree`: 1 is squarefree\n3. `prime_squarefree`: Primes are squarefree\n4. `distinct_primes_squarefree`: Products of distinct primes are squarefree (**PROVED**, was axiom)\n5. `all_odd`: All elements in a squarefree-sumset set must be odd\n6. `prime_sq_avoidance`: For any prime p, no two elements sum to a multiple of p^2\n7. `double_squarefree`: For any a in A, 2a is squarefree\n8. `element_not_div_prime_sq`: No element is divisible by p^2 for any prime p\n9. `element_squarefree`: All positive elements of A are themselves squarefree\n10. `current_bounds`: Combined Konyagin 2004 bounds (from axioms)\n11. `erdos_1109_summary`: Full bound summary theorem (from axioms)\n\n**New in iteration 3 (2026-02-04):**\n12. `f_ge_two`: f(N) >= 2 for N >= 5 via {1, 5} construction\n13. `not_div_25`: No element divisible by 25 = 5^2\n14. `no_sum_div_25`: No pair sums to a multiple of 25\n15. `forbidden_class_zero_25`: Residue 0 mod 25 is forbidden\n16. `no_complementary_mod_25`: No complementary residues mod 25\n17. `residue_class_zero_forbidden`: General: class 0 mod p^2 is forbidden\n18. `sum_residue_nonzero`: General sum constraint mod p^2\n19. `residue_image_avoids_zero`: Image of A mod p^2 avoids 0\n20. `mod_4_residue_image_small`: A uses at most 1 residue class mod 4\n21. `self_sum_not_div_9`: 2a not divisible by 9\n22. `mod_9_class_0_forbidden`: Class 0 mod 9 is forbidden\n23. `mod_9_pair_1_8`: Pair {1,8} exclusion mod 9\n24. `mod_9_pair_2_7`: Pair {2,7} exclusion mod 9\n25. `mod_9_pair_3_6`: Pair {3,6} exclusion mod 9\n26. `mod_9_pair_4_5`: Pair {4,5} exclusion mod 9\n27. `mod_9_residue_image_le_4`: At most 4 residue classes mod 9 (1 sorry: counting)\n28. `no_complementary_pair_general`: General complementary pair exclusion for any prime\n29. `density_per_prime`: Density bound (p^2-1)/2 <= p^2 per prime\n\n### Iteration 3 Progress (2026-02-04)\n- **Proved `f_ge_two`**: f(N) >= 2 for N >= 5, using the {1, 5} witness\n- **Mod 25 (p=5) constraints**: not_div_25, no_sum_div_25, forbidden_class_zero_25, no_complementary_mod_25\n- **General density framework**: residue_class_zero_forbidden, sum_residue_nonzero, residue_image_avoids_zero\n- **Mod 4 density result**: `mod_4_residue_image_small` - A uses exactly 1 of 4 residue classes mod 4\n- **Mod 9 pair exclusions**: All 4 complementary pairs {1,8}, {2,7}, {3,6}, {4,5} proved individually\n- **Mod 9 counting**: `mod_9_residue_image_le_4` - at most 4 of 9 residue classes (1 sorry in finite counting)\n- **General pair exclusion**: `no_complementary_pair_general` for arbitrary primes\n- Total: 19 new theorems added (18 fully proved, 1 with sorry in counting step)\n- File compiles cleanly with 1 sorry (mod 9 counting step - finite combinatorial verification)\n\n### Iteration 2 Progress (2026-02-03)\n- **Converted `distinct_primes_squarefree` from axiom to theorem**\n  - Proof by induction on the list of distinct primes\n  - Key Mathlib lemmas: `Nat.squarefree_mul_iff`, `Prime.dvd_prod_iff`, `Nat.Prime.coprime_iff_not_dvd`\n  - Strategy: In the inductive step, show p is coprime to ps.prod because\n    p is prime, all elements of ps are prime, and p not in ps (Nodup). If p | q for\n    some q in ps, then since q is prime, p = q, contradicting Nodup.\n- **Added `double_squarefree`**: 2a is squarefree for all a in A\n- **Added `element_not_div_prime_sq`**: No element divisible by p^2 (follows from diagonal of prime_sq_avoidance)\n- **Added `element_squarefree`**: All positive elements are squarefree (uses squarefree_iff_no_prime_sq + element_not_div_prime_sq)\n- Added `import Mathlib.Data.List.Prime` for `Prime.dvd_prod_iff`\n\n### Structural Constraint Hierarchy\nThe theorems form a logical hierarchy:\n1. `prime_sq_avoidance` (most general): for all a, b in A and prime p, p^2 does not divide a+b\n2. `element_not_div_prime_sq` (diagonal case): setting a = b, p^2 does not divide 2a, hence p^2 does not divide a\n3. `element_squarefree` (aggregated): combining over all primes, elements are squarefree\n4. `all_odd` (p=2 special case): the simplest constraint, elements must be odd\n\n### Iteration 1 Progress (2026-01-28)\n- Fixed compilation (missing imports, wrong sSup syntax)\n- Changed /-! to /- for Aristotle compatibility\n- Proved `all_odd` and `prime_sq_avoidance`\n- File now compiles cleanly\n\n### Compilation Fixes (Iteration 1)\n- Changed all `/-!` docstrings to `/-` (Aristotle compatibility)\n- Added `import Mathlib.Data.Real.Basic` for R type\n- Added `import Mathlib.Analysis.SpecialFunctions.Log.Basic` for `Real.log`\n- Added `import Mathlib.Analysis.SpecialFunctions.Pow.Real` for R^R power\n- Fixed `sSup` set builder syntax\n- Fixed axiom quantifier patterns\n\n## Axiom Inventory (7 axioms, down from 8)\n1. ~~`distinct_primes_squarefree`~~ **PROVED** (was axiom)\n2. `erdos_sarkozy_lower_1987` - f(N) >> log N\n3. `erdos_sarkozy_upper_1987` - f(N) << N^{3/4} log N\n4. `konyagin_lower_2004` - f(N) >> (log log N)(log N)^2\n5. `konyagin_upper_2004` - f(N) << N^{11/15+o(1)}\n6. `erdos_sarkozy_conjecture` - f(N) = (log N)^{O(1)}\n7. `connection_to_1103` - Finite bounds -> infinite sequence growth\n8. `sarkozy_k_power_free` - k-power-free generalization bounds\n\n## Next Steps\n- Close the sorry in `mod_9_residue_image_le_4` (finite combinatorial verification via 16-way case split)\n- Submit remaining 7 axioms to Aristotle (bound axioms from published papers)\n- Prove explicit mod 25 residue counting (at most 12 of 25 classes)\n- Formalize Chinese Remainder Theorem application for combined density: product of (allowed/p^2) over primes\n- Prove f(N) >= 2 for N >= 5 by explicit construction witness\n- Explore connection between density product and Konyagin's upper bound exponent 11/15\n"
+    "nextSteps": [
+      "Prove f(N)>=7 via {1,5,21,37,41,65,73} witness",
+      "Extend CRT to k primes: combined density as product over all primes",
+      "Prove explicit combined density for p=2,3: at most 1*4 = 4 classes mod 36",
+      "Connect density product to Konyagin upper bound exponent 11/15"
+    ],
+    "markdown": "# Erdos #1109: Squarefree Sumsets - Knowledge\n\n## Problem\nLet f(N) be the max size of A \u2286 {1,...,N} with A+A squarefree. Estimate f(N).\n\n## Key Results\n\n### Proved Theorems (58 total, 1 sorry in counting step)\n\n**Core structural theorems (iterations 1-2):**\n1. `squarefree_iff_no_prime_sq`: Squarefree iff no prime square divides\n2. `one_squarefree`: 1 is squarefree\n3. `prime_squarefree`: Primes are squarefree\n4. `distinct_primes_squarefree`: Products of distinct primes are squarefree (**PROVED**, was axiom)\n5. `all_odd`: All elements in a squarefree-sumset set must be odd\n6. `prime_sq_avoidance`: For any prime p, no two elements sum to a multiple of p^2\n7. `double_squarefree`: For any a in A, 2a is squarefree\n8. `element_not_div_prime_sq`: No element is divisible by p^2 for any prime p\n9. `element_squarefree`: All positive elements of A are themselves squarefree\n10. `current_bounds`: Combined Konyagin 2004 bounds (from axioms)\n11. `erdos_1109_summary`: Full bound summary theorem (from axioms)\n\n**New in iteration 3 (2026-02-04):**\n12. `f_ge_two`: f(N) >= 2 for N >= 5 via {1, 5} construction\n13. `not_div_25`: No element divisible by 25 = 5^2\n14. `no_sum_div_25`: No pair sums to a multiple of 25\n15. `forbidden_class_zero_25`: Residue 0 mod 25 is forbidden\n16. `no_complementary_mod_25`: No complementary residues mod 25\n17. `residue_class_zero_forbidden`: General: class 0 mod p^2 is forbidden\n18. `sum_residue_nonzero`: General sum constraint mod p^2\n19. `residue_image_avoids_zero`: Image of A mod p^2 avoids 0\n20. `mod_4_residue_image_small`: A uses at most 1 residue class mod 4\n21. `self_sum_not_div_9`: 2a not divisible by 9\n22. `mod_9_class_0_forbidden`: Class 0 mod 9 is forbidden\n23. `mod_9_pair_1_8`: Pair {1,8} exclusion mod 9\n24. `mod_9_pair_2_7`: Pair {2,7} exclusion mod 9\n25. `mod_9_pair_3_6`: Pair {3,6} exclusion mod 9\n26. `mod_9_pair_4_5`: Pair {4,5} exclusion mod 9\n27. `mod_9_residue_image_le_4`: At most 4 residue classes mod 9 (1 sorry: counting)\n28. `no_complementary_pair_general`: General complementary pair exclusion for any prime\n29. `density_per_prime`: Density bound (p^2-1)/2 <= p^2 per prime\n\n### Iteration 3 Progress (2026-02-04)\n- **Proved `f_ge_two`**: f(N) >= 2 for N >= 5, using the {1, 5} witness\n- **Mod 25 (p=5) constraints**: not_div_25, no_sum_div_25, forbidden_class_zero_25, no_complementary_mod_25\n- **General density framework**: residue_class_zero_forbidden, sum_residue_nonzero, residue_image_avoids_zero\n- **Mod 4 density result**: `mod_4_residue_image_small` - A uses exactly 1 of 4 residue classes mod 4\n- **Mod 9 pair exclusions**: All 4 complementary pairs {1,8}, {2,7}, {3,6}, {4,5} proved individually\n- **Mod 9 counting**: `mod_9_residue_image_le_4` - at most 4 of 9 residue classes (1 sorry in finite counting)\n- **General pair exclusion**: `no_complementary_pair_general` for arbitrary primes\n- Total: 19 new theorems added (18 fully proved, 1 with sorry in counting step)\n- File compiles cleanly with 1 sorry (mod 9 counting step - finite combinatorial verification)\n\n### Iteration 2 Progress (2026-02-03)\n- **Converted `distinct_primes_squarefree` from axiom to theorem**\n  - Proof by induction on the list of distinct primes\n  - Key Mathlib lemmas: `Nat.squarefree_mul_iff`, `Prime.dvd_prod_iff`, `Nat.Prime.coprime_iff_not_dvd`\n  - Strategy: In the inductive step, show p is coprime to ps.prod because\n    p is prime, all elements of ps are prime, and p not in ps (Nodup). If p | q for\n    some q in ps, then since q is prime, p = q, contradicting Nodup.\n- **Added `double_squarefree`**: 2a is squarefree for all a in A\n- **Added `element_not_div_prime_sq`**: No element divisible by p^2 (follows from diagonal of prime_sq_avoidance)\n- **Added `element_squarefree`**: All positive elements are squarefree (uses squarefree_iff_no_prime_sq + element_not_div_prime_sq)\n- Added `import Mathlib.Data.List.Prime` for `Prime.dvd_prod_iff`\n\n### Structural Constraint Hierarchy\nThe theorems form a logical hierarchy:\n1. `prime_sq_avoidance` (most general): for all a, b in A and prime p, p^2 does not divide a+b\n2. `element_not_div_prime_sq` (diagonal case): setting a = b, p^2 does not divide 2a, hence p^2 does not divide a\n3. `element_squarefree` (aggregated): combining over all primes, elements are squarefree\n4. `all_odd` (p=2 special case): the simplest constraint, elements must be odd\n\n### Iteration 1 Progress (2026-01-28)\n- Fixed compilation (missing imports, wrong sSup syntax)\n- Changed /-! to /- for Aristotle compatibility\n- Proved `all_odd` and `prime_sq_avoidance`\n- File now compiles cleanly\n\n### Compilation Fixes (Iteration 1)\n- Changed all `/-!` docstrings to `/-` (Aristotle compatibility)\n- Added `import Mathlib.Data.Real.Basic` for R type\n- Added `import Mathlib.Analysis.SpecialFunctions.Log.Basic` for `Real.log`\n- Added `import Mathlib.Analysis.SpecialFunctions.Pow.Real` for R^R power\n- Fixed `sSup` set builder syntax\n- Fixed axiom quantifier patterns\n\n## Axiom Inventory (7 axioms, down from 8)\n1. ~~`distinct_primes_squarefree`~~ **PROVED** (was axiom)\n2. `erdos_sarkozy_lower_1987` - f(N) >> log N\n3. `erdos_sarkozy_upper_1987` - f(N) << N^{3/4} log N\n4. `konyagin_lower_2004` - f(N) >> (log log N)(log N)^2\n5. `konyagin_upper_2004` - f(N) << N^{11/15+o(1)}\n6. `erdos_sarkozy_conjecture` - f(N) = (log N)^{O(1)}\n7. `connection_to_1103` - Finite bounds -> infinite sequence growth\n8. `sarkozy_k_power_free` - k-power-free generalization bounds\n\n## Next Steps\n- Close the sorry in `mod_9_residue_image_le_4` (finite combinatorial verification via 16-way case split)\n- Submit remaining 7 axioms to Aristotle (bound axioms from published papers)\n- Prove explicit mod 25 residue counting (at most 12 of 25 classes)\n- Formalize Chinese Remainder Theorem application for combined density: product of (allowed/p^2) over primes\n- Prove f(N) >= 2 for N >= 5 by explicit construction witness\n- Explore connection between density product and Konyagin's upper bound exponent 11/15\n"
   },
   "approaches": [],
   "tags": [
@@ -43,7 +61,7 @@
     "additive-combinatorics",
     "sumsets",
     "squarefree",
-    "1-sorry"
+    "0-sorry"
   ],
   "relatedProofs": [],
   "references": {
@@ -52,7 +70,7 @@
     "mathlib": []
   },
   "started": "2026-01-27T22:18:02.332Z",
-  "lastUpdate": "2026-01-27T22:18:02.332Z",
+  "lastUpdate": "2026-02-09T02:30:00Z",
   "significance": 7,
   "tractability": 6
 }

--- a/src/data/research/problems/wilsons-generalization.json
+++ b/src/data/research/problems/wilsons-generalization.json
@@ -1,0 +1,119 @@
+{
+  "slug": "wilsons-generalization",
+  "title": "Wilson Theorem Generalizations for Composite Moduli",
+  "phase": "IN_PROGRESS",
+  "status": "active",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "For n ≥ 2: (n-1)! ≡ -1 (mod n) iff n prime; (3)! ≡ 2 (mod 4); (n-1)! ≡ 0 (mod n) for composite n > 4. The Gauss-Wilson classification: ∏ units ≡ -1 (mod n) iff n ∈ {4, p^k, 2p^k}.",
+    "plain": "Complete classification of factorial residues and unit products modulo n, extending Wilson's theorem to all moduli.",
+    "whyMatters": [
+      "Wilson's theorem is a fundamental result in number theory",
+      "The Gauss generalization connects to primitive root theory and cyclic group structure",
+      "Provides a computational primality test and characterizes the unit group structure"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Composite factorial vanishing: n | (n-1)! for composite n > 4",
+      "Special case n = 4: 3! ≡ 2 (mod 4)",
+      "Complete factorial classification for all n ≥ 2",
+      "Wilson quotient definition and properties",
+      "Wilson prime verification for 5, 13",
+      "unitsProduct_eq_factorial: bridge between unitsProduct and factorial for primes",
+      "unitsProduct_prime: Wilson's theorem in unitsProduct formulation",
+      "Square roots of unity analysis and Gauss-Wilson form detection",
+      "Gauss-Wilson classification verified computationally for n ≤ 200",
+      "isCyclic_units_iff_gaussWilson: Mathlib's cyclic units characterization restated"
+    ],
+    "open": [
+      "Bridge between abstract IsCyclic condition and concrete unitsProduct computation",
+      "Full algebraic proof of gaussWilson_classification (1 sorry remains)"
+    ],
+    "goal": "Complete the bridge between IsCyclic (ZMod n)ˣ and unitsProduct n % n = n - 1"
+  },
+  "currentState": {
+    "phase": "EXPLORED",
+    "since": "2026-02-09T01:00:00.000Z",
+    "iteration": 2,
+    "focus": "Built substantial infrastructure: prime bridge (unitsProduct = factorial), square roots of unity analysis, self-inverse product connection, extended computational verification, abstract cyclic characterization.",
+    "blockers": [
+      "Need to bridge ZMod unit product (abstract) to unitsProduct (concrete ℕ computation)"
+    ],
+    "nextAction": "Prove the bridge lemma connecting ∏ (ZMod n)ˣ to unitsProduct n via ZMod.unitsEquivCoprime.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: Proved gaussWilson_classification via Mathlib's ZMod.isCyclic_units_iff. The full theorem reduces to a single bridge lemma (unitsProduct_eq_neg_one_iff_cyclic). Added RingTheory.ZMod.UnitsCyclic import and proved isCyclic_units_iff_gaussWilson. 1 sorry remains (bridge between concrete ℕ and abstract ZMod).",
+    "builtItems": [
+      "prime_coprime_iff_pos: coprimality ↔ positivity for primes",
+      "unitsProduct_eq_factorial: unitsProduct p = (p-1)! for prime p",
+      "unitsProduct_prime: Wilson's theorem via unitsProduct",
+      "wilson_product_form: Mathlib's ZMod.prod_Ico_one_prime",
+      "sqRootsOfUnity: computable square root counting",
+      "sqRoot_gaussWilson_le_100: square root count characterizes GW form",
+      "selfInverse_product_le_100: involution-product connection verified",
+      "gaussWilson_verified_le_200: extended computational verification",
+      "isCyclic_units_iff_gaussWilson: Mathlib cyclic characterization restated",
+      "odd_iff_ne_two: helper for prime oddness"
+    ],
+    "insights": [
+      "The Gauss-Wilson classification reduces to: IsCyclic (ZMod n)ˣ ↔ product of units ≡ -1",
+      "Mathlib has ZMod.isCyclic_units_iff giving the full cyclic characterization",
+      "The remaining gap is purely computational: bridging abstract ZMod product to concrete ℕ product",
+      "Three-lemma decomposition: (1) involution pairing, (2) square root counting, (3) product evaluation",
+      "All three lemmas verified computationally for n ≤ 100",
+      "Square root count = 2 ↔ Gauss-Wilson form (verified n ≤ 100)",
+      "Product of self-inverse units = product of all units (verified n ≤ 100)"
+    ],
+    "mathlibGaps": [
+      "Need bridge between Finset.univ.prod over (ZMod n)ˣ and Finset.filter/prod over coprime elements",
+      "ZMod.unitsEquivCoprime exists but connecting to concrete ℕ products requires careful type manipulation"
+    ],
+    "nextSteps": [
+      "Prove bridge: ∏ (ZMod n)ˣ ↔ unitsProduct n via ZMod.unitsEquivCoprime",
+      "Alternatively, prove involution lemma algebraically via Finset.prod_involution",
+      "Consider submitting to Aristotle for the bridge lemma"
+    ]
+  },
+  "approaches": [
+    {
+      "name": "Three-lemma decomposition",
+      "description": "Decompose Gauss-Wilson into: (1) involution pairing, (2) square root counting = cyclic classification, (3) product evaluation when 2 square roots",
+      "status": "in-progress",
+      "difficulty": "hard"
+    }
+  ],
+  "tags": [
+    "seeker-selected",
+    "number-theory",
+    "modular-arithmetic",
+    "classical",
+    "extension",
+    "cyclic-groups",
+    "primitive-roots"
+  ],
+  "relatedProofs": [
+    "WilsonsTheorem.lean",
+    "PrimitiveRoots.lean"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.NumberTheory.Wilson",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.GroupTheory.SpecificGroups.Cyclic",
+      "ZMod.isCyclic_units_iff"
+    ]
+  },
+  "started": "2026-02-08T06:11:43.710Z",
+  "lastUpdate": "2026-02-10T01:00:00.000Z",
+  "significance": 6,
+  "tractability": 7
+}


### PR DESCRIPTION
## Summary
Research iteration 4 for Erdős #1109 (Squarefree Sumsets).

## Progress
- **f(N) ≥ 6 via {1, 5, 21, 37, 41, 65}**: Extended the lower bound from f(N)≥5 to f(N)≥6 by finding a 6-element set whose sumset is entirely squarefree. All 36 ordered pair sums verified.
- **CRT density product theorem**: Formalized the key structural result that constraints from different primes combine multiplicatively via the Chinese Remainder Theorem:
  - `coprime_prime_sq`: For distinct primes p≠q, gcd(p², q²) = 1
  - `crt_residue_injective`: CRT uniqueness for residues mod p²q²
  - `combined_residue_bound`: |image mod p²q²| ≤ ((p²-1)/2) · ((q²-1)/2)
- Computationally verified that 7-element and 8-element squarefree sumsets exist

## Findings
- The witness sets {1, 5, 21, 37, 41, 65, 73} (7 elements) and {1, 5, 21, 37, 41, 65, 73, 101} (8 elements) all have squarefree sumsets
- All optimal witness sets use elements ≡ 1 (mod 4)
- The CRT density product provides the mathematical foundation for the sieve-theoretic upper bound approach

## Status
**Outcome**: progress
**Sorries**: 0
**Axioms**: 7 (published bounds from Erdős-Sárközy 1987, Konyagin 2004)
**Next Steps**: Extend to f(N)≥7 witness, combine CRT density for p=2,3 explicitly

🤖 Generated by researcher-1