### PR TITLE
enrich: deepen annotations and meta for erdos-52

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -260,6 +260,56 @@
       "passes": 1,
       "lastEnriched": "2026-02-11T18:44:48Z",
       "quality": 100
+    },
+    "erdos-955": {
+      "passes": 3,
+      "lastEnriched": "2026-02-11T21:27:17Z",
+      "quality": 100
+    },
+    "erdos-956": {
+      "passes": 1,
+      "lastEnriched": "2026-02-11T21:23:17Z",
+      "quality": 100
+    },
+    "erdos-1161": {
+      "passes": 2,
+      "lastEnriched": "2026-02-11T21:32:37Z",
+      "quality": 100
+    },
+    "erdos-117": {
+      "passes": 2,
+      "lastEnriched": "2026-02-11T21:35:41Z",
+      "quality": 98
+    },
+    "erdos-181": {
+      "passes": 2,
+      "lastEnriched": "2026-02-11T21:38:49Z",
+      "quality": 100
+    },
+    "erdos-319": {
+      "passes": 2,
+      "lastEnriched": "2026-02-11T21:43:38Z",
+      "quality": 98
+    },
+    "erdos-361": {
+      "passes": 1,
+      "lastEnriched": "2026-02-11T21:41:17Z",
+      "quality": 100
+    },
+    "erdos-422": {
+      "passes": 1,
+      "lastEnriched": "2026-02-11T21:44:00Z",
+      "quality": 100
+    },
+    "erdos-424": {
+      "passes": 1,
+      "lastEnriched": "2026-02-11T21:47:34Z",
+      "quality": 98
+    },
+    "erdos-468": {
+      "passes": 1,
+      "lastEnriched": "2026-02-11T21:47:38Z",
+      "quality": 100
     }
   }
 }

