### PR TITLE
enrich(e-transcendental): fix annotations, expand sections, add crossReferences

### DIFF
--- a/src/data/proofs/e-transcendental/annotations.json
+++ b/src/data/proofs/e-transcendental/annotations.json
@@ -6,8 +6,10 @@
     "type": "concept",
     "title": "Transcendence of e: Wiedijk #67",
     "content": "**Main Result**:\n\nEuler's number $e = 2.71828...$ is **transcendental**: it is not the root of any non-zero polynomial with integer coefficients.\n\n$$\\nexists P \\in \\mathbb{Z}[X] \\setminus \\{0\\}: P(e) = 0$$\n\n**Historical Significance**: Hermite (1873) - first proof that a \"naturally occurring\" number is transcendental.\n\n**Status**: Axiomatized pending Lindemann-Weierstrass formalization.",
+    "mathContext": "$\\text{Transcendental}\\; \\mathbb{Z}\\; (\\exp 1)$ — the statement that $e$ is not a root of any nonzero integer polynomial. This is Wiedijk's 100 theorems list entry #67.",
     "significance": "critical",
-    "relatedConcepts": ["transcendental numbers", "Hermite", "exponential function"]
+    "relatedConcepts": ["transcendental numbers", "Hermite", "exponential function"],
+    "prerequisites": ["algebraic vs transcendental numbers", "polynomial rings"]
   },
   {
     "id": "ann-definitions",
@@ -16,9 +18,10 @@
     "type": "definition",
     "title": "Transcendental Numbers",
     "content": "**Definition**:\n\nA number $x$ is transcendental over ring $R$ if it is not algebraic:\n$$\\nexists P \\in R[X] \\setminus \\{0\\}: P(x) = 0$$\n\n**Equivalently**: $1, x, x^2, x^3, \\ldots$ are linearly independent over $R$.\n\n**Key Facts**:\n- Transcendental $\\Rightarrow$ Irrational (but not conversely: $\\sqrt{2}$)\n- Most reals are transcendental (Cantor)\n- Proving specific numbers transcendental is hard!\n\nMathlib: `Transcendental R x`",
-    "mathContext": "Transcendental ℤ (exp 1)",
-    "significance": "major",
-    "relatedConcepts": ["algebraic numbers", "irrationality", "Cantor"]
+    "mathContext": "`Transcendental R x` is defined as $\\neg(\\text{IsAlgebraic}\\; R\\; x)$, i.e., there is no nonzero polynomial in $R[X]$ that evaluates to zero at $x$.",
+    "significance": "key",
+    "relatedConcepts": ["algebraic numbers", "irrationality", "Cantor's uncountability"],
+    "prerequisites": ["polynomial evaluation", "algebraic number definition"]
   },
   {
     "id": "ann-properties",
@@ -26,21 +29,23 @@
     "range": {"startLine": 71, "endLine": 83},
     "type": "theorem",
     "title": "Properties of e",
-    "content": "**Basic Bounds**:\n\n$$e > 0$$\n(exponential is always positive)\n\n$$e > 1$$\n($\\exp$ is increasing and $\\exp(0) = 1$)\n\n$$e < 3$$\nUsing Mathlib's `exp_one_lt_d9`: $e < 2.7182818286$\n\n**Value**: $e \\approx 2.718281828459...$\n\n**Memory trick**: $e \\approx 2.7\\, 1828\\, 1828...$ (\"1828\" repeats)",
-    "mathContext": "0 < e < 3",
-    "significance": "minor",
-    "relatedConcepts": ["exponential bounds", "computation", "Mathlib"]
+    "content": "**Basic Bounds**:\n\n$$e > 0$$\n(exponential is always positive)\n\n$$e > 1$$\n($\\exp$ is increasing and $\\exp(0) = 1$)\n\n$$e < 3$$\nUsing Mathlib's `exp_one_lt_d9`: $e < 2.7182818286$\n\n**Value**: $e \\approx 2.718281828459...$",
+    "mathContext": "$0 < e < 3$. The bounds use `Real.exp_pos` (positivity of $\\exp$), `one_lt_exp_iff` ($\\exp(x) > 1$ iff $x > 0$), and Mathlib's 9-decimal approximation `exp_one_lt_d9`.",
+    "significance": "supporting",
+    "relatedConcepts": ["exponential bounds", "exp_one_lt_d9", "positivity"],
+    "prerequisites": ["Real.exp_pos", "monotonicity of exp"]
   },
   {
     "id": "ann-hermite-proof",
     "proofId": "e-transcendental",
     "range": {"startLine": 88, "endLine": 128},
-    "type": "theorem",
+    "type": "concept",
     "title": "Hermite's Proof Strategy",
     "content": "**Proof Outline** (1873):\n\n**Assume**: $\\sum a_i e^i = 0$ for integers $a_i$.\n\n**Step 1** - Auxiliary polynomial for large prime $p$:\n$$f(x) = \\frac{x^{p-1}(x-1)^p \\cdots (x-n)^p}{(p-1)!}$$\n\n**Step 2** - Key integral:\n$$I_k = \\int_0^k f(x)e^x dx = e^k F(0) - F(k)$$\nwhere $F(x) = f(x) + f'(x) + f''(x) + \\cdots$\n\n**Step 3** - Sum $S = \\sum a_k I_k$ satisfies:\n- $|S| < 1$ for large $p$\n- $S \\neq 0$ and $p | S$\n\n**Contradiction!** A small non-zero integer divisible by $p$ is impossible.",
-    "mathContext": "f(x) = x^{p-1}∏(x-k)^p / (p-1)!",
+    "mathContext": "$f(x) = \\frac{x^{p-1} \\prod_{k=1}^{n}(x-k)^p}{(p-1)!}$. The factorial denominator ensures $f^{(j)}(k)$ has controlled divisibility by $p$, while integration by parts gives $I_k = e^k F(0) - F(k)$.",
     "significance": "critical",
-    "relatedConcepts": ["auxiliary polynomial", "integration by parts", "divisibility"]
+    "relatedConcepts": ["auxiliary polynomial method", "integration by parts", "divisibility arguments"],
+    "prerequisites": ["polynomial calculus", "prime divisibility", "integration by parts"]
   },
   {
     "id": "ann-main-axiom",
@@ -49,39 +54,45 @@
     "type": "theorem",
     "title": "Main Theorem (Axiomatized)",
     "content": "**Main Axiom**:\n$$\\text{Transcendental } \\mathbb{Z} \\ (\\exp 1)$$\n\n**Requirements for full proof**:\n1. Polynomial arithmetic over $\\mathbb{Z}$\n2. Integration by parts for polynomial $\\times$ exponential\n3. Divisibility analysis mod $p$\n4. Asymptotic estimates\n\n**Equivalence**:\n$$\\text{Transcendental } \\mathbb{Z} \\ e \\Leftrightarrow \\text{Transcendental } \\mathbb{Q} \\ e$$\n(Clear denominators to convert $\\mathbb{Q}$-polynomial to $\\mathbb{Z}$-polynomial)",
-    "mathContext": "Transcendental ℤ (exp 1)",
+    "mathContext": "`Transcendental ℤ (Real.exp 1)` — axiomatized because the Lindemann-Weierstrass theorem (the standard generalization) is not yet in Mathlib. The $\\mathbb{Z} \\leftrightarrow \\mathbb{Q}$ equivalence follows from clearing denominators.",
     "significance": "critical",
-    "relatedConcepts": ["axiom", "Lindemann-Weierstrass", "pending formalization"]
+    "relatedConcepts": ["axiom", "Lindemann-Weierstrass", "pending formalization"],
+    "prerequisites": ["Transcendental definition", "polynomial ring theory"]
   },
   {
     "id": "ann-corollaries",
     "proofId": "e-transcendental",
     "range": {"startLine": 162, "endLine": 200},
     "type": "theorem",
-    "title": "Corollaries",
-    "content": "**$e$ is irrational**:\n- If $e = p/q$, then $e$ is root of $qX - p$\n- This makes $e$ algebraic - contradiction!\n\n**$e^n$ is transcendental** ($n \\neq 0$):\n- If $P(e^n) = 0$, then $Q(X) = P(X^n)$ has $e$ as root\n- Contradicts $e$ transcendental\n\n**$1/e$ is transcendental**:\n- Reciprocal polynomial argument\n- $Q(X) = X^n \\cdot P(1/X)$\n\n**$e + 1$ is transcendental**:\n- Shift polynomial: $Q(X) = P(X + 1)$",
-    "mathContext": "e irrational; e^n, 1/e, e+1 transcendental",
-    "significance": "major",
-    "relatedConcepts": ["irrationality", "polynomial composition", "closure properties"]
+    "title": "Corollaries: Irrationality and Closure Properties",
+    "content": "**$e$ is irrational**:\n- If $e = p/q$, then $e$ is root of $qX - p$\n- This makes $e$ algebraic — contradiction!\n\n**$e^n$ is transcendental** ($n \\neq 0$):\n- If $P(e^n) = 0$, then $Q(X) = P(X^n)$ has $e$ as root\n- Contradicts $e$ transcendental\n\n**$1/e$ is transcendental**:\n- Reciprocal polynomial argument: $Q(X) = X^n \\cdot P(1/X)$\n\n**$e + 1$ is transcendental**:\n- Shift polynomial: $Q(X) = P(X + 1)$",
+    "mathContext": "Each corollary follows from the **polynomial substitution** principle: if $\\alpha$ is transcendental and $\\phi$ is a polynomial automorphism of $\\overline{\\mathbb{Q}}(X)$, then $\\phi(\\alpha)$ is also transcendental.",
+    "significance": "key",
+    "relatedConcepts": ["irrationality", "polynomial composition", "closure properties"],
+    "prerequisites": ["transcendence of e", "polynomial substitution"]
   },
   {
     "id": "ann-connections",
     "proofId": "e-transcendental",
     "range": {"startLine": 205, "endLine": 231},
     "type": "concept",
-    "title": "Related Theorems",
-    "content": "**Generalizations**:\n\n| Theorem | Result |\n|---------|--------|\n| Lindemann-Weierstrass (1882) | $e^\\alpha$ transcendental for algebraic $\\alpha \\neq 0$ |\n| Gelfond-Schneider (1934) | $\\alpha^\\beta$ transcendental (Hilbert #7) |\n| Baker (1966) | Linear forms in logarithms |\n\n**Open Problems**:\n- Is $e + \\pi$ transcendental? (Unknown!)\n- Is $e\\pi$ transcendental? (Yes, Gelfond-Schneider)\n- Is $e^e$ transcendental? (Unknown)\n- Is $\\gamma$ irrational? (Unknown!)\n\n**Schanuel's Conjecture** would resolve most of these.",
-    "significance": "major",
-    "relatedConcepts": ["Lindemann-Weierstrass", "Gelfond-Schneider", "Schanuel"]
+    "title": "Related Theorems and Open Problems",
+    "content": "**Generalizations**:\n\n| Theorem | Result |\n|---------|--------|\n| Lindemann-Weierstrass (1882) | $e^\\alpha$ transcendental for algebraic $\\alpha \\neq 0$ |\n| Gelfond-Schneider (1934) | $\\alpha^\\beta$ transcendental (Hilbert #7) |\n| Baker (1966) | Linear forms in logarithms |\n\n**Open Problems**:\n- Is $e + \\pi$ transcendental? (Unknown!)\n- Is $e\\pi$ transcendental? (Yes, by Gelfond-Schneider)\n- Is $e^e$ transcendental? (Unknown)\n- Is $\\gamma$ irrational? (Unknown!)\n\n**Schanuel's Conjecture** would resolve most of these.",
+    "mathContext": "Schanuel's conjecture: if $z_1, \\ldots, z_n$ are $\\mathbb{Q}$-linearly independent, then $\\text{tr.deg}_{\\mathbb{Q}}\\, \\mathbb{Q}(z_1, \\ldots, z_n, e^{z_1}, \\ldots, e^{z_n}) \\geq n$.",
+    "significance": "key",
+    "relatedConcepts": ["Lindemann-Weierstrass", "Gelfond-Schneider", "Schanuel's conjecture", "Baker's theorem"],
+    "prerequisites": ["transcendence theory", "algebraic independence"]
   },
   {
     "id": "ann-significance",
     "proofId": "e-transcendental",
     "range": {"startLine": 237, "endLine": 269},
-    "type": "note",
+    "type": "concept",
     "title": "Historical and Mathematical Significance",
     "content": "**Historical Significance**:\n\nHermite's 1873 proof was revolutionary:\n- **First** \"naturally occurring\" transcendental\n  (Liouville's 1844 examples were constructed)\n- Introduced auxiliary polynomial method\n- Inspired Lindemann's proof of $\\pi$ transcendence (1882)\n\n**Mathematical Implications**:\n- $e$ cannot be constructed with compass/straightedge\n- Exponential function \"escapes\" algebraic relations\n- $e$'s decimal never becomes periodic\n\n**Computation**:\n$$e = 1 + \\frac{1}{1!} + \\frac{1}{2!} + \\frac{1}{3!} + \\cdots$$\n\n$e \\approx 2.7\\, 1828\\, 1828\\, 45\\, 90\\, 45\\ldots$",
-    "significance": "minor",
-    "relatedConcepts": ["history", "computation", "constructibility"]
+    "mathContext": "Transcendence implies $e$ is not constructible (compass/straightedge) and has no eventually periodic decimal or continued fraction of algebraic type. The series $e = \\sum_{n=0}^{\\infty} 1/n!$ converges rapidly, giving efficient computation.",
+    "significance": "supporting",
+    "relatedConcepts": ["constructibility", "compass and straightedge", "convergent series"],
+    "prerequisites": ["transcendental implies non-constructible", "Taylor series of exp"]
   }
 ]

