### PR TITLE
enrich: deepen erdos-780 with mathContext, cross-refs, and historical context

### DIFF
--- a/src/data/proofs/erdos-780/annotations.json
+++ b/src/data/proofs/erdos-780/annotations.json
@@ -5,20 +5,59 @@
     "range": { "startLine": 1, "endLine": 19 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "**Erdős Problem #780: Chromatic Number of Kneser Hypergraphs**\n\nIf n ≥ kr + (t-1)(k-1), any t-coloring of r-sets has k monochromatic disjoint edges.\n\n**Status:** SOLVED (Alon-Frankl-Lovász 1986)\n**Special case k=2:** Kneser's conjecture, proved by Lovász 1978",
-    "mathContext": "The Kneser hypergraph KG^r(n,k) has r-subsets as vertices and k-tuples of disjoint r-sets as edges.",
+    "content": "**Erdős Problem #780: Chromatic Number of Kneser Hypergraphs**\n\nIf $n \\geq kr + (t-1)(k-1)$, any $t$-coloring of $r$-sets has $k$ monochromatic disjoint edges.\n\n**Status:** SOLVED (Alon-Frankl-Lovász 1986)\n**Special case $k=2$:** Kneser's conjecture, proved by Lovász 1978 using the Borsuk-Ulam theorem.",
+    "mathContext": "The Kneser hypergraph $KG^r(n,k)$ has $r$-element subsets of $[n]$ as vertices and $k$-tuples of pairwise disjoint $r$-sets as hyperedges. Its chromatic number $\\chi(KG^r(n,k)) = \\lceil (n - r(k-1))/(k-1) \\rceil$. The $k=2$ case gives the classical Kneser graph $KG(n,r)$ with $\\chi = n - 2r + 2$. The problem connects to topological combinatorics via the Borsuk-Ulam theorem and the nerve/connectivity of the independence complex.",
     "significance": "critical",
-    "relatedConcepts": ["Kneser graph", "Chromatic number", "Borsuk-Ulam theorem", "Intersecting families"]
+    "relatedConcepts": ["Kneser graph", "chromatic number", "Borsuk-Ulam theorem", "intersecting families", "topological combinatorics"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e780-imports",
+    "proofId": "erdos-780",
+    "range": { "startLine": 21, "endLine": 28 },
+    "type": "concept",
+    "title": "Imports and Setup",
+    "content": "Imports `SetFamily.Intersecting` (for intersecting family theory), `SimpleGraph.Basic` (graph infrastructure), `Finset.Basic` (finite set operations), and `Nat.Choose.Basic` (binomial coefficients for Erdős-Ko-Rado). Opens the `Finset` namespace for convenient finite set notation.",
+    "mathContext": "The formalization works within Lean 4's `Finset` framework, using finite subsets of `Fin n` to model the ground set $[n] = \\{0, 1, \\ldots, n-1\\}$. Hyperedges are represented as `{S : Finset (Fin n) // S.card = r}`, leveraging subtype for the uniformity constraint.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset", "SetFamily.Intersecting", "SimpleGraph", "Nat.choose"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e780-hypergraph",
+    "proofId": "erdos-780",
+    "range": { "startLine": 36, "endLine": 44 },
+    "type": "definition",
+    "title": "Uniform Hypergraph and Disjointness",
+    "content": "**`UniformHypergraph α r`**: An $r$-uniform hypergraph on vertex type $\\alpha$ is a subtype of $r$-element `Finset`s.\n\n**`completeHypergraph n r`**: The complete $r$-uniform hypergraph on $n$ vertices uses `Fin n`.\n\n**`disjointEdges`**: Two edges are disjoint if they share no vertices (wraps `Disjoint`).",
+    "mathContext": "An $r$-uniform hypergraph $H = (V, E)$ has $E \\subseteq \\binom{V}{r}$. The complete $r$-uniform hypergraph $K_n^{(r)}$ has $E = \\binom{[n]}{r}$, so $|E| = \\binom{n}{r}$. Two edges $e_1, e_2$ are disjoint iff $e_1 \\cap e_2 = \\emptyset$, which is formalized via Lean's `Disjoint` on lattice elements.",
+    "significance": "key",
+    "relatedConcepts": ["uniform hypergraph", "complete hypergraph", "disjoint sets", "Finset subtype"],
+    "prerequisites": ["ann-e780-imports"]
   },
   {
     "id": "ann-e780-pairwise",
     "proofId": "erdos-780",
-    "range": { "startLine": 45, "endLine": 47 },
+    "range": { "startLine": 46, "endLine": 54 },
     "type": "definition",
-    "title": "Pairwise Disjoint Edges",
-    "content": "**PairwiseDisjoint:** A set of hyperedges is pairwise disjoint if no two share a vertex.\n\nThis forms a matching in the hypergraph. The problem asks for k such edges in one color.",
+    "title": "Matchings and Colorings",
+    "content": "**`PairwiseDisjoint edges`**: A set of hyperedges is pairwise disjoint if no two share a vertex. This is a $k$-matching.\n\n**`EdgeColoring n r t`**: A $t$-coloring assigns each edge of $K_n^{(r)}$ a color in $\\text{Fin}\\, t$.\n\n**`colorClass`**: The set of edges receiving color $i$.",
+    "mathContext": "A matching of size $k$ in a hypergraph is a set of $k$ pairwise disjoint edges. The problem asks: for what $n$ does every $t$-coloring of $K_n^{(r)}$ contain a monochromatic $k$-matching? The coloring function $c : \\binom{[n]}{r} \\to [t]$ partitions the edge set into $t$ color classes $C_i = c^{-1}(i)$.",
     "significance": "key",
-    "leanSymbol": "PairwiseDisjoint"
+    "relatedConcepts": ["matching", "graph coloring", "color class", "pigeonhole"],
+    "prerequisites": ["ann-e780-hypergraph"]
+  },
+  {
+    "id": "ann-e780-kneser-structure",
+    "proofId": "erdos-780",
+    "range": { "startLine": 63, "endLine": 73 },
+    "type": "definition",
+    "title": "Kneser Hypergraph Structure",
+    "content": "**`KneserHypergraph n r k`**: A structure encoding the Kneser hypergraph $KG^r(n,k)$ with fields for vertices ($r$-subsets), edges ($k$-tuples of pairwise disjoint $r$-sets), uniformity, and inclusion constraints.\n\n**`chromaticNumber n r k`** (axiom): The chromatic number of $KG^r(n,k)$.",
+    "mathContext": "The Kneser hypergraph $KG^r(n,k)$ has vertex set $\\binom{[n]}{r}$ and edge set consisting of all collections of $k$ pairwise disjoint $r$-subsets. Its chromatic number $\\chi(KG^r(n,k))$ is the minimum $t$ such that $\\binom{[n]}{r}$ can be $t$-colored with no monochromatic $k$-matching. The AFL theorem shows $\\chi(KG^r(n,k)) = \\lceil (n - r(k-1))/(k-1) \\rceil$. The `chromaticNumber` is axiomatized since defining it requires quantification over all colorings.",
+    "significance": "critical",
+    "relatedConcepts": ["Kneser hypergraph", "chromatic number", "vertex coloring", "independence number"],
+    "prerequisites": ["ann-e780-pairwise"]
   },
   {
     "id": "ann-e780-threshold",
@@ -26,69 +65,83 @@
     "range": { "startLine": 81, "endLine": 82 },
     "type": "definition",
     "title": "The Threshold Function",
-    "content": "**threshold k r t:** n₀ = kr + (t-1)(k-1)\n\nThis is the exact threshold. For n ≥ n₀, a monochromatic k-matching exists. For n < n₀, a coloring avoiding it exists.",
+    "content": "**`threshold k r t`** $= kr + (t-1)(k-1)$: the exact threshold for $n$. For $n \\geq n_0$, a monochromatic $k$-matching exists in every $t$-coloring. For $n < n_0$, a $t$-coloring avoiding it exists.",
+    "mathContext": "$n_0(k, r, t) = kr + (t-1)(k-1) = k(r + t - 2) + 1 - (t-1)$. For $k = 2$: $n_0 = 2r + t - 1$, and $\\chi(KG(n,r)) = n - 2r + 2$. The threshold emerges from a pigeonhole argument combined with topological connectivity: Lovász showed the independence complex of $KG(n,r)$ is $(n - 2r)$-connected, which forces $\\chi \\geq n - 2r + 2$.",
     "significance": "critical",
-    "leanSymbol": "threshold"
+    "relatedConcepts": ["threshold function", "pigeonhole principle", "topological connectivity"],
+    "prerequisites": ["ann-e780-pairwise"]
   },
   {
     "id": "ann-e780-afl",
     "proofId": "erdos-780",
-    "range": { "startLine": 84, "endLine": 89 },
-    "type": "axiom",
-    "title": "Alon-Frankl-Lovász (1986)",
-    "content": "**alon_frankl_lovasz_1986:** The main theorem.\n\nFor n ≥ kr + (t-1)(k-1), any t-coloring of the complete r-uniform hypergraph contains a monochromatic k-matching.\n\nProved using topological methods (Borsuk-Ulam theorem).",
+    "range": { "startLine": 84, "endLine": 94 },
+    "type": "theorem",
+    "title": "Alon-Frankl-Lovász Main Theorem (1986)",
+    "content": "**`alon_frankl_lovasz_1986`** (axiom): For $n \\geq kr + (t-1)(k-1)$ with $r \\geq 1$, $k \\geq 2$, $t \\geq 1$, any $t$-coloring of $K_n^{(r)}$ contains a monochromatic $k$-matching.\n\n**`kneser_hypergraph_chromatic_number`** (axiom): Equivalent formulation as $\\chi(KG^r(n,k)) = \\lceil (n - r(k-1))/(k-1) \\rceil$.",
+    "mathContext": "The AFL proof proceeds by: (1) reducing to a topological problem about the connectivity of the independence complex $\\text{Ind}(KG^r(n,k))$, (2) applying a generalized Borsuk-Ulam theorem to show this complex is sufficiently connected, (3) deducing the chromatic lower bound from the Lusternik-Schnirelmann category. The paper appeared in *Transactions AMS* 298 (1986), 359-370. The formula uses `Nat.ceil` of an integer division since $\\chi$ must be an integer.",
     "significance": "critical",
-    "leanSymbol": "alon_frankl_lovasz_1986"
+    "relatedConcepts": ["Borsuk-Ulam theorem", "independence complex", "Lusternik-Schnirelmann", "topological lower bound"],
+    "prerequisites": ["ann-e780-threshold", "ann-e780-kneser-structure"]
   },
   {
     "id": "ann-e780-tight",
     "proofId": "erdos-780",
-    "range": { "startLine": 105, "endLine": 113 },
-    "type": "axiom",
+    "range": { "startLine": 102, "endLine": 113 },
+    "type": "theorem",
     "title": "Tightness Construction",
-    "content": "**tightness_construction:** The bound is optimal.\n\nFor n = kr - 1 + (t-1)(k-1), partition [n] = X₁ ∪ X₂ ∪ ... ∪ Xₜ where |X₁| = kr-1 and |Xᵢ| = k-1.\n\nColor by first non-empty intersection. This avoids k disjoint monochromatic edges.",
+    "content": "**`tightBound k r t`** $= kr - 1 + (t-1)(k-1)$: one less than the threshold.\n\n**`tightness_construction`** (axiom): For $n = n_0 - 1$, there exists a $t$-coloring with no monochromatic $k$-matching. The construction partitions $[n] = X_1 \\cup X_2 \\cup \\cdots \\cup X_t$ with $|X_1| = kr - 1$ and $|X_i| = k - 1$ for $i \\geq 2$, coloring each edge by its first non-empty intersection.",
+    "mathContext": "The tightness construction is the standard 'sunflower-avoiding' partition coloring. Each edge $e \\in \\binom{[n]}{r}$ receives color $i$ where $i$ is the smallest index with $e \\cap X_i \\neq \\emptyset$. Since $|X_1| = kr - 1$, any $k$ disjoint $r$-sets colored 1 would require $kr$ elements in $X_1$, a contradiction. For colors $i \\geq 2$, each $r$-set colored $i$ must contain an element of $X_i$, but $|X_i| = k-1$ limits the matching size to $k-1$.",
     "significance": "key",
-    "leanSymbol": "tightness_construction"
+    "relatedConcepts": ["tightness", "extremal construction", "partition coloring", "sunflower"],
+    "prerequisites": ["ann-e780-afl"]
   },
   {
     "id": "ann-e780-kneser",
     "proofId": "erdos-780",
-    "range": { "startLine": 123, "endLine": 125 },
-    "type": "axiom",
-    "title": "Kneser's Conjecture (k=2)",
-    "content": "**kneser_conjecture:** χ(KG(n,r)) = n - 2r + 2 for n ≥ 2r.\n\nThis is the k=2 case of the general theorem. Conjectured by Kneser (1955), proved by Lovász (1978).\n\nExample: χ(KG(5,2)) = 3 (Petersen graph).",
+    "range": { "startLine": 123, "endLine": 132 },
+    "type": "theorem",
+    "title": "Kneser's Conjecture ($k = 2$)",
+    "content": "**`kneser_conjecture`** (axiom): $\\chi(KG(n,r)) = n - 2r + 2$ for $n \\geq 2r$. Conjectured by Kneser (1955), proved by Lovász (1978).\n\n**`KneserGraph n r`**: The Kneser graph with $r$-subsets of $[n]$ as vertices.\n\n**`kneserAdj`**: Two $r$-sets are adjacent iff disjoint.",
+    "mathContext": "Lovász's 1978 proof in *J. Comb. Theory A* 25, 319-324 was the first application of algebraic topology (specifically the Borsuk-Ulam theorem) to combinatorics. He showed the neighborhood complex $\\mathcal{N}(KG(n,r))$ is $(n - 2r)$-connected, giving $\\chi(KG(n,r)) \\geq n - 2r + 2$. The upper bound follows from the coloring: assign color $\\min(e)$ if $\\min(e) \\leq n - 2r + 1$, else a final color. Schrijver (1978) strengthened this to the stable Kneser graph (vertex-critical subgraph).",
     "significance": "critical",
-    "leanSymbol": "kneser_conjecture"
+    "relatedConcepts": ["Kneser conjecture", "Lovász 1978", "neighborhood complex", "Schrijver graph"],
+    "prerequisites": ["ann-e780-afl"]
   },
   {
-    "id": "ann-e780-petersen",
+    "id": "ann-e780-small-cases",
     "proofId": "erdos-780",
-    "range": { "startLine": 140, "endLine": 141 },
-    "type": "axiom",
-    "title": "The Petersen Graph",
-    "content": "**petersen_chromatic:** KG(5,2) is the Petersen graph with χ = 3.\n\nVertices are 2-subsets of {1,2,3,4,5}. Adjacent if disjoint.\n\nThis is the most famous example of a Kneser graph.",
+    "range": { "startLine": 140, "endLine": 150 },
+    "type": "theorem",
+    "title": "Small Cases",
+    "content": "Four explicit chromatic number computations (all axiomatized):\n- **`petersen_chromatic`**: $\\chi(KG(5,2)) = 3$ — the **Petersen graph**, with vertices as 2-subsets of $\\{1,\\ldots,5\\}$, adjacent when disjoint.\n- **`kg_7_3_chromatic`**: $\\chi(KG(7,3)) = 2$\n- **`kg_2r_r_chromatic`**: $\\chi(KG(2r,r)) = 2$ — $KG(2r,r)$ is a perfect matching\n- **`kg_2r_plus_1_r`**: $\\chi(KG(2r+1,r)) = 3$",
+    "mathContext": "For $KG(5,2)$: the 10 vertices are 2-subsets of $[5]$, with $\\binom{5}{2} = 10$ vertices and 15 edges. This is the Petersen graph, the smallest vertex-transitive non-Hamiltonian graph. For $KG(2r,r)$: every pair of complementary $r$-subsets forms the only matching, giving $\\alpha(KG(2r,r)) = \\binom{2r-1}{r-1}$ and $\\chi = 2$. For $KG(2r+1,r)$: the formula gives $\\chi = 2r+1-2r+2 = 3$; when $r = 1$ this is the odd cycle $C_{2r+1}$.",
     "significance": "supporting",
-    "leanSymbol": "petersen_chromatic"
+    "relatedConcepts": ["Petersen graph", "vertex-transitive graph", "odd cycle", "perfect matching"],
+    "prerequisites": ["ann-e780-kneser"]
   },
   {
     "id": "ann-e780-ekr",
     "proofId": "erdos-780",
     "range": { "startLine": 160, "endLine": 165 },
-    "type": "axiom",
+    "type": "theorem",
     "title": "Erdős-Ko-Rado Connection",
-    "content": "**erdos_ko_rado:** Maximum intersecting family of r-subsets of [n] has size C(n-1,r-1) for n ≥ 2r.\n\nThis equals the independence number of the Kneser graph.\n\nIntersecting families are independent sets in KG(n,r).",
+    "content": "**`erdos_ko_rado`** (axiom): The maximum intersecting family of $r$-subsets of $[n]$ has size $\\binom{n-1}{r-1}$ for $n \\geq 2r$. This equals the independence number $\\alpha(KG(n,r))$, connecting Kneser chromatic number to intersecting families.",
+    "mathContext": "The Erdős-Ko-Rado theorem (1961, *Quart. J. Math.*) shows that for $n \\geq 2r$, the maximum intersecting family $\\mathcal{F} \\subseteq \\binom{[n]}{r}$ with $|A \\cap B| \\geq 1$ for all $A, B \\in \\mathcal{F}$ satisfies $|\\mathcal{F}| \\leq \\binom{n-1}{r-1}$, achieved by fixing an element. An intersecting family is an independent set in $KG(n,r)$, so $\\alpha(KG(n,r)) = \\binom{n-1}{r-1}$. The fractional chromatic number is $\\chi_f(KG(n,r)) = n/r$.",
     "significance": "key",
-    "leanSymbol": "erdos_ko_rado"
+    "relatedConcepts": ["Erdős-Ko-Rado theorem", "intersecting family", "independence number", "fractional chromatic number"],
+    "prerequisites": ["ann-e780-kneser"]
   },
   {
     "id": "ann-e780-main",
     "proofId": "erdos-780",
     "range": { "startLine": 173, "endLine": 179 },
     "type": "theorem",
-    "title": "Main Result",
-    "content": "**erdos_780_main:** Complete statement of the Alon-Frankl-Lovász theorem.\n\nFor n ≥ kr + (t-1)(k-1), any t-coloring of r-subsets of [n] contains k pairwise disjoint subsets of the same color.",
+    "title": "Main Result Theorem",
+    "content": "**`erdos_780_main`**: Restates the AFL theorem as a proved `theorem` (trivially from the axiom). For $n \\geq kr + (t-1)(k-1)$, any $t$-coloring contains a monochromatic $k$-matching.",
+    "mathContext": "This is a thin wrapper: `erdos_780_main ... := alon_frankl_lovasz_1986 ...`. The distinction between `axiom` and `theorem` matters for Aristotle proof search: axioms are skipped, but this `theorem` is already proved (by invoking the axiom). The formalization pattern of axiomatizing deep results and wrapping them in proved theorems is standard for Lean formalizations of results not yet in Mathlib.",
     "significance": "critical",
-    "leanSymbol": "erdos_780_main"
+    "relatedConcepts": ["axiom wrapper", "formal verification", "Aristotle-friendly"],
+    "prerequisites": ["ann-e780-afl"]
   },
   {
     "id": "ann-e780-summary",
@@ -96,8 +149,10 @@
     "range": { "startLine": 188, "endLine": 198 },
     "type": "theorem",
     "title": "Summary Theorem",
-    "content": "**erdos_780_summary** combines the main AFL 1986 theorem with Kneser's conjecture into a single statement. The proof uses exact ⟨AFL axiom, Kneser axiom⟩.\n\nStatus: SOLVED",
+    "content": "**`erdos_780_summary`**: Combines the AFL main theorem with Kneser's conjecture into a single conjunction. **Proved** via `⟨alon_frankl_lovasz_1986 ..., kneser_conjecture ...⟩`. Status: SOLVED.",
+    "mathContext": "The summary bundles two results: (1) the general AFL theorem for all $n, r, k, t$ above threshold, and (2) the $k=2$ special case giving $\\chi(KG(n,r)) = n - 2r + 2$. This provides a single theorem capturing the full resolution of Erdős Problem #780. Both components are derived from axioms, so 0 sorries remain.",
     "significance": "critical",
-    "leanSymbol": "erdos_780_summary"
+    "relatedConcepts": ["summary theorem", "problem resolution", "0 sorries"],
+    "prerequisites": ["ann-e780-main", "ann-e780-kneser"]
   }
 ]

