### PR TITLE
research: prove A(r) = integral from 0 to r of C(rho) drho via FTC (area-of-circle-oq-01-oq-02)

### DIFF
--- a/proofs/Proofs/AreaFromCircumferenceIntegral.lean
+++ b/proofs/Proofs/AreaFromCircumferenceIntegral.lean
@@ -1,0 +1,146 @@
+import Mathlib.Analysis.Calculus.Deriv.Basic
+import Mathlib.Analysis.Calculus.Deriv.Pow
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import Mathlib.MeasureTheory.Integral.Bochner.FundThmCalculus
+import Mathlib.Tactic
+
+/-
+# Area from Circumference Integration
+
+## What This Proves
+The area of a circle A = πr² can be derived by integrating the circumference
+formula C(ρ) = 2πρ from 0 to r:
+
+  A(r) = ∫₀ʳ C(ρ) dρ = ∫₀ʳ 2πρ dρ = πr²
+
+This formalizes the geometric picture attributed to Archimedes: the disk is
+composed of infinitely many thin concentric rings (annuli). Each ring at
+radius ρ has circumference 2πρ and width dρ, contributing area 2πρ dρ.
+Summing (integrating) from ρ = 0 to ρ = r recovers the full disk area πr².
+
+## Mathematical Statement
+For the area function A(r) = πr² and circumference C(ρ) = 2πρ, we prove:
+
+  ∫ ρ in 0..r, C(ρ) dρ = A(r)   for all r : ℝ
+
+This is the converse direction to the differentiation formula dA/dr = C(r),
+together forming a complete picture of the duality between area and circumference
+via the Fundamental Theorem of Calculus.
+
+## Approach
+- Define circleArea(r) = πr² and circumference(ρ) = 2πρ
+- Show HasDerivAt circleArea (circumference r) r (power rule + constant multiply)
+- Apply FTC Part 2 (integral_eq_sub_of_hasDerivAt):
+    ∫ ρ in 0..r, circumference ρ = circleArea r - circleArea 0 = πr² - 0 = πr²
+- The circumference function is continuous, hence integrable on any interval
+
+## Status
+- [x] Complete proof (no sorries)
+- [x] Uses FTC Part 2 from Mathlib
+- [x] Proves the formula for all r : ℝ (including r < 0 via signed integrals)
+- [x] Corollaries: direct computation verification, annulus formula
+
+## Open Question Origin
+This answers the open question from the Circumference from Area gallery entry:
+"Can the integral direction be formalized: A(r) = ∫₀ʳ C(ρ) dρ?"
+-/
+
+namespace AreaFromCircumferenceIntegral
+
+open Real MeasureTheory intervalIntegral Topology
+
+/-- The area of a circle as a real-valued function of radius. -/
+noncomputable def circleArea (r : ℝ) : ℝ := π * r ^ 2
+
+/-- The circumference of a circle as a function of radius. -/
+noncomputable def circumference (r : ℝ) : ℝ := 2 * π * r
+
+/-- The derivative of the circle area function at radius r equals the circumference 2πr.
+This is the key link: area and circumference are related by differentiation. -/
+theorem hasDerivAt_circleArea (r : ℝ) :
+    HasDerivAt circleArea (circumference r) r := by
+  unfold circleArea circumference
+  have h : HasDerivAt (fun x => π * x ^ 2) (π * (2 * r)) r :=
+    (hasDerivAt_pow 2 r).const_mul π |> (by simpa using ·)
+  convert h using 1
+  ring
+
+/-- The area function is continuous. -/
+theorem continuous_circleArea : Continuous circleArea := by
+  unfold circleArea
+  continuity
+
+/-- The circumference function is continuous. -/
+theorem continuous_circumference : Continuous circumference := by
+  unfold circumference
+  continuity
+
+/-- **Main Theorem**: Integrating the circumference from 0 to r recovers the area.
+  ∫₀ʳ C(ρ) dρ = A(r)
+This is the FTC-based formalization of Archimedes' "sum of rings" argument. -/
+theorem area_from_integral (r : ℝ) :
+    ∫ ρ in (0 : ℝ)..r, circumference ρ = circleArea r := by
+  -- FTC Part 2: ∫₀ʳ F'(ρ) dρ = F(r) - F(0) when F' = circumference
+  have h_deriv : ∀ x ∈ Set.uIcc (0 : ℝ) r, HasDerivAt circleArea (circumference x) x :=
+    fun x _ => hasDerivAt_circleArea x
+  have h_int : IntervalIntegrable circumference volume 0 r :=
+    continuous_circumference.intervalIntegrable 0 r
+  rw [integral_eq_sub_of_hasDerivAt h_deriv h_int]
+  -- Simplify: circleArea r - circleArea 0 = πr² - 0 = πr²
+  simp [circleArea]
+
+/-- The formula holds in particular for non-negative radii. -/
+theorem area_from_integral_nonneg {r : ℝ} (_hr : 0 ≤ r) :
+    ∫ ρ in (0 : ℝ)..r, circumference ρ = circleArea r :=
+  area_from_integral r
+
+/-- Direct computation: ∫₀ʳ 2πρ dρ = πr².
+Unfolds the definitions to show the raw integral formula. -/
+theorem area_from_integral_explicit (r : ℝ) :
+    ∫ ρ in (0 : ℝ)..r, 2 * π * ρ = π * r ^ 2 := by
+  have := area_from_integral r
+  simp only [circumference, circleArea] at this
+  exact this
+
+/-- The area difference between radii r₁ and r₂ equals the integral of circumference
+over [r₁, r₂]. This generalizes the area formula to arbitrary annuli. -/
+theorem annulus_area_from_integral (r₁ r₂ : ℝ) :
+    ∫ ρ in r₁..r₂, circumference ρ = circleArea r₂ - circleArea r₁ := by
+  have h_deriv : ∀ x ∈ Set.uIcc r₁ r₂, HasDerivAt circleArea (circumference x) x :=
+    fun x _ => hasDerivAt_circleArea x
+  have h_int : IntervalIntegrable circumference volume r₁ r₂ :=
+    continuous_circumference.intervalIntegrable r₁ r₂
+  rw [integral_eq_sub_of_hasDerivAt h_deriv h_int]
+
+/-- The annulus between radii r₁ and r₂ has area ∫_{r₁}^{r₂} 2πρ dρ = π(r₂² - r₁²). -/
+theorem annulus_area_formula (r₁ r₂ : ℝ) :
+    ∫ ρ in r₁..r₂, circumference ρ = π * (r₂ ^ 2 - r₁ ^ 2) := by
+  rw [annulus_area_from_integral]
+  unfold circleArea
+  ring
+
+/-- The area formula is consistent: differentiating the integral recovers the circumference.
+This closes the circle (pun intended): ∫↑ gives A, d/dr gives C = 2πr. -/
+theorem diff_area_eq_circumference (r : ℝ) :
+    HasDerivAt (fun s => ∫ ρ in (0 : ℝ)..s, circumference ρ) (circumference r) r := by
+  -- The derivative of (∫₀ˢ C(ρ) dρ) w.r.t. s is C(s) by FTC Part 1
+  exact integral_hasDerivAt_right
+    (continuous_circumference.intervalIntegrable 0 r)
+    (continuous_circumference.stronglyMeasurableAtFilter volume (𝓝 r))
+    continuous_circumference.continuousAt
+
+/-- At radius 1, the integral of circumference from 0 to 1 equals π (the unit disk area). -/
+theorem unit_disk_area : ∫ ρ in (0 : ℝ)..1, circumference ρ = π := by
+  have := area_from_integral 1
+  simp [circumference, circleArea] at this ⊢
+  linarith
+
+/-- Scaling: multiplying the radius by c scales the area by c². -/
+theorem area_scaling (c r : ℝ) :
+    ∫ ρ in (0 : ℝ)..c * r, circumference ρ = c ^ 2 * circleArea r := by
+  rw [area_from_integral]
+  unfold circleArea
+  ring
+
+end AreaFromCircumferenceIntegral

