### PR TITLE
enrich: deepen erdos-107, erdos-1136, erdos-370, birch-swinnerton-dyer, erdos-1091

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/annotations.json
+++ b/src/data/proofs/birch-swinnerton-dyer/annotations.json
@@ -1,24 +1,33 @@
 [
   {
-    "id": "ann-intro",
+    "id": "ann-bsd-intro",
     "proofId": "birch-swinnerton-dyer",
-    "range": {"startLine": 16, "endLine": 89},
-    "type": "concept",
-    "title": "BSD Conjecture: Millennium Prize Problem",
-    "content": "**The Birch and Swinnerton-Dyer Conjecture**:\n\n> The algebraic rank of an elliptic curve equals its analytic rank.\n\n**Weak BSD**:\n$$\\text{rank}(E(\\mathbb{Q})) = \\text{ord}_{s=1} L(E, s)$$\n\n**Strong BSD**: The leading coefficient at s = 1 is:\n$$\\frac{\\Omega \\cdot R \\cdot |Ш| \\cdot \\prod c_p}{|E(\\mathbb{Q})_{\\text{tors}}|^2}$$\n\n**Status: OPEN** — One of 7 Millennium Prize Problems ($1,000,000)",
-    "significance": "critical",
-    "relatedConcepts": ["elliptic curve", "L-function", "rank"]
+    "range": {"startLine": 20, "endLine": 100},
+    "type": "context",
+    "title": "BSD Conjecture: Overview and Imports",
+    "content": "**The Birch and Swinnerton-Dyer Conjecture** -- one of the seven Millennium Prize Problems ($1,000,000). The conjecture connects the algebraic rank of an elliptic curve $E/\\mathbb{Q}$ (the number of independent rational points) with the analytic rank (the order of vanishing of $L(E,s)$ at $s=1$). The file imports Mathlib's elliptic curve infrastructure (`WeierstrassCurve`), L-series, complex analysis, and arithmetic functions. All definitions are noncomputable.",
+    "mathContext": {
+      "latex": "\\text{rank}(E(\\mathbb{Q})) = \\text{ord}_{s=1}\\, L(E, s)",
+      "description": "Weak BSD equates algebraic rank (from Mordell-Weil) with analytic rank (from L-function). Strong BSD gives the leading coefficient in terms of periods, regulators, Sha, and Tamagawa numbers."
+    },
+    "significance": "context",
+    "relatedConcepts": ["millennium-prize", "elliptic-curve", "L-function", "analytic-rank"],
+    "prerequisites": ["algebraic-geometry", "complex-analysis", "number-theory"]
   },
   {
     "id": "ann-elliptic-curve",
     "proofId": "birch-swinnerton-dyer",
-    "range": {"startLine": 116, "endLine": 130},
+    "range": {"startLine": 116, "endLine": 200},
     "type": "definition",
-    "title": "Elliptic Curves over ℚ",
-    "content": "**Elliptic Curve E/ℚ**:\n\nWeierstrass form:\n$$y^2 = x^3 + ax + b, \\quad a, b \\in \\mathbb{Q}$$\n\n**Discriminant**: Δ = −16(4a³ + 27b²) ≠ 0 (smoothness)\n\n**j-invariant**: j = −1728(4a³)/Δ\n\n**Key property**: E(ℚ) forms an abelian group under the chord-tangent law.",
-    "mathContext": "y² = x³ + ax + b",
-    "significance": "major",
-    "relatedConcepts": ["Weierstrass form", "discriminant", "j-invariant"]
+    "title": "Elliptic Curves over Q",
+    "content": "**EllipticCurveQ** is defined in short Weierstrass form $y^2 = x^3 + ax + b$ with $\\Delta = -16(4a^3 + 27b^2) \\neq 0$ (smoothness). The j-invariant is $j = -1728 \\cdot 4a^3/\\Delta$. A conversion `toWeierstrassCurve` embeds this into Mathlib's general `WeierstrassCurve` (setting $a_1 = a_2 = a_3 = 0$, $a_4 = a$, $a_6 = b$). Three verified theorems confirm the discriminant and $c_4$ match Mathlib's formulas.",
+    "mathContext": {
+      "latex": "E: y^2 = x^3 + ax + b, \\quad \\Delta = -16(4a^3 + 27b^2) \\neq 0, \\quad j = \\frac{-1728 \\cdot 4a^3}{\\Delta}",
+      "description": "The simplified EllipticCurveQ structure allows clear exposition while maintaining full compatibility with Mathlib via toWeierstrassCurve. The discriminant and c4 theorems are fully verified (no sorry)."
+    },
+    "significance": "key",
+    "relatedConcepts": ["weierstrass-form", "discriminant", "j-invariant", "mathlib-compatibility"],
+    "prerequisites": ["algebraic-curves", "rational-numbers"]
   },
   {
     "id": "ann-mordell-weil",
@@ -26,10 +35,14 @@
     "range": {"startLine": 128, "endLine": 191},
     "type": "theorem",
     "title": "Mordell-Weil Theorem",
-    "content": "**Mordell-Weil Theorem (1922-28)**:\n\nThe group E(ℚ) of rational points is **finitely generated**:\n$$E(\\mathbb{Q}) \\cong \\mathbb{Z}^r \\oplus T$$\n\nwhere:\n- r = **algebraic rank** (the key unknown!)\n- T = finite **torsion subgroup**\n\n**Mazur's Theorem (1977)**: T is one of exactly 15 groups.\n\n**Computing r**: Major algorithmic challenge in arithmetic geometry.",
-    "mathContext": "E(ℚ) ≅ ℤʳ ⊕ T",
+    "content": "**Mordell-Weil Theorem (1922-28)**: The group $E(\\mathbb{Q})$ of rational points on an elliptic curve is finitely generated: $E(\\mathbb{Q}) \\cong \\mathbb{Z}^r \\oplus T$, where $r$ is the **algebraic rank** (the key unknown in BSD) and $T$ is the finite torsion subgroup. By Mazur's theorem (1977), $T$ is one of exactly 15 possible groups. Computing $r$ is a major open algorithmic problem -- descent methods give upper bounds, but determining the exact rank is hard for rank $\\geq 2$.",
+    "mathContext": {
+      "latex": "E(\\mathbb{Q}) \\cong \\mathbb{Z}^r \\oplus T, \\quad |T| < \\infty, \\quad r = \\text{rank}(E(\\mathbb{Q}))",
+      "description": "The algebraic rank r is the number of independent rational points of infinite order. Mordell-Weil is foundational but does not give an algorithm for computing r -- BSD would provide one via L-function computation."
+    },
     "significance": "critical",
-    "relatedConcepts": ["Mordell-Weil", "rank", "torsion"]
+    "relatedConcepts": ["mordell-weil", "algebraic-rank", "torsion-subgroup", "mazur-theorem"],
+    "prerequisites": ["abelian-groups", "height-functions"]
   },
   {
     "id": "ann-l-function",
@@ -37,21 +50,29 @@
     "range": {"startLine": 193, "endLine": 271},
     "type": "definition",
     "title": "L-Functions of Elliptic Curves",
-    "content": "**L-function L(E, s)**:\n\nEuler product for Re(s) > 3/2:\n$$L(E, s) = \\prod_p L_p(E, s)^{-1}$$\n\n**Local factors**:\n- Good reduction: $L_p = 1 - a_p p^{-s} + p^{1-2s}$\n- Bad reduction: depends on type\n\nwhere $a_p = p + 1 - \\#E(\\mathbb{F}_p)$.\n\n**Root number** w(E) ∈ {±1}: Determines parity of analytic rank.\n\n**Key**: By modularity, L(E, s) has analytic continuation to all ℂ!",
-    "mathContext": "L(E, s) = ∏ Lₚ(E, s)⁻¹",
+    "content": "**$L(E, s)$** is defined via an Euler product for $\\text{Re}(s) > 3/2$: $L(E, s) = \\prod_p L_p(E, s)^{-1}$, where local factors at good primes are $L_p = 1 - a_p p^{-s} + p^{1-2s}$ with $a_p = p + 1 - \\#E(\\mathbb{F}_p)$. The **root number** $w(E) \\in \\{\\pm 1\\}$ determines the parity of the analytic rank. By the **modularity theorem** (Wiles 1995, BCDT 2001), $L(E, s)$ has analytic continuation to all of $\\mathbb{C}$.",
+    "mathContext": {
+      "latex": "L(E, s) = \\prod_{p} L_p(E, s)^{-1}, \\quad a_p = p + 1 - \\#E(\\mathbb{F}_p), \\quad w(E) \\in \\{\\pm 1\\}",
+      "description": "The L-function encodes point counts over finite fields into an analytic object. The Euler product converges for Re(s) > 3/2; analytic continuation comes from modularity. The functional equation relates L(E,s) to L(E,2-s) with sign w(E)."
+    },
     "significance": "critical",
-    "relatedConcepts": ["Euler product", "local factor", "root number"]
+    "relatedConcepts": ["euler-product", "local-factor", "root-number", "modularity"],
+    "prerequisites": ["complex-analysis", "finite-fields", "modular-forms"]
   },
   {
     "id": "ann-modularity",
     "proofId": "birch-swinnerton-dyer",
     "range": {"startLine": 273, "endLine": 314},
     "type": "theorem",
-    "title": "Modularity Theorem (Wiles)",
-    "content": "**Modularity Theorem (Wiles 1995, BCDT 2001)**:\n\nEvery elliptic curve E/ℚ is **modular**:\n$$L(E, s) = L(f, s)$$\n\nfor a weight 2 modular form f.\n\n**Consequences**:\n1. L(E, s) has **analytic continuation** to all ℂ\n2. **Functional equation**: Λ(E, s) = w · Λ(E, 2−s)\n\n**Historical**: This theorem completed Fermat's Last Theorem!",
-    "mathContext": "E/ℚ modular",
+    "title": "Modularity Theorem (Wiles 1995)",
+    "content": "**Modularity Theorem**: Every elliptic curve $E/\\mathbb{Q}$ is modular -- its L-function equals that of a weight 2 newform: $L(E, s) = L(f, s)$. This was proved for semistable curves by Wiles (1995, completing Fermat's Last Theorem) and extended to all $E/\\mathbb{Q}$ by Breuil-Conrad-Diamond-Taylor (2001). The key consequences are: (1) $L(E,s)$ has analytic continuation to all $\\mathbb{C}$, and (2) a functional equation $\\Lambda(E, s) = w(E) \\cdot \\Lambda(E, 2-s)$.",
+    "mathContext": {
+      "latex": "L(E, s) = L(f, s) \\quad \\text{for a weight 2 newform } f, \\quad \\Lambda(E, s) = w(E) \\cdot \\Lambda(E, 2-s)",
+      "description": "Axiomatized in the formalization. Modularity is essential for BSD because without analytic continuation, ord_{s=1} L(E,s) is not even defined."
+    },
     "significance": "critical",
-    "relatedConcepts": ["Wiles", "modular form", "FLT"]
+    "relatedConcepts": ["modular-forms", "fermat-last-theorem", "functional-equation", "wiles"],
+    "prerequisites": ["automorphic-forms", "galois-representations"]
   },
   {
     "id": "ann-analytic-rank",
@@ -59,72 +80,73 @@
     "range": {"startLine": 320, "endLine": 353},
     "type": "definition",
     "title": "Analytic Rank",
-    "content": "**Analytic Rank**:\n\n$$r_{\\text{an}}(E) = \\text{ord}_{s=1} L(E, s)$$\n\nThe order of vanishing at the central point s = 1.\n\n**Parity constraint** (from functional equation):\n- w(E) = +1 ⟹ r_an is even\n- w(E) = −1 ⟹ r_an is odd\n\n**BSD predicts**: r_an = r_alg (algebraic rank).\n\nThis is the heart of the conjecture!",
-    "mathContext": "r_an = ord_{s=1} L(E, s)",
-    "significance": "major",
-    "relatedConcepts": ["order of vanishing", "central point", "parity"]
+    "content": "The **analytic rank** $r_{\\text{an}}(E) = \\text{ord}_{s=1} L(E, s)$ is the order of vanishing of the L-function at the central point $s = 1$. The functional equation constrains its parity: $w(E) = +1$ implies $r_{\\text{an}}$ is even, $w(E) = -1$ implies odd. BSD predicts $r_{\\text{an}} = r_{\\text{alg}}$ -- the heart of the conjecture.",
+    "mathContext": {
+      "latex": "r_{\\text{an}}(E) = \\text{ord}_{s=1}\\, L(E, s), \\quad (-1)^{r_{\\text{an}}} = w(E)",
+      "description": "The parity constraint from the functional equation is the parity conjecture, proved by the Dokchitsers (2010). The analytic rank can be computed numerically to high precision."
+    },
+    "significance": "critical",
+    "relatedConcepts": ["order-of-vanishing", "central-value", "parity-conjecture"],
+    "prerequisites": ["L-function", "functional-equation"]
   },
   {
     "id": "ann-bsd-statement",
     "proofId": "birch-swinnerton-dyer",
     "range": {"startLine": 351, "endLine": 483},
     "type": "concept",
-    "title": "BSD Conjecture Statement",
-    "content": "**BSD CONJECTURE**:\n\n**Weak form**: rank(E(ℚ)) = ord_{s=1} L(E, s)\n\n**Strong form**: The leading coefficient is:\n$$\\lim_{s\\to 1} \\frac{L(E,s)}{(s-1)^r} = \\frac{\\Omega \\cdot R \\cdot |Ш| \\cdot \\prod c_p}{|E(\\mathbb{Q})_{\\text{tors}}|^2}$$\n\nwhere:\n- Ω = real period\n- R = regulator (height pairing determinant)\n- Ш = Shafarevich-Tate group (mysterious!)\n- cₚ = Tamagawa numbers",
-    "mathContext": "rank = ord L(E, 1)",
+    "title": "BSD Conjecture: Formal Statement",
+    "content": "**Weak BSD**: $\\text{rank}(E(\\mathbb{Q})) = \\text{ord}_{s=1} L(E, s)$.\n\n**Strong BSD**: The leading Taylor coefficient at $s = 1$ equals\n$$\\lim_{s \\to 1} \\frac{L(E,s)}{(s-1)^r} = \\frac{\\Omega \\cdot R \\cdot |\\text{III}| \\cdot \\prod c_p}{|E(\\mathbb{Q})_{\\text{tors}}|^2}$$\nwhere $\\Omega$ = real period, $R$ = regulator (Neron-Tate height pairing determinant), $\\text{III}$ = Shafarevich-Tate group (conjectured finite), $c_p$ = Tamagawa numbers at bad primes. Strong BSD implies weak BSD and the finiteness of $\\text{III}$.",
+    "mathContext": {
+      "latex": "\\lim_{s \\to 1} \\frac{L(E,s)}{(s-1)^r} = \\frac{\\Omega \\cdot R \\cdot |\\text{III}| \\cdot \\prod_p c_p}{|E(\\mathbb{Q})_{\\text{tors}}|^2}",
+      "description": "Both weak and strong BSD are stated as Props without asserting truth, correctly reflecting their open status. The strong form involves 5 arithmetic invariants, each difficult to compute independently."
+    },
     "significance": "critical",
-    "relatedConcepts": ["regulator", "Sha", "Tamagawa"]
+    "relatedConcepts": ["regulator", "shafarevich-tate", "tamagawa-number", "real-period"],
+    "prerequisites": ["mordell-weil", "L-function", "neron-tate-height"]
   },
   {
     "id": "ann-proven-cases",
     "proofId": "birch-swinnerton-dyer",
-    "range": {"startLine": 485, "endLine": 554},
+    "range": {"startLine": 485, "endLine": 594},
     "type": "theorem",
-    "title": "Proven Cases of BSD",
-    "content": "**PROVEN CASES**:\n\n**Rank 0** (Kolyvagin 1990):\n$$L(E, 1) \\neq 0 \\Rightarrow \\text{rank} = 0, Ш \\text{ finite}$$\n\n**Rank 1** (Gross-Zagier 1986 + Kolyvagin):\n$$L(E, 1) = 0, L'(E, 1) \\neq 0 \\Rightarrow \\text{rank} = 1, Ш \\text{ finite}$$\n\n**CM curves** (Coates-Wiles 1977):\nFor complex multiplication curves with L(E, 1) ≠ 0.\n\n**Open**: Rank ≥ 2 cases completely unknown!",
-    "mathContext": "Rank 0, 1 proven",
+    "title": "Proven Cases: Rank 0, 1, and Gross-Zagier",
+    "content": "**Rank 0** (Kolyvagin 1990): $L(E, 1) \\neq 0 \\Rightarrow \\text{rank} = 0$ and $\\text{III}$ is finite.\n**Rank 1** (Gross-Zagier 1986 + Kolyvagin): $L(E, 1) = 0, L'(E, 1) \\neq 0 \\Rightarrow \\text{rank} = 1$ and $\\text{III}$ is finite.\n**CM curves** (Coates-Wiles 1977): BSD for CM curves with $L(E, 1) \\neq 0$.\n\nThe **Gross-Zagier formula** $L'(E, 1) = c \\cdot \\hat{h}(P_K)$ bridges L-functions and Heegner points. If $L'(E, 1) \\neq 0$, the Heegner point $P_K$ has nonzero height, hence is non-torsion, giving an explicit generator.\n\n**Rank $\\geq 2$ is completely open!**",
+    "mathContext": {
+      "latex": "L(E, 1) \\neq 0 \\Rightarrow r = 0; \\quad L'(E, 1) \\neq 0 \\Rightarrow r \\leq 1; \\quad L'(E, 1) = c \\cdot \\hat{h}(P_K)",
+      "description": "These are axiomatized as they require deep machinery (Euler systems, Heegner points). Kolyvagin's Euler system method is the deepest technique available for BSD, but it cannot handle rank >= 2."
+    },
     "significance": "critical",
-    "relatedConcepts": ["Kolyvagin", "Gross-Zagier", "Heegner points"]
-  },
-  {
-    "id": "ann-gross-zagier",
-    "proofId": "birch-swinnerton-dyer",
-    "range": {"startLine": 556, "endLine": 594},
-    "type": "theorem",
-    "title": "Gross-Zagier Formula",
-    "content": "**Gross-Zagier Formula (1986)**:\n\n$$L'(E, 1) = c \\cdot \\hat{h}(P_K)$$\n\nwhere:\n- P_K = Heegner point from CM theory\n- ĥ = Néron-Tate height\n- c = explicit constant\n\n**Significance**:\n- Bridges L-functions (analysis) and rational points (algebra)\n- If L'(E, 1) ≠ 0, the Heegner point is non-torsion\n- Combined with Kolyvagin ⟹ rank = 1",
-    "mathContext": "L'(E, 1) ~ height of Heegner point",
-    "significance": "major",
-    "relatedConcepts": ["Heegner point", "Néron-Tate height", "CM theory"]
+    "relatedConcepts": ["kolyvagin", "gross-zagier", "heegner-point", "euler-system"],
+    "prerequisites": ["L-function", "mordell-weil", "CM-theory"]
   },
   {
     "id": "ann-computational",
     "proofId": "birch-swinnerton-dyer",
     "range": {"startLine": 596, "endLine": 656},
     "type": "concept",
-    "title": "Computational Evidence",
-    "content": "**Computational Verification**:\n\n- BSD verified for **millions** of elliptic curves\n- All curves with conductor N ≤ 500,000 checked\n- **No counterexamples ever found!**\n- Leading coefficient matches to high precision\n\n**Congruent Numbers**:\n\nn is congruent (area of rational right triangle) iff:\n$$\\text{rank}(E_n) > 0 \\Leftrightarrow L(E_n, 1) = 0$$\n\nwhere E_n: y² = x³ − n²x.\n\nBSD connects geometry to L-values!",
-    "significance": "major",
-    "relatedConcepts": ["congruent numbers", "computation", "LMFDB"]
-  },
-  {
-    "id": "ann-why-hard",
-    "proofId": "birch-swinnerton-dyer",
-    "range": {"startLine": 628, "endLine": 656},
-    "type": "concept",
-    "title": "Why BSD is Hard",
-    "content": "**Obstacles to Proving BSD**:\n\n1. **Higher rank**: Kolyvagin's methods only work for rank ≤ 1. No way to construct enough independent points for rank ≥ 2.\n\n2. **Sha is mysterious**: Cannot compute |Ш| in general. Examples with |Ш| > 10⁸ exist!\n\n3. **Finding points**: Even if rank ≥ 2, finding explicit generators is computationally hard.\n\n4. **Average rank** (Bhargava-Shankar): ≤ 1, so BSD \"usually\" true, but proving it universally remains elusive.",
-    "significance": "minor",
-    "relatedConcepts": ["Sha", "Euler systems", "descent"]
+    "title": "Computational Evidence and Obstacles",
+    "content": "BSD has been verified computationally for millions of elliptic curves (all with conductor $N \\leq 500{,}000$) with no counterexamples. The leading coefficient matches the predicted formula to high precision. The **congruent number problem** provides a beautiful application: $n$ is a congruent number iff $\\text{rank}(E_n) > 0$ where $E_n: y^2 = x^3 - n^2x$, and BSD predicts this is equivalent to $L(E_n, 1) = 0$.\n\n**Why BSD is hard**: (1) Kolyvagin's Euler system method only works for rank $\\leq 1$; (2) $\\text{III}$ cannot be computed in general; (3) finding generators for rank $\\geq 2$ is computationally difficult. Bhargava-Shankar showed average rank $\\leq 1$.",
+    "mathContext": {
+      "latex": "n \\text{ congruent} \\;\\Leftrightarrow\\; \\text{rank}(E_n) > 0 \\;\\Leftrightarrow\\; L(E_n, 1) = 0, \\quad E_n: y^2 = x^3 - n^2x",
+      "description": "The congruent number problem reduces via BSD to computing L-values. Computational verification via LMFDB databases provides overwhelming evidence for BSD."
+    },
+    "significance": "key",
+    "relatedConcepts": ["congruent-numbers", "LMFDB", "average-rank", "bhargava-shankar"],
+    "prerequisites": ["bsd-conjecture", "computational-number-theory"]
   },
   {
     "id": "ann-summary",
     "proofId": "birch-swinnerton-dyer",
     "range": {"startLine": 708, "endLine": 749},
     "type": "concept",
-    "title": "Problem Status: OPEN",
-    "content": "**BSD Conjecture: Still OPEN since 1965**\n\n**Proven cases**:\n- Rank 0: L(E,1) ≠ 0 ⟹ rank = 0 ✓ (Kolyvagin)\n- Rank 1: L(E,1) = 0, L'(E,1) ≠ 0 ⟹ rank = 1 ✓ (GZ + K)\n- CM curves with L(E,1) ≠ 0 ✓ (Coates-Wiles)\n- Parity conjecture ✓ (Dokchitsers)\n\n**OPEN for rank ≥ 2**!\n\n**Significance**:\n- Central to modern number theory\n- Connects arithmetic and analysis\n- Applications to cryptography\n\n**Prize**: $1,000,000 Millennium Prize",
-    "significance": "minor",
-    "relatedConcepts": ["open problem", "Millennium Prize", "number theory"]
+    "title": "Status Summary",
+    "content": "**BSD Conjecture: OPEN since 1965.** Proven cases: rank 0 (Kolyvagin), rank 1 (Gross-Zagier + Kolyvagin), CM curves with $L(E,1) \\neq 0$ (Coates-Wiles), parity conjecture (Dokchitsers). Open for rank $\\geq 2$. Central to modern number theory, connecting arithmetic and analysis. Millennium Prize: $1,000,000.",
+    "mathContext": {
+      "latex": "\\text{Proven: } r_{\\text{an}} \\leq 1; \\quad \\text{Open: } r_{\\text{an}} \\geq 2; \\quad \\text{Prize: \\$1{,}000{,}000}",
+      "description": "The formalization provides the mathematical framework and formal statement without claiming to prove BSD. It serves as educational infrastructure for one of the deepest open problems in mathematics."
+    },
+    "significance": "context",
+    "relatedConcepts": ["open-problem", "millennium-prize", "arithmetic-geometry"],
+    "prerequisites": ["all-preceding-sections"]
   }
 ]

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -18,59 +18,135 @@
     "mathlibDependencies": [
       {
         "theorem": "WeierstrassCurve",
-        "description": "Elliptic curve definitions",
+        "description": "General Weierstrass curve structure for elliptic curves",
         "module": "Mathlib.AlgebraicGeometry.EllipticCurve.Weierstrass"
+      },
+      {
+        "theorem": "LSeries",
+        "description": "L-series definitions for defining L(E,s)",
+        "module": "Mathlib.NumberTheory.LSeries.Basic"
+      },
+      {
+        "theorem": "Complex.exp",
+        "description": "Complex exponential and analytic functions for L-function theory",
+        "module": "Mathlib.Analysis.Complex.Basic"
       }
     ],
     "originalContributions": [
-      "Formal statement of BSD conjecture (weak and strong forms)",
-      "Definition of L-functions for elliptic curves",
-      "Known cases (rank 0 and 1)",
-      "Educational context"
+      "EllipticCurveQ structure: simplified short Weierstrass form y^2 = x^3 + ax + b",
+      "toWeierstrassCurve: verified embedding into Mathlib's WeierstrassCurve",
+      "toWeierstrassCurve_discriminant: discriminant formula verified by ring",
+      "toWeierstrassCurve_c4: c4 = -48a verified",
+      "L-function definition via Euler product with local factors",
+      "Weak and strong BSD conjecture statements as Props",
+      "Rank 0 and rank 1 proven cases axiomatized (Kolyvagin, Gross-Zagier)",
+      "Gross-Zagier formula axiomatized",
+      "Congruent number connection and computational evidence"
     ],
     "dateAdded": "12/29/25",
