### PR TITLE
enrich(erdos-703): deepen annotations and meta for forbidden r-intersection families

### DIFF
--- a/src/data/proofs/erdos-703/annotations.json
+++ b/src/data/proofs/erdos-703/annotations.json
@@ -1,155 +1,230 @@
 [
   {
+    "id": "ann-703-imports",
+    "proofId": "erdos-703",
+    "type": "concept",
+    "title": "Imports and Dependencies",
+    "content": "Imports Finset.Basic, Finset.Card, Finset.Powerset for set family operations, and Combinatorics.SetFamily.Intersecting for the intersecting family framework. The formalization represents set families as Finset (Finset ℕ) over a ground set Finset.range n.",
+    "range": { "startLine": 31, "endLine": 37 },
+    "significance": "supporting",
+    "mathContext": "Extremal set family theory requires operations on powerset lattices. The choice of `Finset (Finset ℕ)` over `Finset.range n` mirrors the standard combinatorial setup of $\\mathcal{F} \\subseteq 2^{[n]}$.",
+    "relatedConcepts": ["powerset", "set families", "Finset operations"],
+    "prerequisites": ["Mathlib.Data.Finset.Basic", "Mathlib.Data.Finset.Powerset"]
+  },
+  {
     "id": "ann-703-1",
     "proofId": "erdos-703",
     "type": "definition",
-    "title": "r-Intersection",
-    "content": "Two sets A and B have r-intersection if |A ∩ B| = r, meaning they share exactly r common elements.",
+    "title": "r-Intersection Predicate",
+    "content": "Two sets A and B have r-intersection if |A ∩ B| = r, meaning they share exactly r common elements. This is the basic forbidden pattern in the problem.",
     "range": { "startLine": 49, "endLine": 50 },
-    "significance": "high"
+    "significance": "key",
+    "mathContext": "The condition $|A \\cap B| = r$ is the forbidden intersection size. For $r = 0$, this recovers the classical intersecting family condition ($A \\cap B \\neq \\emptyset$). The problem generalizes from forbidding one intersection size to the Frankl-Wilson setting of forbidding a set $L$ of sizes.",
+    "relatedConcepts": ["set intersection", "Erdős-Ko-Rado theorem", "forbidden intersection sizes"],
+    "prerequisites": ["Finset.card", "Finset.inter"]
   },
   {
     "id": "ann-703-2",
     "proofId": "erdos-703",
     "type": "definition",
     "title": "r-Avoiding Family",
-    "content": "A family F avoids r-intersection if no two sets in F have exactly r elements in common. This is the central constraint of the problem.",
+    "content": "A family F avoids r-intersection if no two sets in F have exactly r elements in common: ∀ A, B ∈ F, |A ∩ B| ≠ r. This is the central constraint defining the extremal problem.",
     "range": { "startLine": 57, "endLine": 58 },
-    "significance": "high"
+    "significance": "critical",
+    "mathContext": "An $r$-avoiding family $\\mathcal{F} \\subseteq 2^{[n]}$ satisfies $|A \\cap B| \\neq r$ for all $A, B \\in \\mathcal{F}$. The extremal quantity $T(n,r) = \\max |\\mathcal{F}|$ is the main object of study. Note the condition applies to all pairs, not just distinct pairs.",
+    "relatedConcepts": ["extremal set theory", "forbidden configurations", "intersecting families"],
+    "prerequisites": ["hasRIntersection"]
   },
   {
     "id": "ann-703-3",
     "proofId": "erdos-703",
     "type": "definition",
-    "title": "T(n,r) Definition",
-    "content": "T(n,r) is the maximum size of an r-avoiding family over subsets of {1,...,n}. The main question asks how large T(n,r) can be.",
+    "title": "T(n,r) — Maximum r-Avoiding Family Size",
+    "content": "T(n,r) is the maximum size of an r-avoiding family over subsets of {1,...,n}. Defined using Finset.sup over the powerset filtered by the r-avoiding condition. This is the main extremal quantity of the problem.",
     "range": { "startLine": 64, "endLine": 66 },
-    "significance": "high"
+    "significance": "critical",
+    "mathContext": "$T(n,r) = \\max\\{|\\mathcal{F}| : \\mathcal{F} \\subseteq 2^{[n]},\\ |A \\cap B| \\neq r\\ \\forall A,B \\in \\mathcal{F}\\}$. The trivial upper bound is $T(n,r) \\leq 2^n$, and the main question asks when $T(n,r) < (2-\\delta)^n$. For fixed $r$, $T(n,r)/2^n \\to 1$ as $n \\to \\infty$ (the constraint is weak). But for $r = \\Theta(n)$, the constraint is strong enough for an exponential gap.",
+    "relatedConcepts": ["extremal function", "Turán-type problems", "set family optimization"],
+    "prerequisites": ["avoidsRIntersection", "Finset.powerset", "Finset.sup"]
   },
   {
     "id": "ann-703-4",
     "proofId": "erdos-703",
     "type": "theorem",
-    "title": "T(n,0) = 2^{n-1}",
-    "content": "The trivial case: 0-avoiding families are exactly intersecting families. The maximum is 2^{n-1}, achieved by all sets containing a fixed element.",
+    "title": "T(n,0) = 2^{n-1} — Intersecting Family Maximum",
+    "content": "The trivial case: 0-avoiding families are exactly intersecting families (all pairs must intersect). The maximum is 2^{n-1}, achieved by all sets containing a fixed element. Has a sorry — the proof requires showing the construction achieves 2^{n-1} and that no intersecting family is larger.",
     "range": { "startLine": 78, "endLine": 79 },
-    "significance": "high"
+    "significance": "key",
+    "mathContext": "$T(n,0) = 2^{n-1}$ is essentially the Erdős-Ko-Rado theorem for unrestricted set sizes. The maximum intersecting family is $\\{A \\subseteq [n] : 1 \\in A\\}$, which has $2^{n-1}$ sets. The dual construction $\\{A : 1 \\notin A\\}$ also works. The proof that these are optimal uses the well-known complement argument: $\\mathcal{F}$ and its complement $\\bar{\\mathcal{F}}$ cannot both intersect.",
+    "relatedConcepts": ["Erdős-Ko-Rado theorem", "intersecting family", "sunflower lemma"],
+    "prerequisites": ["T", "avoidsRIntersection"]
   },
   {
     "id": "ann-703-5",
     "proofId": "erdos-703",
     "type": "theorem",
-    "title": "0-Avoiding is Intersecting",
-    "content": "|A ∩ B| ≠ 0 means A and B must intersect. This connects to the classical Erdos-Ko-Rado setting.",
+    "title": "0-Avoiding Equals Intersecting",
+    "content": "|A ∩ B| ≠ 0 is equivalent to A ∩ B ≠ ∅, i.e., A and B must intersect. This connects the r-avoiding framework to classical intersecting family theory. Proved by unfolding definitions and using card_eq_zero / nonempty_iff_ne_empty.",
     "range": { "startLine": 85, "endLine": 88 },
-    "significance": "medium"
+    "significance": "supporting",
+    "mathContext": "The equivalence $|A \\cap B| \\neq 0 \\iff A \\cap B \\neq \\emptyset$ shows that the $r = 0$ case of the forbidden intersection problem recovers the classical setting of Erdős-Ko-Rado. This is the base case that motivates the generalization to $r \\geq 1$.",
+    "relatedConcepts": ["intersecting families", "Finset.Nonempty", "Erdős-Ko-Rado"],
+    "prerequisites": ["avoidsRIntersection", "Finset.card_eq_zero"]
   },
   {
     "id": "ann-703-6",
     "proofId": "erdos-703",
-    "type": "axiom",
-    "title": "Frankl (1977)",
-    "content": "Frankl determined T(n,1) for all n. The optimal family consists of large sets (size > (n+1)/2) and the empty set.",
+    "type": "theorem",
+    "title": "Frankl (1977) — T(n,1) Determination",
+    "content": "Frankl determined T(n,1) for all n. The optimal 1-avoiding family consists of large sets (size > (n+1)/2) plus the empty set. Axiomatized because the proof requires detailed casework on set sizes and intersection counting.",
     "range": { "startLine": 100, "endLine": 102 },
-    "significance": "high"
+    "significance": "key",
+    "mathContext": "Frankl [Fr77] showed that for the $r=1$ case, $T(n,1) = |\\{A \\subseteq [n] : |A| > (n+1)/2\\}| + 1$ (the $+1$ accounts for $\\emptyset$). The key insight is that large sets with $|A| > (n+1)/2$ automatically satisfy $|A \\cap B| \\geq 2$ by pigeonhole, so they avoid 1-intersection. This was the first non-trivial determination of $T(n,r)$.",
+    "relatedConcepts": ["pigeonhole principle", "large set families", "intersection bounds"],
+    "prerequisites": ["T", "avoidsRIntersection"]
   },
   {
     "id": "ann-703-7",
     "proofId": "erdos-703",
     "type": "theorem",
     "title": "Large Sets Avoid 1-Intersection",
-    "content": "If |A|, |B| > (n+1)/2, then |A ∩ B| > 1 by pigeonhole. Large sets cannot have intersection exactly 1.",
+    "content": "If |A|, |B| > (n+1)/2, then |A ∩ B| > 1 by pigeonhole. Large sets cannot have intersection exactly 1. Has a sorry — the proof requires the pigeonhole argument on set sizes within {1,...,n}.",
     "range": { "startLine": 108, "endLine": 112 },
-    "significance": "medium"
+    "significance": "supporting",
+    "mathContext": "If $|A|, |B| > (n+1)/2$ and both $A, B \\subseteq [n]$, then $|A \\cap B| \\geq |A| + |B| - n > (n+1)/2 + (n+1)/2 - n = 1$, so $|A \\cap B| \\geq 2$. This pigeonhole argument is the core of Frankl's construction: large sets automatically avoid 1-intersection.",
+    "relatedConcepts": ["pigeonhole principle", "inclusion-exclusion", "set intersection bounds"],
+    "prerequisites": ["hasRIntersection", "Finset.card"]
   },
   {
     "id": "ann-703-8",
     "proofId": "erdos-703",
     "type": "definition",
-    "title": "Frankl-Furedi Odd Family",
-    "content": "For n + r odd, the optimal family is {A : |A| > (n+r)/2 or |A| < r}. Large sets avoid r-intersection; small sets trivially avoid it.",
+    "title": "Frankl-Füredi Optimal Family (Odd Case)",
+    "content": "For n + r odd, the optimal r-avoiding family is {A ⊆ [n] : |A| > (n+r)/2 or |A| < r}. Large sets avoid r-intersection by pigeonhole (|A ∩ B| > r); small sets have |A| < r so |A ∩ B| < r trivially.",
     "range": { "startLine": 122, "endLine": 123 },
-    "significance": "high"
+    "significance": "key",
+    "mathContext": "The Frankl-Füredi construction $\\mathcal{F}_{\\text{odd}} = \\{A \\subseteq [n] : |A| > (n+r)/2\\} \\cup \\{A : |A| < r\\}$ works because: (1) for two large sets, $|A \\cap B| \\geq |A| + |B| - n > r$; (2) for two small sets, $|A \\cap B| \\leq \\min(|A|, |B|) < r$; (3) for one large and one small, $|A \\cap B| \\leq |B| < r$. The parity condition matters because $(n+r)/2$ must be handled differently for even and odd $n+r$.",
+    "relatedConcepts": ["optimal constructions", "pigeonhole argument", "parity conditions"],
+    "prerequisites": ["avoidsRIntersection", "Finset.powerset"]
   },
   {
     "id": "ann-703-9",
     "proofId": "erdos-703",
     "type": "definition",
-    "title": "Frankl-Furedi Even Family",
-    "content": "For n + r even, the construction is slightly different to handle boundary cases, using |A \\ {1}| instead of |A|.",
+    "title": "Frankl-Füredi Optimal Family (Even Case)",
+    "content": "For n + r even, the construction is slightly different, using |A \\ {0}| ≥ (n+r)/2 instead of |A| > (n+r)/2 to handle the boundary case. This resolves the ambiguity when (n+r)/2 is an integer.",
     "range": { "startLine": 129, "endLine": 131 },
-    "significance": "medium"
+    "significance": "key",
+    "mathContext": "When $n + r$ is even, the boundary sets with $|A| = (n+r)/2$ need special treatment. The even construction uses $|A \\setminus \\{1\\}| \\geq (n+r)/2$, which shifts the threshold by considering a distinguished element. This is a common technique in extremal combinatorics for handling parity issues in optimal constructions.",
+    "relatedConcepts": ["parity in extremal problems", "distinguished element technique", "boundary cases"],
+    "prerequisites": ["franklFurediOdd", "Finset.filter"]
   },
   {
     "id": "ann-703-10",
     "proofId": "erdos-703",
-    "type": "axiom",
-    "title": "Frankl-Furedi (1984)",
-    "content": "For fixed r and n sufficiently large, T(n,r) equals the Frankl-Furedi optimal family size. This determines T(n,r) exactly.",
+    "type": "theorem",
+    "title": "Frankl-Füredi (1984) — Exact T(n,r) for Fixed r",
+    "content": "For fixed r ≥ 1 and n sufficiently large, T(n,r) equals the Frankl-Füredi optimal family size. The construction achieves the maximum, split by parity of n + r. Axiomatized because the optimality proof requires sophisticated double-counting arguments.",
     "range": { "startLine": 138, "endLine": 142 },
-    "significance": "high"
+    "significance": "critical",
+    "mathContext": "The Frankl-Füredi theorem [FrFu84] determines $T(n,r)$ exactly for all fixed $r$ and sufficiently large $n$. The proof that the construction is optimal uses shifting (compression) arguments and properties of the Kruskal-Katona theorem. This result resolves the extremal problem for $r = O(1)$, leaving the case $r = \\Theta(n)$ (the 'middle range') as the main open question.",
+    "relatedConcepts": ["Kruskal-Katona theorem", "shifting method", "extremal set theory"],
+    "prerequisites": ["T", "franklFurediOdd", "franklFurediEven"]
   },
   {
     "id": "ann-703-11",
     "proofId": "erdos-703",
     "type": "definition",
-    "title": "Main Question",
-    "content": "For every epsilon > 0, is there delta > 0 such that T(n,r) < (2-delta)^n when epsilon*n < r < (1/2-epsilon)*n? This asks about the 'middle range'.",
+    "title": "Main Question — Exponential Bound for Middle Range",
+    "content": "For every ε > 0, is there δ > 0 such that T(n,r) < (2-δ)^n when εn < r < (1/2-ε)n? This asks whether the forbidden intersection constraint is strong enough in the 'middle range' to force an exponential gap from the trivial bound 2^n.",
     "range": { "startLine": 153, "endLine": 157 },
-    "significance": "high"
+    "significance": "critical",
+    "mathContext": "The 'middle range' $\\varepsilon n < r < (1/2 - \\varepsilon)n$ is where the problem is most interesting. For $r = O(1)$, $T(n,r)/2^n \\to 1$ (Frankl-Füredi). For $r$ near $n/2$, constraints are very strong. The question asks whether there is a sharp threshold: does $T(n,r)$ drop from $\\sim 2^n$ to $< (2-\\delta)^n$ when $r$ enters the middle range? This is formalized with rational $\\varepsilon, \\delta$ for constructive reasoning.",
+    "relatedConcepts": ["exponential gap", "phase transition", "extremal thresholds"],
+    "prerequisites": ["T"]
   },
   {
     "id": "ann-703-12",
     "proofId": "erdos-703",
-    "type": "axiom",
-    "title": "Frankl-Rodl (1987)",
-    "content": "The answer is YES. For r in the middle range, T(n,r) is exponentially bounded away from 2^n. This resolves the main question.",
+    "type": "theorem",
+    "title": "Frankl-Rödl (1987) — Main Question Resolved YES",
+    "content": "The answer is YES: for r in the middle range, T(n,r) is exponentially bounded away from 2^n. This resolves Erdős Problem #703 and the $250 prize. Axiomatized because the proof uses the probabilistic method and regularity-type arguments.",
     "range": { "startLine": 165, "endLine": 165 },
-    "significance": "high"
+    "significance": "critical",
+    "mathContext": "The Frankl-Rödl theorem [FrRo87] proved that for every $\\varepsilon > 0$, there exists $\\delta > 0$ such that $T(n,r) < (2-\\delta)^n$ whenever $\\varepsilon n < r < (1/2 - \\varepsilon)n$. The proof uses a sophisticated random algebraic construction and the 'Frankl-Rödl nibble' method, which has since become a fundamental technique in probabilistic combinatorics. This earned the \\$250 Erdős prize.",
+    "relatedConcepts": ["probabilistic method", "Frankl-Rödl nibble", "random algebraic constructions"],
+    "prerequisites": ["mainQuestion", "T"]
   },
   {
     "id": "ann-703-13",
     "proofId": "erdos-703",
-    "type": "axiom",
-    "title": "Chromatic Number Connection",
-    "content": "The exponential bound implies that the chromatic number of the unit distance graph in R^n grows exponentially.",
-    "range": { "startLine": 195, "endLine": 196 },
-    "significance": "medium"
+    "type": "theorem",
+    "title": "Chromatic Number Implication",
+    "content": "The affirmative answer to the main question implies that the chromatic number χ(n) of the unit distance graph in ℝ^n grows exponentially. This connects the combinatorial intersection problem to geometric graph coloring.",
+    "range": { "startLine": 194, "endLine": 196 },
+    "significance": "key",
+    "mathContext": "The unit distance graph $G_n$ has $\\mathbb{R}^n$ as vertices with edges between points at Euclidean distance 1. If $\\chi(G_n) = k$, one can construct a $k$-coloring of $\\{0,1\\}^n \\cap G_n$, which gives an $r$-avoiding family for appropriate $r$. The contrapositive: if $T(n,r) < (2-\\delta)^n$, then $\\chi(G_n) \\geq (2-\\delta)^n / T(n,r)$, yielding exponential growth.",
+    "relatedConcepts": ["unit distance graph", "chromatic number", "Borsuk conjecture", "geometric combinatorics"],
+    "prerequisites": ["mainQuestion", "chromaticNumber"]
   },
   {
     "id": "ann-703-14",
     "proofId": "erdos-703",
-    "type": "axiom",
-    "title": "Frankl-Wilson (1981)",
-    "content": "Proved exponential chromatic number growth independently using their mod p theorem on intersection sizes.",
-    "range": { "startLine": 203, "endLine": 204 },
-    "significance": "medium"
+    "type": "theorem",
+    "title": "Frankl-Wilson (1981) — Independent Chromatic Bound",
+    "content": "Frankl-Wilson proved the exponential growth of χ(n) independently using their mod p theorem on intersection sizes. Their approach via modular constraints on set families provides a different (and more quantitative) route to the exponential bound.",
+    "range": { "startLine": 202, "endLine": 204 },
+    "significance": "key",
+    "mathContext": "The Frankl-Wilson theorem [FrWi81] gives $\\chi(G_n) \\geq (1.207...)^n$ by constructing a family of $\\binom{4p}{2p}$ unit vectors in $\\mathbb{R}^{4p}$ with prescribed inner products, then using their intersection theorem modulo $p$. This was historically the first proof of exponential $\\chi(n)$, predating the Frankl-Rödl result by 6 years.",
+    "relatedConcepts": ["Frankl-Wilson theorem", "modular intersection constraints", "algebraic methods in combinatorics"],
+    "prerequisites": ["chromaticNumber"]
   },
   {
     "id": "ann-703-15",
     "proofId": "erdos-703",
     "type": "definition",
-    "title": "L-Avoiding Family",
-    "content": "Generalization: a family avoids a set L of intersection sizes if no two sets have intersection size in L.",
-    "range": { "startLine": 215, "endLine": 216 },
-    "significance": "medium"
+    "title": "L-Avoiding Family (Generalization)",
+    "content": "A family F avoids a set L of intersection sizes if no two sets in F have intersection size in L. This generalizes r-avoiding (where L = {r}) to forbidden sets of intersection sizes, the setting of the Frankl-Wilson theorem.",
+    "range": { "startLine": 214, "endLine": 216 },
+    "significance": "key",
+    "mathContext": "The generalization from forbidding a single intersection size $r$ to forbidding a set $L$ of sizes is central to the Frankl-Wilson approach. The $L$-avoiding condition is: $|A \\cap B| \\notin L$ for all $A, B \\in \\mathcal{F}$. When $|L| = s$, the Frankl-Wilson theorem gives $|\\mathcal{F}| \\leq \\binom{n}{s}$, a polynomial bound regardless of $n$.",
+    "relatedConcepts": ["forbidden intersection patterns", "Frankl-Wilson theorem", "polynomial method"],
+    "prerequisites": ["avoidsRIntersection"]
   },
   {
     "id": "ann-703-16",
     "proofId": "erdos-703",
-    "type": "axiom",
-    "title": "Frankl-Wilson Theorem",
-    "content": "For prime p and sets of uniform size mod p avoiding certain intersections, the family size is bounded by a binomial coefficient.",
-    "range": { "startLine": 223, "endLine": 226 },
-    "significance": "high"
+    "type": "theorem",
+    "title": "Frankl-Wilson Theorem (Mod p Version)",
+    "content": "For prime p, if all sets in F have size ≡ k (mod p) and F avoids intersection sizes in L ⊆ {0,...,p-1} \\ {k} with |L| = s < p, then |F| ≤ C(n,s). This powerful algebraic bound is the key tool connecting intersection problems to chromatic numbers.",
+    "range": { "startLine": 222, "endLine": 226 },
+    "significance": "critical",
+    "mathContext": "The Frankl-Wilson theorem states: if $\\mathcal{F}$ is a family of subsets of $[n]$ with $|A| \\equiv k \\pmod{p}$ for all $A \\in \\mathcal{F}$, and $|A \\cap B| \\pmod{p} \\notin L$ for all distinct $A, B$, where $|L| = s < p$, then $|\\mathcal{F}| \\leq \\binom{n}{s}$. The proof uses the linear algebra (dimension) method: associate each set with a multilinear polynomial, then show these polynomials are linearly independent modulo $p$.",
+    "relatedConcepts": ["linear algebra method", "polynomial method", "modular arithmetic", "Ray-Chaudhuri-Wilson theorem"],
+    "prerequisites": ["avoidsLIntersections", "Nat.Prime", "Nat.choose"]
   },
   {
-    "id": "ann-703-17",
+    "id": "ann-703-summary",
     "proofId": "erdos-703",
     "type": "theorem",
-    "title": "Main Theorem",
-    "content": "Erdos #703 is SOLVED: T(n,r) < (2-delta)^n for middle range r, answering the main question YES.",
-    "range": { "startLine": 260, "endLine": 267 },
-    "significance": "high"
+    "title": "Erdős #703 Main Result — Problem Solved",
+    "content": "Combined statement: the main question is answered YES (via Frankl-Rödl) and T(n,0) = 2^{n-1}. The proof uses frankl_rodl_1987 for the main question and T_n_0 for the trivial case. This theorem ties together the entire formalization.",
+    "range": { "startLine": 258, "endLine": 266 },
+    "significance": "critical",
+    "mathContext": "The combined result packages the solution to Erdős #703 with the base case. The structure `mainQuestion ∧ (∀ n, n ≥ 1 → T n 0 = 2^{n-1})` shows that the formalization captures both the main theorem (Frankl-Rödl) and its starting point (the classical intersecting family bound). The final `erdos_703 : mainQuestion := frankl_rodl_1987` gives the clean statement.",
+    "relatedConcepts": ["problem resolution", "Erdős prizes", "extremal combinatorics milestones"],
+    "prerequisites": ["frankl_rodl_1987", "T_n_0", "mainQuestion"]
+  },
+  {
+    "id": "ann-703-clean",
+    "proofId": "erdos-703",
+    "type": "theorem",
+    "title": "Clean Statement: erdos_703",
+    "content": "The clean one-line resolution: mainQuestion follows directly from frankl_rodl_1987. This is the final statement that Erdős Problem #703 is solved.",
+    "range": { "startLine": 271, "endLine": 271 },
+    "significance": "key",
+    "mathContext": "The clean statement `theorem erdos_703 : mainQuestion := frankl_rodl_1987` is a direct application of the axiomatized Frankl-Rödl theorem. This pattern — axiomatizing deep results and using them to resolve the problem statement — is standard for formalizing solved Erdős problems where the full proof machinery exceeds current Mathlib capabilities.",
+    "relatedConcepts": ["axiomatic formalization", "problem resolution pattern"],
+    "prerequisites": ["frankl_rodl_1987", "mainQuestion"]
   }
 ]

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -21,101 +21,128 @@
     "erdosNumber": 703,
     "erdosUrl": "https://erdosproblems.com/703",
     "erdosProblemStatus": "solved",
