### PR TITLE
enrich: deepen annotations and meta for erdos-680

### DIFF
--- a/src/data/proofs/erdos-680/annotations.json
+++ b/src/data/proofs/erdos-680/annotations.json
@@ -1,56 +1,98 @@
 [
   {
-    "id": "erdos-680-main",
+    "id": "ann-680-imports",
     "proofId": "erdos-680",
-    "type": "conjecture",
-    "range": { "startLine": 29, "endLine": 33 },
-    "title": "Erdős Problem 680",
-    "content": "For sufficiently large n, there exists k ≥ 1 with minFac(n+k) > k² + 1.",
-    "significance": "essential"
+    "type": "concept",
+    "range": { "startLine": 20, "endLine": 26 },
+    "title": "Imports and Dependencies",
+    "content": "Imports Mathlib modules for prime number basics (`Nat.Prime.Basic`), filters for asymptotic statements (`Order.Filter.Basic`, `Topology.Algebra.Order.LiminfLimsup`), real numbers (`Data.Real.Basic`, `Data.Real.Sqrt`), and the general tactic library. The filter imports support expressing Cramér's and Granville's conjectures as asymptotic statements.",
+    "mathContext": "The formalization uses `Nat.minFac` as the least prime factor function $p(m)$, `Real.exp` and `Real.sqrt` for the exponential variant $e^{(1+\\varepsilon)\\sqrt{k}}$, and `Real.log` for the prime gap bound $O((\\log p)^2)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.minFac", "Real.exp", "Filter.atTop", "asymptotic analysis"],
+    "prerequisites": ["Lean 4 imports", "Mathlib library"]
   },
   {
-    "id": "erdos-680-variant",
-    "proofId": "erdos-680",
-    "type": "conjecture",
-    "range": { "startLine": 41, "endLine": 49 },
-    "title": "Exponential Variant",
-    "content": "The bound cannot be improved to e^{(1+ε)√k} + C_ε: for each ε > 0, there exists C such that the exponential version eventually fails.",
-    "significance": "essential"
-  },
-  {
-    "id": "erdos-680-cramer",
+    "id": "ann-680-main-conjecture",
     "proofId": "erdos-680",
     "type": "definition",
-    "range": { "startLine": 58, "endLine": 61 },
-    "title": "Cramér's Conjecture",
-    "content": "Prime gaps after p are O((log p)²). This would imply existence of offsets k with large least prime factors.",
-    "significance": "supporting"
+    "range": { "startLine": 29, "endLine": 37 },
+    "title": "Main Conjecture and HasLargeLPF",
+    "content": "**ErdosProblem680**: For all sufficiently large $n$, there exists $k \\ge 1$ with $p(n+k) > k^2 + 1$, where $p(m) = \\text{minFac}(m)$ is the least prime factor.\n\n**HasLargeLPF n**: The predicate for individual $n$ — there exists $k \\ge 1$ with $p(n+k) > k^2 + 1$. The main conjecture is equivalent to: HasLargeLPF holds for all sufficiently large $n$.",
+    "mathContext": "The conjecture states $\\exists N_0,\\, \\forall n \\ge N_0,\\, \\exists k \\ge 1 : p(n+k) > k^2 + 1$. The threshold $k^2 + 1$ is chosen so that finding such $k$ requires either a prime near $n$ or a number with unusually large smallest prime factor.",
+    "significance": "critical",
+    "relatedConcepts": ["least prime factor", "Nat.minFac", "eventually property", "prime gap conjectures"],
+    "prerequisites": ["prime factorization", "natural number arithmetic"]
   },
   {
-    "id": "erdos-680-k1",
-    "proofId": "erdos-680",
-    "type": "result",
-    "range": { "startLine": 81, "endLine": 87 },
-    "title": "k=1 Case: Odd Integers",
-    "content": "For k=1, minFac(n+1) > 2 means n+1 is odd. Proved using Nat.minFac_le_of_dvd.",
-    "significance": "supporting"
-  },
-  {
-    "id": "erdos-680-prime",
-    "proofId": "erdos-680",
-    "type": "result",
-    "range": { "startLine": 89, "endLine": 95 },
-    "title": "Prime Offsets Give Large LPF",
-    "content": "When n+k is prime, minFac(n+k) = n+k, which exceeds k² + 1 for large n. Proved via Prime.minFac_eq.",
-    "significance": "supporting"
-  },
-  {
-    "id": "erdos-680-granville",
+    "id": "ann-680-variant",
     "proofId": "erdos-680",
     "type": "definition",
-    "range": { "startLine": 99, "endLine": 111 },
-    "title": "Granville's Refinement",
-    "content": "Granville's constant 2e^{-γ} ≈ 1.1229 refines Cramér's conjecture. The maximal prime gap is asymptotically at most 2e^{-γ}(log p)².",
-    "significance": "supporting"
+    "range": { "startLine": 41, "endLine": 54 },
+    "title": "Exponential Variant and Combined Statement",
+    "content": "**ErdosProblem680Variant**: For every $\\varepsilon > 0$, there exists $C > 0$ such that the exponential version (with threshold $e^{(1+\\varepsilon)\\sqrt{k}} + C$) eventually fails. This says the quadratic bound $k^2 + 1$ cannot be improved to an exponential bound.\n\n**ErdosProblem680Combined**: The conjunction of the main conjecture (quadratic bound works) and the variant (exponential bound doesn't). Together they pin down the critical growth rate.",
+    "mathContext": "The exponential variant says: $\\forall \\varepsilon > 0,\\, \\exists C > 0$ such that $\\neg(\\exists N_0,\\, \\forall n \\ge N_0,\\, \\exists k \\ge 1 : p(n+k) > \\lfloor e^{(1+\\varepsilon)\\sqrt{k}} + C \\rfloor)$. The gap between $k^2$ and $e^{\\sqrt{k}}$ is the 'interesting zone' where the problem lives.",
+    "significance": "critical",
+    "relatedConcepts": ["exponential vs polynomial growth", "critical threshold", "floor function"],
+    "prerequisites": ["ErdosProblem680", "Real.exp", "Real.sqrt"]
+  },
+  {
+    "id": "ann-680-cramer",
+    "proofId": "erdos-680",
+    "type": "definition",
+    "range": { "startLine": 58, "endLine": 70 },
+    "title": "Cramér's Conjecture and Its Implication",
+    "content": "**CramerConjecture**: Prime gaps after prime $p$ are $O((\\log p)^2)$. Formalized using `Nat.find (Nat.exists_infinite_primes (p + 1))` to find the next prime after $p$.\n\n**cramer_implies_large_lpf** (axiom): If Cramér's conjecture holds, then for any $\\varepsilon > 0$ and sufficiently large $n$, there exists $k$ with $p(n+k) > \\lfloor e^{(1-\\varepsilon)\\sqrt{k}} \\rfloor$. This is strictly stronger than the $k^2 + 1$ threshold.",
+    "mathContext": "Cramér's conjecture (1936): $p_{n+1} - p_n = O((\\log p_n)^2)$. If true, for $n$ large, there exists a prime in $[n+1, n + O((\\log n)^2)]$. Setting $k = O((\\log n)^2)$ and using $p(n+k) = n+k$ when $n+k$ is prime gives the reduction: $n + k \\gg e^{(1-\\varepsilon)\\sqrt{k}}$ for $k = O((\\log n)^2)$.",
+    "significance": "key",
+    "relatedConcepts": ["Cramér's conjecture", "prime gaps", "next prime function", "Nat.exists_infinite_primes"],
+    "prerequisites": ["prime number theorem", "prime gap theory", "logarithmic functions"]
+  },
+  {
+    "id": "ann-680-basic-properties",
+    "proofId": "erdos-680",
+    "type": "theorem",
+    "range": { "startLine": 76, "endLine": 94 },
+    "title": "Basic Properties: Quadratic vs Exponential and k=1 Case",
+    "content": "**quadratic_weaker_than_exponential** (axiom): For any $\\varepsilon > 0$, eventually $k^2 + 1 < e^{(1+\\varepsilon)\\sqrt{k}}$. This justifies that the main conjecture is strictly weaker than the exponential version.\n\n**lpf_k1_means_odd** (proved): When $k = 1$, the condition $p(n+1) > 1^2 + 1 = 2$ means $n + 1$ is not divisible by 2, i.e., $n + 1$ is odd. Uses `Nat.minFac_le_of_dvd`.\n\n**prime_offset_gives_large_lpf** (proved): If $n + k$ is prime and $k^2 + 1 < n + k$, then $p(n+k) = n + k > k^2 + 1$. The key reduction: finding a prime near $n$ suffices.",
+    "mathContext": "The $k = 1$ case is the simplest: $p(n+1) > 2$ iff $n+1$ is odd (not divisible by 2). For $k = 1$ and $n$ even, this always holds since $n + 1$ is odd. The prime offset lemma reduces the problem to prime gaps: if the nearest prime $p$ to $n$ satisfies $p - n \\le \\sqrt{p - 1}$, then $k = p - n$ works.",
+    "significance": "key",
+    "relatedConcepts": ["parity argument", "Nat.minFac_le_of_dvd", "Prime.minFac_eq", "prime gap reduction"],
+    "prerequisites": ["Nat.minFac", "prime number basics", "omega tactic"]
+  },
+  {
+    "id": "ann-680-granville",
+    "proofId": "erdos-680",
+    "type": "definition",
+    "range": { "startLine": 98, "endLine": 124 },
+    "title": "Granville's Refinement and Prime Distribution Reduction",
+    "content": "**granvilleConstant**: Approximation of $2e^{-\\gamma} \\approx 1.1229$ where $\\gamma$ is the Euler-Mascheroni constant.\n\n**GranvilleRefinement**: The maximal prime gap after $p$ is at most $(2e^{-\\gamma} + \\varepsilon)(\\log p)^2$ for large $p$. Refines Cramér's predicted constant from 1 to $2e^{-\\gamma}$.\n\n**problem680_from_prime_distribution** (proved): Reduces Erdős #680 to prime distribution: if for large $n$ there exists $k$ with $n + k$ prime and $k^2 + 1 < n + k$, then ErdosProblem680 holds. Uses `prime_offset_gives_large_lpf` as the key step.",
+    "mathContext": "Granville (1995) argued that Cramér's random model underestimates gaps near numbers divisible by many small primes. The corrected prediction is $\\max_{p_n \\le x}(p_{n+1} - p_n) \\sim 2e^{-\\gamma}(\\log x)^2$ where $\\gamma \\approx 0.5772$, giving $2e^{-\\gamma} \\approx 1.1229$. The reduction theorem `problem680_from_prime_distribution` shows Erdős #680 follows from any prime gap bound of the form $O(n^{1/2 - \\varepsilon})$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler-Mascheroni constant", "Granville's conjecture", "prime gap models", "Cramér random model"],
+    "prerequisites": ["CramerConjecture", "prime_offset_gives_large_lpf", "Real.exp"]
+  },
+  {
+    "id": "ann-680-structural-lemmas",
+    "proofId": "erdos-680",
+    "type": "theorem",
+    "range": { "startLine": 126, "endLine": 170 },
+    "title": "Structural Lemmas",
+    "content": "Five structural results building the proof toolkit:\n\n**hasLargeLPF_of_succ_prime** (proved): If $n + 1$ is prime and $n \\ge 2$, then HasLargeLPF $n$ holds with $k = 1$, since $p(n+1) = n + 1 > 2$.\n\n**hasLargeLPF_from_nearby_prime** (proved): For any prime $p > n$ with $k = p - n$ satisfying $k^2 + 1 < p$, HasLargeLPF $n$ holds.\n\n**minFac_prime_self** (proved): $p.\\text{minFac} = p$ for prime $p$. One-line proof via `hp.minFac_eq`.\n\n**minFac_gt_of_no_small_divisor** (proved): If $m \\ge 2$ and no prime $\\le b$ divides $m$, then $p(m) > b$. Proof by contradiction using `Nat.minFac_dvd`.\n\n**hasLargeLPF_monotone_offset** (proved): If $p(n+k) > k^2 + 1$ and $n' + k' = n + k$ with $k' \\le k$, then $p(n'+k') > k'^2 + 1$. Smaller offsets give a weaker threshold.",
+    "mathContext": "The monotonicity lemma is key: if we find a 'good' offset $k$ for $n$, any representation $n' + k' = n + k$ with smaller $k'$ also works because $k'^2 + 1 \\le k^2 + 1 < p(n+k) = p(n'+k')$. This means the property transfers to nearby integers.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.minFac_dvd", "Prime.minFac_eq", "proof by contradiction", "nlinarith tactic"],
+    "prerequisites": ["HasLargeLPF", "Nat.minFac properties", "natural number arithmetic"]
+  },
+  {
+    "id": "ann-680-computational",
+    "proofId": "erdos-680",
+    "type": "theorem",
+    "range": { "startLine": 171, "endLine": 195 },
+    "title": "Computational Verification",
+    "content": "**Verified instances**: HasLargeLPF is confirmed for $n = 2, 4, 6, 8, 10, 12, 14, 20, 24, 100$ using `native_decide`.\n\nAll examples use $k = 1$, showing $p(n+1) > 2$ for each case:\n- $n = 2$: $p(3) = 3 > 2$ (prime)\n- $n = 8$: $p(9) = 3 > 2$ ($9 = 3^2$)\n- $n = 14$: $p(15) = 3 > 2$ ($15 = 3 \\cdot 5$)\n- $n = 100$: $p(101) = 101 > 2$ (prime)\n\nThe `native_decide` tactic compiles the decidable proposition to native code for efficient verification.",
+    "mathContext": "For even $n$, $n + 1$ is always odd, so $p(n+1) \\ge 3 > 2 = 1^2 + 1$, meaning $k = 1$ always works. The conjecture becomes interesting for large $n$ where one needs $k > 1$ and $p(n+k) > k^2 + 1$ for that larger $k$. The small-case verification is thus 'easy' — the real challenge is the asymptotic regime.",
+    "significance": "supporting",
+    "relatedConcepts": ["native_decide tactic", "decidable propositions", "computational verification", "small case analysis"],
+    "prerequisites": ["HasLargeLPF", "Nat.minFac computation", "native_decide"]
   }
 ]

