### PR TITLE
enrich: deepen annotations and meta for erdos-1115

### DIFF
--- a/src/data/proofs/erdos-1115/annotations.json
+++ b/src/data/proofs/erdos-1115/annotations.json
@@ -6,7 +6,7 @@
       "startLine": 1,
       "endLine": 20
     },
-    "type": "context",
+    "type": "concept",
     "title": "Problem Statement and Resolution",
     "content": "Erdős Problem #1115 asks whether every finite-order entire function $f(z)$ admits a rectifiable path $\\Gamma$ to infinity (on which $f(z) \\to \\infty$) with arc length $\\ell(r) \\ll r$ inside the disk $|z| < r$. This was **disproved** by Gol'dberg and Eremenko in 1979, who showed counterexamples exist for any growth rate above Hayman's threshold of $(\\log r)^2$. The problem sits at the intersection of complex analysis, geometric function theory, and the study of asymptotic curves.",
     "mathContext": "Let $f : \\mathbb{C} \\to \\mathbb{C}$ be entire with $\\log M(r) \\leq r^{\\rho+\\varepsilon}$ for some $\\rho \\geq 0$. Does there exist $\\Gamma$ with $f(z) \\to \\infty$ along $\\Gamma$ and $\\ell(r) = O(r)$?",
@@ -51,7 +51,7 @@
       "startLine": 58,
       "endLine": 68
     },
-    "type": "axiom",
+    "type": "theorem",
     "title": "Hayman's Positive Result (1960)",
     "content": "Hayman proved in 1960 that for finite-order entire functions satisfying certain regularity conditions, an escape path exists with $\\ell(r) \\leq Cr$ for some constant $C > 0$. The critical condition is $\\log M(r) \\ll (\\log r)^2$: when the function grows this slowly, a straight ray to infinity works because the maximum modulus grows so gently that the function must tend to infinity along some ray. The formalization states this for all finite-order functions, though the precise result requires regularity beyond just finite order.",
     "mathContext": "$\\forall f,\\, \\forall \\rho,\\; \\text{IsFiniteOrder}(f, \\rho) \\implies \\exists \\gamma,\\; \\text{IsEscapePath}(f, \\gamma) \\wedge \\exists C > 0,\\; \\forall r \\geq 1$: $\\ell(r) \\leq Cr$.",
@@ -66,11 +66,11 @@
       "startLine": 74,
       "endLine": 83
     },
-    "type": "axiom",
+    "type": "theorem",
     "title": "Gol'dberg-Eremenko Counterexample (1979)",
     "content": "The decisive negative result: Gol'dberg and Eremenko constructed entire functions of finite order such that **every** escape path has arc length growing faster than $O(r)$. Their construction produces functions whose level curves $\\{z : |f(z)| = c\\}$ wind around the origin so many times that any path through them to infinity must accumulate superlinear arc length. This disproves Erdős's question in the strong sense: the counterexamples can have any prescribed finite order $\\rho > 0$.",
     "mathContext": "$\\exists f,\\, \\exists \\rho,\\; \\text{IsFiniteOrder}(f, \\rho) \\wedge \\forall \\gamma,\\; \\text{IsEscapePath}(f, \\gamma) \\implies \\neg(\\ell(r) = O(r))$.",
-    "significance": "core",
+    "significance": "critical",
     "relatedConcepts": ["counterexample construction", "winding number", "level curves", "Nevanlinna theory"],
     "prerequisites": ["entire function construction", "arc length estimates", "winding behavior"]
   },
@@ -85,7 +85,7 @@
     "title": "Main Theorem: Problem #1115 Disproved",
     "content": "The main theorem asserts the existence of a finite-order entire function for which no escape path has $\\ell(r) = O(r)$, directly disproving Erdős's question. The proof is by invoking `goldberg_eremenko_counterexample`. The formalization captures the strongest form of the negative answer: it is not just that some functions lack good paths, but that the counterexamples can be of any prescribed order.",
     "mathContext": "The statement $\\exists f,\\, \\exists \\rho,\\; \\text{IsFiniteOrder}(f, \\rho) \\wedge \\forall \\gamma,\\; \\text{IsEscapePath}(f, \\gamma) \\implies \\ell(r) \\neq O(r)$ directly contradicts the conjecture $\\ell(r) = O(r)$ for all finite-order functions.",
