### PR TITLE
complete: erdos-205 - fix Docker build errors, 0 sorries

### DIFF
--- a/proofs/Proofs/Erdos205Problem.lean
+++ b/proofs/Proofs/Erdos205Problem.lean
@@ -63,18 +63,26 @@ theorem bigOmega_prime {p : ℕ} (hp : p.Prime) : bigOmega p = 1 := by
   simp [bigOmega, Nat.primeFactorsList_prime hp]
 
 /-- Ω(p^k) = k for prime p.
-    Uses the fact that primeFactorsList of p^k has length k. -/
+    Proved by induction using multiplicativity of primeFactorsList. -/
 theorem bigOmega_prime_pow {p k : ℕ} (hp : p.Prime) : bigOmega (p ^ k) = k := by
-  simp [bigOmega, Nat.primeFactorsList_prime_pow hp]
+  induction k with
+  | zero => simp [bigOmega]
+  | succ k ih =>
+    rw [pow_succ, mul_comm]
+    simp only [bigOmega]
+    have h := Nat.perm_primeFactorsList_mul hp.ne_zero (pow_ne_zero k hp.ne_zero)
+    rw [h.length_eq, List.length_append, Nat.primeFactorsList_prime hp, List.length_singleton]
+    simp [bigOmega] at ih
+    omega
 
 /-- Ω is completely additive: Ω(ab) = Ω(a) + Ω(b) for a, b > 0.
     Prime factors of a*b are a permutation of the concatenation of
     prime factors of a and b. -/
 theorem bigOmega_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
     bigOmega (a * b) = bigOmega a + bigOmega b := by
-  simp [bigOmega]
+  simp only [bigOmega]
   have h := Nat.perm_primeFactorsList_mul ha hb
-  exact h.length_eq
+  rw [h.length_eq, List.length_append]
 
 /-
 ## Part 2: The Erdős Conjecture (Problem 205)
@@ -133,25 +141,29 @@ axiom threshold_dominates_loglog :
     This follows from Finset.inf'_le: the infimum over a set is ≤ any element. -/
 theorem remainder_achieves_min (n k : ℕ) (h : 2^k < n) :
     minOmegaRemainder n ≤ bigOmega (n - 2^k) := by
-  have hn1 : n > 1 := by omega
+  have hn1 : n > 1 := by
+    have : 1 ≤ 2^k := Nat.one_le_two_pow
+    linarith
   unfold minOmegaRemainder
   rw [if_pos hn1]
-  -- k ≤ Nat.log 2 n since 2^k < n
-  have hk_bound : k ∈ Finset.range (Nat.log 2 n + 1) := by
-    simp [Finset.mem_range]
-    exact Nat.lt_succ_of_le (Nat.log_le_of_le_pow (by omega) (le_of_lt h))
+  -- k is in the valid range: 2^k < n implies k < log 2 n + 1
+  have hk_lt : k < Nat.log 2 n + 1 := by
+    by_contra h_not
+    push_neg at h_not
+    have h1 : 2 ^ (Nat.log 2 n + 1) ≤ 2 ^ k :=
+      Nat.pow_le_pow_right (by omega) h_not
+    have h2 : n < 2 ^ (Nat.log 2 n + 1) :=
+      Nat.lt_pow_succ_log_self (by omega : 1 < 2) n
+    omega
   -- k is in the filtered valid set
-  have hk_valid : k ∈ (Finset.range (Nat.log 2 n + 1)).filter (fun j => 2^j < n) := by
-    simp [Finset.mem_filter]
-    exact ⟨hk_bound, h⟩
+  have hk_valid : k ∈ (Finset.range (Nat.log 2 n + 1)).filter (fun j => 2^j < n) :=
+    Finset.mem_filter.mpr ⟨Finset.mem_range.mpr hk_lt, h⟩
   -- The filtered set is nonempty (it contains k)
   have hne : ((Finset.range (Nat.log 2 n + 1)).filter (fun j => 2^j < n)).Nonempty :=
     ⟨k, hk_valid⟩
