### PR TITLE
enrich(erdos-118): deepen annotations and meta for partition ordinals & higher cliques

### DIFF
--- a/src/data/proofs/erdos-118/annotations.json
+++ b/src/data/proofs/erdos-118/annotations.json
@@ -1,65 +1,134 @@
 [
   {
-    "id": "ord-partition",
+    "id": "ann-118-imports",
     "proofId": "erdos-118",
-    "range": { "startLine": 28, "endLine": 29 },
+    "range": { "startLine": 20, "endLine": 22 },
+    "type": "concept",
+    "title": "Imports — Ordinal Arithmetic",
+    "content": "Imports Mathlib's ordinal arithmetic and cardinal number modules. The key dependency is `Ordinal.Arithmetic`, which provides ordinal exponentiation ($\\omega^\\alpha$), the Cantor Normal Form, and basic ordinal arithmetic — all essential for defining the counterexample ordinal $\\omega^{\\omega^2}$.",
+    "mathContext": "Provides `Ordinal.omega`, `Ordinal.omega ^ α`, and ordinal comparison operations needed to define $\\omega^{\\omega^2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ordinal arithmetic", "Cantor Normal Form", "cardinal numbers"],
+    "prerequisites": ["Lean 4", "Mathlib ordinal library"]
+  },
+  {
+    "id": "ann-118-ord-partition",
+    "proofId": "erdos-118",
+    "range": { "startLine": 26, "endLine": 29 },
+    "type": "concept",
+    "title": "ordPartition — Ordinal Partition Relation",
+    "content": "Axiomatizes the **ordinal partition relation** $\\alpha \\to (\\alpha, k)^2$: for any 2-coloring of the pairs $[\\alpha]^2$, there is either a homogeneous red set of order type $\\alpha$ or a blue complete subgraph on $k$ vertices. This is the ordinal generalization of the finite Ramsey relation $n \\to (m, k)^2$, introduced by Erdős and Rado in 1956 as part of their partition calculus for infinite cardinals and ordinals.",
+    "mathContext": "$\\alpha \\to (\\alpha, k)^2$ means: for every $c : [\\alpha]^2 \\to \\{0, 1\\}$, either $\\exists H \\subseteq \\alpha$ of order type $\\alpha$ with $c|_{[H]^2} \\equiv 0$, or $\\exists K \\subseteq \\alpha$ with $|K| = k$ and $c|_{[K]^2} \\equiv 1$.",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey theory", "partition calculus", "Erdős–Rado theorem", "ordinal Ramsey numbers"],
+    "prerequisites": ["ordinals", "2-colorings", "Ramsey theory basics"]
+  },
+  {
+    "id": "ann-118-is-partition-ord",
+    "proofId": "erdos-118",
+    "range": { "startLine": 31, "endLine": 33 },
     "type": "definition",
-    "title": "Ordinal Partition Relation",
-    "content": "α → (α, k)²: for any 2-coloring of pairs from α, there is either a red set of order type α or a blue k-clique. This extends Ramsey theory to infinite ordinals.",
-    "significance": "high"
+    "title": "IsPartitionOrd — Partition Ordinal Predicate",
+    "content": "A wrapper defining when ordinal $\\alpha$ is a **partition ordinal for $k$-cliques**: $\\alpha$ satisfies $\\alpha \\to (\\alpha, k)^2$. The classical theory shows that $\\omega \\to (\\omega, k)^2$ for all finite $k$ (this is just the infinite Ramsey theorem). The question becomes much more delicate for uncountable ordinals and ordinals in the ordinal hierarchy.",
+    "mathContext": "$\\text{IsPartitionOrd}(\\alpha, k) \\iff \\alpha \\to (\\alpha, k)^2$",
+    "significance": "key",
+    "relatedConcepts": ["partition ordinals", "infinite Ramsey theorem", "ordinal classification"],
+    "prerequisites": ["ordinal partition relation"]
   },
   {
-    "id": "erdos-hajnal-conj",
+    "id": "ann-118-conjecture",
     "proofId": "erdos-118",
-    "range": { "startLine": 35, "endLine": 37 },
-    "type": "conjecture",
-    "title": "Erdős–Hajnal Conjecture (Disproved)",
-    "content": "The conjecture that α → (α,3)² implies α → (α,n)² for all n ≥ 3. This would have unified partition ordinals across all clique sizes. DISPROVED.",
-    "significance": "high"
-  },
-  {
-    "id": "counterexample-ord",
-    "proofId": "erdos-118",
-    "range": { "startLine": 42, "endLine": 43 },
+    "range": { "startLine": 35, "endLine": 38 },
     "type": "definition",
-    "title": "Counterexample Ordinal ω^(ω²)",
-    "content": "The ordinal ω^(ω²) = ω^(ω·ω). Larson showed this is a partition ordinal for triangles but not for K_5, providing a concrete counterexample.",
-    "significance": "high"
+    "title": "ErdosHajnalConjecture — The Disproved Conjecture",
+    "content": "The Erdős–Hajnal conjecture (now disproved): if $\\alpha \\to (\\alpha, 3)^2$, then $\\alpha \\to (\\alpha, n)^2$ for all finite $n \\ge 3$. This would have meant that being a partition ordinal for triangles automatically implies being a partition ordinal for all finite cliques — a dramatic simplification of the classification problem. Erdős and Hajnal posed this in the context of their extensive study of partition relations for ordinals.",
+    "mathContext": "$\\forall \\alpha : \\text{Ord},\\, \\alpha \\to (\\alpha, 3)^2 \\implies \\forall n \\ge 3,\\, \\alpha \\to (\\alpha, n)^2$",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős–Hajnal conjecture", "partition classification", "ordinal Ramsey theory"],
+    "prerequisites": ["partition ordinals", "ordinal arithmetic"]
   },
   {
-    "id": "counter-positive",
+    "id": "ann-118-counterexample",
     "proofId": "erdos-118",
-    "range": { "startLine": 47, "endLine": 48 },
-    "type": "theorem",
-    "title": "ω^(ω²) → (ω^(ω²), 3)²",
-    "content": "The partition property holds for triangles. This follows from Schipperus's positive classification results for ordinals with small CNF-length.",
-    "significance": "medium"
-  },
-  {
-    "id": "counter-negative",
-    "proofId": "erdos-118",
-    "range": { "startLine": 51, "endLine": 52 },
-    "type": "theorem",
-    "title": "ω^(ω²) ↛ (ω^(ω²), 5)²",
-    "content": "The partition property fails for K_5. Larson demonstrated an explicit 2-coloring of K_{ω^(ω²)} with no red copy of order type ω^(ω²) and no blue K_5.",
-    "significance": "high"
-  },
-  {
-    "id": "disproof",
-    "proofId": "erdos-118",
-    "range": { "startLine": 56, "endLine": 58 },
-    "type": "theorem",
-    "title": "Formal Disproof",
-    "content": "The Erdős–Hajnal conjecture is false: the counterexample satisfies α → (α,3)² but not α → (α,5)², contradicting the universal implication.",
-    "significance": "high"
-  },
-  {
-    "id": "partition-threshold",
-    "proofId": "erdos-118",
-    "range": { "startLine": 63, "endLine": 64 },
+    "range": { "startLine": 42, "endLine": 44 },
     "type": "definition",
-    "title": "Partition Threshold",
-    "content": "The largest k such that α → (α,k)² holds. For ω^(ω²), this threshold is between 3 and 4. The threshold concept captures the nuanced structure revealed by the disproof.",
-    "significance": "medium"
+    "title": "counterexampleOrd — ω^(ω²)",
+    "content": "Defines the counterexample ordinal $\\omega^{\\omega^2} = \\omega^{\\omega \\cdot \\omega}$. This ordinal sits in the ordinal hierarchy just above $\\omega^{\\omega \\cdot n}$ for all finite $n$. Its Cantor Normal Form (CNF) length is 1 (it's a single power of $\\omega$), but the exponent $\\omega^2$ is large enough to create a gap between the triangle and K_5 partition properties. Larson identified this specific ordinal as the simplest counterexample.",
+    "mathContext": "$\\alpha_0 = \\omega^{\\omega^2} = \\omega^{\\omega \\cdot \\omega}$, defined as `Ordinal.omega ^ (Ordinal.omega ^ 2)`.",
+    "significance": "critical",
+    "relatedConcepts": ["ordinal exponentiation", "Cantor Normal Form", "ordinal hierarchy"],
+    "prerequisites": ["ordinal arithmetic", "ordinal exponentiation"]
+  },
+  {
+    "id": "ann-118-counter-positive",
+    "proofId": "erdos-118",
+    "range": { "startLine": 46, "endLine": 48 },
+    "type": "theorem",
+    "title": "counter_partition_3 — Triangle Partition Property",
+    "content": "Axiomatizes that $\\omega^{\\omega^2} \\to (\\omega^{\\omega^2}, 3)^2$: every 2-coloring of pairs from $\\omega^{\\omega^2}$ yields either a red subset of order type $\\omega^{\\omega^2}$ or a blue triangle. This follows from Schipperus's positive classification results (1999/2010), which characterized partition ordinals for triangles among ordinals with short Cantor Normal Form. The proof uses a delicate tree-coloring argument.",
+    "mathContext": "$\\omega^{\\omega^2} \\to (\\omega^{\\omega^2}, 3)^2$",
+    "significance": "key",
+    "relatedConcepts": ["Schipperus classification", "tree colorings", "positive partition results"],
+    "prerequisites": ["partition ordinals", "Cantor Normal Form"]
+  },
+  {
+    "id": "ann-118-counter-negative",
+    "proofId": "erdos-118",
+    "range": { "startLine": 50, "endLine": 52 },
+    "type": "theorem",
+    "title": "counter_not_partition_5 — K_5 Failure",
+    "content": "Axiomatizes that $\\omega^{\\omega^2} \\not\\to (\\omega^{\\omega^2}, 5)^2$: there exists a 2-coloring of pairs from $\\omega^{\\omega^2}$ with no red set of order type $\\omega^{\\omega^2}$ and no blue $K_5$. Larson's proof constructs an explicit coloring using the ordinal's tree structure — the coloring is based on the **least differing digit** in the Cantor Normal Form representation of ordinals below $\\omega^{\\omega^2}$.",
+    "mathContext": "$\\omega^{\\omega^2} \\not\\to (\\omega^{\\omega^2}, 5)^2$: $\\exists c : [\\omega^{\\omega^2}]^2 \\to 2$ with no red $\\omega^{\\omega^2}$ and no blue $K_5$.",
+    "significance": "critical",
+    "relatedConcepts": ["negative partition results", "explicit colorings", "CNF-based colorings"],
+    "prerequisites": ["ordinal partition relation", "Cantor Normal Form"]
+  },
+  {
+    "id": "ann-118-disproof",
+    "proofId": "erdos-118",
+    "range": { "startLine": 56, "endLine": 61 },
+    "type": "theorem",
+    "title": "erdos_118_disproved — Formal Disproof",
+    "content": "The only fully-proved theorem in the file: derives $\\neg$ ErdosHajnalConjecture by contradiction. Assuming the conjecture, instantiate it at $\\alpha = \\omega^{\\omega^2}$ and $n = 5$: the conjecture plus `counter_partition_3` would give $\\omega^{\\omega^2} \\to (\\omega^{\\omega^2}, 5)^2$, contradicting `counter_not_partition_5`. This is a clean proof by specialization and modus ponens.",
+    "mathContext": "$\\neg (\\alpha \\to (\\alpha, 3)^2 \\implies \\forall n \\ge 3,\\, \\alpha \\to (\\alpha, n)^2)$, witnessed by $\\alpha = \\omega^{\\omega^2}$, $n = 5$.",
+    "significance": "critical",
+    "relatedConcepts": ["proof by contradiction", "counterexample", "modus ponens"],
+    "prerequisites": ["counter_partition_3", "counter_not_partition_5"]
+  },
+  {
+    "id": "ann-118-threshold",
+    "proofId": "erdos-118",
+    "range": { "startLine": 65, "endLine": 77 },
+    "type": "definition",
+    "title": "partitionThreshold and Monotonicity",
+    "content": "Defines the **partition threshold** of an ordinal $\\alpha$: the largest $k$ such that $\\alpha \\to (\\alpha, k)^2$ holds. Axiomatizes that the partition relation is **monotone decreasing** in $k$ ($j \\le k$ and $\\alpha \\to (\\alpha, k)^2$ implies $\\alpha \\to (\\alpha, j)^2$), and that the threshold captures the exact boundary. The threshold concept emerged from the disproof — it shows each ordinal has a characteristic 'partition strength' that may be finite and greater than 3.",
+    "mathContext": "$\\text{thr}(\\alpha) = \\max\\{k : \\alpha \\to (\\alpha, k)^2\\}$, with $j \\le k \\implies (\\alpha \\to (\\alpha,k)^2 \\implies \\alpha \\to (\\alpha,j)^2)$.",
+    "significance": "key",
+    "relatedConcepts": ["partition threshold", "monotonicity of Ramsey properties", "ordinal invariants"],
+    "prerequisites": ["partition ordinals", "ordinal arithmetic"]
+  },
+  {
+    "id": "ann-118-omega2-threshold",
+    "proofId": "erdos-118",
+    "range": { "startLine": 81, "endLine": 85 },
+    "type": "theorem",
+    "title": "omega_omega2_threshold — Threshold Bounds",
+    "content": "The partition threshold of $\\omega^{\\omega^2}$ lies in $\\{3, 4\\}$. We know $\\alpha \\to (\\alpha, 3)^2$ holds (from Schipperus) and $\\alpha \\to (\\alpha, 5)^2$ fails (from Larson), so the threshold is 3 or 4. Whether $\\omega^{\\omega^2} \\to (\\omega^{\\omega^2}, 4)^2$ holds remains an open question — pinning down this exact value would further illuminate the structure of ordinal Ramsey theory.",
+    "mathContext": "$3 \\le \\text{thr}(\\omega^{\\omega^2}) \\le 4$",
+    "significance": "key",
+    "relatedConcepts": ["exact threshold", "open classification questions", "ordinal Ramsey"],
+    "prerequisites": ["partition threshold", "counter_partition_3", "counter_not_partition_5"]
+  },
+  {
+    "id": "ann-118-relation-592",
+    "proofId": "erdos-118",
+    "range": { "startLine": 89, "endLine": 93 },
+    "type": "theorem",
+    "title": "relation_to_592 — Connection to Problem #592",
+    "content": "Restates the existence of an ordinal that is a partition ordinal for triangles but not for $K_5$, connecting to Erdős Problem #592 which asks for a complete classification of ordinals satisfying $\\alpha \\to (\\alpha, 3)^2$. The disproof of #118 shows that classifying partition ordinals for triangles does **not** automatically classify them for all cliques — separate analysis is needed for each clique size.",
+    "mathContext": "$\\exists \\alpha : \\alpha \\to (\\alpha, 3)^2 \\wedge \\alpha \\not\\to (\\alpha, 5)^2$",
+    "significance": "key",
+    "relatedConcepts": ["Erdős Problem 592", "partition ordinal classification", "triangle partition ordinals"],
+    "prerequisites": ["counterexample ordinal", "partition relation"]
   }
 ]

