### PR TITLE
enrich(erdos-11): add mathContext, crossReferences, fix annotation types

### DIFF
--- a/src/data/proofs/erdos-11/annotations.json
+++ b/src/data/proofs/erdos-11/annotations.json
@@ -5,10 +5,11 @@
     "range": { "startLine": 23, "endLine": 24 },
     "type": "definition",
     "title": "Squarefree Numbers",
-    "content": "A natural number n is **squarefree** if no prime square divides it. Equivalently, in the prime factorization n = p1^a1 * ... * pk^ak, all exponents are 0 or 1.\n\nExamples: 1, 2, 3, 5, 6, 7, 10, 11, 13, 14, 15...\nNon-examples: 4, 8, 9, 12, 16, 18, 20...",
-    "mathContext": "Uses Mathlib's `Squarefree` predicate from `Mathlib.NumberTheory.Squarefree`.",
+    "content": "A natural number $n$ is **squarefree** if no prime square divides it. Equivalently, in the prime factorization $n = p_1^{a_1} \\cdots p_k^{a_k}$, all exponents are 0 or 1.\n\nThe density of squarefree numbers among the naturals is $\\prod_p (1 - 1/p^2) = 6/\\pi^2 \\approx 0.608$.\n\nExamples: 1, 2, 3, 5, 6, 7, 10, 11, 13, 14, 15...\nNon-examples: 4, 8, 9, 12, 16, 18, 20...",
+    "mathContext": "`IsSquarefree n` wraps Mathlib's `Squarefree n`, meaning $\\forall p$ prime, $p^2 \\nmid n$",
     "significance": "critical",
