### PR TITLE
fix: use 'as unknown as' cast for erdos-901 and erdos-910 index.ts

### DIFF
--- a/src/data/proofs/erdos-901/index.ts
+++ b/src/data/proofs/erdos-901/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
 // Type assertion for JSON import
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string
@@ -29,7 +29,7 @@ export const proof: Proof = {
   conclusion: meta.conclusion,
 }
 
-export const annotations: Annotation[] = annotationsJson as Annotation[]
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
 export const proofData: ProofData = {
   proof,

--- a/src/data/proofs/erdos-910/index.ts
+++ b/src/data/proofs/erdos-910/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
 // Type assertion for JSON import
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string
@@ -29,7 +29,7 @@ export const proof: Proof = {
   conclusion: meta.conclusion,
 }
 
-export const annotations: Annotation[] = annotationsJson as Annotation[]
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
 export const proofData: ProofData = {
   proof,


### PR DESCRIPTION
## Summary
- Fix TS2352 build errors in `erdos-901/index.ts` and `erdos-910/index.ts`
- Add intermediate `unknown` cast for both meta and annotation JSON imports
- Same recurring enricher template issue as #2661, #2665

## Test plan
- [x] `pnpm build` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)