### PR TITLE
enrich(erdos-411): add leanFile, crossReferences, fix annotation types

### DIFF
--- a/src/data/proofs/erdos-411/annotations.json
+++ b/src/data/proofs/erdos-411/annotations.json
@@ -2,15 +2,17 @@
   {
     "id": "erdos-411-header",
     "proofId": "erdos-411",
-    "type": "context",
+    "type": "concept",
     "range": {
-      "startLine": 1,
-      "endLine": 12
+      "startLine": 14,
+      "endLine": 17
     },
-    "title": "Problem Background",
-    "content": "Erdős Problem #411 studies the arithmetic dynamics of the map $g(n) = n + \\varphi(n)$, where $\\varphi$ is Euler's totient function. Iterating $g$ produces a sequence $n, g(n), g^2(n), \\ldots$ that grows roughly linearly. The problem asks: for which $n$ and $r$ does $g^{k+r}(n) = 2 \\cdot g^k(n)$ hold for all sufficiently large $k$? This is a question about exact exponential growth rates in arithmetic dynamical systems.",
-    "significance": "critical",
-    "mathContext": "arithmetic dynamics / number theory. LaTeX: g(n) = n + \\varphi(n), \\quad g^{k+r}(n) = 2 \\cdot g^k(n) \\text{ for all large } k. Related: Erdős–Graham (1980) Old and New Problems and Results in Combinatorial Number Theory, Steinerberger (2025) reduction for r = 2, Carmichael's totient conjecture. Prerequisites: Euler's totient function φ(n), iteration of arithmetic functions, eventual periodicity, multiplicative functions"
+    "title": "Imports and Setup",
+    "content": "Imports Mathlib's `Nat.Totient` (Euler's totient function $\\varphi(n)$ and its properties including `Nat.totient_even`), `Nat.Basic` (natural number arithmetic), `Filter.Basic` (filter theory for eventual properties), and `Tactic` (automation). These provide the foundation for formalizing arithmetic dynamics of $g(n) = n + \\varphi(n)$.",
+    "significance": "supporting",
+    "mathContext": "$\\varphi(n) = |\\{1 \\leq k \\leq n : \\gcd(k, n) = 1\\}|$, the Euler totient function from `Mathlib.Data.Nat.Totient`",
+    "relatedConcepts": ["Euler's totient function", "Mathlib", "imports"],
+    "prerequisites": ["Lean 4 syntax", "Mathlib library structure"]
   },
   {
     "id": "erdos-411-totientStep",
@@ -23,7 +25,9 @@
     "title": "The Map $g(n) = n + \\varphi(n)$",
     "content": "The function `totientStep` computes $g(n) = n + \\varphi(n)$. Since $\\varphi(n) \\geq 1$ for $n \\geq 1$, this map is strictly increasing. For even $n > 2$, $\\varphi(n)$ is even, so $g$ preserves parity. The map arises naturally from the identity $n = \\sum_{d \\mid n} \\varphi(d)$, making $g(n) = n + \\varphi(n)$ a 'self-augmenting' version of $n$.",
     "significance": "key",
-    "mathContext": "arithmetic dynamics. LaTeX: g(n) = n + \\varphi(n). Lean: def totientStep (n : ℕ) : ℕ := n + n.totient. Related: For prime p, g(p) = p + (p-1) = 2p-1. For p^k, g(p^k) = p^k + p^k(1 - 1/p) = p^k(2 - 1/p)."
+    "mathContext": "$g(n) = n + \\varphi(n)$. For prime $p$: $g(p) = p + (p-1) = 2p-1$. For $p^k$: $g(p^k) = p^k + p^{k-1}(p-1) = p^{k-1}(2p-1)$.",
+    "relatedConcepts": ["Euler's totient function", "arithmetic dynamics", "strictly increasing maps"],
+    "prerequisites": ["Euler's totient function", "basic number theory"]
   },
   {
     "id": "erdos-411-iterated",
@@ -36,7 +40,9 @@
     "title": "Iterated $g^k(n)$",
     "content": "The $k$-th iterate $g^k(n)$ is defined recursively: $g^0(n) = n$ and $g^{k+1}(n) = g(g^k(n))$. The sequence $g^0(n), g^1(n), g^2(n), \\ldots$ is strictly increasing since $g(m) > m$ for $m \\geq 1$. The ratio $g^{k+r}(n) / g^k(n)$ may stabilize as $k \\to \\infty$.",
     "significance": "key",
-    "mathContext": "arithmetic dynamics. LaTeX: g^0(n) = n, \\quad g^{k+1}(n) = g(g^k(n)). Lean: def iteratedTotientStep : ℕ → ℕ → ℕ | 0, n => n | k + 1, n => totientStep (iteratedTotientStep k n)"
+    "mathContext": "$g^0(n) = n$, $g^{k+1}(n) = g(g^k(n))$. Example: $g^0(10) = 10$, $g^1(10) = 14$, $g^2(10) = 20$, $g^3(10) = 28$, $g^4(10) = 40$.",
+    "relatedConcepts": ["function iteration", "discrete dynamical systems", "orbit of a map"],
+    "prerequisites": ["recursion on natural numbers", "function composition"]
   },
   {
     "id": "erdos-411-doubling",
@@ -47,27 +53,31 @@
       "endLine": 38
     },
     "title": "The Doubling Relation",
