### PR TITLE
enrich erdos-107: fix types, add leanFile/crossReferences

### DIFF
--- a/src/data/proofs/erdos-107/annotations.json
+++ b/src/data/proofs/erdos-107/annotations.json
@@ -6,14 +6,11 @@
       "startLine": 24,
       "endLine": 28
     },
-    "type": "context",
+    "type": "concept",
     "title": "Imports and Setup",
     "content": "Imports full Mathlib and opens `Finset` and `BigOperators` for working with finite sets and summation notation. The proof resides in the `Erdos107` namespace.",
-    "mathContext": {
-      "latex": "\\text{import Mathlib}, \\quad \\text{open } \\text{Finset}, \\text{BigOperators}",
-      "description": "The formalization uses Mathlib's EuclideanSpace, Collinear, convexHull, Finset, and Filter.atTop."
-    },
-    "significance": "context",
+    "mathContext": "The formalization uses Mathlib's EuclideanSpace for $\\mathbb{R}^2$, Collinear for the general position predicate, convexHull for the convex $n$-gon definition, Finset for finite point sets, and Filter.atTop for Suk's asymptotic bound.",
+    "significance": "supporting",
     "relatedConcepts": ["mathlib", "euclidean-space", "finset"],
     "prerequisites": ["lean4-basics"]
   },
@@ -21,16 +18,13 @@
     "id": "ann-e107-general-position",
     "proofId": "erdos-107",
     "range": {
-      "startLine": 32,
+      "startLine": 34,
       "endLine": 36
     },
     "type": "definition",
     "title": "General Position",
     "content": "A finite set of points in $\\mathbb{R}^2$ is in **general position** if no three points are collinear. This is formalized using Mathlib's `Collinear` predicate over $\\mathbb{R}$: for any three distinct points $p, q, r \\in S$, the set $\\{p, q, r\\}$ is not collinear. General position is the standard non-degeneracy condition in combinatorial geometry, ensuring that the convex hull structure is well-behaved.",
-    "mathContext": {
-      "latex": "\\text{InGeneralPosition}(S) \\;:\\Leftrightarrow\\; \\forall\\, p, q, r \\in S,\\; p \\neq q \\neq r \\neq p \\;\\Rightarrow\\; \\neg\\,\\text{Collinear}_{\\mathbb{R}}(\\{p, q, r\\})",
-      "description": "Uses Mathlib's Collinear predicate which checks if points lie on a common affine line. Three points are collinear iff they are affinely dependent."
-    },
+    "mathContext": "$\\text{InGeneralPosition}(S) \\;:\\Leftrightarrow\\; \\forall\\, p, q, r \\in S,\\; p \\neq q \\neq r \\neq p \\;\\Rightarrow\\; \\neg\\,\\text{Collinear}_{\\mathbb{R}}(\\{p, q, r\\})$. Uses Mathlib's Collinear predicate which checks if points lie on a common affine line. Three points are collinear iff they are affinely dependent.",
     "significance": "key",
     "relatedConcepts": ["collinearity", "general-position", "affine-dependence", "non-degeneracy"],
     "prerequisites": ["euclidean-plane", "affine-geometry"]
@@ -39,16 +33,13 @@
     "id": "ann-e107-convex-ngon",
     "proofId": "erdos-107",
     "range": {
-      "startLine": 38,
-      "endLine": 46
+      "startLine": 40,
+      "endLine": 41
     },
     "type": "definition",
     "title": "Convex n-gon and Containment",
     "content": "A set of $n$ points forms a **convex $n$-gon** if the set has exactly $n$ points and each point is a vertex of the convex hull (i.e., no point lies in the convex hull of the remaining points). This is the **convex position** characterization: $S$ is in convex position iff every point of $S$ is an extreme point of $\\operatorname{conv}(S)$. A point set **contains a convex $n$-gon** if it has a subset forming one.",
-    "mathContext": {
-      "latex": "\\text{IsConvexNGon}(n, S) \\;:\\Leftrightarrow\\; |S| = n \\;\\wedge\\; \\forall\\, p \\in S,\\; p \\notin \\operatorname{conv}(S \\setminus \\{p\\})",
-      "description": "Uses Mathlib's convexHull over ℝ and Finset.erase. The definition avoids ordering the vertices, capturing convex position purely via the extreme point property."
-    },
+    "mathContext": "$\\text{IsConvexNGon}(n, S) \\;:\\Leftrightarrow\\; |S| = n \\;\\wedge\\; \\forall\\, p \\in S,\\; p \\notin \\operatorname{conv}(S \\setminus \\{p\\})$. Uses Mathlib's convexHull over $\\mathbb{R}$ and Finset.erase. The definition avoids ordering the vertices, capturing convex position purely via the extreme point property.",
     "significance": "critical",
     "relatedConcepts": ["convex-hull", "extreme-point", "convex-position", "polygon"],
     "prerequisites": ["convex-sets", "finset-operations"]
