### PR TITLE
fix: flatten mathContext objects to strings in annotations

### DIFF
--- a/src/data/proofs/erdos-273/annotations.json
+++ b/src/data/proofs/erdos-273/annotations.json
@@ -3,219 +3,156 @@
     "id": "erdos-273-covering-def",
     "proofId": "erdos-273",
     "type": "definition",
-    "range": { "startLine": 25, "endLine": 37 },
+    "range": {
+      "startLine": 25,
+      "endLine": 37
+    },
     "title": "Covering System",
     "content": "A covering system is a finite collection of residue classes $a_i \\pmod{m_i}$ (with $m_i \\geq 2$) whose union is all of $\\mathbb{Z}$. Formalized as a structure `CoveringSystem` with an index type `Fin n`, moduli, residues, a proof that each modulus $\\geq 2$, and the covering property: $\\forall z \\in \\mathbb{Z},\\, \\exists i,\\, z \\equiv a_i \\pmod{m_i}$.",
     "significance": "essential",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "\\text{CoveringSystem}: \\forall z \\in \\mathbb{Z},\\, \\exists i \\in [n],\\, z \\equiv r_i \\pmod{m_i}",
-      "leanSignature": "structure CoveringSystem where n : ℕ; moduli : Fin n → ℕ; residues : Fin n → ℤ; moduli_ge_two : ∀ i, moduli i ≥ 2; covers : ∀ z : ℤ, ∃ i, z % ↑(moduli i) = residues i % ↑(moduli i)",
-      "proofTechnique": "structure definition with existential covering property",
-      "relatedTheorems": ["Chinese Remainder Theorem", "Hough's theorem on distinct covering systems", "Erdős minimum modulus conjecture"],
-      "references": ["Erdős–Graham (1980), p.24", "Hough (2015), Annals of Mathematics"],
-      "formalizationNote": "Uses ℤ modular arithmetic directly via `z % (moduli i : ℤ)` rather than `ZMod`, which is more natural for the covering property statement.",
-      "crossReferences": ["erdos-273-prime-minus-one", "erdos-273-reciprocal"]
-    }
+    "mathContext": "combinatorial number theory. LaTeX: \\text{CoveringSystem}: \\forall z \\in \\mathbb{Z},\\, \\exists i \\in [n],\\, z \\equiv r_i \\pmod{m_i}. Lean: structure CoveringSystem where n : ℕ; moduli : Fin n → ℕ; residues : Fin n → ℤ; moduli_ge_two : ∀ i, moduli i ≥ 2; covers : ∀ z : ℤ, ∃ i, z % ↑(moduli i) = residues i % ↑(moduli i). Technique: structure definition with existential covering property. Uses ℤ modular arithmetic directly via `z % (moduli i : ℤ)` rather than `ZMod`, which is more natural for the covering property statement.. Related: Chinese Remainder Theorem, Hough's theorem on distinct covering systems, Erdős minimum modulus conjecture. Refs: Erdős–Graham (1980), p.24, Hough (2015), Annals of Mathematics. Cross-refs: erdos-273-prime-minus-one, erdos-273-reciprocal"
   },
   {
     "id": "erdos-273-prime-minus-one",
     "proofId": "erdos-273",
     "type": "definition",
-    "range": { "startLine": 43, "endLine": 49 },
+    "range": {
+      "startLine": 43,
+      "endLine": 49
+    },
     "title": "Prime-Minus-One Moduli",
     "content": "Defines `IsPrimeMinusOne k m`: modulus $m = p - 1$ for some prime $p \\geq k$. Then `AllModuliPrimeMinusOne k cs` requires every modulus in the covering system to satisfy this condition. The parameter $k$ controls the prime threshold — $k = 3$ gives Selfridge's case, $k = 5$ is Erdős's open question.",
     "significance": "essential",
-    "mathContext": {
-      "field": "number theory / covering systems",
-      "latex": "\\text{IsPrimeMinusOne}(k, m) :\\Leftrightarrow \\exists p \\text{ prime},\\, p \\geq k,\\, m = p - 1",
-      "leanSignature": "def IsPrimeMinusOne (k : ℕ) (m : ℕ) : Prop := ∃ p : ℕ, p.Prime ∧ k ≤ p ∧ m = p - 1",
-      "proofTechnique": "existential predicate parameterized by prime threshold",
-      "relatedTheorems": ["Dirichlet's theorem on primes in arithmetic progressions", "Linnik's theorem"],
-      "formalizationNote": "The parameterization by k elegantly captures both the p ≥ 3 (solved) and p ≥ 5 (open) cases in a single definition. The allowed moduli for k=5 form the set {4, 6, 10, 12, 16, 18, 22, 28, 30, ...}.",
-      "crossReferences": ["erdos-273-covering-def", "erdos-273-conjecture"]
-    }
+    "mathContext": "number theory / covering systems. LaTeX: \\text{IsPrimeMinusOne}(k, m) :\\Leftrightarrow \\exists p \\text{ prime},\\, p \\geq k,\\, m = p - 1. Lean: def IsPrimeMinusOne (k : ℕ) (m : ℕ) : Prop := ∃ p : ℕ, p.Prime ∧ k ≤ p ∧ m = p - 1. Technique: existential predicate parameterized by prime threshold. The parameterization by k elegantly captures both the p ≥ 3 (solved) and p ≥ 5 (open) cases in a single definition. The allowed moduli for k=5 form the set {4, 6, 10, 12, 16, 18, 22, 28, 30, ...}.. Related: Dirichlet's theorem on primes in arithmetic progressions, Linnik's theorem. Cross-refs: erdos-273-covering-def, erdos-273-conjecture"
   },
   {
     "id": "erdos-273-conjecture",
     "proofId": "erdos-273",
     "type": "conjecture",
-    "range": { "startLine": 55, "endLine": 61 },
+    "range": {
+      "startLine": 55,
+      "endLine": 61
+    },
     "title": "Erdős Problem 273",
     "content": "Does there exist a covering system with all moduli of the form $p - 1$ for primes $p \\geq 5$? The allowed moduli are $\\{4, 6, 10, 12, 16, 18, 22, 28, 30, \\ldots\\}$. Since modulus 2 ($= 3 - 1$) is excluded, covering all residues modulo 2 requires careful use of even moduli $\\geq 4$.",
     "significance": "essential",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "\\exists \\text{CoveringSystem } cs,\\, \\forall i,\\, cs.m_i = p_i - 1 \\text{ for some prime } p_i \\geq 5",
-      "leanSignature": "def ErdosProblem273 : Prop := ∃ cs : CoveringSystem, AllModuliPrimeMinusOne 5 cs",
-      "proofTechnique": "existential statement — asks for construction or impossibility proof",
-      "relatedTheorems": ["Selfridge's covering system (p ≥ 3)", "Erdős–Selfridge conjecture on covering congruences", "Hough's theorem (2015)"],
-      "references": ["Erdős–Graham (1980), p.24", "erdosproblems.com/273"],
-      "designChoices": "Formalized as a pure existence statement `∃ cs, ...` rather than exhibiting a specific system, since the problem is open and may have a negative answer.",
-      "crossReferences": ["erdos-273-selfridge", "erdos-273-obstacles"]
-    }
+    "mathContext": "combinatorial number theory. LaTeX: \\exists \\text{CoveringSystem } cs,\\, \\forall i,\\, cs.m_i = p_i - 1 \\text{ for some prime } p_i \\geq 5. Lean: def ErdosProblem273 : Prop := ∃ cs : CoveringSystem, AllModuliPrimeMinusOne 5 cs. Technique: existential statement — asks for construction or impossibility proof. Related: Selfridge's covering system (p ≥ 3), Erdős–Selfridge conjecture on covering congruences, Hough's theorem (2015). Refs: Erdős–Graham (1980), p.24, erdosproblems.com/273. Cross-refs: erdos-273-selfridge, erdos-273-obstacles. Design: Formalized as a pure existence statement `∃ cs, ...` rather than exhibiting a specific system, since the problem is open and may have a negative answer."
   },
   {
     "id": "erdos-273-selfridge",
     "proofId": "erdos-273",
     "type": "result",
-    "range": { "startLine": 67, "endLine": 72 },
+    "range": {
+      "startLine": 67,
+      "endLine": 72
+    },
     "title": "Selfridge's Example (p ≥ 3)",
     "content": "Selfridge found a covering system when $p \\geq 3$ is allowed. The key modulus is $2 = 3 - 1$, and the construction uses divisors of $360 = 2^3 \\cdot 3^2 \\cdot 5$. The prime-minus-one moduli dividing 360 include $\\{2, 4, 6, 12, 18, 36, 60, 180\\}$, corresponding to primes $\\{3, 5, 7, 13, 19, 37, 61, 181\\}$.",
     "significance": "essential",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "\\exists \\text{CoveringSystem } cs,\\, \\forall i,\\, cs.m_i = p_i - 1 \\text{ for some prime } p_i \\geq 3",
-      "leanSignature": "axiom selfridge_example : ∃ cs : CoveringSystem, AllModuliPrimeMinusOne 3 cs",
-      "proofTechnique": "explicit construction using divisors of 360",
-      "relatedTheorems": ["Chinese Remainder Theorem", "smooth number properties of 360"],
-      "references": ["Erdős–Graham (1980), p.24"],
-      "formalizationNote": "Axiomatized rather than constructively exhibited. A full formalization would require building the explicit residue class assignments for divisors of 360 and verifying the covering property.",
-      "crossReferences": ["erdos-273-conjecture", "erdos-273-easy-primes"]
-    }
+    "mathContext": "combinatorial number theory. LaTeX: \\exists \\text{CoveringSystem } cs,\\, \\forall i,\\, cs.m_i = p_i - 1 \\text{ for some prime } p_i \\geq 3. Lean: axiom selfridge_example : ∃ cs : CoveringSystem, AllModuliPrimeMinusOne 3 cs. Technique: explicit construction using divisors of 360. Axiomatized rather than constructively exhibited. A full formalization would require building the explicit residue class assignments for divisors of 360 and verifying the covering property.. Related: Chinese Remainder Theorem, smooth number properties of 360. Refs: Erdős–Graham (1980), p.24. Cross-refs: erdos-273-conjecture, erdos-273-easy-primes"
   },
   {
     "id": "erdos-273-lcm",
     "proofId": "erdos-273",
     "type": "definition",
-    "range": { "startLine": 78, "endLine": 80 },
+    "range": {
+      "startLine": 78,
+      "endLine": 80
+    },
     "title": "LCM of Moduli",
     "content": "Defines `CoveringSystem.lcm` as $\\text{lcm}(m_1, \\ldots, m_n)$ using `Finset.lcm` over `Finset.univ`. The LCM determines the period of the covering: the covering pattern repeats with period $L = \\text{lcm}(m_i)$. Verification reduces to checking that $\\{0, 1, \\ldots, L-1\\}$ are all covered.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "L(cs) = \\text{lcm}(m_1, m_2, \\ldots, m_n)",
-      "leanSignature": "noncomputable def CoveringSystem.lcm (cs : CoveringSystem) : ℕ := (Finset.univ : Finset (Fin cs.n)).lcm cs.moduli",
-      "proofTechnique": "reduction to finite verification via periodicity",
-      "formalizationNote": "The LCM is noncomputable because `Finset.lcm` requires `DecidableEq` and works over `Finset.univ` for `Fin n`.",
-      "crossReferences": ["erdos-273-reciprocal"]
-    }
+    "mathContext": "combinatorial number theory. LaTeX: L(cs) = \\text{lcm}(m_1, m_2, \\ldots, m_n). Lean: noncomputable def CoveringSystem.lcm (cs : CoveringSystem) : ℕ := (Finset.univ : Finset (Fin cs.n)).lcm cs.moduli. Technique: reduction to finite verification via periodicity. The LCM is noncomputable because `Finset.lcm` requires `DecidableEq` and works over `Finset.univ` for `Fin n`.. Cross-refs: erdos-273-reciprocal"
   },
   {
     "id": "erdos-273-reciprocal",
     "proofId": "erdos-273",
     "type": "result",
-    "range": { "startLine": 82, "endLine": 86 },
+    "range": {
+      "startLine": 82,
+      "endLine": 86
+    },
     "title": "Reciprocal Sum Necessary Condition",
     "content": "In any covering system, the sum of reciprocals $\\sum_{i=1}^n \\frac{1}{m_i} \\geq 1$. This is because each residue class $a_i \\pmod{m_i}$ covers a fraction $1/m_i$ of all integers, and their union must cover everything. Equality holds only when the classes partition $\\mathbb{Z}$ (exact covering).",
     "significance": "essential",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "\\sum_{i=1}^{n} \\frac{1}{m_i} \\geq 1",
-      "leanSignature": "axiom covering_reciprocal_sum (cs : CoveringSystem) : (Finset.univ : Finset (Fin cs.n)).sum (fun i => (1 : ℚ) / (cs.moduli i : ℚ)) ≥ 1",
-      "proofTechnique": "density argument / inclusion-exclusion",
-      "relatedTheorems": ["exact covering system characterization", "Znám's problem on Egyptian fraction representations"],
-      "references": ["Erdős–Graham (1980)", "Guy, Unsolved Problems in Number Theory"],
-      "formalizationNote": "Uses ℚ arithmetic for exact reciprocal sums rather than ℝ, avoiding real-number approximation issues. The inequality is axiomatized; a proof would use natural density or finite verification modulo the LCM.",
-      "crossReferences": ["erdos-273-covering-def", "erdos-273-lcm"]
-    }
+    "mathContext": "combinatorial number theory. LaTeX: \\sum_{i=1}^{n} \\frac{1}{m_i} \\geq 1. Lean: axiom covering_reciprocal_sum (cs : CoveringSystem) : (Finset.univ : Finset (Fin cs.n)).sum (fun i => (1 : ℚ) / (cs.moduli i : ℚ)) ≥ 1. Technique: density argument / inclusion-exclusion. Uses ℚ arithmetic for exact reciprocal sums rather than ℝ, avoiding real-number approximation issues. The inequality is axiomatized; a proof would use natural density or finite verification modulo the LCM.. Related: exact covering system characterization, Znám's problem on Egyptian fraction representations. Refs: Erdős–Graham (1980), Guy, Unsolved Problems in Number Theory. Cross-refs: erdos-273-covering-def, erdos-273-lcm"
   },
   {
     "id": "erdos-273-distinct",
     "proofId": "erdos-273",
     "type": "definition",
-    "range": { "startLine": 88, "endLine": 92 },
+    "range": {
+      "startLine": 88,
+      "endLine": 92
+    },
     "title": "Distinct Covering Systems",
     "content": "A covering system is distinct if all moduli are different: `Function.Injective cs.moduli`. Erdős conjectured that every distinct covering system must include an even modulus. Hough proved this in 2015, showing that the minimum modulus of a distinct covering system is bounded.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "\\text{IsDistinct}(cs) :\\Leftrightarrow m_i \\neq m_j \\text{ for } i \\neq j",
-      "leanSignature": "def IsDistinct (cs : CoveringSystem) : Prop := Function.Injective cs.moduli",
-      "proofTechnique": "injectivity of moduli function",
-      "relatedTheorems": ["Hough's theorem (2015): minimum modulus conjecture", "Erdős minimum modulus problem", "Filaseta–Ford–Konyagin–Pomerance–Yu (2007)"],
-      "references": ["Hough, 'Solution of the minimum modulus problem for covering systems', Annals of Mathematics, 2015"],
-      "formalizationNote": "Uses `Function.Injective` from Mathlib, which naturally captures the distinctness condition.",
-      "crossReferences": ["erdos-273-covering-def", "erdos-273-hough-connection"]
-    }
+    "mathContext": "combinatorial number theory. LaTeX: \\text{IsDistinct}(cs) :\\Leftrightarrow m_i \\neq m_j \\text{ for } i \\neq j. Lean: def IsDistinct (cs : CoveringSystem) : Prop := Function.Injective cs.moduli. Technique: injectivity of moduli function. Uses `Function.Injective` from Mathlib, which naturally captures the distinctness condition.. Related: Hough's theorem (2015): minimum modulus conjecture, Erdős minimum modulus problem, Filaseta–Ford–Konyagin–Pomerance–Yu (2007). Refs: Hough, 'Solution of the minimum modulus problem for covering systems', Annals of Mathematics, 2015. Cross-refs: erdos-273-covering-def, erdos-273-hough-connection"
   },
   {
     "id": "erdos-273-easy-primes",
     "proofId": "erdos-273",
     "type": "context",
-    "range": { "startLine": 98, "endLine": 102 },
+    "range": {
+      "startLine": 98,
+      "endLine": 102
+    },
     "title": "Easy Primes for 360-Based Constructions",
     "content": "The primes $p \\geq 5$ with $p - 1 \\mid 360$ are $\\{5, 7, 13, 19, 37, 61, 181\\}$. These give moduli $\\{4, 6, 12, 18, 36, 60, 180\\}$, which are the building blocks for any 360-based covering attempt. The number 360 is highly composite ($360 = 2^3 \\cdot 3^2 \\cdot 5$), making it rich in prime-minus-one divisors.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "number theory / covering systems",
-      "latex": "\\{p \\geq 5 : p \\text{ prime},\\, (p-1) \\mid 360\\} = \\{5, 7, 13, 19, 37, 61, 181\\}",
-      "leanSignature": "def easyPrimes : Finset ℕ := {5, 7, 13, 19, 37, 61, 181}",
-      "proofTechnique": "enumeration of divisors of a highly composite number",
-      "relatedTheorems": ["Selfridge's covering system", "highly composite number properties"],
-      "formalizationNote": "Defined as an explicit `Finset ℕ`. The factorization $360 = 2^3 \\cdot 3^2 \\cdot 5$ has $\\tau(360) = 24$ divisors; exactly 7 of these are of the form $p-1$ for prime $p \\geq 5$.",
-      "crossReferences": ["erdos-273-selfridge"]
-    }
+    "mathContext": "number theory / covering systems. LaTeX: \\{p \\geq 5 : p \\text{ prime},\\, (p-1) \\mid 360\\} = \\{5, 7, 13, 19, 37, 61, 181\\}. Lean: def easyPrimes : Finset ℕ := {5, 7, 13, 19, 37, 61, 181}. Technique: enumeration of divisors of a highly composite number. Defined as an explicit `Finset ℕ`. The factorization $360 = 2^3 \\cdot 3^2 \\cdot 5$ has $\\tau(360) = 24$ divisors; exactly 7 of these are of the form $p-1$ for prime $p \\geq 5$.. Related: Selfridge's covering system, highly composite number properties. Cross-refs: erdos-273-selfridge"
   },
   {
     "id": "erdos-273-even-difficulty",
     "proofId": "erdos-273",
     "type": "result",
-    "range": { "startLine": 104, "endLine": 109 },
+    "range": {
+      "startLine": 104,
+      "endLine": 109
+    },
     "title": "Even Coverage Difficulty",
     "content": "For $p \\geq 5$, all allowed moduli satisfy $m_i > 2$. Since modulus 2 ($= 3 - 1$) is excluded, every modulus is at least 4. This means no single residue class covers all even (or all odd) integers — each class covers at most $1/4$ of all integers.",
     "significance": "essential",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "\\forall cs,\\, \\text{AllModuliPrimeMinusOne}(5, cs) \\implies \\forall i,\\, m_i > 2",
-      "leanSignature": "axiom difficulty_even_coverage : ∀ cs : CoveringSystem, AllModuliPrimeMinusOne 5 cs → ∀ i, 2 < cs.moduli i",
-      "proofTechnique": "the only prime p with p-1 = 2 is p = 3, excluded by p ≥ 5",
-      "relatedTheorems": ["Hough's theorem on even moduli in distinct coverings"],
-      "formalizationNote": "A simple consequence of the definitions: if $m = p - 1$ and $p \\geq 5$, then $m \\geq 4 > 2$. Axiomatized for convenience.",
-      "crossReferences": ["erdos-273-obstacles", "erdos-273-conjecture"]
-    }
+    "mathContext": "combinatorial number theory. LaTeX: \\forall cs,\\, \\text{AllModuliPrimeMinusOne}(5, cs) \\implies \\forall i,\\, m_i > 2. Lean: axiom difficulty_even_coverage : ∀ cs : CoveringSystem, AllModuliPrimeMinusOne 5 cs → ∀ i, 2 < cs.moduli i. Technique: the only prime p with p-1 = 2 is p = 3, excluded by p ≥ 5. A simple consequence of the definitions: if $m = p - 1$ and $p \\geq 5$, then $m \\geq 4 > 2$. Axiomatized for convenience.. Related: Hough's theorem on even moduli in distinct coverings. Cross-refs: erdos-273-obstacles, erdos-273-conjecture"
   },
   {
     "id": "erdos-273-obstacles",
     "proofId": "erdos-273",
     "type": "result",
-    "range": { "startLine": 111, "endLine": 115 },
+    "range": {
+      "startLine": 111,
+      "endLine": 115
+    },
     "title": "Minimum Modulus ≥ 4",
     "content": "The key structural constraint: without modulus 2 or 3, every modulus in a $p \\geq 5$ covering system is $\\geq 4$. Since covering $\\mathbb{Z}$ requires $\\sum 1/m_i \\geq 1$ and each $m_i \\geq 4$, at least 4 residue classes are needed. But the constraint is much tighter: the moduli must come from the sparse set $\\{p - 1 : p \\text{ prime}, p \\geq 5\\}$.",
     "significance": "essential",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "\\forall cs,\\, \\text{AllModuliPrimeMinusOne}(5, cs) \\implies \\forall i,\\, m_i \\geq 4",
-      "leanSignature": "axiom min_modulus_ge_4 : ∀ cs : CoveringSystem, AllModuliPrimeMinusOne 5 cs → ∀ i, cs.moduli i ≥ 4",
-      "proofTechnique": "prime threshold argument: p ≥ 5 implies p - 1 ≥ 4",
-      "relatedTheorems": ["Erdős minimum modulus conjecture", "covering density bounds"],
-      "references": ["Erdős–Graham (1980), p.24"],
-      "designChoices": "Separates the m > 2 and m ≥ 4 facts into two axioms for clarity, though m ≥ 4 is the stronger and more useful bound.",
-      "crossReferences": ["erdos-273-even-difficulty", "erdos-273-reciprocal"]
-    }
+    "mathContext": "combinatorial number theory. LaTeX: \\forall cs,\\, \\text{AllModuliPrimeMinusOne}(5, cs) \\implies \\forall i,\\, m_i \\geq 4. Lean: axiom min_modulus_ge_4 : ∀ cs : CoveringSystem, AllModuliPrimeMinusOne 5 cs → ∀ i, cs.moduli i ≥ 4. Technique: prime threshold argument: p ≥ 5 implies p - 1 ≥ 4. Related: Erdős minimum modulus conjecture, covering density bounds. Refs: Erdős–Graham (1980), p.24. Cross-refs: erdos-273-even-difficulty, erdos-273-reciprocal. Design: Separates the m > 2 and m ≥ 4 facts into two axioms for clarity, though m ≥ 4 is the stronger and more useful bound."
   },
   {
     "id": "erdos-273-density-analysis",
     "proofId": "erdos-273",
     "type": "context",
-    "range": { "startLine": 55, "endLine": 115 },
+    "range": {
+      "startLine": 55,
+      "endLine": 115
+    },
     "title": "Density Analysis of Allowed Moduli",
     "content": "The density of primes $p$ with $p \\geq 5$ is governed by the prime number theorem: roughly $\\pi(x) \\sim x/\\ln x$ primes up to $x$. The allowed moduli $\\{p - 1 : p \\text{ prime}, p \\geq 5\\}$ have the same density. The sum $\\sum_{p \\geq 5,\\, p \\text{ prime}} \\frac{1}{p-1}$ diverges (since $\\sum 1/p$ diverges), so the reciprocal sum condition $\\sum 1/m_i \\geq 1$ is not the obstruction. The difficulty lies in the covering property itself: arranging residue classes from this sparse set to cover all of $\\mathbb{Z}$.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "analytic number theory / covering systems",
-      "latex": "\\sum_{\\substack{p \\geq 5 \\\\ p \\text{ prime}}} \\frac{1}{p-1} = \\infty",
-      "proofTechnique": "comparison with sum of prime reciprocals via Mertens' theorem",
-      "relatedTheorems": ["Prime number theorem", "Mertens' theorem on $\\sum 1/p$", "Brun's theorem"],
-      "formalizationNote": "Not formalized in the Lean file; included as mathematical context for understanding why the problem is nontrivial despite the density condition being satisfiable.",
-      "crossReferences": ["erdos-273-reciprocal", "erdos-273-conjecture"]
-    }
+    "mathContext": "analytic number theory / covering systems. LaTeX: \\sum_{\\substack{p \\geq 5 \\\\ p \\text{ prime}}} \\frac{1}{p-1} = \\infty. Technique: comparison with sum of prime reciprocals via Mertens' theorem. Not formalized in the Lean file; included as mathematical context for understanding why the problem is nontrivial despite the density condition being satisfiable.. Related: Prime number theorem, Mertens' theorem on $\\sum 1/p$, Brun's theorem. Cross-refs: erdos-273-reciprocal, erdos-273-conjecture"
   },
   {
     "id": "erdos-273-hough-connection",
     "proofId": "erdos-273",
     "type": "context",
-    "range": { "startLine": 88, "endLine": 92 },
+    "range": {
+      "startLine": 88,
+      "endLine": 92
+    },
     "title": "Connection to Hough's Theorem",
     "content": "Hough (2015) proved the Erdős minimum modulus conjecture: the minimum modulus of a distinct covering system is bounded. Specifically, if all moduli are distinct and $> N$, then no covering system exists for $N$ sufficiently large. This implies that Problem 273, if solvable, requires repeated moduli or small moduli from the allowed set. The interaction between Hough's theorem and the prime-minus-one constraint adds a layer of difficulty.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "\\text{Hough (2015): } \\exists N_0,\\, \\text{no distinct covering system with all } m_i > N_0",
-      "proofTechnique": "probabilistic method / Lovász Local Lemma variant",
-      "relatedTheorems": ["Erdős minimum modulus conjecture", "Filaseta–Ford–Konyagin–Pomerance–Yu partial results"],
-      "references": ["Hough, 'Solution of the minimum modulus problem for covering systems', Annals of Mathematics, 2015"],
-      "crossReferences": ["erdos-273-distinct", "erdos-273-obstacles"]
-    }
+    "mathContext": "combinatorial number theory. LaTeX: \\text{Hough (2015): } \\exists N_0,\\, \\text{no distinct covering system with all } m_i > N_0. Technique: probabilistic method / Lovász Local Lemma variant. Related: Erdős minimum modulus conjecture, Filaseta–Ford–Konyagin–Pomerance–Yu partial results. Refs: Hough, 'Solution of the minimum modulus problem for covering systems', Annals of Mathematics, 2015. Cross-refs: erdos-273-distinct, erdos-273-obstacles"
   }
 ]