-    "content": "`DoublingRelation n r` asserts that $g^{k+r}(n) = 2 \\cdot g^k(n)$ for all sufficiently large $k$. This means that after an initial transient, applying $g$ exactly $r$ more times doubles the value. The 'eventually' quantifier (there exists $K$ such that the relation holds for all $k \\geq K$) captures the idea that we care about asymptotic behavior, not initial values.",
+    "content": "`DoublingRelation n r` asserts that $g^{k+r}(n) = 2 \\cdot g^k(n)$ for all sufficiently large $k$. This means that after an initial transient, applying $g$ exactly $r$ more times doubles the value. The 'eventually' quantifier ($\\exists K$ such that the relation holds for all $k \\geq K$) captures the idea that we care about asymptotic behavior, not initial values.",
     "significance": "critical",
-    "mathContext": "arithmetic dynamics. LaTeX: \\text{DoublingRelation}(n, r) \\iff \\exists K,\\; \\forall k \\geq K,\\; g^{k+r}(n) = 2 \\cdot g^k(n). Lean: def DoublingRelation (n r : ℕ) : Prop := ∃ K : ℕ, ∀ k : ℕ, k ≥ K → iteratedTotientStep (k + r) n = 2 * iteratedTotientStep k n. Related: This is equivalent to saying the orbit {g^k(n)} eventually satisfies a linear recurrence with ratio 2 and period r"
+    "mathContext": "$\\text{DoublingRelation}(n, r) \\iff \\exists K,\\; \\forall k \\geq K,\\; g^{k+r}(n) = 2 \\cdot g^k(n)$. This is equivalent to saying the orbit $\\{g^k(n)\\}$ eventually satisfies a linear recurrence with ratio 2 and period $r$.",
+    "relatedConcepts": ["eventual properties", "geometric growth", "linear recurrences", "arithmetic dynamics"],
+    "prerequisites": ["function iteration", "existential and universal quantifiers", "eventual behavior"]
   },
   {
     "id": "erdos-411-conjecture",
     "proofId": "erdos-411",
-    "type": "conjecture",
+    "type": "concept",
     "range": {
       "startLine": 44,
       "endLine": 50
     },
     "title": "Erdős Problem #411",
-    "content": "The problem asks for a complete characterization of all pairs $(n, r)$ satisfying the doubling relation. The formalization states this as the existence of a set $S \\subseteq \\mathbb{N} \\times \\mathbb{N}$ that captures exactly the solution pairs and is nonempty (we know solutions exist). The problem remains OPEN — it is not even known whether the solution set is finite or infinite.",
+    "content": "The problem asks for a complete characterization of all pairs $(n, r)$ satisfying the doubling relation. The formalization states this as the existence of a set $S \\subseteq \\mathbb{N} \\times \\mathbb{N}$ that captures exactly the solution pairs and is nonempty (we know solutions exist). The problem remains OPEN -- it is not even known whether the solution set is finite or infinite.",
     "significance": "critical",
-    "mathContext": "open problems in number theory. LaTeX: \\text{Characterize } \\{(n, r) : g^{k+r}(n) = 2 \\cdot g^k(n) \\text{ for large } k\\}. Lean: def ErdosProblem411 : Prop := ∃ S : Set (ℕ × ℕ), (∀ p : ℕ × ℕ, p ∈ S ↔ DoublingRelation p.1 p.2) ∧ S.Nonempty. The nonemptiness clause is included because we know solutions exist (n = 10, 94 for r = 2). The characterization problem asks for a 'nice' description of S."
+    "mathContext": "Characterize $\\{(n, r) : g^{k+r}(n) = 2 \\cdot g^k(n) \\text{ for large } k\\}$. The nonemptiness clause holds because $(10, 2)$ and $(94, 2)$ are known solutions.",
+    "relatedConcepts": ["open problem", "characterization problem", "arithmetic dynamics"],
+    "prerequisites": ["DoublingRelation", "set theory", "Erdős-Graham monograph"]
   },
   {
     "id": "erdos-411-n10",
     "proofId": "erdos-411",
-    "type": "axiom",
+    "type": "theorem",
     "range": {
       "startLine": 56,
       "endLine": 58
@@ -75,20 +85,24 @@
     "title": "Known Solution: $n = 10$, $r = 2$",
     "content": "For $n = 10$: $g(10) = 10 + \\varphi(10) = 10 + 4 = 14$, $g(14) = 14 + \\varphi(14) = 14 + 6 = 20$, so $g^2(10) = 20 = 2 \\cdot 10$. This doubling pattern persists for all subsequent iterates. Steinerberger's reduction confirms: $\\varphi(10) + \\varphi(14) = 4 + 6 = 10 = n$.",
     "significance": "key",
-    "mathContext": "computational verification. LaTeX: g^2(10) = 20 = 2 \\cdot 10, \\quad \\varphi(10) + \\varphi(14) = 10. Lean: axiom doubling_r2_n10 : DoublingRelation 10 2. Technique: The orbit is 10 → 14 → 20 → 28 → 40 → 56 → 80 → ..., doubling every two steps."
+    "mathContext": "$g^2(10) = 20 = 2 \\cdot 10$. The orbit is $10 \\to 14 \\to 20 \\to 28 \\to 40 \\to 56 \\to 80 \\to \\ldots$, doubling every two steps. Steinerberger check: $\\varphi(10) + \\varphi(14) = 4 + 6 = 10$.",
+    "relatedConcepts": ["computational verification", "Steinerberger's equation", "orbit computation"],
+    "prerequisites": ["DoublingRelation", "totientStep", "Euler's totient values"]
   },
   {
     "id": "erdos-411-n94",
     "proofId": "erdos-411",
-    "type": "axiom",
+    "type": "theorem",
     "range": {
       "startLine": 60,
       "endLine": 61
     },
     "title": "Known Solution: $n = 94$, $r = 2$",
-    "content": "For $n = 94$: $\\varphi(94) = \\varphi(2 \\cdot 47) = 46$, so $g(94) = 140$. Then $\\varphi(140) = \\varphi(2^2 \\cdot 5 \\cdot 7) = 48$, so $g(140) = 188 = 2 \\cdot 94$. Steinerberger's check: $\\varphi(94) + \\varphi(140) = 46 + 48 = 94 = n$.",
+    "content": "For $n = 94$: $\\varphi(94) = \\varphi(2 \\cdot 47) = 46$, so $g(94) = 140$. Then $\\varphi(140) = \\varphi(2^2 \\cdot 5 \\cdot 7) = 48$, so $g(140) = 188 = 2 \\cdot 94$. Steinerberger's check: $\\varphi(94) + \\varphi(140) = 46 + 48 = 94 = n$. Note $94 = 2 \\cdot 47$, fitting Cambie's conjecture with $l = 1$, $p = 47$.",
     "significance": "key",
-    "mathContext": "computational verification. LaTeX: g^2(94) = 188 = 2 \\cdot 94, \\quad \\varphi(94) + \\varphi(140) = 94. Lean: axiom doubling_r2_n94 : DoublingRelation 94 2. Related: 94 = 2 · 47, fitting Cambie's conjecture with l = 1, p = 47"
+    "mathContext": "$g^2(94) = 188 = 2 \\cdot 94$, $\\varphi(94) + \\varphi(140) = 46 + 48 = 94$. Factorization: $94 = 2 \\cdot 47$ (Cambie form with $l = 1$, $p = 47$).",
+    "relatedConcepts": ["computational verification", "Cambie's conjecture", "totient of products"],
+    "prerequisites": ["DoublingRelation", "totient multiplicativity", "prime factorization"]
   },
   {
     "id": "erdos-411-general-ratio",
@@ -101,12 +115,14 @@
     "title": "General Ratio Relation",
     "content": "Generalization of the doubling relation: $g^{k+r}(n) = c \\cdot g^k(n)$ for all large $k$, where $c$ is an arbitrary multiplicative factor. Cambie discovered that ratios besides 2 (specifically 3 and 4) can also occur, extending the landscape of solutions beyond Erdős's original question.",
     "significance": "key",
-    "mathContext": "arithmetic dynamics. LaTeX: \\text{GeneralRatioRelation}(n, r, c) \\iff \\exists K,\\; \\forall k \\geq K,\\; g^{k+r}(n) = c \\cdot g^k(n). Lean: def GeneralRatioRelation (n r c : ℕ) : Prop := ∃ K : ℕ, ∀ k : ℕ, k ≥ K → iteratedTotientStep (k + r) n = c * iteratedTotientStep k n"
+    "mathContext": "$\\text{GeneralRatioRelation}(n, r, c) \\iff \\exists K,\\; \\forall k \\geq K,\\; g^{k+r}(n) = c \\cdot g^k(n)$. Generalizes DoublingRelation (which is the $c = 2$ case).",
+    "relatedConcepts": ["generalized scaling", "Cambie's extensions", "multi-ratio phenomenon"],
+    "prerequisites": ["DoublingRelation", "iteratedTotientStep"]
   },
   {
     "id": "erdos-411-cambie-ratio3",
     "proofId": "erdos-411",
-    "type": "axiom",
+    "type": "theorem",
     "range": {
       "startLine": 69,
       "endLine": 69
@@ -114,12 +130,14 @@
     "title": "Cambie's Ratio-3 Solution",
     "content": "Cambie found that $n = 738$ with period $r = 4$ gives a ratio-3 solution: $g^{k+4}(738) = 3 \\cdot g^k(738)$ for all large $k$. This shows the phenomenon extends beyond doubling to tripling, opening up a richer classification problem.",
     "significance": "key",
-    "mathContext": "arithmetic dynamics. LaTeX: g^{k+4}(738) = 3 \\cdot g^k(738) \\text{ for large } k. Lean: axiom cambie_ratio3 : GeneralRatioRelation 738 4 3"
+    "mathContext": "$g^{k+4}(738) = 3 \\cdot g^k(738)$ for large $k$. Note: $738 = 2 \\cdot 3 \\cdot 123 = 2 \\cdot 3 \\cdot 3 \\cdot 41 = 2 \\cdot 9 \\cdot 41$.",
+    "relatedConcepts": ["GeneralRatioRelation", "Cambie's discoveries", "ratio-3 solutions"],
+    "prerequisites": ["GeneralRatioRelation", "iteratedTotientStep"]
   },
   {
     "id": "erdos-411-cambie-ratio4",
     "proofId": "erdos-411",
-    "type": "axiom",
+    "type": "theorem",
     "range": {
       "startLine": 72,
       "endLine": 73
@@ -127,20 +145,24 @@
     "title": "Cambie's Ratio-4 Solutions",
     "content": "Cambie found two ratio-4 solutions with period $r = 4$: $n = 148646$ and $n = 4325798$. These satisfy $g^{k+4}(n) = 4 \\cdot g^k(n)$ for all large $k$. The existence of ratio-4 solutions (alongside ratio-2 and ratio-3) suggests a rich structure in the possible growth rates.",
     "significance": "key",
-    "mathContext": "arithmetic dynamics. LaTeX: g^{k+4}(148646) = 4 \\cdot g^k(148646), \\quad g^{k+4}(4325798) = 4 \\cdot g^k(4325798). Lean: axiom cambie_ratio4_148646 : GeneralRatioRelation 148646 4 4"
+    "mathContext": "$g^{k+4}(148646) = 4 \\cdot g^k(148646)$ and $g^{k+4}(4325798) = 4 \\cdot g^k(4325798)$ for large $k$.",
+    "relatedConcepts": ["GeneralRatioRelation", "Cambie's discoveries", "ratio-4 solutions"],
+    "prerequisites": ["GeneralRatioRelation", "iteratedTotientStep"]
   },
   {
     "id": "erdos-411-steinerberger",
     "proofId": "erdos-411",
-    "type": "axiom",
+    "type": "theorem",
     "range": {
       "startLine": 79,
       "endLine": 83
     },
     "title": "Steinerberger's Reduction (2025)",
-    "content": "Steinerberger (2025) proved that the $r = 2$ doubling property is equivalent to the single algebraic equation $\\varphi(n) + \\varphi(n + \\varphi(n)) = n$. This is a remarkable simplification: the asymptotic condition '$g^{k+2}(n) = 2 \\cdot g^k(n)$ for large $k$' reduces to a finitely checkable identity involving just two evaluations of $\\varphi$.",
+    "content": "Steinerberger (2025) proved that the $r = 2$ doubling property is equivalent to the single algebraic equation $\\varphi(n) + \\varphi(n + \\varphi(n)) = n$. This is a remarkable simplification: the asymptotic condition '$g^{k+2}(n) = 2 \\cdot g^k(n)$ for large $k$' reduces to a finitely checkable identity involving just two evaluations of $\\varphi$. The key insight is that if $g^2(n) = 2n$, then by induction $g^2(g^k(n)) = 2g^k(n)$, so doubling propagates forward; conversely, eventual doubling implies doubling from the start.",
     "significance": "critical",
-    "mathContext": "analytic number theory / arithmetic dynamics. LaTeX: \\text{DoublingRelation}(n, 2) \\iff \\varphi(n) + \\varphi(n + \\varphi(n)) = n. Lean: axiom steinerberger_r2_equiv (n : ℕ) : DoublingRelation n 2 ↔ n.totient + (n + n.totient).totient = n. Technique: The key insight is that if g²(n) = 2n, then g²(g^k(n)) = g^{k+2}(n). By induction, if the doubling holds once at the 'right' point, it propagates to all subsequent iterates. Conversely, if it holds eventually, backtracking shows it must hold at n itself.. Refs: S. Steinerberger, 'On a problem of Erdős and Graham on iterated totients', 2025"
+    "mathContext": "$\\text{DoublingRelation}(n, 2) \\iff \\varphi(n) + \\varphi(n + \\varphi(n)) = n$. Proof sketch: $g^2(n) = g(n + \\varphi(n)) = (n + \\varphi(n)) + \\varphi(n + \\varphi(n)) = n + \\varphi(n) + \\varphi(n + \\varphi(n))$. So $g^2(n) = 2n \\iff \\varphi(n) + \\varphi(n + \\varphi(n)) = n$.",
+    "relatedConcepts": ["Steinerberger's theorem", "finite reduction", "arithmetic dynamics"],
+    "prerequisites": ["DoublingRelation", "totientStep", "Euler's totient function"]
   },
   {
     "id": "erdos-411-even-preservation",
@@ -151,22 +173,26 @@
       "endLine": 95
     },
     "title": "Even Preservation Under $g$",
-    "content": "For even $n > 2$, $g(n) = n + \\varphi(n)$ is even. This follows because $\\varphi(n)$ is even for $n > 2$ (a classical result: $\\varphi(n) = n \\prod_{p \\mid n}(1 - 1/p)$ is even unless $n \\in \\{1, 2\\}$). Since all known solutions are even, this is a relevant structural constraint.",
+    "content": "For even $n > 2$, $g(n) = n + \\varphi(n)$ is even. This follows because $\\varphi(n)$ is even for $n > 2$ (classical result: the group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ has even order for $n > 2$ since $-1 \\neq 1$). The proof uses Mathlib's `Nat.totient_even` and `dvd_add`. Since all known doubling solutions are even, this is a relevant structural constraint.",
     "significance": "key",
-    "mathContext": "elementary number theory. LaTeX: 2 \\mid n \\text{ and } n > 2 \\implies 2 \\mid g(n). Lean: theorem totientStep_even_of_even {n : ℕ} (hn : 2 ∣ n) (hn2 : n > 2) : 2 ∣ totientStep n. Technique: Uses Mathlib's Nat.totient_even which states φ(n) is even for n > 2. Then g(n) = n + φ(n) is a sum of two even numbers."
+    "mathContext": "$2 \\mid n \\text{ and } n > 2 \\implies 2 \\mid g(n)$. Proof: `Nat.totient_even` gives $2 \\mid \\varphi(n)$, then `dvd_add` gives $2 \\mid (n + \\varphi(n))$. This is one of two fully verified theorems in the file.",
+    "relatedConcepts": ["parity", "Nat.totient_even", "structural constraints", "verified proof"],
+    "prerequisites": ["Euler's totient function", "divisibility", "Nat.totient_even from Mathlib"]
   },
   {
     "id": "erdos-411-cambie-conjecture",
     "proofId": "erdos-411",
-    "type": "conjecture",
+    "type": "concept",
     "range": {
       "startLine": 97,
       "endLine": 102
     },
     "title": "Cambie's Structural Conjecture",
-    "content": "Cambie conjectures that all $r = 2$ doubling solutions have the form $n = 2^l \\cdot p$ where $l \\geq 1$ and $p \\in \\{2, 3, 5, 7, 35, 47\\}$. This would give a complete finite list of solutions: $\\{4, 6, 8, 10, 12, 14, 16, 20, 24, 28, 40, 48, 56, 70, 80, 94, 96, 112, 140, 160, \\ldots\\}$.",
+    "content": "Cambie conjectures that all $r = 2$ doubling solutions have the form $n = 2^l \\cdot p$ where $l \\geq 1$ and $p \\in \\{2, 3, 5, 7, 35, 47\\}$. This would give an infinite but highly structured solution set: for each valid $p$, all numbers $2p, 4p, 8p, \\ldots$ would be solutions. Known examples: $10 = 2^1 \\cdot 5$, $94 = 2^1 \\cdot 47$.",
     "significance": "key",
-    "mathContext": "arithmetic dynamics. LaTeX: \\text{DoublingRelation}(n, 2) \\implies n = 2^l \\cdot p, \\; l \\geq 1, \\; p \\in \\{2, 3, 5, 7, 35, 47\\}. Lean: def CambieConjecture : Prop := ∀ n : ℕ, DoublingRelation n 2 → ∃ l : ℕ, l ≥ 1 ∧ ∃ p ∈ ({2, 3, 5, 7, 35, 47} : Finset ℕ), n = 2 ^ l * p. Note that 10 = 2¹ · 5 and 94 = 2¹ · 47 fit this pattern. Cambie's conjecture would make the solution set infinite (all powers of 2 times each p would work) but highly structured."
+    "mathContext": "$\\text{DoublingRelation}(n, 2) \\implies n = 2^l \\cdot p$, $l \\geq 1$, $p \\in \\{2, 3, 5, 7, 35, 47\\}$. Verification: $10 = 2^1 \\cdot 5$ and $94 = 2^1 \\cdot 47$ fit the pattern.",
+    "relatedConcepts": ["Cambie's conjecture", "structural characterization", "powers of 2"],
+    "prerequisites": ["DoublingRelation", "prime factorization", "known solutions"]
   },
   {
     "id": "erdos-411-monotonicity",
@@ -177,8 +203,10 @@
       "endLine": 108
     },
     "title": "Monotonicity of $g$",
-    "content": "The map $g(n) = n + \\varphi(n) \\geq n$ for all $n$, with strict inequality for $n \\geq 1$ since $\\varphi(n) \\geq 1$. This means the orbit $g^k(n)$ is nondecreasing. The proof is immediate by `omega`.",
+    "content": "The map $g(n) = n + \\varphi(n) \\geq n$ for all $n$, with strict inequality for $n \\geq 1$ since $\\varphi(n) \\geq 1$. This means the orbit $g^k(n)$ is nondecreasing. The proof is immediate by `omega`. This is the second fully verified theorem in the file.",
     "significance": "supporting",
-    "mathContext": "elementary number theory. LaTeX: g(n) = n + \\varphi(n) \\geq n. Lean: theorem totientStep_ge (n : ℕ) : totientStep n ≥ n"
+    "mathContext": "$g(n) = n + \\varphi(n) \\geq n$. Since $\\varphi(n) \\geq 1$ for $n \\geq 1$, the orbit $\\{g^k(n)\\}_{k \\geq 0}$ is strictly increasing.",
+    "relatedConcepts": ["monotonicity", "omega tactic", "orbit growth"],
+    "prerequisites": ["totientStep", "natural number arithmetic"]
   }
 ]

