### PR TITLE
enrich: deepen erdos-461 with mathContext, cross-refs, and historical context

### DIFF
--- a/src/data/proofs/erdos-461/annotations.json
+++ b/src/data/proofs/erdos-461/annotations.json
@@ -1,171 +1,146 @@
 [
   {
-    "id": "erdos-461-header",
+    "id": "ann-461-header",
     "proofId": "erdos-461",
-    "type": "context",
-    "range": {
-      "startLine": 1,
-      "endLine": 14
-    },
+    "type": "concept",
+    "range": { "startLine": 1, "endLine": 14 },
     "title": "Problem Background",
     "content": "Erdős Problem 461 asks whether $f(n,t)$, the count of distinct $t$-smooth components in $\\{n+1,\\ldots,n+t\\}$, grows linearly in $t$. From Erdős–Graham (1980), p.92, who proved the weaker bound $f(n,t) \\gg t/\\log t$.",
-    "significance": "essential",
-    "mathContext": "multiplicative number theory / smooth numbers. LaTeX: f(n,t) = |\\{s_t(m) : n < m \\leq n+t\\}| \\stackrel{?}{\\gg} t. The file contains both axiomatized results and fully proved theorems — a strong formalization with infrastructure lemmas for list products and prime factorization.. Related: Smooth number counting function Ψ(x,y), Dickman's function, Hildebrand–Tenenbaum estimates. Refs: Erdős–Graham (1980), p.92, erdosproblems.com/461"
+    "mathContext": "The $t$-smooth component $s_t(n)$ is the largest divisor of $n$ all of whose prime factors are $< t$. This connects to the smooth number counting function $\\Psi(x, y) = |\\{n \\leq x : P^+(n) \\leq y\\}|$ and Dickman's $\\rho$ function. Hildebrand–Tenenbaum estimates give $\\Psi(x, y) \\sim x \\rho(u)$ where $u = \\log x / \\log y$.",
+    "significance": "critical",
+    "relatedConcepts": ["smooth numbers", "Dickman function", "Hildebrand-Tenenbaum estimates"],
+    "prerequisites": []
   },
   {
-    "id": "erdos-461-smooth-component",
+    "id": "ann-461-smooth-component",
     "proofId": "erdos-461",
     "type": "definition",
-    "range": {
-      "startLine": 24,
-      "endLine": 27
-    },
+    "range": { "startLine": 24, "endLine": 27 },
     "title": "Smooth Component Definition",
-    "content": "The $t$-smooth component $s_t(n)$ is defined as the product of prime factors of $n$ (with multiplicity) that are strictly less than $t$. Formally, `smoothComponent t n = (n.factors.filter (· < t)).prod`. This extracts the largest divisor of $n$ whose prime factorization consists entirely of primes $< t$.",
-    "significance": "essential",
-    "mathContext": "multiplicative number theory. LaTeX: s_t(n) = \\prod_{\\substack{p^a \\| n \\\\ p < t}} p^a. Lean: noncomputable def smoothComponent (t n : ℕ) : ℕ := (n.factors.filter (· < t)).prod. Technique: filtering the prime factor list and taking the product. Uses `Nat.factors` (the list of prime factors with multiplicity) and `List.filter`/`List.prod`. The definition is noncomputable since `Nat.factors` involves factorization. Handles n = 0 correctly: `Nat.factors 0 = []`, so `smoothComponent t 0 = 1`.. Related: Smooth number definition Ψ(x,y), radical of an integer, p-adic valuation. Cross-refs: erdos-461-smooth-axioms, erdos-461-count"
+    "content": "The $t$-smooth component $s_t(n)$ is defined **constructively** as `(n.factors.filter (· < t)).prod` — the product of prime factors of $n$ (with multiplicity) that are strictly less than $t$. This extracts the largest divisor of $n$ whose prime factorization consists entirely of primes $< t$. Handles $n = 0$ correctly: `Nat.factors 0 = []`, so $s_t(0) = 1$.",
+    "mathContext": "$s_t(n) = \\prod_{\\substack{p^a \\| n \\\\ p < t}} p^a$. The definition uses `Nat.factors` (the list of prime factors with multiplicity) and `List.filter`/`List.prod`. Noncomputable since `Nat.factors` involves factorization. The smooth-rough decomposition gives $n = s_t(n) \\cdot r_t(n)$ where $r_t(n)$ has all primes $\\geq t$.",
+    "significance": "critical",
+    "relatedConcepts": ["prime factorization", "smooth-rough decomposition", "Nat.factors"],
+    "prerequisites": ["ann-461-header"]
   },
   {
-    "id": "erdos-461-infrastructure",
+    "id": "ann-461-infrastructure",
     "proofId": "erdos-461",
-    "type": "result",
-    "range": {
-      "startLine": 31,
-      "endLine": 61
-    },
+    "type": "lemma",
+    "range": { "startLine": 33, "endLine": 61 },
     "title": "Infrastructure Lemmas",
-    "content": "Two key helper lemmas proved by induction on lists. `list_prod_filter_dvd`: the product of a filtered sublist divides the product of the full list, i.e., $(l.\\text{filter}\\, p).\\text{prod} \\mid l.\\text{prod}$. `prime_dvd_list_prod_mem`: if a prime $p$ divides the product of a list of primes, then $p$ is a member of that list. Both are fully proved (no `sorry`).",
-    "significance": "supporting",
-    "mathContext": "list algebra / number theory foundations. LaTeX: \\prod_{x \\in \\text{filter}(l, p)} x \\mid \\prod_{x \\in l} x. Technique: structural induction on lists with case analysis on the filter predicate. Marked `private` since they are internal infrastructure. `list_prod_filter_dvd` uses `mul_dvd_mul_left` and `dvd_mul_of_dvd_right`. `prime_dvd_list_prod_mem` uses `Nat.Prime.dvd_mul` for the inductive step.. Cross-refs: erdos-461-smooth-dvd, erdos-461-smooth-smooth"
+    "content": "Two key helper lemmas **proved** by induction on lists. `list_prod_filter_dvd`: the product of a filtered sublist divides the product of the full list, i.e., $(l.\\text{filter}\\, p).\\text{prod} \\mid l.\\text{prod}$. `prime_dvd_list_prod_mem`: if a prime $p$ divides the product of a list of primes, then $p$ is a member of that list.",
+    "mathContext": "$\\prod_{x \\in \\text{filter}(l, p)} x \\mid \\prod_{x \\in l} x$ is proved by structural induction on lists with case analysis on the filter predicate. `list_prod_filter_dvd` uses `mul_dvd_mul_left` and `dvd_mul_of_dvd_right`. `prime_dvd_list_prod_mem` uses `Nat.Prime.dvd_mul` for the inductive step. Both are marked `private` as internal infrastructure.",
+    "significance": "key",
+    "relatedConcepts": ["list induction", "product divisibility", "prime membership"],
+    "prerequisites": ["ann-461-smooth-component"]
   },
   {
-    "id": "erdos-461-smooth-dvd",
+    "id": "ann-461-smooth-dvd",
     "proofId": "erdos-461",
-    "type": "result",
-    "range": {
-      "startLine": 65,
-      "endLine": 69
-    },
-    "title": "Smooth Component Divides n",
-    "content": "Theorem `smoothComponent_dvd`: for $n \\neq 0$, $s_t(n) \\mid n$. Proved by unfolding `smoothComponent`, applying `list_prod_filter_dvd` to `n.factors`, and rewriting with `Nat.prod_factors`.",
-    "significance": "essential",
-    "mathContext": "multiplicative number theory. LaTeX: n \\neq 0 \\implies s_t(n) \\mid n. Lean: theorem smoothComponent_dvd (t n : ℕ) (hn : n ≠ 0) : smoothComponent t n ∣ n. Technique: reduce to list product divisibility via Nat.prod_factors. Related: fundamental theorem of arithmetic, Nat.prod_factors. Cross-refs: erdos-461-infrastructure, erdos-461-smooth-largest"
+    "type": "theorem",
+    "range": { "startLine": 65, "endLine": 69 },
+    "title": "Smooth Component Divides $n$",
+    "content": "**`smoothComponent_dvd`** is **proved**: for $n \\neq 0$, $s_t(n) \\mid n$. The proof unfolds `smoothComponent`, applies `list_prod_filter_dvd` to `n.factors`, and rewrites with `Nat.prod_factors`.",
+    "mathContext": "$n \\neq 0 \\implies s_t(n) \\mid n$. Since $s_t(n)$ is a subproduct of the prime factorization of $n$, divisibility follows from `list_prod_filter_dvd` composed with `Nat.prod_factors hn : n.factors.prod = n`. This is the fundamental theorem of arithmetic in action.",
+    "significance": "critical",
+    "relatedConcepts": ["divisibility", "fundamental theorem of arithmetic", "Nat.prod_factors"],
+    "prerequisites": ["ann-461-infrastructure"]
   },
   {
-    "id": "erdos-461-smooth-smooth",
+    "id": "ann-461-smooth-smooth",
     "proofId": "erdos-461",
-    "type": "result",
-    "range": {
-      "startLine": 71,
-      "endLine": 78
-    },
-    "title": "Smooth Component is t-Smooth",
-    "content": "Theorem `smoothComponent_smooth`: every prime factor $p$ of $s_t(n)$ satisfies $p < t$. Uses `prime_dvd_list_prod_mem` to show $p$ must appear in the filtered list, then extracts the filter predicate $p < t$.",
-    "significance": "essential",
-    "mathContext": "multiplicative number theory. LaTeX: p \\text{ prime},\\, p \\mid s_t(n) \\implies p < t. Lean: theorem smoothComponent_smooth (t n p : ℕ) (hp : p.Prime) (hd : p ∣ smoothComponent t n) : p < t. Technique: membership in filtered list via prime_dvd_list_prod_mem, then extract filter condition. Related: y-smooth numbers: all prime factors ≤ y. Cross-refs: erdos-461-infrastructure, erdos-461-smooth-largest"
+    "type": "theorem",
+    "range": { "startLine": 71, "endLine": 78 },
+    "title": "Smooth Component is $t$-Smooth",
+    "content": "**`smoothComponent_smooth`** is **proved**: every prime factor $p$ of $s_t(n)$ satisfies $p < t$. Uses `prime_dvd_list_prod_mem` to show $p$ must appear in the filtered list, then extracts the filter predicate $p < t$.",
+    "mathContext": "$p$ prime $\\wedge$ $p \\mid s_t(n) \\implies p < t$. The proof chain: $p \\mid s_t(n) = (\\text{factors}(n).\\text{filter}(\\cdot < t)).\\text{prod}$ implies $p \\in \\text{factors}(n).\\text{filter}(\\cdot < t)$ by `prime_dvd_list_prod_mem`, and the filter condition gives $p < t$.",
+    "significance": "critical",
+    "relatedConcepts": ["t-smooth numbers", "filter predicate extraction", "prime factor bound"],
+    "prerequisites": ["ann-461-infrastructure"]
   },
   {
-    "id": "erdos-461-smooth-pos",
+    "id": "ann-461-smooth-pos",
     "proofId": "erdos-461",
-    "type": "result",
-    "range": {
-      "startLine": 80,
-      "endLine": 85
-    },
+    "type": "theorem",
+    "range": { "startLine": 80, "endLine": 85 },
     "title": "Smooth Component is Positive",
-    "content": "Theorem `smoothComponent_pos`: $s_t(n) > 0$ for all $t, n$. Since every element in the filtered factor list is a prime (hence $\\geq 2 > 0$), the product is positive by `List.prod_pos`.",
+    "content": "**`smoothComponent_pos`** is **proved**: $s_t(n) > 0$ for all $t, n$. Since every element in the filtered factor list is a prime (hence $\\geq 2 > 0$), the product is positive by `List.prod_pos`.",
+    "mathContext": "$s_t(n) > 0$ follows from the fact that a product of positive integers is positive. Each factor in the filtered list satisfies $q \\in \\text{factors}(n)$, so $q$ is prime, hence $q \\geq 2 > 0$. `List.prod_pos` gives the result.",
     "significance": "supporting",
-    "mathContext": "number theory foundations. LaTeX: s_t(n) > 0. Lean: theorem smoothComponent_pos (t n : ℕ) : 0 < smoothComponent t n. Technique: product of positive elements is positive. Cross-refs: erdos-461-smooth-component"
+    "relatedConcepts": ["positivity", "product of primes", "List.prod_pos"],
+    "prerequisites": ["ann-461-smooth-component"]
   },
   {
-    "id": "erdos-461-complement",
+    "id": "ann-461-complement",
     "proofId": "erdos-461",
-    "type": "result",
-    "range": {
-      "startLine": 87,
-      "endLine": 96
-    },
+    "type": "lemma",
+    "range": { "startLine": 87, "endLine": 96 },
     "title": "No Small Primes in Complement",
-    "content": "Lemma `no_small_prime_in_complement`: if $p$ is prime with $p < t$ and $p$ divides the product of factors $\\geq t$, this is a contradiction. The proof shows $p$ would appear in the complement list, but the filter condition requires all elements $\\geq t$, contradicting $p < t$.",
-    "significance": "supporting",
-    "mathContext": "list algebra / number theory. LaTeX: p < t \\wedge p \\mid \\prod_{q \\in \\text{factors}(n),\\, q \\geq t} q \\implies \\bot. Technique: membership via prime_dvd_list_prod_mem, then contradiction with filter condition. Key infrastructure for the maximality theorem `smoothComponent_largest`, showing the complement part (all primes ≥ t) is coprime to any t-smooth divisor.. Cross-refs: erdos-461-smooth-largest"
+    "content": "**`no_small_prime_in_complement`** is **proved**: if $p$ is prime with $p < t$ and $p$ divides the product of factors $\\geq t$, this yields a contradiction. Key infrastructure for the maximality theorem, showing the complement part is coprime to any $t$-smooth divisor.",
+    "mathContext": "$p < t \\wedge p \\mid \\prod_{q \\in \\text{factors}(n),\\, q \\geq t} q \\implies \\bot$. By `prime_dvd_list_prod_mem`, $p$ would be in the complement-filtered list, but the filter requires all elements $\\geq t$, contradicting $p < t$. This establishes the coprimality needed for the smooth-rough decomposition.",
+    "significance": "key",
+    "relatedConcepts": ["coprimality", "smooth-rough decomposition", "complement filter"],
+    "prerequisites": ["ann-461-infrastructure"]
   },
   {
-    "id": "erdos-461-smooth-largest",
+    "id": "ann-461-smooth-largest",
     "proofId": "erdos-461",
-    "type": "result",
-    "range": {
-      "startLine": 98,
-      "endLine": 106
-    },
+    "type": "theorem",
+    "range": { "startLine": 98, "endLine": 106 },
     "title": "Smooth Component is Maximal (sorry)",
-    "content": "Theorem `smoothComponent_largest`: if $d \\mid n$ and all prime factors of $d$ are $< t$, then $d \\mid s_t(n)$. This establishes $s_t(n)$ as the largest $t$-smooth divisor of $n$. Contains `sorry` — the proof strategy (noted in docstring) decomposes $n = s_t(n) \\cdot c$ where $c$ has all primes $\\geq t$, then uses coprimality of $d$ and $c$ to conclude $d \\mid s_t(n)$.",
-    "significance": "essential",
-    "mathContext": "multiplicative number theory. LaTeX: d \\mid n \\wedge (\\forall p \\text{ prime},\\, p \\mid d \\implies p < t) \\implies d \\mid s_t(n). Lean: theorem smoothComponent_largest (t n d : ℕ) (hn : n ≠ 0) : d ∣ n → (∀ p : ℕ, p.Prime → p ∣ d → p < t) → d ∣ smoothComponent t n. Technique: coprime decomposition: n = smooth_part × rough_part, then d | n and gcd(d, rough_part) = 1 implies d | smooth_part. The only `sorry` in the file. Would require proving the complement factorization and using Nat.Coprime.dvd_of_dvd_mul_right. An excellent Aristotle candidate.. Related: coprime decomposition of integers, smooth-rough factorization. Cross-refs: erdos-461-complement, erdos-461-smooth-dvd"
+    "content": "**`smoothComponent_largest`**: if $d \\mid n$ and all prime factors of $d$ are $< t$, then $d \\mid s_t(n)$. This establishes $s_t(n)$ as the **largest** $t$-smooth divisor. Contains the file's **only sorry**. The proof strategy: decompose $n = s_t(n) \\cdot c$ where $\\gcd(d, c) = 1$ (since $d$ is $t$-smooth and $c$ has all primes $\\geq t$), then $d \\mid n$ and coprimality gives $d \\mid s_t(n)$.",
+    "mathContext": "$d \\mid n \\wedge (\\forall p \\text{ prime}, p \\mid d \\implies p < t) \\implies d \\mid s_t(n)$. Would require: (1) $n = s_t(n) \\cdot c$ where $c = (n.\\text{factors}.\\text{filter}(\\cdot \\geq t)).\\text{prod}$, (2) $\\gcd(d, c) = 1$ via `no_small_prime_in_complement`, (3) `Nat.Coprime.dvd_of_dvd_mul_right` to extract $d \\mid s_t(n)$. An excellent Aristotle proof search candidate.",
+    "significance": "critical",
+    "relatedConcepts": ["maximality", "coprime decomposition", "Nat.Coprime.dvd_of_dvd_mul_right"],
+    "prerequisites": ["ann-461-complement", "ann-461-smooth-dvd"]
   },
   {
-    "id": "erdos-461-count",
+    "id": "ann-461-count",
     "proofId": "erdos-461",
     "type": "definition",
-    "range": {
-      "startLine": 110,
-      "endLine": 112
-    },
+    "range": { "startLine": 110, "endLine": 112 },
     "title": "Distinct Count Function",
-    "content": "Defines $f(n,t) = |\\{s_t(m) : n < m \\leq n+t\\}|$ using `Finset.Icc` for the interval $[n+1, n+t]$, `Finset.image` to compute the set of smooth components, and `Finset.card` for the cardinality.",
-    "significance": "essential",
-    "mathContext": "combinatorial number theory. LaTeX: f(n,t) = |\\text{image}(s_t, \\{n+1, \\ldots, n+t\\})|. Lean: noncomputable def smoothDistinctCount (n t : ℕ) : ℕ := ((Finset.Icc (n + 1) (n + t)).image (smoothComponent t)).card. Technique: image cardinality of smooth component over a closed interval. Uses `Finset.Icc` rather than `Finset.range` for a natural match with the interval {n+1, ..., n+t}. Noncomputable since `smoothComponent` is noncomputable.. Cross-refs: erdos-461-smooth-component, erdos-461-conjecture"
+    "content": "**`smoothDistinctCount n t`** defines $f(n,t) = |\\{s_t(m) : n < m \\leq n+t\\}|$ using `Finset.Icc` for the interval $[n+1, n+t]$, `Finset.image` to compute the set of smooth components, and `Finset.card` for the cardinality.",
+    "mathContext": "$f(n,t) = |\\text{image}(s_t, \\{n+1, \\ldots, n+t\\})|$. Uses `Finset.Icc` rather than `Finset.range` for a natural match with the interval. Noncomputable since `smoothComponent` is noncomputable (involves factorization). The image operation collapses integers sharing the same smooth component.",
+    "significance": "critical",
+    "relatedConcepts": ["Finset.image", "counting distinct values", "Finset.Icc"],
+    "prerequisites": ["ann-461-smooth-component"]
   },
   {
-    "id": "erdos-461-conjecture",
+    "id": "ann-461-conjecture",
     "proofId": "erdos-461",
-    "type": "conjecture",
-    "range": {
-      "startLine": 116,
-      "endLine": 121
-    },
+    "type": "definition",
+    "range": { "startLine": 116, "endLine": 121 },
     "title": "Main Conjecture: Linear Growth",
-    "content": "Erdős Problem 461: there exists $C > 0$ and $t_0$ such that $f(n,t) \\geq C \\cdot t$ for all $n$ and $t \\geq t_0$. This conjectures that the number of distinct smooth components in a short interval grows linearly, the strongest possible bound since $f(n,t) \\leq t$ trivially.",
-    "significance": "essential",
-    "mathContext": "multiplicative number theory. LaTeX: \\exists C > 0,\\, \\exists t_0,\\, \\forall t \\geq t_0,\\, \\forall n,\\, f(n,t) \\geq C \\cdot t. Lean: def ErdosProblem461 : Prop := ∃ C : ℝ, 0 < C ∧ ∃ t₀ : ℕ, ∀ t : ℕ, t₀ ≤ t → ∀ n : ℕ, C * ↑t ≤ ↑(smoothDistinctCount n t). Technique: existence of a universal constant (asymptotic lower bound). Related: Erdős–Graham t/log t bound, smooth number distribution in short intervals. Refs: Erdős–Graham (1980), p.92. Cross-refs: erdos-461-eg-bound, erdos-461-upper-bound. Design: Quantifies ∀ n uniformly, requiring the bound to hold for ALL starting points, not just typical ones. This makes the conjecture substantially stronger than an average-case statement."
+    "content": "**`ErdosProblem461`**: $\\exists C > 0, \\exists t_0, \\forall t \\geq t_0, \\forall n, f(n,t) \\geq C \\cdot t$. The conjecture asks for linear growth of distinct smooth components, the strongest possible bound since $f(n,t) \\leq t$. Quantifies $\\forall n$ uniformly, making it stronger than an average-case statement.",
+    "mathContext": "The conjecture says $f(n,t) = \\Theta(t)$ since the trivial upper bound $f(n,t) \\leq t$ is already proved. The $\\forall n$ quantification demands the bound holds for ALL starting points, not just typical ones. Compare with the analogous question for prime-counting: the number of primes in $(n, n+t)$ is $\\sim t/\\log t$ by PNT, but short interval results require additional sieve assumptions.",
+    "significance": "critical",
+    "relatedConcepts": ["linear growth conjecture", "uniform bound", "open problem"],
+    "prerequisites": ["ann-461-count"]
   },
   {
-    "id": "erdos-461-eg-bound",
+    "id": "ann-461-eg-bound",
     "proofId": "erdos-461",
-    "type": "result",
-    "range": {
-      "startLine": 125,
-      "endLine": 129
-    },
+    "type": "theorem",
+    "range": { "startLine": 125, "endLine": 129 },
     "title": "Erdős–Graham Lower Bound",
-    "content": "The known bound $f(n,t) \\gg t/\\log t$ for all $n$ and large $t$. This falls a logarithmic factor short of the conjectured linear bound. The gap between $t/\\log t$ and $t$ is the central open question.",
-    "significance": "essential",
-    "mathContext": "multiplicative number theory. LaTeX: \\exists C > 0,\\, \\exists t_0,\\, \\forall t \\geq t_0,\\, \\forall n,\\, f(n,t) \\geq C \\cdot \\frac{t}{\\log t}. Lean: axiom erdos_graham_lower : ∃ C : ℝ, 0 < C ∧ ∃ t₀ : ℕ, ∀ t : ℕ, t₀ ≤ t → ∀ n : ℕ, C * ↑t / Real.log ↑t ≤ ↑(smoothDistinctCount n t). Technique: axiomatized (original proof uses sieve methods and multiplicative function estimates). Axiomatized since the proof requires detailed sieve theory not yet in Mathlib. The statement uses `Real.log` for the natural logarithm.. Related: Hildebrand's smooth number estimates, Tenenbaum's Introduction to Analytic and Probabilistic Number Theory. Refs: Erdős–Graham (1980), p.92. Cross-refs: erdos-461-conjecture"
+    "content": "**`erdos_graham_lower`** (axiom): $f(n,t) \\geq C \\cdot t/\\log t$ for all $n$ and large $t$. This falls a logarithmic factor short of the conjectured linear bound. Axiomatized since the proof requires sieve methods not yet in Mathlib.",
+    "mathContext": "$\\exists C > 0, \\exists t_0, \\forall t \\geq t_0, \\forall n : f(n,t) \\geq C \\cdot t / \\log t$. The original proof in Erdős–Graham (1980, p.92) uses multiplicative function estimates and sieve-theoretic arguments. The logarithmic gap between $t/\\log t$ and $t$ is reminiscent of the prime number theorem gap: the number of primes in $[1, t]$ is $\\sim t/\\log t$ rather than $\\Theta(t)$.",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős-Graham bound", "sieve methods", "logarithmic gap"],
+    "prerequisites": ["ann-461-conjecture"]
   },
   {
-    "id": "erdos-461-boundary-cases",
+    "id": "ann-461-boundary-cases",
     "proofId": "erdos-461",
-    "type": "result",
-    "range": {
-      "startLine": 133,
-      "endLine": 172
-    },
+    "type": "theorem",
+    "range": { "startLine": 133, "endLine": 172 },
     "title": "Boundary Cases and Basic Properties",
-    "content": "Five fully proved boundary results. `smoothComponent_one`: $s_t(1) = 1$. `smoothComponent_t_le_one`: $s_t(n) = 1$ when $t \\leq 1$ (no primes below 1). `smoothDistinctCount_le`: $f(n,t) \\leq t$ (trivial upper bound from interval size). `smoothDistinctCount_zero`: $f(n,0) = 0$. `smoothComponent_zero`: $s_t(0) = 1$. `smoothComponent_prime`: $s_t(p) = p$ if $p < t$, else $1$.",
-    "significance": "supporting",
-    "mathContext": "multiplicative number theory. LaTeX: s_t(1) = 1,\\quad t \\leq 1 \\implies s_t(n) = 1,\\quad f(n,t) \\leq t,\\quad f(n,0) = 0. Technique: direct computation using Nat.factors properties, Finset.card_image_le, and interval cardinality. All five theorems are fully proved with no sorry. `smoothDistinctCount_le` uses the key fact that image cardinality ≤ domain cardinality and `Finset.card_Icc`. `smoothComponent_prime` uses `Nat.factors_prime` to reduce to a singleton list.. Related: Nat.factors_one, Nat.factors_prime, Finset.card_Icc. Cross-refs: erdos-461-smooth-component, erdos-461-count"
-  },
-  {
-    "id": "erdos-461-upper-bound",
-    "proofId": "erdos-461",
-    "type": "result",
-    "range": {
-      "startLine": 148,
-      "endLine": 154
-    },
-    "title": "Trivial Upper Bound f(n,t) ≤ t",
-    "content": "The count $f(n,t) \\leq t$ since the image of a $t$-element set has at most $t$ elements. This is tight in the sense that the conjecture asks whether $f(n,t) \\geq Ct$ — i.e., whether the count is $\\Theta(t)$. Proved using `Finset.card_image_le` and `Finset.card_Icc`.",
-    "significance": "essential",
-    "mathContext": "combinatorics. LaTeX: f(n,t) \\leq t. Lean: theorem smoothDistinctCount_le (n t : ℕ) : smoothDistinctCount n t ≤ t. Technique: image cardinality ≤ domain cardinality, combined with interval cardinality calculation. Fully proved. Together with the conjecture $f(n,t) \\geq Ct$, this would give $f(n,t) = \\Theta(t)$.. Cross-refs: erdos-461-conjecture, erdos-461-count"
+    "content": "Six results are **proved**: `smoothComponent_one` ($s_t(1) = 1$), `smoothComponent_zero` ($s_t(0) = 1$), `smoothComponent_t_le_one` ($t \\leq 1 \\implies s_t(n) = 1$), `smoothComponent_prime` ($s_t(p) = p$ if $p < t$, else $1$), `smoothDistinctCount_le` ($f(n,t) \\leq t$), `smoothDistinctCount_zero` ($f(n,0) = 0$). All fully proved, no sorry.",
+    "mathContext": "The prime case $s_t(p) = p$ or $1$ uses `Nat.factors_prime` reducing to a singleton list $[p]$, then the filter either keeps or drops $p$ based on $p < t$. The upper bound $f(n,t) \\leq t$ uses `Finset.card_image_le` ($|\\text{image}(f, S)| \\leq |S|$) combined with `Finset.card_Icc` ($|[n+1, n+t]| = t$).",
+    "significance": "key",
+    "relatedConcepts": ["boundary analysis", "Nat.factors_prime", "Finset.card_image_le"],
+    "prerequisites": ["ann-461-smooth-component", "ann-461-count"]
   }
 ]