-    "erdosPrizeValue": "$250"
-  },
-  "overview": {
-    "historicalContext": "Intersection problems for set families are fundamental in extremal combinatorics. The classical Erdős-Ko-Rado theorem concerns intersecting families (avoiding 0-intersection). Erdős asked about avoiding r-intersection for general r, particularly whether an exponential bound holds when r is a constant fraction of n. The problem carried a $250 prize.",
-    "problemStatement": "Let T(n,r) be the maximum size of a family F of subsets of {1,...,n} such that |A ∩ B| ≠ r for all A, B in F. Estimate T(n,r). In particular, for every ε > 0, is there δ > 0 such that T(n,r) < (2 - δ)^n for εn < r < (1/2 - ε)n?",
-    "proofStrategy": "The formalization defines r-avoiding families and T(n,r), establishes the trivial case T(n,0) = 2^{n-1}, states the Frankl-Füredi optimal families for fixed r, and axiomatizes the Frankl-Rödl theorem proving the exponential bound for the middle range.",
-    "keyInsights": [
-      "T(n,0) = 2^{n-1} corresponds to classical intersecting families",
-      "Large sets (size > (n+r)/2) avoid r-intersection with each other",
-      "The middle range εn < r < (1/2-ε)n exhibits exponential gap from 2^n",
-      "Connection to unit distance graph chromatic numbers in R^n",
-      "Frankl-Wilson theorem provides key bounds via mod p arguments"
+    "erdosPrizeValue": "$250",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_eq_zero",
+        "description": "Characterization of empty Finset by cardinality",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.nonempty_iff_ne_empty",
+        "description": "Nonempty iff not equal to empty",
+        "module": "Mathlib.Data.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "hasRIntersection: predicate for |A ∩ B| = r",
+      "avoidsRIntersection: family-level r-avoiding property",
+      "T(n,r): extremal function via Finset.sup over powerset",
+      "mainQuestion: formal ε-δ statement of the exponential bound",
+      "franklFurediOdd/Even: explicit optimal constructions",
+      "avoidsLIntersections: generalization to L-avoiding families",
+      "zero_avoiding_is_intersecting: proved connection to classical intersecting families",
+      "erdos_703_solved: combined resolution theorem"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-702",
+      "relationship": "related",
+      "description": "Problem #702 asks the k-uniform version: maximum k-uniform family avoiding r-intersection."
+    },
+    {
+      "targetId": "erdos-1030",
+      "relationship": "technique",
+      "description": "Both problems use probabilistic and algebraic methods in extremal combinatorics."
+    }
+  ],
   "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 31,
