### PR TITLE
Enrich Erdős #1053, #1065, Fair Games Theorem

### DIFF
--- a/src/data/proofs/erdos-1089/annotations.json
+++ b/src/data/proofs/erdos-1089/annotations.json
@@ -1,245 +1,110 @@
 [
   {
-    "id": "ann-1089-point",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 44, "endLine": 45 },
-    "type": "definition",
-    "title": "Point in ℝ^d",
-    "content": "A point in d-dimensional Euclidean space, represented as EuclideanSpace ℝ (Fin d). This is the standard Mathlib representation of ℝ^d.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1089-dist",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 47, "endLine": 49 },
-    "type": "definition",
-    "title": "Euclidean Distance",
-    "content": "The Euclidean distance between two points p, q in ℝ^d, defined as ‖p - q‖. This is the standard 2-norm distance.",
-    "significance": "supporting"
-  },
-  {
     "id": "ann-1089-distinctdist",
     "proofId": "erdos-1089",
-    "range": { "startLine": 51, "endLine": 53 },
+    "range": { "startLine": 51, "endLine": 57 },
     "type": "definition",
-    "title": "Distinct Distances Set",
-    "content": "The set of distinct positive distances determined by a point set P. Computed by taking all pairs, computing distances, and filtering to positive values (to exclude self-distances).",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1089-numdist",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 55, "endLine": 57 },
-    "type": "definition",
-    "title": "Number of Distinct Distances",
-    "content": "The cardinality of the distinct distances set. This is the central quantity: how many different distances appear among pairs of points.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1089-determines",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 65, "endLine": 67 },
-    "type": "definition",
-    "title": "Determines n Distances",
-    "content": "A point set P 'determines at least n distinct distances' if numDistinctDistances P ≥ n. This predicate is used to define the threshold function g.",
-    "significance": "key"
+    "title": "Distinct Distances Set and Count",
+    "content": "**distinctDistances P** computes all positive pairwise distances in a point set, and **numDistinctDistances** returns its cardinality. These are the central quantities: the problem asks how many points guarantee n distinct values.",
+    "mathContext": "For $P \\subseteq \\mathbb{R}^d$, $\\Delta(P) = \\{\\|p - q\\| : p, q \\in P, p \\neq q\\}$. The count $|\\Delta(P)|$ is the number of distinct distances. Implemented via `Finset.product`, `Finset.image`, and `Finset.filter`.",
+    "significance": "critical",
+    "relatedConcepts": ["Distinct distances problem", "Guth-Katz theorem", "Euclidean distance"],
+    "prerequisites": ["EuclideanSpace", "Finset.product", "Finset.image"]
   },
   {
     "id": "ann-1089-gdef",
     "proofId": "erdos-1089",
-    "range": { "startLine": 69, "endLine": 71 },
+    "range": { "startLine": 69, "endLine": 75 },
     "type": "definition",
     "title": "The Function g_d(n)",
-    "content": "g(d, n) is the infimum of m such that EVERY m-point set in ℝ^d determines at least n distinct distances. This is the central object of study.",
-    "significance": "critical"
+    "content": "**g d n** is the infimum of m such that every m-point set in $\\mathbb{R}^d$ determines at least n distinct distances. This threshold function is the central object of Erdős Problem #1089.",
+    "mathContext": "$g_d(n) = \\min\\{m : \\forall P \\subseteq \\mathbb{R}^d,\\, |P| = m \\implies |\\Delta(P)| \\ge n\\}$. Defined via `Nat.sInf` with well-definedness axiomatized for $n \\ge 1$.",
+    "significance": "critical",
+    "relatedConcepts": ["Threshold functions", "Ramsey-type problems", "Extremal combinatorics"],
+    "prerequisites": ["determinesNDistances", "Nat.sInf"]
   },
   {
-    "id": "ann-1089-welldef",
+    "id": "ann-1089-smallcases",
     "proofId": "erdos-1089",
-    "range": { "startLine": 73, "endLine": 75 },
-    "type": "theorem",
-    "title": "g is Well-Defined",
-    "content": "For n ≥ 1, the threshold g_d(n) exists as a finite number. Taken as an axiom since the proof requires showing the set is nonempty and bounded.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-1089-g13",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 83, "endLine": 84 },
-    "type": "theorem",
-    "title": "g_1(3) = 4",
-    "content": "Four points on a line give exactly 3 distinct distances (in optimal configuration). Any 3 points give ≤ 2 distances. This is the 1-dimensional base case.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1089-g23",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 86, "endLine": 87 },
-    "type": "theorem",
-    "title": "g_2(3) = 6",
-    "content": "Six points in the plane guarantee 3 distinct distances. Any 5 points can have only 2 distances (vertices of regular pentagon plus center, carefully arranged).",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1089-g33",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 89, "endLine": 90 },
-    "type": "theorem",
-    "title": "g_3(3) = 7 (Croft 1962)",
-    "content": "Croft proved seven points in 3-space guarantee 3 distinct distances. This required careful analysis of 6-point configurations in ℝ³ with only 2 distances.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1089-gd1",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 92, "endLine": 94 },
-    "type": "theorem",
-    "title": "g_d(1) = 2",
-    "content": "Trivially, any two distinct points determine exactly 1 distance. So g_d(1) = 2 for all d ≥ 1.",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-1089-gd2",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 96, "endLine": 97 },
-    "type": "theorem",
-    "title": "g_d(2) = 3",
-    "content": "Three points determine at least 2 distinct distances (unless collinear and equispaced, which still gives 1). So g_d(2) = 3 for d ≥ 1.",
-    "significance": "supporting"
+    "range": { "startLine": 83, "endLine": 97 },
+    "type": "axiom",
+    "title": "Small Cases: g_1(3)=4, g_2(3)=6, g_3(3)=7",
+    "content": "Known exact values of $g_d(3)$: 4 points on a line, 6 in the plane, 7 in 3-space suffice for 3 distinct distances. Croft (1962) proved $g_3(3) = 7$ by analyzing 6-point configurations in $\\mathbb{R}^3$ with only 2 distances.",
+    "mathContext": "$g_1(3) = 4$, $g_2(3) = 6$, $g_3(3) = 7$. Also $g_d(1) = 2$ (sorry'd) and $g_d(2) = 3$ for $d \\ge 1$. The values grow with dimension because higher-dimensional spaces allow more points with few distances.",
+    "significance": "key",
+    "relatedConcepts": ["Croft's theorem", "Isometric embeddings", "Few-distance sets"],
+    "prerequisites": ["g definition"]
   },
   {
     "id": "ann-1089-cube",
     "proofId": "erdos-1089",
-    "range": { "startLine": 105, "endLine": 106 },
-    "type": "definition",
-    "title": "Cube Vertices",
-    "content": "The vertices of the d-dimensional unit cube {0,1}^d. This is the key construction for lower bounds.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1089-cubecard",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 108, "endLine": 109 },
-    "type": "theorem",
-    "title": "Cube Has 2^d Vertices",
-    "content": "The d-dimensional unit cube has exactly 2^d vertices. Each vertex is a binary string of length d.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1089-cubedist",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 111, "endLine": 113 },
-    "type": "theorem",
-    "title": "Cube Distance Bound",
-    "content": "The vertices of the d-cube have at most d distinct distances: √1, √2, ..., √d. Two vertices differing in k coordinates have distance √k.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1089-cubelower",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 115, "endLine": 117 },
-    "type": "theorem",
-    "title": "Cube Lower Bound",
-    "content": "g_d(d+1) > 2^d: the cube's 2^d vertices have only d distances, so we need more than 2^d points to guarantee d+1 distances.",
-    "significance": "critical"
+    "range": { "startLine": 105, "endLine": 118 },
+    "type": "axiom",
+    "title": "Cube Construction and Lower Bound",
+    "content": "The $d$-dimensional unit cube $\\{0,1\\}^d$ has $2^d$ vertices but only $d$ distinct distances: two vertices differing in $k$ coordinates have distance $\\sqrt{k}$ for $k = 1, \\ldots, d$. This gives $g_d(d+1) > 2^d$.",
+    "mathContext": "The cube vertices are axiomatized as a `Finset (Point d)` with $|\\text{cubeVertices}(d)| = 2^d$ and $|\\Delta(\\text{cubeVertices}(d))| \\le d$. The theorem `cube_lower_bound` ($g_d(d+1) > 2^d$) is sorry'd — the proof would combine the cube axioms with the definition of $g$.",
+    "significance": "critical",
+    "relatedConcepts": ["Hamming distance", "Boolean cube", "Extremal constructions"],
+    "prerequisites": ["cubeVertices axioms", "g definition"]
   },
   {
     "id": "ann-1089-erdoslower",
     "proofId": "erdos-1089",
-    "range": { "startLine": 119, "endLine": 121 },
-    "type": "theorem",
-    "title": "Erdős Lower Bound",
-    "content": "g_d(n) ≥ c·d^{n-1} for some constant c > 0. Erdős wrote this is 'easy' to prove. This establishes polynomial growth in d.",
-    "significance": "critical"
+    "range": { "startLine": 120, "endLine": 122 },
+    "type": "axiom",
+    "title": "Erdős Lower Bound: g_d(n) >> d^{n-1}",
+    "content": "**erdos_lower_bound** axiomatizes that $g_d(n) \\ge c \\cdot d^{n-1}$ for some constant $c > 0$. Erdős described this as 'easy' — the proof uses constructions of large point sets with few distances in high dimensions.",
+    "mathContext": "$\\forall n \\ge 2, \\exists c > 0 : \\forall d \\ge 1, g_d(n) \\ge c \\cdot d^{n-1}$. This polynomial lower bound contrasts with the exponential upper bound, creating the central gap.",
+    "significance": "critical",
+    "relatedConcepts": ["Polynomial growth", "Dimensional analysis", "Asymptotic lower bounds"],
+    "prerequisites": ["g definition", "real-valued casting"]
   },
   {
     "id": "ann-1089-upper",
     "proofId": "erdos-1089",
-    "range": { "startLine": 129, "endLine": 132 },
-    "type": "theorem",
+    "range": { "startLine": 130, "endLine": 133 },
+    "type": "axiom",
     "title": "Erdős-Straus Upper Bound",
-    "content": "g_d(n) ≤ c^{d^{1-b_n}} for constants c > 1 and b_n > 0 depending on n. This is much larger than d^{n-1}, leaving a huge gap.",
-    "significance": "critical"
+    "content": "**erdos_straus_upper_bound** axiomatizes that $g_d(n) \\le c^{d^{1-b_n}}$ for constants $c > 1$ and $b_n > 0$. This stretched-exponential upper bound is vastly larger than the polynomial lower bound $d^{n-1}$.",
+    "mathContext": "$\\forall n \\ge 2, \\exists c > 1, b > 0 : \\forall d \\ge 1, g_d(n) \\le c^{d^{1-b}}$. The gap between $d^{n-1}$ and $c^{d^{1-b}}$ is enormous: polynomial vs. stretched-exponential.",
+    "significance": "critical",
+    "relatedConcepts": ["Stretched exponential", "Erdős-Straus conjecture", "Upper bound constructions"],
+    "prerequisites": ["g definition", "Real.rpow"]
   },
   {
     "id": "ann-1089-ratio",
     "proofId": "erdos-1089",
-    "range": { "startLine": 140, "endLine": 142 },
+    "range": { "startLine": 141, "endLine": 147 },
     "type": "definition",
-    "title": "Normalized Ratio",
-    "content": "gRatio(d, n) = g_d(n) / d^{n-1}. The main question asks whether this ratio converges as d → ∞ for fixed n.",
-    "significance": "critical"
+    "title": "Normalized Ratio and Main Conjecture",
+    "content": "**gRatio d n** = $g_d(n)/d^{n-1}$ is the normalized threshold. **erdos1089Conjecture n** asks whether this ratio converges as $d \\to \\infty$ for fixed $n$. Convergence would determine the exact polynomial growth rate.",
+    "mathContext": "$\\text{gRatio}(d, n) = g_d(n) / d^{n-1}$. The conjecture: $\\exists L \\ge 0 : \\lim_{d \\to \\infty} \\text{gRatio}(d, n) = L$. Formalized via `Filter.Tendsto` to `nhds L`.",
+    "significance": "critical",
+    "relatedConcepts": ["Limit existence", "Filter.Tendsto", "Normalization"],
+    "prerequisites": ["g definition", "Filter.atTop", "nhds"]
   },
   {
-    "id": "ann-1089-conj",
+    "id": "ann-1089-bounded-below",
     "proofId": "erdos-1089",
-    "range": { "startLine": 144, "endLine": 146 },
-    "type": "conjecture",
-    "title": "Main Conjecture",
-    "content": "For each fixed n, does lim_{d→∞} g_d(n)/d^{n-1} exist? This asks whether the ratio converges to some finite limit L.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-1089-bounded",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 148, "endLine": 150 },
-    "type": "definition",
-    "title": "Ratio is Bounded",
-    "content": "A weaker question: is gRatio(d, n) bounded above? The lower bound shows it's bounded below, but is there an upper bound?",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1089-belowbound",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 152, "endLine": 156 },
+    "range": { "startLine": 153, "endLine": 157 },
     "type": "theorem",
