### PR TITLE
enrich(erdos-462): normalize mathContext format, fix annotation types, add missing fields

### DIFF
--- a/src/data/proofs/erdos-462/annotations.json
+++ b/src/data/proofs/erdos-462/annotations.json
@@ -2,18 +2,17 @@
   {
     "id": "erdos-462-header",
     "proofId": "erdos-462",
-    "type": "context",
+    "type": "concept",
     "range": {
       "startLine": 1,
       "endLine": 13
     },
     "title": "Problem Background",
-    "content": "Erdős Problem 462 asks about the distribution of $\\sum p(n)/n$ in short intervals of length $\\sqrt{x} \\cdot (\\log x)^2$. The global sum over composites $n < x$ satisfies $\\sum_{n < x,\\, n \\text{ composite}} p(n)/n \\sim c \\cdot \\sqrt{x}/(\\log x)^2$. The conjecture asks whether this sum is equidistributed on its natural scale. From Erdős–Graham (1980), p.92.",
-    "significance": "essential",
-    "mathContext": {
-      "latex": "\\sum_{\\substack{n < x \\\\ n \\text{ composite}}} \\frac{p(n)}{n} \\sim c \\cdot \\frac{\\sqrt{x}}{(\\log x)^2}",
-      "description": "The global asymptotic established by Alladi and Erdős (1977). The constant c > 0 arises from partial summation over the distribution of least prime factors via the Dickman-de Bruijn ρ-function. The dominant contribution comes from composites with p(n) ≈ √n."
-    }
+    "content": "Erdős Problem 462 asks about the distribution of $\\sum p(n)/n$ in short intervals of length $\\sqrt{x} \\cdot (\\log x)^2$. The global sum over composites $n < x$ satisfies $\\sum_{n < x,\\, n \\text{ composite}} p(n)/n \\sim c \\cdot \\sqrt{x}/(\\log x)^2$. The conjecture asks whether this sum is equidistributed on its natural scale. From Erdős-Graham (1980), p.92.",
+    "significance": "critical",
+    "mathContext": "\\sum_{\\substack{n < x \\\\ n \\text{ composite}}} \\frac{p(n)}{n} \\sim c \\cdot \\frac{\\sqrt{x}}{(\\log x)^2}: The global asymptotic established by Alladi and Erdős (1977). The constant c > 0 arises from partial summation over the distribution of least prime factors via the Dickman-de Bruijn ρ-function. The dominant contribution comes from composites with p(n) ≈ √n.",
+    "relatedConcepts": ["least prime factor", "short interval equidistribution", "Dickman-de Bruijn rho function", "Alladi-Erdős theorem"],
+    "prerequisites": ["prime factorization", "asymptotic analysis", "partial summation", "smooth number distribution"]
   },
   {
     "id": "erdos-462-lpf",
@@ -25,27 +24,25 @@
     },
     "title": "Least Prime Factor Definition",
     "content": "The least prime factor $p(n)$ returns 0 for $n \\leq 1$ and `Nat.minFac n` otherwise. For $n \\geq 2$, $p(n)$ is the smallest prime dividing $n$. For primes, $p(p) = p$; for composites, $p(n) \\leq \\sqrt{n}$.",