--- a/src/data/proofs/erdos-405/annotations.json
+++ b/src/data/proofs/erdos-405/annotations.json
@@ -3,388 +3,325 @@
     "id": "erdos-405-intro",
     "proofId": "erdos-405",
     "type": "context",
-    "range": { "startLine": 1, "endLine": 23 },
+    "range": {
+      "startLine": 1,
+      "endLine": 23
+    },
     "title": "Problem Introduction",
     "content": "Erdős Problem #405 asks whether the Diophantine equation $(p-1)! + a^{p-1} = p^k$ has only finitely many solutions for odd primes $p$. The answer is YES: Yu and Liu (1996) proved there are exactly three solutions. The problem sits at the intersection of factorial arithmetic, modular constraints from Wilson's and Fermat's theorems, and Baker's theory of linear forms in logarithms.",
     "significance": "critical",
-    "mathContext": {
-      "field": "analytic number theory / Diophantine equations",
-      "prerequisites": ["Wilson's theorem", "Fermat's little theorem", "p-adic valuations", "Baker's theory of linear forms in logarithms", "Legendre's formula"],
-      "relatedTheorems": ["Brocard's problem (n! + 1 = m²)", "Catalan's conjecture (Mihailescu's theorem)", "ABC conjecture implications for factorial Diophantine equations"],
-      "latex": "(p-1)! + a^{p-1} = p^k"
-    }
+    "mathContext": "analytic number theory / Diophantine equations. LaTeX: (p-1)! + a^{p-1} = p^k. Related: Brocard's problem (n! + 1 = m²), Catalan's conjecture (Mihailescu's theorem), ABC conjecture implications for factorial Diophantine equations. Prerequisites: Wilson's theorem, Fermat's little theorem, p-adic valuations, Baker's theory of linear forms in logarithms, Legendre's formula"
   },
   {
     "id": "erdos-405-solution-structure",
     "proofId": "erdos-405",
     "type": "definition",
-    "range": { "startLine": 41, "endLine": 56 },
+    "range": {
+      "startLine": 41,
+      "endLine": 56
+    },
     "title": "Solution Structure and Predicate",
     "content": "The `Solution` structure packages a triple $(p, a, k)$ together with proof that $p$ is an odd prime and the equation $(p-1)! + a^{p-1} = p^k$ holds. The `IsSolution` predicate provides an equivalent unbundled version: $\\text{IsSolution}(p, a, k) \\iff p \\text{ prime} \\wedge p \\geq 3 \\wedge (p-1)! + a^{p-1} = p^k$.",
     "significance": "key",
-    "mathContext": {
-      "field": "Diophantine equations",
-      "latex": "\\text{IsSolution}(p, a, k) \\iff \\text{Prime}(p) \\wedge p \\geq 3 \\wedge (p-1)! + a^{p-1} = p^k",
-      "leanSignature": "def IsSolution (p a k : ℕ) : Prop := Nat.Prime p ∧ p ≥ 3 ∧ (p - 1).factorial + a ^ (p - 1) = p ^ k",
-      "designChoices": "The bundled `Solution` structure is convenient for set-theoretic reasoning (e.g., finiteness of AllSolutions), while the unbundled `IsSolution` predicate is more ergonomic for case analysis on specific triples."
-    }
+    "mathContext": "Diophantine equations. LaTeX: \\text{IsSolution}(p, a, k) \\iff \\text{Prime}(p) \\wedge p \\geq 3 \\wedge (p-1)! + a^{p-1} = p^k. Lean: def IsSolution (p a k : ℕ) : Prop := Nat.Prime p ∧ p ≥ 3 ∧ (p - 1).factorial + a ^ (p - 1) = p ^ k. Design: The bundled `Solution` structure is convenient for set-theoretic reasoning (e.g., finiteness of AllSolutions), while the unbundled `IsSolution` predicate is more ergonomic for case analysis on specific triples."
   },
   {
     "id": "erdos-405-solution-1",
     "proofId": "erdos-405",
     "type": "theorem",
-    "range": { "startLine": 64, "endLine": 71 },
+    "range": {
+      "startLine": 64,
+      "endLine": 71
+    },
     "title": "First Solution: $(3, 1, 1)$",
     "content": "Verified computationally: $2! + 1^2 = 2 + 1 = 3 = 3^1$. This is the smallest solution — the simplest instance where a factorial-plus-power equals a prime power. The proof is fully automatic via `norm_num` after establishing that 3 is prime.",
     "significance": "key",
-    "mathContext": {
-      "field": "computational verification",
-      "latex": "2! + 1^{2} = 3 = 3^1",
-      "proofTechnique": "The proof splits the conjunction (primality, bound, equation) and dispatches each goal with norm_num. Lean's kernel performs the arithmetic reduction 2! + 1² = 3 = 3¹.",
-      "leanSignature": "theorem solution_1 : IsSolution 3 1 1"
-    }
+    "mathContext": "computational verification. LaTeX: 2! + 1^{2} = 3 = 3^1. Lean: theorem solution_1 : IsSolution 3 1 1. Technique: The proof splits the conjunction (primality, bound, equation) and dispatches each goal with norm_num. Lean's kernel performs the arithmetic reduction 2! + 1² = 3 = 3¹."
   },
   {
     "id": "erdos-405-solution-2",
     "proofId": "erdos-405",
     "type": "theorem",
-    "range": { "startLine": 73, "endLine": 80 },
+    "range": {
+      "startLine": 73,
+      "endLine": 80
+    },
     "title": "Second Solution: $(3, 5, 3)$",
     "content": "Verified computationally: $2! + 5^2 = 2 + 25 = 27 = 3^3$. This shows $p = 3$ admits two different values of $a$, and that the exponent $k$ can exceed 1. The coincidence $2 + 25 = 27$ arises because $5^2 = 25$ is one less than $26$, and $27 = 3^3$ is a perfect cube.",
     "significance": "key",
-    "mathContext": {
-      "field": "computational verification",
-      "latex": "2! + 5^{2} = 27 = 3^3",
-      "relatedTheorems": ["This is related to the near-miss $5^2 + 2 = 3^3$, a small example of the Catalan-type phenomenon where consecutive perfect powers are rare."],
-      "leanSignature": "theorem solution_2 : IsSolution 3 5 3"
-    }
+    "mathContext": "computational verification. LaTeX: 2! + 5^{2} = 27 = 3^3. Lean: theorem solution_2 : IsSolution 3 5 3. Related: This is related to the near-miss $5^2 + 2 = 3^3$, a small example of the Catalan-type phenomenon where consecutive perfect powers are rare."
   },
   {
     "id": "erdos-405-solution-3",
     "proofId": "erdos-405",
     "type": "theorem",
-    "range": { "startLine": 82, "endLine": 89 },
+    "range": {
+      "startLine": 82,
+      "endLine": 89
+    },
     "title": "Third Solution: $(5, 1, 2)$",
     "content": "Verified computationally: $4! + 1^4 = 24 + 1 = 25 = 5^2$. This is the only solution with $p = 5$ and the largest prime contributing a solution. The identity $24 + 1 = 25$ reflects the well-known near-coincidence of $4!$ and $5^2$.",
     "significance": "key",
-    "mathContext": {
-      "field": "computational verification",
-      "latex": "4! + 1^{4} = 25 = 5^2",
-      "relatedTheorems": ["Brocard's problem asks when n! + 1 is a perfect square; here we have the analogous 4! + 1 = 5² which is a Brocard-type coincidence."],
-      "leanSignature": "theorem solution_3 : IsSolution 5 1 2"
-    }
+    "mathContext": "computational verification. LaTeX: 4! + 1^{4} = 25 = 5^2. Lean: theorem solution_3 : IsSolution 5 1 2. Related: Brocard's problem asks when n! + 1 is a perfect square; here we have the analogous 4! + 1 = 5² which is a Brocard-type coincidence."
   },
   {
     "id": "erdos-405-brindza-erdos",
     "proofId": "erdos-405",
     "type": "axiom",
-    "range": { "startLine": 99, "endLine": 101 },
+    "range": {
+      "startLine": 99,
+      "endLine": 101
+    },
     "title": "Brindza–Erdős Finiteness (1991)",
     "content": "Brindza and Erdős (1991) proved that the set of solutions $\\{(p, a, k) : (p-1)! + a^{p-1} = p^k\\}$ is finite. Their proof uses Baker's theory of linear forms in logarithms, which gives effective (though large) upper bounds on solutions to exponential Diophantine equations. This was the first unconditional finiteness result for Problem #405.",
     "significance": "critical",
-    "mathContext": {
-      "field": "transcendental number theory",
-      "latex": "\\#\\{(p, a, k) \\in \\mathbb{N}^3 : \\text{IsSolution}(p, a, k)\\} < \\infty",
-      "proofTechnique": "Baker's method provides bounds of the form max(p, a, k) < C for an effectively computable constant C. The key is to rewrite the equation as a linear form in logarithms and apply Baker's theorem to bound the exponents.",
-      "references": ["B. Brindza and P. Erdős, 'On some Diophantine problems involving powers and factorials', 1991"],
-      "leanSignature": "axiom brindza_erdos_1991 : { (p, a, k) : ℕ × ℕ × ℕ | IsSolution p a k }.Finite",
-      "formalizationNote": "Axiomatized because Baker's method involves deep transcendence theory not yet available in Mathlib. A full formalization would require formalized Baker's theorem."
-    }
+    "mathContext": "transcendental number theory. LaTeX: \\#\\{(p, a, k) \\in \\mathbb{N}^3 : \\text{IsSolution}(p, a, k)\\} < \\infty. Lean: axiom brindza_erdos_1991 : { (p, a, k) : ℕ × ℕ × ℕ | IsSolution p a k }.Finite. Technique: Baker's method provides bounds of the form max(p, a, k) < C for an effectively computable constant C. The key is to rewrite the equation as a linear form in logarithms and apply Baker's theorem to bound the exponents.. Axiomatized because Baker's method involves deep transcendence theory not yet available in Mathlib. A full formalization would require formalized Baker's theorem.. Refs: B. Brindza and P. Erdős, 'On some Diophantine problems involving powers and factorials', 1991"
   },
   {
     "id": "erdos-405-yu-liu",
     "proofId": "erdos-405",
     "type": "axiom",
-    "range": { "startLine": 103, "endLine": 108 },
+    "range": {
+      "startLine": 103,
+      "endLine": 108
+    },
     "title": "Yu–Liu Complete Characterization (1996)",
     "content": "Yu and Liu (1996) achieved a complete resolution: the only solutions to $(p-1)! + a^{p-1} = p^k$ with $p$ an odd prime are exactly $(3,1,1)$, $(3,5,3)$, and $(5,1,2)$. Their proof refines the Brindza–Erdős bound and performs exhaustive case analysis for small primes.",
     "significance": "critical",
-    "mathContext": {
-      "field": "analytic number theory / Diophantine equations",
-      "latex": "\\text{IsSolution}(p, a, k) \\iff (p,a,k) \\in \\{(3,1,1), (3,5,3), (5,1,2)\\}",
-      "proofTechnique": "Yu–Liu's strategy: (1) use refined Baker bounds to show p ≤ B for some explicit B, (2) for each prime p ≤ B, analyze the equation modulo increasing powers of p, (3) use Legendre's formula and factorial growth to eliminate all but p = 3, 5, (4) solve the remaining cases 2 + a² = 3^k and 24 + a⁴ = 5^k by elementary methods.",
-      "references": ["K. Yu and M. Liu, 'On the equation (p-1)! + a^{p-1} = p^k', 1996"],
-      "leanSignature": "axiom yu_liu_1996 : ∀ p a k : ℕ, IsSolution p a k ↔ (p = 3 ∧ a = 1 ∧ k = 1) ∨ (p = 3 ∧ a = 5 ∧ k = 3) ∨ (p = 5 ∧ a = 1 ∧ k = 2)",
-      "formalizationNote": "Axiomatized as the key external result. The forward direction (solutions ⟹ membership in the list) is the deep content; the reverse direction follows from computational verification (solution_1, solution_2, solution_3)."
-    }
+    "mathContext": "analytic number theory / Diophantine equations. LaTeX: \\text{IsSolution}(p, a, k) \\iff (p,a,k) \\in \\{(3,1,1), (3,5,3), (5,1,2)\\}. Lean: axiom yu_liu_1996 : ∀ p a k : ℕ, IsSolution p a k ↔ (p = 3 ∧ a = 1 ∧ k = 1) ∨ (p = 3 ∧ a = 5 ∧ k = 3) ∨ (p = 5 ∧ a = 1 ∧ k = 2). Technique: Yu–Liu's strategy: (1) use refined Baker bounds to show p ≤ B for some explicit B, (2) for each prime p ≤ B, analyze the equation modulo increasing powers of p, (3) use Legendre's formula and factorial growth to eliminate all but p = 3, 5, (4) solve the remaining cases 2 + a² = 3^k and 24 + a⁴ = 5^k by elementary methods.. Axiomatized as the key external result. The forward direction (solutions ⟹ membership in the list) is the deep content; the reverse direction follows from computational verification (solution_1, solution_2, solution_3).. Refs: K. Yu and M. Liu, 'On the equation (p-1)! + a^{p-1} = p^k', 1996"
   },
   {
     "id": "erdos-405-exactly-three",
     "proofId": "erdos-405",
     "type": "axiom",
-    "range": { "startLine": 111, "endLine": 112 },
+    "range": {
+      "startLine": 111,
+      "endLine": 112
+    },
     "title": "Exactly Three Solutions",
     "content": "The solution set has cardinality exactly 3. This follows from the Yu–Liu characterization (which identifies the three solutions) combined with the computational verification that all three triples are distinct.",
     "significance": "key",
-    "mathContext": {
-      "field": "combinatorics / set theory",
-      "latex": "\\#\\{(p, a, k) \\in \\mathbb{N}^3 : \\text{IsSolution}(p, a, k)\\} = 3",
-      "leanSignature": "axiom exactly_three_solutions : { (p, a, k) : ℕ × ℕ × ℕ | IsSolution p a k }.ncard = 3",
-      "formalizationNote": "Could in principle be derived from yu_liu_1996 and the distinctness of the three triples, but axiomatized for convenience."
-    }
+    "mathContext": "combinatorics / set theory. LaTeX: \\#\\{(p, a, k) \\in \\mathbb{N}^3 : \\text{IsSolution}(p, a, k)\\} = 3. Lean: axiom exactly_three_solutions : { (p, a, k) : ℕ × ℕ × ℕ | IsSolution p a k }.ncard = 3. Could in principle be derived from yu_liu_1996 and the distinctness of the three triples, but axiomatized for convenience."
   },
   {
     "id": "erdos-405-wilson",
     "proofId": "erdos-405",
     "type": "axiom",
-    "range": { "startLine": 121, "endLine": 122 },
+    "range": {
+      "startLine": 121,
+      "endLine": 122
+    },
     "title": "Wilson's Theorem",
     "content": "Wilson's theorem: for any prime $p$, $(p-1)! \\equiv -1 \\pmod{p}$. Equivalently, $(p-1)! \\bmod p = p - 1$. This is one of the oldest results in number theory (first proved by Lagrange, 1771) and provides the key modular constraint on the factorial term in Problem #405.",
     "significance": "key",
-    "mathContext": {
-      "field": "elementary number theory",
-      "latex": "(p-1)! \\equiv -1 \\pmod{p}",
-      "relatedTheorems": ["Mathlib's ZMod.wilsons_lemma provides Wilson's theorem in the ZMod formulation"],
-      "proofTechnique": "The classic proof pairs each element of (ℤ/pℤ)× with its inverse; the only self-inverse elements are ±1, so the product of all elements is (−1).",
-      "leanSignature": "axiom wilson_theorem (p : ℕ) (hp : Nat.Prime p) : (p - 1).factorial % p = p - 1",
-      "formalizationNote": "Axiomatized in the natural number formulation. Mathlib has Wilson's theorem for ZMod but the natural number version used here is a straightforward corollary."
-    }
+    "mathContext": "elementary number theory. LaTeX: (p-1)! \\equiv -1 \\pmod{p}. Lean: axiom wilson_theorem (p : ℕ) (hp : Nat.Prime p) : (p - 1).factorial % p = p - 1. Technique: The classic proof pairs each element of (ℤ/pℤ)× with its inverse; the only self-inverse elements are ±1, so the product of all elements is (−1).. Axiomatized in the natural number formulation. Mathlib has Wilson's theorem for ZMod but the natural number version used here is a straightforward corollary.. Related: Mathlib's ZMod.wilsons_lemma provides Wilson's theorem in the ZMod formulation"
   },
   {
     "id": "erdos-405-fermat",
     "proofId": "erdos-405",
     "type": "axiom",
-    "range": { "startLine": 125, "endLine": 126 },
+    "range": {
+      "startLine": 125,
+      "endLine": 126
+    },
     "title": "Fermat's Little Theorem",
     "content": "Fermat's little theorem: if $p$ is prime and $p \\nmid a$, then $a^{p-1} \\equiv 1 \\pmod{p}$. Combined with Wilson's theorem, this yields the crucial divisibility $(p-1)! + a^{p-1} \\equiv 0 \\pmod{p}$, which is necessary for the sum to equal $p^k$.",
     "significance": "key",
-    "mathContext": {
-      "field": "elementary number theory",
-      "latex": "a^{p-1} \\equiv 1 \\pmod{p} \\quad \\text{when } p \\nmid a",
-      "relatedTheorems": ["Euler's theorem (generalization to φ(n))", "Mathlib's ZMod.pow_card_sub_one_eq_one"],
-      "leanSignature": "axiom fermat_little (p a : ℕ) (hp : Nat.Prime p) (ha : ¬p ∣ a) : a ^ (p - 1) % p = 1",
-      "formalizationNote": "Axiomatized in the natural number remainder formulation. Could be derived from Mathlib's ZMod version."
-    }
+    "mathContext": "elementary number theory. LaTeX: a^{p-1} \\equiv 1 \\pmod{p} \\quad \\text{when } p \\nmid a. Lean: axiom fermat_little (p a : ℕ) (hp : Nat.Prime p) (ha : ¬p ∣ a) : a ^ (p - 1) % p = 1. Axiomatized in the natural number remainder formulation. Could be derived from Mathlib's ZMod version.. Related: Euler's theorem (generalization to φ(n)), Mathlib's ZMod.pow_card_sub_one_eq_one"
   },
   {
     "id": "erdos-405-sum-divisible",
     "proofId": "erdos-405",
     "type": "axiom",
-    "range": { "startLine": 129, "endLine": 131 },
+    "range": {
+      "startLine": 129,
+      "endLine": 131
+    },
     "title": "Sum Divisibility by $p$",
     "content": "When $p \\nmid a$, Wilson gives $(p-1)! \\equiv -1 \\pmod{p}$ and Fermat gives $a^{p-1} \\equiv 1 \\pmod{p}$, so their sum satisfies $p \\mid (p-1)! + a^{p-1}$. This is a necessary condition for the sum to equal $p^k$ and explains why the equation can have solutions at all — the modular arithmetic is 'aligned.'",
     "significance": "key",
-    "mathContext": {
-      "field": "modular arithmetic",
-      "latex": "p \\mid \\bigl((p-1)! + a^{p-1}\\bigr) \\quad \\text{when } p \\nmid a",
-      "proofTechnique": "Direct combination: (−1) + 1 = 0 mod p. This is the starting point of the p-adic analysis — knowing the sum is divisible by p, one then asks about higher powers of p.",
-      "leanSignature": "axiom sum_divisible_by_p (p a : ℕ) (hp : Nat.Prime p) (hp3 : p ≥ 3) (ha : ¬p ∣ a) : p ∣ (p - 1).factorial + a ^ (p - 1)"
-    }
+    "mathContext": "modular arithmetic. LaTeX: p \\mid \\bigl((p-1)! + a^{p-1}\\bigr) \\quad \\text{when } p \\nmid a. Lean: axiom sum_divisible_by_p (p a : ℕ) (hp : Nat.Prime p) (hp3 : p ≥ 3) (ha : ¬p ∣ a) : p ∣ (p - 1).factorial + a ^ (p - 1). Technique: Direct combination: (−1) + 1 = 0 mod p. This is the starting point of the p-adic analysis — knowing the sum is divisible by p, one then asks about higher powers of p."
   },
   {
     "id": "erdos-405-divisible-power",
     "proofId": "erdos-405",
     "type": "axiom",
-    "range": { "startLine": 139, "endLine": 140 },
+    "range": {
+      "startLine": 139,
+      "endLine": 140
+    },
     "title": "Exceptional Case: $p \\mid a$ Implies Large Power",
     "content": "If $p \\mid a$, write $a = pm$. Then $a^{p-1} = p^{p-1} m^{p-1}$, so $p^{p-1} \\mid a^{p-1}$. This means the power term $a^{p-1}$ contributes a very large $p$-adic valuation, severely constraining the equation since $v_p((p-1)!) = 0$.",
     "significance": "key",
-    "mathContext": {
-      "field": "p-adic analysis",
-      "latex": "p \\mid a \\implies p^{p-1} \\mid a^{p-1}",
-      "proofTechnique": "If a = pm then a^{p-1} = (pm)^{p-1} = p^{p-1} · m^{p-1}.",
-      "leanSignature": "axiom divisible_implies_large_power (p a : ℕ) (hp : Nat.Prime p) (ha : p ∣ a) : p ^ (p - 1) ∣ a ^ (p - 1)"
-    }
+    "mathContext": "p-adic analysis. LaTeX: p \\mid a \\implies p^{p-1} \\mid a^{p-1}. Lean: axiom divisible_implies_large_power (p a : ℕ) (hp : Nat.Prime p) (ha : p ∣ a) : p ^ (p - 1) ∣ a ^ (p - 1). Technique: If a = pm then a^{p-1} = (pm)^{p-1} = p^{p-1} · m^{p-1}."
   },
   {
     "id": "erdos-405-divisible-analysis",
     "proofId": "erdos-405",
     "type": "axiom",
-    "range": { "startLine": 144, "endLine": 146 },
+    "range": {
+      "startLine": 144,
+      "endLine": 146
+    },
     "title": "Divisible Case Bounds $k$",
     "content": "When $p \\mid a$, the equation $(p-1)! + a^{p-1} = p^k$ forces $k \\leq p-1$. Since $v_p((p-1)!) = 0$, the $p$-adic valuation of the left side equals $\\min(0, v_p(a^{p-1})) = 0$, so $k$ must be 0 — but $k = 0$ gives $(p-1)! + a^{p-1} = 1$ which is impossible for $p \\geq 3$. The stated bound $k \\leq p-1$ is a weaker but useful intermediate constraint.",
     "significance": "key",
-    "mathContext": {
-      "field": "p-adic analysis",
-      "latex": "p \\mid a \\implies k \\leq p - 1",
-      "proofTechnique": "Comparing p-adic valuations on both sides: v_p(LHS) = min(v_p((p-1)!), v_p(a^{p-1})) = min(0, (p-1)·v_p(a)) while v_p(RHS) = k.",
-      "leanSignature": "axiom divisible_case_analysis (p a k : ℕ) ... (ha : p ∣ a) (heq : ...) : k ≤ p - 1"
-    }
+    "mathContext": "p-adic analysis. LaTeX: p \\mid a \\implies k \\leq p - 1. Lean: axiom divisible_case_analysis (p a k : ℕ) ... (ha : p ∣ a) (heq : ...) : k ≤ p - 1. Technique: Comparing p-adic valuations on both sides: v_p(LHS) = min(v_p((p-1)!), v_p(a^{p-1})) = min(0, (p-1)·v_p(a)) while v_p(RHS) = k."
   },
   {
     "id": "erdos-405-padic-val-def",
     "proofId": "erdos-405",
     "type": "definition",
-    "range": { "startLine": 155, "endLine": 156 },
+    "range": {
+      "startLine": 155,
+      "endLine": 156
+    },
     "title": "Factorial $p$-adic Valuation",
     "content": "The $p$-adic valuation of $n!$ is defined via Legendre's formula: $v_p(n!) = \\sum_{i=1}^{\\infty} \\lfloor n/p^i \\rfloor$. In the formalization, this is computed as a finite sum over `Finset.range n` (which is more than enough terms since $\\lfloor n/p^i \\rfloor = 0$ for $p^i > n$).",
     "significance": "key",
-    "mathContext": {
-      "field": "p-adic analysis",
-      "latex": "v_p(n!) = \\sum_{i=1}^{\\infty} \\left\\lfloor \\frac{n}{p^i} \\right\\rfloor",
-      "relatedTheorems": ["Legendre's formula", "Mathlib's padicValNat"],
-      "leanSignature": "noncomputable def factorialPadicVal (p n : ℕ) : ℕ := (Finset.range n).sum fun i => n / p ^ (i + 1)"
-    }
+    "mathContext": "p-adic analysis. LaTeX: v_p(n!) = \\sum_{i=1}^{\\infty} \\left\\lfloor \\frac{n}{p^i} \\right\\rfloor. Lean: noncomputable def factorialPadicVal (p n : ℕ) : ℕ := (Finset.range n).sum fun i => n / p ^ (i + 1). Related: Legendre's formula, Mathlib's padicValNat"
   },
   {
     "id": "erdos-405-legendre",
     "proofId": "erdos-405",
     "type": "axiom",
-    "range": { "startLine": 159, "endLine": 160 },
+    "range": {
+      "startLine": 159,
+      "endLine": 160
+    },
     "title": "Legendre's Formula",
     "content": "Legendre's formula states that the exact power of a prime $p$ dividing $n!$ is $v_p(n!) = \\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor$. This identity connects the combinatorial definition of factorial to $p$-adic analysis and is essential for understanding the $p$-adic structure of the left side of the equation.",
     "significance": "key",
-    "mathContext": {
-      "field": "p-adic analysis / combinatorics",
-      "latex": "v_p(n!) = \\sum_{i=1}^{\\infty} \\left\\lfloor \\frac{n}{p^i} \\right\\rfloor",
-      "references": ["A.M. Legendre, 'Essai sur la théorie des nombres', 1808"],
-      "leanSignature": "axiom legendre_formula (p n : ℕ) (hp : Nat.Prime p) : padicValNat p n.factorial = factorialPadicVal p n"
-    }
+    "mathContext": "p-adic analysis / combinatorics. LaTeX: v_p(n!) = \\sum_{i=1}^{\\infty} \\left\\lfloor \\frac{n}{p^i} \\right\\rfloor. Lean: axiom legendre_formula (p n : ℕ) (hp : Nat.Prime p) : padicValNat p n.factorial = factorialPadicVal p n. Refs: A.M. Legendre, 'Essai sur la théorie des nombres', 1808"
   },
   {
     "id": "erdos-405-factorial-padic-zero",
     "proofId": "erdos-405",
     "type": "axiom",
-    "range": { "startLine": 163, "endLine": 165 },
+    "range": {
+      "startLine": 163,
+      "endLine": 165
+    },
     "title": "$v_p((p-1)!) = 0$",
     "content": "For an odd prime $p$, the $p$-adic valuation of $(p-1)!$ is zero. This is because $(p-1)! = 1 \\cdot 2 \\cdots (p-1)$ and none of $1, 2, \\ldots, p-1$ is divisible by $p$. By Legendre's formula, $v_p((p-1)!) = \\lfloor (p-1)/p \\rfloor + \\lfloor (p-1)/p^2 \\rfloor + \\cdots = 0$. This is the pivotal constraint: the factorial contributes no factors of $p$.",
     "significance": "critical",
-    "mathContext": {
-      "field": "p-adic analysis",
-      "latex": "v_p\\bigl((p-1)!\\bigr) = 0",
-      "proofTechnique": "By Legendre, each term ⌊(p−1)/p^i⌋ = 0 since p−1 < p. So the entire sum is 0.",
-      "leanSignature": "axiom factorial_padic_zero (p : ℕ) (hp : Nat.Prime p) (hp3 : p ≥ 3) : padicValNat p (p - 1).factorial = 0",
-      "formalizationNote": "Direct corollary of Legendre's formula. Could be proved from legendre_formula but axiomatized for directness."
-    }
+    "mathContext": "p-adic analysis. LaTeX: v_p\\bigl((p-1)!\\bigr) = 0. Lean: axiom factorial_padic_zero (p : ℕ) (hp : Nat.Prime p) (hp3 : p ≥ 3) : padicValNat p (p - 1).factorial = 0. Technique: By Legendre, each term ⌊(p−1)/p^i⌋ = 0 since p−1 < p. So the entire sum is 0.. Direct corollary of Legendre's formula. Could be proved from legendre_formula but axiomatized for directness."
   },
   {
     "id": "erdos-405-large-prime",
     "proofId": "erdos-405",
     "type": "axiom",
-    "range": { "startLine": 174, "endLine": 176 },
+    "range": {
+      "startLine": 174,
+      "endLine": 176
+    },
     "title": "No Solutions for $p \\geq 7$",
     "content": "For primes $p \\geq 7$, the equation $(p-1)! + a^{p-1} = p^k$ has no solutions. The factorial $(p-1)!$ grows super-exponentially while $p^k$ grows at most exponentially in $k$, making the equation impossible for large $p$. The critical observation is that $(p-1)! \\geq 720$ for $p \\geq 7$ but $p^k - a^{p-1}$ cannot match this growth rate.",
     "significance": "critical",
-    "mathContext": {
-      "field": "analytic number theory",
-      "latex": "p \\geq 7,\\; p \\text{ prime} \\implies \\neg\\exists\\, a\\, k,\\; (p-1)! + a^{p-1} = p^k",
-      "proofTechnique": "Size comparison: for p ≥ 7, (p−1)! ≥ 6! = 720. If a^{p−1} < p^k then (p−1)! < p^k, giving k > log_p((p−1)!). But then a^{p−1} = p^k − (p−1)! must be positive and large, leading to contradictions with the p-adic constraints.",
-      "leanSignature": "axiom large_prime_no_solution (p a k : ℕ) (hp : Nat.Prime p) (hp7 : p ≥ 7) (heq : ...) : False"
-    }
+    "mathContext": "analytic number theory. LaTeX: p \\geq 7,\\; p \\text{ prime} \\implies \\neg\\exists\\, a\\, k,\\; (p-1)! + a^{p-1} = p^k. Lean: axiom large_prime_no_solution (p a k : ℕ) (hp : Nat.Prime p) (hp7 : p ≥ 7) (heq : ...) : False. Technique: Size comparison: for p ≥ 7, (p−1)! ≥ 6! = 720. If a^{p−1} < p^k then (p−1)! < p^k, giving k > log_p((p−1)!). But then a^{p−1} = p^k − (p−1)! must be positive and large, leading to contradictions with the p-adic constraints."
   },
   {
     "id": "erdos-405-p3-analysis",
     "proofId": "erdos-405",
     "type": "theorem",
-    "range": { "startLine": 179, "endLine": 190 },
+    "range": {
+      "startLine": 179,
+      "endLine": 190
+    },
     "title": "Analysis for $p = 3$: Two Solutions",
     "content": "When $p = 3$, the equation becomes $2 + a^2 = 3^k$. This is solved by extracting the Yu–Liu characterization and performing case analysis. The two solutions are $(a, k) = (1, 1)$ and $(a, k) = (5, 3)$. The proof uses `yu_liu_1996` and `simp`/`norm_num` to dispatch the cases.",
     "significance": "key",
-    "mathContext": {
-      "field": "Diophantine equations",
-      "latex": "2 + a^2 = 3^k \\implies (a, k) \\in \\{(1, 1), (5, 3)\\}",
-      "proofTechnique": "The proof appeals to the axiomatized Yu–Liu result, rewrites with the hypothesis, and uses rcases to split into three disjunctive branches — two yield the desired conclusions, and the third (p = 5) is eliminated by norm_num since p = 3 ≠ 5.",
-      "relatedTheorems": ["Ramanujan–Nagell equation x² + 7 = 2^n has a similar flavor of exponential Diophantine equations with finitely many solutions"],
-      "leanSignature": "theorem p_equals_3_analysis : ∀ a k : ℕ, IsSolution 3 a k → (a = 1 ∧ k = 1) ∨ (a = 5 ∧ k = 3)"
-    }
+    "mathContext": "Diophantine equations. LaTeX: 2 + a^2 = 3^k \\implies (a, k) \\in \\{(1, 1), (5, 3)\\}. Lean: theorem p_equals_3_analysis : ∀ a k : ℕ, IsSolution 3 a k → (a = 1 ∧ k = 1) ∨ (a = 5 ∧ k = 3). Technique: The proof appeals to the axiomatized Yu–Liu result, rewrites with the hypothesis, and uses rcases to split into three disjunctive branches — two yield the desired conclusions, and the third (p = 5) is eliminated by norm_num since p = 3 ≠ 5.. Related: Ramanujan–Nagell equation x² + 7 = 2^n has a similar flavor of exponential Diophantine equations with finitely many solutions"
   },
   {
     "id": "erdos-405-p5-analysis",
     "proofId": "erdos-405",
     "type": "theorem",
-    "range": { "startLine": 192, "endLine": 202 },
+    "range": {
+      "startLine": 192,
+      "endLine": 202
+    },
     "title": "Analysis for $p = 5$: One Solution",
     "content": "When $p = 5$, the equation becomes $24 + a^4 = 5^k$. The unique solution is $(a, k) = (1, 2)$. No other fourth power plus 24 yields a power of 5. The proof mirrors the $p = 3$ case, using the Yu–Liu characterization and eliminating the $p = 3$ branches.",
     "significance": "key",
-    "mathContext": {
-      "field": "Diophantine equations",
-      "latex": "24 + a^4 = 5^k \\implies (a, k) = (1, 2)",
-      "proofTechnique": "Same rcases strategy as p = 3 analysis. The two p = 3 branches are eliminated by norm_num (since 5 ≠ 3), leaving only the p = 5 branch.",
-      "relatedTheorems": ["The equation a⁴ + 24 = 5^k is related to the problem of representing powers of 5 as sums involving fourth powers"],
-      "leanSignature": "theorem p_equals_5_analysis : ∀ a k : ℕ, IsSolution 5 a k → a = 1 ∧ k = 2"
-    }
+    "mathContext": "Diophantine equations. LaTeX: 24 + a^4 = 5^k \\implies (a, k) = (1, 2). Lean: theorem p_equals_5_analysis : ∀ a k : ℕ, IsSolution 5 a k → a = 1 ∧ k = 2. Technique: Same rcases strategy as p = 3 analysis. The two p = 3 branches are eliminated by norm_num (since 5 ≠ 3), leaving only the p = 5 branch.. Related: The equation a⁴ + 24 = 5^k is related to the problem of representing powers of 5 as sums involving fourth powers"
   },
   {
     "id": "erdos-405-perfect-power-def",
     "proofId": "erdos-405",
     "type": "definition",
-    "range": { "startLine": 210, "endLine": 211 },
+    "range": {
+      "startLine": 210,
+      "endLine": 211
+    },
     "title": "Perfect Power Predicate",
     "content": "A natural number $n$ is a perfect power if $n = b^k$ for some $b, k$ with $k \\geq 2$. The Erdős–Graham remark concerns the broader question of when $(p-1)! + a^{p-1}$ is a perfect power, not necessarily a power of $p$ specifically.",
     "significance": "key",
-    "mathContext": {
-      "field": "number theory",
-      "latex": "\\text{IsPerfectPower}(n) \\iff \\exists\\, b, k \\geq 2,\\; n = b^k",
-      "relatedTheorems": ["Catalan's conjecture (proved by Mihailescu): the only perfect powers differing by 1 are 8 and 9"],
-      "leanSignature": "def IsPerfectPower (n : ℕ) : Prop := ∃ b k : ℕ, k ≥ 2 ∧ n = b ^ k"
-    }
+    "mathContext": "number theory. LaTeX: \\text{IsPerfectPower}(n) \\iff \\exists\\, b, k \\geq 2,\\; n = b^k. Lean: def IsPerfectPower (n : ℕ) : Prop := ∃ b k : ℕ, k ≥ 2 ∧ n = b ^ k. Related: Catalan's conjecture (proved by Mihailescu): the only perfect powers differing by 1 are 8 and 9"
   },
   {
     "id": "erdos-405-example",
     "proofId": "erdos-405",
     "type": "theorem",
-    "range": { "startLine": 214, "endLine": 216 },
+    "range": {
+      "startLine": 214,
+      "endLine": 216
+    },
     "title": "Example: $6! + 2^6 = 28^2$",
     "content": "Erdős and Graham noted that $6! + 2^6 = 720 + 64 = 784 = 28^2$ is a perfect square. This example shows that $(p-1)! + a^{p-1}$ can be a perfect power even outside the $p$-prime-power constraint of Problem #405 (here the base is 28, not a prime). The proof is by `norm_num`.",
     "significance": "key",
-    "mathContext": {
-      "field": "computational verification",
-      "latex": "6! + 2^6 = 720 + 64 = 784 = 28^2",
-      "relatedTheorems": ["This is not of the form p^k for a prime p, showing the perfect-power question is distinct from Problem #405"],
-      "leanSignature": "theorem example_perfect_power : 6.factorial + 2 ^ 6 = 28 ^ 2"
-    }
+    "mathContext": "computational verification. LaTeX: 6! + 2^6 = 720 + 64 = 784 = 28^2. Lean: theorem example_perfect_power : 6.factorial + 2 ^ 6 = 28 ^ 2. Related: This is not of the form p^k for a prime p, showing the perfect-power question is distinct from Problem #405"
   },
   {
     "id": "erdos-405-erdos-graham-conjecture",
     "proofId": "erdos-405",
     "type": "axiom",
-    "range": { "startLine": 221, "endLine": 223 },
+    "range": {
+      "startLine": 221,
+      "endLine": 223
+    },
     "title": "Erdős–Graham Conjecture (Generalized)",
     "content": "Erdős and Graham conjectured more broadly that for $p \\geq 7$, $(p-1)! + a^{p-1}$ is never a power of $p$ with exponent $k \\geq 2$. This is a strengthening of Problem #405 that addresses the perfect-power aspect more directly. The formalization captures this as: for all $p \\geq 7$ prime and $k \\geq 2$, $(p-1)! + a^{p-1} \\neq p^k$.",
     "significance": "key",
-    "mathContext": {
-      "field": "open problems in number theory",
-      "latex": "p \\geq 7,\\; p \\text{ prime},\\; k \\geq 2 \\implies (p-1)! + a^{p-1} \\neq p^k",
-      "relatedTheorems": ["This is related to the broader 'factorial Diophantine equation' literature"],
-      "leanSignature": "axiom erdos_graham_conjecture : ∀ p : ℕ, Nat.Prime p → p ≥ 7 → ∀ a k : ℕ, k ≥ 2 → (p - 1).factorial + a ^ (p - 1) ≠ (p ^ k)",
-      "formalizationNote": "This strengthened conjecture is axiomatized as it represents an open or very difficult problem beyond the scope of Problem #405."
-    }
+    "mathContext": "open problems in number theory. LaTeX: p \\geq 7,\\; p \\text{ prime},\\; k \\geq 2 \\implies (p-1)! + a^{p-1} \\neq p^k. Lean: axiom erdos_graham_conjecture : ∀ p : ℕ, Nat.Prime p → p ≥ 7 → ∀ a k : ℕ, k ≥ 2 → (p - 1).factorial + a ^ (p - 1) ≠ (p ^ k). This strengthened conjecture is axiomatized as it represents an open or very difficult problem beyond the scope of Problem #405.. Related: This is related to the broader 'factorial Diophantine equation' literature"
   },
   {
     "id": "erdos-405-main-statement",
     "proofId": "erdos-405",
     "type": "theorem",
-    "range": { "startLine": 229, "endLine": 238 },
+    "range": {
+      "startLine": 229,
+      "endLine": 238
+    },
     "title": "Main Theorem: Erdős Problem #405",
     "content": "The complete formalization of Erdős Problem #405: (1) the solution set $\\{(p,a,k) : (p-1)! + a^{p-1} = p^k\\}$ is finite (Brindza–Erdős 1991), and (2) a solution exists if and only if $(p,a,k) \\in \\{(3,1,1), (3,5,3), (5,1,2)\\}$ (Yu–Liu 1996). The proof directly combines the two axiomatized external results.",
     "significance": "critical",
-    "mathContext": {
-      "field": "Diophantine equations",
-      "latex": "\\{(p,a,k) : (p-1)!+a^{p-1}=p^k\\} \\text{ is finite, and equals } \\{(3,1,1),(3,5,3),(5,1,2)\\}",
-      "proofTechnique": "Direct conjunction of brindza_erdos_1991 and yu_liu_1996.",
-      "crossReferences": ["erdos-405-brindza-erdos", "erdos-405-yu-liu"],
-      "leanSignature": "theorem erdos_405_statement : ... .Finite ∧ (∀ p a k, IsSolution p a k ↔ ...)"
-    }
+    "mathContext": "Diophantine equations. LaTeX: \\{(p,a,k) : (p-1)!+a^{p-1}=p^k\\} \\text{ is finite, and equals } \\{(3,1,1),(3,5,3),(5,1,2)\\}. Lean: theorem erdos_405_statement : ... .Finite ∧ (∀ p a k, IsSolution p a k ↔ ...). Technique: Direct conjunction of brindza_erdos_1991 and yu_liu_1996.. Cross-refs: erdos-405-brindza-erdos, erdos-405-yu-liu"
   },
   {
     "id": "erdos-405-summary",
     "proofId": "erdos-405",
     "type": "theorem",
-    "range": { "startLine": 244, "endLine": 258 },
+    "range": {
+      "startLine": 244,
+      "endLine": 258
+    },
     "title": "Summary: Existence and Uniqueness",
     "content": "The summary theorem combines both directions: (existence) all three triples satisfy the equation, verified computationally via `solution_1`, `solution_2`, `solution_3`; and (uniqueness) every solution is one of these three, via the Yu–Liu characterization. This provides a complete 'if and only if' in a user-friendly form.",
     "significance": "critical",
-    "mathContext": {
-      "field": "Diophantine equations",
-      "latex": "\\text{IsSolution}(3,1,1) \\wedge \\text{IsSolution}(3,5,3) \\wedge \\text{IsSolution}(5,1,2) \\wedge \\forall\\, p\\, a\\, k,\\; \\text{IsSolution}(p,a,k) \\implies (p,a,k) \\in \\{\\ldots\\}",
-      "proofTechnique": "The existence half uses the three computational verifications. The uniqueness half extracts the forward implication from yu_liu_1996.",
-      "crossReferences": ["erdos-405-solution-1", "erdos-405-solution-2", "erdos-405-solution-3", "erdos-405-yu-liu"],
-      "leanSignature": "theorem erdos_405_summary : IsSolution 3 1 1 ∧ IsSolution 3 5 3 ∧ IsSolution 5 1 2 ∧ (∀ p a k, IsSolution p a k → ...)"
-    }
+    "mathContext": "Diophantine equations. LaTeX: \\text{IsSolution}(3,1,1) \\wedge \\text{IsSolution}(3,5,3) \\wedge \\text{IsSolution}(5,1,2) \\wedge \\forall\\, p\\, a\\, k,\\; \\text{IsSolution}(p,a,k) \\implies (p,a,k) \\in \\{\\ldots\\}. Lean: theorem erdos_405_summary : IsSolution 3 1 1 ∧ IsSolution 3 5 3 ∧ IsSolution 5 1 2 ∧ (∀ p a k, IsSolution p a k → ...). Technique: The existence half uses the three computational verifications. The uniqueness half extracts the forward implication from yu_liu_1996.. Cross-refs: erdos-405-solution-1, erdos-405-solution-2, erdos-405-solution-3, erdos-405-yu-liu"
   },
   {
     "id": "erdos-405-final",
     "proofId": "erdos-405",
     "type": "theorem",
-    "range": { "startLine": 263, "endLine": 267 },
+    "range": {
+      "startLine": 263,
+      "endLine": 267
+    },
     "title": "Final Statement: `erdos_405`",
     "content": "The canonical theorem `erdos_405` states that the solution set is finite and completely characterized. This is a term-mode proof: `⟨brindza_erdos_1991, yu_liu_1996⟩`, directly pairing the two axioms. This concise formulation serves as the definitive Lean statement of the result.",
     "significance": "critical",
-    "mathContext": {
-      "field": "Diophantine equations",
-      "latex": "\\text{erdos\\_405} : \\text{Finite}(S) \\wedge \\text{CharacterizedBy}(S, \\{(3,1,1),(3,5,3),(5,1,2)\\})",
-      "proofTechnique": "Term-mode anonymous constructor pairing the finiteness axiom with the characterization axiom.",
-      "leanSignature": "theorem erdos_405 : ... := ⟨brindza_erdos_1991, yu_liu_1996⟩"
-    }
+    "mathContext": "Diophantine equations. LaTeX: \\text{erdos\\_405} : \\text{Finite}(S) \\wedge \\text{CharacterizedBy}(S, \\{(3,1,1),(3,5,3),(5,1,2)\\}). Lean: theorem erdos_405 : ... := ⟨brindza_erdos_1991, yu_liu_1996⟩. Technique: Term-mode anonymous constructor pairing the finiteness axiom with the characterization axiom."
   }
 ]

