### PR TITLE
enrich(erdos-370): add leanFile, fix annotation types, normalize mathContext

### DIFF
--- a/src/data/proofs/erdos-370/annotations.json
+++ b/src/data/proofs/erdos-370/annotations.json
@@ -2,145 +2,97 @@
   {
     "id": "ann-e370-aristotle",
     "proofId": "erdos-370",
-    "range": {
-      "startLine": 1,
-      "endLine": 10
-    },
-    "type": "attribution",
+    "range": {"startLine": 1, "endLine": 10},
+    "type": "concept",
     "title": "Aristotle Attribution",
-    "content": "This proof was processed by Aristotle (Harmonic) proof search. Aristotle successfully proved 4 theorems automatically: `steinerberger_succ` (the key identity n+1 = m^2), `n63_sqrt_smooth` and `n64_sqrt_smooth` (the worked example), and `example_63` (combining both). Several other declarations failed to load due to Aristotle parser limitations (namespace issues).",
-    "mathContext": {
-      "latex": "\\text{Aristotle proved: } n = m^2 - 1 \\Rightarrow n+1 = m^2, \\quad \\text{gpf}(63) = 7 < \\sqrt{63}, \\quad \\text{gpf}(64) = 2 < \\sqrt{64}",
-      "description": "Aristotle's proofs use norm_num for arithmetic and Real.sqrt_lt_sqrt for the square root comparisons. The steinerberger_succ proof uses nlinarith and omega."
-    },
+    "content": "This proof was processed by the Aristotle (Harmonic) proof search system. Aristotle successfully proved 4 theorems automatically: `steinerberger_succ` (the key identity $n+1 = m^2$), `n63_sqrt_smooth` and `n64_sqrt_smooth` (the worked example), and `example_63` (combining both). Several other declarations failed to load due to Aristotle parser limitations (namespace issues).",
+    "mathContext": "Aristotle proved: $n = m^2 - 1 \\Rightarrow n+1 = m^2$, $\\operatorname{gpf}(63) = 7 < \\sqrt{63}$, $\\operatorname{gpf}(64) = 2 < \\sqrt{64}$, using `norm_num`, `nlinarith`, `omega`, and `Real.sqrt_lt_sqrt`.",
     "significance": "supporting",
-    "relatedConcepts": ["proof-search", "automated-verification"],
-    "prerequisites": []
+    "relatedConcepts": ["proof search", "automated verification", "Aristotle Harmonic"],
+    "prerequisites": ["Lean 4 tactic mode", "norm_num", "nlinarith"]
   },
   {
     "id": "ann-e370-header",
     "proofId": "erdos-370",
-    "range": {
-      "startLine": 12,
-      "endLine": 48
-    },
-    "type": "context",
-    "title": "Problem Overview and Setup",
-    "content": "**Erdos Problem #370** asks whether infinitely many $n$ exist such that both $n$ and $n+1$ have their largest prime factor less than their square root. These are called *consecutive sqrt-smooth numbers*. Steinerberger found an elegant construction: take $n = m^2 - 1 = (m-1)(m+1)$, then $n+1 = m^2$ has small gpf when $m$ is a prime power (especially a power of 2). The formalization imports full Mathlib and opens Nat, Finset, BigOperators.",
-    "mathContext": {
-      "latex": "\\text{gpf}(n) < \\sqrt{n} \\;\\wedge\\; \\text{gpf}(n+1) < \\sqrt{n+1}",
-      "description": "A number n is sqrt-smooth if its greatest prime factor is less than sqrt(n). The problem asks for infinitely many n where both n and n+1 are sqrt-smooth."
-    },
-    "significance": "context",
-    "relatedConcepts": ["smooth-numbers", "greatest-prime-factor", "consecutive-integers"],
-    "prerequisites": ["prime-factorization", "square-root"]
+    "range": {"startLine": 40, "endLine": 48},
+    "type": "concept",
+    "title": "Imports and Namespace Setup",
+    "content": "Imports the full Mathlib library and opens the `Nat`, `Finset`, and `BigOperators` namespaces. The full Mathlib import provides access to `Real.sqrt`, `Set.Infinite`, and arithmetic function infrastructure needed for the formalization.",
+    "mathContext": "Opens `Nat` for natural number operations, `Finset` for finite sets, and `BigOperators` for $\\prod$ notation used in the formalization.",
+    "significance": "supporting",
+    "relatedConcepts": ["Mathlib imports", "namespace management"],
+    "prerequisites": ["Lean 4 import system"]
   },
   {
     "id": "ann-e370-gpf",
     "proofId": "erdos-370",
-    "range": {
-      "startLine": 50,
-      "endLine": 73
-    },
-    "type": "axiom",
+    "range": {"startLine": 50, "endLine": 73},
+    "type": "definition",
     "title": "Greatest Prime Factor: Axiomatization",
-    "content": "The **greatest prime factor** $\\operatorname{gpf}(n)$ is axiomatized with 6 properties: (1) $\\operatorname{gpf}(n) = 0$ for $n \\leq 1$, (2) $\\operatorname{gpf}(n) \\mid n$ for $n > 1$, (3) $\\operatorname{gpf}(n)$ is prime for $n > 1$, (4) $\\operatorname{gpf}(p) = p$ for primes, (5) $\\operatorname{gpf}(p^k) = p$ for prime powers, (6) $\\operatorname{gpf}(mn) \\leq \\max(\\operatorname{gpf}(m), \\operatorname{gpf}(n))$. This axiomatization captures the essential behavior while sidestepping Mathlib's primeFactors API variations.",
-    "mathContext": {
-      "latex": "\\operatorname{gpf}(n) = \\max\\{\\, p \\;|\\; p \\text{ prime}, \\; p \\mid n \\,\\}, \\quad \\operatorname{gpf}(n) = 0 \\text{ for } n \\leq 1",
-      "description": "Axiomatized as a function gpf : N -> N with 6 axioms. The product bound gpf(mn) <= max(gpf(m), gpf(n)) is key for the Steinerberger construction where n = (m-1)(m+1)."
-    },
+    "content": "The **greatest prime factor** $\\operatorname{gpf}(n)$ is axiomatized as a function `gpf : N -> N` with 6 properties: (1) $\\operatorname{gpf}(n) = 0$ for $n \\leq 1$, (2) $\\operatorname{gpf}(n) \\mid n$ for $n > 1$, (3) $\\operatorname{gpf}(n)$ is prime for $n > 1$, (4) $\\operatorname{gpf}(p) = p$ for primes, (5) $\\operatorname{gpf}(p^k) = p$ for prime powers, (6) $\\operatorname{gpf}(mn) \\leq \\max(\\operatorname{gpf}(m), \\operatorname{gpf}(n))$. This axiomatization captures the essential behavior while sidestepping Mathlib's `primeFactors` API variations.",
+    "mathContext": "$\\operatorname{gpf}(n) = \\max\\{p : p \\text{ prime}, p \\mid n\\}$ for $n > 1$; $\\operatorname{gpf}(n) = 0$ for $n \\leq 1$. The product bound $\\operatorname{gpf}(mn) \\leq \\max(\\operatorname{gpf}(m), \\operatorname{gpf}(n))$ is key for the Steinerberger construction.",
     "significance": "critical",
-    "relatedConcepts": ["prime-factorization", "divisibility", "prime-power"],
-    "prerequisites": ["prime-numbers", "natural-number-division"]
+    "relatedConcepts": ["prime factorization", "greatest prime factor", "multiplicative functions", "axiom system"],
+    "prerequisites": ["prime numbers", "divisibility", "Mathlib primeFactors"]
   },
   {
     "id": "ann-e370-smooth",
     "proofId": "erdos-370",
-    "range": {
-      "startLine": 75,
-      "endLine": 90
-    },
+    "range": {"startLine": 75, "endLine": 90},
     "type": "definition",
-    "title": "Smooth Numbers and the Main Predicate",
-    "content": "Three definitions build the problem: (1) **$B$-smooth**: $\\operatorname{gpf}(n) \\leq B$ (all prime factors $\\leq B$), (2) **sqrt-smooth**: $\\operatorname{gpf}(n) < \\sqrt{n}$ (largest prime factor less than square root), (3) **ConsecutiveSqrtSmooth**: both $n$ and $n+1$ are sqrt-smooth. The sqrt comparison uses real-valued casting: `(gpf n : R) < Real.sqrt n`.",
-    "mathContext": {
-      "latex": "\\text{IsSqrtSmooth}(n) \\;:\\Leftrightarrow\\; \\operatorname{gpf}(n) < \\sqrt{n}, \\qquad \\text{ConsecutiveSqrtSmooth}(n) \\;:\\Leftrightarrow\\; \\text{IsSqrtSmooth}(n) \\wedge \\text{IsSqrtSmooth}(n+1)",
-      "description": "IsSqrtSmooth casts gpf n to R and compares with Real.sqrt n. This is a strong smoothness condition -- it means n has a factorization into primes all strictly less than sqrt(n), requiring n to be composite with at least 2 prime factors."
-    },
+    "title": "Smooth Number Predicates",
+    "content": "Three definitions build the problem hierarchy: (1) **$B$-smooth** (`IsSmooth`): $\\operatorname{gpf}(n) \\leq B$, meaning all prime factors are $\\leq B$. (2) **sqrt-smooth** (`IsSqrtSmooth`): $\\operatorname{gpf}(n) < \\sqrt{n}$, using real-valued casting `(gpf n : R) < Real.sqrt n`. (3) **ConsecutiveSqrtSmooth**: both $n$ and $n+1$ are sqrt-smooth. Note that sqrt-smooth implies $n$ is composite with at least two prime factors.",
+    "mathContext": "$\\text{IsSmooth}(B, n) :\\Leftrightarrow \\operatorname{gpf}(n) \\leq B$; $\\text{IsSqrtSmooth}(n) :\\Leftrightarrow \\operatorname{gpf}(n) < \\sqrt{n}$; $\\text{ConsecutiveSqrtSmooth}(n) :\\Leftrightarrow \\text{IsSqrtSmooth}(n) \\wedge \\text{IsSqrtSmooth}(n+1)$.",
     "significance": "key",
-    "relatedConcepts": ["B-smooth-number", "friable-number", "square-root-bound"],
-    "prerequisites": ["gpf-axioms", "real-sqrt"]
+    "relatedConcepts": ["B-smooth number", "friable number", "square root bound", "real casting"],
+    "prerequisites": ["gpf axioms", "Real.sqrt", "natural-to-real casting"]
   },
   {
     "id": "ann-e370-construction",
     "proofId": "erdos-370",
-    "range": {
-      "startLine": 92,
-      "endLine": 109
-    },
+    "range": {"startLine": 92, "endLine": 109},
     "type": "definition",
     "title": "Steinerberger Construction: n = m^2 - 1",
-    "content": "The central construction: $n = m^2 - 1 = (m-1)(m+1)$ (difference of squares). This gives $n + 1 = m^2$, so $\\operatorname{gpf}(n+1) = \\operatorname{gpf}(m)$. If $m$ is a power of 2, then $\\operatorname{gpf}(m^2) = 2 < m = \\sqrt{m^2}$, automatically making $n+1$ sqrt-smooth. For $n$ itself, we need $\\operatorname{gpf}((m-1)(m+1)) < m \\approx \\sqrt{n}$, which requires $m-1$ and $m+1$ to have only small prime factors.\n\nThe factorization identity is axiomatized (since Lean's natural subtraction complicates m^2 - 1 when m < 2). The successor identity `steinerberger_succ` is verified by Aristotle using nlinarith and omega.",
-    "mathContext": {
-      "latex": "n = m^2 - 1 = (m-1)(m+1), \\quad n+1 = m^2, \\quad \\operatorname{gpf}(n+1) = \\operatorname{gpf}(m)",
-      "description": "SteinerbergerConstruction m = m^2 - 1. The factorization axiom and successor theorem together show the structure. ValidSteinerbergerM additionally requires m-1 and m+1 to not be prime."
-    },
+    "content": "The central construction: $n = m^2 - 1 = (m-1)(m+1)$ (difference of squares). This gives $n + 1 = m^2$, so $\\operatorname{gpf}(n+1) = \\operatorname{gpf}(m)$. If $m$ is a power of 2, then $\\operatorname{gpf}(m^2) = 2 < m = \\sqrt{m^2}$, automatically making $n+1$ sqrt-smooth. For $n$ itself, we need $\\operatorname{gpf}((m-1)(m+1)) < m \\approx \\sqrt{n}$, requiring both $m-1$ and $m+1$ to have only small prime factors. The factorization identity is axiomatized since Lean's natural subtraction complicates $m^2 - 1$ when $m < 2$.",
+    "mathContext": "$\\text{SteinerbergerConstruction}(m) = m^2 - 1 = (m-1)(m+1)$, $n + 1 = m^2$, $\\operatorname{gpf}(n+1) = \\operatorname{gpf}(m)$. The `steinerberger_succ` identity is verified by Aristotle using `nlinarith` and `omega`.",
     "significance": "critical",
-    "relatedConcepts": ["difference-of-squares", "factorization", "constructive-proof"],
-    "prerequisites": ["gpf-axioms", "natural-subtraction"]
+    "relatedConcepts": ["difference of squares", "factorization", "constructive proof"],
+    "prerequisites": ["gpf axioms", "natural subtraction", "Lean arithmetic"]
   },
   {
     "id": "ann-e370-example63",
     "proofId": "erdos-370",
-    "range": {
-      "startLine": 111,
-      "endLine": 156
-    },
+    "range": {"startLine": 111, "endLine": 156},
     "type": "theorem",
     "title": "Worked Examples: n=63 and n=224",
-    "content": "Two verified examples of the Steinerberger construction:\n\n**n = 63** ($m = 8 = 2^3$): $63 = 7 \\times 9 = 7 \\times 3^2$, so $\\operatorname{gpf}(63) = 7 < \\sqrt{63} \\approx 7.94$. And $64 = 2^6$, so $\\operatorname{gpf}(64) = 2 < \\sqrt{64} = 8$. Both conditions verified by Aristotle using `Real.sqrt_lt_sqrt`.\n\n**n = 224** ($m = 15$): $224 = 2^5 \\times 7$, $\\operatorname{gpf}(224) = 7 < \\sqrt{224} \\approx 14.97$. And $225 = 15^2 = (3 \\times 5)^2$, $\\operatorname{gpf}(225) = 5 < \\sqrt{225} = 15$.\n\n`ValidSteinerbergerM` additionally requires $m-1$ and $m+1$ to be composite (not prime), ensuring their gpf is strictly less than themselves.",
-    "mathContext": {
-      "latex": "63 = 7 \\cdot 3^2,\\; \\operatorname{gpf}(63) = 7 < 7.94 \\approx \\sqrt{63}; \\quad 64 = 2^6,\\; \\operatorname{gpf}(64) = 2 < 8 = \\sqrt{64}",
-      "description": "The proofs use Real.sqrt_sq and Real.sqrt_lt_sqrt to compare gpf with sqrt. Gpf values are provided by axioms gpf_63 = 7 and gpf_64 = 2. The example_63 theorem combines both sqrt-smooth results."
-    },
+    "content": "Two verified examples of the Steinerberger construction:\n\n**n = 63** ($m = 8 = 2^3$): $63 = 7 \\times 3^2$, so $\\operatorname{gpf}(63) = 7 < \\sqrt{63} \\approx 7.94$. And $64 = 2^6$, so $\\operatorname{gpf}(64) = 2 < \\sqrt{64} = 8$. Both conditions verified by Aristotle using `Real.sqrt_lt_sqrt`.\n\n**n = 224** ($m = 15$): $224 = 2^5 \\times 7$, $\\operatorname{gpf}(224) = 7 < \\sqrt{224} \\approx 14.97$. And $225 = 15^2 = (3 \\times 5)^2$, $\\operatorname{gpf}(225) = 5 < 15$.\n\n`ValidSteinerbergerM` additionally requires $m-1$ and $m+1$ to be composite.",
+    "mathContext": "$\\operatorname{gpf}(63) = 7 < 7.94 \\approx \\sqrt{63}$; $\\operatorname{gpf}(64) = 2 < 8 = \\sqrt{64}$. Proved using `Real.sqrt_sq` and `Real.sqrt_lt_sqrt` with gpf values from axioms `gpf_63 = 7` and `gpf_64 = 2`.",
     "significance": "supporting",
-    "relatedConcepts": ["concrete-verification", "norm-num", "sqrt-comparison"],
-    "prerequisites": ["gpf-63-axiom", "gpf-64-axiom", "real-sqrt"]
+    "relatedConcepts": ["concrete verification", "norm_num", "sqrt comparison", "Aristotle proof"],
+    "prerequisites": ["gpf_63 axiom", "gpf_64 axiom", "Real.sqrt_lt_sqrt"]
   },
   {
     "id": "ann-e370-main",
     "proofId": "erdos-370",
-    "range": {
-      "startLine": 158,
-      "endLine": 201
-    },
+    "range": {"startLine": 158, "endLine": 201},
     "type": "theorem",
-    "title": "Main Theorem: Infinitely Many Solutions",
-    "content": "**erdos_370_infinitely_many**: The set $\\{n : \\text{ConsecutiveSqrtSmooth}(n)\\}$ is infinite. **erdos_370**: There exists an injective function $f : \\mathbb{N} \\to \\mathbb{N}$ with $\\text{ConsecutiveSqrtSmooth}(f(k))$ for all $k$. Both statements are sorry'd -- the proof requires showing infinitely many valid $m$ exist (e.g., $m = 2^k$ for sufficiently large $k$, where both $2^k - 1$ and $2^k + 1$ have small prime factors). Aristotle failed to load these due to namespace issues.",
-    "mathContext": {
-      "latex": "\\bigl|\\{\\, n \\in \\mathbb{N} \\;\\big|\\; \\operatorname{gpf}(n) < \\sqrt{n} \\;\\wedge\\; \\operatorname{gpf}(n+1) < \\sqrt{n+1} \\,\\}\\bigr| = \\infty",
-      "description": "Two formulations: Set.Infinite and injective-function encoding. The sorry'd proofs would use the Steinerberger construction with infinitely many valid m values."
-    },
+    "title": "Main Theorem: Infinitely Many Solutions (sorry'd)",
+    "content": "**erdos_370_infinitely_many**: The set $\\{n : \\text{ConsecutiveSqrtSmooth}(n)\\}$ is infinite. **erdos_370**: There exists an injective function $f : \\mathbb{N} \\to \\mathbb{N}$ with $\\text{ConsecutiveSqrtSmooth}(f(k))$ for all $k$. Both statements are **sorry'd** --- the proof would require showing infinitely many valid $m$ exist (e.g., $m = 2^k$ for suitable $k$, where both $2^k - 1$ and $2^k + 1$ have small prime factors). Aristotle failed to load these due to namespace issues.",
+    "mathContext": "$|\\{n \\in \\mathbb{N} : \\operatorname{gpf}(n) < \\sqrt{n} \\wedge \\operatorname{gpf}(n+1) < \\sqrt{n+1}\\}| = \\infty$. Two formulations: `Set.Infinite` and injective function encoding.",
     "significance": "critical",
-    "relatedConcepts": ["set-infinite", "injective-function", "infinitude"],
-    "prerequisites": ["consecutive-sqrt-smooth", "steinerberger-construction"]
+    "relatedConcepts": ["Set.Infinite", "injective function", "infinitude", "sorry"],
+    "prerequisites": ["ConsecutiveSqrtSmooth", "Steinerberger construction", "infinitely many valid m"]
   },
   {
     "id": "ann-e370-pomerance",
     "proofId": "erdos-370",
-    "range": {
-      "startLine": 203,
-      "endLine": 248
-    },
+    "range": {"startLine": 203, "endLine": 255},
     "type": "concept",
     "title": "Pomerance's Density Perspective",
-    "content": "**Pomerance's observation**: Replacing the exponent $1/2$ with $1/\\sqrt{e} - \\varepsilon \\approx 0.6065 - \\varepsilon$ makes the statement true by a density argument. The **Dickman-de Bruijn function** $\\rho(u)$ gives the density of $u$-smooth numbers (those with $\\operatorname{gpf}(n) \\leq n^{1/u}$). At $u = \\sqrt{e}$, the density reaches $1/2$, so consecutive integers both satisfying the condition have positive probability.\n\nThe formalization defines `PomeranceExponent = 1/sqrt(e)` and axiomatizes a weak form of the Dickman density result. This provides important context: the $1/2$-exponent problem is harder because sqrt-smooth numbers have density 0, making a density argument impossible.",
-    "mathContext": {
-      "latex": "\\rho(u) = \\text{density of } \\{n : \\operatorname{gpf}(n) \\leq n^{1/u}\\}, \\quad \\rho(\\sqrt{e}) = \\frac{1}{2}, \\quad \\text{PomeranceExponent} = \\frac{1}{\\sqrt{e}} \\approx 0.6065",
-      "description": "The Dickman function satisfies rho(1) = 1, rho(2) = 1 - ln 2, and the delay-differential equation u*rho'(u) = -rho(u-1). At u = sqrt(e), rho reaches 1/2, making the exponent 1/sqrt(e) the critical threshold for density arguments."
-    },
+    "content": "**Pomerance's observation**: Replacing the exponent $1/2$ with $1/\\sqrt{e} - \\varepsilon \\approx 0.6065 - \\varepsilon$ makes the statement true by a density argument. The **Dickman-de Bruijn function** $\\rho(u)$ gives the density of $u$-smooth numbers: $\\rho(u) = 1$ for $u \\leq 1$, satisfying the delay-differential equation $u\\rho'(u) = -\\rho(u-1)$. At $u = \\sqrt{e}$, $\\rho(\\sqrt{e}) = 1/2$, so half of all integers are $\\sqrt{e}$-smooth, making consecutive pairs abundant. The formalization defines `PomeranceExponent = 1/sqrt(e)` and axiomatizes a weak Dickman density result. This explains why the original problem with exponent $1/2$ requires constructive methods: sqrt-smooth numbers have density 0.",
+    "mathContext": "$\\rho(u) = $ density of $\\{n : \\operatorname{gpf}(n) \\leq n^{1/u}\\}$; $\\rho(\\sqrt{e}) = 1/2$; $\\text{PomeranceExponent} = 1/\\sqrt{e} \\approx 0.6065$. The Dickman function satisfies $\\rho(2) = 1 - \\ln 2 \\approx 0.307$.",
     "significance": "key",
-    "relatedConcepts": ["dickman-function", "smooth-number-density", "critical-exponent"],
-    "prerequisites": ["asymptotic-density", "real-analysis"]
+    "relatedConcepts": ["Dickman function", "smooth number density", "critical exponent", "delay-differential equation"],
+    "prerequisites": ["asymptotic density", "real analysis", "smooth number theory"]
   }
 ]

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -64,17 +64,67 @@
       "erdos_370: injective-function encoding of infinitude (sorry'd)"
     ]
   },
