### PR TITLE
enrich(batch): deepen annotations and meta for erdos-230,546,55,551,552,557,559,57,58,59

### DIFF
--- a/src/data/proofs/erdos-551/annotations.json
+++ b/src/data/proofs/erdos-551/annotations.json
@@ -1,146 +1,74 @@
 [
   {
-    "id": "ann-551-cycle",
+    "id": "ann-551-defs",
     "proofId": "erdos-551",
-    "range": { "startLine": 36, "endLine": 49 },
+    "range": { "startLine": 34, "endLine": 91 },
     "type": "definition",
-    "title": "cycleGraph",
-    "content": "The cycle graph C_k on k vertices.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-551-contains-cycle",
-    "proofId": "erdos-551",
-    "range": { "startLine": 55, "endLine": 58 },
-    "type": "definition",
-    "title": "ContainsCycle",
-    "content": "G contains C_k as a subgraph.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-551-contains-clique",
-    "proofId": "erdos-551",
-    "range": { "startLine": 60, "endLine": 62 },
-    "type": "definition",
-    "title": "ContainsClique",
-    "content": "G contains K_n as a subgraph (clique).",
-    "significance": "critical"
+    "title": "Graph Definitions: Cycles, Cliques, and Containment",
+    "content": "**cycleGraph** $C_k$ on $k$ vertices: adjacent if indices differ by 1 modulo $k$.\n\n**completeGraph** $K_n$ is the top element of the SimpleGraph lattice (all edges present).\n\n**ContainsCycle** formalizes '$G$ contains $C_k$' via an injective embedding $f: \\text{Fin}\\,k \\to V$ preserving adjacency.\n\n**ContainsClique** formalizes '$G$ contains $K_n$' via a Finset $S$ of size $n$ that forms a clique in $G$.\n\nThese definitions encode the asymmetric Ramsey problem: we seek a red $C_k$ or blue $K_n$.",
+    "mathContext": "$C_k$ is the graph with vertex set $\\{0, \\ldots, k-1\\}$ and edges $\\{i, (i+1) \\bmod k\\}$. $G$ contains $C_k$ if $\\exists$ injective $f: [k] \\hookrightarrow V(G)$ with $f(i) \\sim f((i+1) \\bmod k)$ for all $i$. $G$ contains $K_n$ if $\\exists S \\subseteq V(G)$ with $|S| = n$ forming a clique.",
+    "significance": "critical",
+    "relatedConcepts": ["Hamiltonian cycles", "clique number", "graph embedding", "cycle detection"],
+    "prerequisites": ["graph theory", "modular arithmetic", "injective functions"]
   },
   {
     "id": "ann-551-ramsey",
     "proofId": "erdos-551",
-    "range": { "startLine": 66, "endLine": 73 },
+    "range": { "startLine": 96, "endLine": 157 },
     "type": "definition",
-    "title": "RamseyNumber",
-    "content": "R(C_k, K_n): min N with red C_k or blue K_n.",
-    "significance": "critical"
+    "title": "Ramsey Number R(C_k, K_n) and the Conjecture",
+    "content": "**RamseyNumber** $R(C_k, K_n)$: minimum $N$ such that every 2-coloring of $K_N$ contains a red $C_k$ or blue $K_n$. Defined via `Nat.find`.\n\n**RamseyProperty**: the Ramsey property for given parameters.\n\n**ConjecturedFormula**: $R(C_k, K_n) = (k-1)(n-1) + 1$. This elegant product formula was conjectured by Erdős, Faudree, Rousseau, and Schelp.\n\n**MainConjecture**: the formula holds for all $k \\geq n \\geq 3$ except $(k,n) = (3,3)$.\n\n**exception_3_3**: $R(C_3, K_3) = R(K_3, K_3) = 6 \\neq 5 = (3-1)(3-1)+1$.",
+    "mathContext": "$R(C_k, K_n) = \\min\\{N : K_N \\to \\{\\text{red, blue}\\} \\Rightarrow \\text{red } C_k \\text{ or blue } K_n\\}$. The conjecture $R(C_k, K_n) = (k-1)(n-1)+1$ for $k \\geq n \\geq 3$ (except $(3,3)$) has a beautiful structural explanation: the lower bound graph consists of $(n-1)$ disjoint copies of $K_{k-1}$, which has $(k-1)(n-1)$ vertices, avoids $C_k$ (each component is too small) and its complement avoids $K_n$ (independence number $n-1$).",
+    "significance": "critical",
+    "relatedConcepts": ["asymmetric Ramsey numbers", "Turán-type problems", "graph coloring"],
+    "prerequisites": ["Ramsey theory", "Nat.find", "complete graphs"]
   },
   {
-    "id": "ann-551-formula",
+    "id": "ann-551-lower-bound",
     "proofId": "erdos-551",
-    "range": { "startLine": 88, "endLine": 89 },
-    "type": "definition",
-    "title": "ConjecturedFormula",
-    "content": "R(C_k, K_n) = (k-1)(n-1) + 1.",
-    "significance": "critical"
+    "range": { "startLine": 191, "endLine": 232 },
+    "type": "technique",
+    "title": "Lower Bound: Disjoint Cliques Construction",
+    "content": "**LowerBoundGraph**: $(n-1)$ disjoint copies of $K_{k-1}$, constructed by partitioning vertices via integer division. Vertices $i, j$ are adjacent iff $\\lfloor i/(k-1) \\rfloor = \\lfloor j/(k-1) \\rfloor$ and $i \\neq j$.\n\n**lower_bound_no_cycle**: Each component has $k-1$ vertices, so no component can contain $C_k$ (a cycle needs $k$ vertices).\n\n**lower_bound_complement_no_clique**: The complement consists of $(n-1)$ independent sets of size $k-1$. Any clique in the complement must take at most one vertex from each component, giving at most $n-1$ vertices — too small for $K_n$.",
+    "mathContext": "The graph $G = K_{k-1} \\sqcup K_{k-1} \\sqcup \\cdots \\sqcup K_{k-1}$ ($n-1$ copies) has $(k-1)(n-1)$ vertices. Since $C_k$ requires $k$ vertices and each component has only $k-1$, $G$ is $C_k$-free. The complement $\\bar{G}$ is a complete $(n-1)$-partite graph with parts of size $k-1$, so $\\omega(\\bar{G}) = n-1 < n$, meaning $\\bar{G}$ is $K_n$-free. This shows $R(C_k, K_n) \\geq (k-1)(n-1) + 1$.",
+    "significance": "critical",
+    "relatedConcepts": ["Turán graph", "complete multipartite graphs", "independence number", "disjoint union"],
+    "prerequisites": ["graph products", "clique number bounds", "Ramsey lower bounds"]
   },
   {
-    "id": "ann-551-exception",
+    "id": "ann-551-progression",
     "proofId": "erdos-551",
-    "range": { "startLine": 96, "endLine": 102 },
+    "range": { "startLine": 243, "endLine": 358 },
     "type": "theorem",
-    "title": "Exception (3,3)",
-    "content": "R(C_3, K_3) = 6 ≠ 5.",
-    "significance": "critical"
+    "title": "Progressive Results: Bondy-Erdős → Nikiforov → KLS",
+    "content": "Three progressively stronger results proving the formula for larger ranges:\n\n**bondy_erdos** (1973): Formula holds for $k > n^2 - 2$. The Bondy-Erdős threshold is quadratic in $n$.\n\n**nikiforov** (2005): Formula holds for $k \\geq 4n + 2$. Reduces the threshold from quadratic to linear. Uses spectral graph theory and eigenvalue bounds.\n\n**keevash_long_skokan** (2021): Formula holds for $k \\geq C \\log n / \\log \\log n$. Reduces the threshold to near-logarithmic. Uses the stability method and extremal graph theory.\n\n**kls_improves** (proved by Aristotle): For $n \\geq 100$, the KLS threshold $\\log n / \\log \\log n < 4n + 2$. This uses the bound $e < 3$.",
+    "mathContext": "The threshold progression: $n^2 - 1$ (Bondy-Erdős 1973) $\\to$ $4n + 2$ (Nikiforov 2005) $\\to$ $C \\log n / \\log \\log n$ (KLS 2021). For $n = 100$: Bondy-Erdős needs $k \\geq 9999$, Nikiforov needs $k \\geq 402$, KLS needs $k \\geq C \\cdot \\log 100 / \\log \\log 100 \\approx 3C$. The dramatic improvement from quadratic to near-logarithmic represents 48 years of progress.",
+    "significance": "critical",
+    "relatedConcepts": ["spectral graph theory", "stability method", "extremal graph theory", "Szemerédi regularity"],
+    "prerequisites": ["graph Ramsey theory", "eigenvalue methods", "logarithmic functions"]
   },
   {
-    "id": "ann-551-lower",
+    "id": "ann-551-special",
     "proofId": "erdos-551",
-    "range": { "startLine": 106, "endLine": 127 },
+    "range": { "startLine": 376, "endLine": 420 },
     "type": "theorem",
-    "title": "Lower Bound",
-    "content": "(n-1) copies of K_{k-1} avoid both.",
-    "significance": "critical"
+    "title": "Special Cases: Small Parameters and R(C_k, K_3)",
+    "content": "**cycle_3_is_triangle**: $R(C_3, K_n) = R(K_3, K_n)$ since $C_3 = K_3$.\n\n**ramsey_C4_K3** = 7 and **ramsey_C5_K3** = 9: small verified values.\n\n**ramsey_Ck_K3**: $R(C_k, K_3) = 2k - 1$ for $k \\geq 4$. This is the triangle case: every 2-coloring of $K_{2k-1}$ contains a red $C_k$ or a blue triangle. The formula gives $(k-1)(3-1)+1 = 2k-1$, confirming the conjecture for $n = 3$.",
+    "mathContext": "For $n = 3$: $R(C_k, K_3) = 2k - 1$ for all $k \\geq 4$. This was proved by Faudree and Schelp (1974) and independently by Rosta (1973). The proof uses the fact that a graph on $2k-1$ vertices with no triangle in the complement has minimum degree $\\geq k$, and Dirac's theorem gives a Hamiltonian cycle (hence $C_k$).",
+    "significance": "key",
+    "relatedConcepts": ["Dirac's theorem", "triangle-free graphs", "Ramsey numbers of triangles"],
+    "prerequisites": ["Hamiltonian cycle theory", "minimum degree conditions"]
   },
   {
-    "id": "ann-551-bondy",
+    "id": "ann-551-related-summary",
     "proofId": "erdos-551",
-    "range": { "startLine": 131, "endLine": 135 },
-    "type": "theorem",
-    "title": "Bondy-Erdős (1973)",
-    "content": "Formula holds for k > n² - 2.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-551-nikiforov",
-    "proofId": "erdos-551",
-    "range": { "startLine": 148, "endLine": 152 },
-    "type": "theorem",
-    "title": "Nikiforov (2005)",
-    "content": "Formula holds for k ≥ 4n + 2.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-551-kls",
-    "proofId": "erdos-551",
-    "range": { "startLine": 165, "endLine": 169 },
-    "type": "theorem",
-    "title": "Keevash-Long-Skokan (2021)",
-    "content": "Formula holds for k ≥ C log n / log log n.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-551-ck-k3",
-    "proofId": "erdos-551",
-    "range": { "startLine": 194, "endLine": 197 },
-    "type": "theorem",
-    "title": "R(C_k, K_3)",
-    "content": "R(C_k, K_3) = 2k - 1 for k ≥ 4.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-551-smallest-k",
-    "proofId": "erdos-551",
-    "range": { "startLine": 201, "endLine": 207 },
-    "type": "definition",
-    "title": "SmallestValidK",
-    "content": "Smallest k where identity holds for fixed n.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-551-mono",
-    "proofId": "erdos-551",
-    "range": { "startLine": 220, "endLine": 228 },
-    "type": "theorem",
-    "title": "Monotonicity",
-    "content": "R(C_k, K_n) non-decreasing in k and n.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-551-upper",
-    "proofId": "erdos-551",
-    "range": { "startLine": 238, "endLine": 242 },
-    "type": "theorem",
-    "title": "Upper Bound",
-    "content": "R(C_k, K_n) ≤ (k-1)(n-1) + 1.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-551-main",
-    "proofId": "erdos-551",
-    "range": { "startLine": 251, "endLine": 256 },
-    "type": "theorem",
-    "title": "Main Theorem",
-    "content": "Formula holds iff k ≥ SmallestValidK(n).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-551-solved",
-    "proofId": "erdos-551",
-    "range": { "startLine": 263, "endLine": 267 },
-    "type": "theorem",
-    "title": "Solved Asymptotically",
-    "content": "For each n, formula holds for large k.",
-    "significance": "critical"
+    "range": { "startLine": 425, "endLine": 604 },
+    "type": "insight",
+    "title": "Related Questions, Monotonicity, and Summary",
+    "content": "**SmallestValidK**: For fixed $n$, the smallest $k$ where the formula holds. KLS shows this is at most $O(\\log n / \\log \\log n)$.\n\n**MinRamseyValue**: For fixed $n$, the minimum of $R(C_k, K_n)$ over $k \\geq n$.\n\n**Monotonicity**: $R(C_k, K_n)$ is non-decreasing in both $k$ and $n$. The formula $(k-1)(n-1)+1$ is also monotone.\n\n**Upper bound**: The path-cycle method shows $R(C_k, K_n) \\leq (k-1)(n-1)+1$ for $k \\geq n \\geq 3$, $(k,n) \\neq (3,3)$.\n\n**main_theorem**: The formula holds iff $k \\geq \\text{SmallestValidK}(n)$.\n\n**solved_asymptotically**: For each $n \\geq 3$, the formula holds for all sufficiently large $k$.",
+    "mathContext": "The main theorem establishes $R(C_k, K_n) = (k-1)(n-1)+1 \\iff k \\geq k_0(n)$ where $k_0(n) \\leq \\lceil C \\log n / \\log \\log n \\rceil$. The problem is considered SOLVED: for any fixed $n$, the formula holds for all but finitely many $k$. The remaining question is determining $k_0(n)$ exactly.",
+    "significance": "critical",
+    "relatedConcepts": ["monotonicity of Ramsey numbers", "path-cycle method", "asymptotic Ramsey theory"],
+    "prerequisites": ["all preceding sections", "ceiling function"]
   }
 ]

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -22,111 +22,119 @@
     "erdosProblemStatus": "solved"
   },
   "overview": {
-    "historicalContext": "The Ramsey number R(C_k, K_n) asks for the minimum N such that any 2-coloring of K_N contains a red k-cycle or a blue n-clique. Erdős, Faudree, Rousseau, and Schelp conjectured R(C_k, K_n) = (k-1)(n-1) + 1 for k ≥ n ≥ 3, with one exception at (3,3).",
-    "problemStatement": "Prove R(C_k, K_n) = (k-1)(n-1) + 1 for k ≥ n ≥ 3, except when n = k = 3 where R(C_3, K_3) = 6. The lower bound comes from (n-1) disjoint copies of K_{k-1}. The upper bound requires showing any graph on (k-1)(n-1)+1 vertices contains C_k or its complement contains K_n.",
-    "proofStrategy": "We formalize cycle and clique containment, the Ramsey number definition, the conjectured formula, lower and upper bound constructions, and the progression of results from Bondy-Erdős through Keevash-Long-Skokan. The formalization includes monotonicity properties and related questions.",
+    "historicalContext": "The asymmetric Ramsey number R(C_k, K_n) asks for the minimum N such that every 2-coloring of the edges of K_N contains either a red k-cycle or a blue n-clique. Erdős, Faudree, Rousseau, and Schelp conjectured in 1978 that R(C_k, K_n) = (k-1)(n-1) + 1 for all k ≥ n ≥ 3, with a single exception at (k,n) = (3,3) where the formula gives 5 but the actual value is R(K_3, K_3) = 6. The lower bound comes from a beautiful construction: (n-1) disjoint copies of K_{k-1}, which has (k-1)(n-1) vertices, contains no C_k (each component is too small) and its complement contains no K_n (independence number n-1). Bondy and Erdős (1973) proved the formula for k > n² - 2, a quadratic threshold. Nikiforov (2005) dramatically improved this to k ≥ 4n + 2 using spectral graph theory and eigenvalue bounds. Finally, Keevash, Long, and Skokan (2021) achieved the near-optimal threshold k ≥ C log n / log log n using the stability method and extremal graph theory. The special case R(C_k, K_3) = 2k - 1 for k ≥ 4 was proved independently by Faudree-Schelp (1974) and Rosta (1973) using Dirac's theorem. The formalization includes a formally verified proof (by Aristotle) that the KLS threshold improves on Nikiforov's for n ≥ 100, using the bound e < 3.",
+    "problemStatement": "Prove $R(C_k, K_n) = (k-1)(n-1) + 1$ for $k \\geq n \\geq 3$, except when $n = k = 3$ where $R(C_3, K_3) = 6$. The lower bound comes from $(n-1)$ disjoint copies of $K_{k-1}$. The upper bound requires showing any graph on $(k-1)(n-1)+1$ vertices contains $C_k$ or its complement contains $K_n$.",
+    "proofStrategy": "The formalization defines cycle graphs $C_k$, complete graphs $K_n$, and formalizes containment of cycles and cliques via injective embeddings. The Ramsey number $R(C_k, K_n)$ is defined via `Nat.find`. The lower bound graph — $(n-1)$ disjoint copies of $K_{k-1}$ — is explicitly constructed with adjacency determined by integer division. Three progressively stronger theorems are stated: Bondy-Erdős (quadratic threshold), Nikiforov (linear threshold), and Keevash-Long-Skokan (near-logarithmic threshold). The theorem `kls_improves` was formally verified by Aristotle using the bound $e < 3$. Special cases include $R(C_k, K_3) = 2k-1$ and verified values $R(C_4, K_3) = 7$, $R(C_5, K_3) = 9$. Monotonicity in both parameters and the path-cycle upper bound method complete the picture.",
     "keyInsights": [
-      "Bondy-Erdős (1973): k > n² - 2",
-      "Nikiforov (2005): k ≥ 4n + 2",
-      "Keevash-Long-Skokan (2021): k ≥ C log n / log log n",
-      "Exception: R(C_3, K_3) = 6 ≠ 5",
-      "Lower bound: (n-1) copies of K_{k-1}",
-      "R(C_k, K_3) = 2k - 1 for k ≥ 4"
+      "The threshold progression is dramatic: $n^2 - 1$ (Bondy-Erdős 1973) $\\to$ $4n + 2$ (Nikiforov 2005) $\\to$ $C \\log n / \\log \\log n$ (KLS 2021) — from quadratic to near-logarithmic over 48 years",
+      "The lower bound graph $(n-1) \\sqcup K_{k-1}$ is simultaneously $C_k$-free (components too small for a $k$-cycle) and its complement is $K_n$-free (independence number $n-1$), giving $R(C_k, K_n) \\geq (k-1)(n-1) + 1$",
+      "The exception at $(3,3)$: since $C_3 = K_3$, $R(C_3, K_3) = R(K_3, K_3) = 6$ by classical Ramsey theory, but the formula gives $(3-1)(3-1)+1 = 5$",
+      "For $n = 100$: Bondy-Erdős needs $k \\geq 9999$, Nikiforov needs $k \\geq 402$, KLS needs $k \\geq 3C$ — the improvement is thousandfold",
+      "The triangle case $R(C_k, K_3) = 2k - 1$ for $k \\geq 4$ follows from Dirac's theorem: a graph on $2k-1$ vertices with no triangle in the complement has minimum degree $\\geq k$, hence a Hamiltonian cycle",
+      "Aristotle formally verified `kls_improves`: for $n \\geq 100$, $\\log n / \\log \\log n < 4n + 2$, using $e < 3$ proved via Taylor expansion bounds"
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "summary": "Documentation header with problem statement, Aristotle edit notes, threshold progression, related questions, and Mathlib imports for SimpleGraph and real analysis",
+      "startLine": 1,
+      "endLine": 43
+    },
+    {
       "id": "basic-defs",
-      "title": "Basic Definitions",
-      "summary": "Cycle graphs, cliques, and containment",
-      "startLine": 34,
-      "endLine": 62
+      "title": "Graph Definitions: Cycles, Cliques, Containment",
+      "summary": "cycleGraph C_k via modular adjacency, completeGraph K_n as top of lattice, ContainsCycle via injective embedding preserving cyclic adjacency, ContainsClique via clique Finset of given size",
+      "startLine": 56,
+      "endLine": 91
     },
     {
       "id": "ramsey",
-      "title": "Ramsey Numbers",
-      "summary": "Definition of R(C_k, K_n)",
-      "startLine": 64,
-      "endLine": 84
+      "title": "Ramsey Number R(C_k, K_n)",
+      "summary": "RamseyNumber via Nat.find over existence of N with red C_k or blue K_n, RamseyProperty as the Ramsey property predicate, ramsey_is_min establishing minimality",
+      "startLine": 96,
+      "endLine": 143
     },
     {
       "id": "conjecture",
-      "title": "The Main Conjecture",
-      "summary": "R(C_k, K_n) = (k-1)(n-1) + 1",
-      "startLine": 86,
-      "endLine": 102
+      "title": "The Main Conjecture and Exception",
+      "summary": "ConjecturedFormula (k-1)(n-1)+1, MainConjecture for k ≥ n ≥ 3 excluding (3,3), exception_3_3 showing R(C_3,K_3) = 6, formula_wrong_at_3_3 proved by native_decide",
+      "startLine": 145,
+      "endLine": 174
     },
     {
       "id": "lower-bound",
-      "title": "Lower Bound",
-      "summary": "Construction avoiding both structures",
-      "startLine": 104,
-      "endLine": 127
+      "title": "Lower Bound: Disjoint Cliques Construction",
+      "summary": "LowerBoundGraph partitions (k-1)(n-1) vertices into (n-1) copies of K_{k-1} via integer division, lower_bound_no_cycle (components too small), lower_bound_complement_no_clique (independence number n-1)",
+      "startLine": 191,
+      "endLine": 232
     },
     {
       "id": "bondy-erdos",
-      "title": "Bondy-Erdős (1973)",
-      "summary": "Formula for k > n² - 2",
-      "startLine": 129,
-      "endLine": 144
+      "title": "Bondy-Erdős (1973): Quadratic Threshold",
+      "summary": "bondy_erdos theorem for k > n²-2, BondyErdosThreshold definition, above_bondy_erdos_threshold corollary",
+      "startLine": 243,
+      "endLine": 267
     },
     {
       "id": "nikiforov",
-      "title": "Nikiforov (2005)",
-      "summary": "Formula for k ≥ 4n + 2",
-      "startLine": 146,
-      "endLine": 161
+      "title": "Nikiforov (2005): Linear Threshold",
+      "summary": "nikiforov theorem for k ≥ 4n+2, NikiforovThreshold definition, nikiforov_improves proved by omega for n ≥ 5",
+      "startLine": 278,
+      "endLine": 293
     },
     {
       "id": "kls",
-      "title": "Keevash-Long-Skokan (2021)",
-      "summary": "Formula for k ≥ C log n / log log n",
-      "startLine": 163,
-      "endLine": 178
+      "title": "Keevash-Long-Skokan (2021): Near-Logarithmic Threshold",
+      "summary": "keevash_long_skokan with existential constant C, KLSThreshold as log n / log log n, exp_one_lt_3 lemma via Taylor bounds, kls_improves PROVED by Aristotle for n ≥ 100",
+      "startLine": 312,
+      "endLine": 358
     },
     {
       "id": "special-cases",
-      "title": "Special Cases",
-      "summary": "Small values and R(C_k, K_3)",
-      "startLine": 180,
-      "endLine": 197
+      "title": "Special Cases: Small Parameters and R(C_k, K_3)",
+      "summary": "cycle_3_is_triangle (C_3 = K_3), ramsey_C4_K3 = 7, ramsey_C5_K3 = 9, ramsey_Ck_K3 = 2k-1 for k ≥ 4 (triangle case via Dirac's theorem)",
+      "startLine": 376,
+      "endLine": 420
     },
     {
       "id": "related",
-      "title": "Related Questions",
-      "summary": "Smallest valid k, minimum Ramsey value",
-      "startLine": 199,
-      "endLine": 216
+      "title": "Related Questions: SmallestValidK and MinRamseyValue",
+      "summary": "SmallestValidK via Nat.find for threshold where formula holds, MinRamseyValue as infimum of R(C_k, K_n) over k ≥ n, min_ramsey_achieved existence",
+      "startLine": 425,
+      "endLine": 461
     },
     {
       "id": "monotonicity",
-      "title": "Monotonicity",
-      "summary": "Behavior in k and n",
-      "startLine": 218,
-      "endLine": 234
+      "title": "Monotonicity Properties",
+      "summary": "ramsey_mono_k and ramsey_mono_n (non-decreasing in both parameters), formula_mono PROVED showing ConjecturedFormula is monotone via nlinarith",
+      "startLine": 479,
+      "endLine": 511
     },
     {
       "id": "upper-bound",
-      "title": "Upper Bound Techniques",
-      "summary": "Path-cycle method",
-      "startLine": 236,
-      "endLine": 247
+      "title": "Upper Bound: Path-Cycle Method",
+      "summary": "upper_bound theorem R(C_k, K_n) ≤ (k-1)(n-1)+1 for k ≥ n ≥ 3 excluding (3,3), path_cycle_method establishing RamseyProperty for N ≥ (k-1)(n-1)+1",
+      "startLine": 522,
+      "endLine": 542
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "summary": "Main theorem and current best",
-      "startLine": 249,
-      "endLine": 267
+      "title": "Main Theorem, Current Best, and Asymptotic Resolution",
+      "summary": "main_theorem combining all progress (formula ↔ k ≥ SmallestValidK), current_best via KLS bound, solved_asymptotically showing formula holds for all but finitely many k per fixed n",
+      "startLine": 560,
+      "endLine": 604
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #551 on Ramsey numbers R(C_k, K_n). The conjecture R(C_k, K_n) = (k-1)(n-1) + 1 has been progressively proven for larger ranges of k, with the Keevash-Long-Skokan (2021) result essentially resolving it for all sufficiently large parameters.",
-    "implications": "The problem is considered SOLVED in the sense that for any fixed n, the formula holds for all but finitely many k. The remaining open questions concern the exact threshold where the formula starts to hold.",
+    "summary": "Erdős Problem #551 on R(C_k, K_n) = (k-1)(n-1) + 1 is SOLVED for sufficiently large parameters. The 604-line formalization captures the full 48-year progression: Bondy-Erdős (1973, quadratic threshold), Nikiforov (2005, linear threshold), and KLS (2021, near-logarithmic threshold). The lower bound construction via disjoint cliques, the (3,3) exception, the triangle case R(C_k, K_3) = 2k-1, monotonicity properties, and the path-cycle upper bound method are all formalized. Aristotle formally proved kls_improves and formula_mono; formula_wrong_at_3_3 was verified by native_decide.",
+    "implications": "The near-logarithmic threshold from KLS essentially closes the problem: for any fixed n, the formula holds for all but at most O(log n / log log n) values of k. The linear dependence on n in the formula (k-1)(n-1)+1 has a clean structural explanation via the disjoint cliques lower bound. The progression from quadratic to near-logarithmic thresholds illustrates how spectral methods (Nikiforov) and stability methods (KLS) can dramatically improve on classical combinatorial arguments (Bondy-Erdős).",
     "openQuestions": [
-      "For fixed n, what is the smallest k where the identity holds?",
-      "For fixed n, what is the minimum value of R(C_k, K_n)?",
-      "Can the KLS constant C be made explicit?"
+      "For fixed n, what is the exact smallest k₀(n) where R(C_k, K_n) = (k-1)(n-1)+1 for all k ≥ k₀(n)?",
+      "Can the KLS constant C be determined explicitly, and what is its optimal value?",
+      "What is the minimum of R(C_k, K_n) over k ≥ n for fixed n — does it occur near k = n or at a larger value?",
+      "Can the regularity-free approach (used by AKS for bipartite graphs in Problem #546) be adapted to the cycle-vs-clique setting?"
     ]
   }
 }

