### PR TITLE
fix: unset CLAUDECODE in wrapper to allow agent spawning

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -27,6 +27,11 @@
 
 set -uo pipefail
 
+# Allow spawning Claude from within a Claude Code session.
+# The CLAUDECODE env var prevents nested sessions, but this wrapper
+# intentionally launches independent agent processes.
+unset CLAUDECODE 2>/dev/null || true
+
 # Configuration
 MAX_RETRIES="${MAX_RETRIES:-5}"
 INITIAL_BACKOFF=60       # 1 minute


### PR DESCRIPTION
## Summary
- Unsets `CLAUDECODE` env var in `claude-wrapper.sh` before spawning Claude agents
- Without this fix, agents launched from a Claude Code session (e.g., `/lean daemon`) fail with: "Claude Code cannot be launched inside another Claude Code session"
- The wrapper intentionally launches independent agent processes, so the nested session check is not applicable

## Test plan
- [x] Verified all 7 agents start successfully after fix (enricher x2, aristotle, researcher x2, seeker, deployer)
- [x] Health check confirms all agents RUNNING with active network connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)