### PR TITLE
enrich(erdos-502): deepen annotations and meta for two-distance sets

### DIFF
--- a/src/data/proofs/erdos-502/annotations.json
+++ b/src/data/proofs/erdos-502/annotations.json
@@ -1,56 +1,158 @@
 [
   {
-    "id": "two-distance-set",
+    "id": "ann-502-imports",
     "proofId": "erdos-502",
-    "range": { "startLine": 28, "endLine": 32 },
+    "range": { "startLine": 18, "endLine": 22 },
+    "type": "concept",
+    "title": "Imports",
+    "content": "Imports inner product space basics for the Euclidean metric on ℝⁿ, binomial coefficient library for C(n,k), finite set cardinality, and general tactics.",
+    "mathContext": "The formalization uses $\\text{dist}(x, y) = \\|x - y\\|$ from `InnerProductSpace`, binomial coefficients $\\binom{n}{k}$ from `Nat.choose`, and `Finset.card` for $|A|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euclidean distance", "inner product space", "binomial coefficients"],
+    "prerequisites": ["Lean 4 imports", "Mathlib analysis"]
+  },
+  {
+    "id": "ann-502-twodist",
+    "proofId": "erdos-502",
+    "range": { "startLine": 28, "endLine": 31 },
     "type": "definition",
     "title": "Two-Distance Set",
-    "content": "A finite set A ⊆ ℝⁿ where exactly two distinct distances occur among all pairs. Equivalently, the distance multiset {|x-y| : x ≠ y} has exactly two distinct values.",
-    "significance": "high"
+    "content": "A finite set A ⊆ ℝⁿ where exactly two distinct positive distances occur among all pairs. The definition existentially quantifies over the two distances d₁ ≠ d₂ > 0.",
+    "mathContext": "$\\text{IsTwoDistanceSet}(n, A) :\\equiv \\exists d_1, d_2 > 0,\\; d_1 \\neq d_2,\\; \\forall x \\neq y \\in A,\\; \\|x - y\\| \\in \\{d_1, d_2\\}$. The condition $d_1 \\neq d_2$ prevents degenerate equidistant sets.",
+    "significance": "critical",
+    "relatedConcepts": ["distance geometry", "equidistant sets", "few-distance sets", "Euclidean metric"],
+    "prerequisites": ["Finset", "dist from metric space", "real-valued distances"]
   },
   {
-    "id": "max-two-dist-size",
+    "id": "ann-502-maxsize",
     "proofId": "erdos-502",
-    "range": { "startLine": 35, "endLine": 36 },
+    "range": { "startLine": 34, "endLine": 35 },
     "type": "definition",
     "title": "Maximum Two-Distance Set Size",
-    "content": "f(n) = maxTwoDistSize(n) is the supremum over all two-distance sets in ℝⁿ. The goal is to determine this function exactly or asymptotically.",
-    "significance": "high"
+    "content": "f(n) = maxTwoDistSize(n) is the supremum of cardinalities of two-distance sets in ℝⁿ. This is the central quantity whose asymptotics the problem determines.",
+    "mathContext": "$f(n) = \\sup\\{|A| : A \\subseteq \\mathbb{R}^n,\\; A \\text{ is a two-distance set}\\}$. The supremum is achieved (a finite maximum exists) since two-distance sets in $\\mathbb{R}^n$ have bounded cardinality by the BBS theorem.",
+    "significance": "critical",
+    "relatedConcepts": ["extremal combinatorics", "supremum", "distance geometry"],
+    "prerequisites": ["IsTwoDistanceSet", "Finset.card", "sSup"]
   },
   {
-    "id": "binary-construction",
+    "id": "ann-502-binary",
     "proofId": "erdos-502",
-    "range": { "startLine": 42, "endLine": 49 },
+    "range": { "startLine": 41, "endLine": 42 },
     "type": "definition",
     "title": "Binary Vector Construction",
-    "content": "Vectors in {0,1}ⁿ with exactly two 1-coordinates. Any two such vectors have distance √2 (one common 1-coord) or 2 (no common 1-coord), giving a two-distance set of size C(n,2).",
-    "significance": "medium"
+    "content": "binaryTwoVec n i j creates the indicator vector e_i + e_j ∈ {0,1}ⁿ with exactly two 1-coordinates at positions i and j. These form the standard two-distance set construction.",
+    "mathContext": "$v_{ij} = e_i + e_j$ where $e_k$ is the $k$-th standard basis vector. For $\\{i,j\\} \\neq \\{i', j'\\}$: if $|\\{i,j\\} \\cap \\{i',j'\\}| = 1$, then $\\|v_{ij} - v_{i'j'}\\| = \\sqrt{2}$; if $\\{i,j\\} \\cap \\{i',j'\\} = \\emptyset$, then $\\|v_{ij} - v_{i'j'}\\| = 2$.",
+    "significance": "key",
+    "relatedConcepts": ["indicator vectors", "Johnson scheme", "Hamming distance"],
+    "prerequisites": ["Fin n → ℝ", "standard basis"]
   },
   {
-    "id": "lower-bound",
+    "id": "ann-502-distances",
     "proofId": "erdos-502",
-    "range": { "startLine": 57, "endLine": 60 },
+    "range": { "startLine": 45, "endLine": 49 },
     "type": "theorem",
-    "title": "Lower Bound C(n+1, 2)",
-    "content": "By projecting the binary construction into a suitable subspace, one obtains f(n) ≥ C(n+1, 2) = n(n+1)/2. This is the best known lower bound.",
-    "significance": "high"
+    "title": "Binary Vector Distances",
+    "content": "Any two distinct binary two-vectors have distance √2 or 2. This verifies that the binary construction is indeed a two-distance set.",
+    "mathContext": "For distinct pairs $(i_1, j_1) \\neq (i_2, j_2)$: $\\|v_{i_1 j_1} - v_{i_2 j_2}\\|^2 = 4 - 2|\\{i_1,j_1\\} \\cap \\{i_2,j_2\\}|$, giving distance $\\sqrt{2}$ (one shared index) or $2$ (no shared index).",
+    "significance": "key",
+    "relatedConcepts": ["Euclidean distance computation", "inner product", "binary codes"],
+    "prerequisites": ["binaryTwoVec", "dist", "Real.sqrt"]
   },
   {
-    "id": "upper-bound-bbs",
+    "id": "ann-502-basic-lower",
     "proofId": "erdos-502",
-    "range": { "startLine": 64, "endLine": 67 },
+    "range": { "startLine": 54, "endLine": 55 },
+    "type": "theorem",
+    "title": "Basic Lower Bound f(n) ≥ C(n, 2)",
+    "content": "The binary vector construction gives C(n, 2) = n(n-1)/2 distinct points in ℝⁿ, each a two-distance set. This is the simplest lower bound.",
+    "mathContext": "$|\\{e_i + e_j : 1 \\leq i < j \\leq n\\}| = \\binom{n}{2}$, so $f(n) \\geq \\binom{n}{2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["counting pairs", "binomial coefficient", "constructive lower bound"],
+    "prerequisites": ["binaryTwoVec", "binary_two_distances", "Nat.choose"]
+  },
+  {
+    "id": "ann-502-improved-lower",
+    "proofId": "erdos-502",
+    "range": { "startLine": 58, "endLine": 59 },
+    "type": "theorem",
+    "title": "Improved Lower Bound f(n) ≥ C(n+1, 2)",
+    "content": "By taking the binary construction in ℝⁿ⁺¹ (giving C(n+1, 2) points) and projecting onto an n-dimensional subspace that preserves the two-distance property, we get f(n) ≥ n(n+1)/2.",
+    "mathContext": "$f(n) \\geq \\binom{n+1}{2} = \\frac{n(n+1)}{2}$. The key insight: the binary vectors in $\\mathbb{R}^{n+1}$ lie in an $n$-dimensional affine subspace (they sum to $2$), so after translation they embed in $\\mathbb{R}^n$.",
+    "significance": "key",
+    "relatedConcepts": ["affine subspace", "projection", "dimension reduction"],
+    "prerequisites": ["lower_bound_basic", "affine embedding"]
+  },
+  {
+    "id": "ann-502-bbs",
+    "proofId": "erdos-502",
+    "range": { "startLine": 66, "endLine": 67 },
     "type": "theorem",
     "title": "Bannai–Bannai–Stanton Upper Bound",
-    "content": "f(n) ≤ C(n+2, 2) = (n+1)(n+2)/2. Proved using the polynomial method: associate to each distance a polynomial annihilating the Gram matrix, bounding the dimension of the resulting space.",
-    "significance": "high"
+    "content": "f(n) ≤ C(n+2, 2) = (n+1)(n+2)/2. The polynomial method: for each point a ∈ A, define p_a(x) = (‖x-a‖² - d₁²)(‖x-a‖² - d₂²). These polynomials are linearly independent in a space of dimension C(n+2, 2).",
+    "mathContext": "BBS (1983): For a two-distance set $A$ with distances $d_1, d_2$, define $p_a(x) = (\\|x-a\\|^2 - d_1^2)(\\|x-a\\|^2 - d_2^2)$. Then $p_a(b) = 0$ for $b \\neq a$ and $p_a(a) = d_1^2 d_2^2 > 0$, so $\\{p_a\\}_{a \\in A}$ are linearly independent. Since $p_a \\in \\mathbb{R}[x_1,\\ldots,x_n]_{\\leq 2}$, we get $|A| \\leq \\dim \\mathbb{R}[x_1,\\ldots,x_n]_{\\leq 2} = \\binom{n+2}{2}$.",
+    "significance": "critical",
+    "relatedConcepts": ["polynomial method", "Gram matrix", "linear independence", "dimension argument"],
+    "prerequisites": ["maxTwoDistSize", "Nat.choose", "polynomial space dimension"]
   },
   {
-    "id": "main-bounds",
+    "id": "ann-502-sandwich",
     "proofId": "erdos-502",
-    "range": { "startLine": 74, "endLine": 78 },
+    "range": { "startLine": 72, "endLine": 75 },
     "type": "theorem",
     "title": "Combined Sandwich Bound",
-    "content": "C(n+1,2) ≤ f(n) ≤ C(n+2,2), giving f(n) = Θ(n²). The gap is at most n+1, so the answer is determined up to a linear additive error.",
-    "significance": "high"
+    "content": "The main result: C(n+1,2) ≤ f(n) ≤ C(n+2,2), giving f(n) = Θ(n²). The additive gap is exactly n+1, so the answer is determined up to a linear correction term.",
+    "mathContext": "$\\binom{n+1}{2} \\leq f(n) \\leq \\binom{n+2}{2}$, i.e., $\\frac{n(n+1)}{2} \\leq f(n) \\leq \\frac{(n+1)(n+2)}{2}$. The gap is $\\binom{n+2}{2} - \\binom{n+1}{2} = n + 1$. This establishes $f(n) = \\frac{n^2}{2} + O(n)$.",
+    "significance": "critical",
+    "relatedConcepts": ["asymptotic analysis", "sandwich theorem", "quadratic growth"],
+    "prerequisites": ["lower_bound_improved", "upper_bound_bbs"]
+  },
+  {
+    "id": "ann-502-dim2",
+    "proofId": "erdos-502",
+    "range": { "startLine": 80, "endLine": 80 },
+    "type": "theorem",
+    "title": "Planar Case f(2) = 5",
+    "content": "In ℝ², the maximum two-distance set has exactly 5 points — the vertices of a regular pentagon. Note that C(3,2) = 3 < 5 < 6 = C(4,2), so this small case exceeds the projection lower bound.",
+    "mathContext": "$f(2) = 5$. The regular pentagon with unit edge has distances $1$ and $\\phi = \\frac{1+\\sqrt{5}}{2}$ (the golden ratio). Kelly (1947) proved $5$ is optimal in the plane.",
+    "significance": "key",
+    "relatedConcepts": ["regular pentagon", "golden ratio", "Kelly's theorem"],
+    "prerequisites": ["maxTwoDistSize", "planar geometry"]
+  },
+  {
+    "id": "ann-502-dim3",
+    "proofId": "erdos-502",
+    "range": { "startLine": 83, "endLine": 83 },
+    "type": "theorem",
+    "title": "Three-Dimensional Case f(3) = 6",
+    "content": "In ℝ³, the maximum two-distance set has 6 points, matching the lower bound C(4,2) = 6 exactly.",
+    "mathContext": "$f(3) = 6 = \\binom{4}{2}$. Unlike the planar case, the lower bound is tight here. The extremal configuration can be realized as the vertices of a regular octahedron.",
+    "significance": "supporting",
+    "relatedConcepts": ["octahedron", "tight bound", "three-dimensional geometry"],
+    "prerequisites": ["maxTwoDistSize", "lower_bound_improved"]
+  },
+  {
+    "id": "ann-502-coxeter",
+    "proofId": "erdos-502",
+    "range": { "startLine": 89, "endLine": 91 },
+    "type": "theorem",
+    "title": "Coxeter's Polynomial Growth Question",
+    "content": "Coxeter asked whether f(n) is polynomial in n. The BBS upper bound C(n+2,2) = O(n²) confirms polynomial growth, answering the original motivating question.",
+    "mathContext": "Coxeter's question: Is $f(n) \\leq n^{O(1)}$? Answer: Yes, $f(n) \\leq \\binom{n+2}{2} = \\frac{(n+1)(n+2)}{2} = O(n^2)$. This is a direct corollary of the BBS theorem.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial growth", "Coxeter", "asymptotic bounds"],
+    "prerequisites": ["upper_bound_bbs", "coxeter_polynomial_growth"]
+  },
+  {
+    "id": "ann-502-weaker",
+    "proofId": "erdos-502",
+    "range": { "startLine": 96, "endLine": 97 },
+    "type": "theorem",
+    "title": "Erdős's Original Weaker Bound",
+    "content": "Erdős obtained only f(n) ≤ n! (factorial/exponential) before BBS. This historical bound shows the dramatic improvement from exponential to quadratic achieved by the polynomial method.",
+    "mathContext": "$f(n) \\leq n!$. This exponential bound was the best Erdős could achieve after finding the error in his polynomial bound attempt. The BBS result $f(n) \\leq \\binom{n+2}{2} = O(n^2)$ was a dramatic improvement.",
+    "significance": "supporting",
+    "relatedConcepts": ["factorial bound", "exponential vs polynomial", "historical progress"],
+    "prerequisites": ["maxTwoDistSize", "Nat.factorial"]
   }
 ]

