### PR TITLE
enrich(erdos-1117): deepen annotations and meta for maximum modulus points on circles

### DIFF
--- a/src/data/proofs/erdos-1117/annotations.json
+++ b/src/data/proofs/erdos-1117/annotations.json
@@ -1,56 +1,122 @@
 [
   {
-    "id": "max-modulus",
+    "id": "ann-1117-imports",
     "proofId": "erdos-1117",
-    "range": { "startLine": 34, "endLine": 35 },
+    "range": { "startLine": 22, "endLine": 24 },
+    "type": "concept",
+    "title": "Imports",
+    "content": "Imports Mathlib's complex analysis basics (`Complex.abs`, `Complex.ofReal`), topology infrastructure, and the tactic library. Notably, the formalization uses `Mathlib.Analysis.Complex.Basic` rather than the full Mathlib import, indicating targeted dependency on complex number operations.",
+    "mathContext": "Provides the `Complex.abs` function implementing $|z| = \\sqrt{(\\Re z)^2 + (\\Im z)^2}$ and basic complex arithmetic.",
+    "significance": "supporting",
+    "relatedConcepts": ["complex analysis", "Mathlib", "topology"],
+    "prerequisites": ["Lean 4", "Mathlib"]
+  },
+  {
+    "id": "ann-1117-is-entire",
+    "proofId": "erdos-1117",
+    "range": { "startLine": 28, "endLine": 29 },
+    "type": "concept",
+    "title": "IsEntire — Entire Function Predicate",
+    "content": "Declares `IsEntire` as an axiom: a predicate asserting that $f : \\mathbb{C} \\to \\mathbb{C}$ is holomorphic on all of $\\mathbb{C}$. Entire functions form the natural domain for this problem — they include polynomials, exponentials, and trigonometric functions. The axiomatization avoids the complexity of formalizing differentiability conditions in Lean while preserving the logical structure.",
+    "mathContext": "$f$ is entire if $f$ is holomorphic on $\\mathbb{C}$, i.e., $f'(z)$ exists for all $z \\in \\mathbb{C}$.",
+    "significance": "key",
+    "relatedConcepts": ["holomorphic functions", "Liouville's theorem", "entire functions of finite order"],
+    "prerequisites": ["complex differentiability", "analytic functions"]
+  },
+  {
+    "id": "ann-1117-is-monomial",
+    "proofId": "erdos-1117",
+    "range": { "startLine": 32, "endLine": 33 },
     "type": "definition",
-    "title": "Maximum Modulus M(r)",
-    "content": "M(r) = max_{|z|=r} |f(z)|, the maximum of |f| on the circle of radius r. By the maximum modulus principle, this is increasing for nonconstant entire functions.",
-    "significance": "high"
+    "title": "IsMonomial — Monomial Predicate",
+    "content": "A function is a monomial if $f(z) = cz^n$ for some constant $c \\in \\mathbb{C}$ and non-negative integer $n$. Monomials are the trivial case for Problem 1117: since $|cz^n| = |c| \\cdot r^n$ on $|z| = r$, **every** point on the circle is a maximum modulus point, making $\\nu(r) = \\infty$. The problem therefore restricts to non-monomial entire functions.",
+    "mathContext": "$f$ is a monomial if $f(z) = cz^n$ for some $c \\in \\mathbb{C}$, $n \\in \\mathbb{N}$. Then $|f(z)| = |c| r^n$ for $|z| = r$, so every point achieves the maximum.",
+    "significance": "key",
+    "relatedConcepts": ["monomials", "rotational symmetry", "maximum modulus principle"],
+    "prerequisites": ["polynomial functions", "complex absolute value"]
   },
   {
-    "id": "nu-function",
+    "id": "ann-1117-max-modulus",
     "proofId": "erdos-1117",
-    "range": { "startLine": 41, "endLine": 42 },
+    "range": { "startLine": 35, "endLine": 40 },
     "type": "definition",
-    "title": "Counting Function ν(r)",
-    "content": "ν(r) counts the number of points on |z|=r where |f(z)| = M(r). For non-monomials, this is always finite. The problem asks how it grows.",
-    "significance": "high"
+    "title": "maxModulus — The Maximum Modulus Function M(r)",
+    "content": "Defines $M(r) = \\max_{|z|=r} |f(z)|$, the maximum of $|f|$ on the circle of radius $r$. This is a fundamental object in complex analysis — by the maximum modulus principle, if $f$ is nonconstant, then $|f|$ cannot attain its maximum in the interior, so $M(r)$ captures the boundary behavior. The Hadamard three-circles theorem shows that $\\log M(r)$ is a convex function of $\\log r$.",
+    "mathContext": "$M(r) = \\sup \\{ |f(z)| : |z| = r \\} = \\max_{|z|=r} |f(z)|$, where the max exists since the circle is compact.",
+    "significance": "critical",
+    "relatedConcepts": ["maximum modulus principle", "Hadamard three-circles theorem", "Wiman–Valiron theory", "order of growth"],
+    "prerequisites": ["complex analysis", "supremum on compact sets"]
   },
   {
-    "id": "nu-finite",
+    "id": "ann-1117-nu-function",
     "proofId": "erdos-1117",
-    "range": { "startLine": 50, "endLine": 52 },
+    "range": { "startLine": 42, "endLine": 48 },
+    "type": "definition",
+    "title": "nu — Counting Function ν(r)",
+    "content": "The counting function $\\nu(r) = \\#\\{z : |z| = r,\\, |f(z)| = M(r)\\}$ counts maximum modulus points on the circle of radius $r$. Formalized using `Nat.card` of the set of $z$ on the circle where $|f|$ achieves its maximum. For non-monomials, the set $\\{z : |f(z)| = M(r)\\}$ intersected with the circle is a finite set (since $|f(z)| - M(r)$ has isolated zeros on the circle), so $\\nu(r)$ is a well-defined natural number.",
+    "mathContext": "$\\nu(r) = \\#\\{ z \\in \\mathbb{C} : |z| = r \\text{ and } |f(z)| = M(r) \\}$",
+    "significance": "critical",
+    "relatedConcepts": ["maximum modulus points", "isolated zeros", "finite intersections"],
+    "prerequisites": ["cardinality", "zeros of analytic functions"]
+  },
+  {
+    "id": "ann-1117-nu-finite",
+    "proofId": "erdos-1117",
+    "range": { "startLine": 52, "endLine": 59 },
     "type": "theorem",
-    "title": "Finiteness of ν(r)",
-    "content": "For non-monomial entire functions, the maximum modulus is achieved at finitely many points on each circle. This is because |f(z)| - M(r) has finitely many zeros on |z|=r.",
-    "significance": "medium"
+    "title": "Finiteness and Existence of Maximum Points",
+    "content": "Two basic properties: (1) `nu_finite` — for non-monomial entire functions, $\\nu(r) < \\infty$ for each $r > 0$, because the function $\\theta \\mapsto |f(re^{i\\theta})|$ is real-analytic and non-constant, so it achieves its maximum at finitely many points; (2) `nu_ge_one` — for any entire function, $\\nu(r) \\ge 1$ because the circle $|z| = r$ is compact and $|f|$ is continuous, so the maximum is always attained.",
+    "mathContext": "For non-monomial $f$: $1 \\le \\nu(r) < \\infty$ for all $r > 0$. The finiteness follows from the identity theorem applied to $|f(re^{i\\theta})| - M(r)$.",
+    "significance": "key",
+    "relatedConcepts": ["identity theorem", "real-analytic functions", "compactness", "extreme value theorem"],
+    "prerequisites": ["maximum modulus principle", "compactness of circles"]
   },
   {
-    "id": "herzog-piranian",
+    "id": "ann-1117-herzog-piranian",
     "proofId": "erdos-1117",
-    "range": { "startLine": 60, "endLine": 63 },
+    "range": { "startLine": 63, "endLine": 68 },
     "type": "theorem",
-    "title": "Herzog–Piranian: lim sup = ∞ (1968)",
-    "content": "There exists a non-monomial entire function with lim sup ν(r) = ∞. For every N, there are arbitrarily large r with ν(r) ≥ N. This answers Question 1 affirmatively.",
-    "significance": "high"
+    "title": "Herzog–Piranian (1968): lim sup ν(r) = ∞",
+    "content": "Fritz Herzog and George Piranian (1968) resolved Question 1 affirmatively: there exists a non-monomial entire function $f$ such that $\\limsup_{r \\to \\infty} \\nu(r) = \\infty$. The formalization states this as: for every $N \\in \\mathbb{N}$, there exists such an $f$ and arbitrarily large $r$ with $\\nu(r) \\ge N$. The construction uses a carefully chosen lacunary series where the dominant term rotates to create many near-maximum points.",
+    "mathContext": "$\\exists f \\text{ entire, non-monomial}: \\limsup_{r \\to \\infty} \\nu(r) = \\infty$, i.e., $\\forall N,\\, \\forall R,\\, \\exists r > R : \\nu(r) \\ge N$.",
+    "significance": "critical",
+    "relatedConcepts": ["lacunary series", "Wiman–Valiron theory", "central index", "entire functions of infinite order"],
+    "prerequisites": ["entire functions", "limit superior"]
   },
   {
-    "id": "lim-inf-open",
+    "id": "ann-1117-lim-inf-open",
     "proofId": "erdos-1117",
-    "range": { "startLine": 69, "endLine": 73 },
-    "type": "conjecture",
-    "title": "Open: lim inf ν(r) = ∞?",
-    "content": "Can lim inf ν(r) = ∞ for a non-monomial entire function? This is the key open question of Problem #1117. It asks whether ν(r) can eventually always be large, not just occasionally.",
-    "significance": "high"
+    "range": { "startLine": 72, "endLine": 79 },
+    "type": "insight",
+    "title": "Open Question: lim inf ν(r) = ∞?",
+    "content": "The central open question of Problem 1117: does there exist a non-monomial entire function with $\\liminf_{r \\to \\infty} \\nu(r) = \\infty$? This is much harder than the $\\limsup$ case because it requires $\\nu(r)$ to be eventually large for **all** sufficiently large $r$, not just along a subsequence. The formalization encodes this as a disjunction: either such a function exists, or for every non-monomial entire $f$, there is a bound $N$ such that $\\nu(r) < N$ infinitely often.",
+    "mathContext": "Open: $\\exists f \\text{ entire, non-monomial}: \\liminf_{r \\to \\infty} \\nu(r) = \\infty$? Equivalently: $\\forall N,\\, \\exists R,\\, \\forall r > R : \\nu(r) \\ge N$.",
+    "significance": "critical",
+    "relatedConcepts": ["limit inferior", "eventual properties", "value distribution theory"],
+    "prerequisites": ["limit inferior vs limit superior", "entire functions"]
   },
   {
-    "id": "glucksam-pardo-simon",
+    "id": "ann-1117-glucksam-pardo-simon",
     "proofId": "erdos-1117",
-    "range": { "startLine": 79, "endLine": 84 },
+    "range": { "startLine": 87, "endLine": 92 },
     "type": "theorem",
-    "title": "Glücksam–Pardo-Simón Approximate Result (2024)",
-    "content": "An approximate affirmative answer: there exist entire functions with many points achieving (1-ε) · M(r) for all large r. The gap between (1-ε)·M(r) and M(r) is the remaining difficulty.",
-    "significance": "high"
+    "title": "Glücksam–Pardo-Simón (2024): Approximate Answer",
+    "content": "Adi Glücksam and Leticia Pardo-Simón (2024) provided an **approximate** affirmative answer: for every $\\varepsilon > 0$ and $N \\in \\mathbb{N}$, there exists an entire function $f$ such that for all sufficiently large $r$, there are at least $N$ points on $|z| = r$ where $|f(z)| \\ge (1 - \\varepsilon) M(r)$. The gap between $(1-\\varepsilon)M(r)$ and the exact maximum $M(r)$ is the remaining difficulty — closing this gap would resolve the open problem.",
+    "mathContext": "$\\forall \\varepsilon > 0,\\, \\forall N,\\, \\exists f \\text{ entire}: \\forall r \\gg 1,\\, \\exists z_1, \\ldots, z_N \\text{ on } |z|=r : |f(z_k)| \\ge (1-\\varepsilon) M(r)$.",
+    "significance": "critical",
+    "relatedConcepts": ["approximate maximum", "near-maximum points", "quantitative complex analysis"],
+    "prerequisites": ["maximum modulus", "epsilon-approximation"]
+  },
+  {
+    "id": "ann-1117-hadamard",
+    "proofId": "erdos-1117",
+    "range": { "startLine": 96, "endLine": 100 },
+    "type": "theorem",
+    "title": "maxModulus_nondecreasing — Monotonicity of M(r)",
+    "content": "The maximum modulus $M(r)$ is a nondecreasing function of $r$ for nonconstant entire functions. This follows from the maximum modulus principle: if $|f|$ achieves value $M(r_1)$ at some point on $|z| = r_1$, then on the larger disc $|z| \\le r_2$ (with $r_2 \\ge r_1$), the maximum of $|f|$ can only increase. Moreover, by Hadamard's three-circles theorem, $\\log M(r)$ is a convex function of $\\log r$.",
+    "mathContext": "$0 < r_1 \\le r_2 \\implies M(r_1) \\le M(r_2)$ for nonconstant entire $f$. Furthermore, $\\log M(e^t)$ is convex in $t$.",
+    "significance": "key",
+    "relatedConcepts": ["maximum modulus principle", "Hadamard three-circles theorem", "log-convexity"],
+    "prerequisites": ["maximum modulus principle", "convex functions"]
   }
 ]

