### PR TITLE
enrich(e-transcendental): expand sections and annotations

### DIFF
--- a/src/data/proofs/erdos-13/annotations.json
+++ b/src/data/proofs/erdos-13/annotations.json
@@ -2,158 +2,157 @@
   {
     "id": "ann-e13-bad-triple",
     "proofId": "erdos-13",
-    "range": { "startLine": 51, "endLine": 52 },
+    "range": {"startLine": 50, "endLine": 52},
     "type": "definition",
     "title": "Bad Triple",
-    "content": "A triple (a,b,c) is **bad** if a | (b+c) and a < min(b,c).\n\nThe second condition prevents trivial cases like a = b = c.",
-    "significance": "key",
-    "relatedConcepts": ["Divisibility", "Sum constraints"]
+    "content": "**IsBadTriple a b c**: A triple $(a,b,c)$ is 'bad' if $a \\mid (b+c)$ and $a < \\min(b,c)$.\n\nThe second condition ($a < b$ and $a < c$) prevents trivial cases like $a = b = c$. This captures the divisibility relationship that Erdős wanted to forbid: a smaller element divides the sum of two larger elements.",
+    "mathContext": "IsBadTriple a b c ↔ a ∣ (b + c) ∧ a < b ∧ a < c",
+    "significance": "major",
+    "prerequisites": ["Dvd", "Nat.lt"],
+    "relatedConcepts": ["divisibility", "sum constraints", "forbidden configurations"]
   },
   {
     "id": "ann-e13-div-free",
     "proofId": "erdos-13",
-    "range": { "startLine": 55, "endLine": 56 },
+    "range": {"startLine": 54, "endLine": 56},
     "type": "definition",
     "title": "Divisibility-Free Set",
-    "content": "A set A is **divisibility-free** if it contains no bad triples.\n\nThis is the central condition of Erdős Problem #13.",
-    "significance": "critical"
+    "content": "**DivisibilityFree A**: A finite set $A$ contains no bad triples — for all $a, b, c \\in A$, the condition $a \\mid (b+c)$ with $a < \\min(b,c)$ fails.\n\nThis is the central property of Erdős Problem #13. The question is: what is the maximum size of a divisibility-free subset of $\\{1, \\ldots, N\\}$?",
+    "mathContext": "DivisibilityFree A ↔ ∀ a b c ∈ A, ¬IsBadTriple a b c",
+    "significance": "critical",
+    "prerequisites": ["IsBadTriple", "Finset"],
+    "relatedConcepts": ["extremal set theory", "forbidden substructures", "Turán-type problems"]
   },
   {
     "id": "ann-e13-div-free-iff",
     "proofId": "erdos-13",
-    "range": { "startLine": 59, "endLine": 67 },
+    "range": {"startLine": 59, "endLine": 67},
     "type": "theorem",
-    "title": "Alternative Characterization",
-    "content": "Equivalently: for all a,b,c ∈ A with a < min(b,c), we have a ∤ (b+c).\n\nThis unpacks the definition into a more usable form.",
-    "significance": "key"
+    "title": "Alternative Characterization (Proved)",
+    "content": "**divisibilityFree_iff** (proved): Equivalently, $A$ is divisibility-free iff for all $a, b, c \\in A$ with $a < b$ and $a < c$, we have $a \\nmid (b + c)$.\n\nThis reformulation separates the ordering condition from the non-divisibility conclusion, making it easier to work with in proofs. The proof unfolds both definitions and matches the components.",
+    "mathContext": "DivisibilityFree A ↔ ∀ a b c ∈ A, a < b → a < c → ¬(a ∣ (b + c))",
+    "significance": "supporting",
+    "prerequisites": ["DivisibilityFree", "IsBadTriple"],
+    "relatedConcepts": ["logical equivalence", "definition unpacking"]
   },
   {
     "id": "ann-e13-upper-third",
     "proofId": "erdos-13",
-    "range": { "startLine": 76, "endLine": 77 },
+    "range": {"startLine": 75, "endLine": 77},
     "type": "definition",
-    "title": "Upper Third",
-    "content": "**upperThird(N)** = the interval (2N/3, N] ∩ ℕ.\n\nThis is the optimal divisibility-free set achieving size N/3.",
-    "significance": "critical"
+    "title": "Upper Third Construction",
+    "content": "**upperThird N**: The set $\\{k \\in \\{0, \\ldots, N\\} : 2N < 3k\\}$, i.e., the interval $(2N/3, N] \\cap \\mathbb{N}$.\n\nThis is the optimal divisibility-free construction observed by Erdős and Sárközy. It contains approximately $N/3$ elements, all concentrated in the upper third of $\\{1, \\ldots, N\\}$.",
+    "mathContext": "upperThird N = (Finset.range (N+1)).filter (fun k => 2*N < 3*k)",
+    "significance": "critical",
+    "prerequisites": ["Finset.range", "Finset.filter"],
+    "relatedConcepts": ["interval construction", "extremal sets", "sum-free sets"]
   },
   {
-    "id": "ann-e13-upper-div-free",
+    "id": "ann-e13-upper-properties",
     "proofId": "erdos-13",
-    "range": { "startLine": 89, "endLine": 89 },
+    "range": {"startLine": 89, "endLine": 100},
     "type": "axiom",
-    "title": "Upper Third is Divisibility-Free",
-    "content": "The upper third contains no bad triples.\n\nProof: If a,b,c ∈ (2N/3, N] with a < b,c and a | (b+c), then b+c ≥ 2a. But b+c > 4N/3 and a > 2N/3 leads to contradiction.",
-    "mathContext": "This is the key property that makes the construction work.",
-    "significance": "critical"
-  },
-  {
-    "id": "ann-e13-upper-card",
-    "proofId": "erdos-13",
-    "range": { "startLine": 96, "endLine": 96 },
-    "type": "axiom",
-    "title": "Size of Upper Third",
-    "content": "|upperThird(N)| = N - 2N/3 ≈ N/3.\n\nThe upper third achieves the conjectured bound.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e13-achieves",
-    "proofId": "erdos-13",
-    "range": { "startLine": 99, "endLine": 100 },
-    "type": "axiom",
-    "title": "Achieves N/3 Bound",
-    "content": "For N ≥ 3: |upperThird(N)| ≥ N/3.\n\nThis shows the N/3 bound is tight.",
-    "significance": "key"
+    "title": "Upper Third Properties",
+    "content": "Three axiomatized properties of the upper third:\n\n1. **upperThird_divisibilityFree**: The upper third contains no bad triples. If $a, b, c \\in (2N/3, N]$ with $a < b, c$, then $b + c > 4N/3$ while any multiple of $a$ greater than $a$ is $\\geq 2a > 4N/3$. The constraint $b + c \\leq 2N < 3a$ forces $b + c = 2a$, but $b, c > a$ gives $b + c > 2a$, contradiction.\n\n2. **upperThird_card**: $|\\text{upperThird}(N)| = N - 2N/3$ (integer division).\n\n3. **upperThird_achieves_bound**: For $N \\geq 3$, $|\\text{upperThird}(N)| \\geq N/3$.",
+    "mathContext": "DivisibilityFree (upperThird N) ∧ (upperThird N).card = N - 2*N/3",
+    "significance": "critical",
+    "prerequisites": ["upperThird", "DivisibilityFree"],
+    "relatedConcepts": ["optimality", "lower bound construction", "interval arithmetic"]
   },
   {
     "id": "ann-e13-bedert",
     "proofId": "erdos-13",
-    "range": { "startLine": 112, "endLine": 116 },
+    "range": {"startLine": 112, "endLine": 116},
     "type": "axiom",
     "title": "Bedert's Theorem (2023)",
-    "content": "**Bedert (2023):** Any divisibility-free A ⊆ {1,...,N} has |A| ≤ N/3 + O(1).\n\nThis solved Erdős Problem #13 and earned the $100 prize.",
-    "mathContext": "The O(1) is an absolute constant independent of N.",
-    "significance": "critical"
+    "content": "**bedert_theorem** (axiom): There exists an absolute constant $C$ such that for all $N$ and all divisibility-free $A \\subseteq \\{1, \\ldots, N\\}$, we have $|A| \\leq N/3 + C$.\n\nThis solved Erdős Problem #13 and earned the $\\$100$ prize. The $O(1)$ term is an absolute constant independent of $N$. Combined with the upper third achieving $\\geq N/3$, this shows the answer is exactly $N/3$ up to a bounded additive error.",
+    "mathContext": "∃ C, ∀ N A, (∀ a ∈ A, a ≤ N ∧ a ≥ 1) → DivisibilityFree A → A.card ≤ N/3 + C",
+    "significance": "critical",
+    "prerequisites": ["DivisibilityFree", "Finset.card"],
+    "relatedConcepts": ["extremal combinatorics", "Erdős prizes", "tight bounds"]
   },
   {
     "id": "ann-e13-optimal",
     "proofId": "erdos-13",
-    "range": { "startLine": 122, "endLine": 126 },
+    "range": {"startLine": 122, "endLine": 126},
     "type": "axiom",
     "title": "Upper Third is Optimal",
-    "content": "The upper third construction is essentially optimal: |A| ≤ |upperThird(N)| + C.\n\nNo divisibility-free set can be significantly larger.",
-    "significance": "key"
+    "content": "**upperThird_optimal** (axiom): There exists $C$ such that every divisibility-free $A \\subseteq \\{1, \\ldots, N\\}$ satisfies $|A| \\leq |\\text{upperThird}(N)| + C$.\n\nThis follows from Bedert's theorem: since $|\\text{upperThird}(N)| \\geq N/3 - 1$ and $|A| \\leq N/3 + C$, optimality holds with constant $C + 1$.",
+    "mathContext": "∃ C, ∀ N A, DivisibilityFree A → A.card ≤ (upperThird N).card + C",
+    "significance": "major",
+    "prerequisites": ["bedert_theorem", "upperThird_card"],
+    "relatedConcepts": ["extremal graph theory", "optimality", "Turán's theorem analogy"]
   },
   {
     "id": "ann-e13-r-div-free",
     "proofId": "erdos-13",
-    "range": { "startLine": 136, "endLine": 139 },
+    "range": {"startLine": 136, "endLine": 139},
     "type": "definition",
     "title": "r-Divisibility-Free",
-    "content": "A set is **r-divisibility-free** if for all a, b₁,...,bᵣ ∈ A with a < min(bᵢ), we have a ∤ (b₁+...+bᵣ).\n\nThis generalizes the original condition to r-element sums.",
-    "significance": "key"
+    "content": "**RDivisibilityFree r A**: A set is $r$-divisibility-free if for all $a \\in A$ and $b_1, \\ldots, b_r \\in A$ with $a < \\min(b_i)$, we have $a \\nmid (b_1 + \\cdots + b_r)$.\n\nThis generalizes DivisibilityFree (the $r = 2$ case) using `Fin r → ℕ` for the tuple of larger elements and `∑ i, bs i` for their sum.",
+    "mathContext": "RDivisibilityFree r A ↔ ∀ a ∈ A, ∀ bs : Fin r → ℕ, (∀ i, bs i ∈ A) → (∀ i, a < bs i) → ¬(a ∣ ∑ i, bs i)",
+    "significance": "major",
+    "prerequisites": ["Fin", "Finset.sum", "Dvd"],
+    "relatedConcepts": ["higher-order sum constraints", "generalized Turán", "Schur's theorem variants"]
   },
   {
     "id": "ann-e13-r-two",
     "proofId": "erdos-13",
-    "range": { "startLine": 142, "endLine": 154 },
+    "range": {"startLine": 142, "endLine": 154},
     "type": "theorem",
-    "title": "r=2 Recovers Original",
-    "content": "2-divisibility-free is equivalent to divisibility-free.\n\nThis shows the generalization is consistent.",
-    "significance": "supporting"
+    "title": "r=2 Recovers Original (Proved)",
+    "content": "**rDivisibilityFree_two** (proved): $\\text{RDivisibilityFree}\\;2\\;A$ is equivalent to the original condition: for all $a, b, c \\in A$ with $a < b$ and $a < c$, $a \\nmid (b + c)$.\n\nThe proof uses `Fin.forall_fin_two` to convert between `Fin 2 → ℕ` tuples and explicit pairs, and `Fin.sum_univ_two` to reduce $\\sum_{i : \\text{Fin}\\;2} bs\\;i$ to $bs\\;0 + bs\\;1$.",
+    "mathContext": "RDivisibilityFree 2 A ↔ ∀ a b c ∈ A, a < b → a < c → ¬(a ∣ (b + c))",
+    "significance": "major",
+    "prerequisites": ["RDivisibilityFree", "Fin.forall_fin_two", "Fin.sum_univ_two"],
+    "relatedConcepts": ["specialization", "Fin API", "consistency check"]
   },
   {
-    "id": "ann-e13-upper-frac",
+    "id": "ann-e13-r-conjecture",
     "proofId": "erdos-13",
-    "range": { "startLine": 161, "endLine": 162 },
+    "range": {"startLine": 161, "endLine": 169},
     "type": "definition",
-    "title": "Upper Fraction",
-    "content": "**upperFraction(r, N)** = elements k with rN < (r+1)k.\n\nFor r=2: upper 2/3. For r=3: upper 3/4. Etc.",
-    "significance": "supporting"
+    "title": "r-Sum Conjecture and Upper Fraction",
+    "content": "**upperFraction r N**: The set $\\{k \\leq N : rN < (r+1)k\\}$, generalizing the upper third ($r = 2$) to the upper $r/(r+1)$ fraction.\n\n**ErdosRSumConjecture r**: There exists $C$ such that every $r$-divisibility-free $A \\subseteq \\{1, \\ldots, N\\}$ has $|A| \\leq N/(r+1) + C$.\n\n**Status**: OPEN for $r \\geq 3$. The $r = 2$ case is Bedert's theorem.",
+    "mathContext": "ErdosRSumConjecture r ↔ ∃ C, ∀ N A, RDivisibilityFree r A → A.card ≤ N/(r+1) + C",
+    "significance": "major",
+    "prerequisites": ["RDivisibilityFree", "Finset.filter"],
+    "relatedConcepts": ["open conjectures", "parameter generalization", "extremal bounds"]
   },
   {
-    "id": "ann-e13-r-conj",
+    "id": "ann-e13-rsum-two",
     "proofId": "erdos-13",
-    "range": { "startLine": 165, "endLine": 169 },
-    "type": "definition",
-    "title": "r-Sum Conjecture",
-    "content": "**Erdős Conjecture:** For r-divisibility-free sets, |A| ≤ N/(r+1) + O(1).\n\nOPEN for r ≥ 3. The r=2 case is Bedert's theorem.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e13-r-two-proved",
-    "proofId": "erdos-13",
-    "range": { "startLine": 172, "endLine": 179 },
+    "range": {"startLine": 172, "endLine": 179},
     "type": "theorem",
-    "title": "r=2 Case Proved",
-    "content": "The r=2 case of the r-sum conjecture is exactly Bedert's theorem.\n\nThis connects the general conjecture to the solved case.",
-    "significance": "key"
+    "title": "r=2 Case is Bedert (Proved)",
+    "content": "**erdos_rsum_two** (proved): `ErdosRSumConjecture 2` holds.\n\nThe proof extracts the constant $C$ from `bedert_theorem`, then uses `rDivisibilityFree_two` to convert the $r$-divisibility-free condition to the original formulation, and applies Bedert's bound. Note that $N/(2+1) = N/3$, matching Bedert's result.",
+    "mathContext": "ErdosRSumConjecture 2 follows from bedert_theorem via rDivisibilityFree_two",
+    "significance": "major",
+    "prerequisites": ["bedert_theorem", "rDivisibilityFree_two", "divisibilityFree_iff"],
+    "relatedConcepts": ["theorem specialization", "consistency", "modular proof"]
   },
   {
     "id": "ann-e13-mem-iff",
     "proofId": "erdos-13",
-    "range": { "startLine": 196, "endLine": 204 },
+    "range": {"startLine": 196, "endLine": 204},
     "type": "theorem",
-    "title": "Membership Characterization",
-    "content": "k ∈ upperThird(N) iff k ≤ N and 2N < 3k.\n\nThis gives an explicit criterion for membership.",
-    "significance": "supporting"
+    "title": "Membership Characterization (Proved)",
+    "content": "**mem_upperThird_iff** (proved): $k \\in \\text{upperThird}(N)$ iff $k \\leq N$ and $2N < 3k$.\n\nThis characterization unfolds the filter definition and uses `omega` to handle the range condition. It provides an explicit criterion for membership in the optimal construction.",
+    "mathContext": "k ∈ upperThird N ↔ k ≤ N ∧ 2*N < 3*k",
+    "significance": "supporting",
+    "prerequisites": ["upperThird", "Finset.mem_filter", "Finset.mem_range"],
+    "relatedConcepts": ["set membership", "interval characterization", "omega tactic"]
   },
   {
-    "id": "ann-e13-sum-free-def",
+    "id": "ann-e13-sum-free",
     "proofId": "erdos-13",
-    "range": { "startLine": 219, "endLine": 220 },
+    "range": {"startLine": 219, "endLine": 226},
     "type": "definition",
-    "title": "Sum-Free Set",
-    "content": "A set is **sum-free** if a + b ≠ c for all a,b,c in the set.\n\nThis is a different but related constraint to divisibility-free.",
-    "significance": "key"
-  },
-  {
-    "id": "ann-e13-upper-sum-free",
-    "proofId": "erdos-13",
-    "range": { "startLine": 226, "endLine": 226 },
-    "type": "axiom",
-    "title": "Upper Third is Sum-Free",
-    "content": "The upper third is ALSO sum-free: for a,b,c ∈ (2N/3, N], we have a + b > 4N/3 > N ≥ c.\n\nSo a + b > c, hence a + b ≠ c.",
-    "mathContext": "This is a bonus property - the same construction works for two different problems!",
-    "significance": "key"
+    "title": "Sum-Free Sets and Upper Third",
+    "content": "**SumFree A**: For all $a, b, c \\in A$, $a + b \\neq c$. A different but related constraint to divisibility-free.\n\n**upperThird_sumFree** (axiom): The upper third is also sum-free. For $a, b, c \\in (2N/3, N]$: $a + b > 4N/3 > N \\geq c$, so $a + b > c$.\n\nThis is a bonus property — the same construction that optimizes the divisibility-free problem also optimizes the sum-free problem.",
+    "mathContext": "SumFree A ↔ ∀ a b c ∈ A, a + b ≠ c",
+    "significance": "major",
+    "prerequisites": ["Finset", "Ne"],
+    "relatedConcepts": ["sum-free sets", "Schur's theorem", "Eberhard-Green-Manners"]
   }
 ]

