### PR TITLE
enrich: deepen annotations and meta for erdos-1

### DIFF
--- a/src/data/proofs/erdos-1/annotations.json
+++ b/src/data/proofs/erdos-1/annotations.json
@@ -1,64 +1,74 @@
 [
   {
-    "id": "ann-e1-imports",
+    "id": "ann-e1-header",
     "proofId": "erdos-1",
-    "range": { "startLine": 43, "endLine": 43 },
+    "range": { "startLine": 43, "endLine": 46 },
     "type": "concept",
-    "title": "Mathlib Import",
-    "content": "Imports the full Mathlib library, giving access to `Finset`, `Function.Injective`, and the algebra of finite sums needed for this formalization.",
-    "significance": "supporting"
+    "title": "Import and Namespace Setup",
+    "content": "Imports the full Mathlib library (giving access to Finset, Function.Injective, powerset, BigOperators, and all tactics) and opens the Finset namespace for concise notation. The file was edited by Aristotle (automated proof search), which proved all three theorems.",
+    "mathContext": "Uses `Function.Injective` for the subset sum injectivity, `Finset.powerset` for $\\mathcal{P}(A)$, `Finset.sum id` for $\\sum_{a \\in S} a$, and `Finset.filter` for $S \\cap A$. The full Mathlib import provides `grind`, `aesop`, `linarith`, and `simp_all` tactics.",
+    "significance": "supporting",
+    "relatedConcepts": ["Mathlib", "Finset", "Function.Injective", "Aristotle proof search"],
+    "prerequisites": ["Mathlib import"]
   },
   {
     "id": "ann-e1-distinct-sums-def",
     "proofId": "erdos-1",
-    "range": { "startLine": 48, "endLine": 50 },
+    "range": { "startLine": 49, "endLine": 50 },
     "type": "definition",
     "title": "Distinct Subset Sums Property",
-    "content": "A finite set A has **distinct subset sums** if the function mapping each subset S to its sum is injective. Formally: different subsets must have different sums.\n\nThis is equivalent to saying all 2^n subset sums are distinct, where n = |A|.",
-    "mathContext": "The definition uses `Function.Injective` on the composition: filter elements in A, then sum. This captures 'S.filter (in A)' which extracts the intersection S cap A.",
+    "content": "Defines `hasDistinctSubsetSums A : Prop` as `Function.Injective (fun S => (S.filter (. in A)).sum id)`. For any two finite sets S, T of naturals, if their intersections with A have the same sum, then S = T. This captures the property that all 2^|A| subset sums of A are distinct.",
+    "mathContext": "A set $A$ has distinct subset sums if $\\sum_{a \\in S \\cap A} a = \\sum_{a \\in T \\cap A} a \\Rightarrow S = T$. For $A = \\{1, 2, 4\\}$: the 8 sums are $\\{0, 1, 2, 3, 4, 5, 6, 7\\}$, all distinct. The definition uses `filter` rather than `powerset` membership for flexibility.",
     "significance": "critical",
-    "relatedConcepts": ["Sidon sets", "B_h sequences", "Additive combinatorics"]
+    "relatedConcepts": ["Function.Injective", "Finset.filter", "Finset.sum", "Sidon sets", "B_h sequences"],
+    "prerequisites": ["Function.Injective", "Finset operations"]
   },
   {
-    "id": "ann-e1-main-theorem",
+    "id": "ann-e1-lower-bound",
     "proofId": "erdos-1",
-    "range": { "startLine": 52, "endLine": 65 },
+    "range": { "startLine": 53, "endLine": 65 },
     "type": "theorem",
-    "title": "Erdos Lower Bound: N >= 2^(n-1)",
-    "content": "**Main Result**: If A is a subset of {1,...,N} has n elements with distinct subset sums, then N >= 2^(n-1).\n\nThis is the basic lower bound for Erdos Problem #1. The full conjecture (N >> 2^n without the 1/n factor) remains OPEN with a $500 prize.",
-    "mathContext": "The proof uses a counting argument: if all 2^n subset sums are distinct and bounded by the sum of elements in A, then the maximum element must be large enough to spread out these sums.",
+    "title": "Main Lower Bound: N >= 2^(n-1) (PROVED)",
+    "content": "Proves `erdos_1_lower_bound`: for A in {1,...,N} with positive elements and distinct subset sums, 2^(|A|-1) <= N. The Aristotle proof first establishes |P(A)| <= 2N via the injectivity of the sum function, then case-splits on |A| using `rcases` with 0, 1, and k+2 cases. The base cases use `simp_all` and `linarith`; the inductive case uses `grind`.",
+    "mathContext": "$A \\subseteq \\{1, \\ldots, N\\}$, $|A| = n$, all subset sums distinct $\\Rightarrow 2^{n-1} \\leq N$. The argument: $2^n$ distinct sums lie in $\\{0, 1, \\ldots, \\sum A\\} \\subseteq \\{0, \\ldots, nN\\}$, but the refined bound uses the powerset injection into $\\{0, \\ldots, 2N\\}$, giving $2^n \\leq 2N + 1$, hence $N \\geq 2^{n-1}$.",
     "significance": "critical",
-    "relatedConcepts": ["Pigeonhole principle", "Counting arguments"]
+    "relatedConcepts": ["pigeonhole principle", "powerset cardinality", "grind tactic", "linarith", "Aristotle proof"],
+    "prerequisites": ["hasDistinctSubsetSums", "Finset.powerset", "pow_succ"]
   },
   {
-    "id": "ann-e1-card-subsets",
+    "id": "ann-e1-injective-step",
     "proofId": "erdos-1",
     "range": { "startLine": 58, "endLine": 62 },
     "type": "tactic",
-    "title": "Counting Subsets Bound",
-    "content": "**Key Step**: Show that |P(A)| <= 2N by using injectivity. Since distinct subset sums give an injection from subsets to [0, sum(A)], and sum(A) <= n*N, we get constraints on the cardinality.",
-    "significance": "key"
+    "title": "Powerset Cardinality Bound",
+    "content": "Key step in the lower bound proof: establishes |P(A)| <= 2N. The injectivity of the sum function on subsets gives an injection from P(A) to {0, ..., sum(A)}. Since sum(A) <= |A| * N <= nN, and the sums are non-negative integers, the powerset size is bounded. The proof uses `exact?` to find the right Mathlib lemma and `absurd` for the contradiction argument.",
+    "mathContext": "The injection $S \\mapsto \\sum_{a \\in S \\cap A} a$ maps $\\mathcal{P}(A)$ into $\\{0, 1, \\ldots, \\sum_{a \\in A} a\\}$. Since $\\sum_{a \\in A} a \\leq |A| \\cdot N$ and the map is injective, $|\\mathcal{P}(A)| = 2^n \\leq nN + 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Function.Injective", "exact? tactic", "absurd", "Finset.card_powerset"],
+    "prerequisites": ["hasDistinctSubsetSums", "Finset.powerset"]
   },
   {
     "id": "ann-e1-max-element",
     "proofId": "erdos-1",
-    "range": { "startLine": 67, "endLine": 75 },
+    "range": { "startLine": 68, "endLine": 75 },
     "type": "theorem",
-    "title": "Maximum Element Bound",
-    "content": "**Corollary**: The maximum element of A must be at least 2^(n-1).\n\nThis follows directly from the main theorem: if max(A) < 2^(n-1), then taking N = max(A) would contradict the lower bound.",
-    "mathContext": "Uses `Finset.max'` to extract the maximum element of a nonempty finite set, then applies the main theorem with N = max(A).",
+    "title": "Maximum Element Bound (PROVED)",
+    "content": "Proves `max_element_bound`: for nonempty A with positive elements and distinct subset sums, 2^(|A|-1) <= A.max' hA. The Aristotle proof uses `convert` to reduce to `erdos_1_lower_bound` with N = max(A). The hypothesis that all elements of A are <= max(A) is proved by `Finset.le_max'`. The `assumption` tactic handles the remaining goals.",
+    "mathContext": "$2^{|A|-1} \\leq \\max(A)$. Proof: set $N = \\max(A)$, then $A \\subseteq \\{1, \\ldots, N\\}$ (since $a \\leq \\max(A)$ for all $a \\in A$), so `erdos_1_lower_bound` gives $2^{|A|-1} \\leq N = \\max(A)$. This corollary is often more directly useful than the main theorem.",
     "significance": "key",
-    "relatedConcepts": ["Extremal element", "Reduction to main theorem"]
+    "relatedConcepts": ["Finset.max'", "Finset.le_max'", "convert tactic", "corollary reduction"],
+    "prerequisites": ["erdos_1_lower_bound", "Finset.max'"]
   },
   {
     "id": "ann-e1-spacing",
     "proofId": "erdos-1",
-    "range": { "startLine": 77, "endLine": 83 },
+    "range": { "startLine": 78, "endLine": 83 },
     "type": "theorem",
-    "title": "Subset Sum Spacing (Sidon-like)",
-    "content": "**Sidon Property**: For any two different subsets S != T of A, their sums must differ: sum(S) != sum(T).\n\nThis is essentially the definition of distinct subset sums repackaged as a more usable statement.",
-    "mathContext": "The proof unfolds the definition of `hasDistinctSubsetSums` and uses the filter properties to show that distinct subsets produce distinct filtered sums.",
+    "title": "Subset Sum Spacing (PROVED)",
+    "content": "Proves `subset_sums_spacing`: for A with positive elements and distinct subset sums, if S, T are subsets of A with S != T, then S.sum id != T.sum id. The Aristotle proof applies the injectivity hypothesis from `hasDistinctSubsetSums` and uses `simp_all` with `Finset.subset_iff` to handle the filter-subset correspondence. The `Finset.sum_filter_of_ne` lemma simplifies the filtered sums.",
+    "mathContext": "For $S, T \\subseteq A$ with $S \\neq T$: $\\sum_{a \\in S} a \\neq \\sum_{a \\in T} a$. This is the Sidon-like property for subsets (rather than just pairs). For $A = \\{1, 2, 4\\}$: $\\{1, 4\\}$ sums to 5, $\\{2, 4\\}$ sums to 6 — all $\\binom{3}{2} = 3$ pair sums are distinct, and so are all $2^3 = 8$ subset sums.",
     "significance": "supporting",
-    "relatedConcepts": ["Sidon sets", "Sum-free sets"]
+    "relatedConcepts": ["Sidon sets", "Finset.sum_filter_of_ne", "simp_all tactic", "aesop_cat"],
+    "prerequisites": ["hasDistinctSubsetSums", "Finset.subset_iff"]
   }
 ]

