### PR TITLE
Research: ballot-problem-oq-01 - Cycle lemma infrastructure

### DIFF
--- a/proofs/Proofs/BallotProblemOQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ01.lean
@@ -39,9 +39,10 @@ This generalizes the classical formula P = (p - q)/(p + q) (the case k = 1).
 - [x] Cycle lemma infrastructure (rotation sum/length/identity/membership preservation)
 - [x] Positive sum/length preconditions for cycle lemma
 - [x] Prefix sum relation for rotations (both wrapping and non-wrapping cases)
-- [ ] Cyclic rotation composition (Aristotle-suitable)
-- [ ] Full proof of the cycle lemma (3 sorries remain)
-- [ ] Full proof of the generalized counting formula
+- [x] Rightmost minimum infrastructure (definition, bounds, good rotation existence)
+- [x] Prefix sum strict monotonicity and injectivity on good rotations
+- [ ] Full proof of the cycle lemma counting (1 sorry: counting argument)
+- [ ] Full proof of the generalized counting formula (1 sorry: double counting)
 
 ## References
 - Bertrand (1887): Original ballot problem
@@ -53,34 +54,16 @@ namespace GeneralizedBallot
 
 open List Set
 
-/- ## Part I: Generalized Ballot Sequences
+/- ## Part I: Generalized Ballot Sequences -/
 
-We model the k-fold ballot problem using lattice paths:
-- An upstep (+1) represents a vote for candidate A
-- A downstep (-k) represents a vote for candidate B
-
-A sequence is "k-good" if all prefix sums stay positive, meaning A always
-has more than k times as many votes as B.
--/
-
-/-- A generalized ballot sequence with `a` upsteps (+1) and `b` downsteps (-k).
-This represents an election where A gets `a` votes and B gets `b` votes,
-and each of B's votes "costs" k in the running total. -/
 def kCountedSequence (k a b : ℕ) : Set (List ℤ) :=
   {l | l.count 1 = a ∧ l.count (-(k : ℤ)) = b ∧ ∀ x ∈ l, x = 1 ∨ x = -(k : ℤ)}
 
-/-- A lattice path stays positive if every nonempty prefix has positive sum.
-This means the running total never reaches zero or below. -/
 def kStaysPositive : Set (List ℤ) :=
   {l | ∀ (i : ℕ), 0 < i → i ≤ l.length → 0 < (l.take i).sum}
 
-/- ## Part II: Core Algebraic Lemmas
+/- ## Part II: Core Algebraic Lemmas -/
 
-These helper lemmas express the sum and length of a binary-valued list
-in terms of element counts. They underpin all the basic properties. -/
-
-/-- For a list where every element is 1 or -(k : ℤ), the sum equals
-count(1) - k * count(-k). This is the core algebraic identity. -/
 theorem sum_eq_count_sub_mul_count {k : ℕ} {l : List ℤ}
     (h : ∀ x ∈ l, x = 1 ∨ x = -(k : ℤ)) :
     l.sum = (l.count 1 : ℤ) - (k : ℤ) * (l.count (-(k : ℤ))) := by
@@ -94,17 +77,9 @@ theorem sum_eq_count_sub_mul_count {k : ℕ} {l : List ℤ}
     simp only [List.sum_cons, List.count_cons]
     rw [ih hxs]
     rcases hx with rfl | rfl
-    · -- x = 1: count 1 increases by 1, count (-k) stays the same
-      simp [hne]
-      push_cast
-      omega
-    · -- x = -k: count (-k) increases by 1, count 1 stays the same
-      simp [hne.symm]
-      push_cast
-      ring
+    · simp [hne]; push_cast; omega
+    · simp [hne.symm]; push_cast; ring
 
-/-- For a list where every element is 1 or -(k : ℤ), the length equals
-count(1) + count(-k). -/
 theorem length_eq_count_add_count {k : ℕ} {l : List ℤ}
     (h : ∀ x ∈ l, x = 1 ∨ x = -(k : ℤ)) :
     l.length = l.count 1 + l.count (-(k : ℤ)) := by
@@ -123,23 +98,16 @@ theorem length_eq_count_add_count {k : ℕ} {l : List ℤ}
 
 /- ## Part III: Basic Properties of kCountedSequence -/
 
-/-- The sum of a generalized ballot sequence is `a - k * b`. -/
 theorem kCountedSequence_sum {k a b : ℕ} {l : List ℤ} (hl : l ∈ kCountedSequence k a b) :
     l.sum = (a : ℤ) - k * b := by
   have h := sum_eq_count_sub_mul_count hl.2.2
-  rw [hl.1, hl.2.1] at h
-  exact h
+  rw [hl.1, hl.2.1] at h; exact h
 
-/-- The length of a generalized ballot sequence is `a + b`. -/
 theorem kCountedSequence_length {k a b : ℕ} {l : List ℤ} (hl : l ∈ kCountedSequence k a b) :
     l.length = a + b := by
   have h := length_eq_count_add_count hl.2.2
-  rw [hl.1, hl.2.1] at h
-  exact h
+  rw [hl.1, hl.2.1] at h; exact h
 
-/-- Generalized ballot sequences are finite.
-They are a subset of lists of fixed length with elements from a two-element alphabet,
-so the cardinality is at most 2^(a+b). -/
 theorem kCountedSequence_perm (k a b : ℕ) (l : List ℤ) (hl : l ∈ kCountedSequence k a b) :
     l ~ (List.replicate a 1 ++ List.replicate b (-(k : ℤ))) := by
   rw [List.perm_iff_count]
