### PR TITLE
enrich: deepen annotations and meta for erdos-926, erdos-94, erdos-954

### DIFF
--- a/src/data/proofs/erdos-94/annotations.json
+++ b/src/data/proofs/erdos-94/annotations.json
@@ -1,164 +1,177 @@
 [
   {
-    "id": "ann-94-point",
+    "id": "point-config-and-distances",
     "proofId": "erdos-94",
-    "range": { "startLine": 37, "endLine": 38 },
+    "range": { "startLine": 54, "endLine": 69 },
     "type": "definition",
-    "title": "Point",
-    "content": "A point in the Euclidean plane ℝ². Uses Mathlib's EuclideanSpace.",
-    "significance": "supporting"
+    "title": "Point Configurations and Distance Sets",
+    "content": "Defines a point configuration as a `Finset Point` where `Point = EuclideanSpace ℝ (Fin 2)`. The distance set `distanceSet P` collects all positive pairwise distances, while `distanceMultiset P` records distances with repetition. The distance function `dist'` wraps Mathlib's `dist` for the Euclidean metric.",
+    "significance": "supporting",
+    "mathContext": {
+      "formalStatement": "abbrev Point := EuclideanSpace ℝ (Fin 2)\ndef PointConfig := Finset Point\nnoncomputable def distanceSet (P : PointConfig) : Finset ℝ :=\n  (P.product P).image (fun pq => dist' pq.1 pq.2) |>.filter (· > 0)",
+      "keyFormulas": [
+        "$d(P) = \\{\\|p - q\\| : p, q \\in P,\\, p \\neq q\\}$"
+      ]
+    },
+    "relatedConcepts": ["Euclidean distance", "point set", "distance set"],
+    "prerequisites": ["EuclideanSpace", "Finset.product", "metric space"]
   },
   {
-    "id": "ann-94-config",
+    "id": "distance-multiplicity",
     "proofId": "erdos-94",
-    "range": { "startLine": 41, "endLine": 41 },
+    "range": { "startLine": 73, "endLine": 79 },
     "type": "definition",
-    "title": "Point Configuration",
-    "content": "A finite set of points in ℝ². The vertices of a potential convex polygon.",
-    "significance": "key"
+    "title": "Distance Multiplicity $f(u)$",
+    "content": "The multiplicity $f(u)$ counts ordered pairs at distance $u$ (`distanceMultiplicity`), while `unorderedMultiplicity` divides by 2 for unordered pairs. These functions are the key combinatorial quantities: $f(u) = |\\{(p,q) \\in P^2 : \\|p - q\\| = u,\\, p \\neq q\\}|$.",
+    "significance": "key",
+    "mathContext": {
+      "formalStatement": "noncomputable def distanceMultiplicity (P : PointConfig) (u : ℝ) : ℕ :=\n  ((P.product P).filter fun pq => dist' pq.1 pq.2 = u ∧ pq.1 ≠ pq.2).card\nnoncomputable def unorderedMultiplicity (P : PointConfig) (u : ℝ) : ℕ :=\n  distanceMultiplicity P u / 2",
+      "keyFormulas": [
+        "$f(u) = |\\{\\{p, q\\} \\subset P : \\|p - q\\| = u\\}|$"
+      ]
+    },
+    "relatedConcepts": ["distance frequency", "pair counting"],
+    "prerequisites": ["Finset.filter", "ordered vs unordered pairs"]
   },
   {
-    "id": "ann-94-distset",
+    "id": "sum-multiplicities-proved",
     "proofId": "erdos-94",
-    "range": { "startLine": 47, "endLine": 48 },
-    "type": "definition",
-    "title": "Distance Set",
-    "content": "The set of all distinct positive pairwise distances in a configuration.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-94-mult",
-    "proofId": "erdos-94",
-    "range": { "startLine": 57, "endLine": 58 },
-    "type": "definition",
-    "title": "Distance Multiplicity",
-    "content": "f(u) = number of ordered pairs at distance u. The key function in the problem.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-94-unord",
-    "proofId": "erdos-94",
-    "range": { "startLine": 61, "endLine": 62 },
-    "type": "definition",
-    "title": "Unordered Multiplicity",
-    "content": "f(u) for unordered pairs (half of ordered count). What we actually sum.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-94-summult",
-    "proofId": "erdos-94",
-    "range": { "startLine": 65, "endLine": 67 },
+    "range": { "startLine": 82, "endLine": 134 },
     "type": "theorem",
-    "title": "Sum of Multiplicities",
-    "content": "∑ f(u) = C(n,2). The trivial observation: total pairs equals binomial coefficient.",
-    "significance": "supporting"
+    "title": "Sum of Multiplicities Equals $\\binom{n}{2}$ (Proved by Aristotle)",
+    "content": "The theorem $\\sum_u f(u) = \\binom{n}{2}$ is fully proved in Lean (no sorry). Each unordered pair contributes to exactly one distance value, so the total count equals the number of pairs. The proof establishes evenness of ordered multiplicities via a symmetry argument (pairing $(p,q)$ with $(q,p)$), then converts to unordered counts. This is one of Aristotle's successful proof-search results.",
+    "significance": "key",
+    "mathContext": {
+      "formalStatement": "theorem sum_multiplicities (P : PointConfig) :\n    (distanceSet P).sum (unorderedMultiplicity P) = P.card.choose 2",
+      "keyFormulas": [
+        "$\\sum_{u \\in d(P)} f(u) = \\binom{n}{2}$"
+      ],
+      "leanTactics": ["Finset.sum_image'", "Finset.sum_le_sum_of_subset", "aesop", "grind"]
+    },
+    "relatedConcepts": ["double counting", "binomial coefficient", "partition of pairs"],
+    "prerequisites": ["Finset.sum", "Nat.choose", "evenness via involution"]
   },
   {
-    "id": "ann-94-sumsq",
+    "id": "sum-squared-multiplicities",
     "proofId": "erdos-94",
-    "range": { "startLine": 72, "endLine": 73 },
+    "range": { "startLine": 138, "endLine": 171 },
     "type": "definition",
-    "title": "Sum of Squared Multiplicities",
-    "content": "∑ f(u)². The key quantity we want to bound by O(n³).",
-    "significance": "critical"
+    "title": "Sum of Squared Multiplicities $\\sum f(u)^2$",
+    "content": "The central quantity $\\sum_u f(u)^2$ measures distance clustering. Equivalently, it counts quadruples $(p,q,r,s)$ with $\\|p - q\\| = \\|r - s\\|$ (via `countEqualDistancePairs`), with the relation $4 \\sum f(u)^2 = |\\{(p,q,r,s) : d(p,q) = d(r,s)\\}|$. The factor 4 accounts for ordering within each pair.",
+    "significance": "key",
+    "mathContext": {
+      "formalStatement": "noncomputable def sumSquaredMultiplicities (P : PointConfig) : ℕ :=\n  (distanceSet P).sum fun u => (unorderedMultiplicity P u) ^ 2\ntheorem squared_sum_eq_count (P : PointConfig) :\n    4 * sumSquaredMultiplicities P = countEqualDistancePairs P",
+      "keyFormulas": [
+        "$\\sum_{u} f(u)^2 = \\frac{1}{4}|\\{(p,q,r,s) : d(p,q) = d(r,s)\\}|$"
+      ]
+    },
+    "relatedConcepts": ["equal distance quadruples", "incidence geometry", "Cauchy-Schwarz bound"],
+    "prerequisites": ["sum of squares", "quadruple counting"]
   },
   {
-    "id": "ann-94-quadruple",
+    "id": "convex-position",
     "proofId": "erdos-94",
-    "range": { "startLine": 76, "endLine": 78 },
+    "range": { "startLine": 182, "endLine": 225 },
     "type": "definition",
-    "title": "Equal Distance Pairs",
-    "content": "Count quadruples (p,q,r,s) with d(p,q) = d(r,s). Equivalent formulation of ∑ f(u)².",
-    "significance": "key"
+    "title": "Convex Position and No Three Collinear",
+    "content": "Points are in convex position (`InConvexPosition`) if no point lies in the convex hull of the rest: $\\forall p \\in P,\\, p \\notin \\text{conv}(P \\setminus \\{p\\})$. The weaker condition `NoThreeCollinear` requires no three points are collinear. Convex implies no-three-collinear (axiomatized). Lefmann-Theile showed the $O(n^3)$ bound holds under the weaker condition.",
+    "significance": "key",
+    "mathContext": {
+      "formalStatement": "def InConvexPosition (P : PointConfig) : Prop :=\n  ∀ p ∈ P, p ∈ convexHull ℝ (P.erase p : Set Point) → False\ndef NoThreeCollinear (P : PointConfig) : Prop :=\n  ∀ p q r : Point, p ∈ P → q ∈ P → r ∈ P →\n    p ≠ q → q ≠ r → p ≠ r → ¬Collinear ℝ ({p, q, r} : Set Point)",
+      "keyFormulas": [
+        "$p \\notin \\text{conv}(P \\setminus \\{p\\})$ for all $p \\in P$"
+      ]
+    },
+    "relatedConcepts": ["convex hull", "general position", "collinearity"],
+    "prerequisites": ["convexHull", "Collinear", "Finset.erase"]
   },
   {
-    "id": "ann-94-convex",
+    "id": "fishburn-theorem",
     "proofId": "erdos-94",
-    "range": { "startLine": 88, "endLine": 89 },
-    "type": "definition",
-    "title": "Convex Position",
-    "content": "Points form a convex polygon: no point is in the convex hull of the others.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-94-collinear",
-    "proofId": "erdos-94",
-    "range": { "startLine": 92, "endLine": 95 },
-    "type": "definition",
-    "title": "No Three Collinear",
-    "content": "No three points lie on a line. Weaker than convex position.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-94-fishburn",
-    "proofId": "erdos-94",
-    "range": { "startLine": 105, "endLine": 108 },
+    "range": { "startLine": 239, "endLine": 257 },
     "type": "theorem",
-    "title": "Fishburn's Theorem",
-    "content": "∑ f(u)² ≤ C·n³ for convex polygons. The main result solving the problem.",
-    "significance": "critical"
+    "title": "Fishburn's Theorem: $\\sum f(u)^2 = O(n^3)$",
+    "content": "The main result solving Erdős Problem #94: there exists $C > 0$ such that $\\sum f(u)^2 \\leq C n^3$ for any $n$ points in convex position. Fishburn also showed asymptotically $C$ can be taken as $1 + \\varepsilon$ for any $\\varepsilon > 0$ when $n$ is large enough. Both are axiomatized (sorry). This was a $\\$44$ Erdős prize problem.",
+    "significance": "key",
+    "mathContext": {
+      "formalStatement": "theorem fishburn_theorem :\n    ∃ C : ℝ, C > 0 ∧ ∀ P : PointConfig, InConvexPosition P →\n      (sumSquaredMultiplicities P : ℝ) ≤ C * (P.card : ℝ) ^ 3\ntheorem fishburn_asymptotic :\n    ∀ ε > 0, ∃ N : ℕ, ∀ P : PointConfig, InConvexPosition P → P.card ≥ N →\n      (sumSquaredMultiplicities P : ℝ) ≤ (1 + ε) * (P.card : ℝ) ^ 3",
+      "keyFormulas": [
+        "$\\sum_{u} f(u)^2 \\leq C \\cdot n^3$",
+        "$\\sum_{u} f(u)^2 \\leq (1 + \\varepsilon) n^3$ for $n \\geq N(\\varepsilon)$"
+      ]
+    },
+    "relatedConcepts": ["distance clustering bound", "Erdős prize problem"],
+    "prerequisites": ["convex position", "sum of squared multiplicities"]
   },
   {
-    "id": "ann-94-lt",
+    "id": "lefmann-theile",
     "proofId": "erdos-94",
-    "range": { "startLine": 119, "endLine": 122 },
+    "range": { "startLine": 271, "endLine": 274 },
     "type": "theorem",
-    "title": "Lefmann-Theile Theorem",
-    "content": "Same O(n³) bound under the weaker 'no three collinear' condition. A strengthening.",
-    "significance": "critical"
+    "title": "Lefmann-Theile Strengthening (1995)",
+    "content": "Lefmann and Theile (1995) proved $\\sum f(u)^2 = O(n^3)$ under the weaker assumption that no three points are collinear, rather than requiring convexity. This is a strict generalization: every convex polygon has no three collinear points, but not conversely.",
+    "significance": "key",
+    "mathContext": {
+      "formalStatement": "theorem lefmann_theile_theorem :\n    ∃ C : ℝ, C > 0 ∧ ∀ P : PointConfig, NoThreeCollinear P →\n      (sumSquaredMultiplicities P : ℝ) ≤ C * (P.card : ℝ) ^ 3",
+      "keyFormulas": [
+        "$\\sum_{u} f(u)^2 \\leq C n^3$ when no three points are collinear"
+      ]
+    },
+    "relatedConcepts": ["general position", "collinearity-free configurations"],
+    "prerequisites": ["NoThreeCollinear", "Fishburn's theorem"]
   },
   {
-    "id": "ann-94-regular",
+    "id": "regular-ngon-construction",
     "proofId": "erdos-94",
-    "range": { "startLine": 127, "endLine": 130 },
+    "range": { "startLine": 293, "endLine": 339 },
     "type": "definition",
-    "title": "Regular n-gon",
-    "content": "Vertices of the regular n-gon on the unit circle. The conjectured extremal configuration.",
-    "significance": "key"
+    "title": "Regular $n$-gon and $\\Theta(n^3)$ Lower Bound",
+    "content": "The regular $n$-gon is constructed as $\\{(\\cos(2\\pi k/n), \\sin(2\\pi k/n)) : k = 0, \\ldots, n-1\\}$. It is in convex position (axiomatized) and achieves $\\sum f(u)^2 = \\Theta(n^3)$, showing Fishburn's bound is tight. The distances in a regular $n$-gon are $2\\sin(\\pi j/n)$ for $j = 1, \\ldots, \\lfloor n/2 \\rfloor$, each with multiplicity $n$, giving $\\sum f(u)^2 \\approx n^2 \\cdot \\lfloor n/2 \\rfloor = \\Theta(n^3)$.",
+    "significance": "supporting",
+    "mathContext": {
+      "formalStatement": "noncomputable def regularNGon (n : ℕ) : PointConfig :=\n  if n < 3 then ∅ else\n    (Finset.range n).image fun k =>\n      ![Real.cos (2 * Real.pi * k / n), Real.sin (2 * Real.pi * k / n)]\ntheorem regular_ngon_cubic :\n    ∃ c₁ c₂ : ℝ, c₁ > 0 ∧ c₂ > 0 ∧ ∀ n : ℕ, n ≥ 3 →\n      c₁ * n ^ 3 ≤ (regularNGonSum n : ℝ) ∧ (regularNGonSum n : ℝ) ≤ c₂ * n ^ 3",
+      "keyFormulas": [
+        "$\\text{regularNGon}(n) = \\{e^{2\\pi i k/n} : k = 0, \\ldots, n-1\\}$",
+        "$\\sum f(u)^2 = \\Theta(n^3)$ for the regular $n$-gon"
+      ]
+    },
+    "relatedConcepts": ["regular polygon", "extremal configuration", "distance distribution"],
+    "prerequisites": ["trigonometric parametrization", "convex position"]
   },
   {
-    "id": "ann-94-cubic",
+    "id": "erdos-fishburn-conjecture",
     "proofId": "erdos-94",
-    "range": { "startLine": 142, "endLine": 145 },
-    "type": "theorem",
-    "title": "Regular n-gon is Θ(n³)",
-    "content": "The regular n-gon achieves ∑ f(u)² = Θ(n³), showing the bound is tight.",
-    "significance": "key"
+    "range": { "startLine": 348, "endLine": 372 },
+    "type": "conjecture",
+    "title": "Erdős-Fishburn Extremal Conjecture",
+    "content": "Conjectures that for sufficiently large $n$, the regular $n$-gon maximizes $\\sum f(u)^2$ among all convex $n$-gons. Formalized as `ErdosFishburnConjecture : Prop`. Computationally verified for $n \\leq 10$ (axiomatized). Related to OEIS A387858.",
+    "significance": "supporting",
+    "mathContext": {
+      "formalStatement": "def ErdosFishburnConjecture : Prop :=\n  ∃ N : ℕ, ∀ n : ℕ, n ≥ N → ∀ P : PointConfig, InConvexPosition P → P.card = n →\n    sumSquaredMultiplicities P ≤ regularNGonSum n",
+      "keyFormulas": [
+        "$\\sum f(u)^2 \\leq \\sum_{\\text{reg}} f(u)^2$ for convex $P$ with $|P| = n \\geq N$"
+      ]
+    },
+    "relatedConcepts": ["extremal configuration", "regular polygon optimality", "OEIS A387858"],
+    "prerequisites": ["regularNGon", "sumSquaredMultiplicities"]
   },
   {
-    "id": "ann-94-conjecture",
+    "id": "related-quantities",
     "proofId": "erdos-94",
-    "range": { "startLine": 150, "endLine": 152 },
-    "type": "definition",
-    "title": "Erdős-Fishburn Conjecture",
-    "content": "The regular n-gon maximizes ∑ f(u)² among all convex n-gons (for large n).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-94-distinct",
-    "proofId": "erdos-94",
-    "range": { "startLine": 163, "endLine": 164 },
-    "type": "definition",
-    "title": "Distinct Distances",
-    "content": "Number of distinct distances in the configuration. Bounded by ⌊n/2⌋ + 1 for convex.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-94-maxmult",
-    "proofId": "erdos-94",
-    "range": { "startLine": 172, "endLine": 173 },
-    "type": "definition",
-    "title": "Maximum Multiplicity",
-    "content": "The maximum f(u) over all distances. Bounded by O(n) for convex position.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-94-unit",
-    "proofId": "erdos-94",
-    "range": { "startLine": 183, "endLine": 184 },
-    "type": "definition",
-    "title": "Unit Distance Count",
-    "content": "f(1) = pairs at distance exactly 1. Connection to unit distance problem.",
-    "significance": "supporting"
+    "range": { "startLine": 376, "endLine": 431 },
+    "type": "concept",
+    "title": "Related Quantities: Distinct Distances, Max Multiplicity, Unit Distances",
+    "content": "Three related combinatorial quantities for convex configurations: (1) The number of distinct distances $|d(P)| \\leq \\lfloor n/2 \\rfloor + 1$ (Altman 1963). (2) The maximum single-distance multiplicity $\\max_u f(u) \\leq 2n$ for convex position. (3) The unit distance count $f(1)$, connecting to the Erdős unit distance problem with the convex bound $f(1) \\leq 2n - 2$.",
+    "significance": "supporting",
+    "mathContext": {
+      "formalStatement": "theorem convex_distinct_distances (P : PointConfig) (hP : InConvexPosition P) :\n    numDistinctDistances P ≤ P.card / 2 + 1\ntheorem convex_max_multiplicity (P : PointConfig) (hP : InConvexPosition P) :\n    (maxMultiplicity P : ℝ) ≤ 2 * P.card\ntheorem convex_unit_distance (P : PointConfig) (hP : InConvexPosition P) :\n    (unitDistanceCount P : ℝ) ≤ 2 * P.card - 2",
+      "keyFormulas": [
+        "$|d(P)| \\leq \\lfloor n/2 \\rfloor + 1$",
+        "$\\max_u f(u) \\leq 2n$",
+        "$f(1) \\leq 2n - 2$"
+      ]
+    },
+    "relatedConcepts": ["distinct distances problem", "unit distance problem", "Altman's theorem"],
+    "prerequisites": ["convex position", "distance multiplicity"]
   }
 ]