+      "endLine": 39,
+      "summary": "Imports `Finset.Basic`, `Finset.Card`, `Finset.Powerset`, and `SetFamily.Intersecting`. Opens `Nat Finset` namespace."
+    },
     {
       "id": "r-intersection",
       "title": "Forbidden r-Intersection Families",
-      "startLine": 41,
+      "startLine": 49,
       "endLine": 66,
-      "summary": "Defines r-avoiding families and the function T(n,r).",
-      "description": "A family F avoids r-intersection if no two sets have exactly r elements in common. T(n,r) is the maximum size of such a family over subsets of {1,...,n}."
+      "summary": "Defines `hasRIntersection` ($|A \\cap B| = r$), `avoidsRIntersection` (family-level constraint), and $T(n,r) = \\max|\\mathcal{F}|$ via `Finset.sup` over filtered powerset."
     },
     {
       "id": "trivial-case",
       "title": "The Trivial Case T(n,0)",
-      "startLine": 68,
+      "startLine": 78,
       "endLine": 88,
-      "summary": "T(n,0) = 2^{n-1} is the maximum intersecting family size.",
-      "description": "Avoiding 0-intersection means all pairs must intersect. The maximum is achieved by all sets containing a fixed element, giving 2^{n-1} sets."
+      "summary": "$T(n,0) = 2^{n-1}$: 0-avoiding families are intersecting families. Equivalence proved; optimality has a sorry."
     },
     {
       "id": "frankl-1977",
       "title": "Frankl's Result for r = 1",
-      "startLine": 90,
+      "startLine": 100,
       "endLine": 112,
-      "summary": "Frankl (1977) determined T(n,1) for all n.",
-      "description": "For r = 1, the optimal family consists of large sets (size > (n+1)/2) plus the empty set. Large sets cannot have intersection exactly 1."
+      "summary": "Frankl (1977) determined $T(n,1)$: optimal family is large sets ($|A| > (n+1)/2$) plus $\\emptyset$. Pigeonhole argument for large sets avoiding 1-intersection."
     },
     {
       "id": "frankl-furedi",
       "title": "Frankl-Füredi Optimal Families",
-      "startLine": 114,
+      "startLine": 122,
       "endLine": 142,
-      "summary": "For fixed r and large n, T(n,r) equals the Frankl-Füredi optimal family size.",
-      "description": "The optimal family depends on the parity of n + r. It consists of very large sets (avoiding r-intersection by pigeonhole) and small sets (size < r, trivially avoiding)."
+      "summary": "Explicit constructions split by parity of $n+r$: odd case uses $|A| > (n+r)/2$ or $|A| < r$; even case uses $|A \\setminus \\{1\\}| \\geq (n+r)/2$. Frankl-Füredi (1984) proves optimality for fixed $r$ and large $n$."
     },
     {
       "id": "main-question",
-      "title": "The Main Question - Exponential Bound",
-      "startLine": 144,
-      "endLine": 172,
-      "summary": "Frankl-Rödl (1987) proved T(n,r) < (2-δ)^n for middle range r.",
-      "description": "The main question asked whether T(n,r) is bounded away from 2^n when r is a constant fraction of n. Frankl-Rödl answered YES, proving an exponential gap."
+      "title": "The Main Question — Exponential Bound",
+      "startLine": 153,
+      "endLine": 165,
+      "summary": "Formal $\\varepsilon$-$\\delta$ statement: $T(n,r) < (2-\\delta)^n$ for $\\varepsilon n < r < (1/2-\\varepsilon)n$. **Frankl-Rödl (1987)**: YES, resolving the \\$250 prize."
     },
     {
       "id": "chromatic-connection",
       "title": "Connection to Chromatic Numbers",
-      "startLine": 174,
+      "startLine": 181,
       "endLine": 204,
-      "summary": "The exponential bound implies exponential chromatic numbers for unit distance graphs.",
-      "description": "The affirmative answer implies χ(n) ≥ c^n for the unit distance graph in R^n. Frankl-Wilson proved this independently using their mod p theorem."
+      "summary": "The exponential bound implies $\\chi(G_n) \\geq c^n$ for the unit distance graph. Frankl-Wilson (1981) proved this independently via mod $p$ methods."
     },
     {
       "id": "frankl-wilson",
       "title": "The Frankl-Wilson Theorem",
-      "startLine": 206,
+      "startLine": 214,
       "endLine": 226,
-      "summary": "Powerful bounds via modular constraints on set sizes.",
-      "description": "The Frankl-Wilson theorem bounds families where all sets have the same size mod p and avoid certain intersection sizes. This yields polynomial bounds."
-    },
-    {
-      "id": "related",
-      "title": "Related Problem #702",
-      "startLine": 228,
-      "endLine": 237,
-      "summary": "Problem #702 asks about k-uniform families avoiding r-intersection.",
-      "description": "The uniform version restricts to families where all sets have the same size k, a natural strengthening of the problem."
+      "summary": "Generalizes to $L$-avoiding families. The Frankl-Wilson theorem (mod $p$ version): uniform families with modular constraints satisfy $|\\mathcal{F}| \\leq \\binom{n}{s}$, using the linear algebra method."
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "startLine": 239,
-      "endLine": 275,
-      "summary": "Erdős #703 is SOLVED: the exponential bound holds.",
-      "description": "The main question is resolved YES by Frankl-Rödl. Key results include the trivial T(n,0), Frankl's T(n,1), Frankl-Füredi's exact values, and the exponential gap theorem."
+      "title": "Summary and Resolution",
+      "startLine": 258,
+      "endLine": 273,
+      "summary": "Combined `erdos_703_solved` theorem: `mainQuestion ∧ T(n,0) = 2^{n-1}`. Clean statement `erdos_703 : mainQuestion := frankl_rodl_1987`."
     }
   ],