--- a/src/data/proofs/erdos-406/annotations.json
+++ b/src/data/proofs/erdos-406/annotations.json
@@ -3,195 +3,169 @@
     "id": "erdos-406-header",
     "proofId": "erdos-406",
     "type": "context",
-    "range": { "startLine": 1, "endLine": 16 },
+    "range": {
+      "startLine": 1,
+      "endLine": 16
+    },
     "title": "Problem Background",
     "content": "Erdős Problem #406 asks whether only finitely many powers of 2 have base-3 representations using only digits 0 and 1. Such numbers are simultaneously powers of 2 and sums of distinct powers of 3, living at the intersection of two multiplicatively independent exponential sequences. Only three examples are known: $1 = 2^0$, $4 = 2^2 = 1 + 3$, and $256 = 2^8 = 1 + 3 + 9 + 243$. Saye (2022) verified no further examples exist for $2^n$ with $n \\leq 5.9 \\times 10^{21}$.",
     "significance": "critical",
-    "mathContext": {
-      "field": "number theory / digit problems / S-unit equations",
-      "prerequisites": ["base-b digit representations", "S-unit equations", "linear forms in logarithms", "multiplicative independence"],
-      "relatedTheorems": ["S-unit equation theorem (Evertse–Schlickewei)", "ABC conjecture", "Ridout's theorem on p-adic approximation", "Skolem–Mahler–Lech theorem"],
-      "latex": "\\#\\{k \\in \\mathbb{N} : \\text{digits}_3(2^k) \\subseteq \\{0,1\\}\\} < \\infty?"
-    }
+    "mathContext": "number theory / digit problems / S-unit equations. LaTeX: \\#\\{k \\in \\mathbb{N} : \\text{digits}_3(2^k) \\subseteq \\{0,1\\}\\} < \\infty?. Related: S-unit equation theorem (Evertse–Schlickewei), ABC conjecture, Ridout's theorem on p-adic approximation, Skolem–Mahler–Lech theorem. Prerequisites: base-b digit representations, S-unit equations, linear forms in logarithms, multiplicative independence"
   },
   {
     "id": "erdos-406-digit-01",
     "proofId": "erdos-406",
     "type": "definition",
-    "range": { "startLine": 25, "endLine": 27 },
+    "range": {
+      "startLine": 25,
+      "endLine": 27
+    },
     "title": "HasOnlyDigits01Base3",
     "content": "Predicate asserting that all base-3 digits of $n$ belong to $\\{0, 1\\}$. Equivalently, $n$ is a sum of distinct powers of 3 (a 'ternary-sparse' number). The definition uses `Nat.digits 3 n` which returns the little-endian list of base-3 digits.",
     "significance": "key",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "\\text{HasOnlyDigits01Base3}(n) \\iff \\forall d \\in \\text{digits}_3(n),\\; d \\in \\{0, 1\\}",
-      "leanSignature": "def HasOnlyDigits01Base3 (n : ℕ) : Prop := ∀ d ∈ Nat.digits 3 n, d = 0 ∨ d = 1",
-      "relatedTheorems": ["These are exactly the numbers representable in 'base 3 without carries', analogous to how binary numbers use only {0,1} digits"]
-    }
+    "mathContext": "combinatorial number theory. LaTeX: \\text{HasOnlyDigits01Base3}(n) \\iff \\forall d \\in \\text{digits}_3(n),\\; d \\in \\{0, 1\\}. Lean: def HasOnlyDigits01Base3 (n : ℕ) : Prop := ∀ d ∈ Nat.digits 3 n, d = 0 ∨ d = 1. Related: These are exactly the numbers representable in 'base 3 without carries', analogous to how binary numbers use only {0,1} digits"
   },
   {
     "id": "erdos-406-digit-12",
     "proofId": "erdos-406",
     "type": "definition",
-    "range": { "startLine": 30, "endLine": 31 },
+    "range": {
+      "startLine": 30,
+      "endLine": 31
+    },
     "title": "HasOnlyDigits12Base3",
     "content": "Predicate asserting that all base-3 digits of $n$ belong to $\\{1, 2\\}$. This defines 'ternary-dense' numbers — every ternary digit position is nonzero, so the number is at least $1 + 3 + 9 + \\cdots$ for its digit length.",
     "significance": "key",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "\\text{HasOnlyDigits12Base3}(n) \\iff \\forall d \\in \\text{digits}_3(n),\\; d \\in \\{1, 2\\}",
-      "leanSignature": "def HasOnlyDigits12Base3 (n : ℕ) : Prop := ∀ d ∈ Nat.digits 3 n, d = 1 ∨ d = 2"
-    }
+    "mathContext": "combinatorial number theory. LaTeX: \\text{HasOnlyDigits12Base3}(n) \\iff \\forall d \\in \\text{digits}_3(n),\\; d \\in \\{1, 2\\}. Lean: def HasOnlyDigits12Base3 (n : ℕ) : Prop := ∀ d ∈ Nat.digits 3 n, d = 1 ∨ d = 2"
   },
   {
     "id": "erdos-406-ternary-sparse",
     "proofId": "erdos-406",
     "type": "definition",
-    "range": { "startLine": 34, "endLine": 35 },
+    "range": {
+      "startLine": 34,
+      "endLine": 35
+    },
     "title": "ternarySparse: Powers of 2 with Digits $\\{0,1\\}$",
     "content": "The set $\\{n \\in \\mathbb{N} : n = 2^k \\text{ for some } k \\text{ and } \\text{digits}_3(n) \\subseteq \\{0,1\\}\\}$. This is the intersection of two exponentially growing but multiplicatively independent sets: powers of 2 and sums of distinct powers of 3. The central conjecture is that this intersection is finite.",
     "significance": "critical",
-    "mathContext": {
-      "field": "S-unit equations",
-      "latex": "\\text{ternarySparse} = \\{2^k : k \\in \\mathbb{N},\\; \\text{digits}_3(2^k) \\subseteq \\{0,1\\}\\}",
-      "leanSignature": "def ternarySparse : Set ℕ := { n | ∃ k : ℕ, n = 2 ^ k ∧ HasOnlyDigits01Base3 n }",
-      "relatedTheorems": ["The finiteness can be reformulated as an S-unit equation: 2^k = ε₁·3^{a₁} + ε₂·3^{a₂} + ... with εᵢ ∈ {0,1} has finitely many solutions, related to the S-unit theorem of Evertse."]
-    }
+    "mathContext": "S-unit equations. LaTeX: \\text{ternarySparse} = \\{2^k : k \\in \\mathbb{N},\\; \\text{digits}_3(2^k) \\subseteq \\{0,1\\}\\}. Lean: def ternarySparse : Set ℕ := { n | ∃ k : ℕ, n = 2 ^ k ∧ HasOnlyDigits01Base3 n }. Related: The finiteness can be reformulated as an S-unit equation: 2^k = ε₁·3^{a₁} + ε₂·3^{a₂} + ... with εᵢ ∈ {0,1} has finitely many solutions, related to the S-unit theorem of Evertse."
   },
   {
     "id": "erdos-406-ternary-dense",
     "proofId": "erdos-406",
     "type": "definition",
-    "range": { "startLine": 38, "endLine": 39 },
+    "range": {
+      "startLine": 38,
+      "endLine": 39
+    },
     "title": "ternaryDense: Powers of 2 with Digits $\\{1,2\\}$",
     "content": "The set of powers of 2 whose base-3 representation uses only digits 1 and 2. The variant conjecture asserts that $2^{15} = 32768$ is the largest member.",
     "significance": "key",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "\\text{ternaryDense} = \\{2^k : k \\in \\mathbb{N},\\; \\text{digits}_3(2^k) \\subseteq \\{1,2\\}\\}",
-      "leanSignature": "def ternaryDense : Set ℕ := { n | ∃ k : ℕ, n = 2 ^ k ∧ HasOnlyDigits12Base3 n }"
-    }
+    "mathContext": "combinatorial number theory. LaTeX: \\text{ternaryDense} = \\{2^k : k \\in \\mathbb{N},\\; \\text{digits}_3(2^k) \\subseteq \\{1,2\\}\\}. Lean: def ternaryDense : Set ℕ := { n | ∃ k : ℕ, n = 2 ^ k ∧ HasOnlyDigits12Base3 n }"
   },
   {
     "id": "erdos-406-conjecture",
     "proofId": "erdos-406",
     "type": "conjecture",
-    "range": { "startLine": 43, "endLine": 45 },
+    "range": {
+      "startLine": 43,
+      "endLine": 45
+    },
     "title": "Main Conjecture: Finiteness of ternarySparse",
     "content": "Erdős Problem #406: the set `ternarySparse` is finite. This is equivalent to asking whether there are only finitely many $k$ such that $2^k$ can be written as a sum of distinct powers of 3. The problem remains OPEN despite massive computational verification. A positive answer would follow from sufficiently strong forms of the ABC conjecture.",
     "significance": "critical",
-    "mathContext": {
-      "field": "open problems in number theory",
-      "latex": "\\text{ternarySparse.Finite} \\iff \\#\\{k : 2^k = \\sum_{i \\in S} 3^i,\\; S \\text{ finite}\\} < \\infty",
-      "leanSignature": "def ErdosProblem406 : Prop := ternarySparse.Finite",
-      "relatedTheorems": ["ABC conjecture would imply that for large k, 2^k has many distinct prime factors in its base-3 representation, making all-{0,1} digits impossible", "Ridout's theorem gives weaker results on digit distribution"],
-      "formalizationNote": "Stated as a Prop definition rather than a theorem, since the problem is open."
-    }
+    "mathContext": "open problems in number theory. LaTeX: \\text{ternarySparse.Finite} \\iff \\#\\{k : 2^k = \\sum_{i \\in S} 3^i,\\; S \\text{ finite}\\} < \\infty. Lean: def ErdosProblem406 : Prop := ternarySparse.Finite. Stated as a Prop definition rather than a theorem, since the problem is open.. Related: ABC conjecture would imply that for large k, 2^k has many distinct prime factors in its base-3 representation, making all-{0,1} digits impossible, Ridout's theorem gives weaker results on digit distribution"
   },
   {
     "id": "erdos-406-variant",
     "proofId": "erdos-406",
     "type": "conjecture",
-    "range": { "startLine": 49, "endLine": 51 },
+    "range": {
+      "startLine": 49,
+      "endLine": 51
+    },
     "title": "Variant: $2^{15}$ is the Largest with Digits $\\{1,2\\}$",
     "content": "The variant conjecture states that $2^{15} = 32768$ is the greatest power of 2 whose base-3 representation uses only digits 1 and 2. In base 3, $32768 = 1122221122_3$. This is formalized as: $2^k \\in \\text{ternaryDense} \\implies 2^k \\leq 2^{15}$.",
     "significance": "key",
-    "mathContext": {
-      "field": "open problems in number theory",
-      "latex": "2^k \\in \\text{ternaryDense} \\implies k \\leq 15",
-      "leanSignature": "def ErdosProblem406_variant : Prop := ∀ k : ℕ, 2 ^ k ∈ ternaryDense → 2 ^ k ≤ 2 ^ 15",
-      "formalizationNote": "Also open, supported by Saye's computation."
-    }
+    "mathContext": "open problems in number theory. LaTeX: 2^k \\in \\text{ternaryDense} \\implies k \\leq 15. Lean: def ErdosProblem406_variant : Prop := ∀ k : ℕ, 2 ^ k ∈ ternaryDense → 2 ^ k ≤ 2 ^ 15. Also open, supported by Saye's computation."
   },
   {
     "id": "erdos-406-example-1",
     "proofId": "erdos-406",
     "type": "axiom",
-    "range": { "startLine": 55, "endLine": 56 },
+    "range": {
+      "startLine": 55,
+      "endLine": 56
+    },
     "title": "Known Example: $1 = 2^0$",
     "content": "The number $1 = 2^0$ has base-3 representation $[1]$, which uses only digits 0 and 1. This is the trivial example — every number system represents 1 with a single digit 1.",
     "significance": "key",
-    "mathContext": {
-      "field": "computational verification",
-      "latex": "1 = 2^0 = 3^0 \\in \\text{ternarySparse}",
-      "leanSignature": "axiom one_in_ternarySparse : (1 : ℕ) ∈ ternarySparse",
-      "formalizationNote": "Axiomatized rather than proved; could be verified by native_decide or norm_num on digit computation."
-    }
+    "mathContext": "computational verification. LaTeX: 1 = 2^0 = 3^0 \\in \\text{ternarySparse}. Lean: axiom one_in_ternarySparse : (1 : ℕ) ∈ ternarySparse. Axiomatized rather than proved; could be verified by native_decide or norm_num on digit computation."
   },
   {
     "id": "erdos-406-example-4",
     "proofId": "erdos-406",
     "type": "axiom",
-    "range": { "startLine": 58, "endLine": 59 },
+    "range": {
+      "startLine": 58,
+      "endLine": 59
+    },
     "title": "Known Example: $4 = 2^2$",
     "content": "The number $4 = 2^2$ has base-3 representation $[1, 1]_3 = 1 + 3$. This is a sum of two distinct powers of 3, confirming membership in ternarySparse.",
     "significance": "key",
-    "mathContext": {
-      "field": "computational verification",
-      "latex": "4 = 2^2 = 3^0 + 3^1 \\in \\text{ternarySparse}",
-      "leanSignature": "axiom four_in_ternarySparse : (4 : ℕ) ∈ ternarySparse"
-    }
+    "mathContext": "computational verification. LaTeX: 4 = 2^2 = 3^0 + 3^1 \\in \\text{ternarySparse}. Lean: axiom four_in_ternarySparse : (4 : ℕ) ∈ ternarySparse"
   },
   {
     "id": "erdos-406-example-256",
     "proofId": "erdos-406",
     "type": "axiom",
-    "range": { "startLine": 61, "endLine": 62 },
+    "range": {
+      "startLine": 61,
+      "endLine": 62
+    },
     "title": "Known Example: $256 = 2^8$",
     "content": "The number $256 = 2^8$ has base-3 representation $[1, 1, 1, 0, 0, 1]_3 = 1 + 3 + 9 + 243 = 256$. This is the largest known element of ternarySparse. The gap between this and Saye's verified range ($n \\leq 5.9 \\times 10^{21}$) gives strong evidence for finiteness.",
     "significance": "key",
-    "mathContext": {
-      "field": "computational verification",
-      "latex": "256 = 2^8 = 3^0 + 3^1 + 3^2 + 3^5 \\in \\text{ternarySparse}",
-      "leanSignature": "axiom pow2_8_in_ternarySparse : (256 : ℕ) ∈ ternarySparse",
-      "relatedTheorems": ["The decomposition 256 = 1 + 3 + 9 + 243 uses four powers of 3 from a pool of six ternary digit positions"]
-    }
+    "mathContext": "computational verification. LaTeX: 256 = 2^8 = 3^0 + 3^1 + 3^2 + 3^5 \\in \\text{ternarySparse}. Lean: axiom pow2_8_in_ternarySparse : (256 : ℕ) ∈ ternarySparse. Related: The decomposition 256 = 1 + 3 + 9 + 243 uses four powers of 3 from a pool of six ternary digit positions"
   },
   {
     "id": "erdos-406-saye",
     "proofId": "erdos-406",
     "type": "axiom",
-    "range": { "startLine": 66, "endLine": 71 },
+    "range": {
+      "startLine": 66,
+      "endLine": 71
+    },
     "title": "Saye's Computation (2022)",
     "content": "Saye (2022) verified computationally that for all $16 \\leq n \\leq 5.9 \\times 10^{21}$, the number $2^n$ contains all three ternary digits $\\{0, 1, 2\\}$. This eliminates membership in both ternarySparse and ternaryDense for this enormous range, providing overwhelming computational evidence for both conjectures.",
     "significance": "critical",
-    "mathContext": {
-      "field": "computational number theory",
-      "latex": "\\forall n \\in [16, 5.9 \\times 10^{21}],\\; \\{0,1,2\\} \\subseteq \\text{digits}_3(2^n)",
-      "proofTechnique": "Saye's method uses modular arithmetic and efficient base-3 digit extraction. The verification does not require computing the full decimal expansion of 2^n — only the ternary digits, which can be computed incrementally.",
-      "references": ["R. Saye, 'On the ternary digits of powers of 2', 2022"],
-      "leanSignature": "axiom saye_computation : ∀ n : ℕ, 16 ≤ n → n ≤ 59 * 10 ^ 20 → ¬HasOnlyDigits01Base3 (2 ^ n) ∧ ¬HasOnlyDigits12Base3 (2 ^ n)",
-      "formalizationNote": "Axiomatized as computational evidence. The bound 59 * 10^20 approximates 5.9 × 10²¹."
-    }
+    "mathContext": "computational number theory. LaTeX: \\forall n \\in [16, 5.9 \\times 10^{21}],\\; \\{0,1,2\\} \\subseteq \\text{digits}_3(2^n). Lean: axiom saye_computation : ∀ n : ℕ, 16 ≤ n → n ≤ 59 * 10 ^ 20 → ¬HasOnlyDigits01Base3 (2 ^ n) ∧ ¬HasOnlyDigits12Base3 (2 ^ n). Technique: Saye's method uses modular arithmetic and efficient base-3 digit extraction. The verification does not require computing the full decimal expansion of 2^n — only the ternary digits, which can be computed incrementally.. Axiomatized as computational evidence. The bound 59 * 10^20 approximates 5.9 × 10²¹.. Refs: R. Saye, 'On the ternary digits of powers of 2', 2022"
   },
   {
     "id": "erdos-406-sum-of-powers",
     "proofId": "erdos-406",
     "type": "axiom",
-    "range": { "startLine": 75, "endLine": 78 },
+    "range": {
+      "startLine": 75,
+      "endLine": 78
+    },
     "title": "Digits $\\{0,1\\}$ Equals Sum of Distinct Powers of 3",
     "content": "Numbers with base-3 digits in $\\{0, 1\\}$ are exactly the sums of distinct powers of 3, i.e., subset sums of the geometric progression $\\{1, 3, 9, 27, \\ldots\\}$. This is analogous to how binary representations correspond to subset sums of powers of 2. The question thus asks: which powers of 2 are subset sums of powers of 3?",
     "significance": "key",
-    "mathContext": {
-      "field": "additive combinatorics",
-      "latex": "\\text{HasOnlyDigits01Base3}(n) \\iff \\exists\\, S \\subseteq \\mathbb{N} \\text{ finite},\\; n = \\sum_{i \\in S} 3^i",
-      "leanSignature": "axiom digits01_sum_of_powers (n : ℕ) (h : HasOnlyDigits01Base3 n) : ∃ S : Finset ℕ, n = S.sum (3 ^ ·)",
-      "relatedTheorems": ["These are the elements of the Cantor set (when viewed as {0,1}-digit base-3 numbers in [0,1]) scaled to the integers"]
-    }
+    "mathContext": "additive combinatorics. LaTeX: \\text{HasOnlyDigits01Base3}(n) \\iff \\exists\\, S \\subseteq \\mathbb{N} \\text{ finite},\\; n = \\sum_{i \\in S} 3^i. Lean: axiom digits01_sum_of_powers (n : ℕ) (h : HasOnlyDigits01Base3 n) : ∃ S : Finset ℕ, n = S.sum (3 ^ ·). Related: These are the elements of the Cantor set (when viewed as {0,1}-digit base-3 numbers in [0,1]) scaled to the integers"
   },
   {
     "id": "erdos-406-zero",
     "proofId": "erdos-406",
     "type": "axiom",
-    "range": { "startLine": 80, "endLine": 82 },
+    "range": {
+      "startLine": 80,
+      "endLine": 82
+    },
     "title": "Zero Has Only Digits $\\{0,1\\}$",
     "content": "The base-3 representation of 0 is the empty list, so the predicate $\\forall d \\in \\text{digits}_3(0),\\; d \\in \\{0,1\\}$ is vacuously true. This is a boundary case establishing the predicate's behavior at 0.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "foundational",
-      "latex": "\\text{HasOnlyDigits01Base3}(0)",
-      "leanSignature": "axiom zero_hasOnlyDigits01 : HasOnlyDigits01Base3 0",
-      "formalizationNote": "Vacuously true since Nat.digits 3 0 = []. Could be proved by simp."
-    }
+    "mathContext": "foundational. LaTeX: \\text{HasOnlyDigits01Base3}(0). Lean: axiom zero_hasOnlyDigits01 : HasOnlyDigits01Base3 0. Vacuously true since Nat.digits 3 0 = []. Could be proved by simp."
   }
 ]

