### PR TITLE
enrich: deepen annotations and meta for erdos-652, erdos-657, erdos-660, erdos-664, erdos-631

### DIFF
--- a/src/data/proofs/erdos-631/annotations.json
+++ b/src/data/proofs/erdos-631/annotations.json
@@ -1,12 +1,27 @@
 [
   {
-    "id": "ann-631-header",
+    "id": "ann-631-imports",
     "proofId": "erdos-631",
-    "range": { "startLine": 1, "endLine": 18 },
-    "type": "concept",
-    "title": "Problem Overview",
-    "content": "**Erdős #631:** List chromatic number of planar graphs.\n\n**Question 1:** Does every planar graph have χ_L ≤ 5?\n**Answer:** YES (Thomassen 1994)\n\n**Question 2:** Is this best possible?\n**Answer:** YES (Voigt 1993)\n\n**Status:** SOLVED (both questions answered affirmatively)",
-    "significance": "critical"
+    "range": { "startLine": 20, "endLine": 26 },
+    "type": "context",
+    "title": "Imports and Setup",
+    "content": "Imports all of Mathlib and opens Finset, Function, SimpleGraph, and Nat namespaces. Introduces universe-polymorphic vertex type V with Fintype and DecidableEq instances.",
+    "significance": "useful",
+    "mathContext": "The formalization uses Mathlib's $\\text{SimpleGraph}$ for undirected graphs, $\\text{Finset}$ for finite color sets and list assignments, and $\\text{Fintype}$ to ensure vertex sets are finite. The universe-polymorphic vertex type $V$ allows the theorems to apply to graphs on any finite vertex set.",
+    "relatedConcepts": ["SimpleGraph API", "Fintype instance", "universe polymorphism"],
+    "prerequisites": ["SimpleGraph", "Fintype", "DecidableEq"]
+  },
+  {
+    "id": "ann-631-chromatic",
+    "proofId": "erdos-631",
+    "range": { "startLine": 30, "endLine": 36 },
+    "type": "definition",
+    "title": "Chromatic Number and k-Colorability",
+    "content": "Defines chromaticNumber G as the minimum k for k-colorability (sorry), and IsKColorable G k as the existence of a proper k-coloring f : V → Fin k with f(v) ≠ f(w) for adjacent v, w.",
+    "significance": "key",
+    "mathContext": "The chromatic number $\\chi(G) = \\min\\{k : G \\text{ is } k\\text{-colorable}\\}$. A proper $k$-coloring is a function $f: V \\to [k]$ with $f(v) \\neq f(w)$ whenever $vw \\in E(G)$. The Four Color Theorem states $\\chi(G) \\leq 4$ for planar $G$. The definition sorry reflects that $\\chi(G)$ requires a $\\min$ over a computable predicate, which is non-trivial to formalize constructively.",
+    "relatedConcepts": ["graph coloring", "proper coloring", "chromatic polynomial"],
+    "prerequisites": ["SimpleGraph.Adj", "Fin type"]
   },
   {
     "id": "ann-631-list-assignment",
@@ -14,26 +29,23 @@
     "range": { "startLine": 40, "endLine": 41 },
     "type": "definition",
     "title": "List Assignment",
-    "content": "A **list assignment** L gives each vertex v a finite set L(v) of available colors.\n\nDifferent vertices can have different lists — this is what makes list coloring harder than ordinary coloring.\n\nExample: v₁ gets {red, blue}, v₂ gets {blue, green}.",
-    "significance": "critical"
+    "content": "A list assignment L gives each vertex v a finite set L(v) of available colors from some color type C. This generalizes ordinary coloring where all vertices share the same palette.",
+    "significance": "critical",
+    "mathContext": "A *list assignment* is a function $L: V \\to \\mathcal{P}_{\\text{fin}}(C)$ mapping each vertex to a finite set of colors. The key departure from ordinary coloring: different vertices may have different available colors. This models real-world constraints where resources (frequencies, time slots) vary by location. The type $C$ is left abstract, allowing colors from any decidable-equality type.",
+    "relatedConcepts": ["graph coloring", "constraint satisfaction", "frequency assignment"],
+    "prerequisites": ["Finset", "DecidableEq"]
   },
   {
     "id": "ann-631-list-coloring",
     "proofId": "erdos-631",
-    "range": { "startLine": 43, "endLine": 47 },
+    "range": { "startLine": 43, "endLine": 53 },
     "type": "definition",
-    "title": "List Coloring",
-    "content": "A **list coloring** assigns each vertex a color from its list such that adjacent vertices get different colors.\n\n- Each vertex uses a color from its own list\n- The coloring must still be proper (no adjacent same colors)\n\nThe challenge: works for ANY list assignment, not just specific ones.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-631-choosable",
-    "proofId": "erdos-631",
-    "range": { "startLine": 49, "endLine": 53 },
-    "type": "definition",
-    "title": "k-Choosable",
-    "content": "G is **k-choosable** (k-list-colorable) if for ANY assignment of lists of size k, a proper list coloring exists.\n\nThis is a worst-case guarantee: no matter what lists you give, coloring succeeds.\n\nk-choosability implies (k+1)-choosability.",
-    "significance": "critical"
+    "title": "List Coloring and k-Choosability",
+    "content": "IsListColoring requires each vertex's color to come from its list AND the coloring to be proper. IsKChoosable G k requires that for ANY list assignment with lists of size ≥ k, a proper list coloring exists.",
+    "significance": "critical",
+    "mathContext": "A graph $G$ is *$k$-choosable* (or *$k$-list-colorable*) if for every list assignment $L$ with $|L(v)| \\geq k$ for all $v$, there exists a proper coloring $f$ with $f(v) \\in L(v)$. The universal quantification over all list assignments makes $k$-choosability strictly stronger than $k$-colorability: $k$-choosable $\\Rightarrow$ $k$-colorable (take all lists equal to $[k]$), but not conversely. The formalization quantifies over all color types $C$, ensuring the result holds regardless of the color universe.",
+    "relatedConcepts": ["choosability", "online list coloring", "paint number"],
+    "prerequisites": ["ListAssignment", "IsListColoring", "SimpleGraph.Adj"]
   },
   {
     "id": "ann-631-chi-L",
@@ -41,8 +53,11 @@
     "range": { "startLine": 55, "endLine": 57 },
     "type": "definition",
     "title": "List Chromatic Number",
-    "content": "`listChromaticNumber G` = χ_L(G) = minimum k such that G is k-choosable.\n\nThis measures the 'list coloring difficulty' of G.\n\nχ_L(G) ≥ χ(G) always, but the gap can vary.",
-    "significance": "critical"
+    "content": "The list chromatic number χ_L(G) is the minimum k such that G is k-choosable. Also called the choosability or choice number of G.",
+    "significance": "critical",
+    "mathContext": "The *list chromatic number* $\\chi_L(G) = \\min\\{k : G \\text{ is } k\\text{-choosable}\\}$ satisfies $\\chi_L(G) \\geq \\chi(G)$ always (since $k$-choosability implies $k$-colorability). The gap $\\chi_L - \\chi$ can be arbitrarily large: the complete bipartite graph $K_{n,n}$ has $\\chi = 2$ but $\\chi_L = \\lceil \\log_2 n \\rceil + 1$. For planar graphs, Thomassen proved $\\chi_L \\leq 5$ while the Four Color Theorem gives $\\chi \\leq 4$.",
+    "relatedConcepts": ["choosability", "choice number", "Galvin's theorem"],
+    "prerequisites": ["IsKChoosable"]
   },
   {
     "id": "ann-631-chi-L-ge-chi",
@@ -50,88 +65,106 @@
     "range": { "startLine": 61, "endLine": 64 },
     "type": "theorem",
     "title": "χ_L ≥ χ",
-    "content": "**List chromatic number ≥ chromatic number.**\n\nIf all vertices get the same list of k colors, list coloring reduces to ordinary k-coloring.\n\nSo k-choosability implies k-colorability, hence χ_L ≥ χ.",
-    "significance": "key"
+    "content": "The list chromatic number is always at least the chromatic number. Proved by observing that k-choosability with identical lists reduces to k-colorability.",
+    "significance": "key",
+    "mathContext": "The inequality $\\chi_L(G) \\geq \\chi(G)$ follows because ordinary $k$-coloring is a special case of list coloring where $L(v) = [k]$ for all $v$. If $G$ is $k$-choosable, it can handle *any* lists of size $k$, including identical ones, so it is $k$-colorable. The converse fails: $K_{3,3}$ is 2-colorable but not 2-choosable.",
+    "relatedConcepts": ["choosability gap", "complete bipartite graphs", "Dinitz conjecture"],
+    "prerequisites": ["listChromaticNumber", "chromaticNumber"]
+  },
+  {
+    "id": "ann-631-choosable-implies",
+    "proofId": "erdos-631",
+    "range": { "startLine": 66, "endLine": 91 },
+    "type": "theorem",
+    "title": "Choosability Properties",
+    "content": "Two properties: (1) k-choosability is monotone (k-choosable implies (k+1)-choosable), and (2) k-choosability implies k-colorability. The second is proved by Aristotle using a contrapositive argument with ULift and Finset.filter.",
+    "significance": "key",
+    "mathContext": "Monotonicity: if $G$ is $k$-choosable and $|L(v)| \\geq k+1$, we can restrict each list to a $k$-element subset and apply $k$-choosability. The Aristotle proof of $k$-choosable $\\Rightarrow$ $k$-colorable works by contraposition: if $G$ is not $k$-colorable, construct a specific list assignment (using $\\text{ULift}(\\text{Fin}\\,(k+1))$) that witnesses failure of $k$-choosability. This is one of the few fully machine-proved results in the file.",
+    "relatedConcepts": ["monotonicity", "contrapositive proof", "Aristotle proof search"],
+    "prerequisites": ["IsKChoosable", "IsKColorable", "IsListColoring"]
   },
   {
     "id": "ann-631-planar",
     "proofId": "erdos-631",
-    "range": { "startLine": 94, "endLine": 96 },
+    "range": { "startLine": 94, "endLine": 108 },
     "type": "definition",
-    "title": "Planar Graphs",
-    "content": "A graph is **planar** if it can be drawn in the plane without edge crossings.\n\nPlanarity severely constrains graph structure.\n\nK_5 and K_{3,3} are the minimal non-planar graphs (Kuratowski).",
-    "significance": "key"
+    "title": "Planar Graphs and Euler's Formula",
+    "content": "Defines IsPlanar G (sorry — embeddable in the plane). Axiomatizes Euler's formula V - E + F = 2 for connected planar graphs and the edge bound |E| ≤ 3|V| - 6.",
+    "significance": "key",
+    "mathContext": "A graph $G$ is *planar* if it can be embedded in $\\mathbb{R}^2$ without edge crossings. Euler's formula $|V| - |E| + |F| = 2$ for connected planar graphs implies $|E| \\leq 3|V| - 6$ (since each face has $\\geq 3$ boundary edges and each edge borders $\\leq 2$ faces). This sparsity bound is crucial: it implies every planar graph has a vertex of degree $\\leq 5$, enabling inductive proofs like Thomassen's. Planarity is defined as sorry because formalizing topological embeddings in Lean is non-trivial.",
+    "relatedConcepts": ["Euler's formula", "Kuratowski's theorem", "graph minor", "Wagner's theorem"],
+    "prerequisites": ["SimpleGraph", "edgeFinset", "Connected"]
   },
   {
     "id": "ann-631-four-color",
     "proofId": "erdos-631",
-    "range": { "startLine": 98, "endLine": 104 },
+    "range": { "startLine": 110, "endLine": 120 },
     "type": "axiom",
-    "title": "Four Color Theorem",
-    "content": "**Every planar graph has χ ≤ 4.**\n\nFamously proved by Appel & Haken (1976) using computers.\n\nBut this doesn't immediately give χ_L ≤ 4 — that's the List Coloring Conjecture!",
-    "significance": "key"
+    "title": "Four Color and Five Color Theorems",
+    "content": "Axiomatizes both the Four Color Theorem (χ ≤ 4 for planar, Appel-Haken 1976) and the easier Five Color Theorem (χ ≤ 5).",
+    "significance": "key",
+    "mathContext": "The Four Color Theorem ($\\chi(G) \\leq 4$ for planar $G$) was proved by Appel and Haken (1976) using extensive computer verification, later verified by Gonthier et al. in Coq. The Five Color Theorem ($\\chi(G) \\leq 5$) has a short human proof via vertex of degree $\\leq 5$. For list coloring, the Four Color Theorem does NOT directly imply $\\chi_L \\leq 4$ because list coloring is strictly harder — this gap motivates Problem #631.",
+    "relatedConcepts": ["Appel-Haken proof", "computer-verified proof", "Gonthier formalization"],
+    "prerequisites": ["IsPlanar", "chromaticNumber"]
   },
   {
     "id": "ann-631-thomassen",
     "proofId": "erdos-631",
-    "range": { "startLine": 125, "endLine": 127 },
+    "range": { "startLine": 122, "endLine": 143 },
     "type": "axiom",
-    "title": "Thomassen's Theorem",
-    "content": "**Thomassen (1994):** Every planar graph has χ_L ≤ 5.\n\nThis is the main result! The proof is remarkably short and elegant.\n\nUses induction on |V| + |E| with careful analysis of near-triangulations.\n\nAnswers Question 1 of Erdős #631.",
-    "significance": "critical"
+    "title": "Thomassen's 5-List Theorem",
+    "content": "Thomassen (1994): every planar graph has χ_L ≤ 5. The proof uses induction on |V| + |E| with reduction to near-triangulations where two adjacent vertices on the outer face are precolored. This is the main result answering Question 1.",
+    "significance": "critical",
+    "mathContext": "Thomassen's proof is celebrated for its brevity (3 pages) and elegance. The key technique: consider a *near-triangulation* (planar graph where all bounded faces are triangles) with outer cycle $C$, and two adjacent vertices $v_1, v_2$ on $C$ already colored. If all vertices on $C$ have lists of size $\\geq 3$ and all interior vertices have lists of size $\\geq 5$, a proper list coloring exists. The proof proceeds by induction on $|V| + |E|$: either find a chord of $C$ (splitting into smaller near-triangulations) or use a vertex of degree $\\leq 4$ on $C$ to reduce.",
+    "relatedConcepts": ["near-triangulation", "induction on V+E", "precoloring extension", "Heawood's theorem"],
+    "prerequisites": ["IsPlanar", "listChromaticNumber", "IsKChoosable"]
   },
   {
     "id": "ann-631-voigt",
     "proofId": "erdos-631",
-    "range": { "startLine": 147, "endLine": 150 },
+    "range": { "startLine": 145, "endLine": 165 },
     "type": "axiom",
-    "title": "Voigt's Construction",
-    "content": "**Voigt (1993):** There exists a planar graph with χ_L = 5.\n\nThis shows Thomassen's bound is tight!\n\nThe original construction had 238 vertices.\n\nAnswers Question 2 of Erdős #631: YES, the bound is best possible.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-631-voigt-size",
-    "proofId": "erdos-631",
-    "range": { "startLine": 152, "endLine": 155 },
-    "type": "axiom",
-    "title": "Voigt's Graph Size",
-    "content": "Voigt's original construction has 238 vertices.\n\nThis is quite large! Researchers have worked to find smaller examples.\n\nGutner (1996) gave a simpler construction with fewer vertices.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-631-smallest",
-    "proofId": "erdos-631",
-    "range": { "startLine": 162, "endLine": 165 },
-    "type": "axiom",
-    "title": "Smallest Known Example",
-    "content": "The smallest known planar graph with χ_L = 5 has about 63 vertices.\n\nFinding smaller examples is an active area of research.\n\nThe exact minimum is unknown.",
-    "significance": "supporting"
+    "title": "Voigt's Construction and Sharpness",
+    "content": "Voigt (1993): there exists a planar graph with χ_L = 5, showing Thomassen's bound is tight. The original construction has 238 vertices. Gutner (1996) simplified it, and the smallest known example has ≤ 63 vertices.",
+    "significance": "critical",
+    "mathContext": "Voigt's construction answers Question 2: 5-choosability is best possible for planar graphs. The construction builds a planar graph $G$ and exhibits specific 4-element lists $L(v)$ for which no proper list coloring exists. The graph must be intricate enough that the list assignment creates a combinatorial deadlock. Finding smaller examples is an active area: Voigt's 238-vertex graph was reduced to $\\sim 63$ vertices. The exact minimum size is unknown and connects to the structure theory of non-4-choosable planar graphs.",
+    "relatedConcepts": ["extremal graph", "non-choosable construction", "Mirzakhani construction"],
+    "prerequisites": ["IsPlanar", "listChromaticNumber"]
   },
   {
     "id": "ann-631-list-conj",
     "proofId": "erdos-631",
-    "range": { "startLine": 169, "endLine": 172 },
+    "range": { "startLine": 167, "endLine": 185 },
     "type": "definition",
-    "title": "List Coloring Conjecture",
-    "content": "**Open:** Is χ_L ≤ 4 for all planar graphs?\n\nWe know χ ≤ 4 (Four Color Theorem) and χ_L ≤ 5 (Thomassen).\n\nClosing this gap is a major open problem!\n\nVoigt's construction has χ_L = 5, not 4, so some graphs need 5.",
-    "significance": "critical"
+    "title": "List Coloring Conjecture and the Gap",
+    "content": "The List Coloring Conjecture asks: is every planar graph 4-choosable? This would close the gap between χ ≤ 4 (Four Color) and χ_L ≤ 5 (Thomassen). The chromatic_list_gap theorem formally states both bounds.",
+    "significance": "critical",
+    "mathContext": "The *List Coloring Conjecture* for planar graphs: $\\chi_L(G) \\leq 4$ for all planar $G$. This is distinct from the general List Coloring Conjecture (also called the List Edge Coloring Conjecture), which states $\\chi_L'(G) = \\chi'(G)$ for all graphs. For planar graphs, we have $\\chi \\leq 4$ (Four Color) and $\\chi_L \\leq 5$ (Thomassen), so the gap is exactly 1. The theorem $\\texttt{chromatic\\_list\\_gap}$ bundles both bounds cleanly using $\\texttt{four\\_color\\_theorem}$ and $\\texttt{thomassen\\_five\\_list\\_theorem}$.",
+    "relatedConcepts": ["edge list coloring", "Dinitz conjecture", "Galvin's theorem"],
+    "prerequisites": ["listColoringConjecture", "four_color_theorem", "thomassen_five_list_theorem"]
   },
   {
-    "id": "ann-631-gap",
+    "id": "ann-631-related",
     "proofId": "erdos-631",
-    "range": { "startLine": 179, "endLine": 183 },
-    "type": "theorem",
-    "title": "The χ vs χ_L Gap",
-    "content": "For planar graphs: χ ≤ 4 (Four Color) but χ_L ≤ 5 (Thomassen).\n\nThe gap is exactly 1 — can it be closed?\n\nIf the List Coloring Conjecture is false, there exist planar graphs with χ ≤ 4 but χ_L = 5.\n\nVoigt's graph has χ_L = 5, but what is its χ?",
-    "significance": "key"
+    "range": { "startLine": 187, "endLine": 232 },
+    "type": "context",
+    "title": "Related Results",
+    "content": "Better bounds for restricted planar graphs: (1) Alon-Tarsi (1992): bipartite planar → χ_L ≤ 3; (2) outerplanar → χ_L ≤ 3; (3) planar with girth ≥ 5 → χ_L ≤ 3. Also includes Thomassen's proof structure: key lemma about precolored edges and induction strategy.",
+    "significance": "key",
+    "mathContext": "These results show that structural restrictions on planar graphs can dramatically improve choosability bounds: **Alon-Tarsi** uses the combinatorial nullstellensatz to prove that bipartite planar graphs are 3-choosable (since they have an orientation where outdegree $\\leq 2$ everywhere). **Girth $\\geq 5$**: the absence of short cycles allows discharge arguments to work with lists of size 3. **Outerplanar**: all vertices on the outer face means maximum degree is bounded by a function of the graph structure. These results suggest that 4-choosability might hold for all planar graphs if the right technique is found.",
+    "relatedConcepts": ["Alon-Tarsi theorem", "combinatorial nullstellensatz", "discharge method", "girth"],
+    "prerequisites": ["IsPlanar", "IsBipartite", "IsOuterplanar", "girth"]
   },
   {
     "id": "ann-631-main",
     "proofId": "erdos-631",
-    "range": { "startLine": 263, "endLine": 270 },
+    "range": { "startLine": 245, "endLine": 276 },
     "type": "theorem",
-    "title": "Main Status",
-    "content": "**Erdős Problem #631: SOLVED**\n\n1. **Question 1:** χ_L ≤ 5 for planar? YES (Thomassen 1994)\n2. **Question 2:** Is 5 tight? YES (Voigt 1993)\n3. **Gap:** χ ≤ 4 but χ_L ≤ 5 (can we close it?)\n4. **Open:** List Coloring Conjecture (χ_L ≤ 4 for planar)\n5. **Better bounds:** Bipartite planar, outerplanar, girth ≥ 5 all have χ_L ≤ 3",
-    "significance": "critical"
+    "title": "Main Status: erdos_631_status",
+    "content": "The main theorem erdos_631_status bundles both answers: (1) ∀ planar G, χ_L(G) ≤ 5 (Thomassen), and (2) ∃ planar G with χ_L(G) = 5 (Voigt). Both are direct applications of the axiomatized results.",
+    "significance": "critical",
+    "mathContext": "The theorem $\\texttt{erdos\\_631\\_status}$ is proved by $\\langle\\texttt{thomassen\\_five\\_list\\_theorem}, \\texttt{voigt\\_construction}\\rangle$, cleanly packaging both answers. The conjunction type captures the complete resolution: the upper bound $\\chi_L \\leq 5$ is tight. The remaining open question (List Coloring Conjecture) is recorded separately as $\\texttt{listColoringConjecture}$.",
+    "relatedConcepts": ["tight bound", "solved problem", "constructive witness"],
+    "prerequisites": ["thomassen_five_list_theorem", "voigt_construction"]
   }
 ]