--- a/src/data/proofs/erdos-118/meta.json
+++ b/src/data/proofs/erdos-118/meta.json
@@ -6,6 +6,7 @@
   "meta": {
     "erdosNumber": 118,
     "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos118Problem.lean",
     "tags": [
       "erdos",
       "set-theory",
@@ -25,64 +26,69 @@
     "leanFile": "Proofs/Erdos118Problem.lean",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/118",
-    "erdosUrl": "https://erdosproblems.com/118"
+    "erdosUrl": "https://erdosproblems.com/118",
+    "erdosProblemStatus": "disproved",
+    "badge": "pending",
+    "relatedProblems": [592]
   },
   "sections": [
     {
       "id": "core-definitions",
       "title": "Core Definitions",
-      "startLine": 24,
-      "endLine": 37,
-      "summary": "Define ordPartition, IsPartitionOrd, and the Erdős–Hajnal conjecture."
+      "startLine": 20,
+      "endLine": 38,
+      "summary": "Defines the ordinal partition relation $\\alpha \\to (\\alpha, k)^2$ (axiomatized), the `IsPartitionOrd` predicate, and the Erdős–Hajnal conjecture: $\\alpha \\to (\\alpha,3)^2 \\implies \\forall n \\ge 3,\\, \\alpha \\to (\\alpha,n)^2$."
     },
     {
       "id": "counterexample",
       "title": "The Counterexample",
-      "startLine": 39,
-      "endLine": 50,
-      "summary": "ω^(ω²) satisfies α → (α,3)² but fails α → (α,5)²."
+      "startLine": 40,
+      "endLine": 52,
+      "summary": "Defines the counterexample ordinal $\\omega^{\\omega^2}$ and axiomatizes the two key facts: $\\omega^{\\omega^2} \\to (\\omega^{\\omega^2}, 3)^2$ (Schipperus) and $\\omega^{\\omega^2} \\not\\to (\\omega^{\\omega^2}, 5)^2$ (Larson). Together these witness the failure of the conjecture."
     },
     {
       "id": "disproof",
-      "title": "Disproof",
-      "startLine": 52,
-      "endLine": 58,
-      "summary": "Formal proof that the Erdős–Hajnal conjecture is false."
+      "title": "Formal Disproof",
+      "startLine": 54,
+      "endLine": 61,
+      "summary": "Proves $\\neg$ ErdosHajnalConjecture by instantiating the conjecture at the counterexample ordinal with $n = 5$, deriving a contradiction. This is the only fully-proved theorem in the file — a clean application of modus ponens and contradiction."
     },
     {
       "id": "monotonicity",
       "title": "Partition Threshold and Monotonicity",
-      "startLine": 60,
-      "endLine": 77,
-      "summary": "Define partition threshold, monotonicity in k, and the exact threshold for ω^(ω²)."
+      "startLine": 63,
+      "endLine": 85,
+      "summary": "Introduces the partition threshold $\\text{thr}(\\alpha) = \\max\\{k : \\alpha \\to (\\alpha,k)^2\\}$, axiomatizes monotonicity ($j \\le k$ preserves the relation), and bounds $\\text{thr}(\\omega^{\\omega^2}) \\in \\{3, 4\\}$. The exact value remains open."
     },
     {
       "id": "relation-592",
       "title": "Relation to Problem #592",
-      "startLine": 79,
-      "endLine": 84,
-      "summary": "Connection to the open classification of partition ordinals for triangles."
+      "startLine": 87,
+      "endLine": 93,
+      "summary": "Connects to Erdős Problem #592 on classifying partition ordinals for triangles. The disproof of #118 shows that the triangle classification does not automatically extend to all clique sizes — each $k$ requires independent analysis."
     }
   ],
   "overview": {
-    "historicalContext": "Erdős and Hajnal conjectured that if α → (α,3)² then α → (α,n)² for all finite n. This would mean that partition ordinals for triangles automatically handle all finite cliques. The conjecture was independently disproved by Schipperus and Darby in 1999, showing the partition landscape is more nuanced than expected.",
-    "problemStatement": "Does the ordinal partition relation α → (α,3)² imply α → (α,n)² for all finite n ≥ 3?",
-    "proofStrategy": "We formalize the partition relation, state the conjecture, define the counterexample ordinal ω^(ω²), axiomatize that it satisfies α → (α,3)² but not α → (α,5)², and derive the formal disproof by contradiction.",
+    "historicalContext": "**Erdős–Hajnal Partition Conjecture**\n\nThis problem was posed by Paul Erdős and András Hajnal as part of their extensive development of the **partition calculus** for ordinals, which they initiated in the 1960s building on the Erdős–Rado theorem (1956). The partition calculus generalizes finite Ramsey theory to transfinite settings, asking: for which ordinals $\\alpha$ and integers $k$ does $\\alpha \\to (\\alpha, k)^2$ hold?\n\nThe conjecture asked whether the partition property for triangles ($k = 3$) automatically implies it for all finite cliques — a natural monotonicity conjecture that would have dramatically simplified the classification landscape. In 1999, Rene Schipperus and Jean Darby **independently** disproved the conjecture. Schipperus's work, published in 2010 in the *Annals of Pure and Applied Logic*, provided a comprehensive analysis of partition ordinals using the Cantor Normal Form structure. Jean Larson contributed the explicit counterexample $\\omega^{\\omega^2}$, showing it satisfies $\\alpha \\to (\\alpha, 3)^2$ but fails $\\alpha \\to (\\alpha, 5)^2$.\n\nThe counterexample relies on the ordinal $\\omega^{\\omega^2} = \\omega^{\\omega \\cdot \\omega}$, which is large enough in the ordinal hierarchy for the CNF-based coloring argument to separate triangles from $K_5$. The positive direction (triangles work) uses Schipperus's tree-coloring technique; the negative direction (K_5 fails) uses an explicit coloring based on the least-differing-digit structure of Cantor Normal Forms.\n\nThe Hajnal–Larson (2010) survey in *\"Handbook of Set Theory\"*, Chapter 2.9, provides the definitive account of partition ordinals including this disproof. The result revealed that ordinal Ramsey theory has a much richer structure than the finite case would suggest — different ordinals have different partition thresholds that must be computed individually.",
+    "problemStatement": "Does $\\alpha \\to (\\alpha, 3)^2$ imply $\\alpha \\to (\\alpha, n)^2$ for all finite $n \\ge 3$?\n\nThat is, if every 2-coloring of $K_\\alpha$ yields a red copy of order type $\\alpha$ or a blue triangle, must it also yield a red $\\alpha$ or blue $K_n$ for all $n$?\n\n**Answer**: NO (Schipperus 1999/2010, Darby 1999).\n**Counterexample**: $\\omega^{\\omega^2} \\to (\\omega^{\\omega^2}, 3)^2$ but $\\omega^{\\omega^2} \\not\\to (\\omega^{\\omega^2}, 5)^2$.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Axiomatized partition relation**: The relation $\\alpha \\to (\\alpha, k)^2$ is declared as an axiom, since fully formalizing it requires the theory of ordinal-indexed colorings not yet in Mathlib.\n\n2. **Concrete counterexample**: Defines $\\omega^{\\omega^2}$ using Mathlib's ordinal exponentiation, then axiomatizes the two key facts (triangle success, K_5 failure).\n\n3. **Proved disproof**: The formal negation $\\neg$ ErdosHajnalConjecture is **proved** (not axiomatized), using a clean proof by contradiction that instantiates the conjecture at the counterexample.\n\n4. **Threshold theory**: Introduces the partition threshold as an ordinal invariant and bounds $\\text{thr}(\\omega^{\\omega^2}) \\in \\{3, 4\\}$.",
     "keyInsights": [
-      "Schipperus (1999/2010) and Darby (1999) independently disproved the conjecture",
-      "Larson's counterexample: ω^(ω²) → (ω^(ω²),3)² but ω^(ω²) ↛ (ω^(ω²),5)²",
-      "The partition relation is monotone decreasing in k, but the threshold varies by ordinal",
-      "Different ordinals can have different partition thresholds, not just 3 vs ∞",
-      "Closely related to Problem #592 on classifying partition ordinals for triangles"
+      "**The gap between 3 and ∞**: The conjecture predicted that partition ordinals for triangles are automatically partition ordinals for all finite cliques. The disproof shows a gap: $\\omega^{\\omega^2}$ handles triangles but fails at $K_5$, revealing that the partition landscape is stratified by clique size.",
+      "**CNF structure controls partition properties**: The counterexample exploits the Cantor Normal Form of ordinals below $\\omega^{\\omega^2}$. Larson's coloring is defined by comparing the CNF representations of two ordinals — the 'least differing digit' determines the color. This structural coloring prevents blue $K_5$ while allowing blue triangles.",
+      "**Partition threshold as an ordinal invariant**: The disproof motivates defining $\\text{thr}(\\alpha) = \\max\\{k : \\alpha \\to (\\alpha,k)^2\\}$ as a new invariant of ordinals. For $\\omega$, $\\text{thr}(\\omega) = \\infty$ (the infinite Ramsey theorem). For $\\omega^{\\omega^2}$, the threshold is 3 or 4. Computing thresholds for other ordinals is an active area.",
+      "**Independent disproofs signal robustness**: Schipperus and Darby independently found counterexamples in 1999, using different techniques. This independent discovery suggests the failure is not a pathological edge case but a fundamental feature of the ordinal partition landscape.",
+      "**One proved theorem among axioms**: Unusually for this gallery, the file has 0 sorry's and contains one genuinely proved result (`erdos_118_disproved`). The proof is constructive in the sense that given the axiomatized counterexample, the disproof follows by simple logic — `intro h; have h5 := h ... 5 ...; exact counter_not_partition_5 h5`."
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #118 asked whether α → (α,3)² implies α → (α,n)² for all n. This was disproved: ω^(ω²) is a partition ordinal for triangles but not for K_5. Each ordinal has a partition threshold that can be finite and greater than 3.",
-    "implications": "The disproof reveals that ordinal Ramsey theory has a richer structure than anticipated. The partition threshold is an additional invariant of interest for each ordinal, and the full classification of partition ordinals must be done clique-size by clique-size.",
+    "summary": "Erdős Problem #118 asked whether $\\alpha \\to (\\alpha, 3)^2$ implies $\\alpha \\to (\\alpha, n)^2$ for all finite $n$. This was disproved by Schipperus and Darby (1999), with Larson providing the explicit counterexample $\\omega^{\\omega^2}$. The formalization axiomatizes the counterexample properties and derives the formal disproof as a proved theorem — one of the few fully-proved results in the gallery. The partition threshold $\\text{thr}(\\omega^{\\omega^2}) \\in \\{3, 4\\}$ remains to be determined exactly.",
+    "implications": "**Theoretical Significance**\n\n1. **Stratified partition landscape**: The disproof shows that ordinal Ramsey theory is stratified by clique size — the class of partition ordinals for $K_k$ is strictly larger than for $K_{k+1}$ in general. This contrasts with the finite case where Ramsey numbers grow but the theory is uniform.\n\n2. **New invariant theory**: The partition threshold introduces a new ordinal invariant worthy of systematic study. Computing $\\text{thr}(\\alpha)$ for ordinals in the hierarchy $\\omega^{\\omega^\\gamma}$ is a natural research program.\n\n3. **CNF-based combinatorics**: The counterexample highlights Cantor Normal Form as a tool for combinatorial set theory. The CNF structure provides explicit colorings that can separate partition properties at different clique sizes.\n\n4. **Connection to finite Ramsey theory**: Understanding why the ordinal case is more nuanced than the finite case (where Ramsey's theorem gives $\\omega \\to (\\omega, k)^2$ for all $k$) illuminates the boundary between finite and transfinite combinatorics.",
     "openQuestions": [
-      "What is the exact partition threshold of ω^(ω²)? (Known: between 3 and 4)",
-      "For which ordinals α and k does α → (α,k)² hold?",
-      "How does the partition threshold grow for ordinals of the form ω^(ω^γ)?"
+      "Is the partition threshold of $\\omega^{\\omega^2}$ exactly 3 or 4? That is, does $\\omega^{\\omega^2} \\to (\\omega^{\\omega^2}, 4)^2$ hold?",
+      "What are the partition thresholds for ordinals of the form $\\omega^{\\omega^\\gamma}$ for other limit ordinals $\\gamma$?",
+      "Can the counterexample be pushed down to $n = 4$? Is there $\\alpha$ with $\\alpha \\to (\\alpha, 3)^2$ but $\\alpha \\not\\to (\\alpha, 4)^2$?",
+      "Is there a general formula or algorithm for computing partition thresholds from the CNF of an ordinal?",
+      "How does the partition threshold relate to other ordinal invariants (cofinality, CNF-length, multiplicative structure)?"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Enrichment pass for erdos-118 (Erdős Problem #118: Partition Ordinals and Higher Cliques).

- Added `mathContext` (LaTeX) to all 11 annotations (was 0/7)
- Added `relatedConcepts` and `prerequisites` to every annotation
- Expanded from 7 to 11 annotations covering full Lean file
- Fixed invalid `significance` values (high/medium → critical/key/supporting)
- Fixed invalid annotation type "conjecture" → "definition"
- Added `proofRepoPath`, `badge`, `relatedProblems`, `erdosProblemStatus` fields
- Deepened `historicalContext` (1100+ chars) with Erdős–Rado, Schipperus, Hajnal–Larson handbook
- Enriched `keyInsights` (5 items) with CNF-based colorings, threshold invariant
- Added LaTeX to all 5 section summaries
- Expanded conclusion with stratified partition landscape, CNF combinatorics
- Added 5 specific `openQuestions`

## Test plan
- [x] `pnpm annotations:build` passes with no erdos-118 warnings
- [x] JSON structure validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)