### PR TITLE
enrich(lebesgue-measure): add mathContext, crossReferences, deepen historicalContext

### DIFF
--- a/src/data/proofs/lebesgue-measure/annotations.json
+++ b/src/data/proofs/lebesgue-measure/annotations.json
@@ -1,110 +1,134 @@
 [
   {
+    "id": "ann-imports",
+    "proofId": "lebesgue-measure",
+    "range": {"startLine": 1, "endLine": 12},
+    "type": "concept",
+    "title": "Measure Theory Imports",
+    "content": "Imports Mathlib's measure theory stack: Lebesgue measure construction (`Lebesgue.Basic`), its identification with Haar measure (`EqHaar`), the `lintegral` for non-negative functions, the Bochner integral for signed functions, dominated convergence, the Fundamental Theorem of Calculus, product measures (for Fubini), $L^p$ spaces, and special integrals. This is one of the deepest import chains in Mathlib.",
+    "mathContext": "The import chain builds: $\\sigma$-algebra $\\to$ outer measure $\\to$ Carathéodory extension $\\to$ Haar measure $\\to$ volume on $\\mathbb{R}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Mathlib.MeasureTheory", "Haar measure", "Bochner integral"],
+    "prerequisites": ["measure theory basics", "topology"]
+  },
+  {
     "id": "ann-intro",
     "proofId": "lebesgue-measure",
-    "range": {"startLine": 14, "endLine": 56},
+    "range": {"startLine": 14, "endLine": 60},
     "type": "concept",
     "title": "Lebesgue Measure: Wiedijk #86",
     "content": "**Lebesgue Measure and Integration**:\n\nHenri Lebesgue's 1902 doctoral dissertation revolutionized analysis by introducing:\n\n1. **Lebesgue Measure**: A complete, translation-invariant measure on $\\mathbb{R}^n$ extending the notion of length/area/volume\n\n2. **Key Theorems**:\n   - **Monotone Convergence**: If $f_n \\nearrow f$, then $\\int f_n \\to \\int f$\n   - **Dominated Convergence**: If $|f_n| \\leq g$ integrable and $f_n \\to f$, then $\\int f_n \\to \\int f$\n   - **Fubini's Theorem**: Iterated integrals equal double integrals\n\n**Why Lebesgue?** The Riemann integral can't handle:\n- Functions like the Dirichlet function (1 on $\\mathbb{Q}$, 0 elsewhere)\n- Limits of sequences of Riemann integrable functions\n\nLebesgue's approach: integrate by partitioning the **range** rather than the domain.",
+    "mathContext": "Lebesgue's innovation: define $\\int f\\,d\\mu = \\sup\\{\\int s\\,d\\mu : s \\text{ simple}, s \\leq f\\}$ by partitioning the range of $f$, not the domain",
     "significance": "critical",
-    "relatedConcepts": ["measure theory", "integration", "convergence theorems"]
+    "relatedConcepts": ["measure theory", "integration", "convergence theorems"],
+    "prerequisites": ["Riemann integration", "set theory", "topology"]
   },
   {
     "id": "ann-measure-construction",
     "proofId": "lebesgue-measure",
-    "range": {"startLine": 62, "endLine": 100},
+    "range": {"startLine": 74, "endLine": 100},
     "type": "definition",
     "title": "Lebesgue Measure Construction",
-    "content": "**The Lebesgue Measure on $\\mathbb{R}$**:\n\nIn Mathlib, Lebesgue measure is `volume`, constructed via Haar measure theory.\n\n**Key Properties**:\n```lean\ntheorem lebesgue_measure_Icc (a b : ℝ) (hab : a ≤ b) :\n    volume (Icc a b) = ENNReal.ofReal (b - a)\n\ntheorem lebesgue_measure_singleton (x : ℝ) :\n    volume ({x} : Set ℝ) = 0\n\ntheorem lebesgue_measure_univ :\n    volume (univ : Set ℝ) = ⊤\n```\n\n**Interpretation**:\n- $\\mu([a,b]) = b - a$ (interval has expected length)\n- $\\mu(\\{x\\}) = 0$ (points have zero measure)\n- $\\mu(\\mathbb{R}) = \\infty$ (the line has infinite measure)",
-    "mathContext": "μ([a,b]) = b - a",
+    "content": "**The Lebesgue Measure on $\\mathbb{R}$**:\n\nIn Mathlib, Lebesgue measure is `volume`, constructed via Haar measure theory on the locally compact group $(\\mathbb{R}, +)$.\n\n**Key Properties Proved**:\n- `lebesgue_measure_Icc`: $\\mu([a,b]) = b - a$ for $a \\leq b$\n- `lebesgue_measure_Ioo`: $\\mu((a,b)) = b - a$\n- `lebesgue_measure_singleton`: $\\mu(\\{x\\}) = 0$\n- `lebesgue_measure_univ`: $\\mu(\\mathbb{R}) = \\infty$\n\nThe fact that $\\mu([a,b]) = \\mu((a,b))$ follows from single points having measure zero — the boundary $\\{a, b\\}$ contributes nothing.",
+    "mathContext": "$\\mu([a,b]) = b - a$, $\\mu(\\{x\\}) = 0$, $\\mu(\\mathbb{R}) = +\\infty$",
     "significance": "critical",
-    "relatedConcepts": ["volume", "Real.volume_Icc", "ENNReal"]
+    "relatedConcepts": ["volume", "Real.volume_Icc", "ENNReal", "Haar measure"],
+    "prerequisites": ["outer measure", "Carathéodory extension theorem", "locally compact groups"]
   },
   {
     "id": "ann-translation-invariance",
     "proofId": "lebesgue-measure",
-    "range": {"startLine": 102, "endLine": 128},
+    "range": {"startLine": 116, "endLine": 128},
     "type": "theorem",
     "title": "Translation Invariance",
-    "content": "**Translation Invariance**:\n\nLebesgue measure is invariant under translation: $\\mu(E + c) = \\mu(E)$.\n\n**Lean**:\n```lean\ntheorem lebesgue_measure_translation_invariant :\n    IsAddLeftInvariant (volume : Measure ℝ) := inferInstance\n\ntheorem volume_add_left (c : ℝ) (E : Set ℝ) (hE : MeasurableSet E) :\n    volume ((fun x => c + x) '' E) = volume E\n```\n\n**Significance**:\n- This property **uniquely characterizes** Lebesgue measure (up to scaling)\n- Essential for physics: laws shouldn't depend on position\n- Foundation for Haar measure on groups\n\nIn Mathlib, this follows from the general theory of Haar measures on locally compact groups.",
-    "mathContext": "μ(E + c) = μ(E)",
-    "significance": "major",
-    "relatedConcepts": ["IsAddLeftInvariant", "Haar measure", "uniqueness"]
+    "content": "**Translation Invariance**: $\\mu(E + c) = \\mu(E)$\n\nLebesgue measure is invariant under translation. In Lean, this is expressed as `IsAddLeftInvariant volume`, which Mathlib derives from the fact that Lebesgue measure is a Haar measure on $(\\mathbb{R}, +)$.\n\nThe explicit proof of `volume_add_left` uses `measure_preimage_add`, rewriting the image $c + E$ as the preimage of $E$ under $x \\mapsto -c + x$.\n\n**Uniqueness**: Any translation-invariant Borel measure on $\\mathbb{R}$ that assigns finite measure to $[0,1]$ is a scalar multiple of Lebesgue measure. This is a special case of the uniqueness of Haar measure on locally compact groups.",
+    "mathContext": "$\\mu(E + c) = \\mu(E)$ for all measurable $E$ and $c \\in \\mathbb{R}$; Lebesgue measure is the unique (up to scaling) translation-invariant Borel measure",
+    "significance": "key",
+    "relatedConcepts": ["IsAddLeftInvariant", "Haar measure", "uniqueness of Haar measure", "measure_preimage_add"],
+    "prerequisites": ["locally compact groups", "Borel sigma-algebra", "Haar measure theory"]
   },
   {
     "id": "ann-lebesgue-integral",
     "proofId": "lebesgue-measure",
-    "range": {"startLine": 130, "endLine": 170},
+    "range": {"startLine": 146, "endLine": 170},
     "type": "definition",
     "title": "The Lebesgue Integral",
-    "content": "**Lebesgue Integration**:\n\nFor non-negative measurable $f$:\n$$\\int f \\, d\\mu = \\sup \\left\\{ \\int s \\, d\\mu : s \\text{ simple}, s \\leq f \\right\\}$$\n\n**Mathlib Notation**:\n- `∫⁻ x, f x ∂μ` — lintegral for $[0, \\infty]$-valued functions\n- `∫ x, f x ∂μ` — Bochner integral for signed/complex functions\n\n**Properties**:\n```lean\ntheorem integral_add_of_integrable\n    (hf : Integrable f) (hg : Integrable g) :\n    ∫ (f + g) = ∫ f + ∫ g\n\ntheorem integral_smul_const (c : ℝ) (f : ℝ → ℝ) :\n    ∫ c * f = c * ∫ f\n```\n\n**Key Difference from Riemann**: Partition the **range** of $f$, not the domain.",
-    "mathContext": "∫f dμ = sup{∫s : s simple, s ≤ f}",
+    "content": "**Lebesgue Integration in Mathlib**:\n\nTwo integral notations coexist:\n- `∫⁻ x, f x ∂μ` — the **lintegral** for $[0, \\infty]$-valued functions (using `ENNReal`)\n- `∫ x, f x ∂μ` — the **Bochner integral** for signed/complex/Banach-valued functions\n\n**Properties demonstrated**:\n- `integral_const_on_Icc`: $\\int_{[a,b]} c = c(b-a)$, proved by unfolding `setIntegral_const` and `Real.volume_Icc`\n- `integral_add_of_integrable`: linearity $\\int(f+g) = \\int f + \\int g$\n- `integral_smul_const`: scalar multiplication $\\int(cf) = c\\int f$\n\nThe Bochner integral extends Lebesgue's original construction to Banach-space-valued functions, essential for vector-valued analysis and probability.",
+    "mathContext": "$\\int_a^b c\\,dx = c(b-a)$; $\\int(f+g) = \\int f + \\int g$; $\\int cf = c\\int f$",
     "significance": "critical",
-    "relatedConcepts": ["lintegral", "Bochner integral", "simple functions"]
+    "relatedConcepts": ["lintegral", "Bochner integral", "simple functions", "ENNReal"],
+    "prerequisites": ["measurable functions", "simple function approximation", "Banach spaces"]
   },
   {
     "id": "ann-monotone-convergence",
     "proofId": "lebesgue-measure",
-    "range": {"startLine": 172, "endLine": 210},
+    "range": {"startLine": 191, "endLine": 210},
     "type": "theorem",
     "title": "Monotone Convergence Theorem",
-    "content": "**Monotone Convergence Theorem**:\n\nIf $f_n \\nearrow f$ pointwise (non-decreasing to $f$), then:\n$$\\int f_n \\, d\\mu \\to \\int f \\, d\\mu$$\n\n**Lean**:\n```lean\ntheorem monotone_convergence\n    (hf_mono : ∀ x, Monotone (fun n => f n x))\n    (hf_lim : ∀ x, Tendsto (fun n => f n x) atTop (nhds (g x))) :\n    Tendsto (fun n => ∫⁻ f n) atTop (nhds (∫⁻ g))\n```\n\n**Corollary** (Series):\n$$\\int \\sum_n f_n = \\sum_n \\int f_n$$\n\n**Why Important**: Justifies interchanging limits and integrals under monotonicity — no need for uniform convergence!",
-    "mathContext": "fₙ ↗ f ⟹ ∫fₙ → ∫f",
+    "content": "**Monotone Convergence Theorem** (Beppo Levi, 1906):\n\nIf $f_n \\nearrow f$ pointwise (non-decreasing to $f$), then:\n$$\\int f_n \\, d\\mu \\to \\int f \\, d\\mu$$\n\nThe proof delegates to `lintegral_tendsto_of_tendsto_of_monotone`, converting pointwise hypotheses to almost-everywhere statements via `ae_of_all`.\n\n**Corollary** (`lintegral_tsum_eq`): For non-negative measurable $f_n$,\n$$\\int \\sum_n f_n = \\sum_n \\int f_n$$\nThis is proved via `lintegral_tsum` and is essential for series manipulations in analysis.\n\n**Why Important**: Justifies interchanging limits and integrals under monotonicity — no need for uniform convergence. This is strictly weaker than dominated convergence but applies to $[0,\\infty]$-valued functions where no integrable bound is needed.",
+    "mathContext": "$f_n \\nearrow f \\implies \\int f_n \\to \\int f$; $\\int \\sum_n f_n = \\sum_n \\int f_n$",
     "significance": "critical",
-    "relatedConcepts": ["lintegral_tendsto_of_tendsto_of_monotone", "series", "lintegral_tsum"]
+    "relatedConcepts": ["lintegral_tendsto_of_tendsto_of_monotone", "lintegral_tsum", "ae_of_all"],
+    "prerequisites": ["measurable functions", "ENNReal-valued integration", "filter convergence"]
   },
   {
     "id": "ann-dominated-convergence",
     "proofId": "lebesgue-measure",
-    "range": {"startLine": 212, "endLine": 239},
+    "range": {"startLine": 230, "endLine": 239},
     "type": "theorem",
     "title": "Dominated Convergence Theorem",
-    "content": "**Dominated Convergence Theorem**:\n\nIf $f_n \\to f$ pointwise a.e. and $|f_n| \\leq g$ for integrable $g$, then:\n$$\\int f_n \\, d\\mu \\to \\int f \\, d\\mu$$\n\n**Lean**:\n```lean\ntheorem dominated_convergence\n    (hf_bound : ∀ n, ∀ᵐ x, ‖f n x‖ ≤ bound x)\n    (hbound_int : Integrable bound)\n    (hf_lim : ∀ᵐ x, Tendsto (f · x) atTop (nhds (g x))) :\n    Tendsto (fun n => ∫ f n) atTop (nhds (∫ g))\n```\n\n**The Workhorse Theorem**: This is the most practically useful convergence result:\n- Works for signed functions\n- Only needs pointwise a.e. convergence\n- Requires only a dominating bound, not monotonicity\n\n**Applications**: Differentiating under the integral sign, Fourier analysis, PDE.",
-    "mathContext": "|fₙ| ≤ g, fₙ → f ⟹ ∫fₙ → ∫f",
+    "content": "**Dominated Convergence Theorem** (Lebesgue, 1910):\n\nIf $f_n \\to f$ pointwise a.e. and $\\|f_n(x)\\| \\leq g(x)$ for integrable $g$, then:\n$$\\int f_n \\, d\\mu \\to \\int f \\, d\\mu$$\n\nThe proof is a single line delegating to `tendsto_integral_of_dominated_convergence`, which is one of the deepest results in Mathlib's measure theory library.\n\n**Why this is the workhorse**: Unlike monotone convergence (requires monotonicity) or uniform convergence (requires uniformity), DCT needs only:\n1. Pointwise a.e. convergence\n2. An integrable dominating function\n\nThis generality makes it applicable throughout analysis, probability, and PDE theory. It also implies that $f$ itself is integrable — a free bonus.",
+    "mathContext": "$\\|f_n\\| \\leq g \\in L^1$, $f_n \\to f$ a.e. $\\implies \\int f_n \\to \\int f$ and $f \\in L^1$",
     "significance": "critical",
-    "relatedConcepts": ["tendsto_integral_of_dominated_convergence", "dominating function", "a.e."]
+    "relatedConcepts": ["tendsto_integral_of_dominated_convergence", "AEStronglyMeasurable", "Integrable"],
+    "prerequisites": ["Bochner integral", "a.e. convergence", "integrable functions", "normed spaces"]
   },
   {
     "id": "ann-fubini",
     "proofId": "lebesgue-measure",
-    "range": {"startLine": 241, "endLine": 294},
+    "range": {"startLine": 260, "endLine": 294},
     "type": "theorem",
     "title": "Fubini's Theorem",
-    "content": "**Fubini's Theorem**:\n\nFor product measures, iterated integrals equal the double integral:\n$$\\int\\int f(x,y) \\, dx \\, dy = \\int\\int f(x,y) \\, dy \\, dx = \\iint f \\, d(\\mu \\times \\nu)$$\n\n**Lean** (Tonelli form for non-negative):\n```lean\ntheorem fubini_tonelli (hf : Measurable f) :\n    ∫⁻ x, ∫⁻ y, f (x, y) = ∫⁻ p, f p ∂(volume.prod volume)\n```\n\n**Lean** (General form):\n```lean\ntheorem fubini (hf : Integrable f (volume.prod volume)) :\n    ∫ x, ∫ y, f (x, y) = ∫ y, ∫ x, f (x, y)\n```\n\n**Applications**:\n- Computing volumes by slicing\n- Changing order of integration\n- Multi-dimensional probability",
-    "mathContext": "∫∫f dx dy = ∫∫f dy dx",
+    "content": "**Fubini-Tonelli Theorem**:\n\nTwo forms are proved:\n\n1. **Tonelli** (non-negative): For measurable $f : \\mathbb{R}^2 \\to [0,\\infty]$,\n$$\\int\\int f(x,y)\\,d\\mu(x)\\,d\\nu(y) = \\int f\\,d(\\mu \\times \\nu)$$\nProved via `lintegral_prod`.\n\n2. **Fubini** (integrable): For $f \\in L^1(\\mu \\times \\nu)$,\n$$\\int\\int f(x,y)\\,d\\mu\\,d\\nu = \\int\\int f(x,y)\\,d\\nu\\,d\\mu$$\nThe proof shows both iterated integrals equal the product integral using `integral_prod`, then applies `integral_prod_swap` with `hf.comp_measurable measurable_swap` for the other order.\n\nAlso proves `integral_prod_eq_integral_integral`: the product integral equals the iterated integral.\n\n**Historical note**: Guido Fubini (1907) and Leonida Tonelli (1909) independently established these results. Tonelli's version for non-negative functions doesn't require integrability — a crucial distinction.",
+    "mathContext": "$\\int\\int f\\,dx\\,dy = \\int\\int f\\,dy\\,dx = \\iint f\\,d(\\mu \\times \\nu)$",
     "significance": "critical",
-    "relatedConcepts": ["product measure", "integral_prod", "Tonelli"]
+    "relatedConcepts": ["product measure", "lintegral_prod", "integral_prod", "integral_prod_swap", "measurable_swap"],
+    "prerequisites": ["product measures", "Tonelli's theorem", "integrability on product spaces"]
   },
   {
     "id": "ann-completeness",
     "proofId": "lebesgue-measure",
-    "range": {"startLine": 296, "endLine": 324},
+    "range": {"startLine": 306, "endLine": 324},
     "type": "theorem",
     "title": "Completeness and Null Sets",
-    "content": "**Completeness of Lebesgue Measure**:\n\nSubsets of null sets are measurable (and have measure zero).\n\n**Key Results**:\n```lean\ntheorem countable_measure_zero (hs : s.Countable) :\n    volume s = 0\n\ntheorem rationals_measure_zero :\n    volume (Set.range (Rat.cast : ℚ → ℝ)) = 0\n```\n\n**Famous Examples**:\n- $\\mathbb{Q}$ is countable, so $\\mu(\\mathbb{Q}) = 0$\n- The **Cantor set** is uncountable but has measure zero\n- There exist measure-zero sets with cardinality of the continuum\n\n**Significance**: Completeness means we can work with \"almost everywhere\" statements without worrying about measurability of exceptional sets.",
-    "mathContext": "countable ⟹ measure zero",
-    "significance": "major",
-    "relatedConcepts": ["null sets", "Cantor set", "completion"]
+    "content": "**Completeness of Lebesgue Measure**:\n\nProves two key results about null sets:\n\n1. `countable_measure_zero`: Any countable set $S \\subseteq \\mathbb{R}$ has $\\mu(S) = 0$, via `Set.Countable.measure_zero`.\n\n2. `rationals_measure_zero`: $\\mu(\\mathbb{Q}) = 0$ as a corollary, since $\\mathbb{Q}$ is countable (`Set.countable_range`).\n\nThe Cantor set theorem is stated as `True` (placeholder) but represents the deep fact that uncountable sets can have measure zero. The standard Cantor set $C \\subseteq [0,1]$ satisfies $|C| = |\\mathbb{R}|$ (continuum cardinality) but $\\mu(C) = 0$ because the total length removed is $\\sum_{n=1}^\\infty 2^{n-1}/3^n = 1$.",
+    "mathContext": "$S$ countable $\\implies \\mu(S) = 0$; $\\mu(\\mathbb{Q}) = 0$; Cantor set: $|C| = \\mathfrak{c}$ but $\\mu(C) = 0$",
+    "significance": "key",
+    "relatedConcepts": ["null sets", "Cantor set", "Set.Countable.measure_zero", "completion of measures"],
+    "prerequisites": ["countable sets", "sigma-algebra completion", "geometric series"]
   },
   {
     "id": "ann-riemann-comparison",
     "proofId": "lebesgue-measure",
-    "range": {"startLine": 326, "endLine": 370},
-    "type": "note",
-    "title": "Riemann vs Lebesgue",
-    "content": "**Lebesgue Extends Riemann**:\n\nEvery Riemann integrable function is Lebesgue integrable (with same value), but not vice versa.\n\n**The Dirichlet Function**:\n$$f(x) = \\begin{cases} 1 & x \\in \\mathbb{Q} \\\\ 0 & x \\notin \\mathbb{Q} \\end{cases}$$\n\n- **Riemann**: Not integrable (upper and lower sums differ)\n- **Lebesgue**: $\\int_0^1 f = 0$ because $\\mathbb{Q}$ has measure zero\n\n**Lean**:\n```lean\ntheorem dirichlet_function_integral :\n    ∫ x in Icc 0 1, indicator ℚ (fun _ => 1) x = 0\n```\n\n**Why Lebesgue Wins**: Functions equal almost everywhere have equal integrals. The Dirichlet function equals 0 a.e., so its integral is 0.",
-    "mathContext": "Dirichlet function: Lebesgue integrable, not Riemann",
-    "significance": "major",
-    "relatedConcepts": ["Dirichlet function", "almost everywhere", "indicator"]
+    "range": {"startLine": 337, "endLine": 370},
+    "type": "insight",
+    "title": "Riemann vs Lebesgue Integration",
+    "content": "**Lebesgue Extends Riemann**:\n\nEvery Riemann integrable function is Lebesgue integrable (with the same value), but not vice versa.\n\n`bounded_measurable_integrable_on_Icc` proves that bounded measurable functions on $[a,b]$ are Lebesgue integrable, using `Integrable.mono'` with the constant bound $M$.\n\n**The Dirichlet Function**: $f(x) = \\mathbf{1}_{\\mathbb{Q}}(x)$ is the canonical example:\n- **Riemann**: Not integrable (upper and lower sums always differ by 1)\n- **Lebesgue**: $\\int_0^1 f = 0$ because $\\mathbb{Q} \\cap [0,1]$ has measure zero\n\nThe integral is axiomatized here rather than fully proved. A complete proof would use `integral_eq_zero_of_ae` together with `rationals_measure_zero` to show the integrand is zero almost everywhere.\n\n**Lebesgue's criterion**: A bounded function on $[a,b]$ is Riemann integrable iff its set of discontinuities has Lebesgue measure zero.",
+    "mathContext": "Dirichlet function $\\mathbf{1}_{\\mathbb{Q}}$: not Riemann integrable, but $\\int_0^1 \\mathbf{1}_{\\mathbb{Q}} = 0$ in the Lebesgue sense",
+    "significance": "key",
+    "relatedConcepts": ["Riemann integrability", "Dirichlet function", "Lebesgue's criterion", "integral_eq_zero_of_ae"],
+    "prerequisites": ["Riemann integration", "measure zero", "almost everywhere"]
   },
   {
     "id": "ann-applications",
     "proofId": "lebesgue-measure",
-    "range": {"startLine": 372, "endLine": 401},
-    "type": "note",
-    "title": "Applications",
-    "content": "**Modern Applications**:\n\n1. **Probability Theory**: Kolmogorov axioms use Lebesgue integration\n   - Expected value = Lebesgue integral\n   - Convergence theorems for random variables\n\n2. **Functional Analysis**: $L^p$ spaces\n   - $L^2$ is a Hilbert space (Fourier analysis)\n   - Hölder's inequality: $\\|fg\\|_1 \\leq \\|f\\|_p \\cdot \\|g\\|_q$\n\n3. **PDEs**: Weak solutions\n   - Sobolev spaces use Lebesgue integration\n   - Distributional derivatives\n\n4. **Fourier Analysis**:\n   - $L^2$ theory of Fourier series\n   - Plancherel theorem\n\n**The Dominated Convergence Theorem alone justifies the entire theory** — it's used constantly in analysis and probability.",
-    "significance": "minor",
-    "relatedConcepts": ["Lp spaces", "probability", "Fourier analysis"]
+    "range": {"startLine": 388, "endLine": 401},
+    "type": "concept",
+    "title": "Applications: $L^p$ Spaces and Holder's Inequality",
+    "content": "**Modern Applications of Lebesgue Integration**:\n\n1. **$L^p$ Spaces**: The space $L^p(\\mu)$ of functions with $\\int |f|^p < \\infty$ forms a Banach space. For $p = 2$, it's a Hilbert space — the natural setting for Fourier analysis. The example shows the zero function as an element of $L^2(\\mathbb{R})$.\n\n2. **Holder's Inequality**: For conjugate exponents $\\frac{1}{p} + \\frac{1}{q} = 1$,\n$$\\|fg\\|_1 \\leq \\|f\\|_p \\cdot \\|g\\|_q$$\nThis is stated as a placeholder (`True`). The full result is available in Mathlib as `NNNorm.inner_le_Lp_mul_Lq`.\n\n3. **Probability**: Kolmogorov's axioms define probability as a measure with $\\mu(\\Omega) = 1$; expectations, variances, and moment conditions all use Lebesgue integration.\n\n4. **PDEs**: Sobolev spaces $W^{k,p}$ use $L^p$-based weak derivatives for existence theory of partial differential equations.",
+    "mathContext": "$L^p(\\mu) = \\{f : \\int |f|^p\\,d\\mu < \\infty\\}$; Holder: $\\|fg\\|_1 \\leq \\|f\\|_p \\|g\\|_q$ when $1/p + 1/q = 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["Lp spaces", "Holder inequality", "Hilbert space", "Sobolev spaces", "Kolmogorov axioms"],
+    "prerequisites": ["Banach spaces", "Hilbert spaces", "conjugate exponents"]
   }
 ]

