### PR TITLE
enrich(isoperimetric-theorem): fix annotations, expand sections, add crossReferences

### DIFF
--- a/src/data/proofs/isoperimetric-theorem/annotations.json
+++ b/src/data/proofs/isoperimetric-theorem/annotations.json
@@ -6,8 +6,10 @@
     "type": "concept",
     "title": "Isoperimetric Theorem: Wiedijk #43",
     "content": "**The Isoperimetric Inequality**:\n\nAmong all closed curves with perimeter $L$, the **circle** encloses the maximum area $A$:\n$$4\\pi A \\leq L^2$$\n\nEquality holds **if and only if** the curve is a circle.\n\n**Equivalent forms**:\n- Isoperimetric ratio: $\\frac{A}{L^2} \\leq \\frac{1}{4\\pi}$\n- For fixed area, circle has minimum perimeter\n\n**Historical**: Known as **Dido's Problem** since antiquity. Queen Dido was given as much land as a bull's hide could enclose — she cut it into strips and made a semicircle against the coast!\n\nRigorous proofs came in the 19th century (Steiner 1838, Weierstrass 1870s).",
+    "mathContext": "$4\\pi A \\le L^2$ with equality iff the curve is a circle. This is Wiedijk's 100 theorems list entry #43, one of the foundational results of geometric optimization.",
     "significance": "critical",
