### PR TITLE
enrich: deepen erdos-1138 with mathContext, cross-refs, and historical context

### DIFF
--- a/src/data/proofs/erdos-1138/annotations.json
+++ b/src/data/proofs/erdos-1138/annotations.json
@@ -7,169 +7,300 @@
       "endLine": 17
     },
     "type": "concept",
-    "title": "Problem Overview",
-    "content": "Header documentation for Erdős Problem #1138, providing mathematical context and problem statement.",
-    "mathContext": "Erdős Problem #1138 — Primes in Short Intervals and Maximal Gaps\n\nLet x/2 < y < x and C > 1. If d = max_{p_n < x}(p_{n+1} - p_n)\nis the maximal prime gap below x, then is it true that\n\n  π(y + Cd) - π(y) ~ Cd / log y?\n\nThis combines two deep problems: determining when the prime counting\nfunction obeys its expected asymptotic in short intervals, and\nunderstanding the size of maximal prime gaps.\n\nThe conjectured size of d is approximately (log x)², which is far\nbelow the interval length h for whic",
+    "title": "Problem Statement and Context",
+    "content": "Header documentation for Erdős Problem #1138, stating the conjecture on primes in short intervals near maximal gaps. The problem asks whether the prime counting function obeys its expected asymptotic $\\pi(y + Cd) - \\pi(y) \\sim Cd / \\log y$ when $d$ is the maximal prime gap below $x$ and $y \\in (x/2, x)$. The header notes that even under the Riemann Hypothesis, the conjectured gap size $(\\log x)^2$ is far below the threshold for known short-interval prime number theorems.",
+    "mathContext": "The conjecture connects two central quantities: the maximal prime gap $d(x) = \\max_{p_n < x}(p_{n+1} - p_n)$ and the short-interval prime counting function $\\pi(y+h) - \\pi(y)$. By the PNT, we expect $\\pi(y+h) - \\pi(y) \\approx h/\\log y$ for 'reasonable' $h$. If Cramér's conjecture holds ($d(x) \\sim (\\log x)^2$), then the interval length $Cd$ is approximately $C(\\log x)^2$, which is enormously shorter than any interval for which the short-interval PNT is known to hold.",
     "significance": "critical",
     "relatedConcepts": [
-      "Erdős problems",
-      "Number theory"
+      "prime number theorem",
+      "short interval prime counting",
+      "Cramér's conjecture",
+      "maximal prime gaps"
+    ],
+    "prerequisites": [
+      "prime counting function",
+      "asymptotic equivalence",
+      "Riemann Hypothesis implications"
+    ]
+  },
+  {
+    "id": "ann-e1138-imports",
+    "proofId": "erdos-1138",
+    "range": {
+      "startLine": 19,
+      "endLine": 27
+    },
+    "type": "concept",
+    "title": "Mathlib Imports",
+    "content": "Imports the necessary Mathlib modules: `Nat.Prime.Basic` for the `Nat.Prime` predicate, `Finset.Basic` and `Finset.Card` for the finite set operations used to define the prime counting function, `Data.Real.Basic` for real number arithmetic in the asymptotic bounds, and `Order.Filter.AtTopBot` for the eventual behavior formulation.",
+    "mathContext": "The `Finset.filter` operation is central: $\\pi(n)$ is defined as the cardinality of $\\{k \\in \\{0, \\ldots, n\\} : k \\text{ is prime}\\}$. Real arithmetic is needed because the asymptotic bound $Cd / \\log y$ involves real division and logarithms.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.filter",
+      "Nat.Prime predicate",
+      "real arithmetic"
+    ],
+    "prerequisites": [
+      "Lean 4 import system",
+      "Mathlib library structure"
     ]
   },
   {
     "id": "ann-e1138-primeCounting",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 34,
+      "startLine": 33,
       "endLine": 35
     },
     "type": "definition",
