### PR TITLE
Research: erdos-1109 - Add 12-element witness and complete lower bounds

### DIFF
--- a/proofs/Proofs/Erdos1109Problem.lean
+++ b/proofs/Proofs/Erdos1109Problem.lean
@@ -2532,11 +2532,46 @@ theorem f_ge_eight (N : ℕ) (hN : N ≥ 101) : f N ≥ 8 := by
     exact le_trans (Finset.card_le_card hA_sub) (by simp [Finset.card_range])
   exact le_csSup hbdd h8
 
--- (f >= 9 is subsumed by f >= 10 and f >= 11 below)
-
 -- ============================================================================
 -- Part VIII: 10-Element Witness and f(N) >= 10
 -- ============================================================================
+
+-- Missing squarefree facts used by 10-element and 11-element witnesses
+
+private theorem squarefree_158 : Squarefree (158 : ℕ) := by
+  rw [show (158 : ℕ) = 2 * 79 from by norm_num]
+  have h79 : Nat.Prime 79 := by native_decide
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h79.squarefree⟩)
+
+private theorem squarefree_178 : Squarefree (178 : ℕ) := by
+  rw [show (178 : ℕ) = 2 * 89 from by norm_num]
+  have h89 : Nat.Prime 89 := by native_decide
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h89.squarefree⟩)
+
+private theorem squarefree_210 : Squarefree (210 : ℕ) := by
+  rw [show (210 : ℕ) = 2 * 105 from by norm_num]
+  have h105 : Squarefree (105 : ℕ) := by
+    rw [show (105 : ℕ) = 3 * 35 from by norm_num]
+    have h35 : Squarefree (35 : ℕ) := by
+      rw [show (35 : ℕ) = 5 * 7 from by norm_num]
+      have h7 : Nat.Prime 7 := by native_decide
+      exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, five_prime.squarefree, h7.squarefree⟩
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, three_prime.squarefree, h35⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h105⟩)
+
+private theorem squarefree_238 : Squarefree (238 : ℕ) := by
+  rw [show (238 : ℕ) = 2 * 119 from by norm_num]
+  have h119 : Squarefree (119 : ℕ) := by
+    rw [show (119 : ℕ) = 7 * 17 from by norm_num]
+    have h7 : Nat.Prime 7 := by native_decide
+    have h17 : Nat.Prime 17 := by native_decide
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, h7.squarefree, h17.squarefree⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h119⟩)
+
+private theorem squarefree_274 : Squarefree (274 : ℕ) := by
+  rw [show (274 : ℕ) = 2 * 137 from by norm_num]
+  have h137 : Nat.Prime 137 := by native_decide
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h137.squarefree⟩)
 
 -- New squarefree facts for 10-element witness (sums involving 165)
 
@@ -2745,6 +2780,41 @@ theorem f_ge_ten (N : ℕ) (hN : N ≥ 165) : f N ≥ 10 := by
     exact le_trans (Finset.card_le_card hA_sub) (by simp [Finset.card_range])
   exact le_csSup hbdd h10
 
