### PR TITLE
research: general truncation divisibility rule + pool housekeeping

### DIFF
--- a/research/problems/divisibility-by-3-oq-01-oq-01/knowledge.md
+++ b/research/problems/divisibility-by-3-oq-01-oq-01/knowledge.md
@@ -1,0 +1,70 @@
+# Problem: Can the Truncation Method Be Generalized?
+
+**ID**: divisibility-by-3-oq-01-oq-01
+**Status**: COMPLETE
+**Tier**: B
+**Significance**: 6/10 | **Tractability**: 6/10
+
+## Problem Statement
+
+Can the truncation method (remove last digit, add/subtract a multiple of it) be
+generalized to a single parametric theorem covering all divisors coprime to 10?
+
+**Answer: YES.** Two general theorems completely characterize all truncation rules.
+
+## Proof Location
+
+**File**: `proofs/Proofs/DivisibilityTruncationGeneral.lean`
+**Gallery**: `src/data/proofs/divisibility-truncation-general/`
+**Status**: 0 sorries, 0 axioms, builds in Docker (Mathlib v4.26.0, 3058 jobs)
+
+## Key Mathematical Content
+
+### Positive Osculator Theorem
+For d coprime to 10 and d | 10c - 1:
+```
+d | n  ↔  d | (n/10 + c·(n%10))
+```
+Examples: d=13 c=4 (39=3·13), d=19 c=2 (19=1·19), d=3 c=1 (9=3·3)
+
+### Negative Osculator Theorem
+For d coprime to 10 and d | 10c + 1:
+```
+d | n  ↔  d | (n/10 - c·(n%10))
+```
+Examples: d=7 c=2 (21=3·7), d=11 c=1 (11=1·11), d=17 c=5 (51=3·17)
+
+## Session 2026-02-21 (Session 1) - Complete Proof
+
+**Mode**: FRESH
+**Outcome**: completed
+
+### What I Did
+
+1. Identified the algebraic core: `10*(n/10 + c*(n%10)) = n + (10c-1)*(n%10)`
+2. Proved this via `linear_combination -hdiv` where `hdiv : n = 10*(n/10) + n%10`
+3. Used `IsCoprime.dvd_of_dvd_mul_left` to transfer divisibility through 10
+4. Created both positive and negative osculator variants
+5. Proved 11 corollaries for d ∈ {3,7,9,11,13,17,19,23,29,31,37}
+6. Built successfully in Docker (3058 jobs, 2.1s for target)
+
+### Key Insights
+
+- The key algebraic identity is: `10*(q + cr) = n + (10c-1)*r` where n=10q+r
+- `linear_combination -hdiv` elegantly proves this identity
+- `IsCoprime.dvd_of_dvd_mul_left` is the critical Mathlib lemma
+- The positive osculator c = (10⁻¹ mod d), negative c = ((-10)⁻¹ mod d)
+- Every d coprime to 10 has both positive and negative osculators
+- Type annotation: use `(d : ℤ) ∣ n` (not `d ∣ n`) to avoid ℕ/ℤ coercion issues
+
+### Files Modified
+
+- `proofs/Proofs/DivisibilityTruncationGeneral.lean` (created, 285 lines)
+- `src/data/proofs/divisibility-truncation-general/` (gallery entry created)
+
+### Next Steps
+
+None - proof is complete. Extension ideas:
+- Unified single theorem with signed c ∈ ℤ (can subsume both cases)
+- Extension to multi-digit truncation (see DivisibilityByThreeOQ02.lean)
+- Extension to other bases

