### PR TITLE
enrich(euler-totient): add relatedProofs, verification annotation, deepen mathContext

### DIFF
--- a/src/data/proofs/euler-totient/annotations.json
+++ b/src/data/proofs/euler-totient/annotations.json
@@ -6,9 +6,9 @@
     "range": { "startLine": 1, "endLine": 4 },
     "title": "Library Imports",
     "content": "Imports `ZMod.Basic` for modular arithmetic ($\\mathbb{Z}/n\\mathbb{Z}$ and its unit group), `Nat.Totient` for $\\varphi(n)$, `RingTheory.Int.Basic` for integer ring properties, and `Tactic` for proof automation.",
-    "mathContext": "The formalization uses `ZMod n` (the quotient ring $\\mathbb{Z}/n\\mathbb{Z}$), `(ZMod n)^\\times$ (its unit group of order $\\varphi(n)$), and `Nat.totient` (Euler's totient function). The key Mathlib lemma `ZMod.pow_totient` provides $a^{\\varphi(n)} = 1$ for units.",
+    "mathContext": "The formalization uses `ZMod n` (the quotient ring $\\mathbb{Z}/n\\mathbb{Z}$), `(ZMod n)^\\times$ (its unit group of order $\\varphi(n)$), and `Nat.totient` (Euler's totient function). The key Mathlib lemma `ZMod.pow_totient` provides $a^{\\varphi(n)} = 1$ for units, which is Lagrange's theorem applied to the multiplicative group.",
     "significance": "supporting",
