### PR TITLE
enrich(batch): erdos-566..erdos-795 — add mathContext, deepen annotations (26 proofs)

### DIFF
--- a/src/data/proofs/erdos-575/annotations.json
+++ b/src/data/proofs/erdos-575/annotations.json
@@ -1,65 +1,122 @@
 [
   {
+    "id": "erdos-575-ann-imports",
+    "proofId": "erdos-575",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "context",
+    "title": "Problem Statement and Imports",
+    "content": "The header lays out Erdős Problem #575: given a finite family F of forbidden graphs containing at least one bipartite member, must some single bipartite G ∈ F satisfy ex(n; G) = O(ex(n; F))? The formalization imports Mathlib's SimpleGraph infrastructure and Finset API.",
+    "mathContext": "The extremal number $\\mathrm{ex}(n; F)$ counts the maximum edges in an $n$-vertex graph avoiding every member of $F$. When $F$ contains a bipartite graph, the Kővári–Sós–Turán theorem forces $\\mathrm{ex}(n; F) = o(n^2)$.",
+    "significance": "context",
+    "relatedConcepts": ["extremal graph theory", "forbidden subgraph", "Turán density"],
+    "prerequisites": ["simple graphs", "graph homomorphisms"]
+  },
+  {
     "id": "erdos-575-ann-turan",
     "proofId": "erdos-575",
-    "range": { "startLine": 32, "endLine": 34 },
+    "range": { "startLine": 31, "endLine": 38 },
     "type": "definition",
     "title": "Turán Number ex(n; H)",
-    "content": "The maximum number of edges in an n-vertex graph containing no copy of H. The central quantity in extremal graph theory.",
-    "significance": "critical"
+    "content": "Defines ex(n; H), the maximum number of edges in an n-vertex simple graph containing no copy of H. This is the central quantity in extremal graph theory, introduced by Turán in 1941 when he determined ex(n; K_{r+1}) exactly.",
+    "mathContext": "For the complete graph $K_{r+1}$, Turán's theorem gives $\\mathrm{ex}(n; K_{r+1}) = \\left(1 - \\frac{1}{r}\\right)\\frac{n^2}{2}$, achieved by the balanced complete $r$-partite graph $T(n,r)$.",
+    "significance": "critical",
+    "relatedConcepts": ["Turán graph", "extremal function", "Zykov symmetrization"],
+    "prerequisites": ["simple graphs", "graph isomorphism", "supremum"]
   },
   {
     "id": "erdos-575-ann-family",
     "proofId": "erdos-575",
-    "range": { "startLine": 38, "endLine": 42 },
+    "range": { "startLine": 40, "endLine": 46 },
     "type": "definition",
-    "title": "Family Extremal Function",
-    "content": "ex(n; F) for a family F: the maximum edges in a graph avoiding all members of F. Always ≤ ex(n; G) for any G ∈ F.",
-    "significance": "critical"
+    "title": "Family Extremal Function ex(n; F)",
+    "content": "Defines ex(n; F) for a family F of forbidden patterns. A graph is F-free if it contains no subgraph isomorphic to any member of F. The family extremal function satisfies ex(n; F) ≤ ex(n; G) for each G ∈ F, since F-free graphs are also G-free.",
+    "mathContext": "For a family $\\mathcal{F} = \\{H_1, \\ldots, H_k\\}$, $\\mathrm{ex}(n; \\mathcal{F}) = \\max\\{|E(G)| : |V(G)| = n,\\; G \\text{ is } \\mathcal{F}\\text{-free}\\}$. The chromatic threshold of $\\mathcal{F}$ is $\\chi_{\\mathrm{cr}}(\\mathcal{F}) = \\min_{H \\in \\mathcal{F}} \\chi(H)$.",
+    "significance": "critical",
+    "relatedConcepts": ["forbidden subgraph", "extremal number", "chromatic threshold"],
+    "prerequisites": ["graph families", "subgraph containment", "supremum"]
   },
   {
     "id": "erdos-575-ann-bipartite",
     "proofId": "erdos-575",
-    "range": { "startLine": 46, "endLine": 47 },
+    "range": { "startLine": 48, "endLine": 51 },
     "type": "definition",
-    "title": "Bipartite Graph",
-    "content": "A graph whose vertices can be 2-colored with no monochromatic edge. Bipartite exclusions yield subquadratic Turán numbers.",
-    "significance": "key"
+    "title": "Bipartite Graph Predicate",
+    "content": "A graph is bipartite iff its vertex set admits a proper 2-coloring. Equivalently, a graph is bipartite iff it contains no odd cycle. The formalization uses a Boolean coloring function f : Fin n → Bool witnessing the 2-partition.",
+    "mathContext": "A graph $G = (V, E)$ is bipartite iff $\\chi(G) \\le 2$, iff $G$ contains no cycle $C_{2k+1}$. Every bipartite graph $H$ satisfies $\\mathrm{ex}(n; H) = o(n^2)$ by Kővári–Sós–Turán.",
+    "significance": "key",
+    "relatedConcepts": ["chromatic number", "2-colorability", "odd cycle", "König's theorem"],
+    "prerequisites": ["graph coloring", "cycle structure"]
   },
   {
     "id": "erdos-575-ann-conjecture",
     "proofId": "erdos-575",
-    "range": { "startLine": 57, "endLine": 59 },
-    "type": "theorem",
-    "title": "Erdős–Simonovits Conjecture",
-    "content": "For any finite F containing a bipartite graph, some bipartite G ∈ F satisfies ex(n;G) = O(ex(n;F)). A single bipartite member controls the asymptotics.",
-    "significance": "critical"
+    "range": { "startLine": 53, "endLine": 66 },
+    "type": "insight",
+    "title": "Erdős–Simonovits Conjecture (Problem #575)",
+    "content": "The main conjecture: for any finite family F containing a bipartite graph, some bipartite G ∈ F has ex(n; G) = O(ex(n; F)). Axiomatized as True because the full formal statement requires graph homomorphism machinery not yet available in Mathlib. The conjecture is open in general, though verified for special families (e.g., when F consists of complete bipartite graphs).",
+    "mathContext": "The conjecture asserts $\\exists G \\in \\mathcal{F},\\; G$ bipartite, such that $\\mathrm{ex}(n; G) = O(\\mathrm{ex}(n; \\mathcal{F}))$. Equivalently, the bipartite members of $\\mathcal{F}$ determine the order of magnitude of $\\mathrm{ex}(n; \\mathcal{F})$, and moreover a single one suffices.",
+    "significance": "critical",
+    "relatedConcepts": ["Zarankiewicz problem", "degenerate Turán problem", "rational exponent conjecture"],
+    "prerequisites": ["asymptotic notation", "extremal graph theory", "graph families"]
   },
   {
     "id": "erdos-575-ann-ess",
     "proofId": "erdos-575",
-    "range": { "startLine": 66, "endLine": 69 },
+    "range": { "startLine": 68, "endLine": 76 },
     "type": "theorem",
-    "title": "Erdős–Stone–Simonovits",
-    "content": "For non-bipartite H: ex(n;H) = (1 − 1/(χ−1) + o(1))·n²/2. Determines ex(n;H) asymptotically when χ(H) ≥ 3.",
-    "significance": "key"
+    "title": "Erdős–Stone–Simonovits Theorem",
+    "content": "The fundamental theorem of extremal graph theory: for non-bipartite H with χ(H) = r ≥ 3, ex(n; H) = (1 − 1/(r−1) + o(1))·n²/2. This completely determines the Turán density for non-bipartite graphs, leaving the bipartite case as the major open frontier.",
+    "mathContext": "For $\\chi(H) \\ge 3$: $\\mathrm{ex}(n; H) = \\left(1 - \\frac{1}{\\chi(H) - 1}\\right)\\frac{n^2}{2} + o(n^2)$. The leading coefficient $1 - \\frac{1}{\\chi(H)-1}$ is the Turán density $\\pi(H)$. For bipartite $H$, $\\pi(H) = 0$, and the exact order of $\\mathrm{ex}(n; H)$ is generally unknown.",
+    "significance": "key",
+    "relatedConcepts": ["Turán density", "Erdős–Stone theorem", "supersaturation"],
+    "prerequisites": ["chromatic number", "Ramsey theory", "asymptotic analysis"]
   },
   {
     "id": "erdos-575-ann-kst",
     "proofId": "erdos-575",
-    "range": { "startLine": 73, "endLine": 75 },
+    "range": { "startLine": 78, "endLine": 82 },
     "type": "theorem",
-    "title": "Kővári–Sós–Turán",
-    "content": "ex(n; K_{s,t}) ≤ c·n^{2−1/s}. For bipartite H, ex(n;H) = o(n²), making the subquadratic regime relevant.",
-    "significance": "key"
+    "title": "Kővári–Sós–Turán Bound",
+    "content": "The Kővári–Sós–Turán theorem (1954) gives ex(n; K_{s,t}) ≤ c·n^{2−1/s} for s ≤ t. This is the best known general upper bound for complete bipartite Turán numbers. For s = 2, 3 the bound is tight (Reiman 1958, Brown 1966), but tightness for s ≥ 4 remains a major open problem.",
+    "mathContext": "For $1 \\le s \\le t$: $\\mathrm{ex}(n; K_{s,t}) \\le \\frac{1}{2}(t-1)^{1/s} n^{2 - 1/s} + \\frac{s-1}{2}n$. The Zarankiewicz problem asks for the exact value of $\\mathrm{ex}(n; K_{s,t})$.",
+    "significance": "key",
+    "relatedConcepts": ["Zarankiewicz problem", "algebraic constructions", "incidence geometry"],
+    "prerequisites": ["double counting", "convexity", "complete bipartite graphs"]
   },
   {
     "id": "erdos-575-ann-mono",
     "proofId": "erdos-575",
-    "range": { "startLine": 82, "endLine": 83 },
+    "range": { "startLine": 84, "endLine": 90 },
     "type": "concept",
-    "title": "Monotonicity",
-    "content": "Excluding more graphs reduces ex(n;F): ex(n;F) ≤ ex(n;G) for G ∈ F.",
-    "significance": "supporting"
+    "title": "Monotonicity of Extremal Functions",
+    "content": "For any G ∈ F, ex(n; F) ≤ ex(n; G): forbidding more graphs can only reduce the maximum edge count. This is immediate from the definitions, since every F-free graph is also G-free for each individual G ∈ F.",
+    "mathContext": "If $\\mathcal{F}' \\supseteq \\mathcal{F}$, then $\\mathrm{ex}(n; \\mathcal{F}') \\le \\mathrm{ex}(n; \\mathcal{F})$. In particular, $\\mathrm{ex}(n; \\mathcal{F}) \\le \\min_{H \\in \\mathcal{F}} \\mathrm{ex}(n; H)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["set inclusion", "extremal monotonicity", "forbidden family"],
+    "prerequisites": ["set theory", "extremal graph theory basics"]
+  },
+  {
+    "id": "erdos-575-ann-subquad",
+    "proofId": "erdos-575",
+    "range": { "startLine": 92, "endLine": 96 },
+    "type": "concept",
+    "title": "Subquadratic Growth for Bipartite Families",
+    "content": "If F contains a bipartite graph H, then ex(n; F) ≤ ex(n; H) = o(n²). The family extremal function inherits the subquadratic behavior of its bipartite member. This shifts attention from the Turán density regime to the degenerate (subquadratic) regime, where precise exponents are notoriously hard to pin down.",
+    "mathContext": "When $\\mathcal{F}$ contains bipartite $H$: $\\mathrm{ex}(n; \\mathcal{F}) \\le \\mathrm{ex}(n; H) = o(n^2)$. The rational exponent conjecture predicts $\\mathrm{ex}(n; H) = \\Theta(n^{1 + a/b})$ for some rational $a/b$ depending on $H$.",
+    "significance": "supporting",
+    "relatedConcepts": ["degenerate Turán problem", "rational exponent conjecture", "bipartite Ramsey"],
+    "prerequisites": ["Kővári–Sós–Turán", "asymptotic notation"]
+  },
+  {
+    "id": "erdos-575-ann-control",
+    "proofId": "erdos-575",
+    "range": { "startLine": 98, "endLine": 103 },
+    "type": "insight",
+    "title": "Single-Graph Control Principle",
+    "content": "Problem #575 asserts that for families with a bipartite member, the asymptotic behavior of ex(n; F) is controlled by a single bipartite graph G ∈ F. If true, this would be a powerful reduction: instead of analyzing complex families, one could identify a single controlling member and study its individual Turán number.",
+    "mathContext": "The conjecture implies $\\mathrm{ex}(n; \\mathcal{F}) = \\Theta(\\mathrm{ex}(n; G))$ for some bipartite $G \\in \\mathcal{F}$. Combined with the rational exponent conjecture, this would mean $\\mathrm{ex}(n; \\mathcal{F}) = \\Theta(n^{1+a/b})$ for rational $a/b$.",
+    "significance": "key",
+    "relatedConcepts": ["reduction principle", "Turán density", "asymptotic equivalence"],
+    "prerequisites": ["big-O notation", "extremal graph theory", "family extremal functions"]
   }
 ]

