### PR TITLE
research: complete erdos-1054 problem tracking

### DIFF
--- a/src/data/research/problems/erdos-1054.json
+++ b/src/data/research/problems/erdos-1054.json
@@ -1,0 +1,110 @@
+{
+  "slug": "erdos-1054",
+  "title": "Sum of Smallest Divisors: Non-Representability and Growth Bounds",
+  "phase": "COMPLETE",
+  "status": "complete",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Let f(n) = min{m : n = sum of k smallest divisors of m for some k}. Is f(n) = o(n)? Is this true for almost all n? Is limsup f(n)/n = infinity?",
+    "plain": "For any positive integer n, find the smallest m whose partial divisor sum (sum of its k smallest divisors for some k) equals n. Erdos asked whether f(n) grows slower than n, whether this holds for almost all n, and whether f(n)/n can be arbitrarily large.",
+    "whyMatters": [
+      "Connects divisor structure to density questions in number theory",
+      "Tao disproved the strong conjecture f(n) = o(n), but the almost-all version remains open",
+      "Links to Goldbach's conjecture: if n-1 = q+p for primes q < p, then n is representable via m=qp",
+      "Only two values (2 and 5) appear non-representable, suggesting deep arithmetic structure"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Non-representability classification: among {0,...,199}, exactly 0, 2, 5 are non-representable (OQ-01)",
+      "All n in {1,...,199} \\ {0,2,5} have explicit representability witnesses (OQ-01)",
+      "Prime structure: divisors(p) = {1,p}, so p+1 is representable with f(p+1) <= p (OQ-01)",
+      "Sigma bound: f(sigma(m)) <= m for all m >= 1 (OQ-01)",
+      "sigma(m) representable for all m >= 1 (OQ-01)",
+      "1 is always in partialDivisorSums(m) for m >= 1 (OQ-01)",
+      "Divisor classification for prime products: divisors(qp) = {1,q,p,qp} for distinct primes q < p (OQ-02)",
+      "Goldbach connection: if n-1 = q+p for primes q < p, then n is representable with witness qp (OQ-02)",
+      "Complete witness table for n in [6,20] using prime-product structure (OQ-02)",
+      "f-bounds via Goldbach witnesses for small n (OQ-02)",
+      "Computational f(n) values verified for small n (OQ-01)",
+      "f(n) <= 2n for all representable n <= 20 (OQ-01)",
+      "Sigma values for abundant numbers verified (OQ-01)",
+      "Last partial sum equals sigma(m) (OQ-01)",
+      "Partial sums length equals tau(m) (OQ-01)"
+    ],
+    "open": [
+      "Is f(n) = o(n) for almost all n? (Part II)",
+      "Is limsup f(n)/n = infinity? (Part III)",
+      "Are 0, 2, 5 the ONLY non-representable values?",
+      "Full Goldbach implies all odd n >= 7 representable"
+    ],
+    "goal": "COMPLETE - formalization covers structural bounds, non-representability classification, Goldbach connection, and Tao's result. Open questions documented as axioms."
+  },
+  "currentState": {
+    "phase": "COMPLETE",
+    "since": "2026-02-13T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Three Lean files cover the problem comprehensively: base formalization, OQ-01 (classification + bounds), OQ-02 (Goldbach connection + prime products). All files have 0 sorries.",
+    "blockers": [],
+    "nextAction": "No further work needed. Open questions are genuinely open mathematical problems.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: Three Lean files with zero sorries covering Erdos 1054 comprehensively. OQ-01 proves non-representability classification to n=200 (only 0,2,5 are non-representable), prime structure (p+1 representable), sigma bound (f(sigma(m))<=m), computational f-values, and growth bounds. OQ-02 proves the Goldbach connection (n-1=q+p implies n representable via m=qp), divisor classification for prime products, and extended witness tables. Two axioms encode Tao's published result that f(n)=o(n) is false.",
+    "builtItems": [
+      "proofs/Proofs/Erdos1054Problem.lean - base formalization with axiomatized f(n)",
+      "proofs/Proofs/Erdos1054OQ01.lean - non-representability classification to n=200, sigma bound, prime structure",
+      "proofs/Proofs/Erdos1054OQ02.lean - Goldbach connection, prime product divisor classification, witness tables",
+      "proofs/Proofs/Erdos1054OQ01Extensions.lean - additional extensions",
+      "proofs/Proofs/Erdos1054ConstructionD.lean - construction details",
+      "non_representable_classification_200: computational classification via native_decide",
+      "all_representable_to_200: extracted existential witnesses for all representable n <= 199",
+      "f_sigma_bound: key bound f(sigma(m)) <= m",
+      "divisors_prime_product: {1,q,p,qp} characterization",
+      "goldbach_implies_representable: Goldbach → representability reduction"
+    ],
+    "insights": [
+      "Only 0, 2, 5 appear non-representable up to n=200 - strong computational evidence for conjecture",
+      "2 non-representable because 1 < 2 < 3 = 1+2 (gap between partial sums)",
+      "5 non-representable because 1+4=5 requires 4|m, but then 2|m gives 2 < 4 as smaller divisor",
+      "Goldbach connection: representability reduces to expressing n-1 as sum of two primes for odd n",
+      "For small prime in Goldbach pair (q=2): f(n) <= 2(n-3) ≈ 2n (bounded ratio)",
+      "For equal-sized primes (q ≈ p ≈ n/2): f(n) ≈ n^2/4 (unbounded ratio, consistent with Tao)",
+      "Sigma bound gives f(n)=o(n) along superabundant subsequence",
+      "Prime density gives f(n) < n on a positive-density set"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "approaches": [
+    {
+      "name": "Computational classification + structural bounds",
+      "status": "complete",
+      "description": "OQ-01: Use native_decide for non-representability classification to n=200, prove sigma bound and prime structure theorems. OQ-02: Classify divisors of prime products, establish Goldbach connection with computational verification."
+    }
+  ],
+  "tags": ["seeker-selected", "number-theory", "divisors", "erdos", "open-problem", "complete"],
+  "relatedProofs": ["erdos-1054"],
+  "leanFile": "Erdos1054OQ01.lean",
+  "references": {
+    "papers": [
+      "Erdos: Problem B2 in Guy's 'Unsolved Problems in Number Theory' (2004)",
+      "Tao: Disproof of f(n) = o(n) unconditionally (density bound O(delta^2))"
+    ],
+    "urls": ["https://erdosproblems.com/1054"],
+    "mathlib": [
+      "Mathlib.NumberTheory.Divisors",
+      "Mathlib.Data.Finset.Sort",
+      "Mathlib.Data.Nat.Prime.Basic"
+    ]
+  },
+  "started": "2026-02-13T00:00:00.000Z",
+  "lastUpdate": "2026-02-13T00:00:00.000Z",
+  "significance": 8,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary
- Add problem JSON documenting Erdos 1054 (Sum of Smallest Divisors) research status
- Three Lean files already on main with **zero sorries**

## Progress
- **Erdos1054Problem.lean**: Base formalization with axiomatized f(n), open question statements
- **Erdos1054OQ01.lean**: Non-representability classification to n=200 (only 0,2,5), sigma bound f(sigma(m))<=m, prime structure, computational f-values
- **Erdos1054OQ02.lean**: Goldbach connection, prime product divisor classification, witness tables for n in [6,20]
- 2 axioms encode Tao's published disproof of f(n)=o(n)

## Key Results
- `non_representable_classification_200`: only 0, 2, 5 non-representable in {0,...,199}
- `f_sigma_bound`: f(sigma(m)) <= m
- `divisors_prime_product`: divisors(qp) = {1,q,p,qp} for distinct primes
- `goldbach_implies_representable`: Goldbach-type reduction for representability

## Status
**Outcome**: completed (formalization comprehensive; open questions are genuinely open)

Generated by researcher-1