--- a/src/data/proofs/erdos-52/annotations.json
+++ b/src/data/proofs/erdos-52/annotations.json
@@ -1,56 +1,98 @@
 [
   {
-    "id": "erdos-52-defs",
+    "id": "ann-e52-imports",
     "proofId": "erdos-52",
-    "type": "definition",
+    "range": { "startLine": 14, "endLine": 20 },
+    "type": "concept",
+    "title": "Imports and Dependencies",
+    "content": "Imports `Nat.Basic` and `Int.Basic` for integer arithmetic, `Finset.Basic`/`Finset.Card`/`Finset.Image` for finite set operations (the core data structure), and `Real.Basic` for real exponents in the conjecture statement. The formalization works over $\\mathbb{Z}$ (integers) via `Finset ℤ`, using `Finset.image` for sumsets and product sets, and real-valued exponentiation `(|A| : \\mathbb{R})^{2-\\varepsilon}` for the bound.",
+    "mathContext": "All sets are `Finset ℤ`. Bounds are stated in $\\mathbb{R}$ to handle fractional exponents: $(|A| : \\mathbb{R})^{2-\\varepsilon}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset", "integer arithmetic", "real exponentiation", "Finset.image"],
+    "prerequisites": ["Lean 4 imports", "Mathlib finite set library", "real number basics"]
+  },
+  {
+    "id": "ann-e52-defs",
+    "proofId": "erdos-52",
     "range": { "startLine": 26, "endLine": 36 },
-    "title": "Sumset and Product Set",
-    "content": "sumset A computes {a+b : a,b ∈ A}, productset A computes {a·b : a,b ∈ A}. sumProductMax takes the maximum of their cardinalities — the central quantity in the conjecture.",
-    "significance": "essential"
+    "type": "definition",
+    "title": "Sumset, Product Set, and Sum-Product Maximum",
+    "content": "Three definitions. **sumset**: $A + A = \\{a + b : a, b \\in A\\}$ computed via `(A ×ˢ A).image (fun p => p.1 + p.2)`. **productset**: $A \\cdot A = \\{a \\cdot b : a, b \\in A\\}$ via the same Cartesian product pattern. **sumProductMax**: $\\max(|A+A|, |A \\cdot A|)$, the central quantity. The use of `Finset.product` (`×ˢ`) with `Finset.image` is the standard Lean pattern for defining sumsets. Note these include $a + a$ and $a \\cdot a$ (not just distinct pairs), matching the standard convention.",
+    "mathContext": "$A + A = \\{a + b : a, b \\in A\\}$, $A \\cdot A = \\{ab : a, b \\in A\\}$. Central quantity: $\\max(|A+A|, |A \\cdot A|)$.",
+    "significance": "critical",
+    "relatedConcepts": ["sumset", "product set", "Finset.product", "Finset.image", "Cartesian product"],
+    "prerequisites": ["Finset operations", "integer arithmetic", "max function"]
   },
   {
-    "id": "erdos-52-conjecture",
+    "id": "ann-e52-conjecture",
     "proofId": "erdos-52",
-    "type": "conjecture",
     "range": { "startLine": 42, "endLine": 52 },
-    "title": "Erdős Problem 52",
-    "content": "For every ε > 0, there exists C > 0 such that max(|A+A|, |A·A|) ≥ C·|A|^{2-ε} for all finite sets A with |A| ≥ 2. This is the Erdős–Szemerédi sum-product conjecture, with a $250 prize.",
-    "significance": "essential"
+    "type": "definition",
+    "title": "Erdős Problem #52: The Sum-Product Conjecture",
+    "content": "The conjecture is defined as a `Prop` (not axiom): $\\forall \\varepsilon > 0,\\; \\exists C > 0,\\; \\forall A \\subseteq \\mathbb{Z}$ with $|A| \\geq 2$: $\\max(|A+A|, |A \\cdot A|) \\geq C \\cdot |A|^{2-\\varepsilon}$. The exponent $2 - \\varepsilon$ is optimal: geometric progressions have $|A \\cdot A| = O(|A|^2)$ but $|A + A| \\sim |A|^2$, so the conjecture says one of the two operations must produce near-quadratic output. This is one of the most famous open problems in additive combinatorics, with a **\\$250 Erdős prize**.",
+    "mathContext": "**Conjecture (OPEN, \\$250):** $\\forall \\varepsilon > 0,\\; \\exists C > 0: \\max(|A+A|, |A \\cdot A|) \\geq C |A|^{2-\\varepsilon}$ for $|A| \\geq 2$.",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős–Szemerédi conjecture", "additive combinatorics", "sum-product phenomenon", "Erdős prize"],
+    "prerequisites": ["sumset", "productset", "real exponentiation", "universal-existential statements"]
   },
   {
-    "id": "erdos-52-es-theorem",
+    "id": "ann-e52-es-theorem",
     "proofId": "erdos-52",
-    "type": "result",
     "range": { "startLine": 58, "endLine": 64 },
-    "title": "Erdős–Szemerédi Theorem",
-    "content": "Erdős and Szemerédi (1983) proved that max(|A+A|, |A·A|) ≥ |A|^{1+c} for some absolute constant c > 0. This was the first result establishing super-linear growth.",
-    "significance": "essential"
+    "type": "theorem",
+    "title": "Erdős–Szemerédi Theorem (1983)",
+    "content": "The foundational result: $\\exists c > 0$ such that $\\max(|A+A|, |A \\cdot A|) \\geq |A|^{1+c}$ for all finite $A \\subseteq \\mathbb{Z}$ with $|A| \\geq 2$. This proved the first **super-linear** lower bound, confirming that the sum-product phenomenon is real. The original constant $c$ was very small; subsequent work by Elekes, Solymosi, and others improved it substantially. The axiomatized form uses an existential for $c$ without specifying its value.",
+    "mathContext": "**Erdős–Szemerédi (1983):** $\\exists c > 0: \\max(|A+A|, |A \\cdot A|) \\geq |A|^{1+c}$ for $|A| \\geq 2$.",
+    "significance": "critical",
+    "relatedConcepts": ["super-linear bounds", "sum-product phenomenon", "incidence geometry", "Szemerédi–Trotter theorem"],
+    "prerequisites": ["sumProductMax", "real exponentiation"]
   },
   {
-    "id": "erdos-52-bloom",
+    "id": "ann-e52-bloom",
     "proofId": "erdos-52",
-    "type": "result",
     "range": { "startLine": 70, "endLine": 77 },
-    "title": "Bloom's 2025 Bound",
-    "content": "Bloom (2025) proved the current best exponent: max(|A+A|, |A·A|) ≥ |A|^{1270/951-o(1)} ≈ |A|^{1.335}. This improves on a long line of successive bounds since Erdős–Szemerédi.",
-    "significance": "essential"
+    "type": "theorem",
+    "title": "Bloom's Bound (2025): Exponent $1270/951$",
+    "content": "The current best result: $\\max(|A+A|, |A \\cdot A|) \\geq |A|^{1270/951 - o(1)}$ where $1270/951 \\approx 1.335$. Formalized as: $\\forall \\varepsilon > 0,\\; \\exists N_0,\\; \\forall A$ with $|A| \\geq N_0$: $\\max(|A+A|, |A \\cdot A|) \\geq |A|^{1270/951 - \\varepsilon}$. The exponent improves a long succession: Elekes ($5/4$), Solymosi ($4/3 - \\varepsilon$), Konyagin–Shkredov, Rudnev–Stevens, and finally Bloom. The gap from $1.335$ to the conjectured $2$ remains enormous.",
+    "mathContext": "**Bloom (2025):** $\\max(|A+A|, |A \\cdot A|) \\geq |A|^{1270/951 - \\varepsilon}$ for $|A| \\gg_\\varepsilon 1$. Exponent $\\approx 1.335$.",
+    "significance": "key",
+    "relatedConcepts": ["Elekes's crossing number method", "Solymosi's bound", "Konyagin–Shkredov", "exponent improvements"],
+    "prerequisites": ["sumProductMax", "Erdős–Szemerédi theorem"]
   },
   {
-    "id": "erdos-52-generalized",
+    "id": "ann-e52-trivial",
     "proofId": "erdos-52",
-    "type": "conjecture",
+    "range": { "startLine": 83, "endLine": 98 },
+    "type": "theorem",
+    "title": "Trivial Bounds on Sumsets and Product Sets",
+    "content": "Four elementary bounds. **Lower bounds**: $|A| \\leq |A+A|$ (since $a + \\min(A)$ gives $|A|$ distinct sums) and $|A| \\leq |A \\cdot A|$ (when $0 \\notin A$ and $|A| \\geq 2$). **Upper bounds**: $|A+A| \\leq |A|^2$ and $|A \\cdot A| \\leq |A|^2$ (at most $|A|^2$ pairs). Thus $|A| \\leq \\max(|A+A|, |A \\cdot A|) \\leq |A|^2$. The conjecture asserts the lower bound is nearly $|A|^2$.",
+    "mathContext": "**Trivial:** $|A| \\leq |A+A|, |A \\cdot A| \\leq |A|^2$. The conjecture asks: is the lower bound closer to $|A|^{2-\\varepsilon}$?",
+    "significance": "supporting",
+    "relatedConcepts": ["trivial bounds", "quadratic upper bound", "Cauchy–Davenport theorem"],
+    "prerequisites": ["sumset", "productset", "Finset.card inequalities"]
+  },
+  {
+    "id": "ann-e52-generalized",
+    "proofId": "erdos-52",
     "range": { "startLine": 104, "endLine": 122 },
-    "title": "Generalized Sum-Product Conjecture",
-    "content": "For m ≥ 2 and every ε > 0, max(|mA|, |A^m|) ≥ C·|A|^{m-ε}. This extends the pairwise conjecture to arbitrary m-fold operations.",
-    "significance": "essential"
+    "type": "definition",
+    "title": "Higher-Fold Generalization: $m$-fold Sum-Product",
+    "content": "Defines $m$-fold operations recursively: $mA$ (iterated sumset) and $A^m$ (iterated product set) via `mfoldSumset` and `mfoldProductset`. The generalized conjecture `GeneralizedSumProduct m` states: for $m \\geq 2$ and $\\varepsilon > 0$, $\\max(|mA|, |A^m|) \\geq C \\cdot |A|^{m-\\varepsilon}$. The base case $m = 2$ recovers Problem #52. For $m = 1$, the bound $|A|^{1-\\varepsilon}$ is trivially true. The higher-fold version is even less understood than the pairwise case.",
+    "mathContext": "$mA = A + \\cdots + A$ ($m$ times), $A^m = A \\cdot \\cdots \\cdot A$. **Conjecture:** $\\max(|mA|, |A^m|) \\geq C |A|^{m-\\varepsilon}$.",
+    "significance": "key",
+    "relatedConcepts": ["iterated sumsets", "iterated product sets", "Plünnecke–Ruzsa inequality", "higher-fold sum-product"],
+    "prerequisites": ["sumset", "productset", "recursive definitions", "ErdosProblem52"]
   },
   {
-    "id": "erdos-52-connection",
+    "id": "ann-e52-connection",
     "proofId": "erdos-52",
-    "type": "context",
     "range": { "startLine": 128, "endLine": 135 },
-    "title": "Connection to Problem 53",
-    "content": "Problem 52 (pairwise sums/products) is closely related to Problem 53 (sums/products of distinct subsets, resolved by Chang 2003). A large sumset or product set implies many distinct representations.",
-    "significance": "supporting"
+    "type": "insight",
+    "title": "Connection to Problem #53 (Chang 2003)",
+    "content": "Problem #52 (pairwise operations) relates to Problem #53 (distinct subset sums and products), resolved by Chang (2003). The axiom states $|A+A| + |A \\cdot A| \\geq |A|$ for $|A| \\geq 2$, a weak consequence. The deeper connection: if $|A+A|$ is small (near $|A|$), then $A$ has additive structure (approximate subgroup), which forces $|A \\cdot A|$ to be large. This structural dichotomy — additive or multiplicative structure but not both — is the philosophical core of the sum-product phenomenon.",
+    "mathContext": "**Chang (2003):** resolved Problem #53 on distinct subset sums/products. **Connection:** small $|A+A|$ implies additive structure, forcing large $|A \\cdot A|$.",
+    "significance": "key",
+    "relatedConcepts": ["Problem 53", "Chang's theorem", "additive structure", "approximate groups"],
+    "prerequisites": ["sumset", "productset", "Freiman's theorem"]
   }
 ]

