### PR TITLE
Research: erdos-101 - Fix collinearity proofs and prove trivial_upper_bound_sq

### DIFF
--- a/proofs/Proofs/Erdos101Problem.lean
+++ b/proofs/Proofs/Erdos101Problem.lean
@@ -80,46 +80,32 @@ theorem collinear_rotate {p q r : ℝ × ℝ} (h : collinear p q r) :
 /-- Cyclic permutation: collinear p q r → collinear q r p. -/
 theorem collinear_cycle {p q r : ℝ × ℝ} (h : collinear p q r) :
     collinear q r p :=
-  collinear_swap12 (collinear_swap23 h)
+  collinear_swap23 (collinear_swap12 h)
 
 /-- Collinearity transitivity: if p, q, r are collinear and p, q, s are collinear
-    (with p ≠ q), then p, r, s are collinear. Points on the same line through p, q
-    remain collinear. -/
+    (with p ≠ q), then p, r, s are collinear. -/
 theorem collinear_trans {p q r s : ℝ × ℝ} (hpq : p ≠ q)
     (hpqr : collinear p q r) (hpqs : collinear p q s) :
     collinear p r s := by
   unfold collinear at *
-  -- hpqr: (q.1 - p.1) * (r.2 - p.2) = (r.1 - p.1) * (q.2 - p.2)
-  -- hpqs: (q.1 - p.1) * (s.2 - p.2) = (s.1 - p.1) * (q.2 - p.2)
-  -- Goal: (r.1 - p.1) * (s.2 - p.2) = (s.1 - p.1) * (r.2 - p.2)
-  -- Strategy: p ≠ q means (q.1 - p.1, q.2 - p.2) ≠ (0, 0).
-  -- From hpqr, r - p is proportional to q - p; similarly s - p.
-  -- So r - p and s - p are proportional, giving the goal.
   by_cases hx : q.1 - p.1 = 0
-  · -- q.1 = p.1, so q.2 ≠ p.2
-    have hy : q.2 - p.2 ≠ 0 := by
-      intro hy
-      apply hpq
-      ext <;> linarith
-    -- From hpqr with q.1 - p.1 = 0: 0 = (r.1 - p.1) * (q.2 - p.2)
-    -- So r.1 = p.1
+  · have hy : q.2 - p.2 ≠ 0 := by
+      intro hy; apply hpq; ext <;> linarith
     have hr1 : r.1 - p.1 = 0 := by
       have := hpqr; rw [hx, zero_mul] at this
       exact (mul_eq_zero.mp this.symm).resolve_right hy
-    -- From hpqs with q.1 - p.1 = 0: s.1 = p.1
     have hs1 : s.1 - p.1 = 0 := by
       have := hpqs; rw [hx, zero_mul] at this
       exact (mul_eq_zero.mp this.symm).resolve_right hy
     rw [hr1, hs1]; ring
-  · -- q.1 ≠ p.1
-    -- From hpqr: r.2 - p.2 = (r.1 - p.1) * (q.2 - p.2) / (q.1 - p.1)
-    -- From hpqs: s.2 - p.2 = (s.1 - p.1) * (q.2 - p.2) / (q.1 - p.1)
-    -- Goal: (r.1 - p.1) * (s.2 - p.2) = (s.1 - p.1) * (r.2 - p.2)
-    -- Substitute and simplify - both sides equal
-    -- (r.1 - p.1) * (s.1 - p.1) * (q.2 - p.2) / (q.1 - p.1)
-    have key : (q.1 - p.1) * ((r.1 - p.1) * (s.2 - p.2)) =
-               (q.1 - p.1) * ((s.1 - p.1) * (r.2 - p.2)) := by nlinarith
-    exact mul_left_cancel₀ (sub_ne_zero.mpr (fun h => hx (by rw [h])) : q.1 - p.1 ≠ 0) key
+  · have key : (q.1 - p.1) * ((r.1 - p.1) * (s.2 - p.2)) =
+               (q.1 - p.1) * ((s.1 - p.1) * (r.2 - p.2)) := by
+      have h1 : (r.1 - p.1) * ((q.1 - p.1) * (s.2 - p.2)) =
+                (r.1 - p.1) * ((s.1 - p.1) * (q.2 - p.2)) := by rw [hpqs]
+      have h2 : (s.1 - p.1) * ((q.1 - p.1) * (r.2 - p.2)) =
+                (s.1 - p.1) * ((r.1 - p.1) * (q.2 - p.2)) := by rw [hpqr]
+      nlinarith
+    exact mul_left_cancel₀ hx key
 
 /-- Four points on the same line: if p, q, r, s are all collinear through
     distinct p, q, then q, r, s are collinear. -/
