### PR TITLE
research: erdos-1082-oq-01 - n/2 distinct distances for n ≤ 5

### DIFF
--- a/proofs/Proofs/Erdos1082OQ01.lean
+++ b/proofs/Proofs/Erdos1082OQ01.lean
@@ -158,6 +158,105 @@ theorem conjecture_n_le_3 (S : Finset (ℝ × ℝ)) (h2 : 2 ≤ S.card) (h3 : S.
   have : S.card / 2 ≤ 1 := by omega
   linarith [at_least_one_distance S h2]
 
+/-! ## Extension: n/2 conjecture for n = 4, 5
+
+Since at most 3 points in ℝ² can be mutually equidistant, any set of 4 or more
+points must have at least 2 distinct pairwise distances. This gives ⌊n/2⌋ ≤ 2. -/
+
+/-- Helper: if all 6 pairwise squared distances among 4 distinct points are the same,
+we get a contradiction. -/
+theorem four_distinct_not_equidistant (a b c e : ℝ × ℝ)
+    (hab : a ≠ b) (hac : a ≠ c) (hae : a ≠ e) (hbc : b ≠ c) (hbe : b ≠ e) (hce : c ≠ e)
+    (h_all_eq : distSq a b = distSq a c ∧ distSq a c = distSq a e ∧
+      distSq a e = distSq b c ∧ distSq b c = distSq b e ∧ distSq b e = distSq c e) : False := by
+  obtain ⟨h1, h2, h3, h4, h5⟩ := h_all_eq
+  have hd := distSq_pos_of_ne hab
+  exact no_four_equidistant a b c e (distSq a b) hd hab hac hae hbc hbe hce
+    rfl h1.symm (by linarith) (by linarith) (by linarith) (by linarith)
+
+/-- If a finset of size ≥ 4 has only 1 distinct squared distance, we can extract
+4 distinct points and derive a contradiction. -/
+theorem at_least_two_distances (S : Finset (ℝ × ℝ)) (h4 : 4 ≤ S.card) :
+    2 ≤ (distinctDistSq S).card := by
+  by_contra hlt
+  push_neg at hlt
+  -- distinctDistSq S has card ≤ 1
+  -- But S has ≥ 4 points, so S.offDiag is nonempty (has ≥ 12 elements)
+  -- Since card ≤ 1 and nonempty, all distances are equal to some value d
+  -- Extract 4 points and apply no_four_equidistant
+  -- First, show distinctDistSq S is nonempty
+  have h2 : 2 ≤ S.card := by omega
+  have hne : (distinctDistSq S).Nonempty := by
+    rw [Finset.nonempty_iff_ne_empty]
+    intro hemp
+    have := at_least_one_distance S h2
+    rw [hemp, Finset.card_empty] at this; omega
+  -- So distinctDistSq S has exactly 1 element
+  have hge1 := Finset.Nonempty.card_pos hne
+  have hcard1 : (distinctDistSq S).card = 1 := by omega
+  obtain ⟨d, hd⟩ := Finset.card_eq_one.mp hcard1
+  -- All offDiag pairs have distSq = d
+  have h_all : ∀ pq ∈ S.offDiag, distSq pq.1 pq.2 = d := by
+    intro pq hpq
+    have : distSq pq.1 pq.2 ∈ distinctDistSq S :=
+      Finset.mem_image.mpr ⟨pq, hpq, rfl⟩
+    rw [hd] at this
+    exact Finset.mem_singleton.mp this
+  -- Extract 4 distinct elements from S
+  have ⟨a, ha⟩ := Finset.card_pos.mp (by omega : 0 < S.card)
+  have ⟨b, hb⟩ := Finset.card_pos.mp (show 0 < (S.erase a).card by
+    rw [Finset.card_erase_of_mem ha]; omega)
+  have hab : b ≠ a := Finset.ne_of_mem_erase hb
+  have hb' : b ∈ S := Finset.mem_of_mem_erase hb
+  have ⟨c, hc⟩ := Finset.card_pos.mp (show 0 < ((S.erase a).erase b).card by
+    rw [Finset.card_erase_of_mem hb, Finset.card_erase_of_mem ha]; omega)
+  have hcb : c ≠ b := Finset.ne_of_mem_erase hc
+  have hc_ea : c ∈ S.erase a := Finset.mem_of_mem_erase hc
+  have hca : c ≠ a := Finset.ne_of_mem_erase hc_ea
+  have hc' : c ∈ S := Finset.mem_of_mem_erase hc_ea
+  have ⟨e, he⟩ := Finset.card_pos.mp (show 0 < (((S.erase a).erase b).erase c).card by
+    rw [Finset.card_erase_of_mem hc,
+        Finset.card_erase_of_mem hb,
+        Finset.card_erase_of_mem ha]; omega)
+  have hec : e ≠ c := Finset.ne_of_mem_erase he
+  have he_eab : e ∈ (S.erase a).erase b := Finset.mem_of_mem_erase he
+  have heb : e ≠ b := Finset.ne_of_mem_erase he_eab
+  have he_ea : e ∈ S.erase a := Finset.mem_of_mem_erase he_eab
+  have hea : e ≠ a := Finset.ne_of_mem_erase he_ea
+  have he' : e ∈ S := Finset.mem_of_mem_erase he_ea
+  -- All 6 pairwise distances equal d
+  have dab : distSq a b = d := h_all (a, b) (Finset.mem_offDiag.mpr ⟨ha, hb', hab.symm⟩)
+  have dac : distSq a c = d := h_all (a, c) (Finset.mem_offDiag.mpr ⟨ha, hc', hca.symm⟩)
+  have dae : distSq a e = d := h_all (a, e) (Finset.mem_offDiag.mpr ⟨ha, he', hea.symm⟩)
+  have dbc : distSq b c = d := h_all (b, c) (Finset.mem_offDiag.mpr ⟨hb', hc', hcb.symm⟩)
+  have dbe : distSq b e = d := h_all (b, e) (Finset.mem_offDiag.mpr ⟨hb', he', heb.symm⟩)
+  have dce : distSq c e = d := h_all (c, e) (Finset.mem_offDiag.mpr ⟨hc', he', hec.symm⟩)
+  exact four_distinct_not_equidistant a b c e hab.symm hca.symm hea.symm hcb.symm heb.symm hec.symm
+    ⟨by linarith, by linarith, by linarith, by linarith, by linarith⟩
+
+/-- The n/2 conjecture holds for n = 4 -/
+theorem conjecture_n_eq_4 (S : Finset (ℝ × ℝ)) (h : S.card = 4) :
+    S.card / 2 ≤ (distinctDistSq S).card := by
+  rw [h]; norm_num
+  exact at_least_two_distances S (by omega)
+
+/-- The n/2 conjecture holds for n = 5 -/
+theorem conjecture_n_eq_5 (S : Finset (ℝ × ℝ)) (h : S.card = 5) :
+    S.card / 2 ≤ (distinctDistSq S).card := by
+  rw [h]; norm_num
+  exact at_least_two_distances S (by omega)
+
+/-- The n/2 conjecture holds for all n ≤ 5 -/
+theorem conjecture_n_le_5 (S : Finset (ℝ × ℝ)) (h2 : 2 ≤ S.card) (h5 : S.card ≤ 5) :
+    S.card / 2 ≤ (distinctDistSq S).card := by
+  by_cases h4 : 4 ≤ S.card
+  · -- n = 4 or 5: use at_least_two_distances
+    have : 2 ≤ (distinctDistSq S).card := at_least_two_distances S h4
+    have : S.card / 2 ≤ 2 := by omega
+    omega
+  · -- n ≤ 3: use conjecture_n_le_3
+    exact conjecture_n_le_3 S h2 (by omega)
+
 /-! ## Summary
 
 ### Results Proved (Zero Sorries)
@@ -166,6 +265,10 @@ theorem conjecture_n_le_3 (S : Finset (ℝ × ℝ)) (h2 : 2 ≤ S.card) (h3 : S.
 2. `no_four_equidistant`: 4 mutually equidistant points are impossible in ℝ²
 3. `at_least_one_distance`: n ≥ 2 points → at least 1 distinct distance
 4. `conjecture_n_le_3`: the n/2 conjecture for n ≤ 3
+5. `four_distinct_not_equidistant`: contradiction from 4 distinct equidistant pts
+6. `at_least_two_distances`: any Finset of size ≥ 4 has ≥ 2 distinct distances
+7. `conjecture_n_eq_4`, `conjecture_n_eq_5`: n/2 for n = 4, 5
+8. `conjecture_n_le_5`: n/2 for all n ≤ 5 (unified theorem)
 
 ### Proof Technique
 Given 4 equidistant points with common squared distance d:
@@ -178,6 +281,8 @@ Given 4 equidistant points with common squared distance d:
 ### Mathematical Significance
 At most 3 points in ℝ² can be mutually equidistant → any n ≥ 4 points have ≥ 2
 distinct distances → n/2 conjecture holds for n ≤ 5 (since ⌊n/2⌋ ≤ 2).
+The `at_least_two_distances` theorem directly connects the structural impossibility
+to the counting problem via Finset extraction and pigeonhole on distances.
 -/
 
 end Erdos1082OQ01

--- a/src/data/research/problems/erdos-1082-oq-01.json
+++ b/src/data/research/problems/erdos-1082-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-1082-oq-01",
   "title": "Distinct Distances in General Position: n/2 Lower Bound",
-  "phase": "PROGRESS",
-  "status": "in-progress",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "B",
   "path": "deep-dive",
   "problemStatement": {
@@ -20,55 +20,72 @@
       "equidistant_system_inconsistent: algebraic core showing d⁴/4 = 3d⁴/4 contradiction",
       "at_least_one_distance: n ≥ 2 points have ≥ 1 distinct distance",
       "conjecture_n_le_3: n/2 conjecture holds for n ≤ 3",
+      "four_distinct_not_equidistant: 4 distinct equidistant points → contradiction",
+      "at_least_two_distances: Finset of size ≥ 4 has ≥ 2 distinct squared distances",
+      "conjecture_n_eq_4, conjecture_n_eq_5: n/2 for n = 4, 5",
+      "conjecture_n_le_5: n/2 conjecture for all n ≤ 5 (unified theorem)",
       "distSq properties: nonneg, comm, eq_zero_iff, pos_of_ne"
     ],
     "open": [
       "n/2 conjecture for all n (Erdős Problem 1082, question 1)"
     ],
-    "goal": "Prove structural lemmas toward the n/2 conjecture; small cases verified"
+    "goal": "Formalization complete for provable cases. n/2 verified for n ≤ 5. Main conjecture remains OPEN."
   },
   "currentState": {
-    "phase": "PROGRESS",
-    "since": "2026-02-12",
-    "iteration": 1,
-    "focus": "Proved impossibility of 4 equidistant points via Lagrange identity, establishing n/2 conjecture for n ≤ 5",
+    "phase": "COMPLETE",
+    "since": "2026-02-13T09:20:00.000Z",
+    "iteration": 2,
+    "focus": "Extended n/2 conjecture from n ≤ 3 to n ≤ 5 using Finset extraction and pigeonhole on distances",
     "blockers": [
       "Main conjecture is OPEN for all n - no known proof exists"
     ],
-    "nextAction": "Could prove n/2 conjecture for n ≤ 5 by extracting 4 distinct points from a Finset (requires Finset API work)",
+    "nextAction": "No further provable work. n ≥ 6 would require genuinely new combinatorial arguments beyond equidistant point impossibility.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved key structural lemma (no 4 equidistant points in ℝ²) via elegant Lagrange identity argument. This implies n/2 conjecture for n ≤ 5. Also proved n ≤ 3 case formally.",
+    "progressSummary": "COMPLETE: Erdos1082OQ01.lean has 0 sorries, 0 axioms, 12 theorems. Proved n/2 conjecture for n ≤ 5 by connecting no_four_equidistant structural result to Finset distance counting via pigeonhole.",
     "builtItems": [
       "equidistant_system_inconsistent: algebraic core (zero sorries)",
       "no_four_equidistant: geometric wrapper (zero sorries)",
       "at_least_one_distance: n ≥ 2 → ≥ 1 distance",
-      "conjecture_n_le_3: n/2 for n ≤ 3"
+      "conjecture_n_le_3: n/2 for n ≤ 3",
+      "four_distinct_not_equidistant: 4 equidistant distinct points → False",
+      "at_least_two_distances: |S| ≥ 4 → ≥ 2 distinct distances (key bridge theorem)",
+      "conjecture_n_eq_4: n/2 for n = 4",
+      "conjecture_n_eq_5: n/2 for n = 5",
+      "conjecture_n_le_5: unified n/2 for n ≤ 5"
     ],
     "insights": [
       "Lagrange identity proof: given u=b-a, v=c-a, δ=e-c all with |·|²=d, perpendicular bisector conditions give δ·u=0, δ·v=-d/2, u·v=d/2",
       "Vector triple product: (δ×u)(u×v) = (δ·u)(u·v)-(δ·v)|u|² = 0·(d/2)-(-d/2)·d = d²/2",
       "Squaring: (δ×u)²(u×v)² = d²·3d²/4 = 3d⁴/4 but also = (d²/2)² = d⁴/4, so d=0",
       "Working with ℝ×ℝ avoids EuclideanSpace/WithLp abstraction that causes nlinarith issues",
-      "Separating algebraic core (equidistant_system_inconsistent) from geometric wrapper (no_four_equidistant) avoids heartbeat limits"
+      "Separating algebraic core (equidistant_system_inconsistent) from geometric wrapper (no_four_equidistant) avoids heartbeat limits",
+      "Finset extraction via repeated erase: card_pos.mp + card_erase_of_mem + ne_of_mem_erase pattern",
+      "Finset.card_eq_one.mp + singleton membership check bridges between card=1 and all-equal",
+      "The n/2 bound for n ≤ 5 is tight: 3 equidistant points give only 1 distinct distance, matching ⌊3/2⌋ = 1"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove n/2 for n=4,5 using no_four_equidistant + Finset extraction",
-      "Connect to EuclideanSpace version in Erdos1082Problem.lean",
-      "Could submit to Aristotle for automated proof search on supporting lemmas"
+      "No further provable work without breakthrough on the OPEN conjecture",
+      "n ≥ 6 requires showing not just ≥ 2 distances but ≥ 3, which needs new combinatorial geometry"
     ]
   },
   "approaches": [
     {
       "name": "Lagrange identity / perpendicular bisector",
       "description": "Use overdetermined perpendicular bisector system in 2D to show 4 equidistant points impossible, then derive small cases of n/2 conjecture",
-      "status": "complete-for-structure",
+      "status": "complete",
+      "difficulty": "medium"
+    },
+    {
+      "name": "Finset extraction + pigeonhole",
+      "description": "Extract 4 distinct points from Finset of size ≥ 4, show singleton distance set contradicts no_four_equidistant, derive ≥ 2 distances",
+      "status": "complete",
       "difficulty": "medium"
     }
   ],
@@ -77,7 +94,9 @@
     "geometry",
     "distinct-distances",
     "incidence-geometry",
-    "lagrange-identity"
+    "lagrange-identity",
+    "0-sorry",
+    "0-axiom"
   ],
   "relatedProofs": [
     "Erdos1082Problem.lean",
@@ -93,7 +112,8 @@
     "mathlib": []
   },
   "started": "2026-02-12T07:52:00.000Z",
-  "lastUpdate": "2026-02-12T08:30:00.000Z",
+  "lastUpdate": "2026-02-13T09:20:00.000Z",
+  "completed": "2026-02-13T09:20:00.000Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Extended the Erdős 1082 OQ-01 formalization to prove the n/2 distinct distances conjecture for n ≤ 5
- Connected the structural `no_four_equidistant` theorem to Finset distance counting via pigeonhole argument
- All new theorems are sorry-free and axiom-free (Docker verified)

## Progress
- `four_distinct_not_equidistant`: contradiction from 4 distinct equidistant points
- `at_least_two_distances`: key bridge theorem - any Finset of ≥ 4 points has ≥ 2 distinct distances
- `conjecture_n_eq_4`, `conjecture_n_eq_5`: individual n/2 proofs
- `conjecture_n_le_5`: unified n/2 conjecture for all n ≤ 5

## Technique
Extract 4 distinct points from Finset via repeated `erase` + `card_pos.mp`, then show singleton distance set contradicts `no_four_equidistant` via Lagrange identity.

## Status
**Outcome**: completed
**Sorries**: 0, **Axioms**: 0, **New theorems**: 5
**Note**: Main conjecture remains OPEN for all n. n ≤ 5 is the limit of the equidistant-point-impossibility approach.

🤖 Generated by researcher-1