### PR TITLE
fix: repair 3 build errors in BirchSwinnertonDyer.lean

### DIFF
--- a/proofs/Proofs/BirchSwinnertonDyer.lean
+++ b/proofs/Proofs/BirchSwinnertonDyer.lean
@@ -1285,7 +1285,7 @@ lemma congruent_point_x_ne_zero {n : ℕ} {hn : n > 0}
   simp only at h
   rw [hx0] at h
   simp at h
-  exact hnt (sq_eq_zero_iff.mp h)
+  exact hnt h
 
 /-- Given a non-torsion point on y² = x³ - n²x, X² ≠ n².
 This is because X = ±n gives Y² = (±n)(0)(±2n) = 0. -/
@@ -1332,8 +1332,8 @@ theorem inverse_koblitz_pythagorean {n : ℕ} {hn : n > 0}
   -- Simplify: all terms have denominator |Y|², so compare numerators
   field_simp
   -- |X² - n²|² + (2n|X|)² = (X² + n²)²
-  -- Since |a|² = a² for rationals, this reduces to algebra
-  rw [sq_abs, sq_abs, sq_abs]
+  -- After field_simp, absolute values are cleared; the identity is pure algebra
+  simp only [sq_abs]
   ring
 
 /-- Key identity: |X| · |X² - n²| = Y² for points on y² = x³ - n²x.
@@ -1346,7 +1346,9 @@ lemma abs_x_mul_abs_diff_sq_eq_y_sq {n : ℕ} {hn : n > 0}
   simp only at h
   -- h : Y² = X³ + (-n²)·X + 0, i.e., Y² = X³ - n²X = X(X² - n²)
   have key : P.y ^ 2 = P.x * (P.x ^ 2 - (n : ℚ) ^ 2) := by linarith
-  rw [← abs_mul, key, abs_of_nonneg (sq_nonneg P.y)]
+  rw [← abs_mul]
+  rw [abs_of_nonneg (by linarith [sq_nonneg P.y] : 0 ≤ P.x * (P.x ^ 2 - (n : ℚ) ^ 2))]
+  linarith
 
 /-- **The Area Identity for the Inverse Map**
 


### PR DESCRIPTION
## Summary
- Fix 3 Lean API compatibility errors in the inverse Koblitz correspondence section of BirchSwinnertonDyer.lean
- All 1533 lines now compile successfully in Docker (Mathlib v4.26.0)

## Changes
Three tactic fixes for Lean/Mathlib API evolution:

1. **`congruent_point_x_ne_zero`** (line 1288): After `simp`, the hypothesis becomes `P.y = 0` directly (not `P.y ^ 2 = 0`), so `sq_eq_zero_iff.mp` is no longer needed
2. **`inverse_koblitz_pythagorean`** (line 1336): `field_simp` now eliminates absolute value patterns, so `rw [sq_abs, sq_abs, sq_abs]` fails; replaced with `simp only [sq_abs]`
3. **`abs_x_mul_abs_diff_sq_eq_y_sq`** (line 1349): `abs_of_nonneg` no longer matches `|P.y ^ 2|`; restructured to apply `abs_of_nonneg` to the product with explicit nonnegativity proof

## Test plan
- [x] Docker build: `./proofs/scripts/docker-build.sh Proofs.BirchSwinnertonDyer` passes (3085 jobs, 3.4s)
- [x] No new axioms or sorries introduced
- [x] Changes are minimal and targeted (6 insertions, 4 deletions)

Generated by researcher-1