### PR TITLE
Research: erdos-1109 - Prove f(N)>=7 and f(N)>=8 with witnesses

### DIFF
--- a/proofs/Proofs/Erdos1109Problem.lean
+++ b/proofs/Proofs/Erdos1109Problem.lean
@@ -473,11 +473,7 @@ theorem f_ge_three (N : ℕ) (hN : N ≥ 21) : f N ≥ 3 := by
       simp [Finset.mem_insert, Finset.mem_singleton] at hx
       simp [Finset.mem_range]
       rcases hx with rfl | rfl | rfl <;> omega
-    · have h15 : (1 : ℕ) ≠ 5 := by omega
-      have h121 : (1 : ℕ) ≠ 21 := by omega
-      have h521 : (5 : ℕ) ≠ 21 := by omega
-      simp [Finset.card_insert_of_not_mem, Finset.mem_insert, Finset.mem_singleton,
-        h15, h121, h521, Finset.card_pair h521]
+    · native_decide
   have hbdd : BddAbove {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
     use N + 1
     intro m hm
@@ -1653,8 +1649,7 @@ theorem f_ge_four (N : ℕ) (hN : N ≥ 37) : f N ≥ 4 := by
       simp [Finset.mem_insert, Finset.mem_singleton] at hx
       simp [Finset.mem_range]
       rcases hx with rfl | rfl | rfl | rfl <;> omega
-    · simp [Finset.card_insert_of_not_mem, Finset.mem_insert, Finset.mem_singleton]
-      native_decide
+    · native_decide
   have hbdd : BddAbove {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
     use N + 1
     intro m hm
@@ -1756,8 +1751,7 @@ theorem f_ge_five (N : ℕ) (hN : N ≥ 41) : f N ≥ 5 := by
       simp [Finset.mem_insert, Finset.mem_singleton] at hx
       simp [Finset.mem_range]
       rcases hx with rfl | rfl | rfl | rfl | rfl <;> omega
-    · simp [Finset.card_insert_of_not_mem, Finset.mem_insert, Finset.mem_singleton]
-      native_decide
+    · native_decide
   have hbdd : BddAbove {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
     use N + 1
     intro m hm
@@ -2001,8 +1995,7 @@ theorem f_ge_six (N : ℕ) (hN : N ≥ 65) : f N ≥ 6 := by
       simp [Finset.mem_insert, Finset.mem_singleton] at hx
       simp [Finset.mem_range]
       rcases hx with rfl | rfl | rfl | rfl | rfl | rfl <;> omega
-    · simp [Finset.card_insert_of_not_mem, Finset.mem_insert, Finset.mem_singleton]
-      native_decide
+    · native_decide
   have hbdd : BddAbove {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
     use N + 1
     intro m hm
@@ -2233,5 +2226,285 @@ theorem mod_900_residue_image_le_48 (A : Finset ℕ) (h : hasSquarefreeSumset A)
     _ ≤ 1 * (4 * 12) := Nat.mul_le_mul h4 (Nat.mul_le_mul h9 h25)
     _ = 48 := by ring
 
+/-
+## Part XXVI: f(N) >= 7 and f(N) >= 8
+
+Extending the witness sets: {1,5,21,37,41,65,73} gives f(N)>=7 for N>=73,
+and {1,5,21,37,41,65,73,101} gives f(N)>=8 for N>=101.
+All elements are == 1 (mod 4), ensuring no pairwise sum is divisible by 4.
+-/
+
+-- New squarefree facts for 7-element witness (sums involving 73)
+private theorem squarefree_94 : Squarefree (94 : ℕ) := by
+  rw [show (94 : ℕ) = 2 * 47 from by norm_num]
+  have : Nat.Prime 47 := by native_decide
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, this.squarefree⟩)
+
+private theorem squarefree_110 : Squarefree (110 : ℕ) := by
+  rw [show (110 : ℕ) = 2 * 55 from by norm_num]
+  have h5 : Nat.Prime 5 := by native_decide
+  have h11 : Nat.Prime 11 := by native_decide
+  have h55 : Squarefree (55 : ℕ) := by
+    rw [show (55 : ℕ) = 5 * 11 from by norm_num]
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, h5.squarefree, h11.squarefree⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h55⟩)
+
+private theorem squarefree_114 : Squarefree (114 : ℕ) := by
+  rw [show (114 : ℕ) = 2 * 57 from by norm_num]
+  have h19 : Nat.Prime 19 := by native_decide
+  have h57 : Squarefree (57 : ℕ) := by
+    rw [show (57 : ℕ) = 3 * 19 from by norm_num]
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, three_prime.squarefree, h19.squarefree⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h57⟩)
+
+private theorem squarefree_138 : Squarefree (138 : ℕ) := by
+  rw [show (138 : ℕ) = 2 * 69 from by norm_num]
+  have h23 : Nat.Prime 23 := by native_decide
+  have h69 : Squarefree (69 : ℕ) := by
+    rw [show (69 : ℕ) = 3 * 23 from by norm_num]
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, three_prime.squarefree, h23.squarefree⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h69⟩)
+
+private theorem squarefree_146 : Squarefree (146 : ℕ) := by
+  rw [show (146 : ℕ) = 2 * 73 from by norm_num]
+  have : Nat.Prime 73 := by native_decide
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, this.squarefree⟩)
+
+/--
+**{1, 5, 21, 37, 41, 65, 73} has a squarefree sumset.**
+All 49 ordered pair sums are squarefree. This extends the 6-element set
+by adding 73, introducing 7 new distinct sums:
+74=2*37, 78=2*3*13, 94=2*47, 110=2*5*11, 114=2*3*19, 138=2*3*23, 146=2*73.
+-/
+theorem sept_1_5_21_37_41_65_73_squarefree_sumset :
+    hasSquarefreeSumset ({1, 5, 21, 37, 41, 65, 73} : Finset ℕ) := by
+  intro s hs
+  simp only [sumset, Finset.mem_image, Finset.mem_product, Finset.mem_insert,
+    Finset.mem_singleton] at hs
+  obtain ⟨⟨a, b⟩, ⟨ha, hb⟩, hab⟩ := hs
+  simp only [isSquarefree]
+  rcases ha with rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    rcases hb with rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    simp at hab <;> rw [← hab]
+  -- Row a=1: 2, 6, 22, 38, 42, 66, 74
+  · exact squarefree_2
+  · exact squarefree_6
+  · exact squarefree_22
+  · exact squarefree_38
+  · exact squarefree_42
+  · exact squarefree_66
+  · exact squarefree_74
+  -- Row a=5: 6, 10, 26, 42, 46, 70, 78
+  · exact squarefree_6
+  · exact squarefree_10
+  · exact squarefree_26
+  · exact squarefree_42
+  · exact squarefree_46
+  · exact squarefree_70
+  · exact squarefree_78
+  -- Row a=21: 22, 26, 42, 58, 62, 86, 94
+  · exact squarefree_22
+  · exact squarefree_26
+  · exact squarefree_42
+  · exact squarefree_58
+  · exact squarefree_62
+  · exact squarefree_86
+  · exact squarefree_94
+  -- Row a=37: 38, 42, 58, 74, 78, 102, 110
+  · exact squarefree_38
+  · exact squarefree_42
+  · exact squarefree_58
+  · exact squarefree_74
+  · exact squarefree_78
+  · exact squarefree_102
+  · exact squarefree_110
+  -- Row a=41: 42, 46, 62, 78, 82, 106, 114
+  · exact squarefree_42
+  · exact squarefree_46
+  · exact squarefree_62
+  · exact squarefree_78
+  · exact squarefree_82
+  · exact squarefree_106
+  · exact squarefree_114
+  -- Row a=65: 66, 70, 86, 102, 106, 130, 138
+  · exact squarefree_66
+  · exact squarefree_70
+  · exact squarefree_86
+  · exact squarefree_102
+  · exact squarefree_106
+  · exact squarefree_130
+  · exact squarefree_138
+  -- Row a=73: 74, 78, 94, 110, 114, 138, 146
+  · exact squarefree_74
+  · exact squarefree_78
+  · exact squarefree_94
+  · exact squarefree_110
+  · exact squarefree_114
+  · exact squarefree_138
+  · exact squarefree_146
+
+/--
+**f(N) >= 7 for N >= 73:**
+The set {1, 5, 21, 37, 41, 65, 73} has squarefree sumset, giving f(N) >= 7.
+-/
+theorem f_ge_seven (N : ℕ) (hN : N ≥ 73) : f N ≥ 7 := by
+  unfold f
+  have h7 : (7 : ℕ) ∈ {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
+    simp only [Set.mem_setOf_eq]
+    refine ⟨{1, 5, 21, 37, 41, 65, 73}, ?_, sept_1_5_21_37_41_65_73_squarefree_sumset, ?_⟩
+    · intro x hx
+      simp [Finset.mem_insert, Finset.mem_singleton] at hx
+      simp [Finset.mem_range]
+      rcases hx with rfl | rfl | rfl | rfl | rfl | rfl | rfl <;> omega
+    · native_decide
+  have hbdd : BddAbove {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
+    use N + 1
+    intro m hm
+    simp only [Set.mem_setOf_eq] at hm
+    obtain ⟨A, hA_sub, _, hA_card⟩ := hm
+    rw [← hA_card]
+    exact le_trans (Finset.card_le_card hA_sub) (by simp [Finset.card_range])
+  exact le_csSup hbdd h7
+
+-- New squarefree facts for 8-element witness (sums involving 101)
+private theorem squarefree_122 : Squarefree (122 : ℕ) := by
+  rw [show (122 : ℕ) = 2 * 61 from by norm_num]
+  have : Nat.Prime 61 := by native_decide
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, this.squarefree⟩)
+
+private theorem squarefree_142 : Squarefree (142 : ℕ) := by
+  rw [show (142 : ℕ) = 2 * 71 from by norm_num]
+  have : Nat.Prime 71 := by native_decide
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, this.squarefree⟩)
+
+private theorem squarefree_166 : Squarefree (166 : ℕ) := by
+  rw [show (166 : ℕ) = 2 * 83 from by norm_num]
+  have : Nat.Prime 83 := by native_decide
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, this.squarefree⟩)
+
+private theorem squarefree_174 : Squarefree (174 : ℕ) := by
+  rw [show (174 : ℕ) = 2 * 87 from by norm_num]
+  have h29 : Nat.Prime 29 := by native_decide
+  have h87 : Squarefree (87 : ℕ) := by
+    rw [show (87 : ℕ) = 3 * 29 from by norm_num]
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, three_prime.squarefree, h29.squarefree⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h87⟩)
+
+private theorem squarefree_202 : Squarefree (202 : ℕ) := by
+  rw [show (202 : ℕ) = 2 * 101 from by norm_num]
+  have : Nat.Prime 101 := by native_decide
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, this.squarefree⟩)
+
+/--
+**{1, 5, 21, 37, 41, 65, 73, 101} has a squarefree sumset.**
+All 64 ordered pair sums are squarefree. This extends the 7-element set
+by adding 101, introducing 8 new distinct sums:
+102=2*3*17, 106=2*53, 122=2*61, 138=2*3*23, 142=2*71, 166=2*83, 174=2*3*29, 202=2*101.
+-/
+theorem oct_1_5_21_37_41_65_73_101_squarefree_sumset :
+    hasSquarefreeSumset ({1, 5, 21, 37, 41, 65, 73, 101} : Finset ℕ) := by
+  intro s hs
+  simp only [sumset, Finset.mem_image, Finset.mem_product, Finset.mem_insert,
+    Finset.mem_singleton] at hs
+  obtain ⟨⟨a, b⟩, ⟨ha, hb⟩, hab⟩ := hs
+  simp only [isSquarefree]
+  rcases ha with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    rcases hb with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    simp at hab <;> rw [← hab]
+  -- Row a=1: 2, 6, 22, 38, 42, 66, 74, 102
+  · exact squarefree_2
+  · exact squarefree_6
+  · exact squarefree_22
+  · exact squarefree_38
+  · exact squarefree_42
+  · exact squarefree_66
+  · exact squarefree_74
+  · exact squarefree_102
+  -- Row a=5: 6, 10, 26, 42, 46, 70, 78, 106
+  · exact squarefree_6
+  · exact squarefree_10
+  · exact squarefree_26
+  · exact squarefree_42
+  · exact squarefree_46
+  · exact squarefree_70
+  · exact squarefree_78
+  · exact squarefree_106
+  -- Row a=21: 22, 26, 42, 58, 62, 86, 94, 122
+  · exact squarefree_22
+  · exact squarefree_26
+  · exact squarefree_42
+  · exact squarefree_58
+  · exact squarefree_62
+  · exact squarefree_86
+  · exact squarefree_94
+  · exact squarefree_122
+  -- Row a=37: 38, 42, 58, 74, 78, 102, 110, 138
+  · exact squarefree_38
+  · exact squarefree_42
+  · exact squarefree_58
+  · exact squarefree_74
+  · exact squarefree_78
+  · exact squarefree_102
+  · exact squarefree_110
+  · exact squarefree_138
+  -- Row a=41: 42, 46, 62, 78, 82, 106, 114, 142
+  · exact squarefree_42
+  · exact squarefree_46
+  · exact squarefree_62
+  · exact squarefree_78
+  · exact squarefree_82
+  · exact squarefree_106
+  · exact squarefree_114
+  · exact squarefree_142
+  -- Row a=65: 66, 70, 86, 102, 106, 130, 138, 166
+  · exact squarefree_66
+  · exact squarefree_70
+  · exact squarefree_86
+  · exact squarefree_102
+  · exact squarefree_106
+  · exact squarefree_130
+  · exact squarefree_138
+  · exact squarefree_166
+  -- Row a=73: 74, 78, 94, 110, 114, 138, 146, 174
+  · exact squarefree_74
+  · exact squarefree_78
+  · exact squarefree_94
+  · exact squarefree_110
+  · exact squarefree_114
+  · exact squarefree_138
+  · exact squarefree_146
+  · exact squarefree_174
+  -- Row a=101: 102, 106, 122, 138, 142, 166, 174, 202
+  · exact squarefree_102
+  · exact squarefree_106
+  · exact squarefree_122
+  · exact squarefree_138
+  · exact squarefree_142
+  · exact squarefree_166
+  · exact squarefree_174
+  · exact squarefree_202
+
+/--
+**f(N) >= 8 for N >= 101:**
+The set {1, 5, 21, 37, 41, 65, 73, 101} has squarefree sumset, giving f(N) >= 8.
+-/
+theorem f_ge_eight (N : ℕ) (hN : N ≥ 101) : f N ≥ 8 := by
+  unfold f
+  have h8 : (8 : ℕ) ∈ {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
+    simp only [Set.mem_setOf_eq]
+    refine ⟨{1, 5, 21, 37, 41, 65, 73, 101}, ?_, oct_1_5_21_37_41_65_73_101_squarefree_sumset, ?_⟩
+    · intro x hx
+      simp [Finset.mem_insert, Finset.mem_singleton] at hx
+      simp [Finset.mem_range]
+      rcases hx with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;> omega
+    · native_decide
+  have hbdd : BddAbove {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
+    use N + 1
+    intro m hm
+    simp only [Set.mem_setOf_eq] at hm
+    obtain ⟨A, hA_sub, _, hA_card⟩ := hm
+    rw [← hA_card]
+    exact le_trans (Finset.card_le_card hA_sub) (by simp [Finset.card_range])
+  exact le_csSup hbdd h8
 
 end Erdos1109

--- a/src/data/research/problems/erdos-1109.json
+++ b/src/data/research/problems/erdos-1109.json
@@ -17,19 +17,19 @@
   },
   "currentState": {
     "phase": "DEEP_DIVE",
-    "since": "2026-02-09T18:00:00Z",
-    "iteration": 5,
-    "focus": "CRT combined residue image bounds",
+    "since": "2026-02-10T12:00:00Z",
+    "iteration": 6,
+    "focus": "Explicit witness lower bounds f(N)>=7 and f(N)>=8",
     "blockers": [],
-    "nextAction": "Extend CRT to 4+ primes, prove abstract density bound",
+    "nextAction": "Extend CRT to 4+ primes, prove abstract density bound, find 9-element witness",
     "attemptCounts": {
-      "total": 5,
-      "currentApproach": 2,
+      "total": 6,
+      "currentApproach": 3,
       "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "Iteration 5: Proved CRT combined mod 36 (<=4 classes) and mod 900 (<=48 classes) density bounds. 0 sorries, 7 axioms.",
+    "progressSummary": "Iteration 6: Proved f(N)>=7 via {1,5,21,37,41,65,73} and f(N)>=8 via {1,5,21,37,41,65,73,101}. Fixed deprecated Finset.card_insert_of_not_mem. 0 sorries, 7 axioms.",
     "builtItems": [
       "squarefree_66, squarefree_70, squarefree_86, squarefree_102, squarefree_106, squarefree_130",
       "sext_1_5_21_37_41_65_squarefree_sumset: 6-element witness",
@@ -38,7 +38,11 @@
       "crt_residue_injective: CRT injectivity for residues mod p^2*q^2",
       "combined_residue_bound: |image mod p^2*q^2| <= ((p^2-1)/2)*((q^2-1)/2)",
       "mod_36_residue_image_le_4: CRT combined bound, at most 4 classes mod 36",
-      "mod_900_residue_image_le_48: CRT combined bound, at most 48 classes mod 900"
+      "mod_900_residue_image_le_48: CRT combined bound, at most 48 classes mod 900",
+      "sept_1_5_21_37_41_65_73_squarefree_sumset: 7-element witness",
+      "f_ge_seven: f(N) >= 7 for N >= 73",
+      "oct_1_5_21_37_41_65_73_101_squarefree_sumset: 8-element witness",
+      "f_ge_eight: f(N) >= 8 for N >= 101"
     ],
     "insights": [
       "Found 6-element squarefree sumset {1,5,21,37,41,65} for f(N)>=6",
@@ -47,14 +51,15 @@
       "CRT density product: distinct prime squares are coprime, constraints multiply",
       "Combined bound: |image mod p^2*q^2| <= ((p^2-1)/2)*((q^2-1)/2) via injection into product",
       "CRT injection technique: map residues mod lcm to product of residues mod p^2, bound product card",
-      "Density improvement: 1/4 (mod 4) -> 4/36 (mod 36) -> 48/900 (mod 900) via CRT"
+      "Density improvement: 1/4 (mod 4) -> 4/36 (mod 36) -> 48/900 (mod 900) via CRT",
+      "8-element witness {1,5,21,37,41,65,73,101} all == 1 (mod 4), all pairwise sums squarefree"
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Extend CRT to 4 primes: mod 44100 with at most 1*4*12*24 = 1152 classes",
       "Prove abstract density bound: |A| <= k * ceil(N/m) from |image mod m| <= k",
       "Connect density product to Konyagin upper bound exponent 11/15",
-      "Prove f(N)>=7 via {1,5,21,37,41,65,73} witness"
+      "Find 9-element witness extending {1,5,21,37,41,65,73,101}"
     ],
     "markdown": "# Erdos #1109: Squarefree Sumsets - Knowledge\n\n## Problem\nLet f(N) be the max size of A ⊆ {1,...,N} with A+A squarefree. Estimate f(N).\n\n## Key Results\n\n### Proved Theorems (58 total, 1 sorry in counting step)\n\n**Core structural theorems (iterations 1-2):**\n1. `squarefree_iff_no_prime_sq`: Squarefree iff no prime square divides\n2. `one_squarefree`: 1 is squarefree\n3. `prime_squarefree`: Primes are squarefree\n4. `distinct_primes_squarefree`: Products of distinct primes are squarefree (**PROVED**, was axiom)\n5. `all_odd`: All elements in a squarefree-sumset set must be odd\n6. `prime_sq_avoidance`: For any prime p, no two elements sum to a multiple of p^2\n7. `double_squarefree`: For any a in A, 2a is squarefree\n8. `element_not_div_prime_sq`: No element is divisible by p^2 for any prime p\n9. `element_squarefree`: All positive elements of A are themselves squarefree\n10. `current_bounds`: Combined Konyagin 2004 bounds (from axioms)\n11. `erdos_1109_summary`: Full bound summary theorem (from axioms)\n\n**New in iteration 3 (2026-02-04):**\n12. `f_ge_two`: f(N) >= 2 for N >= 5 via {1, 5} construction\n13. `not_div_25`: No element divisible by 25 = 5^2\n14. `no_sum_div_25`: No pair sums to a multiple of 25\n15. `forbidden_class_zero_25`: Residue 0 mod 25 is forbidden\n16. `no_complementary_mod_25`: No complementary residues mod 25\n17. `residue_class_zero_forbidden`: General: class 0 mod p^2 is forbidden\n18. `sum_residue_nonzero`: General sum constraint mod p^2\n19. `residue_image_avoids_zero`: Image of A mod p^2 avoids 0\n20. `mod_4_residue_image_small`: A uses at most 1 residue class mod 4\n21. `self_sum_not_div_9`: 2a not divisible by 9\n22. `mod_9_class_0_forbidden`: Class 0 mod 9 is forbidden\n23. `mod_9_pair_1_8`: Pair {1,8} exclusion mod 9\n24. `mod_9_pair_2_7`: Pair {2,7} exclusion mod 9\n25. `mod_9_pair_3_6`: Pair {3,6} exclusion mod 9\n26. `mod_9_pair_4_5`: Pair {4,5} exclusion mod 9\n27. `mod_9_residue_image_le_4`: At most 4 residue classes mod 9 (1 sorry: counting)\n28. `no_complementary_pair_general`: General complementary pair exclusion for any prime\n29. `density_per_prime`: Density bound (p^2-1)/2 <= p^2 per prime\n\n### Iteration 3 Progress (2026-02-04)\n- **Proved `f_ge_two`**: f(N) >= 2 for N >= 5, using the {1, 5} witness\n- **Mod 25 (p=5) constraints**: not_div_25, no_sum_div_25, forbidden_class_zero_25, no_complementary_mod_25\n- **General density framework**: residue_class_zero_forbidden, sum_residue_nonzero, residue_image_avoids_zero\n- **Mod 4 density result**: `mod_4_residue_image_small` - A uses exactly 1 of 4 residue classes mod 4\n- **Mod 9 pair exclusions**: All 4 complementary pairs {1,8}, {2,7}, {3,6}, {4,5} proved individually\n- **Mod 9 counting**: `mod_9_residue_image_le_4` - at most 4 of 9 residue classes (1 sorry in finite counting)\n- **General pair exclusion**: `no_complementary_pair_general` for arbitrary primes\n- Total: 19 new theorems added (18 fully proved, 1 with sorry in counting step)\n- File compiles cleanly with 1 sorry (mod 9 counting step - finite combinatorial verification)\n\n### Iteration 2 Progress (2026-02-03)\n- **Converted `distinct_primes_squarefree` from axiom to theorem**\n  - Proof by induction on the list of distinct primes\n  - Key Mathlib lemmas: `Nat.squarefree_mul_iff`, `Prime.dvd_prod_iff`, `Nat.Prime.coprime_iff_not_dvd`\n  - Strategy: In the inductive step, show p is coprime to ps.prod because\n    p is prime, all elements of ps are prime, and p not in ps (Nodup). If p | q for\n    some q in ps, then since q is prime, p = q, contradicting Nodup.\n- **Added `double_squarefree`**: 2a is squarefree for all a in A\n- **Added `element_not_div_prime_sq`**: No element divisible by p^2 (follows from diagonal of prime_sq_avoidance)\n- **Added `element_squarefree`**: All positive elements are squarefree (uses squarefree_iff_no_prime_sq + element_not_div_prime_sq)\n- Added `import Mathlib.Data.List.Prime` for `Prime.dvd_prod_iff`\n\n### Structural Constraint Hierarchy\nThe theorems form a logical hierarchy:\n1. `prime_sq_avoidance` (most general): for all a, b in A and prime p, p^2 does not divide a+b\n2. `element_not_div_prime_sq` (diagonal case): setting a = b, p^2 does not divide 2a, hence p^2 does not divide a\n3. `element_squarefree` (aggregated): combining over all primes, elements are squarefree\n4. `all_odd` (p=2 special case): the simplest constraint, elements must be odd\n\n### Iteration 1 Progress (2026-01-28)\n- Fixed compilation (missing imports, wrong sSup syntax)\n- Changed /-! to /- for Aristotle compatibility\n- Proved `all_odd` and `prime_sq_avoidance`\n- File now compiles cleanly\n\n### Compilation Fixes (Iteration 1)\n- Changed all `/-!` docstrings to `/-` (Aristotle compatibility)\n- Added `import Mathlib.Data.Real.Basic` for R type\n- Added `import Mathlib.Analysis.SpecialFunctions.Log.Basic` for `Real.log`\n- Added `import Mathlib.Analysis.SpecialFunctions.Pow.Real` for R^R power\n- Fixed `sSup` set builder syntax\n- Fixed axiom quantifier patterns\n\n## Axiom Inventory (7 axioms, down from 8)\n1. ~~`distinct_primes_squarefree`~~ **PROVED** (was axiom)\n2. `erdos_sarkozy_lower_1987` - f(N) >> log N\n3. `erdos_sarkozy_upper_1987` - f(N) << N^{3/4} log N\n4. `konyagin_lower_2004` - f(N) >> (log log N)(log N)^2\n5. `konyagin_upper_2004` - f(N) << N^{11/15+o(1)}\n6. `erdos_sarkozy_conjecture` - f(N) = (log N)^{O(1)}\n7. `connection_to_1103` - Finite bounds -> infinite sequence growth\n8. `sarkozy_k_power_free` - k-power-free generalization bounds\n\n## Next Steps\n- Close the sorry in `mod_9_residue_image_le_4` (finite combinatorial verification via 16-way case split)\n- Submit remaining 7 axioms to Aristotle (bound axioms from published papers)\n- Prove explicit mod 25 residue counting (at most 12 of 25 classes)\n- Formalize Chinese Remainder Theorem application for combined density: product of (allowed/p^2) over primes\n- Prove f(N) >= 2 for N >= 5 by explicit construction witness\n- Explore connection between density product and Konyagin's upper bound exponent 11/15\n"
   },
@@ -74,7 +79,7 @@
     "mathlib": []
   },
   "started": "2026-01-27T22:18:02.332Z",
-  "lastUpdate": "2026-02-09T18:00:00Z",
+  "lastUpdate": "2026-02-10T12:00:00Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Prove **f(N) >= 7** for N >= 73 via witness set {1, 5, 21, 37, 41, 65, 73}
- Prove **f(N) >= 8** for N >= 101 via witness set {1, 5, 21, 37, 41, 65, 73, 101}
- Add 10 new squarefree facts (94, 110, 114, 122, 138, 142, 146, 166, 174, 202)
- Fix deprecated `Finset.card_insert_of_not_mem` → `native_decide` for Docker Lean v4.26.0 compatibility

## Test plan
- [x] Docker build passes for isolated test file (TestErdos1109Ext.lean)
- [x] All squarefree facts verified: each sum is product of distinct primes
- [x] Witness sets use elements ≡ 1 (mod 4), avoiding divisibility by 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)