### PR TITLE
enrich(erdos-581): add relatedConcepts to all annotations, fix significance

### DIFF
--- a/src/data/proofs/erdos-581/annotations.json
+++ b/src/data/proofs/erdos-581/annotations.json
@@ -7,7 +7,7 @@
     "title": "Problem Overview",
     "content": "**Erdős Problem #581: Bipartite Subgraphs of Triangle-Free Graphs**\n\nLet f(m) = guaranteed bipartite edges in any triangle-free graph with m edges.\n\n**Question:** Determine f(m).\n\n**Answer (Alon 1996):**\nf(m) = m/2 + Θ(m^{4/5})\n\nTriangle-free graphs are 'more bipartite' than arbitrary graphs.",
     "mathContext": "This connects extremal graph theory to probabilistic methods.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["Triangle-free graphs", "Bipartite graphs", "Extremal combinatorics", "Turán theory"]
   },
   {
@@ -17,7 +17,8 @@
     "type": "definition",
     "title": "Triangle-Free Graph",
     "content": "**IsTriangleFree:**\n\nA graph G is triangle-free if no three vertices form a complete triangle (K₃).\n\nFormally: ∀ a b c, ¬(Adj(a,b) ∧ Adj(b,c) ∧ Adj(a,c))",
-    "significance": "critical"
+    "relatedConcepts": ["Turán's theorem", "K₃-free graphs", "Mantel's theorem", "extremal graph theory"],
+    "significance": "key"
   },
   {
     "id": "ann-e581-bipartite",
@@ -26,7 +27,8 @@
     "type": "definition",
     "title": "Bipartite Graph",
     "content": "**IsBipartite:**\n\nA graph is bipartite if vertices partition into two sets with all edges between them.\n\nV = A ∪ B with A ∩ B = ∅ and all edges go A ↔ B.",
-    "significance": "critical"
+    "relatedConcepts": ["2-colorability", "graph partitioning", "Kővári-Sós-Turán theorem", "bipartite subgraph"],
+    "significance": "key"
   },
   {
     "id": "ann-e581-f-axioms",
@@ -36,7 +38,8 @@
     "title": "Axiomatized Functions",
     "content": "**maxBipartiteEdges** and **f** are axiomatized rather than defined with sorry.\n\nmaxBipartiteEdges(G) represents the supremum over all bipartite subgraphs of G.\n\nf(m) represents the infimum over all triangle-free graphs with m edges of their maximum bipartite subgraph size.\n\nThese are axiomatized because defining them constructively requires choice principles and non-trivial set-theoretic machinery.",
     "mathContext": "The function f(m) is the central object of study in Problem #581.",
-    "significance": "critical"
+    "relatedConcepts": ["infimum over graphs", "Classical.choose in Lean 4", "extremal functions", "supremum of bipartite subgraphs"],
+    "significance": "key"
   },
   {
     "id": "ann-e581-half",
@@ -45,6 +48,7 @@
     "type": "axiom",
     "title": "Trivial Lower Bound",
     "content": "**half_edges_bipartite:**\n\nEvery graph has a bipartite subgraph with ≥ m/2 edges.\n\n**Proof:** Random 2-coloring has expected m/2 bichromatic edges.\n\nThis is the baseline - triangle-freeness should help.",
+    "relatedConcepts": ["probabilistic method", "random 2-coloring", "expected value argument", "Edwards bound"],
     "significance": "key"
   },
   {
@@ -54,7 +58,8 @@
     "type": "axiom",
     "title": "Alon's Upper Bound",
     "content": "**alon_upper_bound:**\n\n∃ c₂ > 0 such that f(m) ≤ m/2 + c₂·m^{4/5}\n\nThis comes from constructing triangle-free graphs where the maximum bipartite subgraph is bounded.\n\nThe constant c₂ is extracted via Classical.choose and proved positive.",
-    "significance": "critical"
+    "relatedConcepts": ["extremal constructions", "m^{4/5} exponent", "Classical.choose", "Alon 1996 Combinatorica"],
+    "significance": "key"
   },
   {
     "id": "ann-e581-lower",
@@ -63,7 +68,8 @@
     "type": "axiom",
     "title": "Alon's Lower Bound",
     "content": "**alon_lower_bound:**\n\n∃ c₁ > 0 such that f(m) ≥ m/2 + c₁·m^{4/5}\n\nTriangle-free graphs MUST have bipartite subgraphs significantly larger than m/2.\n\nThe constant c₁ is extracted via Classical.choose and proved positive.",
-    "significance": "critical"
+    "relatedConcepts": ["probabilistic method", "algebraic constructions", "triangle-free bonus", "m^{4/5} lower bound"],
+    "significance": "key"
   },
   {
     "id": "ann-e581-theta",
@@ -73,7 +79,8 @@
     "title": "Asymptotic Characterization",
     "content": "**ThetaBound** defines big-Theta notation: f(m) - m/2 = Θ(g(m)) means ∃ c₁, c₂ > 0 such that c₁·g(m) ≤ f(m) - m/2 ≤ c₂·g(m).\n\n**alon_main_theorem** proves ThetaBound f (fun m => m^{4/5}), combining both of Alon's bounds via linarith.",
     "mathContext": "This is the precise asymptotic characterization of the deviation from the trivial m/2 bound.",
-    "significance": "critical"
+    "relatedConcepts": ["big-Theta notation", "asymptotic equivalence", "linarith tactic", "Alon's theorem"],
+    "significance": "key"
   },
   {
     "id": "ann-e581-related",
@@ -82,6 +89,7 @@
     "type": "axiom",
     "title": "Related Classical Results",
     "content": "Three related results are axiomatized:\n\n1. **general_graph_bound**: Any graph has a bipartite subgraph with ≥ m/2 edges.\n2. **mantel_theorem** (1907): Triangle-free graphs on n vertices have ≤ n²/4 edges.\n3. **KST_bound** (Kővári-Sós-Turán): |E(G)| ≤ (1/2)n^{3/2} + (1/4)n for triangle-free G.\n\nThese classical results constrain the structure of triangle-free graphs and help explain the 4/5 exponent.",
+    "relatedConcepts": ["Mantel's theorem 1907", "Kővári-Sós-Turán theorem", "Turán-type problems", "extremal graph theory"],
     "significance": "key"
   },
   {
@@ -92,6 +100,7 @@
     "title": "Main Results",
     "content": "**erdos_581** combines both bounds into a single conjunction:\n(∃ c₁ > 0, ∀ m, f(m) ≥ m/2 + c₁·m^{4/5}) ∧ (∃ c₂ > 0, ∀ m, f(m) ≤ m/2 + c₂·m^{4/5})\n\n**erdos_581_summary** further includes positivity of the extracted constants c₁ and c₂, proved using exact ⟨alon_lower_bound, alon_upper_bound, c₁_positive.le, c₂_positive.le⟩.",
     "mathContext": "Status: SOLVED by Alon (1996). The answer f(m) = m/2 + Θ(m^{4/5}) shows triangle-free graphs are inherently more bipartite-like than arbitrary graphs.",
-    "significance": "critical"
+    "relatedConcepts": ["Alon 1996 Combinatorica 16", "conjunction of bounds", "bipartite-like structure", "solved Erdős problems"],
+    "significance": "key"
   }
 ]


### PR DESCRIPTION
## Enrichment: Erdős Problem #581 (Bipartite Subgraphs of Triangle-Free Graphs)

**Quality gaps addressed (93 → 100):**
- `crossRefs`: 3 → 10 — added relatedConcepts to all 10 annotations (was only 1/10) (+7pts)
- Fixed significance: 'critical' → 'key' (8 annotations, data correctness)

**Expected quality: 93 → 100**

🤖 Enricher-1 automated enrichment