### PR TITLE
enrich(erdos-455): add leanFile, crossReferences, deepen annotations

### DIFF
--- a/src/data/proofs/erdos-455/annotations.json
+++ b/src/data/proofs/erdos-455/annotations.json
@@ -1,90 +1,110 @@
 [
   {
-    "id": "ann-e455-header",
+    "id": "ann-e455-imports",
     "proofId": "erdos-455",
-    "range": { "startLine": 1, "endLine": 26 },
+    "range": { "startLine": 17, "endLine": 26 },
     "type": "concept",
-    "title": "Problem Introduction",
-    "content": "**Erdős Problem #455** asks about prime sequences with non-decreasing gaps. If q₁ < q₂ < ... are primes where each gap is at least as large as the previous, must the sequence grow faster than n²? The partial result by Richter (1976) shows liminf q_n/n² > 0.352.",
-    "mathContext": "We import Mathlib modules for primes, filters, monotonicity, and liminf/limsup. The Filter.atTop framework expresses asymptotic statements like \"for all sufficiently large n\".",
+    "title": "Imports and Namespace",
+    "content": "Imports Mathlib modules for primality (`Nat.Prime`), monotonicity (`StrictMono`), asymptotic filters (`Filter.atTop`), limit inferior (`liminf`/`limsup`), and real exponentiation (`Real.rpow`). Opens the `Filter` namespace for convenient use of `atTop` and `∀ᶠ`.",
+    "mathContext": "Key imports: `Mathlib.Data.Nat.Prime.Basic` provides `Nat.Prime` and `Nat.Prime.two_le`; `Mathlib.Topology.Algebra.Order.LiminfLimsup` provides `liminf` and `limsup` for $\\liminf$ and $\\limsup$ of real-valued sequences; `Mathlib.Order.Filter.AtTopBot.Basic` provides the `atTop` filter for asymptotic statements.",
     "significance": "supporting",
-    "relatedConcepts": ["erdos", "primes", "gaps", "open-problem"]
+    "relatedConcepts": ["Mathlib imports", "Filter.atTop", "liminf", "Nat.Prime"],
+    "prerequisites": ["Lean 4 import system", "Mathlib module structure"]
   },
   {
     "id": "ann-e455-nondecgaps",
     "proofId": "erdos-455",
     "range": { "startLine": 34, "endLine": 37 },
     "type": "definition",
-    "title": "Non-Decreasing Gaps",
-    "content": "**HasNonDecreasingGaps** is the key constraint: for all n, the gap q_{n+1} - q_n must be at least as large as the previous gap q_n - q_{n-1}. This is a discrete convexity condition that forces sequences to spread out increasingly.",
-    "mathContext": "Formally: ∀ n, q(n+1) - q(n) ≥ q(n) - q(n-1). Note that for natural number subtraction, if the gaps shrink, the inequality fails.",
+    "title": "Non-Decreasing Gaps Predicate",
+    "content": "**HasNonDecreasingGaps** is the key constraint: for all $n$, the gap $q(n+1) - q(n)$ must be at least as large as the previous gap $q(n) - q(n-1)$. This is a discrete convexity condition — the second difference $\\Delta^2 q(n) \\geq 0$ — that forces sequences to spread out increasingly.",
+    "mathContext": "Formally: $\\texttt{HasNonDecreasingGaps}(q) :\\equiv \\forall n : \\mathbb{N},\\, q(n+1) - q(n) \\geq q(n) - q(n-1)$. Note that Lean uses truncated natural number subtraction, so when $q(n) > q(n-1)$ (as guaranteed by strict monotonicity), this correctly captures the gap comparison. The condition is equivalent to the discrete second derivative $\\Delta^2 q \\geq 0$.",
     "significance": "critical",
-    "relatedConcepts": ["convexity", "gaps", "sequences"]
+    "relatedConcepts": ["discrete convexity", "second differences", "gap sequences", "truncated subtraction"],
+    "prerequisites": ["natural number arithmetic", "truncated subtraction in Lean"]
   },
   {
     "id": "ann-e455-structure",
     "proofId": "erdos-455",
     "range": { "startLine": 39, "endLine": 45 },
     "type": "definition",
-    "title": "Monotone-Gap Prime Sequence",
-    "content": "**MonotoneGapPrimeSeq** bundles all constraints into a single structure: the sequence must be strictly increasing, all terms must be prime, and the gaps must be non-decreasing. This clean formalization makes stating results precise.",
-    "mathContext": "A Lean 4 structure with fields: seq : ℕ → ℕ, strictMono : StrictMono seq, allPrime : ∀ n, (seq n).Prime, nonDecGaps : HasNonDecreasingGaps seq.",
+    "title": "Monotone-Gap Prime Sequence Structure",
+    "content": "**MonotoneGapPrimeSeq** bundles all constraints into a single Lean 4 structure: the sequence $q : \\mathbb{N} \\to \\mathbb{N}$ must be strictly increasing, all terms must be prime, and the gaps must be non-decreasing. This clean formalization makes stating results about such sequences precise and modular.",
+    "mathContext": "A Lean 4 `structure` with fields: `seq : ℕ → ℕ`, `strictMono : StrictMono seq` (i.e., $i < j \\Rightarrow q(i) < q(j)$), `allPrime : ∀ n, (seq n).Prime`, and `nonDecGaps : HasNonDecreasingGaps seq`. The structure approach allows dot notation like `q.strictMono` and `q.allPrime` in proofs.",
     "significance": "critical",
-    "relatedConcepts": ["structure", "primes", "strictmono"]
+    "relatedConcepts": ["Lean structure", "StrictMono", "Nat.Prime", "bundled constraints"],
+    "prerequisites": ["Lean 4 structures", "StrictMono from Mathlib", "Nat.Prime"]
   },
   {
     "id": "ann-e455-richter",
     "proofId": "erdos-455",
-    "range": { "startLine": 54, "endLine": 69 },
+    "range": { "startLine": 68, "endLine": 69 },
     "type": "theorem",
     "title": "Richter's Lower Bound (1976)",
-    "content": "**Richter proved that liminf q_n/n² > 0.352** for any monotone-gap prime sequence. This shows such sequences must grow at least quadratically. The proof uses prime distribution estimates and appeared in Acta Arithmetica.",
-    "mathContext": "Stated as an axiom because the proof requires the Prime Number Theorem and careful gap analysis not formalized in Mathlib. The bound 0.352 comes from explicit calculations in Richter's paper.",
+    "content": "**Richter (1976)** proved that for any monotone-gap prime sequence, $\\liminf_{n \\to \\infty} q_n / n^2 > 0.352$. This shows such sequences must grow at least quadratically. The proof uses careful analysis of the distribution of primes and appeared in *Acta Arithmetica*.",
+    "mathContext": "Axiomatized as: `axiom richter_lower_bound (q : MonotoneGapPrimeSeq) : liminf (fun n : ℕ => (q.seq n : ℝ) / (n : ℝ) ^ 2) atTop > (0.352 : ℝ)`. The cast `(q.seq n : ℝ)` coerces from $\\mathbb{N}$ to $\\mathbb{R}$ for the division. The `liminf` is taken along the `atTop` filter. Proof requires prime distribution estimates (PNT-strength) not yet in Mathlib.",
     "significance": "critical",
-    "relatedConcepts": ["liminf", "quadratic-growth", "prime-distribution"]
+    "relatedConcepts": ["liminf", "quadratic growth", "prime distribution", "Acta Arithmetica"],
+    "prerequisites": ["liminf definition", "Filter.atTop", "coercion ℕ → ℝ", "prime number theorem"]
   },
   {
     "id": "ann-e455-conjecture",
     "proofId": "erdos-455",
-    "range": { "startLine": 71, "endLine": 88 },
+    "range": { "startLine": 80, "endLine": 88 },
     "type": "theorem",
-    "title": "The Open Conjecture",
-    "content": "**Erdős's full conjecture remains open**: must lim q_n/n² = ∞? While Richter proved the liminf is positive, the question of whether the limit exists and equals infinity is unresolved. This would mean superquadratic growth is required.",
-    "mathContext": "We formalize this as an abstract proposition erdos_455_conjecture and prove it equivalent to: ∀ q : MonotoneGapPrimeSeq, Tendsto (q_n/n²) atTop atTop.",
+    "title": "The Open Conjecture and Equivalence",
+    "content": "**Erdős's full conjecture remains open**: must $\\lim q_n/n^2 = \\infty$? The formalization introduces `erdos_455_conjecture` as an abstract `Prop` and states its equivalence to: for all `MonotoneGapPrimeSeq` $q$, the ratio $q_n/n^2$ tends to infinity via `Tendsto`.",
+    "mathContext": "Two axioms: `erdos_455_conjecture : Prop` (the abstract statement) and `erdos_455_statement : erdos_455_conjecture ↔ ∀ q : MonotoneGapPrimeSeq, Tendsto (fun n : ℕ => (q.seq n : ℝ) / (n : ℝ) ^ 2) atTop atTop`. The `Tendsto f atTop atTop` means $\\forall M,\\, \\exists^\\infty n,\\, f(n) > M$, i.e., $f(n) \\to \\infty$.",
     "significance": "critical",
-    "relatedConcepts": ["open-problem", "tendsto", "superquadratic"]
+    "relatedConcepts": ["open problem", "Tendsto", "superquadratic growth", "Filter.atTop"],
+    "prerequisites": ["Tendsto from Mathlib", "Filter.atTop", "MonotoneGapPrimeSeq"]
   },
   {
     "id": "ann-e455-consequence",
     "proofId": "erdos-455",
-    "range": { "startLine": 96, "endLine": 103 },
+    "range": { "startLine": 102, "endLine": 103 },
     "type": "theorem",
     "title": "Quadratic Growth Consequence",
-    "content": "**As a consequence of Richter's bound**, we know q_n ≥ c·n² for some c > 0 and all sufficiently large n. This follows from the definition of liminf: if liminf > 0.352, then eventually the ratio stays above 0.35.",
-    "mathContext": "Stated as: ∃ c > 0, ∀ᶠ n in atTop, q_n ≥ c·n². The \"eventually\" quantifier ∀ᶠ n in atTop means \"for all but finitely many n\".",
-    "significance": "supporting",
-    "relatedConcepts": ["eventually", "lower-bound", "quadratic"]
+    "content": "As a consequence of Richter's bound, we know $q_n \\geq c \\cdot n^2$ for some $c > 0$ and all sufficiently large $n$. This follows from the definition of liminf: if $\\liminf > 0.352$, then eventually the ratio stays above $0.35$.",
+    "mathContext": "Axiomatized as: `axiom growth_at_least_quadratic (q : MonotoneGapPrimeSeq) : ∃ c : ℝ, c > 0 ∧ ∀ᶠ n in atTop, (q.seq n : ℝ) ≥ c * (n : ℝ) ^ 2`. The `∀ᶠ n in atTop` is Mathlib's notation for \"for all sufficiently large $n$\", formally `{n | P n} ∈ atTop`.",
+    "significance": "key",
+    "relatedConcepts": ["eventually filter", "∀ᶠ notation", "quadratic lower bound"],
+    "prerequisites": ["Filter.Eventually", "richter_lower_bound", "liminf properties"]
   },
   {
-    "id": "ann-e455-structural",
+    "id": "ann-e455-gaps-pos",
     "proofId": "erdos-455",
-    "range": { "startLine": 111, "endLine": 124 },
+    "range": { "startLine": 111, "endLine": 114 },
     "type": "theorem",
-    "title": "Structural Properties",
-    "content": "**Basic structural theorems**: gaps are always positive (from strict monotonicity), and all primes in the sequence are at least 2 (from primality). These elementary facts help build intuition about these sequences.",
-    "mathContext": "gaps_pos uses q.strictMono; first_prime_ge_two and all_ge_two use Nat.Prime.two_le from Mathlib.",
+    "title": "Positive Gaps from Strict Monotonicity",
+    "content": "**gaps_pos**: For a strictly increasing sequence, the gaps are always positive: $q(n+1) > q(n)$ for all $n$. The proof is a one-liner using `q.strictMono (Nat.lt_succ_self n)`.",
+    "mathContext": "Proved: `theorem gaps_pos (q : MonotoneGapPrimeSeq) (n : ℕ) : q.seq (n + 1) > q.seq n := q.strictMono (Nat.lt_succ_self n)`. Uses `StrictMono` which gives $i < j \\Rightarrow f(i) < f(j)$, and `Nat.lt_succ_self n : n < n + 1$.",
     "significance": "supporting",
-    "relatedConcepts": ["primes", "monotonicity", "basic-facts"]
+    "relatedConcepts": ["StrictMono", "Nat.lt_succ_self", "positive gaps"],
+    "prerequisites": ["StrictMono", "Nat.lt_succ_self"]
   },
   {
-    "id": "ann-e455-restrictive",
+    "id": "ann-e455-ge-two",
     "proofId": "erdos-455",
-    "range": { "startLine": 126, "endLine": 150 },
-    "type": "concept",
-    "title": "Why the Condition is Restrictive",
-    "content": "**The consecutive primes 2, 3, 5, 7, 11, 13, ... do NOT satisfy this condition!** Their gaps are 1, 2, 2, 4, 2, ... and since 2 < 4, the gap after 13 violates monotonicity. Monotone-gap prime sequences must be carefully chosen subsequences.",
-    "mathContext": "The alternative characterization nonDecGaps_alt shows the condition is equivalent to: for all n ≥ 1, the (n+1)th gap is at least the nth gap.",
+    "range": { "startLine": 116, "endLine": 124 },
+    "type": "theorem",
+    "title": "All Terms at Least 2",
+    "content": "**first_prime_ge_two** and **all_ge_two**: Every prime $p$ satisfies $p \\geq 2$ (the smallest prime is 2). Applied to the sequence, this gives $q_n \\geq 2$ for all $n$.",
+    "mathContext": "Proved using `Nat.Prime.two_le` from Mathlib: `theorem all_ge_two (q : MonotoneGapPrimeSeq) (n : ℕ) : q.seq n ≥ 2 := Nat.Prime.two_le (q.allPrime n)`. The key Mathlib fact is `Nat.Prime.two_le : Nat.Prime p → p ≥ 2`.",
     "significance": "supporting",
-    "relatedConcepts": ["counterexample", "prime-gaps", "restriction"]
+    "relatedConcepts": ["Nat.Prime.two_le", "primality lower bound"],
+    "prerequisites": ["Nat.Prime", "Nat.Prime.two_le"]
+  },
+  {
+    "id": "ann-e455-alt",
+    "proofId": "erdos-455",
+    "range": { "startLine": 139, "endLine": 151 },
+    "type": "theorem",
+    "title": "Alternative Characterization of Non-Decreasing Gaps",
+    "content": "**nonDecGaps_alt**: The non-decreasing gaps condition is equivalent to the same statement restricted to $n \\geq 1$. The $n = 0$ case is vacuously true because `simp` closes it (the natural number subtraction $q(0) - q(0-1)$ simplifies).",
+    "mathContext": "Proved: `theorem nonDecGaps_alt (q : ℕ → ℕ) (hq : StrictMono q) : HasNonDecreasingGaps q ↔ ∀ n ≥ 1, q (n + 1) - q n ≥ q n - q (n - 1)`. The proof splits into two directions via `constructor`. The reverse direction handles $n = 0$ separately using `by_cases hn : n ≥ 1` and `simp [hn]`.",
+    "significance": "supporting",
+    "relatedConcepts": ["iff equivalence", "by_cases", "simp", "base case handling"],
+    "prerequisites": ["HasNonDecreasingGaps", "StrictMono", "Lean tactic mode"]
   }
 ]

