### PR TITLE
fix: enricher annotation type assertion errors

### DIFF
--- a/src/data/proofs/erdos-400/index.ts
+++ b/src/data/proofs/erdos-400/index.ts
@@ -17,7 +17,7 @@ export const proof: Proof = {
   overview: meta.overview, conclusion: meta.conclusion,
 }
 
-export const annotations: Annotation[] = annotationsJson as Annotation[]
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const proofData: ProofData = { proof, annotations }
 
 export async function getProofSource(): Promise<string> {

--- a/src/data/proofs/erdos-412/index.ts
+++ b/src/data/proofs/erdos-412/index.ts
@@ -29,7 +29,7 @@ export const proof: Proof = {
   conclusion: meta.conclusion,
 }
 
-export const annotations: Annotation[] = annotationsJson as Annotation[]
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
 export const proofData: ProofData = {
   proof,

--- a/src/data/proofs/erdos-415/index.ts
+++ b/src/data/proofs/erdos-415/index.ts
@@ -29,7 +29,7 @@ export const proof: Proof = {
   conclusion: meta.conclusion,
 }
 
-export const annotations: Annotation[] = annotationsJson as Annotation[]
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
 export const proofData: ProofData = {
   proof,

--- a/src/data/proofs/erdos-419/index.ts
+++ b/src/data/proofs/erdos-419/index.ts
@@ -29,7 +29,7 @@ export const proof: Proof = {
   conclusion: meta.conclusion,
 }
 
-export const annotations: Annotation[] = annotationsJson as Annotation[]
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
 export const proofData: ProofData = {
   proof,

--- a/src/data/proofs/erdos-428/index.ts
+++ b/src/data/proofs/erdos-428/index.ts
@@ -17,7 +17,7 @@ export const proof: Proof = {
   overview: meta.overview, conclusion: meta.conclusion,
 }
 
-export const annotations: Annotation[] = annotationsJson as Annotation[]
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const proofData: ProofData = { proof, annotations }
 
 export async function getProofSource(): Promise<string> {

--- a/src/data/proofs/erdos-434/index.ts
+++ b/src/data/proofs/erdos-434/index.ts
@@ -29,7 +29,7 @@ export const proof: Proof = {
   conclusion: meta.conclusion,
 }
 
-export const annotations: Annotation[] = annotationsJson as Annotation[]
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
 export const proofData: ProofData = {
   proof,


### PR DESCRIPTION
## Summary
- Fix TS2352 type errors in 6 enricher-generated index.ts files (erdos-400, 412, 415, 419, 428, 434)
- Use `as unknown as Annotation[]` instead of `as Annotation[]` for JSON imports with object-style mathContext

## Test plan
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)