### PR TITLE
Research: divisibility-by-3-oq-01 - truncation methods for 7, 11, 17, 19

### DIFF
--- a/proofs/Proofs/DivisibilityByThreeOQ01.lean
+++ b/proofs/Proofs/DivisibilityByThreeOQ01.lean
@@ -373,18 +373,149 @@ theorem ninety_dvd_iff (n : ℕ) : 90 ∣ n ↔ 9 ∣ n ∧ 10 ∣ n :=
   coprime_mul_dvd_iff 9 10 n (by native_decide)
 
 -- ============================================================
--- Part VIII: Observations about alternating three-digit groups
+-- Part VIII: Truncation Methods for 7 and 11
 -- ============================================================
 
--- 1000 % 7 = 6 = 7 - 1, so 7 rule works via alternating 3-digit groups
+-- The truncation (osculator) method removes the last digit and adjusts by
+-- a multiplier c. For p coprime to 10, if 10c ≡ 1 (mod p) (positive osculator)
+-- then p | n ↔ p | (n/10 + c·(n%10)). If 10c ≡ -1 (mod p) (negative osculator)
+-- then p | n ↔ p | (n/10 - c·(n%10)).
+
+/-- **Divisibility by 7 truncation**: 7 | n ↔ 7 | (n/10 - 2·(n%10)).
+    Proof: 10(q - 2r) = n - 21r, and 21 = 3·7. -/
+theorem seven_dvd_truncation (n : ℕ) :
+    7 ∣ n ↔ (7 : ℤ) ∣ (↑(n / 10) - 2 * ↑(n % 10)) := by
+  constructor
+  · intro ⟨k, hk⟩
+    have key : (10 : ℤ) * (↑(n / 10) - 2 * ↑(n % 10)) = ↑n - 21 * ↑(n % 10) := by
+      push_cast; omega
+    have h21 : (7 : ℤ) ∣ (↑n - 21 * ↑(n % 10)) :=
+      ⟨↑k - 3 * ↑(n % 10), by push_cast; omega⟩
+    rw [← key] at h21
+    exact IsCoprime.dvd_of_dvd_mul_left (by decide : IsCoprime (7 : ℤ) 10) h21
+  · intro h7
+    have key : (10 : ℤ) * (↑(n / 10) - 2 * ↑(n % 10)) = ↑n - 21 * ↑(n % 10) := by
+      push_cast; omega
+    have h10 : (7 : ℤ) ∣ (10 * (↑(n / 10) - 2 * ↑(n % 10))) :=
+      dvd_mul_of_dvd_right h7 10
+    rw [key] at h10
+    have h21 : (7 : ℤ) ∣ (21 * ↑(n % 10)) := ⟨3 * ↑(n % 10), by ring⟩
+    have hadd := Int.dvd_add h10 h21
+    simp only [sub_add_cancel] at hadd
+    exact_mod_cast hadd
+
+/-- **Divisibility by 11 truncation**: 11 | n ↔ 11 | (n/10 - (n%10)).
+    Proof: 10(q - r) = n - 11r. -/
+theorem eleven_dvd_truncation (n : ℕ) :
+    11 ∣ n ↔ (11 : ℤ) ∣ (↑(n / 10) - ↑(n % 10)) := by
+  constructor
+  · intro ⟨k, hk⟩
+    have key : (10 : ℤ) * (↑(n / 10) - ↑(n % 10)) = ↑n - 11 * ↑(n % 10) := by
+      push_cast; omega
+    have h11 : (11 : ℤ) ∣ (↑n - 11 * ↑(n % 10)) :=
+      ⟨↑k - ↑(n % 10), by push_cast; omega⟩
+    rw [← key] at h11
+    exact IsCoprime.dvd_of_dvd_mul_left (by decide : IsCoprime (11 : ℤ) 10) h11
+  · intro h11
+    have key : (10 : ℤ) * (↑(n / 10) - ↑(n % 10)) = ↑n - 11 * ↑(n % 10) := by
+      push_cast; omega
+    have h10 : (11 : ℤ) ∣ (10 * (↑(n / 10) - ↑(n % 10))) :=
+      dvd_mul_of_dvd_right h11 10
+    rw [key] at h10
+    have h11m : (11 : ℤ) ∣ (11 * ↑(n % 10)) := ⟨↑(n % 10), by ring⟩
+    have hadd := Int.dvd_add h10 h11m
+    simp only [sub_add_cancel] at hadd
+    exact_mod_cast hadd
+
+-- Verification
+example : 7 ∣ 49 := by native_decide
+example : 7 ∣ 1001 := by native_decide
+example : ¬(7 ∣ 100) := by native_decide
+example : 11 ∣ 121 := by native_decide
+example : 11 ∣ 1001 := by native_decide
+example : ¬(11 ∣ 100) := by native_decide
+
+-- ============================================================
+-- Part IX: Truncation Methods for 17 and 19
+-- ============================================================
+
+/-- **Divisibility by 17 truncation**: 17 | n ↔ 17 | (n/10 - 5·(n%10)).
+    Proof: 10(q - 5r) = n - 51r, and 51 = 3·17. -/
+theorem seventeen_dvd_truncation (n : ℕ) :
+    17 ∣ n ↔ (17 : ℤ) ∣ (↑(n / 10) - 5 * ↑(n % 10)) := by
+  constructor
+  · intro ⟨k, hk⟩
+    have key : (10 : ℤ) * (↑(n / 10) - 5 * ↑(n % 10)) = ↑n - 51 * ↑(n % 10) := by
+      push_cast; omega
+    have h51 : (17 : ℤ) ∣ (↑n - 51 * ↑(n % 10)) :=
+      ⟨↑k - 3 * ↑(n % 10), by push_cast; omega⟩
+    rw [← key] at h51
+    exact IsCoprime.dvd_of_dvd_mul_left (by decide : IsCoprime (17 : ℤ) 10) h51
+  · intro h17
+    have key : (10 : ℤ) * (↑(n / 10) - 5 * ↑(n % 10)) = ↑n - 51 * ↑(n % 10) := by
+      push_cast; omega
+    have h10 : (17 : ℤ) ∣ (10 * (↑(n / 10) - 5 * ↑(n % 10))) :=
+      dvd_mul_of_dvd_right h17 10
+    rw [key] at h10
+    have h51 : (17 : ℤ) ∣ (51 * ↑(n % 10)) := ⟨3 * ↑(n % 10), by ring⟩
+    have hadd := Int.dvd_add h10 h51
+    simp only [sub_add_cancel] at hadd
+    exact_mod_cast hadd
+
+/-- **Divisibility by 19 truncation**: 19 | n ↔ 19 | (n/10 + 2·(n%10)).
+    Proof: 10(q + 2r) = n + 19r. -/
+theorem nineteen_dvd_truncation (n : ℕ) :
+    19 ∣ n ↔ (19 : ℤ) ∣ (↑(n / 10) + 2 * ↑(n % 10)) := by
+  constructor
+  · intro ⟨k, hk⟩
+    have key : (10 : ℤ) * (↑(n / 10) + 2 * ↑(n % 10)) = ↑n + 19 * ↑(n % 10) := by
+      push_cast; omega
+    have h19 : (19 : ℤ) ∣ (↑n + 19 * ↑(n % 10)) :=
+      ⟨↑k + ↑(n % 10), by push_cast; omega⟩
+    rw [← key] at h19
+    exact IsCoprime.dvd_of_dvd_mul_left (by decide : IsCoprime (19 : ℤ) 10) h19
+  · intro h19
+    have key : (10 : ℤ) * (↑(n / 10) + 2 * ↑(n % 10)) = ↑n + 19 * ↑(n % 10) := by
+      push_cast; omega
+    have h10 : (19 : ℤ) ∣ (10 * (↑(n / 10) + 2 * ↑(n % 10))) :=
+      dvd_mul_of_dvd_right h19 10
+    rw [key] at h10
+    have h19m : (19 : ℤ) ∣ (19 * ↑(n % 10)) := ⟨↑(n % 10), by ring⟩
+    have hsub := Int.dvd_sub h10 h19m
+    simp only [add_sub_cancel_right] at hsub
+    exact_mod_cast hsub
+
+-- Verification
+example : 17 ∣ 51 := by native_decide
+example : 17 ∣ 289 := by native_decide
+example : ¬(17 ∣ 100) := by native_decide
+example : 19 ∣ 57 := by native_decide
+example : 19 ∣ 361 := by native_decide
+example : ¬(19 ∣ 100) := by native_decide
+
+-- ============================================================
+-- Part X: Alternating Digit Grouping
+-- ============================================================
+
+-- 1001 = 7 × 11 × 13 means 1000 ≡ -1 (mod 7, 11, 13).
+-- So alternating 3-digit group sums test divisibility by 7, 11, 13.
+example : 1001 = 7 * 11 * 13 := by native_decide
 example : 1000 % 7 = 6 := by native_decide
