### PR TITLE
enrich: deepen erdos-853 with mathContext, cross-refs, and historical context

### DIFF
--- a/src/data/proofs/erdos-853/annotations.json
+++ b/src/data/proofs/erdos-853/annotations.json
@@ -1,74 +1,122 @@
 [
   {
-    "id": "prime-gap-def",
+    "id": "erdos-853-imports",
     "proofId": "erdos-853",
-    "range": { "startLine": 35, "endLine": 35 },
+    "type": "concept",
+    "range": { "startLine": 1, "endLine": 6 },
+    "title": "Imports and Setup",
+    "content": "Imports `Nat.Prime.Basic` and `Nat.Prime.Nth` for `Nat.nth Nat.Prime` (the $n$-th prime), `Finset.Basic` for finite set operations, `Real.Basic` and `Log.Basic` for the strong conjecture statement involving $\\log x$, and `Tactic` for `omega` and `rcases`.",
+    "significance": "supporting",
+    "mathContext": "The critical import is `Nat.Prime.Nth` which provides `Nat.nth Nat.Prime n` — the $n$-th element of the (infinite) set of primes, along with `Nat.nth_strictMono` for strict monotonicity and `Nat.nth_prime_zero_eq_two`/`Nat.nth_prime_one_eq_three` for concrete values.",
+    "relatedConcepts": ["Nat.nth", "Nat.Prime", "StrictMono", "Real.log"],
+    "prerequisites": ["Lean 4 import system", "Mathlib prime enumeration API"]
+  },
+  {
+    "id": "erdos-853-nthprime",
+    "proofId": "erdos-853",
     "type": "definition",
-    "title": "Prime Gap d_n",
-    "content": "d_n = p_{n+1} - p_n, the difference between consecutive primes. For n ≥ 2, d_n is always even. The sequence starts: 1, 2, 2, 4, 2, 4, 2, 4, 6, 2, ...",
-    "significance": "high"
+    "range": { "startLine": 42, "endLine": 46 },
+    "title": "Prime Enumeration and Gap Function",
+    "content": "`nthPrime n` = `Nat.nth Nat.Prime n` gives the 0-indexed prime sequence ($p_0 = 2, p_1 = 3, p_2 = 5, \\ldots$). `primeGap n` = $p_{n+1} - p_n$ is the $n$-th prime gap. Both are `noncomputable` since `Nat.nth` uses classical choice.",
+    "significance": "critical",
+    "mathContext": "The prime gap sequence $d_n = p_{n+1} - p_n$ begins $1, 2, 2, 4, 2, 4, 2, 4, 6, 2, 6, \\ldots$ (OEIS A001223). The first gap $d_0 = 3 - 2 = 1$ is the only odd gap; for $n \\ge 1$, both $p_n$ and $p_{n+1}$ are odd primes $\\ge 3$, so $d_n$ is even. The prime number theorem implies $d_n \\sim \\log p_n$ on average.",
+    "relatedConcepts": ["prime enumeration", "prime gaps", "OEIS A001223", "prime number theorem"],
+    "prerequisites": ["Nat.nth", "Nat.Prime", "natural number subtraction"]
   },
   {
-    "id": "gap-set-def",
+    "id": "erdos-853-structural",
     "proofId": "erdos-853",
-    "range": { "startLine": 38, "endLine": 39 },
+    "type": "theorem",
+    "range": { "startLine": 48, "endLine": 111 },
+    "title": "Structural Theorems from Mathlib (9 Results)",
+    "content": "Nine theorems proved from Mathlib: `nthPrime_prime` (each $p_n$ is prime), `nthPrime_strictMono` (the sequence is strictly increasing), `primeGap_pos` ($d_n > 0$ by strict monotonicity), `nthPrime_zero` ($p_0 = 2$), `nthPrime_one` ($p_1 = 3$), `primeGap_zero` ($d_0 = 1$), `primeGap_even` ($2 \\mid d_n$ for $n \\ge 1$), `primeGap_ge_two` ($d_n \\ge 2$ for $n \\ge 1$), `nthPrime_mono` (monotonicity).",
+    "significance": "key",
+    "mathContext": "The proof of `primeGap_even` is the most substantial: it shows $p_n$ and $p_{n+1}$ are both odd for $n \\ge 1$ (since primes $\\ge 3$ are odd, and $n \\ge 1 \\Rightarrow p_n \\ge p_1 = 3$), hence their difference is even. The key Mathlib lemma is `Nat.Prime.eq_one_or_self_of_dvd`: if $p$ is prime and $d \\mid p$, then $d = 1$ or $d = p$. Applied with $d = 2$, this forces $p = 2$ (impossible since $p \\ge 3$) or $2 \\nmid p$.",
+    "relatedConcepts": ["parity of primes", "StrictMono", "Nat.Prime.eq_one_or_self_of_dvd", "omega tactic"],
+    "prerequisites": ["nthPrime definition", "Nat.nth_strictMono", "Nat.nth_prime_zero_eq_two"]
+  },
+  {
+    "id": "erdos-853-gapset",
+    "proofId": "erdos-853",
     "type": "definition",
-    "title": "Gap Set",
-    "content": "The set of all prime gap values d_n for primes p_n ≤ x. As x grows, this set accumulates more even integers. The question is whether it eventually contains all even numbers.",
-    "significance": "medium"
+    "range": { "startLine": 116, "endLine": 117 },
+    "title": "Gap Set Definition",
+    "content": "`gapSet x` is the set of prime gap values $\\{d_n : n \\ge 1, p_n \\le x\\}$. Restricting to $n \\ge 1$ ensures all elements are even. As $x$ grows, more gap values are observed.",
+    "significance": "critical",
+    "mathContext": "The gap set $G(x) = \\{p_{n+1} - p_n : n \\ge 1, p_n \\le x\\}$ grows with $x$. The central question is whether $G(x) \\to 2\\mathbb{N}_{\\ge 1}$ as $x \\to \\infty$ — i.e., whether every even integer eventually appears as a prime gap. Computational data (OEIS A390769) shows that $G(x)$ grows quite slowly: even for $x \\sim 10^{18}$, some moderately-sized even gaps remain unobserved.",
+    "relatedConcepts": ["prime gap census", "OEIS A390769", "gap completeness", "set accumulation"],
+    "prerequisites": ["primeGap definition", "nthPrime", "Set comprehension in Lean"]
   },
   {
-    "id": "r-function",
+    "id": "erdos-853-gapset-props",
     "proofId": "erdos-853",
-    "range": { "startLine": 44, "endLine": 44 },
-    "type": "definition",
-    "title": "Smallest Missing Gap r(x)",
-    "content": "r(x) is the smallest positive even integer not yet observed as a prime gap for primes ≤ x. If all even gaps eventually appear, r(x) → ∞.",
-    "significance": "high"
-  },
-  {
-    "id": "r-minimality",
-    "proofId": "erdos-853",
-    "range": { "startLine": 52, "endLine": 54 },
     "type": "theorem",
-    "title": "Minimality of r(x)",
-    "content": "Every even integer 2 ≤ t < r(x) appears as some prime gap d_n with p_n ≤ x. The function r(x) pinpoints exactly where the gap census becomes incomplete.",
-    "significance": "medium"
+    "range": { "startLine": 119, "endLine": 140 },
+    "title": "Gap Set Properties (4 Theorems)",
+    "content": "Four properties proved: `gapSet_mono` ($x \\le y \\Rightarrow G(x) \\subseteq G(y)$, monotonicity), `gapSet_even` (all elements divisible by 2), `gapSet_pos` (all elements positive), `gapSet_ge_two` (all elements $\\ge 2$). These follow directly from the structural theorems on `primeGap`.",
+    "significance": "key",
+    "mathContext": "The monotonicity $G(x) \\subseteq G(y)$ for $x \\le y$ is immediate: if a gap $d_n$ is witnessed by a prime $p_n \\le x$, then $p_n \\le y$ also. Combined with evenness, this shows $G(x)$ is a growing subset of $2\\mathbb{N}_{\\ge 1}$. The question is whether it is eventually all of $2\\mathbb{N}_{\\ge 1}$.",
+    "relatedConcepts": ["monotone set families", "prime gap parity", "set inclusion", "filter convergence"],
+    "prerequisites": ["gapSet definition", "primeGap_even", "primeGap_pos", "primeGap_ge_two"]
   },
   {
-    "id": "weak-conjecture",
+    "id": "erdos-853-r-axioms",
     "proofId": "erdos-853",
-    "range": { "startLine": 59, "endLine": 60 },
-    "type": "conjecture",
-    "title": "Weak Conjecture: r(x) → ∞",
-    "content": "Every even gap size eventually appears among prime gaps. No even number is permanently missing from the gap census. This is the basic form of Problem #853.",
-    "significance": "high"
-  },
-  {
-    "id": "strong-conjecture",
-    "proofId": "erdos-853",
-    "range": { "startLine": 64, "endLine": 66 },
-    "type": "conjecture",
-    "title": "Strong Conjecture: r(x)/log x → ∞",
-    "content": "The smallest missing gap grows faster than log x. This is much stronger than the weak form and would give quantitative information about how quickly the gap census becomes complete.",
-    "significance": "high"
-  },
-  {
-    "id": "maynard-tao",
-    "proofId": "erdos-853",
-    "range": { "startLine": 75, "endLine": 77 },
     "type": "theorem",
-    "title": "Maynard–Tao Bounded Gaps",
-    "content": "There are infinitely many n with d_n ≤ 246. Some small even gap (possibly 2, the twin prime gap) appears infinitely often. This guarantees the gap set grows but says little about completeness.",
-    "significance": "medium"
+    "range": { "startLine": 147, "endLine": 157 },
+    "title": "Axiomatized r(x) Function",
+    "content": "The function $r(x)$ is axiomatized with four properties: `r(x)` exists (as an axiom), `r_even_pos` ($r(x) \\ge 2$ and $r(x)$ is even for $x \\ge 3$), `r_not_gap` ($r(x) \\notin G(x)$), and `r_minimal` (every even $t$ with $2 \\le t < r(x)$ belongs to $G(x)$).",
+    "significance": "critical",
+    "mathContext": "The axiomatization captures $r(x) = \\min\\{t \\in 2\\mathbb{N}_{\\ge 1} : t \\notin G(x)\\}$. This is well-defined because $G(x)$ is finite (there are only finitely many primes $\\le x$) and $2\\mathbb{N}_{\\ge 1}$ is infinite. The minimality axiom `r_minimal` is crucial: it says $G(x) \\supseteq \\{2, 4, 6, \\ldots, r(x) - 2\\}$, so all even numbers below $r(x)$ appear as gaps.",
+    "relatedConcepts": ["well-ordering principle", "minimum of complement", "axiomatization vs definition", "finite vs infinite sets"],
+    "prerequisites": ["gapSet definition", "gapSet properties", "natural number well-ordering"]
   },
   {
-    "id": "cramer-bound",
+    "id": "erdos-853-r-monotone",
     "proofId": "erdos-853",
-    "range": { "startLine": 81, "endLine": 83 },
     "type": "theorem",
-    "title": "Cramér Conjecture Bound",
-    "content": "Cramér's conjecture (largest gap below x is O((log x)²)) implies r(x) ≤ O((log x)²) if all smaller gaps also appear. This gives a conditional upper bound consistent with the strong form.",
-    "significance": "medium"
+    "range": { "startLine": 163, "endLine": 173 },
+    "title": "Monotonicity and Upper Bound of r(x)",
+    "content": "`r_monotone` proves $x \\le y \\Rightarrow r(x) \\le r(y)$: if $r(y) < r(x)$, then by minimality of $r(x)$, we'd have $r(y) \\in G(x) \\subseteq G(y)$, contradicting $r(y) \\notin G(y)$. The trivial upper bound $r(x) \\le x$ is axiomatized.",
+    "significance": "key",
+    "mathContext": "The proof of `r_monotone` is a clean example of proof by contradiction using the interplay of `r_minimal`, `gapSet_mono`, and `r_not_gap`. The bound $r(x) \\le x$ is weak but non-trivial: it requires knowing that the interval $[2, x]$ contains more even numbers than $G(x)$ has elements, which follows from Bertrand's postulate (giving at least $\\Theta(x/\\log x)$ primes).",
+    "relatedConcepts": ["proof by contradiction", "monotone functions", "Bertrand's postulate", "trivial bounds"],
+    "prerequisites": ["r axioms", "gapSet_mono", "push_neg tactic"]
+  },
+  {
+    "id": "erdos-853-conjectures",
+    "proofId": "erdos-853",
+    "type": "theorem",
+    "range": { "startLine": 180, "endLine": 187 },
+    "title": "Main Conjectures (OPEN)",
+    "content": "`erdos_853_weak`: $\\forall M, \\exists X, \\forall x \\ge X, r(x) \\ge M$ (i.e., $r(x) \\to \\infty$). `erdos_853_strong`: $\\forall C > 0, \\exists X, \\forall x \\ge X, r(x) \\ge C \\log x$ (i.e., $r(x)/\\log x \\to \\infty$). Both are axiomatized as OPEN problems.",
+    "significance": "critical",
+    "mathContext": "The weak conjecture says every even number eventually appears as a prime gap — a **completeness** statement for the gap census. The strong form says the smallest missing gap grows faster than $\\log x$, which is the average gap size by PNT. Since Cramér's conjecture predicts maximal gaps $\\sim (\\log x)^2$, the strong form asks for $r(x)$ to lie between $\\log x$ and $(\\log x)^2$.",
+    "relatedConcepts": ["divergence to infinity", "prime number theorem", "Cramer's conjecture", "gap completeness"],
+    "prerequisites": ["r(x) axioms", "Real.log", "Filter.Tendsto"]
+  },
+  {
+    "id": "erdos-853-consequence",
+    "proofId": "erdos-853",
+    "type": "theorem",
+    "range": { "startLine": 193, "endLine": 203 },
+    "title": "Weak Conjecture Implies All Even Gaps Appear",
+    "content": "`weak_implies_all_even_gaps` proves that if $r(x) \\to \\infty$, then every even $t \\ge 2$ belongs to $G(x)$ for all sufficiently large $x$. The proof finds $X'$ with $r(X') > t$, then uses `r_minimal` to conclude $t \\in G(\\max(X, X', 3))$.",
+    "significance": "key",
+    "mathContext": "This is the **logical core** connecting $r(x) \\to \\infty$ to gap completeness. The proof uses a max-of-three argument to ensure $x$ is simultaneously $\\ge X$ (the given lower bound), $\\ge X'$ (to guarantee $r(x) > t$), and $\\ge 3$ (for the axioms to apply). The minimality of $r$ then gives $t \\in G(x)$.",
+    "relatedConcepts": ["logical consequence", "max construction", "gap completeness", "eventual membership"],
+    "prerequisites": ["r_minimal", "erdos_853_weak hypothesis", "le_max_left/right"]
+  },
+  {
+    "id": "erdos-853-maynard-tao",
+    "proofId": "erdos-853",
+    "type": "theorem",
+    "range": { "startLine": 208, "endLine": 216 },
+    "title": "Maynard-Tao and Cramer Bounds",
+    "content": "`maynard_tao_bounded_gaps`: there exists an even $t \\le 246$ appearing as a prime gap infinitely often. `cramer_conjecture_bound`: conditionally, $r(x) \\le C(\\log x)^2$ for some $C > 0$. These are axiomatized as deep results from analytic number theory.",
+    "significance": "key",
+    "mathContext": "**Maynard-Tao (2014)**: Building on Zhang's breakthrough (2013, gap $\\le 7 \\times 10^7$), Maynard and independently Tao proved $\\liminf_{n \\to \\infty} d_n \\le 246$ using the Selberg sieve. The Polymath8b project refined this to 246. This guarantees at least one small gap appears infinitely often, but says nothing about which specific gap or about larger gaps.\n\n**Cramér's conjecture (1936)**: Predicts $\\max_{p_n \\le x} d_n \\sim (\\log x)^2$, based on a probabilistic model where integers $n$ are 'prime' with probability $1/\\log n$. Granville (1995) suggested the constant should be $2e^{-\\gamma} \\approx 1.119$ rather than 1.",
+    "relatedConcepts": ["Maynard-Tao theorem", "bounded gaps", "Cramer's conjecture", "Selberg sieve", "Granville's refinement"],
+    "prerequisites": ["primeGap", "nthPrime", "Real.log", "analytic number theory background"]
   }
 ]