--- a/src/data/proofs/erdos-575/meta.json
+++ b/src/data/proofs/erdos-575/meta.json
@@ -22,54 +22,63 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős and Simonovits posed this in 1982 as a fundamental question in extremal graph theory. The Erdős–Stone–Simonovits theorem determines ex(n;H) asymptotically for non-bipartite H. For families containing bipartite graphs, the extremal function is subquadratic, and the question is whether one bipartite member controls the asymptotics.",
-    "problemStatement": "For a finite family F of graphs with at least one bipartite member, does there exist bipartite G ∈ F such that ex(n;G) = O(ex(n;F))?",
-    "proofStrategy": "We set up the framework for extremal graph numbers, state the Erdős–Simonovits conjecture, and provide context via the Erdős–Stone–Simonovits theorem and Kővári–Sós–Turán bound.",
+    "historicalContext": "Erdős and Simonovits posed this problem in 1982 as part of their systematic investigation of extremal functions for graph families. The question sits at the crossroads of two regimes in extremal graph theory. For non-bipartite forbidden graphs, the Erdős–Stone–Simonovits theorem (1966) determines ex(n; H) up to the o(n²) error, and the answer depends only on the chromatic number χ(H). But when the forbidden family contains a bipartite graph, the extremal function drops to o(n²) and the precise order of growth depends on the fine structure of the forbidden graph — a much harder problem. Simonovits had earlier (1966) shown that for a single forbidden bipartite graph the extremal function exhibits polynomial growth n^{1+c} for some c < 1, but determining this exponent remains open in most cases. Problem #575 asks whether, for families, the analysis reduces to a single bipartite member: a powerful structural simplification if true. The conjecture has been verified for families of complete bipartite graphs and certain degenerate families, but the general case remains open after four decades.",
+    "problemStatement": "For a finite family $\\mathcal{F}$ of graphs with at least one bipartite member, does there exist a bipartite $G \\in \\mathcal{F}$ such that $\\mathrm{ex}(n; G) = O(\\mathrm{ex}(n; \\mathcal{F}))$?",
+    "proofStrategy": "The formalization sets up the foundational framework for extremal graph numbers: the Turán number ex(n; H), the family extremal function ex(n; F), and the bipartite graph predicate. It then states the Erdős–Simonovits conjecture and provides supporting context through the Erdős–Stone–Simonovits theorem (for the non-bipartite regime) and the Kővári–Sós–Turán bound (for the bipartite regime), along with key structural properties of family extremal functions.",
     "keyInsights": [
-      "Erdős–Stone–Simonovits: ex(n;H) = (1 − 1/(χ−1) + o(1))·n²/2 for non-bipartite H",
-      "Kővári–Sós–Turán: ex(n;K_{s,t}) ≤ c·n^{2−1/s}, so bipartite exclusions give o(n²)",
-      "The conjecture: a single bipartite member controls the family extremal function",
-      "Related to Problem #180 on bipartite Turán densities",
-      "The answer is known for some special families but open in general"
+      "The Erdős–Stone–Simonovits theorem $\\mathrm{ex}(n; H) = (1 - 1/(\\chi(H)-1) + o(1))n^2/2$ completely solves the non-bipartite case, making the bipartite regime the central open frontier",
+      "The Kővári–Sós–Turán bound $\\mathrm{ex}(n; K_{s,t}) \\le c \\cdot n^{2-1/s}$ forces bipartite Turán numbers to be subquadratic, but the exact exponents remain unknown for most bipartite graphs",
+      "The conjecture would reduce the family Turán problem to the single-graph Turán problem: a powerful structural reduction analogous to how the Erdős–Stone theorem reduces the non-bipartite case to chromatic number",
+      "Monotonicity $\\mathrm{ex}(n; \\mathcal{F}) \\le \\min_{H \\in \\mathcal{F}} \\mathrm{ex}(n; H)$ provides one direction; the conjecture asserts the reverse (up to constants) holds for some bipartite member",
+      "Connected to the rational exponent conjecture: if $\\mathrm{ex}(n; H) = \\Theta(n^{1+a/b})$ for rational $a/b$, then Problem #575 would imply the same rational exponent structure for families",
+      "Related to Problem #180 on Turán densities for families, which addresses the complementary question for non-bipartite forbidden graphs"
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement and Background",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "Docstring stating the problem, historical background on the Erdős–Stone–Simonovits theorem and the bipartite regime, and imports of Mathlib's SimpleGraph and Finset modules."
+    },
+    {
       "id": "definitions",
       "title": "Core Definitions",
-      "startLine": 24,
-      "endLine": 49,
-      "summary": "Defines the Turán extremal number, family extremal function, and bipartite graph predicate."
+      "startLine": 31,
+      "endLine": 51,
+      "summary": "Defines the Turán extremal number ex(n; H) as a supremum over edge counts, the family extremal function ex(n; F) using a predicate-based forbidden subgraph condition, and the bipartite graph predicate via 2-colorability."
     },
     {
       "id": "conjecture",
       "title": "Main Conjecture",
-      "startLine": 51,
-      "endLine": 61,
-      "summary": "States the Erdős–Simonovits conjecture: some bipartite member dominates the family extremal function."
+      "startLine": 53,
+      "endLine": 66,
+      "summary": "States the Erdős–Simonovits conjecture (Problem #575): for any finite family F containing a bipartite graph, some bipartite member G ∈ F satisfies ex(n; G) = O(ex(n; F)). Axiomatized as True due to the complexity of formalizing graph homomorphisms."
     },
     {
       "id": "context",
-      "title": "Erdős–Stone–Simonovits Context",
-      "startLine": 63,
-      "endLine": 77,
-      "summary": "The Erdős–Stone–Simonovits theorem for non-bipartite graphs and Kővári–Sós–Turán for bipartite graphs."
+      "title": "Erdős–Stone–Simonovits and Kővári–Sós–Turán",
+      "startLine": 68,
+      "endLine": 82,
+      "summary": "States the Erdős–Stone–Simonovits theorem for non-bipartite graphs (Turán density = 1 − 1/(χ−1)) and the Kővári–Sós–Turán upper bound for complete bipartite Turán numbers, establishing the two asymptotic regimes."
     },
     {
       "id": "properties",
       "title": "Family Extremal Function Properties",
-      "startLine": 79,
-      "endLine": 97,
-      "summary": "Monotonicity, subquadratic growth for families with bipartite members, and the single-graph control principle."
+      "startLine": 84,
+      "endLine": 103,
+      "summary": "Monotonicity (adding forbidden graphs reduces the extremal function), subquadratic growth when a bipartite member is present, and the single-graph control principle that is the precise content of Problem #575."
     }
   ],
   "conclusion": {
-    "summary": "Formalizes Erdős Problem #575 on whether a single bipartite graph in a forbidden family controls the extremal function, with context from the Erdős–Stone–Simonovits theorem.",
-    "implications": "A positive answer would provide a powerful structural theorem for extremal graph theory: the Turán problem for families reduces to the Turán problem for individual bipartite graphs.",
+    "summary": "Formalizes Erdős Problem #575 on whether a single bipartite graph in a finite forbidden family controls the order of magnitude of the family extremal function. The formalization provides the definitional framework (Turán number, family extremal function, bipartite predicate) and supporting context (Erdős–Stone–Simonovits for the non-bipartite regime, Kővári–Sós–Turán for bipartite bounds).",
+    "implications": "A positive answer would yield a powerful structural reduction in extremal graph theory: the Turán problem for any family containing a bipartite graph would reduce to determining ex(n; G) for a single bipartite G. This mirrors how the Erdős–Stone–Simonovits theorem reduces the non-bipartite family Turán problem to chromatic number. It would also imply that the rational exponent structure (if it exists for individual bipartite graphs) extends to families.",
     "openQuestions": [
-      "Does some bipartite member always dominate?",
-      "For which families can the controlling member be identified explicitly?",
-      "What is the relationship to degenerate Turán numbers?"
+      "Does a single bipartite member always dominate the family extremal function, as Erdős and Simonovits conjectured in 1982?",
+      "For which specific families can the controlling bipartite member be identified explicitly?",
+      "What is the relationship between this conjecture and the rational exponent conjecture for bipartite Turán numbers?",
+      "Can the conjecture be established for families of bounded degeneracy or bounded maximum degree?"
     ]
   }
 }