--- a/src/data/proofs/lebesgue-measure/meta.json
+++ b/src/data/proofs/lebesgue-measure/meta.json
@@ -30,6 +30,21 @@
         "theorem": "MeasurableSet",
         "description": "Measurable sets",
         "module": "Mathlib.MeasureTheory.MeasurableSpace.Basic"
+      },
+      {
+        "theorem": "lintegral_tendsto_of_tendsto_of_monotone",
+        "description": "Monotone convergence theorem for lintegral",
+        "module": "Mathlib.MeasureTheory.Integral.Lebesgue.Basic"
+      },
+      {
+        "theorem": "tendsto_integral_of_dominated_convergence",
+        "description": "Dominated convergence theorem for Bochner integral",
+        "module": "Mathlib.MeasureTheory.Integral.DominatedConvergence"
+      },
+      {
+        "theorem": "integral_prod",
+        "description": "Fubini's theorem for product measures",
+        "module": "Mathlib.MeasureTheory.Measure.Prod"
       }
     ],
     "originalContributions": [
@@ -40,46 +55,123 @@
     "dateAdded": "12/29/25"
   },
   "overview": {
-    "historicalContext": "Lebesgue introduced his measure and integral in his 1901 thesis, revolutionizing analysis. Unlike the Riemann integral, the Lebesgue integral handles limits more gracefully, enabling powerful theorems like dominated convergence.",
-    "problemStatement": "**Lebesgue Measure**: There exists a complete, translation-invariant measure mu on R^n such that:\n- mu([a,b]) = b - a for intervals\n- mu is countably additive on disjoint measurable sets\n- The measurable sets form a sigma-algebra containing all Borel sets",
-    "proofStrategy": "Construct Lebesgue outer measure using infima of covering collections of intervals. Define measurable sets using Caratheodory's criterion. Verify the measure has the required properties.",
+    "historicalContext": "Henri Lebesgue (1875-1941) introduced his measure and integral in his 1902 doctoral thesis *Intégrale, longueur, aire*, submitted at the Sorbonne under Émile Borel's influence. The work resolved fundamental limitations of Bernhard Riemann's 1854 integral, which could not handle limits of integrable functions or highly discontinuous functions like Dirichlet's indicator of the rationals. Lebesgue's key innovation was to partition the *range* of a function rather than its domain, enabling integration of a vastly larger class of functions. Constantin Carathéodory (1914) later provided an elegant alternative construction via outer measures and his measurability criterion, which is the approach used in Mathlib. Giuseppe Vitali's 1905 construction of a non-measurable set showed that not every subset of $\\mathbb{R}$ can be assigned a measure, demonstrating the necessity of restricting to a $\\sigma$-algebra. The Lebesgue integral's powerful limit theorems — monotone convergence (Beppo Levi, 1906) and dominated convergence (Lebesgue, 1910) — became indispensable tools, forming the foundation of Andrey Kolmogorov's axiomatization of probability theory (1933) and the $L^p$ spaces central to Stefan Banach's functional analysis.",
+    "problemStatement": "**Lebesgue Measure**: There exists a complete, translation-invariant measure $\\mu$ on $\\mathbb{R}^n$ such that:\n- $\\mu([a,b]) = b - a$ for intervals\n- $\\mu$ is countably additive on disjoint measurable sets\n- The measurable sets form a $\\sigma$-algebra containing all Borel sets\n- $\\mu(E + c) = \\mu(E)$ for all measurable $E$ and $c \\in \\mathbb{R}$",
+    "proofStrategy": "Mathlib constructs Lebesgue measure via **Haar measure theory** on the locally compact group $(\\mathbb{R}, +)$. The construction uses the Carathéodory extension theorem: define an outer measure from infima of coverings by intervals, then restrict to sets satisfying Carathéodory's measurability criterion. This file demonstrates the key properties and convergence theorems that make Lebesgue integration indispensable: translation invariance, measure of intervals, monotone and dominated convergence, and Fubini's theorem for product measures.",
     "keyInsights": [
-      "Lebesgue measure extends 'length' far beyond intervals",
-      "Not all sets are measurable (Vitali set construction)",
-      "The Lebesgue integral is more powerful than Riemann's",
-      "Foundation for probability theory and modern analysis"
+      "**Carathéodory's criterion** provides a clean characterization of measurable sets: $E$ is measurable iff $\\mu^*(A) = \\mu^*(A \\cap E) + \\mu^*(A \\setminus E)$ for all $A$, making the $\\sigma$-algebra structure automatic",
+      "**Translation invariance uniquely determines** Lebesgue measure up to a scalar multiple — any translation-invariant Borel measure on $\\mathbb{R}$ is a constant times Lebesgue measure, a deep consequence of Haar measure theory",
+      "**Dominated convergence is the workhorse theorem** of modern analysis: it provides the minimal hypotheses (pointwise a.e. convergence plus an integrable bound) under which limits commute with integrals, replacing the far more restrictive uniform convergence condition",
+      "**Vitali's non-measurable set** (1905) uses the Axiom of Choice to construct a set with no consistent measure, proving that the restriction to $\\sigma$-algebras is unavoidable — not a technical inconvenience but a mathematical necessity",
+      "**The Lebesgue integral unifies** probability and analysis: Kolmogorov's axioms (1933) define probability as a measure, expected values as Lebesgue integrals, and the strong law of large numbers as a consequence of dominated convergence"
     ]
   },
   "sections": [
     {
-      "id": "outer-measure",
-      "title": "Outer Measure Construction",
-      "startLine": 50,
-      "endLine": 120,
-      "summary": "Building measure via coverings by intervals."
+      "id": "imports-and-docstring",
+      "title": "Imports and Documentation",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Imports from Mathlib's measure theory, integration, and topology libraries. The module docstring outlines the five main results formalized: Lebesgue measure construction, translation invariance, monotone convergence, dominated convergence, and Fubini's theorem."
     },
     {
-      "id": "measurable-sets",
-      "title": "Measurable Sets",
-      "startLine": 120,
-      "endLine": 200,
-      "summary": "Caratheodory criterion and sigma-algebra."
+      "id": "measure-construction",
+      "title": "Lebesgue Measure on $\\mathbb{R}$",
+      "startLine": 62,
+      "endLine": 100,
+      "summary": "Demonstrates that `volume` in Mathlib is the Lebesgue measure on $\\mathbb{R}$. Proves $\\mu([a,b]) = b-a$, $\\mu((a,b)) = b-a$, $\\mu(\\{x\\}) = 0$, and $\\mu(\\mathbb{R}) = \\infty$ using Mathlib's `Real.volume_Icc` and related lemmas."
     },
     {
-      "id": "properties",
-      "title": "Key Properties",
-      "startLine": 200,
-      "endLine": 280,
-      "summary": "Translation invariance, completeness, countable additivity."
+      "id": "translation-invariance",
+      "title": "Translation Invariance",
+      "startLine": 102,
+      "endLine": 128,
+      "summary": "Establishes that Lebesgue measure is left-invariant under addition: $\\mu(E + c) = \\mu(E)$. This follows from Mathlib's Haar measure infrastructure via `IsAddLeftInvariant` and `measure_preimage_add`."
+    },
+    {
+      "id": "lebesgue-integral",
+      "title": "The Lebesgue Integral",
+      "startLine": 130,
+      "endLine": 170,
+      "summary": "Introduces both the `lintegral` ($[0,\\infty]$-valued) and Bochner integral (signed/complex-valued) notations. Proves integration of constants over intervals, linearity $\\int(f+g) = \\int f + \\int g$, and scalar multiplication $\\int(cf) = c\\int f$."
+    },
+    {
+      "id": "monotone-convergence",
+      "title": "Monotone Convergence Theorem",
+      "startLine": 172,
+      "endLine": 210,
+      "summary": "Proves the monotone convergence theorem: if $f_n \\nearrow f$ pointwise, then $\\int f_n \\to \\int f$. Also proves the series corollary $\\int \\sum_n f_n = \\sum_n \\int f_n$ via `lintegral_tsum`."
+    },
+    {
+      "id": "dominated-convergence",
+      "title": "Dominated Convergence Theorem",
+      "startLine": 212,
+      "endLine": 239,
+      "summary": "Proves the dominated convergence theorem: if $|f_n| \\leq g$ for integrable $g$ and $f_n \\to f$ a.e., then $\\int f_n \\to \\int f$. Delegates to Mathlib's `tendsto_integral_of_dominated_convergence`."
+    },
+    {
+      "id": "fubini-theorem",
+      "title": "Fubini's Theorem",
+      "startLine": 241,
+      "endLine": 294,
+      "summary": "Proves both the Tonelli form (non-negative functions: iterated lintegral equals product lintegral) and the general Fubini form (integrable functions: order of iterated integrals can be swapped). Uses Mathlib's `lintegral_prod` and `integral_prod`."
+    },
+    {
+      "id": "completeness-null-sets",
+      "title": "Completeness and Null Sets",
+      "startLine": 296,
+      "endLine": 324,
+      "summary": "Shows that countable sets have measure zero and applies this to prove $\\mu(\\mathbb{Q}) = 0$. Notes the Cantor set as a famous example of an uncountable null set."
+    },
+    {
+      "id": "riemann-comparison",
+      "title": "Comparison with Riemann Integration",
+      "startLine": 326,
+      "endLine": 370,
+      "summary": "Proves that bounded measurable functions on $[a,b]$ are Lebesgue integrable. Axiomatizes the Dirichlet function integral $\\int_{[0,1]} \\mathbf{1}_{\\mathbb{Q}} = 0$ as a demonstration that Lebesgue integration handles functions that are not Riemann integrable."
+    },
+    {
+      "id": "applications",
+      "title": "Applications and $L^p$ Spaces",
+      "startLine": 372,
+      "endLine": 413,
+      "summary": "Demonstrates $L^2$ space membership and states Holder's inequality. Includes verification `#check` statements confirming the formalized theorems are well-typed."
     }
   ],
   "conclusion": {
-    "summary": "Lebesgue measure is the foundation of modern analysis and probability. It provides the right notion of 'size' for doing integration theory in full generality.",
-    "implications": "Applications include probability theory, functional analysis, harmonic analysis, and PDEs. The Lebesgue integral's limit theorems are essential throughout mathematics.",
+    "summary": "This formalization demonstrates the core infrastructure of Lebesgue measure theory as built in Mathlib: the measure itself (via Haar measure on $\\mathbb{R}$), its key properties (translation invariance, interval measure, null sets), and the three great convergence theorems (monotone, dominated, Fubini). The proofs leverage Mathlib's deep measure theory library, showing how formal mathematics can present these foundational results with full rigor.",
+    "implications": "Lebesgue measure and integration underpin virtually all of modern analysis: probability theory rests on measure spaces (Kolmogorov's axioms), functional analysis uses $L^p$ spaces built from the Lebesgue integral, Fourier analysis requires $L^2$ completeness, and PDE theory relies on Sobolev spaces defined via weak derivatives and Lebesgue integrability. The dominated convergence theorem alone is invoked thousands of times across mathematical research, making it arguably the single most useful theorem in analysis.",
     "openQuestions": [
-      "What is the structure of non-measurable sets?",
-      "How does Lebesgue measure generalize to infinite dimensions?",
-      "What are the connections to fractal dimension?"
+      "Can the Dirichlet function integral axiom be replaced by a full proof using Mathlib's `integral_eq_zero_of_ae` and the countability of $\\mathbb{Q}$?",
+      "Can Holder's inequality be formally stated and proved rather than axiomatized as `True`?",
+      "How does Lebesgue measure generalize to infinite-dimensional spaces, where no translation-invariant $\\sigma$-finite measure exists (a result relevant to path integrals in quantum mechanics)?",
+      "What is the measure-theoretic relationship between the Cantor set (uncountable, measure zero) and sets of positive measure but empty interior?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "fundamental-theorem-calculus",
+      "relationship": "The Fundamental Theorem of Calculus holds in the Lebesgue setting: if $f$ is absolutely continuous, then $f' \\in L^1$ and $\\int_a^b f' = f(b) - f(a)$."
+    },
+    {
+      "targetId": "fourier-series",
+      "relationship": "Fourier series convergence in $L^2$ relies on the completeness of the Lebesgue $L^2$ space and the Riesz-Fischer theorem."
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "The Central Limit Theorem is stated and proved using measure-theoretic probability, where random variables are measurable functions and expectations are Lebesgue integrals."
+    },
+    {
+      "targetId": "laws-of-large-numbers",
+      "relationship": "The Strong Law of Large Numbers uses dominated convergence and measure-theoretic tools to establish almost sure convergence of sample means."
+    },
+    {
+      "targetId": "cauchy-schwarz-integral",
+      "relationship": "The integral Cauchy-Schwarz inequality $|\\int fg| \\leq \\|f\\|_2 \\|g\\|_2$ is a special case of Holder's inequality in the Lebesgue $L^2$ space."
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "Cantor's theorem that $\\mathbb{R}$ is uncountable connects to the existence of uncountable null sets (like the Cantor set) and non-measurable sets (Vitali's construction)."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for `lebesgue-measure` (Wiedijk #86, quality 91 → improved).

- Expanded `historicalContext` to 900+ chars: Lebesgue's 1902 thesis, Carathéodory (1914), Vitali (1905), Beppo Levi (1906), Kolmogorov (1933), Banach
- Added 5 mathematically deep `keyInsights` with LaTeX (Carathéodory's criterion, translation invariance uniqueness, DCT as workhorse, Vitali's non-measurable set, Lebesgue-Kolmogorov unification)
- Expanded `sections` from 3 to 10, covering the full Lean file (lines 1-413)
- Added `crossReferences` to 6 related gallery proofs (FTC, Fourier series, CLT, LLN, Cauchy-Schwarz integral, Cantor diagonalization)
- Added `mathContext` and `prerequisites` to all 11 annotations
- Fixed invalid annotation types (`note` → `insight`/`concept`) and significance values (`major` → `key`, `minor` → `supporting`)
- Added new import annotation covering lines 1-12
- Aligned all `startLine` values to actual Lean constructs
- Expanded `mathlibDependencies` from 2 to 5 entries
- Deepened `conclusion` with specific `openQuestions` about axiomatized results

## Test plan

- [x] `pnpm annotations:build` passes (non-strict)
- [x] JSON is well-formed
- [x] All annotations have `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- [x] Sections cover full Lean file (10 sections, lines 1-413)

🤖 Generated with [Claude Code](https://claude.com/claude-code)