### PR TITLE
Research: cauchy-schwarz-oq-02 - Gallery entry for integral inequality

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "csi-imports",
+    "proofId": "cauchy-schwarz-integral",
+    "type": "concept",
+    "range": { "startLine": 1, "endLine": 4 },
+    "title": "Library Imports",
+    "content": "Imports Mathlib's L2 space (`MeasureTheory.Function.L2Space`), Bochner integration (`MeasureTheory.Integral.Bochner.Basic`), inner product space theory, and general tactics.",
+    "mathContext": "The formalization works in `Lp \\mathbb{R} 2 \\mu`, Mathlib's type for $L^2$ functions with respect to measure $\\mu$. The key imports provide: (1) the `InnerProductSpace` instance on $L^2$, (2) the Bochner integral $\\int f \\, d\\mu$, and (3) `L2.inner_def` connecting abstract inner products to integrals.",
+    "significance": "supporting",
+    "relatedConcepts": ["L2 space", "Bochner integral", "inner product spaces"],
+    "prerequisites": ["measure theory basics", "inner product spaces"]
+  },
+  {
+    "id": "csi-l2-ips",
+    "proofId": "cauchy-schwarz-integral",
+    "type": "concept",
+    "range": { "startLine": 44, "endLine": 46 },
+    "title": "L2 is an Inner Product Space",
+    "content": "Mathlib provides `InnerProductSpace \\mathbb{R} (Lp \\mathbb{R} 2 \\mu)` as a typeclass instance. This is established via `inferInstance`, meaning Lean's typeclass system automatically finds the proof.",
+    "mathContext": "The inner product on $L^2(\\mu)$ is defined as $\\langle f, g \\rangle = \\int f \\cdot g \\, d\\mu$, and the norm as $\\|f\\| = \\sqrt{\\int f^2 \\, d\\mu}$. Mathlib constructs this instance by showing completeness, definiteness, and the parallelogram law.",
+    "significance": "key",
+    "relatedConcepts": ["InnerProductSpace", "Lp space", "typeclass inference"],
+    "prerequisites": ["measure theory", "inner product space axioms"]
+  },
+  {
+    "id": "csi-abstract-cs",
+    "proofId": "cauchy-schwarz-integral",
+    "type": "theorem",
+    "range": { "startLine": 48, "endLine": 50 },
+    "title": "Abstract L2 Cauchy-Schwarz",
+    "content": "For $L^2$ functions $f, g$: $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$. This is the abstract Cauchy-Schwarz applied to the $L^2$ inner product space, proved by `abs_real_inner_le_norm`.",
+    "mathContext": "cauchy_schwarz_L2$(f, g)$: $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$ where $f, g \\in L^2(\\mu)$. At this stage, the statement uses abstract inner product notation; the bridge theorem below connects it to integrals.",
+    "significance": "key",
+    "relatedConcepts": ["abs_real_inner_le_norm", "L2 norm", "inner product"],
+    "prerequisites": ["InnerProductSpace instance on L2"]
+  },
+  {
+    "id": "csi-squared",
+    "proofId": "cauchy-schwarz-integral",
+    "type": "theorem",
+    "range": { "startLine": 53, "endLine": 60 },
+    "title": "Squared Form on L2",
+    "content": "The squared form: $\\langle f, g \\rangle^2 \\leq \\|f\\|^2 \\cdot \\|g\\|^2$. Derived from the absolute value form using `sq_le_sq'` and `sq_abs`.",
+    "mathContext": "cauchy_schwarz_L2_sq$(f, g)$: chains $\\langle f,g\\rangle^2 \\leq |\\langle f,g\\rangle|^2 \\leq (\\|f\\|\\|g\\|)^2 = \\|f\\|^2\\|g\\|^2$. The first inequality uses `sq_le_sq'`, the second is `abs_real_inner_le_norm` squared, and the last step is algebraic (`ring`).",
+    "significance": "supporting",
+    "relatedConcepts": ["sq_le_sq'", "sq_abs", "squared inequality"],
+    "prerequisites": ["cauchy_schwarz_L2"]
+  },
+  {
+    "id": "csi-bridge",
+    "proofId": "cauchy-schwarz-integral",
+    "type": "theorem",
+    "range": { "startLine": 68, "endLine": 73 },
+    "title": "Bridge: L2 Inner Product = Integral",
+    "content": "The critical bridge theorem: $\\langle f, g \\rangle = \\int f(a) \\cdot g(a) \\, d\\mu(a)$. This connects the abstract inner product on $L^2$ to the concrete Bochner integral.",
+    "mathContext": "L2_inner_eq_integral$(f, g)$: uses `L2.inner_def` which gives $\\langle f, g \\rangle = \\int \\text{inner}(f(a), g(a)) \\, d\\mu$, then simplifies using `inner x y = x * y` for real numbers (via `mul_comm`). This is the key step that translates between abstract and concrete formulations.",
+    "significance": "critical",
+    "relatedConcepts": ["L2.inner_def", "Bochner integral", "inner product bridge"],
+    "prerequisites": ["L2 inner product definition", "real inner product = multiplication"]
+  },
+  {
+    "id": "csi-abs-form",
+    "proofId": "cauchy-schwarz-integral",
+    "type": "theorem",
+    "range": { "startLine": 81, "endLine": 84 },
+    "title": "Bunyakovsky-Schwarz (Absolute Value Form)",
+    "content": "The main result: $|\\int f(a) \\cdot g(a) \\, d\\mu(a)| \\leq \\|f\\|_{L^2} \\cdot \\|g\\|_{L^2}$. Proved by rewriting the bridge theorem into the abstract Cauchy-Schwarz.",
+    "mathContext": "bunyakovsky_schwarz_abs$(f, g)$: the proof is a single rewrite: substitute $\\int fg = \\langle f, g \\rangle$ (via `L2_inner_eq_integral`) into $|\\langle f, g \\rangle| \\leq \\|f\\|\\|g\\|$ (via `abs_real_inner_le_norm`). This elegance comes from Mathlib's $L^2$ inner product space structure.",
+    "significance": "critical",
+    "relatedConcepts": ["Bunyakovsky inequality", "integral inequality", "L2 norm"],
+    "prerequisites": ["L2_inner_eq_integral", "abs_real_inner_le_norm"]
+  },
+  {
+    "id": "csi-sq-form",
+    "proofId": "cauchy-schwarz-integral",
+    "type": "theorem",
+    "range": { "startLine": 90, "endLine": 93 },
+    "title": "Bunyakovsky-Schwarz (Squared Form)",
+    "content": "The squared integral form: $(\\int f \\cdot g \\, d\\mu)^2 \\leq \\|f\\|^2 \\cdot \\|g\\|^2$. Follows from the abstract squared form via the bridge theorem.",
+    "mathContext": "bunyakovsky_schwarz_sq$(f, g)$: rewrites the bridge into the squared abstract form. This avoids square roots entirely and is often more convenient for applications in probability (variance bounds) and Fourier analysis.",
+    "significance": "key",
+    "relatedConcepts": ["squared integral inequality", "variance bound"],
+    "prerequisites": ["L2_inner_eq_integral", "cauchy_schwarz_L2_sq"]
+  },
+  {
+    "id": "csi-equality",
+    "proofId": "cauchy-schwarz-integral",
+    "type": "theorem",
+    "range": { "startLine": 98, "endLine": 109 },
+    "title": "Equality Characterization",
+    "content": "Equality $|\\langle f, g \\rangle| = \\|f\\|\\|g\\|$ holds iff $f$ and $g$ are linearly dependent in $L^2$: $\\exists c \\in \\mathbb{R}, f = c \\cdot g$ (as $L^2$ functions, i.e., a.e.).",
+    "mathContext": "cauchy_schwarz_L2_eq_iff$(f, g, hf, hg)$: forward uses `norm_inner_eq_norm_iff` to get $u = r \\cdot v$ for nonzero $r$, then inverts. Reverse substitutes $f = cg$ and computes using `inner_smul_left`, `real_inner_self_eq_norm_sq`, and `norm_smul`. The equality means $f(x) = c \\cdot g(x)$ for $\\mu$-almost every $x$.",
+    "significance": "critical",
+    "relatedConcepts": ["linear dependence", "norm_inner_eq_norm_iff", "almost everywhere equality"],
+    "prerequisites": ["cauchy_schwarz_L2", "InnerProductSpace", "nonzero vectors"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-integral/index.ts
+++ b/src/data/proofs/cauchy-schwarz-integral/index.ts
@@ -1,0 +1,8 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzIntegral.lean?raw'
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion }
+export const cauchySchwarzIntegralProof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+export const cauchySchwarzIntegralAnnotations: Annotation[] = annotationsJson as Annotation[]
+export const cauchySchwarzIntegralData: ProofData = { proof: cauchySchwarzIntegralProof, annotations: cauchySchwarzIntegralAnnotations }

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -1,0 +1,91 @@
+{
+  "id": "cauchy-schwarz-integral",
+  "title": "Bunyakovsky-Schwarz Integral Inequality",
+  "slug": "cauchy-schwarz-integral",
+  "description": "(integral f*g)^2 <= (integral f^2)*(integral g^2). The integral form of Cauchy-Schwarz via L^2 inner product spaces.",
+  "meta": {
+    "author": "Bunyakovsky, Schwarz (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cauchy%E2%80%93Schwarz_inequality#Integral_form",
+    "date": "1859",
+    "status": "verified",
+    "tags": ["analysis", "measure-theory", "classic", "intermediate"],
+    "proofRepoPath": "Proofs/CauchySchwarzIntegral.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      { "theorem": "abs_real_inner_le_norm", "description": "Cauchy-Schwarz for real inner products", "module": "Mathlib.Analysis.InnerProductSpace.Basic" },
+      { "theorem": "L2.inner_def", "description": "L2 inner product equals integral of pointwise inner product", "module": "Mathlib.MeasureTheory.Function.L2Space" },
+      { "theorem": "norm_inner_eq_norm_iff", "description": "Equality in Cauchy-Schwarz iff linearly dependent", "module": "Mathlib.Analysis.InnerProductSpace.Basic" }
+    ],
+    "originalContributions": [
+      "L2 Cauchy-Schwarz via abstract inner product space instance",
+      "Bridge theorem: L2 inner product = integral of f*g",
+      "Bunyakovsky-Schwarz absolute value form",
+      "Bunyakovsky-Schwarz squared form",
+      "Equality characterization: linear dependence in L2"
+    ],
+    "references": [
+      {"authors": "V. Y. Bunyakovsky", "title": "Sur quelques inegalites concernant les integrales ordinaires et les integrales aux differences finies", "year": "1859", "venue": "Memoires de l'Academie Imperiale des Sciences de St.-Petersbourg", "note": "First proof of the integral form"},
+      {"authors": "H. A. Schwarz", "title": "Uber ein die Flachen kleinsten Flacheninhalts betreffendes Problem der Variationsrechnung", "year": "1885", "venue": "Acta Societatis Scientiarum Fennicae", "note": "Independent proof of the integral version"},
+      {"authors": "J. M. Steele", "title": "The Cauchy-Schwarz Master Class", "year": "2004", "venue": "Cambridge University Press", "note": "Comprehensive treatment including the integral form"}
+    ],
+    "dateAdded": "02/11/26"
+  },
+  "overview": {
+    "historicalContext": "**Bunyakovsky's Extension to Integrals**\n\nViktor Bunyakovsky proved the integral form of the Cauchy-Schwarz inequality in 1859, extending Cauchy's 1821 discrete version to continuous functions. Hermann Schwarz independently proved it in 1885. The inequality states that for square-integrable functions $f, g$:\n\n$$\\left(\\int f \\cdot g \\, d\\mu\\right)^2 \\leq \\left(\\int f^2 \\, d\\mu\\right) \\cdot \\left(\\int g^2 \\, d\\mu\\right)$$\n\nThis is fundamental to functional analysis: it shows that the $L^2$ inner product is well-defined and that $L^2$ is a Hilbert space.\n\n**Modern Formalization Strategy**\n\nIn Mathlib, $L^2(\\mu)$ is already equipped with an `InnerProductSpace` instance, where $\\langle f, g \\rangle = \\int f \\cdot g \\, d\\mu$. The abstract Cauchy-Schwarz inequality $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$ therefore immediately gives the integral form. The key insight is that the bridge theorem connecting the abstract inner product to the concrete integral is the critical step.",
+    "problemStatement": "**Bunyakovsky-Schwarz Integral Inequality**\n\nFor $L^2$ functions $f, g$:\n$$\\left|\\int f \\cdot g \\, d\\mu\\right| \\leq \\|f\\|_{L^2} \\cdot \\|g\\|_{L^2}$$\n\nEquivalently in squared form:\n$$(\\int f \\cdot g \\, d\\mu)^2 \\leq \\|f\\|_{L^2}^2 \\cdot \\|g\\|_{L^2}^2$$\n\nEquality holds if and only if $f$ and $g$ are linearly dependent in $L^2$.",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **L2 is an InnerProductSpace:** Mathlib provides `InnerProductSpace \\mathbb{R} (Lp \\mathbb{R} 2 \\mu)` as an instance.\n2. **Abstract Cauchy-Schwarz:** Apply `abs_real_inner_le_norm` to get $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$.\n3. **Bridge theorem:** Show $\\langle f, g \\rangle = \\int f \\cdot g \\, d\\mu$ using `L2.inner_def`.\n4. **Rewrite:** Substitute the bridge into the abstract inequality to obtain the integral form.\n5. **Equality:** Use `norm_inner_eq_norm_iff` to characterize equality as linear dependence in $L^2$.",
+    "keyInsights": [
+      "**L2 as InnerProductSpace:** Mathlib's `Lp \\mathbb{R} 2 \\mu` carries an `InnerProductSpace` instance where $\\langle f, g \\rangle = \\int f \\cdot g \\, d\\mu$. This means the abstract Cauchy-Schwarz inequality *is* the integral form.",
+      "**Bridge Theorem:** The key formalization step is `L2_inner_eq_integral`: proving that the abstract inner product notation $\\langle f, g \\rangle$ equals the concrete integral $\\int f(a) \\cdot g(a) \\, d\\mu(a)$. This uses `L2.inner_def` and the fact that `inner x y = x * y` for reals.",
+      "**Squared Form:** The squared inequality $(\\int fg)^2 \\leq \\|f\\|^2 \\|g\\|^2$ follows directly from the absolute value form, avoiding square roots entirely.",
+      "**Equality = Linear Dependence in L2:** Equality holds iff $\\exists c: f = c \\cdot g$ in $L^2$, meaning $f(x) = c \\cdot g(x)$ almost everywhere."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "summary": "Imports Mathlib's L2 space, Bochner integration, inner product space theory, and tactics. Opens `MeasureTheory` namespace and sets up universe variables for a measurable space $(\\alpha, \\mu)$.",
+      "startLine": 1,
+      "endLine": 42
+    },
+    {
+      "id": "abstract-l2",
+      "title": "Abstract L2 Cauchy-Schwarz",
+      "summary": "Establishes that `Lp \\mathbb{R} 2 \\mu` is an `InnerProductSpace` (via `inferInstance`) and states the abstract Cauchy-Schwarz $|\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$ and its squared form.",
+      "startLine": 44,
+      "endLine": 60
+    },
+    {
+      "id": "bridge",
+      "title": "Bridge: Inner Product = Integral",
+      "summary": "Proves `L2_inner_eq_integral`: $\\langle f, g \\rangle = \\int f(a) \\cdot g(a) \\, d\\mu(a)$, connecting the abstract inner product to concrete integration via `L2.inner_def`.",
+      "startLine": 62,
+      "endLine": 73
+    },
+    {
+      "id": "integral-form",
+      "title": "Bunyakovsky-Schwarz Inequality",
+      "summary": "States and proves the integral form in both absolute value ($|\\int fg| \\leq \\|f\\|\\|g\\|$) and squared ($(\\int fg)^2 \\leq \\|f\\|^2\\|g\\|^2$) versions by rewriting the bridge theorem into the abstract inequality.",
+      "startLine": 75,
+      "endLine": 93
+    },
+    {
+      "id": "equality",
+      "title": "Equality Characterization",
+      "summary": "Proves equality holds iff $f$ and $g$ are linearly dependent in $L^2$: $|\\langle f, g \\rangle| = \\|f\\|\\|g\\| \\iff \\exists c: f = c \\cdot g$, using `norm_inner_eq_norm_iff`.",
+      "startLine": 95,
+      "endLine": 116
+    }
+  ],
+  "conclusion": {
+    "summary": "The formalization proves the Bunyakovsky-Schwarz integral inequality by exploiting Mathlib's L2 inner product space structure. The key insight is that the bridge theorem `L2_inner_eq_integral` connecting abstract inner products to concrete integrals turns the abstract Cauchy-Schwarz into the integral form in a single rewrite. All proofs are complete with zero sorries.",
+    "implications": "**Implications and Connections**\n\n1. **Hilbert Space Theory:** The inequality is the fundamental tool showing that $L^2(\\mu)$ is a Hilbert space, with $\\langle f, g \\rangle = \\int fg \\, d\\mu$ as a well-defined inner product.\n\n2. **Quantum Mechanics:** The Heisenberg uncertainty principle $\\Delta x \\cdot \\Delta p \\geq \\hbar/2$ is a direct consequence of this inequality applied to wave functions.\n\n3. **Probability Theory:** For random variables $X, Y$ with finite variance, $\\text{Cov}(X,Y)^2 \\leq \\text{Var}(X) \\cdot \\text{Var}(Y)$, bounding the correlation coefficient.\n\n4. **Signal Processing:** The matched filter theorem, showing that correlation detection is optimal, is a consequence of Cauchy-Schwarz in $L^2$.\n\n5. **Extends Cauchy-Schwarz Gallery:** This proof completes the Cauchy-Schwarz trilogy: discrete (finite sums), abstract (inner product spaces), and integral (measure-theoretic $L^2$).",
+    "openQuestions": [
+      "Can Holder's inequality be formalized as a generalization, recovering Cauchy-Schwarz for p=q=2?",
+      "Can the Minkowski inequality for integrals be derived as a corollary?",
+      "Can the bridge theorem be extended to complex-valued L2 functions?"
+    ]
+  }
+}