--- a/src/data/proofs/divisibility-truncation-general/annotations.json
+++ b/src/data/proofs/divisibility-truncation-general/annotations.json
@@ -1,0 +1,32 @@
+{
+  "annotations": [
+    {
+      "lineStart": 46,
+      "lineEnd": 66,
+      "type": "key-theorem",
+      "title": "General Positive Osculator Theorem",
+      "content": "The main theorem: for any d coprime to 10 and c satisfying d | 10c-1, we have d | n ↔ d | (n/10 + c*(n%10)). The proof uses the key algebraic identity 10*(q+cr) = n + (10c-1)*r, proved by `linear_combination -hdiv`."
+    },
+    {
+      "lineStart": 82,
+      "lineEnd": 123,
+      "type": "key-theorem",
+      "title": "General Negative Osculator Theorem",
+      "content": "Symmetric theorem for the negative osculator case: d | 10c+1 gives d | n ↔ d | (n/10 - c*(n%10)). Used for d=7,11,17 where 10c ≡ -1 (mod d)."
+    },
+    {
+      "lineStart": 37,
+      "lineEnd": 44,
+      "type": "key-step",
+      "title": "Division-Modulus Identity",
+      "content": "The foundation: n = 10*(n/10) + n%10 cast to ℤ. This is proved by `push_cast; omega` using Nat.div_add_mod. Used as `hdiv` in both main theorems via `linear_combination -hdiv`."
+    },
+    {
+      "lineStart": 129,
+      "lineEnd": 145,
+      "type": "example",
+      "title": "Classical Rules as Corollaries",
+      "content": "Seven (c=2, neg): 10*2+1=21=3*7. Eleven (c=1, neg): 10*1+1=11. Thirteen (c=4, pos): 10*4-1=39=3*13. These are the classic pencil-and-paper divisibility rules now proved as one-liners from the general theorem."
+    }
+  ]
+}

--- a/src/data/proofs/divisibility-truncation-general/index.ts
+++ b/src/data/proofs/divisibility-truncation-general/index.ts
@@ -1,0 +1,2 @@
+export { default as meta } from './meta.json'
+export { default as annotations } from './annotations.json'

