### PR TITLE
fix: ProofConclusion type errors in cantor-diagonalization-oq-01 and bertrands-postulate-oq-03

### DIFF
--- a/src/data/proofs/bertrands-postulate-oq-03/index.ts
+++ b/src/data/proofs/bertrands-postulate-oq-03/index.ts
@@ -4,7 +4,7 @@ import annotationsJson from './annotations.json'
 import tacticStatesJson from './tacticStates.json'
 import sourceRaw from '../../../../proofs/Proofs/BertrandsPostulateOQ03.lean?raw'
 
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/bertrands-postulate-oq-03/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03/meta.json
@@ -130,7 +130,8 @@
     }
   ],
   "conclusion": {
-    "text": "Starting from Bertrand's Postulate, we prove π(n) ≥ log₂(n) via iterated doubling — a simple but concrete lower bound. The question of the optimal short-interval exponent θ remains one of the deepest open problems in analytic number theory. Baker-Harman-Pintz (2001) holds the record at θ = 0.525 using sophisticated sieve methods. Cramér's conjecture would push θ to zero with only a (log p)² correction, and Legendre's conjecture asks for primes in every [n², (n+1)²] — both open after more than a century.",
+    "summary": "Starting from Bertrand's Postulate, we prove π(n) ≥ log₂(n) via iterated doubling — a simple but concrete lower bound. The question of the optimal short-interval exponent θ remains one of the deepest open problems in analytic number theory.",
+    "implications": "Baker-Harman-Pintz (2001) holds the record at θ = 0.525 using sophisticated sieve methods. Cramér's conjecture would push θ to zero with only a (log p)² correction, and Legendre's conjecture asks for primes in every [n², (n+1)²] — both open after more than a century.",
     "openQuestions": [
       "What is the smallest θ for which every sufficiently large interval [x, x+x^θ] contains a prime? (BHP gives θ=0.525; is θ<1/2 achievable?)",
       "Does every interval [n², (n+1)²] contain a prime? (Legendre's Conjecture — open since 1845)",

--- a/src/data/proofs/cantor-diagonalization-oq-01/index.ts
+++ b/src/data/proofs/cantor-diagonalization-oq-01/index.ts
@@ -4,7 +4,7 @@ import annotationsJson from './annotations.json'
 import tacticStatesJson from './tacticStates.json'
 import sourceRaw from '../../../../proofs/Proofs/CantorDiagonalizationOQ01.lean?raw'
 
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/cantor-diagonalization-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01/meta.json
@@ -110,7 +110,8 @@
     }
   ],
   "conclusion": {
-    "text": "Cantor's diagonal argument is powerful enough to generate the entire beth number tower ℵ₀ < 2^ℵ₀ < 2^(2^ℵ₀) < ⋯ and to establish the fundamental bounds ℵ₀ < ℵ₁ ≤ 2^ℵ₀. But it reaches its fundamental limit when asked whether any cardinality lies *between* ℵ₀ and 2^ℵ₀. The Continuum Hypothesis — that no such intermediate cardinal exists — is provably independent of ZFC (Gödel-Cohen), meaning the diagonal argument, however iterated, cannot resolve this question.",
+    "summary": "Cantor's diagonal argument is powerful enough to generate the entire beth number tower ℵ₀ < 2^ℵ₀ < 2^(2^ℵ₀) < ⋯ and to establish the fundamental bounds ℵ₀ < ℵ₁ ≤ 2^ℵ₀.",
+    "implications": "But it reaches its fundamental limit when asked whether any cardinality lies *between* ℵ₀ and 2^ℵ₀. The Continuum Hypothesis — that no such intermediate cardinal exists — is provably independent of ZFC (Gödel-Cohen), meaning the diagonal argument, however iterated, cannot resolve this question.",
     "openQuestions": [
       "Does there exist a cardinal κ with ℵ₀ < κ < 2^ℵ₀? (The Continuum Hypothesis — independent of ZFC)",
       "Is the Continuum Hypothesis decided by large cardinal axioms?",


### PR DESCRIPTION
## Summary
- Rename `text` → `summary` in both conclusions to match `ProofConclusion` type
- Add required `implications` field (split from original text)
- Use `as unknown as` cast in index.ts to prevent TS2352

## Test plan
- [ ] `pnpm build` succeeds without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)