### PR TITLE
research: prove prime gaps are unbounded via factorial construction

### DIFF
--- a/proofs/Proofs/BoundedPrimeGaps.lean
+++ b/proofs/Proofs/BoundedPrimeGaps.lean
@@ -1290,6 +1290,112 @@ theorem nthPrime_le_of_gaps_bounded (H : ℕ)
       _ = 2 + (k + 1) * H := by ring
 
 /-
+## Part XXI: Large Prime Gaps (Factorial Construction)
+
+The complementary result to bounded prime gaps: prime gaps are UNBOUNDED.
+While Zhang/Polymath proved liminf(primeGap) ≤ 246, the factorial construction
+shows limsup(primeGap) = ∞.
+
+**Key idea**: N! + k is composite for each 2 ≤ k ≤ N, because k ∣ N! (as k ≤ N)
+and thus k ∣ N! + k. Since k ≥ 2 and N! > 0, the number N! + k is composite.
+This gives N - 1 consecutive composite numbers starting at N! + 2, forcing
+some prime gap ≥ N - 1 to exist.
+-/
+
+/-- The key lemma: N! + k is composite for 2 ≤ k ≤ N.
+    Since k ≤ N, we have k ∣ N!, so k ∣ N! + k. But k ≥ 2 and N! > 0 ensure
+    that k is neither 1 nor N! + k, contradicting primality. -/
+lemma factorial_add_composite (N k : ℕ) (hk2 : 2 ≤ k) (hkN : k ≤ N) :
+    ¬ Nat.Prime (N.factorial + k) := by
+  intro h
+  have hk_pos : 0 < k := by omega
+  -- k divides N! (since 0 < k ≤ N)
+  have hk_dvd_fac : k ∣ N.factorial := Nat.dvd_factorial hk_pos hkN
+  -- k divides N! + k
+  have hk_dvd_sum : k ∣ N.factorial + k := dvd_add hk_dvd_fac (dvd_refl k)
+  -- N! > 0, so 1 < k < N! + k
+  have hfac_pos : 0 < N.factorial := Nat.factorial_pos N
+  -- If N! + k is prime, its only divisors are 1 and itself
+  rcases h.eq_one_or_self_of_dvd k hk_dvd_sum with h1 | h2
+  · omega  -- k = 1 contradicts hk2 : 2 ≤ k
+  · omega  -- k = N! + k contradicts hfac_pos : 0 < N!
+
+/-- For any N, the numbers N! + 2, N! + 3, ..., N! + N are all composite.
+    (For N ≥ 2, this gives N - 1 consecutive composite numbers.) -/
+lemma consecutive_composites (N : ℕ) :
+    ∀ k : ℕ, 2 ≤ k → k ≤ N → ¬ Nat.Prime (N.factorial + k) :=
+  fun k hk2 hkN => factorial_add_composite N k hk2 hkN
+
+/-- Prime gaps are unbounded: for any N, some prime gap is at least N.
+
+    **Proof**: By contradiction. If all prime gaps were < N, then by induction,
+    nthPrime k ≤ N! + 1 for all k. The induction works because:
+    - Base: nthPrime 0 = 2 ≤ N! + 1 ✓
+    - Step: if nthPrime k ≤ N! + 1 and primeGap k < N, then
+      nthPrime (k+1) = nthPrime k + primeGap k ≤ N! + N.
+      If this equals N! + j for some 2 ≤ j ≤ N, it would be composite
+      (by factorial_add_composite), contradicting that nthPrime (k+1) is prime.
+      So nthPrime (k+1) ≤ N! + 1.
+    But nthPrime k ≥ k + 2 (by nthPrime_ge_add_two), so nthPrime (N! + 1) ≥ N! + 3,
+    contradicting nthPrime (N! + 1) ≤ N! + 1. -/
+theorem prime_gaps_unbounded (N : ℕ) : ∃ n : ℕ, N ≤ primeGap n := by
+  -- Handle N ≤ 1 directly: any positive gap suffices
+  by_cases hN : N ≤ 1
+  · exact ⟨0, by have := primeGap_pos 0; omega⟩
+  -- For N ≥ 2, argue by contradiction
+  push_neg at hN
+  -- hN : 2 ≤ N
+  by_contra habs
+  push_neg at habs
+  -- habs : ∀ n, primeGap n < N
+  -- Key claim: nthPrime k ≤ N! + 1 for all k (induction using composite barrier)
+  have hbound : ∀ k, nthPrime k ≤ N.factorial + 1 := by
+    intro k
+    induction k with
+    | zero =>
+      rw [nthPrime_zero]  -- nthPrime 0 = 2
+      have := Nat.factorial_pos N
+      omega  -- 2 ≤ N! + 1 since N! ≥ 1
+    | succ k ih =>
+      have hgap := habs k
+      -- nthPrime (k + 1) = nthPrime k + primeGap k
+      have hprime : Nat.Prime (nthPrime k + primeGap k) := by
+        rw [← nthPrime_succ_eq]; exact nthPrime_prime (k + 1)
+      rw [nthPrime_succ_eq]
+      -- Goal: nthPrime k + primeGap k ≤ N! + 1
+      -- Case 1: already ≤ N! + 1
+      by_cases hle : nthPrime k + primeGap k ≤ N.factorial + 1
+      · exact hle
+      -- Case 2: > N! + 1, so falls in the composite range {N!+2, ..., N!+N}
+      · push_neg at hle
+        -- N! + 2 ≤ nthPrime k + primeGap k ≤ N! + N (from ih + gap bound)
+        have hub : nthPrime k + primeGap k ≤ N.factorial + N := by omega
+        -- The offset j = (nthPrime k + primeGap k) - N! satisfies 2 ≤ j ≤ N
+        have hj_lb : 2 ≤ nthPrime k + primeGap k - N.factorial := by omega
+        have hj_ub : nthPrime k + primeGap k - N.factorial ≤ N := by omega
+        have heq : N.factorial + (nthPrime k + primeGap k - N.factorial) =
+                   nthPrime k + primeGap k := by omega
+        -- But N! + j is composite by factorial_add_composite
+        have hcomp := factorial_add_composite N (nthPrime k + primeGap k - N.factorial)
+          hj_lb hj_ub
+        rw [heq] at hcomp
+        -- hprime says nthPrime (k+1) = N! + j is prime: contradiction
+        exact absurd hprime hcomp
+  -- But nthPrime grows: nthPrime (N! + 1) ≥ (N! + 1) + 2 = N! + 3 > N! + 1
+  have hge := nthPrime_ge_add_two (N.factorial + 1)
+  have hle := hbound (N.factorial + 1)
+  omega  -- N! + 3 ≤ nthPrime (N! + 1) ≤ N! + 1: contradiction
+
+/-- The oscillatory nature of prime gaps:
+    - (Zhang/Polymath axiom): liminf(primeGap) ≤ 246 — small gaps occur infinitely often
+    - (Factorial construction): limsup(primeGap) = ∞ — large gaps also occur infinitely often
+    Together these show prime gaps oscillate between arbitrarily small and large values. -/
+theorem prime_gaps_oscillate :
+    (∀ N : ℕ, ∃ n : ℕ, n ≥ N ∧ primeGap n ≤ 246) ∧
+    (∀ N : ℕ, ∃ n : ℕ, N ≤ primeGap n) :=
+  ⟨infinitely_many_small_gaps, prime_gaps_unbounded⟩
+
+/-
 ## Summary
 
 This file establishes:
