### PR TITLE
research: prove zero_in_strip_of_zero in RiemannHypothesis.lean

### DIFF
--- a/proofs/Proofs/RiemannHypothesis.lean
+++ b/proofs/Proofs/RiemannHypothesis.lean
@@ -10,6 +10,9 @@ import Mathlib.NumberTheory.EulerProduct.DirichletLSeries
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Complex
+import Mathlib.Analysis.SpecialFunctions.Gamma.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.NumberTheory.LSeries.HurwitzZetaValues
 import Mathlib.Analysis.Asymptotics.Defs
 import Mathlib.Order.Filter.Basic
 import Mathlib.Analysis.Complex.ExponentialBounds
@@ -580,29 +583,132 @@ theorem no_zeros_re_ge_one (s : ℂ) (hs : 1 ≤ s.re) : riemannZeta s ≠ 0 :=
 
 /-- Non-vanishing on the critical line complement: ζ(s) ≠ 0 for Re(s) = 1 -/
 theorem no_zeros_on_re_one (s : ℂ) (hs : s.re = 1) : riemannZeta s ≠ 0 :=
-  no_zeros_re_ge_one s (le_of_eq hs)
+  no_zeros_re_ge_one s (ge_of_eq hs)
+
+/-- cos(n * π) ≠ 0 for any natural number n: since sin(nπ) = 0 and sin² + cos² = 1 -/
+private lemma cos_nat_mul_pi_ne_zero' (n : ℕ) : Real.cos (↑n * π) ≠ 0 := by
+  intro h
+  have h1 := Real.sin_sq_add_cos_sq (↑n * π)
+  rw [Real.sin_nat_mul_pi, h] at h1
+  norm_num at h1
+
+/-- ζ(s) ≠ 0 when Re(s) ≤ 0 and s is not a non-positive integer.
+Uses the functional equation: ζ(1-s) = F(s) · ζ(s), so ζ(s) = 0 implies ζ(1-s) = 0,
+but Re(1-s) ≥ 1 gives ζ(1-s) ≠ 0. -/
+private theorem zeta_ne_zero_of_re_nonpos (s : ℂ) (h_re : s.re ≤ 0)
+    (h_not_neg_nat : ∀ n : ℕ, s ≠ -↑n) : riemannZeta s ≠ 0 := by
+  intro hs_zero
+  have h_ne_one : s ≠ 1 := by
+    intro heq; rw [heq] at h_re; simp only [Complex.one_re] at h_re; linarith
+  have h_func := riemannZeta_one_sub h_not_neg_nat h_ne_one
+  simp only [hs_zero, mul_zero] at h_func
+  have h_one_le : 1 ≤ (1 - s).re := by
+    simp only [Complex.sub_re, Complex.one_re]; linarith
+  exact absurd h_func (riemannZeta_ne_zero_of_one_le_re h_one_le)
+
+/-- ζ(-n) ≠ 0 for odd n ≥ 1. Uses the functional equation applied to s = n+1:
+ζ(-n) = ζ(1-(n+1)) = 2·(2π)^(-(n+1))·Γ(n+1)·cos(π(n+1)/2)·ζ(n+1).
+When n is odd, n+1 is even so cos(π(n+1)/2) = cos(mπ) ≠ 0 for some m,
+and all other factors are nonzero. -/
+private lemma zeta_neg_odd_ne_zero' (n : ℕ) (hn : n ≥ 1) (hodd : _root_.Odd n) :
+    riemannZeta (-(n : ℂ)) ≠ 0 := by
+  have h_not_neg : ∀ m : ℕ, (↑(n + 1) : ℂ) ≠ -(↑m : ℂ) := by
+    intro m heq
+    have h1 := congr_arg Complex.re heq
+    simp only [Complex.natCast_re, Complex.neg_re] at h1
+    have h2 : (1 : ℝ) ≤ ↑(n + 1) := by exact_mod_cast (show 1 ≤ n + 1 by omega)
+    have h3 : (0 : ℝ) ≤ ↑m := Nat.cast_nonneg _
+    linarith
+  have h_ne_one : (↑(n + 1) : ℂ) ≠ 1 := by
+    intro heq
+    have := congr_arg Complex.re heq
+    simp only [Complex.natCast_re, Complex.one_re] at this
+    norm_cast at this; omega
+  have h_func := riemannZeta_one_sub h_not_neg h_ne_one
+  have h_eq : (1 : ℂ) - ↑(n + 1) = -(↑n : ℂ) := by push_cast; ring
+  rw [h_eq] at h_func
+  intro hzero
+  rw [hzero] at h_func
+  -- All five factors in the RHS product are nonzero
+  have h_two : (2 : ℂ) ≠ 0 := two_ne_zero
+  have h_pow : (2 * ↑π : ℂ) ^ (-(↑(n + 1) : ℂ)) ≠ 0 := by
+    rw [Complex.cpow_def_of_ne_zero]
+    · exact Complex.exp_ne_zero _
+    · simp only [ne_eq, _root_.mul_eq_zero, OfNat.ofNat_ne_zero,
+        Complex.ofReal_eq_zero, false_or]
+      exact Real.pi_pos.ne'
+  have h_gamma : Complex.Gamma (↑(n + 1) : ℂ) ≠ 0 :=
+    Complex.Gamma_ne_zero h_not_neg
+  have h_zeta : riemannZeta (↑(n + 1) : ℂ) ≠ 0 := by
+    apply riemannZeta_ne_zero_of_one_lt_re
+    simp only [Complex.natCast_re]
+    have : (1 : ℝ) < ↑(n + 1) := by exact_mod_cast (show 1 < n + 1 by omega)
+    linarith
+  obtain ⟨k, hk⟩ := hodd
+  -- cos(π(n+1)/2): n = 2k+1, n+1 = 2(k+1), so π(n+1)/2 = π(k+1) and cos(mπ) ≠ 0
+  have h_cos : Complex.cos (↑π * ↑(n + 1) / 2) ≠ 0 := by
+    have heq : ↑π * (↑(n + 1) : ℂ) / 2 = ↑((↑(k + 1) : ℝ) * π) := by
+      subst hk; push_cast; ring
+    rw [heq, ← Complex.ofReal_cos]
+    simp only [Complex.ofReal_ne_zero]
+    exact cos_nat_mul_pi_ne_zero' (k + 1)
+  -- The product 2 * pow * Γ * cos * ζ = 0, but each factor is nonzero
+  have h_eq_zero : 2 * (2 * ↑π) ^ (-(↑(n + 1) : ℂ)) * Complex.Gamma ↑(n + 1) *
+      Complex.cos (↑π * ↑(n + 1) / 2) * riemannZeta ↑(n + 1) = 0 := h_func.symm
+  rcases _root_.mul_eq_zero.mp h_eq_zero with h | h
+  · rcases _root_.mul_eq_zero.mp h with h | h
+    · rcases _root_.mul_eq_zero.mp h with h | h
+      · rcases _root_.mul_eq_zero.mp h with h | h
+        · exact h_two h
+        · exact h_pow h
+      · exact h_gamma h
+    · exact h_cos h
+  · exact h_zeta h
 
 /-- Combining no_zeros_re_ge_one with trivial zeros: any zero of ζ(s) in the critical