-    "title": "Ratio Bounded Below",
-    "content": "From Erdős's lower bound, gRatio(d, n) ≥ c for all d ≥ 1 and some c > 0. The ratio doesn't go to zero.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1089-monon",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 164, "endLine": 166 },
-    "type": "theorem",
-    "title": "Monotonicity in n",
-    "content": "g_d(n) is increasing in n: requiring more distances needs at least as many points. If n₁ ≤ n₂ then g_d(n₁) ≤ g_d(n₂).",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-1089-monod",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 168, "endLine": 170 },
-    "type": "theorem",
-    "title": "Monotonicity in d",
-    "content": "g_d(n) is generally increasing in d for n ≥ 2: higher dimensions allow more points with few distances. If d₁ ≤ d₂ then g_{d₁}(n) ≤ g_{d₂}(n).",
-    "significance": "supporting"
-  },
-  {
-    "id": "ann-1089-fdef",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 178, "endLine": 180 },
-    "type": "definition",
-    "title": "The Function f_d(n)",
-    "content": "f_d(n) = max distinct distances achievable by n points in ℝ^d. This is the inverse perspective from problem #1083.",
-    "significance": "key"
+    "title": "Ratio Bounded Below (Genuinely Proved)",
+    "content": "**ratio_bounded_below** is genuinely proved: the Erdős lower bound $g_d(n) \\ge c \\cdot d^{n-1}$ implies $\\text{gRatio}(d, n) \\ge c > 0$. The ratio doesn't go to zero.",
+    "mathContext": "Proof: from `erdos_lower_bound`, extract $c > 0$ with $g_d(n) \\ge c \\cdot d^{n-1}$, then divide by $d^{n-1}$ to get $\\text{gRatio}(d, n) \\ge c$. Uses `linarith`.",
+    "significance": "key",
+    "relatedConcepts": ["Lower bound extraction", "linarith tactic"],
+    "prerequisites": ["erdos_lower_bound", "gRatio definition"]
   },
   {
     "id": "ann-1089-inverse",
     "proofId": "erdos-1089",
-    "range": { "startLine": 182, "endLine": 184 },
-    "type": "theorem",
-    "title": "g and f Relationship",
-    "content": "g_d(n) = min{m : f_d(m) ≥ n}. The threshold function g is the inverse of the maximum function f. Problem #1089 studies g for fixed n, #1083 studies f.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-1089-open",
-    "proofId": "erdos-1089",
-    "range": { "startLine": 192, "endLine": 194 },
-    "type": "conjecture",
-    "title": "The Open Problem",
-    "content": "erdos1089OpenProblem: for all n ≥ 2, does gRatio(d, n) converge as d → ∞? This remains unresolved despite known bounds.",
-    "significance": "critical"
+    "range": { "startLine": 179, "endLine": 185 },
+    "type": "definition",
+    "title": "Connection to f_d(n) and Problem #1083",
+    "content": "**f d n** = max distinct distances from $n$ points in $\\mathbb{R}^d$. The relationship $g_d(n) = \\min\\{m : f_d(m) \\ge n\\}$ shows $g$ and $f$ are inverse perspectives on the same problem.",
+    "mathContext": "$f_d(n) = \\max\\{|\\Delta(P)| : P \\subseteq \\mathbb{R}^d, |P| = n\\}$ and $g_d(n) = \\inf\\{m : f_d(m) \\ge n\\}$. The `g_f_relationship` axiom formalizes this duality.",
+    "significance": "key",
+    "relatedConcepts": ["Galois connections", "Inverse functions", "Erdős Problem 1083"],
+    "prerequisites": ["f definition", "Nat.sSup", "Nat.sInf"]
   }
 ]