@@ -1323,8 +1429,11 @@ This file establishes:
 27. **Maynard-Tao monotonicity**: Result for m implies result for all m' ≤ m
 28. **Bounded gaps min**: Intersection of two bounded gap results
 29. **Conditional linear bound**: nthPrime ≤ 2 + n·H if all gaps ≤ H
+30. **Large prime gaps**: N! + k is composite for 2 ≤ k ≤ N (factorial construction)
+31. **Gaps unbounded**: ∀ N, ∃ n, primeGap n ≥ N (contrasts with Zhang/Polymath)
+32. **Oscillation**: prime gaps have liminf ≤ 246 AND limsup = ∞
 
-### Proved Theorems (90+ total, 0 sorries)
+### Proved Theorems (94+ total, 0 sorries)
 Key new theorems:
 - `exists_admissible_50_tuple_246` (formerly axiom, now proved via Engelsma/Polymath tuple)
 - `CramerConjecture`, `GranvilleConjecture`, `TwinPrimeConjecture` (formal conjectures)
@@ -1332,6 +1441,9 @@ Key new theorems:
 - `maynard_tao_monotone` (m-tuple result monotone in m)
 - `bounded_gaps_min` (intersection of gap bounds)
 - `nthPrime_le_of_gaps_bounded` (conditional linear bound)
