### PR TITLE
enrich(liouville-theorem): add mathContext, crossReferences, expand historicalContext

### DIFF
--- a/src/data/proofs/liouville-theorem/annotations.json
+++ b/src/data/proofs/liouville-theorem/annotations.json
@@ -3,11 +3,25 @@
     "id": "ann-intro",
     "proofId": "liouville-theorem",
     "range": {"startLine": 8, "endLine": 72},
-    "type": "concept",
-    "title": "Liouville's Theorem on Transcendentals",
-    "content": "**Wiedijk #18**: First Explicit Transcendental Number (1844)\n\nLiouville proved: **Numbers that can be approximated \"too well\" by rationals must be transcendental.**\n\nThis was the **first constructive proof** that transcendental numbers exist — before Cantor's diagonal argument (1874), before e (1873), before π (1882)!",
+    "type": "context",
+    "title": "Historical Introduction and Overview",
+    "content": "**Wiedijk #18**: First Explicit Transcendental Number (1844)\n\nLiouville proved: **Numbers that can be approximated \"too well\" by rationals must be transcendental.**\n\nThis was the **first constructive proof** that transcendental numbers exist — before Cantor's diagonal argument (1874), before Hermite proved $e$ is transcendental (1873), before Lindemann proved $\\pi$ is transcendental (1882). Liouville's approach was entirely novel: rather than proving a specific constant transcendental, he identified a *class* of numbers (now called Liouville numbers) and showed the entire class is transcendental.",
+    "mathContext": "A number $\\xi$ is Liouville if for every $n \\geq 1$, there exist $p, q \\in \\mathbb{Z}$ with $q > 1$ such that $0 < |\\xi - p/q| < 1/q^n$. Liouville showed all such numbers are transcendental.",
     "significance": "critical",
