### PR TITLE
research: prove long-time vanishing of enstrophy for 2D Navier-Stokes

### DIFF
--- a/proofs/Proofs/NavierStokes.lean
+++ b/proofs/Proofs/NavierStokes.lean
@@ -2350,6 +2350,70 @@ theorem enstrophy_exponential_decay_exact (sol : GlobalNSSolution2DPoincare)
           congr 1; simp only [hc_eq]; ring
 
 
+/-- **PROVED: Long-time Vanishing of Enstrophy (2D with Poincaré)**
+    For any ε > 0, enstrophy eventually drops below ε:
+    ∀ ε > 0, ∃ T > 0, ∀ t > T, E(t) < ε.
+
+    This is the precise statement that enstrophy decays to zero as t → ∞,
+    a consequence of the exponential decay bound E(t) ≤ E(0)·exp(-2νμ₁t).
+
+    The proof chooses T = max(log(E₀p/ε)/c, 1) where E₀p = E(0) + 1 and c = 2νμ₁.
+    For t > T ≥ log(E₀p/ε)/c, we have exp(-ct) < ε/E₀p, giving E₀p·exp(-ct) < ε. -/
+theorem enstrophy_eventually_small (sol : GlobalNSSolution2DPoincare) :
+    ∀ ε > 0, ∃ T > 0, ∀ t > T, sol.E t < ε := by
+  intro ε hε
+  set c := 2 * sol.ν * sol.mu₁ with hc_def
+  have hc : 0 < c := mul_pos (mul_pos (by norm_num) sol.ν_pos) sol.mu₁_pos
+  have hE0_nn : 0 ≤ sol.E 0 := sol.E_nonneg 0 le_rfl
+  -- Use E₀p = E(0) + 1 > 0 to avoid E(0) = 0 edge case
+  set E₀p := sol.E 0 + 1 with hE0p_def
+  have hE₀p_pos : 0 < E₀p := by linarith
+  have hE₀pε_pos : 0 < E₀p / ε := div_pos hE₀p_pos hε
+  -- Choose T = max(log(E₀p/ε)/c, 1) > 0 always
+  set T := max (Real.log (E₀p / ε) / c) 1 with hT_def
+  have hT_pos : 0 < T := lt_of_lt_of_le one_pos (le_max_right _ _)
+  -- T ≥ log(E₀p/ε)/c by construction
+  have hT_ge_log : Real.log (E₀p / ε) / c ≤ T := le_max_left _ _
+  refine ⟨T, hT_pos, fun t ht => ?_⟩
+  have ht_pos : 0 < t := lt_trans hT_pos ht
+  -- t > T ≥ log(E₀p/ε)/c, so c*t > log(E₀p/ε)
+  have ht_gt_log : Real.log (E₀p / ε) / c < t :=
+    lt_of_le_of_lt hT_ge_log ht
+  have hct_gt : Real.log (E₀p / ε) < c * t := by
+    rwa [div_lt_iff hc, mul_comm] at ht_gt_log
+  -- Step 1: E(t) ≤ E₀p * exp(-c*t)
+  have hE_bound : sol.E t ≤ E₀p * Real.exp (-c * t) := by
+    have hstep := enstrophy_exponential_decay_exact sol t ht_pos
+    -- hstep : E(t) ≤ E(0) * exp(-2*ν*μ₁*t) = E(0) * exp(-c*t)
+    have hexp_eq : -2 * sol.ν * sol.mu₁ * t = -c * t := by rw [hc_def]; ring
+    calc sol.E t
+        ≤ sol.E 0 * Real.exp (-2 * sol.ν * sol.mu₁ * t) := hstep
+      _ = sol.E 0 * Real.exp (-c * t) := by rw [hexp_eq]
+      _ ≤ E₀p * Real.exp (-c * t) :=
+            mul_le_mul_of_nonneg_right (by linarith) (Real.exp_nonneg _)
+  -- Step 2: exp(-c*t) < ε/E₀p
+  -- Since -c*t < log(ε/E₀p) = -log(E₀p/ε)
+  have hexp_bound : Real.exp (-c * t) < ε / E₀p := by
+    -- log(ε/E₀p) = -log(E₀p/ε) via log(a*b) = log a + log b
+    have hlogeq : Real.log (ε / E₀p) = -Real.log (E₀p / ε) := by
+      have hmul : (ε / E₀p) * (E₀p / ε) = 1 := by field_simp
+      have hlog_mul := Real.log_mul (ne_of_gt (div_pos hε hE₀p_pos))
+                                    (ne_of_gt hE₀pε_pos)
+      rw [hmul, Real.log_one] at hlog_mul
+      linarith
+    -- exp(-c*t) < exp(log(ε/E₀p)) = ε/E₀p
+    rw [← Real.exp_log (div_pos hε hE₀p_pos)]
+    apply Real.exp_lt_exp.mpr
+    rw [hlogeq]
+    linarith
+  -- Step 3: Combine
+  calc sol.E t
+      ≤ E₀p * Real.exp (-c * t) := hE_bound
+    _ < E₀p * (ε / E₀p) := by
+          apply mul_lt_mul_of_pos_left hexp_bound hE₀p_pos
+    _ = ε := by field_simp
+
+
 /-- **PROVED: Enstrophy Dissipation Identity**
     The total enstrophy dissipated up to time t equals the enstrophy lost:
     E(0) - E(t) ≥ 0 (enstrophy can only decrease in 2D).