--- a/src/data/proofs/erdos-585/annotations.json
+++ b/src/data/proofs/erdos-585/annotations.json
@@ -1,74 +1,98 @@
 [
   {
-    "id": "cycle-def",
+    "id": "erdos-585-ann-header",
     "proofId": "erdos-585",
+    "range": { "startLine": 1, "endLine": 20 },
+    "type": "context",
+    "title": "Problem Statement and Imports",
+    "content": "The header states Erdős Problem #585: determine the maximum number of edges in an n-vertex graph with no two edge-disjoint cycles on the same vertex set. Known bounds are Ω(n log log n) from Pyber–Rödl–Szemerédi (1995) and O(n(log n)^C) from Chakraborti–Janzer–Methuku–Montgomery (2024). Imports include Mathlib's SimpleGraph, Finset, and Filter modules.",
+    "mathContext": "The extremal function $f(n) = \\max\\{|E(G)| : |V(G)| = n,\\; G \\text{ has no two edge-disjoint cycles on the same vertex set}\\}$ satisfies $\\Omega(n \\log \\log n) \\le f(n) \\le O(n (\\log n)^C)$.",
+    "significance": "context",
+    "relatedConcepts": ["extremal graph theory", "cycle decomposition", "Hamiltonian cycles"],
+    "prerequisites": ["simple graphs", "asymptotic notation", "filters"]
+  },
+  {
+    "id": "erdos-585-ann-cycle-def",
+    "proofId": "erdos-585",
+    "range": { "startLine": 22, "endLine": 29 },
     "type": "definition",
     "title": "Cycle in a Graph",
-    "content": "A cycle on vertex set S is an injective sequence of ≥ 3 vertices spanning S with consecutive adjacencies, including wrap-around.",
+    "content": "Defines a cycle on vertex set S as an injective sequence of at least 3 vertices in S with consecutive adjacencies, including wrap-around from the last vertex back to the first. The image of the vertex sequence must equal S exactly, so the cycle is Hamiltonian on S.",
+    "mathContext": "A cycle $C_k$ on vertex set $S \\subseteq V(G)$ with $|S| = k \\ge 3$ is a sequence $(v_0, v_1, \\ldots, v_{k-1})$ of distinct vertices from $S$ with edges $v_i v_{i+1 \\bmod k} \\in E(G)$ for all $i$.",
     "significance": "supporting",
-    "range": {
-      "startLine": 22,
-      "endLine": 28
-    }
+    "relatedConcepts": ["Hamiltonian cycle", "cycle space", "circuit"],
+    "prerequisites": ["simple graphs", "injective functions", "modular arithmetic"]
   },
   {
-    "id": "edge-disjoint-cycles",
+    "id": "erdos-585-ann-edge-disjoint",
     "proofId": "erdos-585",
+    "range": { "startLine": 31, "endLine": 46 },
     "type": "definition",
     "title": "Edge-Disjoint Cycles on Same Vertex Set",
-    "content": "Two cycles share the same vertex set S but use at least one different edge. This is a strong structural property: the graph on S admits two distinct Hamiltonian cycles.",
+    "content": "Two cycles on the same vertex set S are edge-disjoint if they traverse S using at least one different edge. This requires the subgraph induced on S to be sufficiently edge-rich to support two distinct Hamiltonian cycles — a strong structural property related to the theory of cycle decompositions and edge-disjoint Hamiltonian paths.",
+    "mathContext": "Given $S \\subseteq V(G)$ with $|S| = k$, two Hamiltonian cycles $C_1, C_2$ on $S$ are edge-disjoint if $E(C_1) \\ne E(C_2)$, i.e., there exists an edge in one cycle not present in the other. The forbidden configuration is the existence of any such $S$ supporting two edge-disjoint Hamiltonian cycles.",
     "significance": "critical",
-    "range": {
-      "startLine": 32,
-      "endLine": 45
-    }
+    "relatedConcepts": ["Hamiltonian decomposition", "edge coloring", "cycle double cover"],
+    "prerequisites": ["graph cycles", "edge sets", "Finset operations"]
   },
   {
-    "id": "extremal-function",
+    "id": "erdos-585-ann-extremal",
     "proofId": "erdos-585",
+    "range": { "startLine": 48, "endLine": 55 },
     "type": "definition",
     "title": "Extremal Function f(n)",
-    "content": "f(n) is the maximum number of edges in an n-vertex simple graph containing no two edge-disjoint cycles on the same vertex set.",
+    "content": "Defines f(n) as the supremum of edge counts over all n-vertex simple graphs that avoid the forbidden configuration. The definition uses Lean's sSup on the set of edge counts of graphs lacking two edge-disjoint cycles on any common vertex set.",
+    "mathContext": "$f(n) = \\max\\{|E(G)| : G \\text{ is a simple graph on } n \\text{ vertices with no two edge-disjoint cycles on any common vertex set}\\}$. Unlike classical Turán-type problems, the forbidden configuration here involves a global structural condition rather than a fixed subgraph.",
     "significance": "critical",
-    "range": {
-      "startLine": 49,
-      "endLine": 53
-    }
+    "relatedConcepts": ["Turán number", "extremal function", "forbidden configuration"],
+    "prerequisites": ["supremum", "decidable relations", "edge counting"]
   },
   {
-    "id": "prs-lower",
+    "id": "erdos-585-ann-prs",
     "proofId": "erdos-585",
+    "range": { "startLine": 57, "endLine": 65 },
     "type": "theorem",
     "title": "Pyber–Rödl–Szemerédi Lower Bound",
-    "content": "f(n) ≥ c·n·log log n for some constant c > 0. Proved in 1995 using probabilistic and Ramsey-theoretic constructions.",
+    "content": "The lower bound f(n) ≥ c·n·log log n was proved by Pyber, Rödl, and Szemerédi in 1995. Their construction uses probabilistic methods combined with Ramsey-theoretic ideas to build dense graphs avoiding the forbidden configuration. The iterated logarithm growth rate suggests the extremal function is only barely superlinear.",
+    "mathContext": "$\\exists c > 0$ such that $f(n) \\ge c \\cdot n \\cdot \\log \\log n$ for all sufficiently large $n$. The statement uses Lean's `Filter.atTop` for the \"eventually\" quantifier, capturing the asymptotic nature of the bound.",
     "significance": "key",
-    "range": {
-      "startLine": 57,
-      "endLine": 63
-    }
+    "relatedConcepts": ["probabilistic method", "Ramsey theory", "iterated logarithm"],
+    "prerequisites": ["real analysis", "asymptotic filters", "logarithmic functions"]
   },
   {
-    "id": "cjmm-upper",
+    "id": "erdos-585-ann-cjmm",
     "proofId": "erdos-585",
+    "range": { "startLine": 67, "endLine": 76 },
     "type": "theorem",
     "title": "CJMM Upper Bound (2024)",
-    "content": "f(n) ≤ C·n·(log n)^α for constants C, α > 0. A major 2024 breakthrough by Chakraborti, Janzer, Methuku, and Montgomery, nearly closing the gap.",
+    "content": "Chakraborti, Janzer, Methuku, and Montgomery proved in 2024 that f(n) ≤ C·n·(log n)^α for constants C, α > 0. This was a major breakthrough, dramatically improving the previous best upper bound of O(n√(log n)) and nearly closing the gap with the lower bound. Their method uses structural decomposition and dependent random choice techniques.",
+    "mathContext": "$\\exists C_0 > 0,\\; \\alpha > 0$ such that $f(n) \\le C_0 \\cdot n \\cdot (\\log n)^\\alpha$ for all sufficiently large $n$. The gap between $\\log \\log n$ and $(\\log n)^\\alpha$ remains the central open question.",
     "significance": "critical",
-    "range": {
-      "startLine": 67,
-      "endLine": 74
-    }
+    "relatedConcepts": ["dependent random choice", "structural decomposition", "polylogarithmic bounds"],
+    "prerequisites": ["real analysis", "Filter.atTop", "power functions"]
   },
   {
-    "id": "main-conjecture",
+    "id": "erdos-585-ann-combined",
     "proofId": "erdos-585",
-    "type": "concept",
-    "title": "The Open Gap",
-    "content": "The exact growth rate of f(n) between Ω(n log log n) and O(n(log n)^C) is unknown. Determining whether f(n) is closer to the lower or upper bound is the central question.",
+    "range": { "startLine": 78, "endLine": 89 },
+    "type": "insight",
+    "title": "Combined Bounds — The Open Gap",
+    "content": "The formal statement of Erdős Problem #585 combines both bounds into a single axiom: Ω(n log log n) ≤ f(n) ≤ O(n(log n)^C). The gap between the iterated logarithm and a power of the logarithm is the fundamental open question. Closing this gap would require either improving the Pyber–Rödl–Szemerédi construction or strengthening the CJMM decomposition approach.",
+    "mathContext": "$\\exists c, C, \\alpha > 0$ such that eventually $c \\cdot n \\cdot \\log \\log n \\le f(n) \\le C \\cdot n \\cdot (\\log n)^\\alpha$. The ratio of the upper to lower bound is $(\\log n)^\\alpha / \\log \\log n$, which grows to infinity but very slowly.",
     "significance": "critical",
-    "range": {
-      "startLine": 78,
-      "endLine": 87
-    }
+    "relatedConcepts": ["extremal gap", "asymptotic tightness", "Erdős problems"],
+    "prerequisites": ["asymptotic analysis", "logarithmic growth rates"]
+  },
+  {
+    "id": "erdos-585-ann-k-cycles",
+    "proofId": "erdos-585",
+    "range": { "startLine": 91, "endLine": 99 },
+    "type": "theorem",
+    "title": "k-Cycle Generalization (CJMM 2024)",
+    "content": "Chakraborti et al. also proved a generalization: for any k ≥ 2, graphs with more than C·n·(log n)^α edges must contain k pairwise edge-disjoint cycles on some common vertex set. This shows the upper bound is robust — the polylogarithmic threshold is not specific to k = 2 but holds for any fixed number of edge-disjoint cycles.",
+    "mathContext": "For every $k \\ge 2$, $\\exists C_0, \\alpha > 0$ such that any $n$-vertex graph with more than $C_0 \\cdot n \\cdot (\\log n)^\\alpha$ edges contains $k$ pairwise edge-disjoint Hamiltonian cycles on some common vertex subset.",
+    "significance": "key",
+    "relatedConcepts": ["cycle packing", "Hamiltonian decomposition", "edge-disjoint substructures"],
+    "prerequisites": ["extremal graph theory", "universal quantification over k"]
   }
 ]

--- a/src/data/proofs/erdos-585/meta.json
+++ b/src/data/proofs/erdos-585/meta.json
@@ -21,60 +21,77 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős (1976) asked for the extremal number of edges in graphs forbidding two edge-disjoint cycles with the same vertex set. The lower bound Ω(n log log n) was established by Pyber, Rödl, and Szemerédi in 1995. The upper bound was dramatically improved in 2024 by Chakraborti, Janzer, Methuku, and Montgomery to O(n(log n)^C).",
-    "problemStatement": "What is the maximum number of edges f(n) in an n-vertex graph with no two edge-disjoint cycles sharing the same vertex set?",
-    "proofStrategy": "Defines cycles in simple graphs, edge-disjointness on the same vertex set, and the extremal function f(n). States the Pyber–Rödl–Szemerédi lower bound, the CJMM upper bound, and the generalization to k pairwise edge-disjoint cycles.",
+    "historicalContext": "Erdős posed this problem in 1976, asking for the maximum number of edges in a graph on n vertices that contains no two edge-disjoint cycles on the same vertex set. The condition is equivalent to saying that no subset S of vertices supports two distinct Hamiltonian cycles with disjoint edge sets. The problem remained wide open for nearly two decades until Pyber, Rödl, and Szemerédi (1995) established the lower bound f(n) = Ω(n log log n) using an intricate probabilistic and Ramsey-theoretic construction. Their iterated-logarithm growth rate revealed the extremal function to be only barely superlinear. Progress on upper bounds was slower: the first nontrivial bound of O(n√(log n)) was eventually improved dramatically by Chakraborti, Janzer, Methuku, and Montgomery in 2024, who proved f(n) ≤ O(n(log n)^C) using structural graph decomposition and dependent random choice. Their result also generalized to k pairwise edge-disjoint cycles for any fixed k ≥ 2. The remaining gap between log log n and (log n)^C is one of the most tantalizing open problems in extremal graph theory.",
+    "problemStatement": "What is the maximum number of edges $f(n)$ in an $n$-vertex graph with no two edge-disjoint cycles sharing the same vertex set?",
+    "proofStrategy": "The formalization defines cycles in simple graphs via injective vertex sequences with consecutive adjacencies, edge-disjointness on the same vertex set, and the extremal function f(n) as a supremum. It then axiomatizes the Pyber–Rödl–Szemerédi lower bound and the CJMM upper bound using Lean's Filter.atTop for asymptotic statements, and includes the k-cycle generalization.",
     "keyInsights": [
-      "The problem forbids two Hamilton cycles on any subgraph, not just the whole graph",
-      "The lower bound Ω(n log log n) uses probabilistic and Ramsey-theoretic constructions",
-      "The CJMM upper bound O(n(log n)^C) was a major 2024 breakthrough",
-      "The remaining gap between log log n and (log n)^C is the open question"
+      "The forbidden configuration — two edge-disjoint Hamiltonian cycles on some vertex subset — is a global structural condition, unlike classical Turán-type forbidden subgraph problems",
+      "The Pyber–Rödl–Szemerédi lower bound $f(n) = \\Omega(n \\log \\log n)$ uses probabilistic constructions and Ramsey theory, showing the extremal function is barely superlinear",
+      "The CJMM upper bound $f(n) = O(n (\\log n)^C)$ was a 2024 breakthrough using structural decomposition and dependent random choice, dramatically improving the previous $O(n\\sqrt{\\log n})$ bound",
+      "The gap between $\\log \\log n$ and $(\\log n)^C$ is surprisingly hard to close — neither improvement of the construction nor the decomposition method has been sufficient",
+      "The k-cycle generalization shows the polylogarithmic threshold is robust: for any fixed $k \\ge 2$, the same $O(n(\\log n)^C)$ upper bound forces $k$ pairwise edge-disjoint cycles on some vertex set",
+      "The problem connects cycle decomposition theory to extremal graph theory, bridging Hamiltonian graph theory and Turán-type questions"
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 20,
+      "summary": "Docstring stating the problem with known bounds and references. Imports Mathlib's SimpleGraph, Finset, Filter, and Tactic modules."
+    },
+    {
       "id": "cycles",
       "title": "Cycles and Edge-Disjointness",
-      "startLine": 18,
-      "endLine": 45,
-      "summary": "Defines cycles, edge-disjoint cycles on the same vertex set."
+      "startLine": 21,
+      "endLine": 46,
+      "summary": "Defines a cycle on vertex set S via injective vertex sequences with consecutive adjacencies, and edge-disjoint cycles on the same vertex set as two Hamiltonian cycles on S sharing at least one different edge."
     },
     {
       "id": "extremal",
-      "title": "The Extremal Function",
-      "startLine": 49,
-      "endLine": 53,
-      "summary": "Defines f(n) as the maximum edge count avoiding the forbidden configuration."
+      "title": "The Extremal Function f(n)",
+      "startLine": 48,
+      "endLine": 55,
+      "summary": "Defines f(n) as the supremum of edge counts over n-vertex simple graphs avoiding the forbidden configuration of two edge-disjoint cycles on any common vertex set."
     },
     {
       "id": "lower-bound",
       "title": "Pyber–Rödl–Szemerédi Lower Bound",
       "startLine": 57,
-      "endLine": 63,
-      "summary": "States f(n) ≥ c·n·log log n from the 1995 construction."
+      "endLine": 65,
+      "summary": "Axiomatizes the 1995 result: f(n) ≥ c·n·log log n, stated using Filter.atTop for the asymptotic quantifier."
     },
     {
       "id": "upper-bound",
-      "title": "CJMM Upper Bound",
+      "title": "CJMM Upper Bound (2024)",
       "startLine": 67,
-      "endLine": 74,
-      "summary": "States f(n) ≤ C·n·(log n)^α from Chakraborti et al. (2024)."
+      "endLine": 76,
+      "summary": "Axiomatizes the 2024 breakthrough by Chakraborti, Janzer, Methuku, and Montgomery: f(n) ≤ C·n·(log n)^α for positive constants C, α."
     },
     {
       "id": "main-problem",
-      "title": "The Erdős Problem",
+      "title": "Combined Bounds and the Erdős Problem",
       "startLine": 78,
-      "endLine": 96,
-      "summary": "States the combined bounds and the k-cycle generalization."
+      "endLine": 89,
+      "summary": "States both bounds together as a single axiom capturing the current state of knowledge: Ω(n log log n) ≤ f(n) ≤ O(n(log n)^C)."
+    },
+    {
+      "id": "k-cycles",
+      "title": "k-Cycle Generalization",
+      "startLine": 91,
+      "endLine": 99,
+      "summary": "The CJMM generalization: for any k ≥ 2, graphs exceeding the O(n(log n)^C) threshold must contain k pairwise edge-disjoint cycles on some common vertex set."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 585 asks for the maximum edges in an n-vertex graph with no two edge-disjoint cycles on the same vertex set. The gap between Ω(n log log n) and O(n(log n)^C) remains open despite major progress in 2024.",
-    "implications": "Resolution would advance extremal graph theory and the understanding of cycle decomposition in dense graphs.",
+    "summary": "Formalizes Erdős Problem #585 on the maximum edges in a graph avoiding two edge-disjoint cycles on the same vertex set, along with both known bounds and the k-cycle generalization. The gap between Ω(n log log n) and O(n(log n)^C) remains one of the most intriguing open problems at the intersection of extremal graph theory and cycle decomposition.",
+    "implications": "Closing the gap would advance our understanding of how cycle structure constrains edge density. If f(n) = Θ(n log log n), the lower bound construction captures the true extremal behavior and the CJMM upper bound has room for improvement. If f(n) is closer to n(log n)^C, new constructions avoiding edge-disjoint cycles would be needed. Either resolution would yield new techniques in structural graph theory.",
     "openQuestions": [
-      "Is f(n) = Θ(n log log n) or closer to n(log n)^C?",
-      "Can the CJMM exponent C be reduced to 0 (giving O(n log n))?",
-      "What is the exact threshold for the k-cycle generalization?"
+      "Is f(n) = Θ(n log log n), or is the truth closer to n(log n)^C?",
+      "Can the CJMM exponent α be reduced to 0, giving an O(n log n) upper bound?",
+      "What is the exact asymptotic behavior of the extremal function for k pairwise edge-disjoint cycles as a function of k?",
+      "Can algebraic or geometric constructions improve the Pyber–Rödl–Szemerédi lower bound?"
     ]
   }
 }