--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -40,30 +40,85 @@
     "dateAdded": "12/29/25"
   },
   "overview": {
-    "historicalContext": "Hermite proved e transcendental in 1873, making it the first 'natural' constant proven transcendental (Liouville's numbers were specifically constructed). This opened the door for Lindemann's proof of pi's transcendence 9 years later.",
+    "historicalContext": "Charles Hermite proved $e$ is transcendental in 1873, making it the first \"naturally occurring\" constant shown to be transcendental—Joseph Liouville had constructed artificial transcendental numbers in 1844, but those were designed to satisfy Liouville's approximation criterion. Hermite's method used an auxiliary polynomial $f(x) = x^{p-1}(x-1)^p \\cdots (x-n)^p / (p-1)!$ combined with integral estimates to derive a contradiction from an assumed algebraic relation for $e$. Nine years later, Ferdinand von Lindemann (1882) extended Hermite's technique to prove $\\pi$ is transcendental, resolving the ancient Greek problem of squaring the circle. The full generalization—the **Lindemann-Weierstrass theorem** (1885)—states that $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are algebraically independent whenever $\\alpha_1, \\ldots, \\alpha_n$ are $\\mathbb{Q}$-linearly independent algebraic numbers. This deep result remains unformalized in Mathlib, so the main theorem here is axiomatized.",
     "problemStatement": "**Theorem**: e is transcendental, i.e., there is no nonzero polynomial P with integer coefficients such that P(e) = 0.\n\nThis is stronger than irrationality (proved by Euler) and even algebraic irrationality.",
     "proofStrategy": "Hermite's proof uses contour integration. Assume e is algebraic with minimal polynomial P. Construct an auxiliary integral that is simultaneously a non-zero integer and arbitrarily small (using factorial growth vs exponential), yielding a contradiction.",
     "keyInsights": [
       "The key is the interplay between factorial and exponential growth",
       "Hermite's method was generalized by Lindemann to e^alpha",
       "Transcendence is much stronger than irrationality",
-      "e was the first 'famous' number proved transcendental"
+      "e was the first 'famous' number proved transcendental",
+      "The **auxiliary polynomial method** introduced by Hermite—constructing a function with carefully controlled divisibility at integer points—became the template for all subsequent transcendence proofs, including Baker's theorem on linear forms in logarithms (1966)"
     ]
   },