--- a/src/data/proofs/erdos-455/meta.json
+++ b/src/data/proofs/erdos-455/meta.json
@@ -3,6 +3,7 @@
   "title": "Erdős Problem #455: Monotone Prime Gap Sequences",
   "slug": "erdos-455",
   "description": "If primes q₁ < q₂ < ... have non-decreasing gaps, must q_n grow faster than n²?",
+  "leanFile": "Proofs/Erdos455Problem.lean",
   "meta": {
     "author": "Richter (1976, partial); Open",
     "sourceUrl": "https://erdosproblems.com/455",
@@ -21,6 +22,7 @@
     "erdosNumber": 455,
     "erdosUrl": "https://erdosproblems.com/455",
     "erdosProblemStatus": "open",
+    "dateAdded": "2026-01-22",
     "mathlib_version": "4.15.0",
     "mathlibDependencies": [
       {
@@ -42,55 +44,109 @@
         "theorem": "liminf",
         "description": "Limit inferior for sequences",
         "module": "Mathlib.Topology.Algebra.Order.LiminfLimsup"
+      },
+      {
+        "theorem": "Real.rpow",
+        "description": "Real number exponentiation",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       }
     ],
     "originalContributions": [
       "Structure MonotoneGapPrimeSeq capturing the problem constraints",
       "Formal statement of Richter's lower bound on liminf",
-      "Equivalence formulation of the open conjecture"
+      "Equivalence formulation of the open conjecture",
+      "Proved gaps_pos, first_prime_ge_two, all_ge_two from Mathlib",
+      "Alternative characterization nonDecGaps_alt with proof"
     ]
   },
   "overview": {
-    "historicalContext": "This problem concerns sequences of primes where consecutive gaps never decrease. Such sequences must spread out increasingly, but the question is: how fast?\n\nErdős asked whether these sequences must grow superquadratically, i.e., whether lim q_n/n² = ∞. This remains open.\n\nIn 1976, Bernd Richter made progress by proving a lower bound: liminf q_n/n² > 0.352. This shows such sequences must grow at least quadratically, but whether they must grow strictly faster remains unknown.",
+    "historicalContext": "**Erdős Problem #455: Monotone Prime Gap Sequences**\n\nThis problem concerns sequences of primes where consecutive gaps never decrease — a discrete convexity condition. Such sequences must spread out increasingly, but the question is: how fast?\n\n**Historical Development:**\n- **Erdős** posed the problem: if $q_1 < q_2 < \\cdots$ are primes with $q_{n+1} - q_n \\geq q_n - q_{n-1}$, must $\\lim q_n/n^2 = \\infty$?\n- **Bernd Richter (1976)**, in *Über die Monotonie von Differenzenfolgen* (Acta Arithmetica), proved the partial result $\\liminf q_n/n^2 > 0.352$, establishing at least quadratic growth.\n- The full conjecture — superquadratic growth — remains open.\n\n**Context:** The sequence of all consecutive primes $(2, 3, 5, 7, 11, 13, \\ldots)$ does NOT satisfy the monotone-gap condition, since the gaps $1, 2, 2, 4, 2, \\ldots$ are not non-decreasing. Monotone-gap prime sequences must be carefully chosen subsequences. The problem connects to the Prime Number Theorem (which gives average gap $\\sim \\log n$) and to Cramér's conjecture on maximal gaps.",
     "problemStatement": "Let $q_1 < q_2 < \\cdots$ be a sequence of primes with non-decreasing gaps:\n$$q_{n+1} - q_n \\geq q_n - q_{n-1}$$\n\n**Open Question**: Must $\\lim_{n \\to \\infty} \\frac{q_n}{n^2} = \\infty$?\n\n**Partial Result (Richter 1976)**: $\\liminf_{n \\to \\infty} \\frac{q_n}{n^2} > 0.352$",
-    "proofStrategy": "We formalize the problem using a structure `MonotoneGapPrimeSeq` that captures all the constraints: strict monotonicity, primality of all terms, and non-decreasing gaps.\n\nRichter's lower bound is stated as an axiom since its proof requires careful prime distribution estimates. The main conjecture is formalized as an equivalence: the conjecture holds iff all such sequences have q_n/n² tending to infinity.\n\nWe also prove basic structural properties: gaps are positive, all terms are at least 2, etc.",
+    "proofStrategy": "We formalize the problem using a structure `MonotoneGapPrimeSeq` that bundles strict monotonicity, primality, and non-decreasing gaps.\n\n1. **HasNonDecreasingGaps**: Predicate $\\forall n,\\, q(n+1) - q(n) \\geq q(n) - q(n-1)$\n2. **MonotoneGapPrimeSeq**: Structure combining `StrictMono`, `allPrime`, and `nonDecGaps`\n3. **Richter's bound**: Axiomatized as $\\liminf q_n/n^2 > 0.352$ (proof requires PNT)\n4. **Open conjecture**: Stated as a `Prop` with equivalence to $\\mathrm{Tendsto}(q_n/n^2, \\mathrm{atTop}, \\mathrm{atTop})$\n5. **Structural properties**: `gaps_pos`, `all_ge_two`, and `nonDecGaps_alt` proved from Mathlib",
     "keyInsights": [
-      "**Non-decreasing gaps are restrictive**: The sequence of all primes (2, 3, 5, 7, 11, 13, ...) does NOT satisfy this condition because the gap 13-11=2 is less than 11-7=4.",
-      "**Quadratic growth is necessary**: Richter's bound shows q_n ≥ 0.352·n² eventually. The gaps must grow like n to maintain non-decreasing differences.",
-      "**The conjecture asks for more**: While quadratic growth is proved, the question is whether strictly superquadratic growth (faster than any cn²) is required.",
-      "**Discrete convexity**: The non-decreasing gaps condition is equivalent to discrete convexity - the sequence lies above its secant lines."
+      "**Non-decreasing gaps force discrete convexity**: The condition $q_{n+1} - q_n \\geq q_n - q_{n-1}$ means the sequence lies above its secant lines, a discrete analogue of convexity. This forces gaps to grow at least linearly, hence terms at least quadratically.",
+      "**Consecutive primes fail the condition**: The sequence $(2, 3, 5, 7, 11, 13, \\ldots)$ has gaps $1, 2, 2, 4, 2, \\ldots$ — the drop from $4$ to $2$ violates monotonicity. Only carefully chosen prime subsequences qualify.",
+      "**Richter's bound $\\liminf q_n/n^2 > 0.352$**: Proved in 1976 using prime distribution estimates. This establishes quadratic growth as a lower bound but falls short of the superquadratic conjecture.",
+      "**The conjecture asks for strictly superquadratic growth**: Not just $q_n \\geq cn^2$ but $q_n/n^2 \\to \\infty$. A simple asymptotic like $q_n \\sim cn^2$ would refute the conjecture.",
+      "**Connection to the Prime Number Theorem**: The PNT gives average prime gap $\\sim \\log p$, so the $n$-th prime is $\\sim n \\log n$. A monotone-gap subsequence must grow much faster than the typical prime."
     ]
   },
   "sections": [
     {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 17,
+      "endLine": 26,
+      "summary": "Imports Mathlib modules for `Nat.Prime`, `StrictMono`, `Filter.atTop`, `liminf`/`limsup`, and `Real.rpow`. Opens the `Filter` namespace."
+    },
+    {
       "id": "definitions",
-      "title": "Definitions",
-      "startLine": 29,
-      "endLine": 46,
-      "summary": "Defines HasNonDecreasingGaps and MonotoneGapPrimeSeq structure"
+      "title": "Core Definitions",
+      "startLine": 34,
+      "endLine": 45,
+      "summary": "Defines `HasNonDecreasingGaps` as $\\forall n,\\, q(n+1) - q(n) \\geq q(n) - q(n-1)$ and the structure `MonotoneGapPrimeSeq` bundling `StrictMono`, `allPrime`, and `nonDecGaps`."
     },
     {
-      "id": "main-results",
-      "title": "Main Results",
-      "startLine": 48,
-      "endLine": 104,
-      "summary": "Richter's bound, the open conjecture, and growth consequences"
+      "id": "richter-bound",
+      "title": "Richter's Lower Bound",
+      "startLine": 54,
+      "endLine": 69,
+      "summary": "Axiomatizes Richter's 1976 result: $\\liminf_{n \\to \\infty} q_n/n^2 > 0.352$ for any `MonotoneGapPrimeSeq`. Proof requires prime distribution estimates beyond current Mathlib."
     },
     {
-      "id": "structure",
+      "id": "open-conjecture",
+      "title": "The Open Conjecture",
+      "startLine": 71,
+      "endLine": 88,
+      "summary": "States Erdős's full conjecture as an abstract `Prop` and proves equivalence: the conjecture holds iff $\\mathrm{Tendsto}(q_n/n^2, \\mathrm{atTop}, \\mathrm{atTop})$ for all monotone-gap prime sequences."
+    },
+    {
+      "id": "consequences",
+      "title": "Consequences of Richter's Bound",
+      "startLine": 96,
+      "endLine": 103,
+      "summary": "Derives $\\exists c > 0,\\, \\forall^\\mathrm{f} n,\\, q_n \\geq c \\cdot n^2$ from the liminf bound, establishing eventual quadratic growth."
+    },
+    {
+      "id": "structural-properties",
       "title": "Structural Properties",
-      "startLine": 106,
-      "endLine": 154,
-      "summary": "Basic properties of monotone-gap prime sequences"
+      "startLine": 111,
+      "endLine": 124,
+      "summary": "Proves `gaps_pos` (strict monotonicity implies positive gaps), `first_prime_ge_two` and `all_ge_two` (primality implies $q_n \\geq 2$) using Mathlib's `Nat.Prime.two_le`."
+    },
+    {
+      "id": "restrictiveness",
+      "title": "Alternative Characterization",
+      "startLine": 137,
+      "endLine": 152,
+      "summary": "Proves `nonDecGaps_alt`: the non-decreasing gaps condition is equivalent to $\\forall n \\geq 1,\\, q(n+1) - q(n) \\geq q(n) - q(n-1)$. The $n = 0$ case is trivial by `simp`."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "foundational",
+      "description": "The PNT gives average prime gap ~ log p; Richter's bound relies on prime distribution estimates that ultimately flow from PNT-type results"
+    },
+    {
+      "targetId": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate bounds maximal prime gaps, providing context for how large gaps in monotone-gap sequences can be"
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The infinitude of primes ensures that monotone-gap prime sequences can be constructed to arbitrary length"
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures the open Erdős Problem #455 about prime sequences with monotonically non-decreasing gaps. While Richter's 1976 result shows such sequences must grow at least quadratically, the question of whether they must grow strictly faster than n² remains open.",
-    "implications": "The problem connects prime distribution theory with discrete convexity. A resolution would shed light on how the distribution of primes constrains specially structured subsequences.",
+    "summary": "This formalization captures the open Erdős Problem #455 about prime sequences with monotonically non-decreasing gaps. Richter's 1976 result shows such sequences must grow at least quadratically ($\\liminf q_n/n^2 > 0.352$), but the question of whether they must grow strictly faster than $n^2$ remains open after nearly 50 years.",
+    "implications": "The problem connects prime distribution theory with discrete convexity. A resolution would shed light on how the distribution of primes constrains specially structured subsequences. The monotone-gap condition is a discrete analogue of convexity, and understanding its consequences for prime subsequences touches on deep questions about the regularity of the prime sequence.",
     "openQuestions": [
-      "Must lim q_n/n² = ∞ for all monotone-gap prime sequences?",
-      "What is the exact value of the liminf constant (Richter showed > 0.352)?",
-      "Do infinitely many monotone-gap prime sequences exist?"
+      "Must $\\lim q_n/n^2 = \\infty$ for all monotone-gap prime sequences, or does some sequence have $q_n = O(n^2)$?",
+      "What is the exact value of Richter's liminf constant — is $0.352$ optimal or can it be improved?",
+      "How many distinct monotone-gap prime sequences exist beginning with a given prime?",
+      "Can the problem be generalized to other arithmetic conditions on gaps (e.g., gaps forming an arithmetic progression)?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Add `leanFile` path, `dateAdded`, `crossReferences` (prime-number-theorem, bertrands-postulate, infinitude-primes)
- Replace header annotation (comment-only lines 1-26) with imports annotation (lines 17-26)
- Add `mathContext` with LaTeX to all 9 annotations
- Add `relatedConcepts` and `prerequisites` to every annotation
- Expand sections from 3 to 7 covering full Lean file
- Deepen `historicalContext` with Richter's paper citation, PNT connection

## Test plan
- [x] `pnpm annotations:build` passes with no erdos-455 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)