### PR TITLE
enrich: deepen annotations and meta for erdos-627

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -360,6 +360,31 @@
       "passes": 1,
       "lastEnriched": "2026-02-12T12:15:00Z",
       "quality": 100
+    },
+    "erdos-613": {
+      "passes": 2,
+      "lastEnriched": "2026-02-13T07:30:24Z",
+      "quality": 80
+    },
+    "erdos-616": {
+      "passes": 1,
+      "lastEnriched": "2026-02-13T07:30:16Z",
+      "quality": 80
+    },
+    "erdos-620": {
+      "passes": 1,
+      "lastEnriched": "2026-02-13T07:34:49Z",
+      "quality": 80
+    },
+    "erdos-623": {
+      "passes": 1,
+      "lastEnriched": "2026-02-13T07:40:33Z",
+      "quality": 80
+    },
+    "erdos-626": {
+      "passes": 1,
+      "lastEnriched": "2026-02-13T07:45:11Z",
+      "quality": 80
     }
   }
 }

--- a/src/data/proofs/erdos-627/annotations.json
+++ b/src/data/proofs/erdos-627/annotations.json
@@ -5,8 +5,23 @@
     "range": { "startLine": 1, "endLine": 20 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "**Erdős #627:** Chromatic number vs clique number ratio.\n\n**Definition:** f(n) = max χ(G)/ω(G) over all n-vertex graphs.\n\n**Question:** Does lim_{n→∞} f(n)/(n/(log n)²) exist?\n\n**Status:** OPEN\n\n**Known:**\n- f(n) ≍ n/(log n)² (Erdős)\n- If limit exists, it's in (log 2)²·[1/4, 1] ≈ [0.12, 0.48]",
-    "significance": "critical"
+    "content": "**Erdős #627:** Chromatic number vs clique number ratio.\n\n**Definition:** $f(n) = \\max_{|V(G)|=n} \\chi(G)/\\omega(G)$.\n\n**Question:** Does $\\lim_{n\\to\\infty} f(n)/(n/(\\log n)^2)$ exist?\n\n**Status:** OPEN\n\n**Known:**\n- $f(n) \\asymp n/(\\log n)^2$ (Erdős)\n- If limit exists, it's in $(\\log 2)^2 \\cdot [1/4, 1] \\approx [0.12, 0.48]$",
+    "significance": "critical",
+    "mathContext": "The function $f(n)$ captures the worst-case gap between clique number and chromatic number. While $\\omega(G) \\leq \\chi(G)$ always, the Tutte-Zykov theorem shows the ratio can be arbitrarily large. Erdős proved $f(n) = \\Theta(n/(\\log n)^2)$ using the probabilistic method for the lower bound and a greedy argument for the upper bound.",
+    "relatedConcepts": ["chromatic number", "clique number", "Ramsey theory", "perfect graphs", "probabilistic method"],
+    "prerequisites": ["graph coloring", "asymptotic notation", "limits"]
+  },
+  {
+    "id": "ann-627-imports",
+    "proofId": "erdos-627",
+    "range": { "startLine": 22, "endLine": 28 },
+    "type": "concept",
+    "title": "Imports and Setup",
+    "content": "Imports the full Mathlib library for access to `SimpleGraph`, `Filter.Tendsto`, `Real.log`, and `Finset`. Opens `Finset`, `Function`, `SimpleGraph`, and `Nat` namespaces. Declares universe-polymorphic vertex type `V` with `Fintype` and `DecidableEq` instances.",
+    "significance": "supporting",
+    "mathContext": "The formalization uses `SimpleGraph V` for undirected graphs on vertex type $V$. The `Fintype V` instance ensures $|V|$ is computable, while `DecidableEq V` enables decidable adjacency and membership tests needed for clique and coloring definitions.",
+    "relatedConcepts": ["SimpleGraph", "Fintype", "DecidableEq"],
+    "prerequisites": ["Lean 4 type classes", "Mathlib graph theory"]
   },
   {
     "id": "ann-627-clique",
@@ -14,8 +29,11 @@
     "range": { "startLine": 32, "endLine": 34 },
     "type": "definition",
     "title": "Clique Number",
-    "content": "The **clique number** ω(G) is the size of the largest clique (complete subgraph) in G.\n\nω(G) = k means G contains K_k but not K_{k+1}.\n\nThis measures local density: how many mutually adjacent vertices exist.",
-    "significance": "critical"
+    "content": "The **clique number** $\\omega(G)$ is the size of the largest complete subgraph in $G$.\n\n$\\omega(G) = k$ means $G$ contains $K_k$ but not $K_{k+1}$.\n\nThis measures local density: how many mutually adjacent vertices exist.",
+    "significance": "critical",
+    "mathContext": "Defined as `noncomputable def cliqueNumber (G : SimpleGraph V) : ℕ` with a sorry body. The clique number $\\omega(G) = \\max\\{k : K_k \\hookrightarrow G\\}$ is NP-hard to compute in general (Karp 1972). For the ratio $\\chi/\\omega$, it serves as the denominator providing a lower bound on chromatic number.",
+    "relatedConcepts": ["complete graph", "NP-hardness", "Ramsey number", "independence number"],
+    "prerequisites": ["graph theory basics", "complete subgraph"]
   },
   {
     "id": "ann-627-chromatic",
@@ -23,8 +41,35 @@
     "range": { "startLine": 36, "endLine": 38 },
     "type": "definition",
     "title": "Chromatic Number",
-    "content": "The **chromatic number** χ(G) is the minimum number of colors needed to color vertices so no adjacent vertices share a color.\n\nχ(G) measures global coloring difficulty, which depends on the entire graph structure.",
-    "significance": "critical"
+    "content": "The **chromatic number** $\\chi(G)$ is the minimum number of colors needed for a proper vertex coloring.\n\n$\\chi(G)$ measures global coloring difficulty, which depends on the entire graph structure, not just local neighborhoods.",
+    "significance": "critical",
+    "mathContext": "Defined as `noncomputable def chromaticNumber (G : SimpleGraph V) : ℕ` with sorry. Computing $\\chi(G)$ is NP-hard (Karp 1972). The key relationship $\\omega(G) \\leq \\chi(G) \\leq \\Delta(G) + 1$ (Brooks' theorem gives $\\chi \\leq \\Delta$ except for complete graphs and odd cycles) bounds chromatic number between clique number and maximum degree.",
+    "relatedConcepts": ["proper coloring", "Brooks' theorem", "greedy coloring", "fractional chromatic number"],
+    "prerequisites": ["graph coloring", "proper vertex coloring"]
+  },
+  {
+    "id": "ann-627-colorable",
+    "proofId": "erdos-627",
+    "range": { "startLine": 41, "endLine": 42 },
+    "type": "definition",
+    "title": "k-Colorability",
+    "content": "A graph is $k$-colorable if there exists $f: V \\to \\{0,\\ldots,k-1\\}$ with $f(v) \\neq f(w)$ whenever $v \\sim w$. Formalized as `IsKColorable G k` using `Fin k` as the color set.",
+    "significance": "supporting",
+    "mathContext": "The definition `∃ f : V → Fin k, ∀ v w, G.Adj v w → f v ≠ f w` directly captures proper $k$-coloring. The chromatic number is then $\\chi(G) = \\min\\{k : \\text{IsKColorable } G\\, k\\}$. This existential formulation avoids constructing explicit colorings.",
+    "relatedConcepts": ["proper coloring", "chromatic polynomial", "list coloring"],
+    "prerequisites": ["function types", "Fin type"]
+  },
+  {
+    "id": "ann-627-contains-clique",
+    "proofId": "erdos-627",
+    "range": { "startLine": 45, "endLine": 46 },
+    "type": "definition",
+    "title": "Contains k-Clique",
+    "content": "A graph contains a $k$-clique if there exists a subset $S \\subseteq V$ with $|S| = k$ where all distinct pairs are adjacent. Formalized via `Finset V` with pairwise adjacency.",
+    "significance": "supporting",
+    "mathContext": "The definition `∃ S : Finset V, S.card = k ∧ ∀ v w, v ∈ S → w ∈ S → v ≠ w → G.Adj v w` uses Finsets rather than graph homomorphisms from $K_k$. This is equivalent to requiring a clique embedding $K_k \\hookrightarrow G$.",
+    "relatedConcepts": ["Ramsey theory", "clique cover", "Turán's theorem"],
+    "prerequisites": ["Finset", "graph adjacency"]
   },
   {
     "id": "ann-627-ratio",
@@ -32,8 +77,11 @@
     "range": { "startLine": 50, "endLine": 52 },
     "type": "definition",
     "title": "The Ratio χ/ω",
-    "content": "`chiOmegaRatio G = χ(G) / ω(G)`\n\nThis ratio measures how much harder coloring is than the clique lower bound suggests.\n\n- Ratio = 1: Graph is 'perfect' (cliques fully determine coloring)\n- Ratio > 1: Global structure requires more colors than local density implies",
-    "significance": "critical"
+    "content": "`chiOmegaRatio G = χ(G) / ω(G)`\n\nThis ratio measures how much harder coloring is than the clique lower bound suggests.\n\n- Ratio $= 1$: Graph is 'perfect' ($\\chi = \\omega$ for all induced subgraphs)\n- Ratio $> 1$: Global structure requires more colors than local density implies",
+    "significance": "critical",
+    "mathContext": "Defined as $(\\chi(G) : \\mathbb{R}) / (\\omega(G) : \\mathbb{R})$ using real division. The ratio $\\chi/\\omega$ is sometimes called the **imperfection ratio**. For perfect graphs (Lovász 1972), this equals 1 for all induced subgraphs. The maximum over $n$-vertex graphs gives $f(n)$, the central object of Problem #627.",
+    "relatedConcepts": ["imperfection ratio", "perfect graphs", "fractional chromatic number"],
+    "prerequisites": ["real division", "graph parameters"]
   },
   {
     "id": "ann-627-chi-ge-omega",
@@ -41,8 +89,11 @@
     "range": { "startLine": 54, "endLine": 57 },
     "type": "theorem",
     "title": "χ ≥ ω Always",
-    "content": "**Fundamental bound:** χ(G) ≥ ω(G) for all graphs.\n\nA k-clique requires k distinct colors (all vertices adjacent), so χ ≥ ω.\n\nThis means the ratio χ/ω is always ≥ 1.",
-    "significance": "key"
+    "content": "**Fundamental bound:** $\\chi(G) \\geq \\omega(G)$ for all graphs.\n\nA $k$-clique requires $k$ distinct colors (all vertices mutually adjacent), so $\\chi \\geq \\omega$.\n\nThis means the ratio $\\chi/\\omega \\geq 1$.",
+    "significance": "key",
+    "mathContext": "This is the trivial lower bound: any proper coloring of $G$ must use at least $\\omega(G)$ colors on any maximum clique. Combined with the ratio definition, it ensures $f(n) \\geq 1$ for all $n \\geq 1$. The interesting question is how much $\\chi$ can exceed $\\omega$.",
+    "relatedConcepts": ["clique bound", "fractional relaxation", "Lovász theta function"],
+    "prerequisites": ["proper coloring", "clique"]
   },
   {
     "id": "ann-627-f-function",
@@ -50,17 +101,23 @@
     "range": { "startLine": 66, "endLine": 68 },
     "type": "definition",
     "title": "The Function f(n)",
-    "content": "`f n` = maximum χ(G)/ω(G) over all graphs G with n vertices.\n\nThis captures the worst-case gap between clique number and chromatic number for n-vertex graphs.\n\nThe question is: how does f(n) grow with n?",
-    "significance": "critical"
+    "content": "$f(n) = \\sup_{|V(G)|=n} \\chi(G)/\\omega(G)$, the maximum ratio over all $n$-vertex graphs.\n\nThis captures the worst-case gap between clique number and chromatic number for $n$-vertex graphs.\n\nThe question is: how does $f(n)$ grow with $n$?",
+    "significance": "critical",
+    "mathContext": "Defined noncomputably as a sorry since computing the supremum over all $n$-vertex graphs requires enumerating all graphs. The function $f(n)$ is well-defined because the set of $n$-vertex graphs is finite (up to isomorphism). Erdős proved $f(n) = \\Theta(n/(\\log n)^2)$, so the supremum is finite and achieved.",
+    "relatedConcepts": ["extremal graph theory", "supremum", "graph enumeration"],
+    "prerequisites": ["supremum", "graph isomorphism"]
   },
   {
     "id": "ann-627-tutte-zykov",
     "proofId": "erdos-627",
     "range": { "startLine": 80, "endLine": 83 },
-    "type": "axiom",
+    "type": "theorem",
     "title": "Tutte-Zykov Construction",
-    "content": "**Tutte and Zykov (independently):**\n\nGraphs with ω = 2 (triangle-free) can have arbitrarily large χ!\n\nThis is surprising: triangle-free graphs seem 'sparse' but can still require many colors. The ratio χ/ω can be arbitrarily large.",
-    "significance": "critical"
+    "content": "**Tutte (1947) and Zykov (1949) independently:**\n\nGraphs with $\\omega = 2$ (triangle-free) can have arbitrarily large $\\chi$!\n\nThis is surprising: triangle-free graphs seem 'sparse' but can still require many colors. The ratio $\\chi/\\omega$ can be arbitrarily large.",
+    "significance": "critical",
+    "mathContext": "Axiomatized as `tutte_zykov_construction`. Tutte's construction uses a recursive Mycielski-type operation: starting from $K_2$, each step adds a 'shadow' vertex layer preserving triangle-freeness while increasing $\\chi$ by 1. Zykov's construction is similar but uses a different recursive scheme. Erdős (1959) later gave a non-constructive proof using the probabilistic method, showing random $G(n,p)$ graphs are triangle-free with high $\\chi$.",
+    "relatedConcepts": ["Mycielski construction", "probabilistic method", "Erdős 1959 theorem", "Shift graph"],
+    "prerequisites": ["triangle-free graph", "recursive construction"]
   },
   {
     "id": "ann-627-triangle-free",
@@ -68,8 +125,11 @@
     "range": { "startLine": 89, "endLine": 98 },
     "type": "theorem",
     "title": "Triangle-Free Large χ",
-    "content": "For any k, there exist triangle-free graphs with chromatic number ≥ k.\n\nThis follows from Tutte-Zykov: ω = 2 means no triangles (K_3).\n\n**Intuition breaker:** Locally sparse (no triangles) doesn't mean globally easy to color!",
-    "significance": "key"
+    "content": "For any $k$, there exist triangle-free graphs with $\\chi \\geq k$.\n\nThis follows from Tutte-Zykov: $\\omega = 2$ means no triangles ($K_3$).\n\n**Intuition breaker:** Locally sparse (no triangles) doesn't mean globally easy to color!",
+    "significance": "key",
+    "mathContext": "Derived from `tutte_zykov_construction` by noting $\\omega = 2$ implies triangle-freeness (any triangle would give $\\omega \\geq 3$). The proof applies the axiom and extracts the triangle-free property. Erdős and Hajnal generalized this: for any $g$ and $k$, there exist graphs with girth $\\geq g$ and $\\chi \\geq k$ (no short cycles but high chromatic number).",
+    "relatedConcepts": ["girth", "Erdős-Hajnal girth-chromatic theorem", "high-girth high-chromatic graphs"],
+    "prerequisites": ["triangle-free", "Tutte-Zykov theorem"]
   },
   {
     "id": "ann-627-normalized",
@@ -77,17 +137,23 @@
     "range": { "startLine": 102, "endLine": 104 },
     "type": "definition",
     "title": "Normalized Function",
-    "content": "`fNormalized n = f n / (n / (log n)²)`\n\nSince f(n) ≍ n/(log n)², this normalization should be bounded.\n\nThe main question: does fNormalized(n) converge as n → ∞?",
-    "significance": "critical"
+    "content": "`fNormalized n = f(n) / (n / (log n)²)`\n\nSince $f(n) \\asymp n/(\\log n)^2$, this normalization should be bounded.\n\nThe main question: does $\\text{fNormalized}(n) \\to L$ as $n \\to \\infty$?",
+    "significance": "critical",
+    "mathContext": "Defined as `f n / (n / (Real.log n)^2)`. The Erdős asymptotic $f(n) = \\Theta(n/(\\log n)^2)$ ensures this ratio stays in $[c_1, c_2]$ for positive constants. The open question is whether it converges rather than oscillating. This is analogous to asking whether $\\pi(x)/(x/\\log x) \\to 1$ (the prime number theorem), but here convergence itself is unknown.",
+    "relatedConcepts": ["asymptotic analysis", "limit existence", "oscillation", "prime number theorem analogy"],
+    "prerequisites": ["real division", "Real.log", "asymptotic notation"]
   },
   {
     "id": "ann-627-erdos-asymptotic",
     "proofId": "erdos-627",
     "range": { "startLine": 112, "endLine": 117 },
-    "type": "axiom",
+    "type": "theorem",
     "title": "Erdős's Asymptotic",
-    "content": "**Erdős proved:** f(n) ≍ n/(log n)²\n\nMeaning: c₁ · n/(log n)² ≤ f(n) ≤ c₂ · n/(log n)² for constants c₁, c₂ > 0.\n\nSo f(n) grows, but slower than linear. The (log n)² denominator makes growth sub-polynomial.",
-    "significance": "critical"
+    "content": "**Erdős proved:** $f(n) \\asymp n/(\\log n)^2$\n\nMeaning: $c_1 \\cdot n/(\\log n)^2 \\leq f(n) \\leq c_2 \\cdot n/(\\log n)^2$ for constants $c_1, c_2 > 0$.\n\nSo $f(n)$ grows, but slower than linear. The $(\\log n)^2$ denominator makes growth sub-polynomial.",
+    "significance": "critical",
+    "mathContext": "Axiomatized as `erdos_asymptotic`. The lower bound uses Erdős's probabilistic method (1959): a random graph $G(n, n^{-1/2})$ has $\\omega(G) = O(\\sqrt{n} \\log n)$ and $\\chi(G) = \\Omega(\\sqrt{n}/\\log n)$, giving ratio $\\Omega(n/(\\log n)^2)$. The upper bound uses Ramsey-type arguments: if $\\omega(G) \\geq c\\log n$, then $\\chi \\leq n/\\log n$ by a greedy argument, bounding the ratio by $O(n/(\\log n)^2)$.",
+    "relatedConcepts": ["probabilistic method", "random graphs", "Ramsey bounds", "greedy coloring"],
+    "prerequisites": ["asymptotic analysis", "probabilistic method", "random graph model G(n,p)"]
   },
   {
     "id": "ann-627-limit",
@@ -95,17 +161,23 @@
     "range": { "startLine": 132, "endLine": 134 },
     "type": "definition",
     "title": "Limit Existence",
-    "content": "`LimitExists` means lim_{n→∞} f(n)/(n/(log n)²) exists.\n\nWe know this ratio is bounded, but it might oscillate rather than converge.\n\nThis is the OPEN question.",
-    "significance": "critical"
+    "content": "`LimitExists` means $\\lim_{n\\to\\infty} f(n)/(n/(\\log n)^2)$ exists.\n\nWe know this ratio is bounded, but it might oscillate rather than converge.\n\nThis is the OPEN question of Problem #627.",
+    "significance": "critical",
+    "mathContext": "Formalized using Mathlib's `Filter.Tendsto fNormalized Filter.atTop (nhds L)` for some $L \\in \\mathbb{R}$. The `atTop` filter captures $n \\to \\infty$. This asks whether $\\text{fNormalized}$ is a Cauchy sequence modulo null sets. The bounded oscillation scenario would mean $\\liminf < \\limsup$, which is consistent with current knowledge.",
+    "relatedConcepts": ["Filter.Tendsto", "nhds", "liminf", "limsup", "Cauchy sequence"],
+    "prerequisites": ["topological limits", "filter convergence", "Mathlib filter API"]
   },
   {
     "id": "ann-627-limit-bounds",
     "proofId": "erdos-627",
     "range": { "startLine": 136, "endLine": 139 },
-    "type": "axiom",
+    "type": "theorem",
     "title": "Limit Bounds",
-    "content": "**If the limit exists,** it lies in (log 2)² · [1/4, 1].\n\nNumerically: (log 2)² ≈ 0.48, so the limit (if it exists) is in [0.12, 0.48].\n\nThis 4× gap shows we don't know f(n) precisely even asymptotically.",
-    "significance": "critical"
+    "content": "**If the limit exists,** it lies in $(\\log 2)^2 \\cdot [1/4, 1]$.\n\nNumerically: $(\\log 2)^2 \\approx 0.48$, so the limit (if it exists) is in $[0.12, 0.48]$.\n\nThis $4\\times$ gap shows we don't know $f(n)$ precisely even asymptotically.",
+    "significance": "critical",
+    "mathContext": "Axiomatized as `limit_if_exists_bounded`. The upper bound $(\\log 2)^2$ comes from the Ramsey bound $R(k,k) \\leq 4^k$: graphs on $n$ vertices have $\\omega \\geq \\frac{1}{2}\\log_2 n$, giving $\\chi/\\omega \\leq 2n/\\log_2 n \\cdot 1/(\\log n) = O(n/(\\log n)^2)$ with constant $(\\log 2)^2$. The lower bound $(\\log 2)^2/4$ uses explicit constructions.",
+    "relatedConcepts": ["Ramsey upper bound", "explicit construction bounds", "logarithmic estimates"],
+    "prerequisites": ["Ramsey numbers", "logarithm properties"]
   },
   {
     "id": "ann-627-perfect",
@@ -113,17 +185,23 @@
     "range": { "startLine": 152, "endLine": 154 },
     "type": "definition",
     "title": "Perfect Graphs",
-    "content": "A graph is **perfect** if χ(H) = ω(H) for all induced subgraphs H.\n\nFor perfect graphs, the χ/ω ratio is exactly 1 — no gap at all!\n\nExamples: bipartite graphs, chordal graphs, comparability graphs.",
-    "significance": "key"
+    "content": "A graph is **perfect** if $\\chi(H) = \\omega(H)$ for all induced subgraphs $H$.\n\nFor perfect graphs, the $\\chi/\\omega$ ratio is exactly 1 — no gap at all!\n\nExamples: bipartite graphs, chordal graphs, comparability graphs.",
+    "significance": "key",
+    "mathContext": "Defined as `IsPerfect G := ∀ S, chromaticNumber (G.induce S) = cliqueNumber (G.induce S)`. Lovász (1972) proved the Perfect Graph Theorem: $G$ is perfect iff $\\overline{G}$ is perfect. The Strong Perfect Graph Theorem (Chudnovsky et al. 2006) gives a forbidden subgraph characterization. Perfect graphs show that $f(n)$ is driven by imperfect graphs.",
+    "relatedConcepts": ["Perfect Graph Theorem", "Strong Perfect Graph Theorem", "chordal graph", "comparability graph"],
+    "prerequisites": ["induced subgraph", "graph complement"]
   },
   {
     "id": "ann-627-spgt",
     "proofId": "erdos-627",
     "range": { "startLine": 162, "endLine": 168 },
-    "type": "axiom",
+    "type": "theorem",
     "title": "Strong Perfect Graph Theorem",
-    "content": "**Chudnovsky, Robertson, Seymour, Thomas (2006):**\n\nG is perfect ⟺ G has no odd hole or odd antihole.\n\nAn odd hole is an induced odd cycle C_{2k+1} for k ≥ 2.\nAn odd antihole is the complement of an odd hole.\n\nThis landmark theorem completely characterizes perfect graphs!",
-    "significance": "key"
+    "content": "**Chudnovsky, Robertson, Seymour, Thomas (2006):**\n\n$G$ is perfect $\\iff$ $G$ has no odd hole or odd antihole.\n\nAn odd hole is an induced odd cycle $C_{2k+1}$ for $k \\geq 2$.\nAn odd antihole is the complement of an odd hole.\n\nThis landmark theorem completely characterizes perfect graphs!",
+    "significance": "key",
+    "mathContext": "Axiomatized as `strong_perfect_graph_theorem`. This was conjectured by Berge (1961) and proved 45 years later. The proof is 150+ pages. The theorem implies polynomial-time recognition: checking for odd holes/antiholes. For Problem #627, it clarifies that extremal graphs achieving $f(n)$ must contain odd holes or antiholes.",
+    "relatedConcepts": ["Berge conjecture", "odd hole", "odd antihole", "polynomial-time recognition"],
+    "prerequisites": ["induced cycle", "graph complement", "perfect graph definition"]
   },
   {
     "id": "ann-627-ramsey",
@@ -131,8 +209,11 @@
     "range": { "startLine": 172, "endLine": 178 },
     "type": "theorem",
     "title": "Ramsey Connection",
-    "content": "**Connection to Ramsey numbers:**\n\nf(R(k,k)) ≥ k, where R(k,k) is the diagonal Ramsey number.\n\nRamsey graphs (those achieving Ramsey bounds) have large χ/ω ratio because they avoid both large cliques and large independent sets.",
-    "significance": "key"
+    "content": "**Connection to Ramsey numbers:**\n\n$f(R(k,k)) \\geq k$, where $R(k,k)$ is the diagonal Ramsey number.\n\nRamsey graphs (those achieving Ramsey bounds) have large $\\chi/\\omega$ ratio because they avoid both large cliques and large independent sets.",
+    "significance": "key",
+    "mathContext": "The Ramsey number $R(k,k)$ ensures any graph on $R(k,k)$ vertices has $\\omega \\geq k$ or $\\alpha \\geq k$. A Ramsey graph $G$ on $R(k,k)-1$ vertices has $\\omega < k$ and $\\alpha < k$, giving $\\chi \\geq n/\\alpha > (R(k,k)-1)/k$ and ratio $\\chi/\\omega \\geq (R(k,k)-1)/(k \\cdot (k-1))$. The Erdős-Szekeres bound $R(k,k) \\leq \\binom{2k-2}{k-1}$ yields the connection to $f(n)$.",
+    "relatedConcepts": ["Ramsey numbers", "diagonal Ramsey", "Erdős-Szekeres bound", "independence number"],
+    "prerequisites": ["Ramsey theory", "independence number"]
   },
   {
     "id": "ann-627-mycielski",
@@ -140,8 +221,11 @@
     "range": { "startLine": 187, "endLine": 195 },
     "type": "definition",
     "title": "Mycielski Construction",
-    "content": "**Mycielski (1955):** Explicit construction of triangle-free high-χ graphs.\n\nM_k has ω = 2 and χ = k. The construction recursively builds larger graphs.\n\nM_1 = K_2, and M_{k+1} extends M_k by adding 'shadow' vertices.\n\nThis gives concrete examples of large χ/ω ratio.",
-    "significance": "key"
+    "content": "**Mycielski (1955):** Explicit construction of triangle-free high-$\\chi$ graphs.\n\n$M_k$ has $\\omega = 2$ and $\\chi = k$. The construction recursively builds larger graphs.\n\n$M_1 = K_2$, and $M_{k+1}$ extends $M_k$ by adding 'shadow' vertices and a universal vertex.\n\nThis gives concrete examples of large $\\chi/\\omega$ ratio.",
+    "significance": "key",
+    "mathContext": "Defined noncomputably as `mycielskiGraph : ℕ → (Σ V, SimpleGraph V)`. The Mycielski construction takes $G$ with $n$ vertices, adds $n$ shadow vertices $u_1, \\ldots, u_n$ (each $u_i$ connected to neighbors of $v_i$) plus one universal vertex $w$ connected to all shadows. This preserves $\\omega = 2$ while increasing $\\chi$ by 1. The resulting $M_k$ has $3 \\cdot 2^{k-2} - 1$ vertices.",
+    "relatedConcepts": ["Mycielskian", "shadow vertices", "universal vertex", "recursive graph construction"],
+    "prerequisites": ["triangle-free graphs", "recursive construction"]
   },
   {
     "id": "ann-627-kneser",
@@ -149,8 +233,23 @@
     "range": { "startLine": 197, "endLine": 204 },
     "type": "definition",
     "title": "Kneser Graphs",
-    "content": "**Kneser graph K(n,k):** Vertices are k-subsets of [n], edges connect disjoint subsets.\n\n**Lovász (1978):** χ(K(n,k)) = n - 2k + 2 (used topological methods!)\n\nKneser graphs provide another family achieving large χ/ω ratio.\n\nK(5,2) is the famous Petersen graph.",
-    "significance": "key"
+    "content": "**Kneser graph** $K(n,k)$: Vertices are $k$-subsets of $[n]$, edges connect disjoint subsets.\n\n**Lovász (1978):** $\\chi(K(n,k)) = n - 2k + 2$ (proved using the Borsuk-Ulam theorem!).\n\nKneser graphs provide another family achieving large $\\chi/\\omega$ ratio.\n\n$K(5,2)$ is the famous Petersen graph.",
+    "significance": "key",
+    "mathContext": "Defined as `kneserGraph (n k : ℕ) : SimpleGraph (Finset (Fin n))`. Lovász's 1978 proof was revolutionary: it applied algebraic topology (Borsuk-Ulam theorem) to combinatorics, founding **topological combinatorics**. The chromatic number $n - 2k + 2$ was conjectured by Kneser (1955). For large $n/k$, the ratio $\\chi/\\omega$ of $K(n,k)$ grows, contributing to lower bounds on $f(n)$.",
+    "relatedConcepts": ["Borsuk-Ulam theorem", "topological combinatorics", "Petersen graph", "Kneser conjecture"],
+    "prerequisites": ["subset systems", "Finset (Fin n)", "topological methods"]
+  },
+  {
+    "id": "ann-627-growth",
+    "proofId": "erdos-627",
+    "range": { "startLine": 208, "endLine": 222 },
+    "type": "theorem",
+    "title": "Growth Rate Analysis",
+    "content": "Restates and derives consequences of the Erdős asymptotic. `f_growth_rate` directly invokes `erdos_asymptotic`. `ratio_bounded` shows $f(n) \\cdot (\\log n)^2 / n$ is bounded away from 0 and $\\infty$.",
+    "significance": "supporting",
+    "mathContext": "The theorem `f_growth_rate` is proved by `exact erdos_asymptotic`, while `ratio_bounded` requires algebraic manipulation of the bounds $c_1 n/(\\log n)^2 \\leq f(n) \\leq c_2 n/(\\log n)^2$ to show $c_1 \\leq f(n)(\\log n)^2/n \\leq c_2$. This confirms the normalization is well-behaved.",
+    "relatedConcepts": ["Θ-notation", "bounded ratio", "asymptotic equivalence"],
+    "prerequisites": ["Erdős asymptotic", "real arithmetic"]
   },
   {
     "id": "ann-627-main",
@@ -158,7 +257,10 @@
     "range": { "startLine": 226, "endLine": 245 },
     "type": "theorem",
     "title": "Main Status",
-    "content": "**Erdős Problem #627: OPEN**\n\n1. **f(n) ≍ n/(log n)²:** Erdős established the growth rate\n2. **Limit question:** Does f(n)/(n/(log n)²) converge? UNKNOWN\n3. **Limit bounds:** If exists, in (log 2)²·[1/4, 1] ≈ [0.12, 0.48]\n4. **Tutte-Zykov:** Triangle-free graphs can have arbitrarily large χ\n5. **Perfect graphs:** χ = ω always (ratio exactly 1)\n6. **Constructions:** Mycielski, Kneser achieve high ratio",
-    "significance": "critical"
+    "content": "**Erdős Problem #627: OPEN**\n\n1. **$f(n) \\asymp n/(\\log n)^2$:** Erdős established the growth rate\n2. **Limit question:** Does $f(n)/(n/(\\log n)^2)$ converge? UNKNOWN\n3. **Limit bounds:** If exists, in $(\\log 2)^2 \\cdot [1/4, 1] \\approx [0.12, 0.48]$\n4. **Tutte-Zykov:** Triangle-free graphs can have arbitrarily large $\\chi$\n5. **Perfect graphs:** $\\chi = \\omega$ always (ratio exactly 1)\n6. **Constructions:** Mycielski, Kneser achieve high ratio",
+    "significance": "critical",
+    "mathContext": "The status theorem `erdos_627_status` combines two key results into a conjunction: the Erdős asymptotic bound (from `erdos_asymptotic`) and the Tutte-Zykov construction (from `tutte_zykov_construction`). The proof is `exact ⟨erdos_asymptotic, tutte_zykov_construction⟩`, showing these are the two foundational results underlying Problem #627.",
+    "relatedConcepts": ["conjunction proof", "existential witness", "problem status summary"],
+    "prerequisites": ["Erdős asymptotic", "Tutte-Zykov construction"]
   }
 ]

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -24,126 +24,129 @@
     "erdosUrl": "https://erdosproblems.com/627",
     "erdosProblemStatus": "open",
     "mathlibDependencies": [
-      {
-        "theorem": "SimpleGraph",
-        "description": "Simple undirected graphs",
-        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
-      },
-      {
-        "theorem": "Filter.Tendsto",
-        "description": "Limits and convergence",
-        "module": "Mathlib.Order.Filter.Basic"
-      },
-      {
-        "theorem": "Real.log",
-        "description": "Natural logarithm",
-        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
-      }
+      "Mathlib.Combinatorics.SimpleGraph.Basic",
+      "Mathlib.Order.Filter.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Data.Finset.Basic",
+      "Mathlib.Tactic"
     ],
     "originalContributions": [
-      "Definition of χ/ω ratio for graphs",
+      "Definition of χ/ω ratio (chiOmegaRatio) for SimpleGraph V",
       "Definition of f(n) as maximum ratio over n-vertex graphs",
-      "Statement of Tutte-Zykov construction (ω=2, χ arbitrary)",
-      "Statement of Erdős's asymptotic bounds",
-      "Formalization of limit existence question",
-      "Connection to perfect graphs and Strong Perfect Graph Theorem",
-      "Mycielski and Kneser graph constructions",
-      "Ramsey theory connection"
+      "Formalization of Tutte-Zykov construction (ω=2, χ arbitrary)",
+      "Statement of Erdős's asymptotic bounds f(n) = Θ(n/(log n)²)",
+      "Formalization of limit existence question via Filter.Tendsto",
+      "Proof that perfect graph ratio is exactly 1",
+      "Connection to Ramsey numbers: f(R(k,k)) ≥ k",
+      "Mycielski and Kneser graph constructions with chromatic properties",
+      "Strong Perfect Graph Theorem statement (Chudnovsky et al. 2006)"
     ]
   },
   "overview": {
-    "historicalContext": "This problem explores how far chromatic number can exceed clique number. While ω(G) ≤ χ(G) always, the gap can be arbitrarily large.\n\n**Historical Development:**\n- Tutte and Zykov independently showed ω=2 graphs can have arbitrarily large χ\n- Erdős established f(n) ≍ n/(log n)²\n- The Mycielski construction (1955) gives explicit examples\n- Lovász's proof of Kneser graph chromatic number (1978) provides another construction\n- Strong Perfect Graph Theorem (2006) characterizes χ = ω graphs\n\n**Key insight:** Triangle-free graphs can require arbitrarily many colors!",
-    "problemStatement": "**Setup:** Let f(n) = max χ(G)/ω(G) over all graphs G on n vertices.\n\n**Question:** Does lim_{n→∞} f(n) / (n/(log n)²) exist?\n\n**Status:** OPEN\n- f(n) ≍ n/(log n)² is known (Erdős)\n- If the limit exists, it lies in (log 2)² · [1/4, 1] ≈ [0.12, 0.48]\n- The ratio is bounded but may oscillate",
-    "proofStrategy": "The formalization:\n\n1. Defines clique number ω(G) and chromatic number χ(G)\n2. Defines the ratio χ/ω and proves it's ≥ 1\n3. Defines f(n) as the supremum of ratios\n4. States Tutte-Zykov construction showing f(n) → ∞\n5. States Erdős's asymptotic bounds\n6. Formalizes limit existence and potential bounds\n7. Connects to perfect graphs (χ = ω always)\n8. References Mycielski and Kneser constructions",
+    "historicalContext": "The gap between chromatic number and clique number has been a central theme in graph theory since the 1940s. Tutte (1947) and Zykov (1949) independently constructed triangle-free graphs with arbitrarily large chromatic number, disproving the intuition that local sparsity implies easy colorability. Their recursive constructions showed $\\omega = 2$ is compatible with $\\chi = k$ for any $k$.\n\nErdős transformed the field in 1959 with his celebrated probabilistic proof that graphs of arbitrarily high girth and chromatic number exist—a non-constructive argument that stunned the mathematical community. This result, along with his asymptotic analysis, established $f(n) = \\Theta(n/(\\log n)^2)$ where $f(n) = \\max_{|V(G)|=n} \\chi(G)/\\omega(G)$. The lower bound comes from random graphs $G(n, n^{-1/2})$, which have $\\omega = O(\\sqrt{n} \\log n)$ and $\\chi = \\Omega(\\sqrt{n}/\\log n)$.\n\nMycielski (1955) gave the first explicit construction: a recursive family $M_k$ with $\\omega(M_k) = 2$ and $\\chi(M_k) = k$. Lovász (1978) proved $\\chi(K(n,k)) = n - 2k + 2$ for Kneser graphs using the Borsuk-Ulam theorem, founding topological combinatorics. The Strong Perfect Graph Theorem (Chudnovsky, Robertson, Seymour, Thomas 2006) characterized graphs where $\\chi = \\omega$ always holds, settling Berge's 1961 conjecture after 45 years.\n\nProblem #627 asks whether the normalized function $f(n)/(n/(\\log n)^2)$ converges. If the limit $L$ exists, it lies in $(\\log 2)^2 \\cdot [1/4, 1] \\approx [0.12, 0.48]$. The $4\\times$ gap between these bounds reflects deep uncertainty about the precise constant.",
+    "problemStatement": "**Setup:** Let $f(n) = \\max_{|V(G)|=n} \\chi(G)/\\omega(G)$.\n\n**Question:** Does $\\lim_{n\\to\\infty} f(n) / (n/(\\log n)^2)$ exist?\n\n**Status:** OPEN\n- $f(n) \\asymp n/(\\log n)^2$ is known (Erdős)\n- If the limit exists, it lies in $(\\log 2)^2 \\cdot [1/4, 1] \\approx [0.12, 0.48]$\n- The ratio is bounded but may oscillate",
+    "proofStrategy": "The formalization defines clique number $\\omega(G)$ and chromatic number $\\chi(G)$ as noncomputable functions on `SimpleGraph V`, then builds the ratio $\\chi/\\omega$ and the extremal function $f(n)$.\n\nThe Tutte-Zykov construction and Erdős asymptotic are axiomatized since they require probabilistic arguments and recursive constructions not yet in Mathlib. The limit existence question uses `Filter.Tendsto` with `Filter.atTop` and `nhds L`.\n\nConnections to perfect graphs ($\\chi = \\omega$ characterized by the Strong Perfect Graph Theorem), Ramsey theory ($f(R(k,k)) \\geq k$), and explicit constructions (Mycielski, Kneser) are formalized to provide context.",
     "keyInsights": [
-      "**χ ≥ ω always:** A k-clique needs k colors, providing a lower bound on χ.",
-      "**Gap can be huge:** Tutte-Zykov shows χ/ω can be arbitrarily large even with ω = 2.",
-      "**f(n) = Θ(n/(log n)²):** The maximum ratio grows roughly like n/(log n)².",
-      "**Perfect graphs:** For perfect graphs, χ = ω exactly (no gap).",
-      "**Limit bounds:** If the limit exists, it's roughly between 0.12 and 0.48."
+      "**$\\chi \\geq \\omega$ always:** A $k$-clique forces $k$ colors, but the gap $\\chi - \\omega$ can grow as $\\Theta(n/(\\log n)^2)$ for $n$-vertex graphs.",
+      "**Tutte-Zykov surprise:** Triangle-free ($\\omega = 2$) graphs can have arbitrarily large $\\chi$, first shown constructively by Tutte (1947) and Zykov (1949), then non-constructively by Erdős (1959).",
+      "**$f(n) = \\Theta(n/(\\log n)^2)$:** The lower bound uses random graphs $G(n, n^{-1/2})$ via the probabilistic method; the upper bound uses Ramsey-type arguments bounding $\\omega \\geq c\\log n$.",
+      "**Perfect graphs give ratio 1:** The Strong Perfect Graph Theorem (2006) characterizes when $\\chi = \\omega$ for all induced subgraphs, showing extremal graphs must contain odd holes or antiholes.",
+      "**Limit bounds $(\\log 2)^2 \\cdot [1/4, 1]$:** The upper bound comes from $R(k,k) \\leq 4^k$ (giving $\\omega \\geq \\frac{1}{2}\\log_2 n$); the lower bound from explicit constructions. The $4\\times$ gap remains open."
     ]
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "summary": "Imports full Mathlib for `SimpleGraph`, `Filter.Tendsto`, and `Real.log`. Declares vertex type $V$ with `Fintype` and `DecidableEq` instances.",
+      "startLine": 22,
+      "endLine": 28
+    },
+    {
       "id": "basic-parameters",
       "title": "Basic Graph Parameters",
-      "summary": "Clique number, chromatic number, colorability",
+      "summary": "Defines clique number $\\omega(G)$ and chromatic number $\\chi(G)$ as noncomputable functions. Defines $k$-colorability (`IsKColorable`) and clique containment (`ContainsClique`) via `Finset V`.",
       "startLine": 30,
       "endLine": 46
     },
     {
       "id": "ratio",
       "title": "The Ratio χ/ω",
-      "summary": "Definition and basic properties",
+      "summary": "Defines `chiOmegaRatio G = (χ(G) : ℝ) / (ω(G) : ℝ)`. Proves $\\chi \\geq \\omega$ always and that the ratio $\\geq 1$ when $\\omega > 0$.",
       "startLine": 48,
       "endLine": 62
     },
     {
       "id": "f-function",
       "title": "The Function f(n)",
-      "summary": "Maximum ratio over n-vertex graphs",
+      "summary": "Defines $f(n) = \\sup_{|V(G)|=n} \\chi(G)/\\omega(G)$. Proves $f(n) \\geq 1$ for $n \\geq 1$ and monotonicity of $f$.",
       "startLine": 64,
       "endLine": 76
     },
     {
       "id": "tutte-zykov",
       "title": "Tutte-Zykov Construction",
-      "summary": "Triangle-free graphs with large χ",
+      "summary": "Axiomatizes the Tutte-Zykov theorem: $\\forall k,\\, \\exists G$ with $\\omega(G) = 2$ and $\\chi(G) \\geq k$. Derives $f(n) \\to \\infty$ and existence of triangle-free graphs with large $\\chi$.",
       "startLine": 78,
       "endLine": 98
     },
     {
       "id": "erdos-asymptotics",
       "title": "Erdős's Asymptotic Bounds",
-      "summary": "f(n) ≍ n/(log n)²",
+      "summary": "Axiomatizes $f(n) \\asymp n/(\\log n)^2$ with explicit constants $c_1, c_2$. Defines `fNormalized` and proves the normalized ratio is bounded. States a weaker lower bound $f(n) \\gg n^{1/2}/\\log n$.",
       "startLine": 100,
       "endLine": 128
     },
     {
       "id": "main-question",
       "title": "The Main Question",
-      "summary": "Does the limit of f(n)/(n/(log n)²) exist?",
+      "summary": "Defines `LimitExists` via `Filter.Tendsto fNormalized atTop (nhds L)`. Axiomatizes the conditional bound: if $L$ exists, $L \\in (\\log 2)^2 \\cdot [1/4, 1]$. Defines numerical limit bounds $\\approx [0.12, 0.48]$.",
       "startLine": 130,
       "endLine": 148
     },
     {
       "id": "perfect-graphs",
       "title": "Perfect Graphs",
-      "summary": "Graphs with χ = ω",
+      "summary": "Defines `IsPerfect G` as $\\chi(H) = \\omega(H)$ for all induced subgraphs $H$. Proves perfect graphs have ratio exactly 1. Axiomatizes the Strong Perfect Graph Theorem (Chudnovsky et al. 2006).",
       "startLine": 150,
       "endLine": 168
     },
     {
       "id": "ramsey",
       "title": "Ramsey Theory Connection",
-      "summary": "Ramsey numbers and f(n)",
+      "summary": "Defines `ramseyNumber k` and proves $f(R(k,k)) \\geq k$. Axiomatizes $R(k,k) \\leq 4^k$ connecting diagonal Ramsey bounds to the $\\chi/\\omega$ extremal function.",
       "startLine": 170,
       "endLine": 183
     },
     {
       "id": "constructions",
       "title": "Explicit Constructions",
-      "summary": "Mycielski and Kneser graphs",
+      "summary": "Defines Mycielski graphs ($\\omega = 2$, $\\chi = k$) and Kneser graphs $K(n,k)$. Axiomatizes Lovász's theorem $\\chi(K(n,k)) = n - 2k + 2$ (1978, via Borsuk-Ulam).",
       "startLine": 185,
       "endLine": 204
     },
     {
       "id": "main-status",
       "title": "Main Problem Status",
-      "summary": "Complete status summary",
+      "summary": "Combines the Erdős asymptotic and Tutte-Zykov construction into `erdos_627_status`, proving both hold simultaneously. Includes `#check` commands for key axioms.",
       "startLine": 224,
       "endLine": 252
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #627 is OPEN. We know f(n) = Θ(n/(log n)²), where f(n) is the maximum χ/ω ratio over n-vertex graphs, but whether the normalized limit exists is unknown. If the limit exists, it lies in (log 2)² · [1/4, 1] ≈ [0.12, 0.48].",
-    "implications": "This problem connects to:\n\n1. **Perfect Graph Theory:** The Strong Perfect Graph Theorem characterizes χ = ω\n2. **Extremal Graph Theory:** Understanding gaps between graph parameters\n3. **Ramsey Theory:** Ramsey numbers provide bounds on f(n)\n4. **Graph Constructions:** Mycielski, Kneser graphs achieve high χ/ω\n5. **Probabilistic Method:** Random graphs contribute to bounds",
+    "summary": "Erdős Problem #627 is OPEN. We know $f(n) = \\Theta(n/(\\log n)^2)$, where $f(n)$ is the maximum $\\chi/\\omega$ ratio over $n$-vertex graphs, but whether the normalized limit $\\lim_{n\\to\\infty} f(n)/(n/(\\log n)^2)$ exists remains unknown. If the limit exists, it lies in $(\\log 2)^2 \\cdot [1/4, 1] \\approx [0.12, 0.48]$. The formalization captures the full landscape: Tutte-Zykov constructions, the Erdős asymptotic, perfect graph characterization, Ramsey connections, and explicit Mycielski/Kneser families.",
+    "implications": "This problem connects several pillars of combinatorics:\n\n1. **Perfect Graph Theory:** The SPGT (2006) characterizes when $\\chi = \\omega$, showing extremal graphs must be imperfect\n2. **Probabilistic Method:** Erdős's random graph arguments provide the best lower bounds on $f(n)$\n3. **Ramsey Theory:** Diagonal Ramsey bounds $R(k,k) \\leq 4^k$ directly constrain the limit\n4. **Topological Combinatorics:** Lovász's Kneser graph proof (1978) via Borsuk-Ulam opened a new field\n5. **Extremal Graph Theory:** Understanding which graphs maximize $\\chi/\\omega$ for fixed vertex count",
     "openQuestions": [
-      "Does lim_{n→∞} f(n)/(n/(log n)²) exist?",
-      "If the limit exists, what is its exact value?",
-      "Can the bounds (log 2)²·[1/4, 1] be narrowed?",
-      "What is the structure of extremal graphs achieving f(n)?",
-      "How does the answer change if we restrict to specific graph classes?"
+      "Does $\\lim_{n\\to\\infty} f(n)/(n/(\\log n)^2)$ exist, or does the normalized ratio oscillate between the known bounds?",
+      "Can the gap $(\\log 2)^2 \\cdot [1/4, 1]$ be narrowed by improving either the Ramsey upper bound or explicit construction lower bound?",
+      "What is the structure of extremal graphs achieving $f(n)$—are they random-like, or do they have algebraic structure (e.g., Paley graphs)?",
+      "Does the answer change for restricted graph classes (e.g., $K_t$-minor-free graphs, where Hadwiger's conjecture predicts $\\chi \\leq t-1$)?"
     ]
-  }
+  },
+  "relatedProofs": [
+    {
+      "id": "erdos-613",
+      "relationship": "Both involve Ramsey-theoretic phenomena in graph theory—erdos-613 addresses size Ramsey numbers while erdos-627 uses Ramsey bounds to constrain the χ/ω limit"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Enriched annotations from 17 to 22, all with `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites`
- Added annotations for imports/setup and growth rate analysis section
- Fixed 4 invalid "axiom" annotation types to "theorem"
- Deepened `historicalContext` with Tutte 1947, Zykov 1949, Erdős 1959 probabilistic proof, Mycielski 1955, Lovász 1978 Borsuk-Ulam, SPGT 2006 (~1500 chars)
- Added LaTeX to all 11 section summaries
- Made `keyInsights` reference specific bounds and random graph model $G(n, n^{-1/2})$
- Made `openQuestions` specific: oscillation vs convergence, Paley graph structure, Hadwiger conjecture connection
- Added `relatedProofs` cross-reference to erdos-613

## Test plan
- [x] `pnpm annotations:build` passes (non-strict warnings only, none from erdos-627)

🤖 Generated with [Claude Code](https://claude.com/claude-code)