### PR TITLE
enrich: deepen annotations and meta for erdos-422

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -260,6 +260,36 @@
       "passes": 1,
       "lastEnriched": "2026-02-11T18:44:48Z",
       "quality": 100
+    },
+    "erdos-955": {
+      "passes": 3,
+      "lastEnriched": "2026-02-11T21:27:17Z",
+      "quality": 100
+    },
+    "erdos-956": {
+      "passes": 1,
+      "lastEnriched": "2026-02-11T21:23:17Z",
+      "quality": 100
+    },
+    "erdos-1161": {
+      "passes": 2,
+      "lastEnriched": "2026-02-11T21:32:37Z",
+      "quality": 100
+    },
+    "erdos-117": {
+      "passes": 2,
+      "lastEnriched": "2026-02-11T21:35:41Z",
+      "quality": 98
+    },
+    "erdos-181": {
+      "passes": 2,
+      "lastEnriched": "2026-02-11T21:38:49Z",
+      "quality": 100
+    },
+    "erdos-319": {
+      "passes": 1,
+      "lastEnriched": "2026-02-11T21:39:21Z",
+      "quality": 100
     }
   }
 }

--- a/src/data/proofs/erdos-422/annotations.json
+++ b/src/data/proofs/erdos-422/annotations.json
@@ -1,56 +1,86 @@
 [
   {
-    "id": "hofstadter-f",
+    "id": "ann-e422-imports",
     "proofId": "erdos-422",
-    "range": { "startLine": 28, "endLine": 33 },
+    "range": { "startLine": 20, "endLine": 22 },
+    "type": "concept",
+    "title": "Imports and Dependencies",
+    "content": "Imports `Nat.Basic` for natural number arithmetic, `Set.Finite.Basic` for `Set.Infinite` (used in the missing-integers conjecture), and `Tactic` for automation. The formalization uses `ℕ → ℕ` for the sequence type and `Set.Infinite` to express that infinitely many integers are missed.",
+    "mathContext": "The sequence $f : \\mathbb{N} \\to \\mathbb{N}$ is modeled as a total function; well-definedness is a separate predicate. `Set.Infinite` captures the cardinality condition.",
+    "significance": "supporting",
+    "relatedConcepts": ["Set.Infinite", "natural number arithmetic", "total functions on ℕ"],
+    "prerequisites": ["Lean 4 imports", "Mathlib set theory"]
+  },
+  {
+    "id": "ann-e422-definition",
+    "proofId": "erdos-422",
+    "range": { "startLine": 28, "endLine": 37 },
     "type": "definition",
-    "title": "Hofstadter Recursive Sequence",
-    "content": "f(1)=f(2)=1, f(n) = f(n−f(n−1))+f(n−f(n−2)). The recursion is self-referential: the indices at which f is evaluated depend on earlier values of f.",
-    "significance": "high"
+    "title": "Hofstadter Sequence and Well-Definedness Predicate",
+    "content": "**hofstadterF** defines $f$ by pattern matching: $f(0) = 0$ (unused sentinel), $f(1) = f(2) = 1$, and $f(n+3) = f(n+3 - f(n+2)) + f(n+3 - f(n+1))$. The shift to $n+3$ avoids subtraction issues with natural numbers. Marked `noncomputable` because Lean cannot verify termination — the recursion's well-definedness is itself an open problem. **IsWellDefined** is a separate predicate asserting $\\forall k \\leq n,\\; k \\geq 3 \\Rightarrow f(k-1) < k \\land f(k-2) < k$, ensuring recursive indices stay positive. This separation of definition from well-definedness reflects the mathematical reality: the recursion can be written down, but its totality is unproved.",
+    "mathContext": "$f(1) = f(2) = 1$, $f(n) = f(n - f(n-1)) + f(n - f(n-2))$ for $n \\geq 3$. Well-defined iff $f(k-1) < k$ and $f(k-2) < k$ for all $k \\geq 3$.",
+    "significance": "critical",
+    "relatedConcepts": ["self-referential recursion", "noncomputable definition", "termination", "well-definedness predicate"],
+    "prerequisites": ["pattern matching", "natural number subtraction", "Lean equation compiler"]
   },
   {
-    "id": "well-defined",
+    "id": "ann-e422-well-defined",
     "proofId": "erdos-422",
-    "range": { "startLine": 42, "endLine": 43 },
-    "type": "conjecture",
-    "title": "Well-Definedness",
-    "content": "Is f(n) well-defined for all n? The recursive indices must stay within range. This is the most fundamental open question.",
-    "significance": "high"
+    "range": { "startLine": 41, "endLine": 43 },
+    "type": "theorem",
+    "title": "Well-Definedness Conjecture",
+    "content": "States $\\forall n,\\; \\text{IsWellDefined}(n)$ — that the recursive indices always stay in range. This is axiomatized because it is the **most fundamental open question** about the sequence. Computationally verified for billions of terms, but no proof exists. The difficulty is that the recursion is self-referential: to bound $f(n)$, you need bounds on $f$ at points determined by $f$ itself, creating a circular dependency that defeats standard induction.",
+    "mathContext": "**Conjecture (OPEN):** $\\forall n \\geq 3: f(n-1) < n \\land f(n-2) < n$. Equivalently, the recursion never attempts to evaluate $f$ at a non-positive index.",
+    "significance": "critical",
+    "relatedConcepts": ["totality of recursion", "computational verification", "inductive proof barriers"],
+    "prerequisites": ["IsWellDefined", "hofstadterF"]
   },
   {
-    "id": "missing-integers",
+    "id": "ann-e422-missing-surjectivity",
     "proofId": "erdos-422",
-    "range": { "startLine": 46, "endLine": 47 },
-    "type": "conjecture",
-    "title": "Missing Integers",
-    "content": "Does f miss infinitely many positive integers? The range of f may have gaps that persist indefinitely.",
-    "significance": "high"
+    "range": { "startLine": 45, "endLine": 51 },
+    "type": "theorem",
+    "title": "Missing Integers and Non-Surjectivity",
+    "content": "Two related conjectures. **Missing integers** (lines 46–47): $\\{m > 0 : \\forall n,\\; f(n) \\neq m\\}$ is infinite — the range of $f$ has infinitely many gaps. Uses `Set.Infinite` from Mathlib. **Non-surjectivity** (lines 50–51): $f$ restricted to positive integers is not surjective, stated as $\\neg\\text{Surjective}(n \\mapsto f(n+1))$. The shift by 1 avoids the $f(0) = 0$ sentinel. These are logically related: infinitely many missing integers implies non-surjectivity, but the converse is weaker (finitely many gaps would also give non-surjectivity).",
+    "mathContext": "**Conjecture:** $|\\{m \\in \\mathbb{N}^+ : m \\notin \\text{Im}(f)\\}| = \\infty$. **Consequence:** $f : \\mathbb{N}^+ \\to \\mathbb{N}^+$ is not surjective.",
+    "significance": "key",
+    "relatedConcepts": ["Set.Infinite", "Function.Surjective", "range gaps", "image of a sequence"],
+    "prerequisites": ["hofstadterF", "set theory basics", "function surjectivity"]
   },
   {
-    "id": "surjectivity",
+    "id": "ann-e422-growth",
     "proofId": "erdos-422",
-    "range": { "startLine": 50, "endLine": 51 },
-    "type": "conjecture",
-    "title": "Surjectivity Question",
-    "content": "Is f surjective onto the positive integers? Equivalently, does every positive integer appear as f(n) for some n?",
-    "significance": "high"
+    "range": { "startLine": 53, "endLine": 57 },
+    "type": "theorem",
+    "title": "Linear Growth Bound",
+    "content": "States $\\forall \\varepsilon > 0,\\; \\exists N_0,\\; \\forall n \\geq N_0: f(n) \\leq (1 + \\varepsilon)n$. This captures the computational observation that $f(n)/n$ appears to approach 1 (or at least stay bounded). The $\\varepsilon$-formulation is the standard way to express $f(n) = O(n)$ with leading constant 1. The coercion to $\\mathbb{R}$ is needed for the multiplication $(1 + \\varepsilon) \\cdot n$. Even this weak growth bound is unproved — it would follow from well-definedness plus a monotonicity-type argument, but neither is available.",
+    "mathContext": "**Conjecture:** $f(n) \\leq (1 + \\varepsilon)n$ for $n \\gg 1$, i.e., $\\limsup f(n)/n \\leq 1$.",
+    "significance": "key",
+    "relatedConcepts": ["asymptotic growth", "linear bound", "limsup", "real coercion"],
+    "prerequisites": ["hofstadterF", "real arithmetic", "asymptotic notation"]
   },
   {
-    "id": "initial-values",
+    "id": "ann-e422-initial-values",
     "proofId": "erdos-422",
-    "range": { "startLine": 59, "endLine": 63 },
-    "type": "note",
-    "title": "Initial Values",
-    "content": "The sequence begins 1, 1, 2, 3, 3, 4, ... (OEIS A005185). These values are computable, but the long-term behavior is unknown.",
-    "significance": "medium"
+    "range": { "startLine": 63, "endLine": 66 },
+    "type": "theorem",
+    "title": "Initial Values (OEIS A005185)",
+    "content": "Axiomatizes $f(1) = 1, f(2) = 1, f(3) = 2, f(4) = 3, f(5) = 3, f(6) = 4$. These are computable from the recursion: $f(3) = f(3 - f(2)) + f(3 - f(1)) = f(2) + f(2) = 2$, $f(4) = f(4 - f(3)) + f(4 - f(2)) = f(2) + f(3) = 3$, etc. Axiomatized rather than proved because the `noncomputable` definition cannot be unfolded by the kernel. The sequence (OEIS A005185) has been computed to billions of terms.",
+    "mathContext": "Sequence begins $1, 1, 2, 3, 3, 4, 5, 7, 7, 8, \\ldots$ (OEIS A005185). Each value is computable assuming prior values stay in range.",
+    "significance": "supporting",
+    "relatedConcepts": ["OEIS A005185", "computational verification", "noncomputable unfolding"],
+    "prerequisites": ["hofstadterF", "natural number computation"]
   },
   {
-    "id": "self-referential",
+    "id": "ann-e422-observations",
     "proofId": "erdos-422",
-    "range": { "startLine": 72, "endLine": 75 },
-    "type": "note",
-    "title": "Self-Referential Difficulty",
-    "content": "The recursion f(n) = f(n−f(n−1))+f(n−f(n−2)) is self-referential: the evaluation points depend on the sequence itself. This makes rigorous analysis extremely challenging.",
-    "significance": "medium"
+    "range": { "startLine": 70, "endLine": 78 },
+    "type": "insight",
+    "title": "Self-Referential Nature and Open Questions",
+    "content": "Three observations in comments. **Hofstadter origin**: the sequence was communicated by Hofstadter (author of 'Gödel, Escher, Bach') to Erdős, appearing in the 1980 Erdős–Graham monograph. **Self-referential difficulty**: unlike standard recursions $f(n) = g(f(n-1), f(n-2))$ where evaluation points are fixed, here the evaluation points $n - f(n-1)$ and $n - f(n-2)$ depend on $f$ itself, creating a nested feedback loop. This defeats inductive proofs because the induction hypothesis at step $n$ requires information about $f$ at unpredictable earlier points. **Eventually constant**: whether $f$ becomes constant is also open — computational evidence suggests it does not.",
+    "mathContext": "The key difficulty: $f(n) = f(n - f(n-1)) + f(n - f(n-2))$ has **variable evaluation points**, unlike $f(n) = f(n-1) + f(n-2)$ (Fibonacci). The indices $n - f(n-1)$ are data-dependent.",
+    "significance": "key",
+    "relatedConcepts": ["Hofstadter sequences", "Gödel Escher Bach", "Erdős–Graham monograph", "feedback loops in recursion"],
+    "prerequisites": ["self-referential definitions", "induction limitations"]
   }
 ]

