### PR TITLE
enrich: add leanFile and relatedProofs to erdos-1040

### DIFF
--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -9,6 +9,7 @@
     "date": "",
     "status": "pending",
     "proofRepoPath": "Proofs/Erdos1040Problem.lean",
+    "leanFile": "Proofs/Erdos1040Problem.lean",
     "tags": [
       "complex-analysis",
       "polynomials",
@@ -21,7 +22,8 @@
     "erdosNumber": 1040,
     "erdosUrl": "https://erdosproblems.com/1040",
     "erdosProblemStatus": "open",
-    "relatedProblems": [1039]
+    "relatedProblems": [1039],
+    "relatedProofs": ["erdos-1039"]
   },
   "overview": {
     "historicalContext": "**Erdős-Herzog-Piranian Problem (1958)**\n\nThis problem originates from the 1958 paper \"Metric properties of polynomials\" by Paul Erdős, Fritz Herzog, and George Piranian, published in the Journal d'Analyse Mathématique. The paper studied the geometry of polynomial sublevel sets $\\{z : |f(z)| < 1\\}$ — also known as **polynomial lemniscates** — and their relationship to the distribution of roots.\n\nThe central quantity $\\mu(F)$ measures the smallest possible area of a lemniscate whose roots are constrained to lie in $F$. The **transfinite diameter** (or logarithmic capacity) $\\rho(F)$, introduced by Fekete in 1923 and developed by Szegő, Pólya, and others, measures the 'size' of $F$ from the perspective of potential theory. Fekete proved that $\\rho(F) = \\lim_{n \\to \\infty} d_n(F)$ where $d_n(F)$ is the geometric mean of pairwise distances among optimal $n$-point configurations (Fekete points).\n\n**Key historical milestones**:\n- **1923**: Michael Fekete introduced the transfinite diameter and proved the fundamental limit theorem, establishing the triple equivalence $\\rho(F) = \\text{cap}(F) = \\tau(F)$ (Chebyshev constant)\n- **1924**: Gábor Szegő connected transfinite diameter to conformal mapping radius, showing $\\rho(F) = \\text{cap}(F)$ equals the conformal radius of $\\mathbb{C} \\setminus F$ at infinity\n- **1958**: Erdős, Herzog, and Piranian proved the conjecture for **line segments** (using Chebyshev polynomials $T_n$) and **closed discs** (using roots of unity), and posed the general question\n- **1973**: Erdős and Elisha Netanyahu strengthened the small-diameter result, proving explicit quantitative disc bounds for bounded connected sets with $0 < \\rho(F) < 1$\n\nThe problem connects potential theory to the geometry of polynomial level curves, a topic with roots in the work of Chebyshev (1850s), Bernstein, Walsh, and the classical approximation theory school.",


### PR DESCRIPTION
## Summary
- Add `leanFile` field to erdos-1040 meta.json for gallery integration
- Add `relatedProofs` linking to erdos-1039 (companion problem on inscribed disc radius)
- Entry already had excellent enrichment (28 annotations with full mathContext, 800+ char historicalContext with LaTeX)

## Test plan
- [x] `pnpm annotations:build` passes with no erdos-1040 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)