### PR TITLE
enrich(cramers-rule): deepen historical context and refine sections

### DIFF
--- a/src/data/proofs/cramers-rule/annotations.json
+++ b/src/data/proofs/cramers-rule/annotations.json
@@ -118,5 +118,17 @@
     "significance": "supporting",
     "relatedConcepts": ["Field", "inv_mul_cancel", "Fin 2", "2x2 determinant"],
     "prerequisites": ["cramers_rule", "Field", "Matrix.det"]
+  },
+  {
+    "id": "cr-checks",
+    "proofId": "cramers-rule",
+    "type": "concept",
+    "range": { "startLine": 156, "endLine": 159 },
+    "title": "Verification of Core Mathlib Lemmas",
+    "content": "Uses `#check` to verify that the four core Mathlib lemmas (`mulVec_cramer`, `cramer_apply`, `cramer_eq_adjugate_mulVec`, `mul_adjugate`) exist and have the expected types. This serves as documentation and a guard against Mathlib API changes.",
+    "mathContext": "The four checked identities form a complete picture: $\\text{cramer}(A,b)_i = \\det(A_i)$ (component), $A \\cdot \\text{cramer}(A,b) = \\det(A) \\cdot b$ (main), $\\text{cramer}(A,b) = \\text{adj}(A) \\cdot b$ (adjugate), and $A \\cdot \\text{adj}(A) = \\det(A) \\cdot I$ (fundamental).",
+    "significance": "supporting",
+    "relatedConcepts": ["#check command", "Mathlib API stability", "type verification"],
+    "prerequisites": ["Lean 4 #check command"]
   }
 ]