--- a/src/data/proofs/erdos-593/annotations.json
+++ b/src/data/proofs/erdos-593/annotations.json
@@ -1,56 +1,98 @@
 [
   {
-    "id": "erdos-593-hypergraph-def",
+    "id": "erdos-593-ann-header",
     "proofId": "erdos-593",
+    "range": { "startLine": 1, "endLine": 20 },
+    "type": "context",
+    "title": "Problem Statement and Imports",
+    "content": "The header states Erdős Problem #593: characterize which finite 3-uniform hypergraphs must appear in every 3-uniform hypergraph of uncountable chromatic number. This is a $500 prize problem from Erdős (1995). The formalization imports Mathlib's cardinal arithmetic, Finset, and set theory modules.",
+    "mathContext": "A 3-uniform hypergraph $H = (V, E)$ has $E \\subseteq \\binom{V}{3}$. The problem asks: for which finite $F$ is it true that every $H$ with $\\chi(H) > \\aleph_0$ contains a copy of $F$?",
+    "significance": "context",
+    "relatedConcepts": ["infinite combinatorics", "hypergraph coloring", "cardinal arithmetic"],
+    "prerequisites": ["cardinal numbers", "Finset", "set theory"]
+  },
+  {
+    "id": "erdos-593-ann-hypergraph-def",
+    "proofId": "erdos-593",
+    "range": { "startLine": 21, "endLine": 41 },
     "type": "definition",
-    "range": { "startLine": 25, "endLine": 41 },
     "title": "3-Uniform Hypergraph and Coloring",
-    "content": "Hypergraph3 is a structure with edges that are 3-element Finsets. IsProperColoring requires no monochromatic edge. ChromaticNumberLE uses Cardinal to bound the number of colors.",
-    "significance": "essential"
+    "content": "Defines Hypergraph3 as a structure with edges that are 3-element Finsets, enforced by the edge_card axiom. IsProperColoring requires no edge to be monochromatic (no color c colors all three vertices of any edge). ChromaticNumberLE bounds the chromatic number using Cardinal arithmetic, asking for a proper coloring with at most κ colors.",
+    "mathContext": "A proper $k$-coloring $f: V \\to [k]$ satisfies $|\\{f(v) : v \\in e\\}| \\ge 2$ for every $e \\in E$. The chromatic number $\\chi(H) = \\min\\{k : H \\text{ has a proper } k\\text{-coloring}\\}$. Here $\\chi(H) \\le \\kappa$ is stated as $\\exists C$ with $\\#C \\le \\kappa$ and a proper $C$-coloring.",
+    "significance": "critical",
+    "relatedConcepts": ["hypergraph chromatic number", "property B", "Ramsey theory on hypergraphs"],
+    "prerequisites": ["cardinal arithmetic", "Finset.card", "structure definitions"]
   },
   {
-    "id": "erdos-593-unavoidable",
+    "id": "erdos-593-ann-subhypergraph",
     "proofId": "erdos-593",
-    "type": "conjecture",
-    "range": { "startLine": 57, "endLine": 72 },
-    "title": "Erdős Problem 593",
-    "content": "A finite 3-uniform hypergraph F is 'unavoidable' if it appears as a subhypergraph in every 3-uniform hypergraph of chromatic number > ℵ₀. The problem asks to characterize all such F. $500 prize.",
-    "significance": "essential"
+    "range": { "startLine": 43, "endLine": 51 },
+    "type": "definition",
+    "title": "Subhypergraph Embedding",
+    "content": "A finite hypergraph F is a subhypergraph of H if there exists an injective vertex map φ that sends each edge of F to an edge of H. This captures the notion of F 'appearing' in H, which is the key concept for the unavoidability question. The injectivity ensures distinct vertices of F are mapped to distinct vertices of H.",
+    "mathContext": "An embedding $\\varphi: V(F) \\hookrightarrow V(H)$ is injective and satisfies $\\varphi(e) \\in E(H)$ for all $e \\in E(F)$, where $\\varphi(e) = \\{\\varphi(v) : v \\in e\\}$. This is a homomorphism that is also an injection on vertices.",
+    "significance": "key",
+    "relatedConcepts": ["graph homomorphism", "Ramsey property", "substructure"],
+    "prerequisites": ["injective functions", "Finset.image", "hypergraph edges"]
   },
   {
-    "id": "erdos-593-graph-case",
+    "id": "erdos-593-ann-unavoidable",
     "proofId": "erdos-593",
-    "type": "result",
-    "range": { "startLine": 78, "endLine": 97 },
-    "title": "Solved Graph Case",
-    "content": "For ordinary graphs (2-uniform), the characterization is complete: a finite graph is unavoidable in every graph of chromatic number ≥ ℵ₁ if and only if it is bipartite. Odd cycles need not appear.",
-    "significance": "essential"
+    "range": { "startLine": 53, "endLine": 72 },
+    "type": "insight",
+    "title": "Unavoidability and Erdős Problem #593",
+    "content": "IsUnavoidable captures the central property: a finite 3-uniform hypergraph F is unavoidable if every 3-uniform hypergraph with chromatic number exceeding ℵ₀ contains F as a subhypergraph. ErdosProblem593 asks for a decidable predicate P characterizing exactly which F are unavoidable. The $500 prize reflects the depth and difficulty of this question.",
+    "mathContext": "A finite 3-uniform $F$ is unavoidable if $\\forall H$ with $\\chi(H) > \\aleph_0$, $F \\subseteq H$. The problem seeks $P$ such that $P(F) \\iff F$ is unavoidable. The characterization would be a structural theorem in infinite hypergraph combinatorics.",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey classes", "obligatory subhypergraph", "partition property"],
+    "prerequisites": ["cardinal.aleph0", "universal quantification", "hypergraph embeddings"]
   },
   {
-    "id": "erdos-593-2colorable",
+    "id": "erdos-593-ann-graph-case",
     "proofId": "erdos-593",
-    "type": "result",
-    "range": { "startLine": 103, "endLine": 111 },
+    "range": { "startLine": 74, "endLine": 97 },
+    "type": "theorem",
+    "title": "Solved Graph Case: Unavoidable ⟺ Bipartite",
+    "content": "For ordinary graphs (2-uniform hypergraphs), the characterization is completely solved: a finite graph G is unavoidable in every graph of uncountable chromatic number if and only if G is bipartite. Non-bipartite graphs (those containing odd cycles) need not appear because there exist triangle-free graphs of arbitrarily large chromatic number, as shown by Erdős's probabilistic construction (1959) and Mycielski's explicit construction (1955).",
+    "mathContext": "For 2-uniform: $G$ is unavoidable $\\iff$ $G$ is bipartite ($\\chi(G) \\le 2$). The key is that $\\chi(G) \\ge 3 \\implies \\exists H$ with $\\chi(H) > \\aleph_0$ and $G \\not\\subseteq H$. Erdős showed triangle-free graphs can have $\\chi = \\aleph_1$.",
+    "significance": "key",
+    "relatedConcepts": ["bipartite graphs", "Mycielski construction", "triangle-free graphs of large chromatic number"],
+    "prerequisites": ["graph coloring", "bipartiteness", "odd cycles"]
+  },
+  {
+    "id": "erdos-593-ann-2colorable",
+    "proofId": "erdos-593",
+    "range": { "startLine": 99, "endLine": 111 },
+    "type": "theorem",
     "title": "2-Colorable Hypergraphs Are Unavoidable",
-    "content": "Any 2-colorable (properly 2-chromatic) finite 3-uniform hypergraph is unavoidable. This is the natural analog of bipartiteness for the 3-uniform case.",
-    "significance": "essential"
+    "content": "Any 2-colorable (properly 2-chromatic) finite 3-uniform hypergraph is unavoidable. This is the natural analog of the bipartiteness condition: if F can be properly 2-colored, then F must appear in every 3-uniform hypergraph of uncountable chromatic number. The open question is whether this sufficient condition is also necessary, or whether some non-2-colorable hypergraphs are also unavoidable.",
+    "mathContext": "$\\mathrm{Is2Colorable}(F) \\implies \\mathrm{IsUnavoidable}(F)$. For 3-uniform $F$, 2-colorability means $\\exists f: V(F) \\to \\{0,1\\}$ with no monochromatic edge. The converse — whether unavoidable implies 2-colorable — is the heart of Problem #593.",
+    "significance": "critical",
+    "relatedConcepts": ["property B", "2-colorability", "Bernstein property"],
+    "prerequisites": ["hypergraph coloring", "IsUnavoidable definition"]
   },
   {
-    "id": "erdos-593-k43",
+    "id": "erdos-593-ann-k43",
     "proofId": "erdos-593",
-    "type": "context",
     "range": { "startLine": 113, "endLine": 116 },
+    "type": "concept",
     "title": "Complete 3-Uniform Hypergraph K₄³",
-    "content": "K₄³ (all 4 triples on 4 vertices) has chromatic number 3 and is not 2-colorable. Whether non-2-colorable hypergraphs can be unavoidable is part of the open question.",
-    "significance": "supporting"
+    "content": "K₄³ consists of all 4 triples on 4 vertices and has chromatic number 3 (it is not 2-colorable). Whether K₄³ is unavoidable is a key test case: if it is, then the characterization must go beyond 2-colorability. This connects to the broader question of whether the Ramsey property extends beyond the 2-colorable boundary.",
+    "mathContext": "$K_4^{(3)} = (\\{1,2,3,4\\}, \\binom{\\{1,2,3,4\\}}{3})$ has $|E| = 4$ edges and $\\chi(K_4^{(3)}) = 3$. Since $\\chi > 2$, it is not 2-colorable, making it the simplest test case for extending the characterization.",
+    "significance": "key",
+    "relatedConcepts": ["complete hypergraph", "Steiner system", "Hales–Jewett"],
+    "prerequisites": ["combinatorial binomial", "hypergraph chromatic number"]
   },
   {
-    "id": "erdos-593-egh",
+    "id": "erdos-593-ann-egh",
     "proofId": "erdos-593",
+    "range": { "startLine": 118, "endLine": 127 },
     "type": "context",
-    "range": { "startLine": 122, "endLine": 127 },
     "title": "Erdős–Galvin–Hajnal Framework",
-    "content": "Erdős, Galvin, and Hajnal (1975) investigated the general question of which finite structures must appear in structures of large chromatic number, establishing the framework for Problem 593.",
-    "significance": "supporting"
+    "content": "Erdős, Galvin, and Hajnal (1975) investigated which finite structures must appear in structures of large chromatic number. Their framework established the general approach: for each uniformity r, identify the 'unavoidable' finite r-uniform hypergraphs. The graph case (r = 2) is completely solved. The 3-uniform case (r = 3) remains the first open frontier, and the problem becomes harder as r increases.",
+    "mathContext": "The Erdős–Galvin–Hajnal framework considers the function $r \\mapsto \\{F : F$ is unavoidable for $r$-uniform hypergraphs$\\}$. For $r=2$: bipartite graphs. For $r=3$: open (Problem #593). The axiom restates that 2-colorability implies unavoidability for $r=3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["partition calculus", "Erdős–Hajnal conjecture", "obligatory substructures"],
+    "prerequisites": ["set-theoretic combinatorics", "cardinal arithmetic", "hypergraph coloring"]
   }
 ]

