### PR TITLE
enrich: deepen annotations and meta for erdos-320, erdos-331, erdos-338

### DIFF
--- a/src/data/proofs/erdos-331/annotations.json
+++ b/src/data/proofs/erdos-331/annotations.json
@@ -2,181 +2,157 @@
   {
     "id": "ann-331-counting",
     "proofId": "erdos-331",
-    "range": { "startLine": 41, "endLine": 43 },
+    "range": { "startLine": 41, "endLine": 48 },
     "type": "definition",
-    "title": "countingFunction",
-    "content": "|A ∩ {1,...,N}| the counting function.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-331-density",
-    "proofId": "erdos-331",
-    "range": { "startLine": 45, "endLine": 48 },
-    "type": "definition",
-    "title": "HasDensityAtLeast",
-    "content": "Set has density ≥ c·N^α.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-331-sqrtdensity",
-    "proofId": "erdos-331",
-    "range": { "startLine": 50, "endLine": 51 },
-    "type": "definition",
-    "title": "HasSqrtDensity",
-    "content": "Density ≫ N^{1/2}.",
-    "significance": "critical"
+    "title": "Counting Function and Density",
+    "content": "The counting function |A ∩ {1,...,N}| measures the growth rate of a set A ⊆ ℕ. Implemented via Finset.filter over Finset.Icc 1 N, giving exact counts as natural numbers. HasDensityAtLeast(A, α) formalizes |A ∩ {1,...,N}| ≥ c · N^α for some c > 0 and all sufficiently large N — this is 'lower density at least α' in the asymptotic sense. The critical special case HasSqrtDensity means α = 1/2: the set grows at least as fast as √N. The finer HasExactSqrtDensity requires the counting function to be asymptotic to c · √N via Filter.Tendsto to nhds c.",
+    "mathContext": "$$|A \\cap \\{1,\\ldots,N\\}| \\ge c \\cdot N^\\alpha \\quad \\text{for all large } N$$\nThe counting function $A(N) = |A \\cap \\{1,\\ldots,N\\}|$ grows like $N^\\alpha$. The critical case $\\alpha = 1/2$: $A(N) \\gg N^{1/2}$ means $A(N) \\ge c\\sqrt{N}$ for some $c > 0$. **Exact asymptotic**: $A(N) \\sim c\\sqrt{N}$ means $\\lim_{N \\to \\infty} A(N)/\\sqrt{N} = c$.",
+    "significance": "key",
+    "relatedConcepts": ["counting function", "asymptotic density", "lower density", "Filter.Tendsto", "nhds"],
+    "prerequisites": ["Finset.Icc", "Finset.filter", "Finset.card", "Real.rpow"]
   },
   {
     "id": "ann-331-commondiff",
     "proofId": "erdos-331",
-    "range": { "startLine": 61, "endLine": 64 },
+    "range": { "startLine": 61, "endLine": 72 },
     "type": "definition",
-    "title": "HasCommonDifference",
-    "content": "a₁ - a₂ = b₁ - b₂ ≠ 0.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-331-infinitelymany",
-    "proofId": "erdos-331",
-    "range": { "startLine": 70, "endLine": 72 },
-    "type": "definition",
-    "title": "HasInfinitelyManyCommonDifferences",
-    "content": "Infinitely many common differences.",
-    "significance": "key"
+    "title": "Common Differences",
+    "content": "A common difference d ≠ 0 between sets A and B requires a₁ − a₂ = d for some a₁, a₂ ∈ A AND b₁ − b₂ = d for some b₁, b₂ ∈ B. Equivalently, d ∈ (A − A) ∩ (B − B) \\ {0} where A − A = {a − a' : a, a' ∈ A} is the difference set. The set commonDifferences(A, B) collects all such d, and HasInfinitelyManyCommonDifferences requires this set to be infinite (Set.Infinite). Erdős's question was whether sufficient density of A and B forces this intersection to be infinite.",
+    "mathContext": "A **common difference** is $d \\neq 0$ with $d \\in (A - A) \\cap (B - B)$, where\n$$A - A = \\{a_1 - a_2 : a_1, a_2 \\in A\\}$$\nThe set of common differences is $\\text{CD}(A,B) = (A - A) \\cap (B - B) \\setminus \\{0\\}$. The question: if $|A(N)|, |B(N)| \\gg N^{1/2}$, must $\\text{CD}(A,B)$ be infinite?",
+    "significance": "critical",
+    "relatedConcepts": ["difference set", "sumset", "additive combinatorics", "Set.Infinite"],
+    "prerequisites": ["Set ℤ", "Int.sub", "Set.Infinite"]
   },
   {
     "id": "ann-331-conjecture",
     "proofId": "erdos-331",
     "range": { "startLine": 78, "endLine": 83 },
     "type": "definition",
-    "title": "ErdosConjecture331",
-    "content": "Density ≫ N^{1/2} implies infinitely many common differences?",
-    "significance": "critical"
+    "title": "The Original Conjecture",
+    "content": "ErdosConjecture331 formalizes: for all A, B ⊆ ℕ with HasSqrtDensity A and HasSqrtDensity B, the sets must have infinitely many common differences. This was posed by Erdős and Graham (1980, p. 50) as a natural extension of the philosophy that 'density forces structure.' The conjecture would have implied that difference sets of dense sets necessarily overlap heavily. Ruzsa showed this is FALSE.",
+    "mathContext": "$$\\forall A, B \\subseteq \\mathbb{N},\\quad |A(N)|, |B(N)| \\gg N^{1/2} \\implies |\\text{CD}(A,B)| = \\infty$$\nThis is a **false** conjecture. The heuristic: $|A - A| \\approx |A|^2 \\sim N$ and similarly $|B - B| \\sim N$, so $(A-A) \\cap (B-B)$ 'should' be large. But Ruzsa showed the structure of $A$ and $B$ can prevent any overlap.",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős-Graham conjecture", "density implies structure", "additive combinatorics", "disproved conjectures"],
+    "prerequisites": ["HasSqrtDensity", "HasInfinitelyManyCommonDifferences"]
   },
   {
-    "id": "ann-331-evenpos",
+    "id": "ann-331-ruzsa-construction",
     "proofId": "erdos-331",
-    "range": { "startLine": 89, "endLine": 92 },
+    "range": { "startLine": 89, "endLine": 103 },
     "type": "definition",
-    "title": "evenBinaryPositions",
-    "content": "Binary digits only in even positions.",
-    "significance": "critical"
+    "title": "Ruzsa's Binary Digit Construction",
+    "content": "Ruzsa's counterexample uses the binary representation of natural numbers. evenBinaryPositions consists of numbers whose binary digits are nonzero only in positions 0, 2, 4, ... (i.e., only in 4^k places). Formally, n ∈ evenBinaryPositions iff (n / 2^(2k+1)) % 2 = 0 for all k — every odd-position bit is 0. Similarly, oddBinaryPositions has digits only in positions 1, 3, 5, ... These are 'orthogonal' in the sense that their binary representations use disjoint bit positions, so addition is carry-free: n = a + b with a ∈ A, b ∈ B is the same as interleaving the binary digits of a and b.",
+    "mathContext": "Write $n = \\sum_{i \\ge 0} d_i \\cdot 2^i$ in binary. Then:\n$$A = \\{n : d_{2k+1} = 0 \\text{ for all } k\\} = \\left\\{\\sum_k a_k \\cdot 4^k : a_k \\in \\{0,1\\}\\right\\}$$\n$$B = \\{n : d_{2k} = 0 \\text{ for all } k\\} = \\left\\{\\sum_k b_k \\cdot 2 \\cdot 4^k : b_k \\in \\{0,1\\}\\right\\}$$\nSince $A$ uses only even bit positions and $B$ uses only odd bit positions, their binary representations are **disjoint**: $a + b$ is a **carry-free** addition.",
+    "significance": "critical",
+    "relatedConcepts": ["binary representation", "carry-free addition", "digit sets", "Sidon-like sets"],
+    "prerequisites": ["Nat.Digits", "binary representation", "modular arithmetic"]
   },
   {
-    "id": "ann-331-oddpos",
+    "id": "ann-331-density-axioms",
     "proofId": "erdos-331",
-    "range": { "startLine": 94, "endLine": 97 },
-    "type": "definition",
-    "title": "oddBinaryPositions",
-    "content": "Binary digits only in odd positions.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-331-ruzsaa",
-    "proofId": "erdos-331",
-    "range": { "startLine": 99, "endLine": 100 },
-    "type": "definition",
-    "title": "ruzsaA",
-    "content": "Ruzsa's set A: even positions.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-331-ruzsab",
-    "proofId": "erdos-331",
-    "range": { "startLine": 102, "endLine": 103 },
-    "type": "definition",
-    "title": "ruzsaB",
-    "content": "Ruzsa's set B: odd positions.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-331-adensity",
-    "proofId": "erdos-331",
-    "range": { "startLine": 105, "endLine": 106 },
+    "range": { "startLine": 105, "endLine": 109 },
     "type": "theorem",
-    "title": "ruzsaA_has_sqrt_density",
-    "content": "A has density ≫ N^{1/2}.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-331-bdensity",
-    "proofId": "erdos-331",
-    "range": { "startLine": 108, "endLine": 109 },
-    "type": "theorem",
-    "title": "ruzsaB_has_sqrt_density",
-    "content": "B has density ≫ N^{1/2}.",
-    "significance": "key"
+    "title": "Density of Ruzsa's Sets",
+    "content": "Both ruzsaA and ruzsaB have density ≫ N^{1/2}, axiomatized as ruzsaA_has_sqrt_density and ruzsaB_has_sqrt_density. The counting argument: elements of A up to N are sums ∑ aₖ · 4^k with aₖ ∈ {0,1} and ∑ aₖ · 4^k ≤ N. The number of such sums is approximately √N because 4^k grows exponentially and the 'effective length' of the binary expansion is ~ log₄ N = ½ log₂ N, giving 2^(½ log₂ N) = √N choices. The same holds for B by the same argument with a factor-of-2 shift.",
+    "mathContext": "$$|A \\cap \\{1,\\ldots,N\\}| \\sim \\sqrt{N}, \\quad |B \\cap \\{1,\\ldots,N\\}| \\sim \\sqrt{N}$$\nThe elements of $A$ up to $N$ are $\\sum_{k=0}^{\\lfloor \\log_4 N \\rfloor} a_k \\cdot 4^k$ with $a_k \\in \\{0,1\\}$. There are $2^{\\lfloor \\log_4 N \\rfloor + 1} \\approx N^{\\log_4 2} = N^{1/2}$ such elements.",
+    "significance": "key",
+    "relatedConcepts": ["counting in base 4", "exponential growth", "density calculation"],
+    "prerequisites": ["HasSqrtDensity", "ruzsaA", "ruzsaB"]
   },
   {
     "id": "ann-331-unique",
     "proofId": "erdos-331",
     "range": { "startLine": 111, "endLine": 114 },
     "type": "theorem",
-    "title": "ruzsa_unique_representation",
-    "content": "Every n = a + b has unique representation.",
-    "significance": "critical"
+    "title": "Unique Representation Property",
+    "content": "The key structural property: every positive integer n has a UNIQUE decomposition n = a + b with a ∈ ruzsaA and b ∈ ruzsaB. This follows from the binary orthogonality: writing n = ∑ dᵢ · 2^i, the unique decomposition is a = ∑ d₂ₖ · 4^k (even-position digits) and b = ∑ d₂ₖ₊₁ · 2 · 4^k (odd-position digits). Since addition is carry-free, this is the only way to split n. Axiomatized using ExistsUnique (∃!) on pairs (a, b).",
+    "mathContext": "$$\\forall n \\ge 1,\\; \\exists! (a, b) \\in A \\times B : a + b = n$$\n**Proof sketch**: Write $n = \\sum_{i \\ge 0} d_i \\cdot 2^i$. Then $a = \\sum_{k \\ge 0} d_{2k} \\cdot 4^k$ and $b = \\sum_{k \\ge 0} d_{2k+1} \\cdot 2 \\cdot 4^k$. Since even and odd bit positions are disjoint, $a + b = n$ with **no carries**, and this is the unique such decomposition.",
+    "significance": "critical",
+    "relatedConcepts": ["unique representation", "ExistsUnique", "direct sum decomposition", "carry-free addition"],
+    "prerequisites": ["ruzsaA", "ruzsaB", "binary representation", "ExistsUnique"]
   },
   {
     "id": "ann-331-nocommon",
     "proofId": "erdos-331",
-    "range": { "startLine": 120, "endLine": 124 },
+    "range": { "startLine": 120, "endLine": 134 },
     "type": "theorem",
-    "title": "ruzsa_no_common_differences",
-    "content": "Ruzsa's sets have NO common differences.",
-    "significance": "critical"
+    "title": "No Common Differences",
+    "content": "The crucial consequence: Ruzsa's sets have NO nontrivial common differences at all — the set commonDifferences(A, B) is empty, not just finite. The proof: if a₁ − a₂ = b₁ − b₂ = d ≠ 0, then a₁ + b₂ = a₂ + b₁. By unique representation, since both sides decompose the same number into A + B, we get a₁ = a₂ and b₂ = b₁, contradicting d ≠ 0. This is axiomatized. The theorem ruzsa_counterexample is genuinely proved from this axiom by combining the density and emptiness results, then using Set.not_infinite_empty.",
+    "mathContext": "$$\\text{CD}(A, B) = (A - A) \\cap (B - B) \\setminus \\{0\\} = \\emptyset$$\n**Proof**: Suppose $a_1 - a_2 = b_1 - b_2 = d \\neq 0$. Then $a_1 + b_2 = a_2 + b_1 = n$. By unique representation, $(a_1, b_2)$ and $(a_2, b_1)$ are the same pair, so $a_1 = a_2$ and $b_2 = b_1$, giving $d = 0$. Contradiction.",
+    "significance": "critical",
+    "relatedConcepts": ["empty difference intersection", "unique representation implies no common differences", "Set.not_infinite_empty"],
+    "prerequisites": ["ruzsa_unique_representation", "commonDifferences", "Set.Infinite"]
   },
   {
-    "id": "ann-331-counterexample",
-    "proofId": "erdos-331",
-    "range": { "startLine": 126, "endLine": 134 },
-    "type": "theorem",
-    "title": "ruzsa_counterexample",
-    "content": "Ruzsa's sets disprove the conjecture.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-331-disproved",
+    "id": "ann-331-disproof",
     "proofId": "erdos-331",
     "range": { "startLine": 136, "endLine": 141 },
     "type": "theorem",
-    "title": "erdos_331_disproved",
-    "content": "Conjecture FALSE.",
-    "significance": "critical"
+    "title": "The Disproof",
+    "content": "The theorem erdos_331_disproved is genuinely proved in Lean: it assumes ErdosConjecture331, instantiates with ruzsaA and ruzsaB (which have sqrt density by axiom), obtains HasInfinitelyManyCommonDifferences, but ruzsa_counterexample.2.2 gives the negation. This clean proof-by-contradiction demonstrates the power of the formalization: three axioms (two density, one no-common-differences) combine to refute the universal statement.",
+    "mathContext": "**Proof**: Assume $\\forall A, B$ with $A(N), B(N) \\gg \\sqrt{N}$, $|\\text{CD}(A,B)| = \\infty$. Apply to $(A, B) = (\\text{ruzsaA}, \\text{ruzsaB})$. Then $\\text{CD} = \\emptyset$ is infinite — contradiction. $\\square$\n\nThe Lean proof: `intro h; have := h ruzsaA ruzsaB ...; exact ruzsa_counterexample.2.2 this`.",
+    "significance": "critical",
+    "relatedConcepts": ["proof by contradiction", "universal statement negation", "existential witness"],
+    "prerequisites": ["ErdosConjecture331", "ruzsa_counterexample", "ruzsaA_has_sqrt_density", "ruzsaB_has_sqrt_density"]
+  },
+  {
+    "id": "ann-331-characterization",
+    "proofId": "erdos-331",
+    "range": { "startLine": 147, "endLine": 161 },
+    "type": "insight",
+    "title": "Understanding the Counterexample",
+    "content": "Three structural insights explain why Ruzsa's construction works. First, ruzsaA_characterization shows A consists of sums of powers of 4 (base-4 numbers with digits {0,1}), giving A a Sidon-like structure. Second, ruzsaB_eq_double_ruzsaA (axiom) shows B = 2·A: every element of B is exactly twice an element of A, reflecting the 1-bit shift between even and odd positions. Third, ruzsa_exact_growth (axiom) confirms the density is exactly ~c·√N (not just ≫ √N), showing the counterexample just barely meets the density threshold.",
+    "mathContext": "$A = \\{\\sum_k a_k \\cdot 4^k : a_k \\in \\{0,1\\}\\}$ and $B = 2A = \\{2a : a \\in A\\}$. The map $a \\mapsto 2a$ shifts all binary digits one position to the left, converting even-position digits to odd-position digits. The exact density: $|A \\cap \\{1,\\ldots,N\\}| \\sim c \\cdot N^{1/2}$ for a specific constant $c > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["base-4 representation", "Sidon set", "doubling map", "exact asymptotics"],
+    "prerequisites": ["ruzsaA", "ruzsaB", "HasExactSqrtDensity"]
   },
   {
     "id": "ann-331-variant",
     "proofId": "erdos-331",
-    "range": { "startLine": 166, "endLine": 171 },
+    "range": { "startLine": 166, "endLine": 178 },
     "type": "definition",
-    "title": "RuzsaVariant",
-    "content": "Stronger variant with exact asymptotics.",
-    "significance": "key"
+    "title": "Ruzsa's Stronger Variant (Open)",
+    "content": "Ruzsa himself suggested a stronger variant: if we require the EXACT asymptotic |A ∩ {1,...,N}| ~ cₐ · N^{1/2} (convergence, not just lower bound), must A and B share infinitely many common differences? This is formalized as RuzsaVariant and remains OPEN. The axiom ruzsaVariantOpen represents the open status. Ruzsa's own construction has exact √N density, so it cannot serve as a counterexample to the ≫ version while also having exact density — but the subtle point is that the variant asks about ALL sets with exact density, which might have additional structure.",
+    "mathContext": "**Ruzsa's Variant (OPEN)**: If $\\lim_{N \\to \\infty} |A(N)|/\\sqrt{N} = c_A > 0$ and $\\lim_{N \\to \\infty} |B(N)|/\\sqrt{N} = c_B > 0$, must $|\\text{CD}(A,B)| = \\infty$?\n\nThe difference from the original: $\\gg \\sqrt{N}$ (lower bound) vs $\\sim c\\sqrt{N}$ (exact asymptotic). The exact condition imposes more regularity on the sets.",
+    "significance": "key",
+    "relatedConcepts": ["exact asymptotics", "open problem", "density regularity", "Ruzsa variant"],
+    "prerequisites": ["HasExactSqrtDensity", "HasInfinitelyManyCommonDifferences"]
+  },
+  {
+    "id": "ann-331-diffset",
+    "proofId": "erdos-331",
+    "range": { "startLine": 184, "endLine": 198 },
+    "type": "definition",
+    "title": "Difference Set Sparseness",
+    "content": "The difference set A − A = {a − a' : a, a' ∈ A} for Ruzsa's A is sparse: it has only ~√N elements up to N (axiom ruzsaA_sparse_differences). This is because A − A consists of numbers whose base-4 digits lie in {−1, 0, 1}, giving |{d ∈ A−A : |d| ≤ N}| ~ N^{1/2}. For generic sets of density √N, the difference set would have ~N elements (Plünnecke-Ruzsa inequality gives |A−A| ≤ |A|² ≈ N). The extreme sparseness of A−A is what allows (A−A) ∩ (B−B) to be empty.",
+    "mathContext": "The difference set $A - A = \\{a_1 - a_2 : a_1, a_2 \\in A\\}$ has $|\\{d \\in A - A : |d| \\le N\\}| \\le c \\cdot N^{1/2}$. Compare: a random set of density $\\sqrt{N}$ would have $|A - A| \\sim N$ by the **Plünnecke-Ruzsa inequality**. Ruzsa's $A$ has $|A - A| \\sim \\sqrt{N}$ — it is a **Sidon-like** set with very few repeated differences.",
+    "significance": "key",
+    "relatedConcepts": ["difference set", "Plünnecke-Ruzsa inequality", "Sidon set", "sparse structure"],
+    "prerequisites": ["differenceSet", "ruzsaA", "Finset.filter"]
   },
   {
     "id": "ann-331-largerdensity",
     "proofId": "erdos-331",
-    "range": { "startLine": 200, "endLine": 203 },
+    "range": { "startLine": 204, "endLine": 213 },
     "type": "theorem",
-    "title": "larger_density_common_differences",
-    "content": "Density > N^{1/2} guarantees common differences.",
-    "significance": "key"
+    "title": "Larger Density Forces Common Differences",
+    "content": "The axiom larger_density_common_differences states that for density > N^α with α > 1/2, common differences are guaranteed. This establishes √N as a sharp threshold: above it, common differences are forced; at it, counterexamples exist. The proof (not formalized) uses a pigeonhole/counting argument: if |A−A| ≫ N^(2α) and |B−B| ≫ N^(2α) with 2α > 1, then |(A−A) ∩ (B−B)| must be infinite since both difference sets are 'large' relative to {1,...,N}.",
+    "mathContext": "For $\\alpha > 1/2$: if $|A(N)| \\gg N^\\alpha$ and $|B(N)| \\gg N^\\alpha$, then $|\\text{CD}(A,B)| = \\infty$.\n\n**Heuristic**: $|A - A| \\gtrsim |A|^2 \\sim N^{2\\alpha}$. For $2\\alpha > 1$, the difference sets have positive density in $\\{-N,\\ldots,N\\}$, so their intersection must be infinite by a pigeonhole argument.",
+    "significance": "key",
+    "relatedConcepts": ["threshold phenomenon", "pigeonhole principle", "sumset growth", "positive density intersection"],
+    "prerequisites": ["HasDensityAtLeast", "HasInfinitelyManyCommonDifferences"]
   },
   {
-    "id": "ann-331-main",
+    "id": "ann-331-summary",
     "proofId": "erdos-331",
-    "range": { "startLine": 230, "endLine": 230 },
+    "range": { "startLine": 234, "endLine": 243 },
     "type": "theorem",
-    "title": "erdos_331",
-    "content": "Main theorem: conjecture DISPROVED.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-331-ruzsa",
-    "proofId": "erdos-331",
-    "range": { "startLine": 235, "endLine": 239 },
-    "type": "theorem",
-    "title": "erdos_331_ruzsa",
-    "content": "Ruzsa provided the counterexample.",
-    "significance": "critical"
+    "title": "Summary: Main Theorems",
+    "content": "Three genuinely proved theorems conclude the formalization. erdos_331 = erdos_331_disproved: the conjecture is false. erdos_331_main is the same (alias). erdos_331_ruzsa produces the existential witness: ∃ A, B with sqrt density and no infinite common differences, using ruzsaA and ruzsaB. The proofs chain cleanly: density axioms + no-common-differences axiom → counterexample → disproof. The file has 0 sorries (all definitions are complete) and 7 axioms (2 density, 1 unique representation, 1 no common differences, 1 B = 2A, 1 exact growth, 1 sparse differences, 1 larger density, 1 variant open).",
+    "mathContext": "**Proved**: $\\neg\\text{ErdosConjecture331}$ and $\\exists A, B : |A(N)|, |B(N)| \\gg \\sqrt{N} \\land |\\text{CD}(A,B)| < \\infty$.\n\nThe **proof chain**: `ruzsaA_has_sqrt_density` + `ruzsaB_has_sqrt_density` + `ruzsa_no_common_differences` → `ruzsa_counterexample` → `erdos_331_disproved`.",
+    "significance": "critical",
+    "relatedConcepts": ["disproof", "existential witness", "proof chain", "axiom inventory"],
+    "prerequisites": ["all previous sections"]
   }
 ]