--- a/src/data/proofs/erdos-631/meta.json
+++ b/src/data/proofs/erdos-631/meta.json
@@ -15,7 +15,9 @@
       "list-coloring",
       "chromatic-number",
       "planar-graphs",
-      "solved"
+      "solved",
+      "choosability",
+      "topological-graph-theory"
     ],
     "badge": "solved",
     "sorries": 11,
@@ -25,125 +27,157 @@
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph",
-        "description": "Simple undirected graphs",
+        "description": "Simple undirected graphs for modeling planar graphs and adjacency",
         "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
       },
       {
         "theorem": "SimpleGraph.IsBipartite",
-        "description": "Bipartite graphs",
+        "description": "Bipartite graph predicate for the Alon-Tarsi theorem ($\\chi_L \\leq 3$ for bipartite planar)",
         "module": "Mathlib.Combinatorics.SimpleGraph.Bipartite"
       },
       {
         "theorem": "SimpleGraph.girth",
-        "description": "Girth of graphs",
+        "description": "Graph girth for the result that planar graphs with girth $\\geq 5$ are 3-choosable",
         "module": "Mathlib.Combinatorics.SimpleGraph.Girth"
+      },
+      {
+        "theorem": "SimpleGraph.Connected",
+        "description": "Connectedness predicate used in Euler's formula $V - E + F = 2$",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Connectivity"
+      },
+      {
+        "theorem": "SimpleGraph.edgeFinset",
+        "description": "Finite edge set for the planar edge bound $|E| \\leq 3|V| - 6$",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
       }
     ],
     "originalContributions": [
-      "Definition of list chromatic number (choosability)",
-      "Definition of k-choosable graphs",
-      "Statement of Thomassen's 5-list theorem",
-      "Statement of Voigt's construction",
-      "Definition of planar and outerplanar graphs",
-      "Reference to Four Color Theorem",
-      "Reference to Alon-Tarsi theorem",
-      "The List Coloring Conjecture",
-      "Thomassen's proof technique"
+      "ListAssignment and IsListColoring: list coloring framework with abstract color type C",
+      "IsKChoosable: k-choosability as ∀ list assignments with |L(v)| ≥ k, ∃ proper list coloring",
+      "listChromaticNumber: χ_L(G) = min k for k-choosability (noncomputable, sorry)",
+      "chromaticNumber and IsKColorable: ordinary graph coloring definitions",
+      "list_chromatic_ge_chromatic: χ_L ≥ χ (sorry)",
+      "choosable_implies_colorable: k-choosable ⇒ k-colorable (proved by Aristotle)",
+      "IsPlanar: planarity predicate (sorry) with Euler's formula and edge bound axioms",
+      "thomassen_five_list_theorem: χ_L ≤ 5 for planar (axiom, main result)",
+      "voigt_construction: ∃ planar G with χ_L = 5 (axiom, sharpness)",
+      "listColoringConjecture: is χ_L ≤ 4 for planar? (open)",
+      "chromatic_list_gap: bundles Four Color + Thomassen (proved from axioms)",
+      "alon_tarsi_theorem, outerplanar_3_choosable, planar_girth_5_choosable: restricted bounds",
+      "erdos_631_status: complete resolution ⟨Thomassen, Voigt⟩ (proved from axioms)"
+    ],
+    "relatedProofs": [
+      {
+        "id": "erdos-58",
+        "relationship": "Both concern chromatic numbers of structured graph classes; #58 studies chromatic number of triangle-free graphs while #631 studies list chromatic number of planar graphs"
+      },
+      {
+        "id": "erdos-664",
+        "relationship": "Both are resolved Erdős combinatorics problems; #664 studies blocking sets (disproved by Alon) while #631 studies list coloring (proved by Thomassen, tight by Voigt)"
+      }
     ]
   },
   "overview": {
-    "historicalContext": "List coloring generalizes ordinary graph coloring by allowing each vertex to have its own set of available colors. The list chromatic number χ_L(G) is the minimum k such that G is k-choosable.\n\n**Historical Development:**\n- 1979: Erdős, Rubin, Taylor posed the problem\n- 1993: Voigt constructed a planar graph with χ_L = 5\n- 1994: Thomassen proved χ_L ≤ 5 for all planar graphs\n- 1996: Gutner gave simpler construction\n- 2000s: Search for smallest non-4-choosable planar graph\n\n**Key insight:** χ_L can exceed χ, and the gap χ_L vs χ for planar graphs is exactly 1.",
-    "problemStatement": "**Question 1:** Does every planar graph have χ_L(G) ≤ 5?\n\n**Answer:** YES (Thomassen 1994)\n\n**Question 2:** Is this best possible?\n\n**Answer:** YES (Voigt 1993)\n\nThomassen's proof is remarkably short and elegant, using induction on vertices + edges. Voigt's construction shows the bound cannot be improved.\n\n**Open:** Is χ_L ≤ 4 for planar? (List Coloring Conjecture)",
-    "proofStrategy": "The formalization:\n\n1. Defines list assignment and list coloring\n2. Defines k-choosability and χ_L\n3. Shows basic properties (χ_L ≥ χ, monotonicity)\n4. Defines planarity and states Four Color Theorem\n5. States Thomassen's theorem as main result\n6. States Voigt's construction showing sharpness\n7. Discusses the List Coloring Conjecture\n8. Covers related results (Alon-Tarsi, outerplanar, girth)",
+    "historicalContext": "**Origins: Erdős, Rubin, and Taylor (1979)**\n\nProblem #631 was posed by Erdős, Rubin, and Taylor in their foundational 1979 paper on list coloring. They introduced the concept of choosability — a strengthening of graph coloring where each vertex has its own list of available colors — and asked two questions about planar graphs: (1) Is every planar graph 5-choosable? (2) Is 5 best possible?\n\n**List Coloring: A Harder Problem**\n\nOrdinary graph coloring assigns colors from a shared palette $\\{1, \\ldots, k\\}$; list coloring assigns from vertex-specific lists $L(v)$ with $|L(v)| \\geq k$. The list chromatic number $\\chi_L(G) \\geq \\chi(G)$ always, and the gap can be arbitrarily large: $K_{n,n}$ has $\\chi = 2$ but $\\chi_L = \\lceil \\log_2 n \\rceil + 1$. For planar graphs, the Four Color Theorem gives $\\chi \\leq 4$, but $\\chi_L \\leq 4$ does not follow and remains open.\n\n**Thomassen's Elegant Proof (1994)**\n\nCarsten Thomassen proved that every planar graph is 5-choosable in a remarkably short and elegant paper. His proof uses induction on $|V| + |E|$, reducing to *near-triangulations* (planar graphs where all bounded faces are triangles) with an outer cycle. The key insight: precolor two adjacent vertices on the outer cycle, give outer vertices lists of size $\\geq 3$ and inner vertices lists of size $\\geq 5$, then either find a chord (splitting the problem) or a low-degree vertex (reducing it). The proof is self-contained and avoids the computational machinery of the Four Color Theorem.\n\n**Voigt's Construction (1993)**\n\nMargit Voigt answered the sharpness question one year before Thomassen's proof: she constructed a planar graph on 238 vertices that is not 4-choosable (i.e., $\\chi_L = 5$). The construction exhibits specific 4-element lists that create an unavoidable conflict. Gutner (1996) simplified the construction, and the smallest known example has about 63 vertices.\n\n**The Remaining Gap**\n\nWith $\\chi \\leq 4$ (Four Color) and $\\chi_L \\leq 5$ (Thomassen), there is a gap of exactly 1. The *List Coloring Conjecture for planar graphs* asks whether $\\chi_L \\leq 4$; this remains a major open problem. Evidence in favor comes from restricted classes: bipartite planar graphs have $\\chi_L \\leq 3$ (Alon-Tarsi 1992), as do outerplanar graphs and planar graphs of girth $\\geq 5$.",
+    "problemStatement": "**Question 1:** Does every planar graph $G$ have $\\chi_L(G) \\leq 5$?\n**Answer:** YES (Thomassen 1994)\n\n**Question 2:** Is this best possible?\n**Answer:** YES (Voigt 1993 — there exists a planar graph with $\\chi_L = 5$)\n\n**Open:** Is $\\chi_L(G) \\leq 4$ for all planar $G$? (List Coloring Conjecture)",
+    "proofStrategy": "The formalization builds a complete list coloring framework: (1) **Color infrastructure** — `ListAssignment`, `IsListColoring`, `IsKChoosable`, `listChromaticNumber` with abstract color types; (2) **Ordinary coloring** — `chromaticNumber`, `IsKColorable`, and the comparison $\\chi_L \\geq \\chi$; (3) **Planar graph theory** — `IsPlanar`, Euler's formula, edge bound $|E| \\leq 3|V|-6$; (4) **Classical results** — Four Color Theorem, Five Color Theorem as axioms; (5) **Main results** — Thomassen's theorem ($\\chi_L \\leq 5$) and Voigt's construction ($\\chi_L = 5$ witness) as axioms; (6) **The gap** — `listColoringConjecture` ($\\chi_L \\leq 4$?) and `chromatic_list_gap` bundling both bounds; (7) **Restricted classes** — Alon-Tarsi (bipartite planar), outerplanar, girth $\\geq 5$ results. One result (`choosable_implies_colorable`) is fully proved by Aristotle.",
     "keyInsights": [
-      "**Thomassen (1994):** χ_L ≤ 5 for all planar graphs.",
-      "**Voigt (1993):** Some planar graphs have χ_L = 5 (tight).",
-      "**Gap:** χ ≤ 4 (Four Color) but χ_L ≤ 5 — can we close it?",
-      "**List Coloring Conjecture:** Is χ_L ≤ 4 for planar? OPEN.",
-      "**Better bounds:** Outerplanar, bipartite planar, girth ≥ 5 all have χ_L ≤ 3."
+      "**Thomassen's proof is short and beautiful**: 3 pages, using induction on $|V|+|E|$ with near-triangulations and precoloring extension — no computer assistance needed, unlike the Four Color Theorem",
+      "**List coloring is strictly harder than ordinary coloring**: $\\chi_L(G) \\geq \\chi(G)$ always, and for $K_{n,n}$ the gap is $\\lceil \\log_2 n \\rceil - 1$. For planar graphs, the gap is at most 1 (between 4 and 5)",
+      "**Voigt's construction precedes the upper bound**: the non-4-choosable planar graph was found in 1993, one year before Thomassen proved the matching upper bound in 1994 — the problem was solved from both directions almost simultaneously",
+      "**The List Coloring Conjecture remains open**: whether $\\chi_L \\leq 4$ for all planar graphs is one of the most important open problems in graph coloring theory, despite strong evidence from restricted classes",
+      "**Restricted planar classes are 3-choosable**: bipartite planar (Alon-Tarsi), outerplanar, and girth $\\geq 5$ planar graphs all satisfy $\\chi_L \\leq 3$, suggesting the difficulty concentrates on dense planar graphs with triangles",
+      "**One theorem is machine-proved**: `choosable_implies_colorable` ($k$-choosable $\\Rightarrow$ $k$-colorable) was proved by Aristotle using a contrapositive argument with `ULift` and `Finset.filter`"
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement and References",
+      "startLine": 1,
+      "endLine": 26,
+      "summary": "Documentation header with problem statement, Thomassen/Voigt resolution, context on list chromatic number, and namespace setup with $\\text{SimpleGraph}$ and $\\text{Finset}$"
+    },
+    {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "summary": "Chromatic number and colorability",
       "startLine": 28,
-      "endLine": 36
+      "endLine": 36,
+      "summary": "Defines $\\text{chromaticNumber}$ ($\\chi(G)$, noncomputable sorry) and $\\text{IsKColorable}$ ($\\exists f: V \\to \\text{Fin}\\,k$ with $f(v) \\neq f(w)$ for adjacent $v,w$)"
     },
     {
       "id": "list-coloring",
-      "title": "List Coloring",
-      "summary": "List assignment, choosability, χ_L",
+      "title": "List Coloring Definitions",
       "startLine": 38,
-      "endLine": 57
+      "endLine": 57,
+      "summary": "Defines $\\text{ListAssignment}$ ($V \\to \\text{Finset}\\,C$), $\\text{IsListColoring}$ (proper coloring from lists), $\\text{IsKChoosable}$ ($\\forall L$ with $|L(v)| \\geq k$, $\\exists$ proper list coloring), and $\\text{listChromaticNumber}$ ($\\chi_L(G)$)"
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "summary": "Comparison with χ, monotonicity",
       "startLine": 59,
-      "endLine": 74
+      "endLine": 91,
+      "summary": "Proves $\\chi_L \\geq \\chi$ (sorry), choosable monotonicity (sorry), and $k$-choosable $\\Rightarrow$ $k$-colorable (**proved by Aristotle** via contrapositive with $\\text{ULift}$)"
     },
     {
       "id": "planar-graphs",
       "title": "Planar Graphs",
-      "summary": "Euler's formula, edge bounds",
-      "startLine": 76,
-      "endLine": 92
+      "startLine": 92,
+      "endLine": 108,
+      "summary": "Defines $\\text{IsPlanar}$ (sorry), Euler's formula $V - E + F = 2$, and edge bound $|E| \\leq 3|V| - 6$ as axioms"
     },
     {
       "id": "four-color",
       "title": "The Four Color Theorem",
-      "summary": "χ ≤ 4 for planar",
-      "startLine": 94,
-      "endLine": 104
+      "startLine": 110,
+      "endLine": 120,
+      "summary": "Axiomatizes the Four Color Theorem ($\\chi \\leq 4$ for planar) and Five Color Theorem ($\\chi \\leq 5$)"
     },
     {
       "id": "thomassen",
       "title": "Thomassen's Theorem",
-      "summary": "Main result: χ_L ≤ 5 for planar",
-      "startLine": 106,
-      "endLine": 127
+      "startLine": 122,
+      "endLine": 143,
+      "summary": "Main result: $\\chi_L(G) \\leq 5$ for planar $G$ (axiom). Includes proof technique description: induction on $|V|+|E|$ via near-triangulations with precolored edge"
     },
     {
       "id": "voigt",
-      "title": "Voigt's Construction",
-      "summary": "Sharpness: planar graph with χ_L = 5",
-      "startLine": 129,
-      "endLine": 149
+      "title": "Voigt's Construction and Sharpness",
+      "startLine": 145,
+      "endLine": 165,
+      "summary": "Sharpness: $\\exists$ planar $G$ with $\\chi_L = 5$ (axiom). Voigt's 238-vertex construction, Gutner's simplification, smallest known $\\leq 63$ vertices"
     },
     {
       "id": "list-conjecture",
       "title": "The List Coloring Conjecture",
-      "summary": "Open: is χ_L ≤ 4 for planar?",
-      "startLine": 151,
-      "endLine": 169
+      "startLine": 167,
+      "endLine": 185,
+      "summary": "Open: $\\chi_L \\leq 4$ for planar? $\\texttt{chromatic\\_list\\_gap}$ bundles both bounds $\\langle\\text{Four Color}, \\text{Thomassen}\\rangle$ (proved from axioms)"
     },
     {
       "id": "related-results",
       "title": "Related Results",
-      "summary": "Alon-Tarsi, outerplanar, girth",
-      "startLine": 171,
-      "endLine": 196
+      "startLine": 187,
+      "endLine": 232,
+      "summary": "Alon-Tarsi: bipartite planar $\\Rightarrow \\chi_L \\leq 3$. Outerplanar $\\Rightarrow \\chi_L \\leq 3$. Girth $\\geq 5$ planar $\\Rightarrow \\chi_L \\leq 3$. Thomassen's proof structure via key lemma and induction"
     },
     {
       "id": "main-status",
       "title": "Main Problem Status",
-      "summary": "Complete status summary",
-      "startLine": 229,
-      "endLine": 261
+      "startLine": 245,
+      "endLine": 276,
+      "summary": "Theorem $\\texttt{erdos\\_631\\_status}$: $\\langle\\texttt{thomassen\\_five\\_list\\_theorem}, \\texttt{voigt\\_construction}\\rangle$ — both questions answered, bound is tight"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #631 is SOLVED. Thomassen (1994) proved that every planar graph has list chromatic number at most 5. Voigt (1993) showed this bound is tight by constructing a planar graph with χ_L = 5. Whether χ_L ≤ 4 holds for all planar graphs (the List Coloring Conjecture) remains open.",
-    "implications": "This problem connects to:\n\n1. **Four Color Theorem:** χ ≤ 4, but χ_L ≤ 5 (gap of 1)\n2. **List Coloring Theory:** Relationship between χ and χ_L\n3. **Planar Graph Theory:** Special structure of planar graphs\n4. **Alon-Tarsi Theorem:** Planar bipartite has χ_L ≤ 3\n5. **List Coloring Conjecture:** Major open problem",
+    "summary": "Erdős Problem #631, posed by Erdős, Rubin, and Taylor in 1979, asked whether every planar graph has list chromatic number $\\chi_L \\leq 5$ and whether this is best possible. Both questions were answered affirmatively: Thomassen (1994) proved the upper bound with a short, elegant induction on near-triangulations, and Voigt (1993) constructed a planar graph with $\\chi_L = 5$ showing tightness. The formalization captures these as axioms alongside a complete list coloring framework, with one result (choosable implies colorable) fully proved by Aristotle. The gap between $\\chi \\leq 4$ (Four Color) and $\\chi_L \\leq 5$ (Thomassen) remains: the List Coloring Conjecture ($\\chi_L \\leq 4$ for planar) is open.",
+    "implications": "Thomassen's theorem established list coloring as a central topic in graph theory, showing that the extra difficulty of list coloring (versus ordinary coloring) adds at most 1 to the chromatic number for planar graphs. The proof technique — precoloring extension on near-triangulations — has been widely generalized to other surfaces and graph classes. The resolution of #631 leaves the List Coloring Conjecture as the natural successor problem, connecting to the Alon-Tarsi theorem, the combinatorial nullstellensatz, and the structure theory of planar graphs. The restricted class results ($\\chi_L \\leq 3$ for bipartite planar, outerplanar, girth $\\geq 5$) suggest that dense triangulations are the hard case.",
     "openQuestions": [
-      "Is χ_L ≤ 4 for all planar graphs? (List Coloring Conjecture)",
-      "What is the smallest planar graph with χ_L = 5?",
-      "Can Thomassen's proof be simplified further?",
-      "What graph classes satisfy χ_L = χ?",
-      "Are there other characterizations of 4-choosable planar graphs?"
+      "Is $\\chi_L(G) \\leq 4$ for all planar graphs $G$? (List Coloring Conjecture — the central remaining question)",
+      "What is the smallest planar graph with $\\chi_L = 5$? (Current record: $\\sim 63$ vertices, exact minimum unknown)",
+      "For which planar graphs does $\\chi_L = \\chi$? Can the class be characterized?",
+      "Does the Alon-Tarsi technique extend beyond bipartite planar to prove 4-choosability for larger classes?",
+      "What is $\\chi_L$ for graphs embeddable on other surfaces (torus, projective plane)?"
     ]
   }
 }