-    "relatedConcepts": ["isoperimetric inequality", "circle", "optimization"]
+    "relatedConcepts": ["isoperimetric inequality", "circle", "optimization", "Dido's problem"],
+    "prerequisites": ["arc length", "enclosed area", "calculus of variations"]
   },
   {
     "id": "ann-curve",
@@ -15,10 +17,11 @@
     "range": {"startLine": 81, "endLine": 98},
     "type": "definition",
     "title": "Simple Closed Curves",
-    "content": "**Simple Closed Curve Structure**:\n\n```lean\nstructure SimpleClosedCurve where\n  perimeter : ℝ\n  perimeter_pos : 0 < perimeter\n  enclosedArea : ℝ\n  area_nonneg : 0 ≤ enclosedArea\n```\n\n**Properties**:\n- **Simple**: Doesn't self-intersect\n- **Closed**: Returns to starting point\n- **Perimeter** $L$: Arc length (positive)\n- **Area** $A$: Enclosed region (non-negative)\n\nWe abstract away the curve parameterization and focus on these geometric quantities.",
-    "mathContext": "L = perimeter, A = area",
-    "significance": "major",
-    "relatedConcepts": ["Jordan curve", "arc length", "enclosed area"]
+    "content": "A `SimpleClosedCurve` carries a perimeter $L > 0$ and an enclosed area $A \\ge 0$. We abstract away the parameterization to focus on these geometric invariants, avoiding the full complexity of defining curves as continuous injective maps $\\gamma : [0,1] \\to \\mathbb{R}^2$.",
+    "mathContext": "The structure packages $L > 0$ and $A \\ge 0$ as data, with `perimeter_pos : 0 < L` and `area_nonneg : 0 \\le A` as proofs. This is a common Lean pattern for bundling data with invariants.",
+    "significance": "key",
+    "relatedConcepts": ["Jordan curve theorem", "arc length", "enclosed area", "Green's theorem"],
+    "prerequisites": ["simple closed curve", "positivity of perimeter"]
   },
   {
     "id": "ann-circle",
@@ -26,10 +29,11 @@
     "range": {"startLine": 104, "endLine": 134},
     "type": "definition",
     "title": "Circle: The Optimal Shape",
-    "content": "**Circle Properties**:\n\nFor a circle with radius $r$:\n- **Perimeter**: $L = 2\\pi r$\n- **Area**: $A = \\pi r^2$\n\n**Lean**:\n```lean\nstructure Circle where\n  radius : ℝ\n  radius_pos : 0 < radius\n\ndef Circle.perimeter (c : Circle) : ℝ := 2 * π * c.radius\ndef Circle.area (c : Circle) : ℝ := π * c.radius ^ 2\n```\n\n**Verification**:\n- Perimeter is positive: $2\\pi r > 0$\n- Area is positive: $\\pi r^2 > 0$\n\nCircles can be converted to `SimpleClosedCurve` via `Circle.toCurve`.",
-    "mathContext": "L = 2πr, A = πr²",
-    "significance": "major",
-    "relatedConcepts": ["circumference", "πr²", "radius"]
+    "content": "Defines `Circle` with a positive radius $r > 0$, along with `Circle.perimeter` ($2\\pi r$) and `Circle.area` ($\\pi r^2$). Includes verification that both are positive and a coercion `Circle.toCurve` to `SimpleClosedCurve`.",
+    "mathContext": "$L = 2\\pi r$ and $A = \\pi r^2$ for a circle of radius $r$. The ratio $A/L^2 = \\pi r^2 / (4\\pi^2 r^2) = 1/(4\\pi)$, the maximum possible.",
+    "significance": "key",
+    "relatedConcepts": ["circumference", "area of circle", "radius"],
+    "prerequisites": ["Real.pi_pos", "circle geometry"]
   },
   {
     "id": "ann-ratio",
@@ -37,10 +41,11 @@
     "range": {"startLine": 140, "endLine": 162},
     "type": "definition",
     "title": "Isoperimetric Ratio",
-    "content": "**The Isoperimetric Ratio**:\n\n$$\\rho = \\frac{A}{L^2}$$\n\nmeasures how efficiently a curve encloses area relative to its perimeter.\n\n**Optimal value**: $\\rho_{\\max} = \\frac{1}{4\\pi} \\approx 0.0796$\n\n**For any curve**: $\\frac{A}{L^2} \\leq \\frac{1}{4\\pi}$\n\n**Lean**:\n```lean\nnoncomputable def isoperimetricRatio (C : SimpleClosedCurve) : ℝ :=\n  C.A / C.L ^ 2\n\nnoncomputable def optimalRatio : ℝ := 1 / (4 * π)\n```\n\nThe isoperimetric ratio is always non-negative.",
-    "mathContext": "ρ = A/L² ≤ 1/(4π)",
-    "significance": "major",
-    "relatedConcepts": ["efficiency", "shape factor", "circularity"]
+    "content": "The **isoperimetric ratio** $\\rho = A/L^2$ measures how efficiently a curve encloses area. The optimal value $\\rho_{\\max} = 1/(4\\pi) \\approx 0.0796$ is achieved only by circles. This dimensionless quantity is invariant under scaling.",
+    "mathContext": "$\\rho(C) = \\frac{A}{L^2} \\le \\frac{1}{4\\pi}$. The ratio is dimensionless and scale-invariant: $\\rho(\\lambda C) = \\rho(C)$ for any $\\lambda > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["shape factor", "circularity index", "dimensionless ratio"],
+    "prerequisites": ["SimpleClosedCurve", "Real.pi"]
   },
   {
     "id": "ann-circle-optimal",
@@ -48,10 +53,11 @@
     "range": {"startLine": 168, "endLine": 182},
     "type": "theorem",
     "title": "Circle Achieves Optimal Ratio",
-    "content": "**Verification: Circle is Optimal**\n\nFor a circle with radius $r$:\n- $L = 2\\pi r$\n- $A = \\pi r^2$\n- Ratio: $\\frac{A}{L^2} = \\frac{\\pi r^2}{(2\\pi r)^2} = \\frac{\\pi r^2}{4\\pi^2 r^2} = \\frac{1}{4\\pi}$ ✓\n\n**Lean**:\n```lean\ntheorem circle_achieves_optimal_ratio (c : Circle) :\n    isoperimetricRatio c.toCurve = optimalRatio\n```\n\nThis confirms circles exactly achieve the theoretical maximum ratio.",
-    "mathContext": "A/L² = 1/(4π) for circles",
-    "significance": "major",
-    "relatedConcepts": ["field_simp", "ring", "verification"]
+    "content": "Verifies that every circle achieves $\\rho = 1/(4\\pi)$. The proof is algebraic: $\\pi r^2 / (2\\pi r)^2 = \\pi r^2 / (4\\pi^2 r^2) = 1/(4\\pi)$, closed by `field_simp` and `ring`.",
+    "mathContext": "$\\frac{\\pi r^2}{(2\\pi r)^2} = \\frac{1}{4\\pi}$ — pure algebra confirming the circle saturates the isoperimetric bound.",
+    "significance": "key",
+    "relatedConcepts": ["algebraic verification", "field_simp", "ring tactic"],
+    "prerequisites": ["Circle.toCurve", "isoperimetricRatio", "optimalRatio"]
   },
   {
     "id": "ann-main-theorem",
@@ -59,10 +65,11 @@
     "range": {"startLine": 188, "endLine": 233},
     "type": "theorem",
     "title": "The Isoperimetric Inequality",
-    "content": "**Main Theorem** (Wiedijk #43):\n\nFor any simple closed curve with perimeter $L$ and area $A$:\n$$4\\pi A \\leq L^2$$\n\n**Equivalent**: $\\frac{A}{L^2} \\leq \\frac{1}{4\\pi}$\n\n**Proof Approaches** (all beyond current Mathlib):\n1. **Steiner symmetrization**: Reflect to improve non-circles\n2. **Fourier/Wirtinger**: Parameterize by Fourier series\n3. **Brunn-Minkowski**: $|A+B|^{1/n} \\geq |A|^{1/n} + |B|^{1/n}$\n4. **Calculus of variations**: Lagrange multipliers\n\n**Status**: Main result axiomatized.\n\n**Lean**:\n```lean\naxiom isoperimetric_inequality (C : SimpleClosedCurve) :\n    4 * π * C.A ≤ C.L ^ 2\n```",
-    "mathContext": "4πA ≤ L²",
+    "content": "**Main Theorem** (Wiedijk #43):\n\n$4\\pi A \\le L^2$ for any simple closed curve. Axiomatized because full proofs require techniques beyond current Mathlib:\n1. **Steiner symmetrization** (1838)\n2. **Fourier/Wirtinger inequality** (Hurwitz 1902)\n3. **Brunn-Minkowski inequality**\n4. **Calculus of variations** (Lagrange multipliers)\n\nThe ratio form $A/L^2 \\le 1/(4\\pi)$ follows as a corollary.",
+    "mathContext": "The axiom states $4\\pi A \\le L^2$. Hurwitz's 1902 proof via Fourier analysis: parameterize the curve as $(x(t), y(t))$ with $t \\in [0, 2\\pi]$, expand in Fourier series, and apply Parseval's theorem plus the Wirtinger inequality to bound the area integral.",
     "significance": "critical",
-    "relatedConcepts": ["Steiner symmetrization", "Brunn-Minkowski", "calculus of variations"]
+    "relatedConcepts": ["Steiner symmetrization", "Brunn-Minkowski", "Wirtinger inequality", "Fourier analysis"],
+    "prerequisites": ["SimpleClosedCurve", "Real.pi_pos"]
   },
   {
     "id": "ann-equality",
@@ -70,41 +77,46 @@
     "range": {"startLine": 239, "endLine": 276},
     "type": "theorem",
     "title": "Equality Characterization",
-    "content": "**When Does Equality Hold?**\n\n$$4\\pi A = L^2 \\quad \\Leftrightarrow \\quad \\text{curve is a circle}$$\n\n**Definition**:\n```lean\ndef IsOptimal (C : SimpleClosedCurve) : Prop :=\n  4 * π * C.A = C.L ^ 2\n```\n\n**Theorems**:\n```lean\ntheorem circle_isOptimal (c : Circle) : IsOptimal c.toCurve\n\naxiom equality_iff_circle (C : SimpleClosedCurve) :\n    IsOptimal C ↔ ∃ (c : Circle), C.perimeter = c.perimeter ∧\n                                  C.enclosedArea = c.area\n```\n\nThis is the \"rigidity\" part: circles are the **unique** optimal shapes.",
-    "mathContext": "4πA = L² ⟺ circle",
+    "content": "**Rigidity**: $4\\pi A = L^2$ if and only if the curve is a circle. Defines `IsOptimal` and proves circles satisfy it. The converse (optimality implies circularity) is axiomatized — this is the \"rigidity\" part requiring deeper analysis.",
+    "mathContext": "$4\\pi A = L^2 \\iff C$ is a circle. In the Fourier proof, equality in Wirtinger's inequality forces all higher Fourier coefficients to vanish, so the curve must be $x(t) = a\\cos t + c_1$, $y(t) = a\\sin t + c_2$ — a circle of radius $a$.",
     "significance": "critical",
-    "relatedConcepts": ["uniqueness", "rigidity", "characterization"]
+    "relatedConcepts": ["rigidity", "uniqueness", "equality case", "Fourier characterization"],
+    "prerequisites": ["isoperimetric_inequality", "Circle.toCurve"]
   },
   {
     "id": "ann-examples",
     "proofId": "isoperimetric-theorem",
     "range": {"startLine": 281, "endLine": 327},
-    "type": "note",
+    "type": "concept",
     "title": "Example: Square vs Circle",
-    "content": "**Comparison: Square vs Circle**\n\nFor same perimeter $L$:\n\n**Circle** (radius $r = L/(2\\pi)$):\n- Area: $\\pi r^2 = \\frac{L^2}{4\\pi}$\n- Ratio: $\\frac{1}{4\\pi} \\approx 0.0796$\n\n**Square** (side $s = L/4$):\n- Area: $s^2 = \\frac{L^2}{16}$\n- Ratio: $\\frac{1}{16} = 0.0625$\n\n**Circle wins by ~27%!**\n\n**Lean verification**:\n```lean\ntheorem square_ratio (sq : Square) :\n    isoperimetricRatio sq.toCurve = 1 / 16\n\ntheorem square_suboptimal (sq : Square) :\n    isoperimetricRatio sq.toCurve < optimalRatio\n```",
-    "mathContext": "1/16 < 1/(4π)",
-    "significance": "major",
-    "relatedConcepts": ["square", "comparison", "suboptimal"]
+    "content": "Compares the isoperimetric ratio of squares ($1/16 = 0.0625$) vs circles ($1/(4\\pi) \\approx 0.0796$). The circle wins by $\\sim 27\\%$. Formally proves `square_suboptimal`: the square's ratio is strictly less than optimal.",
+    "mathContext": "$\\frac{A_{\\text{square}}}{L_{\\text{square}}^2} = \\frac{(L/4)^2}{L^2} = \\frac{1}{16} < \\frac{1}{4\\pi} \\approx 0.0796$. The deficit measures how far the square deviates from optimality.",
+    "significance": "supporting",
+    "relatedConcepts": ["square", "comparison", "suboptimality deficit"],
+    "prerequisites": ["isoperimetricRatio", "optimalRatio"]
   },
   {
     "id": "ann-3d",
     "proofId": "isoperimetric-theorem",
     "range": {"startLine": 374, "endLine": 398},
     "type": "concept",
-    "title": "Generalization to 3D",
-    "content": "**3D Isoperimetric Inequality**:\n\nFor a region with volume $V$ and surface area $S$:\n$$36\\pi V^2 \\leq S^3$$\n\nEquality iff the region is a **sphere**.\n\n**General $n$ dimensions**:\n$$n \\omega_n^{1/n} V^{(n-1)/n} \\leq S$$\n\nwhere $\\omega_n$ = volume of unit $n$-ball.\n\n**Physical interpretation**: Soap bubbles are spherical because they minimize surface energy for a given enclosed volume!",
-    "mathContext": "36πV² ≤ S³ in 3D",
-    "significance": "major",
-    "relatedConcepts": ["sphere", "soap bubbles", "surface area"]
+    "title": "Generalization to 3D and Higher Dimensions",
+    "content": "**3D Isoperimetric Inequality**: $36\\pi V^2 \\le S^3$ with equality iff the region is a sphere. Generalizes to $n$ dimensions: $n \\omega_n^{1/n} V^{(n-1)/n} \\le S$ where $\\omega_n$ is the volume of the unit $n$-ball.\n\n**Physical interpretation**: Soap bubbles minimize surface energy for a given volume, naturally forming spheres!",
+    "mathContext": "$36\\pi V^2 \\le S^3$ in 3D. In general: $\\frac{S}{n \\omega_n^{1/n}} \\ge V^{(n-1)/n}$ where $\\omega_n = \\frac{\\pi^{n/2}}{\\Gamma(n/2 + 1)}$.",
+    "significance": "key",
+    "relatedConcepts": ["sphere", "soap bubbles", "n-ball volume", "Gamma function"],
+    "prerequisites": ["isoperimetric inequality", "volume and surface area in ℝⁿ"]
   },
   {
     "id": "ann-applications",
     "proofId": "isoperimetric-theorem",
     "range": {"startLine": 404, "endLine": 438},
-    "type": "note",
-    "title": "Applications",
-    "content": "**Applications of the Isoperimetric Inequality**:\n\n**Biology**: Cells are often spherical to minimize membrane material.\n\n**Engineering**: Storage tanks use cylindrical/spherical shapes for efficiency.\n\n**Physics**: Soap bubbles form spheres to minimize surface energy.\n\n**Urban Planning**: Circular cities are more efficient than elongated ones.\n\n**Mathematics Connections**:\n- Sobolev inequalities in PDEs\n- Concentration of measure\n- Geometric measure theory\n- Optimal transport\n\n**Historical Note**: The search for a rigorous proof took over **2000 years**!",
-    "significance": "minor",
-    "relatedConcepts": ["optimization", "biology", "physics", "Sobolev"]
+    "type": "concept",
+    "title": "Applications and Mathematical Connections",
+    "content": "Applications span physics (soap bubbles, crystal growth), engineering (optimal tank design), biology (spherical cells), and mathematics (Sobolev inequalities, concentration of measure, optimal transport). The search for a rigorous proof took over **2000 years** from Dido's problem to Weierstrass.",
+    "mathContext": "The Sobolev inequality $\\|f\\|_{L^{n/(n-1)}} \\le C_n \\|\\nabla f\\|_{L^1}$ is a functional-analytic reformulation of the isoperimetric inequality via the co-area formula.",
+    "significance": "supporting",
+    "relatedConcepts": ["Sobolev inequality", "concentration of measure", "optimal transport", "co-area formula"],
+    "prerequisites": ["isoperimetric inequality", "Sobolev spaces"]
   }
 ]