--- a/src/data/proofs/erdos-853/meta.json
+++ b/src/data/proofs/erdos-853/meta.json
@@ -21,25 +21,28 @@
     "erdosUrl": "https://erdosproblems.com/853",
     "erdosProblemStatus": "open",
     "dateAdded": "2025-01-01",
-    "mathlib_version": "4.x"
-  },
-  "overview": {
-    "historicalContext": "Erdős posed this problem in 1985 [Er85c], asking about the completeness of prime gap sizes. For primes up to x, we observe a finite set of gap values d_n = p_{n+1} - p_n. The function r(x) measures how far this set is from containing all even integers: it is the smallest even number ≥ 2 not appearing as any gap.\n\nThe problem connects deeply to several strands of prime number theory. Cramér's probabilistic model (1936) predicts prime gaps of size up to ~(log x)², which would imply r(x) ≤ O((log x)²). Granville refined the predicted constant to 2e^{-γ} ≈ 1.119. On the small-gap side, the Maynard–Tao theorem (2014) guarantees that gaps ≤ 246 occur infinitely often, confirming that at least some small even gaps eventually appear in gapSet(x).\n\nThis formalization is notably rich: 14 theorems are proved directly from Mathlib, including primeGap_even (all gaps after d₀ are even), primeGap_pos (all gaps are positive), gapSet_mono (monotonicity of the gap set), r_monotone (r is weakly increasing), and weak_implies_all_even_gaps (the weak conjecture implies all even gaps eventually appear). The file demonstrates that significant structural theory can be derived from Mathlib's Nat.nth infrastructure.",
-    "problemStatement": "Is r(x) → ∞, where r(x) is the smallest even integer not appearing as a prime gap for primes up to x?",
-    "proofStrategy": "We build on Mathlib's Nat.nth and Nat.Prime to define nthPrime and primeGap. The function r(x) is axiomatized with its key properties (even, minimal, not in gapSet). We prove 14 structural theorems from Mathlib and state both open conjectures. Connections to Maynard–Tao and Cramér are formalized.",
-    "keyInsights": [
-      "**Even gap restriction**: All prime gaps d_n for n ≥ 1 are even (proved from Mathlib: both p_n and p_{n+1} are odd primes ≥ 3). The only odd gap is d₀ = 1 (the gap between 2 and 3).",
-      "**Monotonicity of r**: As x grows, more gap values appear in gapSet(x), so the smallest missing gap r(x) can only increase. This is proved from the axioms about r.",
-      "**Maynard–Tao constraint**: The bounded gaps theorem guarantees some gap ≤ 246 appears infinitely often, confirming small even gaps are realized. But this says nothing about whether all even gaps eventually appear.",
-      "**Cramér's upper bound**: Cramér's conjecture would imply r(x) ≤ O((log x)²), constraining how fast r(x) can grow. The strong form r(x)/log x → ∞ asks for growth between log x and (log x)².",
-      "**14 proved theorems**: The file derives primeGap_pos, primeGap_zero, primeGap_even, primeGap_ge_two, gapSet_mono, gapSet_even, gapSet_pos, gapSet_ge_two, r_monotone, weak_implies_all_even_gaps, and more directly from Mathlib."
-    ],
+    "mathlib_version": "4.x",
     "mathlibDependencies": [
-      "Mathlib.Data.Nat.Prime.Basic",
-      "Mathlib.Data.Nat.Prime.Nth",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Data.Real.Basic",
-      "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      {
+        "theorem": "Nat.nth",
+        "description": "The n-th element of an infinite set (used for prime enumeration)",
+        "module": "Mathlib.Data.Nat.Prime.Nth"
+      },
+      {
+        "theorem": "Nat.Prime",
+        "description": "Primality predicate for natural numbers",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Real.log",
+        "description": "Natural logarithm for the strong conjecture statement",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Finset",
+        "description": "Finite sets with decidable membership",
+        "module": "Mathlib.Data.Finset.Basic"
+      }
     ],
     "originalContributions": [
       "nthPrime: 0-indexed prime via Nat.nth",
@@ -56,6 +59,30 @@
       "weak_implies_all_even_gaps: proved weak conjecture ⟹ all even gaps appear",
       "erdos_853_weak: weak conjecture r(x) → ∞",
       "erdos_853_strong: strong conjecture r(x)/log x → ∞"
+    ],
+    "crossReferences": [
+      {
+        "targetId": "prime-number-theorem",
+        "relationship": "foundational",
+        "description": "PNT gives average gap size ~log x, providing context for the strong conjecture r(x)/log x → ∞ which asks for the smallest missing gap to grow faster than the average gap"
+      },
+      {
+        "targetId": "twin-primes-special",
+        "relationship": "thematic",
+        "description": "Twin primes (gap = 2) are the smallest possible gap; Problem 853 asks whether ALL even gaps eventually appear, generalizing the twin prime question to arbitrary even gaps"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "**Erdős Problem #853: Completeness of the Prime Gap Census**\n\nErdős posed this problem in 1985 [Er85c], asking about the completeness of prime gap sizes. For primes up to $x$, we observe a finite set of gap values $d_n = p_{n+1} - p_n$. The function $r(x)$ measures how far this set is from containing all even integers: it is the smallest even number $\\ge 2$ not appearing as any gap.\n\n**Historical Timeline:**\n- 1849: Polignac conjectured every even number is a prime gap infinitely often\n- 1936: Cramér proposed his probabilistic model for prime gaps, predicting maximal gap $\\sim (\\log x)^2$\n- 1985: Erdős formulated Problem 853, asking whether $r(x) \\to \\infty$\n- 1995: Granville refined Cramér's constant to $2e^{-\\gamma} \\approx 1.119$\n- 2013: Zhang proved bounded gaps ($\\liminf d_n \\le 7 \\times 10^7$), the first finite bound\n- 2014: Maynard and Tao independently improved to $\\liminf d_n \\le 246$\n- 2014: Polymath8b project achieved the current bound of 246\n\n**The Key Tension:** The Maynard-Tao theorem guarantees some small gap appears infinitely often, confirming that at least some entries of the gap census grow without bound. But this says nothing about whether ALL even gaps eventually appear. The problem asks about the **completeness** of the gap set $G(x) = \\{d_n : p_n \\le x\\}$, which is a fundamentally different question from the existence of small gaps.\n\n**Notably rich formalization:** This file proves 14 theorems directly from Mathlib (no sorries), including the crucial `primeGap_even` (all gaps after $d_0$ are even), `r_monotone` (the smallest missing gap is weakly increasing), and `weak_implies_all_even_gaps` (the weak conjecture implies gap completeness).",
+    "problemStatement": "Is $r(x) \\to \\infty$, where $r(x) = \\min\\{t \\in 2\\mathbb{N}_{\\ge 1} : t \\notin G(x)\\}$ is the smallest even integer not appearing as a prime gap for primes up to $x$? The stronger form asks whether $r(x)/\\log x \\to \\infty$.",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Prime Infrastructure:** `nthPrime` and `primeGap` via Mathlib's `Nat.nth`. Prove 9 structural theorems from Mathlib.\n2. **Gap Set:** `gapSet(x)` with 4 proved properties (monotonicity, evenness, positivity, $\\ge 2$)\n3. **r(x) Axiomatization:** Four axioms characterizing $r(x)$ as the minimum missing even gap\n4. **Proved Properties:** `r_monotone` from the axioms; `weak_implies_all_even_gaps` from the weak conjecture\n5. **Deep Connections:** Maynard-Tao bounded gaps and Cramér's conditional upper bound",
+    "keyInsights": [
+      "**Even gap restriction**: All prime gaps $d_n$ for $n \\ge 1$ are even (proved from Mathlib: both $p_n$ and $p_{n+1}$ are odd primes $\\ge 3$). The only odd gap is $d_0 = 1$ (between 2 and 3). This justifies restricting $r(x)$ to even values.",
+      "**Monotonicity of r**: As $x$ grows, more gap values enter $G(x)$, so $r(x)$ can only increase. Proved by contradiction: if $r(y) < r(x)$ for $x \\le y$, minimality gives $r(y) \\in G(x) \\subseteq G(y)$, contradicting $r(y) \\notin G(y)$.",
+      "**Maynard-Tao constraint**: The bounded gaps theorem guarantees some gap $\\le 246$ appears infinitely often, confirming small even gaps are realized. But this gives no information about completeness of the gap census.",
+      "**Cramér's conditional bound**: Cramér's conjecture ($\\max_{p_n \\le x} d_n \\sim (\\log x)^2$) would imply $r(x) \\le O((\\log x)^2)$. Combined with the strong conjecture $r(x)/\\log x \\to \\infty$, this would place $r(x)$ between $\\log x$ and $(\\log x)^2$.",
+      "**14 proved theorems**: The file derives extensive structural theory from Mathlib with 0 sorries, demonstrating the power of Mathlib's `Nat.nth` prime enumeration infrastructure."
     ]
   },
   "sections": [
@@ -63,46 +90,47 @@
       "id": "infrastructure",
       "title": "Mathlib-Based Prime Infrastructure",
       "startLine": 40,
-      "endLine": 101,
-      "summary": "Defines nthPrime and primeGap using Nat.nth. Proves 9 structural theorems from Mathlib: nthPrime_prime, nthPrime_strictMono, primeGap_pos, primeGap_zero, primeGap_even, primeGap_ge_two, nthPrime_zero, nthPrime_one, nthPrime_mono."
+      "endLine": 111,
+      "summary": "Defines `nthPrime(n) = \\mathrm{Nat.nth}\\,\\mathrm{Prime}\\,n$ and `primeGap(n) = p_{n+1} - p_n$`. Proves 9 structural theorems: `nthPrime_prime`, `nthPrime_strictMono`, `primeGap_pos`, `primeGap_zero` ($d_0 = 1$), `primeGap_even` ($2 \\mid d_n$ for $n \\ge 1$), `primeGap_ge_two`, `nthPrime_zero` ($p_0 = 2$), `nthPrime_one` ($p_1 = 3$), `nthPrime_mono`."
     },
     {
       "id": "gap-set",
       "title": "Gap Set and r(x)",
       "startLine": 113,
       "endLine": 157,
-      "summary": "Defines gapSet(x) and proves gapSet_mono, gapSet_even, gapSet_pos, gapSet_ge_two. Axiomatizes r(x) with r_even_pos, r_not_gap, r_minimal."
+      "summary": "Defines $G(x) = \\{d_n : n \\ge 1, p_n \\le x\\}$. Proves `gapSet_mono` ($G(x) \\subseteq G(y)$), `gapSet_even`, `gapSet_pos`, `gapSet_ge_two`. Axiomatizes $r(x)$ with `r_even_pos`, `r_not_gap`, `r_minimal`."
     },
     {
       "id": "monotonicity",
       "title": "Proved Properties of r(x)",
       "startLine": 159,
       "endLine": 173,
-      "summary": "Proves r_monotone (r is weakly increasing) from the axioms. States the trivial upper bound r(x) ≤ x."
+      "summary": "Proves `r_monotone` ($x \\le y \\Rightarrow r(x) \\le r(y)$) by contradiction using `r_minimal` and `gapSet_mono`. Axiomatizes trivial upper bound $r(x) \\le x$."
     },
     {
       "id": "main-conjectures",
       "title": "Main Conjectures",
       "startLine": 175,
       "endLine": 203,
-      "summary": "States erdos_853_weak (r(x) → ∞) and erdos_853_strong (r(x)/log x → ∞). Proves weak_implies_all_even_gaps: the weak conjecture implies every even gap ≥ 2 eventually appears."
+      "summary": "States `erdos_853_weak` ($r(x) \\to \\infty$) and `erdos_853_strong` ($r(x)/\\log x \\to \\infty$). Proves `weak_implies_all_even_gaps`: the weak conjecture implies every even $t \\ge 2$ eventually enters $G(x)$."
     },
     {
       "id": "related-results",
       "title": "Related Results",
       "startLine": 205,
       "endLine": 238,
-      "summary": "Axiomatizes Maynard–Tao bounded gaps (infinitely many d_n ≤ 246) and Cramér's conjecture bound on r(x)."
+      "summary": "Axiomatizes `maynard_tao_bounded_gaps` ($\\exists\\, t \\le 246$ even with $d_n = t$ infinitely often) and `cramer_conjecture_bound` ($r(x) \\le C(\\log x)^2$ conditionally)."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 853 asks whether all even gap sizes eventually appear among prime gaps. The formalization is notably rich, with 14 theorems proved from Mathlib and 0 sorries. Both weak (r→∞) and strong (r/log x→∞) forms are stated, with connections to Maynard–Tao and Cramér.",
-    "implications": "Proving r(x) → ∞ would confirm that primes realize every possible even gap, a fundamental completeness result for prime distribution. The strong form would quantify how quickly new gaps appear.",
+    "summary": "Erdős Problem 853 asks whether all even gap sizes eventually appear among prime gaps. The formalization is notably rich: 14 theorems proved from Mathlib with 0 sorries, including gap evenness, gap set monotonicity, r(x) monotonicity, and the logical equivalence between r(x)→∞ and gap completeness. Both weak and strong forms are stated, with connections to Maynard-Tao and Cramér.",
+    "implications": "**Connections to Prime Number Theory**\n\n1. **Gap Completeness**: Proving $r(x) \\to \\infty$ would confirm that primes realize every possible even gap — a fundamental completeness result for prime distribution\n2. **Polignac's Conjecture**: The even stronger claim that every even gap appears infinitely often (Polignac 1849) implies the weak form of Problem 853\n3. **Cramér's Model**: The probabilistic model for primes predicts $r(x) \\sim (\\log x)^2$, consistent with the strong form\n4. **Maynard-Tao Sieve**: Modern sieve methods can produce many small gaps but struggle with arbitrary prescribed gaps\n5. **Hardy-Littlewood Conjectures**: The prime $k$-tuples conjecture would imply Polignac's conjecture and hence Problem 853",
     "openQuestions": [
-      "Is there a specific even gap that never occurs (i.e., does r(x) stabilize)?",
-      "What is the growth rate of r(x)? Is it closer to log x or (log x)²?",
-      "Does the Hardy–Littlewood conjecture on prime pairs imply r(x) → ∞?",
-      "Can the Maynard–Tao machinery be extended to show all even gaps ≤ some bound B(x) appear?"
+      "Is there a specific even gap size that never occurs as a prime gap (i.e., does r(x) stabilize at some finite value)?",
+      "What is the growth rate of r(x)? Is it closer to log x or (log x)^2?",
+      "Does the Hardy-Littlewood prime k-tuples conjecture imply r(x) → ∞?",
+      "Can the Maynard-Tao machinery be extended to show all even gaps ≤ some explicit bound B(x) appear for primes up to x?",
+      "What does computational data suggest about the first even gap not observed below 10^18?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Expanded annotations from 8 to 10 with mathContext (LaTeX), relatedConcepts, prerequisites
- Fixed invalid annotation types (conjecture→theorem, high/medium→critical/key/supporting)
- Fixed startLine references to match actual Lean constructs
- Added crossReferences to prime-number-theorem and twin-primes-special
- Deepened historicalContext with timeline: Polignac 1849, Cramer 1936, Zhang 2013, Maynard-Tao 2014
- Structured mathlibDependencies as objects; added LaTeX to all section summaries

## Test plan
- [x] `pnpm annotations:build` passes (3 non-strict warnings for axiom lines, expected)
- [x] All annotations have valid types, significance, mathContext, relatedConcepts, prerequisites
- [x] Cross-references target existing gallery proofs
- [x] Section startLines point to actual Lean constructs

🤖 Generated with [Claude Code](https://claude.com/claude-code)