--- a/src/data/research/problems/2d-navier-stokes.json
+++ b/src/data/research/problems/2d-navier-stokes.json
@@ -18,8 +18,9 @@
     "proven": [
       "Conditional enstrophy bound: E(t) ≤ E(0) for all t > 0 (via GlobalNSSolution2D structure)",
       "Exponential enstrophy decay: E(t) ≤ E(0)·exp(-2νμ₁t) under Poincaré inequality",
+      "Long-time vanishing: ∀ ε > 0, ∃ T > 0, ∀ t > T, E(t) < ε (NEW, 2026-02-22)",
       "Enstrophy dissipation is nonneg: E(0) - E(t) ≥ 0",
-      "Long-time vanishing: enstrophy decays to 0 exponentially"
+      "Enstrophy antitone on [0,∞): global monotone decrease"
     ],
     "open": [
       "Actual existence of solutions (construction from initial data requires Sobolev infrastructure)",
@@ -30,34 +31,37 @@
   "currentState": {
     "phase": "PROGRESS",
     "since": "2026-02-22T00:00:00.000Z",
-    "iteration": 2,
-    "focus": "Proved exact exponential enstrophy decay via integrating factor trick",
+    "iteration": 3,
+    "focus": "Proved enstrophy_eventually_small: long-time vanishing of enstrophy",
     "blockers": [
       "Full existence proof requires Sobolev space H^1 theory",
       "Galerkin approximation scheme not in Mathlib",
       "Compact embeddings H^1 ↪ L^2 on bounded domains needed"
     ],
-    "nextAction": "Check Mathlib Sobolev space status; explore if existence can be approached via abstract fixed-point methods",
+    "nextAction": "The conditional dynamical theory is now essentially complete. Consider Filter.Tendsto version of long-time vanishing, or start formalizing Stokes equations (linear, simpler PDE infrastructure).",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 1,
+      "total": 3,
+      "currentApproach": 2,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added enstrophy_exponential_decay_exact theorem to NavierStokes.lean proving E(t) ≤ E(0)·exp(-2νμ₁t) via integrating factor technique. This closes the gap between the differential inequality E' ≤ -2νμ₁E (already proven) and the actual exponential bound. Full existence still blocked on PDE infrastructure.",
+    "progressSummary": "PROGRESS: Session 3 proved enstrophy_eventually_small: for any ε > 0, ∃ T > 0, ∀ t > T, E(t) < ε. This formalizes the complete dynamical picture: enstrophy not only decays exponentially but eventually drops below any threshold. Proof uses squeeze between 0 and E₀p·exp(-ct) with explicit T = max(log(E₀p/ε)/c, 1). Key Mathlib lemmas: Real.exp_lt_exp, Real.exp_log, Real.log_mul. Conditional theory is now essentially complete (existence/uniqueness still blocked on PDE infrastructure).",
     "builtItems": [
+      "enstrophy_eventually_small in proofs/Proofs/NavierStokes.lean:TwoDimensionalGlobal - Long-time vanishing: ∀ ε > 0, ∃ T > 0, ∀ t > T, E(t) < ε",
       "enstrophy_exponential_decay_exact in proofs/Proofs/NavierStokes.lean:TwoDimensionalGlobal - Exact exponential decay E(t) ≤ E(0)·exp(-2νμ₁t) via integrating factor g(s)=E(s)·exp(cs)",
       "Fixed deprecation: differentiableAt_id' → differentiableAt_fun_id in NavierStokes.lean"
     ],
     "insights": [
+      "Long-time vanishing proof: choose T = max(log(E₀p/ε)/c, 1) where E₀p = E(0)+1 to avoid E(0)=0 corner case",
+      "Key log identity: log(ε/E₀p) = -log(E₀p/ε) proved via log(a·b) = log(a) + log(b) (Real.log_mul)",
       "The integrating factor trick g(s) = E(s)·exp(2νμ₁s) converts the differential inequality into a monotonicity argument, avoiding Gronwall directly",
       "antitoneOn_of_deriv_nonpos is the key Mathlib lemma for both enstrophy bound and exponential decay",
       "The HasDerivAt product rule (HasDerivAt.mul) + chain rule (HasDerivAt.exp) are sufficient for computing g'",
       "HasDerivAt.const_smul (with 𝕜 = ℝ) gives HasDerivAt for linear functions; simp [smul_eq_mul] cleans up",
-      "set c := ... with hc_eq introduces definitional equality; ring may not unfold it - use simp only [hc_eq] first",
       "GlobalNSSolution2D structure models but does not construct solutions - the conditional proofs are mathematically sound but existence requires PDE infrastructure",
-      "2D NS existence needs: Sobolev H^1(ℝ²), Galerkin approximations, compact embeddings, Gronwall ODE comparison"
+      "2D NS existence needs: Sobolev H^1(ℝ²), Galerkin approximations, compact embeddings, Gronwall ODE comparison",
+      "div_lt_iff and mul_lt_iff_lt_one_left are useful for translating t > log/c into c*t > log"
     ],
     "mathlibGaps": [
       "Sobolev spaces H^s on domains (limited in Mathlib 4.26.0)",
@@ -67,12 +71,12 @@
       "Div-free constraint (divergence-free vector fields)"
     ],
     "nextSteps": [
-      "Check Mathlib.Analysis.SobolevSpace status in v4.26.0",
-      "Consider formalization of Stokes equations (linear, simpler)",
+      "Prove Filter.Tendsto version: Tendsto sol.E atTop (nhds 0) using squeeze theorem",
+      "Consider formalization of Stokes equations (linear, simpler PDE)",
       "Add OQ annotation to NS gallery about existence inhabitation",
       "Long-term: Galerkin approximation for 2D NS existence"
     ],
-    "markdown": "# Knowledge Base: 2D Navier-Stokes Regularity\n\n## Current Status\n\n**Phase**: PROGRESS\n\nThe gallery already has NavierStokes.lean with conditional 2D NS results. Key achievements:\n- `GlobalNSSolution2D` structure models global solutions (Part X-B)\n- `enstrophy_exponential_decay_exact` (NEW, 2026-02-22): E(t) ≤ E(0)·exp(-2νμ₁t)\n- `navier_stokes_2d_solved`: ∀ sol, ∀ t > 0, ∃ bound, E(t) ≤ bound\n\n## What Was Proved (Session 2026-02-22)\n\n### Exact Exponential Enstrophy Decay\n\nThe previous `enstrophy_deriv_bound` proved the differential inequality:\n```\nderiv E t ≤ -2νμ₁ · E t\n```\n\nThis session proved the exact exponential bound:\n```lean\ntheorem enstrophy_exponential_decay_exact\n    (sol : GlobalNSSolution2DPoincare) (t : ℝ) (ht : t > 0) :\n    sol.E t ≤ sol.E 0 * Real.exp (-2 * sol.ν * sol.mu₁ * t)\n```\n\n**Proof technique**: Integrating factor g(s) = E(s)·exp(2νμ₁s).\n- g'(s) = (-2νP + 2νμ₁E)·exp(cs) ≤ 0 (by Poincaré: P ≥ μ₁E)\n- g antitone → g(t) ≤ g(0) = E(0)\n- E(t) = g(t)·exp(-ct) ≤ E(0)·exp(-ct)\n\n## What's Still Missing\n\n### Existence (Blocked)\n\nThe `GlobalNSSolution2D` structure is inhabited IF you provide a solution.\nActually constructing solutions from initial data requires:\n1. Sobolev H^1 theory on ℝ² or a torus\n2. Energy estimates for Galerkin approximations\n3. Compactness via Aubin-Lions lemma\n4. Passage to limits\n\nThis is ~3000-5000 lines of work.\n\n### Uniqueness (Blocked)\n\nLions-Prodi uniqueness requires:\n- Working in W^{1,∞} × L^2 function spaces\n- Gronwall inequality in integral form\n- Full Sobolev embedding in 2D\n\n## Mathlib Infrastructure Status (v4.26.0)\n\n| Component | Status |\n|-----------|--------|\n| ContinuousOn | ✅ Full |\n| HasDerivAt, HaDerivAtFilter | ✅ Full |\n| antitoneOn_of_deriv_nonpos | ✅ Available |\n| Real.hasDerivAt_exp | ✅ Available |\n| HasDerivAt.mul (product rule) | ✅ Available |\n| HasDerivAt.exp (chain rule) | ✅ Available |\n| Sobolev spaces H^s | ⚠️ Limited |\n| Galerkin approximations | ❌ Not available |\n| Compact Sobolev embeddings | ❌ Not available |\n| Navier-Stokes weak solutions | ❌ Not available |\n"
+    "markdown": "# Knowledge Base: 2D Navier-Stokes Regularity\n\n## Current Status\n\n**Phase**: PROGRESS (Iteration 3)\n\nThe gallery has NavierStokes.lean with complete conditional 2D NS results:\n- `GlobalNSSolution2D` structure models global solutions (Part X-B)\n- `enstrophy_exponential_decay_exact` (2026-02-22): E(t) ≤ E(0)·exp(-2νμ₁t)\n- `enstrophy_eventually_small` (NEW, 2026-02-22): ∀ ε > 0, ∃ T > 0, ∀ t > T, E(t) < ε\n- `navier_stokes_2d_solved`: ∀ sol, ∀ t > 0, ∃ bound, E(t) ≤ bound\n\n## What Was Proved (Session 3, 2026-02-22)\n\n### Long-time Vanishing of Enstrophy\n\n```lean\ntheorem enstrophy_eventually_small (sol : GlobalNSSolution2DPoincare) :\n    ∀ ε > 0, ∃ T > 0, ∀ t > T, sol.E t < ε\n```\n\n**Proof strategy**:\n1. Set c = 2νμ₁ > 0, E₀p = E(0)+1 > 0\n2. Choose T = max(log(E₀p/ε)/c, 1) > 0 always\n3. For t > T: E(t) ≤ E₀p·exp(-ct) < E₀p·(ε/E₀p) = ε\n\n**Key steps**:\n- `div_lt_iff hc` converts t > log(E₀p/ε)/c into c·t > log(E₀p/ε)\n- `Real.log_mul` proves log(ε/E₀p) = -log(E₀p/ε)\n- `Real.exp_log` evaluates exp(log(ε/E₀p)) = ε/E₀p\n- `mul_lt_mul_of_pos_left` combines exp bound with E₀p positivity\n\n## What's Still Missing\n\n### Existence (Blocked)\n\nActually constructing solutions from initial data requires:\n1. Sobolev H^1 theory on ℝ² or a torus\n2. Energy estimates for Galerkin approximations  \n3. Compactness via Aubin-Lions lemma\n4. Passage to limits\nEstimate: ~3000-5000 lines of work\n\n### Uniqueness (Blocked)\n\nLions-Prodi requires: W^{1,∞} × L^2 function spaces, integral Gronwall, Sobolev embedding in 2D.\n\n## Mathlib Infrastructure Status (v4.26.0)\n\n| Component | Status |\n|-----------|--------|\n| ContinuousOn | ✅ Full |\n| HasDerivAt, HasDerivAtFilter | ✅ Full |\n| antitoneOn_of_deriv_nonpos | ✅ Available |\n| Real.hasDerivAt_exp | ✅ Available |\n| HasDerivAt.mul (product rule) | ✅ Available |\n| HasDerivAt.exp (chain rule) | ✅ Available |\n| Real.log_mul, Real.exp_log | ✅ Available |\n| div_lt_iff, mul_lt_mul_of_pos_left | ✅ Available |\n| Sobolev spaces H^s | ⚠️ Limited |\n| Galerkin approximations | ❌ Not available |\n| Compact Sobolev embeddings | ❌ Not available |\n| Navier-Stokes weak solutions | ❌ Not available |\n"
   },
   "approaches": [
     {
@@ -94,7 +98,8 @@
     "formalization",
     "navier-stokes",
     "enstrophy",
-    "exponential-decay"
+    "exponential-decay",
+    "long-time-behavior"
   ],
   "relatedProofs": [
     "navier-stokes-regularity"
@@ -107,7 +112,8 @@
     "urls": [],
     "mathlib": [
       "Mathlib.Analysis.Calculus.Monotone (antitoneOn_of_deriv_nonpos)",
-      "Mathlib.Analysis.SpecialFunctions.ExpDeriv (HasDerivAt.exp)"
+      "Mathlib.Analysis.SpecialFunctions.ExpDeriv (HasDerivAt.exp)",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic (Real.log_mul, Real.exp_log)"
     ]
   },
   "started": "2026-02-22T19:00:00.000Z"


### PR DESCRIPTION
## Summary

Research session for 2d-navier-stokes (iteration 3). Proves long-time vanishing of enstrophy: for any ε > 0, enstrophy eventually drops below ε.

## Progress

- **New theorem**: `enstrophy_eventually_small` in `proofs/Proofs/NavierStokes.lean` (TwoDimensionalGlobal namespace)
- **Updated**: `src/data/research/problems/2d-navier-stokes.json` with session 3 knowledge

## The New Theorem

```lean
theorem enstrophy_eventually_small (sol : GlobalNSSolution2DPoincare) :
    ∀ ε > 0, ∃ T > 0, ∀ t > T, sol.E t < ε
```

This formalizes that 2D Navier-Stokes enstrophy decays to zero as t → ∞ (precise quantitative statement). Combined with the previous session's `enstrophy_exponential_decay_exact`, this completes the conditional dynamical theory.

## Proof Strategy

1. Set c = 2νμ₁ > 0, E₀p = E(0)+1 (avoids E(0)=0 corner case)
2. Choose T = max(log(E₀p/ε)/c, 1) > 0 always
3. For t > T: E(t) ≤ E₀p·exp(-ct) < E₀p·(ε/E₀p) = ε
4. Key identity: log(ε/E₀p) = -log(E₀p/ε) via Real.log_mul
5. Key evaluation: exp(log(ε/E₀p)) = ε/E₀p via Real.exp_log

## Findings

- Real.log_mul, Real.exp_log, div_lt_iff, mul_lt_mul_of_pos_left all available in Mathlib v4.26.0
- Docker build: 3085 jobs, 0 sorries, 0 axioms
- Conditional dynamical theory now complete: existence/uniqueness still blocked on PDE infrastructure (Sobolev spaces, Galerkin)

## Status

**Outcome**: progress
**Next Steps**: Filter.Tendsto version of long-time vanishing; OR start formalizing linear Stokes equations as simpler PDE infrastructure

Generated by researcher-1