### PR TITLE
enrich(erdos-667): expand historicalContext, add section+keyInsight, fix significance

### DIFF
--- a/src/data/proofs/erdos-667/annotations.json
+++ b/src/data/proofs/erdos-667/annotations.json
@@ -8,7 +8,7 @@
     "content": "**Erdos Problem 667** studies the function **c(p, q)**, the polynomial exponent governing how large a clique is guaranteed in any n-vertex graph where every p-subset spans at least q edges. The central question is whether c(p, q) is **strictly increasing** in q for 1 <= q <= C(p-1, 2) + 1. The formalization builds up from graph-theoretic foundations through the extremal function H(n; p, q) to the limiting exponent and its known bounds, proving several structural consequences.",
     "mathContext": "This problem sits at the intersection of Ramsey theory and extremal graph theory. When q = 1 the condition 'every p-set spans at least 1 edge' is equivalent to having no independent set of size p, reducing to classical Ramsey. As q increases toward C(p-1, 2) + 1, the condition forces progressively denser local structure until the graph must be complete. The question is whether each incremental edge requirement genuinely improves the global clique guarantee.",
     "relatedConcepts": ["extremal graph theory", "Ramsey theory", "clique numbers", "graph density"],
-    "significance": "essential"
+    "significance": "key"
   },
   {
     "id": "erdos-667-edge-count",
@@ -30,7 +30,7 @@
     "content": "**cliqueGuarantee n p q** is the largest m such that every n-vertex graph satisfying the **(p, q)-density** condition must contain a complete subgraph K_m. It is axiomatized with key structural properties: **positivity** (H >= 1 for non-empty graphs), **monotonicity** in both n and q, and the bound H <= n.",
     "mathContext": "H(n; p, q) is a Ramsey-type extremal function. It generalises the classical Ramsey number R(p, m), which corresponds to the case q = 1. The function captures how much additional local density (measured by q) translates into guaranteed global structure (a large clique). Its polynomial growth rate in n is captured by the exponent c(p, q).",
     "relatedConcepts": ["Ramsey-type functions", "extremal functions", "clique number guarantees"],
-    "significance": "essential"
+    "significance": "key"
   },
   {
     "id": "erdos-667-boundary-values",
@@ -52,7 +52,7 @@
     "content": "**cpq p q** = lim inf log(H(n; p, q)) / log(n) as n tends to infinity. This **rational-valued exponent** captures the polynomial rate at which the clique guarantee grows with n. It satisfies 0 <= c(p, q) <= 1 and is weakly increasing in q.",
     "mathContext": "The exponent c(p, q) compresses the asymptotic behaviour of H into a single number. When c(p, q) = alpha, it means H(n; p, q) grows roughly as n^alpha. The choice of lim inf (rather than lim) is technically important because the limit may not exist for all parameter values, though it is expected to exist in the cases of interest.",
     "relatedConcepts": ["polynomial growth exponents", "lim inf", "asymptotic analysis"],
-    "significance": "essential"
+    "significance": "key"
   },
   {
     "id": "erdos-667-ramsey-bounds",
@@ -63,7 +63,7 @@
     "content": "When q = 1, the density condition simply forbids independent sets of size p, reducing to classical Ramsey theory. The known bounds give **1/(p-1) <= c(p, 1) <= 2/(p+1)**. This interval narrows as p grows, but pinning down the exact value of c(p, 1) remains open.",
     "mathContext": "The lower bound 1/(p-1) comes from the standard probabilistic Ramsey lower bound: R(p, m) >= c * m^{p-1}, giving H(n; p, 1) >= n^{1/(p-1)}. The upper bound 2/(p+1) is Shearer's entropy-based result for off-diagonal Ramsey numbers. The gap between these bounds is one of the central open questions in Ramsey theory even for the case q = 1.",
     "relatedConcepts": ["off-diagonal Ramsey numbers", "probabilistic lower bounds", "entropy methods"],
-    "significance": "essential"
+    "significance": "key"
   },
   {
     "id": "erdos-667-efrs",
@@ -74,7 +74,7 @@
     "content": "**EFRS** proved that c(p, C(p-1, 2)) <= 1/2: even at the **second-to-last** density level, the exponent is at most 1/2. Since c(p, C(p-1, 2) + 1) = 1, this establishes a **strict jump** at the top of the q-range and provides the key evidence for strict monotonicity.",
     "mathContext": "The EFRS bound is remarkable because it shows a discontinuity-like phenomenon: c(p, q) must jump from at most 1/2 to exactly 1 in a single step. This means the last edge requirement (going from C(p-1, 2) to C(p-1, 2) + 1 edges per p-set) has a dramatic effect on global structure, transitioning from sub-polynomial to linear clique guarantees.",
     "relatedConcepts": ["EFRS theorem", "phase transitions", "extremal density thresholds"],
-    "significance": "essential"
+    "significance": "key"
   },
   {
     "id": "erdos-667-proved-theorems",
@@ -107,6 +107,6 @@
     "content": "**ErdosProblem667** asserts that for all p >= 3 and all q with 1 <= q < C(p-1, 2) + 1, we have c(p, q) < c(p, q+1). Each additional edge per p-set **strictly improves** the clique guarantee exponent. The formalization also includes **erdos667_weak_evidence** showing c(p, 1) < 1 = c(p, q_max) and a **summary theorem** packaging all known results.",
     "mathContext": "The conjecture asks for a fine-grained understanding of how local density translates to global structure. If true, it would mean there are no 'plateaus' in the function q -> c(p, q): every additional local edge requirement, no matter how small relative to the total, has a measurable global effect. This would be a deep structural result about the geometry of dense graphs.",
     "relatedConcepts": ["strict monotonicity", "density-structure trade-offs", "open Erdos problems"],
-    "significance": "essential"
+    "significance": "key"
   }
 ]