@@ -57,16 +48,13 @@
     "id": "ann-e107-f-definition",
     "proofId": "erdos-107",
     "range": {
-      "startLine": 48,
+      "startLine": 50,
       "endLine": 56
     },
     "type": "definition",
     "title": "The Function f(n)",
     "content": "The central object of study: $f(n) = \\inf\\{N \\mid \\text{any } N \\text{ points in general position contain a convex } n\\text{-gon}\\}$. The set `CardSet(n)` collects all threshold values $N$, and $f(n)$ is its infimum. The Erdos-Szekeres theorem proves this infimum is achieved (i.e., $f(n)$ is finite for all $n \\geq 3$).",
-    "mathContext": {
-      "latex": "f(n) = \\inf\\,\\bigl\\{\\, N \\in \\mathbb{N} \\;\\big|\\; \\forall\\, S \\subseteq \\mathbb{R}^2,\\; |S| = N \\wedge \\text{gen. pos.}(S) \\;\\Rightarrow\\; S \\supseteq \\text{convex } n\\text{-gon}\\,\\bigr\\}",
-      "description": "Defined noncomputably via sInf since the existence of the minimum requires the Erdos-Szekeres theorem. The function is a Ramsey-type extremal function."
-    },
+    "mathContext": "$f(n) = \\inf\\,\\bigl\\{\\, N \\in \\mathbb{N} \\;\\big|\\; \\forall\\, S \\subseteq \\mathbb{R}^2,\\; |S| = N \\wedge \\text{gen. pos.}(S) \\;\\Rightarrow\\; S \\supseteq \\text{convex } n\\text{-gon}\\,\\bigr\\}$. Defined noncomputably via sInf since the existence of the minimum requires the Erdos-Szekeres theorem. The function is a Ramsey-type extremal function.",
     "significance": "critical",
     "relatedConcepts": ["extremal-function", "ramsey-type", "infimum", "threshold-function"],
     "prerequisites": ["general-position", "convex-ngon", "natural-number-infimum"]
@@ -75,16 +63,13 @@
     "id": "ann-e107-small-cases",
     "proofId": "erdos-107",
     "range": {
-      "startLine": 58,
-      "endLine": 85
+      "startLine": 80,
+      "endLine": 84
     },
     "type": "theorem",
     "title": "Small Cases: f(3)=3, f(4)=5, f(5)=9",
     "content": "The known exact values of $f$: **$f(3) = 3$** (trivial: three non-collinear points form a triangle), **$f(4) = 5$** (Klein 1931: case analysis on the convex hull of 5 points), and **$f(5) = 9$** (Makai-Turan: any 9 points in general position contain a convex pentagon). Klein's proof of $f(4) = 5$ was the observation that sparked the entire problem: if the convex hull of 5 points is a quadrilateral or pentagon, we're done; if it's a triangle, the two interior points with two hull vertices form a convex quadrilateral.",
-    "mathContext": {
-      "latex": "f(3) = 3, \\quad f(4) = 5, \\quad f(5) = 9",
-      "description": "f(3) has a sorry proof (needs case analysis), f(4) and f(5) are axiomatized. The pattern 3, 5, 9 matches 2^{n-2}+1 for n=3,4,5, supporting the conjecture."
-    },
+    "mathContext": "$f(3) = 3, \\quad f(4) = 5, \\quad f(5) = 9$. The values $f(4)$ and $f(5)$ are axiomatized; $f(3)$ has a sorry proof (needs case analysis showing $3 \\in \\text{CardSet}(3)$ and $2 \\notin \\text{CardSet}(3)$). All three values match $2^{n-2}+1$ for $n=3,4,5$.",
     "significance": "key",
     "relatedConcepts": ["case-analysis", "convex-hull-structure", "base-cases"],
     "prerequisites": ["general-position", "convex-ngon"]
