### PR TITLE
enrich: add crossReferences to 6 proofs

### DIFF
--- a/src/data/proofs/derangements/meta.json
+++ b/src/data/proofs/derangements/meta.json
@@ -99,6 +99,23 @@
       "summary": "#check statements confirming the Mathlib API surface."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "inclusion-exclusion",
+      "relationship": "foundational",
+      "description": "The derangement formula D(n) = n! * sum((-1)^k/k!) is a direct application of the inclusion-exclusion principle, counting permutations that avoid all n fixed-point events."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "Both use inclusion-exclusion over arithmetic/combinatorial structures: derangements over permutation fixed points, Euler's totient over prime divisibility."
+    },
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "related",
+      "description": "The factorial n! in the derangement formula connects to prime factorization: D(n)/n! converges to 1/e, linking combinatorics to analysis via the Fundamental Theorem of Arithmetic."
+    }
+  ],
   "conclusion": {
     "summary": "The derangements formula $D_n = n! \\sum (-1)^k/k!$ is verified using Mathlib's `Combinatorics.Derangements` module. The formalization includes the formal definition (no fixed points), the recurrence relation $D_{n+2} = (n+1)(D_n + D_{n+1})$, the closed-form sum, concrete examples, and algebraic properties. The connection to $1/e$ through the Taylor series truncation is the central mathematical insight.",
     "implications": "The derangements formula is foundational in combinatorial probability. The convergence $D_n/n! \\to 1/e$ is an archetype of 'universal' probabilities in random combinatorics — the probability of a derangement stabilizes by $n = 5$ and is essentially independent of $n$ for large $n$. The inclusion-exclusion derivation serves as a pedagogical template for sieve methods in analytic combinatorics.",

--- a/src/data/proofs/euler-totient/meta.json
+++ b/src/data/proofs/euler-totient/meta.json
@@ -100,6 +100,28 @@
       "endLine": 136
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "chinese-remainder-non-coprime",
+      "relationship": "related",
+      "description": "The Chinese Remainder Theorem gives the multiplicativity of Euler's totient: phi(mn) = phi(m)*phi(n) for coprime m,n, which is key to computing phi for arbitrary integers."
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "related",
+      "description": "Euler's product formula phi(n) = n * prod(1 - 1/p) connects the totient function to the prime factorization of n, relating to the infinitude of primes."
+    },
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "The unique prime factorization from FTA is essential for computing phi(n) = n * prod(1 - 1/p) over the prime divisors of n."
+    },
+    {
+      "targetId": "gcd-algorithm",
+      "relationship": "related",
+      "description": "The GCD algorithm determines coprimality gcd(a,n) = 1, which is the hypothesis of Euler's theorem: a^phi(n) = 1 mod n."
+    }
+  ],
   "conclusion": {
     "summary": "The formalization presents Euler's theorem $a^{\\varphi(n)} = 1$ as a one-line consequence of Lagrange's theorem applied to the unit group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$. Fermat's little theorem is derived as a 3-line corollary via $\\varphi(p) = p-1$. The formalization includes totient function properties ($\\varphi(p) = p-1$, $\\varphi(p^k) = p^{k-1}(p-1)$), verified examples, and a counterexample demonstrating the coprimality requirement. All proofs are complete with zero sorries.",
     "implications": "**Implications and Applications**\n\n1. **RSA Cryptography:** Euler's theorem guarantees that RSA decryption inverts encryption: $m^{ed} \\equiv m \\pmod{n}$ when $ed \\equiv 1 \\pmod{\\varphi(n)}$.\n\n2. **Primality Testing:** Fermat's test checks if $a^{n-1} \\equiv 1 \\pmod{n}$. Failure implies $n$ is composite (but Carmichael numbers are false positives).\n\n3. **Discrete Logarithms:** The order of elements in $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ divides $\\varphi(n)$, fundamental to Diffie-Hellman key exchange.\n\n4. **Chinese Remainder Theorem:** The multiplicativity $\\varphi(mn) = \\varphi(m)\\varphi(n)$ for $\\gcd(m,n)=1$ connects Euler's theorem to CRT.\n\n5. **Mobius Inversion:** The identity $n = \\sum_{d \\mid n} \\varphi(d)$ connects the totient to Möbius inversion and the theory of arithmetic functions.",

--- a/src/data/proofs/fundamental-arithmetic/meta.json
+++ b/src/data/proofs/fundamental-arithmetic/meta.json
@@ -98,6 +98,28 @@
       "summary": "Proves prime iff singleton factorization, coprime implies disjoint factors ($\\gcd(m,n) = 1 \\Rightarrow$ disjoint lists), and connects `primeFactorsList.count` to `Nat.factorization` (the Finsupp representation)."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity",
+      "relationship": "foundational",
+      "description": "Bezout's identity (gcd(a,b) = ax + by) is the key lemma for proving Euclid's lemma (p|ab implies p|a or p|b), which underpins the uniqueness of prime factorization."
+    },
+    {
+      "targetId": "gcd-algorithm",
+      "relationship": "foundational",
+      "description": "The Euclidean algorithm computes GCDs, providing the constructive backbone for the division and factorization steps in FTA."
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "extends",
+      "description": "The existence part of FTA guarantees every integer > 1 has a prime factor; the infinitude of primes shows no finite set of primes suffices for all integers."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "Euler's totient function phi(n) = n * prod(1-1/p) is computed from the unique prime factorization guaranteed by FTA."
+    }
+  ],
   "conclusion": {
     "summary": "The formalization presents the Fundamental Theorem of Arithmetic with existence (via `Nat.prod_primeFactorsList`), uniqueness (via `primeFactorsList_unique` and Euclid's Lemma), the algebraic UFD characterization, and practical corollaries including coprime disjoint factors and the Finsupp factorization representation. All proofs are complete with zero sorries.",
     "implications": "The FTA underpins all of multiplicative number theory: the Möbius function, Euler's totient, the Riemann zeta function, and RSA cryptography all depend on unique factorization. The UFD characterization connects to algebraic number theory, where failure of unique factorization in number rings motivated Dedekind's theory of ideals.",

--- a/src/data/proofs/herons-formula/meta.json
+++ b/src/data/proofs/herons-formula/meta.json
@@ -89,6 +89,28 @@
       "summary": "Defines `triangle_area(a,b,c) = \\sqrt{s(s-a)(s-b)(s-c)}` and proves non-negativity via `sqrt_nonneg`. Concludes with `#check` statements exporting the main results."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "Heron's formula can be derived from the Pythagorean theorem by expressing the triangle altitude in terms of side lengths and applying a^2 + h^2 = c^2."
+    },
+    {
+      "targetId": "triangle-angle-sum",
+      "relationship": "related",
+      "description": "Both are fundamental triangle geometry results. The triangle angle sum (180 degrees) and Heron's formula together characterize Euclidean triangles."
+    },
+    {
+      "targetId": "triangle-inequality",
+      "relationship": "foundational",
+      "description": "The triangle inequality ensures s(s-a)(s-b)(s-c) >= 0 for valid triangles, making the square root in Heron's formula well-defined."
+    },
+    {
+      "targetId": "ptolemys-theorem",
+      "relationship": "related",
+      "description": "Both are classical geometry results from antiquity. Heron (c. 60 AD) and Ptolemy (c. 150 AD) developed foundational geometric computation tools."
+    }
+  ],
   "conclusion": {
     "summary": "The formalization provides a complete treatment of Heron's formula: the main identity in abstract inner product spaces via Mathlib, computable definitions of the semi-perimeter and Heron product, algebraic expansions proved by `ring`, concrete verifications for classic triangles, and the non-negativity theorem connecting Heron's formula to the triangle inequality. All proofs are complete with zero sorries.",
     "implications": "Heron's formula sits at the intersection of Euclidean geometry, algebra, and analysis. The algebraic expansion form is the basis for numerically stable area computation (Kahan's algorithm). The connection to the Cayley-Menger determinant generalizes to volumes of simplices in higher dimensions. In algebraic geometry, the formula relates to the discriminant of the triangle viewed as a polynomial system.",

--- a/src/data/proofs/ptolemys-theorem/meta.json
+++ b/src/data/proofs/ptolemys-theorem/meta.json
@@ -48,6 +48,23 @@
     {"id": "converse", "title": "Converse and Ptolemy's Inequality", "startLine": 209, "endLine": 231, "summary": "The converse: $AC \\cdot BD = AB \\cdot CD + AD \\cdot BC$ implies concyclicity. Ptolemy's inequality $AC \\cdot BD \\le AB \\cdot CD + AD \\cdot BC$ holds for all four-point configurations, with equality iff concyclic. Related to the cross-ratio being real and positive."},
     {"id": "history", "title": "Historical Context: The Almagest", "startLine": 233, "endLine": 268, "summary": "Historical discussion of chord tables ($\\text{chord}(\\theta) = d\\sin(\\theta/2)$), the equivalence to the sine addition formula $\\sin(\\alpha+\\beta) = \\sin\\alpha\\cos\\beta + \\cos\\alpha\\sin\\beta$, Ptolemy's legacy in astronomy (al-Khwarizmi, al-Biruni), and `#check` verification of all five exported theorems."}
   ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "Ptolemy's theorem generalizes the Pythagorean theorem: when the cyclic quadrilateral is a rectangle, AC*BD = AB*CD + BC*DA reduces to the Pythagorean relation on the diagonal."
+    },
+    {
+      "targetId": "herons-formula",
+      "relationship": "related",
+      "description": "Both are foundational classical geometry results. Ptolemy's theorem (c. 150 AD) and Heron's formula (c. 60 AD) provide algebraic tools for geometric computation from antiquity."
+    },
+    {
+      "targetId": "triangle-angle-sum",
+      "relationship": "related",
+      "description": "The inscribed angle theorem, closely related to the triangle angle sum, underpins the proof that opposite angles in a cyclic quadrilateral sum to 180 degrees."
+    }
+  ],
   "conclusion": {
     "summary": "This formalization verifies Ptolemy's Theorem (Wiedijk #95) using Mathlib's cospherical geometry framework. It provides the main theorem, three alternative formulations, a diagonal-product corollary, three numerical examples (including the Pythagorean theorem as a special case), and discusses the converse characterization and Ptolemy's inequality.",
     "implications": "Ptolemy's theorem bridges ancient and modern mathematics. It yields the trigonometric addition formulas (the foundation of trigonometry), generalizes the Pythagorean theorem, and characterizes cyclic quadrilaterals. The complex-number proof reveals connections to conformal mappings and inversive geometry. Ptolemy's inequality generalizes to higher dimensions and is related to the positive semidefiniteness of the Cayley-Menger determinant.",

--- a/src/data/proofs/triangular-reciprocals/meta.json
+++ b/src/data/proofs/triangular-reciprocals/meta.json
@@ -44,6 +44,23 @@
     {"id": "triangular-connection", "title": "Connection to Triangular Numbers", "startLine": 267, "endLine": 291, "summary": "Proves 1/T_n = 2/(n(n+1)) by showing n(n+1) is always even (case split on parity of n), then field_simp and linarith."},
     {"id": "examples", "title": "Pedagogical Examples", "startLine": 293, "endLine": 305, "summary": "Computes T_1 = 1, T_2 = 3, T_3 = 6, T_4 = 10, T_5 = 15 via native_decide. Exports main theorems with #check."}
   ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series",
+      "relationship": "related",
+      "description": "Both are classical infinite series with exact closed-form sums. The geometric series sum(r^n) = 1/(1-r) and sum(2/(n(n+1))) = 2 are paradigmatic examples of convergent series."
+    },
+    {
+      "targetId": "arithmetic-series",
+      "relationship": "related",
+      "description": "Triangular numbers T(n) = n(n+1)/2 are partial sums of the arithmetic series 1 + 2 + ... + n. The reciprocal sum inverts this relationship."
+    },
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "related",
+      "description": "The harmonic series sum(1/n) diverges, but sum(2/(n(n+1))) converges to 2. The key difference is the extra factor 1/(n+1) which provides sufficient decay via telescoping."
+    }
+  ],
   "conclusion": {
     "summary": "The telescoping series identity ∑1/T_n = 2 is fully verified, including convergence via comparison with the p-series, the epsilon-N limit argument, and the connection between triangular numbers and the product n(n+1).",
     "implications": "The telescoping technique generalizes to ∑1/(n(n+k)) via partial fractions with k terms, extending to all figurate number reciprocals (pentagonal, hexagonal, etc.). The comparison test framework connects these sums to p-series theory. Leibniz's 1673 evaluation of this series was a milestone in the development of calculus and infinite series theory.",


### PR DESCRIPTION
## Summary
Added `crossReferences` to 6 gallery proofs that were missing them (all quality 72, passes 1-2):

- **derangements**: links to inclusion-exclusion (foundational), euler-totient, fundamental-arithmetic
- **euler-totient**: links to chinese-remainder-non-coprime, infinitude-primes, fundamental-arithmetic (foundational), gcd-algorithm
- **fundamental-arithmetic**: links to bezout-identity (foundational), gcd-algorithm (foundational), infinitude-primes (extends), euler-totient
- **herons-formula**: links to pythagorean-theorem, triangle-angle-sum, triangle-inequality (foundational), ptolemys-theorem
- **triangular-reciprocals**: links to geometric-series, arithmetic-series, harmonic-divergence
- **ptolemys-theorem**: links to pythagorean-theorem, herons-formula, triangle-angle-sum

## Test plan
- [x] `pnpm annotations:build` passes with no new warnings for any of the 6 proofs

🤖 Generated with [Claude Code](https://claude.com/claude-code)