### PR TITLE
fix: ProofConclusion type for continuum-hypothesis-oq-01

### DIFF
--- a/src/data/proofs/continuum-hypothesis-oq-01/index.ts
+++ b/src/data/proofs/continuum-hypothesis-oq-01/index.ts
@@ -4,7 +4,7 @@ import annotationsJson from './annotations.json'
 import tacticStatesJson from './tacticStates.json'
 import sourceRaw from '../../../../proofs/Proofs/ContinuumHypothesisOQ01.lean?raw'
 
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/continuum-hypothesis-oq-01/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-01/meta.json
@@ -127,7 +127,8 @@
     }
   ],
   "conclusion": {
-    "text": "The Lean formalization reveals the core tension in the CH axiom-adoption question: natural axioms exist for both CH and ¬CH, but they differ in their relationship to large cardinal axioms. V=L settles CH positively but excludes measurable cardinals (Scott, 1961). PFA and MM settle CH negatively (¬CH, 2^ℵ₀ = ℵ₂) while remaining consistent with large cardinals. This large-cardinal compatibility asymmetry explains why most contemporary set theorists lean toward the ¬CH side, though Woodin's Ultimate-L program keeps open the possibility of a canonical inner model satisfying GCH while accommodating all large cardinals.",
+    "summary": "The Lean formalization reveals the core tension in the CH axiom-adoption question: natural axioms exist for both CH and ¬CH, but they differ in their relationship to large cardinal axioms. V=L settles CH positively but excludes measurable cardinals (Scott, 1961). PFA and MM settle CH negatively (¬CH, 2^ℵ₀ = ℵ₂) while remaining consistent with large cardinals.",
+    "implications": "This large-cardinal compatibility asymmetry explains why most contemporary set theorists lean toward the ¬CH side, though Woodin's Ultimate-L program keeps open the possibility of a canonical inner model satisfying GCH while accommodating all large cardinals.",
     "openQuestions": [
       "Does Woodin's Ultimate-L program yield a canonical inner model satisfying GCH and all large cardinal axioms?",
       "Is there a mathematically compelling axiom that decides CH and is also large-cardinal compatible?",


### PR DESCRIPTION
## Summary
- Rename `text` → `summary` in conclusion to match `ProofConclusion` type
- Add required `implications` field split from original text
- Use `as unknown as` cast in index.ts to prevent TS2352 error

## Test plan
- [ ] `pnpm build` succeeds without TypeScript errors
- [ ] Gallery page for continuum-hypothesis-oq-01 renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)