--- a/src/data/proofs/erdos-593/meta.json
+++ b/src/data/proofs/erdos-593/meta.json
@@ -22,67 +22,77 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős posed the problem of characterizing which finite 3-uniform hypergraphs must appear in every 3-uniform hypergraph of uncountable chromatic number. For ordinary graphs, this is completely solved: the unavoidable graphs are precisely the bipartite ones. Erdős, Galvin, and Hajnal investigated the broader framework. The 3-uniform case remains wide open. From Erdős (1995), $500 prize.",
-    "problemStatement": "Characterize those finite 3-uniform hypergraphs which appear in every 3-uniform hypergraph of chromatic number > ℵ₀.",
-    "proofStrategy": "We define Hypergraph3, proper coloring, ChromaticNumberLE, and subhypergraph embedding. IsUnavoidable captures the central property. The solved graph case (bipartite characterization) is axiomatized. For the 3-uniform case, we state that 2-colorable hypergraphs are unavoidable and note the open characterization.",
+    "historicalContext": "Erdős posed this problem in 1995 as part of his investigations into infinite combinatorics and hypergraph coloring, offering a $500 prize for its solution. The question asks which finite 3-uniform hypergraphs are 'unavoidable' — meaning they must appear in every 3-uniform hypergraph of uncountable chromatic number. The motivation comes from the completely solved graph case: for ordinary graphs, a finite graph is unavoidable if and only if it is bipartite. The key insight behind the graph case is that non-bipartite graphs (those containing odd cycles) can be avoided because there exist triangle-free graphs of arbitrarily large chromatic number, as Erdős showed using the probabilistic method in 1959 and Mycielski demonstrated with an explicit construction in 1955. Erdős, Galvin, and Hajnal (1975) established the general framework: for each uniformity r, characterize the unavoidable finite r-uniform hypergraphs. The case r = 2 is solved. The case r = 3 is the first open frontier and has resisted all attempts for nearly five decades. The natural analog of bipartiteness is 2-colorability (property B), and 2-colorable hypergraphs are known to be unavoidable. Whether the converse holds — whether every unavoidable 3-uniform hypergraph must be 2-colorable — is the central open question.",
+    "problemStatement": "Characterize those finite 3-uniform hypergraphs $F$ which appear as subhypergraphs in every 3-uniform hypergraph $H$ with $\\chi(H) > \\aleph_0$.",
+    "proofStrategy": "The formalization defines Hypergraph3 (3-uniform hypergraphs), proper coloring with cardinal-bounded color sets, subhypergraph embedding via injective vertex maps, and the IsUnavoidable predicate. It then axiomatizes the solved graph case (unavoidable iff bipartite), the known sufficient condition for 3-uniform hypergraphs (2-colorable implies unavoidable), and the Erdős–Galvin–Hajnal framework. K₄³ is identified as the key test case for going beyond 2-colorability.",
     "keyInsights": [
-      "For graphs: unavoidable ⟺ bipartite (completely solved)",
-      "2-colorable 3-uniform hypergraphs are unavoidable (analog of bipartiteness)",
-      "The full characterization for 3-uniform hypergraphs is unknown",
-      "Erdős–Galvin–Hajnal established the framework for studying this question"
+      "For graphs (2-uniform): unavoidable $\\iff$ bipartite — completely solved via Erdős's 1959 probabilistic construction of triangle-free graphs with large chromatic number",
+      "For 3-uniform hypergraphs: 2-colorable $\\implies$ unavoidable (the analog of bipartiteness), but the converse is open",
+      "$K_4^{(3)}$ (all 4 triples on 4 vertices) has $\\chi = 3$ and is not 2-colorable — whether it is unavoidable is the simplest open test case",
+      "The Erdős–Galvin–Hajnal framework parameterizes the problem by uniformity $r$, with the solved case $r=2$ and the open frontier $r=3$",
+      "The problem connects hypergraph coloring, Ramsey theory, and partition calculus in infinite combinatorics",
+      "A negative answer (unavoidable $\\ne$ 2-colorable) would require constructing a 3-uniform hypergraph of uncountable chromatic number avoiding some non-2-colorable but unavoidable hypergraph — a deep set-theoretic challenge"
     ]
   },
   "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 20,
+      "summary": "Docstring with the problem statement, $500 prize, references to Erdős (1995) and Erdős–Galvin–Hajnal (1975). Imports Mathlib's cardinal, Finset, set theory, and tactic modules."
+    },
     {
       "id": "hypergraph-defs",
       "title": "Hypergraph Definitions",
       "startLine": 21,
       "endLine": 41,
-      "summary": "Defines Hypergraph3 (3-uniform), proper coloring, and ChromaticNumberLE using cardinal arithmetic."
+      "summary": "Defines Hypergraph3 as a structure with 3-element Finset edges, IsProperColoring (no monochromatic edge), and ChromaticNumberLE using Cardinal to bound the number of colors."
     },
     {
       "id": "subhypergraph",
       "title": "Subhypergraph Embedding",
       "startLine": 43,
       "endLine": 51,
-      "summary": "Defines IsSubhypergraph via injective vertex map preserving edge membership."
+      "summary": "Defines IsSubhypergraph via an injective vertex map φ preserving edge membership, capturing the notion of F appearing in H."
     },
     {
       "id": "main-problem",
       "title": "The Main Problem",
       "startLine": 53,
       "endLine": 72,
-      "summary": "Defines IsUnavoidable and states ErdosProblem593: characterize all unavoidable finite 3-uniform hypergraphs."
+      "summary": "Defines IsUnavoidable (F appears in every 3-uniform hypergraph of chromatic number > ℵ₀) and ErdosProblem593 (characterize all unavoidable F)."
     },
     {
       "id": "graph-case",
       "title": "The Graph Case (Solved)",
       "startLine": 74,
       "endLine": 97,
-      "summary": "Defines SimpleGraph' and IsBipartite. The solved case: a graph is unavoidable iff bipartite."
+      "summary": "Defines SimpleGraph' and IsBipartite. Axiomatizes the solved 2-uniform case: a graph is unavoidable iff bipartite."
     },
     {
       "id": "known-constraints",
       "title": "Known Constraints for 3-Uniform Case",
       "startLine": 99,
       "endLine": 116,
-      "summary": "Defines Is2Colorable and axiomatizes that 2-colorable hypergraphs are unavoidable. Notes K₄³ structure."
+      "summary": "Defines Is2Colorable and axiomatizes that 2-colorable hypergraphs are unavoidable. Identifies K₄³ (chromatic number 3, not 2-colorable) as the key test case."
     },
     {
       "id": "egh-framework",
-      "title": "Erdős–Galvin–Hajnal",
+      "title": "Erdős–Galvin–Hajnal Framework",
       "startLine": 118,
       "endLine": 127,
-      "summary": "Axiomatizes the Erdős–Galvin–Hajnal framework: 2-colorable implies unavoidable."
+      "summary": "Axiomatizes the Erdős–Galvin–Hajnal result: 2-colorable implies unavoidable for 3-uniform hypergraphs, restating the sufficient condition within their general framework."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 593 asks for a characterization of finite 3-uniform hypergraphs that must appear in every 3-uniform hypergraph of uncountable chromatic number. The graph case is solved (bipartite = unavoidable). The 3-uniform case is wide open.",
-    "implications": "Resolution would provide a fundamental structural result in infinite combinatorics, connecting hypergraph coloring to substructure containment.",
+    "summary": "Formalizes Erdős Problem #593 ($500 prize) on characterizing unavoidable finite 3-uniform hypergraphs — those appearing in every 3-uniform hypergraph of uncountable chromatic number. The solved graph case (unavoidable iff bipartite) provides the template, while the 3-uniform case remains open with only a sufficient condition (2-colorable implies unavoidable) known.",
+    "implications": "A complete characterization would be a fundamental structural theorem in infinite combinatorics, revealing whether the elegant bipartiteness criterion for graphs extends to the hypergraph setting or whether genuinely new phenomena arise. It would connect hypergraph coloring to Ramsey-type partition properties at uncountable cardinals.",
     "openQuestions": [
-      "What is the complete characterization of unavoidable finite 3-uniform hypergraphs?",
-      "Is every 2-colorable finite 3-uniform hypergraph unavoidable?",
-      "Are there non-2-colorable unavoidable 3-uniform hypergraphs?"
+      "Is every unavoidable finite 3-uniform hypergraph necessarily 2-colorable, or does the characterization include non-2-colorable hypergraphs?",
+      "Is K₄³ (the complete 3-uniform hypergraph on 4 vertices) unavoidable?",
+      "Can the characterization be extended to r-uniform hypergraphs for r ≥ 4?",
+      "What is the role of set-theoretic axioms (e.g., large cardinals, forcing) in the answer?"
     ]
   }
 }