-    "relatedConcepts": ["ZMod", "unit group", "totient function"],
+    "relatedConcepts": ["ZMod", "unit group", "totient function", "Mathlib.Data.ZMod"],
     "prerequisites": ["Lean 4 basics", "Mathlib ring theory"]
   },
   {
@@ -18,9 +18,9 @@
     "range": { "startLine": 56, "endLine": 58 },
     "title": "Euler's Theorem (Wiedijk #10)",
     "content": "For $n > 0$ and $a$ coprime to $n$ (i.e., $a \\in (\\mathbb{Z}/n\\mathbb{Z})^\\times$): $a^{\\varphi(n)} = 1$. The proof is a one-liner applying `ZMod.pow_totient`, which follows from Lagrange's theorem in group theory.",
-    "mathContext": "euler_totient$(n)$ [NeZero $n$] $(a : (\\text{ZMod}\\,n)^\\times)$: $a^{\\text{Nat.totient}\\,n} = 1$. The multiplicative group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ has order $\\varphi(n)$ by definition. Lagrange's theorem: $a^{|G|} = 1$ for any $a \\in G$. This is Wiedijk's 100 Theorems #10.",
+    "mathContext": "The multiplicative group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ has order $\\varphi(n)$ by definition of the totient. Lagrange's theorem states $a^{|G|} = 1$ for any element $a$ of a finite group $G$. This gives $a^{\\varphi(n)} = 1$ immediately. The one-line proof `ZMod.pow_totient a` is one of the shortest proofs of a deep theorem in the Lean 4 Mathlib library. This is **Wiedijk's 100 Theorems #10**.",
     "significance": "critical",
-    "relatedConcepts": ["ZMod.pow_totient", "Lagrange's theorem", "unit group order", "Wiedijk 100"],
+    "relatedConcepts": ["ZMod.pow_totient", "Lagrange's theorem", "unit group order", "Wiedijk 100 Theorems"],
     "prerequisites": ["ZMod", "Units", "Nat.totient", "NeZero"]
   },
   {
@@ -30,9 +30,9 @@
     "range": { "startLine": 70, "endLine": 74 },
     "title": "Fermat's Little Theorem (Corollary)",
     "content": "For prime $p$ and $a$ coprime to $p$: $a^{p-1} = 1$ in $\\mathbb{Z}/p\\mathbb{Z}$. This follows from Euler's theorem since $\\varphi(p) = p-1$ for prime $p$ (`Nat.totient_prime`).",
-    "mathContext": "fermat_little_theorem$(p)$ [Fact (Nat.Prime $p$)] $(a : (\\text{ZMod}\\,p)^\\times)$: $a^{p-1} = 1$. Proof: rewrite $p-1$ as $\\varphi(p)$ using `Nat.totient_prime`, then apply `euler_totient`. Fermat stated this in 1640; Euler proved it in 1736.",
+    "mathContext": "The proof rewrites $p - 1$ as $\\varphi(p)$ using `Nat.totient_prime`, then applies `euler_totient`. Fermat stated $a^{p-1} \\equiv 1 \\pmod{p}$ in a 1640 letter to Frénicle de Bessy without proof. Euler proved it in 1736 and generalized it in 1763. The derivation of Fermat from Euler in 3 lines illustrates the power of abstraction: the special case is literally the general case with $n = p$.",
     "significance": "critical",
-    "relatedConcepts": ["Nat.totient_prime", "Fermat 1640", "prime moduli"],
+    "relatedConcepts": ["Nat.totient_prime", "Fermat 1640", "prime moduli", "specialization"],
     "prerequisites": ["euler_totient", "Nat.Prime", "Nat.totient_prime"]
   },
   {
@@ -42,19 +42,19 @@
     "range": { "startLine": 80, "endLine": 82 },
     "title": "Fermat's Little Theorem (Full Form)",
     "content": "For prime $p$ and any $a \\in \\mathbb{Z}/p\\mathbb{Z}$: $a^p = a$. This holds even when $p \\mid a$ (both sides are 0). Proved directly via `ZMod.pow_card`.",
-    "mathContext": "fermat_little_theorem_full$(p)$ [Fact (Nat.Prime $p$)] $(a : \\text{ZMod}\\,p)$: $a^p = a$. This is the unconditional form: for $\\gcd(a,p) = 1$, multiply $a^{p-1} = 1$ by $a$; for $p \\mid a$, $a = 0$ so $a^p = 0 = a$. Uses `ZMod.pow_card` which works for all finite fields.",
+    "mathContext": "This is the unconditional form: for $\\gcd(a,p) = 1$, multiply $a^{p-1} = 1$ by $a$ to get $a^p = a$; for $p \\mid a$, we have $a = 0$ so $a^p = 0 = a$. More deeply, `ZMod.pow_card` uses the fact that $x \\mapsto x^p$ is the **Frobenius endomorphism** of the finite field $\\mathbb{F}_p$, which fixes every element since $|\\mathbb{F}_p| = p$.",
     "significance": "key",
-    "relatedConcepts": ["ZMod.pow_card", "finite field", "Frobenius endomorphism"],
+    "relatedConcepts": ["ZMod.pow_card", "finite field", "Frobenius endomorphism", "unconditional form"],
     "prerequisites": ["ZMod", "Nat.Prime", "finite field theory"]
   },
   {
     "id": "et-totient-values",
     "proofId": "euler-totient",
     "type": "concept",
-    "range": { "startLine": 88, "endLine": 104 },
-    "title": "Totient Values and Verification",
-    "content": "Computed values: $\\varphi(1)=1$, $\\varphi(2)=1$, $\\varphi(3)=2$, $\\varphi(4)=2$, $\\varphi(5)=4$, $\\varphi(6)=2$. All verified by `rfl` (definitional equality). The examples $2^{\\varphi(5)} \\equiv 1 \\pmod{5}$ and $3^{\\varphi(7)} \\equiv 1 \\pmod{7}$ are verified by `native_decide`.",
-    "mathContext": "The totient values are computed from the definition: $\\varphi(n) = |\\{k : 1 \\leq k \\leq n, \\gcd(k,n) = 1\\}|$. For primes, $\\varphi(p) = p-1$. For prime powers, $\\varphi(p^k) = p^{k-1}(p-1)$. The multiplicative property $\\varphi(mn) = \\varphi(m)\\varphi(n)$ for $\\gcd(m,n)=1$ allows efficient computation.",
+    "range": { "startLine": 88, "endLine": 113 },
+    "title": "Totient Values and Euler's Theorem Verification",
+    "content": "Computed values: $\\varphi(1)=1$, $\\varphi(2)=1$, $\\varphi(3)=2$, $\\varphi(4)=2$, $\\varphi(5)=4$, $\\varphi(6)=2$ (by `rfl`). Verified $2^{\\varphi(5)} \\equiv 1 \\pmod{5}$, $3^{\\varphi(7)} \\equiv 1 \\pmod{7}$, and $2^6 \\equiv 1 \\pmod{7}$ (by `native_decide`).",
+    "mathContext": "The totient values are computed from $\\varphi(n) = |\\{k : 1 \\leq k \\leq n, \\gcd(k,n) = 1\\}|$. For primes, $\\varphi(p) = p-1$. For prime powers, $\\varphi(p^k) = p^{k-1}(p-1)$. The multiplicative property $\\varphi(mn) = \\varphi(m)\\varphi(n)$ for $\\gcd(m,n)=1$ allows efficient computation. The `rfl` proofs use definitional computation; `native_decide` compiles to native code for modular exponentiation.",
     "significance": "supporting",
     "relatedConcepts": ["native_decide", "rfl", "coprimality", "multiplicative functions"],
     "prerequisites": ["Nat.totient", "ZMod arithmetic"]
@@ -66,9 +66,9 @@
     "range": { "startLine": 115, "endLine": 117 },
     "title": "Non-Coprime Counterexample",
     "content": "Demonstrates that coprimality is essential: $2^{\\varphi(4)} = 2^2 = 4 \\equiv 0 \\pmod{4}$, not 1. Since $\\gcd(2,4) = 2 \\neq 1$, the hypothesis of Euler's theorem fails.",
-    "mathContext": "The counterexample $2^{\\varphi(4)} \\not\\equiv 1 \\pmod{4}$ shows the `Units` hypothesis is essential. In `ZMod 4`, the element $2$ is not a unit ($2 \\cdot 2 = 0$, a zero divisor), so Lagrange's theorem does not apply. Verified by `native_decide`.",
+    "mathContext": "In `ZMod 4`, the element $2$ is a zero divisor ($2 \\cdot 2 = 0$), not a unit, so Lagrange's theorem does not apply. The Carmichael function $\\lambda(n)$ gives the smallest exponent such that $a^{\\lambda(n)} \\equiv 1$ for all units; $\\lambda(n) \\mid \\varphi(n)$ but can be strictly smaller (e.g., $\\lambda(8) = 2$ while $\\varphi(8) = 4$).",
     "significance": "supporting",
-    "relatedConcepts": ["counterexample", "zero divisors", "coprimality requirement"],
+    "relatedConcepts": ["counterexample", "zero divisors", "Carmichael function", "coprimality requirement"],
     "prerequisites": ["euler_totient", "ZMod"]
   },
   {
@@ -78,9 +78,9 @@
     "range": { "startLine": 124, "endLine": 125 },
     "title": "Totient of a Prime",
     "content": "$\\varphi(p) = p - 1$ for prime $p$: every element $1, 2, \\ldots, p-1$ is coprime to $p$. Direct application of `Nat.totient_prime`.",
-    "mathContext": "totient_prime$(p, hp)$: $\\text{Nat.totient}\\,p = p - 1$ for `Nat.Prime p`. This is the bridge from Euler's theorem to Fermat's: substituting $\\varphi(p) = p-1$ into $a^{\\varphi(n)} = 1$ gives $a^{p-1} = 1$.",
+    "mathContext": "This is the bridge from Euler's theorem to Fermat's: substituting $\\varphi(p) = p-1$ into $a^{\\varphi(n)} = 1$ gives $a^{p-1} = 1$. More generally, $\\mathbb{Z}/p\\mathbb{Z}$ is a field for prime $p$, so $(\\mathbb{Z}/p\\mathbb{Z})^\\times = \\mathbb{Z}/p\\mathbb{Z} \\setminus \\{0\\}$ has order $p - 1$.",
     "significance": "key",
-    "relatedConcepts": ["Nat.totient_prime", "prime definition", "coprimality with primes"],
+    "relatedConcepts": ["Nat.totient_prime", "prime fields", "coprimality with primes"],
     "prerequisites": ["Nat.Prime", "Nat.totient"]
   },
   {
@@ -90,9 +90,21 @@
     "range": { "startLine": 128, "endLine": 130 },
     "title": "Totient of a Prime Power",
     "content": "$\\varphi(p^k) = p^{k-1}(p-1)$ for prime $p$ and $k > 0$. Among $1, \\ldots, p^k$, exactly $p^{k-1}$ are divisible by $p$, so $\\varphi(p^k) = p^k - p^{k-1} = p^{k-1}(p-1)$.",
-    "mathContext": "totient_prime_pow$(p, k, hp, hk)$: $\\text{Nat.totient}(p^k) = p^{k-1} \\cdot (p-1)$. This, combined with the multiplicative property $\\varphi(mn) = \\varphi(m)\\varphi(n)$ for coprime $m, n$, gives the full prime factorization formula: $\\varphi(n) = n \\prod_{p \\mid n}(1 - 1/p)$.",
+    "mathContext": "This, combined with the multiplicative property $\\varphi(mn) = \\varphi(m)\\varphi(n)$ for coprime $m, n$, gives the product formula: $\\varphi(n) = n \\prod_{p \\mid n}(1 - 1/p)$. For example, $\\varphi(12) = \\varphi(4)\\varphi(3) = 2 \\cdot 2 = 4$. The identity $n = \\sum_{d \\mid n} \\varphi(d)$ (counting elements of $\\mathbb{Z}/n\\mathbb{Z}$ by their order) is a deep consequence.",
     "significance": "key",
-    "relatedConcepts": ["Nat.totient_prime_pow", "prime powers", "Euler product formula"],
+    "relatedConcepts": ["Nat.totient_prime_pow", "prime powers", "Euler product formula", "Mobius inversion"],
     "prerequisites": ["Nat.Prime", "Nat.totient", "Nat.pow"]
+  },
+  {
+    "id": "et-verification",
+    "proofId": "euler-totient",
+    "type": "concept",
+    "range": { "startLine": 132, "endLine": 135 },
+    "title": "Verification Checks",
+    "content": "Uses `#check` to confirm the core API surface: `euler_totient`, `fermat_little_theorem`, `fermat_little_theorem_full`.",
+    "mathContext": "The `#check` command displays type signatures without proving anything, serving as documentation and a compilation guard. The three checked terms represent the complete hierarchy: Euler's general theorem, Fermat's coprime form, and Fermat's unconditional form.",
+    "significance": "supporting",
+    "relatedConcepts": ["#check", "compilation guard", "API surface"],
+    "prerequisites": ["euler_totient", "fermat_little_theorem"]
   }
 ]