--- a/src/data/proofs/erdos-780/meta.json
+++ b/src/data/proofs/erdos-780/meta.json
@@ -28,111 +28,128 @@
     "mathlibDependencies": [
       {
         "theorem": "SetFamily.Intersecting",
-        "description": "Intersecting set families",
+        "description": "Intersecting set families: ∀ A B ∈ F, (A ∩ B).Nonempty",
         "module": "Mathlib.Combinatorics.SetFamily.Intersecting"
       },
       {
         "theorem": "SimpleGraph",
-        "description": "Simple graph definitions",
+        "description": "Simple graph definitions and basic graph theory infrastructure",
         "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
       },
       {
-        "theorem": "Finset",
-        "description": "Finite sets for hyperedges",
+        "theorem": "Finset.card",
+        "description": "Finite set cardinality, image, filter for hyperedge operations",
         "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Nat.choose",
+        "description": "Binomial coefficients C(n,r) for Erdős-Ko-Rado independence bound",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
       }
     ],
     "originalContributions": [
-      "UniformHypergraph and completeHypergraph definitions",
-      "PairwiseDisjoint predicate for matching",
-      "EdgeColoring definition for t-colorings",
-      "KneserHypergraph structure",
-      "threshold function: kr + (t-1)(k-1)",
-      "alon_frankl_lovasz_1986 main theorem axiom",
-      "tightness_construction showing bound is optimal",
-      "kneser_conjecture axiom (k=2 special case)",
-      "Small cases: Petersen graph, KG(7,3), KG(2r,r), KG(2r+1,r)"
+      "UniformHypergraph and completeHypergraph definitions as Finset subtypes",
+      "PairwiseDisjoint predicate for k-matchings in hypergraphs",
+      "EdgeColoring and colorClass definitions for t-colorings",
+      "KneserHypergraph structure with vertices, edges, uniformity, and disjointness fields",
+      "Threshold function: n₀ = kr + (t-1)(k-1)",
+      "alon_frankl_lovasz_1986 main theorem (axiom) with kneser_hypergraph_chromatic_number equivalent",
+      "tightness_construction showing the bound is optimal",
+      "kneser_conjecture axiom (k=2 special case, Lovász 1978)",
+      "Four small cases: Petersen graph KG(5,2), KG(7,3), KG(2r,r), KG(2r+1,r)",
+      "erdos_ko_rado axiom connecting independence number to intersecting families",
+      "Two proved theorems (erdos_780_main, erdos_780_summary) wrapping axioms"
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #780** asks about the chromatic number of Kneser hypergraphs, generalizing the famous Kneser conjecture.\n\n**Historical Development:**\n- **1955:** Kneser conjectures χ(KG(n,r)) = n - 2r + 2\n- **1978:** Lovász proves Kneser's conjecture using the Borsuk-Ulam theorem - a revolutionary application of topology to combinatorics\n- **1986:** Alon-Frankl-Lovász extend to hypergraphs: any t-coloring of r-sets with n ≥ kr + (t-1)(k-1) has k monochromatic disjoint edges\n- **2004:** Matoušek gives a purely combinatorial proof\n\n**Key Innovation:** Lovász's proof was the first major application of topological methods to a purely combinatorial problem.",
-    "problemStatement": "**Problem Statement**\n\nSuppose $n \\geq kr + (t-1)(k-1)$ and the edges of the complete $r$-uniform hypergraph on $n$ vertices are $t$-colored. Prove that some color class must contain $k$ pairwise disjoint edges.\n\n**Equivalent Formulation:** Determine the chromatic number of the Kneser hypergraph $KG^r(n,k)$.\n\n**Status:** SOLVED by Alon-Frankl-Lovász (1986)\n\n**The bound is tight:** For $n = kr - 1 + (t-1)(k-1)$, there exists a $t$-coloring without $k$ disjoint monochromatic edges.",
-    "proofStrategy": "**Proof Strategy**\n\n1. **Topological Method:** Use the Borsuk-Ulam theorem to establish connectivity bounds\n\n2. **Independence Complex:** Show the independence complex of the Kneser graph is highly connected\n\n3. **Chromatic Lower Bound:** Connectivity implies chromatic number lower bound\n\n4. **Tightness:** Construct explicit coloring achieving the bound\n\n5. **Generalization:** Extend from k=2 (Kneser) to general k (hypergraph version)",
+    "historicalContext": "Erdős Problem #780 generalizes the famous Kneser conjecture to hypergraphs. **Kneser (1955)** conjectured that $\\chi(KG(n,r)) = n - 2r + 2$, i.e., any $(n - 2r + 1)$-coloring of the $r$-subsets of $[n]$ must contain two disjoint sets of the same color. This remained open until **Lovász's landmark 1978 proof** (*J. Comb. Theory A* 25, 319-324), which was the **first major application of algebraic topology to combinatorics**, using the Borsuk-Ulam theorem via the neighborhood complex $\\mathcal{N}(KG(n,r))$. Schrijver simultaneously found a vertex-critical subgraph (the stable Kneser graph) with the same chromatic number.\n\n**Alon, Frankl, and Lovász (1986)** extended this to $r$-uniform hypergraphs (*Trans. AMS* 298, 359-370): if $n \\geq kr + (t-1)(k-1)$, any $t$-coloring of $\\binom{[n]}{r}$ contains $k$ pairwise disjoint monochromatic edges. Their proof generalizes the topological approach using the independence complex and a Borsuk-Ulam-type argument via the Lusternik-Schnirelmann category. **Matoušek (2004)** later gave a purely combinatorial proof using Tucker's lemma. The problem connects to the Erdős-Ko-Rado theorem (1961): the maximum intersecting family gives $\\alpha(KG(n,r)) = \\binom{n-1}{r-1}$, and the fractional chromatic number is $\\chi_f(KG(n,r)) = n/r$.",
+    "problemStatement": "**Theorem (Alon-Frankl-Lovász 1986):** Suppose $n \\geq kr + (t-1)(k-1)$ with $r \\geq 1$, $k \\geq 2$, $t \\geq 1$. If the edges of the complete $r$-uniform hypergraph $K_n^{(r)}$ are $t$-colored, some color class contains $k$ pairwise disjoint edges.\n\n**Equivalently:** $\\chi(KG^r(n,k)) = \\lceil (n - r(k-1))/(k-1) \\rceil$.\n\n**Special case ($k = 2$):** Kneser's conjecture: $\\chi(KG(n,r)) = n - 2r + 2$ for $n \\geq 2r$.\n\n**Status:** SOLVED. The bound $n_0 = kr + (t-1)(k-1)$ is tight.",
+    "proofStrategy": "The formalization axiomatizes the main theorems (AFL 1986, Kneser's conjecture, tightness construction, Erdős-Ko-Rado) since the proofs require topological methods not in Mathlib. The structure layer is fully defined: `UniformHypergraph`, `PairwiseDisjoint`, `EdgeColoring`, `KneserHypergraph`, `threshold`. Two summary theorems (`erdos_780_main`, `erdos_780_summary`) are proved from the axioms. Small cases (Petersen graph, $KG(7,3)$, $KG(2r,r)$, $KG(2r+1,r)$) are axiomatized as concrete instances.",
     "keyInsights": [
-      "**Threshold Formula:** n₀ = kr + (t-1)(k-1) is the exact threshold for forcing k monochromatic disjoint edges.",
-      "**Kneser's Conjecture (k=2):** χ(KG(n,r)) = n - 2r + 2 for n ≥ 2r. The Petersen graph KG(5,2) has χ = 3.",
-      "**Topological Methods:** Lovász's proof was revolutionary - it used algebraic topology (Borsuk-Ulam) to prove a combinatorial result.",
-      "**Tightness Construction:** Partition [n] = X₁ ∪ ... ∪ Xₜ with |X₁| = kr-1 and |Xᵢ| = k-1. Color by first intersection.",
-      "**Erdős-Ko-Rado Connection:** Maximum independent sets in Kneser graphs are intersecting families.",
-      "**Schrijver Graph:** A vertex-critical subgraph with the same chromatic number exists."
+      "**Exact threshold:** $n_0 = kr + (t-1)(k-1)$ is both necessary and sufficient — the tightness construction partitions $[n_0 - 1] = X_1 \\cup \\cdots \\cup X_t$ with $|X_1| = kr - 1$, $|X_i| = k-1$, coloring by first intersection",
+      "**Topology meets combinatorics:** Lovász's 1978 proof revolutionized combinatorics by showing the neighborhood complex $\\mathcal{N}(KG(n,r))$ is $(n-2r)$-connected, giving $\\chi \\geq n - 2r + 2$ via the Borsuk-Ulam theorem",
+      "**Erdős-Ko-Rado duality:** Maximum intersecting families are independent sets in the Kneser graph: $\\alpha(KG(n,r)) = \\binom{n-1}{r-1}$, giving the fractional chromatic number $\\chi_f = n/r$",
+      "**Chromatic number formula:** $\\chi(KG^r(n,k)) = \\lceil (n - r(k-1))/(k-1) \\rceil$ generalizes $\\chi(KG(n,r)) = n - 2r + 2$",
+      "**Petersen graph as prototype:** $KG(5,2)$ is the Petersen graph with $\\chi = 3$, the smallest non-trivial example of the Kneser conjecture",
+      "**Schrijver refinement:** There exists a vertex-critical subgraph (the stable Kneser graph) achieving the same chromatic number"
     ]
   },
   "sections": [
     {
       "id": "definitions",
-      "title": "Basic Definitions",
-      "summary": "UniformHypergraph, PairwiseDisjoint, EdgeColoring",
-      "startLine": 30,
+      "title": "Hypergraph Definitions",
+      "summary": "Defines `UniformHypergraph`, `completeHypergraph`, `disjointEdges` via `Disjoint`, `PairwiseDisjoint` for $k$-matchings, `EdgeColoring` as $c : K_n^{(r)} \\to \\text{Fin}\\, t$, and `colorClass` $C_i = c^{-1}(i)$.",
+      "startLine": 36,
       "endLine": 54
     },
     {
       "id": "kneser-hypergraph",
       "title": "The Kneser Hypergraph",
-      "summary": "KneserHypergraph structure, chromaticNumber",
-      "startLine": 56,
+      "summary": "Defines `KneserHypergraph` structure with vertices ($r$-subsets), edges ($k$-tuples of pairwise disjoint $r$-sets), uniformity and inclusion constraints. Axiomatizes `chromaticNumber` $\\chi(KG^r(n,k))$.",
+      "startLine": 63,
       "endLine": 73
     },
     {
       "id": "main-theorem",
       "title": "The Main Theorem (AFL 1986)",
-      "summary": "threshold, alon_frankl_lovasz_1986",
+      "summary": "Defines `threshold k r t` $= kr + (t-1)(k-1)$. Axiomatizes `alon_frankl_lovasz_1986`: $n \\geq n_0 \\implies$ monochromatic $k$-matching in every $t$-coloring. Also `kneser_hypergraph_chromatic_number`: $\\chi(KG^r(n,k)) = \\lceil (n - r(k-1))/(k-1) \\rceil$.",
       "startLine": 75,
       "endLine": 94
     },
     {
       "id": "tightness",
       "title": "Tightness Construction",
-      "summary": "tightBound, tightness_construction",
+      "summary": "Defines `tightBound` $= kr - 1 + (t-1)(k-1)$. Axiomatizes `tightness_construction`: partition coloring with $|X_1| = kr-1$, $|X_i| = k-1$ avoids $k$ disjoint monochromatic edges, proving optimality of the threshold.",
       "startLine": 96,
       "endLine": 113
     },
     {
       "id": "kneser-conjecture",
-      "title": "Kneser's Conjecture (k=2)",
-      "summary": "kneser_conjecture, KneserGraph, kneserAdj",
+      "title": "Kneser's Conjecture ($k = 2$)",
+      "summary": "Axiomatizes `kneser_conjecture`: $\\chi(KG(n,r)) = n - 2r + 2$ for $n \\geq 2r$ (Lovász 1978). Defines `KneserGraph` and `kneserAdj` (disjointness adjacency).",
       "startLine": 115,
       "endLine": 132
     },
     {
       "id": "small-cases",
       "title": "Small Cases",
-      "summary": "Petersen graph, KG(7,3), KG(2r,r), KG(2r+1,r)",
+      "summary": "Four axiomatized instances: $\\chi(KG(5,2)) = 3$ (Petersen graph), $\\chi(KG(7,3)) = 2$, $\\chi(KG(2r,r)) = 2$ (perfect matching), $\\chi(KG(2r+1,r)) = 3$ (odd graph).",
       "startLine": 134,
       "endLine": 150
     },
     {
       "id": "connections",
-      "title": "Connections",
-      "summary": "Erdős-Ko-Rado theorem",
+      "title": "Erdős-Ko-Rado Connection",
+      "summary": "Axiomatizes `erdos_ko_rado`: maximum intersecting family of $r$-subsets of $[n]$ has size $\\binom{n-1}{r-1}$ for $n \\geq 2r$, giving $\\alpha(KG(n,r)) = \\binom{n-1}{r-1}$.",
       "startLine": 152,
       "endLine": 165
     },
     {
       "id": "summary",
-      "title": "Summary",
-      "summary": "erdos_780_main and erdos_780_summary",
+      "title": "Summary Theorems",
+      "summary": "**Proves** `erdos_780_main` (wrapper for AFL axiom) and `erdos_780_summary` (conjunction of AFL + Kneser's conjecture). 0 sorries.",
       "startLine": 167,
       "endLine": 200
     }
   ],