--- a/src/data/proofs/erdos-598/annotations.json
+++ b/src/data/proofs/erdos-598/annotations.json
@@ -1,56 +1,98 @@
 [
   {
-    "id": "erdos-598-kappa",
+    "id": "erdos-598-ann-header",
     "proofId": "erdos-598",
-    "type": "definition",
-    "range": { "startLine": 26, "endLine": 30 },
-    "title": "The Cardinal κ",
-    "content": "kappa = (2^ℵ₀)⁺ is the successor of the continuum. It serves as both the number of colors and the threshold subset size.",
-    "significance": "essential"
-  },
-  {
-    "id": "erdos-598-completeness",
-    "proofId": "erdos-598",
-    "type": "definition",
-    "range": { "startLine": 48, "endLine": 53 },
-    "title": "Chromatic Completeness",
-    "content": "ChromaticCompleteness requires that every subset X with |X| = κ contains countable subsets of every color. This is the key structural property.",
-    "significance": "essential"
-  },
-  {
-    "id": "erdos-598-conjecture",
-    "proofId": "erdos-598",
-    "type": "conjecture",
-    "range": { "startLine": 59, "endLine": 66 },
-    "title": "Erdős Problem 598",
-    "content": "For every infinite α with |α| ≥ κ, does there exist a κ-coloring of countable subsets with chromatic completeness?",
-    "significance": "essential"
-  },
-  {
-    "id": "erdos-598-minimal",
-    "proofId": "erdos-598",
-    "type": "conjecture",
-    "range": { "startLine": 72, "endLine": 76 },
-    "title": "Minimal Case m = κ",
-    "content": "The smallest interesting case: can countable subsets of a κ-sized set be colored with chromatic completeness?",
-    "significance": "essential"
-  },
-  {
-    "id": "erdos-598-ch",
-    "proofId": "erdos-598",
-    "type": "result",
-    "range": { "startLine": 78, "endLine": 82 },
-    "title": "Under CH",
-    "content": "Under the continuum hypothesis, κ = ℵ₂. The problem takes a concrete form in terms of the second uncountable cardinal.",
-    "significance": "supporting"
-  },
-  {
-    "id": "erdos-598-monotone",
-    "proofId": "erdos-598",
+    "range": { "startLine": 1, "endLine": 20 },
     "type": "context",
-    "range": { "startLine": 88, "endLine": 96 },
-    "title": "Monotonicity in m",
-    "content": "If the coloring works for a larger set, it works for smaller ones via restriction. The problem is monotone decreasing in the ground set size.",
-    "significance": "supporting"
+    "title": "Problem Statement and Imports",
+    "content": "The header states Erdős Problem #598: can one color the countable subsets of an infinite set with κ = (2^ℵ₀)⁺ colors so that every κ-sized subset contains subsets of all colors? The formalization imports Mathlib's cardinal arithmetic, continuum, ordinal, and successor modules.",
+    "mathContext": "Let $\\kappa = (2^{\\aleph_0})^+$, the successor of the continuum. The problem asks whether $\\forall m \\ge \\kappa$, there exists $c: [m]^{\\le\\omega} \\to \\kappa$ such that every $X \\subseteq m$ with $|X| = \\kappa$ satisfies $c([X]^{\\le\\omega}) = \\kappa$.",
+    "significance": "context",
+    "relatedConcepts": ["partition calculus", "cardinal coloring", "continuum function"],
+    "prerequisites": ["cardinal arithmetic", "successor cardinals", "countable sets"]
+  },
+  {
+    "id": "erdos-598-ann-kappa",
+    "proofId": "erdos-598",
+    "range": { "startLine": 22, "endLine": 30 },
+    "type": "definition",
+    "title": "The Cardinal κ = (2^ℵ₀)⁺",
+    "content": "Defines κ as Order.succ (2 ^ ℵ₀), the successor of the continuum cardinal. Under CH, κ = ℵ₂; without CH, κ can be much larger. The axiom kappa_gt_aleph0 records that κ exceeds ℵ₀. This cardinal serves a dual role: as the number of colors and as the minimum subset size that must realize all colors.",
+    "mathContext": "$\\kappa = (2^{\\aleph_0})^+ = \\mathfrak{c}^+$. Under CH ($\\mathfrak{c} = \\aleph_1$), $\\kappa = \\aleph_2$. Under $\\mathfrak{c} = \\aleph_{\\omega}$, $\\kappa = \\aleph_{\\omega+1}$. The successor operation ensures $\\kappa$ is a regular cardinal (Hausdorff's theorem).",
+    "significance": "critical",
+    "relatedConcepts": ["continuum hypothesis", "successor cardinal", "regular cardinal", "König's theorem"],
+    "prerequisites": ["cardinal exponentiation", "Order.succ", "aleph hierarchy"]
+  },
+  {
+    "id": "erdos-598-ann-countable",
+    "proofId": "erdos-598",
+    "range": { "startLine": 32, "endLine": 37 },
+    "type": "definition",
+    "title": "Countable Subsets",
+    "content": "CountableSubset α is the type of countable subsets of α, defined as the subtype { S : Set α // S.Countable }. These are the objects being colored. The number of countable subsets of a set of cardinality m is m^ℵ₀, which by König's theorem satisfies m^ℵ₀ ≥ m⁺ when cf(m) = ω.",
+    "mathContext": "The set $[\\alpha]^{\\le\\omega} = \\{S \\subseteq \\alpha : |S| \\le \\aleph_0\\}$ of countable subsets. For $|\\alpha| = m$, $|[\\alpha]^{\\le\\omega}| = m^{\\aleph_0}$.",
+    "significance": "key",
+    "relatedConcepts": ["countable set", "power set", "cardinal exponentiation"],
+    "prerequisites": ["Set.Countable", "subtype", "cardinal arithmetic"]
+  },
+  {
+    "id": "erdos-598-ann-completeness",
+    "proofId": "erdos-598",
+    "range": { "startLine": 39, "endLine": 53 },
+    "type": "definition",
+    "title": "Chromatic Completeness",
+    "content": "ChromaticCompleteness requires that for every subset X ⊆ α with |X| = κ, every color c < κ is realized by some countable subset of X. This is a strong Ramsey-type property: no matter how one selects a κ-sized subset, it must contain countable subsets of every single color. The coloring must be 'complete' on every large piece.",
+    "mathContext": "A coloring $c: [\\alpha]^{\\le\\omega} \\to \\kappa$ is chromatically complete if $\\forall X \\subseteq \\alpha$ with $|X| = \\kappa$, $\\forall \\gamma < \\kappa$, $\\exists S \\in [X]^{\\le\\omega}$ with $c(S) = \\gamma$. Equivalently, $c''[X]^{\\le\\omega} = \\kappa$ for every $\\kappa$-sized $X$.",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey property", "partition relation", "homogeneous set"],
+    "prerequisites": ["cardinal equality", "universal quantification", "Set.Iio"]
+  },
+  {
+    "id": "erdos-598-ann-conjecture",
+    "proofId": "erdos-598",
+    "range": { "startLine": 55, "endLine": 66 },
+    "type": "insight",
+    "title": "Erdős Problem #598",
+    "content": "The central conjecture: for every infinite type α with |α| ≥ κ, there exists a κ-coloring of countable subsets with chromatic completeness. This is a partition-calculus question asking whether the successor of the continuum is the right threshold for universal color realization. Erdős posed this in 1987 as part of his investigations into partition properties of cardinal arithmetic.",
+    "mathContext": "The problem asserts $\\forall m \\ge \\kappa = (2^{\\aleph_0})^+$, $\\exists c: [m]^{\\le\\omega} \\to \\kappa$ such that $c$ is chromatically complete. The existential quantifier over colorings makes this a combinatorial existence problem in ZFC (or possibly independent of ZFC).",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős–Rado partition relation", "cardinal invariants of the continuum", "ZFC independence"],
+    "prerequisites": ["Infinite typeclass", "cardinal comparison", "existential quantification"]
+  },
+  {
+    "id": "erdos-598-ann-minimal",
+    "proofId": "erdos-598",
+    "range": { "startLine": 68, "endLine": 76 },
+    "type": "concept",
+    "title": "Minimal Case m = κ",
+    "content": "The smallest interesting case sets the ground set to have cardinality exactly κ. If the coloring exists even for this minimal case, monotonicity gives it for all larger m. This is the hardest case since there are fewest countable subsets to work with. The number of countable subsets is κ^ℵ₀ = (2^ℵ₀)^{+ℵ₀}, which under GCH equals κ itself.",
+    "mathContext": "The minimal case asks: $\\exists c: [\\kappa]^{\\le\\omega} \\to \\kappa$ chromatically complete? Here $|[\\kappa]^{\\le\\omega}| = \\kappa^{\\aleph_0}$. Under GCH, $\\kappa^{\\aleph_0} = \\kappa$ since $\\kappa$ is a successor cardinal $> 2^{\\aleph_0}$.",
+    "significance": "key",
+    "relatedConcepts": ["GCH", "cardinal exponentiation", "minimal counterexample"],
+    "prerequisites": ["Set.Iio", "CountableSubset", "ChromaticCompleteness"]
+  },
+  {
+    "id": "erdos-598-ann-ch",
+    "proofId": "erdos-598",
+    "range": { "startLine": 78, "endLine": 82 },
+    "type": "theorem",
+    "title": "Under CH: κ = ℵ₂",
+    "content": "Under the continuum hypothesis (2^ℵ₀ = ℵ₁), κ = ℵ₂. The problem takes a concrete form: can one color countable subsets with ℵ₂ colors so that every ℵ₂-sized subset realizes all colors? This is the most computationally accessible version and connects to classical results in set theory about partition properties of ℵ₂.",
+    "mathContext": "CH asserts $2^{\\aleph_0} = \\aleph_1$, so $\\kappa = \\aleph_1^+ = \\aleph_2$. The problem becomes: $\\forall m \\ge \\aleph_2$, $\\exists c: [m]^{\\le\\omega} \\to \\aleph_2$ chromatically complete.",
+    "significance": "key",
+    "relatedConcepts": ["continuum hypothesis", "aleph-2", "Shelah's pcf theory"],
+    "prerequisites": ["Cardinal.continuum", "aleph function", "cardinal successor"]
+  },
+  {
+    "id": "erdos-598-ann-monotone",
+    "proofId": "erdos-598",
+    "range": { "startLine": 84, "endLine": 96 },
+    "type": "concept",
+    "title": "Monotonicity in Ground Set Size",
+    "content": "If a chromatically complete coloring exists for a ground set of cardinality m', it also exists for any m ≤ m'. The coloring can be restricted to the smaller set. This means the problem is hardest for the minimal case m = κ, and solving that case would settle all larger cases. The axiom formalizes this with an existential witness for the restricted coloring.",
+    "mathContext": "If $m \\le m'$ and $c: [m']^{\\le\\omega} \\to \\kappa$ is chromatically complete, then the restriction $c|_{[m]^{\\le\\omega}}$ is chromatically complete for $m$. This follows from $[X]^{\\le\\omega} \\cap [m]^{\\le\\omega} \\ne \\emptyset$ for $X \\subseteq m$ with $|X| = \\kappa$.",
+    "significance": "supporting",
+    "relatedConcepts": ["restriction of coloring", "monotone property", "hereditary property"],
+    "prerequisites": ["cardinal ordering", "function restriction", "Infinite typeclass"]
   }
 ]

--- a/src/data/proofs/erdos-598/meta.json
+++ b/src/data/proofs/erdos-598/meta.json
@@ -21,67 +21,77 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős (1987) posed this question about coloring countable subsets of infinite sets. The problem sits at the intersection of set theory, Ramsey theory, and cardinal arithmetic. It asks whether the successor of the continuum provides enough colors for a certain completeness property.",
-    "problemStatement": "Let m be an infinite cardinal and κ = (2^ℵ₀)⁺. Can one color the countable subsets of m with κ colors so that every X ⊆ m with |X| = κ contains subsets of every color?",
-    "proofStrategy": "We define kappa = (2^ℵ₀)⁺, CountableSubset, ChromaticCompleteness (every κ-sized subset hits all colors). ErdosProblem598 states the universal version. Special cases include the minimal case m = κ and the CH scenario where κ = ℵ₂. Monotonicity in m is axiomatized.",
+    "historicalContext": "Erdős posed this problem in 1987 in his paper on combinatorial problems in set theory. The question lies at the intersection of partition calculus, cardinal arithmetic, and the combinatorics of countable subsets. The classical Erdős–Rado partition relation ℵ₁ → (ℵ₁)²_{ℵ₀} (1956) established foundational results about coloring pairs, but coloring countable subsets introduces an entirely different combinatorial landscape. The successor of the continuum κ = (2^ℵ₀)⁺ appears as the natural threshold because it is the smallest cardinal exceeding the number of reals, and questions about partition properties at this level are known to be sensitive to set-theoretic axioms. Under CH, κ = ℵ₂ and the problem connects to classical partition properties of ℵ₂ studied by Todorcevic, Shelah, and others. The problem asks whether κ colors suffice for a 'chromatic completeness' property: every κ-sized subset must realize all colors among its countable subsets. This is a strong Ramsey-type requirement that goes beyond standard partition relations by quantifying over all large subsets simultaneously.",
+    "problemStatement": "Let $m$ be an infinite cardinal and $\\kappa = (2^{\\aleph_0})^+$. Can one color the countable subsets of $m$ with $\\kappa$ colors so that every $X \\subseteq m$ with $|X| = \\kappa$ contains subsets of every color?",
+    "proofStrategy": "The formalization defines κ = (2^ℵ₀)⁺ using Lean's Cardinal and Order.succ, CountableSubset as countable subsets of a type, and ChromaticCompleteness as the requirement that every κ-sized subset realizes all colors. ErdosProblem598 states the universal version for all ground sets of size ≥ κ. Special cases include the minimal case m = κ and the CH scenario. Monotonicity in the ground set size is axiomatized.",
     "keyInsights": [
-      "κ = (2^ℵ₀)⁺ is the natural threshold: both the number of colors and the subset size",
-      "Chromatic completeness requires every large subset to realize all colors",
-      "Under CH, κ = ℵ₂ and the problem has a concrete cardinal-arithmetic form",
-      "The problem is monotone in m: larger ground sets make it easier"
+      "The cardinal $\\kappa = (2^{\\aleph_0})^+$ serves a dual role: both the number of colors and the minimum subset size that must realize all colors, creating a delicate balance",
+      "Chromatic completeness is a strong Ramsey-type property: every κ-sized subset must contain countable subsets of every single color, with no exceptions",
+      "Under CH, $\\kappa = \\aleph_2$ and the problem connects to Todorcevic's and Shelah's work on partition properties of $\\aleph_2$",
+      "The problem is monotone in $m$: solving the minimal case $m = \\kappa$ settles all larger cases, making this the critical instance",
+      "The answer may depend on set-theoretic axioms beyond ZFC — partition properties at successor cardinals are notoriously sensitive to forcing",
+      "The problem generalizes the Erdős–Rado partition calculus from coloring finite tuples to coloring countable sets, a qualitative leap in combinatorial complexity"
     ]
   },
   "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 20,
