### PR TITLE
enrich(erdos-419): normalize mathContext, fix types, add leanFile path

### DIFF
--- a/src/data/proofs/erdos-419/meta.json
+++ b/src/data/proofs/erdos-419/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Graham-Ivić-Pomerance (1996), Sawhney (rediscovery)",
     "sourceUrl": "https://erdosproblems.com/419",
     "date": "1996",
-    "status": "complete",
+    "status": "enhanced",
     "proofRepoPath": "Proofs/Erdos419Problem.lean",
     "tags": [
       "erdos",
@@ -26,7 +26,7 @@
     "erdosProblemStatus": "solved",
     "dateAdded": "2026-01-22",
     "dateUpdated": "2026-02-12",
-    "mathlib_version": "4.15.0",
+    "mathlib_version": "4.24.0",
     "mathlibDependencies": [
       {
         "theorem": "Nat.divisors",
@@ -91,6 +91,7 @@
     ]
   },
   "leanFile": {
+    "path": "Proofs/Erdos419Problem.lean",
     "imports": [
       "Mathlib.NumberTheory.Divisors",
       "Mathlib.NumberTheory.ArithmeticFunction",
@@ -101,9 +102,15 @@
     "opens": ["Nat", "ArithmeticFunction"],
     "namespace": "Erdos419",
     "lineCount": 252,
+    "mainTheorems": [
+      "sawhney_characterization", "limit_set_properties", "erdos_419_summary"
+    ],
+    "mainDefinitions": [
+      "tau", "factorialDivisorRatio", "padicValFactorial", "limitPointSet"
+    ],
     "axiomCount": 21,
     "theoremCount": 3,
-    "definitionCount": 4
+    "sorryCount": 0
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary
- Converted all `mathContext` from `{latex, description}` objects to simple LaTeX strings
- Fixed annotation type `context` → `concept` for intro annotation
- Fixed annotation type `axiom` → `theorem` for 6 axiom-line annotations (closest valid type)
- Added `path` and `mainTheorems`/`mainDefinitions`/`sorryCount` to `leanFile` object
- Updated `mathlib_version` from 4.15.0 to 4.24.0
- Updated status to `enhanced`
- Added `relatedConcepts` and `prerequisites` to all annotations

## Test plan
- [x] JSON validation passes
- [x] `pnpm annotations:build` passes (non-strict mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)