### PR TITLE
enrich(gcd-algorithm-oq-01): deepen Euclidean algorithm complexity annotations

### DIFF
--- a/src/data/proofs/gcd-algorithm-oq-01/annotations.json
+++ b/src/data/proofs/gcd-algorithm-oq-01/annotations.json
@@ -1,110 +1,170 @@
 [
   {
+    "id": "ann-gcd-oq01-imports",
+    "proofId": "gcd-algorithm-oq-01",
+    "type": "concept",
+    "range": { "startLine": 1, "endLine": 4 },
+    "title": "Imports and Dependencies",
+    "content": "Imports `Data.Nat.Fib.Basic` for Fibonacci number definitions and lemmas (`fib`, `fib_add_two`, `Nat.fib_mono`, `fib_lt_fib_succ`), `Data.Nat.GCD.Basic` for GCD infrastructure, `Data.Nat.Log` for `Nat.log` used in the logarithmic and 5-digit bounds, and `Tactic` for proof automation including `omega`, `linarith`, `ring`, and `native_decide`.",
+    "mathContext": "Key Mathlib lemmas: $\\text{fib\\_add\\_two}: \\text{fib}(n+2) = \\text{fib}(n) + \\text{fib}(n+1)$, $\\text{fib\\_mono}: m \\leq n \\implies \\text{fib}(m) \\leq \\text{fib}(n)$",
+    "significance": "supporting",
+    "relatedConcepts": ["Fibonacci sequence", "natural number logarithm", "GCD", "proof automation"],
+    "prerequisites": ["Mathlib.Data.Nat.Fib.Basic", "Mathlib.Data.Nat.Log", "Mathlib.Tactic"]
+  },
+  {
     "id": "ann-gcd-oq01-step-count",
     "proofId": "gcd-algorithm-oq-01",
     "range": { "startLine": 37, "endLine": 41 },
     "type": "definition",
     "title": "Euclidean Step Counting Function",
-    "content": "The step counting function for the Euclidean algorithm. Returns the number of division steps before reaching remainder 0. The termination proof uses the fact that a % b < b.",
-    "significance": "key"
+    "content": "Defines `euclideanSteps a b` as the number of division steps in the Euclidean algorithm before reaching remainder 0. If $b = 0$, returns 0; otherwise computes `euclideanSteps b (a % b) + 1`. Termination is proved using the fact that $a \\bmod b < b$ for $b > 0$ (`Nat.mod_lt`). The function counts the same steps as `Nat.gcd` but returns the count rather than the result.",
+    "mathContext": "$\\text{euclideanSteps}(a, b) = \\begin{cases} 0 & b = 0 \\\\ \\text{euclideanSteps}(b, a \\bmod b) + 1 & b > 0 \\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": ["Euclidean algorithm", "well-founded recursion", "Nat.mod_lt", "termination proof"],
+    "prerequisites": ["Nat.mod_lt", "Nat.pos_of_ne_zero"]
   },
   {
     "id": "ann-gcd-oq01-unfolding",
     "proofId": "gcd-algorithm-oq-01",
-    "range": { "startLine": 60, "endLine": 65 },
+    "range": { "startLine": 60, "endLine": 69 },
     "type": "lemma",
     "title": "Unfolding Lemmas for euclideanSteps",
-    "content": "Unfolding lemmas for euclideanSteps: the zero case and the positive case. These are essential for reasoning about the step count in proofs.",
-    "significance": "supporting"
+    "content": "Three structural lemmas: `euclideanSteps_zero` (simp lemma, $b = 0$ case), `euclideanSteps_pos_eq` ($b > 0$ gives the recursive equation), and `euclideanSteps_ge_one` ($b > 0$ implies at least 1 step). These are the interface lemmas through which all subsequent proofs reason about `euclideanSteps`, avoiding direct unfolding of the recursive definition.",
+    "mathContext": "$b > 0 \\implies \\text{euclideanSteps}(a, b) = \\text{euclideanSteps}(b, a \\bmod b) + 1 \\geq 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["simp lemma", "API design", "recursive definition unfolding"],
+    "prerequisites": ["euclideanSteps", "Nat.pos_iff_ne_zero"]
   },
   {
     "id": "ann-gcd-oq01-lame-bound",
     "proofId": "gcd-algorithm-oq-01",
-    "range": { "startLine": 79, "endLine": 81 },
+    "range": { "startLine": 79, "endLine": 143 },
     "type": "theorem",
-    "title": "Core Lamé Bound via Strong Induction",
-    "content": "The core Lamé bound, proved by strong induction on the step count n. The key invariant: if euclideanSteps(a,b) = n then fib(n+1) <= b, and for n >= 2, fib(n) <= a % b. This captures how the Fibonacci sequence provides the tightest lower bound on inputs requiring n steps.",
-    "significance": "critical"
+    "title": "Core Lame Bound via Strong Induction",
+    "content": "The core result, proved by strong induction (`Nat.strongRecOn`) on the step count $n$. The two-part invariant: if $\\text{euclideanSteps}(a, b) = n$ with $b > 0$, then (1) $\\text{fib}(n+1) \\leq b$, and (2) for $n \\geq 2$, $\\text{fib}(n) \\leq a \\bmod b$. The base cases $n = 0$ (impossible since $b > 0$), $n = 1$ (remainder is 0, so $b \\geq \\text{fib}(2) = 1$), and the inductive step $n + 2$ which uses the Fibonacci recurrence $\\text{fib}(n+3) = \\text{fib}(n+2) + \\text{fib}(n+1)$ and the division algorithm $b = (b/r) \\cdot r + b \\bmod r \\geq r + b \\bmod r$.",
+    "mathContext": "$\\text{euclideanSteps}(a, b) = n \\wedge b > 0 \\implies \\text{fib}(n+1) \\leq b \\wedge (n \\geq 2 \\implies \\text{fib}(n) \\leq a \\bmod b)$",
+    "significance": "critical",
+    "relatedConcepts": ["strong induction", "Fibonacci recurrence", "division algorithm", "Nat.strongRecOn"],
+    "prerequisites": ["euclideanSteps_pos_eq", "euclideanSteps_zero", "fib_add_two", "Nat.div_add_mod"]
   },
   {
     "id": "ann-gcd-oq01-lame-classical",
     "proofId": "gcd-algorithm-oq-01",
     "range": { "startLine": 145, "endLine": 147 },
     "type": "theorem",
-    "title": "Lamé's Theorem (Classical Form)",
-    "content": "Lamé's Theorem in its classical form: fib(steps+1) <= b when b > 0. This is the fundamental result connecting Euclidean algorithm complexity to Fibonacci numbers.",
-    "significance": "critical"
+    "title": "Lame's Theorem (Classical Form)",
+    "content": "Lame's Theorem in its classical form: $\\text{fib}(\\text{steps} + 1) \\leq b$ when $b > 0$. A direct corollary of `lame_pair_bound` by extracting the first component. This is the fundamental result connecting Euclidean algorithm complexity to Fibonacci growth, first proved by Gabriel Lame in 1844, making it one of the earliest results in computational complexity.",
+    "mathContext": "$b > 0 \\implies \\text{fib}(\\text{euclideanSteps}(a, b) + 1) \\leq b$",
+    "significance": "critical",
+    "relatedConcepts": ["Lame's theorem", "Fibonacci lower bound", "algorithm analysis", "computational complexity history"],
+    "prerequisites": ["lame_pair_bound"]
   },
   {
     "id": "ann-gcd-oq01-contrapositive",
     "proofId": "gcd-algorithm-oq-01",
     "range": { "startLine": 150, "endLine": 155 },
     "type": "theorem",
-    "title": "Contrapositive of Lamé's Theorem",
-    "content": "Contrapositive of Lamé's theorem: if b < fib(k+2), then the algorithm takes at most k steps. This form is more convenient for deriving upper bounds on step count.",
-    "significance": "key"
+    "title": "Contrapositive of Lame's Theorem",
+    "content": "Contrapositive form: if $b < \\text{fib}(k+2)$, then $\\text{euclideanSteps}(a, b) \\leq k$. More convenient for deriving explicit upper bounds. The proof is by contradiction: assuming $\\text{steps} > k$, Lame's theorem gives $\\text{fib}(\\text{steps}+1) \\leq b$, and monotonicity of Fibonacci (`Nat.fib_mono`) gives $\\text{fib}(k+2) \\leq \\text{fib}(\\text{steps}+1)$, contradicting $b < \\text{fib}(k+2)$.",
+    "mathContext": "$b > 0 \\wedge b < \\text{fib}(k+2) \\implies \\text{euclideanSteps}(a, b) \\leq k$",
+    "significance": "key",
+    "relatedConcepts": ["contrapositive", "Fibonacci monotonicity", "upper bound derivation"],
+    "prerequisites": ["lame_theorem", "Nat.fib_mono"]
   },
   {
     "id": "ann-gcd-oq01-fib-mod",
     "proofId": "gcd-algorithm-oq-01",
-    "range": { "startLine": 162, "endLine": 165 },
+    "range": { "startLine": 162, "endLine": 167 },
     "type": "lemma",
     "title": "Fibonacci Mod Recurrence",
-    "content": "F(n+2) mod F(n+1) = F(n) for n >= 2. This follows from the Fibonacci recurrence: fib(n+2) = fib(n) + fib(n+1), and since fib(n) < fib(n+1), the mod operation just returns fib(n).",
-    "significance": "supporting"
+    "content": "Key lemma: $\\text{fib}(n+2) \\bmod \\text{fib}(n+1) = \\text{fib}(n)$ for $n \\geq 2$. Follows from the Fibonacci recurrence $\\text{fib}(n+2) = \\text{fib}(n) + \\text{fib}(n+1)$ and the fact that $\\text{fib}(n) < \\text{fib}(n+1)$ for $n \\geq 2$ (`fib_lt_fib_succ`). This shows consecutive Fibonacci pairs reduce to the previous pair under one Euclidean step.",
+    "mathContext": "$n \\geq 2 \\implies \\text{fib}(n+2) \\bmod \\text{fib}(n+1) = \\text{fib}(n)$",
+    "significance": "key",
+    "relatedConcepts": ["Fibonacci recurrence", "modular arithmetic", "fib_lt_fib_succ", "Nat.add_mod_right"],
+    "prerequisites": ["fib_add_two", "fib_lt_fib_succ", "Nat.mod_eq_of_lt"]
   },
   {
     "id": "ann-gcd-oq01-worst-case",
     "proofId": "gcd-algorithm-oq-01",
-    "range": { "startLine": 175, "endLine": 192 },
+    "range": { "startLine": 171, "endLine": 192 },
     "type": "theorem",
     "title": "Fibonacci Worst-Case Optimality",
-    "content": "Worst-case optimality: consecutive Fibonacci numbers (fib(n+2), fib(n+1)) require exactly n steps in the Euclidean algorithm. Combined with Lamé's theorem, this shows Fibonacci pairs are the unique worst case (up to the bound).",
-    "significance": "critical"
+    "content": "Proves $\\text{euclideanSteps}(\\text{fib}(n+2), \\text{fib}(n+1)) = n$ for all $n \\geq 1$, by induction on $n$. The base case $n = 1$ is verified by `native_decide`. The inductive step uses `fib_mod_fib` to show each Euclidean step reduces $(\\text{fib}(k+3), \\text{fib}(k+2))$ to $(\\text{fib}(k+2), \\text{fib}(k+1))$. Combined with Lame's theorem, this establishes that consecutive Fibonacci numbers are the unique worst-case inputs (up to the bound).",
+    "mathContext": "$n \\geq 1 \\implies \\text{euclideanSteps}(\\text{fib}(n+2), \\text{fib}(n+1)) = n$",
+    "significance": "critical",
+    "relatedConcepts": ["worst-case optimality", "tight bound", "Fibonacci reduction", "native_decide"],
+    "prerequisites": ["euclideanSteps_pos_eq", "fib_mod_fib", "Nat.fib_pos"]
   },
   {
     "id": "ann-gcd-oq01-exp-bound",
     "proofId": "gcd-algorithm-oq-01",
-    "range": { "startLine": 209, "endLine": 225 },
+    "range": { "startLine": 203, "endLine": 218 },
     "type": "theorem",
     "title": "Exponential Fibonacci Lower Bound",
-    "content": "Exponential lower bound for odd-indexed Fibonacci numbers: fib(2n+1) >= 2^n. This bridges the gap between Fibonacci growth and powers of 2, enabling the logarithmic step bound.",
-    "significance": "supporting"
+    "content": "Proves $\\text{fib}(2n+1) \\geq 2^n$ by induction. The inductive step uses $\\text{fib}(2k+3) = \\text{fib}(2k+2) + \\text{fib}(2k+1)$ and $\\text{fib}(2k+2) = \\text{fib}(2k) + \\text{fib}(2k+1)$, giving $\\text{fib}(2k+3) = 2 \\cdot \\text{fib}(2k+1) + \\text{fib}(2k) \\geq 2 \\cdot 2^k = 2^{k+1}$. This bridges Fibonacci growth to powers of 2, enabling the logarithmic step bound.",
+    "mathContext": "$\\forall n:\\; 2^n \\leq \\text{fib}(2n+1)$. Proof: $\\text{fib}(2k+3) \\geq 2 \\cdot \\text{fib}(2k+1) \\geq 2^{k+1}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Fibonacci growth rate", "golden ratio", "exponential lower bound", "induction"],
+    "prerequisites": ["fib_add_two", "fib_one"]
   },
   {
     "id": "ann-gcd-oq01-log-bound",
     "proofId": "gcd-algorithm-oq-01",
-    "range": { "startLine": 227, "endLine": 235 },
+    "range": { "startLine": 221, "endLine": 231 },
     "type": "theorem",
     "title": "Logarithmic Step Bound",
-    "content": "Logarithmic step bound: euclideanSteps(a,b) <= 2*log2(b) + 2. Derived by combining Lamé's theorem with the exponential Fibonacci lower bound. This confirms the O(log b) worst-case complexity.",
-    "significance": "critical"
+    "content": "Derives $\\text{euclideanSteps}(a, b) \\leq 2 \\log_2(b) + 2$ by chaining: $b < 2^{L+1}$ (definition of $L = \\lfloor \\log_2 b \\rfloor$), $2^{L+1} \\leq \\text{fib}(2(L+1)+1)$ (exponential lower bound), and $\\text{fib}(2(L+1)+1) \\leq \\text{fib}(2L+4)$ (monotonicity). Then `lame_step_bound` gives $\\text{steps} \\leq 2L + 2$. This confirms the $O(\\log b)$ worst-case complexity.",
+    "mathContext": "$b > 0 \\implies \\text{euclideanSteps}(a, b) \\leq 2 \\lfloor \\log_2 b \\rfloor + 2 = O(\\log b)$",
+    "significance": "critical",
+    "relatedConcepts": ["logarithmic complexity", "Nat.log", "calc chain", "O(log n) bound"],
+    "prerequisites": ["lame_step_bound", "fib_exponential_lower", "Nat.fib_mono", "Nat.lt_pow_succ_log_self"]
+  },
+  {
+    "id": "ann-gcd-oq01-digits",
+    "proofId": "gcd-algorithm-oq-01",
+    "range": { "startLine": 237, "endLine": 237 },
+    "type": "definition",
+    "title": "Decimal Digits Function",
+    "content": "Defines `decimalDigits b = ⌊log₁₀(b)⌋ + 1`, the number of decimal digits of $b$. For $b \\in [10^{k-1}, 10^k)$, this returns $k$. Verified by `native_decide` on examples: $\\text{decimalDigits}(1) = 1$, $\\text{decimalDigits}(10) = 2$, $\\text{decimalDigits}(100) = 3$.",
+    "mathContext": "$\\text{decimalDigits}(b) = \\lfloor \\log_{10} b \\rfloor + 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["decimal representation", "Nat.log", "digit counting"],
+    "prerequisites": ["Nat.log"]
   },
   {
     "id": "ann-gcd-oq01-5digit",
     "proofId": "gcd-algorithm-oq-01",
-    "range": { "startLine": 255, "endLine": 267 },
+    "range": { "startLine": 250, "endLine": 262 },
     "type": "theorem",
-    "title": "Lamé's Classical 5-Digit Bound",
-    "content": "Lamé's classical 5-digit bound: the number of steps is at most 5 times the number of decimal digits of b (for b < 10^20). Uses fib(5k+2) >= 10^k, verified by interval_cases and native_decide for k <= 20.",
-    "significance": "key"
+    "title": "Lame's Classical 5-Digit Bound",
+    "content": "Lame's famous 1844 result: $\\text{euclideanSteps}(a, b) \\leq 5 \\cdot \\text{decimalDigits}(b)$ for $b < 10^{20}$. Uses the intermediate result $\\text{fib}(5k+2) \\geq 10^k$ (proved by `interval_cases` and `native_decide` for $k \\leq 20$). The bound $b < 10^{20}$ ensures $d + 1 \\leq 20$ so the Fibonacci-vs-power-of-10 comparison applies. For unrestricted $b$, the result follows from $\\text{fib}(n) \\sim \\varphi^n / \\sqrt{5}$ where $\\log_{10} \\varphi \\approx 0.209 > 1/5$.",
+    "mathContext": "$b < 10^{20} \\wedge b > 0 \\implies \\text{steps} \\leq 5 \\cdot \\text{decimalDigits}(b)$. Uses $\\text{fib}(5k+2) \\geq 10^k$",
+    "significance": "key",
+    "relatedConcepts": ["Lame's theorem", "decimal digit bound", "interval_cases", "native_decide", "golden ratio"],
+    "prerequisites": ["lame_step_bound", "fib_ge_pow10", "decimalDigits", "Nat.lt_pow_succ_log_self"]
   },
   {
     "id": "ann-gcd-oq01-avg-infra",
     "proofId": "gcd-algorithm-oq-01",
-    "range": { "startLine": 281, "endLine": 295 },
+    "range": { "startLine": 276, "endLine": 282 },
     "type": "definition",
-    "title": "Average Step Count Infrastructure",
-    "content": "Infrastructure for computing finite averages: totalSteps(N) sums euclideanSteps over all pairs (a,b) with 1 <= b <= a <= N. This enables numerical verification of Dixon's asymptotic formula for small N.",
-    "significance": "supporting"
+    "title": "Finite Average Computation Infrastructure",
+    "content": "Defines `totalSteps N` as the sum of $\\text{euclideanSteps}(i+1, j+1)$ over all pairs with $1 \\leq j+1 \\leq i+1 \\leq N$, and `pairCount N = N(N+1)/2$ as the number of such pairs. The ratio $\\text{totalSteps}(N) / \\text{pairCount}(N)$ gives the exact finite average for inputs up to $N$. Verified: $\\text{totalSteps}(1) = 1$, $\\text{totalSteps}(2) = 3$, $\\text{totalSteps}(3) = 7$.",
+    "mathContext": "$\\text{totalSteps}(N) = \\sum_{i=1}^{N} \\sum_{j=1}^{i} \\text{euclideanSteps}(i, j)$, $\\text{pairCount}(N) = N(N+1)/2$",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum", "average complexity", "numerical verification", "Finset.range"],
+    "prerequisites": ["euclideanSteps", "Finset.range", "Finset.sum"]
   },
   {
     "id": "ann-gcd-oq01-dixon",
     "proofId": "gcd-algorithm-oq-01",
-    "range": { "startLine": 297, "endLine": 314 },
+    "range": { "startLine": 297, "endLine": 309 },
     "type": "concept",
     "title": "Dixon's Theorem (Asymptotic Average)",
-    "content": "Dixon's theorem (1970): the average number of steps in the Euclidean algorithm for inputs up to N is (12 ln 2 / pi^2) ln N, approximately 0.8427 ln N. This requires continued fractions, the Gauss map T(x) = {1/x}, and ergodic theory, none of which are currently available in Mathlib v4.26.0.",
-    "significance": "key"
+    "content": "Dixon's theorem (1970): the average number of Euclidean algorithm steps for inputs up to $N$ is $(12 \\ln 2 / \\pi^2) \\ln N \\approx 0.8427 \\ln N$. The proof uses the ergodic theory of the Gauss map $T(x) = \\{1/x\\}$ (fractional part of reciprocal) on $[0,1]$ with invariant measure $d\\mu = (\\ln 2)^{-1} (1+x)^{-1} dx$. The connection: continued fraction partial quotients of $a/b$ correspond to Euclidean steps, and Birkhoff's ergodic theorem gives the average. None of this machinery (continued fractions, ergodic theory, the Gauss map) is available in Mathlib as of v4.26.0.",
+    "mathContext": "Dixon (1970): $\\frac{1}{N^2} \\sum_{1 \\leq b \\leq a \\leq N} \\text{steps}(a,b) \\to \\frac{12 \\ln 2}{\\pi^2} \\ln N \\approx 0.8427 \\ln N$",
+    "significance": "key",
+    "relatedConcepts": ["Dixon's theorem", "Gauss map", "continued fractions", "ergodic theory", "Birkhoff's theorem"],
+    "prerequisites": ["measure theory", "continued fractions", "ergodic theory"]
   }
 ]

