### PR TITLE
enrich(erdos-697): add mathContext, prerequisites, crossReferences, fix sections

### DIFF
--- a/src/data/proofs/erdos-697/annotations.json
+++ b/src/data/proofs/erdos-697/annotations.json
@@ -6,9 +6,10 @@
     "type": "concept",
     "title": "Problem Overview",
     "content": "**Erdős Problem #697** asks: let δ(m,α) be the density of integers divisible by some d ≡ 1 (mod m) with 1 < d < exp(m^α). Does a sharp threshold β exist?\n\n**Answer:** YES, β = 1/log 2 ≈ 1.443 (Hall 1992).\n\n- For α < β: density → 0\n- For α > β: density → 1",
-    "mathContext": "This concerns divisibility by modular residues, a topic in multiplicative number theory.",
+    "mathContext": "Let $\\delta(m, \\alpha) = \\lim_{N \\to \\infty} \\frac{|\\{n \\le N : \\exists d \\mid n,\\; d \\equiv 1 \\pmod{m},\\; 1 < d < e^{m^\\alpha}\\}|}{N}$. The question is whether there exists $\\beta$ such that $\\delta(m, \\alpha) \\to 0$ for $\\alpha < \\beta$ and $\\delta(m, \\alpha) \\to 1$ for $\\alpha > \\beta$.",
     "significance": "critical",