+  "leanFile": {
+    "path": "Proofs/Erdos370Problem.lean",
+    "lineCount": 255,
+    "namespace": "Erdos370",
+    "imports": [
+      "Mathlib"
+    ],
+    "mainTheorems": [
+      "steinerberger_succ",
+      "n63_sqrt_smooth",
+      "n64_sqrt_smooth",
+      "example_63",
+      "erdos_370_infinitely_many",
+      "erdos_370"
+    ],
+    "mainDefinitions": [
+      "gpf",
+      "IsSmooth",
+      "IsSqrtSmooth",
+      "ConsecutiveSqrtSmooth",
+      "SteinerbergerConstruction",
+      "ValidSteinerbergerM",
+      "PomeranceExponent"
+    ],
+    "axiomCount": 11,
+    "theoremCount": 4,
+    "sorryCount": 2
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1136",
+      "relationship": "related-problem",
+      "description": "Both are Erdős problems about sets of integers satisfying arithmetic constraints, resolved by clever constructions. Erdős #1136 uses binary structure; #370 uses difference of squares."
+    },
+    {
+      "targetId": "erdos-984",
+      "relationship": "related-problem",
+      "description": "Both are Erdős problems in combinatorial number theory where extremal constructions play a central role in resolving density/existence questions."
+    },
+    {
+      "targetId": "erdos-527",
+      "relationship": "thematic",
+      "description": "Both involve density and structure questions where the answer depends on a critical threshold parameter (the exponent $1/\\sqrt{e}$ in #370, analogous thresholds in #527)."
+    },
+    {
+      "targetId": "prime-reciprocal-divergence",
+      "relationship": "foundational",
+      "description": "Prime distribution underlies smooth number theory. The density of smooth numbers is governed by the Dickman function, which depends on the distribution of prime factors."
+    }
+  ],
   "overview": {
-    "historicalContext": "This problem appears in Erdos and Graham's influential monograph 'Old and New Problems and Results in Combinatorial Number Theory' (1980, p. 69). They asked whether infinitely many consecutive integers n, n+1 both have their largest prime factor less than their square root. Such numbers are called 'sqrt-smooth' -- their prime factorizations are dominated by small primes relative to the number's magnitude.\n\nThe trivial observation is that sqrt-smooth numbers exist (e.g., any perfect square p^2 with p prime has gpf = p = sqrt(p^2)) but finding consecutive pairs is much harder. Pomerance observed that if the exponent 1/2 is relaxed to 1/sqrt(e) - epsilon (approximately 0.6065), the statement follows from density considerations via the Dickman-de Bruijn function, which gives the proportion of 'u-smooth' numbers. At u = sqrt(e), exactly half of all integers are u-smooth, making consecutive pairs abundant.\n\nSteinerberger found the elegant solution: take n = m^2 - 1 = (m-1)(m+1). Then n+1 = m^2, so gpf(n+1) = gpf(m). If m is a power of 2, gpf(m^2) = 2 < m = sqrt(m^2). For n itself, we need gpf((m-1)(m+1)) < m. When m = 8: n = 63 = 7 * 9, gpf(63) = 7 < sqrt(63) approximately 7.94, and gpf(64) = 2 < 8. There are infinitely many valid choices of m, resolving the problem.\n\nThe proof was partially verified by Aristotle proof search, which confirmed the n=63 example and the key identity n+1 = m^2. The main infinitude theorem remains sorry'd, requiring a proof that infinitely many m yield valid constructions.",
+    "historicalContext": "This problem appears in Erdős and Graham's influential monograph *Old and New Problems and Results in Combinatorial Number Theory* (1980, p. 69). They asked whether infinitely many consecutive integers $n$, $n+1$ both have their largest prime factor less than their square root. Such numbers are called *sqrt-smooth* --- their prime factorizations are dominated by small primes relative to the number's magnitude.\n\nThe trivial observation is that sqrt-smooth numbers exist (e.g., any perfect square $p^2$ with $p$ prime has $\\operatorname{gpf} = p = \\sqrt{p^2}$, though this gives equality not strict inequality) but finding consecutive pairs is much harder. Carl Pomerance observed that if the exponent $1/2$ is relaxed to $1/\\sqrt{e} - \\varepsilon$ (approximately $0.6065 - \\varepsilon$), the statement follows from density considerations via the **Dickman-de Bruijn function** $\\rho(u)$, which gives the proportion of $u$-smooth numbers. At $u = \\sqrt{e}$, exactly half of all integers are $u$-smooth, making consecutive pairs abundant by a simple probability argument.\n\nStefan Steinerberger found the elegant constructive solution: take $n = m^2 - 1 = (m-1)(m+1)$. Then $n+1 = m^2$, so $\\operatorname{gpf}(n+1) = \\operatorname{gpf}(m)$. If $m$ is a power of 2, $\\operatorname{gpf}(m^2) = 2 < m = \\sqrt{m^2}$. For $n$ itself, we need $\\operatorname{gpf}((m-1)(m+1)) < m$. The first valid case is $m = 8$: $n = 63 = 7 \\times 9$, $\\operatorname{gpf}(63) = 7 < \\sqrt{63} \\approx 7.94$, and $\\operatorname{gpf}(64) = 2 < 8 = \\sqrt{64}$. There are infinitely many valid choices of $m$, resolving the problem completely.\n\nThe proof was partially verified by the Aristotle proof search system, which confirmed the $n=63$ example and the key identity $n+1 = m^2$. The main infinitude theorem remains sorry'd, requiring a proof that infinitely many $m$ yield valid constructions.",
     "problemStatement": "Are there infinitely many n such that gpf(n) < sqrt(n) and gpf(n+1) < sqrt(n+1), where gpf denotes the greatest prime factor?",
-    "proofStrategy": "The formalization axiomatizes gpf with 6 properties (value at 1, divisibility, primality, prime/prime-power values, product bound) and defines three smoothness predicates. The Steinerberger construction n = m^2 - 1 is formalized with the factorization (m-1)(m+1) axiomatized and the successor identity n+1 = m^2 verified. The worked example n=63 is fully verified (Aristotle proved all 4 component theorems). The main infinitude theorem is stated in two forms (Set.Infinite and injective function) but remains sorry'd. Pomerance's density perspective is included with the critical exponent 1/sqrt(e) and a weak Dickman density axiom.",
+    "proofStrategy": "The formalization axiomatizes gpf with 6 properties (value at 1, divisibility, primality, prime/prime-power values, product bound) and defines three smoothness predicates. The Steinerberger construction $n = m^2 - 1$ is formalized with the factorization $(m-1)(m+1)$ axiomatized and the successor identity $n+1 = m^2$ verified. The worked example $n=63$ is fully verified (Aristotle proved all 4 component theorems). The main infinitude theorem is stated in two forms (`Set.Infinite` and injective function) but remains sorry'd. Pomerance's density perspective is included with the critical exponent $1/\\sqrt{e}$ and a weak Dickman density axiom.",
     "keyInsights": [
-      "The difference-of-squares factorization n = m^2 - 1 = (m-1)(m+1) is the key construction: it forces n+1 = m^2, making gpf(n+1) = gpf(m) automatically small when m is a prime power",
-      "For m = 2^k (powers of 2), gpf(m^2) = 2 < m = sqrt(m^2), so n+1 is always sqrt-smooth -- the challenge is making n sqrt-smooth too",
-      "The concrete example n=63 (m=8=2^3) works because 63 = 7*9 has gpf = 7 < 7.94 = sqrt(63), a tight but valid margin",
-      "Pomerance's density observation shows the critical exponent is 1/sqrt(e) approximately 0.6065: above this, density arguments work; below (including 1/2), explicit constructions are needed",
-      "The Dickman-de Bruijn function rho(u) governs smooth number density: rho(sqrt(e)) = 1/2 is the threshold where half of integers are u-smooth",
-      "Aristotle successfully verified 4 of the 6 non-axiom theorems, demonstrating automated proof search for concrete number-theoretic computations"
+      "**Difference-of-squares factorization**: The construction $n = m^2 - 1 = (m-1)(m+1)$ forces $n+1 = m^2$, making $\\operatorname{gpf}(n+1) = \\operatorname{gpf}(m)$ automatically small when $m$ is a prime power. This reduces the problem to finding $m$ with both $m-1$ and $m+1$ having small prime factors.",
+      "**Powers of 2 make $n+1$ sqrt-smooth**: For $m = 2^k$, $\\operatorname{gpf}(m^2) = 2 < 2^k = \\sqrt{(2^k)^2}$, so $n+1$ is always sqrt-smooth. The challenge shifts entirely to making $n = (2^k - 1)(2^k + 1)$ sqrt-smooth.",
+      "**Tight margin for $n = 63$**: The first valid case $m = 8$ gives $\\operatorname{gpf}(63) = 7 < 7.94 \\approx \\sqrt{63}$, a margin of less than 1. This shows the sqrt-smooth condition is barely satisfied, explaining why the problem is nontrivial.",
+      "**Pomerance's critical exponent $1/\\sqrt{e}$**: The Dickman function $\\rho(u)$ gives the density of $n^{1/u}$-smooth numbers. At $u = \\sqrt{e}$, $\\rho(\\sqrt{e}) = 1/2$, so density arguments work for exponents above $1/\\sqrt{e} \\approx 0.6065$ but fail at the problem's exponent $1/2$.",
+      "**The Dickman-de Bruijn function**: $\\rho(u)$ satisfies $\\rho(u) = 1$ for $u \\leq 1$ and the delay-differential equation $u\\rho'(u) = -\\rho(u-1)$. Its values $\\rho(2) = 1 - \\ln 2 \\approx 0.307$ and $\\rho(\\sqrt{e}) = 1/2$ govern smooth number statistics.",
+      "**Aristotle's contribution**: Automated proof search verified 4 of 6 non-axiom theorems, demonstrating that concrete number-theoretic computations (like $\\operatorname{gpf}(63) = 7 < \\sqrt{63}$) are within reach of current proof search technology."
     ]
   },
   "sections": [
@@ -83,73 +133,59 @@
       "title": "Aristotle Attribution",
       "startLine": 1,
       "endLine": 10,
-      "summary": "Generated by Aristotle proof search (Harmonic). Lists 4 automatically proved theorems: steinerberger_succ, n63_sqrt_smooth, n64_sqrt_smooth, example_63."
+      "summary": "Attribution to the Aristotle (Harmonic) proof search system. Lists 4 automatically proved theorems: `steinerberger_succ`, `n63_sqrt_smooth`, `n64_sqrt_smooth`, `example_63`."
     },
     {
       "id": "header",
       "title": "Problem Overview",
       "startLine": 12,
       "endLine": 48,
-      "summary": "Problem statement, history (Erdos-Graham 1980, Pomerance density observation, Steinerberger construction), key insight n = m^2 - 1, worked example n=63."
+      "summary": "Problem statement, history (Erdős-Graham 1980, Pomerance density observation, Steinerberger construction), key insight $n = m^2 - 1$, worked example $n = 63$."
     },
     {
       "id": "gpf-definition",
       "title": "Greatest Prime Factor Axiomatization",
       "startLine": 50,
       "endLine": 73,
-      "summary": "6 axioms for gpf: value at n<=1, divisibility, primality, gpf of prime, gpf of prime power, and product bound gpf(mn) <= max(gpf(m), gpf(n))."
+      "summary": "Six axioms for $\\operatorname{gpf}$: value at $n \\leq 1$, divisibility, primality, $\\operatorname{gpf}(p) = p$, $\\operatorname{gpf}(p^k) = p$, and product bound $\\operatorname{gpf}(mn) \\leq \\max(\\operatorname{gpf}(m), \\operatorname{gpf}(n))$."
     },
     {
       "id": "smooth-numbers",
       "title": "Smooth Number Definitions",
       "startLine": 75,
       "endLine": 90,
-      "summary": "IsSmooth (B-smooth: gpf(n) <= B), IsSqrtSmooth (gpf(n) < sqrt(n) via real casting), ConsecutiveSqrtSmooth (both n and n+1 sqrt-smooth)."
+      "summary": "Defines `IsSmooth` ($B$-smooth: $\\operatorname{gpf}(n) \\leq B$), `IsSqrtSmooth` ($\\operatorname{gpf}(n) < \\sqrt{n}$ via real casting), `ConsecutiveSqrtSmooth` (both $n$ and $n+1$ sqrt-smooth)."
     },
     {
       "id": "steinerberger",
       "title": "Steinerberger Construction and Examples",
       "startLine": 92,
       "endLine": 156,
-      "summary": "SteinerbergerConstruction m = m^2 - 1 with factorization axiom and verified successor identity. Examples: n=63 (m=8) fully verified by Aristotle, n=224 (m=15) stated. ValidSteinerbergerM predicate for valid m."
+      "summary": "`SteinerbergerConstruction(m) = m^2 - 1` with factorization axiom and verified successor identity $n + 1 = m^2$. Examples: $n=63$ ($m=8$) fully verified by Aristotle, $n=224$ ($m=15$) stated."
     },
     {
       "id": "main-theorem",
       "title": "Main Infinitude Theorem",
       "startLine": 158,
       "endLine": 201,
-      "summary": "Two sorry'd statements: erdos_370_infinitely_many (Set.Infinite) and erdos_370 (injective function). Aristotle failed to load due to namespace issues. Proof requires showing infinitely many valid m exist."
+      "summary": "Two sorry'd statements: `erdos_370_infinitely_many` ($\\text{Set.Infinite}$) and `erdos_370` (injective function). Requires proving infinitely many valid $m$ exist."
     },
     {
       "id": "pomerance",
       "title": "Pomerance's Density Perspective",
       "startLine": 203,
-      "endLine": 248,
-      "summary": "PomeranceExponent = 1/sqrt(e) approximately 0.6065 and Dickman density axiom. Explains why relaxing the exponent makes the problem trivial by density, while 1/2 requires constructive methods."
+      "endLine": 255,
+      "summary": "Defines `PomeranceExponent` $= 1/\\sqrt{e} \\approx 0.6065$ and axiomatizes a weak Dickman density result. Explains why exponent $1/2$ requires constructive methods while $1/\\sqrt{e}$ follows from density."
     }
   ],
   "conclusion": {
-    "summary": "Erdos Problem #370 is SOLVED: there are infinitely many n where both n and n+1 are sqrt-smooth. The Steinerberger construction n = m^2 - 1 = (m-1)(m+1) provides an elegant infinite family of examples. The formalization verifies the concrete case n=63 (via Aristotle proof search) and connects to the deeper theory of smooth number density via Pomerance's observation and the Dickman function.",
-    "implications": "The elegant Steinerberger solution demonstrates how difference-of-squares factorization can reduce deep-sounding number-theoretic questions to elementary observations. The connection to the Dickman function reveals that the exponent 1/2 is below the density threshold 1/sqrt(e), explaining why the problem requires constructive methods rather than probabilistic arguments.",
+    "summary": "Erdős Problem #370 is SOLVED: there are infinitely many $n$ where both $n$ and $n+1$ are sqrt-smooth. Steinerberger's construction $n = m^2 - 1 = (m-1)(m+1)$ provides an elegant infinite family. The formalization verifies the concrete case $n = 63$ (via Aristotle proof search) and connects to smooth number density theory via Pomerance's observation and the Dickman-de Bruijn function.",
+    "implications": "The Steinerberger solution demonstrates how difference-of-squares factorization can reduce deep-sounding number-theoretic questions to elementary observations. The connection to the Dickman function reveals that the exponent $1/2$ lies below the density threshold $1/\\sqrt{e}$, explaining why the problem requires constructive methods rather than probabilistic arguments. This distinction between 'density-easy' and 'construction-required' exponents is a recurring theme in smooth number theory.",
     "openQuestions": [
-      "What is the asymptotic density or count of n <= N with ConsecutiveSqrtSmooth(n)?",
-      "Are there infinitely many n with gpf(n), gpf(n+1), gpf(n+2) all less than their square roots (triples)?",
-      "What is the smallest n satisfying ConsecutiveSqrtSmooth(n) with gpf(n) = gpf(n+1)? (i.e., same largest prime factor)",
-      "Can the Steinerberger construction be optimized to find the densest infinite family?"
+      "What is the asymptotic count of $n \\leq N$ with $\\text{ConsecutiveSqrtSmooth}(n)$? Can the Steinerberger construction be optimized to find the densest infinite family?",
+      "Are there infinitely many $n$ with $\\operatorname{gpf}(n), \\operatorname{gpf}(n+1), \\operatorname{gpf}(n+2)$ all less than their square roots (consecutive triples)?",
+      "Can the main infinitude theorem be proved in Lean by showing infinitely many $m = 2^k$ yield $\\operatorname{gpf}((2^k-1)(2^k+1)) < 2^k$?",
+      "What is the exact critical exponent below which the Erdős-Graham problem requires constructive rather than density-based proofs?"
     ]
-  },
-  "crossReferences": [
-    {
-      "proofId": "erdos-1136",
-      "relationship": "Both are Erdos problems about sets of integers satisfying additive/multiplicative constraints, resolved by clever constructions"
-    },
-    {
-      "proofId": "erdos-984",
-      "relationship": "Both are Erdos problems in combinatorial number theory where extremal constructions play a central role"
-    },
-    {
-      "proofId": "erdos-527",
-      "relationship": "Both involve density and structure questions where the answer depends on a critical threshold parameter"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- Added `leanFile` metadata (imports, theorems, definitions, axiom/sorry counts)
- Fixed annotation types: `attribution` -> `concept`, `context` -> `concept`, `axiom` -> `definition` (valid schema types)
- Normalized `mathContext` from `{latex, description}` objects to simple LaTeX strings
- Standardized `crossReferences` format (`targetId` + `relationship` + `description`)
- Added cross-reference to `prime-reciprocal-divergence` (smooth number foundations)
- Deepened `historicalContext` with Stefan Steinerberger, Pomerance density context
- Added LaTeX to all section summaries
- Enhanced conclusion with density-vs-construction theme

## Test plan
- [x] `pnpm annotations:build` passes (no warnings from erdos-370)
- [x] Only erdos-370 files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)