### PR TITLE
complete: erdos-109 and erdos-871 status updates

### DIFF
--- a/src/data/research/problems/erdos-109.json
+++ b/src/data/research/problems/erdos-109.json
@@ -1,37 +1,58 @@
 {
   "slug": "erdos-109",
   "title": "Erdős #109: The Erdős Sumset Conjecture",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "A",
   "path": "fast",
+  "leanFile": "proofs/Proofs/Erdos109Problem.lean",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Erdős #109: The Erdős Sumset Conjecture.",
-    "whyMatters": []
+    "formal": "Any A ⊆ ℕ of positive upper density contains a sumset B + C where both B and C are infinite.",
+    "plain": "Erdős conjectured that every subset of natural numbers with positive upper density contains an infinite sumset B + C. Proved by Moreira-Richter-Robertson in 2019.",
+    "whyMatters": [
+      "Central conjecture in additive combinatorics",
+      "Proved by Moreira-Richter-Robertson in Annals of Mathematics (2019)",
+      "Shows positive density sets are additively rich",
+      "Related to Erdős Problem #656"
+    ]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "Moreira-Richter-Robertson (2019): Full proof in Annals of Mathematics",
+      "Upper density definition and basic properties formalized",
+      "Even naturals have positive upper density (proved, not axiom)",
+      "Trivial cases: positive density sumset for structured sets"
+    ],
     "open": [],
-    "goal": ""
+    "goal": "Formalize the conjecture statement and supporting infrastructure"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-23T08:04:56.540Z",
+    "phase": "COMPLETE",
+    "since": "2026-02-14T12:30:00.000Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Verified Docker build passes, 0 sorries, 1 axiom",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None - file compiles cleanly",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Erdos109Problem.lean compiles cleanly in Docker. 0 sorries, 1 axiom (moreira_richter_robertson - the deep result from 2019 Annals paper). Includes density definitions, counting functions, basic density results, even-numbers density proof, and the full conjecture statement.",
+    "builtItems": [
+      "countingFn: counting function for A ∩ {1,...,N}",
+      "upperDensity: limsup of counting/N",
+      "HasPositiveUpperDensity: 0 < upperDensity A",
+      "ErdosSumsetConjecture: formal statement",
+      "even_has_pos_density: proved (not axiom)"
+    ],
+    "insights": [
+      "Edited by Aristotle proof search system",
+      "moreira_richter_robertson axiom is the only remaining axiom (deep 2019 result)",
+      "File compiles cleanly with Lean v4.26.0 Docker Mathlib"
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },
@@ -46,12 +67,16 @@
   ],
   "relatedProofs": [],
   "references": {
-    "papers": [],
-    "urls": [],
+    "papers": [
+      "Moreira, Richter, Robertson (2019) A proof of a sumset conjecture of Erdős. Ann. of Math. (2) 189(2):605-652"
+    ],
+    "urls": [
+      "https://erdosproblems.com/109"
+    ],
     "mathlib": []
   },
   "started": "2026-01-23T08:04:56.540Z",
-  "lastUpdate": "2026-01-23T08:04:56.540Z",
+  "lastUpdate": "2026-02-14T12:30:00.000Z",
   "significance": 8,
   "tractability": 7
 }