--- a/src/data/proofs/erdos-660/annotations.json
+++ b/src/data/proofs/erdos-660/annotations.json
@@ -2,193 +2,193 @@
   {
     "id": "ann-660-statement",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 7,
-      "endLine": 19
-    },
+    "range": { "startLine": 7, "endLine": 19 },
     "type": "concept",
     "title": "Problem Statement",
-    "content": "The core question: given n vertices of a convex polyhedron in 3D space, must there be at least (1-o(1))·n/2 distinct pairwise distances? The little-o notation means the bound approaches n/2 as n grows large.",
-    "significance": "critical"
+    "content": "The core question: given $n$ vertices of a convex polyhedron in $\\mathbb{R}^3$, must there be at least $(1-o(1)) \\cdot n/2$ distinct pairwise distances? The $(1-o(1))$ factor means the lower bound approaches $n/2$ as $n \\to \\infty$, so the conjecture asserts an asymptotically sharp linear bound.",
+    "mathContext": "Conjecture: $|\\Delta(V)| \\geq (1 - o(1)) \\cdot n/2$ where $V$ is the vertex set of a convex polyhedron with $|V| = n$.",
+    "significance": "critical",
+    "relatedConcepts": ["convex polyhedron", "distinct distances", "little-o notation", "asymptotic bound"],
+    "prerequisites": ["convex hull", "extreme points", "Euclidean distance"]
   },
   {
     "id": "ann-660-altman",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 17,
-      "endLine": 22
-    },
+    "range": { "startLine": 17, "endLine": 22 },
     "type": "insight",