--- a/src/data/proofs/erdos-552/annotations.json
+++ b/src/data/proofs/erdos-552/annotations.json
@@ -1,173 +1,98 @@
 [
   {
-    "id": "ann-552-cycle",
+    "id": "ann-552-graphs",
     "proofId": "erdos-552",
-    "range": { "startLine": 41, "endLine": 48 },
+    "range": { "startLine": 38, "endLine": 57 },
     "type": "definition",
-    "title": "Cycle Graph",
-    "content": "The cycle graph Cₙ on n vertices. Vertices i and j are adjacent if they differ by 1 mod n.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-552-c4",
-    "proofId": "erdos-552",
-    "range": { "startLine": 51, "endLine": 51 },
-    "type": "definition",
-    "title": "C₄",
-    "content": "The 4-cycle, the specific cycle graph in this problem.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-552-star",
-    "proofId": "erdos-552",
-    "range": { "startLine": 54, "endLine": 57 },
-    "type": "definition",
-    "title": "Star Graph",
-    "content": "Sₙ = K_{1,n}: one center vertex connected to n leaves. The other graph in our Ramsey problem.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-552-subgraph",
-    "proofId": "erdos-552",
-    "range": { "startLine": 62, "endLine": 64 },
-    "type": "definition",
-    "title": "Contains Subgraph",
-    "content": "G contains H if there's an injective map preserving adjacency. Used in Ramsey definition.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-552-complement",
-    "proofId": "erdos-552",
-    "range": { "startLine": 67, "endLine": 70 },
-    "type": "definition",
-    "title": "Graph Complement",
-    "content": "The complement has edges exactly where the original doesn't. Represents the 'other color' in 2-colorings.",
-    "significance": "supporting"
+    "title": "Graph Definitions: C_4 and Star Graph S_n",
+    "content": "**cycleGraph** $C_n$ on $n$ vertices with adjacency $(i+1) \\bmod n = j$. **C4** is the 4-cycle, the specific cycle in this problem.\n\n**starGraph** $S_n = K_{1,n}$ on $n+1$ vertices: vertex 0 is the center, connected to all other vertices ($i \\neq 0$). The star is the other graph in the Ramsey pair.\n\nThe asymmetry between $C_4$ (a small, dense cycle) and $S_n$ (a large, sparse tree) makes this Ramsey number particularly interesting: $C_4$ is extremal for the Zarankiewicz problem while $S_n$ is the simplest tree with $n$ edges.",
+    "mathContext": "$C_4$ is the graph with vertex set $\\{0,1,2,3\\}$ and edges $\\{01, 12, 23, 30\\}$. The star $S_n = K_{1,n}$ has vertex set $\\{0, 1, \\ldots, n\\}$ with edges $\\{0i : 1 \\leq i \\leq n\\}$. A graph $G$ is $C_4$-free iff $\\operatorname{ex}(n, C_4) \\leq \\frac{1}{2}(1 + \\sqrt{4n - 3})$ (Kővári-Sós-Turán), which is the key connection to the $\\sqrt{n}$ term in the Ramsey bounds.",
+    "significance": "critical",
+    "relatedConcepts": ["Zarankiewicz problem", "extremal graph theory", "bipartite graphs", "tree Ramsey numbers"],
+    "prerequisites": ["graph theory", "modular arithmetic", "star graphs"]
   },
   {
     "id": "ann-552-ramsey",
     "proofId": "erdos-552",
-    "range": { "startLine": 74, "endLine": 77 },
+    "range": { "startLine": 59, "endLine": 81 },
     "type": "definition",
-    "title": "Ramsey Number",
-    "content": "R(H₁, H₂) = minimum N such that every 2-coloring of K_N contains monochromatic H₁ or H₂.",
-    "significance": "critical"
+    "title": "Ramsey Number R(C_4, S_n) Definition",
+    "content": "**ContainsSubgraph** formalizes $H \\subseteq G$ via injective adjacency-preserving maps.\n\n**complement** gives $\\bar{G}$ with edges where $G$ has none (encoding 2-colorings).\n\n**ramseyNumber** $R(H_1, H_2)$ is defined as $\\inf\\{N : \\forall G \\text{ on } \\operatorname{Fin} N, G \\supseteq H_1 \\text{ or } \\bar{G} \\supseteq H_2\\}$.\n\n**R_C4_Sn** specializes to $R(C_4, S_n)$: the minimum $N$ where every 2-coloring of $K_N$ contains a red $C_4$ or a blue $S_n$.",
+    "mathContext": "$R(C_4, S_n) = \\min\\{N : K_N \\to \\{\\text{red, blue}\\} \\Rightarrow \\text{red } C_4 \\text{ or blue } S_n\\}$. Since $S_n$ has maximum degree $n$, any graph with minimum degree $\\geq n$ contains $S_n$ as a subgraph. Thus $R(C_4, S_n)$ is related to the maximum number of vertices in a $C_4$-free graph with minimum degree $< n$.",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey's theorem", "graph complement", "subgraph embedding", "degree conditions"],
+    "prerequisites": ["Ramsey theory", "graph homomorphisms", "set infimum"]
   },
   {
-    "id": "ann-552-rc4sn",
+    "id": "ann-552-bounds",
     "proofId": "erdos-552",
-    "range": { "startLine": 80, "endLine": 81 },
-    "type": "definition",
-    "title": "R(C₄, Sₙ)",
-    "content": "The specific Ramsey number: minimum N where every 2-coloring has red C₄ or blue Sₙ.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-552-parsons",
-    "proofId": "erdos-552",
-    "range": { "startLine": 86, "endLine": 88 },
+    "range": { "startLine": 83, "endLine": 101 },
     "type": "theorem",
-    "title": "Parsons Upper Bound",
-    "content": "R(C₄, Sₙ) ≤ n + ⌈√n⌉ + 1. The 1975 upper bound, still the best known.",
-    "significance": "critical"
+    "title": "Known Bounds: Parsons Upper and BEFRS Lower",
+    "content": "**parsons_upper_bound** (1975): $R(C_4, S_n) \\leq n + \\lceil\\sqrt{n}\\rceil + 1$. Uses the Kővári-Sós-Turán theorem: a $C_4$-free graph on $N$ vertices has at most $\\frac{1}{2}(1 + \\sqrt{4N-3})$ edges per vertex on average, so if $N > n + \\lceil\\sqrt{n}\\rceil + 1$, either $G$ contains $C_4$ or $\\bar{G}$ has a vertex of degree $\\geq n$.\n\n**befrs_lower_bound** (1989): $R(C_4, S_n) \\geq n + \\sqrt{n} - 6n^{11/40}$. Uses Huxley's prime gap bound to find prime powers $q$ near $\\sqrt{n}$, then constructs $C_4$-free graphs from projective planes PG(2,$q$) achieving independence number $< n$.\n\n**asymptotic_bounds** combines both: $R(C_4, S_n) = n + \\sqrt{n} + O(n^{11/40})$.",
+    "mathContext": "Parsons (1975): $R(C_4, S_n) \\leq n + \\lceil\\sqrt{n}\\rceil + 1$. BEFRS (1989): $R(C_4, S_n) \\geq n + \\sqrt{n} - 6n^{11/40}$, where the exponent $11/40 = 0.275$ comes from Huxley's bound on gaps between consecutive primes: $p_{k+1} - p_k = O(p_k^{11/20})$, and $\\sqrt{n^{11/20}} = n^{11/40}$. The gap between upper and lower bounds is $O(n^{11/40})$, vanishing compared to $\\sqrt{n}$.",
+    "significance": "critical",
+    "relatedConcepts": ["Kővári-Sós-Turán theorem", "Huxley prime gap bound", "extremal number ex(n,C_4)", "Turán-type problems"],
+    "prerequisites": ["extremal graph theory", "prime gap estimates", "asymptotic analysis"]
   },
   {
-    "id": "ann-552-befrs",
+    "id": "ann-552-exact",
     "proofId": "erdos-552",
-    "range": { "startLine": 92, "endLine": 95 },
+    "range": { "startLine": 103, "endLine": 119 },
     "type": "theorem",
-    "title": "BEFRS Lower Bound",
-    "content": "R(C₄, Sₙ) ≥ n + √n - 6n^{11/40}. The 1989 lower bound from Burr-Erdős-Faudree-Rousseau-Schelp.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-552-exact1",
-    "proofId": "erdos-552",
-    "range": { "startLine": 106, "endLine": 108 },
-    "type": "theorem",
-    "title": "Exact Value q² + 1",
-    "content": "For n = q² + 1 (q prime power): R = n + ⌈√n⌉ = n + q. The smaller case.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-552-exact2",
-    "proofId": "erdos-552",
-    "range": { "startLine": 111, "endLine": 113 },
-    "type": "theorem",
-    "title": "Exact Value q²",
-    "content": "For n = q² (q prime power): R = n + ⌈√n⌉ + 1 = n + q + 1. The larger case.",
-    "significance": "key"
+    "title": "Exact Values for Prime Power Parameters",
+    "content": "**exact_value_q2_plus_1**: For $n = q^2 + 1$ ($q$ prime power), $R(C_4, S_n) = n + q = n + \\lceil\\sqrt{n}\\rceil$. The polarity graph of PG(2,$q$) gives a $C_4$-free graph on $q^2 + q + 1$ vertices with minimum degree $q$, achieving the lower bound.\n\n**exact_value_q2**: For $n = q^2$ ($q$ prime power), $R(C_4, S_n) = n + q + 1 = n + \\lceil\\sqrt{n}\\rceil + 1$. The upper bound is tight here.\n\n**exact_value_q2_minus_t**: For $n = q^2 - t$ with $0 \\leq t \\leq q$, $R(C_4, S_n) = q^2 - t + q + 1$.\n\nAll known exact values are either $n + \\lceil\\sqrt{n}\\rceil$ or $n + \\lceil\\sqrt{n}\\rceil + 1$, differing by at most 1.",
+    "mathContext": "The projective plane PG(2,$q$) has $q^2 + q + 1$ points. Its polarity graph $G_q$ has $q^2 + q + 1$ vertices, is $C_4$-free (because PG(2,$q$) has no degenerate quadrangles), and has $\\frac{1}{2}q(q+1)^2$ edges. For $n = q^2 + 1$: removing $q$ vertices from $G_q$ gives a $C_4$-free graph on $q^2 + 1$ vertices with independence number $\\leq q^2$, showing $R(C_4, S_{q^2+1}) \\geq q^2 + 1 + q$. Combined with Parsons's upper bound, this gives equality.",
+    "significance": "key",
+    "relatedConcepts": ["projective planes", "polarity graphs", "incidence geometry", "finite geometry"],
+    "prerequisites": ["finite projective planes", "prime powers", "graph constructions from geometry"]
   },
   {
     "id": "ann-552-question",
     "proofId": "erdos-552",
-    "range": { "startLine": 125, "endLine": 126 },
-    "type": "definition",
-    "title": "Erdős Question",
-    "content": "For c > 0, are there infinitely many n with R(C₄, Sₙ) ≤ n + √n - c? The main open question.",
-    "significance": "critical"
+    "range": { "startLine": 121, "endLine": 134 },
+    "type": "concept",
+    "title": "The Erdős Question ($100 Prize)",
+    "content": "**ErdosQuestion**: For $c > 0$, are there infinitely many $n$ with $R(C_4, S_n) \\leq n + \\sqrt{n} - c$?\n\n**ErdosConjecture**: This holds for ALL $c > 0$. The $\\$100$ prize question.\n\n**ErdosConjectureNegation**: There exists $c > 0$ such that eventually $R(C_4, S_n) > n + \\sqrt{n} - c$.\n\nThe conjecture asks whether $R(C_4, S_n) - n - \\sqrt{n} \\to -\\infty$. Since known exact values oscillate between $n + \\lceil\\sqrt{n}\\rceil$ and $n + \\lceil\\sqrt{n}\\rceil + 1$, the question is about the arithmetic of $\\lceil\\sqrt{n}\\rceil - \\sqrt{n}$ for $n$ near prime power squares.",
+    "mathContext": "The conjecture is equivalent to: $\\liminf_{n \\to \\infty} (R(C_4, S_n) - n - \\sqrt{n}) = -\\infty$. Since $R(C_4, S_n) \\leq n + \\lceil\\sqrt{n}\\rceil + 1$ and $\\lceil\\sqrt{n}\\rceil - \\sqrt{n} \\in [0, 1)$, this asks whether $R(C_4, S_n) = n + \\lceil\\sqrt{n}\\rceil$ (the smaller value) for infinitely many $n$ where $\\lceil\\sqrt{n}\\rceil$ is close to $\\sqrt{n}$. The problem reduces to: are there infinitely many $n$ near $q^2 + 1$ for prime powers $q$? This connects to the distribution of prime powers — hence to prime gaps.",
+    "significance": "critical",
+    "relatedConcepts": ["prime gap distribution", "Bertrand's postulate", "Ingham's theorem", "additive combinatorics"],
+    "prerequisites": ["Ramsey theory", "analytic number theory", "prime distribution"]
   },
   {
-    "id": "ann-552-conjecture",
+    "id": "ann-552-primes",
     "proofId": "erdos-552",
-    "range": { "startLine": 129, "endLine": 130 },
-    "type": "definition",
-    "title": "Erdős Conjecture",
-    "content": "The question holds for ALL c > 0. This is the $100 prize question.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-552-primegap",
-    "proofId": "erdos-552",
-    "range": { "startLine": 139, "endLine": 142 },
-    "type": "definition",
-    "title": "Prime Gap",
-    "content": "The gap between consecutive primes. Connected to the problem via projective plane constructions.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-552-cramer",
-    "proofId": "erdos-552",
-    "range": { "startLine": 145, "endLine": 147 },
-    "type": "definition",
-    "title": "Cramér's Conjecture",
-    "content": "Prime gaps are O((log p)²). If true, the lower bound improves significantly.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-552-cramerimprove",
-    "proofId": "erdos-552",
-    "range": { "startLine": 150, "endLine": 153 },
+    "range": { "startLine": 136, "endLine": 153 },
     "type": "theorem",
-    "title": "Cramér Improves Bound",
-    "content": "Under Cramér's conjecture: R ≥ n + √n - n^ε for any ε > 0. A conditional result.",
-    "significance": "key"
+    "title": "Prime Gap Connection and Cramér's Conjecture",
+    "content": "**primeGap** computes the gap between consecutive primes via $\\inf\\{q > p : q \\text{ prime}\\} - p$.\n\n**CramerConjecture**: $\\text{primeGap}(p) = O((\\log p)^2)$. This is one of the most important open problems in analytic number theory.\n\n**cramer_implies_better_bound**: Under Cramér's conjecture, for any $\\varepsilon > 0$, eventually $R(C_4, S_n) \\geq n + \\sqrt{n} - n^\\varepsilon$. The improvement comes from finding a prime power $q$ with $|q - \\sqrt{n}| = O((\\log n)^2)$, so the construction gives $R \\geq n + \\sqrt{n} - O((\\log n)^2) \\geq n + \\sqrt{n} - n^\\varepsilon$.",
+    "mathContext": "The connection: exact values occur at $n = q^2 + c$ for prime powers $q$. How close is the nearest prime power $q$ to $\\sqrt{n}$? If $q$ is the nearest prime to $\\sqrt{n}$, then $|q^2 - n| \\leq 2q \\cdot \\text{primeGap}(q)$. Under Cramér: $\\text{primeGap}(q) = O((\\log q)^2) = O((\\log n)^2)$, so $|q^2 - n| = O(\\sqrt{n}(\\log n)^2)$, and the error in $R$ is $O((\\log n)^2) = n^{o(1)}$. Unconditionally, Huxley's bound gives $\\text{primeGap}(q) = O(q^{11/20})$, yielding error $O(n^{11/40})$.",
+    "significance": "key",
+    "relatedConcepts": ["Cramér's conjecture", "prime gaps", "Huxley's theorem", "Riemann hypothesis"],
+    "prerequisites": ["prime number theorem", "analytic number theory", "sieve methods"]
   },
   {
-    "id": "ann-552-f",
+    "id": "ann-552-f-function",
     "proofId": "erdos-552",
-    "range": { "startLine": 158, "endLine": 158 },
-    "type": "definition",
-    "title": "Function f(n)",
-    "content": "f(n) = R(C₄, Sₙ). Convenient notation for studying the sequence.",
-    "significance": "supporting"
+    "range": { "startLine": 155, "endLine": 171 },
+    "type": "concept",
+    "title": "The Function f(n) = R(C_4, S_n) and Its Properties",
+    "content": "**f** $= R(C_4, S_n)$ as a function of $n$.\n\n**ConsecutiveEqualQuestion**: Does $f(n+1) = f(n)$ infinitely often? Since adding one leaf to the star might not change the Ramsey number.\n\n**BoundedIncreaseQuestion**: Is $f(n+1) \\leq f(n) + 2$ always? The star gains one leaf, so the Ramsey number should increase by at most a bounded amount.\n\n**f_eventually_increasing**: $f$ is eventually strictly increasing — for large $n$, adding a leaf to $S_n$ always increases the Ramsey number.",
+    "mathContext": "Since $S_n \\subseteq S_{n+1}$, we have $R(C_4, S_n) \\leq R(C_4, S_{n+1})$, so $f$ is non-decreasing. The question is about the step sizes. If $f(n) = n + \\lceil\\sqrt{n}\\rceil + c_n$ where $c_n \\in \\{0, 1\\}$, then $f(n+1) - f(n) = 1 + (\\lceil\\sqrt{n+1}\\rceil - \\lceil\\sqrt{n}\\rceil) + (c_{n+1} - c_n)$. Since $\\lceil\\sqrt{n+1}\\rceil - \\lceil\\sqrt{n}\\rceil \\in \\{0, 1\\}$ and $c_{n+1} - c_n \\in \\{-1, 0, 1\\}$, we get $f(n+1) - f(n) \\in \\{0, 1, 2, 3\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["monotone functions", "integer sequences", "Ramsey number growth rates"],
+    "prerequisites": ["integer floor/ceiling functions", "monotonicity of Ramsey numbers"]
   },
   {
-    "id": "ann-552-conseq",
+    "id": "ann-552-constructions",
     "proofId": "erdos-552",
-    "range": { "startLine": 161, "endLine": 162 },
-    "type": "definition",
-    "title": "Consecutive Equal",
-    "content": "Does f(n+1) = f(n) infinitely often? A related open question.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-552-parsonscons",
-    "proofId": "erdos-552",
-    "range": { "startLine": 176, "endLine": 179 },
-    "type": "theorem",
-    "title": "Parsons Construction",
-    "content": "Uses projective plane PG(2,q) to construct extremal graphs. The polarity graph achieves the bound.",
-    "significance": "key"
+    "range": { "startLine": 173, "endLine": 197 },
+    "type": "technique",
+    "title": "Parsons Construction and Extremal Results",
+    "content": "**parsons_construction**: For prime $q$, there exists a $C_4$-free graph on $q^2 + q + 1$ vertices such that its complement has no $S_{q^2}$ (star with $q^2$ leaves). The construction uses the projective plane PG(2,$q$): vertices are points, edges connect non-orthogonal points under a polarity.\n\n**polarityGraph**: The polarity graph of PG(2,$q$) — the explicit $C_4$-free extremal graph.\n\n**c4_minimum_degree**: If every vertex of a graph on $n \\geq 4$ vertices has degree $\\geq n/2$, then $G$ contains $C_4$. A Dirac-type condition for 4-cycles.\n\n**c4_star_extremal**: The weaker bound $R(C_4, S_n) \\leq n + 2\\sqrt{n} + 3$, obtained without projective planes.",
+    "mathContext": "The polarity graph $G_q$ of PG(2,$q$) has $q^2 + q + 1$ vertices and $\\frac{1}{2}q(q+1)^2$ edges. It is $C_4$-free because in a projective plane, any two points determine a unique line, so there is no $4$-cycle (which would require two points on two common lines). The maximum degree is $q + 1$ (self-conjugate points have degree $q$). The Kővári-Sós-Turán theorem shows $\\operatorname{ex}(n, C_4) \\leq \\frac{1}{2}(1 + \\sqrt{4n - 3})$, which the polarity graph nearly achieves.",
+    "significance": "key",
+    "relatedConcepts": ["projective planes", "polarity graphs", "Kővári-Sós-Turán theorem", "Turán number ex(n,C_4)"],
+    "prerequisites": ["finite geometry", "incidence structures", "extremal graph theory"]
   }
 ]

