### PR TITLE
enrich(erdos-726): deepen annotations and meta for upper-half residue equidistribution

### DIFF
--- a/src/data/proofs/erdos-726/annotations.json
+++ b/src/data/proofs/erdos-726/annotations.json
@@ -1,56 +1,122 @@
 [
   {
-    "id": "upper-half-residue",
+    "id": "erdos-726-ann-imports",
     "proofId": "erdos-726",
-    "range": { "startLine": 27, "endLine": 29 },
-    "type": "definition",
-    "title": "Upper Half Residue",
-    "content": "n mod p lies in (p/2, p): the least nonnegative residue r = n % p satisfies p/2 < r < p. Roughly half of all residues satisfy this for odd p.",
-    "significance": "high"
+    "range": { "startLine": 19, "endLine": 22 },
+    "type": "concept",
+    "title": "Imports and Dependencies",
+    "content": "Imports Mathlib's logarithm functions, prime number API, finite set cardinality, and tactics. The logarithm import is essential for stating both Mertens' theorem (log log n) and the EGRS conjecture ((log log n)/2).",
+    "mathContext": "Uses $\\text{Real.log}$ for $\\log\\log n$, $\\text{Nat.Prime}$ for primality testing, $\\text{Finset.Icc}$ for prime enumeration, and $\\text{positivity}$ tactic for nonnegativity proofs.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.log", "Nat.Prime", "Finset.Icc", "positivity"],
+    "prerequisites": ["Lean 4 syntax", "Mathlib library"]
   },
   {
-    "id": "upper-half-sum",
+    "id": "erdos-726-ann-upper-half",
     "proofId": "erdos-726",
-    "range": { "startLine": 32, "endLine": 34 },
+    "range": { "startLine": 28, "endLine": 35 },
     "type": "definition",
-    "title": "Upper Half Weighted Sum",
-    "content": "Σ_{p ≤ n, p prime, n mod p ∈ (p/2,p)} 1/p. The sum of prime reciprocals restricted to primes where n has an upper-half residue.",
-    "significance": "high"
+    "title": "Upper Half Residue Predicate",
+    "content": "Defines isUpperHalfResidue(n, p): the least nonnegative residue r = n mod p satisfies r > p/2. For odd prime p, exactly (p−1)/2 nonzero residues satisfy this condition. The decidable instance enables computational filtering over Finsets.",
+    "mathContext": "For odd prime $p$: $|\\{r \\in \\{1, \\ldots, p-1\\} : r > p/2\\}| = (p-1)/2$. The residue $n \\bmod p$ is in the upper half iff $n$ is closer to a multiple of $p$ from below than from above.",
+    "significance": "critical",
+    "relatedConcepts": ["residue class", "decidable predicate", "modular arithmetic"],
+    "prerequisites": ["modular arithmetic", "Decidable typeclass"]
   },
   {
-    "id": "mertens",
+    "id": "erdos-726-ann-sums",
     "proofId": "erdos-726",
-    "range": { "startLine": 39, "endLine": 42 },
+    "range": { "startLine": 37, "endLine": 53 },
+    "type": "definition",
+    "title": "Weighted Sums: Upper Half, Lower Half, Mertens",
+    "content": "Defines three weighted prime reciprocal sums: upperHalfSum (over primes where n mod p > p/2), lowerHalfSum (the complement), and mertensSum (all primes ≤ n). The EGRS conjecture asserts upperHalfSum ~ (log log n)/2, which equals half of mertensSum.",
+    "mathContext": "$U(n) = \\sum_{\\substack{p \\le n \\\\ n \\bmod p > p/2}} \\frac{1}{p}$, $L(n) = \\sum_{\\substack{p \\le n \\\\ n \\bmod p \\le p/2}} \\frac{1}{p}$, $M(n) = \\sum_{p \\le n} \\frac{1}{p}$. Clearly $U(n) + L(n) = M(n)$.",
+    "significance": "critical",
+    "relatedConcepts": ["prime reciprocal sum", "Mertens' sum", "sum partition"],
+    "prerequisites": ["Finset.sum", "prime enumeration", "real division"]
+  },
+  {
+    "id": "erdos-726-ann-mertens",
+    "proofId": "erdos-726",
+    "range": { "startLine": 59, "endLine": 62 },
     "type": "theorem",
     "title": "Mertens' Theorem",
-    "content": "Σ_{p≤n} 1/p ~ log log n. The classical result on prime reciprocal sums, which provides the baseline that the EGRS conjecture splits in half.",
-    "significance": "medium"
+    "content": "Mertens' theorem (1874): ∑_{p≤n} 1/p = log log n + M + o(1), where M ≈ 0.2615 is the Meissel-Mertens constant. Formalized here as mertensSum(n) ~ Real.log(Real.log n). This provides the baseline: the EGRS conjecture claims the upper half gets exactly half of this.",
+    "mathContext": "$\\sum_{p \\le n} \\frac{1}{p} = \\log\\log n + M + O(1/\\log n)$ where $M = \\gamma + \\sum_p (\\log(1-1/p) + 1/p) \\approx 0.2615$. Here $\\gamma$ is Euler's constant.",
+    "significance": "key",
+    "relatedConcepts": ["Mertens' theorem", "Meissel-Mertens constant", "prime number theorem", "Euler's constant"],
+    "prerequisites": ["prime reciprocal sums", "asymptotic analysis", "natural logarithm"]
   },
   {
-    "id": "egrs-conjecture",
+    "id": "erdos-726-ann-conjecture",
     "proofId": "erdos-726",
-    "range": { "startLine": 49, "endLine": 52 },
-    "type": "conjecture",
-    "title": "EGRS Conjecture",
-    "content": "upperHalfSum(n) ~ (log log n)/2: the upper-half residues contribute exactly half of Mertens' sum. A quantitative equidistribution statement for residues modulo primes.",
-    "significance": "high"
+    "range": { "startLine": 64, "endLine": 69 },
+    "type": "insight",
+    "title": "EGRS Conjecture (Problem #726)",
+    "content": "The Erdős-Graham-Ruzsa-Straus conjecture (1975): upperHalfSum(n) ~ (log log n)/2. This says the prime reciprocal sum, restricted to primes where n has an upper-half residue, is asymptotically exactly half of Mertens' total. The conjecture remains open after 51 years. Making the uniform residue heuristic rigorous is the key difficulty.",
+    "mathContext": "$\\sum_{\\substack{p \\le n \\\\ n \\bmod p > p/2}} \\frac{1}{p} \\sim \\frac{\\log\\log n}{2}$ as $n \\to \\infty$. Formalized via $|U(n) - (\\log\\log n)/2| < \\varepsilon$ for all $n \\ge N(\\varepsilon)$.",
+    "significance": "critical",
+    "relatedConcepts": ["equidistribution", "prime reciprocal sum", "asymptotic formula"],
+    "prerequisites": ["Mertens' theorem", "residue distribution", "asymptotic notation"]
   },
   {
-    "id": "heuristic",
+    "id": "erdos-726-ann-residue-props",
     "proofId": "erdos-726",
-    "range": { "startLine": 56, "endLine": 63 },
-    "type": "note",
-    "title": "Uniform Residue Heuristic",
-    "content": "For random n, n mod p is uniform on {0,...,p-1}. The fraction in (p/2, p) is ≈ 1/2 for each prime. The challenge is that n is fixed, not random, so correlations between primes must be controlled.",
-    "significance": "medium"
-  },
-  {
-    "id": "partition",
-    "proofId": "erdos-726",
-    "range": { "startLine": 71, "endLine": 74 },
+    "range": { "startLine": 75, "endLine": 93 },
     "type": "theorem",
-    "title": "Sum Partition",
-    "content": "The upper and lower half sums partition Mertens' full sum exactly. If the conjecture holds for the upper half, the lower half automatically contributes ~ (log log n)/2 as well.",
-    "significance": "medium"
+    "title": "Basic Residue Properties",
+    "content": "Proves three fundamental facts: (1) n mod p < p (residue bound), (2) 0 is not an upper-half residue, (3) if p divides n then n is not an upper-half residue. Also establishes that the upper half (p/2, p) contains exactly (p−1)/2 elements for odd primes. These structural facts support the heuristic that each prime contributes to the upper-half sum with probability ≈ 1/2.",
+    "mathContext": "For odd prime $p$: $|\\{r \\in [1, p-1] : r > p/2\\}| = (p-1)/2$. The elements $\\{\\lceil p/2 \\rceil + 1, \\ldots, p-1\\}$ form the upper half. If $p \\mid n$, the residue is 0, which is never in the upper half.",
+    "significance": "supporting",
+    "relatedConcepts": ["residue properties", "divisibility", "upper half count"],
+    "prerequisites": ["modular arithmetic", "Nat.mod_lt"]
+  },
+  {
+    "id": "erdos-726-ann-sum-partition",
+    "proofId": "erdos-726",
+    "range": { "startLine": 99, "endLine": 157 },
+    "type": "theorem",
+    "title": "Sum Partition and Bounds",
+    "content": "Establishes the algebraic framework: both half-sums are nonneg, each is bounded by the full Mertens sum, and the sum is 0 for n < 2 (no primes). These are proved using Finset.sum_nonneg with positivity and Finset.sum_le_sum_of_subset_of_nonneg. Together they show the half-sums form a valid partition of Mertens' sum.",
+    "mathContext": "$0 \\le U(n) \\le M(n)$, $0 \\le L(n) \\le M(n)$, and $U(n) + L(n) = M(n)$. For $n < 2$: $U(n) = L(n) = M(n) = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sum nonnegativity", "subset summation", "partition identity"],
+    "prerequisites": ["Finset.sum_nonneg", "positivity tactic"]
+  },
+  {
+    "id": "erdos-726-ann-heuristic",
+    "proofId": "erdos-726",
+    "range": { "startLine": 162, "endLine": 165 },
+    "type": "concept",
+    "title": "Uniform Residue Heuristic",
+    "content": "For an odd prime p, exactly (p−1)/2 out of p−1 nonzero residues lie in the upper half, giving probability 1/2. If n were random, each prime would contribute to the upper-half sum independently with probability ≈ 1/2, giving upperHalfSum ≈ (1/2)·mertensSum ≈ (log log n)/2. The difficulty is making this rigorous for fixed n, controlling correlations across primes.",
+    "mathContext": "Heuristic: $\\Pr[n \\bmod p > p/2] \\approx 1/2$ for each prime $p$. If independent: $U(n) \\approx \\frac{1}{2}\\sum_{p \\le n} 1/p \\approx \\frac{\\log\\log n}{2}$. Rigorizing requires: are residues $n \\bmod p_1, n \\bmod p_2, \\ldots$ sufficiently independent?",
+    "significance": "key",
+    "relatedConcepts": ["equidistribution heuristic", "CRT independence", "Bombieri-Vinogradov"],
+    "prerequisites": ["probability", "Chinese Remainder Theorem", "prime independence"]
+  },
+  {
+    "id": "erdos-726-ann-implications",
+    "proofId": "erdos-726",
+    "range": { "startLine": 171, "endLine": 180 },
+    "type": "insight",
+    "title": "Implications: Lower Half and Ratio",
+    "content": "The conjecture has two immediate consequences: (1) the lower-half sum also tends to (log log n)/2, by the partition identity U + L = M; (2) the ratio U(n)/M(n) → 1/2. These show the EGRS conjecture is equivalent to an equidistribution statement: exactly half the prime reciprocal weight falls in each half of the residue range.",
+    "mathContext": "If $U(n) \\sim (\\log\\log n)/2$ and $M(n) \\sim \\log\\log n$, then $L(n) = M(n) - U(n) \\sim (\\log\\log n)/2$ and $U(n)/M(n) \\to 1/2$.",
+    "significance": "key",
+    "relatedConcepts": ["equidistribution", "ratio limit", "partition symmetry"],
+    "prerequisites": ["EGRS conjecture", "Mertens' theorem", "asymptotic algebra"]
+  },
+  {
+    "id": "erdos-726-ann-monotone",
+    "proofId": "erdos-726",
+    "range": { "startLine": 186, "endLine": 202 },
+    "type": "theorem",
+    "title": "Monotonicity and Positivity of Mertens' Sum",
+    "content": "The Mertens sum is non-decreasing (more primes available as n grows) and positive for n ≥ 2 (at least the prime 2 contributes 1/2). The monotonicity proof uses Finset.sum_le_sum_of_subset_of_nonneg; positivity uses Finset.single_le_sum to extract the p = 2 contribution.",
+    "mathContext": "$m \\le n \\implies M(m) \\le M(n)$ since primes up to $m$ are a subset of primes up to $n$. $M(n) \\ge 1/2$ for $n \\ge 2$ since $2$ is prime and contributes $1/2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["monotone sums", "positivity", "prime 2"],
+    "prerequisites": ["Finset subset summation", "positivity tactic"]
   }
 ]

