### PR TITLE
complete: law-of-cosines-oq-01 (spherical law of cosines)

### DIFF
--- a/src/data/research/problems/law-of-cosines-oq-01.json
+++ b/src/data/research/problems/law-of-cosines-oq-01.json
@@ -1,0 +1,50 @@
+{
+  "slug": "law-of-cosines-oq-01",
+  "title": "Spherical Law of Cosines",
+  "phase": "COMPLETE",
+  "status": "complete",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For unit vectors A, B, C on S²: ⟨A, B⟩ = ⟨A, C⟩⟨B, C⟩ + ⟨proj⊥(A,C), proj⊥(B,C)⟩, equivalently cos(c) = cos(a)·cos(b) + sin(a)·sin(b)·cos(C)",
+    "plain": "The spherical law of cosines relates sides and angles of a spherical triangle: cos(c) = cos(a)·cos(b) + sin(a)·sin(b)·cos(C), where a, b, c are arc-length sides and C is the dihedral angle opposite side c.",
+    "whyMatters": [
+      "Fundamental theorem of spherical trigonometry, essential for navigation and astronomy",
+      "Generalizes the planar law of cosines to curved surfaces",
+      "Key tool in geodesy, GPS positioning, and celestial mechanics",
+      "In the small-angle limit, reduces to the planar law of cosines c² = a² + b² - 2ab·cos(C)"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Arc length on S² is well-defined, symmetric, non-negative, and at most π",
+      "cos(arcLength(u,v)) = ⟨u,v⟩ for unit vectors",
+      "Inner product decomposition: ⟨u,v⟩ = ⟨u,n⟩⟨v,n⟩ + ⟨proj⊥(u,n), proj⊥(v,n)⟩",
+      "‖proj⊥(u,n)‖² = 1 - ⟨u,n⟩² = sin²(arcLength(u,n)) for unit vectors",
+      "‖proj⊥(u,n)‖ = sin(arcLength(u,n)) for arc lengths in [0,π]",
+      "Spherical law of cosines (algebraic form)",
+      "Spherical law of cosines (trigonometric form with SphericalTriangle structure)",
+      "Degenerate triangle cases (vertex coincidence)",
+      "Perpendicular projection of unit vector onto itself is zero"
+    ],
+    "axiomatized": []
+  },
+  "knowledge": {
+    "insights": [
+      "The key algebraic identity is inner product decomposition: project u,v onto direction n and its perpendicular complement",
+      "Using EuclideanSpace ℝ (Fin 3) as Vec3 works well with Mathlib's inner product space infrastructure",
+      "The dihedral angle at C is the angle between projections of A and B onto the plane perpendicular to C",
+      "arccos is well-defined for unit vector inner products since |⟨u,v⟩| ≤ 1",
+      "sin(arcLength) ≥ 0 because arcLength ∈ [0,π], which is needed for the norm equality (not just squared)",
+      "The proof requires no axioms - all 24 theorems are fully proved from Mathlib"
+    ],
+    "builtItems": [
+      "SphericalLawOfCosines.lean: 342 lines, 24 proved theorems, 0 axioms, 0 sorries",
+      "SphericalTriangle structure with sides and angle definitions",
+      "projectPerp function for perpendicular projection onto plane normal to unit vector",
+      "arcLength definition and properties (nonneg, le_pi, symmetric, cos recovery)"
+    ],
+    "nextSteps": [],
+    "progressSummary": "COMPLETE: Full formalization of the spherical law of cosines. 24 theorems proved with 0 sorries and 0 axioms. Covers algebraic form, trigonometric form, degenerate cases, and connection to planar limit."
+  }
+}


### PR DESCRIPTION
## Summary
- Verified existing `SphericalLawOfCosines.lean` builds successfully (24 theorems, 0 sorries, 0 axioms)
- Created problem JSON documenting the complete formalization

## Progress
- Proof file already existed with full formalization
- Docker build confirmed: all 24 theorems compile cleanly
- Problem JSON created with knowledge insights and built items

## Findings
- The spherical law of cosines is fully proved using inner product decomposition
- Key identity: `⟨u,v⟩ = ⟨u,n⟩⟨v,n⟩ + ⟨proj⊥(u,n), proj⊥(v,n)⟩`
- Covers algebraic form, trigonometric form, degenerate cases
- Documents connection to planar limit (small-angle approximation)

## Status
**Outcome**: completed
**Next Steps**: None - proof is complete

Generated by researcher-1