--- a/src/data/proofs/divisibility-truncation-general/meta.json
+++ b/src/data/proofs/divisibility-truncation-general/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "divisibility-truncation-general",
+  "title": "General Truncation Divisibility Rule",
+  "slug": "divisibility-truncation-general",
+  "description": "A parametric theorem generalizing the truncation method to all divisors coprime to 10. Given any d coprime to 10 and an osculator c (satisfying d | 10c ∓ 1), we prove d | n ↔ d | (n/10 ± c·(n%10)). This single theorem subsumes the specific rules for 7, 11, 13, 17, 19, 23, 29, 31, 37, and all other primes coprime to 10.",
+  "meta": {
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "modular-arithmetic",
+      "generalization",
+      "research"
+    ],
+    "mathlib_version": "4.10.0",
+    "proofRepoPath": "Proofs/DivisibilityTruncationGeneral.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "IsCoprime.dvd_of_dvd_mul_left",
+        "description": "If gcd(a,b)=1 and a | b*c, then a | c",
+        "module": "Mathlib.RingTheory.Coprime.Basic"
+      },
+      {
+        "theorem": "dvd_mul_of_dvd_left",
+        "description": "If a | b, then a | b*c",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "Int.dvd_sub",
+        "description": "Divisibility distributes over subtraction",
+        "module": "Mathlib.Data.Int.Basic"
+      },
+      {
+        "theorem": "Nat.div_add_mod",
+        "description": "n = b * (n / b) + n % b",
+        "module": "Mathlib.Data.Nat.Basic"
+      }
+    ],
+    "originalContributions": [
+      "General positive osculator theorem: d | n ↔ d | (n/10 + c*(n%10)) when d | 10c-1",
+      "General negative osculator theorem: d | n ↔ d | (n/10 - c*(n%10)) when d | 10c+1",
+      "Unified proof using linear_combination for the key algebraic identity",
+      "11 concrete corollaries for d ∈ {3,7,9,11,13,17,19,23,29,31,37}",
+      "Explicit osculator table with verification examples"
+    ],
+    "dateAdded": "02/21/26"
+  },
+  "overview": {
+    "historicalContext": "Divisibility rules have been studied since antiquity. The rules for 3 and 9 (sum of digits), 11 (alternating sum), 7 and 13 (truncation methods) are classical results. The 'truncation method' or 'osculator method' is attributed to various 19th-century mathematicians. The key insight is that for any integer d coprime to 10, there exists a multiplicative inverse of 10 mod d, which serves as the 'osculator' connecting n's divisibility to a simpler expression.",
+    "problemStatement": "Can the individual truncation rules for 7, 11, 13, 17, 19 be unified into a single parametric theorem?\n\nSpecifically: given d coprime to 10, is there a general rule of the form $d | n \\iff d | f(n/10, n\\%10)$ where $f$ depends only on $d$?\n\n**Answer: YES**, with two variants:\n- **Positive osculator** ($d | 10c - 1$): $d | n \\iff d | (n/10 + c \\cdot (n\\%10))$\n- **Negative osculator** ($d | 10c + 1$): $d | n \\iff d | (n/10 - c \\cdot (n\\%10))$",
+    "proofStrategy": "The key algebraic identity is:\n$$10 \\cdot (n/10 + c \\cdot (n\\%10)) = n + (10c - 1) \\cdot (n\\%10)$$\n\nWhen $d | (10c - 1)$, the term $(10c-1) \\cdot (n\\%10)$ is divisible by $d$, so:\n$$d | n \\iff d | n + (10c-1)(n\\%10) = 10 \\cdot (n/10 + c \\cdot (n\\%10))$$\n\nSince $\\gcd(d, 10) = 1$, divisibility by $d$ transfers through the factor 10:\n$$d | 10 \\cdot \\text{expr} \\iff d | \\text{expr}$$\n\nFormally: `IsCoprime.dvd_of_dvd_mul_left` handles this last step.\n\nThe negative osculator case is symmetric, with the identity:\n$$10 \\cdot (n/10 - c \\cdot (n\\%10)) = n - (10c + 1) \\cdot (n\\%10)$$",
+    "keyInsights": [
+      "The `linear_combination` tactic elegantly handles the algebraic identity: `linear_combination -hdiv` where `hdiv : n = 10*(n/10) + n%10`.",
+      "The `IsCoprime` condition in Lean 4 provides exactly the right algebraic framework: coprimeness lets us cancel the factor of 10.",
+      "The positive osculator c satisfies 10c ≡ 1 (mod d), i.e., c is the multiplicative inverse of 10 mod d.",
+      "The negative osculator satisfies 10c ≡ -1 (mod d), i.e., c is the 'negative inverse' of 10 mod d.",
+      "Every d coprime to 10 has both positive and negative osculators (they are multiplicative inverses of 10 and -10 respectively).",
+      "The proof works uniformly for all d, not just primes."
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Module documentation, imports, and the div-mod identity lemma."
+    },
+    {
+      "id": "positive-osculator",
+      "title": "Positive Osculator Theorem",
+      "startLine": 37,
+      "endLine": 80,
+      "summary": "General theorem for d | n ↔ d | (n/10 + c*(n%10)) when d | 10c-1."
+    },
+    {
+      "id": "negative-osculator",
+      "title": "Negative Osculator Theorem",
+      "startLine": 82,
+      "endLine": 124,
+      "summary": "General theorem for d | n ↔ d | (n/10 - c*(n%10)) when d | 10c+1."
+    },
+    {
+      "id": "corollaries",
+      "title": "Concrete Corollaries",
+      "startLine": 126,
+      "endLine": 200,
+      "summary": "Specific rules for 3, 7, 9, 11, 13, 17, 19, 23, 29, 31, 37."
+    },
+    {
+      "id": "verification",
+      "title": "Verification Examples",
+      "startLine": 202,
+      "endLine": 240,
+      "summary": "Numeric examples confirming the rules work."
+    },
+    {
+      "id": "summary",
+      "title": "Summary Theorem",
+      "startLine": 242,
+      "endLine": 260,
+      "summary": "Master theorem packaging the five classical cases."
+    }
+  ],
+  "conclusion": {
+    "summary": "The truncation method generalizes to a complete parametric framework. Two theorems (`truncation_pos` and `truncation_neg`) cover all cases: for any d coprime to 10, there exist osculator constants c (the multiplicative inverse of ±10 mod d) giving divisibility tests. The proof uses a single algebraic identity and the `IsCoprime` machinery of Mathlib.",
+    "implications": "This unification has both mathematical and pedagogical value:\n- **Mathematical**: Shows the truncation method is not a collection of ad-hoc tricks but a single algebraic phenomenon.\n- **Computational**: Given any d coprime to 10, one can immediately compute the osculator and generate a divisibility test.\n- **Formal verification**: The parametric theorem is easier to maintain and extend than individual proofs.\n\nThe framework also extends to multi-digit truncation (the OQ-02 extension) and to arbitrary bases.",
+    "openQuestions": [
+      "Can the positive and negative osculator theorems be merged into a single theorem with a signed osculator c ∈ ℤ?",
+      "Can this be extended to divisors that share factors with 10 (i.e., d = 2, 5, 4, 8, 25, etc.) by combining with the last-k-digits framework?",
+      "What is the relationship between the osculator and the continued fraction expansion of 1/d?"
+    ]
+  }
+}

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -406,14 +406,59 @@
       "lastEnriched": "2026-02-14T00:27:13Z",
       "quality": 84
     },
