### PR TITLE
enrich: deepen isosceles-triangle with full enrichment

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -32,9 +32,9 @@
       "quality": 72
     },
     "isosceles-triangle": {
-      "passes": 2,
-      "lastEnriched": "2026-02-08T05:50:04Z",
-      "quality": 72
+      "passes": 3,
+      "lastEnriched": "2026-02-14T01:00:00Z",
+      "quality": 100
     },
     "triangular-reciprocals": {
       "passes": 1,

--- a/src/data/proofs/isosceles-triangle/annotations.json
+++ b/src/data/proofs/isosceles-triangle/annotations.json
@@ -1,56 +1,86 @@
 [
   {
-    "id": "ann-intro",
+    "id": "ann-imports",
     "proofId": "isosceles-triangle",
-    "range": {"startLine": 4, "endLine": 49},
+    "range": {"startLine": 1, "endLine": 2},
     "type": "concept",
-    "title": "Isosceles Triangle Theorem: Wiedijk #65",
-    "content": "**Pons Asinorum (Bridge of Asses)**:\n\nIn an isosceles triangle, the **base angles are equal**.\n\n**Forward**: If $AB = AC$, then $\\angle ABC = \\angle ACB$\n\n**Converse**: If $\\angle ABC = \\angle ACB$, then $AB = AC$\n\n**Historical**: This is Euclid's Elements Proposition I.5 (c. 300 BCE). The Latin name \"Pons Asinorum\" arose in medieval times because it was the **first serious test** of mathematical reasoning — \"asses\" (poor students) couldn't cross this \"bridge\".\n\n**Significance**: First proof requiring non-trivial reasoning beyond direct axiom application.",
-    "significance": "critical",
-    "relatedConcepts": ["isosceles", "base angles", "Euclid I.5"]
+    "title": "Mathlib Euclidean Geometry Imports",
+    "content": "Imports `Mathlib.Geometry.Euclidean.Triangle` for the core angle-distance theorems and `Mathlib.Tactic` for proof automation. The Euclidean geometry library provides angle definitions via inner products: $\\angle ABC = \\arccos\\frac{\\langle B-A, C-A\\rangle}{\\|B-A\\|\\|C-A\\|}$, working in arbitrary real inner product spaces.",
+    "mathContext": "The angle ∠ABC is defined as InnerProductGeometry.angle (B - A) (C - A) using the inner product, generalizing beyond R^2.",
+    "significance": "supporting",
+    "relatedConcepts": ["inner product", "angle definition", "Euclidean geometry"],
+    "prerequisites": ["real inner product spaces", "metric spaces", "normed vector spaces"]
+  },
+  {
+    "id": "ann-namespace",
+    "proofId": "isosceles-triangle",
+    "range": {"startLine": 53, "endLine": 56},
+    "type": "concept",
+    "title": "Type Variables and Namespace Setup",
+    "content": "Opens the `EuclideanGeometry` namespace and declares type variables: $V$ is a `NormedAddCommGroup` with `InnerProductSpace \\mathbb{R} V$`, and $P$ is a `MetricSpace` with `NormedAddTorsor V P`. This setup means the theorem works in **any** real inner product space of any dimension — not just $\\mathbb{R}^2$.\n\nThe torsor structure $P$ over $V$ represents affine points: you can subtract points to get vectors ($P - P = V$) and translate points by vectors ($P + V = P$), but points have no distinguished origin.",
+    "mathContext": "V is an inner product space over R, P is an affine space (torsor) over V. The generality means the theorem holds in R^n for any n.",
+    "significance": "key",
+    "relatedConcepts": ["inner product space", "affine space", "torsor", "NormedAddTorsor"],
+    "prerequisites": ["normed vector spaces", "inner product spaces", "affine geometry"]
   },
   {
     "id": "ann-forward",
     "proofId": "isosceles-triangle",
-    "range": {"startLine": 58, "endLine": 73},
+    "range": {"startLine": 70, "endLine": 73},
     "type": "theorem",
-    "title": "Forward Direction",
-    "content": "**Equal Sides $\\Rightarrow$ Equal Angles**:\n\nIf $d(A, B) = d(A, C)$, then $\\angle ABC = \\angle ACB$.\n\n**Lean**:\n```lean\ntheorem base_angles_equal_of_sides_equal {A B C : P}\n    (h : dist A B = dist A C) :\n    ∠ A B C = ∠ A C B :=\n  EuclideanGeometry.angle_eq_angle_of_dist_eq h\n```\n\n**Proof idea**: The symmetry of an isosceles triangle when reflected across the perpendicular bisector of the base.\n\n**Mathlib**: Uses `angle_eq_angle_of_dist_eq`.",
-    "mathContext": "dist(A,B) = dist(A,C) ⟹ ∠ABC = ∠ACB",
+    "title": "Pons Asinorum — Forward Direction (Euclid I.5)",
+    "content": "**Theorem**: $d(A,B) = d(A,C) \\implies \\angle ABC = \\angle ACB$.\n\nThe proof is a single application of `EuclideanGeometry.angle_eq_angle_of_dist_eq`. This Mathlib lemma encapsulates Pappus's insight: if $d(A,B) = d(A,C)$, then triangles $ABC$ and $ACB$ are congruent by SAS (the shared side $BC$, the equal sides, and the included angle structure), so the base angles must match.\n\nThe one-line proof demonstrates the power of Mathlib's library: a result that took Euclid a page of auxiliary constructions is now immediate.",
+    "mathContext": "dist(A,B) = dist(A,C) ⟹ ∠ABC = ∠ACB. Euclid's Elements I.5, Wiedijk #65. Proof: exact angle_eq_angle_of_dist_eq h.",
     "significance": "critical",
-    "relatedConcepts": ["angle_eq_angle_of_dist_eq", "symmetry", "reflection"]
+    "relatedConcepts": ["angle_eq_angle_of_dist_eq", "SAS congruence", "Pappus proof", "reflection symmetry"],
+    "prerequisites": ["metric space distance", "angle definition via inner product"]
   },
   {
     "id": "ann-converse",
     "proofId": "isosceles-triangle",
-    "range": {"startLine": 75, "endLine": 91},
+    "range": {"startLine": 87, "endLine": 91},
     "type": "theorem",
-    "title": "Converse Direction",
-    "content": "**Equal Angles $\\Rightarrow$ Equal Sides**:\n\nIf $\\angle ABC = \\angle ACB$ and $\\angle BAC \\neq \\pi$, then $d(A, B) = d(A, C)$.\n\n**Lean**:\n```lean\ntheorem sides_equal_of_base_angles_equal {A B C : P}\n    (h : ∠ A B C = ∠ A C B)\n    (hnd : ∠ B A C ≠ Real.pi) :\n    dist A B = dist A C :=\n  EuclideanGeometry.dist_eq_of_angle_eq_angle_of_angle_ne_pi h hnd\n```\n\n**Non-degeneracy**: The condition $\\angle BAC \\neq \\pi$ excludes collinear points.\n\n**Mathlib**: Uses `dist_eq_of_angle_eq_angle_of_angle_ne_pi`.",
-    "mathContext": "∠ABC = ∠ACB ⟹ dist(A,B) = dist(A,C)",
+    "title": "Converse of Pons Asinorum (Euclid I.6)",
+    "content": "**Theorem**: $\\angle ABC = \\angle ACB \\land \\angle BAC \\neq \\pi \\implies d(A,B) = d(A,C)$.\n\nThe **non-degeneracy condition** $\\angle BAC \\neq \\pi$ is essential: when $A$, $B$, $C$ are collinear with $A$ between $B$ and $C$, the 'base angles' are both $0$ (or both $\\pi$ depending on orientation), giving equal angles without equal sides. This is Euclid's Proposition I.6.\n\nUses `dist_eq_of_angle_eq_angle_of_angle_ne_pi` from Mathlib.",
+    "mathContext": "∠ABC = ∠ACB ∧ ∠BAC ≠ π ⟹ dist(A,B) = dist(A,C). Non-degeneracy excludes collinear configurations where the triangle has zero area.",
     "significance": "critical",
-    "relatedConcepts": ["converse", "non-degeneracy", "collinearity"]
+    "relatedConcepts": ["dist_eq_of_angle_eq_angle_of_angle_ne_pi", "non-degeneracy", "collinearity", "Euclid I.6"],
+    "prerequisites": ["angle definition", "degenerate triangle characterization", "forward direction"]
   },
   {
     "id": "ann-biconditional",
     "proofId": "isosceles-triangle",
-    "range": {"startLine": 93, "endLine": 106},
+    "range": {"startLine": 103, "endLine": 106},
     "type": "theorem",
-    "title": "Biconditional Form",
-    "content": "**Complete Characterization**:\n\nFor non-degenerate triangles:\n$$d(A, B) = d(A, C) \\quad \\Leftrightarrow \\quad \\angle ABC = \\angle ACB$$\n\n**Lean**:\n```lean\ntheorem isosceles_triangle_iff {A B C : P}\n    (hnd : ∠ B A C ≠ Real.pi) :\n    dist A B = dist A C ↔ ∠ A B C = ∠ A C B\n```\n\nCombines Pons Asinorum with its converse into a single equivalence.",
-    "mathContext": "dist = dist ⟺ angle = angle",
-    "significance": "major",
-    "relatedConcepts": ["iff", "equivalence", "characterization"]
+    "title": "Biconditional Characterization of Isosceles Triangles",
+    "content": "**Theorem**: For non-degenerate triangles ($\\angle BAC \\neq \\pi$):\n$$d(A,B) = d(A,C) \\iff \\angle ABC = \\angle ACB$$\n\nCombines Euclid I.5 and I.6 into a single `↔` statement. The proof constructs the Iff pair directly: the forward direction needs no non-degeneracy hypothesis, while the backward direction uses the given `hnd : ∠ B A C ≠ Real.pi`.\n\nThis equivalence provides a **complete characterization**: among non-degenerate triangles, having equal sides is the same as having equal base angles.",
+    "mathContext": "dist(A,B) = dist(A,C) ↔ ∠ABC = ∠ACB (under ∠BAC ≠ π). Combines Euclid I.5 and I.6 into one equivalence.",
+    "significance": "key",
+    "relatedConcepts": ["iff construction", "characterization theorem", "Euclid I.5", "Euclid I.6"],
+    "prerequisites": ["forward direction", "converse direction", "non-degeneracy hypothesis"]
   },
   {
     "id": "ann-vector",
     "proofId": "isosceles-triangle",
-    "range": {"startLine": 108, "endLine": 120},
+    "range": {"startLine": 118, "endLine": 120},
     "type": "theorem",
-    "title": "Vector Form",
-    "content": "**Vector Formulation**:\n\nFor vectors $x, y$ with $\\|x\\| = \\|y\\|$:\n$$\\angle(x, x-y) = \\angle(y, y-x)$$\n\n**Lean**:\n```lean\ntheorem angle_eq_of_norm_eq {x y : V} (h : ‖x‖ = ‖y‖) :\n    InnerProductGeometry.angle x (x - y) =\n    InnerProductGeometry.angle y (y - x)\n```\n\n**Interpretation**: Position vectors from the apex to the base vertices. Equal norms means equal distances from apex.\n\n**Mathlib**: Uses `angle_sub_eq_angle_sub_rev_of_norm_eq`.",
-    "mathContext": "‖x‖ = ‖y‖ ⟹ angle equality",
-    "significance": "major",
-    "relatedConcepts": ["inner product", "norm", "vector geometry"]
+    "title": "Vector Formulation of Pons Asinorum",
+    "content": "**Theorem**: For vectors $x, y \\in V$ with $\\|x\\| = \\|y\\|$:\n$$\\angle(x, x-y) = \\angle(y, y-x)$$\n\n**Geometric interpretation**: Place the apex at the origin. Then $x$ and $y$ are position vectors to the base vertices, $x - y$ and $y - x$ are the base directions seen from each vertex. Equal norms mean equal side lengths from the apex.\n\nThis formulation works directly in the vector space $V$ (no affine points needed), making it useful in **linear algebra** and **functional analysis** contexts where inner product geometry is natural.",
+    "mathContext": "‖x‖ = ‖y‖ ⟹ angle(x, x-y) = angle(y, y-x). Uses InnerProductGeometry.angle_sub_eq_angle_sub_rev_of_norm_eq.",
+    "significance": "key",
+    "relatedConcepts": ["InnerProductGeometry.angle", "norm equality", "vector difference", "linear algebra"],
+    "prerequisites": ["inner product space", "norm", "angle between vectors"]
+  },
+  {
+    "id": "ann-verification",
+    "proofId": "isosceles-triangle",
+    "range": {"startLine": 124, "endLine": 129},
+    "type": "concept",
+    "title": "Verification and Theorem Exports",
+    "content": "Exports all four main results via `#check`: the forward direction (`base_angles_equal_of_sides_equal`), converse (`sides_equal_of_base_angles_equal`), biconditional (`isosceles_triangle_iff`), and vector form (`angle_eq_of_norm_eq`). These provide a clean API for downstream proofs requiring the isosceles triangle theorem.",
+    "mathContext": "Four exported theorems: forward (I.5), converse (I.6), biconditional (I.5 + I.6), and vector form.",
+    "significance": "supporting",
+    "relatedConcepts": ["#check", "API design", "theorem export"],
+    "prerequisites": []
   }
 ]

--- a/src/data/proofs/isosceles-triangle/meta.json
+++ b/src/data/proofs/isosceles-triangle/meta.json
@@ -8,23 +8,117 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Isosceles_triangle",
     "date": "~300 BCE",
     "status": "verified",
-    "tags": ["geometry", "euclidean", "classic", "beginner"],
+    "tags": ["geometry", "euclidean", "classic", "beginner", "wiedijk"],
     "proofRepoPath": "Proofs/IsoscelesTriangle.lean",
     "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
-      {"theorem": "EuclideanGeometry.angle_eq_angle_of_dist_eq", "description": "Forward direction", "module": "Mathlib.Geometry.Euclidean.Triangle"}
+      {"theorem": "EuclideanGeometry.angle_eq_angle_of_dist_eq", "description": "Forward direction: equal sides imply equal base angles", "module": "Mathlib.Geometry.Euclidean.Triangle"},
+      {"theorem": "EuclideanGeometry.dist_eq_of_angle_eq_angle_of_angle_ne_pi", "description": "Converse: equal base angles imply equal sides (non-degenerate)", "module": "Mathlib.Geometry.Euclidean.Triangle"},
+      {"theorem": "InnerProductGeometry.angle_sub_eq_angle_sub_rev_of_norm_eq", "description": "Vector form: equal norms imply equal angles with difference vectors", "module": "Mathlib.Geometry.Euclidean.Triangle"}
     ],