--- a/src/data/proofs/erdos-552/meta.json
+++ b/src/data/proofs/erdos-552/meta.json
@@ -23,82 +23,98 @@
     "erdosPrizeValue": "$100"
   },
   "overview": {
-    "historicalContext": "This $100 Erdős problem was posed by Burr, Erdős, Faudree, Rousseau, and Schelp (1989). Parsons (1975) gave the upper bound and exact values for special n. The problem is connected to prime gaps: under Cramér's conjecture, the bounds tighten significantly.",
-    "problemStatement": "Determine R(C₄, Sₙ), where C₄ is the 4-cycle and Sₙ = K_{1,n} is the star on n+1 vertices. In particular: for any c > 0, are there infinitely many n with R(C₄, Sₙ) ≤ n + √n - c?",
-    "proofStrategy": "We formalize cycle and star graphs, the Ramsey number definition, known bounds (Parsons upper, BEFRS lower), exact values for n = q² ± t, and the connection to prime gaps via Cramér's conjecture.",
+    "historicalContext": "This $100 Erdős problem was posed by Burr, Erdős, Faudree, Rousseau, and Schelp in 1989. It asks for the precise asymptotic behavior of R(C₄, Sₙ), the Ramsey number of the 4-cycle versus the star graph K_{1,n}. Parsons (1975) established the upper bound R(C₄, Sₙ) ≤ n + ⌈√n⌉ + 1 using the Kővári-Sós-Turán theorem, which bounds the number of edges in C₄-free graphs. Parsons also determined exact values when n is related to prime powers: R(C₄, S_{q²+1}) = n + q using the polarity graph of the projective plane PG(2,q), a remarkable C₄-free extremal graph with q²+q+1 vertices. BEFRS (1989) proved the lower bound R(C₄, Sₙ) ≥ n + √n - 6n^{11/40}, where the exponent 11/40 comes from Huxley's prime gap bound. The problem is deeply connected to analytic number theory: the exact value of R(C₄, Sₙ) depends on how close n is to q² for a prime power q, and finding such q requires prime gap estimates. Under Cramér's conjecture on prime gaps, the lower bound would improve to n + √n - n^{o(1)}, nearly closing the gap. All known exact values lie in {n + ⌈√n⌉, n + ⌈√n⌉ + 1}, a remarkably narrow range. The $100 prize question asks: for any c > 0, are there infinitely many n with R(C₄, Sₙ) ≤ n + √n - c?",
+    "problemStatement": "Determine $R(C_4, S_n)$, where $C_4$ is the 4-cycle and $S_n = K_{1,n}$ is the star on $n+1$ vertices. In particular: for any $c > 0$, are there infinitely many $n$ with $R(C_4, S_n) \\leq n + \\sqrt{n} - c$?",
+    "proofStrategy": "The formalization defines the cycle graph $C_4$ and star graph $S_n = K_{1,n}$ using Mathlib's `SimpleGraph`, then defines the Ramsey number $R(C_4, S_n)$ via set infimum. Known bounds are formalized: Parsons's upper bound $n + \\lceil\\sqrt{n}\\rceil + 1$ and BEFRS's lower bound $n + \\sqrt{n} - 6n^{11/40}$, with their combination as asymptotic bounds. Exact values for $n = q^2 + 1$, $n = q^2$, and $n = q^2 - t$ (prime power $q$) use projective plane constructions. The Erdős question and its negation are formalized as propositions. The connection to prime gaps is captured through the primeGap function, Cramér's conjecture, and the conditional improvement theorem. The function $f(n) = R(C_4, S_n)$ is studied for monotonicity and step-size questions.",
     "keyInsights": [
-      "Lower bound: n + √n - 6n^{11/40} (BEFRS 1989)",
-      "Upper bound: n + ⌈√n⌉ + 1 (Parsons 1975)",
-      "Exact: n = q² + 1 gives R = n + ⌈√n⌉, n = q² gives R = n + ⌈√n⌉ + 1",
-      "All known values are n + ⌈√n⌉ or n + ⌈√n⌉ + 1",
-      "Under Cramér's conjecture: lower bound improves to n + √n - n^{o(1)}"
+      "The bounds $n + \\sqrt{n} - 6n^{11/40} \\leq R(C_4, S_n) \\leq n + \\lceil\\sqrt{n}\\rceil + 1$ leave an additive gap of $O(n^{11/40})$, which is $o(\\sqrt{n})$ — the leading term $n + \\sqrt{n}$ is determined",
+      "Exact values come from projective plane constructions: the polarity graph of PG(2,$q$) is a $C_4$-free graph on $q^2+q+1$ vertices achieving the extremal bound $\\operatorname{ex}(n, C_4) \\sim \\frac{1}{2}n^{3/2}$",
+      "The problem reduces to prime gap arithmetic: R(C₄, Sₙ) depends on how close √n is to a prime power, connecting Ramsey theory to analytic number theory",
+      "Under Cramér's conjecture (prime gaps $O((\\log p)^2)$), the lower bound improves to $n + \\sqrt{n} - n^\\varepsilon$ for any $\\varepsilon > 0$ — the gap becomes sub-polynomial",
+      "All known exact values are in $\\{n + \\lceil\\sqrt{n}\\rceil, n + \\lceil\\sqrt{n}\\rceil + 1\\}$ — a range of width 1, suggesting the true answer oscillates between two values depending on number-theoretic properties of $n$",
+      "The Erdős question ($\\$100$) asks whether $\\liminf_{n \\to \\infty}(R(C_4, S_n) - n - \\sqrt{n}) = -\\infty$, which would mean the smaller value $n + \\lceil\\sqrt{n}\\rceil$ occurs with $\\lceil\\sqrt{n}\\rceil$ arbitrarily close to $\\sqrt{n}$"
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement, Known Bounds, and Imports",
+      "summary": "Documentation header with problem statement, $100 prize, BEFRS/Parsons bounds, exact values for prime powers, Cramér connection, and Mathlib imports for SimpleGraph and real analysis",
+      "startLine": 1,
+      "endLine": 36
+    },
+    {
       "id": "graphs",
-      "title": "Graph Definitions",
-      "summary": "Cycle graph C₄ and star graph Sₙ = K_{1,n}",
+      "title": "Graph Definitions: C_4 and Star Graph S_n",
+      "summary": "cycleGraph C_n via modular adjacency with symmetry/loopless proofs, C4 as cycleGraph 4, starGraph S_n = K_{1,n} with center vertex 0 adjacent to all leaves",
       "startLine": 38,
       "endLine": 57
     },
     {
       "id": "ramsey",
-      "title": "Ramsey Numbers",
-      "summary": "Subgraph containment, complement, R(H₁,H₂) definition",
+      "title": "Ramsey Number R(C_4, S_n)",
+      "summary": "ContainsSubgraph via injective adjacency-preserving maps, complement graph definition, ramseyNumber via sInf, R_C4_Sn specializing to the cycle-star pair",
       "startLine": 59,
       "endLine": 81
     },
     {
       "id": "bounds",
-      "title": "Known Bounds",
-      "summary": "Parsons upper bound and BEFRS lower bound",
+      "title": "Known Bounds: Parsons Upper and BEFRS Lower",
+      "summary": "parsons_upper_bound (1975): R ≤ n + ⌈√n⌉ + 1. befrs_lower_bound (1989): R ≥ n + √n - 6n^{11/40} via Filter.atTop. asymptotic_bounds combining both into R = n + √n + O(n^{11/40})",
       "startLine": 83,
       "endLine": 101
     },
     {
       "id": "exact",
-      "title": "Exact Values",
-      "summary": "n = q² ± t for prime power q",
+      "title": "Exact Values for Prime Power Parameters",
+      "summary": "exact_value_q2_plus_1: R = n + q for n = q²+1. exact_value_q2: R = n + q + 1 for n = q². exact_value_q2_minus_t: R = q²-t+q+1 for 0 ≤ t ≤ q. All via projective plane constructions",
       "startLine": 103,
       "endLine": 119
     },
     {
       "id": "main-question",
-      "title": "The Main Question",
-      "summary": "Erdős's question about infinitely many n with R ≤ n + √n - c",
+      "title": "The Erdős Question ($100 Prize)",
+      "summary": "ErdosQuestion: infinitely many n with R ≤ n + √n - c. ErdosConjecture: holds for ALL c > 0. ErdosConjectureNegation: eventual lower bound n + √n - c₀",
       "startLine": 121,
       "endLine": 134
     },
     {
       "id": "prime-gaps",
-      "title": "Prime Gap Connection",
-      "summary": "Cramér's conjecture and improved bounds",
+      "title": "Prime Gap Connection and Cramér's Conjecture",
+      "summary": "primeGap function via sInf of primes exceeding p, CramerConjecture as O((log p)²), cramer_implies_better_bound: conditionally R ≥ n + √n - n^ε for any ε > 0",
       "startLine": 136,
       "endLine": 153
     },
     {
       "id": "f-function",
-      "title": "The Function f(n)",
-      "summary": "Questions about f(n+1) = f(n) and bounded increase",
+      "title": "The Function f(n) = R(C_4, S_n)",
+      "summary": "f = R_C4_Sn convenience wrapper, ConsecutiveEqualQuestion (f(n+1) = f(n) infinitely often?), BoundedIncreaseQuestion (f(n+1) ≤ f(n) + 2?), f_eventually_increasing",
       "startLine": 155,
       "endLine": 171
     },
     {
       "id": "constructions",
-      "title": "Constructions",
-      "summary": "Parsons construction via projective planes",
+      "title": "Parsons Construction and Extremal Results",
+      "summary": "parsons_construction via PG(2,q) for prime q, polarityGraph definition (sorry), c4_minimum_degree Dirac-type condition, c4_star_extremal weaker bound R ≤ n + 2√n + 3",
       "startLine": 173,
-      "endLine": 196
+      "endLine": 197
+    },
+    {
+      "id": "summary",
+      "title": "Summary and Open Questions",
+      "summary": "Overview of formalized results: OPEN status, $100 prize, known bounds, exact values, prime gap connection, key sorries, open dependence on prime gaps",
+      "startLine": 199,
+      "endLine": 238
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #552, a $100 problem on R(C₄, Sₙ). The bounds n + √n - O(n^{11/40}) < R < n + ⌈√n⌉ + 1 are known, but the exact asymptotic behavior depends on prime gaps. The question of whether R ≤ n + √n - c for infinitely many n remains open.",
-    "implications": "This connects Ramsey theory to analytic number theory via prime gaps. Understanding R(C₄, Sₙ) has implications for extremal graph theory and the structure of C₄-free graphs.",
+    "summary": "Erdős Problem #552 on R(C₄, Sₙ) remains OPEN with a $100 prize. The 239-line formalization captures the tight bounds n + √n - 6n^{11/40} ≤ R ≤ n + ⌈√n⌉ + 1 (Parsons 1975, BEFRS 1989), exact values for n near prime power squares via projective plane constructions, the $100 prize question about whether R ≤ n + √n - c for infinitely many n, and the deep connection to prime gaps through Cramér's conjecture. The problem beautifully connects Ramsey theory, extremal graph theory (Kővári-Sós-Turán), finite geometry (projective planes), and analytic number theory (prime gaps).",
+    "implications": "This problem exemplifies how Ramsey-theoretic questions can reduce to number-theoretic ones. The polarity graph of PG(2,q) provides the extremal constructions, but the quality of these constructions depends on the distribution of prime powers — a fundamental question in number theory. The narrow gap between upper and lower bounds (width O(n^{11/40})) suggests that the exact answer involves subtle arithmetic properties of the parameter n.",
     "openQuestions": [
-      "For any c > 0, are there infinitely many n with R(C₄, Sₙ) ≤ n + √n - c?",
-      "Does f(n+1) = f(n) infinitely often?",
-      "Is the answer to Erdős's question equivalent to some statement about prime gaps?"
+      "For any c > 0, are there infinitely many n with R(C₄, Sₙ) ≤ n + √n - c? (The $100 Erdős prize question)",
+      "Does f(n+1) = f(n) infinitely often — can the star gain a leaf without changing the Ramsey number?",
+      "Is the answer to Erdős's question equivalent to some specific statement about prime gaps?",
+      "Can the BEFRS exponent 11/40 be improved unconditionally, without assuming Cramér's conjecture?"
     ]
   }
 }

--- a/src/data/proofs/erdos-557/annotations.json
+++ b/src/data/proofs/erdos-557/annotations.json
@@ -1,74 +1,62 @@
 [
   {
-    "id": "tree-def",
+    "id": "ann-557-defs",
     "proofId": "erdos-557",
-    "range": { "startLine": 30, "endLine": 31 },
+    "range": { "startLine": 29, "endLine": 64 },
     "type": "definition",
-    "title": "Tree Structure",
-    "content": "A tree on n vertices modeled as a SimpleGraph on Fin n. Trees are connected acyclic graphs with n-1 edges and degeneracy 1.",
-    "significance": "medium"
+    "title": "Core Definitions: Trees, Edge Colorings, and Multicolor Ramsey Numbers",
+    "content": "**Tree** on $n$ vertices modeled as a `SimpleGraph (Fin n)`. Trees are connected acyclic graphs with $n-1$ edges and degeneracy 1.\n\n**EdgeColoring** assigns each edge of $K_m$ one of $k$ colors (as `Fin m -> Fin m -> Fin k`).\n\n**HasMonochromaticCopy**: a $k$-coloring of $K_m$ contains a monochromatic copy of $T$ if $\\exists$ color $c$ and injective $f: [n] \\hookrightarrow [m]$ with all image edges colored $c$.\n\n**ramseyTree** $R(T; k)$ is axiomatized as the minimum $m$ such that every $k$-coloring of $K_m$ contains a monochromatic copy of $T$. Both the existence guarantee (`ramseyTree_spec`) and minimality (`ramseyTree_minimal`) are axiomatized.",
+    "mathContext": "$R(T; k) = \\min\\{m : \\text{every } k\\text{-coloring of } E(K_m) \\text{ contains monochromatic } T\\}$. By Ramsey's theorem, $R(T; k) < \\infty$ for any finite tree $T$ and finite $k$. The multicolor Ramsey number is defined using the infimum/Nat.find approach. The key structure: trees have degeneracy 1 (every subgraph has a vertex of degree $\\leq 1$), which makes them the simplest class of connected graphs from a Ramsey perspective.",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey's theorem", "graph degeneracy", "monochromatic subgraphs", "edge colorings"],
+    "prerequisites": ["Ramsey theory", "tree graph theory", "injective functions"]
   },
   {
-    "id": "monochromatic-copy",
+    "id": "ann-557-conjecture",
     "proofId": "erdos-557",
-    "range": { "startLine": 37, "endLine": 41 },
-    "type": "definition",
-    "title": "Monochromatic Copy",
-    "content": "A k-coloring of K_m contains a monochromatic copy of T if there exists an injective vertex map preserving adjacency where all image edges have the same color. This is the Ramsey-theoretic containment condition.",
-    "significance": "high"
+    "range": { "startLine": 66, "endLine": 72 },
+    "type": "concept",
+    "title": "Erdős Problem #557: Linear Bound Conjecture",
+    "content": "**erdos_557_conjecture** (OPEN): $\\exists C$ such that $R(T; k) \\leq kn + C$ for all trees $T$ on $n$ vertices and all $k \\geq 1$ colors.\n\nThis says the multicolor tree Ramsey number is linear in both $n$ (the tree size) and $k$ (the number of colors), with only an additive constant overhead. The conjecture would establish that trees have the simplest possible multicolor Ramsey behavior among connected graphs.",
+    "mathContext": "The conjecture $R(T; k) \\leq kn + C$ is sharp: stars give $R(S_n; k) \\geq k(n-1) + 1$, so $R(T; k) = kn + \\Theta(k)$ in the worst case. For $k = 2$, this is known: $R(T; 2) \\leq 2n - 2$ (so $C = -2$ works). The difficulty is that the iterative coloring approach — using $R(T; k) \\leq R(T; k-1) + n - 1$ — gives $R(T; k) \\leq (k-1)(n-1) + R(T; 1) = k(n-1) + 1$ only when iterated perfectly, and actually loses constants at each step.",
+    "significance": "critical",
+    "relatedConcepts": ["Burr-Erdős conjecture", "graph Ramsey linearity", "tree Ramsey theory"],
+    "prerequisites": ["multicolor Ramsey theory", "tree structure", "linear bounds"]
   },
   {
-    "id": "ramsey-tree-spec",
+    "id": "ann-557-star",
     "proofId": "erdos-557",
-    "range": { "startLine": 50, "endLine": 52 },
+    "range": { "startLine": 74, "endLine": 96 },
     "type": "theorem",
-    "title": "Ramsey Number Specification",
-    "content": "R(T;k) is the minimum m such that every k-coloring of K_m contains a monochromatic T. Axiomatized with both the existence guarantee and minimality property.",
-    "significance": "high"
+    "title": "Star Lower Bound: R(S_n; k) >= k(n-1) + 1",
+    "content": "**starTree** defines $S_n = K_{1,n-1}$: vertex 0 is the center, connected to all other vertices.\n\n**star_ramsey_lower**: $R(S_n; k) \\geq k(n-1) + 1$. In any $k$-coloring of $K_m$ with $m = k(n-1)$, distribute edges so each vertex has at most $n-2$ edges of each color. By pigeonhole: each vertex has $m - 1 = k(n-1) - 1$ incident edges, and $\\lceil(k(n-1)-1)/k\\rceil = n - 1$ edges of the most common color. But we need $n - 1$ edges of the SAME color at one vertex for $S_n$, and with $k(n-1)$ vertices, some vertex has exactly $n - 1$ edges of some color — just barely not enough. Adding one more vertex forces a monochromatic star.",
+    "mathContext": "For the star $S_n = K_{1,n-1}$: $R(S_n; k) \\geq k(n-1) + 1$. The extremal coloring: partition the $k(n-1)$ vertices into $k$ groups of $n-1$, color edges within group $i$ by color $i$, and color cross-edges arbitrarily. Each vertex has at most $n-2$ edges of each color (from its own group), so no monochromatic $S_n$. This shows $R(T; k) \\geq k(n-1) + 1$ for the star, matching the conjectured upper bound $kn + C$ up to $O(k)$.",
+    "significance": "critical",
+    "relatedConcepts": ["pigeonhole principle", "extremal colorings", "star graphs", "degree conditions"],
+    "prerequisites": ["pigeonhole principle", "star graph structure", "Ramsey lower bounds"]
   },
   {
-    "id": "main-conjecture",
+    "id": "ann-557-known",
     "proofId": "erdos-557",
-    "range": { "startLine": 64, "endLine": 66 },
-    "type": "conjecture",
-    "title": "Linear Bound Conjecture",
-    "content": "R(T;k) ≤ k·n + C for an absolute constant C, any tree T on n vertices, any k ≥ 1. This says the multicolor tree Ramsey number grows linearly in both n and k.",
-    "significance": "high"
-  },
-  {
-    "id": "star-lower",
-    "proofId": "erdos-557",
-    "range": { "startLine": 85, "endLine": 86 },
+    "range": { "startLine": 98, "endLine": 112 },
     "type": "theorem",
-    "title": "Star Lower Bound",
-    "content": "R(S_n;k) ≥ k(n-1)+1: in K_{k(n-1)}, distribute edges evenly among k colors so each vertex has at most n-2 edges per color, avoiding a monochromatic star. This shows the conjecture is tight.",
-    "significance": "high"
+    "title": "Known Cases: Two-Color Tree Ramsey and Monotonicity",
+    "content": "**two_color_tree_ramsey**: $R(T; 2) \\leq 2n - 2$ for any tree $T$ on $n \\geq 2$ vertices. This classical result (proved via the longest monochromatic path argument) settles the $k = 2$ case with $C = -2$.\n\n**path_two_color**: $R(P_n; 2) = \\lfloor 3(n-1)/2 \\rfloor + 1$ (Gerencsér-Gyárfás, 1967). The exact formula for paths shows that paths are easier than general trees.\n\n**ramsey_tree_monotone_k**: $R(T; k) \\leq R(T; k+1)$. More colors can only increase the Ramsey number, since any $(k+1)$-coloring restricts to a $k$-coloring by merging two colors.",
+    "mathContext": "The 2-color tree Ramsey bound $R(T; 2) \\leq 2n - 2$ is proved by induction on $n$: in a 2-coloring of $K_{2n-2}$, find the longest monochromatic path $P$; if $|P| \\geq n$, embed $T$ along it; otherwise, use the complement structure. For paths: $R(P_n; 2) = \\lfloor 3(n-1)/2 \\rfloor + 1$ (Gerencsér-Gyárfás 1967). For 3 colors: $R(P_n; 3)$ was determined by Gyárfás, Ruszinkó, Sárközy, and Szemerédi (2007).",
+    "significance": "key",
+    "relatedConcepts": ["tree Ramsey number", "Gerencsér-Gyárfás theorem", "path Ramsey numbers", "monochromatic path method"],
+    "prerequisites": ["2-color Ramsey theory", "path graphs", "induction on tree structure"]
   },
   {
-    "id": "two-color-tree",
+    "id": "ann-557-burr-erdos",
     "proofId": "erdos-557",
-    "range": { "startLine": 93, "endLine": 94 },
+    "range": { "startLine": 114, "endLine": 129 },
     "type": "theorem",
-    "title": "Two-Color Tree Ramsey",
-    "content": "R(T;2) ≤ 2n-2 for any tree T on n ≥ 2 vertices. This classical result settles the k=2 case of the conjecture with constant C = -2.",
-    "significance": "medium"
-  },
-  {
-    "id": "monotonicity",
-    "proofId": "erdos-557",
-    "range": { "startLine": 101, "endLine": 102 },
-    "type": "theorem",
-    "title": "Monotonicity in Colors",
-    "content": "R(T;k) ≤ R(T;k+1): more colors can only make it harder to find a monochromatic copy. This ensures the conjecture's linear dependence on k is the natural growth rate.",
-    "significance": "medium"
-  },
-  {
-    "id": "burr-erdos",
-    "proofId": "erdos-557",
-    "range": { "startLine": 111, "endLine": 113 },
-    "type": "theorem",
-    "title": "Burr–Erdős for Trees",
-    "content": "Lee (2017) proved the Burr–Erdős conjecture: R(G;2) = O(n) for graphs G of bounded degeneracy. Trees have degeneracy 1, giving R(T;2) = O(n). The multicolor generalization would resolve Problem #557.",
-    "significance": "medium"
+    "title": "Connection to Burr-Erdős Conjecture and Problem #548",
+    "content": "**burr_erdos_trees** (Lee 2017): The Burr-Erdős conjecture is now a theorem: $R(G; 2) \\leq cn$ for graphs $G$ of bounded degeneracy $d$, where $c = c(d)$. Trees have degeneracy 1, giving $R(T; 2) = O(n)$ with an explicit constant.\n\n**problem_548_implies_557**: Problem #548 is the multicolor Burr-Erdős conjecture: $R(G; k) \\leq c(d,k) \\cdot n$ for graphs of degeneracy $d$ with $k$ colors. Since trees have degeneracy 1, this would give $R(T; k) \\leq c(1,k) \\cdot n$, and the conjecture $c(1,k) = k + o(1)$ would resolve Problem #557.",
+    "mathContext": "Burr and Erdős (1975) conjectured $R(G; 2) = O(n)$ for bounded-degeneracy graphs. Lee (2017) proved this in full generality: for every $d$, there exists $c(d)$ such that $R(G; 2) \\leq c(d) n$ for all $n$-vertex graphs $G$ with degeneracy $\\leq d$. The multicolor extension is OPEN: does $R(G; k) \\leq c(d, k) n$ hold? For trees ($d = 1$), this specializes to Problem #557. The key difficulty: the iterative approach $R(T; k) \\leq R(T; k-1) + R(T; 1) - 1$ gives $R(T; k) \\leq (k-1)(n-1) + n = kn - k + 1$, which is already nearly the conjecture.",
+    "significance": "key",
+    "relatedConcepts": ["Burr-Erdős conjecture", "graph degeneracy", "Lee's theorem", "bounded-degree Ramsey"],
+    "prerequisites": ["graph degeneracy", "Ramsey theory for sparse graphs", "Lee's 2017 proof"]
   }
 ]