-    "title": "Primecounting",
-    "content": "/-- The prime counting function π(n) = |{p ≤ n : p prime}|. -/",
-    "significance": "supporting"
+    "title": "Prime Counting Function",
+    "content": "Defines $\\pi(n)$ as the number of primes at most $n$, computed by filtering `Finset.range(n+1)` for primes and taking the cardinality. This is noncomputable because `Nat.Prime` uses `Decidable` instances that may not reduce efficiently, though the definition is mathematically transparent.",
+    "mathContext": "$\\pi(n) = |\\{p \\le n : p \\text{ is prime}\\}| = (\\texttt{Finset.range}(n+1)).\\texttt{filter}(\\texttt{Nat.Prime}).\\texttt{card}$. The prime counting function is one of the most studied objects in number theory, with the PNT establishing $\\pi(x) \\sim x / \\log x$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "prime number theorem",
+      "Chebyshev's estimates",
+      "Mertens' theorems",
+      "Finset.filter"
+    ],
+    "prerequisites": [
+      "Nat.Prime",
+      "Finset.range",
+      "cardinality of finite sets"
+    ]
   },
   {
     "id": "ann-e1138-primesInInterval",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 38,
+      "startLine": 37,
       "endLine": 39
     },
     "type": "definition",
-    "title": "Primesininterval",
-    "content": "/-- Count of primes in the interval (a, b]: π(b) - π(a). -/",
-    "significance": "supporting"
+    "title": "Primes in an Interval",
+    "content": "Defines the count of primes in the half-open interval $(a, b]$ as $\\pi(b) - \\pi(a)$. This is the key quantity in the Erdős conjecture: the formalization asks whether $\\pi(y + Cd) - \\pi(y) \\sim Cd / \\log y$ for appropriate $y$ and $d$.",
+    "mathContext": "$\\texttt{primesInInterval}(a, b) = \\pi(b) - \\pi(a) = |\\{p : a < p \\le b, \\, p \\text{ prime}\\}|$. Note that since $\\pi$ is defined on $\\mathbb{N}$, this subtraction is natural number subtraction (truncated at 0), which is correct because $\\pi$ is monotone.",
+    "significance": "key",
+    "relatedConcepts": [
+      "short interval prime number theorem",
+      "Selberg sieve",
+      "prime counting function"
+    ],
+    "prerequisites": [
+      "primeCounting",
+      "monotonicity of π"
+    ]
   },
   {
     "id": "ann-e1138-primeGapBelow",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 44,
+      "startLine": 43,
       "endLine": 46
     },
     "type": "definition",
-    "title": "Primegapbelow",
-    "content": "/-- The set of prime gaps below x: {p_{n+1} - p_n : p_n < x, p_n and p_{n+1} consecutive primes}. -/",
-    "significance": "supporting"
+    "title": "Set of Prime Gaps Below x",
+    "content": "Defines the set of consecutive prime gaps below $x$: $\\{q - p : p, q \\text{ consecutive primes}, q \\le x\\}$. The consecutiveness condition is formalized as: $p$ and $q$ are both prime, $p < q$, and there is no prime $r$ with $p < r < q$ (encoded as $\\forall r, \\text{Prime}(r) \\to p < r \\to q \\le r$).",
+    "mathContext": "$\\texttt{primeGapBelow}(x) = \\{d \\in \\mathbb{N} : \\exists p, q \\text{ with } p, q \\text{ prime}, p < q \\le x, \\text{consecutive}, d = q - p\\}$. The consecutiveness condition $\\forall r, \\text{Prime}(r) \\to p < r \\to q \\le r$ elegantly encodes that no prime lies strictly between $p$ and $q$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "consecutive primes",
+      "prime gap function",
+      "Cramér's conjecture",
+      "Bertrand's postulate"
+    ],
+    "prerequisites": [
+      "Nat.Prime",
+      "set-builder notation in Lean"
+    ]
   },
   {
     "id": "ann-e1138-maxPrimeGap",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 49,
+      "startLine": 48,
       "endLine": 51
     },
     "type": "definition",