-strip must satisfy 0 < Re(s) < 1 (not just Re(s) < 1, but also Re(s) > 0). -/
+strip must satisfy 0 < Re(s) < 1 (not just Re(s) < 1, but also Re(s) > 0).
+
+**Proof**: If Re(s) ≤ 0 and ζ(s) = 0, then either:
+- s is not a non-positive integer: the functional equation gives ζ(1-s) = F(s)·ζ(s) = 0,
+  but Re(1-s) ≥ 1 gives ζ(1-s) ≠ 0, contradiction.
+- s = 0: ζ(0) = -1/2 ≠ 0, contradiction.
+- s = -n for odd n: ζ(-n) ≠ 0 by functional equation analysis, contradiction.
+- s = -2(k+1): this is a trivial zero, contradicting the hypothesis. -/
 theorem zero_in_strip_of_zero (s : ℂ)
     (hs : riemannZeta s = 0) (hnt : ¬isTrivialZero s) :
     s ∈ criticalStrip := by
   constructor
-  · -- Re(s) > 0: if Re(s) ≤ 0, then s is either 0 or a negative integer
-    -- At s = 0: ζ(0) = -1/2 ≠ 0
-    -- At s = -2n: these are trivial zeros, contradicting hnt
-    -- For other s with Re(s) ≤ 0: use functional equation
+  · -- Re(s) > 0: show ζ has no non-trivial zeros with Re(s) ≤ 0
     by_contra h_not
     push_neg at h_not
