### PR TITLE
enrich(erdos-90): deepen annotations and meta for unit distance problem

### DIFF
--- a/src/data/proofs/erdos-90/annotations.json
+++ b/src/data/proofs/erdos-90/annotations.json
@@ -1,14 +1,47 @@
 [
   {
+    "id": "imports",
+    "proofId": "erdos-90",
+    "type": "context",
+    "title": "Mathlib Imports",
+    "content": "Imports six Mathlib modules: InnerProductSpace.Basic for EuclideanSpace ℝ (Fin 2), MetricSpace.Basic for the dist function, Finset.Basic and Finset.Card for finite point sets and offDiag enumeration, Filter.Basic for the atTop filter used in asymptotic statements, and Tactic for general automation.",
+    "significance": "supporting",
+    "mathContext": "The formalization uses `EuclideanSpace \\mathbb{R} (\\text{Fin}\\,2)` as the type of points in $\\mathbb{R}^2$, which carries both the inner product structure and the induced metric `dist`.",
+    "relatedConcepts": ["inner product space", "metric space", "finite sets", "filter"],
+    "prerequisites": ["Mathlib type classes", "EuclideanSpace definition"],
+    "range": {
+      "startLine": 17,
+      "endLine": 22
+    }
+  },
+  {
     "id": "unit-distance-count",
     "proofId": "erdos-90",
     "type": "definition",
     "title": "Unit Distance Pairs Count",
     "content": "Counts unordered pairs of distinct points at Euclidean distance exactly 1. Uses offDiag filtering on Finset of points in ℝ², divided by 2 for unordered pairs.",
-    "significance": "critical",
+    "significance": "key",
+    "mathContext": "For a finite set $S \\subset \\mathbb{R}^2$, defines $\\text{udpc}(S) = |\\{(p, q) \\in S \\times S : p \\neq q,\\, \\|p - q\\| = 1\\}| / 2$. The `offDiag` function produces all ordered pairs $(p, q)$ with $p \\neq q$; dividing by 2 converts to unordered pairs $\\{p, q\\}$.",
+    "relatedConcepts": ["Finset.offDiag", "dist", "unit circle", "unordered pairs"],
+    "prerequisites": ["Finset operations", "EuclideanSpace metric"],
     "range": {
-      "startLine": 22,
-      "endLine": 25
+      "startLine": 26,
+      "endLine": 28
+    }
+  },
+  {
+    "id": "unit-distance-counts-set",
+    "proofId": "erdos-90",
+    "type": "definition",
+    "title": "Achievable Unit Distance Counts",
+    "content": "The set unitDistanceCounts(n) collects all possible values of unitDistancePairsCount over n-point configurations. This is the set whose supremum defines u(n).",
+    "significance": "supporting",
+    "mathContext": "Defines $\\mathcal{U}(n) = \\{\\text{udpc}(S) : S \\subset \\mathbb{R}^2,\\, |S| = n\\}$, the range of the unit distance counting function over all $n$-point configurations. This is a subset of $\\mathbb{N}$ whose supremum is the extremal function $u(n)$.",
+    "relatedConcepts": ["set comprehension", "extremal function", "point configuration"],
+    "prerequisites": ["unitDistancePairsCount", "set-builder notation in Lean"],
+    "range": {
+      "startLine": 30,
+      "endLine": 33
     }
   },
   {
@@ -17,10 +50,28 @@
     "type": "definition",
     "title": "Maximum Unit Distances u(n)",
     "content": "The function u(n) = max over all n-point configurations of the number of unit-distance pairs. Defined as sSup of the set of achievable counts.",
-    "significance": "critical",
+    "significance": "key",
+    "mathContext": "Defines $u(n) = \\sup \\mathcal{U}(n) = \\sup\\{\\text{udpc}(S) : |S| = n\\}$. The use of `sSup` (supremum in a conditionally complete lattice) requires the set to be bounded above, which is axiomatized in `unitDistanceCounts_bddAbove`.",
+    "relatedConcepts": ["sSup", "conditionally complete lattice", "extremal combinatorics"],
+    "prerequisites": ["unitDistanceCounts", "BddAbove"],
     "range": {
-      "startLine": 33,
-      "endLine": 35
+      "startLine": 35,
+      "endLine": 37
+    }
+  },
+  {
+    "id": "bdd-above",
+    "proofId": "erdos-90",
+    "type": "theorem",
+    "title": "Well-Definedness of u(n)",
+    "content": "The set of achievable unit distance counts is bounded above, ensuring that sSup (and hence u(n)) is well-defined. The bound is C(n,2) = n(n-1)/2, the total number of unordered pairs.",
+    "significance": "supporting",
+    "mathContext": "Axiomatizes $\\mathcal{U}(n) \\subseteq [0, \\binom{n}{2}]$: since there are at most $\\binom{n}{2}$ unordered pairs, the set of achievable unit distance counts is bounded. This ensures $u(n) = \\mathrm{sSup}(\\mathcal{U}(n))$ is a natural number rather than $\\infty$.",
+    "relatedConcepts": ["BddAbove", "binomial coefficient", "sSup well-definedness"],
+    "prerequisites": ["unitDistanceCounts", "Finset.card"],
+    "range": {
+      "startLine": 43,
+      "endLine": 44
     }
   },
   {
@@ -29,10 +80,13 @@
     "type": "theorem",
     "title": "Spencer–Szemerédi–Trotter Bound",
     "content": "u(n) = O(n^{4/3}), proved in 1984 using the Szemerédi–Trotter incidence theorem. This is the best known upper bound and has stood for over 40 years.",
-    "significance": "critical",
+    "significance": "key",
+    "mathContext": "States $\\exists C > 0,\\, \\forall n \\geq 1: u(n) \\leq C \\cdot n^{4/3}$. The proof reduces unit distances to point-circle incidences: for each point $p_i$, the unit circle $C_i = \\{q : |p_i - q| = 1\\}$ contributes incidences with other points. The Szemerédi–Trotter theorem bounds $I(P, \\mathcal{C}) = O(|P|^{2/3} |\\mathcal{C}|^{2/3} + |P| + |\\mathcal{C}|)$, giving $O(n^{4/3})$ when $|P| = |\\mathcal{C}| = n$.",
+    "relatedConcepts": ["Szemerédi–Trotter theorem", "incidence geometry", "unit circles", "crossing number inequality"],
+    "prerequisites": ["maxUnitDistances", "incidence bounds"],
     "range": {
-      "startLine": 47,
-      "endLine": 53
+      "startLine": 48,
+      "endLine": 54
     }
   },
   {
@@ -42,9 +96,12 @@
     "title": "Lattice Lower Bound",
     "content": "Integer lattice constructions achieve n^{1+c/log log n} unit distances, establishing the conjectured order of magnitude from below.",
     "significance": "key",
+    "mathContext": "States $\\exists c > 0$ such that $\\forall^\\infty n: u(n) \\geq n^{1+c/\\log\\log n}$. The construction uses $\\sqrt{n} \\times \\sqrt{n}$ integer lattice points and exploits the fact that the number of representations of an integer $m$ as $m = a^2 + b^2$ is $r_2(m) = 4 \\sum_{d|m} \\chi(d)$ where $\\chi$ is the non-principal character mod 4. Choosing $m$ with many small prime factors $\\equiv 1 \\pmod{4}$ maximizes $r_2(m)$, yielding the $n^{c/\\log\\log n}$ factor.",
+    "relatedConcepts": ["sums of two squares", "integer lattice", "highly composite numbers", "Ramanujan–Hardy"],
+    "prerequisites": ["maxUnitDistances", "Filter.atTop", "Real.log"],
     "range": {
-      "startLine": 57,
-      "endLine": 62
+      "startLine": 58,
+      "endLine": 63
     }
   },
   {
@@ -53,10 +110,13 @@
     "type": "concept",
     "title": "The Erdős Conjecture",
     "content": "u(n) = n^{1+O(1/log log n)}: the maximum number of unit distances grows only slightly faster than linear. This would match the lattice lower bound. $500 prize.",
-    "significance": "critical",
+    "significance": "key",
+    "mathContext": "Conjectures $\\exists C > 0$ such that $\\forall^\\infty n: u(n) \\leq n^{1+C/\\log\\log n}$. Combined with the lattice lower bound $u(n) \\geq n^{1+c/\\log\\log n}$, this would pin down $u(n) = n^{1+\\Theta(1/\\log\\log n)}$. The double logarithm arises because the number of prime factors of a typical integer $m \\leq n$ is $\\sim \\log\\log n$ (Hardy–Ramanujan theorem).",
+    "relatedConcepts": ["extremal function", "Hardy–Ramanujan theorem", "double logarithm", "prize problem"],
+    "prerequisites": ["maxUnitDistances", "lattice_lower_bound"],
     "range": {
-      "startLine": 66,
-      "endLine": 72
+      "startLine": 67,
+      "endLine": 74
     }
   },
   {
@@ -66,9 +126,12 @@
     "title": "Weak Conjecture: u(n) = n^{1+o(1)}",
     "content": "The weaker form states u(n) ≤ n^{1+ε} for every ε > 0 and large n. Even this is wide open. Erdős offered $300 (later $250) for this version.",
     "significance": "key",
+    "mathContext": "States $\\forall \\varepsilon > 0,\\, \\forall^\\infty n: u(n) \\leq n^{1+\\varepsilon}$. This is equivalent to $\\lim_{n \\to \\infty} \\frac{\\log u(n)}{\\log n} = 1$, meaning the exponent in $u(n) \\approx n^\\alpha$ satisfies $\\alpha = 1$. The current best gives $\\alpha \\leq 4/3$; even proving $\\alpha < 4/3$ would be a breakthrough.",
+    "relatedConcepts": ["subpolynomial growth", "exponent", "o(1) notation"],
+    "prerequisites": ["maxUnitDistances", "ErdosProblem90"],
     "range": {
-      "startLine": 75,
-      "endLine": 80
+      "startLine": 76,
+      "endLine": 81
     }
   },
   {
@@ -78,9 +141,12 @@
     "title": "Valtr's Metric Obstruction",
     "content": "Valtr constructed a non-Euclidean metric on ℝ² where n points can have Θ(n^{4/3}) unit distances. Since SST methods generalize to such metrics, breaking the n^{4/3} barrier requires exploiting Euclidean geometry specifically.",
     "significance": "key",
+    "mathContext": "Axiomatizes the existence of a semimetric $d : \\mathbb{R}^2 \\times \\mathbb{R}^2 \\to \\mathbb{R}$ (symmetric, non-negative, $d(x,x) = 0$) and constant $c > 0$ such that $\\forall^\\infty n$, some $n$-point set has $\\geq c \\cdot n^{4/3}$ pairs at $d$-distance 1. The key point: the Szemerédi–Trotter theorem applies to any family of curves with bounded pairwise intersection, so $d$-unit circles also satisfy the $O(n^{4/3})$ bound. Valtr shows this bound is **tight** in the general convex-curve setting.",
+    "relatedConcepts": ["semimetric", "convex curves", "incidence geometry", "algebraic structure of Euclidean distance"],
+    "prerequisites": ["spencer_szemeredi_trotter", "metric space axioms"],
     "range": {
-      "startLine": 84,
-      "endLine": 96
+      "startLine": 85,
+      "endLine": 98
     }
   }
 ]

