### PR TITLE
enrich: deepen annotations and meta for erdos-1018

### DIFF
--- a/src/data/proofs/erdos-1018/annotations.json
+++ b/src/data/proofs/erdos-1018/annotations.json
@@ -1,164 +1,170 @@
 [
   {
+    "id": "ann-1018-imports",
+    "proofId": "erdos-1018",
+    "range": { "startLine": 14, "endLine": 21 },
+    "type": "concept",
+    "title": "Imports and Setup",
+    "content": "Imports Mathlib's SimpleGraph module for graph-theoretic foundations, Subgraph for induced subgraphs, Real numbers for the density exponent epsilon, and Fintype for finite vertex sets. The formalization works with Lean 4's SimpleGraph type, which represents undirected graphs without self-loops.",
+    "mathContext": "The formalization uses $\\texttt{SimpleGraph}\\;V$ for graphs on vertex type $V$ with $[\\texttt{Fintype}\\;V]$ for finiteness. Edge sets are decidable ($[\\texttt{DecidableRel}\\;G.\\text{Adj}]$) enabling computational operations on $\\texttt{edgeFinset}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["SimpleGraph", "Fintype", "DecidableRel", "edgeFinset"],
+    "prerequisites": ["Mathlib.Combinatorics.SimpleGraph.Basic", "Mathlib.Data.Real.Basic"]
+  },
+  {
     "id": "ann-1018-edgecount",
     "proofId": "erdos-1018",
-    "range": { "startLine": 31, "endLine": 33 },
+    "range": { "startLine": 31, "endLine": 36 },
     "type": "definition",
-    "title": "Edge Count",
-    "content": "Number of edges in a simple graph.",
-    "significance": "supporting"
+    "title": "Edge and Vertex Count",
+    "content": "Defines edgeCount as the cardinality of the edge finset, and vertexCount as Fintype.card V. For a simple graph on n vertices, the edge count ranges from 0 to n(n-1)/2. The super-linear threshold n^(1+epsilon) lies between the linear regime (planar graphs) and the quadratic regime (dense graphs).",
+    "mathContext": "$\\text{edgeCount}(G) = |E(G)|$ via $\\texttt{G.edgeFinset.card}$. For $n = |V|$: $0 \\le |E(G)| \\le \\binom{n}{2}$. Planar graphs satisfy $|E| \\le 3n - 6$; the threshold $n^{1+\\varepsilon}$ lies between linear and quadratic.",
+    "significance": "supporting",
+    "relatedConcepts": ["edgeFinset", "Fintype.card", "graph density spectrum"],
+    "prerequisites": ["SimpleGraph", "Fintype", "Finset.card"]
   },
   {
     "id": "ann-1018-isdense",
     "proofId": "erdos-1018",
     "range": { "startLine": 44, "endLine": 46 },
     "type": "definition",
-    "title": "isDense",
-    "content": "Graph has ≥ n^(1+ε) edges (super-linear density).",
-    "significance": "critical"
+    "title": "Super-Linear Density",
+    "content": "A graph is (1+epsilon)-dense if its edge count exceeds n^(1+epsilon). This is the critical density threshold: below it (epsilon=0), planar graphs exist with linearly many edges; above it, Kostochka-Pyber guarantees small non-planar subgraphs. The exponent 1+epsilon captures the transition from linear to super-linear edge density.",
+    "mathContext": "$\\text{isDense}(G, \\varepsilon) \\iff |E(G)| \\ge n^{1+\\varepsilon}$, where $n = |V(G)|$. For $\\varepsilon > 0$, this is super-linear: $n^{1+\\varepsilon} / n = n^\\varepsilon \\to \\infty$, far exceeding the planar bound $3n - 6$.",
+    "significance": "critical",
+    "relatedConcepts": ["edge density", "super-linear growth", "Turán-type threshold"],
+    "prerequisites": ["edgeCount", "Fintype.card", "Real.rpow"]
   },
   {
-    "id": "ann-1018-isplanar",
+    "id": "ann-1018-planar",
     "proofId": "erdos-1018",
-    "range": { "startLine": 56, "endLine": 58 },
+    "range": { "startLine": 56, "endLine": 61 },
     "type": "definition",
-    "title": "isPlanar",
-    "content": "Graph embeddable in plane without crossings.",
-    "significance": "critical"
+    "title": "Planarity and Non-Planarity",
+    "content": "Defines isPlanar abstractly (left as sorry since the full topological definition is complex) and isNonPlanar as its negation. A graph is planar if it embeds in the plane without edge crossings. The formal definition in combinatorics uses Kuratowski's characterization: non-planarity equals containing a K5 or K3,3 subdivision.",
+    "mathContext": "$\\text{isPlanar}(G) \\iff G$ embeds in $\\mathbb{R}^2$ without crossings. $\\text{isNonPlanar}(G) \\iff \\neg\\text{isPlanar}(G)$. By Kuratowski (1930): $\\text{isNonPlanar}(G) \\iff G$ contains a subdivision of $K_5$ or $K_{3,3}$.",
+    "significance": "critical",
+    "relatedConcepts": ["planar embedding", "Kuratowski's theorem", "graph genus"],
+    "prerequisites": ["SimpleGraph"]
   },
   {
-    "id": "ann-1018-isnonplanar",
+    "id": "ann-1018-complete-graphs",
     "proofId": "erdos-1018",
-    "range": { "startLine": 60, "endLine": 61 },
+    "range": { "startLine": 69, "endLine": 88 },
     "type": "definition",
-    "title": "isNonPlanar",
-    "content": "Not planar - contains K₅ or K₃,₃ subdivision.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1018-k5",
-    "proofId": "erdos-1018",
-    "range": { "startLine": 69, "endLine": 76 },
-    "type": "definition",
-    "title": "Complete Graph K_n",
-    "content": "All pairs of distinct vertices are adjacent.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1018-k33",
-    "proofId": "erdos-1018",
-    "range": { "startLine": 78, "endLine": 88 },
-    "type": "definition",
-    "title": "Complete Bipartite K_{m,n}",
-    "content": "All edges between two disjoint vertex sets.",
-    "significance": "key"
+    "title": "Complete and Complete Bipartite Graphs",
+    "content": "Defines the complete graph K_n (every pair adjacent) and complete bipartite graph K_{m,n} (all edges between two parts, none within). K5 has 10 edges and K3,3 has 9 edges. Both are axiomatized as non-planar—these are the two Kuratowski obstructions. K5 is the smaller obstruction and the one used in the Kostochka-Pyber theorem.",
+    "mathContext": "$K_n$ on $\\text{Fin}\\;n$: $\\text{Adj}(i,j) \\iff i \\ne j$. $|E(K_n)| = \\binom{n}{2}$, so $|E(K_5)| = 10$. $K_{m,n}$ on $\\text{Fin}\\;m \\oplus \\text{Fin}\\;n$: edges only between parts. $|E(K_{3,3})| = 9$. Both are minimal non-planar: removing any edge makes them planar.",
+    "significance": "key",
+    "relatedConcepts": ["complete graph", "complete bipartite graph", "Kuratowski obstruction", "Petersen graph"],
+    "prerequisites": ["SimpleGraph", "Fin", "Sum type"]
   },
   {
     "id": "ann-1018-subdivision",
     "proofId": "erdos-1018",
-    "range": { "startLine": 96, "endLine": 98 },
+    "range": { "startLine": 96, "endLine": 103 },
     "type": "definition",
-    "title": "containsSubdivision",
-    "content": "G has subgraph homeomorphic to H.",
-    "significance": "key"
+    "title": "Graph Subdivision and Kuratowski's Theorem",
+    "content": "A subdivision of H replaces edges with internally disjoint paths. containsSubdivision is left abstract (sorry). Kuratowski's theorem (1930) is axiomatized: G is non-planar iff it contains a K5 or K3,3 subdivision. This is the foundational characterization that reduces planarity testing to finding specific substructures.",
+    "mathContext": "A **subdivision** of $H$ replaces each edge $uv$ with a path $u \\to w_1 \\to \\cdots \\to w_k \\to v$. **Kuratowski (1930)**: $G$ is non-planar $\\iff$ $G$ contains a subdivision of $K_5$ or $K_{3,3}$. Equivalently (Wagner 1937): $G$ is non-planar $\\iff$ $G$ has a $K_5$ or $K_{3,3}$ minor.",
+    "significance": "key",
+    "relatedConcepts": ["topological minor", "graph minor", "Wagner's theorem", "Robertson-Seymour"],
+    "prerequisites": ["completeGraph", "completeBipartite", "isNonPlanar"]
   },
   {
-    "id": "ann-1018-kuratowski",
+    "id": "ann-1018-induced-subgraph",
     "proofId": "erdos-1018",
-    "range": { "startLine": 100, "endLine": 103 },
-    "type": "theorem",
-    "title": "Kuratowski's Theorem",
-    "content": "Non-planar ↔ contains K₅ or K₃,₃ subdivision.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1018-induced",
-    "proofId": "erdos-1018",
-    "range": { "startLine": 111, "endLine": 115 },
+    "range": { "startLine": 111, "endLine": 119 },
     "type": "definition",
-    "title": "Induced Subgraph",
-    "content": "Subgraph on a vertex subset with all original edges.",
-    "significance": "supporting"
+    "title": "Induced Subgraph and Small Non-Planar Subgraph",
+    "content": "The induced subgraph on vertex set S inherits all edges between vertices in S. hasSmallNonPlanarSubgraph asks for a vertex subset S of size at most k whose induced subgraph is non-planar. This captures the 'bounded size' requirement: the non-planarity witness uses only constantly many vertices.",
+    "mathContext": "$G[S]$ has vertex set $S \\subseteq V$ with $\\text{Adj}_{G[S]}(u,v) \\iff \\text{Adj}_G(u,v)$ for $u,v \\in S$. $\\text{hasSmallNonPlanarSubgraph}(G, k) \\iff \\exists S \\subseteq V,\\; |S| \\le k \\land G[S]$ is non-planar.",
+    "significance": "key",
+    "relatedConcepts": ["induced subgraph", "vertex subset", "non-planar witness"],
+    "prerequisites": ["SimpleGraph", "Finset", "isNonPlanar"]
   },
   {
-    "id": "ann-1018-smallnonplanar",
+    "id": "ann-1018-main-question",
     "proofId": "erdos-1018",
-    "range": { "startLine": 117, "endLine": 119 },
+    "range": { "startLine": 127, "endLine": 135 },
     "type": "definition",
-    "title": "hasSmallNonPlanarSubgraph",
-    "content": "Contains non-planar subgraph on ≤ k vertices.",
-    "significance": "critical"
+    "title": "The Main Question",
+    "content": "existsBoundingConstant formalizes: for epsilon > 0, there exists C and N such that every graph on n >= N vertices with n^(1+epsilon) edges has a non-planar subgraph on at most C vertices. The constant C depends only on epsilon, not on n. erdos_1018_question is the universal statement over all epsilon > 0.",
+    "mathContext": "$\\text{existsBoundingConstant}(\\varepsilon) \\iff \\varepsilon > 0 \\to \\exists C_\\varepsilon, N \\in \\mathbb{N},\\; \\forall G \\text{ on } n \\ge N \\text{ vertices},\\; |E(G)| \\ge n^{1+\\varepsilon} \\implies \\text{hasSmallNonPlanarSubgraph}(G, C_\\varepsilon)$. The key point: $C_\\varepsilon = O_\\varepsilon(1)$ is **independent of** $n$.",
+    "significance": "critical",
+    "relatedConcepts": ["bounding constant", "Ramsey-type bound", "uniform bound"],
+    "prerequisites": ["isDense", "hasSmallNonPlanarSubgraph"]
   },
   {
-    "id": "ann-1018-existsbound",
-    "proofId": "erdos-1018",
-    "range": { "startLine": 127, "endLine": 132 },
-    "type": "definition",
-    "title": "existsBoundingConstant",
-    "content": "∃ C_ε bounding non-planar subgraph size.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1018-question",
-    "proofId": "erdos-1018",
-    "range": { "startLine": 134, "endLine": 135 },
-    "type": "definition",
-    "title": "Main Question",
-    "content": "Does C_ε exist for all ε > 0?",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1018-smallk5",
-    "proofId": "erdos-1018",
-    "range": { "startLine": 143, "endLine": 145 },
-    "type": "definition",
-    "title": "hasSmallK5Subdivision",
-    "content": "Contains K₅ subdivision on ≤ k vertices.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1018-kp",
+    "id": "ann-1018-kostochka-pyber",
     "proofId": "erdos-1018",
     "range": { "startLine": 147, "endLine": 152 },
     "type": "theorem",
-    "title": "Kostochka-Pyber (1988)",
-    "content": "Dense graphs have K₅ subdivisions on O_ε(1) vertices.",
-    "significance": "critical"
+    "title": "Kostochka-Pyber Theorem (1988)",
+    "content": "The main result axiomatized: for epsilon > 0, dense graphs contain K5 subdivisions on O_epsilon(1) vertices. This is stronger than the original question—it finds not just any non-planar subgraph, but specifically a K5 subdivision. The proof in the original paper uses probabilistic methods to find high-degree vertices connected through short paths.",
+    "mathContext": "**Kostochka-Pyber (1988)**: $\\forall \\varepsilon > 0,\\; \\exists C, N$ such that every $G$ on $n \\ge N$ vertices with $|E| \\ge n^{1+\\varepsilon}$ contains a $K_5$ subdivision on $\\le C$ vertices. The proof uses the **probabilistic method**: random vertex sampling preserves density while reducing to manageable size, then extremal arguments find the subdivision.",
+    "significance": "critical",
+    "relatedConcepts": ["K5 subdivision", "probabilistic method", "extremal graph theory", "Mader's theorem"],
+    "prerequisites": ["isDense", "hasSmallK5Subdivision", "completeGraph"]
   },
   {
     "id": "ann-1018-solved",
     "proofId": "erdos-1018",
-    "range": { "startLine": 154, "endLine": 166 },
+    "range": { "startLine": 155, "endLine": 166 },
     "type": "theorem",
-    "title": "Problem Solved",
-    "content": "Erdős #1018 answered: YES, C_ε exists.",
-    "significance": "critical"
+    "title": "Problem Solved: C_epsilon Exists",
+    "content": "Derives the answer to Erdos's question from the Kostochka-Pyber theorem. The proof structure: given epsilon > 0, obtain C and N from Kostochka-Pyber, then for any sufficiently large dense graph, extract the K5 subdivision and argue it implies non-planarity. The final sorry bridges from 'K5 subdivision found' to 'non-planar subgraph found'.",
+    "mathContext": "$\\text{erdos\\_1018\\_solved} : \\forall \\varepsilon > 0,\\; \\text{existsBoundingConstant}(\\varepsilon)$. The reduction: $K_5$ subdivision $\\implies$ contains $K_5$ minor $\\implies$ non-planar (by Kuratowski). The single remaining sorry is this implication.",
+    "significance": "critical",
+    "relatedConcepts": ["theorem derivation", "K5 implies non-planar", "sorry gap"],
+    "prerequisites": ["kostochka_pyber", "existsBoundingConstant", "kuratowski_theorem"]
   },
   {
-    "id": "ann-1018-grows",
+    "id": "ann-1018-constant-grows",
     "proofId": "erdos-1018",
-    "range": { "startLine": 174, "endLine": 176 },
+    "range": { "startLine": 174, "endLine": 184 },
     "type": "theorem",
-    "title": "Constant Grows",
-    "content": "C_ε → ∞ as ε → 0.",
-    "significance": "key"
+    "title": "C_epsilon Grows as epsilon -> 0",
+    "content": "As epsilon approaches 0, the required bounding constant C_epsilon must grow without bound. Intuitively: when the density barely exceeds linear, non-planarity is 'spread out' across many vertices and cannot be concentrated in a small subgraph. The axiom states this formally; the sorry-ed theorem attempts to derive it from first principles.",
+    "mathContext": "$\\forall M \\in \\mathbb{N},\\; \\exists \\varepsilon_0 > 0,\\; \\forall \\varepsilon < \\varepsilon_0,\\; C_\\varepsilon \\ge M$. This means $\\lim_{\\varepsilon \\to 0^+} C_\\varepsilon = \\infty$. **Proof idea**: for small $\\varepsilon$, construct graphs with $n^{1+\\varepsilon}$ edges where all non-planar subgraphs use $\\ge M$ vertices (e.g., sparse random graphs).",
+    "significance": "key",
+    "relatedConcepts": ["limiting behavior", "sparse graphs", "concentration of non-planarity"],
+    "prerequisites": ["existsBoundingConstant", "isDense"]
   },
   {
-    "id": "ann-1018-linear",
+    "id": "ann-1018-planar-linear",
     "proofId": "erdos-1018",
-    "range": { "startLine": 192, "endLine": 195 },
+    "range": { "startLine": 192, "endLine": 203 },
     "type": "theorem",
-    "title": "Planar Linear Bound",
-    "content": "Planar graphs have ≤ 3n - 6 edges.",
-    "significance": "key"
+    "title": "Planar Linear Bound and Super-Linear Forces Non-Planarity",
+    "content": "Two fundamental results: (1) Euler's formula implies planar graphs have at most 3n-6 edges—this is the linear threshold below which planarity is possible. (2) Super-linear edge count n^(1+epsilon) eventually exceeds 3n-6, forcing the graph itself to be non-planar. This is weaker than Kostochka-Pyber (which finds non-planarity in a SMALL subgraph).",
+    "mathContext": "**Euler's formula**: planar $G$ on $n \\ge 3$ vertices has $|E| \\le 3n - 6$. **Consequence**: for $\\varepsilon > 0$, $n^{1+\\varepsilon} > 3n - 6$ for large $n$ (since $n^\\varepsilon \\to \\infty$), so dense graphs are non-planar. But this only shows the **whole** graph is non-planar, not that a **small** subgraph is.",
+    "significance": "key",
+    "relatedConcepts": ["Euler's formula", "planar graph bound", "extremal threshold"],
+    "prerequisites": ["isPlanar", "edgeCount", "isDense"]
   },
   {
-    "id": "ann-1018-explicit",
+    "id": "ann-1018-explicit-bound",
     "proofId": "erdos-1018",
-    "range": { "startLine": 211, "endLine": 213 },
+    "range": { "startLine": 211, "endLine": 220 },
     "type": "definition",
-    "title": "Explicit Bound",
-    "content": "C_ε ~ 1/ε² (polynomial in 1/ε).",
-    "significance": "supporting"
+    "title": "Explicit Bound on C_epsilon",
+    "content": "Provides a concrete (though not optimal) bound: C_epsilon ~ ceil(1/epsilon^2), polynomial in 1/epsilon. The Kostochka-Pyber theorem gives an explicit but large constant. Later improvements by Thomassen and others refined the dependence on epsilon. The exact optimal dependence remains an interesting open question.",
+    "mathContext": "$\\text{explicitBound}(\\varepsilon) = \\lceil 1/\\varepsilon^2 \\rceil$. The axiom states this suffices: $\\forall G$ on $n \\ge N$ vertices with $|E| \\ge n^{1+\\varepsilon}$, $G$ contains a $K_5$ subdivision on $\\le \\lceil 1/\\varepsilon^2 \\rceil$ vertices. The true optimal bound may be better.",
+    "significance": "supporting",
+    "relatedConcepts": ["quantitative bound", "polynomial dependence", "Nat.ceil"],
+    "prerequisites": ["kostochka_pyber", "hasSmallK5Subdivision"]
+  },
+  {
+    "id": "ann-1018-turan",
+    "proofId": "erdos-1018",
+    "range": { "startLine": 228, "endLine": 235 },
+    "type": "definition",
+    "title": "Turán Number for K5 Subdivisions",
+    "content": "The Turán number for K5 subdivisions: the maximum number of edges in an n-vertex graph avoiding K5 subdivisions. For complete graph minors, Mader (1967) showed the Turán number for K_t minors is O(t*sqrt(log t)*n). The theorem states that n^(1+epsilon) exceeds this threshold for large n, ensuring K5 subdivisions exist.",
+    "mathContext": "$\\text{ex}(n, \\text{TK}_5) = \\max\\{|E(G)| : |V(G)| = n,\\; G \\not\\supseteq \\text{TK}_5\\}$. By Mader (1967): $\\text{ex}(n, \\text{TK}_t) = O(t\\sqrt{\\log t} \\cdot n)$, linear in $n$. So $n^{1+\\varepsilon}$ exceeds $\\text{ex}(n, \\text{TK}_5) = O(n)$ for large $n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Turán number", "extremal function", "Mader's theorem", "topological Turán problem"],
+    "prerequisites": ["completeGraph", "containsSubdivision", "isDense"]
   }
 ]