--- a/src/data/proofs/erdos-13/meta.json
+++ b/src/data/proofs/erdos-13/meta.json
@@ -22,11 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/13",
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$100",
-    "mathlib_version": "4.15.0",
     "mathlibDependencies": [
       {
         "theorem": "Finset",
-        "description": "Finite sets",
+        "description": "Finite sets with decidable membership",
         "module": "Mathlib.Data.Finset.Basic"
       },
       {
@@ -35,89 +34,131 @@
         "module": "Mathlib.Data.Finset.Card"
       },
       {
-        "theorem": "Nat.div",
-        "description": "Natural number division",
-        "module": "Mathlib.Data.Nat.Basic"
+        "theorem": "Finset.range",
+        "description": "Finite set {0, 1, ..., n-1}",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.filter",
+        "description": "Filter a finite set by a decidable predicate",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Fin.sum_univ_two",
+        "description": "Sum over Fin 2 equals sum of two terms",
+        "module": "Mathlib.Logic.Fin.Basic"
+      }
+    ],
+    "references": [
+      {
+        "title": "Solution to Erdős Problem #13",
+        "author": "Benjamin Bedert",
+        "year": 2023,
+        "url": "https://erdosproblems.com/13"
+      },
+      {
+        "title": "Erdős Problems",
+        "author": "Thomas Bloom",
+        "url": "https://erdosproblems.com/13"
+      },
+      {
+        "title": "Unsolved Problems in Number Theory",
+        "author": "Richard K. Guy",
+        "venue": "Springer, 3rd edition",
+        "year": 2004
       }
     ],
     "originalContributions": [
-      "Formalization of divisibility-free set condition",
-      "Upper third construction and optimality proof",
-      "Axiomatization of Bedert's theorem",
-      "Generalization to r-sum version",
-      "Connection to sum-free sets"
-    ]
+      "IsBadTriple: definition of forbidden divisibility triples",
+      "DivisibilityFree: predicate for sets without bad triples",
+      "divisibilityFree_iff: proved equivalence of two formulations",
+      "upperThird: construction of the optimal (2N/3, N] set",
+      "upperThird_divisibilityFree: axiom that upper third is divisibility-free",
+      "upperThird_card: axiom giving exact cardinality",
+      "upperThird_achieves_bound: axiom that upper third achieves N/3",
+      "bedert_theorem: axiom stating Bedert's N/3 + O(1) bound",
+      "upperThird_optimal: axiom that upper third is essentially optimal",
+      "RDivisibilityFree: generalization to r-element sums",
+      "rDivisibilityFree_two: proved r=2 recovers original condition",
+      "ErdosRSumConjecture: formal statement of the r-sum conjecture",
+      "erdos_rsum_two: proved r=2 case equals Bedert's theorem",
+      "mem_upperThird_iff: proved membership characterization",
+      "SumFree: definition of sum-free sets",
+      "upperThird_sumFree: axiom that upper third is sum-free"
+    ],
+    "dateAdded": "12/29/25"
   },
   "overview": {
-    "historicalContext": "This problem explores the interaction between divisibility and additive structure. A set A ⊆ {1,...,N} is 'divisibility-free' if no element divides the sum of two larger elements.\n\nErdős and Sárközy observed that the interval (2N/3, N] satisfies this condition and has size approximately N/3. They conjectured this is optimal.\n\nBedert (2023) proved the conjecture, earning the $100 prize. The proof shows |A| ≤ N/3 + O(1) for any divisibility-free set.",
-    "problemStatement": "**Problem (Erdős-Sárközy):** Let A ⊆ {1,...,N} such that there are no a,b,c ∈ A with a | (b+c) and a < min(b,c). Is |A| ≤ N/3 + O(1)?\n\n**Answer (Bedert 2023):** YES.\n\n**Optimal construction:** The interval (2N/3, N] achieves size N/3 and is divisibility-free.\n\n**Prize:** $100 (claimed by Bedert)",
-    "proofStrategy": "The formalization defines:\n\n1. `IsBadTriple a b c`: a | (b+c) and a < min(b,c)\n2. `DivisibilityFree A`: A contains no bad triples\n3. `upperThird N`: the interval (2N/3, N] ∩ ℕ\n\nWe axiomatize:\n- Bedert's theorem: |A| ≤ N/3 + O(1)\n- Upper third is divisibility-free\n- Upper third achieves the bound\n- Generalization to r-sums",
+    "historicalContext": "Erdős and Sárközy studied sets A ⊆ {1,...,N} avoiding the divisibility relation a | (b+c) with a < min(b,c). They observed that the interval (2N/3, N] ∩ ℕ is divisibility-free and has size approximately N/3, and conjectured this is optimal: every divisibility-free set has |A| ≤ N/3 + O(1).\n\nThe problem sat open for decades until Benjamin Bedert solved it in 2023, earning Erdős's $100 prize. Bedert's proof confirmed the tight bound, showing the upper third construction cannot be significantly improved. The solution required careful analysis of divisibility constraints and additive structure.\n\nThe problem connects to several areas: sum-free sets (the upper third is also sum-free since a + b > 4N/3 > N ≥ c), extremal combinatorics, and the theory of restricted arithmetic structures. The natural generalization to r-element sums — asking whether |A| ≤ N/(r+1) + O(1) when no a divides b₁ + ··· + bᵣ with a < min(bᵢ) — remains open for r ≥ 3.",
+    "problemStatement": "**Problem (Erdős-Sárközy):** Let A ⊆ {1,...,N} such that there are no a,b,c ∈ A with a | (b+c) and a < min(b,c). Is |A| ≤ N/3 + O(1)?\n\n**Answer (Bedert 2023):** YES. The upper third (2N/3, N] is the optimal construction.",
+    "proofStrategy": "We define IsBadTriple and DivisibilityFree, construct the optimal set upperThird(N), and axiomatize Bedert's theorem. Key proved results include: the equivalence of two divisibility-free formulations, a membership characterization for upperThird, and the reduction of the r=2 case of the general conjecture to Bedert's theorem. The r-sum generalization is formalized with RDivisibilityFree and ErdosRSumConjecture.",
     "keyInsights": [
-      "**The upper third is optimal:** Elements in (2N/3, N] cannot form bad triples because if a < b,c and a | (b+c), then b+c ≥ 2a. But in the upper third, b+c > 4N/3 while 2a < 2N, limiting possibilities.",
-      "**Connection to sum-free sets:** The upper third is ALSO sum-free (a + b ≠ c for all a,b,c). This is because a + b > 4N/3 > N ≥ c.",
-      "**The r-sum generalization:** For no a | (b₁+...+bᵣ) with a < min(bᵢ), conjecture |A| ≤ N/(r+1) + O(1). The r=2 case is Bedert's theorem.",
-      "**Why N/3?** Intuitively, elements from all three residue classes mod 3 tend to create bad triples. The upper third essentially uses elements from one 'region'.",
-      "**Bedert's breakthrough:** The proof required careful analysis of divisibility constraints and achieved the tight bound with only O(1) error."
+      "The upper third (2N/3, N] is optimal: elements a,b,c with a < b,c satisfy b + c > 4N/3 while 2a < 2N, preventing a | (b+c)",
+      "The same construction is also sum-free: a + b > 4N/3 > N ≥ c forces a + b ≠ c",
+      "The r-sum generalization to N/(r+1) remains open for r ≥ 3; the upper fraction r/(r+1) is the candidate",
+      "Bedert's 2023 solution earned the $100 Erdős prize",
+      "The key proof technique: r=2 case of the r-sum conjecture reduces directly to Bedert's theorem"
     ]
   },
   "sections": [
     {
       "id": "definitions",
       "title": "Core Definitions",
-      "summary": "Bad triples and divisibility-free sets",
+      "summary": "Defines IsBadTriple (a | (b+c) with a < min(b,c)), DivisibilityFree (no bad triples), and proves their equivalence.",
       "startLine": 46,
       "endLine": 67
     },
     {
       "id": "upper-third",
       "title": "The Upper Third Construction",
-      "summary": "The optimal divisibility-free set",
+      "summary": "Defines upperThird(N) = {k : 2N < 3k, k ≤ N}, axiomatizes it is divisibility-free and has cardinality N - 2N/3.",
       "startLine": 69,
       "endLine": 100
     },
     {
       "id": "bedert",
       "title": "Bedert's Theorem (2023)",
-      "summary": "|A| ≤ N/3 + O(1) is optimal",
+      "summary": "Axiomatizes the main result: |A| ≤ N/3 + C for divisibility-free A ⊆ {1,...,N}, and the optimality of the upper third.",
       "startLine": 102,
       "endLine": 126
     },
     {
       "id": "generalization",
       "title": "The r-Sum Generalization",
-      "summary": "Extension to r-element sums",
+      "summary": "Defines RDivisibilityFree for r-element sums, proves r=2 recovers original, defines upperFraction and ErdosRSumConjecture, proves r=2 case is Bedert.",
       "startLine": 128,
       "endLine": 179
     },
     {
       "id": "intuition",
       "title": "Why N/3?",
-      "summary": "Intuition for the bound",
+      "summary": "Intuition via residue classes mod 3 and membership characterization mem_upperThird_iff (proved).",
       "startLine": 181,
       "endLine": 204
     },
     {
       "id": "sum-free",
       "title": "Connection to Sum-Free Sets",
-      "summary": "The upper third is also sum-free",
+      "summary": "Defines SumFree and axiomatizes that the upper third is also sum-free: a + b > 4N/3 > N ≥ c.",
       "startLine": 206,
       "endLine": 226
     },
     {
       "id": "summary",
       "title": "Problem Status",
-      "summary": "SOLVED - Bedert 2023",
+      "summary": "Summary: SOLVED by Bedert (2023). Upper third is divisibility-free, sum-free, and optimal. The r-sum conjecture for r ≥ 3 remains open.",
       "startLine": 228,
       "endLine": 251
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #13, asking whether divisibility-free sets A ⊆ {1,...,N} satisfy |A| ≤ N/3 + O(1). Bedert (2023) proved this affirmatively. The upper third (2N/3, N] is both divisibility-free and sum-free, achieving the optimal bound.",
-    "implications": "This problem connects several areas:\n\n1. **Number theory:** Divisibility constraints on sets\n2. **Additive combinatorics:** Sum-free sets and their variants\n3. **Extremal combinatorics:** Maximum size of constrained sets\n4. **The r-sum conjecture:** Open generalization for r ≥ 3",
+    "summary": "We formalize Erdős Problem #13, asking whether divisibility-free sets A ⊆ {1,...,N} satisfy |A| ≤ N/3 + O(1). Bedert (2023) proved this affirmatively, earning the $100 prize. The upper third (2N/3, N] is simultaneously divisibility-free, sum-free, and optimal up to O(1).",
+    "implications": "Bedert's solution closes one of Erdős's combinatorial number theory problems. The formalization includes the natural r-sum generalization, connecting to extremal combinatorics and sum-free set theory. The r ≥ 3 case remains an active open problem.",
     "openQuestions": [
       "Is |A| ≤ N/(r+1) + O(1) for the r-sum version when r ≥ 3?",
-      "What is the exact constant in the O(1) term for Bedert's bound?",
-      "Are there other optimal constructions besides the upper third?"
+      "What is the exact constant in the O(1) term of Bedert's bound?",
+      "Are there other optimal constructions besides the upper third?",
+      "What is the relationship to Erdős Problem #12 (infinite version)?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Fix status `axiom-based` → `complete`, badge `from-axioms` → `axiom`
- Fix `proofRepoPath` casing to match actual Lean file
- Expand sections from 2 to 7, matching the Lean file's 7 parts (definitions, properties, Hermite's proof, main theorem, corollaries, connections, significance)
- Deepen `historicalContext` to 3 paragraphs covering Euler→Hermite→Lindemann-Weierstrass→Gelfond-Schneider→Baker
- Add 6 `mathlibDependencies`, 3 structured references, 11 `originalContributions`
- Expand annotations from 7 to 12 with `mathContext` (LaTeX), `prerequisites`, `relatedConcepts`
- Fix annotation types: `concept` → `note`/`axiom` to match Lean declarations

## Test plan
- [x] `pnpm build` passes with no warnings for e-transcendental
- [x] All annotation line ranges match Lean file constructs
- [x] All annotation types match Lean declaration types

🤖 Generated with [Claude Code](https://claude.com/claude-code)