--- a/src/data/proofs/erdos-726/meta.json
+++ b/src/data/proofs/erdos-726/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-726",
-  "title": "Erdős Problem #726: Residues in the Upper Half Interval",
+  "title": "Residues in the Upper Half Interval",
   "slug": "erdos-726",
   "description": "For n → ∞, is Σ_{p≤n, n mod p ∈ (p/2,p)} 1/p ~ (log log n)/2? The upper half residues should contribute exactly half of Mertens' sum. Erdős–Graham–Ruzsa–Straus (1975). Status: OPEN.",
   "meta": {
@@ -12,68 +12,107 @@
       "prime-numbers",
       "residue-distribution",
       "mertens-theorem",
+      "equidistribution",
       "open"
     ],
     "references": [
-      "Erdős–Graham–Ruzsa–Straus (1975): original conjecture",
-      "Mertens (1874): Σ 1/p ~ log log n",
+      "Erdős, Graham, Ruzsa & Straus (1975): On the prime factors of C(2n, n)",
+      "Mertens (1874): Ein Beitrag zur analytischen Zahlentheorie",
+      "Bombieri & Davenport (1968): Small differences between consecutive primes",
+      "Granville & Soundararajan (2007): Large character sums",
       "https://erdosproblems.com/726"
     ],
     "leanFile": "Proofs/Erdos726Problem.lean",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/726",