--- a/src/data/proofs/cramers-rule/meta.json
+++ b/src/data/proofs/cramers-rule/meta.json
@@ -30,7 +30,7 @@
     "wiedijkNumber": 97
   },
   "overview": {
-    "historicalContext": "**Multiple Independent Discoveries**\n\n**Gabriel Cramer** (1704-1752) published the rule in his 1750 *Introduction à l'Analyse des Lignes Courbes Algébriques*, deriving it for systems of polynomial equations. However, **Colin Maclaurin** had the result by 1729 (published posthumously in 1748), and the method appears in Chinese mathematics from the 12th century in texts on systems of linear equations.\n\n**The Adjugate Connection**\n\nThe mathematical backbone is the adjugate (classical adjoint) matrix identity $A \\cdot \\text{adj}(A) = \\det(A) \\cdot I$, which holds over any commutative ring. **Cayley** (1858) and **Hamilton** developed the matrix algebra framework that made this identity precise. The adjugate's entries are signed minors (cofactors), connecting Cramer's rule to cofactor expansion of determinants.\n\n**Computational Perspective**\n\nDespite its theoretical elegance, Cramer's rule has $O(n! \\cdot n)$ naive complexity (computing $n+1$ determinants). **Gaussian elimination** achieves $O(n^3)$, making Cramer impractical for large systems. However, the rule remains valuable for: (1) theoretical proofs about solution existence, (2) small systems ($n \\leq 3$) in engineering, and (3) symbolic computation where entries are polynomials rather than numbers.\n\nThis is #97 on **Freek Wiedijk**'s list of 100 theorems formalized in proof assistants.",
+    "historicalContext": "**Multiple Independent Discoveries**\n\n**Gabriel Cramer** (1704-1752) published the rule in his 1750 *Introduction à l'Analyse des Lignes Courbes Algébriques*, deriving it for systems of polynomial equations arising from curve intersections. However, **Colin Maclaurin** had the result by 1729 (published posthumously in 1748 in *Treatise of Algebra*), and the method appears in Chinese mathematics as early as the 12th century. **Leibniz** (1693) also developed determinant-like methods for solving linear systems in a letter to l'Hôpital, predating both Cramer and Maclaurin, though without systematic matrix notation.\n\n**The Adjugate Connection**\n\nThe mathematical backbone is the adjugate (classical adjoint) matrix identity $A \\cdot \\text{adj}(A) = \\det(A) \\cdot I$, which holds over any commutative ring — a remarkable algebraic fact requiring no invertibility hypothesis. **Cayley** (1858) and **Hamilton** developed the matrix algebra framework that made this identity precise. The adjugate's entries are signed minors (cofactors), connecting Cramer's rule to the Laplace expansion of determinants along arbitrary rows or columns. This identity also underpins the Cayley-Hamilton theorem: substituting $A$ for $\\lambda$ in $\\det(A - \\lambda I)$ yields the zero matrix.\n\n**Computational Perspective**\n\nDespite its theoretical elegance, Cramer's rule has $O(n! \\cdot n)$ naive complexity via the Leibniz formula for determinants. **Gaussian elimination** achieves $O(n^3)$, and **Bareiss's algorithm** (1968) computes integer determinants without fractions in $O(n^3)$ as well. Cramer's rule remains valuable for: (1) theoretical proofs about solution existence and continuity of solutions as functions of parameters, (2) small systems ($n \\leq 3$) in engineering, (3) symbolic computation where entries are polynomials or formal power series, and (4) proving structural results like the Cayley-Hamilton theorem.\n\nThis is #97 on **Freek Wiedijk**'s list of 100 theorems formalized in proof assistants.",
     "problemStatement": "**Cramer's Rule**\n\nFor a system $Ax = b$ over a commutative ring $R$:\n$$A \\cdot \\text{cramer}(A, b) = \\det(A) \\cdot b$$\n\nwhere $\\text{cramer}(A,b)_i = \\det(A_i)$ and $A_i$ is $A$ with column $i$ replaced by $b$.\n\nWhen $\\det(A)$ is invertible: $x_i = \\det(A_i)/\\det(A)$.",
     "proofStrategy": "**Formalization Strategy**\n\n1. **Component formula:** $\\text{cramer}(A,b)_i = \\det(A.\\text{updateColumn}\\,i\\,b)$ via `Matrix.cramer_apply`.\n2. **Main identity:** $A \\cdot \\text{cramer}(A,b) = \\det(A) \\cdot b$ via `Matrix.mulVec_cramer`.\n3. **Solution form:** When `Invertible A.det`, divide to get $A \\cdot (\\det(A)^{-1} \\cdot \\text{cramer}(A,b)) = b$.\n4. **Adjugate bridge:** $\\text{cramer}(A,b) = \\text{adj}(A) \\cdot b$ connects to the adjugate identity $A \\cdot \\text{adj}(A) = \\det(A) \\cdot I$.\n5. **Linearity:** The Cramer map $b \\mapsto \\text{cramer}(A,b)$ is $R$-linear, following from multilinearity of $\\det$ in its columns.\n6. **Transpose:** Row-based form via $\\text{cramer}(A^T,b)_i = \\det(A[\\text{row}\\,i \\leftarrow b])$.",
     "keyInsights": [
@@ -44,9 +44,16 @@
   "sections": [
     {
       "id": "imports",
-      "title": "Imports and Setup",
-      "summary": "Imports `Matrix.Adjugate` (providing `cramer`, `mulVec_cramer`, `mul_adjugate`) and declares variables over `CommRing R` with `Fintype n` and `DecidableEq n`.",
+      "title": "Imports and Documentation",
+      "summary": "Imports `Mathlib.LinearAlgebra.Matrix.Adjugate` (providing `Matrix.cramer`, `mulVec_cramer`, `mul_adjugate`) and `Mathlib.Tactic` for proof automation. The module docstring explains the general identity $A \\cdot \\text{cramer}(A,b) = \\det(A) \\cdot b$ and the classical formula $x_i = \\det(A_i)/\\det(A)$.",
       "startLine": 1,
+      "endLine": 50
+    },
+    {
+      "id": "setup",
+      "title": "Namespace and Type Variables",
+      "summary": "Opens the `CramersRule` namespace, declares universe-polymorphic variables: $n$ with `DecidableEq` and `Fintype` (enabling finite sums for the Leibniz determinant formula $\\det(A) = \\sum_{\\sigma \\in S_n} \\text{sgn}(\\sigma)\\prod_i A_{i,\\sigma(i)}$), and $R$ as a `CommRing` (providing $+$, $\\times$, $0$, $1$, $-$).",
+      "startLine": 52,
       "endLine": 57
     },
     {
@@ -108,5 +115,6 @@
       "Can the result extend to non-commutative settings using quasideterminants (Gelfand-Retakh)?",
       "Can Cramer's rule for underdetermined systems (using generalized inverses) be formalized?"
     ]
-  }
+  },
+  "relatedProofs": ["cayley-hamilton"]
 }


### PR DESCRIPTION
## Summary
- Expanded `historicalContext` with Leibniz (1693) as earliest contributor, Bareiss's algorithm (1968), and Cayley-Hamilton theorem connection
- Split oversized first section (lines 1-57) into two: "Imports and Documentation" and "Namespace and Type Variables" with Leibniz formula detail
- Added annotation for `#check` verification section covering the four core Mathlib identities
- Added `relatedProofs` cross-reference to `cayley-hamilton`

## Test plan
- [x] `pnpm annotations:build` passes (one non-strict warning for `#check` at line 156, acceptable)
- [x] JSON validated
- [x] All annotation types and significance values are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)