-    "relatedConcepts": ["Divisibility", "Density", "Modular arithmetic", "Threshold phenomena"]
+    "relatedConcepts": ["natural density", "modular arithmetic", "threshold phenomena", "sieve methods"],
+    "prerequisites": ["asymptotic density", "divisibility", "congruence classes"]
   },
   {
     "id": "ann-697-admissible",
@@ -16,8 +17,11 @@
     "range": { "startLine": 46, "endLine": 48 },
     "type": "definition",
     "title": "IsAdmissibleDivisor",
-    "content": "A divisor d of n is admissible for (m, α) if:\n- d divides n\n- d > 1\n- d ≡ 1 (mod m)\n- d < exp(m^α)",
-    "significance": "critical"
+    "content": "A divisor d of n is admissible for (m, α) if:\n- d divides n\n- d > 1\n- d ≡ 1 (mod m)\n- d < exp(m^α)\n\nThe upper bound $e^{m^\\alpha}$ grows with $m$, and the congruence constraint $d \\equiv 1 \\pmod{m}$ restricts to a thin arithmetic progression.",
+    "mathContext": "$d \\mid n \\wedge d > 1 \\wedge d \\equiv 1 \\pmod{m} \\wedge d < e^{m^\\alpha}$. The admissible divisors lie in the arithmetic progression $\\{1 + km : k \\ge 1\\}$ truncated at $e^{m^\\alpha}$.",
+    "significance": "critical",
+    "relatedConcepts": ["divisibility", "arithmetic progressions", "exponential bounds"],
+    "prerequisites": ["modular arithmetic", "divisor function"]
   },
   {
     "id": "ann-697-covered",
@@ -25,8 +29,11 @@
     "range": { "startLine": 50, "endLine": 52 },
     "type": "definition",
     "title": "IsCovered",
-    "content": "An integer n is covered if it has at least one admissible divisor for the given (m, α). The density δ(m, α) measures how many integers are covered.",
-    "significance": "key"
+    "content": "An integer n is covered if it has at least one admissible divisor for the given (m, α). The density δ(m, α) measures the proportion of covered integers.",
+    "mathContext": "$\\text{IsCovered}(m, \\alpha, n) \\iff \\exists d : \\text{IsAdmissibleDivisor}(n, m, \\alpha, d)$",
+    "significance": "key",
+    "relatedConcepts": ["covering systems", "divisor structure"],
+    "prerequisites": ["IsAdmissibleDivisor"]
   },
   {
     "id": "ann-697-delta",
@@ -34,8 +41,11 @@
     "range": { "startLine": 58, "endLine": 61 },
     "type": "definition",
     "title": "delta - The Density Function",
-    "content": "δ(m, α) = lim_{N→∞} (covered integers ≤ N) / N\n\nThis measures the asymptotic proportion of integers divisible by some d ≡ 1 (mod m) in the allowed range.",
-    "significance": "critical"
+    "content": "δ(m, α) = lim_{N→∞} (covered integers ≤ N) / N.\n\nFormalized using `Filter.liminf` with `Filter.atTop`, which captures the asymptotic density as a limit inferior. Returns 0 for degenerate cases m ≤ 1.",
+    "mathContext": "$\\delta(m, \\alpha) = \\liminf_{N \\to \\infty} \\frac{|\\{n \\le N : \\text{IsCovered}(m, \\alpha, n)\\}|}{N}$. Uses Mathlib's `Filter.liminf` for the limit inferior along the cofinite filter.",
+    "significance": "critical",
+    "relatedConcepts": ["asymptotic density", "Filter.liminf", "natural density"],
+    "prerequisites": ["IsCovered", "Filter.atTop", "limit inferior"]
   },
   {
     "id": "ann-697-threshold",
@@ -43,8 +53,11 @@
     "range": { "startLine": 67, "endLine": 71 },
     "type": "definition",
     "title": "HasSharpThreshold",
-    "content": "A sharp threshold β exists if:\n- For all α < β: δ(m, α) → 0 as m → ∞\n- For all α > β: δ(m, α) → 1 as m → ∞\n\nThis captures a phase transition in divisibility.",
-    "significance": "critical"
+    "content": "A sharp threshold β exists if:\n- For all α < β: δ(m, α) → 0 as m → ∞\n- For all α > β: δ(m, α) → 1 as m → ∞\n\nThis captures a **phase transition** in divisibility: below the threshold almost no integers have admissible divisors; above it, almost all do.",
+    "mathContext": "$\\exists \\beta > 1 : (\\alpha < \\beta \\Rightarrow \\delta(m, \\alpha) \\to 0) \\wedge (\\alpha > \\beta \\Rightarrow \\delta(m, \\alpha) \\to 1)$ as $m \\to \\infty$. Uses `Filter.Tendsto` with `nhds 0` and `nhds 1`.",
+    "significance": "critical",
+    "relatedConcepts": ["phase transitions", "sharp thresholds", "Filter.Tendsto"],
+    "prerequisites": ["delta definition", "topological convergence"]
   },
   {
     "id": "ann-697-hallthreshold",
@@ -52,8 +65,11 @@
     "range": { "startLine": 73, "endLine": 74 },
     "type": "definition",
     "title": "hallThreshold = 1/log 2",
-    "content": "The critical threshold β = 1/log 2 ≈ 1.443.\n\nThis value separates the regime where almost no integers are covered from where almost all are covered.",
-    "significance": "critical"
+    "content": "The critical threshold β = 1/log 2 ≈ 1.443. The proof that β > 1 uses the fact that log 2 < 1 (since 2 < e), verified via Mathlib's `exp_one_gt_d9`.",
+    "mathContext": "$\\beta = \\frac{1}{\\ln 2} \\approx 1.4427$. Since $\\ln 2 < 1 < \\ln e$, we have $\\beta = 1/\\ln 2 > 1$.",
+    "significance": "critical",
+    "relatedConcepts": ["natural logarithm", "log 2", "critical exponents"],
+    "prerequisites": ["Real.log", "exp_one_gt_d9"]
   },
   {
     "id": "ann-697-trivial",
@@ -61,36 +77,47 @@
     "range": { "startLine": 85, "endLine": 93 },
     "type": "theorem",
     "title": "Trivial Upper Bound",
-    "content": "For α < 1: δ(m, α) → 0 as m → ∞.\n\nThis is trivial because the number of d ≡ 1 (mod m) with d < exp(m^α) is about exp(m^α)/m = m^{α-1} → 0.",
-    "significance": "key"
+    "content": "For α < 1: δ(m, α) → 0 as m → ∞.\n\nThe count of d ≡ 1 (mod m) with d < exp(m^α) is about exp(m^α)/m. When α < 1, this is m^{α−1} → 0, so there aren't enough admissible divisors to cover a positive density.",
+    "mathContext": "$|\\{d \\equiv 1 \\pmod{m} : 1 < d < e^{m^\\alpha}\\}| \\approx \\frac{e^{m^\\alpha}}{m} \\approx m^{\\alpha - 1} \\to 0$ when $\\alpha < 1$.",
+    "significance": "key",
+    "relatedConcepts": ["counting in arithmetic progressions", "exponential vs polynomial growth"],
+    "prerequisites": ["arithmetic progression counting", "asymptotic analysis"]
   },
   {
     "id": "ann-697-erdos1979",
     "proofId": "erdos-697",
-    "range": { "startLine": 99, "endLine": 104 },
+    "range": { "startLine": 107, "endLine": 108 },
     "type": "theorem",
     "title": "Erdős α = 1 Claim",
-    "content": "**Erdős (1979):** δ(m, 1) → 0 as m → ∞.\n\nErdős claimed this in his 1979 Astérisque paper but didn't publish a full proof. It was later confirmed by Hall.",
-    "significance": "key"
+    "content": "**Erdős (1979):** δ(m, 1) → 0 as m → ∞.\n\nErdős claimed this in \"Some unconventional problems in number theory\" (Astérisque, 1979) without a full proof. It was later confirmed by Hall's more general result. This is the boundary of the trivial range.",
+    "mathContext": "$\\delta(m, 1) \\to 0$ as $m \\to \\infty$. At $\\alpha = 1$, there are about $e^m / m$ admissible divisors, but their multiplicative structure doesn't cover enough integers.",
+    "significance": "key",
+    "relatedConcepts": ["Erdős 1979 Astérisque paper", "boundary behavior"],
+    "prerequisites": ["trivial_upper_bound", "delta definition"]
   },
   {
     "id": "ann-697-hall",
     "proofId": "erdos-697",
     "range": { "startLine": 110, "endLine": 120 },
-    "type": "axiom",
+    "type": "theorem",
     "title": "Hall's Theorem (1992)",
-    "content": "**Hall's Theorem:**\n\nThe sharp threshold exists and equals β = 1/log 2.\n\n- For α < 1/log 2: lim δ(m, α) = 0\n- For α > 1/log 2: lim δ(m, α) = 1",
-    "mathContext": "Published in J. Number Theory (1992): \"On some conjectures of P. Erdős in Astérisque I\"",
-    "significance": "critical"
+    "content": "**Hall's Theorem:**\n\nThe sharp threshold exists and equals β = 1/log 2.\n\n- For α < 1/log 2: lim δ(m, α) = 0\n- For α > 1/log 2: lim δ(m, α) = 1\n\nPublished in J. Number Theory (1992): \"On some conjectures of P. Erdős in Astérisque I\".",
+    "mathContext": "Hall's analysis uses sieve methods to show that for $\\alpha > 1/\\ln 2$, the number of admissible divisors in $[1, e^{m^\\alpha}]$ grows fast enough that their multiples cover almost all integers. The value $1/\\ln 2$ is the critical exponent where the Brun sieve transitions from ineffective to effective.",
+    "significance": "critical",
+    "relatedConcepts": ["Brun's sieve", "sieve methods", "J. Number Theory"],
+    "prerequisites": ["HasSharpThreshold", "hallThreshold", "sieve theory"]
   },
   {
     "id": "ann-697-threshold-proof",
     "proofId": "erdos-697",
-    "range": { "startLine": 122, "endLine": 129 },
+    "range": { "startLine": 129, "endLine": 135 },
     "type": "theorem",
     "title": "Threshold is 1/log 2",
-    "content": "Combines Hall's theorem to show the threshold exists and equals exactly 1/log 2 ≈ 1.443.",
-    "significance": "critical"
+    "content": "Combines Hall's theorem to produce the full result: the threshold exists, equals 1/log 2, is greater than 1, and the density converges to 0 below and 1 above. This is the definitive answer to Erdős's question.",
+    "mathContext": "$\\text{HasSharpThreshold} \\wedge \\beta = 1/\\ln 2 \\wedge \\beta > 1 \\wedge (\\alpha < \\beta \\Rightarrow \\delta \\to 0) \\wedge (\\alpha > \\beta \\Rightarrow \\delta \\to 1)$",
+    "significance": "critical",
+    "relatedConcepts": ["complete solution", "threshold identification"],
+    "prerequisites": ["hall_theorem", "hallThreshold_in_range"]
   },
   {
     "id": "ann-697-intuition",
@@ -98,8 +125,11 @@
     "range": { "startLine": 135, "endLine": 149 },
     "type": "insight",
     "title": "Why 1/log 2?",
-    "content": "**Intuition:**\n\nThe number of d ≡ 1 (mod m) with d < exp(m^α) is about exp(m^α)/m.\n\nFor coverage, we need this to be ≥ 1, which happens when m^α ≥ log m.\n\nThe precise value 1/log 2 comes from the multiplicative structure of such divisors.",
-    "significance": "key"
+    "content": "**Intuition:**\n\nThe count of $d \\equiv 1 \\pmod{m}$ with $d < e^{m^\\alpha}$ is roughly $e^{m^\\alpha}/m$. For coverage, this must exceed a critical mass. The value $1/\\ln 2$ arises from the **multiplicative structure** of such divisors: Hall's sieve analysis shows that the critical density of admissible primes transitions at this exponent.",
+    "mathContext": "Heuristically, $|\\{d \\equiv 1 \\pmod{m} : d < x\\}| \\sim x/m$, so for $x = e^{m^\\alpha}$ this is $e^{m^\\alpha}/m$. The critical exponent $1/\\ln 2$ emerges from the probability that a random integer is divisible by at least one element of a random set of size $\\sim 2^k$.",
+    "significance": "key",
+    "relatedConcepts": ["sieve heuristics", "multiplicative structure", "probabilistic method"],
+    "prerequisites": ["counting in arithmetic progressions", "probability heuristics"]
   },
   {
     "id": "ann-697-example-m2",
@@ -107,8 +137,11 @@
     "range": { "startLine": 181, "endLine": 184 },
     "type": "theorem",
     "title": "Example: m = 2",
-    "content": "For m = 2: d ≡ 1 (mod 2) means d is odd.\n\nEvery integer > 1 is divisible by an odd d > 1 (itself if odd, or its odd part if even).\n\nSo δ(2, α) = 1 for all α > 0.",
-    "significance": "supporting"
+    "content": "For m = 2: d ≡ 1 (mod 2) means d is odd. Every integer > 1 is divisible by an odd d > 1 (itself if odd, or its odd part if even). So δ(2, α) = 1 for all α > 0.\n\nThis shows the threshold phenomenon is non-trivial only for large m.",
+    "mathContext": "$d \\equiv 1 \\pmod{2} \\iff d$ is odd. Every $n > 1$ has an odd divisor $> 1$ (its largest odd divisor), so $\\delta(2, \\alpha) = 1$ trivially.",
+    "significance": "supporting",
+    "relatedConcepts": ["odd divisors", "largest odd divisor", "trivial cases"],
+    "prerequisites": ["fundamental theorem of arithmetic"]
   },
   {
     "id": "ann-697-answer",
@@ -116,16 +149,22 @@
     "range": { "startLine": 209, "endLine": 210 },
     "type": "theorem",
     "title": "The Answer is YES",
-    "content": "erdos_697_answer: HasSharpThreshold\n\nThe sharp threshold exists, confirming Erdős's conjecture.",
-    "significance": "critical"
+    "content": "`erdos_697_answer : HasSharpThreshold` — the headline result extracting the threshold existence from Hall's theorem.",
+    "mathContext": "Extracts the first component of `hall_theorem : HasSharpThreshold ∧ ...` to confirm $\\exists \\beta > 1$ with the sharp threshold property.",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős problem resolution", "existential witness"],
+    "prerequisites": ["hall_theorem"]
   },
   {
     "id": "ann-697-summary",
     "proofId": "erdos-697",
     "range": { "startLine": 218, "endLine": 231 },
     "type": "theorem",
-    "title": "Summary",
-    "content": "**Erdős Problem #697: SOLVED**\n\n- Question: Does sharp threshold β exist?\n- Answer: YES, β = 1/log 2 ≈ 1.443 (Hall 1992)\n- For α < β: density → 0\n- For α > β: density → 1",
-    "significance": "critical"
+    "title": "Summary and Final Statement",
+    "content": "**Erdős Problem #697: SOLVED**\n\n- Question: Does sharp threshold β exist?\n- Answer: YES, β = 1/log 2 ≈ 1.443 (Hall 1992)\n- For α < β: density → 0\n- For α > β: density → 1\n\nThe `erdos_697_summary` combines both the existence and the β > 1 bound.",
+    "mathContext": "`HasSharpThreshold ∧ hallThreshold > 1` — packages the complete solution: the threshold exists and is strictly greater than 1.",
+    "significance": "critical",
+    "relatedConcepts": ["complete solution", "problem closure"],
+    "prerequisites": ["erdos_697_answer", "hallThreshold_in_range"]
   }
 ]