--- a/src/data/proofs/euler-totient/meta.json
+++ b/src/data/proofs/euler-totient/meta.json
@@ -34,7 +34,8 @@
       {"authors": "G. H. Hardy, E. M. Wright", "title": "An Introduction to the Theory of Numbers", "year": "1938", "venue": "Oxford University Press", "note": "Standard reference for the totient function and its properties"}
     ],
     "dateAdded": "12/26/25",
-    "wiedijkNumber": 10
+    "wiedijkNumber": 10,
+    "relatedProofs": ["fundamental-arithmetic", "derangements", "cramers-rule"]
   },
   "overview": {
     "historicalContext": "**From Fermat to Euler to RSA**\n\n**Pierre de Fermat** stated his 'little theorem' $a^{p-1} \\equiv 1 \\pmod{p}$ for prime $p$ in a 1640 letter to Frénicle de Bessy, without proof. **Leonhard Euler** first proved it in 1736 and then generalized it in 1763 to arbitrary moduli: $a^{\\varphi(n)} \\equiv 1 \\pmod{n}$ for $\\gcd(a,n) = 1$, introducing the totient function $\\varphi(n)$.\n\n**The Group-Theoretic Proof**\n\nThe modern proof uses **Lagrange's theorem**: the multiplicative group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ has order $\\varphi(n)$, so any element raised to the group order equals the identity. This elegant one-line proof, used in the formalization, replaced Euler's original inductive argument.\n\n**RSA Cryptography**\n\nEuler's theorem is the mathematical foundation of **RSA encryption** (Rivest-Shamir-Adleman, 1977). For primes $p, q$ with $n = pq$: $\\varphi(n) = (p-1)(q-1)$. Choosing $ed \\equiv 1 \\pmod{\\varphi(n)}$, the encryption $m \\mapsto m^e \\pmod{n}$ is inverted by $c \\mapsto c^d \\pmod{n}$ because $m^{ed} = m^{1+k\\varphi(n)} = m \\cdot (m^{\\varphi(n)})^k \\equiv m \\pmod{n}$.\n\nThis is #10 on **Freek Wiedijk**'s list of 100 theorems formalized in proof assistants.",


### PR DESCRIPTION
## Summary
- Added `relatedProofs`: fundamental-arithmetic, derangements, cramers-rule
- Added verification annotation covering `#check` commands (9 total annotations)
- Deepened mathContext: Frobenius endomorphism for full Fermat, Carmichael function for counterexample, Mobius inversion for prime power formula
- Expanded totient values annotation to cover full examples + verification block

## Test plan
- [x] `pnpm annotations:build` passes (pre-existing warnings only from other entries)
- [x] All annotations have mathContext, relatedConcepts, prerequisites
- [x] No invalid types or significance values

🤖 Generated with [Claude Code](https://claude.com/claude-code)