--- a/src/data/proofs/erdos-411/annotations.json
+++ b/src/data/proofs/erdos-411/annotations.json
@@ -3,206 +3,182 @@
     "id": "erdos-411-header",
     "proofId": "erdos-411",
     "type": "context",
-    "range": { "startLine": 1, "endLine": 12 },
+    "range": {
+      "startLine": 1,
+      "endLine": 12
+    },
     "title": "Problem Background",
     "content": "Erdős Problem #411 studies the arithmetic dynamics of the map $g(n) = n + \\varphi(n)$, where $\\varphi$ is Euler's totient function. Iterating $g$ produces a sequence $n, g(n), g^2(n), \\ldots$ that grows roughly linearly. The problem asks: for which $n$ and $r$ does $g^{k+r}(n) = 2 \\cdot g^k(n)$ hold for all sufficiently large $k$? This is a question about exact exponential growth rates in arithmetic dynamical systems.",
     "significance": "critical",
-    "mathContext": {
-      "field": "arithmetic dynamics / number theory",
-      "prerequisites": ["Euler's totient function φ(n)", "iteration of arithmetic functions", "eventual periodicity", "multiplicative functions"],
-      "relatedTheorems": ["Erdős–Graham (1980) Old and New Problems and Results in Combinatorial Number Theory", "Steinerberger (2025) reduction for r = 2", "Carmichael's totient conjecture"],
-      "latex": "g(n) = n + \\varphi(n), \\quad g^{k+r}(n) = 2 \\cdot g^k(n) \\text{ for all large } k"
-    }
+    "mathContext": "arithmetic dynamics / number theory. LaTeX: g(n) = n + \\varphi(n), \\quad g^{k+r}(n) = 2 \\cdot g^k(n) \\text{ for all large } k. Related: Erdős–Graham (1980) Old and New Problems and Results in Combinatorial Number Theory, Steinerberger (2025) reduction for r = 2, Carmichael's totient conjecture. Prerequisites: Euler's totient function φ(n), iteration of arithmetic functions, eventual periodicity, multiplicative functions"
   },
   {
     "id": "erdos-411-totientStep",
     "proofId": "erdos-411",
     "type": "definition",
-    "range": { "startLine": 23, "endLine": 24 },
+    "range": {
+      "startLine": 23,
+      "endLine": 24
+    },
     "title": "The Map $g(n) = n + \\varphi(n)$",
     "content": "The function `totientStep` computes $g(n) = n + \\varphi(n)$. Since $\\varphi(n) \\geq 1$ for $n \\geq 1$, this map is strictly increasing. For even $n > 2$, $\\varphi(n)$ is even, so $g$ preserves parity. The map arises naturally from the identity $n = \\sum_{d \\mid n} \\varphi(d)$, making $g(n) = n + \\varphi(n)$ a 'self-augmenting' version of $n$.",
     "significance": "key",
-    "mathContext": {
-      "field": "arithmetic dynamics",
-      "latex": "g(n) = n + \\varphi(n)",
-      "leanSignature": "def totientStep (n : ℕ) : ℕ := n + n.totient",
-      "relatedTheorems": ["For prime p, g(p) = p + (p-1) = 2p-1. For p^k, g(p^k) = p^k + p^k(1 - 1/p) = p^k(2 - 1/p)."]
-    }
+    "mathContext": "arithmetic dynamics. LaTeX: g(n) = n + \\varphi(n). Lean: def totientStep (n : ℕ) : ℕ := n + n.totient. Related: For prime p, g(p) = p + (p-1) = 2p-1. For p^k, g(p^k) = p^k + p^k(1 - 1/p) = p^k(2 - 1/p)."
   },
   {
     "id": "erdos-411-iterated",
     "proofId": "erdos-411",
     "type": "definition",
-    "range": { "startLine": 27, "endLine": 29 },
+    "range": {
+      "startLine": 27,
+      "endLine": 29
+    },
     "title": "Iterated $g^k(n)$",
     "content": "The $k$-th iterate $g^k(n)$ is defined recursively: $g^0(n) = n$ and $g^{k+1}(n) = g(g^k(n))$. The sequence $g^0(n), g^1(n), g^2(n), \\ldots$ is strictly increasing since $g(m) > m$ for $m \\geq 1$. The ratio $g^{k+r}(n) / g^k(n)$ may stabilize as $k \\to \\infty$.",
     "significance": "key",
-    "mathContext": {
-      "field": "arithmetic dynamics",
-      "latex": "g^0(n) = n, \\quad g^{k+1}(n) = g(g^k(n))",
-      "leanSignature": "def iteratedTotientStep : ℕ → ℕ → ℕ | 0, n => n | k + 1, n => totientStep (iteratedTotientStep k n)"
-    }
+    "mathContext": "arithmetic dynamics. LaTeX: g^0(n) = n, \\quad g^{k+1}(n) = g(g^k(n)). Lean: def iteratedTotientStep : ℕ → ℕ → ℕ | 0, n => n | k + 1, n => totientStep (iteratedTotientStep k n)"
   },
   {
     "id": "erdos-411-doubling",
     "proofId": "erdos-411",
     "type": "definition",
-    "range": { "startLine": 35, "endLine": 38 },
+    "range": {
+      "startLine": 35,
+      "endLine": 38
+    },
     "title": "The Doubling Relation",
     "content": "`DoublingRelation n r` asserts that $g^{k+r}(n) = 2 \\cdot g^k(n)$ for all sufficiently large $k$. This means that after an initial transient, applying $g$ exactly $r$ more times doubles the value. The 'eventually' quantifier (there exists $K$ such that the relation holds for all $k \\geq K$) captures the idea that we care about asymptotic behavior, not initial values.",
     "significance": "critical",
-    "mathContext": {
-      "field": "arithmetic dynamics",
-      "latex": "\\text{DoublingRelation}(n, r) \\iff \\exists K,\\; \\forall k \\geq K,\\; g^{k+r}(n) = 2 \\cdot g^k(n)",
-      "leanSignature": "def DoublingRelation (n r : ℕ) : Prop := ∃ K : ℕ, ∀ k : ℕ, k ≥ K → iteratedTotientStep (k + r) n = 2 * iteratedTotientStep k n",
-      "relatedTheorems": ["This is equivalent to saying the orbit {g^k(n)} eventually satisfies a linear recurrence with ratio 2 and period r"]
-    }
+    "mathContext": "arithmetic dynamics. LaTeX: \\text{DoublingRelation}(n, r) \\iff \\exists K,\\; \\forall k \\geq K,\\; g^{k+r}(n) = 2 \\cdot g^k(n). Lean: def DoublingRelation (n r : ℕ) : Prop := ∃ K : ℕ, ∀ k : ℕ, k ≥ K → iteratedTotientStep (k + r) n = 2 * iteratedTotientStep k n. Related: This is equivalent to saying the orbit {g^k(n)} eventually satisfies a linear recurrence with ratio 2 and period r"
   },
   {
     "id": "erdos-411-conjecture",
     "proofId": "erdos-411",
     "type": "conjecture",
-    "range": { "startLine": 44, "endLine": 50 },
+    "range": {
+      "startLine": 44,
+      "endLine": 50
+    },
     "title": "Erdős Problem #411",
     "content": "The problem asks for a complete characterization of all pairs $(n, r)$ satisfying the doubling relation. The formalization states this as the existence of a set $S \\subseteq \\mathbb{N} \\times \\mathbb{N}$ that captures exactly the solution pairs and is nonempty (we know solutions exist). The problem remains OPEN — it is not even known whether the solution set is finite or infinite.",
     "significance": "critical",
-    "mathContext": {
-      "field": "open problems in number theory",
-      "latex": "\\text{Characterize } \\{(n, r) : g^{k+r}(n) = 2 \\cdot g^k(n) \\text{ for large } k\\}",
-      "leanSignature": "def ErdosProblem411 : Prop := ∃ S : Set (ℕ × ℕ), (∀ p : ℕ × ℕ, p ∈ S ↔ DoublingRelation p.1 p.2) ∧ S.Nonempty",
-      "formalizationNote": "The nonemptiness clause is included because we know solutions exist (n = 10, 94 for r = 2). The characterization problem asks for a 'nice' description of S."
-    }
+    "mathContext": "open problems in number theory. LaTeX: \\text{Characterize } \\{(n, r) : g^{k+r}(n) = 2 \\cdot g^k(n) \\text{ for large } k\\}. Lean: def ErdosProblem411 : Prop := ∃ S : Set (ℕ × ℕ), (∀ p : ℕ × ℕ, p ∈ S ↔ DoublingRelation p.1 p.2) ∧ S.Nonempty. The nonemptiness clause is included because we know solutions exist (n = 10, 94 for r = 2). The characterization problem asks for a 'nice' description of S."
   },
   {
     "id": "erdos-411-n10",
     "proofId": "erdos-411",
     "type": "axiom",
-    "range": { "startLine": 56, "endLine": 58 },
+    "range": {
+      "startLine": 56,
+      "endLine": 58
+    },
     "title": "Known Solution: $n = 10$, $r = 2$",
     "content": "For $n = 10$: $g(10) = 10 + \\varphi(10) = 10 + 4 = 14$, $g(14) = 14 + \\varphi(14) = 14 + 6 = 20$, so $g^2(10) = 20 = 2 \\cdot 10$. This doubling pattern persists for all subsequent iterates. Steinerberger's reduction confirms: $\\varphi(10) + \\varphi(14) = 4 + 6 = 10 = n$.",
     "significance": "key",
-    "mathContext": {
-      "field": "computational verification",
-      "latex": "g^2(10) = 20 = 2 \\cdot 10, \\quad \\varphi(10) + \\varphi(14) = 10",
-      "leanSignature": "axiom doubling_r2_n10 : DoublingRelation 10 2",
-      "proofTechnique": "The orbit is 10 → 14 → 20 → 28 → 40 → 56 → 80 → ..., doubling every two steps."
-    }
+    "mathContext": "computational verification. LaTeX: g^2(10) = 20 = 2 \\cdot 10, \\quad \\varphi(10) + \\varphi(14) = 10. Lean: axiom doubling_r2_n10 : DoublingRelation 10 2. Technique: The orbit is 10 → 14 → 20 → 28 → 40 → 56 → 80 → ..., doubling every two steps."
   },
   {
     "id": "erdos-411-n94",
     "proofId": "erdos-411",
     "type": "axiom",
-    "range": { "startLine": 60, "endLine": 61 },
+    "range": {
+      "startLine": 60,
+      "endLine": 61
+    },
     "title": "Known Solution: $n = 94$, $r = 2$",
     "content": "For $n = 94$: $\\varphi(94) = \\varphi(2 \\cdot 47) = 46$, so $g(94) = 140$. Then $\\varphi(140) = \\varphi(2^2 \\cdot 5 \\cdot 7) = 48$, so $g(140) = 188 = 2 \\cdot 94$. Steinerberger's check: $\\varphi(94) + \\varphi(140) = 46 + 48 = 94 = n$.",
     "significance": "key",
-    "mathContext": {
-      "field": "computational verification",
-      "latex": "g^2(94) = 188 = 2 \\cdot 94, \\quad \\varphi(94) + \\varphi(140) = 94",
-      "leanSignature": "axiom doubling_r2_n94 : DoublingRelation 94 2",
-      "relatedTheorems": ["94 = 2 · 47, fitting Cambie's conjecture with l = 1, p = 47"]
-    }
+    "mathContext": "computational verification. LaTeX: g^2(94) = 188 = 2 \\cdot 94, \\quad \\varphi(94) + \\varphi(140) = 94. Lean: axiom doubling_r2_n94 : DoublingRelation 94 2. Related: 94 = 2 · 47, fitting Cambie's conjecture with l = 1, p = 47"
   },
   {
     "id": "erdos-411-general-ratio",
     "proofId": "erdos-411",
     "type": "definition",
-    "range": { "startLine": 65, "endLine": 67 },
+    "range": {
+      "startLine": 65,
+      "endLine": 67
+    },
     "title": "General Ratio Relation",
     "content": "Generalization of the doubling relation: $g^{k+r}(n) = c \\cdot g^k(n)$ for all large $k$, where $c$ is an arbitrary multiplicative factor. Cambie discovered that ratios besides 2 (specifically 3 and 4) can also occur, extending the landscape of solutions beyond Erdős's original question.",
     "significance": "key",
-    "mathContext": {
-      "field": "arithmetic dynamics",
-      "latex": "\\text{GeneralRatioRelation}(n, r, c) \\iff \\exists K,\\; \\forall k \\geq K,\\; g^{k+r}(n) = c \\cdot g^k(n)",
-      "leanSignature": "def GeneralRatioRelation (n r c : ℕ) : Prop := ∃ K : ℕ, ∀ k : ℕ, k ≥ K → iteratedTotientStep (k + r) n = c * iteratedTotientStep k n"
-    }
+    "mathContext": "arithmetic dynamics. LaTeX: \\text{GeneralRatioRelation}(n, r, c) \\iff \\exists K,\\; \\forall k \\geq K,\\; g^{k+r}(n) = c \\cdot g^k(n). Lean: def GeneralRatioRelation (n r c : ℕ) : Prop := ∃ K : ℕ, ∀ k : ℕ, k ≥ K → iteratedTotientStep (k + r) n = c * iteratedTotientStep k n"
   },
   {
     "id": "erdos-411-cambie-ratio3",
     "proofId": "erdos-411",
     "type": "axiom",
-    "range": { "startLine": 69, "endLine": 69 },
+    "range": {
+      "startLine": 69,
+      "endLine": 69
+    },
     "title": "Cambie's Ratio-3 Solution",
     "content": "Cambie found that $n = 738$ with period $r = 4$ gives a ratio-3 solution: $g^{k+4}(738) = 3 \\cdot g^k(738)$ for all large $k$. This shows the phenomenon extends beyond doubling to tripling, opening up a richer classification problem.",
     "significance": "key",
-    "mathContext": {
-      "field": "arithmetic dynamics",
-      "latex": "g^{k+4}(738) = 3 \\cdot g^k(738) \\text{ for large } k",
-      "leanSignature": "axiom cambie_ratio3 : GeneralRatioRelation 738 4 3"
-    }
+    "mathContext": "arithmetic dynamics. LaTeX: g^{k+4}(738) = 3 \\cdot g^k(738) \\text{ for large } k. Lean: axiom cambie_ratio3 : GeneralRatioRelation 738 4 3"
   },
   {
     "id": "erdos-411-cambie-ratio4",
     "proofId": "erdos-411",
     "type": "axiom",
-    "range": { "startLine": 72, "endLine": 73 },
+    "range": {
+      "startLine": 72,
+      "endLine": 73
+    },
     "title": "Cambie's Ratio-4 Solutions",
     "content": "Cambie found two ratio-4 solutions with period $r = 4$: $n = 148646$ and $n = 4325798$. These satisfy $g^{k+4}(n) = 4 \\cdot g^k(n)$ for all large $k$. The existence of ratio-4 solutions (alongside ratio-2 and ratio-3) suggests a rich structure in the possible growth rates.",
     "significance": "key",
-    "mathContext": {
-      "field": "arithmetic dynamics",
-      "latex": "g^{k+4}(148646) = 4 \\cdot g^k(148646), \\quad g^{k+4}(4325798) = 4 \\cdot g^k(4325798)",
-      "leanSignature": "axiom cambie_ratio4_148646 : GeneralRatioRelation 148646 4 4"
-    }
+    "mathContext": "arithmetic dynamics. LaTeX: g^{k+4}(148646) = 4 \\cdot g^k(148646), \\quad g^{k+4}(4325798) = 4 \\cdot g^k(4325798). Lean: axiom cambie_ratio4_148646 : GeneralRatioRelation 148646 4 4"
   },
   {
     "id": "erdos-411-steinerberger",
     "proofId": "erdos-411",
     "type": "axiom",
-    "range": { "startLine": 79, "endLine": 83 },
+    "range": {
+      "startLine": 79,
+      "endLine": 83
+    },
     "title": "Steinerberger's Reduction (2025)",
     "content": "Steinerberger (2025) proved that the $r = 2$ doubling property is equivalent to the single algebraic equation $\\varphi(n) + \\varphi(n + \\varphi(n)) = n$. This is a remarkable simplification: the asymptotic condition '$g^{k+2}(n) = 2 \\cdot g^k(n)$ for large $k$' reduces to a finitely checkable identity involving just two evaluations of $\\varphi$.",
     "significance": "critical",
-    "mathContext": {
-      "field": "analytic number theory / arithmetic dynamics",
-      "latex": "\\text{DoublingRelation}(n, 2) \\iff \\varphi(n) + \\varphi(n + \\varphi(n)) = n",
-      "proofTechnique": "The key insight is that if g²(n) = 2n, then g²(g^k(n)) = g^{k+2}(n). By induction, if the doubling holds once at the 'right' point, it propagates to all subsequent iterates. Conversely, if it holds eventually, backtracking shows it must hold at n itself.",
-      "references": ["S. Steinerberger, 'On a problem of Erdős and Graham on iterated totients', 2025"],
-      "leanSignature": "axiom steinerberger_r2_equiv (n : ℕ) : DoublingRelation n 2 ↔ n.totient + (n + n.totient).totient = n"
-    }
+    "mathContext": "analytic number theory / arithmetic dynamics. LaTeX: \\text{DoublingRelation}(n, 2) \\iff \\varphi(n) + \\varphi(n + \\varphi(n)) = n. Lean: axiom steinerberger_r2_equiv (n : ℕ) : DoublingRelation n 2 ↔ n.totient + (n + n.totient).totient = n. Technique: The key insight is that if g²(n) = 2n, then g²(g^k(n)) = g^{k+2}(n). By induction, if the doubling holds once at the 'right' point, it propagates to all subsequent iterates. Conversely, if it holds eventually, backtracking shows it must hold at n itself.. Refs: S. Steinerberger, 'On a problem of Erdős and Graham on iterated totients', 2025"
   },
   {
     "id": "erdos-411-even-preservation",
     "proofId": "erdos-411",
     "type": "theorem",
-    "range": { "startLine": 91, "endLine": 95 },
+    "range": {
+      "startLine": 91,
+      "endLine": 95
+    },
     "title": "Even Preservation Under $g$",
     "content": "For even $n > 2$, $g(n) = n + \\varphi(n)$ is even. This follows because $\\varphi(n)$ is even for $n > 2$ (a classical result: $\\varphi(n) = n \\prod_{p \\mid n}(1 - 1/p)$ is even unless $n \\in \\{1, 2\\}$). Since all known solutions are even, this is a relevant structural constraint.",
     "significance": "key",
-    "mathContext": {
-      "field": "elementary number theory",
-      "latex": "2 \\mid n \\text{ and } n > 2 \\implies 2 \\mid g(n)",
-      "proofTechnique": "Uses Mathlib's Nat.totient_even which states φ(n) is even for n > 2. Then g(n) = n + φ(n) is a sum of two even numbers.",
-      "leanSignature": "theorem totientStep_even_of_even {n : ℕ} (hn : 2 ∣ n) (hn2 : n > 2) : 2 ∣ totientStep n"
-    }
+    "mathContext": "elementary number theory. LaTeX: 2 \\mid n \\text{ and } n > 2 \\implies 2 \\mid g(n). Lean: theorem totientStep_even_of_even {n : ℕ} (hn : 2 ∣ n) (hn2 : n > 2) : 2 ∣ totientStep n. Technique: Uses Mathlib's Nat.totient_even which states φ(n) is even for n > 2. Then g(n) = n + φ(n) is a sum of two even numbers."
   },
   {
     "id": "erdos-411-cambie-conjecture",
     "proofId": "erdos-411",
     "type": "conjecture",
-    "range": { "startLine": 97, "endLine": 102 },
+    "range": {
+      "startLine": 97,
+      "endLine": 102
+    },
     "title": "Cambie's Structural Conjecture",
     "content": "Cambie conjectures that all $r = 2$ doubling solutions have the form $n = 2^l \\cdot p$ where $l \\geq 1$ and $p \\in \\{2, 3, 5, 7, 35, 47\\}$. This would give a complete finite list of solutions: $\\{4, 6, 8, 10, 12, 14, 16, 20, 24, 28, 40, 48, 56, 70, 80, 94, 96, 112, 140, 160, \\ldots\\}$.",
     "significance": "key",
-    "mathContext": {
-      "field": "arithmetic dynamics",
-      "latex": "\\text{DoublingRelation}(n, 2) \\implies n = 2^l \\cdot p, \\; l \\geq 1, \\; p \\in \\{2, 3, 5, 7, 35, 47\\}",
-      "leanSignature": "def CambieConjecture : Prop := ∀ n : ℕ, DoublingRelation n 2 → ∃ l : ℕ, l ≥ 1 ∧ ∃ p ∈ ({2, 3, 5, 7, 35, 47} : Finset ℕ), n = 2 ^ l * p",
-      "formalizationNote": "Note that 10 = 2¹ · 5 and 94 = 2¹ · 47 fit this pattern. Cambie's conjecture would make the solution set infinite (all powers of 2 times each p would work) but highly structured."
-    }
+    "mathContext": "arithmetic dynamics. LaTeX: \\text{DoublingRelation}(n, 2) \\implies n = 2^l \\cdot p, \\; l \\geq 1, \\; p \\in \\{2, 3, 5, 7, 35, 47\\}. Lean: def CambieConjecture : Prop := ∀ n : ℕ, DoublingRelation n 2 → ∃ l : ℕ, l ≥ 1 ∧ ∃ p ∈ ({2, 3, 5, 7, 35, 47} : Finset ℕ), n = 2 ^ l * p. Note that 10 = 2¹ · 5 and 94 = 2¹ · 47 fit this pattern. Cambie's conjecture would make the solution set infinite (all powers of 2 times each p would work) but highly structured."
   },
   {
     "id": "erdos-411-monotonicity",
     "proofId": "erdos-411",
     "type": "theorem",
-    "range": { "startLine": 106, "endLine": 108 },
+    "range": {
+      "startLine": 106,
+      "endLine": 108
+    },
     "title": "Monotonicity of $g$",
     "content": "The map $g(n) = n + \\varphi(n) \\geq n$ for all $n$, with strict inequality for $n \\geq 1$ since $\\varphi(n) \\geq 1$. This means the orbit $g^k(n)$ is nondecreasing. The proof is immediate by `omega`.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "elementary number theory",
-      "latex": "g(n) = n + \\varphi(n) \\geq n",
-      "leanSignature": "theorem totientStep_ge (n : ℕ) : totientStep n ≥ n"
-    }
+    "mathContext": "elementary number theory. LaTeX: g(n) = n + \\varphi(n) \\geq n. Lean: theorem totientStep_ge (n : ℕ) : totientStep n ≥ n"
   }
 ]

