### PR TITLE
enrich: deepen annotations and meta for erdos-606

### DIFF
--- a/src/data/proofs/erdos-606/annotations.json
+++ b/src/data/proofs/erdos-606/annotations.json
@@ -3,10 +3,25 @@
     "id": "ann-606-header",
     "proofId": "erdos-606",
     "range": { "startLine": 1, "endLine": 28 },
-    "type": "concept",
-    "title": "Problem Statement",
-    "content": "Erdős Problem #606: Given n distinct points in ℝ², what values can f(n) take, where f(n) is the number of distinct lines determined by these points? The Erdős-Salamon theorem gives a complete characterization for large n.",
-    "significance": "critical"
+    "type": "context",
+    "title": "Problem Statement and References",
+    "content": "Erdős Problem #606: Given $n$ distinct points in $\\mathbb{R}^2$, what values can $f(n)$ take, where $f(n)$ is the number of distinct lines determined by these points? The Erdős-Salamon theorem gives a complete characterization for large $n$: the achievable values are $\\{1\\} \\cup [n, \\binom{n}{2}] \\setminus \\{\\binom{n}{2}-1, \\binom{n}{2}-3\\}$.",
+    "mathContext": "The problem asks for the exact set $\\mathcal{A}(n) = \\{k \\in \\mathbb{N} : \\exists \\text{ config } P \\text{ of } n \\text{ points with } f(P) = k\\}$. The answer involves the binomial coefficient $\\binom{n}{2} = \\frac{n(n-1)}{2}$, which counts the maximum number of lines when no three points are collinear.",
+    "significance": "critical",
+    "relatedConcepts": ["Sylvester-Gallai theorem", "Beck's theorem", "incidence geometry", "combinatorial geometry"],
+    "prerequisites": ["Euclidean geometry", "combinatorics", "binomial coefficients"]
+  },
+  {
+    "id": "ann-606-imports",
+    "proofId": "erdos-606",
+    "range": { "startLine": 30, "endLine": 38 },
+    "type": "context",
+    "title": "Mathlib Imports",
+    "content": "Imports from Mathlib for inner product spaces (defining $\\mathbb{R}^2$ as `EuclideanSpace ℝ (Fin 2)`), finite set cardinality, affine independence, and general tactics. The use of `EuclideanSpace` provides a concrete model of the Euclidean plane with the standard inner product.",
+    "mathContext": "The type `EuclideanSpace ℝ (Fin 2)` is isomorphic to $\\mathbb{R}^2$ with the $\\ell^2$ norm, providing the geometric structure needed for points and lines.",
+    "significance": "context",
+    "relatedConcepts": ["Euclidean space", "inner product space", "affine space"],
+    "prerequisites": ["linear algebra", "Mathlib type system"]
   },
   {
     "id": "ann-606-point",
@@ -14,44 +29,47 @@
     "range": { "startLine": 41, "endLine": 47 },
     "type": "definition",
     "title": "Point Configuration",
-    "content": "A point configuration is n distinct points in the Euclidean plane ℝ². Distinctness is crucial - coincident points would trivially reduce line counts. The injective function ensures all n points are different.",
-    "significance": "key"
+    "content": "A point in the plane is defined as an element of `EuclideanSpace ℝ (Fin 2)`. A point configuration bundles $n$ points with a proof of injectivity (distinctness). The `Function.Injective` constraint ensures $|P| = n$ exactly — without it, repeated points could artificially deflate line counts.",
+    "mathContext": "A configuration is a map $P: \\{1, \\ldots, n\\} \\to \\mathbb{R}^2$ with $P(i) \\neq P(j)$ for $i \\neq j$. The injectivity condition $P(i) = P(j) \\Rightarrow i = j$ formalizes distinctness.",
+    "significance": "key",
+    "relatedConcepts": ["injective function", "point set", "finite configuration"],
+    "prerequisites": ["set theory", "function injectivity"]
   },
   {
     "id": "ann-606-line",
     "proofId": "erdos-606",
     "range": { "startLine": 49, "endLine": 62 },
     "type": "definition",
-    "title": "Lines in ℝ²",
-    "content": "A line is determined by two distinct points p and q. Lines are equivalent if they contain the same set of points. A point x lies on line (p,q) iff x = p + t(q-p) for some real t (parametric form).",
-    "significance": "key"
+    "title": "Lines and Line Equivalence",
+    "content": "A line is defined parametrically by two distinct points $p \\neq q$. The equivalence relation `Line.equiv` identifies lines that contain the same set of points, so the line through $(p,q)$ equals the line through $(q,p)$ or any other pair on the same line. The `onLine` predicate checks if $x$ lies on the line through $p$ and $q$.",
+    "mathContext": "A point $x$ lies on line $\\ell(p,q)$ iff $x = p + t(q - p)$ for some $t \\in \\mathbb{R}$. Two lines $\\ell_1, \\ell_2$ are equivalent iff $\\{x : x \\in \\ell_1\\} = \\{x : x \\in \\ell_2\\}$. This parametric form avoids the slope-intercept representation, which fails for vertical lines.",
+    "significance": "key",
+    "relatedConcepts": ["parametric equation", "affine line", "equivalence relation"],
+    "prerequisites": ["linear algebra", "parametric curves"]
   },
   {
-    "id": "ann-606-maxlines",
+    "id": "ann-606-counting",
     "proofId": "erdos-606",
-    "range": { "startLine": 80, "endLine": 81 },
+    "range": { "startLine": 64, "endLine": 81 },
     "type": "definition",
-    "title": "Maximum Lines",
-    "content": "The maximum number of distinct lines from n points is C(n,2) = n(n-1)/2, achieved when no three points are collinear. Each pair determines a unique line, and all C(n,2) pairs give different lines.",
-    "significance": "critical"
+    "title": "Counting Distinct Lines",
+    "content": "The `distinctPairs` function enumerates ordered pairs $(i,j)$ with $i < j$, giving $\\binom{n}{2}$ pairs. The function `numDistinctLines` counts equivalence classes of lines under `Line.equiv` — this is the key quantity $f(n)$ in the problem. The `maxLines` function computes the upper bound $\\binom{n}{2}$.",
+    "mathContext": "$|\\{(i,j) : 1 \\le i < j \\le n\\}| = \\binom{n}{2} = \\frac{n(n-1)}{2}$. When no three points are collinear, each pair determines a unique line, so $f(n) = \\binom{n}{2}$. In general $f(n) \\le \\binom{n}{2}$ with equality iff points are in general position.",
+    "significance": "key",
+    "relatedConcepts": ["binomial coefficient", "equivalence classes", "general position"],
+    "prerequisites": ["combinatorics", "equivalence relations"]
   },
   {
     "id": "ann-606-collinear",
     "proofId": "erdos-606",
-    "range": { "startLine": 85, "endLine": 91 },
+    "range": { "startLine": 85, "endLine": 106 },
     "type": "definition",
-    "title": "Collinearity",
-    "content": "Three points are collinear if they all lie on a common line. If ALL n points are collinear, they determine exactly 1 line. This is the minimum possible line count for any configuration.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-606-general",
-    "proofId": "erdos-606",
-    "range": { "startLine": 93, "endLine": 106 },
-    "type": "definition",
-    "title": "General Position",
-    "content": "Points are in 'general position' if no three are collinear. This is the generic case - random points are almost surely in general position. General position achieves the maximum C(n,2) lines.",
-    "significance": "key"
+    "title": "Collinearity and General Position",
+    "content": "Three points are collinear if they share a common line. `AllCollinear` means every triple is collinear (all $n$ points on one line), giving $f(n) = 1$. `GeneralPosition` means no triple is collinear, giving $f(n) = \\binom{n}{2}$. These are the two extremes of the problem, and the theorems `all_collinear_one_line` and `general_position_max_lines` confirm these boundary values.",
+    "mathContext": "Points $p, q, r$ are collinear iff $\\det(q - p, r - p) = 0$, equivalently iff the vectors $q - p$ and $r - p$ are linearly dependent. General position ($\\forall i \\neq j \\neq k$, not collinear) is a generic condition — it holds for a dense open subset of $(\\mathbb{R}^2)^n$.",
+    "significance": "key",
+    "relatedConcepts": ["linear dependence", "determinant test", "generic position", "algebraic variety"],
+    "prerequisites": ["linear algebra", "determinants"]
   },
   {
     "id": "ann-606-ordinary",
@@ -59,133 +77,142 @@
     "range": { "startLine": 110, "endLine": 112 },
     "type": "definition",
     "title": "Ordinary Line",
-    "content": "An ordinary line contains exactly 2 points of the configuration. The Sylvester-Gallai theorem guarantees at least one ordinary line exists for any non-collinear configuration.",
-    "significance": "key"
+    "content": "An ordinary line passes through exactly 2 points of the configuration. The Sylvester-Gallai theorem guarantees at least one such line whenever the points are not all collinear. This notion is central to the Erdős-Salamon analysis because ordinary lines are the 'simplest' incidence pattern.",
+    "mathContext": "A line $\\ell$ is ordinary for configuration $P$ if $|\\ell \\cap P| = 2$. Equivalently, $\\ell$ is determined by exactly one pair of points from $P$. The dual notion is a $k$-rich line with $|\\ell \\cap P| = k \\ge 3$.",
+    "significance": "key",
+    "relatedConcepts": ["k-rich line", "point-line duality", "ordinary point"],
+    "prerequisites": ["incidence geometry"]
   },
   {
     "id": "ann-606-sylvester",
     "proofId": "erdos-606",
-    "range": { "startLine": 114, "endLine": 121 },
-    "type": "axiom",
-    "title": "Sylvester-Gallai Theorem",
-    "content": "If n ≥ 3 points are not all collinear, they determine at least one ordinary line (containing exactly 2 points). This classical result dates to Sylvester (1893) with a proof by Gallai (1944).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-606-minlines",
-    "proofId": "erdos-606",
-    "range": { "startLine": 123, "endLine": 126 },
-    "type": "theorem",
-    "title": "Minimum Lines (Non-collinear)",
-    "content": "Corollary of Sylvester-Gallai: if points are not all collinear, they determine at least n lines. This follows by induction using the ordinary line guaranteed by the theorem.",
-    "significance": "key"
+    "range": { "startLine": 114, "endLine": 126 },
+    "type": "technique",
+    "title": "Sylvester-Gallai Theorem and Minimum Lines",
+    "content": "The Sylvester-Gallai theorem (1893/1944): if $n \\ge 3$ points are not all collinear, they determine at least one ordinary line. This is axiomatized here since its full proof requires non-trivial arguments (Gallai's proof uses an extremal distance argument). The corollary `min_lines_noncollinear` shows non-collinear points determine $\\ge n$ lines — a key lower bound for the Erdős-Salamon characterization.",
+    "mathContext": "Sylvester-Gallai: $\\neg\\text{AllCollinear}(P) \\Rightarrow \\exists \\ell, |\\ell \\cap P| = 2$. The minimum lines bound $f(n) \\ge n$ for non-collinear configurations follows by induction: remove an ordinary line's 2 points, apply to the remaining $n-2$ points, and account for the new lines created.",
+    "significance": "critical",
+    "relatedConcepts": ["Gallai's proof", "Melchior's inequality", "Kelly's proof", "extremal principle"],
+    "prerequisites": ["projective geometry", "well-ordering principle"]
   },
   {
     "id": "ann-606-achievable",
     "proofId": "erdos-606",
-    "range": { "startLine": 130, "endLine": 143 },
-    "type": "definition",
-    "title": "Achievable Line Counts",
-    "content": "AchievableLineCounts(n) is the set of integers k such that some configuration of n points determines exactly k lines. The main problem is to characterize this set completely.",
-    "significance": "critical"
+    "range": { "startLine": 128, "endLine": 143 },
+    "type": "concept",
+    "title": "Achievable Line Counts and Main Problem",
+    "content": "The set `AchievableLineCounts(n)` formalizes the central question: which integers $k$ can equal $f(n)$ for some configuration of $n$ points? The `Erdos606Statement` captures the structure of the answer — it includes 1 (collinear case) and almost all values in $[n, \\binom{n}{2}]$, with the two specific exceptions.",
+    "mathContext": "$\\mathcal{A}(n) = \\{k \\in \\mathbb{N} : \\exists P \\text{ with } |P| = n, f(P) = k\\}$. The Erdős-Salamon theorem states: for $n \\ge N_0$, $\\mathcal{A}(n) = \\{1\\} \\cup \\{k : n \\le k \\le \\binom{n}{2}\\} \\setminus \\{\\binom{n}{2} - 1, \\binom{n}{2} - 3\\}$.",
+    "significance": "critical",
+    "relatedConcepts": ["spectrum problem", "realizability", "inverse problems in combinatorics"],
+    "prerequisites": ["set theory", "combinatorial geometry"]
   },
   {
     "id": "ann-606-minus1",
     "proofId": "erdos-606",
     "range": { "startLine": 147, "endLine": 153 },
-    "type": "axiom",
+    "type": "insight",
     "title": "C(n,2)-1 Not Achievable",
-    "content": "You cannot achieve exactly C(n,2)-1 lines for n ≥ 4. This would require exactly one pair of points to lie on a line containing a third point, while all other pairs determine unique lines - geometrically impossible.",
-    "significance": "critical"
+    "content": "The value $\\binom{n}{2} - 1$ is not achievable for $n \\ge 4$. To have exactly one 'missing' line, exactly one pair of points would need to be collinear with a third point, while all other triples are non-collinear. But if points $p, q, r$ are collinear, this collinearity forces $\\binom{3}{2} - 1 = 2$ 'missing' lines (pairs $(p,q)$, $(p,r)$, $(q,r)$ all determine the same line), not just 1.",
+    "mathContext": "If three points are collinear, they reduce the line count by $\\binom{3}{2} - 1 = 2$, not by 1. More generally, $k$ collinear points reduce the count by $\\binom{k}{2} - 1$. Since $\\binom{k}{2} - 1 \\ge 2$ for $k \\ge 3$, a reduction of exactly 1 is impossible.",
+    "significance": "critical",
+    "relatedConcepts": ["collinearity reduction formula", "pigeonhole principle", "geometric rigidity"],
+    "prerequisites": ["combinatorics", "proof by contradiction"]
   },
   {
     "id": "ann-606-minus3",
     "proofId": "erdos-606",
     "range": { "startLine": 155, "endLine": 161 },
-    "type": "axiom",
+    "type": "insight",
     "title": "C(n,2)-3 Not Achievable",
-    "content": "You cannot achieve exactly C(n,2)-3 lines for n ≥ 6. The geometric analysis shows this intermediate value is impossible - you can't have exactly the right pattern of collinearities.",
-    "significance": "critical"
+    "content": "The value $\\binom{n}{2} - 3$ is not achievable for $n \\ge 6$. A reduction of 3 from the maximum would require a specific pattern of collinearities. Case analysis shows: one 4-point line gives reduction $\\binom{4}{2} - 1 = 5$; two disjoint 3-point lines give $2 \\times 2 = 4$; one 3-point line gives reduction 2. No combination yields exactly 3.",
+    "mathContext": "The line count reduction from collinearities is $\\sum_\\ell (\\binom{m_\\ell}{2} - 1)$ where $m_\\ell \\ge 3$ is the number of points on each $\\ge 3$-rich line $\\ell$. Since each term $\\binom{m}{2} - 1 \\ge 2$, the possible reductions are $\\{0, 2, 4, 5, 6, \\ldots\\}$, and 3 is excluded.",
+    "significance": "critical",
+    "relatedConcepts": ["partition analysis", "collinearity spectrum", "integer representation"],
+    "prerequisites": ["combinatorics", "case analysis"]
   },
   {
     "id": "ann-606-minus2",
     "proofId": "erdos-606",
     "range": { "startLine": 163, "endLine": 166 },
-    "type": "theorem",
+    "type": "technique",
     "title": "C(n,2)-2 IS Achievable",
-    "content": "C(n,2)-2 is achievable: place 3 points collinear and the rest in general position. The 3 collinear points reduce the count by 2 (3 pairs share one line instead of determining 3 lines).",
-    "significance": "key"
+    "content": "The value $\\binom{n}{2} - 2$ is achievable by placing exactly 3 points on a line and the remaining $n - 3$ points in general position (no other collinearities). The three collinear points contribute 1 line instead of 3, reducing the count by exactly $\\binom{3}{2} - 1 = 2$.",
+    "mathContext": "Construction: place $p_1, p_2, p_3$ on a line $\\ell$, and $p_4, \\ldots, p_n$ in general position with respect to each other and to $\\ell$. Then $f(P) = \\binom{n}{2} - (\\binom{3}{2} - 1) = \\binom{n}{2} - 2$.",
+    "significance": "key",
+    "relatedConcepts": ["explicit constructions", "perturbation arguments"],
+    "prerequisites": ["analytic geometry", "general position arguments"]
   },
   {
     "id": "ann-606-density",
     "proofId": "erdos-606",
     "range": { "startLine": 168, "endLine": 176 },
-    "type": "axiom",
+    "type": "technique",
     "title": "Erdős Density Result",
-    "content": "Erdős showed that all integers in [cn^{3/2}, C(n,2)-4] are achievable for some constant c > 0. This fills in most of the gap between the minimum n and maximum C(n,2).",
-    "significance": "key"
+    "content": "Erdős showed that all integers in $[cn^{3/2}, \\binom{n}{2} - 4]$ are achievable for some constant $c > 0$. The constructions use algebraic curves and careful perturbation arguments. The lower bound $cn^{3/2}$ comes from constructing configurations with controlled collinearity patterns using lattice-like structures.",
+    "mathContext": "For each $k \\in [cn^{3/2}, \\binom{n}{2} - 4]$, there exists a configuration $P$ of $n$ points with $f(P) = k$. The gap between $n$ and $cn^{3/2}$ is filled by more delicate constructions in the Erdős-Salamon paper, showing all of $[n, \\binom{n}{2} - 4]$ is achievable.",
+    "significance": "key",
+    "relatedConcepts": ["algebraic constructions", "lattice points", "perturbation methods"],
+    "prerequisites": ["algebraic geometry", "number theory"]
   },
   {
-    "id": "ann-606-collinear-config",
+    "id": "ann-606-constructions",
     "proofId": "erdos-606",
-    "range": { "startLine": 180, "endLine": 193 },
-    "type": "definition",
-    "title": "Collinear Configuration",
-    "content": "n points on a line (e.g., (0,0), (1,0), ..., (n-1,0)) determine exactly 1 line. This is the extreme minimum case, showing f(n) = 1 is always achievable.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-606-circle-config",
-    "proofId": "erdos-606",
-    "range": { "startLine": 195, "endLine": 202 },
-    "type": "definition",
-    "title": "Circle Configuration",
-    "content": "n points evenly spaced on a circle are in general position (no 3 collinear). This achieves the maximum C(n,2) lines, showing the upper bound is always achievable.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-606-grid",
-    "proofId": "erdos-606",
-    "range": { "startLine": 204, "endLine": 215 },
-    "type": "definition",
-    "title": "Grid Configuration",
-    "content": "An m×m grid of points has many collinearities (rows, columns, diagonals). The line count is C(m²,2) minus O(m³) for the shared lines. Grids achieve many intermediate values.",
-    "significance": "key"
+    "range": { "startLine": 178, "endLine": 215 },
+    "type": "technique",
+    "title": "Explicit Constructions",
+    "content": "Three key constructions establish achievability of boundary values. The collinear configuration $p_i = (i, 0)$ gives $f = 1$. The circle configuration $p_i = (\\cos(2\\pi i/n), \\sin(2\\pi i/n))$ gives $f = \\binom{n}{2}$ since points on a circle are in general position. The $m \\times m$ grid provides intermediate values: the grid's rows, columns, and diagonal lines create controlled collinearities.",
+    "mathContext": "Collinear: $P = \\{(i, 0) : 0 \\le i < n\\}$, $f(P) = 1$. Circle: $P = \\{(\\cos\\frac{2\\pi i}{n}, \\sin\\frac{2\\pi i}{n}) : 0 \\le i < n\\}$, $f(P) = \\binom{n}{2}$. Grid: $P = \\{(i, j) : 0 \\le i, j < m\\}$ with $n = m^2$, $f(P) = \\binom{m^2}{2} - \\Theta(m^3)$.",
+    "significance": "key",
+    "relatedConcepts": ["lattice configurations", "trigonometric identities", "grid geometry"],
+    "prerequisites": ["analytic geometry", "trigonometry"]
   },
   {
     "id": "ann-606-beck",
     "proofId": "erdos-606",
-    "range": { "startLine": 219, "endLine": 227 },
-    "type": "axiom",
+    "range": { "startLine": 217, "endLine": 227 },
+    "type": "technique",
     "title": "Beck's Theorem",
-    "content": "Beck's dichotomy: For n points, either (1) at least n/100 points lie on a single line, OR (2) the points determine at least cn² distinct lines. There's no middle ground - either very concentrated or very spread.",
-    "significance": "critical"
+    "content": "Beck's theorem (1983) provides a fundamental dichotomy: for $n$ points, either a large fraction ($\\ge n/100$) lies on a single line, or the configuration determines $\\Omega(n^2)$ distinct lines. There is no 'middle ground.' This connects to Problem #606 because it shows that low line counts ($f(n) \\ll n^2$) force many points to be collinear.",
+    "mathContext": "Beck's theorem: either $\\exists \\ell$ with $|\\ell \\cap P| \\ge n/100$, or $f(P) \\ge n^2/10000$. The constant $1/100$ can be replaced by any $\\epsilon > 0$ with a corresponding constant $c(\\epsilon)$ for the line bound.",
+    "significance": "critical",
+    "relatedConcepts": ["Szemerédi-Trotter theorem", "incidence bounds", "sum-product estimates"],
+    "prerequisites": ["incidence geometry", "probabilistic method"]
   },
   {
     "id": "ann-606-szemeredi",
     "proofId": "erdos-606",
-    "range": { "startLine": 231, "endLine": 236 },
-    "type": "axiom",
-    "title": "Szemerédi-Trotter Bound",
-    "content": "The number of incidences between n points and m lines is O((nm)^{2/3} + n + m). This fundamental bound limits how 'clustered' points and lines can be, with applications throughout incidence geometry.",
-    "significance": "key"
+    "range": { "startLine": 229, "endLine": 244 },
+    "type": "technique",
+    "title": "Szemerédi-Trotter Incidence Bound",
+    "content": "The Szemerédi-Trotter theorem (1983) bounds the number of point-line incidences: at most $O((nm)^{2/3} + n + m)$ incidences between $n$ points and $m$ lines. This is tight and has been called 'the most important theorem in incidence geometry.' The corollary shows that if no line is too rich ($|\\ell \\cap P| \\le \\sqrt{n}$), then $f(P) = \\Omega(n^2 / \\log n)$.",
+    "mathContext": "Let $I(P, L) = |\\{(p, \\ell) \\in P \\times L : p \\in \\ell\\}|$ count incidences. Then $I(P, L) \\le C((|P| \\cdot |L|)^{2/3} + |P| + |L|)$. When each line has $\\le \\sqrt{n}$ points, total incidences $\\le \\sqrt{n} \\cdot f(P)$, giving $f(P) \\ge \\Omega(n^2/\\log n)$ by the bound.",
+    "significance": "key",
+    "relatedConcepts": ["crossing number inequality", "cell decomposition", "Elekes' sum-product"],
+    "prerequisites": ["graph theory", "algebraic geometry"]
   },
   {
     "id": "ann-606-erdos-salamon",
     "proofId": "erdos-606",
-    "range": { "startLine": 248, "endLine": 258 },
-    "type": "axiom",
-    "title": "Erdős-Salamon Characterization",
-    "content": "For large n, achievable line counts are exactly: {1} ∪ [n, C(n,2)] \\ {C(n,2)-1, C(n,2)-3}. This completely characterizes the possible values - a satisfying answer to the original problem.",
-    "significance": "critical"
+    "range": { "startLine": 246, "endLine": 258 },
+    "type": "concept",
+    "title": "Erdős-Salamon Complete Characterization",
+    "content": "The Erdős-Salamon theorem (1988) completely characterizes the achievable line counts for sufficiently large $n$. The result is stated using set notation: $\\mathcal{A}(n) = \\{1\\} \\cup ([n, \\binom{n}{2}] \\setminus \\{\\binom{n}{2}-1, \\binom{n}{2}-3\\})$. The proof combines the impossibility results (gap at $-1$ and $-3$) with construction results showing every other value is achievable.",
+    "mathContext": "In Lean, the characterization is: $\\exists N, \\forall n \\ge N, \\mathcal{A}(n) = \\{1\\} \\cup (\\text{Set.Icc } n \\, (\\text{maxLines } n) \\setminus \\{\\text{maxLines } n - 1, \\text{maxLines } n - 3\\})$. The existential $N$ means the result holds for 'sufficiently large' $n$, leaving the exact threshold as an open question.",
+    "significance": "critical",
+    "relatedConcepts": ["spectrum theorems", "extremal set theory", "threshold phenomena"],
+    "prerequisites": ["combinatorics", "discrete geometry"]
   },
   {
     "id": "ann-606-solved",
     "proofId": "erdos-606",
     "range": { "startLine": 260, "endLine": 273 },
-    "type": "theorem",
-    "title": "Main Theorem",
-    "content": "Erdős Problem #606 is solved: for sufficiently large n, we know exactly which line counts are achievable. The two 'forbidden' values C(n,2)-1 and C(n,2)-3 are the only gaps in the range [n, C(n,2)].",
-    "significance": "critical"
+    "type": "insight",
+    "title": "Main Theorem: Problem Solved",
+    "content": "The culminating theorem `erdos_606_solved` derives from the Erdős-Salamon characterization. It extracts the two key consequences: (1) $1 \\in \\mathcal{A}(n)$ (collinear case always works), and (2) every $k \\in [n, \\binom{n}{2}]$ except $\\binom{n}{2}-1$ and $\\binom{n}{2}-3$ is achievable. The proof unwraps the set characterization using membership in the union and difference of sets.",
+    "mathContext": "The proof structure: obtain $N$ from `erdos_salamon_characterization`, then for $n \\ge N$, rewrite $\\mathcal{A}(n)$ and show $1 \\in \\{1\\} \\cup \\ldots$ (trivially) and $k \\in [n, \\binom{n}{2}] \\setminus \\{\\text{gaps}\\}$ (by set difference membership). The Lean proof uses `Set.mem_diff`, `Set.mem_Icc`, and `Set.mem_singleton_iff`.",
+    "significance": "critical",
+    "relatedConcepts": ["set membership proofs", "logical unwrapping", "formal verification"],
+    "prerequisites": ["Lean 4 tactics", "set theory in Lean"]
   }
 ]