--- a/src/data/proofs/erdos-94/meta.json
+++ b/src/data/proofs/erdos-94/meta.json
@@ -2,111 +2,142 @@
   "id": "erdos-94",
   "title": "Erdős #94: Distance Multiplicities in Convex Polygons",
   "slug": "erdos-94",
-  "description": "For n points forming a convex polygon with distance multiplicities f(u), prove ∑ f(u)² = O(n³). Solved by Fishburn, strengthened by Lefmann-Theile.",
+  "description": "For n points forming a convex polygon with distance multiplicities f(u), prove ∑ f(u)² = O(n³). Solved by Fishburn, strengthened by Lefmann-Theile (1995) to 'no three collinear'. Regular n-gon achieves Θ(n³). Erdős-Fishburn conjecture: regular n-gon is extremal.",
   "meta": {
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/94",
     "date": "1990s",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos94Problem.lean",
+    "leanFile": "Proofs/Erdos94Problem.lean",
     "tags": [
       "erdos",
       "geometry",
       "convex",
       "distances",
-      "combinatorics"
+      "combinatorics",
+      "discrete-geometry",
+      "extremal-configuration"
     ],
     "badge": "wip",
     "sorries": 12,
     "erdosNumber": 94,
     "erdosUrl": "https://erdosproblems.com/94",
     "erdosProblemStatus": "solved",
-    "erdosPrizeValue": "$44"
+    "erdosPrizeValue": "$44",
+    "mathlibDependencies": [
+      "Mathlib.Analysis.InnerProductSpace.PiL2",
+      "Mathlib.Data.Finset.Basic",
+      "Mathlib.Topology.MetricSpace.Basic",
+      "Mathlib.Analysis.Convex.Basic"
+    ],
+    "originalContributions": [
+      "Point/PointConfig: type aliases for EuclideanSpace ℝ (Fin 2) and Finset Point",
+      "distanceSet/distanceMultiset: distance set and multiset from Finset.product",
+      "distanceMultiplicity/unorderedMultiplicity: ordered and unordered pair counts",
+      "sum_multiplicities: fully proved ∑ f(u) = C(n,2) by Aristotle (no sorry)",
+      "sumSquaredMultiplicities/countEqualDistancePairs: key quantity and quadruple formulation",
+      "InConvexPosition: no point in convex hull of rest (convexHull ℝ)",
+      "NoThreeCollinear: no three points collinear (Collinear ℝ)",
+      "fishburn_theorem/fishburn_asymptotic: ∑ f(u)² ≤ C·n³ (axiomatized)",
+      "lefmann_theile_theorem: O(n³) under no-three-collinear (axiomatized)",
+      "regularNGon: unit circle construction via cos/sin",
+      "ErdosFishburnConjecture: regular n-gon maximizes ∑ f(u)²",
+      "convex_distinct_distances/convex_max_multiplicity/convex_unit_distance: related bounds"
+    ]
   },
   "overview": {
-    "historicalContext": "This $44 Erdős problem was solved by Fishburn. Lefmann and Theile (1995) strengthened it to work under the weaker 'no three collinear' condition instead of convexity. Erdős and Fishburn conjectured that the regular n-gon maximizes ∑ f(u)². Related to OEIS sequence A387858.",
-    "problemStatement": "Suppose n points in ℝ² form the vertices of a convex polygon. Let f(u) count pairs at distance u. Prove that ∑ f(u)² = O(n³). Note: trivially ∑ f(u) = C(n,2).",
-    "proofStrategy": "We formalize point configurations, distance multiplicities, and the sum of squares. The main theorem (Fishburn) states ∑ f(u)² ≤ C·n³. Lefmann-Theile strengthens this to 'no three collinear'. We also formalize the regular n-gon and the Erdős-Fishburn extremal conjecture.",
+    "historicalContext": "Erdős posed this $44 prize problem asking whether $\\sum f(u_i)^2 = O(n^3)$ for $n$ points in convex position, where $f(u)$ counts pairs at distance $u$. The question connects to the broader study of distance distributions in discrete geometry. Fishburn resolved it affirmatively, establishing the cubic upper bound. Lefmann and Theile (1995) strengthened the result by proving the same bound under the weaker assumption that no three points are collinear — a strict generalization since convex position implies no-three-collinear but not conversely. The trivial identity $\\sum f(u) = \\binom{n}{2}$ means the problem asks about the 'concentration' of distances: by Cauchy-Schwarz, $\\sum f(u)^2 \\geq \\binom{n}{2}^2 / |d(P)|$, so the $O(n^3)$ bound constrains how clustered the distance distribution can be. Erdős and Fishburn conjectured that the regular $n$-gon maximizes $\\sum f(u)^2$ among all convex $n$-gons for large $n$, verified computationally for $n \\leq 10$ (OEIS A387858). The formalization includes an Aristotle-proved theorem ($\\sum f(u) = \\binom{n}{2}$) alongside 12 axiomatized results.",
+    "problemStatement": "Suppose $n$ points in $\\mathbb{R}^2$ form the vertices of a convex polygon. Let $f(u)$ count the number of pairs at distance $u$. Prove that $\\sum_u f(u)^2 = O(n^3)$. Note: trivially $\\sum f(u) = \\binom{n}{2}$.",
+    "proofStrategy": "The formalization defines point configurations in $\\mathbb{R}^2$ via `EuclideanSpace ℝ (Fin 2)`, distance multiplicities via `Finset.product` and `Finset.filter`, and the sum of squared multiplicities as the central quantity. Convex position uses `convexHull ℝ`, and the no-three-collinear condition uses `Collinear ℝ`. The main theorems (Fishburn, Lefmann-Theile, regular $n$-gon bounds) are axiomatized. The sum-of-multiplicities identity $\\sum f(u) = \\binom{n}{2}$ is fully proved by Aristotle via a double-counting argument with an involution-based evenness proof.",
     "keyInsights": [
-      "Trivial: ∑ f(u) = C(n,2) (total pairs)",
-      "Fishburn: ∑ f(u)² ≤ C·n³ for convex polygons",
-      "Lefmann-Theile (1995): Same bound under 'no three collinear'",
-      "Regular n-gon achieves Θ(n³), conjectured to be maximum",
-      "Equivalent to counting quadruples with equal distances"
+      "**Double counting gives $\\sum f(u) = \\binom{n}{2}$**: Each unordered pair $(p,q)$ has exactly one distance, so the multiplicities partition $\\binom{n}{2}$ pairs. The Lean proof by Aristotle establishes this via `Finset.sum_image'` and an involution argument for evenness.",
+      "**Quadruple interpretation**: $\\sum f(u)^2$ equals (up to factor 4) the count of quadruples $(p,q,r,s)$ with $d(p,q) = d(r,s)$. This reformulation connects to incidence geometry: each equal-distance quadruple corresponds to an incidence between a distance value and two pairs.",
+      "**Cauchy-Schwarz lower bound**: By Cauchy-Schwarz, $\\sum f(u)^2 \\geq (\\sum f(u))^2 / |d(P)| = \\binom{n}{2}^2 / |d(P)|$. Since $|d(P)| \\leq \\lfloor n/2 \\rfloor + 1$ for convex $n$-gons (Altman), this gives $\\sum f(u)^2 \\geq \\Omega(n^3)$.",
+      "**Regular $n$-gon achieves $\\Theta(n^3)$**: The $\\lfloor n/2 \\rfloor$ distinct distances in a regular $n$-gon each have multiplicity $n$, giving $\\sum f(u)^2 \\approx n^2 \\cdot n/2 = \\Theta(n^3)$. This shows Fishburn's bound is tight.",
+      "**Lefmann-Theile weakens the hypothesis**: The $O(n^3)$ bound holds even without convexity — it suffices that no three points are collinear. This suggests the distance clustering phenomenon is controlled by general position rather than convexity per se."
     ]
   },
   "sections": [
     {
       "id": "point-config",
       "title": "Point Configurations",
-      "summary": "Points in ℝ², distances, and distance sets",
+      "summary": "Defines `Point := EuclideanSpace ℝ (Fin 2)`, `PointConfig := Finset Point`, `dist'` wrapping `dist`, `distanceSet` as positive pairwise distances, and `distanceMultiset` with repetitions.",
       "startLine": 35,
       "endLine": 52
     },
     {
       "id": "multiplicity",
       "title": "Distance Multiplicity",
-      "summary": "f(u) = count of pairs at distance u",
+      "summary": "Defines `distanceMultiplicity P u` (ordered pairs) and `unorderedMultiplicity P u` (half of ordered). Proves `sum_multiplicities`: $\\sum f(u) = \\binom{n}{2}$ via Aristotle (no sorry).",
       "startLine": 54,
       "endLine": 67
     },
     {
       "id": "sum-squared",
       "title": "Sum of Squared Multiplicities",
-      "summary": "The key quantity ∑ f(u)² and equivalent formulations",
+      "summary": "Defines `sumSquaredMultiplicities P = ∑ f(u)²` and `countEqualDistancePairs P` counting quadruples with equal distances. States `squared_sum_eq_count`: $4 \\sum f(u)^2 = |\\{(p,q,r,s) : d(p,q) = d(r,s)\\}|$ (sorry).",
       "startLine": 69,
       "endLine": 83
     },
     {
       "id": "convex-position",
       "title": "Convex Position",
-      "summary": "Definition and relation to 'no three collinear'",
+      "summary": "Defines `InConvexPosition P` (no point in convex hull of rest) and `NoThreeCollinear P` (no three collinear). States `convex_implies_no_collinear` (sorry).",
       "startLine": 85,
       "endLine": 100
     },
     {
       "id": "fishburn",
       "title": "Fishburn's Theorem",
-      "summary": "The main O(n³) bound for convex polygons",
+      "summary": "States `fishburn_theorem`: $\\exists C > 0,\\, \\sum f(u)^2 \\leq C n^3$ for convex polygons (sorry). States `fishburn_asymptotic`: constant approaches $1 + \\varepsilon$ for large $n$ (sorry).",
       "startLine": 102,
       "endLine": 114
     },
     {
       "id": "lefmann-theile",
       "title": "Lefmann-Theile Strengthening",
-      "summary": "Bound under weaker 'no three collinear' condition",
+      "summary": "States `lefmann_theile_theorem`: $O(n^3)$ bound under weaker `NoThreeCollinear` condition (sorry).",
       "startLine": 116,
       "endLine": 122
     },
     {
       "id": "regular-ngon",
       "title": "Regular n-gon",
-      "summary": "Construction and Θ(n³) lower bound",
+      "summary": "Constructs `regularNGon n` via $\\cos/\\sin$ on the unit circle. States `regular_ngon_convex` (sorry) and `regular_ngon_cubic`: $\\Theta(n^3)$ (sorry).",
       "startLine": 124,
       "endLine": 145
     },
     {
       "id": "extremal",
       "title": "Erdős-Fishburn Conjecture",
-      "summary": "Regular n-gon maximizes ∑ f(u)²",
+      "summary": "Defines `ErdosFishburnConjecture : Prop` — regular $n$-gon maximizes $\\sum f(u)^2$ for large $n$. States `conjecture_small_cases` for $n \\leq 10$ (sorry).",
       "startLine": 147,
       "endLine": 158
     },
     {
       "id": "connections",
       "title": "Connections",
-      "summary": "Unit distance problem and related quantities",
+      "summary": "Defines `numDistinctDistances`, `maxMultiplicity`, `unitDistanceCount`. States convex bounds: $|d(P)| \\leq \\lfloor n/2 \\rfloor + 1$, $\\max f(u) \\leq 2n$, $f(1) \\leq 2n - 2$ (all sorry).",
       "startLine": 160,
       "endLine": 189
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #94, a $44 problem solved by Fishburn. The bound ∑ f(u)² = O(n³) was proved for convex polygons and strengthened by Lefmann-Theile to 'no three collinear'. The Erdős-Fishburn conjecture that the regular n-gon is extremal remains open.",
-    "implications": "This result bounds the 'clustering' of distances in convex configurations. It has connections to distinct distances problems and incidence geometry. The quadruple-counting interpretation links to algebraic techniques.",
+    "summary": "This formalization captures Erdős Problem #94, a $44 prize problem solved by Fishburn. The bound $\\sum f(u)^2 = O(n^3)$ is proved for convex polygons and strengthened by Lefmann-Theile to 'no three collinear'. The regular $n$-gon achieves $\\Theta(n^3)$. One theorem ($\\sum f(u) = \\binom{n}{2}$) is fully proved by Aristotle; the remaining 12 results are axiomatized.",
+    "implications": "The cubic bound constrains the clustering of distances in convex configurations. Combined with the Cauchy-Schwarz lower bound and Altman's distinct distance count, it pins down $\\sum f(u)^2 = \\Theta(n^3)$ for convex polygons. The quadruple-counting interpretation connects to incidence geometry and algebraic techniques. The Erdős-Fishburn conjecture, if true, would identify the regular polygon as the unique extremal configuration.",
     "openQuestions": [
-      "Does the regular n-gon maximize ∑ f(u)² for large n?",
-      "What is the exact constant C in Fishburn's theorem?",
-      "Can the bound be improved for specific classes of convex polygons?"
+      "Does the regular $n$-gon maximize $\\sum f(u)^2$ among all convex $n$-gons for sufficiently large $n$ (Erdős-Fishburn conjecture)?",
+      "What is the exact asymptotic constant: is $\\sum f(u)^2 \\sim c \\cdot n^3$ for convex $n$-gons, and what is $c$?",
+      "Can Fishburn's bound be improved to $\\sum f(u)^2 \\leq n^3 / 2 + o(n^3)$ for convex position?",
+      "Does the $O(n^3)$ bound extend to higher dimensions: what is $\\sum f(u)^2$ for $n$ points on a convex surface in $\\mathbb{R}^d$?",
+      "What is the exact value of $\\sum f(u)^2$ for the regular $n$-gon as a function of $n$ (connecting to OEIS A387858)?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-86",
+    "erdos-146",
+    "erdos-533",
+    "erdos-365"
+  ]
 }

--- a/src/data/proofs/erdos-954/annotations.json
+++ b/src/data/proofs/erdos-954/annotations.json
@@ -1,56 +1,142 @@
 [
   {
-    "id": "rep-count",
+    "id": "rep-count-definition",
     "proofId": "erdos-954",
     "range": { "startLine": 28, "endLine": 31 },
     "type": "definition",
-    "title": "Representation Count",
-    "content": "R(n) counts pairs (i,j) with i ≤ j, j ≥ 1, and a(i) + a(j) ≤ n. This is the cumulative sumset counting function, not individual representations.",
-    "significance": "high"
+    "title": "Representation Count $R_k(n)$",
+    "content": "The cumulative representation count $R_k(n) = |\\{(i,j) : 0 \\leq i \\leq j \\leq k,\\, j \\geq 1,\\, a_i + a_j \\leq n\\}|$ counts ordered pairs from the first $k+1$ elements whose sum is at most $n$. Implemented as a Finset sum over $j \\in [1,k]$ of filtered subsets. This is a cumulative counting function, not individual representations at $n$.",
+    "significance": "key",
+    "mathContext": {
+      "formalStatement": "def repCount (a : ℕ → ℕ) (k : ℕ) (n : ℕ) : ℕ :=\n  (Finset.Icc 1 k).sum fun j =>\n    (Finset.Icc 0 j).filter (fun i => a i + a j ≤ n) |>.card",
+      "keyFormulas": [
+        "$R_k(n) = |\\{(i,j) : 0 \\leq i \\leq j \\leq k,\\, j \\geq 1,\\, a_i + a_j \\leq n\\}|$"
+      ]
+    },
+    "relatedConcepts": ["sumset counting", "representation function", "additive number theory"],
+    "prerequisites": ["Finset.Icc", "Finset.sum", "Finset.filter"]
   },
   {
-    "id": "greedy-condition",
+    "id": "greedy-construction",
     "proofId": "erdos-954",
-    "range": { "startLine": 35, "endLine": 38 },
+    "range": { "startLine": 35, "endLine": 42 },
     "type": "definition",
-    "title": "Greedy Selection Rule",
-    "content": "a(k+1) is the smallest n with R(n) < n. This makes the sequence grow as slowly as possible while keeping the representation count under control.",
-    "significance": "high"
+    "title": "Greedy Selection Rule and Rosen Sequence",
+    "content": "The greedy condition `IsGreedyNext a k` requires $a_{k+1}$ to be the smallest $n$ with $R_k(n) < n$, and that all $m$ between $a_k$ and $a_{k+1}$ satisfy $R_k(m) \\geq m$. `IsRosenSequence a` combines $a_0 = 0$, $a_1 = 1$, strict monotonicity, and the greedy property at every step $k \\geq 1$.",
+    "significance": "key",
+    "mathContext": {
+      "formalStatement": "def IsGreedyNext (a : ℕ → ℕ) (k : ℕ) : Prop :=\n  repCount a k (a (k + 1)) < a (k + 1) ∧\n  ∀ m, a k < m → m < a (k + 1) → repCount a k m ≥ m\ndef IsRosenSequence (a : ℕ → ℕ) : Prop :=\n  a 0 = 0 ∧ a 1 = 1 ∧ StrictMono a ∧ ∀ k ≥ 1, IsGreedyNext a k",
+      "keyFormulas": [
+        "$a_{k+1} = \\min\\{n > a_k : R_k(n) < n\\}$"
+      ]
+    },
+    "relatedConcepts": ["greedy algorithm", "minimality condition", "additive basis"],
+    "prerequisites": ["StrictMono", "representation count"]
   },
   {
-    "id": "rosen-sequence",
+    "id": "computable-construction",
     "proofId": "erdos-954",
-    "range": { "startLine": 41, "endLine": 43 },
+    "range": { "startLine": 43, "endLine": 80 },
     "type": "definition",
-    "title": "Rosen Sequence",
-    "content": "The full greedy sequence: a(0)=0, a(1)=1, strictly increasing, satisfying the greedy condition at every step. Begins 0,1,3,5,9,13,17,24,31,38,45,...",
-    "significance": "high"
+    "title": "Computable Sequence Construction",
+    "content": "A List-based implementation of the greedy algorithm. `repCountList xs n` computes the representation count for a list, `findNextRosen xs last` searches for the next greedy element with bounded fuel, and `buildRosen n` constructs the first $n+1$ terms. The `rosenTerm k` function extracts the $k$-th term.",
+    "significance": "supporting",
+    "mathContext": {
+      "formalStatement": "def repCountList (xs : List ℕ) (n : ℕ) : ℕ\ndef findNextRosen (xs : List ℕ) (last : ℕ) : ℕ → ℕ\ndef buildRosen : ℕ → List ℕ × ℕ\ndef rosenTerm (k : ℕ) : ℕ",
+      "keyFormulas": [
+        "$(a_k)_{k=0}^{10} = (0, 1, 3, 5, 9, 13, 17, 24, 31, 38, 45)$"
+      ]
+    },
+    "relatedConcepts": ["List-based computation", "fuel-bounded recursion"],
+    "prerequisites": ["List.foldl", "List.countP", "List indexing"]
   },
   {
-    "id": "weak-conjecture",
+    "id": "verified-initial-values",
     "proofId": "erdos-954",
-    "range": { "startLine": 72, "endLine": 75 },
+    "range": { "startLine": 85, "endLine": 95 },
+    "type": "theorem",
+    "title": "Verified Initial Values (OEIS A390642)",
+    "content": "The first 11 terms of the Rosen sequence $(0, 1, 3, 5, 9, 13, 17, 24, 31, 38, 45)$ are verified by `native_decide`. These match OEIS A390642. The gaps between consecutive terms grow: $1, 2, 2, 4, 4, 4, 7, 7, 7, 7$, suggesting roughly $\\sqrt{k}$-type growth in spacing.",
+    "significance": "supporting",
+    "mathContext": {
+      "formalStatement": "theorem rosen_term_0 : rosenTerm 0 = 0 := by native_decide\ntheorem rosen_term_1 : rosenTerm 1 = 1 := by native_decide\n-- ... through rosen_term_10 : rosenTerm 10 = 45",
+      "leanTactics": ["native_decide"]
+    },
+    "relatedConcepts": ["OEIS A390642", "computational verification"],
+    "prerequisites": ["Decidable computation", "native_decide"]
+  },
+  {
+    "id": "basic-properties-proved",
+    "proofId": "erdos-954",
+    "range": { "startLine": 99, "endLine": 131 },
+    "type": "theorem",
+    "title": "Basic Structural Properties (Proved)",
+    "content": "Four theorems proved directly from the greedy definition (no sorry): (1) `repcount_below_at_elements`: $R_k(a_{k+1}) < a_{k+1}$ at each new element. (2) `repcount_above_between`: $R_k(m) \\geq m$ for $a_k < m < a_{k+1}$. (3) `rosen_strictMono`: strict monotonicity of the sequence. (4) `rosen_growth`: $a_k \\geq k$ by induction. These establish the basic structure of the greedy construction.",
+    "significance": "key",
+    "mathContext": {
+      "formalStatement": "theorem repcount_below_at_elements (a : ℕ → ℕ) (h : IsRosenSequence a) (k : ℕ) (hk : 1 ≤ k) :\n    repCount a k (a (k + 1)) < a (k + 1)\ntheorem rosen_growth (a : ℕ → ℕ) (h : IsRosenSequence a) (k : ℕ) :\n    a k ≥ k",
+      "keyFormulas": [
+        "$R_k(a_{k+1}) < a_{k+1}$",
+        "$R_k(m) \\geq m$ for $a_k < m < a_{k+1}$",
+        "$a_k \\geq k$"
+      ],
+      "leanTactics": ["omega", "induction"]
+    },
+    "relatedConcepts": ["greedy algorithm correctness", "growth rate"],
+    "prerequisites": ["IsRosenSequence", "StrictMono"]
+  },
+  {
+    "id": "main-conjectures",
+    "proofId": "erdos-954",
+    "range": { "startLine": 133, "endLine": 151 },
     "type": "conjecture",
-    "title": "Weak Conjecture: R(x) = (1+o(1))x",
-    "content": "Erdős and Rosen could not prove even this weak form: that the representation count is asymptotic to x. This would mean the greedy construction achieves near-optimal density.",
-    "significance": "high"
+    "title": "Main Conjectures: Weak and Strong",
+    "content": "The `fullRepCount` extends the representation count over the infinite sequence. **Weak conjecture** (axiom): $R(x) \\leq (1+\\varepsilon)x$ for large $x$, i.e., $R(x) = (1+o(1))x$. Even this is unproved. **Strong conjecture** (axiom): $|R(x) - x| \\leq C x^{1/4} \\log x$. The exponent $1/4$ comes from analogy with B$_2$ sequences where $R(x) \\sim \\sqrt{x}$ and optimal error is $\\sim x^{1/4}$.",
+    "significance": "key",
+    "mathContext": {
+      "formalStatement": "axiom erdos_954_weak_conjecture (a : ℕ → ℕ) (h : IsRosenSequence a) :\n    ∀ ε > 0, ∃ N, ∀ x ≥ N, (fullRepCount a x : ℤ) ≤ ((1 + ε) * x : ℤ)\naxiom erdos_954_strong_conjecture (a : ℕ → ℕ) (h : IsRosenSequence a) :\n    ∃ C : ℝ, ∀ x : ℕ, 1 ≤ x →\n      |(fullRepCount a x : ℤ) - (x : ℤ)| ≤ C * (x : ℝ) ^ (1/4 : ℝ) * Real.log x",
+      "keyFormulas": [
+        "$R(x) = (1 + o(1))x$ (weak)",
+        "$|R(x) - x| = O(x^{1/4 + o(1)})$ (strong)"
+      ]
+    },
+    "relatedConcepts": ["asymptotic analysis", "error term estimates", "open Erdős problem"],
+    "prerequisites": ["fullRepCount", "IsRosenSequence"]
   },
   {
-    "id": "strong-conjecture",
+    "id": "sidon-connection",
     "proofId": "erdos-954",
-    "range": { "startLine": 78, "endLine": 81 },
-    "type": "conjecture",
-    "title": "Strong Conjecture: O(x^{1/4+o(1)}) Error",
-    "content": "The error |R(x) - x| should be O(x^{1/4+o(1)}). The exponent 1/4 comes from analogy with B₂ sequences where R(x) ~ √x and the optimal error is √x^{1/2} = x^{1/4}.",
-    "significance": "high"
+    "range": { "startLine": 153, "endLine": 172 },
+    "type": "concept",
+    "title": "Connection to Sidon Sets and Erdős-Turán Conjecture",
+    "content": "A B$_2$ (Sidon) sequence requires all pairwise sums to be distinct, giving density $\\sim \\sqrt{x}$. Rosen's sequence relaxes this: it allows repeated sums but controls their cumulative count, achieving density $\\sim x$. The axiom `rosen_not_b2` asserts the Rosen sequence is not B$_2$. The Erdős-Turán conjecture (Problem #28) states every B$_2$ sequence has unbounded representation function; Rosen's construction is related but distinct since it controls cumulative rather than individual representations.",
+    "significance": "supporting",
+    "mathContext": {
+      "formalStatement": "def IsB2Sequence (a : ℕ → ℕ) (k : ℕ) : Prop :=\n  ∀ i₁ j₁ i₂ j₂, i₁ ≤ j₁ → j₁ ≤ k → i₂ ≤ j₂ → j₂ ≤ k →\n    a i₁ + a j₁ = a i₂ + a j₂ → (i₁ = i₂ ∧ j₁ = j₂)\naxiom rosen_not_b2 (a : ℕ → ℕ) (h : IsRosenSequence a) : ∃ k, ¬IsB2Sequence a k",
+      "keyFormulas": [
+        "B$_2$: $a_i + a_j = a_k + a_l \\Rightarrow \\{i,j\\} = \\{k,l\\}$",
+        "Rosen: $R(x) < x$ at elements, $R(x) \\geq x$ between"
+      ]
+    },
+    "relatedConcepts": ["Sidon set", "B₂ sequence", "Erdős-Turán conjecture", "additive basis"],
+    "prerequisites": ["IsB2Sequence", "representation function"]
   },
   {
-    "id": "b2-connection",
+    "id": "repcount-monotonicity",
     "proofId": "erdos-954",
-    "range": { "startLine": 86, "endLine": 99 },
-    "type": "note",
-    "title": "Connection to Sidon Sets",
-    "content": "A B₂ (Sidon) sequence requires all pairwise sums distinct, giving R(x) ~ √x. Rosen's sequence relaxes this to R(x) ~ x, allowing much denser sequences. Related to Erdős–Turán conjecture (Problem #28).",
-    "significance": "medium"
+    "range": { "startLine": 174, "endLine": 187 },
+    "type": "theorem",
+    "title": "Representation Count Monotonicity in $k$ (Proved)",
+    "content": "Proved in Lean: $R_k(n) \\leq R_{k+1}(n)$, i.e., adding more sequence elements can only increase the representation count. The proof uses `Finset.sum_le_sum_of_subset_of_nonneg` since $[1,k] \\subseteq [1,k+1]$. This is a fundamental monotonicity property of the greedy construction.",
+    "significance": "supporting",
+    "mathContext": {
+      "formalStatement": "theorem repCount_mono_k (a : ℕ → ℕ) (k n : ℕ) :\n    repCount a k n ≤ repCount a (k + 1) n",
+      "keyFormulas": [
+        "$R_k(n) \\leq R_{k+1}(n)$"
+      ],
+      "leanTactics": ["Finset.sum_le_sum_of_subset_of_nonneg", "omega"]
+    },
+    "relatedConcepts": ["monotonicity", "subset sum inequality"],
+    "prerequisites": ["repCount", "Finset.Icc subset"]
   }
 ]

--- a/src/data/proofs/erdos-954/meta.json
+++ b/src/data/proofs/erdos-954/meta.json
@@ -4,26 +4,64 @@
   "slug": "erdos-954",
   "description": "Define a greedy sequence 0 = a₀ < a₁ < ⋯ where a_{k+1} is minimal with representation count < a_{k+1}. Is R(x) = x + O(x^{1/4+o(1)})? Even R(x) ≤ (1+o(1))x is open. Status: OPEN.",
   "meta": {
-    "erdosNumber": 954,
+    "author": "Paul Erdős, Rosen",
+    "sourceUrl": "https://erdosproblems.com/954",
+    "date": "1977",
     "status": "formalized",
+    "proofRepoPath": "Proofs/Erdos954Problem.lean",
+    "leanFile": "Proofs/Erdos954Problem.lean",
     "tags": [
       "erdos",
       "number-theory",
       "additive-combinatorics",
       "greedy-algorithms",
       "representation-functions",
-      "open"
+      "open-problem",
+      "sidon-sets"
+    ],
+    "badge": "formalized",
+    "sorries": 0,
+    "erdosNumber": 954,
+    "erdosUrl": "https://erdosproblems.com/954",
+    "erdosProblemStatus": "open",
+    "mathlibDependencies": [
+      "Mathlib.Data.Finset.Card",
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.Order.Filter.Basic"
+    ],
+    "originalContributions": [
+      "repCount: cumulative representation count R_k(n) via Finset.Icc sums",
+      "IsGreedyNext/IsRosenSequence: greedy condition and full sequence predicate",
+      "repCountList/findNextRosen/buildRosen/rosenTerm: computable List-based construction",
+      "rosen_term_0 through rosen_term_10: 11 initial values verified by native_decide",
+      "repcount_below_at_elements: R_k(a_{k+1}) < a_{k+1} (proved from definition)",
+      "repcount_above_between: R_k(m) ≥ m between consecutive elements (proved)",
+      "rosen_strictMono: strict monotonicity (proved from definition)",
+      "rosen_growth: a_k ≥ k by induction (proved)",
+      "repcount_lower_bound_pre_element: R_k(a_{k+1}-1) ≥ a_{k+1}-1 (proved)",
+      "fullRepCount: infinite-sequence representation count",
+      "erdos_954_weak/strong_conjecture: both open conjectures as axioms",
+      "IsB2Sequence: Sidon set definition for connection to Problem #28",
+      "repCount_mono_k: monotonicity R_k(n) ≤ R_{k+1}(n) (proved)"
     ],
     "references": [
       "Erdős (1977): original problem (Er77c, p.71)",
       "Rosen: greedy sequence construction",
       "OEIS A390642: the Rosen sequence",
       "https://erdosproblems.com/954"
-    ],
-    "leanFile": "Proofs/Erdos954Problem.lean",
-    "sorries": 0,
-    "sourceUrl": "https://erdosproblems.com/954",
-    "erdosUrl": "https://erdosproblems.com/954"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős posed this problem in his 1977 paper (Er77c, p.71), studying a greedy additive sequence construction due to Rosen. The sequence $0 = a_0 < a_1 < a_2 < \\cdots$ is built by choosing $a_{k+1}$ as the smallest integer $n$ where the cumulative representation count $R_k(n) = |\\{(i,j) : i \\leq j,\\, j \\geq 1,\\, a_i + a_j \\leq n\\}|$ drops below $n$. This greedy rule creates a sequence that is as dense as possible while keeping the representation count under control. The construction mirrors the philosophy behind Sidon (B$_2$) sets, where all pairwise sums must be distinct, but relaxes the uniqueness condition to a cumulative density condition. While B$_2$ sets have density $\\sim \\sqrt{x}$, the Rosen sequence aims for density $\\sim x$. Erdős and Rosen could not prove even the weak conjecture that $R(x) = (1+o(1))x$, let alone the strong conjecture with $x^{1/4+o(1)}$ error. The exponent $1/4$ comes from analogy with optimal B$_2$ error terms. The sequence begins $(0, 1, 3, 5, 9, 13, 17, 24, 31, 38, 45, \\ldots)$ and appears as OEIS A390642. The formalization is notable for combining computable verification (11 terms via `native_decide`) with 5 genuinely proved structural theorems and 0 sorries.",
+    "problemStatement": "Let $0 = a_0 < a_1 < a_2 < \\cdots$ where $a_{k+1}$ is the smallest $n$ with $R_k(n) < n$, where $R_k(n)$ counts pairs $(i,j)$ with $i \\leq j$, $j \\geq 1$, and $a_i + a_j \\leq n$. Is $R(x) = x + O(x^{1/4+o(1)})$? Even $R(x) \\leq (1+o(1))x$ is open.",
+    "proofStrategy": "The formalization defines the representation count `repCount` via `Finset.Icc` sums, the greedy condition `IsGreedyNext`, and the full sequence predicate `IsRosenSequence`. A computable List-based construction (`buildRosen`) generates terms verified against OEIS A390642 by `native_decide`. Five structural theorems are proved from the greedy definition: representation count bounds at and between elements, strict monotonicity, linear growth, and monotonicity in $k$. Both the weak and strong conjectures are axiomatized, along with the connection to B$_2$ sequences and the Erdős-Turán conjecture.",
+    "keyInsights": [
+      "**Greedy duality**: By construction, $R_k(a_{k+1}) < a_{k+1}$ (the count drops below the threshold at each new element) while $R_k(m) \\geq m$ for all $m$ between consecutive elements. This oscillation characterizes the sequence completely.",
+      "**Computable verification**: The first 11 terms $(0, 1, 3, 5, 9, 13, 17, 24, 31, 38, 45)$ are generated by a List-based algorithm and verified by `native_decide`, providing concrete evidence for the conjectures. The gap pattern $1, 2, 2, 4, 4, 4, 7, 7, 7, 7$ suggests $\\sqrt{k}$-type growth.",
+      "**Relaxation of Sidon condition**: B$_2$ (Sidon) sequences require all pairwise sums distinct, giving density $\\sim \\sqrt{x}$. Rosen's sequence allows repeated sums but controls cumulative count, potentially achieving density $\\sim x$ — a quadratic improvement.",
+      "**The $x^{1/4}$ exponent**: For B$_2$ sequences, $R(x) \\sim \\sqrt{x}$ and the optimal error is $O(x^{1/4})$. Scaling to Rosen's setting where $R(x) \\sim x$, the analogous error is $O(x^{1/4})$ — the same exponent but relative to a much larger main term.",
+      "**Five proved theorems with 0 sorries**: All structural properties (monotonicity of $R_k$ in $k$, growth $a_k \\geq k$, greedy bounds) are fully proved. Only the open conjectures and the non-B$_2$ claim are axiomatized."
+    ]
   },
   "sections": [
     {
@@ -31,57 +69,66 @@
       "title": "Core Definitions",
       "startLine": 25,
       "endLine": 44,
-      "summary": "Define repCount, the greedy condition IsGreedyNext, and IsRosenSequence."
+      "summary": "Defines `repCount a k n` as the cumulative representation count via `Finset.Icc` sums, `IsGreedyNext a k` as the minimality condition $a_{k+1} = \\min\\{n : R_k(n) < n\\}$, and `IsRosenSequence a` combining initial values, strict monotonicity, and the greedy property."
+    },
+    {
+      "id": "computable",
+      "title": "Computable Construction",
+      "startLine": 43,
+      "endLine": 80,
+      "summary": "List-based implementation: `repCountList` computes $R_k(n)$, `findNextRosen` searches with bounded fuel, `buildRosen` constructs terms, `rosenTerm` extracts the $k$-th value."
     },
     {
       "id": "initial-values",
-      "title": "Known Initial Values",
-      "startLine": 46,
-      "endLine": 51,
-      "summary": "The first 11 values of the Rosen sequence from OEIS A390642."
+      "title": "Verified Initial Values",
+      "startLine": 81,
+      "endLine": 95,
+      "summary": "Eleven theorems `rosen_term_0` through `rosen_term_10` verify $(0, 1, 3, 5, 9, 13, 17, 24, 31, 38, 45)$ via `native_decide`, matching OEIS A390642."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "startLine": 53,
-      "endLine": 63,
-      "summary": "By construction: R(a_{k+1}) < a_{k+1} and R(m) ≥ m between consecutive elements."
+      "startLine": 97,
+      "endLine": 131,
+      "summary": "Five proved theorems: $R_k(a_{k+1}) < a_{k+1}$, $R_k(m) \\geq m$ between elements, strict monotonicity, $a_k \\geq k$ by induction, and $R_k(a_{k+1}-1) \\geq a_{k+1}-1$ from the greedy gap."
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
-      "startLine": 65,
-      "endLine": 82,
-      "summary": "Weak conjecture R(x) = (1+o(1))x and strong conjecture R(x) = x + O(x^{1/4+o(1)})."
+      "startLine": 133,
+      "endLine": 151,
+      "summary": "Defines `fullRepCount` for the infinite sequence. States weak conjecture $R(x) = (1+o(1))x$ and strong conjecture $|R(x) - x| = O(x^{1/4} \\log x)$ as axioms."
     },
     {
       "id": "sidon-connection",
       "title": "Connection to Sidon Sets",
-      "startLine": 84,
-      "endLine": 100,
-      "summary": "Rosen's sequence as a relaxation of B₂ sequences; connection to Erdős–Turán conjecture."
+      "startLine": 153,
+      "endLine": 172,
+      "summary": "Defines `IsB2Sequence` for Sidon sets. Axiomatizes `rosen_not_b2` and `erdos_turan_context` (Erdős-Turán conjecture, Problem #28)."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Representation Count Monotonicity",
+      "startLine": 174,
+      "endLine": 187,
+      "summary": "Proves `repCount_mono_k`: $R_k(n) \\leq R_{k+1}(n)$ via `Finset.sum_le_sum_of_subset_of_nonneg`."
     }
   ],
-  "overview": {
-    "historicalContext": "Rosen constructed this greedy sequence and studied it with Erdős in the 1970s. The construction mirrors the philosophy behind Sidon sets (B₂ sequences) but relaxes the uniqueness condition to a cumulative count condition. The sequence appears as OEIS A390642.",
-    "problemStatement": "Let 0 = a₀ < a₁ < a₂ < ⋯ where a_{k+1} is the smallest n with repCount(n) < n. Is R(x) = x + O(x^{1/4+o(1)})?",
-    "proofStrategy": "We formalize the greedy construction, state both the weak conjecture R(x) = (1+o(1))x and the strong conjecture with x^{1/4} error, and connect to B₂ sequences and the Erdős–Turán conjecture.",
-    "keyInsights": [
-      "The greedy rule ensures R(a_{k+1}) < a_{k+1} while R(m) ≥ m between consecutive elements",
-      "The weak conjecture R(x) ≤ (1+o(1))x remains open",
-      "The x^{1/4} error term parallels B₂ sequence theory where R(x) ~ √x",
-      "The Rosen sequence is not B₂ — it allows repeated sums but controls their density",
-      "The problem cannot be resolved by finite computation"
+  "conclusion": {
+    "summary": "Erdős Problem #954 formalizes Rosen's greedy additive sequence, an open problem from 1977. The formalization achieves 0 sorries with 5 genuinely proved structural theorems, 11 computationally verified initial values, and 3 axioms for the open conjectures and structural claims. The computable construction allows verification against OEIS A390642.",
+    "implications": "A resolution of even the weak conjecture would illuminate the fundamental limits of greedy additive constructions and the tradeoff between sequence density and representation control. The connection to Sidon sets suggests that understanding Rosen's sequence could inform the broader theory of additive bases and the Erdős-Turán conjecture.",
+    "openQuestions": [
+      "Is $R(x) \\leq (1+o(1))x$ (weak conjecture)? Erdős and Rosen could not prove this.",
+      "Is $|R(x) - x| = O(x^{1/4+o(1)})$ (strong conjecture)?",
+      "What is the density of the Rosen sequence: is $a_k \\sim ck$ for some constant $c$?",
+      "Can the greedy construction be modified (e.g., different threshold) to achieve provably better error bounds?",
+      "Is the Rosen sequence the unique sequence satisfying the greedy property, or are there ties in the minimization?"
     ]
   },
-  "conclusion": {
-    "summary": "Erdős Problem #954 asks about the representation count of Rosen's greedy additive sequence. Even the weak estimate R(x) = (1+o(1))x is unproven, let alone the conjectured x^{1/4+o(1)} error bound. The problem remains open.",
-    "implications": "A resolution would illuminate the boundary between Sidon-type uniqueness and density-controlled additive constructions. The greedy approach suggests a natural tradeoff between sequence density and representation control.",
-    "openQuestions": [
-      "Is R(x) ≤ (1+o(1))x?",
-      "Is R(x) = x + O(x^{1/4+o(1)})?",
-      "What is the density of the Rosen sequence?",
-      "Can the greedy construction be optimized with a different threshold?"
-    ]
-  }
+  "relatedProofs": [
+    "erdos-28",
+    "erdos-533",
+    "erdos-117",
+    "erdos-839"
+  ]
 }


### PR DESCRIPTION
## Summary
- **erdos-926** (Turán Number of $H_k$): 17→11 annotations with full mathContext, mathlibDependencies (4), originalContributions (12). Deepened historicalContext with Erdős 1971, Füredi 1991, AKS 2003.
- **erdos-94** (Distance Multiplicities in Convex Polygons): 17→10 annotations with full mathContext, mathlibDependencies (4), originalContributions (12). Highlighted Aristotle-proved theorem.
- **erdos-954** (Rosen's Greedy Additive Sequence): 6→8 annotations with full mathContext, mathlibDependencies (3), originalContributions (13). Added badge, date, author. 0 sorries, 5 proved theorems.

## Test plan
- [x] JSON validates (`python3 -c "import json; json.load(open(...))"`)
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)