### PR TITLE
enrich: deepen annotations and meta for erdos-159, erdos-192, erdos-215, erdos-216

### DIFF
--- a/src/data/proofs/erdos-216/annotations.json
+++ b/src/data/proofs/erdos-216/annotations.json
@@ -1,58 +1,134 @@
 [
   {
-    "id": "ann-e216-definitions",
-    "range": { "startLine": 49, "endLine": 69 },
-    "type": "definition",
-    "title": "Geometric Primitives",
-    "content": "The formalization represents points in ℝ² via Mathlib's EuclideanSpace ℝ (Fin 2), with PointSet as Finset Point. The predicates InGeneralPosition (no three collinear) and IsConvexKGon (k vertices in convex position) are axiomatized since full definitions require cross-product and convex-hull infrastructure not needed for the combinatorial content of the problem.",
-    "significance": "key"
+    "id": "ann-e216-overview",
+    "proofId": "erdos-216",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "context",
+    "title": "Problem Overview: Empty Convex Polygons and the Function g(k)",
+    "content": "Erdős Problem #216 asks: for each $k$, what is the smallest $n = g(k)$ such that any $n$ points in general position in $\\mathbb{R}^2$ must contain an empty convex $k$-gon (one with no other points inside)? The complete answer: $g(3) = 3$, $g(4) = 5$, $g(5) = 10$ (Harborth 1978), $g(6) = 30$ (Heule-Scheucher 2024), and $g(k)$ **does not exist** for $k \\geq 7$ (Horton 1983). This is a variant of the Happy Ending Problem (Erdős #107), where the emptiness condition creates a sharp threshold at $k = 7$. The formalization imports `Finset.Basic`, `Finset.Card`, `Convex.Basic`, `EuclideanDist`, and `Real.Basic`.",
+    "mathContext": "$g(k) = \\min\\{n : \\text{any } n \\text{ points in general position contain an empty convex } k\\text{-gon}\\}$. Complete: $g(3)=3, g(4)=5, g(5)=10, g(6)=30$, $g(k) = \\nexists$ for $k \\geq 7$.",
+    "significance": "critical",
+    "relatedConcepts": ["empty convex polygons", "general position", "Horton sets", "Happy Ending Problem"],
+    "prerequisites": ["convex position", "point sets in the plane", "general position (no 3 collinear)"]
   },
   {
-    "id": "ann-e216-empty",
+    "id": "ann-e216-definitions",
+    "proofId": "erdos-216",
+    "range": { "startLine": 49, "endLine": 69 },
+    "type": "definition",
+    "title": "Geometric Primitives: Points, General Position, Convex k-Gons",
+    "content": "Three foundational definitions: (1) `Point := EuclideanSpace ℝ (Fin 2)` and `PointSet := Finset Point` for finite planar point sets. (2) `InGeneralPosition S` — axiomatized predicate that no three points of $S$ are collinear. This is the standard non-degeneracy condition in discrete geometry; formalizing it fully would require cross-product computations. (3) `IsConvexKGon vertices k` — axiomatized predicate that $k$ points are in convex position (they form the vertices of a convex polygon). The structural axiom `convexKGon_card` guarantees the vertex set has exactly $k$ elements.",
+    "mathContext": "$\\text{Point} = \\mathbb{R}^2$. General position: no 3 collinear. Convex $k$-gon: $k$ points as vertices of a convex polygon, $|\\text{vertices}| = k$.",
+    "significance": "key",
+    "relatedConcepts": ["EuclideanSpace", "Finset", "general position", "convex position"],
+    "prerequisites": ["EuclideanSpace ℝ (Fin 2)", "Finset basics", "collinearity"]
+  },
+  {
+    "id": "ann-e216-empty-polygons",
+    "proofId": "erdos-216",
     "range": { "startLine": 71, "endLine": 86 },
     "type": "definition",
-    "title": "Empty Convex Polygons",
-    "content": "An empty convex k-gon in a point set S is a convex k-gon whose interior contains no other points of S. This 'emptiness' condition is the key distinction from the Happy Ending Problem (#107): it makes the problem much harder and causes the function g(k) to have a finite threshold. IsEmptyConvexKGon is axiomatized with a structural axiom guaranteeing vertices lie in S.",
-    "significance": "critical"
+    "title": "Empty Convex Polygons: The Key Distinction",
+    "content": "The critical definition: `IsEmptyConvexKGon S vertices k` — the $k$ vertices form a convex polygon whose interior contains no other points of $S$. This **emptiness** condition is what distinguishes Problem #216 from the classical Happy Ending Problem (#107). The structural axiom `emptyConvexKGon_sub` ensures vertices lie in $S$ and form a valid convex $k$-gon. `ContainsEmptyKGon S k` is the existential wrapper: $\\exists$ vertices forming an empty convex $k$-gon in $S$. The emptiness condition makes the problem dramatically harder and introduces the $k = 7$ threshold.",
+    "mathContext": "Empty convex $k$-gon in $S$: $k$ points of $S$ in convex position with no point of $S$ strictly inside the convex hull. $\\text{ContainsEmptyKGon}(S, k) \\iff \\exists V \\subseteq S,\\, |V| = k,\\, V \\text{ convex},\\, \\text{conv}(V)^\\circ \\cap S = \\emptyset$.",
+    "significance": "critical",
+    "relatedConcepts": ["convex hull interior", "empty polygon", "Erdős-Szekeres type problems"],
+    "prerequisites": ["convex hull", "interior of convex set", "Finset subset"]
   },
   {
     "id": "ann-e216-function-g",
+    "proofId": "erdos-216",
     "range": { "startLine": 88, "endLine": 100 },
     "type": "definition",
-    "title": "The Function g(k)",
-    "content": "g(k) is defined as Option ℕ using Nat.find: it returns some n (the smallest threshold) when a finite threshold exists, and none otherwise. This elegant formulation captures both existence and non-existence in a single definition, enabling the characterization theorem g_exists_iff.",
-    "significance": "critical"
+    "title": "The Function g(k): Threshold or Non-Existence",
+    "content": "The function `g k : Option ℕ` is defined using `Nat.find`: if a threshold exists (there is some $n$ such that every $n$ points in general position contain an empty convex $k$-gon), return `some (Nat.find h)` giving the smallest such $n$; otherwise return `none`. The `Option` type elegantly captures both cases — existence ($k \\leq 6$) and non-existence ($k \\geq 7$) — in a single definition. The predicate `gExists k` is shorthand for `(g k).isSome`.",
+    "mathContext": "$g(k) = \\begin{cases} \\min\\{n : \\forall S,\\, |S| \\geq n \\wedge \\text{GP}(S) \\implies \\text{empty } k\\text{-gon in } S\\} & \\text{if threshold exists} \\\\ \\nexists & \\text{otherwise} \\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": ["Option type", "Nat.find", "Ramsey-type threshold", "decision procedure"],
+    "prerequisites": ["Option ℕ", "Nat.find", "decidability of existence"]
   },
   {
     "id": "ann-e216-known-values",
+    "proofId": "erdos-216",
     "range": { "startLine": 102, "endLine": 120 },
-    "type": "theorem",
-    "title": "Known Exact Values of g",
-    "content": "Four axioms record the known values: g(3)=3 (trivial), g(4)=5 (Erdős), g(5)=10 (Harborth 1978), and g(6)=30 (Heule-Scheucher 2024). The g(6)=30 result was a landmark: existence was proved by Nicolás (2007) and Gerken (2008), but the exact value required SAT solvers verifying all 29-point configurations and finding a 30-point universal property.",
-    "significance": "critical"
+    "type": "axiom",
+    "title": "Known Exact Values: g(3) Through g(6)",
+    "content": "Four axioms record the known values: (1) `g_3`: $g(3) = 3$ — trivial, any 3 non-collinear points form an empty triangle. (2) `g_4`: $g(4) = 5$ — attributed to Erdős; any 5 points in general position contain an empty quadrilateral. (3) `g_5`: $g(5) = 10$ — Harborth (1978), proved in *Konvexe Fünfecke in ebenen Punktmengen*. (4) `g_6`: $g(6) = 30$ — the landmark result. **Existence** of $g(6)$ was proved independently by Nicolás (2007) and Gerken (2008). The **exact value** 30 was determined by Heule and Scheucher (2024) using SAT solvers: they verified that every 30-point general-position set contains an empty hexagon, and exhibited a 29-point set without one.",
+    "mathContext": "$g(3) = 3$, $g(4) = 5$, $g(5) = 10$ (Harborth 1978), $g(6) = 30$ (Heule-Scheucher 2024). The jump from $g(5) = 10$ to $g(6) = 30$ is dramatic.",
+    "significance": "core",
+    "relatedConcepts": ["SAT solvers in combinatorics", "computer-assisted proofs", "empty hexagon theorem"],
+    "prerequisites": ["Harborth 1978", "Nicolás 2007", "Gerken 2008", "Heule-Scheucher 2024"]
   },
   {
     "id": "ann-e216-horton",
+    "proofId": "erdos-216",
     "range": { "startLine": 122, "endLine": 148 },
     "type": "theorem",
     "title": "Horton's Theorem: g(7) Does Not Exist",
-    "content": "Horton (1983) constructed arbitrarily large point sets in general position containing no empty 7-gon. The key idea: recursively interlace two smaller Horton sets so that any potential empty heptagon must use points from both halves, but the interlacing prevents this. The theorem g_7_not_exists is actually proved (not axiomatized) from the horton_sets_exist axiom, demonstrating a genuine deduction in the formalization.",
-    "significance": "critical"
+    "content": "**Horton (1983)** constructed point sets of arbitrary size containing no empty 7-gon. `IsHortonSet S` means $S$ is in general position and has no empty 7-gon. The axiom `horton_sets_exist` asserts Horton sets exist for every size $n$. The key theorem `g_7_not_exists : g 7 = none` is **genuinely proved** in Lean (not axiomatized): unfold `g`, apply `dite_eq_right_iff`, and derive a contradiction from Horton sets. The axiom `g_ge_7_not_exists` extends to all $k \\geq 7$: since a Horton set with no empty 7-gon also has no empty $k$-gon for $k > 7$ (larger polygons are harder to find).",
+    "mathContext": "Horton (1983): $\\forall n,\\, \\exists S \\subseteq \\mathbb{R}^2,\\, |S| = n,\\, \\text{GP}(S),\\, \\neg\\text{empty 7-gon in } S$. Therefore $g(7) = \\nexists$ and $g(k) = \\nexists$ for $k \\geq 7$.",
+    "significance": "core",
+    "relatedConcepts": ["Horton sets", "recursive construction", "threshold non-existence", "convex partition"],
+    "prerequisites": ["Horton's interlacing construction", "monotonicity of empty k-gon existence"]
+  },
+  {
+    "id": "ann-e216-bounds",
+    "proofId": "erdos-216",
+    "range": { "startLine": 150, "endLine": 162 },
+    "type": "theorem",
+    "title": "Bounds, Growth, and Existence for k <= 6",
+    "content": "Two results: (1) `g_lower_bound`: for $3 \\leq k \\leq 6$, $g(k) \\geq 2k - 3$. This gives $g(3) \\geq 3$, $g(4) \\geq 5$, $g(5) \\geq 7$, $g(6) \\geq 9$ — the first two are tight, the last two are not (actual values are 10 and 30). (2) `g_exists_le_6`: proved by `interval_cases k` followed by `simp` with the four known-value axioms, establishing that $g(k)$ exists for all $3 \\leq k \\leq 6$.",
+    "mathContext": "$g(k) \\geq 2k - 3$ for $3 \\leq k \\leq 6$. $\\text{gExists}(k) \\iff k \\leq 6$ (for $k \\geq 3$). Proved by case analysis.",
+    "significance": "key",
+    "relatedConcepts": ["lower bounds", "interval_cases tactic", "case analysis"],
+    "prerequisites": ["known g values", "interval_cases", "Option.isSome"]
+  },
+  {
+    "id": "ann-e216-horton-construction",
+    "proofId": "erdos-216",
+    "range": { "startLine": 164, "endLine": 180 },
+    "type": "axiom",
+    "title": "The Horton Construction: Base Case and Recursion",
+    "content": "The Horton construction formalized: (1) `hortonBase`: the trivial 1-point Horton set $\\{(0,0)\\}$ using `![0, 0]` (Fin.VecNotation). (2) `horton_recursive`: given two Horton sets $S_1, S_2$ of equal size, there exists a combined Horton set of size $|S_1| + |S_2|$. The actual construction 'interlaces' the two sets vertically so that any potential empty 7-gon must use points from both halves, but the vertical separation prevents the required convexity. (3) `horton_has_empty_6`: crucially, Horton sets of size $\\geq 30$ **do** contain empty hexagons — the non-existence threshold is exactly $k = 7$, not $k = 6$.",
+    "mathContext": "Horton construction: $H_1 = \\{(0,0)\\}$. $H_n = \\text{interlace}(H_{\\lfloor n/2 \\rfloor}, H_{\\lceil n/2 \\rceil})$. $H_n$ has no empty 7-gon but has empty 6-gons for $n \\geq 30$.",
+    "significance": "key",
+    "relatedConcepts": ["recursive construction", "interlacing", "vertical separation", "empty hexagon in Horton sets"],
+    "prerequisites": ["Fin.VecNotation ![0,0]", "recursive point set construction"]
   },
   {
     "id": "ann-e216-happy-ending",
+    "proofId": "erdos-216",
     "range": { "startLine": 182, "endLine": 203 },
-    "type": "insight",
-    "title": "Connection to the Happy Ending Problem",
-    "content": "The Happy Ending Problem (Erdős #107) asks the same question without the emptiness condition. Its function g'(k) exists for ALL k (Erdős-Szekeres 1935), with conjectured value 2^(k-2)+1. The contrast is striking: removing the emptiness requirement eliminates the k=7 threshold entirely. The axiom empty_implies_nonempty formalizes g(k) ≥ g'(k), since every empty polygon is also a (non-empty) polygon.",
-    "significance": "key"
+    "type": "definition",
+    "title": "Connection to Happy Ending Problem (#107)",
+    "content": "The **Happy Ending Problem** (Erdős #107): $g'(k)$ is the smallest $n$ such that any $n$ points in general position contain a convex $k$-gon (not necessarily empty). Key differences from Problem #216: (1) `happy_ending_exists`: $g'(k)$ exists for **all** $k \\geq 3$ (Erdős-Szekeres 1935), unlike $g(k)$ which fails for $k \\geq 7$. (2) `erdos_szekeres_conjecture`: the conjectured value $g'(k) = 2^{k-2} + 1$ (verified for $k \\leq 6$). (3) `empty_implies_nonempty`: $g(k) \\geq g'(k)$ when both exist, since every empty polygon is also a (non-empty) polygon. The emptiness condition is what creates the $k = 7$ threshold.",
+    "mathContext": "$g'(k) = \\min\\{n : \\forall S,\\, |S| \\geq n \\implies \\text{convex } k\\text{-gon in } S\\}$. Exists $\\forall k \\geq 3$. Conjecture: $g'(k) = 2^{k-2} + 1$. Always $g(k) \\geq g'(k)$.",
+    "significance": "key",
+    "relatedConcepts": ["Happy Ending Problem", "Erdős-Szekeres theorem", "Ramsey theory", "empty vs non-empty"],
+    "prerequisites": ["Erdős-Szekeres 1935", "convex position", "Ramsey-type results"]
+  },
+  {
+    "id": "ann-e216-computational",
+    "proofId": "erdos-216",
+    "range": { "startLine": 205, "endLine": 215 },
+    "type": "axiom",
+    "title": "Computational Verification: g(6) = 30",
+    "content": "Two computational axioms for the $g(6) = 30$ result: (1) `g_6_lower_witness`: there exists a 29-point set in general position with no empty hexagon — the lower bound witness. (2) `g_6_upper`: every 30-point general-position set contains an empty hexagon — the upper bound. Together these pin down $g(6) = 30$ exactly. Heule and Scheucher (2024) verified both directions using SAT solvers: the lower bound by explicit construction, the upper bound by exhaustive case analysis encoded as a satisfiability problem.",
+    "mathContext": "$\\exists S,\\, |S| = 29,\\, \\text{GP}(S),\\, \\neg\\text{empty 6-gon}$. $\\forall S,\\, |S| \\geq 30 \\wedge \\text{GP}(S) \\implies \\text{empty 6-gon}$. Hence $g(6) = 30$.",
+    "significance": "key",
+    "relatedConcepts": ["SAT solvers", "exhaustive search", "computer-verified mathematics", "Heule-Scheucher 2024"],
+    "prerequisites": ["SAT solving", "combinatorial search", "point configuration enumeration"]
   },
   {
     "id": "ann-e216-summary",
-    "range": { "startLine": 235, "endLine": 270 },
-    "type": "summary",
-    "title": "Complete Resolution of Problem #216",
-    "content": "The summary theorem erdos_216_summary and the characterization g_exists_iff together completely resolve the problem: g(k) exists if and only if k ≤ 6, with exact values 3, 5, 10, 30. This is one of the few Erdős problems with a complete, clean answer — a sharp threshold at k=7 separating existence from non-existence.",
-    "significance": "critical"
+    "proofId": "erdos-216",
+    "range": { "startLine": 217, "endLine": 272 },
+    "type": "theorem",
+    "title": "Summary: Complete Resolution of Problem #216",
+    "content": "Four summary theorems: (1) `erdos_216_summary`: the 6-fold conjunction of $g(3)=3, g(4)=5, g(5)=10, g(6)=30, g(7)=\\text{none}$, and $\\forall k \\geq 7,\\, g(k) = \\text{none}$. Proved by `exact ⟨g_3, g_4, g_5, g_6, g_7_not_exists, g_ge_7_not_exists⟩`. (2) `erdos_216`: identical statement. (3) `known_g_values`: just the four known values. (4) `g_exists_iff`: the characterization $k \\geq 3 \\implies (\\text{gExists}(k) \\iff k \\leq 6)$, proved by `interval_cases` and the known values/Horton results. This gives the complete resolution: $g(k)$ exists iff $k \\leq 6$.",
+    "mathContext": "$\\text{erdos\\_216\\_summary}: g(3)=3 \\wedge g(4)=5 \\wedge g(5)=10 \\wedge g(6)=30 \\wedge g(7)=\\nexists \\wedge (\\forall k \\geq 7,\\, g(k)=\\nexists)$. $g\\text{Exists}(k) \\iff k \\leq 6$ for $k \\geq 3$.",
+    "significance": "core",
+    "relatedConcepts": ["complete characterization", "threshold phenomenon", "existence-nonexistence dichotomy"],
+    "prerequisites": ["all known g values", "g_7_not_exists", "g_ge_7_not_exists", "interval_cases"]
   }
 ]