--- a/src/data/proofs/erdos-460/annotations.json
+++ b/src/data/proofs/erdos-460/annotations.json
@@ -3,219 +3,195 @@
     "id": "erdos-460-header",
     "proofId": "erdos-460",
     "type": "context",
-    "range": { "startLine": 1, "endLine": 14 },
+    "range": {
+      "startLine": 1,
+      "endLine": 14
+    },
     "title": "Problem Background",
     "content": "Erdős Problem #460 concerns a greedy coprime sieve: given $n$, construct a sequence $a_0 = 0, a_1 = 1, a_2, \\ldots$ where each $a_k$ is the least integer exceeding $a_{k-1}$ such that $n - a_k$ is coprime to all previous $n - a_i$. The central question is whether the sum of reciprocals $\\sum_{0 < a_i < n} 1/a_i$ tends to infinity as $n \\to \\infty$. This connects greedy algorithms, coprimality structure, and divergence of reciprocal sums.",
     "significance": "critical",
-    "mathContext": {
-      "field": "sieve theory / multiplicative number theory",
-      "prerequisites": ["coprimality (gcd)", "greedy algorithms on integers", "reciprocal sum divergence", "least prime factor", "sieve of Eratosthenes"],
-      "relatedTheorems": ["Eggleton–Erdős–Selfridge growth bound", "Mertens' theorem on prime reciprocal sums", "Brun's theorem on twin prime reciprocals"],
-      "latex": "\\sum_{\\substack{0 < a_i < n}} \\frac{1}{a_i} \\to \\infty \\text{ as } n \\to \\infty?"
-    }
+    "mathContext": "sieve theory / multiplicative number theory. LaTeX: \\sum_{\\substack{0 < a_i < n}} \\frac{1}{a_i} \\to \\infty \\text{ as } n \\to \\infty?. Related: Eggleton–Erdős–Selfridge growth bound, Mertens' theorem on prime reciprocal sums, Brun's theorem on twin prime reciprocals. Prerequisites: coprimality (gcd), greedy algorithms on integers, reciprocal sum divergence, least prime factor, sieve of Eratosthenes"
   },
   {
     "id": "erdos-460-sieve-def",
     "proofId": "erdos-460",
     "type": "definition",
-    "range": { "startLine": 27, "endLine": 32 },
+    "range": {
+      "startLine": 27,
+      "endLine": 32
+    },
     "title": "Greedy Coprime Sieve Sequence",
     "content": "The function `greedyCoprimeSieve n k` gives the $k$-th element of the greedy sequence for a fixed $n$. Starting with $a_0 = 0, a_1 = 1$, each subsequent $a_k$ is the least integer greater than $a_{k-1}$ such that $\\gcd(n - a_k, n - a_i) = 1$ for all $i < k$. The sieve ensures the shifted values $n - a_0, n - a_1, \\ldots$ are pairwise coprime.",
     "significance": "critical",
-    "mathContext": {
-      "field": "sieve theory",
-      "latex": "a_k = \\min\\{m > a_{k-1} : \\gcd(n - m, n - a_i) = 1 \\; \\forall i < k\\}",
-      "leanSignature": "noncomputable def greedyCoprimeSieve (n : ℕ) : ℕ → ℕ",
-      "designChoices": "Defined as a constant function (fun _ => 0) with behavior specified by axioms sieve_initial and sieve_greedy. This pattern separates the specification from an explicit construction, which would be complex."
-    }
+    "mathContext": "sieve theory. LaTeX: a_k = \\min\\{m > a_{k-1} : \\gcd(n - m, n - a_i) = 1 \\; \\forall i < k\\}. Lean: noncomputable def greedyCoprimeSieve (n : ℕ) : ℕ → ℕ. Design: Defined as a constant function (fun _ => 0) with behavior specified by axioms sieve_initial and sieve_greedy. This pattern separates the specification from an explicit construction, which would be complex."
   },
   {
     "id": "erdos-460-sieve-initial",
     "proofId": "erdos-460",
     "type": "axiom",
-    "range": { "startLine": 35, "endLine": 36 },
+    "range": {
+      "startLine": 35,
+      "endLine": 36
+    },
     "title": "Initial Values: $a_0 = 0, a_1 = 1$",
     "content": "The sieve starts with $a_0 = 0$ and $a_1 = 1$ for any $n \\geq 2$. The choice $a_0 = 0$ means $n - a_0 = n$, and $a_1 = 1$ gives $n - a_1 = n - 1$. Since $\\gcd(n, n-1) = 1$ always holds, the greedy condition is satisfied.",
     "significance": "key",
-    "mathContext": {
-      "field": "sieve theory",
-      "latex": "a_0 = 0, \\quad a_1 = 1",
-      "leanSignature": "axiom sieve_initial (n : ℕ) (hn : n ≥ 2) : greedyCoprimeSieve n 0 = 0 ∧ greedyCoprimeSieve n 1 = 1"
-    }
+    "mathContext": "sieve theory. LaTeX: a_0 = 0, \\quad a_1 = 1. Lean: axiom sieve_initial (n : ℕ) (hn : n ≥ 2) : greedyCoprimeSieve n 0 = 0 ∧ greedyCoprimeSieve n 1 = 1"
   },
   {
     "id": "erdos-460-sieve-greedy",
     "proofId": "erdos-460",
     "type": "axiom",
-    "range": { "startLine": 40, "endLine": 45 },
+    "range": {
+      "startLine": 40,
+      "endLine": 45
+    },
     "title": "Greedy Selection Property",
     "content": "For $k \\geq 2$, the axiom captures three properties: (1) $a_k > a_{k-1}$ (strict increase), (2) $\\gcd(n - a_k, n - a_i) = 1$ for all $i < k$ (pairwise coprimality of shifted values), and (3) minimality — every integer between $a_{k-1}$ and $a_k$ fails the coprimality condition for some earlier term.",
     "significance": "critical",
-    "mathContext": {
-      "field": "sieve theory / greedy algorithms",
-      "latex": "a_k > a_{k-1}, \\quad \\gcd(n - a_k, n - a_i) = 1 \\; \\forall i < k, \\quad \\nexists\\, m \\in (a_{k-1}, a_k) \\text{ coprime to all}",
-      "leanSignature": "axiom sieve_greedy (n : ℕ) (hn : n ≥ 2) (k : ℕ) (hk : k ≥ 2) : ...",
-      "proofTechnique": "The minimality clause is crucial: it ensures the sequence is uniquely defined by the greedy rule, not just any coprime subsequence."
-    }
+    "mathContext": "sieve theory / greedy algorithms. LaTeX: a_k > a_{k-1}, \\quad \\gcd(n - a_k, n - a_i) = 1 \\; \\forall i < k, \\quad \\nexists\\, m \\in (a_{k-1}, a_k) \\text{ coprime to all}. Lean: axiom sieve_greedy (n : ℕ) (hn : n ≥ 2) (k : ℕ) (hk : k ≥ 2) : .... Technique: The minimality clause is crucial: it ensures the sequence is uniquely defined by the greedy rule, not just any coprime subsequence."
   },
   {
     "id": "erdos-460-sieve-count",
     "proofId": "erdos-460",
     "type": "definition",
-    "range": { "startLine": 52, "endLine": 54 },
+    "range": {
+      "startLine": 52,
+      "endLine": 54
+    },
     "title": "Sieve Count",
     "content": "`sieveCount n` counts how many terms of the sieve sequence are less than $n$. Since the sequence is increasing and bounded by $n$, this is finite. The count determines the range of summation for the reciprocal sum.",
     "significance": "key",
-    "mathContext": {
-      "field": "combinatorics",
-      "latex": "\\text{sieveCount}(n) = \\#\\{k : a_k < n\\}",
-      "leanSignature": "noncomputable def sieveCount (n : ℕ) : ℕ := Finset.card ((Finset.range n).filter (...))"
-    }
+    "mathContext": "combinatorics. LaTeX: \\text{sieveCount}(n) = \\#\\{k : a_k < n\\}. Lean: noncomputable def sieveCount (n : ℕ) : ℕ := Finset.card ((Finset.range n).filter (...))"
   },
   {
     "id": "erdos-460-reciprocal-sum",
     "proofId": "erdos-460",
     "type": "definition",
-    "range": { "startLine": 60, "endLine": 65 },
+    "range": {
+      "startLine": 60,
+      "endLine": 65
+    },
     "title": "Reciprocal Sum $\\sum 1/a_i$",
     "content": "The sum $\\sum_{0 < a_i < n} 1/a_i$ is computed over positive sieve terms less than $n$. This is a finite sum for each $n$. The central question is whether this sum diverges as $n \\to \\infty$. If the Eggleton–Erdős–Selfridge conjectured bound $a_k \\ll k \\log k$ holds, then the reciprocal sum would be $\\gg \\sum 1/(k \\log k) = \\infty$.",
     "significance": "critical",
-    "mathContext": {
-      "field": "analytic number theory",
-      "latex": "S(n) = \\sum_{\\substack{k : a_k > 0 \\\\ a_k < n}} \\frac{1}{a_k}",
-      "leanSignature": "noncomputable def sieveReciprocalSum (n : ℕ) : ℝ",
-      "relatedTheorems": ["If aₖ ~ k log k, then Σ 1/aₖ ~ Σ 1/(k log k) which diverges (integral test). The quadratic bound aₖ < k^{2+ε} only gives Σ 1/k^{2+ε} which converges, so the known bound is insufficient."]
-    }
+    "mathContext": "analytic number theory. LaTeX: S(n) = \\sum_{\\substack{k : a_k > 0 \\\\ a_k < n}} \\frac{1}{a_k}. Lean: noncomputable def sieveReciprocalSum (n : ℕ) : ℝ. Related: If aₖ ~ k log k, then Σ 1/aₖ ~ Σ 1/(k log k) which diverges (integral test). The quadratic bound aₖ < k^{2+ε} only gives Σ 1/k^{2+ε} which converges, so the known bound is insufficient."
   },
   {
     "id": "erdos-460-conjecture",
     "proofId": "erdos-460",
     "type": "conjecture",
-    "range": { "startLine": 71, "endLine": 79 },
+    "range": {
+      "startLine": 71,
+      "endLine": 79
+    },
     "title": "Main Conjecture: Divergence of Reciprocal Sum",
     "content": "Erdős Problem #460: for every $M > 0$, there exists $N_0$ such that for all $n \\geq N_0$, the reciprocal sum $\\sum_{0 < a_i < n} 1/a_i > M$. Equivalently, $\\lim_{n \\to \\infty} S(n) = \\infty$. The problem is OPEN — the known growth bound $a_k < k^{2+\\varepsilon}$ is too weak to imply divergence.",
     "significance": "critical",
-    "mathContext": {
-      "field": "open problems in number theory",
-      "latex": "\\forall M > 0,\\; \\exists N_0,\\; \\forall n \\geq N_0,\\; \\sum_{0 < a_i < n} \\frac{1}{a_i} > M",
-      "leanSignature": "def ErdosProblem460 : Prop := ∀ M : ℝ, M > 0 → ∃ N₀ : ℕ, ∀ n : ℕ, n ≥ N₀ → sieveReciprocalSum n > M",
-      "formalizationNote": "The divergence is stated in the ε-N form rather than using filters, for concreteness."
-    }
+    "mathContext": "open problems in number theory. LaTeX: \\forall M > 0,\\; \\exists N_0,\\; \\forall n \\geq N_0,\\; \\sum_{0 < a_i < n} \\frac{1}{a_i} > M. Lean: def ErdosProblem460 : Prop := ∀ M : ℝ, M > 0 → ∃ N₀ : ℕ, ∀ n : ℕ, n ≥ N₀ → sieveReciprocalSum n > M. The divergence is stated in the ε-N form rather than using filters, for concreteness."
   },
   {
     "id": "erdos-460-ees-bound",
     "proofId": "erdos-460",
     "type": "axiom",
-    "range": { "startLine": 87, "endLine": 90 },
+    "range": {
+      "startLine": 87,
+      "endLine": 90
+    },
     "title": "Eggleton–Erdős–Selfridge Bound: $a_k < k^{2+o(1)}$",
     "content": "Eggleton, Erdős, and Selfridge proved that the sieve sequence satisfies $a_k < k^{2+\\varepsilon}$ for any $\\varepsilon > 0$ and all sufficiently large $k$. This quadratic-type growth is the best known upper bound. It means the sieve doesn't grow too fast, but is insufficient for reciprocal sum divergence (since $\\sum 1/k^{2+\\varepsilon}$ converges).",
     "significance": "critical",
-    "mathContext": {
-      "field": "sieve theory",
-      "latex": "\\forall \\varepsilon > 0,\\; \\exists K_0,\\; \\forall k \\geq K_0,\\; a_k < k^{2+\\varepsilon}",
-      "proofTechnique": "The proof uses the fact that primes up to k have product ~ e^k (by the prime number theorem), so the sieve can find coprime elements within roughly k² steps.",
-      "leanSignature": "axiom eggleton_erdos_selfridge (n : ℕ) (hn : n ≥ 2) : ∀ ε : ℝ, ε > 0 → ∃ K₀ : ℕ, ∀ k : ℕ, k ≥ K₀ → (greedyCoprimeSieve n k : ℝ) < (k : ℝ) ^ ((2 : ℝ) + ε)"
-    }
+    "mathContext": "sieve theory. LaTeX: \\forall \\varepsilon > 0,\\; \\exists K_0,\\; \\forall k \\geq K_0,\\; a_k < k^{2+\\varepsilon}. Lean: axiom eggleton_erdos_selfridge (n : ℕ) (hn : n ≥ 2) : ∀ ε : ℝ, ε > 0 → ∃ K₀ : ℕ, ∀ k : ℕ, k ≥ K₀ → (greedyCoprimeSieve n k : ℝ) < (k : ℝ) ^ ((2 : ℝ) + ε). Technique: The proof uses the fact that primes up to k have product ~ e^k (by the prime number theorem), so the sieve can find coprime elements within roughly k² steps."
   },
   {
     "id": "erdos-460-conjectured-bound",
     "proofId": "erdos-460",
     "type": "axiom",
-    "range": { "startLine": 93, "endLine": 96 },
+    "range": {
+      "startLine": 93,
+      "endLine": 96
+    },
     "title": "Conjectured Bound: $a_k \\ll k \\log k$",
     "content": "It is conjectured that $a_k \\leq C \\cdot k \\log k$ for some constant $C > 0$. If true, this would immediately imply Problem #460 since $\\sum_{k=2}^{N} 1/(k \\log k)$ diverges (by the integral test, as $\\int dx/(x \\ln x) = \\ln \\ln x \\to \\infty$).",
     "significance": "key",
-    "mathContext": {
-      "field": "sieve theory",
-      "latex": "a_k \\leq C \\cdot k \\log k",
-      "leanSignature": "axiom sieve_conjectured_bound : ∃ C : ℝ, C > 0 ∧ ∀ n : ℕ, n ≥ 2 → ∀ k : ℕ, k ≥ 2 → (greedyCoprimeSieve n k : ℝ) ≤ C * (k : ℝ) * Real.log (k : ℝ)",
-      "relatedTheorems": ["The bound k log k is natural: it matches the typical spacing between integers whose shifted values avoid small primes (cf. Mertens' theorem)."]
-    }
+    "mathContext": "sieve theory. LaTeX: a_k \\leq C \\cdot k \\log k. Lean: axiom sieve_conjectured_bound : ∃ C : ℝ, C > 0 ∧ ∀ n : ℕ, n ≥ 2 → ∀ k : ℕ, k ≥ 2 → (greedyCoprimeSieve n k : ℝ) ≤ C * (k : ℝ) * Real.log (k : ℝ). Related: The bound k log k is natural: it matches the typical spacing between integers whose shifted values avoid small primes (cf. Mertens' theorem)."
   },
   {
     "id": "erdos-460-least-prime",
     "proofId": "erdos-460",
     "type": "definition",
-    "range": { "startLine": 103, "endLine": 105 },
+    "range": {
+      "startLine": 103,
+      "endLine": 105
+    },
     "title": "Least Prime Factor",
     "content": "The least prime factor $P^-(n)$ of $n$ is defined as `Nat.minFac n` for $n > 1$, and 0 for $n \\leq 1$. This function appears in the sufficient condition for Problem #460: the filtered sum over $a$ where $P^-(n-a) > a$.",
     "significance": "key",
-    "mathContext": {
-      "field": "multiplicative number theory",
-      "latex": "P^-(n) = \\min\\{p \\text{ prime} : p \\mid n\\}",
-      "leanSignature": "noncomputable def leastPrimeFactor (n : ℕ) : ℕ := if n ≤ 1 then 0 else Nat.minFac n"
-    }
+    "mathContext": "multiplicative number theory. LaTeX: P^-(n) = \\min\\{p \\text{ prime} : p \\mid n\\}. Lean: noncomputable def leastPrimeFactor (n : ℕ) : ℕ := if n ≤ 1 then 0 else Nat.minFac n"
   },
   {
     "id": "erdos-460-filtered-sum",
     "proofId": "erdos-460",
     "type": "definition",
-    "range": { "startLine": 110, "endLine": 114 },
+    "range": {
+      "startLine": 110,
+      "endLine": 114
+    },
     "title": "Least Prime Factor Filtered Sum $f(n)$",
     "content": "The function $f(n) = \\sum_{\\substack{0 < a < n \\\\ P^-(n-a) > a}} 1/a$ sums reciprocals over those $a < n$ whose complement $n - a$ has all prime factors exceeding $a$. This is a 'smooth number' condition on $n - a$. Divergence of $f(n)$ would imply Problem #460.",
     "significance": "key",
-    "mathContext": {
-      "field": "sieve theory / smooth numbers",
-      "latex": "f(n) = \\sum_{\\substack{0 < a < n \\\\ P^-(n-a) > a}} \\frac{1}{a}",
-      "leanSignature": "noncomputable def leastPrimeFilteredSum (n : ℕ) : ℝ",
-      "relatedTheorems": ["The condition P⁻(n-a) > a means n-a has no 'small' prime divisors relative to a. This is related to the counting function Ψ(x,y) of y-smooth numbers."]
-    }
+    "mathContext": "sieve theory / smooth numbers. LaTeX: f(n) = \\sum_{\\substack{0 < a < n \\\\ P^-(n-a) > a}} \\frac{1}{a}. Lean: noncomputable def leastPrimeFilteredSum (n : ℕ) : ℝ. Related: The condition P⁻(n-a) > a means n-a has no 'small' prime divisors relative to a. This is related to the counting function Ψ(x,y) of y-smooth numbers."
   },
   {
     "id": "erdos-460-filtered-implies",
     "proofId": "erdos-460",
     "type": "axiom",
-    "range": { "startLine": 117, "endLine": 119 },
+    "range": {
+      "startLine": 117,
+      "endLine": 119
+    },
     "title": "Filtered Sum Implies Full Divergence",
     "content": "If $f(n) \\to \\infty$ then Problem #460 holds. This is because the greedy coprime sieve must include at least the terms counted by the filtered sum — if $P^-(n-a) > a$, then $n - a$ is automatically coprime to all $n - a_i$ for $a_i < a$ (since $n - a$ has no prime factors $\\leq a$).",
     "significance": "key",
-    "mathContext": {
-      "field": "sieve theory",
-      "latex": "f(n) \\to \\infty \\implies \\text{ErdosProblem460}",
-      "proofTechnique": "If P⁻(n-a) > a, then for any a' < a, gcd(n-a, n-a') cannot share a prime ≤ a. Since all prime factors of n-a exceed a, and a' < a, the coprimality is automatic.",
-      "leanSignature": "axiom filtered_sum_implies_full : (∀ M : ℝ, M > 0 → ∃ N₀ : ℕ, ∀ n ≥ N₀, leastPrimeFilteredSum n > M) → ErdosProblem460"
-    }
+    "mathContext": "sieve theory. LaTeX: f(n) \\to \\infty \\implies \\text{ErdosProblem460}. Lean: axiom filtered_sum_implies_full : (∀ M : ℝ, M > 0 → ∃ N₀ : ℕ, ∀ n ≥ N₀, leastPrimeFilteredSum n > M) → ErdosProblem460. Technique: If P⁻(n-a) > a, then for any a' < a, gcd(n-a, n-a') cannot share a prime ≤ a. Since all prime factors of n-a exceed a, and a' < a, the coprimality is automatic."
   },
   {
     "id": "erdos-460-small-prime-sum",
     "proofId": "erdos-460",
     "type": "definition",
-    "range": { "startLine": 126, "endLine": 132 },
+    "range": {
+      "startLine": 126,
+      "endLine": 132
+    },
     "title": "Small Prime Divisible Sum",
     "content": "The sum restricted to sieve terms $a_k$ where $n - a_k$ has a prime factor $p \\leq a_k$. These are the 'easy' terms to include in the sieve — their coprimality follows from avoiding specific small primes.",
     "significance": "key",
-    "mathContext": {
-      "field": "sieve theory",
-      "latex": "\\sum_{\\substack{a_k \\in \\text{sieve} \\\\ \\exists p \\leq a_k,\\; p \\mid (n - a_k)}} \\frac{1}{a_k}",
-      "leanSignature": "noncomputable def smallPrimeDivisibleSum (n : ℕ) : ℝ"
-    }
+    "mathContext": "sieve theory. LaTeX: \\sum_{\\substack{a_k \\in \\text{sieve} \\\\ \\exists p \\leq a_k,\\; p \\mid (n - a_k)}} \\frac{1}{a_k}. Lean: noncomputable def smallPrimeDivisibleSum (n : ℕ) : ℝ"
   },
   {
     "id": "erdos-460-large-prime-sum",
     "proofId": "erdos-460",
     "type": "definition",
-    "range": { "startLine": 135, "endLine": 140 },
+    "range": {
+      "startLine": 135,
+      "endLine": 140
+    },
     "title": "Large Prime Sum",
     "content": "The complementary sum over sieve terms where $P^-(n - a_k) > a_k$ — all prime factors of $n - a_k$ exceed $a_k$. These are the 'hard' terms where coprimality is automatic but the contribution to the reciprocal sum depends on the distribution of smooth numbers.",
     "significance": "key",
-    "mathContext": {
-      "field": "sieve theory / smooth numbers",
-      "latex": "\\sum_{\\substack{a_k \\in \\text{sieve} \\\\ P^-(n - a_k) > a_k}} \\frac{1}{a_k}",
-      "leanSignature": "noncomputable def largePrimeSum (n : ℕ) : ℝ"
-    }
+    "mathContext": "sieve theory / smooth numbers. LaTeX: \\sum_{\\substack{a_k \\in \\text{sieve} \\\\ P^-(n - a_k) > a_k}} \\frac{1}{a_k}. Lean: noncomputable def largePrimeSum (n : ℕ) : ℝ"
   },
   {
     "id": "erdos-460-restricted-question",
     "proofId": "erdos-460",
     "type": "axiom",
-    "range": { "startLine": 143, "endLine": 146 },
+    "range": {
+      "startLine": 143,
+      "endLine": 146
+    },
     "title": "Restricted Sum Divergence Question",
     "content": "Erdős asked whether the two restricted sums (small-prime and large-prime) individually diverge. If either one diverges, Problem #460 follows since the full sum dominates each restricted sum. This splits the divergence question into two potentially easier subproblems with different flavors: the small-prime case is combinatorial, while the large-prime case involves smooth number estimates.",
     "significance": "key",
-    "mathContext": {
-      "field": "sieve theory",
-      "latex": "\\left(\\text{smallPrimeDivisibleSum}(n) \\to \\infty\\right) \\vee \\left(\\text{largePrimeSum}(n) \\to \\infty\\right) \\implies \\text{ErdosProblem460}",
-      "leanSignature": "axiom erdos_460_restricted_question : (...) → ErdosProblem460"
-    }
+    "mathContext": "sieve theory. LaTeX: \\left(\\text{smallPrimeDivisibleSum}(n) \\to \\infty\\right) \\vee \\left(\\text{largePrimeSum}(n) \\to \\infty\\right) \\implies \\text{ErdosProblem460}. Lean: axiom erdos_460_restricted_question : (...) → ErdosProblem460"
   }
 ]