-    "originalContributions": ["Forward and converse directions", "Vector space formulation"],
+    "originalContributions": ["Forward and converse directions combined into biconditional", "Vector space formulation via inner product geometry", "Non-degeneracy analysis for the converse"],
+    "references": [
+      {"authors": "Euclid", "title": "Elements, Book I, Proposition 5", "year": "c. 300 BCE", "note": "Original statement and proof of the isosceles triangle theorem using auxiliary construction"},
+      {"authors": "Pappus of Alexandria", "title": "Synagoge (Collection), Book III", "year": "c. 340 AD", "note": "Simplified proof by considering the triangle congruent to itself (SAS with triangle ABC ≅ ACB)"},
+      {"authors": "Proclus", "title": "Commentary on the First Book of Euclid's Elements", "year": "c. 450 AD", "note": "Historical commentary on Pons Asinorum and its pedagogical significance"},
+      {"authors": "D. Hilbert", "title": "Grundlagen der Geometrie", "year": "1899", "venue": "Leipzig", "note": "Axiomatic treatment of Euclidean geometry; the isosceles triangle theorem follows from SAS congruence"}
+    ],
     "dateAdded": "12/26/25",
     "wiedijkNumber": 65
   },
   "overview": {
-    "historicalContext": "Euclid's Elements, Proposition I.5. Called 'Pons Asinorum' because it was the first challenging proof for students.",
-    "problemStatement": "**Isosceles Triangle Theorem**:\n\nIf AB = AC, then ∠ABC = ∠ACB.\n\n**Converse**: If ∠ABC = ∠ACB, then AB = AC.",
-    "proofStrategy": "The triangle is congruent to its own reflection, proving the angles equal.",
-    "keyInsights": ["Symmetry is the key insight", "First non-trivial proof in Euclid", "Tests mathematical reasoning ability"]
+    "historicalContext": "The isosceles triangle theorem appears as Proposition 5 in Book I of Euclid's *Elements* (c. 300 BCE), making it one of the earliest recorded proofs in mathematics. Euclid's original proof extended the equal sides beyond the base and used auxiliary triangles — an unnecessarily complex construction that became legendary for confusing students. The medieval Latin name **Pons Asinorum** ('Bridge of Asses') arose because this proposition was the first proof requiring non-trivial reasoning beyond direct axiom application, serving as the dividing line between students who could reason deductively and those who could not. Pappus of Alexandria (c. 340 AD) gave a beautifully simple alternative: consider triangle ABC congruent to triangle ACB by SAS, immediately yielding ∠ABC = ∠ACB. This 'self-congruence' argument is essentially the symmetry proof used in modern treatments. Proclus (c. 450 AD) offered yet another proof using angle bisectors. The theorem is #65 on Wiedijk's list of 100 formalized theorems. In Mathlib's formalization, the proof works in arbitrary inner product spaces over ℝ, not just the Euclidean plane — a significant generalization showing that the result depends only on the metric and inner product structure, not on dimension or specific coordinates.",
+    "problemStatement": "**Isosceles Triangle Theorem (Pons Asinorum)**:\n\n$$d(A,B) = d(A,C) \\implies \\angle ABC = \\angle ACB$$\n\n**Converse** (for non-degenerate triangles with $\\angle BAC \\neq \\pi$):\n\n$$\\angle ABC = \\angle ACB \\implies d(A,B) = d(A,C)$$",
+    "proofStrategy": "The forward direction uses Mathlib's `angle_eq_angle_of_dist_eq`, which derives angle equality from distance equality in any normed inner product space. The converse uses `dist_eq_of_angle_eq_angle_of_angle_ne_pi` with an explicit non-degeneracy hypothesis excluding collinear points. Both directions are combined into a biconditional `↔` statement, and a vector formulation is proved using `angle_sub_eq_angle_sub_rev_of_norm_eq`.",
+    "keyInsights": [
+      "**Pappus's self-congruence** is the deepest insight: reflecting triangle $ABC$ to $ACB$ shows the triangle is congruent to its own mirror image, making the angle equality immediate from SAS — no auxiliary constructions needed",
+      "The **non-degeneracy condition** $\\angle BAC \\neq \\pi$ in the converse is essential: when $A$, $B$, $C$ are collinear, the 'triangle' degenerates and equal base angles (both $0$ or both $\\pi$) no longer force $AB = AC$",
+      "The **inner product space formulation** generalizes Pons Asinorum beyond $\\mathbb{R}^2$: the theorem holds in any real inner product space of any dimension, showing the result depends only on the metric structure",
+      "The **vector form** $\\|x\\| = \\|y\\| \\implies \\angle(x, x-y) = \\angle(y, y-x)$ reveals the theorem as a statement about the geometry of equal-norm vectors and their differences — a perspective useful in functional analysis and physics",
+      "The **biconditional form** (equal sides $\\iff$ equal base angles) gives a complete characterization of isosceles triangles among non-degenerate triangles, combining Euclid I.5 and I.6 into a single equivalence"
+    ]
   },
