### PR TITLE
enrich: deepen annotations and meta for erdos-1002

### DIFF
--- a/src/data/proofs/erdos-1002/annotations.json
+++ b/src/data/proofs/erdos-1002/annotations.json
@@ -4,27 +4,24 @@
     "proofId": "erdos-1002",
     "range": { "startLine": 30, "endLine": 31 },
     "type": "definition",
-    "title": "Fractional Part",
-    "content": "frac(x) = x - ⌊x⌋, the fractional part of x.",
-    "significance": "supporting"
+    "title": "Fractional Part Function",
+    "content": "The fractional part $\\{x\\} = x - \\lfloor x \\rfloor$ maps $\\mathbb{R}$ to $[0, 1)$. For irrational $\\alpha$, the sequence $\\{\\alpha\\}, \\{2\\alpha\\}, \\{3\\alpha\\}, \\ldots$ is equidistributed in $[0,1)$ by Weyl's equidistribution theorem (1916). The deviation $1/2 - \\{x\\}$ has mean zero over $[0,1)$, so the sum $\\sum (1/2 - \\{\\alpha k\\})$ measures the cumulative deviation from uniformity.",
+    "mathContext": "$\\{x\\} = x - \\lfloor x \\rfloor \\in [0, 1)$ with $\\int_0^1 (1/2 - \\{x\\})\\,dx = 0$",
+    "significance": "supporting",
+    "relatedConcepts": ["floor function", "equidistribution", "Weyl's theorem"],
+    "prerequisites": ["Int.floor", "Int.fract"]
   },
   {
     "id": "ann-1002-innersum",
     "proofId": "erdos-1002",
-    "range": { "startLine": 48, "endLine": 50 },
+    "range": { "startLine": 48, "endLine": 54 },
     "type": "definition",
-    "title": "Inner Sum",
-    "content": "Σ_{1≤k≤n} (1/2 - {αk}), deviation from uniform distribution.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1002-f",
-    "proofId": "erdos-1002",
-    "range": { "startLine": 52, "endLine": 54 },
-    "type": "definition",
-    "title": "Weighted Sum f(α,n)",
-    "content": "f(α,n) = innerSum(α,n) / log(n), the normalized deviation.",
-    "significance": "critical"
+    "title": "Inner Sum and Weighted Function f(alpha, n)",
+    "content": "The inner sum $S(\\alpha, n) = \\sum_{k=1}^{n} (1/2 - \\{\\alpha k\\})$ accumulates the deviation of $\\{\\alpha k\\}$ from the midpoint $1/2$. The normalized function $f(\\alpha, n) = S(\\alpha, n)/\\log n$ rescales by the natural logarithm. The choice of $\\log n$ normalization is natural because for 'typical' $\\alpha$, the inner sum grows roughly as $\\log n$ — this follows from the theory of continued fractions and the Gauss-Kuzmin statistics of the partial quotients.",
+    "mathContext": "$f(\\alpha, n) = \\frac{1}{\\log n} \\sum_{k=1}^{n} \\left(\\frac{1}{2} - \\{\\alpha k\\}\\right)$",
+    "significance": "critical",
+    "relatedConcepts": ["Weyl sums", "discrepancy", "logarithmic normalization"],
+    "prerequisites": ["Int.fract", "Real.log", "Finset.sum"]
   },
   {
     "id": "ann-1002-distfunc",
@@ -32,26 +29,23 @@
     "range": { "startLine": 63, "endLine": 68 },
     "type": "definition",
     "title": "Distribution Function",
-    "content": "Non-decreasing g with g(-∞)=0, g(+∞)=1.",
-    "significance": "key"
+    "content": "A distribution function $g : \\mathbb{R} \\to [0,1]$ is a non-decreasing function with $\\lim_{c \\to -\\infty} g(c) = 0$ and $\\lim_{c \\to +\\infty} g(c) = 1$. In the context of this problem, $g(c)$ represents the limiting proportion of $\\alpha \\in (0,1)$ for which $f(\\alpha, n) \\le c$. The existence of such a $g$ means the 'statistical behavior' of $f$ over all $\\alpha$ stabilizes as $n \\to \\infty$.",
+    "mathContext": "$g : \\mathbb{R} \\to [0,1]$ non-decreasing with $g(-\\infty) = 0$, $g(+\\infty) = 1$",
+    "significance": "key",
+    "relatedConcepts": ["cumulative distribution function", "weak convergence", "measure theory"],
+    "prerequisites": ["Monotone", "Filter.Tendsto"]
   },
   {
     "id": "ann-1002-levelset",
     "proofId": "erdos-1002",
-    "range": { "startLine": 77, "endLine": 79 },
+    "range": { "startLine": 77, "endLine": 88 },
     "type": "definition",
-    "title": "Level Set",
-    "content": "{α ∈ (0,1) : f(α,n) ≤ c}, the set of α with bounded f.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1002-asymptotic",
-    "proofId": "erdos-1002",
-    "range": { "startLine": 81, "endLine": 88 },
-    "type": "definition",
-    "title": "Asymptotic Distribution",
-    "content": "∃g: μ(levelSet(n,c)) → g(c) as n → ∞.",
-    "significance": "critical"
+    "title": "Level Set and Asymptotic Distribution",
+    "content": "The level set $L(n, c) = \\{\\alpha \\in (0,1) : f(\\alpha, n) \\le c\\}$ is a measurable subset of $(0,1)$ whose Lebesgue measure $\\mu(L(n,c))$ is the proportion of $\\alpha$ values with $f(\\alpha, n) \\le c$. The function $f$ has an **asymptotic distribution** if there exists a distribution function $g$ such that $\\mu(L(n, c)) \\to g(c)$ for every continuity point $c$ of $g$. This is precisely weak convergence of the induced measures.",
+    "mathContext": "$L(n, c) = \\{\\alpha \\in (0,1) : f(\\alpha, n) \\le c\\}$, $\\mu(L(n,c)) \\to g(c)$ as $n \\to \\infty$",
+    "significance": "critical",
+    "relatedConcepts": ["Lebesgue measure", "weak convergence", "Prokhorov's theorem"],
+    "prerequisites": ["MeasureTheory.MeasureSpace", "Filter.Tendsto"]
   },
   {
     "id": "ann-1002-conjecture",
@@ -59,26 +53,23 @@
     "range": { "startLine": 97, "endLine": 98 },
     "type": "definition",
     "title": "Main Conjecture (OPEN)",
-    "content": "f(α,n) has an asymptotic distribution function.",
-    "significance": "critical"
+    "content": "The central question: does $f(\\alpha, n)$ possess an asymptotic distribution function? Erdős conjectured it does, but the answer remains unknown. If the distribution exists, a natural guess (motivated by Kesten's theorem) is the Cauchy distribution $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$ for some parameter $\\rho > 0$. However, fixing $\\beta = 0$ may change the distributional behavior entirely.",
+    "mathContext": "$\\exists\\, g,\\; \\forall\\, c,\\; \\lim_{n \\to \\infty} \\mu(\\{\\alpha : f(\\alpha, n) \\le c\\}) = g(c)$",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős problems", "open problems", "limit distributions"],
+    "prerequisites": ["hasAsymptoticDistribution", "f"]
   },
   {
     "id": "ann-1002-twoparam",
     "proofId": "erdos-1002",
-    "range": { "startLine": 109, "endLine": 114 },
+    "range": { "startLine": 109, "endLine": 122 },
     "type": "definition",
-    "title": "Two-Parameter Variant",
-    "content": "f(α,β,n) = (1/log n) Σ (1/2 - {β + αk}), adds shift β.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1002-cauchy",
-    "proofId": "erdos-1002",
-    "range": { "startLine": 120, "endLine": 122 },
-    "type": "definition",
-    "title": "Cauchy Distribution",
-    "content": "g(c) = (1/π)arctan(ρc) + 1/2, the limiting distribution.",
-    "significance": "key"
+    "title": "Two-Parameter Variant and Cauchy Distribution",
+    "content": "The two-parameter variant introduces a shift: $f(\\alpha, \\beta, n) = \\frac{1}{\\log n} \\sum_{k=1}^{n} (1/2 - \\{\\beta + \\alpha k\\})$. The extra parameter $\\beta$ allows averaging over both $\\alpha$ and $\\beta$, which provides the ergodic independence needed for limit theorems. The Cauchy distribution function $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$ arises naturally from the connection to continued fractions and the Gauss map $T(x) = \\{1/x\\}$ on $(0,1)$.",
+    "mathContext": "$f(\\alpha, \\beta, n) = \\frac{1}{\\log n} \\sum_{k=1}^{n} \\left(\\frac{1}{2} - \\{\\beta + \\alpha k\\}\\right)$, $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$",
+    "significance": "critical",
+    "relatedConcepts": ["Cauchy distribution", "Gauss map", "ergodic theory"],
+    "prerequisites": ["Real.arctan", "f"]
   },
   {
     "id": "ann-1002-kesten",
@@ -86,52 +77,70 @@
     "range": { "startLine": 128, "endLine": 133 },
     "type": "theorem",
     "title": "Kesten's Theorem (1960)",
-    "content": "The two-parameter variant has Cauchy asymptotic distribution.",
-    "significance": "critical"
+    "content": "Harry Kesten (1960) proved that the two-parameter variant $f(\\alpha, \\beta, n)$ has an asymptotic Cauchy distribution when averaged over both $\\alpha$ and $\\beta$ uniformly on $(0,1)^2$. The proof uses the connection between continued fractions and the ergodic properties of the natural extension of the Gauss map. This landmark result in the metric theory of continued fractions remains one of the deepest applications of ergodic theory to number theory.",
+    "mathContext": "$\\mu(\\{(\\alpha, \\beta) : f(\\alpha, \\beta, n) \\le c\\}) \\to \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$",
+    "significance": "critical",
+    "relatedConcepts": ["metric number theory", "Gauss-Kuzmin theorem", "natural extension"],
+    "prerequisites": ["twoParamF", "cauchyDistribution"]
   },
   {
     "id": "ann-1002-special",
     "proofId": "erdos-1002",
     "range": { "startLine": 142, "endLine": 145 },
     "type": "theorem",
-    "title": "Special Case Relationship",
-    "content": "f(α,n) = f(α,0,n), one-parameter is β=0 case.",
-    "significance": "key"
+    "title": "One-Parameter as Special Case",
+    "content": "The one-parameter function satisfies $f(\\alpha, n) = f(\\alpha, 0, n)$: it is the two-parameter variant with $\\beta = 0$. This relationship shows why Problem #1002 is a natural refinement of Kesten's theorem — but fixing $\\beta = 0$ eliminates the averaging that makes Kesten's proof work. The conditional distribution (given $\\beta = 0$) may differ from the unconditional Cauchy distribution.",
+    "mathContext": "$f(\\alpha, n) = f(\\alpha, 0, n)$, i.e., the one-parameter case is $\\beta = 0$",
+    "significance": "key",
+    "relatedConcepts": ["conditional distribution", "marginal distribution", "specialization"],
+    "prerequisites": ["f", "twoParamF"]
   },
   {
     "id": "ann-1002-weyl",
     "proofId": "erdos-1002",
     "range": { "startLine": 154, "endLine": 159 },
     "type": "theorem",
-    "title": "Weyl Equidistribution",
-    "content": "{αk} mod 1 is equidistributed for irrational α.",
-    "significance": "supporting"
+    "title": "Weyl Equidistribution Theorem",
+    "content": "Hermann Weyl's theorem (1916): for irrational $\\alpha$, the sequence $(\\{n\\alpha\\})_{n \\ge 1}$ is equidistributed modulo 1, meaning $\\frac{1}{N}\\#\\{1 \\le n \\le N : \\{n\\alpha\\} \\in [a,b)\\} \\to b - a$ as $N \\to \\infty$. This implies $\\frac{1}{n}\\sum_{k=1}^{n}(1/2 - \\{\\alpha k\\}) \\to 0$, so the inner sum grows sublinearly. The $\\log n$ normalization captures the precise growth rate.",
+    "mathContext": "$\\frac{1}{N}\\#\\{n \\le N : \\{n\\alpha\\} \\in [a,b)\\} \\to b - a$ (Weyl 1916)",
+    "significance": "supporting",
+    "relatedConcepts": ["Weyl's criterion", "exponential sums", "ergodic theorem"],
+    "prerequisites": ["Irrational"]
   },
   {
     "id": "ann-1002-oscillation",
     "proofId": "erdos-1002",
     "range": { "startLine": 161, "endLine": 166 },
     "type": "theorem",
-    "title": "Oscillation for Fixed α",
-    "content": "For fixed irrational α, f(α,n) oscillates without settling.",
-    "significance": "key"
+    "title": "Oscillation for Fixed alpha",
+    "content": "For fixed irrational $\\alpha$, the function $n \\mapsto f(\\alpha, n)$ oscillates: it does not converge to a limit. This oscillation reflects the arithmetic structure of $\\alpha$'s continued fraction expansion — the partial quotients cause the sum to swing as denominators of convergents are reached. The distribution question asks about the statistical behavior over *all* $\\alpha$, not a single fixed one.",
+    "mathContext": "For fixed irrational $\\alpha$, $f(\\alpha, n)$ does not converge as $n \\to \\infty$",
+    "significance": "key",
+    "relatedConcepts": ["continued fractions", "convergents", "three-distance theorem"],
+    "prerequisites": ["f", "Irrational"]
   },
   {
     "id": "ann-1002-bounded",
     "proofId": "erdos-1002",
-    "range": { "startLine": 174, "endLine": 177 },
+    "range": { "startLine": 174, "endLine": 182 },
     "type": "theorem",
-    "title": "Boundedness",
-    "content": "f(α,n) is bounded for α ∈ (0,1).",
-    "significance": "supporting"
+    "title": "Boundedness and Continued Fraction Bound",
+    "content": "Two partial results: (1) $f(\\alpha, n)$ is bounded for each $\\alpha \\in (0,1)$, ensuring no extreme outliers, and (2) $|S(\\alpha, n)| \\le C \\log n$ for irrational $\\alpha$, where $C$ depends on $\\alpha$'s continued fraction expansion. This bound follows from the classical estimate $|\\sum_{k=1}^{n} e^{2\\pi i k\\alpha}| \\le \\cot(\\pi \\|\\alpha\\|/2)$ and the three-distance theorem. These bounds justify the $\\log n$ normalization.",
+    "mathContext": "$|f(\\alpha, n)| \\le C(\\alpha)$ and $|S(\\alpha, n)| \\le C(\\alpha) \\log n$",
+    "significance": "key",
+    "relatedConcepts": ["Erdős-Turán inequality", "exponential sums", "three-distance theorem"],
+    "prerequisites": ["f", "innerSum", "Real.log"]
   },
   {
-    "id": "ann-1002-cfbound",
+    "id": "ann-1002-summary",
     "proofId": "erdos-1002",
-    "range": { "startLine": 179, "endLine": 182 },
-    "type": "theorem",
-    "title": "Continued Fraction Bound",
-    "content": "|innerSum(α,n)| ≤ C·log(n) for irrational α.",
-    "significance": "key"
+    "range": { "startLine": 184, "endLine": 208 },
+    "type": "concept",
+    "title": "Summary and Open Status",
+    "content": "The formalization captures the full problem setup: the weighted sum $f(\\alpha, n)$, the notion of asymptotic distribution, Kesten's two-parameter theorem with Cauchy distribution, and the relationship to the one-parameter case. All definitions are complete (0 sorries), but the main conjecture remains **OPEN** — this is a mathematical, not formalization, gap. The problem connects Diophantine approximation, ergodic theory, and probability, making it one of the more analytically deep Erdős problems.",
+    "mathContext": "Problem #1002: Does $f(\\alpha, n)$ have an asymptotic distribution? Status: OPEN",
+    "significance": "critical",
+    "relatedConcepts": ["open problems", "Diophantine approximation", "analytic number theory"],
+    "prerequisites": ["erdos_1002_conjecture"]
   }
 ]

