### PR TITLE
enrich: deepen annotations and meta for erdos-588

### DIFF
--- a/src/data/proofs/erdos-588/annotations.json
+++ b/src/data/proofs/erdos-588/annotations.json
@@ -1,74 +1,74 @@
 [
   {
-    "id": "ann-588-1",
+    "id": "ann-588-imports",
     "proofId": "erdos-588",
-    "range": {
-      "startLine": 1,
-      "endLine": 22
-    },
+    "range": { "startLine": 24, "endLine": 28 },
     "type": "concept",
-    "title": "Problem Overview",
-    "content": "Erd\u0151s Problem #588: Collinear Points in Planar Configurations. Status: OPEN",
-    "significance": "critical"
+    "title": "Imports and Namespace",
+    "content": "Imports `Real.Basic` for real number arithmetic (needed for asymptotic bounds like $n^{2 - c/\\sqrt{\\log n}}$), `Nat.Basic` for natural number operations, and `Finset.Basic` for finite set operations on point configurations. Opens the `Erdos588` namespace.",
+    "significance": "supporting",
+    "mathContext": "The formalization works with $\\mathbb{R}$ for the asymptotic statements (little-$o$ notation, real exponents) and $\\mathbb{N}$ for the discrete combinatorial quantities ($f_k(n)$, point counts). The `Real.sqrt` and `Real.log` functions from Mathlib are needed to express the Solymosi-Stojaković lower bound $n^{2 - c/\\sqrt{\\log n}}$, which involves real-valued exponents that depend on $n$.",
+    "relatedConcepts": ["Real arithmetic", "Finset", "asymptotic notation", "namespace"],
+    "prerequisites": ["Mathlib.Data.Real.Basic", "Mathlib.Data.Nat.Basic"]
   },
   {
-    "id": "ann-588-2",
+    "id": "ann-588-defs",
     "proofId": "erdos-588",
-    "range": {
-      "startLine": 37,
-      "endLine": 41
-    },
+    "range": { "startLine": 34, "endLine": 42 },
     "type": "definition",
-    "title": "F",
-    "content": "f_k(n): the maximum number of lines containing at least k points, minimized over all configurations of n points with no k+1 collinear.",
-    "significance": "key"
+    "title": "Point Type and Extremal Function $f_k(n)$",
+    "content": "`Point := ℝ × ℝ` models points in the Euclidean plane. `f (k n : ℕ) : ℕ` (axiom) is the extremal function: the maximum number of lines containing $\\ge k$ points, over all configurations of $n$ points with no $k+1$ collinear.",
+    "significance": "critical",
+    "mathContext": "The extremal function $f_k(n)$ is defined as $\\max \\{ |\\mathcal{L}_k(P)| : P \\subseteq \\mathbb{R}^2, |P| = n, \\text{no } k+1 \\text{ collinear} \\}$ where $\\mathcal{L}_k(P) = \\{ \\ell : |\\ell \\cap P| \\ge k \\}$ is the set of $k$-rich lines. The axiomatization of $f$ as an opaque function (rather than a computed definition) is necessary because actually computing this extremal quantity requires an optimization over all possible point configurations — a fundamentally non-constructive operation. The `Point := ℝ × ℝ` abbreviation suffices for the formal statements though the actual arguments work in any configuration space.",
+    "relatedConcepts": ["extremal function", "k-rich lines", "general position", "point configuration", "incidence geometry"],
+    "prerequisites": ["Real arithmetic", "Nat", "point-line incidence"]
   },
   {
-    "id": "ann-588-3",
+    "id": "ann-588-sylvester",
     "proofId": "erdos-588",
-    "range": {
-      "startLine": 47,
-      "endLine": 55
-    },
-    "type": "axiom",
-    "title": "Sylvester K3",
-    "content": "**Sylvester's Theorem**: f\u2083(n) = n\u00b2/6 + O(n).  For configurations with no 4 collinear points, the number of lines through at least 3 points is approximately n\u00b2/6. \u2203 C : \u211d, C > 0 \u2227 \u2200 n : \u2115, n \u2265 3 \u2192 |(f 3 n : \u211d) - (n : \u211d)^2 / 6| \u2264 C * n",
-    "significance": "key"
-  },
-  {
-    "id": "ann-588-4",
-    "proofId": "erdos-588",
-    "range": {
-      "startLine": 61,
-      "endLine": 67
-    },
-    "type": "axiom",
-    "title": "Lower Bound K4",
-    "content": "**Known lower bound**: f_k(n) \u226b n^{2 - c/\u221a(log n)} for some constant c > 0. This is close to n\u00b2 but not quite o(n\u00b2). \u2203 c : \u211d, c > 0 \u2227 \u2200 n : \u2115, n \u2265 3 \u2192 (f 4 n : \u211d) \u2265 (n : \u211d) ^ (2 - c / Real.sqrt (Real.log n))",
-    "significance": "key"
-  },
-  {
-    "id": "ann-588-5",
-    "proofId": "erdos-588",
-    "range": {
-      "startLine": 69,
-      "endLine": 78
-    },
-    "type": "axiom",
-    "title": "Erdos Conjecture K4",
-    "content": "**Erd\u0151s's Conjecture (OPEN)**: f_k(n) = o(n\u00b2) for k \u2265 4.  That is, requiring at most k collinear points (k \u2265 4) should force the number of k-rich lines to be strictly subquadratic. \u2200 k : \u2115, k \u2265 4 \u2192 \u2200 \u03b5 : \u211d, \u03b5 > 0 \u2192 \u2203 N\u2080 : \u2115, \u2200 n : \u2115, n \u2265 N\u2080 \u2192 (f k n : \u211d) \u2264 \u03b5 * (n : \u211d)^2",
-    "significance": "core"
-  },
-  {
-    "id": "ann-588-6",
-    "proofId": "erdos-588",
-    "range": {
-      "startLine": 84,
-      "endLine": 93
-    },
+    "range": { "startLine": 48, "endLine": 56 },
     "type": "theorem",
-    "title": "Erdos 588",
-    "content": "The k = 3 case is resolved (Sylvester). The k \u2265 4 case remains open: is f_k(n) = o(n\u00b2)? \u2203 C : \u211d, C > 0 \u2227 \u2200 n : \u2115, n \u2265 3 \u2192 |(f 3 n : \u211d) - (n : \u211d)^2 / 6| \u2264 C * n := sylvester_k3",
-    "significance": "core"
+    "title": "Sylvester's Theorem: The $k=3$ Case",
+    "content": "`sylvester_k3` (axiom): $\\exists C > 0$ such that $|f_3(n) - n^2/6| \\le Cn$ for all $n \\ge 3$. This determines $f_3(n) = n^2/6 + O(n)$, showing the $k=3$ case gives $\\Theta(n^2)$ lines.",
+    "significance": "critical",
+    "mathContext": "The result $f_3(n) = n^2/6 + O(n)$ shows that for 3-rich lines (the weakest non-trivial case), the count is quadratic. The constant $1/6$ arises from the **Sylvester-Gallai** framework: $n$ points in general position determine $\\binom{n}{2} = n(n-1)/2$ lines, and each line contains exactly 2 points unless it is 3-rich. The 3-rich lines account for $\\sim n^2/6$ of these, as each such line 'absorbs' $\\binom{k}{2} \\ge 3$ pairs. This quadratic behavior for $k=3$ is exactly why the conjecture requires $k \\ge 4$ — the problem asks whether the transition from $k=3$ to $k=4$ causes a qualitative drop from $\\Theta(n^2)$ to $o(n^2)$.",
+    "relatedConcepts": ["Sylvester-Gallai theorem", "3-rich lines", "quadratic count", "general position", "binomial pairs"],
+    "prerequisites": ["f (extremal function)", "Real.abs", "asymptotic notation"]
+  },
+  {
+    "id": "ann-588-lower",
+    "proofId": "erdos-588",
+    "range": { "startLine": 62, "endLine": 68 },
+    "type": "theorem",
+    "title": "Solymosi-Stojaković Lower Bound",
+    "content": "`lower_bound_k4` (axiom): $\\exists c > 0$ such that $f_4(n) \\ge n^{2 - c/\\sqrt{\\log n}}$ for all $n \\ge 3$. This gives $f_4(n) \\ge n^{2-o(1)}$, tantalizingly close to $n^2$ but still consistent with $o(n^2)$.",
+    "significance": "critical",
+    "mathContext": "**József Solymosi** and **Miloš Stojaković** (2013) constructed point configurations achieving $n^{2-O(1/\\sqrt{\\log n})}$ 4-rich lines. Their construction uses a probabilistic argument on lattice points: take points on a $\\sqrt{n} \\times \\sqrt{n}$ integer grid, then apply a random projective transformation. The grid structure creates many collinear 4-tuples (lines of the form $ax + by = c$ with integer parameters), and the transformation preserves collinearity while destroying unwanted 5-point alignments. The exponent $2 - c/\\sqrt{\\log n}$ tends to $2$ but slower than any polynomial — it approaches $n^2$ at a rate determined by the number-theoretic structure of grid collinearities. This lower bound replaced earlier results: **Kárteszi** (1963) showed $f_k(n) \\ge \\Omega(n \\log n)$ and **Grünbaum** (1976) showed $f_k(n) \\ge \\Omega(n^{1+1/(k-2)})$.",
+    "relatedConcepts": ["Solymosi-Stojaković construction", "lattice points", "projective transformation", "subquadratic gap", "Kárteszi bound", "Grünbaum bound"],
+    "prerequisites": ["f (extremal function)", "Real.sqrt", "Real.log"]
+  },
+  {
+    "id": "ann-588-conjecture",
+    "proofId": "erdos-588",
+    "range": { "startLine": 70, "endLine": 79 },
+    "type": "theorem",
+    "title": "The Erdős Conjecture: $f_k(n) = o(n^2)$",
+    "content": "`erdos_conjecture_k4` (axiom): $\\forall k \\ge 4,\\, \\forall \\varepsilon > 0,\\, \\exists N_0$ such that $f_k(n) \\le \\varepsilon n^2$ for $n \\ge N_0$. This is the $\\varepsilon$-$N$ formulation of $f_k(n) = o(n^2)$.",
+    "significance": "critical",
+    "mathContext": "The conjecture asks whether the quadratic barrier breaks at $k=4$. The $\\varepsilon$-$N$ formulation is the standard definition of little-$o$: $f_k(n) = o(n^2)$ means $f_k(n)/n^2 \\to 0$ as $n \\to \\infty$. This is a stronger statement than just $f_k(n) < n^2$ — it says the ratio tends to zero, meaning $k$-rich lines become negligible compared to the total number of point pairs. The conjecture is related to the **Szemerédi-Trotter theorem** (1983), which gives $I(P, \\mathcal{L}) \\le O(n^{2/3}m^{2/3} + n + m)$ for incidences between $n$ points and $m$ lines. If every line is $k$-rich, then the total incidence count is $\\ge km$, and Szemerédi-Trotter gives $km \\le O(n^{2/3}m^{2/3} + n + m)$, yielding $m \\le O(n^2/k^3)$ for $m \\gg n$ — but this only gives $O(n^2)$, not $o(n^2)$, so the conjecture requires going beyond Szemerédi-Trotter. Erdős offered a **\\$100 prize** for its resolution.",
+    "relatedConcepts": ["little-o notation", "Szemerédi-Trotter theorem", "incidence bounds", "k-rich line count", "Erdős prize"],
+    "prerequisites": ["f (extremal function)", "Real arithmetic", "limit definitions"]
+  },
+  {
+    "id": "ann-588-main",
+    "proofId": "erdos-588",
+    "range": { "startLine": 91, "endLine": 94 },
+    "type": "theorem",
+    "title": "Main Theorem: Resolved $k=3$ Case",
+    "content": "`erdos_588`: restates `sylvester_k3` as the main proved result — $f_3(n) = n^2/6 + O(n)$. The $k \\ge 4$ conjecture remains **OPEN**. Proved by `exact sylvester_k3`.",
+    "significance": "key",
+    "mathContext": "The main theorem records the current state of knowledge: the $k=3$ case is completely resolved while $k \\ge 4$ remains open. The formalization honestly reflects this by proving only what is known (the Sylvester result) while axiomatizing the conjecture. The gap between the resolved $k=3$ (quadratic) and conjectured $k \\ge 4$ (subquadratic) represents one of the most tantalizing open problems in discrete geometry — a phase transition in the structure of point-line incidences that has resisted proof for over 50 years despite the Solymosi-Stojaković lower bound coming within $n^{o(1)}$ of the quadratic barrier.",
+    "relatedConcepts": ["open problem", "phase transition at k=4", "Sylvester result", "discrete geometry"],
+    "prerequisites": ["sylvester_k3", "erdos_conjecture_k4"]
   }
 ]