--- a/src/data/proofs/gcd-algorithm-oq-01/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-01/meta.json
@@ -48,70 +48,93 @@
       "Exponential lower bound: fib(2n+1) >= 2^n",
       "Finite average computation infrastructure"
     ],
-    "dateAdded": "02/10/26"
+    "dateAdded": "02/10/26",
+    "crossReferences": [
+      {
+        "proofId": "gcd-algorithm",
+        "relationship": "Base formalization of the GCD algorithm; this OQ-01 file extends it with complexity analysis, worst-case optimality, and average-case infrastructure"
+      }
+    ]
   },
   "overview": {
-    "historicalContext": "The Euclidean algorithm (c. 300 BCE) is one of the oldest algorithms still in use. Gabriel Lame proved in 1844 that the number of division steps is bounded by 5 times the number of decimal digits of the smaller input. This was one of the first complexity analyses of an algorithm. The average-case complexity was determined by Dixon (1970) using ergodic theory of the Gauss map.",
+    "historicalContext": "The Euclidean algorithm, described in Book VII of Euclid's *Elements* (c. 300 BCE), is one of the oldest algorithms still in active use. Gabriel Lamé proved in 1844 that the algorithm requires at most $5k$ division steps when the smaller input has $k$ decimal digits, making this one of the first computational complexity results in history. Lamé's key insight was that consecutive Fibonacci numbers are worst-case inputs: $\\gcd(F_{n+2}, F_{n+1})$ requires exactly $n$ steps, and since $F_n \\sim \\varphi^n/\\sqrt{5}$ (where $\\varphi = (1+\\sqrt{5})/2$), inputs with $k$ digits satisfy $n \\leq 5k$. The connection between Fibonacci numbers and the Euclidean algorithm was noted even earlier by Léger (1837). The average-case analysis came much later: Dixon (1970) proved the average number of steps is $(12 \\ln 2 / \\pi^2) \\ln N \\approx 0.8427 \\ln N$ using the ergodic theory of the Gauss map $T(x) = \\{1/x\\}$ and its invariant measure $d\\mu = (\\ln 2)^{-1}(1+x)^{-1}dx$. Heilbronn (1969) obtained the leading constant independently. The variance was computed by Hensley (1994).",
     "problemStatement": "**Open Question**: What is the average-case complexity of the Euclidean algorithm?\n\n**Known**: The worst case is O(log(min(a,b))), achieved by consecutive Fibonacci numbers. Dixon's theorem states the average number of steps is (12 ln 2 / pi^2) ln N, approximately 0.8427 ln N.\n\n**This formalization**: Proves the worst-case bounds and builds infrastructure toward the average case.",
     "proofStrategy": "**Lame's Theorem**: By strong induction on the step count n. If euclideanSteps(a,b) = n with b > 0, then fib(n+1) <= b. The key insight is that at each step, the pair (b, a%b) satisfies b >= fib(n) and a%b >= fib(n-1), using the Fibonacci recurrence fib(n+1) = fib(n) + fib(n-1).\n\n**Worst Case**: Consecutive Fibonacci numbers (fib(n+2), fib(n+1)) take exactly n steps, since fib(n+2) mod fib(n+1) = fib(n) by the Fibonacci recurrence.\n\n**Logarithmic Bound**: From fib(2n+1) >= 2^n and Lame's theorem, we derive steps <= 2*log2(b) + 2.",
     "keyInsights": [
-      "Fibonacci numbers are the worst-case inputs for the Euclidean algorithm",
-      "Lame's theorem reduces complexity analysis to Fibonacci growth rate",
-      "The 5-digit bound (steps <= 5*digits) follows from fib(5k+2) >= 10^k",
-      "Dixon's average-case result requires ergodic theory not yet in Mathlib"
+      "**Fibonacci worst case**: Consecutive Fibonacci numbers $(F_{n+2}, F_{n+1})$ require exactly $n$ Euclidean steps because $F_{n+2} \\bmod F_{n+1} = F_n$ by the recurrence. This is both an upper and lower bound witness.",
+      "**Strong induction structure**: Lamé's theorem uses a two-part invariant (both $\\text{fib}(n+1) \\leq b$ and $\\text{fib}(n) \\leq a \\bmod b$) proved by `Nat.strongRecOn`. The second component is needed for the inductive step but not the final statement.",
+      "**Fibonacci-to-logarithm bridge**: The chain $\\text{fib}(2n+1) \\geq 2^n$ converts the Fibonacci bound into the logarithmic bound $\\text{steps} \\leq 2\\log_2(b) + 2$, confirming $O(\\log b)$ complexity without the golden ratio.",
+      "**5-digit bound via $\\text{fib}(5k+2) \\geq 10^k$**: Lamé's classical digit bound follows from the more precise comparison of Fibonacci numbers with powers of 10, verified computationally for $k \\leq 20$ using `interval_cases` and `native_decide`.",
+      "**Dixon's theorem is ergodic**: The average-case constant $12\\ln 2/\\pi^2$ arises from the invariant measure of the Gauss map $T(x) = \\{1/x\\}$, connecting number theory to dynamical systems. Formalizing this requires continued fractions and Birkhoff's ergodic theorem, neither available in Mathlib."
     ]
   },
   "sections": [
     {
-      "id": "step-counting",
+      "id": "sec-gcd-oq01-imports",
+      "title": "Imports and Namespace",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Imports `Data.Nat.Fib.Basic` (Fibonacci lemmas), `Data.Nat.GCD.Basic`, `Data.Nat.Log` (for $\\lfloor \\log_b n \\rfloor$), and `Tactic`. Opens `Nat` namespace and documents the open question status."
+    },
+    {
+      "id": "sec-gcd-oq01-step-counting",
       "title": "Step Counting Function",
       "startLine": 32,
-      "endLine": 69,
-      "summary": "Definition of euclideanSteps with termination proof and basic properties."
+      "endLine": 53,
+      "summary": "Defines `euclideanSteps` with termination proof via `Nat.mod_lt`, plus 10 verification examples showing $\\text{euclideanSteps}(F_{n+2}, F_{n+1}) = n$ for $n = 0, \\ldots, 8$."
     },
     {
-      "id": "lame-theorem",
-      "title": "Lame's Theorem",
+      "id": "sec-gcd-oq01-unfolding",
+      "title": "Unfolding Lemmas",
+      "startLine": 55,
+      "endLine": 69,
+      "summary": "Three interface lemmas: `euclideanSteps_zero` (simp), `euclideanSteps_pos_eq` ($b > 0$ recursive case), and `euclideanSteps_ge_one` ($b > 0 \\implies \\text{steps} \\geq 1$)."
+    },
+    {
+      "id": "sec-gcd-oq01-lame",
+      "title": "Lamé's Theorem",
       "startLine": 71,
       "endLine": 155,
-      "summary": "Core result: fib(steps+1) <= b, proved by strong induction. Includes contrapositive form."
+      "summary": "Core result by strong induction: $\\text{euclideanSteps}(a,b) = n \\wedge b > 0 \\implies \\text{fib}(n+1) \\leq b$. Includes classical form `lame_theorem` and contrapositive `lame_step_bound`: $b < \\text{fib}(k+2) \\implies \\text{steps} \\leq k$."
     },
     {
-      "id": "worst-case",
+      "id": "sec-gcd-oq01-worst-case",
       "title": "Worst Case: Consecutive Fibonacci Numbers",
       "startLine": 157,
-      "endLine": 200,
-      "summary": "Consecutive Fibonacci pairs achieve exactly n steps, proving the bound is tight."
+      "endLine": 196,
+      "summary": "Proves $\\text{euclideanSteps}(F_{n+2}, F_{n+1}) = n$ for $n \\geq 1$ via `fib_mod_fib`: $F_{n+2} \\bmod F_{n+1} = F_n$. Includes saturation verification examples."
     },
     {
-      "id": "logarithmic-bound",
+      "id": "sec-gcd-oq01-logarithmic",
       "title": "Logarithmic Bound",
-      "startLine": 202,
-      "endLine": 235,
-      "summary": "steps <= 2*log2(b) + 2, derived from fib(2n+1) >= 2^n."
+      "startLine": 198,
+      "endLine": 231,
+      "summary": "Proves $\\text{fib}(2n+1) \\geq 2^n$ by induction, then derives $\\text{steps} \\leq 2\\lfloor\\log_2 b\\rfloor + 2$ via `calc` chain confirming $O(\\log b)$ complexity."
     },
     {
-      "id": "five-digit-bound",
-      "title": "Lame's 5-Digit Bound",
-      "startLine": 237,
-      "endLine": 271,
-      "summary": "steps <= 5*decimalDigits(b) for b < 10^20, using fib(5k+2) >= 10^k."
+      "id": "sec-gcd-oq01-5digit",
+      "title": "Lamé's 5-Digit Bound",
+      "startLine": 232,
+      "endLine": 267,
+      "summary": "Defines `decimalDigits` and proves $\\text{steps} \\leq 5 \\cdot \\text{decimalDigits}(b)$ for $b < 10^{20}$, using $\\text{fib}(5k+2) \\geq 10^k$ verified by `interval_cases`/`native_decide`."
     },
     {
-      "id": "finite-average",
-      "title": "Finite Average Computation",
-      "startLine": 273,
-      "endLine": 295,
-      "summary": "Infrastructure for computing exact averages over bounded inputs."
+      "id": "sec-gcd-oq01-average",
+      "title": "Finite Average Computation and Dixon's Theorem",
+      "startLine": 268,
+      "endLine": 312,
+      "summary": "Defines `totalSteps N` and `pairCount N` for exact finite averages. Documents Dixon's theorem: average steps $\\sim (12\\ln 2/\\pi^2)\\ln N \\approx 0.8427 \\ln N$, requiring continued fractions and ergodic theory not yet in Mathlib."
     }
   ],
   "conclusion": {
     "summary": "This formalization provides a complete treatment of the worst-case complexity of the Euclidean algorithm, from the fundamental Lame bound through tight examples and practical digit-based bounds. All results are fully proved (0 sorries).\n\nThe average-case analysis (Dixon's theorem) remains unformalized due to its dependence on continued fractions, the Gauss map, and ergodic theory.",
     "implications": "**Algorithm Analysis**: Demonstrates formal verification of classical complexity results.\n\n**Number Theory**: The deep connection between Fibonacci numbers and the Euclidean algorithm exemplifies how number-theoretic structure governs algorithmic behavior.\n\n**Future Work**: Formalizing Dixon's theorem would require developing ergodic theory in Mathlib.",
     "openQuestions": [
-      "Can Dixon's average-case theorem be formalized once Mathlib has ergodic theory?",
-      "What is the distribution of step counts for random inputs?",
-      "How does the complexity extend to the extended Euclidean algorithm?"
+      "Can Dixon's average-case theorem ($\\sim 0.8427 \\ln N$ steps on average) be formalized once Mathlib has continued fractions and ergodic theory for the Gauss map?",
+      "What is the full distribution of step counts? Hensley (1994) computed the variance; can the limiting distribution be formalized?",
+      "Can the 5-digit bound be extended beyond $b < 10^{20}$ by formalizing the golden ratio identity $\\text{fib}(n) = \\lfloor \\varphi^n / \\sqrt{5} + 1/2 \\rfloor$ in Mathlib?",
+      "How does the complexity analysis extend to the binary GCD algorithm or Stein's algorithm?",
+      "Can the worst-case uniqueness be strengthened: are consecutive Fibonacci numbers the ONLY pairs achieving the maximum step count for a given $b$?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Expanded annotations from 11 to 14 covering full 313-line Lean file with `mathContext`, `relatedConcepts`, and `prerequisites` on all entries
- Deepened `historicalContext` with Léger (1837), Heilbronn (1969), Hensley (1994) references and golden ratio connection
- Added 5 bold `keyInsights` covering strong induction structure, Fibonacci-to-log bridge, and ergodic theory connection
- Added `crossReferences` to gcd-algorithm base formalization
- Expanded sections from 6 to 8 with LaTeX in summaries
- Expanded open questions from 3 to 5 (5-digit generalization, binary GCD, uniqueness)

## Test plan
- [x] `pnpm annotations:build` passes (2 non-strict warnings: `lemma` vs `theorem` keyword mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)