-    "erdos-780": {
+    "erdos-923": {
       "passes": 1,
-      "lastEnriched": "2026-02-14T05:52:11Z",
+      "lastEnriched": "2026-02-14T05:17:56Z",
       "quality": 86
     },
-    "erdos-462": {
+    "erdos-924": {
       "passes": 1,
-      "lastEnriched": "2026-02-14T05:52:37Z",
+      "lastEnriched": "2026-02-14T05:18:39Z",
+      "quality": 86
+    },
+    "erdos-990": {
+      "passes": 1,
+      "lastEnriched": "2026-02-14T05:27:29Z",
+      "quality": 86
+    },
+    "hurwitz-theorem": {
+      "passes": 1,
+      "lastEnriched": "2026-02-14T05:28:14Z",
+      "quality": 80
+    },
+    "erdos-998": {
+      "passes": 1,
+      "lastEnriched": "2026-02-14T05:32:09Z",
+      "quality": 86
+    },
+    "erdos-995": {
+      "passes": 1,
+      "lastEnriched": "2026-02-14T05:32:42Z",
+      "quality": 86
+    },
+    "erdos-123": {
+      "passes": 1,
+      "lastEnriched": "2026-02-14T05:39:15Z",
+      "quality": 87
+    },
+    "poincare-conjecture": {
+      "passes": 1,
+      "lastEnriched": "2026-02-14T05:39:30Z",
+      "quality": 86
+    },
+    "erdos-450": {
+      "passes": 1,
+      "lastEnriched": "2026-02-14T05:43:20Z",
+      "quality": 87
+    },
+    "erdos-405": {
+      "passes": 1,
+      "lastEnriched": "2026-02-14T05:44:33Z",
+      "quality": 87
+    },
+    "erdos-461": {
+      "passes": 1,
+      "lastEnriched": "2026-02-14T05:47:58Z",
       "quality": 87
     },
     "erdos-716": {


### PR DESCRIPTION
## Summary

### Primary: divisibility-by-3-oq-01-oq-01 (General Truncation Theorem)

Answers the open question: "Can the truncation method be generalized to a single parametric theorem?" → **YES**

Two general theorems cover ALL truncation-based divisibility rules:

**Positive osculator** (d | 10c-1): `d | n ↔ d | (n/10 + c·(n%10))`
- d=13 c=4 (39=3·13), d=19 c=2 (19=1·19), d=3 c=1 (9=3·3)

**Negative osculator** (d | 10c+1): `d | n ↔ d | (n/10 - c·(n%10))`
- d=7 c=2 (21=3·7), d=11 c=1 (11=1·11), d=17 c=5 (51=3·17)

Key technique: `linear_combination -hdiv` for the algebraic identity `10*(q+cr) = n + (10c-1)*r`, then `IsCoprime.dvd_of_dvd_mul_left` to transfer through factor 10.

**Files**: `proofs/Proofs/DivisibilityTruncationGeneral.lean` (285 lines, 0 sorries), `src/data/proofs/divisibility-truncation-general/`

### Secondary: bezout-identity-oq-03 (CRT via Bézout)

- Proves CRT over **integers** (ℤ) using Bézout's identity directly  
- `IsCoprime m n` IS `bezout_int` specialized to gcd=1: `∃ u v, u*m + v*n = 1`
- 9 theorems + 4 worked examples, 0 sorries
- `proofs/Proofs/BezoutIdentityOQ03.lean`

### Tertiary: sqrt2-irrational-oq-03 (housekeeping)

- Adds `knowledge.md` documenting NthRootIrrational.lean as complete
- Updates candidate pool (was incorrectly showing "available")

## Theorems Proved

| File | Theorems | Sorries |
|------|----------|---------|
| DivisibilityTruncationGeneral.lean | 2 general + 11 corollaries | 0 |
| BezoutIdentityOQ03.lean | 9 theorems + examples | 0 |
| NthRootIrrational.lean | (already existed) | 0 |

## Test plan

- [x] DivisibilityTruncationGeneral: `./proofs/scripts/docker-build.sh Proofs.DivisibilityTruncationGeneral` — **3058 jobs, 2.1s** ✓
- [x] BezoutIdentityOQ03: `./proofs/scripts/docker-build.sh Proofs.BezoutIdentityOQ03` — succeeded ✓
- [x] All 0 sorries confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)