-    "relatedConcepts": ["transcendental numbers", "Diophantine approximation", "algebraic numbers"]
+    "relatedConcepts": ["transcendental numbers", "Diophantine approximation", "algebraic numbers", "continued fractions"],
+    "prerequisites": ["algebraic number", "minimal polynomial", "transcendental number"]
+  },
+  {
+    "id": "ann-setup",
+    "proofId": "liouville-theorem",
+    "range": {"startLine": 74, "endLine": 104},
+    "type": "definition",
+    "title": "Definitions and Background",
+    "content": "**Core definitions from Mathlib**:\n\n- `IsAlgebraic ℤ x`: $x$ is a root of some nonzero polynomial with integer coefficients\n- `Transcendental ℤ x`: $x$ is not algebraic (no such polynomial exists)\n- `Liouville x`: for every $n$, there exist $p/q$ with $q > 1$ approximating $x$ to within $1/q^n$\n\nThe **degree** of an algebraic number is the degree of its minimal polynomial — the lowest-degree nonzero polynomial it satisfies. This degree controls the approximation quality: higher degree means potentially better approximation by rationals.",
+    "mathContext": "$\\alpha$ is algebraic of degree $n$ if $n = \\deg(\\min_\\alpha)$ where $\\min_\\alpha$ is the minimal polynomial of $\\alpha$ over $\\mathbb{Q}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["minimal polynomial", "algebraic closure", "polynomial degree"],
+    "prerequisites": ["ring theory", "polynomial rings", "field extensions"]
   },
   {
     "id": "ann-approximation",
@@ -15,10 +29,11 @@
     "range": {"startLine": 109, "endLine": 163},
     "type": "theorem",
     "title": "Liouville's Approximation Theorem",
-    "content": "**Key Result**: If α is algebraic of degree n ≥ 2, then:\n\n$$\\left|\\alpha - \\frac{p}{q}\\right| > \\frac{c}{q^n}$$\n\nfor some constant c > 0 and all rationals p/q.\n\n**Proof idea**:\n1. Let P(x) be α's minimal polynomial (degree n)\n2. For p/q ≠ α: q^n · P(p/q) is a nonzero integer, so ≥ 1\n3. Mean Value Theorem bounds the difference\n4. This gives the 1/q^n lower bound",
-    "mathContext": "$|\\alpha - p/q| > c/q^n$",
+    "content": "**Key Result**: If $\\alpha$ is algebraic of degree $n \\geq 2$, then:\n\n$$\\left|\\alpha - \\frac{p}{q}\\right| > \\frac{c}{q^n}$$\n\nfor some constant $c > 0$ and all rationals $p/q$.\n\n**Proof idea**:\n1. Let $P(x)$ be $\\alpha$'s minimal polynomial (degree $n$)\n2. For $p/q \\neq \\alpha$: $q^n \\cdot P(p/q)$ is a nonzero integer, so $\\geq 1$\n3. Mean Value Theorem bounds the difference\n4. This gives the $1/q^n$ lower bound\n\nThe crucial step is that $P(p/q) \\neq 0$ because $P$ is irreducible over $\\mathbb{Q}$ and $p/q$ is rational while $\\alpha$ is irrational (for $n \\geq 2$). Clearing denominators gives the integrality argument.",
+    "mathContext": "$|\\alpha - p/q| > c/q^n$ where $n = \\deg(\\min_\\alpha)$ and $c = 1/\\sup_{|t - \\alpha| \\leq 1} |P'(t)|$",
     "significance": "critical",
-    "relatedConcepts": ["minimal polynomial", "Mean Value Theorem"]
+    "relatedConcepts": ["minimal polynomial", "Mean Value Theorem", "irreducible polynomial", "integrality"],
+    "prerequisites": ["algebraic number theory", "real analysis", "polynomial irreducibility"]
   },
   {
     "id": "ann-liouville-def",
@@ -26,52 +41,94 @@
     "range": {"startLine": 169, "endLine": 182},
     "type": "definition",
     "title": "Liouville Numbers",
-    "content": "**Definition**: ξ is a **Liouville number** if for every n ≥ 1, there exist p, q with q > 1 such that:\n\n$$0 < \\left|\\xi - \\frac{p}{q}\\right| < \\frac{1}{q^n}$$\n\nThese numbers can be approximated **better than any polynomial bound allows**.\n\nBy the approximation theorem, such numbers cannot be algebraic!",
-    "mathContext": "$|\\xi - p/q| < 1/q^n$",
+    "content": "**Definition**: $\\xi$ is a **Liouville number** if for every $n \\geq 1$, there exist $p, q$ with $q > 1$ such that:\n\n$$0 < \\left|\\xi - \\frac{p}{q}\\right| < \\frac{1}{q^n}$$\n\nThese numbers can be approximated **better than any polynomial bound allows**.\n\nBy the approximation theorem, such numbers cannot be algebraic! The definition captures a precise boundary: algebraic numbers of degree $n$ resist approximation beyond $c/q^n$, but Liouville numbers beat $1/q^n$ for *every* $n$.",
+    "mathContext": "$\\xi \\in \\mathcal{L}$ iff $\\forall n \\geq 1, \\exists p/q$ with $q > 1$: $0 < |\\xi - p/q| < q^{-n}$",
     "significance": "major",
-    "relatedConcepts": ["rational approximation", "continued fractions"]
+    "relatedConcepts": ["rational approximation", "continued fractions", "irrationality measure"],
+    "prerequisites": ["Diophantine approximation", "algebraic number theory"]
   },
   {
     "id": "ann-main-theorem",
     "proofId": "liouville-theorem",
-    "range": {"startLine": 184, "endLine": 198},
+    "range": {"startLine": 184, "endLine": 204},
     "type": "theorem",
-    "title": "Main Theorem",
-    "content": "**Theorem**: All Liouville numbers are transcendental.\n\n**Proof by contradiction**:\n1. Suppose ξ is Liouville and algebraic of degree n\n2. Approximation theorem: $|\\xi - p/q| > c/q^n$\n3. Liouville property: $|\\xi - p/q| < 1/q^{n+1}$\n4. For large q: $1/q^{n+1} < c/q^n$ — contradiction!\n\nMathlib: `Liouville.transcendental`",
-    "mathContext": "Liouville ⟹ Transcendental",
+    "title": "Main Theorem: Liouville Numbers Are Transcendental",
+    "content": "**Theorem**: All Liouville numbers are transcendental.\n\n**Proof by contradiction**:\n1. Suppose $\\xi$ is Liouville and algebraic of degree $n$\n2. Approximation theorem: $|\\xi - p/q| > c/q^n$\n3. Liouville property: $|\\xi - p/q| < 1/q^{n+1}$ for some $p/q$\n4. For large $q$: $1/q^{n+1} < c/q^n$ — contradiction!\n\nThe proof in Lean is a one-liner using Mathlib's `Liouville.transcendental`, which encapsulates this argument. The alternative statement `liouville_not_algebraic` unfolds the definition to show the equivalence explicitly.",
+    "mathContext": "$\\text{Liouville}(\\xi) \\Longrightarrow \\text{Transcendental}(\\xi)$",
     "significance": "critical",
-    "relatedConcepts": ["proof by contradiction", "transcendence"]
+    "relatedConcepts": ["proof by contradiction", "transcendence", "contrapositive"],
+    "prerequisites": ["Liouville approximation theorem", "algebraic number degree"]
   },
   {
     "id": "ann-constant",
     "proofId": "liouville-theorem",
     "range": {"startLine": 210, "endLine": 247},
     "type": "theorem",
-    "title": "Liouville's Constant",
-    "content": "**The first explicit transcendental** (1844):\n\n$$L = \\sum_{n=1}^{\\infty} 10^{-n!} = 0.110001000000000000000001...$$\n\nThe 1's appear at positions 1!, 2!, 3!, 4!, ... = 1, 2, 6, 24, 120, ...\n\n**Why L is Liouville**: Partial sums give approximations p/q where:\n$$|L - p/q| < 2 \\cdot 10^{-(m+1)!} < 1/q^m$$\n\nThis beats any polynomial bound!",
-    "mathContext": "$L = \\sum 10^{-n!}$",
+    "title": "Liouville's Constant — The First Transcendental",
+    "content": "**The first explicit transcendental number** (1844):\n\n$$L = \\sum_{n=1}^{\\infty} 10^{-n!} = 0.110001000000000000000001\\ldots$$\n\nThe 1's appear at positions $1!, 2!, 3!, 4!, \\ldots = 1, 2, 6, 24, 120, \\ldots$\n\n**Why $L$ is Liouville**: Partial sums give approximations $p/q$ where:\n$$|L - p/q| < 2 \\cdot 10^{-(m+1)!} < 1/q^m$$\n\nThis beats any polynomial bound! The Lean proof uses `liouville_liouvilleNumber` from Mathlib, which verifies the Liouville property by computing the tail bound of the series. The generalization `liouville_any_base_transcendental` shows $\\sum b^{-n!}$ is transcendental for any base $b \\geq 2$.",
+    "mathContext": "$L = \\sum_{n=1}^{\\infty} 10^{-n!}$, with partial sums $L_m = p_m/10^{m!}$ satisfying $|L - L_m| < 2 \\cdot 10^{-(m+1)!}$",
     "significance": "critical",
-    "relatedConcepts": ["explicit construction", "factorial", "decimal expansion"]
+    "relatedConcepts": ["explicit construction", "factorial growth", "series convergence", "decimal expansion"],
+    "prerequisites": ["infinite series", "factorial", "comparison test"]
   },
   {
     "id": "ann-properties",
     "proofId": "liouville-theorem",
     "range": {"startLine": 263, "endLine": 297},
     "type": "concept",
-    "title": "Properties of Liouville Numbers",
-    "content": "**Surprising facts**:\n\n1. **Uncountable**: Despite being \"rare\", there are as many Liouville numbers as real numbers!\n2. **Measure zero**: Almost all reals are NOT Liouville (probability 0)\n3. **Closed under operations**: If L is Liouville, so is L + r and r·L for rational r ≠ 0\n\nSo: Liouville numbers are simultaneously \"everywhere\" (uncountable) and \"nowhere\" (measure zero).",
+    "title": "Algebraic Properties of Liouville Numbers",
+    "content": "**Closure properties**:\n\n1. **Translation invariance**: If $L$ is Liouville and $r \\in \\mathbb{Q}$, then $L + r$ is Liouville. Proof: if $|L - p/q| < 1/q^n$, then $|(L+r) - (p + rq)/q| = |L - p/q| < 1/q^n$.\n\n2. **Scaling invariance**: If $L$ is Liouville and $r \\in \\mathbb{Q} \\setminus \\{0\\}$, then $rL$ is Liouville. For $r = a/b$, if $|L - p/q| < 1/q^n$, then $|rL - ap/(bq)| = |r| \\cdot |L - p/q|$.\n\n3. **Uncountability**: The set of Liouville numbers has cardinality $\\mathfrak{c} = 2^{\\aleph_0}$, proved by considering $\\sum a_n \\cdot 10^{-n!}$ with $a_n \\in \\{0,1\\}$.",
+    "mathContext": "$L + \\mathbb{Q} \\subseteq \\mathcal{L}$ and $\\mathbb{Q}^\\times \\cdot L \\subseteq \\mathcal{L}$ for any Liouville $L$; $|\\mathcal{L}| = \\mathfrak{c}$",
     "significance": "major",
-    "relatedConcepts": ["measure theory", "cardinality", "Borel sets"]
+    "relatedConcepts": ["measure theory", "cardinality", "Borel sets", "G-delta sets"],
+    "prerequisites": ["set theory", "cardinality", "rational arithmetic"]
   },
   {
     "id": "ann-roth",
     "proofId": "liouville-theorem",
     "range": {"startLine": 303, "endLine": 346},
     "type": "concept",
-    "title": "Roth's Improvement",
-    "content": "**Roth's Theorem (1955, Fields Medal)**:\n\n$$\\left|\\alpha - \\frac{p}{q}\\right| > \\frac{c}{q^{2+\\varepsilon}}$$\n\nfor ANY algebraic irrational α and ANY ε > 0!\n\n**History of the exponent**:\n- Liouville (1844): n (degree)\n- Thue (1909): n/2 + 1 + ε\n- Siegel (1921): 2√n + ε\n- Roth (1955): **2 + ε** (optimal!)\n\nThe exponent 2 cannot be improved (Hurwitz's theorem).",
-    "mathContext": "$|\\alpha - p/q| > c/q^{2+\\varepsilon}$",
+    "title": "Roth's Theorem and the Thue-Siegel-Roth Progression",
+    "content": "**Roth's Theorem (1955, Fields Medal 1958)**:\n\n$$\\left|\\alpha - \\frac{p}{q}\\right| > \\frac{c}{q^{2+\\varepsilon}}$$\n\nfor ANY algebraic irrational $\\alpha$ and ANY $\\varepsilon > 0$.\n\n**History of the exponent**:\n- Liouville (1844): $n$ (degree)\n- Thue (1909): $n/2 + 1 + \\varepsilon$\n- Siegel (1921): $2\\sqrt{n} + \\varepsilon$\n- Dyson (1947): $\\sqrt{2n} + \\varepsilon$\n- Roth (1955): $2 + \\varepsilon$ (optimal!)\n\nThe exponent 2 cannot be improved: by Hurwitz's theorem, $|\\alpha - p/q| < 1/(\\sqrt{5} q^2)$ has infinitely many solutions for any irrational $\\alpha$. Roth's proof introduced the *large sieve* method and influenced Schmidt's subspace theorem.",
+    "mathContext": "$|\\alpha - p/q| > c(\\alpha, \\varepsilon)/q^{2+\\varepsilon}$ for all $\\varepsilon > 0$ and algebraic irrational $\\alpha$",
     "significance": "major",
-    "relatedConcepts": ["Fields Medal", "Diophantine approximation", "Hurwitz's theorem"]
+    "relatedConcepts": ["Fields Medal", "Diophantine approximation", "Hurwitz's theorem", "subspace theorem"],
+    "prerequisites": ["Liouville approximation theorem", "algebraic number theory"]
+  },
+  {
+    "id": "ann-connections",
+    "proofId": "liouville-theorem",
+    "range": {"startLine": 348, "endLine": 373},
+    "type": "concept",
+    "title": "Connections to Transcendence Theory",
+    "content": "**The transcendence theory landscape**:\n\nLiouville's theorem was the starting point for a rich theory:\n\n1. **Hermite-Lindemann (1882)**: $e^\\alpha$ is transcendental for algebraic $\\alpha \\neq 0$. This proves $e$ and $\\pi$ are transcendental by entirely different methods (auxiliary polynomial construction).\n\n2. **Gelfond-Schneider (1934)**: $\\alpha^\\beta$ is transcendental when $\\alpha \\neq 0, 1$ is algebraic and $\\beta$ is algebraic irrational. This resolved Hilbert's 7th problem.\n\n3. **Baker's Theorem (1966)**: Effective lower bounds for $|\\beta_1 \\log \\alpha_1 + \\cdots + \\beta_n \\log \\alpha_n|$. Earned Baker the Fields Medal (1970).\n\n**Diophantine approximation connections**: Dirichlet's theorem guarantees $|\\alpha - p/q| < 1/(qN)$ for some $q \\leq N$, while Hurwitz sharpens this to $1/(\\sqrt{5} q^2)$ infinitely often. Continued fractions provide the best approximations.",
+    "mathContext": "Hermite-Lindemann: $\\alpha \\in \\overline{\\mathbb{Q}} \\setminus \\{0\\} \\Rightarrow e^\\alpha \\notin \\overline{\\mathbb{Q}}$; Gelfond-Schneider: $\\alpha^\\beta \\notin \\overline{\\mathbb{Q}}$ for suitable $\\alpha, \\beta$",
+    "significance": "supporting",
+    "relatedConcepts": ["Hermite-Lindemann theorem", "Gelfond-Schneider theorem", "Baker's theorem", "Dirichlet's approximation theorem"],
+    "prerequisites": ["transcendence theory", "complex analysis", "logarithms"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "liouville-theorem",
+    "range": {"startLine": 375, "endLine": 386},
+    "type": "technique",
+    "title": "Generalized Liouville Numbers",
+    "content": "**Any base works**: The sum $\\sum_{n=1}^\\infty b^{-n!}$ is transcendental for any integer base $b \\geq 2$. The Lean proof is uniform in the base, using `liouville_liouvilleNumber` which only requires $b \\geq 2$.\n\nThe base-2 case $\\sum 2^{-n!}$ has a particularly clean binary representation: $0.110001\\ldots_2$ with 1's at positions $1!, 2!, 3!, \\ldots$ This provides the simplest possible explicit transcendental — a binary number whose digit pattern is completely determined by the factorial function.",
+    "mathContext": "$\\forall b \\geq 2: \\sum_{n=1}^\\infty b^{-n!}$ is transcendental",
+    "significance": "supporting",
+    "relatedConcepts": ["base representation", "binary expansion", "parameterized construction"],
+    "prerequisites": ["infinite series", "factorial growth"]
+  },
+  {
+    "id": "ann-measure",
+    "proofId": "liouville-theorem",
+    "range": {"startLine": 388, "endLine": 411},
+    "type": "concept",
+    "title": "Measure-Theoretic Perspective",
+    "content": "**A beautiful paradox**: Liouville numbers are simultaneously everywhere and nowhere.\n\n- **Uncountable** ($|\\mathcal{L}| = \\mathfrak{c}$): there are \"as many\" Liouville numbers as reals\n- **Measure zero** ($\\lambda(\\mathcal{L}) = 0$): a randomly chosen real is almost surely NOT Liouville\n- **$G_\\delta$ dense**: Liouville numbers form a dense $G_\\delta$ set (countable intersection of open dense sets)\n\nBy the Baire category theorem, this means Liouville numbers are **residual** — \"generic\" in the topological sense! So topologically most reals are Liouville, but measure-theoretically almost none are. This contrast between Baire category and Lebesgue measure is a recurring theme in real analysis.",
+    "mathContext": "$\\mathcal{L} = \\bigcap_{n=1}^\\infty \\bigcup_{q=2}^\\infty \\bigcup_{p \\in \\mathbb{Z}} \\left(\\frac{p}{q} - \\frac{1}{q^n}, \\frac{p}{q} + \\frac{1}{q^n}\\right)$, which is $G_\\delta$ and has measure zero",
+    "significance": "major",
+    "relatedConcepts": ["Lebesgue measure", "Baire category theorem", "G-delta sets", "residual sets"],
+    "prerequisites": ["measure theory", "topology", "Baire category theorem"]
   }
 ]

