### PR TITLE
enrich: deepen annotations and meta for erdos-468

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -260,6 +260,46 @@
       "passes": 1,
       "lastEnriched": "2026-02-11T18:44:48Z",
       "quality": 100
+    },
+    "erdos-955": {
+      "passes": 3,
+      "lastEnriched": "2026-02-11T21:27:17Z",
+      "quality": 100
+    },
+    "erdos-956": {
+      "passes": 1,
+      "lastEnriched": "2026-02-11T21:23:17Z",
+      "quality": 100
+    },
+    "erdos-1161": {
+      "passes": 2,
+      "lastEnriched": "2026-02-11T21:32:37Z",
+      "quality": 100
+    },
+    "erdos-117": {
+      "passes": 2,
+      "lastEnriched": "2026-02-11T21:35:41Z",
+      "quality": 98
+    },
+    "erdos-181": {
+      "passes": 2,
+      "lastEnriched": "2026-02-11T21:38:49Z",
+      "quality": 100
+    },
+    "erdos-319": {
+      "passes": 2,
+      "lastEnriched": "2026-02-11T21:43:38Z",
+      "quality": 98
+    },
+    "erdos-361": {
+      "passes": 1,
+      "lastEnriched": "2026-02-11T21:41:17Z",
+      "quality": 100
+    },
+    "erdos-422": {
+      "passes": 1,
+      "lastEnriched": "2026-02-11T21:44:00Z",
+      "quality": 100
     }
   }
 }