--- a/src/data/proofs/erdos-557/meta.json
+++ b/src/data/proofs/erdos-557/meta.json
@@ -23,64 +23,73 @@
     "leanFile": "Proofs/Erdos557Problem.lean",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/557",
-    "erdosUrl": "https://erdosproblems.com/557"
+    "erdosUrl": "https://erdosproblems.com/557",
+    "erdosProblemStatus": "open"
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "summary": "Documentation header with problem statement, star lower bound, path results, Burr-Erdős connection, references, and Mathlib imports for SimpleGraph",
+      "startLine": 1,
+      "endLine": 27
+    },
+    {
       "id": "core-definitions",
-      "title": "Core Definitions",
-      "startLine": 27,
-      "endLine": 60,
-      "summary": "Define Tree, EdgeColoring, HasMonochromaticCopy, and the multicolor Ramsey number R(T;k) for trees."
+      "title": "Core Definitions: Trees, Colorings, Ramsey Numbers",
+      "summary": "Tree structure on Fin n, EdgeColoring as m→m→Fin k, HasMonochromaticCopy via injective embedding with uniform color, multicolorRamseyTree with Nat.find, axiomatized ramseyTree with spec and minimality",
+      "startLine": 29,
+      "endLine": 64
     },
     {
       "id": "main-conjecture",
-      "title": "Main Conjecture",
-      "startLine": 62,
-      "endLine": 66,
-      "summary": "Erdős Problem #557: R(T;k) ≤ k·n + C for an absolute constant C."
+      "title": "Erdős Problem #557: Linear Bound Conjecture (OPEN)",
+      "summary": "erdos_557_conjecture axiom: ∃ C, R(T;k) ≤ k·n + C for all trees T on n vertices, all k ≥ 1",
+      "startLine": 66,
+      "endLine": 72
     },
     {
       "id": "star-lower-bound",
-      "title": "Lower Bound: Stars",
-      "startLine": 68,
-      "endLine": 89,
-      "summary": "Stars K_{1,n-1} give R(S_n;k) ≥ k(n-1)+1 by pigeonhole on vertex degrees, showing the conjecture is tight."
+      "title": "Star Lower Bound: R(S_n; k) >= k(n-1) + 1",
+      "summary": "starTree defines K_{1,n-1} with center vertex 0, star_ramsey_lower axiom via pigeonhole on vertex degrees showing conjecture is tight",
+      "startLine": 74,
+      "endLine": 96
     },
     {
       "id": "known-cases",
-      "title": "Known Special Cases",
-      "startLine": 91,
-      "endLine": 107,
-      "summary": "Two-color tree Ramsey: R(T;2) ≤ 2n-2. Path two-color formula (Gerencsér–Gyárfás). Monotonicity in k."
+      "title": "Known Special Cases: k=2 and Monotonicity",
+      "summary": "two_color_tree_ramsey: R(T;2) ≤ 2n-2. path_two_color: Gerencsér-Gyárfás formula ⌊3(n-1)/2⌋+1. ramsey_tree_monotone_k: R(T;k) ≤ R(T;k+1)",
+      "startLine": 98,
+      "endLine": 112
     },
     {
       "id": "burr-erdos-connection",
-      "title": "Connection to Burr–Erdős",
-      "startLine": 109,
-      "endLine": 121,
-      "summary": "The Burr–Erdős conjecture (Lee 2017) gives R(T;2) ≤ c·n. Problem #548 (multicolor version) implies #557."
+      "title": "Burr-Erdős Connection and Problem #548",
+      "summary": "burr_erdos_trees: Lee (2017) proved R(G;2) = O(n) for bounded degeneracy. problem_548_implies_557: multicolor Burr-Erdős for degeneracy d would resolve #557 for trees (d=1)",
+      "startLine": 114,
+      "endLine": 129
     }
   ],
   "overview": {
-    "historicalContext": "Erdős and Graham posed this in 1975, asking for linear-in-n bounds on multicolor tree Ramsey numbers. The 2-color case is well understood via the tree Ramsey theorem. The multicolor case remains open and is connected to the broader Burr–Erdős program.",
-    "problemStatement": "Is R(T; k) ≤ k·n + O(1) for any tree T on n vertices and any k ≥ 1 colors?",
-    "proofStrategy": "We formalize the multicolor Ramsey number for trees, state the linear-bound conjecture, prove tightness via the star lower bound, and connect to the Burr–Erdős conjecture and its multicolor generalization.",
+    "historicalContext": "Erdős and Graham posed this problem in 1975 (p. 516 of their monograph), asking whether the multicolor Ramsey number of any tree T on n vertices satisfies R(T; k) ≤ kn + O(1). The 2-color case was already understood: R(T; 2) ≤ 2n - 2 for any tree, and for paths the exact formula R(P_n; 2) = ⌊3(n-1)/2⌋ + 1 was determined by Gerencsér and Gyárfás in 1967. The star S_n = K_{1,n-1} provides the matching lower bound R(S_n; k) ≥ k(n-1) + 1 by a pigeonhole argument on vertex degrees, showing the conjectured bound is best possible up to an additive constant. The problem is closely connected to the Burr-Erdős conjecture (Problem #548), which asks for R(G; k) = O(n) for all bounded-degeneracy graphs. Lee proved the 2-color Burr-Erdős conjecture in 2017 using a novel probabilistic approach, confirming R(T; 2) = O(n) for all trees. However, the multicolor case (k ≥ 3) remains open. The key difficulty is that iterative arguments — reducing k colors to k-1 colors — lose additive constants at each step, and it is unclear whether the constant C can be made independent of k.",
+    "problemStatement": "Is $R(T; k) \\leq k \\cdot n + O(1)$ for any tree $T$ on $n$ vertices and any $k \\geq 1$ colors? Here $R(T; k)$ is the minimum $m$ such that every $k$-coloring of $K_m$ contains a monochromatic copy of $T$.",
+    "proofStrategy": "The formalization defines trees as `SimpleGraph (Fin n)`, edge colorings as functions `Fin m → Fin m → Fin k`, and monochromatic copies via injective adjacency-preserving maps with uniform color. The multicolor Ramsey number $R(T; k)$ is axiomatized with both existence and minimality. The conjecture is stated as an axiom. The star lower bound is formalized with an explicit star graph construction. Known results include the 2-color tree Ramsey bound $R(T; 2) \\leq 2n - 2$, the Gerencsér-Gyárfás path formula, monotonicity in $k$, and the connection to the Burr-Erdős conjecture.",
     "keyInsights": [
-      "Stars give the matching lower bound R(S_n;k) ≥ k(n-1)+1 by pigeonhole",
-      "For k=2, the tree Ramsey theorem gives R(T;2) ≤ 2n-2",
-      "The conjecture is implied by the multicolor Burr–Erdős conjecture (Problem #548)",
-      "Lee's 2017 proof of Burr–Erdős (k=2) gives R(T;2) = O(n) for trees",
-      "The key difficulty is the k-color case where iterative arguments lose factors"
+      "Stars provide the tight lower bound $R(S_n; k) \\geq k(n-1) + 1$ via pigeonhole: in $K_{k(n-1)}$, partition vertices into $k$ groups of $n-1$ and color edges within each group monochromatically",
+      "For $k = 2$: $R(T; 2) \\leq 2n - 2$ is classical, proved by finding the longest monochromatic path and embedding the tree along it",
+      "Lee's 2017 proof of the Burr-Erdős conjecture confirms $R(T; 2) = O(n)$ for all trees, but his probabilistic technique does not directly extend to $k \\geq 3$ colors",
+      "The iterative approach $R(T; k) \\leq R(T; k-1) + n - 1$ gives $R(T; k) \\leq k(n-1) + 1$, which is already nearly tight but with a constant depending on $k$",
+      "The conjecture would establish that trees have the simplest possible multicolor Ramsey behavior: linear in both parameters with only an additive constant — the same growth rate as the trivial star lower bound"
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #557 remains open. The conjectured bound R(T;k) ≤ kn + O(1) is tight by the star example. The 2-color case is resolved but the general multicolor case requires new techniques beyond the iterative approach.",
-    "implications": "A resolution would establish that trees have the simplest possible multicolor Ramsey behavior among connected graphs, confirming the principle that sparse graphs have linear Ramsey numbers.",
+    "summary": "Erdős Problem #557 on multicolor tree Ramsey numbers remains OPEN. The 129-line formalization captures the conjecture R(T; k) ≤ kn + C, the matching star lower bound R(S_n; k) ≥ k(n-1) + 1, the settled 2-color case R(T; 2) ≤ 2n - 2, the Gerencsér-Gyárfás path formula, monotonicity in k, and the connection to the Burr-Erdős conjecture (proved by Lee 2017 for k=2). All statements are axiomatized (0 sorries).",
+    "implications": "A resolution would confirm that trees — as the simplest connected graphs (degeneracy 1) — have the simplest possible multicolor Ramsey behavior: R(T; k) = kn + Θ(k). This would be a cornerstone of the multicolor Burr-Erdős program, establishing that sparse graph structure translates directly into linear Ramsey bounds across all numbers of colors.",
     "openQuestions": [
-      "Can the multicolor case be reduced to iterated 2-color results?",
-      "What is the correct constant C in R(T;k) ≤ kn + C?",
-      "Does the bound hold for forests as well as trees?"
+      "Can the multicolor case k ≥ 3 be reduced to iterated applications of the 2-color result without losing constants?",
+      "What is the correct universal constant C in R(T; k) ≤ kn + C — is C = 0, C = -k, or something else?",
+      "Does R(T; k) ≤ kn + C hold for forests (disconnected acyclic graphs) as well as trees?",
+      "Can Lee's probabilistic approach to the 2-color Burr-Erdős conjecture be extended to handle k ≥ 3 colors?"
     ]
   }
 }

--- a/src/data/proofs/erdos-559/annotations.json
+++ b/src/data/proofs/erdos-559/annotations.json
@@ -1,182 +1,86 @@
 [
   {
-    "id": "ann-559-statement",
+    "id": "ann-559-defs",
     "proofId": "erdos-559",
-    "range": {
-      "startLine": 7,
-      "endLine": 12
-    },
-    "type": "concept",
-    "title": "Problem Statement",
-    "content": "The Beck-Erdős conjecture: for graphs G with n vertices and maximum degree d, is R̂(G) = O_d(n)? This asks if the size Ramsey number grows only linearly in the number of vertices when degree is bounded.",
-    "significance": "critical"
+    "range": { "startLine": 48, "endLine": 71 },
+    "type": "definition",
+    "title": "Graph Definitions: FiniteGraph, Edge Count, Degree",
+    "content": "**FiniteGraph** defines a simple graph with symmetric adjacency and no loops on a finite vertex type.\n\n**edgeCount** counts edges as unordered pairs $(u, v)$ with $u < v$ and $G.\\text{adj}(u, v)$.\n\n**degree** counts the neighbors of a vertex $v$. **maxDegree** $\\Delta(G)$ is the supremum over all vertex degrees.\n\nThe conjecture concerns graphs with bounded $\\Delta(G) \\leq d$: can their size Ramsey numbers be controlled linearly in $n$?",
+    "mathContext": "For a graph $G = (V, E)$ with $|V| = n$: $|E| = \\sum_{v} \\deg(v) / 2$ (handshaking lemma). The maximum degree $\\Delta(G) \\leq d$ constrains the local structure: each vertex has at most $d$ neighbors. Bounded-degree graphs can still have complex global structure — which is why the size Ramsey question is subtle.",
+    "significance": "key",
+    "relatedConcepts": ["simple graph", "maximum degree", "handshaking lemma", "bounded-degree graphs"],
+    "prerequisites": ["graph theory basics", "Fintype", "decidable relations"]
   },
   {
-    "id": "ann-559-size-ramsey",
+    "id": "ann-559-ramsey",
     "proofId": "erdos-559",
-    "range": {
-      "startLine": 85,
-      "endLine": 92
-    },
+    "range": { "startLine": 73, "endLine": 92 },
     "type": "definition",
-    "title": "Size Ramsey Number",
-    "content": "R̂(G) is the minimum number of edges m such that there exists a graph H with m edges that is Ramsey for G. Being 'Ramsey for G' means any 2-coloring of H's edges contains a monochromatic copy of G.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-559-ramsey-for",
-    "proofId": "erdos-559",
-    "range": {
-      "startLine": 73,
-      "endLine": 81
-    },
-    "type": "definition",
-    "title": "Ramsey Property",
-    "content": "H is Ramsey for G if every 2-coloring of H's edges contains a monochromatic copy of G—an injective embedding f: V(G) → V(H) where all edges of G map to edges of the same color in H.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-559-finite-graph",
-    "proofId": "erdos-559",
-    "range": {
-      "startLine": 50,
-      "endLine": 55
-    },
-    "type": "definition",
-    "title": "Finite Graph Structure",
-    "content": "A simple graph with finite vertex type, defined by an adjacency relation that is symmetric (undirected) and loopless (no self-edges). This provides the foundation for all graph-theoretic concepts.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-559-degree",
-    "proofId": "erdos-559",
-    "range": {
-      "startLine": 64,
-      "endLine": 71
-    },
-    "type": "definition",
-    "title": "Degree and Maximum Degree",
-    "content": "The degree of vertex v is the number of its neighbors. The maximum degree Δ(G) is the supremum over all vertices. The conjecture concerns graphs with bounded Δ(G) ≤ d.",
-    "significance": "key"
+    "title": "Ramsey Property and Size Ramsey Number R̂(G)",
+    "content": "**IsRamseyFor**: $H$ is Ramsey for $G$ if every 2-coloring of $H$'s edges contains a monochromatic copy of $G$ — an injective embedding $f: V(G) \\hookrightarrow V(H)$ where all image edges have the same color.\n\n**sizeRamsey** $\\hat{R}(G)$ is defined via `Nat.find` as the minimum $m$ such that $\\exists H$ with $m$ edges that is Ramsey for $G$. The complete graph on $V$ trivially satisfies this (by Ramsey's theorem), providing the well-definedness witness.",
+    "mathContext": "$\\hat{R}(G) = \\min\\{|E(H)| : H \\text{ is Ramsey for } G\\}$. Unlike the classical Ramsey number $R(G)$ (which minimizes vertices), the size Ramsey number minimizes edges. We always have $\\hat{R}(G) \\leq \\binom{R(G)}{2}$ (take $H = K_{R(G)}$), but $\\hat{R}(G)$ can be much smaller since $H$ need not be complete. The key insight: sparse Ramsey hosts are possible.",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey's theorem", "size Ramsey number", "Ramsey host graph", "sparse regularity"],
+    "prerequisites": ["Ramsey theory", "edge counting", "Nat.find"]
   },
   {
     "id": "ann-559-conjecture",
     "proofId": "erdos-559",
-    "range": {
-      "startLine": 96,
-      "endLine": 105
-    },
+    "range": { "startLine": 94, "endLine": 109 },
     "type": "theorem",
-    "title": "The Beck-Erdős Conjecture",
-    "content": "For each d ≥ 1, there exists c_d > 0 such that R̂(G) ≤ c_d · n for all n-vertex graphs G with maximum degree at most d. This would make size Ramsey numbers linear in n for bounded degree.",
-    "significance": "critical"
+    "title": "Beck-Erdős Conjecture (DISPROVED)",
+    "content": "**beck_erdos_conjecture**: For each $d \\geq 1$, $\\exists c_d > 0$ such that $\\hat{R}(G) \\leq c_d n$ for all $n$-vertex graphs $G$ with $\\Delta(G) \\leq d$.\n\n**beck_erdos_conjecture_false**: This is FALSE (Rödl-Szemerédi 2000). The conjecture was motivated by Beck's 1983 proof for paths and seemed natural: bounded degree limits local complexity, so why not global Ramsey complexity? The answer: bounded-degree graphs can still encode complex global structures (via expander-like properties) that force superlinear size Ramsey numbers.",
+    "mathContext": "The conjecture $\\hat{R}(G) \\leq c_d n$ when $\\Delta(G) \\leq d$ is equivalent to: the class of bounded-degree graphs has linear size Ramsey numbers. Rödl and Szemerédi (2000) disproved this for $d = 3$ by constructing degree-3 graphs $G_n$ on $n$ vertices with $\\hat{R}(G_n) \\geq cn(\\log n)^c$. Their construction uses a delicate probabilistic argument: random regular graphs of degree 3 have this property with positive probability.",
+    "significance": "critical",
+    "relatedConcepts": ["size Ramsey linearity", "random regular graphs", "Ramsey complexity", "graph regularity"],
+    "prerequisites": ["Ramsey theory", "bounded-degree graph theory", "probabilistic method"]
   },
   {
-    "id": "ann-559-disproved",
+    "id": "ann-559-positive",
     "proofId": "erdos-559",
-    "range": {
-      "startLine": 107,
-      "endLine": 109
-    },
+    "range": { "startLine": 111, "endLine": 150 },
     "type": "theorem",
-    "title": "Conjecture is FALSE",
-    "content": "The Beck-Erdős conjecture is false for d ≥ 3. Rödl and Szemerédi (2000) constructed degree-3 graphs requiring superlinear size Ramsey numbers, definitively disproving the conjecture.",
-    "significance": "critical"
+    "title": "Positive Results: Paths, Trees, and Cycles",
+    "content": "**beck_paths** (Beck 1983): $\\hat{R}(P_n) = O(n)$ for paths. Beck's original breakthrough — he showed random graphs of linear size are Ramsey for paths, initiating the study of size Ramsey numbers.\n\n**friedman_pippenger_trees** (1987): $\\hat{R}(T) = O(n)$ for any $n$-vertex tree $T$. The proof uses expander graphs: a sufficiently good expander with $O(n)$ edges is Ramsey for any tree with $n$ vertices.\n\n**haxell_kohayakawa_luczak_cycles** (1995): $\\hat{R}(C_n) = O(n)$ for cycles. This completed the picture for $\\Delta \\leq 2$: paths, cycles, and hence all graphs with maximum degree $\\leq 2$ have linear size Ramsey numbers.",
+    "mathContext": "Beck (1983) proved $\\hat{R}(P_n) \\leq cn$ by showing that a random graph $G(N, p)$ with $N = cn$ and appropriate $p$ is Ramsey for $P_n$ with high probability. Friedman-Pippenger (1987) extended this to all trees using expansion: if $H$ is a $(k, \\varepsilon)$-expander with $|V(H)| \\geq (1 + \\varepsilon)n$, then $H$ contains every tree with $n$ vertices and maximum degree $\\leq k$. Since good expanders have $O(n)$ edges, this gives $\\hat{R}(T) = O(n)$. The transition from linear to superlinear happens precisely at $\\Delta = 3$.",
+    "significance": "key",
+    "relatedConcepts": ["Beck's theorem", "expander graphs", "expansion lemma", "sparse Ramsey graphs"],
+    "prerequisites": ["random graphs", "graph expansion", "tree embedding"]
   },
   {
-    "id": "ann-559-paths",
+    "id": "ann-559-counter",
     "proofId": "erdos-559",
-    "range": {
-      "startLine": 113,
-      "endLine": 125
-    },
+    "range": { "startLine": 152, "endLine": 171 },
     "type": "theorem",
-    "title": "Paths: Linear Bound",
-    "content": "Beck (1983) proved R̂(P_n) = O(n) for paths. This was the first positive result and motivated the general conjecture. Paths are the simplest connected graphs with Δ = 2.",
-    "significance": "key"
+    "title": "Counterexamples: Rödl-Szemerédi and Tikhomirov",
+    "content": "**rodl_szemeredi_counterexample** (2000): $\\exists c > 0$ such that for all $N \\geq 2$, $\\exists$ degree-3 graph $G$ on $N$ vertices with $\\hat{R}(G) \\geq cN(\\log N)^c$. This was the key breakthrough disproving the Beck-Erdős conjecture at $d = 3$, the smallest possible counterexample degree.\n\n**tikhomirov_improved_lower_bound** (2022): $\\exists c > 0$ with $\\hat{R}(G) \\geq cN \\cdot \\exp(c\\sqrt{\\log N})$. This is much stronger than any polylogarithmic factor but still subpolynomial — the lower bound is $n^{1+o(1)}$, leaving a large gap with the upper bound $n^{3/2+o(1)}$.",
+    "mathContext": "Rödl-Szemerédi's construction: take a random 3-regular graph $G_n$. With positive probability, any graph $H$ that is Ramsey for $G_n$ must have $\\geq cn(\\log n)^c$ edges. The argument uses the fact that random regular graphs have complex neighborhood structure that resists embedding into sparse Ramsey hosts. Tikhomirov's improvement to $n \\cdot \\exp(c\\sqrt{\\log n})$ uses a refined analysis of the structure of Ramsey hosts, showing they must contain many more paths than a linear-sized graph can accommodate.",
+    "significance": "critical",
+    "relatedConcepts": ["random regular graphs", "Ramsey host complexity", "superlinear lower bounds", "subpolynomial gaps"],
+    "prerequisites": ["probabilistic method", "regular graph theory", "size Ramsey lower bounds"]
   },
   {
-    "id": "ann-559-trees",
+    "id": "ann-559-upper",
     "proofId": "erdos-559",
-    "range": {
-      "startLine": 127,
-      "endLine": 138
-    },
+    "range": { "startLine": 173, "endLine": 200 },
     "type": "theorem",
-    "title": "Trees: Linear Bound",
-    "content": "Friedman-Pippenger (1987) extended Beck's result to all trees: R̂(T) = O(n) for any n-vertex tree T. Their proof uses expander graphs and expansion properties.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-559-cycles",
-    "proofId": "erdos-559",
-    "range": {
-      "startLine": 140,
-      "endLine": 150
-    },
-    "type": "theorem",
-    "title": "Cycles: Linear Bound",
-    "content": "Haxell-Kohayakawa-Luczak (1995) proved R̂(C_n) = O(n) for cycles. This completed the picture for graphs with Δ ≤ 2: all such graphs have linear size Ramsey numbers.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-559-rodl-szemeredi",
-    "proofId": "erdos-559",
-    "range": {
-      "startLine": 154,
-      "endLine": 162
-    },
-    "type": "theorem",
-    "title": "Rödl-Szemerédi Counterexample",
-    "content": "The key breakthrough: there exist degree-3 graphs with R̂(G) ≫ n(log n)^c for some c > 0. This proves the conjecture fails at d = 3, the smallest possible counterexample degree.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-559-tikhomirov",
-    "proofId": "erdos-559",
-    "range": {
-      "startLine": 164,
-      "endLine": 171
-    },
-    "type": "theorem",
-    "title": "Tikhomirov's Improved Lower Bound",
-    "content": "Tikhomirov (2022) improved the lower bound to R̂(G) ≫ n·exp(c√(log n)). This is stronger than any poly-logarithmic factor but still subpolynomial in n.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-559-upper-bounds",
-    "proofId": "erdos-559",
-    "range": {
-      "startLine": 175,
-      "endLine": 200
-    },
-    "type": "theorem",
-    "title": "Upper Bounds for Degree-3",
-    "content": "Progress on upper bounds: Kohayakawa et al. showed n^{5/3+o(1)}, Conlon-Nenadov-Trujić improved to n^{8/5}, and Draganić-Petrova (2022) achieved n^{3/2+o(1)}, the current best.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-559-gap",
-    "proofId": "erdos-559",
-    "range": {
-      "startLine": 204,
-      "endLine": 210
-    },
-    "type": "insight",
-    "title": "The Remaining Gap",
-    "content": "Current bounds for d = 3: lower n·exp(c√(log n)), upper n^{3/2+o(1)}. The gap between these is substantial—the lower bound is barely superlinear while the upper is polynomial.",
-    "significance": "key"
+    "title": "Upper Bounds for Degree-3: Progressing Toward n^{3/2}",
+    "content": "**kohayakawa_upper_bound**: $\\hat{R}(G) \\leq n^{5/3+o(1)}$ for degree-3 graphs. The initial polynomial upper bound.\n\n**conlon_nenadov_trujic_upper_bound**: $\\hat{R}(G) \\leq cn^{8/5}$ for degree-3 graphs. Improved the exponent from $5/3 \\approx 1.667$ to $8/5 = 1.6$.\n\n**draganic_petrova_best_upper_bound** (2022): $\\hat{R}(G) \\leq n^{3/2+o(1)}$. The current best, reducing the exponent to $3/2 = 1.5$. The proof uses sparse regularity and the blow-up lemma to embed bounded-degree graphs into random-like subgraphs of the Ramsey host.",
+    "mathContext": "The exponent progression: $5/3 \\to 8/5 \\to 3/2$ for degree-3 graphs. Combined with Tikhomirov's lower bound $n \\cdot \\exp(c\\sqrt{\\log n}) = n^{1+o(1)}$, the current gap is between exponents $1+o(1)$ and $3/2+o(1)$. The key technique for upper bounds is the **sparse regularity method**: decompose a random graph into regular pairs using Szemerédi's regularity lemma for sparse graphs, then apply the blow-up lemma to embed $G$. The regularity method naturally gives polynomial bounds; breaking below $n^{3/2}$ would likely require fundamentally new ideas.",
+    "significance": "key",
+    "relatedConcepts": ["sparse regularity lemma", "blow-up lemma", "polynomial Ramsey bounds", "random graph embedding"],
+    "prerequisites": ["Szemerédi regularity", "blow-up lemma", "sparse graph theory"]
   },
   {
     "id": "ann-559-open",
     "proofId": "erdos-559",
-    "range": {
-      "startLine": 211,
-      "endLine": 218
-    },
-    "type": "definition",
-    "title": "Open Question",
-    "content": "What is the true growth rate for degree-3 graphs? Is it closer to n^{1+ε} or n^{3/2}? Determining the exact exponent or showing it doesn't exist remains a major open problem.",
-    "significance": "critical"
+    "range": { "startLine": 202, "endLine": 237 },
+    "type": "insight",
+    "title": "The Open Question: True Growth Rate for Degree 3",
+    "content": "**open_degree_3_question** formalizes the existence of a tight growth function: $\\exists f$ such that $\\hat{R}(G) \\leq f(N)$ for all degree-3 $G$ on $N$ vertices, and $\\hat{R}(G) \\geq f(N)/2$ for some such $G$.\n\nCurrent bounds for $d = 3$: $n \\cdot \\exp(c\\sqrt{\\log n}) \\leq \\hat{R}(G) \\leq n^{3/2+o(1)}$. The gap between exponents $1+o(1)$ and $3/2+o(1)$ is substantial. Is the true answer closer to $n^{1+\\varepsilon}$ (nearly linear) or $n^{3/2}$ (polynomial)?",
+    "mathContext": "The gap spans from $n^{1+o(1)}$ to $n^{1.5+o(1)}$ — a factor of $n^{0.5-o(1)}$. Neither side has obvious room for dramatic improvement: the lower bound technique (analyzing random regular graph embedding) seems hard to push past $n^{1+o(1)}$, while the upper bound technique (sparse regularity + blow-up) seems stuck at $n^{3/2}$. Resolving this gap would require either: (a) a fundamentally new lower bound technique, or (b) a non-regularity-based embedding method for upper bounds. Some experts conjecture the truth is $n^{1+o(1)}$ (nearly linear).",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey growth rates", "extremal exponents", "sparse vs dense Ramsey", "graph embedding techniques"],
+    "prerequisites": ["all preceding sections", "exponent analysis"]
   }
 ]