-    "erdosUrl": "https://erdosproblems.com/726"
+    "erdosUrl": "https://erdosproblems.com/726",
+    "relatedProofs": ["erdos-725", "erdos-727"]
   },
   "sections": [
     {
+      "id": "file-header",
+      "title": "Problem Statement and Background",
+      "startLine": 1,
+      "endLine": 17,
+      "summary": "Module docstring introducing the EGRS conjecture (1975): $\\sum_{p \\le n,\\, n \\bmod p > p/2} 1/p \\sim (\\log\\log n)/2$, asserting the upper-half residues contribute exactly half of Mertens' prime reciprocal sum."
+    },
+    {
+      "id": "imports",
+      "title": "Library Imports",
+      "startLine": 19,
+      "endLine": 22,
+      "summary": "Imports Mathlib's logarithm functions, prime API, Finset cardinality, and tactics for asymptotic statements and nonnegativity proofs."
+    },
+    {
       "id": "core-definitions",
       "title": "Core Definitions",
-      "startLine": 24,
-      "endLine": 34,
-      "summary": "Define isUpperHalfResidue and the weighted sum upperHalfSum."
+      "startLine": 28,
+      "endLine": 53,
+      "summary": "Defines the upper-half residue predicate $n \\bmod p > p/2$ (with decidable instance), and three weighted sums: $U(n)$, $L(n)$, $M(n) = \\sum_{p \\le n} 1/p$ satisfying $U + L = M$."
     },
     {
-      "id": "mertens",
-      "title": "Mertens' Theorem",
-      "startLine": 36,
-      "endLine": 42,
-      "summary": "Mertens' theorem: Σ_{p≤n} 1/p ~ log log n provides the baseline."
+      "id": "mertens-conjecture",
+      "title": "Mertens' Theorem and EGRS Conjecture",
+      "startLine": 59,
+      "endLine": 69,
+      "summary": "States Mertens' theorem $M(n) \\sim \\log\\log n$ and the EGRS conjecture $U(n) \\sim (\\log\\log n)/2$. Both are formalized as $\\varepsilon$-$N$ asymptotic statements."
     },
     {
-      "id": "main-conjecture",
-      "title": "The Main Conjecture",
-      "startLine": 44,
-      "endLine": 52,
-      "summary": "EGRS conjecture: upper half contributes (log log n)/2, exactly half of Mertens."
+      "id": "residue-properties",
+      "title": "Basic Residue Properties",
+      "startLine": 75,
+      "endLine": 93,
+      "summary": "Proves residue bounds, that $0$ and multiples of $p$ are not upper-half, and that the upper half contains exactly $(p-1)/2$ elements for odd primes — the 1/2 probability underlying the heuristic."
     },
     {
-      "id": "heuristic-complement",
-      "title": "Heuristic and Complementary Sum",
-      "startLine": 54,
-      "endLine": 86,
-      "summary": "Uniform residue heuristic, lower half sum, partition of Mertens' sum."
+      "id": "sum-partition",
+      "title": "Sum Partition and Bounds",
+      "startLine": 99,
+      "endLine": 157,
+      "summary": "Proves nonnegativity of all three sums, bounds $U(n), L(n) \\le M(n)$, and handles base cases $n < 2$. Uses $\\text{Finset.sum\\_nonneg}$ and $\\text{positivity}$ tactic throughout."
+    },
+    {
+      "id": "heuristic",
+      "title": "Uniform Residue Heuristic",
+      "startLine": 162,
+      "endLine": 165,
+      "summary": "For odd prime $p$, the fraction of nonzero residues in the upper half is exactly $1/2$. Heuristically each prime contributes to $U(n)$ with probability $1/2$; rigorizing requires controlling inter-prime correlations."
+    },
+    {
+      "id": "implications",
+      "title": "Implications of the Conjecture",
+      "startLine": 171,
+      "endLine": 180,
+      "summary": "The EGRS conjecture implies $L(n) \\sim (\\log\\log n)/2$ and $U(n)/M(n) \\to 1/2$: an equidistribution of prime reciprocal weight across the two halves of the residue range."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Monotonicity and Growth",
+      "startLine": 186,
+      "endLine": 202,
+      "summary": "Proves $M(m) \\le M(n)$ for $m \\le n$ (monotonicity) and $M(n) > 0$ for $n \\ge 2$ (positivity from the prime $p = 2$ contributing $1/2$)."
     }
   ],
   "overview": {
-    "historicalContext": "This conjecture was formulated by Erdős, Graham, Ruzsa, and Straus in 1975. It asks about the equidistribution of residues modulo primes in a quantitative sense: not just that residues are roughly uniform, but that the reciprocal sum contribution from each half-interval is exactly half of Mertens' classical sum.",
-    "problemStatement": "As n → ∞, prove that Σ_{p ≤ n, n mod p ∈ (p/2, p)} 1/p ~ (log log n)/2.",
-    "proofStrategy": "We formalize the upper-half residue condition, the weighted sum, Mertens' theorem for context, and the main EGRS conjecture. The heuristic argument from uniform residue distribution is stated but making it rigorous is the challenge.",
+    "historicalContext": "This conjecture was formulated by Erdős, Graham, Ruzsa, and Straus in their 1975 paper 'On the prime factors of C(2n, n),' where they studied the prime factorization of central binomial coefficients. The question asks for a quantitative equidistribution result: not merely that residues n mod p are roughly uniform over {0, ..., p−1} (which follows from the Chinese Remainder Theorem for coprime moduli), but that the prime reciprocal sum restricted to each half of the residue range is exactly half of Mertens' classical sum ∑ 1/p ~ log log n. The heuristic argument is compelling — for an odd prime p, exactly (p−1)/2 of the p−1 nonzero residues lie in the upper half (p/2, p), giving probability 1/2 for each prime. If these events were independent across primes, the conclusion would follow immediately. The difficulty is that n mod p₁ and n mod p₂ are not truly independent (they are determined by the same n), though CRT ensures joint independence for any finite set of primes. Controlling the error accumulated over all primes ≤ n requires tools from analytic number theory, potentially including the Bombieri-Vinogradov theorem or large sieve inequalities. The conjecture remains open after over 50 years.",
+    "problemStatement": "As $n \\to \\infty$, prove that $\\sum_{\\substack{p \\le n,\\, p \\text{ prime} \\\\ n \\bmod p \\in (p/2, p)}} \\frac{1}{p} \\sim \\frac{\\log\\log n}{2}$.",
+    "proofStrategy": "The formalization defines the upper-half residue predicate (with decidable instance for computation), the three weighted sums U(n), L(n), M(n), and states both Mertens' theorem and the EGRS conjecture as ε-N asymptotic formulas. It proves structural properties: residue bounds, sum nonnegativity, partition bounds, monotonicity, and positivity. The heuristic half-fraction and implications (lower half, ratio) are stated as axioms.",
     "keyInsights": [
-      "Mertens' theorem gives Σ 1/p ~ log log n as the baseline",
-      "For random n, residues mod p are roughly uniform, so each half gets ~1/2 of the sum",
-      "Making the heuristic rigorous requires controlling prime-to-prime correlations",
-      "The upper and lower half sums partition Mertens' sum exactly",
-      "The conjecture says the partition is asymptotically equal"
+      "**Mertens baseline**: $\\sum_{p \\le n} 1/p \\sim \\log\\log n$ provides the total; the conjecture says the upper half gets exactly $1/2$ of this slowly growing sum",
+      "**Half-fraction is exact**: For odd prime $p$, exactly $(p-1)/2$ of $p-1$ nonzero residues exceed $p/2$, giving probability $1/2$ per prime — the heuristic is not approximate but exact for each prime",
+      "**Independence is the challenge**: CRT gives joint independence of residues for any finite set of primes, but controlling the accumulated error over all $\\pi(n)$ primes requires analytic tools",
+      "**Partition symmetry**: $U(n) + L(n) = M(n)$ exactly, so proving the conjecture for either half automatically gives the other — a rare case where two asymptotic statements are equivalent",
+      "**Rich proof structure**: The Lean formalization proves 8 theorems (not just axioms), including monotonicity, positivity, and sum bounds, giving computational verification of the algebraic framework"
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #726 conjectures that residues in the upper half interval (p/2, p) contribute exactly half of Mertens' prime reciprocal sum. The heuristic from uniform residue distribution is natural, but rigorous proof requires controlling correlations across primes.",
-    "implications": "A proof would provide a quantitative equidistribution result for residues modulo primes, strengthening classical results on the distribution of integers in residue classes.",
+    "summary": "Formalizes Erdős Problem #726 on the equidistribution of prime reciprocal sums across residue halves. The EGRS conjecture (1975) asserts that primes where n has an upper-half residue contribute exactly (log log n)/2 — half of Mertens' total. The formalization proves 8 structural theorems and states the conjecture alongside its heuristic motivation.",
+    "implications": "A proof would establish a deep quantitative equidistribution result for residues modulo primes, going beyond CRT-based results for fixed sets of primes to a statement about all primes simultaneously. This connects to the Bombieri-Vinogradov theorem, the Elliott-Halberstam conjecture, and the general question of how 'random' a fixed integer n looks modulo varying primes.",
     "openQuestions": [
-      "Is the contribution of each half-interval exactly (log log n)/2?",
-      "What is the error term in the asymptotic?",
-      "Does the result extend to other interval partitions (e.g., (p/3, 2p/3))?",
-      "Can sieve methods or the large sieve address the correlations?"
+      "Can the Bombieri-Vinogradov theorem or large sieve inequality be used to control the inter-prime error terms?",
+      "What is the correct error term: O(1), O(1/log n), or something else?",
+      "Does the conjecture generalize to other interval partitions: Σ_{n mod p ∈ (αp, p)} 1/p ~ (1−α) log log n for 0 < α < 1?",
+      "Is there a connection to the distribution of n mod p for structured sequences (e.g., n = 2^k or n = k!)?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enriched erdos-726 (Residues in the Upper Half Interval) annotations: 6 → 10, all with mathContext (LaTeX), relatedConcepts, prerequisites
- Fixed invalid types (`conjecture`→`insight`, `note`→`concept`) and significance values (`high`→`critical`/`key`, `medium`→`supporting`)
- Expanded historicalContext to 1000+ chars covering EGRS (1975), CRT independence, Bombieri-Vinogradov, large sieve
- Added 9 sections with LaTeX summaries, 5 bold keyInsights, enriched conclusion
- Added relatedProofs [erdos-725, erdos-727], expanded references

🤖 Generated with [Claude Code](https://claude.com/claude-code)