--- a/src/data/proofs/erdos-461/annotations.json
+++ b/src/data/proofs/erdos-461/annotations.json
@@ -3,223 +3,169 @@
     "id": "erdos-461-header",
     "proofId": "erdos-461",
     "type": "context",
-    "range": { "startLine": 1, "endLine": 14 },
+    "range": {
+      "startLine": 1,
+      "endLine": 14
+    },
     "title": "Problem Background",
     "content": "Erdős Problem 461 asks whether $f(n,t)$, the count of distinct $t$-smooth components in $\\{n+1,\\ldots,n+t\\}$, grows linearly in $t$. From Erdős–Graham (1980), p.92, who proved the weaker bound $f(n,t) \\gg t/\\log t$.",
     "significance": "essential",
-    "mathContext": {
-      "field": "multiplicative number theory / smooth numbers",
-      "latex": "f(n,t) = |\\{s_t(m) : n < m \\leq n+t\\}| \\stackrel{?}{\\gg} t",
-      "references": ["Erdős–Graham (1980), p.92", "erdosproblems.com/461"],
-      "relatedTheorems": ["Smooth number counting function Ψ(x,y)", "Dickman's function", "Hildebrand–Tenenbaum estimates"],
-      "formalizationNote": "The file contains both axiomatized results and fully proved theorems — a strong formalization with infrastructure lemmas for list products and prime factorization."
-    }
+    "mathContext": "multiplicative number theory / smooth numbers. LaTeX: f(n,t) = |\\{s_t(m) : n < m \\leq n+t\\}| \\stackrel{?}{\\gg} t. The file contains both axiomatized results and fully proved theorems — a strong formalization with infrastructure lemmas for list products and prime factorization.. Related: Smooth number counting function Ψ(x,y), Dickman's function, Hildebrand–Tenenbaum estimates. Refs: Erdős–Graham (1980), p.92, erdosproblems.com/461"
   },
   {
     "id": "erdos-461-smooth-component",
     "proofId": "erdos-461",
     "type": "definition",
-    "range": { "startLine": 24, "endLine": 27 },
+    "range": {
+      "startLine": 24,
+      "endLine": 27
+    },
     "title": "Smooth Component Definition",
     "content": "The $t$-smooth component $s_t(n)$ is defined as the product of prime factors of $n$ (with multiplicity) that are strictly less than $t$. Formally, `smoothComponent t n = (n.factors.filter (· < t)).prod`. This extracts the largest divisor of $n$ whose prime factorization consists entirely of primes $< t$.",
     "significance": "essential",
-    "mathContext": {
-      "field": "multiplicative number theory",
-      "latex": "s_t(n) = \\prod_{\\substack{p^a \\| n \\\\ p < t}} p^a",
-      "leanSignature": "noncomputable def smoothComponent (t n : ℕ) : ℕ := (n.factors.filter (· < t)).prod",
-      "proofTechnique": "filtering the prime factor list and taking the product",
-      "relatedTheorems": ["Smooth number definition Ψ(x,y)", "radical of an integer", "p-adic valuation"],
-      "formalizationNote": "Uses `Nat.factors` (the list of prime factors with multiplicity) and `List.filter`/`List.prod`. The definition is noncomputable since `Nat.factors` involves factorization. Handles n = 0 correctly: `Nat.factors 0 = []`, so `smoothComponent t 0 = 1`.",
-      "crossReferences": ["erdos-461-smooth-axioms", "erdos-461-count"]
-    }
+    "mathContext": "multiplicative number theory. LaTeX: s_t(n) = \\prod_{\\substack{p^a \\| n \\\\ p < t}} p^a. Lean: noncomputable def smoothComponent (t n : ℕ) : ℕ := (n.factors.filter (· < t)).prod. Technique: filtering the prime factor list and taking the product. Uses `Nat.factors` (the list of prime factors with multiplicity) and `List.filter`/`List.prod`. The definition is noncomputable since `Nat.factors` involves factorization. Handles n = 0 correctly: `Nat.factors 0 = []`, so `smoothComponent t 0 = 1`.. Related: Smooth number definition Ψ(x,y), radical of an integer, p-adic valuation. Cross-refs: erdos-461-smooth-axioms, erdos-461-count"
   },
   {
     "id": "erdos-461-infrastructure",
     "proofId": "erdos-461",
     "type": "result",
-    "range": { "startLine": 31, "endLine": 61 },
+    "range": {
+      "startLine": 31,
+      "endLine": 61
+    },
     "title": "Infrastructure Lemmas",
     "content": "Two key helper lemmas proved by induction on lists. `list_prod_filter_dvd`: the product of a filtered sublist divides the product of the full list, i.e., $(l.\\text{filter}\\, p).\\text{prod} \\mid l.\\text{prod}$. `prime_dvd_list_prod_mem`: if a prime $p$ divides the product of a list of primes, then $p$ is a member of that list. Both are fully proved (no `sorry`).",
     "significance": "supporting",
-    "mathContext": {
-      "field": "list algebra / number theory foundations",
-      "latex": "\\prod_{x \\in \\text{filter}(l, p)} x \\mid \\prod_{x \\in l} x",
-      "proofTechnique": "structural induction on lists with case analysis on the filter predicate",
-      "formalizationNote": "Marked `private` since they are internal infrastructure. `list_prod_filter_dvd` uses `mul_dvd_mul_left` and `dvd_mul_of_dvd_right`. `prime_dvd_list_prod_mem` uses `Nat.Prime.dvd_mul` for the inductive step.",
-      "crossReferences": ["erdos-461-smooth-dvd", "erdos-461-smooth-smooth"]
-    }
+    "mathContext": "list algebra / number theory foundations. LaTeX: \\prod_{x \\in \\text{filter}(l, p)} x \\mid \\prod_{x \\in l} x. Technique: structural induction on lists with case analysis on the filter predicate. Marked `private` since they are internal infrastructure. `list_prod_filter_dvd` uses `mul_dvd_mul_left` and `dvd_mul_of_dvd_right`. `prime_dvd_list_prod_mem` uses `Nat.Prime.dvd_mul` for the inductive step.. Cross-refs: erdos-461-smooth-dvd, erdos-461-smooth-smooth"
   },
   {
     "id": "erdos-461-smooth-dvd",
     "proofId": "erdos-461",
     "type": "result",
-    "range": { "startLine": 65, "endLine": 69 },
+    "range": {
+      "startLine": 65,
+      "endLine": 69
+    },
     "title": "Smooth Component Divides n",
     "content": "Theorem `smoothComponent_dvd`: for $n \\neq 0$, $s_t(n) \\mid n$. Proved by unfolding `smoothComponent`, applying `list_prod_filter_dvd` to `n.factors`, and rewriting with `Nat.prod_factors`.",
     "significance": "essential",
-    "mathContext": {
-      "field": "multiplicative number theory",
-      "latex": "n \\neq 0 \\implies s_t(n) \\mid n",
-      "leanSignature": "theorem smoothComponent_dvd (t n : ℕ) (hn : n ≠ 0) : smoothComponent t n ∣ n",
-      "proofTechnique": "reduce to list product divisibility via Nat.prod_factors",
-      "relatedTheorems": ["fundamental theorem of arithmetic", "Nat.prod_factors"],
-      "crossReferences": ["erdos-461-infrastructure", "erdos-461-smooth-largest"]
-    }
+    "mathContext": "multiplicative number theory. LaTeX: n \\neq 0 \\implies s_t(n) \\mid n. Lean: theorem smoothComponent_dvd (t n : ℕ) (hn : n ≠ 0) : smoothComponent t n ∣ n. Technique: reduce to list product divisibility via Nat.prod_factors. Related: fundamental theorem of arithmetic, Nat.prod_factors. Cross-refs: erdos-461-infrastructure, erdos-461-smooth-largest"
   },
   {
     "id": "erdos-461-smooth-smooth",
     "proofId": "erdos-461",
     "type": "result",
-    "range": { "startLine": 71, "endLine": 78 },
+    "range": {
+      "startLine": 71,
+      "endLine": 78
+    },
     "title": "Smooth Component is t-Smooth",
     "content": "Theorem `smoothComponent_smooth`: every prime factor $p$ of $s_t(n)$ satisfies $p < t$. Uses `prime_dvd_list_prod_mem` to show $p$ must appear in the filtered list, then extracts the filter predicate $p < t$.",
     "significance": "essential",
-    "mathContext": {
-      "field": "multiplicative number theory",
-      "latex": "p \\text{ prime},\\, p \\mid s_t(n) \\implies p < t",
-      "leanSignature": "theorem smoothComponent_smooth (t n p : ℕ) (hp : p.Prime) (hd : p ∣ smoothComponent t n) : p < t",
-      "proofTechnique": "membership in filtered list via prime_dvd_list_prod_mem, then extract filter condition",
-      "relatedTheorems": ["y-smooth numbers: all prime factors ≤ y"],
-      "crossReferences": ["erdos-461-infrastructure", "erdos-461-smooth-largest"]
-    }
+    "mathContext": "multiplicative number theory. LaTeX: p \\text{ prime},\\, p \\mid s_t(n) \\implies p < t. Lean: theorem smoothComponent_smooth (t n p : ℕ) (hp : p.Prime) (hd : p ∣ smoothComponent t n) : p < t. Technique: membership in filtered list via prime_dvd_list_prod_mem, then extract filter condition. Related: y-smooth numbers: all prime factors ≤ y. Cross-refs: erdos-461-infrastructure, erdos-461-smooth-largest"
   },
   {
     "id": "erdos-461-smooth-pos",
     "proofId": "erdos-461",
     "type": "result",
-    "range": { "startLine": 80, "endLine": 85 },
+    "range": {
+      "startLine": 80,
+      "endLine": 85
+    },
     "title": "Smooth Component is Positive",
     "content": "Theorem `smoothComponent_pos`: $s_t(n) > 0$ for all $t, n$. Since every element in the filtered factor list is a prime (hence $\\geq 2 > 0$), the product is positive by `List.prod_pos`.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "number theory foundations",
-      "latex": "s_t(n) > 0",
-      "leanSignature": "theorem smoothComponent_pos (t n : ℕ) : 0 < smoothComponent t n",
-      "proofTechnique": "product of positive elements is positive",
-      "crossReferences": ["erdos-461-smooth-component"]
-    }
+    "mathContext": "number theory foundations. LaTeX: s_t(n) > 0. Lean: theorem smoothComponent_pos (t n : ℕ) : 0 < smoothComponent t n. Technique: product of positive elements is positive. Cross-refs: erdos-461-smooth-component"
   },
   {
     "id": "erdos-461-complement",
     "proofId": "erdos-461",
     "type": "result",
-    "range": { "startLine": 87, "endLine": 96 },
+    "range": {
+      "startLine": 87,
+      "endLine": 96
+    },
     "title": "No Small Primes in Complement",
     "content": "Lemma `no_small_prime_in_complement`: if $p$ is prime with $p < t$ and $p$ divides the product of factors $\\geq t$, this is a contradiction. The proof shows $p$ would appear in the complement list, but the filter condition requires all elements $\\geq t$, contradicting $p < t$.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "list algebra / number theory",
-      "latex": "p < t \\wedge p \\mid \\prod_{q \\in \\text{factors}(n),\\, q \\geq t} q \\implies \\bot",
-      "proofTechnique": "membership via prime_dvd_list_prod_mem, then contradiction with filter condition",
-      "formalizationNote": "Key infrastructure for the maximality theorem `smoothComponent_largest`, showing the complement part (all primes ≥ t) is coprime to any t-smooth divisor.",
-      "crossReferences": ["erdos-461-smooth-largest"]
-    }
+    "mathContext": "list algebra / number theory. LaTeX: p < t \\wedge p \\mid \\prod_{q \\in \\text{factors}(n),\\, q \\geq t} q \\implies \\bot. Technique: membership via prime_dvd_list_prod_mem, then contradiction with filter condition. Key infrastructure for the maximality theorem `smoothComponent_largest`, showing the complement part (all primes ≥ t) is coprime to any t-smooth divisor.. Cross-refs: erdos-461-smooth-largest"
   },
   {
     "id": "erdos-461-smooth-largest",
     "proofId": "erdos-461",
     "type": "result",
-    "range": { "startLine": 98, "endLine": 106 },
+    "range": {
+      "startLine": 98,
+      "endLine": 106
+    },
     "title": "Smooth Component is Maximal (sorry)",
     "content": "Theorem `smoothComponent_largest`: if $d \\mid n$ and all prime factors of $d$ are $< t$, then $d \\mid s_t(n)$. This establishes $s_t(n)$ as the largest $t$-smooth divisor of $n$. Contains `sorry` — the proof strategy (noted in docstring) decomposes $n = s_t(n) \\cdot c$ where $c$ has all primes $\\geq t$, then uses coprimality of $d$ and $c$ to conclude $d \\mid s_t(n)$.",
     "significance": "essential",
-    "mathContext": {
-      "field": "multiplicative number theory",
-      "latex": "d \\mid n \\wedge (\\forall p \\text{ prime},\\, p \\mid d \\implies p < t) \\implies d \\mid s_t(n)",
-      "leanSignature": "theorem smoothComponent_largest (t n d : ℕ) (hn : n ≠ 0) : d ∣ n → (∀ p : ℕ, p.Prime → p ∣ d → p < t) → d ∣ smoothComponent t n",
-      "proofTechnique": "coprime decomposition: n = smooth_part × rough_part, then d | n and gcd(d, rough_part) = 1 implies d | smooth_part",
-      "relatedTheorems": ["coprime decomposition of integers", "smooth-rough factorization"],
-      "formalizationNote": "The only `sorry` in the file. Would require proving the complement factorization and using Nat.Coprime.dvd_of_dvd_mul_right. An excellent Aristotle candidate.",
-      "crossReferences": ["erdos-461-complement", "erdos-461-smooth-dvd"]
-    }
+    "mathContext": "multiplicative number theory. LaTeX: d \\mid n \\wedge (\\forall p \\text{ prime},\\, p \\mid d \\implies p < t) \\implies d \\mid s_t(n). Lean: theorem smoothComponent_largest (t n d : ℕ) (hn : n ≠ 0) : d ∣ n → (∀ p : ℕ, p.Prime → p ∣ d → p < t) → d ∣ smoothComponent t n. Technique: coprime decomposition: n = smooth_part × rough_part, then d | n and gcd(d, rough_part) = 1 implies d | smooth_part. The only `sorry` in the file. Would require proving the complement factorization and using Nat.Coprime.dvd_of_dvd_mul_right. An excellent Aristotle candidate.. Related: coprime decomposition of integers, smooth-rough factorization. Cross-refs: erdos-461-complement, erdos-461-smooth-dvd"
   },
   {
     "id": "erdos-461-count",
     "proofId": "erdos-461",
     "type": "definition",
-    "range": { "startLine": 110, "endLine": 112 },
+    "range": {
+      "startLine": 110,
+      "endLine": 112
+    },
     "title": "Distinct Count Function",
     "content": "Defines $f(n,t) = |\\{s_t(m) : n < m \\leq n+t\\}|$ using `Finset.Icc` for the interval $[n+1, n+t]$, `Finset.image` to compute the set of smooth components, and `Finset.card` for the cardinality.",
     "significance": "essential",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "f(n,t) = |\\text{image}(s_t, \\{n+1, \\ldots, n+t\\})|",
-      "leanSignature": "noncomputable def smoothDistinctCount (n t : ℕ) : ℕ := ((Finset.Icc (n + 1) (n + t)).image (smoothComponent t)).card",
-      "proofTechnique": "image cardinality of smooth component over a closed interval",
-      "formalizationNote": "Uses `Finset.Icc` rather than `Finset.range` for a natural match with the interval {n+1, ..., n+t}. Noncomputable since `smoothComponent` is noncomputable.",
-      "crossReferences": ["erdos-461-smooth-component", "erdos-461-conjecture"]
-    }
+    "mathContext": "combinatorial number theory. LaTeX: f(n,t) = |\\text{image}(s_t, \\{n+1, \\ldots, n+t\\})|. Lean: noncomputable def smoothDistinctCount (n t : ℕ) : ℕ := ((Finset.Icc (n + 1) (n + t)).image (smoothComponent t)).card. Technique: image cardinality of smooth component over a closed interval. Uses `Finset.Icc` rather than `Finset.range` for a natural match with the interval {n+1, ..., n+t}. Noncomputable since `smoothComponent` is noncomputable.. Cross-refs: erdos-461-smooth-component, erdos-461-conjecture"
   },
   {
     "id": "erdos-461-conjecture",
     "proofId": "erdos-461",
     "type": "conjecture",
-    "range": { "startLine": 116, "endLine": 121 },
+    "range": {
+      "startLine": 116,
+      "endLine": 121
+    },
     "title": "Main Conjecture: Linear Growth",
     "content": "Erdős Problem 461: there exists $C > 0$ and $t_0$ such that $f(n,t) \\geq C \\cdot t$ for all $n$ and $t \\geq t_0$. This conjectures that the number of distinct smooth components in a short interval grows linearly, the strongest possible bound since $f(n,t) \\leq t$ trivially.",
     "significance": "essential",
-    "mathContext": {
-      "field": "multiplicative number theory",
-      "latex": "\\exists C > 0,\\, \\exists t_0,\\, \\forall t \\geq t_0,\\, \\forall n,\\, f(n,t) \\geq C \\cdot t",
-      "leanSignature": "def ErdosProblem461 : Prop := ∃ C : ℝ, 0 < C ∧ ∃ t₀ : ℕ, ∀ t : ℕ, t₀ ≤ t → ∀ n : ℕ, C * ↑t ≤ ↑(smoothDistinctCount n t)",
-      "proofTechnique": "existence of a universal constant (asymptotic lower bound)",
-      "relatedTheorems": ["Erdős–Graham t/log t bound", "smooth number distribution in short intervals"],
-      "references": ["Erdős–Graham (1980), p.92"],
-      "designChoices": "Quantifies ∀ n uniformly, requiring the bound to hold for ALL starting points, not just typical ones. This makes the conjecture substantially stronger than an average-case statement.",
-      "crossReferences": ["erdos-461-eg-bound", "erdos-461-upper-bound"]
-    }
+    "mathContext": "multiplicative number theory. LaTeX: \\exists C > 0,\\, \\exists t_0,\\, \\forall t \\geq t_0,\\, \\forall n,\\, f(n,t) \\geq C \\cdot t. Lean: def ErdosProblem461 : Prop := ∃ C : ℝ, 0 < C ∧ ∃ t₀ : ℕ, ∀ t : ℕ, t₀ ≤ t → ∀ n : ℕ, C * ↑t ≤ ↑(smoothDistinctCount n t). Technique: existence of a universal constant (asymptotic lower bound). Related: Erdős–Graham t/log t bound, smooth number distribution in short intervals. Refs: Erdős–Graham (1980), p.92. Cross-refs: erdos-461-eg-bound, erdos-461-upper-bound. Design: Quantifies ∀ n uniformly, requiring the bound to hold for ALL starting points, not just typical ones. This makes the conjecture substantially stronger than an average-case statement."
   },
   {
     "id": "erdos-461-eg-bound",
     "proofId": "erdos-461",
     "type": "result",
-    "range": { "startLine": 125, "endLine": 129 },
+    "range": {
+      "startLine": 125,
+      "endLine": 129
+    },
     "title": "Erdős–Graham Lower Bound",
     "content": "The known bound $f(n,t) \\gg t/\\log t$ for all $n$ and large $t$. This falls a logarithmic factor short of the conjectured linear bound. The gap between $t/\\log t$ and $t$ is the central open question.",
     "significance": "essential",
-    "mathContext": {
-      "field": "multiplicative number theory",
-      "latex": "\\exists C > 0,\\, \\exists t_0,\\, \\forall t \\geq t_0,\\, \\forall n,\\, f(n,t) \\geq C \\cdot \\frac{t}{\\log t}",
-      "leanSignature": "axiom erdos_graham_lower : ∃ C : ℝ, 0 < C ∧ ∃ t₀ : ℕ, ∀ t : ℕ, t₀ ≤ t → ∀ n : ℕ, C * ↑t / Real.log ↑t ≤ ↑(smoothDistinctCount n t)",
-      "proofTechnique": "axiomatized (original proof uses sieve methods and multiplicative function estimates)",
-      "relatedTheorems": ["Hildebrand's smooth number estimates", "Tenenbaum's Introduction to Analytic and Probabilistic Number Theory"],
-      "references": ["Erdős–Graham (1980), p.92"],
-      "formalizationNote": "Axiomatized since the proof requires detailed sieve theory not yet in Mathlib. The statement uses `Real.log` for the natural logarithm.",
-      "crossReferences": ["erdos-461-conjecture"]
-    }
+    "mathContext": "multiplicative number theory. LaTeX: \\exists C > 0,\\, \\exists t_0,\\, \\forall t \\geq t_0,\\, \\forall n,\\, f(n,t) \\geq C \\cdot \\frac{t}{\\log t}. Lean: axiom erdos_graham_lower : ∃ C : ℝ, 0 < C ∧ ∃ t₀ : ℕ, ∀ t : ℕ, t₀ ≤ t → ∀ n : ℕ, C * ↑t / Real.log ↑t ≤ ↑(smoothDistinctCount n t). Technique: axiomatized (original proof uses sieve methods and multiplicative function estimates). Axiomatized since the proof requires detailed sieve theory not yet in Mathlib. The statement uses `Real.log` for the natural logarithm.. Related: Hildebrand's smooth number estimates, Tenenbaum's Introduction to Analytic and Probabilistic Number Theory. Refs: Erdős–Graham (1980), p.92. Cross-refs: erdos-461-conjecture"
   },
   {
     "id": "erdos-461-boundary-cases",
     "proofId": "erdos-461",
     "type": "result",
-    "range": { "startLine": 133, "endLine": 172 },
+    "range": {
+      "startLine": 133,
+      "endLine": 172
+    },
     "title": "Boundary Cases and Basic Properties",
     "content": "Five fully proved boundary results. `smoothComponent_one`: $s_t(1) = 1$. `smoothComponent_t_le_one`: $s_t(n) = 1$ when $t \\leq 1$ (no primes below 1). `smoothDistinctCount_le`: $f(n,t) \\leq t$ (trivial upper bound from interval size). `smoothDistinctCount_zero`: $f(n,0) = 0$. `smoothComponent_zero`: $s_t(0) = 1$. `smoothComponent_prime`: $s_t(p) = p$ if $p < t$, else $1$.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "multiplicative number theory",
-      "latex": "s_t(1) = 1,\\quad t \\leq 1 \\implies s_t(n) = 1,\\quad f(n,t) \\leq t,\\quad f(n,0) = 0",
-      "proofTechnique": "direct computation using Nat.factors properties, Finset.card_image_le, and interval cardinality",
-      "relatedTheorems": ["Nat.factors_one", "Nat.factors_prime", "Finset.card_Icc"],
-      "formalizationNote": "All five theorems are fully proved with no sorry. `smoothDistinctCount_le` uses the key fact that image cardinality ≤ domain cardinality and `Finset.card_Icc`. `smoothComponent_prime` uses `Nat.factors_prime` to reduce to a singleton list.",
-      "crossReferences": ["erdos-461-smooth-component", "erdos-461-count"]
-    }
+    "mathContext": "multiplicative number theory. LaTeX: s_t(1) = 1,\\quad t \\leq 1 \\implies s_t(n) = 1,\\quad f(n,t) \\leq t,\\quad f(n,0) = 0. Technique: direct computation using Nat.factors properties, Finset.card_image_le, and interval cardinality. All five theorems are fully proved with no sorry. `smoothDistinctCount_le` uses the key fact that image cardinality ≤ domain cardinality and `Finset.card_Icc`. `smoothComponent_prime` uses `Nat.factors_prime` to reduce to a singleton list.. Related: Nat.factors_one, Nat.factors_prime, Finset.card_Icc. Cross-refs: erdos-461-smooth-component, erdos-461-count"
   },
   {
     "id": "erdos-461-upper-bound",
     "proofId": "erdos-461",
     "type": "result",
-    "range": { "startLine": 148, "endLine": 154 },
+    "range": {
+      "startLine": 148,
+      "endLine": 154
+    },
     "title": "Trivial Upper Bound f(n,t) ≤ t",
     "content": "The count $f(n,t) \\leq t$ since the image of a $t$-element set has at most $t$ elements. This is tight in the sense that the conjecture asks whether $f(n,t) \\geq Ct$ — i.e., whether the count is $\\Theta(t)$. Proved using `Finset.card_image_le` and `Finset.card_Icc`.",
     "significance": "essential",
-    "mathContext": {
-      "field": "combinatorics",
-      "latex": "f(n,t) \\leq t",
-      "leanSignature": "theorem smoothDistinctCount_le (n t : ℕ) : smoothDistinctCount n t ≤ t",
-      "proofTechnique": "image cardinality ≤ domain cardinality, combined with interval cardinality calculation",
-      "formalizationNote": "Fully proved. Together with the conjecture $f(n,t) \\geq Ct$, this would give $f(n,t) = \\Theta(t)$.",
-      "crossReferences": ["erdos-461-conjecture", "erdos-461-count"]
-    }
+    "mathContext": "combinatorics. LaTeX: f(n,t) \\leq t. Lean: theorem smoothDistinctCount_le (n t : ℕ) : smoothDistinctCount n t ≤ t. Technique: image cardinality ≤ domain cardinality, combined with interval cardinality calculation. Fully proved. Together with the conjecture $f(n,t) \\geq Ct$, this would give $f(n,t) = \\Theta(t)$.. Cross-refs: erdos-461-conjecture, erdos-461-count"
   }
 ]

