### PR TITLE
enrich: deepen annotations and meta for erdos-823

### DIFF
--- a/src/data/proofs/erdos-823/annotations.json
+++ b/src/data/proofs/erdos-823/annotations.json
@@ -1,119 +1,146 @@
 [
   {
+    "id": "ann-823-imports",
+    "proofId": "erdos-823",
+    "range": { "startLine": 28, "endLine": 36 },
+    "type": "concept",
+    "title": "Imports and Setup",
+    "content": "Imports Mathlib's `ArithmeticFunction` (for $\\sigma$ and $\\varphi$), `Topology.Basic` and `Topology.Instances.Real` (for filter-based convergence $n_k/m_k \\to \\alpha$), and opens `ArithmeticFunction`, `Filter`, `Topology` namespaces. The convergence is formalized via Lean's `Tendsto` and `atTop` filter rather than $\\varepsilon$-$N$ definitions.",
+    "mathContext": "Uses `ArithmeticFunction.sigma 1` for $\\sigma(n) = \\sum_{d \\mid n} d$ and `Filter.Tendsto` for $\\lim_{k \\to \\infty} n_k/m_k = \\alpha$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Mathlib ArithmeticFunction", "filter convergence", "topological limits"],
+    "prerequisites": ["Lean 4", "Mathlib topology", "Mathlib number theory"]
+  },
+  {
     "id": "ann-823-sigma",
     "proofId": "erdos-823",
     "range": { "startLine": 44, "endLine": 45 },
     "type": "definition",
-    "title": "Sum of Divisors",
-    "content": "σ(n) = sum of all divisors of n.",
-    "significance": "critical"
+    "title": "Sum of Divisors Function",
+    "content": "Defines $\\sigma(n) = \\texttt{ArithmeticFunction.sigma 1 n}$, the sum of all positive divisors of $n$. The parameter $1$ in `sigma 1` refers to the $k$-th power divisor sum $\\sigma_k(n) = \\sum_{d \\mid n} d^k$; setting $k = 1$ gives the classical sum of divisors. Key values: $\\sigma(1) = 1$, $\\sigma(p) = p + 1$ for primes, $\\sigma(p^k) = (p^{k+1} - 1)/(p - 1)$.",
+    "mathContext": "$\\sigma(n) = \\sum_{d \\mid n} d$. For prime powers: $\\sigma(p^k) = 1 + p + p^2 + \\cdots + p^k = \\frac{p^{k+1} - 1}{p - 1}$.",
+    "significance": "critical",
+    "relatedConcepts": ["divisor sum", "multiplicative function", "arithmetic function"],
+    "prerequisites": ["divisibility", "prime factorization"]
   },
   {
     "id": "ann-823-multiplicative",
     "proofId": "erdos-823",
     "range": { "startLine": 61, "endLine": 63 },
     "type": "theorem",
-    "title": "Multiplicativity",
-    "content": "σ(mn) = σ(m)σ(n) for coprime m, n.",
-    "significance": "key"
+    "title": "Multiplicativity of σ",
+    "content": "Axiomatizes $\\sigma(mn) = \\sigma(m)\\sigma(n)$ for coprime $m, n$. This is the **key structural property** enabling Pollack's construction: by choosing coprime building blocks with controlled $\\sigma$ values, one can construct $\\sigma$-pairs with any desired ratio. Multiplicativity follows from the Chinese Remainder Theorem applied to the divisor lattice.",
+    "mathContext": "$\\gcd(m, n) = 1 \\implies \\sigma(mn) = \\sigma(m) \\cdot \\sigma(n)$",
+    "significance": "critical",
+    "relatedConcepts": ["multiplicative function", "Chinese Remainder Theorem", "coprimality"],
+    "prerequisites": ["sum of divisors", "coprime integers"]
   },
   {
     "id": "ann-823-sigmapair",
     "proofId": "erdos-823",
-    "range": { "startLine": 71, "endLine": 72 },
+    "range": { "startLine": 71, "endLine": 80 },
     "type": "definition",
-    "title": "IsSigmaPair",
-    "content": "Pair (n,m) with σ(n) = σ(m).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-823-converging",
-    "proofId": "erdos-823",
-    "range": { "startLine": 74, "endLine": 80 },
-    "type": "definition",
-    "title": "SigmaSequenceConvergingTo",
-    "content": "Sequences with equal σ values and ratio → α.",
-    "significance": "critical"
+    "title": "σ-Pairs and Converging Sequences",
+    "content": "Defines `IsSigmaPair n m` ($\\sigma(n) = \\sigma(m)$) and `SigmaSequenceConvergingTo α`: existence of sequences $n_k, m_k \\geq 1$ with $\\sigma(n_k) = \\sigma(m_k)$ and $n_k/m_k \\to \\alpha$. The convergence uses Lean's `Tendsto` with `atTop` and neighborhood filter $\\mathcal{N}(\\alpha)$. The condition $\\alpha \\geq 1$ is WLOG: if $\\alpha < 1$, swap $n$ and $m$.",
+    "mathContext": "$\\text{IsSigmaPair}(n, m) \\iff \\sigma(n) = \\sigma(m)$. $\\text{SigmaSequenceConvergingTo}(\\alpha) \\iff \\exists (n_k), (m_k),\\; \\sigma(n_k) = \\sigma(m_k) \\wedge n_k/m_k \\to \\alpha$.",
+    "significance": "critical",
+    "relatedConcepts": ["σ-pairs", "sequence convergence", "ratio limits"],
+    "prerequisites": ["sum of divisors", "topological convergence"]
   },
   {
     "id": "ann-823-pollack",
     "proofId": "erdos-823",
-    "range": { "startLine": 86, "endLine": 92 },
+    "range": { "startLine": 88, "endLine": 99 },
     "type": "theorem",
-    "title": "Pollack 2015",
-    "content": "For all α ≥ 1, such sequences exist.",
-    "significance": "critical"
+    "title": "Pollack's Theorem (2015) and Main Result (Proved)",
+    "content": "Axiomatizes Pollack's 2015 theorem and **proves** `erdos_823_solved` as a direct corollary. Pollack's proof constructs sequences by exploiting: (1) the abundance of $\\sigma$-pairs (many $n \\neq m$ with $\\sigma(n) = \\sigma(m)$), (2) multiplicativity to scale pairs to desired ratios, and (3) a density argument showing the achievable ratios are dense in $[1, \\infty)$. The proof appeared in *Remarks on fibers of the sum-of-divisors function* (Mathematika, 2015).",
+    "mathContext": "$\\forall \\alpha \\geq 1,\\; \\exists (n_k), (m_k) \\text{ with } \\sigma(n_k) = \\sigma(m_k) \\text{ and } n_k/m_k \\to \\alpha$. Proved by `intro _; obtain ... := pollack_2015 α hα; exact ⟨...⟩`.",
+    "significance": "critical",
+    "relatedConcepts": ["Pollack", "sequence construction", "multiplicative scaling"],
+    "prerequisites": ["σ-pairs", "multiplicativity of σ", "filter convergence"]
   },
   {
-    "id": "ann-823-solved",
+    "id": "ann-823-examples",
     "proofId": "erdos-823",
-    "range": { "startLine": 94, "endLine": 99 },
-    "type": "theorem",
-    "title": "Main Theorem",
-    "content": "Erdős #823 solved affirmatively.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-823-example1415",
-    "proofId": "erdos-823",
-    "range": { "startLine": 107, "endLine": 117 },
-    "type": "example",
-    "title": "σ(14) = σ(15)",
-    "content": "Both equal 24, ratio 14/15 ≈ 0.93.",
-    "significance": "supporting"
+    "range": { "startLine": 107, "endLine": 129 },
+    "type": "insight",
+    "title": "Concrete σ-Pair Examples",
+    "content": "Three families of $\\sigma$-pairs illustrating different phenomena. **Consecutive integers**: $\\sigma(14) = \\sigma(15) = 24$ (ratio $14/15 \\approx 0.93$) and $\\sigma(957) = \\sigma(958)$ (ratio $\\approx 0.999$). **Non-consecutive**: $\\sigma(206) = \\sigma(210) = 432$ (ratio $\\approx 0.981$). The $14, 15$ pair works because $14 = 2 \\cdot 7$ gives $\\sigma = 3 \\cdot 8 = 24$ and $15 = 3 \\cdot 5$ gives $\\sigma = 4 \\cdot 6 = 24$. Such coincidences are not rare: Erdős and Pomerance showed that the number of $n \\leq x$ with $\\sigma(n) = \\sigma(n+1)$ is $\\gg x/(\\log x)^c$.",
+    "mathContext": "$\\sigma(14) = (1+2)(1+7) = 24 = (1+3)(1+5) = \\sigma(15)$. $\\sigma(206) = \\sigma(210) = 432$. $\\sigma(957) = \\sigma(958)$.",
+    "significance": "key",
+    "relatedConcepts": ["σ-coincidences", "consecutive integers", "multiplicative structure"],
+    "prerequisites": ["sum of divisors", "prime factorization"]
   },
   {
     "id": "ann-823-phi",
     "proofId": "erdos-823",
-    "range": { "startLine": 137, "endLine": 138 },
+    "range": { "startLine": 137, "endLine": 158 },
     "type": "definition",
-    "title": "Euler Totient",
-    "content": "φ(n) counts integers coprime to n.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-823-phieasy",
-    "proofId": "erdos-823",
-    "range": { "startLine": 147, "endLine": 152 },
-    "type": "theorem",
-    "title": "Erdos Phi Remark",
-    "content": "Analogous φ result is 'easy to prove'.",
-    "significance": "key"
+    "title": "Euler Totient Analogy",
+    "content": "Defines $\\varphi(n) = \\texttt{ArithmeticFunction.totient n}$ and axiomatizes the 'easy' analogous result for $\\varphi$. Erdős noted that $\\varphi$-pairs are far more abundant than $\\sigma$-pairs because $\\varphi(n) = \\varphi(2n)$ for all odd $n$ (since $\\varphi(2) = 1$). This gives trivial $\\varphi$-pairs at any ratio: take $n_k = 2^{a_k} p$ and $m_k = 2^{b_k} p$ for appropriate $a_k, b_k$. Examples: $\\varphi(1) = \\varphi(2) = 1$, $\\varphi(3) = \\varphi(4) = \\varphi(6) = 2$.",
+    "mathContext": "$\\varphi(n) = |\\{k \\leq n : \\gcd(k, n) = 1\\}|$. For odd $n$: $\\varphi(2n) = \\varphi(2)\\varphi(n) = \\varphi(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler totient", "φ-pairs", "multiplicative functions"],
+    "prerequisites": ["totient function", "coprimality"]
   },
   {
     "id": "ann-823-fiber",
     "proofId": "erdos-823",
-    "range": { "startLine": 164, "endLine": 165 },
+    "range": { "startLine": 164, "endLine": 176 },
     "type": "definition",
-    "title": "sigmaFiber",
-    "content": "σ⁻¹(m) = {n : σ(n) = m}.",
-    "significance": "key"
+    "title": "σ-Fibers and Their Properties",
+    "content": "Defines `sigmaFiber m` = $\\sigma^{-1}(m) = \\{n : \\sigma(n) = m\\}$ and axiomatizes three structural properties: (1) $\\sigma^{-1}(24) \\ni 14, 15$, (2) fibers can be arbitrarily large ($\\forall K,\\; \\exists m,\\; |\\sigma^{-1}(m)| \\geq K$), (3) every sufficiently large even number is a $\\sigma$-value. The large fiber property follows from multiplicativity: for any prime $p$, the values $\\sigma(p^k) = (p^{k+1}-1)/(p-1)$ are distinct, so multiplying by coprime factors with matching $\\sigma$ grows fiber sizes.",
+    "mathContext": "$\\sigma^{-1}(m) = \\{n \\in \\mathbb{N} : \\sigma(n) = m\\}$. $|\\sigma^{-1}(m)|$ is unbounded. Every large even number is in $\\text{Im}(\\sigma)$.",
+    "significance": "key",
+    "relatedConcepts": ["fiber", "preimage", "σ-value distribution"],
+    "prerequisites": ["sum of divisors", "set cardinality"]
   },
   {
-    "id": "ann-823-largefibers",
+    "id": "ann-823-density",
     "proofId": "erdos-823",
-    "range": { "startLine": 170, "endLine": 172 },
+    "range": { "startLine": 183, "endLine": 194 },
     "type": "theorem",
-    "title": "Large Fibers",
-    "content": "Fibers can be arbitrarily large.",
-    "significance": "key"
+    "title": "Density Results for σ-Values",
+    "content": "Two density axioms: (1) the set of $\\sigma$-values has **positive lower density** ($\\exists c > 0,\\; |\\{m \\leq N : \\sigma^{-1}(m) \\neq \\emptyset\\}| \\geq cN$), and (2) the set of $\\sigma$-values with **multiple preimages** also has positive density. These results go back to Erdős (1959) and Pomerance. The positive density of multi-preimage values is precisely what enables Pollack's construction: it ensures enough $\\sigma$-pairs exist to approximate any ratio.",
+    "mathContext": "$|\\{m \\leq N : \\sigma^{-1}(m) \\neq \\emptyset\\}| \\geq cN$ and $|\\{m \\leq N : |\\sigma^{-1}(m)| \\geq 2\\}| \\geq cN$ for constants $c > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["natural density", "σ-value distribution", "counting arguments"],
+    "prerequisites": ["σ-fibers", "asymptotic density"]
   },
   {
-    "id": "ann-823-perfect",
+    "id": "ann-823-computations",
     "proofId": "erdos-823",
-    "range": { "startLine": 206, "endLine": 210 },
-    "type": "example",
-    "title": "Perfect Numbers",
-    "content": "σ(6) = 12, σ(28) = 56 (both satisfy σ(n) = 2n).",
-    "significance": "supporting"
+    "range": { "startLine": 201, "endLine": 213 },
+    "type": "theorem",
+    "title": "Computational Examples and Perfect Numbers",
+    "content": "Verified computations via `native_decide`: $\\sigma(p) = p + 1$ for $p = 2, 3, 5, 7$ (primes), $\\sigma(6) = 12$ and $\\sigma(28) = 56$ (perfect numbers, $\\sigma(n) = 2n$), and integer ratio $14000/15 = 933$. The perfect number examples connect to the Euclid-Euler theorem: $n$ is an even perfect number iff $n = 2^{p-1}(2^p - 1)$ with $2^p - 1$ prime (Mersenne prime).",
+    "mathContext": "$\\sigma(2) = 3$, $\\sigma(3) = 4$, $\\sigma(5) = 6$, $\\sigma(7) = 8$. $\\sigma(6) = 12 = 2 \\cdot 6$, $\\sigma(28) = 56 = 2 \\cdot 28$.",
+    "significance": "supporting",
+    "relatedConcepts": ["perfect numbers", "Mersenne primes", "native_decide"],
+    "prerequisites": ["sum of divisors", "prime factorization"]
   },
   {
-    "id": "ann-823-main",
+    "id": "ann-823-keyinsight",
+    "proofId": "erdos-823",
+    "range": { "startLine": 224, "endLine": 228 },
+    "type": "theorem",
+    "title": "Abundance of σ-Pairs",
+    "content": "Axiomatizes that infinitely many $\\sigma$-pairs $(n, m)$ with $n \\neq m$ exist. This is the fundamental fact enabling Pollack's construction. The proof that $\\sigma$-pairs are infinite uses the pigeonhole principle on the fibers: since $|\\sigma^{-1}(m)| \\geq 2$ for positive-density many $m$, there are infinitely many $m$ with at least two preimages, yielding infinitely many pairs.",
+    "mathContext": "$\\exists (n_k, m_k)_{k \\geq 1},\\; n_k \\neq m_k \\wedge \\sigma(n_k) = \\sigma(m_k)$",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "infinite σ-pairs", "fiber counting"],
+    "prerequisites": ["σ-fibers", "density of multi-preimage values"]
+  },
+  {
+    "id": "ann-823-summary",
     "proofId": "erdos-823",
     "range": { "startLine": 259, "endLine": 268 },
     "type": "theorem",
-    "title": "Complete Statement",
-    "content": "Main theorem + φ analogy + solved status.",
-    "significance": "critical"
+    "title": "Complete Statement (Proved)",
+    "content": "**Verified proof** combining the main theorem and the $\\varphi$-analogue into a single conjunction. Proved by extracting the Pollack result for $\\sigma$ and the Erdős remark for $\\varphi$: `exact ⟨fun α hα => erdos_823_solved α hα, fun α hα => let ⟨n, m, _, hphi, hconv⟩ := erdos_phi_easy α hα; ⟨n, m, hphi, hconv⟩⟩`. This packages the complete resolution of Problem #823.",
+    "mathContext": "$(\\forall \\alpha \\geq 1,\\; \\text{SigmaSequenceConvergingTo}(\\alpha)) \\wedge (\\forall \\alpha \\geq 1,\\; \\exists (n_k), (m_k),\\; \\varphi(n_k) = \\varphi(m_k) \\wedge n_k/m_k \\to \\alpha)$",
+    "significance": "critical",
+    "relatedConcepts": ["theorem packaging", "σ-φ duality", "complete resolution"],
+    "prerequisites": ["Pollack's theorem", "Erdős φ remark"]
   }
 ]