-    "millenniumProblem": "bsd"
+    "millenniumProblem": "bsd",
+    "proofRepoPath": "Proofs/BirchSwinnertonDyer.lean"
   },
   "overview": {
-    "historicalContext": "The BSD conjecture arose from extensive computational experiments in the 1960s. It connects arithmetic (rational points) with analysis (L-functions) in a precise quantitative way.",
+    "historicalContext": "The BSD conjecture arose from pioneering computational experiments by Bryan Birch and Peter Swinnerton-Dyer at Cambridge in the early 1960s. Using the EDSAC computer, they computed the product of local factors N_p/p for many elliptic curves and observed that the growth rate of this product as p -> infinity appeared to correlate with the number of rational points on the curve. In 1965, they published their conjecture: the rank of the Mordell-Weil group E(Q) equals the order of vanishing of the L-function L(E, s) at s = 1.\n\nThe first major progress came from Coates and Wiles (1977), who proved BSD for elliptic curves with complex multiplication when L(E, 1) != 0. The breakthrough decade was the 1980s-90s: Gross and Zagier (1986) established their celebrated formula relating L'(E, 1) to the height of Heegner points, and Kolyvagin (1990) introduced Euler systems to prove the rank 0 and rank 1 cases. These results established that if L(E, 1) != 0 then rank = 0, and if L(E, 1) = 0 but L'(E, 1) != 0 then rank = 1, with the Shafarevich-Tate group finite in both cases.\n\nWiles' proof of the modularity theorem for semistable curves (1995) -- which famously proved Fermat's Last Theorem as a corollary -- was essential for BSD because it guaranteed that L(E, s) has analytic continuation, making the order of vanishing at s = 1 well-defined. Breuil-Conrad-Diamond-Taylor (2001) completed the modularity theorem for all elliptic curves over Q.\n\nIn 2000, the Clay Mathematics Institute designated BSD as one of seven Millennium Prize Problems, carrying a $1,000,000 prize. Despite massive computational evidence (verified for all curves with conductor <= 500,000 with no counterexamples), the conjecture remains open for rank >= 2. Bhargava and Shankar (2015) showed the average rank of elliptic curves is at most 7/6, providing statistical evidence that BSD is 'usually true', but a proof for individual curves of higher rank remains elusive.",
     "problemStatement": "**Weak BSD:** rank(E(Q)) = ord_{s=1} L(E,s)\n\n**Strong BSD:** The leading Taylor coefficient of L(E,s) at s=1 equals a precise formula involving periods, regulators, and the Shafarevich-Tate group.",
-    "proofStrategy": "This file provides:\n1. Abstract definitions of elliptic curves and L-functions\n2. The formal BSD statement\n3. Known proven cases (rank 0, rank 1)",
+    "proofStrategy": "The formalization provides a complete educational framework for BSD. Part I defines EllipticCurveQ in short Weierstrass form with verified embedding into Mathlib's WeierstrassCurve (discriminant and c4 theorems proved by ring). Part II defines L-functions via Euler products with local factors, analytic continuation (from modularity), and the root number. Part III states the analytic rank and both weak and strong BSD as Props. Part IV axiomatizes the proven cases (rank 0, rank 1, Gross-Zagier formula) and presents computational evidence and the congruent number application.",
     "keyInsights": [
-      "The conjecture is OPEN - one of the Millennium Prize Problems",
-      "Proven for rank 0 and rank 1 by Gross-Zagier and Kolyvagin",
-      "Modularity theorem is essential (proven by Wiles et al.)"
+      "BSD connects two fundamentally different invariants of an elliptic curve: the algebraic rank (from Mordell-Weil, counting independent rational points) and the analytic rank (from the L-function, an analytic object encoding arithmetic data)",
+      "The modularity theorem (Wiles et al.) is a prerequisite for even stating BSD precisely, since L(E,s) needs analytic continuation to define ord_{s=1}",
+      "Rank 0 and rank 1 are proved via Kolyvagin's Euler systems and the Gross-Zagier formula, but these methods fundamentally cannot reach rank >= 2",
+      "The strong form of BSD predicts a precise leading coefficient formula involving 5 arithmetic invariants, making it far more than just an equality of ranks",
+      "The congruent number problem provides a beautiful application: n is a congruent number iff rank(E_n) > 0 iff L(E_n, 1) = 0",
+      "The formalization connects directly to Mathlib via toWeierstrassCurve with verified discriminant and c4 formulas"
     ]
   },
   "sections": [
     {
+      "id": "docstring",
+      "title": "Module Docstring",
+      "startLine": 20,
+      "endLine": 93,
+      "summary": "Comprehensive overview: BSD statement (weak and strong), status table (proven vs conjectured components), historical timeline (1960s-2001), Mathlib dependencies, and references."
+    },
+    {
       "id": "elliptic-curves",
-      "title": "Elliptic Curves",
-      "startLine": 1,
-      "endLine": 100,
-      "summary": "Definition of elliptic curves and the Mordell-Weil group."
+      "title": "Part I: Elliptic Curves over Q",
+      "startLine": 104,
+      "endLine": 200,
+      "summary": "EllipticCurveQ structure (short Weierstrass form), discriminant and j-invariant definitions, toWeierstrassCurve embedding into Mathlib, verified discriminant/c4 theorems."
+    },
+    {
+      "id": "mordell-weil",
+      "title": "Mordell-Weil and Algebraic Rank",
+      "startLine": 128,
+      "endLine": 191,
+      "summary": "Mordell-Weil theorem (E(Q) finitely generated), algebraic rank definition, torsion subgroup. The rank r is the key algebraic unknown in BSD."
     },
     {
       "id": "l-functions",
-      "title": "L-Functions",
-      "startLine": 101,
-      "endLine": 180,
-      "summary": "Definition of the L-function and analytic continuation."
+      "title": "Part II: L-Functions",
+      "startLine": 193,
+      "endLine": 314,
+      "summary": "L(E,s) via Euler product with local factors, a_p = p+1-#E(F_p), root number w(E), modularity theorem (axiomatized), analytic continuation and functional equation."
     },
     {
-      "id": "bsd",
-      "title": "The BSD Conjecture",
-      "startLine": 181,
-      "endLine": 260,
-      "summary": "Statement of weak and strong BSD."
+      "id": "analytic-rank",
+      "title": "Analytic Rank",
+      "startLine": 320,
+      "endLine": 353,
+      "summary": "Analytic rank r_an = ord_{s=1} L(E,s), parity constraint from functional equation, connection to weak BSD."
+    },
+    {
+      "id": "bsd-statement",
+      "title": "Part III: The BSD Conjecture",
+      "startLine": 351,
+      "endLine": 483,
+      "summary": "Formal statement of weak BSD (rank = analytic rank) and strong BSD (leading coefficient formula with Omega, R, Sha, c_p, torsion). Both stated as Props, correctly reflecting open status."
+    },
+    {
+      "id": "proven-cases",
+      "title": "Part IV: Proven Cases",
+      "startLine": 485,
+      "endLine": 594,
+      "summary": "Rank 0 (Kolyvagin 1990), rank 1 (Gross-Zagier + Kolyvagin), CM curves (Coates-Wiles 1977). Gross-Zagier formula L'(E,1) = c * h(P_K). All axiomatized."
+    },
+    {
+      "id": "computational",
+      "title": "Computational Evidence",
+      "startLine": 596,
+      "endLine": 656,
+      "summary": "Verified for millions of curves, congruent number application E_n: y^2 = x^3 - n^2x, obstacles to proving general BSD (Sha computation, higher rank)."
+    },
+    {
+      "id": "summary",
+      "title": "Summary and Status",
+      "startLine": 708,
+      "endLine": 749,
+      "summary": "BSD remains OPEN since 1965. Proven for rank 0 and 1. Millennium Prize: $1,000,000. Central to arithmetic geometry."
     }
   ],
   "conclusion": {
-    "summary": "The BSD Conjecture remains open. This formalization provides the mathematical framework and statement, along with the known partial results.",
-    "implications": "BSD is central to arithmetic geometry. A proof would have profound implications for understanding elliptic curves and their rational points.",
+    "summary": "The BSD Conjecture remains one of the deepest open problems in mathematics. This formalization provides a comprehensive framework: elliptic curves connected to Mathlib via verified embeddings, L-functions defined via Euler products, both weak and strong BSD formally stated, and proven cases (rank 0, 1) axiomatized. The formalization serves as educational infrastructure for understanding this Millennium Prize Problem.",
+    "implications": "A proof of BSD would have profound consequences: it would provide an algorithm for computing the rank of any elliptic curve (via L-function computation), resolve the congruent number problem completely, establish finiteness of the Shafarevich-Tate group, and represent a landmark in the Langlands program connecting arithmetic and automorphic forms.",
     "openQuestions": [
-      "Is the Shafarevich-Tate group always finite?",
-      "Can we extend the rank 0 and 1 results to higher rank?",
-      "What is the connection to the Bloch-Kato conjecture?"
+      "Is the Shafarevich-Tate group always finite? (Implied by strong BSD)",
+      "Can Kolyvagin's Euler system method be extended to rank >= 2?",
+      "What is the connection between BSD and the Bloch-Kato conjecture for general motives?",
+      "Can p-adic methods (Iwasawa theory) provide progress toward higher rank cases?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "proofId": "fundamental-theorem-algebra",
+      "relationship": "Both concern deep connections between algebraic structures and analytic properties -- BSD connects rational points (algebra) with L-functions (analysis)"
+    },
+    {
+      "proofId": "hilbert-17",
+      "relationship": "Both are landmark problems connecting algebra and analysis -- Hilbert 17 (sums of squares and positive polynomials) and BSD (rational points and L-functions)"
+    },
+    {
+      "proofId": "kepler-conjecture",
+      "relationship": "Both are famous long-standing conjectures that required fundamentally new techniques -- BSD remains open while Kepler was resolved by Hales (1998)"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1091/annotations.json
+++ b/src/data/proofs/erdos-1091/annotations.json
@@ -2,120 +2,136 @@
   {
     "id": "ann-1091-header",
     "proofId": "erdos-1091",
-    "range": { "startLine": 1, "endLine": 18 },
-    "type": "concept",
-    "title": "Problem Overview",
-    "content": "**Erdős Problem #1091** asks: Must a K₄-free graph with χ(G) = 4 contain an odd cycle with at least two diagonals? The first question is SOLVED (Voss 1982). The general f(r) question remains OPEN.",
-    "mathContext": "A K₄-free graph contains no complete graph on 4 vertices. Despite being K₄-free, such graphs can have chromatic number 4 (needing 4 colors).",
-    "significance": "critical",
-    "relatedConcepts": ["K4-free", "chromatic-number", "odd-cycles", "graph-diagonals"]
+    "range": { "startLine": 1, "endLine": 31 },
+    "type": "context",
+    "title": "Problem Overview and Setup",
+    "content": "**Erdos Problem #1091**: Must a $K_4$-free graph with $\\chi(G) = 4$ contain an odd cycle with at least two diagonals? The first question is **SOLVED** (Voss 1982). The general $f(r)$ question remains **OPEN**. The formalization imports Mathlib's SimpleGraph, Coloring, and Clique infrastructure, working with finite types with decidable equality.",
+    "mathContext": {
+      "latex": "K_4\\text{-free}, \\quad \\chi(G) \\geq 4 \\;\\Rightarrow\\; \\exists\\, C \\text{ odd cycle with } \\geq 2 \\text{ diagonals}",
+      "description": "A K4-free graph has no complete subgraph on 4 vertices. Despite this clique restriction, the chromatic number can still be 4 or higher (by Mycielski's construction). The problem asks about structural consequences for odd cycles."
+    },
+    "significance": "context",
+    "relatedConcepts": ["K4-free", "chromatic-number", "odd-cycles", "graph-diagonals"],
+    "prerequisites": ["graph-theory-basics", "coloring"]
   },
   {
     "id": "ann-1091-cycle",
     "proofId": "erdos-1091",
-    "range": { "startLine": 33, "endLine": 41 },
+    "range": { "startLine": 33, "endLine": 44 },
     "type": "definition",
-    "title": "Cycle",
-    "content": "A cycle is formalized as a list of distinct vertices where consecutive vertices are adjacent, plus a closing edge from last to first vertex. Length must be ≥ 3.",
-    "significance": "critical"
+    "title": "Cycle and Odd Cycle",
+    "content": "A **cycle** in a graph $G$ is a list of $\\geq 3$ distinct vertices where consecutive vertices are adjacent, plus a closing edge from last to first. The `Cycle.isOdd` predicate checks if the length is odd. This formalization captures cycles as ordered vertex lists rather than using Mathlib's Walk type, allowing direct index-based reasoning about diagonals.",
+    "mathContext": {
+      "latex": "C = (v_0, v_1, \\ldots, v_{k-1}), \\quad v_i \\sim v_{i+1}, \\quad v_{k-1} \\sim v_0, \\quad k \\geq 3",
+      "description": "The Cycle structure stores vertices as a List V with explicit adjacency proofs for consecutive pairs and the closing edge. Nodup ensures distinctness. Odd cycles have odd length (important for graph coloring theory)."
+    },
+    "significance": "key",
+    "relatedConcepts": ["graph-cycle", "odd-cycle", "list-representation"],
+    "prerequisites": ["simple-graph", "list-operations"]
   },
   {
     "id": "ann-1091-diagonal",
     "proofId": "erdos-1091",
-    "range": { "startLine": 46, "endLine": 54 },
+    "range": { "startLine": 46, "endLine": 60 },
     "type": "definition",
-    "title": "Cycle.isDiagonal",
-    "content": "A diagonal of a cycle is an edge between two non-consecutive vertices. The definition checks that the vertices are in the cycle but not adjacent in the cyclic order.",
-    "significance": "critical"
+    "title": "Cycle Diagonals and Count",
+    "content": "A **diagonal** of a cycle $C$ is an edge $uv$ where $u, v \\in C$ are non-consecutive in the cyclic order but adjacent in $G$. The `diagonalCount` counts unordered pairs $\\{u, v\\}$ with $u < v$ to avoid double-counting. Diagonals create 'shortcuts' across the cycle, and their existence constrains the graph's structure -- K4-free graphs with high $\\chi$ must have such shortcuts in their odd cycles.",
+    "mathContext": {
+      "latex": "\\text{isDiagonal}(u, v) \\;:\\Leftrightarrow\\; u, v \\in C \\;\\wedge\\; u \\not\\sim_{\\text{cyc}} v \\;\\wedge\\; u \\sim_G v",
+      "description": "Non-consecutiveness is checked modularly: (i+1) mod |C| != j and (j+1) mod |C| != i. The diagonal count uses Finset.filter on V x V with the ordering constraint u < v."
+    },
+    "significance": "critical",
+    "relatedConcepts": ["chord", "cycle-diagonal", "shortcut-edge"],
+    "prerequisites": ["cycle-definition", "modular-arithmetic"]
   },
   {
     "id": "ann-1091-k4free",
     "proofId": "erdos-1091",
-    "range": { "startLine": 62, "endLine": 64 },
+    "range": { "startLine": 62, "endLine": 68 },
     "type": "definition",
-    "title": "IsK4Free",
-    "content": "A graph is K₄-free if it contains no clique of size 4, i.e., no 4 vertices that are all pairwise adjacent.",
-    "significance": "critical"
+    "title": "K4-Free and Chromatic Number",
+    "content": "**IsK4Free**: $G$ contains no clique of size 4: $\\neg \\exists\\, S \\subseteq V,\\, |S| = 4 \\wedge G.\\text{IsClique}(S)$. **chromaticNumber**: the minimum $k$ such that $G$ has a proper $k$-coloring, defined via $\\text{sSup}$ of valid coloring sizes. K4-free graphs can still require arbitrarily many colors (Mycielski's theorem), making the interaction between clique-freeness and chromatic number subtle.",
+    "mathContext": {
+      "latex": "\\text{IsK4Free}(G) \\;:\\Leftrightarrow\\; \\omega(G) \\leq 3, \\qquad \\chi(G) = \\min\\{k : G \\text{ is } k\\text{-colorable}\\}",
+      "description": "Uses Mathlib's SimpleGraph.IsClique for the clique condition and SimpleGraph.Coloring for proper colorings. The chromatic number definition uses sSup, which may differ from the standard infimum convention."
+    },
+    "significance": "critical",
+    "relatedConcepts": ["clique-number", "chromatic-number", "clique-free"],
+    "prerequisites": ["simple-graph", "graph-coloring", "clique"]
   },
   {
     "id": "ann-1091-larson",
     "proofId": "erdos-1091",
-    "range": { "startLine": 74, "endLine": 78 },
+    "range": { "startLine": 70, "endLine": 94 },
     "type": "axiom",
-    "title": "Larson's Theorem (1979)",
-    "content": "Every K₄-free graph with χ(G) ≥ 4 contains an odd cycle with at least one diagonal. This was the first major result on this problem.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1091-bollobas",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 80, "endLine": 94 },
-    "type": "axiom",
-    "title": "Bollobás-Erdős Conjecture",
-    "content": "The Bollobás-Erdős alternatives (proved by Larson 1979): if G is K₄-free with no odd cycle having a diagonal, then G is bipartite, has a cut vertex, or has a vertex of degree ≤ 2.",
-    "significance": "key"
+    "title": "Larson's Theorem and Bollobas-Erdos (1979)",
+    "content": "**Larson (1979)**: Every $K_4$-free graph with $\\chi(G) \\geq 4$ contains an odd cycle with at least **one** diagonal. This was the first major result.\n\n**Bollobas-Erdos Conjecture** (proved by Larson): If $G$ is $K_4$-free with no odd cycle having a diagonal, then $G$ is bipartite, has a cut vertex, or has a vertex of degree $\\leq 2$. The three alternatives are captured by the `BollobasErdosAlternative` structure.",
+    "mathContext": {
+      "latex": "K_4\\text{-free} \\;\\wedge\\; \\chi \\geq 4 \\;\\Rightarrow\\; \\exists\\, C \\text{ odd, } \\text{diag}(C) \\geq 1",
+      "description": "Both axiomatized. Larson's theorem is subsumed by Voss's stronger result. The Bollobas-Erdos alternatives show that the absence of odd-cycle diagonals forces extreme structural restrictions on K4-free graphs."
+    },
+    "significance": "key",
+    "relatedConcepts": ["structural-theorem", "bipartite", "cut-vertex"],
+    "prerequisites": ["K4-free", "chromatic-number", "cycle-diagonal"]
   },
   {
     "id": "ann-1091-voss",
     "proofId": "erdos-1091",
-    "range": { "startLine": 100, "endLine": 104 },
+    "range": { "startLine": 96, "endLine": 111 },
     "type": "axiom",
-    "title": "Voss's Theorem (1982)",
-    "content": "Every K₄-free graph with χ(G) ≥ 4 contains an odd cycle with at least TWO diagonals. This is a significant strengthening of Larson's result and solves the first question.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1091-implies",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 106, "endLine": 111 },
-    "type": "theorem",
-    "title": "voss_implies_larson",
-    "content": "Voss's theorem (≥2 diagonals) immediately implies Larson's theorem (≥1 diagonal). Fully proved.",
-    "significance": "supporting"
+    "title": "Voss's Theorem (1982): Two Diagonals",
+    "content": "**Voss (1982)**: Every $K_4$-free graph with $\\chi(G) \\geq 4$ contains an odd cycle with at least **two** diagonals. This significant strengthening of Larson's result answers the first question of Erdos #1091 affirmatively. The corollary `voss_implies_larson` is fully verified: $\\geq 2$ implies $\\geq 1$ via `Nat.le_of_succ_le`.",
+    "mathContext": {
+      "latex": "K_4\\text{-free} \\;\\wedge\\; \\chi \\geq 4 \\;\\Rightarrow\\; \\exists\\, C \\text{ odd, } \\text{diag}(C) \\geq 2",
+      "description": "Axiomatized. The proof uses deep structural analysis of K4-free graphs with high chromatic number, showing that odd cycles in such graphs must have rich diagonal structure."
+    },
+    "significance": "critical",
+    "relatedConcepts": ["strengthening", "diagonal-count", "solved"],
+    "prerequisites": ["K4-free", "chromatic-number"]
   },
   {
     "id": "ann-1091-wheel",
     "proofId": "erdos-1091",
-    "range": { "startLine": 117, "endLine": 135 },
-    "type": "definition",
-    "title": "PentagonalWheel",
-    "content": "The pentagonal wheel: vertices 0-4 form a 5-cycle, vertex 5 is the center connected to all of 0-4. This graph is K₄-free with χ = 4 but every odd cycle has ≤ 2 diagonals.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1091-not3",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 147, "endLine": 157 },
+    "range": { "startLine": 113, "endLine": 157 },
     "type": "theorem",
