### PR TITLE
enrich: deepen annotations and meta for erdos-683

### DIFF
--- a/src/data/proofs/erdos-683/annotations.json
+++ b/src/data/proofs/erdos-683/annotations.json
@@ -1,83 +1,110 @@
 [
   {
-    "id": "ann-683-overview",
+    "id": "ann-683-imports",
     "proofId": "erdos-683",
-    "range": { "startLine": 1, "endLine": 29 },
+    "range": { "startLine": 31, "endLine": 39 },
     "type": "concept",
-    "title": "Problem Overview",
-    "content": "**Erdős Problem #683: Largest Prime Divisor of C(n,k)**\n\nIs P(C(n,k)) ≥ min(n-k+1, k^{1+c}) for some c > 0?\n\n**Known:** P(C(n,k)) > k (Sylvester-Schur) and P(C(n,k)) ≫ k log k (Erdős 1955).\n**Believed:** P(C(n,k)) > k^{1+c} with finitely many exceptions for any c > 0.\n**Heuristic:** P(C(n,k)) > e^{c√k} from prime gap statistics.\n\n**STATUS: OPEN.** Related to Problem #961 (essentially equivalent).",
-    "significance": "critical"
+    "title": "Imports and Setup",
+    "content": "Imports Mathlib modules for natural number basics, binomial coefficients (`Nat.Choose.Basic`), primes (`Nat.Prime.Basic`), logarithms (`SpecialFunctions.Log.Basic`), and real exponentiation (`SpecialFunctions.Pow.Real`). Opens `Nat` and `Real` namespaces within the `Erdos683` namespace.",
+    "mathContext": "The formalization requires `Nat.choose` for $\\binom{n}{k}$, `Real.log` for the Erdős 1955 bound $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$, and `Real.rpow` for the conjectured bound $k^{1+c}$ and heuristic $e^{c\\sqrt{k}}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.choose", "Real.log", "Real.rpow", "Filter.atTop"],
+    "prerequisites": ["Lean 4 imports", "Mathlib library"]
   },
   {
     "id": "ann-683-largest-prime",
     "proofId": "erdos-683",
-    "range": { "startLine": 49, "endLine": 78 },
+    "range": { "startLine": 47, "endLine": 76 },
     "type": "definition",
-    "title": "Largest Prime Divisor P(n)",
-    "content": "**largestPrimeDivisor and P(C(n,k)):**\n\nP(n) = largest prime dividing n (1 if n ≤ 1). Three key properties axiomatized:\n- P_is_prime: P(n) is prime when n > 1\n- P_divides: P(n) divides n\n- P_largest: P(n) is maximal among prime divisors\n\nP(n,k) = P(C(n,k)) = largest prime divisor of the binomial coefficient.",
-    "significance": "critical"
+    "title": "Largest Prime Divisor $P(n)$",
+    "content": "**largestPrimeDivisor n**: Returns the largest prime factor of $n$ (or 1 if $n \\le 1$). Defined using `Nat.find` on the existence of a prime divisor, but key properties are axiomatized:\n\n1. **P_is_prime**: $P(n)$ is prime when $n > 1$\n2. **P_divides**: $P(n) \\mid n$ when $n > 1$\n3. **P_largest**: For any prime $p \\mid n$, $p \\le P(n)$\n\n**P n k** = $P(\\binom{n}{k})$: the largest prime divisor of the binomial coefficient.",
+    "mathContext": "$P(n) = \\max\\{p \\in \\mathbb{P} : p \\mid n\\}$ for $n > 1$, and $P(1) = 1$ by convention. The three axioms uniquely characterize $P(n)$ as the maximum of the prime support. For binomial coefficients, $P(\\binom{n}{k})$ captures the largest prime appearing in the factorization of $\\binom{n}{k} = \\frac{n!}{k!(n-k)!}$.",
+    "significance": "critical",
+    "relatedConcepts": ["greatest prime factor", "Nat.find", "prime support", "fundamental theorem of arithmetic"],
+    "prerequisites": ["prime numbers", "Nat.exists_prime_and_dvd", "Nat.choose"]
   },
   {
     "id": "ann-683-sylvester-schur",
     "proofId": "erdos-683",
-    "range": { "startLine": 93, "endLine": 113 },
+    "range": { "startLine": 89, "endLine": 109 },
     "type": "theorem",
-    "title": "Sylvester-Schur Theorem",
-    "content": "**sylvester_schur (axiom):** P(C(n,k)) > k for k ≤ n/2.\n\nThe product (n-k+1)···n of k consecutive integers > k must contain a prime > k. This foundational result from 1892/1929 is the starting point.\n\n**binom_has_large_prime (proved):** Derives the existential form ∃ p, p.Prime ∧ p ∣ C(n,k) ∧ p > k from the Sylvester-Schur axiom.",
-    "significance": "critical"
+    "title": "Sylvester-Schur Theorem: $P(\\binom{n}{k}) > k$",
+    "content": "**sylvester_schur** (axiom): $P(\\binom{n}{k}) > k$ for $1 \\le k \\le n/2$.\n\nThe product $(n-k+1)(n-k+2) \\cdots n$ of $k$ consecutive integers, each exceeding $k$, must contain a prime factor $> k$. Sylvester (1892) proved this for consecutive products; Schur (1929) extended it to binomial coefficients.\n\n**choose_gt_one** (axiom): $\\binom{n}{k} > 1$ for valid parameters.\n\n**binom_has_large_prime** (proved): Derives the existential form $\\exists p$ prime with $p \\mid \\binom{n}{k}$ and $p > k$, combining the three axiomatized properties of $P$.",
+    "mathContext": "Sylvester-Schur: among any $k$ consecutive integers $> k$, at least one has a prime factor $> k$. Equivalently, $\\binom{n}{k} = \\frac{n!}{k!(n-k)!}$ always has a prime factor exceeding $k$ when $k \\le n/2$. The proof uses the pigeonhole principle on the prime factorization of the consecutive product.",
+    "significance": "critical",
+    "relatedConcepts": ["Sylvester's theorem", "consecutive integers", "pigeonhole on prime factors", "Bertrand's postulate generalization"],
+    "prerequisites": ["P definition", "Nat.choose", "prime factorization"]
   },
   {
     "id": "ann-683-erdos-1955",
     "proofId": "erdos-683",
-    "range": { "startLine": 126, "endLine": 137 },
+    "range": { "startLine": 120, "endLine": 131 },
     "type": "theorem",
-    "title": "Erdős 1955: P ≫ k log k",
-    "content": "**erdos_1955_bound (axiom):** ∃ c > 0 such that P(C(n,k)) ≥ c·k·log k for k ≤ n/2.\n\nA significant improvement over Sylvester-Schur — the prime divisor exceeds not just k, but c·k·log k.\n\n**erdos_1955_asymptotic (proved):** Instantiates the bound for specific n, k from the existential axiom.",
-    "significance": "critical"
+    "title": "Erdős 1955: $P(\\binom{n}{k}) \\gg k \\log k$",
+    "content": "**erdos_1955_bound** (axiom): There exists $c > 0$ such that $P(\\binom{n}{k}) \\ge c \\cdot k \\cdot \\log k$ for all $k \\le n/2$.\n\nA significant quantitative improvement over Sylvester-Schur: the prime factor exceeds not just $k$ but $k \\log k$. Erdős's proof uses the prime number theorem and a careful counting argument on prime factors in consecutive products.\n\n**erdos_1955_asymptotic** (proved): Instantiates the bound for specific $n, k$ from the existential axiom using `obtain`.",
+    "mathContext": "Erdős (1955) proved $P(\\binom{n}{k}) \\ge c \\cdot k \\cdot \\log k$ by analyzing the prime factorization of $\\binom{n}{k}$. The key is that among $k$ consecutive integers, the prime number theorem ensures $\\sim k/\\log k$ of them are prime, and these primes contribute large factors. The logarithmic improvement $k \\to k \\log k$ was a breakthrough over the linear bound.",
+    "significance": "critical",
+    "relatedConcepts": ["prime number theorem", "asymptotic notation", "quantitative improvement over Sylvester-Schur"],
+    "prerequisites": ["sylvester_schur", "Real.log", "prime counting function"]
   },
   {
     "id": "ann-683-conjecture",
     "proofId": "erdos-683",
-    "range": { "startLine": 148, "endLine": 161 },
-    "type": "concept",
+    "range": { "startLine": 140, "endLine": 153 },
+    "type": "definition",
     "title": "The Main Conjecture (OPEN)",
-    "content": "**erdosConjecture683:** ∃ c > 0, ∀ n k, P(C(n,k)) ≥ min(n-k+1, k^{1+c}).\n\nThe minimum captures two regimes:\n- k small relative to n: the product has k terms, expect a prime > k^{1+c}\n- k close to n/2: use n-k+1 as a natural bound\n\n**erdos_1979_belief:** For ANY c > 0, the bound k^{1+c} holds with finitely many exceptions. This is even stronger than the main conjecture.",
-    "significance": "critical"
+    "content": "**erdosConjecture683**: $\\exists c > 0$ such that $P(\\binom{n}{k}) \\ge \\min(n - k + 1, k^{1+c})$ for all $1 \\le k \\le n$.\n\nThe $\\min$ captures two regimes:\n- When $k$ is small relative to $n$: expect $P(\\binom{n}{k}) > k^{1+c}$ (power-law growth)\n- When $k \\approx n$: bound by $n - k + 1$ since the product has only $k$ terms starting at $n - k + 1$\n\n**erdos_1979_belief** (axiom): For ANY $c > 0$, $P(\\binom{n}{k}) > k^{1+c}$ with only finitely many exceptions. This is strictly stronger than the conjecture (which only claims some $c > 0$ works).",
+    "mathContext": "The conjecture predicts $P(\\binom{n}{k}) \\ge \\min(n-k+1, k^{1+c})$. Current best: $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$ (Erdős 1955). The gap from $k \\log k$ to $k^{1+c}$ is enormous for large $k$. Erdős's belief that $P > k^{1+c}$ for ALL $c > 0$ (with finite exceptions) would place this problem in the same regime as Cramér's conjecture — the polynomial growth rate $k^{1+c}$ for any $c$ is equivalent to saying $\\log P(\\binom{n}{k})/\\log k \\to \\infty$.",
+    "significance": "critical",
+    "relatedConcepts": ["polynomial vs logarithmic bounds", "finite exceptions", "Cramér's conjecture analogy"],
+    "prerequisites": ["sylvester_schur", "erdos_1955_bound", "Real.rpow"]
   },
   {
     "id": "ann-683-heuristic",
     "proofId": "erdos-683",
-    "range": { "startLine": 175, "endLine": 188 },
-    "type": "axiom",
-    "title": "Prime Gap Heuristic",
-    "content": "**prime_gap_heuristic:** P(C(n,k)) > e^{c√k} for some c > 0, eventually.\n\nThis stretched exponential bound is far stronger than polynomial k^{1+c}.\n\n**heuristic_stronger_than_conjecture:** Proves e^{c√k} > k^{1+c} eventually — the heuristic dominates the conjecture for large k.",
-    "significance": "key"
+    "range": { "startLine": 165, "endLine": 178 },
+    "type": "theorem",
+    "title": "Prime Gap Heuristic: $P > e^{c\\sqrt{k}}$",
+    "content": "**prime_gap_heuristic** (axiom): $P(\\binom{n}{k}) > e^{c\\sqrt{k}}$ for some $c > 0$, eventually.\n\nThis stretched exponential bound far exceeds the polynomial conjecture $k^{1+c}$. It arises from Cramér-type heuristics: in a random model of the primes, among $k$ 'random' integers near $n$, the largest prime gap is $\\sim (\\log n)^2$, so the largest prime factor should be $\\sim n/(\\log n)^2 \\gg e^{c\\sqrt{k}}$.\n\n**heuristic_stronger_than_conjecture** (axiom): $e^{c\\sqrt{k}} > k^{1+c}$ eventually, since exponential growth dominates polynomial growth.",
+    "mathContext": "The heuristic $P(\\binom{n}{k}) > e^{c\\sqrt{k}}$ comes from Cramér's model: the product $(n-k+1) \\cdots n$ contains $\\sim k/\\log n$ primes, and the largest prime gap in the interval is $\\sim (\\log n)^2$. The largest prime in the product is thus $\\sim n - O((\\log n)^2) \\approx n$. Since $k \\le n/2$, this gives $P \\approx n \\ge 2k$, far exceeding any polynomial in $k$.",
+    "significance": "key",
+    "relatedConcepts": ["Cramér's random model", "stretched exponential", "prime gaps in intervals", "Filter.atTop"],
+    "prerequisites": ["erdosConjecture683", "Real.exp", "Real.sqrt"]
   },
   {
     "id": "ann-683-consecutive",
     "proofId": "erdos-683",
-    "range": { "startLine": 210, "endLine": 227 },
+    "range": { "startLine": 196, "endLine": 213 },
     "type": "definition",
-    "title": "Consecutive Products and Bertrand",
-    "content": "**consecutiveProduct m k:** The product (m)(m+1)···(m+k-1) of k consecutive integers.\n\nC(n,k) = (n-k+1)···n / k! — the numerator is such a product.\n\n**bertrand_for_central:** P(C(2n,n)) > n, from Bertrand's postulate (there's always a prime between n and 2n).\n\n**consecutive_has_large_prime:** Among k consecutive integers starting at m > k, at least one has a prime divisor > k.",
-    "significance": "key"
+    "title": "Consecutive Products and Bertrand's Connection",
+    "content": "**consecutiveProduct m k**: The product $m(m+1) \\cdots (m+k-1)$ defined via `Finset.range` and `∏`.\n\nSince $\\binom{n}{k} = \\frac{(n-k+1)(n-k+2) \\cdots n}{k!}$, the numerator is `consecutiveProduct (n-k+1) k`.\n\n**bertrand_for_central** (axiom): $P(\\binom{2n}{n}) > n$ for $n \\ge 1$. Follows from Bertrand's postulate: there exists a prime $p$ with $n < p \\le 2n$, and this $p$ divides $\\binom{2n}{n}$ but not $n!^2$.\n\n**consecutive_has_large_prime** (axiom): Among $k$ consecutive integers starting at $m > k$, at least one has a prime divisor $> k$. This is Sylvester's original result for products.",
+    "mathContext": "The connection $\\binom{n}{k} = \\frac{\\prod_{i=0}^{k-1}(n-k+1+i)}{k!}$ means that large prime factors of the numerator survive division by $k!$ (since $k! = \\prod_{i=1}^{k} i$ contains only primes $\\le k$). Any prime $p > k$ dividing the numerator also divides $\\binom{n}{k}$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.prod", "Bertrand's postulate", "Chebyshev's theorem", "prime factorization of factorials"],
+    "prerequisites": ["Nat.choose", "consecutiveProduct", "Bertrand's postulate"]
   },
   {
-    "id": "ann-683-specific",
+    "id": "ann-683-specific-cases",
     "proofId": "erdos-683",
-    "range": { "startLine": 238, "endLine": 249 },
-    "type": "axiom",
-    "title": "Specific Cases",
-    "content": "**central_binom_bound:** P(C(2k,k)) > (4/3)k for large k. The central binomial coefficient has particularly large prime divisors.\n\n**small_k_case_2:** P(C(n,2)) ≥ (n-1)/2 for n ≥ 4. Since C(n,2) = n(n-1)/2, one of n or n-1 has a large prime factor.",
-    "significance": "supporting"
+    "range": { "startLine": 222, "endLine": 233 },
+    "type": "theorem",
+    "title": "Central Binomial and Small $k$ Cases",
+    "content": "**central_binom_bound** (axiom): $P(\\binom{2k}{k}) > \\frac{4}{3}k$ for large $k$. The central binomial coefficient has particularly large prime divisors because it encodes the middle row of Pascal's triangle, with maximal combinatorial complexity.\n\n**small_k_case_2** (axiom): $P(\\binom{n}{2}) \\ge (n-1)/2$ for $n \\ge 4$. Since $\\binom{n}{2} = n(n-1)/2$, and at least one of $n, n-1$ has a prime factor $\\ge (n-1)/2$ (by Bertrand's postulate applied to $(n-1)/2$).",
+    "mathContext": "For the central coefficient: $\\binom{2k}{k} \\sim \\frac{4^k}{\\sqrt{\\pi k}}$ by Stirling. The Korselt criterion and Erdős's analysis show that primes in $(k, 2k]$ divide $\\binom{2k}{k}$, and Bertrand guarantees at least one such prime. The $4/3$ constant improves on this by analyzing the distribution of primes in $(k, 4k/3]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["central binomial coefficient", "Stirling's approximation", "Korselt criterion", "Bertrand's postulate"],
+    "prerequisites": ["P definition", "Nat.choose", "Bertrand's postulate"]
   },
   {
     "id": "ann-683-summary",
     "proofId": "erdos-683",
-    "range": { "startLine": 271, "endLine": 277 },
+    "range": { "startLine": 253, "endLine": 259 },
     "type": "theorem",
     "title": "Summary Theorem",
-    "content": "**erdos_683_summary (proved from axioms):**\n\nCombines the two proven bounds:\n1. **Sylvester-Schur:** ∀ n k, 1 ≤ k → 2k ≤ n → P(C(n,k)) > k\n2. **Erdős 1955:** ∃ c > 0, ∀ n k, P(C(n,k)) ≥ c·k·log k\n\nProved by: `⟨fun n k hk hn => sylvester_schur hk hn, erdos_1955_bound⟩`",
-    "significance": "critical"
+    "content": "**erdos_683_summary** (proved): Combines the two established bounds into a conjunction:\n1. Sylvester-Schur: $\\forall n, k,\\, 1 \\le k \\le n/2 \\Rightarrow P(\\binom{n}{k}) > k$\n2. Erdős 1955: $\\exists c > 0,\\, \\forall n, k,\\, 1 \\le k \\le n/2 \\Rightarrow P(\\binom{n}{k}) \\ge c \\cdot k \\log k$\n\nProved by the term-mode pair `⟨fun n k hk hn => sylvester_schur hk hn, erdos_1955_bound⟩`.",
+    "mathContext": "The summary captures the state of the art: $P(\\binom{n}{k}) > k$ (proved 1892) and $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$ (proved 1955). The gap to the conjectured $k^{1+c}$ remains open after 70+ years.",
+    "significance": "critical",
+    "relatedConcepts": ["state of the art", "conjunction of bounds", "term-mode proof"],
+    "prerequisites": ["sylvester_schur", "erdos_1955_bound"]
   }
 ]

