### PR TITLE
fix(erdos-706): enricher type cast safety

### DIFF
--- a/src/data/proofs/erdos-706/index.ts
+++ b/src/data/proofs/erdos-706/index.ts
@@ -3,7 +3,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string; title: string; slug: string; description: string
   meta: ProofMeta; sections: ProofSection[]
   overview?: ProofOverview; conclusion?: ProofConclusion


### PR DESCRIPTION
## Summary
- Fix TypeScript build error in erdos-706 enrichment: use `as unknown as` instead of `as` for type cast
- Same enricher type safety pattern as previous fixes

## Test plan
- [x] Build passes with this fix