-    "title": "Altman's 2D Result",
-    "content": "In 1963, Altman proved that convex polygon vertices in ℝ² always determine at least n/2 distinct distances. This is the solved 2D analogue that motivates the 3D conjecture.",
-    "significance": "key"
+    "title": "Altman's 2D Result (1963)",
+    "content": "Edward Altman proved in 1963 that the vertices of a convex $n$-gon in $\\mathbb{R}^2$ determine at least $\\lfloor n/2 \\rfloor$ distinct distances. The proof exploits the cyclic ordering of vertices on the convex hull: consecutive vertices at different 'levels' of the polygon must have distinct distances. This is the solved 2D analogue that motivates the 3D conjecture.",
+    "mathContext": "Altman (1963): For a convex polygon with vertices $v_1, \\ldots, v_n$ in $\\mathbb{R}^2$, $|\\Delta(\\{v_i\\})| \\geq \\lfloor n/2 \\rfloor$.",
+    "significance": "key",
+    "relatedConcepts": ["convex polygon", "cyclic ordering", "2D distinct distances"],
+    "prerequisites": ["convex hull in 2D", "floor function"]
   },
   {
     "id": "ann-660-context",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 24,
-      "endLine": 29
-    },
+    "range": { "startLine": 24, "endLine": 29 },
     "type": "insight",
-    "title": "Distinct Distances Problem",
-    "content": "The distinct distances problem asks: how many different pairwise distances must n points determine? Erdős posed this in 1946. For arbitrary points, Guth-Katz (2015) proved Ω(n/log n). For convex positions, better bounds are expected.",
-    "significance": "key"
+    "title": "Broader Distinct Distances Landscape",
+    "content": "The distinct distances problem, posed by Erdős in 1946, asks for the minimum number of distinct pairwise distances among $n$ points. For arbitrary point sets in $\\mathbb{R}^2$, Guth-Katz (2015) proved $\\Omega(n/\\log n)$. For points in *convex position* (vertices of a convex body), the geometric constraint should force even more distances — the conjecture predicts $\\Theta(n)$ rather than $\\Theta(n/\\log n)$.",
+    "mathContext": "General: $|\\Delta| \\geq \\Omega(n/\\log n)$ (Guth-Katz). Convex: conjectured $|\\Delta| \\geq (1-o(1)) \\cdot n/2$.",
+    "significance": "key",
+    "relatedConcepts": ["Erdős distinct distances", "Guth-Katz theorem", "convex position", "polynomial partitioning"],
+    "prerequisites": ["combinatorial geometry", "asymptotic notation"]
   },
   {
     "id": "ann-660-point3d",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 43,
-      "endLine": 44
-    },
-    "type": "code",
-    "title": "Point3D Type",
-    "content": "We represent points in ℝ³ using Mathlib's EuclideanSpace type. This gives us the full structure of Euclidean space including the distance metric.",
-    "significance": "supporting"
+    "range": { "startLine": 43, "endLine": 44 },
+    "type": "definition",
+    "title": "Point in $\\mathbb{R}^3$",
+    "content": "Points in $\\mathbb{R}^3$ are represented using Mathlib's `EuclideanSpace` type, which provides the full metric space structure including the Euclidean distance. This is a more sophisticated choice than bare $\\mathbb{R} \\times \\mathbb{R} \\times \\mathbb{R}$, giving access to Mathlib's inner product space API.",
+    "mathContext": "$\\text{Point3D} := \\text{EuclideanSpace}\\, \\mathbb{R}\\, (\\text{Fin}\\, 3)$, the standard 3-dimensional Euclidean space.",
+    "significance": "supporting",
+    "relatedConcepts": ["EuclideanSpace", "Fin type", "metric space"],
+    "prerequisites": ["Mathlib.Analysis.InnerProductSpace"]
   },
   {
     "id": "ann-660-dist",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 46,
-      "endLine": 48
-    },
+    "range": { "startLine": 46, "endLine": 48 },
     "type": "definition",
-    "title": "Euclidean Distance",
-    "content": "The distance between two points p and q is defined using Mathlib's built-in dist function, which computes the standard Euclidean distance √((p₁-q₁)² + (p₂-q₂)² + (p₃-q₃)²).",
-    "significance": "supporting"
+    "title": "Euclidean Distance in 3D",
+    "content": "Uses Mathlib's built-in `dist` function from the metric space structure. In $\\mathbb{R}^3$, this computes $d(p,q) = \\sqrt{(p_1-q_1)^2 + (p_2-q_2)^2 + (p_3-q_3)^2}$. The metric space API provides symmetry, triangle inequality, and non-negativity for free.",
+    "mathContext": "$d(p,q) = \\|p - q\\|_2 = \\sqrt{\\sum_{i=1}^{3}(p_i - q_i)^2}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Euclidean metric", "metric space", "L2 norm"],
+    "prerequisites": ["dist function", "EuclideanSpace"]
   },
   {
     "id": "ann-660-polyhedron",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 50,
-      "endLine": 55
-    },
+    "range": { "startLine": 50, "endLine": 55 },
     "type": "definition",
     "title": "Convex Polyhedron Vertices",
-    "content": "A set of points forms convex polyhedron vertices if: (1) the set is nonempty, (2) every point is an extreme point (vertex) of the convex hull, and (3) the convex hull is nonempty. This captures the geometric notion of vertices of a 3D convex body.",
-    "significance": "key"
+    "content": "Captures the geometric notion of a convex polyhedron's vertex set: a nonempty finite set $S \\subset \\mathbb{R}^3$ where every point is an extreme point of the convex hull $\\text{conv}(S)$. An extreme point cannot be written as a convex combination of other points in the set. This ensures $S$ truly consists of vertices (not interior or edge points).",
+    "mathContext": "$S$ is a convex polyhedron vertex set iff $S \\neq \\emptyset$ and $\\forall p \\in S: p \\in \\text{ext}(\\text{conv}(S))$, where $\\text{ext}$ denotes extreme points.",
+    "significance": "key",
+    "relatedConcepts": ["extreme point", "convex hull", "Krein-Milman theorem", "vertex enumeration"],
+    "prerequisites": ["convexity", "convex hull", "extreme point characterization"]
   },
   {
     "id": "ann-660-pairwise",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 57,
-      "endLine": 59
-    },
-    "type": "code",
-    "title": "Pairwise Distances",
-    "content": "Given a finite set S of points, we compute all pairwise distances by taking the Cartesian product S × S and mapping each pair to its Euclidean distance. The result is a finite set of real numbers.",
-    "significance": "supporting"
+    "range": { "startLine": 57, "endLine": 59 },
+    "type": "definition",
+    "title": "Pairwise Distance Set",
+    "content": "Computes all pairwise distances via the Cartesian product $S \\times S$ mapped through the distance function. The result is a finite set of reals (automatically deduplicated by `Finset.image`). Includes the zero distance from self-pairs.",
+    "mathContext": "$\\Delta(S) = \\{d(p,q) : p, q \\in S\\}$, the multiset of all pairwise distances.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.product", "Finset.image", "distance set"],
+    "prerequisites": ["Cartesian product", "image of finite set"]
   },
   {
     "id": "ann-660-distinct",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 61,
-      "endLine": 63
-    },
+    "range": { "startLine": 61, "endLine": 63 },
     "type": "definition",
     "title": "Distinct Distances Count",
-    "content": "We count distinct distances by filtering out zero (self-distances where a point is paired with itself) and taking the cardinality. This gives the number of genuinely different positive distances.",
-    "significance": "key"
+    "content": "Counts genuinely different positive distances by filtering out zero (self-distances where $p = q$) and taking cardinality. This gives the standard distinct distances count $|\\Delta^+(S)|$, the central quantity in the problem.",
+    "mathContext": "$|\\Delta^+(S)| = |\\{d(p,q) : p, q \\in S,\\, p \\neq q\\}|$, the number of distinct positive pairwise distances.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.filter", "Finset.card", "positive distances"],
+    "prerequisites": ["distance set", "filtering"]
   },
   {
     "id": "ann-660-altman-thm",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 83,
-      "endLine": 92
-    },
+    "range": { "startLine": 83, "endLine": 92 },
     "type": "theorem",
-    "title": "Altman's Theorem",
-    "content": "This theorem states the solved 2D case: any convex polygon with n ≥ 3 vertices has at least ⌊n/2⌋ distinct distances. The proof uses geometric properties of convex curves but is marked sorry as it requires substantial development.",
-    "significance": "key"
+    "title": "Altman's Theorem (2D Case)",
+    "content": "Formalizes Altman's 1963 result: any convex polygon with $n \\geq 3$ vertices determines at least $\\lfloor n/2 \\rfloor$ distinct distances. The proof relies on the cyclic structure of convex polygons: for each diagonal length, there are at most 2 diagonals of that length in a convex polygon, giving the $n/2$ bound. Marked `sorry` since the full geometric argument requires substantial development.",
+    "mathContext": "For a convex $n$-gon in $\\mathbb{R}^2$ with $n \\geq 3$: $|\\Delta^+| \\geq \\lfloor n/2 \\rfloor$.",
+    "significance": "key",
+    "relatedConcepts": ["convex polygon", "diagonal counting", "cyclic ordering"],
+    "prerequisites": ["convex polygon definition", "floor function"]
   },
   {
     "id": "ann-660-littleo",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 96,
-      "endLine": 98
-    },
+    "range": { "startLine": 96, "endLine": 98 },
     "type": "definition",
-    "title": "Little-o Notation",
-    "content": "We formalize f(n) = o(g(n)) as: for every ε > 0, eventually |f(n)/g(n)| < ε. This captures functions that grow strictly slower than g. Here, (1-o(1)) means a quantity approaching 1.",
-    "significance": "key"
+    "title": "Little-o Asymptotic Notation",
+    "content": "Formalizes $f(n) = o(g(n))$ as: for every $\\varepsilon > 0$, there exists $N$ such that for all $n \\geq N$, $|f(n)/g(n)| < \\varepsilon$. In the conjecture, $(1 - o(1))$ means a factor approaching 1, so the bound $(1 - o(1)) \\cdot n/2$ is asymptotically $n/2$.",
+    "mathContext": "$f = o(g) \\iff \\forall \\varepsilon > 0,\\, \\exists N,\\, \\forall n \\geq N: |f(n)/g(n)| < \\varepsilon$. Here $\\varepsilon(n) = o(1)$ means $\\varepsilon(n) \\to 0$.",
+    "significance": "key",
+    "relatedConcepts": ["asymptotic notation", "Filter.Tendsto", "vanishing function"],
+    "prerequisites": ["limits", "epsilon-N definition"]
   },
   {
     "id": "ann-660-conjecture",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 100,
-      "endLine": 112
-    },
+    "range": { "startLine": 100, "endLine": 112 },
     "type": "theorem",
-    "title": "Main Conjecture",
-    "content": "The open problem: there exists a vanishing function ε(n) → 0 such that n vertices of any convex polyhedron determine at least (1 - ε(n)) · n/2 distinct distances. This is marked sorry as it remains unproven.",
-    "significance": "critical"
+    "title": "Main Conjecture (OPEN)",
+    "content": "The open conjecture: there exists a vanishing function $\\varepsilon(n) \\to 0$ such that any convex polyhedron with $n$ vertices determines at least $(1 - \\varepsilon(n)) \\cdot n/2$ distinct distances. This extends Altman's exact $\\lfloor n/2 \\rfloor$ bound from 2D to an asymptotic $n/2$ bound in 3D. The weaker form (some linear bound $cn$) is also open.",
+    "mathContext": "$\\exists \\varepsilon : \\mathbb{N} \\to \\mathbb{R},\\, \\varepsilon(n) \\to 0,\\, \\forall n,\\, \\forall V$ convex polyhedron vertices with $|V| = n$: $|\\Delta^+(V)| \\geq (1 - \\varepsilon(n)) \\cdot n/2$.",
+    "significance": "critical",
+    "relatedConcepts": ["open conjecture", "asymptotic lower bound", "convex geometry"],
+    "prerequisites": ["convex polyhedron vertices", "little-o notation", "distinct distances"]
   },
   {
     "id": "ann-660-trivial",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 116,
-      "endLine": 121
-    },
+    "range": { "startLine": 116, "endLine": 121 },
     "type": "theorem",
     "title": "Trivial Lower Bound",
-    "content": "Any two distinct points have a positive distance between them. So n ≥ 2 points must have at least 1 distinct distance. This is the weakest possible lower bound.",
-    "significance": "supporting"
+    "content": "The weakest possible bound: any $n \\geq 2$ points must have at least 1 distinct distance (since two distinct points are at positive distance). The gap between this trivial bound and the conjectured $\\Theta(n)$ illustrates the difficulty of the problem.",
+    "mathContext": "$n \\geq 2 \\implies |\\Delta^+| \\geq 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["trivial bound", "lower bound", "metric positivity"],
+    "prerequisites": ["distance positivity"]
   },
   {
     "id": "ann-660-tetrahedron",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 134,
-      "endLine": 139
-    },
+    "range": { "startLine": 134, "endLine": 139 },
     "type": "example",
-    "title": "Regular Tetrahedron",
-    "content": "The regular tetrahedron has 4 vertices, all equidistant from each other. Thus it has exactly 1 distinct distance (the edge length). This shows the conjecture bound is not tight for small n.",
-    "significance": "supporting"
+    "title": "Regular Tetrahedron (4 Vertices, 1 Distance)",
+    "content": "The regular tetrahedron is the simplest Platonic solid: all 4 vertices are mutually equidistant at edge length $a$. With $|\\Delta^+| = 1$ vs. the conjectured bound $\\approx 2$, it shows the conjecture is not tight for small $n$. The tetrahedron is the unique convex polytope in $\\mathbb{R}^3$ with all edges equal.",
+    "mathContext": "Regular tetrahedron: $n = 4$, $|\\Delta^+| = 1$. Conjecture predicts $(1-o(1)) \\cdot 2 \\approx 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Platonic solid", "equidistant points", "simplex"],
+    "prerequisites": ["regular tetrahedron", "edge-transitive"]
   },
   {
     "id": "ann-660-cube",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 141,
-      "endLine": 147
-    },
+    "range": { "startLine": 141, "endLine": 147 },
     "type": "example",
-    "title": "Cube Distances",
-    "content": "A cube has 8 vertices with exactly 3 distinct distances: edge length a, face diagonal a√2, and space diagonal a√3. The conjecture predicts ≥ (1-o(1))·4 distances for large n.",
-    "significance": "supporting"
+    "title": "Cube (8 Vertices, 3 Distances)",
+    "content": "The cube has 8 vertices with exactly 3 distinct distances: edge length $a$, face diagonal $a\\sqrt{2}$, and space diagonal $a\\sqrt{3}$. With $|\\Delta^+| = 3$ vs. the conjectured $\\approx 4$, the cube is already close to the conjectured threshold. The distance structure reflects the three types of vertex pairs: adjacent, face-diagonal, and space-diagonal.",
+    "mathContext": "Cube: $n = 8$, distances $\\{a, a\\sqrt{2}, a\\sqrt{3}\\}$, so $|\\Delta^+| = 3$. Conjecture: $\\geq (1-o(1)) \\cdot 4$.",
+    "significance": "supporting",
+    "relatedConcepts": ["cube geometry", "face diagonal", "space diagonal", "vertex-transitive"],
+    "prerequisites": ["Platonic solids", "Pythagorean theorem in 3D"]
   },
   {
     "id": "ann-660-octahedron",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 149,
-      "endLine": 154
-    },
+    "range": { "startLine": 149, "endLine": 154 },
     "type": "example",
