### PR TITLE
enrich(erdos-155): deepen annotations and meta for Sidon set growth and F(N) asymptotics

### DIFF
--- a/src/data/proofs/erdos-155/annotations.json
+++ b/src/data/proofs/erdos-155/annotations.json
@@ -1,65 +1,134 @@
 [
   {
-    "id": "sidon-set",
+    "id": "ann-155-imports",
     "proofId": "erdos-155",
-    "range": { "startLine": 30, "endLine": 33 },
+    "range": { "startLine": 26, "endLine": 29 },
+    "type": "concept",
+    "title": "Imports and Dependencies",
+    "content": "Imports Mathlib's `Finset` operations, natural number basics, `Filter` theory, and the tactic library. The formalization uses `Finset.filter`, `Finset.card`, and `Finset.range` for combinatorial definitions, and `Real.sqrt` for the asymptotic bounds.",
+    "mathContext": "Uses `Finset.filter`, `Finset.card`, `Real.sqrt`, and `Nat.floor` from Mathlib for finite set counting and real-valued asymptotic bounds.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset", "Real.sqrt", "Nat.floor", "Mathlib tactics"],
+    "prerequisites": ["Lean 4", "Mathlib"]
+  },
+  {
+    "id": "ann-155-sidon-def",
+    "proofId": "erdos-155",
+    "range": { "startLine": 36, "endLine": 38 },
     "type": "definition",
-    "title": "Sidon Set (B₂ Set)",
-    "content": "A set of integers where all pairwise sums a+b (a ≤ b) are distinct. Equivalently, if a+b = c+d with a ≤ b, c ≤ d, then a=c and b=d. Named after Simon Sidon.",
-    "significance": "high"
+    "title": "Sidon Set ($B_2$ Set)",
+    "content": "A set $S$ of natural numbers is a **Sidon set** (also called a $B_2$ set) if all pairwise sums $a + b$ with $a \\le b$, $a, b \\in S$ are distinct. Equivalently, the representation function $r(n) = \\#\\{(a,b) \\in S^2 : a + b = n, a \\le b\\}$ satisfies $r(n) \\le 1$ for all $n$. Named after the Hungarian mathematician Simon Sidon, who asked Erdős about such sets in 1932. The equivalent formulation via distinct differences ($a - b = c - d$ implies $\\{a,b\\} = \\{c,d\\}$) is sometimes more convenient.",
+    "mathContext": "$S$ is Sidon iff $\\forall a \\le b, c \\le d \\in S : a + b = c + d \\Rightarrow (a,b) = (c,d)$. The number of pairwise sums $\\binom{|S|}{2} + |S|$ must be $\\le 2N$ for $S \\subseteq [N]$, giving $|S| \\le \\sqrt{2N} + O(1)$.",
+    "significance": "critical",
+    "relatedConcepts": ["B_2 set", "distinct pairwise sums", "additive combinatorics", "representation function"],
+    "prerequisites": ["Finset", "pairwise sums"]
   },
   {
-    "id": "max-sidon-size",
+    "id": "ann-155-max-sidon",
     "proofId": "erdos-155",
-    "range": { "startLine": 36, "endLine": 36 },
+    "range": { "startLine": 41, "endLine": 41 },
     "type": "definition",
-    "title": "Maximum Sidon Size F(N)",
-    "content": "F(N) is the largest cardinality of a Sidon subset of {1,...,N}. This is the central function of the problem.",
-    "significance": "high"
+    "title": "Maximum Sidon Size $F(N)$",
+    "content": "The function $F(N)$ gives the maximum cardinality of a Sidon subset of $\\{1, \\ldots, N\\}$. This is the central extremal function of Sidon set theory. Defined axiomatically (as an opaque function) with separate axioms for achievability and optimality, since computing $F(N)$ exactly requires checking exponentially many subsets.",
+    "mathContext": "$F(N) = \\max\\{|S| : S \\subseteq [N],\\, S \\text{ is Sidon}\\}$. Known values (OEIS A003022): $F(1)=1$, $F(2)=2$, $F(3)=3$, $F(6)=4$, $F(11)=5$, $F(18)=6$, $F(26)=7$, $F(35)=8$.",
+    "significance": "critical",
+    "relatedConcepts": ["extremal function", "OEIS A003022", "Sidon set"],
+    "prerequisites": ["IsSidonSet"]
   },
   {
-    "id": "erdos-turan-bound",
+    "id": "ann-155-achievable",
     "proofId": "erdos-155",
-    "range": { "startLine": 60, "endLine": 62 },
+    "range": { "startLine": 44, "endLine": 45 },
     "type": "theorem",
-    "title": "Erdős–Turán Upper Bound",
-    "content": "F(N) ≤ √N + N^{1/4} + 1 (Lindström 1969, refining Erdős–Turán 1941). Combined with lower bounds, this gives F(N) ~ √N.",
-    "significance": "high"
+    "title": "Achievability and Optimality of $F(N)$",
+    "content": "Two companion axioms: (1) **achievability** — there exists a Sidon subset of $\\{1,\\ldots,N\\}$ of size exactly $F(N)$; (2) **optimality** — no Sidon subset of $\\{1,\\ldots,N\\}$ exceeds $F(N)$ in cardinality. Together they characterize $F(N)$ as a maximum (not just supremum). These are axiomatized since the existence proof requires the finite extremal principle.",
+    "mathContext": "$\\exists S \\subseteq [N] : S \\text{ Sidon} \\wedge |S| = F(N)$, and $\\forall S \\subseteq [N] : S \\text{ Sidon} \\Rightarrow |S| \\le F(N)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["extremal principle", "maximum vs supremum"],
+    "prerequisites": ["IsSidonSet", "maxSidonSize"]
   },
   {
-    "id": "lower-bound",
+    "id": "ann-155-monotone",
     "proofId": "erdos-155",
-    "range": { "startLine": 65, "endLine": 67 },
+    "range": { "startLine": 55, "endLine": 55 },
     "type": "theorem",
-    "title": "Lower Bound F(N) ≥ (1-o(1))√N",
-    "content": "Singer's perfect difference set construction (1938) and refinements give Sidon sets of size ~√N in {1,...,N}, matching the upper bound asymptotically.",
-    "significance": "medium"
+    "title": "Monotonicity: $F(N) \\le F(N+1) \\le F(N) + 1$",
+    "content": "Two basic structural properties: (1) $F$ is monotone nondecreasing — enlarging the interval $[N]$ to $[N+1]$ can only help; (2) $F$ increases by at most 1 per step — adding one new element $N+1$ to the interval can increase the maximum Sidon set by at most 1. Together: the sequence $F(1), F(2), \\ldots$ is a nondecreasing integer sequence with steps of 0 or 1.",
+    "mathContext": "$F(N) \\le F(N+1) \\le F(N) + 1$. The increase points $\\{N : F(N+1) > F(N)\\}$ form a sparse set, with $\\sim \\sqrt{N}$ increase points in $[1,N]$ (since $F(N) \\sim \\sqrt{N}$).",
+    "significance": "key",
+    "relatedConcepts": ["monotone functions", "integer sequences", "step size"],
+    "prerequisites": ["maxSidonSize"]
   },
   {
-    "id": "main-conjecture",
+    "id": "ann-155-upper",
     "proofId": "erdos-155",
-    "range": { "startLine": 73, "endLine": 76 },
-    "type": "conjecture",
-    "title": "Main Conjecture: F(N+k) ≤ F(N)+1",
-    "content": "For every fixed k ≥ 1, eventually F(N+k) ≤ F(N)+1. This says F can increase by at most 1 over any fixed-length interval, once N is large enough.",
-    "significance": "high"
-  },
-  {
-    "id": "strong-form",
-    "proofId": "erdos-155",
-    "range": { "startLine": 80, "endLine": 84 },
-    "type": "conjecture",
-    "title": "Strong Form: k ≈ ε√N",
-    "content": "F(N + ⌊ε√N⌋) ≤ F(N) + 1 for large N. This much stronger version says F plateaus on intervals of length proportional to √N.",
-    "significance": "high"
-  },
-  {
-    "id": "small-values",
-    "proofId": "erdos-155",
-    "range": { "startLine": 96, "endLine": 99 },
+    "range": { "startLine": 64, "endLine": 65 },
     "type": "theorem",
-    "title": "Known Values of F(N)",
-    "content": "F(1)=1, F(2)=2, F(3)=3, F(6)=4, F(11)=5, F(18)=6, F(26)=7. The gaps between increase points grow: 1,1,3,5,7,8 — consistent with ~√N spacing.",
-    "significance": "medium"
+    "title": "Erdős–Turán/Lindström Upper Bound",
+    "content": "The classical upper bound $F(N) \\le \\sqrt{N} + N^{1/4} + 1$, refined by Lindström (1969) from the original Erdős–Turán (1941) bound $F(N) = O(\\sqrt{N})$. The proof counts pairwise sums: a Sidon set $S \\subseteq [N]$ has $\\binom{|S|}{2}$ distinct pairwise sums in $[2, 2N]$, giving $|S|^2/2 \\lesssim 2N$, hence $|S| \\lesssim \\sqrt{2N}$. Lindström's refinement uses a more careful counting of sums near the boundary.",
+    "mathContext": "$F(N) \\le \\sqrt{N} + N^{1/4} + 1$. The leading term $\\sqrt{N}$ is sharp: $F(N) = (1 + o(1))\\sqrt{N}$ by matching lower bounds.",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős–Turán theorem", "Lindström bound", "pairwise sum counting", "B_2 problem"],
+    "prerequisites": ["maxSidonSize", "Real.sqrt"]
+  },
+  {
+    "id": "ann-155-lower",
+    "proofId": "erdos-155",
+    "range": { "startLine": 69, "endLine": 71 },
+    "type": "theorem",
+    "title": "Lower Bound: $F(N) \\ge (1-o(1))\\sqrt{N}$",
+    "content": "Singer's perfect difference set construction (1938) and its refinements (Ruzsa, Cilleruelo) produce Sidon sets of size $(1-o(1))\\sqrt{N}$ in $\\{1,\\ldots,N\\}$, matching the upper bound asymptotically. Singer's construction uses the fact that for $q$ a prime power, the set of elements of $\\mathbb{F}_{q^2}^*$ with specified trace gives a perfect difference set of size $q+1$ in $\\mathbb{Z}/(q^2+q+1)$. This yields $F(N) \\ge \\sqrt{N} - O(N^{1/4})$ when $N$ is near $q^2 + q + 1$.",
+    "mathContext": "$F(N) \\ge (1-\\varepsilon)\\sqrt{N}$ for all $N \\ge N_0(\\varepsilon)$. Singer's construction: for $q$ prime power, $\\{1, \\ldots, q^2+q+1\\}$ contains a Sidon set of size $q+1 = \\sqrt{N} + O(1)$.",
+    "significance": "key",
+    "relatedConcepts": ["Singer difference sets", "perfect difference sets", "finite fields", "Cilleruelo's construction"],
+    "prerequisites": ["maxSidonSize", "finite field constructions"]
+  },
+  {
+    "id": "ann-155-main",
+    "proofId": "erdos-155",
+    "range": { "startLine": 80, "endLine": 81 },
+    "type": "insight",
+    "title": "Main Conjecture: $F(N+k) \\le F(N) + 1$ for Fixed $k$",
+    "content": "The central open problem: for every fixed $k \\ge 1$, is $F(N+k) \\le F(N) + 1$ for all sufficiently large $N$ (where $N_0$ may depend on $k$)? This asserts that $F$ increases by at most 1 over any interval of fixed length, once $N$ is large enough. Since $F(N) \\sim \\sqrt{N}$, the increase points $\\{N : F(N+1) > F(N)\\}$ have density $\\sim 1/\\sqrt{N} \\to 0$, so heuristically adjacent increase points are $\\sim \\sqrt{N}$ apart — far more than any fixed $k$.",
+    "mathContext": "$\\forall k \\ge 1,\\, \\exists N_0 : \\forall N \\ge N_0,\\, F(N+k) \\le F(N) + 1$. The heuristic gap between increase points is $N/(F(N)) \\sim \\sqrt{N} \\to \\infty$.",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős Problem #155", "growth rate", "increase points", "density zero"],
+    "prerequisites": ["maxSidonSize", "monotonicity"]
+  },
+  {
+    "id": "ann-155-strong",
+    "proofId": "erdos-155",
+    "range": { "startLine": 88, "endLine": 90 },
+    "type": "insight",
+    "title": "Stronger Form: $k \\approx \\varepsilon\\sqrt{N}$",
+    "content": "Erdős's stronger conjecture: $F(N + \\lfloor \\varepsilon\\sqrt{N} \\rfloor) \\le F(N) + 1$ for all sufficiently large $N$ (depending on $\\varepsilon$). This says $F$ plateaus over intervals of length proportional to $\\sqrt{N}$, meaning consecutive increase points are separated by at least $\\sim \\varepsilon\\sqrt{N}$. If true, this would give sharp information about the distribution of increase points, showing they are roughly uniformly spaced with gap $\\sim \\sqrt{N}$.",
+    "mathContext": "$\\forall \\varepsilon > 0,\\, \\exists N_0 : \\forall N \\ge N_0,\\, F(N + \\lfloor\\varepsilon\\sqrt{N}\\rfloor) \\le F(N) + 1$. This implies increase points have minimal gap $\\sim \\varepsilon\\sqrt{N}$.",
+    "significance": "critical",
+    "relatedConcepts": ["strong Sidon conjecture", "increase point spacing", "plateau length"],
+    "prerequisites": ["main conjecture", "Nat.floor", "Real.sqrt"]
+  },
+  {
+    "id": "ann-155-sparse",
+    "proofId": "erdos-155",
+    "range": { "startLine": 96, "endLine": 100 },
+    "type": "theorem",
+    "title": "Increase Points Are Sparse",
+    "content": "A consequence of $F(N) \\sim \\sqrt{N}$: the number of increase points $\\{N \\le M : F(N+1) > F(N)\\}$ is at most $(1+\\varepsilon)\\sqrt{M}$ for large $M$. Since $F$ starts at 1 and reaches $\\sim \\sqrt{M}$, and each increase adds exactly 1, there are exactly $F(M)-F(1) \\sim \\sqrt{M}$ increase points in $[1,M]$. The conjecture says these increase points are far apart; this axiom just bounds their count.",
+    "mathContext": "$|\\{N \\le M : F(N+1) > F(N)\\}| \\le (1+\\varepsilon)\\sqrt{M}$ for $M \\ge M_0(\\varepsilon)$. Since $F(M) \\sim \\sqrt{M}$ and each increase adds 1, the count of increase points equals $F(M) - F(1) \\sim \\sqrt{M}$.",
+    "significance": "key",
+    "relatedConcepts": ["density of increase points", "sparse sets", "counting argument"],
+    "prerequisites": ["maxSidonSize", "asymptotic bounds"]
+  },
+  {
+    "id": "ann-155-small-values",
+    "proofId": "erdos-155",
+    "range": { "startLine": 107, "endLine": 109 },
+    "type": "theorem",
+    "title": "Known Small Values of $F(N)$",
+    "content": "Exact values from OEIS A003022: $F(1)=1$, $F(2)=2$, $F(3)=3$, $F(6)=4$, $F(11)=5$, $F(18)=6$. The gaps between consecutive increase points are $1, 1, 3, 5, 7$, growing roughly as $\\sqrt{N}$ — consistent with both the main conjecture and the strong form. The increase points themselves ($1, 2, 3, 6, 11, 18, 26, 35, \\ldots$, OEIS A143824) are a fundamental sequence in Sidon set theory.",
+    "mathContext": "$F(1)=1, F(2)=2, F(3)=3, F(6)=4, F(11)=5, F(18)=6$. Gaps: $1, 1, 3, 5, 7, 8, 9, \\ldots$ The $n$-th gap is $\\approx 2n-1 \\approx 2\\sqrt{N}$ where $N$ is the $n$-th increase point.",
+    "significance": "supporting",
+    "relatedConcepts": ["OEIS A003022", "OEIS A143824", "small Sidon sets", "computed values"],
+    "prerequisites": ["maxSidonSize"]
   }
 ]