--- a/src/data/proofs/erdos-331/meta.json
+++ b/src/data/proofs/erdos-331/meta.json
@@ -42,117 +42,122 @@
       }
     ],
     "originalContributions": [
-      "countingFunction, HasDensityAtLeast, HasSqrtDensity: density definitions",
-      "HasCommonDifference, commonDifferences: common difference predicates",
-      "HasInfinitelyManyCommonDifferences: infinitude condition",
-      "ErdosConjecture331: formal statement of the conjecture",
-      "evenBinaryPositions, oddBinaryPositions: Ruzsa's sets",
-      "ruzsaA, ruzsaB: the counterexample sets",
-      "ruzsa_unique_representation: key property of the construction",
-      "ruzsa_no_common_differences, ruzsa_counterexample: disproof",
-      "erdos_331_disproved, erdos_331_main: main theorems",
-      "RuzsaVariant: open variant with exact asymptotics"
+      "countingFunction via Finset.filter over Finset.Icc for exact growth measurement",
+      "HasDensityAtLeast and HasSqrtDensity formalizing lower density conditions",
+      "HasExactSqrtDensity via Filter.Tendsto for the stronger Ruzsa variant",
+      "HasCommonDifference and commonDifferences capturing difference set intersection",
+      "ErdosConjecture331 as the formal universal statement",
+      "evenBinaryPositions/oddBinaryPositions via modular arithmetic on binary digits",
+      "ruzsaA and ruzsaB as the named counterexample sets",
+      "ruzsa_unique_representation: every n ≥ 1 has unique A + B decomposition",
+      "ruzsa_counterexample: genuinely proved conjunction of density + no common differences",
+      "erdos_331_disproved: genuinely proved negation of the conjecture",
+      "erdos_331_ruzsa: existential witness for the counterexample",
+      "RuzsaVariant: formalization of the open stronger question",
+      "differenceSet and ruzsaA_sparse_differences: structural explanation",
+      "larger_density_common_differences: threshold α > 1/2 forces common differences"
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #331 (Common Differences in Dense Sets)**\n\n**Origin:**\nErdős and Graham (1980) asked whether sets A, B ⊆ ℕ with density ≫ N^{1/2} must have infinitely many common differences: solutions to a₁ - a₂ = b₁ - b₂ ≠ 0.\n\n**Ruzsa's Counterexample:**\nImre Ruzsa provided an elegant counterexample using binary representations:\n- A = numbers with nonzero binary digits only in even positions (0, 2, 4, ...)\n- B = numbers with nonzero binary digits only in odd positions (1, 3, 5, ...)\n\nBoth sets have density exactly ~ c·N^{1/2}, but every positive integer n has a UNIQUE representation n = a + b with a ∈ A and b ∈ B. This forces the set of common differences to be empty.\n\n**Significance:**\nThe threshold N^{1/2} is critical: for larger density, common differences are guaranteed.",
-    "problemStatement": "**Problem Statement (Disproved)**\n\nLet A, B ⊆ ℕ such that for all large N:\n- |A ∩ {1,...,N}| ≫ N^{1/2}\n- |B ∩ {1,...,N}| ≫ N^{1/2}\n\n**Question:** Must there be infinitely many solutions to a₁ - a₂ = b₁ - b₂ ≠ 0?\n\n**Answer: NO (DISPROVED)**\n\nRuzsa constructed sets with the required density but NO common differences.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Density Definitions:** countingFunction, HasDensityAtLeast, HasSqrtDensity\n\n2. **Common Differences:** HasCommonDifference, commonDifferences, HasInfinitelyManyCommonDifferences\n\n3. **Conjecture:** ErdosConjecture331 formal statement\n\n4. **Ruzsa's Construction:** evenBinaryPositions, oddBinaryPositions, ruzsaA, ruzsaB\n\n5. **Key Properties:** ruzsaA_has_sqrt_density, ruzsaB_has_sqrt_density, ruzsa_unique_representation\n\n6. **Disproof:** ruzsa_no_common_differences, ruzsa_counterexample, erdos_331_disproved\n\n7. **Open Variant:** RuzsaVariant with exact asymptotics",
+    "historicalContext": "**Erdős Problem #331: Common Differences in Dense Sets**\n\nThis problem belongs to the tradition of additive combinatorics questions that ask: 'when does density force arithmetic structure?' The general philosophy, articulated by Erdős throughout his career, is that sufficiently dense sets must contain patterns — arithmetic progressions (Szemerédi's theorem), sumsets with large doubling (Freiman-Ruzsa theory), or in this case, common differences.\n\n**The Question (Erdős-Graham, 1980):** Given sets A, B ⊆ ℕ both with counting function growing at least as fast as √N, must there exist infinitely many 'common differences' — values d ≠ 0 such that d = a₁ − a₂ = b₁ − b₂ for some a₁, a₂ ∈ A and b₁, b₂ ∈ B? Equivalently, must the intersection (A − A) ∩ (B − B) be infinite?\n\n**The Heuristic Behind the Conjecture:** If |A| ~ √N, then the difference set A − A should have about |A|² ~ N elements (by the Plünnecke-Ruzsa inequality, |A − A| ≤ K|A| for sets with small doubling, but generically |A − A| ~ |A|²). Similarly |B − B| ~ N. Two sets of density ~N in {−N,...,N} 'should' intersect in ~N elements by a pigeonhole argument. So the conjecture seemed natural.\n\n**Ruzsa's Counterexample:** Imre Ruzsa provided a remarkably elegant disproof using binary representations. Define:\n- A = {n ∈ ℕ : n has nonzero binary digits only in even positions (0, 2, 4, ...)}\n- B = {n ∈ ℕ : n has nonzero binary digits only in odd positions (1, 3, 5, ...)}\n\nBoth sets have density exactly ~c√N (elements are sums of distinct powers of 4, counted in base 4). The key insight: since A uses even bit positions and B uses odd bit positions, every positive integer n has a UNIQUE decomposition n = a + b with a ∈ A, b ∈ B (just split the binary digits into even and odd positions). This unique representation property forces the common difference set to be EMPTY: if a₁ − a₂ = b₁ − b₂, then a₁ + b₂ = a₂ + b₁, which by uniqueness gives a₁ = a₂ and b₁ = b₂.\n\n**The Threshold Phenomenon:** The density √N is sharp. For density > N^α with α > 1/2, common differences are guaranteed by a counting argument. Ruzsa's construction lives exactly at the critical threshold.\n\n**Open Variant:** Ruzsa himself posed a stronger variant: if the density is exactly asymptotic to c√N (not just ≫ √N), must common differences exist? This refined question remains open, as Ruzsa's construction satisfies both the original ≫ condition and the exact asymptotic condition simultaneously.",
+    "problemStatement": "**Problem Statement (DISPROVED)**\n\nLet $A, B \\subseteq \\mathbb{N}$ such that for all sufficiently large $N$:\n$$|A \\cap \\{1,\\ldots,N\\}| \\gg N^{1/2}, \\quad |B \\cap \\{1,\\ldots,N\\}| \\gg N^{1/2}$$\n\n**Question:** Must there exist infinitely many $d \\neq 0$ with $d \\in (A - A) \\cap (B - B)$?\n\n**Answer: NO** (Ruzsa counterexample)\n\n**Construction:**\n- $A$ = numbers with binary digits only in even positions (sums of powers of $4$)\n- $B$ = numbers with binary digits only in odd positions ($= 2A$)\n- Every $n \\ge 1$ has **unique** $n = a + b$ with $a \\in A, b \\in B$\n- Therefore $(A - A) \\cap (B - B) \\setminus \\{0\\} = \\emptyset$\n\n**Threshold:** For density $\\gg N^\\alpha$ with $\\alpha > 1/2$, common differences are guaranteed.\n\n**Status: DISPROVED**",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Density Framework:** countingFunction via Finset.filter/Finset.Icc, HasDensityAtLeast for general density, HasSqrtDensity for the critical α = 1/2, HasExactSqrtDensity via Filter.Tendsto for Ruzsa's variant\n\n2. **Common Differences:** HasCommonDifference as existential over pairs, commonDifferences as set comprehension, HasInfinitelyManyCommonDifferences via Set.Infinite\n\n3. **Conjecture:** ErdosConjecture331 as universal quantification over sets with sqrt density\n\n4. **Ruzsa's Construction:** evenBinaryPositions and oddBinaryPositions defined via modular arithmetic on binary digits (n / 2^(2k+1)) % 2 = 0. Named aliases ruzsaA, ruzsaB\n\n5. **Key Properties Axiomatized:** density of A and B (2 axioms), unique representation (1 axiom), empty common differences (1 axiom)\n\n6. **Genuine Proofs:** ruzsa_counterexample assembles the three properties. erdos_331_disproved proves ¬ErdosConjecture331 by contradiction. erdos_331_ruzsa provides the existential witness\n\n7. **Structural Analysis:** B = 2A, exact growth, sparse differences, larger density threshold\n\n8. **Open Variant:** RuzsaVariant with exact asymptotics, axiomatized as open",
     "keyInsights": [
-      "**Binary Representation:** Separating even/odd bit positions creates orthogonal sets",
-      "**Unique Representation:** Every n = a + b uniquely forces no common differences",
-      "**Critical Threshold:** N^{1/2} is the boundary for this phenomenon",
-      "**Ruzsa's Variant:** With exact asymptotics |A| ~ c·N^{1/2}, the question remains open",
-      "**Sparse Difference Sets:** Both A - A and B - B have density only N^{1/2}"
+      "**Binary Orthogonality Creates Perfect Independence:** Ruzsa's construction splits the binary digit positions of ℕ into two disjoint sets (even and odd). This is a 'direct sum decomposition' of ℕ in base 2: every number is uniquely the sum of an even-position part and an odd-position part. The orthogonality is absolute — not just probabilistic or approximate, but exactly carry-free. This rigidity is what drives the empty common difference set",
+      "**Unique Representation ⟹ No Common Differences:** The logical core of the proof is beautifully simple. If a₁ − a₂ = b₁ − b₂ = d ≠ 0, rearranging gives a₁ + b₂ = a₂ + b₁. Both sides are A + B decompositions of the same number. Uniqueness forces a₁ = a₂ and b₂ = b₁, so d = 0. This is a three-line proof from the unique representation axiom — the essence of why counterexamples to 'density implies structure' conjectures often use algebraic constructions",
+      "**The √N Threshold Is Sharp:** For density > N^α with α > 1/2, common differences are unavoidable because both A − A and B − B have density > 1 in the integers, forcing intersection. At exactly α = 1/2, the difference sets A − A and B − B can each have density only ~√N (Sidon-like), and two sets of density √N in {−N,...,N} can easily be disjoint. The threshold is a phase transition between forced structure and freedom",
+      "**B = 2A: Scaling Preserves Orthogonality:** The relationship B = 2A (multiplying by 2 shifts all binary digits left by one position, converting even to odd positions) reveals that A and B are essentially the same set viewed at different scales. This self-similar structure is characteristic of constructions in additive combinatorics that achieve extremal behavior",
+      "**Ruzsa's Open Variant Remains Subtle:** Even though Ruzsa's own sets have exact √N density, it is unknown whether ALL sets with exact density ~c√N must share common differences. The exact asymptotic condition (convergence of A(N)/√N) imposes regularity that might prevent the extreme sparseness needed to avoid common differences. This is one of the few cases where strengthening 'big-O' to 'asymptotic' might change the answer"
     ]
   },
   "sections": [
     {
-      "id": "erd-s-problem-331-common-diffe",
-      "title": "Erdős Problem #331: Common Differences in Dense Sets",
+      "id": "header",
+      "title": "Header and Imports",
       "startLine": 1,
-      "endLine": 36,
-      "summary": "Erdős Problem #331: Common Differences in Dense Sets"
+      "endLine": 35,
+      "summary": "Problem header documenting the DISPROVED status, Ruzsa's binary counterexample, the unique representation property, and the reference to Erdős-Graham (1980, p. 50). Imports Mathlib for natural numbers, reals, finite sets, binary digits, and filters."
     },
     {
       "id": "counting-functions",
-      "title": "Counting Functions",
+      "title": "Part I: Counting Functions",
       "startLine": 37,
-      "endLine": 56,
-      "summary": "Counting Functions"
+      "endLine": 55,
+      "summary": "Defines countingFunction via Finset.filter over Finset.Icc 1 N. HasDensityAtLeast(A, α) requires |A ∩ {1,...,N}| ≥ c·N^α for large N. HasSqrtDensity specializes to α = 1/2. HasExactSqrtDensity requires the counting function divided by √N to converge to c via Filter.Tendsto."
     },
     {
       "id": "common-differences",
-      "title": "Common Differences",
+      "title": "Part II: Common Differences",
       "startLine": 57,
-      "endLine": 73,
-      "summary": "Common Differences"
+      "endLine": 72,
+      "summary": "Defines HasCommonDifference(A, B, d) requiring d ≠ 0 with d ∈ (A−A) ∩ (B−B). The set commonDifferences(A, B) collects all such d. HasInfinitelyManyCommonDifferences requires Set.Infinite on this set."
     },
     {
-      "id": "the-original-conjecture",
-      "title": "The Original Conjecture",
+      "id": "conjecture",
+      "title": "Part III: The Original Conjecture",
       "startLine": 74,
-      "endLine": 84,
-      "summary": "The Original Conjecture"
+      "endLine": 83,
+      "summary": "Formalizes ErdosConjecture331: for all A, B with sqrt density, there are infinitely many common differences. This universal statement is what Ruzsa disproves with his binary construction."
     },
     {
-      "id": "ruzsa-s-counterexample",
-      "title": "Ruzsa's Counterexample",
+      "id": "ruzsa-construction",
+      "title": "Part IV: Ruzsa's Counterexample",
       "startLine": 85,
-      "endLine": 115,
-      "summary": "Ruzsa's Counterexample"
+      "endLine": 114,
+      "summary": "Defines evenBinaryPositions (digits only in positions 0, 2, 4, ...) and oddBinaryPositions (digits only in positions 1, 3, 5, ...) via modular arithmetic. Names ruzsaA and ruzsaB as aliases. Axiomatizes sqrt density for both sets and the unique representation property: every n ≥ 1 has unique decomposition n = a + b."
     },
     {
-      "id": "the-disproof",
-      "title": "The Disproof",
+      "id": "disproof",
+      "title": "Part V: The Disproof",
       "startLine": 116,
-      "endLine": 142,
-      "summary": "The Disproof"
+      "endLine": 141,
+      "summary": "Axiomatizes ruzsa_no_common_differences: CD(A,B) = ∅. GENUINELY PROVES ruzsa_counterexample by assembling density + emptiness + Set.not_infinite_empty. GENUINELY PROVES erdos_331_disproved by contradiction: instantiating the universal conjecture with Ruzsa's sets yields a contradiction."
     },
     {
-      "id": "understanding-the-counterexamp",
-      "title": "Understanding the Counterexample",
+      "id": "understanding",
+      "title": "Part VI: Understanding the Counterexample",
       "startLine": 143,
-      "endLine": 162,
-      "summary": "Understanding the Counterexample"
+      "endLine": 161,
+      "summary": "Structural analysis: ruzsaA_characterization shows A = {sums of powers of 4}. Axiomatizes B = 2A (odd positions = doubled even positions). Axiomatizes exact growth ~c√N for both sets, confirming the construction sits precisely at the density threshold."
     },
     {
-      "id": "ruzsa-s-stronger-variant",
-      "title": "Ruzsa's Stronger Variant",
+      "id": "variant",
+      "title": "Part VII: Ruzsa's Stronger Variant",
       "startLine": 163,
-      "endLine": 179,
-      "summary": "Ruzsa's Stronger Variant"
+      "endLine": 178,
+      "summary": "Defines RuzsaVariant: with exact asymptotic density |A(N)| ~ c·√N (convergence, not just lower bound), must common differences exist? Axiomatized as OPEN. The distinction between ≫ √N and ~ c√N is subtle but may change the answer."
     },
     {
-      "id": "the-difference-set",
-      "title": "The Difference Set",
+      "id": "difference-set",
+      "title": "Part VIII: The Difference Set",
       "startLine": 180,
-      "endLine": 199,
-      "summary": "The Difference Set"
+      "endLine": 198,
+      "summary": "Defines differenceSet A − A = {a − a' : a, a' ∈ A}. Axiomatizes sparseness: |{d ∈ A−A : |d| ≤ N}| ≤ c√N for Ruzsa's A. This extreme sparseness (generic sets have |A−A| ~ N) is why (A−A) ∩ (B−B) can be empty."
     },
     {
-      "id": "comparison-with-larger-densiti",
-      "title": "Comparison with Larger Densities",
+      "id": "larger-density",
+      "title": "Part IX: Comparison with Larger Densities",
       "startLine": 200,
-      "endLine": 214,
-      "summary": "Comparison with Larger Densities"
+      "endLine": 213,
+      "summary": "Axiomatizes larger_density_common_differences: for α > 1/2, density N^α forces infinite common differences. This establishes √N as a sharp threshold — the counterexample exists precisely at the critical exponent."
     },
     {
       "id": "summary",
-      "title": "Summary",
+      "title": "Part X: Summary",
       "startLine": 215,
       "endLine": 245,
-      "summary": "Summary"
+      "summary": "Three genuinely proved theorems: erdos_331 = ¬ErdosConjecture331, erdos_331_main (alias), and erdos_331_ruzsa (existential witness ∃ A, B with sqrt density and no infinite common differences). Clean proof chain from axioms through counterexample to disproof. File has 0 sorries and 8 axioms."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #331 asked whether sets A, B ⊆ ℕ with density ≫ N^{1/2} must have infinitely many common differences. Ruzsa provided a counterexample using binary representations: A has nonzero digits only in even positions, B in odd positions. The answer is NO.",
-    "implications": "**Connections**\n\n1. **Additive Combinatorics:** Shows density alone doesn't guarantee common structure\n\n2. **Binary Representations:** Orthogonal digit positions create independent sets\n\n3. **Threshold Phenomena:** Critical density N^{1/2} separates behaviors\n\n4. **Unique Representation:** The key is unique sums, not just density",
+    "summary": "Erdős Problem #331 asked whether sets A, B ⊆ ℕ with density ≫ √N must share infinitely many common differences d = a₁ − a₂ = b₁ − b₂ ≠ 0. Ruzsa disproved this with an elegant construction using binary digit separation: A uses even bit positions, B uses odd bit positions, giving every positive integer a unique A + B decomposition that forces the common difference set to be empty. The formalization captures this in 245 lines of Lean 4 with 0 sorries and 8 axioms. Three theorems are genuinely proved: the counterexample assembly, the disproof by contradiction, and the existential witness. The threshold √N is sharp: larger density guarantees common differences.",
+    "implications": "**Connections Across Additive Combinatorics**\n\n1. **Density Does Not Always Force Structure:** This disproof is a cautionary example in the 'density implies structure' paradigm. While Szemerédi's theorem (density forces arithmetic progressions) and the Green-Tao theorem (primes contain arithmetic progressions) show that density often forces patterns, Problem #331 shows the paradigm has sharp limits — the exact density threshold matters\n\n2. **Sidon Sets and Small Doubling:** Ruzsa's sets A and B are Sidon-like: they have |A − A| ~ |A| (linear growth of the difference set), compared to the generic |A − A| ~ |A|² (quadratic). This connection to Sidon set theory (sets where all pairwise sums are distinct) reveals that extremal additive combinatorics constructions often share structural features\n\n3. **Direct Sum Decompositions:** The unique representation ℕ = A + B (every number = unique a + b) is a perfect direct sum decomposition of the natural numbers. Such decompositions are rare and structurally rigid. They connect to the theory of perfect difference sets and tiling problems in additive number theory\n\n4. **Binary and p-adic Structure:** Using binary digit positions to construct extremal sets is a powerful technique in additive combinatorics. Similar constructions appear in Ruzsa's other work on sumset problems, in Behrend's construction of progression-free sets, and in the theory of automatic sequences\n\n5. **Phase Transitions at Critical Exponents:** The sharp transition at density exponent 1/2 — below which counterexamples exist, above which structure is forced — is an instance of a phase transition phenomenon that appears throughout combinatorics, from random graph theory (Erdős-Rényi thresholds) to percolation to Ramsey theory",
     "openQuestions": [
-      "Does the stronger condition |A| ~ c·N^{1/2} (exact asymptotic) force common differences?",
-      "What is the minimum density that guarantees infinitely many common differences?",
-      "Are there other constructions with different properties?",
-      "What happens for three or more sets?"
+      "Does the stronger condition |A ∩ {1,...,N}| ~ c·N^{1/2} (exact asymptotic, not just lower bound) force infinitely many common differences? This is Ruzsa's open variant.",
+      "What is the exact minimum density exponent α* such that density ≫ N^{α*} guarantees infinitely many common differences? Is it exactly 1/2, or is there a gap between the counterexample and the positive result?",
+      "Can the counterexample be extended to three or more sets? For A, B, C with sqrt density, must there be d ≠ 0 in (A−A) ∩ (B−B) ∩ (C−C)?",
+      "Is there a quantitative version: for sets with density ~N^α (α > 1/2), how many common differences are there up to N? What is the growth rate of |(A−A) ∩ (B−B) ∩ {1,...,N}|?",
+      "Do analogues of Ruzsa's construction exist for other algebraic structures (e.g., ℤ_p, ℤ/nℤ, or function fields)?"
     ]
   }
 }