--- a/src/data/proofs/erdos-606/meta.json
+++ b/src/data/proofs/erdos-606/meta.json
@@ -22,98 +22,127 @@
     "erdosProblemStatus": "solved"
   },
   "overview": {
-    "historicalContext": "**The Distinct Lines Problem**\n\nThis classic problem in discrete geometry asks: given n points in the plane, how many distinct lines can they determine? The answer ranges from 1 (all collinear) to C(n,2) (general position).\n\n**Key Historical Results**:\n- **Sylvester-Gallai (1893/1944)**: Non-collinear points determine at least one 'ordinary' line (with exactly 2 points)\n- **Erdős (1985)**: Posed the complete characterization problem\n- **Erdős-Salamon (1988)**: Solved for large n - all values from n to C(n,2) achievable except C(n,2)-1 and C(n,2)-3\n\n**Why These Exceptions?**\n- C(n,2)-1 would require exactly one 'coincidence' - geometrically impossible\n- C(n,2)-3 would require a specific pattern that can't exist\n\n**Related Theorems**: Beck's theorem, Szemerédi-Trotter incidence bound, and the orchard problem are all closely connected.",
-    "problemStatement": "**Problem Statement**\n\nGiven n distinct points in ℝ², let f(n) count the number of distinct lines determined by these points. What are the possible values of f(n)?\n\n**Bounds**:\n- Minimum: f(n) = 1 (all points collinear)\n- Maximum: f(n) = C(n,2) = n(n-1)/2 (general position, no 3 collinear)\n\n**The Question**: Which integers between 1 and C(n,2) are achievable?\n\n**Answer**: For large n, achievable values are {1} ∪ [n, C(n,2)] \\ {C(n,2)-1, C(n,2)-3}.",
-    "proofStrategy": "**Proof Approach**\n\nThe Erdős-Salamon characterization combines:\n\n1. **Constructions**: Show values ARE achievable\n   - Collinear: 1 line\n   - Circle: C(n,2) lines (general position)\n   - Grids: intermediate values via controlled collinearities\n\n2. **Impossibility Proofs**: Show values are NOT achievable\n   - C(n,2)-1: Would need exactly one 3-point line, impossible\n   - C(n,2)-3: Geometric analysis rules out this configuration\n\n3. **Density Arguments**: Erdős showed almost all intermediate values work using probabilistic and algebraic constructions.\n\n**Key Tools**: Sylvester-Gallai theorem, Beck's dichotomy, incidence bounds.",
+    "historicalContext": "**The Distinct Lines Problem**\n\nThis classic problem in discrete geometry asks: given $n$ points in the plane, how many distinct lines can they determine? The answer ranges from 1 (all collinear) to $\\binom{n}{2}$ (general position).\n\n**Key Historical Results**:\n- **Sylvester (1893)**: Posed the question of whether $n$ non-collinear points always determine an ordinary line (one with exactly 2 points). This went unresolved for 50 years.\n- **Gallai (1944)**: Proved Sylvester's conjecture using an elegant extremal argument. The result is now called the Sylvester-Gallai theorem.\n- **Motzkin (1951)**: Gave a shorter proof and established that non-collinear points determine at least $n$ distinct lines.\n- **Beck (1983)**: Proved the fundamental dichotomy — either many points are collinear, or the number of lines is $\\Omega(n^2)$.\n- **Szemerédi-Trotter (1983)**: Established the tight incidence bound $O((nm)^{2/3} + n + m)$, a cornerstone of combinatorial geometry.\n- **Erdős (1985)**: Posed the complete characterization problem as Problem #606.\n- **Erdős-Salamon (1988)**: Solved it for large $n$ — all values from $n$ to $\\binom{n}{2}$ are achievable except exactly two: $\\binom{n}{2}-1$ and $\\binom{n}{2}-3$.\n\n**Why These Exceptions?**\n- $\\binom{n}{2}-1$: Three collinear points reduce the line count by $\\binom{3}{2}-1 = 2$, not 1. More generally, $k$ collinear points reduce by $\\binom{k}{2}-1 \\ge 2$. No combination of collinearities can yield a reduction of exactly 1.\n- $\\binom{n}{2}-3$: The possible reductions from collinearities are sums of numbers $\\ge 2$, so the achievable reductions are $\\{0, 2, 4, 5, 6, \\ldots\\}$. Since 3 is not in this set, $\\binom{n}{2}-3$ is excluded.\n\n**Related Theorems**: Beck's theorem, the Szemerédi-Trotter incidence bound, the orchard problem, and the Dirac-Motzkin conjecture (proved by Green-Tao, 2013) are all closely connected.",
+    "problemStatement": "**Problem Statement**\n\nGiven $n$ distinct points in $\\mathbb{R}^2$, let $f(n)$ count the number of distinct lines determined by these points. What are the possible values of $f(n)$?\n\n**Bounds**:\n- Minimum: $f(n) = 1$ (all points collinear)\n- Maximum: $f(n) = \\binom{n}{2} = \\frac{n(n-1)}{2}$ (general position, no 3 collinear)\n\n**The Question**: Which integers between 1 and $\\binom{n}{2}$ are achievable?\n\n**Answer (Erdős-Salamon, 1988)**: For sufficiently large $n$, the achievable values are exactly $\\{1\\} \\cup [n, \\binom{n}{2}] \\setminus \\{\\binom{n}{2}-1, \\binom{n}{2}-3\\}$.",
+    "proofStrategy": "**Proof Approach**\n\nThe Erdős-Salamon characterization combines three threads:\n\n1. **Lower bound (Sylvester-Gallai)**:\n   Non-collinear configurations determine $\\ge n$ lines. This is proved by induction using the ordinary line guaranteed by Sylvester-Gallai: remove its two points, apply induction, count the new lines.\n\n2. **Impossibility proofs (gap analysis)**:\n   - $\\binom{n}{2}-1$: Three collinear points reduce by 2, four by 5, etc. No sum of reductions $\\ge 2$ equals 1.\n   - $\\binom{n}{2}-3$: Similarly, 3 is not a sum of integers $\\ge 2$.\n\n3. **Construction proofs (achievability)**:\n   - **Collinear**: All on a line gives 1.\n   - **Near-general position**: Three collinear + rest general gives $\\binom{n}{2}-2$.\n   - **Grids**: $m \\times m$ grids give $\\binom{m^2}{2} - \\Theta(m^3)$ via row/column/diagonal collinearities.\n   - **Algebraic curves**: Points on curves of degree $d$ provide fine control over collinearities.\n   - **Erdős density argument**: All values in $[cn^{3/2}, \\binom{n}{2}-4]$ are achievable.\n   - **Salamon's constructions**: Fill in $[n, cn^{3/2}]$ to complete the characterization.\n\n**Key Tools**: Sylvester-Gallai theorem, Beck's dichotomy, Szemerédi-Trotter incidence bound, algebraic curve constructions.",
     "keyInsights": [
-      "The minimum is 1 (all collinear) or n (Sylvester-Gallai forces at least n lines)",
-      "C(n,2)-1 is impossible: you can't have exactly one '3-point coincidence'",
-      "C(n,2)-3 is impossible for geometric reasons involving line multiplicities",
-      "Grids provide a systematic way to achieve intermediate line counts",
-      "Beck's theorem: either many collinear points OR Ω(n²) lines"
+      "The gap structure is controlled by a simple number-theoretic observation: collinearities reduce line counts by $\\binom{k}{2}-1 \\ge 2$, so reductions of 1 and 3 are impossible as sums of integers $\\ge 2$",
+      "Beck's dichotomy creates a sharp threshold: configurations either have $\\Omega(n)$ collinear points or $\\Omega(n^2)$ distinct lines, with nothing in between — this constrains where achievable values can cluster",
+      "The Szemerédi-Trotter bound implies that for 'sparse' configurations ($\\le \\sqrt{n}$ points per line), the number of lines must be $\\Omega(n^2/\\log n)$, leaving only 'dense' configurations to fill the lower range",
+      "Grid configurations provide a bridge between the collinear extreme ($f = 1$) and general position ($f = \\binom{n}{2}$), with line counts varying by $\\Theta(m^3)$ as grid parameters change",
+      "The Erdős-Salamon result is a 'spectrum theorem' — analogous to inverse problems in additive combinatorics, where one characterizes which structural parameters are realizable"
     ]
   },
   "sections": [
     {
+      "id": "header-imports",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Problem statement, references, and Mathlib imports for Euclidean spaces, finite sets, and affine geometry"
+    },
+    {
       "id": "points-lines",
-      "title": "Points and Lines",
+      "title": "Points and Lines in ℝ²",
       "startLine": 39,
       "endLine": 62,
-      "summary": "Definitions of points, configurations, and lines in ℝ²"
+      "summary": "Defines Point as EuclideanSpace ℝ (Fin 2), PointConfiguration with injectivity, Line with parametric representation, and line equivalence"
     },
     {
       "id": "counting-lines",
       "title": "Counting Distinct Lines",
       "startLine": 64,
       "endLine": 81,
-      "summary": "Distinct pairs and maximum line count C(n,2)"
+      "summary": "Defines distinctPairs, numDistinctLines (via equivalence classes), and maxLines = n(n-1)/2"
     },
     {
       "id": "collinearity",
-      "title": "Collinearity",
+      "title": "Collinearity and General Position",
       "startLine": 83,
       "endLine": 106,
-      "summary": "Collinear points, general position, and their line counts"
+      "summary": "Defines Collinear, AllCollinear (→ 1 line), and GeneralPosition (→ C(n,2) lines) with boundary theorems"
     },
     {
       "id": "sylvester-gallai",
       "title": "Sylvester-Gallai Theorem",
       "startLine": 108,
       "endLine": 126,
-      "summary": "Non-collinear points have an ordinary line; implies ≥ n lines"
+      "summary": "Defines ordinary lines, axiomatizes Sylvester-Gallai, and derives the minimum bound f(n) ≥ n for non-collinear configurations"
     },
     {
       "id": "main-problem",
       "title": "The Main Problem",
       "startLine": 128,
       "endLine": 143,
-      "summary": "Achievable line counts and the main characterization question"
+      "summary": "Defines AchievableLineCounts(n) as the set of realizable values and states the Erdős Problem #606 characterization question"
     },
     {
       "id": "known-results",
-      "title": "Known Results",
+      "title": "Known Results: Gaps and Density",
       "startLine": 145,
       "endLine": 176,
-      "summary": "Non-achievable values and Erdős density result"
+      "summary": "Axioms for the two impossible values C(n,2)-1 and C(n,2)-3, the achievable C(n,2)-2, and Erdős's density result for the range [cn^{3/2}, C(n,2)-4]"
     },
     {
       "id": "constructions",
-      "title": "Constructions",
+      "title": "Explicit Constructions",
       "startLine": 178,
       "endLine": 215,
-      "summary": "Collinear, circular, and grid configurations"
+      "summary": "Collinear (f=1), circle (f=C(n,2)), and grid (intermediate values) configurations with correctness statements"
     },
     {
       "id": "beck-theorem",
       "title": "Beck's Theorem",
       "startLine": 217,
       "endLine": 227,
-      "summary": "Dichotomy: many collinear points or many lines"
+      "summary": "Beck's dichotomy: ≥n/100 collinear points on one line, or ≥cn² distinct lines"
     },
     {
       "id": "szemeredi-trotter",
       "title": "Szemerédi-Trotter Bound",
       "startLine": 229,
       "endLine": 244,
-      "summary": "Incidence bound and its implications"
+      "summary": "Incidence bound O((nm)^{2/3} + n + m) and corollary for sparse configurations"
     },
     {
       "id": "complete-characterization",
       "title": "Complete Characterization",
       "startLine": 246,
       "endLine": 273,
-      "summary": "Erdős-Salamon theorem and main result"
+      "summary": "Erdős-Salamon characterization axiom and the main theorem erdos_606_solved, which derives the achievability result from set-theoretic reasoning"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #606 characterizes which line counts are achievable for n points in the plane. The Erdős-Salamon theorem shows that for large n, all values from n to C(n,2) are achievable except exactly two: C(n,2)-1 and C(n,2)-3. These exceptions arise from fundamental geometric impossibilities.",
-    "implications": "**Theoretical Significance**\n\n1. **Discrete Geometry**: Complete answer to a basic counting question about points and lines\n\n2. **Incidence Geometry**: Connects to Szemerédi-Trotter bounds and Beck's theorem\n\n3. **Extremal Combinatorics**: The 'gaps' at C(n,2)-1 and C(n,2)-3 reveal geometric rigidity\n\n4. **Algebraic Methods**: Constructions use algebraic curves and finite fields",
+    "summary": "Erdős Problem #606 completely characterizes which line counts are achievable for $n$ points in the plane. The Erdős-Salamon theorem (1988) shows that for sufficiently large $n$, the achievable set is $\\{1\\} \\cup [n, \\binom{n}{2}] \\setminus \\{\\binom{n}{2}-1, \\binom{n}{2}-3\\}$. The two gaps arise from a number-theoretic constraint: collinearities reduce line counts by $\\binom{k}{2}-1 \\ge 2$, making reductions of 1 and 3 impossible.",
+    "implications": "**Theoretical Significance**\n\n1. **Discrete Geometry**: Provides a complete answer to one of the most natural counting questions about points and lines, resolving a problem that connects to the Sylvester-Gallai tradition going back to 1893.\n\n2. **Spectrum Theorems**: The result is a prototype for 'spectrum problems' in combinatorics — characterizing which parameter values are realizable. Similar questions arise for graph properties, hypergraph colorings, and additive structures.\n\n3. **Incidence Geometry**: The proof weaves together Beck's theorem and the Szemerédi-Trotter bound, demonstrating how modern incidence-geometric tools solve classical problems.\n\n4. **Algebraic Methods**: The constructions achieving intermediate line counts use algebraic curves and lattice structures, showing the interplay between geometry and algebra.",
     "openQuestions": [
-      "What is the exact threshold N for the Erdős-Salamon characterization?",
-      "What values below n are achievable for specific small n?",
-      "Analogous questions for higher dimensions",
-      "Computational complexity of determining if k lines are achievable",
-      "Probabilistic distribution of line counts for random point sets"
+      "What is the exact threshold $N_0$ for which the Erdős-Salamon characterization holds? The proof gives an existence result without computing the constant.",
+      "For small $n$ (say $n \\le 20$), what is the complete list of achievable values? The problem becomes finite-combinatorial but computationally challenging.",
+      "What is the higher-dimensional analogue? For $n$ points in $\\mathbb{R}^d$, which counts of determined hyperplanes are achievable?",
+      "What is the computational complexity of deciding whether $k$ lines are achievable for given $n$? Is it NP-hard, or does the algebraic structure allow polynomial algorithms?",
+      "Can the Green-Tao resolution of the Dirac-Motzkin conjecture (on the number of ordinary lines) be used to sharpen the small-$n$ analysis?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-607",
+      "relationship": "extends",
+      "description": "Erdős Problem #607 studies incidence signatures of point configurations, a natural refinement of the line-counting question in Problem #606"
+    },
+    {
+      "targetId": "erdos-604",
+      "relationship": "related",
+      "description": "The pinned distance problem (#604) is another Erdős problem about point configurations in the plane, using similar incidence-geometric techniques"
+    },
+    {
+      "targetId": "erdos-605",
+      "relationship": "related",
+      "description": "Repeated distances on a sphere (#605) explores similar distance/incidence themes in a spherical setting"
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "uses",
+      "description": "The maximum line count C(n,2) = n(n-1)/2 is the binomial coefficient formalized in the combinations formula"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Enrichment pass for erdos-606 (Distinct Lines from n Points)
- Added `mathContext` with LaTeX formulas to all 18 annotations
- Added `relatedConcepts` and `prerequisites` arrays throughout
- Expanded `historicalContext` with detailed timeline (Sylvester 1893 → Erdős-Salamon 1988)
- Deepened `keyInsights` with number-theoretic gap analysis and spectrum theorem connection
- Added `crossReferences` to erdos-607, erdos-604, erdos-605, combinations-formula
- Expanded `conclusion` implications and open questions

## Test plan
- [x] JSON validates with `python3 -c "import json; json.load(open(...))"`
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)