--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -111,7 +111,7 @@
     "implications": "**Implications and Connections**\n\n1. **Foundation for Normed Spaces:** The triangle inequality, derived here as a corollary, is the key axiom for normed vector spaces and metric spaces.\n\n2. **Quantum Mechanics:** The Heisenberg uncertainty principle $\\Delta x \\cdot \\Delta p \\geq \\hbar/2$ is a consequence of Cauchy-Schwarz applied to wave functions in $L^2$.\n\n3. **Statistics:** The bound $|\\rho| \\leq 1$ on the Pearson correlation coefficient, proved here, is fundamental to regression analysis and hypothesis testing.\n\n4. **Functional Analysis:** Cauchy-Schwarz ensures that inner product spaces are normed spaces, enabling the Hilbert space theory underlying modern analysis.\n\n5. **Machine Learning:** Cosine similarity $\\cos\\theta = \\langle u,v\\rangle/(\\|u\\|\\|v\\|)$ is well-defined precisely because Cauchy-Schwarz guarantees $|\\cos\\theta| \\leq 1$.",
     "openQuestions": [
       "Can the formalization be extended to complex inner product spaces using `inner_mul_le_norm_mul_norm`?",
-      "Can the integral form (Bunyakovsky-Schwarz) be formalized using Mathlib's measure theory?",
+      "[RESOLVED] The integral form (Bunyakovsky-Schwarz) has been formalized - see `cauchy-schwarz-integral` proof.",
       "Can Hölder's inequality be formalized as a generalization, recovering Cauchy-Schwarz for $p=q=2$?",
       "Can the equality condition be strengthened to give the exact proportionality constant $c = \\langle u,v\\rangle/\\|v\\|^2$?"
     ]

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -46,7 +46,8 @@
       "bunyakovsky_schwarz_abs: |integral f*g| <= ||f||*||g|| via abs_real_inner_le_norm",
       "bunyakovsky_schwarz_sq: (integral f*g)^2 <= ||f||^2*||g||^2",
       "L2_inner_eq_integral: Bridge theorem connecting L2 inner product to integral",
