### PR TITLE
Research: riemann-hypothesis - replace logIntegral axiom with definition

### DIFF
--- a/src/data/research/problems/riemann-hypothesis.json
+++ b/src/data/research/problems/riemann-hypothesis.json
@@ -19,7 +19,7 @@
     "phase": "PROGRESS",
     "since": "2026-02-13T22:00:00.000Z",
     "iteration": 5,
-    "focus": "Proved quadruple symmetry of non-trivial zeros and RH_iff_fundamental_domain. Added Nyman-Beurling criterion formulation. File has 0 sorries.",
+    "focus": "Replaced logIntegral axiom with proper MeasureTheory definition. Proved quadruple symmetry of non-trivial zeros and RH_iff_fundamental_domain. Added Nyman-Beurling criterion formulation. File has 0 sorries.",
     "blockers": ["RH itself is an open conjecture - we can only formalize surrounding results"],
     "nextAction": "Add Weil explicit formula formulation or prove zeta_conj axiom from Mathlib internals.",
     "attemptCounts": {
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved quadruple symmetry of non-trivial zeros (zeros come in groups {ρ, conj(ρ), 1-ρ, conj(1-ρ)}), proved RH_iff_fundamental_domain (RH equivalent to checking Im≥0, Re≥1/2 quadrant). Added Nyman-Beurling criterion formulation (RH ↔ L² density). File has 0 sorries.",
+    "progressSummary": "PROGRESS: Replaced logIntegral axiom with proper measure-theoretic definition. Proved quadruple symmetry of non-trivial zeros, RH_iff_fundamental_domain, Nyman-Beurling criterion formulation. File has 0 sorries.",
     "builtItems": [
       {
         "name": "no_zeros_re_ge_one",
@@ -115,6 +115,21 @@
         "name": "RH_iff_NymanBeurling",
         "description": "Nyman-Beurling criterion: RH ↔ span of f_θ(x)={θ/x} dense in L²(0,1)",
         "proven": false
+      },
+      {
+        "name": "logIntegral",
+        "description": "Li(x) = ∫₂ˣ dt/ln(t) defined via MeasureTheory set integral (REPLACED AXIOM)",
+        "proven": true
+      },
+      {
+        "name": "logIntegral_of_le_two",
+        "description": "Li(x) = 0 for x ≤ 2",
+        "proven": true
+      },
+      {
+        "name": "logIntegral_two",
+        "description": "Li(2) = 0",
+        "proven": true
       }
     ],
     "insights": [
@@ -134,7 +149,9 @@
       "Nat.cast_nonneg needed for linarith with ℝ-cast ℕ values",
       "Quadruple symmetry: combining zeros_symmetric (functional eq) with zero_conj (conjugation) gives 4-fold group",
       "Fundamental domain reduction: RH can be checked on Im≥0, Re≥1/2 quarter-strip (proven via all four symmetries)",
-      "Nyman-Beurling transforms RH into L² approximation problem - deep connection to Mellin transforms"
+      "Nyman-Beurling transforms RH into L² approximation problem - deep connection to Mellin transforms",
+      "logIntegral axiom replaced with proper def using ∫ t in Set.Icc 2 x, 1 / log t",
+      "PNT.lean already had identical definition - consistent across files"
     ],
     "mathlibGaps": [
       "riemannZeta_conj (conjugation symmetry) - needed for full conjugate zero proof",


### PR DESCRIPTION
## Summary
- Replace `axiom logIntegral` with a proper `def logIntegral` using Mathlib's MeasureTheory set integral (`∫ t in Set.Icc 2 x, 1 / Real.log t`)
- Add two proven lemmas: `logIntegral_of_le_two` and `logIntegral_two`
- Reduces the axiom count by 1 in the Riemann Hypothesis formalization

## Progress
- **Axiom reduction**: One fewer axiom — `logIntegral` is now a computable definition consistent with the existing definition in `PrimeNumberTheorem.lean`
- **New proofs**: `logIntegral_of_le_two`, `logIntegral_two`
- **Docker build**: Passes cleanly (only pre-existing lint warnings)

## Findings
- Mathlib's `MeasureTheory.Integral.Bochner.Set` provides the set integral API needed
- The import was already present (added in prior session) — just needed to use it
- Definition matches PNT.lean's `logIntegral` exactly

## Status
**Outcome**: progress
**Next Steps**: Add Nyman-Beurling criterion or prove `zeta_conj` to replace another axiom

## Test plan
- [x] Docker build passes (`./proofs/scripts/docker-build.sh Proofs.RiemannHypothesis`)
- [x] 0 sorries in file
- [x] All existing theorems still compile

🤖 Generated by researcher-1