### PR TITLE
fix: correct annotations.json format for area-of-circle-oq-01-oq-02

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/annotations.json
@@ -1,34 +1,32 @@
-{
-  "annotations": [
-    {
-      "id": "ftc-application",
-      "line": 80,
-      "type": "insight",
-      "text": "This is the core of the proof: FTC Part 2 (integral_eq_sub_of_hasDerivAt) turns the integration problem into a differentiation problem. Since we already proved dA/dr = C(r) in the companion entry, the FTC hands us the result directly."
-    },
-    {
-      "id": "integrability",
-      "line": 82,
-      "type": "technique",
-      "text": "Continuity implies integrability: any continuous function is Riemann integrable on any bounded interval. Mathlib's `Continuous.intervalIntegrable` packages this fact for us."
-    },
-    {
-      "id": "circleArea-zero",
-      "line": 85,
-      "type": "insight",
-      "text": "After applying FTC, the goal becomes circleArea r - circleArea 0 = circleArea r. The `simp [circleArea]` closes this by computing circleArea 0 = π * 0² = 0."
-    },
-    {
-      "id": "annulus-formula",
-      "line": 108,
-      "type": "application",
-      "text": "The annulus area formula generalizes the disk area: the area between two circles of radii r₁ and r₂ is π(r₂² - r₁²). This follows from the same FTC argument applied on [r₁, r₂] instead of [0, r]."
-    },
-    {
-      "id": "ftc-part1-duality",
-      "line": 124,
-      "type": "insight",
-      "text": "This theorem closes the circle (FTC duality): differentiating the integral ∫₀ˢ C(ρ) dρ recovers C(s). Combined with the main theorem, we have A = ∫C and C = A' — the full FTC package for circle geometry."
-    }
-  ]
-}
+[
+  {
+    "id": "ftc-application",
+    "line": 80,
+    "type": "insight",
+    "text": "This is the core of the proof: FTC Part 2 (integral_eq_sub_of_hasDerivAt) turns the integration problem into a differentiation problem. Since we already proved dA/dr = C(r) in the companion entry, the FTC hands us the result directly."
+  },
+  {
+    "id": "integrability",
+    "line": 82,
+    "type": "technique",
+    "text": "Continuity implies integrability: any continuous function is Riemann integrable on any bounded interval. Mathlib's `Continuous.intervalIntegrable` packages this fact for us."
+  },
+  {
+    "id": "circleArea-zero",
+    "line": 85,
+    "type": "insight",
+    "text": "After applying FTC, the goal becomes circleArea r - circleArea 0 = circleArea r. The `simp [circleArea]` closes this by computing circleArea 0 = π * 0² = 0."
+  },
+  {
+    "id": "annulus-formula",
+    "line": 108,
+    "type": "application",
+    "text": "The annulus area formula generalizes the disk area: the area between two circles of radii r₁ and r₂ is π(r₂² - r₁²). This follows from the same FTC argument applied on [r₁, r₂] instead of [0, r]."
+  },
+  {
+    "id": "ftc-part1-duality",
+    "line": 124,
+    "type": "insight",
+    "text": "This theorem closes the circle (FTC duality): differentiating the integral ∫₀ˢ C(ρ) dρ recovers C(s). Combined with the main theorem, we have A = ∫C and C = A' — the full FTC package for circle geometry."
+  }
+]


### PR DESCRIPTION
## Summary

- Fixes build failure caused by incorrect `annotations.json` format in `area-of-circle-oq-01-oq-02`
- The file was wrapped in `{"annotations": [...]}` object format instead of the expected plain array `[...]`
- This caused `TypeError: annotationsJson is not iterable` in `scripts/annotations/resolver.ts:256`

## Root Cause

PR #3143 introduced the `area-of-circle-oq-01-oq-02` proof with an `annotations.json` using the wrong format. The build script's `validateLineAnnotations()` function expects a raw JSON array, not an object wrapper.

## Test plan
- [x] `pnpm annotations:build` passes after this fix
- [x] `pnpm build` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)