### PR TITLE
fix: erdos-72 type safety for mathlibDependencies

### DIFF
--- a/src/data/proofs/erdos-72/index.ts
+++ b/src/data/proofs/erdos-72/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 
 // Type assertion for JSON import
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/erdos-72/meta.json
+++ b/src/data/proofs/erdos-72/meta.json
@@ -33,12 +33,12 @@
       }
     ],
     "mathlibDependencies": [
-      "Mathlib.Combinatorics.SimpleGraph.Basic",
-      "Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting",
-      "Mathlib.Combinatorics.SimpleGraph.Subgraph",
-      "Mathlib.Data.Finset.Card",
-      "Mathlib.Analysis.Asymptotics.Asymptotics",
-      "Mathlib.Topology.Instances.Real"
+      { "theorem": "Mathlib.Combinatorics.SimpleGraph.Basic", "description": "Core simple graph definitions and operations" },
+      { "theorem": "Mathlib.Combinatorics.SimpleGraph.Connectivity.WalkCounting", "description": "Walk and cycle counting in simple graphs" },
+      { "theorem": "Mathlib.Combinatorics.SimpleGraph.Subgraph", "description": "Subgraph type and operations" },
+      { "theorem": "Mathlib.Data.Finset.Card", "description": "Cardinality of finite sets" },
+      { "theorem": "Mathlib.Analysis.Asymptotics.Asymptotics", "description": "Asymptotic analysis and big-O notation" },
+      { "theorem": "Mathlib.Topology.Instances.Real", "description": "Topological structure on the reals" }
     ],
     "originalContributions": [
       "countingFunction, hasDensityZero: natural density framework using Tendsto",


### PR DESCRIPTION
## Summary
- Fix erdos-72 `mathlibDependencies` from plain strings to `{theorem, description}` objects (matches `MathlibDependency` type)
- Fix `index.ts` to use `as unknown as` pattern to avoid TS2352 conversion error
- Build was broken by batch enrichment PR #2834 which introduced plain string dependencies

## Test plan
- [ ] `pnpm build` passes without TS2352 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)