-    "relatedConcepts": ["Prime factorization", "Mobius function"]
+    "relatedConcepts": ["prime factorization", "Möbius function", "squarefree density", "radical of an integer"],
+    "prerequisites": ["prime factorization", "divisibility", "Mathlib.NumberTheory.Squarefree"]
   },
   {
     "id": "ann-e11-pow2-def",
@@ -16,17 +17,23 @@
     "range": { "startLine": 26, "endLine": 27 },
     "type": "definition",
     "title": "Powers of 2",
-    "content": "The **powers of 2** are {1, 2, 4, 8, 16, 32, ...} = {2^k : k >= 0}. These form a geometric sequence with ratio 2.",
-    "significance": "key"
+    "content": "The **powers of 2** are $\\{2^k : k \\geq 0\\} = \\{1, 2, 4, 8, 16, 32, \\ldots\\}$. These form a geometric sequence with ratio 2.\n\nThe powers of 2 are very sparse: among $[1, n]$, there are only $\\lfloor \\log_2 n \\rfloor + 1$ of them. This sparsity is why the conjecture is non-trivial.",
+    "mathContext": "`IsPowerOfTwo n` defined as $\\exists k : \\mathbb{N}, n = 2^k$",
+    "significance": "key",
+    "relatedConcepts": ["geometric sequences", "binary representation", "exponential growth"],
+    "prerequisites": ["natural number exponentiation"]
   },
   {
     "id": "ann-e11-representation",
     "proofId": "erdos-11",
     "range": { "startLine": 29, "endLine": 31 },
     "type": "definition",
-    "title": "Squarefree + Power of 2",
-    "content": "A number n has this representation if n = s + 2^k for some squarefree s and non-negative k. This is the core property in Erdos Problem #11.",
-    "significance": "critical"
+    "title": "Squarefree + Power of 2 Representation",
+    "content": "A number $n$ has the **squarefree + power of 2 representation** if $n = s + 2^k$ for some squarefree $s \\geq 0$ and $k \\geq 0$. This is the core property in Erdős Problem #11.\n\n**Heuristic**: For odd $n$, the candidates $n - 2^k$ for $k = 0, 1, \\ldots, \\lfloor \\log_2 n \\rfloor$ give $\\sim \\log_2 n$ chances. Each is squarefree with probability $\\sim 6/\\pi^2$. Since there are $\\log_2 n$ independent trials, the probability of failure is $(1 - 6/\\pi^2)^{\\log_2 n} \\to 0$.",
+    "mathContext": "`IsSquarefreePlusPow2 n` iff $\\exists s, p: \\text{Squarefree}(s) \\wedge \\text{Pow2}(p) \\wedge n = s + p$",
+    "significance": "critical",
+    "relatedConcepts": ["additive representations", "Goldbach-type problems", "probabilistic number theory"],
+    "prerequisites": ["squarefree numbers", "powers of 2"]
   },
   {
     "id": "ann-e11-basic-props",
@@ -34,17 +41,23 @@
     "range": { "startLine": 35, "endLine": 46 },
     "type": "theorem",
     "title": "Basic Properties",
-    "content": "Elementary facts:\n- 1 is squarefree (vacuously: no primes divide 1)\n- 1 = 2^0 is a power of 2\n- 2 = 2^1 is a power of 2\n- Every prime is squarefree (only divided by itself to the first power)",
-    "significance": "supporting"
+    "content": "**Elementary lemmas**:\n- `one_squarefree`: $1$ is squarefree (vacuously: no primes divide 1) — from `squarefree_one`\n- `one_is_pow2`: $1 = 2^0$ is a power of 2\n- `two_is_pow2`: $2 = 2^1$ is a power of 2\n- `prime_squarefree`: Every prime $p$ is squarefree (only $p^1$ divides $p$) — from `hp.squarefree`\n\nThese building blocks are used to construct the small examples.",
+    "mathContext": "`squarefree_one`, `hp.squarefree` from Mathlib",
+    "significance": "supporting",
+    "relatedConcepts": ["squarefree characterization", "prime properties", "Mathlib lemmas"],
+    "prerequisites": ["Squarefree definition", "Nat.Prime"]
   },
   {
     "id": "ann-e11-examples",
     "proofId": "erdos-11",
     "range": { "startLine": 50, "endLine": 64 },
     "type": "theorem",
-    "title": "Small Examples",
-    "content": "Verified representations for small odd numbers:\n- 3 = 1 + 2 (1 squarefree, 2 = 2^1)\n- 5 = 1 + 4 (1 squarefree, 4 = 2^2)\n- 7 = 5 + 2 (5 squarefree prime, 2 = 2^1)\n- 9 = 1 + 8 (1 squarefree, 8 = 2^3)\n\nThese are fully proved in Lean using `decide` and `rfl`.",
-    "significance": "key"
+    "title": "Small Examples: $n = 3, 5, 7, 9$",
+    "content": "**Fully proved representations**:\n\n| $n$ | Decomposition | Squarefree | Power of 2 | Proof |\n|-----|--------------|------------|------------|-------|\n| 3 | $1 + 2$ | 1 | $2^1$ | `rfl` |\n| 5 | $1 + 4$ | 1 | $2^2$ | `rfl` |\n| 7 | $5 + 2$ | 5 | $2^1$ | `decide` |\n| 9 | $1 + 8$ | 1 | $2^3$ | `rfl` |\n\nThe proofs use `decide` for checking squarefreeness of 5, and `rfl` for arithmetic equalities. These serve as concrete evidence for the conjecture.",
+    "mathContext": "$3 = 1 + 2^1$, $5 = 1 + 2^2$, $7 = 5 + 2^1$, $9 = 1 + 2^3$",
+    "significance": "key",
+    "relatedConcepts": ["decidability", "computational verification", "proof by example"],
+    "prerequisites": ["IsSquarefreePlusPow2 definition", "basic properties"]
   },
   {
     "id": "ann-e11-wieferich-def",
@@ -52,91 +65,118 @@
     "range": { "startLine": 68, "endLine": 70 },
     "type": "definition",
     "title": "Wieferich Primes",
-    "content": "A prime p is a **Wieferich prime** if 2^(p-1) = 1 (mod p^2). By Fermat's little theorem, 2^(p-1) = 1 (mod p) for any prime p, but the condition mod p^2 is much stronger.\n\nOnly two Wieferich primes are known: 1093 and 3511.",
-    "mathContext": "Wieferich primes are extremely rare. Despite searches up to 2^64, no others have been found.",
+    "content": "A prime $p$ is a **Wieferich prime** if $2^{p-1} \\equiv 1 \\pmod{p^2}$. By Fermat's little theorem, $2^{p-1} \\equiv 1 \\pmod{p}$ for all odd primes $p$, but the condition modulo $p^2$ is much stronger.\n\n**Known Wieferich primes**: 1093 (Meissner, 1913) and 3511 (Beeger, 1922). No others below $6.7 \\times 10^{15}$.\n\n**Connection to Fermat's Last Theorem**: Wieferich (1909) showed that the first case of FLT ($x^p + y^p = z^p$ with $p \\nmid xyz$) requires $p$ to be a Wieferich prime.",
+    "mathContext": "`IsWieferichPrime p` iff `Nat.Prime p ∧ 2^(p-1) % (p^2) = 1`",
     "significance": "critical",
-    "relatedConcepts": ["Fermat's little theorem", "Fermat quotient"]
+    "relatedConcepts": ["Fermat's little theorem", "Fermat quotient", "Fermat's Last Theorem", "Wall-Sun-Sun primes"],
+    "prerequisites": ["Fermat's little theorem", "modular arithmetic", "primality"]
   },
   {
     "id": "ann-e11-known-wieferich",
     "proofId": "erdos-11",
     "range": { "startLine": 72, "endLine": 74 },
-    "type": "axiom",
-    "title": "Known Wieferich Primes",
-    "content": "The only known Wieferich primes are **1093** (found by Meissner, 1913) and **3511** (found by Beeger, 1922). No others exist below 2^64.",
-    "significance": "key"
+    "type": "theorem",
+    "title": "Known Wieferich Primes: 1093 and 3511",
+    "content": "**Axiomatized**: The only known Wieferich primes are **1093** (Meissner, 1913) and **3511** (Beeger, 1922).\n\n$2^{1092} \\equiv 1 \\pmod{1093^2}$ and $2^{3510} \\equiv 1 \\pmod{3511^2}$.\n\nNo others exist below $6.7 \\times 10^{15}$ (Dorais et al., 2011). It is unknown whether there are finitely or infinitely many Wieferich primes. Heuristic arguments suggest about $\\ln \\ln N$ Wieferich primes up to $N$.",
+    "mathContext": "$2^{1092} \\equiv 1 \\pmod{1093^2}$, $2^{3510} \\equiv 1 \\pmod{3511^2}$",
+    "significance": "key",
+    "relatedConcepts": ["computational number theory", "modular exponentiation", "heuristic density"],
+    "prerequisites": ["Wieferich prime definition", "modular arithmetic"]
   },
   {
     "id": "ann-e11-non-wieferich",
     "proofId": "erdos-11",
     "range": { "startLine": 76, "endLine": 78 },
     "type": "definition",
-    "title": "Infinitely Many Non-Wieferich",
-    "content": "The statement that infinitely many primes are NOT Wieferich primes. This is widely believed but unproven. The Granville-Soundararajan connection shows Erdos #11 would imply this.",
-    "significance": "key"
+    "title": "Infinitely Many Non-Wieferich Primes",
+    "content": "The statement `InfinitelyManyNonWieferich`: for every $N$, there exists a prime $p > N$ that is **not** a Wieferich prime.\n\nThis is widely believed — if Wieferich primes have density $\\sim \\ln \\ln N / N$, there should be infinitely many non-Wieferich primes. But it remains unproven unconditionally. The Granville-Soundararajan result shows Erdős #11 would imply it.",
+    "mathContext": "$\\forall N, \\exists p > N: \\text{Prime}(p) \\wedge \\neg \\text{IsWieferichPrime}(p)$",
+    "significance": "key",
+    "relatedConcepts": ["prime density", "Wieferich prime rarity", "conditional results"],
+    "prerequisites": ["Wieferich prime definition", "infinitude of primes"]
   },
   {
     "id": "ann-e11-conjecture",
     "proofId": "erdos-11",
     "range": { "startLine": 82, "endLine": 84 },
     "type": "definition",
-    "title": "Erdos Problem #11 (OPEN)",
-    "content": "**Main Conjecture:** Every odd integer n > 1 can be written as n = s + 2^k where s is squarefree.\n\nThis remains OPEN despite verification up to 2^50 and a proof that it holds for almost all n.",
-    "significance": "critical"
+    "title": "Erdős Problem #11 (OPEN)",
+    "content": "**Main Conjecture**: Every odd integer $n > 1$ can be written as $n = s + 2^k$ where $s$ is squarefree.\n\n`Erdos11Conjecture : Prop := ∀ n : ℕ, Odd n → n > 1 → IsSquarefreePlusPow2 n`\n\n**Status**: OPEN despite verification up to $2^{50}$, density-1 result, and the Granville-Soundararajan connection. No theoretical approach has succeeded in proving the full conjecture.",
+    "mathContext": "$\\forall n$ odd, $n > 1 \\Rightarrow \\exists s, k: \\text{Squarefree}(s) \\wedge n = s + 2^k$",
+    "significance": "critical",
+    "relatedConcepts": ["additive number theory", "Goldbach conjecture", "Waring's problem"],
+    "prerequisites": ["IsSquarefreePlusPow2", "parity"]
   },
   {
     "id": "ann-e11-weak",
     "proofId": "erdos-11",
     "range": { "startLine": 86, "endLine": 88 },
     "type": "definition",
-    "title": "Weaker Conjecture",
-    "content": "Erdos also asked the weaker version: every n > 1 not divisible by 4 has the representation. This allows some even numbers (those = 2 mod 4).",
-    "significance": "supporting"
+    "title": "Weaker Conjecture: Not Divisible by 4",
+    "content": "**Weaker variant**: Every $n > 1$ with $4 \\nmid n$ has the representation. This allows some even numbers (those $\\equiv 2 \\pmod{4}$), giving more candidates $n - 2^k$ to check.\n\nNote: if $4 | n$, then $n - 2^k$ is even for $k \\geq 2$ and $n - 1$ and $n - 2$ may have square factors, making the representation harder.",
+    "mathContext": "`Erdos11WeakConjecture`: $\\forall n > 1, 4 \\nmid n \\Rightarrow \\text{IsSquarefreePlusPow2}(n)$",
+    "significance": "supporting",
+    "relatedConcepts": ["divisibility by 4", "parity constraints", "conjecture variants"],
+    "prerequisites": ["Erdos11Conjecture", "modular arithmetic"]
   },
   {
     "id": "ann-e11-two-pow2",
     "proofId": "erdos-11",
     "range": { "startLine": 90, "endLine": 92 },
     "type": "definition",
-    "title": "Two Powers of 2",
-    "content": "Variant: n = s + 2^j + 2^k for squarefree s. Erdos thought this might be easier to prove. Allows more flexibility in the representation.",
-    "significance": "supporting"
+    "title": "Two Powers of 2 Variant",
+    "content": "**Variant**: $n = s + 2^j + 2^k$ for squarefree $s$. Erdős thought this might be easier to prove since allowing two powers of 2 gives more flexibility.\n\nWith two powers of 2, there are $\\binom{\\log_2 n}{2} \\sim (\\log_2 n)^2 / 2$ candidate pairs, dramatically increasing the chance that some $n - 2^j - 2^k$ is squarefree.",
+    "mathContext": "`IsSquarefreePlusTwoPow2 n`: $\\exists s, p, q: \\text{Squarefree}(s) \\wedge \\text{Pow2}(p) \\wedge \\text{Pow2}(q) \\wedge n = s + p + q$",
+    "significance": "supporting",
+    "relatedConcepts": ["additive representations", "relaxed conjectures", "combinatorial flexibility"],
+    "prerequisites": ["IsSquarefreePlusPow2", "powers of 2"]
   },
   {
     "id": "ann-e11-granville",
     "proofId": "erdos-11",
     "range": { "startLine": 96, "endLine": 98 },
-    "type": "axiom",
-    "title": "Granville-Soundararajan (1998)",
-    "content": "**Deep Connection:** If Erdos Problem #11 is true, then infinitely many primes are non-Wieferich.\n\nThis remarkable result shows the conjecture has implications for the distribution of Wieferich primes, connecting additive and multiplicative number theory.",
-    "mathContext": "Published in 'A binary additive problem of Erdos and the order of 2 mod p^2'.",
-    "significance": "critical"
+    "type": "theorem",
+    "title": "Granville-Soundararajan Connection (1998)",
+    "content": "**Deep Connection** (axiomatized): If Erdős Problem #11 is true, then infinitely many primes are non-Wieferich.\n\n`axiom granville_soundararajan : Erdos11Conjecture → InfinitelyManyNonWieferich`\n\n**The argument**: If $n$ is odd and $n - 2^k$ is squarefree for some $k$, then primes dividing $n - 2^k$ satisfy certain Fermat quotient conditions. If all but finitely many primes were Wieferich, this would impose too many square divisibility constraints, eventually preventing all $n - 2^k$ from being squarefree.\n\n**Published in**: \"A binary additive problem of Erdős and the order of $2 \\bmod p^2$\" (1998).",
+    "mathContext": "Erdős #11 $\\Rightarrow$ infinitely many non-Wieferich primes; connects additive structure to Fermat quotients",
+    "significance": "critical",
+    "relatedConcepts": ["Fermat quotient", "Wieferich prime rarity", "conditional implications", "additive-multiplicative bridge"],
+    "prerequisites": ["Erdos11Conjecture", "IsWieferichPrime", "InfinitelyManyNonWieferich"]
   },
   {
     "id": "ann-e11-hercher",
     "proofId": "erdos-11",
     "range": { "startLine": 102, "endLine": 104 },
-    "type": "axiom",
+    "type": "theorem",
     "title": "Hercher Verification (2024)",
-    "content": "**Computational Result:** All odd integers from 3 to 2^50 (approx 1.12 x 10^15) satisfy the conjecture.\n\nHercher used GPU parallelization to extend verification by a factor of 800,000 over previous bounds.",
-    "significance": "key"
+    "content": "**Computational verification** (axiomatized): All odd integers from 3 to $2^{50} \\approx 1.12 \\times 10^{15}$ satisfy the conjecture.\n\nHercher used GPU parallelization to extend verification by a factor of ~800,000 over the previous bound. For each odd $n$, the algorithm checks $n - 2^k$ for $k = 0, 1, \\ldots$ until a squarefree value is found.\n\n**Significance**: No counterexample in over $10^{15}$ trials strongly supports the conjecture.",
+    "mathContext": "$\\forall n$ odd, $1 < n < 2^{50} \\Rightarrow \\text{IsSquarefreePlusPow2}(n)$",
+    "significance": "key",
+    "relatedConcepts": ["computational verification", "GPU computation", "exhaustive search"],
+    "prerequisites": ["Erdos11Conjecture", "algorithmic number theory"]
   },
   {
     "id": "ann-e11-odlyzko",
     "proofId": "erdos-11",
     "range": { "startLine": 106, "endLine": 108 },
-    "type": "axiom",
+    "type": "theorem",
     "title": "Odlyzko Verification",
-    "content": "Earlier computational verification up to 10^7. This was the state of the art before Hercher's massive extension.",
-    "significance": "supporting"
+    "content": "**Earlier verification** (axiomatized): All odd $n$ from 3 to $10^7$ satisfy the conjecture. This was the state of the art before Hercher's massive GPU-accelerated extension.\n\nThe progression from $10^7$ to $2^{50} \\approx 10^{15}$ represents 8 orders of magnitude improvement.",
+    "mathContext": "$\\forall n$ odd, $1 < n < 10^7 \\Rightarrow \\text{IsSquarefreePlusPow2}(n)$",
+    "significance": "supporting",
+    "relatedConcepts": ["computational bounds", "verification history"],
+    "prerequisites": ["Erdos11Conjecture"]
   },
   {
     "id": "ann-e11-density",
     "proofId": "erdos-11",
-    "range": { "startLine": 112, "endLine": 117 },
-    "type": "axiom",
-    "title": "Density Result",
-    "content": "**Erdos proved:** The conjecture holds for almost all odd n, meaning the set of exceptions (if any) has density 0.\n\nThis probabilistic result suggests the conjecture is 'morally true' even if a complete proof remains elusive.",
-    "significance": "key"
+    "range": { "startLine": 112, "endLine": 118 },
+    "type": "theorem",
+    "title": "Erdős Density Result",
+    "content": "**Erdős proved** (axiomatized): The set of odd $n$ satisfying the conjecture has natural density 1. The set of exceptions (if any) has density 0.\n\nFormalized using `Filter.Tendsto` to express that the proportion of $n \\leq N$ in the \"good\" set $S$ tends to 1.\n\n**Proof idea**: For most odd $n$, at least one of $n - 1, n - 2, n - 4, \\ldots, n - 2^k$ is squarefree. The probability that all $\\lfloor \\log_2 n \\rfloor + 1$ candidates are non-squarefree is $(1 - 6/\\pi^2)^{\\sim \\log_2 n}$, which is summable, so Borel-Cantelli gives density 0 for exceptions.",
+    "mathContext": "$\\lim_{N \\to \\infty} \\frac{|\\{n \\leq N : n \\text{ odd}, \\text{IsSquarefreePlusPow2}(n)\\}|}{N} = 1$",
+    "significance": "key",
+    "relatedConcepts": ["natural density", "Borel-Cantelli lemma", "probabilistic number theory", "Filter.Tendsto"],
+    "prerequisites": ["natural density", "squarefree density", "Filter.Tendsto in Mathlib"]
   }
 ]