-  "sections": [
+  "crossReferences": [
     {
-      "id": "irrationality-review",
-      "title": "From Irrationality to Transcendence",
-      "startLine": 50,
-      "endLine": 100,
-      "summary": "Historical progression of results about e."
+      "targetId": "pi-transcendental",
+      "relationship": "related",
+      "description": "Lindemann's 1882 proof of $\\pi$'s transcendence directly extended Hermite's method for $e$. Both results are special cases of the Lindemann-Weierstrass theorem."
     },
     {
-      "id": "hermites-proof",
-      "title": "Hermite's Proof",
-      "startLine": 100,
+      "targetId": "leibniz-pi",
+      "relationship": "related",
+      "description": "Both formalizations involve the constant $\\pi$ and its deep properties. Leibniz's series computes $\\pi$ as a limit, while transcendence shows $\\pi$ (like $e$) satisfies no polynomial relation."
+    }
+  ],
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Module Documentation",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Imports Mathlib's algebraic and analytic infrastructure: `Transcendental` from ring theory, `Real.exp` and exponential bounds, `Irrational` definition, and `Complex.Analytic` for the exponential function's analytic theory."
+    },
+    {
+      "id": "definitions-background",
+      "title": "Definitions and Background",
+      "startLine": 46,
+      "endLine": 66,
+      "summary": "Reviews the definition of transcendental numbers ($\\nexists P \\in R[X] \\setminus \\{0\\}: P(x) = 0$), the distinction from irrationality, and Cantor's result that most reals are transcendental. Uses `#check` to verify Mathlib provides `Transcendental` and `Real.exp 1`."
+    },
+    {
+      "id": "e-properties",
+      "title": "Key Properties of e from Mathlib",
+      "startLine": 67,
+      "endLine": 83,
+      "summary": "Establishes $e > 0$, $e > 1$, and $e < 3$ using Mathlib's `exp_pos`, `one_lt_exp_iff`, and `exp_one_lt_d9`. These bounds verify the exponential constant lies in $(1, 3)$."
+    },
+    {
+      "id": "hermite-proof",
+      "title": "Hermite's Proof Strategy (1873)",
+      "startLine": 84,
+      "endLine": 128,
+      "summary": "Detailed exposition of Hermite's proof outline: (1) assume $\\sum a_i e^i = 0$, (2) construct auxiliary polynomial $f(x) = x^{p-1}\\prod(x-k)^p / (p-1)!$, (3) define key integrals $I_k = \\int_0^k f(x)e^x dx$, (4) show the sum $S = \\sum a_k I_k$ is simultaneously small and a nonzero multiple of $p$—contradiction."
+    },
+    {
+      "id": "main-axioms",
+      "title": "Main Theorem (Axiomatized)",
+      "startLine": 130,
+      "endLine": 157,
+      "summary": "Axiomatizes `Transcendental ℤ (Real.exp 1)` and the equivalent `Transcendental ℚ (Real.exp 1)`, pending formalization of the Lindemann-Weierstrass theorem in Mathlib. Notes that clearing denominators converts $\\mathbb{Q}$-algebraicity to $\\mathbb{Z}$-algebraicity."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries: Irrationality and Closure Properties",
+      "startLine": 158,
       "endLine": 200,
-      "summary": "The integral method for proving transcendence."
+      "summary": "Derives (via axioms) that $e$ is irrational, $e^n$ is transcendental for $n \\neq 0$, $1/e$ is transcendental, and $e+1$ is transcendental. Each follows from the closure of transcendental numbers under polynomial substitutions."
+    },
+    {
+      "id": "connections",
+      "title": "Connections to Other Results",
+      "startLine": 201,
+      "endLine": 231,
+      "summary": "Surveys generalizations: Lindemann-Weierstrass (1882), Gelfond-Schneider (1934, Hilbert's 7th problem), Baker's theorem (1966), and the open Schanuel's conjecture. Notes that $e + \\pi$ and $e^e$ transcendence remain open."
+    },
+    {
+      "id": "significance",
+      "title": "Historical and Mathematical Significance",
+      "startLine": 233,
+      "endLine": 273,
+      "summary": "Discusses the revolutionary impact of Hermite's 1873 proof, its implications for constructibility and algebraic relations, and open problems including whether $e + \\pi$ is transcendental, whether $e$ is normal, and the irrationality of the Euler-Mascheroni constant $\\gamma$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Fixed invalid `significance` values (`major`→`key`, `minor`→`supporting`) in 5 annotations
- Fixed invalid annotation type `note`→`concept` for ann-significance
- Added `mathContext` to `ann-intro` and expanded `mathContext` on all 8 annotations
- Added `prerequisites` to all 8 annotations (was missing on all)
- Expanded `historicalContext` with Liouville (1844), Lindemann-Weierstrass (1885), detailed Hermite auxiliary polynomial method
- Added 5th `keyInsight` on auxiliary polynomial method and Baker's theorem
- Replaced 2 vague sections (wrong line ranges) with 8 accurate sections covering full file (lines 1–273)
- Added `crossReferences` to pi-transcendental and leibniz-pi

## Test plan
- [x] `pnpm annotations:build` passes with no warnings for this entry
- [x] JSON is well-formed

🤖 Generated with [Claude Code](https://claude.com/claude-code)