--- a/src/data/proofs/isoperimetric-theorem/meta.json
+++ b/src/data/proofs/isoperimetric-theorem/meta.json
@@ -35,30 +35,90 @@
     "dateAdded": "12/29/25"
   },
   "overview": {
-    "historicalContext": "The isoperimetric problem is one of the oldest in mathematics, known to the ancient Greeks. The legendary Queen Dido founded Carthage by using an ox hide cut into a thin strip to enclose maximum land. Rigorous proofs came in the 19th century.",
+    "historicalContext": "The isoperimetric problem is one of the oldest in mathematics. According to Virgil's *Aeneid* (29–19 BCE), Queen Dido of Carthage was promised as much land as a bull's hide could encompass; she cut it into thin strips and formed a semicircle against the coast, maximizing the enclosed area. The ancient Greeks knew the circle was optimal, and Zenodorus (~200 BCE) gave geometric arguments. The first attempt at a rigorous proof was by Jakob Steiner (1838) using his **symmetrization** method, but this assumed the optimal curve exists. Karl Weierstrass (1870s) filled this gap using the direct method of the calculus of variations. Adolf Hurwitz (1902) gave an elegant proof via **Fourier analysis** and the Wirtinger inequality. The Brunn-Minkowski inequality (1887–1896) provides yet another route. The theorem generalizes to Riemannian manifolds, where Lévy and Gromov established isoperimetric comparisons, and to metric measure spaces via Lott-Sturm-Villani theory.",
     "problemStatement": "**Isoperimetric Theorem**: For any simple closed curve with perimeter L enclosing area A:\n\n$$4\\pi A \\leq L^2$$\n\nEquality holds if and only if the curve is a circle.",
     "proofStrategy": "Modern proofs use calculus of variations, Fourier analysis, or the Brunn-Minkowski inequality. The key is showing that any deviation from circular shape decreases the area-to-perimeter ratio.",
     "keyInsights": [
       "The circle is uniquely optimal among all shapes",
       "Generalizes to spheres in higher dimensions",
       "Connected to eigenvalue problems and heat diffusion",
-      "Foundation for geometric measure theory"
+      "Foundation for geometric measure theory",
+      "The **Sobolev inequality** $\\|f\\|_{L^{n/(n-1)}} \\le C_n \\|\\nabla f\\|_{L^1}$ is a functional-analytic reformulation via the co-area formula, connecting geometry to PDE theory"
     ]
   },