--- a/src/data/proofs/erdos-1117/meta.json
+++ b/src/data/proofs/erdos-1117/meta.json
@@ -6,6 +6,7 @@
   "meta": {
     "erdosNumber": 1117,
     "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos1117Problem.lean",
     "tags": [
       "erdos",
       "complex-analysis",
@@ -23,65 +24,68 @@
     "leanFile": "Proofs/Erdos1117Problem.lean",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/1117",
-    "erdosUrl": "https://erdosproblems.com/1117"
+    "erdosUrl": "https://erdosproblems.com/1117",
+    "erdosProblemStatus": "open",
+    "badge": "pending"
   },
   "sections": [
     {
       "id": "core-definitions",
       "title": "Core Definitions",
-      "startLine": 24,
-      "endLine": 46,
-      "summary": "Define IsEntire, IsMonomial, maxModulus M(r), and ν(r)."
+      "startLine": 22,
+      "endLine": 48,
+      "summary": "Defines the foundational objects: `IsEntire` (entire function predicate), `IsMonomial` ($f(z) = cz^n$), the maximum modulus $M(r) = \\max_{|z|=r} |f(z)|$ via `maxModulus`, and the counting function $\\nu(r) = \\#\\{z : |z|=r,\\, |f(z)|=M(r)\\}$ via `nu`. All core definitions are axiomatized except `IsMonomial`."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "startLine": 48,
-      "endLine": 55,
-      "summary": "ν(r) is finite for non-monomials and ≥ 1 for all entire functions."
+      "startLine": 50,
+      "endLine": 59,
+      "summary": "States that $1 \\le \\nu(r) < \\infty$ for non-monomial entire functions: finiteness from the identity theorem (the real-analytic function $\\theta \\mapsto |f(re^{i\\theta})|$ has finitely many maxima), and existence from compactness of the circle."
     },
     {
       "id": "question-1",
-      "title": "Question 1: lim sup (Solved)",
-      "startLine": 57,
-      "endLine": 63,
-      "summary": "Herzog–Piranian (1968): lim sup ν(r) = ∞ is possible."
+      "title": "Question 1: lim sup ν(r) = ∞ (Solved)",
+      "startLine": 61,
+      "endLine": 68,
+      "summary": "The solved part: Herzog–Piranian (1968) showed $\\limsup_{r \\to \\infty} \\nu(r) = \\infty$ is achievable. Formalized as: for every $N$, there exists a non-monomial entire $f$ and arbitrarily large $r$ with $\\nu(r) \\ge N$."
     },
     {
       "id": "question-2",
-      "title": "Question 2: lim inf (Open)",
-      "startLine": 65,
-      "endLine": 73,
-      "summary": "Can lim inf ν(r) = ∞? This is the open question."
+      "title": "Question 2: lim inf ν(r) = ∞ (Open)",
+      "startLine": 70,
+      "endLine": 79,
+      "summary": "The open part: can $\\liminf_{r \\to \\infty} \\nu(r) = \\infty$ for a non-monomial entire function? Formalized as a disjunction — either such $f$ exists, or every non-monomial has $\\nu(r)$ bounded infinitely often."
     },
     {
       "id": "approximate-context",
-      "title": "Approximate Result and Context",
-      "startLine": 75,
-      "endLine": 92,
-      "summary": "Glücksam–Pardo-Simón (2024) approximate result. Hadamard context."
+      "title": "Approximate Result and Hadamard Context",
+      "startLine": 81,
+      "endLine": 100,
+      "summary": "Glücksam–Pardo-Simón (2024): for any $\\varepsilon > 0$ and $N$, there exists entire $f$ with $N$ points achieving $(1-\\varepsilon)M(r)$ for all large $r$. Also states monotonicity of $M(r)$ from the maximum modulus principle and the Hadamard three-circles theorem."
     }
   ],
   "overview": {
-    "historicalContext": "This problem appears as Problem 2.16 in Hayman's 1974 collection, attributed to Erdős. It studies the distribution of maximum modulus points of entire functions on circles. For monomials, every point is a maximum point. For other entire functions, the maximum is achieved at finitely many points, and the question is how this count grows with the radius.",
-    "problemStatement": "For a non-monomial entire function f, let ν(r) count the points on |z|=r where |f(z)| = M(r). Can lim inf ν(r) = ∞?",
-    "proofStrategy": "We formalize entire functions, maximum modulus, the counting function ν(r), and state the two questions. The first (lim sup) was solved by Herzog–Piranian (1968). The second (lim inf) remains open, with an approximate answer by Glücksam–Pardo-Simón (2024).",
+    "historicalContext": "**Maximum Modulus Points and Erdős's Question (1974)**\n\nThis problem appears as Problem 2.16 in W. K. Hayman's influential 1974 collection *\"Research Problems in Function Theory\"*, attributed to Paul Erdős. It belongs to a rich tradition of studying the **maximum modulus function** $M(r) = \\max_{|z|=r} |f(z)|$ of entire functions, dating back to the foundational work of Jacques Hadamard (1896), Anders Wiman (1903), and Gábor Szegő (1920s).\n\nThe maximum modulus principle — that a nonconstant holomorphic function cannot attain its maximum in the interior of its domain — implies that $M(r)$ captures essential boundary behavior. For monomials $f(z) = cz^n$, the modulus $|f(z)| = |c|r^n$ is constant on each circle, so every point is a maximum point. For any other entire function, the maximum is achieved at only finitely many points on each circle.\n\nFritz Herzog and George Piranian (1968) answered the first question: they constructed an entire function with $\\limsup_{r \\to \\infty} \\nu(r) = \\infty$, using lacunary power series whose dominant term rotates, creating many near-maximum points at specific radii. The much harder second question — whether $\\liminf \\nu(r) = \\infty$ is possible — has resisted attack for over 50 years.\n\nIn 2024, Adi Glücksam (Tel Aviv University) and Leticia Pardo-Simón provided the closest approach yet: they showed that for every $\\varepsilon > 0$, one can construct entire functions with many points achieving at least $(1-\\varepsilon) M(r)$ on every sufficiently large circle. Closing the gap from $(1-\\varepsilon)M(r)$ to the exact maximum $M(r)$ remains the key challenge.",
+    "problemStatement": "For a non-monomial entire function $f$, let $\\nu(r) = \\#\\{z : |z| = r,\\, |f(z)| = M(r)\\}$ count the maximum modulus points on the circle of radius $r$.\n\n**Question 1** (Solved): Can $\\limsup_{r \\to \\infty} \\nu(r) = \\infty$? **YES** — Herzog–Piranian (1968).\n\n**Question 2** (Open): Can $\\liminf_{r \\to \\infty} \\nu(r) = \\infty$?\n\n**Approximate answer**: YES in the $(1-\\varepsilon)$ sense — Glücksam–Pardo-Simón (2024).",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Axiomatized primitives**: `IsEntire`, `maxModulus`, and `nu` are declared as axioms rather than fully formalized, since Lean's Mathlib does not yet have a complete theory of entire functions. The logical relationships between them are faithfully captured.\n\n2. **Concrete definition**: `IsMonomial` is the one fully-defined predicate ($f(z) = cz^n$), providing the boundary case where $\\nu(r) = \\infty$.\n\n3. **Three main results**: The Herzog–Piranian theorem (1968), the open question as a disjunction, and the Glücksam–Pardo-Simón approximate result (2024) are each stated as axioms with their precise quantifier structure.\n\n4. **Supporting context**: Monotonicity of $M(r)$ from the maximum modulus principle, and the connection to Hadamard's three-circles theorem.",
     "keyInsights": [
-      "For monomials cz^n, every point on |z|=r achieves the maximum — ν(r) is infinite",
-      "For non-monomials, ν(r) is finite but can be arbitrarily large on some circles",
-      "Herzog–Piranian (1968): lim sup ν(r) = ∞ is achievable",
-      "The lim inf question asks whether ν(r) can eventually always be large",
-      "Glücksam–Pardo-Simón (2024): approximate affirmative (near-maximum at many points)"
+      "**Monomials as the degenerate case**: For $f(z) = cz^n$, the modulus $|f(z)| = |c|r^n$ is constant on $|z| = r$, so $\\nu(r) = \\infty$. Non-monomials break this rotational symmetry, making $\\nu(r)$ finite. The problem asks how badly the symmetry can be broken while keeping many maximum points.",
+      "**The lim sup vs lim inf gap**: $\\limsup \\nu(r) = \\infty$ means $\\nu(r)$ is occasionally large (along a subsequence of radii). $\\liminf \\nu(r) = \\infty$ means $\\nu(r)$ is eventually always large. The gap between 'occasionally' and 'always' is the fundamental difficulty — occasional large values can be achieved by engineering the power series to create resonance at specific radii.",
+      "**Wiman–Valiron theory connection**: The maximum modulus theory for entire functions is closely linked to Wiman–Valiron theory, which describes the behavior of $f$ near points where $|f|$ is maximal in terms of the **central index** $N(r)$ (the index of the dominant term in the power series). The central index controls the local geometry of maximum modulus points.",
+      "**The $(1-\\varepsilon)$ barrier**: Glücksam and Pardo-Simón showed that **near**-maximum points ($|f(z)| \\ge (1-\\varepsilon)M(r)$) can be made plentiful on every circle. But the exact maximum is achieved on a measure-zero subset of the circle, and perturbing from near-maximum to exact maximum requires fundamentally different techniques.",
+      "**No sorry's — pure axiomatization**: Unusually for this gallery, the file has 0 sorry's because all mathematical content is axiomatized rather than proved. This reflects the current state of Lean's complex analysis library — entire function theory is not yet formalized enough for constructive proofs."
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #1117 has two parts: (1) can lim sup ν(r) = ∞? — YES, by Herzog–Piranian (1968); (2) can lim inf ν(r) = ∞? — OPEN, with an approximate affirmative by Glücksam–Pardo-Simón (2024). The gap between exact and approximate maximum remains the key difficulty.",
-    "implications": "A resolution would advance our understanding of the geometry of maximum modulus sets for entire functions, connecting to classical value distribution theory and the structure of level sets in complex analysis.",
+    "summary": "Erdős Problem #1117 formalizes a two-part question about the growth of maximum modulus point counts on circles for non-monomial entire functions. Part 1 ($\\limsup \\nu(r) = \\infty$) was solved by Herzog–Piranian in 1968 via lacunary series constructions. Part 2 ($\\liminf \\nu(r) = \\infty$) remains open after more than 50 years, with the best partial result being the 2024 approximate answer by Glücksam–Pardo-Simón showing that near-maximum points can be made abundant on every circle.",
+    "implications": "**Theoretical Significance**\n\n1. **Value distribution theory**: A resolution would advance the classical theory of Nevanlinna, Ahlfors, and Hayman on how entire functions distribute their values, specifically the geometric structure of level sets.\n\n2. **Wiman–Valiron theory extensions**: The problem is intimately connected to how the central index $N(r)$ controls the angular distribution of maximum modulus points, potentially requiring new asymptotic techniques.\n\n3. **Approximation theory**: Understanding the distribution of maximum points connects to best polynomial approximation on circles and the theory of Chebyshev-like extremal problems.\n\n4. **Ergodic aspects**: The $\\liminf$ question has an ergodic flavor — asking whether a property that holds 'infinitely often' (as in the $\\limsup$ result) can be upgraded to 'eventually always'. This connects to density and recurrence phenomena in dynamical systems.",
     "openQuestions": [
-      "Can lim inf ν(r) = ∞ for a non-monomial entire function?",
-      "Can the Glücksam–Pardo-Simón approximate result be made exact?",
-      "What is the typical behavior of ν(r) for 'generic' entire functions?",
-      "How does ν(r) relate to the order and type of the entire function?"
+      "Can $\\liminf_{r \\to \\infty} \\nu(r) = \\infty$ for a non-monomial entire function, or is there an intrinsic obstruction?",
+      "Can the Glücksam–Pardo-Simón $(1-\\varepsilon)$ approximate result be strengthened to the exact maximum?",
+      "What is the typical behavior of $\\nu(r)$ for 'generic' entire functions of given order $\\rho$?",
+      "How does the order of growth of $f$ constrain the growth of $\\nu(r)$? Is there a relationship between $\\nu(r)$ and the central index $N(r)$?",
+      "For the Herzog–Piranian construction, what is the density of radii $r$ where $\\nu(r) \\ge N$?"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Enrichment pass for erdos-1117 (Erdős Problem #1117: Maximum Modulus Points on Circles).

- Added `mathContext` (LaTeX) to all 10 annotations (was 0/6)
- Added `relatedConcepts` and `prerequisites` to every annotation
- Expanded from 6 to 10 annotations covering full Lean file
- Fixed invalid `significance` values (high/medium → critical/key/supporting)
- Fixed invalid annotation type "conjecture" → "insight"
- Added `proofRepoPath` and `badge` fields to meta
- Deepened `historicalContext` (900+ chars) with Hayman, Hadamard, Wiman, Szegő
- Enriched `keyInsights` (5 items) with Wiman–Valiron theory, (1-ε) barrier analysis
- Added LaTeX to all 5 section summaries
- Expanded conclusion with Nevanlinna theory, ergodic aspects, approximation theory
- Added 5 specific `openQuestions`

## Test plan
- [x] `pnpm annotations:build` passes (only expected axiom/theorem mismatch warning)
- [x] JSON structure validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)