+- `factorial_add_composite` (N! + k composite for 2 ≤ k ≤ N)
+- `prime_gaps_unbounded` (∀ N, ∃ n, N ≤ primeGap n, proved from factorial construction)
+- `prime_gaps_oscillate` (combines Zhang/Polymath with factorial construction)
 
 ### Axioms Used (3)
 - `polymath_bounded_gaps_246`: Polymath 8b optimization (2014)

--- a/research/problems/bounded-prime-gaps/knowledge.md
+++ b/research/problems/bounded-prime-gaps/knowledge.md
@@ -114,3 +114,15 @@ Note: `zhang_bounded_gaps_70M` was converted from axiom to theorem (derived from
 16. **`dickson_triple_implies_prime_triples`**: Dickson for {0,2,6} → prime triples infinitely often
 17. **`admissible_card_lt_of_prime`**: Rephrased admissibility condition
 **Outcome**: 40 proved theorems, 4 axioms, 0 sorries. Build verified via Docker.
+
+### Research Session (2026-02-23)
+**Mode**: BUILD (researcher-1)
+**Decision**: BUILD - Add complementary large prime gap construction
+**Changes** (4 new theorems via factorial construction):
+1. **`factorial_add_composite`**: N! + k is composite for 2 ≤ k ≤ N. Proof: k | N! (since k ≤ N) and k | k, so k | N!+k. Since N!+k is prime and k ∣ N!+k, we'd need k=1 or k=N!+k, both impossible.
+2. **`consecutive_composites`**: ∀ k, 2 ≤ k → k ≤ N → ¬ Nat.Prime (N! + k). Direct corollary of factorial_add_composite.
+3. **`prime_gaps_unbounded`**: ∀ N, ∃ n, primeGap n ≥ N. By contradiction: if all gaps < N, by induction nthPrime k ≤ N!+1 for all k (since N!+2,...,N!+N are composite). But nthPrime grows as k+2, so nthPrime(N!+1) ≥ N!+3 > N!+1. Contradiction.
+4. **`prime_gaps_oscillate`**: Combines Polymath axiom (liminf ≤ 246) with factorial result (limsup = ∞).
+
+**Mathematical insight**: The bounded gaps theorem (Zhang/Polymath) and the factorial construction are complementary: prime gaps oscillate between bounded small values and arbitrarily large values. The liminf ≤ 246 and limsup = ∞ together characterize prime gap behavior.
+**Outcome**: 94+ proved theorems, 3 axioms, 0 sorries. Build verified via Docker (no warnings).

--- a/src/data/research/problems/bounded-prime-gaps.json
+++ b/src/data/research/problems/bounded-prime-gaps.json
@@ -6,7 +6,7 @@
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "∃ C : ℕ, ∀ᶠ n in atTop, nthPrime (n+1) - nthPrime n ≤ C. Specifically C = 246 (Polymath 8b) and conditionally C = 12 (under Elliott-Halberstam).",
+    "formal": "\u2203 C : \u2115, \u2200\u1da0 n in atTop, nthPrime (n+1) - nthPrime n \u2264 C. Specifically C = 246 (Polymath 8b) and conditionally C = 12 (under Elliott-Halberstam).",
     "plain": "There are infinitely many pairs of primes that differ by at most 246. This was proved by Zhang (2013, with bound 70,000,000) and optimized by Polymath 8b (2014, bound 246). Maynard-Tao (2015) generalized to m-tuples.",
     "whyMatters": [
       "Landmark result in analytic number theory (Zhang 2013)",
@@ -21,13 +21,16 @@
       "Admissible tuple framework: empty, singleton, subset, card < 2 cases",
       "Specific admissible tuples: {0,2}, {0,2,6}, {0,4,6}, {0,2,6,8}, {0,2,6,8,12}, {0,4,6,10,12}",
       "Non-admissibility: {0,1}, {0,1,2}, {0,1,2,3,4}, general range criterion",
-      "Polymath 50-tuple constructive existence (50 elements, diameter ≤ 246)",
+      "Polymath 50-tuple constructive existence (50 elements, diameter \u2264 246)",
       "Zhang bound 70M follows from Polymath bound 246",
-      "nthPrime properties: primality, strict monotonicity, positivity, p₀=2, p₁=3",
-      "Prime gap properties: positivity, evenness for n≥1, gap ≥ 2 for n≥1",
-      "Consequences: liminf ≤ 246, bounded consecutive gaps from m-tuples",
+      "nthPrime properties: primality, strict monotonicity, positivity, p\u2080=2, p\u2081=3",
+      "Prime gap properties: positivity, evenness for n\u22651, gap \u2265 2 for n\u22651",
+      "Consequences: liminf \u2264 246, bounded consecutive gaps from m-tuples",
       "Dickson connections: twin primes from {0,2}, prime triples from {0,2,6}",
-      "Elliott-Halberstam conditional bound (12) implies Polymath bound (246)"
+      "Elliott-Halberstam conditional bound (12) implies Polymath bound (246)",
+      "Factorial construction: N_fac+k is composite for 2 <= k <= N (elementary, no sieve theory)",
+      "Prime gaps unbounded: forall N, exists n, primeGap n >= N (proved via factorial construction)",
+      "Oscillatory behavior: prime_gaps_oscillate combining Polymath + factorial results"
     ],
     "axiomatized": [
       "polymath_bounded_gaps_246: Polymath 8b main result (sieve theory)",
@@ -38,12 +41,14 @@
   "knowledge": {
     "insights": [
       "Admissible tuples are the right abstraction - their formal definition (for all p, |image mod p| < p) is clean and computable",
-      "The Polymath 50-tuple can be verified constructively via native_decide for each prime ≤ 47, then interval_cases + decide for composites 48-52",
+      "The Polymath 50-tuple can be verified constructively via native_decide for each prime \u2264 47, then interval_cases + decide for composites 48-52",
       "Zhang's original 70M bound follows trivially from Polymath's 246 (converted axiom to theorem)",
       "Dickson conjecture for specific tuples implies specific prime pattern conjectures (twin primes, triples)",
-      "Even prime gaps for n ≥ 1 follows from both p_n, p_{n+1} being odd primes (≥ 3)",
+      "Even prime gaps for n \u2265 1 follows from both p_n, p_{n+1} being odd primes (\u2265 3)",
       "The 3 remaining axioms are deep sieve theory (Selberg sieve, Bombieri-Vinogradov, GPY) - not in Mathlib",
-      "Fixed build issue: omega can't handle prime enumeration in range; use interval_cases + decide instead"
+      "Fixed build issue: omega can't handle prime enumeration in range; use interval_cases + decide instead",
+      "Factorial construction: N_fac+k is composite for 2 <= k <= N, giving arbitrarily large prime gap runs. Elementary - no sieve theory needed.",
+      "Prime gaps oscillate: liminf <= 246 (Zhang/Polymath) AND limsup = inf (factorial). Together they characterize the oscillatory nature of prime gaps."
     ],
     "builtItems": [
       "BoundedPrimeGaps.lean: 1350 lines, 90 proved theorems, 3 axioms, 0 sorries",
@@ -51,9 +56,12 @@
       "Polymath 50-tuple constructive proof of exists_admissible_50_tuple_246",
       "nthPrime and primeGap definitions with structural properties",
       "Connections to twin prime conjecture and Dickson conjecture",
-      "Fixed omega build error at line 349 using interval_cases"
+      "Fixed omega build error at line 349 using interval_cases",
+      "factorial_add_composite: N_fac+k composite for 2 <= k <= N (BoundedPrimeGaps.lean)",
+      "prime_gaps_unbounded: forall N, exists n, N <= primeGap n - proved by contradiction using factorial composites",
+      "prime_gaps_oscillate: combines Polymath (liminf <= 246) with factorial (limsup = inf)"
     ],
     "nextSteps": [],
-    "progressSummary": "COMPLETE: Comprehensive formalization of bounded prime gaps. 90 proved theorems, 3 axioms (deep sieve theory), 0 sorries. Fixed build error. Axioms are fundamental results requiring Selberg sieve infrastructure not available in Mathlib."
+    "progressSummary": "COMPLETE: Comprehensive formalization of bounded prime gaps. 94+ proved theorems, 3 axioms (deep sieve theory), 0 sorries. Includes complementary large prime gap construction via factorials."
   }
 }


### PR DESCRIPTION
## Summary

Adds complementary large prime gap theorems to `BoundedPrimeGaps.lean`, completing the two-sided characterization of prime gap distribution.

The existing file already proves the **small gap** side: Zhang/Polymath (liminf ≤ 246). This PR adds the **large gap** side via an elementary factorial construction.

### New Theorems (4)

**`factorial_add_composite`** (key lemma): N! + k is composite for 2 ≤ k ≤ N
- Since k ≤ N, we have k ∣ N!, so k ∣ N! + k
- But k ≥ 2 and N! > 0 make k neither 1 nor N! + k — contradicting primality

**`consecutive_composites`**: N! + 2, N! + 3, ..., N! + N are all composite (N-1 consecutive composites)

**`prime_gaps_unbounded`**: ∀ N, ∃ n, N ≤ primeGap n
- By contradiction: assume all gaps < N
- By induction, nthPrime k ≤ N! + 1 for all k (since N!+2,...,N!+N are composite, any nthPrime(k+1) in that range would be composite — contradicting primality)
- But nthPrime k ≥ k + 2 (by `nthPrime_ge_add_two`), so nthPrime(N!+1) ≥ N!+3 > N!+1. Contradiction.

**`prime_gaps_oscillate`**: Combines the two sides:
```
(∀ N, ∃ n ≥ N, primeGap n ≤ 246) ∧  -- Zhang/Polymath
(∀ N, ∃ n, N ≤ primeGap n)           -- factorial construction
```

### Mathematical Significance

The bounded gaps theorem (Zhang 2013, Polymath 2014) proves prime gaps are **infinitely often small** (liminf ≤ 246). The factorial construction — known since Euclid — proves they are **also infinitely often large** (limsup = ∞). Together they show prime gaps **oscillate** between arbitrarily small and large values.

The factorial construction is elementary: it uses only `Nat.dvd_factorial`, `dvd_add`, `Nat.factorial_pos`, and the `eq_one_or_self_of_dvd` criterion for primality.

### Build Status

✅ Docker build: 0 sorries, 0 warnings, 3072 targets compiled

**Total: 94+ proved theorems, 3 axioms (deep sieve theory not in Mathlib)**

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.BoundedPrimeGaps` — succeeds with no warnings
- [x] New theorems have no `sorry` statements
- [x] Proof uses only existing Mathlib APIs (`Nat.dvd_factorial`, `nthPrime_succ_eq`, `nthPrime_ge_add_two`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)