--- a/src/data/proofs/erdos-559/meta.json
+++ b/src/data/proofs/erdos-559/meta.json
@@ -22,69 +22,84 @@
     "erdosProblemStatus": "solved"
   },
   "overview": {
-    "historicalContext": "This problem was posed by Beck in 1983, with possible prior interest from Erdős. Beck's original paper proved the conjecture for paths. The problem asks whether the size Ramsey number—the minimum number of edges in a graph H that is Ramsey for G—is linear in n for bounded-degree graphs G with n vertices. This is a natural question connecting extremal graph theory with Ramsey theory.",
-    "problemStatement": "Let R̂(G) denote the size Ramsey number: the minimal number of edges m such that there exists a graph H with m edges that is Ramsey for G (any 2-coloring of H's edges contains a monochromatic copy of G). Conjecture (Beck/Erdős): If G has n vertices and maximum degree d, then R̂(G) ≪_d n (i.e., R̂(G) = O_d(n), linear in n with constant depending on d).",
-    "proofStrategy": "The conjecture was DISPROVED for d ≥ 3. The formalization captures: (1) Basic graph definitions with FiniteGraph structure, edge counting, degree functions. (2) The Ramsey property and size Ramsey number definition. (3) The Beck-Erdős conjecture statement and its negation. (4) Positive special cases where linearity holds (paths, trees, cycles). (5) Counterexamples showing superlinear lower bounds for degree-3 graphs. (6) Best known upper bounds showing polynomial growth.",
+    "historicalContext": "Beck posed this problem in 1983, motivated by his proof that the size Ramsey number of paths is linear: R̂(P_n) = O(n). He conjectured that the same linearity holds for all bounded-degree graphs: R̂(G) ≤ c_d · n when Δ(G) ≤ d. The conjecture was supported by positive results for increasingly general graph classes: Friedman and Pippenger (1987) proved it for all trees using expander graphs, and Haxell, Kohayakawa, and Luczak (1995) proved it for cycles, completing the picture for Δ ≤ 2. However, Rödl and Szemerédi (2000) dramatically disproved the conjecture for d = 3, constructing degree-3 graphs with R̂(G) ≥ cn(log n)^c using a probabilistic argument involving random 3-regular graphs. Tikhomirov (2022) strengthened this to R̂(G) ≥ cn · exp(c√(log n)), a bound that is superlinear but subpolynomial (n^{1+o(1)}). On the upper bound side, a sequence of improvements — Kohayakawa et al. (n^{5/3+o(1)}), Conlon-Nenadov-Trujić (n^{8/5}), and Draganić-Petrova (2022, n^{3/2+o(1)}) — has steadily reduced the exponent but a substantial gap remains between the lower bound n^{1+o(1)} and the upper bound n^{3/2+o(1)}.",
+    "problemStatement": "Let $\\hat{R}(G)$ denote the size Ramsey number: the minimal number of edges $m$ such that there exists a graph $H$ with $m$ edges that is Ramsey for $G$ (any 2-coloring of $H$'s edges contains a monochromatic copy of $G$). Conjecture (Beck/Erdős): If $G$ has $n$ vertices and maximum degree $d$, then $\\hat{R}(G) \\leq c_d n$ for some constant $c_d$ depending only on $d$.",
+    "proofStrategy": "The formalization defines `FiniteGraph` with adjacency, symmetry, looplessness, edge counting, degree, and maximum degree. The Ramsey property `IsRamseyFor` and size Ramsey number `sizeRamsey` are defined via `Nat.find`. The Beck-Erdős conjecture and its negation are stated, with `beck_erdos_conjecture_false` as the main theorem. Positive cases are formalized: `IsPath`, `IsTree`, `IsCycle` with linear bounds (Beck, Friedman-Pippenger, Haxell-Kohayakawa-Luczak). Counterexamples formalize the Rödl-Szemerédi and Tikhomirov lower bounds. Upper bounds capture the progression from $n^{5/3}$ to $n^{3/2}$. The open question about the exact growth rate is formalized as a proposition.",
     "keyInsights": [
-      "The conjecture HOLDS for restricted graph classes: paths (Beck 1983), trees (Friedman-Pippenger 1987), cycles (Haxell-Kohayakawa-Luczak 1995)",
-      "The conjecture FAILS for general degree-3 graphs, with counterexamples by Rödl-Szemerédi (2000) achieving R̂(G) ≫ n(log n)^c",
-      "Tikhomirov (2022) improved the lower bound to R̂(G) ≫ n·exp(c√(log n))",
-      "Best upper bounds for degree-3 graphs are polynomial: n^{3/2+o(1)} by Draganić-Petrova (2022)",
-      "The exact growth rate for degree-3 graphs remains a major open problem, with a substantial gap between lower and upper bounds"
+      "The conjecture HOLDS for $\\Delta \\leq 2$ (paths, trees, cycles all have $\\hat{R}(G) = O(n)$) but FAILS at $\\Delta = 3$ — the transition is sharp",
+      "Rödl-Szemerédi (2000) disproved the conjecture using random 3-regular graphs: their complex global structure forces any Ramsey host to have superlinear edges",
+      "Tikhomirov (2022) improved the lower bound to $n \\cdot \\exp(c\\sqrt{\\log n}) = n^{1+o(1)}$, which is superlinear but subpolynomial",
+      "The upper bound progression $n^{5/3} \\to n^{8/5} \\to n^{3/2}$ uses increasingly refined sparse regularity methods, but the $n^{3/2}$ barrier seems hard to break",
+      "The Friedman-Pippenger tree result uses a beautiful connection to expander graphs: good expanders with $O(n)$ edges contain every tree with $n$ vertices",
+      "The gap between $n^{1+o(1)}$ and $n^{3/2+o(1)}$ for degree-3 graphs is one of the most important open problems in size Ramsey theory"
     ]
   },
   "sections": [
     {
-      "title": "Basic Definitions",
+      "id": "header",
+      "title": "Problem Statement, Resolution, and References",
+      "summary": "Documentation header with Beck-Erdős conjecture, DISPROVED status, known positive/negative results, upper bound progression, and references to Beck, Rödl-Szemerédi, Tikhomirov, Draganić-Petrova",
+      "startLine": 1,
+      "endLine": 46
+    },
+    {
+      "id": "basic-defs",
+      "title": "Graph Definitions: FiniteGraph, Edges, Degree",
+      "summary": "FiniteGraph structure with adj/symm/loopless/dec, edgeCount via filtered unordered pairs, degree via neighbor count, maxDegree via Finset.sup",
       "startLine": 48,
-      "endLine": 71,
-      "summary": "Defines FiniteGraph structure with adjacency, symmetry, looplessness. Includes edgeCount (counting unordered pairs), degree (neighbors of a vertex), and maxDegree (supremum over all vertices)."
+      "endLine": 71
     },
     {
+      "id": "ramsey",
       "title": "Ramsey Property and Size Ramsey Number",
+      "summary": "IsRamseyFor via 2-colorings and monochromatic copies, sizeRamsey via Nat.find over minimum edges with Ramsey host",
       "startLine": 73,
-      "endLine": 92,
-      "summary": "Defines IsRamseyFor: H is Ramsey for G if any 2-coloring of H's edges contains a monochromatic copy of G. The size Ramsey number sizeRamsey(G) is the minimum edges needed for such an H."
+      "endLine": 92
     },
     {
-      "title": "The Beck-Erdős Conjecture (Disproved)",
+      "id": "conjecture",
+      "title": "Beck-Erdős Conjecture (DISPROVED)",
+      "summary": "beck_erdos_conjecture: R̂(G) ≤ c_d·n for Δ(G) ≤ d. beck_erdos_conjecture_false: negation proved by Rödl-Szemerédi (2000)",
       "startLine": 94,
-      "endLine": 109,
-      "summary": "States the conjecture: for each d ≥ 1, there exists c > 0 such that R̂(G) ≤ c·n for all n-vertex graphs G with maximum degree at most d. The theorem beck_erdos_conjecture_false asserts this is false."
+      "endLine": 109
     },
     {
-      "title": "Positive Results (Special Cases)",
+      "id": "positive",
+      "title": "Positive Results: Paths, Trees, Cycles",
+      "summary": "IsPath/IsTree/IsCycle definitions, beck_paths (1983), friedman_pippenger_trees (1987), haxell_kohayakawa_luczak_cycles (1995) — all proving R̂ = O(n)",
       "startLine": 111,
-      "endLine": 150,
-      "summary": "Formalizes the classes where linearity DOES hold: IsPath, IsTree, IsCycle definitions and theorems beck_paths, friedman_pippenger_trees, haxell_kohayakawa_luczak_cycles proving R̂(G) = O(n) for these families."
+      "endLine": 150
     },
     {
-      "title": "Counterexamples (d = 3)",
+      "id": "counterexamples",
+      "title": "Counterexamples for Degree 3",
+      "summary": "rodl_szemeredi_counterexample: R̂(G) ≥ cn(log n)^c for d=3. tikhomirov_improved_lower_bound: R̂(G) ≥ cn·exp(c√(log n))",
       "startLine": 152,
-      "endLine": 171,
-      "summary": "The key negative results: rodl_szemeredi_counterexample shows degree-3 graphs can have R̂(G) ≫ n(log n)^c; tikhomirov_improved_lower_bound achieves R̂(G) ≫ n·exp(c√(log n))."
+      "endLine": 171
     },
     {
-      "title": "Upper Bounds for Degree-3",
+      "id": "upper-bounds",
+      "title": "Upper Bounds for Degree 3: n^{5/3} → n^{8/5} → n^{3/2}",
+      "summary": "kohayakawa_upper_bound n^{5/3+o(1)}, conlon_nenadov_trujic n^{8/5}, draganic_petrova_best n^{3/2+o(1)} (current best) — all via sparse regularity",
       "startLine": 173,
-      "endLine": 200,
-      "summary": "Best known upper bounds: Kohayakawa et al. n^{5/3+o(1)}, Conlon-Nenadov-Trujić n^{8/5}, Draganić-Petrova n^{3/2+o(1)} (current best)."
+      "endLine": 200
     },
     {
-      "title": "The Open Question",
+      "id": "open-question",
+      "title": "The Open Question and Summary",
+      "summary": "open_degree_3_question: tight growth rate for d=3 between n^{1+o(1)} and n^{3/2+o(1)}. Summary of DISPROVED status and remaining gap",
       "startLine": 202,
-      "endLine": 218,
-      "summary": "The remaining challenge: what is the exact growth rate for degree-3 graphs? Currently bounded between n·exp(c√(log n)) and n^{3/2+o(1)}, a substantial gap."
+      "endLine": 237
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #559 asked whether size Ramsey numbers are linear for bounded-degree graphs. This was DISPROVED for d ≥ 3 by Rödl-Szemerédi (2000). The conjecture holds for special graph classes (paths, trees, cycles), but general degree-3 graphs can have superlinear size Ramsey numbers. The exact growth rate for d = 3 remains open, with current bounds ranging from n·exp(c√(log n)) to n^{3/2+o(1)}.",
-    "implications": "This result shows that Ramsey theory for sparse graphs is more complex than anticipated. The linear bound fails even at degree 3, yet the true behavior is neither fully linear nor polynomial—it lies in an intermediate regime that is still not well-understood.",
+    "summary": "Erdős Problem #559 on size Ramsey numbers for bounded-degree graphs was DISPROVED for d ≥ 3 by Rödl-Szemerédi (2000). The 238-line formalization captures the full landscape: the conjecture and its negation, positive results for paths (Beck 1983), trees (Friedman-Pippenger 1987), and cycles (Haxell-Kohayakawa-Luczak 1995), counterexamples from Rödl-Szemerédi and Tikhomirov, and the upper bound progression from n^{5/3} to n^{3/2}. The sharp transition at Δ = 3 between linear and superlinear behavior is a fundamental phenomenon in size Ramsey theory.",
+    "implications": "The disproof reveals that bounded degree alone does not guarantee linear size Ramsey numbers — global graph structure matters even when local structure is constrained. The gap between n^{1+o(1)} and n^{3/2+o(1)} for degree-3 graphs highlights a fundamental limitation of current techniques: probabilistic lower bounds give barely-superlinear growth, while regularity-based upper bounds give polynomial growth. New methods are needed on both sides.",
     "openQuestions": [
-      "What is the exact growth rate of R̂(G) for degree-3 graphs?",
-      "Can the gap between n·exp(c√(log n)) and n^{3/2+o(1)} be closed?",
-      "For which specific degree-3 graph families does linearity hold?",
-      "What happens at degree d = 2 (beyond cycles)?"
+      "What is the true growth rate of R̂(G) for degree-3 graphs? Is it n^{1+o(1)} or n^{3/2} or something in between?",
+      "Can the gap between lower bound n·exp(c√(log n)) and upper bound n^{3/2+o(1)} be closed?",
+      "For which specific degree-3 graph families (beyond random regular graphs) is the size Ramsey number superlinear?",
+      "What happens at degree d = 2 beyond cycles — e.g., for unions of paths and cycles?"
     ]
   }
 }

