### PR TITLE
enricher-2: Enrich continuum-hypothesis, bezout, denumerability-rationals, erdos-405, erdos-970, erdos-151, erdos-314

### DIFF
--- a/src/data/proofs/erdos-330/annotations.json
+++ b/src/data/proofs/erdos-330/annotations.json
@@ -4,11 +4,12 @@
     "proofId": "erdos-330",
     "range": { "startLine": 1, "endLine": 17 },
     "type": "concept",
-    "title": "Problem Overview",
+    "title": "Problem Overview: Minimal Bases with Positive Density",
     "content": "**Erdős Problem #330** (Erdős–Nathanson, OPEN):\n\nDoes there exist a minimal asymptotic additive basis A of order h with positive upper density such that for every n ∈ A, the set of integers not representable from A \\ {n} also has positive upper density?\n\nThis asks whether minimality can be 'quantitatively strong' — not just qualitatively essential, but each element accounting for a positive proportion of representable integers.",
-    "mathContext": "Additive basis theory studies how sets A ⊆ ℕ represent integers as sums. Minimal bases are the 'critical' ones where every element matters. Problem #330 asks how much each element matters.",
+    "mathContext": "An additive basis $A \\subseteq \\mathbb{N}$ of order $h$ represents all sufficiently large integers as sums of $\\le h$ elements. $A$ is minimal if removing any $n \\in A$ destroys the basis property. Problem #330 asks: can $A$ have $\\bar{d}(A) > 0$ and $\\bar{d}(\\{m : m \\text{ not representable from } A \\setminus \\{n\\}\\}) > 0$ for all $n \\in A$?",
     "significance": "critical",