--- a/src/data/proofs/erdos-422/meta.json
+++ b/src/data/proofs/erdos-422/meta.json
@@ -8,6 +8,7 @@
     "sourceUrl": "https://erdosproblems.com/422",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos422Problem.lean",
+    "leanFile": "Proofs/Erdos422Problem.lean",
     "tags": [
       "erdos",
       "number-theory",
@@ -26,17 +27,18 @@
   "overview": {
     "historicalContext": "Douglas Hofstadter, famous for 'Godel, Escher, Bach' (1979), proposed this self-referential sequence and communicated it to Erdős. It appears in the Erdős–Graham monograph 'Old and New Problems and Results in Combinatorial Number Theory' (1980), and is listed as OEIS A005185.\n\nThe sequence f(1)=f(2)=1, f(n) = f(n-f(n-1)) + f(n-f(n-2)) is remarkable because its most basic property — whether f(n) is well-defined for all n — is unknown. The recursion is self-referential: to compute f(n), you need f(n-1) and f(n-2) to determine the indices n-f(n-1) and n-f(n-2), and then evaluate f at those indices. If f(n-1) ≥ n or f(n-2) ≥ n, the indices become non-positive and the recursion breaks down.\n\nComputationally, the sequence has been verified to be well-defined for billions of terms, and it appears to grow roughly linearly with a complicated local structure. The sequence begins 1, 1, 2, 3, 3, 4, 5, 7, 7, 8, ... and exhibits no obvious pattern. It is one of the simplest self-referential recursions whose behavior resists all known analytical techniques, making it a paradigmatic example of 'simple to state, impossible to analyze.'",
     "problemStatement": "Define f(1)=f(2)=1, f(n) = f(n-f(n-1))+f(n-f(n-2)) for n > 2. Is f well-defined for all n? Does it miss infinitely many integers?",
-    "proofStrategy": "We formalize the recursion using Lean's equation compiler with explicit pattern matching on 0, 1, 2, and n+3. The well-definedness predicate IsWellDefined checks that recursive indices stay positive. Main questions are stated as axioms. Known initial values are axiomatized.",
+    "proofStrategy": "The formalization defines `hofstadterF` via Lean's equation compiler with pattern matching on $0, 1, 2, n+3$, marked `noncomputable` since termination is unprovable (the open problem). The well-definedness predicate `IsWellDefined` checks $f(k-1) < k \\land f(k-2) < k$ for $k \\geq 3$. Four open conjectures are axiomatized: well-definedness, infinitely many missing integers ($\\text{Set.Infinite}$), non-surjectivity, and linear growth $f(n) \\leq (1+\\varepsilon)n$. Initial values $f(1) = \\cdots = f(6)$ are axiomatized since the `noncomputable` definition cannot be unfolded. All results are axioms (0 sorries); the formalization captures the problem's structure faithfully.",
     "keyInsights": [
-      "**Well-definedness is unknown**: The most fundamental question — whether f(n) is defined for all n — is open. The recursion requires f(n-1) < n and f(n-2) < n for the indices to be valid, and this has only been verified computationally.",
-      "**Self-referential indexing**: Unlike standard recursions where f(n) depends on f(n-1) and f(n-2), here the indices themselves depend on f. This creates a nested feedback loop that defeats inductive arguments.",
-      "**OEIS A005185**: The sequence begins 1, 1, 2, 3, 3, 4, 5, 7, 7, 8, ... and has been computed to many terms without encountering a failure of well-definedness.",
-      "**Missing integers**: Even assuming well-definedness, whether f misses infinitely many integers (i.e., fails to be surjective) is unknown. The related question of whether f is eventually constant is also open.",
-      "**Linear growth conjecture**: Computational evidence suggests f(n) grows linearly, formalized here as f(n) ≤ (1+ε)n for any ε > 0 and large enough n."
+      "**Well-definedness is the first barrier**: The recursion $f(n) = f(n - f(n-1)) + f(n - f(n-2))$ requires $f(n-1) < n$ and $f(n-2) < n$ for the indices to be positive. This has been verified computationally for billions of terms but never proved, making it the most fundamental open question.",
+      "**Self-referential indexing defeats induction**: Unlike Fibonacci ($f(n) = f(n-1) + f(n-2)$) where evaluation points are fixed, here the points $n - f(n-1)$ and $n - f(n-2)$ depend on $f$ itself. An induction at step $n$ needs bounds on $f$ at data-dependent earlier indices, creating a circular dependency.",
+      "**OEIS A005185**: The sequence $1, 1, 2, 3, 3, 4, 5, 7, 7, 8, \\ldots$ exhibits no discernible pattern. It has been computed to billions of terms without encountering a well-definedness failure or settling into periodic behavior.",
+      "**Missing integers and non-surjectivity**: Even assuming well-definedness, whether $\\{m > 0 : m \\notin \\text{Im}(f)\\}$ is infinite is unknown. The weaker question of surjectivity ($\\text{Im}(f) = \\mathbb{N}^+$?) is also open, as is eventual constancy.",
+      "**Linear growth conjecture**: Computational evidence suggests $\\limsup f(n)/n \\leq 1$, formalized as $f(n) \\leq (1 + \\varepsilon)n$ for any $\\varepsilon > 0$ and $n$ sufficiently large. Even this weak bound is unproved."
     ],
     "mathlibDependencies": [
-      "Mathlib.Data.Nat.Basic",
-      "Mathlib.Data.Set.Finite.Basic"
+      { "theorem": "Nat.succ", "description": "Natural number successor and basic arithmetic", "module": "Mathlib.Data.Nat.Basic" },
+      { "theorem": "Set.Infinite", "description": "Predicate for infinite sets (used for missing integers)", "module": "Mathlib.Data.Set.Finite.Basic" },
+      { "theorem": "Function.Surjective", "description": "Surjectivity predicate for the non-surjectivity conjecture", "module": "Mathlib.Logic.Function.Basic" }
     ],
     "originalContributions": [
       "hofstadterF: recursive definition via equation compiler",
@@ -46,46 +48,58 @@
       "erdos_422_surjectivity: non-surjectivity conjecture",
       "erdos_422_growth: linear growth bound f(n) ≤ (1+ε)n",
       "initial_values: axiom for f(1)=1, f(2)=1, ..., f(6)=4"
+    ],
+    "relatedProofs": [
+      { "id": "erdos-423", "relationship": "Consecutive-terms greedy sequence — another self-referential sequence from the same section of Erdős–Graham (1980) with open growth rate" },
+      { "id": "erdos-424", "relationship": "Multiplicative generation sequence {a_i · a_j − 1} — iteratively defined sequence with unknown density, from the same problem cluster" }
     ]
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 20,
+      "endLine": 22,
+      "summary": "Imports `Nat.Basic`, `Set.Finite.Basic` (for `Set.Infinite`), and `Tactic`."
+    },
+    {
       "id": "definition",
-      "title": "Definition",
+      "title": "Sequence Definition and Well-Definedness",
       "startLine": 24,
       "endLine": 37,
-      "summary": "Defines hofstadterF via Lean's equation compiler with cases for 0, 1, 2, and n+3. Defines IsWellDefined predicate checking recursive indices stay positive."
+      "summary": "Defines `hofstadterF` via equation compiler: $f(n+3) = f(n+3 - f(n+2)) + f(n+3 - f(n+1))$. Defines `IsWellDefined`: $f(k-1) < k \\land f(k-2) < k$ for $k \\geq 3$."
     },
     {
       "id": "main-questions",
-      "title": "Main Questions",
+      "title": "Main Open Questions",
       "startLine": 39,
       "endLine": 57,
-      "summary": "States four open questions as axioms: well-definedness for all n, infinitely many missing integers, non-surjectivity, and linear growth rate."
+      "summary": "Four axiomatized conjectures: well-definedness $\\forall n$, $|\\{m \\notin \\text{Im}(f)\\}| = \\infty$, non-surjectivity, and linear growth $f(n) \\leq (1+\\varepsilon)n$."
     },
     {
       "id": "known-values",
-      "title": "Known Values",
+      "title": "Known Initial Values",
       "startLine": 59,
       "endLine": 66,
-      "summary": "Axiomatizes the first six values: f(1)=1, f(2)=1, f(3)=2, f(4)=3, f(5)=3, f(6)=4."
+      "summary": "Axiomatizes $f(1) = 1, f(2) = 1, f(3) = 2, f(4) = 3, f(5) = 3, f(6) = 4$ (OEIS A005185)."
     },
     {
       "id": "observations",
-      "title": "Observations",
+      "title": "Observations and Context",
       "startLine": 68,
       "endLine": 78,
-      "summary": "Comments on Hofstadter's origin, the self-referential difficulty, and the open question of eventual constancy."
+      "summary": "Hofstadter origin (communicated to Erdős), self-referential indexing difficulty vs. Fibonacci, and the open question of eventual constancy."
     }
   ],
   "conclusion": {
     "summary": "Erdős Problem 422 concerns a Hofstadter-type sequence whose most basic properties — well-definedness, surjectivity, growth — are all unknown. The self-referential recursion resists standard analysis techniques. 0 sorries.",
     "implications": "Understanding this sequence would shed light on self-referential recursive dynamics, a notoriously difficult area at the boundary of number theory, dynamical systems, and computability theory.",
     "openQuestions": [
-      "Is f(n) well-defined for all n, or does the recursion eventually break down?",
-      "Does f miss infinitely many positive integers?",
-      "Is f eventually surjective, eventually constant, or neither?",
-      "What is the precise growth rate of f? Is f(n)/n bounded?"
+      "Is $f(n)$ well-defined for all $n \\in \\mathbb{N}$, or does the recursion eventually produce a non-positive index?",
+      "Is $\\{m > 0 : m \\notin \\text{Im}(f)\\}$ infinite? What is the density of missing integers?",
+      "Is $f$ eventually surjective, eventually constant, or neither? What is $\\liminf f(n)/n$?",
+      "What is the precise growth rate? Is $\\lim f(n)/n = 1$, or does $f(n)/n$ oscillate?",
+      "Are there other initial conditions $(f(1), f(2)) \\neq (1,1)$ for which the same recursion is provably well-defined or provably breaks down?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enrich erdos-422 (Hofstadter-Type Recursive Sequence) with deeper annotations, cross-references, and mathematical context
- Add `mathContext`, `relatedConcepts`, `prerequisites` to all 7 annotations covering full Lean file
- Add `leanFile`, `relatedProofs` (erdos-423, erdos-424), structured `mathlibDependencies`
- Fix invalid annotation types (`conjecture`→`theorem`, `note`→`insight`) and significance (`high`/`medium`→`critical`/`key`/`supporting`)
- Add LaTeX to sections, keyInsights, proofStrategy, and openQuestions

## Test plan
- [x] `pnpm annotations:build` passes with no erdos-422 errors (1 non-strict type warning for axiom line)
- [x] All annotations have valid types and significance values
- [x] All annotations have mathContext, relatedConcepts, prerequisites

🤖 Generated with [Claude Code](https://claude.com/claude-code)