--- a/src/data/proofs/erdos-823/meta.json
+++ b/src/data/proofs/erdos-823/meta.json
@@ -15,7 +15,9 @@
       "sum-of-divisors",
       "sequences",
       "limits",
-      "arithmetic-functions"
+      "arithmetic-functions",
+      "multiplicative-functions",
+      "solved"
     ],
     "badge": "mathlib",
     "sorries": 0,
@@ -24,108 +26,192 @@
     "erdosProblemStatus": "solved",
     "solvedBy": "Paul Pollack",
     "solvedYear": 2015,
+    "dateAdded": "2026-01-23",
+    "mathlib_version": "4.15.0",
     "mathlibDependencies": [
       {
         "theorem": "ArithmeticFunction.sigma",
-        "description": "The sum of divisors function σ(n)"
+        "description": "The sum of divisors function σ_k(n)",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction"
       },
       {
         "theorem": "ArithmeticFunction.totient",
-        "description": "Euler's totient function φ(n)"
+        "description": "Euler's totient function φ(n)",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction"
       },
       {
         "theorem": "Filter.Tendsto",
-        "description": "Convergence of sequences via filters"
+        "description": "Convergence of sequences via filters",
+        "module": "Mathlib.Topology.Basic"
       },
       {
         "theorem": "Topology.atTop",
-        "description": "The at-infinity filter for sequences"
+        "description": "The at-infinity filter for sequences",
+        "module": "Mathlib.Topology.Instances.Real"
       },
       {
         "theorem": "Finset.filter",
-        "description": "Filtering finite sets by predicates"
+        "description": "Filtering finite sets by predicates",
+        "module": "Mathlib.Data.Finset.Basic"
       },
       {
         "theorem": "Set.ncard",
-        "description": "Natural-valued cardinality for sets"
+        "description": "Natural-valued cardinality for sets",
+        "module": "Mathlib.Data.Set.Card"
       }
     ],
     "originalContributions": [
-      "sigma function formalization",
-      "IsSigmaPair definition",
-      "SigmaSequenceConvergingTo predicate",
-      "Pollack's 2015 theorem axiomatization",
-      "sigma-pair examples (14-15, 206-210, 957-958)",
-      "Euler totient analogy formalization",
-      "sigmaFiber definition and properties",
-      "Density results for sigma values",
-      "Perfect number examples",
-      "Main theorem combining all results"
+      "sigma function via ArithmeticFunction.sigma 1",
+      "sigma_multiplicative axiom: σ(mn) = σ(m)σ(n) for coprime m, n",
+      "IsSigmaPair and SigmaSequenceConvergingTo definitions",
+      "pollack_2015 axiom and erdos_823_solved theorem (proved)",
+      "σ-pair examples: (14,15), (206,210), (957,958)",
+      "Euler totient analogy with erdos_phi_easy axiom",
+      "sigmaFiber definition with arbitrarily large fibers axiom",
+      "Density results: positive density of σ-values and multi-preimage values",
+      "Perfect number examples: σ(6)=12, σ(28)=56",
+      "erdos_823_statement: complete resolution (proved)"
+    ],
+    "crossReferences": [
+      {
+        "proofId": "erdos-824",
+        "relationship": "Coprime pairs with equal σ: counts h(x) of coprime (a,b) with σ(a) = σ(b), proved h(x)/x → ∞ (Pollack-Pomerance 2016)"
+      },
+      {
+        "proofId": "erdos-48",
+        "relationship": "Pairs with φ(n) = σ(m): infinitely many exist (Ford-Luca-Pomerance 2010) — connects the two functions"
+      },
+      {
+        "proofId": "erdos-830",
+        "relationship": "Amicable pairs (σ(n)-n = m, σ(m)-m = n): a related problem on the structure of σ"
+      },
+      {
+        "proofId": "perfect-numbers",
+        "relationship": "Euclid-Euler theorem on perfect numbers (σ(n) = 2n); σ-fiber structure"
+      },
+      {
+        "proofId": "euler-totient",
+        "relationship": "Euler's totient function formalization; the 'easy' φ-analogue mentioned by Erdős"
+      },
+      {
+        "proofId": "fundamental-arithmetic",
+        "relationship": "Fundamental Theorem of Arithmetic — prime factorization underlying σ's multiplicativity"
+      },
+      {
+        "proofId": "erdos-826",
+        "relationship": "Divisor function growth along shifts — another problem on arithmetic function behavior"
+      }
+    ],
+    "relatedProblems": [
+      "erdos-824",
+      "erdos-48",
+      "erdos-830",
+      "erdos-826",
+      "perfect-numbers",
+      "euler-totient",
+      "fundamental-arithmetic"
     ]
   },
   "overview": {
-    "historicalContext": "This problem asks whether the sum-of-divisors function σ has enough flexibility to produce sequences with equal values at any prescribed ratio limit. Erdős posed this in 1974, noting the analogous result for Euler's totient φ(n) is 'easy to prove.' The σ case proved more challenging, requiring sophisticated analysis of the fibers of σ. Paul Pollack resolved it affirmatively in 2015, demonstrating that for any α ≥ 1, one can construct sequences n_k, m_k with σ(n_k) = σ(m_k) and n_k/m_k → α. The proof leverages the multiplicativity of σ and the rich structure of prime factorizations.",
-    "problemStatement": "Let α ≥ 1. Is there a sequence of integers n_k, m_k such that n_k/m_k → α and σ(n_k) = σ(m_k) for all k ≥ 1, where σ is the sum of divisors function?",
-    "proofStrategy": "Pollack's approach uses careful construction via multiplicativity of σ and properties of prime factorizations. The key observation is that σ-pairs (numbers with equal σ values) are abundant enough to approximate any ratio. Examples like σ(14) = σ(15) = 24 show that consecutive integers can have equal σ values, providing flexibility for ratio approximation.",
+    "historicalContext": "**The Sum of Divisors Function and Ratio Flexibility**\n\nThe sum of divisors function $\\sigma(n) = \\sum_{d \\mid n} d$ is one of the most studied objects in number theory, with roots going back to Euclid's characterization of perfect numbers ($\\sigma(n) = 2n$). Its multiplicativity — $\\sigma(mn) = \\sigma(m)\\sigma(n)$ for $\\gcd(m,n) = 1$ — makes it tractable yet rich in structure.\n\n**Problem #823 (Erdős, 1974)**: Given $\\alpha \\geq 1$, do there exist sequences $n_k, m_k$ with $\\sigma(n_k) = \\sigma(m_k)$ and $n_k/m_k \\to \\alpha$? Erdős posed this in his 1974 paper *Remarks on some problems in number theory*, noting that the analogous result for Euler's totient $\\varphi$ is 'easy to prove.' The $\\varphi$ case is easy because $\\varphi(n) = \\varphi(2n)$ for odd $n$, giving trivial $\\varphi$-pairs at ratio $2$, and multiplicativity handles arbitrary ratios. For $\\sigma$, no such simple identity exists.\n\n**σ-Pairs and Their Abundance**: Numbers $n \\neq m$ with $\\sigma(n) = \\sigma(m)$ (called $\\sigma$-pairs) are surprisingly common. Examples include $\\sigma(14) = \\sigma(15) = 24$, $\\sigma(206) = \\sigma(210) = 432$, and $\\sigma(957) = \\sigma(958)$. The pair $(14, 15)$ works because $14 = 2 \\cdot 7$ gives $\\sigma = (1+2)(1+7) = 24$ while $15 = 3 \\cdot 5$ gives $\\sigma = (1+3)(1+5) = 24$ — a coincidence enabled by multiplicativity. Erdős and Pomerance showed that the number of $n \\leq x$ with $\\sigma(n) = \\sigma(n+1)$ grows as $x/(\\log x)^c$.\n\n**Pollack's Resolution (2015)**: Paul Pollack proved the affirmative answer in his paper *Remarks on fibers of the sum-of-divisors function* (Mathematika 61(3), 2015, pp. 616–636). His proof exploits three key facts: (1) the set of $\\sigma$-values with multiple preimages has positive lower density, (2) multiplicativity allows scaling of $\\sigma$-pairs to approximate any ratio, and (3) a careful density argument closes the approximation gap. The construction is non-explicit — it proves existence of appropriate sequences without giving a formula.\n\n**The Fiber Perspective**: Pollack's approach centers on the *fibers* $\\sigma^{-1}(m) = \\{n : \\sigma(n) = m\\}$. Key structural results include: fibers can be arbitrarily large, every sufficiently large even number is a $\\sigma$-value, and the set of $m$ with $|\\sigma^{-1}(m)| \\geq 2$ has positive density. These facts, combined with multiplicativity, give enough raw material to construct converging sequences at any prescribed ratio.",
+    "problemStatement": "**Problem Statement (SOLVED)**\n\nLet $\\alpha \\geq 1$. Does there exist a sequence of integers $n_k, m_k$ such that $\\sigma(n_k) = \\sigma(m_k)$ for all $k \\geq 1$ and $n_k/m_k \\to \\alpha$?\n\n**Answer: YES** (Pollack, 2015)\n\nThe result also holds for all $\\alpha > 0$ by symmetry ($\\alpha < 1$ case: swap $n$ and $m$).\n\nErdős noted that the analogous result for $\\varphi(n)$ is 'easy to prove.'",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **σ from Mathlib**: Defines $\\sigma(n) = \\texttt{ArithmeticFunction.sigma 1 n}$, leveraging Mathlib's arithmetic function infrastructure. Axiomatizes key properties: values at $1$, primes, prime powers, and multiplicativity.\n\n2. **Problem Formalization**: Defines `IsSigmaPair` ($\\sigma(n) = \\sigma(m)$) and `SigmaSequenceConvergingTo α` using Lean's filter-based `Tendsto` for convergence.\n\n3. **Pollack's Theorem**: Axiomatized as `pollack_2015`. The main result `erdos_823_solved` is **proved** as a direct corollary.\n\n4. **Concrete Examples**: Three $\\sigma$-pairs are axiomatized: $(14, 15)$, $(206, 210)$, $(957, 958)$. Ratios verified by `native_decide`.\n\n5. **Totient Analogy**: Defines $\\varphi$ via `ArithmeticFunction.totient` and axiomatizes the 'easy' $\\varphi$ result. Examples: $\\varphi(1) = \\varphi(2)$, $\\varphi(3) = \\varphi(4) = \\varphi(6)$.\n\n6. **Fiber Structure**: Defines `sigmaFiber` and axiomatizes unbounded fibers, positive density of $\\sigma$-values, and positive density of multi-preimage values.\n\n7. **Summary**: `erdos_823_statement` is **proved** as a conjunction of the $\\sigma$ and $\\varphi$ results.",
     "keyInsights": [
-      "σ-pairs are surprisingly common (σ(14) = σ(15), σ(206) = σ(210))",
-      "The multiplicativity σ(mn) = σ(m)σ(n) for coprime m,n enables constructions",
-      "Fibers σ⁻¹(m) can be arbitrarily large",
-      "The analogous φ result is 'easy' due to even more abundant φ-pairs",
-      "Many even numbers are achieved as σ values"
+      "**Multiplicativity is the engine**: $\\sigma(mn) = \\sigma(m)\\sigma(n)$ for coprime $m, n$ allows building $\\sigma$-pairs with controlled ratios. Given a pair $(a, b)$ with $\\sigma(a) = \\sigma(b)$, multiplying by coprime factors $c$ gives $(ac, bc)$ with $\\sigma(ac) = \\sigma(a)\\sigma(c) = \\sigma(b)\\sigma(c) = \\sigma(bc)$ — the same $\\sigma$-value at ratio $a/b$. Different coprime multipliers generate different ratios",
+      "**φ is easy, σ is hard**: For $\\varphi$, the identity $\\varphi(2n) = \\varphi(n)$ for odd $n$ gives trivial pairs $(n, 2n)$ at ratio $1/2$. No analogous identity exists for $\\sigma$: $\\sigma(2n) = 3\\sigma(n)$ only when $\\gcd(2, n) = 1$, and this changes the $\\sigma$-value rather than preserving it. Pollack's proof must work harder to find $\\sigma$-preserving modifications",
+      "**Fiber density is the key input**: The positive density of $\\{m : |\\sigma^{-1}(m)| \\geq 2\\}$ is what makes the construction possible. This density result (Erdős 1959, refined by Pomerance and others) ensures that $\\sigma$-pairs are abundant enough to approximate any real number via ratios",
+      "**The $14, 15$ coincidence reveals structure**: $\\sigma(14) = (1+2)(1+7) = 24 = (1+3)(1+5) = \\sigma(15)$. This works because the products $(1+p_1)(1+p_2)$ can equal each other for different prime pairs — a consequence of the rich factorization structure of integers near $\\sigma$-values",
+      "**Non-constructive vs explicit**: Pollack's proof is existential — it shows sequences exist without giving a formula. For specific $\\alpha$ (e.g., $\\alpha = \\sqrt{2}$), explicitly constructing such sequences remains an interesting computational challenge"
     ]
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 28,
+      "endLine": 36,
+      "summary": "Imports `ArithmeticFunction`, `Topology.Basic`, `Topology.Instances.Real`. Opens `ArithmeticFunction`, `Filter`, `Topology` namespaces."
+    },
+    {
       "id": "divisor-basics",
       "title": "Sum of Divisors Basics",
-      "startLine": 1,
-      "endLine": 50,
-      "summary": "Definitions and properties of σ(n)"
+      "startLine": 44,
+      "endLine": 63,
+      "summary": "Defines $\\sigma(n) = \\texttt{ArithmeticFunction.sigma 1 n}$. Axiomatizes: $\\sigma(1) = 1$, $\\sigma(p) = p+1$, $\\sigma(p^k)(p-1) = p^{k+1} - 1$, multiplicativity $\\sigma(mn) = \\sigma(m)\\sigma(n)$ for coprime inputs."
     },
     {
       "id": "main-problem",
       "title": "The Main Problem",
-      "startLine": 51,
-      "endLine": 100,
-      "summary": "σ-pairs and convergent sequences"
+      "startLine": 71,
+      "endLine": 80,
+      "summary": "Defines `IsSigmaPair n m` ($\\sigma(n) = \\sigma(m)$) and `SigmaSequenceConvergingTo α` ($\\exists (n_k), (m_k),\\; \\sigma(n_k) = \\sigma(m_k) \\wedge n_k/m_k \\to \\alpha$)."
     },
     {
       "id": "pollack-theorem",
-      "title": "Pollack's Theorem",
-      "startLine": 101,
-      "endLine": 150,
-      "summary": "Resolution for all α ≥ 1"
+      "title": "Pollack's Theorem (2015)",
+      "startLine": 88,
+      "endLine": 99,
+      "summary": "Axiomatizes `pollack_2015` and **proves** `erdos_823_solved` as a direct corollary."
     },
     {
       "id": "sigma-pairs",
-      "title": "Examples of σ-pairs",
-      "startLine": 151,
-      "endLine": 200,
-      "summary": "Concrete pairs with equal σ values"
+      "title": "Examples of σ-Pairs",
+      "startLine": 107,
+      "endLine": 129,
+      "summary": "Axiomatizes $\\sigma(14) = \\sigma(15) = 24$, $\\sigma(206) = \\sigma(210) = 432$, $\\sigma(957) = \\sigma(958)$. Ratio checks via `native_decide`."
     },
     {
       "id": "totient-analogy",
       "title": "Euler Totient Analogy",
-      "startLine": 201,
-      "endLine": 250,
-      "summary": "The 'easy' φ case noted by Erdős"
+      "startLine": 137,
+      "endLine": 158,
+      "summary": "Defines $\\varphi(n)$ via `ArithmeticFunction.totient`. Axiomatizes the 'easy' $\\varphi$-analogue and examples: $\\varphi(1) = \\varphi(2) = 1$, $\\varphi(3) = \\varphi(4) = \\varphi(6) = 2$."
     },
     {
       "id": "fiber-properties",
-      "title": "Fiber Properties",
-      "startLine": 251,
-      "endLine": 300,
-      "summary": "Structure of preimages under σ"
+      "title": "σ-Fiber Structure",
+      "startLine": 164,
+      "endLine": 176,
+      "summary": "Defines `sigmaFiber m` ($\\sigma^{-1}(m)$). Axiomatizes: $14, 15 \\in \\sigma^{-1}(24)$, fibers can be arbitrarily large, every large even number is a $\\sigma$-value."
+    },
+    {
+      "id": "density-results",
+      "title": "Density Results",
+      "startLine": 183,
+      "endLine": 194,
+      "summary": "Axiomatizes positive density of $\\sigma$-values ($|\\{m \\leq N : \\sigma^{-1}(m) \\neq \\emptyset\\}| \\geq cN$) and positive density of multi-preimage values."
+    },
+    {
+      "id": "computations",
+      "title": "Computational Examples",
+      "startLine": 201,
+      "endLine": 213,
+      "summary": "Verified: $\\sigma(p) = p+1$ for small primes, $\\sigma(6) = 12$, $\\sigma(28) = 56$ (perfect numbers)."
+    },
+    {
+      "id": "key-insight",
+      "title": "Abundance of σ-Pairs",
+      "startLine": 224,
+      "endLine": 228,
+      "summary": "Axiomatizes infinitely many $\\sigma$-pairs $(n, m)$ with $n \\neq m$ — the fundamental enabling fact for Pollack's construction."
+    },
+    {
+      "id": "summary",
+      "title": "Complete Statement (Proved)",
+      "startLine": 259,
+      "endLine": 268,
+      "summary": "`erdos_823_statement`: **proved** conjunction of the $\\sigma$ result (Pollack) and $\\varphi$ result (Erdős)."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #823 was solved affirmatively by Paul Pollack in 2015. For any α ≥ 1, there exist sequences n_k, m_k with σ(n_k) = σ(m_k) and n_k/m_k → α. The proof uses the multiplicativity of σ and abundance of σ-pairs to construct appropriate sequences.",
-    "implications": "The result reveals deep structure in the value distribution of the sum-of-divisors function. It shows that despite σ being determined by prime factorizations, there is enough flexibility to achieve any asymptotic ratio between pairs with equal σ values.",
+    "summary": "This formalization resolves Erdős Problem #823 by axiomatizing Pollack's 2015 theorem and proving the main result as a direct corollary. The file builds the sum-of-divisors function from Mathlib's `ArithmeticFunction.sigma`, defines $\\sigma$-pairs and converging sequences, presents concrete examples ($\\sigma(14) = \\sigma(15) = 24$), formalizes the Euler totient analogy, and develops the fiber structure ($\\sigma^{-1}(m)$ with density results). Two verified proofs package the complete resolution.",
+    "implications": "**Number-Theoretic Significance**\n\n1. **Value Distribution of Multiplicative Functions**: Problem #823 reveals that the image of $\\sigma$ is rich enough to support ratio-approximating sequences — a deep structural property not shared by all multiplicative functions. This connects to the broader study of value distribution initiated by Erdős in the 1930s.\n\n2. **σ vs φ Asymmetry**: The difficulty gap between the $\\sigma$ and $\\varphi$ cases highlights a fundamental asymmetry: $\\varphi(2n) = \\varphi(n)$ for odd $n$ gives $\\varphi$ trivial ratio-$2$ pairs, while $\\sigma$ lacks such identities. This asymmetry recurs throughout multiplicative number theory.\n\n3. **Fiber Structure**: Pollack's approach via $\\sigma$-fibers connects to the broader study of preimage sizes of arithmetic functions. The positive density of multi-preimage values is a quantitative refinement of the classical observation that $\\sigma$ is 'far from injective.'\n\n4. **Connection to Perfect and Amicable Numbers**: The $\\sigma$-fiber at $2n$ contains all perfect numbers. More generally, the rich fiber structure of $\\sigma$ underlies the theory of amicable numbers ($\\sigma(a) - a = b$, $\\sigma(b) - b = a$) and aliquot sequences.\n\n5. **Formal Verification**: The file demonstrates how classical number-theoretic results can be formalized using Mathlib's arithmetic function infrastructure, with `Tendsto` providing a clean formalization of asymptotic ratio convergence.",
     "openQuestions": [
-      "Rate of convergence: How fast can n_k/m_k approach α?",
-      "Explicit constructions for specific α values",
-      "Analogous questions for other multiplicative functions"
+      "How fast can $n_k/m_k$ converge to $\\alpha$? Is there a rate like $|n_k/m_k - \\alpha| = O(1/k)$ or better?",
+      "Can the sequences be made explicit for specific $\\alpha$ (e.g., $\\alpha = \\sqrt{2}$ or $\\alpha = \\pi$)?",
+      "Does the analogous result hold for other multiplicative functions $f$ — what properties of $f$ are needed?",
+      "What is the precise density of the set $\\{m : |\\sigma^{-1}(m)| \\geq 2\\}$? Is it $c + o(1)$ for an explicit $c$?",
+      "Can the Lean formalization be extended to prove some of the axiomatized results (e.g., $\\sigma(14) = 24$ directly from the Mathlib definition)?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enriched all 12 annotations with mathContext (LaTeX), relatedConcepts, and prerequisites for erdos-823 (Equal Sum of Divisors with Arbitrary Ratio)
- Deepened historicalContext with Euclid's perfect numbers, Erdős (1974), Pomerance, and Pollack's 2015 resolution in Mathematika
- Added 7 cross-references to related gallery proofs (erdos-824, erdos-48, erdos-830, perfect-numbers, euler-totient, fundamental-arithmetic, erdos-826)
- Expanded to 11 LaTeX-rich sections covering the full 270-line Lean file
- Added 5 specific open questions about convergence rates, explicit constructions, and generalizations

## Test plan
- [x] `pnpm annotations:build` passes (only expected non-strict axiom→theorem warnings)
- [x] All 12 annotations have mathContext, relatedConcepts, prerequisites
- [x] Cross-references point to existing gallery proofs

🤖 Generated with [Claude Code](https://claude.com/claude-code)