### PR TITLE
enrich(triangular-reciprocals): fix annotation types and add cross-references

### DIFF
--- a/src/data/proofs/triangular-reciprocals/annotations.json
+++ b/src/data/proofs/triangular-reciprocals/annotations.json
@@ -19,7 +19,7 @@
     "title": "Triangular Numbers",
     "content": "**Definition of Triangular Numbers**:\n\n$$T_n = \\frac{n(n+1)}{2} = 1 + 2 + \\cdots + n$$\n\n**Lean**:\n```lean\ndef triangular (n : ℕ) : ℕ := n * (n + 1) / 2\n```\n\n**First few values**:\n- $T_1 = 1$, $T_2 = 3$, $T_3 = 6$, $T_4 = 10$, $T_5 = 15$\n\n**Visual**: These count dots in triangular arrays. The formula $T_n = n(n+1)/2$ is attributed to young Gauss, though the Pythagoreans knew it centuries earlier. Note the Lean definition uses natural number division, which is exact because $n(n+1)$ is always even (one of two consecutive integers must be even).",
     "mathContext": "Tₙ = n(n+1)/2",
-    "significance": "major",
+    "significance": "key",
     "relatedConcepts": ["figurate numbers", "arithmetic progression", "Gauss sum", "natural number division"],
     "prerequisites": ["natural number arithmetic", "divisibility of consecutive integers"]
   },
@@ -55,7 +55,7 @@
     "title": "Series Convergence",
     "content": "**Convergence Proof**:\n\nThe series $\\sum \\frac{1}{n(n+1)}$ converges because:\n\n$$\\frac{1}{n(n+1)} \\leq \\frac{1}{n^2}$$\n\n(since $n(n+1) \\geq n^2$) and the **p-series** $\\sum \\frac{1}{n^2}$ converges (since $p = 2 > 1$).\n\n**Lean**: The bound uses `one_div_le_one_div_of_le` with `nlinarith` for $n(n+1) \\geq n^2$. The p-series convergence comes from `Real.summable_nat_rpow_inv` with the condition $1 < 2$ discharged by `norm_num`. The 2x-scaled version inherits summability via `Summable.mul_left 2`.\n\n**Note**: The comparison test (`Summable.of_nonneg_of_le`) requires explicit non-negativity proofs, handled by `positivity` for $n \\neq 0$ and `rfl` for $n = 0$ (where the term is $1/(0 \\cdot 1) = 0$ by convention).",
     "mathContext": "1/(n(n+1)) ≤ 1/n² and ∑1/n² converges",
-    "significance": "major",
+    "significance": "key",
     "relatedConcepts": ["comparison test", "p-series", "Summable", "Real.summable_nat_rpow_inv", "Summable.of_nonneg_of_le"],
     "prerequisites": ["comparison test for series", "p-series convergence (p > 1)", "non-negativity arguments"]
   },
@@ -79,7 +79,7 @@
     "title": "Corollary: Unscaled Sum",
     "content": "**Corollary**: Sum of $\\frac{1}{n(n+1)}$ equals 1:\n\n$$\\sum_{n=1}^{\\infty} \\frac{1}{n(n+1)} = 1$$\n\nThis is the result Leibniz computed in 1673 — one of the earliest evaluated infinite series. The proof divides the main result by 2 using `HasSum.div_const`.\n\n**Relation to triangular numbers**:\n$$\\sum_{n=1}^{\\infty} \\frac{1}{T_n} = \\sum_{n=1}^{\\infty} \\frac{2}{n(n+1)} = 2 = 2 \\cdot \\sum_{n=1}^{\\infty} \\frac{1}{n(n+1)}$$\n\nSo the sum of reciprocals of triangular numbers is twice the Leibniz series.",
     "mathContext": "∑ 1/(n(n+1)) = 1 (Leibniz 1673)",
-    "significance": "major",
+    "significance": "key",
     "relatedConcepts": ["scaling", "HasSum.div_const", "Leibniz series", "reciprocal triangular"],
     "prerequisites": ["HasSum scalar operations", "algebraic simplification"]
   },
@@ -91,7 +91,7 @@
     "title": "Connection to Triangular Numbers",
     "content": "**Reciprocal of Triangular Number**:\n\n$$\\frac{1}{T_n} = \\frac{2}{n(n+1)}$$\n\nsince $T_n = \\frac{n(n+1)}{2}$.\n\n**Lean Proof**: The key challenge is showing that natural number division by 2 is exact. The proof splits on the parity of $n$: if $n = 2k$, then $n(n+1) = 2k(2k+1)$ and $2 | n(n+1)$ via the factor $2k$; if $n = 2k+1$, then $n+1 = 2(k+1)$ and $2 | n(n+1)$ via the factor $2(k+1)$. After extracting the divisibility witness $m$ with $n(n+1) = 2m$, the proof uses `field_simp` and `linarith` to complete the real-number identity.\n\n**Divisibility**: $n(n+1)$ is always even (consecutive integers), so division by 2 is exact. This is a standard number-theoretic fact, but formalizing it requires explicit case analysis.",
     "mathContext": "1/Tₙ = 2/(n(n+1)) via divisibility of consecutive integers",
-    "significance": "major",
+    "significance": "key",
     "relatedConcepts": ["even divisibility", "consecutive integers", "Nat.even_or_odd", "natural number division"],
     "prerequisites": ["parity of integers", "divisibility", "natural vs real number division"]
   },
@@ -99,11 +99,11 @@
     "id": "ann-examples",
     "proofId": "triangular-reciprocals",
     "range": {"startLine": 293, "endLine": 305},
-    "type": "note",
+    "type": "concept",
     "title": "Verified Examples and Exports",
     "content": "**Triangular Number Examples**:\n\n| $n$ | $T_n$ | Formula |\n|-----|-------|----------|\n| 1 | 1 | $1 \\cdot 2 / 2 = 1$ |\n| 2 | 3 | $2 \\cdot 3 / 2 = 3$ |\n| 3 | 6 | $3 \\cdot 4 / 2 = 6$ |\n| 4 | 10 | $4 \\cdot 5 / 2 = 10$ |\n| 5 | 15 | $5 \\cdot 6 / 2 = 15$ |\n\nAll verified with `native_decide` — Lean's kernel evaluates the definition and confirms the computed value. The `#check` statements export the four main theorems for use in other modules.",
     "mathContext": "T₁ = 1, T₂ = 3, T₃ = 6, T₄ = 10, T₅ = 15",
-    "significance": "minor",
+    "significance": "supporting",
     "relatedConcepts": ["native_decide", "numerical verification", "#check"],
     "prerequisites": ["Lean native_decide tactic"]
   }

--- a/src/data/proofs/triangular-reciprocals/meta.json
+++ b/src/data/proofs/triangular-reciprocals/meta.json
@@ -52,5 +52,6 @@
       "Formalize the connection to the digamma function: ∑1/(n(n+k)) = H_k/k where H_k is a harmonic number",
       "Prove the alternating version: ∑(-1)^{n+1}·2/(n(n+1)) = 4·ln(2) - 2"
     ]
-  }
+  },
+  "relatedProofs": ["basel-problem", "arithmetic-series"]
 }


### PR DESCRIPTION
## Summary
- Fixed invalid significance values: `major`→`key` (3 occurrences), `minor`→`supporting` (1 occurrence)
- Fixed invalid annotation type: `note`→`concept` (1 occurrence)
- Added `relatedProofs` cross-references to `basel-problem` and `arithmetic-series`

## Test plan
- [x] `pnpm annotations:build` passes with no triangular-reciprocals warnings
- [x] JSON validated
- [x] All annotation types and significance values are now valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)