-    -- We need Re(s) ≥ 1 for 1-s, since Re(1-s) = 1 - Re(s) ≥ 1
-    have h_one_minus : 1 ≤ (1 - s).re := by
-      simp only [Complex.sub_re, Complex.one_re]
-      linarith
-    -- ζ(1-s) ≠ 0 since Re(1-s) ≥ 1
-    have h_nonzero := no_zeros_re_ge_one (1 - s) h_one_minus
-    -- But if s is in the strip, zeros_symmetric would give ζ(1-s) = 0
-    -- Instead, we handle this by cases: s must be a negative integer or 0
-    sorry
+    -- Case split: is s a non-positive integer or not?
+    by_cases h_neg_nat : ∃ n : ℕ, s = -↑n
+    · -- s = -n for some n ∈ ℕ
+      obtain ⟨n, rfl⟩ := h_neg_nat
+      -- Sub-case: n = 0
+      by_cases hn0 : n = 0
+      · subst hn0
+        simp only [_root_.Nat.cast_zero, neg_zero] at hs
+        rw [riemannZeta_zero] at hs; norm_num at hs
+      -- Sub-case: n ≥ 1, check parity
+      · have hn1 : n ≥ 1 := Nat.one_le_iff_ne_zero.mpr hn0
+        rcases Nat.even_or_odd n with ⟨k, hk⟩ | hodd
+        · -- n even and ≥ 2: s = -n is a trivial zero (n = k + k = 2*(k-1+1))
+          have hk_pos : k ≥ 1 := by omega
+          apply hnt
+          refine ⟨k - 1, ?_⟩
+          -- Need: -(↑n : ℂ) = -2 * (↑(k - 1) + 1)
+          -- Since k ≥ 1: k - 1 + 1 = k (in ℕ), and n = k + k = 2k
+          have : (↑(k - 1) : ℂ) + 1 = ↑k := by
+            have : (k - 1 + 1 : ℕ) = k := by omega
+            rw [show (↑(k - 1) : ℂ) + 1 = (↑(k - 1 + 1) : ℂ) from by push_cast; ring]
+            exact_mod_cast this
+          rw [this]; subst hk; push_cast; ring
+        · -- n odd: ζ(-n) ≠ 0
+          exact absurd hs (zeta_neg_odd_ne_zero' n hn1 hodd)
+    · -- s is not a non-positive integer
+      push_neg at h_neg_nat
+      exact absurd hs (zeta_ne_zero_of_re_nonpos s h_not h_neg_nat)
   · -- Re(s) < 1: if Re(s) ≥ 1, then ζ(s) ≠ 0
     by_contra h_not
     push_neg at h_not
@@ -645,7 +751,7 @@ axiom zeta_conj (s : ℂ) :
 /-- Zeros come in conjugate pairs: if ζ(s) = 0 then ζ(conj(s)) = 0 -/
 theorem zero_conj (s : ℂ) (hs : riemannZeta s = 0) :
     riemannZeta (starRingEnd ℂ s) = 0 := by
-  rw [zeta_conj, hs, map_zero]
+  rw [zeta_conj, hs, _root_.map_zero]
 
 /-- Non-trivial zeros come in conjugate pairs (within the critical strip).
 Since Re(conj(s)) = Re(s), conjugation preserves the critical strip. -/
@@ -700,7 +806,7 @@ GRH implies:
 For every Dirichlet character χ modulo N, all non-trivial zeros of L(s, χ) lie
 on the critical line Re(s) = 1/2. -/
 def GeneralizedRiemannHypothesis : Prop :=
-  ∀ (N : ℕ) (χ : DirichletCharacter ℂ N) (s : ℂ),
+  ∀ (N : ℕ) [NeZero N] (χ : DirichletCharacter ℂ N) (s : ℂ),
     DirichletCharacter.LFunction χ s = 0 →
     0 < s.re → s.re < 1 →
     s.re = 1/2
@@ -717,7 +823,7 @@ theorem GRH_implies_RH (h : GeneralizedRiemannHypothesis) : RiemannHypothesis :=
   have hL : DirichletCharacter.LFunction (1 : DirichletCharacter ℂ 1) s = riemannZeta s :=
     congr_fun DirichletCharacter.LFunction_modOne_eq s
   -- Apply GRH to N=1 and the trivial character
-  exact h 1 1 s (hL ▸ hz) hpos hlt
+  exact h 1 (1 : DirichletCharacter ℂ 1) s (hL ▸ hz) hpos hlt
 
 /- ═══════════════════════════════════════════════════════════════════════════════
 PART XII: SUMMARY AND SIGNIFICANCE

--- a/src/data/research/problems/riemann-hypothesis.json
+++ b/src/data/research/problems/riemann-hypothesis.json
@@ -17,19 +17,19 @@
   },
   "currentState": {
     "phase": "PROGRESS",
-    "since": "2026-02-11T22:30:00.000Z",
-    "iteration": 3,
-    "focus": "Proved GRH_implies_RH using DirichletCharacter.LFunction_modOne_eq from Mathlib. Only 1 sorry remains (zero_in_strip_of_zero Re(s)>0 direction).",
+    "since": "2026-02-13T19:00:00.000Z",
+    "iteration": 4,
+    "focus": "Completed zero_in_strip_of_zero proof. File now has 0 sorries (excluding axioms for deep/open results). Also fixed GRH definition to include NeZero N constraint.",
     "blockers": ["RH itself is an open conjecture - we can only formalize surrounding results"],
-    "nextAction": "Complete zero_in_strip_of_zero sorry or add Nyman-Beurling criterion.",
+    "nextAction": "Add Nyman-Beurling criterion or Weil explicit formula formulation.",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved GRH_implies_RH via DirichletCharacter.LFunction_modOne_eq (for χ : DirichletCharacter ℂ 1, L(χ,s) = ζ(s)). Added Mathlib.NumberTheory.LSeries.DirichletContinuation import. File now has only 1 sorry: zero_in_strip_of_zero (Re(s)>0 direction).",
+    "progressSummary": "PROGRESS: Proved zero_in_strip_of_zero (non-trivial zeros have Re(s) > 0), completing the only sorry in the file. File now has 0 sorries. Also fixed GRH definition with [NeZero N] constraint and fixed pre-existing compilation errors (map_zero ambiguity, le_of_eq direction).",
     "builtItems": [
       {
         "name": "no_zeros_re_ge_one",
@@ -58,7 +58,7 @@
       },
       {
         "name": "GeneralizedRiemannHypothesis",
-        "description": "GRH formulation for Dirichlet L-functions",
+        "description": "GRH formulation for Dirichlet L-functions (with [NeZero N])",
         "proven": false
       },
       {
@@ -80,31 +80,49 @@
         "name": "Li_criterion",
         "description": "Equivalent formulation via Li coefficients",
         "proven": true
+      },
+      {
+        "name": "zero_in_strip_of_zero",
+        "description": "Non-trivial zeros are in the critical strip 0 < Re(s) < 1 (PROVEN via functional equation + trivial zero classification)",
+        "proven": true
+      },
+      {
+        "name": "zeta_ne_zero_of_re_nonpos",
+        "description": "ζ(s) ≠ 0 when Re(s) ≤ 0 and s is not a non-positive integer",
+        "proven": true
+      },
+      {
+        "name": "zeta_neg_odd_ne_zero'",
+        "description": "ζ(-n) ≠ 0 for odd n ≥ 1",
+        "proven": true
       }
     ],
     "insights": [
       "Mathlib now has riemannZeta_ne_zero_of_one_le_re - PNT-strength non-vanishing on Re(s)≥1",
       "DirichletCharacter.LFunction is now available in Mathlib with non-vanishing results",
-      "DirichletCharacter.LFunction_modOne_eq: L(χ,s) = ζ(s) for the unique character mod 1 (in DirichletContinuation)",
-      "Conjugation symmetry (zeta_conj) axiomatized - not yet in Mathlib but mathematically straightforward",
+      "DirichletCharacter.LFunction_modOne_eq: L(χ,s) = ζ(s) for the unique character mod 1",
+      "Conjugation symmetry (zeta_conj) axiomatized - not yet in Mathlib",
       "RH can be reduced to checking upper half-plane zeros only (proven from conjugation)",
       "GRH formulated using Mathlib's DirichletCharacter.LFunction",
-      "GRH_implies_RH now PROVEN: specialize GRH to N=1, use LFunction_modOne_eq",
-      "PrimeNumberTheoremAnd project could replace some axioms with proofs if added as dependency",
-      "Zero confinement to open strip 0<Re(s)<1 partially proven (Re(s)<1 direction complete, Re(s)>0 has sorry)"
+      "GRH_implies_RH PROVEN: specialize GRH to N=1, use LFunction_modOne_eq",
+      "Zero confinement to critical strip FULLY PROVEN: both Re(s) > 0 and Re(s) < 1",
+      "Re(s) > 0 direction uses functional equation + trivial zero classification",
+      "Key technique: for Re(s) ≤ 0, functional equation ζ(1-s) = F(s)·ζ(s) gives contradiction since Re(1-s) ≥ 1",
+      "Odd negative integers: cos factor in functional equation is cos(mπ) ≠ 0",
+      "Even negative integers ≥ 2: these are exactly the trivial zeros",
+      "With open Nat, must use _root_.Odd, _root_.mul_eq_zero, _root_.map_zero to avoid ambiguity",
+      "Nat.cast_nonneg needed for linarith with ℝ-cast ℕ values"
     ],
     "mathlibGaps": [
       "riemannZeta_conj (conjugation symmetry) - needed for full conjugate zero proof",
-      "Zero classification for Re(s)≤0 (functional equation doesn't easily give this)",
-      "PNT itself (only non-vanishing is in Mathlib, not the asymptotic)"
+      "PNT asymptotic (only non-vanishing is in Mathlib, not π(x)~x/log(x))"
     ],
     "nextSteps": [
-      "Complete zero_in_strip_of_zero sorry (Re(s)>0 direction - needs zero classification for Re(s)≤0)",
       "Add Nyman-Beurling criterion (RH ↔ density of certain functions in L²)",
+      "Add Weil explicit formula formulation",
       "Explore adding PrimeNumberTheoremAnd as dependency to upgrade axioms",
-      "Add Weil explicit formula formulation"
-    ],
-    "markdown": "# Knowledge Base: Riemann Hypothesis\n\n## The Problem\n\n> All non-trivial zeros of the Riemann zeta function ζ(s) have real part equal to 1/2.\n\n## What We've Built (as of 2026-02-11)\n\n### RiemannHypothesis.lean (~770 lines)\n- Formal statement of RH using Mathlib's `riemannZeta`\n- PNT-strength non-vanishing: ζ(s)≠0 for Re(s)≥1 (PROVEN from Mathlib)\n- Zeros symmetric under s↦1-s (PROVEN via functional equation)\n- Conjugate symmetry: ζ(s)=0 ⟹ ζ(conj(s))=0 (from axiom)\n- RH ↔ checking upper half-plane only (PROVEN)\n- Equivalent formulations: Robin's inequality, Mertens bound, prime counting\n- GRH for Dirichlet L-functions (formalized)\n- **GRH implies RH (PROVEN via LFunction_modOne_eq)**\n\n### RiemannHypothesisConsequences.lean (~632 lines)\n- Mertens function with computed values up to 100\n- Chebyshev θ(x) and ψ(x) functions\n- Von Mangoldt function verifications\n- Zeta special values: ζ(2), ζ(4), ζ(-1), ζ(-3)\n- Li's criterion, zero counting formula\n\n### Mathlib Status (2026-02-11)\n\n| Component | Status | Notes |\n|-----------|--------|-------|\n| Riemann zeta ζ(s) | ✅ | Full definition with analytic continuation |\n| Functional equation | ✅ | completedRiemannZeta_one_sub |\n| Non-vanishing Re(s)≥1 | ✅ | riemannZeta_ne_zero_of_one_le_re (PNT) |\n| Euler product | ✅ | riemannZeta_eulerProduct_tprod |\n| Special values | ✅ | ζ(2), ζ(4), ζ(-k) via Bernoulli |\n| Dirichlet L-functions | ✅ | DirichletCharacter.LFunction |\n| L → ζ bridge | ✅ | LFunction_modOne_eq (DirichletContinuation) |\n| L-function non-vanishing | ✅ | LFunction_ne_zero_of_one_le_re |\n| Conjugation symmetry | ❌ | Not in Mathlib (axiomatized here) |\n| PNT asymptotic | ❌ | Only non-vanishing, not π(x)~x/log(x) |\n\n## Remaining Sorries (1)\n- `zero_in_strip_of_zero` (Re(s)>0 direction) - needs zero classification for Re(s)≤0\n\n## Key References\n- Riemann (1859), Edwards (1974), Conrey (2003), Bombieri (2000)\n- PrimeNumberTheoremAnd: github.com/AlexKontorovich/PrimeNumberTheoremAnd\n- Loeffler & Stoll (2025): Formalizing zeta and L-functions in Lean (arXiv:2503.00959)\n"
+      "Consider proving zeta_conj to replace the axiom"
+    ]
   },
   "approaches": [],
   "tags": [
@@ -124,7 +142,7 @@
     ]
   },
   "started": "2026-01-01T21:55:27.885Z",
