### PR TITLE
enrich: deepen annotations and meta for erdos-419

### DIFF
--- a/src/data/proofs/erdos-419/meta.json
+++ b/src/data/proofs/erdos-419/meta.json
@@ -108,7 +108,7 @@
     }
   },
   "overview": {
-    "historicalContext": "Erdős Problem #419 asks about the limit points of the ratio τ((n+1)!)/τ(n!), where τ(n) counts the positive divisors of n. The factorial n! has a very regular prime factorization given by Legendre's formula, so the ratio is controlled by the prime factorization of n+1.\n\nErdős and Graham posed this problem in 1980, conjecturing that the values 1 + 1/k for k ≥ 1 should be limit points. In 1996, Erdős, Graham, Ivić, and Pomerance proved the complete characterization: the limit points are exactly {1} ∪ {1 + 1/k : k ≥ 1}.\n\nThe key insight is a small/large prime dichotomy: decompose the primes dividing n+1 into 'small' (p ≤ n^(2/3)) and 'large' (p > n^(2/3)). Small primes contribute negligibly to the ratio (their factorial valuations are enormous by Legendre's formula). At most one large prime can exist, and it determines the dominant term. When n+1 = pk for large prime p, the ratio approaches 1 + 1/k. When n+1 has only small prime factors (highly composite), the ratio approaches 1.\n\nMehtaab Sawhney later independently rediscovered the argument, presenting an elegant version of the proof.",
+    "historicalContext": "Erdős Problem #419 asks about the limit points of the ratio τ((n+1)!)/τ(n!), where τ(n) counts the positive divisors of n. The factorial n! has a very regular prime factorization given by Legendre's formula (Adrien-Marie Legendre, 1808), so the ratio is controlled by the prime factorization of n+1.\n\nErdős and Graham posed this problem in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (L'Enseignement Mathématique, Geneva). They conjectured that the values 1 + 1/k for k ≥ 1 should be limit points.\n\nIn 1996, Erdős, Graham, Aleksandar Ivić, and Carl Pomerance proved the complete characterization in their paper 'On the number of divisors of n!' (Analytic Number Theory: Proceedings of a Conference in Honor of Heini Halberstam). Ivić, a Serbian mathematician known for his work on the Riemann zeta function and exponential sums, brought analytic techniques. Pomerance, one of the foremost algorithmic number theorists, contributed expertise in smooth number distribution. Together they showed the limit points are exactly {1} ∪ {1 + 1/k : k ≥ 1}.\n\nThe key insight is a small/large prime dichotomy: decompose the primes dividing n+1 into 'small' (p ≤ n^(2/3)) and 'large' (p > n^(2/3)). Small primes contribute negligibly to the ratio (their factorial valuations are enormous by Legendre's formula). At most one large prime can exist, and it determines the dominant term. When n+1 = pk for large prime p, the ratio approaches 1 + 1/k. When n+1 has only small prime factors (a 'smooth' or 'friable' number), the ratio approaches 1. The existence of infinitely many n for each case relies on Dirichlet's theorem on primes in arithmetic progressions (1837).\n\nMehtaab Sawhney later independently rediscovered the argument, presenting an elegant version of the proof that clarifies the small/large prime decomposition.",
     "problemStatement": "If τ(n) counts the number of divisors of n, what is the set of limit points of τ((n+1)!)/τ(n!)? Answer: The limit points are exactly {1} ∪ {1 + 1/k : k ≥ 1} = {1, 2, 3/2, 4/3, 5/4, ...}.",
     "proofStrategy": "The proof uses the multiplicative formula τ(n) = ∏ₚ (vₚ(n) + 1) to express the ratio as:\n\nτ((n+1)!)/τ(n!) = ∏_{p|n+1} (1 + vₚ(n+1)/(vₚ(n!) + 1))\n\n**Small primes** (p ≤ n^(2/3)): By Legendre's formula, vₚ(n!) ≥ n/p ≥ n^(1/3), while vₚ(n+1) ≤ log₂(n). So each factor is 1 + O(log n / n^(1/3)), and the product over ≤ log₂(n) small primes gives 1 + o(1).\n\n**Large primes** (p > n^(2/3)): At most one such p divides n+1. If n+1 = pk, then vₚ(n!) = k - 1, giving factor (k+1)/k = 1 + 1/k.\n\nCombining: ratio ≈ 1 · (1 + 1/k) when there's a large prime, or ≈ 1 when n+1 is smooth. By Dirichlet's theorem, each case occurs infinitely often.",
     "keyInsights": [
@@ -121,73 +121,80 @@
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Namespace",
+      "summary": "Imports Mathlib's `NumberTheory.Divisors`, `ArithmeticFunction`, `Nat.Factorial.Basic`, `Padics.PadicVal`, and `SpecificLimits.Basic`. Opens `Nat` and `ArithmeticFunction` namespaces.",
+      "startLine": 22,
+      "endLine": 30
+    },
+    {
       "id": "definitions",
-      "title": "Part 1: Basic Definitions",
-      "summary": "Defines τ(n) = n.divisors.card, axiomatizes the multiplicative formula τ(n) = ∏ₚ(vₚ(n)+1), and defines factorialDivisorRatio(n) = τ((n+1)!)/τ(n!) as a rational number with a zero guard.",
-      "startLine": 33,
-      "endLine": 50
+      "title": "Basic Definitions",
+      "summary": "Defines $\\tau(n) = |\\{d : d \\mid n\\}|$ via `n.divisors.card`, axiomatizes the multiplicative formula $\\tau(n) = \\prod_{p \\mid n} (v_p(n) + 1)$, and defines the factorial divisor ratio $\\tau((n+1)!)/\\tau(n!) \\in \\mathbb{Q}$.",
+      "startLine": 37,
+      "endLine": 48
     },
     {
       "id": "ratio-formula",
-      "title": "Part 2: The Ratio Formula",
-      "summary": "Defines padicValFactorial via Legendre's formula, axiomatizes the identity equating it with padicValNat on factorials, and states the key ratio product formula: the ratio is a Finset.prod over (n+1).primeFactors.",
-      "startLine": 52,
-      "endLine": 74
+      "title": "The Ratio Formula",
+      "summary": "Defines `padicValFactorial` via Legendre's formula $v_p(n!) = \\sum_{i \\ge 1} \\lfloor n/p^i \\rfloor$, axiomatizes the identity with `padicValNat`, and states the key product formula: $\\tau((n+1)!)/\\tau(n!) = \\prod_{p \\mid n+1} (1 + v_p(n+1)/(v_p(n!)+1))$.",
+      "startLine": 56,
+      "endLine": 71
     },
     {
       "id": "prime-bounds",
-      "title": "Part 3: Prime Factorization Bounds",
-      "summary": "Axiomatizes three bounds: number of prime divisors < log₂(n), p-adic valuations < log₂(n), and at most one prime p | n+1 exceeding n^(2/3). These control the product structure.",
-      "startLine": 76,
-      "endLine": 92
+      "title": "Prime Factorization Bounds",
+      "summary": "Axiomatizes three bounds: $\\omega(n) < \\log_2 n$, $v_p(n) < \\log_2 n$, and at most one prime $p \\mid n+1$ with $p > n^{2/3}$. These control the product structure of the ratio.",
+      "startLine": 79,
+      "endLine": 88
     },
     {
       "id": "small-primes",
-      "title": "Part 4: Small Primes Contribution",
-      "summary": "Shows the product over primes p ≤ n^(2/3) satisfies 1 ≤ S ≤ 1 + (log n)²/n^(1/3) → 1. Uses Legendre to bound each factor and multiplies across O(log n) small primes.",
-      "startLine": 94,
-      "endLine": 113
+      "title": "Small Primes Contribution",
+      "summary": "Shows the product over primes $p \\le n^{2/3}$ satisfies $1 \\le S \\le 1 + (\\log n)^2/n^{1/3} \\to 1$. Each factor is $1 + O(\\log n / n^{1/3})$ by Legendre's bound $v_p(n!) \\ge n/p \\ge n^{1/3}$.",
+      "startLine": 96,
+      "endLine": 108
     },
     {
       "id": "large-primes",
-      "title": "Part 5: Large Prime Contribution",
-      "summary": "If p > n^(2/3) divides n+1, then vₚ(n+1) = 1 and vₚ(n!) = k-1 where n+1 = pk. The factor is (k+1)/k ≈ 1 + 1/k. When n+1 is prime (k=1), ratio ≈ 2.",
-      "startLine": 115,
-      "endLine": 128
+      "title": "Large Prime Contribution",
+      "summary": "If $p > n^{2/3}$ divides $n+1$, then $v_p(n+1) = 1$ (since $p^2 > n+1$) and $v_p(n!) = k-1$ where $n+1 = pk$. The factor is $(k+1)/k = 1 + 1/k$. When $n+1$ is prime ($k=1$), the ratio $\\approx 2$.",
+      "startLine": 116,
+      "endLine": 122
     },
     {
       "id": "limit-points",
-      "title": "Part 6: The Set of Limit Points",
-      "summary": "Defines limitPointSet = {1} ∪ {1 + 1/k : k ≥ 1} and axiomatizes three results: 1 is a limit point (smooth numbers), each 1+1/k is a limit point (Dirichlet), and these are the only limit points (small/large decomposition).",
+      "title": "The Set of Limit Points",
+      "summary": "Defines $L = \\{1\\} \\cup \\{1 + 1/k : k \\ge 1\\}$ and axiomatizes: $1 \\in L$ (smooth numbers), $1+1/k \\in L$ (Dirichlet's theorem ensures infinitely many $n+1 = pk$), and $L$ contains all limit points.",
       "startLine": 130,
-      "endLine": 157
+      "endLine": 150
     },
     {
       "id": "examples",
-      "title": "Part 7: Examples and Concrete Cases",
-      "summary": "Four concrete cases: n+1 prime → ratio ≈ 2, n+1 = 2p → ratio ≈ 3/2, n+1 = 3p → ratio ≈ 4/3, n+1 smooth → ratio ≈ 1. Verified with norm_num examples: 1+1/1=2, 1+1/2=3/2, 1+1/3=4/3, 1+1/4=5/4.",
-      "startLine": 159,
-      "endLine": 180
+      "title": "Examples and Concrete Cases",
+      "summary": "Four cases: $n+1$ prime $\\Rightarrow$ ratio $\\approx 2$; $n+1 = 2p \\Rightarrow \\approx 3/2$; $n+1 = 3p \\Rightarrow \\approx 4/3$; $n+1$ smooth $\\Rightarrow \\approx 1$. Verified: $1+1/1=2$, $1+1/2=3/2$, $1+1/3=4/3$, $1+1/4=5/4$.",
+      "startLine": 158,
+      "endLine": 172
     },
     {
       "id": "proof-structure",
-      "title": "Part 8: The Proof Structure and Main Theorem",
-      "summary": "Axiomatizes ratio_decomposition (S·L form with S → 1 and L ∈ {1} ∪ {1+1/k}). Proves sawhney_characterization as a full iff via pattern matching on Set.mem_union, combining the three limit point axioms.",
-      "startLine": 182,
-      "endLine": 210
+      "title": "The Proof Structure and Main Theorem",
+      "summary": "Axiomatizes `ratio_decomposition`: ratio $= S \\cdot L$ with $S \\to 1$ and $L \\in \\{1\\} \\cup \\{1+1/k\\}$. Proves `sawhney_characterization`: $x$ is a limit point $\\iff x \\in L$, via `Set.mem_union` case analysis.",
+      "startLine": 180,
+      "endLine": 201
     },
     {
       "id": "asymptotics",
-      "title": "Part 9: Asymptotics of τ(n!)",
-      "summary": "Axiomatizes τ(n!) ≥ 2^(n/log n) and log τ(n!) ~ n log n / log log n. Provides context for why the ratio stays bounded — both numerator and denominator are astronomically large.",
-      "startLine": 212,
-      "endLine": 225
+      "title": "Asymptotics of $\\tau(n!)$",
+      "summary": "Axiomatizes $\\tau(n!) \\ge 2^{n/\\log n}$ and $\\log \\tau(n!) \\sim n \\log n / \\log \\log n$. Provides context: both numerator and denominator are astronomically large, explaining why the ratio stays in $[1, 2]$.",
+      "startLine": 209,
+      "endLine": 215
     },
     {
       "id": "summary",
-      "title": "Part 10: Summary",
-      "summary": "Proves limit_set_properties (1 ∈ set, 1+1/k ∈ set, all ≥ 1) by constructive case analysis with linarith. Proves erdos_419_summary packaging characterization, existence of 1, and existence of 1+1/k into a single triple.",
-      "startLine": 227,
+      "title": "Summary",
+      "summary": "Proves `limit_set_properties` ($1 \\in L$, $1+1/k \\in L$, all $\\ge 1$) by constructive case analysis with `linarith`. Proves `erdos_419_summary` packaging the characterization, existence of $1$, and existence of $1+1/k$.",
+      "startLine": 223,
       "endLine": 252
     }
   ],


### PR DESCRIPTION
## Summary
- Added imports section and LaTeX to all 11 section summaries
- Fixed annotation types to valid values (context→concept, axiom→theorem/definition)
- Added top-level `relatedConcepts` and `prerequisites` to all 14 annotations
- Deepened historicalContext with Ivić, Pomerance, Dirichlet bios and references
- Added cross-reference to `legendre-partial`
- Fixed annotation startLines to point to actual Lean constructs

## Test plan
- [x] `pnpm annotations:build` passes (only expected axiom→theorem non-strict warnings)
- [x] All annotation startLines verified against Lean file
- [x] JSON validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)