-    "title": "Maxprimegap",
-    "content": "/-- The maximal prime gap below x. -/",
-    "significance": "supporting"
+    "title": "Maximal Prime Gap",
+    "content": "Defines $d(x) = \\sup\\{q - p : p, q \\text{ consecutive primes}, q \\le x\\}$ using `sSup` (the supremum in $\\mathbb{N}$ with its conditionally complete lattice structure). This is noncomputable because computing the supremum requires deciding primality across all pairs.",
+    "mathContext": "$d(x) = \\text{sSup}(\\texttt{primeGapBelow}(x))$. Known values include $d(10) = 4$ (gap between 7 and 11), $d(100) = 8$ (gap between 89 and 97), and $d(10^{18}) = 1476$ (discovered computationally). Cramér conjectured $d(x) \\sim (\\log x)^2$; the best proven upper bound is $d(x) \\ll x^{0.525}$ (Baker–Harman–Pintz, 2001).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "supremum in conditionally complete lattice",
+      "Cramér's conjecture",
+      "Baker–Harman–Pintz theorem",
+      "prime gap records"
+    ],
+    "prerequisites": [
+      "sSup",
+      "BddAbove",
+      "primeGapBelow"
+    ]
   },
   {
     "id": "ann-e1138-primeCounting_mono",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 56,
+      "startLine": 55,
       "endLine": 60
     },
     "type": "theorem",
-    "title": "Primecounting Mono",
-    "content": "/-- π is monotone: if a ≤ b then π(a) ≤ π(b). -/",
-    "significance": "key"
+    "title": "Monotonicity of π",
+    "content": "Proves that $\\pi$ is monotone: $a \\le b \\Rightarrow \\pi(a) \\le \\pi(b)$. The proof chains `Finset.card_le_card` with `Finset.filter_subset_filter` and `Finset.range_mono`. This is essential for ensuring that `primesInInterval` (defined as $\\pi(b) - \\pi(a)$) is non-negative in the natural number sense.",
+    "mathContext": "$a \\le b \\implies \\pi(a) \\le \\pi(b)$. The proof is: $\\{p \\le a : \\text{prime}\\} \\subseteq \\{p \\le b : \\text{prime}\\}$ since $\\{0, \\ldots, a\\} \\subseteq \\{0, \\ldots, b\\}$, and subset implies $\\le$ on cardinalities.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.card_le_card",
+      "monotone functions",
+      "natural number subtraction"
+    ],
+    "prerequisites": [
+      "primeCounting",
+      "Finset.range_mono",
+      "Finset.filter_subset_filter"
+    ]
   },
   {
-    "id": "ann-e1138-primeCounting_zero",
+    "id": "ann-e1138-small-values",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 63,
-      "endLine": 65
-    },
-    "type": "theorem",
-    "title": "Primecounting Zero",
-    "content": "/-- π(0) = 0 (no primes at or below 0). -/",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1138-primeCounting_one",
-    "proofId": "erdos-1138",
-    "range": {
-      "startLine": 68,
-      "endLine": 70
-    },
-    "type": "theorem",
-    "title": "Primecounting One",
-    "content": "/-- π(1) = 0 (1 is not prime). -/",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e1138-primeCounting_two",
-    "proofId": "erdos-1138",
-    "range": {
-      "startLine": 73,
+      "startLine": 62,
       "endLine": 75
     },
     "type": "theorem",
-    "title": "Primecounting Two",
-    "content": "/-- π(2) = 1. -/",
-    "significance": "key"
+    "title": "Small Values of π",
+    "content": "Establishes $\\pi(0) = 0$, $\\pi(1) = 0$, and $\\pi(2) = 1$ by computation. These are proved using `simp` followed by `decide`, which unfolds the definitions and checks the finite computation. The fact $\\pi(2) = 1$ confirms that 2 is the smallest (and only even) prime.",
+    "mathContext": "$\\pi(0) = 0$ (no primes $\\le 0$), $\\pi(1) = 0$ (1 is not prime), $\\pi(2) = 1$ (2 is the unique even prime). These base cases anchor the prime counting function and are used for sanity-checking the definition.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "smallest prime",
+      "decidability of finite computations",
+      "Nat.not_prime_zero",
+      "Nat.not_prime_one"
+    ],
+    "prerequisites": [
+      "primeCounting",
+      "decide tactic"
+    ]
   },
   {
     "id": "ann-e1138-primeCounting_le",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 78,
+      "startLine": 77,
       "endLine": 80
     },
     "type": "theorem",
