### PR TITLE
enrich: deepen erdos-450 with mathContext, cross-refs, and historical context

### DIFF
--- a/src/data/proofs/erdos-450/annotations.json
+++ b/src/data/proofs/erdos-450/annotations.json
@@ -1,92 +1,110 @@
 [
   {
-    "id": "erdos-450-header",
+    "id": "ann-450-imports",
     "proofId": "erdos-450",
     "type": "concept",
-    "range": { "startLine": 1, "endLine": 27 },
-    "title": "Problem Overview",
-    "content": "Erdős Problem #450 from Erdős-Graham (1980, p.89) asks about the density of integers with a divisor in (n, 2n) within short intervals.\n\nCambie showed the 'for all x' version fails in certain regimes using Ford's divisor distribution work. The problem remains OPEN.",
-    "significance": "critical",
-    "relatedConcepts": ["divisor distribution", "short intervals", "density"]
-  },
-  {
-    "id": "erdos-450-divisor",
-    "proofId": "erdos-450",
-    "type": "definition",
-    "range": { "startLine": 38, "endLine": 48 },
-    "title": "Divisors in (n, 2n)",
-    "content": "**HasDivisorIn m n**: m has a divisor d with n < d < 2n.\n\n**countWithDivisor x y n**: counts integers in (x, x+y) having such a divisor.\n\nThese are the core objects of study - we want to bound the count relative to y.",
-    "significance": "key",
-    "relatedConcepts": ["divisibility", "counting", "interval"]
-  },
-  {
-    "id": "erdos-450-density",
-    "proofId": "erdos-450",
-    "type": "definition",
-    "range": { "startLine": 52, "endLine": 57 },
-    "title": "Density Bound",
-    "content": "**DensityBound**: the count of integers with a divisor in (n,2n) within (x,x+y) is at most ε·y, using rational ε (εNum/εDen) to stay in ℕ.",
-    "significance": "key",
-    "relatedConcepts": ["density", "rational approximation"]
-  },
-  {
-    "id": "erdos-450-forall",
-    "proofId": "erdos-450",
-    "type": "definition",
-    "range": { "startLine": 61, "endLine": 71 },
-    "title": "For All x Version",
-    "content": "**ErdosProblem450_ForAll**: Given ε > 0 and n, find y such that the density bound holds for ALL x. Cambie showed this version fails in certain parameter ranges.",
-    "significance": "critical",
-    "relatedConcepts": ["universal quantifier", "interval length"]
-  },
-  {
-    "id": "erdos-450-exists",
-    "proofId": "erdos-450",
-    "type": "definition",
-    "range": { "startLine": 75, "endLine": 84 },
-    "title": "Existential x Version",
-    "content": "**ErdosProblem450_Exists**: Given ε > 0 and n, find y such that the density bound holds for SOME x. This weaker version remains open.",
-    "significance": "key",
-    "relatedConcepts": ["existential quantifier", "open problem"]
-  },
-  {
-    "id": "erdos-450-cambie",
-    "proofId": "erdos-450",
-    "type": "axiom",
-    "range": { "startLine": 88, "endLine": 100 },
-    "title": "Cambie's No-y Result",
-    "content": "**cambie_no_y_for_all**: For certain ε and n, no finite y works for the 'for all x' version. This uses Ford's work on divisor distribution.\n\nThe logarithmic condition involves ε·(log n)^δ·(log log n)^{3/2} with δ ≈ 0.086.",
-    "significance": "critical",
-    "relatedConcepts": ["Cambie", "Ford", "divisor anatomy"]
-  },
-  {
-    "id": "erdos-450-small-eps",
-    "proofId": "erdos-450",
-    "type": "axiom",
-    "range": { "startLine": 102, "endLine": 114 },
-    "title": "Small ε Regime",
-    "content": "**cambie_small_epsilon**: For y ≥ 2n+1, every interval of length y contains at least one multiple of some d in (n, 2n). So y(ε,n) ∼ 2n for very small ε.",
-    "significance": "key",
-    "relatedConcepts": ["multiples", "interval length threshold"]
-  },
-  {
-    "id": "erdos-450-ford",
-    "proofId": "erdos-450",
-    "type": "axiom",
-    "range": { "startLine": 116, "endLine": 125 },
-    "title": "Ford's Divisor Distribution",
-    "content": "**ford_divisor_distribution**: For all n ≥ 2, every interval of length 4n contains integers with a divisor in (n, 2n). A consequence of Ford's foundational work on the anatomy of integers.",
+    "range": { "startLine": 26, "endLine": 34 },
+    "title": "Imports and Setup",
+    "content": "The formalization uses basic Mathlib infrastructure: `Nat.Basic` and `Nat.GCD.Basic` for divisibility, `Finset.Basic` and `Finset.Card` for counting, and general tactics. The namespace `Erdos450` isolates the development.",
+    "mathContext": "The counting function uses `Finset.range y` and `Finset.filter` to enumerate integers in an interval satisfying a predicate. The `Finset.card` function gives the count. All arithmetic stays in $\\mathbb{N}$ with rational $\\varepsilon$ encoded as $\\varepsilon_{\\text{Num}} / \\varepsilon_{\\text{Den}}$ to avoid real number overhead.",
     "significance": "supporting",
-    "relatedConcepts": ["Ford", "divisor distribution", "anatomy of integers"]
+    "relatedConcepts": ["Finset", "divisibility", "natural number arithmetic"],
+    "prerequisites": []
   },
   {
-    "id": "erdos-450-summary",
+    "id": "ann-450-divisor",
+    "proofId": "erdos-450",
+    "type": "definition",
+    "range": { "startLine": 38, "endLine": 44 },
+    "title": "Divisors in $(n, 2n)$",
+    "content": "**`HasDivisorIn m n`**: integer $m$ has a divisor $d$ with $n < d < 2n$. **`countWithDivisor x y n`**: counts integers in $(x, x+y)$ having such a divisor, using `Finset.filter` over `Finset.range y`.",
+    "mathContext": "$\\text{HasDivisorIn}(m, n) := \\exists d \\mid m, \\; n < d < 2n$. The counting function $N(x, y, n) = |\\{1 \\leq i \\leq y : \\exists d \\mid (x+i), \\; n < d < 2n\\}|$. The interval $(n, 2n)$ is open, so for $n = 1$ the interval $(1, 2)$ is empty and the count is always $0$.",
+    "significance": "critical",
+    "relatedConcepts": ["divisibility", "counting function", "open interval"],
+    "prerequisites": ["ann-450-imports"]
+  },
+  {
+    "id": "ann-450-infrastructure",
     "proofId": "erdos-450",
     "type": "theorem",
-    "range": { "startLine": 129, "endLine": 143 },
-    "title": "Summary Theorem",
-    "content": "**erdos_450_summary** combines:\n1. The 'for all x' version can fail (Cambie)\n2. Every long interval has integers with divisors in (n, 2n)\n\nThe problem remains OPEN for the existential version.",
+    "range": { "startLine": 48, "endLine": 109 },
+    "title": "Infrastructure Lemmas",
+    "content": "Seven lemmas are **proved**: (1) `countWithDivisor_le` — count $\\leq y$ (via `card_filter_le`). (2) `countWithDivisor_zero` — empty interval has count $0$. (3,4) `countWithDivisor_n_zero/one` — degenerate $n$ cases. (5) `countWithDivisor_mono_y` — monotonicity in interval length. (6) `hasDivisorIn_of_dvd` — any multiple of $d \\in (n, 2n)$ qualifies. (7) `hasDivisorIn_succ` — $n+1$ has divisor $n+1 \\in (n, 2n)$ for $n \\geq 1$.",
+    "mathContext": "The monotonicity proof uses `Finset.card_le_card` and `Finset.filter_subset_filter` with `Finset.range_mono`. The bound $N(x, y, n) \\leq y$ follows from $|\\text{filter}(S, P)| \\leq |S|$. The degenerate cases $n = 0$ (interval $(0, 0)$ empty) and $n = 1$ (interval $(1, 2)$ empty) use `omega` to derive contradictions on divisor bounds.",
+    "significance": "key",
+    "relatedConcepts": ["monotonicity", "filter cardinality", "boundary cases"],
+    "prerequisites": ["ann-450-divisor"]
+  },
+  {
+    "id": "ann-450-density",
+    "proofId": "erdos-450",
+    "type": "definition",
+    "range": { "startLine": 111, "endLine": 148 },
+    "title": "Density Bound and Trivial Cases",
+    "content": "**`DensityBound x y n εNum εDen`**: the count satisfies $N(x, y, n) \\cdot \\varepsilon_{\\text{Den}} \\leq \\varepsilon_{\\text{Num}} \\cdot y$, encoding $N \\leq \\varepsilon \\cdot y$ in $\\mathbb{N}$. Four trivial cases are **proved**: $y = 0$, $\\varepsilon \\geq 1$ (count $\\leq y$), $n = 0$, and $n = 1$.",
+    "mathContext": "Rational encoding: $\\varepsilon = \\varepsilon_{\\text{Num}} / \\varepsilon_{\\text{Den}}$ avoids real arithmetic. The inequality $N \\cdot \\varepsilon_{\\text{Den}} \\leq \\varepsilon_{\\text{Num}} \\cdot y$ is equivalent to $N/y \\leq \\varepsilon$ when $y, \\varepsilon_{\\text{Den}} > 0$. The proof of `densityBound_large_eps` chains: $N \\cdot \\varepsilon_{\\text{Den}} \\leq y \\cdot \\varepsilon_{\\text{Den}} \\leq y \\cdot \\varepsilon_{\\text{Num}} = \\varepsilon_{\\text{Num}} \\cdot y$.",
+    "significance": "key",
+    "relatedConcepts": ["rational approximation", "density", "trivial bounds"],
+    "prerequisites": ["ann-450-divisor"]
+  },
+  {
+    "id": "ann-450-forall",
+    "proofId": "erdos-450",
+    "type": "definition",
+    "range": { "startLine": 150, "endLine": 160 },
+    "title": "For All $x$ Version",
+    "content": "**`ErdosProblem450_ForAll`**: given $\\varepsilon > 0$ and $n \\geq 2$, there exists $y \\geq 1$ such that $N(x, y, n) \\leq \\varepsilon \\cdot y$ for **all** $x$. This is the stronger version that Cambie showed **fails** in certain regimes.",
+    "mathContext": "$\\forall \\varepsilon > 0, \\forall n \\geq 2, \\exists y \\geq 1 : \\forall x, N(x, y, n) \\leq \\varepsilon \\cdot y$. The quantifier order is crucial: requiring the bound for ALL starting points $x$ simultaneously is much harder than for a single well-chosen $x$. The 'for all' version demands uniformity across all translates of the interval.",
     "significance": "critical",
-    "relatedConcepts": ["summary", "open problem"]
+    "relatedConcepts": ["universal quantifier", "uniform bound", "interval translation"],
+    "prerequisites": ["ann-450-density"]
+  },
+  {
+    "id": "ann-450-exists",
+    "proofId": "erdos-450",
+    "type": "definition",
+    "range": { "startLine": 162, "endLine": 176 },
+    "title": "Existential $x$ Version and Implication",
+    "content": "**`ErdosProblem450_Exists`**: same as above but the density bound need only hold for **some** $x$. The theorem `forAll_implies_exists` is **proved**: the universal version implies the existential (take $x = 0$). The existential version remains open.",
+    "mathContext": "$\\forall \\varepsilon > 0, \\forall n \\geq 2, \\exists y \\geq 1, \\exists x : N(x, y, n) \\leq \\varepsilon \\cdot y$. The proof of `forAll_implies_exists` extracts $y$ from the universal version and witnesses $x = 0$. Since Cambie disproved the universal version, the existential version is the natural remaining question.",
+    "significance": "critical",
+    "relatedConcepts": ["existential quantifier", "open problem", "quantifier weakening"],
+    "prerequisites": ["ann-450-forall"]
+  },
+  {
+    "id": "ann-450-cambie",
+    "proofId": "erdos-450",
+    "type": "theorem",
+    "range": { "startLine": 178, "endLine": 196 },
+    "title": "Cambie's No-$y$ Result and Small $\\varepsilon$ Regime",
+    "content": "Two axioms encode Cambie's results: (1) **`cambie_no_y_for_all`**: for certain $\\varepsilon, n$, no finite $y$ works universally—the 'for all $x$' version fails. (2) **`cambie_small_epsilon`**: for $y \\geq 2n + 1$, every interval of that length contains at least one integer with a divisor in $(n, 2n)$.",
+    "mathContext": "Cambie's negative result uses Ford's work: when $\\varepsilon \\cdot (\\log n)^\\delta \\cdot (\\log \\log n)^{3/2} \\to \\infty$ with $\\delta = 1 - \\frac{1+\\log\\log 2}{\\log 2} \\approx 0.0860713$, the set of integers with a divisor in $(n, 2n)$ is too densely distributed for any uniform $y$ to work. The small-$\\varepsilon$ bound $y \\geq 2n + 1$ follows because by the pigeonhole principle, an interval of length $> 2n$ must contain a multiple of some $d$ with $n < d < 2n$.",
+    "significance": "critical",
+    "relatedConcepts": ["Cambie", "Ford's theorem", "logarithmic density", "pigeonhole principle"],
+    "prerequisites": ["ann-450-forall", "ann-450-divisor"]
+  },
+  {
+    "id": "ann-450-ford",
+    "proofId": "erdos-450",
+    "type": "theorem",
+    "range": { "startLine": 198, "endLine": 203 },
+    "title": "Ford's Divisor Distribution",
+    "content": "**`ford_divisor_distribution`** (axiom): for all $n \\geq 2$, every interval of length $4n$ contains integers with a divisor in $(n, 2n)$. This is a consequence of Kevin Ford's foundational work on the anatomy of integers and the distribution of divisors.",
+    "mathContext": "Ford's result (Annals of Mathematics, 2008) studies $H(x, y, z) = |\\{n \\leq x : \\exists d \\mid n, y < d \\leq z\\}|$. For the special case $z = 2y$, Ford showed that the density of such integers is $\\asymp (\\log y)^{-\\delta} (\\log \\log y)^{-3/2}$ where $\\delta \\approx 0.086$. The bound $4n$ here is a simplified version guaranteeing at least one such integer exists in any interval of that length.",
+    "significance": "key",
+    "relatedConcepts": ["Ford's theorem", "divisor anatomy", "Annals of Mathematics 2008"],
+    "prerequisites": ["ann-450-divisor"]
+  },
+  {
+    "id": "ann-450-corollaries",
+    "proofId": "erdos-450",
+    "type": "theorem",
+    "range": { "startLine": 205, "endLine": 224 },
+    "title": "Corollaries and Summary",
+    "content": "**`not_forAll_in_general`** is **proved**: the 'for all $x$' version is false, by combining Cambie's axiom with a contradiction argument. **`erdos_450_summary`** packages both known results: (1) the universal version fails, and (2) intervals of length $\\geq 2n + 1$ always contain divisor-rich integers.",
+    "mathContext": "The proof of `not_forAll_in_general` uses classical logic: assume `ErdosProblem450_ForAll`, extract $y$ from the universal quantifier, but Cambie's axiom provides a bad $x$ for any such $y$, yielding a contradiction. This is a clean application of $\\forall y, \\exists x, \\neg P(x, y)$ contradicting $\\exists y, \\forall x, P(x, y)$.",
+    "significance": "critical",
+    "relatedConcepts": ["proof by contradiction", "quantifier negation", "open problem summary"],
+    "prerequisites": ["ann-450-cambie", "ann-450-exists"]
   }
 ]