@@ -129,17 +115,14 @@ theorem collinear_four {p q r s : ℝ × ℝ} (hpq : p ≠ q)
   collinear_trans (Ne.symm hpq) (collinear_swap12 hpqr) (collinear_swap12 hpqs)
 
 /-- Full transitivity over a line: if r, s, t all lie on the line through
-    distinct p, q, then r, s, t are collinear. This is the key lemma
-    connecting our determinant-based collinearity to the geometric notion
-    of "lying on a common line". -/
+    distinct p, q, then r, s, t are collinear. -/
 theorem collinear_any_triple {p q r s t : ℝ × ℝ} (hpq : p ≠ q)
     (hr : collinear p q r) (hs : collinear p q s) (ht : collinear p q t) :
     collinear r s t := by
-  have h1 := collinear_trans hpq hr hs  -- collinear p r s
-  have h2 := collinear_trans hpq hr ht  -- collinear p r t
+  have h1 := collinear_trans hpq hr hs
+  have h2 := collinear_trans hpq hr ht
   by_cases hrp : r = p
-  · subst hrp
-    exact collinear_trans hpq hs ht
+  · subst hrp; exact collinear_trans hpq hs ht
   · exact collinear_trans hrp (collinear_swap12 h1) (collinear_swap12 h2)
 
 /- ## Structural Properties -/
@@ -160,15 +143,13 @@ theorem noFiveCollinear_small (P : PlanarPointSet) (h : P.points.card ≤ 4) :
       · simp [hbc, hbd, hbe]
     · simp [hab, hac, had, hae]
   have hsub : {a, b, c, d, e} ⊆ P.points := by
-    intro x hx
-    simp at hx
+    intro x hx; simp at hx
     rcases hx with rfl | rfl | rfl | rfl | rfl <;> assumption
   have := Finset.card_le_card hsub
-  rw [h5] at this
-  omega
+  rw [h5] at this; omega
 
-/-- For sets with fewer than 4 points, fourPointLineCount is zero
-    (no 4-element collinear subset can exist). -/
+open Classical in
+/-- For sets with fewer than 4 points, fourPointLineCount is zero. -/
 theorem fourPointLineCount_lt_four (P : PlanarPointSet) (h : P.points.card < 4) :
     fourPointLineCount P = 0 := by
   unfold fourPointLineCount
@@ -176,50 +157,37 @@ theorem fourPointLineCount_lt_four (P : PlanarPointSet) (h : P.points.card < 4) 
   rw [Finset.filter_eq_empty_iff]
   intro S hS
   simp only [not_and]
-  intro hcard
-  exfalso
+  intro hcard; exfalso
   have hsub := Finset.mem_powerset.mp hS
-  have := Finset.card_le_card hsub
-  omega
+  have := Finset.card_le_card hsub; omega
 
-/-- Under NoFiveCollinear, for any two distinct points a, b in P, the set of
-    points in P collinear with a and b has at most 4 elements.
-    This is the key structural consequence of the NoFiveCollinear condition.
-
-    Proof: By contradiction. If |L| ≥ 5 where L = {p ∈ P | collinear a b p},
-    then L \ {a,b} has ≥ 3 elements. Extract c, d, e from L \ {a,b}; these
-    5 distinct points a, b, c, d, e ∈ P all satisfy collinear a b ·,
-    contradicting NoFiveCollinear. -/
 open Classical in