+/--
+**{1, 5, 21, 37, 41, 65, 73, 101, 137} has a squarefree sumset.**
+This 9-element set is a subset of the 10-element witness.
+-/
+theorem nona_1_5_21_37_41_65_73_101_137_squarefree_sumset :
+    hasSquarefreeSumset ({1, 5, 21, 37, 41, 65, 73, 101, 137} : Finset ℕ) := by
+  apply subset_squarefree_sumset {1, 5, 21, 37, 41, 65, 73, 101, 137, 165}
+  · exact deca_1_5_21_37_41_65_73_101_137_165_squarefree_sumset
+  · intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;> simp [Finset.mem_insert]
+
+/--
+**f(N) >= 9 for N >= 137:**
+The set {1, 5, 21, 37, 41, 65, 73, 101, 137} has squarefree sumset.
+-/
+theorem f_ge_nine (N : ℕ) (hN : N ≥ 137) : f N ≥ 9 := by
+  unfold f
+  have h9 : (9 : ℕ) ∈ {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
+    simp only [Set.mem_setOf_eq]
+    refine ⟨{1, 5, 21, 37, 41, 65, 73, 101, 137}, ?_, nona_1_5_21_37_41_65_73_101_137_squarefree_sumset, ?_⟩
+    · intro x hx
+      simp [Finset.mem_insert, Finset.mem_singleton] at hx
+      simp [Finset.mem_range]
+      rcases hx with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;> omega
+    · native_decide
+  have hbdd : BddAbove {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
+    use N + 1
+    intro m hm
+    simp only [Set.mem_setOf_eq] at hm
+    obtain ⟨A, hA_sub, _, hA_card⟩ := hm
+    rw [← hA_card]
+    exact le_trans (Finset.card_le_card hA_sub) (by simp [Finset.card_range])
+  exact le_csSup hbdd h9
+
 /-
 ## Part XXVIII: Four-Prime CRT Density Bound
 
@@ -2770,7 +2840,7 @@ Since 4, 9, 25, and 49 are pairwise coprime with lcm = 44100, each element's res
 mod 44100 is determined by its residues mod 4, mod 9, mod 25, and mod 49.
 The per-prime bounds are 1, 4, 12, 24 respectively, giving 1 × 4 × 12 × 24 = 1152.
 -/
-set_option maxHeartbeats 400000 in
+set_option maxHeartbeats 800000 in
 theorem mod_44100_residue_image_le_1152 (A : Finset ℕ) (h : hasSquarefreeSumset A) :
     (A.image (· % 44100)).card ≤ 1152 := by
   have hbnd : A.image (· % 44100) ⊆ Finset.range 44100 := by
@@ -2829,7 +2899,11 @@ theorem mod_44100_residue_image_le_1152 (A : Finset ℕ) (h : hasSquarefreeSumse
     intro p hp
     simp only [Finset.mem_image, Finset.mem_product] at hp ⊢
     obtain ⟨r, ⟨a, ha, rfl⟩, rfl⟩ := hp
-    exact ⟨⟨a, ha, by omega⟩, ⟨a, ha, by omega⟩, ⟨a, ha, by omega⟩, ⟨a, ha, by omega⟩⟩
+    have hm4 : a % 44100 % 4 = a % 4 := Nat.mod_mod_of_dvd a (by norm_num : 4 ∣ 44100)
+    have hm9 : a % 44100 % 9 = a % 9 := Nat.mod_mod_of_dvd a (by norm_num : 9 ∣ 44100)
+    have hm25 : a % 44100 % 25 = a % 25 := Nat.mod_mod_of_dvd a (by norm_num : 25 ∣ 44100)
+    have hm49 : a % 44100 % 49 = a % 49 := Nat.mod_mod_of_dvd a (by norm_num : 49 ∣ 44100)
+    exact ⟨⟨a, ha, hm4⟩, ⟨a, ha, hm9⟩, ⟨a, ha, hm25⟩, ⟨a, ha, hm49⟩⟩
   have h4 := mod_4_residue_image_small A h
   have h9 := mod_9_residue_image_le_4 A h
   have h25 := mod_25_residue_image_le_12 A h
@@ -2867,24 +2941,28 @@ r mod m is at most N/m + 1.
 theorem fiber_card_bound (N m r : ℕ) (hm : m ≥ 1) :
     ((Finset.range (N + 1)).filter (fun a => a % m = r)).card ≤ N / m + 1 := by
   by_cases hr : r > N
-  · have : (Finset.range (N + 1)).filter (fun a => a % m = r) = ∅ := by
+  · have hempty : (Finset.range (N + 1)).filter (fun a => a % m = r) = ∅ := by
       ext x
-      simp only [Finset.mem_filter, Finset.mem_range, Finset.not_mem_empty, iff_false]
+      simp only [Finset.mem_filter, Finset.mem_range, Finset.notMem_empty, iff_false]
       intro ⟨hx, hxr⟩
-      have := Nat.mod_lt x (by omega : m > 0)
+      have hmod := Nat.mod_lt x (by omega : m > 0)
       omega
-    rw [this]; simp; omega
+    rw [hempty, Finset.card_empty]; omega
   · push_neg at hr
     -- Inject into {0,...,N/m} via a ↦ a/m
     suffices h : ((Finset.range (N + 1)).filter (fun a => a % m = r)).card ≤
         (Finset.range (N / m + 1)).card by
       rwa [Finset.card_range] at h
     apply Finset.card_le_card_of_injOn (· / m) (fun a ha => ?_) (fun a₁ ha₁ a₂ ha₂ heq => ?_)
-    · simp only [Finset.mem_filter, Finset.mem_range] at ha ⊢
-      exact Nat.lt_succ_of_le (Nat.div_le_div_right (by omega))
+    · simp only [Finset.mem_filter, Finset.mem_range] at ha
+      simp only [Finset.mem_range]
+      have ha_lt := ha.1
+      have h_div := Nat.div_le_div_right (Nat.lt_succ_iff.mp ha_lt).le
+      omega
     · simp only [Finset.mem_filter, Finset.mem_range] at ha₁ ha₂
-      have := Nat.div_add_mod a₁ m
-      have := Nat.div_add_mod a₂ m
+      have d1 := Nat.div_add_mod a₁ m
+      have d2 := Nat.div_add_mod a₂ m
+      have : a₁ % m = a₂ % m := by rw [ha₁.2, ha₂.2]
       omega
 
 /--
@@ -2903,9 +2981,8 @@ theorem density_from_residues (A : Finset ℕ) (N m k : ℕ)
         simp only [Finset.mem_biUnion, Finset.mem_image, Finset.mem_filter]
         exact ⟨x % m, ⟨x, hx, rfl⟩, hx, rfl⟩)
     · intro r _ s _ hrs
-      ext a
-      simp only [Finset.mem_filter, Finset.mem_inter]
-      intro ⟨⟨_, hr⟩, _, hs⟩
+      simp only [Finset.disjoint_filter]
+      intro a _ hr hs
       exact hrs (hr.symm.trans hs)
   -- Each fiber has ≤ N/m + 1 elements
   have h_fiber : ∀ r ∈ A.image (· % m),
@@ -2955,7 +3032,7 @@ theorem two_prime_density (A : Finset ℕ) (h : hasSquarefreeSumset A) (N : ℕ)
     (hA_sub : A ⊆ Finset.range (N + 1)) :
     A.card ≤ ((p * p - 1) / 2) * ((q * q - 1) / 2) * (N / (p * p * (q * q)) + 1) :=
   density_from_residues A N (p * p * (q * q)) (((p * p - 1) / 2) * ((q * q - 1) / 2))
-    (by have := hp.pos; have := hq.pos; omega) hA_sub (combined_residue_bound A h p q hp hq hpq)
+    (by positivity) hA_sub (combined_residue_bound A h p q hp hq hpq)
 
 /--
 **f(N) is sub-linear (sandwich bounds):**
@@ -2975,7 +3052,7 @@ Per-prime bound for p=11: (121-1)/2 = 60.
 Total: 1152 × 60 = 69120 out of 5336100.
 Density: 69120/5336100 ≈ 1.30%.
 -/
-set_option maxHeartbeats 800000 in
+set_option maxHeartbeats 1600000 in
 theorem mod_5336100_residue_image_le_69120 (A : Finset ℕ) (h : hasSquarefreeSumset A) :
     (A.image (· % 5336100)).card ≤ 69120 := by
   have hbnd : A.image (· % 5336100) ⊆ Finset.range 5336100 := by
@@ -3043,8 +3120,13 @@ theorem mod_5336100_residue_image_le_69120 (A : Finset ℕ) (h : hasSquarefreeSu
     intro p hp
     simp only [Finset.mem_image, Finset.mem_product] at hp ⊢
     obtain ⟨r, ⟨a, ha, rfl⟩, rfl⟩ := hp
-    exact ⟨⟨a, ha, by omega⟩, ⟨a, ha, by omega⟩, ⟨a, ha, by omega⟩,
-           ⟨a, ha, by omega⟩, ⟨a, ha, by omega⟩⟩
+    have hm4 : a % 5336100 % 4 = a % 4 := Nat.mod_mod_of_dvd a (by norm_num : 4 ∣ 5336100)
+    have hm9 : a % 5336100 % 9 = a % 9 := Nat.mod_mod_of_dvd a (by norm_num : 9 ∣ 5336100)
+    have hm25 : a % 5336100 % 25 = a % 25 := Nat.mod_mod_of_dvd a (by norm_num : 25 ∣ 5336100)
+    have hm49 : a % 5336100 % 49 = a % 49 := Nat.mod_mod_of_dvd a (by norm_num : 49 ∣ 5336100)
+    have hm121 : a % 5336100 % 121 = a % 121 := Nat.mod_mod_of_dvd a (by norm_num : 121 ∣ 5336100)
+    exact ⟨⟨a, ha, hm4⟩, ⟨a, ha, hm9⟩, ⟨a, ha, hm25⟩,
+           ⟨a, ha, hm49⟩, ⟨a, ha, hm121⟩⟩
   have h4 := mod_4_residue_image_small A h
   have h9 := mod_9_residue_image_le_4 A h
   have h25 := mod_25_residue_image_le_12 A h
@@ -3356,5 +3438,294 @@ theorem f_ge_eleven (N : ℕ) (hN : N ≥ 181) : f N ≥ 11 := by
     rw [← hA_card]
     exact le_trans (Finset.card_le_card hA_sub) (by simp [Finset.card_range])
   exact le_csSup hbdd h11
+
+-- ============================================================================
+-- Part XI: 12-Element Witness and f(N) >= 12
+-- ============================================================================
+
+-- New squarefree facts for 12-element witness (sums involving 217)
+
+private theorem squarefree_258 : Squarefree (258 : ℕ) := by
+  rw [show (258 : ℕ) = 2 * 129 from by norm_num]
+  have h129 : Squarefree (129 : ℕ) := by
+    rw [show (129 : ℕ) = 3 * 43 from by norm_num]
+    have h43 : Nat.Prime 43 := by native_decide
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, three_prime.squarefree, h43.squarefree⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h129⟩)
+
+private theorem squarefree_290 : Squarefree (290 : ℕ) := by
+  rw [show (290 : ℕ) = 2 * 145 from by norm_num]
+  have h145 : Squarefree (145 : ℕ) := by
+    rw [show (145 : ℕ) = 5 * 29 from by norm_num]
+    have h29 : Nat.Prime 29 := by native_decide
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, five_prime.squarefree, h29.squarefree⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h145⟩)
+
+private theorem squarefree_354 : Squarefree (354 : ℕ) := by
+  rw [show (354 : ℕ) = 2 * 177 from by norm_num]
+  have h177 : Squarefree (177 : ℕ) := by
+    rw [show (177 : ℕ) = 3 * 59 from by norm_num]
+    have h59 : Nat.Prime 59 := by native_decide
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, three_prime.squarefree, h59.squarefree⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h177⟩)
+
+private theorem squarefree_382 : Squarefree (382 : ℕ) := by
+  rw [show (382 : ℕ) = 2 * 191 from by norm_num]
+  have h191 : Nat.Prime 191 := by native_decide
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h191.squarefree⟩)
+
+private theorem squarefree_398 : Squarefree (398 : ℕ) := by
+  rw [show (398 : ℕ) = 2 * 199 from by norm_num]
+  have h199 : Nat.Prime 199 := by native_decide
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h199.squarefree⟩)
+
+private theorem squarefree_434 : Squarefree (434 : ℕ) := by
+  rw [show (434 : ℕ) = 2 * 217 from by norm_num]
+  have h217 : Squarefree (217 : ℕ) := by
+    rw [show (217 : ℕ) = 7 * 31 from by norm_num]
+    have h7 : Nat.Prime 7 := by native_decide
+    have h31 : Nat.Prime 31 := by native_decide
+    exact Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, h7.squarefree, h31.squarefree⟩
+  exact (Nat.squarefree_mul_iff.mpr ⟨by rw [Nat.Coprime]; native_decide, squarefree_2, h217⟩)
+
+/--
+**{1, 5, 21, 37, 41, 65, 73, 101, 137, 165, 181, 217} has a squarefree sumset.**
+All 144 ordered pair sums are squarefree.
+-/
+theorem dodeca_squarefree_sumset :
+    hasSquarefreeSumset ({1, 5, 21, 37, 41, 65, 73, 101, 137, 165, 181, 217} : Finset ℕ) := by
+  intro s hs
+  simp only [sumset, Finset.mem_image, Finset.mem_product, Finset.mem_insert,
+    Finset.mem_singleton] at hs
+  obtain ⟨⟨a, b⟩, ⟨ha, hb⟩, hab⟩ := hs
+  simp only [isSquarefree]
+  rcases ha with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    rcases hb with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    simp at hab <;> rw [← hab]
+  -- Row a=1: 2, 6, 22, 38, 42, 66, 74, 102, 138, 166, 182, 218
+  · exact squarefree_2
+  · exact squarefree_6
+  · exact squarefree_22
+  · exact squarefree_38
+  · exact squarefree_42
+  · exact squarefree_66
+  · exact squarefree_74
+  · exact squarefree_102
+  · exact squarefree_138
+  · exact squarefree_166
+  · exact squarefree_182
+  · exact squarefree_218
+  -- Row a=5
+  · exact squarefree_6
+  · exact squarefree_10
+  · exact squarefree_26
+  · exact squarefree_42
+  · exact squarefree_46
+  · exact squarefree_70
+  · exact squarefree_78
+  · exact squarefree_106
+  · exact squarefree_142
+  · exact squarefree_170
+  · exact squarefree_186
+  · exact squarefree_222
+  -- Row a=21
+  · exact squarefree_22
+  · exact squarefree_26
+  · exact squarefree_42
+  · exact squarefree_58
+  · exact squarefree_62
+  · exact squarefree_86
+  · exact squarefree_94
+  · exact squarefree_122
+  · exact squarefree_158
+  · exact squarefree_186
+  · exact squarefree_202
+  · exact squarefree_238
+  -- Row a=37
+  · exact squarefree_38
+  · exact squarefree_42
+  · exact squarefree_58
+  · exact squarefree_74
+  · exact squarefree_78
+  · exact squarefree_102
+  · exact squarefree_110
+  · exact squarefree_138
+  · exact squarefree_174
+  · exact squarefree_202
+  · exact squarefree_218
+  · exact squarefree_254
+  -- Row a=41
+  · exact squarefree_42
+  · exact squarefree_46
+  · exact squarefree_62
+  · exact squarefree_78
+  · exact squarefree_82
+  · exact squarefree_106
+  · exact squarefree_114
+  · exact squarefree_142
+  · exact squarefree_178
+  · exact squarefree_206
+  · exact squarefree_222
+  · exact squarefree_258
+  -- Row a=65
+  · exact squarefree_66
+  · exact squarefree_70
+  · exact squarefree_86
+  · exact squarefree_102
+  · exact squarefree_106
+  · exact squarefree_130
+  · exact squarefree_138
+  · exact squarefree_166
+  · exact squarefree_202
+  · exact squarefree_230
+  · exact squarefree_246
+  · exact squarefree_282
+  -- Row a=73
+  · exact squarefree_74
+  · exact squarefree_78
+  · exact squarefree_94
+  · exact squarefree_110
+  · exact squarefree_114
+  · exact squarefree_138
+  · exact squarefree_146
+  · exact squarefree_174
+  · exact squarefree_210
+  · exact squarefree_238
+  · exact squarefree_254
+  · exact squarefree_290
+  -- Row a=101
+  · exact squarefree_102
+  · exact squarefree_106
+  · exact squarefree_122
+  · exact squarefree_138
+  · exact squarefree_142
+  · exact squarefree_166
+  · exact squarefree_174
+  · exact squarefree_202
+  · exact squarefree_238
+  · exact squarefree_266
+  · exact squarefree_282
+  · exact squarefree_318
+  -- Row a=137
+  · exact squarefree_138
+  · exact squarefree_142
+  · exact squarefree_158
+  · exact squarefree_174
+  · exact squarefree_178
+  · exact squarefree_202
+  · exact squarefree_210
+  · exact squarefree_238
+  · exact squarefree_274
+  · exact squarefree_302
+  · exact squarefree_318
+  · exact squarefree_354
+  -- Row a=165
+  · exact squarefree_166
+  · exact squarefree_170
+  · exact squarefree_186
+  · exact squarefree_202
+  · exact squarefree_206
+  · exact squarefree_230
+  · exact squarefree_238
+  · exact squarefree_266
+  · exact squarefree_302
+  · exact squarefree_330
+  · exact squarefree_346
+  · exact squarefree_382
+  -- Row a=181
+  · exact squarefree_182
+  · exact squarefree_186
+  · exact squarefree_202
+  · exact squarefree_218
+  · exact squarefree_222
+  · exact squarefree_246
+  · exact squarefree_254
+  · exact squarefree_282
+  · exact squarefree_318
+  · exact squarefree_346
+  · exact squarefree_362
+  · exact squarefree_398
+  -- Row a=217
+  · exact squarefree_218
+  · exact squarefree_222
+  · exact squarefree_238
+  · exact squarefree_254
+  · exact squarefree_258
+  · exact squarefree_282
+  · exact squarefree_290
+  · exact squarefree_318
+  · exact squarefree_354
+  · exact squarefree_382
+  · exact squarefree_398
+  · exact squarefree_434
+
+/--
+**f(N) >= 12 for N >= 217:**
+-/
+theorem f_ge_twelve (N : ℕ) (hN : N ≥ 217) : f N ≥ 12 := by
+  unfold f
+  have h12 : (12 : ℕ) ∈ {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
+    simp only [Set.mem_setOf_eq]
+    refine ⟨{1, 5, 21, 37, 41, 65, 73, 101, 137, 165, 181, 217}, ?_, dodeca_squarefree_sumset, ?_⟩
+    · intro x hx
+      simp [Finset.mem_insert, Finset.mem_singleton] at hx
+      simp [Finset.mem_range]
+      rcases hx with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;> omega
+    · native_decide
+  have hbdd : BddAbove {m : ℕ | ∃ A : Finset ℕ, A ⊆ range (N + 1) ∧ hasSquarefreeSumset A ∧ A.card = m} := by
+    use N + 1
+    intro m hm
+    simp only [Set.mem_setOf_eq] at hm
+    obtain ⟨A, hA_sub, _, hA_card⟩ := hm
+    rw [← hA_card]
+    exact le_trans (Finset.card_le_card hA_sub) (by simp [Finset.card_range])
+  exact le_csSup hbdd h12
+
+-- ============================================================================
+-- Part XII: Sub-Linear Upper Bound
+-- ============================================================================
+
+/--
+**Sub-linear upper bound:** f(N) ≤ N/77 + 69120.
+From the 5-prime CRT density: 69120/5336100 < 1/77.
+-/
+theorem f_sublinear (A : Finset ℕ) (h : hasSquarefreeSumset A) (N : ℕ)
+    (hA_sub : A ⊆ Finset.range (N + 1)) :
+    A.card ≤ N / 77 + 69120 := by
+  have h5 := f_upper_5336100 A h N hA_sub
+  have h_key : 69120 * (N / 5336100) ≤ N / 77 := by
+    set k := N / 5336100
+    have hk : k * 5336100 ≤ N := Nat.div_mul_le_self N 5336100
+    have step1 : 69120 * k ≤ 5336100 * k / 77 := by
+      have : 69120 * k * 77 ≤ 5336100 * k := by nlinarith [show 69120 * 77 ≤ 5336100 from by norm_num]
+      omega
+    have step2 : 5336100 * k / 77 ≤ N / 77 := Nat.div_le_div_right (by linarith)
+    linarith
+  calc A.card
+      ≤ 69120 * (N / 5336100 + 1) := h5
+    _ = 69120 * (N / 5336100) + 69120 := by ring
+    _ ≤ N / 77 + 69120 := Nat.add_le_add_right h_key _
+
+/--
+**Complete bounds:** 12 ≤ f(N) ≤ N/77 + 69120 for large N.
+-/
+theorem f_complete_bounds (N : ℕ) (hN : N ≥ 5322240) :
+    12 ≤ f N ∧
+    ∀ (A : Finset ℕ), hasSquarefreeSumset A → A ⊆ Finset.range (N + 1) →
+      A.card ≤ N / 77 + 69120 :=
+  ⟨f_ge_twelve N (by omega), fun A h hA_sub => f_sublinear A h N hA_sub⟩
+
+/--
+**Lower bound chain:** f(1) ≥ 1, ..., f(217) ≥ 12.
+-/
+theorem f_lower_bound_chain :
+    f 1 ≥ 1 ∧ f 5 ≥ 2 ∧ f 21 ≥ 3 ∧ f 37 ≥ 4 ∧ f 41 ≥ 5 ∧
+    f 65 ≥ 6 ∧ f 73 ≥ 7 ∧ f 101 ≥ 8 ∧ f 137 ≥ 9 ∧ f 165 ≥ 10 ∧
+    f 181 ≥ 11 ∧ f 217 ≥ 12 :=
+  ⟨f_ge_one 1 (by omega), f_ge_two 5 (by omega), f_ge_three 21 (by omega),
+   f_ge_four 37 (by omega), f_ge_five 41 (by omega), f_ge_six 65 (by omega),
+   f_ge_seven 73 (by omega), f_ge_eight 101 (by omega), f_ge_nine 137 (by omega),
+   f_ge_ten 165 (by omega), f_ge_eleven 181 (by omega), f_ge_twelve 217 (by omega)⟩
+
 
 end Erdos1109


### PR DESCRIPTION
## Summary
Research iteration 8 for Erdős Problem #1109 (Squarefree Sumsets). Extends lower bounds from f(N) >= 11 to f(N) >= 12 and adds complete bound summary.

## Progress
- Added 5 missing squarefree lemma definitions (158, 178, 210, 238, 274) that were used but undefined
- Proved f(N) >= 9 via subset of the 10-element witness (filling a gap in the chain)
- Found and proved 12-element squarefree sumset witness: {1, 5, 21, 37, 41, 65, 73, 101, 137, 165, 181, 217}
- Added 6 new squarefree facts for the 12-element witness sums (258, 290, 354, 382, 398, 434)
- Proved f(N) >= 12 for N >= 217
- Added f_sublinear theorem: f(N) <= N/77 + 69120 from 5-prime CRT density
- Added f_complete_bounds: 12 <= f(N) <= N/77 + 69120 for large N
- Added f_lower_bound_chain combining all 12 lower bounds in one theorem

## Findings
- 12-element witness {1,5,21,37,41,65,73,101,137,165,181,217} all == 1 (mod 4), all pairwise sums squarefree
- Complete lower bound chain: f(1)>=1, f(5)>=2, ..., f(217)>=12
- Sub-linear upper bound: f(N) <= N/77 + 69120 (from 5-prime CRT density product)

## Status
**Outcome**: progress
**Next Steps**: Find 13+ element witnesses, extend CRT to 6+ primes, connect to Konyagin upper bound

🤖 Generated by researcher-1