-  -- Finset.inf' is ≤ any element in the set
-  simp only
-  split
-  · exact Finset.inf'_le _ hk_valid
-  · omega
+  -- Use dif_pos since hne is a decidable nonempty proof
+  rw [dif_pos hne]
+  exact Finset.inf'_le _ hk_valid
 
 /-- Auxiliary: log log is monotone increasing for x ≥ 16.
     (Actually needs x > e^e ≈ 15.15, but 16 suffices for our purposes.) -/
@@ -292,7 +304,7 @@ The key covering system uses the orders of 2 modulo small primes:
 
 The residue classes {0 mod 2, 0 mod 4, 0 mod 3, 0 mod 12, 0 mod 8, 0 mod 24}
 cover all non-negative integers. For n in a suitable arithmetic progression
-mod 3·5·7·13·17·241 = 11184810, every n - 2^k is divisible by one of these primes.
+mod 3·5·7·13·17·241 = 5592405, every n - 2^k is divisible by one of these primes.
 -/
 
 /-- A covering system: residue classes that cover all of ℤ.
@@ -300,10 +312,10 @@ mod 3·5·7·13·17·241 = 11184810, every n - 2^k is divisible by one of these 
 def IsCoveringSystem (S : List (ℕ × ℕ)) : Prop :=
   ∀ n : ℤ, ∃ am ∈ S, (n : ℤ) % (am.2 : ℤ) = (am.1 : ℤ) % (am.2 : ℤ)
 
-/-- The Erdős covering modulus: 3 · 5 · 7 · 13 · 17 · 241 = 11184810 -/
+/-- The Erdős covering modulus: 3 · 5 · 7 · 13 · 17 · 241 = 5592405 -/
 def erdosCoveringModulus : ℕ := 3 * 5 * 7 * 13 * 17 * 241
 
-theorem erdosCoveringModulus_val : erdosCoveringModulus = 11184810 := by native_decide
+theorem erdosCoveringModulus_val : erdosCoveringModulus = 5592405 := by native_decide
 
 /-- A de Polignac number is an odd number that cannot be written as 2^k + p
     for any prime p and k ≥ 0. Named after Alphonse de Polignac (1849). -/

--- a/src/data/research/problems/erdos-205.json
+++ b/src/data/research/problems/erdos-205.json
@@ -1,38 +1,72 @@
 {
   "slug": "erdos-205",
   "title": "Erdős #205: Powers of 2 plus numbers with few prime factors",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "A",
   "path": "fast",
+  "leanFile": "proofs/Proofs/Erdos205Problem.lean",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Erdős #205: Powers of 2 plus numbers with few prime factors.",
-    "whyMatters": []
+    "formal": "Is it true that all sufficiently large n can be written as 2^k + m where Ω(m) < log log m? (Ω counts prime factors with multiplicity.) Answer: NO.",
+    "plain": "Erdős asked whether every large integer n can be written as 2^k + m where m has fewer than log log m prime factors (counted with multiplicity). This was disproved: there are infinitely many n where every remainder n - 2^k has at least c√(log n/log log n) prime factors.",
+    "whyMatters": [
+      "Tests whether almost-prime representations are universal",
+      "Connected to Romanoff's theorem on 2^k + p representations",
+      "Uses covering systems, a key Erdős technique",
+      "Disproved by Barreto-Leeham (2026), quantified by Tao-Alexeev"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Romanoff (1934): positive density of integers are 2^k + p for prime p",
+      "Erdős (1950): positive density of odd integers cannot be 2^k + p (covering systems)",
+      "Barreto-Leeham (2026): infinitely many counterexamples to the conjecture",
+      "Tao-Alexeev (2026): Ω(n - 2^k) ≥ c√(log n/log log n) for counterexamples"
+    ],
+    "open": [
+      "Do arbitrarily large odd counterexamples exist?"
+    ],
+    "goal": "Formalize the disproof structure and supporting results in Lean"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-23T08:04:56.542Z",
+    "phase": "COMPLETE",
+    "since": "2026-02-14T12:00:00.000Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Fixed all Docker build errors, 0 sorries",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None - file compiles cleanly",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
+    "progressSummary": "COMPLETED: Fixed 8 Docker build errors in Erdos205Problem.lean. File now compiles with 0 sorries, 6 axioms (deep analytic/number-theoretic results). Covers bigOmega properties, counterexample-based disproof, covering systems, de Polignac numbers, concrete Ω computations, and axiomatized analytic bounds.",
+    "builtItems": [
+      "bigOmega definition and properties (Ω(1)=0, Ω(p)=1, Ω(p^k)=k, multiplicativity)",
+      "bigOmega_prime_pow: proved by induction using perm_primeFactorsList_mul (API fix)",
+      "bigOmega_mul: fixed using rw [h.length_eq, List.length_append] (API fix)",
+      "remainder_achieves_min: fixed log bound via by_contra + lt_pow_succ_log_self (API fix)",
+      "loglog_mono_nat: log log monotonicity for m ≥ 16",
+      "erdos_205_disproved: ¬Erdos205Conjecture from axiomatized counterexample",
+      "12 concrete Ω computations via native_decide",
+      "Covering system verification: orders of 2 mod {3,5,7,13,17,241}",
+      "De Polignac numbers: 127 and 149 verified",
+      "erdosCoveringModulus corrected from 11184810 to 5592405"
+    ],
+    "insights": [
+      "Nat.primeFactorsList_prime_pow does NOT exist in Docker Mathlib v4.26.0",
+      "Use induction + perm_primeFactorsList_mul + primeFactorsList_prime instead",
+      "Nat.log_le_of_le_pow does NOT exist - use by_contra + Nat.lt_pow_succ_log_self",
+      "Perm.length_eq gives length of perm, need List.length_append for the sum",
+      "omega cannot handle 2^k < n directly for n > 1; use Nat.one_le_two_pow + linarith",
+      "3 * 5 * 7 * 13 * 17 * 241 = 5592405 (not 11184810 as originally claimed)"
+    ],
+    "mathlibGaps": [
+      "Nat.primeFactorsList_prime_pow missing from Mathlib v4.26.0",
+      "Nat.log_le_of_le_pow missing from Mathlib v4.26.0"
+    ],
     "nextSteps": []
   },
   "approaches": [],