+      "summary": "Docstring with the problem statement, open status, and reference to Erdős (1987). Imports Mathlib's cardinal, continuum, ordinal, and successor modules."
+    },
     {
       "id": "cardinal-setup",
       "title": "Cardinal Setup",
       "startLine": 22,
       "endLine": 30,
-      "summary": "Defines kappa = (2^ℵ₀)⁺ and its basic properties."
+      "summary": "Defines κ = (2^ℵ₀)⁺ as Order.succ (2 ^ ℵ₀) and axiomatizes κ > ℵ₀."
     },
     {
       "id": "countable-subsets",
       "title": "Countable Subsets",
       "startLine": 32,
       "endLine": 37,
-      "summary": "Defines CountableSubset α as countable subsets of α."
+      "summary": "Defines CountableSubset α as the subtype of countable subsets of α."
     },
     {
       "id": "coloring-property",
       "title": "The Coloring Property",
       "startLine": 39,
       "endLine": 53,
-      "summary": "Defines ChromaticCompleteness: every κ-sized subset contains all colors."
+      "summary": "Defines IsKappaColoring (any function is a valid coloring) and ChromaticCompleteness (every κ-sized subset X contains countable subsets of every color)."
     },
     {
       "id": "conjecture",
       "title": "The Conjecture",
       "startLine": 55,
       "endLine": 66,
-      "summary": "States ErdosProblem598: the coloring exists for all |α| ≥ κ."
+      "summary": "States ErdosProblem598: for every infinite α with |α| ≥ κ, a chromatically complete κ-coloring exists."
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
       "startLine": 68,
       "endLine": 82,
-      "summary": "Minimal case m = κ and the CH scenario where κ = ℵ₂."
+      "summary": "The minimal case m = κ and the CH scenario where κ = ℵ₂, giving the problem its most concrete form."
     },
     {
       "id": "monotonicity",
       "title": "Monotonicity",
       "startLine": 84,
       "endLine": 96,
-      "summary": "Coloring existence is monotone: larger ground sets inherit colorings."
+      "summary": "Axiomatizes that coloring existence is monotone in the ground set size: larger sets inherit chromatically complete colorings from smaller ones via restriction."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 598 asks whether countable subsets of infinite sets can be colored with (2^ℵ₀)⁺ colors such that every large subset contains all colors. The problem remains open.",
-    "implications": "Resolution would advance understanding of partition relations for countable subsets and the combinatorics of cardinal successors.",
+    "summary": "Formalizes Erdős Problem #598 on whether countable subsets of infinite sets can be colored with (2^ℵ₀)⁺ colors achieving chromatic completeness. The formalization captures the cardinal setup, the key definitions, and structural properties including monotonicity and the CH specialization.",
+    "implications": "Resolution would advance the understanding of partition relations for countable subsets at the successor of the continuum. A positive answer would establish a new partition-calculus result, while a negative answer (or independence from ZFC) would reveal limitations of combinatorial methods at this cardinal level and connect to Shelah's pcf theory.",
     "openQuestions": [
-      "Does the chromatic completeness coloring exist for m = κ?",
-      "Is the answer independent of ZFC?",
-      "Does the answer change under CH vs. ¬CH?"
+      "Does the chromatically complete coloring exist for the minimal case m = κ?",
+      "Is the answer independent of ZFC, like many partition properties at successor cardinals?",
+      "Does the answer change under CH versus ¬CH, or is it absolute?",
+      "What is the relationship to the Erdős–Rado partition relation and Shelah's pcf theory?"
     ]
   }
 }

--- a/src/data/proofs/erdos-638/annotations.json
+++ b/src/data/proofs/erdos-638/annotations.json
@@ -1,65 +1,98 @@
 [
   {
-    "id": "erdos-638-mono-triangle",
+    "id": "erdos-638-ann-header",
     "proofId": "erdos-638",
-    "type": "definition",
-    "range": { "startLine": 26, "endLine": 32 },
-    "title": "Monochromatic Triangle",
-    "content": "HasMonoTriangle defines a monochromatic triangle: three mutually adjacent vertices whose pairwise edges all receive the same colour under a vertex-pair colouring function c : V → V → α.",
-    "significance": "essential"
-  },
-  {
-    "id": "erdos-638-triangle-ramsey",
-    "proofId": "erdos-638",
-    "type": "definition",
-    "range": { "startLine": 34, "endLine": 38 },
-    "title": "n-Colour Triangle Ramsey Property",
-    "content": "HasTriangleRamsey states that every colouring of vertex pairs with Fin n colours yields a monochromatic triangle. This captures the finite-colour Ramsey property for a single graph.",
-    "significance": "essential"
-  },
-  {
-    "id": "erdos-638-ramsey-family",
-    "proofId": "erdos-638",
-    "type": "definition",
-    "range": { "startLine": 45, "endLine": 48 },
-    "title": "Ramsey Family",
-    "content": "IsRamseyFamily defines a family S of finite graphs (indexed by vertex count) such that for every n ≥ 1, some member G ∈ S(m) has the n-colour triangle Ramsey property. This is the key hypothesis of the problem.",
-    "significance": "essential"
-  },
-  {
-    "id": "erdos-638-cardinal-ramsey",
-    "proofId": "erdos-638",
-    "type": "definition",
-    "range": { "startLine": 52, "endLine": 54 },
-    "title": "Cardinal Triangle Ramsey Property",
-    "content": "HasCardinalTriangleRamsey generalises the Ramsey property to arbitrary colour types κ, requiring every κ-colouring of vertex pairs to yield a monochromatic triangle.",
-    "significance": "essential"
-  },
-  {
-    "id": "erdos-638-conjecture",
-    "proofId": "erdos-638",
-    "type": "conjecture",
-    "range": { "startLine": 60, "endLine": 65 },
-    "title": "Erdős Problem 638",
-    "content": "The main conjecture: for every Ramsey family S and every infinite colour type κ, there exists a graph G whose vertex pairs exhibit the cardinal triangle Ramsey property for κ. Uses Lean's Infinite typeclass to express infinite cardinality.",
-    "significance": "essential"
-  },
-  {
-    "id": "erdos-638-classical",
-    "proofId": "erdos-638",
+    "range": { "startLine": 1, "endLine": 22 },
     "type": "context",
-    "range": { "startLine": 69, "endLine": 77 },
-    "title": "Classical Ramsey Theorem",
-    "content": "The classical finite Ramsey theorem for triangles (axiomatised): for every n ≥ 1, some complete graph K_N has the n-colour triangle Ramsey property. As a corollary, the family of complete graphs forms a Ramsey family.",
-    "significance": "supporting"
+    "title": "Problem Statement and Imports",
+    "content": "The header states Erdős Problem #638: given a Ramsey family S of finite graphs (where for every n, some member forces a monochromatic triangle under n-colourings), does there exist, for every infinite cardinal κ, a graph whose finite subgraphs lie in S and whose edges cannot be κ-coloured without a monochromatic triangle? Erdős noted an affirmative answer would enable many extensions and generalisations.",
+    "mathContext": "A family $\\mathcal{S}$ is Ramsey if $\\forall n \\ge 1$, $\\exists G_n \\in \\mathcal{S}$ with $G_n \\to (K_3)^2_n$ (every $n$-colouring of $E(G_n)$ yields a monochromatic $K_3$). The problem asks: $\\forall \\kappa \\ge \\aleph_0$, $\\exists G$ with the $\\kappa$-colour Ramsey property.",
+    "significance": "context",
+    "relatedConcepts": ["Ramsey theory", "infinite combinatorics", "compactness"],
+    "prerequisites": ["simple graphs", "Fin", "graph coloring"]
   },
   {
-    "id": "erdos-638-monotonicity",
+    "id": "erdos-638-ann-mono-triangle",
     "proofId": "erdos-638",
-    "type": "result",
-    "range": { "startLine": 81, "endLine": 84 },
-    "title": "Monotonicity of Ramsey Property",
-    "content": "If a graph has the n-colour triangle Ramsey property and m ≤ n, then it also has the m-colour property. This follows because any m-colouring can be viewed as a special n-colouring.",
-    "significance": "supporting"
+    "range": { "startLine": 24, "endLine": 32 },
+    "type": "definition",
+    "title": "Monochromatic Triangle",
+    "content": "HasMonoTriangle defines a monochromatic triangle under a vertex-pair colouring c : V → V → α. Three mutually adjacent vertices a, b, d with c(a,b) = c(b,d) = c(a,d) form the monochromatic triangle. The coloring is defined on ordered vertex pairs rather than edges, which simplifies the Lean formalization while being equivalent for symmetric colorings.",
+    "mathContext": "A monochromatic $K_3$ under $c: \\binom{V}{2} \\to \\alpha$ is a triple $\\{a,b,d\\}$ with $a \\sim b \\sim d \\sim a$ in $G$ and $c(a,b) = c(b,d) = c(a,d)$. The arrow notation $G \\to (K_3)^2_n$ means every $n$-colouring of $E(G)$ contains such a triple.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey number R(3,3)", "edge coloring", "Schur's theorem"],
+    "prerequisites": ["SimpleGraph.Adj", "distinctness", "equality chains"]
+  },
+  {
+    "id": "erdos-638-ann-triangle-ramsey",
+    "proofId": "erdos-638",
+    "range": { "startLine": 34, "endLine": 38 },
+    "type": "definition",
+    "title": "n-Colour Triangle Ramsey Property",
+    "content": "HasTriangleRamsey G n states that every colouring of vertex pairs with Fin n colours yields a monochromatic triangle. This is the finite-colour Ramsey property for a fixed graph G. By the classical Ramsey theorem, for every n there exists N such that K_N has this property; the smallest such N is the Ramsey number R(3,3,...,3) with n arguments.",
+    "mathContext": "The $n$-colour Ramsey property: $G \\to (K_3)^2_n$, i.e., $\\forall c: E(G) \\to [n]$, $\\exists$ monochromatic $K_3$. The classical Ramsey number $R_n(3) = R(\\underbrace{3,\\ldots,3}_n)$ gives the minimum vertex count for $K_{R_n(3)}$ to have this property.",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey number", "partition regularity", "Hales–Jewett"],
+    "prerequisites": ["Fin n", "universal quantification", "HasMonoTriangle"]
+  },
+  {
+    "id": "erdos-638-ann-ramsey-family",
+    "proofId": "erdos-638",
+    "range": { "startLine": 40, "endLine": 48 },
+    "type": "definition",
+    "title": "Ramsey Family",
+    "content": "IsRamseyFamily defines a family S of finite graphs (indexed by vertex count m) such that for every n ≥ 1, some member G ∈ S(m) has the n-colour triangle Ramsey property. The family of complete graphs trivially forms a Ramsey family by the classical theorem. The key question is what happens when S is a more restricted family.",
+    "mathContext": "A Ramsey family $\\mathcal{S} = \\bigcup_m \\mathcal{S}(m)$ satisfies $\\forall n \\ge 1$, $\\exists m$, $\\exists G \\in \\mathcal{S}(m)$ with $G \\to (K_3)^2_n$. The classical Ramsey theorem shows $\\{K_m : m \\in \\mathbb{N}\\}$ is a Ramsey family.",
+    "significance": "critical",
+    "relatedConcepts": ["Nešetřil–Rödl theorem", "structural Ramsey theory", "age of a structure"],
+    "prerequisites": ["indexed families", "existential quantification", "HasTriangleRamsey"]
+  },
+  {
+    "id": "erdos-638-ann-cardinal-ramsey",
+    "proofId": "erdos-638",
+    "range": { "startLine": 50, "endLine": 54 },
+    "type": "definition",
+    "title": "Cardinal Triangle Ramsey Property",
+    "content": "HasCardinalTriangleRamsey generalises the Ramsey property to arbitrary colour types κ (not just Fin n). For an infinite type κ, requiring every κ-colouring to yield a monochromatic triangle is a much stronger condition than the finite-colour version. This is the property that the conjecture asserts must be achievable.",
+    "mathContext": "For a type $\\kappa$: $G \\to (K_3)^2_\\kappa$ means $\\forall c: E(G) \\to \\kappa$, $\\exists$ monochromatic $K_3$. When $|\\kappa| = \\aleph_0$, this requires a countably-coloured Ramsey property; for uncountable $\\kappa$, it is even stronger.",
+    "significance": "critical",
+    "relatedConcepts": ["infinite Ramsey theory", "Erdős–Rado theorem", "partition calculus"],
+    "prerequisites": ["type-parametric coloring", "HasMonoTriangle", "Infinite typeclass"]
+  },
+  {
+    "id": "erdos-638-ann-conjecture",
+    "proofId": "erdos-638",
+    "range": { "startLine": 56, "endLine": 65 },
+    "type": "insight",
+    "title": "Erdős Problem #638: The Main Conjecture",
+    "content": "The central conjecture: for every Ramsey family S and every infinite colour type κ, there exists a graph G with the cardinal triangle Ramsey property for κ. Erdős noted an affirmative answer would enable many extensions and generalisations. The problem asks whether the finite Ramsey property for increasingly many colors can be 'compiled' into an infinite-colour Ramsey property, a compactness-type question.",
+    "mathContext": "The conjecture: $\\forall \\mathcal{S}$ Ramsey, $\\forall \\kappa$ infinite, $\\exists G$ with $G \\to (K_3)^2_\\kappa$. This is a partition-calculus statement lifting $G_n \\to (K_3)^2_n$ (for all $n$) to $G \\to (K_3)^2_\\kappa$ for infinite $\\kappa$.",
+    "significance": "critical",
+    "relatedConcepts": ["compactness principle", "ultraproduct", "Erdős–Rado partition relation"],
+    "prerequisites": ["IsRamseyFamily", "Infinite typeclass", "existential quantification"]
+  },
+  {
+    "id": "erdos-638-ann-classical",
+    "proofId": "erdos-638",
+    "range": { "startLine": 67, "endLine": 77 },
+    "type": "theorem",
+    "title": "Classical Ramsey Theorem and Complete Graph Family",
+    "content": "The classical Ramsey theorem for triangles: for every n ≥ 1, there exists N such that K_N (represented as ⊤ : SimpleGraph (Fin N)) has the n-colour triangle Ramsey property. As a corollary, the family of complete graphs {K_m : m ∈ ℕ} forms a Ramsey family. This is Ramsey's theorem (1930) specialized to triangles and multiple colors.",
+    "mathContext": "Ramsey's theorem (1930): $\\forall n \\ge 1$, $\\exists N = R_n(3)$ such that $K_N \\to (K_3)^2_n$. The known bounds are $R_2(3) = 6$ (Ramsey), $R_3(3) = 17$ (Greenwood–Gleason 1955), and $R_n(3)$ grows exponentially in $n$.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey's theorem", "complete graphs", "Greenwood–Gleason"],
+    "prerequisites": ["SimpleGraph.top", "Fin N", "HasTriangleRamsey"]
+  },
+  {
+    "id": "erdos-638-ann-monotonicity",
+    "proofId": "erdos-638",
+    "range": { "startLine": 79, "endLine": 84 },
+    "type": "concept",
+    "title": "Monotonicity of the Ramsey Property",
+    "content": "If a graph G has the n-colour triangle Ramsey property and m ≤ n, then G also has the m-colour property. This follows because any m-colouring is a special case of an n-colouring (embed Fin m into Fin n). Monotonicity means the Ramsey family condition only needs to be checked at each n individually.",
+    "mathContext": "If $G \\to (K_3)^2_n$ and $m \\le n$, then $G \\to (K_3)^2_m$. This follows from the injection $\\mathrm{Fin}\\,m \\hookrightarrow \\mathrm{Fin}\\,n$: any $m$-colouring $c: E(G) \\to [m]$ can be viewed as an $n$-colouring.",
+    "significance": "supporting",
+    "relatedConcepts": ["color monotonicity", "Fin embedding", "Ramsey monotonicity"],
+    "prerequisites": ["Fin m ≤ Fin n", "HasTriangleRamsey", "function composition"]
   }
 ]