@@ -93,16 +78,13 @@
     "id": "ann-e107-ersz-lower",
     "proofId": "erdos-107",
     "range": {
-      "startLine": 88,
+      "startLine": 95,
       "endLine": 95
     },
     "type": "theorem",
     "title": "Erdos-Szekeres Lower Bound (1960)",
     "content": "**$2^{n-2}+1 \\leq f(n)$** for all $n \\geq 3$: There exist $2^{n-2}$ points in general position containing no convex $n$-gon. The construction is recursive: start with a suitable configuration for $n-1$ and carefully place new points to double the count while preventing any convex $n$-gon. This shows the conjectured value $2^{n-2}+1$ would be tight.",
-    "mathContext": {
-      "latex": "\\forall\\, n \\geq 3:\\quad 2^{n-2} + 1 \\leq f(n)",
-      "description": "Axiomatized. The construction uses a 'double sequence' (Horton set variant). The points are arranged so that certain orientations prevent large convex subsets."
-    },
+    "mathContext": "$\\forall\\, n \\geq 3:\\quad 2^{n-2} + 1 \\leq f(n)$. Axiomatized. The construction uses a 'double sequence' (Horton set variant). The points are arranged so that certain orientations prevent large convex subsets.",
     "significance": "critical",
     "relatedConcepts": ["lower-bound", "extremal-construction", "horton-set", "recursive-construction"],
     "prerequisites": ["f-definition", "general-position"]
@@ -111,16 +93,13 @@
     "id": "ann-e107-upper-bounds",
     "proofId": "erdos-107",
     "range": {
-      "startLine": 97,
+      "startLine": 103,
       "endLine": 124
     },
     "type": "theorem",
     "title": "Upper Bounds: ES (1935), Suk (2017), HMPT (2020)",
     "content": "Three progressively tighter upper bounds on $f(n)$:\n\n1. **Erdos-Szekeres (1935)**: $f(n) \\leq \\binom{2n-4}{n-2} + 1 \\sim 4^n/\\sqrt{n}$, using Ramsey theory\n2. **Suk (2017)**: $f(n) \\leq 2^{(1+o(1))n}$, a breakthrough reducing the base from 4 to 2 via a novel cups-and-caps argument with improved counting\n3. **HMPT (2020)**: $f(n) \\leq 2^{n + O(\\sqrt{n \\log n})}$, the current best bound by Holmsen-Mojarrad-Pach-Tardos\n\nThe gap between lower bound $2^{n-2}+1$ and upper bound $2^{n+O(\\sqrt{n\\log n})}$ is now only $O(\\sqrt{n \\log n})$ in the exponent.",
-    "mathContext": {
-      "latex": "2^{n-2}+1 \\;\\leq\\; f(n) \\;\\leq\\; 2^{n + C\\sqrt{n \\log n}}",
-      "description": "All three bounds axiomatized. Suk's bound uses Filter.atTop for the o(1) term. HMPT uses an existential constant C > 0. The exponential gap has been dramatically narrowed from ~4^n to ~2^{O(sqrt(n log n))} above 2^n."
-    },
+    "mathContext": "$2^{n-2}+1 \\;\\leq\\; f(n) \\;\\leq\\; 2^{n + C\\sqrt{n \\log n}}$. All three bounds axiomatized. Suk's bound uses Filter.atTop for the $o(1)$ term. HMPT uses an existential constant $C > 0$. The exponential gap has been dramatically narrowed from $\\sim 4^n$ to $\\sim 2^{O(\\sqrt{n \\log n})}$ above $2^n$.",
     "significance": "critical",
     "relatedConcepts": ["ramsey-theory", "cups-and-caps", "upper-bound", "asymptotic-analysis"],
     "prerequisites": ["f-definition", "binomial-coefficient", "asymptotic-notation"]
@@ -129,16 +108,13 @@
     "id": "ann-e107-main-conjecture",
     "proofId": "erdos-107",
     "range": {
-      "startLine": 126,
+      "startLine": 137,
       "endLine": 138
     },
-    "type": "concept",
+    "type": "definition",
     "title": "The Happy Ending Conjecture (OPEN)",
     "content": "**Conjecture (Erdos-Szekeres)**: $f(n) = 2^{n-2}+1$ for all $n \\geq 3$. This is defined as a `Prop` without asserting truth, since it remains **OPEN**. Erdos offered **$500** for a proof and **$100** for a counterexample. The conjecture is supported by the three known values ($f(3)=3, f(4)=5, f(5)=9$, all matching $2^{n-2}+1$) and by the tightening upper bounds. The name 'Happy Ending' comes from George Szekeres and Esther Klein's marriage, prompted by their collaboration on this problem.",
