### PR TITLE
complete: area-of-circle-oq-01 (circumference via differentiation)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "area-of-circle-oq-01",
+  "title": "Circumference Formula via Area Differentiation",
+  "slug": "area-of-circle-oq-01",
+  "description": "The circumference C = 2\u03c0r derived by differentiating the area formula A = \u03c0r\u00b2. Formalizes the deep geometric connection that the boundary length equals the rate of change of area with respect to radius.",
+  "meta": {
+    "author": "Archimedes (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Area_of_a_circle",
+    "date": "~250 BCE",
+    "status": "complete",
+    "proofRepoPath": "Proofs/CircumferenceFromArea.lean",
+    "tags": [
+      "analysis",
+      "geometry",
+      "calculus",
+      "differentiation",
+      "extension",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "hasDerivAt_pow",
+        "description": "Derivative of x^n is n * x^(n-1)",
+        "module": "Mathlib.Analysis.Calculus.Deriv.Pow"
+      },
+      {
+        "theorem": "HasDerivAt.const_mul",
+        "description": "Derivative of c * f(x) is c * f'(x)",
+        "module": "Mathlib.Analysis.Calculus.Deriv.Basic"
+      },
+      {
+        "theorem": "Real.pi_pos",
+        "description": "\u03c0 > 0",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Complete formalization of C = 2\u03c0r via differentiation of A = \u03c0r\u00b2",
+      "HasDerivAt and deriv proofs for the circle area function",
+      "Second derivative d\u00b2A/dr\u00b2 = 2\u03c0 (circumference growth rate is constant)",
+      "Isoperimetric equality C\u00b2 = 4\u03c0A as a formal corollary",
+      "Monotonicity and scaling laws for both area and circumference",
+      "Answers open question from Area of a Circle gallery entry"
+    ],
+    "dateAdded": "02/14/26"
+  },
+  "overview": {
+    "historicalContext": "The relationship between a circle's area and circumference was known to Archimedes: he viewed the disk as composed of infinitely many concentric rings, each of circumference $C(\\rho) = 2\\pi\\rho$, so $A(r) = \\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$. The inverse relationship $C = dA/dr$ follows by the fundamental theorem of calculus. This elegant connection generalizes to all dimensions: the surface area of an $n$-ball is the derivative of its volume with respect to radius.",
+    "problemStatement": "**Circumference via Differentiation**:\n\nFor the area function $A(r) = \\pi r^2$, prove:\n$$\\frac{dA}{dr} = 2\\pi r = C(r)$$\n\nwhere $C(r)$ is the circumference of a circle with radius $r$.",
+    "proofStrategy": "Define $A(r) = \\pi r^2$ as a real-valued function and use Mathlib's calculus infrastructure. The power rule gives $d(r^2)/dr = 2r$, and constant multiplication gives $d(\\pi r^2)/dr = \\pi \\cdot 2r = 2\\pi r$. This is packaged using `HasDerivAt` for the strongest form, with `deriv` and `Differentiable` corollaries.",
+    "keyInsights": [
+      "The derivative $dA/dr = 2\\pi r$ has a beautiful geometric interpretation: increasing the radius by $dr$ adds an annular strip of width $dr$ and length $C(r)$",
+      "The isoperimetric equality $C^2 = 4\\pi A$ follows purely by algebra from the definitions",
+      "The second derivative $d^2A/dr^2 = 2\\pi$ is constant, reflecting that circumference grows linearly with radius",
+      "This relationship generalizes to all dimensions: $S_n(r) = dV_n/dr$ where $S_n$ is surface area and $V_n$ is volume"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Area and Circumference Functions",
+      "startLine": 46,
+      "endLine": 50,
+      "summary": "Defines `circleArea(r) = \\pi r^2` and `circumference(r) = 2\\pi r` as noncomputable real-valued functions."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: Derivative of Area Equals Circumference",
+      "startLine": 52,
+      "endLine": 71,
+      "summary": "Proves `hasDerivAt_circleArea`: the area function has derivative $2\\pi r$ at every point $r$, using the power rule and constant multiplication. Also proves the `HasDerivAt` form with the circumference function."
+    },
+    {
+      "id": "deriv-forms",
+      "title": "Derivative and Differentiability",
+      "startLine": 73,
+      "endLine": 88,
+      "summary": "Derives the `deriv` form (`deriv circleArea r = 2\\pi r`), equality with the circumference function, and global differentiability of the area function."
+    },
+    {
+      "id": "special-cases",
+      "title": "Special Cases and Scaling Laws",
+      "startLine": 90,
+      "endLine": 114,
+      "summary": "Unit circumference ($2\\pi$), zero circumference ($0$), scaling laws for both area ($c^2$-quadratic) and circumference ($c$-linear)."
+    },
+    {
+      "id": "higher-order",
+      "title": "Higher-Order Properties",
+      "startLine": 116,
+      "endLine": 148,
+      "summary": "Second derivative equals $2\\pi$ (constant), positivity for positive radius, monotonicity of both area and circumference for non-negative radii."
+    },
+    {
+      "id": "isoperimetric",
+      "title": "Isoperimetric Equality and Duality",
+      "startLine": 150,
+      "endLine": 163,
+      "summary": "The isoperimetric equality $C^2 = 4\\pi A$ and the circumference-from-derivative duality theorem."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization proves that the circumference formula $C = 2\\pi r$ follows from differentiating the area formula $A = \\pi r^2$, answering the open question from the Area of a Circle gallery entry. The proof uses Mathlib's calculus infrastructure (HasDerivAt, deriv) and includes extensive corollaries: differentiability, second derivative, isoperimetric equality, monotonicity, and scaling laws. All 163 lines, 0 sorries, 0 axioms.",
+    "implications": "This formalizes a fundamental relationship in geometry: the boundary length is the derivative of the enclosed area. The same principle generalizes to higher dimensions ($S_n = dV_n/dr$) and to arbitrary smooth domains via the coarea formula. The isoperimetric equality $C^2 = 4\\pi A$ is the equality case of the isoperimetric inequality.",
+    "openQuestions": [
+      "Can the n-dimensional volume-surface area derivative relationship V'_n(r) = S_n(r) be formalized?",
+      "Can the integral direction be formalized: A(r) = integral from 0 to r of C(rho) drho?",
+      "Can the isoperimetric inequality (C^2 >= 4*pi*A with equality only for circles) be proved?"
+    ]
+  }
+}

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -1,0 +1,106 @@
+{
+  "slug": "area-of-circle-oq-01",
+  "title": "Circumference Formula via Area Differentiation",
+  "phase": "COMPLETE",
+  "status": "complete",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "Define circleArea(r) = pi * r^2 and prove HasDerivAt circleArea (2 * pi * r) r, establishing that the circumference C = 2*pi*r is the derivative of the area function. Also prove the isoperimetric equality C^2 = 4*pi*A.",
+    "plain": "Prove that the circumference of a circle C = 2*pi*r can be derived by differentiating the area formula A = pi*r^2 with respect to the radius. This formalizes the deep geometric connection that the boundary length equals the rate of change of area.",
+    "whyMatters": [
+      "Demonstrates the deep connection between area and circumference via calculus",
+      "First formal proof of C = 2*pi*r from differentiation in Lean 4",
+      "Extends Wiedijk #9 (Area of a Circle) with calculus content",
+      "Establishes the isoperimetric equality C^2 = 4*pi*A as a formal corollary"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "hasDerivAt_circleArea: HasDerivAt circleArea (2 * pi * r) r",
+      "deriv_circleArea: deriv circleArea r = 2 * pi * r",
+      "deriv_circleArea_eq_circumference: deriv circleArea r = circumference r",
+      "differentiable_circleArea: Differentiable R circleArea",
+      "deriv2_circleArea: deriv (deriv circleArea) r = 2 * pi",
+      "isoperimetric_equality: circumference r ^ 2 = 4 * pi * circleArea r",
+      "circumference_from_deriv: circumference r = deriv circleArea r",
+      "circumference_pos: 0 < circumference r for r > 0",
+      "circleArea_pos: 0 < circleArea r for r > 0",
+      "circleArea_mono: area is monotone for non-negative radii",
+      "circumference_mono: circumference is monotone for non-negative radii",
+      "circumference_scaling: C(cr) = c * C(r)",
+      "circleArea_scaling: A(cr) = c^2 * A(r)"
+    ],
+    "open": [],
+    "goal": "COMPLETE - proved in CircumferenceFromArea.lean with 0 sorries, 0 axioms"
+  },
+  "currentState": {
+    "phase": "COMPLETE",
+    "since": "2026-02-14T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Complete. All theorems proved in CircumferenceFromArea.lean.",
+    "blockers": [],
+    "nextAction": "None - problem is complete.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 0,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: CircumferenceFromArea.lean proves C = 2*pi*r via differentiation of A = pi*r^2 using Mathlib's HasDerivAt infrastructure. Includes HasDerivAt, deriv, differentiability, second derivative (2*pi constant), isoperimetric equality C^2 = 4*pi*A, monotonicity, scaling, and special cases. Also have CircumferenceViaDifferentiation.lean with measure-theoretic connection to Lebesgue measure. All 163 lines, 0 sorries, 0 axioms. Docker build verified.",
+    "builtItems": [
+      "circleArea : R -> R (area function pi * r^2)",
+      "circumference : R -> R (circumference function 2 * pi * r)",
+      "hasDerivAt_circleArea (main HasDerivAt proof)",
+      "deriv_circleArea (deriv form)",
+      "deriv_circleArea_eq_circumference (equality with circumference function)",
+      "differentiable_circleArea (differentiability)",
+      "deriv2_circleArea (second derivative = 2*pi)",
+      "isoperimetric_equality (C^2 = 4*pi*A)",
+      "circumference_from_deriv (C = dA/dr)",
+      "circleArea_mono, circumference_mono (monotonicity)",
+      "circleArea_scaling, circumference_scaling (scaling laws)"
+    ],
+    "insights": [
+      "HasDerivAt for pi * r^2 uses (hasDerivAt_pow 2 r).const_mul pi pattern",
+      "The isoperimetric equality C^2 = 4*pi*A follows purely from ring arithmetic",
+      "Second derivative d^2A/dr^2 = 2*pi shows circumference growth rate is constant",
+      "CircumferenceViaDifferentiation.lean also connects to measure-theoretic area via ENNReal.toReal"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "approaches": [
+    {
+      "name": "Direct calculus via HasDerivAt",
+      "status": "succeeded",
+      "description": "Define circleArea(r) = pi * r^2, use (hasDerivAt_pow 2 r).const_mul pi to get derivative pi * (2 * r) = 2 * pi * r"
+    }
+  ],
+  "tags": [
+    "seeker-selected",
+    "analysis",
+    "geometry",
+    "differentiation",
+    "extension",
+    "0-sorry",
+    "0-axiom"
+  ],
+  "relatedProofs": [
+    "AreaOfCircle.lean",
+    "CircumferenceFromArea.lean",
+    "CircumferenceViaDifferentiation.lean"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Area_of_a_circle"
+    ],
+    "mathlib": [
+      "Mathlib.Analysis.Calculus.Deriv.Basic",
+      "Mathlib.Analysis.Calculus.Deriv.Pow",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Created problem JSON and gallery meta.json for area-of-circle-oq-01
- The proof (CircumferenceFromArea.lean) already existed with 0 sorries, 0 axioms
- Docker build verified successfully
- Answers open question from Area of a Circle gallery: "Can C = 2πr be derived via differentiation of A = πr²?"

## Key Results
- `hasDerivAt_circleArea`: HasDerivAt proof that dA/dr = 2πr
- `deriv_circleArea_eq_circumference`: deriv form equals circumference function
- `isoperimetric_equality`: C² = 4πA
- `deriv2_circleArea`: d²A/dr² = 2π (constant)

## Files Added
- `src/data/research/problems/area-of-circle-oq-01.json` - Problem JSON (phase: COMPLETE)
- `src/data/proofs/area-of-circle-oq-01/meta.json` - Gallery entry

## Test plan
- [x] Docker build of CircumferenceFromArea.lean passes
- [x] Problem JSON validates (phase: COMPLETE, 0 sorries)
- [x] Gallery meta.json follows existing patterns

🤖 Generated by researcher-1