### PR TITLE
enrich(erdos-28): deepen Erdős–Turán conjecture annotations and meta

### DIFF
--- a/src/data/proofs/erdos-28/annotations.json
+++ b/src/data/proofs/erdos-28/annotations.json
@@ -1,56 +1,146 @@
 [
   {
+    "id": "imports-setup",
+    "proofId": "erdos-28",
+    "range": { "startLine": 20, "endLine": 29 },
+    "type": "concept",
+    "title": "Imports and Setup",
+    "content": "Imports Mathlib modules for additive combinatorics (SumConv for Minkowski sums), Finset cardinality, filter convergence (atTop, Tendsto), and real-valued functions (log, sqrt). Opens the Filter and Set namespaces and enables pointwise set operations for the A + A notation.",
+    "mathContext": "The pointwise sum $A + A = \\{a + b : a, b \\in A\\}$ is the **Minkowski sum** of $A$ with itself. Filter convergence via `atTop` formalizes limits as $N \\to \\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Minkowski sum", "pointwise set operations", "filter convergence"],
+    "prerequisites": ["Mathlib Finset API", "Lean 4 set notation"]
+  },
+  {
     "id": "rep-function",
     "proofId": "erdos-28",
-    "range": { "startLine": 33, "endLine": 35 },
+    "range": { "startLine": 33, "endLine": 36 },
     "type": "definition",
     "title": "Representation Function",
-    "content": "r(n) counts pairs (a,b) with a ≤ b, a,b ∈ A, a+b = n. This is the ordered representation count, central to additive number theory.",
-    "significance": "high"
+    "content": "Defines $r_A(n)$ as the number of pairs $(a, b)$ with $a \\leq b$, both in $A$, summing to $n$. This ordered-pair convention avoids double-counting and is standard in additive number theory. The function filters the interval $[0, n]$ for elements $a \\in A$ with $n - a \\in A$ and $a \\leq n - a$.",
+    "mathContext": "$r_A(n) = |\\{(a,b) \\in A \\times A : a + b = n, \\, a \\leq b\\}|$. Some references use the unordered count $r'_A(n) = |\\{(a,b) : a + b = n\\}|$ which counts each unordered pair twice (except when $a = b = n/2$). The conjecture is equivalent under either convention.",
+    "significance": "critical",
+    "relatedConcepts": ["additive energy", "sumset", "Schnirelmann density", "B_2 sets"],
+    "prerequisites": ["Finset.filter", "set membership", "natural number subtraction"]
   },
   {
     "id": "asymptotic-basis",
     "proofId": "erdos-28",
-    "range": { "startLine": 39, "endLine": 41 },
+    "range": { "startLine": 38, "endLine": 41 },
     "type": "definition",
     "title": "Asymptotic Basis of Order 2",
-    "content": "A ⊆ ℕ with (A+A)ᶜ finite: every sufficiently large integer is a sum of two elements of A. The prototypical example is the set of squares (Lagrange needed 4; we ask for 2).",
-    "significance": "high"
+    "content": "A set $A \\subseteq \\mathbb{N}$ is an asymptotic basis of order 2 if its sumset $A + A$ misses only finitely many natural numbers. This is formalized as $(A + A)^c$ being finite. Classical examples include the primes (by Goldbach-type results for large numbers) and perfect squares (every sufficiently large integer is a sum of at most 4 squares by Lagrange, but 2 squares require additional conditions).",
+    "mathContext": "$A$ is an **asymptotic basis of order 2** if $|\\mathbb{N} \\setminus (A + A)| < \\infty$. Equivalently, there exists $N_0$ such that for all $n \\geq N_0$, we have $n \\in A + A$. The **Schnirelmann density** of $A + A$ is 1 when $A$ is a basis.",
+    "significance": "critical",
+    "relatedConcepts": ["Schnirelmann density", "Waring's problem", "Goldbach conjecture", "essential component"],
+    "prerequisites": ["Set.Finite", "set complement", "Minkowski sum"]
+  },
+  {
+    "id": "counting-fn",
+    "proofId": "erdos-28",
+    "range": { "startLine": 43, "endLine": 45 },
+    "type": "definition",
+    "title": "Counting Function",
+    "content": "The counting function $A(N) = |A \\cap [1, N]|$ measures the density of $A$ up to $N$. For any basis of order 2, a simple pigeonhole argument shows $A(N) \\geq c\\sqrt{N}$ — the number of pairs from $A \\cap [1,N]$ must cover all integers up to $N$. This is the density threshold relevant to the stronger conjecture.",
+    "mathContext": "$A(N) = |A \\cap \\{1, 2, \\ldots, N\\}|$. If $A + A \\supseteq \\{1, \\ldots, N\\}$, then $\\binom{A(N)}{2} \\geq N$, giving $A(N) \\gg \\sqrt{N}$. The **density version** of the conjecture replaces the basis condition with $A(N) \\gg \\sqrt{N}$.",
+    "significance": "key",
+    "relatedConcepts": ["asymptotic density", "Schnirelmann density", "pigeonhole principle"],
+    "prerequisites": ["Finset.Icc", "Finset.filter", "counting arguments"]
   },
   {
     "id": "main-conjecture",
     "proofId": "erdos-28",
-    "range": { "startLine": 52, "endLine": 54 },
-    "type": "conjecture",
-    "title": "Erdős–Turán Conjecture",
-    "content": "If A is an asymptotic basis of order 2, then r(n) is unbounded. No additive basis can have all representation counts bounded by a single constant. $500 bounty.",
-    "significance": "high"
+    "range": { "startLine": 49, "endLine": 56 },
+    "type": "theorem",
+    "title": "Erdős–Turán Conjecture (1941)",
+    "content": "The central conjecture: if $A$ is an asymptotic basis of order 2, then $\\limsup_{n \\to \\infty} r_A(n) = \\infty$. Formalized as: for every bound $B$, there exists $n$ with $r_A(n) \\geq B$. This is stated as an axiom because the conjecture remains OPEN after 85 years. Erdős offered a $500 bounty — one of his largest prizes, reflecting the problem's depth.",
+    "mathContext": "$\\forall B \\in \\mathbb{N}, \\; \\exists n \\in \\mathbb{N}: \\; r_A(n) \\geq B$. Equivalently, $\\limsup_{n \\to \\infty} r_A(n) = \\infty$. The negation — that some basis has $r_A(n) \\leq C$ for all $n$ — would give a remarkable **thin basis** with perfectly controlled representations.",
+    "significance": "critical",
+    "relatedConcepts": ["thin bases", "B_2[g] sets", "Sidon sets", "additive energy"],
+    "prerequisites": ["repFunction", "IsAsymptoticBasis2", "limsup"]
   },
   {
     "id": "strong-form",
     "proofId": "erdos-28",
     "range": { "startLine": 60, "endLine": 63 },
-    "type": "conjecture",
+    "type": "theorem",
     "title": "Logarithmic Growth Conjecture",
-    "content": "lim sup r(n)/log n > 0: the representation function grows at least logarithmically along a subsequence. Much stronger than the basic conjecture.",
-    "significance": "high"
+    "content": "The stronger form predicts $\\limsup r_A(n) / \\log n > 0$: representation counts grow at least logarithmically along some subsequence. This is motivated by probabilistic heuristics — if $A$ has density $\\sim \\sqrt{N}$, then for a 'random' such set, $r_A(n)$ has expectation $\\sim \\log n$. Proving even the weaker form (unboundedness without rate) remains out of reach.",
+    "mathContext": "$\\exists c > 0, \\; \\forall N, \\; \\exists n \\geq N: \\; r_A(n) \\geq c \\log n$. Heuristically, if $\\mathbb{P}[a \\in A] \\approx 1/\\sqrt{a}$, then $\\mathbb{E}[r_A(n)] = \\sum_{a \\leq n} \\frac{1}{\\sqrt{a}} \\cdot \\frac{1}{\\sqrt{n-a}} \\approx \\log n$.",
+    "significance": "key",
+    "relatedConcepts": ["probabilistic method", "random sets", "logarithmic growth", "second moment method"],
+    "prerequisites": ["repFunction", "IsAsymptoticBasis2", "Real.log"]
   },
   {
-    "id": "erdos-fuchs",
+    "id": "density-version",
     "proofId": "erdos-28",
-    "range": { "startLine": 94, "endLine": 99 },
+    "range": { "startLine": 65, "endLine": 70 },
     "type": "theorem",
-    "title": "Erdős–Fuchs Theorem",
-    "content": "The cumulative sum Σ_{n≤N} r(n) cannot be cN + o(N^{1/4}/√(log N)). This shows representations must fluctuate, but does NOT prove individual r(n) is unbounded.",
-    "significance": "medium"
+    "title": "Density Version of the Conjecture",
+    "content": "Replaces the basis condition with the weaker hypothesis $A(N) \\geq c\\sqrt{N}$ for all large $N$. Since every basis of order 2 satisfies this density bound, this version is strictly stronger. It asks: does sufficient density alone force unbounded representations, without requiring $A + A$ to cover almost all integers?",
+    "mathContext": "If $A(N) \\geq c\\sqrt{N}$ for some $c > 0$ and all $N \\geq 1$, then $\\limsup r_A(n) = \\infty$. This generalizes the main conjecture since $\\text{IsAsymptoticBasis2}(A) \\Rightarrow A(N) \\gg \\sqrt{N}$.",
+    "significance": "key",
+    "relatedConcepts": ["density conditions", "sumset structure", "inverse sumset theory"],
+    "prerequisites": ["countingFn", "Real.sqrt", "basis_counting_lower"]
+  },
+  {
+    "id": "basis-counting",
+    "proofId": "erdos-28",
+    "range": { "startLine": 74, "endLine": 77 },
+    "type": "theorem",
+    "title": "Basis Counting Lower Bound",
+    "content": "A necessary condition: any basis of order 2 must have $A(N) \\geq c\\sqrt{N}$. This follows by counting: the sumset $A + A$ contains $\\sim N$ elements up to $N$, but $|A + A| \\leq \\binom{A(N)+1}{2}$, so $A(N) \\gg \\sqrt{N}$. This bound is essentially tight — Sidon sets achieve $A(N) \\sim \\sqrt{N}$ but are too thin to be bases.",
+    "mathContext": "$|A \\cap [1,N]| \\geq c\\sqrt{N}$ for some absolute constant $c > 0$ and all $N \\geq 1$. The upper bound $|A + A| \\leq \\binom{|A|+1}{2}$ gives $N \\leq \\binom{A(N)+1}{2}$, hence $A(N) \\geq \\sqrt{2N} - 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["pigeonhole principle", "Plünnecke–Ruzsa inequality", "sumset size bounds"],
+    "prerequisites": ["countingFn", "IsAsymptoticBasis2", "binomial coefficient bounds"]
   },
   {
     "id": "sidon-connection",
     "proofId": "erdos-28",
-    "range": { "startLine": 82, "endLine": 85 },
+    "range": { "startLine": 79, "endLine": 84 },
     "type": "theorem",
-    "title": "Sidon Sets Are Not Bases",
-    "content": "If r(n) ≤ 1 for all n (Sidon/B₂ condition), then A is too sparse to be a basis. This confirms the conjecture for the extremal case r ≤ 1.",
-    "significance": "medium"
+    "title": "Sidon Sets Cannot Be Bases",
+    "content": "A Sidon set (or $B_2$ set) has $r_A(n) \\leq 1$ for all $n$: each integer has at most one representation as $a + b$. Such sets satisfy $A(N) \\leq \\sqrt{N} + O(N^{1/4})$ (by the Lindström–Erdős–Turán bound), which is too sparse for a basis. This confirms the conjecture vacuously: the extremal case $r \\leq 1$ is incompatible with being a basis.",
+    "mathContext": "If $r_A(n) \\leq 1$ for all $n$, then $A$ is a **Sidon set** ($B_2$ set). Sidon sets satisfy $|A \\cap [1,N]| \\leq \\sqrt{N} + O(N^{1/4})$, but bases require $|A \\cap [1,N]| \\gg \\sqrt{N}$ with a constant that forces density beyond the Sidon threshold.",
+    "significance": "key",
+    "relatedConcepts": ["Sidon sets", "B_2 sequences", "Erdős–Turán bound on Sidon sets", "Singer difference sets"],
+    "prerequisites": ["repFunction", "IsAsymptoticBasis2", "Sidon set density bounds"]
+  },
+  {
+    "id": "problem-40",
+    "proofId": "erdos-28",
+    "range": { "startLine": 88, "endLine": 93 },
+    "type": "theorem",
+    "title": "Connection to Problem #40 (B₂[g] Sets)",
+    "content": "Problem #40 asks: if $r_A(n) \\leq g$ for some constant $g$ (i.e., $A$ is a $B_2[g]$ set), can $A$ be a basis of order 2? The Erdős–Turán conjecture (#28) implies the answer is no for every finite $g$. This formalization shows #28 $\\Rightarrow$ #40, connecting two of Erdős's most celebrated problems in additive combinatorics.",
+    "mathContext": "A $B_2[g]$ set satisfies $r_A(n) \\leq g$ for all $n$. Problem #28 states $\\limsup r_A(n) = \\infty$ for any basis, which immediately implies no $B_2[g]$ set (with bounded $r$) can be a basis. The converse implication (#40 $\\Rightarrow$ #28) is unknown.",
+    "significance": "key",
+    "relatedConcepts": ["B_2[g] sets", "Erdős Problem #40", "Erdős Problem #1145", "additive structure"],
+    "prerequisites": ["repFunction", "IsAsymptoticBasis2", "erdos_turan_conjecture"]
+  },
+  {
+    "id": "erdos-fuchs",
+    "proofId": "erdos-28",
+    "range": { "startLine": 97, "endLine": 103 },
+    "type": "theorem",
+    "title": "Erdős–Fuchs Theorem (1956)",
+    "content": "The Erdős–Fuchs theorem shows the cumulative representation count $\\sum_{n \\leq N} r_A(n)$ cannot be approximated by a linear function $cN$ with error $o(N^{1/4} / \\sqrt{\\log N})$. This is a fluctuation result: the partial sums of $r_A(n)$ must oscillate. However, it does NOT imply the Erdős–Turán conjecture — the fluctuations could come from occasional large values with $r_A(n)$ still bounded.",
+    "mathContext": "$\\nexists \\, c > 0$ such that $\\sum_{n \\leq N} r_A(n) = cN + o\\left(\\frac{N^{1/4}}{\\sqrt{\\log N}}\\right)$. The exponent $1/4$ is sharp (Montgomery–Vaughan, 1990). This is an **Omega result**: $\\sum r_A(n) - cN = \\Omega(N^{1/4} / \\sqrt{\\log N})$.",
+    "significance": "key",
+    "relatedConcepts": ["Erdős–Fuchs theorem", "oscillation theorems", "circle method", "Montgomery–Vaughan improvement"],
+    "prerequisites": ["repFunction", "IsAsymptoticBasis2", "asymptotic notation", "Finset.sum"]
+  },
+  {
+    "id": "average-rep",
+    "proofId": "erdos-28",
+    "range": { "startLine": 105, "endLine": 111 },
+    "type": "theorem",
+    "title": "Average Representation Unbounded (Halberstam–Roth)",
+    "content": "For a basis of order 2, the average representation $\\frac{1}{N}\\sum_{n \\leq N} r_A(n) \\to \\infty$ as $N \\to \\infty$. This follows because $A + A$ covers all large integers, so the sum grows like $N$, but the representation function concentrates differently than a uniform distribution. Crucially, this does NOT prove $\\limsup r_A(n) = \\infty$ — the average could diverge even if individual values are bounded (e.g., if the average is pulled up by a bounded function applied to more and more terms).",
+    "mathContext": "$\\frac{1}{N+1} \\sum_{n=0}^{N} r_A(n) \\to \\infty$ as $N \\to \\infty$. More precisely, if $A + A \\supseteq \\{N_0, N_0+1, \\ldots\\}$, then $\\sum_{n \\leq N} r_A(n) \\geq N - N_0$ for $N \\geq N_0$, so the average is at least $\\sim 1$. But actually the sum grows faster because of multiplicities, making the average tend to $\\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cesàro mean", "divergence of averages", "Halberstam–Roth", "additive bases density"],
+    "prerequisites": ["repFunction", "IsAsymptoticBasis2", "Filter.Tendsto", "atTop"]
   }
 ]