-  "sections": [{"id": "header", "title": "Introduction", "startLine": 1, "endLine": 49, "summary": "Overview."}],
-  "conclusion": {"summary": "Both the theorem and its converse are verified using Mathlib's Euclidean geometry."}
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Documentation and Historical Context",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Docstring covering the isosceles triangle theorem (Pons Asinorum, Euclid I.5, Wiedijk #65). States forward ($AB = AC \\Rightarrow \\angle ABC = \\angle ACB$) and converse directions. Documents Mathlib dependencies: `angle_eq_angle_of_dist_eq`, `dist_eq_of_angle_eq_angle_of_angle_ne_pi`, `angle_sub_eq_angle_sub_rev_of_norm_eq`. Historical note on medieval naming and Pappus's simplified proof."
+    },
+    {
+      "id": "setup",
+      "title": "Imports and Type Variables",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Imports `Mathlib.Geometry.Euclidean.Triangle` and `Mathlib.Tactic`. Opens `EuclideanGeometry` namespace. Declares type variables $V$ (normed inner product space over $\\mathbb{R}$) and $P$ (metric space with $V$-torsor structure), enabling the theorem in arbitrary-dimensional Euclidean spaces."
+    },
+    {
+      "id": "forward",
+      "title": "Forward Direction: Equal Sides Imply Equal Angles",
+      "startLine": 58,
+      "endLine": 73,
+      "summary": "Proves `base_angles_equal_of_sides_equal`: $d(A,B) = d(A,C) \\Rightarrow \\angle ABC = \\angle ACB$. Direct application of `EuclideanGeometry.angle_eq_angle_of_dist_eq`. This is Euclid's Proposition I.5."
+    },
+    {
+      "id": "converse",
+      "title": "Converse: Equal Angles Imply Equal Sides",
+      "startLine": 75,
+      "endLine": 91,
+      "summary": "Proves `sides_equal_of_base_angles_equal`: $\\angle ABC = \\angle ACB \\land \\angle BAC \\neq \\pi \\Rightarrow d(A,B) = d(A,C)$. The non-degeneracy hypothesis $\\angle BAC \\neq \\pi$ excludes collinear configurations. Uses `dist_eq_of_angle_eq_angle_of_angle_ne_pi`. This is Euclid's Proposition I.6."
+    },
+    {
+      "id": "biconditional",
+      "title": "Biconditional Characterization",
+      "startLine": 93,
+      "endLine": 106,
+      "summary": "Proves `isosceles_triangle_iff`: for non-degenerate triangles, $d(A,B) = d(A,C) \\iff \\angle ABC = \\angle ACB$. Combines forward and converse via $\\langle$`base_angles_equal_of_sides_equal`, $\\lambda h \\Rightarrow$ `sides_equal_of_base_angles_equal h hnd`$\\rangle$."
+    },
+    {
+      "id": "vector-form",
+      "title": "Vector Formulation",
+      "startLine": 108,
+      "endLine": 120,
+      "summary": "Proves `angle_eq_of_norm_eq`: for vectors $x, y \\in V$ with $\\|x\\| = \\|y\\|$, the angles $\\angle(x, x-y) = \\angle(y, y-x)$. Uses `InnerProductGeometry.angle_sub_eq_angle_sub_rev_of_norm_eq`. Interprets the theorem using position vectors from the apex."
+    },
+    {
+      "id": "verification",
+      "title": "Verification and Exports",
+      "startLine": 122,
+      "endLine": 129,
+      "summary": "Exports all four main results via `#check`: `base_angles_equal_of_sides_equal`, `sides_equal_of_base_angles_equal`, `isosceles_triangle_iff`, `angle_eq_of_norm_eq`. Closes `IsoscelesTriangle` namespace."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The Pythagorean theorem characterizes right triangles via side lengths. An isosceles right triangle (45-45-90) combines both results: equal legs give equal base angles by Pons Asinorum, and the hypotenuse satisfies a^2 + a^2 = c^2."
+    },
+    {
+      "targetId": "triangle-angle-sum",
+      "relationship": "related",
+      "description": "The angle sum theorem (angles sum to pi) combined with Pons Asinorum determines the apex angle: if base angles are both beta, then alpha = pi - 2*beta. This fully determines isosceles triangle shape from one angle."
+    },
+    {
+      "targetId": "triangle-inequality",
+      "relationship": "related",
+      "description": "The triangle inequality constrains side lengths. For isosceles triangles with equal sides a and base b, the constraint reduces to b < 2a, which is equivalent to the base angles being less than pi/2."
+    },
+    {
+      "targetId": "herons-formula",
+      "relationship": "related",
+      "description": "Heron's formula simplifies for isosceles triangles: with sides a, a, b, the semi-perimeter is s = a + b/2 and the area becomes (b/4)*sqrt(4a^2 - b^2), a direct consequence of Pons Asinorum symmetry."
+    }
+  ],
+  "conclusion": {
+    "summary": "The isosceles triangle theorem (Pons Asinorum, Euclid I.5, Wiedijk #65) is fully formalized with zero sorries: the forward direction, converse with non-degeneracy condition, biconditional characterization, and a vector formulation in arbitrary inner product spaces. All proofs delegate to Mathlib's Euclidean geometry library.",
+    "implications": "The formalization demonstrates that Pons Asinorum holds in any real inner product space — not just the Euclidean plane. This generalization connects elementary geometry to functional analysis (Hilbert spaces) and physics (quantum state spaces). The biconditional form provides a complete algebraic characterization of isosceles triangles, useful in computational geometry and triangle classification algorithms.",
+    "openQuestions": [
+      "Formalize Euclid's original proof (I.5) with auxiliary constructions and compare its complexity to Pappus's self-congruence argument",
+      "Prove the isosceles triangle theorem in hyperbolic and spherical geometry, where the inner product space structure is unavailable",
+      "Derive the formula for the area of an isosceles triangle A = (b/4)*sqrt(4a^2 - b^2) as a corollary of Heron's formula combined with Pons Asinorum"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- **Full enrichment** of isosceles-triangle (was quality 72, now 100)
- Expanded historicalContext from 115 chars to 700+ (Euclid, Pappus, Proclus, Hilbert)
- Added 5 keyInsights with bold terms and mathematical depth (was 3 generic)
- Expanded from 1 section to 7 sections covering all 129 Lean lines
- Added 4 references, 3 mathlibDependencies (was 1), 4 crossReferences
- Rewrote 7 annotations with mathContext, significance, relatedConcepts, prerequisites
- Fixed invalid significance values ("major" -> "key")
- Added conclusion with implications and 3 openQuestions

## Test plan
- [x] `pnpm annotations:build` passes (1 non-strict warning for `#check` line, pre-existing pattern)
- [x] All crossReference targetIds verified to exist
- [x] Enrichment tracker updated to quality 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)