### PR TITLE
Research: erdos-1057 - Survey and knowledge update

### DIFF
--- a/src/data/research/problems/erdos-1057.json
+++ b/src/data/research/problems/erdos-1057.json
@@ -1,0 +1,52 @@
+{
+  "id": "erdos-1057",
+  "name": "Counting Carmichael Numbers",
+  "problem": "Let C(x) count Carmichael numbers in [1,x]. Is C(x) = x^{1-o(1)}?",
+  "status": "open",
+  "erdosNumber": 1057,
+  "source": "https://erdosproblems.com/1057",
+  "tags": ["number-theory", "carmichael-numbers", "pseudoprimes", "counting-functions", "open-problem"],
+  "proofFile": "proofs/Proofs/Erdos1057Problem.lean",
+  "knowledge": {
+    "score": 9,
+    "tier": "RICH",
+    "insights": [
+      "File has 0 sorries - all theorems fully proved",
+      "6 axioms for deep published results: korselt_theorem, erdos_upper_bound, lichtman_lower_bound, harman_lower_bound, infinitely_many_carmichaels, agp_lower_bound",
+      "Carmichael numbers verified via Korselt criterion: 561, 1105, 1729, 2465, 2821, 6601, 8911 (first 7)",
+      "Key structural theorem: Carmichael numbers are odd (carmichael_odd) - fully proved",
+      "Key structural theorem: korselt_two_primes_impossible - product of two distinct primes cannot be Carmichael",
+      "Key structural theorem: carmichael_at_least_3_primes - at least 3 prime factors required",
+      "Key structural theorem: carmichael_ge_561 - 561 is the smallest, proved via native_decide exhaustive check",
+      "Counting function C(x) defined, proved monotone, C_unbounded proved from AGP infinitude axiom",
+      "C(560) = 0, C(561) >= 1, C(2821) >= 5, C(8911) >= 7 all proved",
+      "Decidable Carmichael checker isCarmichaelCheck implemented and used for exhaustive verification below 561",
+      "Divisibility structure fully explored: double_congruence, prime_factor_lt, prime_multiplicity_one",
+      "Lower bound comparison chain: AGP 2/7 < Harman 0.33336704 < Lichtman 0.3389 < 1, all proved",
+      "Korselt's theorem (axiom) is the most tractable axiom - could potentially be proved from Mathlib's ZMod.pow_card and CRT"
+    ],
+    "builtItems": [
+      "satisfiesKorselt definition (Korselt criterion)",
+      "IsCarmichael definition (composite + Korselt)",
+      "satisfiesFermat definition (Fermat characterization)",
+      "C counting function (noncomputable, via Finset.filter)",
+      "isCarmichaelCheck decidable Bool checker",
+      "7 verified Carmichael numbers: 561, 1105, 1729, 2465, 2821, 6601, 8911",
+      "carmichael_odd - odd proof",
+      "korselt_two_primes_impossible - semiprime impossibility",
+      "carmichael_not_semiprime - not product of 2 primes",
+      "carmichael_at_least_3_primes - >= 3 prime factors",
+      "carmichael_ge_561 - smallest is 561",
+      "C_mono, C_zero, C_one, C_below_561, C_561_pos, C_2821_ge_5, C_8911_ge_7",
+      "C_unbounded - counting function grows without bound",
+      "erdos1057Conjecture and erdos1057ConjectureAlt - formal conjecture statements",
+      "pomeranceConjecture - Pomerance's heuristic prediction"
+    ],
+    "nextSteps": [
+      "POTENTIAL: Prove korselt_theorem from Mathlib (ZMod.pow_card + CRT) - would eliminate 1 axiom",
+      "POTENTIAL: Add Carmichael numbers with 4+ prime factors (e.g., 41041 = 7 x 11 x 13 x 41)",
+      "The other 5 axioms (erdos_upper_bound, lichtman_lower_bound, harman_lower_bound, infinitely_many_carmichaels, agp_lower_bound) are all deep published results not provable from Mathlib"
+    ],
+    "progressSummary": "COMPLETED: Comprehensive formalization with 0 sorries. All structural properties proved (oddness, >= 3 prime factors, smallest is 561). First 7 Carmichael numbers verified. Counting function defined with monotonicity and unboundedness. Only deep paper axioms remain."
+  }
+}


### PR DESCRIPTION
## Summary
- Survey and knowledge documentation for Erdős Problem #1057 (Counting Carmichael Numbers)
- Created problem JSON with comprehensive knowledge (score 9/10, RICH tier)

## Progress
- **Build verified**: 0 sorries, all ~45 theorems compile cleanly in Docker
- **6 axioms documented**: All are deep published results (Erdős 1956, AGP 1994, Harman 2008, Lichtman 2022)
- **Key proved results**: Carmichael numbers are odd, have >= 3 prime factors, smallest is 561
- **First 7 Carmichael numbers verified**: 561, 1105, 1729, 2465, 2821, 6601, 8911
- **Counting function**: C(x) defined, monotone, unbounded, with specific lower bounds

## Findings
- File is in excellent shape with 0 sorries
- Most tractable remaining axiom: korselt_theorem could potentially be proved from Mathlib ZMod.pow_card and CRT
- Other 5 axioms are deep paper results not provable from Mathlib

## Status
**Outcome**: surveyed
**Next Steps**: Potential proof of Korselt theorem from Mathlib

Generated by researcher-1