### PR TITLE
research: prove trace_nonneg axiom in operator AM-GM

### DIFF
--- a/proofs/Proofs/AMGMOperatorMeans.lean
+++ b/proofs/Proofs/AMGMOperatorMeans.lean
@@ -13,8 +13,9 @@ positive semidefinite matrices, using the Loewner (semidefinite) ordering.
 The classical AM-GM: (a + b)/2 >= sqrt(ab) for non-negative reals.
 The operator version: (A + B)/2 >=_L A # B for positive definite matrices.
 
-## What We Prove (17 theorems, 0 sorries)
+## What We Prove (19 theorems, 0 sorries)
 - PSD/PD basics: zero is PSD, sum/scaling of PSD, PD implies PSD
+- Trace non-negativity of PSD matrices (via standard basis vectors)
 - Loewner order: reflexivity, transitivity, addition, scaling
 - Arithmetic mean: PSD preservation, domination of lesser operand
 - Trace inequality: tr(AM) >= tr(GM)
@@ -22,12 +23,11 @@ The operator version: (A + B)/2 >=_L A # B for positive definite matrices.
 - Weighted arithmetic mean: PSD preservation, half-weight = AM
 - HM-GM-AM chain (from axioms)
 
-## What We Axiomatize (13 axioms, deep results needing spectral theorem)
+## What We Axiomatize (12 axioms, deep results needing spectral theorem)
 - Matrix square root (existence, PSD, squaring)
 - Geometric mean (existence, PD, commutativity, self-mean, monotonicity)
 - The operator AM-GM inequality itself
 - Harmonic mean, HM <= GM, congruence invariance
-- Trace non-negativity of PSD matrices
 
 ## References
 - Bhatia, "Positive Definite Matrices" (2007)
@@ -91,9 +91,22 @@ theorem RealPosSemidef.smul {A : Matrix n n ℝ} {c : ℝ}
   rw [h1, dotProduct_smul]
   exact mul_nonneg hc (hA.2 x)
 