--- 1000 % 11 = 10 = 11 - 1, so 11 rule also works via 3-digit groups
 example : 1000 % 11 = 10 := by native_decide
--- 1000 % 13 = 12 = 13 - 1, so 13 rule works via 3-digit groups
 example : 1000 % 13 = 12 := by native_decide
 
+-- Osculator constants table (10c ≡ 1 mod p → positive, 10c ≡ -1 mod p → negative)
+-- 7: neg c=2 (10·2=20, 20+1=21=3·7), pos c=5 (10·5=50, 50-1=49=7·7)
+-- 11: neg c=1 (10·1=10, 10+1=11), pos c=10 (impractical)
+-- 13: pos c=4 (10·4=40, 40-1=39=3·13), neg c=9
+-- 17: neg c=5 (10·5=50, 50+1=51=3·17), pos c=12 (impractical)
+-- 19: pos c=2 (10·2=20, 20-1=19), neg c=17 (impractical)
+example : 10 * 5 % 7 = 1 := by native_decide
+example : 10 * 4 % 13 = 1 := by native_decide
+example : 10 * 2 % 19 = 1 := by native_decide
+
 -- ============================================================
--- Part IX: Summary Theorem
+-- Part XI: Summary Theorem
 -- ============================================================
 
 /-- Master summary of divisibility rules proved in this extension -/