-    "title": "Primecounting Le",
-    "content": "/-- π(n) ≤ n + 1 (trivial upper bound). -/",
-    "significance": "key"
+    "title": "Trivial Upper Bound on π",
+    "content": "Proves $\\pi(n) \\le n + 1$: the number of primes up to $n$ is at most the total number of natural numbers up to $n$. Uses `Finset.card_filter_le` which states that filtering a finite set can only reduce cardinality.",
+    "mathContext": "$\\pi(n) = |\\{p \\le n : \\text{prime}\\}| \\le |\\{0, \\ldots, n\\}| = n + 1$. This is far from the PNT bound $\\pi(n) \\sim n/\\log n$, but it is the tightest bound provable from the definition alone without analytic methods.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.card_filter_le",
+      "prime number theorem",
+      "Chebyshev bounds"
+    ],
+    "prerequisites": [
+      "primeCounting",
+      "Finset.card_filter_le"
+    ]
   },
   {
     "id": "ann-e1138-maxPrimeGap_le",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 83,
+      "startLine": 82,
       "endLine": 88
     },
     "type": "theorem",
-    "title": "Maxprimegap Le",
-    "content": "/-- The maximal prime gap below x is at most x (trivial bound). -/",
-    "significance": "key"
+    "title": "Trivial Bound on Maximal Prime Gap",
+    "content": "Attempts to prove $d(x) \\le x$: the maximal gap between consecutive primes below $x$ cannot exceed $x$ itself. The proof handles the empty case (no gaps when there are fewer than 2 primes below $x$) but leaves the non-empty case as sorry, requiring a `BddAbove` proof for the gap set and a bound on its `sSup`.",
+    "mathContext": "$d(x) = \\sup\\{q - p : p, q \\text{ consecutive primes}, q \\le x\\} \\le x$ because each gap satisfies $q - p < q \\le x$. The sorry arises from the need to show the set is bounded above (for `sSup` to be meaningful in $\\mathbb{N}$) and then that the supremum respects the pointwise bound.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sSup and BddAbove",
+      "csSup_le",
+      "conditional completeness"
+    ],
+    "prerequisites": [
+      "maxPrimeGap",
+      "sSup properties",
+      "BddAbove for finite subsets of ℕ"
+    ]
   },
   {
     "id": "ann-e1138-erdos_1138",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 110,
+      "startLine": 90,
       "endLine": 117
     },
-    "type": "axiom",
-    "title": "Erdos 1138",
-    "content": "axiom erdos_1138",
-    "significance": "critical"
+    "type": "theorem",
+    "title": "Erdős Problem 1138 (Main Conjecture)",
+    "content": "The central conjecture, stated as an axiom: for any constant $C > 1$ and tolerance $\\varepsilon > 0$, there exists $N$ such that for all $x \\ge N$ and all $y$ with $x/2 < y < x$, the number of primes in $(y, y + \\lfloor Cd \\rfloor]$ satisfies $(1 - \\varepsilon) \\cdot Cd/\\log y \\le \\pi(y + \\lfloor Cd \\rfloor) - \\pi(y) \\le (1 + \\varepsilon) \\cdot Cd/\\log y$. The extensive docstring documents the problem's status (OPEN) and why it is out of reach: even under RH, short-interval PNT needs $h > x^{1/2+\\varepsilon}$, while $Cd \\sim C(\\log x)^2$ is far shorter.",
+    "mathContext": "The $\\varepsilon$-sandwich formulation avoids division: $f(x) \\sim g(x)$ is equivalent to $(1-\\varepsilon)g(x) \\le f(x) \\le (1+\\varepsilon)g(x)$ for all $\\varepsilon > 0$ eventually. The use of `Nat.floor (C * d)` converts the real-valued interval length to a natural number endpoint. The universality over $y \\in (x/2, x)$ is the strongest form, implying both average and worst-case control.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "short interval prime number theorem",
+      "asymptotic equivalence",
+      "Cramér's conjecture",
+      "Huxley's theorem",
+      "Maier's theorem"
+    ],
+    "prerequisites": [
+      "primesInInterval",
+      "maxPrimeGap",
+      "Real.log",
+      "Nat.floor",
+      "filter-based limits"
+    ]
   },
   {
-    "id": "ann-e1138-bertrand_postulate",
+    "id": "ann-e1138-bertrand",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 123,
+      "startLine": 121,
       "endLine": 124
     },