--- a/src/data/proofs/erdos-338/annotations.json
+++ b/src/data/proofs/erdos-338/annotations.json
@@ -1,200 +1,110 @@
 [
   {
-    "id": "ann-338-001",
+    "id": "ann-338-basis-defs",
     "proofId": "erdos-338",
-    "range": { "startLine": 52, "endLine": 54 },
+    "range": { "startLine": 47, "endLine": 92 },
     "type": "definition",
-    "title": "Additive Basis of Order h",
-    "content": "A set A ⊆ ℕ is an additive basis of order h if every sufficiently large integer n can be expressed as a sum of at most h elements from A (with repetition allowed). The representation uses Multiset to allow repeated summands. This is the standard definition of Schnirelmann-Erdős.",
-    "significance": "critical"
+    "title": "Basis and Restricted Order Definitions",
+    "content": "The core definitions formalize the distinction between order and restricted order. IsBasisOfOrder(A, h) uses Multiset (allowing repetition): every large n = x₁ + x₂ + ... + xₖ with xᵢ ∈ A and k ≤ h. IsExactOrder requires h to be tight: A is a basis of order h but NOT h−1. HasRestrictedOrder(A, t) uses Finset (requiring distinctness): every large n = s₁ + s₂ + ... + sₖ with distinct sᵢ ∈ A and k ≤ t. The key mathematical distinction: Multiset ℕ allows {2, 2, 3} while Finset ℕ requires {2, 3, 5}. HasFiniteRestrictedOrder is the existential ∃ t, HasRestrictedOrder A t, and minimalRestrictedOrder computes the least such t via Nat.find.",
+    "mathContext": "**Order $h$**: $\\forall n \\ge N,\\; \\exists x_1, \\ldots, x_k \\in A$ (with repetition) : $k \\le h$ and $\\sum x_i = n$.\n\n**Restricted order $t$**: $\\forall n \\ge N,\\; \\exists \\{s_1, \\ldots, s_k\\} \\subseteq A$ (**distinct**) : $k \\le t$ and $\\sum s_i = n$.\n\nThe distinction: `Multiset` (order) vs `Finset` (restricted). Not all bases have finite restricted order.",
+    "significance": "critical",
+    "relatedConcepts": ["additive basis", "Schnirelmann density", "Multiset vs Finset", "Waring's problem", "Nat.find"],
+    "prerequisites": ["Multiset", "Finset", "Finset.sum", "Set ℕ"]
   },
   {
-    "id": "ann-338-002",
+    "id": "ann-338-bateman",
     "proofId": "erdos-338",
-    "range": { "startLine": 60, "endLine": 61 },
-    "type": "definition",
-    "title": "Exact Order of a Basis",
-    "content": "The exact order h is achieved when the basis is of order h but NOT of order h-1. This captures the minimal number of summands needed - h is tight, not just an upper bound.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-338-003",
-    "proofId": "erdos-338",
-    "range": { "startLine": 67, "endLine": 68 },
-    "type": "definition",
-    "title": "Restricted Representation",
-    "content": "A restricted representation uses a Finset instead of Multiset - each element can only appear once. The sum uses Finset.sum id since elements are distinct natural numbers. This is the key constraint that distinguishes restricted order from regular order.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-338-004",
-    "proofId": "erdos-338",
-    "range": { "startLine": 75, "endLine": 77 },
-    "type": "definition",
-    "title": "Restricted Order",
-    "content": "The restricted order t requires every sufficiently large integer to be representable as a sum of at most t DISTINCT elements. The key difference from regular order is using Finset (distinct elements) instead of Multiset (allows repetition). Not all bases have finite restricted order.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-338-005",
-    "proofId": "erdos-338",
-    "range": { "startLine": 83, "endLine": 84 },
-    "type": "definition",
-    "title": "Has Finite Restricted Order",
-    "content": "A basis has finite restricted order if there exists SOME finite t that works. This is an existence predicate - not all bases have this property. Bateman showed bases of order h ≥ 3 can fail to have finite restricted order.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-338-006",
-    "proofId": "erdos-338",
-    "range": { "startLine": 103, "endLine": 104 },
-    "type": "definition",
-    "title": "Bateman's Example Set",
-    "content": "The set A = {1} ∪ {x > 0 : h | x} consists of 1 and all positive multiples of h. For h = 3, this is {1, 3, 6, 9, 12, ...}. It forms a basis of order h but has no finite restricted order.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-338-007",
-    "proofId": "erdos-338",
-    "range": { "startLine": 115, "endLine": 117 },
+    "range": { "startLine": 98, "endLine": 117 },
     "type": "theorem",
-    "title": "Bateman's Observation",
-    "content": "The theorem combines both properties of Bateman's set: it IS a basis of order h, but it has NO finite restricted order. This shows that finite restricted order is not automatic for bases of order h ≥ 3.",
-    "significance": "critical"
+    "title": "Bateman's Observation: Order ≥ 3 Doesn't Imply Restricted Order",
+    "content": "Bateman's example A = {1} ∪ {x > 0 : h | x} is a basis of order h (represent n using h−r copies of h and r copies of 1, where n ≡ r mod h) but has NO finite restricted order for h ≥ 3. The reason: the only elements are 1 and multiples of h. A restricted representation of n must use distinct elements, so at most one copy of 1 and distinct multiples h, 2h, 3h, .... The sum of the first t multiples of h is h·t(t+1)/2, which grows as t², but we need sums up to n with only t summands, requiring t ~ √(2n/h). Since t grows unboundedly, no fixed t works. The theorem bateman_observation is genuinely proved by pairing the two axioms.",
+    "mathContext": "$$A = \\{1\\} \\cup \\{x > 0 : h \\mid x\\} = \\{1, h, 2h, 3h, \\ldots\\}$$\n**Basis of order $h$**: $n = qh + r$ where $0 \\le r < h$, so $n = r \\cdot 1 + q \\cdot h$ using $r + q \\le h$ summands (with repetition of $1$).\n\n**No restricted order**: The distinct multiples $h, 2h, \\ldots, th$ sum to $h \\cdot t(t+1)/2$. To represent $n$ using distinct elements, we need $t \\gtrsim \\sqrt{2n/h} \\to \\infty$.",
+    "significance": "critical",
+    "relatedConcepts": ["multiples of h", "quadratic growth", "division algorithm", "distinct summands"],
+    "prerequisites": ["IsBasisOfOrder", "HasFiniteRestrictedOrder", "batemanSet"]
   },
   {
-    "id": "ann-338-008",
+    "id": "ann-338-kelly",
     "proofId": "erdos-338",
-    "range": { "startLine": 127, "endLine": 128 },
-    "type": "concept",
-    "title": "Kelly's Theorem (1957)",
-    "content": "Kelly proved that EVERY basis of order 2 has restricted order at most 4. This is the best known upper bound for order-2 bases. Kelly conjectured the bound should be 3, but this was later disproved by Hennecart.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-338-009",
-    "proofId": "erdos-338",
-    "range": { "startLine": 134, "endLine": 135 },
-    "type": "definition",
-    "title": "Kelly's Conjecture",
-    "content": "Kelly conjectured that every order-2 basis has restricted order at most 3 (not just 4). This was formulated as: for all A, if IsBasisOfOrder A 2 then HasRestrictedOrder A 3. The conjecture stood for nearly 50 years before being disproved.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-338-010",
-    "proofId": "erdos-338",
-    "range": { "startLine": 163, "endLine": 167 },
+    "range": { "startLine": 122, "endLine": 144 },
     "type": "theorem",
-    "title": "Hennecart Disproves Kelly",
-    "content": "The proof shows Kelly's conjecture is false by contradiction: if the conjecture held, Hennecart's basis (which is order 2) would have restricted order ≤ 3, but it has restricted order exactly 4. This is a classic counterexample proof.",
-    "significance": "critical"
+    "title": "Kelly's Theorem and Conjecture (1957)",
+    "content": "Kelly proved the remarkable result that EVERY basis of order 2 has restricted order at most 4. The proof uses a clever pigeonhole argument: if A is a basis of order 2, then for large n, n = a + b with a, b ∈ A. Among the many representations (a, b), one can find 4 distinct elements that sum to n (possibly via combining two different representations). Kelly conjectured the bound should be 3, not 4 — this conjecture stood for nearly 50 years before Hennecart disproved it in 2005. The theorem kelly_conjecture_false has a sorry because the proof requires the Hennecart construction; the genuine proof is given later as hennecart_disproves_kelly.",
+    "mathContext": "**Kelly's Theorem**: If $A$ is a basis of order $2$, then $A$ has restricted order $\\le 4$.\n\n**Kelly's Conjecture** (FALSE): If $A$ is a basis of order $2$, then $A$ has restricted order $\\le 3$.\n\nKelly's conjecture reduces the bound by 1. The gap: some order-2 bases require restricted order exactly 4 (not 3).",
+    "significance": "critical",
+    "relatedConcepts": ["order-2 bases", "pigeonhole argument", "Kelly's conjecture", "50-year conjecture"],
+    "prerequisites": ["IsBasisOfOrder", "HasRestrictedOrder", "kellyConjecture"]
   },
   {
-    "id": "ann-338-011",
+    "id": "ann-338-hennecart",
     "proofId": "erdos-338",
-    "range": { "startLine": 173, "endLine": 174 },
-    "type": "definition",
-    "title": "Perfect Squares Set",
-    "content": "The set of perfect squares {0, 1, 4, 9, 16, 25, ...} where each n = k² for some k. By Lagrange's four-squares theorem, this set has order 4 (every positive integer is a sum of 4 squares). Pall showed the restricted order is 5.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-338-012",
-    "proofId": "erdos-338",
-    "range": { "startLine": 176, "endLine": 177 },
-    "type": "definition",
-    "title": "Triangular Numbers Set",
-    "content": "The triangular numbers T_k = k(k+1)/2 are {0, 1, 3, 6, 10, 15, 21, ...}. Gauss's 'Eureka' theorem shows these have order 3. Schinzel proved the restricted order is also 3 - one of the rare cases where order equals restricted order.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-338-013",
-    "proofId": "erdos-338",
-    "range": { "startLine": 205, "endLine": 207 },
+    "range": { "startLine": 150, "endLine": 167 },
     "type": "theorem",
-    "title": "Triangular Numbers: Equal Orders",
-    "content": "Triangular numbers provide an example where order = restricted order = 3. This is significant because it shows the gap between order and restricted order can be zero for some natural sets.",
-    "significance": "key"
+    "title": "Hennecart's Counterexample (2005)",
+    "content": "Hennecart constructed an explicit basis of order 2 with restricted order EXACTLY 4 — not 3. The construction (axiomatized as hennecart_basis) uses a carefully designed set where order-2 representations exist but no large enough integer can be written as a sum of 3 distinct elements. The disproof hennecart_disproves_kelly is genuinely proved in Lean: it assumes kellyConjecture, applies it to hennecart_basis (which is order 2 by axiom) to get restricted order ≤ 3, but hennecart_restricted_order_four.2 asserts ¬HasRestrictedOrder hennecart_basis 3. Contradiction.",
+    "mathContext": "**Hennecart (2005)**: $\\exists A$ basis of order $2$ with restricted order exactly $4$:\n$$\\text{HasRestrictedOrder}(A, 4) \\land \\neg\\text{HasRestrictedOrder}(A, 3)$$\nThis disproves Kelly's conjecture that restricted order $\\le 3$ suffices. The Lean proof: assume Kelly's conjecture → apply to Hennecart's basis → get restricted order $\\le 3$ → contradiction with $\\neg\\text{HasRestrictedOrder}(A, 3)$.",
+    "significance": "critical",
+    "relatedConcepts": ["counterexample", "proof by contradiction", "Kelly's conjecture disproved"],
+    "prerequisites": ["kellyConjecture", "hennecart_basis axiom", "IsBasisOfOrder"]
   },
   {
-    "id": "ann-338-014",
+    "id": "ann-338-squares",
     "proofId": "erdos-338",
-    "range": { "startLine": 210, "endLine": 213 },
+    "range": { "startLine": 173, "endLine": 213 },
     "type": "theorem",
-    "title": "Squares: Different Orders",
-    "content": "Squares have order 4 (Lagrange) but restricted order 5 (Pall). The gap of 1 shows that even for classical sets, order and restricted order can differ. The distinction is that without repetition, one more term may be needed.",
-    "significance": "key"
+    "title": "Classical Examples: Squares and Triangular Numbers",
+    "content": "Two classical number-theoretic sets illustrate the order/restricted order gap. SQUARES: By Lagrange's four-squares theorem (1770), every positive integer is a sum of 4 squares, giving order 4. Pall (1933) showed restricted order is 5 — some integers require 5 distinct squares. The gap of 1 arises because without repetition, representations like 4 = 2² need to use other squares. TRIANGULAR NUMBERS: Gauss's 'Eureka' theorem (1796) shows order 3. Schinzel (1954) proved restricted order is also 3, making triangular numbers a rare case where order = restricted order. The theorems triangular_orders_equal and squares_orders_differ are both genuinely proved by pairing axioms.",
+    "mathContext": "**Squares** $\\{k^2 : k \\ge 0\\}$: order $= 4$ (Lagrange), restricted order $= 5$ (Pall). Gap $= 1$.\n\n**Triangular** $\\{k(k+1)/2 : k \\ge 0\\}$: order $= 3$ (Gauss), restricted order $= 3$ (Schinzel). Gap $= 0$.\n\nThe squares example: $n = a^2 + b^2 + c^2 + d^2$ allows $a = b$, but distinct-squares representation may need $5$ terms.",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange four-squares theorem", "Gauss Eureka theorem", "Pall's theorem", "Schinzel's theorem"],
+    "prerequisites": ["squares", "triangular", "IsBasisOfOrder", "HasRestrictedOrder"]
   },
   {
-    "id": "ann-338-015",
+    "id": "ann-338-hhp",
     "proofId": "erdos-338",
-    "range": { "startLine": 223, "endLine": 225 },
-    "type": "concept",
-    "title": "HHP Exponential Lower Bound",
-    "content": "Hegyvári, Hennecart, and Plagne (2007) showed that for order k ≥ 2, there exist bases with restricted order at least 2^{k-2} + k - 1. This is EXPONENTIAL in k, showing the gap can grow very large.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-338-016",
-    "proofId": "erdos-338",
-    "range": { "startLine": 228, "endLine": 236 },
+    "range": { "startLine": 219, "endLine": 236 },
     "type": "theorem",
-    "title": "Exponential Gap Theorem",
-    "content": "This theorem reformulates the HHP bound: for any restricted order t that works for the constructed basis, we must have t ≥ 2^{k-2} + k - 1. The proof uses contraposition: if t were smaller, the HHP axiom would give a contradiction.",
-    "significance": "key"
+    "title": "HHP Exponential Lower Bound (2007)",
+    "content": "Hegyvári, Hennecart, and Plagne proved the most striking result: for order k ≥ 2, there exist bases whose restricted order is at least 2^{k−2} + k − 1, which is EXPONENTIAL in k. For k = 2: bound = 1 + 1 = 2 (trivial). For k = 3: bound = 2 + 2 = 4. For k = 4: bound = 4 + 3 = 7. For k = 10: bound = 256 + 9 = 265. The theorem exponential_gap is genuinely proved from the axiom hhp_lower_bound: it obtains the basis A, then proves ∀ t, HasRestrictedOrder A t → t ≥ 2^{k−2} + k − 1 by contraposition using push_neg.",
+    "mathContext": "**HHP (2007)**: For $k \\ge 2$, $\\exists A$ basis of order $k$ with restricted order $\\ge 2^{k-2} + k - 1$.\n\nThe **exponential gap**: order $k$ vs restricted order $\\ge 2^{k-2} + k - 1$. Values:\n| $k$ | order | min restricted order |\n|-----|-------|---------------------|\n| 2 | 2 | 2 |\n| 3 | 3 | 4 |\n| 4 | 4 | 7 |\n| 5 | 5 | 12 |\n| 10 | 10 | 265 |",
+    "significance": "critical",
+    "relatedConcepts": ["exponential growth", "order-restricted order gap", "push_neg tactic", "contraposition"],
+    "prerequisites": ["hhp_lower_bound axiom", "IsBasisOfOrder", "HasRestrictedOrder"]
   },
   {
-    "id": "ann-338-017",
+    "id": "ann-338-open-questions",
     "proofId": "erdos-338",
-    "range": { "startLine": 246, "endLine": 247 },
+    "range": { "startLine": 242, "endLine": 274 },
     "type": "definition",
-    "title": "Open Question 1: Existence Conditions",
-    "content": "The first open question asks for a characterization P such that HasFiniteRestrictedOrder A ↔ P A. What property of a basis guarantees (or prevents) the existence of a finite restricted order?",
-    "significance": "supporting"
+    "title": "The Four Main Open Questions",
+    "content": "The four open questions formalized as Prop definitions capture the complete landscape of Problem #338. OpenQuestion1: characterize when restricted order exists (∃ predicate P with HasFiniteRestrictedOrder A ↔ P A). OpenQuestion2: bound restricted order by a function of order (∃ f with restricted order ≤ f(order)). OpenQuestion3: characterize when order = restricted order (∃ P with IsBasisOfOrder A h ∧ HasRestrictedOrder A h ↔ IsBasisOfOrder A h ∧ P A). OpenQuestion4: robustness — if removing any finite set preserves the basis, must restricted order exist? IsRobustBasis formalizes this as ∀ F : Finset ℕ, IsBasisOfOrder (A \\ ↑F) h.",
+    "mathContext": "**Q1**: $\\exists P : \\text{HasFiniteRestrictedOrder}(A) \\iff P(A)$\n\n**Q2**: $\\exists f : \\text{restricted\\_order}(A) \\le f(\\text{order}(A))$ (the HHP bound shows $f(k) \\ge 2^{k-2} + k - 1$)\n\n**Q3**: $\\exists P : (\\text{order} = \\text{restricted\\_order}) \\iff P(A)$\n\n**Q4**: $(\\forall F \\text{ finite},\\; A \\setminus F \\text{ is basis}) \\implies \\text{HasFiniteRestrictedOrder}(A)$?",
+    "significance": "key",
+    "relatedConcepts": ["characterization problem", "robustness", "function bounding", "predicate existence"],
+    "prerequisites": ["HasFiniteRestrictedOrder", "IsBasisOfOrder", "IsRobustBasis"]
   },
   {
-    "id": "ann-338-018",
+    "id": "ann-338-properties",
     "proofId": "erdos-338",
-    "range": { "startLine": 253, "endLine": 256 },
-    "type": "definition",
-    "title": "Open Question 2: Bounding",
-    "content": "Can we bound restricted order in terms of order? This asks for a function f such that restricted order ≤ f(order) whenever restricted order exists. The HHP bound shows if f exists, it must grow at least exponentially.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-338-019",
-    "proofId": "erdos-338",
-    "range": { "startLine": 270, "endLine": 271 },
-    "type": "definition",
-    "title": "Robust Basis",
-    "content": "A basis A is 'robust' of order h if A \\ F remains a basis of order h for ALL finite sets F. This removes any finite set of elements and the remainder is still a basis of the same order. The open question asks if robustness implies finite restricted order.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-338-020",
-    "proofId": "erdos-338",
-    "range": { "startLine": 284, "endLine": 297 },
+    "range": { "startLine": 280, "endLine": 318 },
     "type": "theorem",
-    "title": "Restricted Implies Regular",
-    "content": "If A has restricted order t, then A has (regular) order t. The proof converts the Finset representation to a Multiset by taking s.val. Since distinct sums are a special case of sums with repetition, restricted order bounds regular order from above.",
-    "significance": "key"
+    "title": "Basic Properties of Restricted Order",
+    "content": "Three structural properties are formalized. restricted_implies_regular (genuinely proved): if A has restricted order t, it has regular order t — convert the Finset to Multiset via s.val. This shows every restricted representation is also a regular representation. order_le_restricted_order (sorry): if A has exact order h and restricted order t, then h ≤ t. Intuitively, restricted representations are harder (no repetition), so more summands may be needed. restricted_order_monotone (genuinely proved): HasRestrictedOrder A t implies HasRestrictedOrder A (t+1) via Nat.le_succ_of_le on the cardinality bound. This shows the restricted order predicate is upward closed.",
+    "mathContext": "**Restricted ⟹ Regular**: $\\text{HasRestrictedOrder}(A, t) \\implies \\text{IsBasisOfOrder}(A, t)$. Proof: `Finset` $\\subseteq$ `Multiset` (convert via `.val`).\n\n**Order $\\le$ Restricted**: $\\text{IsExactOrder}(A, h) \\land \\text{HasRestrictedOrder}(A, t) \\implies h \\le t$. (Sorry)\n\n**Monotonicity**: $\\text{HasRestrictedOrder}(A, t) \\implies \\text{HasRestrictedOrder}(A, t+1)$. Proof: $|s| \\le t \\implies |s| \\le t+1$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.val", "Multiset conversion", "monotonicity", "Nat.le_succ_of_le"],
+    "prerequisites": ["HasRestrictedOrder", "IsBasisOfOrder", "IsExactOrder", "Finset.val"]
   },
   {
-    "id": "ann-338-021",
+    "id": "ann-338-summary",
     "proofId": "erdos-338",
-    "range": { "startLine": 312, "endLine": 318 },
-    "type": "theorem",
-    "title": "Monotonicity of Restricted Order",
-    "content": "If HasRestrictedOrder A t holds, then HasRestrictedOrder A (t+1) also holds. The proof uses the same representation s but notes s.card ≤ t implies s.card ≤ t+1. This shows restricted order is upward closed.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-338-022",
-    "proofId": "erdos-338",
-    "range": { "startLine": 349, "endLine": 359 },
+    "range": { "startLine": 349, "endLine": 361 },
     "type": "theorem",
     "title": "Summary Theorem",
-    "content": "The summary combines four key results: (1) Kelly's theorem holds, (2) Kelly's conjecture is false, (3) squares have order 4 and restricted order 5, (4) triangular numbers have both orders equal to 3. This provides a snapshot of the known landscape.",
-    "significance": "critical"
+    "content": "The summary theorem erdos_338_summary is genuinely proved, assembling four key results: (1) Kelly's theorem (∀ order-2 basis, restricted order ≤ 4), (2) Kelly's conjecture is false (¬kellyConjecture via hennecart_disproves_kelly), (3) squares have order 4 and restricted order 5, (4) triangular numbers have both orders equal to 3. The proof uses refine to split the conjunction, then dispatches each goal with the appropriate axiom combination. Final tally: 2 sorries (kelly_conjecture_false has a sorry but is superseded by hennecart_disproves_kelly which is fully proved; order_le_restricted_order has a sorry), 11 axioms, and 7 genuinely proved theorems.",
+    "mathContext": "**Proved**: Kelly's theorem $\\land$ $\\neg$Kelly's conjecture $\\land$ squares$(4, 5)$ $\\land$ triangulars$(3, 3)$.\n\nThe file status: $2$ sorries, $11$ axioms, $7$ genuinely proved theorems (bateman_observation, hennecart_disproves_kelly, triangular_orders_equal, squares_orders_differ, exponential_gap, restricted_implies_regular, restricted_order_monotone, erdos_338_summary).",
+    "significance": "critical",
+    "relatedConcepts": ["summary theorem", "OPEN problem", "proof inventory", "refine tactic"],
+    "prerequisites": ["kelly_theorem", "hennecart_disproves_kelly", "squares axioms", "triangular axioms"]
   }
 ]