--- a/src/data/proofs/area-of-circle-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/annotations.json
@@ -1,0 +1,34 @@
+{
+  "annotations": [
+    {
+      "id": "ftc-application",
+      "line": 80,
+      "type": "insight",
+      "text": "This is the core of the proof: FTC Part 2 (integral_eq_sub_of_hasDerivAt) turns the integration problem into a differentiation problem. Since we already proved dA/dr = C(r) in the companion entry, the FTC hands us the result directly."
+    },
+    {
+      "id": "integrability",
+      "line": 82,
+      "type": "technique",
+      "text": "Continuity implies integrability: any continuous function is Riemann integrable on any bounded interval. Mathlib's `Continuous.intervalIntegrable` packages this fact for us."
+    },
+    {
+      "id": "circleArea-zero",
+      "line": 85,
+      "type": "insight",
+      "text": "After applying FTC, the goal becomes circleArea r - circleArea 0 = circleArea r. The `simp [circleArea]` closes this by computing circleArea 0 = π * 0² = 0."
+    },
+    {
+      "id": "annulus-formula",
+      "line": 108,
+      "type": "application",
+      "text": "The annulus area formula generalizes the disk area: the area between two circles of radii r₁ and r₂ is π(r₂² - r₁²). This follows from the same FTC argument applied on [r₁, r₂] instead of [0, r]."
+    },
+    {
+      "id": "ftc-part1-duality",
+      "line": 124,
+      "type": "insight",
+      "text": "This theorem closes the circle (FTC duality): differentiating the integral ∫₀ˢ C(ρ) dρ recovers C(s). Combined with the main theorem, we have A = ∫C and C = A' — the full FTC package for circle geometry."
+    }
+  ]
+}

