### PR TITLE
enrich(erdos-488): deepen annotations and meta for divisibility density

### DIFF
--- a/src/data/proofs/erdos-488/annotations.json
+++ b/src/data/proofs/erdos-488/annotations.json
@@ -1,56 +1,122 @@
 [
   {
-    "id": "erdos-488-multiples",
+    "id": "imports-setup",
     "proofId": "erdos-488",
+    "range": { "startLine": 19, "endLine": 23 },
+    "type": "concept",
+    "title": "Imports and Dependencies",
+    "content": "Imports specific Mathlib modules: Nat.Basic for natural number arithmetic, Finset.Basic and Finset.Card for finite set operations and cardinality, Rat.Basic for rational arithmetic (used in density ratios), and Tactic for proof automation.",
+    "mathContext": "The formalization uses $\\mathbb{N}$, $\\mathbb{Q}$, and `Finset` (finite subsets of $\\mathbb{N}$). The density ratio $|B \\cap [1,N]|/N$ is computed in $\\mathbb{Q}$ to avoid rounding issues.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset operations", "rational arithmetic", "Lean 4 imports"],
+    "prerequisites": ["Lean 4 syntax", "Mathlib module structure"]
+  },
+  {
+    "id": "multiples-set-def",
+    "proofId": "erdos-488",
+    "range": { "startLine": 29, "endLine": 30 },
     "type": "definition",
-    "range": { "startLine": 27, "endLine": 29 },
     "title": "Multiples Set B(A)",
-    "content": "multiplesSet A is the set of positive integers divisible by some element of A. This is the central object: the problem studies the density regularity of this set.",
-    "significance": "essential"
+    "content": "Defines `multiplesSet A` as the set of positive integers divisible by some element of A. This is the central object of the problem — a union of arithmetic progressions whose density regularity is being studied.",
+    "mathContext": "$B(A) = \\{n \\in \\mathbb{N} : n \\geq 1 \\land \\exists a \\in A,\\; a \\mid n\\} = \\bigcup_{a \\in A} \\{a, 2a, 3a, \\ldots\\}$. This is the set of positive multiples of elements of $A$.",
+    "significance": "critical",
+    "relatedConcepts": ["arithmetic progressions", "divisibility", "Schnirelmann density", "multiplicative number theory"],
+    "prerequisites": ["divisibility relation", "set comprehension", "Finset membership"]
   },
   {
-    "id": "erdos-488-ratio",
+    "id": "counting-function",
     "proofId": "erdos-488",
+    "range": { "startLine": 35, "endLine": 36 },
     "type": "definition",
-    "range": { "startLine": 37, "endLine": 39 },
+    "title": "Multiples Counting Function",
+    "content": "Defines `multiplesCount A N` as the number of elements in B(A) ∩ [1,N], computed by filtering Finset.Icc 1 N for elements divisible by some a ∈ A. Marked noncomputable because the existence check involves quantification over a Finset.",
+    "mathContext": "$|B(A) \\cap [1, N]| = |\\{n \\in [1, N] : \\exists a \\in A,\\; a \\mid n\\}|$. By inclusion-exclusion: $|B(A) \\cap [1,N]| = \\sum_{\\emptyset \\neq S \\subseteq A} (-1)^{|S|+1} \\lfloor N / \\operatorname{lcm}(S) \\rfloor$.",
+    "significance": "key",
+    "relatedConcepts": ["inclusion-exclusion principle", "floor function", "Finset.filter", "cardinality"],
+    "prerequisites": ["Finset.Icc", "divisibility decidability", "Finset.filter"]
+  },
+  {
+    "id": "density-ratio",
+    "proofId": "erdos-488",
+    "range": { "startLine": 39, "endLine": 40 },
+    "type": "definition",
     "title": "Density Ratio",
-    "content": "multiplesRatio A N is |B(A) ∩ [1,N]| / N, the proportion of integers up to N that are multiples of some element of A.",
-    "significance": "essential"
+    "content": "Defines `multiplesRatio A N` as the proportion of integers in [1,N] that belong to B(A). This rational-valued function is the central quantity in the conjecture — the claim is that it can at most double as N increases past max(A).",
+    "mathContext": "$\\rho(A, N) = \\frac{|B(A) \\cap [1,N]|}{N} \\in \\mathbb{Q}$. As $N \\to \\infty$, $\\rho(A, N) \\to \\delta(B(A))$, the natural density. The conjecture states $\\rho(A, m) < 2 \\rho(A, n)$ for $m > n \\geq \\max(A)$.",
+    "significance": "critical",
+    "relatedConcepts": ["natural density", "asymptotic density", "Schnirelmann density", "rational division"],
+    "prerequisites": ["multiplesCount definition", "rational number casting"]
   },
   {
-    "id": "erdos-488-conjecture",
+    "id": "main-conjecture",
     "proofId": "erdos-488",
-    "type": "conjecture",
-    "range": { "startLine": 44, "endLine": 52 },
-    "title": "Erdős Problem 488",
-    "content": "For every finite A with elements ≥ 2 and m > n ≥ max(A), the density ratio satisfies |B∩[1,m]|/m < 2·|B∩[1,n]|/n. The density can at most double.",
-    "significance": "essential"
+    "range": { "startLine": 47, "endLine": 54 },
+    "type": "definition",
+    "title": "Erdős Problem 488: Density Doubling Inequality",
+    "content": "The main conjecture: for every finite set A with elements ≥ 2 and every m > n ≥ max(A), the density ratio at m is strictly less than twice the density ratio at n. This is stated as a Prop (not axiom), reflecting its status as a well-defined mathematical statement whose truth is unknown.",
+    "mathContext": "$\\text{ErdosProblem488} :\\equiv \\forall A \\subseteq \\mathbb{N}_{\\geq 2} \\text{ finite},\\; \\forall m > n \\geq \\max(A),\\; \\rho(A, m) < 2\\rho(A, n)$. The threshold $n \\geq \\max(A)$ ensures every element of $A$ has at least one multiple in $[1, n]$.",
+    "significance": "critical",
+    "relatedConcepts": ["density regularity", "doubling constants", "Erdős-Graham problems", "sieve bounds"],
+    "prerequisites": ["multiplesRatio definition", "Finset.max'", "Finset.Nonempty"]
   },
   {
-    "id": "erdos-488-optimal",
+    "id": "constant-optimal",
     "proofId": "erdos-488",
-    "type": "result",
-    "range": { "startLine": 59, "endLine": 65 },
+    "range": { "startLine": 62, "endLine": 68 },
+    "type": "theorem",
     "title": "Optimality of Constant 2",
-    "content": "The constant 2 is sharp: for A = {a}, n = 2a-1, m = 2a, the ratio of density ratios approaches 2 as a → ∞.",
-    "significance": "essential"
+    "content": "The constant 2 in the conjecture is sharp. For the singleton A = {a}, taking n = 2a-1 and m = 2a, the ratio of density ratios approaches 2 as a → ∞. The key insight is that ⌊(2a-1)/a⌋ = 1 while ⌊2a/a⌋ = 2, causing a near-doubling in the count.",
+    "mathContext": "For $A = \\{a\\}$: $\\rho(\\{a\\}, 2a) = 2/(2a) = 1/a$ and $\\rho(\\{a\\}, 2a-1) = 1/(2a-1)$. Thus $\\rho(\\{a\\}, 2a) / \\rho(\\{a\\}, 2a-1) = (2a-1)/a = 2 - 1/a \\to 2$ as $a \\to \\infty$.",
+    "significance": "critical",
+    "relatedConcepts": ["floor function discontinuities", "extremal examples", "sharpness of bounds"],
+    "prerequisites": ["multiplesRatio definition", "singleton count formula", "rational arithmetic"]
   },
   {
-    "id": "erdos-488-singleton",
+    "id": "singleton-count",
     "proofId": "erdos-488",
-    "type": "result",
-    "range": { "startLine": 69, "endLine": 70 },
-    "title": "Singleton Count",
-    "content": "For A = {a}, the multiples count |B∩[1,N]| = ⌊N/a⌋. This is the basic case from which the optimality example derives.",
-    "significance": "supporting"
+    "range": { "startLine": 73, "endLine": 74 },
+    "type": "theorem",
+    "title": "Singleton Count Formula",
+    "content": "For A = {a}, the multiples count |B∩[1,N]| = ⌊N/a⌋. This is the fundamental building block: the number of multiples of a in [1,N] is exactly the integer quotient N/a. The general case follows by inclusion-exclusion.",
+    "mathContext": "$|\\{n \\in [1,N] : a \\mid n\\}| = \\lfloor N/a \\rfloor$. The multiples are $a, 2a, \\ldots, \\lfloor N/a \\rfloor \\cdot a$.",
+    "significance": "key",
+    "relatedConcepts": ["integer division", "floor function", "arithmetic progression counting"],
+    "prerequisites": ["divisibility", "natural number division"]
   },
   {
-    "id": "erdos-488-davenport",
+    "id": "monotonicity-N",
     "proofId": "erdos-488",
-    "type": "result",
-    "range": { "startLine": 86, "endLine": 91 },
-    "title": "Davenport's Density",
-    "content": "The asymptotic density of B(A) exists in (0,1] for any finite set A of positive integers. This can be computed by inclusion–exclusion.",
-    "significance": "supporting"
+    "range": { "startLine": 77, "endLine": 78 },
+    "type": "theorem",
+    "title": "Monotonicity in N",
+    "content": "The multiples count is monotone non-decreasing: extending the interval [1,M] to [1,N] with M ≤ N can only add elements, never remove them. This basic property ensures the density ratio doesn't vanish.",
+    "mathContext": "If $M \\leq N$, then $B(A) \\cap [1,M] \\subseteq B(A) \\cap [1,N]$, so $|B(A) \\cap [1,M]| \\leq |B(A) \\cap [1,N]|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["monotone functions", "interval inclusion", "Finset.filter subset"],
+    "prerequisites": ["multiplesCount definition", "Finset.Icc monotonicity"]
+  },
+  {
+    "id": "subset-monotonicity",
+    "proofId": "erdos-488",
+    "range": { "startLine": 81, "endLine": 82 },
+    "type": "theorem",
+    "title": "Monotonicity in A",
+    "content": "Adding elements to A increases the multiples count: if A ⊆ B, then multiplesCount A N ≤ multiplesCount B N. More divisors means more multiples in any interval.",
+    "mathContext": "If $A \\subseteq B$, then $B(A) \\subseteq B(B)$, so $|B(A) \\cap [1,N]| \\leq |B(B) \\cap [1,N]|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["subset monotonicity", "union of sets", "Finset subset"],
+    "prerequisites": ["multiplesCount definition", "multiplesSet subset property"]
+  },
+  {
+    "id": "davenport-density",
+    "proofId": "erdos-488",
+    "range": { "startLine": 88, "endLine": 92 },
+    "type": "theorem",
+    "title": "Davenport's Density Theorem",
+    "content": "The asymptotic density δ(B(A)) exists in (0,1] for any finite set A of positive integers. The density ratio converges to δ in the usual ε-N₀ sense. This 1933 result of Davenport provides the foundation: the density is well-defined, and the conjecture asks about the rate of convergence.",
+    "mathContext": "Davenport (1933): For finite $A \\subset \\mathbb{N}_{\\geq 1}$, $\\exists \\delta \\in (0,1]$ such that $\\forall \\varepsilon > 0,\\; \\exists N_0,\\; \\forall N \\geq N_0,\\; |\\rho(A, N) - \\delta| < \\varepsilon$. The density equals $\\delta = \\sum_{\\emptyset \\neq S \\subseteq A} (-1)^{|S|+1} / \\operatorname{lcm}(S)$.",
+    "significance": "key",
+    "relatedConcepts": ["natural density", "inclusion-exclusion", "Davenport's theorem", "lcm", "Besicovitch's counterexample"],
+    "prerequisites": ["multiplesRatio definition", "rational absolute value", "convergence of sequences"]
   }
 ]