-    "significance": "essential",
-    "mathContext": {
-      "latex": "p(n) = \\min\\{q : q \\text{ prime},\\, q \\mid n\\}",
-      "description": "Defined via Nat.minFac with a case split on n ≤ 1 (returns 0 as sentinel). Classifies integers by smooth/rough type: n is y-smooth iff p(n) > y. Noncomputable since Nat.minFac involves trial division."
-    }
+    "significance": "critical",
+    "mathContext": "p(n) = \\min\\{q : q \\text{ prime},\\, q \\mid n\\}: Defined via Nat.minFac with a case split on n ≤ 1 (returns 0 as sentinel). Classifies integers by smooth/rough type: n is y-smooth iff p(n) > y. Noncomputable since Nat.minFac involves trial division.",
+    "relatedConcepts": ["Nat.minFac", "smooth numbers", "rough numbers", "trial division", "sieve of Eratosthenes"],
+    "prerequisites": ["prime numbers", "divisibility", "Nat.minFac API"]
   },
   {
     "id": "erdos-462-lpf-properties",
     "proofId": "erdos-462",
-    "type": "result",
+    "type": "theorem",
     "range": {
       "startLine": 26,
       "endLine": 36
     },
     "title": "Least Prime Factor Properties",
     "content": "Three axiomatized properties for $n \\geq 2$: (1) `leastPrimeFactor_prime`: $p(n)$ is prime. (2) `leastPrimeFactor_dvd`: $p(n) \\mid n$. (3) `leastPrimeFactor_le`: $p(n) \\leq q$ for any prime $q \\mid n$ (minimality). These are all provable from `Nat.minFac_prime`, `Nat.minFac_dvd`, and `Nat.minFac_le`.",
-    "significance": "essential",
-    "mathContext": {
-      "latex": "p(n) \\text{ prime},\\quad p(n) \\mid n,\\quad \\forall q \\text{ prime},\\, q \\mid n \\Rightarrow p(n) \\leq q",
-      "description": "All three properties are provable from Mathlib's Nat.minFac API (good Aristotle candidates). Axiomatized here for simplicity, but could be replaced with direct proofs."
-    }
+    "significance": "key",
+    "mathContext": "p(n) \\text{ prime},\\quad p(n) \\mid n,\\quad \\forall q \\text{ prime},\\, q \\mid n \\Rightarrow p(n) \\leq q: All three properties are provable from Mathlib's Nat.minFac API (good Aristotle candidates). Axiomatized here for simplicity, but could be replaced with direct proofs.",
+    "relatedConcepts": ["Nat.minFac_prime", "Nat.minFac_dvd", "Nat.minFac_le", "prime minimality"],
+    "prerequisites": ["Nat.minFac API", "Nat.Prime definition", "divisibility ordering"]
   },
   {
     "id": "erdos-462-composite-sum",
@@ -57,11 +54,10 @@
     },
     "title": "Composite Sum Definition",
     "content": "Defines `compositeSum(x) = \\sum_{n=2}^{x-1} [n \\text{ composite}] \\cdot p(n)/n`. Sums over `Finset.Icc 2 (x-1)`, filtering out primes by setting their contribution to 0. This captures the global behavior: the sum over composites grows as $\\Theta(\\sqrt{x}/(\\log x)^2)$.",
-    "significance": "essential",
-    "mathContext": {
-      "latex": "S(x) = \\sum_{\\substack{2 \\leq n < x \\\\ n \\text{ composite}}} \\frac{p(n)}{n}",
-      "description": "Conditional summation filtering primes via if-then-else in the summand. Primes contribute 0 since p(prime)/prime = 1 is uninteresting. The composite-only version isolates the number-theoretically interesting behavior."
-    }
+    "significance": "critical",
+    "mathContext": "S(x) = \\sum_{\\substack{2 \\leq n < x \\\\ n \\text{ composite}}} \\frac{p(n)}{n}: Conditional summation filtering primes via if-then-else in the summand. Primes contribute 0 since p(prime)/prime = 1 is uninteresting. The composite-only version isolates the number-theoretically interesting behavior.",
+    "relatedConcepts": ["Finset.Icc", "conditional summation", "prime filtering", "composite number enumeration"],
+    "prerequisites": ["Finset summation", "prime testing", "least prime factor definition"]
   },
   {
     "id": "erdos-462-interval-sum",
@@ -73,48 +69,45 @@
     },
     "title": "Interval Sum Definition",
     "content": "Defines `intervalSum(a, b) = \\sum_{n=a}^{b} p(n)/n` over `Finset.Icc a b`. Unlike `compositeSum`, this includes primes (for which $p(n)/n = 1$). The conjecture asks whether this sum is bounded below on intervals of the natural length scale.",
