### PR TITLE
enrich: deepen poincare-conjecture with mathContext, cross-refs, and historical context

### DIFF
--- a/src/data/proofs/poincare-conjecture/annotations.json
+++ b/src/data/proofs/poincare-conjecture/annotations.json
@@ -1,194 +1,278 @@
 [
   {
+    "id": "ann-pc-imports",
+    "proofId": "poincare-conjecture",
+    "range": { "startLine": 1, "endLine": 15 },
+    "type": "concept",
+    "title": "Imports and Dependencies",
+    "content": "The formalization draws on Mathlib's topology, homotopy theory, and algebraic topology infrastructure. Key imports include `FundamentalGroupoid.FundamentalGroup` for $\\pi_1(X, x)$ and `SimplyConnected` for the triviality condition. The `PiL2` import provides EuclideanSpace for defining spheres.",
+    "mathContext": "Mathlib's FundamentalGroup X x is defined as the automorphism group Aut(x) in the fundamental groupoid of X. SimplyConnectedSpace X means the fundamental groupoid is equivalent to Discrete Unit. These are the standard algebraic-topological definitions.",
+    "significance": "supporting",
+    "relatedConcepts": ["fundamental groupoid", "algebraic topology", "Mathlib infrastructure"],
+    "prerequisites": []
+  },
+  {
     "id": "ann-sphere3",
     "proofId": "poincare-conjecture",
-    "range": {
-      "startLine": 94,
-      "endLine": 125
-    },
+    "range": { "startLine": 110, "endLine": 145 },
     "type": "definition",
-    "title": "The 3-Sphere S³",
-    "content": "The 3-sphere S³ is defined as the unit sphere in ℝ⁴: all points at distance 1 from the origin. This is the higher-dimensional analogue of the familiar 2-sphere (the surface of a ball). In the Poincaré Conjecture, S³ plays the role of the 'simplest' 3-manifold.",
-    "mathContext": "S³ = {x ∈ ℝ⁴ : ||x|| = 1} = Metric.sphere 0 1 in EuclideanSpace ℝ (Fin 4). Properties: compact (closed and bounded), connected (path-connected in dimension > 1), and nonempty (contains (1,0,0,0)).",
+    "title": "The 3-Sphere $S^3$",
+    "content": "The 3-sphere $S^3$ is defined as the unit sphere in $\\mathbb{R}^4$: all points at distance 1 from the origin. Properties proved constructively: nonempty (contains $(1,0,0,0)$), compact (closed and bounded in $\\mathbb{R}^4$), connected and path-connected (via Mathlib's `isConnected_sphere` requiring $\\dim > 1$).",
+    "mathContext": "$S^3 = \\{x \\in \\mathbb{R}^4 : \\|x\\| = 1\\} = \\text{Metric.sphere } 0 \\; 1$ in EuclideanSpace $\\mathbb{R}$ (Fin 4). The proof that $S^3$ is connected uses Module.rank $\\mathbb{R}$ $(\\mathbb{R}^4) > 1$, which follows from finrank = 4. Path-connectedness follows from `isPathConnected_sphere`. These are genuine Lean proofs, not axioms.",
     "significance": "critical",
-    "relatedConcepts": [
-      "unit sphere",
-      "Euclidean space",
-      "compactness"
-    ]
+    "relatedConcepts": ["unit sphere", "Euclidean space", "compactness", "path-connectedness"],
+    "prerequisites": ["ann-pc-imports"]
   },
   {
     "id": "ann-simply-connected",
     "proofId": "poincare-conjecture",
-    "range": {
-      "startLine": 127,
-      "endLine": 157
-    },
+    "range": { "startLine": 147, "endLine": 167 },
     "type": "definition",
-    "title": "Simply Connected Spaces",
-    "content": "A space is simply connected if it is path-connected and every loop can be continuously shrunk to a point. Formally, the fundamental group π₁(X) is trivial. This captures the intuition that the space has 'no holes' through which a loop could be threaded.",
-    "mathContext": "Simply connected ⟺ path-connected AND ∀ loops γ, γ is homotopic to the constant loop. The fundamental group π₁(X, x) at basepoint x captures equivalence classes of loops under homotopy.",
+    "title": "Simply Connected Spaces and Fundamental Group",
+    "content": "A space is simply connected if it is path-connected and every loop can be continuously shrunk to a point. The formalization uses Mathlib's `SimplyConnectedSpace`, which says the fundamental groupoid is equivalent to `Discrete Unit`. Two key results are **proved**: `loops_nullhomotopic_of_simply_connected` extracts loop contractibility, and `pathConnected_of_simply_connected` shows path-connectedness follows.",
+    "mathContext": "SimplyConnectedSpace X $\\iff$ path-connected $\\wedge$ $\\forall x, \\forall \\gamma : \\text{Path } x \\; x, \\; \\gamma \\simeq \\text{refl}_x$. Equivalently, $\\pi_1(X, x)$ is trivial for all $x$. The bridge theorem `simply_connected_iff_loops_nullhomotopic` connects Mathlib's categorical definition to the classical loop-contractibility formulation.",
     "significance": "critical",
-    "relatedConcepts": [
-      "fundamental group",
-      "homotopy",
-      "path-connectedness"
-    ]
+    "relatedConcepts": ["fundamental group", "homotopy", "path-connectedness", "loop space"],
+    "prerequisites": ["ann-pc-imports"]
   },
   {
     "id": "ann-closed-manifold",
     "proofId": "poincare-conjecture",
-    "range": {
-      "startLine": 159,
-      "endLine": 182
-    },
+    "range": { "startLine": 169, "endLine": 182 },
     "type": "definition",
-    "title": "Closed 3-Manifolds",
-    "content": "A closed 3-manifold is a compact, connected topological space without boundary where every point has a neighborhood homeomorphic to ℝ³. 'Closed' in topology means compact without boundary (like a sphere), not 'closed set'.",
-    "mathContext": "The structure ClosedManifold encodes: (1) CompactSpace M - finite extent, (2) ConnectedSpace M - one piece, (3) Nonempty M - has points, (4) locally Euclidean - looks like ℝ³ near each point.",
+    "title": "Closed $n$-Manifolds",
+    "content": "A closed $n$-manifold is a compact, connected, nonempty topological space where every point has a neighborhood homeomorphic to $\\mathbb{R}^n$. 'Closed' means compact without boundary (not the point-set topology meaning). The abbreviation `Closed3Manifold` specializes to $n = 3$.",
+    "mathContext": "The structure `ClosedManifold n M` requires: (1) `CompactSpace M`, (2) `ConnectedSpace M`, (3) `Nonempty M`, (4) $\\forall x : M, \\exists U$ open with $x \\in U$ and $U \\cong_t \\mathbb{R}^n$. The locally Euclidean condition is the key manifold property, distinguishing manifolds from more general topological spaces.",
     "significance": "key",
-    "relatedConcepts": [
-      "topological manifold",
-      "compactness",
-      "local Euclidean structure"
-    ]
+    "relatedConcepts": ["topological manifold", "compactness", "locally Euclidean", "dimension"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-homeomorphism",
+    "proofId": "poincare-conjecture",
+    "range": { "startLine": 184, "endLine": 201 },
+    "type": "definition",
+    "title": "Homeomorphism as Equivalence Relation",
+    "content": "The predicate `AreHomeomorphic X Y` asserts the existence of a homeomorphism $X \\cong_t Y$. Three properties are **proved**: reflexivity (identity map), symmetry (inverse homeomorphism), and transitivity (composition). This establishes homeomorphism as an equivalence relation on topological spaces.",
+    "mathContext": "`AreHomeomorphic X Y := Nonempty (X ≃ₜ Y)` wraps Mathlib's `Homeomorph` in a propositional existence. The proofs use `Homeomorph.refl`, `.symm`, and `.trans`. This is a standard wrapper that simplifies stating the Poincaré Conjecture as a proposition rather than constructing explicit homeomorphisms.",
+    "significance": "key",
+    "relatedConcepts": ["topological equivalence", "continuous bijection", "equivalence relation"],
+    "prerequisites": []
   },
   {
     "id": "ann-poincare-statement",
     "proofId": "poincare-conjecture",
-    "range": {
-      "startLine": 208,
-      "endLine": 233
-    },
+    "range": { "startLine": 203, "endLine": 212 },
     "type": "theorem",
-    "title": "The Poincaré Conjecture Statement",
-    "content": "Every simply connected, closed 3-manifold is homeomorphic to S³. In other words: if a 3-dimensional 'universe' is finite (closed), in one piece (connected), and has no holes (simply connected), then it must be a 3-sphere.",
-    "mathContext": "Formally: ∀ M, (Closed3Manifold M) → (SimplyConnected M) → (M ≅ₜ S³). This was the most famous open problem in topology for 99 years until Perelman's proof.",
+    "title": "The Poincaré Conjecture (Formal Statement)",
+    "content": "The conjecture is stated as: for every type $M$ with a topology, if $M$ is a closed 3-manifold and $M$ is simply connected, then $M$ is homeomorphic to $S^3$. This is the canonical formulation Poincaré posed in 1904: simple connectivity characterizes the 3-sphere among closed 3-manifolds.",
+    "mathContext": "`PoincareConjectureStatement := ∀ (M : Type) [TopologicalSpace M], Closed3Manifold M → SimplyConnectedSpace M → AreHomeomorphic M Sphere3`. Poincaré originally asked whether homology alone suffices (it doesn't — the Poincaré homology sphere has $H_*(M) \\cong H_*(S^3)$ but $\\pi_1(M) \\neq 1$). He then refined to homotopy: $\\pi_1(M) = 1 \\implies M \\cong S^3$.",
     "significance": "critical",
-    "prerequisites": [
-      "ann-sphere3",
-      "ann-simply-connected",
-      "ann-closed-manifold"
-    ],
-    "relatedConcepts": [
-      "characterization theorem",
-      "topological classification"
-    ]
+    "relatedConcepts": ["Millennium Prize", "topological classification", "Poincaré homology sphere"],
+    "prerequisites": ["ann-sphere3", "ann-simply-connected", "ann-closed-manifold", "ann-homeomorphism"]
   },
   {
     "id": "ann-ricci-flow",
     "proofId": "poincare-conjecture",
-    "range": {
-      "startLine": 235,
-      "endLine": 280
-    },
+    "range": { "startLine": 214, "endLine": 233 },
     "type": "concept",
-    "title": "Hamilton's Ricci Flow",
-    "content": "Ricci flow is a geometric PDE that evolves a Riemannian metric: ∂g/∂t = -2 Ric(g). Introduced by Richard Hamilton in 1982, it acts like a heat equation for geometry, smoothing out irregularities in curvature over time.",
-    "mathContext": "The Ricci curvature tensor Ric(g) measures how the metric deviates from flat space. Under Ricci flow, positively curved regions shrink while negatively curved regions expand. For S³, the flow shrinks uniformly to a point.",
+    "title": "Ricci Flow and Perelman's Approach",
+    "content": "Ricci flow is the geometric PDE $\\partial g / \\partial t = -2 \\operatorname{Ric}(g)$ introduced by Hamilton (1982). It evolves a Riemannian metric like a heat equation for geometry. The file axiomatizes `RicciCurvature`, `RiemannianMetric`, and the flow operator. Perelman's key innovations—surgery and finite extinction—are stated as axioms.",
+    "mathContext": "The Ricci flow $\\partial g_{ij}/\\partial t = -2 R_{ij}$ shrinks positively curved regions and expands negatively curved ones. Hamilton (1982) proved that on a closed 3-manifold with positive Ricci curvature, the flow converges to a round metric (constant curvature $+1$), yielding $M \\cong S^3$. Perelman extended this to all simply connected closed 3-manifolds via surgery.",
     "significance": "key",
-    "relatedConcepts": [
-      "Riemannian geometry",
-      "heat equation",
-      "geometric evolution"
-    ]
+    "relatedConcepts": ["Riemannian geometry", "heat equation", "geometric evolution", "Hamilton's theorem"],
+    "prerequisites": ["ann-poincare-statement"]
   },
   {
     "id": "ann-perelman-surgery",
     "proofId": "poincare-conjecture",
-    "range": {
-      "startLine": 282,
-      "endLine": 323
-    },
+    "range": { "startLine": 227, "endLine": 233 },
     "type": "theorem",
-    "title": "Perelman's Surgery Theorem (Axiom)",
-    "content": "Perelman's key innovation: when Ricci flow develops singularities, perform 'surgery' by cutting out the bad regions and capping them off with standard pieces. This allows the flow to continue past singularities.",
-    "mathContext": "The axiom captures: given any metric g on a closed 3-manifold M, surgery produces a new manifold M' that is still closed, and if M was simply connected, M' remains simply connected. This preserves the topological property we care about.",
+    "title": "Perelman's Surgery and Finite Extinction",
+    "content": "Two critical axioms encode Perelman's proof: (1) **Surgery**: given any metric on a closed 3-manifold, surgery produces a new closed 3-manifold preserving simple connectivity. (2) **Finite extinction**: a simply connected closed 3-manifold becomes extinct under Ricci flow with surgery in finite time, yielding homeomorphism to $S^3$.",
+    "mathContext": "Perelman's surgery procedure (arXiv:math/0303109) cuts out $\\varepsilon$-horns near singularities and caps them with standard $S^2 \\times [0,\\infty)$ pieces. The finite extinction theorem (arXiv:math/0307245, also Colding-Minicozzi 2005) shows that $\\pi_1(M) = 1$ forces the width $W(g(t))$ to become zero in finite time, so the manifold disappears—leaving only $S^3$ pieces.",
     "significance": "critical",
-    "prerequisites": [
-      "ann-ricci-flow"
-    ],
-    "relatedConcepts": [
-      "surgery theory",
-      "singularity analysis",
-      "geometric topology"
-    ]
+    "relatedConcepts": ["surgery theory", "singularity analysis", "epsilon-horns", "W-functional"],
+    "prerequisites": ["ann-ricci-flow"]
   },
   {
-    "id": "ann-finite-extinction",
+    "id": "ann-thurston",
     "proofId": "poincare-conjecture",
-    "range": {
-      "startLine": 301,
-      "endLine": 311
-    },
-    "type": "theorem",
-    "title": "Finite Extinction Time (Axiom)",
-    "content": "For a simply connected, closed 3-manifold, Ricci flow with surgery causes the manifold to 'go extinct' in finite time - it either shrinks to a point or becomes a round 3-sphere. This is the heart of Perelman's proof.",
-    "mathContext": "The key insight: simply connected manifolds cannot contain incompressible tori or other obstructions that would prevent collapse. The fundamental group triviality forces eventual spherical geometry.",
-    "significance": "critical",
-    "prerequisites": [
-      "ann-perelman-surgery"
-    ],
-    "relatedConcepts": [
-      "extinction time",
-      "spherical collapse"
-    ]
+    "range": { "startLine": 235, "endLine": 252 },
+    "type": "definition",
+    "title": "Thurston's Eight Model Geometries",
+    "content": "Thurston's Geometrization Conjecture (proved by Perelman) states every closed 3-manifold decomposes into pieces each carrying one of exactly 8 model geometries: $S^3$, $\\mathbb{E}^3$, $\\mathbb{H}^3$, $S^2 \\times \\mathbb{R}$, $\\mathbb{H}^2 \\times \\mathbb{R}$, $\\widetilde{\\text{SL}_2(\\mathbb{R})}$, Nil, Sol. The count $= 8$ is **proved** via `native_decide`.",
+    "mathContext": "The `ThurstonGeometry` inductive type enumerates all 8 geometries. Each geometry $G$ is a simply connected homogeneous Riemannian manifold with $\\text{Isom}(G)$ acting transitively. A 3-manifold $M$ is 'geometric' if $M \\cong G/\\Gamma$ for a discrete $\\Gamma \\leq \\text{Isom}(G)$. Thurston classified these in 1982; Perelman proved every closed 3-manifold admits such a decomposition.",
+    "significance": "key",
+    "relatedConcepts": ["geometric structures", "model geometries", "Thurston classification", "homogeneous spaces"],
+    "prerequisites": ["ann-ricci-flow"]
+  },
+  {
+    "id": "ann-w-entropy",
+    "proofId": "poincare-conjecture",
+    "range": { "startLine": 254, "endLine": 266 },
+    "type": "concept",
+    "title": "Perelman's $W$-Entropy and Hamilton's Theorem",
+    "content": "Perelman's $W$-entropy functional is **monotone** along Ricci flow, providing a Lyapunov function that controls the flow's behavior. Hamilton's earlier theorem (1982) handles the special case: simply connected $+$ positive Ricci curvature $\\implies S^3$. Both are axiomatized since they require deep PDE analysis.",
+    "mathContext": "Perelman's $\\mathcal{W}(g, f, \\tau) = \\int_M [\\tau(|\\nabla f|^2 + R) + f - n](4\\pi\\tau)^{-n/2} e^{-f} dV$ is monotone under coupled Ricci flow. This is the 'no local collapsing' ingredient. Hamilton's 1982 paper 'Three-manifolds with positive Ricci curvature' (J. Differential Geometry 17) proved the first convergence result for Ricci flow.",
+    "significance": "key",
+    "relatedConcepts": ["entropy functional", "Lyapunov function", "no local collapsing", "positive Ricci curvature"],
+    "prerequisites": ["ann-ricci-flow"]
   },
   {
     "id": "ann-main-theorem",
     "proofId": "poincare-conjecture",
-    "range": {
-      "startLine": 325,
-      "endLine": 340
-    },
+    "range": { "startLine": 268, "endLine": 277 },
     "type": "theorem",
-    "title": "Poincaré Conjecture (Theorem)",
-    "content": "Every simply connected, closed 3-manifold is homeomorphic to S³. The proof follows directly from the finite extinction axiom: apply Ricci flow with surgery until the manifold becomes extinct, which leaves us with S³.",
-    "mathContext": "The proof structure: given M satisfying the hypotheses, Perelman's finite extinction theorem directly yields the homeomorphism M ≅ S³. The hard work is encapsulated in the axioms.",
+    "title": "The Poincaré Conjecture (Main Theorem)",
+    "content": "**`poincare_conjecture_holds`**: the Poincaré Conjecture is derived from the axioms. Given a simply connected closed 3-manifold $M$, `perelman_finite_extinction` yields $T > 0$ and a homeomorphism $M \\cong S^3$. The proof is a one-line extraction from the existential statement.",
+    "mathContext": "The formal proof: `intro M _ hM hsc; obtain ⟨_, _, h⟩ := perelman_finite_extinction M hM hsc; exact h`. This is deliberately simple—the mathematical content is in the axioms. The proof structure mirrors the mathematical argument: Perelman's theorem directly implies the conjecture.",
     "significance": "critical",
-    "prerequisites": [
-      "ann-poincare-statement",
-      "ann-finite-extinction"
-    ],
-    "relatedConcepts": [
-      "Millennium Prize",
-      "topological classification"
-    ]
+    "relatedConcepts": ["Millennium Prize", "axiom-derived proof", "Perelman's theorem"],
+    "prerequisites": ["ann-poincare-statement", "ann-perelman-surgery"]
   },
   {
-    "id": "ann-other-dimensions",
+    "id": "ann-generalized-dims",
     "proofId": "poincare-conjecture",
-    "range": {
-      "startLine": 342,
-      "endLine": 382
-    },
-    "type": "concept",
-    "title": "Poincaré Conjecture in Other Dimensions",
-    "content": "The generalized Poincaré Conjecture (is every simply connected, closed n-manifold homeomorphic to Sⁿ?) has different proofs for different dimensions: n=2 (classical), n=3 (Perelman 2003), n=4 (Freedman 1982, topological), n≥5 (Smale 1961).",
-    "mathContext": "The difficulty varies dramatically by dimension. n=3 was hardest because geometric techniques (Ricci flow) were needed. Higher dimensions admit h-cobordism arguments. The smooth version in dimension 4 remains open!",
+    "range": { "startLine": 279, "endLine": 296 },
+    "type": "theorem",
+    "title": "Generalized Poincaré in Other Dimensions",
+    "content": "The generalized Poincaré Conjecture is axiomatized per dimension: $n \\geq 5$ (Smale 1961, h-cobordism), $n = 4$ (Freedman 1982, topological), $n = 2$ (classical uniformization). Each returns a homeomorphism to the $n$-sphere. Dimension 3 was the last to be resolved.",
+    "mathContext": "Smale's proof for $n \\geq 5$ uses the h-cobordism theorem and Whitney trick. Freedman's proof for $n = 4$ uses Casson handles and is highly non-constructive. The smooth 4-dimensional Poincaré conjecture remains **open** — it is unknown whether every exotic $S^4$ is diffeomorphic to the standard one. This dimensional sensitivity is captured by the separate axiom statements.",
+    "significance": "key",
+    "relatedConcepts": ["h-cobordism theorem", "Freedman's theorem", "Smale's theorem", "exotic spheres"],
+    "prerequisites": ["ann-poincare-statement"]
+  },
+  {
+    "id": "ann-consequences",
+    "proofId": "poincare-conjecture",
+    "range": { "startLine": 298, "endLine": 343 },
+    "type": "theorem",
+    "title": "Consequences and Alternative Formulations",
+    "content": "Several corollaries are **proved**: (1) `trivial_pi1_implies_sphere` — direct application. (2) `poincare_of_trivial_pi1` — if $\\pi_1(M, x)$ is trivial at every point, then $M \\cong S^3$, bridging Mathlib's `FundamentalGroup` with the conjecture. (3) `not_sphere_has_nontrivial_pi1` — contrapositive. (4) `poincare_dichotomy` — every closed 3-manifold is either $S^3$ or has nontrivial $\\pi_1$.",
+    "mathContext": "The `poincare_of_trivial_pi1` proof is notable: it constructs `SimplyConnectedSpace M` from the hypothesis that `FundamentalGroup M x` is `Subsingleton` at every point, using `Quotient.exact` and `Subsingleton.elim` on the homotopy quotient. This bridges Mathlib's algebraic topology API with the geometric statement.",
+    "significance": "critical",
+    "relatedConcepts": ["fundamental group", "contrapositive", "classification dichotomy", "FundamentalGroup bridge"],
+    "prerequisites": ["ann-main-theorem", "ann-simply-connected"]
+  },
+  {
+    "id": "ann-sphere-properties",
+    "proofId": "poincare-conjecture",
+    "range": { "startLine": 351, "endLine": 376 },
+    "type": "theorem",
+    "title": "Generalized $n$-Sphere Properties",
+    "content": "Four properties of the $n$-sphere $S^n \\subset \\mathbb{R}^{n+1}$ are **proved** for all $n$: connectedness and path-connectedness (for $n \\geq 1$, using rank $> 1$), nonemptiness (contains $(1, 0, \\ldots, 0)$), and compactness. These feed into the generalized Poincaré statement.",
+    "mathContext": "The proof of `sphere_n_connected` uses `isConnected_sphere` which requires `1 < Module.rank ℝ (EuclideanSpace ℝ (Fin (n+1)))`. This is established via `finrank_euclideanSpace_fin` giving finrank $= n + 1 \\geq 2$. The `SphereN n` definition $:= \\text{Metric.sphere } 0 \\; 1$ in $\\mathbb{R}^{n+1}$ provides a uniform notation.",
+    "significance": "key",
+    "relatedConcepts": ["n-sphere", "module rank", "Mathlib sphere API", "uniform construction"],
+    "prerequisites": ["ann-sphere3"]
+  },
+  {
+    "id": "ann-poincare-all-dims",
+    "proofId": "poincare-conjecture",
+    "range": { "startLine": 378, "endLine": 417 },
+    "type": "theorem",
+    "title": "Poincaré Conjecture for All Dimensions $\\geq 2$",
+    "content": "**`poincare_all_dimensions`** is **proved** by case analysis: if $n \\geq 5$, use Smale's theorem; otherwise `interval_cases n` dispatches $n = 2$ (uniformization), $n = 3$ (Perelman), $n = 4$ (Freedman). This unifies all known results into a single theorem: `GeneralizedPoincareStatement n` holds for all $n \\geq 2$.",
+    "mathContext": "The proof structure mirrors the historical arc: Smale (1961) for $n \\geq 5$, Freedman (1982) for $n = 4$, Perelman (2003) for $n = 3$, classical for $n = 2$. The `interval_cases` tactic enumerates $n \\in \\{2, 3, 4\\}$ when $2 \\leq n$ and $n < 5$. Each case is a one-line application of the corresponding theorem.",
+    "significance": "critical",
+    "relatedConcepts": ["interval_cases tactic", "case analysis", "dimension unification"],
+    "prerequisites": ["ann-generalized-dims", "ann-main-theorem"]
+  },
+  {
+    "id": "ann-fundamental-group-char",
+    "proofId": "poincare-conjecture",
+    "range": { "startLine": 432, "endLine": 442 },
+    "type": "theorem",
+    "title": "Fundamental Group Triviality",
+    "content": "**`fundamental_group_trivial_of_sc`** is **proved**: for a simply connected space $X$, the fundamental group $\\pi_1(X, x)$ is a subsingleton (trivial) at every point. The proof uses `simply_connected_iff_paths_homotopic` which gives `Subsingleton` on all path homotopy quotients.",
+    "mathContext": "In Mathlib, `FundamentalGroup X x` is `CategoryTheory.Aut x` in the fundamental groupoid. `SimplyConnectedSpace` implies all path quotients are singletons via `simply_connected_iff_paths_homotopic`. Specializing the endpoints to $x_0 = x_1 = x$ gives triviality of the loop space quotient, i.e., $\\pi_1(X, x) \\cong 1$.",
+    "significance": "key",
+    "relatedConcepts": ["fundamental group", "subsingleton", "path homotopy quotient", "algebraic topology bridge"],
+    "prerequisites": ["ann-simply-connected"]
+  },
+  {
+    "id": "ann-sphere-retraction",
+    "proofId": "poincare-conjecture",
+    "range": { "startLine": 444, "endLine": 466 },
+    "type": "theorem",
+    "title": "Normalization Retraction onto the Sphere",
+    "content": "Two results about the normalization map $x \\mapsto x/\\|x\\|$ are **proved**: (1) `normalize_mem_sphere` — nonzero vectors are sent to the unit sphere, and (2) `normalize_on_sphere` — vectors already on the sphere are fixed. This map is a retraction from $\\mathbb{R}^n \\setminus \\{0\\}$ onto $S^{n-1}$.",
+    "mathContext": "The proof of `normalize_mem_sphere` uses $\\|\\|x\\|^{-1} \\cdot x\\| = \\|x\\|^{-1} \\cdot \\|x\\| = 1$ via `norm_smul`, `norm_inv`, `norm_norm`, and `inv_mul_cancel₀`. For `normalize_on_sphere`, if $\\|x\\| = 1$ then $\\|x\\|^{-1} = 1$ so $1 \\cdot x = x$. These are foundational for constructing deformation retractions in algebraic topology.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "generalized Poincaré conjecture",
-      "h-cobordism",
-      "smooth vs topological"
-    ]
+    "relatedConcepts": ["retraction", "deformation retract", "normalization", "homotopy type"],
+    "prerequisites": ["ann-sphere3"]
+  },
+  {
+    "id": "ann-s3-instances",
+    "proofId": "poincare-conjecture",
+    "range": { "startLine": 468, "endLine": 512 },
+    "type": "definition",
+    "title": "$S^3$ Type Class Instances and Simple Connectivity",
+    "content": "Subset properties of $S^3 \\subset \\mathbb{R}^4$ are lifted to type class instances on $\\uparrow S^3$: `CompactSpace`, `ConnectedSpace`, `Nonempty`. The locally Euclidean property (via stereographic projection) and simple connectivity ($\\pi_1(S^3) = 1$, via Seifert–van Kampen) are axiomatized since they require tools beyond current Mathlib.",
+    "mathContext": "The instance `sphere3_compact_inst` uses `isCompact_iff_compactSpace.mp sphere3_compact` to lift `IsCompact Sphere3` to `CompactSpace (↥Sphere3)`. Simple connectivity of $S^n$ for $n \\geq 2$ follows from Seifert–van Kampen: decompose into overlapping hemispheres $D^n_+, D^n_-$ with $D^n_+ \\cap D^n_- \\simeq S^{n-1} \\times (-\\varepsilon, \\varepsilon)$, connected for $n \\geq 2$, giving $\\pi_1(S^n) = \\pi_1(D^n) *_{\\pi_1(\\text{overlap})} \\pi_1(D^n) = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["type class lifting", "Seifert-van Kampen theorem", "stereographic projection", "hemisphere decomposition"],
+    "prerequisites": ["ann-sphere3", "ann-simply-connected"]
+  },
+  {
+    "id": "ann-classification",
+    "proofId": "poincare-conjecture",
+    "range": { "startLine": 522, "endLine": 545 },
+    "type": "theorem",
+    "title": "3-Manifold Classification via Simple Connectivity",
+    "content": "**`closed_3_manifold_classification`** is **proved**: a closed 3-manifold is simply connected $\\iff$ it is homeomorphic to $S^3$. The forward direction is Perelman's theorem; the reverse uses `simply_connected_of_homeomorphic` (axiom: homeomorphisms preserve $\\pi_1$ triviality).",
+    "mathContext": "This biconditional captures the full strength of the Poincaré Conjecture: simple connectivity perfectly characterizes $S^3$ among closed 3-manifolds. The proof uses `poincare_conjecture_holds` for ($\\Rightarrow$) and `simply_connected_of_homeomorphic` for ($\\Leftarrow$). The latter requires that homeomorphisms induce isomorphisms on fundamental groups—a fact that Mathlib's `FundamentalGroupoid.instFunctor` partially handles.",
+    "significance": "critical",
+    "relatedConcepts": ["topological characterization", "biconditional", "fundamental group invariance"],
+    "prerequisites": ["ann-main-theorem", "ann-s3-instances"]
+  },
+  {
+    "id": "ann-connected-sum",
+    "proofId": "poincare-conjecture",
+    "range": { "startLine": 547, "endLine": 605 },
+    "type": "definition",
+    "title": "Connected Sum and Prime Decomposition",
+    "content": "The connected sum $M \\# N$ is axiomatized with properties: commutativity ($M \\# N \\cong N \\# M$), identity ($M \\# S^3 \\cong M$). A 3-manifold is **prime** if it cannot decompose as a nontrivial connected sum. **Kneser's theorem** (1929, uniqueness by Milnor 1962): every closed orientable 3-manifold decomposes uniquely into prime factors. $S^3$ is **proved** to be prime.",
+    "mathContext": "The connected sum removes a small 3-ball from each manifold and glues along the resulting $S^2$ boundaries. The `IsPrime3Manifold` predicate says $M \\cong A \\# B \\implies A \\cong S^3 \\lor B \\cong S^3$. The proof `sphere3_is_prime` uses `sphere3_prime_factor_left` (axiom): if $S^3 \\cong A \\# B$ then $\\pi_1(S^3) = 1 = \\pi_1(A) * \\pi_1(B)$ forces both factors to be $S^3$ by Poincaré.",
+    "significance": "key",
+    "relatedConcepts": ["connected sum", "prime decomposition", "Kneser theorem", "Milnor uniqueness"],
+    "prerequisites": ["ann-main-theorem", "ann-homeomorphism"]
+  },
+  {
+    "id": "ann-geometrization-consequence",
+    "proofId": "poincare-conjecture",
+    "range": { "startLine": 607, "endLine": 627 },
+    "type": "theorem",
+    "title": "Geometrization and Spherical Geometry",
+    "content": "**`simply_connected_geometry`** is **proved**: a simply connected closed 3-manifold admits only spherical geometry among Thurston's 8 types. This follows because the other 7 geometries require nontrivial $\\pi_1$ (e.g., $\\mathbb{E}^3$-manifolds have $\\mathbb{Z}^3$; $\\mathbb{H}^3$-manifolds have infinite $\\pi_1$). Combined with `thurston_geometrization`, every piece must be spherical.",
+    "mathContext": "The axiom `simply_connected_only_spherical` encodes: of Thurston's 8 geometries ($S^3, \\mathbb{E}^3, \\mathbb{H}^3, S^2 \\times \\mathbb{R}, \\mathbb{H}^2 \\times \\mathbb{R}, \\widetilde{\\text{SL}_2\\mathbb{R}}, \\text{Nil}, \\text{Sol}$), only $S^3$-geometry admits compact quotients with $\\pi_1 = 1$. The spherical space forms are $S^3/\\Gamma$ where $\\Gamma \\leq SO(4)$ acts freely; $\\pi_1(S^3/\\Gamma) \\cong \\Gamma$, so $\\Gamma = 1$ gives $S^3$ itself.",
+    "significance": "key",
+    "relatedConcepts": ["Thurston geometrization", "spherical space forms", "geometric structures", "quotient manifolds"],
+    "prerequisites": ["ann-thurston", "ann-main-theorem"]
   },
   {
     "id": "ann-historical",
     "proofId": "poincare-conjecture",
-    "range": {
-      "startLine": 404,
-      "endLine": 460
-    },
-    "type": "historical",
-    "title": "Historical Context",
-    "content": "Poincaré posed the conjecture in 1904. After 99 years of failed attempts, Grigori Perelman posted three papers to arXiv in 2002-2003, completing the proof using Ricci flow with surgery. He declined both the Fields Medal (2006) and the $1 million Millennium Prize (2010).",
-    "mathContext": "Perelman's reasoning for declining included: 'My contribution is no greater than Hamilton's' (who invented Ricci flow). He also expressed disagreement with the mathematical community's ethics around credit and recognition.",
+    "range": { "startLine": 419, "endLine": 430 },
+    "type": "insight",
+    "title": "Historical Timeline",
+    "content": "The topological Poincaré Conjecture has been proved in **all dimensions**: $n = 1$ (trivial), $n = 2$ (uniformization), $n \\geq 5$ (Smale 1961, Fields Medal 1966), $n = 4$ (Freedman 1982, Fields Medal 1986), $n = 3$ (Perelman 2002–2003, declined Fields Medal 2006 and Millennium Prize 2010). Dimension 3 was the last and hardest case.",
+    "mathContext": "The historical paradox: higher dimensions were easier because the Whitney trick works for $n \\geq 5$ (allowing handle cancellation in h-cobordisms). Dimension 4 required Freedman's revolutionary Casson handle technique. Dimension 3 was uniquely hard because neither h-cobordism nor Casson handles apply—Ricci flow with surgery was the entirely new approach needed.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "Fields Medal",
-      "Millennium Prize",
-      "mathematical community"
-    ]
+    "relatedConcepts": ["Fields Medal", "Millennium Prize", "Whitney trick", "dimensional hierarchy"],
+    "prerequisites": ["ann-poincare-all-dims"]
+  },
+  {
+    "id": "ann-summary",
+    "proofId": "poincare-conjecture",
+    "range": { "startLine": 629, "endLine": 696 },
+    "type": "concept",
+    "title": "Summary of Verified Results",
+    "content": "The formalization contains 698 lines covering 20 parts. **Proved results** include: $S^3$ and $S^n$ topological properties, loop contractibility, fundamental group triviality, Thurston geometry count, Poincaré dichotomy, normalization retraction, $S^3$ primality, and the all-dimensions unification. **Axiomatized**: Perelman's surgery/extinction, Thurston geometrization, $W$-entropy monotonicity, Hamilton's theorem, Seifert–van Kampen for spheres, connected sum properties, Kneser decomposition.",
+    "mathContext": "The ratio of proved to axiomatized results is notable: 15+ theorems proved vs ~12 axioms. The axioms encode deep analytic and topological results (PDEs, surgery theory, algebraic topology) while the proved theorems handle the logical structure, typeclass lifting, case analysis, and algebraic topology bridges. This demonstrates how formal mathematics can capture the architecture of a proof even when the technical core requires axiomatization.",
+    "significance": "supporting",
+    "relatedConcepts": ["proof architecture", "axiom-theorem ratio", "formal verification strategy"],
+    "prerequisites": []
   }
 ]

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -1,12 +1,13 @@
 {
   "id": "poincare-conjecture",
-  "title": "The Poincare Conjecture",
+  "title": "The Poincaré Conjecture",
   "slug": "poincare-conjecture",
   "description": "Every simply connected, closed 3-manifold is homeomorphic to the 3-sphere. Solved by Grigori Perelman in 2002-2003 using Ricci flow with surgery.",
   "meta": {
     "author": "Grigori Perelman (2002-2003)",
     "date": "2003",
     "status": "verified",
+    "proofRepoPath": "Proofs/PoincareConjecture.lean",
     "tags": [
       "topology",
       "differential-geometry",
@@ -15,56 +16,215 @@
     ],
     "badge": "original",
     "sorries": 0,
-    "mathlibDependencies": [],
+    "mathlibDependencies": [
+      {
+        "theorem": "SimplyConnectedSpace",
+        "description": "Simply connected space typeclass from algebraic topology",
+        "module": "Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected"
+      },
+      {
+        "theorem": "FundamentalGroup",
+        "description": "Fundamental group π₁(X,x) as automorphisms in fundamental groupoid",
+        "module": "Mathlib.AlgebraicTopology.FundamentalGroupoid.FundamentalGroup"
+      },
+      {
+        "theorem": "isConnected_sphere",
+        "description": "Connectedness of spheres in normed spaces of rank > 1",
+        "module": "Mathlib.Analysis.Normed.Module.Connected"
+      },
+      {
+        "theorem": "isCompact_sphere",
+        "description": "Compactness of metric spheres",
+        "module": "Mathlib.Topology.MetricSpace.Basic"
+      },
+      {
+        "theorem": "EuclideanSpace",
+        "description": "Finite-dimensional inner product space ℝⁿ",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Path.Homotopic",
+        "description": "Homotopy relation on paths for fundamental group construction",
+        "module": "Mathlib.Topology.Homotopy.Path"
+      }
+    ],
     "originalContributions": [
-      "Formal statement of the Poincare Conjecture",
-      "Definition of simply connected 3-manifolds",
-      "Axiomatization of Ricci flow approach",
-      "Historical context"
+      "Formal statement of the Poincaré Conjecture using Mathlib's SimplyConnectedSpace",
+      "S³ topological properties proved: nonempty, compact, connected, path-connected",
+      "General n-sphere properties proved for all dimensions",
+      "Bridge between FundamentalGroup triviality and SimplyConnectedSpace",
+      "poincare_of_trivial_pi1: π₁(M,x) trivial ∀x ⟹ M ≅ S³",
+      "poincare_all_dimensions: unified theorem for all n ≥ 2",
+      "closed_3_manifold_classification: SC ⟺ homeomorphic to S³",
+      "Thurston's 8 geometries enumerated with count proved via native_decide",
+      "Connected sum, prime decomposition, S³ primality proved",
+      "Axiomatization of Perelman's Ricci flow surgery approach",
+      "Normalization retraction onto sphere proved"
     ],
     "dateAdded": "12/29/25",
     "millenniumProblem": "poincare"
   },
   "overview": {
-    "historicalContext": "The Poincare Conjecture was posed in 1904 and remained open for nearly a century. Perelman proved it in 2002-2003 using Hamilton's Ricci flow, declining both the Fields Medal and the Millennium Prize.",
-    "problemStatement": "**Theorem (Perelman):** Every simply connected, closed 3-manifold is homeomorphic to the 3-sphere S^3.\n\nThis was the first Millennium Prize Problem to be solved.",
-    "proofStrategy": "Perelman used Ricci flow with surgery: evolve the metric by the Ricci flow equation, perform surgery when singularities form, and show the manifold eventually becomes spherical or goes extinct.",
+    "historicalContext": "Henri Poincaré posed the conjecture in 1904 in his fifth complement to Analysis Situs, after discovering that homology alone does not characterize the 3-sphere (the Poincaré homology sphere $\\Sigma(2,3,5)$ has $H_*(M) \\cong H_*(S^3)$ but $|\\pi_1| = 120$). The problem resisted all attempts for nearly a century.\n\nRichard Hamilton introduced Ricci flow in his landmark 1982 paper in J. Differential Geometry, proving that closed 3-manifolds with positive Ricci curvature are diffeomorphic to $S^3$. Grigori Perelman extended this in three arXiv preprints (2002–2003): 'The entropy formula for the Ricci flow' (math/0211159), 'Ricci flow with surgery on three-manifolds' (math/0303109), and 'Finite extinction time for the solutions to the Ricci flow' (math/0307245). His proof also established Thurston's Geometrization Conjecture.\n\nPerelman was awarded the Fields Medal in 2006 (declined) and the Clay Millennium Prize of $1 million in 2010 (also declined), saying 'I'm not interested in money or fame.' The detailed verification was completed by Kleiner–Lott (2008), Morgan–Tian (2007), and Cao–Zhu (2006).",
+    "problemStatement": "**Theorem (Perelman, 2003):** Every simply connected, closed 3-manifold is homeomorphic to the 3-sphere $S^3$.\n\nFormally: $\\forall M, \\; \\text{Closed3Manifold}(M) \\to \\text{SimplyConnectedSpace}(M) \\to M \\cong_t S^3$.\n\nThis was the first of the seven Millennium Prize Problems to be solved. The conjecture is equivalent to: $\\pi_1(M) = 1$ characterizes $S^3$ among closed 3-manifolds.",
+    "proofStrategy": "The Lean formalization defines the 3-sphere $S^3 \\subset \\mathbb{R}^4$, proves its topological properties (compact, connected, path-connected, nonempty), and uses Mathlib's `SimplyConnectedSpace` and `FundamentalGroup` infrastructure. Perelman's Ricci flow with surgery approach is axiomatized: the surgery procedure preserves simple connectivity, and finite extinction time forces convergence to $S^3$. The main theorem is derived from these axioms. The file extends to Thurston's geometrization (8 model geometries), the generalized Poincaré Conjecture for all dimensions $\\geq 2$, connected sum / prime decomposition, and the biconditional classification theorem.",
     "keyInsights": [
-      "Ricci flow evolves the metric toward constant curvature",
-      "Surgery handles singularity formation",
-      "Simply connected implies spherical in dimension 3"
+      "**Ricci flow as heat equation for geometry:** The PDE $\\partial g/\\partial t = -2\\operatorname{Ric}(g)$ smooths curvature irregularities, driving simply connected manifolds toward constant positive curvature (the round $S^3$ metric)",
+      "**Surgery handles singularities:** When Ricci flow develops singularities (necks pinching off), Perelman's surgery cuts at the neck and caps with standard pieces, preserving $\\pi_1 = 1$",
+      "**Finite extinction from simple connectivity:** The key insight — $\\pi_1(M) = 1$ prevents incompressible tori that would allow infinite-time survival. The $W$-entropy monotonicity forces extinction in finite time",
+      "**Dimensional paradox:** The conjecture was hardest in dimension 3, despite being solved earlier in all other dimensions: $n \\geq 5$ (Smale 1961), $n = 4$ (Freedman 1982), $n = 2$ (classical). The Whitney trick fails in low dimensions",
+      "**Thurston's geometrization:** Every closed 3-manifold decomposes into pieces carrying one of exactly 8 model geometries. Simply connected manifolds can only carry spherical geometry, so they must be $S^3$"
     ]
   },
   "sections": [
     {
-      "id": "definitions",
-      "title": "Topological Definitions",
-      "startLine": 1,
-      "endLine": 100,
-      "summary": "Definitions of 3-manifolds, simply connected, and the 3-sphere."
+      "id": "sphere3",
+      "title": "The 3-Sphere $S^3$",
+      "startLine": 110,
+      "endLine": 145,
+      "summary": "Defines $S^3 = \\{x \\in \\mathbb{R}^4 : \\|x\\| = 1\\}$ and **proves** nonemptiness, compactness, connectedness, and path-connectedness using Mathlib's sphere API."
+    },
+    {
+      "id": "simply-connected",
+      "title": "Simply Connected Spaces",
+      "startLine": 147,
+      "endLine": 167,
+      "summary": "Uses Mathlib's `SimplyConnectedSpace` and **proves** that simply connected spaces have null-homotopic loops and are path-connected."
+    },
+    {
+      "id": "closed-manifolds",
+      "title": "Closed Manifolds",
+      "startLine": 169,
+      "endLine": 182,
+      "summary": "Defines `ClosedManifold n M` requiring compact, connected, nonempty, and locally homeomorphic to $\\mathbb{R}^n$. Abbreviation `Closed3Manifold` for $n = 3$."
+    },
+    {
+      "id": "homeomorphism",
+      "title": "Homeomorphism",
+      "startLine": 184,
+      "endLine": 201,
+      "summary": "Defines `AreHomeomorphic X Y` and **proves** reflexivity, symmetry, transitivity — establishing homeomorphism as an equivalence relation."
+    },
+    {
+      "id": "poincare-statement",
+      "title": "The Poincaré Conjecture (Statement)",
+      "startLine": 203,
+      "endLine": 212,
+      "summary": "States `PoincareConjectureStatement` : $\\forall M$, closed 3-manifold $\\wedge$ simply connected $\\implies M \\cong_t S^3$."
     },
     {
       "id": "ricci-flow",
-      "title": "Ricci Flow",
-      "startLine": 101,
-      "endLine": 180,
-      "summary": "The Ricci flow equation and surgery procedure."
+      "title": "Ricci Flow and Perelman's Axioms",
+      "startLine": 214,
+      "endLine": 266,
+      "summary": "Axiomatizes Ricci curvature, Riemannian metric, Ricci flow, Perelman's surgery and finite extinction, Thurston's 8 geometries, $W$-entropy monotonicity, and Hamilton's positive Ricci theorem."
     },
     {
       "id": "main-theorem",
-      "title": "Main Theorem",
-      "startLine": 181,
-      "endLine": 250,
-      "summary": "Statement and proof structure of the Poincare Conjecture."
+      "title": "The Main Theorem",
+      "startLine": 268,
+      "endLine": 277,
+      "summary": "**Proves** `poincare_conjecture_holds` by extracting the homeomorphism from `perelman_finite_extinction`."
+    },
+    {
+      "id": "generalized-dims",
+      "title": "Generalized Poincaré (Per Dimension)",
+      "startLine": 279,
+      "endLine": 296,
+      "summary": "Axiomatizes the generalized conjecture for $n = 2$ (uniformization), $n = 4$ (Freedman), $n \\geq 5$ (Smale)."
+    },
+    {
+      "id": "consequences",
+      "title": "Consequences and Applications",
+      "startLine": 298,
+      "endLine": 343,
+      "summary": "**Proves** corollaries: `trivial_pi1_implies_sphere`, `poincare_of_trivial_pi1` (bridging FundamentalGroup), contrapositive, and dichotomy."
+    },
+    {
+      "id": "sphere-properties",
+      "title": "Generalized $n$-Sphere Properties",
+      "startLine": 351,
+      "endLine": 376,
+      "summary": "**Proves** connectedness, path-connectedness, nonemptiness, and compactness of $S^n \\subset \\mathbb{R}^{n+1}$ for all $n$."
+    },
+    {
+      "id": "all-dimensions",
+      "title": "Poincaré for All Dimensions $\\geq 2$",
+      "startLine": 378,
+      "endLine": 417,
+      "summary": "**Proves** `poincare_all_dimensions` by case analysis: Smale for $n \\geq 5$, then `interval_cases` dispatching $n \\in \\{2, 3, 4\\}$."
+    },
+    {
+      "id": "historical-notes",
+      "title": "Historical Notes",
+      "startLine": 419,
+      "endLine": 430,
+      "summary": "Timeline: Smale (1961, $n \\geq 5$), Freedman (1982, $n = 4$), Perelman (2003, $n = 3$). Smooth 4D case still open."
+    },
+    {
+      "id": "fundamental-group",
+      "title": "Fundamental Group Characterization",
+      "startLine": 432,
+      "endLine": 442,
+      "summary": "**Proves** `fundamental_group_trivial_of_sc`: for simply connected spaces, $\\pi_1(X, x)$ is trivial (Subsingleton) at every point."
+    },
+    {
+      "id": "sphere-retraction",
+      "title": "Sphere Retraction",
+      "startLine": 444,
+      "endLine": 466,
+      "summary": "**Proves** the normalization map $x \\mapsto x/\\|x\\|$ sends nonzero vectors to $S^{n-1}$ and fixes sphere points."
+    },
+    {
+      "id": "s3-instances",
+      "title": "$S^3$ Type Class Instances",
+      "startLine": 468,
+      "endLine": 520,
+      "summary": "Lifts $S^3$ properties to type class instances. Axiomatizes locally Euclidean and simple connectivity (Seifert–van Kampen needed)."
+    },
+    {
+      "id": "classification",
+      "title": "3-Manifold Classification",
+      "startLine": 522,
+      "endLine": 545,
+      "summary": "**Proves** `closed_3_manifold_classification`: simply connected $\\iff$ homeomorphic to $S^3$."
+    },
+    {
+      "id": "connected-sum",
+      "title": "Connected Sum and Prime Decomposition",
+      "startLine": 547,
+      "endLine": 605,
+      "summary": "Axiomatizes connected sum $M \\# N$ with commutativity and identity. Defines primality, states Kneser's theorem, **proves** $S^3$ is prime."
+    },
+    {
+      "id": "geometrization-consequence",
+      "title": "Geometrization Consequences",
+      "startLine": 607,
+      "endLine": 627,
+      "summary": "**Proves** `simply_connected_geometry`: simply connected 3-manifolds admit only spherical Thurston geometry."
+    },
+    {
+      "id": "summary",
+      "title": "Summary of Verified Results",
+      "startLine": 629,
+      "endLine": 698,
+      "summary": "Catalogues all proved results (15+) and axiomatized components (~12), with `#check` statements verifying each declaration."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "hurwitz-theorem",
+      "relationship": "Both establish classification theorems: Hurwitz classifies normed division algebras ($n \\in \\{1,2,4,8\\}$), Poincaré classifies simply connected closed 3-manifolds (only $S^3$). Both use biconditional characterizations."
     }
   ],
   "conclusion": {
-    "summary": "The Poincare Conjecture is proven: every simply connected, closed 3-manifold is a 3-sphere. This was the first Millennium Prize Problem to be solved.",
-    "implications": "Perelman's proof revolutionized geometric analysis and topology. The Ricci flow technique has since been applied to many other problems.",
+    "summary": "The Poincaré Conjecture is SOLVED (Perelman, 2002–2003): every simply connected, closed 3-manifold is homeomorphic to $S^3$. The formalization provides 698 lines covering 20 parts, with 15+ genuinely proved theorems and ~12 axioms encapsulating the deep PDE and surgery-theoretic content of Perelman's proof.",
+    "implications": "Perelman's proof also established Thurston's Geometrization Conjecture, revolutionizing 3-manifold topology. The Ricci flow technique has since been applied to the differentiable sphere theorem (Brendle–Schoen 2009), classification of manifolds with positive isotropic curvature, and the study of Kähler–Ricci flow in complex geometry.",
     "openQuestions": [
-      "Can Ricci flow techniques generalize to higher dimensions?",
-      "What are the computational aspects of Ricci flow?",
-      "How does this connect to the geometrization conjecture?"
+      "The smooth 4-dimensional Poincaré conjecture: is every smooth homotopy 4-sphere diffeomorphic to $S^4$?",
+      "Can Perelman's surgery procedure be made effective/algorithmic for computational topology?",
+      "What are the optimal constants in the no-local-collapsing theorem?",
+      "Can Ricci flow techniques prove the Borel conjecture for aspherical manifolds?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Expand annotations from 10 to 22, covering all 20 parts of the 698-line Lean file
- Add mathContext, relatedConcepts, prerequisites to every annotation
- Fix invalid `"type": "historical"` → `"insight"`
- Expand sections from 3 to 19, matching the Lean file structure
- Deepen historicalContext with Poincaré 1904, Hamilton 1982, Perelman 2002–2003 arXiv papers, verification teams
- Add 6 mathlibDependencies, crossReference to hurwitz-theorem, proofRepoPath
- Expand keyInsights to 5 with LaTeX, openQuestions to 4 (smooth 4D Poincaré, algorithmic surgery)

## Test plan
- [x] `pnpm annotations:build` passes (non-strict warnings only for axiom type mismatch)
- [ ] Verify gallery renders enriched content correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)