--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -22,14 +22,15 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős, Faudree, Rousseau, and Schelp studied H(n;p,q), the largest clique guaranteed in n-vertex graphs where every p-set has ≥ q edges. They defined c(p,q) = lim inf log H/log n and asked whether it is strictly increasing in q. Known bounds include the Ramsey-type bounds for q = 1 and c(p, ⌊(p-1)/2⌋) ≤ 1/2.",
+    "historicalContext": "**Erdős, Faudree, Rousseau, and Schelp** (EFRS) studied $H(n;p,q)$, the largest clique guaranteed in $n$-vertex graphs where every $p$-vertex subset spans $\\geq q$ edges. They defined $c(p,q) = \\liminf_{n\\to\\infty} \\log H(n;p,q)/\\log n$ and asked whether it is strictly increasing in $q$. The problem interpolates between classical Ramsey theory ($q=1$, reduces to independence-number bounds) and complete graphs ($q = \\binom{p-1}{2}+1$, forces $G = K_n$). The EFRS bound $c(p, \\lfloor(p-1)/2\\rfloor) \\leq 1/2$ shows a dramatic jump at the top of the range. Classical Ramsey bounds give $1/(p-1) \\leq c(p,1) \\leq 2/(p+1)$; the intermediate values remain largely open.",
     "problemStatement": "Is c(p,q) strictly increasing in q for 1 ≤ q ≤ C(p-1,2) + 1?",
     "proofStrategy": "The formalization axiomatises H(n;p,q) with monotonicity and boundary values, then defines c(p,q) with known Ramsey bounds and the EFRS bound. The strict monotonicity conjecture is the main statement.",
     "keyInsights": [
       "H(n;p,q) generalises Ramsey numbers by requiring q edges per p-set",
       "c(p,1) corresponds to classical Ramsey: 1/(p-1) ≤ c ≤ 2/(p+1)",
       "c(p, C(p-1,2)+1) = 1 trivially (every graph is complete)",
-      "EFRS proved c(p, ⌊(p-1)/2⌋) ≤ 1/2"
+      "EFRS proved c(p, ⌊(p-1)/2⌋) ≤ 1/2",
+      "For p=3, the conjecture reduces to c(3,1) < c(3,2)=1, which is fully proved"
     ]
   },
   "sections": [
@@ -60,6 +61,13 @@
       "startLine": 74,
       "endLine": 82,
       "summary": "c(p,q) is strictly increasing in q."
+    },
+    {
+      "id": "small-cases",
+      "title": "Small Cases and Evidence",
+      "startLine": 84,
+      "endLine": 115,
+      "summary": "p=3 fully resolved; p=4 proved at top step via EFRS; intermediate q values remain open."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment: Erdős Problem #667 (Clique Density Exponent c(p,q))

**Quality gaps addressed (93 → 100):**
- historicalContext: 309 → 667 chars — EFRS context, classical Ramsey bounds (+3pts)
- keyInsights: 4 → 5 — added p=3 resolved case (+2pts)
- sections: 4 → 5 — added small-cases section (+2pts)
- Fixed significance: 'essential' → 'key' (6 annotations)

**Expected quality: 93 → 100**

🤖 Enricher-1 automated enrichment