### PR TITLE
enrich(de-moivre): add references, fix annotation types

### DIFF
--- a/src/data/proofs/de-moivre/annotations.json
+++ b/src/data/proofs/de-moivre/annotations.json
@@ -31,7 +31,7 @@
     "title": "Exponential Form",
     "content": "**Two equivalent exponential formulations**:\n\n1. $(e^{\\theta I})^n = e^{n\\theta I}$ — with $\\theta I$ ordering\n2. $(e^{I\\theta})^n = e^{I \\cdot n\\theta}$ — with $I\\theta$ ordering\n\nBoth reduce to `exp_nat_mul` plus `ring` (to rearrange the exponent). These are the 'cleanest' statements because they avoid the trigonometric functions entirely — the identity is purely about the exponential function.\n\n**Why two versions**: Mathlib's `exp_mul_I` uses $\\theta \\cdot I$ ordering, but mathematical convention often writes $e^{i\\theta}$ with $I$ first. Both orderings are provided for convenience.",
     "mathContext": "(exp(θI))^n = exp(nθI)",
-    "significance": "major",
+    "significance": "key",
     "relatedConcepts": ["exponential function", "complex analysis", "ring tactic"],
     "prerequisites": ["complex exponential", "exp power rule for natural number exponents"]
   },
@@ -43,7 +43,7 @@
     "title": "Integer Exponents",
     "content": "De Moivre's theorem extends to **all integers** (including negative):\n\n$$(\\cos\\theta + i\\sin\\theta)^{n} = \\cos(n\\theta) + i\\sin(n\\theta) \\quad \\text{for } n \\in \\mathbb{Z}$$\n\nFor $n = -1$: $(\\cos\\theta + i\\sin\\theta)^{-1} = \\cos\\theta - i\\sin\\theta = \\overline{e^{i\\theta}}$\n\nThis is the **complex conjugate** — geometrically, reflection across the real axis. On the unit circle, $z^{-1} = \\bar{z}$ because $|z| = 1$.\n\n**Lean**: Uses `Complex.exp_int_mul` (integer version of the power rule) and `zpow` (integer exponentiation). The trigonometric form `de_moivre_int'` reuses `de_moivre_int` after Euler's formula conversion, with `ofReal_intCast` for the ℤ → ℝ → ℂ coercion chain.",
     "mathContext": "(cos θ + i sin θ)^n for n ∈ ℤ",
-    "significance": "major",
+    "significance": "key",
     "relatedConcepts": ["complex conjugate", "negative exponents", "zpow", "Complex.exp_int_mul"],
     "prerequisites": ["integer exponentiation (zpow)", "complex conjugation", "unit circle geometry"]
   },
@@ -55,7 +55,7 @@
     "title": "Double and Triple Angle Formulas",
     "content": "**n = 2** (double angle):\n$$\\cos(2\\theta) + i\\sin(2\\theta) = (\\cos\\theta + i\\sin\\theta)^2$$\n\nExpanding the RHS and comparing real/imaginary parts:\n$$\\cos(2\\theta) = \\cos^2\\theta - \\sin^2\\theta, \\quad \\sin(2\\theta) = 2\\sin\\theta\\cos\\theta$$\n\n**n = 3** (triple angle):\n$$\\cos(3\\theta) = 4\\cos^3\\theta - 3\\cos\\theta, \\quad \\sin(3\\theta) = 3\\sin\\theta - 4\\sin^3\\theta$$\n\n**Lean**: Both are one-liners — just `exact de_moivre θ 2` and `exact de_moivre θ 3`. The binomial expansion and real/imaginary separation are not formalized here, but the complex-valued identities follow immediately. This demonstrates the power of De Moivre: all multiple-angle formulas are special cases of a single theorem.",
     "mathContext": "cos(2θ) = cos²θ - sin²θ, sin(2θ) = 2 sin θ cos θ",
-    "significance": "major",
+    "significance": "key",
     "relatedConcepts": ["trig identities", "angle formulas", "Chebyshev polynomials", "binomial expansion"],
     "prerequisites": ["De Moivre's theorem (main)", "binomial theorem for complex numbers"]
   },
@@ -75,7 +75,7 @@
     "id": "ann-applications",
     "proofId": "de-moivre",
     "range": {"startLine": 210, "endLine": 240},
-    "type": "note",
+    "type": "concept",
     "title": "Applications and Exports",
     "content": "**De Moivre's theorem is fundamental to**:\n\n| Domain | Application |\n|--------|------------|\n| **Signal processing** | Fourier analysis: DFT uses roots of unity |\n| **Electrical engineering** | AC circuits: phasor representation |\n| **Physics** | Wave mechanics, quantum theory |\n| **Number theory** | Cyclotomic fields, Galois theory |\n| **Numerical analysis** | FFT algorithm relies on roots of unity |\n\n**The elegance**: Powers become multiplication of angles, roots become division of angles. A rotation by angle $\\theta$ iterated $n$ times is a rotation by $n\\theta$ — De Moivre's theorem is the algebraic expression of this geometric fact.\n\nThe `#check` statements export all six main theorems for use in other modules.",
     "mathContext": "Powers ↔ angle multiplication, roots ↔ angle division",

--- a/src/data/proofs/de-moivre/meta.json
+++ b/src/data/proofs/de-moivre/meta.json
@@ -19,6 +19,11 @@
       {"theorem": "Complex.exp_two_pi_mul_I", "description": "exp(2πi) = 1", "module": "Mathlib.Analysis.SpecialFunctions.Complex.Circle"}
     ],
     "originalContributions": ["Extension to integer exponents", "Double and triple angle formula derivations", "Roots of unity connection via exp(2πik/n)"],
+    "references": [
+      {"authors": "A. de Moivre", "title": "Aequationum quarundam Potestatis tertiae, quintae, septimae...", "year": "1707", "venue": "Philosophical Transactions", "note": "Earliest implicit form of de Moivre's formula"},
+      {"authors": "L. Euler", "title": "Introductio in analysin infinitorum", "year": "1748", "venue": "Lausanne", "note": "Modern formulation connecting e^{iθ} = cos θ + i sin θ to de Moivre's theorem"},
+      {"authors": "T. Needham", "title": "Visual Complex Analysis", "year": "1997", "venue": "Oxford University Press", "note": "Geometric interpretation of de Moivre as iterated rotation"}
+    ],
     "dateAdded": "12/26/25",
     "wiedijkNumber": 17
   },


### PR DESCRIPTION
## Summary
- Add 3 references to meta.json: de Moivre 1707, Euler 1748, Needham 1997
- Fix annotation significance: `major` → `key` (3 instances)
- Fix annotation type: `note` → `concept`

## Test plan
- [x] `pnpm annotations:build` passes (no de-moivre warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)