--- a/src/data/proofs/erdos-468/annotations.json
+++ b/src/data/proofs/erdos-468/annotations.json
@@ -1,56 +1,86 @@
 [
   {
-    "id": "partial-divisor-sums",
+    "id": "ann-e468-imports",
     "proofId": "erdos-468",
-    "range": { "startLine": 30, "endLine": 34 },
+    "range": { "startLine": 17, "endLine": 21 },
+    "type": "concept",
+    "title": "Imports and Dependencies",
+    "content": "Imports `Nat.Divisors` for `n.divisors` (the divisor set of $n$), `Finset.Card` for cardinality, `Finset.Sort` for sorting divisors in increasing order, `Nat.Basic` for arithmetic, and `Tactic` for automation. The formalization combines multiplicative number theory (`Nat.divisors`) with list operations (sorting, prefix sums) to construct the partial-sum sets.",
+    "mathContext": "Uses `n.divisors : Finset \\mathbb{N}` from Mathlib, filtered to $\\{d \\mid n : d > 1\\}$ and sorted by $\\leq$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.divisors", "Finset.Sort", "List.take", "prefix sums"],
+    "prerequisites": ["Lean 4 imports", "Mathlib divisor functions"]
+  },
+  {
+    "id": "ann-e468-core-defs",
+    "proofId": "erdos-468",
+    "range": { "startLine": 25, "endLine": 42 },
     "type": "definition",
-    "title": "Partial Divisor Sums D_n",
-    "content": "D_n = {d₁, d₁+d₂, d₁+d₂+d₃, ...} where d₁ < d₂ < ⋯ are divisors of n greater than 1. For n=6: divisors {2,3,6} give D_6 = {2, 5, 11}.",
-    "significance": "high"
+    "title": "Core Definitions: $D_n$, Previous Sums, New Elements",
+    "content": "Four key definitions. **properDivisorsSorted**: sorts $\\{d \\mid n : d > 1\\}$ in increasing order as a `List ℕ`. **partialDivisorSums**: $D_n = \\{d_1, d_1+d_2, \\ldots, d_1+\\cdots+d_k\\}$ computed via `List.take` and `List.sum` on prefixes of the sorted divisors, then converted to `Finset`. **previousPartialSums**: $\\bigcup_{m < n} D_m$ as a `Set ℕ` using indexed union. **newElements**: $D_n \\setminus \\bigcup_{m < n} D_m$ — the genuinely new partial sums contributed by $n$. All are `noncomputable` due to classical set operations.",
+    "mathContext": "$D_n = \\{\\sum_{i=1}^{j} d_i : 1 \\leq j \\leq k\\}$ where $1 < d_1 < \\cdots < d_k$ are divisors of $n$. New elements: $D_n \\setminus \\bigcup_{m<n} D_m$.",
+    "significance": "critical",
+    "relatedConcepts": ["prefix sums", "divisor sets", "set difference", "indexed union"],
+    "prerequisites": ["Nat.divisors", "Finset.sort", "List operations", "Set.iUnion"]
   },
   {
-    "id": "new-elements",
+    "id": "ann-e468-new-elements",
     "proofId": "erdos-468",
-    "range": { "startLine": 40, "endLine": 42 },
+    "range": { "startLine": 46, "endLine": 55 },
+    "type": "theorem",
+    "title": "Question 1: New Elements Exist and Grow",
+    "content": "Two axioms for Question 1. **new_elements_exist** (lines 48–49): for $n \\geq 2$, the set $D_n \\setminus \\bigcup_{m<n} D_m$ is nonempty — every integer $\\geq 2$ contributes at least one new partial sum. **new_element_count_conjecture** (lines 53–55): $|D_n|$ grows without bound — for any $B$, eventually $|D_n| \\geq B$. This follows from the fact that $d(n)$ (number of divisors) is unbounded, so $|D_n| = d(n) - 1$ grows for highly composite $n$.",
+    "mathContext": "**Axiom 1:** $D_n \\setminus \\bigcup_{m<n} D_m \\neq \\emptyset$ for $n \\geq 2$. **Axiom 2:** $\\forall B,\\; \\exists N,\\; \\forall n \\geq N: |D_n| \\geq B$.",
+    "significance": "key",
+    "relatedConcepts": ["nonempty set", "divisor count growth", "highly composite numbers"],
+    "prerequisites": ["newElements", "partialDivisorSums", "Finset.card"]
+  },
+  {
+    "id": "ann-e468-first-appearance",
+    "proofId": "erdos-468",
+    "range": { "startLine": 59, "endLine": 67 },
     "type": "definition",
-    "title": "New Elements",
-    "content": "Elements in D_n not appearing in any D_m for m < n. Question 1 asks about the size of this set.",
-    "significance": "high"
+    "title": "First Appearance Function and Main Conjecture",
+    "content": "**firstAppearance** defines $f(N) = \\inf\\{n : N \\in D_n\\}$ using `sInf`. The **main conjecture** (lines 65–67) states $f(N) = o(N)$: $\\forall \\varepsilon > 0,\\; \\exists N_0,\\; \\forall N \\geq N_0: f(N) \\leq \\varepsilon N$. This means every large $N$ first appears as a partial divisor sum of some $n$ much smaller than $N$. The intuition: highly composite numbers have many divisors, so their partial sums cover many values efficiently. For instance, $D_{12}$ already covers $\\{2, 5, 9, 15, 27\\}$ from just $n = 12$.",
+    "mathContext": "$f(N) = \\min\\{n : N \\in D_n\\}$. **Conjecture (OPEN):** $f(N) = o(N)$, i.e., $f(N)/N \\to 0$.",
+    "significance": "critical",
+    "relatedConcepts": ["sInf", "sublinear growth", "covering efficiency", "highly composite numbers"],
+    "prerequisites": ["partialDivisorSums", "real arithmetic", "epsilon-delta"]
   },
   {
-    "id": "first-appearance",
+    "id": "ann-e468-almost-all",
     "proofId": "erdos-468",
-    "range": { "startLine": 58, "endLine": 60 },
-    "type": "definition",
-    "title": "First Appearance Function",
-    "content": "f(N) = min{n : N ∈ D_n}. The smallest integer whose divisor partial sums include N. The main conjecture is f(N) = o(N).",
-    "significance": "high"
+    "range": { "startLine": 69, "endLine": 73 },
+    "type": "theorem",
+    "title": "Almost-All Variant of the Conjecture",
+    "content": "States $f(N) = o(N)$ for almost all $N$: the density of exceptions $\\{N \\leq M : f(N) > \\varepsilon N\\}$ is $\\leq \\delta M$ for any $\\delta > 0$ and large $M$. This is a natural weakening that may be approachable via averaging: if most $N$ values are covered by some moderately-sized $n$, the average of $f(N)/N$ could be bounded even if some individual values are large. The density-based formulation uses `Finset.filter` and `Finset.card`.",
+    "mathContext": "**Weak conjecture (OPEN):** $|\\{N \\leq M : f(N) > \\varepsilon N\\}| = o(M)$, i.e., $f(N) = o(N)$ for density-1 set of $N$.",
+    "significance": "key",
+    "relatedConcepts": ["natural density", "almost-all results", "averaging arguments", "density of exceptions"],
+    "prerequisites": ["firstAppearance", "Finset.filter", "density arguments"]
   },
   {
-    "id": "conjecture-sublinear",
+    "id": "ann-e468-examples",
     "proofId": "erdos-468",
-    "range": { "startLine": 63, "endLine": 66 },
-    "type": "conjecture",
-    "title": "Sublinear Growth Conjecture",
-    "content": "f(N) = o(N): every integer N first appears as a partial divisor sum of some n much smaller than N. The partial sums 'cover' ℕ efficiently.",
-    "significance": "high"
+    "range": { "startLine": 77, "endLine": 81 },
+    "type": "insight",
+    "title": "Concrete Examples: $D_6$ and $D_{12}$",
+    "content": "Two concrete computations. **$D_6$**: divisors $> 1$ are $\\{2, 3, 6\\}$, partial sums $2, 2+3=5, 2+3+6=11$, so $D_6 = \\{2, 5, 11\\}$. **$D_{12}$**: divisors $> 1$ are $\\{2, 3, 4, 6, 12\\}$, partial sums $2, 5, 9, 15, 27$, so $D_{12} = \\{2, 5, 9, 15, 27\\}$. Note $D_{12}$ has 5 elements (more than $D_6$'s 3), illustrating how composite numbers generate more partial sums. The overlap $\\{2, 5\\} \\in D_6 \\cap D_{12}$ shows that new elements per step can be fewer than $|D_n|$.",
+    "mathContext": "$D_6 = \\{2, 5, 11\\}$, $D_{12} = \\{2, 5, 9, 15, 27\\}$. Note $|D_n| = d(n) - 1$ where $d(n) = |\\{d : d \\mid n\\}|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["divisor enumeration", "prefix sum computation", "highly composite numbers"],
+    "prerequisites": ["partialDivisorSums", "integer factorization"]
   },
   {
-    "id": "almost-all",
+    "id": "ann-e468-boundaries",
     "proofId": "erdos-468",
-    "range": { "startLine": 69, "endLine": 72 },
-    "type": "conjecture",
-    "title": "Almost All Variant",
-    "content": "f(N) = o(N) for almost all N: the density of exceptions where f(N) is not sublinear tends to 0. A weaker but still open form.",
-    "significance": "high"
-  },
-  {
-    "id": "examples",
-    "proofId": "erdos-468",
-    "range": { "startLine": 76, "endLine": 80 },
-    "type": "note",
-    "title": "Small Examples",
-    "content": "D_6 = {2, 5, 11} from divisors {2,3,6}. D_12 = {2, 5, 9, 15, 27} from divisors {2,3,4,6,12}. The sets grow with the divisor count.",
-    "significance": "medium"
+    "range": { "startLine": 85, "endLine": 95 },
+    "type": "theorem",
+    "title": "Boundary Elements of $D_n$",
+    "content": "Two structural axioms. **Smallest element** (lines 87–88): $\\min(D_n) = \\text{minFac}(n)$, the smallest prime factor of $n$, since it is the first divisor $> 1$. **Largest element** (lines 91–92): $\\max(D_n) = \\sigma(n) - 1$, the sum of all divisors minus 1 (the total partial sum excludes the divisor 1). These anchor the set $D_n$ between $\\text{minFac}(n)$ and $\\sigma(n) - 1$. The connection to the OEIS sequences A167485, A387502, A387503 is noted in a comment.",
+    "mathContext": "$\\min(D_n) = p_1(n)$ (smallest prime factor), $\\max(D_n) = \\sigma(n) - 1$ where $\\sigma(n) = \\sum_{d \\mid n} d$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.minFac", "sum of divisors σ(n)", "OEIS A167485", "boundary elements"],
+    "prerequisites": ["partialDivisorSums", "Nat.divisors.sum", "prime factorization"]
   }
 ]