-    "title": "Octahedron Distances",
-    "content": "The regular octahedron has 6 vertices arranged so opposite vertices are at distance 2a (axis) while adjacent vertices are at distance a√2 (edge). This gives exactly 2 distinct distances.",
-    "significance": "supporting"
+    "title": "Octahedron (6 Vertices, 2 Distances)",
+    "content": "The regular octahedron has 6 vertices with exactly 2 distinct distances: the edge length $a\\sqrt{2}$ (between adjacent vertices) and the axis length $2a$ (between opposite vertices). With $|\\Delta^+| = 2$ vs. conjectured $\\approx 3$, it illustrates how high symmetry can reduce the distance count.",
+    "mathContext": "Octahedron: $n = 6$, distances $\\{a\\sqrt{2}, 2a\\}$, so $|\\Delta^+| = 2$. Conjecture: $\\geq (1-o(1)) \\cdot 3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["octahedron", "dual of cube", "antipodal vertices"],
+    "prerequisites": ["Platonic solids", "vertex coordinates"]
   },
   {
     "id": "ann-660-guthkatz",
     "proofId": "erdos-660",
-    "range": {
-      "startLine": 170,
-      "endLine": 177
-    },
+    "range": { "startLine": 170, "endLine": 177 },
     "type": "theorem",
-    "title": "Guth-Katz Theorem",
-    "content": "The landmark 2015 result: any n points in the plane determine at least c·n/log(n) distinct distances. This resolved Erdős's 1946 conjecture up to the log factor. For convex positions, we expect even better bounds.",
-    "significance": "key"
+    "title": "Guth-Katz Theorem (2015)",
+    "content": "The landmark result by Larry Guth and Nets Hawk Katz: any $n$ points in $\\mathbb{R}^2$ determine at least $\\Omega(n/\\log n)$ distinct distances. This resolved Erdős's 1946 conjecture up to the logarithmic factor. The proof uses the polynomial partitioning method. For points in convex position, the convexity constraint should eliminate the $\\log n$ loss, which is why Problem #660 conjectures a clean $\\Theta(n)$ bound.",
+    "mathContext": "Guth-Katz (2015): $|\\Delta| \\geq c \\cdot n / \\log n$ for any $n$ points in $\\mathbb{R}^2$. For convex position: conjectured $|\\Delta| \\geq (1-o(1)) \\cdot n/2$.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial partitioning", "Elekes-Sharir framework", "incidence geometry"],
+    "prerequisites": ["distinct distances problem", "polynomial method"]
   }
 ]

--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -14,24 +14,78 @@
       "combinatorial-geometry",
       "distinct-distances",
       "convex-polyhedra",
-      "open-problem"
+      "open-problem",
+      "convex-geometry",
+      "3D-geometry"
     ],
     "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 660,
     "erdosUrl": "https://erdosproblems.com/660",
-    "erdosProblemStatus": "open"
+    "erdosProblemStatus": "open",
+    "mathlibDependencies": [
+      {
+        "theorem": "EuclideanSpace",
+        "description": "Provides the $\\mathbb{R}^3$ metric space structure with built-in distance function",
+        "module": "Mathlib.Analysis.InnerProductSpace.EuclideanDist"
+      },
+      {
+        "theorem": "dist",
+        "description": "Built-in Euclidean distance $d(p,q) = \\|p-q\\|_2$ from metric space instance",
+        "module": "Mathlib.Topology.MetricSpace.Basic"
+      },
+      {
+        "theorem": "Finset.product",
+        "description": "Cartesian product $S \\times S$ for iterating over all point pairs",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "convexHull",
+        "description": "Convex hull construction for defining polyhedron vertices as extreme points",
+        "module": "Mathlib.Analysis.Convex.Hull"
+      }
+    ],
+    "originalContributions": [
+      "Point3D via EuclideanSpace ℝ (Fin 3) with Mathlib metric structure",
+      "ConvexPolyhedronVertices predicate using extreme points of convex hull",
+      "pairwiseDistances and distinctDistances for counting distinct positive distances",
+      "Altman's theorem (2D analogue): convex n-gon has ≥⌊n/2⌋ distances",
+      "Little-o notation formalization for asymptotic bounds",
+      "Main conjecture: (1-o(1))·n/2 distances for 3D convex polyhedra",
+      "Weaker linear conjecture: cn distances for some constant c",
+      "Platonic solid examples: tetrahedron (1), octahedron (2), cube (3) distances",
+      "Guth-Katz theorem statement for general distinct distances"
+    ],
+    "relatedProofs": [
+      {
+        "id": "erdos-652",
+        "relationship": "Studies pointwise distance counts R(x_i) in planar point sets; #660 studies total distinct distances in convex 3D configurations"
+      },
+      {
+        "id": "erdos-94",
+        "relationship": "Investigates distance multiplicities specifically in convex polygons, the 2D setting that Altman's theorem addresses"
+      },
+      {
+        "id": "erdos-98",
+        "relationship": "Studies distinct distances in general position; #660 specializes to convex position in 3D"
+      },
+      {
+        "id": "erdos-657",
+        "relationship": "Isosceles-free constraint forces many distances; convexity in #660 is a different structural constraint with similar consequences"
+      }
+    ]
   },
   "overview": {
-    "historicalContext": "Erdős Problem #660 asks whether the vertices of a convex polyhedron in three-dimensional space must determine nearly n/2 distinct pairwise distances. This problem extends a classical result by Altman (1963) who proved that the vertices of a convex polygon in ℝ² always determine at least n/2 distinct distances. In his 1975 paper, Erdős mentioned that Altman may have proved an even stronger result (≫n distances) but provided no reference. The distinct distances problem is one of the central topics in combinatorial geometry, with the general case (arbitrary point sets) being resolved by Guth and Katz in 2015.",
-    "problemStatement": "Let x₁, ..., xₙ ∈ ℝ³ be the vertices of a convex polyhedron. Are there at least (1 - o(1)) · n/2 many distinct distances between the xᵢ? The notation (1 - o(1)) means that the ratio approaches 1 as n → ∞, so the conjecture asserts a linear lower bound with constant approaching 1/2.",
-    "proofStrategy": "This problem remains OPEN. Our formalization defines convex polyhedron vertices using extreme points of convex hulls and the distinct distances function. We state the main conjecture using little-o notation formalized via limit definitions. We also include Altman's solved 2D analogue as a comparison point, along with special cases for Platonic solids (tetrahedron, cube, octahedron) that can be verified computationally.",
+    "historicalContext": "**Origins: Erdős and the Convex Distance Problem (1975)**\n\nProblem #660 was posed by Erdős in 1975, building on a rich tradition of distance problems in convex geometry. The question is deceptively simple: must the vertices of a convex polyhedron in $\\mathbb{R}^3$ determine many distinct distances?\n\n**Altman's 2D Solution (1963)**\n\nThe 2D analogue was solved by Edward Altman in 1963: the $n$ vertices of a convex polygon determine at least $\\lfloor n/2 \\rfloor$ distinct distances. Altman's proof exploits the cyclic ordering of vertices on the convex hull — for each 'diagonal length,' there are at most 2 diagonals of that length connecting vertices of a convex polygon, giving the $n/2$ bound. Erdős mentioned that Altman may have proved an even stronger result ($\\gg n$ distances), but no reference was provided.\n\n**The Convexity Advantage**\n\nFor arbitrary point sets, the Guth-Katz theorem (2015) gives $\\Omega(n/\\log n)$ distinct distances — nearly optimal but with a logarithmic loss. For points in convex position, the rigidity of the convex hull is expected to eliminate this loss entirely, yielding a clean $\\Theta(n)$ bound. The conjecture's constant $1/2$ matches Altman's 2D result.\n\n**The 3D Challenge**\n\nThe jump from 2D to 3D is non-trivial because convex polyhedra lack the cyclic ordering that makes Altman's argument work. In 3D, the combinatorial structure of the face lattice (vertices, edges, faces) is far more complex, and the relationship between convex hull geometry and distance distributions is not well understood. Even proving a linear bound (without the $1/2$ constant) remains open.\n\n**Platonic Solid Tests**\n\nThe five Platonic solids provide test cases: tetrahedron (4 vertices, 1 distance), octahedron (6 vertices, 2 distances), cube (8 vertices, 3 distances), icosahedron (12 vertices, 3 distances), dodecahedron (20 vertices, 5 distances). All satisfy the conjecture, but they represent only highly symmetric special cases.",
+    "problemStatement": "Let $x_1, \\ldots, x_n \\in \\mathbb{R}^3$ be the vertices of a convex polyhedron. Are there at least $(1 - o(1)) \\cdot n/2$ distinct distances among the $x_i$? The $(1 - o(1))$ notation means the ratio of distinct distances to $n/2$ approaches 1 as $n \\to \\infty$.",
+    "proofStrategy": "This problem remains **OPEN**. The formalization defines convex polyhedron vertices via extreme points of convex hulls in $\\mathbb{R}^3$ (using Mathlib's `EuclideanSpace` and convex hull API) and the distinct distances function via `Finset.image` on the Cartesian product. The conjecture is stated using little-o notation formalized through epsilon-N limits. Supporting content includes: (1) Altman's solved 2D theorem as motivation; (2) Platonic solid examples as concrete test cases; (3) the Guth-Katz theorem as context for the general problem; (4) weaker conjectures (any linear bound) as stepping stones.",
     "keyInsights": [
-      "The 2D case is solved: Altman (1963) proved vertices of a convex n-gon determine ≥n/2 distinct distances",
-      "The 3D generalization remains open and cannot be resolved by finite computation",
-      "For structured point sets (convex positions), stronger bounds than the general Guth-Katz result are expected",
-      "Regular polyhedra provide test cases: tetrahedron (1 distance), octahedron (2), cube (3)",
-      "The little-o notation captures the asymptotic nature of the conjectured bound"
+      "Altman's 2D result ($\\geq \\lfloor n/2 \\rfloor$ distances for convex polygons) uses the cyclic ordering of vertices, which has no direct 3D analogue",
+      "The conjecture is asymptotic: the constant $1/2$ may not hold exactly for small $n$ — Platonic solids show $|\\Delta^+|$ can be well below $n/2$",
+      "Convexity should eliminate the $\\log n$ factor present in the general Guth-Katz bound, as the convex hull structure prevents distance-rich collinear configurations",
+      "Even proving a weaker linear bound $|\\Delta^+| \\geq cn$ for any constant $c > 0$ remains open in 3D",
+      "The face lattice of a convex polyhedron (Euler's formula: $V - E + F = 2$) constrains which vertex pairs can be close, but this has not been sufficient to prove the conjecture",
+      "The problem connects to the broader question of how geometric constraints (convexity, general position, etc.) affect the distance spectrum of point configurations"
     ]
   },
   "sections": [
@@ -40,51 +94,53 @@
       "title": "Geometric Definitions",
       "startLine": 39,
       "endLine": 63,
-      "summary": "Definitions for points in ℝ³, Euclidean distance, convex polyhedron vertices, and the distinct distances function."
+      "summary": "Defines Point3D via EuclideanSpace $\\mathbb{R}$ (Fin 3), Euclidean distance using Mathlib's metric API, ConvexPolyhedronVertices as extreme points of convex hull, and the distinct distances counting function"
     },
     {
       "id": "altman-2d",
-      "title": "Altman's 2D Result",
+      "title": "Altman's 2D Result (1963)",
       "startLine": 65,
       "endLine": 92,
-      "summary": "The solved two-dimensional analogue: convex polygon vertices in ℝ² determine at least n/2 distinct distances."
+      "summary": "Formalizes the solved 2D analogue: convex polygon vertices in $\\mathbb{R}^2$ determine $\\geq \\lfloor n/2 \\rfloor$ distinct distances (Altman 1963), using the cyclic structure of convex polygons"
     },
     {
       "id": "main-conjecture",
       "title": "The Open Conjecture",
       "startLine": 94,
       "endLine": 112,
-      "summary": "The main statement of Erdős Problem #660 formalized with little-o asymptotic notation."
+      "summary": "States Erdős Problem #660 formally: $\\exists \\varepsilon(n) \\to 0$ such that convex polyhedron vertices determine $\\geq (1 - \\varepsilon(n)) \\cdot n/2$ distinct distances, using little-o notation"
     },
     {
       "id": "partial-results",
       "title": "Weaker Bounds",
       "startLine": 114,
       "endLine": 130,
-      "summary": "Trivial lower bounds and the weaker linear conjecture without precise constants."
+      "summary": "Trivial lower bound ($\\geq 1$ distance for $n \\geq 2$) and the weaker linear conjecture (some constant $c > 0$ with $|\\Delta^+| \\geq cn$)"
     },
     {
       "id": "special-cases",
       "title": "Platonic Solids",
       "startLine": 132,
       "endLine": 166,
-      "summary": "Concrete examples: tetrahedron (4 vertices, 1 distance), cube (8 vertices, 3 distances), octahedron (6 vertices, 2 distances)."
+      "summary": "Concrete examples: regular tetrahedron ($n=4$, 1 distance), cube ($n=8$, distances $\\{a, a\\sqrt{2}, a\\sqrt{3}\\}$), octahedron ($n=6$, distances $\\{a\\sqrt{2}, 2a\\}$)"
     },
     {
       "id": "guth-katz",
       "title": "General Distinct Distances",
       "startLine": 168,
       "endLine": 179,
-      "summary": "The Guth-Katz theorem (2015) for arbitrary point sets: Ω(n/log n) distinct distances in the plane."
+      "summary": "The Guth-Katz theorem (2015): $\\Omega(n/\\log n)$ distinct distances for arbitrary planar point sets, contextualizing why convex position should yield $\\Theta(n)$ without the log factor"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #660 remains open. We formalize the conjecture that convex polyhedron vertices in ℝ³ determine at least (1-o(1))·n/2 distinct distances, building on Altman's solved 2D result. The problem connects to the broader distinct distances problem in combinatorial geometry.",
-    "implications": "Resolution of this problem would extend our understanding of distance distributions in convex sets across dimensions. The 2D/3D comparison suggests geometric constraints of convexity force many distinct distances, but the precise constants remain elusive in three dimensions.",
+    "summary": "Erdős Problem #660 remains open. The conjecture that convex polyhedron vertices in $\\mathbb{R}^3$ determine at least $(1-o(1)) \\cdot n/2$ distinct distances extends Altman's solved 2D result ($\\geq \\lfloor n/2 \\rfloor$ for convex polygons) to three dimensions. The formalization captures the conjecture using extreme points of convex hulls and little-o asymptotics, with Platonic solids as concrete test cases and the Guth-Katz theorem providing context from the general distinct distances problem.",
+    "implications": "Resolution would establish that the convexity constraint forces a clean linear distance count in 3D, without the logarithmic loss present in the general Guth-Katz bound. This would illuminate the fundamental question of how geometric structure (convex position vs. arbitrary position) affects distance distributions. The 2D → 3D transition is a key test case for understanding how dimension affects combinatorial geometry problems, and progress here could inform analogous questions in higher dimensions.",
     "openQuestions": [
-      "Does the conjecture hold with constant exactly 1/2 (not just approaching 1/2)?",
-      "What is the minimum number of distinct distances for convex polyhedra with n vertices?",
-      "How does the answer generalize to higher dimensions ℝᵈ for d > 3?"
+      "Does the conjecture hold with constant exactly $1/2$, or only asymptotically approaching $1/2$?",
+      "Can even the weaker bound $|\\Delta^+| \\geq cn$ for some absolute constant $c > 0$ be proved in 3D?",
+      "How does the minimum distinct distance count for convex polytope vertices scale in $\\mathbb{R}^d$ for $d \\geq 4$?",
+      "Is there a connection between the face lattice structure (Euler's formula $V - E + F = 2$) and the minimum distance count?",
+      "Can the polynomial partitioning technique from Guth-Katz be adapted to exploit convexity in 3D?"
     ]
   }
 }

