### PR TITLE
enrich: deepen annotations and meta for erdos-523

### DIFF
--- a/src/data/proofs/erdos-523/annotations.json
+++ b/src/data/proofs/erdos-523/annotations.json
@@ -1,173 +1,158 @@
 [
   {
-    "id": "ann-523-signvec",
+    "id": "ann-523-imports",
     "proofId": "erdos-523",
-    "range": { "startLine": 42, "endLine": 43 },
-    "type": "definition",
-    "title": "SignVector",
-    "content": "εₖ ∈ {-1, 1} for k = 0, ..., n.",
-    "significance": "key"
+    "type": "concept",
+    "range": { "startLine": 28, "endLine": 36 },
+    "title": "Imports and Setup",
+    "content": "Imports Mathlib's complex number basics (for polynomial evaluation on the unit circle), real number basics (for the maximum modulus), logarithm functions (for the $\\sqrt{n \\log n}$ scaling), finite sets (for indexing coefficients), and big operators (for the summation $\\sum \\varepsilon_k z^k$). Opens `Complex`, `Finset`, `BigOperators`, and `Real` namespaces.",
+    "mathContext": "The formalization works over $\\mathbb{C}$ for polynomial values and $\\mathbb{R}$ for the maximum modulus and scaling function. The unit circle $\\{z \\in \\mathbb{C} : |z| = 1\\}$ is parameterized as $z = e^{i\\theta}$ for $\\theta \\in [0, 2\\pi)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Complex numbers", "BigOperators", "Finset.sum", "Real.log"],
+    "prerequisites": ["Mathlib.Data.Complex.Basic", "Mathlib.Analysis.SpecialFunctions.Log.Basic"]
   },
   {
-    "id": "ann-523-valid",
+    "id": "ann-523-signvec",
     "proofId": "erdos-523",
-    "range": { "startLine": 45, "endLine": 47 },
     "type": "definition",
-    "title": "IsValidSign",
-    "content": "All entries are ±1.",
-    "significance": "key"
+    "range": { "startLine": 42, "endLine": 47 },
+    "title": "Sign Vectors and Validity",
+    "content": "`SignVector n` is a function `Fin (n+1) -> Int` representing the coefficient vector $(\\varepsilon_0, \\ldots, \\varepsilon_n)$. `IsValidSign s` requires every entry to be $+1$ or $-1$. There are $2^{n+1}$ valid sign vectors, forming the vertices of the $(n+1)$-dimensional hypercube $\\{-1, +1\\}^{n+1}$.",
+    "mathContext": "A Rademacher random variable takes values $\\pm 1$ with equal probability $1/2$. The sign vector $(\\varepsilon_0, \\ldots, \\varepsilon_n)$ consists of $n+1$ i.i.d. Rademacher variables. The space of all sign vectors has $|\\{\\pm 1\\}^{n+1}| = 2^{n+1}$ elements, each equally likely under the uniform distribution.",
+    "significance": "key",
+    "relatedConcepts": ["Rademacher distribution", "hypercube", "random signs", "Boolean function"],
+    "prerequisites": ["Fin type", "Int", "probability basics"]
   },
   {
     "id": "ann-523-randpoly",
     "proofId": "erdos-523",
-    "range": { "startLine": 49, "endLine": 51 },
     "type": "definition",
-    "title": "randomPolynomial",
-    "content": "f(z) = ∑ εₖ z^k.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-523-maxmod",
-    "proofId": "erdos-523",
-    "range": { "startLine": 53, "endLine": 55 },
-    "type": "definition",
-    "title": "maxModulus",
-    "content": "sup_{|z|=1} |f(z)|.",
-    "significance": "critical"
+    "range": { "startLine": 49, "endLine": 59 },
+    "title": "Random Polynomial and Evaluation",
+    "content": "`randomPolynomial s z` computes $f(z) = \\sum_{k=0}^n \\varepsilon_k z^k$ as a `BigOperators` sum over `Fin (n+1)`. `maxModulus s` takes the supremum of $|f(e^{i\\theta})|$ over all $\\theta \\in \\mathbb{R}$ (i.e., over the unit circle). `evalOnCircle s theta` evaluates at the specific point $z = e^{i\\theta}$.",
+    "mathContext": "The random polynomial $f(z) = \\sum_{k=0}^n \\varepsilon_k z^k$ is a random element of the space of Littlewood polynomials. On the unit circle $|z| = 1$, writing $z = e^{i\\theta}$, we get $f(e^{i\\theta}) = \\sum_{k=0}^n \\varepsilon_k e^{ik\\theta}$, which is a random trigonometric polynomial (random Fourier series with $n+1$ terms).",
+    "significance": "critical",
+    "relatedConcepts": ["Littlewood polynomial", "random Fourier series", "trigonometric polynomial", "unit circle"],
+    "prerequisites": ["Complex.exp", "Complex.I", "BigOperators.sum"]
   },
   {
     "id": "ann-523-scale",
     "proofId": "erdos-523",
-    "range": { "startLine": 65, "endLine": 67 },
     "type": "definition",
-    "title": "expectedScale",
-    "content": "√(n log n) scaling.",
-    "significance": "key"
+    "range": { "startLine": 65, "endLine": 71 },
+    "title": "Scaling Function and Normalized Maximum",
+    "content": "`expectedScale n` returns $\\sqrt{n \\log n}$ for $n \\geq 2$ (with a guard returning 1 for $n \\leq 1$). `scaledMaxModulus s` normalizes the maximum by this scale: $M_n / \\sqrt{n \\log n}$. The central question is whether this ratio converges to a constant almost surely.",
+    "mathContext": "The scaling $\\sqrt{n \\log n}$ arises from the balance between two effects: the $L^2$ norm $\\|f\\|_2 = \\sqrt{n+1} \\approx \\sqrt{n}$ (by Parseval's theorem) and the maximum-to-$L^2$ ratio, which grows as $\\sqrt{\\log n}$ (by the entropy/covering-number argument for the unit circle). The product $\\sqrt{n} \\cdot \\sqrt{\\log n} = \\sqrt{n \\log n}$ is the natural scale.",
+    "significance": "key",
+    "relatedConcepts": ["scaling function", "normalization", "entropy method", "covering numbers"],
+    "prerequisites": ["Real.sqrt", "Real.log"]
   },
   {
     "id": "ann-523-sz",
     "proofId": "erdos-523",
-    "range": { "startLine": 77, "endLine": 82 },
     "type": "theorem",
-    "title": "salem_zygmund_order",
-    "content": "Salem-Zygmund: √(n log n) is the right order.",
-    "significance": "critical"
+    "range": { "startLine": 79, "endLine": 87 },
+    "title": "Salem-Zygmund Order-of-Magnitude Result (1954)",
+    "content": "Axiomatizes the Salem-Zygmund theorem: there exist constants $0 < c_1 \\leq c_2$ such that $c_1 \\sqrt{n \\log n} \\leq \\max_{|z|=1} |f(z)| \\leq c_2 \\sqrt{n \\log n}$ with high probability. This establishes the correct order of magnitude but not the exact constant. The `SalemZygmundResult` definition packages this as a `Prop`.",
+    "mathContext": "Raphael Salem and Antoni Zygmund proved in their 1954 paper 'Some properties of trigonometric series whose terms have random signs' that the maximum of a random trigonometric polynomial $\\sum_{k=0}^n \\varepsilon_k e^{ik\\theta}$ on $[0, 2\\pi]$ is of order $\\sqrt{n \\log n}$ with high probability. Their proof used the first and second moment methods combined with a union bound over a net of points on the circle.",
+    "significance": "critical",
+    "relatedConcepts": ["order of magnitude", "first moment method", "second moment method", "random trigonometric series"],
+    "prerequisites": ["probability theory", "trigonometric polynomials", "moment methods"]
   },
   {
     "id": "ann-523-question",
     "proofId": "erdos-523",
-    "range": { "startLine": 93, "endLine": 99 },
     "type": "definition",
-    "title": "ErdosQuestion523",
-    "content": "Does max = (C + o(1))√(n log n) a.s.?",
-    "significance": "critical"
+    "range": { "startLine": 93, "endLine": 99 },
+    "title": "The Erdos Question (1961)",
+    "content": "`ErdosQuestion523` formalizes Erdos's question from 1961: does there exist a constant $C > 0$ such that $\\max_{|z|=1} |f(z)| = (C + o(1))\\sqrt{n \\log n}$ almost surely? This asks for an exact asymptotic, going beyond Salem-Zygmund's order-of-magnitude result. The existential quantification over $C$ is the key: Erdos asked whether the ratio $M_n / \\sqrt{n \\log n}$ converges at all.",
+    "mathContext": "Erdos posed this question in [Er61] (1961, p.253). The 'almost surely' qualifier means: with probability 1 over the random signs $\\varepsilon_k$, the ratio $\\max_{|z|=1} |\\sum \\varepsilon_k z^k| / \\sqrt{n \\log n}$ converges to $C$ as $n \\to \\infty$. This is a stronger statement than convergence in probability or convergence in distribution.",
+    "significance": "critical",
+    "relatedConcepts": ["exact asymptotic", "almost sure convergence", "concentration of measure"],
+    "prerequisites": ["Salem-Zygmund result", "probability theory", "o(1) notation"]
   },
   {
     "id": "ann-523-halasz",
     "proofId": "erdos-523",
-    "range": { "startLine": 105, "endLine": 111 },
     "type": "theorem",
-    "title": "halasz_theorem",
-    "content": "Halász 1973: YES with C = 1.",
-    "significance": "critical"
+    "range": { "startLine": 107, "endLine": 121 },
+    "title": "Halasz's Theorem: C = 1 (1973)",
+    "content": "The definitive result: Gabor Halasz proved in 1973 that the answer to Erdos's question is YES with the exact constant $C = 1$. The axiom `halasz_theorem` states that for every $\\varepsilon > 0$, the maximum modulus is within $(1 \\pm \\varepsilon)\\sqrt{n \\log n}$ with probability tending to 1. The `halaszConstant = 1` records the exact value. The theorem `erdos_523_answer` proves `ErdosQuestion523` by witnessing $C = 1$.",
+    "mathContext": "Halasz's 1973 paper 'On a result of Salem and Zygmund concerning random polynomials' proved: almost surely, $\\max_{|z|=1} |\\sum_{k=0}^n \\varepsilon_k z^k| = (1 + o(1))\\sqrt{n \\log n}$. The proof combines a sharp upper bound (via Dudley's entropy integral or chaining) with a matching lower bound (via the second moment method applied to the maximum over a carefully chosen net).",
+    "significance": "critical",
+    "relatedConcepts": ["exact constant", "chaining argument", "Dudley entropy integral", "Borel-Cantelli lemma"],
+    "prerequisites": ["Salem-Zygmund result", "Gaussian comparison", "covering numbers"]
   },
   {
-    "id": "ann-523-const",
+    "id": "ann-523-prob-framework",
     "proofId": "erdos-523",
-    "range": { "startLine": 113, "endLine": 114 },
     "type": "definition",
-    "title": "halaszConstant",
-    "content": "The optimal constant C = 1.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-523-answer",
-    "proofId": "erdos-523",
-    "range": { "startLine": 116, "endLine": 121 },
-    "type": "theorem",
-    "title": "erdos_523_answer",
-    "content": "The answer is YES.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-523-as",
-    "proofId": "erdos-523",
-    "range": { "startLine": 136, "endLine": 139 },
-    "type": "definition",
-    "title": "AlmostSureConvergence",
-    "content": "Convergence with probability 1.",
-    "significance": "key"
+    "range": { "startLine": 128, "endLine": 142 },
+    "title": "Probabilistic Framework",
+    "content": "Sets up the probability space: `probabilitySpace n = SignVector n` (the $2^{n+1}$ sign vectors), `uniformSignDistribution` (each sign $\\pm 1$ with probability $1/2$, independently), and `AlmostSureConvergence C` (the ratio $M_n / \\sqrt{n \\log n} \\to C$ with probability 1). The axiom `halasz_almost_sure` asserts almost sure convergence to $C = 1$.",
+    "mathContext": "The probability space is $(\\Omega, \\mathcal{F}, \\mathbb{P}) = (\\{\\pm 1\\}^{\\mathbb{N}}, 2^{\\Omega}, \\text{uniform})$. The random polynomial $f_n(z) = \\sum_{k=0}^n \\varepsilon_k z^k$ is a martingale in $n$ for fixed $z$. Almost sure convergence of $M_n / \\sqrt{n \\log n} \\to 1$ means the set $\\{\\omega : \\lim_{n \\to \\infty} M_n(\\omega) / \\sqrt{n \\log n} = 1\\}$ has probability 1.",
+    "significance": "key",
+    "relatedConcepts": ["measure theory", "product probability space", "almost sure convergence", "martingale"],
+    "prerequisites": ["probability space", "independence", "Borel-Cantelli lemma"]
   },
   {
     "id": "ann-523-l2",
     "proofId": "erdos-523",
-    "range": { "startLine": 148, "endLine": 151 },
     "type": "definition",
-    "title": "L2Norm",
-    "content": "L² norm on the circle.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-523-l2exact",
-    "proofId": "erdos-523",
-    "range": { "startLine": 153, "endLine": 155 },
-    "type": "theorem",
-    "title": "L2_norm_exact",
-    "content": "L² norm = √(n+1).",
-    "significance": "key"
+    "range": { "startLine": 148, "endLine": 164 },
+    "title": "L2 Norm, Parseval, and Maximum-to-L2 Gap",
+    "content": "`L2Norm s` computes the $L^2$ norm of $f$ on the unit circle: $\\|f\\|_2 = \\sqrt{\\frac{1}{2\\pi}\\int_0^{2\\pi} |f(e^{i\\theta})|^2 d\\theta}$. The axiom `L2_norm_exact` proves $\\|f\\|_2 = \\sqrt{n+1}$ for any valid sign vector (by Parseval's theorem, since the coefficients have modulus 1). The axiom `max_vs_L2` gives the lower bound $M \\geq \\sqrt{n \\log n}/2$, showing the maximum exceeds the $L^2$ norm by a $\\sqrt{\\log n}$ factor.",
+    "mathContext": "By Parseval's theorem, $\\|f\\|_2^2 = \\sum_{k=0}^n |\\varepsilon_k|^2 = n + 1$ since $|\\varepsilon_k| = 1$. The $L^\\infty / L^2$ ratio $\\|f\\|_\\infty / \\|f\\|_2 \\approx \\sqrt{\\log n}$ reflects the 'peaking' phenomenon: the maximum of $n$ roughly independent Gaussian-like random variables grows as $\\sqrt{2 \\log n}$, and the unit circle can be discretized into $\\sim n$ effective independent points.",
+    "significance": "key",
+    "relatedConcepts": ["Parseval's theorem", "L2 norm", "peaking phenomenon", "maximum of Gaussians"],
+    "prerequisites": ["Lebesgue integration", "Parseval's theorem", "Real.sqrt"]
   },
   {
     "id": "ann-523-littlewood",
     "proofId": "erdos-523",
-    "range": { "startLine": 170, "endLine": 172 },
     "type": "definition",
-    "title": "IsLittlewood",
-    "content": "Polynomial with ±1 coefficients.",
-    "significance": "key"
+    "range": { "startLine": 170, "endLine": 183 },
+    "title": "Littlewood Polynomials and Typical Behavior",
+    "content": "`IsLittlewood p n` asserts that $p$ has $\\pm 1$ coefficients up to degree $n$ -- a Littlewood polynomial. The `LittlewoodProblem` concerns the deterministic extremal question: what is $\\min_p \\max_{|z|=1} |p(z)|$ over all Littlewood polynomials? The axiom `typical_littlewood` states that 'most' Littlewood polynomials have maximum $\\approx \\sqrt{n \\log n}$, connecting the random and deterministic theories.",
+    "mathContext": "John Edensor Littlewood (1885-1977) studied polynomials with $\\pm 1$ coefficients extensively. The 'flat' Littlewood polynomials -- those with $\\max_{|z|=1} |p(z)| = O(\\sqrt{n})$ -- are extremely rare. Balister, Bollobas, Morris, Sahasrabudhe, and Tiba (2019) proved that no Littlewood polynomial can be flat for sufficiently large $n$, confirming the conjecture that $\\min \\max |p(z)| \\gg \\sqrt{n}$.",
+    "significance": "key",
+    "relatedConcepts": ["Littlewood conjecture", "flat polynomials", "Rudin-Shapiro polynomials", "extremal polynomials"],
+    "prerequisites": ["polynomial basics", "complex analysis on unit circle"]
   },
   {
-    "id": "ann-523-upper",
+    "id": "ann-523-bounds",
     "proofId": "erdos-523",
-    "range": { "startLine": 189, "endLine": 192 },
     "type": "theorem",
-    "title": "upper_bound_high_prob",
-    "content": "max ≤ (1+ε)√(n log n) w.h.p.",
-    "significance": "key"
+    "range": { "startLine": 189, "endLine": 203 },
+    "title": "Upper and Lower Bounds with High Probability",
+    "content": "The two complementary axioms: `upper_bound_high_prob` states $\\max |f(z)| \\leq (1+\\varepsilon)\\sqrt{n \\log n}$ with probability $\\to 1$, and `lower_bound_high_prob` states $\\max |f(z)| \\geq (1-\\varepsilon)\\sqrt{n \\log n}$ with probability $\\to 1$. Together they pinch the maximum to $(1 \\pm \\varepsilon)\\sqrt{n \\log n}$. The `halaszProofSketch` notes the techniques: chaining for the upper bound, second moment method for the lower bound.",
+    "mathContext": "The **upper bound** uses the chaining technique: cover the unit circle with $\\sim n$ points, bound the maximum at net points by a union bound over sub-Gaussian tails, and control the oscillation between net points by Bernstein's inequality. The **lower bound** uses the second moment method: show $\\mathbb{E}[M_n^2] / (\\mathbb{E}[M_n])^2 \\to 1$, implying concentration via the Paley-Zygmund inequality.",
+    "significance": "key",
+    "relatedConcepts": ["chaining", "covering numbers", "Dudley entropy integral", "second moment method", "Paley-Zygmund inequality"],
+    "prerequisites": ["probability theory", "metric entropy", "union bound"]
   },
   {
-    "id": "ann-523-lower",
+    "id": "ann-523-related",
     "proofId": "erdos-523",
-    "range": { "startLine": 194, "endLine": 197 },
-    "type": "theorem",
-    "title": "lower_bound_high_prob",
-    "content": "max ≥ (1-ε)√(n log n) w.h.p.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-523-mahler",
-    "proofId": "erdos-523",
-    "range": { "startLine": 214, "endLine": 217 },
     "type": "definition",
-    "title": "mahlerMeasure",
-    "content": "Geometric mean measure.",
-    "significance": "supporting"
+    "range": { "startLine": 210, "endLine": 222 },
+    "title": "Rudin Conjecture and Mahler Measure",
+    "content": "`RudinConjecture` concerns the deterministic minimum: is $\\min_p \\max_{|z|=1} |p(z)| = \\Theta(\\sqrt{n})$ over Littlewood polynomials? `mahlerMeasure s` computes the Mahler measure $M(f) = \\exp(\\frac{1}{2\\pi} \\int_0^{2\\pi} \\log|f(e^{i\\theta})| d\\theta)$, the geometric mean of $|f|$ on the unit circle. `szegoConnection` notes the link to Szego's theorem.",
+    "mathContext": "The Mahler measure $M(f) = \\exp(\\frac{1}{2\\pi}\\int_0^{2\\pi} \\log|f(e^{i\\theta})|d\\theta)$ satisfies $M(f) \\leq \\|f\\|_\\infty$ by Jensen's inequality. For random Littlewood polynomials, the Mahler measure concentrates around $\\sqrt{n/e}$, related to the Lehmer conjecture about minimal Mahler measures of integer polynomials.",
+    "significance": "supporting",
+    "relatedConcepts": ["Mahler measure", "Lehmer conjecture", "Jensen's inequality", "Rudin conjecture", "flat polynomials"],
+    "prerequisites": ["geometric mean", "logarithmic integrals", "Toeplitz matrices"]
   },
   {
-    "id": "ann-523-main",
+    "id": "ann-523-summary",
     "proofId": "erdos-523",
-    "range": { "startLine": 238, "endLine": 238 },
     "type": "theorem",
-    "title": "erdos_523",
-    "content": "Main theorem: YES with C = 1.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-523-exactconst",
-    "proofId": "erdos-523",
-    "range": { "startLine": 240, "endLine": 245 },
-    "type": "theorem",
-    "title": "erdos_523_constant",
-    "content": "The constant is exactly 1.",
-    "significance": "critical"
+    "range": { "startLine": 238, "endLine": 253 },
+    "title": "Summary: Complete Resolution",
+    "content": "Four concluding theorems: `erdos_523` and `erdos_523_solved` both assert `ErdosQuestion523` (forwarding from `erdos_523_answer`). `erdos_523_constant` witnesses $C = 1$ explicitly. `erdos_523_main` packages `halasz_theorem`. The problem is completely solved: $\\max_{|z|=1} |\\sum \\varepsilon_k z^k| = (1 + o(1))\\sqrt{n \\log n}$ almost surely.",
+    "mathContext": "The complete answer to Erdos Problem #523: the maximum modulus of a random $\\pm 1$ polynomial of degree $n$ on the unit circle satisfies $M_n = (1 + o(1))\\sqrt{n \\log n}$ almost surely. The constant $C = 1$ means no extra multiplicative factor beyond $\\sqrt{n \\log n}$. This is the sharpest possible result for this class of random polynomials.",
+    "significance": "critical",
+    "relatedConcepts": ["complete resolution", "exact asymptotic", "random polynomial theory"],
+    "prerequisites": ["halasz_theorem", "ErdosQuestion523", "erdos_523_answer"]
   }
 ]