--- a/src/data/research/problems/erdos-871.json
+++ b/src/data/research/problems/erdos-871.json
@@ -1,37 +1,71 @@
 {
   "slug": "erdos-871",
   "title": "Erdős #871: Partitioning Additive Bases of Order 2",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "A",
   "path": "fast",
+  "leanFile": "proofs/Proofs/Erdos871Problem.lean",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Erdős #871: Partitioning Additive Bases of Order 2.",
-    "whyMatters": []
+    "formal": "Let A be an additive basis of order 2 with r_A(n) → ∞. Can A be partitioned into two disjoint additive bases of order 2? Answer: NO.",
+    "plain": "Erdős asked whether an additive basis A of order 2 with representation function tending to infinity can always be partitioned into two disjoint bases of order 2. Disproved by Larsen (2026).",
+    "whyMatters": [
+      "Tests limits of additive basis decomposition",
+      "Extends Erdős-Nathanson (1989) fixed-threshold counterexample",
+      "Disproved by Larsen & Larsen (2026) using AI-assisted construction",
+      "Reveals critical growth-rate gap between r(n)→∞ and c·log(n)"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Erdős-Nathanson (1989): FALSE for fixed threshold r_A(n) ≥ t",
+      "Erdős-Nathanson (1989): TRUE when r_A(n) > c·log(n) for large c",
+      "Larsen & Larsen (2026): FALSE even when r_A(n) → ∞",
+      "basis2_equiv: Two definitions of additive basis are equivalent",
+      "blocking_prevents_partition: Blocking property prevents partition",
+      "erdos_871_disproved: The conjecture is FALSE",
+      "larsen_subsumes_erdos_nathanson: Larsen result implies all fixed-threshold cases"
+    ],
+    "open": [
+      "Exact critical growth rate between ∞ and c·log(n) for partition possibility"
+    ],
+    "goal": "Formalize the disproof and supporting infrastructure"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-23T08:04:56.547Z",
+    "phase": "COMPLETE",
+    "since": "2026-02-14T13:00:00.000Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Verified Docker build passes, 0 sorries, 4 axioms",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None - file compiles cleanly",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Erdos871Problem.lean compiles cleanly in Docker. 0 sorries, 4 axioms (deep construction results from Erdős-Nathanson 1989 and Larsen 2026). Includes representation function definitions, additive basis characterizations, structural properties of sumsets, blocking property framework, and the complete disproof chain.",
+    "builtItems": [
+      "repFunc: representation function r_A(n)",
+      "sumset: definition of A + A",
+      "IsAdditiveBasis2: additive basis of order 2",
+      "RepTendsToInfty: r_A(n) → ∞",
+      "RepEventuallyGe: r_A(n) ≥ t eventually",
+      "CanPartitionIntoBases: partition into two disjoint bases",
+      "HasBlockingProperty: blocking condition for partitions",
+      "basis2_equiv: equivalence of basis definitions",
+      "repTendsToInfty_implies_basis: growth implies basis",
+      "blocking_prevents_partition: blocking ⇒ no partition",
+      "erdos_871_disproved: ¬Erdos871Conjecture",
+      "growth_rate_dichotomy: gap between ∞ and c·log(n)",
+      "larsen_subsumes_erdos_nathanson: subsumption result"
+    ],
+    "insights": [
+      "4 axioms for deep constructions: erdos_nathanson_1989, erdos_nathanson_positive, larsen_counterexample, larsen_construction_blocking",
+      "Critical growth-rate gap: r(n)→∞ is insufficient but c·log(n) suffices",
+      "File compiles cleanly with Lean v4.26.0 Docker Mathlib"
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },
@@ -46,12 +80,17 @@
   ],
   "relatedProofs": [],
   "references": {
-    "papers": [],
-    "urls": [],
+    "papers": [
+      "Erdős, P. & Nathanson, M. (1989). Partitions of bases into disjoint unions of bases. Acta Arithmetica LII.",
+      "Larsen, D. & Larsen, M. (2026). Robust additive bases without minimal subbases. arXiv:2601.18507."
+    ],
+    "urls": [
+      "https://erdosproblems.com/871"
+    ],
     "mathlib": []
   },
   "started": "2026-01-23T08:04:56.547Z",
-  "lastUpdate": "2026-01-23T08:04:56.547Z",
+  "lastUpdate": "2026-02-14T13:00:00.000Z",
   "significance": 7,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary
- Updated erdos-109.json (Erdős Sumset Conjecture) from NEW → COMPLETE
- Updated erdos-871.json (Partitioning Additive Bases) from NEW → COMPLETE
- Both Lean files already compile cleanly in Docker with 0 sorries
- erdos-109: 1 axiom (Moreira-Richter-Robertson 2019)
- erdos-871: 4 axioms (Erdős-Nathanson 1989 + Larsen 2026)

## Test plan
- [x] Verified Docker build passes for both Lean files
- [x] JSON schema is valid
- [x] Knowledge sections document all built items and axioms

🤖 Generated with [Claude Code](https://claude.com/claude-code)