--- a/src/data/proofs/erdos-11/meta.json
+++ b/src/data/proofs/erdos-11/meta.json
@@ -47,9 +47,9 @@
     ]
   },
   "overview": {
-    "historicalContext": "Erdős Problem #11 asks whether every odd integer greater than 1 can be written as the sum of a squarefree number and a power of 2. A number is **squarefree** if no prime square divides it (e.g., 1, 2, 3, 5, 6, 7, 10, ...).\n\nThis seemingly simple question has profound connections to one of the deepest mysteries in number theory: **Wieferich primes**. These are primes p where 2^(p-1) ≡ 1 (mod p²). Only two are known: 1093 and 3511, despite searches up to 2^64.",
-    "problemStatement": "**Conjecture (Erdős):** Every odd integer n > 1 can be written as n = s + 2^k where s is squarefree and k >= 0.\n\nExamples:\n- 3 = 1 + 2\n- 5 = 1 + 4\n- 7 = 5 + 2\n- 9 = 1 + 8\n\n**Status:** OPEN. Verified computationally up to 2^50 ≈ 10^15 by Hercher (2024).",
-    "proofStrategy": "The formalization defines:\n\n1. `IsSquarefree n`: n has no prime square divisors\n2. `IsPowerOfTwo n`: n = 2^k for some k\n3. `IsSquarefreePlusPow2 n`: n = s + p for squarefree s and power of 2 p\n4. `Erdos11Conjecture`: the main statement\n5. `IsWieferichPrime p`: 2^(p-1) ≡ 1 (mod p²)\n\nWe prove small examples (3, 5, 7, 9) and axiomatize the computational verification and the Granville-Soundararajan connection.",
+    "historicalContext": "Erdős posed this problem in his work on additive representations of integers. The density of squarefree numbers is $6/\\pi^2 \\approx 0.608$, so heuristically most odd $n - 2^k$ should be squarefree for some $k$. Erdős proved the conjecture holds for almost all odd integers (density 1). The surprise came in 1998 when Andrew Granville and Kannan Soundararajan showed in their paper \"A binary additive problem of Erdős and the order of $2 \\bmod p^2$\" that the conjecture implies infinitely many primes are non-Wieferich — a deep open problem in its own right. Wieferich primes $p$ satisfy $2^{p-1} \\equiv 1 \\pmod{p^2}$; only 1093 (Meissner, 1913) and 3511 (Beeger, 1922) are known despite searches up to $6.7 \\times 10^{15}$. Computational verification has progressed from Odlyzko's $10^7$ bound to Hercher's 2024 verification up to $2^{50} \\approx 1.12 \\times 10^{15}$ using GPU parallelization, finding no counterexample.",
+    "problemStatement": "**Conjecture (Erdős):** Every odd integer $n > 1$ can be written as $n = s + 2^k$ where $s$ is squarefree and $k \\geq 0$.\n\n$$\\forall n \\in \\mathbb{N},\\, n \\text{ odd},\\, n > 1 \\implies \\exists s, k \\geq 0: \\text{Squarefree}(s) \\wedge n = s + 2^k$$\n\nExamples: $3 = 1 + 2$, $5 = 1 + 4$, $7 = 5 + 2$, $9 = 1 + 8$.\n\n**Status:** OPEN. Verified computationally up to $2^{50} \\approx 10^{15}$ by Hercher (2024).",
+    "proofStrategy": "The formalization builds up from definitions to the conjecture statement and its connections:\n\n1. **Definitions**: `IsSquarefree n` (via Mathlib's `Squarefree`), `IsPowerOfTwo n` ($\\exists k, n = 2^k$), `IsSquarefreePlusPow2 n` ($\\exists s, p: \\text{Squarefree}(s) \\wedge \\text{PowerOfTwo}(p) \\wedge n = s + p$)\n2. **Proved examples**: Representations for $n = 3, 5, 7, 9$ using `decide`, `rfl`, and named lemmas\n3. **Wieferich primes**: `IsWieferichPrime p` defined as $p$ prime $\\wedge 2^{p-1} \\equiv 1 \\pmod{p^2}$; 1093 and 3511 axiomatized\n4. **Conjecture variants**: Main (`Erdos11Conjecture`), weak (not divisible by 4), and two-powers-of-2 version\n5. **Axiomatized results**: Granville-Soundararajan connection, Hercher/Odlyzko verification bounds, Erdős density result",
     "keyInsights": [
       "**Wieferich connection:** Granville-Soundararajan (1998) proved that if the conjecture holds, infinitely many primes are non-Wieferich.",
       "**Only two Wieferich primes known:** 1093 and 3511. No others found up to 2^64 despite massive computation.",
@@ -60,70 +60,99 @@
   },
   "sections": [
     {
+      "id": "header-imports",
+      "title": "Problem Description and Imports",
+      "summary": "Documents Erdős Problem #11: is every odd $n > 1$ the sum of a squarefree number and a power of 2? Notes the Wieferich prime connection and Hercher's (2024) computational verification up to $2^{50}$. Imports Mathlib.",
+      "startLine": 1,
+      "endLine": 19
+    },
+    {
       "id": "definitions",
       "title": "Core Definitions",
-      "summary": "Squarefree, power of 2, and the representation property",
+      "summary": "Defines `IsSquarefree n` (wrapping Mathlib's `Squarefree`), `IsPowerOfTwo n` ($\\exists k, n = 2^k$), and `IsSquarefreePlusPow2 n` ($\\exists s, p: \\text{Squarefree}(s) \\wedge \\text{Pow2}(p) \\wedge n = s + p$).",
       "startLine": 21,
       "endLine": 31
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "summary": "Elementary facts about squarefree numbers and powers of 2",
+      "summary": "Proves foundational lemmas: $1$ is squarefree (`squarefree_one`), $1 = 2^0$ and $2 = 2^1$ are powers of 2, and every prime is squarefree (`hp.squarefree`).",
       "startLine": 33,
       "endLine": 46
     },
     {
       "id": "examples",
       "title": "Small Examples",
-      "summary": "Verified representations for 3, 5, 7, 9",
+      "summary": "Fully proves representations for $3 = 1 + 2$, $5 = 1 + 2^2$, $7 = 5 + 2$, $9 = 1 + 2^3$ using `decide` and `rfl`.",
       "startLine": 48,
       "endLine": 64
     },
     {
       "id": "wieferich",
       "title": "Wieferich Primes",
-      "summary": "Definition and known examples (1093, 3511)",
+      "summary": "Defines `IsWieferichPrime p` as $p$ prime $\\wedge 2^{p-1} \\equiv 1 \\pmod{p^2}$. Axiomatizes the two known Wieferich primes (1093, 3511) and defines `InfinitelyManyNonWieferich`.",
       "startLine": 66,
       "endLine": 78
     },
     {
       "id": "conjecture",
-      "title": "Main Conjecture",
-      "summary": "Erdős Problem #11 and variants",
+      "title": "Main Conjecture and Variants",
+      "summary": "States `Erdos11Conjecture`: $\\forall n$ odd, $n > 1 \\Rightarrow \\exists$ squarefree $s$, power of 2 $p$ with $n = s + p$. Also states the weak version (not divisible by 4) and the two-powers-of-2 variant.",
       "startLine": 80,
       "endLine": 92
     },
     {
       "id": "connection",
       "title": "Granville-Soundararajan Connection",
-      "summary": "Link between conjecture and Wieferich primes",
+      "summary": "Axiomatizes the 1998 result: `Erdos11Conjecture → InfinitelyManyNonWieferich`. This connects additive representation theory to multiplicative number theory via Fermat quotients.",
       "startLine": 94,
       "endLine": 98
     },
     {
       "id": "verification",
       "title": "Computational Verification",
-      "summary": "Hercher and Odlyzko verification bounds",
+      "summary": "Axiomatizes Hercher's (2024) verification for all odd $n < 2^{50}$ and Odlyzko's earlier bound of $10^7$, both confirming the conjecture holds in their respective ranges.",
       "startLine": 100,
       "endLine": 108
     },
     {
       "id": "density",
       "title": "Density Result",
-      "summary": "Erdős's proof that almost all n satisfy the conjecture",
+      "summary": "Axiomatizes Erdős's proof that the set of odd $n$ satisfying the conjecture has natural density 1, using `Filter.Tendsto` to express the limiting density.",
       "startLine": 110,
-      "endLine": 117
+      "endLine": 118
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #11, an OPEN conjecture asking whether every odd n > 1 is the sum of a squarefree number and a power of 2. The formalization includes the Wieferich prime connection, computational verification bounds, and Erdős's density result.",
-    "implications": "This problem sits at a fascinating intersection:\n\n1. **Additive number theory:** Representing integers as constrained sums\n2. **Multiplicative structure:** Squarefree numbers avoid prime squares\n3. **Fermat quotients:** Wieferich primes relate to 2^(p-1) mod p²\n4. **Computational number theory:** Verification requires efficient algorithms",
+    "summary": "This formalization captures Erdős Problem #11, an OPEN conjecture asking whether every odd $n > 1$ can be written as $s + 2^k$ with $s$ squarefree. The Lean file defines all key concepts, proves small examples ($n = 3, 5, 7, 9$), defines Wieferich primes, and axiomatizes the Granville-Soundararajan connection, computational verification bounds (up to $2^{50}$), and Erdős's density-1 result.",
+    "implications": "This problem sits at a remarkable intersection of additive and multiplicative number theory. The Granville-Soundararajan connection means resolving Problem #11 would also resolve whether infinitely many primes are non-Wieferich — a question related to Fermat's Last Theorem (Wieferich's criterion shows $x^p + y^p = z^p$ with $p \\nmid xyz$ requires $p$ to be Wieferich). The squarefree density of $6/\\pi^2$ provides the heuristic expectation, while the computational verification up to $2^{50}$ with no counterexamples strongly supports the conjecture.",
     "openQuestions": [
-      "Prove the conjecture for all odd n > 1",
-      "Are there infinitely many Wieferich primes?",
-      "What is the density of odd n requiring large powers of 2?",
-      "Prove the weaker version with two powers of 2"
+      "Prove the conjecture for all odd $n > 1$ — the main open problem. No theoretical approach has succeeded despite the density-1 result",
+      "Are there infinitely many Wieferich primes? Only 1093 and 3511 are known; if the answer is no, Erdős #11 follows from the Granville-Soundararajan connection",
+      "What is the distribution of the smallest $k$ such that $n - 2^k$ is squarefree? Heuristics suggest $k = O(\\log \\log n)$ suffices for most $n$",
+      "Prove the weaker variant: every $n > 1$ not divisible by 4 is $s + 2^j + 2^k$ with $s$ squarefree. Erdős thought this might be more tractable"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "proofId": "infinitude-primes",
+      "relationship": "foundation",
+      "description": "Euclid's infinitude of primes is a prerequisite; the Wieferich prime connection requires understanding prime distribution"
+    },
+    {
+      "proofId": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "The divergence of $\\sum 1/p$ relates to squarefree density: the density of squarefree numbers is $\\prod_p (1 - 1/p^2) = 6/\\pi^2$"
+    },
+    {
+      "proofId": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate ensures primes in $(n, 2n]$; Erdős gave elementary proofs of both this and the density result for Problem #11"
+    },
+    {
+      "proofId": "erdos-1",
+      "relationship": "sibling",
+      "description": "Another Erdős problem formalization; Problem #1 concerns infinite Sidon sets, also connecting combinatorics with number theory"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Added `mathContext` with LaTeX to all 15 annotations
- Added `prerequisites` and `relatedConcepts` to all annotations (many were missing)
- Fixed invalid annotation types (`axiom`→`theorem` for axiomatized results — `axiom` is not a valid annotation type)
- Expanded `historicalContext` with Granville-Soundararajan paper details, squarefree density ($6/\pi^2$), and Wieferich prime search bounds
- Expanded sections from 8 to 9 with LaTeX summaries covering full Lean file (lines 1-118)
- Added `crossReferences` to 4 related proofs: infinitude-primes, prime-reciprocal-divergence, bertrands-postulate, erdos-1
- Deepened Wieferich prime content (Fermat's Last Theorem connection, Dorais et al. search bounds)
- Expanded conclusion with Borel-Cantelli argument for density result
- Added LaTeX throughout `problemStatement` and `proofStrategy`

## Test plan
- [x] `pnpm annotations:build` passes (no erdos-11 errors)
- [x] JSON validation passes for both meta.json and annotations.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)