--- a/src/data/proofs/erdos-468/meta.json
+++ b/src/data/proofs/erdos-468/meta.json
@@ -8,6 +8,7 @@
     "sourceUrl": "https://erdosproblems.com/468",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos468Problem.lean",
+    "leanFile": "Proofs/Erdos468Problem.lean",
     "tags": [
       "erdos",
       "number-theory",
@@ -26,19 +27,19 @@
   "overview": {
     "historicalContext": "Erdős and Graham posed this problem in their influential 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory.' For each positive integer n, the set D_n consists of the cumulative sums of the divisors of n greater than 1, sorted in increasing order. For example, 6 has divisors 2, 3, 6, so D_6 = {2, 2+3, 2+3+6} = {2, 5, 11}.\n\nThe problem has two parts. First, how many elements of D_n are genuinely new — not appearing in any D_m for m < n? This asks about the rate at which the union ⋃_n D_n grows. Second, for a given target N, what is the smallest n such that N ∈ D_n? If this first-appearance function f(N) satisfies f(N) = o(N), then most partial sums arise from relatively small integers.\n\nThe problem connects several themes in number theory: the additive structure of divisor sets, the distribution of the sum-of-divisors function σ(n), and the combinatorics of ordered partitions. The OEIS sequences A167485, A387502, and A387503 track related quantities. Despite its elementary formulation, the problem remains completely open.",
     "problemStatement": "Let D_n be the set of partial sums of divisors of n (excluding 1). (1) How many elements of D_n are new? (2) If f(N) = min{n : N ∈ D_n}, is f(N) = o(N)?",
-    "proofStrategy": "We formalize D_n as partial sums of sorted divisors > 1 using Nat.divisors and List operations. The first-appearance function f(N) uses sInf. Both conjectures are stated: the strong form (f(N) = o(N) for all N) and the weak form (for almost all N). Small examples and structural observations are axiomatized.",
+    "proofStrategy": "The formalization constructs $D_n$ from `Nat.divisors` filtered to $d > 1$, sorted via `Finset.sort`, with prefix sums via `List.take` and `List.sum`. The first-appearance function $f(N) = \\inf\\{n : N \\in D_n\\}$ uses `sInf`. Both conjectures are axiomatized: the strong form ($f(N) = o(N)$ for all $N$) and the almost-all form (density of exceptions $\\to 0$). Boundary elements ($\\min = p_1(n)$, $\\max = \\sigma(n) - 1$) and examples ($D_6$, $D_{12}$) are also stated. All results are axioms (0 sorries).",
     "keyInsights": [
-      "**Cumulative sum construction**: D_n is built from the divisors d₁ < d₂ < ... of n (excluding 1) by taking partial sums d₁, d₁+d₂, d₁+d₂+d₃, etc. The ordering matters — different orderings would give different sets.",
-      "**Boundary elements**: The smallest element of D_n is always the least prime factor of n (= n.minFac), and the largest is σ(n) - 1, the sum of all divisors minus 1. This anchors the partial sum set.",
-      "**New elements grow**: Each n contributes at least one new partial sum not seen in any earlier D_m. The rate of new element generation relates to the growth of ⋃_n D_n.",
-      "**Sublinear first appearance**: f(N) = o(N) would mean that to represent N as a partial divisor sum, you don't need n anywhere near N itself. Highly composite numbers n have many divisors and thus many partial sums, so they represent many N values efficiently.",
-      "**Almost-all weakening**: The weaker conjecture f(N) = o(N) for almost all N allows a density-zero set of exceptions, which may be more tractable via averaging arguments."
+      "**Cumulative sum construction**: $D_n = \\{d_1, d_1+d_2, \\ldots, \\sum_{i=1}^k d_i\\}$ where $1 < d_1 < \\cdots < d_k$ are divisors of $n$. The ordering is essential — different orderings yield different partial sum sets. We have $|D_n| = d(n) - 1$ where $d(n)$ is the divisor count.",
+      "**Boundary anchoring**: $\\min(D_n) = p_1(n)$ (smallest prime factor) and $\\max(D_n) = \\sigma(n) - 1$ where $\\sigma(n) = \\sum_{d \\mid n} d$. This bounds $D_n \\subseteq [p_1(n),\\, \\sigma(n) - 1]$.",
+      "**New elements exist**: Each $n \\geq 2$ contributes at least one new partial sum not in $\\bigcup_{m<n} D_m$. The rate of new element generation determines how quickly $\\bigcup_n D_n$ covers $\\mathbb{N}$.",
+      "**Sublinear first appearance**: $f(N) = o(N)$ would mean partial divisor sums cover $\\mathbb{N}$ efficiently — each $N$ arises from some $n \\ll N$. Highly composite numbers (large $d(n)$) generate many partial sums from a single $n$.",
+      "**Almost-all weakening**: $f(N) = o(N)$ for density-1 set of $N$ allows a measure-zero set of exceptions. This may be tractable via averaging: $\\sum_{N \\leq M} f(N)/N = o(M)$ would suffice."
     ],
     "mathlibDependencies": [
-      "Mathlib.Data.Nat.Divisors",
-      "Mathlib.Data.Finset.Card",
-      "Mathlib.Data.Finset.Sort",
-      "Mathlib.Data.Nat.Basic"
+      { "theorem": "Nat.divisors", "description": "Set of all divisors of n", "module": "Mathlib.Data.Nat.Divisors" },
+      { "theorem": "Finset.card", "description": "Cardinality of finite sets", "module": "Mathlib.Data.Finset.Card" },
+      { "theorem": "Finset.sort", "description": "Sorting finite sets into ordered lists", "module": "Mathlib.Data.Finset.Sort" },
+      { "theorem": "Nat.minFac", "description": "Smallest prime factor of n", "module": "Mathlib.Data.Nat.Basic" }
     ],
     "originalContributions": [
       "properDivisorsSorted: sorted divisors > 1 via Finset.sort",
@@ -51,46 +52,58 @@
       "erdos_468_almost_all: f(N) = o(N) almost-all form",
       "d6_example, d12_example: concrete computations",
       "smallest_partial_sum, largest_partial_sum: boundary axioms"
+    ],
+    "relatedProofs": [
+      { "id": "erdos-955", "relationship": "Sum of proper divisors σ(n)−n — studies the same divisor function but takes total sums rather than partial sums" },
+      { "id": "erdos-466", "relationship": "Divisor-related combinatorial number theory from the same section of the Erdős–Graham monograph" }
     ]
   },
   "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 17,
+      "endLine": 21,
+      "summary": "Imports `Nat.Divisors`, `Finset.Card`, `Finset.Sort`, `Nat.Basic`, and `Tactic`."
+    },
     {
       "id": "core-definitions",
       "title": "Core Definitions",
       "startLine": 23,
       "endLine": 42,
-      "summary": "Defines properDivisorsSorted (divisors > 1 in order), partialDivisorSums (D_n as cumulative sums), previousPartialSums (union of earlier sets), and newElements (genuinely new partial sums)."
+      "summary": "Defines `properDivisorsSorted`, `partialDivisorSums` ($D_n$), `previousPartialSums` ($\\bigcup_{m<n} D_m$), and `newElements` ($D_n \\setminus \\bigcup_{m<n} D_m$)."
     },
     {
       "id": "question-1",
       "title": "Question 1: New Elements",
       "startLine": 44,
       "endLine": 55,
-      "summary": "Axiomatizes that each n ≥ 2 contributes nonempty new elements, and conjectures the count grows without bound."
+      "summary": "Axiomatizes $D_n \\setminus \\bigcup_{m<n} D_m \\neq \\emptyset$ for $n \\geq 2$ and conjectures $|D_n| \\to \\infty$."
     },
     {
       "id": "question-2",
-      "title": "Question 2: First Appearance",
+      "title": "Question 2: First Appearance $f(N)$",
       "startLine": 57,
       "endLine": 73,
-      "summary": "Defines firstAppearance f(N) via sInf. States strong conjecture (f(N) = o(N) for all N) and weak form (for almost all N via density)."
+      "summary": "Defines $f(N) = \\inf\\{n : N \\in D_n\\}$ via `sInf`. States strong conjecture $f(N) = o(N)$ and weak form (for density-1 set of $N$)."
     },
     {
       "id": "examples",
-      "title": "Examples and Observations",
+      "title": "Examples and Boundary Elements",
       "startLine": 75,
       "endLine": 95,
-      "summary": "Concrete examples: D_6 = {2,5,11}, D_12 = {2,5,9,15,27}. Boundary axioms: smallest element is minFac(n), largest is σ(n)-1."
+      "summary": "$D_6 = \\{2, 5, 11\\}$, $D_{12} = \\{2, 5, 9, 15, 27\\}$. Boundary: $\\min(D_n) = p_1(n)$, $\\max(D_n) = \\sigma(n) - 1$."
     }
   ],
   "conclusion": {
     "summary": "Erdős Problem 468 asks about partial sums of divisors: how many are new for each n, and how quickly does f(N) grow? Both questions remain open. The formalization captures the construction, examples, and both the strong and almost-all conjectures. 0 sorries.",
     "implications": "Understanding partial divisor sums would shed light on the additive structure of divisor sets, connecting multiplicative number theory to additive combinatorics.",
     "openQuestions": [
-      "How large is |D_n \\ ⋃_{m<n} D_m| as a function of n?",
-      "Is f(N) = o(N) for all N, or only for almost all N?",
-      "What is the density of ⋃_n D_n in ℕ — does every large integer eventually appear?",
-      "How does the number of partial sums |D_n| relate to d(n), the number of divisors of n?"
+      "How large is $|D_n \\setminus \\bigcup_{m<n} D_m|$ as a function of $n$? Does it grow like $d(n)$ or slower?",
+      "Is $f(N) = o(N)$ for all $N$, or only for a density-1 subset? What is the growth rate of $f(N)$?",
+      "Does $\\bigcup_n D_n$ have density 1 in $\\mathbb{N}$? Does every sufficiently large integer eventually appear as a partial divisor sum?",
+      "What is $\\max(D_n) - \\min(D_n) = \\sigma(n) - 1 - p_1(n)$, and how does the internal structure of $D_n$ relate to the factorization of $n$?",
+      "Can the problem be generalized to other orderings of divisors, or to $k$-th smallest divisors?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enrich erdos-468 (Partial Sums of Divisors) with deeper annotations, cross-references, and mathematical context
- Add `mathContext`, `relatedConcepts`, `prerequisites` to all 7 annotations covering full Lean file
- Add `leanFile`, `relatedProofs` (erdos-955, erdos-466), structured `mathlibDependencies`
- Fix invalid annotation types (`conjecture`→`theorem`, `note`→`insight`) and significance (`high`/`medium`→`critical`/`key`/`supporting`)
- Add LaTeX to sections, keyInsights, proofStrategy, and openQuestions

## Test plan
- [x] `pnpm annotations:build` passes with no erdos-468 errors
- [x] All annotations have valid types and significance values
- [x] All annotations have mathContext, relatedConcepts, prerequisites

🤖 Generated with [Claude Code](https://claude.com/claude-code)