### PR TITLE
research: complete denumerability-rationals-oq-02 (Cantor's characterization)

### DIFF
--- a/proofs/Proofs/DenumerabilityRationalsOQ02.lean
+++ b/proofs/Proofs/DenumerabilityRationalsOQ02.lean
@@ -1,11 +1,9 @@
 import Mathlib.Order.CountableDenseLinearOrder
 import Mathlib.Data.Rat.Denumerable
-import Mathlib.Data.Rat.Order
 import Mathlib.Logic.Denumerable
 import Mathlib.Logic.Equiv.Basic
 import Mathlib.SetTheory.Cardinal.Basic
 import Mathlib.Order.Hom.Basic
-import Mathlib.Data.Int.Order
 import Mathlib.Tactic
 
 /-
@@ -18,17 +16,11 @@ theorem: **ℚ is, up to order-isomorphism, the unique countable dense linear or
 endpoints.** Any two countable, densely ordered linear orders without minimum or maximum
 elements are order-isomorphic to each other — and hence to ℚ.
 
-This is far deeper than mere denumerability. While OQ-01 shows |ℚ| = |ℕ| (a set-theoretic
-fact about cardinality), OQ-02 shows that ℚ is characterized by its order structure:
-no other countable dense linear order without endpoints exists.
-
 ## The Back-and-Forth Method
 
 The proof uses Cantor's **back-and-forth argument** (1895):
 1. Enumerate both orders as sequences (possible since they're countable)
-2. Build an order-isomorphism step by step:
-   - "Forth": extend the partial map to include the next element of α
-   - "Back": extend the partial map to include the next element of β
+2. Build an order-isomorphism step by step
 3. The density + no-endpoints conditions ensure each extension is always possible
 4. The resulting map is a total order-isomorphism
 
@@ -39,9 +31,8 @@ and `Order.iso_of_countable_dense` (the full theorem).
 - `cantor_characterization`: Any countable dense linear order without endpoints ≃o ℚ
 - `countable_dense_linear_orders_iso`: Any two such orders are isomorphic
 - `rationals_selfsimilar`: ℚ ≃o ℚ (non-trivial self-isomorphism exists)
-- `integers_embed_in_rationals`: ℤ embeds order-preservingly into ℚ
+- `integers_embed`: ℤ embeds order-preservingly into ℚ
 - `rationals_dense`: Between any two rationals lies another
-- `rationals_no_endpoints`: ℚ has no minimum or maximum
 
 ## Wiedijk's 100 Theorems: #3 (Extension)
 -/
@@ -52,32 +43,11 @@ namespace DenumerabilityRationalsOQ02
 -- Part I: ℚ as a Countable Dense Linear Order Without Endpoints
 -- ========================================================================
 
-/- ## The Four Properties of ℚ
-
-ℚ satisfies four key order-theoretic properties:
-1. Linear order (total order)
-2. Countable
-3. Densely ordered (between any two elements lies a third)
-4. No endpoints (no minimum, no maximum)
-
-Cantor's theorem says these four properties characterize ℚ uniquely. -/
-
-/-- ℚ is a linear order. -/
 instance : LinearOrder ℚ := inferInstance
-
-/-- ℚ is countable. -/
 instance : Countable ℚ := inferInstance
-
-/-- ℚ is densely ordered: between any two rationals lies another. -/
 instance : DenselyOrdered ℚ := inferInstance
-
-/-- ℚ has no minimum element. -/
 instance : NoMinOrder ℚ := inferInstance
-
-/-- ℚ has no maximum element. -/
 instance : NoMaxOrder ℚ := inferInstance
-
-/-- ℚ is nonempty. -/
 instance : Nonempty ℚ := ⟨0⟩
 
 /-- Density spelled out: for any p < q in ℚ, there exists r with p < r < q. -/
@@ -96,19 +66,8 @@ theorem rationals_no_max (q : ℚ) : ∃ r : ℚ, q < r :=
 -- Part II: Cantor's Characterization Theorem
 -- ========================================================================
 
-/- ## The Main Theorem
-
-Cantor's characterization (1895): Any countable dense linear order without endpoints
-is order-isomorphic to ℚ. This is an immediate consequence of Mathlib's
-`Order.iso_of_countable_dense`, which proves the general statement for any
-two such orders. -/
-
 /-- **Cantor's Characterization Theorem**: Any countable dense linear order without
-endpoints is order-isomorphic to ℚ.
-
-This is the deepest result about ℚ as an ordered set. It says that the four
-properties (linear, countable, dense, no endpoints) completely determine ℚ
-up to order-isomorphism. -/
+endpoints is order-isomorphic to ℚ. -/
 theorem cantor_characterization
     (α : Type*) [LinearOrder α] [Countable α] [DenselyOrdered α]
     [NoMinOrder α] [NoMaxOrder α] [Nonempty α] :
@@ -116,10 +75,7 @@ theorem cantor_characterization
   Order.iso_of_countable_dense α ℚ
 
 /-- **Uniqueness of Countable Dense Linear Orders**: Any two countable dense
-linear orders without endpoints are order-isomorphic.
-
-This is the general form: it applies to any pair of such orders,
-not just comparison with ℚ. -/
+linear orders without endpoints are order-isomorphic. -/
 theorem countable_dense_linear_orders_iso
     (α β : Type*) [LinearOrder α] [LinearOrder β]
     [Countable α] [DenselyOrdered α] [NoMinOrder α] [NoMaxOrder α] [Nonempty α]
@@ -131,31 +87,12 @@ theorem countable_dense_linear_orders_iso
 -- Part III: The Back-and-Forth Infrastructure
 -- ========================================================================
 
-/- ## Partial Isomorphisms and Extensions
-
-Mathlib's `Order.PartialIso α β` represents finite partial order-isomorphisms
-between linear orders α and β. The back-and-forth method works by:
-
-1. Starting with the empty partial isomorphism
-2. At each step, extending it to include one more element
-3. The key lemma: if α, β are dense with no endpoints, any partial isomorphism
-   can be extended to include any given element
-
-The extension is possible because density provides "room" to map any new element
-while preserving the order. -/
-
-/-- `Order.PartialIso α β` captures finite partial isomorphisms between
-two linear orders. This is the building block of the back-and-forth method. -/
 example : Type := Order.PartialIso ℚ ℚ
 
-/-- Partial isomorphisms can be reversed (back step). -/
 example (f : Order.PartialIso ℚ ℚ) : Order.PartialIso ℚ ℚ :=
   f.comm
 
-/-- The key density lemma: given finitely many elements of a dense linear order
-with no endpoints, any gap between "low" and "high" elements contains a point.
-
-This is what makes the back-and-forth extension always succeed. -/
+/-- The key density lemma. -/
 theorem density_extension_lemma
     {α : Type*} [LinearOrder α] [DenselyOrdered α] [NoMinOrder α]
     [NoMaxOrder α] [Nonempty α]
@@ -167,58 +104,37 @@ theorem density_extension_lemma
 -- Part IV: Self-Similarity of ℚ
 -- ========================================================================
 
-/- ## ℚ is Self-Similar
-
-A striking consequence: ℚ is order-isomorphic to itself via non-trivial maps.
-The back-and-forth construction gives us "non-obvious" automorphisms of (ℚ, <). -/
-
-/-- ℚ is order-isomorphic to itself (self-similarity).
-While the identity is trivially such an isomorphism, the back-and-forth
-method shows there exist many non-trivial order-automorphisms. -/
+/-- ℚ is order-isomorphic to itself (self-similarity). -/
 theorem rationals_selfsimilar : Nonempty (ℚ ≃o ℚ) :=
   Order.iso_of_countable_dense ℚ ℚ
 
-/-- The identity is an order-automorphism of ℚ. -/
 def trivial_automorphism : ℚ ≃o ℚ := OrderIso.refl ℚ
 
 -- ========================================================================
 -- Part V: Embedding Results
 -- ========================================================================
 
-/- ## Order Embeddings
-
-Since ℚ is the "universal" countable dense linear order, many familiar
-ordered sets embed into ℚ. -/
-
-/-- The integers embed order-preservingly into the rationals.
-This is the canonical inclusion ℤ ↪ ℚ preserving the linear order. -/
+/-- The integers embed order-preservingly into the rationals. -/
 def integers_embed : ℤ ↪o ℚ where
   toFun := fun n => (n : ℚ)
-  inj' := by
-    intro a b h
-    exact_mod_cast h
+  inj' := Int.cast_injective
   map_rel_iff' := by
     intro a b
-    simp [Int.cast_le]
+    change (a : ℚ) ≤ (b : ℚ) ↔ a ≤ b
+    exact Int.cast_le
 
 /-- The natural numbers embed order-preservingly into the rationals. -/
 def naturals_embed : ℕ ↪o ℚ where
   toFun := fun n => (n : ℚ)
-  inj' := by
-    intro a b h
-    exact_mod_cast h
+  inj' := Nat.cast_injective
   map_rel_iff' := by
     intro a b
-    simp [Nat.cast_le]
+    change (a : ℚ) ≤ (b : ℚ) ↔ a ≤ b
+    exact Nat.cast_le
 
 -- ========================================================================
 -- Part VI: Concrete Density Examples
 -- ========================================================================
-
-/- ## Arithmetic Witnesses of Density
-
-For concrete rationals, we can exhibit explicit witnesses of density.
-The midpoint (p + q) / 2 always works. -/
 
 /-- The midpoint of two rationals lies strictly between them. -/
 theorem midpoint_between (p q : ℚ) (h : p < q) :
@@ -228,8 +144,8 @@ theorem midpoint_between (p q : ℚ) (h : p < q) :
   · linarith
 
 /-- Explicit witness: between 1/3 and 1/2 lies 5/12. -/
-example : (1 : ℚ) / 3 < 5 / 12 ∧ 5 / 12 < 1 / 2 := by
-  constructor <;> norm_num
+example : (1 : ℚ) / 3 < (5 : ℚ) / 12 ∧ (5 : ℚ) / 12 < (1 : ℚ) / 2 :=
+  ⟨by norm_num, by norm_num⟩
 
 /-- Explicit witness: between 0 and any positive rational lies half of it. -/
 theorem half_between_zero (q : ℚ) (hq : 0 < q) : 0 < q / 2 ∧ q / 2 < q := by
@@ -241,54 +157,12 @@ theorem half_between_zero (q : ℚ) (hq : 0 < q) : 0 < q / 2 ∧ q / 2 < q := by
 -- Part VII: No Minimum and No Maximum — Constructive Witnesses
 -- ========================================================================
 
-/-- For any q, q - 1 < q. -/
 theorem pred_lt (q : ℚ) : q - 1 < q := by linarith
-
-/-- For any q, q < q + 1. -/
 theorem succ_gt (q : ℚ) : q < q + 1 := by linarith
-
--- ========================================================================
--- Part VIII: Topological and Measure-Theoretic Context
--- ========================================================================
-
-/- ## Why This Matters
-
-Cantor's characterization has deep consequences:
-
-### Order Theory
-- ℚ is the Fraïssé limit of the class of finite linear orders
-- Every countable linear order embeds into ℚ (Cantor showed this too)
-- The automorphism group Aut(ℚ, <) is a rich topological group
-
-### Topology
-- (ℚ, <) with the order topology is homeomorphic to ℚ with the subspace
-  topology from ℝ — the order characterization implies topological uniqueness
-- ℚ is the unique countable metrizable space without isolated points
-  (Sierpiński's theorem, 1920)
-
-### Model Theory
-- ℚ is ω-categorical: its first-order theory has exactly one countable model
-- This is equivalent to Cantor's characterization by the Ryll-Nardzewski theorem
-- The theory of dense linear orders without endpoints is complete and decidable
-
-### Descriptive Set Theory
-- The back-and-forth argument generalizes to Ehrenfeucht-Fraïssé games
-- These games characterize elementary equivalence in first-order logic
-
-### Connection to OQ-01
-- OQ-01 (denumerability): |ℚ| = |ℕ| = ℵ₀ — a cardinality fact
-- OQ-02 (characterization): ℚ is the UNIQUE such order — a structural fact
-- Together: ℚ is determined by "countably infinite + dense + no endpoints"
--/
 
 -- ========================================================================
 -- Part IX: Density Propagation
 -- ========================================================================
-
-/- ## Iterated Density
-
-Between any two rationals, we can find arbitrarily many rationals.
-This follows from iterating the density property. -/
 
 /-- Between any two distinct rationals, there exist at least two distinct
 rationals strictly between them. -/
@@ -322,79 +196,40 @@ theorem card_rat_eq_nat : Cardinal.mk ℚ = Cardinal.mk ℕ := by
 -- Part XI: Comparison with Other Familiar Orders
 -- ========================================================================
 
-/- ## ℤ is NOT Dense
-
-The integers fail the density condition: there is nothing between n and n+1.
-This is why ℤ ≇ ℚ as ordered sets, even though |ℤ| = |ℚ| = ℵ₀. -/
-
 /-- There is no integer strictly between n and n + 1. -/
 theorem no_integer_between (n : ℤ) : ¬∃ m : ℤ, n < m ∧ m < n + 1 := by
   intro ⟨m, hm1, hm2⟩
   omega
 
-/- ## ℕ Has a Minimum
-
-The natural numbers have 0 as a minimum element, so ℕ fails the "no minimum"
-condition. Even if we restricted to ℕ \ {0}, ℕ still wouldn't be dense. -/
-
 /-- 0 is the minimum of ℕ. -/
 theorem nat_has_min : ∀ n : ℕ, 0 ≤ n := Nat.zero_le
-
-/- ## Summary of Order-Theoretic Classification
-
-| Order | Linear | Countable | Dense | No min | No max | ≃o ℚ? |
-|-------|--------|-----------|-------|--------|--------|-------|
-| ℚ     | ✓      | ✓         | ✓     | ✓      | ✓      | ✓     |
-| ℤ     | ✓      | ✓         | ✗     | ✓      | ✓      | ✗     |
-| ℕ     | ✓      | ✓         | ✗     | ✗      | ✓      | ✗     |
-| ℝ     | ✓      | ✗         | ✓     | ✓      | ✓      | ✗     |
-| {0,1} | ✓      | ✓         | ✗     | ✗      | ✗      | ✗     |
-
-The key insight: ℚ occupies a unique position. It is the ONLY (up to ≃o)
-countable dense linear order without endpoints.
--/
 
 -- ========================================================================
 -- Part XII: The Universality of ℚ
 -- ========================================================================
 
-/- ## Every Countable Linear Order Embeds in ℚ
-
-A related classical result: every countable linear order can be embedded
-(order-preservingly) into ℚ. This makes ℚ "universal" for countable orders.
-
-This is a stronger statement than the characterization theorem —
-the characterization says dense+no-endpoints orders are ISOMORPHIC to ℚ,
-while universality says ALL countable orders EMBED in ℚ.
-
-We state this as an axiom since the full proof requires additional
-Mathlib infrastructure (well-ordering + transfinite induction on countable types).
--/
-
--- For any finite linear order, we can embed it explicitly into ℚ
--- by spacing out elements. Here's a concrete example:
-
 /-- Three elements {0, 1, 2} embed into ℚ preserving their order. -/
 example : ∃ f : Fin 3 → ℚ, StrictMono f :=
-  ⟨fun n => (n : ℚ), by intro a b h; exact_mod_cast h⟩
+  ⟨fun n => (n : ℚ), fun {a b} h => by
+    show ((a : ℕ) : ℚ) < ((b : ℕ) : ℚ)
+    exact Nat.cast_lt.mpr h⟩
 
 /-- Any Fin n embeds strictly monotonically into ℚ. -/
 theorem fin_embeds (n : ℕ) : ∃ f : Fin n → ℚ, StrictMono f :=
-  ⟨fun k => (k : ℚ), by intro a b h; exact_mod_cast h⟩
+  ⟨fun k => (k : ℚ), fun {a b} h => by
+    show ((a : ℕ) : ℚ) < ((b : ℕ) : ℚ)
+    exact Nat.cast_lt.mpr h⟩
 
 -- ========================================================================
 -- Verification Examples
 -- ========================================================================
 
-/-- Verify: the characterization applies to ℚ itself. -/
 example : Nonempty (ℚ ≃o ℚ) := cantor_characterization ℚ
 
-/-- Verify: midpoint density for 1/4 and 3/4. -/
-example : (1 : ℚ) / 4 < (1 / 4 + 3 / 4) / 2 ∧
-    (1 / 4 + 3 / 4) / 2 < 3 / 4 := by
-  constructor <;> norm_num
+example : (1 : ℚ) / 4 < ((1 : ℚ) / 4 + (3 : ℚ) / 4) / 2 ∧
+    ((1 : ℚ) / 4 + (3 : ℚ) / 4) / 2 < (3 : ℚ) / 4 :=
+  ⟨by norm_num, by norm_num⟩
 
-/-- Verify: the integer embedding preserves order. -/
 example : integers_embed 3 < integers_embed 5 := by
   show (3 : ℚ) < 5
   norm_num

--- a/src/data/research/problems/denumerability-rationals-oq-02.json
+++ b/src/data/research/problems/denumerability-rationals-oq-02.json
@@ -1,0 +1,38 @@
+{
+  "id": "denumerability-rationals-oq-02",
+  "title": "Cantor's Characterization of the Rationals",
+  "description": "ℚ is, up to order-isomorphism, the unique countable dense linear order without endpoints (Cantor 1895). Uses the back-and-forth method.",
+  "category": "order-theory",
+  "status": "completed",
+  "phase": "COMPLETE",
+  "difficulty": "intermediate",
+  "leanFile": "proofs/Proofs/DenumerabilityRationalsOQ02.lean",
+  "knowledge": {
+    "score": 10,
+    "tier": "COMPLETE",
+    "insights": [
+      "Mathlib provides Order.iso_of_countable_dense which directly proves the characterization",
+      "Order.PartialIso captures finite partial isomorphisms (building blocks of back-and-forth)",
+      "Order.exists_between_finsets is the key density extension lemma",
+      "exact_mod_cast and simp [Int.cast_le] have API differences in Docker Mathlib v4.26.0",
+      "For Fin n → ℚ strict monotonicity, use Nat.cast_lt.mpr with explicit show",
+      "For ↪o map_rel_iff', use change + exact Int.cast_le/Nat.cast_le"
+    ],
+    "builtItems": [
+      "cantor_characterization: α ≃o ℚ for any countable dense linear order without endpoints",
+      "countable_dense_linear_orders_iso: general form for any two such orders",
+      "integers_embed: ℤ ↪o ℚ (order embedding)",
+      "naturals_embed: ℕ ↪o ℚ (order embedding)",
+      "density_extension_lemma: key lemma for back-and-forth",
+      "midpoint_between, two_between, three_between: density propagation results",
+      "card_rat_aleph0, card_rat_eq_nat: cardinal arithmetic connections",
+      "no_integer_between: ℤ is not dense"
+    ],
+    "progressSummary": "COMPLETE: Full formalization of Cantor's characterization theorem. 0 sorries, 0 axioms. All theorems proved using Mathlib's Order.iso_of_countable_dense. Fixed API compatibility issues with Docker Mathlib v4.26.0.",
+    "nextSteps": []
+  },
+  "sorries": 0,
+  "axioms": 0,
+  "theorems": 18,
+  "completedAt": "2026-02-14T21:30:00Z"
+}


### PR DESCRIPTION
## Summary
- Complete formalization of Cantor's characterization theorem (OQ-02): ℚ is the unique countable dense linear order without endpoints
- Fix API compatibility with Docker Mathlib v4.26.0 (removed obsolete imports, fixed cast lemma patterns)
- 0 sorries, 0 axioms, 18 formal theorems

## Progress
- `cantor_characterization`: Any countable dense linear order without endpoints ≃o ℚ
- `countable_dense_linear_orders_iso`: General form for any two such orders
- `integers_embed` / `naturals_embed`: Order embeddings ℤ ↪o ℚ and ℕ ↪o ℚ
- Density propagation: `two_between`, `three_between`
- Cardinal arithmetic: `card_rat_aleph0`, `card_rat_eq_nat`
- Comparison: `no_integer_between` (ℤ not dense)

## Findings
- `Order.iso_of_countable_dense` in Mathlib directly proves the characterization
- `Mathlib.Data.Rat.Order` and `Mathlib.Data.Int.Order` no longer exist in Docker Mathlib v4.26.0
- `exact_mod_cast` fails for cast patterns in this version; use `change` + explicit cast lemmas

## Status
**Outcome**: completed
**Next Steps**: None - proof is complete

🤖 Generated by researcher-1