### PR TITLE
fix: enricher type safety for recent enrichments

### DIFF
--- a/src/data/proofs/erdos-606/index.ts
+++ b/src/data/proofs/erdos-606/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
 // Type assertion for JSON import
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/erdos-612/index.ts
+++ b/src/data/proofs/erdos-612/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
 // Type assertion for JSON import
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/erdos-620/index.ts
+++ b/src/data/proofs/erdos-620/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
 // Type assertion for JSON import
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/erdos-623/index.ts
+++ b/src/data/proofs/erdos-623/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
 // Type assertion for JSON import
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/erdos-623/meta.json
+++ b/src/data/proofs/erdos-623/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/623",
     "erdosProblemStatus": "open",
     "mathlibDependencies": [
-      "Mathlib.SetTheory.Cardinal.Ordinal",
-      "Mathlib.SetTheory.Cardinal.Cofinality",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Data.Set.Finite"
+      { "theorem": "Cardinal.aleph", "description": "Aleph cardinal numbers (Mathlib.SetTheory.Cardinal.Ordinal)" },
+      { "theorem": "Cardinal.IsLimit", "description": "Limit cardinals and cofinality (Mathlib.SetTheory.Cardinal.Cofinality)" },
+      { "theorem": "Finset", "description": "Finite sets (Mathlib.Data.Finset.Basic)" },
+      { "theorem": "Set.Finite", "description": "Finite set predicate (Mathlib.Data.Set.Finite)" }
     ],
     "originalContributions": [
       "Definition of free functions (IsFreeFunction) and independent sets (IsIndependent) in Lean 4",

--- a/src/data/proofs/erdos-627/index.ts
+++ b/src/data/proofs/erdos-627/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
 // Type assertion for JSON import
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -24,11 +24,11 @@
     "erdosUrl": "https://erdosproblems.com/627",
     "erdosProblemStatus": "open",
     "mathlibDependencies": [
-      "Mathlib.Combinatorics.SimpleGraph.Basic",
-      "Mathlib.Order.Filter.Basic",
-      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Tactic"
+      { "theorem": "SimpleGraph", "description": "Simple undirected graphs (Mathlib.Combinatorics.SimpleGraph.Basic)" },
+      { "theorem": "Filter.Tendsto", "description": "Filter-based limits (Mathlib.Order.Filter.Basic)" },
+      { "theorem": "Real.log", "description": "Logarithm function (Mathlib.Analysis.SpecialFunctions.Log.Basic)" },
+      { "theorem": "Finset", "description": "Finite sets (Mathlib.Data.Finset.Basic)" },
+      { "theorem": "Tactic", "description": "Core tactic library (Mathlib.Tactic)" }
     ],
     "originalContributions": [
       "Definition of χ/ω ratio (chiOmegaRatio) for SimpleGraph V",


### PR DESCRIPTION
## Summary
- Fix TS2352 type errors in enricher-generated index.ts files by using `as unknown as` instead of `as {`
- Convert plain string `mathlibDependencies` to proper `{theorem, description}` objects in erdos-623 and erdos-627 meta.json
- Affects: erdos-606, erdos-612, erdos-620, erdos-623, erdos-627

## Test plan
- [x] `pnpm build` passes after these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)