--- a/src/data/proofs/erdos-588/meta.json
+++ b/src/data/proofs/erdos-588/meta.json
@@ -73,10 +73,34 @@
         "citation": "Solymosi, J. and Stojaković, M., Many collinear k-tuples with no k+1 collinear points, DCG (2013)",
         "type": "paper"
       }
-    ]
+    ],
+    "dateUpdated": "2026-02-12",
+    "mathContext": {
+      "field": "Discrete Geometry",
+      "subfield": "Point-Line Incidences",
+      "difficulty": "research-level",
+      "keyTechniques": [
+        "Sylvester-Gallai theorem for k=3 baseline",
+        "Lattice point constructions with projective transformations (Solymosi-Stojaković)",
+        "Szemerédi-Trotter incidence bounds",
+        "Extremal function analysis over point configurations",
+        "Number-theoretic structure of grid collinearities"
+      ],
+      "prerequisites": [
+        "Point-line incidence geometry in the plane",
+        "Asymptotic notation (little-o, big-O, big-Theta)",
+        "Szemerédi-Trotter theorem (conceptual)",
+        "Extremal combinatorics and counting arguments"
+      ],
+      "consequences": [
+        "Would establish a phase transition in k-rich line counts at k=4",
+        "Would complement Szemerédi-Trotter with a qualitative structural result",
+        "Connections to the orchard problem and collinear point triples"
+      ]
+    }
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #588: k-Point Lines**\n\nThis problem generalizes Problem #101 (the k=4 case). It asks about the maximum number of 'k-rich' lines (lines containing ≥k points) when no k+1 points are collinear.\n\n**Key History:**\n- Sylvester: f_3(n) = n²/6 + O(n), so k≥4 is necessary\n- Kárteszi (1963): f_k(n) ≥ Ω(n log n)\n- Grünbaum (1976): f_k(n) ≥ Ω(n^{1+1/(k-2)})\n- Solymosi-Stojaković (2013): f_k(n) ≥ n^{2-o(1)}\n\nThe conjecture f_k(n) = o(n²) remains OPEN despite the lower bound being extremely close to n².",
+    "historicalContext": "**Erdős Problem #588: k-Point Lines in General Position**\n\nThis problem, posed by Paul Erdős in the 1970s with a $100 prize, generalizes Problem #101 (the $k=4$ case). It asks about the maximum number of '$k$-rich' lines (lines containing $\\ge k$ points) when no $k+1$ points are collinear.\n\n**The Function $f_k(n)$**: Given $n$ points in $\\mathbb{R}^2$ with no $k+1$ collinear, $f_k(n)$ is the maximum number of lines through $\\ge k$ points.\n\n**Key Developments:**\n- **Sylvester**: Established $f_3(n) = n^2/6 + O(n)$ — the $k=3$ case is quadratic, motivating the question for $k \\ge 4$\n- **Kárteszi (1963)**: Proved $f_k(n) \\ge \\Omega(n \\log n)$ using combinatorial constructions, showing the function grows superlinearly\n- **Grünbaum (1976)**: Improved to $f_k(n) \\ge \\Omega(n^{1+1/(k-2)})$ using algebraic configurations. For $k=4$ this gives $\\Omega(n^{3/2})$\n- **Solymosi-Stojaković (2013)**: Achieved $f_k(n) \\ge n^{2-O(1/\\sqrt{\\log n})}$ via lattice-point constructions with projective transformations. This is $n^{2-o(1)}$, tantalizingly close to $n^2$\n\n**The Conjecture**: Is $f_k(n) = o(n^2)$ for $k \\ge 4$? Despite the Solymosi-Stojaković lower bound being extremely close to $n^2$, the conjecture asserts $f_k(n)/n^2 \\to 0$. The $\\$100$ prize remains unclaimed.\n\n**Connection to Szemerédi-Trotter**: The incidence theorem gives $O(n^2/k^3)$ as an upper bound for $k$-rich lines, which is $O(n^2)$ — matching the trivial bound. Going below quadratic requires structural arguments beyond incidence counting.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nLet f_k(n) be the minimum such that if n points in R² have no k+1 points collinear, then there are at most f_k(n) lines containing at least k points.\n\n**Conjecture:** f_k(n) = o(n²) for k ≥ 4.\n\n**Known Bounds:**\n- Lower: f_k(n) ≥ n^{2 - O(1/√log n)} (Solymosi-Stojaković)\n- Upper: f_k(n) ≤ O(n²) (trivial)\n\n**Prize:** $100",
     "proofStrategy": "**Formalization Approach**\n\n1. **Geometry:** Define Point, Line, OnLine for plane geometry.\n2. **General Position:** Define InKGeneralPosition (no k+1 collinear).\n3. **k-Rich Lines:** Define IsKRich and the counting function f_k.\n4. **Known Results:** Axiomatize bounds from Sylvester, Kárteszi, Grünbaum, Solymosi-Stojaković.\n5. **Conjecture:** State the o(n²) conjecture formally.\n6. **Connections:** Link to Szemerédi-Trotter and Problem #101.",
     "keyInsights": [
@@ -90,67 +114,32 @@
   },
   "sections": [
     {
-      "id": "geometry",
-      "title": "Point Configurations and Lines",
-      "summary": "Point, Line, OnLine, Collinear",
-      "startLine": 43,
-      "endLine": 63
+      "id": "definitions",
+      "title": "Part I: Definitions",
+      "summary": "Defines `Point := ℝ × ℝ` and axiomatizes the extremal function `f (k n : ℕ) : ℕ` representing the maximum number of $k$-rich lines for $n$ points with no $k+1$ collinear.",
+      "startLine": 34,
+      "endLine": 42
     },
     {
-      "id": "general-position",
-      "title": "General Position",
-      "summary": "InKGeneralPosition, In4GeneralPosition",
-      "startLine": 65,
+      "id": "sylvester",
+      "title": "Part II: The $k=3$ Case (Resolved)",
+      "summary": "Axiomatizes `sylvester_k3`: $\\exists C > 0,\\, |f_3(n) - n^2/6| \\le Cn$ for $n \\ge 3$. This gives $f_3(n) = n^2/6 + O(n) = \\Theta(n^2)$, showing the $k=3$ case is quadratic.",
+      "startLine": 48,
+      "endLine": 56
+    },
+    {
+      "id": "k4-open",
+      "title": "Part III: The $k \\ge 4$ Case (Open)",
+      "summary": "Axiomatizes `lower_bound_k4`: $f_4(n) \\ge n^{2 - c/\\sqrt{\\log n}}$ (Solymosi-Stojaković 2013). Axiomatizes `erdos_conjecture_k4`: the $\\varepsilon$-$N$ formulation of $f_k(n) = o(n^2)$ for $k \\ge 4$.",
+      "startLine": 62,
       "endLine": 79
     },
     {
-      "id": "k-rich",
-      "title": "k-Rich Lines",
-      "summary": "IsKRich, kRichLines, f_k",
-      "startLine": 81,
-      "endLine": 114
-    },
-    {
-      "id": "known-results",
-      "title": "Known Results",
-      "summary": "Sylvester, Kárteszi, Grünbaum, Solymosi-Stojaković",
-      "startLine": 116,
-      "endLine": 146
-    },
-    {
-      "id": "conjecture",
-      "title": "The Erdős Conjecture",
-      "summary": "erdos_588_conjecture, limit form",
-      "startLine": 148,
-      "endLine": 168
-    },
-    {
-      "id": "trivial-bounds",
-      "title": "Trivial Bounds",
-      "summary": "Upper O(n²), Lower Ω(n)",
-      "startLine": 170,
-      "endLine": 181
-    },
-    {
-      "id": "k4-case",
-      "title": "Special Case k=4",
-      "summary": "problem_101 connection",
-      "startLine": 183,
-      "endLine": 194
-    },
-    {
-      "id": "connections",
-      "title": "Connections to Incidence Geometry",
-      "summary": "Szemerédi-Trotter theorem",
-      "startLine": 196,
-      "endLine": 211
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "Status and open nature",
-      "startLine": 213,
-      "endLine": 249
+      "id": "main-theorem",
+      "title": "Part IV: Main Theorem",
+      "summary": "`erdos_588` restates `sylvester_k3` as the proved result. The $k \\ge 4$ conjecture remains **OPEN**. Prize: $\\$100$.",
+      "startLine": 91,
+      "endLine": 94
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Replaced 6 shallow annotations (invalid types "axiom"/"core", no mathContext/relatedConcepts/prerequisites) with 6 comprehensive annotations with full fields
- Added top-level mathContext field to meta.json with keyTechniques, prerequisites, and consequences
- Deepened historicalContext with Kárteszi, Grünbaum, Solymosi-Stojaković details and Szemerédi-Trotter connection
- Rewrote section summaries with LaTeX notation, corrected to match actual Lean file structure (4 parts, not 9)
- Added dateUpdated field

## Test plan
- [x] `pnpm annotations:build` passes (no warnings for erdos-588)
- [x] JSON valid and well-formed

🤖 Generated with [Claude Code](https://claude.com/claude-code)