### PR TITLE
enrich(erdos-50): deepen annotations and meta for totient distribution singularity

### DIFF
--- a/src/data/proofs/erdos-50/annotations.json
+++ b/src/data/proofs/erdos-50/annotations.json
@@ -1,74 +1,158 @@
 [
   {
+    "id": "erdos-50-ann-imports",
+    "proofId": "erdos-50",
+    "type": "concept",
+    "range": { "startLine": 28, "endLine": 32 },
+    "title": "Imports and Setup",
+    "content": "Imports $\\texttt{Nat.Totient}$ for Euler's totient function $\\varphi(n)$, $\\texttt{MeasureTheory.Measure.Lebesgue.Basic}$ for the Lebesgue measure and almost-everywhere quantifiers ($\\forall^\\text{ae}$), and $\\texttt{Tactic}$ for proof automation. Opens $\\texttt{Filter}$ and $\\texttt{Finset}$ namespaces for asymptotic density definitions.",
+    "mathContext": "The formalization uses $\\texttt{Nat.totient}$ for $\\varphi(n)$, $\\texttt{HasDerivAt}$ for the derivative condition $f'(x) = 0$, and $\\forall^{\\text{ae}}$ for Lebesgue-a.e. statements. The $\\texttt{Filter.liminf}$ captures the natural density as an asymptotic limit.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.totient", "MeasureTheory.MeasureSpace.volume", "Filter.liminf"],
+    "prerequisites": ["Lean 4 import system", "Mathlib measure theory"]
+  },
+  {
     "id": "erdos-50-ann-totientSet",
     "proofId": "erdos-50",
-    "range": { "startLine": 33, "endLine": 34 },
     "type": "definition",
-    "title": "totientRatioBelow",
-    "content": "The set {n > 0 : φ(n)/n < c}. The ratio φ(n)/n measures how 'divisible' n is by small primes.",
-    "significance": "critical"
+    "range": { "startLine": 37, "endLine": 38 },
+    "title": "Totient Ratio Sublevel Set",
+    "content": "The set $\\{n \\in \\mathbb{N} : n > 0,\\; \\varphi(n)/n < c\\}$ for $c \\in [0,1]$. The ratio $\\varphi(n)/n = \\prod_{p \\mid n}(1 - 1/p)$ measures how 'smooth' or 'highly composite' $n$ is: it is small when $n$ has many small prime factors (e.g., primorials $p_k\\# = 2 \\cdot 3 \\cdot 5 \\cdots p_k$) and close to 1 when $n$ is prime.",
+    "mathContext": "$\\texttt{totientRatioBelow}(c) = \\{n \\in \\mathbb{N}^+ : \\varphi(n)/n < c\\}$. For $c = 1/2$: includes all even $n > 2$ (since $\\varphi(2k)/(2k) \\leq 1/2$). For $c = 1$: equals $\\{n > 1\\}$.",
+    "significance": "critical",
+    "relatedConcepts": ["Euler totient", "prime factorization", "smooth numbers", "sublevel set"],
+    "prerequisites": ["Nat.totient", "prime divisors"]
+  },
+  {
+    "id": "erdos-50-ann-density",
+    "proofId": "erdos-50",
+    "type": "definition",
+    "range": { "startLine": 41, "endLine": 44 },
+    "title": "Natural Density via $\\liminf$",
+    "content": "The natural density $d(S) = \\lim_{N \\to \\infty} \\frac{|S \\cap \\{0,\\ldots,N\\}|}{N+1}$ formalized as $\\texttt{Filter.liminf}$ of the counting ratios. When the limit exists (as Schoenberg proved for $S = \\{n : \\varphi(n)/n < c\\}$), this equals the standard natural density.",
+    "mathContext": "$\\texttt{naturalDensity}(S) = \\liminf_{N \\to \\infty} \\frac{|S \\cap [0,N]|}{N+1}$. For well-behaved sets, $\\liminf = \\limsup$ and the density is the common limit. Schoenberg's theorem guarantees this for the totient sublevel sets.",
+    "significance": "key",
+    "relatedConcepts": ["natural density", "asymptotic density", "Filter.liminf", "Schnirelmann density"],
+    "prerequisites": ["Finset.filter", "Finset.card", "Filter.atTop"]
   },
   {
     "id": "erdos-50-ann-schoenbergF",
     "proofId": "erdos-50",
-    "range": { "startLine": 44, "endLine": 45 },
     "type": "definition",
-    "title": "Schoenberg's Distribution Function",
-    "content": "f(c) = natural density of {n : φ(n)/n < c}. Schoenberg proved this limit exists for all c ∈ [0,1].",
-    "significance": "critical"
+    "range": { "startLine": 49, "endLine": 50 },
+    "title": "Schoenberg's Distribution Function $f$",
+    "content": "The distribution function $f(c) = d(\\{n : \\varphi(n)/n < c\\})$ gives the natural density of integers whose totient ratio falls below $c$. Isaac Schoenberg proved in 1928 that $f$ is well-defined, continuous, and monotone non-decreasing on $[0,1]$ with $f(0) = 0$ and $f(1) = 1$—making it a continuous CDF of a probability measure $\\mu_f$ on $[0,1]$.",
+    "mathContext": "$f(c) = \\lim_{N \\to \\infty} \\frac{|\\{n \\leq N : \\varphi(n)/n < c\\}|}{N}$. As a CDF: $\\mu_f([a,b)) = f(b) - f(a)$. Schoenberg (1928): $f$ is continuous and $f(0) = 0$, $f(1) = 1$.",
+    "significance": "critical",
+    "relatedConcepts": ["distribution function", "CDF", "probability measure", "Stieltjes measure"],
+    "prerequisites": ["naturalDensity", "totientRatioBelow"]
   },
   {
-    "id": "erdos-50-ann-schoenberg",
+    "id": "erdos-50-ann-schoenberg-thm",
     "proofId": "erdos-50",
-    "range": { "startLine": 51, "endLine": 52 },
     "type": "theorem",
-    "title": "Schoenberg's Density Theorem",
-    "content": "The natural density of {n : φ(n)/n < c} exists for every c ∈ [0,1] and lies in [0,1].",
-    "significance": "key"
+    "range": { "startLine": 56, "endLine": 57 },
+    "title": "Schoenberg's Density Theorem (1928)",
+    "content": "For every $c \\in [0,1]$, the natural density $d(\\{n : \\varphi(n)/n < c\\})$ exists and lies in $[0,1]$. Schoenberg's proof uses the multiplicative structure of $\\varphi(n)/n = \\prod_{p \\mid n}(1-1/p)$ and the independence of divisibility by distinct primes to establish convergence of the counting function.",
+    "mathContext": "$\\forall c \\in [0,1],\\; \\exists d \\in [0,1] : f(c) = d$. Schoenberg's argument: $\\varphi(n)/n$ is a multiplicative function of $n$'s prime factors, and the 'events' $p \\mid n$ are asymptotically independent by the Chinese Remainder Theorem.",
+    "significance": "key",
+    "relatedConcepts": ["density existence", "multiplicative functions", "Chinese Remainder Theorem"],
+    "prerequisites": ["schoenbergF", "natural density convergence"]
+  },
+  {
+    "id": "erdos-50-ann-mono",
+    "proofId": "erdos-50",
+    "type": "theorem",
+    "range": { "startLine": 60, "endLine": 61 },
+    "title": "Monotonicity of $f$",
+    "content": "The distribution function $f$ is monotone non-decreasing: if $c_1 \\leq c_2$, then $f(c_1) \\leq f(c_2)$. This follows immediately from the set inclusion $\\{n : \\varphi(n)/n < c_1\\} \\subseteq \\{n : \\varphi(n)/n < c_2\\}$, so the density of the smaller set cannot exceed that of the larger.",
+    "mathContext": "$c_1 \\leq c_2 \\Rightarrow \\{n : \\varphi(n)/n < c_1\\} \\subseteq \\{n : \\varphi(n)/n < c_2\\} \\Rightarrow f(c_1) \\leq f(c_2)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["monotone function", "set inclusion", "density monotonicity"],
+    "prerequisites": ["schoenbergF", "sublevel set ordering"]
+  },
+  {
+    "id": "erdos-50-ann-boundary",
+    "proofId": "erdos-50",
+    "type": "theorem",
+    "range": { "startLine": 64, "endLine": 64 },
+    "title": "Boundary Values $f(0) = 0$, $f(1) = 1$",
+    "content": "At the endpoints: $f(0) = 0$ because no positive integer satisfies $\\varphi(n)/n < 0$, and $f(1) = 1$ because $\\varphi(n)/n < 1$ for all $n > 1$ (with only $\\varphi(1)/1 = 1$ excluded, having density 0).",
+    "mathContext": "$f(0) = d(\\emptyset) = 0$; $f(1) = d(\\{n > 1\\}) = 1$. Only $n = 1$ satisfies $\\varphi(n)/n = 1$; all $n > 1$ have $\\varphi(n)/n < 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["boundary conditions", "totient of 1", "density of cofinite sets"],
+    "prerequisites": ["schoenbergF", "totient_ratio_lt_one"]
   },
   {
     "id": "erdos-50-ann-continuous",
     "proofId": "erdos-50",
-    "range": { "startLine": 62, "endLine": 62 },
     "type": "theorem",
-    "title": "Continuity of f",
-    "content": "Schoenberg's function f is continuous on [0,1], making it a distribution function of a continuous probability measure.",
-    "significance": "key"
+    "range": { "startLine": 67, "endLine": 67 },
+    "title": "Continuity of $f$",
+    "content": "Schoenberg's function $f$ is continuous on $[0,1]$, meaning the corresponding measure $\\mu_f$ is atomless—no single value $c$ has positive mass. This follows because $\\{n : \\varphi(n)/n = c\\}$ has density zero for each fixed $c$ (the set of $n$ with $\\varphi(n)/n$ equal to a specific value is thin).",
+    "mathContext": "$f \\in C([0,1])$. Continuity of $f$ at $c$ means $\\mu_f(\\{c\\}) = f(c^+) - f(c^-) = 0$: no atom at $c$. The measure $\\mu_f = df$ is atomless but singular.",
+    "significance": "key",
+    "relatedConcepts": ["continuous distribution", "atomless measure", "Cantor function analogy"],
+    "prerequisites": ["schoenbergF", "Schoenberg's theorem"]
   },
   {
     "id": "erdos-50-ann-singular",
     "proofId": "erdos-50",
-    "range": { "startLine": 69, "endLine": 71 },
     "type": "theorem",
-    "title": "Erdős's Pure Singularity",
-    "content": "f'(x) = 0 for Lebesgue-almost every x ∈ [0,1]. The function increases only on a set of measure zero — a purely singular distribution.",
-    "significance": "critical"
+    "range": { "startLine": 74, "endLine": 77 },
+    "title": "Erdős's Pure Singularity Theorem",
+    "content": "Erdős proved that $f'(x) = 0$ for Lebesgue-almost every $x \\in [0,1]$: the distribution function $f$ is purely singular. Like the Cantor function, $f$ is continuous and non-decreasing but manages to increase from 0 to 1 while having zero derivative almost everywhere. The increase is concentrated on a Lebesgue-null set—the 'singular support' of $\\mu_f$.",
+    "mathContext": "$f'(x) = 0$ for a.e. $x \\in [0,1]$ with respect to Lebesgue measure [Erdős]. Equivalently, $\\mu_f \\perp \\lambda$ where $\\lambda$ is Lebesgue measure. The measure $\\mu_f$ is supported on a set of Lebesgue measure zero, analogous to the Cantor measure on the Cantor set.",
+    "significance": "critical",
+    "relatedConcepts": ["purely singular function", "Cantor function", "singular measure", "Lebesgue decomposition"],
+    "prerequisites": ["schoenbergF_continuous", "HasDerivAt", "MeasureTheory.ae"]
   },
   {
     "id": "erdos-50-ann-conjecture",
     "proofId": "erdos-50",
-    "range": { "startLine": 78, "endLine": 79 },
     "type": "theorem",
-    "title": "Main Conjecture ($250)",
-    "content": "There is no x where f'(x) exists and is positive. This strengthens 'a.e. zero derivative' to 'everywhere zero where defined.'",
-    "significance": "critical"
+    "range": { "startLine": 85, "endLine": 86 },
+    "title": "Erdős Problem #50: The $250 Prize Conjecture",
+    "content": "The $250 prize question: is it true that $f'(x) > 0$ for **no** $x$ whatsoever? Erdős proved $f'(x) = 0$ almost everywhere, but 'almost everywhere' allows a measure-zero exceptional set where $f'(x)$ might exist and be positive. The conjecture asks whether this exceptional set is actually empty. The distinction between 'measure-zero exceptions' and 'no exceptions' is subtle but fundamental in analysis.",
+    "mathContext": "$\\neg \\exists x \\in \\mathbb{R},\\; \\exists d > 0 : f'(x) = d$. Equivalently: wherever $f$ is differentiable, $f'(x) = 0$. This would mean the singular support of $\\mu_f$ has no points of 'local absolute continuity.'",
+    "significance": "critical",
+    "relatedConcepts": ["pointwise vs. a.e.", "differentiability of singular functions", "Erdős prize problems"],
+    "prerequisites": ["erdos_purely_singular", "HasDerivAt"]
   },
   {
     "id": "erdos-50-ann-product",
     "proofId": "erdos-50",
-    "range": { "startLine": 85, "endLine": 86 },
-    "type": "concept",
-    "title": "Euler Product Formula",
-    "content": "φ(n)/n = ∏_{p | n} (1 − 1/p). The ratio depends only on the set of prime divisors, not their multiplicities.",
-    "significance": "key"
+    "type": "theorem",
+    "range": { "startLine": 92, "endLine": 93 },
+    "title": "Euler Product Formula for $\\varphi(n)/n$",
+    "content": "The fundamental identity $\\varphi(n)/n = \\prod_{p \\mid n}(1 - 1/p)$ shows the totient ratio depends only on the set of prime divisors, not their multiplicities. For example, $\\varphi(12)/12 = (1-1/2)(1-1/3) = 1/3$ and $\\varphi(72)/72 = (1-1/2)(1-1/3) = 1/3$ since both have the same prime factors $\\{2,3\\}$.",
+    "mathContext": "$\\varphi(n)/n = \\prod_{p \\in \\texttt{n.primeFactors}} (1 - 1/p)$. This multiplicative structure is key to Schoenberg's proof: the events '$p \\mid n$' for distinct primes $p$ are asymptotically independent.",
+    "significance": "key",
+    "relatedConcepts": ["Euler product", "multiplicative functions", "prime factorization", "Nat.primeFactors"],
+    "prerequisites": ["Nat.totient", "Finset.prod"]
   },
   {
     "id": "erdos-50-ann-inf",
     "proofId": "erdos-50",
-    "range": { "startLine": 91, "endLine": 92 },
-    "type": "concept",
-    "title": "Infimum is Zero",
-    "content": "liminf φ(n)/n = 0, achieved along primorials (products of the first k primes).",
-    "significance": "supporting"
+    "type": "theorem",
+    "range": { "startLine": 97, "endLine": 98 },
+    "title": "Infimum of $\\varphi(n)/n$ is Zero",
+    "content": "The $\\liminf$ of $\\varphi(n)/n$ as $n \\to \\infty$ is 0, achieved along primorials $p_k\\# = 2 \\cdot 3 \\cdot 5 \\cdots p_k$. Since $\\varphi(p_k\\#)/p_k\\# = \\prod_{i=1}^k (1 - 1/p_i) \\to 0$ (the product diverges to 0 by Mertens' theorem: $\\prod_{p \\leq x}(1-1/p) \\sim e^{-\\gamma}/\\log x$), the totient ratio can be made arbitrarily small.",
+    "mathContext": "$\\liminf_{n \\to \\infty} \\varphi(n)/n = 0$. Along primorials: $\\varphi(p_k\\#)/p_k\\# = \\prod_{p \\leq p_k}(1 - 1/p) \\sim \\frac{2e^{-\\gamma}}{\\log p_k} \\to 0$ by Mertens' third theorem ($\\gamma \\approx 0.5772$).",
+    "significance": "key",
+    "relatedConcepts": ["primorials", "Mertens' theorem", "Euler-Mascheroni constant", "highly composite numbers"],
+    "prerequisites": ["totient_ratio_product", "prime number theorem"]
+  },
+  {
+    "id": "erdos-50-ann-lt-one",
+    "proofId": "erdos-50",
+    "type": "theorem",
+    "range": { "startLine": 102, "endLine": 103 },
+    "title": "$\\varphi(n)/n < 1$ for $n > 1$",
+    "content": "For every $n > 1$, $\\varphi(n)/n < 1$ because $n$ has at least one prime factor $p$, giving $\\varphi(n)/n \\leq 1 - 1/p < 1$. The unique maximum $\\varphi(1)/1 = 1$ occurs only at $n = 1$. This ensures $f(1) = 1$: the density of $\\{n > 0 : \\varphi(n)/n < 1\\}$ is 1 since only $n = 1$ is excluded.",
+    "mathContext": "$n > 1 \\Rightarrow \\exists p \\text{ prime}, p \\mid n \\Rightarrow \\varphi(n)/n \\leq 1 - 1/p < 1$. The function $\\varphi(n)/n$ achieves its supremum 1 uniquely at $n = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["prime divisor existence", "totient upper bound", "φ(1) = 1"],
+    "prerequisites": ["Nat.totient", "prime factorization"]
   }
 ]