--- a/src/data/proofs/erdos-680/meta.json
+++ b/src/data/proofs/erdos-680/meta.json
@@ -21,25 +21,55 @@
     "erdosUrl": "https://erdosproblems.com/680",
     "erdosProblemStatus": "open",
     "dateAdded": "2025-01-01",
-    "mathlib_version": "4.x"
-  },
-  "overview": {
-    "historicalContext": "Erdős posed this problem in 1979 [Er79d], asking about the least prime factors of integers near a given n. The least prime factor p(m) = minFac(m) is the smallest prime dividing m; for primes, p(m) = m itself. The question is whether, for large n, there must exist some nearby offset k ≥ 1 where p(n+k) exceeds the quadratic threshold k² + 1.\n\nThe problem connects intimately to prime gap conjectures. If n+k happens to be prime, then p(n+k) = n+k, which trivially exceeds k²+1 for large n. So the question reduces to: is there always a prime within distance O(√n) of n? Cramér's conjecture (1936) predicts that the largest prime gap below x is O((log x)²), which would imply a much stronger result. Granville (1995) refined the predicted constant from 1 to 2e^{-γ} ≈ 1.1229.\n\nThe formalization is notably rich with 195 lines, including 10 proved theorems from Mathlib, computational examples verifying HasLargeLPF for specific values, and a chain of reductions connecting the problem to prime distribution. The problem is related to Erdős Problems #681 and #682, which ask similar questions with different thresholds.",
-    "problemStatement": "For all sufficiently large n, does there exist k ≥ 1 such that the least prime factor of n+k exceeds k² + 1? The variant asks whether replacing k² + 1 by e^{(1+ε)√k} + C_ε makes this false.",
-    "proofStrategy": "We formalize both the main conjecture and exponential variant using Nat.minFac. Connections to Cramér's conjecture and Granville's refinement are stated. We prove lpf_k1_means_odd, prime_offset_gives_large_lpf, hasLargeLPF_of_succ_prime, hasLargeLPF_from_nearby_prime, minFac_gt_of_no_small_divisor, hasLargeLPF_monotone_offset, and problem680_from_prime_distribution. Computational examples verify HasLargeLPF for n = 2,4,6,...,100.",
-    "keyInsights": [
-      "**Prime offset reduction**: When n+k is prime, minFac(n+k) = n+k ≫ k²+1 for large n. So the problem reduces to finding a prime near n, connecting it to prime gap conjectures.",
-      "**Quadratic vs exponential**: The exponential bound e^{(1+ε)√k} grows much faster than k², so the exponential variant is strictly stronger. The quadratic bound k²+1 is the 'right' threshold where the problem becomes interesting.",
-      "**Cramér's implication**: Cramér's conjecture (gaps ≤ O((log p)²)) would imply that for large n, a prime exists within distance O((log n)²), easily satisfying the k²+1 threshold. This is formalized as cramer_implies_large_lpf.",
-      "**Granville's refinement**: Granville refined Cramér's expected constant from 1 to 2e^{-γ}, predicting slightly larger gaps. The constant is approximated in the formalization.",
-      "**Computational verification**: HasLargeLPF is verified via native_decide for n = 2,4,6,8,...,100, confirming the conjecture computationally for small values."
-    ],
+    "mathlib_version": "4.15.0",
     "mathlibDependencies": [
-      "Mathlib.Data.Nat.Prime.Basic",
-      "Mathlib.Order.Filter.Basic",
-      "Mathlib.Topology.Algebra.Order.LiminfLimsup",
-      "Mathlib.Data.Real.Basic",
-      "Mathlib.Data.Real.Sqrt"
+      {
+        "theorem": "Nat.minFac",
+        "description": "Least prime factor function",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.minFac_le_of_dvd",
+        "description": "minFac is at most any divisor ≥ 2",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.exists_infinite_primes",
+        "description": "Infinitude of primes (used to find next prime)",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Real.exp",
+        "description": "Exponential function for exponential variant",
+        "module": "Mathlib.Data.Real.Basic"
+      },
+      {
+        "theorem": "Real.sqrt",
+        "description": "Square root for exponential bound",
+        "module": "Mathlib.Data.Real.Sqrt"
+      }
+    ],
+    "references": [
+      {
+        "key": "Er79d",
+        "citation": "Erdős, P. (1979). Some unconventional problems in number theory. Math. Mag. 52, 67-70.",
+        "type": "paper"
+      },
+      {
+        "key": "Cr36",
+        "citation": "Cramér, H. (1936). On the order of magnitude of the difference between consecutive prime numbers. Acta Arith. 2, 23-46.",
+        "type": "paper"
+      },
+      {
+        "key": "Gr95",
+        "citation": "Granville, A. (1995). Harald Cramér and the distribution of prime numbers. Scand. Actuar. J. 1, 12-28.",
+        "type": "paper"
+      },
+      {
+        "key": "Ma15",
+        "citation": "Maynard, J. (2015). Large gaps between primes. Ann. of Math. 183, 915-933.",
+        "type": "paper"
+      }
     ],
     "originalContributions": [
       "ErdosProblem680: main conjecture minFac(n+k) > k²+1",
@@ -54,67 +84,112 @@
       "minFac_gt_of_no_small_divisor: proved lower bounds on minFac",
       "hasLargeLPF_monotone_offset: proved monotonicity of offset bounds",
       "problem680_from_prime_distribution: proved reduction to prime distribution"
+    ],
+    "relatedProblems": [
+      {
+        "id": "erdos-4",
+        "relationship": "Erdős #4 asks about large prime gaps — directly relevant since #680 reduces to prime gap bounds. The Maynard-Tao theorem (2016) on large gaps provides partial context for understanding when $p(n+k)$ can be large."
+      },
+      {
+        "id": "prime-number-theorem",
+        "relationship": "The PNT $\\pi(x) \\sim x/\\ln x$ underlies both Cramér's conjecture and the expected density of primes near $n$. The prime gap reduction in #680 implicitly uses the PNT to estimate how far one must search for a prime."
+      },
+      {
+        "id": "bertrands-postulate",
+        "relationship": "Bertrand's postulate guarantees a prime in $(n, 2n]$, giving a weak version of the prime gap bound needed for #680: with $k \\le n$ and $n + k$ prime, we need $k^2 + 1 < n + k$, which holds for $k \\le \\sqrt{n}$."
+      },
+      {
+        "id": "infinitude-primes",
+        "relationship": "The infinitude of primes (Euclid) is used directly in the formalization: `Nat.exists_infinite_primes (p + 1)` finds the next prime after $p$, enabling the definition of CramerConjecture."
+      },
+      {
+        "id": "erdos-648",
+        "relationship": "Erdős #648 studies the greatest prime factor $P(n)$ while #680 studies the least prime factor $p(n)$. They are dual perspectives on the same arithmetic function: the prime factorization structure of integers near $n$."
+      },
+      {
+        "id": "erdos-1055",
+        "relationship": "Erdős #1055 classifies primes by smoothness of $p+1$, connecting to the least prime factor of $p + 1$. Both problems relate to the distribution of prime factors of integers in structured positions."
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős posed Problem #680 in 1979, asking about the least prime factors of integers near a given $n$. The least prime factor $p(m) = \\min\\{q \\text{ prime} : q \\mid m\\}$ is a fundamental arithmetic function: for primes, $p(m) = m$ itself, while for composites, $p(m) \\le \\sqrt{m}$ by the basic divisibility bound.\n\nThe problem connects deeply to prime gap conjectures. If $n + k$ is prime for some small $k$, then $p(n + k) = n + k \\gg k^2 + 1$ for large $n$, trivially satisfying the bound. So Erdős's question effectively asks: is there always a prime (or near-prime with large least factor) within distance $O(\\sqrt{n})$ of every large $n$?\n\nHarald Cramér (1936) conjectured that consecutive prime gaps satisfy $p_{n+1} - p_n = O((\\log p_n)^2)$, based on a probabilistic model of the primes. This would easily resolve #680, since $(\\log n)^2 \\ll \\sqrt{n}$. Andrew Granville (1995) refined Cramér's conjecture by analyzing the effect of small prime divisors on gap distributions, predicting the constant $2e^{-\\gamma} \\approx 1.1229$ (where $\\gamma \\approx 0.5772$ is the Euler-Mascheroni constant) rather than Cramér's implicit constant of 1.\n\nUnconditionally, the best result on prime gaps is Baker-Harman-Pintz (2001): the interval $[x, x + x^{0.525}]$ always contains a prime. This gives $k = O(n^{0.525})$, but the threshold $k^2 + 1 \\approx n^{1.05}$ exceeds $n + k \\approx n$, so this unconditional bound does not resolve #680. Progress would require either gap bounds of order $O(n^{1/2-\\varepsilon})$ or direct results on least prime factors of shifted integers.",
+    "problemStatement": "For all sufficiently large $n$, does there exist $k \\ge 1$ such that $p(n+k) > k^2 + 1$, where $p(m)$ is the least prime factor of $m$?\n\nThe stronger variant: for every $\\varepsilon > 0$, the bound $e^{(1+\\varepsilon)\\sqrt{k}} + C_\\varepsilon$ eventually fails as a replacement for $k^2 + 1$.\n\n**Status**: OPEN",
+    "proofStrategy": "The formalization proceeds in seven sections:\n\n1. **Main conjecture**: Define `ErdosProblem680` and `HasLargeLPF` using `Nat.minFac`\n2. **Exponential variant**: Define `ErdosProblem680Variant` and the combined statement\n3. **Prime gap connections**: Formalize `CramerConjecture` and axiomatize `cramer_implies_large_lpf`\n4. **Basic properties**: Prove the $k = 1$ case (`lpf_k1_means_odd`) and the prime offset reduction (`prime_offset_gives_large_lpf`)\n5. **Granville's refinement**: Define `granvilleConstant`, `GranvilleRefinement`, and prove `problem680_from_prime_distribution`\n6. **Structural lemmas**: Prove `hasLargeLPF_of_succ_prime`, `hasLargeLPF_from_nearby_prime`, `minFac_gt_of_no_small_divisor`, and `hasLargeLPF_monotone_offset`\n7. **Computational verification**: Verify `HasLargeLPF` for $n = 2, 4, 6, \\ldots, 100$ using `native_decide`\n\nNotably, the formalization has **0 sorries** and **10 proved theorems**, with only 2 axioms for results beyond current proof techniques.",
+    "keyInsights": [
+      "**Prime gap reduction**: The key insight is that when $n + k$ is prime, $p(n+k) = n + k \\gg k^2 + 1$ for large $n$. So Problem #680 reduces to finding a prime within $O(\\sqrt{n})$ of $n$, connecting it directly to Cramér's conjecture on prime gaps.",
+      "**Quadratic threshold is critical**: The threshold $k^2 + 1$ sits precisely at the boundary where the problem is interesting. Below $k^2$, the conjecture would be trivial from Bertrand's postulate. Above $e^{\\sqrt{k}}$, it would be false. The quadratic threshold captures the exact tension between prime density and offset distance.",
+      "**Granville's constant $2e^{-\\gamma}$**: Cramér's original model treats primes as independent random events with density $1/\\log n$. Granville showed this underestimates gaps near multiples of small primes, leading to the corrected constant $2e^{-\\gamma} \\approx 1.1229$. This nuance is formalized in the `GranvilleRefinement` definition.",
+      "**Monotonicity of the LPF bound**: The proved lemma `hasLargeLPF_monotone_offset` shows that if $p(n+k) > k^2 + 1$, then the same value $n + k$ also satisfies $p(n'+k') > k'^2 + 1$ for any $(n', k')$ with $n' + k' = n + k$ and $k' \\le k$. This transfers the property to neighboring integers.",
+      "**Computational evidence is 'easy'**: All verified cases ($n \\le 100$) use $k = 1$, exploiting that $n + 1$ is odd for even $n$. The conjecture becomes truly challenging only in the asymptotic regime where $k > 1$ witnesses are needed."
     ]
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 20,
+      "endLine": 26,
+      "summary": "Imports Mathlib modules for `Nat.Prime`, filters, real numbers, square roots, and tactics."
+    },
+    {
       "id": "main-conjecture",
-      "title": "Least Prime Factor and the Main Conjecture",
+      "title": "Main Conjecture: $p(n+k) > k^2 + 1$",
       "startLine": 27,
       "endLine": 37,
-      "summary": "Defines ErdosProblem680 (for large n, some k gives minFac(n+k) > k²+1) and HasLargeLPF predicate."
+      "summary": "Defines `ErdosProblem680` ($\\exists N_0, \\forall n \\ge N_0, \\exists k \\ge 1 : p(n+k) > k^2 + 1$) and `HasLargeLPF` (the predicate for individual $n$)."
     },
     {
       "id": "exponential-variant",
       "title": "Exponential Variant",
       "startLine": 39,
       "endLine": 54,
-      "summary": "States ErdosProblem680Variant (exponential bound eventually fails) and ErdosProblem680Combined."
+      "summary": "States `ErdosProblem680Variant` ($\\forall \\varepsilon > 0$, the exponential bound $e^{(1+\\varepsilon)\\sqrt{k}} + C$ eventually fails) and `ErdosProblem680Combined` (both statements together)."
     },
     {
       "id": "cramer",
-      "title": "Connections to Prime Gap Conjectures",
+      "title": "Cramér's Conjecture Connection",
       "startLine": 56,
       "endLine": 70,
-      "summary": "Formalizes CramerConjecture and axiomatizes cramer_implies_large_lpf."
+      "summary": "Formalizes `CramerConjecture` ($p_{n+1} - p_n \\le C(\\log p_n)^2$) using `Nat.find` for the next prime. Axiomatizes `cramer_implies_large_lpf`: Cramér's conjecture implies a stronger version of #680."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
       "startLine": 72,
       "endLine": 95,
-      "summary": "Proves lpf_k1_means_odd, prime_offset_gives_large_lpf, and axiomatizes quadratic_weaker_than_exponential."
+      "summary": "Axiomatizes $k^2 + 1 < e^{(1+\\varepsilon)\\sqrt{k}}$ for large $k$. Proves the $k = 1$ case (`lpf_k1_means_odd`: $p(n+1) > 2$ iff $n+1$ is odd) and the prime offset reduction (`prime_offset_gives_large_lpf`)."
     },
     {
       "id": "granville",
-      "title": "Granville's Refinement",
+      "title": "Granville's Refinement and Prime Distribution Reduction",
       "startLine": 96,
       "endLine": 124,
-      "summary": "Defines granvilleConstant (≈2e^{-γ}), GranvilleRefinement conjecture, and proves problem680_from_prime_distribution."
+      "summary": "Defines `granvilleConstant` ($2e^{-\\gamma} \\approx 1.1229$) and `GranvilleRefinement`. Proves `problem680_from_prime_distribution`: if primes exist near $n$ with $k^2 + 1 < n + k$, then #680 holds."
     },
     {
       "id": "structural",
       "title": "Structural Lemmas",
       "startLine": 126,
       "endLine": 170,
-      "summary": "Proves hasLargeLPF_of_succ_prime, hasLargeLPF_from_nearby_prime, minFac_prime_self, minFac_gt_of_no_small_divisor, hasLargeLPF_monotone_offset."
+      "summary": "Five proved lemmas: successor-prime case, nearby-prime case, `minFac_prime_self`, `minFac_gt_of_no_small_divisor` (excluding small divisors), and `hasLargeLPF_monotone_offset` (monotonicity in offset)."
     },
     {
       "id": "computational",
       "title": "Computational Verification",
       "startLine": 171,
       "endLine": 195,
-      "summary": "Verifies HasLargeLPF for n = 2,4,6,...,100 using native_decide, confirming the conjecture computationally."
+      "summary": "Verifies `HasLargeLPF` for $n = 2, 4, 6, 8, 10, 12, 14, 20, 24, 100$ using `native_decide`. All cases use $k = 1$ witness."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 680 formalizes both the quadratic (k²+1) and exponential (e^{(1+ε)√k}) variants, with connections to Cramér and Granville. Notable for 10 proved theorems and computational verification for small cases. 0 sorries.",
-    "implications": "Resolution would clarify the relationship between prime gaps and least prime factors, with implications for smooth number distribution and the Cramér model of primes.",
+    "summary": "Erdős Problem #680 asks whether every large integer $n$ has some nearby offset $k$ where the least prime factor $p(n+k)$ exceeds $k^2 + 1$. The formalization includes 10 proved theorems, 0 sorries, and establishes the reduction to prime gap conjectures. The key insight is that finding a prime near $n$ suffices, connecting the problem to Cramér's and Granville's conjectures. Both the quadratic conjecture and the exponential variant are formalized, pinning down the critical growth rate.",
+    "implications": "**Theoretical Significance**\n\n1. **Prime gap interface**: Resolution would establish a new connection between the distribution of least prime factors and the distribution of primes, two apparently separate topics in analytic number theory.\n\n2. **Smooth number structure**: Understanding when $p(n+k)$ is large requires understanding when $n + k$ avoids small prime factors — precisely the complement of smooth numbers. A positive resolution would constrain how dense smooth numbers can be near arbitrary integers.\n\n3. **Conditional results**: The formalized reduction `cramer_implies_large_lpf` shows that progress on prime gaps automatically implies progress on #680. The Cramér conjecture is one of the most important open problems in prime number theory.\n\n4. **Threshold phenomena**: The quadratic-vs-exponential dichotomy reveals a phase transition in the structure of least prime factors near integers, with the threshold somewhere between $k^2$ and $e^{\\sqrt{k}}$.",
     "openQuestions": [
-      "Is the quadratic bound k²+1 tight, or can it be improved to k^α for some α > 2?",
-      "What is the correct exponent in the exponential variant: (1+ε)√k or something else?",
-      "Can unconditional progress be made without assuming Cramér's conjecture?",
-      "What is the relationship between this problem and the distribution of smooth numbers near n?"
+      "Can unconditional progress be made using Baker-Harman-Pintz gap bounds ($p_{n+1} - p_n \\ll p_n^{0.525}$), perhaps with a weaker threshold than $k^2 + 1$?",
+      "Is the quadratic bound $k^2 + 1$ tight, or can it be strengthened to $k^\\alpha + 1$ for some $\\alpha > 2$?",
+      "What is the correct exponent in the exponential variant: is $(1 + \\varepsilon)\\sqrt{k}$ the critical growth rate, or could $e^{c\\sqrt{k}}$ work for some specific $c > 1$?",
+      "How does this problem relate to the Erdős-Straus conjecture (#681) and the related Problem #682, which ask similar questions with different thresholds?"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Enrichment pass for **Erdős Problem #680: Least Prime Factor Exceeding k² + 1**.

### Changes
- **Annotations (8 total)**: Rewrote all 6 existing annotations (fixed invalid types `conjecture`/`result`), added 2 new annotations covering structural lemmas and computational verification. All now have `mathContext`, `relatedConcepts`, `prerequisites`.
- **Historical context**: Expanded to ~1500 chars with Cramér (1936), Granville (1995), Baker-Harman-Pintz (2001), and analysis of why current unconditional bounds don't suffice.
- **Cross-references**: Added 6 links (erdos-4, prime-number-theorem, bertrands-postulate, infinitude-primes, erdos-648, erdos-1055).
- **References**: Added 4 academic references (Erdős 1979, Cramér 1936, Granville 1995, Maynard 2015).
- **Mathlib dependencies**: Updated from generic list to specific theorems used (`Nat.minFac`, `Nat.minFac_le_of_dvd`, `Nat.exists_infinite_primes`).
- **Sections**: 8 sections with LaTeX summaries and verified line ranges.
- **Conclusion**: Expanded with smooth number structure implications and 4 open questions.

## Test plan
- [x] `pnpm annotations:build` passes (only expected non-strict warning for axiom line)
- [x] JSON validates correctly
- [x] All annotation line ranges verified against Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)