--- a/src/data/proofs/erdos-462/annotations.json
+++ b/src/data/proofs/erdos-462/annotations.json
@@ -3,193 +3,143 @@
     "id": "erdos-462-header",
     "proofId": "erdos-462",
     "type": "context",
-    "range": { "startLine": 1, "endLine": 13 },
+    "range": {
+      "startLine": 1,
+      "endLine": 13
+    },
     "title": "Problem Background",
     "content": "Erdős Problem 462 asks about the distribution of $\\sum p(n)/n$ in short intervals of length $\\sqrt{x} \\cdot (\\log x)^2$. The global sum over composites $n < x$ satisfies $\\sum_{n < x,\\, n \\text{ composite}} p(n)/n \\sim c \\cdot \\sqrt{x}/(\\log x)^2$. The conjecture asks whether this sum is equidistributed on its natural scale. From Erdős–Graham (1980), p.92.",
     "significance": "essential",
-    "mathContext": {
-      "field": "analytic number theory / prime distribution",
-      "latex": "\\sum_{\\substack{n < x \\\\ n \\text{ composite}}} \\frac{p(n)}{n} \\sim c \\cdot \\frac{\\sqrt{x}}{(\\log x)^2}",
-      "references": ["Erdős–Graham (1980), p.92", "erdosproblems.com/462"],
-      "relatedTheorems": ["de Bruijn's result on smooth number distribution", "Alladi–Erdős (1977) on distribution of p(n)"],
-      "formalizationNote": "The constant $c > 0$ in the asymptotic is not explicitly computed in the formalization; only the two-sided Θ bound is stated."
-    }
+    "mathContext": "analytic number theory / prime distribution. LaTeX: \\sum_{\\substack{n < x \\\\ n \\text{ composite}}} \\frac{p(n)}{n} \\sim c \\cdot \\frac{\\sqrt{x}}{(\\log x)^2}. The constant $c > 0$ in the asymptotic is not explicitly computed in the formalization; only the two-sided Θ bound is stated.. Related: de Bruijn's result on smooth number distribution, Alladi–Erdős (1977) on distribution of p(n). Refs: Erdős–Graham (1980), p.92, erdosproblems.com/462"
   },
   {
     "id": "erdos-462-lpf",
     "proofId": "erdos-462",
     "type": "definition",
-    "range": { "startLine": 21, "endLine": 24 },
+    "range": {
+      "startLine": 21,
+      "endLine": 24
+    },
     "title": "Least Prime Factor Definition",
     "content": "The least prime factor $p(n)$ returns 0 for $n \\leq 1$ and `Nat.minFac n` otherwise. For $n \\geq 2$, $p(n)$ is the smallest prime dividing $n$. For primes, $p(p) = p$; for composites, $p(n) \\leq \\sqrt{n}$.",
     "significance": "essential",
-    "mathContext": {
-      "field": "number theory",
-      "latex": "p(n) = \\min\\{q : q \\text{ prime},\\, q \\mid n\\}",
-      "leanSignature": "noncomputable def leastPrimeFactor (n : ℕ) : ℕ := if h : n ≤ 1 then 0 else n.minFac",
-      "proofTechnique": "case split on n ≤ 1, then delegation to Nat.minFac",
-      "relatedTheorems": ["Nat.minFac", "Nat.minFac_prime", "smooth number classification via least prime factor"],
-      "formalizationNote": "Returns 0 for n ≤ 1 as a sentinel value. Noncomputable since Nat.minFac involves trial division.",
-      "crossReferences": ["erdos-462-lpf-properties", "erdos-462-sums"]
-    }
+    "mathContext": "number theory. LaTeX: p(n) = \\min\\{q : q \\text{ prime},\\, q \\mid n\\}. Lean: noncomputable def leastPrimeFactor (n : ℕ) : ℕ := if h : n ≤ 1 then 0 else n.minFac. Technique: case split on n ≤ 1, then delegation to Nat.minFac. Returns 0 for n ≤ 1 as a sentinel value. Noncomputable since Nat.minFac involves trial division.. Related: Nat.minFac, Nat.minFac_prime, smooth number classification via least prime factor. Cross-refs: erdos-462-lpf-properties, erdos-462-sums"
   },
   {
     "id": "erdos-462-lpf-properties",
     "proofId": "erdos-462",
     "type": "result",
-    "range": { "startLine": 26, "endLine": 36 },
+    "range": {
+      "startLine": 26,
+      "endLine": 36
+    },
     "title": "Least Prime Factor Properties",
     "content": "Three axiomatized properties for $n \\geq 2$: (1) `leastPrimeFactor_prime`: $p(n)$ is prime. (2) `leastPrimeFactor_dvd`: $p(n) \\mid n$. (3) `leastPrimeFactor_le`: $p(n) \\leq q$ for any prime $q \\mid n$ (minimality). These are all provable from `Nat.minFac_prime`, `Nat.minFac_dvd`, and `Nat.minFac_le`.",
     "significance": "essential",
-    "mathContext": {
-      "field": "number theory",
-      "latex": "p(n) \\text{ prime},\\quad p(n) \\mid n,\\quad \\forall q \\text{ prime},\\, q \\mid n \\implies p(n) \\leq q",
-      "leanSignature": "axiom leastPrimeFactor_prime (n : ℕ) (hn : 2 ≤ n) : (leastPrimeFactor n).Prime",
-      "proofTechnique": "axiomatized (all provable from Nat.minFac properties in Mathlib)",
-      "relatedTheorems": ["Nat.minFac_prime", "Nat.minFac_dvd", "Nat.minFac_le"],
-      "formalizationNote": "Could be proved rather than axiomatized using `Nat.minFac_prime (by omega)`, `Nat.minFac_dvd n`, and `Nat.minFac_le hpn`. Good Aristotle candidates.",
-      "crossReferences": ["erdos-462-lpf", "erdos-462-basic-properties"]
-    }
+    "mathContext": "number theory. LaTeX: p(n) \\text{ prime},\\quad p(n) \\mid n,\\quad \\forall q \\text{ prime},\\, q \\mid n \\implies p(n) \\leq q. Lean: axiom leastPrimeFactor_prime (n : ℕ) (hn : 2 ≤ n) : (leastPrimeFactor n).Prime. Technique: axiomatized (all provable from Nat.minFac properties in Mathlib). Could be proved rather than axiomatized using `Nat.minFac_prime (by omega)`, `Nat.minFac_dvd n`, and `Nat.minFac_le hpn`. Good Aristotle candidates.. Related: Nat.minFac_prime, Nat.minFac_dvd, Nat.minFac_le. Cross-refs: erdos-462-lpf, erdos-462-basic-properties"
   },
   {
     "id": "erdos-462-composite-sum",
     "proofId": "erdos-462",
     "type": "definition",
-    "range": { "startLine": 40, "endLine": 44 },
+    "range": {
+      "startLine": 40,
+      "endLine": 44
+    },
     "title": "Composite Sum Definition",
     "content": "Defines `compositeSum(x) = \\sum_{n=2}^{x-1} [n \\text{ composite}] \\cdot p(n)/n`. Sums over `Finset.Icc 2 (x-1)`, filtering out primes by setting their contribution to 0. This captures the global behavior: the sum over composites grows as $\\Theta(\\sqrt{x}/(\\log x)^2)$.",
     "significance": "essential",
-    "mathContext": {
-      "field": "analytic number theory",
-      "latex": "S(x) = \\sum_{\\substack{2 \\leq n < x \\\\ n \\text{ composite}}} \\frac{p(n)}{n}",
-      "leanSignature": "noncomputable def compositeSum (x : ℕ) : ℝ := (Finset.Icc 2 (x - 1)).sum fun n => if n.Prime then 0 else (leastPrimeFactor n : ℝ) / (n : ℝ)",
-      "proofTechnique": "conditional summation filtering primes",
-      "relatedTheorems": ["Alladi–Erdős (1977) asymptotic", "distribution of smooth numbers"],
-      "formalizationNote": "Primes contribute 0 to this sum. For the full sum including primes, one would add $\\sum_{p < x} 1$, but the composite-only version isolates the interesting behavior.",
-      "crossReferences": ["erdos-462-asymptotic", "erdos-462-interval-sum"]
-    }
+    "mathContext": "analytic number theory. LaTeX: S(x) = \\sum_{\\substack{2 \\leq n < x \\\\ n \\text{ composite}}} \\frac{p(n)}{n}. Lean: noncomputable def compositeSum (x : ℕ) : ℝ := (Finset.Icc 2 (x - 1)).sum fun n => if n.Prime then 0 else (leastPrimeFactor n : ℝ) / (n : ℝ). Technique: conditional summation filtering primes. Primes contribute 0 to this sum. For the full sum including primes, one would add $\\sum_{p < x} 1$, but the composite-only version isolates the interesting behavior.. Related: Alladi–Erdős (1977) asymptotic, distribution of smooth numbers. Cross-refs: erdos-462-asymptotic, erdos-462-interval-sum"
   },
   {
     "id": "erdos-462-interval-sum",
     "proofId": "erdos-462",
     "type": "definition",
-    "range": { "startLine": 46, "endLine": 49 },
+    "range": {
+      "startLine": 46,
+      "endLine": 49
+    },
     "title": "Interval Sum Definition",
     "content": "Defines `intervalSum(a, b) = \\sum_{n=a}^{b} p(n)/n$ over `Finset.Icc a b`. Unlike `compositeSum`, this includes primes (for which $p(n)/n = 1$). The conjecture asks whether this sum is bounded below on intervals of the natural length scale.",
     "significance": "essential",
-    "mathContext": {
-      "field": "analytic number theory",
-      "latex": "I(a,b) = \\sum_{n=a}^{b} \\frac{p(n)}{n}",
-      "leanSignature": "noncomputable def intervalSum (a b : ℕ) : ℝ := (Finset.Icc a b).sum fun n => (leastPrimeFactor n : ℝ) / (n : ℝ)",
-      "proofTechnique": "direct summation over a closed interval",
-      "formalizationNote": "Includes all integers in [a,b], not just composites. For $n \\leq 1$, $p(n) = 0$ so the contribution is 0. For primes, $p(n)/n = 1$.",
-      "crossReferences": ["erdos-462-conjecture", "erdos-462-composite-sum"]
-    }
+    "mathContext": "analytic number theory. LaTeX: I(a,b) = \\sum_{n=a}^{b} \\frac{p(n)}{n}. Lean: noncomputable def intervalSum (a b : ℕ) : ℝ := (Finset.Icc a b).sum fun n => (leastPrimeFactor n : ℝ) / (n : ℝ). Technique: direct summation over a closed interval. Includes all integers in [a,b], not just composites. For $n \\leq 1$, $p(n) = 0$ so the contribution is 0. For primes, $p(n)/n = 1$.. Cross-refs: erdos-462-conjecture, erdos-462-composite-sum"
   },
   {
     "id": "erdos-462-asymptotic",
     "proofId": "erdos-462",
     "type": "result",
-    "range": { "startLine": 53, "endLine": 59 },
+    "range": {
+      "startLine": 53,
+      "endLine": 59
+    },
     "title": "Known Asymptotic: $\\Theta(\\sqrt{x}/(\\log x)^2)$",
     "content": "The composite sum satisfies $c_1 \\cdot \\sqrt{x}/(\\log x)^2 \\leq S(x) \\leq c_2 \\cdot \\sqrt{x}/(\\log x)^2$ for constants $0 < c_1 \\leq c_2$ and all $x \\geq x_0$. This two-sided bound establishes the growth rate and motivates the interval length $C\\sqrt{x}(\\log x)^2$ in the conjecture.",
     "significance": "essential",
-    "mathContext": {
-      "field": "analytic number theory",
-      "latex": "S(x) = \\Theta\\left(\\frac{\\sqrt{x}}{(\\log x)^2}\\right)",
-      "leanSignature": "axiom compositeSum_asymptotic : ∃ c₁ c₂ : ℝ, 0 < c₁ ∧ c₁ ≤ c₂ ∧ ∃ x₀ : ℕ, ∀ x : ℕ, x₀ ≤ x → c₁ * ↑x ^ (1/2 : ℝ) / (Real.log ↑x) ^ 2 ≤ compositeSum x ∧ compositeSum x ≤ c₂ * ↑x ^ (1/2 : ℝ) / (Real.log ↑x) ^ 2",
-      "proofTechnique": "axiomatized; the proof uses sieve methods and partial summation over the least prime factor distribution",
-      "relatedTheorems": ["Alladi–Erdős (1977)", "de Bruijn's smooth number asymptotic", "partial summation / Abel summation"],
-      "references": ["Erdős–Graham (1980), p.92", "Alladi and Erdős, 'On an additive arithmetic function', Pacific J. Math. (1977)"],
-      "formalizationNote": "States the Θ-bound as a conjunction of upper and lower bounds with existential constants. Uses `Real.log` and `(x : ℝ) ^ (1/2 : ℝ)` for $\\sqrt{x}$.",
-      "crossReferences": ["erdos-462-composite-sum", "erdos-462-conjecture"]
-    }
+    "mathContext": "analytic number theory. LaTeX: S(x) = \\Theta\\left(\\frac{\\sqrt{x}}{(\\log x)^2}\\right). Lean: axiom compositeSum_asymptotic : ∃ c₁ c₂ : ℝ, 0 < c₁ ∧ c₁ ≤ c₂ ∧ ∃ x₀ : ℕ, ∀ x : ℕ, x₀ ≤ x → c₁ * ↑x ^ (1/2 : ℝ) / (Real.log ↑x) ^ 2 ≤ compositeSum x ∧ compositeSum x ≤ c₂ * ↑x ^ (1/2 : ℝ) / (Real.log ↑x) ^ 2. Technique: axiomatized; the proof uses sieve methods and partial summation over the least prime factor distribution. States the Θ-bound as a conjunction of upper and lower bounds with existential constants. Uses `Real.log` and `(x : ℝ) ^ (1/2 : ℝ)` for $\\sqrt{x}$.. Related: Alladi–Erdős (1977), de Bruijn's smooth number asymptotic, partial summation / Abel summation. Refs: Erdős–Graham (1980), p.92, Alladi and Erdős, 'On an additive arithmetic function', Pacific J. Math. (1977). Cross-refs: erdos-462-composite-sum, erdos-462-conjecture"
   },
   {
     "id": "erdos-462-conjecture",
     "proofId": "erdos-462",
     "type": "conjecture",
-    "range": { "startLine": 63, "endLine": 70 },
+    "range": {
+      "startLine": 63,
+      "endLine": 70
+    },
     "title": "Main Conjecture: Short Interval Equidistribution",
     "content": "There exist $C > 0$ and $\\delta > 0$ such that $\\sum_{x \\leq n \\leq x + C\\sqrt{x}(\\log x)^2} p(n)/n \\geq \\delta$ for all sufficiently large $x$. This asks whether the least prime factor sum is equidistributed on its natural scale: intervals of length $\\sqrt{x}(\\log x)^2$ should capture a bounded-below fraction of the global sum.",
     "significance": "essential",
-    "mathContext": {
-      "field": "analytic number theory / short interval problems",
-      "latex": "\\exists C, \\delta > 0,\\, \\exists x_0,\\, \\forall x \\geq x_0,\\, \\sum_{x \\leq n \\leq x + C\\sqrt{x}(\\log x)^2} \\frac{p(n)}{n} \\geq \\delta",
-      "leanSignature": "def ErdosProblem462 : Prop := ∃ C : ℝ, 0 < C ∧ ∃ δ : ℝ, 0 < δ ∧ ∃ x₀ : ℕ, ∀ x : ℕ, x₀ ≤ x → δ ≤ intervalSum x ⌊↑x + C * ↑x ^ (1/2 : ℝ) * (Real.log ↑x) ^ 2⌋₊",
-      "proofTechnique": "existential statement with floor function for the interval endpoint",
-      "relatedTheorems": ["Huxley's short interval estimates", "prime number theorem in short intervals", "Selberg sieve in short intervals"],
-      "references": ["Erdős–Graham (1980), p.92"],
-      "designChoices": "Uses `⌊...⌋₊` (Nat floor) for the right endpoint since intervalSum takes ℕ arguments. The interval length $C\\sqrt{x}(\\log x)^2$ matches the growth rate of compositeSum, making the conjecture scale-appropriate.",
-      "crossReferences": ["erdos-462-asymptotic", "erdos-462-interval-sum"]
-    }
+    "mathContext": "analytic number theory / short interval problems. LaTeX: \\exists C, \\delta > 0,\\, \\exists x_0,\\, \\forall x \\geq x_0,\\, \\sum_{x \\leq n \\leq x + C\\sqrt{x}(\\log x)^2} \\frac{p(n)}{n} \\geq \\delta. Lean: def ErdosProblem462 : Prop := ∃ C : ℝ, 0 < C ∧ ∃ δ : ℝ, 0 < δ ∧ ∃ x₀ : ℕ, ∀ x : ℕ, x₀ ≤ x → δ ≤ intervalSum x ⌊↑x + C * ↑x ^ (1/2 : ℝ) * (Real.log ↑x) ^ 2⌋₊. Technique: existential statement with floor function for the interval endpoint. Related: Huxley's short interval estimates, prime number theorem in short intervals, Selberg sieve in short intervals. Refs: Erdős–Graham (1980), p.92. Cross-refs: erdos-462-asymptotic, erdos-462-interval-sum. Design: Uses `⌊...⌋₊` (Nat floor) for the right endpoint since intervalSum takes ℕ arguments. The interval length $C\\sqrt{x}(\\log x)^2$ matches the growth rate of compositeSum, making the conjecture scale-appropriate."
   },
   {
     "id": "erdos-462-prime-self",
     "proofId": "erdos-462",
     "type": "result",
-    "range": { "startLine": 74, "endLine": 76 },
+    "range": {
+      "startLine": 74,
+      "endLine": 76
+    },
     "title": "Least Prime Factor of a Prime",
     "content": "For a prime $p$, $p(p) = p$ — the least prime factor of a prime is itself. Axiomatized; provable from `Nat.Prime.minFac_eq`.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "number theory",
-      "latex": "p \\text{ prime} \\implies p(p) = p",
-      "leanSignature": "axiom leastPrimeFactor_prime_self (p : ℕ) (hp : p.Prime) : leastPrimeFactor p = p",
-      "proofTechnique": "direct from Nat.Prime.minFac_eq",
-      "formalizationNote": "Simple consequence of the definition. Could be proved with `simp [leastPrimeFactor, Nat.Prime.minFac_eq hp]` and a case analysis on $p \\leq 1$.",
-      "crossReferences": ["erdos-462-lpf"]
-    }
+    "mathContext": "number theory. LaTeX: p \\text{ prime} \\implies p(p) = p. Lean: axiom leastPrimeFactor_prime_self (p : ℕ) (hp : p.Prime) : leastPrimeFactor p = p. Technique: direct from Nat.Prime.minFac_eq. Simple consequence of the definition. Could be proved with `simp [leastPrimeFactor, Nat.Prime.minFac_eq hp]` and a case analysis on $p \\leq 1$.. Cross-refs: erdos-462-lpf"
   },
   {
     "id": "erdos-462-ge-two",
     "proofId": "erdos-462",
     "type": "result",
-    "range": { "startLine": 78, "endLine": 80 },
+    "range": {
+      "startLine": 78,
+      "endLine": 80
+    },
     "title": "Lower Bound: $p(n) \\geq 2$",
     "content": "For $n \\geq 2$, the least prime factor satisfies $p(n) \\geq 2$. This is immediate since the smallest prime is 2. Bounds individual terms in the sum: $p(n)/n \\geq 2/n$.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "number theory",
-      "latex": "n \\geq 2 \\implies p(n) \\geq 2",
-      "leanSignature": "axiom leastPrimeFactor_ge_two (n : ℕ) (hn : 2 ≤ n) : 2 ≤ leastPrimeFactor n",
-      "proofTechnique": "every prime is ≥ 2, and p(n) is prime for n ≥ 2",
-      "crossReferences": ["erdos-462-lpf-properties", "erdos-462-sqrt-bound"]
-    }
+    "mathContext": "number theory. LaTeX: n \\geq 2 \\implies p(n) \\geq 2. Lean: axiom leastPrimeFactor_ge_two (n : ℕ) (hn : 2 ≤ n) : 2 ≤ leastPrimeFactor n. Technique: every prime is ≥ 2, and p(n) is prime for n ≥ 2. Cross-refs: erdos-462-lpf-properties, erdos-462-sqrt-bound"
   },
   {
     "id": "erdos-462-sqrt-bound",
     "proofId": "erdos-462",
     "type": "result",
-    "range": { "startLine": 82, "endLine": 84 },
+    "range": {
+      "startLine": 82,
+      "endLine": 84
+    },
     "title": "Upper Bound: $p(n) \\leq \\sqrt{n}$ for Composites",
     "content": "For composite $n \\geq 2$, $p(n) \\leq \\sqrt{n}$. This is because a composite $n$ has a factor $\\leq \\sqrt{n}$, and the least prime factor is the smallest such factor. This bounds individual terms: $p(n)/n \\leq 1/\\sqrt{n}$ for composites, explaining why the sum converges slowly.",
     "significance": "essential",
-    "mathContext": {
-      "field": "number theory",
-      "latex": "n \\geq 2,\\, n \\text{ composite} \\implies p(n) \\leq \\sqrt{n}",
-      "leanSignature": "axiom leastPrimeFactor_le_sqrt (n : ℕ) (hn : 2 ≤ n) (hc : ¬n.Prime) : (leastPrimeFactor n : ℝ) ≤ (n : ℝ) ^ (1/2 : ℝ)",
-      "proofTechnique": "every composite has a factor ≤ √n; the least prime factor is the smallest prime factor",
-      "relatedTheorems": ["trial division bound", "Nat.minFac_le_sqrt"],
-      "formalizationNote": "States the bound in ℝ using `(n : ℝ) ^ (1/2 : ℝ)` rather than `Nat.sqrt` to avoid integer truncation. Key for establishing the growth rate of compositeSum.",
-      "crossReferences": ["erdos-462-asymptotic", "erdos-462-ge-two"]
-    }
+    "mathContext": "number theory. LaTeX: n \\geq 2,\\, n \\text{ composite} \\implies p(n) \\leq \\sqrt{n}. Lean: axiom leastPrimeFactor_le_sqrt (n : ℕ) (hn : 2 ≤ n) (hc : ¬n.Prime) : (leastPrimeFactor n : ℝ) ≤ (n : ℝ) ^ (1/2 : ℝ). Technique: every composite has a factor ≤ √n; the least prime factor is the smallest prime factor. States the bound in ℝ using `(n : ℝ) ^ (1/2 : ℝ)` rather than `Nat.sqrt` to avoid integer truncation. Key for establishing the growth rate of compositeSum.. Related: trial division bound, Nat.minFac_le_sqrt. Cross-refs: erdos-462-asymptotic, erdos-462-ge-two"
   },
   {
     "id": "erdos-462-equidistribution-context",
     "proofId": "erdos-462",
     "type": "context",
-    "range": { "startLine": 61, "endLine": 70 },
+    "range": {
+      "startLine": 61,
+      "endLine": 70
+    },
     "title": "Equidistribution on Natural Scales",
     "content": "The conjecture is a short-interval equidistribution problem. Since $S(x) = \\Theta(\\sqrt{x}/(\\log x)^2)$, the sum grows by $\\Theta(1)$ over intervals of length $\\Theta(\\sqrt{x}(\\log x)^2)$ on average. The conjecture asks whether this holds not just on average but uniformly — i.e., no interval of the natural scale is anomalously empty. This is analogous to short-interval prime number theorem questions where one asks if $\\pi(x+h) - \\pi(x) \\sim h/\\log x$.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "analytic number theory",
-      "latex": "\\Delta S = S(x + h) - S(x) \\geq \\delta \\text{ for } h = C\\sqrt{x}(\\log x)^2",
-      "proofTechnique": "comparison with average increments of a slowly growing function",
-      "relatedTheorems": ["Prime number theorem in short intervals", "Huxley (1972): primes in short intervals", "Selberg sieve applications"],
-      "formalizationNote": "Not formalized; provides conceptual context for why the interval length $\\sqrt{x}(\\log x)^2$ is the natural choice.",
-      "crossReferences": ["erdos-462-conjecture", "erdos-462-asymptotic"]
-    }
+    "mathContext": "analytic number theory. LaTeX: \\Delta S = S(x + h) - S(x) \\geq \\delta \\text{ for } h = C\\sqrt{x}(\\log x)^2. Technique: comparison with average increments of a slowly growing function. Not formalized; provides conceptual context for why the interval length $\\sqrt{x}(\\log x)^2$ is the natural choice.. Related: Prime number theorem in short intervals, Huxley (1972): primes in short intervals, Selberg sieve applications. Cross-refs: erdos-462-conjecture, erdos-462-asymptotic"
   }
 ]

