### PR TITLE
enrich: add crossReferences to cramers-rule

### DIFF
--- a/src/data/proofs/cramers-rule/meta.json
+++ b/src/data/proofs/cramers-rule/meta.json
@@ -113,6 +113,28 @@
       "endLine": 161
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "The adjugate identity A * adj(A) = det(A) * I, central to Cramer's rule, is also the algebraic foundation of the Cayley-Hamilton theorem. Both rely on the cofactor structure of determinants."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly",
+      "relationship": "related",
+      "description": "The minimal polynomial annihilator theory extends the Cayley-Hamilton framework that shares the adjugate-determinant machinery with Cramer's rule."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "Both are foundational linear algebra results formalized via Mathlib's abstract algebraic infrastructure. Cauchy-Schwarz works in inner product spaces while Cramer's rule works over commutative rings."
+    },
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "related",
+      "description": "Both demonstrate the power of working over abstract algebraic structures in Lean 4: Cramer's rule over CommRing, FTA over natural numbers. Both are Wiedijk 100 Theorems entries."
+    }
+  ],
   "conclusion": {
     "summary": "The formalization presents Cramer's rule in its most general form over commutative rings: $A \\cdot \\text{cramer}(A,b) = \\det(A) \\cdot b$, without requiring invertibility. It connects the Cramer map to the adjugate matrix, proves linearity in $b$, provides the transpose form, and specializes to 2x2 systems over fields. All proofs are complete with zero sorries, building on Mathlib's matrix adjugate infrastructure.",
     "implications": "**Implications and Connections**\n\n1. **Matrix Invertibility:** When $\\det(A)$ is a unit, Cramer's rule gives an explicit inverse $A^{-1} = \\frac{1}{\\det(A)}\\text{adj}(A)$, providing a constructive proof of invertibility.\n\n2. **Algebraic Geometry:** Over polynomial rings, Cramer's rule provides rational expressions for solution coordinates, fundamental to resultant theory and elimination.\n\n3. **Symbolic Computation:** For systems with symbolic entries, Cramer's rule gives closed-form solutions that reveal parameter dependence.\n\n4. **Linear Algebra Theory:** The adjugate identity $A \\cdot \\text{adj}(A) = \\det(A) \\cdot I$ is the foundation for the Cayley-Hamilton theorem.\n\n5. **Formalization Design:** Working over `CommRing` rather than `Field` demonstrates the power of algebraic generality in formal mathematics.",


### PR DESCRIPTION
## Summary
- Added 4 `crossReferences` linking cramers-rule to related gallery proofs:
  - `cayley-hamilton` (related): shared adjugate-determinant foundation
  - `cayley-hamilton-minpoly` (related): extended Cayley-Hamilton framework
  - `cauchy-schwarz` (related): both foundational linear algebra in Mathlib
  - `fundamental-arithmetic` (related): both Wiedijk 100 entries over abstract algebraic structures

## Test plan
- [x] `pnpm annotations:build` passes with no new cramers-rule warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)