### PR TITLE
enrich erdos-1091: fix types, add leanFile/crossReferences

### DIFF
--- a/src/data/proofs/erdos-1091/annotations.json
+++ b/src/data/proofs/erdos-1091/annotations.json
@@ -2,29 +2,23 @@
   {
     "id": "ann-1091-header",
     "proofId": "erdos-1091",
-    "range": { "startLine": 1, "endLine": 31 },
-    "type": "context",
+    "range": { "startLine": 20, "endLine": 25 },
+    "type": "concept",
     "title": "Problem Overview and Setup",
     "content": "**Erdos Problem #1091**: Must a $K_4$-free graph with $\\chi(G) = 4$ contain an odd cycle with at least two diagonals? The first question is **SOLVED** (Voss 1982). The general $f(r)$ question remains **OPEN**. The formalization imports Mathlib's SimpleGraph, Coloring, and Clique infrastructure, working with finite types with decidable equality.",
-    "mathContext": {
-      "latex": "K_4\\text{-free}, \\quad \\chi(G) \\geq 4 \\;\\Rightarrow\\; \\exists\\, C \\text{ odd cycle with } \\geq 2 \\text{ diagonals}",
-      "description": "A K4-free graph has no complete subgraph on 4 vertices. Despite this clique restriction, the chromatic number can still be 4 or higher (by Mycielski's construction). The problem asks about structural consequences for odd cycles."
-    },
-    "significance": "context",
+    "mathContext": "$K_4$-free, $\\chi(G) \\geq 4 \\Rightarrow \\exists\\, C$ odd cycle with $\\geq 2$ diagonals. A $K_4$-free graph has no complete subgraph on 4 vertices. Despite this clique restriction, the chromatic number can still be 4 or higher (by Mycielski's construction).",
+    "significance": "supporting",
     "relatedConcepts": ["K4-free", "chromatic-number", "odd-cycles", "graph-diagonals"],
     "prerequisites": ["graph-theory-basics", "coloring"]
   },
   {
     "id": "ann-1091-cycle",
     "proofId": "erdos-1091",
-    "range": { "startLine": 33, "endLine": 44 },
+    "range": { "startLine": 34, "endLine": 44 },
     "type": "definition",
     "title": "Cycle and Odd Cycle",
     "content": "A **cycle** in a graph $G$ is a list of $\\geq 3$ distinct vertices where consecutive vertices are adjacent, plus a closing edge from last to first. The `Cycle.isOdd` predicate checks if the length is odd. This formalization captures cycles as ordered vertex lists rather than using Mathlib's Walk type, allowing direct index-based reasoning about diagonals.",
-    "mathContext": {
-      "latex": "C = (v_0, v_1, \\ldots, v_{k-1}), \\quad v_i \\sim v_{i+1}, \\quad v_{k-1} \\sim v_0, \\quad k \\geq 3",
-      "description": "The Cycle structure stores vertices as a List V with explicit adjacency proofs for consecutive pairs and the closing edge. Nodup ensures distinctness. Odd cycles have odd length (important for graph coloring theory)."
-    },
+    "mathContext": "$C = (v_0, v_1, \\ldots, v_{k-1})$ with $v_i \\sim v_{i+1}$, $v_{k-1} \\sim v_0$, $k \\geq 3$. The Cycle structure stores vertices as a List $V$ with explicit adjacency proofs for consecutive pairs and the closing edge. Nodup ensures distinctness. Odd cycles have odd length (important for graph coloring theory).",
     "significance": "key",
     "relatedConcepts": ["graph-cycle", "odd-cycle", "list-representation"],
     "prerequisites": ["simple-graph", "list-operations"]
@@ -32,14 +26,11 @@
   {
     "id": "ann-1091-diagonal",
     "proofId": "erdos-1091",
-    "range": { "startLine": 46, "endLine": 60 },
+    "range": { "startLine": 47, "endLine": 60 },
     "type": "definition",
     "title": "Cycle Diagonals and Count",
     "content": "A **diagonal** of a cycle $C$ is an edge $uv$ where $u, v \\in C$ are non-consecutive in the cyclic order but adjacent in $G$. The `diagonalCount` counts unordered pairs $\\{u, v\\}$ with $u < v$ to avoid double-counting. Diagonals create 'shortcuts' across the cycle, and their existence constrains the graph's structure -- K4-free graphs with high $\\chi$ must have such shortcuts in their odd cycles.",
-    "mathContext": {
-      "latex": "\\text{isDiagonal}(u, v) \\;:\\Leftrightarrow\\; u, v \\in C \\;\\wedge\\; u \\not\\sim_{\\text{cyc}} v \\;\\wedge\\; u \\sim_G v",
-      "description": "Non-consecutiveness is checked modularly: (i+1) mod |C| != j and (j+1) mod |C| != i. The diagonal count uses Finset.filter on V x V with the ordering constraint u < v."
-    },
+    "mathContext": "$\\text{isDiagonal}(u, v) \\Leftrightarrow u, v \\in C \\wedge u \\not\\sim_{\\text{cyc}} v \\wedge u \\sim_G v$. Non-consecutiveness is checked modularly: $(i+1) \\bmod |C| \\neq j$ and $(j+1) \\bmod |C| \\neq i$. The diagonal count uses Finset.filter on $V \\times V$ with the ordering constraint $u < v$.",
     "significance": "critical",
     "relatedConcepts": ["chord", "cycle-diagonal", "shortcut-edge"],
     "prerequisites": ["cycle-definition", "modular-arithmetic"]
@@ -47,14 +38,11 @@
   {
     "id": "ann-1091-k4free",
     "proofId": "erdos-1091",
-    "range": { "startLine": 62, "endLine": 68 },
+    "range": { "startLine": 63, "endLine": 68 },
     "type": "definition",
     "title": "K4-Free and Chromatic Number",
     "content": "**IsK4Free**: $G$ contains no clique of size 4: $\\neg \\exists\\, S \\subseteq V,\\, |S| = 4 \\wedge G.\\text{IsClique}(S)$. **chromaticNumber**: the minimum $k$ such that $G$ has a proper $k$-coloring, defined via $\\text{sSup}$ of valid coloring sizes. K4-free graphs can still require arbitrarily many colors (Mycielski's theorem), making the interaction between clique-freeness and chromatic number subtle.",
-    "mathContext": {
-      "latex": "\\text{IsK4Free}(G) \\;:\\Leftrightarrow\\; \\omega(G) \\leq 3, \\qquad \\chi(G) = \\min\\{k : G \\text{ is } k\\text{-colorable}\\}",
-      "description": "Uses Mathlib's SimpleGraph.IsClique for the clique condition and SimpleGraph.Coloring for proper colorings. The chromatic number definition uses sSup, which may differ from the standard infimum convention."
-    },
+    "mathContext": "$\\text{IsK4Free}(G) \\Leftrightarrow \\omega(G) \\leq 3$, $\\chi(G) = \\min\\{k : G \\text{ is } k\\text{-colorable}\\}$. Uses Mathlib's SimpleGraph.IsClique for the clique condition and SimpleGraph.Coloring for proper colorings.",
     "significance": "critical",
     "relatedConcepts": ["clique-number", "chromatic-number", "clique-free"],
     "prerequisites": ["simple-graph", "graph-coloring", "clique"]
@@ -62,14 +50,11 @@
   {
     "id": "ann-1091-larson",
     "proofId": "erdos-1091",
-    "range": { "startLine": 70, "endLine": 94 },
-    "type": "axiom",
+    "range": { "startLine": 76, "endLine": 94 },
+    "type": "theorem",
     "title": "Larson's Theorem and Bollobas-Erdos (1979)",
     "content": "**Larson (1979)**: Every $K_4$-free graph with $\\chi(G) \\geq 4$ contains an odd cycle with at least **one** diagonal. This was the first major result.\n\n**Bollobas-Erdos Conjecture** (proved by Larson): If $G$ is $K_4$-free with no odd cycle having a diagonal, then $G$ is bipartite, has a cut vertex, or has a vertex of degree $\\leq 2$. The three alternatives are captured by the `BollobasErdosAlternative` structure.",
-    "mathContext": {
-      "latex": "K_4\\text{-free} \\;\\wedge\\; \\chi \\geq 4 \\;\\Rightarrow\\; \\exists\\, C \\text{ odd, } \\text{diag}(C) \\geq 1",
-      "description": "Both axiomatized. Larson's theorem is subsumed by Voss's stronger result. The Bollobas-Erdos alternatives show that the absence of odd-cycle diagonals forces extreme structural restrictions on K4-free graphs."
-    },
+    "mathContext": "$K_4$-free $\\wedge\\; \\chi \\geq 4 \\Rightarrow \\exists\\, C$ odd, $\\text{diag}(C) \\geq 1$. Both axiomatized. Larson's theorem is subsumed by Voss's stronger result. The Bollobas-Erdos alternatives show that the absence of odd-cycle diagonals forces extreme structural restrictions on $K_4$-free graphs.",
     "significance": "key",
     "relatedConcepts": ["structural-theorem", "bipartite", "cut-vertex"],
     "prerequisites": ["K4-free", "chromatic-number", "cycle-diagonal"]
@@ -77,14 +62,11 @@
   {
     "id": "ann-1091-voss",
     "proofId": "erdos-1091",
-    "range": { "startLine": 96, "endLine": 111 },
-    "type": "axiom",
+    "range": { "startLine": 102, "endLine": 111 },
+    "type": "theorem",
     "title": "Voss's Theorem (1982): Two Diagonals",
     "content": "**Voss (1982)**: Every $K_4$-free graph with $\\chi(G) \\geq 4$ contains an odd cycle with at least **two** diagonals. This significant strengthening of Larson's result answers the first question of Erdos #1091 affirmatively. The corollary `voss_implies_larson` is fully verified: $\\geq 2$ implies $\\geq 1$ via `Nat.le_of_succ_le`.",
-    "mathContext": {
-      "latex": "K_4\\text{-free} \\;\\wedge\\; \\chi \\geq 4 \\;\\Rightarrow\\; \\exists\\, C \\text{ odd, } \\text{diag}(C) \\geq 2",
-      "description": "Axiomatized. The proof uses deep structural analysis of K4-free graphs with high chromatic number, showing that odd cycles in such graphs must have rich diagonal structure."
-    },
+    "mathContext": "$K_4$-free $\\wedge\\; \\chi \\geq 4 \\Rightarrow \\exists\\, C$ odd, $\\text{diag}(C) \\geq 2$. Axiomatized. The corollary `voss_implies_larson` is proved by extracting the cycle from Voss's result and weakening the diagonal bound.",
     "significance": "critical",
     "relatedConcepts": ["strengthening", "diagonal-count", "solved"],
     "prerequisites": ["K4-free", "chromatic-number"]
@@ -92,14 +74,11 @@
   {
     "id": "ann-1091-wheel",
     "proofId": "erdos-1091",
-    "range": { "startLine": 113, "endLine": 157 },
-    "type": "theorem",
+    "range": { "startLine": 118, "endLine": 157 },
+    "type": "definition",
     "title": "Pentagonal Wheel: Extremal Counterexample",
     "content": "The **pentagonal wheel** $W_5$: vertices $\\{0,1,2,3,4\\}$ form a 5-cycle, vertex 5 is the center connected to all outer vertices. Properties (axiomatized): $W_5$ is $K_4$-free, $\\chi(W_5) = 4$, and every odd cycle has $\\leq 2$ diagonals. The **three_diagonals_not_guaranteed** theorem is fully verified: it assumes the universal $\\geq 3$ statement, instantiates it with $W_5$, and derives a contradiction via `omega` from the max-2-diagonals axiom. This shows Voss's bound is tight.",
-    "mathContext": {
-      "latex": "W_5 = C_5 + K_1, \\quad \\omega(W_5) = 3, \\quad \\chi(W_5) = 4, \\quad \\max_{C \\text{ odd}} \\text{diag}(C) = 2",
-      "description": "PentagonalWheel is defined as a SimpleGraph (Fin 6) with explicit adjacency. The symmetry and loop-free properties are proved by case analysis. The extremal property (max 2 diagonals in odd cycles) makes it the tight counterexample for the 3-diagonal question."
-    },
+    "mathContext": "$W_5 = C_5 + K_1$, $\\omega(W_5) = 3$, $\\chi(W_5) = 4$, $\\max_{C \\text{ odd}} \\text{diag}(C) = 2$. PentagonalWheel is defined as a SimpleGraph (Fin 6) with explicit adjacency. The symmetry and loop-free properties are proved by case analysis.",
     "significance": "critical",
     "relatedConcepts": ["wheel-graph", "extremal-example", "tight-bound"],
     "prerequisites": ["cycle-diagonal", "K4-free", "chromatic-number"]
@@ -107,14 +86,11 @@
   {
     "id": "ann-1091-general",
     "proofId": "erdos-1091",
-    "range": { "startLine": 159, "endLine": 175 },
+    "range": { "startLine": 165, "endLine": 175 },
     "type": "definition",
     "title": "General Question (OPEN)",
     "content": "The **OPEN** general question: Does there exist $f(r) \\to \\infty$ such that every graph with $\\chi \\geq 4$ that is locally 3-colorable (every subgraph on $\\leq r$ vertices has $\\chi \\leq 3$) contains an odd cycle with $\\geq f(r)$ diagonals? **IsLocallyColorable** captures the local coloring condition using induced subgraphs. **GeneralQuestion** is defined as a Prop without asserting truth.",
-    "mathContext": {
-      "latex": "\\exists\\, f : \\mathbb{N} \\to \\mathbb{N},\\; f(r) \\to \\infty \\;\\wedge\\; \\forall\\, G,\\; \\chi(G) \\geq 4 \\;\\wedge\\; \\text{loc-3-col}(G, r) \\;\\Rightarrow\\; \\exists\\, C \\text{ odd, } \\text{diag}(C) \\geq f(r)",
-      "description": "IsLocallyColorable uses SimpleGraph.induce to restrict to subgraphs. The divergence condition f(r) -> infinity is formalized as: for all N, exists r such that f(r') >= N for all r' >= r."
-    },
+    "mathContext": "$\\exists\\, f : \\mathbb{N} \\to \\mathbb{N}$, $f(r) \\to \\infty$ $\\wedge$ $\\forall\\, G$, $\\chi(G) \\geq 4$ $\\wedge$ loc-3-col$(G, r)$ $\\Rightarrow$ $\\exists\\, C$ odd, $\\text{diag}(C) \\geq f(r)$. IsLocallyColorable uses SimpleGraph.induce to restrict to subgraphs. The divergence condition is formalized as: for all $N$, exists $r$ such that $f(r') \\geq N$ for all $r' \\geq r$.",
     "significance": "critical",
     "relatedConcepts": ["local-coloring", "divergent-function", "open-problem"],
     "prerequisites": ["chromatic-number", "induced-subgraph"]
@@ -122,14 +98,11 @@
   {
     "id": "ann-1091-related",
     "proofId": "erdos-1091",
-    "range": { "startLine": 177, "endLine": 209 },
+    "range": { "startLine": 180, "endLine": 207 },
     "type": "theorem",
     "title": "Related Results and Summary",
     "content": "**K4_free_high_chi_possible** (verified): The pentagonal wheel witnesses that $K_4$-free graphs can have $\\chi \\geq 4$.\n\n**mycielski_construction** (axiomatized): Triangle-free ($K_3$-free) graphs can have arbitrarily high $\\chi$, contextualizing why $K_4$-free high-$\\chi$ graphs exist.\n\n**erdos_1091_summary** (verified): Combines Voss ($\\geq 2$ guaranteed) with the pentagonal wheel counterexample ($\\geq 3$ not guaranteed), giving a complete answer to the specific question.",
-    "mathContext": {
-      "latex": "\\forall\\, k,\\; \\exists\\, G \\text{ triangle-free with } \\chi(G) \\geq k \\quad \\text{(Mycielski)}",
-      "description": "K4_free_high_chi_possible is proved by instantiation with PentagonalWheel. The Mycielski construction is a classical result in graph theory. The summary theorem combines both directions into a single statement."
-    },
+    "mathContext": "$\\forall\\, k$, $\\exists\\, G$ triangle-free with $\\chi(G) \\geq k$ (Mycielski). K4_free_high_chi_possible is proved by instantiation with PentagonalWheel. The summary theorem combines both directions into a single statement.",
     "significance": "key",
     "relatedConcepts": ["mycielski-graph", "summary-theorem", "existence-witness"],
     "prerequisites": ["pentagonal-wheel", "voss-theorem"]

--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -39,9 +39,9 @@
         "module": "Mathlib.Combinatorics.SimpleGraph.Clique"
       },
       {
-        "theorem": "SimpleGraph.induce",
-        "description": "Induced subgraphs for local colorability",
-        "module": "Mathlib.Combinatorics.SimpleGraph.Subgraph"
+        "theorem": "Finset.filter",
+        "description": "Finite set filtering for diagonal counting",
+        "module": "Mathlib.Data.Finset.Basic"
       }
     ],
     "originalContributions": [
@@ -58,6 +58,19 @@
       "K4_free_high_chi_possible: verified existence witness",
       "erdos_1091_summary: verified combined result"
     ],
+    "leanFile": {
+      "lineCount": 209,
+      "structureCount": 2,
+      "axiomCount": 7,
+      "theoremCount": 4,
+      "defCount": 8,
+      "imports": [
+        "Mathlib.Combinatorics.SimpleGraph.Basic",
+        "Mathlib.Combinatorics.SimpleGraph.Coloring",
+        "Mathlib.Combinatorics.SimpleGraph.Clique",
+        "Mathlib.Data.Finset.Basic"
+      ]
+    },
     "dateAdded": "2026-01-26"
   },
   "overview": {
@@ -65,12 +78,12 @@
     "problemStatement": "**Problem**: Let $G$ be a $K_4$-free graph with chromatic number 4. Must $G$ contain an odd cycle with at least two diagonals?\n\n**Answer**: YES (Voss 1982)\n\n**More General Question** (OPEN): Is there some $f(r) \\to \\infty$ such that every graph with $\\chi(G) \\geq 4$, in which every subgraph on $\\leq r$ vertices has $\\chi \\leq 3$, contains an odd cycle with at least $f(r)$ diagonals?",
     "proofStrategy": "The formalization defines cycles as vertex lists with adjacency proofs, diagonals as non-consecutive edges, and the standard graph predicates (K4-free, chromatic number). Larson's and Voss's theorems are axiomatized. The pentagonal wheel is explicitly constructed as SimpleGraph (Fin 6) with verified symmetry and loop-freeness, and the impossibility of 3 diagonals is fully proved by contradiction. The general f(r) question is formalized using induced subgraphs for local colorability but left open.",
     "keyInsights": [
-      "K4-free does not mean low chromatic number: the pentagonal wheel is K4-free but has chi = 4, and Mycielski's construction gives triangle-free graphs with arbitrarily high chi",
-      "Progressive strengthening: 0 diagonals (trivial) -> 1 diagonal (Larson 1979) -> 2 diagonals (Voss 1982) -> not 3 diagonals (pentagonal wheel counterexample)",
-      "The Bollobas-Erdos structure theorem shows that absence of odd cycles with diagonals in K4-free graphs forces extreme restrictions: bipartiteness, cut vertices, or low degree",
-      "The pentagonal wheel W5 = C5 + K1 is the extremal example achieving exactly 2 diagonals in every odd cycle, making Voss's bound tight",
-      "The general f(r) question explores the frontier between local and global colorability: how does the local structure (small subgraphs 3-colorable) constrain global cycle structure?",
-      "Three verified theorems (voss_implies_larson, three_diagonals_not_guaranteed, erdos_1091_summary) demonstrate non-trivial mathematical reasoning in Lean"
+      "**K4-free does not mean low chromatic number**: the pentagonal wheel is K4-free but has $\\chi = 4$, and Mycielski's construction gives triangle-free graphs with arbitrarily high $\\chi$",
+      "**Progressive strengthening**: 0 diagonals (trivial) $\\to$ 1 diagonal (Larson 1979) $\\to$ 2 diagonals (Voss 1982) $\\to$ not 3 diagonals (pentagonal wheel counterexample)",
+      "**The Bollobas-Erdos structure theorem** shows that absence of odd cycles with diagonals in K4-free graphs forces extreme restrictions: bipartiteness, cut vertices, or low degree",
+      "**The pentagonal wheel** $W_5 = C_5 + K_1$ is the extremal example achieving exactly 2 diagonals in every odd cycle, making Voss's bound tight",
+      "**The general $f(r)$ question** explores the frontier between local and global colorability: how does the local structure (small subgraphs 3-colorable) constrain global cycle structure?",
+      "**Three verified theorems** (voss_implies_larson, three_diagonals_not_guaranteed, erdos_1091_summary) demonstrate non-trivial mathematical reasoning in Lean"
     ]
   },
   "sections": [
@@ -79,60 +92,60 @@
       "title": "Module Docstring",
       "startLine": 1,
       "endLine": 18,
-      "summary": "Problem statement, answer (YES for 2 diagonals), history (Larson 1979, Voss 1982), and general open question about f(r)."
+      "summary": "Problem statement, answer (YES for 2 diagonals), history (Larson 1979, Voss 1982), and general open question about $f(r)$."
     },
     {
       "id": "basic-definitions",
       "title": "Part 1: Basic Definitions",
       "startLine": 27,
       "endLine": 68,
-      "summary": "Cycle structure (vertex list with adjacency), isOdd, isDiagonal (non-consecutive edge), diagonalCount (unordered pairs), IsK4Free (no 4-clique), chromaticNumber (min colors)."
+      "summary": "Cycle structure (vertex list with adjacency), isOdd, isDiagonal (non-consecutive edge), diagonalCount (unordered pairs via Finset.filter), IsK4Free (no 4-clique), chromaticNumber (min colors via sSup)."
     },
     {
       "id": "larson-theorem",
       "title": "Part 2: Larson's Theorem (1979)",
       "startLine": 70,
       "endLine": 94,
-      "summary": "larson_one_diagonal (axiom): K4-free, chi >= 4 implies odd cycle with >= 1 diagonal. BollobasErdosAlternative structure and bollobas_erdos_conjecture (axiom)."
+      "summary": "`larson_one_diagonal` (axiom): $K_4$-free, $\\chi \\geq 4$ implies odd cycle with $\\geq 1$ diagonal. `BollobasErdosAlternative` structure and `bollobas_erdos_conjecture` (axiom)."
     },
     {
       "id": "voss-theorem",
       "title": "Part 3: Voss's Theorem (1982)",
       "startLine": 96,
       "endLine": 111,
-      "summary": "voss_two_diagonals (axiom): K4-free, chi >= 4 implies odd cycle with >= 2 diagonals. voss_implies_larson (verified corollary)."
+      "summary": "`voss_two_diagonals` (axiom): $K_4$-free, $\\chi \\geq 4$ implies odd cycle with $\\geq 2$ diagonals. `voss_implies_larson` (verified corollary via `Nat.le_of_succ_le`)."
     },
     {
       "id": "counterexample",
       "title": "Part 4: Pentagonal Wheel Counterexample",
       "startLine": 113,
       "endLine": 157,
-      "summary": "PentagonalWheel definition as SimpleGraph (Fin 6) with proved symmetry/loop-freeness. Axioms for K4-free, chi=4, max 2 diagonals. Verified three_diagonals_not_guaranteed by contradiction."
+      "summary": "PentagonalWheel definition as SimpleGraph (Fin 6) with proved symmetry/loop-freeness. Axioms for $K_4$-free, $\\chi=4$, max 2 diagonals. Verified `three_diagonals_not_guaranteed` by contradiction with `omega`."
     },
     {
       "id": "general-question",
       "title": "Part 5: General Question (OPEN)",
       "startLine": 159,
       "endLine": 175,
-      "summary": "IsLocallyColorable (induced subgraph coloring) and GeneralQuestion (existence of f(r) -> infinity). The main unsolved part of Problem #1091."
+      "summary": "IsLocallyColorable (induced subgraph coloring) and GeneralQuestion (existence of $f(r) \\to \\infty$). The main unsolved part of Problem #1091."
     },
     {
       "id": "related-results",
       "title": "Part 6: Related Results",
       "startLine": 177,
       "endLine": 189,
-      "summary": "K4_free_high_chi_possible (verified via PentagonalWheel), mycielski_construction (axiom: triangle-free graphs with arbitrary chi)."
+      "summary": "`K4_free_high_chi_possible` (verified via PentagonalWheel), `mycielski_construction` (axiom: triangle-free graphs with arbitrary $\\chi$)."
     },
     {
       "id": "summary",
       "title": "Part 7: Summary",
       "startLine": 191,
       "endLine": 209,
-      "summary": "erdos_1091_summary (verified): combines Voss (>= 2 guaranteed) and pentagonal wheel (>= 3 not guaranteed) into a single theorem."
+      "summary": "`erdos_1091_summary` (verified): combines Voss ($\\geq 2$ guaranteed) and pentagonal wheel ($\\geq 3$ not guaranteed) into a single theorem."
     }
   ],
   "conclusion": {
-    "summary": "Erdos Problem #1091 is partially solved. The specific question (two diagonals in K4-free chi=4 graphs) was answered YES by Voss (1982), building on Larson (1979). The pentagonal wheel shows that three diagonals cannot be guaranteed, making Voss's bound tight. The general f(r) question remains OPEN. The formalization includes 3 fully verified theorems and the extremal pentagonal wheel construction.",
+    "summary": "Erdos Problem #1091 is partially solved. The specific question (two diagonals in K4-free chi=4 graphs) was answered YES by Voss (1982), building on Larson (1979). The pentagonal wheel shows that three diagonals cannot be guaranteed, making Voss's bound tight. The general f(r) question remains OPEN. The formalization includes 4 fully verified theorems and the extremal pentagonal wheel construction.",
     "implications": "The problem reveals deep connections between clique-freeness, chromatic number, and cycle structure in graphs. The pentagonal wheel serves as an extremal example showing the tightness of Voss's bound. The open general question connects local colorability to global cycle structure, a frontier area in structural graph theory.",
     "openQuestions": [
       "Is there f(r) -> infinity for the general locally 3-colorable case?",
@@ -143,15 +156,15 @@
   },
   "crossReferences": [
     {
-      "proofId": "erdos-984",
+      "targetProofId": "erdos-984",
       "relationship": "Both are Erdos problems in combinatorics involving structural constraints on graphs/sets with extremal colorings or partitions"
     },
     {
-      "proofId": "erdos-723",
+      "targetProofId": "erdos-723",
       "relationship": "Both involve combinatorial structures (graphs/projective planes) where counting arguments and explicit constructions determine extremal behavior"
     },
     {
-      "proofId": "erdos-107",
+      "targetProofId": "erdos-107",
       "relationship": "Both are Erdos problems with a clear progression of bounds (trivial -> intermediate -> tight), with explicit extremal constructions showing tightness"
     }
   ]


### PR DESCRIPTION
## Summary
- Fixed `annotations.json`: invalid types (`context`→`concept`, `axiom`→`theorem`), invalid significance (`context`→`supporting`), converted `mathContext` from object to string format, adjusted startLine values to point at correct Lean constructs
- Enriched `meta.json`: added `leanFile` field (209 lines, 2 structures, 7 axioms, 4 theorems, 8 defs), fixed `crossReferences` keys (`proofId`→`targetProofId`), updated `mathlibDependencies` to match actual imports, added LaTeX to section summaries
- Build passes (2 non-strict axiom type warnings, expected for axiomatized results)

## Test plan
- [x] `pnpm annotations:build` passes for erdos-1091 (2 non-strict warnings only)
- [ ] Visual review of annotations in gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)