@@ -155,223 +123,115 @@ theorem kCountedSequence_perm (k a b : ℕ) (l : List ℤ) (hl : l ∈ kCountedS
       rw [this]; simp [List.count_append, List.count_replicate, hx1, hxk]
 
 theorem kCountedSequence_finite (k a b : ℕ) : (kCountedSequence k a b).Finite := by
-  -- Every element is a permutation of a fixed witness list w.
-  -- The set of permutations of w is finite (subset of w.permutations list).
   let w := List.replicate a 1 ++ List.replicate b (-(k : ℤ))
   apply Set.Finite.subset (Finset.finite_toSet w.permutations.toFinset)
   intro l hl
   simp only [Finset.coe_toSet, List.mem_toFinset, List.mem_permutations]
   exact kCountedSequence_perm k a b l hl
 
-/-- There is at least one generalized ballot sequence.
-The witness is `replicate a 1 ++ replicate b (-(k : ℤ))`. -/
 theorem kCountedSequence_nonempty (k a b : ℕ) : (kCountedSequence k a b).Nonempty := by
   use List.replicate a 1 ++ List.replicate b (-(k : ℤ))
   have hne : (1 : ℤ) ≠ -(k : ℤ) := by omega
   refine ⟨?_, ?_, ?_⟩
-  · -- count 1 = a
-    simp only [List.count_append, List.count_replicate]
-    simp [hne, hne.symm]
-  · -- count (-k) = b
-    simp only [List.count_append, List.count_replicate]
-    simp [hne, hne.symm]
-  · -- all elements are 1 or -k
-    intro x hx
-    rw [List.mem_append] at hx
+  · simp only [List.count_append, List.count_replicate]; simp [hne, hne.symm]
+  · simp only [List.count_append, List.count_replicate]; simp [hne, hne.symm]
+  · intro x hx; rw [List.mem_append] at hx
     rcases hx with hx | hx
     · exact Or.inl (List.eq_of_mem_replicate hx)
     · exact Or.inr (List.eq_of_mem_replicate hx)
 
-/- ## Part IV: Connection to Classical Ballot Problem
+/- ## Part IV: Connection to Classical Ballot Problem -/
 
-When k = 1, the generalized ballot problem reduces to the classical one.
-The key observation: `kCountedSequence 1 a b` is exactly Mathlib's `countedSequence a b`
-(since steps are +1 and -1), and our `kStaysPositive` corresponds to Mathlib's
-`staysPositive` (which checks all nonempty suffixes have positive sum).
--/
-
-/-- When k = 1, a generalized ballot sequence is exactly a classical ballot sequence.
-The only values in the list are +1 and -1, matching Mathlib's `countedSequence`. -/
 theorem kCountedSequence_eq_countedSequence (a b : ℕ) :
     kCountedSequence 1 a b = Ballot.countedSequence a b := by
   ext l
   simp only [kCountedSequence, Ballot.countedSequence, Set.mem_setOf_eq]
   constructor
-  · rintro ⟨h1, h2, h3⟩
-    refine ⟨h1, ?_, h3⟩
-    simpa using h2
-  · rintro ⟨h1, h2, h3⟩
-    refine ⟨h1, ?_, h3⟩
-    simpa using h2
+  · rintro ⟨h1, h2, h3⟩; refine ⟨h1, ?_, h3⟩; simpa using h2
+  · rintro ⟨h1, h2, h3⟩; refine ⟨h1, ?_, h3⟩; simpa using h2
 
 /- ## Part V: The Generalized Ballot Theorem -/
 
-/-- **The Generalized Ballot Theorem (k-fold dominance)**
-
-The number of good sequences satisfies the ballot equation.
-This follows from the cycle lemma by double counting:
-- For each sequence, exactly `a - k*b` of its `a+b` rotations are good (cycle lemma)
-- Each good sequence arises as a rotation from exactly `a+b` source sequences
-- Therefore: good_count * (a+b) = total_sequences * (a - k*b) -/
 theorem generalized_ballot_count (k a b : ℕ) (hab : k * b < a) :
     ∃ (good_count : ℕ),
       good_count * (a + b) = (a - k * b) * (a + b).choose a := by
   sorry -- Requires: cycle_lemma + double counting + rotation bijectivity
 
-/-- The probability form of the generalized ballot theorem.
-When `a > k * b`, the probability is `(a - k * b) / (a + b)`. -/
 theorem generalized_ballot_prob (k a b : ℕ) (hab : k * b < a) :
     ((a : ℚ) - k * b) / (a + b) > 0 := by
-  have h1 : (0 : ℚ) < a - k * b := by
-    rw [sub_pos]
-    exact_mod_cast hab
-  have h2 : (0 : ℚ) < a + b := by
-    have : 0 < a := by omega
-    positivity
+  have h1 : (0 : ℚ) < a - k * b := by rw [sub_pos]; exact_mod_cast hab
+  have h2 : (0 : ℚ) < a + b := by have : 0 < a := by omega; positivity
   exact div_pos h1 h2
 
 /- ## Part VI: Special Cases and Verification -/
 
-/-- When k = 1, the generalized formula reduces to the classical ballot formula.
-With `a > b`, P = (a - b)/(a + b). -/
 theorem generalized_ballot_classical (a b : ℕ) :
-    ((a : ℚ) - 1 * b) / (a + b) = (a - b) / (a + b) := by
-  ring
+    ((a : ℚ) - 1 * b) / (a + b) = (a - b) / (a + b) := by ring
 
-/-- Example: k = 2, a = 5, b = 2. Since 5 > 2*2 = 4, the probability is
-(5 - 2*2)/(5 + 2) = 1/7. -/
 example : ((5 : ℚ) - 2 * 2) / (5 + 2) = 1 / 7 := by norm_num
-
-/-- Example: k = 3, a = 10, b = 3. Since 10 > 3*3 = 9, the probability is
-(10 - 3*3)/(10 + 3) = 1/13. -/
 example : ((10 : ℚ) - 3 * 3) / (10 + 3) = 1 / 13 := by norm_num
-
-/-- Example: k = 1, a = 3, b = 1. This is the classical case: P = 2/4 = 1/2. -/
 example : ((3 : ℚ) - 1 * 1) / (3 + 1) = 1 / 2 := by norm_num
-
-/-- Example: k = 2, a = 7, b = 3. P = (7 - 6)/(7 + 3) = 1/10. -/
 example : ((7 : ℚ) - 2 * 3) / (7 + 3) = 1 / 10 := by norm_num
 
-/- ## Part VII: The Cycle Lemma
+/- ## Part VII: The Cycle Lemma -/
 
-The key tool for proving the generalized ballot theorem is the Dvoretzky-Motzkin
-Cycle Lemma (1947).
-
-Cycle Lemma: Given a sequence of integers x_1, x_2, ..., x_n with total
-sum S > 0, exactly S of the n cyclic permutations have all positive partial sums.
-
-For our application:
-- The sequence has a entries of +1 and b entries of -k
-- Total sum = a - kb > 0
-- Length = a + b
-- Number of "good" cyclic permutations = a - kb
-
-This gives us the fraction of good orderings: (a - kb) / (a + b).
--/
-
-/-- A cyclic rotation of a list by `i` positions. -/
 def cyclicRotation (l : List ℤ) (i : ℕ) : List ℤ :=
   l.drop i ++ l.take i
 
-/-- Cyclic rotation preserves the sum of the list. -/
 theorem cyclicRotation_sum (l : List ℤ) (i : ℕ) :
     (cyclicRotation l i).sum = l.sum := by
   simp only [cyclicRotation, List.sum_append]
   have h := congr_arg List.sum (List.take_append_drop i l)
-  rw [List.sum_append] at h
-  omega
+  rw [List.sum_append] at h; omega
 
-/-- Cyclic rotation preserves the length of the list. -/
 theorem cyclicRotation_length (l : List ℤ) (i : ℕ) (hi : i ≤ l.length) :
     (cyclicRotation l i).length = l.length := by
-  simp [cyclicRotation, List.length_drop, List.length_take, Nat.min_eq_left hi]
-  omega
+  simp [cyclicRotation, List.length_drop, List.length_take, Nat.min_eq_left hi]; omega
 
-/-- Cyclic rotation by 0 is the identity. -/
-theorem cyclicRotation_zero (l : List ℤ) :
-    cyclicRotation l 0 = l := by
+theorem cyclicRotation_zero (l : List ℤ) : cyclicRotation l 0 = l := by
   simp [cyclicRotation]
 
-/-- Cyclic rotation by n (the length) returns the original list. -/
-theorem cyclicRotation_length_self (l : List ℤ) :
-    cyclicRotation l l.length = l := by
+theorem cyclicRotation_length_self (l : List ℤ) : cyclicRotation l l.length = l := by
   simp [cyclicRotation]
 
-/-- Cyclic rotation preserves membership in kCountedSequence.
-All rotations of a ballot sequence are themselves ballot sequences. -/
 theorem cyclicRotation_mem_kCountedSequence {k a b : ℕ} {l : List ℤ}
     (hl : l ∈ kCountedSequence k a b) (i : ℕ) (hi : i ≤ l.length) :
     cyclicRotation l i ∈ kCountedSequence k a b := by
   have ⟨h1, h2, h3⟩ := hl
   refine ⟨?_, ?_, ?_⟩
-  · -- count 1 is preserved by rotation
-    simp only [cyclicRotation, List.count_append]
+  · simp only [cyclicRotation, List.count_append]
     have := congr_arg (List.count 1) (List.take_append_drop i l)
-    rw [List.count_append] at this
-    omega
-  · -- count (-k) is preserved by rotation
-    simp only [cyclicRotation, List.count_append]
+    rw [List.count_append] at this; omega
+  · simp only [cyclicRotation, List.count_append]
     have := congr_arg (List.count (-(k : ℤ))) (List.take_append_drop i l)
-    rw [List.count_append] at this
-    omega
-  · -- all elements are 1 or -k
-    intro x hx
-    rw [cyclicRotation, List.mem_append] at hx
+    rw [List.count_append] at this; omega
+  · intro x hx; rw [cyclicRotation, List.mem_append] at hx
     rcases hx with hx | hx
     · exact h3 x (List.drop_subset i l hx)
     · exact h3 x (List.take_subset i l hx)
 
-/-- Cyclic rotation of a rotation composes: rotating by i then by j equals rotating by i+j
-(modulo length). For the non-wrapping case where i+j ≤ length. -/
 theorem cyclicRotation_compose (l : List ℤ) (i j : ℕ)
     (hi : i ≤ l.length) (hj : j ≤ l.length - i) :
     cyclicRotation (cyclicRotation l i) j = cyclicRotation l (i + j) := by
-  -- cyclicRotation l i = l.drop i ++ l.take i
-  -- Since j ≤ length(l.drop i), the take/drop of the concatenation stays in the first part.
   simp only [cyclicRotation]
-  have hlen_drop : l.drop i |>.length = l.length - i := List.length_drop i l
-  have hj_le : j ≤ (l.drop i).length := by omega
-  -- Simplify drop/take of the concatenation using the length bound
+  have hj_le : j ≤ (l.drop i).length := by simp [List.length_drop]; omega
   rw [List.drop_append_of_le_length hj_le, List.take_append_of_le_length hj_le]
-  -- Now we have: ((l.drop i).drop j ++ l.take i) ++ (l.drop i).take j
-  --            = l.drop (i + j) ++ l.take (i + j)
-  rw [List.drop_drop]
-  -- LHS: l.drop (i + j) ++ l.take i ++ (l.drop i).take j
-  -- RHS: l.drop (i + j) ++ l.take (i + j)
-  -- Suffices: l.take i ++ (l.drop i).take j = l.take (i + j)
-  rw [List.append_assoc]
-  congr 1
-  -- l.take i ++ (l.drop i).take j = l.take (i + j)
-  rw [← List.take_add]
+  rw [List.drop_drop, List.append_assoc]
+  congr 1; rw [← List.take_add]
 
-/-- A kCountedSequence where k*b < a has positive sum, which is the precondition
-for the cycle lemma. -/
 theorem kCountedSequence_pos_sum {k a b : ℕ} {l : List ℤ}
     (hl : l ∈ kCountedSequence k a b) (hab : k * b < a) :
-    0 < l.sum := by
-  rw [kCountedSequence_sum hl]
-  omega
+    0 < l.sum := by rw [kCountedSequence_sum hl]; omega
 
-/-- A kCountedSequence has positive length when a + b > 0. -/
 theorem kCountedSequence_pos_length {k a b : ℕ} {l : List ℤ}
     (hl : l ∈ kCountedSequence k a b) (hab : 0 < a + b) :
-    0 < l.length := by
-  rw [kCountedSequence_length hl]
-  exact hab
+    0 < l.length := by rw [kCountedSequence_length hl]; exact hab
 
-/-- The prefix sum of a cyclic rotation relates to prefix sums of the original.
-For rotation starting at position i:
-  prefixSum(rotation, j) = prefixSum(original, i+j) - prefixSum(original, i)
-when i+j <= n, and wraps around with an additive correction of S = sum(l). -/
-/-- Helper: sum of l.drop i equals l.sum - (l.take i).sum -/
 private theorem sum_drop_eq (l : List ℤ) (i : ℕ) :
     (l.drop i).sum = l.sum - (l.take i).sum := by
   have h := congr_arg List.sum (List.take_append_drop i l)
-  rw [List.sum_append] at h
-  omega
+  rw [List.sum_append] at h; omega
 
-/-- Helper: the "middle slice" (l.drop i).take j has sum = prefixSum(i+j) - prefixSum(i)
-    when i + j ≤ l.length. -/
 private theorem take_drop_sum (l : List ℤ) (i j : ℕ)
     (hi : i ≤ l.length) (hij : i + j ≤ l.length) :
     ((l.drop i).take j).sum = (l.take (i + j)).sum - (l.take i).sum := by
@@ -379,12 +239,9 @@ private theorem take_drop_sum (l : List ℤ) (i j : ℕ)
     rw [← List.take_take]
     conv_lhs => rw [← List.take_append_drop i l]
     rw [List.take_append_eq_append_take]
-    simp [List.length_take, Nat.min_eq_left hi]
-    congr 1
-    omega
+    simp [List.length_take, Nat.min_eq_left hi]; congr 1; omega
   have := congr_arg List.sum key
-  rw [List.sum_append] at this
-  omega
+  rw [List.sum_append] at this; omega
 
 theorem cyclicRotation_prefixSum (l : List ℤ) (i j : ℕ)
     (hi : i ≤ l.length) (hj : j ≤ l.length) :
@@ -395,82 +252,46 @@ theorem cyclicRotation_prefixSum (l : List ℤ) (i j : ℕ)
         (l.take (i + j - l.length)).sum + l.sum - (l.take i).sum := by
   simp only [cyclicRotation]
   by_cases hij : i + j ≤ l.length
-  · -- Non-wrapping case: j ≤ length(l.drop i), so take j stays within l.drop i
-    simp only [hij, ↓reduceIte]
-    have hj_le : j ≤ (l.drop i).length := by
-      simp [List.length_drop]
-      omega
+  · simp only [hij, ↓reduceIte]
+    have hj_le : j ≤ (l.drop i).length := by simp [List.length_drop]; omega
     rw [List.take_append_of_le_length hj_le]
     exact take_drop_sum l i j hi hij
-  · -- Wrapping case: j > length(l.drop i), take all of l.drop i plus some of l.take i
-    push_neg at hij
+  · push_neg at hij
     simp only [show ¬(i + j ≤ l.length) from by omega, ↓reduceIte]
-    have hdrop_len : (l.drop i).length = l.length - i := List.length_drop i l
-    have hj_gt : (l.drop i).length ≤ j := by omega
-    rw [List.take_append]
-    rw [List.take_of_length_le hj_gt]
-    rw [List.sum_append]
-    rw [sum_drop_eq]
-    -- Simplify j - (l.drop i).length = i + j - l.length
+    have hj_gt : (l.drop i).length ≤ j := by simp [List.length_drop]; omega
+    rw [List.take_append, List.take_of_length_le hj_gt, List.sum_append, sum_drop_eq]
     have hlen_eq : j - (l.drop i).length = i + j - l.length := by
-      rw [hdrop_len]; omega
+      simp [List.length_drop]; omega
     rw [hlen_eq]
-    -- Simplify (l.take i).take(i+j-n) = l.take(i+j-n)
     have htake_take : ((l.take i).take (i + j - l.length)).sum =
         (l.take (i + j - l.length)).sum := by
-      congr 1
-      rw [List.take_take]
-      congr 1
-      exact Nat.min_eq_left (by omega)
-    rw [htake_take]
-    omega
+      congr 1; rw [List.take_take]; congr 1; exact Nat.min_eq_left (by omega)
+    rw [htake_take]; omega
 
-/-- The prefix sum function: prefixSum l i = sum of first i elements. -/
 def prefixSum (l : List ℤ) (i : ℕ) : ℤ := (l.take i).sum
 
-/-- Prefix sum at 0 is 0. -/
-theorem prefixSum_zero (l : List ℤ) : prefixSum l 0 = 0 := by
-  simp [prefixSum]
+theorem prefixSum_zero (l : List ℤ) : prefixSum l 0 = 0 := by simp [prefixSum]
 
-/-- Prefix sum at the full length is the total sum. -/
 theorem prefixSum_length (l : List ℤ) : prefixSum l l.length = l.sum := by
   simp [prefixSum, List.take_length]
 
-/-- Prefix sum of the doubled sequence satisfies periodicity:
-    prefixSum(l ++ l, i + n) = prefixSum(l ++ l, i) + sum(l) for i ≤ n. -/
 theorem prefixSum_doubled_periodic (l : List ℤ) (i : ℕ) (hi : i ≤ l.length) :
     prefixSum (l ++ l) (i + l.length) = prefixSum (l ++ l) i + l.sum := by
   simp only [prefixSum]
   rw [show i + l.length = l.length + i from by omega]
-  rw [List.take_add]
-  rw [List.sum_append]
-  congr 1
-  -- (l ++ l).take(l.length) = l
-  rw [List.take_left]
-  -- Now: ((l ++ l).drop l.length).take i = l.take i
-  rw [List.drop_left]
-  -- ((l ++ l).drop l.length) = l, so take i of that = l.take i
-  -- But we need: (l ++ l).take i = the first i elements
-  -- Actually: prefixSum(l++l, i) = prefixSum(l, i) since i ≤ l.length
-  -- and (l++l).drop(l.length) = l, so take i of that = l.take i
-  rfl
+  rw [List.take_add, List.sum_append]
+  congr 1; rw [List.take_left]; rw [List.drop_left]; rfl
 
-/-- A rotation i is "good" if all prefix sums of the rotated sequence are positive. -/
 def isGoodRotation (l : List ℤ) (i : ℕ) : Prop :=
   ∀ j, 0 < j → j ≤ l.length → 0 < ((cyclicRotation l i).take j).sum
 
-/-- Good rotation is decidable for concrete lists and positions. -/
 instance (l : List ℤ) (i : ℕ) : Decidable (isGoodRotation l i) :=
   inferInstanceAs (Decidable (∀ j, 0 < j → j ≤ l.length →
     0 < ((cyclicRotation l i).take j).sum))
 
-/-- The set of good rotations as a Finset. -/
 def goodRotations (l : List ℤ) : Finset ℕ :=
   (Finset.range l.length).filter (fun i => isGoodRotation l i)
 
-/-- The good rotation condition can be characterized purely in terms of the prefix sum
-function of the doubled sequence. Position i is good iff P(i) is strictly less than
-P(i+1), P(i+2), ..., P(i+n) in the doubled prefix sum sequence. -/
 theorem isGoodRotation_iff_prefixSum (l : List ℤ) (i : ℕ) (hi : i < l.length) :
     isGoodRotation l i ↔
       ∀ j, 0 < j → j ≤ l.length →
@@ -482,116 +303,129 @@ theorem isGoodRotation_iff_prefixSum (l : List ℤ) (i : ℕ) (hi : i < l.length
     rw [cyclicRotation_prefixSum l i j (le_of_lt hi) hjn] at hgood
     simp only [prefixSum]
     split_ifs at hgood with hij
-    · -- Non-wrapping: P(i+j) - P(i) > 0, so P(i) < P(i+j)
-      -- Also: i+j ≤ l.length, so (l++l).take(i+j) = l.take(i+j)
-      rw [List.take_append_of_le_length (by omega)]
-      omega
-    · -- Wrapping: P(i+j-n) + S - P(i) > 0
-      push_neg at hij
-      -- Decompose (l++l).take(i+j) via l.length + (i+j-l.length)
-      have hrw : i + j = l.length + (i + j - l.length) := by omega
-      rw [hrw, List.take_add, List.sum_append, List.take_left, List.drop_left]
-      omega
+    · rw [List.take_append_of_le_length (by omega)]; omega
+    · push_neg at hij
+      rw [show i + j = l.length + (i + j - l.length) from by omega,
+          List.take_add, List.sum_append, List.take_left, List.drop_left]; omega
   · intro h j hj hjn
     rw [cyclicRotation_prefixSum l i j (le_of_lt hi) hjn]
     have hpf := h j hj hjn
     simp only [prefixSum] at hpf
     split_ifs with hij
-    · -- Non-wrapping
-      rw [List.take_append_of_le_length (by omega)] at hpf
-      omega
-    · -- Wrapping
-      push_neg at hij
-      have hrw : i + j = l.length + (i + j - l.length) := by omega
-      rw [hrw, List.take_add, List.sum_append, List.take_left, List.drop_left] at hpf
-      omega
+    · rw [List.take_append_of_le_length (by omega)] at hpf; omega
+    · push_neg at hij
+      rw [show i + j = l.length + (i + j - l.length) from by omega,
+          List.take_add, List.sum_append, List.take_left, List.drop_left] at hpf; omega
 
-/-- For the doubled sequence, prefixSum(l++l, i) = prefixSum(l, i) when i ≤ l.length. -/
 theorem prefixSum_doubled_le (l : List ℤ) (i : ℕ) (hi : i ≤ l.length) :
     prefixSum (l ++ l) i = prefixSum l i := by
-  simp only [prefixSum]
-  rw [List.take_append_of_le_length hi]
+  simp only [prefixSum]; rw [List.take_append_of_le_length hi]
 
-/-- **The Cycle Lemma (Dvoretzky-Motzkin, 1947).**
+/- ## Cycle Lemma Infrastructure -/
 
-For a list of integers with positive sum S and length n,
-exactly S of the n cyclic rotations have all positive prefix sums.
+noncomputable def minPrefixSum (l : List ℤ) : ℤ :=
+  ((Finset.range (l.length + 1)).image (prefixSum l)).min'
+    (Finset.Nonempty.image ⟨0, Finset.mem_range.mpr (Nat.zero_lt_succ _)⟩ _)
 
-Proof Strategy (Rightmost Minimum):
-1. Define prefixSum(i) = sum of first i elements, with prefixSum(0) = 0.
-2. For the "doubled" sequence (period 2), consider positions 0, 1, ..., 2n-1.
-3. The prefix sums satisfy prefixSum(i + n) = prefixSum(i) + S.
-4. In each window of n consecutive positions, there are exactly S positions j
-   where j is a "new minimum" (prefixSum(j) < prefixSum(i) for all i in the window
-   before j). These correspond exactly to good starting positions.
+noncomputable def rightmostMinPos (l : List ℤ) : ℕ :=
+  ((Finset.range (l.length + 1)).filter (fun i => prefixSum l i = minPrefixSum l)).max'
+    (by
+      unfold minPrefixSum
+      have hmin := Finset.min'_mem
+        ((Finset.range (l.length + 1)).image (prefixSum l))
+        (Finset.Nonempty.image ⟨0, Finset.mem_range.mpr (Nat.zero_lt_succ _)⟩ _)
+      rw [Finset.mem_image] at hmin
+      obtain ⟨a, ha_mem, ha_eq⟩ := hmin
+      exact ⟨a, Finset.mem_filter.mpr ⟨ha_mem, ha_eq.symm⟩⟩)
 
-This is the fundamental counting tool for the generalized ballot problem. -/
-theorem cycle_lemma (l : List ℤ) (hn : 0 < l.length)
-    (hS : 0 < l.sum) :
-    ((Finset.range l.length).filter
-      (fun i => ∀ j, 0 < j → j ≤ l.length →
-        0 < ((cyclicRotation l i).take j).sum)).card = l.sum.toNat := by
-  sorry -- The full cycle lemma proof; requires rightmost minimum injection argument
+theorem rightmostMinPos_le (l : List ℤ) : rightmostMinPos l ≤ l.length := by
+  unfold rightmostMinPos
+  have hm := Finset.max'_mem _ _
+  rw [Finset.mem_filter, Finset.mem_range] at hm; omega
 
-/-- Verification: For the simple list [2, -1], sum = 1 > 0, length = 2.
-The cycle lemma predicts exactly 1 good rotation. -/
-example : ((Finset.range 2).filter (fun i =>
-    ∀ j, 0 < j → j ≤ 2 →
-      0 < ((cyclicRotation [2, -1] i).take j).sum)).card = 1 := by
-  native_decide
+theorem prefixSum_rightmostMinPos (l : List ℤ) :
+    prefixSum l (rightmostMinPos l) = minPrefixSum l := by
+  unfold rightmostMinPos
+  exact (Finset.max'_mem _ _ |> Finset.mem_filter.mp).2
 
-/- ## Part VIII: Lattice Path Interpretation
+theorem minPrefixSum_le_zero (l : List ℤ) : minPrefixSum l ≤ 0 := by
+  unfold minPrefixSum; apply Finset.min'_le
+  exact Finset.mem_image.mpr ⟨0, Finset.mem_range.mpr (Nat.zero_lt_succ _), prefixSum_zero l⟩
 
-The k-fold ballot problem has a beautiful lattice path interpretation:
+theorem minPrefixSum_le (l : List ℤ) (i : ℕ) (hi : i ≤ l.length) :
+    minPrefixSum l ≤ prefixSum l i := by
+  unfold minPrefixSum
+  exact Finset.min'_le _ _ (Finset.mem_image.mpr ⟨i, Finset.mem_range.mpr (by omega), rfl⟩)
 
-Setup:
-- Start at the origin (0, 0)
-- A vote for A = upstep to (x+1, y+1)
-- A vote for B = downstep to (x+1, y-k)
-- End at (a+b, a-kb)
+theorem prefixSum_gt_after_rightmostMin (l : List ℤ) (j : ℕ)
+    (hj : rightmostMinPos l < j) (hjn : j ≤ l.length) :
+    minPrefixSum l < prefixSum l j := by
+  by_contra h; push_neg at h
+  have heq : prefixSum l j = minPrefixSum l := le_antisymm h (minPrefixSum_le l j hjn)
+  have hj_in : j ∈ (Finset.range (l.length + 1)).filter
+      (fun i => prefixSum l i = minPrefixSum l) :=
+    Finset.mem_filter.mpr ⟨Finset.mem_range.mpr (by omega), heq⟩
+  exact absurd (Finset.le_max' _ j hj_in) (by unfold rightmostMinPos at hj; omega)
 
-k-good paths are those that never touch or go below the x-axis.
+theorem rightmostMinPos_lt (l : List ℤ) (hS : 0 < l.sum) :
+    rightmostMinPos l < l.length := by
+  by_contra h; push_neg at h
+  have heq : rightmostMinPos l = l.length := le_antisymm (rightmostMinPos_le l) h
+  have : minPrefixSum l = l.sum := by
+    rw [← prefixSum_length l, ← heq]; exact prefixSum_rightmostMinPos l
+  linarith [minPrefixSum_le_zero l]
 
-When k = 1: standard Dyck-like paths above the x-axis
-When k = 2: paths where each downstep drops by 2 (steeper descent)
-When k = 3: each B vote is "worth" 3 A votes in the count
+theorem goodRotation_at_rightmostMin (l : List ℤ) (hn : 0 < l.length) (hS : 0 < l.sum) :
+    isGoodRotation l (rightmostMinPos l) := by
+  set m := rightmostMinPos l
+  have hm_lt : m < l.length := rightmostMinPos_lt l hS
+  have hm_val : prefixSum l m = minPrefixSum l := prefixSum_rightmostMinPos l
+  intro j hj hjn
+  rw [cyclicRotation_prefixSum l m j (le_of_lt hm_lt) hjn]
+  split_ifs with hmj
+  · linarith [prefixSum_gt_after_rightmostMin l (m + j) (by omega) hmj]
+  · push_neg at hmj
+    linarith [minPrefixSum_le l (m + j - l.length) (by omega)]
 
-Connection to ballot counting:
-In the election, at any point after counting some votes, if A has alpha votes
-and B has beta votes, the lattice height is alpha - k*beta. The condition
-"A has more than k times B's votes" (alpha > k*beta) is exactly "height > 0".
+theorem goodRotations_nonempty (l : List ℤ) (hn : 0 < l.length) (hS : 0 < l.sum) :
+    (goodRotations l).Nonempty :=
+  ⟨rightmostMinPos l, Finset.mem_filter.mpr
+    ⟨Finset.mem_range.mpr (rightmostMinPos_lt l hS),
+     goodRotation_at_rightmostMin l hn hS⟩⟩
 
-This gives us a clean bijection between:
-- Vote orderings where A always dominates by factor k
-- Lattice paths from (0,0) to (a+b, a-kb) that stay strictly above y=0
--/
+theorem goodRotation_prefixSum_strictMono (l : List ℤ) (i₁ i₂ : ℕ)
+    (hi₁ : i₁ < l.length) (hi₂ : i₂ < l.length) (hlt : i₁ < i₂)
+    (hg₁ : isGoodRotation l i₁) :
+    prefixSum l i₁ < prefixSum l i₂ := by
+  have h := (isGoodRotation_iff_prefixSum l i₁ hi₁).mp hg₁ (i₂ - i₁) (by omega) (by omega)
+  rwa [show i₁ + (i₂ - i₁) = i₂ from by omega, prefixSum_doubled_le l i₂ (le_of_lt hi₂)] at h
 
-/-- The height at position i in a k-ballot path equals
-the number of A votes minus k times the number of B votes so far. -/
+theorem goodRotation_prefixSum_injective (l : List ℤ) (i₁ i₂ : ℕ)
+    (hi₁ : i₁ < l.length) (hi₂ : i₂ < l.length)
+    (hg₁ : isGoodRotation l i₁) (hg₂ : isGoodRotation l i₂)
+    (heq : prefixSum l i₁ = prefixSum l i₂) : i₁ = i₂ := by
+  rcases lt_trichotomy i₁ i₂ with hlt | rfl | hgt
+  · exact absurd heq (ne_of_lt (goodRotation_prefixSum_strictMono l i₁ i₂ hi₁ hi₂ hlt hg₁))
+  · rfl
+  · exact absurd heq.symm (ne_of_lt (goodRotation_prefixSum_strictMono l i₂ i₁ hi₂ hi₁ hgt hg₂))
+
+/-- **The Cycle Lemma (Dvoretzky-Motzkin, 1947) for ballot sequences.** -/
+theorem cycle_lemma {k a b : ℕ} {l : List ℤ} (hl : l ∈ kCountedSequence k a b)
+    (hab : k * b < a) :
+    (goodRotations l).card = a - k * b := by
+  sorry -- Counting argument: combine injectivity with level crossing surjectivity
+
+/-- Verification examples -/
+example : (goodRotations [1, 1, -1]).card = 1 := by native_decide
+example : (goodRotations [1, 1, 1, -1, -1]).card = 1 := by native_decide
+example : (goodRotations [1, 1, 1, -1]).card = 2 := by native_decide
+
+/- ## Part VIII: Lattice Path Interpretation -/
+
 theorem path_height_interpretation {k a b : ℕ} {l : List ℤ}
     (hl : l ∈ kCountedSequence k a b) (i : ℕ) (hi : i ≤ l.length) :
     (l.take i).sum = (l.take i).count 1 - (k : ℤ) * (l.take i).count (-(k : ℤ)) := by
   apply sum_eq_count_sub_mul_count
-  intro x hx
-  exact hl.2.2 x (List.take_subset i l hx)
-
-/- ## Part IX: Extensions and Open Directions
-
-The k-fold generalization opens several research directions:
-
-1. Multi-candidate ballot problem: Given candidates with votes v_1 > v_2 > ... > v_m,
-   what is the probability that candidate 1 always leads candidate 2, who always
-   leads candidate 3, etc.? This requires a multi-dimensional lattice path analysis.
-
-2. Continuous-time version: The ballot problem has a continuous analogue in
-   terms of Brownian motion (the Brownian ballot problem).
-
-3. Weighted voting: Different votes could have different weights, leading to
-   lattice paths with varying step sizes.
-
-4. Random walks with barriers: The ballot problem is equivalent to counting
-   random walks that avoid a barrier, connecting to the theory of reflected
-   random walks.
--/
+  intro x hx; exact hl.2.2 x (List.take_subset i l hx)
 
 end GeneralizedBallot

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -7,7 +7,7 @@
   "path": "full",
   "problemStatement": {
     "formal": "For a > k*b, the probability that A maintains > k times B's votes throughout counting is (a - k*b)/(a + b)",
-    "plain": "The Generalized Ballot Problem extends Bertrand's classical result to the k-fold case: when candidate A must maintain more than k times the votes of candidate B throughout counting, the probability is (a - k*b)/(a + b).",
+    "plain": "The Generalized Ballot Problem extends Bertrand's classical result to the k-fold case.",
     "whyMatters": [
       "Generalizes the classical ballot theorem (k=1) to arbitrary dominance factors",
       "Uses the Dvoretzky-Motzkin cycle lemma - a fundamental combinatorial tool",
@@ -16,94 +16,70 @@
   },
   "knownResults": {
     "proven": [
-      "kCountedSequence definitions and basic properties (sum, length)",
-      "Permutation characterization: every element is a permutation of replicate a 1 ++ replicate b (-k)",
-      "Finiteness of kCountedSequence (via permutation embedding)",
-      "Nonemptiness of kCountedSequence",
-      "Connection to classical ballot problem: kCountedSequence 1 a b = countedSequence a b",
-      "Cyclic rotation preserves sum, length, composition, and kCountedSequence membership",
-      "Cyclic rotation prefix sum formula (both wrapping and non-wrapping cases)",
-      "Prefix sum of doubled sequence periodicity: P(l++l, i+n) = P(l++l, i) + S",
+      "kCountedSequence definitions and basic properties (sum, length, finiteness, nonemptiness)",
+      "Connection to classical ballot: kCountedSequence 1 a b = countedSequence a b",
+      "Cyclic rotation infrastructure (sum, length, composition, kCountedSequence preservation)",
+      "Prefix sum relation for rotations (wrapping and non-wrapping cases)",
       "Good rotation characterization via doubled prefix sums",
-      "Positive sum and length for ballot sequences with k*b < a",
-      "Path height interpretation via prefix sums",
-      "Probability positivity: (a - k*b)/(a + b) > 0",
-      "Special cases verified: k=2 a=5 b=2 (1/7), k=3 a=10 b=3 (1/13), etc.",
-      "Classical reduction: formula reduces to (a-b)/(a+b) when k=1",
-      "Verification example: [2,-1] has exactly 1 good rotation (native_decide)"
+      "Rightmost minimum infrastructure (definition, bounds, good rotation proof)",
+      "Prefix sum strict monotonicity and injectivity on good rotations",
+      "Corrected cycle lemma statement (restricted to kCountedSequence)",
+      "Verification examples via native_decide"
     ],
     "open": [
-      "Dvoretzky-Motzkin cycle lemma (rightmost minimum injection argument)",
-      "Full generalized ballot counting theorem (depends on cycle lemma)"
+      "Cycle lemma counting (injectivity proved, surjectivity via level crossings needed)",
+      "Generalized ballot counting theorem (depends on cycle lemma)"
     ],
     "goal": "Complete proof of the generalized ballot theorem via the cycle lemma"
   },
   "currentState": {
     "phase": "IN_PROGRESS",
-    "since": "2026-02-10T11:21:00Z",
-    "iteration": 3,
-    "focus": "Proved kCountedSequence_finite and cyclicRotation_compose. Added prefix sum infrastructure for cycle lemma. All infrastructure complete; only cycle_lemma remains.",
+    "since": "2026-02-10T17:30:00Z",
+    "iteration": 4,
+    "focus": "Built rightmost min infrastructure. Found/fixed bug in cycle lemma statement. Proved good rotation existence and injectivity.",
     "blockers": [
-      "Cycle lemma requires rightmost minimum injection argument - deep combinatorial proof"
+      "Cycle lemma surjectivity: need level crossing argument for ballot sequences"
     ],
-    "nextAction": "Submit file to Aristotle for cycle_lemma sorry. If Aristotle fails, manual proof via Finset injection.",
+    "nextAction": "Prove surjectivity or submit to Aristotle",
     "attemptCounts": {
-      "total": 3,
-      "currentApproach": 3,
+      "total": 4,
+      "currentApproach": 4,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: ~30 theorems/lemmas, 2 sorries. Complete rotation infrastructure, prefix sum relation (wrapping + non-wrapping), doubled sequence periodicity, good rotation characterization. Only cycle_lemma and generalized_ballot_count remain.",
+    "progressSummary": "PROGRESS: ~35 theorems proved, 2 sorries remain. Key: rightmost min infrastructure + good rotation proof + strict monotonicity + injectivity. Critical bug found: cycle lemma wrong for arbitrary integers.",
     "builtItems": [
-      "proofs/Proofs/BallotProblemOQ01.lean - ~30 theorems, 2 sorries (~600 lines)",
-      "kCountedSequence_finite: finiteness via permutation embedding into w.permutations.toFinset",
-      "cyclicRotation_compose: rotation composition for non-wrapping case",
-      "cyclicRotation_prefixSum: prefix sum of rotations (wrapping and non-wrapping)",
-      "prefixSum_doubled_periodic: P(l++l, i+n) = P(l++l, i) + S",
-      "isGoodRotation_iff_prefixSum: good rotation ↔ prefix sum strict minimum",
-      "prefixSum_doubled_le: P(l++l, i) = P(l, i) for i ≤ n",
-      "native_decide verification for [2, -1] list"
+      "proofs/Proofs/BallotProblemOQ01.lean - ~35 theorems, 2 sorries (~430 lines)",
+      "minPrefixSum, rightmostMinPos with full bounds",
+      "goodRotation_at_rightmostMin, goodRotations_nonempty",
+      "goodRotation_prefixSum_strictMono, goodRotation_prefixSum_injective"
     ],
     "insights": [
-      "kCountedSequence elements are exactly permutations of replicate a 1 ++ replicate b (-k) - finiteness via w.permutations.toFinset",
-      "Cyclic rotation preserves element counts (proved via congr_arg on take_append_drop identity)",
-      "Prefix sum of cyclic rotation has clean two-case formula: non-wrapping gives P(i+j)-P(i), wrapping adds full sum S",
-      "The doubled sequence l++l makes cyclic behavior linear - key insight for cycle lemma",
-      "Good rotation i ↔ prefixSum(i) is strict minimum in window [i, i+n] of doubled sequence",
-      "Classical connection is clean: kCountedSequence 1 a b = Ballot.countedSequence a b with just simpa",
-      "Cycle lemma final step needs rightmost minimum injection: map each position in doubled sequence to its window's rightmost minimum"
+      "CRITICAL: Cycle lemma FALSE for arbitrary integers. [5,-2] has sum 3 but only 2 rotations. Must restrict to ballot sequences.",
+      "Rightmost minimum m gives provably good rotation via wrapping/non-wrapping case analysis",
+      "P is strictly monotone on good rotations: i1 < i2 both good implies P(i1) < P(i2)",
+      "Surjectivity needs level crossing: ballot steps are +1 or -k so P passes through all integer levels"
     ],
     "mathlibGaps": [
-      "No direct Mathlib support for generalized (k-fold) ballot problem",
-      "Cycle lemma not in Mathlib - would be a valuable contribution",
-      "List.permutations finiteness API could be cleaner (used toFinset workaround)"
+      "No cycle lemma in Mathlib",
+      "No k-fold ballot problem in Mathlib"
     ],
     "nextSteps": [
-      "Submit to Aristotle for cycle_lemma sorry",
-      "Manual attempt: cycle_lemma via rightmost minimum injection into Finset",
-      "If cycle_lemma proved, derive generalized_ballot_count immediately",
-      "Consider multi-candidate generalization as next research problem"
+      "Prove cycle lemma surjectivity via level crossing for ballot sequences",
+      "Alternative: submit to Aristotle",
+      "If proved, derive generalized_ballot_count via double counting"
     ]
   },
   "approaches": [
     {
       "name": "Cycle lemma via rightmost minimum",
       "status": "in-progress",
-      "description": "Model ballot sequences as lists with +1 and -k steps. Use cyclic rotations and the Dvoretzky-Motzkin cycle lemma (rightmost minimum argument) to count good orderings. All infrastructure complete; cycle lemma proof remains."
+      "description": "Model as lists with +1 and -k steps. Cycle lemma via rightmost minimum. Infrastructure complete; counting argument remains."
     }
   ],
-  "tags": [
-    "seeker-selected",
-    "combinatorics",
-    "probability",
-    "extension",
-    "lattice-paths",
-    "cycle-lemma"
-  ],
-  "relatedProofs": [
-    "ballot-problem"
-  ],
+  "tags": ["seeker-selected", "combinatorics", "probability", "extension", "lattice-paths", "cycle-lemma"],
+  "relatedProofs": ["ballot-problem"],
   "references": {
     "papers": [
       "Bertrand (1887): Original ballot problem",
@@ -111,13 +87,10 @@
       "Renault (2007): Four Proofs of the Ballot Theorem"
     ],
     "urls": [],
-    "mathlib": [
-      "Archive.Wiedijk100Theorems.BallotProblem",
-      "Mathlib.Tactic"
-    ]
+    "mathlib": ["Archive.Wiedijk100Theorems.BallotProblem", "Mathlib.Tactic"]
   },
   "started": "2026-02-08T06:11:43.709Z",
-  "lastUpdate": "2026-02-10T11:30:00Z",
+  "lastUpdate": "2026-02-10T17:30:00Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Added rightmost minimum infrastructure for cycle lemma proof
- Proved good rotation existence, prefix sum monotonicity, and injectivity
- **CRITICAL BUG FIX**: Cycle lemma was incorrectly stated for arbitrary integers
- Added verification examples via `native_decide`

## Progress
- **~35 theorems proved**, 2 sorries remain (cycle_lemma counting + ballot_count)
- New theorems: `minPrefixSum`, `rightmostMinPos`, `goodRotation_at_rightmostMin`, `goodRotation_prefixSum_strictMono`, `goodRotation_prefixSum_injective`
- Refactored from ~600 to ~430 lines

## Key Finding
The cycle lemma for **arbitrary** integer sequences is **false**. Counterexample: `[5, -2]` has sum 3 but only 2 rotations. The lemma must be restricted to sequences with bounded steps (like ballot sequences with entries {+1, -k}).

## Files
- `proofs/Proofs/BallotProblemOQ01.lean` - Main proof (35 declarations, 2 sorries)
- `src/data/research/problems/ballot-problem-oq-01.json` - Updated metadata

## Status
**Outcome**: progress
**Next Steps**: Prove cycle lemma surjectivity via level crossing argument for ballot sequences

Generated by researcher-1