--- a/src/data/proofs/erdos-1/meta.json
+++ b/src/data/proofs/erdos-1/meta.json
@@ -9,6 +9,7 @@
     "date": "1931",
     "status": "complete",
     "proofRepoPath": "Proofs/Erdos1Problem.lean",
+    "leanFile": "Proofs/Erdos1Problem.lean",
     "tags": [
       "erdos",
       "additive-combinatorics",
@@ -46,55 +47,69 @@
     ]
   },
   "overview": {
-    "historicalContext": "Erdős called this 'perhaps my first serious problem,' dating it to 1931 when he was just 18 years old. A set A has **distinct subset sums** if no two different subsets have the same sum. The question: if A is contained in {1,...,N} with |A| = n and has distinct subset sums, how small can N be?\n\nThe powers of 2, i.e., {1, 2, 4, ..., 2^(n-1)}, trivially have distinct subset sums and give N = 2^(n-1). The conjecture asks whether this is essentially optimal: must N be at least a constant times 2^n?",
-    "problemStatement": "Let A be a subset of {1, 2, ..., N} with |A| = n elements. If all 2^n subset sums of A are distinct, then:\n\n**Conjecture (Erdős 1931):** N >> 2^n, meaning N >= c * 2^n for some absolute constant c > 0.\n\n**Prize:** $500 (one of Erdős's original prize problems)",
-    "proofStrategy": "The formalization proves the basic lower bound N >= 2^(n-1) via a counting argument:\n\n1. Define `hasDistinctSubsetSums` as injectivity of the sum function on subsets\n2. Show that distinct subset sums must span a range of size at least 2^n\n3. Since sums are bounded by n*N, we get 2^n <= n*N, giving N >= 2^n/n\n4. A refined argument using the maximum element gives N >= 2^(n-1)\n\nThe full conjecture (N >> 2^n with no 1/n factor) remains OPEN.",
+    "historicalContext": "Erdős called this 'perhaps my first serious problem,' posing it in 1931 at age 18. A set $A \\subseteq \\{1, \\ldots, N\\}$ has distinct subset sums if the map $S \\mapsto \\sum_{a \\in S} a$ is injective on subsets of $A$. The powers of 2, $\\{1, 2, 4, \\ldots, 2^{n-1}\\}$, trivially satisfy this with $N = 2^{n-1}$, and Erdős conjectured this is essentially optimal: $N \\geq c \\cdot 2^n$ for some absolute constant $c > 0$. He offered \\$500 for a proof or disproof. The basic lower bound $N \\geq 2^{n-1}$ was known early via a counting/pigeonhole argument. Conway and Guy (1968) constructed sets with $N < 0.22002 \\cdot 2^n$, showing the constant $c$ (if it exists) is at most $0.22$. Lunnon (1988) computed optimal sets for small $n$. The best lower bound is due to Dubroff, Fox, and Xu (2021): $N \\geq \\sqrt{2/\\pi} \\cdot 2^n / \\sqrt{n}$, which still has a $1/\\sqrt{n}$ gap from the conjectured $c \\cdot 2^n$. The problem connects to Sidon sets ($B_2$ sequences), uniquely decodable codes in information theory, and the knapsack problem in computational complexity.",
+    "problemStatement": "Let $A \\subseteq \\{1, 2, \\ldots, N\\}$ with $|A| = n$. If all $2^n$ subset sums $\\{\\sum_{a \\in S} a : S \\subseteq A\\}$ are distinct, must $N \\geq c \\cdot 2^n$ for some absolute constant $c > 0$? The basic bound $N \\geq 2^{n-1}$ is proved here; the full conjecture remains open with a \\$500 prize.",
+    "proofStrategy": "The formalization defines `hasDistinctSubsetSums A` as injectivity of the function $S \\mapsto (S \\cap A).\\text{sum}\\,\\text{id}$ on `Finset N`. Three theorems are proved by Aristotle: (1) `erdos_1_lower_bound`: $2^{|A|-1} \\leq N$ via a powerset cardinality argument; (2) `max_element_bound`: $2^{|A|-1} \\leq \\max(A)$ by reducing to the lower bound with $N = \\max(A)$; (3) `subset_sums_spacing`: distinct subsets $S \\neq T$ of $A$ have $\\sum S \\neq \\sum T$, extracted from the injectivity definition.",
     "keyInsights": [
-      "**Powers of 2 are extremal:** {1, 2, 4, ..., 2^(n-1)} has distinct sums with N = 2^(n-1), showing 2^n is the right order of magnitude.",
-      "**Counting argument:** 2^n distinct sums in [0, nN] gives the trivial bound N >= 2^n / n.",
-      "**Maximum element bound:** The max element alone must be >= 2^(n-1), proved in our formalization.",
-      "**Best known lower bound:** Dubroff-Fox-Xu (2021) proved N >= sqrt(2/pi) * 2^n / sqrt(n).",
-      "**Conway-Guy construction:** Upper bound examples show N < 0.22002 * 2^n is achievable."
+      "**Powers of 2 are extremal**: $\\{1, 2, 4, \\ldots, 2^{n-1}\\}$ has distinct subset sums with $N = 2^{n-1}$. Each subset sum is a distinct binary representation, so the $2^n$ sums are $0, 1, 2, \\ldots, 2^n - 1$.",
+      "**Counting argument**: $2^n$ distinct sums in $[0, nN]$ gives the trivial bound $N \\geq 2^n / n$. The refined argument uses the maximum element to get $N \\geq 2^{n-1}$ without the $1/n$ factor.",
+      "**Maximum element bound**: If $\\max(A) = M$, then sums including $M$ and sums excluding $M$ must interleave, forcing $M \\geq 2^{n-1}$. The Lean proof reduces to `erdos_1_lower_bound` via `Finset.le_max'`.",
+      "**Dubroff-Fox-Xu (2021)**: The best known lower bound is $N \\geq \\sqrt{2/\\pi} \\cdot 2^n / \\sqrt{n}$, using probabilistic and entropy methods. The $1/\\sqrt{n}$ gap to $c \\cdot 2^n$ remains.",
+      "**Conway-Guy construction**: The upper bound $N < 0.22002 \\cdot 2^n$ uses a greedy algorithm with a specific recursion. The Conway-Guy conjecture (that their construction is optimal) is also open."
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement and Aristotle Header",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Aristotle proof header documenting three proved theorems. Problem statement: if $A \\subseteq \\{1, \\ldots, N\\}$ with $|A| = n$ has all $2^n$ subset sums distinct, then $N \\geq 2^{n-1}$. Imports full Mathlib and opens `Finset` namespace."
+    },
+    {
       "id": "definition",
-      "title": "Distinct Subset Sums",
-      "summary": "Definition of the distinct subset sums property",
+      "title": "Distinct Subset Sums Definition",
       "startLine": 48,
-      "endLine": 50
+      "endLine": 50,
+      "summary": "Defines `hasDistinctSubsetSums A` as `Function.Injective (\\lambda S \\Rightarrow (S.\\text{filter}\\,(\\cdot \\in A)).\\text{sum}\\,\\text{id})`. This captures: distinct subsets of $A$ have distinct sums."
     },
     {
       "id": "main-theorem",
-      "title": "Main Lower Bound",
-      "summary": "Proof that N >= 2^(n-1) for sets with distinct subset sums",
+      "title": "Main Lower Bound (Aristotle-proved)",
       "startLine": 52,
-      "endLine": 65
+      "endLine": 65,
+      "summary": "Proves `erdos_1_lower_bound`: $2^{|A|-1} \\leq N$ for $A \\subseteq \\{1, \\ldots, N\\}$ with distinct subset sums. Uses powerset cardinality bound $|\\mathcal{P}(A)| \\leq 2N$, then case-splits on $|A|$ with `pow_succ`, `mul_assoc`, `linarith`, and `grind`."
     },
     {
       "id": "max-element",
-      "title": "Maximum Element Bound",
-      "summary": "The max element must be at least 2^(n-1)",
+      "title": "Maximum Element Bound (Aristotle-proved)",
       "startLine": 67,
-      "endLine": 75
+      "endLine": 75,
+      "summary": "Proves `max_element_bound`: $2^{|A|-1} \\leq \\max(A)$ for nonempty $A$ with distinct subset sums. Reduces to `erdos_1_lower_bound` via `convert` with $N = A.\\text{max'}$, using `Finset.le_max'` for the containment hypothesis."
     },
     {
       "id": "spacing",
-      "title": "Subset Sum Spacing",
-      "summary": "Sidon-like property: different subsets have different sums",
+      "title": "Subset Sum Spacing (Aristotle-proved)",
       "startLine": 77,
-      "endLine": 83
+      "endLine": 83,
+      "summary": "Proves `subset_sums_spacing`: for $S, T \\subseteq A$ with $S \\neq T$, $\\sum S \\neq \\sum T$. Unfolds `hasDistinctSubsetSums`, applies `simp_all` and `Finset.sum_filter_of_ne` to reduce to the injectivity hypothesis."
     }
   ],
   "conclusion": {
-    "summary": "We formalize the basic theory around Erdős Problem #1, proving that any set A with n elements in {1,...,N} having distinct subset sums must satisfy N >= 2^(n-1). The full conjecture—that N >> 2^n with no 1/n factor—remains one of the oldest open problems in combinatorics.",
-    "implications": "This problem connects to:\n\n1. **Sidon sets:** Sets where all pairwise sums are distinct (a weaker condition)\n2. **B_h sequences:** Generalization to h-fold sums\n3. **Coding theory:** Distinct subset sums relate to uniquely decodable codes\n4. **Additive combinatorics:** Structure theory of sumsets",
+    "summary": "Erdős Problem #1 formalizes the basic theory of distinct subset sums. All three theorems are fully proved by Aristotle (no axioms or sorries): the lower bound $2^{n-1} \\leq N$ via a powerset counting argument, the maximum element bound $2^{n-1} \\leq \\max(A)$ by reduction, and the Sidon-like spacing property. The full conjecture $N \\geq c \\cdot 2^n$ remains open with a \\$500 Erdős prize.",
+    "implications": "This problem is foundational in additive combinatorics and connects to Sidon sets ($B_2$ sequences where all pairwise sums are distinct), uniquely decodable codes in information theory, and the knapsack problem in computational complexity. The gap between the best lower bound $\\Omega(2^n / \\sqrt{n})$ and the Conway-Guy upper bound $O(0.22 \\cdot 2^n)$ suggests deep structural constraints on extremal sets.",
     "openQuestions": [
-      "Prove N >= c * 2^n for some constant c > 0 (the $500 problem!)",
-      "Improve the constant in the lower bound beyond sqrt(2/pi)",
-      "Find better constructions than Conway-Guy for the upper bound",
-      "Characterize extremal sets achieving the minimum N"
+      "Prove or disprove $N \\geq c \\cdot 2^n$ for some absolute constant $c > 0$ (the \\$500 problem).",
+      "Improve the Dubroff-Fox-Xu lower bound $N \\geq \\sqrt{2/\\pi} \\cdot 2^n / \\sqrt{n}$.",
+      "Is the Conway-Guy construction optimal among all distinct-subset-sum sets?",
+      "Characterize the structure of extremal sets achieving the minimum $N$."
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-28",
+    "erdos-106",
+    "erdos-347",
+    "erdos-533",
+    "erdos-867"
+  ]
 }


### PR DESCRIPTION
## Summary
- Rewrote historicalContext with LaTeX (~950 chars): Erdős 1931, Conway-Guy 1968, Lunnon 1988, Dubroff-Fox-Xu 2021, Sidon sets, knapsack
- All 6 annotations now have mathContext/relatedConcepts/prerequisites
- Added LaTeX to section summaries, keyInsights, conclusion
- Added `leanFile`, `relatedProofs` fields

## Test plan
- [x] `pnpm annotations:build` passes (no erdos-1 errors at all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)