-    "relatedConcepts": ["additive basis", "minimal basis", "upper density", "additive number theory"]
+    "prerequisites": ["additive basis definition", "upper density $\\bar{d}(S) = \\limsup |S \\cap [1,n]|/n$", "minimal basis definition", "asymptotic vs exact basis distinction"],
+    "relatedConcepts": ["additive basis", "minimal basis", "upper density", "additive number theory", "Erdős–Nathanson", "Stöhr-Härtter theory"]
   },
   {
     "id": "ann-e330-representable",
@@ -17,9 +18,10 @@
     "type": "definition",
     "title": "Representability and Asymptotic Basis",
     "content": "**IsRepresentable A h m:** m can be written as a sum of at most h elements from A (with repetition).\n\nFormally: there exists a sequence f : Fin k → ℕ with k ≤ h, all values in A, summing to m.\n\n**IsAsympBasis A h:** every sufficiently large integer is representable — there exists N₀ such that all m ≥ N₀ are representable.\n\n**Example:** The set of squares {0, 1, 4, 9, ...} is an asymptotic basis of order 4 (Lagrange's theorem).",
-    "mathContext": "Waring's problem asks for the minimal h such that k-th powers form a basis of order h. General additive bases generalize this beyond perfect powers.",
+    "mathContext": "$A$ is an asymptotic basis of order $h$ iff $\\exists N_0,\\, \\forall m \\ge N_0,\\, \\exists k \\le h,\\, f : [k] \\to A : \\sum_{i=1}^k f(i) = m$. Uses Fin k → ℕ (length-k sequences) and Finset.univ.sum. Lagrange's four-square theorem: squares form a basis of order 4.",
     "significance": "essential",
-    "relatedConcepts": ["additive basis", "Waring's problem", "Lagrange's theorem"]
+    "prerequisites": ["Fin k in Lean", "Finset.univ.sum", "Set membership A : Set ℕ", "Waring's problem background"],
+    "relatedConcepts": ["additive basis", "Waring's problem", "Lagrange's four-square theorem", "Goldbach conjecture", "Schnirelmann density"]
   },
   {
     "id": "ann-e330-density",
@@ -28,9 +30,10 @@
     "type": "definition",
     "title": "Upper Density",
     "content": "**upperDensity S:** axiomatised as the upper asymptotic density of S ⊆ ℕ.\n\nProperties: 0 ≤ upperDensity(S) ≤ 1.\n\n**HasPosDensity A** means upperDensity(A) > 0.\n\nUpper density measures the 'thickness' of a set: d̄(S) = lim sup |S ∩ {1,...,n}| / n.",
-    "mathContext": "Upper density is used rather than natural density because the latter may not exist for all sets. A set with positive upper density is 'non-negligible' in the integers.",
+    "mathContext": "$\\bar{d}(S) = \\limsup_{n\\to\\infty} |S \\cap \\{1,\\ldots,n\\}|/n \\in [0,1]$. Axiomatized with upperDensity_nonneg and upperDensity_le_one. Upper (vs natural) density is used because $\\lim$ may not exist. HasPosDensity A ↔ $\\bar{d}(A) > 0$.",
     "significance": "key",
-    "relatedConcepts": ["upper density", "asymptotic density", "natural density"]
+    "prerequisites": ["lim sup definition", "Set ℕ cardinality / counting", "Real positivity 0 < x", "axiom declarations for noncomputable density"],
+    "relatedConcepts": ["upper density", "asymptotic density", "natural density", "Schnirelmann density", "Banach density"]
   },
   {
     "id": "ann-e330-minimal",
@@ -39,9 +42,10 @@
     "type": "definition",
     "title": "Minimal Basis and Unrepresentable Sets",
     "content": "**IsMinimalBasis A h:** A is an asymptotic basis of order h, and removing any single element n ∈ A destroys the basis property.\n\n**unrepresentableWithout A n h:** the set of integers that become unrepresentable when n is removed from A.\n\nMinimal bases are extremal: every element is essential. The question is *how* essential — does removal affect a positive proportion of integers?",
-    "mathContext": "Minimal bases are analogues of critical graphs in graph theory. The concept was introduced by Stöhr (1955) and Härtter (1956).",
+    "mathContext": "$A$ is minimal iff $A$ is a basis of order $h$ AND $\\forall n \\in A,\\, A \\setminus \\{n\\}$ is NOT a basis. $\\text{unrepresentableWithout}(A,n,h) = \\{m : m \\notin h\\text{-fold sumset of } A\\setminus\\{n\\}\\}$. Introduced by Stöhr (1955) and Härtter (1956).",
     "significance": "essential",
-    "relatedConcepts": ["minimal basis", "critical structure", "extremal combinatorics"]
+    "prerequisites": ["IsAsympBasis definition", "Set.diff notation A \\ {n}", "negation of IsAsympBasis", "Set comprehension {m : Prop} in Lean"],
+    "relatedConcepts": ["minimal basis", "critical structure", "extremal combinatorics", "Stöhr-Härtter theory", "essential elements"]
   },
   {
     "id": "ann-e330-known",
@@ -50,9 +54,10 @@
     "type": "result",
     "title": "Known Results",
     "content": "**minimal_basis_infinite_unrep:** For a minimal basis, removing any element leaves *infinitely many* integers unrepresentable. This is immediate from the definition of minimality.\n\n**minimal_basis_exists:** Minimal bases of every order h ≥ 2 exist.\n\n**minimal_basis_pos_density_exists:** (Härtter 1956, Stöhr 1955) Minimal bases with positive density exist for every h ≥ 2.\n\nThe weaker condition (minimality + positive density) is established. Problem #330 asks for the stronger condition (each removal yields positive-density unrepresentables).",
-    "mathContext": "The progression: minimality (qualitative) → positive density basis (quantitative) → positive density unrepresentables (strongly quantitative). Each step is harder.",
+    "mathContext": "Hierarchy: (1) minimal basis (qualitative), (2) minimal basis with $\\bar{d}(A) > 0$ (Härtter-Stöhr 1955-56), (3) minimal basis where each removal creates $\\bar{d} > 0$ holes (Problem #330, open). Set.Infinite formalizes 'infinitely many' unrepresentables.",
     "significance": "key",
-    "relatedConcepts": ["Härtter", "Stöhr", "existence theorems", "additive number theory"]
+    "prerequisites": ["Set.Infinite in Lean", "IsMinimalBasis definition", "h ≥ 2 hypothesis (h=1 basis is trivial: A = ℕ)", "existence proofs via axiom"],
+    "relatedConcepts": ["Härtter 1956", "Stöhr 1955", "existence theorems", "additive combinatorics history", "infinite unrepresentables"]
   },
   {
     "id": "ann-e330-conjecture",
@@ -61,8 +66,9 @@
     "type": "conjecture",
     "title": "Erdős Problem #330 (OPEN)",
     "content": "**erdos_330_strong_minimal_basis:**\n\nThere exist A, h such that:\n1. A is a minimal basis of order h\n2. A has positive upper density\n3. For every n ∈ A, the set unrepresentableWithout(A, n, h) has positive upper density\n\nThis 'strong minimality' condition says every element of A is quantitatively important — removing any one element makes a positive proportion of integers unreachable.",
-    "mathContext": "A positive answer would demonstrate that additive bases can be simultaneously dense AND have every element be critically important. This is a deep structural question about additive combinatorics.",
+    "mathContext": "$\\exists A \\subseteq \\mathbb{N},\\, \\exists h \\ge 2 :$ (a) $A$ is minimal basis of order $h$, (b) $\\bar{d}(A) > 0$, (c) $\\forall n \\in A,\\, \\bar{d}(\\text{unrepresentableWithout}(A,n,h)) > 0$. Axiomatized since OPEN: no explicit construction is known. A positive answer requires simultaneously achieving density AND quantitative minimality.",
     "significance": "critical",
-    "relatedConcepts": ["strong minimality", "additive basis", "open problem", "Erdős–Nathanson"]
+    "prerequisites": ["IsMinimalBasis definition", "HasPosDensity definition", "unrepresentableWithout definition", "∃ quantifier over (A : Set ℕ) in Lean"],
+    "relatedConcepts": ["strong minimality", "additive basis", "open problem", "Erdős–Nathanson", "quantitative combinatorics", "density Ramsey theory"]
   }
 ]


### PR DESCRIPTION
## Mathematical Enrichment Pass

This PR adds mathematical depth to seven proof gallery entries:

### continuum-hypothesis
- Added 5th keyInsight, deepened historicalContext, 2 new sections
- mathContext, prerequisites, relatedConcepts to all 17 annotations

### bezout-identity-oq-03
- Created 10 comprehensive annotations from empty
- Covers Bézout's identity and Chinese Remainder Theorem

### denumerability-rationals
- Enriched 6 existing + 2 new annotations (encoding-mechanism, comparison-reals)

### erdos-405 (Factorial Plus Power = Prime Power)
- prerequisites/relatedConcepts to all 25 annotations
- Covers Zsygmondy's theorem, Baker's theory, p-adic valuations

### erdos-970 (Jacobsthal's Function)
- mathContext/prerequisites/relatedConcepts to all 11 annotations
- Added new Rankin lower bound annotation

### erdos-151 (Clique Transversal, Erdős–Gallai Conjecture)
- prerequisites to all 8 annotations, mathContext to axioms annotation
- Covers τ(G), H(n) ≥ √n, K₄-free open case

### erdos-314 (Harmonic Sum Error Term - SOLVED 2024)
- prerequisites/relatedConcepts/mathContext to all 10 annotations
- Covers harmonic sums, m(n) ≈ en, Lim-Steinerberger 2024 resolution,
  optimal exponent 2+δ conjecture (still open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)