--- a/src/data/proofs/erdos-155/meta.json
+++ b/src/data/proofs/erdos-155/meta.json
@@ -6,84 +6,115 @@
   "meta": {
     "erdosNumber": 155,
     "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos155Problem.lean",
+    "badge": "axiom",
+    "erdosProblemStatus": "open",
     "tags": [
       "erdos",
       "additive-combinatorics",
       "sidon-sets",
       "extremal-combinatorics",
       "growth-rate",
-      "open"
+      "open",
+      "B2-sets",
+      "difference-sets"
     ],
     "references": [
-      "Erdős–Turán (1941): F(N) = O(√N)",
-      "Lindström (1969): F(N) ≤ √N + N^{1/4} + 1",
-      "Singer (1938): perfect difference sets",
-      "Erdős (1992, 1994): problem statements",
-      "OEIS A003022, A143824",
+      "Erdős–Turán (1941): On a problem of Sidon in additive number theory",
+      "Singer (1938): A theorem in finite projective geometry and some applications to number theory",
+      "Lindström (1969): An inequality for B_2 sequences",
+      "Erdős (1992, 1994): Problem statements on slow growth of F(N)",
+      "Cilleruelo (2010): Sidon sets in N^d",
+      "Ruzsa (1993): Solving a linear equation in a set of integers",
+      "O'Bryant (2004): A complete annotated bibliography of work related to Sidon sets",
+      "OEIS A003022: maximal Sidon sets, A143824: increase points",
       "https://erdosproblems.com/155"
     ],
     "leanFile": "Proofs/Erdos155Problem.lean",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/155",
-    "erdosUrl": "https://erdosproblems.com/155"
+    "erdosUrl": "https://erdosproblems.com/155",
+    "relatedProblems": ["erdos-142", "erdos-234"]
+  },
+  "overview": {
+    "historicalContext": "The study of Sidon sets ($B_2$ sets) began when the Hungarian mathematician Simon Sidon asked Erdős in 1932 about sets of integers with all pairwise sums distinct. Erdős and Turán (1941) proved the fundamental upper bound $F(N) = O(\\sqrt{N})$ by counting pairwise sums, and Singer (1938) achieved the matching lower bound $F(N) \\ge (1-o(1))\\sqrt{N}$ using perfect difference sets from finite projective geometry. Lindström (1969) refined the upper bound to $F(N) \\le \\sqrt{N} + N^{1/4} + 1$, and the gap between upper and lower bounds in the second-order term remains open (the '$\\sqrt{N} + 1/2$ vs $\\sqrt{N} + N^{1/4}$' question). Erdős posed Problem #155 around 1992, asking about the fine growth structure: since $F(N)$ increases by 1 only $\\sim \\sqrt{N}$ times in $[1,N]$, the increase points should be very sparse — heuristically spaced $\\sim \\sqrt{N}$ apart. The conjecture that $F(N+k) \\le F(N) + 1$ for fixed $k$ formalizes this, and the stronger form $k \\approx \\varepsilon\\sqrt{N}$ would nearly pin down the increase point distribution.",
+    "problemStatement": "Is it true that for every $k \\ge 1$, $F(N+k) \\le F(N) + 1$ for all sufficiently large $N$, where $F(N)$ is the maximum Sidon subset size of $\\{1,\\ldots,N\\}$?",
+    "proofStrategy": "We formalize Sidon sets, define $F(N)$ axiomatically with achievability and optimality axioms, state the Erdős–Turán/Lindström upper bound and Singer lower bound, and present the main conjecture ($F(N+k) \\le F(N)+1$ for fixed $k$) and its stronger form ($k \\approx \\varepsilon\\sqrt{N}$). Consequences about the sparsity of increase points and known small values from OEIS A003022 are also axiomatized.",
+    "keyInsights": [
+      "**$F(N) \\sim \\sqrt{N}$ with tight bounds**: Erdős–Turán gives $F(N) \\le \\sqrt{N} + N^{1/4} + 1$; Singer's finite-field construction gives $F(N) \\ge \\sqrt{N} - O(N^{1/4})$. The second-order term remains unknown.",
+      "**Increase points have density $\\sim 1/\\sqrt{N}$**: Since $F$ increases $\\sim \\sqrt{N}$ times in $[1,N]$ (one step at a time), the average gap between increase points is $\\sim \\sqrt{N}$, making any fixed $k$ negligible for large $N$",
+      "**The strong form implies near-uniform spacing**: If $F(N + \\lfloor\\varepsilon\\sqrt{N}\\rfloor) \\le F(N)+1$, then increase points are separated by at least $\\varepsilon\\sqrt{N}$, meaning they distribute almost uniformly at scale $\\sqrt{N}$",
+      "**Singer's finite geometry construction**: For $q$ prime power, the set of elements with specified trace in $\\mathbb{F}_{q^2}^*$ gives a perfect difference set of size $q+1$ in $\\mathbb{Z}/(q^2+q+1)$, yielding optimal Sidon sets",
+      "**Computational evidence from OEIS A003022**: Known values $F(1)=1, F(3)=3, F(6)=4, F(11)=5, F(18)=6, F(26)=7$ show gaps $1,1,3,5,7,8$ between increase points, growing consistently with the conjectured $\\sqrt{N}$ spacing"
+    ]
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports",
+      "startLine": 26,
+      "endLine": 29,
+      "summary": "Imports `Finset`, `Nat`, `Filter`, and Mathlib tactics for finite set operations and real-valued bounds."
+    },
+    {
       "id": "core-definitions",
       "title": "Core Definitions",
-      "startLine": 26,
-      "endLine": 47,
-      "summary": "Define IsSidonSet, maxSidonSize F(N), achievability and optimality."
+      "startLine": 31,
+      "endLine": 50,
+      "summary": "Defines `IsSidonSet` ($\\forall a \\le b, c \\le d \\in S : a+b = c+d \\Rightarrow (a,b) = (c,d)$) and axiomatizes $F(N)$ with achievability and optimality. The axiom `maxSidonSize : \\mathbb{N} \\to \\mathbb{N}$ is opaque, characterized by its properties."
     },
     {
       "id": "monotonicity",
       "title": "Monotonicity",
-      "startLine": 49,
-      "endLine": 55,
-      "summary": "F is monotone nondecreasing and increases by at most 1 per step."
+      "startLine": 52,
+      "endLine": 58,
+      "summary": "Axiomatizes $F(N) \\le F(N+1) \\le F(N) + 1$: the sequence $F(1), F(2), \\ldots$ is nondecreasing with steps of 0 or 1."
     },
     {
       "id": "asymptotic-bounds",
       "title": "Asymptotic Bounds",
-      "startLine": 57,
-      "endLine": 67,
-      "summary": "Erdős–Turán upper bound F(N) ≤ √N + N^{1/4} + 1 and lower bound F(N) ≥ (1-o(1))√N."
+      "startLine": 60,
+      "endLine": 71,
+      "summary": "Axiomatizes the Erdős–Turán/Lindström upper bound $F(N) \\le \\sqrt{N} + N^{1/4} + 1$ and the Singer lower bound $F(N) \\ge (1-\\varepsilon)\\sqrt{N}$ for large $N$. Together: $F(N) = (1+o(1))\\sqrt{N}$."
     },
     {
       "id": "main-conjecture",
-      "title": "Main and Stronger Conjectures",
-      "startLine": 69,
-      "endLine": 84,
-      "summary": "F(N+k) ≤ F(N)+1 for fixed k and large N. Stronger form: k ≈ ε√N."
+      "title": "Main Conjecture: $F(N+k) \\le F(N) + 1$",
+      "startLine": 73,
+      "endLine": 81,
+      "summary": "The central open problem: for every fixed $k \\ge 1$, $F(N+k) \\le F(N) + 1$ for all sufficiently large $N$. The quantifier structure $\\forall k, \\exists N_0, \\forall N \\ge N_0$ allows $N_0$ to depend on $k$."
+    },
+    {
+      "id": "strong-form",
+      "title": "Stronger Form: $k \\approx \\varepsilon\\sqrt{N}$",
+      "startLine": 83,
+      "endLine": 90,
+      "summary": "Erdős's stronger conjecture: $F(N + \\lfloor\\varepsilon\\sqrt{N}\\rfloor) \\le F(N) + 1$, implying consecutive increase points are separated by $\\ge \\varepsilon\\sqrt{N}$."
     },
     {
       "id": "consequences",
-      "title": "Consequences and Small Values",
-      "startLine": 86,
-      "endLine": 102,
-      "summary": "Increase points are sparse (density ~√N). Known values: F(1)=1, ..., F(18)=6."
+      "title": "Consequences: Sparse Increase Points",
+      "startLine": 92,
+      "endLine": 100,
+      "summary": "The number of increase points in $[1,M]$ is $\\le (1+\\varepsilon)\\sqrt{M}$. Since $F(M) \\sim \\sqrt{M}$ and each increase adds 1, this count equals $F(M) - 1 \\sim \\sqrt{M}$."
+    },
+    {
+      "id": "small-values",
+      "title": "Known Small Values (OEIS A003022)",
+      "startLine": 102,
+      "endLine": 110,
+      "summary": "Axiomatizes $F(1)=1, F(2)=2, F(3)=3, F(6)=4, F(11)=5, F(18)=6$. Gaps between increase points: $1, 1, 3, 5, 7$, growing as $\\sim \\sqrt{N}$."
     }
   ],
