### PR TITLE
complete: bounded-prime-gaps (fix build, 90 theorems)

### DIFF
--- a/proofs/Proofs/BoundedPrimeGaps.lean
+++ b/proofs/Proofs/BoundedPrimeGaps.lean
@@ -342,12 +342,19 @@ private theorem polymath50Tuple_admissible : IsAdmissible polymath50Tuple := by
                               · -- p is prime, ≥ 2, ≠ all primes ≤ 47, so p ≥ 53
                                 have hp53 : p ≥ 53 := by
                                   have h2le := hp.two_le
-                                  have hodd := hp.eq_two_or_odd.elim
-                                    (fun h => absurd h hp2) id
                                   by_contra hlt
                                   push_neg at hlt
-                                  have : p = 49 ∨ p = 51 := by omega
-                                  rcases this with rfl | rfl <;> exact absurd hp (by decide)
+                                  -- p ∈ {2,...,52}, prime, not equal to any prime ≤ 47
+                                  interval_cases p <;>
+                                    first | exact absurd rfl hp2 | exact absurd rfl hp3
+                                           | exact absurd rfl hp5 | exact absurd rfl hp7
+                                           | exact absurd rfl hp11 | exact absurd rfl hp13
+                                           | exact absurd rfl hp17 | exact absurd rfl hp19
+                                           | exact absurd rfl hp23 | exact absurd rfl hp29
+                                           | exact absurd rfl hp31 | exact absurd rfl hp37
+                                           | exact absurd rfl hp41 | exact absurd rfl hp43
+                                           | exact absurd rfl hp47
+                                           | exact absurd hp (by decide)
                                 linarith
 
 private theorem polymath50Tuple_le_246 : ∀ a ∈ polymath50Tuple, a ≤ 246 := by native_decide

--- a/src/data/research/problems/bounded-prime-gaps.json
+++ b/src/data/research/problems/bounded-prime-gaps.json
@@ -1,0 +1,59 @@
+{
+  "slug": "bounded-prime-gaps",
+  "title": "Bounded Prime Gaps (Zhang/Polymath/Maynard-Tao)",
+  "phase": "COMPLETE",
+  "status": "complete",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "∃ C : ℕ, ∀ᶠ n in atTop, nthPrime (n+1) - nthPrime n ≤ C. Specifically C = 246 (Polymath 8b) and conditionally C = 12 (under Elliott-Halberstam).",
+    "plain": "There are infinitely many pairs of primes that differ by at most 246. This was proved by Zhang (2013, with bound 70,000,000) and optimized by Polymath 8b (2014, bound 246). Maynard-Tao (2015) generalized to m-tuples.",
+    "whyMatters": [
+      "Landmark result in analytic number theory (Zhang 2013)",
+      "First unconditional proof of bounded prime gaps",
+      "Polymath 8b collaborative optimization to 246",
+      "Maynard-Tao generalization to m-tuples in bounded intervals",
+      "Key step toward twin prime conjecture"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Admissible tuple framework: empty, singleton, subset, card < 2 cases",
+      "Specific admissible tuples: {0,2}, {0,2,6}, {0,4,6}, {0,2,6,8}, {0,2,6,8,12}, {0,4,6,10,12}",
+      "Non-admissibility: {0,1}, {0,1,2}, {0,1,2,3,4}, general range criterion",
+      "Polymath 50-tuple constructive existence (50 elements, diameter ≤ 246)",
+      "Zhang bound 70M follows from Polymath bound 246",
+      "nthPrime properties: primality, strict monotonicity, positivity, p₀=2, p₁=3",
+      "Prime gap properties: positivity, evenness for n≥1, gap ≥ 2 for n≥1",
+      "Consequences: liminf ≤ 246, bounded consecutive gaps from m-tuples",
+      "Dickson connections: twin primes from {0,2}, prime triples from {0,2,6}",
+      "Elliott-Halberstam conditional bound (12) implies Polymath bound (246)"
+    ],
+    "axiomatized": [
+      "polymath_bounded_gaps_246: Polymath 8b main result (sieve theory)",
+      "maynard_tao_m_tuples: Maynard-Tao m-tuple generalization (sieve theory)",
+      "bounded_gaps_conditional_EH: Conditional result under Elliott-Halberstam conjecture"
+    ]
+  },
+  "knowledge": {
+    "insights": [
+      "Admissible tuples are the right abstraction - their formal definition (for all p, |image mod p| < p) is clean and computable",
+      "The Polymath 50-tuple can be verified constructively via native_decide for each prime ≤ 47, then interval_cases + decide for composites 48-52",
+      "Zhang's original 70M bound follows trivially from Polymath's 246 (converted axiom to theorem)",
+      "Dickson conjecture for specific tuples implies specific prime pattern conjectures (twin primes, triples)",
+      "Even prime gaps for n ≥ 1 follows from both p_n, p_{n+1} being odd primes (≥ 3)",
+      "The 3 remaining axioms are deep sieve theory (Selberg sieve, Bombieri-Vinogradov, GPY) - not in Mathlib",
+      "Fixed build issue: omega can't handle prime enumeration in range; use interval_cases + decide instead"
+    ],
+    "builtItems": [
+      "BoundedPrimeGaps.lean: 1350 lines, 90 proved theorems, 3 axioms, 0 sorries",
+      "IsAdmissible definition and comprehensive admissibility infrastructure",
+      "Polymath 50-tuple constructive proof of exists_admissible_50_tuple_246",
+      "nthPrime and primeGap definitions with structural properties",
+      "Connections to twin prime conjecture and Dickson conjecture",
+      "Fixed omega build error at line 349 using interval_cases"
+    ],
+    "nextSteps": [],
+    "progressSummary": "COMPLETE: Comprehensive formalization of bounded prime gaps. 90 proved theorems, 3 axioms (deep sieve theory), 0 sorries. Fixed build error. Axioms are fundamental results requiring Selberg sieve infrastructure not available in Mathlib."
+  }
+}


### PR DESCRIPTION
## Summary
- Fixed build failure in `BoundedPrimeGaps.lean` (omega tactic)
- Created problem JSON documenting complete formalization

## Progress
- Fixed `polymath50Tuple_admissible` proof: omega cannot enumerate primes in range
- Replaced with `interval_cases p` + pattern matching on prime equality hypotheses
- 90 proved theorems, 3 axioms (deep sieve theory), 0 sorries, 1350 lines

## Findings
- The 3 remaining axioms (Polymath bound, Maynard-Tao, Elliott-Halberstam conditional) require Selberg sieve infrastructure not in Mathlib
- Build fix: `omega` can't determine compositeness of specific numbers; `interval_cases` + `decide` handles this cleanly
- The formalization covers admissible tuples, prime gap properties, and connections to twin prime conjecture

## Status
**Outcome**: completed (build fix + documentation)
**Next Steps**: None - as complete as possible given current Mathlib

Generated by researcher-1