-    "title": "three_diagonals_not_guaranteed",
-    "content": "Proof that 3 diagonals cannot be universally guaranteed: the pentagonal wheel is a counterexample satisfying all hypotheses but having ≤ 2 diagonals in every odd cycle. Fully proved from axioms about the wheel.",
-    "significance": "critical"
+    "title": "Pentagonal Wheel: Extremal Counterexample",
+    "content": "The **pentagonal wheel** $W_5$: vertices $\\{0,1,2,3,4\\}$ form a 5-cycle, vertex 5 is the center connected to all outer vertices. Properties (axiomatized): $W_5$ is $K_4$-free, $\\chi(W_5) = 4$, and every odd cycle has $\\leq 2$ diagonals. The **three_diagonals_not_guaranteed** theorem is fully verified: it assumes the universal $\\geq 3$ statement, instantiates it with $W_5$, and derives a contradiction via `omega` from the max-2-diagonals axiom. This shows Voss's bound is tight.",
+    "mathContext": {
+      "latex": "W_5 = C_5 + K_1, \\quad \\omega(W_5) = 3, \\quad \\chi(W_5) = 4, \\quad \\max_{C \\text{ odd}} \\text{diag}(C) = 2",
+      "description": "PentagonalWheel is defined as a SimpleGraph (Fin 6) with explicit adjacency. The symmetry and loop-free properties are proved by case analysis. The extremal property (max 2 diagonals in odd cycles) makes it the tight counterexample for the 3-diagonal question."
+    },
+    "significance": "critical",
+    "relatedConcepts": ["wheel-graph", "extremal-example", "tight-bound"],
+    "prerequisites": ["cycle-diagonal", "K4-free", "chromatic-number"]
   },
   {
     "id": "ann-1091-general",
     "proofId": "erdos-1091",
-    "range": { "startLine": 169, "endLine": 175 },
+    "range": { "startLine": 159, "endLine": 175 },
     "type": "definition",
-    "title": "GeneralQuestion (OPEN)",
-    "content": "The OPEN general question: Does there exist f(r) → ∞ such that locally 3-colorable graphs with χ ≥ 4 have odd cycles with ≥ f(r) diagonals? This is the main unsolved part of Problem #1091.",
-    "significance": "critical"
+    "title": "General Question (OPEN)",
+    "content": "The **OPEN** general question: Does there exist $f(r) \\to \\infty$ such that every graph with $\\chi \\geq 4$ that is locally 3-colorable (every subgraph on $\\leq r$ vertices has $\\chi \\leq 3$) contains an odd cycle with $\\geq f(r)$ diagonals? **IsLocallyColorable** captures the local coloring condition using induced subgraphs. **GeneralQuestion** is defined as a Prop without asserting truth.",
+    "mathContext": {
+      "latex": "\\exists\\, f : \\mathbb{N} \\to \\mathbb{N},\\; f(r) \\to \\infty \\;\\wedge\\; \\forall\\, G,\\; \\chi(G) \\geq 4 \\;\\wedge\\; \\text{loc-3-col}(G, r) \\;\\Rightarrow\\; \\exists\\, C \\text{ odd, } \\text{diag}(C) \\geq f(r)",
+      "description": "IsLocallyColorable uses SimpleGraph.induce to restrict to subgraphs. The divergence condition f(r) -> infinity is formalized as: for all N, exists r such that f(r') >= N for all r' >= r."
+    },
+    "significance": "critical",
+    "relatedConcepts": ["local-coloring", "divergent-function", "open-problem"],
+    "prerequisites": ["chromatic-number", "induced-subgraph"]
   },
   {
-    "id": "ann-1091-mycielski",
+    "id": "ann-1091-related",
     "proofId": "erdos-1091",
-    "range": { "startLine": 186, "endLine": 189 },
-    "type": "axiom",
-    "title": "mycielski_construction",
-    "content": "The Mycielski construction shows triangle-free graphs can have arbitrarily high χ. This contextualizes why K₄-free high-χ graphs exist.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-1091-summary",
-    "proofId": "erdos-1091",
-    "range": { "startLine": 193, "endLine": 207 },
+    "range": { "startLine": 177, "endLine": 209 },
     "type": "theorem",
-    "title": "erdos_1091_summary",
-    "content": "Summary theorem combining the two main results: (1) Two diagonals guaranteed (Voss), and (2) three diagonals NOT guaranteed (pentagonal wheel). Fully proved from axioms.",
-    "significance": "critical"
+    "title": "Related Results and Summary",
+    "content": "**K4_free_high_chi_possible** (verified): The pentagonal wheel witnesses that $K_4$-free graphs can have $\\chi \\geq 4$.\n\n**mycielski_construction** (axiomatized): Triangle-free ($K_3$-free) graphs can have arbitrarily high $\\chi$, contextualizing why $K_4$-free high-$\\chi$ graphs exist.\n\n**erdos_1091_summary** (verified): Combines Voss ($\\geq 2$ guaranteed) with the pentagonal wheel counterexample ($\\geq 3$ not guaranteed), giving a complete answer to the specific question.",
+    "mathContext": {
+      "latex": "\\forall\\, k,\\; \\exists\\, G \\text{ triangle-free with } \\chi(G) \\geq k \\quad \\text{(Mycielski)}",
+      "description": "K4_free_high_chi_possible is proved by instantiation with PentagonalWheel. The Mycielski construction is a classical result in graph theory. The summary theorem combines both directions into a single statement."
+    },
+    "significance": "key",
+    "relatedConcepts": ["mycielski-graph", "summary-theorem", "existence-witness"],
+    "prerequisites": ["pentagonal-wheel", "voss-theorem"]
   }
 ]

