### PR TITLE
enrich(bezout-identity-oq-03): add 10 comprehensive annotations

### DIFF
--- a/src/data/proofs/bezout-identity-oq-03/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-03/annotations.json
@@ -1,1 +1,122 @@
-[]
+[
+  {
+    "id": "ann-imports",
+    "proofId": "bezout-identity-oq-03",
+    "range": { "startLine": 1, "endLine": 3 },
+    "type": "context",
+    "title": "Lean Mathlib Dependencies",
+    "content": "The proof imports three Mathlib modules. `Mathlib.Data.Int.GCD` provides the core Bézout identity via `Int.gcd_eq_gcd_ab`, along with the explicit Bézout coefficient functions `Int.gcdA` and `Int.gcdB`. `Mathlib.RingTheory.Coprime.Basic` provides `IsCoprime.mul_dvd`, the key lemma for uniqueness. `Mathlib.Tactic` gives access to `linear_combination`, `push_cast`, and `linarith`.",
+    "mathContext": "The Mathlib theorem `Int.gcd_eq_gcd_ab : (Int.gcd a b : ℤ) = a * Int.gcdA a b + b * Int.gcdB a b` is the formalized Bézout identity. The coefficients $u = \\text{gcdA}(a,b)$ and $v = \\text{gcdB}(a,b)$ are the Bézout witnesses computed by the extended Euclidean algorithm.",
+    "significance": "context",
+    "relatedConcepts": ["extended Euclidean algorithm", "Bézout's identity", "IsCoprime", "modular arithmetic"],
+    "prerequisites": ["Lean 4 imports", "Mathlib structure"]
+  },
+  {
+    "id": "ann-bezout-int",
+    "proofId": "bezout-identity-oq-03",
+    "range": { "startLine": 45, "endLine": 52 },
+    "type": "definition",
+    "title": "bezout_int: The Foundation",
+    "content": "This theorem restates Bézout's identity in a clean existential form: for any integers a and b, there exist integers x, y such that gcd(a,b) = a*x + b*y. The proof is a one-liner: it simply unpacks Mathlib's `Int.gcd_eq_gcd_ab` using the explicit coefficient functions `Int.gcdA` and `Int.gcdB`. This explicit computation via the extended Euclidean algorithm is what makes the CRT solution constructive.",
+    "mathContext": "Bézout's identity: for any $a, b \\in \\mathbb{Z}$, $\\exists\\, x, y \\in \\mathbb{Z}$ such that $\\gcd(a,b) = ax + by$. The proof constructs the witnesses explicitly: $x = \\text{gcdA}(a,b)$, $y = \\text{gcdB}(a,b)$, where these are computed by the extended Euclidean algorithm.",
+    "significance": "key",
+    "relatedConcepts": ["extended Euclidean algorithm", "greatest common divisor", "integer linear combinations", "Euclidean domain"],
+    "prerequisites": ["divisibility in ℤ", "Euclidean algorithm", "gcd definition"]
+  },
+  {
+    "id": "ann-coprime-bezout",
+    "proofId": "bezout-identity-oq-03",
+    "range": { "startLine": 54, "endLine": 63 },
+    "type": "technique",
+    "title": "coprime_bezout: Specializing to gcd = 1",
+    "content": "This theorem specializes `bezout_int` to the coprime case: when gcd(m, n) = 1, the linear combination becomes m*u + n*v = 1. The proof calls `bezout_int`, substitutes h : gcd(m,n) = 1, then uses `push_cast` to coerce from ℕ to ℤ (since `Int.gcd` returns ℕ) and `linarith` to reorder the equation. This is exactly the form of Bézout's identity needed for CRT.",
+    "mathContext": "When $\\gcd(m,n) = 1$ (coprime), Bézout's identity gives $\\exists\\, u, v \\in \\mathbb{Z}$ such that $mu + nv = 1$. The `push_cast` tactic handles the coercion from $\\mathbb{N}$ to $\\mathbb{Z}$, since `Int.gcd` is defined to return a natural number that must be cast: $(\\text{Int.gcd}\\, m\\, n : \\mathbb{Z}) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["coprimality", "type coercion in Lean", "Bézout coefficients", "push_cast tactic"],
+    "prerequisites": ["bezout_int", "Int.gcd type signature", "ℕ to ℤ coercions"]
+  },
+  {
+    "id": "ann-crt-existence",
+    "proofId": "bezout-identity-oq-03",
+    "range": { "startLine": 67, "endLine": 90 },
+    "type": "insight",
+    "title": "CRT Existence: The Explicit Formula",
+    "content": "This is the heart of the proof. Given Bézout coefficients u, v with m*u + n*v = 1, the explicit CRT solution is x = a·n·v + b·m·u. The `linear_combination` tactic proves both congruences in a single line each. For x ≡ a (mod m): the witness for m | (a - x) is u*(a-b), verified by `linear_combination -a * hbez` which multiplies the Bézout equation by -a. For x ≡ b (mod n): the witness is v*(b-a), from `linear_combination -b * hbez`.",
+    "mathContext": "The CRT solution formula: $x = a \\cdot nv + b \\cdot mu$. Verification of $x \\equiv a \\pmod{m}$: $$a - x = a - a \\cdot nv - b \\cdot mu = a(1 - nv) - b \\cdot mu = a \\cdot mu - b \\cdot mu = mu(a-b)$$ so $m \\mid (a-x)$. Verification of $x \\equiv b \\pmod{n}$: $$b - x = b(1 - mu) - a \\cdot nv = b \\cdot nv - a \\cdot nv = nv(b-a)$$ so $n \\mid (b-x)$.",
+    "significance": "key",
+    "relatedConcepts": ["Chinese Remainder Theorem", "modular arithmetic", "linear_combination tactic", "congruences as divisibility"],
+    "prerequisites": ["coprime_bezout", "Int.modEq_iff_dvd", "linear algebra over ℤ"]
+  },
+  {
+    "id": "ann-is-coprime-bridge",
+    "proofId": "bezout-identity-oq-03",
+    "range": { "startLine": 94, "endLine": 100 },
+    "type": "concept",
+    "title": "Bridging gcd-Coprimality and IsCoprime",
+    "content": "This small lemma bridges two different notions of coprimality in Mathlib: the concrete `Int.gcd m n = 1` and the abstract `IsCoprime m n`. The type `IsCoprime m n` is defined in Mathlib as `∃ u v, u * m + v * n = 1` — precisely Bézout's identity with coefficient-first ordering. The proof takes Bézout coefficients from `coprime_bezout` and reorders them via `linear_combination hbez` to match IsCoprime's convention.",
+    "mathContext": "In Mathlib, `IsCoprime m n` is defined as $\\exists\\, u\\, v,\\, um + vn = 1$ (note: coefficients come first). This is equivalent to $\\gcd(m,n) = 1$ but expressed ring-theoretically. The `linear_combination hbez` reorders from $mu + nv = 1$ to $um + vn = 1$, exploiting commutativity of multiplication.",
+    "significance": "supporting",
+    "relatedConcepts": ["IsCoprime in Mathlib", "algebraic vs. number-theoretic coprimality", "ring theory", "commutative rings"],
+    "prerequisites": ["coprime_bezout", "IsCoprime definition", "Lean 4 type definitions"]
+  },
+  {
+    "id": "ann-crt-uniqueness",
+    "proofId": "bezout-identity-oq-03",
+    "range": { "startLine": 102, "endLine": 111 },
+    "type": "insight",
+    "title": "CRT Uniqueness via IsCoprime.mul_dvd",
+    "content": "If x and y both satisfy the same congruence system, then m | (y - x) and n | (y - x). From IsCoprime.mul_dvd (when gcd(m,n) = 1, and m | k, n | k, then m*n | k), we conclude m*n | (y - x), i.e., x ≡ y (mod m*n). The proof converts congruences to divisibility with `Int.modEq_iff_dvd`, then directly applies `isCoprime_of_gcd_eq_one`. This two-line proof captures a key theorem of modular arithmetic.",
+    "mathContext": "Uniqueness: if $x \\equiv y \\pmod{m}$ and $x \\equiv y \\pmod{n}$ with $\\gcd(m,n) = 1$, then $m \\mid (y-x)$ and $n \\mid (y-x)$. By `IsCoprime.mul_dvd`: coprime divisors multiply, so $mn \\mid (y-x)$, i.e., $x \\equiv y \\pmod{mn}$. The solution is unique modulo $mn$.",
+    "significance": "key",
+    "relatedConcepts": ["uniqueness of CRT solution", "IsCoprime.mul_dvd", "modular arithmetic", "divisibility"],
+    "prerequisites": ["IsCoprime", "Int.modEq_iff_dvd", "isCoprime_of_gcd_eq_one"]
+  },
+  {
+    "id": "ann-crt-iscop",
+    "proofId": "bezout-identity-oq-03",
+    "range": { "startLine": 117, "endLine": 139 },
+    "type": "concept",
+    "title": "CRT via IsCoprime: The Algebraic Reformulation",
+    "content": "This section presents the CRT using `IsCoprime` directly, bypassing the gcd detour. Since `IsCoprime m n` *is* Bézout's identity (u*m + v*n = 1 by definition), we can directly destructure it to get Bézout coefficients. Note the coefficient-first ordering in IsCoprime: hbez has the form u*m + v*n = 1, so the solution is x = a*v*n + b*u*m (instead of a*n*v + b*m*u). The same linear_combination argument works. `crt_unique_iscop` becomes a single line.",
+    "mathContext": "The algebraic formulation: `IsCoprime m n` $\\overset{\\text{def}}{=}$ $\\exists\\, u\\, v,\\, um + vn = 1$. This is precisely Bézout's identity for $\\gcd = 1$, stated ring-theoretically. The CRT proof with IsCoprime is conceptually cleaner: no gcd normalization needed, just unpack the definition. Solution: $x = a \\cdot vn + b \\cdot um$ (matching the $um + vn = 1$ ordering).",
+    "significance": "supporting",
+    "relatedConcepts": ["algebraic number theory", "ring-theoretic coprimality", "IsCoprime in commutative rings", "Bézout domains"],
+    "prerequisites": ["IsCoprime definition", "CRT existence proof", "linear_combination tactic"]
+  },
+  {
+    "id": "ann-combined",
+    "proofId": "bezout-identity-oq-03",
+    "range": { "startLine": 143, "endLine": 154 },
+    "type": "insight",
+    "title": "Full CRT: Combined Existence-Uniqueness",
+    "content": "This theorem packages both existence and uniqueness into a single statement: there exists x satisfying both congruences, and any other solution y is congruent to x modulo m*n. The proof delegates to `crt_exists_via_bezout` for existence, then for uniqueness uses transitivity: x ≡ a ≡ y (mod m) gives x ≡ y (mod m), and similarly for n, then `crt_unique_via_bezout` concludes x ≡ y (mod m*n).",
+    "mathContext": "Full CRT (integer form): For $\\gcd(m,n) = 1$, $\\forall a,b \\in \\mathbb{Z}$: $\\exists!\\, x \\pmod{mn}$ with $x \\equiv a \\pmod{m}$ and $x \\equiv b \\pmod{n}$. Lean's formulation gives existence of $x$ and: $\\forall y$, if $y \\equiv a \\pmod{m}$ and $y \\equiv b \\pmod{n}$ then $x \\equiv y \\pmod{mn}$.",
+    "significance": "key",
+    "relatedConcepts": ["Chinese Remainder Theorem", "uniqueness modulo mn", "congruence transitivity", "ring isomorphism ℤ/mnℤ ≅ ℤ/mℤ × ℤ/nℤ"],
+    "prerequisites": ["crt_exists_via_bezout", "crt_unique_via_bezout", "Int.ModEq transitivity"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "bezout-identity-oq-03",
+    "range": { "startLine": 156, "endLine": 221 },
+    "type": "context",
+    "title": "Worked Examples with Explicit Bézout Coefficients",
+    "content": "Four concrete examples illustrate the CRT formula. Example 1 (mod 3, 5): Bézout: 3·2 + 5·(-1) = 1, solution x = 2·5·(-1) + 3·3·2 = -10 + 18 = 8. Example 2 (mod 7, 11): Bézout: 7·8 + 11·(-5) = 1, solution x = 2·11·(-5) + 3·7·8 = -110 + 168 = 58. Example 3 (mod 4, 9): Bézout: 4·7 + 9·(-3) = 1, solution x = 0 + 28 = 28. Example 4 demonstrates negative solutions over ℤ: mod 6 and 7. All verified by `decide` and `norm_num`.",
+    "mathContext": "The classic Sun Zi problem: $x \\equiv 2 \\pmod{3}$, $x \\equiv 3 \\pmod{5}$, $x \\equiv 2 \\pmod{7}$ has solution $x = 23$ (mod 105). Here we use two-modulus versions. The `decide` tactic works for small concrete integer congruences by checking all residues. The `norm_num` tactic handles arithmetic calculations. Both reflect that CRT solutions are effectively computable.",
+    "significance": "supporting",
+    "relatedConcepts": ["Sunzi Suanjing", "modular arithmetic", "decide tactic", "norm_num tactic"],
+    "prerequisites": ["CRT formula", "Bézout coefficients", "modular verification"]
+  },
+  {
+    "id": "ann-crt-function",
+    "proofId": "bezout-identity-oq-03",
+    "range": { "startLine": 229, "endLine": 257 },
+    "type": "technique",
+    "title": "crtInt: Explicit Computable CRT Function",
+    "content": "This section provides a computable function crtInt that returns an explicit CRT solution using Mathlib's built-in Bézout coefficient functions. The definition is: crtInt m n a b = a*n*gcdB(m,n) + b*m*gcdA(m,n). The correctness theorems crtInt_mod_left and crtInt_mod_right verify both congruences by unfolding the definition and applying the Bézout identity. The proof pattern is identical to the existential CRT proof: rw [Int.modEq_iff_dvd], construct witness, apply linear_combination.",
+    "mathContext": "The explicit formula: $\\text{crtInt}(m, n, a, b) = a \\cdot n \\cdot \\text{gcdB}(m,n) + b \\cdot m \\cdot \\text{gcdA}(m,n)$. Here $\\text{gcdA}(m,n)$ and $\\text{gcdB}(m,n)$ are Mathlib's computable Bézout coefficients satisfying $m \\cdot \\text{gcdA}(m,n) + n \\cdot \\text{gcdB}(m,n) = \\gcd(m,n)$. When $\\gcd(m,n) = 1$, this gives the Bézout equation directly.",
+    "significance": "supporting",
+    "relatedConcepts": ["computable mathematics", "verified computation", "extended Euclidean algorithm", "decidability"],
+    "prerequisites": ["Int.gcdA", "Int.gcdB", "crt_exists_via_bezout", "Lean 4 def vs theorem"]
+  }
+]


### PR DESCRIPTION
## Summary

Enrichment pass for `bezout-identity-oq-03` (CRT via Bézout's Identity, quality: 45, passes: 0).

### What was enriched

**annotations.json** was completely empty ([]). Added 10 comprehensive annotations covering all major proof sections:

- `ann-imports`: Lean Mathlib dependencies and their roles
- `ann-bezout-int`: `bezout_int` theorem - the foundational Bézout identity
- `ann-coprime-bezout`: `coprime_bezout` - specializing to gcd = 1 case
- `ann-crt-existence`: Core CRT existence with explicit formula $x = a \cdot nv + b \cdot mu$
- `ann-is-coprime-bridge`: Bridging `Int.gcd = 1` and `IsCoprime` notions
- `ann-crt-uniqueness`: Uniqueness via `IsCoprime.mul_dvd`
- `ann-crt-iscop`: Algebraic CRT formulation using `IsCoprime` directly
- `ann-combined`: Full existence-uniqueness combined theorem
- `ann-examples`: Four worked examples with explicit Bézout coefficients
- `ann-crt-function`: Computable `crtInt` function with correctness theorems

### Quality improvements

Each annotation includes:
- `mathContext`: LaTeX formulas explaining the mathematics
- `significance`: key/supporting/context classification
- `relatedConcepts`: connections to broader mathematics
- `prerequisites`: required background knowledge

### Coverage

Annotations span lines 1–257 of the 285-line proof, covering all major proof sections defined in `sections` array of meta.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)