-    "significance": "essential",
-    "mathContext": {
-      "latex": "I(a,b) = \\sum_{n=a}^{b} \\frac{p(n)}{n}",
-      "description": "Direct summation over a closed interval including all integers. For n ≤ 1, p(n) = 0 so contribution is 0. For primes, p(n)/n = 1. Including primes (unlike compositeSum) is a design choice since their positive contributions help the lower bound."
-    }
+    "significance": "key",
+    "mathContext": "I(a,b) = \\sum_{n=a}^{b} \\frac{p(n)}{n}: Direct summation over a closed interval including all integers. For n ≤ 1, p(n) = 0 so contribution is 0. For primes, p(n)/n = 1. Including primes (unlike compositeSum) is a design choice since their positive contributions help the lower bound.",
+    "relatedConcepts": ["Finset.Icc", "interval summation", "prime contribution", "short interval analysis"],
+    "prerequisites": ["Finset.Icc summation", "least prime factor definition", "real number division"]
   },
   {
     "id": "erdos-462-asymptotic",
     "proofId": "erdos-462",
-    "type": "result",
+    "type": "theorem",
     "range": {
       "startLine": 53,
       "endLine": 59
     },
     "title": "Known Asymptotic: $\\Theta(\\sqrt{x}/(\\log x)^2)$",
     "content": "The composite sum satisfies $c_1 \\cdot \\sqrt{x}/(\\log x)^2 \\leq S(x) \\leq c_2 \\cdot \\sqrt{x}/(\\log x)^2$ for constants $0 < c_1 \\leq c_2$ and all $x \\geq x_0$. This two-sided bound establishes the growth rate and motivates the interval length $C\\sqrt{x}(\\log x)^2$ in the conjecture.",
-    "significance": "essential",
-    "mathContext": {
-      "latex": "S(x) = \\Theta\\!\\left(\\frac{\\sqrt{x}}{(\\log x)^2}\\right)",
-      "description": "The proof uses Abel summation over the distribution of p(n). The contribution from composites with p(n) = q is approximately (1/q) · Ψ(x/q, q)/(x/q), where Ψ counts smooth numbers. Summing over primes q ≤ √x gives the √x/(log x)² behavior."
-    }
+    "significance": "critical",
+    "mathContext": "S(x) = \\Theta\\!\\left(\\frac{\\sqrt{x}}{(\\log x)^2}\\right): The proof uses Abel summation over the distribution of p(n). The contribution from composites with p(n) = q is approximately (1/q) · Ψ(x/q, q)/(x/q), where Ψ counts smooth numbers. Summing over primes q ≤ √x gives the √x/(log x)² behavior.",
+    "relatedConcepts": ["Abel summation", "smooth number counting function Ψ", "Theta notation", "two-sided asymptotic bounds"],
+    "prerequisites": ["Alladi-Erdős 1977 result", "smooth number estimates", "Abel summation formula", "prime number theorem"]
   },
   {
     "id": "erdos-462-conjecture",
     "proofId": "erdos-462",
-    "type": "conjecture",
+    "type": "concept",
     "range": {
       "startLine": 63,
       "endLine": 70
     },
     "title": "Main Conjecture: Short Interval Equidistribution",
     "content": "There exist $C > 0$ and $\\delta > 0$ such that $\\sum_{x \\leq n \\leq x + C\\sqrt{x}(\\log x)^2} p(n)/n \\geq \\delta$ for all sufficiently large $x$. This asks whether the least prime factor sum is equidistributed on its natural scale: intervals of length $\\sqrt{x}(\\log x)^2$ should capture a bounded-below fraction of the global sum.",
-    "significance": "essential",
-    "mathContext": {
-      "latex": "\\exists C, \\delta > 0,\\, \\exists x_0,\\, \\forall x \\geq x_0 : \\sum_{x \\leq n \\leq x + C\\sqrt{x}(\\log x)^2} \\frac{p(n)}{n} \\geq \\delta",
-      "description": "Existential statement with ⌊·⌋₊ (Nat floor) for the interval endpoint. Asserts no anomalously empty intervals exist at the natural scale. Maier (1985) showed such equidistribution can fail for prime counting at fine scales, but the coarser scale here makes it more plausible."
-    }
+    "significance": "critical",
+    "mathContext": "\\exists C, \\delta > 0,\\, \\exists x_0,\\, \\forall x \\geq x_0 : \\sum_{x \\leq n \\leq x + C\\sqrt{x}(\\log x)^2} \\frac{p(n)}{n} \\geq \\delta: Existential statement with ⌊·⌋₊ (Nat floor) for the interval endpoint. Asserts no anomalously empty intervals exist at the natural scale. Maier (1985) showed such equidistribution can fail for prime counting at fine scales, but the coarser scale here makes it more plausible.",
+    "relatedConcepts": ["Maier's theorem", "short interval estimates", "equidistribution", "Nat.floor"],
+    "prerequisites": ["compositeSum asymptotic", "short interval analysis", "Maier phenomenon", "existential quantification in Lean 4"]
   },
   {
     "id": "erdos-462-prime-self",
     "proofId": "erdos-462",
-    "type": "result",
+    "type": "theorem",
     "range": {
       "startLine": 74,
       "endLine": 76
@@ -122,15 +115,14 @@
     "title": "Least Prime Factor of a Prime",
     "content": "For a prime $p$, $p(p) = p$ — the least prime factor of a prime is itself. Axiomatized; provable from `Nat.Prime.minFac_eq`.",
     "significance": "supporting",
-    "mathContext": {
-      "latex": "p \\text{ prime} \\implies p(p) = p",
-      "description": "Direct from Nat.Prime.minFac_eq. Good Aristotle candidate — provable with simp [leastPrimeFactor, Nat.Prime.minFac_eq hp]."
-    }
+    "mathContext": "p \\text{ prime} \\implies p(p) = p: Direct from Nat.Prime.minFac_eq. Good Aristotle candidate — provable with simp [leastPrimeFactor, Nat.Prime.minFac_eq hp].",
+    "relatedConcepts": ["Nat.Prime.minFac_eq", "prime self-divisibility", "fixed point of p(n)"],
+    "prerequisites": ["Nat.Prime definition", "Nat.minFac API"]
   },
   {
     "id": "erdos-462-ge-two",
     "proofId": "erdos-462",
-    "type": "result",
+    "type": "theorem",
     "range": {
       "startLine": 78,
       "endLine": 80
@@ -138,25 +130,23 @@
     "title": "Lower Bound: $p(n) \\geq 2$",
     "content": "For $n \\geq 2$, the least prime factor satisfies $p(n) \\geq 2$. This is immediate since the smallest prime is 2. Bounds individual terms in the sum: $p(n)/n \\geq 2/n$.",
     "significance": "supporting",
-    "mathContext": {
-      "latex": "n \\geq 2 \\implies p(n) \\geq 2",
-      "description": "Every prime is ≥ 2 (Nat.Prime.two_le), and p(n) is prime for n ≥ 2. Provides the lower bound on per-term contributions to the sum."
-    }
+    "mathContext": "n \\geq 2 \\implies p(n) \\geq 2: Every prime is ≥ 2 (Nat.Prime.two_le), and p(n) is prime for n ≥ 2. Provides the lower bound on per-term contributions to the sum.",
+    "relatedConcepts": ["Nat.Prime.two_le", "smallest prime", "summand lower bound"],
+    "prerequisites": ["Nat.Prime.two_le", "leastPrimeFactor_prime"]
   },
   {
     "id": "erdos-462-sqrt-bound",
     "proofId": "erdos-462",
-    "type": "result",
+    "type": "theorem",
     "range": {
       "startLine": 82,
       "endLine": 84
     },
     "title": "Upper Bound: $p(n) \\leq \\sqrt{n}$ for Composites",
     "content": "For composite $n \\geq 2$, $p(n) \\leq \\sqrt{n}$. This is because a composite $n$ has a factor $\\leq \\sqrt{n}$, and the least prime factor is the smallest such factor. This bounds individual terms: $p(n)/n \\leq 1/\\sqrt{n}$ for composites, explaining why the sum converges slowly.",
-    "significance": "essential",
-    "mathContext": {
-      "latex": "n \\geq 2,\\, n \\text{ composite} \\implies p(n) \\leq \\sqrt{n}",
-      "description": "Standard trial division bound: composite n = ab with 1 < a ≤ b implies a ≤ √n. Stated in ℝ using (n : ℝ)^(1/2) to avoid integer truncation. The per-term bound p(n)/n ≤ 1/√n explains the √x factor in the global asymptotic."
-    }
+    "significance": "key",
+    "mathContext": "n \\geq 2,\\, n \\text{ composite} \\implies p(n) \\leq \\sqrt{n}: Standard trial division bound: composite n = ab with 1 < a ≤ b implies a ≤ √n. Stated in ℝ using (n : ℝ)^(1/2) to avoid integer truncation. The per-term bound p(n)/n ≤ 1/√n explains the √x factor in the global asymptotic.",
+    "relatedConcepts": ["trial division", "composite factorization", "square root bound", "summand upper bound"],
+    "prerequisites": ["composite number definition", "integer square root", "real number exponentiation"]
   }
 ]

--- a/src/data/proofs/erdos-462/meta.json
+++ b/src/data/proofs/erdos-462/meta.json
@@ -23,6 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/462",
     "erdosProblemStatus": "open",
     "dateAdded": "2026-01-15",
+    "dateUpdated": "2026-02-14",
     "mathlib_version": "4.15.0",
     "mathlibDependencies": [
       {
@@ -66,6 +67,7 @@
     ]
   },
   "leanFile": {
+    "path": "Proofs/Erdos462Problem.lean",
     "imports": [
       "Mathlib.Data.Nat.Prime.Basic",
       "Mathlib.Data.Real.Basic",


### PR DESCRIPTION
## Summary
- Flattened `mathContext` from object `{latex, description}` to string format on all 10 annotations
- Fixed invalid `significance` values (`essential` → `critical`/`key`/`supporting`) on all annotations
- Fixed invalid annotation types (`result` → `theorem`, `conjecture` → `concept`) on 5 annotations
- Added `relatedConcepts` and `prerequisites` arrays to all 10 annotations
- Added `leanFile.path` and `dateUpdated` fields to meta.json

## Quality improvements
- All annotations now have consistent string-format mathContext
- All annotations have valid types from the schema (`theorem`, `definition`, `concept`, `insight`)
- All annotations have valid significance values (`critical`, `key`, `supporting`)
- Full field coverage: mathContext, significance, relatedConcepts, prerequisites on every annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)