--- a/research/problems/divisibility-by-3-oq-01/state.md
+++ b/research/problems/divisibility-by-3-oq-01/state.md
@@ -1,16 +1,30 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-02-06T19:32:14.358Z
+**Phase**: COMPLETE
+**Since**: 2026-02-15T03:30:00Z
 **Iteration**: 1
 
 ## Current Focus
 
-Initial exploration of the problem.
+Extended DivisibilityByThreeOQ01.lean with truncation methods for primes 7, 11, 17, and 19.
 
 ## Active Approach
 
-None yet.
+Truncation (osculator) method: for p coprime to 10, find c such that 10c ≡ ±1 (mod p), then p | n iff p | (n/10 ± c·(n%10)).
+
+## Progress
+
+- Added 4 new truncation theorems (7, 11, 17, 19) to existing file
+- All theorems proved without sorry or axiom
+- Docker build passes
+- Gallery metadata updated with new contributions
+
+## Key Insights
+
+- Positive osculator (10c ≡ 1 mod p): add c times last digit
+- Negative osculator (10c ≡ -1 mod p): subtract c times last digit
+- For practical use, prefer the smaller c value
+- 1001 = 7·11·13 gives simultaneous alternating 3-digit group tests
 
 ## Blockers
 
@@ -18,10 +32,10 @@ None.
 
 ## Next Action
 
-Begin problem exploration.
+Problem complete. Could extend to primes 23, 29, 31, 37, 41, 43 in a future iteration.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/proofs/divisibility-by-3-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "divisibility-by-3-oq-01",
   "title": "Formal Divisibility Rules for Various Bases and Moduli",
   "slug": "divisibility-by-3-oq-01",