--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1091",
-  "title": "Erdős Problem #1091: Odd Cycles with Diagonals in K₄-Free Graphs",
+  "title": "Erdos Problem #1091: Odd Cycles with Diagonals in K4-Free Graphs",
   "slug": "erdos-1091",
-  "description": "Must a K₄-free graph with χ(G) = 4 contain an odd cycle with at least two diagonals? Answer: YES (Voss 1982). General f(r) question: OPEN.",
+  "description": "Must a K4-free graph with chi(G) = 4 contain an odd cycle with at least two diagonals? Answer: YES (Voss 1982). General f(r) question: OPEN.",
   "meta": {
-    "author": "Erdős (problem), Larson (1979), Voss (1982)",
+    "author": "Erdos (problem), Larson (1979), Voss (1982)",
     "sourceUrl": "https://erdosproblems.com/1091",
     "date": "1982",
     "status": "complete",
@@ -25,109 +25,134 @@
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph",
-        "description": "Basic simple graph structure",
+        "description": "Basic simple graph structure for vertices and edges",
         "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
       },
       {
         "theorem": "SimpleGraph.Coloring",
-        "description": "Graph coloring definitions",
+        "description": "Proper graph colorings for chromatic number",
         "module": "Mathlib.Combinatorics.SimpleGraph.Coloring"
       },
       {
         "theorem": "SimpleGraph.IsClique",
-        "description": "Clique and clique-free definitions",
+        "description": "Clique and clique-free predicates for K4-free condition",
         "module": "Mathlib.Combinatorics.SimpleGraph.Clique"
       },
       {
-        "theorem": "Finset.card",
-        "description": "Cardinality of finite sets",
-        "module": "Mathlib.Data.Finset.Basic"
+        "theorem": "SimpleGraph.induce",
+        "description": "Induced subgraphs for local colorability",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Subgraph"
       }
     ],
     "originalContributions": [
-      "Formalized Cycle structure with vertices, adjacency, and closing edge",
-      "Defined Cycle.isOdd, Cycle.isDiagonal, Cycle.diagonalCount",
-      "Defined IsK4Free and chromaticNumber",
-      "Stated Larson's theorem (1979): one diagonal guaranteed",
-      "Stated Bollobás-Erdős conjecture (proved by Larson)",
-      "Stated Voss's theorem (1982): two diagonals guaranteed",
-      "Defined PentagonalWheel as counterexample for three diagonals",
-      "Proved three_diagonals_not_guaranteed from pentagonal wheel",
-      "Formalized IsLocallyColorable and GeneralQuestion (OPEN)",
-      "Connected to Mycielski construction for triangle-free graphs"
-    ]
+      "Cycle structure: vertices list with adjacency, closing edge, length >= 3",
+      "Cycle.isOdd, Cycle.isDiagonal, Cycle.diagonalCount: odd cycle and diagonal predicates",
+      "IsK4Free, chromaticNumber: clique-free and coloring number definitions",
+      "larson_one_diagonal: Larson's 1979 theorem (axiomatized)",
+      "BollobasErdosAlternative: structural alternatives for diagonal-free K4-free graphs",
+      "voss_two_diagonals: Voss's 1982 strengthening (axiomatized)",
+      "voss_implies_larson: verified corollary (>= 2 implies >= 1)",
+      "PentagonalWheel: explicit W5 construction as SimpleGraph (Fin 6)",
+      "three_diagonals_not_guaranteed: verified impossibility of >= 3 diagonals",
+      "IsLocallyColorable, GeneralQuestion: open f(r) question formalized",
+      "K4_free_high_chi_possible: verified existence witness",
+      "erdos_1091_summary: verified combined result"
+    ],
+    "dateAdded": "2026-01-26"
   },
   "overview": {
-    "historicalContext": "This problem concerns the structure of K₄-free graphs with high chromatic number. Erdős originally asked about the existence of just one diagonal in odd cycles.\n\nLarson (1979) proved that one diagonal always exists, and moreover proved the Bollobás-Erdős conjecture: if a K₄-free graph has no odd cycle with a diagonal, then it must be bipartite, have a cut vertex, or have a vertex of degree ≤ 2.\n\nVoss (1982) strengthened this to show that TWO diagonals are always guaranteed. The pentagonal wheel (5-cycle with central hub) shows that three diagonals cannot always be guaranteed.\n\nThe general question asks whether there exists f(r) → ∞ such that locally 3-colorable graphs with χ ≥ 4 have odd cycles with at least f(r) diagonals. This remains OPEN.",
-    "problemStatement": "**Problem**: Let $G$ be a $K_4$-free graph with chromatic number 4. Must $G$ contain an odd cycle with at least two diagonals?\n\n**Answer**: YES (Voss 1982)\n\n**More General Question** (OPEN): Is there some $f(r) \\to \\infty$ such that every graph with $\\chi(G) \\geq 4$, in which every subgraph on $\\leq r$ vertices has $\\chi \\leq 3$, contains an odd cycle with at least $f(r)$ diagonals?\n\n**Known Results**:\n- Larson (1979): At least 1 diagonal guaranteed\n- Voss (1982): At least 2 diagonals guaranteed\n- Pentagonal wheel: Shows 3 diagonals cannot be guaranteed\n- General f(r) question: OPEN",
-    "proofStrategy": "The formalization defines cycles as lists of vertices with adjacency conditions, and diagonals as non-consecutive edges. The key theorems by Larson and Voss are stated as axioms. The pentagonal wheel is explicitly constructed to prove that 3 diagonals cannot be universally guaranteed. The general f(r) question is formalized but left open.",
+    "historicalContext": "Erdos Problem #1091 concerns the structure of odd cycles in graphs that are K4-free (contain no complete graph on 4 vertices) but have high chromatic number. The problem has its roots in the broader question of how clique-freeness constrains graph structure when the chromatic number is large.\n\nThe Bollobas-Erdos conjecture proposed that K4-free graphs without odd cycles having diagonals must have very restricted structure: they are bipartite, have a cut vertex, or have a low-degree vertex. Larson (1979) proved this conjecture and established that every K4-free graph with chi >= 4 must contain an odd cycle with at least one diagonal.\n\nVoss (1982) significantly strengthened Larson's result by proving that at least TWO diagonals are guaranteed. This answered the specific question of Problem #1091 affirmatively. The pentagonal wheel W5 (a 5-cycle with a central hub vertex) serves as an extremal counterexample: it is K4-free with chi = 4, but every odd cycle has at most 2 diagonals, showing that 3 diagonals cannot be universally guaranteed and making Voss's bound tight.\n\nThe problem connects to Mycielski's classical construction, which shows that triangle-free (and hence K4-free) graphs can have arbitrarily high chromatic number. The general open question asks whether there exists f(r) -> infinity such that graphs with chi >= 4 that are locally 3-colorable (every subgraph on <= r vertices has chi <= 3) must contain odd cycles with >= f(r) diagonals. This remains one of the open parts of the problem.",
+    "problemStatement": "**Problem**: Let $G$ be a $K_4$-free graph with chromatic number 4. Must $G$ contain an odd cycle with at least two diagonals?\n\n**Answer**: YES (Voss 1982)\n\n**More General Question** (OPEN): Is there some $f(r) \\to \\infty$ such that every graph with $\\chi(G) \\geq 4$, in which every subgraph on $\\leq r$ vertices has $\\chi \\leq 3$, contains an odd cycle with at least $f(r)$ diagonals?",
+    "proofStrategy": "The formalization defines cycles as vertex lists with adjacency proofs, diagonals as non-consecutive edges, and the standard graph predicates (K4-free, chromatic number). Larson's and Voss's theorems are axiomatized. The pentagonal wheel is explicitly constructed as SimpleGraph (Fin 6) with verified symmetry and loop-freeness, and the impossibility of 3 diagonals is fully proved by contradiction. The general f(r) question is formalized using induced subgraphs for local colorability but left open.",
     "keyInsights": [
-      "**K₄-free doesn't mean low χ**: The pentagonal wheel is K₄-free but has χ = 4.",
-      "**Progressive strengthening**: 0 diagonals (trivial) → 1 (Larson) → 2 (Voss) → not 3 (counterexample).",
-      "**Bollobás-Erdős structure**: Absence of odd cycles with diagonals forces very specific graph structure.",
-      "**Local vs global coloring**: The f(r) question explores how local colorability constrains global structure.",
-      "**Pentagonal wheel is extremal**: It achieves exactly 2 diagonals, showing Voss's bound is tight."
+      "K4-free does not mean low chromatic number: the pentagonal wheel is K4-free but has chi = 4, and Mycielski's construction gives triangle-free graphs with arbitrarily high chi",
+      "Progressive strengthening: 0 diagonals (trivial) -> 1 diagonal (Larson 1979) -> 2 diagonals (Voss 1982) -> not 3 diagonals (pentagonal wheel counterexample)",
+      "The Bollobas-Erdos structure theorem shows that absence of odd cycles with diagonals in K4-free graphs forces extreme restrictions: bipartiteness, cut vertices, or low degree",
+      "The pentagonal wheel W5 = C5 + K1 is the extremal example achieving exactly 2 diagonals in every odd cycle, making Voss's bound tight",
+      "The general f(r) question explores the frontier between local and global colorability: how does the local structure (small subgraphs 3-colorable) constrain global cycle structure?",
+      "Three verified theorems (voss_implies_larson, three_diagonals_not_guaranteed, erdos_1091_summary) demonstrate non-trivial mathematical reasoning in Lean"
     ]
   },
   "sections": [
     {
+      "id": "docstring",
+      "title": "Module Docstring",
+      "startLine": 1,
+      "endLine": 18,
+      "summary": "Problem statement, answer (YES for 2 diagonals), history (Larson 1979, Voss 1982), and general open question about f(r)."
+    },
+    {
       "id": "basic-definitions",
-      "title": "Basic Definitions",
-      "summary": "Cycle, isOdd, isDiagonal, diagonalCount, IsK4Free, chromaticNumber",
+      "title": "Part 1: Basic Definitions",
       "startLine": 27,
-      "endLine": 68
+      "endLine": 68,
+      "summary": "Cycle structure (vertex list with adjacency), isOdd, isDiagonal (non-consecutive edge), diagonalCount (unordered pairs), IsK4Free (no 4-clique), chromaticNumber (min colors)."
     },
     {
       "id": "larson-theorem",
-      "title": "Larson's Theorem (1979)",
-      "summary": "larson_one_diagonal, BollobasErdosAlternative, bollobas_erdos_conjecture",
+      "title": "Part 2: Larson's Theorem (1979)",
       "startLine": 70,
-      "endLine": 94
+      "endLine": 94,
+      "summary": "larson_one_diagonal (axiom): K4-free, chi >= 4 implies odd cycle with >= 1 diagonal. BollobasErdosAlternative structure and bollobas_erdos_conjecture (axiom)."
     },
     {
       "id": "voss-theorem",
-      "title": "Voss's Theorem (1982)",
-      "summary": "voss_two_diagonals, voss_implies_larson",
+      "title": "Part 3: Voss's Theorem (1982)",
       "startLine": 96,
-      "endLine": 111
+      "endLine": 111,
+      "summary": "voss_two_diagonals (axiom): K4-free, chi >= 4 implies odd cycle with >= 2 diagonals. voss_implies_larson (verified corollary)."
     },
     {
       "id": "counterexample",
-      "title": "Counterexample for Three Diagonals",
-      "summary": "PentagonalWheel construction, three_diagonals_not_guaranteed",
+      "title": "Part 4: Pentagonal Wheel Counterexample",
       "startLine": 113,
-      "endLine": 157
+      "endLine": 157,
+      "summary": "PentagonalWheel definition as SimpleGraph (Fin 6) with proved symmetry/loop-freeness. Axioms for K4-free, chi=4, max 2 diagonals. Verified three_diagonals_not_guaranteed by contradiction."
     },
     {
       "id": "general-question",
-      "title": "The General Question (OPEN)",
-      "summary": "IsLocallyColorable, GeneralQuestion",
+      "title": "Part 5: General Question (OPEN)",
       "startLine": 159,
-      "endLine": 175
+      "endLine": 175,
+      "summary": "IsLocallyColorable (induced subgraph coloring) and GeneralQuestion (existence of f(r) -> infinity). The main unsolved part of Problem #1091."
     },
     {
       "id": "related-results",
-      "title": "Related Results",
-      "summary": "K4_free_high_chi_possible, mycielski_construction",
+      "title": "Part 6: Related Results",
       "startLine": 177,
-      "endLine": 189
+      "endLine": 189,
+      "summary": "K4_free_high_chi_possible (verified via PentagonalWheel), mycielski_construction (axiom: triangle-free graphs with arbitrary chi)."
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "summary": "erdos_1091_summary combining Voss + counterexample",
+      "title": "Part 7: Summary",
       "startLine": 191,
-      "endLine": 209
+      "endLine": 209,
+      "summary": "erdos_1091_summary (verified): combines Voss (>= 2 guaranteed) and pentagonal wheel (>= 3 not guaranteed) into a single theorem."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1091 asks whether K₄-free graphs with χ = 4 must contain odd cycles with multiple diagonals. The first question (two diagonals) was solved affirmatively by Voss (1982), building on Larson's 1979 result for one diagonal. The pentagonal wheel shows that three diagonals cannot be guaranteed. The general f(r) question remains OPEN.",
-    "implications": "This problem reveals deep connections between clique-freeness, chromatic number, and cycle structure. The pentagonal wheel serves as an extremal example showing the tightness of Voss's bound. The open general question connects local colorability properties to global cycle structure.",
+    "summary": "Erdos Problem #1091 is partially solved. The specific question (two diagonals in K4-free chi=4 graphs) was answered YES by Voss (1982), building on Larson (1979). The pentagonal wheel shows that three diagonals cannot be guaranteed, making Voss's bound tight. The general f(r) question remains OPEN. The formalization includes 3 fully verified theorems and the extremal pentagonal wheel construction.",
+    "implications": "The problem reveals deep connections between clique-freeness, chromatic number, and cycle structure in graphs. The pentagonal wheel serves as an extremal example showing the tightness of Voss's bound. The open general question connects local colorability to global cycle structure, a frontier area in structural graph theory.",
     "openQuestions": [
-      "Is there f(r) → ∞ for the general locally 3-colorable case?",
-      "What other structural properties force odd cycles with diagonals?",
-      "Can the pentagonal wheel characterization be generalized?",
-      "What is the relationship to Mycielski-type constructions?"
+      "Is there f(r) -> infinity for the general locally 3-colorable case?",
+      "Can the pentagonal wheel characterization be generalized to other wheel-like constructions?",
+      "What is the relationship between diagonal count in odd cycles and the Mycielski hierarchy?",
+      "What structural properties beyond K4-freeness guarantee more diagonals in odd cycles?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "proofId": "erdos-984",
+      "relationship": "Both are Erdos problems in combinatorics involving structural constraints on graphs/sets with extremal colorings or partitions"
+    },
+    {
+      "proofId": "erdos-723",
+      "relationship": "Both involve combinatorial structures (graphs/projective planes) where counting arguments and explicit constructions determine extremal behavior"
+    },
+    {
+      "proofId": "erdos-107",
+      "relationship": "Both are Erdos problems with a clear progression of bounds (trivial -> intermediate -> tight), with explicit extremal constructions showing tightness"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1113/annotations.json
+++ b/src/data/proofs/erdos-1113/annotations.json
@@ -2,92 +2,136 @@
   {
     "id": "ann-e1113-overview",
     "proofId": "erdos-1113",
-    "range": { "startLine": 1, "endLine": 31 },
-    "type": "concept",
-    "title": "Problem Overview",
-    "content": "**Erdős Problem #1113:** Are there Sierpinski numbers with no finite covering set?\n\n**Status: OPEN** — Izotov's candidate m = 734110615000775^4 is conjectured uncovered. If NO, infinitely many Fermat primes would exist (considered unlikely).",
-    "mathContext": "Connects covering systems in number theory with the distribution of Fermat primes.",
-    "significance": "critical",
-    "relatedConcepts": ["Sierpinski numbers", "Covering systems", "Fermat primes"]
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "context",
+    "title": "Problem Overview and Imports",
+    "content": "**Erdos Problem #1113**: Are there Sierpinski numbers with no finite covering set? **Status: OPEN.** Izotov's candidate $m = 734110615000775^4$ is conjectured uncovered. If NO (all Sierpinski numbers are covered), infinitely many Fermat primes would exist -- considered highly unlikely since only 5 Fermat primes ($F_0$ through $F_4$) are known. Imports Nat.Basic, Nat.Prime.Basic, Finset.Basic, and Nat.Parity from Mathlib.",
+    "mathContext": {
+      "latex": "\\exists\\, m \\text{ odd},\\; \\forall\\, k,\\; 2^k m + 1 \\text{ composite} \\;\\wedge\\; \\nexists\\, P \\text{ finite, } \\forall\\, k,\\; \\exists\\, p \\in P,\\; p \\mid 2^k m + 1",
+      "description": "The problem asks for a Sierpinski number whose compositeness cannot be explained by any finite set of primes covering the sequence. This connects covering systems in combinatorial number theory with the distribution of Fermat primes."
+    },
+    "significance": "context",
+    "relatedConcepts": ["sierpinski-numbers", "covering-systems", "fermat-primes"],
+    "prerequisites": ["prime-numbers", "divisibility"]
   },
   {
     "id": "ann-e1113-sierpinski",
     "proofId": "erdos-1113",
-    "range": { "startLine": 44, "endLine": 62 },
+    "range": { "startLine": 42, "endLine": 62 },
     "type": "definition",
     "title": "Sierpinski Numbers",
-    "content": "**IsSierpinskiNumber m:** Odd m > 0 where 2^k·m + 1 is composite for ALL k ≥ 0.\n\nNo matter what exponent k you choose, the formula never produces a prime. The characterization via AllComposite is proved equivalent.",
+    "content": "**IsSierpinskiNumber** $m$: An odd positive integer $m$ where $2^k \\cdot m + 1$ is composite for ALL $k \\geq 0$. No matter what exponent $k$ you choose, the formula never produces a prime. The equivalent `AllComposite` characterization via `sierpinskiSequence` is proved by `sierpinski_iff_all_composite` (verified).",
+    "mathContext": {
+      "latex": "\\text{IsSierpinskiNumber}(m) \\;:\\Leftrightarrow\\; m \\text{ odd} \\;\\wedge\\; m > 0 \\;\\wedge\\; \\forall\\, k \\geq 0,\\; 2^k m + 1 \\text{ is composite}",
+      "description": "Defined as Odd m, m > 0, and not Nat.Prime (2^k * m + 1) for all k. The sierpinskiSequence helper and AllComposite predicate provide equivalent formulations."
+    },
     "significance": "critical",
-    "leanSymbol": "IsSierpinskiNumber"
+    "relatedConcepts": ["composite-number", "sierpinski-sequence", "primality-testing"],
+    "prerequisites": ["nat-prime", "odd-numbers"]
   },
   {
     "id": "ann-e1113-covering",
     "proofId": "erdos-1113",
-    "range": { "startLine": 66, "endLine": 79 },
+    "range": { "startLine": 64, "endLine": 79 },
     "type": "definition",
     "title": "Covering Sets",
-    "content": "**IsCoveringSet m P:** A finite set P of primes that 'covers' the Sierpinski sequence — for every k, some p ∈ P divides 2^k·m + 1.\n\nCovering sets explain WHY a number is Sierpinski: each term has a guaranteed prime divisor from the set.",
+    "content": "**IsCoveringSet** $m$ $P$: A finite set $P$ of primes that 'covers' the Sierpinski sequence -- for every $k$, some $p \\in P$ divides $2^k \\cdot m + 1$. **HasFiniteCoveringSet** asserts the existence of such a $P$. The axiom `covering_set_implies_sierpinski` confirms that covered numbers are indeed Sierpinski: if every term has a prime divisor from $P$, none can be prime.",
+    "mathContext": {
+      "latex": "\\text{IsCoveringSet}(m, P) \\;:\\Leftrightarrow\\; (\\forall\\, p \\in P,\\, p \\text{ prime}) \\;\\wedge\\; \\forall\\, k,\\; \\exists\\, p \\in P,\\; p \\mid 2^k m + 1",
+      "description": "Covering sets explain compositeness via periodicity: since 2^k mod p is periodic, a finite set of primes can cover all residue classes. The covering set {3,5,7,13,19,37,73} works for 78557 because these 7 primes partition N by periodicity."
+    },
     "significance": "critical",
-    "leanSymbol": "IsCoveringSet"
+    "relatedConcepts": ["covering-system", "modular-periodicity", "finite-explanation"],
+    "prerequisites": ["prime-divisibility", "finset"]
   },
   {
     "id": "ann-e1113-question",
     "proofId": "erdos-1113",
-    "range": { "startLine": 83, "endLine": 99 },
+    "range": { "startLine": 81, "endLine": 99 },
     "type": "definition",
-    "title": "The Main Question",
-    "content": "**ErdosProblem1113:** ∃ m, IsSierpinskiNumber m ∧ ¬HasFiniteCoveringSet m\n\nDoes there exist a Sierpinski number that CANNOT be explained by any covering set?\n\nEquivalently: is it FALSE that every Sierpinski number has a covering? (Proved as problem_equivalence.)",
+    "title": "The Main Question (OPEN)",
+    "content": "**ErdosProblem1113**: $\\exists\\, m,\\, \\text{IsSierpinskiNumber}(m) \\wedge \\neg\\text{HasFiniteCoveringSet}(m)$. The alternative formulation **AllSierpinskiHaveCoverings** states every Sierpinski number is covered. The `problem_equivalence` theorem (verified) proves these are exact negations: Problem 1113 holds iff not all Sierpinski numbers have coverings.",
+    "mathContext": {
+      "latex": "\\text{ErdosProblem1113} \\;\\Leftrightarrow\\; \\neg\\,\\text{AllSierpinskiHaveCoverings}",
+      "description": "Verified equivalence using push_neg. The two-direction proof is straightforward: existence of an uncovered number is the negation of universal covering."
+    },
     "significance": "critical",
-    "leanSymbol": "ErdosProblem1113"
+    "relatedConcepts": ["open-problem", "logical-equivalence"],
+    "prerequisites": ["sierpinski-number", "covering-set"]
   },
   {
     "id": "ann-e1113-78557",
     "proofId": "erdos-1113",
-    "range": { "startLine": 103, "endLine": 112 },
+    "range": { "startLine": 101, "endLine": 119 },
     "type": "axiom",
-    "title": "Smallest Known Sierpinski Number",
-    "content": "**78557 (Selfridge):** The smallest known Sierpinski number, with covering set {3, 5, 7, 13, 19, 37, 73}.\n\nSeven primes together cover all terms 2^k·78557 + 1.",
+    "title": "78557 and Sierpinski's Theorem",
+    "content": "**78557** (Selfridge): The smallest known Sierpinski number, with covering set $\\{3, 5, 7, 13, 19, 37, 73\\}$. Both the Sierpinski property and the covering are axiomatized. **Sierpinski (1960)** proved infinitely many Sierpinski numbers with coverings exist: for every $N$, there exists $m > N$ that is Sierpinski with a finite covering set.",
+    "mathContext": {
+      "latex": "78557 \\text{ is Sierpinski with covering } \\{3, 5, 7, 13, 19, 37, 73\\}",
+      "description": "The 7-element covering works because 2^k has period dividing lcm(2,4,3,12,18,36,72) = 36 modulo these primes. Each residue class of k mod 36 is covered by at least one prime."
+    },
     "significance": "key",
-    "leanSymbol": "selfridge_78557"
+    "relatedConcepts": ["selfridge-conjecture", "smallest-sierpinski", "covering-construction"],
+    "prerequisites": ["sierpinski-number", "covering-set"]
   },
   {
     "id": "ann-e1113-izotov",
     "proofId": "erdos-1113",
-    "range": { "startLine": 123, "endLine": 130 },
+    "range": { "startLine": 121, "endLine": 130 },
     "type": "axiom",
-    "title": "Izotov's Candidate",
-    "content": "**Izotov (1995):** m = 734110615000775^4 is a Sierpinski number conjectured to have NO covering set.\n\nThis is a 4th power, consistent with the FFK conjecture. It is the strongest evidence that Problem #1113 has answer YES.",
+    "title": "Izotov's Candidate (1995)",
+    "content": "**Izotov (1995)**: $m = 734110615000775^4$ is a Sierpinski number conjectured to have NO covering set. This is a 4th power (verified by `izotov_is_power`), consistent with the FFK conjecture. It is the strongest evidence that Problem #1113 has answer YES -- if uncovered Sierpinski numbers exist, they may all be perfect powers.",
+    "mathContext": {
+      "latex": "m = 734110615000775^4, \\quad \\text{IsSierpinskiNumber}(m) \\;\\wedge\\; \\text{IsPerfectPower}(m)",
+      "description": "Axiomatized: izotov_is_sierpinski states the Sierpinski property. The candidate is a 4th power, so it falls under the 'perfect power' exception in the FFK conjecture."
+    },
     "significance": "critical",
-    "leanSymbol": "izotov_is_sierpinski"
+    "relatedConcepts": ["candidate-example", "perfect-power", "conjectured-uncovered"],
+    "prerequisites": ["sierpinski-number", "covering-set"]
   },
   {
     "id": "ann-e1113-ffk",
     "proofId": "erdos-1113",
-    "range": { "startLine": 134, "endLine": 154 },
+    "range": { "startLine": 132, "endLine": 154 },
     "type": "definition",
-    "title": "FFK Conjecture",
-    "content": "**FFKConjecture (2008):** Every Sierpinski number is either a perfect power OR has a finite covering set.\n\nIzotov's candidate IS a 4th power (proved as izotov_is_power), so the FFK conjecture is consistent with it being uncovered.",
+    "title": "FFK Conjecture and Power Result",
+    "content": "**FFKConjecture (Filaseta-Finch-Kozek 2008)**: Every Sierpinski number is either a perfect power ($m = n^k$, $k \\geq 2$) OR has a finite covering set. This refines Erdos #1113 by suggesting that uncovered Sierpinski numbers can only arise from the algebraic structure of perfect powers. `izotov_is_power` (verified) and `ffk_consistent_with_izotov` (verified) show the conjecture is compatible with Izotov's example. FFK also proved: for every $\\ell \\geq 1$, there exists $m$ where $2^k \\cdot m^i + 1$ is composite for all $1 \\leq i \\leq \\ell$ and $k \\geq 0$.",
+    "mathContext": {
+      "latex": "\\text{FFKConjecture}: \\forall\\, m,\\; \\text{Sierpinski}(m) \\;\\Rightarrow\\; \\text{IsPerfectPower}(m) \\;\\vee\\; \\text{HasCovering}(m)",
+      "description": "IsPerfectPower m = exists n k, k >= 2, m = n^k. The FFK power result (axiomatized) shows that for any l, simultaneous Sierpinski conditions 2^k * m^i + 1 composite for i=1..l are achievable."
+    },
     "significance": "critical",
-    "leanSymbol": "FFKConjecture"
+    "relatedConcepts": ["perfect-power", "refined-conjecture", "simultaneous-compositeness"],
+    "prerequisites": ["sierpinski-number", "covering-set", "exponentiation"]
   },
   {
     "id": "ann-e1113-fermat",
     "proofId": "erdos-1113",
-    "range": { "startLine": 158, "endLine": 176 },
+    "range": { "startLine": 156, "endLine": 184 },
     "type": "axiom",
-    "title": "Fermat Prime Connection",
-    "content": "**Erdős-Graham observation:** If ALL Sierpinski numbers have covering sets, then infinitely many Fermat primes exist.\n\nSince infinitely many Fermat primes is considered highly unlikely (only 5 known: F_0 through F_4), this strongly supports answer YES to Problem #1113.",
+    "title": "Connection to Fermat Primes",
+    "content": "**Fermat numbers** $F_n = 2^{2^n} + 1$. Only 5 are known to be prime: $F_0 = 3, F_1 = 5, F_2 = 17, F_3 = 257, F_4 = 65537$. $F_5 = 4294967297 = 641 \\times 6700417$ is composite (axiomatized). The **Erdos-Graham observation** (axiomatized): if ALL Sierpinski numbers have covering sets, then infinitely many Fermat primes exist. Since this is considered highly unlikely, it provides strong indirect evidence that Problem #1113 has answer YES.",
+    "mathContext": {
+      "latex": "F_n = 2^{2^n} + 1, \\quad \\text{AllSierpinskiHaveCoverings} \\;\\Rightarrow\\; \\forall\\, N,\\; \\exists\\, n > N,\\; F_n \\text{ prime}",
+      "description": "The connection arises because if m = 1, then 2^k * 1 + 1 = 2^k + 1, and the prime values are exactly the Fermat primes. If all Sierpinski numbers have coverings, the covering argument can be bootstrapped to produce Fermat primes."
+    },
     "significance": "critical",
-    "leanSymbol": "erdos_graham_connection"
+    "relatedConcepts": ["fermat-number", "fermat-prime", "contrapositive-evidence"],
+    "prerequisites": ["sierpinski-number", "covering-set", "prime-numbers"]
   },
   {
     "id": "ann-e1113-summary",
     "proofId": "erdos-1113",
-    "range": { "startLine": 188, "endLine": 207 },
+    "range": { "startLine": 186, "endLine": 207 },
     "type": "theorem",
     "title": "Summary Theorem",
-    "content": "**erdos_1113_summary:** Combines the key results:\n1. Izotov's candidate is a Sierpinski number\n2. It is a perfect power (consistent with FFK)\n3. FFK conjecture is compatible\n\nThe summary theorem is proved from the axiomatized results.\n\n**Status: OPEN**",
+    "content": "**erdos_1113_summary** (verified): Combines the key results: (1) Izotov's candidate is a Sierpinski number, (2) it is a perfect power (4th power), (3) the FFK conjecture is compatible. Proved directly from axioms and the verified `izotov_is_power` and `ffk_consistent_with_izotov` theorems. **Problem Status: OPEN.**",
+    "mathContext": {
+      "latex": "\\text{Sierpinski}(m_{\\text{Iz}}) \\;\\wedge\\; \\text{PerfectPower}(m_{\\text{Iz}}) \\;\\wedge\\; (\\text{FFK} \\Rightarrow \\text{PerfectPower}(m_{\\text{Iz}}) \\vee \\text{HasCovering}(m_{\\text{Iz}}))",
+      "description": "The summary combines axioms (izotov_is_sierpinski) with verified results (izotov_is_power via norm_num/rfl, ffk_consistent_with_izotov via function application)."
+    },
     "significance": "critical",
-    "leanSymbol": "erdos_1113_summary"
+    "relatedConcepts": ["summary-theorem", "open-problem"],
+    "prerequisites": ["izotov-candidate", "ffk-conjecture"]
   }
 ]

--- a/src/data/proofs/erdos-1113/meta.json
+++ b/src/data/proofs/erdos-1113/meta.json
@@ -28,31 +28,36 @@
     "mathlibDependencies": [
       {
         "theorem": "Nat.Prime",
-        "description": "Prime number predicate",
+        "description": "Prime number predicate, used for Sierpinski number definition and covering set primes",
         "module": "Mathlib.Data.Nat.Prime.Basic"
       },
       {
         "theorem": "Finset",
-        "description": "Finite sets for covering sets",
+        "description": "Finite sets for representing covering sets P of primes",
         "module": "Mathlib.Data.Finset.Basic"
       },
       {
         "theorem": "Odd",
-        "description": "Odd number predicate",
+        "description": "Odd number predicate for the Sierpinski number definition (m must be odd)",
         "module": "Mathlib.Data.Nat.Parity"
+      },
+      {
+        "theorem": "Nat.Basic",
+        "description": "Basic natural number operations including exponentiation for 2^k * m + 1",
+        "module": "Mathlib.Data.Nat.Basic"
       }
     ],
     "originalContributions": [
-      "IsSierpinskiNumber definition: 2^k·m + 1 always composite",
-      "IsCoveringSet definition: primes covering the sequence",
-      "HasFiniteCoveringSet predicate",
-      "ErdosProblem1113: main question formalization",
-      "smallestKnownSierpinski = 78557 with its covering set",
-      "izotovCandidate: conjectured uncovered example",
-      "IsPerfectPower definition",
-      "FFKConjecture: refined conjecture about perfect powers",
-      "FermatNumber, IsFermatPrime: connection to Fermat primes",
-      "erdos_graham_connection: link to infinitely many Fermat primes"
+      "IsSierpinskiNumber definition with AllComposite equivalence (sierpinski_iff_all_composite verified)",
+      "IsCoveringSet and HasFiniteCoveringSet definitions with covering_set_implies_sierpinski axiom",
+      "ErdosProblem1113 and AllSierpinskiHaveCoverings with problem_equivalence verified",
+      "smallestKnownSierpinski = 78557 with explicit 7-element covering set {3,5,7,13,19,37,73}",
+      "izotovCandidate = 734110615000775^4 with izotov_is_power verified via norm_num",
+      "FFKConjecture: Sierpinski implies perfect power or covered, with ffk_consistent_with_izotov verified",
+      "Fermat number definitions with F5 factorization axiomatized",
+      "erdos_graham_connection: AllSierpinskiHaveCoverings implies infinitely many Fermat primes",
+      "erdos_1113_summary combining Izotov, perfect power, and FFK compatibility (verified)",
+      "sierpinski_infinitely_many: Sierpinski's theorem that infinitely many covered numbers exist"
     ],
     "references": [
       {
@@ -69,88 +74,119 @@
         "key": "FFK08",
         "citation": "Filaseta, M., Finch, C., Kozek, M., On powers associated with Sierpinski numbers, J. Number Theory (2008), 1916-1940.",
         "type": "paper"
+      },
+      {
+        "key": "Se75",
+        "citation": "Selfridge, J., Solution of problem 4995, Amer. Math. Monthly (1975), 307.",
+        "type": "paper"
+      },
+      {
+        "key": "EG80",
+        "citation": "Erdős, P. and Graham, R., Old and New Problems and Results in Combinatorial Number Theory, Monogr. Enseign. Math. 28, Geneva, 1980.",
+        "type": "book"
       }
     ]
   },
   "overview": {
-    "historicalContext": "**Sierpinski Numbers and Covering Systems**\n\nA Sierpinski number m is a positive odd integer where 2^k·m + 1 is composite for all k ≥ 0. Sierpinski (1960) proved infinitely many exist using covering systems - finite sets of primes that 'cover' the sequence.\n\n**The Question (Erdős-Graham 1980):** Are there Sierpinski numbers that CANNOT be explained by a covering system?\n\n**Key Development:**\n- **Selfridge:** Found 78557, the smallest known Sierpinski number (with covering set {3,5,7,13,19,37,73})\n- **Izotov (1995):** Proposed m = 734110615000775^4 as uncovered\n- **FFK (2008):** Conjectured all Sierpinski numbers are either perfect powers or covered\n\n**Deep Connection:** If ALL Sierpinski numbers have coverings, infinitely many Fermat primes exist - considered highly unlikely.",
+    "historicalContext": "In 1960, Wacław Sierpiński proved a striking result: there exist infinitely many odd positive integers m such that 2^k · m + 1 is composite for every k >= 0. His proof relied on covering systems -- finite sets of primes whose modular periodicities 'cover' all residue classes of k, guaranteeing that some prime in the set always divides 2^k · m + 1. John Selfridge later identified 78557 as a Sierpinski number with covering set {3, 5, 7, 13, 19, 37, 73}, and it is conjectured (but not yet proven) to be the smallest Sierpinski number. The 'Seventeen or Bust' distributed computing project has been working since 2002 to verify this, reducing the candidates to just a few remaining values.\n\nErdős and Graham (1980) posed a deeper question: must every Sierpinski number have a finite covering set, or can Sierpinski numbers exist for 'non-periodic' reasons? This is Problem #1113 in the Erdős collection. The question probes whether covering systems are the only mechanism producing Sierpinski numbers, or whether other number-theoretic phenomena (such as the algebraic structure of perfect powers) can also force universal compositeness. The answer has profound implications: if ALL Sierpinski numbers have covering sets, then a classical argument shows infinitely many Fermat primes must exist -- a conclusion considered extremely unlikely given that only five Fermat primes (F_0 through F_4) are known.\n\nIn 1995, Izotov proposed the candidate m = 734110615000775^4, a Sierpinski number conjectured to have no finite covering set. Notably, this candidate is a perfect 4th power. This observation led Filaseta, Finch, and Kozek (2008) to formulate the FFK Conjecture: every Sierpinski number is either a perfect power (m = n^k for some k >= 2) or has a finite covering set. This elegant refinement suggests that uncovered Sierpinski numbers, if they exist, must arise from the multiplicative structure of perfect powers rather than from arbitrary number-theoretic coincidences.\n\nThe connection to Fermat primes provides the strongest indirect evidence that uncovered Sierpinski numbers exist. Setting m = 1 in the Sierpinski sequence gives 2^k + 1, whose prime values are exactly the Fermat primes. If every Sierpinski number has a covering set, then covering-system arguments can be bootstrapped to show infinitely many Fermat primes exist. Since F_5 = 4294967297 = 641 × 6700417 is composite and no Fermat prime beyond F_4 = 65537 has been found, the mathematical community strongly suspects that only finitely many Fermat primes exist -- making the affirmative answer to Problem #1113 highly likely.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nA Sierpinski number $m$ is an odd positive integer where $2^k \\cdot m + 1$ is composite for all $k \\geq 0$.\n\nA covering set $P$ for $m$ is a finite set of primes such that every $2^k \\cdot m + 1$ is divisible by some $p \\in P$.\n\n**Question:** Are there Sierpinski numbers with no finite covering set?\n\n**Evidence for YES:**\n- Izotov's candidate $m = 734110615000775^4$\n- If NO, infinitely many Fermat primes exist (unlikely)\n\n**Status: OPEN**",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Sierpinski Numbers:** Define IsSierpinskiNumber as all terms composite.\n\n2. **Covering Sets:** Define IsCoveringSet requiring divisibility by primes in P.\n\n3. **Main Question:** ErdosProblem1113 asks for uncovered Sierpinski numbers.\n\n4. **Known Examples:** 78557 with explicit covering set.\n\n5. **Izotov's Candidate:** Axiomatize the specific example.\n\n6. **FFK Conjecture:** Perfect powers or covered.\n\n7. **Fermat Connection:** Link to infinitely many Fermat primes.",
+    "proofStrategy": "The formalization is structured in seven parts. Part 1 imports Nat.Basic, Nat.Prime.Basic, Finset.Basic, and Nat.Parity from Mathlib, establishing the arithmetic foundation. Part 2 defines IsSierpinskiNumber (odd, positive, all terms composite) with an equivalent AllComposite characterization via sierpinskiSequence, connected by the verified sierpinski_iff_all_composite. Part 3 defines IsCoveringSet (finite primes covering divisibility) and HasFiniteCoveringSet, with the axiom covering_set_implies_sierpinski confirming covered numbers are Sierpinski. Part 4 formalizes the main question as ErdosProblem1113 (existence of uncovered Sierpinski) and AllSierpinskiHaveCoverings (universal covering), proving their equivalence via push_neg. Part 5 axiomatizes 78557, Izotov's candidate (with izotov_is_power verified by norm_num), and Sierpinski's infinitude theorem. Part 6 defines IsPerfectPower and FFKConjecture, verifying ffk_consistent_with_izotov. Part 7 defines Fermat numbers, axiomatizes F5's factorization and the Erdős-Graham connection, and proves the summary theorem combining all key results.",
     "keyInsights": [
-      "**Covering Systems:** Finite prime sets explaining compositeness",
-      "**78557:** Smallest known Sierpinski number with 7-element covering set",
-      "**Izotov's Candidate:** 734110615000775^4 is conjectured uncovered",
-      "**FFK Conjecture:** Perfect powers might escape covering sets",
-      "**Fermat Connection:** NO answer implies infinitely many Fermat primes",
-      "**Positive Density:** Covered Sierpinski numbers have positive density"
+      "Covering sets exploit modular periodicity: since 2^k mod p has period dividing p-1, a finite set of primes can cover all residue classes of k, explaining why every term is composite",
+      "The covering set {3, 5, 7, 13, 19, 37, 73} for 78557 works because these primes' periodicities partition N via lcm(2, 4, 3, 12, 18, 36, 72) = 36 -- each k mod 36 class has a covering prime",
+      "Izotov's candidate 734110615000775^4 is a perfect 4th power, consistent with the FFK prediction that uncovered Sierpinski numbers must be algebraically special",
+      "The Erdős-Graham observation creates a powerful contrapositive: disproving uncovered Sierpinski numbers would prove infinitely many Fermat primes, which no known technique can establish",
+      "The problem_equivalence theorem (verified via push_neg) shows Problem #1113 is exactly the negation of AllSierpinskiHaveCoverings, reducing an existential question to a universal one",
+      "The FFK power result shows that for any l >= 1, there exists m where 2^k · m^i + 1 is composite for all 1 <= i <= l and k >= 0, demonstrating deep simultaneous compositeness phenomena"
     ]
   },
   "sections": [
     {
+      "id": "imports-overview",
+      "title": "Problem Overview and Imports",
+      "summary": "Module docstring describing Problem #1113 and imports from Mathlib (Nat.Basic, Nat.Prime.Basic, Finset.Basic, Nat.Parity). Sets up the arithmetic foundation for Sierpinski numbers and covering systems.",
+      "startLine": 1,
+      "endLine": 40
+    },
+    {
       "id": "sierpinski-numbers",
       "title": "Sierpinski Numbers",
-      "summary": "Definition and basic properties",
+      "summary": "Defines IsSierpinskiNumber (odd, positive, all 2^k·m+1 composite), sierpinskiSequence helper, AllComposite predicate, and proves sierpinski_iff_all_composite establishing their equivalence.",
       "startLine": 42,
       "endLine": 62
     },
     {
       "id": "covering-sets",
       "title": "Covering Sets",
-      "summary": "Finite prime sets covering the sequence",
+      "summary": "Defines IsCoveringSet (finite primes P where for every k, some p in P divides 2^k·m+1) and HasFiniteCoveringSet. Axiomatizes covering_set_implies_sierpinski: covered numbers are Sierpinski.",
       "startLine": 64,
       "endLine": 79
     },
     {
       "id": "main-question",
-      "title": "The Main Question",
-      "summary": "Erdős Problem #1113 formalization",
+      "title": "The Main Question (OPEN)",
+      "summary": "Formalizes ErdosProblem1113 (exists uncovered Sierpinski number) and AllSierpinskiHaveCoverings (every Sierpinski is covered). Proves problem_equivalence showing these are exact negations via push_neg.",
       "startLine": 81,
       "endLine": 99
     },
     {
       "id": "known-examples",
-      "title": "Known Sierpinski Numbers",
-      "summary": "78557 and its covering set",
+      "title": "78557 and Sierpinski's Theorem",
+      "summary": "Axiomatizes 78557 as smallest known Sierpinski number with covering set {3,5,7,13,19,37,73}. Axiomatizes Sierpinski's 1960 infinitude theorem: for every N, a covered Sierpinski number exceeding N exists.",
       "startLine": 101,
-      "endLine": 112
+      "endLine": 119
     },
     {
       "id": "izotov",
-      "title": "Izotov's Candidate",
-      "summary": "734110615000775^4 conjectured uncovered",
+      "title": "Izotov's Candidate (1995)",
+      "summary": "Axiomatizes izotovCandidate = 734110615000775^4 as Sierpinski. Verifies izotov_is_power (it is a perfect 4th power) via norm_num/rfl. This is the strongest evidence for Problem #1113 having answer YES.",
       "startLine": 121,
       "endLine": 130
     },
     {
       "id": "ffk-conjecture",
-      "title": "Filaseta-Finch-Kozek Conjecture",
-      "summary": "Perfect powers or covered",
+      "title": "FFK Conjecture and Power Result",
+      "summary": "Defines IsPerfectPower (m = n^k, k >= 2) and FFKConjecture (Sierpinski implies perfect power or covered). Verifies ffk_consistent_with_izotov. Axiomatizes the FFK power result on simultaneous compositeness.",
       "startLine": 132,
       "endLine": 154
     },
     {
       "id": "fermat-connection",
       "title": "Connection to Fermat Primes",
-      "summary": "NO implies infinitely many Fermat primes",
+      "summary": "Defines FermatNumber (2^(2^n)+1) and IsFermatPrime. Axiomatizes known Fermat primes F0-F4, F5's factorization (641 × 6700417), and the Erdős-Graham connection: universal covering implies infinitely many Fermat primes.",
       "startLine": 156,
       "endLine": 184
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "summary": "Problem status and main result",
+      "title": "Summary Theorem",
+      "summary": "Proves erdos_1113_summary combining: (1) Izotov's candidate is Sierpinski, (2) it is a perfect power, (3) FFK conjecture is compatible. Verified from axioms and norm_num results. Problem Status: OPEN.",
       "startLine": 186,
       "endLine": 207
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1113 asks whether Sierpinski numbers without covering sets exist. Izotov's candidate m = 734110615000775^4 is the leading example. The FFK conjecture suggests uncovered Sierpinski numbers must be perfect powers. A negative answer would imply infinitely many Fermat primes - considered unlikely.",
-    "implications": "**Implications**\n\n1. **Covering Systems Theory:** Tests limits of this technique.\n\n2. **Fermat Primes:** Deep connection to their infinitude.\n\n3. **Prime Distribution:** Understanding compositeness patterns.\n\n4. **Perfect Powers:** Special role in the theory.",
+    "summary": "Erdős Problem #1113 remains OPEN. The formalization captures the full landscape: Sierpinski numbers via covering systems (78557 with its 7-element covering set), Izotov's conjectured uncovered candidate (734110615000775^4, verified as a perfect 4th power), the FFK Conjecture refining the question to perfect powers, and the deep connection to Fermat primes. The verified summary theorem combines Izotov's Sierpinski property, perfect power status, and FFK compatibility into a single result.",
+    "implications": "Resolution of Problem #1113 would have far-reaching consequences. An affirmative answer (uncovered Sierpinski numbers exist) would demonstrate that covering systems are not the sole mechanism for universal compositeness, opening new directions in analytic number theory. A negative answer would imply infinitely many Fermat primes via the Erdős-Graham connection -- a result that would revolutionize our understanding of Fermat numbers and would likely require entirely new techniques in prime distribution theory.",
     "openQuestions": [
-      "Does Izotov's candidate truly lack a covering set?",
-      "Is the FFK conjecture true?",
-      "Are there non-power Sierpinski numbers without coverings?",
-      "Can covering systems always explain compositeness?"
+      "Does Izotov's candidate m = 734110615000775^4 truly lack a covering set, or can one be found computationally?",
+      "Is the FFK Conjecture true -- are perfect powers the only possible uncovered Sierpinski numbers?",
+      "Are there non-power Sierpinski numbers without covering sets, contradicting FFK?",
+      "What is the relationship between the density of covered Sierpinski numbers and the number-theoretic properties of their covering sets?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "proofId": "erdos-370",
+      "relationship": "Both problems involve prime factorization structure of arithmetic sequences -- Problem #370 studies greatest prime factors of consecutive integers while Problem #1113 studies prime divisors covering the Sierpinski sequence 2^k·m+1"
+    },
+    {
+      "proofId": "erdos-984",
+      "relationship": "Both involve combinatorial number theory with finite set constructions -- Sidon sets (finite sets with unique pairwise sums) and covering sets (finite prime sets with complete divisibility coverage)"
+    },
+    {
+      "proofId": "erdos-107",
+      "relationship": "Both are Erdős problems where existence questions connect to deep structural phenomena -- the Happy Ending problem asks about convex subsets while Problem #1113 asks about uncovered Sierpinski numbers"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- **erdos-107**: Added mathContext to 9 annotations, expanded historicalContext to 4 paragraphs, crossReferences, sections 4->8
- **erdos-1136**: Structured mathContext on 9 annotations, expanded historicalContext to 3 paragraphs, crossReferences, sections 4->6
- **erdos-370**: Structured mathContext on 8 annotations, expanded historicalContext to 4 paragraphs, mathlibDependencies, crossReferences
- **birch-swinnerton-dyer**: Structured mathContext on 10 annotations, expanded historicalContext to 4 paragraphs (1960s EDSAC to Millennium Prize), sections 3->9, crossReferences
- **erdos-1091**: Structured mathContext on 9 annotations (cycle diagonals, Voss/Larson theorems, pentagonal wheel), expanded historicalContext to 4 paragraphs, crossReferences, sections 7->8

## Test plan
- [x] All JSON files validated with `python3 -c "import json; json.load(open(...))"`
- [ ] Visual review of enriched entries in gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)