### PR TITLE
enrich: deepen erdos-1179 with mathContext, cross-refs, and historical context

### DIFF
--- a/src/data/proofs/erdos-1179/annotations.json
+++ b/src/data/proofs/erdos-1179/annotations.json
@@ -2,198 +2,169 @@
   {
     "id": "ann-e1179-header",
     "proofId": "erdos-1179",
-    "range": {
-      "startLine": 1,
-      "endLine": 33
-    },
+    "range": { "startLine": 1, "endLine": 33 },
     "type": "concept",
-    "title": "Problem Overview",
-    "content": "Header documentation for Erdős Problem #1179, providing mathematical context and problem statement.",
-    "mathContext": "Erdős Problem #1179: Uniform Subset Sum Representations in Abelian Groups\n\n  Source: https://erdosproblems.com/1179\n  Status: PROVED (answered in the affirmative)\n\n  Statement:\n  For 0 < ε < 1, let g_ε(N) be the minimal k such that: if G is an abelian\n  group of size N and A ⊆ G is a uniformly random subset of size k, then with\n  probability → 1 as N → ∞, the representation function\n\n    F_A(g) = #{S ⊆ A : ∑_{x ∈ S} x = g}\n\n  satisfies |F_A(g) - 2^k/N| ≤ ε · 2^k/N for all g ∈ G.\n\n  Question: Est",
+    "title": "Problem Overview: Uniform Subset Sum Representations",
+    "content": "**Erdős Problem #1179** concerns the function $g_\\varepsilon(N)$: the minimal $k$ such that a random $k$-subset of any abelian group of order $N$ has $\\varepsilon$-uniform representation counts with high probability.\n\nThe representation function $F_A(g) = |\\{S \\subseteq A : \\sum_{x \\in S} x = g\\}|$ counts how many subsets of $A$ sum to each group element $g$. $\\varepsilon$-uniformity means all counts are within $\\varepsilon$ of the expected value $2^k/N$.\n\n**Status: PROVED.** $g_\\varepsilon(N) = (1 + o_\\varepsilon(1))\\log_2 N$, combining the trivial lower bound with the Erdős-Hall (1976) upper bound.",
+    "mathContext": "The problem asks for the threshold $k$ at which the random subset sum distribution becomes approximately uniform. This is a question about the concentration of a random combinatorial measure around its mean $2^k/N$.",
     "significance": "critical",
-    "relatedConcepts": [
-      "Erdős problems",
-      "Number theory"
-    ]
+    "relatedConcepts": ["additive combinatorics", "probabilistic method", "representation function", "uniform distribution"],
+    "prerequisites": ["finite abelian groups", "subset sums", "probability theory"]
   },
   {
     "id": "ann-e1179-reprCount",
     "proofId": "erdos-1179",
-    "range": {
-      "startLine": 51,
-      "endLine": 53
-    },
+    "range": { "startLine": 51, "endLine": 53 },
     "type": "definition",
-    "title": "Reprcount",
-    "content": "noncomputable def reprCount",
-    "significance": "supporting"
+    "title": "reprCount: The Representation Function",
+    "content": "**Definition** (`reprCount A g`): The number of subsets $S \\subseteq A$ with $\\sum_{x \\in S} x = g$.\n\nComputed as `(A.powerset.filter (fun S => S.sum id = g)).card`. This is the discrete analogue of a convolution: $F_A = 1_A * 1_A * \\cdots * 1_A$ ($|A|$ times) in the group ring, where $*$ denotes additive convolution.\n\nMarked `noncomputable` because `filter` on `powerset` requires `DecidableEq` and enumerating $2^{|A|}$ subsets.",
+    "mathContext": "Via Fourier analysis: $\\hat{F}_A(\\chi) = \\prod_{a \\in A}(1 + \\chi(a))$ for characters $\\chi$ of $G$. The uniform distribution has $\\hat{F}(\\chi) = 0$ for $\\chi \\neq 1$ and $\\hat{F}(1) = 2^k/N$. Deviation from uniformity is controlled by $\\max_{\\chi \\neq 1} |\\hat{F}_A(\\chi)|$.",
+    "significance": "critical",
+    "relatedConcepts": ["subset sum", "convolution", "powerset", "Fourier analysis on groups"],
+    "prerequisites": ["Finset.powerset", "AddCommGroup", "group ring"]
   },
   {
     "id": "ann-e1179-expectedReprCount",
     "proofId": "erdos-1179",
-    "range": {
-      "startLine": 56,
-      "endLine": 57
-    },
+    "range": { "startLine": 56, "endLine": 57 },
     "type": "definition",
-    "title": "Expectedreprcount",
-    "content": "noncomputable def expectedReprCount",
-    "significance": "supporting"
+    "title": "expectedReprCount: The Target Value",
+    "content": "**Definition** (`expectedReprCount k N`): The expected representation count $2^k/N$.\n\nIf $|A| = k$ and all $2^k$ subsets summed to distinct elements (impossible when $2^k > N$), each element would have exactly $2^k/N$ representations. $\\varepsilon$-uniformity means each count is within $\\varepsilon$ of this target.",
+    "mathContext": "By `total_reprCount`, $\\sum_g F_A(g) = 2^k$. If $|G| = N$, the average is $2^k/N$. For $k \\approx \\log_2 N$, this average is $\\approx 1$.",
+    "significance": "key",
+    "relatedConcepts": ["expected value", "uniform distribution", "average representation"],
+    "prerequisites": ["reprCount definition", "group order"]
   },
   {
     "id": "ann-e1179-IsEpsUniform",
     "proofId": "erdos-1179",
-    "range": {
-      "startLine": 63,
-      "endLine": 66
-    },
+    "range": { "startLine": 63, "endLine": 66 },
     "type": "definition",
-    "title": "Isepsuniform",
-    "content": "def IsEpsUniform",
-    "significance": "supporting"
+    "title": "IsEpsUniform: The Central Property",
+    "content": "**Definition** (`IsEpsUniform A ε`): $\\forall g \\in G,\\, |F_A(g) - 2^k/N| \\leq \\varepsilon \\cdot 2^k/N$.\n\nThis is the *discrepancy condition*: every group element has approximately the expected number of subset sum representations. The multiplicative form $|F_A(g)/\\mu - 1| \\leq \\varepsilon$ (where $\\mu = 2^k/N$) shows this is a relative error bound.\n\nFor $\\varepsilon < 1$, this implies $F_A(g) > 0$ for all $g$, so the set spans $G$ (connecting to Problem #543).",
+    "mathContext": "In terms of the $L^\\infty$ norm on $G$: $\\|F_A - \\mu\\|_\\infty \\leq \\varepsilon \\mu$ where $\\mu = 2^k/N$ is the uniform measure. Via Parseval, this relates to $\\|\\hat{F}_A\\|_2$ and character sums.",
+    "significance": "critical",
+    "relatedConcepts": ["discrepancy", "relative error", "uniform distribution", "L-infinity norm"],
+    "prerequisites": ["reprCount", "expectedReprCount", "absolute value"]
   },
   {
-    "id": "ann-e1179-total_reprCount",
+    "id": "ann-e1179-total",
     "proofId": "erdos-1179",
-    "range": {
-      "startLine": 72,
-      "endLine": 73
-    },
-    "type": "axiom",
-    "title": "Total Reprcount",
-    "content": "axiom total_reprCount",
-    "significance": "key"
+    "range": { "startLine": 72, "endLine": 73 },
+    "type": "theorem",
+    "title": "Total Representation Count",
+    "content": "**Axiom** (`total_reprCount`): $\\sum_{g \\in G} F_A(g) = 2^{|A|}$.\n\nEach of the $2^{|A|}$ subsets of $A$ sums to exactly one element of $G$, so the representation counts form a partition of $2^{|A|}$. This is the 'conservation law' for representations: the total is determined by $|A|$, independent of the group structure.",
+    "mathContext": "This is the counting identity $\\sum_{g \\in G} |\\{S \\subseteq A : \\sum S = g\\}| = |\\mathcal{P}(A)| = 2^{|A|}$. It follows from the fact that the map $S \\mapsto \\sum S$ is a function from $\\mathcal{P}(A)$ to $G$.",
+    "significance": "key",
+    "relatedConcepts": ["partition of subsets", "counting identity", "conservation law"],
+    "prerequisites": ["reprCount definition", "power set cardinality"]
   },
   {
-    "id": "ann-e1179-reprCount_empty_zero",
+    "id": "ann-e1179-empty-cases",
     "proofId": "erdos-1179",
-    "range": {
-      "startLine": 76,
-      "endLine": 77
-    },
-    "type": "axiom",
-    "title": "Reprcount Empty Zero",
-    "content": "axiom reprCount_empty_zero",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1179-reprCount_empty_nonzero",
-    "proofId": "erdos-1179",
-    "range": {
-      "startLine": 80,
-      "endLine": 81
-    },
-    "type": "axiom",
-    "title": "Reprcount Empty Nonzero",
-    "content": "axiom reprCount_empty_nonzero",
-    "significance": "key"
+    "range": { "startLine": 76, "endLine": 81 },
+    "type": "theorem",
+    "title": "Empty Set Base Cases",
+    "content": "**Axioms**: `reprCount_empty_zero` ($F_\\emptyset(0) = 1$) and `reprCount_empty_nonzero` ($F_\\emptyset(g) = 0$ for $g \\neq 0$).\n\nThe empty set $A = \\emptyset$ has exactly one subset (the empty set $\\emptyset$), which sums to $0$. So $F_\\emptyset(0) = 1$ and $F_\\emptyset(g) = 0$ for $g \\neq 0$. These are the base cases for inductive arguments.",
+    "mathContext": "The identity: $F_\\emptyset = \\delta_0$ (Dirac delta at the identity of $G$). This is the 'initial condition' for the convolution recurrence $F_{A \\cup \\{a\\}} = F_A + F_A(\\cdot - a)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["base case", "Dirac delta", "empty sum convention"],
+    "prerequisites": ["reprCount definition", "empty set"]
   },
   {
     "id": "ann-e1179-gEps",
     "proofId": "erdos-1179",
-    "range": {
-      "startLine": 89,
-      "endLine": 89
-    },
-    "type": "axiom",
-    "title": "Geps",
-    "content": "axiom gEps",
-    "significance": "key"
+    "range": { "startLine": 89, "endLine": 93 },
+    "type": "definition",
+    "title": "gEps: The Threshold Function",
+    "content": "**Axioms** (`gEps ε N`) and (`gEps_pos`): The function $g_\\varepsilon(N)$ is the minimal $k$ such that a random $k$-subset of any abelian group of order $N$ has $\\varepsilon$-uniform representations with high probability.\n\nAxiomatized because the definition involves: (1) quantification over all abelian groups of order $N$, (2) probability over random subsets, and (3) asymptotic convergence. The positivity axiom ensures $g_\\varepsilon(N) \\geq 1$ for valid parameters.\n\nThis is the central object of the problem: Erdős asks for the asymptotic behavior of $g_\\varepsilon(N)$.",
+    "mathContext": "$g_\\varepsilon(N) = \\min\\{k : \\Pr[\\text{random } A \\subseteq G, |A|=k, \\text{IsEpsUniform}(A,\\varepsilon)] \\to 1\\}$ where the probability is uniform over $k$-subsets and the condition holds for all $G$ with $|G| = N$.",
+    "significance": "critical",
+    "relatedConcepts": ["threshold function", "probabilistic method", "minimax", "high probability"],
+    "prerequisites": ["IsEpsUniform", "probability theory", "abelian groups"]
   },
   {
-    "id": "ann-e1179-gEps_pos",
+    "id": "ann-e1179-lower-bound",
     "proofId": "erdos-1179",
-    "range": {
-      "startLine": 92,
-      "endLine": 93
-    },
-    "type": "axiom",
-    "title": "Geps Pos",
-    "content": "axiom gEps_pos",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1179-trivial_lower_bound",
-    "proofId": "erdos-1179",
-    "range": {
-      "startLine": 104,
-      "endLine": 105
-    },
-    "type": "axiom",
-    "title": "Trivial Lower Bound",
-    "content": "axiom trivial_lower_bound",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1179-erdos_renyi_upper",
-    "proofId": "erdos-1179",
-    "range": {
-      "startLine": 114,
-      "endLine": 116
-    },
-    "type": "axiom",
-    "title": "Erdos Renyi Upper",
-    "content": "axiom erdos_renyi_upper",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e1179-erdos_hall_upper",
-    "proofId": "erdos-1179",
-    "range": {
-      "startLine": 124,
-      "endLine": 127
-    },
-    "type": "axiom",
-    "title": "Erdos Hall Upper",
-    "content": "axiom erdos_hall_upper",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e1179-main_asymptotic",
-    "proofId": "erdos-1179",
-    "range": {
-      "startLine": 135,
-      "endLine": 137
-    },
-    "type": "axiom",
-    "title": "Main Asymptotic",
-    "content": "axiom main_asymptotic",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e1179-uniform_implies_spanning",
-    "proofId": "erdos-1179",
-    "range": {
-      "startLine": 147,
-      "endLine": 151
-    },
-    "type": "axiom",
-    "title": "Uniform Implies Spanning",
-    "content": "axiom uniform_implies_spanning",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1179-gEps_mono",
-    "proofId": "erdos-1179",
-    "range": {
-      "startLine": 156,
-      "endLine": 158
-    },
-    "type": "axiom",
-    "title": "Geps Mono",
-    "content": "axiom gEps_mono",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1179-erdos_1179_summary",
-    "proofId": "erdos-1179",
-    "range": {
-      "startLine": 171,
-      "endLine": 176
-    },
+    "range": { "startLine": 104, "endLine": 105 },
     "type": "theorem",
-    "title": "Erdos 1179 Summary",
-    "content": "theorem erdos_1179_summary",
-    "significance": "critical"
+    "title": "Trivial Lower Bound: g_ε(N) ≥ log₂ N",
+    "content": "**Axiom** (`trivial_lower_bound`): $g_\\varepsilon(N) \\geq \\log_2 N$ for all $0 < \\varepsilon < 1$.\n\n**Proof:** If $k < \\log_2 N$ then $2^k < N$, so $\\sum_g F_A(g) = 2^k < N$. By pigeonhole, some $g$ has $F_A(g) = 0$, while $\\varepsilon$-uniformity requires $F_A(g) \\geq (1-\\varepsilon) \\cdot 2^k/N > 0$. Contradiction.\n\nThis bound is tight up to lower-order terms: the main theorem shows $g_\\varepsilon(N) \\sim \\log_2 N$.",
+    "mathContext": "Information-theoretic bound: to represent $N$ elements, we need $\\geq \\log_2 N$ bits of 'entropy'. Each element of $A$ provides one bit (include/exclude in subset), so $|A| \\geq \\log_2 N$.",
+    "significance": "critical",
+    "relatedConcepts": ["counting argument", "pigeonhole principle", "information-theoretic bound"],
+    "prerequisites": ["total_reprCount", "IsEpsUniform", "logarithm"]
+  },
+  {
+    "id": "ann-e1179-erdos-renyi",
+    "proofId": "erdos-1179",
+    "range": { "startLine": 114, "endLine": 116 },
+    "type": "theorem",
+    "title": "Erdős-Rényi Upper Bound (1965)",
+    "content": "**Axiom** (`erdos_renyi_upper`): $\\exists C > 0,\\, \\forall N \\geq 2,\\, g_\\varepsilon(N) \\leq 2\\log_2 N + C$.\n\n**Proof technique (second moment method):** For random $A$ with $|A| = k \\approx 2\\log_2 N$:\n- $\\mathbb{E}[F_A(g)] = 2^k/N \\approx N$ (large)\n- $\\text{Var}[F_A(g)] = O(\\mathbb{E}[F_A(g)]^2 / N)$\n\nBy Chebyshev, $F_A(g)$ concentrates around its mean. The factor 2 comes from the variance requiring $2^k \\gg N^2$ for concentration, i.e., $k \\gg 2\\log_2 N$.",
+    "mathContext": "Second moment method: $\\Pr[|X - \\mu| \\geq t] \\leq \\text{Var}(X)/t^2$. For $X = F_A(g)$, the variance involves correlations between subsets $S, S'$ with $\\sum S = \\sum S' = g$, controlled by $|S \\cap S'|$.",
+    "significance": "key",
+    "relatedConcepts": ["second moment method", "Chebyshev inequality", "variance", "Erdős-Rényi"],
+    "prerequisites": ["probability theory", "second moment method", "reprCount"]
+  },
+  {
+    "id": "ann-e1179-erdos-hall",
+    "proofId": "erdos-1179",
+    "range": { "startLine": 124, "endLine": 127 },
+    "type": "theorem",
+    "title": "Erdős-Hall Upper Bound (1976)",
+    "content": "**Axiom** (`erdos_hall_upper`): $g_\\varepsilon(N) \\leq (1 + C \\cdot \\frac{\\log\\log\\log N}{\\log\\log N}) \\cdot \\log_2 N$.\n\nThis improves the leading coefficient from 2 (Erdős-Rényi) to $1 + o(1)$.\n\n**Proof technique (character sums):** The deviation $F_A(g) - 2^k/N$ is expressed via Fourier inversion on $G$:\n$$F_A(g) - 2^k/N = \\frac{1}{N} \\sum_{\\chi \\neq 1} \\overline{\\chi(g)} \\prod_{a \\in A}(1 + \\chi(a))$$\nBounding $|\\prod_{a \\in A}(1+\\chi(a))|$ for non-trivial characters $\\chi$ gives the result. The triple-logarithmic error comes from large deviation estimates.",
+    "mathContext": "Fourier analysis on $G$: the character group $\\hat{G}$ has $|\\hat{G}| = N$. For random $A$, $\\mathbb{E}[\\prod_{a \\in A}(1+\\chi(a))] = 0$ for $\\chi \\neq 1$ (cancellation). Large deviation bounds on the product give the $\\log\\log\\log N/\\log\\log N$ error.",
+    "significance": "critical",
+    "relatedConcepts": ["character sums", "Fourier analysis on groups", "large deviation", "Erdős-Hall"],
+    "prerequisites": ["character theory", "Fourier inversion", "large deviation bounds"]
+  },
+  {
+    "id": "ann-e1179-main",
+    "proofId": "erdos-1179",
+    "range": { "startLine": 135, "endLine": 137 },
+    "type": "theorem",
+    "title": "Main Asymptotic: g_ε(N) ~ log₂ N",
+    "content": "**Axiom** (`main_asymptotic`): $\\forall \\delta > 0,\\, \\exists N_0,\\, \\forall N \\geq N_0,\\, |g_\\varepsilon(N)/\\log_2 N - 1| < \\delta$.\n\nThis is the complete answer to Erdős Problem #1179: $g_\\varepsilon(N) \\sim \\log_2 N$ as $N \\to \\infty$. It follows from combining the trivial lower bound ($\\geq \\log_2 N$) with the Erdős-Hall upper bound ($\\leq (1+o(1))\\log_2 N$).\n\nThe $\\varepsilon$-$\\delta$ formulation captures the limit: $g_\\varepsilon(N)/\\log_2 N \\to 1$.",
+    "mathContext": "Asymptotic equivalence: $g_\\varepsilon(N) = (1 + o_\\varepsilon(1))\\log_2 N$ means the ratio converges to 1. The rate of convergence depends on $\\varepsilon$ through the Erdős-Hall error term $O_\\varepsilon(\\log\\log\\log N / \\log\\log N)$.",
+    "significance": "critical",
+    "relatedConcepts": ["asymptotic equivalence", "o-notation", "limit", "threshold"],
+    "prerequisites": ["trivial_lower_bound", "erdos_hall_upper", "real analysis"]
+  },
+  {
+    "id": "ann-e1179-spanning",
+    "proofId": "erdos-1179",
+    "range": { "startLine": 147, "endLine": 151 },
+    "type": "theorem",
+    "title": "Uniform Implies Spanning (Connection to #543)",
+    "content": "**Axiom** (`uniform_implies_spanning`): If $A$ is $\\varepsilon$-uniform (with $\\varepsilon < 1$ and $|A| \\geq \\lceil\\log_2 N\\rceil$), then $F_A(g) \\geq 1$ for all $g \\in G$.\n\n**Proof:** $\\varepsilon$-uniformity gives $F_A(g) \\geq (1-\\varepsilon) \\cdot 2^k/N$. Since $k \\geq \\log_2 N$, we have $2^k \\geq N$, so $(1-\\varepsilon) \\cdot 2^k/N \\geq 1 - \\varepsilon > 0$. Since $F_A(g)$ is a natural number, $F_A(g) \\geq 1$.\n\nThis shows Problem #1179 (uniformity) is strictly stronger than Problem #543 (spanning).",
+    "mathContext": "The hierarchy: uniformity $\\Rightarrow$ spanning $\\Rightarrow$ non-trivial representation. Problem #543 shows spanning requires $\\log_2 N + \\Theta(\\log\\log N)$, while #1179 shows uniformity only requires $(1+o(1))\\log_2 N$.",
+    "significance": "key",
+    "relatedConcepts": ["spanning", "Problem #543", "coupon collector", "minimum vs average"],
+    "prerequisites": ["IsEpsUniform", "reprCount", "integer rounding"]
+  },
+  {
+    "id": "ann-e1179-mono",
+    "proofId": "erdos-1179",
+    "range": { "startLine": 156, "endLine": 158 },
+    "type": "theorem",
+    "title": "Monotonicity in ε",
+    "content": "**Axiom** (`gEps_mono`): $\\varepsilon_1 \\leq \\varepsilon_2 \\Rightarrow g_{\\varepsilon_1}(N) \\geq g_{\\varepsilon_2}(N)$.\n\nTighter tolerance (smaller $\\varepsilon$) requires more elements (larger $k$). This is because $\\varepsilon_1$-uniformity implies $\\varepsilon_2$-uniformity when $\\varepsilon_1 \\leq \\varepsilon_2$, so the threshold is non-increasing in $\\varepsilon$.",
+    "mathContext": "The function $\\varepsilon \\mapsto g_\\varepsilon(N)$ is non-increasing. The main asymptotic $g_\\varepsilon(N) \\sim \\log_2 N$ holds for each fixed $\\varepsilon \\in (0,1)$, with the rate of convergence depending on $\\varepsilon$.",
+    "significance": "supporting",
+    "relatedConcepts": ["monotonicity", "tolerance parameter", "nested events"],
+    "prerequisites": ["gEps definition", "implication of uniformity"]
+  },
+  {
+    "id": "ann-e1179-summary",
+    "proofId": "erdos-1179",
+    "range": { "startLine": 171, "endLine": 176 },
+    "type": "theorem",
+    "title": "Summary Theorem: Lower Bound + Main Asymptotic",
+    "content": "**Theorem** (`erdos_1179_summary`): Combines the lower bound and main asymptotic:\n\n1. $\\forall N \\geq 2,\\, g_\\varepsilon(N) \\geq \\log_2 N$\n2. $g_\\varepsilon(N)/\\log_2 N \\to 1$ as $N \\to \\infty$\n\nProved from `trivial_lower_bound` and `main_asymptotic`. The contrast with Problem #543 is noted: spanning needs $\\log_2 N + \\Theta(\\log\\log N)$, but the extra $\\log\\log N$ is NOT needed for approximate uniformity.",
+    "mathContext": "The complete picture: $\\log_2 N \\leq g_\\varepsilon(N) \\leq (1 + C_\\varepsilon \\frac{\\log\\log\\log N}{\\log\\log N})\\log_2 N$. The lower bound is tight: $g_\\varepsilon(N)/\\log_2 N \\to 1$.",
+    "significance": "critical",
+    "relatedConcepts": ["summary", "sandwich theorem", "asymptotic equivalence"],
+    "prerequisites": ["trivial_lower_bound", "main_asymptotic"]
   }
 ]