--- a/src/data/proofs/erdos-90/meta.json
+++ b/src/data/proofs/erdos-90/meta.json
@@ -10,71 +10,138 @@
     "proofRepoPath": "Proofs/Erdos90Problem.lean",
     "tags": [
       "erdos",
-      "combinatorial geometry",
-      "unit distance",
-      "incidence geometry"
+      "combinatorial-geometry",
+      "unit-distance",
+      "incidence-geometry",
+      "open"
     ],
     "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 90,
     "erdosUrl": "https://erdosproblems.com/90",
-    "erdosProblemStatus": "open"
+    "erdosProblemStatus": "open",
+    "mathlibDependencies": [
+      {
+        "theorem": "EuclideanSpace",
+        "description": "ℝ²-valued inner product space, the ambient space for point configurations",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "dist",
+        "description": "Euclidean distance function on metric spaces, used to define unit distance pairs",
+        "module": "Mathlib.Topology.MetricSpace.Basic"
+      },
+      {
+        "theorem": "Finset.offDiag",
+        "description": "Ordered pairs of distinct elements from a finite set, used to enumerate point pairs",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Filter.atTop",
+        "description": "Filter for 'eventually for all large n', used in asymptotic statements",
+        "module": "Mathlib.Order.Filter.Basic"
+      },
+      {
+        "theorem": "Real.log",
+        "description": "Natural logarithm, used in the exponent n^{1+c/log log n}",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "sSup",
+        "description": "Supremum of a set of natural numbers, used to define u(n) = max over configurations",
+        "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Defined unitDistancePairsCount via Finset.offDiag filtering and division by 2 for unordered pairs",
+      "Defined unitDistanceCounts as the set of achievable counts for n-point configurations",
+      "Defined maxUnitDistances u(n) via sSup of achievable unit distance counts",
+      "Axiomatized the BddAbove property ensuring u(n) is well-defined",
+      "Stated the Spencer–Szemerédi–Trotter O(n^{4/3}) upper bound with explicit constant",
+      "Stated the lattice lower bound n^{1+c/log log n} using Filter.atTop",
+      "Formalized both the main conjecture and the weak form u(n) = n^{1+o(1)}",
+      "Axiomatized Valtr's obstruction as existence of a non-Euclidean semimetric achieving Θ(n^{4/3}) unit distances"
+    ]
   },
   "overview": {
-    "historicalContext": "Erdős posed this problem in 1946. It is one of the most famous problems in combinatorial geometry. The unit distance problem asks for the maximum number u(n) of pairs of points at distance 1 in a set of n points in the plane. Erdős offered a $500 prize for its resolution.",
-    "problemStatement": "Does every set of n distinct points in ℝ² contain at most n^{1+O(1/log log n)} pairs at unit distance?",
-    "proofStrategy": "Full rewrite from formal-conjectures. Defines unit distance counting via offDiag filtering, states the Spencer–Szemerédi–Trotter O(n^{4/3}) upper bound, the lattice lower bound, the main conjecture, its weak form u(n) = n^{1+o(1)}, and Valtr's metric obstruction.",
+    "historicalContext": "Erdős posed Problem 90 in 1946, making it one of the oldest open problems in combinatorial geometry. The unit distance problem asks: given $n$ points in $\\mathbb{R}^2$, what is the maximum number $u(n)$ of pairs at Euclidean distance exactly 1? Erdős himself showed the trivial bound $u(n) \\leq \\binom{n}{2}$ and constructed lattice examples achieving $u(n) \\geq n^{1+c/\\log\\log n}$ for a constant $c > 0$, exploiting the number-theoretic fact that $\\lfloor\\sqrt{n}\\rfloor \\times \\lfloor\\sqrt{n}\\rfloor$ integer lattice points have many representations as sums of two squares. In 1984, Spencer, Szemerédi, and Trotter proved $u(n) = O(n^{4/3})$ using the celebrated Szemerédi–Trotter incidence theorem, which bounds the number of incidences between $n$ points and $m$ lines (or circles). This $n^{4/3}$ bound has stood for over 40 years. In 2005, Valtr constructed a non-Euclidean metric on $\\mathbb{R}^2$ achieving $\\Theta(n^{4/3})$ unit distances, proving that any improvement must exploit specific properties of the Euclidean metric. Erdős offered $\\$500$ for the full resolution and $\\$250$–$300$ for even the weaker form $u(n) = n^{1+o(1)}$. The problem connects to the Erdős distinct distances problem (solved by Guth–Katz in 2015 using algebraic methods), but the unit distance conjecture remains stubbornly open.",
+    "problemStatement": "Let $u(n)$ denote the maximum number of unordered pairs at Euclidean distance 1 among $n$ points in $\\mathbb{R}^2$. Is $u(n) = n^{1+O(1/\\log\\log n)}$?",
+    "proofStrategy": "The formalization defines $u(n)$ constructively: `unitDistancePairsCount` filters `Finset.offDiag` for pairs at `dist = 1` and divides by 2 for unordered pairs; `maxUnitDistances` takes the `sSup` over all $n$-point configurations. The key results are axiomatized since they require deep analytic and algebraic arguments: the SST upper bound (which rests on the Szemerédi–Trotter incidence theorem), the lattice lower bound (which uses number-theoretic estimates on sums of two squares), and Valtr's obstruction (a non-trivial metric construction). Both the main conjecture $u(n) \\leq n^{1+C/\\log\\log n}$ and the weak form $u(n) \\leq n^{1+\\varepsilon}$ are stated as axioms. The formalization captures the complete logical structure of the problem: definitions, known bounds, conjectures, and the fundamental obstruction to further progress.",
     "keyInsights": [
-      "The trivial upper bound C(n,2) is improved to O(n^{4/3}) via the Szemerédi–Trotter incidence theorem",
-      "Lattice constructions achieve n^{1+c/log log n} unit distances, matching the conjectured bound",
-      "Valtr's obstruction shows the n^{4/3} barrier cannot be broken by purely combinatorial methods",
-      "Any improvement must exploit specific properties of Euclidean distance"
+      "The **Szemerédi–Trotter incidence theorem** gives $u(n) = O(n^{4/3})$ by viewing unit distances as incidences between points and unit circles: each point $p$ contributes a unit circle $\\{q : |p - q| = 1\\}$, and the SST theorem bounds point-curve incidences",
+      "**Lattice constructions** achieve $n^{1+c/\\log\\log n}$: in a $\\sqrt{n} \\times \\sqrt{n}$ integer lattice, the number of representations of an integer as a sum of two squares is controlled by its prime factorization, and integers with many small prime factors yield many unit distance pairs",
+      "**Valtr's obstruction** (2005) is a fundamental barrier: he constructed a non-Euclidean semimetric $d$ on $\\mathbb{R}^2$ where $n$ points achieve $\\Theta(n^{4/3})$ $d$-unit distances, proving that the SST incidence approach — which works for any convex curve, not just circles — cannot break the $n^{4/3}$ barrier alone",
+      "The **weak conjecture** $u(n) = n^{1+o(1)}$ would already be a major breakthrough, requiring the exponent of the upper bound to approach 1. Even this weaker form has resisted all known techniques for 80 years",
+      "The problem is closely related to the **Erdős distinct distances problem** (how few distinct distances can $n$ points determine?), solved by Guth–Katz (2015) using polynomial partitioning — but those algebraic methods have not yet yielded progress on unit distances"
     ]
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 23,
+      "summary": "Imports Mathlib modules for inner product spaces (`EuclideanSpace`), metric spaces (`dist`), finite sets (`Finset.offDiag`, `Finset.card`), filters (`Filter.atTop`), and general tactics. These provide the $\\mathbb{R}^2$ ambient space, Euclidean distance, and the asymptotic filter framework."
+    },
+    {
       "id": "counting",
-      "title": "Unit Distance Counting",
-      "startLine": 18,
-      "endLine": 39,
-      "summary": "Defines unit distance pair counting and the maximum function u(n)."
+      "title": "Unit Distance Counting Definitions",
+      "startLine": 24,
+      "endLine": 38,
+      "summary": "Defines three core objects: `unitDistancePairsCount` counts unordered pairs at distance 1 via `offDiag` filtering and division by 2; `unitDistanceCounts(n)` is the set of achievable counts for $n$-point configurations; `maxUnitDistances(n) = \\mathrm{sSup}(\\text{unitDistanceCounts}(n))$ is the extremal function $u(n)$."
+    },
+    {
+      "id": "trivial-bound",
+      "title": "Trivial Upper Bound",
+      "startLine": 39,
+      "endLine": 44,
+      "summary": "Axiomatizes `unitDistanceCounts_bddAbove`: the set of achievable unit distance counts is bounded above (by $\\binom{n}{2}$), ensuring the `sSup` defining $u(n)$ is well-defined."
     },
     {
       "id": "upper-bound",
       "title": "Spencer–Szemerédi–Trotter Upper Bound",
-      "startLine": 47,
-      "endLine": 53,
-      "summary": "States the O(n^{4/3}) upper bound from the Szemerédi–Trotter incidence theorem."
+      "startLine": 46,
+      "endLine": 54,
+      "summary": "States $u(n) \\leq C \\cdot n^{4/3}$ for a constant $C > 0$ and all $n \\geq 1$. This 1984 result applies the Szemerédi–Trotter incidence theorem to unit circles: each point generates a unit circle, and bounding point-circle incidences gives the $n^{4/3}$ bound."
     },
     {
       "id": "lower-bound",
       "title": "Lattice Lower Bound",
-      "startLine": 57,
-      "endLine": 62,
-      "summary": "States the n^{1+c/log log n} lower bound from lattice constructions."
+      "startLine": 56,
+      "endLine": 63,
+      "summary": "States that for some $c > 0$, eventually $u(n) \\geq n^{1+c/\\log\\log n}$. This is achieved by integer lattice configurations exploiting the arithmetic of sums of two squares. The double-logarithmic factor arises from the Ramanujan–Hardy estimate for highly composite numbers."
     },
     {
       "id": "conjecture",
-      "title": "The Erdős Conjecture",
-      "startLine": 66,
-      "endLine": 80,
-      "summary": "States the main conjecture u(n) = n^{1+O(1/log log n)} and the weaker n^{1+o(1)} version."
+      "title": "The Erdős Conjecture and Weak Form",
+      "startLine": 65,
+      "endLine": 81,
+      "summary": "States the main conjecture (`ErdosProblem90`): $u(n) \\leq n^{1+C/\\log\\log n}$ eventually, matching the lattice lower bound up to the constant $C$. Also states the weak form (`erdos_90_weak`): $u(n) \\leq n^{1+\\varepsilon}$ for every $\\varepsilon > 0$ and large $n$."
     },
     {
       "id": "obstruction",
-      "title": "Valtr's Obstruction",
-      "startLine": 84,
-      "endLine": 96,
-      "summary": "Explains why purely combinatorial methods cannot improve beyond n^{4/3}."
+      "title": "Valtr's Metric Obstruction",
+      "startLine": 83,
+      "endLine": 99,
+      "summary": "Axiomatizes Valtr's 2005 result: there exists a semimetric $d$ on $\\mathbb{R}^2$ (symmetric, non-negative, zero on the diagonal) and a constant $c > 0$ such that for all large $n$, some $n$-point configuration has $\\geq c \\cdot n^{4/3}$ $d$-unit distances. This proves the $n^{4/3}$ barrier is intrinsic to incidence-geometric methods."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 90 is one of the central questions in combinatorial geometry. The gap between the n^{4/3} upper bound and the n^{1+c/log log n} lower bound has remained open since 1946. Valtr's obstruction shows that new geometric ideas are needed.",
-    "implications": "Resolution would have profound consequences for incidence geometry, Kakeya-type problems, and the algebraic structure of Euclidean distance.",
+    "summary": "Erdős Problem #90 formalizes the complete logical structure of the unit distance problem: the extremal function u(n) defined via offDiag filtering, the Spencer–Szemerédi–Trotter O(n^{4/3}) upper bound (1984), the lattice lower bound n^{1+c/log log n}, the main conjecture (with $500 prize), the weak form ($250–300 prize), and Valtr's fundamental obstruction showing that breaking n^{4/3} requires Euclidean-specific methods. The file has 0 sorries and 6 axioms (all representing deep results or open conjectures).",
+    "implications": "Resolution would transform combinatorial geometry. The unit distance problem is intimately connected to the Erdős distinct distances problem (solved by Guth–Katz 2015), Kakeya-type problems, and the algebraic structure of Euclidean distance. Valtr's obstruction shows that purely topological or incidence-theoretic methods are insufficient; progress requires exploiting the algebraic nature of circles in the Euclidean plane, perhaps via polynomial methods as in the distinct distances solution.",
     "openQuestions": [
-      "Can the O(n^{4/3}) upper bound be improved at all?",
-      "What special property of Euclidean distance would enable such an improvement?",
-      "Does the problem have different behavior in higher dimensions?"
+      "Can the O(n^{4/3}) upper bound be improved at all, even to O(n^{4/3 - ε}) for some ε > 0?",
+      "What specific property of Euclidean distance (beyond convexity of unit circles) would enable progress?",
+      "Can polynomial partitioning methods (successful for distinct distances) be adapted for unit distances?",
+      "What is the exact constant c in the lattice lower bound n^{1+c/log log n}?",
+      "Does the problem have fundamentally different behavior in dimensions d ≥ 3?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-891",
+      "relationship": "thematic",
+      "description": "Both are Erdős open problems connecting combinatorial structure to number-theoretic phenomena; #891 studies prime factors in intervals, while #90 connects unit distances to sums of two squares"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Enriched erdos-90 (Unit Distance Problem) with deeper mathematical context
- Added mathlibDependencies (6 modules: EuclideanSpace, dist, Finset.offDiag, Filter.atTop, Real.log, sSup)
- Added originalContributions (8 items covering all definitions and axioms)
- Expanded historicalContext with 1946 origin, SST 1984, Valtr 2005, Guth-Katz connection
- Added 5 keyInsights with LaTeX mathematical notation
- Expanded from 5 to 7 sections covering full 99-line Lean file
- Enriched annotations: 7→10 with mathContext, relatedConcepts, prerequisites on all
- Standardized significance values (critical→key, added supporting for auxiliary lemmas)
- Added crossReference to erdos-891 (thematic)
- Added 5 expanded openQuestions in conclusion

## Test plan
- [x] JSON validates (python3 -c "import json; json.load(...)")
- [x] `pnpm build` passes (pre-existing yang-mills errors only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)