+/-- Under NoFiveCollinear, for any two distinct points a, b in P, the set of
+    points in P collinear with a and b has at most 4 elements. -/
 theorem noFiveCollinear_line_bound (P : PlanarPointSet) (hP : NoFiveCollinear P)
     (a b : ℝ × ℝ) (ha : a ∈ P.points) (hb : b ∈ P.points) (hab : a ≠ b) :
     (P.points.filter (fun p => collinear a b p)).card ≤ 4 := by
   by_contra h
   push_neg at h
   set L := P.points.filter (fun p => collinear a b p)
-  -- a, b ∈ L
-  have ha_L : a ∈ L := Finset.mem_filter.mpr ⟨ha, collinear_self a b⟩
+  have ha_L : a ∈ L := Finset.mem_filter.mpr ⟨ha, by unfold collinear; ring⟩
   have hb_L : b ∈ L := Finset.mem_filter.mpr ⟨hb, collinear_self_right a b⟩
-  -- L' = L \ {a, b} has ≥ 3 elements
   set L' := (L.erase a).erase b
+  have hb_ea : b ∈ L.erase a := Finset.mem_erase.mpr ⟨Ne.symm hab, hb_L⟩
   have hL'_card : L'.card ≥ 3 := by
-    have h1 := Finset.card_erase_le (a := a) (s := L)
-    have h2 := Finset.card_erase_le (a := b) (s := L.erase a)
+    have h1 : (L.erase a).card = L.card - 1 := Finset.card_erase_of_mem ha_L
+    have h2 : L'.card = (L.erase a).card - 1 := Finset.card_erase_of_mem hb_ea
     omega
-  -- Extract c from L'
   have hL'_ne : L'.Nonempty := Finset.card_pos.mp (by omega)
   obtain ⟨c, hc⟩ := hL'_ne
-  -- Extract d from L' \ {c}
   have hL'c : (L'.erase c).card ≥ 2 := by
     have := Finset.card_erase_of_mem hc; omega
   have hL'c_ne : (L'.erase c).Nonempty := Finset.card_pos.mp (by omega)
   obtain ⟨d, hd⟩ := hL'c_ne
-  -- Extract e from L' \ {c, d}
   have hL'cd : ((L'.erase c).erase d).card ≥ 1 := by
     have := Finset.card_erase_of_mem hd; omega
   have hL'cd_ne : ((L'.erase c).erase d).Nonempty := Finset.card_pos.mp (by omega)
   obtain ⟨e, he⟩ := hL'cd_ne
-  -- Trace membership: e ∈ L' \ {c, d} → ... → L
   have he_ec : e ∈ L'.erase c := Finset.mem_of_mem_erase he
   have he_L' : e ∈ L' := Finset.mem_of_mem_erase he_ec
   have hd_L' : d ∈ L' := Finset.mem_of_mem_erase hd
@@ -229,26 +197,88 @@ theorem noFiveCollinear_line_bound (P : PlanarPointSet) (hP : NoFiveCollinear P)
   have hc_L : c ∈ L := Finset.mem_of_mem_erase hc_eaL
   have hd_L : d ∈ L := Finset.mem_of_mem_erase hd_eaL
   have he_L : e ∈ L := Finset.mem_of_mem_erase he_eaL
-  -- Membership and collinearity
   have hc_P : c ∈ P.points := (Finset.mem_filter.mp hc_L).1
   have hd_P : d ∈ P.points := (Finset.mem_filter.mp hd_L).1
   have he_P : e ∈ P.points := (Finset.mem_filter.mp he_L).1
   have hcol_c : collinear a b c := (Finset.mem_filter.mp hc_L).2
   have hcol_d : collinear a b d := (Finset.mem_filter.mp hd_L).2
   have hcol_e : collinear a b e := (Finset.mem_filter.mp he_L).2