--- a/src/data/proofs/erdos-664/annotations.json
+++ b/src/data/proofs/erdos-664/annotations.json
@@ -1,12 +1,27 @@
 [
   {
+    "id": "ann-664-imports",
+    "proofId": "erdos-664",
+    "range": { "startLine": 31, "endLine": 38 },
+    "type": "context",
+    "title": "Imports and Setup",
+    "content": "Imports Mathlib modules for natural numbers, finite sets with cardinality, real numbers with square root, big operators for summation, and opens the Finset, BigOperators, and Real namespaces.",
+    "significance": "useful",
+    "mathContext": "The formalization requires $\\text{Finset.card}$ for set sizes $|A_i|$ and $|B \\cap A_i|$, $\\text{Real.sqrt}$ for the threshold $c\\sqrt{n}$, and $\\text{Real.log}$ for the logarithmic lower bound $\\Omega(\\log n)$.",
+    "relatedConcepts": ["Mathlib finite set API", "real-valued cardinality bounds", "square root threshold"],
+    "prerequisites": ["Finset.card", "Real.sqrt", "Real.log"]
+  },
+  {
     "id": "ann-664-setfamily",
     "proofId": "erdos-664",
-    "range": { "startLine": 46, "endLine": 47 },
+    "range": { "startLine": 46, "endLine": 51 },
     "type": "definition",
-    "title": "SetFamily",
-    "content": "Collection of m subsets of {1,...,n}.",
-    "significance": "key"
+    "title": "SetFamily and familySizes",
+    "content": "A set family is a function from Fin m to Finset (Fin n), representing m subsets of {1,...,n}. The familySizes function extracts the cardinality of each set.",
+    "significance": "key",
+    "mathContext": "The family $\\mathcal{A} = \\{A_1, \\ldots, A_m\\}$ where each $A_i \\subseteq [n]$ is modeled as a dependent function type $\\text{Fin}\\, m \\to \\text{Finset}\\,(\\text{Fin}\\, n)$. This cleanly handles both the ground set constraint ($A_i \\subseteq [n]$) and finite indexing.",
+    "relatedConcepts": ["indexed family of sets", "hypergraph", "ground set"],
+    "prerequisites": ["Fin type", "Finset"]
   },
   {
     "id": "ann-664-large",
@@ -14,8 +29,11 @@
     "range": { "startLine": 53, "endLine": 55 },
     "type": "definition",
     "title": "AllLargerThan",
-    "content": "All sets have size > c√n.",
-    "significance": "key"
+    "content": "All sets in the family have cardinality strictly greater than c√n, where c is a real parameter. This ensures the sets are 'large' relative to the ground set.",
+    "significance": "key",
+    "mathContext": "The condition $|A_i| > c\\sqrt{n}$ for all $i$ is the 'density' requirement. In Alon's construction with $n = q^2 + q + 1$, each set has size $\\approx (2/5)(q+1) \\approx (2/5)\\sqrt{n}$, so the constant $c = 2/5$ suffices. The threshold $\\sqrt{n}$ is natural: a projective plane of order $q$ has lines of size $q+1 \\approx \\sqrt{n}$.",
+    "relatedConcepts": ["density parameter", "projective plane line size", "size threshold"],
+    "prerequisites": ["SetFamily", "Real.sqrt"]
   },
   {
     "id": "ann-664-pairwise",
@@ -23,8 +41,11 @@
     "range": { "startLine": 57, "endLine": 59 },
     "type": "definition",
     "title": "PairwiseSmallIntersection",
-    "content": "Any two sets intersect in at most 1 element.",
-    "significance": "critical"
+    "content": "Any two distinct sets in the family intersect in at most one element: |Aᵢ ∩ Aⱼ| ≤ 1 for all i ≠ j.",
+    "significance": "critical",
+    "mathContext": "The condition $|A_i \\cap A_j| \\leq 1$ for $i \\neq j$ makes the family *near-linear* (or *almost disjoint*). This mirrors the fundamental property of projective planes: any two distinct lines meet in exactly one point. The near-linear condition prevents trivial blocking strategies where a single element covers many sets simultaneously.",
+    "relatedConcepts": ["near-linear hypergraph", "almost disjoint family", "projective plane axiom", "sunflower-free"],
+    "prerequisites": ["SetFamily", "Finset.inter", "Finset.card"]
   },
   {
     "id": "ann-664-nearlinear",
@@ -32,8 +53,11 @@
     "range": { "startLine": 61, "endLine": 65 },
     "type": "definition",
     "title": "NearLinearFamily",
-    "content": "Large sets with small pairwise intersection.",
-    "significance": "critical"
+    "content": "A structure bundling a set family with both conditions: all sets are large (> c√n) and pairwise intersections are small (≤ 1). This captures the hypothesis of Erdős's question.",
+    "significance": "critical",
+    "mathContext": "A near-linear family with parameters $(n, m, c)$ satisfies: (1) $|A_i| > c\\sqrt{n}$ for all $i \\in [m]$, and (2) $|A_i \\cap A_j| \\leq 1$ for $i \\neq j$. The Lean structure bundles the family with proofs of both properties, enabling clean theorem statements. The terminology 'near-linear' comes from hypergraph theory: a hypergraph is *linear* if every two edges share at most one vertex.",
+    "relatedConcepts": ["linear hypergraph", "Steiner system", "block design"],
+    "prerequisites": ["SetFamily", "AllLargerThan", "PairwiseSmallIntersection"]
   },
   {
     "id": "ann-664-blocker",
@@ -41,8 +65,11 @@
     "range": { "startLine": 71, "endLine": 73 },
     "type": "definition",
     "title": "IsBlocker",
-    "content": "B intersects every set in the family.",
-    "significance": "key"
+    "content": "A set B is a blocker (transversal) if it has non-empty intersection with every set in the family: B ∩ Aᵢ ≠ ∅ for all i.",
+    "significance": "key",
+    "mathContext": "A *blocking set* or *transversal* $B$ satisfies $B \\cap A_i \\neq \\emptyset$ for all $i \\in [m]$. In projective plane terms, $B$ meets every line. The formalization uses $\\text{Finset.Nonempty}$ for the non-emptiness condition, which unfolds to $\\exists x, x \\in B \\cap A_i$.",
+    "relatedConcepts": ["transversal", "hitting set", "vertex cover", "set cover dual"],
+    "prerequisites": ["SetFamily", "Finset.inter", "Finset.Nonempty"]
   },
   {
     "id": "ann-664-bounded",
@@ -50,8 +77,11 @@
     "range": { "startLine": 75, "endLine": 77 },
     "type": "definition",
     "title": "HasBoundedIntersection",
-    "content": "B meets each set in at most k elements.",
-    "significance": "key"
+    "content": "A set B has bounded intersection with parameter k if |B ∩ Aᵢ| ≤ k for all i.",
+    "significance": "key",
+    "mathContext": "The bound $|B \\cap A_i| \\leq k$ for all $i$ ensures the blocker $B$ doesn't concentrate on any single set. Without this constraint, one could trivially take $B = A_1$ (which blocks $A_1$ completely but may have $|B \\cap A_1| = |A_1| \\gg 1$). The question is whether $k$ can be chosen as an absolute constant depending only on $c$, not on $n$.",
+    "relatedConcepts": ["equitable partition", "balanced coloring", "dispersed transversal"],
+    "prerequisites": ["SetFamily", "Finset.card"]
   },
   {
     "id": "ann-664-good",
@@ -59,17 +89,23 @@
     "range": { "startLine": 79, "endLine": 81 },
     "type": "definition",
     "title": "IsGoodBlocker",
-    "content": "Blocker with O(1) intersection with each set.",
-    "significance": "critical"
+    "content": "A good blocker satisfies both conditions: it blocks (meets every set) and has bounded intersection (meets each in at most k elements). This is the object whose existence Erdős asked about.",
+    "significance": "critical",
+    "mathContext": "Erdős asked whether for every constant $c \\in (0,1)$ there exists $k = k(c)$ such that every near-linear family admits a $k$-good blocker. The conjunction $\\text{IsBlocker} \\wedge \\text{HasBoundedIntersection}$ formalizes the notion of a 'well-distributed' transversal that covers the family without over-concentrating.",
+    "relatedConcepts": ["well-distributed transversal", "balanced hitting set", "dispersed cover"],
+    "prerequisites": ["IsBlocker", "HasBoundedIntersection"]
   },
   {
     "id": "ann-664-question",
     "proofId": "erdos-664",
-    "range": { "startLine": 87, "endLine": 92 },
+    "range": { "startLine": 87, "endLine": 98 },
     "type": "definition",
     "title": "ErdosQuestion664",
-    "content": "Do good blockers always exist?",
-    "significance": "critical"
+    "content": "The formal statement of Erdős's question: for any c ∈ (0,1), there exists k such that every near-linear family on any ground set of size ≥ 10 admits a k-good blocker.",
+    "significance": "critical",
+    "mathContext": "Formally: $\\forall c \\in (0,1),\\, \\exists k \\in \\mathbb{N},\\, \\forall n,m \\geq 10,\\, \\forall \\mathcal{F} \\in \\text{NearLinear}(n,m,c),\\, \\exists B \\subseteq [n],\\, \\text{IsGoodBlocker}(\\mathcal{F}, B, k)$. The quantifier order is crucial: $k$ depends on $c$ but not on $n$ or $m$. The threshold $\\geq 10$ avoids degenerate small cases. Alon showed the answer is NO.",
+    "relatedConcepts": ["uniform bound", "Ramsey-type question", "finite vs infinite"],
+    "prerequisites": ["NearLinearFamily", "IsGoodBlocker"]
   },
   {
     "id": "ann-664-disproof",
@@ -77,17 +113,23 @@
     "range": { "startLine": 104, "endLine": 106 },
     "type": "theorem",
     "title": "alon_disproof",
-    "content": "Alon: The answer is NO.",
-    "significance": "critical"
+    "content": "Alon's theorem: the answer to Erdős's question is NO. Formalized as ¬ErdosQuestion664.",
+    "significance": "critical",
+    "mathContext": "Alon proved $\\neg\\text{ErdosQuestion664}$: for every $k$, there exist near-linear families where no $k$-good blocker exists. The negation unfolds to: $\\exists c \\in (0,1)$ (namely $c = 2/5$) such that $\\forall k,\\, \\exists n,m,\\, \\exists \\mathcal{F} \\in \\text{NearLinear}(n,m,c)$ with no $k$-good blocker. The axiomatization reflects that Alon's proof uses probabilistic arguments over projective planes that are beyond current Lean/Mathlib capabilities.",
+    "relatedConcepts": ["probabilistic method", "Lovász Local Lemma", "counterexample construction"],
+    "prerequisites": ["ErdosQuestion664"]
   },
   {
     "id": "ann-664-projorder",
     "proofId": "erdos-664",
-    "range": { "startLine": 108, "endLine": 109 },
+    "range": { "startLine": 108, "endLine": 114 },
     "type": "definition",
-    "title": "projectivePlaneOrder",
-    "content": "Order q gives q²+q+1 points/lines.",
-    "significance": "key"
+    "title": "Projective Plane Parameters",
+    "content": "The projective plane of order q has q² + q + 1 points and lines. For prime power q, such a plane (PG(2,q)) exists.",
+    "significance": "key",
+    "mathContext": "The Desarguesian projective plane $\\text{PG}(2,q)$ over $\\mathbb{F}_q$ has $q^2 + q + 1$ points and the same number of lines, each line containing $q+1$ points, each point on $q+1$ lines. For Alon's construction, $n = m = q^2 + q + 1$ and each set $A_i$ corresponds to a (thinned) line. The identity $q+1 \\approx \\sqrt{q^2+q+1} = \\sqrt{n}$ explains why the sets have size $\\approx \\sqrt{n}$.",
+    "relatedConcepts": ["Desarguesian plane", "Galois field", "finite geometry", "Fano plane"],
+    "prerequisites": ["prime power", "projectivePlaneOrder"]
   },
   {
     "id": "ann-664-construction",
@@ -95,8 +137,23 @@
     "range": { "startLine": 116, "endLine": 131 },
     "type": "theorem",
     "title": "alon_construction",
-    "content": "Counterexample: any blocker has Ω(log n) intersection.",
-    "significance": "critical"
+    "content": "Alon's explicit counterexample: for each large prime q, there exists a near-linear family on n = q² + q + 1 elements where every blocker has intersection ≥ (log n)/10 with some set.",
+    "significance": "critical",
+    "mathContext": "For prime $q \\geq 100$, Alon constructs $\\mathcal{A} = \\{A_1, \\ldots, A_m\\}$ with $n = m = q^2+q+1$ such that: (1) $|A_i| \\geq (2/5)\\sqrt{n}$, (2) $|A_i \\cap A_j| \\leq 1$ for $i \\neq j$, and (3) for any blocker $B$, $\\exists j$ with $|B \\cap A_j| \\geq (\\log n)/10$. The construction randomly thins each line of $\\text{PG}(2,q)$ to $\\approx 2/5$ of its points. The covering structure of the projective plane forces any transversal to concentrate on at least one line.",
+    "relatedConcepts": ["random thinning", "concentration inequality", "projective plane lines"],
+    "prerequisites": ["NearLinearFamily", "IsBlocker", "projectivePlaneOrder"]
+  },
+  {
+    "id": "ann-664-whyworks",
+    "proofId": "erdos-664",
+    "range": { "startLine": 140, "endLine": 166 },
+    "type": "context",
+    "title": "Why the Counterexample Works",
+    "content": "The counterexample relies on three properties of projective planes: each line has q+1 points, any two lines meet in exactly one point, and random thinning preserves these properties while forcing any blocker to have large intersection with some line.",
+    "significance": "key",
+    "mathContext": "The proof proceeds in three steps: (1) **Line structure**: $\\text{PG}(2,q)$ has lines of size $q+1 \\approx \\sqrt{n}$, satisfying the density condition. (2) **Intersection**: Two distinct lines meet in exactly one point, giving $|A_i \\cap A_j| = 1 \\leq 1$. After random thinning, the intersection can only decrease, so $|A_i \\cap A_j| \\leq 1$ is preserved. (3) **Covering argument**: Each point lies on $q+1$ lines. A blocker $B$ must hit all $q^2+q+1$ lines. By pigeonhole over the points of $B$, some line receives $\\geq \\Omega(\\log n)$ elements of $B$.",
+    "relatedConcepts": ["pigeonhole principle", "covering number", "point-line duality"],
+    "prerequisites": ["projective_line_size", "projective_intersection", "random_thinning_preserves"]
   },
   {
     "id": "ann-664-logbound",
@@ -104,52 +161,58 @@
     "range": { "startLine": 162, "endLine": 166 },
     "type": "theorem",
     "title": "logarithmic_lower_bound",
-    "content": "Any blocker has |B ∩ Aⱼ| ≥ Ω(log n) for some j.",
-    "significance": "critical"
+    "content": "Any blocker B must satisfy |B ∩ Aⱼ| ≥ Ω(log n) for some j. This is the key quantitative content of Alon's disproof.",
+    "significance": "critical",
+    "mathContext": "The logarithmic lower bound $|B \\cap A_j| \\geq \\Omega(\\log n)$ grows without bound as $n \\to \\infty$, contradicting the existence of a uniform constant $k = O_c(1)$. The log factor arises from a coupon-collector-type argument: to hit all $\\approx n$ lines using points that each cover $\\approx \\sqrt{n}$ lines, one needs $\\approx \\sqrt{n} \\log n / \\sqrt{n} = \\log n$ points on some line.",
+    "relatedConcepts": ["coupon collector", "greedy covering", "logarithmic barrier"],
+    "prerequisites": ["alon_construction", "IsBlocker"]
   },
   {
     "id": "ann-664-bbd",
     "proofId": "erdos-664",
-    "range": { "startLine": 172, "endLine": 174 },
+    "range": { "startLine": 168, "endLine": 185 },
     "type": "definition",
-    "title": "IsBalancedBlockDesign",
-    "content": "Every pair in exactly one block.",
-    "significance": "key"
+    "title": "Balanced Block Design and Original Question",
+    "content": "A balanced block design (BBD) has every pair of elements in exactly one block. Erdős's original 1981 question used BBDs instead of general near-linear families. This version remains open.",
+    "significance": "key",
+    "mathContext": "A $(v, k, 1)$-design (balanced incomplete block design with $\\lambda = 1$) has every pair of elements in exactly one block. Projective planes are $(q^2+q+1, q+1, 1)$-designs. Erdős's original formulation asked about BBDs specifically; the near-linear family version is a generalization that Alon disproved. The BBD version is strictly stronger (harder to disprove) because BBDs have more structure than arbitrary near-linear families.",
+    "relatedConcepts": ["BIBD", "Steiner system", "Fisher inequality", "resolvable design"],
+    "prerequisites": ["SetFamily"]
   },
   {
-    "id": "ann-664-original",
+    "id": "ann-664-finitegeom",
     "proofId": "erdos-664",
-    "range": { "startLine": 176, "endLine": 181 },
-    "type": "definition",
-    "title": "ErdosQuestion664_Original",
-    "content": "Original 1981 version using BBD (still open).",
-    "significance": "key"
+    "range": { "startLine": 187, "endLine": 205 },
+    "type": "context",
+    "title": "Finite Geometry Interpretation",
+    "content": "The problem translates to: in a projective plane, can we find a blocking set that meets every line in O(1) points? Bruen's bound gives the minimum blocking set size as q + √q + 1.",
+    "significance": "key",
+    "mathContext": "In $\\text{PG}(2,q)$, a *blocking set* $B$ satisfies $B \\cap \\ell \\neq \\emptyset$ for every line $\\ell$. Bruen (1971) proved $|B| \\geq q + \\sqrt{q} + 1$, with equality for *Baer subplanes* (when $q$ is a perfect square). Alon's result shows that even though small blocking sets exist, they cannot simultaneously bound $|B \\cap \\ell|$ uniformly. Problem #1159 asks whether the bound can be made $O(\\log n)$ instead of $O(1)$.",
+    "relatedConcepts": ["Baer subplane", "Bruen's bound", "Rédei polynomial", "minimal blocking set"],
+    "prerequisites": ["projectivePlaneOrder", "IsBlocker"]
   },
   {
-    "id": "ann-664-minblock",
+    "id": "ann-664-constant",
     "proofId": "erdos-664",
-    "range": { "startLine": 199, "endLine": 202 },
-    "type": "theorem",
-    "title": "minimum_blocking_set_size",
-    "content": "Bruen: minimum blocker size q + √q + 1.",
-    "significance": "key"
+    "range": { "startLine": 207, "endLine": 222 },
+    "type": "context",
+    "title": "The Constant 2/5 and Other Constants",
+    "content": "The constant 2/5 in Alon's construction comes from the random thinning probability. Any constant c < 1/2 yields a similar counterexample.",
+    "significance": "useful",
+    "mathContext": "Retaining each point independently with probability $p$ gives expected line size $p(q+1)$. For $p = 2/5$, the expected size is $(2/5)(q+1) \\approx (2/5)\\sqrt{n}$. Concentration (Chernoff bounds) ensures all lines have size close to the expectation. The theorem $\\texttt{other\\_constants\\_work}$ states the construction works for any $c < 1/2$; the barrier at $c = 1/2$ relates to the covering threshold where a random subset begins to block all lines.",
+    "relatedConcepts": ["Chernoff bound", "random subset", "retention probability", "threshold phenomenon"],
+    "prerequisites": ["alon_construction"]
   },
   {
     "id": "ann-664-main",
     "proofId": "erdos-664",
-    "range": { "startLine": 263, "endLine": 263 },
+    "range": { "startLine": 261, "endLine": 279 },
     "type": "theorem",
-    "title": "erdos_664",
-    "content": "Main theorem: conjecture is FALSE.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-664-constructive",
-    "proofId": "erdos-664",
-    "range": { "startLine": 268, "endLine": 278 },
-    "type": "theorem",
-    "title": "erdos_664_constructive",
-    "content": "Explicit counterexample for each large prime q.",
-    "significance": "critical"
+    "title": "Main Results",
+    "content": "Three equivalent formulations of the main result: erdos_664, erdos_664_main, and erdos_664_disproved all state ¬ErdosQuestion664. The constructive version erdos_664_constructive provides the explicit counterexample for each large prime q.",
+    "significance": "critical",
+    "mathContext": "The main theorem $\\texttt{erdos\\_664} : \\neg\\text{ErdosQuestion664}$ follows directly from $\\texttt{alon\\_disproof}$. The constructive version provides, for each prime $q \\geq 100$, an explicit family on $n = q^2+q+1$ elements witnessing the failure. The redundant formulations ($\\texttt{erdos\\_664\\_main}$, $\\texttt{erdos\\_664\\_disproved}$) provide semantic aliases for different contexts.",
+    "relatedConcepts": ["constructive disproof", "explicit counterexample", "infinitely many counterexamples"],
+    "prerequisites": ["alon_disproof", "alon_construction"]
   }
 ]