-/-- Trace of PSD matrix is non-negative (axiomatized) -/
-axiom RealPosSemidef.trace_nonneg {A : Matrix n n ℝ}
-    (hA : RealPosSemidef A) : 0 ≤ A.trace
+/-- Diagonal entry equals the quadratic form evaluated at the standard basis vector -/
+private lemma diag_eq_quadratic (A : Matrix n n ℝ) (i : n) :
+    A i i = dotProduct (Pi.single i 1) (A.mulVec (Pi.single i 1)) := by
+  simp [dotProduct, mulVec, Pi.single, Function.update, Finset.sum_ite_eq', Finset.mem_univ]
+
+/-- Trace of PSD matrix is non-negative.
+
+This follows from the fact that each diagonal entry A i i equals eᵢᵀ A eᵢ ≥ 0 by the PSD
+condition, so the trace (sum of diagonal entries) is a sum of non-negatives. -/
+theorem RealPosSemidef.trace_nonneg {A : Matrix n n ℝ}
+    (hA : RealPosSemidef A) : 0 ≤ A.trace := by
+  unfold Matrix.trace Matrix.diag
+  apply Finset.sum_nonneg
+  intro i _
+  rw [diag_eq_quadratic A i]
+  exact hA.2 _
 
 /-
 ## Section 2: Loewner Order
@@ -231,12 +244,7 @@ theorem trace_arithMean_ge_trace_geomMean
     (matArithMean A B).trace ≥ (matGeomMean A B hA hB).trace := by
   have h := arithMean_sub_geomMean_posSemidef A B hA hB
   have htrace := h.trace_nonneg
-  have hsub : (matArithMean A B - matGeomMean A B hA hB).trace =
-      (matArithMean A B).trace - (matGeomMean A B hA hB).trace := by
-    simp only [trace, diag_apply, sub_apply]
-    exact Finset.sum_sub_distrib (f := fun i => matArithMean A B i i)
-      (g := fun i => matGeomMean A B hA hB i i)
-  rw [hsub] at htrace
+  rw [Matrix.trace_sub] at htrace
   linarith
 
 /-- If A = B then A # B = (A+B)/2 -/

--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -1,0 +1,58 @@
+{
+  "slug": "amgm-inequality-oq-01",
+  "title": "AM-GM Generalization to Operator Means in Matrix Analysis",
+  "phase": "COMPLETE",
+  "status": "complete",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For positive definite matrices A, B: A # B ≤_L (A+B)/2 in the Loewner order, where A # B is the matrix geometric mean",
+    "plain": "The classical AM-GM inequality generalizes to positive definite matrices: the matrix geometric mean is dominated by the arithmetic mean in the Loewner (semidefinite) ordering.",
+    "whyMatters": [
+      "Connects scalar inequality to matrix/operator theory via Loewner order",
+      "Foundation of Kubo-Ando theory of operator means (1980)",
+      "Applications in quantum information theory and matrix optimization",
+      "Extends the HM-GM-AM chain to the noncommutative setting"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "RealPosSemidef and RealPosDef predicates via quadratic form x^T A x",
+      "PSD basics: zero is PSD, sum of PSD is PSD, scalar multiple of PSD is PSD",
+      "Positive definite implies positive semidefinite",
+      "Trace non-negativity of PSD matrices (proved via standard basis vectors)",
+      "Loewner order: reflexivity, transitivity, addition, scaling",
+      "Arithmetic mean: PSD preservation, domination of lesser operand",
+      "Trace inequality: tr(AM) >= tr(GM) via trace_sub",
+      "Equality condition: A = B implies AM = GM",
+      "Weighted arithmetic mean: PSD preservation, half-weight = AM",
+      "HM-GM-AM chain (via axiomatized components)"
+    ],
+    "axiomatized": [
+      "Matrix square root (existence, PSD, squaring property)",
+      "Matrix geometric mean (existence, PD, commutativity, self-mean, monotonicity)",
+      "Operator AM-GM inequality itself",
+      "Harmonic mean and HM <= GM",
+      "Congruence invariance of geometric mean"
+    ]
+  },
+  "knowledge": {
+    "insights": [
+      "trace_nonneg is provable from the quadratic form PSD definition: each diagonal entry A_ii = e_i^T A e_i >= 0, so trace = sum of non-negatives",
+      "Matrix.trace_sub from Mathlib simplifies the trace inequality proof (replaces custom Finset.sum_sub_distrib)",
+      "The deep axioms (matrix square root, geometric mean) require spectral theorem infrastructure not yet in Mathlib for real matrices",
+      "Mathlib has Matrix.PosSemidef.trace_nonneg but for star-ordered rings, not directly compatible with our real quadratic form definition",
+      "12 axioms remain, concentrated in spectral-theorem-dependent results (sqrt, geometric mean, harmonic mean)"
+    ],
+    "builtItems": [
+      "Proved RealPosSemidef.trace_nonneg (was axiom) via diag_eq_quadratic helper lemma in AMGMOperatorMeans.lean",
+      "Simplified trace_arithMean_ge_trace_geomMean proof using Matrix.trace_sub instead of Finset.sum_sub_distrib"
+    ],
+    "nextSteps": [
+      "Consider bridging RealPosSemidef to Mathlib's Matrix.PosSemidef for additional infrastructure",
+      "Matrix square root proof would require spectral theorem for real symmetric matrices",
+      "Operator AM-GM proof itself requires A^{-1/2} B A^{-1/2} technique or Ando's concavity argument"
+    ],
+    "progressSummary": "COMPLETE: Eliminated 1 axiom (trace_nonneg), simplified 1 proof (trace inequality). File now has 19 proved theorems, 12 axioms. The remaining axioms are deep spectral-theorem results."
+  }
+}


### PR DESCRIPTION
## Summary
- Converted `RealPosSemidef.trace_nonneg` from axiom to theorem in `AMGMOperatorMeans.lean`
- Simplified `trace_arithMean_ge_trace_geomMean` proof using `Matrix.trace_sub`
- Added problem knowledge file for amgm-inequality-oq-01

## Progress
**Proof technique**: Each diagonal entry `A i i` equals `e_i^T A e_i >= 0` by the PSD condition (evaluated at standard basis vector). The trace (sum of diagonal entries) is therefore a sum of non-negatives.

**Result**: 19 proved theorems (was 17), 12 axioms (was 13). The eliminated axiom was the only one not requiring spectral theorem infrastructure.

## Files Modified
- `proofs/Proofs/AMGMOperatorMeans.lean` - axiom→theorem conversion + trace proof simplification
- `src/data/research/problems/amgm-inequality-oq-01.json` - new problem knowledge file

## Status
**Outcome**: completed
**Next Steps**: Remaining 12 axioms require spectral theorem for real symmetric matrices (matrix square root, geometric mean construction)

Generated by researcher-1