--- a/src/data/proofs/erdos-523/meta.json
+++ b/src/data/proofs/erdos-523/meta.json
@@ -58,101 +58,101 @@
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #523 (Maximum of Random Polynomials)**\n\n**Origin:**\nErdős posed this problem in [Er61] (1961, p.253), asking about the maximum modulus of random ±1 polynomials on the unit circle.\n\n**Key Results:**\n- Salem-Zygmund (1954): Established that √(n log n) is the correct order of magnitude\n- Halász (1973): Proved the exact asymptotic with constant C = 1\n\n**Significance:**\nThis is a fundamental result in the theory of Littlewood polynomials and random Fourier series, connecting probability, complex analysis, and harmonic analysis.",
+    "historicalContext": "Erdos Problem #523 concerns the maximum modulus of random $\\pm 1$ polynomials on the unit circle, a fundamental question at the intersection of probability, complex analysis, and harmonic analysis.\n\nThe story begins with Raphael Salem and Antoni Zygmund's 1954 paper 'Some properties of trigonometric series whose terms have random signs,' where they established that $\\max_{|z|=1} |\\sum_{k=0}^n \\varepsilon_k z^k| = \\Theta(\\sqrt{n \\log n})$ with high probability. Their proof combined the first and second moment methods with union bounds over discretized points on the circle. This left open the question of whether the ratio converges to a definite constant.\n\nErdos posed the exact-constant question in 1961 ([Er61], p.253): does $\\max_{|z|=1} |f(z)| / \\sqrt{n \\log n} \\to C$ almost surely for some $C > 0$? The answer came from Gabor Halasz in 1973, who proved $C = 1$ exactly. Halasz's proof was a tour de force combining sharp chaining arguments for the upper bound with second-moment methods for the lower bound.\n\nThe problem connects deeply to Littlewood polynomials (polynomials with $\\pm 1$ coefficients), studied by J.E. Littlewood since the 1960s. The result shows that 'typical' Littlewood polynomials have maximum $\\approx \\sqrt{n \\log n}$, much larger than the $L^2$ norm $\\sqrt{n+1}$ -- the extra $\\sqrt{\\log n}$ factor reflects the peaking phenomenon where the supremum of $n$ correlated random variables exceeds their typical size by $\\sqrt{\\log n}$. This connects to Kahane's theory of random Fourier series and the modern theory of Gaussian processes.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet f(z) = ∑_{k=0}^n εₖ z^k be a random polynomial where εₖ ∈ {-1,1} independently uniformly at random.\n\nDoes there exist C > 0 such that, almost surely,\n$$\\max_{|z|=1} |f(z)| = (C + o(1))\\sqrt{n \\log n}?$$\n\n**Answer: YES, with C = 1**\n\n(Halász 1973)",
     "proofStrategy": "**Formalization Approach**\n\n1. **Sign Vectors:** SignVector, IsValidSign\n\n2. **Random Polynomial:** randomPolynomial, evalOnCircle\n\n3. **Maximum Modulus:** maxModulus, expectedScale\n\n4. **Salem-Zygmund:** salem_zygmund_order (order of magnitude)\n\n5. **Halász:** halasz_theorem (C = 1 exactly)\n\n6. **L² Analysis:** L2Norm, L2_norm_exact\n\n7. **Probability:** AlmostSureConvergence, halasz_almost_sure\n\n8. **Littlewood:** IsLittlewood, typical_littlewood",
     "keyInsights": [
-      "**Random ±1 Polynomials:** Littlewood polynomials with random signs",
-      "**√(n log n) Scaling:** The natural scale for maximum on circle",
-      "**C = 1:** The exact constant (Halász)",
-      "**L² vs L^∞:** Max exceeds L² norm by √(log n) factor",
-      "**Almost Sure:** Convergence with probability 1"
+      "**$\\sqrt{n \\log n}$ decomposition**: The scaling decomposes as $\\sqrt{n} \\cdot \\sqrt{\\log n}$, where $\\sqrt{n}$ is the $L^2$ norm (Parseval) and $\\sqrt{\\log n}$ is the maximum-to-$L^2$ ratio (peaking over $\\sim n$ effective degrees of freedom on the circle)",
+      "**Exact constant $C = 1$**: Halasz's result $C = 1$ means no hidden multiplicative constant -- the maximum is asymptotically exactly $\\sqrt{n \\log n}$, not $2\\sqrt{n \\log n}$ or $\\sqrt{2n \\log n}$. This required sharp two-sided bounds, not just order-of-magnitude estimates",
+      "**Random vs. deterministic**: While most Littlewood polynomials have $\\max \\approx \\sqrt{n \\log n}$ (random result), the minimum over all Littlewood polynomials is $\\Theta(\\sqrt{n \\log n})$ too -- flat polynomials with $\\max = O(\\sqrt{n})$ do not exist for large $n$",
+      "**Chaining vs. moments**: The upper bound uses the chaining technique (entropy integral), while the lower bound uses the second moment method. This two-pronged approach is paradigmatic in the theory of suprema of stochastic processes",
+      "**Almost sure convergence**: The result holds with probability 1, not just in probability. This stronger statement uses Borel-Cantelli arguments and requires careful control of the probability tails"
     ]
   },
   "sections": [
     {
-      "id": "erd-s-problem-523-maximum-of-r",
-      "title": "Erdős Problem #523: Maximum of Random Polynomials on Unit Circle",
+      "id": "header",
+      "title": "Problem Header and Imports",
       "startLine": 1,
-      "endLine": 37,
-      "summary": "Erdős Problem #523: Maximum of Random Polynomials on Unit Circle"
+      "endLine": 36,
+      "summary": "Documentation header with references to Salem-Zygmund (1954), Halasz (1973), and Erdos (1961). Imports Mathlib modules for $\\mathbb{C}$, $\\mathbb{R}$, logarithms, finite sets, and big operators."
     },
     {
       "id": "random-polynomials",
       "title": "Random Polynomials",
-      "startLine": 38,
-      "endLine": 60,
-      "summary": "Random Polynomials"
+      "startLine": 42,
+      "endLine": 59,
+      "summary": "Defines `SignVector n` ($\\pm 1$ coefficient vectors), `IsValidSign` (validity predicate), `randomPolynomial` ($f(z) = \\sum \\varepsilon_k z^k$), `maxModulus` ($\\sup_{|z|=1} |f(z)|$), and `evalOnCircle` ($f(e^{i\\theta})$)."
     },
     {
-      "id": "the-scaling-function",
+      "id": "scaling",
       "title": "The Scaling Function",
-      "startLine": 61,
-      "endLine": 72,
-      "summary": "The Scaling Function"
+      "startLine": 65,
+      "endLine": 71,
+      "summary": "Defines `expectedScale n` $= \\sqrt{n \\log n}$ and `scaledMaxModulus` $= M_n / \\sqrt{n \\log n}$, the normalized ratio whose convergence is the central question."
     },
     {
-      "id": "salem-zygmund-result",
-      "title": "Salem-Zygmund Result",
-      "startLine": 73,
-      "endLine": 88,
-      "summary": "Salem-Zygmund Result"
+      "id": "salem-zygmund",
+      "title": "Salem-Zygmund Result (1954)",
+      "startLine": 79,
+      "endLine": 87,
+      "summary": "Axiomatizes the Salem-Zygmund theorem: $\\exists c_1, c_2 > 0$ bounding $\\max |f(z)|$ between $c_1 \\sqrt{n \\log n}$ and $c_2 \\sqrt{n \\log n}$ with high probability. Establishes the order but not the exact constant."
     },
     {
-      "id": "the-erd-s-question",
-      "title": "The Erdős Question",
-      "startLine": 89,
-      "endLine": 100,
-      "summary": "The Erdős Question"
+      "id": "erdos-question",
+      "title": "The Erdos Question (1961)",
+      "startLine": 93,
+      "endLine": 99,
+      "summary": "Formalizes Erdos's question: does $\\max |f(z)| = (C + o(1))\\sqrt{n \\log n}$ almost surely for some $C > 0$?"
     },
     {
-      "id": "hal-sz-s-theorem",
-      "title": "Halász's Theorem",
-      "startLine": 101,
-      "endLine": 122,
-      "summary": "Halász's Theorem"
+      "id": "halasz-theorem",
+      "title": "Halasz's Theorem (1973)",
+      "startLine": 107,
+      "endLine": 121,
+      "summary": "The definitive answer: YES with $C = 1$. Axiomatizes `halasz_theorem`, defines `halaszConstant = 1`, and proves `erdos_523_answer` by witnessing the existential."
     },
     {
       "id": "probabilistic-framework",
       "title": "Probabilistic Framework",
-      "startLine": 123,
-      "endLine": 143,
-      "summary": "Probabilistic Framework"
+      "startLine": 128,
+      "endLine": 142,
+      "summary": "Defines `probabilitySpace`, `uniformSignDistribution`, `AlmostSureConvergence C`, and axiomatizes `halasz_almost_sure` (a.s. convergence to $C = 1$)."
     },
     {
-      "id": "properties-of-random-polynomia",
-      "title": "Properties of Random Polynomials",
-      "startLine": 144,
-      "endLine": 165,
-      "summary": "Properties of Random Polynomials"
+      "id": "l2-analysis",
+      "title": "$L^2$ Analysis and Maximum-to-$L^2$ Gap",
+      "startLine": 148,
+      "endLine": 164,
+      "summary": "Defines `L2Norm` via integration over the circle. Axiomatizes $\\|f\\|_2 = \\sqrt{n+1}$ (Parseval) and the lower bound $M \\geq \\sqrt{n \\log n}/2$, quantifying the $\\sqrt{\\log n}$ gap between $L^2$ and $L^\\infty$ norms."
     },
     {
-      "id": "littlewood-polynomials",
+      "id": "littlewood",
       "title": "Littlewood Polynomials",
-      "startLine": 166,
-      "endLine": 184,
-      "summary": "Littlewood Polynomials"
+      "startLine": 170,
+      "endLine": 183,
+      "summary": "Defines `IsLittlewood` (polynomials with $\\pm 1$ coefficients), `LittlewoodProblem` (deterministic extremal question), and axiomatizes `typical_littlewood` (most Littlewood polynomials have $\\max \\approx \\sqrt{n \\log n}$)."
     },
     {
-      "id": "upper-and-lower-bounds",
+      "id": "bounds",
       "title": "Upper and Lower Bounds",
-      "startLine": 185,
-      "endLine": 204,
-      "summary": "Upper and Lower Bounds"
+      "startLine": 189,
+      "endLine": 203,
+      "summary": "Matching bounds: `upper_bound_high_prob` ($\\max \\leq (1+\\varepsilon)\\sqrt{n \\log n}$ w.h.p.) and `lower_bound_high_prob` ($\\max \\geq (1-\\varepsilon)\\sqrt{n \\log n}$ w.h.p.). Notes proof techniques: chaining for upper, second moment for lower."
     },
     {
-      "id": "related-problems",
+      "id": "related",
       "title": "Related Problems",
-      "startLine": 205,
-      "endLine": 223,
-      "summary": "Related Problems"
+      "startLine": 210,
+      "endLine": 222,
+      "summary": "Defines `RudinConjecture` (minimum max over Littlewood polynomials), `mahlerMeasure` (geometric mean on circle), and `szegoConnection` (Toeplitz determinant link)."
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "startLine": 224,
-      "endLine": 255,
-      "summary": "Summary"
+      "title": "Summary: SOLVED",
+      "startLine": 238,
+      "endLine": 253,
+      "summary": "Four concluding theorems: `erdos_523`, `erdos_523_constant` ($C = 1$), `erdos_523_main`, and `erdos_523_solved`. **Status: Completely solved by Halasz (1973).**"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Replaced 18 shallow annotations (1-line content, no mathContext) with 13 comprehensive annotations covering all sections of the Lean proof
- All annotations now have mathContext, relatedConcepts, prerequisites, and significance
- Deepened historicalContext with Salem-Zygmund (1954), Halász (1973) narrative
- Improved keyInsights with bold formatting and mathematical depth (√(n log n) decomposition, chaining vs moments)
- Rewrote all 12 section summaries from title-only to substantive LaTeX descriptions

## Test plan
- [x] `pnpm annotations:build` passes (non-strict warnings for axiom lines expected)
- [x] JSON valid and schema-compliant

🤖 Generated with [Claude Code](https://claude.com/claude-code)