--- a/src/data/proofs/erdos-216/meta.json
+++ b/src/data/proofs/erdos-216/meta.json
@@ -28,147 +28,157 @@
     "mathlibDependencies": [
       {
         "theorem": "Finset.Basic",
-        "description": "Basic finite set operations",
+        "description": "Finset operations for finite point sets and vertex subsets",
         "module": "Mathlib.Data.Finset.Basic"
       },
       {
         "theorem": "Finset.Card",
-        "description": "Cardinality of finite sets",
+        "description": "Cardinality for counting points and vertices (card = k conditions)",
         "module": "Mathlib.Data.Finset.Card"
       },
       {
         "theorem": "Convex.Basic",
-        "description": "Convexity definitions",
+        "description": "Convexity definitions (used conceptually for convex k-gon axioms)",
         "module": "Mathlib.Analysis.Convex.Basic"
       },
       {
-        "theorem": "EuclideanSpace",
-        "description": "Euclidean space ℝⁿ",
+        "theorem": "EuclideanDist",
+        "description": "EuclideanSpace ℝ (Fin 2) for the plane, used as Point type",
         "module": "Mathlib.Analysis.InnerProductSpace.EuclideanDist"
       },
       {
-        "theorem": "Nat.find",
-        "description": "Finding least natural number satisfying predicate",
+        "theorem": "Real.Basic",
+        "description": "Real number arithmetic for coordinate computations",
         "module": "Mathlib.Data.Real.Basic"
       }
     ],
     "originalContributions": [
-      "Point and PointSet definitions for ℝ²",
-      "InGeneralPosition definition (no three collinear)",
-      "IsConvexKGon definition for convex k-gons",
-      "IsEmptyConvexKGon definition (no interior points)",
-      "ContainsEmptyKGon predicate",
-      "g(k) function as Option ℕ (none when doesn't exist)",
-      "gExists predicate",
-      "Known values g_3, g_4, g_5, g_6 as axioms",
-      "IsHortonSet definition and horton_sets_exist axiom",
-      "g_7_not_exists theorem (proved from Horton axiom)",
-      "g_ge_7_not_exists axiom for k ≥ 7",
-      "g_lower_bound axiom",
-      "g_exists_le_6 theorem",
-      "Horton construction axioms (base, recursive, has_empty_6)",
-      "Happy Ending Problem connection (happyEnding function)",
-      "Erdős-Szekeres conjecture formalization",
-      "empty_implies_nonempty axiom",
-      "Computational verification axioms (g_6_lower_witness, g_6_upper)",
-      "erdos_216_summary comprehensive theorem",
-      "known_g_values theorem",
-      "g_exists_iff characterization theorem"
+      "Point := EuclideanSpace ℝ (Fin 2), PointSet := Finset Point",
+      "InGeneralPosition: axiomatized no-three-collinear predicate",
+      "IsConvexKGon: axiomatized convex k-gon with convexKGon_card structural axiom",
+      "IsEmptyConvexKGon: empty interior condition with emptyConvexKGon_sub",
+      "ContainsEmptyKGon: existential wrapper",
+      "g : ℕ → Option ℕ via Nat.find (some n or none)",
+      "gExists: shorthand for (g k).isSome",
+      "g_3, g_4, g_5, g_6 axioms: known exact values",
+      "IsHortonSet: general position + no empty 7-gon",
+      "g_7_not_exists: genuinely proved from horton_sets_exist axiom",
+      "g_ge_7_not_exists axiom: extension to all k ≥ 7",
+      "g_exists_le_6: proved by interval_cases",
+      "hortonBase, horton_recursive, horton_has_empty_6: Horton construction axioms",
+      "happyEnding: non-empty variant function",
+      "erdos_szekeres_conjecture: g'(k) = 2^(k-2) + 1",
+      "g_6_lower_witness, g_6_upper: computational verification axioms",
+      "erdos_216_summary, g_exists_iff: complete characterization theorems"
+    ],
+    "relatedProblems": [
+      {
+        "id": "erdos-107",
+        "relationship": "Parent problem: #107 (Happy Ending Problem) asks the same question without the empty interior condition; g'(k) exists for all k, while g(k) exists only for k ≤ 6"
+      }
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #216: Empty Convex Polygons**\n\nThis is a variant of the famous 'Happy Ending Problem' (Erdős #107). The key difference is requiring the convex polygon to be EMPTY - no other points from the set lie in its interior.\n\n**Historical Timeline:**\n- 1935: Erdős and Szekeres study convex polygons (non-empty variant)\n- Erdős observed g(4) = 5 (same as happy ending)\n- 1978: Harborth proved g(5) = 10\n- 1983: Horton constructed sets with no empty 7-gon, proving g(k) doesn't exist for k ≥ 7\n- 2007: Nicolás proved g(6) exists\n- 2008: Gerken independently proved g(6) exists\n- 2024: Heule-Scheucher determined g(6) = 30 using SAT solvers\n\n**The Problem:** For each k, what is the minimum n such that any n points in general position contain an empty convex k-gon?",
-    "problemStatement": "**Problem Statement (Partially Solved)**\n\nLet g(k) be the smallest integer (if it exists) such that any g(k) points in ℝ² in general position contains an empty convex k-gon (a convex k-gon with no point in its interior).\n\n**Questions:**\n1. Does g(k) exist for all k?\n2. If so, what is g(k)?\n\n**Complete Answer:**\n- g(3) = 3 (trivial: any 3 points form an empty triangle)\n- g(4) = 5 (Erdős)\n- g(5) = 10 (Harborth, 1978)\n- g(6) = 30 (Heule-Scheucher, 2024)\n- g(k) does NOT exist for k ≥ 7 (Horton, 1983)\n\n**Status: COMPLETELY RESOLVED** - The function g(k) exists if and only if k ≤ 6.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Point Sets:** Define Point as EuclideanSpace ℝ (Fin 2), PointSet as Finset Point\n\n2. **General Position:** InGeneralPosition requires no three collinear points\n\n3. **Empty Polygons:** IsEmptyConvexKGon requires k vertices forming a convex polygon with no other points inside\n\n4. **The Function g:** Define as Option ℕ - returns some n when threshold exists, none otherwise\n\n5. **Known Values:** Axiomatize g(3)=3, g(4)=5, g(5)=10, g(6)=30 based on published results\n\n6. **Horton's Theorem:** Define Horton sets and axiomatize their existence; prove g(7)=none\n\n7. **Connection:** Link to Happy Ending Problem and Erdős-Szekeres conjecture",
+    "historicalContext": "**Erdős Problem #216: Empty Convex Polygons**\n\nThis is a variant of the famous Happy Ending Problem (Erdős #107). The key distinction is requiring the convex polygon to be **empty** — no other points from the set lie in its interior.\n\n**Historical Timeline:**\n- **1935:** Erdős and Szekeres prove the Happy Ending theorem: for every $k$, there exists $N$ such that any $N$ points in general position contain a convex $k$-gon. This is the non-empty variant.\n- **1935:** Klein (later Esther Szekeres) observes $g'(4) = 5$ for the non-empty version.\n- **Erdős:** Observes $g(4) = 5$ for the empty version (same as happy ending since any convex quadrilateral among 5 points is empty).\n- **1978:** Harborth proves $g(5) = 10$ in *Konvexe Fünfecke in ebenen Punktmengen*. This is the first non-trivial empty polygon result.\n- **1983:** J.D. Horton constructs point sets of arbitrary size containing no empty 7-gon, published in *Canadian Mathematical Bulletin*. This proves $g(k)$ does not exist for $k \\geq 7$, revealing the sharp threshold.\n- **2007:** Carlos M. Nicolás proves $g(6)$ exists (the empty hexagon theorem).\n- **2008:** Tobias Gerken independently proves $g(6)$ exists using a different method.\n- **2024:** Marijn Heule and Manfred Scheucher determine $g(6) = 30$ exactly, using SAT solvers. Published as *Happy Ending: An Empty Hexagon in Every Set of 30 Points*. They exhibit a 29-point configuration with no empty hexagon and verify that all 30-point configurations contain one.\n\n**The Complete Resolution:**\nThe function $g(k)$ exists if and only if $k \\leq 6$, with exact values $g(3) = 3$, $g(4) = 5$, $g(5) = 10$, $g(6) = 30$. This is one of the few Erdős problems with a complete, clean answer.",
+    "problemStatement": "**Problem Statement (Solved)**\n\nLet $g(k)$ be the smallest integer (if it exists) such that any $g(k)$ points in $\\mathbb{R}^2$ in general position (no three collinear) contain an empty convex $k$-gon — a convex $k$-gon with no point of the set in its interior.\n\n**Questions:**\n1. Does $g(k)$ exist for all $k$?\n2. If so, what is $g(k)$?\n\n**Complete Answer:**\n- $g(3) = 3$ (trivial: any 3 points form an empty triangle)\n- $g(4) = 5$ (Erdős)\n- $g(5) = 10$ (Harborth, 1978)\n- $g(6) = 30$ (Heule-Scheucher, 2024)\n- $g(k)$ does NOT exist for $k \\geq 7$ (Horton, 1983)\n\n**Status:** COMPLETELY RESOLVED. The function $g(k)$ exists precisely for $k \\leq 6$.",
+    "proofStrategy": "**Formalization Approach**\n\nThe 272-line formalization in the `Erdos216` namespace:\n\n1. **Geometric Primitives (lines 49–69):** `Point := EuclideanSpace ℝ (Fin 2)`, `PointSet := Finset Point`. `InGeneralPosition` and `IsConvexKGon` axiomatized with structural axiom `convexKGon_card`.\n\n2. **Empty Polygons (lines 71–86):** `IsEmptyConvexKGon` axiomatized with `emptyConvexKGon_sub` structural axiom. `ContainsEmptyKGon` as existential wrapper.\n\n3. **The Function g (lines 88–100):** `g k : Option ℕ` via `Nat.find` — elegantly captures both existence and non-existence.\n\n4. **Known Values (lines 102–120):** Four axioms for $g(3)=3, g(4)=5, g(5)=10, g(6)=30$.\n\n5. **Horton's Theorem (lines 122–148):** `IsHortonSet`, `horton_sets_exist` axiom, `g_7_not_exists` **genuinely proved** by contradiction with Horton sets.\n\n6. **Bounds (lines 150–162):** `g_lower_bound` axiom and `g_exists_le_6` proved by `interval_cases`.\n\n7. **Horton Construction (lines 164–180):** Base case, recursion, and `horton_has_empty_6` (Horton sets have empty hexagons for $n \\geq 30$).\n\n8. **Happy Ending Connection (lines 182–203):** `happyEnding` function, `erdos_szekeres_conjecture`, `empty_implies_nonempty`.\n\n9. **Computational Results (lines 205–215):** 29-point lower witness and 30-point upper bound.\n\n10. **Summary (lines 217–272):** `erdos_216_summary`, `g_exists_iff` characterization proved.",
     "keyInsights": [
-      "**Empty vs Non-Empty:** The empty interior condition makes a huge difference - g(k) has a finite threshold (k=6) while the happy ending version exists for all k",
-      "**Horton Sets:** These ingenious constructions have arbitrarily many points but no empty 7-gon, constructed by recursively interlacing smaller Horton sets",
-      "**Computational Breakthrough:** g(6)=30 required SAT solvers to verify - too large for hand proof",
-      "**Ramsey-Theoretic:** The problem is #2 in Ramsey theory in the Erdős problem collection",
-      "**Clean Characterization:** g(k) exists iff k ≤ 6 - a complete resolution of the existence question"
+      "**Empty vs. non-empty threshold:** The emptiness condition creates a sharp dichotomy: the non-empty Happy Ending function $g'(k)$ exists for all $k$ (Erdős-Szekeres 1935), but the empty version $g(k)$ exists only for $k \\leq 6$. A single additional constraint — no interior points — transforms a universally-existing Ramsey function into one with a finite threshold.",
+      "**Horton sets are the obstruction:** Horton's 1983 construction recursively interlaces two smaller point sets vertically, creating configurations where any potential empty 7-gon must use points from both halves, but the vertical gap prevents the required convexity. Crucially, Horton sets **do** contain empty hexagons (for $n \\geq 30$), so the obstruction is precisely at $k = 7$.",
+      "**SAT solving in discrete geometry:** The determination of $g(6) = 30$ by Heule-Scheucher (2024) is a landmark application of SAT solvers to combinatorial geometry. The proof encodes all possible 30-point configurations as Boolean satisfiability problems, verifying exhaustively that no counterexample exists. This is too large for hand verification.",
+      "**The Option type as mathematical modeling:** The formalization uses `g k : Option ℕ` — returning `some n` when the threshold exists and `none` otherwise. This is a clean Lean 4 idiom that naturally captures the existence/non-existence dichotomy, enabling the elegant characterization `g_exists_iff : gExists k ↔ k ≤ 6`.",
+      "**Genuine Lean proof of g(7) = none:** The theorem `g_7_not_exists` is not axiomatized but **proved** in Lean from the `horton_sets_exist` axiom: unfold the definition of `g`, derive a contradiction between the Horton set (no empty 7-gon) and the universal property (every large set has one). This demonstrates non-trivial reasoning in the formalization.",
+      "**Growth rate mystery:** The known values $3, 5, 10, 30$ grow rapidly: each roughly doubles or triples. The jump from $g(5) = 10$ to $g(6) = 30$ is dramatic and was not predicted before the SAT computation."
     ]
   },
   "sections": [
     {
+      "id": "header-and-imports",
+      "title": "Header, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module documentation with problem statement, complete answer (g(k) exists iff k ≤ 6), historical timeline, and 5 references (Harborth, Horton, Nicolás, Gerken, Heule-Scheucher); imports Finset.Basic/Card, Convex.Basic, EuclideanDist, Real.Basic; opens Finset and Erdos216 namespace"
+    },
+    {
       "id": "basic-definitions",
-      "title": "Basic Definitions",
-      "summary": "Point, PointSet, InGeneralPosition, IsConvexKGon axioms",
+      "title": "Part I: Geometric Primitives",
       "startLine": 49,
-      "endLine": 69
+      "endLine": 69,
+      "summary": "Defines Point := EuclideanSpace ℝ (Fin 2), PointSet := Finset Point; axiomatizes InGeneralPosition (no 3 collinear) and IsConvexKGon (convex position) with convexKGon_card structural axiom"
     },
     {
       "id": "empty-polygons",
-      "title": "Empty Convex Polygons",
-      "summary": "IsEmptyConvexKGon axiom, ContainsEmptyKGon definition",
+      "title": "Part II: Empty Convex Polygons",
       "startLine": 71,
-      "endLine": 86
+      "endLine": 86,
+      "summary": "Axiomatizes IsEmptyConvexKGon (empty interior condition) with emptyConvexKGon_sub structural axiom; defines ContainsEmptyKGon as existential wrapper"
     },
     {
       "id": "function-g",
-      "title": "The Function g(k)",
-      "summary": "Definition of g(k) as Option ℕ, gExists predicate",
+      "title": "Part III: The Function g(k)",
       "startLine": 88,
-      "endLine": 100
+      "endLine": 100,
+      "summary": "Defines g : ℕ → Option ℕ via dite and Nat.find (some n when threshold exists, none otherwise); gExists k := (g k).isSome"
     },
     {
       "id": "known-values",
-      "title": "Known Values",
-      "summary": "g_3, g_4, g_5, g_6 axioms with historical attribution",
+      "title": "Part IV: Known Exact Values",
       "startLine": 102,
-      "endLine": 120
+      "endLine": 120,
+      "summary": "Four axioms: g_3 = some 3 (trivial), g_4 = some 5 (Erdős), g_5 = some 10 (Harborth 1978), g_6 = some 30 (Heule-Scheucher 2024)"
     },
     {
       "id": "horton-theorem",
-      "title": "Horton's Theorem",
-      "summary": "IsHortonSet, horton_sets_exist, g_7_not_exists theorem",
+      "title": "Part V: Horton's Theorem",
       "startLine": 122,
-      "endLine": 148
+      "endLine": 148,
+      "summary": "Defines IsHortonSet (GP + no empty 7-gon); axiom horton_sets_exist for arbitrary size; theorem g_7_not_exists genuinely proved by contradiction; axiom g_ge_7_not_exists for k ≥ 7"
     },
     {
       "id": "bounds-growth",
-      "title": "Bounds and Growth",
-      "summary": "g_lower_bound, g_exists_le_6 theorem",
+      "title": "Part VI: Bounds and Existence",
       "startLine": 150,
-      "endLine": 162
+      "endLine": 162,
+      "summary": "Axiom g_lower_bound: g(k) ≥ 2k-3 for 3 ≤ k ≤ 6; theorem g_exists_le_6 proved by interval_cases + simp with known values"
     },
     {
       "id": "horton-construction",
-      "title": "The Horton Construction",
-      "summary": "hortonBase, horton_recursive, horton_has_empty_6 axioms",
+      "title": "Part VII: Horton Construction Details",
       "startLine": 164,
-      "endLine": 180
+      "endLine": 180,
+      "summary": "hortonBase = {![0,0]}; axiom horton_recursive: combining two Horton sets; axiom horton_has_empty_6: Horton sets ≥ 30 points contain empty hexagons"
     },
     {
       "id": "happy-ending",
-      "title": "Connection to Happy Ending Problem",
-      "summary": "happyEnding function, Erdős-Szekeres conjecture, comparison",
+      "title": "Part VIII: Happy Ending Connection",
       "startLine": 182,
-      "endLine": 203
+      "endLine": 203,
+      "summary": "Defines happyEnding (non-empty variant) via Option ℕ; axiom happy_ending_exists for all k ≥ 3; erdos_szekeres_conjecture: g'(k) = 2^(k-2)+1; axiom empty_implies_nonempty: g(k) ≥ g'(k)"
     },
     {
       "id": "computational",
-      "title": "Computational Results",
-      "summary": "g_6_lower_witness, g_6_upper axioms",
+      "title": "Part IX: Computational Verification",
       "startLine": 205,
-      "endLine": 215
+      "endLine": 215,
+      "summary": "Axiom g_6_lower_witness: 29-point set with no empty hexagon; axiom g_6_upper: every 30-point GP set has empty hexagon"
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "summary": "erdos_216_summary, erdos_216, known_g_values, g_exists_iff theorems",
+      "title": "Part X: Summary Theorems",
       "startLine": 217,
-      "endLine": 272
+      "endLine": 272,
+      "summary": "Theorem erdos_216_summary: 6-fold conjunction proved by exact tuple; erdos_216 alias; known_g_values; g_exists_iff: complete characterization gExists(k) ↔ k ≤ 6 proved by interval_cases"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #216 is completely resolved. The function g(k) - the minimum number of points guaranteeing an empty convex k-gon - exists precisely for k ≤ 6. The exact values are g(3)=3, g(4)=5, g(5)=10, and g(6)=30 (the last determined by Heule-Scheucher in 2024 using SAT solvers). Horton's 1983 construction of arbitrarily large point sets with no empty 7-gon proves g(k) does not exist for k ≥ 7.",
-    "implications": "**Geometric Ramsey Theory Connections**\n\n1. **Happy Ending Problem:** The non-empty version (Erdős #107) has g'(k) for all k, conjectured to be 2^(k-2)+1\n\n2. **Computational Methods:** The g(6)=30 result showcases the power of SAT solvers in discrete geometry\n\n3. **Horton Sets:** These constructions have applications beyond this problem in computational geometry\n\n4. **Complete Resolution:** Unlike many Erdős problems, this one has a complete answer\n\n5. **Threshold Phenomenon:** The sharp transition at k=7 is a beautiful combinatorial result",
+    "summary": "Erdős Problem #216 is completely resolved. The function $g(k)$ — the minimum number of points guaranteeing an empty convex $k$-gon — exists precisely for $k \\leq 6$. The exact values are $g(3)=3$, $g(4)=5$, $g(5)=10$, and $g(6)=30$ (the last determined by Heule-Scheucher in 2024 using SAT solvers). Horton's 1983 construction of arbitrarily large point sets with no empty 7-gon proves $g(k)$ does not exist for $k \\geq 7$. The 272-line formalization captures the complete characterization, with `g_7_not_exists` genuinely proved and `g_exists_iff` giving the full existence criterion.",
+    "implications": "**Connections and Impact**\n\n1. **Happy Ending Problem (#107):** The non-empty version has $g'(k)$ for all $k$ (Erdős-Szekeres 1935), conjectured to be $2^{k-2}+1$. The empty version's finite threshold at $k = 7$ reveals a fundamental structural difference: empty polygons are much harder to force than non-empty ones.\n\n2. **Computational Combinatorics:** The $g(6) = 30$ result by Heule-Scheucher (2024) is a flagship example of SAT-based mathematics, joining the ranks of the Boolean Pythagorean Triples problem and Schur number 5.\n\n3. **Horton Sets in Computational Geometry:** Horton's construction has found applications beyond this problem: in studying visibility graphs, art gallery problems, and other geometric Ramsey questions.\n\n4. **Complete Resolution:** Unlike many Erdős problems that remain open or partially resolved, Problem #216 has a complete, clean answer: a sharp threshold at $k = 7$ separating existence from non-existence.",
     "openQuestions": [
-      "Efficient algorithms for finding empty k-gons in point sets?",
-      "Analogous problems in higher dimensions?",
-      "Tight bounds on Horton set constructions?",
-      "Connections to other Ramsey-type problems in geometry?",
-      "Generalizations with restricted point configurations?"
+      "Efficient algorithms for finding empty k-gons in point sets (current best is roughly O(n^k))?",
+      "Analogous problems in higher dimensions: what is the threshold dimension for empty convex polytopes?",
+      "Can the SAT-based proof of g(6) = 30 be converted to a human-verifiable proof?",
+      "Tight bounds on the minimum size of Horton sets avoiding empty k-gons for k = 6?",
+      "What is the maximum number of empty convex k-gons in an n-point set?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enriched erdos-159 (Ramsey numbers R(C₄, Kₙ), power saving conjecture)
- Enriched erdos-192 (unit vector walks, abelian squares, Keränen 1992)
- Enriched erdos-215 (Steinhaus lattice point problem, Jackson-Mauldin 2002)
- Enriched erdos-216 (empty convex polygons, g(k) exists iff k ≤ 6)

All entries: corrected mathlibDependencies to match actual imports, added mathContext/relatedConcepts/prerequisites to all annotations, deepened historicalContext with specific mathematicians and publications, added 6 keyInsights each, corrected section line ranges, added relatedProblems cross-references.

## Test plan
- [x] All JSON files validated with `python3 -c "import json; json.load(open(...))"`
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)