### PR TITLE
enrich: deepen annotations and meta for erdos-27, 282, 276

### DIFF
--- a/src/data/proofs/erdos-335/annotations.json
+++ b/src/data/proofs/erdos-335/annotations.json
@@ -28,6 +28,18 @@
     "proofId": "erdos-335",
     "range": { "startLine": 33, "endLine": 35 },
     "type": "definition",
+    "title": "Counting Function",
+    "content": "The counting function $|A \\cap \\{1,\\ldots,N\\}|$ measures how many elements of $A$ lie in the initial interval. Implemented via `Set.ncard` (the cardinality of a set, possibly infinite but here applied to the finite intersection $A \\cap [1, N]$). This is the building block for asymptotic density.",
+    "mathContext": "$\\text{countingFn}(A, N) = |A \\cap \\{1, \\ldots, N\\}| = \\text{Set.ncard}(A \\cap \\text{Set.Icc}\\, 1\\, N)$. The use of `Set.Icc 1 N` (closed interval in $\\mathbb{N}$) ensures we count elements in $\\{1, 2, \\ldots, N\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Set.ncard", "Set.Icc", "counting measure", "partial sums"],
+    "prerequisites": ["set intersection", "natural number intervals", "cardinality"]
+  },
+  {
+    "id": "erdos-335-ann-density",
+    "proofId": "erdos-335",
+    "range": { "startLine": 34, "endLine": 35 },
+    "type": "definition",
     "title": "Asymptotic Density",
     "content": "**asympDensity A** $= \\lim_{N \\to \\infty} |A \\cap [1,N]|/N$. The natural measure of 'how thick' a set of integers is, defined via `Filter.limUnder atTop`.",
     "significance": "key",


### PR DESCRIPTION
## Summary

Enrichment passes for erdos-27, erdos-282, and erdos-276.

### erdos-27 (Almost Covering Systems)
- Added `mathContext` to all 18 annotations with `relatedConcepts` and `prerequisites`
- Expanded `historicalContext` with FFKPY disproof details, Carmichael number connections
- Enriched `keyInsights` with critical threshold analysis, telescoping product barrier

### erdos-282 (Greedy Algorithm for Egyptian Fractions)
- Added `mathContext` to all 13 annotations (expanded from 7), added 6 new annotations
- Expanded `historicalContext` with Rhind Papyrus origins, Fibonacci's descent argument
- Enriched `keyInsights` with representability vs termination gap, dense vs sparse dichotomy
- Added missing `proofRepoPath` field

### erdos-276 (Composite Lucas Sequences)
- Added `mathContext` to all 8 annotations (expanded from 6), added 2 new annotations
- Expanded `historicalContext` with Graham's Pisano period construction, optimization race
- Enriched `keyInsights` with Pisano period bridge, covering system necessity, Fibonacci primes contrast
- Added missing `proofRepoPath` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)