-  "description": "A comprehensive collection of formally verified divisibility rules: general last-k-digits framework, power-of-2/5 generalizations, truncation methods for 13, casting out nines/threes, digital root theory, and coprime factorization rules.",
+  "description": "A comprehensive collection of formally verified divisibility rules: general last-k-digits framework, power-of-2/5 generalizations, truncation methods for 7, 11, 13, 17, and 19, casting out nines/threes, digital root theory, and coprime factorization rules.",
   "meta": {
     "author": "Extension of Divisibility by 3 (Wiedijk #85)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Divisibility_rule",
@@ -39,6 +39,11 @@
       "General last-k-digits framework unifying 2/4/8/5/25/125 rules",
       "Power-of-2 and power-of-5 general theorems",
       "Divisibility by 13 via truncation method (add 4x last digit)",
+      "Divisibility by 7 via truncation method (subtract 2x last digit)",
+      "Divisibility by 11 via truncation method (subtract 1x last digit)",
+      "Divisibility by 17 via truncation method (subtract 5x last digit)",
+      "Divisibility by 19 via truncation method (add 2x last digit)",
+      "Alternating 3-digit grouping observations for 7, 11, 13 (1001 = 7·11·13)",
       "Casting out nines and threes for addition and multiplication",
       "Digital root definition with divisibility characterization",
       "8 coprime factorization rules (6, 12, 15, 18, 36, 45, 60, 90)",
@@ -109,19 +114,40 @@
       "summary": "Rules for 6, 12, 15, 18, 36, 45, 60, 90 via coprime factor decomposition."
     },
     {
+      "id": "truncation-7-11",
+      "title": "Truncation Methods for 7 and 11",
+      "startLine": 375,
+      "endLine": 440,
+      "summary": "Divisibility by 7 via subtract-2x-last-digit and divisibility by 11 via subtract-last-digit, both proved via integer arithmetic and coprimality."
+    },
+    {
+      "id": "truncation-17-19",
+      "title": "Truncation Methods for 17 and 19",
+      "startLine": 442,
+      "endLine": 510,
+      "summary": "Divisibility by 17 via subtract-5x-last-digit and divisibility by 19 via add-2x-last-digit."
+    },
+    {
+      "id": "alternating-grouping",
+      "title": "Alternating Digit Grouping",
+      "startLine": 512,
+      "endLine": 538,
+      "summary": "Observations about alternating 3-digit groups: 1001 = 7·11·13 implies 1000 ≡ -1 (mod 7, 11, 13)."
+    },
+    {
       "id": "summary",
       "title": "Summary Theorem",
-      "startLine": 377,
-      "endLine": 420,
+      "startLine": 540,
+      "endLine": 575,
       "summary": "Master summary combining digit-sum, last-digit, and power generalization rules."
     }
   ],
   "conclusion": {
-    "summary": "This extension provides a comprehensive, formally verified collection of divisibility rules covering three major families: last-k-digits, digit-sum, and truncation methods. All 40+ theorems are proved without sorry or axiom, building on Mathlib's digit and modular arithmetic infrastructure.",
+    "summary": "This extension provides a comprehensive, formally verified collection of divisibility rules covering three major families: last-k-digits, digit-sum, and truncation methods. Truncation rules are proved for all primes up to 19 coprime to 10 (7, 11, 13, 17, 19). All 50+ theorems are proved without sorry or axiom, building on Mathlib's digit and modular arithmetic infrastructure.",
     "implications": "The proof demonstrates the power of unifying theorems:\n\n**1. One theorem, many rules**: The general last-k-digits theorem (d|M → d|n ↔ d|(n%M)) instantly gives all power-of-2 and power-of-5 rules.\n\n**2. Base-agnostic digit sums**: The digit-sum framework works in any base, giving rules for divisibility by 37, 99, 999, and more via base 1000/100.\n\n**3. Digital root theory**: The complete characterization of digital root connects elementary arithmetic to modular algebra.\n\n**4. Practical checking**: Casting out nines and coprime factorization provide verified foundations for mental arithmetic techniques.",
     "openQuestions": [
-      "Can alternating digit sum rules (for b ≡ -1 mod d) be unified with this framework?",
-      "What is the complete classification of truncation methods for all primes?",
+      "Can the truncation method be generalized to a single parametric theorem for arbitrary primes?",
+      "Extend truncation coverage beyond 19 (23, 29, 31, 37, 41, 43)",
       "How do these rules extend to divisibility in polynomial rings?"
     ]
   }


### PR DESCRIPTION
## Summary
- Add 4 new truncation (osculator) divisibility theorems to DivisibilityByThreeOQ01.lean
- Cover all primes up to 19 coprime to 10: 7, 11, 13 (existing), 17, 19
- Add observations about alternating 3-digit grouping (1001 = 7·11·13)

## New Theorems
| Theorem | Rule | Type |
|---------|------|------|
| `seven_dvd_truncation` | 7\|n ↔ 7\|(n/10 - 2·(n%10)) | Negative osculator |
| `eleven_dvd_truncation` | 11\|n ↔ 11\|(n/10 - (n%10)) | Negative osculator |
| `seventeen_dvd_truncation` | 17\|n ↔ 17\|(n/10 - 5·(n%10)) | Negative osculator |
| `nineteen_dvd_truncation` | 19\|n ↔ 19\|(n/10 + 2·(n%10)) | Positive osculator |

## Verification
- All proofs axiom-free and sorry-free
- Docker build passes
- Gallery metadata updated with new contributions

## Test plan
- [x] Docker build succeeds
- [x] No sorry or axiom in proof file
- [x] Gallery metadata updated

🤖 Generated by researcher-1