--- a/src/data/proofs/erdos-338/meta.json
+++ b/src/data/proofs/erdos-338/meta.json
@@ -20,93 +20,134 @@
     "sorries": 2,
     "erdosNumber": 338,
     "erdosUrl": "https://erdosproblems.com/338",
-    "erdosProblemStatus": "open"
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-01-22",
+    "mathlib_version": "4.15.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Multiset.Basic",
+        "description": "Multiset type for representations with repetition",
+        "module": "Mathlib.Data.Multiset.Basic"
+      },
+      {
+        "theorem": "Finset.Basic",
+        "description": "Finite sets for distinct-element representations",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.Card",
+        "description": "Cardinality of finite sets, used for summand count bounds",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Nat.find",
+        "description": "Finding least natural number satisfying a predicate (minimalRestrictedOrder)",
+        "module": "Mathlib.Data.Nat.Find"
+      }
+    ],
+    "originalContributions": [
+      "IsBasisOfOrder definition using Multiset for representations with repetition",
+      "IsExactOrder definition requiring minimality (basis of order h but not h−1)",
+      "HasRestrictedOrder definition using Finset for distinct-element representations",
+      "HasFiniteRestrictedOrder existential and minimalRestrictedOrder via Nat.find",
+      "batemanSet construction: {1} ∪ {x > 0 : h | x} with genuinely proved bateman_observation",
+      "Kelly's theorem and conjecture axiomatization with kelly_conjecture_false placeholder",
+      "hennecart_basis axioms and genuinely proved hennecart_disproves_kelly by contradiction",
+      "Squares and triangular number axioms with genuinely proved order comparison theorems",
+      "HHP exponential lower bound axiom with genuinely proved exponential_gap via push_neg",
+      "Four open questions formalized as Prop definitions (OpenQuestion1-4)",
+      "IsRobustBasis definition for the robustness question (Q4)",
+      "restricted_implies_regular genuinely proved via Finset.val conversion to Multiset",
+      "restricted_order_monotone genuinely proved via Nat.le_succ_of_le",
+      "erdos_338_summary assembling four key results in a single conjunction"
+    ]
   },
   "overview": {
-    "historicalContext": "The study of additive bases is a central topic in additive number theory. The order of a basis is the minimum number of summands needed to represent all sufficiently large integers. The restricted order is similar but requires DISTINCT summands. This problem, posed by Erdős, explores the relationship between these two concepts. Kelly (1957) initiated the study by proving that order-2 bases have restricted order at most 4 and conjectured the bound is 3. Hennecart (2005) disproved Kelly's conjecture by constructing an order-2 basis with restricted order exactly 4. Hegyvári, Hennecart, and Plagne (2007) showed the gap between order and restricted order can grow exponentially.",
-    "problemStatement": "The restricted order of a basis is the least integer t (if it exists) such that every sufficiently large integer is the sum of at most t distinct summands from A. The problem asks: (1) What are necessary and sufficient conditions for restricted order to exist? (2) Can restricted order be bounded in terms of order? (3) When does restricted order equal order? (4) If A \\ F is a basis for all finite F, must A have restricted order?",
-    "proofStrategy": "The formalization defines additive basis of order h (using multisets for representations with repetition) and restricted order (using finite sets for distinct summands). Key results are axiomatized: Bateman's observation (order ≥ 3 doesn't guarantee finite restricted order), Kelly's theorem (order 2 implies restricted order ≤ 4), Hennecart's counterexample, and the HHP exponential lower bound. Classical examples include squares (order 4, restricted 5) and triangular numbers (order = restricted = 3). Basic properties like monotonicity and the implication from restricted to regular order are proved.",
+    "historicalContext": "**Erdős Problem #338: Restricted Order of Additive Bases**\n\nThe concept of an additive basis goes back to Waring's problem (1770): Waring conjectured that for each $k$, every positive integer is a sum of a fixed number of $k$-th powers. Hilbert proved this in 1909, establishing that the set of $k$-th powers is a basis of finite order $g(k)$. The order of a basis $A$ is the minimum $h$ such that every sufficiently large integer can be written as $x_1 + x_2 + \\cdots + x_k$ with $x_i \\in A$ and $k \\le h$, allowing repetitions.\n\nThe **restricted order** adds a crucial constraint: the summands must be **distinct**. This seemingly small change — replacing Multiset representations with Finset representations — has profound consequences. Bateman observed that for $h \\ge 3$, the set $A = \\{1\\} \\cup \\{x > 0 : h \\mid x\\}$ is a basis of order $h$ but has no finite restricted order at all, because distinct multiples of $h$ grow quadratically: the sum of the first $t$ multiples is $h \\cdot t(t+1)/2$, requiring $t \\gtrsim \\sqrt{2n/h} \\to \\infty$.\n\n**Kelly (1957)** initiated the systematic study by proving the remarkable result that every basis of order 2 has restricted order at most 4 — a pigeonhole argument exploiting the richness of order-2 representations. Kelly conjectured the sharp bound should be 3. This conjecture stood for nearly 50 years before **Hennecart (2005)** constructed an explicit order-2 basis with restricted order exactly 4, disproving Kelly.\n\nThe most striking result came from **Hegyvári, Hennecart, and Plagne (HHP, 2007)**: for order $k \\ge 2$, there exist bases whose restricted order is at least $2^{k-2} + k - 1$. This exponential lower bound shows the gap between order and restricted order can be enormous — for order 10, the restricted order can be at least 265.\n\nTwo classical examples illuminate the landscape: **squares** have order 4 (Lagrange's four-squares theorem, 1770) but restricted order 5 (Pall, 1933) — the gap of 1 arises because representations like $4 = 2^2$ need repetition. **Triangular numbers** are the rare case where order equals restricted order: both are 3, by Gauss's Eureka theorem (1796) and Schinzel (1954). The problem remains **OPEN**: all four of Erdős's questions about characterizing when restricted order exists, bounding it, determining when it equals order, and whether robustness implies restricted order, are unsolved.",
+    "problemStatement": "Let $A \\subseteq \\mathbb{N}$ be an additive basis of order $h$: every sufficiently large $n$ can be written as $n = x_1 + \\cdots + x_k$ with $x_i \\in A$ (repetitions allowed) and $k \\le h$.\n\nThe **restricted order** of $A$ is the least $t$ (if it exists) such that every sufficiently large $n = s_1 + \\cdots + s_k$ with **distinct** $s_i \\in A$ and $k \\le t$.\n\n**Open Questions:**\n1. Characterize which bases have finite restricted order\n2. Can restricted order be bounded by a function of order?\n3. When does restricted order equal order?\n4. If $A \\setminus F$ is a basis for all finite $F$, must $A$ have restricted order?\n\n**Known Results:**\n- Order $\\ge 3$ does NOT guarantee finite restricted order (Bateman)\n- Order $2$ implies restricted order $\\le 4$ (Kelly 1957)\n- The bound $4$ is sharp: $\\exists$ order-2 basis with restricted order $= 4$ (Hennecart 2005)\n- For order $k$, restricted order can be $\\ge 2^{k-2} + k - 1$ (HHP 2007)\n\n**Status: OPEN**",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Representation Types:** IsBasisOfOrder uses Multiset ℕ (allowing repetition: {2, 2, 3} is valid) while HasRestrictedOrder uses Finset ℕ (requiring distinctness: {2, 3, 5}). This type-level distinction encodes the mathematical difference at the foundation\n\n2. **Exact vs Existence:** IsExactOrder requires A to be a basis of order h but NOT h−1 (minimality). HasFiniteRestrictedOrder is the existential ∃ t, and minimalRestrictedOrder computes the least such t via Nat.find, which requires a decidability proof\n\n3. **Axiom Structure:** 11 axioms capture the deep results — Bateman's observation on batemanSet, Kelly's theorem and conjecture, Hennecart's basis properties, squares and triangulars classical values, and HHP lower bound. These are axiomatized because the proofs require combinatorial arguments beyond Mathlib\n\n4. **Genuine Proofs (7 theorems):** bateman_observation (pairing axioms), hennecart_disproves_kelly (contradiction from Kelly's conjecture applied to Hennecart's basis), triangular_orders_equal and squares_orders_differ (pairing axioms), exponential_gap (push_neg/contraposition from HHP), restricted_implies_regular (Finset.val to Multiset), restricted_order_monotone (Nat.le_succ_of_le)\n\n5. **Open Questions as Props:** Four Prop definitions formalize the open questions without asserting truth or falsity, capturing the mathematical landscape of what remains unknown",
     "keyInsights": [
-      "Order allows repetitions (multisets); restricted order requires distinct elements (finite sets)",
-      "Bateman's example A = {1} ∪ {x : h | x} shows order h ≥ 3 doesn't imply finite restricted order",
-      "Kelly proved order 2 implies restricted order ≤ 4; his conjecture of ≤ 3 was disproved",
-      "The gap between order and restricted order can grow exponentially: at least 2^{k-2} + k - 1 for order k",
-      "Triangular numbers have equal order and restricted order; squares have order 4 but restricted order 5"
+      "**Multiset vs Finset: A Type-Theoretic Distinction with Number-Theoretic Depth.** The entire problem hinges on replacing Multiset (allowing repetition) with Finset (requiring distinctness) in the representation constraint. In Lean 4, this is a type-level distinction — Multiset ℕ vs Finset ℕ — that cleanly captures the mathematical difference. The Finset.val function provides a canonical embedding of Finset into Multiset, which is exactly how restricted_implies_regular is proved: every restricted representation is automatically a regular one",
+      "**Bateman's Quadratic Barrier.** The set A = {1} ∪ {multiples of h} is a basis of order h (by the division algorithm: n = qh + r using q copies of h and r copies of 1, with q + r ≤ h) but fails the restricted order condition because the distinct multiples h, 2h, ..., th sum to h·t(t+1)/2, which grows quadratically. Representing n requires t ~ √(2n/h) distinct summands, so no fixed t works. This shows that for h ≥ 3, order alone says nothing about restricted order",
+      "**Kelly's 50-Year Conjecture and Its Demise.** Kelly's 1957 theorem — every order-2 basis has restricted order ≤ 4 — uses a pigeonhole argument exploiting the abundance of representations n = a + b. His conjecture that 3 suffices stood until Hennecart's 2005 counterexample. The Lean proof of the disproof is genuinely elegant: assume Kelly's conjecture, apply it to Hennecart's order-2 basis to get restricted order ≤ 3, but the axiom asserts ¬HasRestrictedOrder hennecart_basis 3. Contradiction",
+      "**The HHP Exponential Explosion.** The 2007 result of Hegyvári, Hennecart, and Plagne is the most dramatic: for order k, the restricted order can be at least 2^{k−2} + k − 1. This exponential growth suggests that no polynomial function f(k) can bound restricted order in terms of order — though this remains unproven. The Lean proof uses push_neg and contraposition: if every basis of order k had restricted order < 2^{k−2} + k − 1, we'd contradict the HHP construction",
+      "**The Squares-Triangulars Dichotomy.** Squares have order 4 (Lagrange) but restricted order 5 (Pall) — the gap of 1 reflects the fact that representations like 4 = 2² need repetition, so requiring distinctness costs one extra summand. Triangular numbers have both order and restricted order equal to 3 (Gauss + Schinzel), making them the paradigmatic example of 'order = restricted order'. Understanding what distinguishes these cases is the content of Open Question 3"
     ]
   },
   "sections": [
     {
       "id": "basic-defs",
-      "title": "Basic Definitions",
+      "title": "Basis and Restricted Order Definitions",
       "startLine": 43,
       "endLine": 92,
-      "summary": "Defines additive basis of order h, exact order, restricted representations, restricted order, and finite restricted order."
+      "summary": "Defines IsBasisOfOrder(A, h) using Multiset ℕ (allowing repetition): every sufficiently large n = x₁ + ··· + xₖ with xᵢ ∈ A and k ≤ h. IsExactOrder requires minimality (order h but not h−1). HasRestrictedOrder(A, t) uses Finset ℕ (requiring distinctness). HasFiniteRestrictedOrder is the existential ∃ t, and minimalRestrictedOrder computes the least such t via Nat.find. The type-level Multiset/Finset distinction is the formal backbone of the entire formalization."
     },
     {
       "id": "bateman",
-      "title": "Bateman's Observation",
+      "title": "Bateman's Observation: Order ≥ 3 Doesn't Imply Restricted Order",
       "startLine": 94,
       "endLine": 117,
-      "summary": "Bateman's example showing order h ≥ 3 doesn't guarantee finite restricted order: A = {1} ∪ {x : h | x}."
+      "summary": "Defines batemanSet(h) = {1} ∪ {x > 0 : h | x} and axiomatizes it as a basis of order h with no finite restricted order for h ≥ 3. The theorem bateman_observation is genuinely proved by pairing the two axioms. The key insight: n = qh + r uses q + r ≤ h summands with repetition, but distinct multiples of h sum to h·t(t+1)/2, requiring t ~ √(2n/h) → ∞ distinct summands."
     },
     {
       "id": "kelly",
-      "title": "Kelly's Results (1957)",
+      "title": "Kelly's Theorem and Conjecture (1957)",
       "startLine": 119,
       "endLine": 144,
-      "summary": "Kelly's theorem (order 2 implies restricted order ≤ 4) and his disproved conjecture (≤ 3)."
+      "summary": "Axiomatizes Kelly's theorem: every basis of order 2 has restricted order ≤ 4. Formalizes kellyConjecture as the stronger claim (restricted order ≤ 3). The theorem kelly_conjecture_false has a sorry because the direct proof uses Hennecart's construction; the genuine disproof appears later as hennecart_disproves_kelly. Kelly's pigeonhole argument exploits the many representations n = a + b to find 4 distinct elements summing to n."
     },
     {
       "id": "hennecart",
       "title": "Hennecart's Counterexample (2005)",
       "startLine": 146,
       "endLine": 167,
-      "summary": "Hennecart constructed an order-2 basis with restricted order exactly 4, disproving Kelly's conjecture."
+      "summary": "Axiomatizes hennecart_basis as an order-2 basis with restricted order exactly 4 (HasRestrictedOrder 4 ∧ ¬HasRestrictedOrder 3). The theorem hennecart_disproves_kelly is genuinely proved: assume Kelly's conjecture → apply to Hennecart's basis → get restricted order ≤ 3 → contradiction with ¬HasRestrictedOrder 3. This resolved a 50-year-old conjecture by showing Kelly's bound of 4 is sharp."
     },
     {
       "id": "examples",
-      "title": "Classical Examples",
+      "title": "Classical Examples: Squares and Triangular Numbers",
       "startLine": 169,
       "endLine": 213,
-      "summary": "Squares (order 4, restricted 5) and triangular numbers (order = restricted = 3)."
+      "summary": "Defines squares = {k² : k ≥ 0} and triangular = {k(k+1)/2 : k ≥ 0}. Axiomatizes: squares have order 4 (Lagrange, 1770) and restricted order 5 (Pall, 1933); triangulars have order 3 (Gauss Eureka, 1796) and restricted order 3 (Schinzel, 1954). The theorems triangular_orders_equal and squares_orders_differ are genuinely proved by pairing the respective axioms, exhibiting the two contrasting behaviors."
     },
     {
       "id": "hhp",
-      "title": "HHP Lower Bound (2007)",
+      "title": "HHP Exponential Lower Bound (2007)",
       "startLine": 215,
       "endLine": 236,
-      "summary": "For order k ≥ 2, restricted order can be at least 2^{k-2} + k - 1 (exponential gap)."
+      "summary": "Axiomatizes hhp_lower_bound: for k ≥ 2, there exists a basis of order k whose restricted order is at least 2^{k−2} + k − 1. The theorem exponential_gap is genuinely proved by obtaining the basis A from the axiom, then showing ∀ t, HasRestrictedOrder A t → t ≥ 2^{k−2} + k − 1 by contraposition using push_neg. Values: k=3 gives ≥4, k=4 gives ≥7, k=10 gives ≥265."
     },
     {
       "id": "open-questions",
-      "title": "Open Questions",
+      "title": "The Four Main Open Questions",
       "startLine": 238,
       "endLine": 274,
-      "summary": "The four main open questions: existence conditions, bounding, equality conditions, and robustness."
+      "summary": "Formalizes four Prop definitions capturing Erdős's open questions. Q1 (characterization): ∃ predicate P with HasFiniteRestrictedOrder A ↔ P A. Q2 (bounding): ∃ f with restricted order ≤ f(order). Q3 (equality): ∃ P characterizing when order = restricted order. Q4 (robustness): defines IsRobustBasis as ∀ F : Finset ℕ, IsBasisOfOrder (A \\ ↑F) h, and asks whether robustness implies HasFiniteRestrictedOrder."
     },
     {
       "id": "properties",
-      "title": "Basic Properties",
+      "title": "Basic Properties of Restricted Order",
       "startLine": 276,
       "endLine": 318,
-      "summary": "Properties: restricted implies regular order, order ≤ restricted order, and monotonicity."
+      "summary": "Three structural results. restricted_implies_regular (genuinely proved): HasRestrictedOrder A t → IsBasisOfOrder A t, converting Finset to Multiset via s.val. order_le_restricted_order (sorry): IsExactOrder A h ∧ HasRestrictedOrder A t → h ≤ t. restricted_order_monotone (genuinely proved): HasRestrictedOrder A t → HasRestrictedOrder A (t+1) via Nat.le_succ_of_le on cardinality."
     },
     {
       "id": "summary",
-      "title": "Summary",
+      "title": "Summary Theorem",
       "startLine": 320,
       "endLine": 361,
-      "summary": "Summary theorem combining Kelly's theorem, the false conjecture, and classical examples."
+      "summary": "Assembles erdos_338_summary as a four-part conjunction: (1) Kelly's theorem (order 2 → restricted ≤ 4), (2) ¬kellyConjecture via hennecart_disproves_kelly, (3) squares have order 4 and restricted 5, (4) triangulars have both = 3. Genuinely proved using refine to split the conjunction. Final inventory: 2 sorries, 11 axioms, 7 genuinely proved theorems."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #338 remains OPEN. The main questions about characterizing when restricted order exists, bounding it in terms of order, and when they are equal are unsolved. Key partial results include: Kelly's bound of 4 for order-2 bases, Hennecart's counterexample to Kelly's conjecture of 3, Bateman's example showing order ≥ 3 doesn't guarantee finite restricted order, and the HHP exponential lower bound.",
-    "implications": "The gap between order and restricted order reveals the fundamental difference between representations allowing repetitions and those requiring distinctness. The exponential gap in the HHP lower bound suggests there may be no polynomial bound on restricted order in terms of order. The problem connects to questions about robustness of additive bases.",
+    "summary": "Erdős Problem #338 remains OPEN — all four of Erdős's questions about the restricted order of additive bases are unsolved. The formalization captures the complete landscape of known partial results in 361 lines of Lean 4: Bateman's observation that order ≥ 3 doesn't guarantee finite restricted order, Kelly's sharp bound of 4 for order-2 bases (with Hennecart's disproof of the conjectured bound of 3), the squares/triangulars dichotomy, and the HHP exponential lower bound 2^{k−2} + k − 1. Of the 20 declarations, 7 are genuinely proved theorems, 11 are axioms for deep combinatorial results, and 2 are sorries for standard Mathlib-level lemmas. The key genuine proofs use elegant Lean techniques: Finset.val for the restricted-implies-regular implication, proof by contradiction for the Kelly conjecture disproof, and push_neg/contraposition for the exponential gap.",
+    "implications": "**Connections Across Additive Number Theory**\n\n1. **Waring's Problem and Beyond:** The order concept generalizes Waring's problem ($g(k)$ for $k$-th powers). The restricted order adds the distinctness constraint, connecting to questions about representations of integers by sums of distinct $k$-th powers — a topic studied by Hooley, Vaughan, and others in analytic number theory\n\n2. **Schnirelmann Density:** The classical approach to additive bases via Schnirelmann density ($\\sigma(A) = \\inf_n A(n)/n$) gives $\\sigma(A) > 0 \\implies A$ is a basis. The restricted order question asks how this density-based existence translates when distinctness is imposed, connecting density to structural properties of representations\n\n3. **Sumsets and Additive Combinatorics:** In the language of additive combinatorics, order $h$ means $hA \\supseteq [N, \\infty)$ for $hA = A + A + \\cdots + A$ ($h$ times, with repetition). Restricted order asks about the $h$-fold sumset where each element is used at most once — the 'distinct sumset' variant. This connects to Freiman-Ruzsa theory and the structure of sumsets\n\n4. **Exponential vs Polynomial Gaps:** The HHP bound $2^{k-2} + k - 1$ is exponential but the question of whether restricted order is always at most exponential in order (Open Question 2) remains open. If a polynomial bound existed, it would have profound implications for the structure theory of additive bases\n\n5. **Robustness and Stability:** Open Question 4 connects to the stability theory of additive bases: if removing any finite set preserves the basis property, the basis is 'robust'. Whether robustness implies finite restricted order is a natural stability question with parallels in Ramsey theory and ergodic theory",
     "openQuestions": [
-      "What are necessary and sufficient conditions for a basis to have finite restricted order?",
-      "Can restricted order be bounded by a function of order (for bases that have restricted order)?",
-      "What characterizes bases where order equals restricted order?",
-      "If A \\ F is a basis for all finite F, must A have restricted order?"
+      "What are necessary and sufficient conditions for a basis to have finite restricted order? Is there a density or structural criterion?",
+      "Can restricted order be bounded by a function of order for bases that have finite restricted order? Is the exponential HHP bound close to optimal?",
+      "What characterizes bases where order equals restricted order? Are triangular numbers typical or exceptional?",
+      "If A \\ F is a basis for all finite F (robustness), must A have finite restricted order?",
+      "For order k = 2, is there a basis with restricted order exactly 3, or is the restricted order always 2 or 4?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enriched erdos-320 (Distinct Sums of Unit Fractions): 16 annotations with mathContext/LaTeX, deepened historicalContext with Egyptian fractions/Bleicher-Erdős/BGMS, 5 keyInsights, substantive section summaries
- Enriched erdos-331 (Common Differences in Dense Sets): 13 annotations with mathContext/LaTeX, deepened historicalContext with Ruzsa's binary construction/unique representation, 5 keyInsights, substantive section summaries

## Test plan
- [x] JSON validates for all files
- [x] All annotations have mathContext, relatedConcepts, prerequisites
- [x] Section summaries are substantive (not title repeats)
- [x] keyInsights are detailed paragraphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)