### PR TITLE
enrich: deepen erdos-900 with mathContext, cross-refs, and historical context

### DIFF
--- a/src/data/proofs/erdos-900/annotations.json
+++ b/src/data/proofs/erdos-900/annotations.json
@@ -1,209 +1,146 @@
 [
   {
-    "id": "ann-900-header",
+    "id": "ann-900-1",
     "proofId": "erdos-900",
-    "range": { "startLine": 1, "endLine": 24 },
+    "range": { "startLine": 26, "endLine": 30 },
     "type": "concept",
-    "title": "Problem Overview",
-    "content": "**Erdős Problem #900: Longest Path in Sparse Random Graphs**\n\nThere exists f:(1/2,∞)→ℝ with f(c)→0 as c→1/2 and f(c)→1 as c→∞, such that G(n,cn) has whp a path of length ≥f(c)n.\n\n**Answer**: PROVED (Ajtai-Komlós-Szemerédi 1981)",
-    "significance": "critical"
+    "title": "Imports and Namespace Setup",
+    "content": "Imports all of Mathlib (via `import Mathlib`) and opens the `Erdos900` namespace with `Finset` and `Function` for the definitions. The broad import brings in `SimpleGraph`, `Filter.Tendsto`, `Real.log`, and the full algebraic hierarchy needed for the formalization.",
+    "mathContext": "The `SimpleGraph (Fin n)` type models labeled graphs on $\\{0, \\ldots, n-1\\}$. `Filter.Tendsto` formalizes limits $\\lim_{c \\to 1/2^+} f(c) = 0$ and $\\lim_{c \\to \\infty} f(c) = 1$. `Real.log` provides $\\log n$ for subcritical path bounds.",
+    "significance": "supporting",
+    "relatedConcepts": ["SimpleGraph", "Filter.Tendsto", "Real.log", "Fin"],
+    "prerequisites": ["Lean 4 type system", "Mathlib graph theory"]
   },
   {
-    "id": "ann-900-graph",
+    "id": "ann-900-2",
     "proofId": "erdos-900",
-    "range": { "startLine": 38, "endLine": 39 },
+    "range": { "startLine": 38, "endLine": 52 },
     "type": "definition",
-    "title": "Graph",
-    "content": "**Graph n** = SimpleGraph (Fin n)\n\nA simple undirected graph on n labeled vertices.",
-    "significance": "supporting"
+    "title": "Random Graph Model",
+    "content": "`Graph n` abbreviates `SimpleGraph (Fin n)`. `maxEdges n = \\binom{n}{2}` counts the edges in $K_n$. `ErdosRenyiModel n m` is the type of graphs on $n$ vertices with exactly $m$ edges (the $G(n,m)$ model). `BinomialModel n p` is the $G(n,p)$ model where each edge appears independently with probability $p$. `expectedEdges n p = p \\cdot \\binom{n}{2}$ relates the two models.",
+    "mathContext": "The $G(n, m)$ model: uniform distribution over graphs with $n$ vertices and $m$ edges. The $G(n, p)$ model: each of $\\binom{n}{2}$ edges included independently with probability $p$. For $m = pn$, both models are equivalent in the sparse regime ($p = c/n$) for most monotone properties. When $m = cn$, the average degree is $2c$.",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős-Rényi model", "G(n,m)", "G(n,p)", "SimpleGraph"],
+    "prerequisites": ["SimpleGraph", "Nat.choose", "probability distributions"]
   },
   {
-    "id": "ann-900-erdos-renyi",
+    "id": "ann-900-3",
     "proofId": "erdos-900",
-    "range": { "startLine": 44, "endLine": 46 },
+    "range": { "startLine": 60, "endLine": 74 },
     "type": "definition",
-    "title": "Erdős-Rényi Model",
-    "content": "**G(n, m)**: Random graph with n vertices and exactly m edges.\n\nUniform distribution over all such graphs.",
-    "significance": "critical"
+    "title": "Paths and Path Length",
+    "content": "`IsPath G vs` requires the vertex list `vs` to have no duplicates (`Nodup`) and consecutive vertices to be adjacent in $G$. `pathLength vs = |vs| - 1` counts edges. `longestPathLength G` is the supremum over all path lengths (noncomputable). `HasPathOfLength G k` asserts existence of a path with $\\geq k$ edges.",
+    "mathContext": "A **path** in $G$ is a sequence $v_0, v_1, \\ldots, v_\\ell$ of distinct vertices with $v_i \\sim v_{i+1}$ for all $i$. The **length** $\\ell = |\\text{vs}| - 1$ counts edges. The **longest path problem** is NP-hard in general, but random graphs have well-characterized longest path lengths due to their expansion properties.",
+    "significance": "critical",
+    "relatedConcepts": ["List.Nodup", "SimpleGraph.Adj", "NP-hardness", "graph traversal"],
+    "prerequisites": ["SimpleGraph adjacency", "List operations", "Fin indexing"]
   },
   {
-    "id": "ann-900-path",
+    "id": "ann-900-4",
     "proofId": "erdos-900",
-    "range": { "startLine": 60, "endLine": 63 },
+    "range": { "startLine": 82, "endLine": 93 },
     "type": "definition",
-    "title": "Path",
-    "content": "**IsPath(G, vs)**: A sequence of distinct vertices with consecutive adjacency.\n\nvs.Nodup ∧ ∀ i, G.Adj vs[i] vs[i+1]",
-    "significance": "key"
+    "title": "High Probability Framework",
+    "content": "`WithHighProbability P` asserts $P(n)$ holds with probability $\\to 1$ as $n \\to \\infty$ (placeholder). `probHasProperty n m P` computes the probability that $G(n,m) \\models P$ (sorry — requires measure theory). `WhpInSparseRandom c P` asserts $P$ holds whp in $G(n, \\lfloor cn \\rfloor)$: for all $\\varepsilon > 0$, eventually $\\Pr[P] > 1 - \\varepsilon$.",
+    "mathContext": "**Whp (with high probability):** $\\Pr[\\text{event}] \\to 1$ as $n \\to \\infty$. Formally: $\\forall \\varepsilon > 0,\\; \\exists N,\\; \\forall n \\geq N: \\Pr_{G \\sim G(n, \\lfloor cn \\rfloor)}[P(G)] > 1 - \\varepsilon$. This is the standard asymptotic notion in random graph theory, equivalent to convergence in probability.",
+    "significance": "key",
+    "relatedConcepts": ["convergence in probability", "asymptotic notation", "Filter.Tendsto", "measure theory"],
+    "prerequisites": ["probability theory", "Nat.floor", "Filter.atTop"]
   },
   {
-    "id": "ann-900-path-length",
+    "id": "ann-900-5",
     "proofId": "erdos-900",
-    "range": { "startLine": 65, "endLine": 66 },
+    "range": { "startLine": 101, "endLine": 115 },
     "type": "definition",
-    "title": "Path Length",
-    "content": "**pathLength(vs)** = |vs| - 1 = number of edges in the path.\n\nThe quantity we want to maximize.",
-    "significance": "key"
+    "title": "Giant Component Phase Transition",
+    "content": "`criticalDensity = 1/2` is the threshold for the giant component. Three axioms characterize the transition: `subcritical_forest` ($c < 1/2 \\Rightarrow$ forest whp), `critical_transition` ($c > 1/2 \\Rightarrow$ cycles whp), and `supercritical_giant` ($c > 1/2 \\Rightarrow$ unique giant component of size $\\Theta(n)$). This is the Erdős-Rényi theorem (1960).",
+    "mathContext": "**Phase transition at $c = 1/2$:** For $G(n, cn)$: (1) $c < 1/2$: all components have size $O(\\log n)$, graph is a forest whp. (2) $c = 1/2$: largest component has size $\\Theta(n^{2/3})$. (3) $c > 1/2$: unique **giant component** of size $\\alpha(c) \\cdot n + o(n)$ where $\\alpha(c)$ satisfies $1 - \\alpha = e^{-2c\\alpha}$. The average degree is $2c$, so $c = 1/2$ corresponds to average degree $1$.",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős-Rényi theorem", "giant component", "phase transition", "percolation"],
+    "prerequisites": ["SimpleGraph.IsAcyclic", "SimpleGraph.Connected", "random graph theory"]
   },
   {
-    "id": "ann-900-longest-path",
+    "id": "ann-900-6",
     "proofId": "erdos-900",
-    "range": { "startLine": 68, "endLine": 70 },
+    "range": { "startLine": 123, "endLine": 143 },
     "type": "definition",
-    "title": "Longest Path Length",
-    "content": "**longestPathLength(G)** = sup over all paths in G.\n\nThe central quantity of the problem.",
-    "significance": "critical"
+    "title": "Path Length Function f(c)",
+    "content": "`pathLengthFunction c` returns 0 for $c \\leq 1/2$ and sorry for $c > 1/2$ (the exact function is implicit). Four axioms characterize it: `f_limit_at_half` ($f(c) \\to 0$ as $c \\to 1/2^+$), `f_limit_at_infinity` ($f(c) \\to 1$ as $c \\to \\infty$), `f_monotone` ($f$ is increasing), and `f_range` ($0 < f(c) < 1$ for $c > 1/2$).",
+    "mathContext": "The function $f:(1/2, \\infty) \\to (0,1)$ satisfies: (1) $\\lim_{c \\to 1/2^+} f(c) = 0$: near threshold, paths are sublinear. (2) $\\lim_{c \\to \\infty} f(c) = 1$: dense graphs have nearly Hamiltonian paths. (3) $f$ is monotone increasing. The exact form of $f$ involves the survival probability of a branching process with Poisson$(2c)$ offspring.",
+    "significance": "critical",
+    "relatedConcepts": ["Filter.Tendsto", "nhdsWithin", "branching processes", "survival probability"],
+    "prerequisites": ["Filter.atTop", "nhds", "pathLengthFunction definition"]
   },
   {
-    "id": "ann-900-whp",
+    "id": "ann-900-7",
     "proofId": "erdos-900",
-    "range": { "startLine": 82, "endLine": 84 },
-    "type": "definition",
-    "title": "With High Probability",
-    "content": "**whp**: An event holds with probability → 1 as n → ∞.\n\nStandard notion in probabilistic combinatorics.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-900-whp-sparse",
-    "proofId": "erdos-900",
-    "range": { "startLine": 90, "endLine": 93 },
-    "type": "definition",
-    "title": "Whp in Sparse Random",
-    "content": "**WhpInSparseRandom(c, P)**: P holds whp in G(n, cn).\n\nFor all ε > 0, ∃ N such that n ≥ N ⟹ Prob[P] > 1 - ε.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-900-critical",
-    "proofId": "erdos-900",
-    "range": { "startLine": 101, "endLine": 102 },
-    "type": "definition",
-    "title": "Critical Density",
-    "content": "**c = 1/2**: The threshold for giant component emergence.\n\nAverage degree = 2c, so c = 1/2 means average degree 1.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-900-subcritical",
-    "proofId": "erdos-900",
-    "range": { "startLine": 104, "endLine": 106 },
-    "type": "axiom",
-    "title": "Subcritical Forest",
-    "content": "**c < 1/2**: G(n, cn) is a forest whp.\n\nNo cycles, only trees. Paths are O(log n).",
-    "significance": "key"
-  },
-  {
-    "id": "ann-900-supercritical",
-    "proofId": "erdos-900",
-    "range": { "startLine": 112, "endLine": 115 },
-    "type": "axiom",
-    "title": "Supercritical Giant",
-    "content": "**c > 1/2**: A unique giant component of size Θ(n) emerges.\n\nThis allows for linear-length paths.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-900-path-function",
-    "proofId": "erdos-900",
-    "range": { "startLine": 123, "endLine": 127 },
-    "type": "definition",
-    "title": "Path Length Function",
-    "content": "**f(c)**: The fraction of n achieved by longest path whp.\n\nFor c > 1/2, longest path ≈ f(c)·n.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-900-limit-half",
-    "proofId": "erdos-900",
-    "range": { "startLine": 129, "endLine": 131 },
-    "type": "axiom",
-    "title": "f(c) → 0 at 1/2",
-    "content": "**lim_{c→1/2⁺} f(c) = 0**\n\nNear the threshold, paths are short (o(n)).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-900-limit-inf",
-    "proofId": "erdos-900",
-    "range": { "startLine": 133, "endLine": 135 },
-    "type": "axiom",
-    "title": "f(c) → 1 at ∞",
-    "content": "**lim_{c→∞} f(c) = 1**\n\nDense graphs have nearly Hamiltonian paths.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-900-monotone",
-    "proofId": "erdos-900",
-    "range": { "startLine": 137, "endLine": 139 },
-    "type": "axiom",
-    "title": "f is Monotone",
-    "content": "**f is increasing on (1/2, ∞)**\n\nMore edges → longer paths.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-900-aks",
-    "proofId": "erdos-900",
-    "range": { "startLine": 151, "endLine": 155 },
-    "type": "axiom",
-    "title": "AKS Theorem",
-    "content": "**Ajtai-Komlós-Szemerédi (1981)**:\n\nG(n, cn) has whp a path of length ≥ f(c)·n.\n\nThe main result solving Erdős #900.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-900-tight",
-    "proofId": "erdos-900",
-    "range": { "startLine": 157, "endLine": 160 },
-    "type": "axiom",
-    "title": "AKS Tight",
-    "content": "**Tightness**: The bound f(c)·n is essentially optimal.\n\nLongest path ≈ f(c)·n (up to o(n) error).",
-    "significance": "key"
-  },
-  {
-    "id": "ann-900-subcrit-path",
-    "proofId": "erdos-900",
-    "range": { "startLine": 191, "endLine": 194 },
-    "type": "axiom",
-    "title": "Subcritical Path Length",
-    "content": "**c < 1/2**: Longest path is O(log n).\n\nForests have logarithmic diameter.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-900-hamiltonian",
-    "proofId": "erdos-900",
-    "range": { "startLine": 206, "endLine": 208 },
-    "type": "definition",
-    "title": "Hamiltonian Path",
-    "content": "**IsHamiltonianPath**: Path visiting every vertex exactly once.\n\nThe maximum possible path length = n - 1.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-900-ham-threshold",
-    "proofId": "erdos-900",
-    "range": { "startLine": 214, "endLine": 217 },
-    "type": "axiom",
-    "title": "Hamiltonian Threshold",
-    "content": "**For c ≥ (log n)/2**: G(n, cn) has whp a Hamiltonian path.\n\nThe dense regime where f(c) → 1.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-900-rotation",
-    "proofId": "erdos-900",
-    "range": { "startLine": 241, "endLine": 245 },
-    "type": "axiom",
-    "title": "Rotation-Extension",
-    "content": "**Rotation-extension technique**: Key method in AKS proof.\n\nEither extend path or path already covers all reachable vertices.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-900-conjecture",
-    "proofId": "erdos-900",
-    "range": { "startLine": 253, "endLine": 259 },
-    "type": "definition",
-    "title": "Erdős Conjecture",
-    "content": "**ErdosConjecture900**: ∃ f with the three required properties.\n\n1. f(c) → 0 as c → 1/2\n2. f(c) → 1 as c → ∞\n3. G(n, cn) has whp path ≥ f(c)n",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-900-main",
-    "proofId": "erdos-900",
-    "range": { "startLine": 261, "endLine": 272 },
+    "range": { "startLine": 151, "endLine": 165 },
     "type": "theorem",
-    "title": "Main Result",
-    "content": "**Erdős Problem #900: SOLVED**\n\nThe conjecture is TRUE.\n\nAjtai-Komlós-Szemerédi (1981) proved f(c) exists with all required properties.",
-    "significance": "critical"
+    "title": "Ajtai-Komlós-Szemerédi Theorem",
+    "content": "`aks_theorem` (axiom): for $c > 1/2$, $G(n, cn)$ has whp a path of length $\\geq \\lfloor f(c) \\cdot n \\rfloor$. `aks_tight` (axiom): the bound is tight — longest path $\\leq \\lceil (f(c) + 0.01) \\cdot n \\rceil$ whp. `large_c_almost_hamiltonian` (sorry): for $c > 10$, $f(c) > 0.99$. This is the main result solving Problem #900.",
+    "mathContext": "**AKS Theorem (1981):** For every $c > 1/2$, the longest path in $G(n, cn)$ has length $(f(c) + o(1))n$ whp, where $f(c)$ is determined by the structure of the giant component. The proof uses a **depth-first search** to find a long path, then **rotation-extension** to lengthen it until it covers all reachable vertices in the giant component.",
+    "significance": "critical",
+    "relatedConcepts": ["rotation-extension", "DFS", "giant component structure", "Combinatorica"],
+    "prerequisites": ["pathLengthFunction", "WhpInSparseRandom", "HasPathOfLength"]
+  },
+  {
+    "id": "ann-900-8",
+    "proofId": "erdos-900",
+    "range": { "startLine": 173, "endLine": 183 },
+    "type": "theorem",
+    "title": "Special Cases of f(c)",
+    "content": "Three axioms pinning $f$ at specific values: `f_at_one` ($0.1 < f(1) < 0.9$: at average degree 2, the path covers a positive but non-trivial fraction), `f_at_two` ($f(2) > f(1)$: monotonicity witness), and `f_near_critical` ($f(1/2 + \\varepsilon) < \\varepsilon$ for small $\\varepsilon$: near the threshold, $f$ is sublinear in the perturbation).",
+    "mathContext": "At $c = 1$, the average degree is $2$ and the giant component has size $\\approx 0.796n$ (from $1 - \\alpha = e^{-2\\alpha}$). The longest path covers a fraction $f(1) \\in (0.1, 0.9)$ of $n$. Near the critical point, $f(1/2 + \\varepsilon) \\sim C\\varepsilon$ for small $\\varepsilon > 0$, reflecting the gradual emergence of long paths.",
+    "significance": "supporting",
+    "relatedConcepts": ["giant component size", "survival probability", "critical scaling"],
+    "prerequisites": ["pathLengthFunction", "Filter.Tendsto"]
+  },
+  {
+    "id": "ann-900-9",
+    "proofId": "erdos-900",
+    "range": { "startLine": 191, "endLine": 198 },
+    "type": "theorem",
+    "title": "Subcritical Path Length",
+    "content": "`subcritical_path_length` (axiom): for $c < 1/2$, the longest path in $G(n, cn)$ is $O(\\log n)$ whp. `tree_diameter` (axiom): any connected acyclic graph (tree) on $n$ vertices has diameter $\\leq 2\\lceil \\log n \\rceil$. Together these show that in the subcritical regime, paths are logarithmically bounded.",
+    "mathContext": "For $c < 1/2$, $G(n, cn)$ is a forest whp, so the longest path is bounded by the diameter of the largest tree component. The largest component has size $O(\\log n)$ (Erdős-Rényi), so the longest path is $O(\\log n)$. More precisely, the largest component has size $\\sim \\frac{1}{1-2c} \\log n$ whp.",
+    "significance": "key",
+    "relatedConcepts": ["tree diameter", "component size", "branching process", "Real.log"],
+    "prerequisites": ["subcritical_forest", "SimpleGraph.IsAcyclic", "Real.log"]
+  },
+  {
+    "id": "ann-900-10",
+    "proofId": "erdos-900",
+    "range": { "startLine": 206, "endLine": 222 },
+    "type": "definition",
+    "title": "Hamiltonian Paths and Threshold",
+    "content": "`IsHamiltonianPath G vs` requires `IsPath G vs` with `vs.length = n` (visits every vertex). `HasHamiltonianPath G` existentially asserts one. `komlos_szemeredi_hamiltonian` (axiom): for $m \\geq (\\log n / 2) \\cdot n$, $G(n,m)$ has a Hamiltonian path with probability $> 0.99$. `hamiltonian_threshold` (axiom): the sharp threshold for Hamiltonian paths is at $p \\sim (\\log n)/(2n)$.",
+    "mathContext": "The **Hamiltonian path threshold** in $G(n,p)$ is at $p = (\\log n + \\log\\log n + \\omega(1))/(2n)$, proved by Komlós and Szemerédi (1983). At this density, the minimum degree transitions from 0 to $\\geq 1$, which is necessary and sufficient for Hamiltonicity. This gives the regime where $f(c) \\to 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Hamiltonian path", "Komlós-Szemerédi", "minimum degree", "sharp threshold"],
+    "prerequisites": ["IsPath", "pathLength", "probHasProperty"]
+  },
+  {
+    "id": "ann-900-11",
+    "proofId": "erdos-900",
+    "range": { "startLine": 230, "endLine": 245 },
+    "type": "theorem",
+    "title": "Proof Techniques: DFS, Expansion, Rotation-Extension",
+    "content": "Three axioms encoding the key techniques of the AKS proof: `dfs_path_finding` (DFS finds a longest path), `random_graph_expansion` (for $c > 1/2$, random graphs expand: every set $S$ with $|S| \\leq n/2$ has $\\geq |S|/2$ external neighbors whp), and `rotation_extension` (any path can either be extended or already covers all reachable vertices).",
+    "mathContext": "**Rotation-extension** (Pósa 1976): Given a path $v_0, \\ldots, v_k$, if $v_k$ has a neighbor $v_i$ with $i < k-1$, we can 'rotate' to get $v_0, \\ldots, v_i, v_k, v_{k-1}, \\ldots, v_{i+1}$ — a new path of the same length with endpoint $v_{i+1}$. If $v_{i+1}$ has a neighbor outside the path, we can extend. The **expansion property** ensures that rotations eventually reach new vertices.",
+    "significance": "key",
+    "relatedConcepts": ["Pósa rotation", "vertex expansion", "DFS", "path extension"],
+    "prerequisites": ["IsPath", "SimpleGraph.neighborFinset", "Finset operations"]
+  },
+  {
+    "id": "ann-900-12",
+    "proofId": "erdos-900",
+    "range": { "startLine": 253, "endLine": 272 },
+    "type": "theorem",
+    "title": "Main Result: Erdős Problem #900 Solved",
+    "content": "`ErdosConjecture900` existentially asserts a function $f$ with three properties: $f(c) \\to 0$ at $1/2$, $f(c) \\to 1$ at $\\infty$, and $G(n,cn)$ has whp a path of length $\\geq \\lfloor f(c) n \\rfloor$ for $c > 1/2$. The theorem `erdos_900` proves this by witnessing $f = \\text{pathLengthFunction}$ and combining `f_limit_at_half`, `f_limit_at_infinity`, and `aks_theorem`. This is a verified proof (no sorry).",
+    "mathContext": "$\\text{ErdosConjecture900} :\\equiv \\exists f: \\mathbb{R} \\to \\mathbb{R},\\; \\lim_{c \\to 1/2^+} f(c) = 0 \\wedge \\lim_{c \\to \\infty} f(c) = 1 \\wedge \\forall c > 1/2: G(n, cn) \\text{ has whp path } \\geq f(c)n$. The proof: $\\langle \\text{pathLengthFunction}, \\text{f\\_limit\\_at\\_half}, \\text{f\\_limit\\_at\\_infinity}, \\lambda c\\, hc \\Rightarrow \\text{aks\\_theorem}\\, c\\, hc \\rangle$.",
+    "significance": "critical",
+    "relatedConcepts": ["existential witness", "conjunction introduction", "Ajtai-Komlós-Szemerédi"],
+    "prerequisites": ["pathLengthFunction", "f_limit_at_half", "f_limit_at_infinity", "aks_theorem"]
   }
 ]