--- a/src/data/proofs/erdos-488/meta.json
+++ b/src/data/proofs/erdos-488/meta.json
@@ -19,70 +19,87 @@
     "sorries": 0,
     "erdosNumber": 488,
     "erdosUrl": "https://erdosproblems.com/488",
-    "erdosProblemStatus": "open"
+    "erdosProblemStatus": "open",
+    "references": [
+      "Erdős (1961): original formulation (with likely typo)",
+      "Erdős (1966): corrected formulation with a | n",
+      "Davenport (1933): natural density of sequences of multiples",
+      "Besicovitch (1935): sequences of multiples need not have asymptotic density",
+      "Halberstam & Roth (1966): Sequences, Chapter 2",
+      "https://erdosproblems.com/488"
+    ]
   },
   "overview": {
-    "historicalContext": "Erdős posed this problem in 1961 about the density regularity of multiples of a finite set. The 1961 version had a likely typo (a ∤ n instead of a | n), corrected in 1966. The constant 2 is shown to be optimal by the singleton example A = {a} with n = 2a-1, m = 2a.",
-    "problemStatement": "Let A be a finite set of integers ≥ 2 and B = {n ≥ 1 : a | n for some a ∈ A}. Is |B ∩ [1,m]|/m < 2·|B ∩ [1,n]|/n for all m > n ≥ max(A)?",
-    "proofStrategy": "The formalization defines the multiples set B(A), the counting function and density ratio, and states the conjecture as a universal inequality. The optimality of constant 2 is axiomatised via the singleton example.",
+    "historicalContext": "Erdős posed this problem in 1961, asking whether the density of multiples of a finite set satisfies a doubling inequality. The 1961 formulation contained a likely typographic error (writing $a \\nmid n$ instead of $a \\mid n$), corrected in a 1966 paper. The problem sits within the classical theory of sequences of multiples, initiated by Davenport's 1933 theorem that the natural density of the set of multiples of any sequence exists (extending Schnirelmann density ideas). Besicovitch (1935) showed that for infinite sets, the asymptotic density of multiples need not exist, making the finite-set case fundamentally different. The optimality claim — that the constant 2 cannot be improved — connects to the behavior of the floor function $\\lfloor N/a \\rfloor$ near the transition points $N = 2a - 1$ and $N = 2a$, where the density ratio jumps discontinuously. Halberstam and Roth's 1966 monograph 'Sequences' provides the definitive treatment of this circle of ideas, placing Erdős's question in the context of additive and multiplicative number theory.",
+    "problemStatement": "Let $A$ be a finite set of integers $\\geq 2$ and $B = \\{n \\geq 1 : a \\mid n \\text{ for some } a \\in A\\}$. Is it true that for every $m > n \\geq \\max(A)$, $\\frac{|B \\cap [1,m]|}{m} < 2 \\cdot \\frac{|B \\cap [1,n]|}{n}$?",
+    "proofStrategy": "The formalization defines the multiples set $B(A)$ as a set comprehension, then introduces a counting function `multiplesCount` using `Finset.filter` on `Finset.Icc 1 N`, and the density ratio as a rational quotient. The main conjecture is stated as a universal inequality over all finite $A$ and valid pairs $(n, m)$. Supporting results include the singleton count formula $|B(\\{a\\}) \\cap [1, N]| = \\lfloor N/a \\rfloor$, monotonicity of the counting function, and Davenport's theorem on the existence of asymptotic density. The optimality of the constant 2 is axiomatized via the singleton example $A = \\{a\\}$ with $n = 2a - 1$, $m = 2a$.",
     "keyInsights": [
-      "B(A) is the set of positive multiples of elements of A",
-      "The density ratio |B ∩ [1,N]|/N stabilises as N grows",
-      "The constant 2 is optimal: A = {a}, n = 2a-1, m = 2a gives ratio approaching 2",
-      "The 1961 version had a ∤ n (typo), corrected to a | n in 1966"
+      "**Multiples set as union of arithmetic progressions**: $B(A) = \\bigcup_{a \\in A} a\\mathbb{Z}_{>0}$, so $|B \\cap [1,N]|$ can be computed by inclusion-exclusion over the $\\lfloor N/a \\rfloor$ terms",
+      "**Density stabilization beyond max(A)**: For $N \\geq \\max(A)$, every element of $A$ contributes at least one multiple to $[1, N]$, and the density ratio $|B \\cap [1,N]|/N$ begins to stabilize toward its asymptotic limit",
+      "**Optimality via floor function jumps**: For $A = \\{a\\}$, the density ratio at $N = 2a - 1$ is $\\lfloor(2a-1)/a\\rfloor/(2a-1) = 1/(2a-1)$, while at $N = 2a$ it is $2/(2a)= 1/a$, giving a ratio approaching $2$ as $a \\to \\infty$",
+      "**Davenport's density theorem**: The natural density $\\delta(B(A)) = \\lim_{N \\to \\infty} |B \\cap [1,N]|/N$ exists for any finite $A$ and equals the inclusion-exclusion sum $\\sum_{\\emptyset \\neq S \\subseteq A} (-1)^{|S|+1} / \\operatorname{lcm}(S)$",
+      "**Connection to Besicovitch's counterexample**: For infinite sets, multiples need not have asymptotic density (Besicovitch, 1935), making the finite-set hypothesis essential to the problem"
     ]
   },
   "sections": [
     {
+      "id": "header-and-imports",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 24,
+      "summary": "Module docstring stating Erdős Problem 488 on the density doubling inequality for multiples of finite sets. Imports `Nat.Basic`, `Finset.Basic`, `Finset.Card`, `Rat.Basic`, and `Tactic`."
+    },
+    {
       "id": "multiples-set",
-      "title": "Multiples Set",
-      "startLine": 24,
-      "endLine": 29,
-      "summary": "Definition of B(A): positive integers divisible by some element of A."
+      "title": "Multiples Set Definition",
+      "startLine": 27,
+      "endLine": 30,
+      "summary": "Defines `multiplesSet A` as the set $B(A) = \\{n \\geq 1 : \\exists a \\in A,\\; a \\mid n\\}$ — the positive integers divisible by some element of $A$."
     },
     {
       "id": "counting-function",
-      "title": "Counting Function",
-      "startLine": 31,
-      "endLine": 39,
-      "summary": "multiplesCount and multiplesRatio: counting elements of B(A) in intervals and the density ratio."
+      "title": "Counting Function and Density Ratio",
+      "startLine": 34,
+      "endLine": 40,
+      "summary": "Defines `multiplesCount A N` as $|B(A) \\cap [1, N]|$ using `Finset.filter` and `multiplesRatio A N` as the rational quotient $|B(A) \\cap [1,N]| / N$."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture",
-      "startLine": 41,
-      "endLine": 53,
-      "summary": "Erdős Problem 488: the density ratio inequality |B∩[1,m]|/m < 2·|B∩[1,n]|/n."
+      "startLine": 44,
+      "endLine": 54,
+      "summary": "States `ErdosProblem488`: for all finite $A$ with elements $\\geq 2$ and $m > n \\geq \\max(A)$, the density ratio satisfies $\\frac{|B \\cap [1,m]|}{m} < 2 \\cdot \\frac{|B \\cap [1,n]|}{n}$."
     },
     {
       "id": "optimality",
       "title": "Optimality of Constant 2",
-      "startLine": 55,
-      "endLine": 66,
-      "summary": "The constant 2 cannot be improved, shown via A = {a}, n = 2a-1, m = 2a."
+      "startLine": 58,
+      "endLine": 68,
+      "summary": "Axiom `constant_2_optimal`: for any $\\varepsilon > 0$, there exists $a \\geq 2$ such that with $A = \\{a\\}$, $n = 2a - 1$, $m = 2a$, the ratio of density ratios exceeds $2 - \\varepsilon$."
     },
     {
-      "id": "basic-properties",
-      "title": "Inclusion–Exclusion for Multiples",
-      "startLine": 68,
+      "id": "inclusion-exclusion",
+      "title": "Inclusion-Exclusion for Multiples",
+      "startLine": 72,
       "endLine": 82,
-      "summary": "Singleton count formula, monotonicity, and subset monotonicity."
+      "summary": "Three axioms: the singleton count formula $|B(\\{a\\}) \\cap [1,N]| = \\lfloor N/a \\rfloor$, monotonicity of `multiplesCount` in $N$, and monotonicity in $A$ (adding elements increases the count)."
     },
     {
       "id": "davenport-density",
-      "title": "Davenport's Density",
-      "startLine": 84,
-      "endLine": 92,
-      "summary": "The asymptotic density of B(A) exists and lies in (0,1]."
+      "title": "Davenport's Density Theorem",
+      "startLine": 86,
+      "endLine": 93,
+      "summary": "Axiom `multiplesSet_density_exists`: the asymptotic density $\\delta(B(A))$ exists in $(0, 1]$ for any finite $A$ with all elements $\\geq 1$, and the density ratio converges to $\\delta$."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 488 on the regularity of density ratios for multiples of finite sets, with the optimality of the constant 2 and basic properties of multiples counting.",
-    "implications": "The conjecture, if true, would establish a strong uniformity property for the density of multiples, showing that the density ratio never doubles beyond the threshold max(A).",
+    "summary": "This formalization captures Erdős Problem 488 on the density regularity of multiples of finite sets, defining the key objects (multiples set, counting function, density ratio) and stating the main doubling inequality as a universal proposition. Supporting axioms establish the singleton count formula, monotonicity properties, the optimality of the constant 2, and Davenport's theorem on asymptotic density existence.",
+    "implications": "A proof of the conjecture would establish a fundamental uniformity property for the density of divisibility sequences: the density ratio can fluctuate but never more than doubles past the threshold $\\max(A)$. This connects to broader questions about the regularity of arithmetic functions and sieve methods, and would complement Davenport's density theorem with a quantitative stability bound.",
     "openQuestions": [
-      "Is the inequality |B∩[1,m]|/m < 2·|B∩[1,n]|/n true for all m > n ≥ max(A)?",
-      "Can the constant 2 be improved for specific families of sets A?",
-      "What is the relationship to Davenport's theorem on natural density of multiples?"
+      "Can the density doubling inequality be proved using sieve methods (e.g., the Selberg sieve or Brun's sieve applied to multiples)?",
+      "For which specific families of sets A (e.g., A consisting of primes, or A a geometric progression) can the constant be improved below 2?",
+      "What is the optimal constant for the density ratio inequality when A is allowed to be infinite but with bounded reciprocal sum $\\sum_{a \\in A} 1/a < \\infty$?",
+      "Is there a continuous analogue of this problem for Lebesgue-measurable sets, relating to the density of unions of scaled lattices?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enrichment pass for erdos-488 (Divisibility Density in Multiples of Finite Sets)
- Expanded from 6 to 10 annotations covering the full 93-line Lean file
- Fixed all annotation types and significance values to valid schema values
- Added `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to every annotation
- Expanded sections from 6 to 7, covering lines 1-93
- Deepened `historicalContext` with Davenport (1933), Besicovitch (1935), Halberstam-Roth (1966)
- Expanded `keyInsights` with bold formatting, LaTeX, and inclusion-exclusion details
- Added references to Davenport, Besicovitch, Halberstam-Roth

## Test plan
- [x] `pnpm annotations:build` passes (only expected axiom-type warnings)
- [x] All JSON valid
- [x] No out-of-bounds line references

🤖 Generated with [Claude Code](https://claude.com/claude-code)