+  "overview": {
+    "historicalContext": "Intersection problems for set families are fundamental in extremal combinatorics, originating with the Erdős-Ko-Rado theorem (1961) on intersecting families. Erdős extended this to forbidden r-intersection, asking how large a family can be if no two sets share exactly r elements. For r = 0, the answer T(n,0) = 2^{n-1} is classical. Frankl (1977) solved the r = 1 case. Frankl-Füredi (1984) determined T(n,r) exactly for fixed r and large n, showing the optimal families consist of very large and very small sets. The key open question — whether T(n,r) < (2-δ)^n for r in the 'middle range' εn < r < (1/2-ε)n — carried a $250 Erdős prize. Frankl and Rödl (1987) resolved this affirmatively using the 'nibble method', now a fundamental technique in probabilistic combinatorics. The result connects to geometry: it implies exponential chromatic number for the unit distance graph in ℝ^n, also proved independently by Frankl-Wilson (1981) via modular algebraic methods.",
+    "problemStatement": "Let T(n,r) be the maximum size of a family F of subsets of {1,...,n} such that |A ∩ B| ≠ r for all A, B in F. Estimate T(n,r). In particular, for every ε > 0, is there δ > 0 such that T(n,r) < (2 - δ)^n for εn < r < (1/2 - ε)n?",
+    "proofStrategy": "The formalization builds up from basic definitions (r-intersection, r-avoiding families, T(n,r)) through known results (T(n,0) = 2^{n-1}, Frankl 1977, Frankl-Füredi 1984) to the main Frankl-Rödl theorem. Deep results are axiomatized; the connections to chromatic numbers and the Frankl-Wilson theorem are also formalized.",
+    "keyInsights": [
+      "**Base case T(n,0) = 2^{n-1}**: The r = 0 case reduces to classical intersecting families, connecting to the Erdős-Ko-Rado framework",
+      "**Pigeonhole mechanism**: Large sets ($|A| > (n+r)/2$) automatically satisfy $|A \\cap B| > r$, providing the key construction ingredient for all known optimal families",
+      "**Phase transition at r = Θ(n)**: For fixed r, $T(n,r)/2^n \\to 1$ as $n \\to \\infty$; but for $r = \\Theta(n)$, the Frankl-Rödl theorem gives an exponential gap $T(n,r) < (2-\\delta)^n$",
+      "**Geometric connection**: The exponential bound on $T(n,r)$ implies $\\chi(\\mathbb{R}^n) \\geq c^n$ for the unit distance graph, linking combinatorics to high-dimensional geometry",
+      "**Algebraic methods**: The Frankl-Wilson theorem uses the linear algebra (dimension) method modulo a prime $p$, bounding $|\\mathcal{F}| \\leq \\binom{n}{s}$ via polynomial independence"
+    ]
+  },
   "conclusion": {
-    "summary": "Erdős Problem #703 is SOLVED. The answer to 'Is T(n,r) < (2-δ)^n for middle range r?' is YES, proved by Frankl-Rödl (1987). Exact values of T(n,r) for fixed r and large n were determined by Frankl-Füredi (1984).",
-    "implications": "The exponential bound has deep connections to geometry (unit distance graph chromatic numbers) and coding theory. The Frankl-Rödl theorem is a fundamental result in extremal combinatorics.",
+    "summary": "Erdős Problem #703 is SOLVED. The answer to 'Is T(n,r) < (2-δ)^n for middle range r?' is YES, proved by Frankl-Rödl (1987) using the nibble method. The formalization covers the full development from T(n,0) through optimal families to the main theorem, with connections to the Frankl-Wilson theorem and unit distance graph chromatic numbers. 2 sorries remain (T_n_0 proof, large_sets_avoid_1).",
+    "implications": "The Frankl-Rödl theorem is a cornerstone of extremal set theory. The exponential bound has deep connections to geometry (unit distance graph chromatic numbers), coding theory (bounds on codes with forbidden distances), and probability (the nibble method became a general-purpose tool in probabilistic combinatorics).",
     "openQuestions": [
-      "What is the optimal δ as a function of ε?",
-      "Can the Frankl-Füredi families be characterized for all n, not just large n?",
-      "What happens for r near n/2 (boundary of the middle range)?"
+      "What is the optimal δ = δ(ε) as a function of ε in the Frankl-Rödl bound?",
+      "Can the Frankl-Füredi families be characterized for all n and r, not just fixed r and large n?",
+      "What happens at the boundary r ≈ εn or r ≈ (1/2-ε)n — is there a sharp phase transition?",
+      "Can the two remaining sorries (T_n_0 and large_sets_avoid_1) be closed with current Mathlib?",
+      "Does the Frankl-Wilson polynomial method extend to give tight bounds on T(n,r) in the middle range?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- **Annotations**: 17→19, all with mathContext (LaTeX), relatedConcepts, prerequisites
- Fixed 6 invalid `axiom` types → `theorem`, all `high`/`medium` significance → `critical`/`key`/`supporting`
- Added imports and clean statement annotations
- **Meta**: added mathlibDependencies, originalContributions, crossReferences (erdos-702, erdos-1030)
- Deepened historicalContext: EKR → Frankl → Frankl-Füredi → Frankl-Rödl → Frankl-Wilson timeline (~700 chars)
- Bold keyInsights with LaTeX (5 items), sections 8→9 with LaTeX summaries, open questions 3→5

## Test plan
- [x] `pnpm annotations:build` passes (6 non-strict warnings: theorem type on axiom lines - expected)
- [ ] Verify gallery renders correctly for erdos-703

🤖 Generated with [Claude Code](https://claude.com/claude-code)