-    "mathContext": {
-      "latex": "\\text{HappyEndingConjecture} :\\Leftrightarrow \\forall\\, n \\geq 3,\\; f(n) = 2^{n-2} + 1",
-      "description": "Stated as def (a Prop) rather than axiom, correctly reflecting its open status. The value f(6) is unknown: the conjecture predicts f(6) = 17."
-    },
+    "mathContext": "$\\text{HappyEndingConjecture} :\\Leftrightarrow \\forall\\, n \\geq 3,\\; f(n) = 2^{n-2} + 1$. Stated as def (a Prop) rather than axiom, correctly reflecting its open status. The value $f(6)$ is unknown: the conjecture predicts $f(6) = 17$.",
     "significance": "critical",
     "relatedConcepts": ["open-problem", "erdos-prize", "combinatorial-geometry"],
     "prerequisites": ["f-definition", "ersz-lower-bound"]
@@ -147,18 +123,30 @@
     "id": "ann-e107-existence",
     "proofId": "erdos-107",
     "range": {
-      "startLine": 140,
-      "endLine": 170
+      "startLine": 148,
+      "endLine": 152
     },
     "type": "theorem",
-    "title": "Existence and Verified Bounds",
+    "title": "Existence and Finiteness of f(n)",
     "content": "**Erdos-Szekeres (1935)**: For every $n \\geq 3$, $f(n)$ is finite, i.e., `CardSet(n)` is nonempty. This is the foundational result that makes the problem well-defined. The proof uses the upper bound: $\\binom{2n-4}{n-2}+1 \\in \\text{CardSet}(n)$. Additionally, explicit bounds for $f(4)$ are stated: $4 < f(4)$ (4 points can avoid a quadrilateral) and $f(4) \\leq 5$ (Klein's result).",
-    "mathContext": {
-      "latex": "\\forall\\, n \\geq 3,\\; \\text{CardSet}(n) \\neq \\emptyset \\quad\\text{(i.e., } f(n) < \\infty\\text{)}",
-      "description": "f_finite has a sorry; the proof would instantiate the Ramsey-theoretic argument. The small-case bounds f_4_lb and f_4_ub together with f_four_eq give a complete picture for n=4."
-    },
+    "mathContext": "$\\forall\\, n \\geq 3,\\; \\text{CardSet}(n) \\neq \\emptyset$ (i.e., $f(n) < \\infty$). Has a sorry proof; the proof would instantiate the Ramsey-theoretic argument showing $\\binom{2n-4}{n-2}+1$ points suffice.",
     "significance": "key",
     "relatedConcepts": ["finiteness", "well-definedness", "ramsey-theorem"],
     "prerequisites": ["ersz-upper-bound", "cardset-definition"]
+  },
+  {
+    "id": "ann-e107-verified-bounds",
+    "proofId": "erdos-107",
+    "range": {
+      "startLine": 157,
+      "endLine": 169
+    },
+    "type": "theorem",
+    "title": "Verified Small Bounds for f(4)",
+    "content": "Three theorems bracketing $f(4)$: `f_3_value` ($f(3) = 3$, sorry), `f_4_lb` ($4 < f(4)$, sorry), and `f_4_ub` ($f(4) \\leq 5$, sorry). Together with the axiom `f_four_eq`, these give a complete picture for $n = 4$. The sorry proofs would require explicit case analysis on point configurations in the plane.",
+    "mathContext": "$f(3) = 3$, $4 < f(4)$, and $f(4) \\leq 5$, all with sorry proofs requiring combinatorial case analysis on small point sets in general position.",
+    "significance": "supporting",
+    "relatedConcepts": ["case-analysis", "small-cases", "explicit-computation"],
+    "prerequisites": ["f-definition", "general-position", "convex-ngon"]
   }
 ]

--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -36,6 +36,16 @@
         "theorem": "EuclideanSpace",
         "description": "Euclidean space type for R^2 point sets",
         "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Filter.atTop",
+        "description": "At-top filter used to formalize Suk's o(1) asymptotic term",
+        "module": "Mathlib.Order.Filter.AtTopBot.Basic"
+      },
+      {
+        "theorem": "Nat.choose",
+        "description": "Binomial coefficient for the original Erdos-Szekeres upper bound C(2n-4, n-2)+1",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
       }
     ],
     "originalContributions": [
@@ -47,6 +57,16 @@
       "HMPT bound 2^{n+O(sqrt(n log n))} with existential constant",
       "HappyEndingConjecture as Prop (correctly open)"
     ],