-  "sections": [
+  "crossReferences": [
     {
-      "id": "perimeter-area",
-      "title": "Perimeter and Area",
-      "startLine": 50,
-      "endLine": 100,
-      "summary": "Definitions for closed curves."
+      "targetId": "area-of-circle",
+      "relationship": "related",
+      "description": "The area formula $A = \\pi r^2$ and circumference $C = 2\\pi r$ used to define Circle and verify the optimal isoperimetric ratio $1/(4\\pi)$ are formalized in the Area of a Circle entry."
     },
     {
-      "id": "isoperimetric-inequality",
-      "title": "Isoperimetric Inequality",
-      "startLine": 100,
-      "endLine": 180,
-      "summary": "Main inequality and equality case."
+      "targetId": "area-of-circle-oq-01",
+      "relationship": "related",
+      "description": "The isoperimetric equality $C^2 = 4\\pi A$ proved in the Circumference from Area entry is the equality case of this theorem restricted to circles."
+    },
+    {
+      "targetId": "picks-theorem",
+      "relationship": "related",
+      "description": "Pick's theorem relates area to lattice points for polygons. Both results connect perimeter/boundary information to enclosed area, though in different settings (continuous vs discrete)."
+    }
+  ],
+  "sections": [
+    {
+      "id": "docstring-setup",
+      "title": "Module Documentation and Imports",
+      "startLine": 1,
+      "endLine": 78,
+      "summary": "Extensive docstring covering the mathematical statement $4\\pi A \\le L^2$, four historical proof approaches (Steiner symmetrization, Fourier/Wirtinger, Brunn-Minkowski, calculus of variations), and status. Imports Mathlib's trigonometric constants, measure theory, and tactic library."
+    },
+    {
+      "id": "curve-definitions",
+      "title": "Simple Closed Curves and Circle Definitions",
+      "startLine": 81,
+      "endLine": 134,
+      "summary": "Defines `SimpleClosedCurve` (perimeter $L > 0$, area $A \\ge 0$) and `Circle` (radius $r > 0$) with derived `perimeter = 2\\pi r$, `area = \\pi r^2$, and coercion `Circle.toCurve`. Proves positivity of circle's perimeter and area."
+    },
+    {
+      "id": "isoperimetric-ratio",
+      "title": "Isoperimetric Ratio",
+      "startLine": 140,
+      "endLine": 182,
+      "summary": "Defines the dimensionless ratio $\\rho = A/L^2$ and the optimal value $1/(4\\pi)$. Proves `circle_achieves_optimal_ratio`: every circle attains the theoretical maximum via algebraic computation (`field_simp` + `ring`)."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: The Isoperimetric Inequality",
+      "startLine": 188,
+      "endLine": 233,
+      "summary": "Axiomatizes $4\\pi A \\le L^2$ for all simple closed curves. Derives the ratio form $A/L^2 \\le 1/(4\\pi)$ as a corollary. Documents why the proof is beyond current Mathlib (requires symmetrization, Fourier analysis, or Brunn-Minkowski)."
+    },
+    {
+      "id": "equality-case",
+      "title": "Equality Characterization",
+      "startLine": 239,
+      "endLine": 276,
+      "summary": "Defines `IsOptimal` ($4\\pi A = L^2$) and proves circles satisfy it. Axiomatizes the converse: optimality implies circularity. This **rigidity** result is the key qualitative insight."
+    },
+    {
+      "id": "examples-comparison",
+      "title": "Examples: Square vs Circle",
+      "startLine": 281,
+      "endLine": 370,
+      "summary": "Defines `Square` and `EquilateralTriangle`, computes their isoperimetric ratios ($1/16$ and $1/(12\\sqrt{3})$ respectively), and proves both are strictly suboptimal compared to circles."
+    },
+    {
+      "id": "higher-dimensions",
+      "title": "Higher-Dimensional Generalizations",
+      "startLine": 374,
+      "endLine": 398,
+      "summary": "States the 3D isoperimetric inequality $36\\pi V^2 \\le S^3$ (sphere is optimal) and the general $n$-dimensional form involving $\\omega_n$, the volume of the unit $n$-ball."
+    },
+    {
+      "id": "applications",
+      "title": "Applications and Connections",
+      "startLine": 404,
+      "endLine": 449,
+      "summary": "Discusses applications in physics (soap bubbles), biology (cell shapes), engineering (optimal tanks), and connections to Sobolev inequalities, concentration of measure, geometric measure theory, and optimal transport."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Fixed invalid `significance` values (`major`→`key`, `minor`→`supporting`) in 6 annotations
- Fixed invalid annotation types (`note`→`concept`) for 2 annotations
- Added `mathContext` to ann-intro and expanded existing mathContext fields
- Added `prerequisites` to all 10 annotations (was missing on all)
- Expanded `historicalContext` from ~190 chars to 800+ with Zenodorus, Steiner, Weierstrass, Hurwitz (1902 Fourier proof), Brunn-Minkowski, Lévy-Gromov, Lott-Sturm-Villani
- Added 5th `keyInsight` on Sobolev inequality connection
- Replaced 2 vague sections with 8 accurate sections covering full file (lines 1–449)
- Added `crossReferences` to area-of-circle, area-of-circle-oq-01, picks-theorem

## Test plan
- [x] `pnpm annotations:build` passes with no warnings for this entry
- [x] JSON is well-formed

🤖 Generated with [Claude Code](https://claude.com/claude-code)