--- a/src/data/proofs/erdos-57/annotations.json
+++ b/src/data/proofs/erdos-57/annotations.json
@@ -1,101 +1,62 @@
 [
   {
-    "id": "ann-e57-cycle-lengths",
+    "id": "ann-57-defs",
     "proofId": "erdos-57",
-    "range": { "startLine": 34, "endLine": 35 },
+    "range": { "startLine": 28, "endLine": 49 },
     "type": "definition",
-    "title": "Cycle Lengths",
-    "content": "The set of all **cycle lengths** in a graph G. A cycle is a closed walk with no repeated vertices except the endpoints. Uses Mathlib's Walk.IsCycle predicate.",
-    "significance": "key"
+    "title": "Core Definitions: Cycle Lengths, Colorability, Infinite Chromatic Number",
+    "content": "**cycleLengths** $\\mathcal{C}(G) = \\{n \\in \\mathbb{N} : \\exists u, \\exists$ cycle $p$ at $u$ with $|p| = n\\}$ using Mathlib's `Walk.IsCycle` predicate (closed walk, no repeated internal vertices, length $\\geq 3$).\n\n**oddCycleLengths** $\\mathcal{C}_{\\text{odd}}(G) = \\{n \\in \\mathcal{C}(G) : n \\text{ is odd}\\}$. These are the central objects in the Erdős-Hajnal conjecture.\n\n**IsColorable** $G$ $k$: $\\exists f: V \\to \\text{Fin}\\, k$ with $G.\\text{Adj}(u,v) \\Rightarrow f(u) \\neq f(v)$.\n\n**HasInfiniteChromaticNumber** $G$: $\\forall k, \\neg\\text{IsColorable}\\, G\\, k$, i.e., $\\chi(G) = \\infty$.",
+    "mathContext": "A graph $G$ has $\\chi(G) = \\infty$ iff it is not $k$-colorable for any finite $k$. Such graphs must be infinite (since finite graphs have $\\chi(G) \\leq |V|$). The classical hierarchy: $\\chi(G) \\leq 2$ iff $G$ is bipartite iff $\\mathcal{C}_{\\text{odd}}(G) = \\emptyset$. Beyond 2 colors, the relationship between $\\chi$ and cycle structure becomes subtle — high chromatic number forces rich cycle structure, but the exact quantitative relationship is the content of Problem #57.",
+    "significance": "critical",
+    "relatedConcepts": ["graph coloring", "chromatic number", "Walk.IsCycle", "proper coloring"],
+    "prerequisites": ["SimpleGraph", "Fintype", "Walk theory in Mathlib"]
   },
   {
-    "id": "ann-e57-odd-cycle-lengths",
+    "id": "ann-57-harmonic",
     "proofId": "erdos-57",
-    "range": { "startLine": 38, "endLine": 39 },
-    "type": "definition",
-    "title": "Odd Cycle Lengths",
-    "content": "The set of all **odd cycle lengths** in G: the subset of cycleLengths where the length is odd. These are the key objects in the Erdős-Hajnal conjecture.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e57-colorable",
-    "proofId": "erdos-57",
-    "range": { "startLine": 44, "endLine": 45 },
-    "type": "definition",
-    "title": "k-Colorable",
-    "content": "A graph is **k-colorable** if there exists a function f: V → Fin k such that adjacent vertices get different colors. This is the standard graph coloring property.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-e57-infinite-chromatic",
-    "proofId": "erdos-57",
-    "range": { "startLine": 48, "endLine": 49 },
-    "type": "definition",
-    "title": "Infinite Chromatic Number",
-    "content": "A graph has **infinite chromatic number** if it's not k-colorable for any finite k. Such graphs require infinitely many colors to properly color.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e57-harmonic-sum",
-    "proofId": "erdos-57",
-    "range": { "startLine": 54, "endLine": 55 },
-    "type": "definition",
-    "title": "Odd Cycle Harmonic Sum",
-    "content": "The sum **∑ 1/aᵢ** where aᵢ are the odd cycle lengths. Uses ENNReal to allow the value ∞ (⊤). This is the central quantity in the Erdős-Hajnal conjecture.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e57-main-axiom",
-    "proofId": "erdos-57",
-    "range": { "startLine": 63, "endLine": 64 },
-    "type": "axiom",
-    "title": "Erdős-Hajnal Conjecture (SOLVED)",
-    "content": "**Liu-Montgomery (2020)**: If G has infinite chromatic number, then the harmonic sum of odd cycle lengths equals ⊤ (infinity). This quantifies how 'many' odd cycles such graphs must have.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e57-corollary",
-    "proofId": "erdos-57",
-    "range": { "startLine": 111, "endLine": 119 },
+    "range": { "startLine": 51, "endLine": 64 },
     "type": "theorem",
-    "title": "Infinitely Many Odd Cycle Lengths",
-    "content": "**Corollary**: Graphs with infinite chromatic number have infinitely many distinct odd cycle lengths. Proof: if finitely many, the harmonic sum would be finite, contradicting erdos_57.",
-    "significance": "key"
+    "title": "Harmonic Sum and the Erdős-Hajnal Conjecture (SOLVED)",
+    "content": "**oddCycleHarmonicSum** $\\sum_{n \\in \\mathcal{C}_{\\text{odd}}(G)} 1/n$ computed as a `tsum` over the subtype `oddCycleLengths G` in `ENNReal`, allowing $\\infty = \\top$.\n\n**erdos_57** (axiom, Liu-Montgomery 2020): $\\chi(G) = \\infty \\Rightarrow \\sum_{n \\in \\mathcal{C}_{\\text{odd}}(G)} 1/n = \\top$. The harmonic sum of odd cycle lengths diverges for graphs with infinite chromatic number.",
+    "mathContext": "The use of `ENNReal` ($[0, \\infty]$) is essential: the sum is either a finite nonneg real or $\\top = \\infty$. The axiom states it equals $\\top$. This is sharp in the sense that the reciprocal sum is the right measure: there exist graphs with $\\chi(G) = \\infty$ whose odd cycle lengths have lower density 0 (high-girth constructions with $\\text{girth}(G_n) \\to \\infty$ but $\\chi(G_n) \\to \\infty$, then take their union). Yet even for such graphs, the reciprocal sum still diverges. Liu-Montgomery's proof uses a sophisticated combination of the dependent random choice method with structural decompositions of graphs lacking short odd cycles.",
+    "significance": "critical",
+    "relatedConcepts": ["ENNReal", "tsum", "divergent series", "dependent random choice"],
+    "prerequisites": ["extended nonneg reals", "tsum over subtypes", "Ramsey-type combinatorics"]
   },
   {
-    "id": "ann-e57-upper-density",
+    "id": "ann-57-proved",
     "proofId": "erdos-57",
-    "range": { "startLine": 124, "endLine": 125 },
-    "type": "definition",
-    "title": "Upper Density",
-    "content": "The **upper density** of S ⊆ ℕ is limsup of |S ∩ [1,N]|/N as N → ∞. Measures the 'proportion' of integers in S in the limit.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-e57-density-conjecture",
-    "proofId": "erdos-57",
-    "range": { "startLine": 131, "endLine": 133 },
-    "type": "definition",
-    "title": "Upper Density Conjecture (OPEN)",
-    "content": "**Erdős (1981)**: If G has infinite chromatic number, must the odd cycle lengths have positive upper density? This is OPEN and stronger than the solved problem.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-e57-half-density",
-    "proofId": "erdos-57",
-    "range": { "startLine": 139, "endLine": 141 },
-    "type": "definition",
-    "title": "Half Density Conjecture (OPEN)",
-    "content": "**Erdős (1995-96)**: If G has infinite chromatic number, is the upper density of odd cycle lengths at least 1/2? Even stronger speculation, still OPEN.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-e57-bipartite-char",
-    "proofId": "erdos-57",
-    "range": { "startLine": 146, "endLine": 148 },
+    "range": { "startLine": 66, "endLine": 119 },
     "type": "theorem",
-    "title": "Bipartite Characterization",
-    "content": "A graph is **bipartite** iff it has no odd cycles. This is equivalent to χ(G) ≤ 2. Classical result connecting parity of cycles to chromatic structure.",
-    "significance": "supporting"
+    "title": "Proved Results: Finite Sum Lemma, Positivity, and Infinite Odd Cycles",
+    "content": "**finite_reciprocal_sum_ne_top**: If $S \\subseteq \\mathbb{N}$ is finite with all elements positive, then $\\sum_{n \\in S} 1/n \\neq \\top$. Proved by converting `tsum` over the finite subtype to `Finset.sum`, then showing each term $1/n < \\top$ in `ENNReal`.\n\n**oddCycleLengths_pos**: Every odd cycle length is positive ($\\geq 3$), since `Walk.IsCycle` has `three_le_length`.\n\n**infinite_odd_cycle_lengths**: $\\chi(G) = \\infty \\Rightarrow \\mathcal{C}_{\\text{odd}}(G)$ is infinite. Proof by contradiction: if finite, `finite_reciprocal_sum_ne_top` gives $\\sum 1/n \\neq \\top$, contradicting `erdos_57`.",
+    "mathContext": "The corollary `infinite_odd_cycle_lengths` is the qualitative consequence of the quantitative `erdos_57`. The logical chain: $\\chi(G) = \\infty \\xrightarrow{\\text{erdos\\_57}} \\sum 1/a_i = \\infty \\xrightarrow{\\text{finite\\_reciprocal\\_sum\\_ne\\_top}} |\\mathcal{C}_{\\text{odd}}| = \\infty$. The proof is clean: the ENNReal framework handles the $\\infty$ comparison directly. Note that the converse fails: a graph can have infinitely many odd cycle lengths but finite chromatic number (e.g., add all odd cycles to a path).",
+    "significance": "key",
+    "relatedConcepts": ["proof by contradiction", "tsum_subtype", "Finset.sum", "ENNReal.sum_lt_top"],
+    "prerequisites": ["ENNReal arithmetic", "tsum over finite sets", "Walk.IsCycle.three_le_length"]
+  },
+  {
+    "id": "ann-57-open",
+    "proofId": "erdos-57",
+    "range": { "startLine": 121, "endLine": 141 },
+    "type": "insight",
+    "title": "Open Density Conjectures: Positive Density and Half Density",
+    "content": "**UpperDensityConjecture** (Erdős 1981): $\\chi(G) = \\infty \\Rightarrow \\overline{d}(\\mathcal{C}_{\\text{odd}}(G)) > 0$, where $\\overline{d}(S) = \\limsup_{N \\to \\infty} |S \\cap [1,N]|/N$.\n\n**HalfDensityConjecture** (Erdős 1995-96): $\\chi(G) = \\infty \\Rightarrow \\overline{d}(\\mathcal{C}_{\\text{odd}}(G)) \\geq 1/2$. The bound $1/2$ would be tight: graphs with no even cycles have $\\overline{d}(\\mathcal{C}_{\\text{odd}}) = 1/2$ (only odd lengths present, comprising half of all integers).",
+    "mathContext": "The hierarchy of conjectures in increasing strength: (1) infinitely many odd cycle lengths (PROVED, corollary of #57); (2) $\\sum 1/a_i = \\infty$ (PROVED, Liu-Montgomery 2020 = Problem #57); (3) $\\overline{d} > 0$ (OPEN, Erdős 1981); (4) $\\overline{d} \\geq 1/2$ (OPEN, Erdős 1995-96). The density conjectures are strictly stronger than the harmonic divergence: a set $S$ with $\\overline{d}(S) > 0$ has $\\sum_{n \\in S} 1/n = \\infty$, but not conversely (e.g., $S = \\{2^k\\}$ has $\\sum 1/2^k = 1$ but $\\overline{d} = 0$; however $S = $ primes has $\\sum 1/p = \\infty$ and $\\overline{d} = 0$). The formalization uses `Filter.limsup` at `Filter.atTop`.",
+    "significance": "key",
+    "relatedConcepts": ["upper density", "limsup", "density of integer sets", "Filter.atTop"],
+    "prerequisites": ["Filter.limsup", "Set.ncard", "real analysis"]
+  },
+  {
+    "id": "ann-57-bipartite",
+    "proofId": "erdos-57",
+    "range": { "startLine": 143, "endLine": 153 },
+    "type": "theorem",
+    "title": "Bipartite Characterization and 2-Colorable Graphs",
+    "content": "**bipartite_iff_no_odd_cycles** (sorry): $G$ is bipartite $\\iff \\mathcal{C}_{\\text{odd}}(G) = \\emptyset$. Uses Mathlib's `SimpleGraph.IsBipartite`. This is the classical König-type characterization.\n\n**colorable_two_no_odd_cycles** (sorry): $\\text{IsColorable}\\, G\\, 2 \\Rightarrow \\mathcal{C}_{\\text{odd}}(G) = \\emptyset$. The forward direction of the bipartite characterization: a 2-coloring assigns vertices to two classes, and any cycle must alternate between them, forcing even length.",
+    "mathContext": "The bipartite characterization $G \\text{ bipartite} \\iff \\text{no odd cycles}$ is the foundation of the chromatic-cycle connection. It can be restated as: $\\chi(G) \\leq 2 \\iff \\mathcal{C}_{\\text{odd}}(G) = \\emptyset$. Problem #57 extends this to $\\chi(G) = \\infty$: not only must odd cycles exist, but they must be so numerous that $\\sum 1/a_i = \\infty$. The gap between $\\chi(G) = 3$ and $\\chi(G) = \\infty$ is where most of the difficulty lies — finite chromatic number $\\geq 3$ guarantees at least one odd cycle but says nothing about divergence of the reciprocal sum.",
+    "significance": "key",
+    "relatedConcepts": ["bipartite graphs", "König's theorem", "2-colorability", "odd cycle characterization"],
+    "prerequisites": ["SimpleGraph.IsBipartite", "Walk.IsCycle", "graph coloring theory"]
   }
 ]

--- a/src/data/proofs/erdos-57/meta.json
+++ b/src/data/proofs/erdos-57/meta.json
@@ -13,70 +13,102 @@
       "erdos",
       "graph-theory",
       "chromatic-number",
-      "cycles"
+      "cycles",
+      "combinatorics",
+      "solved"
     ],
     "badge": "wip",
     "sorries": 2,
     "erdosNumber": 57,
     "erdosUrl": "https://erdosproblems.com/57",
-    "erdosProblemStatus": "solved"
+    "erdosProblemStatus": "solved",
+    "references": [
+      "Erdős-Hajnal (1966): original conjecture on odd cycle lengths",
+      "Erdős (1981): upper density conjecture for odd cycle lengths",
+      "Erdős (1995-96): half density speculation (≥ 1/2)",
+      "Liu-Montgomery (2020): 'A solution to Erdős and Hajnal's odd cycle problem'",
+      "https://erdosproblems.com/57"
+    ],
+    "leanFile": "Proofs/Erdos57Problem.lean"
   },
   "overview": {
-    "historicalContext": "Conjectured by Erdős and Hajnal in 1966, this problem connects chromatic number to the structure of odd cycles. Erdős later asked (1981) whether the odd cycle lengths must have positive upper density, and speculated (1995-96) it might be at least 1/2. Liu and Montgomery solved the original conjecture in 2020.",
-    "problemStatement": "If G is a graph with infinite chromatic number and a₁ < a₂ < ⋯ are the lengths of the odd cycles of G, then ∑ 1/aᵢ = ∞.",
-    "proofStrategy": "The formalization uses Mathlib's SimpleGraph and Walk.IsCycle. The main result is stated as an axiom, with a corollary proving infinite chromatic number implies infinitely many odd cycle lengths. Related open questions about density are also formalized.",
+    "historicalContext": "Erdős and Hajnal conjectured in 1966 that graphs with infinite chromatic number must have 'many' odd cycles, quantified by the divergence of the reciprocal sum ∑ 1/aᵢ. The conjecture sits in a hierarchy of increasingly strong claims: (1) infinitely many odd cycle lengths, (2) ∑ 1/aᵢ = ∞ (this problem), (3) positive upper density (Erdős 1981, OPEN), (4) upper density ≥ 1/2 (Erdős 1995-96, OPEN). The foundation is the classical bipartite characterization: χ(G) ≤ 2 iff no odd cycles. Problem #57 asks what happens at χ(G) = ∞. Liu and Montgomery solved it in 2020 using dependent random choice and structural decomposition techniques from extremal combinatorics. Their proof analyzes graphs lacking short odd cycles, showing that even in the high-girth regime (where odd cycles are sparse), the reciprocal sum still diverges. The result has connections to Ramsey theory and the Gyárfás-Sumner conjecture on χ-bounded classes.",
+    "problemStatement": "If $G$ is a graph with $\\chi(G) = \\infty$ and $a_1 < a_2 < \\cdots$ are the lengths of the odd cycles of $G$, then $\\sum 1/a_i = \\infty$.",
+    "proofStrategy": "The formalization defines cycle lengths via Mathlib's `Walk.IsCycle`, models infinite chromatic number as `∀ k, ¬IsColorable G k`, and computes the harmonic sum as a `tsum` in `ENNReal` (allowing ∞ = ⊤). The main result `erdos_57` is axiomatized. Three results are proved: `finite_reciprocal_sum_ne_top` (finite sum in ENNReal is not ⊤), `oddCycleLengths_pos` (odd cycles have length ≥ 3 via `three_le_length`), and the corollary `infinite_odd_cycle_lengths` (by contradiction using the first two). Open density conjectures are formalized using `Filter.limsup`. The bipartite characterization has 2 sorries.",
     "keyInsights": [
-      "Infinite chromatic number forces divergent reciprocal sum of odd cycle lengths",
-      "This implies infinitely many distinct odd cycle lengths",
-      "Bipartite graphs have no odd cycles (χ ≤ 2)",
-      "Lower density of odd cycle lengths can be 0 (high girth graphs)",
-      "Open: Does infinite χ imply positive upper density of odd cycle lengths?"
+      "The harmonic sum ∑ 1/aᵢ in ENNReal is the right framework: it is either finite (a real number) or ⊤ (infinity), and the axiom asserts it equals ⊤ for χ(G) = ∞",
+      "The corollary 'infinitely many odd cycle lengths' follows by contradiction: a finite set has finite reciprocal sum, contradicting ∑ 1/aᵢ = ⊤",
+      "High-girth constructions (Erdős 1959, Kwan-Sudakov 2021) show χ(G) = ∞ is compatible with lower density 0 for odd cycle lengths — the reciprocal sum divergence is a precisely calibrated measure",
+      "The hierarchy: no odd cycles (χ ≤ 2) → finitely many → infinitely many → ∑ 1/aᵢ = ∞ (PROVED) → d̄ > 0 (OPEN) → d̄ ≥ 1/2 (OPEN)",
+      "Liu-Montgomery's dependent random choice technique: embed dense bipartite subgraphs into neighborhoods, then use the odd-cycle-free structure to derive contradictions"
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement, History, and Imports",
+      "summary": "Documentation header with Erdős-Hajnal (1966) conjecture, historical progression through density conjectures, Liu-Montgomery (2020) solution, Mathlib import",
+      "startLine": 1,
+      "endLine": 27
+    },
+    {
       "id": "definitions",
-      "title": "Core Definitions",
-      "summary": "Cycle lengths, odd cycle lengths, colorability, infinite chromatic number",
+      "title": "Core Definitions: Cycles, Coloring, Infinite Chromatic Number",
+      "summary": "cycleLengths via Walk.IsCycle existential, oddCycleLengths as odd-parity filter, IsColorable via proper k-coloring, HasInfiniteChromaticNumber as ∀ k negation",
       "startLine": 28,
-      "endLine": 52
+      "endLine": 49
     },
     {
       "id": "harmonic-sum",
-      "title": "Harmonic Sum",
-      "summary": "Definition of ∑ 1/aᵢ over odd cycle lengths using ENNReal",
-      "startLine": 54,
-      "endLine": 58
+      "title": "Harmonic Sum in ENNReal",
+      "summary": "oddCycleHarmonicSum as tsum over oddCycleLengths subtype of 1/n in ENNReal, allowing ⊤ value",
+      "startLine": 51,
+      "endLine": 55
     },
     {
       "id": "main-result",
-      "title": "Main Result (Liu-Montgomery 2020)",
-      "summary": "The solved conjecture and its corollary",
-      "startLine": 60,
-      "endLine": 72
+      "title": "Main Result: erdos_57 Axiom (Liu-Montgomery 2020)",
+      "summary": "Axiom: HasInfiniteChromaticNumber G → oddCycleHarmonicSum G = ⊤. The solved Erdős-Hajnal conjecture",
+      "startLine": 57,
+      "endLine": 64
+    },
+    {
+      "id": "proved-lemmas",
+      "title": "Proved Lemmas: Finite Sum, Positivity, Corollary",
+      "summary": "finite_reciprocal_sum_ne_top via tsum→Finset.sum conversion + ENNReal.sum_lt_top. oddCycleLengths_pos via three_le_length. infinite_odd_cycle_lengths by contradiction combining both",
+      "startLine": 66,
+      "endLine": 119
     },
     {
       "id": "open-questions",
-      "title": "Related Open Questions",
-      "summary": "Density conjectures from Erdős (1981, 1995-96)",
-      "startLine": 74,
-      "endLine": 94
+      "title": "Open Density Conjectures (Erdős 1981, 1995-96)",
+      "summary": "upperDensity via Filter.limsup of |S ∩ [1,N]|/N. UpperDensityConjecture: d̄ > 0. HalfDensityConjecture: d̄ ≥ 1/2. Both OPEN, strictly stronger than #57",
+      "startLine": 121,
+      "endLine": 141
     },
     {
       "id": "bipartite",
-      "title": "Bipartite Characterization",
-      "summary": "Connection between 2-colorability and odd cycles",
-      "startLine": 96,
-      "endLine": 109
+      "title": "Bipartite Characterization (2 sorries)",
+      "summary": "bipartite_iff_no_odd_cycles: G.IsBipartite ↔ oddCycleLengths G = ∅ (sorry). colorable_two_no_odd_cycles: IsColorable G 2 → empty odd cycles (sorry). Classical foundation for the chromatic-cycle connection",
+      "startLine": 143,
+      "endLine": 153
+    },
+    {
+      "id": "historical-notes",
+      "title": "Historical Notes and References",
+      "summary": "Liu-Montgomery proof technique overview, fundamental bipartite-odd cycle connection, references to Erdős-Hajnal (1966) and Liu-Montgomery (2020)",
+      "startLine": 155,
+      "endLine": 167
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #57, solved by Liu and Montgomery in 2020. The result shows that graphs with infinite chromatic number must have 'many' odd cycles in a precise sense: the reciprocal sum of their lengths diverges.",
-    "implications": "This establishes a fundamental quantitative connection between chromatic number and odd cycle structure, going beyond the classical fact that bipartite graphs have no odd cycles.",
+    "summary": "Erdős Problem #57 was SOLVED by Liu and Montgomery in 2020. The 167-line formalization axiomatizes the main result (∑ 1/aᵢ = ⊤ for χ(G) = ∞) and proves three supporting results: finite reciprocal sums are not ⊤, odd cycle lengths are positive, and the corollary that infinitely many odd cycle lengths exist. Two sorries remain for the bipartite characterization. Open density conjectures from Erdős (1981, 1995-96) are formalized but remain unresolved.",
+    "implications": "The result establishes a precise quantitative threshold for odd cycle richness: the reciprocal sum divergence is the exact boundary between what is proved and what remains open. The density conjectures would further strengthen the connection between chromatic complexity and cycle structure, potentially illuminating the broader question of which graph properties are forced by high chromatic number.",
     "openQuestions": [
-      "Must odd cycle lengths have positive upper density?",
-      "Is the upper density at least 1/2 (Erdős 1995-96)?",
-      "What is the relationship to problem [65] on general cycle lengths?"
+      "Must odd cycle lengths have positive upper density when χ(G) = ∞? (Erdős 1981, OPEN)",
+      "Is the upper density of odd cycle lengths at least 1/2? (Erdős 1995-96, OPEN)",
+      "What is the relationship to Problem #65 on general cycle lengths in graphs with large chromatic number?",
+      "Can the bipartite characterization sorries be proved via Aristotle (Mathlib's SimpleGraph.IsBipartite)?"
     ]
   }
 }