-  "overview": {
-    "historicalContext": "Erdős posed this problem around 1992, building on the classical Erdős–Turán (1941) study of Sidon sets. The function F(N) measures the largest B₂ subset of {1,...,N}. While F(N) ~ √N is well-established, the fine structure of its growth — whether F can jump by more than 1 over intervals of fixed length — remains unknown.",
-    "problemStatement": "Is it true that for every k ≥ 1, F(N+k) ≤ F(N) + 1 for all sufficiently large N, where F(N) is the maximum Sidon subset size of {1,...,N}?",
-    "proofStrategy": "We formalize Sidon sets, define F(N) axiomatically, state the Erdős–Turán asymptotic bounds, and present both the basic conjecture (fixed k) and the stronger form (k ≈ ε√N). We also state consequences about the sparsity of increase points.",
-    "keyInsights": [
-      "A Sidon (B₂) set has all pairwise sums distinct: |S| ≤ √N + O(N^{1/4})",
-      "F(N) ~ √N, so F increases by 1 about √N times in {1,...,N}",
-      "The conjecture says F plateaus on every fixed-length interval for large N",
-      "The stronger form suggests plateaus of length ~ε√N between increases",
-      "Known values: F(1)=1, F(2)=2, F(3)=3, F(6)=4, F(11)=5, F(18)=6"
-    ]
-  },
   "conclusion": {
-    "summary": "Erdős Problem #155 asks whether the maximum Sidon subset function F(N) grows so slowly that F(N+k) ≤ F(N)+1 for any fixed k and large N. This captures the intuition that F increases by 1 very rarely. The problem remains open, with a stronger variant suggesting plateaus of length ~ε√N.",
-    "implications": "A positive answer would provide fine structural information about the distribution of Sidon sets, complementing the classical Erdős–Turán asymptotics. It would show that the 'next' larger Sidon set requires a substantial expansion of the interval.",
+    "summary": "Erdős Problem #155 asks whether the maximum Sidon subset function F(N) grows so slowly that F(N+k) ≤ F(N)+1 for any fixed k and large N. Since F(N) ~ √N and increases by exactly 1 at each jump, the ~√N increase points should be far apart. The problem remains open, with a stronger variant suggesting plateaus of length ~ε√N between consecutive increases.",
+    "implications": "A positive answer would provide precise structural information about the distribution of maximum Sidon sets, showing that optimal Sidon subsets of [N] and [N+k] differ by at most one element for large N. This connects to the broader question of understanding the second-order term in F(N) = √N + O(N^{1/4}), with implications for combinatorial number theory and the structure of B_2 sequences.",
     "openQuestions": [
-      "Does F(N+k) ≤ F(N)+1 hold for all fixed k and large N?",
-      "Does the stronger form with k ≈ ε√N hold?",
-      "What is the exact threshold: the largest k(N) such that F(N+k(N)) ≤ F(N)+1?",
-      "Can the gap F(N) - √N be determined more precisely?"
+      "Does F(N+k) ≤ F(N)+1 hold for all fixed k and sufficiently large N?",
+      "Does the stronger form with k ≈ ε√N hold? What is the largest growth rate k(N) for which F(N+k(N)) ≤ F(N)+1?",
+      "What is the second-order term in F(N) = √N + ??? Specifically, is F(N) = √N + O(1) or F(N) = √N + Θ(N^{1/4})?",
+      "Are the increase points of F(N) approximately uniformly distributed at scale √N, or do they cluster?",
+      "Can probabilistic methods (random Sidon sets) shed light on the gap structure of F?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enriched annotations.json: expanded from 7 to 11 annotations with full mathContext, relatedConcepts, prerequisites; fixed all invalid significance values (high/medium → critical/key/supporting) and invalid types (conjecture → insight)
- Enriched meta.json: deep historicalContext (1000+ chars, Sidon 1932, Erdős–Turán 1941, Singer 1938, Lindström 1969), 5 keyInsights with LaTeX/bold, 8 section summaries with LaTeX, expanded conclusion with 5 specific openQuestions
- Added proofRepoPath, badge, erdosProblemStatus, relatedProblems, expanded references and tags

## Test plan
- [x] `pnpm annotations:build` passes (expected axiom/theorem mismatch warnings are non-strict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)