### PR TITLE
fix: correct enricher type errors in erdos-94 and erdos-954

### DIFF
--- a/src/data/proofs/erdos-94/annotations.json
+++ b/src/data/proofs/erdos-94/annotations.json
@@ -2,176 +2,221 @@
   {
     "id": "point-config-and-distances",
     "proofId": "erdos-94",
-    "range": { "startLine": 54, "endLine": 69 },
+    "range": {
+      "startLine": 54,
+      "endLine": 69
+    },
     "type": "definition",
     "title": "Point Configurations and Distance Sets",
     "content": "Defines a point configuration as a `Finset Point` where `Point = EuclideanSpace ℝ (Fin 2)`. The distance set `distanceSet P` collects all positive pairwise distances, while `distanceMultiset P` records distances with repetition. The distance function `dist'` wraps Mathlib's `dist` for the Euclidean metric.",
     "significance": "supporting",
-    "mathContext": {
-      "formalStatement": "abbrev Point := EuclideanSpace ℝ (Fin 2)\ndef PointConfig := Finset Point\nnoncomputable def distanceSet (P : PointConfig) : Finset ℝ :=\n  (P.product P).image (fun pq => dist' pq.1 pq.2) |>.filter (· > 0)",
-      "keyFormulas": [
-        "$d(P) = \\{\\|p - q\\| : p, q \\in P,\\, p \\neq q\\}$"
-      ]
-    },
-    "relatedConcepts": ["Euclidean distance", "point set", "distance set"],
-    "prerequisites": ["EuclideanSpace", "Finset.product", "metric space"]
+    "mathContext": "abbrev Point := EuclideanSpace ℝ (Fin 2)\ndef PointConfig := Finset Point\nnoncomputable def distanceSet (P : PointConfig) : Finset ℝ :=\n  (P.product P).image (fun pq => dist' pq.1 pq.2) |>.filter (· > 0). Key formulas: $d(P) = \\{\\|p - q\\| : p, q \\in P,\\, p \\neq q\\}$",
+    "relatedConcepts": [
+      "Euclidean distance",
+      "point set",
+      "distance set"
+    ],
+    "prerequisites": [
+      "EuclideanSpace",
+      "Finset.product",
+      "metric space"
+    ]
   },
   {
     "id": "distance-multiplicity",
     "proofId": "erdos-94",
-    "range": { "startLine": 73, "endLine": 79 },
+    "range": {
+      "startLine": 73,
+      "endLine": 79
+    },
     "type": "definition",
     "title": "Distance Multiplicity $f(u)$",
     "content": "The multiplicity $f(u)$ counts ordered pairs at distance $u$ (`distanceMultiplicity`), while `unorderedMultiplicity` divides by 2 for unordered pairs. These functions are the key combinatorial quantities: $f(u) = |\\{(p,q) \\in P^2 : \\|p - q\\| = u,\\, p \\neq q\\}|$.",
     "significance": "key",
-    "mathContext": {
-      "formalStatement": "noncomputable def distanceMultiplicity (P : PointConfig) (u : ℝ) : ℕ :=\n  ((P.product P).filter fun pq => dist' pq.1 pq.2 = u ∧ pq.1 ≠ pq.2).card\nnoncomputable def unorderedMultiplicity (P : PointConfig) (u : ℝ) : ℕ :=\n  distanceMultiplicity P u / 2",
-      "keyFormulas": [
-        "$f(u) = |\\{\\{p, q\\} \\subset P : \\|p - q\\| = u\\}|$"
-      ]
-    },
-    "relatedConcepts": ["distance frequency", "pair counting"],
-    "prerequisites": ["Finset.filter", "ordered vs unordered pairs"]
+    "mathContext": "noncomputable def distanceMultiplicity (P : PointConfig) (u : ℝ) : ℕ :=\n  ((P.product P).filter fun pq => dist' pq.1 pq.2 = u ∧ pq.1 ≠ pq.2).card\nnoncomputable def unorderedMultiplicity (P : PointConfig) (u : ℝ) : ℕ :=\n  distanceMultiplicity P u / 2. Key formulas: $f(u) = |\\{\\{p, q\\} \\subset P : \\|p - q\\| = u\\}|$",
+    "relatedConcepts": [
+      "distance frequency",
+      "pair counting"
+    ],
+    "prerequisites": [
+      "Finset.filter",
+      "ordered vs unordered pairs"
+    ]
   },
   {
     "id": "sum-multiplicities-proved",
     "proofId": "erdos-94",
-    "range": { "startLine": 82, "endLine": 134 },
+    "range": {
+      "startLine": 82,
+      "endLine": 134
+    },
     "type": "theorem",
     "title": "Sum of Multiplicities Equals $\\binom{n}{2}$ (Proved by Aristotle)",
     "content": "The theorem $\\sum_u f(u) = \\binom{n}{2}$ is fully proved in Lean (no sorry). Each unordered pair contributes to exactly one distance value, so the total count equals the number of pairs. The proof establishes evenness of ordered multiplicities via a symmetry argument (pairing $(p,q)$ with $(q,p)$), then converts to unordered counts. This is one of Aristotle's successful proof-search results.",
     "significance": "key",
-    "mathContext": {
-      "formalStatement": "theorem sum_multiplicities (P : PointConfig) :\n    (distanceSet P).sum (unorderedMultiplicity P) = P.card.choose 2",
-      "keyFormulas": [
-        "$\\sum_{u \\in d(P)} f(u) = \\binom{n}{2}$"
-      ],
-      "leanTactics": ["Finset.sum_image'", "Finset.sum_le_sum_of_subset", "aesop", "grind"]
-    },
-    "relatedConcepts": ["double counting", "binomial coefficient", "partition of pairs"],
-    "prerequisites": ["Finset.sum", "Nat.choose", "evenness via involution"]
+    "mathContext": "theorem sum_multiplicities (P : PointConfig) :\n    (distanceSet P).sum (unorderedMultiplicity P) = P.card.choose 2. Key formulas: $\\sum_{u \\in d(P)} f(u) = \\binom{n}{2}$. Lean tactics: Finset.sum_image', Finset.sum_le_sum_of_subset, aesop, grind",
+    "relatedConcepts": [
+      "double counting",
+      "binomial coefficient",
+      "partition of pairs"
+    ],
+    "prerequisites": [
+      "Finset.sum",
+      "Nat.choose",
+      "evenness via involution"
+    ]
   },
   {
     "id": "sum-squared-multiplicities",
     "proofId": "erdos-94",
-    "range": { "startLine": 138, "endLine": 171 },
+    "range": {
+      "startLine": 138,
+      "endLine": 171
+    },
     "type": "definition",
     "title": "Sum of Squared Multiplicities $\\sum f(u)^2$",
     "content": "The central quantity $\\sum_u f(u)^2$ measures distance clustering. Equivalently, it counts quadruples $(p,q,r,s)$ with $\\|p - q\\| = \\|r - s\\|$ (via `countEqualDistancePairs`), with the relation $4 \\sum f(u)^2 = |\\{(p,q,r,s) : d(p,q) = d(r,s)\\}|$. The factor 4 accounts for ordering within each pair.",
     "significance": "key",
-    "mathContext": {
-      "formalStatement": "noncomputable def sumSquaredMultiplicities (P : PointConfig) : ℕ :=\n  (distanceSet P).sum fun u => (unorderedMultiplicity P u) ^ 2\ntheorem squared_sum_eq_count (P : PointConfig) :\n    4 * sumSquaredMultiplicities P = countEqualDistancePairs P",
-      "keyFormulas": [
-        "$\\sum_{u} f(u)^2 = \\frac{1}{4}|\\{(p,q,r,s) : d(p,q) = d(r,s)\\}|$"
-      ]
-    },
-    "relatedConcepts": ["equal distance quadruples", "incidence geometry", "Cauchy-Schwarz bound"],
-    "prerequisites": ["sum of squares", "quadruple counting"]
+    "mathContext": "noncomputable def sumSquaredMultiplicities (P : PointConfig) : ℕ :=\n  (distanceSet P).sum fun u => (unorderedMultiplicity P u) ^ 2\ntheorem squared_sum_eq_count (P : PointConfig) :\n    4 * sumSquaredMultiplicities P = countEqualDistancePairs P. Key formulas: $\\sum_{u} f(u)^2 = \\frac{1}{4}|\\{(p,q,r,s) : d(p,q) = d(r,s)\\}|$",
+    "relatedConcepts": [
+      "equal distance quadruples",
+      "incidence geometry",
+      "Cauchy-Schwarz bound"
+    ],
+    "prerequisites": [
+      "sum of squares",
+      "quadruple counting"
+    ]
   },
   {
     "id": "convex-position",
     "proofId": "erdos-94",
-    "range": { "startLine": 182, "endLine": 225 },
+    "range": {
+      "startLine": 182,
+      "endLine": 225
+    },
     "type": "definition",
     "title": "Convex Position and No Three Collinear",
     "content": "Points are in convex position (`InConvexPosition`) if no point lies in the convex hull of the rest: $\\forall p \\in P,\\, p \\notin \\text{conv}(P \\setminus \\{p\\})$. The weaker condition `NoThreeCollinear` requires no three points are collinear. Convex implies no-three-collinear (axiomatized). Lefmann-Theile showed the $O(n^3)$ bound holds under the weaker condition.",
     "significance": "key",
-    "mathContext": {
-      "formalStatement": "def InConvexPosition (P : PointConfig) : Prop :=\n  ∀ p ∈ P, p ∈ convexHull ℝ (P.erase p : Set Point) → False\ndef NoThreeCollinear (P : PointConfig) : Prop :=\n  ∀ p q r : Point, p ∈ P → q ∈ P → r ∈ P →\n    p ≠ q → q ≠ r → p ≠ r → ¬Collinear ℝ ({p, q, r} : Set Point)",
-      "keyFormulas": [
-        "$p \\notin \\text{conv}(P \\setminus \\{p\\})$ for all $p \\in P$"
-      ]
-    },
-    "relatedConcepts": ["convex hull", "general position", "collinearity"],
-    "prerequisites": ["convexHull", "Collinear", "Finset.erase"]
+    "mathContext": "def InConvexPosition (P : PointConfig) : Prop :=\n  ∀ p ∈ P, p ∈ convexHull ℝ (P.erase p : Set Point) → False\ndef NoThreeCollinear (P : PointConfig) : Prop :=\n  ∀ p q r : Point, p ∈ P → q ∈ P → r ∈ P →\n    p ≠ q → q ≠ r → p ≠ r → ¬Collinear ℝ ({p, q, r} : Set Point). Key formulas: $p \\notin \\text{conv}(P \\setminus \\{p\\})$ for all $p \\in P$",
+    "relatedConcepts": [
+      "convex hull",
+      "general position",
+      "collinearity"
+    ],
+    "prerequisites": [
+      "convexHull",
+      "Collinear",
+      "Finset.erase"
+    ]
   },
   {
     "id": "fishburn-theorem",
     "proofId": "erdos-94",
-    "range": { "startLine": 239, "endLine": 257 },
+    "range": {
+      "startLine": 239,
+      "endLine": 257
+    },
     "type": "theorem",
     "title": "Fishburn's Theorem: $\\sum f(u)^2 = O(n^3)$",
     "content": "The main result solving Erdős Problem #94: there exists $C > 0$ such that $\\sum f(u)^2 \\leq C n^3$ for any $n$ points in convex position. Fishburn also showed asymptotically $C$ can be taken as $1 + \\varepsilon$ for any $\\varepsilon > 0$ when $n$ is large enough. Both are axiomatized (sorry). This was a $\\$44$ Erdős prize problem.",
     "significance": "key",
-    "mathContext": {
-      "formalStatement": "theorem fishburn_theorem :\n    ∃ C : ℝ, C > 0 ∧ ∀ P : PointConfig, InConvexPosition P →\n      (sumSquaredMultiplicities P : ℝ) ≤ C * (P.card : ℝ) ^ 3\ntheorem fishburn_asymptotic :\n    ∀ ε > 0, ∃ N : ℕ, ∀ P : PointConfig, InConvexPosition P → P.card ≥ N →\n      (sumSquaredMultiplicities P : ℝ) ≤ (1 + ε) * (P.card : ℝ) ^ 3",
-      "keyFormulas": [
-        "$\\sum_{u} f(u)^2 \\leq C \\cdot n^3$",
-        "$\\sum_{u} f(u)^2 \\leq (1 + \\varepsilon) n^3$ for $n \\geq N(\\varepsilon)$"
-      ]
-    },
-    "relatedConcepts": ["distance clustering bound", "Erdős prize problem"],
-    "prerequisites": ["convex position", "sum of squared multiplicities"]
+    "mathContext": "theorem fishburn_theorem :\n    ∃ C : ℝ, C > 0 ∧ ∀ P : PointConfig, InConvexPosition P →\n      (sumSquaredMultiplicities P : ℝ) ≤ C * (P.card : ℝ) ^ 3\ntheorem fishburn_asymptotic :\n    ∀ ε > 0, ∃ N : ℕ, ∀ P : PointConfig, InConvexPosition P → P.card ≥ N →\n      (sumSquaredMultiplicities P : ℝ) ≤ (1 + ε) * (P.card : ℝ) ^ 3. Key formulas: $\\sum_{u} f(u)^2 \\leq C \\cdot n^3$; $\\sum_{u} f(u)^2 \\leq (1 + \\varepsilon) n^3$ for $n \\geq N(\\varepsilon)$",
+    "relatedConcepts": [
+      "distance clustering bound",
+      "Erdős prize problem"
+    ],
+    "prerequisites": [
+      "convex position",
+      "sum of squared multiplicities"
+    ]
   },
   {
     "id": "lefmann-theile",
     "proofId": "erdos-94",
-    "range": { "startLine": 271, "endLine": 274 },
+    "range": {
+      "startLine": 271,
+      "endLine": 274
+    },
     "type": "theorem",
     "title": "Lefmann-Theile Strengthening (1995)",
     "content": "Lefmann and Theile (1995) proved $\\sum f(u)^2 = O(n^3)$ under the weaker assumption that no three points are collinear, rather than requiring convexity. This is a strict generalization: every convex polygon has no three collinear points, but not conversely.",
     "significance": "key",
-    "mathContext": {
-      "formalStatement": "theorem lefmann_theile_theorem :\n    ∃ C : ℝ, C > 0 ∧ ∀ P : PointConfig, NoThreeCollinear P →\n      (sumSquaredMultiplicities P : ℝ) ≤ C * (P.card : ℝ) ^ 3",
-      "keyFormulas": [
-        "$\\sum_{u} f(u)^2 \\leq C n^3$ when no three points are collinear"
-      ]
-    },
-    "relatedConcepts": ["general position", "collinearity-free configurations"],
-    "prerequisites": ["NoThreeCollinear", "Fishburn's theorem"]
+    "mathContext": "theorem lefmann_theile_theorem :\n    ∃ C : ℝ, C > 0 ∧ ∀ P : PointConfig, NoThreeCollinear P →\n      (sumSquaredMultiplicities P : ℝ) ≤ C * (P.card : ℝ) ^ 3. Key formulas: $\\sum_{u} f(u)^2 \\leq C n^3$ when no three points are collinear",
+    "relatedConcepts": [
+      "general position",
+      "collinearity-free configurations"
+    ],
+    "prerequisites": [
+      "NoThreeCollinear",
+      "Fishburn's theorem"
+    ]
   },
   {
     "id": "regular-ngon-construction",
     "proofId": "erdos-94",
-    "range": { "startLine": 293, "endLine": 339 },
+    "range": {
+      "startLine": 293,
+      "endLine": 339
+    },
     "type": "definition",
     "title": "Regular $n$-gon and $\\Theta(n^3)$ Lower Bound",
     "content": "The regular $n$-gon is constructed as $\\{(\\cos(2\\pi k/n), \\sin(2\\pi k/n)) : k = 0, \\ldots, n-1\\}$. It is in convex position (axiomatized) and achieves $\\sum f(u)^2 = \\Theta(n^3)$, showing Fishburn's bound is tight. The distances in a regular $n$-gon are $2\\sin(\\pi j/n)$ for $j = 1, \\ldots, \\lfloor n/2 \\rfloor$, each with multiplicity $n$, giving $\\sum f(u)^2 \\approx n^2 \\cdot \\lfloor n/2 \\rfloor = \\Theta(n^3)$.",
     "significance": "supporting",
-    "mathContext": {
-      "formalStatement": "noncomputable def regularNGon (n : ℕ) : PointConfig :=\n  if n < 3 then ∅ else\n    (Finset.range n).image fun k =>\n      ![Real.cos (2 * Real.pi * k / n), Real.sin (2 * Real.pi * k / n)]\ntheorem regular_ngon_cubic :\n    ∃ c₁ c₂ : ℝ, c₁ > 0 ∧ c₂ > 0 ∧ ∀ n : ℕ, n ≥ 3 →\n      c₁ * n ^ 3 ≤ (regularNGonSum n : ℝ) ∧ (regularNGonSum n : ℝ) ≤ c₂ * n ^ 3",
-      "keyFormulas": [
-        "$\\text{regularNGon}(n) = \\{e^{2\\pi i k/n} : k = 0, \\ldots, n-1\\}$",
-        "$\\sum f(u)^2 = \\Theta(n^3)$ for the regular $n$-gon"
-      ]
-    },
-    "relatedConcepts": ["regular polygon", "extremal configuration", "distance distribution"],
-    "prerequisites": ["trigonometric parametrization", "convex position"]
+    "mathContext": "noncomputable def regularNGon (n : ℕ) : PointConfig :=\n  if n < 3 then ∅ else\n    (Finset.range n).image fun k =>\n      ![Real.cos (2 * Real.pi * k / n), Real.sin (2 * Real.pi * k / n)]\ntheorem regular_ngon_cubic :\n    ∃ c₁ c₂ : ℝ, c₁ > 0 ∧ c₂ > 0 ∧ ∀ n : ℕ, n ≥ 3 →\n      c₁ * n ^ 3 ≤ (regularNGonSum n : ℝ) ∧ (regularNGonSum n : ℝ) ≤ c₂ * n ^ 3. Key formulas: $\\text{regularNGon}(n) = \\{e^{2\\pi i k/n} : k = 0, \\ldots, n-1\\}$; $\\sum f(u)^2 = \\Theta(n^3)$ for the regular $n$-gon",
+    "relatedConcepts": [
+      "regular polygon",
+      "extremal configuration",
+      "distance distribution"
+    ],
+    "prerequisites": [
+      "trigonometric parametrization",
+      "convex position"
+    ]
   },
   {
     "id": "erdos-fishburn-conjecture",
     "proofId": "erdos-94",
-    "range": { "startLine": 348, "endLine": 372 },
+    "range": {
+      "startLine": 348,
+      "endLine": 372
+    },
     "type": "conjecture",
     "title": "Erdős-Fishburn Extremal Conjecture",
     "content": "Conjectures that for sufficiently large $n$, the regular $n$-gon maximizes $\\sum f(u)^2$ among all convex $n$-gons. Formalized as `ErdosFishburnConjecture : Prop`. Computationally verified for $n \\leq 10$ (axiomatized). Related to OEIS A387858.",
     "significance": "supporting",
-    "mathContext": {
-      "formalStatement": "def ErdosFishburnConjecture : Prop :=\n  ∃ N : ℕ, ∀ n : ℕ, n ≥ N → ∀ P : PointConfig, InConvexPosition P → P.card = n →\n    sumSquaredMultiplicities P ≤ regularNGonSum n",
-      "keyFormulas": [
-        "$\\sum f(u)^2 \\leq \\sum_{\\text{reg}} f(u)^2$ for convex $P$ with $|P| = n \\geq N$"
-      ]
-    },
-    "relatedConcepts": ["extremal configuration", "regular polygon optimality", "OEIS A387858"],
-    "prerequisites": ["regularNGon", "sumSquaredMultiplicities"]
+    "mathContext": "def ErdosFishburnConjecture : Prop :=\n  ∃ N : ℕ, ∀ n : ℕ, n ≥ N → ∀ P : PointConfig, InConvexPosition P → P.card = n →\n    sumSquaredMultiplicities P ≤ regularNGonSum n. Key formulas: $\\sum f(u)^2 \\leq \\sum_{\\text{reg}} f(u)^2$ for convex $P$ with $|P| = n \\geq N$",
+    "relatedConcepts": [
+      "extremal configuration",
+      "regular polygon optimality",
+      "OEIS A387858"
+    ],
+    "prerequisites": [
+      "regularNGon",
+      "sumSquaredMultiplicities"
+    ]
   },
   {
     "id": "related-quantities",
     "proofId": "erdos-94",
-    "range": { "startLine": 376, "endLine": 431 },
+    "range": {
+      "startLine": 376,
+      "endLine": 431
+    },
     "type": "concept",
     "title": "Related Quantities: Distinct Distances, Max Multiplicity, Unit Distances",
     "content": "Three related combinatorial quantities for convex configurations: (1) The number of distinct distances $|d(P)| \\leq \\lfloor n/2 \\rfloor + 1$ (Altman 1963). (2) The maximum single-distance multiplicity $\\max_u f(u) \\leq 2n$ for convex position. (3) The unit distance count $f(1)$, connecting to the Erdős unit distance problem with the convex bound $f(1) \\leq 2n - 2$.",
     "significance": "supporting",
-    "mathContext": {
-      "formalStatement": "theorem convex_distinct_distances (P : PointConfig) (hP : InConvexPosition P) :\n    numDistinctDistances P ≤ P.card / 2 + 1\ntheorem convex_max_multiplicity (P : PointConfig) (hP : InConvexPosition P) :\n    (maxMultiplicity P : ℝ) ≤ 2 * P.card\ntheorem convex_unit_distance (P : PointConfig) (hP : InConvexPosition P) :\n    (unitDistanceCount P : ℝ) ≤ 2 * P.card - 2",
-      "keyFormulas": [
-        "$|d(P)| \\leq \\lfloor n/2 \\rfloor + 1$",
-        "$\\max_u f(u) \\leq 2n$",
-        "$f(1) \\leq 2n - 2$"
-      ]
-    },
-    "relatedConcepts": ["distinct distances problem", "unit distance problem", "Altman's theorem"],
-    "prerequisites": ["convex position", "distance multiplicity"]
+    "mathContext": "theorem convex_distinct_distances (P : PointConfig) (hP : InConvexPosition P) :\n    numDistinctDistances P ≤ P.card / 2 + 1\ntheorem convex_max_multiplicity (P : PointConfig) (hP : InConvexPosition P) :\n    (maxMultiplicity P : ℝ) ≤ 2 * P.card\ntheorem convex_unit_distance (P : PointConfig) (hP : InConvexPosition P) :\n    (unitDistanceCount P : ℝ) ≤ 2 * P.card - 2. Key formulas: $|d(P)| \\leq \\lfloor n/2 \\rfloor + 1$; $\\max_u f(u) \\leq 2n$; $f(1) \\leq 2n - 2$",
+    "relatedConcepts": [
+      "distinct distances problem",
+      "unit distance problem",
+      "Altman's theorem"
+    ],
+    "prerequisites": [
+      "convex position",
+      "distance multiplicity"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-94/meta.json
+++ b/src/data/proofs/erdos-94/meta.json
@@ -26,10 +26,26 @@
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$44",
     "mathlibDependencies": [
-      "Mathlib.Analysis.InnerProductSpace.PiL2",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Topology.MetricSpace.Basic",
-      "Mathlib.Analysis.Convex.Basic"
+      {
+        "theorem": "PiL2",
+        "description": "From Mathlib.Analysis.InnerProductSpace.PiL2",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Basic",
+        "description": "From Mathlib.Data.Finset.Basic",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Basic",
+        "description": "From Mathlib.Topology.MetricSpace.Basic",
+        "module": "Mathlib.Topology.MetricSpace.Basic"
+      },
+      {
+        "theorem": "Basic",
+        "description": "From Mathlib.Analysis.Convex.Basic",
+        "module": "Mathlib.Analysis.Convex.Basic"
+      }
     ],
     "originalContributions": [
       "Point/PointConfig: type aliases for EuclideanSpace ℝ (Fin 2) and Finset Point",

--- a/src/data/proofs/erdos-954/annotations.json
+++ b/src/data/proofs/erdos-954/annotations.json
@@ -2,141 +2,176 @@
   {
     "id": "rep-count-definition",
     "proofId": "erdos-954",
-    "range": { "startLine": 28, "endLine": 31 },
+    "range": {
+      "startLine": 28,
+      "endLine": 31
+    },
     "type": "definition",
     "title": "Representation Count $R_k(n)$",
     "content": "The cumulative representation count $R_k(n) = |\\{(i,j) : 0 \\leq i \\leq j \\leq k,\\, j \\geq 1,\\, a_i + a_j \\leq n\\}|$ counts ordered pairs from the first $k+1$ elements whose sum is at most $n$. Implemented as a Finset sum over $j \\in [1,k]$ of filtered subsets. This is a cumulative counting function, not individual representations at $n$.",
     "significance": "key",
-    "mathContext": {
-      "formalStatement": "def repCount (a : ℕ → ℕ) (k : ℕ) (n : ℕ) : ℕ :=\n  (Finset.Icc 1 k).sum fun j =>\n    (Finset.Icc 0 j).filter (fun i => a i + a j ≤ n) |>.card",
-      "keyFormulas": [
-        "$R_k(n) = |\\{(i,j) : 0 \\leq i \\leq j \\leq k,\\, j \\geq 1,\\, a_i + a_j \\leq n\\}|$"
-      ]
-    },
-    "relatedConcepts": ["sumset counting", "representation function", "additive number theory"],
-    "prerequisites": ["Finset.Icc", "Finset.sum", "Finset.filter"]
+    "mathContext": "def repCount (a : ℕ → ℕ) (k : ℕ) (n : ℕ) : ℕ :=\n  (Finset.Icc 1 k).sum fun j =>\n    (Finset.Icc 0 j).filter (fun i => a i + a j ≤ n) |>.card. Key formulas: $R_k(n) = |\\{(i,j) : 0 \\leq i \\leq j \\leq k,\\, j \\geq 1,\\, a_i + a_j \\leq n\\}|$",
+    "relatedConcepts": [
+      "sumset counting",
+      "representation function",
+      "additive number theory"
+    ],
+    "prerequisites": [
+      "Finset.Icc",
+      "Finset.sum",
+      "Finset.filter"
+    ]
   },
   {
     "id": "greedy-construction",
     "proofId": "erdos-954",
-    "range": { "startLine": 35, "endLine": 42 },
+    "range": {
+      "startLine": 35,
+      "endLine": 42
+    },
     "type": "definition",
     "title": "Greedy Selection Rule and Rosen Sequence",
     "content": "The greedy condition `IsGreedyNext a k` requires $a_{k+1}$ to be the smallest $n$ with $R_k(n) < n$, and that all $m$ between $a_k$ and $a_{k+1}$ satisfy $R_k(m) \\geq m$. `IsRosenSequence a` combines $a_0 = 0$, $a_1 = 1$, strict monotonicity, and the greedy property at every step $k \\geq 1$.",
     "significance": "key",
-    "mathContext": {
-      "formalStatement": "def IsGreedyNext (a : ℕ → ℕ) (k : ℕ) : Prop :=\n  repCount a k (a (k + 1)) < a (k + 1) ∧\n  ∀ m, a k < m → m < a (k + 1) → repCount a k m ≥ m\ndef IsRosenSequence (a : ℕ → ℕ) : Prop :=\n  a 0 = 0 ∧ a 1 = 1 ∧ StrictMono a ∧ ∀ k ≥ 1, IsGreedyNext a k",
-      "keyFormulas": [
-        "$a_{k+1} = \\min\\{n > a_k : R_k(n) < n\\}$"
-      ]
-    },
-    "relatedConcepts": ["greedy algorithm", "minimality condition", "additive basis"],
-    "prerequisites": ["StrictMono", "representation count"]
+    "mathContext": "def IsGreedyNext (a : ℕ → ℕ) (k : ℕ) : Prop :=\n  repCount a k (a (k + 1)) < a (k + 1) ∧\n  ∀ m, a k < m → m < a (k + 1) → repCount a k m ≥ m\ndef IsRosenSequence (a : ℕ → ℕ) : Prop :=\n  a 0 = 0 ∧ a 1 = 1 ∧ StrictMono a ∧ ∀ k ≥ 1, IsGreedyNext a k. Key formulas: $a_{k+1} = \\min\\{n > a_k : R_k(n) < n\\}$",
+    "relatedConcepts": [
+      "greedy algorithm",
+      "minimality condition",
+      "additive basis"
+    ],
+    "prerequisites": [
+      "StrictMono",
+      "representation count"
+    ]
   },
   {
     "id": "computable-construction",
     "proofId": "erdos-954",
-    "range": { "startLine": 43, "endLine": 80 },
+    "range": {
+      "startLine": 43,
+      "endLine": 80
+    },
     "type": "definition",
     "title": "Computable Sequence Construction",
     "content": "A List-based implementation of the greedy algorithm. `repCountList xs n` computes the representation count for a list, `findNextRosen xs last` searches for the next greedy element with bounded fuel, and `buildRosen n` constructs the first $n+1$ terms. The `rosenTerm k` function extracts the $k$-th term.",
     "significance": "supporting",
-    "mathContext": {
-      "formalStatement": "def repCountList (xs : List ℕ) (n : ℕ) : ℕ\ndef findNextRosen (xs : List ℕ) (last : ℕ) : ℕ → ℕ\ndef buildRosen : ℕ → List ℕ × ℕ\ndef rosenTerm (k : ℕ) : ℕ",
-      "keyFormulas": [
-        "$(a_k)_{k=0}^{10} = (0, 1, 3, 5, 9, 13, 17, 24, 31, 38, 45)$"
-      ]
-    },
-    "relatedConcepts": ["List-based computation", "fuel-bounded recursion"],
-    "prerequisites": ["List.foldl", "List.countP", "List indexing"]
+    "mathContext": "def repCountList (xs : List ℕ) (n : ℕ) : ℕ\ndef findNextRosen (xs : List ℕ) (last : ℕ) : ℕ → ℕ\ndef buildRosen : ℕ → List ℕ × ℕ\ndef rosenTerm (k : ℕ) : ℕ. Key formulas: $(a_k)_{k=0}^{10} = (0, 1, 3, 5, 9, 13, 17, 24, 31, 38, 45)$",
+    "relatedConcepts": [
+      "List-based computation",
+      "fuel-bounded recursion"
+    ],
+    "prerequisites": [
+      "List.foldl",
+      "List.countP",
+      "List indexing"
+    ]
   },
   {
     "id": "verified-initial-values",
     "proofId": "erdos-954",
-    "range": { "startLine": 85, "endLine": 95 },
+    "range": {
+      "startLine": 85,
+      "endLine": 95
+    },
     "type": "theorem",
     "title": "Verified Initial Values (OEIS A390642)",
     "content": "The first 11 terms of the Rosen sequence $(0, 1, 3, 5, 9, 13, 17, 24, 31, 38, 45)$ are verified by `native_decide`. These match OEIS A390642. The gaps between consecutive terms grow: $1, 2, 2, 4, 4, 4, 7, 7, 7, 7$, suggesting roughly $\\sqrt{k}$-type growth in spacing.",
     "significance": "supporting",
-    "mathContext": {
-      "formalStatement": "theorem rosen_term_0 : rosenTerm 0 = 0 := by native_decide\ntheorem rosen_term_1 : rosenTerm 1 = 1 := by native_decide\n-- ... through rosen_term_10 : rosenTerm 10 = 45",
-      "leanTactics": ["native_decide"]
-    },
-    "relatedConcepts": ["OEIS A390642", "computational verification"],
-    "prerequisites": ["Decidable computation", "native_decide"]
+    "mathContext": "theorem rosen_term_0 : rosenTerm 0 = 0 := by native_decide\ntheorem rosen_term_1 : rosenTerm 1 = 1 := by native_decide\n-- ... through rosen_term_10 : rosenTerm 10 = 45. Lean tactics: native_decide",
+    "relatedConcepts": [
+      "OEIS A390642",
+      "computational verification"
+    ],
+    "prerequisites": [
+      "Decidable computation",
+      "native_decide"
+    ]
   },
   {
     "id": "basic-properties-proved",
     "proofId": "erdos-954",
-    "range": { "startLine": 99, "endLine": 131 },
+    "range": {
+      "startLine": 99,
+      "endLine": 131
+    },
     "type": "theorem",
     "title": "Basic Structural Properties (Proved)",
     "content": "Four theorems proved directly from the greedy definition (no sorry): (1) `repcount_below_at_elements`: $R_k(a_{k+1}) < a_{k+1}$ at each new element. (2) `repcount_above_between`: $R_k(m) \\geq m$ for $a_k < m < a_{k+1}$. (3) `rosen_strictMono`: strict monotonicity of the sequence. (4) `rosen_growth`: $a_k \\geq k$ by induction. These establish the basic structure of the greedy construction.",
     "significance": "key",
-    "mathContext": {
-      "formalStatement": "theorem repcount_below_at_elements (a : ℕ → ℕ) (h : IsRosenSequence a) (k : ℕ) (hk : 1 ≤ k) :\n    repCount a k (a (k + 1)) < a (k + 1)\ntheorem rosen_growth (a : ℕ → ℕ) (h : IsRosenSequence a) (k : ℕ) :\n    a k ≥ k",
-      "keyFormulas": [
-        "$R_k(a_{k+1}) < a_{k+1}$",
-        "$R_k(m) \\geq m$ for $a_k < m < a_{k+1}$",
-        "$a_k \\geq k$"
-      ],
-      "leanTactics": ["omega", "induction"]
-    },
-    "relatedConcepts": ["greedy algorithm correctness", "growth rate"],
-    "prerequisites": ["IsRosenSequence", "StrictMono"]
+    "mathContext": "theorem repcount_below_at_elements (a : ℕ → ℕ) (h : IsRosenSequence a) (k : ℕ) (hk : 1 ≤ k) :\n    repCount a k (a (k + 1)) < a (k + 1)\ntheorem rosen_growth (a : ℕ → ℕ) (h : IsRosenSequence a) (k : ℕ) :\n    a k ≥ k. Key formulas: $R_k(a_{k+1}) < a_{k+1}$; $R_k(m) \\geq m$ for $a_k < m < a_{k+1}$; $a_k \\geq k$. Lean tactics: omega, induction",
+    "relatedConcepts": [
+      "greedy algorithm correctness",
+      "growth rate"
+    ],
+    "prerequisites": [
+      "IsRosenSequence",
+      "StrictMono"
+    ]
   },
   {
     "id": "main-conjectures",
     "proofId": "erdos-954",
-    "range": { "startLine": 133, "endLine": 151 },
+    "range": {
+      "startLine": 133,
+      "endLine": 151
+    },
     "type": "conjecture",
     "title": "Main Conjectures: Weak and Strong",
     "content": "The `fullRepCount` extends the representation count over the infinite sequence. **Weak conjecture** (axiom): $R(x) \\leq (1+\\varepsilon)x$ for large $x$, i.e., $R(x) = (1+o(1))x$. Even this is unproved. **Strong conjecture** (axiom): $|R(x) - x| \\leq C x^{1/4} \\log x$. The exponent $1/4$ comes from analogy with B$_2$ sequences where $R(x) \\sim \\sqrt{x}$ and optimal error is $\\sim x^{1/4}$.",
     "significance": "key",
-    "mathContext": {
-      "formalStatement": "axiom erdos_954_weak_conjecture (a : ℕ → ℕ) (h : IsRosenSequence a) :\n    ∀ ε > 0, ∃ N, ∀ x ≥ N, (fullRepCount a x : ℤ) ≤ ((1 + ε) * x : ℤ)\naxiom erdos_954_strong_conjecture (a : ℕ → ℕ) (h : IsRosenSequence a) :\n    ∃ C : ℝ, ∀ x : ℕ, 1 ≤ x →\n      |(fullRepCount a x : ℤ) - (x : ℤ)| ≤ C * (x : ℝ) ^ (1/4 : ℝ) * Real.log x",
-      "keyFormulas": [
-        "$R(x) = (1 + o(1))x$ (weak)",
-        "$|R(x) - x| = O(x^{1/4 + o(1)})$ (strong)"
-      ]
-    },
-    "relatedConcepts": ["asymptotic analysis", "error term estimates", "open Erdős problem"],
-    "prerequisites": ["fullRepCount", "IsRosenSequence"]
+    "mathContext": "axiom erdos_954_weak_conjecture (a : ℕ → ℕ) (h : IsRosenSequence a) :\n    ∀ ε > 0, ∃ N, ∀ x ≥ N, (fullRepCount a x : ℤ) ≤ ((1 + ε) * x : ℤ)\naxiom erdos_954_strong_conjecture (a : ℕ → ℕ) (h : IsRosenSequence a) :\n    ∃ C : ℝ, ∀ x : ℕ, 1 ≤ x →\n      |(fullRepCount a x : ℤ) - (x : ℤ)| ≤ C * (x : ℝ) ^ (1/4 : ℝ) * Real.log x. Key formulas: $R(x) = (1 + o(1))x$ (weak); $|R(x) - x| = O(x^{1/4 + o(1)})$ (strong)",
+    "relatedConcepts": [
+      "asymptotic analysis",
+      "error term estimates",
+      "open Erdős problem"
+    ],
+    "prerequisites": [
+      "fullRepCount",
+      "IsRosenSequence"
+    ]
   },
   {
     "id": "sidon-connection",
     "proofId": "erdos-954",
-    "range": { "startLine": 153, "endLine": 172 },
+    "range": {
+      "startLine": 153,
+      "endLine": 172
+    },
     "type": "concept",
     "title": "Connection to Sidon Sets and Erdős-Turán Conjecture",
     "content": "A B$_2$ (Sidon) sequence requires all pairwise sums to be distinct, giving density $\\sim \\sqrt{x}$. Rosen's sequence relaxes this: it allows repeated sums but controls their cumulative count, achieving density $\\sim x$. The axiom `rosen_not_b2` asserts the Rosen sequence is not B$_2$. The Erdős-Turán conjecture (Problem #28) states every B$_2$ sequence has unbounded representation function; Rosen's construction is related but distinct since it controls cumulative rather than individual representations.",
     "significance": "supporting",
-    "mathContext": {
-      "formalStatement": "def IsB2Sequence (a : ℕ → ℕ) (k : ℕ) : Prop :=\n  ∀ i₁ j₁ i₂ j₂, i₁ ≤ j₁ → j₁ ≤ k → i₂ ≤ j₂ → j₂ ≤ k →\n    a i₁ + a j₁ = a i₂ + a j₂ → (i₁ = i₂ ∧ j₁ = j₂)\naxiom rosen_not_b2 (a : ℕ → ℕ) (h : IsRosenSequence a) : ∃ k, ¬IsB2Sequence a k",
-      "keyFormulas": [
-        "B$_2$: $a_i + a_j = a_k + a_l \\Rightarrow \\{i,j\\} = \\{k,l\\}$",
-        "Rosen: $R(x) < x$ at elements, $R(x) \\geq x$ between"
-      ]
-    },
-    "relatedConcepts": ["Sidon set", "B₂ sequence", "Erdős-Turán conjecture", "additive basis"],
-    "prerequisites": ["IsB2Sequence", "representation function"]
+    "mathContext": "def IsB2Sequence (a : ℕ → ℕ) (k : ℕ) : Prop :=\n  ∀ i₁ j₁ i₂ j₂, i₁ ≤ j₁ → j₁ ≤ k → i₂ ≤ j₂ → j₂ ≤ k →\n    a i₁ + a j₁ = a i₂ + a j₂ → (i₁ = i₂ ∧ j₁ = j₂)\naxiom rosen_not_b2 (a : ℕ → ℕ) (h : IsRosenSequence a) : ∃ k, ¬IsB2Sequence a k. Key formulas: B$_2$: $a_i + a_j = a_k + a_l \\Rightarrow \\{i,j\\} = \\{k,l\\}$; Rosen: $R(x) < x$ at elements, $R(x) \\geq x$ between",
+    "relatedConcepts": [
+      "Sidon set",
+      "B₂ sequence",
+      "Erdős-Turán conjecture",
+      "additive basis"
+    ],
+    "prerequisites": [
+      "IsB2Sequence",
+      "representation function"
+    ]
   },
   {
     "id": "repcount-monotonicity",
     "proofId": "erdos-954",
-    "range": { "startLine": 174, "endLine": 187 },
+    "range": {
+      "startLine": 174,
+      "endLine": 187
+    },
     "type": "theorem",
     "title": "Representation Count Monotonicity in $k$ (Proved)",
     "content": "Proved in Lean: $R_k(n) \\leq R_{k+1}(n)$, i.e., adding more sequence elements can only increase the representation count. The proof uses `Finset.sum_le_sum_of_subset_of_nonneg` since $[1,k] \\subseteq [1,k+1]$. This is a fundamental monotonicity property of the greedy construction.",
     "significance": "supporting",
-    "mathContext": {
-      "formalStatement": "theorem repCount_mono_k (a : ℕ → ℕ) (k n : ℕ) :\n    repCount a k n ≤ repCount a (k + 1) n",
-      "keyFormulas": [
-        "$R_k(n) \\leq R_{k+1}(n)$"
-      ],
-      "leanTactics": ["Finset.sum_le_sum_of_subset_of_nonneg", "omega"]
-    },
-    "relatedConcepts": ["monotonicity", "subset sum inequality"],
-    "prerequisites": ["repCount", "Finset.Icc subset"]
+    "mathContext": "theorem repCount_mono_k (a : ℕ → ℕ) (k n : ℕ) :\n    repCount a k n ≤ repCount a (k + 1) n. Key formulas: $R_k(n) \\leq R_{k+1}(n)$. Lean tactics: Finset.sum_le_sum_of_subset_of_nonneg, omega",
+    "relatedConcepts": [
+      "monotonicity",
+      "subset sum inequality"
+    ],
+    "prerequisites": [
+      "repCount",
+      "Finset.Icc subset"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-954/meta.json
+++ b/src/data/proofs/erdos-954/meta.json
@@ -25,9 +25,21 @@
     "erdosUrl": "https://erdosproblems.com/954",
     "erdosProblemStatus": "open",
     "mathlibDependencies": [
-      "Mathlib.Data.Finset.Card",
-      "Mathlib.Data.Nat.Basic",
-      "Mathlib.Order.Filter.Basic"
+      {
+        "theorem": "Card",
+        "description": "From Mathlib.Data.Finset.Card",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Basic",
+        "description": "From Mathlib.Data.Nat.Basic",
+        "module": "Mathlib.Data.Nat.Basic"
+      },
+      {
+        "theorem": "Basic",
+        "description": "From Mathlib.Order.Filter.Basic",
+        "module": "Mathlib.Order.Filter.Basic"
+      }
     ],
     "originalContributions": [
       "repCount: cumulative representation count R_k(n) via Finset.Icc sums",


### PR DESCRIPTION
## Summary
- Flatten `mathContext` from objects to strings in annotations.json for erdos-94 and erdos-954
- Convert `mathlibDependencies` from plain strings to `{theorem, description}` objects in meta.json
- Fixes build failure caused by TypeScript type mismatches (TS2352)

## Test plan
- [x] `pnpm annotations:build` passes without TS errors
- [x] Verified against working enricher files (erdos-1) for correct format

🤖 Generated with [Claude Code](https://claude.com/claude-code)