--- a/src/data/proofs/erdos-52/meta.json
+++ b/src/data/proofs/erdos-52/meta.json
@@ -8,6 +8,7 @@
     "sourceUrl": "https://erdosproblems.com/52",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos52Problem.lean",
+    "leanFile": "Proofs/Erdos52Problem.lean",
     "tags": [
       "erdos",
       "additive-combinatorics",
@@ -18,77 +19,98 @@
     "sorries": 0,
     "erdosNumber": 52,
     "erdosUrl": "https://erdosproblems.com/52",
-    "erdosProblemStatus": "open"
+    "erdosProblemStatus": "open",
+    "mathlib_version": "4.15.0",
+    "mathlibDependencies": [
+      { "theorem": "Finset.card", "description": "Cardinality of finite sets", "module": "Mathlib.Data.Finset.Card" },
+      { "theorem": "Finset.image", "description": "Image of a function on a finite set", "module": "Mathlib.Data.Finset.Image" },
+      { "theorem": "Int.add", "description": "Integer addition for sumset construction", "module": "Mathlib.Data.Int.Basic" },
+      { "theorem": "Real.rpow", "description": "Real exponentiation for fractional exponents", "module": "Mathlib.Data.Real.Basic" }
+    ],
+    "relatedProofs": [
+      { "id": "erdos-1", "relationship": "Foundational Erdős problem — both concern extremal combinatorial structure" },
+      { "id": "erdos-10", "relationship": "Erdős–Sós conjecture on trees — related extremal combinatorics problem from the same era" }
+    ]
   },
   "overview": {
     "historicalContext": "The Erdős–Szemerédi sum-product conjecture (1983) is one of the most influential problems in additive combinatorics. It asserts that a finite set cannot simultaneously have small sumset and small product set. Erdős and Szemerédi proved the first super-linear bound |A|^{1+c}. Successive improvements by Solymosi, Konyagin–Shkredov, Rudnev–Stevens, and Bloom have raised the exponent, with Bloom (2025) achieving |A|^{1270/951} ≈ |A|^{1.335}. The conjectured exponent 2-ε remains far out of reach. Related to Problems 53, 808, 818.",
     "problemStatement": "For every ε > 0, does there exist C > 0 such that for every finite set A ⊂ ℤ with |A| ≥ 2, max(|A+A|, |A·A|) ≥ C·|A|^{2-ε}?",
-    "proofStrategy": "We define sumset, productset, and sumProductMax. The main conjecture ErdosProblem52 asserts the near-quadratic lower bound. We axiomatize the Erdős–Szemerédi theorem and Bloom's current best bound. Trivial bounds and higher-fold generalizations are formalized. The connection to Problem 53 is stated.",
+    "proofStrategy": "The formalization defines `sumset` ($A+A$), `productset` ($A \\cdot A$), and `sumProductMax` ($\\max(|A+A|, |A \\cdot A|)$) using `Finset.product` and `Finset.image`. The conjecture `ErdosProblem52` is a `def : Prop` asserting $\\max(|A+A|, |A \\cdot A|) \\geq C |A|^{2-\\varepsilon}$. The Erdős–Szemerédi theorem ($|A|^{1+c}$) and Bloom's bound ($|A|^{1270/951 - \\varepsilon}$) are axiomatized. Trivial bounds ($|A| \\leq |A+A| \\leq |A|^2$) and $m$-fold generalizations are formalized. The connection to Problem #53 (Chang 2003) is stated. All deep results are axioms (0 sorries).",
     "keyInsights": [
-      "A set cannot simultaneously have both small sumset and small product set",
-      "Erdős–Szemerédi (1983): max(|A+A|, |A·A|) ≥ |A|^{1+c} for some c > 0",
-      "Bloom (2025): current best exponent 1270/951 ≈ 1.335, still far from the conjectured 2-ε",
-      "The higher-fold generalization asks for max(|mA|, |A^m|) ≥ |A|^{m-ε}"
+      "**Sum-product dichotomy**: A finite set $A$ cannot simultaneously have small sumset $|A+A|$ and small product set $|A \\cdot A|$. Arithmetic progressions have $|A+A| = O(|A|)$ but $|A \\cdot A| \\sim |A|^2$; geometric progressions have the reverse. The conjecture asserts one must always be near-quadratic.",
+      "**Erdős–Szemerédi (1983)**: $\\max(|A+A|, |A \\cdot A|) \\geq |A|^{1+c}$ for some $c > 0$. This was the first super-linear bound, proved using the Szemerédi–Trotter incidence theorem. The original $c$ was tiny.",
+      "**Bloom (2025)**: Current best exponent $1270/951 \\approx 1.335$, extending a line of improvements: Elekes ($5/4$), Solymosi ($4/3 - \\varepsilon$), Konyagin–Shkredov ($4/3 + c$), Rudnev–Stevens. The gap to the conjectured $2 - \\varepsilon$ remains vast.",
+      "**Incidence geometry connection**: All major advances use point-line incidence bounds (Szemerédi–Trotter). Elekes's key insight: $|A+A| \\cdot |A \\cdot A|$ counts incidences of the point set $A \\times A$ with lines $y = a(x-b)$.",
+      "**Higher-fold generalization**: For $m$-fold operations, $\\max(|mA|, |A^m|) \\geq C |A|^{m-\\varepsilon}$ is conjectured. The Plünnecke–Ruzsa inequality gives bounds for iterated sumsets but not the full sum-product version."
     ]
   },
   "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 14,
