### PR TITLE
enrich: deepen annotations and meta for erdos-947, erdos-98

### DIFF
--- a/src/data/proofs/erdos-98/annotations.json
+++ b/src/data/proofs/erdos-98/annotations.json
@@ -1,74 +1,86 @@
 [
   {
-    "id": "general-position",
+    "id": "ann-e98-imports",
     "proofId": "erdos-98",
-    "type": "definition",
-    "title": "General Position",
-    "content": "A point set is in general position if all points are distinct, no 3 are collinear, and no 4 are concyclic. This prevents structured configurations that minimize distinct distances.",
-    "significance": "critical",
-    "range": {
-      "startLine": 43,
-      "endLine": 45
-    }
+    "range": { "startLine": 15, "endLine": 20 },
+    "type": "concept",
+    "title": "Imports and Dependencies",
+    "content": "Imports `InnerProductSpace.Basic` for `EuclideanSpace ℝ (Fin 2)` and the `dist` metric, `SpecialFunctions.Log.Basic` for `Real.log`, `Real.exp`, `Real.sqrt` used in upper bounds, `Finset.Basic` and `Finset.Card` for counting distinct distances, and `Filter.Basic` for `Filter.Tendsto` and `Filter.atTop` in the asymptotic statements. The `Tactic` import provides `omega`, `simp`, and other automation.",
+    "mathContext": "The formalization represents $\\mathbb{R}^2$ as `EuclideanSpace ℝ (Fin 2)`, a type alias for `PiLp 2 (fun _ : Fin 2 ↦ ℝ)`. The metric $d(P, Q) = \\|P - Q\\|_2$ is provided by `dist`. Asymptotic statements use `Filter.atTop` for $n \\to \\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": ["EuclideanSpace", "dist metric", "Filter.atTop", "Real.log", "Real.exp"],
+    "prerequisites": ["Lean 4 imports", "inner product spaces", "Mathlib filter library"]
   },
   {
-    "id": "h-function",
+    "id": "ann-e98-general-position",
     "proofId": "erdos-98",
+    "range": { "startLine": 25, "endLine": 46 },
     "type": "definition",
-    "title": "The Function h(n)",
-    "content": "h(n) is the minimum number of distinct distances among all n-point configurations in general position. The conjecture is h(n)/n → ∞.",
+    "title": "Point Configuration and General Position",
+    "content": "**PointConfig** $n$ defines an $n$-point configuration as `Fin n → EuclideanSpace ℝ (Fin 2)` — a function assigning each index a point in $\\mathbb{R}^2$.\n\n**NoThreeCollinear**: for any 3 distinct indices $i, j, k$, no affine line $ax + by + c = 0$ passes through all three points. Formalized via the non-existence of $(a, b, c) \\neq (0, 0, 0)$ satisfying all three linear equations.\n\n**NoFourConcyclic**: for any 4 distinct indices, no circle with center and radius $r$ passes through all four. Uses `dist center (P i) = r`.\n\n**InGeneralPosition**: `Function.Injective P` (all points distinct) $\\wedge$ `NoThreeCollinear P` $\\wedge$ `NoFourConcyclic P`.",
+    "mathContext": "General position in $\\mathbb{R}^2$: no 3 points on a line, no 4 on a circle. The collinearity test uses the affine equation $ax + by + c = 0$ rather than cross products. The concyclicity test checks equidistance from a common center. The $\\sqrt{n} \\times \\sqrt{n}$ integer lattice has $\\Theta(n^{3/2})$ collinear triples, so general position excludes the extremal configurations for the unrestricted distinct distances problem.",
     "significance": "critical",
-    "range": {
-      "startLine": 55,
-      "endLine": 58
-    }
+    "relatedConcepts": ["Function.Injective", "affine lines", "circles", "Finset.card for distinctness"],
+    "prerequisites": ["EuclideanSpace ℝ (Fin 2)", "Finset cardinality", "dist metric"]
   },
   {
-    "id": "pach-bound",
+    "id": "ann-e98-distances",
     "proofId": "erdos-98",
+    "range": { "startLine": 51, "endLine": 59 },
+    "type": "definition",
+    "title": "Distinct Distances and $h(n)$",
+    "content": "**numDistinctDistances**: counts the number of distinct positive pairwise distances. Computed as the cardinality of $\\{d(P_i, P_j) : i, j \\in \\text{Fin}\\; n,\\; d(P_i, P_j) > 0\\}$ using `Finset.univ.product`, `Finset.image`, and `Finset.filter`.\n\n**$h(n)$**: the infimum over all general-position configurations of $n$ points. Defined via `sInf` on the set $\\{\\text{numDistinctDistances}(P) : P \\text{ in general position}\\}$. Both are `noncomputable` due to the use of `sInf` and `dist`.",
+    "mathContext": "$h(n) = \\min\\{|\\{d(P_i, P_j) : 1 \\leq i < j \\leq n\\}| : P \\text{ in general position}\\}$. The filter $d > 0$ excludes self-distances $d(P_i, P_i) = 0$. Using `sInf` rather than `Finset.min` handles the case where the set of configurations may be infinite (it always is for $n \\geq 3$).",
+    "significance": "critical",
+    "relatedConcepts": ["sInf", "Finset.image", "Finset.filter", "noncomputable definitions", "pairwise distances"],
+    "prerequisites": ["PointConfig", "InGeneralPosition", "dist", "Finset.product"]
+  },
+  {
+    "id": "ann-e98-pach",
+    "proofId": "erdos-98",
+    "range": { "startLine": 64, "endLine": 66 },
     "type": "theorem",
     "title": "Pach's Upper Bound",
-    "content": "h(n) < n^{log₂ 3} ≈ n^{1.585}: there exist general-position configurations with fewer than n^{1.585} distinct distances.",
+    "content": "**pach_upper_bound** (axiom): $h(n) < n^{\\log_2 3}$ for all sufficiently large $n$. The exponent $\\log_2 3 \\approx 1.585$ is expressed as `Real.log 3 / Real.log 2`. The `∀ᶠ n in Filter.atTop` quantifier means \"for all sufficiently large $n$\".\n\nPach's construction uses Horton sets — point sets with no empty convex pentagon — adapted to ensure general position while keeping the number of distinct distances subquadratic.",
+    "mathContext": "Pach (1993) showed $h(n) < n^{\\log_2 3}$ by constructing general-position configurations with few distinct distances using a divide-and-conquer approach. The exponent $\\log_2 3$ arises from a recurrence $T(n) = 2T(n/2) + n$ with a multiplicative distance structure.",
     "significance": "key",
-    "range": {
-      "startLine": 62,
-      "endLine": 65
-    }
+    "relatedConcepts": ["Filter.Eventually", "Filter.atTop", "Real.log", "Horton sets", "subquadratic growth"],
+    "prerequisites": ["h function", "Filter.atTop", "Real.log / Real.log (change of base)"]
   },
   {
-    "id": "efp-bound",
+    "id": "ann-e98-efp",
     "proofId": "erdos-98",
+    "range": { "startLine": 69, "endLine": 72 },
     "type": "theorem",
-    "title": "Erdős–Füredi–Pach Bound",
-    "content": "h(n) < n·exp(c√(log n)): a stronger upper bound, showing h(n) is close to linear. This is the best known upper bound on h(n).",
+    "title": "Erdős–Füredi–Pach Improved Bound",
+    "content": "**efp_upper_bound** (axiom): $\\exists c > 0$ such that $h(n) < n \\cdot \\exp(c\\sqrt{\\log n})$ for sufficiently large $n$. This is the best known upper bound on $h(n)$, showing it grows only slightly faster than linearly.\n\nThe existential $c$ is quantified first, then the eventual bound follows. The expression `Real.exp (c * Real.sqrt (Real.log n))` is a slowly growing function — much slower than any polynomial $n^\\varepsilon$.",
+    "mathContext": "The bound $h(n) < n \\cdot e^{c\\sqrt{\\log n}}$ is subpolynomial in $n$: for any $\\varepsilon > 0$, $e^{c\\sqrt{\\log n}} = o(n^\\varepsilon)$. This means $h(n)/n \\to \\infty$ would require the true growth to be between $n$ and $n \\cdot e^{c\\sqrt{\\log n}}$ — a very narrow window.",
     "significance": "critical",
-    "range": {
-      "startLine": 68,
-      "endLine": 71
-    }
+    "relatedConcepts": ["Real.exp", "Real.sqrt", "Real.log", "subpolynomial growth", "Filter.Eventually"],
+    "prerequisites": ["h function", "real exponential and logarithm", "Filter.atTop"]
   },
   {
-    "id": "main-conjecture",
+    "id": "ann-e98-conjecture",
     "proofId": "erdos-98",
-    "type": "concept",
-    "title": "The Erdős Conjecture: h(n)/n → ∞",
-    "content": "General position should force superlinearly many distinct distances. Even the weaker statement h(n) ≥ n is unknown. Open since the 1970s.",
-    "significance": "critical",
-    "range": {
-      "startLine": 75,
-      "endLine": 82
-    }
-  },
-  {
-    "id": "guth-katz",
-    "proofId": "erdos-98",
+    "range": { "startLine": 79, "endLine": 84 },
     "type": "theorem",
-    "title": "Guth–Katz Comparison",
-    "content": "Without general-position assumptions, any n points determine Ω(n/log n) distinct distances (Guth–Katz 2015). General position should give more, but this isn't proved.",
+    "title": "The Erdős Conjecture and Weak Form",
+    "content": "**ErdosProblem98** (axiom): $h(n)/n \\to \\infty$ as $n \\to \\infty$, formalized as `Filter.Tendsto (fun n ↦ h(n)/n) Filter.atTop Filter.atTop`. This is the strong conjecture: general position forces superlinearly many distinct distances.\n\n**erdos_98_weak** (axiom): $h(n) \\geq n$ for all sufficiently large $n$, using `∀ᶠ n in Filter.atTop`. Even this much weaker bound remains **open** — Erdős himself could not prove it. A proof of $h(n) \\geq n$ would already be a significant breakthrough.",
+    "mathContext": "The conjecture $h(n)/n \\to \\infty$ is equivalent to: for every $C > 0$, $h(n) > Cn$ for large $n$. The weak form $h(n) \\geq n$ asks merely for $C = 1$. The EFP bound $h(n) < n \\cdot e^{c\\sqrt{\\log n}}$ shows the conjecture, if true, would be nearly tight.",
+    "significance": "critical",
+    "relatedConcepts": ["Filter.Tendsto", "Filter.atTop", "superlinear growth", "open problems in combinatorial geometry"],
+    "prerequisites": ["h function", "Filter.Tendsto to atTop", "Filter.Eventually"]
+  },
+  {
+    "id": "ann-e98-guth-katz",
+    "proofId": "erdos-98",
+    "range": { "startLine": 91, "endLine": 95 },
+    "type": "theorem",
+    "title": "Guth–Katz Comparison (Without General Position)",
+    "content": "**guth_katz_comparison** (axiom): without any general-position assumption, any injective $n$-point configuration determines at least $c \\cdot n / \\log n$ distinct distances. This is the Guth–Katz theorem (2015), which resolved the Erdős distinct distances conjecture up to the $\\log n$ factor.\n\nThe formalization uses $\\forall n \\geq 2$ (not just eventually) with an explicit constant $c > 0$. The hypothesis `Function.Injective P` ensures all points are distinct but allows collinear and concyclic configurations.",
+    "mathContext": "Guth–Katz (2015): any $n$ points in $\\mathbb{R}^2$ determine $\\Omega(n/\\log n)$ distinct distances. Their proof uses the Elekes–Sharir framework reducing to line counting in $\\mathbb{R}^3$, then applies the polynomial partitioning technique. General position should improve this to $\\omega(n)$, but the gap between $\\Omega(n/\\log n)$ and $h(n)/n \\to \\infty$ is wide open.",
     "significance": "key",
-    "range": {
-      "startLine": 86,
-      "endLine": 93
-    }
+    "relatedConcepts": ["Guth–Katz theorem", "polynomial partitioning", "Elekes–Sharir framework", "Function.Injective"],
+    "prerequisites": ["numDistinctDistances", "PointConfig", "Real.log", "Function.Injective"]
   }
 ]