--- a/src/data/proofs/erdos-502/meta.json
+++ b/src/data/proofs/erdos-502/meta.json
@@ -6,6 +6,7 @@
   "meta": {
     "erdosNumber": 502,
     "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos502Problem.lean",
     "tags": [
       "erdos",
       "geometry",
@@ -16,65 +17,97 @@
     ],
     "references": [
       "Erdős (1961): original problem, posed by Coxeter",
-      "Bannai–Bannai–Stanton (1983): upper bound C(n+2,2)",
-      "Petrov–Pohoata (2021): simpler proof of BBS bound",
+      "Kelly (1947): early two-distance results in the plane",
+      "Bannai–Bannai–Stanton (1983): upper bound C(n+2,2) via polynomial method",
+      "Blokhuis (1984): simplified BBS proof using linear algebra",
+      "Petrov–Pohoata (2021): simpler proof via Croot–Lev–Pach polynomial method",
       "https://erdosproblems.com/502"
     ],
     "leanFile": "Proofs/Erdos502Problem.lean",
     "sorries": 0,
+    "badge": "formalized",
     "sourceUrl": "https://erdosproblems.com/502",
-    "erdosUrl": "https://erdosproblems.com/502"
+    "erdosUrl": "https://erdosproblems.com/502",
+    "erdosProblemStatus": "solved"
   },
   "sections": [
     {
+      "id": "header-and-imports",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 23,
+      "summary": "Module docstring stating the problem, its solved status, and references. Imports `Analysis.InnerProductSpace.Basic` for the metric structure on $\\mathbb{R}^n$, `Combinatorics.Choose.Basic` for binomial coefficients, and `Data.Finset.Card` for finite set cardinalities."
+    },
+    {
       "id": "core-definitions",
       "title": "Core Definitions",
-      "startLine": 25,
-      "endLine": 38,
-      "summary": "Define IsTwoDistanceSet and the maximum size function maxTwoDistSize."
+      "startLine": 24,
+      "endLine": 36,
+      "summary": "Defines `IsTwoDistanceSet n A` requiring exactly two distinct positive distances $d_1 \\neq d_2$ among all pairs in $A \\subseteq \\mathbb{R}^n$, and `maxTwoDistSize n = \\sup\\{|A| : A \\text{ is a two-distance set in } \\mathbb{R}^n\\}$."
     },
     {
       "id": "binary-construction",
       "title": "The Binary Vector Construction",
-      "startLine": 40,
-      "endLine": 52,
-      "summary": "Binary vectors with exactly two 1-coordinates form a two-distance set."
+      "startLine": 37,
+      "endLine": 50,
+      "summary": "Constructs `binaryTwoVec n i j` — indicator vectors $e_i + e_j \\in \\{0,1\\}^n$ — forming a two-distance set with distances $\\sqrt{2}$ (one shared coordinate) and $2$ (disjoint supports), giving $\\binom{n}{2}$ points."
     },
     {
-      "id": "bounds",
-      "title": "Lower and Upper Bounds",
-      "startLine": 54,
-      "endLine": 70,
-      "summary": "Lower bound C(n+1,2) from projections, upper bound C(n+2,2) from BBS."
+      "id": "lower-bound",
+      "title": "Lower Bounds",
+      "startLine": 51,
+      "endLine": 60,
+      "summary": "Basic lower bound $f(n) \\geq \\binom{n}{2}$ from binary vectors, improved to $f(n) \\geq \\binom{n+1}{2}$ via projection into a suitable $(n-1)$-dimensional affine subspace."
+    },
+    {
+      "id": "upper-bound",
+      "title": "Upper Bound — Bannai–Bannai–Stanton",
+      "startLine": 61,
+      "endLine": 68,
+      "summary": "The BBS theorem: $f(n) \\leq \\binom{n+2}{2}$. The proof associates to each point a polynomial vanishing on the other distance, bounding the dimension of the resulting polynomial space by $\\binom{n+2}{2}$."
     },
     {
       "id": "main-result",
-      "title": "Main Result and Small Cases",
-      "startLine": 72,
-      "endLine": 95,
-      "summary": "Combined sandwich bound and exact values for dimensions 2 and 3."
+      "title": "Main Combined Bounds",
+      "startLine": 69,
+      "endLine": 76,
+      "summary": "The sandwich theorem: $\\binom{n+1}{2} \\leq f(n) \\leq \\binom{n+2}{2}$, establishing $f(n) = \\Theta(n^2)$ with an additive gap of at most $n+1$."
+    },
+    {
+      "id": "small-cases",
+      "title": "Small Cases",
+      "startLine": 77,
+      "endLine": 84,
+      "summary": "Exact values: $f(2) = 5$ (vertices of a regular pentagon) and $f(3) = 6$. These match the lower bound $\\binom{3}{2} = 3$ and $\\binom{4}{2} = 6$ respectively, with the planar case being exceptional."
+    },
+    {
+      "id": "coxeter-question",
+      "title": "Coxeter's Original Question and Historical Context",
+      "startLine": 85,
+      "endLine": 98,
+      "summary": "Coxeter's question — is $f(n)$ polynomial? — answered affirmatively by BBS. Erdős's original weaker bound $f(n) \\leq n!$ (exponential) is stated as a historical record of the pre-BBS state of knowledge."
     }
   ],
   "overview": {
-    "historicalContext": "Coxeter asked Erdős for the maximum size of a two-distance set in ℝⁿ. Erdős initially believed f(n) ≤ n^O(1) but found an error in his proof, leaving only the weaker exponential bound. The polynomial bound was eventually established by Bannai, Bannai, and Stanton in 1983 using the polynomial method. Petrov and Pohoata gave a simpler proof in 2021.",
+    "historicalContext": "H.S.M. Coxeter posed this problem to Erdős around 1961, asking whether the maximum size of a two-distance set in $\\mathbb{R}^n$ is polynomial in $n$. Erdős initially believed he could prove $f(n) \\leq n^{O(1)}$ but discovered an error, leaving only exponential bounds. The question remained open until Bannai, Bannai, and Stanton (1983) proved $f(n) \\leq \\binom{n+2}{2}$ using the polynomial method: for a two-distance set with distances $d_1, d_2$, the polynomials $p_a(x) = (\\|x-a\\|^2 - d_1^2)(\\|x-a\\|^2 - d_2^2)$ are linearly independent in a space of dimension $\\binom{n+2}{2}$, yielding the bound. Blokhuis (1984) simplified the argument using linear algebra over the Gram matrix. In 2021, Petrov and Pohoata gave an even simpler proof leveraging the Croot–Lev–Pach polynomial method from additive combinatorics. For the lower bound, the binary vector construction $\\{e_i + e_j : i < j\\}$ gives $\\binom{n}{2}$ points; a clever projection into $\\mathbb{R}^n$ from $\\mathbb{R}^{n+1}$ improves this to $\\binom{n+1}{2}$. The exact value $f(n)$ is known only for small $n$: Kelly (1947) showed $f(2) = 5$ (regular pentagon), and $f(3) = 6$ is classical.",
     "problemStatement": "Given n, find the maximum cardinality f(n) of a finite set A ⊆ ℝⁿ such that the set of pairwise distances {|x-y| : x ≠ y ∈ A} has exactly two elements.",
-    "proofStrategy": "We formalize the two-distance set definition, the binary vector construction giving C(n+1,2), and the Bannai–Bannai–Stanton upper bound C(n+2,2). The gap between C(n+1,2) and C(n+2,2) remains open for general n.",
+    "proofStrategy": "The formalization defines the two-distance set property, constructs binary vectors as witnesses for the lower bound, and states the Bannai–Bannai–Stanton upper bound. The main theorem combines both into the sandwich $\\binom{n+1}{2} \\leq f(n) \\leq \\binom{n+2}{2}$. Small cases $f(2) = 5$ and $f(3) = 6$ are axiomatized. Coxeter's polynomial growth question is resolved as a direct corollary of BBS.",
     "keyInsights": [
-      "Binary vectors with exactly two 1-coordinates give a two-distance set with distances √2 and 2",
-      "A suitable projection improves the lower bound from C(n,2) to C(n+1,2)",
-      "The Bannai–Bannai–Stanton proof uses the polynomial/Gram matrix method",
-      "The exact value is known for small dimensions: f(2) = 5, f(3) = 6",
-      "The gap between C(n+1,2) and C(n+2,2) is open for general n"
+      "**Binary vector construction**: Vectors $e_i + e_j \\in \\{0,1\\}^n$ give distances $\\sqrt{2}$ (shared coordinate) or $2$ (disjoint), yielding $\\binom{n}{2}$ points; projection improves this to $\\binom{n+1}{2}$",
+      "**Polynomial method for upper bound**: For distances $d_1, d_2$, the polynomials $p_a(x) = (\\|x-a\\|^2 - d_1^2)(\\|x-a\\|^2 - d_2^2)$ are linearly independent in $\\mathbb{R}[x_1,\\ldots,x_n]_{\\leq 2}$, whose dimension is $\\binom{n+2}{2}$",
+      "**Tight quadratic growth**: The gap $\\binom{n+2}{2} - \\binom{n+1}{2} = n+1$ is small, so $f(n) = \\frac{n^2}{2} + O(n)$ — the answer is known up to a linear correction",
+      "**Exceptional small cases**: $f(2) = 5$ (regular pentagon, beating $\\binom{3}{2} = 3$) shows the lower bound is not always tight; by $n = 3$, $f(3) = 6 = \\binom{4}{2}$ matches the lower bound exactly",
+      "**Evolution of proof techniques**: From Erdős's failed polynomial attempt (1961) through BBS's Gram matrix method (1983) to Petrov–Pohoata's Croot–Lev–Pach approach (2021) — each generation simplified the argument using new algebraic tools"
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #502 asks for the maximum two-distance set in ℝⁿ. The answer is Θ(n²): the Bannai–Bannai–Stanton upper bound C(n+2,2) and the projection lower bound C(n+1,2) sandwich f(n) quadratically in n. The problem is considered solved.",
-    "implications": "The result confirms that two-distance sets grow quadratically, answering Coxeter's original question. The polynomial method used in the proof has become a fundamental tool in discrete geometry and combinatorics.",
+    "summary": "Erdős Problem #502 asks for the maximum two-distance set in $\\mathbb{R}^n$. The answer is $\\Theta(n^2)$: the Bannai–Bannai–Stanton upper bound $\\binom{n+2}{2}$ and the projection lower bound $\\binom{n+1}{2}$ sandwich $f(n)$ with an additive gap of $n+1$. The formalization captures both bounds, the binary vector construction, exact small-case values, and the historical resolution of Coxeter's polynomial growth question.",
+    "implications": "The polynomial method, first applied here by Bannai–Bannai–Stanton, became one of the most powerful tools in combinatorial geometry. Its descendant, the Croot–Lev–Pach method (2016), resolved the cap set problem and led to Petrov–Pohoata's simplified proof. The two-distance problem is a prototype for the general $k$-distance problem, where the polynomial method gives $f_k(n) \\leq \\binom{n+k}{k}$.",
     "openQuestions": [
-      "What is the exact value of f(n) for all n?",
-      "Is f(n) = C(n+1,2) for all sufficiently large n?",
-      "What is the structure of extremal two-distance sets?",
-      "How does the answer change for k-distance sets with k ≥ 3?"
+      "Is $f(n) = \\binom{n+1}{2}$ for all sufficiently large $n$? This would close the linear gap between upper and lower bounds",
+      "What is the structure of extremal two-distance sets? Are they related to strongly regular graphs or spherical designs?",
+      "For $k$-distance sets ($k \\geq 3$), the gap between lower and upper bounds widens — can it be narrowed?",
+      "Does the answer change for two-distance sets on the sphere $S^{n-1}$ versus all of $\\mathbb{R}^n$?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Expanded annotations from 6→13 with full `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` on all entries
- Fixed invalid significance values (`high`/`medium`→`critical`/`key`/`supporting`)
- Added `proofRepoPath`, `badge`, `erdosProblemStatus` fields to meta
- Deepened `historicalContext` with Coxeter (1961), Kelly (1947), BBS (1983), Blokhuis (1984), Petrov–Pohoata (2021) timeline
- Added 5 bold `keyInsights` with polynomial method details and proof technique evolution
- Expanded sections from 4→8 covering full Lean file with LaTeX in summaries
- Added references for Kelly and Blokhuis

## Test plan
- [x] `pnpm annotations:build` passes (only expected axiom-type warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)