--- a/src/data/proofs/erdos-58/annotations.json
+++ b/src/data/proofs/erdos-58/annotations.json
@@ -1,128 +1,62 @@
 [
   {
-    "id": "ann-e58-cycle-lengths",
+    "id": "ann-58-defs",
     "proofId": "erdos-58",
-    "range": { "startLine": 31, "endLine": 33 },
+    "range": { "startLine": 26, "endLine": 62 },
     "type": "definition",
-    "title": "Cycle Lengths",
-    "content": "The set of all **cycle lengths** in a graph G, using Mathlib's Walk.IsCycle predicate. A cycle is a closed walk with no repeated vertices except endpoints.",
-    "significance": "supporting"
+    "title": "Core Definitions: Odd Cycle Counts, Chromatic Number, Cliques",
+    "content": "**cycleLengths** / **oddCycleLengths**: as in Problem #57, using `Walk.IsCycle`.\n\n**numOddCycleLengths** $k(G) = |\\mathcal{C}_{\\text{odd}}(G)|$ via `Set.ncard` — the number of distinct odd cycle lengths.\n\n**chromaticNumber** $\\chi(G)$: axiomatized with `chromaticNumber_spec` giving both $\\text{IsColorable}\\, G\\, \\chi(G)$ and minimality $\\forall k < \\chi(G),\\, \\neg\\text{IsColorable}\\, G\\, k$.\n\n**ContainsClique** $G$ $n$: $\\exists S \\subseteq V$ with $|S| = n$ and all pairs adjacent. This characterizes when equality holds in Gyárfás' bound.",
+    "mathContext": "The chromatic number $\\chi(G)$ is axiomatized rather than defined because Mathlib's `SimpleGraph.chromaticNumber` was still evolving. The axiomatization is clean: existence of optimal coloring + minimality. The key parameter is $k = |\\mathcal{C}_{\\text{odd}}(G)|$, counting distinct odd cycle lengths. Note: $k = 0$ iff bipartite ($\\chi \\leq 2$); $k < \\infty$ iff finitely many odd cycle lengths; $k = \\infty$ is the setting of Problem #57.",
+    "significance": "key",
+    "relatedConcepts": ["graph chromatic number", "Set.ncard", "clique number", "Walk.IsCycle"],
+    "prerequisites": ["SimpleGraph", "proper coloring", "Finset cliques"]
   },
   {
-    "id": "ann-e58-odd-cycle-lengths",
+    "id": "ann-58-gyarfas",
     "proofId": "erdos-58",
-    "range": { "startLine": 35, "endLine": 37 },
-    "type": "definition",
-    "title": "Odd Cycle Lengths",
-    "content": "The set of all **odd cycle lengths** in G. These are the key objects relating to chromatic number bounds in this problem.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e58-num-odd-cycles",
-    "proofId": "erdos-58",
-    "range": { "startLine": 39, "endLine": 41 },
-    "type": "definition",
-    "title": "Number of Odd Cycle Lengths",
-    "content": "The count of distinct odd cycle lengths in G, denoted k in the theorem statements. Uses Set.ncard for cardinality of potentially infinite sets.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e58-colorable",
-    "proofId": "erdos-58",
-    "range": { "startLine": 45, "endLine": 47 },
-    "type": "definition",
-    "title": "k-Colorable",
-    "content": "A graph is **k-colorable** if there exists f: V -> Fin k with adjacent vertices receiving different colors. Standard graph coloring definition.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-e58-chromatic-number",
-    "proofId": "erdos-58",
-    "range": { "startLine": 49, "endLine": 55 },
-    "type": "definition",
-    "title": "Chromatic Number",
-    "content": "The **chromatic number** chi(G) is the minimum k for which G is k-colorable. Axiomatized here for simplicity, with specification given separately.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e58-contains-clique",
-    "proofId": "erdos-58",
-    "range": { "startLine": 59, "endLine": 61 },
-    "type": "definition",
-    "title": "Contains Clique",
-    "content": "G **contains K_n** if there exists a set S of n vertices that are pairwise adjacent. This characterizes when equality holds in Gyarfas' bound.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-e58-gyarfas-upper",
-    "proofId": "erdos-58",
-    "range": { "startLine": 65, "endLine": 70 },
-    "type": "axiom",
-    "title": "Gyarfas Upper Bound (1992)",
-    "content": "**Main Result**: If G has at most k distinct odd cycle lengths, then chi(G) <= 2k+2. This is the core of the solved conjecture.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e58-gyarfas-equality",
-    "proofId": "erdos-58",
-    "range": { "startLine": 72, "endLine": 78 },
-    "type": "axiom",
-    "title": "Gyarfas Equality Characterization",
-    "content": "**Equality Case**: chi(G) = 2k+2 with <=k odd cycle lengths iff G contains K_{2k+2}. Complete graphs are the extremal examples.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e58-gyarfas-structural",
-    "proofId": "erdos-58",
-    "range": { "startLine": 80, "endLine": 89 },
-    "type": "axiom",
-    "title": "Gyarfas Structural Result",
-    "content": "**2-Connected Case**: If G is 2-connected with <=k odd cycle lengths, then G contains K_{2k+2} or has a vertex of degree <=2k. Powerful structural dichotomy.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e58-bollobas-shelah",
-    "proofId": "erdos-58",
-    "range": { "startLine": 93, "endLine": 101 },
+    "range": { "startLine": 64, "endLine": 90 },
     "type": "theorem",
-    "title": "Bollobas-Shelah (k=1)",
-    "content": "**Special Case**: At most 1 odd cycle length implies chi <= 4. This was proved before Gyarfas' general result and motivated the conjecture.",
-    "significance": "key"
+    "title": "Gyárfás' Theorem (1992): χ(G) ≤ 2k+2 and Equality Characterization",
+    "content": "**gyarfas_upper_bound**: $|\\mathcal{C}_{\\text{odd}}(G)| \\leq k \\Rightarrow \\chi(G) \\leq 2k+2$. The central result solving the Bollobás-Erdős conjecture.\n\n**gyarfas_equality**: $(|\\mathcal{C}_{\\text{odd}}(G)| \\leq k \\wedge \\chi(G) = 2k+2) \\iff K_{2k+2} \\subseteq G$. Complete graphs are the unique extremal examples.\n\n**gyarfas_structural**: For 2-connected $G$ with $|\\mathcal{C}_{\\text{odd}}| \\leq k$: either $K_{2k+2} \\subseteq G$ or $\\exists v$ with $\\deg(v) \\leq 2k$. This structural dichotomy is the engine of Gyárfás' inductive proof.",
+    "mathContext": "Gyárfás' proof strategy: induction on $|V|$ using the structural result. If $G$ is 2-connected with $\\leq k$ odd cycle lengths and no $K_{2k+2}$, then some vertex $v$ has $\\deg(v) \\leq 2k$. Remove $v$, apply induction to get a $(2k+2)$-coloring of $G - v$, then extend to $v$ since it has $\\leq 2k < 2k+2$ neighbors. The equality characterization: $K_{2k+2}$ has exactly $k$ odd cycle lengths $\\{3, 5, 7, \\ldots, 2k+1\\}$ (all odd lengths from 3 to $2k+1$) and $\\chi(K_{2k+2}) = 2k+2$.",
+    "significance": "critical",
+    "relatedConcepts": ["graph coloring bounds", "extremal graph theory", "2-connected graphs", "vertex removal induction"],
+    "prerequisites": ["graph connectivity", "clique containment", "induction on vertex count"]
   },
   {
-    "id": "ann-e58-bipartite-case",
+    "id": "ann-58-special",
     "proofId": "erdos-58",
-    "range": { "startLine": 103, "endLine": 111 },
+    "range": { "startLine": 92, "endLine": 112 },
     "type": "theorem",
-    "title": "Bipartite Case (k=0)",
-    "content": "**k=0 Case**: No odd cycles implies chi <= 2 (bipartite). This is the classical result that odd-cycle-free graphs are 2-colorable.",
-    "significance": "supporting"
+    "title": "Special Cases: Bipartite (k=0) and Bollobás-Shelah (k=1)",
+    "content": "**bollobas_shelah**: $|\\mathcal{C}_{\\text{odd}}| \\leq 1 \\Rightarrow \\chi(G) \\leq 4$. Proved from `gyarfas_upper_bound G 1` by `omega`. The original result by Bollobás and Shelah that motivated the general conjecture.\n\n**no_odd_cycles_bipartite**: $|\\mathcal{C}_{\\text{odd}}| = 0 \\Rightarrow \\chi(G) \\leq 2$. Proved from `gyarfas_upper_bound G 0` by `omega`. Recovers the classical bipartite characterization: no odd cycles means 2-colorable.",
+    "mathContext": "The $k = 0$ case is classical: a graph with no odd cycles is bipartite, hence $\\chi \\leq 2$. The $k = 1$ case (Bollobás-Shelah) is already nontrivial: if all odd cycles have the same length $\\ell$, then $\\chi(G) \\leq 4$. The equality case $\\chi = 4$ occurs for $K_4$ (which has a unique odd cycle length 3). Both proofs are one-line applications of Gyárfás' bound followed by `omega` — demonstrating how the general theorem subsumes earlier results.",
+    "significance": "key",
+    "relatedConcepts": ["bipartite graphs", "Bollobás-Shelah theorem", "omega tactic"],
+    "prerequisites": ["gyarfas_upper_bound", "basic arithmetic"]
   },
   {
-    "id": "ann-e58-consecutive-odd",
+    "id": "ann-58-gao-huo-ma",
     "proofId": "erdos-58",
-    "range": { "startLine": 115, "endLine": 117 },
-    "type": "definition",
-    "title": "Consecutive Odd Lengths",
-    "content": "A set of **consecutive odd integers** {2m+1, 2m+3, ...}. Used in the Gao-Huo-Ma strengthening.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-e58-gao-huo-ma",
-    "proofId": "erdos-58",
-    "range": { "startLine": 119, "endLine": 128 },
-    "type": "axiom",
-    "title": "Gao-Huo-Ma Theorem (2021)",
-    "content": "**Strengthening**: If chi(G) >= 2k+3, then G has k+1 consecutive odd cycle lengths. High chromatic number forces very structured odd cycles.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e58-chi-5-corollary",
-    "proofId": "erdos-58",
-    "range": { "startLine": 132, "endLine": 139 },
+    "range": { "startLine": 114, "endLine": 129 },
     "type": "theorem",
-    "title": "chi >= 5 Corollary",
-    "content": "If chi(G) >= 5, then G has at least 2 distinct odd cycle lengths. Derived by contrapositive from Gyarfas' bound with k=1.",
-    "significance": "key"
+    "title": "Gao-Huo-Ma Strengthening (2021): Consecutive Odd Cycle Lengths",
+    "content": "**consecutiveOddLengths** defines $\\{2m+1, 2m+3, \\ldots, 2m+2c-1\\}$: a run of $c$ consecutive odd integers starting at $2m+1$.\n\n**gao_huo_ma**: $\\chi(G) \\geq 2k+3 \\Rightarrow \\exists m$ such that $\\{2m+1, 2m+3, \\ldots, 2m+2k+1\\} \\subseteq \\mathcal{C}_{\\text{odd}}(G)$. High chromatic number forces $k+1$ consecutive odd cycle lengths, not just $k+1$ arbitrary ones.",
+    "mathContext": "The Gao-Huo-Ma theorem is a qualitative strengthening: Gyárfás showed that $\\chi(G) \\geq 2k+3$ implies $|\\mathcal{C}_{\\text{odd}}| \\geq k+1$ (by contrapositive). Gao-Huo-Ma show these $k+1$ odd cycle lengths can be chosen to be consecutive. For example, $\\chi(G) \\geq 5$ implies $G$ has cycles of lengths $2m+1$ and $2m+3$ for some $m$. This is strictly stronger: having lengths $\\{3, 7\\}$ gives two distinct odd lengths but not consecutive ones. The proof uses a refined structural analysis of the interaction between odd cycles of different lengths.",
+    "significance": "key",
+    "relatedConcepts": ["consecutive integers", "cycle length gaps", "chromatic forcing"],
+    "prerequisites": ["gyarfas_upper_bound", "Set.ncard", "odd integer arithmetic"]
+  },
+  {
+    "id": "ann-58-corollaries",
+    "proofId": "erdos-58",
+    "range": { "startLine": 131, "endLine": 148 },
+    "type": "theorem",
+    "title": "Corollaries: χ ≥ 5 Forces Two Odd Lengths, Equality Implies Clique",
+    "content": "**chi_5_two_odd_lengths**: $\\chi(G) \\geq 5 \\Rightarrow |\\mathcal{C}_{\\text{odd}}| \\geq 2$. Proved by contrapositive: if $|\\mathcal{C}_{\\text{odd}}| \\leq 1$, Gyárfás gives $\\chi \\leq 4$, contradicting $\\chi \\geq 5$.\n\n**equality_implies_clique**: $|\\mathcal{C}_{\\text{odd}}| \\leq k \\wedge \\chi = 2k+2 \\Rightarrow K_{2k+2} \\subseteq G$. Direct application of `gyarfas_equality`'s forward direction.",
+    "mathContext": "These corollaries illustrate the power of Gyárfás' theorem. The first ($\\chi \\geq 5 \\Rightarrow$ two odd lengths) refines the classical fact that $\\chi \\geq 3 \\Rightarrow$ at least one odd cycle. Combined with Problem #57 (infinite $\\chi \\Rightarrow \\sum 1/a_i = \\infty$), we get a complete picture: as $\\chi$ grows, the odd cycle structure becomes progressively richer — from none ($\\chi \\leq 2$) to at least $\\lfloor(\\chi-2)/2\\rfloor$ distinct lengths (Gyárfás) to divergent reciprocal sum ($\\chi = \\infty$, Liu-Montgomery).",
+    "significance": "key",
+    "relatedConcepts": ["contrapositive reasoning", "clique detection", "chromatic number hierarchy"],
+    "prerequisites": ["gyarfas_upper_bound", "gyarfas_equality", "omega tactic"]
   }
 ]

--- a/src/data/proofs/erdos-58/meta.json
+++ b/src/data/proofs/erdos-58/meta.json
@@ -13,70 +13,95 @@
       "erdos",
       "graph-theory",
       "chromatic-number",
-      "cycles"
+      "cycles",
+      "combinatorics",
+      "solved"
     ],
     "badge": "wip",
     "sorries": 0,
     "erdosNumber": 58,
     "erdosUrl": "https://erdosproblems.com/58",
-    "erdosProblemStatus": "solved"
+    "erdosProblemStatus": "solved",
+    "references": [
+      "Bollobás-Erdős: original conjecture",
+      "Bollobás-Shelah: confirmed k=1 case (χ ≤ 4)",
+      "Gyárfás (1992): 'Graphs with k odd cycle lengths' — full solution",
+      "Gao-Huo-Ma (2021): 'A strengthening on odd cycles in graphs of given chromatic number'",
+      "https://erdosproblems.com/58"
+    ],
+    "leanFile": "Proofs/Erdos58Problem.lean"
   },
   "overview": {
-    "historicalContext": "Conjectured by Bollobás and Erdős, this problem quantifies the relationship between chromatic number and the diversity of odd cycle lengths. Bollobás and Shelah confirmed k=1. Gyárfás proved the full result in 1992, also showing that 2-connected graphs either contain K_{2k+2} or have a low-degree vertex. Gao-Huo-Ma (2021) strengthened this to show high chromatic number forces consecutive odd cycle lengths.",
-    "problemStatement": "If G is a graph which contains odd cycles of ≤ k different lengths, then χ(G) ≤ 2k+2, with equality if and only if G contains K_{2k+2}.",
-    "proofStrategy": "The formalization defines odd cycle lengths and chromatic number, then states Gyárfás' theorem as axioms. Special cases k=0 (bipartite) and k=1 (Bollobás-Shelah) are derived. The Gao-Huo-Ma strengthening about consecutive odd lengths is also formalized.",
+    "historicalContext": "Bollobás and Erdős conjectured that a graph with at most k distinct odd cycle lengths satisfies χ(G) ≤ 2k+2. The case k=0 is the classical bipartite characterization (χ ≤ 2 iff no odd cycles). Bollobás and Shelah proved the k=1 case: at most one odd cycle length implies χ ≤ 4. Gyárfás solved the general conjecture in 1992 using an inductive argument powered by a structural dichotomy for 2-connected graphs: either the graph contains K_{2k+2} or has a low-degree vertex (degree ≤ 2k). He also characterized equality: χ(G) = 2k+2 iff K_{2k+2} ⊆ G. In 2021, Gao, Huo, and Ma substantially strengthened the result: if χ(G) ≥ 2k+3, then G contains k+1 consecutive odd cycle lengths {2m+1, 2m+3, ..., 2m+2k+1} for some m. This is strictly stronger than just having k+1 distinct odd lengths. The problem is closely related to Problem #57 (Liu-Montgomery 2020), which handles the infinite chromatic number case: χ(G) = ∞ implies ∑ 1/aᵢ = ∞ over odd cycle lengths.",
+    "problemStatement": "If $G$ is a graph which contains odd cycles of $\\leq k$ different lengths, then $\\chi(G) \\leq 2k+2$, with equality if and only if $G$ contains $K_{2k+2}$.",
+    "proofStrategy": "The formalization axiomatizes the chromatic number with a specification (existence + minimality). Gyárfás' theorem is stated as three axioms: the upper bound χ ≤ 2k+2, the equality characterization via K_{2k+2}, and the structural dichotomy for 2-connected graphs. Four theorems are proved: the Bollobás-Shelah case (k=1), the bipartite case (k=0), a χ ≥ 5 corollary, and the equality-implies-clique direction — all by combining the axioms with omega. The Gao-Huo-Ma consecutive odd lengths strengthening is axiomatized.",
     "keyInsights": [
-      "k=0: No odd cycles implies bipartite (χ ≤ 2)",
-      "k=1: At most one odd cycle length implies χ ≤ 4 (Bollobás-Shelah)",
-      "Equality χ = 2k+2 characterizes graphs containing K_{2k+2}",
-      "2-connected case: either K_{2k+2} or low-degree vertex exists",
-      "Gao-Huo-Ma: High χ forces k+1 consecutive odd cycle lengths"
+      "The bound χ ≤ 2k+2 is tight: K_{2k+2} has exactly k odd cycle lengths {3, 5, ..., 2k+1} and χ(K_{2k+2}) = 2k+2",
+      "Gyárfás' proof engine: in 2-connected graphs with ≤ k odd cycle lengths and no K_{2k+2}, some vertex has degree ≤ 2k, enabling induction by vertex removal + greedy extension",
+      "The hierarchy of chromatic forcing: χ ≤ 2 → no odd cycles; χ ≤ 2k+2 → ≤ k odd lengths (Gyárfás); χ = ∞ → ∑ 1/aᵢ = ∞ (Problem #57, Liu-Montgomery)",
+      "Gao-Huo-Ma's consecutive odd lengths strengthening: χ ≥ 2k+3 forces not just k+1 distinct odd lengths but k+1 consecutive ones — revealing that high chromatic number constrains the gaps between odd cycle lengths",
+      "All four proved theorems are one- or two-line applications of the axioms with omega or direct rewriting, demonstrating clean modular proof architecture"
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement, History, and Imports",
+      "summary": "Documentation header with Bollobás-Erdős conjecture, Bollobás-Shelah k=1, Gyárfás 1992 solution, Gao-Huo-Ma 2021 strengthening, Mathlib import",
+      "startLine": 1,
+      "endLine": 25
+    },
+    {
       "id": "definitions",
-      "title": "Core Definitions",
-      "summary": "Cycle lengths, odd cycle lengths, chromatic number, cliques",
+      "title": "Core Definitions: Cycles, Coloring, Cliques",
+      "summary": "cycleLengths and oddCycleLengths via Walk.IsCycle, numOddCycleLengths via Set.ncard, IsColorable, axiomatized chromaticNumber with spec, ContainsClique via Finset",
       "startLine": 26,
       "endLine": 62
     },
     {
       "id": "main-results",
-      "title": "Gyárfás' Theorem (1992)",
-      "summary": "Upper bound, equality characterization, structural result",
+      "title": "Gyárfás' Theorem (1992): Upper Bound, Equality, Structure",
+      "summary": "gyarfas_upper_bound: k odd lengths → χ ≤ 2k+2. gyarfas_equality: χ = 2k+2 ↔ K_{2k+2} ⊆ G. gyarfas_structural: 2-connected → K_{2k+2} or low-degree vertex",
       "startLine": 64,
-      "endLine": 88
+      "endLine": 90
     },
     {
       "id": "special-cases",
-      "title": "Special Cases",
-      "summary": "Bollobás-Shelah (k=1) and bipartite case (k=0)",
-      "startLine": 90,
-      "endLine": 108
+      "title": "Special Cases: k=0 (Bipartite) and k=1 (Bollobás-Shelah)",
+      "summary": "bollobas_shelah: 1 odd length → χ ≤ 4 (proved by omega from gyarfas_upper_bound). no_odd_cycles_bipartite: 0 odd lengths → χ ≤ 2 (proved by omega)",
+      "startLine": 92,
+      "endLine": 112
     },
     {
       "id": "gao-huo-ma",
-      "title": "Gao-Huo-Ma Strengthening (2021)",
-      "summary": "High chromatic number forces consecutive odd cycle lengths",
-      "startLine": 110,
-      "endLine": 126
+      "title": "Gao-Huo-Ma Strengthening (2021): Consecutive Odd Lengths",
+      "summary": "consecutiveOddLengths definition. gao_huo_ma axiom: χ ≥ 2k+3 → k+1 consecutive odd cycle lengths exist. Strictly stronger than Gyárfás' count bound",
+      "startLine": 114,
+      "endLine": 129
     },
     {
       "id": "corollaries",
-      "title": "Corollaries",
-      "summary": "Derived results from the main theorems",
-      "startLine": 128,
-      "endLine": 145
+      "title": "Proved Corollaries",
+      "summary": "chi_5_two_odd_lengths: χ ≥ 5 → 2+ odd lengths (by contrapositive + omega). equality_implies_clique: forward direction of gyarfas_equality (by rewrite)",
+      "startLine": 131,
+      "endLine": 148
+    },
+    {
+      "id": "historical-notes",
+      "title": "Historical Notes and References",
+      "summary": "Progression from k=0 (bipartite) through k=1 (Bollobás-Shelah) to general k (Gyárfás), Gao-Huo-Ma consecutive strengthening, references",
+      "startLine": 150,
+      "endLine": 166
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #58, solved by Gyárfás in 1992. The result establishes a tight relationship between chromatic number and the number of distinct odd cycle lengths: χ(G) ≤ 2k+2 with equality characterizing the presence of K_{2k+2}.",
-    "implications": "This provides a powerful tool for bounding chromatic number by analyzing odd cycle structure. The Gao-Huo-Ma strengthening shows that high chromatic number forces very specific cycle structures.",
+    "summary": "Erdős Problem #58 was SOLVED by Gyárfás in 1992. The 166-line formalization axiomatizes the three components of Gyárfás' theorem (upper bound, equality characterization, structural dichotomy) and the Gao-Huo-Ma consecutive lengths strengthening (2021). Four theorems are proved from these axioms: the k=0 bipartite case, the k=1 Bollobás-Shelah case, a χ ≥ 5 corollary, and the equality-implies-clique direction. All proofs are clean one-line arguments using omega.",
+    "implications": "Combined with Problem #57 (Liu-Montgomery 2020), this gives a complete quantitative picture of how chromatic number controls odd cycle structure: from none (bipartite) through bounded counts (Gyárfás) to divergent reciprocal sums (infinite χ). The Gao-Huo-Ma strengthening suggests that the structure is even more rigid than counting alone reveals — high chromatic number forces consecutive odd cycle lengths.",
     "openQuestions": [
-      "Can the structural result be strengthened further?",
-      "What about even cycle lengths?",
-      "Connections to Problem #57 on harmonic sums of odd cycle lengths"
+      "Can the Gao-Huo-Ma consecutive lengths result be further strengthened to determine the starting point m?",
+      "What is the analogous theory for even cycle lengths vs chromatic number?",
+      "Connection to Problem #57: does the Gyárfás bound give quantitative information about the rate of divergence of ∑ 1/aᵢ?",
+      "Can the chromaticNumber axioms be replaced by Mathlib's SimpleGraph.chromaticNumber once it stabilizes?"
     ]
   }
 }