--- a/src/data/proofs/erdos-697/meta.json
+++ b/src/data/proofs/erdos-697/meta.json
@@ -66,90 +66,102 @@
       "**Erdős 1979:** Claimed α = 1 gives density 0, confirmed by Hall"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-696",
+      "relationship": "related",
+      "description": "Problem #696 concerns chains of prime divisors with congruence conditions $d \\equiv 1 \\pmod{m}$. Both problems arise from Erdős's 1979 Astérisque paper and share the theme of understanding when congruence-constrained divisors sufficiently cover integers."
+    },
+    {
+      "targetId": "erdos-698",
+      "relationship": "related",
+      "description": "Adjacent problem in Erdős's collection. While #697 concerns divisor density with modular constraints, #698 addresses GCDs of binomial coefficients—both explore the fine structure of divisibility."
+    }
+  ],
   "sections": [
     {
       "id": "erd-s-problem-697-density-of-i",
-      "title": "Erdős Problem #697: Density of Integers Divisible by d ≡ 1 (mod m)",
+      "title": "Problem Statement and References",
       "startLine": 1,
       "endLine": 41,
-      "summary": "Erdős Problem #697: Density of Integers Divisible by d ≡ 1 (mod m)"
+      "summary": "Module docstring stating the problem: does $\\delta(m, \\alpha) \\to 0$ or $1$ exhibit a sharp threshold $\\beta$? Summarizes the answer ($\\beta = 1/\\ln 2$, Hall 1992), key results (trivial bound for $\\alpha < 1$, Erdős's $\\alpha = 1$ claim), and references [Er79e], [Ha92]. Imports Mathlib's logarithm, exponential, and filter modules."
     },
     {
       "id": "part-1-basic-definitions",
       "title": "Part 1: Basic Definitions",
       "startLine": 42,
       "endLine": 62,
-      "summary": "Part 1: Basic Definitions"
+      "summary": "Defines `IsAdmissibleDivisor` ($d \\mid n$, $d \\equiv 1 \\pmod{m}$, $1 < d < e^{m^\\alpha}$), `IsCovered` (existence of an admissible divisor), `coveredCount` (count via `Finset.filter`), and `delta` (asymptotic density via `Filter.liminf`)."
     },
     {
       "id": "part-2-the-threshold-question",
       "title": "Part 2: The Threshold Question",
       "startLine": 63,
       "endLine": 80,
-      "summary": "Part 2: The Threshold Question"
+      "summary": "Formalizes `HasSharpThreshold` as $\\exists \\beta > 1$ with density $\\to 0$ below and $\\to 1$ above, using `Filter.Tendsto`. Defines `hallThreshold = 1/\\ln 2$ and proves $\\beta > 1$ via `exp_one_gt_d9` and monotonicity of $\\ln$."
     },
     {
       "id": "part-3-trivial-bounds",
       "title": "Part 3: Trivial Bounds",
       "startLine": 81,
       "endLine": 94,
-      "summary": "Part 3: Trivial Bounds"
+      "summary": "Axiomatizes the trivial bound: for $\\alpha < 1$, $\\delta(m, \\alpha) \\to 0$ because $|\\{d \\equiv 1 \\pmod{m} : d < e^{m^\\alpha}\\}| \\approx m^{\\alpha - 1} \\to 0$."
     },
     {
       "id": "part-4-erd-s-s-claim-for-1",
       "title": "Part 4: Erdős's Claim for α = 1",
       "startLine": 95,
       "endLine": 104,
-      "summary": "Part 4: Erdős's Claim for α = 1"
+      "summary": "Axiomatizes Erdős's 1979 claim that $\\delta(m, 1) \\to 0$, extending the trivial range from $\\alpha < 1$ to $\\alpha \\le 1$."
     },
     {
       "id": "part-5-hall-s-theorem-1992",
       "title": "Part 5: Hall's Theorem (1992)",
       "startLine": 105,
       "endLine": 129,
-      "summary": "Part 5: Hall's Theorem (1992)"
+      "summary": "The core axiom: Hall's theorem giving `HasSharpThreshold` with the specific value $\\beta = 1/\\ln 2$. The combined theorem `threshold_is_one_over_log_two` packages existence, the threshold value, and both convergence directions."
     },
     {
       "id": "part-6-why-1-log-2",
       "title": "Part 6: Why 1/log 2?",
       "startLine": 130,
       "endLine": 148,
-      "summary": "Part 6: Why 1/log 2?"
+      "summary": "Intuition for the threshold value: the count of admissible $d$ is $\\sim e^{m^\\alpha}/m$. The critical exponent $1/\\ln 2$ arises from sieve-theoretic analysis of when enough admissible divisors exist to cover positive density."
     },
     {
       "id": "part-7-behavior-at-threshold",
       "title": "Part 7: Behavior at Threshold",
       "startLine": 149,
       "endLine": 163,
-      "summary": "Part 7: Behavior at Threshold"
+      "summary": "Notes that Hall's theorem leaves the exact behavior at $\\alpha = \\beta = 1/\\ln 2$ as an open question—the density may be 0, 1, or intermediate."
     },
     {
       "id": "part-8-connection-to-problem-6",
       "title": "Part 8: Connection to Problem #696",
       "startLine": 164,
       "endLine": 172,
-      "summary": "Part 8: Connection to Problem #696"
+      "summary": "Commentary linking to Erdős Problem #696, which concerns chains of prime divisors under the same congruence condition $d \\equiv 1 \\pmod{m}$."
     },
     {
       "id": "part-9-examples",
       "title": "Part 9: Examples",
       "startLine": 173,
       "endLine": 185,
-      "summary": "Part 9: Examples"
+      "summary": "Concrete cases: for $m = 2$, every integer has an odd divisor, so $\\delta(2, \\alpha) = 1$ trivially. For $m = p$ (large prime), the smallest admissible $d$ is $1 + p$, making the density analysis non-trivial."
     },
     {
       "id": "part-10-historical-context",
       "title": "Part 10: Historical Context",
       "startLine": 186,
       "endLine": 196,
-      "summary": "Part 10: Historical Context"
+      "summary": "Notes on the problem's origins in Erdős's 1979 Astérisque paper and Hall's 1992 resolution in J. Number Theory."
     },
     {
       "id": "part-11-main-results",
       "title": "Part 11: Main Results",
       "startLine": 197,
       "endLine": 232,
-      "summary": "Part 11: Main Results"
+      "summary": "Final theorems: `erdos_697_answer` (threshold exists), `erdos_697_threshold` (full characterization with $\\beta = 1/\\ln 2$), `erdos_697_summary` (threshold exists and $\\beta > 1$), and `erdos_697_solved` (problem is completely resolved)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Added `mathContext` to all 14 annotations (was missing on 12/14)
- Added `prerequisites` to all 14 annotations (was missing on all)
- Fixed invalid annotation type `axiom`→`theorem` for Hall's theorem annotation
- Fixed annotation line ranges to point at actual Lean constructs (not comment lines)
- Replaced 12 placeholder section summaries (just repeated titles) with substantive LaTeX descriptions
- Added `crossReferences` to erdos-696 and erdos-698

## Test plan
- [x] `pnpm annotations:build` passes (1 non-strict warning for axiom line, expected)
- [x] JSON is well-formed

🤖 Generated with [Claude Code](https://claude.com/claude-code)