--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -15,66 +15,96 @@
       "open"
     ],
     "references": [
-      "Erdős–Turán (1941): original conjecture",
-      "Erdős–Fuchs (1956): fluctuation theorem",
-      "Halberstam–Roth: average representation",
+      "Erdős–Turán (1941): 'On a problem of Sidon in additive number theory and some related problems', J. London Math. Soc.",
+      "Erdős–Fuchs (1956): 'On a problem of additive number theory', J. London Math. Soc.",
+      "Halberstam–Roth (1966): 'Sequences', Oxford University Press",
+      "Montgomery–Vaughan (1990): sharpened Erdős–Fuchs with optimal exponent",
       "https://erdosproblems.com/28"
     ],
     "leanFile": "Proofs/Erdos28Problem.lean",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/28",
-    "erdosUrl": "https://erdosproblems.com/28"
+    "erdosUrl": "https://erdosproblems.com/28",
+    "relatedProofs": ["erdos-40"]
   },
   "sections": [
     {
+      "id": "header-imports",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "Module docstring stating the conjecture and its $500 bounty, followed by Mathlib imports for additive combinatorics (`SumConv`), Finset operations, filter convergence (`atTop`, `Tendsto`), and real analysis (`Real.log`, `Real.sqrt`). Opens `Filter` and `Set` namespaces with `Pointwise` scoping for $A + A$ notation."
+    },
+    {
       "id": "core-definitions",
       "title": "Core Definitions",
-      "startLine": 25,
-      "endLine": 46,
-      "summary": "Define repFunction, IsAsymptoticBasis2, and countingFn."
+      "startLine": 31,
+      "endLine": 45,
+      "summary": "Three foundational definitions: the **representation function** $r_A(n) = |\\{(a,b) : a+b=n, a \\leq b, a,b \\in A\\}|$, the **asymptotic basis** condition $(A+A)^c$ finite, and the **counting function** $A(N) = |A \\cap [1,N]|$. These encode the core objects of the Erdős–Turán conjecture in Lean 4."
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
-      "startLine": 48,
+      "startLine": 47,
       "endLine": 56,
-      "summary": "The Erdős–Turán conjecture: basis of order 2 implies unbounded representations."
+      "summary": "The Erdős–Turán conjecture (1941): $\\forall B, \\exists n: r_A(n) \\geq B$ whenever $A$ is an asymptotic basis of order 2. Stated as an axiom since the problem remains **OPEN** with a \\$500 bounty. Equivalent to $\\limsup r_A(n) = \\infty$."
     },
     {
       "id": "stronger-forms",
-      "title": "Stronger Forms",
+      "title": "Stronger Forms of the Conjecture",
       "startLine": 58,
-      "endLine": 72,
-      "summary": "Strong form with log n lower bound and density version with √N hypothesis."
+      "endLine": 70,
+      "summary": "Two strengthenings: (1) the **logarithmic form** $\\limsup r_A(n)/\\log n > 0$, motivated by probabilistic heuristics showing $\\mathbb{E}[r_A(n)] \\sim \\log n$ for random sets of density $\\sqrt{N}$; (2) the **density version** replacing the basis hypothesis with $A(N) \\geq c\\sqrt{N}$, which is strictly weaker than being a basis."
     },
     {
-      "id": "known-results",
-      "title": "Known Results and Connections",
-      "startLine": 74,
-      "endLine": 105,
-      "summary": "Sidon sets, Problem #40 connection, Erdős–Fuchs fluctuation theorem, average rep."
+      "id": "counting-bounds",
+      "title": "Counting Lower Bounds",
+      "startLine": 72,
+      "endLine": 77,
+      "summary": "Necessary density condition: any basis of order 2 has $A(N) \\gg \\sqrt{N}$ by a pigeonhole/counting argument. Since $|A+A| \\leq \\binom{A(N)+1}{2}$ and $A+A$ must cover $\\sim N$ integers, we get $A(N) \\geq \\sqrt{2N} - 1$."
+    },
+    {
+      "id": "sidon-sets",
+      "title": "Sidon Sets and Extremal Case",
+      "startLine": 79,
+      "endLine": 84,
+      "summary": "Sidon sets ($B_2$ sets) have $r_A(n) \\leq 1$, making them too sparse ($A(N) \\leq \\sqrt{N} + O(N^{1/4})$) to be bases. This confirms the conjecture vacuously for the extremal case $r \\leq 1$."
+    },
+    {
+      "id": "problem-40-connection",
+      "title": "Connection to Problem #40",
+      "startLine": 86,
+      "endLine": 93,
+      "summary": "Problem #40 generalizes the Sidon observation: can any $B_2[g]$ set (with $r_A(n) \\leq g$) be a basis? The Erdős–Turán conjecture implies the answer is **no** for every finite $g$. This formalizes the implication #28 $\\Rightarrow$ #40."
+    },
+    {
+      "id": "partial-results",
+      "title": "Partial Results: Erdős–Fuchs and Averages",
+      "startLine": 95,
+      "endLine": 112,
+      "summary": "Two key partial results: (1) the **Erdős–Fuchs theorem** (1956) showing $\\sum_{n \\leq N} r_A(n) \\neq cN + o(N^{1/4}/\\sqrt{\\log N})$ — representations must oscillate, but this doesn't imply individual unboundedness; (2) **Halberstam–Roth** showing the average $\\frac{1}{N}\\sum r_A(n) \\to \\infty$, which also falls short of proving the conjecture."
     }
   ],
   "overview": {
-    "historicalContext": "Erdős and Turán conjectured this in 1941, making it one of the oldest open problems in additive combinatorics. The $500 bounty reflects its importance. The conjecture says that if A+A covers all integers (basis of order 2), then some integers have many representations. Despite decades of work, even the basic conjecture remains open.",
-    "problemStatement": "If A ⊆ ℕ and A + A contains all but finitely many natural numbers, must lim sup r_A(n) = ∞, where r_A(n) counts representations n = a + b with a, b ∈ A?",
-    "proofStrategy": "We formalize the representation function, the asymptotic basis condition, state the main conjecture and its stronger forms, and connect to known results (Erdős–Fuchs, Sidon sets, Problem #40).",
+    "historicalContext": "Paul Erdős and Pál Turán posed this conjecture in their landmark 1941 paper 'On a problem of Sidon in additive number theory and some related problems' (J. London Math. Soc.), which also introduced the systematic study of $B_2$ sequences. The conjecture emerged from their investigation of how the representation function $r_A(n)$ behaves for additive bases — sets $A$ whose sumset $A + A$ covers all sufficiently large integers. Erdős attached a $500 bounty, one of his largest prizes, signaling its depth within additive combinatorics. Key partial results include the Erdős–Fuchs theorem (1956), which proved that cumulative representations must fluctuate (sharpened by Montgomery and Vaughan in 1990 to the optimal exponent $1/4$), and the Halberstam–Roth observation that average representations diverge. The conjecture connects to a web of related problems: Problem #40 on $B_2[g]$ sets, the structure theory of Sidon sets (initiated by Simon Sidon in the 1930s), and Waring-type problems on additive bases of higher order. Despite 85 years of effort by leaders in additive combinatorics — including Nathanson, Cilleruelo, and Lev — even the basic conjecture remains completely open.",
+    "problemStatement": "If $A \\subseteq \\mathbb{N}$ and $A + A$ contains all but finitely many natural numbers, must $\\limsup_{n \\to \\infty} r_A(n) = \\infty$, where $r_A(n) = |\\{(a,b) \\in A \\times A : a + b = n, \\; a \\leq b\\}|$?",
+    "proofStrategy": "We formalize the core objects of the conjecture — the representation function $r_A(n)$, the asymptotic basis condition, and the counting function — then state the main conjecture and two strengthenings (logarithmic growth and density version) as axioms. We connect these to known results: the basis counting lower bound ($A(N) \\gg \\sqrt{N}$), the Sidon set exclusion, the implication to Problem #40, the Erdős–Fuchs fluctuation theorem, and the Halberstam–Roth average divergence.",
     "keyInsights": [
-      "The conjecture says no basis of order 2 has uniformly bounded representations",
-      "The stronger form predicts r(n) ≥ c log n infinitely often",
-      "Erdős–Fuchs shows cumulative representations must fluctuate — but this doesn't imply the conjecture",
-      "Sidon sets (r ≤ 1) are too sparse to be bases, confirming the conjecture vacuously",
-      "Connected to Problems #40 and #1145 on B₂[g] sets"
+      "**No thin basis can exist**: The conjecture asserts that controlling $r_A(n) \\leq C$ is fundamentally incompatible with $A + A$ covering all large integers — a profound structural constraint on sumsets",
+      "**Logarithmic growth from probabilistic heuristics**: For a 'random' set of density $\\sim \\sqrt{N}$, each $r_A(n)$ has expectation $\\sim \\log n$, suggesting $\\limsup r_A(n)/\\log n > 0$ as the natural quantitative form",
+      "**Erdős–Fuchs falls short**: The cumulative sum $\\sum r_A(n)$ must oscillate by $\\Omega(N^{1/4}/\\sqrt{\\log N})$, but these fluctuations could concentrate in a few large terms without any single $r_A(n)$ being large — a subtle gap between average and pointwise behavior",
+      "**Sidon sets confirm the extremal case**: Sets with $r \\leq 1$ (Sidon/$B_2$ sets) satisfy $A(N) \\leq \\sqrt{N} + O(N^{1/4})$, which is too sparse for a basis, confirming the conjecture vacuously at the boundary",
+      "**Hierarchy of related problems**: #28 implies #40 ($B_2[g]$ sets cannot be bases), connects to #1145 on dense $B_2[g]$ constructions, and motivates the density version that weakens the basis hypothesis to $A(N) \\gg \\sqrt{N}$"
     ]
   },
   "conclusion": {
-    "summary": "The Erdős–Turán conjecture on additive bases is one of the most important open problems in additive combinatorics. Despite partial results like the Erdős–Fuchs theorem and connections to Sidon sets, the basic conjecture remains unresolved after 80+ years.",
-    "implications": "A proof would establish a fundamental dichotomy: either a set is too sparse to be a basis, or it must have arbitrarily many representations. This would have deep consequences for additive number theory and the structure of sumsets.",
+    "summary": "This formalization captures the full landscape of the Erdős–Turán conjecture on additive bases: the core definitions, the main conjecture and its strengthenings, connections to Sidon sets and Problem #40, and the partial results (Erdős–Fuchs, Halberstam–Roth) that illuminate why the problem is so hard. The gap between what is known (average representations diverge, cumulative sums oscillate) and what is conjectured (individual representations are unbounded) highlights a deep open question about the pointwise behavior of additive structure.",
+    "implications": "A proof would establish that no additive basis of order 2 can have uniformly bounded representations — a fundamental dichotomy in additive number theory. This would resolve Problem #40 as a corollary, settle the structure of $B_2[g]$ sets relative to bases, and likely introduce new techniques at the intersection of additive combinatorics and analytic number theory. The density version, if true, would extend the result far beyond bases to any sufficiently dense set.",
     "openQuestions": [
-      "Does lim sup r(n) = ∞ for every asymptotic basis of order 2?",
-      "Is lim sup r(n)/log n > 0?",
-      "Does the conclusion hold under the weaker hypothesis |A ∩ [1,N]| ≫ √N?",
-      "What is the relationship to the density version of the conjecture?"
+      "Can the Erdős–Fuchs fluctuation theorem be strengthened to imply pointwise unboundedness of $r_A(n)$, or is there a fundamental barrier?",
+      "Does the conjecture hold under the weaker density hypothesis $A(N) \\geq c\\sqrt{N}$, without assuming $A + A$ covers almost all integers?",
+      "What is the correct growth rate: is $\\limsup r_A(n)/\\log n > 0$, or could representations grow slower than logarithmically?",
+      "Can Fourier-analytic or circle-method techniques (as used in Waring's problem) be adapted to attack this conjecture?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Added `mathContext`, `significance`, `relatedConcepts`, `prerequisites` to all 12 annotations (expanded from 6)
- Fixed annotation types (`conjecture`→`theorem`, `high/medium`→`critical/key/supporting`)
- Deepened `historicalContext` with 1941 paper citation, Montgomery–Vaughan (1990), and key contributors
- Enhanced 5 `keyInsights` with bold formatting and mathematical depth (probabilistic heuristics, Erdős–Fuchs gap)
- Expanded `sections` from 4 to 8 with LaTeX in summaries
- Added cross-reference to `erdos-40`
- Improved `conclusion` with specific `openQuestions` on Fourier-analytic approaches

## Test plan
- [x] `pnpm annotations:build` passes with no warnings for erdos-28
- [x] JSON validated (meta.json and annotations.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)