--- a/src/data/proofs/erdos-461/meta.json
+++ b/src/data/proofs/erdos-461/meta.json
@@ -23,24 +23,29 @@
     "erdosProblemStatus": "open",
     "mathlibDependencies": [
       {
-        "theorem": "Mathlib.Data.Nat.Prime.Basic",
-        "description": "Basic from Mathlib.Data.Nat.Prime"
+        "theorem": "Nat.factors",
+        "description": "Prime factorization with multiplicity for natural numbers",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
       },
       {
-        "theorem": "Mathlib.Data.Finset.Basic",
-        "description": "Basic from Mathlib.Data.Finset"
+        "theorem": "Finset.Icc",
+        "description": "Closed intervals [a, b] as finite sets",
+        "module": "Mathlib.Data.Finset.Basic"
       },
       {
-        "theorem": "Mathlib.Data.Finset.Card",
-        "description": "Card from Mathlib.Data.Finset"
+        "theorem": "Finset.card_image_le",
+        "description": "Image cardinality is at most domain cardinality",
+        "module": "Mathlib.Data.Finset.Card"
       },
       {
-        "theorem": "Mathlib.Data.Real.Basic",
-        "description": "Basic from Mathlib.Data.Real"
+        "theorem": "Real.log",
+        "description": "Natural logarithm on real numbers for the Erdős-Graham bound",
+        "module": "Mathlib.Data.Real.Basic"
       },
       {
-        "theorem": "Mathlib.Tactic",
-        "description": "Tactic from Mathlib"
+        "theorem": "Nat.Prime.dvd_mul",
+        "description": "Prime divisibility of products for list membership lemmas",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
       }
     ],
     "originalContributions": [
@@ -52,15 +57,15 @@
     ]
   },
   "overview": {
-    "historicalContext": "This problem originates from Erdős and Graham's 1980 monograph (p.92). They introduced the $t$-smooth component of an integer — the largest divisor whose prime factors are all $< t$ — and asked whether the number of distinct smooth components in a short interval $\\{n+1, \\ldots, n+t\\}$ is linear in $t$. They proved the weaker bound $f(n,t) \\gg t/\\log t$. The problem connects smooth number theory to short interval statistics, a topic central to analytic number theory.",
-    "problemStatement": "Define $s_t(n)$ as the largest divisor of $n$ all of whose prime factors are $< t$. Let $f(n,t) = |\\{s_t(m) : n < m \\leq n+t\\}|$. Is $f(n,t) \\gg t$ uniformly in $n$?",
-    "proofStrategy": "The formalization takes a constructive approach: `smoothComponent` is defined via `Nat.factors` filtering (not axiomatized), enabling proved properties. Core theorems `smoothComponent_dvd` ($s_t(n) \\mid n$), `smoothComponent_smooth` (all prime factors $< t$), and `smoothComponent_pos` ($s_t(n) > 0$) are all fully proved. The maximality theorem `smoothComponent_largest` remains a `sorry` with documented proof strategy via coprime decomposition. The counting function `smoothDistinctCount` uses `Finset.Icc` and `Finset.image`. The main conjecture `ErdosProblem461` asks for $f(n,t) \\geq Ct$, and the known bound $f(n,t) \\gg t/\\log t$ is axiomatized.",
+    "historicalContext": "This problem originates from Erdős and Graham's 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (Monographie no. 28, L'Enseignement Mathématique, p.92). They introduced the $t$-smooth component of an integer — the largest divisor whose prime factors are all $< t$ — and asked whether the number of distinct smooth components in a short interval $\\{n+1, \\ldots, n+t\\}$ is linear in $t$.\n\nErdős and Graham proved the weaker bound $f(n,t) \\gg t/\\log t$ using sieve methods and multiplicative function estimates. The problem connects to the broader study of smooth (or 'friable') numbers, a central topic in analytic number theory with applications to cryptography (factoring algorithms like the number field sieve rely on smooth number density). Key related work includes Hildebrand's 1986 estimates for $\\Psi(x, y)$ (the count of $y$-smooth numbers up to $x$), Tenenbaum's probabilistic approach, and Ford's 2008 Annals paper on divisor distribution.\n\nThe problem remains OPEN: the logarithmic gap between the known $t/\\log t$ and the conjectured $t$ has not been closed.",
+    "problemStatement": "Define $s_t(n)$ as the largest divisor of $n$ all of whose prime factors are $< t$. Let $f(n,t) = |\\{s_t(m) : n < m \\leq n+t\\}|$. Is $f(n,t) \\gg t$ uniformly in $n$?\n\nFormally: $\\exists C > 0, \\exists t_0, \\forall t \\geq t_0, \\forall n : f(n,t) \\geq C \\cdot t$.",
+    "proofStrategy": "The formalization takes a constructive approach: `smoothComponent` is defined via `Nat.factors` filtering (not axiomatized), enabling proved properties. Core theorems `smoothComponent_dvd` ($s_t(n) \\mid n$), `smoothComponent_smooth` (all prime factors $< t$), and `smoothComponent_pos` ($s_t(n) > 0$) are all fully proved. The maximality theorem `smoothComponent_largest` remains a `sorry` with documented proof strategy via coprime decomposition. The counting function uses `Finset.Icc` and `Finset.image`. The Erdős–Graham bound $f(n,t) \\gg t/\\log t$ is axiomatized.",
     "keyInsights": [
-      "The $t$-smooth component captures the 'smooth part' of an integer — the product of all prime power divisors with primes $< t$",
-      "Erdős–Graham proved $f(n,t) \\gg t/\\log t$, falling short of the conjectured linear bound by a logarithmic factor",
-      "The trivial upper bound $f(n,t) \\leq t$ is proved; the conjecture asks for $f(n,t) = \\Theta(t)$",
-      "The formalization is notably strong: most theorems are fully proved, with only the maximality property `smoothComponent_largest` as a sorry",
-      "The smooth-rough decomposition $n = s_t(n) \\cdot c$ (where all primes of $c$ are $\\geq t$) is key infrastructure prepared for the maximality proof"
+      "**Constructive smooth component:** $s_t(n)$ is defined as `(n.factors.filter (· < t)).prod`, not axiomatized — enabling fully proved core properties (divisibility, smoothness, positivity)",
+      "**Erdős–Graham bound falls a log factor short:** The known $f(n,t) \\gg t/\\log t$ vs conjectured $f(n,t) \\gg t$ parallels the prime counting gap ($\\pi(t) \\sim t/\\log t$ vs $t$)",
+      "**Near-complete formalization:** Only 1 sorry (`smoothComponent_largest`) out of ~15 results; the coprime decomposition infrastructure is already in place",
+      "**Uniform $\\forall n$ quantification:** The conjecture requires the bound for ALL starting points, not just typical ones — substantially stronger than an average-case statement",
+      "**Smooth-rough decomposition as key tool:** The factorization $n = s_t(n) \\cdot r_t(n)$ where $\\gcd(s_t(n), r_t(n)) = 1$ underlies the maximality proof strategy"
     ]
   },
   "sections": [
@@ -69,35 +74,41 @@
       "title": "Smooth Components",
       "startLine": 22,
       "endLine": 106,
-      "summary": "Constructive definition of `smoothComponent` via `Nat.factors` filtering. Includes infrastructure lemmas (`list_prod_filter_dvd`, `prime_dvd_list_prod_mem`, `no_small_prime_in_complement`) and three core proved theorems: $s_t(n) \\mid n$, all prime factors $< t$, $s_t(n) > 0$. The maximality theorem `smoothComponent_largest` has `sorry` with a documented coprime decomposition strategy."
+      "summary": "Constructive definition of $s_t(n) = (n.\\text{factors}.\\text{filter}(\\cdot < t)).\\text{prod}$. **Proves** infrastructure lemmas, $s_t(n) \\mid n$, smoothness, positivity, complement coprimality. The maximality `smoothComponent_largest` has the file's only sorry."
     },
     {
       "id": "counting",
       "title": "Counting Distinct Smooth Components",
       "startLine": 108,
       "endLine": 112,
-      "summary": "Defines $f(n,t) = |\\text{image}(s_t, [n+1, n+t])|$ using `Finset.Icc` and `Finset.image`. Noncomputable since `smoothComponent` involves factorization."
+      "summary": "Defines $f(n,t) = |\\text{image}(s_t, [n+1, n+t])|$ via `Finset.Icc` and `Finset.image`."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture",
       "startLine": 114,
       "endLine": 121,
-      "summary": "States `ErdosProblem461`: $\\exists C > 0,\\, \\exists t_0,\\, \\forall t \\geq t_0,\\, \\forall n,\\, f(n,t) \\geq Ct$. Quantifies uniformly over all starting points $n$."
+      "summary": "States `ErdosProblem461`: $\\exists C > 0, \\exists t_0, \\forall t \\geq t_0, \\forall n : f(n,t) \\geq Ct$."
     },
     {
       "id": "known-results",
       "title": "Known Results",
       "startLine": 123,
       "endLine": 129,
-      "summary": "Axiomatizes the Erdős–Graham bound $f(n,t) \\geq C \\cdot t/\\log t$ using `Real.log`. The logarithmic gap between this and the conjectured $Ct$ is the open question."
+      "summary": "Axiomatizes the Erdős–Graham bound $f(n,t) \\geq C \\cdot t/\\log t$ using `Real.log`."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
       "startLine": 131,
       "endLine": 172,
-      "summary": "Six fully proved results: $s_t(1) = 1$, $s_t(0) = 1$, $t \\leq 1 \\implies s_t(n) = 1$, $s_t(p) = p$ if $p < t$ else $1$, $f(n,t) \\leq t$, and $f(n,0) = 0$. All use `Nat.factors` properties and `Finset` cardinality bounds."
+      "summary": "**Proves** 6 results: $s_t(1) = 1$, $s_t(0) = 1$, $t \\leq 1 \\implies s_t(n) = 1$, $s_t(p)$ for primes, $f(n,t) \\leq t$, $f(n,0) = 0$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "erdos-450",
+      "relationship": "Both problems study density phenomena in short intervals: #450 asks about divisor density in $(n, 2n)$ intervals, #461 asks about distinct smooth component counts. Both connect to Ford's work on divisor distribution and the anatomy of integers."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Added `mathContext`, `relatedConcepts`, and `prerequisites` to all 12 annotations
- Fixed annotation startLine to point to actual Lean constructs (not section comments)
- Deepened `historicalContext` with Hildebrand 1986, Tenenbaum probabilistic approach, cryptography connections
- Added `crossReferences` linking to erdos-450 (both study density in short intervals)
- Fixed `mathlibDependencies` with proper theorem names and descriptions
- Expanded `keyInsights` to 5 items with LaTeX and bold formatting

## Test plan
- [x] `pnpm annotations:build` passes with zero erdos-461-specific warnings
- [x] All annotations have valid types (`concept`, `definition`, `lemma`, `theorem`)
- [x] All annotations have valid significance values (`critical`, `key`, `supporting`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)