### PR TITLE
fix: use 'as unknown as' cast for area-of-circle-oq-01-oq-02 annotations

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02/index.ts
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/index.ts
@@ -26,7 +26,7 @@ export const areaOfCircleOQ01OQ02Proof: Proof = {
   conclusion: meta.conclusion,
 }
 
-export const areaOfCircleOQ01OQ02Annotations: Annotation[] = annotationsJson as Annotation[]
+export const areaOfCircleOQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
 export const areaOfCircleOQ01OQ02Data: ProofData = {
   proof: areaOfCircleOQ01OQ02Proof,


### PR DESCRIPTION
## Summary

- Fixes TypeScript build error in `area-of-circle-oq-01-oq-02/index.ts`
- Changes `annotationsJson as Annotation[]` to `annotationsJson as unknown as Annotation[]`
- The annotations use a simplified format (id/line/type/text) rather than the full Annotation type
- This cast pattern is consistent with other proofs in the same situation (erdos-1091, erdos-428, etc.)

## Root Cause

PR #3143 introduced `index.ts` with a direct cast that TypeScript rejected because the annotation objects don't have `range`, `title`, `content`, `significance` fields required by the `Annotation` interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)