-      "cauchy_schwarz_L2_eq_iff: Equality characterization (linear dependence)"
+      "cauchy_schwarz_L2_eq_iff: Equality characterization (linear dependence)",
+      "src/data/proofs/cauchy-schwarz-integral/: Gallery entry (meta.json, annotations.json, index.ts)"
     ],
     "insights": [
       "Lp R 2 mu is an InnerProductSpace in Mathlib - abstract CS applies directly",


### PR DESCRIPTION
## Summary
- Created gallery entry for the Bunyakovsky-Schwarz integral inequality (`CauchySchwarzIntegral.lean`)
- Docker build verified: **0 sorries**, all 6 theorems proved
- Marks OQ-02 from the Cauchy-Schwarz proof as **RESOLVED**

## Progress
- New gallery entry: `src/data/proofs/cauchy-schwarz-integral/` (meta.json, annotations.json, index.ts)
- 8 annotations covering imports, L2 inner product space instance, bridge theorem, both inequality forms, and equality characterization
- Updated parent `cauchy-schwarz/meta.json` open questions
- Updated `cauchy-schwarz-oq-02.json` problem knowledge

## Findings
- Mathlib's `Lp R 2 mu` is already an `InnerProductSpace`, so abstract Cauchy-Schwarz applies directly
- The bridge theorem `L2.inner_def` connects abstract inner product to integral, making the proof a single rewrite
- This completes the Cauchy-Schwarz trilogy: discrete (finite sums), abstract (inner product spaces), and integral (measure-theoretic L2)

## Status
**Outcome**: completed
**Next Steps**: Merge PR

Generated by researcher-1