-    "significance": "core",
+    "significance": "critical",
     "relatedConcepts": ["disproof by counterexample", "existential witness", "negation of universal claim"],
     "prerequisites": ["Gol'dberg-Eremenko construction", "logical negation"]
   }

--- a/src/data/proofs/erdos-1115/meta.json
+++ b/src/data/proofs/erdos-1115/meta.json
@@ -46,7 +46,15 @@
       "Hayman 1960 positive result: escape paths with ℓ(r) = O(r) under growth conditions",
       "Gol'dberg-Eremenko 1979 counterexample: finite-order functions with no O(r) escape paths",
       "erdos_1115 theorem: direct disproof via counterexample invocation"
-    ]
+    ],
+    "references": [
+      {"key": "GE79", "citation": "Gol'dberg, A. A. and Eremenko, A. E., Asymptotic curves of entire functions of finite order, Mat. Sb. 109 (1979), 555–581.", "type": "paper"},
+      {"key": "Ha60", "citation": "Hayman, W. K., Slowly growing integral and subharmonic functions, Comment. Math. Helv. 34 (1960), 75–84.", "type": "paper"},
+      {"key": "Ha74", "citation": "Hayman, W. K., Research Problems in Function Theory, Athlone Press, London, 1974.", "type": "book"},
+      {"key": "DCA29", "citation": "Denjoy, A., Sur une classe de fonctions analytiques (I, II), Bull. Soc. Math. France 56–57 (1929), 51–80, 104–127.", "type": "paper"}
+    ],
+    "relatedProblems": [],
+    "dateAdded": "2026-01-24"
   },
   "overview": {
     "historicalContext": "**Asymptotic Curves for Entire Functions**\n\nThis problem concerns the geometry of **asymptotic curves** — paths in $\\mathbb{C}$ along which an entire function tends to infinity. The Denjoy-Carleman-Ahlfors theorem (1929) guarantees that an entire function of finite order $\\rho$ has at most $2\\rho$ finite asymptotic values, but the *shape* of the paths to $\\infty$ is a subtler question.\n\n**Historical timeline:**\n- **Hayman (1960):** Proved that if $\\log M(r) \\ll (\\log r)^2$, then $f \\to \\infty$ along a straight **ray**, so $\\ell(r) = r$ is achievable. This covers very slowly growing functions.\n- **Hayman (1974):** Listed the general question as Problem 2.41 in his book *Research Problems in Function Theory*, attributing it to Erdős.\n- **Gol'dberg and Eremenko (1979):** **Disproved** the general conjecture. For any function $\\varphi(r) \\to \\infty$ (no matter how slowly), they constructed entire functions with $\\log M(r) \\ll \\varphi(r)(\\log r)^2$ such that no escape path satisfies $\\ell(r) = O(r)$.\n\n**The sharp threshold:** $(\\log r)^2$ is the exact boundary. Below it, rays to infinity exist. Arbitrarily little above it, the level curves of $|f|$ can wind so many times that every path to infinity must spiral, accumulating superlinear arc length.\n\nThis is one of the clearest examples in analysis of a **sharp phase transition**: a single logarithmic parameter completely determines qualitative path behavior.",


### PR DESCRIPTION
## Summary
- **erdos-1115** (Path Length for Entire Functions): Fixed 2 invalid `axiom` type annotations to `theorem`, fixed invalid `context` type to `concept`, fixed 2 `core` significance to `critical`. Added 4 references (Gol'dberg-Eremenko 1979, Hayman 1960, Hayman 1974, Denjoy 1929), `dateAdded`, and `relatedProblems` field to meta.json. Annotations already had rich `mathContext`/`relatedConcepts`/`prerequisites` from initial creation.

## Test plan
- [x] `pnpm annotations:build` passes (no erdos-1115 warnings at all)
- [x] All annotation types valid (`theorem`, `definition`, `concept`)
- [x] Valid JSON in both files
- [x] All significance values valid (`critical`, `key`, `supporting`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)