--- a/src/data/proofs/liouville-theorem/meta.json
+++ b/src/data/proofs/liouville-theorem/meta.json
@@ -40,46 +40,136 @@
     "dateAdded": "12/29/25"
   },
   "overview": {
-    "historicalContext": "Liouville's 1844 result was the first explicit proof that transcendental numbers exist. Before this, their existence was only suspected. The Liouville constant L = sum of 10^(-n!) was the first number proven transcendental.",
-    "problemStatement": "**Liouville's Theorem**: If alpha is algebraic of degree n >= 2, then there exists c > 0 such that |alpha - p/q| > c/q^n for all rationals p/q.\n\n**Corollary**: Numbers that violate this bound (Liouville numbers) must be transcendental.",
-    "proofStrategy": "For algebraic alpha with minimal polynomial P of degree n, if p/q is close to alpha, then q^n|P(p/q)| >= 1 (since it's a nonzero integer). The Mean Value Theorem bounds P(p/q) in terms of |alpha - p/q|, yielding the approximation bound.",
+    "historicalContext": "Joseph Liouville published his groundbreaking result in 1844 in the *Journal de Mathématiques Pures et Appliquées*, a journal he himself had founded in 1836. At the time, mathematicians strongly suspected that transcendental numbers existed — Euler had conjectured as much — but no one had produced a single example. Liouville's insight was indirect: rather than analyzing a specific constant, he identified a *structural property* (superpolynomial approximability by rationals) that forces transcendence. He then exhibited $L = \\sum 10^{-n!}$ as a concrete number with this property. This was nearly 30 years before Cantor's cardinality argument (1874) showed transcendentals are overwhelmingly common, and predated Hermite's proof that $e$ is transcendental (1873) and Lindemann's proof for $\\pi$ (1882). Liouville's method via Diophantine approximation remains the conceptual foundation for modern transcendence theory, influencing the Thue-Siegel-Roth progression that culminated in Roth's Fields Medal.",
+    "problemStatement": "**Liouville's Theorem**: If $\\alpha$ is algebraic of degree $n \\geq 2$, then there exists $c > 0$ such that $|\\alpha - p/q| > c/q^n$ for all rationals $p/q$.\n\n**Corollary**: Numbers that violate this bound (Liouville numbers) must be transcendental.",
+    "proofStrategy": "For algebraic $\\alpha$ with minimal polynomial $P$ of degree $n$, if $p/q$ is close to $\\alpha$, then $q^n|P(p/q)| \\geq 1$ (since it is a nonzero integer after clearing denominators). The Mean Value Theorem bounds $P(p/q) = P(p/q) - P(\\alpha) = (p/q - \\alpha) P'(\\xi)$ for some $\\xi$ between $p/q$ and $\\alpha$. If $|\\alpha - p/q| < 1$, then $|P'(\\xi)|$ is bounded by a constant $M$ depending only on $\\alpha$, yielding $|\\alpha - p/q| \\geq 1/(M q^n)$. The Lean formalization uses Mathlib's `Liouville.transcendental` which encapsulates this contrapositive argument.",
     "keyInsights": [
-      "Algebraic numbers cannot be approximated too well by rationals",
-      "The degree of the minimal polynomial limits approximability",
-      "Liouville numbers violate all polynomial bounds, so must be transcendental",
-      "Roth's theorem (1955) improved the exponent to 2+epsilon for all algebraic irrationals"
+      "Algebraic numbers cannot be approximated too well by rationals — the degree of the minimal polynomial imposes a hard limit of $c/q^n$",
+      "The proof hinges on an integrality argument: $q^n P(p/q)$ is a nonzero integer when $P$ is the minimal polynomial, giving a lower bound of 1",
+      "Liouville numbers violate all polynomial approximation bounds simultaneously, so they cannot satisfy any algebraic equation",
+      "The Liouville constant $L = \\sum 10^{-n!}$ achieves superpolynomial approximation because factorial gaps in the decimal expansion make partial sums extraordinarily close to $L$",
+      "Roth's theorem (1955) dramatically improved the exponent from $n$ to $2 + \\varepsilon$, showing algebraic irrationals are even harder to approximate than Liouville's bound suggests"
     ]
   },
   "sections": [
     {
+      "id": "introduction",
+      "title": "Historical Introduction and Documentation",
+      "startLine": 8,
+      "endLine": 72,
+      "summary": "Module documentation covering the historical significance of Liouville's 1844 result as the first explicit transcendental number, theorem statements, Mathlib dependencies, and references."
+    },
+    {
+      "id": "definitions",
+      "title": "Background and Definitions",
+      "startLine": 74,
+      "endLine": 104,
+      "summary": "Core definitions: algebraic and transcendental numbers via Mathlib's IsAlgebraic and Transcendental, plus the Liouville number definition capturing superpolynomial rational approximability."
+    },
+    {
       "id": "approximation-theorem",
       "title": "Liouville's Approximation Theorem",
       "startLine": 105,
-      "endLine": 165,
-      "summary": "Algebraic numbers have bounded rational approximability."
+      "endLine": 163,
+      "summary": "The approximation bound: algebraic numbers of degree n resist rational approximation beyond c/q^n. Stated as an axiom with the full proof outline via minimal polynomials and the Mean Value Theorem."
     },
     {
       "id": "transcendence",
       "title": "Transcendence of Liouville Numbers",
       "startLine": 165,
-      "endLine": 210,
-      "summary": "Main result using Mathlib's Liouville.transcendental."
+      "endLine": 204,
+      "summary": "Main result: Liouville numbers are transcendental. Proved via Mathlib's Liouville.transcendental, with an alternative formulation showing non-algebraicity explicitly."
     },
     {
       "id": "liouville-constant",
       "title": "The Liouville Constant",
       "startLine": 206,
-      "endLine": 260,
-      "summary": "Explicit construction: L = sum of 10^(-n!)."
+      "endLine": 257,
+      "summary": "Explicit construction of the first transcendental number L = Σ 10^(-n!), with Lean proofs that it is Liouville, transcendental, and irrational."
+    },
+    {
+      "id": "properties",
+      "title": "Properties of Liouville Numbers",
+      "startLine": 259,
+      "endLine": 297,
+      "summary": "Algebraic closure properties: Liouville numbers are closed under rational translation and nonzero rational scaling, and the set is uncountable."
+    },
+    {
+      "id": "roth-theorem",
+      "title": "Roth's Theorem and Generalizations",
+      "startLine": 299,
+      "endLine": 346,
+      "summary": "The Thue-Siegel-Roth progression improving the approximation exponent from n to 2+ε, culminating in Roth's optimal result (Fields Medal 1958)."
+    },
+    {
+      "id": "connections",
+      "title": "Connections to Other Results",
+      "startLine": 348,
+      "endLine": 373,
+      "summary": "Relationships to Hermite-Lindemann, Gelfond-Schneider, Baker's theorem, and Diophantine approximation (Dirichlet, Hurwitz, continued fractions)."
+    },
+    {
+      "id": "examples",
+      "title": "Examples and Computations",
+      "startLine": 375,
+      "endLine": 386,
+      "summary": "Generalization: Σ b^(-n!) is transcendental for any base b ≥ 2, with Lean proofs for b=2 and arbitrary b."
+    },
+    {
+      "id": "measure-theory",
+      "title": "Measure-Theoretic Perspective",
+      "startLine": 388,
+      "endLine": 411,
+      "summary": "Liouville numbers form a measure-zero yet uncountable G-delta dense set — topologically generic but measure-theoretically negligible."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 413,
+      "endLine": 444,
+      "summary": "Recap of Wiedijk #18: the approximation bound, Liouville numbers, transcendence proof, explicit example, historical impact, and Mathlib formalization status."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetProofId": "e-transcendental",
+      "relationship": "related",
+      "description": "Hermite's 1873 proof that e is transcendental — the second specific transcendental number proved, using auxiliary polynomial methods rather than Diophantine approximation"
+    },
+    {
+      "targetProofId": "pi-transcendental",
+      "relationship": "related",
+      "description": "Lindemann's 1882 proof that π is transcendental, resolving the ancient problem of squaring the circle and building on techniques from Hermite-Lindemann"
+    },
+    {
+      "targetProofId": "hermite-lindemann",
+      "relationship": "generalizes",
+      "description": "The Hermite-Lindemann theorem provides a much more powerful transcendence criterion (e^α transcendental for algebraic α ≠ 0), superseding Liouville's approximation approach for specific constants"
+    },
+    {
+      "targetProofId": "gelfond-schneider",
+      "relationship": "related",
+      "description": "The Gelfond-Schneider theorem (1934) resolved Hilbert's 7th problem using transcendence methods that evolved from the tradition Liouville began"
+    },
+    {
+      "targetProofId": "sqrt2-irrational",
+      "relationship": "specializes",
+      "description": "Irrationality of √2 is the simplest case of the algebraic-transcendental hierarchy: √2 is algebraic of degree 2, hence not Liouville, while Liouville numbers go further and are transcendental"
+    },
+    {
+      "targetProofId": "denumerability-rationals",
+      "relationship": "related",
+      "description": "Countability of rationals contextualizes Liouville's result: algebraic numbers are countable while transcendentals (including Liouville numbers) are uncountable"
     }
   ],
   "conclusion": {
-    "summary": "Liouville's theorem opened the field of transcendence theory by providing the first explicit transcendental numbers. The technique of bounding rational approximations remains fundamental to Diophantine approximation.",
-    "implications": "The theorem evolved into Roth's theorem (Fields Medal 1958), which gives optimal exponent 2+epsilon. This connects to Baker's theorem on linear forms in logarithms and modern transcendence theory.",
+    "summary": "Liouville's theorem opened the field of transcendence theory by providing the first explicit transcendental numbers. The technique of bounding rational approximations remains fundamental to Diophantine approximation, and the approximation exponent problem spawned a century of improvements culminating in Roth's optimal result.",
+    "implications": "The theorem evolved into Roth's theorem (Fields Medal 1958), which gives optimal exponent $2+\\varepsilon$. This connects to Baker's theorem on linear forms in logarithms (Fields Medal 1970), Schmidt's subspace theorem, and modern transcendence theory. The measure-theoretic perspective — that Liouville numbers are simultaneously uncountable and measure-zero — foreshadows the Baire category vs. measure duality that pervades real analysis.",
     "openQuestions": [
-      "Is there an effective version of Roth's theorem?",
-      "Which specific constants are Liouville numbers?",
-      "What is the Hausdorff dimension of Liouville numbers?"
+      "Is there an effective version of Roth's theorem that gives computable constants?",
+      "What is the irrationality measure of specific constants like e, π, or ln(2)?",
+      "What is the Hausdorff dimension of the set of numbers with irrationality measure exactly μ for a given μ > 2?",
+      "Can Liouville's approximation approach be extended to p-adic or function field settings?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Added `mathContext` to all 11 annotations (4 new annotations covering definitions, connections, examples, measure theory)
- Expanded `historicalContext` from ~240 chars to 800+ chars with Liouville's journal founding, Euler's conjecture, historical timeline
- Added 6 `crossReferences` linking to e-transcendental, pi-transcendental, hermite-lindemann, gelfond-schneider, sqrt2-irrational, denumerability-rationals
- Expanded `sections` from 3 to 11, covering full Lean file (lines 8-444)
- Added `prerequisites` to all annotations
- Deepened `proofStrategy`, added 5th `keyInsight`, added 4th `openQuestion`

## Test plan
- [x] JSON validates (`python3 -c "import json; json.load(open(...))"`)
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)