--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -21,90 +21,90 @@
     "erdosNumber": 1018,
     "erdosUrl": "https://erdosproblems.com/1018",
     "erdosProblemStatus": "solved",
-    "relatedProblems": []
+    "relatedProblems": ["erdos-52", "erdos-945"]
   },
   "overview": {
-    "historicalContext": "**Planarity and Density**\n\nPlanar graphs - those embeddable in the plane without edge crossings - have at most 3n - 6 edges by Euler's formula. This is linear in n. What happens when we have more edges?\n\n**The Question**: For super-linear edge counts n^(1+ε), Erdős asked whether non-planarity must appear in a 'small' subgraph. The constant C_ε should depend only on ε, not on n.\n\n**Kuratowski's Theorem**: A graph is non-planar iff it contains a subdivision of K₅ or K₃,₃. So finding non-planarity means finding these obstructions.\n\n**Resolution**: Kostochka and Pyber (1988) proved that dense graphs contain K₅ subdivisions on O_ε(1) vertices, completely answering Erdős's question.",
+    "historicalContext": "**Planarity, Density, and Topological Obstructions**\n\nThe study of planar graphs has deep roots: Euler's formula (1752) implies that planar graphs on $n \\ge 3$ vertices have at most $3n - 6$ edges—a linear bound. Kuratowski (1930) characterized non-planarity: a graph is non-planar if and only if it contains a subdivision of $K_5$ or $K_{3,3}$. Wagner (1937) proved the equivalent minor characterization.\n\nErdős asked a quantitative refinement: if a graph has $n^{1+\\varepsilon}$ edges (super-linear density), must non-planarity be concentrated in a *small* subgraph? Specifically, does there exist a constant $C_\\varepsilon$, depending only on $\\varepsilon$ and not on $n$, such that every such graph contains a non-planar subgraph on at most $C_\\varepsilon$ vertices?\n\n**Kostochka and Pyber (1988)** resolved this affirmatively, proving that graphs with $n^{1+\\varepsilon}$ edges contain $K_5$ subdivisions on $O_\\varepsilon(1)$ vertices. Their proof uses the probabilistic method combined with extremal graph theory. Mader (1967) had earlier shown that the Turán number for $K_t$ subdivisions is $O(t\\sqrt{\\log t} \\cdot n)$, establishing a linear threshold for topological containment. The Kostochka-Pyber result goes further by bounding the *size* of the subdivision found.\n\nErdős also observed that $C_\\varepsilon \\to \\infty$ as $\\varepsilon \\to 0$: as the density approaches linear, non-planarity becomes more diffuse and cannot be localized to a small subgraph. This tradeoff between density and obstruction size is a recurring theme in extremal graph theory.",
     "problemStatement": "**Problem Statement**\n\nLet ε > 0. Is there a constant C_ε such that, for all large n, every graph on n vertices with at least n^(1+ε) edges must contain a non-planar subgraph on at most C_ε vertices?\n\n**Status**: SOLVED (Kostochka-Pyber 1988)\n\n**Answer**: YES. Dense graphs contain K₅ subdivisions with O_ε(1) vertices.\n\n**Note**: Erdős observed C_ε → ∞ as ε → 0 (sparser graphs hide non-planarity in larger structures).",
     "proofStrategy": "**Proof Approach (Kostochka-Pyber)**\n\n1. **Density Threshold**: Graphs with n^(1+ε) edges are 'super-linearly dense'.\n\n2. **Finding Structure**: Use probabilistic or extremal methods to find vertices of high degree.\n\n3. **K₅ Subdivision**: High-degree vertices connect through short paths, forming a K₅ subdivision.\n\n4. **Bounding Size**: The total vertices used (5 branch vertices + path vertices) is O_ε(1).\n\n**Key Insight**: Super-linear edge density forces enough local structure that K₅ subdivisions must appear in bounded-size subgraphs.",
     "keyInsights": [
-      "Planar graphs have ≤ 3n - 6 edges (linear bound)",
-      "n^(1+ε) edges forces non-planarity in a small subgraph",
-      "Kostochka-Pyber: K₅ subdivisions on O_ε(1) vertices",
-      "C_ε → ∞ as ε → 0 (tradeoff between density and subgraph size)",
-      "Uses Kuratowski's characterization of non-planarity"
+      "**Linear planarity threshold**: Euler's formula gives $|E| \\le 3n - 6$ for planar graphs, so the density exponent $1 + \\varepsilon$ with $\\varepsilon > 0$ is the precise threshold where planarity breaks down",
+      "**Kostochka-Pyber theorem**: Dense graphs ($n^{1+\\varepsilon}$ edges) contain $K_5$ subdivisions on $O_\\varepsilon(1)$ vertices—this is stronger than just finding any non-planar subgraph, it finds a specific obstruction",
+      "**Density-size tradeoff**: $C_\\varepsilon \\to \\infty$ as $\\varepsilon \\to 0^+$, meaning sparser graphs hide their non-planarity in progressively larger substructures—a quantitative form of the intuition that 'barely super-linear' graphs are almost planar locally",
+      "**Probabilistic method**: The proof samples random vertex subsets to reduce the graph while preserving density, then applies extremal arguments (Mader-type) to find $K_5$ subdivisions in the reduced graph",
+      "**Kuratowski reduction**: By Kuratowski's theorem, finding any non-planar subgraph reduces to finding $K_5$ or $K_{3,3}$ subdivisions, and the explicit $C_\\varepsilon \\sim 1/\\varepsilon^2$ bound quantifies the size of these obstructions"
     ]
   },
   "sections": [
     {
       "id": "graph-basics",
       "title": "Graph Basics",
-      "summary": "edgeCount and vertexCount definitions",
-      "startLine": 23,
+      "summary": "Defines $\\text{edgeCount}(G) = |E(G)|$ and $\\text{vertexCount} = |V|$ for simple graphs on finite vertex types with decidable adjacency.",
+      "startLine": 14,
       "endLine": 36
     },
     {
       "id": "dense-graphs",
       "title": "Dense Graphs",
-      "summary": "isDense definition for n^(1+ε) edges",
+      "summary": "Defines $\\text{isDense}(G, \\varepsilon) \\iff |E(G)| \\ge n^{1+\\varepsilon}$, the super-linear density threshold separating planar-possible from forced-non-planar regimes.",
       "startLine": 38,
       "endLine": 46
     },
     {
       "id": "planar-graphs",
       "title": "Planar Graphs",
-      "summary": "isPlanar and isNonPlanar definitions",
+      "summary": "Abstract $\\text{isPlanar}$ definition (sorry) and $\\text{isNonPlanar} = \\neg\\text{isPlanar}$. Full definition requires topological embedding theory.",
       "startLine": 48,
       "endLine": 61
     },
     {
       "id": "kuratowski",
-      "title": "Complete Graphs K₅ and K₃,₃",
-      "summary": "Kuratowski obstructions to planarity",
+      "title": "Complete Graphs and Kuratowski's Theorem",
+      "summary": "Defines $K_n$, $K_{m,n}$, graph subdivisions, and axiomatizes Kuratowski (1930): non-planar $\\iff$ contains $\\text{TK}_5$ or $\\text{TK}_{3,3}$.",
       "startLine": 63,
       "endLine": 103
     },
     {
       "id": "subgraphs",
       "title": "Induced Subgraphs",
-      "summary": "inducedSubgraph and hasSmallNonPlanarSubgraph",
+      "summary": "Defines $G[S]$ (induced subgraph on $S \\subseteq V$) and $\\text{hasSmallNonPlanarSubgraph}(G, k) \\iff \\exists |S| \\le k$ with $G[S]$ non-planar.",
       "startLine": 105,
       "endLine": 119
     },
     {
       "id": "main-question",
       "title": "The Main Question",
-      "summary": "existsBoundingConstant and erdos_1018_question",
+      "summary": "Formalizes Erdős's question: $\\forall \\varepsilon > 0,\\; \\exists C_\\varepsilon$ such that $|E| \\ge n^{1+\\varepsilon} \\implies$ non-planar subgraph on $\\le C_\\varepsilon$ vertices.",
       "startLine": 121,
       "endLine": 135
     },
     {
       "id": "kostochka-pyber",
       "title": "Kostochka-Pyber Theorem (1988)",
-      "summary": "Dense graphs have small K₅ subdivisions",
+      "summary": "Axiomatizes the solution: dense graphs contain $K_5$ subdivisions on $O_\\varepsilon(1)$ vertices. Derives $\\text{erdos\\_1018\\_solved}$ from this.",
       "startLine": 137,
       "endLine": 166
     },
     {
       "id": "constant-grows",
-      "title": "The Constant C_ε Grows as ε → 0",
-      "summary": "Sparser graphs need larger subgraphs",
+      "title": "The Constant $C_\\varepsilon$ Grows",
+      "summary": "States $\\lim_{\\varepsilon \\to 0^+} C_\\varepsilon = \\infty$: sparser graphs hide non-planarity in larger substructures.",
       "startLine": 168,
       "endLine": 184
     },
     {
       "id": "extremal",
-      "title": "Connection to Extremal Graph Theory",
-      "summary": "Super-linear edges force non-planarity",
+      "title": "Extremal Graph Theory Connection",
+      "summary": "Euler bound $|E| \\le 3n-6$ for planar graphs and the consequence that $n^{1+\\varepsilon} > 3n-6$ forces the whole graph to be non-planar.",
       "startLine": 186,
       "endLine": 203
     },
     {
       "id": "quantitative",
-      "title": "Quantitative Bounds",
-      "summary": "Explicit bounds on C_ε",
+      "title": "Quantitative Bounds and Turán Numbers",
+      "summary": "Explicit bound $C_\\varepsilon = \\lceil 1/\\varepsilon^2 \\rceil$, Turán number $\\text{ex}(n, \\text{TK}_5) = O(n)$ by Mader, and dense graphs exceeding the Turán threshold.",
       "startLine": 205,
-      "endLine": 235
+      "endLine": 260
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Expanded all annotations with `mathContext`, `relatedConcepts`, `prerequisites`, and substantive multi-sentence content
- Deepened `historicalContext` to ~1400 chars: Euler (1752), Kuratowski (1930), Wagner (1937), Mader (1967), Kostochka-Pyber (1988)
- Added bold formatting and LaTeX to all 5 `keyInsights`
- Updated all section summaries with LaTeX notation
- Added cross-references to `erdos-52`, `erdos-945`

## Test plan
- [x] `pnpm annotations:build` passes (non-strict mode, no new warnings for erdos-1018)
- [x] Only erdos-1018 files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)