### PR TITLE
research(abel-ruffini): mark Galois extensions formalization complete

### DIFF
--- a/src/data/research/problems/abel-ruffini-galois-extensions.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions.json
@@ -1,0 +1,105 @@
+{
+  "slug": "abel-ruffini-galois-extensions",
+  "title": "Abel-Ruffini Galois Theory Extensions",
+  "phase": "COMPLETE",
+  "status": "completed",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "S_n is solvable iff n ≤ 4; A_n is solvable iff n ≤ 4; A₅ is simple; polynomial unsolvability follows from non-solvable Galois group.",
+    "plain": "Prove the complete classification of solvability for symmetric and alternating groups, and connect it to the Abel-Ruffini theorem on polynomial unsolvability by radicals.",
+    "whyMatters": [
+      "Foundational result connecting group theory to polynomial solvability",
+      "Complete classification of solvable symmetric groups (n ≤ 4)",
+      "The simplicity of A₅ provides the key obstruction for degree ≥ 5"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "S₀, S₁, S₂, S₃, S₄ are solvable (via subsingleton, commutativity, short exact sequences)",
+      "A₀, A₁, A₂, A₃, A₄ are solvable (A₃ commutative, A₄ via Klein four-group V₄)",
+      "S_n not solvable for n ≥ 5 (Mathlib's Equiv.Perm.not_solvable)",
+      "A_n not solvable for n ≥ 5 (via S_n non-solvability)",
+      "Complete iff: S_n solvable ↔ n ≤ 4, A_n solvable ↔ n ≤ 4",
+      "A₅ is simple (alternatingGroup.isSimpleGroup_five)",
+      "Cardinalities: |S₂|=2, |S₃|=6, |S₄|=24, |S₅|=120, |S₆|=720, |S₇|=5040, |S₈|=40320",
+      "Cardinalities: |A₃|=3, |A₄|=12, |A₅|=60, |A₆|=360, |A₇|=2520, |A₈|=20160",
+      "Factorial identities: |S_n| = n!, |A_n| = n!/2 verified computationally",
+      "Non-commutativity witnesses: S₃, S₄, S₅, A₄, A₅ all non-commutative",
+      "Contrapositive of Galois theorem: non-solvable Galois group → not solvable by radicals",
+      "Galois group order = extension degree (for finite Galois extensions)",
+      "Solvability preservation: subgroups, quotients, isomorphisms",
+      "Klein four-group V₄ construction with normality, commutativity proofs",
+      "Sign kernel equals alternating group"
+    ],
+    "open": [],
+    "goal": "Complete formalization achieved. 55+ theorems, 0 sorries, 0 axioms."
+  },
+  "currentState": {
+    "phase": "COMPLETE",
+    "since": "2026-02-15T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Complete. All theorems proved, zero sorries, zero axioms.",
+    "blockers": [],
+    "nextAction": "None — formalization is complete.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: 534-line file with 55+ theorems, 0 sorries, 0 axioms. Complete classification of symmetric and alternating group solvability (S_n solvable iff n ≤ 4, A_n solvable iff n ≤ 4). Builds cleanly in Docker with Mathlib v4.26.0.",
+    "builtItems": [
+      "perm_fin_0_solvable through perm_fin_4_solvable: S₀-S₄ solvable",
+      "alternating_fin_0_solvable through alternating_fin_4_solvable: A₀-A₄ solvable",
+      "symmetric_solvable_iff: S_n solvable ↔ n ≤ 4",
+      "alternating_solvable_iff: A_n solvable ↔ n ≤ 4",
+      "a5_simple: A₅ is simple",
+      "not_solvable_by_rad_of_not_solvable_galois: contrapositive of Galois theorem",
+      "galois_group_order: |Aut(E/F)| = [E:F]",
+      "klein_four: V₄ ◁ A₄ construction",
+      "sign_kernel_is_alternating: ker(sign) = A_n",
+      "Card computations for S₂-S₈ and A₀-A₈"
+    ],
+    "insights": [
+      "S₃ and S₄ solvability proved via sign exact sequence 1 → A_n → S_n → ℤˣ → 1",
+      "A₄ solvability proved via Klein four-group exact sequence 1 → V₄ → A₄ → A₄/V₄ → 1",
+      "native_decide handles V₄ normality and quotient commutativity for A₄",
+      "decide handles S₂ commutativity and A₃ commutativity efficiently",
+      "Mathlib's Equiv.Perm.not_solvable provides non-solvability for n ≥ 5"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "approaches": [],
+  "tags": [
+    "galois-theory",
+    "group-theory",
+    "solvability",
+    "symmetric-groups",
+    "alternating-groups",
+    "0-sorry",
+    "0-axioms"
+  ],
+  "relatedProofs": [
+    "AbelRuffiniGaloisExtensions.lean",
+    "AbelRuffini.lean"
+  ],
+  "leanFile": "AbelRuffiniGaloisExtensions.lean",
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.FieldTheory.AbelRuffini",
+      "Mathlib.GroupTheory.Solvable",
+      "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "Mathlib.FieldTheory.Galois.Basic",
+      "Mathlib.GroupTheory.Perm.Sign"
+    ]
+  },
+  "started": "2026-02-15T00:00:00.000Z",
+  "lastUpdate": "2026-02-15T00:00:00.000Z",
+  "significance": 7,
+  "tractability": 8
+}


### PR DESCRIPTION
## Summary
- Add problem JSON for abel-ruffini-galois-extensions marking formalization as COMPLETE
- The Lean file `AbelRuffiniGaloisExtensions.lean` is already on main with 55+ theorems, 0 sorries, 0 axioms
- Docker build verified successfully

## What's in the formalization
- **Complete classification**: S_n solvable iff n ≤ 4, A_n solvable iff n ≤ 4
- **A₅ simplicity**: alternatingGroup.isSimpleGroup_five
- **Klein four-group**: V₄ ◁ A₄ construction for A₄ solvability
- **Galois connection**: contrapositive of Abel-Ruffini (non-solvable Galois group → not solvable by radicals)
- **Cardinalities**: |S₂| through |S₈|, |A₀| through |A₈|
- **Non-commutativity**: witnesses for S₃, S₄, S₅, A₄, A₅

## Test plan
- [x] Docker build passes for Proofs.AbelRuffiniGaloisExtensions
- [x] Problem JSON validates with correct structure

🤖 Generated by researcher-1