--- a/src/data/proofs/erdos-1002/meta.json
+++ b/src/data/proofs/erdos-1002/meta.json
@@ -24,85 +24,85 @@
     "relatedProblems": []
   },
   "overview": {
-    "historicalContext": "**Fractional Part Distribution**\n\nThe fractional part function {x} = x - ⌊x⌋ plays a central role in Diophantine approximation. For irrational α, the sequence {α}, {2α}, {3α}, ... is equidistributed in [0,1) by Weyl's theorem.\n\n**The Weighted Sum**: Erdős considered the deviation from uniformity: f(α,n) = (1/log n) Σ (1/2 - {αk}). The factor 1/2 centers the fractional part, and dividing by log n normalizes the sum.\n\n**Distribution Question**: Rather than asking about specific α, Erdős asked whether f(α,n) has an *asymptotic distribution* - does the measure of {α : f(α,n) ≤ c} converge as n → ∞?\n\n**Kesten's Breakthrough**: In 1960, Kesten proved the two-parameter variant f(α,β,n) = (1/log n) Σ (1/2 - {β + αk}) has asymptotic Cauchy distribution. Averaging over β provides independence that the one-parameter case lacks.",
+    "historicalContext": "**Fractional Parts in Number Theory**\n\nThe study of fractional parts $\\{n\\alpha\\}$ for irrational $\\alpha$ is central to Diophantine approximation. Hermann Weyl's equidistribution theorem (1916) established that $\\{\\alpha\\}, \\{2\\alpha\\}, \\{3\\alpha\\}, \\ldots$ is uniformly distributed in $[0,1)$, a foundational result connecting number theory to ergodic theory.\n\n**Gauss and Continued Fractions**: Carl Friedrich Gauss studied the map $T(x) = \\{1/x\\}$ on $(0,1)$, discovering its invariant measure $d\\mu = dx/(\\log 2 \\cdot (1+x))$. The Gauss-Kuzmin theorem (Kuzmin 1928, Lévy 1929) describes the rate at which iterates of $T$ converge to this measure.\n\n**Erdős's Question**: Erdős asked whether $f(\\alpha, n) = \\frac{1}{\\log n}\\sum_{k=1}^{n}(1/2 - \\{\\alpha k\\})$ has an asymptotic distribution function — does the proportion of $\\alpha$ with $f(\\alpha, n) \\le c$ converge as $n \\to \\infty$?\n\n**Kesten's Breakthrough**: Harry Kesten (1960) proved the two-parameter variant $f(\\alpha, \\beta, n) = \\frac{1}{\\log n}\\sum(1/2 - \\{\\beta + \\alpha k\\})$ has a Cauchy limit distribution $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + 1/2$, using the ergodic properties of the natural extension of the Gauss map. The extra parameter $\\beta$ provides the independence needed for the ergodic argument. Fixing $\\beta = 0$ destroys this independence, and the one-parameter problem remains **OPEN**.",
     "problemStatement": "**Problem Statement**\n\nFor any 0 < α < 1, define:\n$$f(\\alpha,n) = \\frac{1}{\\log n} \\sum_{1 \\leq k \\leq n} \\left(\\frac{1}{2} - \\{\\alpha k\\}\\right)$$\n\nDoes f(α,n) possess an asymptotic distribution function?\n\nMore precisely: Does there exist a non-decreasing function g with g(-∞) = 0, g(+∞) = 1, such that:\n$$\\lim_{n \\to \\infty} |\\{\\alpha \\in (0,1) : f(\\alpha,n) \\leq c\\}| = g(c)?$$\n\n**Status**: OPEN\n\n**Related Result**: Kesten (1960) proved that f(α,β,n) with an additional shift parameter β has Cauchy distribution g(c) = (1/π)arctan(ρc) + 1/2.",
     "proofStrategy": "**Why This Problem is Difficult**\n\nThe key difficulty is the loss of independence when β = 0:\n\n1. **Two-Parameter Case**: Averaging over both α and β provides sufficient independence for ergodic methods.\n\n2. **One-Parameter Case**: With β = 0 fixed, the sequence {αk} for different k values has subtle correlations.\n\n3. **Continued Fractions**: The behavior of f(α,n) depends on the continued fraction expansion of α. Different Diophantine properties of α lead to different behaviors.\n\n4. **Dynamical Systems**: The problem connects to geodesic flows on modular surfaces, but the relevant ergodic theory is incomplete.\n\n**Potential Approaches**:\n- Study the joint distribution of (α, {α}, {2α}, ..., {nα})\n- Analyze the Fourier transform of the distribution\n- Use number-theoretic properties of continued fractions",
     "keyInsights": [
-      "The fractional part {αk} for irrational α is equidistributed (Weyl's theorem)",
-      "The deviation from uniformity, weighted by 1/log n, captures subtle arithmetic structure",
-      "Kesten's two-parameter result uses averaging over β to achieve independence",
-      "Fixing β = 0 destroys the independence and makes the problem much harder",
-      "The answer may depend on Diophantine properties of α (how well approximable it is)"
+      "**Weyl equidistribution**: $\\{\\alpha k\\}$ is equidistributed in $[0,1)$ for irrational $\\alpha$, so the inner sum grows sublinearly — the $\\log n$ normalization captures the precise scale",
+      "**Kesten's Cauchy limit**: The two-parameter variant $f(\\alpha, \\beta, n)$ converges to $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$ via ergodic properties of the Gauss map's natural extension",
+      "**Loss of independence**: Fixing $\\beta = 0$ eliminates the averaging over the shift parameter that provides the crucial ergodic independence in Kesten's proof",
+      "**Continued fraction connection**: The behavior of $f(\\alpha, n)$ depends on $\\alpha$'s continued fraction partial quotients — large quotients cause large oscillations in the sum",
+      "**Open status**: Neither the existence of a limiting distribution nor its form (Cauchy or otherwise) is known for the one-parameter case"
     ]
   },
   "sections": [
     {
       "id": "fractional-part",
       "title": "Fractional Part",
-      "summary": "Definition of frac(x) = x - ⌊x⌋",
+      "summary": "$\\{x\\} = x - \\lfloor x \\rfloor$ fractional part definition and basic properties",
       "startLine": 24,
       "endLine": 37
     },
     {
       "id": "weighted-sum",
       "title": "The Weighted Sum f(α, n)",
-      "summary": "innerSum and f definitions",
+      "summary": "$S(\\alpha, n) = \\sum_{k=1}^{n}(1/2 - \\{\\alpha k\\})$ and $f(\\alpha, n) = S(\\alpha, n)/\\log n$",
       "startLine": 39,
       "endLine": 54
     },
     {
       "id": "distribution-functions",
       "title": "Distribution Functions",
-      "summary": "isDistributionFunction definition",
+      "summary": "$g : \\mathbb{R} \\to [0,1]$ non-decreasing with $g(-\\infty) = 0$, $g(+\\infty) = 1$",
       "startLine": 56,
       "endLine": 68
     },
     {
       "id": "asymptotic-distribution",
       "title": "Asymptotic Distribution",
-      "summary": "levelSet and hasAsymptoticDistribution",
+      "summary": "Level set $L(n,c) = \\{\\alpha : f(\\alpha,n) \\le c\\}$ and $\\mu(L(n,c)) \\to g(c)$ convergence",
       "startLine": 70,
       "endLine": 88
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture (OPEN)",
-      "summary": "erdos_1002_conjecture definition",
+      "summary": "OPEN: $\\exists\\, g,\\; \\mu(\\{\\alpha : f(\\alpha,n) \\le c\\}) \\to g(c)$ as $n \\to \\infty$",
       "startLine": 90,
       "endLine": 101
     },
     {
       "id": "kesten-theorem",
       "title": "Kesten's Theorem (1960)",
-      "summary": "Two-parameter variant has Cauchy distribution",
+      "summary": "Kesten (1960): $f(\\alpha, \\beta, n)$ has Cauchy limit $g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$",
       "startLine": 103,
       "endLine": 133
     },
     {
       "id": "relationship",
       "title": "Relationship Between Problems",
-      "summary": "One-parameter as special case",
+      "summary": "$f(\\alpha, n) = f(\\alpha, 0, n)$: one-parameter case is $\\beta = 0$ specialization",
       "startLine": 135,
       "endLine": 145
     },
     {
       "id": "difficulty",
       "title": "Why the Problem is Difficult",
-      "summary": "Independence is lost when β = 0",
+      "summary": "Fixing $\\beta = 0$ destroys ergodic independence; Weyl equidistribution and oscillation for fixed $\\alpha$",
       "startLine": 147,
       "endLine": 166
     },
     {
       "id": "partial-results",
       "title": "Partial Results",
-      "summary": "Boundedness and continued fraction bounds",
+      "summary": "$|f(\\alpha, n)| \\le C(\\alpha)$ boundedness and $|S(\\alpha, n)| \\le C \\log n$ continued fraction bound",
       "startLine": 168,
       "endLine": 182
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Overview and open problems",
+      "summary": "Full problem formalization with 0 sorries; main conjecture OPEN (mathematical gap, not formalization gap)",
       "startLine": 184,
       "endLine": 208
     }


### PR DESCRIPTION
## Summary
- Replace 14 shallow annotations (missing all enrichment fields) with 12 substantive annotations, all with `mathContext`, `relatedConcepts`, `prerequisites`
- Deepen `historicalContext` to ~1400 chars: Weyl (1916), Gauss map, Kuzmin (1928), Lévy (1929), Kesten (1960)
- Add bold formatting and LaTeX to all 5 `keyInsights`
- Update all 10 section summaries with LaTeX notation

## Test plan
- [x] `pnpm annotations:build` passes (no warnings for erdos-1002)
- [x] All annotations have required fields (mathContext, relatedConcepts, prerequisites)
- [x] No invalid annotation types
- [x] Section summaries contain LaTeX notation

🤖 Generated with [Claude Code](https://claude.com/claude-code)