--- a/src/data/proofs/erdos-900/meta.json
+++ b/src/data/proofs/erdos-900/meta.json
@@ -66,108 +66,118 @@
       "Axiomatization of the Ajtai-Komlós-Szemerédi theorem",
       "Subcritical regime analysis (O(log n) paths)"
     ],
+    "crossReferences": [
+      {
+        "targetProof": "ramseys-theorem",
+        "relationship": "Ramsey theory and random graph theory are deeply intertwined: the Erdős-Rényi model was partly motivated by probabilistic lower bounds for Ramsey numbers. Both problems concern structure emerging from combinatorial constraints — Ramsey from coloring, random graphs from probability."
+      },
+      {
+        "targetProof": "randomized-maxcut",
+        "relationship": "Both problems study random graphs and the probabilistic method. The randomized MaxCut algorithm exploits the same expansion properties of random graphs that the AKS theorem uses to find long paths. Both demonstrate that random graphs have near-optimal combinatorial properties."
+      }
+    ],
     "relatedProblems": []
   },
   "overview": {
-    "historicalContext": "**Random Graphs and Long Paths**\n\nThe Erdős-Rényi random graph G(n, m) is the uniform distribution over graphs with n vertices and m edges. When m = cn for constant c, this is the 'sparse' regime.\n\n**Phase Transition at c = 1/2**: Below this threshold, the graph is a forest (whp). Above it, a 'giant component' of size Θ(n) emerges.\n\n**Erdős's Question**: How long is the longest path in G(n, cn)? The answer depends on c:\n- For c < 1/2: O(log n) (logarithmic)\n- For c > 1/2: Θ(n) (linear in n)\n\n**The Solution**: Ajtai, Komlós, and Szemerédi (1981) proved there exists f(c) such that the longest path has length approximately f(c)·n, where f(c) → 0 as c → 1/2 and f(c) → 1 as c → ∞.",
-    "problemStatement": "**Problem Statement**\n\nProve: There exists a function f:(1/2, ∞) → ℝ such that:\n1. f(c) → 0 as c → 1/2⁺\n2. f(c) → 1 as c → ∞\n3. G(n, cn) has (with high probability) a path of length at least f(c)·n\n\n**Answer**: PROVED by Ajtai-Komlós-Szemerédi (1981)\n\nThe function f(c) captures the phase transition from logarithmic to linear path lengths.",
-    "proofStrategy": "**The Formalization**\n\n1. Defines the Erdős-Rényi model G(n, m)\n2. Defines paths and path length\n3. Sets up probabilistic framework (whp events)\n4. States the giant component phase transition at c = 1/2\n5. Defines the path length function f(c)\n6. States its limiting behavior (→ 0 at 1/2, → 1 at ∞)\n7. Axiomatizes the AKS theorem\n8. Covers subcritical regime (O(log n) paths)\n9. Covers Hamiltonian path threshold",
+    "historicalContext": "**Erdős Problem #900: Longest Path in Sparse Random Graphs**\n\nThe study of random graphs began with the seminal 1960 paper of Paul Erdős and Alfréd Rényi, \"On the evolution of random graphs,\" which introduced the $G(n, m)$ model and discovered the **giant component phase transition** at $m = n/2$ (average degree 1). Below this threshold, $G(n, cn)$ is a forest of small trees; above it, a unique giant component of size $\\Theta(n)$ emerges.\n\nErdős asked (c. 1982, [Er82e]): how long is the longest path in $G(n, cn)$ when $c > 1/2$? The giant component has $\\Theta(n)$ vertices, but having many vertices does not guarantee long paths — the component could be bushy rather than elongated.\n\n**Miklós Ajtai, János Komlós, and Endre Szemerédi** resolved this in 1981 in the first volume of *Combinatorica*. They proved there exists a function $f:(1/2, \\infty) \\to (0,1)$ such that $G(n, cn)$ has whp a path of length $(f(c) + o(1))n$, with $f(c) \\to 0$ as $c \\to 1/2^+$ and $f(c) \\to 1$ as $c \\to \\infty$.\n\nThe proof introduced the **rotation-extension technique** (building on Pósa's 1976 method): start with a DFS path, then repeatedly rotate endpoints and extend until the path covers all reachable vertices. The **expansion property** of random graphs — every small vertex set has many external neighbors — ensures this process terminates with a path of length proportional to the giant component.\n\nThe Hamiltonian path threshold was later determined by Komlós and Szemerédi (1983): $G(n, p)$ has a Hamiltonian path whp when $p = (\\log n + \\log\\log n + \\omega(1))/(2n)$, connecting to the minimum degree condition.\n\nThe AKS theorem exemplifies the **probabilistic method** in combinatorics: random graphs achieve near-optimal path lengths, answering a question about deterministic graph structure through probability.",
+    "problemStatement": "**Problem Statement (Solved)**\n\nProve: There exists a function $f:(1/2, \\infty) \\to \\mathbb{R}$ such that:\n1. $f(c) \\to 0$ as $c \\to 1/2^+$\n2. $f(c) \\to 1$ as $c \\to \\infty$\n3. $G(n, cn)$ has (with high probability) a path of length $\\geq f(c) \\cdot n$\n\n**Answer:** PROVED by Ajtai-Komlós-Szemerédi (1981). The function $f(c)$ captures the phase transition from logarithmic to linear path lengths at the giant component threshold $c = 1/2$.",
+    "proofStrategy": "**Formalization Approach**\n\nThe formalization builds from graph definitions through the probabilistic framework to the main theorem:\n\n1. **Random Graph Model (Lines 38–52):** Defines `Graph n = SimpleGraph (Fin n)`, the $G(n,m)$ model as a subtype with exactly $m$ edges, and the $G(n,p)$ model.\n\n2. **Paths (Lines 60–74):** Defines `IsPath G vs` (distinct vertices with consecutive adjacency), `pathLength`, `longestPathLength` (supremum), and `HasPathOfLength`.\n\n3. **Probabilistic Framework (Lines 82–93):** Defines `WithHighProbability` and `WhpInSparseRandom c P`: probability $\\to 1$ as $n \\to \\infty$ in $G(n, \\lfloor cn \\rfloor)$.\n\n4. **Phase Transition (Lines 101–115):** Axiomatizes the giant component: subcritical forest, critical transition, supercritical giant of size $\\Theta(n)$.\n\n5. **Path Length Function (Lines 123–143):** Defines $f(c)$ with four axioms: limits at $1/2$ and $\\infty$, monotonicity, and range $(0,1)$.\n\n6. **AKS Theorem (Lines 151–165):** Axiomatizes the main result: path $\\geq f(c)n$ whp, with tightness.\n\n7. **Special Cases and Techniques (Lines 167–245):** Specific values of $f$, subcritical $O(\\log n)$ bound, Hamiltonian threshold, and rotation-extension.\n\n8. **Main Result (Lines 253–272):** `erdos_900` proves `ErdosConjecture900` by witnessing `pathLengthFunction` — a verified proof combining axioms.",
     "keyInsights": [
-      "The threshold c = 1/2 corresponds to average degree 1 (edge of connectivity)",
-      "Below c = 1/2, the graph is a forest and paths are O(log n)",
-      "Above c = 1/2, the giant component allows linear-length paths",
-      "f(c) is monotone increasing from 0 to 1 on (1/2, ∞)",
-      "The rotation-extension technique is key to the AKS proof",
-      "For very large c (dense graphs), paths are nearly Hamiltonian"
+      "**Phase Transition at $c = 1/2$:** The threshold corresponds to average degree $1$ in $G(n, cn)$. Below it, the graph is a forest with $O(\\log n)$ paths. Above it, the giant component of size $\\alpha(c) \\cdot n$ (where $1 - \\alpha = e^{-2c\\alpha}$) supports paths of length $f(c) \\cdot n$. This is a continuous phase transition: $f(c) \\to 0$ smoothly as $c \\to 1/2^+$.",
+      "**Rotation-Extension Technique:** Pósa (1976) introduced the key idea: given a path $v_0, \\ldots, v_k$, if $v_k$ is adjacent to some $v_i$ with $i < k-1$, 'rotate' to get a new path with endpoint $v_{i+1}$. If $v_{i+1}$ has a neighbor outside the path, extend. AKS showed that the expansion property of random graphs guarantees this process reaches linear length.",
+      "**Branching Process Connection:** The exact form of $f(c)$ relates to the survival probability of a Galton-Watson branching process with Poisson$(2c)$ offspring. The giant component size $\\alpha(c)$ satisfies the same equation, and $f(c) \\leq \\alpha(c)$ with equality conjectured for some models.",
+      "**From Logarithmic to Hamiltonian:** The full picture spans three regimes: (1) $c < 1/2$: paths $O(\\log n)$ in trees. (2) $1/2 < c < O(\\log n)$: paths $f(c) \\cdot n$ with $0 < f(c) < 1$. (3) $c \\geq (\\log n)/2$: Hamiltonian paths exist (Komlós-Szemerédi 1983). The AKS function $f$ interpolates continuously between regimes (1) and (3).",
+      "**Verified Main Theorem:** The proof of `erdos_900` is fully verified: it witnesses `pathLengthFunction` and combines the three axiomatized properties via an exact triple `⟨f_limit_at_half, f_limit_at_infinity, fun c hc => aks_theorem c hc⟩`. The 3 sorries are in `probHasProperty` (measure theory), `pathLengthFunction` (implicit construction), and `large_c_almost_hamiltonian` (quantitative bound)."
     ]
   },
   "sections": [
     {
       "id": "random-graph-model",
       "title": "Random Graph Model",
-      "summary": "Erdős-Rényi G(n, m)",
+      "summary": "Defines `Graph n = SimpleGraph (Fin n)`, `maxEdges n = \\binom{n}{2}$, and two random graph models: $G(n,m)$ (exactly $m$ edges) and $G(n,p)$ (each edge independently with probability $p$). Relates them via `expectedEdges n p = p \\cdot \\binom{n}{2}$.",
       "startLine": 32,
       "endLine": 52
     },
     {
       "id": "paths",
       "title": "Paths in Graphs",
-      "summary": "Path definition and length",
+      "summary": "Defines `IsPath G vs` (distinct vertices, consecutive adjacency), `pathLength vs = |vs| - 1$, `longestPathLength G = \\sup\\{\\text{pathLength}(vs) : \\text{IsPath}(G, vs)\\}$, and `HasPathOfLength G k`.",
       "startLine": 54,
       "endLine": 74
     },
     {
       "id": "probability",
       "title": "High Probability Events",
-      "summary": "Whp framework for random graphs",
+      "summary": "Defines `WithHighProbability P` and `WhpInSparseRandom c P`: $\\forall \\varepsilon > 0,\\; \\exists N,\\; \\forall n \\geq N: \\Pr_{G(n, \\lfloor cn \\rfloor)}[P(G)] > 1 - \\varepsilon$. Includes `probHasProperty` (sorry — requires measure theory).",
       "startLine": 76,
       "endLine": 93
     },
     {
       "id": "giant-component",
       "title": "The Giant Component Threshold",
-      "summary": "Phase transition at c = 1/2",
+      "summary": "Critical density $c = 1/2$. Axiomatizes: $c < 1/2 \\Rightarrow$ forest whp, $c > 1/2 \\Rightarrow$ cycles whp, $c > 1/2 \\Rightarrow$ unique giant component of size $\\geq \\alpha n$ for some $\\alpha > 0$.",
       "startLine": 95,
       "endLine": 115
     },
     {
       "id": "path-function",
       "title": "The Path Length Function",
-      "summary": "f(c) and its properties",
+      "summary": "Defines `pathLengthFunction c` with four axioms: $\\lim_{c \\to 1/2^+} f(c) = 0$, $\\lim_{c \\to \\infty} f(c) = 1$, $f$ monotone increasing, $0 < f(c) < 1$ for $c > 1/2$. Uses `Filter.Tendsto` and `nhdsWithin`.",
       "startLine": 117,
       "endLine": 143
     },
     {
       "id": "aks-theorem",
       "title": "The Ajtai-Komlós-Szemerédi Theorem",
-      "summary": "Main result solving Erdős #900",
+      "summary": "Axiomatizes `aks_theorem`: $G(n, cn)$ has whp path $\\geq \\lfloor f(c)n \\rfloor$ for $c > 1/2$. States tightness (`aks_tight`) and `large_c_almost_hamiltonian` ($c > 10 \\Rightarrow f(c) > 0.99$, sorry).",
       "startLine": 145,
       "endLine": 165
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "summary": "Behavior at specific c values",
+      "summary": "Pinpoints $f$ at specific values: $0.1 < f(1) < 0.9$ (average degree 2), $f(2) > f(1)$ (monotonicity witness), $f(1/2 + \\varepsilon) < \\varepsilon$ for small $\\varepsilon$ (critical scaling).",
       "startLine": 167,
       "endLine": 183
     },
     {
       "id": "subcritical",
       "title": "The Subcritical Regime",
-      "summary": "O(log n) paths below threshold",
+      "summary": "For $c < 1/2$: longest path is $O(\\log n)$ whp (`subcritical_path_length`). Trees have diameter $\\leq 2\\lceil \\log n \\rceil$ (`tree_diameter`).",
       "startLine": 185,
       "endLine": 198
     },
     {
       "id": "hamiltonian",
       "title": "Hamiltonian Paths",
-      "summary": "The dense regime",
+      "summary": "Defines `IsHamiltonianPath` (path visiting all $n$ vertices). Axiomatizes `komlos_szemeredi_hamiltonian`: for $m \\geq (\\log n / 2) \\cdot n$, Hamiltonian path exists with high probability. Sharp threshold at $p \\sim (\\log n)/(2n)$.",
       "startLine": 200,
       "endLine": 222
     },
     {
       "id": "techniques",
       "title": "Proof Techniques",
-      "summary": "DFS, expansion, rotation-extension",
+      "summary": "Axiomatizes three AKS tools: `dfs_path_finding` (DFS finds longest path), `random_graph_expansion` ($|N(S) \\setminus S| \\geq |S|/2$ for $|S| \\leq n/2$ whp), and `rotation_extension` (Pósa's rotate-or-extend dichotomy).",
       "startLine": 224,
       "endLine": 245
     },
     {
       "id": "main-result",
       "title": "Main Result",
-      "summary": "Erdős Problem #900 is SOLVED",
+      "summary": "Defines `ErdosConjecture900` and proves `erdos_900`: witnesses $f = \\text{pathLengthFunction}$ with $\\langle \\text{f\\_limit\\_at\\_half}, \\text{f\\_limit\\_at\\_infinity}, \\text{aks\\_theorem} \\rangle$. Verified proof (no sorry in the main theorem).",
       "startLine": 247,
       "endLine": 283
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #900 asks for a function f(c) characterizing the longest path length in sparse random graphs G(n, cn). SOLVED by Ajtai-Komlós-Szemerédi (1981) who proved f(c) exists with f(c)→0 as c→1/2 and f(c)→1 as c→∞, establishing the phase transition from logarithmic to linear path lengths.",
-    "implications": "**Theoretical Significance**\n\n1. **Phase Transitions**: Demonstrates sharp transition at c = 1/2 for path lengths\n\n2. **Random Graph Theory**: Foundational result on structure of sparse random graphs\n\n3. **Probabilistic Method**: Showcases power of probabilistic combinatorics\n\n4. **Hamiltonian Path Theory**: Connects to threshold for spanning paths",
+    "summary": "Erdős Problem #900 asks for a function $f(c)$ characterizing the longest path length in sparse random graphs $G(n, cn)$. SOLVED by Ajtai-Komlós-Szemerédi (1981): $f$ exists with $f(c) \\to 0$ as $c \\to 1/2^+$ and $f(c) \\to 1$ as $c \\to \\infty$. The formalization has 3 sorry statements (in `probHasProperty`, `pathLengthFunction` for $c > 1/2$, and `large_c_almost_hamiltonian`), with the main theorem `erdos_900` fully verified from axioms.",
+    "implications": "**Broader Mathematical Connections**\n\n1. **Random Graph Theory:** The AKS theorem is a cornerstone result in the theory of random graphs, establishing that $G(n, cn)$ has near-optimal path lengths for $c > 1/2$. It demonstrated that the giant component is not only large but also well-connected enough for linear-length paths.\n\n2. **Phase Transitions in Combinatorics:** The sharp transition at $c = 1/2$ from logarithmic to linear path lengths exemplifies the phenomenon of phase transitions in discrete mathematics, analogous to percolation transitions in statistical physics. The function $f(c)$ is the order parameter.\n\n3. **Algorithmic Implications:** The rotation-extension technique provides an efficient algorithm for finding long paths in random graphs, running in polynomial expected time. This connects to the broader question of average-case complexity for NP-hard problems.\n\n4. **Extremal Graph Theory:** The problem connects to Turán-type questions: what is the minimum number of edges guaranteeing a path of length $k$? Random graphs show that $\\Theta(n)$ edges suffice for paths of length $\\Theta(n)$, which is tight.\n\n5. **Branching Processes:** The giant component structure is intimately linked to Galton-Watson branching processes with Poisson offspring. The survival probability of such processes determines both the giant component size $\\alpha(c)$ and bounds the path length function $f(c)$.",
     "openQuestions": [
-      "Exact formula for f(c)?",
-      "Tight concentration bounds on longest path length?",
-      "Extension to other random graph models (e.g., preferential attachment)?",
-      "Algorithmic aspects: finding long paths efficiently"
+      "What is the exact formula for $f(c)$? Is it expressible in terms of the survival probability of Poisson$(2c)$ branching processes?",
+      "What are tight concentration bounds for the longest path length around $f(c) \\cdot n$? Is the deviation $O(\\sqrt{n})$ or smaller?",
+      "How does the longest path behave at the critical point $c = 1/2$ exactly? The largest component has size $\\Theta(n^{2/3})$ — what fraction does the longest path cover?",
+      "Can the AKS result be extended to other random graph models (e.g., random regular graphs, preferential attachment, geometric random graphs)?",
+      "What is the algorithmic complexity of finding the longest path in $G(n, cn)$? Can the rotation-extension approach be made to run in $O(n)$ expected time?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Consolidate 21 annotations to 12 comprehensive ones with full mathContext, relatedConcepts, prerequisites
- Fix all invalid annotation types (axiom → theorem, no invalid significance values)
- Deepen historicalContext with Erdős-Rényi 1960, AKS 1981, Pósa rotation-extension, Komlós-Szemerédi 1983
- Add cross-references to ramseys-theorem and randomized-maxcut
- Add LaTeX to all 11 section summaries
- Expand keyInsights with branching process connections and phase transition analysis
- Deepen openQuestions and conclusion with 5 specific mathematical connections

## Test plan
- [x] `pnpm annotations:build` passes (no erdos-900 warnings)
- [x] All 12 annotations have mathContext, relatedConcepts, prerequisites
- [x] Cross-references point to valid gallery entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)