--- a/src/data/proofs/erdos-664/meta.json
+++ b/src/data/proofs/erdos-664/meta.json
@@ -15,7 +15,9 @@
       "blocking-sets",
       "projective-planes",
       "finite-geometry",
-      "disproved"
+      "disproved",
+      "probabilistic-method",
+      "hypergraph-theory"
     ],
     "badge": "axiom",
     "sorries": 0,
@@ -27,133 +29,156 @@
     "mathlibDependencies": [
       {
         "theorem": "Finset.card",
-        "description": "Cardinality of finite sets",
+        "description": "Cardinality of finite sets for $|A_i|$, $|B \\cap A_i|$, and size comparisons",
         "module": "Mathlib.Data.Finset.Card"
       },
       {
         "theorem": "Real.sqrt",
-        "description": "Square root for size bounds",
+        "description": "Square root for the density threshold $c\\sqrt{n}$ in the near-linear condition",
         "module": "Mathlib.Data.Real.Sqrt"
       },
       {
         "theorem": "Real.log",
-        "description": "Logarithm for intersection bounds",
+        "description": "Logarithm for expressing Alon's lower bound $|B \\cap A_j| \\geq (\\log n)/10$",
         "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Finset.inter",
+        "description": "Finite set intersection for pairwise $|A_i \\cap A_j| \\leq 1$ and blocker intersection $B \\cap A_i$",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.Nonempty",
+        "description": "Non-emptiness predicate for the blocking condition $B \\cap A_i \\neq \\emptyset$",
+        "module": "Mathlib.Data.Finset.Basic"
       }
     ],
     "originalContributions": [
-      "SetFamily: indexed collection of finite sets",
-      "AllLargerThan: sets of size > c√n",
-      "PairwiseSmallIntersection: |Aᵢ ∩ Aⱼ| ≤ 1",
-      "NearLinearFamily: structure combining conditions",
-      "IsBlocker, HasBoundedIntersection, IsGoodBlocker",
-      "ErdosQuestion664: formal problem statement",
-      "alon_disproof axiom: the answer is NO",
-      "projectivePlaneOrder, projective_plane_exists",
-      "alon_construction axiom: explicit counterexample",
-      "IsBalancedBlockDesign: original weaker formulation",
-      "ErdosQuestion664_Original: balanced design version (open)"
+      "SetFamily: indexed collection of m finite subsets of [n] via Fin m → Finset (Fin n)",
+      "AllLargerThan: density condition |Aᵢ| > c√n with real-valued comparison",
+      "PairwiseSmallIntersection: near-linear condition |Aᵢ ∩ Aⱼ| ≤ 1 for i ≠ j",
+      "NearLinearFamily: Lean structure bundling family with both properties",
+      "IsBlocker/HasBoundedIntersection/IsGoodBlocker: transversal theory definitions",
+      "ErdosQuestion664: formal statement with correct quantifier order (k depends on c, not n)",
+      "alon_disproof axiom: ¬ErdosQuestion664 (the answer is NO)",
+      "projectivePlaneOrder and projective_plane_exists: PG(2,q) parameters",
+      "alon_construction axiom: explicit counterexample with Ω(log n) intersection",
+      "IsBalancedBlockDesign: original 1981 formulation (still open)",
+      "ErdosQuestion664_Original: balanced block design version",
+      "minimum_blocking_set_size: Bruen's bound q + √q + 1 for projective planes"
+    ],
+    "relatedProofs": [
+      {
+        "id": "erdos-1159",
+        "relationship": "Stronger variant: #1159 asks whether O(log n)-bounded blocking sets exist in projective planes specifically, while #664 asked about O(1)-bounded blockers in general near-linear families"
+      },
+      {
+        "id": "erdos-661",
+        "relationship": "Both involve extremal questions about structured combinatorial configurations; #661 studies bipartite distinct distances while #664 studies blocking sets in near-linear families"
+      }
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #664 (Blocking Sets with Bounded Intersection)**\n\n**Origin:**\nErdős posed this problem in [Er81] (1981), asking whether near-linear set families (large sets with small pairwise intersection) always admit 'nice' blocking sets that intersect each set in O(1) points.\n\n**Motivation:**\nThis relates to blocking sets in finite geometries: can we find a blocking set (meeting every line) that doesn't concentrate on any single line?\n\n**Resolution:**\nNils Alon disproved the conjecture using a probabilistic construction based on projective planes. For n = q² + q + 1, random subsets of projective plane lines give families where any blocker must have logarithmically large intersection with some set.",
-    "problemStatement": "**Problem Statement (Disproved)**\n\nLet c < 1 and A₁,...,Aₘ ⊆ {1,...,n} with |Aᵢ| > c√n and |Aᵢ ∩ Aⱼ| ≤ 1 for i ≠ j.\n\nMust there exist B such that B ∩ Aᵢ ≠ ∅ and |B ∩ Aᵢ| = O_c(1) for all i?\n\n**Answer: NO**\n\n**Alon's Counterexample:**\nFor n = m = q² + q + 1 (q large prime), random subsets of projective plane lines give:\n- |Aᵢ| ≥ (2/5)√n\n- |Aᵢ ∩ Aⱼ| ≤ 1\n- Any blocker has |B ∩ Aⱼ| ≥ Ω(log n) for some j",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Set Families:** SetFamily, familySizes, AllLargerThan\n\n2. **Intersection:** PairwiseSmallIntersection, NearLinearFamily\n\n3. **Blocking:** IsBlocker, HasBoundedIntersection, IsGoodBlocker\n\n4. **The Question:** ErdosQuestion664 (O(1)-blockers exist?)\n\n5. **Disproof:** alon_disproof axiom\n\n6. **Construction:** Projective plane parameters, alon_construction\n\n7. **Original Version:** IsBalancedBlockDesign (still open)",
+    "historicalContext": "**Origins: Erdős and Blocking Sets (1981)**\n\nErdős posed Problem #664 in [Er81] (1981), in his influential paper \"On the combinatorial problems I would most like to see solved.\" The question arose from the study of blocking sets in finite geometries and transversal theory: given a family of large sets with small pairwise intersections, can we always find a 'nice' transversal that hits each set without over-concentrating?\n\n**The Near-Linear Setting**\n\nThe hypothesis — $|A_i| > c\\sqrt{n}$ with $|A_i \\cap A_j| \\leq 1$ — defines a *near-linear* (or *almost disjoint*) set family. Such families arise naturally from lines in projective planes, where each line has $q+1 \\approx \\sqrt{n}$ points and any two lines meet in exactly one point. Erdős asked whether the near-linear structure is rigid enough to force the existence of a well-distributed transversal.\n\n**Alon's Disproof via Projective Planes**\n\nNils Alon disproved the conjecture using a probabilistic construction based on the Desarguesian projective plane $\\text{PG}(2,q)$. Starting with the $q^2+q+1$ lines of $\\text{PG}(2,q)$, Alon randomly retains each point on each line independently with probability $\\approx 2/5$. The thinned lines maintain: (1) size $\\approx (2/5)(q+1) > (2/5)\\sqrt{n}$; (2) pairwise intersection $\\leq 1$ (since thinning can only reduce intersections); and crucially (3) any transversal must concentrate $\\Omega(\\log n)$ points on at least one line, by a coupon-collector-type covering argument.\n\n**The Logarithmic Barrier**\n\nThe key quantitative result is that for any blocker $B$, there exists $j$ with $|B \\cap A_j| \\geq \\Omega(\\log n)$. Since $\\log n \\to \\infty$, no uniform constant $k = O_c(1)$ can bound all intersections — answering Erdős's question in the negative. The logarithmic growth is tight: the ESS (Erdős-Simonovits-Sós) construction for Problem #1159 shows that $O(\\log n)$-bounded blocking sets do exist in projective planes.\n\n**The Open Balanced Design Version**\n\nErdős's original 1981 formulation used balanced block designs (every pair in exactly one block) rather than general near-linear families. Since BBDs have strictly more structure, Alon's counterexample doesn't directly apply, and this version remains open. Alon conjectured that the BBD version is also false, but this has not been established.",
+    "problemStatement": "Let $c < 1$ be a constant and $A_1, \\ldots, A_m \\subseteq \\{1, \\ldots, n\\}$ with $|A_i| > c\\sqrt{n}$ and $|A_i \\cap A_j| \\leq 1$ for $i \\neq j$. Must there exist $B$ such that $B \\cap A_i \\neq \\emptyset$ and $|B \\cap A_i| = O_c(1)$ for all $i$?\n\n**Answer: NO.** For $n = q^2 + q + 1$ (large prime $q$), Alon constructs families where any blocker $B$ satisfies $|B \\cap A_j| \\geq \\Omega(\\log n)$ for some $j$.",
+    "proofStrategy": "The formalization builds up in layers: (1) **Set family infrastructure** — `SetFamily`, `familySizes`, `AllLargerThan`, `PairwiseSmallIntersection`, and the `NearLinearFamily` structure bundling these conditions; (2) **Transversal theory** — `IsBlocker`, `HasBoundedIntersection`, `IsGoodBlocker` defining the desired objects; (3) **The formal question** — `ErdosQuestion664` with precise quantifier ordering ($k$ depends on $c$ but not $n$ or $m$); (4) **Alon's disproof** — `alon_disproof` (negation) and `alon_construction` (explicit counterexample) as axioms; (5) **The mechanism** — projective plane parameters, random thinning preservation, and the logarithmic lower bound explaining *why* the construction works; (6) **Original version** — `IsBalancedBlockDesign` and `ErdosQuestion664_Original` preserving the open BBD formulation.",
     "keyInsights": [
-      "**Near-Linear Families:** Sets > c√n with ≤1 pairwise intersection",
-      "**Blocking Sets:** Transversals meeting each set",
-      "**Projective Planes:** PG(2,q) has q²+q+1 points and lines",
-      "**Random Thinning:** Probabilistic construction preserves properties",
-      "**Logarithmic Barrier:** Any blocker has Ω(log n) intersection somewhere"
+      "The **near-linear condition** ($|A_i \\cap A_j| \\leq 1$) is not strong enough to force well-distributed transversals — despite preventing any element from covering many sets simultaneously, the global covering structure can still force concentration",
+      "**Projective planes provide the counterexample** because their symmetric structure ($q^2+q+1$ points, $q^2+q+1$ lines, $q+1$ points per line, $q+1$ lines per point) creates an unavoidable covering bottleneck: each point lies on only $q+1 \\approx \\sqrt{n}$ lines, so covering all $n$ lines forces $\\Omega(\\log n)$ concentration",
+      "**Random thinning** is the key probabilistic tool: retaining each point with probability $p$ preserves the near-linear condition ($|A_i \\cap A_j|$ can only decrease) while maintaining the covering difficulty (the thinned family still has $\\approx n$ sets, each of size $\\approx p\\sqrt{n}$)",
+      "The **logarithmic lower bound** $|B \\cap A_j| \\geq \\Omega(\\log n)$ is tight: the ESS construction for Problem #1159 achieves $O(\\log n)$-bounded blocking sets in projective planes, showing that $\\log n$ is the correct order of magnitude",
+      "The **balanced block design version remains open**: BBDs impose the additional constraint that every pair of elements appears in exactly one block (not just $\\leq 1$), and this extra structure might be sufficient to force $O(1)$-bounded transversals",
+      "The constant $c = 2/5$ is not special — the construction works for any $c < 1/2$, with the barrier at $c = 1/2$ related to the random covering threshold where a random point subset begins to block all lines with high probability"
     ]
   },
   "sections": [
     {
-      "id": "erd-s-problem-664-blocking-set",
-      "title": "Erdős Problem #664: Blocking Sets with Bounded Intersection",
+      "id": "header",
+      "title": "Problem Statement and References",
       "startLine": 1,
-      "endLine": 41,
-      "summary": "Erdős Problem #664: Blocking Sets with Bounded Intersection"
+      "endLine": 39,
+      "summary": "Documentation header with problem statement, Alon's disproof via projective plane construction, references to [Er81] and Problem #1159"
     },
     {
-      "id": "set-families-with-bounded-inte",
+      "id": "set-families",
       "title": "Set Families with Bounded Intersection",
       "startLine": 42,
       "endLine": 66,
-      "summary": "Set Families with Bounded Intersection"
+      "summary": "Defines $\\text{SetFamily}(n,m)$ as $\\text{Fin}\\,m \\to \\text{Finset}\\,(\\text{Fin}\\,n)$, $\\text{AllLargerThan}$ ($|A_i| > c\\sqrt{n}$), $\\text{PairwiseSmallIntersection}$ ($|A_i \\cap A_j| \\leq 1$), and the $\\text{NearLinearFamily}$ structure bundling both conditions"
     },
     {
       "id": "blocking-sets",
       "title": "Blocking Sets",
       "startLine": 67,
       "endLine": 82,
-      "summary": "Blocking Sets"
+      "summary": "Defines $\\text{IsBlocker}$ (transversal meeting every set), $\\text{HasBoundedIntersection}$ ($|B \\cap A_i| \\leq k$ for all $i$), and $\\text{IsGoodBlocker}$ (both conditions combined)"
     },
     {
-      "id": "the-erd-s-question",
+      "id": "erdos-question",
       "title": "The Erdős Question",
       "startLine": 83,
       "endLine": 99,
-      "summary": "The Erdős Question"
+      "summary": "Formal statement $\\text{ErdosQuestion664}$: $\\forall c \\in (0,1),\\, \\exists k,\\, \\forall n,m \\geq 10,\\, \\forall \\mathcal{F},\\, \\exists B$ with $\\text{IsGoodBlocker}(\\mathcal{F}, B, k)$"
     },
     {
-      "id": "alon-s-counterexample",
+      "id": "alon-counterexample",
       "title": "Alon's Counterexample",
       "startLine": 100,
       "endLine": 139,
-      "summary": "Alon's Counterexample"
+      "summary": "Axiomatizes Alon's disproof ($\\neg\\text{ErdosQuestion664}$), projective plane parameters ($q^2+q+1$), and the explicit construction giving families where any blocker has $|B \\cap A_j| \\geq (\\log n)/10$ for some $j$"
     },
     {
-      "id": "why-the-counterexample-works",
+      "id": "mechanism",
       "title": "Why the Counterexample Works",
       "startLine": 140,
       "endLine": 167,
-      "summary": "Why the Counterexample Works"
+      "summary": "Three axiomatized properties: projective lines have $q+1$ points, two lines meet in exactly one point, random thinning preserves near-linearity while forcing blocker concentration. The logarithmic lower bound via coupon-collector argument"
     },
     {
-      "id": "balanced-block-designs-origina",
-      "title": "Balanced Block Designs (Original Weaker Version)",
+      "id": "balanced-designs",
+      "title": "Balanced Block Designs (Original Version)",
       "startLine": 168,
       "endLine": 186,
-      "summary": "Balanced Block Designs (Original Weaker Version)"
+      "summary": "Defines $\\text{IsBalancedBlockDesign}$ (every pair in exactly one block) and $\\text{ErdosQuestion664\\_Original}$ — the 1981 formulation that remains OPEN"
     },
     {
-      "id": "finite-geometry-interpretation",
+      "id": "finite-geometry",
       "title": "Finite Geometry Interpretation",
       "startLine": 187,
       "endLine": 206,
-      "summary": "Finite Geometry Interpretation"
+      "summary": "Blocking sets in projective planes, Bruen's bound $q + \\sqrt{q} + 1$ for minimum blocking set size, connection to Problem #1159"
     },
     {
-      "id": "the-constant-2-5",
+      "id": "constant-analysis",
       "title": "The Constant 2/5",
       "startLine": 207,
       "endLine": 223,
-      "summary": "The Constant 2/5"
+      "summary": "Analysis of the retention probability $p \\approx 2/5$: any $c < 1/2$ works via Chernoff concentration bounds"
     },
     {
       "id": "related-problems",
       "title": "Related Problems",
       "startLine": 224,
       "endLine": 243,
-      "summary": "Related Problems"
+      "summary": "Connections to Problem #1159 (bounded blocking sets in projective planes), set cover/transversal theory, and hypergraph coloring"
     },
     {
       "id": "summary",
-      "title": "Summary",
+      "title": "Summary and Main Theorems",
       "startLine": 244,
       "endLine": 281,
-      "summary": "Summary"
+      "summary": "Four equivalent formulations: $\\texttt{erdos\\_664}$, $\\texttt{erdos\\_664\\_main}$, $\\texttt{erdos\\_664\\_disproved}$ (all $\\neg\\text{ErdosQuestion664}$), and $\\texttt{erdos\\_664\\_constructive}$ (explicit counterexample for each prime $q \\geq 100$)"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #664 asked whether near-linear set families (|Aᵢ| > c√n, pairwise intersection ≤ 1) always admit blocking sets with O(1) intersection. Alon disproved this using projective plane constructions: for n = q² + q + 1, any blocker must have Ω(log n) intersection with some set. The original balanced block design version remains open.",
-    "implications": "**Connections**\n\n1. **Finite Geometry:** Blocking sets in projective planes\n\n2. **Probabilistic Method:** Random subset construction\n\n3. **Hypergraph Theory:** Near-linear hypergraphs\n\n4. **Set Cover:** Transversal and hitting set problems",
+    "summary": "Erdős Problem #664, posed in 1981, asked whether near-linear set families (sets of size $> c\\sqrt{n}$ with pairwise intersection $\\leq 1$) always admit blocking sets with $O(1)$ intersection. Alon disproved this using random subsets of projective plane lines: for $n = q^2+q+1$, any blocker must have $\\Omega(\\log n)$ intersection with some set. The formalization captures the disproof as axioms, with the full construction mechanism (projective plane structure, random thinning, covering argument) explained through supporting axioms. The original balanced block design version remains open.",
+    "implications": "Alon's disproof reveals a fundamental asymmetry in transversal theory: the near-linear condition ($|A_i \\cap A_j| \\leq 1$) prevents *local* overlap but cannot prevent *global* concentration of transversals. The tight logarithmic bound ($\\Theta(\\log n)$) connects to covering theory and the coupon collector problem. The projective plane construction bridges finite geometry and probabilistic combinatorics, and the unresolved BBD version tests whether the stronger design-theoretic structure ($\\lambda = 1$ BIBD) can overcome this limitation. Problem #1159 extends the question by asking whether $O(\\log n)$-bounded blocking sets always exist in projective planes (the ESS theorem confirms this for Desarguesian planes).",
     "openQuestions": [
-      "Is the balanced block design version also false?",
-      "What is the exact threshold for the logarithmic lower bound?",
-      "Does the construction extend to other combinatorial structures?",
-      "What is the minimum blocker size for general near-linear families?"
+      "Is the balanced block design version (ErdosQuestion664_Original) also false, as Alon conjectured?",
+      "For non-Desarguesian projective planes, do $O(\\log n)$-bounded blocking sets still exist?",
+      "What is the exact threshold constant: is the counterexample possible for $c \\geq 1/2$, or is $c < 1/2$ necessary?",
+      "Can the logarithmic lower bound be improved for specific families of near-linear hypergraphs beyond projective planes?",
+      "What is the computational complexity of deciding whether a given near-linear family admits a $k$-good blocker?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enrich erdos-652 (Distance Multiplicity Spectrum): Add mathContext/relatedConcepts/prerequisites, expand historicalContext, cross-references
- Enrich erdos-657 (Isosceles-Free Point Sets): Add mathContext/relatedConcepts/prerequisites, Kelley-Meka breakthrough context
- Enrich erdos-660 (Distinct Distances in Convex Polyhedra): Add mathContext/relatedConcepts/prerequisites, Altman's 2D result context
- Enrich erdos-664 (Blocking Sets): Add mathContext/relatedConcepts/prerequisites, Alon's projective plane disproof context
- Enrich erdos-631 (List Chromatic Number): Add mathContext/relatedConcepts/prerequisites, Thomassen/Voigt resolution, List Coloring Conjecture

## Test plan
- [x] All JSON files validate with `python3 -c "import json; json.load(open(...))"`
- [x] Annotations include mathContext, relatedConcepts, prerequisites
- [x] Meta includes expanded historicalContext, keyInsights, proofStrategy, conclusion
- [x] Cross-references point to existing gallery entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)