### PR TITLE
fix: use 'as unknown as' cast for erdos-715 and erdos-749 index.ts

### DIFF
--- a/src/data/proofs/erdos-715/index.ts
+++ b/src/data/proofs/erdos-715/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
 // Type assertion for JSON import
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/erdos-749/index.ts
+++ b/src/data/proofs/erdos-749/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string; title: string; slug: string; description: string
   meta: ProofMeta; sections: ProofSection[]
   overview?: ProofOverview; conclusion?: ProofConclusion


### PR DESCRIPTION
## Summary
- Fix TS2352 build errors in `erdos-715/index.ts` and `erdos-749/index.ts`
- Add intermediate `unknown` cast for JSON meta imports (same pattern as #2661)

## Test plan
- [x] `pnpm build` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)