@@ -46,12 +80,19 @@
   ],
   "relatedProofs": [],
   "references": {
-    "papers": [],
-    "urls": [],
+    "papers": [
+      "Romanoff (1934): Über einige Sätze der additiven Zahlentheorie",
+      "Erdős (1950): On integers of the form 2^k + p",
+      "Barreto, Leeham (2026): Counterexample to Erdős #205",
+      "Tao, Alexeev (2026): Quantification of the counterexample"
+    ],
+    "urls": [
+      "https://www.erdosproblems.com/205"
+    ],
     "mathlib": []
   },
   "started": "2026-01-23T08:04:56.542Z",
-  "lastUpdate": "2026-01-23T08:04:56.542Z",
+  "lastUpdate": "2026-02-14T12:00:00.000Z",
   "significance": 7,
   "tractability": 8
 }


### PR DESCRIPTION
## Summary
- Fixed 8 Docker build errors in `Erdos205Problem.lean`
- File now compiles cleanly with **0 sorries** and 6 axioms (deep analytic results)
- Updated problem JSON to COMPLETE status with full knowledge base

## Changes
- **bigOmega_prime_pow**: Replaced missing `Nat.primeFactorsList_prime_pow` with induction proof
- **bigOmega_mul**: Fixed type mismatch using `rw [h.length_eq, List.length_append]`
- **remainder_achieves_min**: Fixed log bound using `by_contra + Nat.lt_pow_succ_log_self`
- **erdosCoveringModulus**: Corrected value from 11184810 to 5592405

## What's in the file
Erdős Problem #205 (DISPROVED): Can all large n be written as 2^k + m with Ω(m) < log log m?
- bigOmega function with proved properties (Ω(1)=0, Ω(p)=1, Ω(p^k)=k, multiplicativity)
- Main disproof theorem from axiomatized Barreto-Leeham counterexample
- 12 concrete Ω computations via native_decide
- Covering system formalization with de Polignac number verification (127, 149)
- Romanoff's theorem and Erdős covering obstruction (axiomatized)

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.Erdos205Problem`

Generated by researcher-1