+      "endLine": 20,
+      "summary": "Imports `Finset.Basic`/`Card`/`Image`, `Int.Basic`, `Real.Basic`, `Tactic`. All sets are `Finset ℤ`."
+    },
     {
       "id": "sumset-productset",
       "title": "Sumset and Product Set",
       "startLine": 22,
       "endLine": 36,
-      "summary": "Defines sumset A+A, productset A·A, and sumProductMax as the maximum of their cardinalities."
+      "summary": "Defines $A+A$, $A \\cdot A$ via `Finset.product` and `Finset.image`, and $\\max(|A+A|, |A \\cdot A|)$."
     },
     {
       "id": "conjecture",
       "title": "The Sum-Product Conjecture",
       "startLine": 38,
       "endLine": 52,
-      "summary": "States ErdosProblem52: for every ε > 0, max(|A+A|, |A·A|) ≥ C·|A|^{2-ε} for some constant C."
+      "summary": "States `ErdosProblem52`: $\\forall \\varepsilon > 0,\\; \\exists C > 0: \\max(|A+A|, |A \\cdot A|) \\geq C |A|^{2-\\varepsilon}$."
     },
     {
       "id": "erdos-szemeredi",
-      "title": "The Erdős–Szemerédi Theorem",
+      "title": "The Erdős–Szemerédi Theorem (1983)",
       "startLine": 54,
       "endLine": 64,
-      "summary": "Axiomatizes the foundational 1983 result: max(|A+A|, |A·A|) ≥ |A|^{1+c} for some c > 0."
+      "summary": "Axiomatizes $\\exists c > 0: \\max(|A+A|, |A \\cdot A|) \\geq |A|^{1+c}$ — the first super-linear bound."
     },
     {
       "id": "bloom-bound",
-      "title": "Current Best Bound",
+      "title": "Bloom's Bound (2025)",
       "startLine": 66,
       "endLine": 77,
-      "summary": "Axiomatizes Bloom's 2025 bound: exponent 1270/951 ≈ 1.335."
+      "summary": "Axiomatizes $\\max(|A+A|, |A \\cdot A|) \\geq |A|^{1270/951 - \\varepsilon}$ where $1270/951 \\approx 1.335$."
     },
     {
       "id": "trivial-bounds",
       "title": "Trivial Bounds",
       "startLine": 79,
       "endLine": 98,
-      "summary": "Axiomatizes that |A| ≤ |A+A|, |A| ≤ |A·A|, and both are at most |A|²."
+      "summary": "Four bounds: $|A| \\leq |A+A|$, $|A| \\leq |A \\cdot A|$ (when $0 \\notin A$), and both $\\leq |A|^2$."
     },
     {
       "id": "generalizations",
-      "title": "Higher-Fold Generalizations",
+      "title": "$m$-Fold Generalizations",
       "startLine": 100,
       "endLine": 122,
-      "summary": "Defines m-fold sumset and product set, and states the generalized conjecture for arbitrary m ≥ 2."
+      "summary": "Defines $mA$ and $A^m$ recursively. States $\\max(|mA|, |A^m|) \\geq C |A|^{m-\\varepsilon}$ for $m \\geq 2$."
     },
     {
       "id": "connection-p53",
-      "title": "Connection to Problem 53",
+      "title": "Connection to Problem #53",
       "startLine": 124,
       "endLine": 135,
-      "summary": "States the connection to Problem 53: large sumset or product set implies many representations."
+      "summary": "Problem #53 (Chang 2003) on subset sums/products is related: large $|A+A|$ or $|A \\cdot A|$ implies many representations."
     }
   ],
   "conclusion": {
     "summary": "Erdős Problem 52 asks for a near-quadratic lower bound on max(|A+A|, |A·A|). The Erdős–Szemerédi theorem established super-linearity, and successive improvements have reached exponent ~1.335 (Bloom 2025), but the conjectured exponent 2-ε remains open.",
     "implications": "Resolution would be a breakthrough in additive combinatorics, with implications for incidence geometry, exponential sums, and the structure theory of finite sets.",
     "openQuestions": [
-      "Can the exponent be improved beyond 1270/951?",
-      "Does the conjecture hold for all rings, not just integers?",
-      "What is the correct higher-fold generalization for m-fold sums and products?"
+      "Can the exponent be improved beyond $1270/951 \\approx 1.335$? Is $3/2$ achievable?",
+      "Does the conjecture hold over all rings (e.g., $\\mathbb{F}_p$, $\\mathbb{R}$)? Bourgain–Katz–Tao proved it for $\\mathbb{F}_p$ with exponent $1 + \\varepsilon$.",
+      "Is the $m$-fold generalization $\\max(|mA|, |A^m|) \\geq C |A|^{m-\\varepsilon}$ true for $m \\geq 3$?",
+      "What is the extremal structure? Do sets near the bound necessarily have 'additive' or 'multiplicative' structure (approximate arithmetic progressions or geometric progressions)?",
+      "Can the sum-product phenomenon be proved for specific families (e.g., subsets of primes, random sets) with better exponents?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enrich erdos-52 (The Sum-Product Conjecture) with deeper annotations, cross-references, and mathematical context
- Add `mathContext`, `relatedConcepts`, `prerequisites` to all 8 annotations covering full Lean file (135 lines)
- Add `leanFile`, `relatedProofs`, structured `mathlibDependencies` (Finset.card, Finset.image, Int.add, Real.rpow)
- Fix invalid annotation types (`conjecture`→`definition`, `result`→`theorem`, `context`→`insight`) and significance (`essential`→`critical`/`key`/`supporting`)
- Add LaTeX to sections, keyInsights, proofStrategy, and openQuestions
- Deepen keyInsights with incidence geometry connection and Elekes's crossing number method

## Test plan
- [x] `pnpm annotations:build` passes with no erdos-52 errors
- [x] All annotations have valid types and significance values
- [x] All annotations have mathContext, relatedConcepts, prerequisites

🤖 Generated with [Claude Code](https://claude.com/claude-code)