--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -17,91 +17,131 @@
       "combinatorial-geometry",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 1089,
     "erdosUrl": "https://erdosproblems.com/1089",
-    "erdosProblemStatus": "open"
-  },
-  "overview": {
-    "historicalContext": "This is the higher-dimensional generalization of the famous distinct distances problem. Kelly posed this problem about the threshold function g_d(n)—the minimum number of points in ℝ^d that guarantee n distinct pairwise distances. Erdős (1975) showed 'easily' that g_d(n) ≫ d^{n-1}. The hypercube provides a key construction: its 2^d vertices achieve only d distinct distances. Croft (1962) computed g_3(3) = 7, showing even small cases require careful analysis.",
-    "problemStatement": "Let g_d(n) be minimal such that every collection of g_d(n) points in ℝ^d determines at least n distinct distances. Estimate g_d(n). In particular, does lim_{d→∞} g_d(n)/d^{n-1} exist?",
-    "proofStrategy": "The Lean formalization defines g_d(n) as the infimum of thresholds guaranteeing n distinct distances. The cube construction provides the key lower bound: 2^d vertices have distances √1, √2, ..., √d (at most d values). Known bounds are captured as axioms: Erdős's lower bound g_d(n) ≫ d^{n-1} and Erdős-Straus upper bound g_d(n) ≤ c^{d^{1-b_n}}. The gap between bounds leaves the limit question open.",
-    "keyInsights": [
-      "g_d(n) = min{m : every m-point set in ℝ^d has ≥ n distinct distances}",
-      "Cube bound: 2^d vertices of the d-cube have only d distinct distances",
-      "Known small values: g_1(3)=4, g_2(3)=6, g_3(3)=7 (Croft 1962)",
-      "Lower bound: g_d(n) ≫ d^{n-1} (Erdős, 'easy')",
-      "Upper bound: g_d(n) ≤ c^{d^{1-b_n}} for some constants (Erdős-Straus)",
-      "Inverse of f_d(n) from problem #1083: g_d(n) > m iff f_d(m) < n"
-    ]
+    "erdosProblemStatus": "open",
+    "mathlibDependencies": [
+      {
+        "theorem": "EuclideanSpace",
+        "description": "Finite-dimensional Euclidean space ℝ^d",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Filter.Tendsto",
+        "description": "Limit formulation for the main conjecture",
+        "module": "Mathlib.Order.Filter.Basic"
+      },
+      {
+        "theorem": "Nat.sInf",
+        "description": "Infimum of natural number sets for threshold definition",
+        "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      },
+      {
+        "theorem": "Finset.product",
+        "description": "Cartesian product of finite sets for pairwise distances",
+        "module": "Mathlib.Data.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "g_d(n) threshold function definition via Nat.sInf",
+      "distinctDistances and numDistinctDistances via Finset operations",
+      "Cube construction axiomatized with vertex count and distance bound",
+      "ratio_bounded_below genuinely proved from Erdős lower bound",
+      "f_d(n) inverse function and g-f relationship axiomatized",
+      "Monotonicity properties in both d and n axiomatized",
+      "erdos1089Conjecture formalized via Filter.Tendsto"
+    ],
+    "dateAdded": "12/29/25"
   },
   "sections": [
     {
       "id": "points",
       "title": "Points and Distances",
-      "summary": "Points in ℝ^d and distinct distance counting",
+      "summary": "Defines Point d = EuclideanSpace ℝ (Fin d), Euclidean distance via ‖p - q‖, distinctDistances via Finset.product/image/filter, and numDistinctDistances as the cardinality.",
       "startLine": 38,
       "endLine": 57
     },
     {
       "id": "gfunction",
       "title": "The Function g_d(n)",
-      "summary": "Definition of the threshold function",
+      "summary": "Defines determinesNDistances (numDistinctDistances P ≥ n) and g d n via Nat.sInf. Axiomatizes well-definedness for n ≥ 1.",
       "startLine": 59,
       "endLine": 75
     },
     {
       "id": "small",
       "title": "Small Cases",
-      "summary": "Known exact values: g_1(3)=4, g_2(3)=6, g_3(3)=7",
+      "summary": "Axiomatizes g_1(3) = 4, g_2(3) = 6, g_3(3) = 7 (Croft 1962). Proves g_d(1) = 2 (sorry'd) and axiomatizes g_d(2) = 3.",
       "startLine": 77,
       "endLine": 97
     },
     {
       "id": "lower",
-      "title": "Lower Bound",
-      "summary": "Cube construction and d^{n-1} bound",
+      "title": "Lower Bound: Cube Construction",
+      "summary": "Axiomatizes cubeVertices with 2^d vertices and ≤ d distinct distances. The sorry'd cube_lower_bound gives g_d(d+1) > 2^d. The general erdos_lower_bound axiomatizes g_d(n) ≥ c·d^{n-1}.",
       "startLine": 99,
-      "endLine": 121
+      "endLine": 122
     },
     {
       "id": "upper",
-      "title": "Upper Bound",
-      "summary": "Erdős-Straus exponential bound",
-      "startLine": 123,
-      "endLine": 132
+      "title": "Upper Bound: Erdős-Straus",
+      "summary": "Axiomatizes the Erdős-Straus bound: g_d(n) ≤ c^{d^{1-b_n}} for constants c > 1, b_n > 0. This stretched-exponential upper bound creates a vast gap with the polynomial lower bound.",
+      "startLine": 124,
+      "endLine": 133
     },
     {
       "id": "conjecture",
       "title": "The Main Conjecture",
-      "summary": "Does g_d(n)/d^{n-1} converge as d → ∞?",
-      "startLine": 134,
-      "endLine": 156
+      "summary": "Defines gRatio(d, n) = g_d(n)/d^{n-1} and erdos1089Conjecture via Filter.Tendsto. Defines ratioIsBounded as a weaker question. Proves ratio_bounded_below genuinely from the Erdős lower bound.",
+      "startLine": 135,
+      "endLine": 157
     },
     {
       "id": "mono",
       "title": "Monotonicity Properties",
-      "summary": "How g_d(n) varies with d and n",
-      "startLine": 158,
-      "endLine": 170
+      "summary": "Axiomatizes g_mono_n (g increasing in n: more distances need more points) and g_mono_d (g increasing in d for n ≥ 2: higher dimensions allow more few-distance configurations).",
+      "startLine": 159,
+      "endLine": 171
     },
     {
       "id": "inverse",
-      "title": "Connection to f_d(n)",
-      "summary": "Relationship with problem #1083",
-      "startLine": 172,
-      "endLine": 184
+      "title": "Connection to f_d(n) and Problem #1083",
+      "summary": "Defines f d n = max distinct distances from n points. Axiomatizes g_f_relationship: g_d(n) = min{m : f_d(m) ≥ n}. Names the full open problem as erdos1089OpenProblem.",
+      "startLine": 173,
+      "endLine": 202
+    }
+  ],
+  "overview": {
+    "historicalContext": "The distinct distances problem in higher dimensions was posed by L.M. Kelly and Paul Erdős in 1975. It generalizes the famous planar distinct distances problem (solved by Guth and Katz in 2015 up to logarithmic factors) to arbitrary dimension d, but with a twist: instead of fixing d and varying n, it fixes the number of distinct distances n and asks how the threshold g_d(n) grows with d.\n\nThe key construction is the d-dimensional unit cube {0,1}^d: its 2^d vertices produce only d distinct distances (√1, √2, ..., √d), since two vertices differing in k coordinates have distance √k. This shows g_d(d+1) > 2^d. Erdős proved 'easily' that g_d(n) ≫ d^{n-1} for fixed n, establishing a polynomial lower bound. Croft (1962) computed the exact value g_3(3) = 7, showing that even small cases require careful geometric analysis.\n\nThe upper bound side is less understood: the Erdős-Straus bound g_d(n) ≤ c^{d^{1-b_n}} is stretched-exponential, leaving an enormous gap with the polynomial lower bound. The central open question is whether g_d(n)/d^{n-1} converges as d → ∞ for each fixed n. If the limit exists, it determines the exact polynomial growth rate of g_d(n) in d.",
+    "problemStatement": "Let $g_d(n)$ be minimal such that every collection of $g_d(n)$ points in $\\mathbb{R}^d$ determines at least $n$ distinct distances. Estimate $g_d(n)$. In particular, does $\\lim_{d \\to \\infty} g_d(n)/d^{n-1}$ exist?",
+    "proofStrategy": "The formalization defines g_d(n) as the infimum of thresholds guaranteeing n distinct distances in ℝ^d, using Mathlib's EuclideanSpace. The cube construction is axiomatized (embedding {0,1}^d into ℝ^d would require substantial infrastructure). Known bounds are captured as axioms. The theorem ratio_bounded_below is genuinely proved from the Erdős lower bound axiom. The f_d(n) inverse function connects to Problem #1083.",
+    "keyInsights": [
+      "g_d(n) = min{m : every m-point set in ℝ^d has ≥ n distinct distances} — the threshold function",
+      "The d-cube {0,1}^d has 2^d vertices but only d distinct distances √1, ..., √d, giving g_d(d+1) > 2^d",
+      "Known small values: g_1(3)=4, g_2(3)=6, g_3(3)=7 (Croft 1962) — values grow with dimension",
+      "Lower bound: g_d(n) ≫ d^{n-1} (Erdős, 'easy') establishes polynomial growth",
+      "Upper bound: g_d(n) ≤ c^{d^{1-b_n}} (Erdős-Straus) — stretched-exponential, creating a huge gap",
+      "The ratio g_d(n)/d^{n-1} is bounded below (genuinely proved) but convergence is unknown"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1083",
+      "relationship": "Inverse problem",
+      "description": "Problem #1083 studies f_d(n) = max distinct distances from n points; g_d(n) = min{m : f_d(m) ≥ n} is the inverse perspective."
     }
   ],
   "conclusion": {
-    "summary": "The threshold function g_d(n) captures how many points in ℝ^d guarantee n distinct distances. The cube construction shows g_d(d+1) > 2^d, while Erdős proved g_d(n) ≫ d^{n-1}. The Erdős-Straus upper bound g_d(n) ≤ c^{d^{1-b_n}} leaves a huge gap. Whether g_d(n)/d^{n-1} converges as d → ∞ remains the central open question.",
-    "implications": "This connects to the famous distinct distances problem in the plane (Guth-Katz 2015) and understanding how distance structure changes with dimension. The focus on fixed n as d → ∞ differs from typical questions about n points in fixed dimension.",
+    "summary": "The threshold function g_d(n) captures how many points in ℝ^d guarantee n distinct distances. The cube construction shows g_d(d+1) > 2^d, while Erdős proved g_d(n) ≫ d^{n-1}. The Erdős-Straus upper bound g_d(n) ≤ c^{d^{1-b_n}} leaves a vast gap between polynomial and stretched-exponential growth. Whether g_d(n)/d^{n-1} converges as d → ∞ remains the central open question.",
+    "implications": "This connects to the famous distinct distances problem in the plane (Guth-Katz 2015) and understanding how distance structure changes with dimension. The focus on fixed n as d → ∞ differs from typical questions about n points in fixed dimension, probing the fundamental geometry of high-dimensional Euclidean space.",
     "openQuestions": [
-      "Does lim_{d→∞} g_d(n)/d^{n-1} exist for each fixed n?",
-      "What is the true growth rate of g_d(n)?",
-      "Can the upper and lower bounds be improved?",
-      "What is g_4(3)? Higher exact values unknown."
+      "Does lim_{d→∞} g_d(n)/d^{n-1} exist for each fixed n ≥ 2?",
+      "What is the true growth rate of g_d(n): closer to d^{n-1} or to the stretched exponential?",
+      "Can the Erdős-Straus upper bound be improved to polynomial in d?",
+      "What is g_4(3)? No exact values are known beyond d = 3.",
+      "Is the ratio g_d(n)/d^{n-1} monotone in d, which would imply convergence?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Enriched proof gallery entries with mathematical depth (mathContext with LaTeX, relatedConcepts, prerequisites)
- Expanded historicalContext to 3 paragraphs, keyInsights to 6+, openQuestions to 5
- Added crossReferences, mathlibDependencies, corrected section line ranges
- Fixed badge/status fields

## Entries enriched
- erdos-781, erdos-716, erdos-247
- kroneckers-jugendtraum, fair-games-theorem
- erdos-1053, erdos-1065, erdos-1059
- erdos-1040, erdos-1057, erdos-1089

## Test plan
- [x] JSON validates for all enriched files
- [x] `pnpm build` passes (pre-existing research:build failure only)
- [x] Section line ranges verified against Lean source files
- [x] Annotation line ranges verified against Lean source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)