### PR TITLE
enricher-2: Enrich erdos-151, erdos-314, erdos-330, erdos-334

### DIFF
--- a/src/data/proofs/erdos-334/annotations.json
+++ b/src/data/proofs/erdos-334/annotations.json
@@ -6,9 +6,10 @@
     "type": "definition",
     "title": "Smooth Number Definition",
     "content": "**isSmooth n y:**\n\nA natural number n is y-smooth if every prime factor p of n satisfies p ≤ y.\n\n**Definition:**\n```lean\ndef isSmooth (n : ℕ) (y : ℕ) : Prop :=\n  ∀ p : ℕ, p.Prime → p ∣ n → p ≤ y\n```\n\nSmooth numbers are fundamental in number theory and cryptography.",
-    "mathContext": "Smooth numbers appear in factorization algorithms, the quadratic sieve, and Pollard's rho algorithm.",
+    "mathContext": "$n$ is $y$-smooth iff $\\forall p \\text{ prime}, p \\mid n \\Rightarrow p \\le y$. Equivalently, all prime factors of $n$ are $\\le y$. Smooth numbers appear in the quadratic sieve, Pollard's rho, and index calculus algorithms for discrete logarithms. The Dickman function $\\rho(u)$ gives the density of $x^{1/u}$-smooth numbers up to $x$.",
     "significance": "critical",