-  "lastUpdate": "2026-02-11T22:30:00.000Z",
+  "lastUpdate": "2026-02-13T19:00:00.000Z",
   "significance": 10,
   "tractability": 1
 }


### PR DESCRIPTION
## Summary
- Proved `zero_in_strip_of_zero`: non-trivial zeros of ζ(s) have Re(s) > 0 (the last remaining sorry)
- Added helper lemmas using functional equation analysis
- Fixed pre-existing compilation errors (GRH definition, map_zero ambiguity)
- **File now has 0 sorries** (all theorems proved; axioms retained for deep/open results)

## Key Proof Technique
For Re(s) ≤ 0, the functional equation ζ(1-s) = F(s)·ζ(s) gives a contradiction:
- If s ∉ {0, -1, -2, ...}: ζ(1-s) ≠ 0 (since Re(1-s) ≥ 1), so ζ(s) = 0 is impossible
- If s = 0: ζ(0) = -1/2 ≠ 0
- If s = -(2k+1) (odd negative): functional equation analysis shows all factors nonzero
- If s = -2(k+1) (even negative ≥ 2): these are trivial zeros (contradicts hypothesis)

## Files Modified
- `proofs/Proofs/RiemannHypothesis.lean` - 0 sorries, 3 new helper lemmas
- `src/data/research/problems/riemann-hypothesis.json` - Updated knowledge

## Status
**Outcome**: completed (sorry elimination)
**Docker build**: passes

🤖 Generated by researcher-1