+    "leanFile": {
+      "lineCount": 188,
+      "structureCount": 0,
+      "axiomCount": 5,
+      "theoremCount": 5,
+      "defCount": 6,
+      "imports": [
+        "Mathlib"
+      ]
+    },
     "dateAdded": "2026-01-19"
   },
   "overview": {
@@ -54,12 +74,12 @@
     "problemStatement": "Let f(n) be minimal such that any f(n) points in R^2, no three on a line, contain n points which form the vertices of a convex n-gon. Prove that f(n) = 2^{n-2} + 1.",
     "proofStrategy": "The formalization defines convex n-gons via the convex hull property (each point is an extreme point of the hull), capturing convex position without vertex ordering. The function f(n) is defined as the infimum of the threshold set CardSet(n). Known bounds are axiomatized: the Erdos-Szekeres lower bound 2^{n-2}+1 <= f(n), three progressively tighter upper bounds (ES 1935, Suk 2017, HMPT 2020), and small cases f(4) = 5 and f(5) = 9. The main conjecture is expressed as a Prop (not an axiom) to correctly reflect its open status. The Suk bound formalizes the o(1) term using Lean's Filter.atTop.",
     "keyInsights": [
-      "The convex n-gon definition via extreme points (p not in conv(S \\ {p})) elegantly avoids vertex ordering, making it purely combinatorial",
-      "Erdos-Szekeres (1960) proved the lower bound 2^{n-2}+1 <= f(n) via a recursive 'double sequence' construction (Horton-set variant)",
-      "The original ES upper bound ~4^n stood for 80 years until Suk (2017) reduced the exponential base from 4 to 2, a dramatic improvement",
-      "HMPT (2020) further tightened to 2^{n+O(sqrt(n log n))}, leaving only an O(sqrt(n log n)) gap in the exponent",
-      "All three known values f(3)=3, f(4)=5, f(5)=9 match 2^{n-2}+1, but f(6) remains unknown",
-      "The Happy Ending name reflects the Szekeres-Klein romance, making this one of the few mathematical problems named for a love story"
+      "**The convex n-gon definition via extreme points** (p not in conv(S \\ {p})) elegantly avoids vertex ordering, making it purely combinatorial",
+      "**Erdos-Szekeres (1960) proved the lower bound** $2^{n-2}+1 \\leq f(n)$ via a recursive 'double sequence' construction (Horton-set variant)",
+      "**The original ES upper bound** $\\sim 4^n$ stood for 80 years until Suk (2017) reduced the exponential base from 4 to 2, a dramatic improvement",
+      "**HMPT (2020) further tightened** to $2^{n+O(\\sqrt{n \\log n})}$, leaving only an $O(\\sqrt{n \\log n})$ gap in the exponent",
+      "**All three known values** $f(3)=3, f(4)=5, f(5)=9$ match $2^{n-2}+1$, but $f(6)$ remains unknown",
+      "**The Happy Ending name** reflects the Szekeres-Klein romance, making this one of the few mathematical problems named for a love story"
     ]
   },
   "sections": [
@@ -75,42 +95,42 @@
       "title": "Core Definitions",
       "startLine": 30,
       "endLine": 56,
-      "summary": "Defines InGeneralPosition (no three collinear via Mathlib's Collinear), IsConvexNGon (extreme point characterization), HasConvexNGon (subset containment), CardSet (threshold set), and f(n) (infimum of CardSet)."
+      "summary": "Defines InGeneralPosition (no three collinear via Mathlib's Collinear), IsConvexNGon ($|S|=n$ with every point extreme), HasConvexNGon (subset containment), CardSet (threshold set $\\{N \\mid \\ldots\\}$), and $f(n) = \\inf(\\text{CardSet}(n))$."
     },
     {
       "id": "small-cases",
       "title": "Small Cases",
       "startLine": 58,
       "endLine": 85,
-      "summary": "Known exact values: f(3)=3 (sorry proof), f(4)=5 (Klein 1931, axiomatized), f(5)=9 (Makai-Turan, axiomatized). All match the conjectured 2^{n-2}+1."
+      "summary": "Known exact values: $f(3)=3$ (sorry proof), $f(4)=5$ (Klein 1931, axiomatized), $f(5)=9$ (Makai-Turan, axiomatized). All match $2^{n-2}+1$."
     },
     {
       "id": "lower-bound",
       "title": "Erdos-Szekeres Lower Bound",
       "startLine": 86,
       "endLine": 95,
-      "summary": "Axiomatized: 2^{n-2}+1 <= f(n) for n >= 3. Construction provides 2^{n-2} points with no convex n-gon via recursive doubling."
+      "summary": "Axiomatized: $2^{n-2}+1 \\leq f(n)$ for $n \\geq 3$. Construction provides $2^{n-2}$ points with no convex $n$-gon via recursive doubling."
     },
     {
       "id": "upper-bounds",
       "title": "Upper Bounds",
       "startLine": 97,
       "endLine": 124,
-      "summary": "Three progressively tighter bounds: ES (1935) C(2n-4,n-2)+1 via Ramsey theory, Suk (2017) 2^{(1+o(1))n} via cups-caps, HMPT (2020) 2^{n+O(sqrt(n log n))}. All axiomatized."
+      "summary": "Three progressively tighter bounds: ES (1935) $\\binom{2n-4}{n-2}+1$ via Ramsey theory, Suk (2017) $2^{(1+o(1))n}$ via cups-caps with Filter.atTop, HMPT (2020) $2^{n+O(\\sqrt{n \\log n})}$ with existential constant $C$."
     },
     {
       "id": "conjecture",
       "title": "Main Conjecture (OPEN)",
       "startLine": 126,
       "endLine": 138,
-      "summary": "HappyEndingConjecture defined as a Prop: f(n) = 2^{n-2}+1 for all n >= 3. Correctly stated without asserting truth. $500 Erdos prize."
+      "summary": "HappyEndingConjecture defined as a Prop: $f(n) = 2^{n-2}+1$ for all $n \\geq 3$. Correctly stated without asserting truth. $500 Erdos prize."
     },
     {
       "id": "existence",
       "title": "Existence and Verified Bounds",
       "startLine": 140,
       "endLine": 170,
-      "summary": "f_finite: CardSet(n) is nonempty for n >= 3. Explicit bounds f_4_lb and f_4_ub bracket f(4). All have sorry proofs requiring case analysis or the Ramsey argument."
+      "summary": "`f_finite`: CardSet$(n)$ is nonempty for $n \\geq 3$. Explicit bounds `f_4_lb` and `f_4_ub` bracket $f(4)$. All have sorry proofs requiring case analysis or the Ramsey argument."
     },
     {
       "id": "historical-notes",
@@ -132,16 +152,24 @@
   },
   "crossReferences": [
     {
-      "proofId": "erdos-467",
-      "relationship": "Both are Erdos problems in combinatorial geometry involving extremal point configurations and convex structure"
+      "targetProofId": "ramseys-theorem",
+      "relationship": "The original Erdos-Szekeres (1935) proof uses Ramsey-theoretic arguments to establish the existence of f(n), and the upper bound C(2n-4,n-2)+1 follows from Ramsey's theorem"
     },
     {
-      "proofId": "erdos-984",
+      "targetProofId": "erdos-984",
       "relationship": "Both are Ramsey-type problems in combinatorics where existence of structured subconfigurations is guaranteed above a threshold"
     },
     {
-      "proofId": "erdos-909",
-      "relationship": "Both are Erdos problems with deep topological/geometric content, connecting combinatorial structure to fundamental properties of spaces"
+      "targetProofId": "erdos-90",
+      "relationship": "Both are famous open Erdos problems in combinatorial geometry involving extremal properties of planar point sets ($500 prize each)"
+    },
+    {
+      "targetProofId": "erdos-106",
+      "relationship": "Neighboring Erdos problem in discrete geometry involving optimization over planar configurations"
+    },
+    {
+      "targetProofId": "erdos-467",
+      "relationship": "Both are Erdos problems involving extremal combinatorial thresholds and structured subconfigurations"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fixed `annotations.json`: invalid type `context`→`concept`, invalid significance `context`→`supporting`, converted `mathContext` from object to string format, added new annotation for verified small bounds, adjusted startLine values
- Enriched `meta.json`: added `leanFile` field (188 lines, 5 axioms, 5 theorems, 6 defs), fixed `crossReferences` keys (`proofId`→`targetProofId`), improved cross-references to include `ramseys-theorem`, `erdos-90`, `erdos-106`, added `mathlibDependencies` for `Filter.atTop` and `Nat.choose`
- Build passes (2 non-strict axiom type warnings, expected for axiomatized results with no `axiom` annotation type)

## Test plan
- [x] `pnpm annotations:build` passes for erdos-107 (2 non-strict warnings only)
- [ ] Visual review of annotations in gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)