--- a/src/data/proofs/erdos-467/annotations.json
+++ b/src/data/proofs/erdos-467/annotations.json
@@ -3,172 +3,130 @@
     "id": "erdos-467-residue-assign",
     "proofId": "erdos-467",
     "type": "definition",
-    "range": { "startLine": 33, "endLine": 34 },
+    "range": {
+      "startLine": 33,
+      "endLine": 34
+    },
     "title": "Residue Assignment",
     "content": "A `ResidueAssignment x` is a function assigning to each prime $p \\leq x$ a residue class $a_p$. The assignment determines which integers each prime 'covers': prime $p$ covers $n$ when $n \\equiv a_p \\pmod{p}$.",
     "significance": "essential",
-    "mathContext": {
-      "field": "combinatorial number theory / covering systems",
-      "latex": "\\text{ResidueAssignment}(x) : \\{p \\leq x : p \\text{ prime}\\} \\to \\mathbb{Z}/p\\mathbb{Z}",
-      "leanSignature": "def ResidueAssignment (x : ℕ) := (p : ℕ) → p.Prime → p ≤ x → ℕ",
-      "proofTechnique": "dependent function type over primes ≤ x",
-      "relatedTheorems": ["covering congruences", "Chinese Remainder Theorem"],
-      "formalizationNote": "Uses dependent types to restrict to primes ≤ x. The residue is a natural number; congruence is checked via `n % p = a % p`.",
-      "crossReferences": ["erdos-467-partition", "erdos-467-dual-covering"]
-    }
+    "mathContext": "combinatorial number theory / covering systems. LaTeX: \\text{ResidueAssignment}(x) : \\{p \\leq x : p \\text{ prime}\\} \\to \\mathbb{Z}/p\\mathbb{Z}. Lean: def ResidueAssignment (x : ℕ) := (p : ℕ) → p.Prime → p ≤ x → ℕ. Technique: dependent function type over primes ≤ x. Uses dependent types to restrict to primes ≤ x. The residue is a natural number; congruence is checked via `n % p = a % p`.. Related: covering congruences, Chinese Remainder Theorem. Cross-refs: erdos-467-partition, erdos-467-dual-covering"
   },
   {
     "id": "erdos-467-partition",
     "proofId": "erdos-467",
     "type": "definition",
-    "range": { "startLine": 37, "endLine": 40 },
+    "range": {
+      "startLine": 37,
+      "endLine": 40
+    },
     "title": "Prime Partition Structure",
     "content": "A `PrimePartition x` partitions primes $\\leq x$ into sets $A$ and $B$ via a Boolean classifier `inA`. Both sets must be non-empty (witnessed by existential proofs).",
     "significance": "essential",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "\\{p \\leq x : p \\text{ prime}\\} = A \\sqcup B,\\quad A \\neq \\emptyset,\\, B \\neq \\emptyset",
-      "leanSignature": "structure PrimePartition (x : ℕ) where inA : (p : ℕ) → p.Prime → p ≤ x → Bool; nonemptyA : ...; nonemptyB : ...",
-      "proofTechnique": "Boolean classification with non-emptiness witnesses",
-      "formalizationNote": "Uses `Bool` for the classifier rather than `Prop`, enabling computation. The non-emptiness fields are existential proofs.",
-      "crossReferences": ["erdos-467-residue-assign", "erdos-467-dual-covering"]
-    }
+    "mathContext": "combinatorial number theory. LaTeX: \\{p \\leq x : p \\text{ prime}\\} = A \\sqcup B,\\quad A \\neq \\emptyset,\\, B \\neq \\emptyset. Lean: structure PrimePartition (x : ℕ) where inA : (p : ℕ) → p.Prime → p ≤ x → Bool; nonemptyA : ...; nonemptyB : .... Technique: Boolean classification with non-emptiness witnesses. Uses `Bool` for the classifier rather than `Prop`, enabling computation. The non-emptiness fields are existential proofs.. Cross-refs: erdos-467-residue-assign, erdos-467-dual-covering"
   },
   {
     "id": "erdos-467-coverage-defs",
     "proofId": "erdos-467",
     "type": "definition",
-    "range": { "startLine": 42, "endLine": 56 },
+    "range": {
+      "startLine": 42,
+      "endLine": 56
+    },
     "title": "Coverage and Dual Covering",
     "content": "Defines `CoveredByA`, `CoveredByB`, and `IsDualCovering`. An integer $n$ is covered by $A$ if $\\exists p \\in A,\\, n \\equiv a_p \\pmod{p}$. A dual covering requires every $n < x$ is covered by both $A$ and $B$ independently.",
     "significance": "essential",
-    "mathContext": {
-      "field": "covering systems",
-      "latex": "\\text{IsDualCovering} :\\Leftrightarrow \\forall n < x,\\, (\\exists p \\in A,\\, n \\equiv a_p) \\wedge (\\exists q \\in B,\\, n \\equiv a_q)",
-      "leanSignature": "def IsDualCovering (x : ℕ) (assign : ResidueAssignment x) (part : PrimePartition x) : Prop := ∀ n : ℕ, n < x → CoveredByA x assign part n ∧ CoveredByB x assign part n",
-      "proofTechnique": "universal quantification with conjunction of two coverage conditions",
-      "relatedTheorems": ["covering system definition", "exact covering systems"],
-      "crossReferences": ["erdos-467-conjecture", "erdos-467-double-hit"]
-    }
+    "mathContext": "covering systems. LaTeX: \\text{IsDualCovering} :\\Leftrightarrow \\forall n < x,\\, (\\exists p \\in A,\\, n \\equiv a_p) \\wedge (\\exists q \\in B,\\, n \\equiv a_q). Lean: def IsDualCovering (x : ℕ) (assign : ResidueAssignment x) (part : PrimePartition x) : Prop := ∀ n : ℕ, n < x → CoveredByA x assign part n ∧ CoveredByB x assign part n. Technique: universal quantification with conjunction of two coverage conditions. Related: covering system definition, exact covering systems. Cross-refs: erdos-467-conjecture, erdos-467-double-hit"
   },
   {
     "id": "erdos-467-conjecture",
     "proofId": "erdos-467",
     "type": "conjecture",
-    "range": { "startLine": 62, "endLine": 68 },
+    "range": {
+      "startLine": 62,
+      "endLine": 68
+    },
     "title": "Main Conjecture: Erdős Problem 467",
     "content": "For all sufficiently large $x$, there exist a residue assignment and a prime partition achieving dual coverage. The problem asks whether the redundancy in prime residue classes ($\\sum 1/p$ diverges) is enough to split primes into two halves that each cover everything.",
     "significance": "essential",
-    "mathContext": {
-      "field": "combinatorial number theory / covering systems",
-      "latex": "\\exists X,\\, \\forall x \\geq X,\\, \\exists (a_p)_{p \\leq x},\\, \\exists A \\sqcup B,\\, \\text{IsDualCovering}(x)",
-      "leanSignature": "axiom erdos_467_conjecture : ∃ X : ℕ, ∀ x : ℕ, x ≥ X → ∃ assign : ResidueAssignment x, ∃ part : PrimePartition x, IsDualCovering x assign part",
-      "proofTechnique": "existential statement — asks for construction or probabilistic existence",
-      "relatedTheorems": ["Erdős covering congruence problems", "Hough's theorem", "Lovász Local Lemma"],
-      "references": ["Erdős–Graham (1980), p.93", "erdosproblems.com/467"],
-      "designChoices": "Axiomatized since the problem is open. The quantifier structure (∃X, ∀x≥X, ∃assign, ∃part) carefully captures 'for sufficiently large x'.",
-      "crossReferences": ["erdos-467-coverage-defs", "erdos-467-mertens"]
-    }
+    "mathContext": "combinatorial number theory / covering systems. LaTeX: \\exists X,\\, \\forall x \\geq X,\\, \\exists (a_p)_{p \\leq x},\\, \\exists A \\sqcup B,\\, \\text{IsDualCovering}(x). Lean: axiom erdos_467_conjecture : ∃ X : ℕ, ∀ x : ℕ, x ≥ X → ∃ assign : ResidueAssignment x, ∃ part : PrimePartition x, IsDualCovering x assign part. Technique: existential statement — asks for construction or probabilistic existence. Related: Erdős covering congruence problems, Hough's theorem, Lovász Local Lemma. Refs: Erdős–Graham (1980), p.93, erdosproblems.com/467. Cross-refs: erdos-467-coverage-defs, erdos-467-mertens. Design: Axiomatized since the problem is open. The quantifier structure (∃X, ∀x≥X, ∃assign, ∃part) carefully captures 'for sufficiently large x'."
   },
   {
     "id": "erdos-467-residue-basics",
     "proofId": "erdos-467",
     "type": "result",
-    "range": { "startLine": 74, "endLine": 98 },
+    "range": {
+      "startLine": 74,
+      "endLine": 98
+    },
     "title": "Residue Class Properties (Proved)",
     "content": "Seven fully proved basic properties: $n \\bmod p < p$, $n \\bmod p = 0 \\iff p \\mid n$, $n \\bmod 2 \\in \\{0,1\\}$, residue periodicity $(a + kp) \\bmod p = a \\bmod p$, every $n \\geq 2$ has a prime factor, prime factors are $\\leq n$, and for $n < x$ prime factors are $\\leq x$.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "modular arithmetic",
-      "latex": "n \\bmod p < p,\\quad n \\bmod p = 0 \\iff p \\mid n",
-      "proofTechnique": "direct application of Nat.mod, Nat.dvd, and Nat.minFac lemmas",
-      "formalizationNote": "All seven results are fully proved with no sorry.",
-      "crossReferences": ["erdos-467-zero-assignment"]
-    }
+    "mathContext": "modular arithmetic. LaTeX: n \\bmod p < p,\\quad n \\bmod p = 0 \\iff p \\mid n. Technique: direct application of Nat.mod, Nat.dvd, and Nat.minFac lemmas. All seven results are fully proved with no sorry.. Cross-refs: erdos-467-zero-assignment"
   },
   {
     "id": "erdos-467-zero-assignment",
     "proofId": "erdos-467",
     "type": "result",
-    "range": { "startLine": 110, "endLine": 138 },
+    "range": {
+      "startLine": 110,
+      "endLine": 138
+    },
     "title": "Zero Assignment Analysis (Proved)",
     "content": "The zero assignment $a_p = 0$ for all $p$ is fully analyzed: $n = 0$ is covered by every prime, $n = 1$ is never covered (no prime divides 1), and every $n \\geq 2$ is covered via its smallest prime factor. The equivalence `zero_assign_cover_iff`: coverage by $p$ iff $p \\mid n$.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "covering systems",
-      "latex": "a_p = 0 \\implies (p \\text{ covers } n \\iff p \\mid n)",
-      "leanSignature": "def zeroAssignment (x : ℕ) : ResidueAssignment x := fun _ _ _ => 0",
-      "proofTechnique": "modular arithmetic reduces to divisibility",
-      "formalizationNote": "Shows single-set coverage is easy for $n \\geq 2$ using all primes. The dual coverage challenge is splitting primes so both halves independently cover.",
-      "crossReferences": ["erdos-467-residue-assign"]
-    }
+    "mathContext": "covering systems. LaTeX: a_p = 0 \\implies (p \\text{ covers } n \\iff p \\mid n). Lean: def zeroAssignment (x : ℕ) : ResidueAssignment x := fun _ _ _ => 0. Technique: modular arithmetic reduces to divisibility. Shows single-set coverage is easy for $n \\geq 2$ using all primes. The dual coverage challenge is splitting primes so both halves independently cover.. Cross-refs: erdos-467-residue-assign"
   },
   {
     "id": "erdos-467-partition-props",
     "proofId": "erdos-467",
     "type": "result",
-    "range": { "startLine": 144, "endLine": 190 },
+    "range": {
+      "startLine": 144,
+      "endLine": 190
+    },
     "title": "Partition and Dual Covering Properties (Proved)",
     "content": "Six fully proved structural results. `dual_implies_A/B_covers`: projections. `dual_covering_double_hit`: every $n < x$ is hit by $\\geq 2$ primes (one from each side). `partition_uses_two_primes`: $\\geq 2$ primes required. `partition_has_distinct_labels`: $A \\neq B$. `partition_needs_prime`: $x \\geq 2$ necessary.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "combinatorial number theory",
-      "latex": "\\text{IsDualCovering} \\implies \\forall n < x,\\, \\exists p \\in A,\\, \\exists q \\in B",
-      "proofTechnique": "direct decomposition of conjunction and existential witnesses",
-      "formalizationNote": "All six results are fully proved. `dual_covering_double_hit` is the key structural lemma.",
-      "crossReferences": ["erdos-467-coverage-defs"]
-    }
+    "mathContext": "combinatorial number theory. LaTeX: \\text{IsDualCovering} \\implies \\forall n < x,\\, \\exists p \\in A,\\, \\exists q \\in B. Technique: direct decomposition of conjunction and existential witnesses. All six results are fully proved. `dual_covering_double_hit` is the key structural lemma.. Cross-refs: erdos-467-coverage-defs"
   },
   {
     "id": "erdos-467-residue-periodicity",
     "proofId": "erdos-467",
     "type": "result",
-    "range": { "startLine": 196, "endLine": 209 },
+    "range": {
+      "startLine": 196,
+      "endLine": 209
+    },
     "title": "Residue Class Periodicity (Proved)",
     "content": "Three proved results: $(n + p) \\bmod p = n \\bmod p$ (periodicity), $a < p \\implies a \\bmod p = a$ (identity in range), and $n \\bmod p < p$ (range bound). These establish that each residue class covers exactly $1/p$ fraction of integers.",
     "significance": "supporting",
-    "mathContext": {
-      "field": "modular arithmetic",
-      "latex": "(n + p) \\bmod p = n \\bmod p",
-      "proofTechnique": "Nat.add_mod, Nat.mod_self, Nat.mod_eq_of_lt",
-      "crossReferences": ["erdos-467-residue-basics"]
-    }
+    "mathContext": "modular arithmetic. LaTeX: (n + p) \\bmod p = n \\bmod p. Technique: Nat.add_mod, Nat.mod_self, Nat.mod_eq_of_lt. Cross-refs: erdos-467-residue-basics"
   },
   {
     "id": "erdos-467-crt",
     "proofId": "erdos-467",
     "type": "result",
-    "range": { "startLine": 215, "endLine": 218 },
+    "range": {
+      "startLine": 215,
+      "endLine": 218
+    },
     "title": "CRT for Distinct Primes",
     "content": "For distinct primes $p, q$ and any residues $a, b$, the Chinese Remainder Theorem guarantees $\\exists n,\\, n \\equiv a \\pmod{p} \\wedge n \\equiv b \\pmod{q}$. Axiomatized; provable from `ZMod.chineseRemainder`. CRT implies coverage events from distinct primes are independent.",
     "significance": "essential",
-    "mathContext": {
-      "field": "number theory",
-      "latex": "p \\neq q \\text{ prime} \\implies \\forall a, b,\\, \\exists n,\\, n \\equiv a \\pmod{p} \\wedge n \\equiv b \\pmod{q}",
-      "leanSignature": "axiom crt_for_primes (p q a b : ℕ) (hp : p.Prime) (hq : q.Prime) (hne : p ≠ q) : ∃ n, n % p = a % p ∧ n % q = b % q",
-      "proofTechnique": "axiomatized (provable via ZMod.chineseRemainder)",
-      "relatedTheorems": ["Chinese Remainder Theorem", "ZMod.chineseRemainder"],
-      "formalizationNote": "CRT implies independence: the probability of avoiding coverage by coprime moduli is $\\prod (1 - 1/p)$.",
-      "crossReferences": ["erdos-467-mertens"]
-    }
+    "mathContext": "number theory. LaTeX: p \\neq q \\text{ prime} \\implies \\forall a, b,\\, \\exists n,\\, n \\equiv a \\pmod{p} \\wedge n \\equiv b \\pmod{q}. Lean: axiom crt_for_primes (p q a b : ℕ) (hp : p.Prime) (hq : q.Prime) (hne : p ≠ q) : ∃ n, n % p = a % p ∧ n % q = b % q. Technique: axiomatized (provable via ZMod.chineseRemainder). CRT implies independence: the probability of avoiding coverage by coprime moduli is $\\prod (1 - 1/p)$.. Related: Chinese Remainder Theorem, ZMod.chineseRemainder. Cross-refs: erdos-467-mertens"
   },
   {
     "id": "erdos-467-mertens",
     "proofId": "erdos-467",
     "type": "result",
-    "range": { "startLine": 224, "endLine": 229 },
+    "range": {
+      "startLine": 224,
+      "endLine": 229
+    },
     "title": "Mertens-type Estimate",
     "content": "By Mertens' third theorem, $\\prod_{p \\leq x} (1 - 1/p) \\sim e^{-\\gamma}/\\log x$, where $\\gamma \\approx 0.5772$ is the Euler-Mascheroni constant. This bounds the 'uncovered probability' — the fraction of integers not hit by any prime's residue class. For dual coverage, both $A$ and $B$ need enough primes that $\\prod_{p \\in A} (1 - 1/p)$ is small enough.",
     "significance": "essential",
-    "mathContext": {
-      "field": "analytic number theory",
-      "latex": "\\prod_{p \\leq x} \\left(1 - \\frac{1}{p}\\right) \\sim \\frac{e^{-\\gamma}}{\\log x}",
-      "leanSignature": "axiom mertens_product : ∃ c : ℝ, c > 0 ∧ ...",
-      "proofTechnique": "axiomatized (Mertens' third theorem)",
-      "relatedTheorems": ["Mertens' theorems", "Euler product for ζ(s)", "prime harmonic series divergence"],
-      "references": ["Mertens (1874)", "Hardy–Wright, An Introduction to the Theory of Numbers"],
-      "formalizationNote": "The axiom statement is incomplete — it only asserts positivity rather than the full Mertens asymptotic. A complete formalization would need the Euler-Mascheroni constant.",
-      "crossReferences": ["erdos-467-crt", "erdos-467-conjecture"]
-    }
+    "mathContext": "analytic number theory. LaTeX: \\prod_{p \\leq x} \\left(1 - \\frac{1}{p}\\right) \\sim \\frac{e^{-\\gamma}}{\\log x}. Lean: axiom mertens_product : ∃ c : ℝ, c > 0 ∧ .... Technique: axiomatized (Mertens' third theorem). The axiom statement is incomplete — it only asserts positivity rather than the full Mertens asymptotic. A complete formalization would need the Euler-Mascheroni constant.. Related: Mertens' theorems, Euler product for ζ(s), prime harmonic series divergence. Refs: Mertens (1874), Hardy–Wright, An Introduction to the Theory of Numbers. Cross-refs: erdos-467-crt, erdos-467-conjecture"
   }
 ]


### PR DESCRIPTION
## Summary
- Flatten `mathContext` from objects to strings in 8 annotation files that were breaking the TypeScript build
- Recent enricher batches (#2441, #2465) created `mathContext` as structured objects, but the `Annotation` type requires it to be an optional string
- Affected files: erdos-273, erdos-405, erdos-406, erdos-411, erdos-460, erdos-461, erdos-462, erdos-467

## Test plan
- [ ] `pnpm build` succeeds without type errors
- [ ] Website renders correctly with flattened mathContext strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)