--- a/src/data/proofs/erdos-59/annotations.json
+++ b/src/data/proofs/erdos-59/annotations.json
@@ -1,146 +1,62 @@
 [
   {
-    "id": "ann-e59-contains-subgraph",
+    "id": "ann-59-defs",
     "proofId": "erdos-59",
-    "range": { "startLine": 34, "endLine": 36 },
+    "range": { "startLine": 32, "endLine": 65 },
     "type": "definition",
-    "title": "Contains Subgraph",
-    "content": "G **contains H as a subgraph** if there exists an injective function f: V → V such that every edge in H maps to an edge in G. This captures when H appears as a pattern within G.",
-    "significance": "key"
+    "title": "Core Definitions: Subgraph Containment, H-Free, Bipartiteness, Cycle Graphs",
+    "content": "**ContainsSubgraph**: $H \\subseteq G$ via injective homomorphism $f: V \\hookrightarrow V$ preserving adjacency.\n\n**IsFree**: $G$ is $H$-free if $\\neg(H \\subseteq G)$. The problem counts $H$-free labeled graphs on $n$ vertices.\n\n**IsBipartite**: $\\exists A, B$ partitioning $V$ with no edges within $A$ or $B$. Equivalent to no odd cycles.\n\n**cycleGraph** $C_n$ (axiomatized), with `odd_cycle_not_bipartite` and `even_cycle_bipartite`. **C6** $= C_6$ is the key counterexample; **K3** $= C_3$ satisfies the conjecture.",
+    "mathContext": "The subgraph containment relation used here is injection-based (not necessarily induced). For counting problems, this is the standard notion: $G$ is $H$-free if no subgraph of $G$ is isomorphic to $H$. The bipartite/non-bipartite dichotomy is fundamental: for non-bipartite $H$, the Turán number $\\text{ex}(n; H) = \\Theta(n^2)$ (by Turán's theorem for cliques, Bondy-Simonovits for general non-bipartite), so $2^{\\text{ex}(n;H)} = 2^{\\Theta(n^2)}$. For bipartite $H$, $\\text{ex}(n; H) = O(n^{2-\\varepsilon})$ (subquadratic), and the counting behavior is qualitatively different.",
+    "significance": "key",
+    "relatedConcepts": ["subgraph isomorphism", "H-free graphs", "bipartite graphs", "cycle graphs"],
+    "prerequisites": ["SimpleGraph", "Fintype", "injective functions"]
   },
   {
-    "id": "ann-e59-is-free",
+    "id": "ann-59-counting",
     "proofId": "erdos-59",
-    "range": { "startLine": 38, "endLine": 40 },
+    "range": { "startLine": 67, "endLine": 100 },
     "type": "definition",
-    "title": "H-Free Graph",
-    "content": "A graph G is **H-free** if it does not contain H as a subgraph. The central question is how many H-free graphs exist on n vertices.",
-    "significance": "key"
+    "title": "Turán Numbers, Free Graph Counts, and Asymptotic Bound Definitions",
+    "content": "**turanNumber** $\\text{ex}(n; k)$: maximum edges in an $n$-vertex graph avoiding all $k$-vertex forbidden subgraphs. Axiomatized.\n\n**countFreeGraphs** $(n, k)$: number of labeled $H$-free graphs on $n$ vertices where $|V(H)| = k$. Axiomatized.\n\n**HasOptimalBound** $f \\leq 2^{(1+o(1))g}$: $\\forall \\varepsilon > 0, \\exists N_0, \\forall n \\geq N_0: f(n) \\leq 2^{(1+\\varepsilon)g(n)}$.\n\n**ExceedsOptimalBound**: $\\exists c > 0$ with $f(n) \\geq 2^{(1+c)g(n)}$ for infinitely many $n$.\n\n**HasPolynomialBound** $f = 2^{O(g)}$: $\\exists C > 0, N_0$ with $f(n) \\leq 2^{C \\cdot g(n)}$ for $n \\geq N_0$.",
+    "mathContext": "The conjecture $|\\{H\\text{-free graphs on } n \\text{ vertices}\\}| \\leq 2^{(1+o(1))\\text{ex}(n;H)}$ says the count is essentially $2^{\\text{ex}(n;H)}$. The trivial upper bound is $2^{\\binom{n}{2}}$ (all labeled graphs). For non-bipartite $H$: $\\text{ex}(n; H) = \\Theta(n^2)$, so $2^{\\text{ex}} = 2^{\\Theta(n^2)}$ — the bound says most of the $2^{\\binom{n}{2}}$ graphs are $H$-free. For bipartite $H$: $\\text{ex}(n; H) = O(n^{2-\\varepsilon})$ is subquadratic, so the bound would say far fewer graphs are $H$-free — and this is where it fails.",
+    "significance": "critical",
+    "relatedConcepts": ["Turán number", "graph enumeration", "asymptotic analysis", "o(1) notation"],
+    "prerequisites": ["extremal graph theory", "labeled graph counting", "real analysis"]
   },
   {
-    "id": "ann-e59-bipartite",
+    "id": "ann-59-results",
     "proofId": "erdos-59",
-    "range": { "startLine": 42, "endLine": 46 },
-    "type": "definition",
-    "title": "Bipartite Graph",
-    "content": "A graph is **bipartite** if its vertices can be partitioned into two independent sets A and B with no edges within either set. Equivalently, the graph has no odd cycles.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e59-cycle-graph",
-    "proofId": "erdos-59",
-    "range": { "startLine": 50, "endLine": 51 },
-    "type": "definition",
-    "title": "Cycle Graph",
-    "content": "The **cycle graph C_n** has n vertices arranged in a cycle. Odd cycles are non-bipartite; even cycles are bipartite. This distinction is crucial for the problem.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-e59-c6",
-    "proofId": "erdos-59",
-    "range": { "startLine": 61, "endLine": 62 },
-    "type": "definition",
-    "title": "The 6-Cycle C_6",
-    "content": "**C_6** is the 6-cycle, the key counterexample. Being an even cycle, it is bipartite, which explains why the conjecture fails for it.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e59-turan-number",
-    "proofId": "erdos-59",
-    "range": { "startLine": 75, "endLine": 77 },
-    "type": "definition",
-    "title": "Turán Number",
-    "content": "The **Turán number ex(n; H)** is the maximum number of edges in an n-vertex H-free graph. It measures how dense a graph can be while still avoiding H.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e59-count-free",
-    "proofId": "erdos-59",
-    "range": { "startLine": 79, "endLine": 81 },
-    "type": "definition",
-    "title": "Count of Free Graphs",
-    "content": "**countFreeGraphs(n, k)** counts the number of labeled H-free graphs on n vertices where H has k vertices. The conjecture bounds this in terms of 2^{ex(n;H)}.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e59-optimal-bound",
-    "proofId": "erdos-59",
-    "range": { "startLine": 85, "endLine": 89 },
-    "type": "definition",
-    "title": "HasOptimalBound",
-    "content": "f has **optimal bound** 2^{(1+o(1))g(n)} means for every ε > 0, we have f(n) ≤ 2^{(1+ε)g(n)} for all sufficiently large n. This captures the conjectured bound.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e59-exceeds-bound",
-    "proofId": "erdos-59",
-    "range": { "startLine": 91, "endLine": 93 },
-    "type": "definition",
-    "title": "ExceedsOptimalBound",
-    "content": "f **exceeds the optimal bound** if there exists c > 0 such that f(n) ≥ 2^{(1+c)g(n)} for infinitely many n. This is how counterexamples are formalized.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e59-efr-theorem",
-    "proofId": "erdos-59",
-    "range": { "startLine": 102, "endLine": 110 },
+    "range": { "startLine": 102, "endLine": 131 },
     "type": "theorem",
-    "title": "Erdős-Frankl-Rödl Theorem (1986)",
-    "content": "**Non-Bipartite Case**: For non-bipartite H, the number of H-free graphs on n vertices is at most 2^{(1+o(1))ex(n;H)}. The conjecture holds for this case.",
-    "significance": "critical"
+    "title": "Main Results: Erdős-Frankl-Rödl (1986) and Morris-Saxton Counterexample (2016)",
+    "content": "**erdos_frankl_rodl_nonbipartite**: For non-bipartite $H$, $|\\{H\\text{-free}\\}| \\leq 2^{(1+o(1))\\text{ex}(n;H)}$. The conjecture holds for the non-bipartite case.\n\n**morris_saxton_c6_counterexample**: $\\exists c > 0$ with $|\\{C_6\\text{-free}\\}| \\geq 2^{(1+c)\\text{ex}(n;C_6)}$ for infinitely many $n$. This DISPROVES the conjecture.\n\n**morris_saxton_conjecture** (OPEN): The weaker bound $2^{O(\\text{ex}(n;H))}$ holds for all $H$. Formalized as `HasPolynomialBound` for all $k$.",
+    "mathContext": "Erdős-Frankl-Rödl (1986): their proof uses the Szemerédi regularity lemma. For non-bipartite $H$, the Turán number $\\text{ex}(n; H) = (1 - 1/(\\chi(H)-1) + o(1))\\binom{n}{2}$, so the Turán density is positive. The regularity lemma shows that most $H$-free graphs look like the Turán graph, giving the $2^{(1+o(1))\\text{ex}}$ bound. Morris-Saxton (2016): for $C_6$, $\\text{ex}(n; C_6) = \\Theta(n^{4/3})$ (Kővári-Sós-Turán). They construct $C_6$-free graphs using algebraic methods (incidence geometry over finite fields), showing the count exceeds $2^{(1+c)n^{4/3}}$. The excess comes from the rich structure of $C_6$-free bipartite graphs built from projective planes.",
+    "significance": "critical",
+    "relatedConcepts": ["Szemerédi regularity lemma", "graph counting", "algebraic constructions", "projective planes"],
+    "prerequisites": ["regularity lemma", "Turán densities", "Kővári-Sós-Turán bound"]
   },
   {
-    "id": "ann-e59-morris-saxton",
+    "id": "ann-59-resolution",
     "proofId": "erdos-59",
-    "range": { "startLine": 112, "endLine": 120 },
+    "range": { "startLine": 132, "endLine": 172 },
     "type": "theorem",
-    "title": "Morris-Saxton Counterexample (2016)",
-    "content": "**C_6 Counterexample**: For the 6-cycle, there are at least 2^{(1+c)ex(n;C_6)} C_6-free graphs for infinitely many n and some c > 0. This DISPROVES the original conjecture.",
-    "significance": "critical"
+    "title": "Problem Resolution and Bipartiteness of C_6",
+    "content": "**erdos_59_disproved** (1 sorry): $\\neg\\forall k, \\text{HasOptimalBound}(\\text{countFreeGraphs}(\\cdot, k), \\text{turanNumber}(\\cdot, k))$. Uses $k = 6$ and `morris_saxton_c6_counterexample` to derive a contradiction with the optimal bound. The sorry is in extracting a specific counterexample $n > N_0$ from the infinite set.\n\n**c6_is_bipartite**: $C_6$ is bipartite (even cycle). **k3_not_bipartite**: $K_3 = C_3$ is not bipartite (odd cycle).",
+    "mathContext": "The proof of `erdos_59_disproved` follows the standard contradiction pattern: assume the conjecture holds for all $k$, specialize to $k = 6$, then the optimal bound gives $|\\{C_6\\text{-free}\\}| \\leq 2^{(1+\\varepsilon)\\text{ex}(n;C_6)}$ for large $n$ (any $\\varepsilon > 0$), while Morris-Saxton gives $|\\{C_6\\text{-free}\\}| \\geq 2^{(1+c)\\text{ex}(n;C_6)}$ for infinitely many $n$. Choosing $\\varepsilon = c/2 < c$ yields the contradiction. The sorry is a technical gap: extracting an element from `Set.Infinite` that is also $\\geq N_0$.",
+    "significance": "critical",
+    "relatedConcepts": ["proof by contradiction", "Set.Infinite", "bipartite vs non-bipartite dichotomy"],
+    "prerequisites": ["push_neg", "Set.Infinite.nonempty", "real arithmetic"]
   },
   {
-    "id": "ann-e59-ms-conjecture",
+    "id": "ann-59-turan-bounds",
     "proofId": "erdos-59",
-    "range": { "startLine": 122, "endLine": 128 },
-    "type": "definition",
-    "title": "Morris-Saxton Conjecture",
-    "content": "**Open Conjecture**: The weaker bound 2^{O(ex(n;G))} may still hold for all G. This would mean there exists a constant C such that the count is at most 2^{C·ex(n;G)}.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e59-disproved",
-    "proofId": "erdos-59",
-    "range": { "startLine": 132, "endLine": 154 },
+    "range": { "startLine": 174, "endLine": 200 },
     "type": "theorem",
-    "title": "Erdős Problem 59: DISPROVED",
-    "content": "**Main Result**: The conjecture is FALSE in general. True for non-bipartite H (Erdős-Frankl-Rödl 1986), but false for C_6 (Morris-Saxton 2016). The problem is completely resolved.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e59-c6-bipartite",
-    "proofId": "erdos-59",
-    "range": { "startLine": 156, "endLine": 162 },
-    "type": "theorem",
-    "title": "C_6 is Bipartite",
-    "content": "The counterexample C_6 is bipartite (an even cycle). This is why the Erdős-Frankl-Rödl theorem doesn't apply to it.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-e59-turan-theorem",
-    "proofId": "erdos-59",
-    "range": { "startLine": 174, "endLine": 180 },
-    "type": "theorem",
-    "title": "Turán's Theorem (1941)",
-    "content": "**Classical Result**: ex(n; K_{r+1}) = (1 - 1/r) · n²/2 asymptotically. The extremal graph is the Turán graph T(n,r), a balanced complete r-partite graph.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-e59-kst",
-    "proofId": "erdos-59",
-    "range": { "startLine": 182, "endLine": 187 },
-    "type": "theorem",
-    "title": "Kővári-Sós-Turán Theorem (1954)",
-    "content": "**Even Cycle Bound**: For C_{2k}, we have ex(n; C_{2k}) = O(n^{1+1/k}). This subquadratic growth is characteristic of bipartite forbidden subgraphs.",
-    "significance": "supporting"
+    "title": "Classical Turán Bounds and Corollaries",
+    "content": "**turan_theorem**: $\\text{ex}(n; K_{r+1}) = (1 - 1/r)n^2/2 + O(n)$. The Turán graph $T(n,r)$ is the unique extremal graph.\n\n**kovari_sos_turan**: $\\text{ex}(n; C_{2k}) = O(n^{1+1/k})$ for $k \\geq 2$. This subquadratic bound is what makes the bipartite case qualitatively different.\n\n**non_bipartite_satisfies_conjecture** / **triangle_free_optimal**: Direct applications of `erdos_frankl_rodl_nonbipartite` confirming the conjecture for non-bipartite $H$ and specifically for $K_3$.",
+    "mathContext": "For $C_6$: $k = 3$ in KST gives $\\text{ex}(n; C_6) = O(n^{4/3})$. The matching lower bound $\\text{ex}(n; C_6) = \\Omega(n^{4/3})$ comes from incidence structures: the Levi graph of a projective plane $\\text{PG}(2, q)$ is $C_6$-free with $\\Theta(q^{4/3})$ edges (when $n = 2(q^2 + q + 1)$). The same algebraic structure that makes $\\text{ex}(n; C_6)$ large also creates many $C_6$-free graphs — this is the mechanism behind Morris-Saxton's counterexample. For non-bipartite $H$: $\\text{ex}(n; H) = \\Theta(n^2)$ (positive Turán density), so there are $\\sim 2^{\\Theta(n^2)}$ $H$-free graphs — essentially the same order as the Turán graph's neighborhoods.",
+    "significance": "key",
+    "relatedConcepts": ["Turán's theorem", "Kővári-Sós-Turán", "Turán graph", "projective planes"],
+    "prerequisites": ["extremal graph theory", "asymptotic notation", "complete multipartite graphs"]
   }
 ]

--- a/src/data/proofs/erdos-59/meta.json
+++ b/src/data/proofs/erdos-59/meta.json
@@ -13,84 +13,109 @@
       "erdos",
       "extremal-graph-theory",
       "turan-numbers",
-      "graph-counting"
+      "graph-counting",
+      "combinatorics",
+      "solved"
     ],
     "badge": "wip",
     "sorries": 1,
     "erdosNumber": 59,
     "erdosUrl": "https://erdosproblems.com/59",
-    "erdosProblemStatus": "solved"
+    "erdosProblemStatus": "solved",
+    "references": [
+      "Erdős-Frankl-Rödl (1986): 'The asymptotic number of graphs not containing a fixed subgraph'",
+      "Morris-Saxton (2016): 'The number of C_{2l}-free graphs'",
+      "Kővári-Sós-Turán (1954): bipartite Turán bounds",
+      "Turán (1941): extremal number for complete graphs",
+      "https://erdosproblems.com/59"
+    ],
+    "leanFile": "Proofs/Erdos59Problem.lean"
   },
   "overview": {
-    "historicalContext": "This problem connects Turán-type extremal graph theory with graph enumeration. The question asks whether forbidding a subgraph H limits the number of labeled graphs to roughly 2^{ex(n;H)}. Erdős, Frankl, and Rödl (1986) proved this for non-bipartite H. Morris and Saxton (2016) found a striking counterexample: for the 6-cycle C_6, there are superpolynomially more C_6-free graphs than the conjecture predicts.",
-    "problemStatement": "Is it true that the number of graphs on n vertices which do not contain G is at most 2^{(1+o(1))ex(n;G)}?",
-    "proofStrategy": "The formalization defines subgraph containment, bipartiteness, and asymptotic bounds (HasOptimalBound, ExceedsOptimalBound). The Erdős-Frankl-Rödl theorem is stated as an axiom for non-bipartite graphs. The Morris-Saxton counterexample is axiomatized showing C_6 violates the bound. The main theorem derives that the conjecture is false in general.",
+    "historicalContext": "Erdős conjectured that the number of labeled H-free graphs on n vertices is at most 2^{(1+o(1))ex(n;H)}, where ex(n;H) is the Turán number. This connects extremal graph theory (how dense can an H-free graph be?) with graph enumeration (how many H-free graphs exist?). Erdős, Frankl, and Rödl proved in 1986 that the bound holds for all non-bipartite H, using the Szemerédi regularity lemma to show that most H-free graphs resemble the Turán graph. The bipartite case remained open until Morris and Saxton (2016) found a striking counterexample: the 6-cycle C_6. Using algebraic constructions related to projective planes, they showed there are superpolynomially more C_6-free graphs than the conjecture predicts. Specifically, for C_6 with ex(n;C_6) = Θ(n^{4/3}), the count exceeds 2^{(1+c)n^{4/3}}. This disproved the conjecture but left open the weaker question (Morris-Saxton conjecture): does 2^{O(ex(n;H))} hold for all H? The dichotomy between bipartite and non-bipartite forbidden subgraphs is fundamental and persists across extremal combinatorics.",
+    "problemStatement": "Is it true that the number of graphs on $n$ vertices which do not contain $G$ is at most $2^{(1+o(1))\\text{ex}(n;G)}$?",
+    "proofStrategy": "The formalization defines subgraph containment, H-free property, and bipartiteness. Cycle graphs are axiomatized with bipartiteness properties. Turán numbers and free graph counts are axiomatized since they involve extremal combinatorial computation. Three asymptotic bound predicates (HasOptimalBound, ExceedsOptimalBound, HasPolynomialBound) capture the conjectured bound, counterexample, and open conjecture. The Erdős-Frankl-Rödl theorem and Morris-Saxton counterexample are axioms. The main theorem `erdos_59_disproved` has 1 sorry (extracting a large element from Set.Infinite). Classical Turán bounds and two corollaries are also included.",
     "keyInsights": [
-      "Non-bipartite case: Erdős-Frankl-Rödl (1986) proved the bound holds",
-      "Bipartite counterexample: C_6 has more free graphs than predicted (Morris-Saxton 2016)",
-      "Open: Whether the weaker bound 2^{O(ex(n;G))} holds for all G",
-      "Turán numbers measure maximum edges avoiding a subgraph",
-      "The gap between bipartite and non-bipartite cases is fundamental"
+      "The bipartite/non-bipartite dichotomy is fundamental: for non-bipartite H, the regularity lemma forces most H-free graphs to look like the Turán graph, giving 2^{(1+o(1))ex}. Bipartite H allows more diverse structures",
+      "C_6 is the simplest counterexample because ex(n;C_6) = Θ(n^{4/3}) comes from projective plane constructions, and these algebraic structures generate many distinct C_6-free graphs beyond what the Turán number alone predicts",
+      "The gap between 2^{(1+o(1))ex} and 2^{O(ex)} is the key open question: the Morris-Saxton conjecture posits 2^{O(ex)} always holds, but 2^{(1+o(1))ex} fails for bipartite H",
+      "Turán's theorem gives ex(n;K_{r+1}) exactly, while Kővári-Sós-Turán gives ex(n;C_{2k}) = O(n^{1+1/k}) — the subquadratic growth for bipartite graphs is what makes their counting behavior different",
+      "The sorry in erdos_59_disproved is a technical gap (extracting n ≥ N₀ from Set.Infinite), not a mathematical one — the argument is complete modulo this Lean extraction step"
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement, History, and Imports",
+      "summary": "Documentation with EFR 1986 for non-bipartite, Morris-Saxton 2016 counterexample for C_6, open question on weaker 2^{O(ex)} bound, Mathlib import",
+      "startLine": 1,
+      "endLine": 30
+    },
+    {
       "id": "definitions",
-      "title": "Core Definitions",
-      "summary": "Subgraph containment, H-free graphs, bipartiteness",
+      "title": "Core Definitions: Subgraph Containment, H-Free, Bipartite",
+      "summary": "ContainsSubgraph via injective adjacency-preserving map, IsFree as negation, IsBipartite via vertex partition with independent sets",
       "startLine": 32,
       "endLine": 46
     },
     {
       "id": "constructions",
-      "title": "Graph Constructions",
-      "summary": "Cycle graphs C_n, C_6, K_3 with bipartiteness properties",
+      "title": "Axiomatized Graph Constructions",
+      "summary": "cycleGraph axiom with odd_cycle_not_bipartite and even_cycle_bipartite. C6 = cycleGraph 6, K3 = cycleGraph 3",
       "startLine": 48,
       "endLine": 65
     },
     {
       "id": "counting",
-      "title": "Counting Functions",
-      "summary": "Turán number and free graph count (axiomatized)",
+      "title": "Counting Functions: Turán Number and Free Graph Count",
+      "summary": "turanNumber and countFreeGraphs axiomatized (extremal computation intractable to formalize directly)",
       "startLine": 67,
-      "endLine": 81
+      "endLine": 83
     },
     {
       "id": "asymptotic",
-      "title": "Asymptotic Bounds",
-      "summary": "HasOptimalBound, ExceedsOptimalBound, HasPolynomialBound",
-      "startLine": 83,
-      "endLine": 98
+      "title": "Asymptotic Bound Definitions",
+      "summary": "HasOptimalBound (2^{(1+o(1))g}), ExceedsOptimalBound (2^{(1+c)g} infinitely often), HasPolynomialBound (2^{O(g)})",
+      "startLine": 85,
+      "endLine": 100
     },
     {
       "id": "main-results",
-      "title": "Main Results",
-      "summary": "Erdős-Frankl-Rödl theorem and Morris-Saxton counterexample",
-      "startLine": 100,
-      "endLine": 128
+      "title": "Main Results: EFR Theorem and Morris-Saxton Counterexample",
+      "summary": "erdos_frankl_rodl_nonbipartite axiom: non-bipartite H satisfies HasOptimalBound. morris_saxton_c6_counterexample axiom: C_6 exceeds it. morris_saxton_conjecture: open 2^{O(ex)} bound",
+      "startLine": 102,
+      "endLine": 131
     },
     {
       "id": "resolution",
-      "title": "Problem Resolution",
-      "summary": "Erdős 59 disproved; special cases for C_6 and K_3",
-      "startLine": 130,
-      "endLine": 170
+      "title": "Problem Resolution: DISPROVED + Bipartiteness Results",
+      "summary": "erdos_59_disproved (1 sorry): negation of universal optimal bound via k=6. c6_is_bipartite and k3_not_bipartite proved from cycle axioms",
+      "startLine": 132,
+      "endLine": 172
     },
     {
       "id": "turan-bounds",
-      "title": "Turán Number Bounds",
-      "summary": "Turán's theorem and Kővári-Sós-Turán theorem",
-      "startLine": 172,
-      "endLine": 187
+      "title": "Classical Turán Bounds and Corollaries",
+      "summary": "turan_theorem: ex(n;K_{r+1}) = (1-1/r)n²/2 + O(n). kovari_sos_turan: ex(n;C_{2k}) = O(n^{1+1/k}). Corollaries: non-bipartite and triangle-free satisfy conjecture",
+      "startLine": 174,
+      "endLine": 200
+    },
+    {
+      "id": "summary",
+      "title": "Summary and References",
+      "summary": "Problem status DISPROVED. True for non-bipartite (EFR 1986), false for C_6 (Morris-Saxton 2016). Open: weaker 2^{O(ex)} bound. References",
+      "startLine": 202,
+      "endLine": 223
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #59, which asks whether the count of H-free graphs is bounded by 2^{(1+o(1))ex(n;H)}. The problem is DISPROVED: Morris and Saxton (2016) showed the 6-cycle C_6 violates this bound, while Erdős-Frankl-Rödl (1986) proved it holds for non-bipartite graphs.",
-    "implications": "The resolution reveals a fundamental dichotomy between bipartite and non-bipartite forbidden subgraphs. For non-bipartite H, the structure is rigid enough that Turán numbers essentially determine the count. Bipartite forbidden subgraphs allow more flexibility, leading to superpolynomially more graphs.",
+    "summary": "Erdős Problem #59 is DISPROVED. The 223-line formalization captures the complete resolution: the Erdős-Frankl-Rödl theorem (1986) proves the bound for non-bipartite H, while the Morris-Saxton counterexample (2016) disproves it for C_6. The main theorem has 1 sorry (a technical extraction from Set.Infinite). Classical Turán bounds, the Morris-Saxton weaker conjecture, and bipartiteness results are also formalized.",
+    "implications": "The resolution reveals a fundamental structural dichotomy in extremal graph theory: for non-bipartite forbidden subgraphs, the Turán number essentially determines the count of free graphs (via the regularity lemma). For bipartite forbidden subgraphs, algebraic structures (projective planes) create additional diversity that the Turán number alone cannot capture. This parallels the KST/Turán divide throughout extremal combinatorics.",
     "openQuestions": [
-      "Does the weaker bound 2^{O(ex(n;G))} hold for all G? (Morris-Saxton Conjecture)",
-      "What is the exact growth rate for C_{2k}-free graphs for k > 3?",
-      "Can we characterize which bipartite graphs satisfy the original bound?"
+      "Does the weaker bound 2^{O(ex(n;G))} hold for all G? (Morris-Saxton Conjecture, OPEN)",
+      "For which bipartite graphs H does the original 2^{(1+o(1))ex} bound hold?",
+      "What is the exact counting exponent for C_{2k}-free graphs for k > 3?",
+      "Can the sorry in erdos_59_disproved be resolved via Set.Infinite.exists_gt or similar Mathlib lemma?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- **erdos-230** (Ultraflat Polynomials): Enriched 10 annotations with mathContext, expanded historicalContext to 900+ chars, added 3 new sections
- **erdos-546** (Ramsey Numbers and Edge Count): Consolidated 14→9 annotations with full enrichment, 11 sections covering Sudakov's theorem and multi-color generalization
- **erdos-55** (Ramsey r-Complete Sets): Consolidated 11→5 substantive annotations, expanded historicalContext with Burr-Erdős and CFP timeline
- **erdos-551** (Cycle vs Clique Ramsey): Consolidated 15→6 annotations, 13 sections covering Bondy-Erdős→Nikiforov→KLS progression
- **erdos-552** (R(C₄, Sₙ) and Prime Gaps): Consolidated 18→8 annotations, 10 sections covering Parsons/BEFRS bounds, projective plane constructions, Cramér's conjecture connection

## Test plan
- [ ] Verify JSON validity of all enriched files
- [ ] Check gallery renders correctly with enriched data
- [ ] Validate annotation line ranges match Lean proof structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)