-  -- Distinctness: c, d, e ∉ {a, b} and pairwise distinct
-  have hac : a ≠ c := fun h => absurd hc_eaL (h ▸ Finset.not_mem_erase a L)
-  have hbc : b ≠ c := fun h => absurd hc (h ▸ Finset.not_mem_erase b (L.erase a))
-  have had : a ≠ d := fun h => absurd hd_eaL (h ▸ Finset.not_mem_erase a L)
-  have hbd : b ≠ d := fun h => absurd hd_L' (h ▸ Finset.not_mem_erase b (L.erase a))
-  have hae : a ≠ e := fun h => absurd he_eaL (h ▸ Finset.not_mem_erase a L)
-  have hbe : b ≠ e := fun h => absurd he_L' (h ▸ Finset.not_mem_erase b (L.erase a))
-  have hcd : c ≠ d := fun h => absurd hd (h ▸ Finset.not_mem_erase c L')
-  have hce : c ≠ e := fun h => absurd he_ec (h ▸ Finset.not_mem_erase c L')
-  have hde : d ≠ e := fun h => absurd he (h ▸ Finset.not_mem_erase d (L'.erase c))
-  -- Apply NoFiveCollinear
+  have hac : a ≠ c := fun h => absurd hc_eaL (h ▸ Finset.notMem_erase a L)
+  have hbc : b ≠ c := fun h => absurd hc (h ▸ Finset.notMem_erase b (L.erase a))
+  have had : a ≠ d := fun h => absurd hd_eaL (h ▸ Finset.notMem_erase a L)
+  have hbd : b ≠ d := fun h => absurd hd_L' (h ▸ Finset.notMem_erase b (L.erase a))
+  have hae : a ≠ e := fun h => absurd he_eaL (h ▸ Finset.notMem_erase a L)
+  have hbe : b ≠ e := fun h => absurd he_L' (h ▸ Finset.notMem_erase b (L.erase a))
+  have hcd : c ≠ d := fun h => absurd hd (h ▸ Finset.notMem_erase c L')
+  have hce : c ≠ e := fun h => absurd he_ec (h ▸ Finset.notMem_erase c L')
+  have hde : d ≠ e := fun h => absurd he (h ▸ Finset.notMem_erase d (L'.erase c))
   exact hP a b c d e ha hb hc_P hd_P he_P hab hac had hae hbc hbd hbe hcd hce hde
     ⟨hcol_c, hcol_d, hcol_e⟩
+
+/- ## Uniqueness of Four-Collinear Subsets -/
+
+open Classical in
+/-- If two 4-element collinear subsets of P both contain distinct points a, b,
+    then under NoFiveCollinear they must be equal. -/
+theorem four_collinear_unique (P : PlanarPointSet) (hP : NoFiveCollinear P)
+    (S₁ S₂ : Finset (ℝ × ℝ))
+    (hS₁_sub : S₁ ⊆ P.points) (hS₂_sub : S₂ ⊆ P.points)
+    (hS₁_card : S₁.card = 4) (hS₂_card : S₂.card = 4)
+    (a b : ℝ × ℝ) (hab : a ≠ b)
+    (ha₁ : a ∈ S₁) (hb₁ : b ∈ S₁) (ha₂ : a ∈ S₂) (hb₂ : b ∈ S₂)
+    (hcol₁ : ∀ p ∈ S₁, collinear a b p)
+    (hcol₂ : ∀ p ∈ S₂, collinear a b p) :
+    S₁ = S₂ := by
+  set L := P.points.filter (fun p => collinear a b p) with hL_def
+  have hL_bound := noFiveCollinear_line_bound P hP a b
+    (hS₁_sub ha₁) (hS₁_sub hb₁) hab
+  have hS₁_L : S₁ ⊆ L := by
+    intro x hx; exact Finset.mem_filter.mpr ⟨hS₁_sub hx, hcol₁ x hx⟩
+  have hS₂_L : S₂ ⊆ L := by
+    intro x hx; exact Finset.mem_filter.mpr ⟨hS₂_sub hx, hcol₂ x hx⟩
+  have hS₁_eq : S₁ = L := by
+    apply Finset.eq_of_subset_of_card_le hS₁_L
+    rw [hS₁_card]; exact hL_bound
+  have hS₂_eq : S₂ = L := by
+    apply Finset.eq_of_subset_of_card_le hS₂_L
+    rw [hS₂_card]; exact hL_bound
+  rw [hS₁_eq, hS₂_eq]
+
+open Classical in
+/-- Two distinct 4-element collinear subsets of P (under NoFiveCollinear)
+    share at most one element. -/
+theorem four_collinear_overlap_small (P : PlanarPointSet) (hP : NoFiveCollinear P)
+    (S₁ S₂ : Finset (ℝ × ℝ))
+    (hS₁_sub : S₁ ⊆ P.points) (hS₂_sub : S₂ ⊆ P.points)
+    (hS₁_card : S₁.card = 4) (hS₂_card : S₂.card = 4)
+    (hne : S₁ ≠ S₂)
+    (a₁ b₁ : ℝ × ℝ) (hab₁ : a₁ ≠ b₁)
+    (ha₁ : a₁ ∈ S₁) (hb₁ : b₁ ∈ S₁)
+    (hcol₁ : ∀ p ∈ S₁, collinear a₁ b₁ p)
+    (a₂ b₂ : ℝ × ℝ) (hab₂ : a₂ ≠ b₂)
+    (ha₂ : a₂ ∈ S₂) (hb₂ : b₂ ∈ S₂)
+    (hcol₂ : ∀ p ∈ S₂, collinear a₂ b₂ p) :
+    (S₁ ∩ S₂).card ≤ 1 := by
+  by_contra h
+  push_neg at h
+  have hne2 : (S₁ ∩ S₂).card ≥ 2 := h
+  have ⟨x, hx⟩ := Finset.card_pos.mp (by omega : (S₁ ∩ S₂).card > 0)
+  have ⟨y, hy⟩ := Finset.card_pos.mp (show ((S₁ ∩ S₂).erase x).card > 0 by
+    have := Finset.card_erase_of_mem hx; omega)
+  have hy_mem : y ∈ S₁ ∩ S₂ := Finset.mem_of_mem_erase hy
+  have hxy : x ≠ y := fun h => by subst h; exact absurd hy (Finset.notMem_erase x _)
+  have hx₁ := (Finset.mem_inter.mp hx).1
+  have hx₂ := (Finset.mem_inter.mp hx).2
+  have hy₁ := (Finset.mem_inter.mp hy_mem).1
+  have hy₂ := (Finset.mem_inter.mp hy_mem).2
+  have hcol₁' : ∀ p ∈ S₁, collinear x y p := by
+    intro p hp
+    exact collinear_any_triple hab₁ (hcol₁ x hx₁) (hcol₁ y hy₁) (hcol₁ p hp)
+  have hcol₂' : ∀ p ∈ S₂, collinear x y p := by
+    intro p hp
+    exact collinear_any_triple hab₂ (hcol₂ x hx₂) (hcol₂ y hy₂) (hcol₂ p hp)
+  exact hne (four_collinear_unique P hP S₁ S₂ hS₁_sub hS₂_sub hS₁_card hS₂_card x y hxy
+    hx₁ hy₁ hx₂ hy₂ hcol₁' hcol₂')
 
 /- ## Main Conjecture -/
 
@@ -278,14 +308,77 @@ axiom solymosi_stojakovic_lower :
       NoFiveCollinear P ∧ P.points.card = n ∧
         (fourPointLineCount P : ℝ) ≥ (n : ℝ) ^ (2 - C / Real.sqrt (Real.log n))
 
-/-- **Trivial Upper Bound**: Under NoFiveCollinear, each line has ≤ 4 points,
-    so each line contributes at most C(4,4)=1 four-point subset. Since there are
-    at most C(n,2) lines, fourPointLineCount ≤ n(n−1)/2.
+open Classical in
+/-- **Trivial Upper Bound (n²)**: Under NoFiveCollinear, fourPointLineCount ≤ n².
+    Injection from 4-collinear subsets to ordered pairs via existential witnesses. -/
+theorem trivial_upper_bound_sq (P : PlanarPointSet) (hP : NoFiveCollinear P) :
+    fourPointLineCount P ≤ P.points.card * P.points.card := by
+  unfold fourPointLineCount
+  set F := P.points.powerset.filter (fun S =>
+    S.card = 4 ∧
+    ∃ a b : ℝ × ℝ, a ∈ S ∧ b ∈ S ∧ a ≠ b ∧
+      ∀ p ∈ S, collinear a b p)
+  have hF_sub : ∀ S ∈ F, S ⊆ P.points :=
+    fun S hS => Finset.mem_powerset.mp (Finset.mem_of_mem_filter S hS)
+  have hF_prop : ∀ S ∈ F, S.card = 4 ∧
+      ∃ a b : ℝ × ℝ, a ∈ S ∧ b ∈ S ∧ a ≠ b ∧ ∀ p ∈ S, collinear a b p :=
+    fun S hS => (Finset.mem_filter.mp hS).2
+  let witnessMap : Finset (ℝ × ℝ) → (ℝ × ℝ) × (ℝ × ℝ) := fun S =>
+    if h : ∃ a b : ℝ × ℝ, a ∈ S ∧ b ∈ S ∧ a ≠ b ∧ ∀ p ∈ S, collinear a b p
+    then (h.choose, h.choose_spec.choose)
+    else ((0, 0), (0, 0))
+  have hF_dite : ∀ S ∈ F, ∃ a b : ℝ × ℝ, a ∈ S ∧ b ∈ S ∧ a ≠ b ∧
+      ∀ p ∈ S, collinear a b p :=
+    fun S hS => (hF_prop S hS).2
+  have hmap_a_mem : ∀ S ∈ F, (witnessMap S).1 ∈ S := by
+    intro S hS
+    have hdite := hF_dite S hS
+    show (witnessMap S).1 ∈ S
+    simp only [witnessMap, dif_pos hdite]
+    exact hdite.choose_spec.choose_spec.1
+  have hmap_b_mem : ∀ S ∈ F, (witnessMap S).2 ∈ S := by
+    intro S hS
+    have hdite := hF_dite S hS
+    show (witnessMap S).2 ∈ S
+    simp only [witnessMap, dif_pos hdite]
+    exact hdite.choose_spec.choose_spec.2.1
+  have hmap_ne : ∀ S ∈ F, (witnessMap S).1 ≠ (witnessMap S).2 := by
+    intro S hS
+    have hdite := hF_dite S hS
+    show (witnessMap S).1 ≠ (witnessMap S).2
+    simp only [witnessMap, dif_pos hdite]
+    exact hdite.choose_spec.choose_spec.2.2.1
+  have hmap_col : ∀ S ∈ F, ∀ p ∈ S,
+      collinear (witnessMap S).1 (witnessMap S).2 p := by
+    intro S hS p hp
+    have hdite := hF_dite S hS
+    show collinear (witnessMap S).1 (witnessMap S).2 p
+    simp only [witnessMap, dif_pos hdite]
+    exact hdite.choose_spec.choose_spec.2.2.2 p hp
+  calc F.card ≤ (P.points ×ˢ P.points).card := by
+        apply Finset.card_le_card_of_injOn witnessMap
+        · intro S hS
+          exact Finset.mem_product.mpr
+            ⟨hF_sub S hS (hmap_a_mem S hS), hF_sub S hS (hmap_b_mem S hS)⟩
+        · intro S₁ hS₁ S₂ hS₂ heq
+          have h₁ := hF_prop S₁ hS₁
+          have h₂ := hF_prop S₂ hS₂
+          have ha₂ : (witnessMap S₁).1 ∈ S₂ := by
+            rw [congr_arg Prod.fst heq]; exact hmap_a_mem S₂ hS₂
+          have hb₂ : (witnessMap S₁).2 ∈ S₂ := by
+            rw [congr_arg Prod.snd heq]; exact hmap_b_mem S₂ hS₂
+          have hcol₂ : ∀ p ∈ S₂, collinear (witnessMap S₁).1 (witnessMap S₁).2 p := by
+            intro p hp
+            have := hmap_col S₂ hS₂ p hp
+            rwa [← congr_arg Prod.fst heq, ← congr_arg Prod.snd heq] at this
+          exact four_collinear_unique P hP S₁ S₂ (hF_sub S₁ hS₁) (hF_sub S₂ hS₂)
+            h₁.1 h₂.1 _ _ (hmap_ne S₁ hS₁)
+            (hmap_a_mem S₁ hS₁) (hmap_b_mem S₁ hS₁) ha₂ hb₂
+            (hmap_col S₁ hS₁) hcol₂
+    _ = P.points.card * P.points.card := Finset.card_product _ _
 
-    Note: The original statement lacked NoFiveCollinear, which is necessary —
-    without it, n collinear points yield C(n,4) ≫ n² four-point subsets.
-    Full proof requires a "line" abstraction and injection into unordered pairs;
-    kept as axiom pending that infrastructure. -/
+/-- **Trivial Upper Bound (tight)**: Under NoFiveCollinear, fourPointLineCount ≤ n(n−1)/2.
+    Follows from injection into unordered pairs. Kept as axiom pending formalization. -/
 axiom trivial_upper_bound :
   ∀ P : PlanarPointSet, NoFiveCollinear P →
     fourPointLineCount P ≤ P.points.card * (P.points.card - 1) / 2
@@ -301,8 +394,7 @@ axiom collinear_triples_no_four :
         fourPointLineCount P = 0
 
 /-- **Szemerédi–Trotter Bound**: the number of point-line incidences
-    is O(n^{2/3} m^{2/3} + n + m) for n points and m lines in the plane.
-    This is the key incidence-geometry tool for bounding four-point lines. -/
+    is O(n^{2/3} m^{2/3} + n + m) for n points and m lines in the plane. -/
 axiom szemeredi_trotter :
   ∃ C : ℝ, C > 0 ∧
     ∀ (n m : ℕ), ∀ (incidences : ℕ),


### PR DESCRIPTION
## Summary
- Fix 6 build errors in `Erdos101Problem.lean` for Docker Lean v4.26.0 compatibility
- Prove 3 new theorems: `four_collinear_unique`, `four_collinear_overlap_small`, `trivial_upper_bound_sq`
- The n² upper bound on fourPointLineCount is proved via injection into ordered pairs using `Finset.card_le_card_of_injOn`

## New Theorems
| Theorem | Statement |
|---------|-----------|
| `four_collinear_unique` | Two 4-element collinear subsets sharing 2 distinct points are equal (under NoFiveCollinear) |
| `four_collinear_overlap_small` | Distinct 4-element collinear subsets share at most 1 element |
| `trivial_upper_bound_sq` | `fourPointLineCount P ≤ n²` via injection into ordered pairs |

## Bug Fixes
- `collinear_cycle`: term-mode proof used wrong composition order
- `collinear_trans`: `nlinarith` needed intermediate lemmas; `mul_left_cancel₀` argument simplified
- `fourPointLineCount_lt_four`: missing `open Classical in` for `DecidablePred`
- `noFiveCollinear_line_bound`: `collinear_self a b` gives wrong type; `card_erase_le` insufficient for omega
- Deprecated `Finset.not_mem_erase` → `Finset.notMem_erase`

## Test plan
- [x] Docker build succeeds with 0 errors, 0 sorries
- [x] Only linter warnings about unused variables in overlap theorem (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)