-    "relatedConcepts": ["Prime factorization", "Dickman function", "Cryptography"]
+    "prerequisites": ["Nat.Prime in Lean", "dvd notation p ∣ n", "∀ universal quantifier over primes", "prime factorization existence"],
+    "relatedConcepts": ["Prime factorization", "Dickman function ρ(u)", "Cryptography", "Quadratic sieve", "Index calculus"]
   },
   {
     "id": "ann-e334-one-smooth",
@@ -17,7 +18,10 @@
     "type": "theorem",
     "title": "1 is Trivially Smooth",
     "content": "**one_smooth:**\n\nThe number 1 is y-smooth for any bound y, since 1 has no prime factors at all.\n\n**Proof:** If p is prime and p | 1, then p ≤ 1 (contradiction), so the condition is vacuously true.",
-    "significance": "supporting"
+    "mathContext": "$\\text{isSmooth}(1, y)$ is vacuously true because no prime divides 1: $\\forall p \\text{ prime}, p \\nmid 1$. In Lean: Nat.Prime.one_dvd is False (no prime divides 1), so the ∀ is vacuously satisfied.",
+    "significance": "supporting",
+    "prerequisites": ["Nat.Prime.not_dvd_one (no prime divides 1)", "vacuous truth in ∀ quantifiers", "isSmooth definition"],
+    "relatedConcepts": ["Vacuous truth", "Base case in smoothness proofs", "Prime divisibility"]
   },
   {
     "id": "ann-e334-prime-power",
@@ -26,16 +30,22 @@
     "type": "theorem",
     "title": "Prime Powers are p-Smooth",
     "content": "**prime_power_smooth:**\n\nAny power p^k of a prime p is p-smooth, since its only prime factor is p itself.\n\n**Application:** Powers of 2 are 2-smooth, powers of 3 are 3-smooth, etc. These are building blocks for smooth representations.",
-    "significance": "key"
+    "mathContext": "If $p$ is prime, then $p^k$ is $p$-smooth: the only prime dividing $p^k$ is $p$ itself. Lean proof uses Nat.Prime.dvd_prime_pow: if $q$ prime and $q \\mid p^k$, then $q = p$. Powers of 2 (Hamming numbers) and powers of 2×3×5 (5-smooth or regular numbers) are classical examples.",
+    "significance": "key",
+    "prerequisites": ["Nat.Prime.dvd_prime_pow", "prime uniqueness in prime power factors", "isSmooth definition"],
+    "relatedConcepts": ["Prime powers", "Hamming numbers (5-smooth)", "Regular numbers", "2-smooth = powers of 2"]
   },
   {
     "id": "ann-e334-smooth-mul",
     "proofId": "erdos-334",
     "range": { "startLine": 68, "endLine": 73 },
     "type": "theorem",
-    "title": "Product of Smooth Numbers",
+    "title": "Product of Smooth Numbers is Smooth",
     "content": "**smooth_mul:**\n\nThe product of two y-smooth numbers is also y-smooth.\n\n**Proof:** If p | ab, then p | a or p | b. Either way, p ≤ y since both a and b are y-smooth.\n\nThis closure property is essential for constructing smooth pair representations.",
-    "significance": "key"
+    "mathContext": "$\\text{isSmooth}(a,y) \\wedge \\text{isSmooth}(b,y) \\Rightarrow \\text{isSmooth}(a \\cdot b, y)$. Proof: if prime $p \\mid ab$, then $p \\mid a$ or $p \\mid b$ (by Euclid's lemma / Nat.Prime.dvd_mul), and in either case $p \\le y$. This makes y-smooth numbers a multiplicative semigroup.",
+    "significance": "key",
+    "prerequisites": ["Nat.Prime.dvd_mul (Euclid's lemma)", "isSmooth definition", "Or.elim for case analysis"],
+    "relatedConcepts": ["Multiplicative semigroup", "Euclid's lemma", "Closure under products", "Smooth number arithmetic"]
   },
   {
     "id": "ann-e334-pair-repr",
@@ -44,16 +54,22 @@
     "type": "definition",
     "title": "Smooth Pair Representation",
     "content": "**hasSmootPairRepr n y:**\n\nA number n has a y-smooth pair representation if n = a + b where both a and b are y-smooth.\n\n**Definition:**\n```lean\ndef hasSmootPairRepr (n : ℕ) (y : ℕ) : Prop :=\n  ∃ a b : ℕ, a + b = n ∧ isSmooth a y ∧ isSmooth b y\n```\n\nThe central question: how small can y be as a function of n?",
-    "significance": "critical"
+    "mathContext": "$\\text{hasSmootPairRepr}(n, y) \\iff \\exists a, b \\in \\mathbb{N} : a + b = n,\\, \\text{isSmooth}(a,y),\\, \\text{isSmooth}(b,y)$. The function $f(n) = \\min\\{y : \\text{hasSmootPairRepr}(n,y)\\}$ is what Problem #334 asks about. Key: n = a + 0 with a = n gives trivial n-smooth representation.",
+    "significance": "critical",
+    "prerequisites": ["isSmooth definition", "∃ a b : ℕ existential in Lean", "addition a + b = n", "And.intro for ∧"],
+    "relatedConcepts": ["Smooth pair sum", "Additive representation", "Sumset A + A", "Waring's problem analogue"]
   },
   {
     "id": "ann-e334-min-smooth",
     "proofId": "erdos-334",
     "range": { "startLine": 101, "endLine": 103 },
     "type": "definition",
-    "title": "Minimal Smoothness Function",
+    "title": "Minimal Smoothness Function f(n)",
     "content": "**minSmoothness n:**\n\nThe function f(n) is the smallest y such that n has a y-smooth pair representation.\n\nDetermining the growth rate of f(n) is the core of Erdős Problem #334.",
-    "significance": "critical"
+    "mathContext": "$f(n) = \\min\\{y \\ge 0 : \\text{hasSmootPairRepr}(n, y)\\}$. Trivially $f(n) \\le n$ (take $a=n, b=0$, giving $n$-smooth). Erdős asks: what is the true order of $f(n)$? Conjectured: $f(n) \\le e^{O(\\sqrt{\\log n})}$. Known: $f(n) \\le n^{4/(9\\sqrt{e})+\\varepsilon}$ (Balog 1989).",
+    "significance": "critical",
+    "prerequisites": ["hasSmootPairRepr definition", "natural number minimum", "axiom for noncomputable min", "Nat.find or similar in Lean"],
+    "relatedConcepts": ["Minimal smoothness bound", "Growth rate of f(n)", "Erdős #334 open question", "Balog's theorem"]
   },
   {
     "id": "ann-e334-exists",
@@ -61,8 +77,11 @@
     "range": { "startLine": 110, "endLine": 111 },
     "type": "axiom",
     "title": "Existence of Smooth Representations",
-    "content": "**minSmoothness_exists:**\n\nEvery n ≥ 1 can be written as a + b with a, b having only \"small\" prime factors.\n\nTrival bound: y ≤ n always works (since n = n + 0 and n is n-smooth).\n\nThe question is: how much smaller than n can y be?",
-    "significance": "key"
+    "content": "**minSmoothness_exists:**\n\nEvery n ≥ 1 can be written as a + b with a, b having only \"small\" prime factors.\n\nTrivial bound: y ≤ n always works (since n = n + 0 and n is n-smooth).\n\nThe question is: how much smaller than n can y be?",
+    "mathContext": "Trivial: $n = n + 0$, so $a = n$ is $n$-smooth (any prime $p \\mid n$ satisfies $p \\le n$), and $b = 0$ is vacuously smooth. Thus $f(n) \\le n$ always. The gap from $n$ to the conjectured $e^{O(\\sqrt{\\log n})}$ is enormous.",
+    "significance": "key",
+    "prerequisites": ["minSmoothness definition", "hasSmootPairRepr with b=0 (trivial case)", "n ≥ 1 hypothesis"],
+    "relatedConcepts": ["Trivial upper bound f(n) ≤ n", "Existential smoothness", "Non-trivial smooth representations"]
   },
   {
     "id": "ann-e334-cube-root",
@@ -71,8 +90,10 @@
     "type": "axiom",
     "title": "Erdős's Original n^{1/3} Question",
     "content": "**erdos_cube_root_bound:**\n\nErdős originally asked whether f(n) ≤ n^{1/3} holds for all sufficiently large n.\n\n**Status:** This has been answered positively—the cube root bound is achievable.\n\nBut stronger bounds are now known (Balog 1989).",
-    "mathContext": "The cube root appears naturally: if we could always find a = p^k and b = q^l with p, q ≤ n^{1/3}, we'd need p^k + q^l = n.",
-    "significance": "key"
+    "mathContext": "The exponent $1/3 \\approx 0.333$ was Erdős's original conjectured threshold. The cube root appears because: if $n = a + b$ with $a, b$ smooth up to $n^{1/3}$, heuristically $a \\approx b \\approx n/2$ and each has largest prime $\\le n^{1/3}$. Balog improved to $n^{4/(9\\sqrt{e})} \\approx n^{0.2695}$.",
+    "significance": "key",
+    "prerequisites": ["Real.rpow for n^{1/3}", "n ≥ 2 (or large enough)", "hasSmootPairRepr with y = n^{1/3}"],
+    "relatedConcepts": ["Cube root threshold", "Balog's improvement", "Smooth number heuristics", "Dickman function at u=3"]
   },
   {
     "id": "ann-e334-balog-exp",
@@ -81,17 +102,22 @@
     "type": "definition",
     "title": "Balog's Exponent 4/(9√e)",
     "content": "**balogExponent:**\n\n```lean\nnoncomputable def balogExponent : ℝ := 4 / (9 * Real.sqrt Real.exp 1)\n```\n\n**Value:** 4/(9√e) ≈ 4/(9 × 1.6487) ≈ 0.2695\n\nThis significantly improves Erdős's n^{1/3} ≈ n^{0.333}.",
-    "significance": "critical"
+    "mathContext": "$\\beta = \\frac{4}{9\\sqrt{e}} \\approx 0.2695$. Balog proved $f(n) \\le n^{\\beta+\\varepsilon}$ for any $\\varepsilon > 0$. The constant $4/(9\\sqrt{e})$ arises from optimizing saddle-point estimates in the Selberg-Delange method for counting smooth numbers in arithmetic progressions.",
+    "significance": "critical",
+    "prerequisites": ["Real.sqrt in Lean", "Real.exp 1 = e", "noncomputable def for transcendental constants", "Real.div"],
+    "relatedConcepts": ["Balog's theorem (1989)", "Selberg-Delange method", "Saddle-point method", "Smooth number counting"]
   },
   {
     "id": "ann-e334-balog-bound",
     "proofId": "erdos-334",
     "range": { "startLine": 138, "endLine": 140 },
     "type": "axiom",
-    "title": "Balog's 1989 Result",
+    "title": "Balog's 1989 Theorem",
     "content": "**balog_bound:**\n\nFor every ε > 0, there exists a constant C such that every n ≥ 2 can be written as a + b with both summands being n^{0.2695+ε}-smooth.\n\n**Reference:** Balog [Ba89]: \"On additive representation of integers\", Acta Math. Hungar. (1989).\n\nThis is the current state of the art.",
-    "mathContext": "The proof uses sophisticated estimates on the density of smooth numbers via the Dickman function.",
-    "significance": "critical"
+    "mathContext": "$\\forall \\varepsilon > 0,\\, \\exists C,\\, \\forall n \\ge 2 : n = a + b$ with $a, b$ both $n^{\\beta+\\varepsilon}$-smooth where $\\beta = 4/(9\\sqrt{e})$. Axiomatized since the proof requires deep analytic number theory: Dickman's function estimates, Selberg-Delange method, and exponential sum bounds.",
+    "significance": "critical",
+    "prerequisites": ["balogExponent definition", "hasSmootPairRepr definition", "Real.rpow for n^{β+ε}", "Dickman function background"],
+    "relatedConcepts": ["Dickman function", "Selberg-Delange method", "Smooth numbers in arithmetic progressions", "Current best bound"]
   },
   {
     "id": "ann-e334-weak-conj",
@@ -100,7 +126,10 @@
     "type": "definition",
     "title": "Weak Conjecture: f(n) ≤ n^{o(1)}",
     "content": "**weakConjecture:**\n\nFor any ε > 0, f(n) ≤ n^ε for all sufficiently large n.\n\n**Meaning:** f(n) grows slower than any fixed polynomial power—it's subpolynomial.\n\n**Status:** OPEN. Current best is n^{0.2695}, which is still polynomial.",
-    "significance": "key"
+    "mathContext": "$\\text{weakConjecture} \\iff \\forall \\varepsilon > 0,\\, \\exists N,\\, \\forall n \\ge N : f(n) \\le n^\\varepsilon$. This is $f(n) = n^{o(1)}$ in asymptotic notation. The current barrier is Balog's $n^{0.2695}$. A proof would require new ideas beyond existing smooth number density estimates.",
+    "significance": "key",
+    "prerequisites": ["minSmoothness definition", "Real.rpow for n^ε", "subpolynomial growth / o(1) notation", "Filter.atTop in Lean (for ∀ large n)"],
+    "relatedConcepts": ["Subpolynomial growth", "n^{o(1)} notation", "Strong conjecture e^{O(√log n)}", "Gap from Balog to conjecture"]
   },
   {
     "id": "ann-e334-strong-conj",
@@ -109,7 +138,10 @@
     "type": "definition",
     "title": "Strong Conjecture: f(n) ≤ e^{O(√log n)}",
     "content": "**strongConjecture:**\n\nf(n) ≤ e^{C√(log n)} for some constant C.\n\n**Growth rate:** Much slower than any polynomial—almost poly-logarithmic.\n\n**Status:** OPEN. This would be a dramatic improvement over current bounds.",
-    "significance": "key"
+    "mathContext": "$f(n) \\le e^{C\\sqrt{\\log n}}$ for some $C > 0$. This growth is between polynomial ($n^\\varepsilon$) and polylogarithmic ($\\log^k n$). It appears in the number field sieve running time. If true, every $n$ decomposes as $a+b$ where both summands have all prime factors $\\le e^{C\\sqrt{\\log n}}$.",
+    "significance": "key",
+    "prerequisites": ["Real.log", "Real.sqrt (log n)", "Real.exp", "e^{O(√log n)} growth rate", "comparison to number field sieve complexity"],
+    "relatedConcepts": ["Number field sieve", "Subexponential complexity", "L-notation", "Smooth number sieving bounds"]
   },
   {
     "id": "ann-e334-example-10",
@@ -118,7 +150,10 @@
     "type": "theorem",
     "title": "Example: 10 = 2 + 8",
     "content": "**example_10:**\n\n10 has a 2-smooth pair representation: 10 = 2 + 8.\n\n**Verification:**\n- 2 = 2¹ is 2-smooth (only prime factor is 2)\n- 8 = 2³ is 2-smooth (only prime factor is 2)\n\nThis is a complete proof using Nat.Prime.dvd_prime_pow.",
-    "significance": "key"
+    "mathContext": "$10 = 2 + 8$ with $2 = 2^1$ and $8 = 2^3$, both 2-smooth. Proof uses Nat.Prime.dvd_prime_pow: if prime $p \\mid 2^k$ then $p = 2$. The smallest representable y for 10 is thus $f(10) \\le 2$.",
+    "significance": "key",
+    "prerequisites": ["hasSmootPairRepr definition", "Nat.Prime.dvd_prime_pow", "decide or norm_num for decidable propositions", "2-smooth = powers of 2"],
+    "relatedConcepts": ["Concrete smooth examples", "Powers of 2 as 2-smooth", "f(10) = 2 computation", "Verification by cases"]
   },
   {
     "id": "ann-e334-example-100",
@@ -127,18 +162,22 @@
     "type": "theorem",
     "title": "Example: 100 = 64 + 36",
     "content": "**example_100:**\n\n100 has a 3-smooth pair representation: 100 = 64 + 36.\n\n**Verification:**\n- 64 = 2⁶ is 2-smooth (hence 3-smooth)\n- 36 = 2² × 3² is 3-smooth (prime factors 2 and 3)\n\nThe proof handles both prime divisibility cases using dvd_mul.",
-    "significance": "key"
+    "mathContext": "$100 = 64 + 36$. $64 = 2^6$ is 3-smooth. $36 = 4 \\cdot 9 = 2^2 \\cdot 3^2$ has prime factors 2 and 3, both $\\le 3$. Lean proof: for prime $p \\mid 36$, by Nat.Prime.dvd_mul get $p \\mid 4$ or $p \\mid 9$, then $p = 2$ or $p = 3$.",
+    "significance": "key",
+    "prerequisites": ["hasSmootPairRepr for 3-smooth", "Nat.Prime.dvd_mul", "case analysis Or.elim", "2 ≤ 3 and 3 ≤ 3"],
+    "relatedConcepts": ["3-smooth numbers (Hamming numbers)", "f(100) ≤ 3", "Concrete computation", "dvd_mul case analysis"]
   },
   {
     "id": "ann-e334-dickman",
     "proofId": "erdos-334",
     "range": { "startLine": 240, "endLine": 242 },
     "type": "axiom",
-    "title": "de Bruijn's Asymptotic",
+    "title": "Dickman-de Bruijn Asymptotic",
     "content": "**de_bruijn_asymptotic:**\n\nThe count ψ(x, y) of y-smooth numbers up to x satisfies:\n\nψ(x, y) ~ x · ρ(u) where u = log x / log y\n\nand ρ is the **Dickman function**.\n\n**Importance:** Understanding smooth number density is key to proving bounds on f(n).",
-    "mathContext": "The Dickman function ρ(u) satisfies ρ(u) = 1 for u ≤ 1 and uρ'(u) + ρ(u-1) = 0 for u > 1.",
+    "mathContext": "$\\psi(x,y) = |\\{n \\le x : n \\text{ is } y\\text{-smooth}\\}| \\sim x \\rho(u)$ where $u = \\log x / \\log y$ and $\\rho$ is the Dickman function satisfying $u\\rho'(u) = -\\rho(u-1)$ for $u > 1$, $\\rho(u) = 1$ for $0 \\le u \\le 1$. At $u=3$ (cube root bound): $\\rho(3) \\approx 0.0486$.",
     "significance": "key",
-    "relatedConcepts": ["Smooth numbers", "Analytic number theory"]
+    "prerequisites": ["Dickman function ρ(u) definition (delay differential equation)", "ψ(x,y) counting function", "Real.log", "asymptotic density of smooth numbers"],
+    "relatedConcepts": ["Dickman function", "Smooth number counting ψ(x,y)", "Analytic number theory", "de Bruijn's estimate", "Selberg-Delange method"]
   },
   {
     "id": "ann-e334-summary",
@@ -147,7 +186,10 @@
     "type": "theorem",
     "title": "Summary Theorem",
     "content": "**erdos_334_summary:**\n\nCombines all main results:\n1. Erdős's n^{1/3} question is resolved (erdos_cube_root_bound)\n2. Balog's bound n^{0.2695+ε} is current best (balog_bound)\n3. The optimal bound remains unknown\n\nThis summarizes the state of knowledge for Erdős #334.",
-    "significance": "key"
+    "mathContext": "Summary packages: (1) $f(n) \\le n^{1/3}$ (Erdős, resolved), (2) $f(n) \\le n^{\\beta+\\varepsilon}$ where $\\beta = 4/(9\\sqrt{e}) \\approx 0.2695$ (Balog 1989), (3) weakConjecture and strongConjecture remain open. Proved by combining the three main axioms via And.intro.",
+    "significance": "key",
+    "prerequisites": ["erdos_cube_root_bound axiom", "balog_bound axiom", "weakConjecture / strongConjecture definitions", "And.intro for conjunction"],
+    "relatedConcepts": ["State of knowledge summary", "Open vs proved bounds", "Erdős #334 current status", "Path from n^{1/3} to n^{o(1)}"]
   },
   {
     "id": "ann-e334-main",
@@ -156,7 +198,10 @@
     "type": "theorem",
     "title": "Main Theorem: n^{0.27+ε}-Smooth",
     "content": "**erdos_334:**\n\nFor any ε > 0, there exists N such that every n ≥ N can be written as a + b with both summands being n^{0.27+ε}-smooth.\n\n**Derivation:** 0.27 > 4/(9√e) ≈ 0.2695, so this follows from Balog's bound.\n\nThis is the main formalized result.",
-    "significance": "critical"
+    "mathContext": "$\\forall \\varepsilon > 0,\\, \\exists N,\\, \\forall n \\ge N : n = a + b$ with $a, b$ being $n^{0.27+\\varepsilon}$-smooth. Since $0.27 > 4/(9\\sqrt{e}) \\approx 0.2695$, this is a slight weakening of Balog's bound (more conservative exponent). Proved by: $0.27 > \\beta \\Rightarrow$ apply balog_bound with $\\varepsilon' = 0.27 - \\beta + \\varepsilon$.",
+    "significance": "critical",
+    "prerequisites": ["balog_bound axiom", "balogExponent ≈ 0.2695", "0.27 > balogExponent (arithmetic)", "Real.rpow monotonicity"],
+    "relatedConcepts": ["Balog's theorem application", "Conservative exponent 0.27", "Main result formalization", "Real arithmetic for exponent comparison"]
   },
   {
     "id": "ann-e334-open",
@@ -165,6 +210,9 @@
     "type": "definition",
     "title": "The Open Question",
     "content": "**openQuestion:**\n\nWhat is the true growth rate of f(n)?\n\n**Current gap:**\n- Upper bound: n^{0.2695} (Balog)\n- Conjectured: n^{o(1)} or even e^{O(√log n)}\n\nClosing this gap is Erdős Problem #334.",
-    "significance": "critical"
+    "mathContext": "The open question: $\\text{weakConjecture} \\vee \\text{strongConjecture}$? Currently $f(n) \\le n^{0.2695+\\varepsilon}$ (Balog). The conjecture $f(n) \\le e^{O(\\sqrt{\\log n})}$ would give a subexponential (but superpolylogarithmic) bound. Closing this gap requires new tools combining smooth number theory with additive combinatorics.",
+    "significance": "critical",
+    "prerequisites": ["weakConjecture definition", "strongConjecture definition", "balog_bound (current best)", "gap between polynomial and subexponential bounds"],
+    "relatedConcepts": ["Open problem status", "Smooth number conjecture", "Green's Open Problems List #59", "Erdős-Graham 1980"]
   }
 ]


### PR DESCRIPTION
## Mathematical Enrichment Pass

This PR adds mathematical depth to four proof gallery entries:

### erdos-151 (Clique Transversal, Erdős–Gallai Conjecture)
- Added prerequisites to all 8 annotations, mathContext to axioms annotation
- Covers: clique transversal τ(G), H(n) ≥ √n, open K₄-free case

### erdos-314 (Harmonic Sum Error Term - SOLVED 2024)
- Added prerequisites/relatedConcepts/mathContext to all 10 annotations
- Covers harmonic sums, m(n) ≈ en, Lim-Steinerberger 2024 resolution

### erdos-330 (Minimal Additive Bases with Positive Density)
- Added prerequisites to all 6 annotations
- Covers: additive basis, upper density, Stöhr-Härtter (1955-56) theory

### erdos-334 (Smooth Number Pair Representations)
- Added prerequisites/relatedConcepts/mathContext to all 18 annotations
- Covers: y-smooth numbers, Dickman ρ(u), Balog's n^{0.2695} bound,
  weak/strong conjectures, Lean proof examples (10=2+8, 100=64+36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)