--- a/src/data/proofs/erdos-1179/meta.json
+++ b/src/data/proofs/erdos-1179/meta.json
@@ -24,151 +24,133 @@
     "erdosProblemStatus": "proved",
     "mathlib_version": "4.15.0",
     "mathlibDependencies": [
-      {
-        "theorem": "Basic",
-        "description": "From Mathlib.Data.Finset.Basic",
-        "module": "Mathlib.Data.Finset.Basic"
-      },
-      {
-        "theorem": "Powerset",
-        "description": "From Mathlib.Data.Finset.Powerset",
-        "module": "Mathlib.Data.Finset.Powerset"
-      },
-      {
-        "theorem": "Card",
-        "description": "From Mathlib.Data.Finset.Card",
-        "module": "Mathlib.Data.Finset.Card"
-      },
-      {
-        "theorem": "Basic",
-        "description": "From Mathlib.Data.Fintype.Basic",
-        "module": "Mathlib.Data.Fintype.Basic"
-      },
-      {
-        "theorem": "Basic",
-        "description": "From Mathlib.Data.Real.Basic",
-        "module": "Mathlib.Data.Real.Basic"
-      },
-      {
-        "theorem": "Basic",
-        "description": "From Mathlib.Analysis.SpecialFunctions.Log.Basic",
-        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
-      },
-      {
-        "theorem": "Tactic",
-        "description": "From Mathlib.Tactic",
-        "module": "Mathlib.Tactic"
-      }
+      { "theorem": "Finset.powerset", "description": "Powerset of finite sets for enumerating subsets", "module": "Mathlib.Data.Finset.Powerset" },
+      { "theorem": "Finset.card", "description": "Cardinality of finite sets", "module": "Mathlib.Data.Finset.Card" },
+      { "theorem": "Real.logb", "description": "Logarithm base b for log₂ N bounds", "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic" },
+      { "theorem": "Fintype.card", "description": "Cardinality of finite types (group order)", "module": "Mathlib.Data.Fintype.Basic" }
     ],
     "originalContributions": [
-      "reprCount",
-      "expectedReprCount",
-      "IsEpsUniform",
-      "total_reprCount",
-      "reprCount_empty_zero",
-      "reprCount_empty_nonzero",
-      "gEps",
-      "gEps_pos",
-      "trivial_lower_bound",
-      "erdos_renyi_upper",
-      "erdos_hall_upper",
-      "main_asymptotic",
-      "uniform_implies_spanning",
-      "gEps_mono",
-      "erdos_1179_summary"
+      "reprCount: representation function F_A(g) = #{S ⊆ A : ∑ x = g}",
+      "expectedReprCount: expected count 2^k/N",
+      "IsEpsUniform: ε-uniformity of representation counts",
+      "total_reprCount: ∑_g F_A(g) = 2^|A|",
+      "gEps: the function g_ε(N)",
+      "trivial_lower_bound: g_ε(N) ≥ log₂ N",
+      "erdos_renyi_upper: g_ε(N) ≤ (2+o(1)) log₂ N",
+      "erdos_hall_upper: g_ε(N) ≤ (1+o(1)) log₂ N",
+      "main_asymptotic: g_ε(N) ~ log₂ N",
+      "uniform_implies_spanning: ε-uniform ⟹ spanning",
+      "gEps_mono: monotonicity in ε"
     ]
   },
   "overview": {
-    "historicalContext": "Erdős Problem #1179 concerns uniform subset sum representations in abelian groups. This problem has been PROVED.\n\nKnown results include: - Trivial lower bound: g_ε(N) ≥ log₂ N (need 2^k ≥ N representations) - Erdős-Rényi (1965): g_ε(N) ≤ (2 + o(1)) log₂ N + O_ε(1) - Erdős-Hall (1976): g_ε(N) ≤ (1 + O_ε(log log log N / log log N)) log₂ N - [ErRe65] Erdős, Rényi: Probabilistic Methods in Group Theory (1965)\n\nThis problem is catalogued at erdosproblems.com/1179.",
-    "problemStatement": "Question: Estimate g_ε(N). In particular, is g_ε(N) = (1 + o_ε(1)) log₂ N?",
-    "proofStrategy": "The formalization is structured in 179 lines of Lean 4 code. It uses 11 axioms for results that require external references or deep mathematical arguments beyond Mathlib.",
+    "historicalContext": "**Erdős Problem #1179: Uniform Subset Sum Representations**\n\n**Background: Additive Combinatorics in Groups**\nThis problem lies at the intersection of additive combinatorics and probabilistic number theory. It concerns how well a random subset of a finite abelian group can 'represent' all group elements via subset sums.\n\n**The Representation Function:**\nFor a subset $A$ of a finite abelian group $G$ with $|G| = N$, define $F_A(g) = |\\{S \\subseteq A : \\sum_{x \\in S} x = g\\}|$ for each $g \\in G$. If $|A| = k$, there are $2^k$ subsets total, so the 'expected' count is $2^k/N$ per element.\n\n**Erdős-Rényi (1965):**\nPaul Erdős and Alfréd Rényi studied random subsets of abelian groups in their foundational paper on probabilistic group theory. They showed that a random set of size $k \\approx 2\\log_2 N$ gives approximately uniform representations, establishing $g_\\varepsilon(N) \\leq (2 + o(1))\\log_2 N$. Their proof uses the second moment method.\n\n**Erdős-Hall (1976):**\nErdős and Richard R. Hall improved the bound to $g_\\varepsilon(N) \\leq (1 + o(1))\\log_2 N$ using character sum estimates (discrete Fourier analysis on $G$) and large deviation bounds. This reduced the leading coefficient from 2 to $1 + o(1)$.\n\n**Main Result:**\nCombined with the trivial lower bound $g_\\varepsilon(N) \\geq \\log_2 N$ (counting argument), this gives $g_\\varepsilon(N) \\sim \\log_2 N$: the answer to Erdős's question is YES.\n\n**Connection to Problem #543:**\nProblem #543 asks about *spanning* (every element represented at least once), while #1179 asks for *uniform* representations. Uniformity is stronger but, remarkably, requires the same leading term $\\log_2 N$.",
+    "problemStatement": "**Problem Statement (PROVED)**\n\nFor $0 < \\varepsilon < 1$, let $g_\\varepsilon(N)$ be the minimal $k$ such that: if $G$ is an abelian group of order $N$ and $A \\subseteq G$ is a uniformly random subset of size $k$, then with probability $\\to 1$ as $N \\to \\infty$, the representation function\n$$F_A(g) = |\\{S \\subseteq A : \\textstyle\\sum_{x \\in S} x = g\\}|$$\nsatisfies $|F_A(g) - 2^k/N| \\leq \\varepsilon \\cdot 2^k/N$ for all $g \\in G$.\n\n**Question:** Is $g_\\varepsilon(N) = (1 + o_\\varepsilon(1))\\log_2 N$?\n\n**Answer: YES.** The trivial lower bound $\\log_2 N$ and the Erdős-Hall upper bound $(1+o(1))\\log_2 N$ combine to give $g_\\varepsilon(N) \\sim \\log_2 N$.",
+    "proofStrategy": "**Formalization Strategy**\n\nThe 179-line Lean 4 file formalizes the problem structure and key results:\n\n1. **Representation Counts** (lines 47-57): Defines `reprCount A g` as the number of subsets of $A$ summing to $g$ (via `Finset.powerset.filter`), and `expectedReprCount k N = 2^k/N`.\n\n2. **Uniformity** (lines 59-66): `IsEpsUniform A ε` requires $|F_A(g) - 2^k/N| \\leq \\varepsilon \\cdot 2^k/N$ for all $g \\in G$.\n\n3. **Elementary Properties** (lines 68-81): `total_reprCount` ($\\sum_g F_A(g) = 2^{|A|}$), and empty-set base cases.\n\n4. **The Function $g_\\varepsilon(N)$** (lines 83-93): Axiomatized since it involves quantification over all groups and probabilistic convergence.\n\n5. **Lower Bound** (lines 95-105): `trivial_lower_bound`: $g_\\varepsilon(N) \\geq \\log_2 N$ from the counting argument $2^k \\geq N$.\n\n6. **Upper Bounds** (lines 107-127): `erdos_renyi_upper` (Erdős-Rényi 1965, coefficient 2) and `erdos_hall_upper` (Erdős-Hall 1976, coefficient $1 + o(1)$).\n\n7. **Main Asymptotic** (lines 129-137): $g_\\varepsilon(N)/\\log_2 N \\to 1$.\n\n8. **Comparison with #543** (lines 139-151): `uniform_implies_spanning` shows uniformity implies spanning.\n\n9. **Summary** (lines 160-176): Combines lower bound and main asymptotic into `erdos_1179_summary`.",
     "keyInsights": [
-      "**Known result**: Trivial lower bound: g_ε(N) ≥ log₂ N (need 2^k ≥ N representations)",
-      "**Known result**: Erdős-Rényi (1965): g_ε(N) ≤ (2 + o(1)) log₂ N + O_ε(1)",
-      "**Known result**: Erdős-Hall (1976): g_ε(N) ≤ (1 + O_ε(log log log N / log log N)) log₂ N",
-      "**Known result**: [ErRe65] Erdős, Rényi: Probabilistic Methods in Group Theory (1965)",
-      "**Known result**: [ErHa76] Erdős, Hall (1976)"
+      "**Counting Argument:** $g_\\varepsilon(N) \\geq \\log_2 N$ because $|A| = k$ gives only $2^k$ subsets; for uniformity at level $\\approx 2^k/N \\geq 1$, we need $k \\geq \\log_2 N$",
+      "**Second Moment Method:** Erdős-Rényi (1965) proved $g_\\varepsilon(N) \\leq 2\\log_2 N + O(1)$ by showing variance of $F_A(g)$ is small when $k \\approx 2\\log_2 N$",
+      "**Character Sum Estimates:** Erdős-Hall (1976) improved to $(1+o(1))\\log_2 N$ using Fourier analysis on $G$: $\\hat{1}_A(\\chi) = \\sum_{a \\in A} \\chi(a)$ controls $F_A(g)$ via inversion",
+      "**Spanning vs. Uniformity:** Problem #543 (spanning) needs $\\log_2 N + \\Theta(\\log\\log N)$; problem #1179 (uniformity) needs only $(1+o(1))\\log_2 N$. Extra $\\log\\log N$ is for *minimum* coverage, not uniformity",
+      "**Monotonicity:** Tighter tolerance $\\varepsilon_1 < \\varepsilon_2$ requires more elements: $g_{\\varepsilon_1}(N) \\geq g_{\\varepsilon_2}(N)$",
+      "**Universality:** The result holds for ALL abelian groups of order $N$, not just $\\mathbb{Z}/N\\mathbb{Z}$. The Fourier analysis works on any finite abelian group via its character group"
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Problem statement, known results (Erdős-Rényi 1965, Erdős-Hall 1976), comparison with #543, references, and imports from Mathlib (`Finset`, `Real.logb`, `Fintype`)"
+    },
+    {
       "id": "representation-counts",
       "title": "Representation Counts",
-      "summary": "",
       "startLine": 47,
-      "endLine": 58
+      "endLine": 57,
+      "summary": "Defines `reprCount A g = |\\{S \\subseteq A : \\sum_{x \\in S} x = g\\}|$ via `powerset.filter` and `expectedReprCount k N = 2^k/N`"
     },
     {
-      "id": "uniformity-of-representations",
+      "id": "uniformity",
       "title": "Uniformity of Representations",
-      "summary": "IsEpsUniform",
       "startLine": 59,
-      "endLine": 67
+      "endLine": 66,
+      "summary": "Defines `IsEpsUniform A ε`: $|F_A(g) - 2^k/N| \\leq \\varepsilon \\cdot 2^k/N$ for all $g \\in G$. This is the central notion of 'approximately equal representation counts'"
     },
     {
-      "id": "elementary-properties",
+      "id": "elementary",
       "title": "Elementary Properties",
-      "summary": "total_reprCount, reprCount_empty_zero, reprCount_empty_nonzero",
       "startLine": 68,
-      "endLine": 82
+      "endLine": 81,
+      "summary": "Three axioms: `total_reprCount` ($\\sum_g F_A(g) = 2^{|A|}$, each subset sums to exactly one element), `reprCount_empty_zero` ($F_\\emptyset(0) = 1$), `reprCount_empty_nonzero` ($F_\\emptyset(g) = 0$ for $g \\neq 0$)"
     },
     {
-      "id": "the-function-g-n",
-      "title": "The Function g_ε(N)",
-      "summary": "gEps, gEps_pos",
+      "id": "geps-function",
+      "title": "The Function $g_\\varepsilon(N)$",
       "startLine": 83,
-      "endLine": 94
+      "endLine": 93,
+      "summary": "Axiomatizes `gEps ε N` (minimal $k$ for high-probability $\\varepsilon$-uniformity) and `gEps_pos` ($g_\\varepsilon(N) \\geq 1$ for valid parameters)"
     },
     {
-      "id": "trivial-lower-bound",
+      "id": "lower-bound",
       "title": "Trivial Lower Bound",
-      "summary": "trivial_lower_bound",
       "startLine": 95,
-      "endLine": 106
+      "endLine": 105,
+      "summary": "Axiom `trivial_lower_bound`: $g_\\varepsilon(N) \\geq \\log_2 N$. If $k < \\log_2 N$ then $2^k < N$, so $\\sum_g F_A(g) < N$ and some element has $F_A(g) = 0$, violating $\\varepsilon$-uniformity"
     },
     {
       "id": "upper-bounds",
       "title": "Upper Bounds",
-      "summary": "erdos_renyi_upper, erdos_hall_upper",
       "startLine": 107,
-      "endLine": 128
+      "endLine": 127,
+      "summary": "Two axioms: `erdos_renyi_upper` ($g_\\varepsilon(N) \\leq 2\\log_2 N + C$, via second moment method) and `erdos_hall_upper` ($g_\\varepsilon(N) \\leq (1 + O(\\log\\log\\log N/\\log\\log N))\\log_2 N$, via character sums)"
     },
     {
-      "id": "the-main-result",
-      "title": "The Main Result",
-      "summary": "main_asymptotic",
+      "id": "main-result",
+      "title": "The Main Asymptotic Result",
       "startLine": 129,
-      "endLine": 138
+      "endLine": 137,
+      "summary": "Axiom `main_asymptotic`: $g_\\varepsilon(N)/\\log_2 N \\to 1$ as $N \\to \\infty$. Formalized as: $\\forall \\delta > 0,\\, \\exists N_0,\\, \\forall N \\geq N_0,\\, |g_\\varepsilon(N)/\\log_2 N - 1| < \\delta$"
     },
     {
-      "id": "comparison-with-problem-543",
+      "id": "comparison-543",
       "title": "Comparison with Problem #543",
-      "summary": "uniform_implies_spanning",
       "startLine": 139,
-      "endLine": 152
+      "endLine": 151,
+      "summary": "Axiom `uniform_implies_spanning`: $\\varepsilon$-uniformity implies every element has $F_A(g) \\geq 1$, so #1179 is strictly stronger than #543 (spanning). Shows $g_\\varepsilon(N) \\geq f(N)$ where $f(N)$ is the #543 threshold"
     },
     {
       "id": "monotonicity",
       "title": "Monotonicity",
-      "summary": "gEps_mono",
       "startLine": 153,
-      "endLine": 159
+      "endLine": 158,
+      "summary": "Axiom `gEps_mono`: $\\varepsilon_1 \\leq \\varepsilon_2 \\Rightarrow g_{\\varepsilon_1}(N) \\geq g_{\\varepsilon_2}(N)$. Tighter tolerance requires more elements"
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "summary": "erdos_1179_summary",
+      "title": "Summary Theorem",
       "startLine": 160,
-      "endLine": 179
+      "endLine": 179,
+      "summary": "Theorem `erdos_1179_summary`: combines lower bound ($\\geq \\log_2 N$) and main asymptotic ($\\to 1$) into a single statement. Proved from the axiomatized results. Notes comparison with #543"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-543",
+      "relationship": "related-problem",
+      "description": "Problem #543 asks about spanning (f(N) = min k for random k-subset to represent every element). Problem #1179 is the stronger uniformity version; uniform_implies_spanning shows #1179 ⟹ #543"
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1179 (Uniform Subset Sum Representations in Abelian Groups) in Lean 4, including core definitions, key structural results, and the main theorem.",
-    "implications": "The formalization demonstrates how solved problems in combinatorics and number theory can be rigorously expressed in Lean 4.",
+    "summary": "Erdős Problem #1179 is PROVED: g_ε(N) = (1 + o_ε(1)) log₂ N. The trivial lower bound log₂ N from counting and the Erdős-Hall (1976) upper bound (1 + o(1)) log₂ N combine to determine the asymptotic. The formalization captures the key definitions (representation counts, ε-uniformity), bounds (Erdős-Rényi, Erdős-Hall), and the connection to Problem #543 (spanning).",
+    "implications": "**Connections and Implications**\n\n1. **Probabilistic Combinatorics:** The second moment method (Erdős-Rényi) and character sum technique (Erdős-Hall) are paradigmatic tools in probabilistic additive combinatorics\n\n2. **Fourier Analysis on Groups:** The Erdős-Hall improvement uses the discrete Fourier transform $\\hat{f}(\\chi) = \\sum_{g} f(g)\\chi(g)$ on finite abelian groups. Character sums control the deviation from uniformity\n\n3. **Additive Number Theory:** The problem generalizes to arbitrary abelian groups, connecting to the theory of sumsets and Freiman-Ruzsa theory\n\n4. **Comparison with Spanning:** The extra $\\Theta(\\log\\log N)$ gap between spanning (#543, needs $\\log_2 N + \\Theta(\\log\\log N)$) and uniformity (#1179, needs $(1+o(1))\\log_2 N$) reveals that achieving minimum coverage is harder than average uniformity\n\n5. **Coding Theory:** Uniform subset sums relate to balanced codes and universal hashing, with applications in cryptography",
     "openQuestions": [
-      "Find constructive proofs for axiomatized results",
-      "Fill in sorry placeholders with complete proofs",
-      "Strengthen connections to other Erdős problems"
+      "What is the precise second-order term in g_ε(N)? Is it g_ε(N) = log₂ N + c_ε log log N + o(log log N) for some explicit c_ε?",
+      "Can the Erdős-Hall bound be improved to g_ε(N) ≤ log₂ N + O_ε(1) (bounded additive constant)?",
+      "What happens for non-abelian groups? Does uniformity still hold at the same threshold?",
+      "What is the optimal dependence on ε? How does g_ε(N) behave as ε → 0?",
+      "Can the probabilistic argument be derandomized to give an explicit construction of ε-uniform sets of size (1+o(1)) log₂ N?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Expanded historicalContext with Erdős-Rényi/Erdős-Hall details, proof techniques
- Rewrote problemStatement with full LaTeX (g_ε(N), F_A(g), ε-uniformity)
- Expanded proofStrategy from generic to line-by-line coverage of 179-line file
- Improved keyInsights with mathematical depth (second moment, character sums, Fourier analysis)
- Enhanced all 11 sections with LaTeX summaries
- Consolidated 16 one-line annotations to 14 with deep mathContext, relatedConcepts, prerequisites
- Fixed invalid annotation types (axiom→theorem/definition)
- Added crossReference to erdos-543 (spanning vs uniformity)
- Added 5 specific open questions

## Test plan
- [x] `pnpm annotations:build` passes (axiom-type warnings expected, non-strict)
- [x] JSON validates with python3
- [x] All 14 annotations have mathContext, relatedConcepts, prerequisites
- [x] All significance values are valid (critical/key/supporting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)