+  "crossReferences": [
+    {
+      "proofId": "borsuk-ulam",
+      "relationship": "The Borsuk-Ulam theorem is the key topological tool in Lovász's 1978 proof of Kneser's conjecture and the AFL 1986 generalization. The topological argument shows the neighborhood/independence complex has high connectivity, forcing the chromatic lower bound."
+    },
+    {
+      "proofId": "ramseys-theorem",
+      "relationship": "Both are Ramsey-type results: Ramsey's theorem guarantees monochromatic complete subgraphs in colored complete graphs, while the AFL theorem guarantees monochromatic matchings in colored hypergraphs. Both establish unavoidable monochromatic substructures."
+    }
+  ],
   "conclusion": {
-    "summary": "Erdős Problem #780 determines the chromatic number of Kneser hypergraphs. Alon-Frankl-Lovász (1986) proved that if n ≥ kr + (t-1)(k-1), any t-coloring of r-subsets contains k monochromatic disjoint sets. This generalizes Lovász's 1978 proof of Kneser's conjecture using topological methods.",
-    "implications": "**Implications for Combinatorics**\n\n1. **Topological Combinatorics:** Established topology as a powerful tool for combinatorial problems.\n\n2. **Extremal Set Theory:** Deep connections to Erdős-Ko-Rado and intersecting families.\n\n3. **Graph Coloring:** Provides exact chromatic numbers for an important family of graphs.\n\n4. **Algorithmic:** The independence number bound has algorithmic applications.",
+    "summary": "Erdős Problem #780 is SOLVED: the Alon-Frankl-Lovász theorem (1986) determines the exact chromatic number of Kneser hypergraphs. The formalization axiomatizes the main results (since the proofs require topology beyond Mathlib) and proves the summary theorems with 0 sorries. The threshold $n_0 = kr + (t-1)(k-1)$ is tight, with the tightness construction using a partition coloring.",
+    "implications": "The AFL theorem established topological combinatorics as a major field. Lovász's original 1978 proof of Kneser's conjecture demonstrated that the Borsuk-Ulam theorem could solve purely combinatorial problems, inspiring decades of research in topological methods. The Erdős-Ko-Rado connection provides the independence number $\\alpha(KG(n,r)) = \\binom{n-1}{r-1}$, and the fractional chromatic number $\\chi_f(KG(n,r)) = n/r$ gives further structural information.",
     "openQuestions": [
-      "Are there purely combinatorial proofs that are simpler than Matoušek's 2004 proof?",
-      "What are the chromatic numbers for other variations of Kneser-type graphs?",
-      "Can the fractional chromatic number n/r be computed efficiently?",
-      "What is the structure of optimal colorings?"
+      "Can Matoušek's 2004 combinatorial proof be formalized in Lean using only existing Mathlib?",
+      "What is the chromatic number of generalized Kneser-type structures (q-analogs, multipartite versions)?",
+      "Can the topological proof via Borsuk-Ulam be formalized once Mathlib has sufficient algebraic topology?",
+      "What is the structure of optimal colorings achieving $\\chi(KG^r(n,k))$?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Expanded annotations from 10 to 13 with full `mathContext`, `relatedConcepts`, and `prerequisites` on every annotation
- Fixed 5 invalid `"type": "axiom"` annotations to `"theorem"` (valid type)
- Added new annotations for imports/setup, hypergraph definitions, matchings/colorings
- Added `crossReferences` to borsuk-ulam (key topological tool) and ramseys-theorem (Ramsey-type parallel)
- Deepened `historicalContext` with Kneser 1955, Lovász 1978 (JCTA 25), AFL 1986 (Trans. AMS 298), Schrijver 1978, Matoušek 2004, EKR 1961
- Expanded `keyInsights` to 6 items with LaTeX formulas
- Added LaTeX to all section summaries
- Improved `mathlibDependencies` descriptions

## Test plan
- [x] `pnpm annotations:build` passes with zero erdos-780-specific warnings
- [x] All annotations have valid types (`concept`, `definition`, `theorem`)
- [x] All annotations have valid significance values (`critical`, `key`, `supporting`)
- [x] All annotations have `mathContext`, `relatedConcepts`, and `prerequisites`

🤖 Generated with [Claude Code](https://claude.com/claude-code)