--- a/src/data/proofs/erdos-683/meta.json
+++ b/src/data/proofs/erdos-683/meta.json
@@ -18,10 +18,42 @@
     "mathlib_version": "4.15.0",
     "dateAdded": "2026-01-19",
     "mathlibDependencies": [
-      { "theorem": "Nat.choose", "description": "Binomial coefficients", "module": "Mathlib.Data.Nat.Choose.Basic" },
-      { "theorem": "Nat.Prime", "description": "Prime numbers", "module": "Mathlib.Data.Nat.Prime.Basic" },
-      { "theorem": "Real.log", "description": "Natural logarithm", "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic" },
-      { "theorem": "Real.rpow", "description": "Real exponentiation", "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real" }
+      { "theorem": "Nat.choose", "description": "Binomial coefficient $\\binom{n}{k}$", "module": "Mathlib.Data.Nat.Choose.Basic" },
+      { "theorem": "Nat.Prime", "description": "Primality predicate and basic properties", "module": "Mathlib.Data.Nat.Prime.Basic" },
+      { "theorem": "Real.log", "description": "Natural logarithm for the $k \\log k$ bound", "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic" },
+      { "theorem": "Real.rpow", "description": "Real exponentiation for $k^{1+c}$ and $e^{c\\sqrt{k}}$", "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real" }
+    ],
+    "references": [
+      {
+        "key": "Sy1892",
+        "citation": "Sylvester, J.J. (1892). On arithmetical series. Messenger of Mathematics 21, 1–19, 87–120.",
+        "type": "paper"
+      },
+      {
+        "key": "Sc1929",
+        "citation": "Schur, I. (1929). Einige Sätze über Primzahlen mit Anwendung auf Irreduzibilitätsfragen. Sitzungsberichte der Preussischen Akademie der Wissenschaften, Phys.-Math. Klasse, 23–24.",
+        "type": "paper"
+      },
+      {
+        "key": "Er1934",
+        "citation": "Erdős, P. (1934). A theorem of Sylvester and Schur. Journal of the London Mathematical Society 9, 282–288.",
+        "type": "paper"
+      },
+      {
+        "key": "Er1955",
+        "citation": "Erdős, P. (1955). On consecutive integers. Nieuw Archief voor Wiskunde 3, 124–128.",
+        "type": "paper"
+      },
+      {
+        "key": "Er1979",
+        "citation": "Erdős, P. (1979). Some unconventional problems in number theory. Mathematics Magazine 52, 67–70.",
+        "type": "paper"
+      },
+      {
+        "key": "ErdosProblems",
+        "citation": "Erdős Problems. Problem #683.",
+        "type": "website"
+      }
     ],
     "originalContributions": [
       "largestPrimeDivisor with P_is_prime, P_divides, P_largest axioms",
@@ -34,93 +66,126 @@
       "consecutiveProduct, bertrand_for_central, consecutive_has_large_prime",
       "central_binom_bound and small_k_case_2",
       "erdos_683_summary combining proven bounds"
+    ],
+    "relatedProblems": [
+      {
+        "id": "erdos-685",
+        "relationship": "companion",
+        "description": "Studies prime divisors of binomial coefficients from a different angle"
+      },
+      {
+        "id": "erdos-684",
+        "relationship": "companion",
+        "description": "Smooth parts of binomial coefficients — the complementary viewpoint to large prime factors"
+      },
+      {
+        "id": "erdos-648",
+        "relationship": "thematic",
+        "description": "Decreasing greatest prime factors in sequences — same $P(n)$ function applied to sequence problems"
+      },
+      {
+        "id": "erdos-680",
+        "relationship": "thematic",
+        "description": "Least prime factor bounds — studies the small end of the prime factor spectrum"
+      },
+      {
+        "id": "bertrands-postulate",
+        "relationship": "foundation",
+        "description": "Bertrand's postulate implies $P(\\binom{2n}{n}) > n$, a special case of Sylvester-Schur"
+      },
+      {
+        "id": "erdos-961",
+        "relationship": "equivalent",
+        "description": "Smooth numbers in consecutive intervals — essentially equivalent to Problem #683"
+      }
     ]
   },
   "overview": {
-    "historicalContext": "Sylvester (1892) proved that the product of k consecutive integers greater than k contains a prime factor exceeding k. Schur (1929) refined this to show that the binomial coefficient C(n,k) itself has such a large prime divisor. This foundational result — P(C(n,k)) > k for k ≤ n/2 — became the starting point for deeper investigations.\n\nErdős made this problem his own over several decades. In 1934 he gave a new proof of the Sylvester-Schur theorem. In 1955, he significantly improved the bound to P(C(n,k)) ≫ k log k. By 1979, he conjectured the much stronger bound P(C(n,k)) ≥ min(n-k+1, k^{1+c}) for some absolute constant c > 0, and wrote that it 'seems certain' that P(C(n,k)) > k^{1+c} holds with only finitely many exceptions for any c > 0.\n\nThe problem remains open despite substantial progress. Standard heuristics based on prime gap statistics suggest the even stronger bound P(C(n,k)) > e^{c√k}, a stretched exponential that far exceeds any polynomial growth. The problem connects number theory (prime distribution in consecutive products) with combinatorics (binomial coefficients), and is essentially equivalent to Problem #961.",
-    "problemStatement": "**Problem Statement (OPEN)**\n\nFor every 1 ≤ k ≤ n, is there a constant c > 0 such that:\n  P(C(n,k)) ≥ min(n - k + 1, k^{1+c})\n\nwhere P(m) denotes the largest prime divisor of m?\n\n**Known:**\n- P(C(n,k)) > k for k ≤ n/2 (Sylvester-Schur)\n- P(C(n,k)) ≫ k log k (Erdős 1955)\n\n**Believed:**\n- For any c > 0, P(C(n,k)) > k^{1+c} with finitely many exceptions",
-    "proofStrategy": "The formalization defines the largest prime divisor function P and applies it to binomial coefficients. The Sylvester-Schur theorem and Erdős's 1955 improvement are axiomatized with proper type signatures. The main conjecture is stated as a definition. Connections to products of consecutive integers, Bertrand's postulate, and specific cases (central binomial, k=2) are explored. The summary theorem combines the two proven bounds.",
+    "historicalContext": "**Origins: Sylvester and Schur (1892–1929)**\n\nJ.J. Sylvester (1892) proved that among any $k$ consecutive integers greater than $k$, at least one has a prime factor exceeding $k$. Issai Schur (1929) refined this to show that the binomial coefficient $\\binom{n}{k}$ itself has a prime divisor $> k$ when $k \\le n/2$. The key insight is that $\\binom{n}{k} = \\frac{(n-k+1) \\cdots n}{k!}$, and primes $> k$ in the numerator survive division by $k!$.\n\n**Erdős's Contributions (1934–1979)**\n\nErdős gave a new proof of the Sylvester-Schur theorem in 1934, using elementary methods. In 1955, he achieved a breakthrough by proving $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$ using the prime number theorem and a counting argument on prime factors in consecutive products. By 1979, in 'Some unconventional problems in number theory,' Erdős conjectured the far stronger bound $P(\\binom{n}{k}) \\ge \\min(n-k+1, k^{1+c})$ and wrote that it 'seems certain' that $P > k^{1+c}$ for ANY $c > 0$ with only finitely many exceptions.\n\n**Current Status and Heuristics**\n\nThe problem remains open after 45+ years. The gap from $k \\log k$ (Erdős 1955) to $k^{1+c}$ (the conjecture) is enormous. Cramér-type probabilistic heuristics based on the random model of primes suggest the even stronger stretched exponential bound $P > e^{c\\sqrt{k}}$, which dwarfs any polynomial. The problem is essentially equivalent to Erdős Problem #961 on smooth numbers in consecutive intervals.",
+    "problemStatement": "**Problem Statement (OPEN)**\n\nFor every $1 \\le k \\le n$, does there exist a constant $c > 0$ such that:\n$$P(\\binom{n}{k}) \\ge \\min(n - k + 1,\\, k^{1+c})$$\nwhere $P(m)$ denotes the largest prime divisor of $m$?\n\n**Known:**\n- $P(\\binom{n}{k}) > k$ for $k \\le n/2$ (Sylvester 1892, Schur 1929)\n- $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$ for $k \\le n/2$ (Erdős 1955)\n\n**Believed:**\n- For any $c > 0$, $P(\\binom{n}{k}) > k^{1+c}$ with only finitely many exceptions (Erdős 1979)",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Axiomatic approach to $P(n)$**: Defines `largestPrimeDivisor` via `Nat.find`, then axiomatizes the three key properties (primality, divisibility, maximality) to avoid dependence on Mathlib's factorization internals\n2. **Hierarchy of bounds**: Formalizes the chain $k < k \\log k < k^{1+c} < e^{c\\sqrt{k}}$ with each result building on the previous\n3. **Two-regime structure**: The $\\min(n-k+1, k^{1+c})$ captures the transition at $k \\approx n^{1/(1+c)}$\n4. **Consecutive product connection**: Defines `consecutiveProduct` and links it to $\\binom{n}{k}$ via the numerator identity\n5. **Special cases**: Verifies the central binomial ($k = n/2$) and small $k$ cases as consistency checks\n6. **Summary theorem**: Combines the two proven bounds (Sylvester-Schur and Erdős 1955) into a single conjunction via term-mode proof",
     "keyInsights": [
-      "**Sylvester-Schur:** P(C(n,k)) > k is the foundation",
-      "**Erdős 1955:** P(C(n,k)) ≫ k log k is a significant improvement",
-      "**The Conjecture:** min(n-k+1, k^{1+c}) captures two regimes",
-      "**Heuristic:** Prime gap statistics suggest e^{c√k}",
-      "**Consecutive Products:** C(n,k) numerator is (n-k+1)···n",
-      "**Bertrand Connection:** Implies P(C(2n,n)) > n"
+      "**Sylvester-Schur foundation**: $P(\\binom{n}{k}) > k$ because primes $> k$ in the numerator $(n-k+1) \\cdots n$ survive division by $k!$, which contains only primes $\\le k$",
+      "**Erdős's logarithmic leap**: The improvement from $k$ to $c \\cdot k \\log k$ uses the prime number theorem — among $k$ consecutive integers, $\\sim k/\\log k$ are prime, providing a logarithmic factor",
+      "**Two-regime conjecture**: $\\min(n-k+1, k^{1+c})$ captures that for small $k$ the bound is polynomial in $k$, while for $k$ near $n$ the bound degrades to $n-k+1$ (only $k$ terms in the product)",
+      "**Cramér heuristic**: The random model of primes predicts the largest prime gap in $[n-k, n]$ is $\\sim (\\log n)^2$, giving $P \\approx n \\gg e^{c\\sqrt{k}}$ — a stretched exponential far exceeding any polynomial",
+      "**Bertrand's postulate as base case**: For the central binomial $\\binom{2n}{n}$, Bertrand's postulate gives a prime $p \\in (n, 2n]$ dividing $\\binom{2n}{n}$, so $P(\\binom{2n}{n}) > n$",
+      "**Equivalence with Problem #961**: Both problems reduce to understanding the distribution of smooth numbers in short intervals — large prime factors of $\\binom{n}{k}$ are equivalent to non-smoothness of the consecutive product"
     ]
   },
   "sections": [
     {
       "id": "definitions",
-      "title": "Basic Definitions",
+      "title": "Basic Definitions: $P(n)$ and $P(\\binom{n}{k})$",
       "startLine": 41,
       "endLine": 78,
-      "summary": "largestPrimeDivisor, P(C(n,k)), P_is_prime, P_divides, P_largest"
+      "summary": "Defines `largestPrimeDivisor` via `Nat.find` and `P n k = P(\\binom{n}{k})`. Axiomatizes $P(n)$ as prime, dividing $n$, and maximal among prime divisors."
     },
     {
       "id": "sylvester-schur",
-      "title": "Sylvester-Schur Theorem",
+      "title": "Sylvester-Schur Theorem: $P(\\binom{n}{k}) > k$",
       "startLine": 80,
       "endLine": 113,
-      "summary": "sylvester_schur axiom, choose_gt_one, binom_has_large_prime (proved)"
+      "summary": "Axiomatizes $P(\\binom{n}{k}) > k$ for $k \\le n/2$ and derives the existential form $\\exists p$ prime with $p \\mid \\binom{n}{k}$ and $p > k$ (proved from axioms)."
     },
     {
       "id": "erdos-1955",
-      "title": "Erdős's 1955 Improvement",
+      "title": "Erdős 1955: $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$",
       "startLine": 115,
       "endLine": 137,
-      "summary": "erdos_1955_bound axiom, erdos_1955_asymptotic (proved)"
+      "summary": "Axiomatizes the quantitative improvement $P(\\binom{n}{k}) \\ge c \\cdot k \\log k$ and instantiates it for specific $n, k$ via `obtain`."
     },
     {
       "id": "main-conjecture",
-      "title": "The Main Conjecture",
+      "title": "The Main Conjecture: $P \\ge \\min(n-k+1, k^{1+c})$",
       "startLine": 139,
       "endLine": 161,
-      "summary": "erdosConjecture683 (OPEN), erdos_1979_belief"
+      "summary": "Formalizes `erdosConjecture683` as a `Prop` and axiomatizes Erdős's 1979 belief that $P > k^{1+c}$ for all $c > 0$ with finite exceptions."
     },
     {
       "id": "heuristics",
-      "title": "Heuristic Bounds",
+      "title": "Heuristic Bounds: $P > e^{c\\sqrt{k}}$",
       "startLine": 163,
       "endLine": 188,
-      "summary": "prime_gap_heuristic, heuristic_stronger_than_conjecture"
+      "summary": "Axiomatizes the Cramér-type heuristic $P(\\binom{n}{k}) > e^{c\\sqrt{k}}$ and the comparison $e^{c\\sqrt{k}} > k^{1+c}$ (stretched exponential vs polynomial)."
     },
     {
       "id": "min-bound",
-      "title": "The min(n-k+1, k^{1+c}) Bound",
+      "title": "Trivial Upper Bound: $P(\\binom{n}{k}) \\le n$",
       "startLine": 190,
       "endLine": 199,
-      "summary": "P_upper_bound axiom"
+      "summary": "Axiomatizes $P(\\binom{n}{k}) \\le n$, the trivial upper bound since $\\binom{n}{k}$ divides products of terms $\\le n$."
     },
     {
       "id": "consecutive",
-      "title": "Products of Consecutive Integers",
+      "title": "Consecutive Products and Bertrand's Postulate",
       "startLine": 201,
       "endLine": 227,
-      "summary": "consecutiveProduct, bertrand_for_central, consecutive_has_large_prime"
+      "summary": "Defines `consecutiveProduct m k = \\prod_{i=0}^{k-1}(m+i)` and axiomatizes Bertrand-type results: $P(\\binom{2n}{n}) > n$ and Sylvester's theorem for consecutive products."
     },
     {
       "id": "specific-cases",
-      "title": "Specific Cases",
+      "title": "Central Binomial and Small $k$ Cases",
       "startLine": 229,
       "endLine": 249,
-      "summary": "central_binom_bound, small_k_case_2"
+      "summary": "Axiomatizes $P(\\binom{2k}{k}) > \\frac{4}{3}k$ for large $k$ and $P(\\binom{n}{2}) \\ge (n-1)/2$ for $n \\ge 4$ as consistency checks."
     },
     {
       "id": "summary",
-      "title": "Summary",
+      "title": "Summary Theorem",
       "startLine": 251,
-      "endLine": 279,
-      "summary": "erdos_683_summary combining sylvester_schur and erdos_1955_bound"
+      "endLine": 262,
+      "summary": "Combines Sylvester-Schur ($P > k$) and Erdős 1955 ($P \\ge c \\cdot k \\log k$) into a single conjunction, proved in term mode."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #683 remains OPEN. The Sylvester-Schur theorem establishes P(C(n,k)) > k, and Erdős (1955) improved this to P(C(n,k)) ≫ k log k. The conjectured bound P(C(n,k)) ≥ min(n-k+1, k^{1+c}) for some c > 0 is still unproven, though Erdős believed it holds with only finitely many exceptions for any c > 0.",
-    "implications": "This problem connects the prime factorization of binomial coefficients to the distribution of primes in products of consecutive integers. Progress would illuminate the structure of factorial-type numbers and their prime divisors.",
+    "summary": "Erdős Problem #683 remains OPEN. The formalization captures the complete hierarchy of known and conjectured bounds on $P(\\binom{n}{k})$: from the foundational Sylvester-Schur theorem ($P > k$, 1892/1929) through Erdős's improvement ($P \\ge c \\cdot k \\log k$, 1955) to the main conjecture ($P \\ge \\min(n-k+1, k^{1+c})$, 1979) and the Cramér-type heuristic ($P > e^{c\\sqrt{k}}$). The summary theorem formally combines the two proven bounds.",
+    "implications": "**Connections and Significance**\n\n1. **Prime distribution in factorials**: Progress would illuminate how primes distribute in the factorization of $n!/k!(n-k)!$, connecting combinatorics and analytic number theory\n2. **Smooth number theory**: Equivalent to Problem #961 — understanding when consecutive products avoid being smooth\n3. **Cramér's conjecture**: The heuristic bound $e^{c\\sqrt{k}}$ links this to the deep conjecture on prime gaps $\\sim (\\log p)^2$\n4. **Irrationality and transcendence**: Schur's original motivation connected prime factors of binomial coefficients to irrationality proofs",
     "openQuestions": [
-      "Prove the main conjecture for some c > 0",
-      "Determine optimal value of c in the bound",
-      "Prove the heuristic e^{c√k} bound"
+      "Prove $P(\\binom{n}{k}) \\ge k^{1+c}$ for some explicit $c > 0$ (even $c = \\epsilon$ would be a breakthrough)",
+      "Close the gap between $k \\log k$ and $k^{1+\\epsilon}$ — is there an intermediate bound like $k (\\log k)^2$?",
+      "Determine whether the Cramér heuristic $P > e^{c\\sqrt{k}}$ can be made rigorous under GRH or other conjectures",
+      "Prove or disprove Erdős's belief that exceptions to $P > k^{1+c}$ are finite for every $c > 0$"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enriched 9 annotations with `mathContext`, `relatedConcepts`, `prerequisites` for erdos-683 (Largest Prime Divisor of Binomial Coefficients)
- Deepened `historicalContext` with Sylvester (1892), Schur (1929), Erdős (1934/1955/1979) contributions
- Added 6 scholarly references and 6 cross-references (erdos-685, erdos-684, erdos-648, erdos-680, bertrands-postulate, erdos-961)
- Improved all 9 sections with LaTeX-rich summaries
- Added 4 specific open questions in conclusion

## Test plan
- [x] `pnpm annotations:build` passes (non-strict mode, no erdos-683 warnings)
- [ ] Verify gallery renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)