### PR TITLE
enrich: add references and cross-references for cramers-rule

### DIFF
--- a/src/data/proofs/cramers-rule/meta.json
+++ b/src/data/proofs/cramers-rule/meta.json
@@ -26,8 +26,15 @@
       "Linearity properties of the Cramer map",
       "2x2 system example over a field"
     ],
+    "references": [
+      {"authors": "G. Cramer", "title": "Introduction à l'Analyse des Lignes Courbes Algébriques", "year": "1750", "venue": "Geneva", "note": "First published statement of Cramer's rule for systems of polynomial equations"},
+      {"authors": "C. Maclaurin", "title": "A Treatise of Algebra", "year": "1748", "venue": "London (posthumous)", "note": "Contains the rule independently, predating Cramer's publication but published posthumously"},
+      {"authors": "A. Cayley", "title": "A Memoir on the Theory of Matrices", "year": "1858", "venue": "Philosophical Transactions of the Royal Society", "note": "Systematic matrix algebra framework including the adjugate identity"},
+      {"authors": "E. H. Bareiss", "title": "Sylvester's identity and multistep integer-preserving Gaussian elimination", "year": "1968", "venue": "Mathematics of Computation", "note": "Fraction-free algorithm for determinants, an alternative to Cramer's rule for integer matrices"}
+    ],
     "dateAdded": "12/26/25",
-    "wiedijkNumber": 97
+    "wiedijkNumber": 97,
+    "mathlib_version": "4.15.0"
   },
   "overview": {
     "historicalContext": "**Multiple Independent Discoveries**\n\n**Gabriel Cramer** (1704-1752) published the rule in his 1750 *Introduction à l'Analyse des Lignes Courbes Algébriques*, deriving it for systems of polynomial equations arising from curve intersections. However, **Colin Maclaurin** had the result by 1729 (published posthumously in 1748 in *Treatise of Algebra*), and the method appears in Chinese mathematics as early as the 12th century. **Leibniz** (1693) also developed determinant-like methods for solving linear systems in a letter to l'Hôpital, predating both Cramer and Maclaurin, though without systematic matrix notation.\n\n**The Adjugate Connection**\n\nThe mathematical backbone is the adjugate (classical adjoint) matrix identity $A \\cdot \\text{adj}(A) = \\det(A) \\cdot I$, which holds over any commutative ring — a remarkable algebraic fact requiring no invertibility hypothesis. **Cayley** (1858) and **Hamilton** developed the matrix algebra framework that made this identity precise. The adjugate's entries are signed minors (cofactors), connecting Cramer's rule to the Laplace expansion of determinants along arbitrary rows or columns. This identity also underpins the Cayley-Hamilton theorem: substituting $A$ for $\\lambda$ in $\\det(A - \\lambda I)$ yields the zero matrix.\n\n**Computational Perspective**\n\nDespite its theoretical elegance, Cramer's rule has $O(n! \\cdot n)$ naive complexity via the Leibniz formula for determinants. **Gaussian elimination** achieves $O(n^3)$, and **Bareiss's algorithm** (1968) computes integer determinants without fractions in $O(n^3)$ as well. Cramer's rule remains valuable for: (1) theoretical proofs about solution existence and continuity of solutions as functions of parameters, (2) small systems ($n \\leq 3$) in engineering, (3) symbolic computation where entries are polynomials or formal power series, and (4) proving structural results like the Cayley-Hamilton theorem.\n\nThis is #97 on **Freek Wiedijk**'s list of 100 theorems formalized in proof assistants.",
@@ -116,5 +123,14 @@
       "Can Cramer's rule for underdetermined systems (using generalized inverses) be formalized?"
     ]
   },
-  "relatedProofs": ["cayley-hamilton"]
+  "relatedProblems": [
+    {
+      "id": "cayley-hamilton",
+      "relationship": "The adjugate identity $A \\cdot \\text{adj}(A) = \\det(A) \\cdot I$, central to Cramer's rule, is also the algebraic foundation of the Cayley-Hamilton theorem. Substituting $A$ for $\\lambda$ in the characteristic polynomial yields the zero matrix via the same cofactor machinery."
+    },
+    {
+      "id": "cauchy-schwarz",
+      "relationship": "Both are foundational linear algebra results formalized via Mathlib's abstract algebraic infrastructure. Cauchy-Schwarz works in inner product spaces while Cramer's rule works over commutative rings, showcasing Mathlib's generality."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add 4 historical references (Cramer 1750, Maclaurin 1748, Cayley 1858, Bareiss 1968)
- Convert `relatedProofs` to `relatedProblems` with detailed relationship descriptions (cayley-hamilton, cauchy-schwarz)
- Add `mathlib_version: "4.15.0"`

## Test plan
- [x] `pnpm annotations:build` passes with no cramers-rule warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)