--- a/src/data/proofs/area-of-circle-oq-01-oq-02/index.ts
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/index.ts
@@ -1,0 +1,34 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaFromCircumferenceIntegral.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+export const areaOfCircleOQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const areaOfCircleOQ01OQ02Annotations: Annotation[] = annotationsJson as Annotation[]
+
+export const areaOfCircleOQ01OQ02Data: ProofData = {
+  proof: areaOfCircleOQ01OQ02Proof,
+  annotations: areaOfCircleOQ01OQ02Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
@@ -1,0 +1,130 @@
+{
+  "id": "area-of-circle-oq-01-oq-02",
+  "title": "Area from Circumference Integration",
+  "slug": "area-of-circle-oq-01-oq-02",
+  "description": "The area of a circle A = πr² derived by integrating the circumference C(ρ) = 2πρ from 0 to r. Formalizes Archimedes' geometric vision of the disk as a sum of concentric rings via the Fundamental Theorem of Calculus.",
+  "meta": {
+    "author": "Archimedes (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Area_of_a_circle",
+    "date": "~250 BCE",
+    "status": "complete",
+    "proofRepoPath": "Proofs/AreaFromCircumferenceIntegral.lean",
+    "tags": [
+      "analysis",
+      "geometry",
+      "calculus",
+      "integration",
+      "ftc",
+      "extension",
+      "research"
+    ],
+    "badge": "open",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "intervalIntegral.integral_eq_sub_of_hasDerivAt",
+        "description": "FTC Part 2: ∫ₐᵇ F'(x) dx = F(b) - F(a) when F is differentiable",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.FundThmCalculus"
+      },
+      {
+        "theorem": "intervalIntegral.integral_hasDerivAt_right",
+        "description": "FTC Part 1: d/dr ∫₀ʳ f(ρ) dρ = f(r) when f is continuous",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.FundThmCalculus"
+      },
+      {
+        "theorem": "Continuous.intervalIntegrable",
+        "description": "Continuous functions are integrable on any interval",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "hasDerivAt_pow",
+        "description": "Derivative of x^n is n * x^(n-1)",
+        "module": "Mathlib.Analysis.Calculus.Deriv.Pow"
+      }
+    ],
+    "originalContributions": [
+      "Complete formalization of A(r) = ∫₀ʳ C(ρ) dρ via FTC Part 2",
+      "Answers the open question from the Circumference from Area gallery entry",
+      "Annulus area formula: ∫_{r₁}^{r₂} 2πρ dρ = π(r₂² - r₁²)",
+      "Duality theorem: differentiating the integral recovers the circumference (FTC Part 1)",
+      "Unit disk area verification: ∫₀¹ 2πρ dρ = π",
+      "Scaling law: changing radius by c scales area by c²"
+    ],
+    "dateAdded": "02/23/26"
+  },
+  "overview": {
+    "historicalContext": "Archimedes of Syracuse (~287–212 BCE) conceived of the disk as being composed of infinitely many concentric circular rings (annuli). Each ring at radius ρ has circumference $2\\pi\\rho$ and infinitesimal width $d\\rho$, contributing area $2\\pi\\rho\\, d\\rho$ to the total. Summing all rings from $\\rho = 0$ to $\\rho = r$ gives the total area $A = \\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$. This argument—though not stated in integral notation by Archimedes—is the conceptual foundation of his proof in *Measurement of a Circle* and anticipates Leibniz's integral calculus by nearly two millennia. The formal statement $A(r) = \\int_0^r C(\\rho)\\, d\\rho$ follows from the Fundamental Theorem of Calculus (Newton–Leibniz, 1660s–1680s): since $\\frac{dA}{dr} = C(r)$, which was proved in the companion entry (*Circumference via Area Differentiation*), the FTC gives $A(r) - A(0) = \\int_0^r C(\\rho)\\, d\\rho$, and $A(0) = 0$ yields the formula.",
+    "problemStatement": "**Area from Circumference Integration**:\n\nFor the circumference function $C(\\rho) = 2\\pi\\rho$ and the area function $A(r) = \\pi r^2$, prove:\n$$A(r) = \\int_0^r C(\\rho)\\, d\\rho$$\n\nThis holds for all $r \\in \\mathbb{R}$ (signed integral for $r < 0$).",
+    "proofStrategy": "The proof applies **FTC Part 2** (the evaluation theorem): if $F$ is differentiable with $F' = f$, then $\\int_a^b f(x)\\, dx = F(b) - F(a)$. Since the companion entry proved $\\frac{d}{dr}(\\pi r^2) = 2\\pi r$, we have $A' = C$. Applying FTC on $[0, r]$ gives $\\int_0^r C(\\rho)\\, d\\rho = A(r) - A(0) = \\pi r^2 - 0 = \\pi r^2$. The circumference function is continuous (hence integrable), and the power rule supplies the derivative.",
+    "keyInsights": [
+      "The formula $A(r) = \\int_0^r C(\\rho)\\, d\\rho$ and $C(r) = \\frac{dA}{dr}$ together express that **area and circumference are mutual inverses under the FTC** — integration and differentiation cancel each other",
+      "The same pattern holds in all dimensions: the volume $V_n(r)$ of an $n$-ball satisfies $S_n(r) = V_n'(r)$ and $V_n(r) = \\int_0^r S_n(\\rho)\\, d\\rho$, where $S_n$ is the surface area",
+      "The proof works for **all $r \\in \\mathbb{R}$**, not just $r \\geq 0$, because Mathlib's `intervalIntegral` is the signed integral — for $r < 0$, $\\int_0^r 2\\pi\\rho\\, d\\rho = \\pi r^2$ still holds",
+      "The **annulus formula** $\\int_{r_1}^{r_2} 2\\pi\\rho\\, d\\rho = \\pi(r_2^2 - r_1^2)$ is an immediate corollary, computing the area of the ring between two circles",
+      "Combining the two open-question answers: differentiating then integrating (or integrating then differentiating) $\\pi r^2$ returns $\\pi r^2$ — a concrete illustration of the FTC for the most classical function in geometry"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle",
+      "relationship": "extends",
+      "description": "The foundational Area of a Circle entry proves A = πr² via Lebesgue measure. This entry derives the same formula by integration, using circumference as the integrand."
+    },
+    {
+      "targetId": "area-of-circle-oq-01",
+      "relationship": "companion",
+      "description": "The companion entry proves C = dA/dr (differentiation direction). This entry proves A = ∫C dr (integration direction). Together they establish the complete FTC duality for circle geometry."
+    },
+    {
+      "targetId": "fundamental-theorem-calculus",
+      "relationship": "uses",
+      "description": "This proof is a direct application of FTC Part 2 (integral_eq_sub_of_hasDerivAt) from the Fundamental Theorem of Calculus entry."
+    }
+  ],
+  "sections": [
+    {
+      "id": "imports-setup",
+      "title": "Imports and Module Setup",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Imports Mathlib's calculus and interval integral infrastructure. Opens `Real`, `MeasureTheory`, `intervalIntegral`, and `Topology` namespaces within `AreaFromCircumferenceIntegral`."
+    },
+    {
+      "id": "definitions",
+      "title": "Area and Circumference Functions",
+      "startLine": 46,
+      "endLine": 56,
+      "summary": "Defines `circleArea(r) = π * r²` and `circumference(ρ) = 2 * π * ρ` as noncomputable real-valued functions. Proves continuity of both functions."
+    },
+    {
+      "id": "derivative",
+      "title": "Derivative of Area Equals Circumference",
+      "startLine": 58,
+      "endLine": 72,
+      "summary": "Proves `hasDerivAt_circleArea`: the area function has derivative `circumference r` at every point `r`, using the power rule and constant multiplication. This is the bridge to FTC."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: Integration Recovers Area",
+      "startLine": 74,
+      "endLine": 92,
+      "summary": "Proves `area_from_integral`: ∫ ρ in 0..r, circumference ρ = circleArea r for all r. Uses FTC Part 2 (integral_eq_sub_of_hasDerivAt) with continuity of circumference for integrability."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries and Special Cases",
+      "startLine": 93,
+      "endLine": 153,
+      "summary": "Derives: explicit form (∫₀ʳ 2πρ dρ = πr²), annulus area formula (∫_{r₁}^{r₂} 2πρ dρ = π(r₂² - r₁²)), FTC Part 1 duality (differentiating the integral recovers circumference), unit disk area (= π), and quadratic scaling law."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization proves A(r) = ∫₀ʳ C(ρ) dρ using the Fundamental Theorem of Calculus, answering the open question from the Circumference from Area gallery entry. The proof uses the companion result dA/dr = C(r) as the antiderivative relationship, then applies FTC Part 2. Together with its companion, it establishes the complete integration-differentiation duality for circle geometry. The proof file contains 153 lines, 0 sorries, 0 axioms.",
+    "implications": "The integration-differentiation duality $A' = C$ and $A = \\int C$ is not special to circles — it holds for all dimensions. The $n$-ball volume $V_n(r) = \\pi^{n/2} r^n / \\Gamma(n/2+1)$ satisfies $V_n' = S_n$ where $S_n$ is surface area, and $V_n(r) = \\int_0^r S_n(\\rho)\\, d\\rho$. This pattern reflects a deep principle in geometric measure theory: the boundary measure is the variation of the volume measure.",
+    "openQuestions": [
+      "Can the n-dimensional analogue V_n(r) = ∫₀ʳ S_n(ρ) dρ be formalized for all n?",
+      "Can the isoperimetric inequality C² ≥ 4πA (with equality only for circles) be proved?",
+      "Can Archimedes' original method of exhaustion (polygon approximation) be formalized as a Riemann sum that converges to ∫₀ʳ 2πρ dρ?"
+    ]
+  }
+}

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -1,0 +1,72 @@
+{
+  "slug": "area-of-circle-oq-01-oq-02",
+  "title": "Can the integral direction be formalized: A(r) = integral from 0 to r of C(rh...",
+  "phase": "COMPLETE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETE",
+    "since": "2026-02-21T19:21:07.130Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: Proved A(r) = integral from 0 to r of C(rho) drho via FTC Part 2. 0 sorries, 0 axioms.",
+    "builtItems": [
+      "AreaFromCircumferenceIntegral.lean: area_from_integral (main theorem)",
+      "AreaFromCircumferenceIntegral.lean: annulus_area_from_integral (generalization)",
+      "AreaFromCircumferenceIntegral.lean: annulus_area_formula (explicit π(r2²-r1²) form)",
+      "AreaFromCircumferenceIntegral.lean: diff_area_eq_circumference (FTC Part 1 duality)",
+      "AreaFromCircumferenceIntegral.lean: unit_disk_area, area_scaling (corollaries)"
+    ],
+    "insights": [
+      "FTC Part 2 (integral_eq_sub_of_hasDerivAt) directly solves the problem when we know dA/dr = C(r)",
+      "circumference continuity implies IntervalIntegrable on any [0,r] via Continuous.intervalIntegrable",
+      "The formula holds for all r : ℝ (not just r >= 0) because Mathlib uses signed intervalIntegral",
+      "Annulus area formula ∫_{r1}^{r2} 2πρ dρ = π(r2² - r1²) is a free corollary of the same FTC argument",
+      "The integration and differentiation directions together give the full FTC duality for circle geometry"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "approaches": [],
+  "tags": [
+    "seeker-selected",
+    "extension",
+    "challenging",
+    "analysis",
+    "geometry",
+    "calculus",
+    "differentiation",
+    "extension",
+    "research"
+  ],
+  "relatedProofs": [],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-02-21T19:21:07.130Z",
+  "lastUpdate": "2026-02-21T19:21:07.130Z",
+  "significance": 6,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary

- Formalizes the integral direction of the area-circumference duality: **A(r) = integral from 0 to r of C(rho) drho**
- Answers the open question from the *Circumference from Area* gallery entry (area-of-circle-oq-01)
- Complete proof: 0 sorries, 0 axioms, builds in Docker (Mathlib v4.26.0)

## Mathematical Content

The key theorem proves A(r) = integral_0^r circumference(rho) drho for all r in ℝ.

**Proof strategy**: FTC Part 2 (integral_eq_sub_of_hasDerivAt) with companion result dA/dr = C(r):
- HasDerivAt circleArea (circumference x) x for all x (power rule)
- circumference is continuous (hence integrable on any interval)
- FTC gives: integral_0^r C(rho) drho = A(r) - A(0) = pi*r^2 - 0 = pi*r^2

**Corollaries proved**:
- Annulus area formula: integral_{r1}^{r2} 2pi*rho drho = pi(r2^2 - r1^2)
- FTC Part 1 duality: d/dr [integral_0^r C(rho) drho] = C(r)
- Unit disk: integral_0^1 2pi*rho drho = pi
- Scaling law: integral_0^{c*r} 2pi*rho drho = c^2 * pi*r^2

## Files Modified

- proofs/Proofs/AreaFromCircumferenceIntegral.lean (new, 153 lines)
- src/data/proofs/area-of-circle-oq-01-oq-02/ (gallery entry: meta.json, annotations.json, index.ts)
- src/data/research/problems/area-of-circle-oq-01-oq-02.json (problem knowledge, COMPLETE)

## Status
**Outcome**: completed (0 sorries, 0 axioms)
**Next steps**: n-dimensional analogue V_n(r) = integral_0^r S_n(rho) drho remains open

🤖 Generated by researcher-1