--- a/src/data/proofs/erdos-98/meta.json
+++ b/src/data/proofs/erdos-98/meta.json
@@ -8,6 +8,7 @@
     "sourceUrl": "https://erdosproblems.com/98",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos98Problem.lean",
+    "leanFile": "Proofs/Erdos98Problem.lean",
     "tags": [
       "erdos",
       "combinatorial-geometry",
@@ -25,7 +26,7 @@
   "overview": {
     "historicalContext": "The distinct distances problem is one of Erdős's most famous contributions to combinatorial geometry. In its unrestricted form, Erdős (1946) conjectured that n points in the plane determine at least Ω(n/√(log n)) distinct distances, which was finally proved (up to the √(log n) factor) by Guth and Katz in 2015 using algebraic techniques.\n\nProblem 98 considers the more structured setting where the point configuration is in 'general position': no three points collinear and no four points concyclic. These constraints eliminate lattice-like configurations (which achieve the minimum in the unrestricted problem) and should force more distinct distances. Erdős conjectured that h(n)/n → ∞, where h(n) is the minimum number of distinct distances over all general-position configurations of n points.\n\nRemarkably, even the much weaker bound h(n) ≥ n is unknown. The best upper bounds come from Pach, who showed h(n) < n^{log₂ 3} ≈ n^{1.585}, and the Erdős–Furedi–Pach improvement h(n) < n·exp(c√(log n)), which is much closer to linear. The gap between the Guth–Katz Ω(n/log n) lower bound (which applies without general position) and the conjectured superlinear growth remains wide open.",
     "problemStatement": "For n points in ℝ² with no 3 collinear and no 4 concyclic, does the minimum number of distinct distances h(n) satisfy h(n)/n → ∞?",
-    "proofStrategy": "We define PointConfig as Fin n → EuclideanSpace ℝ (Fin 2), then define NoThreeCollinear (no affine line through 3 points), NoFourConcyclic (no circle through 4 points), and InGeneralPosition (injective + both conditions). The function h(n) uses sInf over all general-position configurations. Upper bounds (Pach, EFP) and the main conjecture are axiomatized. The Guth–Katz comparison is stated.",
+    "proofStrategy": "The formalization defines `PointConfig` as `Fin n → EuclideanSpace ℝ (Fin 2)`, with general position requiring `Function.Injective P`, `NoThreeCollinear` (no affine line $ax + by + c = 0$ through 3 points), and `NoFourConcyclic` (no circle through 4 points). `numDistinctDistances` counts $|\\{d(P_i, P_j) > 0\\}|$ via `Finset.image/filter`, and $h(n) = \\text{sInf}$ over general-position configurations. Upper bounds (Pach: $n^{\\log_2 3}$, EFP: $n \\cdot e^{c\\sqrt{\\log n}}$), the main conjecture ($h(n)/n \\to \\infty$ via `Filter.Tendsto`), and the Guth–Katz baseline ($\\Omega(n/\\log n)$) are axiomatized. 0 sorries.",
     "keyInsights": [
       "**General position eliminates extremal configurations**: The √n × √n integer lattice achieves Θ(n/√(log n)) distances but has many collinear and concyclic points. General position prevents such structured configurations.",
       "**Pach's upper bound**: h(n) < n^{log₂ 3} ≈ n^{1.585} shows that general position does not force quadratically many distances. The construction uses Horton sets and related point configurations.",
@@ -34,11 +35,11 @@
       "**Guth–Katz baseline**: Without general position, the Guth–Katz theorem gives Ω(n/log n) distances. General position should give more, but quantifying the improvement is the open challenge."
     ],
     "mathlibDependencies": [
-      "Mathlib.Analysis.InnerProductSpace.Basic",
-      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Data.Finset.Card",
-      "Mathlib.Order.Filter.Basic"
+      { "theorem": "EuclideanSpace", "description": "Inner product space $\\mathbb{R}^n$ with Euclidean metric and `dist`", "module": "Mathlib.Analysis.InnerProductSpace.Basic" },
+      { "theorem": "Real.log / Real.exp / Real.sqrt", "description": "Logarithm, exponential, and square root for upper bound expressions", "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic" },
+      { "theorem": "Finset.image / Finset.filter", "description": "Image and filter operations for counting distinct distances", "module": "Mathlib.Data.Finset.Basic" },
+      { "theorem": "Finset.card", "description": "Cardinality of finite sets for distance counting", "module": "Mathlib.Data.Finset.Card" },
+      { "theorem": "Filter.Tendsto / Filter.atTop", "description": "Asymptotic statements: $h(n)/n \\to \\infty$ and eventually quantifiers", "module": "Mathlib.Order.Filter.Basic" }
     ],
     "originalContributions": [
       "PointConfig: n-point configuration in ℝ² via EuclideanSpace",
@@ -52,46 +53,63 @@
       "ErdosProblem98: h(n)/n → ∞ conjecture",
       "erdos_98_weak: h(n) ≥ n weaker conjecture",
       "guth_katz_comparison: Ω(n/log n) without general position"
+    ],
+    "relatedProofs": [
+      { "id": "erdos-52", "relationship": "Sum-product conjecture — connected via incidence geometry: Elekes used sum-product to bound distinct distances" }
     ]
   },
   "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 15,
+      "endLine": 20,
+      "summary": "Imports `InnerProductSpace.Basic` for `EuclideanSpace ℝ (Fin 2)`, `SpecialFunctions.Log.Basic` for $\\log$, $\\exp$, $\\sqrt{}$, `Finset` for counting, and `Filter.Basic` for asymptotic statements."
+    },
     {
       "id": "general-position",
       "title": "General Position Conditions",
       "startLine": 22,
       "endLine": 46,
-      "summary": "Defines PointConfig (Fin n → EuclideanSpace), NoThreeCollinear (no affine line through 3 points), NoFourConcyclic (no circle through 4 points), and InGeneralPosition (injective + both)."
+      "summary": "Defines `PointConfig` ($\\text{Fin}\\; n \\to \\mathbb{R}^2$), `NoThreeCollinear` (no affine line $ax + by + c = 0$ through 3 points), `NoFourConcyclic` (no circle through 4 points), and `InGeneralPosition` (injective $\\wedge$ both constraints)."
     },
     {
       "id": "distances",
-      "title": "Distinct Distances and h(n)",
+      "title": "Distinct Distances and $h(n)$",
       "startLine": 48,
       "endLine": 59,
-      "summary": "Defines numDistinctDistances (count of positive pairwise distances) and h(n) (sInf over general-position configurations)."
+      "summary": "Defines `numDistinctDistances` as $|\\{d(P_i, P_j) > 0\\}|$ via `Finset.image` and `Finset.filter`, and $h(n) = \\inf$ over general-position configurations via `sInf`."
     },
     {
       "id": "upper-bounds",
       "title": "Known Upper Bounds",
       "startLine": 61,
       "endLine": 72,
-      "summary": "Axiomatizes Pach's bound h(n) < n^{log₂ 3} (eventually) and the EFP bound h(n) < n·exp(c√(log n)) for some c > 0."
+      "summary": "Axioms for Pach's bound $h(n) < n^{\\log_2 3}$ and the Erdős–Füredi–Pach bound $h(n) < n \\cdot e^{c\\sqrt{\\log n}}$ using `Filter.atTop` and `Real.exp`."
     },
     {
       "id": "conjecture",
       "title": "The Erdős Conjecture",
       "startLine": 74,
+      "endLine": 84,
+      "summary": "Axioms for `ErdosProblem98` ($h(n)/n \\to \\infty$ via `Filter.Tendsto`) and `erdos_98_weak` ($h(n) \\geq n$ eventually). Both remain **OPEN**."
+    },
+    {
+      "id": "guth-katz",
+      "title": "Guth–Katz Comparison",
+      "startLine": 86,
       "endLine": 96,
-      "summary": "Axiomatizes ErdosProblem98 (h(n)/n → ∞ via Filter.Tendsto), erdos_98_weak (h(n) ≥ n eventually), and guth_katz_comparison (Ω(n/log n) without general position)."
+      "summary": "Axiom `guth_katz_comparison`: without general position, $\\Omega(n/\\log n)$ distinct distances for any injective $n$-point configuration. Provides a baseline for the general-position improvement."
     }
   ],
   "conclusion": {
     "summary": "Erdős Problem 98 asks whether general-position points (no 3 collinear, no 4 concyclic) determine superlinearly many distances. The formalization captures the general-position conditions, known upper bounds (Pach, EFP), the main conjecture h(n)/n → ∞, and the Guth–Katz comparison. 0 sorries.",
     "implications": "Resolution would clarify how algebraic constraints (collinearity, concyclicity) affect the distinct distance problem, connecting combinatorial geometry to algebraic geometry techniques.",
     "openQuestions": [
-      "Does h(n)/n → ∞, or does h(n) grow only linearly?",
-      "Is h(n) ≥ n for large n? Even this weaker bound is unknown.",
-      "Can general position give Ω(n^{1+ε}) distinct distances for some ε > 0?",
-      "Can the Guth–Katz algebraic technique be adapted to exploit general position?"
+      "Does $h(n)/n \\to \\infty$, or does $h(n)$ grow only linearly? The EFP bound $h(n) < n \\cdot e^{c\\sqrt{\\log n}}$ constrains the growth to be at most subpolynomially superlinear.",
+      "Is $h(n) \\geq n$ for large $n$? Even this weaker bound remains unknown despite decades of effort.",
+      "Can general position force $\\Omega(n^{1+\\varepsilon})$ distinct distances for some $\\varepsilon > 0$, or is the truth closer to $\\Theta(n)$?",
+      "Can the Guth–Katz polynomial partitioning technique be adapted to exploit collinearity/concyclicity constraints for stronger lower bounds?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enriched erdos-947 (No Exact Covering Systems Exist): fixed invalid types (`axiom`→`theorem`, `example`→`definition`/`insight`), added `mathContext`/`relatedConcepts`/`prerequisites` to all 9 annotations, added `leanFile`/`relatedProofs`, LaTeX throughout
- Enriched erdos-98 (Distinct Distances in General Position): added `mathContext`/`relatedConcepts`/`prerequisites` to all 7 annotations, added `leanFile`/`relatedProofs`, fixed `mathlibDependencies` format, LaTeX throughout sections/keyInsights/openQuestions

## Test plan
- [x] `pnpm annotations:build` passes (no erdos-947 or erdos-98 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)