--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -22,60 +22,70 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős posed this problem connecting finite Ramsey theory with infinite cardinal arithmetic. The question lifts the classical finite Ramsey theorem to infinite settings, asking whether Ramsey families (collections of finite graphs with increasing colour-forcing properties) can be extended to infinite graphs with infinite-colour Ramsey properties.",
-    "problemStatement": "Let S be a family of finite graphs such that for every n, some G_n in S forces a monochromatic triangle under n-colourings. For every infinite cardinal κ, does there exist G with all finite subgraphs in S such that every κ-colouring of G yields a monochromatic triangle?",
-    "proofStrategy": "The formalization defines monochromatic triangles via vertex-pair colourings, HasTriangleRamsey for finite colours, HasCardinalTriangleRamsey for arbitrary colour types, and IsRamseyFamily for the family condition. The conjecture uses Lean's Infinite typeclass for infinite colour types.",
+    "historicalContext": "Erdős posed this problem connecting finite Ramsey theory with infinite combinatorics. The classical Ramsey theorem (1930) guarantees that for every n, some complete graph K_N forces a monochromatic triangle under n-colourings. The multicolour Ramsey numbers R(3,3,...,3) with n arguments grow exponentially, as established through work of Erdős and Szekeres (1935) and subsequent improvements. Problem #638 asks whether this finite phenomenon can be 'compiled' into an infinite-cardinal version: given a Ramsey family S (where for each n, some member handles n colours), can one always find a single graph that handles infinitely many colours simultaneously? This is a compactness-type question, but classical compactness (König's lemma or the compactness theorem of logic) does not directly apply because the colourings are not over a fixed finite set. The Nešetřil–Rödl theorem (1977) on structural Ramsey theory and the Erdős–Rado partition calculus provide relevant context. Erdős himself noted that an affirmative answer would enable many extensions and generalisations, suggesting he believed the answer was positive.",
+    "problemStatement": "Let $\\mathcal{S}$ be a family of finite graphs such that $\\forall n \\ge 1$, $\\exists G_n \\in \\mathcal{S}$ with every $n$-colouring of $E(G_n)$ yielding a monochromatic $K_3$. For every infinite $\\kappa$, does there exist $G$ with $G \\to (K_3)^2_\\kappa$?",
+    "proofStrategy": "The formalization defines monochromatic triangles via vertex-pair colourings, the n-colour Ramsey property HasTriangleRamsey, the cardinal-colour generalization HasCardinalTriangleRamsey, and the Ramsey family condition IsRamseyFamily. The main conjecture ErdosProblem638 asserts the existence of graphs with infinite-cardinal Ramsey properties. Supporting results include the classical Ramsey theorem (axiomatized), the complete graph Ramsey family, and colour monotonicity.",
     "keyInsights": [
-      "The problem lifts finite Ramsey theory to infinite cardinals via compactness-like arguments",
-      "Erdős notes an affirmative answer would enable many extensions and generalisations",
-      "The classical Ramsey theorem ensures complete graphs form a Ramsey family",
-      "Monotonicity: the n-colour Ramsey property implies the m-colour property for m ≤ n"
+      "The problem lifts finite Ramsey theory to infinite cardinals, asking whether increasing finite colour-forcing properties can be 'compiled' into a single infinite-colour property",
+      "Classical compactness does not directly apply: the colour sets Fin n vary with n, so ultraproduct or direct limit constructions face technical obstacles",
+      "Erdős noted an affirmative answer would enable many extensions and generalisations, suggesting deep structural connections",
+      "The classical Ramsey theorem ensures complete graphs $\\{K_m\\}$ form a Ramsey family, providing the canonical example for the conjecture",
+      "Monotonicity ($G \\to (K_3)^2_n$ implies $G \\to (K_3)^2_m$ for $m \\le n$) means the Ramsey family condition captures genuinely increasing difficulty as $n$ grows",
+      "The Nešetřil–Rödl theorem on structural Ramsey theory and the Erdős–Rado partition calculus provide the broader theoretical framework for this question"
     ]
   },
   "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 22,
+      "summary": "Docstring with the problem statement, Erdős's note on extensions, and reference. Imports Mathlib's SimpleGraph, Fin, and Tactic modules."
+    },
     {
       "id": "ramsey-property",
       "title": "Ramsey Property for Triangles",
       "startLine": 24,
       "endLine": 38,
-      "summary": "HasMonoTriangle and HasTriangleRamsey: definitions of monochromatic triangles and the n-colour Ramsey property."
+      "summary": "Defines HasMonoTriangle (monochromatic triangle under a vertex-pair colouring) and HasTriangleRamsey (every n-colouring yields a monochromatic triangle)."
     },
     {
       "id": "ramsey-families",
-      "title": "Ramsey Families",
+      "title": "Ramsey Families and Cardinal Ramsey",
       "startLine": 40,
       "endLine": 54,
-      "summary": "IsRamseyFamily: for every n, some member forces monochromatic triangles. HasCardinalTriangleRamsey for arbitrary colour types."
+      "summary": "Defines IsRamseyFamily (for every n, some member forces monochromatic triangles) and HasCardinalTriangleRamsey (the Ramsey property for arbitrary colour types κ)."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture",
       "startLine": 56,
       "endLine": 65,
-      "summary": "Erdős Problem 638: for every Ramsey family and infinite colour type, a graph with the cardinal Ramsey property exists."
+      "summary": "States ErdosProblem638: for every Ramsey family S and every infinite colour type κ, there exists a graph G with the cardinal triangle Ramsey property."
     },
     {
       "id": "classical-ramsey",
       "title": "Classical Ramsey Theorem",
       "startLine": 67,
       "endLine": 77,
-      "summary": "The classical finite Ramsey theorem for triangles and the fact that complete graphs form a Ramsey family."
+      "summary": "Axiomatizes the classical Ramsey theorem for triangles and the fact that the family of complete graphs forms a Ramsey family."
     },
     {
       "id": "basic-observations",
-      "title": "Basic Observations",
+      "title": "Monotonicity",
       "startLine": 79,
       "endLine": 84,
-      "summary": "Monotonicity: the n-colour property implies the m-colour property for m ≤ n."
+      "summary": "Axiomatizes colour monotonicity: the n-colour Ramsey property implies the m-colour property for m ≤ n."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 638 on lifting Ramsey families to infinite cardinal colourings, with the classical Ramsey theorem and monotonicity as supporting results.",
-    "implications": "An affirmative answer would significantly extend Ramsey theory to infinite settings and connect combinatorial arguments with set-theoretic cardinal arithmetic.",
+    "summary": "Formalizes Erdős Problem #638 on lifting Ramsey families to infinite-cardinal colourings. The formalization captures the finite-colour Ramsey property, the family condition, and the conjecture that infinite-cardinal analogues always exist, supported by the classical Ramsey theorem and colour monotonicity.",
+    "implications": "An affirmative answer would significantly extend Ramsey theory to infinite settings, establishing a bridge between finite combinatorial Ramsey properties and infinite partition calculus. It would enable the extensions and generalisations Erdős anticipated, potentially yielding new tools for infinite graph colouring problems.",
     "openQuestions": [
-      "Does every Ramsey family extend to infinite cardinals?",
-      "Is the answer dependent on the axioms of set theory (e.g., GCH)?",
-      "Can compactness arguments resolve the problem?"
+      "Does every Ramsey family extend to infinite cardinals, as Erdős conjectured?",
+      "Can compactness-type arguments (ultraproducts, direct limits) resolve the problem, or are new techniques needed?",
+      "Is the answer dependent on set-theoretic axioms (GCH, large cardinals)?",
+      "Does the answer change if triangles K₃ are replaced by larger complete graphs K_r?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- **erdos-575**: Bipartite Turán dominance — added mathContext to 10 annotations, expanded historicalContext (Simonovits 1966), 6 keyInsights
- **erdos-585**: Edge-disjoint cycles — added mathContext to 8 annotations, expanded historicalContext (CJMM 2024 breakthrough)
- **erdos-593**: Unavoidable hypergraphs — added mathContext to 8 annotations, fixed significance values
- **erdos-598**: Coloring countable subsets — added mathContext to 8 annotations, expanded historicalContext (Shelah pcf theory)
- **erdos-638**: Ramsey families — added mathContext to 8 annotations, expanded historicalContext (Nešetřil–Rödl 1977)
- **erdos-566**: Ramsey size linearity — fixed non-standard types/significance, added missing meta fields
- **erdos-654**: Distinct distances / no four concyclic — added mathContext to 8 annotations, expanded historicalContext (Guth–Katz 2015)

## Changes per proof
- Added `mathContext` (LaTeX) to all annotations
- Added `relatedConcepts` and `prerequisites` arrays
- Expanded `historicalContext`, `keyInsights`, `conclusion`
- Added `header` section coverage for lines 1-N
- Fixed non-standard `significance` and `type` values
- Added missing meta fields (`author`, `badge`, `proofRepoPath`, `erdosProblemStatus`)

## Test plan
- [x] All JSON files validated with `python3 -c "import json; json.load(...)"`
- [x] All annotations have `mathContext`, `relatedConcepts`, `prerequisites`
- [x] Standard significance values: critical, key, supporting, context
- [x] Standard annotation types: definition, theorem, concept, insight, context, technique

🤖 Generated with [Claude Code](https://claude.com/claude-code)