--- a/src/data/proofs/erdos-50/meta.json
+++ b/src/data/proofs/erdos-50/meta.json
@@ -1,83 +1,123 @@
 {
   "id": "erdos-50",
-  "title": "Singularity of the Totient Distribution Function",
+  "title": "Erdős Problem #50: Singularity of the Totient Distribution Function",
   "slug": "erdos-50",
   "description": "Schoenberg proved the density f(c) = d({n : φ(n)/n < c}) exists for all c. Erdős showed f is purely singular. $250 prize: is it true that f'(x) > 0 for no x?",
   "meta": {
-    "author": "Erdős",
+    "author": "Schoenberg (1928, density existence); Erdős (pure singularity, $250 prize question)",
     "sourceUrl": "https://erdosproblems.com/50",
+    "date": "1930s",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos50Problem.lean",
     "tags": [
       "erdos",
-      "number theory",
-      "Euler totient",
-      "distribution functions",
-      "singular functions",
-      "measure theory"
+      "number-theory",
+      "Euler-totient",
+      "distribution-functions",
+      "singular-functions",
+      "measure-theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 50,
     "erdosUrl": "https://erdosproblems.com/50",
-    "erdosProblemStatus": "open"
+    "erdosProblemStatus": "open",
+    "mathlib_version": "4.15.0",
+    "mathlibDependencies": [
+      { "theorem": "Nat.totient", "description": "Euler's totient function φ(n)", "module": "Mathlib.Data.Nat.Totient" },
+      { "theorem": "MeasureTheory.MeasureSpace.volume", "description": "Lebesgue measure on ℝ", "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Basic" },
+      { "theorem": "HasDerivAt", "description": "Derivative existence at a point", "module": "Mathlib.Analysis.Calculus.Deriv.Basic" },
+      { "theorem": "Filter.liminf", "description": "Limit inferior along a filter", "module": "Mathlib.Order.Filter.Basic" },
+      { "theorem": "Continuous", "description": "Topological continuity", "module": "Mathlib.Topology.Basic" }
+    ],
+    "originalContributions": [
+      "totientRatioBelow: sublevel set {n > 0 : φ(n)/n < c}",
+      "naturalDensity: asymptotic natural density via Filter.liminf",
+      "schoenbergF: Schoenberg's distribution function f(c)",
+      "schoenberg_density_exists: density exists for all c ∈ [0,1] (axiomatized)",
+      "schoenbergF_mono: monotonicity of f (axiomatized)",
+      "schoenbergF_boundary: f(0) = 0 and f(1) = 1 (axiomatized)",
+      "schoenbergF_continuous: continuity of f (axiomatized)",
+      "erdos_purely_singular: f'(x) = 0 a.e. (axiomatized)",
+      "erdos_50_conjecture: f'(x) > 0 for no x (axiomatized)",
+      "totient_ratio_product: Euler product formula (axiomatized)",
+      "totient_ratio_inf: liminf φ(n)/n = 0 (axiomatized)",
+      "totient_ratio_lt_one: φ(n)/n < 1 for n > 1 (axiomatized)"
+    ],
+    "dateAdded": "2026-01-19"
   },
   "overview": {
-    "historicalContext": "Schoenberg proved that the distribution of φ(n)/n has a well-defined density function f(c). Erdős proved f is purely singular — continuous but with derivative zero almost everywhere. The $250 prize asks whether f'(x) > 0 for literally no x, not just almost no x.",
-    "problemStatement": "Is it true that there is no x such that f'(x) exists and is positive, where f(c) is the density of {n : φ(n)/n < c}?",
-    "proofStrategy": "We formalize the totient ratio set, Schoenberg's density function f, its properties (continuity, monotonicity, boundary values), Erdős's pure singularity result, and the main prize conjecture.",
+    "historicalContext": "Isaac Schoenberg proved in 1928 that for every $c \\in [0,1]$, the natural density $f(c) = d(\\{n : \\varphi(n)/n < c\\})$ exists, giving a well-defined continuous distribution function on $[0,1]$. Erdős studied this function intensively and proved a remarkable result: $f$ is purely singular—continuous and non-decreasing from 0 to 1, yet $f'(x) = 0$ for Lebesgue-almost every $x$. This makes $f$ analogous to the classical Cantor function (devil's staircase), which climbs from 0 to 1 on the Cantor set while having zero derivative almost everywhere. Erdős offered a $250 prize for the following strengthening: is it true that there is no $x$ at all where $f'(x)$ exists and is positive? This is the subtle distinction between 'zero derivative almost everywhere' (which allows a measure-zero exceptional set) and 'zero derivative everywhere it exists' (no exceptions). The problem connects Euler's totient function—one of the oldest objects in number theory, studied by Euler in the 1760s—to deep questions in real analysis about the differentiability of singular measures. The multiplicative structure $\\varphi(n)/n = \\prod_{p \\mid n}(1-1/p)$ ties the distribution to probabilistic number theory and Mertens' theorem on products over primes.",
+    "problemStatement": "**Problem Statement (OPEN, $250 prize)**\n\nLet $f(c) = d(\\{n : \\varphi(n)/n < c\\})$ be Schoenberg's distribution function. Erdős proved $f'(x) = 0$ for Lebesgue-almost every $x$.\n\n**Question:** Is it true that there is no $x$ such that $f'(x)$ exists and is positive?\n\nEquivalently: wherever $f$ is differentiable, is the derivative necessarily zero?",
+    "proofStrategy": "The formalization defines the totient ratio sublevel set, natural density via $\\texttt{Filter.liminf}$, and Schoenberg's distribution function $f$. It axiomatizes Schoenberg's density existence theorem, the properties of $f$ (monotonicity, boundary values, continuity), Erdős's pure singularity result ($f' = 0$ a.e.), and the $250 prize conjecture ($f'(x) > 0$ for no $x$). Properties of $\\varphi(n)/n$ including the Euler product formula are also axiomatized.",
     "keyInsights": [
-      "φ(n)/n = ∏_{p | n} (1 − 1/p) depends only on the prime factorization",
-      "Schoenberg's theorem: the density f(c) exists for all c ∈ [0,1]",
-      "Erdős proved f is purely singular: f' = 0 a.e.",
-      "The $250 question asks: does f'(x) > 0 for literally no x?",
-      "The distinction is between 'almost everywhere zero' and 'everywhere zero where it exists'"
+      "**Cantor function analogy:** Schoenberg's $f$ is a naturally occurring 'devil's staircase'—continuous and non-decreasing from 0 to 1 but with zero derivative almost everywhere, just like the classical Cantor function",
+      "**Measure-zero vs. empty:** Erdős's $250 question distinguishes between $f'(x) = 0$ for a.e. $x$ (proved) and $f'(x) > 0$ for no $x$ (open)—a subtle gap between measure theory and pointwise analysis",
+      "**Multiplicative structure:** The Euler product $\\varphi(n)/n = \\prod_{p \\mid n}(1-1/p)$ makes the totient ratio depend only on the prime support, connecting to probabilistic independence of prime divisibility events",
+      "**Mertens' theorem connection:** The vanishing of $\\varphi(n)/n$ along primorials follows from $\\prod_{p \\leq x}(1-1/p) \\sim 2e^{-\\gamma}/\\log x \\to 0$, connecting Schoenberg's function to prime distribution theory",
+      "**Singular measures in nature:** Unlike the Cantor function (which is constructed artificially), Schoenberg's $f$ arises naturally from number-theoretic data—a rare example of a 'natural' singular distribution"
     ]
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 28,
+      "endLine": 32,
+      "summary": "Imports $\\texttt{Nat.Totient}$ for $\\varphi(n)$, $\\texttt{MeasureTheory.Measure.Lebesgue.Basic}$ for the Lebesgue measure and $\\forall^{\\text{ae}}$ quantifier, and opens $\\texttt{Filter}$/$\\texttt{Finset}$ for density computation."
+    },
+    {
       "id": "definitions",
       "title": "Core Definitions",
-      "startLine": 27,
-      "endLine": 46,
-      "summary": "Defines the set {n : φ(n)/n < c}, natural density, and Schoenberg's distribution function f(c)."
+      "startLine": 34,
+      "endLine": 50,
+      "summary": "Defines $\\texttt{totientRatioBelow}(c) = \\{n > 0 : \\varphi(n)/n < c\\}$, $\\texttt{naturalDensity}(S)$ via $\\texttt{Filter.liminf}$, and Schoenberg's $f(c) = d(\\{n : \\varphi(n)/n < c\\})$."
     },
     {
       "id": "schoenberg",
-      "title": "Schoenberg's Theorem",
-      "startLine": 48,
-      "endLine": 63,
-      "summary": "The density exists for all c, f is monotone non-decreasing, f(0) = 0, f(1) = 1, and f is continuous."
+      "title": "Schoenberg's Theorem and Properties",
+      "startLine": 52,
+      "endLine": 67,
+      "summary": "Axiomatizes Schoenberg's density existence theorem, monotonicity ($c_1 \\leq c_2 \\Rightarrow f(c_1) \\leq f(c_2)$), boundary values ($f(0) = 0$, $f(1) = 1$), and continuity of $f$ on $[0,1]$."
     },
     {
       "id": "singularity",
-      "title": "Erdős's Pure Singularity",
-      "startLine": 65,
-      "endLine": 72,
-      "summary": "Erdős proved f'(x) = 0 for Lebesgue-almost every x ∈ [0,1]."
+      "title": "Erdős's Pure Singularity Result",
+      "startLine": 69,
+      "endLine": 77,
+      "summary": "Axiomatizes Erdős's theorem: $f'(x) = 0$ for Lebesgue-almost every $x \\in [0,1]$, making $f$ a purely singular distribution function analogous to the Cantor function."
     },
     {
       "id": "conjecture",
-      "title": "Main Conjecture ($250)",
-      "startLine": 74,
-      "endLine": 80,
-      "summary": "The $250 prize question: f'(x) > 0 for no x at all, not just almost no x."
+      "title": "Main Conjecture ($250 Prize)",
+      "startLine": 79,
+      "endLine": 86,
+      "summary": "The $250 prize question: $\\neg \\exists x,\\; \\exists d > 0 : f'(x) = d$. Wherever $f$ is differentiable, the derivative must be zero—strengthening 'a.e.' to 'everywhere it exists.'"
     },
     {
-      "id": "properties",
-      "title": "Properties of φ(n)/n",
-      "startLine": 82,
-      "endLine": 97,
-      "summary": "The Euler product formula for φ(n)/n, infimum is 0 (along primorials), and φ(n)/n < 1 for n > 1."
+      "id": "euler-product",
+      "title": "Euler Product Formula",
+      "startLine": 88,
+      "endLine": 93,
+      "summary": "Axiomatizes $\\varphi(n)/n = \\prod_{p \\in \\texttt{n.primeFactors}}(1 - 1/p)$: the totient ratio depends only on the prime support of $n$, not on multiplicities."
+    },
+    {
+      "id": "extremal",
+      "title": "Extremal Properties of $\\varphi(n)/n$",
+      "startLine": 95,
+      "endLine": 103,
+      "summary": "Axiomatizes $\\liminf \\varphi(n)/n = 0$ (via primorials and Mertens' theorem) and $\\varphi(n)/n < 1$ for $n > 1$ (from existence of a prime factor)."
     }
   ],
   "conclusion": {
-    "summary": "Formalizes Erdős Problem #50 on the singularity of the totient distribution function, including Schoenberg's density theorem, Erdős's pure singularity result, and the $250 prize question.",
-    "implications": "A positive answer would strengthen the purely singular characterization to a pointwise statement, revealing deep structure in the distribution of Euler's totient function.",
+    "summary": "Erdős Problem #50 asks whether Schoenberg's distribution function f—the natural density of {n : φ(n)/n < c}—has the property that f'(x) > 0 for no x at all. Erdős proved f is purely singular (f' = 0 a.e.), but the pointwise strengthening remains open with a $250 prize. The formalization axiomatizes Schoenberg's density theorem, all properties of f, Erdős's singularity result, and the prize conjecture.",
+    "implications": "A positive answer would establish that Schoenberg's function is 'maximally singular'—differentiable nowhere with positive derivative. This would reveal deep structure in the distribution of φ(n)/n and connect to broader questions about singular measures arising from number-theoretic data.",
     "openQuestions": [
-      "Does f'(x) > 0 for any x? ($250 prize)",
-      "What is the Hausdorff dimension of the support of df?",
-      "Can the singular measure df be characterized more explicitly?"
+      "Does f'(x) > 0 for any x at all? ($250 Erdős prize)",
+      "What is the Hausdorff dimension of the singular support of the measure df?",
+      "Can the singular measure df be expressed as a weak limit of discrete measures on the rationals {φ(n)/n}?",
+      "What is the modulus of continuity of f? Is f Hölder continuous, and if so, with what exponent?",
+      "Do analogous distribution functions for other multiplicative functions (e.g., σ(n)/n) exhibit similar singularity?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Expanded annotations from 8 to 13 with full `mathContext`, `relatedConcepts`, `prerequisites`
- Added imports annotation, natural density definition, monotonicity, boundary values, continuity annotations
- Expanded historicalContext with Schoenberg (1928), Cantor function analogy, Euler (1760s), Mertens' theorem, measure-zero vs. empty distinction
- Added `mathlibDependencies`, `originalContributions`, `mathlib_version`, `dateAdded`, detailed `author`/`date`
- 7 LaTeX sections covering full Lean file (104 lines)
- 5 bold keyInsights on Cantor analogy, measure-zero vs. empty, multiplicative structure, Mertens connection, natural singular measures
- 5 specific openQuestions including Hausdorff dimension and Hölder continuity

## Test plan
- [x] `pnpm annotations:build` passes (non-strict mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)