--- a/src/data/proofs/erdos-411/meta.json
+++ b/src/data/proofs/erdos-411/meta.json
@@ -6,6 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/411",
+    "date": "1980",
     "status": "formalized",
     "proofRepoPath": "Proofs/Erdos411Problem.lean",
     "tags": [
@@ -20,6 +21,8 @@
     "erdosNumber": 411,
     "erdosUrl": "https://erdosproblems.com/411",
     "erdosProblemStatus": "open",
+    "dateAdded": "2026-01-26",
+    "mathlib_version": "4.24.0",
     "mathlibDependencies": [
       {
         "theorem": "Nat.totient",
@@ -46,70 +49,130 @@
       "Formalized Cambie's structural conjecture on the form of r = 2 solutions"
     ]
   },
+  "leanFile": {
+    "path": "Proofs/Erdos411Problem.lean",
+    "lineCount": 109,
+    "namespace": "root",
+    "imports": [
+      "Mathlib.Data.Nat.Totient",
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.Order.Filter.Basic",
+      "Mathlib.Tactic"
+    ],
+    "mainTheorems": [
+      "totientStep_even_of_even",
+      "totientStep_ge"
+    ],
+    "mainDefinitions": [
+      "totientStep",
+      "iteratedTotientStep",
+      "DoublingRelation",
+      "ErdosProblem411",
+      "GeneralRatioRelation",
+      "CambieConjecture"
+    ],
+    "axiomCount": 6,
+    "theoremCount": 2,
+    "sorryCount": 0
+  },
   "overview": {
-    "historicalContext": "Erdős and Graham (1980, p. 81) posed this question about iterating $g(n) = n + \\varphi(n)$. The function $g$ always increases $n$, and the iterates $g^k(n)$ grow roughly linearly. The question asks when this growth is exactly doubling with a fixed period. Steinerberger (2025) achieved a breakthrough by reducing the $r = 2$ case to a single equation $\\varphi(n) + \\varphi(n + \\varphi(n)) = n$. Cambie extended the investigation to general ratios, finding solutions with multiplicative factors 3 and 4.",
+    "historicalContext": "Erdős and Graham posed this question in their influential monograph 'Old and New Problems and Results in Combinatorial Number Theory' (1980, p. 81). They studied the iteration $g(n) = n + \\varphi(n)$, where $\\varphi$ is Euler's totient function, asking for which $n$ and $r$ the $r$-step iterate doubles the value: $g^{k+r}(n) = 2 \\cdot g^k(n)$ for all large $k$. The function $g$ is a natural object: since $\\varphi(n)$ counts integers up to $n$ coprime to $n$, the map $n \\mapsto n + \\varphi(n)$ augments $n$ by its 'coprime complement.'\n\nThe simplest solutions are $n = 10$ (orbit: $10 \\to 14 \\to 20 \\to 28 \\to 40 \\to \\ldots$, doubling every 2 steps) and $n = 94$. For decades, little progress was made on characterizing all solutions. Stefan Steinerberger achieved a breakthrough in 2025 by showing the $r = 2$ case reduces to a single finitely-checkable equation: $\\varphi(n) + \\varphi(n + \\varphi(n)) = n$. This transforms an asymptotic dynamical condition into elementary number theory.\n\nSjoerd Cambie extended the investigation to general multiplicative ratios $c \\neq 2$, discovering that $n = 738$ gives a ratio-3 solution ($g^{k+4}(738) = 3 \\cdot g^k(738)$) and $n = 148646, 4325798$ give ratio-4 solutions. These findings reveal the problem has far richer structure than Erdős originally anticipated. Cambie also conjectured that all $r = 2$ solutions have the form $n = 2^l \\cdot p$ for $p \\in \\{2, 3, 5, 7, 35, 47\\}$.\n\nThe problem belongs to a cluster of related Erdős questions (#410--#415) about iterating arithmetic functions: $\\sigma$ (sum of divisors), $\\tau$ (divisor count), $\\omega$ (distinct prime factors), and $\\varphi$ (totient). Together they form a rich chapter in arithmetic dynamics, connecting multiplicative number theory to discrete dynamical systems.",
     "problemStatement": "Let $g(n) = n + \\varphi(n)$ and $g^k = g \\circ \\cdots \\circ g$ ($k$ times). For which $n$ and $r$ is $g^{k+r}(n) = 2 \\cdot g^k(n)$ for all sufficiently large $k$?",
     "proofStrategy": "The formalization defines `totientStep` ($g$), `iteratedTotientStep` ($g^k$), and `DoublingRelation`. The main conjecture `ErdosProblem411` asks for a characterization of all solution pairs $(n, r)$. Known solutions ($n = 10, 94$ for $r = 2$) are axiomatized. `GeneralRatioRelation` extends to arbitrary multiplicative ratios. Steinerberger's equivalence and structural properties (even preservation, monotonicity) are formalized. Cambie's conjecture on the form $n = 2^l \\cdot p$ is stated.",
     "keyInsights": [
-      "$g(n) = n + \\varphi(n)$ is a natural arithmetic iteration; for $n = 10$, the orbit is $10 \\to 14 \\to 20 \\to 28 \\to 40 \\to \\ldots$, doubling every two steps",
-      "Steinerberger's reduction: the $r = 2$ doubling property is equivalent to the single equation $\\varphi(n) + \\varphi(n + \\varphi(n)) = n$",
-      "Cambie found solutions with ratios 3 and 4 (not just doubling), showing the problem has richer structure than originally anticipated",
-      "All known $r = 2$ solutions have the form $n = 2^l \\cdot p$ for small $p \\in \\{2, 3, 5, 7, 35, 47\\}$ (Cambie's conjecture)",
-      "Even preservation under $g$ (for $n > 2$) constrains the orbit to stay in the even numbers"
+      "**Orbit structure**: $g(n) = n + \\varphi(n)$ produces strictly increasing orbits; for $n = 10$, the orbit $10 \\to 14 \\to 20 \\to 28 \\to 40 \\to \\ldots$ doubles every two steps because $\\varphi(10) + \\varphi(14) = 4 + 6 = 10$",
+      "**Steinerberger's reduction**: The asymptotic condition $g^{k+2}(n) = 2 \\cdot g^k(n)$ for large $k$ is equivalent to the single equation $\\varphi(n) + \\varphi(n + \\varphi(n)) = n$, transforming dynamics into elementary arithmetic",
+      "**Multi-ratio phenomenon**: Cambie found solutions with ratios 3 and 4 (not just doubling), revealing that the set $\\{c : \\exists n, r,\\, g^{k+r}(n) = c \\cdot g^k(n)\\}$ is larger than $\\{2\\}$",
+      "**Structural rigidity**: All known $r = 2$ solutions have the form $n = 2^l \\cdot p$ for small primes $p \\in \\{2, 3, 5, 7, 35, 47\\}$ (Cambie's conjecture), suggesting the solution set is highly constrained",
+      "**Parity constraint**: Even preservation under $g$ (for $n > 2$) via $\\varphi(n)$ being even restricts orbits to even numbers, a structural constraint from Mathlib's `Nat.totient_even`"
     ]
   },
   "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and References",
+      "startLine": 1,
+      "endLine": 17,
+      "summary": "Module docstring stating the problem: characterize $(n, r)$ with $g^{k+r}(n) = 2 \\cdot g^k(n)$. References Erdős--Graham (1980) and Steinerberger (2025). Imports `Mathlib.Data.Nat.Totient`, `Mathlib.Data.Nat.Basic`, `Mathlib.Order.Filter.Basic`, `Mathlib.Tactic`."
+    },
     {
       "id": "iteration-function",
       "title": "The Iteration Function",
       "startLine": 19,
       "endLine": 29,
-      "summary": "Defines `totientStep` $g(n) = n + \\varphi(n)$ and `iteratedTotientStep` $g^k(n)$ by recursion on $k$."
+      "summary": "Defines `totientStep` $g(n) = n + \\varphi(n)$ and `iteratedTotientStep` $g^k(n)$ by recursion: $g^0(n) = n$, $g^{k+1}(n) = g(g^k(n))$."
     },
     {
       "id": "doubling-relation",
       "title": "The Doubling Relation",
       "startLine": 31,
       "endLine": 38,
-      "summary": "Defines `DoublingRelation n r`: $g^{k+r}(n) = 2 \\cdot g^k(n)$ for all sufficiently large $k$."
+      "summary": "Defines `DoublingRelation n r`: $\\exists K,\\, \\forall k \\geq K,\\, g^{k+r}(n) = 2 \\cdot g^k(n)$. Uses existential quantification over the transient period $K$."
     },
     {
       "id": "conjecture",
       "title": "The Conjecture",
       "startLine": 40,
       "endLine": 50,
-      "summary": "`ErdosProblem411`: characterize all $(n, r)$ with the doubling property. Formalized as the existence of a nonempty set $S$ capturing all solutions."
+      "summary": "`ErdosProblem411`: characterize all $(n, r)$ with the doubling property. Formalized as $\\exists S \\subseteq \\mathbb{N} \\times \\mathbb{N}$ capturing all solutions with $S \\neq \\emptyset$."
     },
     {
       "id": "known-solutions",
       "title": "Known Solutions",
       "startLine": 52,
       "endLine": 73,
-      "summary": "Axiomatized: $n = 10, 94$ for $r = 2$; Cambie's ratio-3 ($n = 738$, $r = 4$) and ratio-4 ($n = 148646, 4325798$, $r = 4$) solutions."
+      "summary": "Axiomatized solutions: $n = 10, 94$ for $r = 2$; `GeneralRatioRelation` definition; Cambie's ratio-3 ($n = 738$, $r = 4$) and ratio-4 ($n = 148646, 4325798$, $r = 4$) solutions."
     },
     {
       "id": "steinerberger-reduction",
       "title": "Steinerberger's Reduction",
       "startLine": 75,
       "endLine": 83,
-      "summary": "The $r = 2$ case is equivalent to $\\varphi(n) + \\varphi(n + \\varphi(n)) = n$, reducing an asymptotic condition to a finite check."
+      "summary": "Axiomatized equivalence: $\\text{DoublingRelation}(n, 2) \\iff \\varphi(n) + \\varphi(n + \\varphi(n)) = n$. Reduces asymptotic dynamics to a single finite equation (Steinerberger 2025)."
     },
     {
       "id": "structural-properties",
       "title": "Structural Properties",
       "startLine": 85,
       "endLine": 109,
-      "summary": "Even preservation under $g$ (proved via `Nat.totient_even`), Cambie's conjecture on the form $n = 2^l \\cdot p$, and monotonicity $g(n) \\geq n$."
+      "summary": "Proved: even preservation $2 \\mid n \\wedge n > 2 \\implies 2 \\mid g(n)$ via `Nat.totient_even`. Cambie's conjecture: $r = 2$ solutions have form $n = 2^l \\cdot p$, $p \\in \\{2, 3, 5, 7, 35, 47\\}$. Monotonicity: $g(n) \\geq n$ by `omega`."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #411 asks for all $(n, r)$ such that iterating $g(n) = n + \\varphi(n)$ satisfies $g^{k+r}(n) = 2 \\cdot g^k(n)$ for large $k$. Solutions are known for $r = 2$ ($n = 10, 94$) and for general ratios (Cambie). Steinerberger's 2025 reduction simplifies the $r = 2$ case to a single equation. The problem remains open.",
-    "implications": "A full characterization would reveal deep structure in the arithmetic dynamics of the totient function and its interaction with addition. The connection between multiplicative properties of $\\varphi$ and the additive iteration $g$ is a fundamental question in number theory.",
+    "summary": "Erdős Problem #411 asks for all $(n, r)$ such that iterating $g(n) = n + \\varphi(n)$ satisfies $g^{k+r}(n) = 2 \\cdot g^k(n)$ for large $k$. Solutions are known for $r = 2$ ($n = 10, 94$) and for general ratios 3 and 4 (Cambie). Steinerberger's 2025 reduction simplifies the $r = 2$ case to a single finitely-checkable equation. The formalization axiomatizes 6 known solutions, proves 2 structural properties, and states the full open problem.",
+    "implications": "A full characterization would reveal deep structure in the arithmetic dynamics of the totient function and its interaction with addition. The connection between the multiplicative nature of $\\varphi$ and the additive iteration $g(n) = n + \\varphi(n)$ is fundamental. The multi-ratio phenomenon discovered by Cambie suggests the problem is part of a richer classification of growth rates in arithmetic dynamical systems.",
     "openQuestions": [
-      "Are there finitely or infinitely many $(n, r)$ with the doubling property?",
+      "Are there finitely or infinitely many $(n, r)$ with the doubling property? Cambie's conjecture would give infinitely many (all $2^l \\cdot p$ for each valid $p$)",
       "Does Cambie's conjecture ($n = 2^l \\cdot p$ for small $p$) hold for all $r = 2$ solutions?",
-      "What ratios $c$ besides 2, 3, 4 admit solutions to $g^{k+r}(n) = c \\cdot g^k(n)$?",
-      "Can Steinerberger's reduction be extended to $r > 2$?"
+      "What ratios $c$ besides 2, 3, 4 admit solutions to $g^{k+r}(n) = c \\cdot g^k(n)$? Is the set of admissible ratios finite?",
+      "Can Steinerberger's reduction technique (from asymptotic dynamics to finite equation) be extended to $r > 2$ or general ratios $c$?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-410",
+      "relationship": "sibling",
+      "description": "Both iterate arithmetic functions (φ vs σ) and study growth rates; #410 asks if $\\lim_{k \\to \\infty} \\sigma_k(n)^{1/k} = \\infty$"
+    },
+    {
+      "targetId": "erdos-412",
+      "relationship": "sibling",
+      "description": "Both study orbit dynamics of arithmetic function iterations; #412 asks whether iterated σ-sequences eventually merge"
+    },
+    {
+      "targetId": "erdos-413",
+      "relationship": "sibling",
+      "description": "Both study iterations $n \\mapsto n + f(n)$; #413 uses $f = \\omega$ (distinct prime factors) instead of $f = \\varphi$"
+    },
+    {
+      "targetId": "erdos-414",
+      "relationship": "sibling",
+      "description": "Both study arithmetic function iteration dynamics; #414 uses $h(n) = n + \\tau(n)$ and asks about orbit merging"
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "uses",
+      "description": "The foundational theorem $a^{\\varphi(n)} \\equiv 1 \\pmod{n}$ underlies the properties of $\\varphi$ used throughout #411"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add `leanFile` metadata (109 lines, 6 axioms, 2 theorems, 6 definitions)
- Add 5 `crossReferences` to sibling problems erdos-410..414 and euler-totient
- Fix annotation types: `context`→`concept`, `axiom`→`theorem`, `conjecture`→`concept`
- Normalize `mathContext` to LaTeX strings, add `prerequisites` to all 14 annotations
- Deepen `historicalContext` with Steinerberger/Cambie full names, #410-415 cluster context
- Add `date`, `dateAdded`, `mathlib_version` fields
- Add header section covering imports (lines 1-17)

## Test plan
- [x] `pnpm annotations:build` passes (no warnings from erdos-411)

🤖 Generated with [Claude Code](https://claude.com/claude-code)