### PR TITLE
enrich(cauchy-schwarz): add references

### DIFF
--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -27,6 +27,12 @@
       "Triangle inequality derived from Cauchy-Schwarz",
       "Correlation coefficient bound as application"
     ],
+    "references": [
+      {"authors": "A.-L. Cauchy", "title": "Cours d'Analyse de l'École Royale Polytechnique", "year": "1821", "venue": "Paris", "note": "First proof of the discrete (finite sum) version of the inequality"},
+      {"authors": "V. Y. Bunyakovsky", "title": "Sur quelques inégalités concernant les intégrales ordinaires et les intégrales aux différences finies", "year": "1859", "venue": "Mémoires de l'Académie Impériale des Sciences de St.-Pétersbourg", "note": "Extension to integrals"},
+      {"authors": "H. A. Schwarz", "title": "Über ein die Flächen kleinsten Flächeninhalts betreffendes Problem der Variationsrechnung", "year": "1885", "venue": "Acta Societatis Scientiarum Fennicae", "note": "Independent proof of the integral version"},
+      {"authors": "J. M. Steele", "title": "The Cauchy-Schwarz Master Class", "year": "2004", "venue": "Cambridge University Press", "note": "Comprehensive treatment of Cauchy-Schwarz and related inequalities"}
+    ],
     "dateAdded": "12/26/25",
     "wiedijkNumber": 78
   },


### PR DESCRIPTION
## Summary
- Add 4 references to meta.json: Cauchy 1821, Bunyakovsky 1859, Schwarz 1885, Steele 2004

## Test plan
- [x] `pnpm annotations:build` passes (no cauchy-schwarz warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)