-    "type": "axiom",
-    "title": "Bertrand Postulate",
-    "content": "axiom bertrand_postulate",
-    "significance": "key"
+    "type": "theorem",
+    "title": "Bertrand's Postulate",
+    "content": "States Bertrand's postulate as an axiom: for every $n \\ge 1$, there exists a prime $p$ with $n < p \\le 2n$. This was conjectured by Bertrand in 1845 and proved by Chebyshev in 1852. Erdős gave an elegant elementary proof in 1932 at age 19 — his first published paper. The result implies that $d(n) < n$ for all $n$, but this is vastly weaker than Cramér's conjecture $d(x) \\sim (\\log x)^2$.",
+    "mathContext": "$\\forall n \\ge 1, \\, \\exists p \\text{ prime}: n < p \\le 2n$. Equivalently, the prime gap after any prime $p$ is at most $p$: $p_{n+1} - p_n < p_n$. Bertrand's postulate is available in Mathlib as `Nat.bertrand`, but is stated here as an axiom for self-containedness.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chebyshev's theorem",
+      "Erdős's first paper",
+      "prime gap upper bounds",
+      "Nat.bertrand in Mathlib"
+    ],
+    "prerequisites": [
+      "Nat.Prime",
+      "basic arithmetic inequalities"
+    ]
   },
   {
-    "id": "ann-e1138-cramer_conjecture",
+    "id": "ann-e1138-cramer",
     "proofId": "erdos-1138",
     "range": {
-      "startLine": 129,
+      "startLine": 126,
       "endLine": 132
     },
-    "type": "axiom",
-    "title": "Cramer Conjecture",
-    "content": "axiom cramer_conjecture",
-    "significance": "key"
+    "type": "theorem",
+    "title": "Cramér's Conjecture",
+    "content": "States Cramér's conjecture as an axiom: for every $\\varepsilon > 0$, eventually $d(x) \\le (1 + \\varepsilon)(\\log x)^2$. Harald Cramér proposed this in 1936 based on his probabilistic model of primes, where each integer $n$ is independently 'prime' with probability $1/\\log n$. Under this model, the maximal gap below $x$ is $(\\log x)^2$ with probability 1. The conjecture is OPEN and far stronger than any proven result. If true, Erdős's conjecture would ask for the PNT in intervals of length $\\sim C(\\log x)^2$.",
+    "mathContext": "$\\forall \\varepsilon > 0, \\, \\exists N, \\, \\forall x \\ge N: d(x) \\le (1 + \\varepsilon)(\\log x)^2$. The best unconditional bound is $d(x) \\ll x^{0.525}$ (Baker–Harman–Pintz, 2001). Under RH, one gets $d(x) \\ll \\sqrt{x} \\log x$ (Cramér, 1920). Granville (1995) suggested the constant may be $2e^{-\\gamma} \\approx 1.1229$ rather than 1.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cramér's probabilistic model",
+      "Baker–Harman–Pintz theorem",
+      "Granville's refinement",
+      "Euler–Mascheroni constant"
+    ],
+    "prerequisites": [
+      "maxPrimeGap",
+      "Real.log",
+      "asymptotic notation"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-1138/meta.json
+++ b/src/data/proofs/erdos-1138/meta.json
@@ -76,61 +76,95 @@
     ]
   },
   "overview": {
-    "historicalContext": "Erdős Problem #1138 asks about the prime counting function in short intervals near maximal gaps. The problem connects two fundamental aspects of prime distribution: the size of maximal gaps between consecutive primes, and the accuracy of asymptotic estimates for π(x) in short intervals.\n\nThe conjectured maximal gap d ~ (log x)² (Cramér's conjecture) is far below the threshold h > x^{7/12} needed for unconditional short interval prime number theorem, or even h > x^{1/2+ε} under the Riemann Hypothesis. This makes the problem particularly deep.\n\nThis problem is catalogued at erdosproblems.com/1138.",
-    "problemStatement": "For x/2 < y < x and C > 1, if d is the maximal prime gap below x, is π(y + Cd) - π(y) ~ Cd / log y?",
-    "proofStrategy": "The formalization is structured in 135 lines of Lean 4 code. It uses 3 axioms for results that require external references or deep mathematical arguments beyond Mathlib. There is 1 sorry placeholder for structural results that can be filled in with additional work. The main conjecture is stated as an axiom since it is an open problem.",
+    "historicalContext": "Erdős Problem #1138 sits at the intersection of two of the deepest themes in analytic number theory: the distribution of primes in short intervals and the structure of maximal prime gaps. The prime number theorem, proved independently by Hadamard and de la Vallée Poussin in 1896, establishes that $\\pi(x) \\sim x/\\log x$, but understanding $\\pi(x+h) - \\pi(x)$ for short intervals $h = o(x)$ is far harder. Huxley (1972) showed unconditionally that the asymptotic $\\pi(x+h) - \\pi(x) \\sim h/\\log x$ holds for $h > x^{7/12}$, while under the Riemann Hypothesis one can take $h > x^{1/2+\\varepsilon}$.\n\nMeanwhile, the maximal prime gap $d(x) = \\max_{p_n < x}(p_{n+1} - p_n)$ is conjectured by Cramér (1936) to satisfy $d(x) \\sim (\\log x)^2$, based on a probabilistic model of the primes. The best unconditional result, due to Baker–Harman–Pintz (2001), gives a prime in every interval $[x, x + x^{0.525}]$, but this is enormously larger than $(\\log x)^2$. Erdős's question asks whether the prime counting function still behaves asymptotically correctly in intervals of length $Cd(x)$ — intervals potentially as short as $C(\\log x)^2$ — centered around arbitrary points $y \\in (x/2, x)$. This would require a dramatic strengthening of all known short-interval results.\n\nThe problem reflects Erdős's characteristic approach of posing questions that connect disparate areas: here, the combinatorial structure of prime gaps meets the analytic machinery of the prime number theorem.",
+    "problemStatement": "For $x/2 < y < x$ and $C > 1$, if $d = \\max_{p_n < x}(p_{n+1} - p_n)$ is the maximal prime gap below $x$, is it true that $\\pi(y + Cd) - \\pi(y) \\sim Cd / \\log y$ as $x \\to \\infty$?",
+    "proofStrategy": "The formalization builds the necessary infrastructure in stages. First, the prime counting function $\\pi(n)$ is defined using `Finset.filter` over `Finset.range`, giving a computable definition. Interval counting $\\pi(b) - \\pi(a)$ and the maximal prime gap $d(x) = \\sup\\{q - p : p, q \\text{ consecutive primes}, q \\le x\\}$ are then defined. Basic properties of $\\pi$ (monotonicity, values at 0, 1, 2, and trivial upper bounds) are proved. The conjecture itself is stated as an axiom using the $\\varepsilon$-formulation: for every $\\varepsilon > 0$, the ratio of the actual prime count to the expected count lies in $[1-\\varepsilon, 1+\\varepsilon]$ for sufficiently large $x$. Related results — Bertrand's postulate and Cramér's conjecture — are included as axioms to contextualize the problem.",
     "keyInsights": [
-      "**The prime counting function π(n) = |{p ≤ n**: The prime counting function π(n) = |{p ≤ n : p prime}|.",
-      "**Count of primes in the interval (a, b]**: Count of primes in the interval (a, b]: π(b) - π(a).",
-      "**The set of prime gaps below x**: The set of prime gaps below x: {p_{n+1} - p_n : p_n < x, p_n and p_{n+1} consecutive primes}.",
-      "**The maximal prime gap below x.**: The maximal prime gap below x.",
-      "**π is monotone**: π is monotone: if a ≤ b then π(a) ≤ π(b)."
+      "**Gap between conjecture and provability**: Cramér's conjecture predicts $d(x) \\sim (\\log x)^2$, but even under the Riemann Hypothesis, short interval PNT requires $h > x^{1/2+\\varepsilon}$. The gap between $(\\log x)^2$ and $x^{1/2+\\varepsilon}$ is astronomical, making this problem completely out of reach of current methods.",
+      "**Uniformity over the interval $(x/2, x)$**: The conjecture asks for the asymptotic to hold for *all* $y$ in the second half $(x/2, x)$, not just a typical $y$. This uniformity requirement is much stronger than an average-case statement and rules out approaches based on mean-value theorems alone.",
+      "**The $\\varepsilon$-formulation captures asymptotic equivalence**: The Lean statement uses $(1-\\varepsilon) \\cdot Cd/\\log y \\le \\pi(y+Cd) - \\pi(y) \\le (1+\\varepsilon) \\cdot Cd/\\log y$ for all $\\varepsilon > 0$, which is the standard way to formalize $f \\sim g$ as $f/g \\to 1$ without division-by-zero issues.",
+      "**Bertrand's postulate as a weak baseline**: Bertrand's postulate guarantees a prime in $(n, 2n]$, an interval of length $n$. Erdős's conjecture asks for the expected prime count in intervals potentially as short as $C(\\log x)^2$ — exponentially shorter than what Bertrand provides.",
+      "**Cramér's probabilistic model**: Cramér modeled primes via independent random variables with $\\Pr[n \\text{ is prime}] = 1/\\log n$. Under this model, the maximal gap below $x$ is $(\\log x)^2$ with probability 1, and the short interval count obeys the PNT. Erdős's conjecture essentially asks whether the 'real' primes behave like Cramér's model at this fine scale."
     ]
   },
   "sections": [
     {
+      "id": "header-and-imports",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "Problem statement and Mathlib imports. The file imports `Nat.Prime.Basic` for primality, `Finset` for finite set operations used in the counting function, `Data.Real.Basic` for real-valued asymptotics, and `Order.Filter.AtTopBot` for the limit formulation."
+    },
+    {
       "id": "prime-counting-infrastructure",
       "title": "Prime Counting Infrastructure",
-      "summary": "",
       "startLine": 31,
-      "endLine": 40
+      "endLine": 40,
+      "summary": "Defines the prime counting function $\\pi(n) = |\\{p \\le n : p \\text{ prime}\\}|$ via `Finset.filter` on `Finset.range(n+1)`, and the interval counting function $\\pi(b) - \\pi(a)$ for counting primes in $(a, b]$."
     },
     {
       "id": "maximal-prime-gap",
-      "title": "Maximal Prime Gap",
-      "summary": "primeGapBelow",
+      "title": "Maximal Prime Gap Definitions",
       "startLine": 41,
-      "endLine": 52
+      "endLine": 52,
+      "summary": "Defines the set of consecutive prime gaps below $x$ as $\\{q - p : p, q \\text{ consecutive primes}, q \\le x\\}$ and the maximal gap $d(x) = \\sup$ of this set using `sSup`. The consecutiveness condition is encoded via the universal quantifier $\\forall r, \\text{Prime } r \\to p < r \\to q \\le r$."
     },
     {
       "id": "basic-properties",
-      "title": "Basic Properties",
-      "summary": "primeCounting_mono, primeCounting_zero, primeCounting_one, primeCounting_two, primeCounting_le, maxPrimeGap_le",
+      "title": "Basic Properties of $\\pi$",
       "startLine": 53,
-      "endLine": 89
+      "endLine": 89,
+      "summary": "Proves fundamental properties: monotonicity ($a \\le b \\Rightarrow \\pi(a) \\le \\pi(b)$) via `Finset.card_le_card`, exact values $\\pi(0) = 0$, $\\pi(1) = 0$, $\\pi(2) = 1$ by `decide`, the trivial bound $\\pi(n) \\le n + 1$ via `Finset.card_filter_le`, and $d(x) \\le x$ (with a sorry for the `BddAbove` argument)."
     },
     {
-      "id": "the-erd-s-conjecture",
-      "title": "The Erdős Conjecture",
-      "summary": "erdos_1138",
+      "id": "erdos-conjecture",
+      "title": "The Erdős Conjecture (Problem 1138)",
       "startLine": 90,
-      "endLine": 118
+      "endLine": 118,
+      "summary": "States the main conjecture: for $C > 1$ and $\\varepsilon > 0$, there exists $N$ such that for all $x \\ge N$ and $y \\in (x/2, x)$, the prime count $\\pi(y + \\lfloor Cd \\rfloor) - \\pi(y)$ lies within $(1 \\pm \\varepsilon) \\cdot Cd / \\log y$. Declared as an axiom since this is an open problem."
     },
     {
-      "id": "related-known-results",
+      "id": "related-results",
       "title": "Related Known Results",
-      "summary": "bertrand_postulate, cramer_conjecture",
       "startLine": 119,
-      "endLine": 135
+      "endLine": 135,
+      "summary": "States Bertrand's postulate (for $n \\ge 1$, there exists a prime in $(n, 2n]$) and Cramér's conjecture ($d(x) \\le (1+\\varepsilon)(\\log x)^2$ eventually) as axioms, providing context for the strength of Erdős's conjecture relative to known and conjectured bounds on prime gaps."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1138 (Primes in Short Intervals and Maximal Gaps) in Lean 4, including core definitions, key structural results, and the open conjecture stated as an axiom.",
-    "implications": "The formalization demonstrates how open problems in combinatorics and number theory can be rigorously expressed in Lean 4.",
+    "summary": "This formalization captures Erdős Problem #1138, which asks whether the prime number theorem holds at the scale of maximal prime gaps. The infrastructure — prime counting via `Finset.filter`, maximal gaps via `sSup`, and the $\\varepsilon$-formulation of asymptotic equivalence — provides a clean Lean 4 framework for this deep open problem in analytic number theory.",
+    "implications": "A positive resolution would imply that primes are remarkably well-distributed even at scales far below what current analytic methods can handle. It would confirm aspects of Cramér's probabilistic model of the primes and have consequences for understanding the fine structure of prime gaps. A negative resolution would reveal unexpected irregularities in prime distribution at the $(\\log x)^2$ scale.",
     "openQuestions": [
-      "Resolve the conjecture",
-      "Fill in sorry placeholders with complete proofs",
-      "Strengthen connections to other Erdős problems"
+      "Can the short interval prime number theorem be extended to intervals of length $(\\log x)^{2+\\varepsilon}$, bridging toward the conjectured $(\\log x)^2$ scale?",
+      "Does Maier's theorem (1985) — showing that $\\pi(x+h) - \\pi(x)$ deviates from $h/\\log x$ for certain $h$ around $(\\log x)^A$ — obstruct Erdős's conjecture, or does the maximal gap normalization avoid Maier's phenomenon?",
+      "Can the sorry in `maxPrimeGap_le` be resolved by establishing `BddAbove` for the set of prime gaps below $x$ and bounding the supremum?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "bertrands-postulate",
+      "relationship": "strengthens",
+      "description": "Bertrand's postulate guarantees a prime in $(n, 2n]$; Erdős #1138 asks for the full asymptotic in intervals potentially as short as $C(\\log x)^2$"
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "extends",
+      "description": "The PNT gives $\\pi(x) \\sim x/\\log x$ globally; this problem asks for the analogous short-interval asymptotic $\\pi(y+h) - \\pi(y) \\sim h/\\log y$ at the maximal gap scale"
+    },
+    {
+      "targetId": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "Even assuming RH, short-interval PNT requires $h > x^{1/2+\\varepsilon}$, far larger than the conjectured $(\\log x)^2$ maximal gap. Resolving Erdős #1138 would require methods beyond RH."
+    },
+    {
+      "targetId": "prime-reciprocal-divergence",
+      "relationship": "foundational",
+      "description": "The divergence of $\\sum 1/p$ quantifies the density of primes; prime gap questions probe the complementary question of how irregularly primes are spaced"
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The infinitude of primes is the most basic prerequisite; Erdős #1138 asks about the fine quantitative distribution of these infinitely many primes"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for erdos-1138 (Primes in Short Intervals and Maximal Gaps).

- Added `mathContext` with LaTeX formulas to all 13 annotations
- Added `relatedConcepts` and `prerequisites` to every annotation
- Fixed invalid `axiom` annotation types to `theorem`
- Deepened `historicalContext` with Hadamard, de la Vallée Poussin (1896), Huxley (1972), Cramér (1936), Baker–Harman–Pintz (2001)
- Replaced 5 definition-restating `keyInsights` with substantive mathematical insights about the gap between conjecture and provability, uniformity requirements, and Cramér's probabilistic model
- Added LaTeX to all section summaries
- Expanded `conclusion` with Maier's theorem connection and specific open questions
- Added 5 cross-references: `bertrands-postulate`, `prime-number-theorem`, `riemann-hypothesis`, `prime-reciprocal-divergence`, `infinitude-primes`

## Test plan

- [x] `pnpm annotations:build` passes with no erdos-1138 warnings
- [ ] Visual review of gallery entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)