--- a/src/data/proofs/erdos-450/meta.json
+++ b/src/data/proofs/erdos-450/meta.json
@@ -19,71 +19,114 @@
     "sorries": 0,
     "erdosNumber": 450,
     "erdosUrl": "https://erdosproblems.com/450",
-    "erdosProblemStatus": "open"
+    "erdosProblemStatus": "open",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card",
+        "description": "Cardinality of finite sets for counting",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.filter",
+        "description": "Filtering finite sets by a predicate",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Nat.dvd",
+        "description": "Divisibility relation on natural numbers",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      }
+    ],
+    "originalContributions": [
+      "HasDivisorIn definition: existence of divisor in (n, 2n)",
+      "countWithDivisor: counting function via Finset.filter",
+      "7 infrastructure lemmas proved (monotonicity, bounds, degenerate cases)",
+      "DensityBound with rational ε encoding in ℕ",
+      "4 density bound trivial cases proved",
+      "Both 'for all x' and 'exists x' problem statements formalized",
+      "forAll_implies_exists theorem proved",
+      "not_forAll_in_general theorem proved (contradiction from Cambie)",
+      "Cambie's no-y result, small-ε regime, Ford's distribution axiomatized",
+      "erdos_450_summary combining known results"
+    ]
   },
   "overview": {
-    "historicalContext": "Erdős Problem #450 from Erdős–Graham (1980, p.89) asks about the density of integers having a divisor in (n, 2n) within short intervals. Cambie showed that the 'for all x' interpretation fails for certain parameter ranges, using Ford's work on divisor distribution.",
-    "problemStatement": "How large must y = y(ε, n) be such that the number of integers in (x, x+y) with a divisor in (n, 2n) is at most ε·y?",
-    "proofStrategy": "We define HasDivisorIn (existence of a divisor in (n, 2n)), the counting function countWithDivisor, density bounds, and state both the 'for all x' and 'exists x' versions. Cambie's results and Ford's divisor distribution are axiomatized.",
+    "historicalContext": "Erdős Problem #450 appears in Erdős and Graham's 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p.89). It asks about the density of integers having a 'medium-sized' divisor—one lying in the interval $(n, 2n)$—within short intervals $(x, x+y)$.\n\nThe problem connects to deep questions about the anatomy of integers studied by Erdős, Kac, Tenenbaum, and others. Kevin Ford's landmark paper 'The distribution of integers with a divisor in a given interval' (Annals of Mathematics, 2008) established precise asymptotics for the density of such integers, showing it behaves as $(\\log n)^{-\\delta} (\\log \\log n)^{-3/2}$ where $\\delta = 1 - \\frac{1 + \\log\\log 2}{\\log 2} \\approx 0.0861$.\n\nStijn Cambie made key observations on the problem: the 'for all $x$' interpretation fails when $\\varepsilon$ is not sufficiently small relative to the Ford density. The existential version (does there exist a good starting point $x$?) remains open.",
+    "problemStatement": "How large must $y = y(\\varepsilon, n)$ be such that the number of integers in $(x, x+y)$ with a divisor in $(n, 2n)$ is at most $\\varepsilon \\cdot y$?\n\nFormally: $\\forall \\varepsilon > 0, \\forall n \\geq 2, \\exists y$ such that $|\\{x < m \\leq x + y : \\exists d \\mid m, \\; n < d < 2n\\}| \\leq \\varepsilon \\cdot y$.\n\nThe answer depends on whether this must hold for all $x$ (Cambie: NO for certain regimes) or just some $x$ (OPEN).",
+    "proofStrategy": "The formalization defines `HasDivisorIn` (existence of a divisor in $(n, 2n)$) and `countWithDivisor` as a `Finset.filter` count. The density condition uses rational $\\varepsilon = \\varepsilon_{\\text{Num}}/\\varepsilon_{\\text{Den}}$ to stay in $\\mathbb{N}$. Seven infrastructure lemmas are proved (monotonicity, boundary cases). Both problem versions are stated, with `forAll_implies_exists` and `not_forAll_in_general` proved. Cambie's results and Ford's distribution are axiomatized.",
     "keyInsights": [
-      "The problem has a quantifier subtlety: 'for all x' vs 'exists x'",
-      "Cambie: the 'for all x' version fails when ε·(log n)^δ·(log log n)^{3/2} → ∞",
-      "For ε ≪ 1/n, y(ε, n) ∼ 2n (intervals of length 2n suffice)",
-      "Ford's work on divisor anatomy is foundational",
-      "The problem connects divisor distribution to interval density"
+      "**Quantifier subtlety:** The problem has two natural readings: $\\forall x$ (uniform) vs $\\exists x$ (existential). Cambie showed the universal version is **false** in certain parameter regimes, making the existential version the right question",
+      "**Ford's density constant $\\delta \\approx 0.086$:** The density of integers with a divisor in $(n, 2n)$ is $(\\log n)^{-\\delta}(\\log\\log n)^{-3/2}$, where $\\delta = 1 - (1 + \\log\\log 2)/\\log 2$. This controls the threshold where the problem transitions from trivial to impossible",
+      "**Pigeonhole for small $\\varepsilon$:** When $y \\geq 2n + 1$, any interval contains a multiple of some $d \\in (n, 2n)$, so $y(\\varepsilon, n) \\sim 2n$ when $\\varepsilon \\ll 1/n$",
+      "**Rational $\\varepsilon$ encoding:** The formalization avoids real arithmetic by encoding $\\varepsilon = \\varepsilon_{\\text{Num}}/\\varepsilon_{\\text{Den}}$ and cross-multiplying, keeping all proofs in $\\mathbb{N}$",
+      "**Proved contradiction:** `not_forAll_in_general` combines Cambie's axiom with a logical argument to formally prove the universal version fails"
     ]
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 26,
+      "endLine": 34,
+      "summary": "Imports `Nat.Basic`, `Nat.GCD.Basic`, `Finset.Basic`, `Finset.Card`, and tactics. Opens `Finset` namespace."
+    },
+    {
       "id": "divisors",
       "title": "Part I: Divisors in an Interval",
       "startLine": 36,
-      "endLine": 48,
-      "summary": "Defines HasDivisorIn and countWithDivisor."
+      "endLine": 44,
+      "summary": "Defines `HasDivisorIn m n := \\exists d \\mid m, \\; n < d < 2n$ and counting function $N(x, y, n)$ via `Finset.filter`."
+    },
+    {
+      "id": "infrastructure",
+      "title": "Part II: Infrastructure Lemmas",
+      "startLine": 46,
+      "endLine": 109,
+      "summary": "**Proves** 7 lemmas: $N \\leq y$, $N(x, 0, n) = 0$, degenerate $n$ cases, monotonicity in $y$, divisor witnesses for multiples, $n+1$, and $m \\in (n, 2n)$."
     },
     {
       "id": "density",
-      "title": "Part II: The Density Condition",
-      "startLine": 50,
-      "endLine": 57,
-      "summary": "Defines DensityBound using rational ε approximation."
+      "title": "Part III: Density Condition",
+      "startLine": 111,
+      "endLine": 148,
+      "summary": "Defines `DensityBound` using rational $\\varepsilon = \\varepsilon_{\\text{Num}}/\\varepsilon_{\\text{Den}}$. **Proves** 4 trivial cases: $y = 0$, $\\varepsilon \\geq 1$, $n = 0$, $n = 1$."
     },
     {
-      "id": "for-all",
-      "title": "Part III: The Problem (For All x)",
-      "startLine": 59,
-      "endLine": 71,
-      "summary": "ErdosProblem450_ForAll: density bound holds for all starting points x."
-    },
-    {
-      "id": "existential",
-      "title": "Part IV: The Problem (Existential x)",
-      "startLine": 73,
-      "endLine": 84,
-      "summary": "ErdosProblem450_Exists: density bound holds for some x."
+      "id": "problem-statements",
+      "title": "Part IV: Problem Statements",
+      "startLine": 150,
+      "endLine": 176,
+      "summary": "States `ErdosProblem450_ForAll` ($\\forall x$) and `ErdosProblem450_Exists` ($\\exists x$). **Proves** `forAll_implies_exists`."
     },
     {
       "id": "known-results",
-      "title": "Part V: Known Results",
-      "startLine": 86,
-      "endLine": 125,
-      "summary": "Cambie's observations and Ford's divisor distribution results."
+      "title": "Part V: Known Results (Axiomatized)",
+      "startLine": 178,
+      "endLine": 203,
+      "summary": "Axiomatizes Cambie's no-$y$ result, small-$\\varepsilon$ regime ($y \\geq 2n+1$ suffices), and Ford's $4n$-interval guarantee."
     },
     {
-      "id": "summary",
-      "title": "Part VI: Summary",
-      "startLine": 127,
-      "endLine": 143,
-      "summary": "Summary theorem combining Cambie's failure result with small-ε bounds."
+      "id": "corollaries",
+      "title": "Part VI: Corollaries and Summary",
+      "startLine": 205,
+      "endLine": 226,
+      "summary": "**Proves** `not_forAll_in_general` (universal version is false) and `erdos_450_summary` packaging both Cambie results."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "erdos-998",
+      "relationship": "Both problems concern density and distribution in intervals: #998 studies equidistribution discrepancy for irrational rotations, #450 studies divisor density in short intervals. Both involve the question of which intervals achieve extremal behavior."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #450 asks for the interval length y needed to bound the density of integers with a divisor in (n, 2n). The answer depends on quantifier choice (for all x vs exists x). Cambie showed the universal version fails for certain ε, n ranges. Open.",
-    "implications": "Resolution would deepen understanding of divisor distribution in short intervals, with connections to the anatomy of integers and multiplicative number theory.",
+    "summary": "Erdős Problem #450 remains OPEN in its existential form. The formalization proves that the 'for all x' version is false (via Cambie's observation and Ford's density results), establishes the pigeonhole bound y ∼ 2n for small ε, and provides 11 proved theorems alongside 3 axioms.",
+    "implications": "Resolution of the existential version would connect the anatomy of integers (Ford's program) to the fine structure of divisor density in short intervals, with implications for understanding the distribution of smooth and rough numbers.",
     "openQuestions": [
-      "For which ε and n does y(ε, n) exist in the 'for all x' version?",
-      "What is the exact threshold for the 'exists x' version?",
-      "Can Ford's techniques give tighter bounds on y(ε, n)?"
+      "For which ε and n does y(ε, n) exist in the 'exists x' version?",
+      "What is the sharp threshold separating trivial from impossible regimes?",
+      "Can Ford's Annals 2008 techniques give tighter bounds on y(ε, n)?",
+      "Is there a connection to the Erdős multiplication table problem?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Add mathContext, relatedConcepts, prerequisites to all 9 annotations
- Fix invalid `"type": "axiom"` → `"theorem"` on 3 annotations
- Add coverage for imports, infrastructure lemmas, density bound trivial cases, corollaries
- Deepen historicalContext with Erdős-Graham 1980 (p.89), Ford's Annals 2008, Cambie's observations
- Expand sections from 6 to 7 with LaTeX summaries
- Add 3 mathlibDependencies, crossReference to erdos-998
- Expand keyInsights to 5 with LaTeX (Ford's δ constant, quantifier subtlety, rational encoding)

## Test plan
- [x] `pnpm annotations:build` passes (zero erdos-450 warnings)
- [ ] Verify gallery renders enriched content correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)