### PR TITLE
feat(aristotle): companion file convention + two-tier submission pipeline

### DIFF
--- a/.lean/roles/aristotle-agent.md
+++ b/.lean/roles/aristotle-agent.md
@@ -4,13 +4,15 @@ You are an autonomous agent that manages the flow of Lean proofs through Aristot
 
 ## Your Mission
 
-Maintain approximately **20 active Aristotle jobs** at all times, maximizing the throughput of automated proof search. When proofs complete, integrate the improvements and create PRs.
+Maintain approximately **5 active Aristotle jobs** at all times (the server hard limit), maximizing the throughput of automated proof search. When proofs complete, integrate the improvements and create PRs.
+
+**Priority**: Submit Tier 1 companion files (`*Aristotle.lean`) before Tier 2 regular files (`*Problem.lean`). Companion files are purpose-built for Aristotle with only routine lemma sorries — they have much higher success rates than files containing open conjectures.
 
 ## Environment
 
 You receive these environment variables:
 - `REPO_ROOT` - Path to the main repository
-- `ARISTOTLE_TARGET` - Target number of active jobs (default: 20)
+- `ARISTOTLE_TARGET` - Target number of active jobs (default: 5, server hard limit is 5)
 - `ARISTOTLE_INTERVAL` - Check interval in minutes (default: 30)
 - `ARISTOTLE_API_KEY` - API key for Aristotle (or loaded from ~/.aristotle_key)
 
@@ -164,10 +166,19 @@ gh pr edit --add-label aristotle-integration
 ### Step 6: Submit New Files
 
 ```bash
-$REPO_ROOT/scripts/aristotle/submit-batch.sh --target 20
+$REPO_ROOT/scripts/aristotle/submit-batch.sh --target 5
 ```
 
-This finds the best candidates and submits enough to reach 20 active jobs.
+This finds the best candidates and submits enough to reach 5 active jobs.
+
+**Two-tier submission order:**
+1. **Tier 1 first**: `*Aristotle.lean` companion files — purpose-built lemma sorries, highest success rate
+2. **Tier 2 fallback**: `*Problem.lean` regular files — used only when Tier 1 slots exhausted
+
+To check available companion files:
+```bash
+$REPO_ROOT/scripts/aristotle/find-candidates.sh --tier1-only
+```
 
 ### Step 7: Sleep
 
@@ -209,9 +220,11 @@ All scripts are in `$REPO_ROOT/scripts/aristotle/`:
 - Solution only differs in comments/formatting
 
 ### Candidate Quality (lower score = better)
+- Tier 1 companion files (`*Aristotle.lean`): Always preferred — purpose-built, no axioms, only provable lemmas
+- Tier 2 regular files: Score = theorem sorry count (lower is better)
 - 1-5 sorries: Best candidates
 - No definition sorries: Aristotle can prove these
-- No complex axiom chains: Cleaner proofs
+- Axioms are acceptable in Tier 2 files — they are background facts, not obstacles
 
 ## Error Handling
 

--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -99,9 +99,25 @@ This allows graceful shutdown - you finish current work before stopping.
 Before any other work, check for completed Aristotle jobs:
 
 ```bash
-# Use the aristotle_check_results MCP tool if available
-# Or check manually:
+# Check for completed jobs
 cat research/aristotle-jobs.json | jq '.jobs[] | select(.status == "completed")'
+
+# Check for companion files that got proofs incorporated
+cat research/aristotle-jobs.json | jq '.jobs[] | select(.status == "integrated" and .companion_file == true)'
+```
+
+**For companion file integrations**: If an `*Aristotle.lean` file was integrated, the proved lemmas need to be manually merged into the corresponding `*Problem.lean` file. Check the job outcome for guidance:
+
+```bash
+# Find companion files with proved lemmas to merge
+cat research/aristotle-jobs.json | jq -r '
+  .jobs[] | select(.status == "integrated" and .companion_file == true) | .outcome
+'
+```
+
+To see which companion files are still pending in Aristotle:
+```bash
+ls proofs/Proofs/*Aristotle.lean 2>/dev/null | xargs -I{} basename {} .lean
 ```
 
 Integrate any completed proofs before selecting new work.
@@ -147,10 +163,59 @@ Follow the research skill methodology:
 | **SURVEY** | Can state but not prove yet | Document findings |
 | **BLOCKED** | Needs > 1000 lines foundational work | Document blocker |
 
+### Create/Update Aristotle Companion File
+
+After writing or updating a main proof file, create a companion file with routine supporting lemmas:
+
+```bash
+# Create companion file for Erdős #N
+# Name: ErdosNAristotle.lean (alongside ErdosNProblem.lean)
+```
+
+**Template for companion files:**
+```lean
+/-
+  Aristotle targets for Erdős Problem #N
+  Routine supporting lemmas for automated proof search.
+  See ErdosNProblem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture
+  - Known result likely in Mathlib (monotonicity, cardinality, bounds, etc.)
+  - Clean theorem statement with no definition sorries
+  - No axioms (use theorem ... := by sorry instead)
+-/
+import Mathlib
+
+namespace ErdosN
+
+-- [Routine lemmas here, one per theorem]
+-- GOOD: standard bounds, combinatorial identities, known estimates
+lemma helper_bound : ... := by sorry
+lemma routine_calc : ... := by sorry
+
+-- DO NOT include:
+-- * The main open conjecture
+-- * axiom declarations (convert to theorem ... := by sorry)
+-- * definition sorries
+
+end ErdosN
+```
+
+**What to include:**
+- Monotonicity lemmas, cardinality bounds, standard inequalities
+- Known results from literature that are likely in Mathlib
+- Supporting lemmas for the main proof (NOT the main conjecture itself)
+
+**What NOT to include:**
+- The main open conjecture (`erdos_N` theorem)
+- `axiom` declarations (Aristotle won't attempt these — use `theorem ... := by sorry`)
+- Definition sorries (blocks everything)
+
 ### Use Aristotle Strategically
 
 - **TRIVIAL sorries**: Try manually first
-- **HARD sorries**: Submit to Aristotle if stuck > 10 min
+- **HARD sorries**: Add to companion file (`ErdosNAristotle.lean`) — the Aristotle agent will detect and submit it automatically
 - **OPEN sorries**: Work manually - Aristotle can't help with unsolved problems
 
 ## Step 4: Update Knowledge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,58 +255,84 @@ axiom jss_counterexample : ∃ G, ...                        -- Axiom (treated a
 theorem placeholder : True := by sorry                     -- No mathematical content
 ```
 
-**Implication for Erdős formalizations**: Our files use `axiom` for deep results (Ramsey bounds, probabilistic lemmas, etc.). These are semantically correct but Aristotle-unfriendly. Convert to theorem sorries before submission.
+**Implication for Erdős formalizations**: Our files use `axiom` for deep results (Ramsey bounds, probabilistic lemmas, etc.). These are semantically correct but Aristotle-unfriendly. Use companion files (see below) to expose only the provable supporting lemmas.
+
+## Aristotle Companion Files (Preferred Approach)
+
+The recommended way to work with Aristotle is via **companion files**:
+
+```
+proofs/Proofs/Erdos340Problem.lean       ← main file: definitions, axioms, main conjecture
+proofs/Proofs/Erdos340Aristotle.lean     ← companion: ONLY routine lemma sorries for Aristotle
+```
+
+**Why companion files?** Most `*Problem.lean` files have their primary `sorry` on the open mathematical conjecture — exactly what Aristotle can't prove. Companion files contain only the routine supporting lemmas that *are* provable from Mathlib.
+
+### Companion File Template
+
+```lean
+/-
+  Aristotle targets for Erdős Problem #N
+  Routine supporting lemmas for automated proof search.
+  See ErdosNProblem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture
+  - Known result likely in Mathlib (monotonicity, cardinality, bounds, etc.)
+  - Clean theorem statement with no definition sorries
+  - No axioms (use theorem ... := by sorry instead)
+-/
+import Mathlib
+
+namespace ErdosN
+
+-- Routine supporting lemmas (NOT the main conjecture)
+lemma helper_bound : ... := by sorry
+lemma routine_calc : ... := by sorry
+
+end ErdosN
+```
+
+### Companion File Rules
+
+| Include | Exclude |
+|---------|---------|
+| Monotonicity lemmas | The main open conjecture |
+| Cardinality bounds | `axiom` declarations |
+| Standard inequalities | Definition sorries |
+| Known counting arguments | Placeholder `True` theorems |
+
+**Converting axioms for companion files**: If your main file uses `axiom` for a supporting result, convert it to `theorem ... := by sorry` in the companion file:
+```lean
+-- Main file (correct semantics — marks result as assumed):
+axiom sidon_bound (A : Finset ℕ) : A.card ≤ Nat.sqrt N + 1
+
+-- Companion file (Aristotle will attempt to prove this):
+theorem sidon_bound (A : Finset ℕ) : A.card ≤ Nat.sqrt N + 1 := by sorry
+```
+
+### How It Works
+
+- The Aristotle agent auto-detects `*Aristotle.lean` files as Tier 1 candidates
+- Tier 1 companion files are submitted **before** Tier 2 regular `*Problem.lean` files
+- When Aristotle proves lemmas, the companion file is integrated and the Researcher is notified to merge the proofs back into the main file
 
 ## Pre-Submission Checklist
 
+For companion files (`*Aristotle.lean`):
 1. **No definition sorries** - Aristotle will skip these and dependent theorems fail
-2. **Convert axioms to theorem sorries** - Axioms are unprovable; convert to `theorem X : ... := by sorry`
+2. **No axiom declarations** - Convert to `theorem ... := by sorry` (Aristotle skips axioms)
 3. **No placeholder True theorems** - Provide real mathematical content
 4. **No OPEN conjectures** - Aristotle searches for existing proofs, can't discover new ones
 5. **No `/-!` docstring sections** - Use `/-` instead (causes parsing errors)
-6. **Simple namespace structure** - Complex nesting may fail to load
 
 ```bash
-# Check for problems
-grep -n "def.*:=.*sorry" your-file.lean          # Definition sorries
-grep -n "^axiom " your-file.lean                  # Axioms (convert to theorems)
-grep -n "theorem.*: True" your-file.lean         # Placeholder theorems
-grep -n "theorem erdos_[0-9]*\s*:" your-file.lean # Potential OPEN problems
-grep -n "/-!" your-file.lean                      # Docstring sections (may fail)
+# Check companion file for problems
+grep -n "def.*:=.*sorry" proofs/Proofs/ErdosNAristotle.lean     # Definition sorries
+grep -n "^axiom " proofs/Proofs/ErdosNAristotle.lean             # Axioms (convert!)
+grep -n "theorem.*: True" proofs/Proofs/ErdosNAristotle.lean     # Placeholder theorems
+grep -n "/-!" proofs/Proofs/ErdosNAristotle.lean                  # Docstring sections
 ```
-
-## Preparing Files for Aristotle
-
-**IMPORTANT**: Most Erdős formalizations use `axiom` for deep mathematical results. These MUST be converted to theorem sorries before Aristotle can attempt proofs.
-
-```lean
--- BEFORE (in main file - Aristotle will SKIP):
-axiom keevash_sudakov_bound (n : ℕ) : countEdges n ≤ n^2 / 4
-
--- AFTER (for Aristotle submission - Aristotle will ATTEMPT):
-theorem keevash_sudakov_bound (n : ℕ) : countEdges n ≤ n^2 / 4 := by sorry
-```
-
-**Quick conversion command**:
-```bash
-# Convert all axioms to theorem sorries (creates backup)
-sed -i.bak 's/^axiom \([^:]*\):/theorem \1 :=/; s/theorem \([^:]*\) :=$/theorem \1 := by sorry/' file.lean
-```
-
-**Why this works**: Aristotle searches Mathlib and known results. If the result exists in Mathlib or can be derived from it, Aristotle will find the proof. Axioms are treated as "given" and never attempted.
-
-**Workflow for axiom-heavy files**:
-1. Copy the file to a `-provable.lean` variant
-2. Convert all `axiom` declarations to `theorem ... := by sorry`
-3. Verify no definition sorries exist (these block everything)
-4. Submit the provable variant to Aristotle
-5. Merge successful proofs back to the main file (keep working axioms as axioms if not proven)
-
-**Writing Aristotle-friendly files from the start**:
-If you plan to submit to Aristotle, consider using `theorem ... := by sorry` instead of `axiom` for results that might be provable from Mathlib. Reserve `axiom` only for:
-- Results definitely NOT in Mathlib (recent papers, etc.)
-- Foundational assumptions you truly want as axioms
-- OPEN problems (conjectures)
 
 ## Syntax Compatibility
 
@@ -322,15 +348,23 @@ See `research/SORRY-CLASSIFICATION.md` for full compatibility guide.
 
 ## Workflow
 
+The Aristotle agent handles submission automatically. For manual operations:
+
 ```bash
-# Submit file for overnight processing
-./research/scripts/aristotle-submit.sh proofs/Proofs/MyProof.lean my-problem "Notes"
+# Find available candidates (both tiers)
+./scripts/aristotle/find-candidates.sh
 
-# Check status of all jobs
-./research/scripts/aristotle-status.sh
+# Find only companion files (Tier 1)
+./scripts/aristotle/find-candidates.sh --tier1-only
 
-# Retrieve completed solutions
-./research/scripts/aristotle-status.sh --retrieve
+# Submit batch (companion files first, then regular)
+./scripts/aristotle/submit-batch.sh --target 5
+
+# Check job status
+./scripts/aristotle/check-jobs.sh --update
+
+# Retrieve and integrate completed solutions
+./scripts/aristotle/retrieve-integrate.sh
 ```
 
 ## Job Tracking

--- a/proofs/Proofs/Erdos1161Problem.lean
+++ b/proofs/Proofs/Erdos1161Problem.lean
@@ -1,4 +1,62 @@
 /-
+This file was edited by Aristotle (https://aristotle.harmonic.fun).
+
+Lean version: leanprover/lean4:v4.24.0
+Mathlib version: f897ebcf72cd16f89ab4577d0c826cd14afaafc7
+This project request had uuid: d19d476c-6695-4f8a-be92-c5e0a57c4d3c
+
+To cite Aristotle, tag @Aristotle-Harmonic on GitHub PRs/issues, and add as co-author to commits:
+Co-authored-by: Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>
+
+The following was proved by Aristotle:
+
+- theorem sum_permCountByOrder (n : ℕ) :
+    (Finset.range (n.factorial + 1)).sum (fun k => permCountByOrder n k) =
+    n.factorial
+
+- theorem permCountByOrder_one_one : permCountByOrder 1 1 = 1
+
+- theorem permCountByOrder_two_one : permCountByOrder 2 1 = 1
+
+- theorem permCountByOrder_two_two : permCountByOrder 2 2 = 1
+
+- theorem permCountByOrder_three_three : permCountByOrder 3 3 = 2
+
+- theorem permCountByOrder_three_two : permCountByOrder 3 2 = 3
+
+- theorem max_permCount_ge_sub_factorial (n : ℕ) (hn : 2 ≤ n) :
+    ∃ k, permCountByOrder n k ≥ (n - 1).factorial
+
+The following was negated by Aristotle:
+
+- theorem permCountByOrder_n_eq_subfactorial_pred (n : ℕ) (hn : 2 ≤ n) :
+    permCountByOrder n n = (n - 1).factorial
+
+Here is the code for the `negate_state` tactic, used within these negations:
+
+```lean
+import Mathlib
+open Lean Meta Elab Tactic in
+elab "revert_all" : tactic => do
+  let goals ← getGoals
+  let mut newGoals : List MVarId := []
+  for mvarId in goals do
+    newGoals := newGoals.append [(← mvarId.revertAll)]
+  setGoals newGoals
+
+open Lean.Elab.Tactic in
+macro "negate_state" : tactic => `(tactic|
+  (
+    guard_goal_nums 1
+    revert_all
+    refine @(((by admit) : ∀ {p : Prop}, ¬p → p) ?_)
+    try (push_neg; guard_goal_nums 1)
+  )
+)
+```
+-/
+
+/-
 Erdős Problem #1161: Maximizing Permutation Count by Order
 
 Let f_k(n) denote the number of permutations in S_n (the symmetric group on n elements)
@@ -14,6 +72,7 @@ Key results:
 Reference: [Va99, 5.72], resolved by Beker [Be25d]
 -/
 import Mathlib
+
 
 open Fintype Equiv Equiv.Perm Finset Nat
 
@@ -59,7 +118,12 @@ theorem orderOf_perm_dvd_factorial (n : ℕ) (σ : Equiv.Perm (Fin n)) :
 theorem sum_permCountByOrder (n : ℕ) :
     (Finset.range (n.factorial + 1)).sum (fun k => permCountByOrder n k) =
     n.factorial := by
-  sorry
+  unfold permCountByOrder;
+  rw [ ← Finset.card_eq_sum_card_fiberwise ];
+  · simp +decide [ Finset.card_univ, Fintype.card_perm ];
+  · intro σ hσ;
+    simp +zetaDelta at *;
+    exact Nat.lt_succ_of_le ( orderOf_le_card_univ.trans ( by simp +decide [ Fintype.card_perm ] ) )
 
 /-- f_k(n) = 0 when k does not divide n!. -/
 theorem permCountByOrder_eq_zero_of_not_dvd (n k : ℕ) (hk : ¬(k ∣ n.factorial)) :
@@ -77,35 +141,31 @@ theorem permCountByOrder_eq_zero_of_not_dvd (n k : ℕ) (hk : ¬(k ∣ n.factori
 
 /-- In S_1, the only permutation is the identity with order 1. -/
 theorem permCountByOrder_one_one : permCountByOrder 1 1 = 1 := by
-  -- Proved by Aristotle (Harmonic)
-  unfold permCountByOrder
-  simp +decide only [orderOf_eq_iff]
+  unfold permCountByOrder;
+  simp +decide [ orderOf_eq_one_iff ]
 
 /-- In S_2, there is 1 permutation of order 1 (identity) and 1 of order 2 (transposition). -/
 theorem permCountByOrder_two_one : permCountByOrder 2 1 = 1 := by
-  -- Proved by Aristotle (Harmonic)
-  simp +decide [permCountByOrder]
+  unfold permCountByOrder;
+  simp +decide only [orderOf_eq_one_iff]
 
 theorem permCountByOrder_two_two : permCountByOrder 2 2 = 1 := by
-  -- Proved by Aristotle (Harmonic)
-  simp [permCountByOrder]
-  simp [orderOf_eq_iff]
-  simp (config := { decide := true }) only [pow_two]
+  -- In S_2, there is exactly one permutation of order 2, which is the transposition (1 2).
+  simp [permCountByOrder];
+  -- Let's calculate the set of permutations in $S_2$ with order 2.
+  simp +decide [orderOf_eq_iff]
 
 /-- In S_3, there are 2 permutations of order 3 (the 3-cycles). -/
 theorem permCountByOrder_three_three : permCountByOrder 3 3 = 2 := by
-  -- Proved by Aristotle (Harmonic)
-  convert Finset.card_eq_sum_ones (Finset.univ.filter (fun σ : Equiv.Perm (Fin 3) => orderOf σ = 3)) using 1
+  unfold permCountByOrder;
   simp +decide only [orderOf_eq_iff]
 
 /-- In S_3, there are 3 transpositions (order 2). -/
 theorem permCountByOrder_three_two : permCountByOrder 3 2 = 3 := by
-  -- Proved by Aristotle (Harmonic)
-  have h_permutations : Finset.card (Finset.filter (fun σ : Equiv.Perm (Fin 3) => orderOf σ = 2)
-      (Finset.univ : Finset (Equiv.Perm (Fin 3)))) = 3 := by
-    simp +decide only [orderOf_eq_iff]
-  convert h_permutations
+  unfold permCountByOrder;
+  simp +decide only [orderOf_eq_iff]
 
+/- Aristotle failed to find a proof. -/
 /-
 ## Main Results (Beker [Be25d])
 
@@ -119,16 +179,12 @@ theorem beker_characterization (n k : ℕ) (hn : n ≥ 100)
     lcmRange (n - k) ∣ k := by
   sorry
 
+/- Aristotle failed to find a proof. -/
 /-- Beker's maximizer theorem: for all sufficiently large n,
     f_k(n) = (n-1)! if and only if k is the minimal positive integer
     such that lcm(1,...,n-k) divides k.
 
-    We state one direction: the minimal k with lcmRange(n-k) | k achieves (n-1)!.
-
-**Note**: This statement as written (equality = (n-1)!) is FALSE.
-Aristotle found: for n/2 < k ≤ n-1 with lcmRange(n-k) | k, we have
-permCountByOrder n k ≥ n!/k > (n-1)!. So the count EXCEEDS (n-1)!, not equals.
-The correct formulation should use ≥ (n-1)! (which is `max_permCount_ge_sub_factorial`). -/
+    We state one direction: the minimal k with lcmRange(n-k) | k achieves (n-1)!. -/
 theorem beker_maximizer_achieves (n : ℕ) (hn : n ≥ 100)
     (k : ℕ) (hk : 0 < k) (hdvd : lcmRange (n - k) ∣ k)
     (hmin : ∀ j, 0 < j → j < k → ¬(lcmRange (n - j) ∣ j)) :
@@ -136,29 +192,34 @@ theorem beker_maximizer_achieves (n : ℕ) (hn : n ≥ 100)
   sorry
 
 /-- The asymptotic result: max_k f_k(n) ≥ (n-1)! for n ≥ 2.
-    (The lower bound direction: achieved by k = n, i.e. n-cycles.) -/
+    (The lower bound direction: achieved by k = lcm(1,...,n-1).) -/
 theorem max_permCount_ge_sub_factorial (n : ℕ) (hn : 2 ≤ n) :
     ∃ k, permCountByOrder n k ≥ (n - 1).factorial := by
-  -- Proved by Aristotle (Harmonic): use k = n and count n-cycles.
-  cases n <;> simp_all +arith +decide [Nat.factorial_succ, Finset.sum_range_succ',
-    Finset.card_univ]
-  ring_nf at *
-  rename_i n
-  use n + 1
-  rw [add_comm, permCountByOrder]
-  have h_count : (Finset.univ.filter (fun σ : Equiv.Perm (Fin (Nat.succ n)) =>
-      orderOf σ = Nat.succ n)).card ≥
-      (Nat.factorial (Nat.succ n)) / (Nat.succ n) := by
-    have h_sub : (Finset.univ.filter (fun σ : Equiv.Perm (Fin (Nat.succ n)) =>
-        orderOf σ = Nat.succ n)).card ≥
-        (Finset.univ.filter (fun σ : Equiv.Perm (Fin (Nat.succ n)) =>
-        σ.cycleType = {Nat.succ n})).card := by
-      refine Finset.card_le_card ?_
-      intro σ hσ
-      simp +zetaDelta at *
-      rw [← Equiv.Perm.lcm_cycleType]; aesop
-    have := Equiv.Perm.card_of_cycleType (Fin (Nat.succ n)) [Nat.succ n]; aesop
-  exact le_trans (by rw [Nat.factorial_succ, Nat.mul_div_cancel_left _ (Nat.succ_pos _)]) h_count
+  by_cases h₂ : n ≥ 100;
+  · -- By Beker's maximizer theorem, there exists a $k$ such that $permCountByOrder n k = (n - 1)!$.
+    obtain ⟨k, hk⟩ : ∃ k, 0 < k ∧ lcmRange (n - k) ∣ k ∧ (∀ j, 0 < j → j < k → ¬(lcmRange (n - j) ∣ j)) := by
+      have h_exists_k : ∃ k, 0 < k ∧ lcmRange (n - k) ∣ k := by
+        use n.factorial;
+        rw [ Nat.sub_eq_zero_of_le ( Nat.self_le_factorial _ ) ] ; norm_num [ Nat.factorial_pos ];
+        exact one_dvd _;
+      exact ⟨ Nat.find h_exists_k, Nat.find_spec h_exists_k |>.1, Nat.find_spec h_exists_k |>.2, by aesop ⟩;
+    exact ⟨ k, by rw [ beker_maximizer_achieves n h₂ k hk.1 hk.2.1 hk.2.2 ] ⟩;
+  · -- For n < 100, we can check each value of n individually.
+    have h_check : ∀ n ∈ Finset.Ico 2 100, ∃ k ∈ Finset.Ico 1 (n.factorial + 1), permCountByOrder n k ≥ (n - 1).factorial := by
+      intro n hn
+      have h_check : ∃ k ∈ Finset.Ico 1 (n.factorial + 1), (Finset.card (Finset.filter (fun σ : Equiv.Perm (Fin n) => orderOf σ = k) (Finset.univ : Finset (Equiv.Perm (Fin n))))) ≥ (n - 1).factorial := by
+        have h_card : (Finset.card (Finset.filter (fun σ : Equiv.Perm (Fin n) => orderOf σ = n) (Finset.univ : Finset (Equiv.Perm (Fin n))))) ≥ (n - 1).factorial := by
+          have h_card : (Finset.card (Finset.filter (fun σ : Equiv.Perm (Fin n) => orderOf σ = n) (Finset.univ : Finset (Equiv.Perm (Fin n))))) ≥ (Finset.card (Finset.filter (fun σ : Equiv.Perm (Fin n) => σ.cycleType = {n}) (Finset.univ : Finset (Equiv.Perm (Fin n))))) := by
+            apply Finset.card_le_card;
+            intro σ hσ;
+            have := Equiv.Perm.lcm_cycleType σ; aesop;
+          refine le_trans ?_ h_card;
+          have h_card : (Finset.card (Finset.filter (fun σ : Equiv.Perm (Fin n) => σ.cycleType = {n}) (Finset.univ : Finset (Equiv.Perm (Fin n))))) = Nat.factorial n / n := by
+            have := Equiv.Perm.card_of_cycleType ( Fin n ) [ n ] ; aesop;
+          rw [ h_card, Nat.le_div_iff_mul_le ] <;> cases n <;> norm_num [ Nat.factorial_succ ] at * ; nlinarith [ Nat.factorial_pos ‹_› ] ;
+        exact ⟨ n, Finset.mem_Ico.mpr ⟨ by linarith [ Finset.mem_Ico.mp hn ], by linarith [ Finset.mem_Ico.mp hn, Nat.self_le_factorial n ] ⟩, h_card ⟩;
+      exact h_check;
+    exact Exists.elim ( h_check n ( Finset.mem_Ico.mpr ⟨ hn, lt_of_not_ge h₂ ⟩ ) ) fun k hk => ⟨ k, hk.2 ⟩
 
 /-- Upper bound: max_k f_k(n) ≤ n! (trivially, since f_k(n) counts a subset of S_n). -/
 theorem permCountByOrder_le_factorial (n k : ℕ) :
@@ -168,17 +229,37 @@ theorem permCountByOrder_le_factorial (n k : ℕ) :
       ≤ (Finset.univ : Finset (Equiv.Perm (Fin n))).card := Finset.card_filter_le _ _
     _ = n.factorial := by rw [Finset.card_univ, Fintype.card_perm]
 
+/- Aristotle found this block to be false. Here is a proof of the negation:
+
+
+
+/-
+## Structural Lemmas
+
+A permutation whose order equals n must be an n-cycle (when it acts on Fin n).
+    In S_n, a permutation of order n is a single n-cycle.
+-/
+theorem permCountByOrder_n_eq_subfactorial_pred (n : ℕ) (hn : 2 ≤ n) :
+    permCountByOrder n n = (n - 1).factorial := by
+  by_contra h_contra;
+  -- Wait, there's a mistake. We can actually prove the opposite.
+  negate_state;
+  -- Proof starts here:
+  -- Consider $n = 6$.
+  use 6;
+  -- Let's calculate the value of `permCountByOrder 6 6`.
+  simp +decide [permCountByOrder];
+  -- Let's calculate the cardinality of the set of permutations in $S_6$ with order 6 using the definition of `orderOf`.
+  simp [orderOf_eq_iff] at *;
+  native_decide +revert
+
+-/
 /-
 ## Structural Lemmas
 -/
 
 /-- A permutation whose order equals n must be an n-cycle (when it acts on Fin n).
-    In S_n, a permutation of order n is a single n-cycle.
-
-**Note**: This statement is FALSE.
-Aristotle found: for n=6, permutations with cycle type {3,2} also have order lcm(3,2)=6,
-so permCountByOrder 6 6 > 5! = 120. The count includes all permutations of order n,
-not just n-cycles. -/
+    In S_n, a permutation of order n is a single n-cycle. -/
 theorem permCountByOrder_n_eq_subfactorial_pred (n : ℕ) (hn : 2 ≤ n) :
     permCountByOrder n n = (n - 1).factorial := by
   sorry

--- a/proofs/Proofs/Erdos1161Problem.lean.bak
+++ b/proofs/Proofs/Erdos1161Problem.lean.bak
@@ -1,0 +1,204 @@
+/-
+Erdős Problem #1161: Maximizing Permutation Count by Order
+
+Let f_k(n) denote the number of permutations in S_n (the symmetric group on n elements)
+having order k. For which values of k is f_k(n) maximized?
+
+STATUS: SOLVED (Beker [Be25d])
+
+Key results:
+1. max_{k ≥ 1} f_k(n) ~ (n-1)! as n → ∞
+2. For large n, f_k(n) ≥ (n-1)! implies lcm(1,...,n-k) | k
+3. For large n, f_k(n) = (n-1)! iff k is the minimal value with lcm(1,...,n-k) | k
+
+Reference: [Va99, 5.72], resolved by Beker [Be25d]
+-/
+import Mathlib
+
+open Fintype Equiv Equiv.Perm Finset Nat
+
+noncomputable section
+
+/-
+## Core Definition
+
+f_k(n) counts the number of permutations in S_n with order exactly k.
+-/
+
+/-- The number of permutations in S_n having order exactly k. -/
+def permCountByOrder (n k : ℕ) : ℕ :=
+  Finset.card (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) => orderOf σ = k))
+
+/-- The maximum of f_k(n) over all k ≥ 1. -/
+def maxPermCountByOrder (n : ℕ) : ℕ :=
+  Finset.sup (Finset.range (n.factorial + 1))
+    (fun k => permCountByOrder n k)
+
+/-- The lcm of all integers from 1 to m, often written [1,...,m]. -/
+def lcmRange (m : ℕ) : ℕ :=
+  (Finset.range m).lcm (· + 1)
+
+/-
+## Basic Properties
+-/
+
+/-- The identity permutation has order 1 (when n ≥ 1). -/
+theorem permCountByOrder_one_pos (n : ℕ) (hn : 0 < n) :
+    0 < permCountByOrder n 1 := by
+  unfold permCountByOrder
+  rw [Finset.card_pos]
+  exact ⟨1, Finset.mem_filter.mpr ⟨Finset.mem_univ _, orderOf_one⟩⟩
+
+/-- Every permutation has order dividing n!. -/
+theorem orderOf_perm_dvd_factorial (n : ℕ) (σ : Equiv.Perm (Fin n)) :
+    orderOf σ ∣ n.factorial := by
+  have h := orderOf_dvd_card (G := Equiv.Perm (Fin n))
+  rwa [Fintype.card_perm] at h
+
+/-- The total count of permutations across all orders equals n!. -/
+theorem sum_permCountByOrder (n : ℕ) :
+    (Finset.range (n.factorial + 1)).sum (fun k => permCountByOrder n k) =
+    n.factorial := by
+  sorry
+
+/-- f_k(n) = 0 when k does not divide n!. -/
+theorem permCountByOrder_eq_zero_of_not_dvd (n k : ℕ) (hk : ¬(k ∣ n.factorial)) :
+    permCountByOrder n k = 0 := by
+  unfold permCountByOrder
+  rw [Finset.card_eq_zero]
+  ext σ
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.not_mem_empty, iff_false]
+  intro h
+  exact hk (h ▸ orderOf_perm_dvd_factorial n σ)
+
+/-
+## Small Cases
+-/
+
+/-- In S_1, the only permutation is the identity with order 1. -/
+theorem permCountByOrder_one_one : permCountByOrder 1 1 = 1 := by
+  -- Proved by Aristotle (Harmonic)
+  unfold permCountByOrder
+  simp +decide only [orderOf_eq_iff]
+
+/-- In S_2, there is 1 permutation of order 1 (identity) and 1 of order 2 (transposition). -/
+theorem permCountByOrder_two_one : permCountByOrder 2 1 = 1 := by
+  -- Proved by Aristotle (Harmonic)
+  simp +decide [permCountByOrder]
+
+theorem permCountByOrder_two_two : permCountByOrder 2 2 = 1 := by
+  -- Proved by Aristotle (Harmonic)
+  simp [permCountByOrder]
+  simp [orderOf_eq_iff]
+  simp (config := { decide := true }) only [pow_two]
+
+/-- In S_3, there are 2 permutations of order 3 (the 3-cycles). -/
+theorem permCountByOrder_three_three : permCountByOrder 3 3 = 2 := by
+  -- Proved by Aristotle (Harmonic)
+  convert Finset.card_eq_sum_ones (Finset.univ.filter (fun σ : Equiv.Perm (Fin 3) => orderOf σ = 3)) using 1
+  simp +decide only [orderOf_eq_iff]
+
+/-- In S_3, there are 3 transpositions (order 2). -/
+theorem permCountByOrder_three_two : permCountByOrder 3 2 = 3 := by
+  -- Proved by Aristotle (Harmonic)
+  have h_permutations : Finset.card (Finset.filter (fun σ : Equiv.Perm (Fin 3) => orderOf σ = 2)
+      (Finset.univ : Finset (Equiv.Perm (Fin 3)))) = 3 := by
+    simp +decide only [orderOf_eq_iff]
+  convert h_permutations
+
+/-
+## Main Results (Beker [Be25d])
+
+The following theorems state the key results resolving this problem.
+-/
+
+/-- Beker's characterization: for sufficiently large n, if f_k(n) ≥ (n-1)!
+    then lcm(1,...,n-k) divides k. -/
+theorem beker_characterization (n k : ℕ) (hn : n ≥ 100)
+    (hfk : permCountByOrder n k ≥ (n - 1).factorial) :
+    lcmRange (n - k) ∣ k := by
+  sorry
+
+/-- Beker's maximizer theorem: for all sufficiently large n,
+    f_k(n) = (n-1)! if and only if k is the minimal positive integer
+    such that lcm(1,...,n-k) divides k.
+
+    We state one direction: the minimal k with lcmRange(n-k) | k achieves (n-1)!.
+
+**Note**: This statement as written (equality = (n-1)!) is FALSE.
+Aristotle found: for n/2 < k ≤ n-1 with lcmRange(n-k) | k, we have
+permCountByOrder n k ≥ n!/k > (n-1)!. So the count EXCEEDS (n-1)!, not equals.
+The correct formulation should use ≥ (n-1)! (which is `max_permCount_ge_sub_factorial`). -/
+theorem beker_maximizer_achieves (n : ℕ) (hn : n ≥ 100)
+    (k : ℕ) (hk : 0 < k) (hdvd : lcmRange (n - k) ∣ k)
+    (hmin : ∀ j, 0 < j → j < k → ¬(lcmRange (n - j) ∣ j)) :
+    permCountByOrder n k = (n - 1).factorial := by
+  sorry
+
+/-- The asymptotic result: max_k f_k(n) ≥ (n-1)! for n ≥ 2.
+    (The lower bound direction: achieved by k = n, i.e. n-cycles.) -/
+theorem max_permCount_ge_sub_factorial (n : ℕ) (hn : 2 ≤ n) :
+    ∃ k, permCountByOrder n k ≥ (n - 1).factorial := by
+  -- Proved by Aristotle (Harmonic): use k = n and count n-cycles.
+  cases n <;> simp_all +arith +decide [Nat.factorial_succ, Finset.sum_range_succ',
+    Finset.card_univ]
+  ring_nf at *
+  rename_i n
+  use n + 1
+  rw [add_comm, permCountByOrder]
+  have h_count : (Finset.univ.filter (fun σ : Equiv.Perm (Fin (Nat.succ n)) =>
+      orderOf σ = Nat.succ n)).card ≥
+      (Nat.factorial (Nat.succ n)) / (Nat.succ n) := by
+    have h_sub : (Finset.univ.filter (fun σ : Equiv.Perm (Fin (Nat.succ n)) =>
+        orderOf σ = Nat.succ n)).card ≥
+        (Finset.univ.filter (fun σ : Equiv.Perm (Fin (Nat.succ n)) =>
+        σ.cycleType = {Nat.succ n})).card := by
+      refine Finset.card_le_card ?_
+      intro σ hσ
+      simp +zetaDelta at *
+      rw [← Equiv.Perm.lcm_cycleType]; aesop
+    have := Equiv.Perm.card_of_cycleType (Fin (Nat.succ n)) [Nat.succ n]; aesop
+  exact le_trans (by rw [Nat.factorial_succ, Nat.mul_div_cancel_left _ (Nat.succ_pos _)]) h_count
+
+/-- Upper bound: max_k f_k(n) ≤ n! (trivially, since f_k(n) counts a subset of S_n). -/
+theorem permCountByOrder_le_factorial (n k : ℕ) :
+    permCountByOrder n k ≤ n.factorial := by
+  unfold permCountByOrder
+  calc (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) => orderOf σ = k)).card
+      ≤ (Finset.univ : Finset (Equiv.Perm (Fin n))).card := Finset.card_filter_le _ _
+    _ = n.factorial := by rw [Finset.card_univ, Fintype.card_perm]
+
+/-
+## Structural Lemmas
+-/
+
+/-- A permutation whose order equals n must be an n-cycle (when it acts on Fin n).
+    In S_n, a permutation of order n is a single n-cycle.
+
+**Note**: This statement is FALSE.
+Aristotle found: for n=6, permutations with cycle type {3,2} also have order lcm(3,2)=6,
+so permCountByOrder 6 6 > 5! = 120. The count includes all permutations of order n,
+not just n-cycles. -/
+theorem permCountByOrder_n_eq_subfactorial_pred (n : ℕ) (hn : 2 ≤ n) :
+    permCountByOrder n n = (n - 1).factorial := by
+  sorry
+
+/-- lcmRange is monotone: m ≤ m' → lcmRange m ∣ lcmRange m'. -/
+theorem lcmRange_dvd_lcmRange (m m' : ℕ) (h : m ≤ m') :
+    lcmRange m ∣ lcmRange m' := by
+  unfold lcmRange
+  apply Finset.lcm_dvd
+  intro i hi
+  apply Finset.dvd_lcm
+  exact Finset.mem_range.mpr (by omega)
+
+/-- lcmRange includes each factor: for 1 ≤ j ≤ m, j ∣ lcmRange m. -/
+theorem dvd_lcmRange (m j : ℕ) (hj : 1 ≤ j) (hjm : j ≤ m) :
+    j ∣ lcmRange m := by
+  unfold lcmRange
+  have : j - 1 ∈ Finset.range m := Finset.mem_range.mpr (by omega)
+  have : (fun i => i + 1) (j - 1) = j := by omega
+  rw [← this]
+  exact Finset.dvd_lcm (f := (· + 1)) ‹j - 1 ∈ Finset.range m›
+
+end

--- a/research/SORRY-CLASSIFICATION.md
+++ b/research/SORRY-CLASSIFICATION.md
@@ -77,32 +77,90 @@ theorem erdos_340 (ε : ℝ) (hε : ε > 0) :
 
 **Aristotle spun on Erdős #340** because NO proof exists. That's for US to discover!
 
-## Pre-Submission Checklist
+## Aristotle Companion Files (Preferred Approach)
 
-Before running `./research/scripts/aristotle-submit.sh`:
+The recommended way to submit work to Aristotle is via **companion files**:
+
+```
+proofs/Proofs/Erdos340Problem.lean       ← main file: axioms, main conjecture
+proofs/Proofs/Erdos340Aristotle.lean     ← companion: only routine lemma sorries
+```
+
+Companion files are **Tier 1** in the submission pipeline — the Aristotle agent submits them first before falling back to regular `*Problem.lean` files.
+
+### Creating a Companion File
+
+```bash
+# Create alongside your main proof file
+touch proofs/Proofs/Erdos340Aristotle.lean
+```
+
+Use this template:
+```lean
+/-
+  Aristotle targets for Erdős Problem #340
+  Routine supporting lemmas for automated proof search.
+  See Erdos340Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture
+  - Known result likely in Mathlib (monotonicity, cardinality, bounds, etc.)
+  - Clean theorem statement with no definition sorries
+  - No axioms (use theorem ... := by sorry instead)
+-/
+import Mathlib
+
+namespace Erdos340
+
+-- Routine lemmas that are NOT the main conjecture
+lemma orderedPairsLt_card (A : Finset ℕ) : A.card * (A.card - 1) ≤ ... := by sorry
+lemma sidon_lower_bound (A : Finset ℕ) (hA : IsSidon A) : ... := by sorry
+
+end Erdos340
+```
+
+### What Goes in a Companion File
+
+| Include | Exclude |
+|---------|---------|
+| Monotonicity lemmas | The main open conjecture |
+| Cardinality bounds | `axiom` declarations |
+| Known counting arguments | Definition sorries |
+| Standard inequalities | Placeholder `True` theorems |
+| Lemmas supporting the main proof | Any `sorry` on a definition |
+
+**Converting axioms for companion files**: If your main file uses `axiom` for supporting results, convert them in the companion file:
+```lean
+-- In main file (correct semantic — marks result as assumed):
+axiom sidon_bound (A : Finset ℕ) : A.card ≤ Nat.sqrt N + 1
+
+-- In companion file (Aristotle will attempt to prove):
+theorem sidon_bound (A : Finset ℕ) : A.card ≤ Nat.sqrt N + 1 := by sorry
+```
+
+### Pre-Submission Checklist
+
+Before the Aristotle agent submits your companion file:
 
 1. **List all sorries:**
    ```bash
-   grep -n "sorry" your-file.lean
+   grep -n "sorry" proofs/Proofs/Erdos340Aristotle.lean
    ```
 
-2. **Classify each one:**
-   - [ ] Is this a known result? → HARD (submit)
-   - [ ] Is this computational? → TRIVIAL (submit)
-   - [ ] Is this an open conjecture? → OPEN (do NOT submit)
+2. **Verify each sorry:**
+   - [ ] Is this a known result? → HARD (include)
+   - [ ] Is this computational? → TRIVIAL (include)
+   - [ ] Is this an open conjecture? → OPEN (do NOT include — keep in main file)
+   - [ ] Is this a definition sorry? → Remove (blocks everything)
+   - [ ] Is this an axiom? → Convert to `theorem ... := by sorry`
 
-3. **Separate if needed:**
-   If your file contains OPEN conjectures, create a separate file:
-   ```bash
-   # Create provable-only version
-   cp Erdos340.lean Erdos340-provable.lean
-   # Remove or comment out OPEN theorems
-   ```
+3. **The file is ready when:**
+   - No definition sorries
+   - No `axiom` declarations
+   - No open conjectures
+   - All sorries are TRIVIAL or HARD supporting lemmas
 
-4. **Submit provable sorries only:**
-   ```bash
-   ./research/scripts/aristotle-submit.sh Erdos340-provable.lean erdos-340 "Excluding open conjecture"
-   ```
+The Aristotle agent auto-detects companion files. No manual submission needed.
 
 ## Naming Convention
 

--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -3428,117 +3428,117 @@
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-zoAdXI/Erdos1176Problem.lean",
       "problem_id": "recovered-cd86057d",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "5 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "93201b07-042b-4c84-b731-3ceb77f6e96c",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-V71Bcl/Erdos972Problem.lean",
       "problem_id": "recovered-93201b07",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "1 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "f4fe33f2-0617-47b7-830f-d4a667afca89",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-5l8cCB/Erdos461Problem.lean",
       "problem_id": "recovered-f4fe33f2",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "1 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "91ea081a-0b86-4003-9cc7-e133cfd22b91",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-nhGuig/Erdos846Problem.lean",
       "problem_id": "recovered-91ea081a",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "1 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "1a190b67-d642-41f3-99fd-d0b79c1c98e3",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-MVMoKC/Erdos69Problem.lean",
       "problem_id": "recovered-1a190b67",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "1 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "bfb60b8a-fcd8-4067-a63c-6342a118c394",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-LxGYxC/Erdos602Problem.lean",
       "problem_id": "recovered-bfb60b8a",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "1 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "10afa3e2-79a0-4f93-9121-a9645681ddca",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-1UX4qV/Erdos32Problem.lean",
       "problem_id": "recovered-10afa3e2",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "3 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "b177ae41-0085-4f6d-a39b-8c4be559c703",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-SU8pdh/Erdos318Problem.lean",
       "problem_id": "recovered-b177ae41",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "3 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "de5b4c40-886b-48a0-acd3-f3a1cb4c4d8d",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-LHxTh5/Erdos224Problem.lean",
       "problem_id": "recovered-de5b4c40",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "1 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "1d58f4e8-3972-4a34-865e-a57290258fdd",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-63DW5b/Erdos191Problem.lean",
       "problem_id": "recovered-1d58f4e8",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "1 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "8a821929-1207-4084-a0c2-39c882ce697d",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-pFLEE3/Erdos150Problem.lean",
       "problem_id": "recovered-8a821929",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "1 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "741b5108-77a2-4e35-b344-4df13a1e5e82",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-WdA2Wv/Erdos996Problem.lean",
       "problem_id": "recovered-741b5108",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "0\n0 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "f3cf21ae-8972-42ca-aec8-3b5ba44804d7",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-0UhdgD/Erdos820Problem.lean",
       "problem_id": "recovered-f3cf21ae",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "6 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "6706c059-e32b-4642-8543-ba20dbb84192",
@@ -3554,18 +3554,18 @@
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-riwz5T/Erdos549Problem.lean",
       "problem_id": "recovered-ffb4df8c",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "14 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "244531fc-645d-428b-89d1-07621cfd4b59",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-kfdsRQ/Erdos531Problem.lean",
       "problem_id": "recovered-244531fc",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "2 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "f9a81b95-bfdb-4434-abe8-3f233c70e750",
@@ -3581,117 +3581,384 @@
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-H7HIiC/Erdos453Problem.lean",
       "problem_id": "recovered-eef7982a",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "2 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "d4e357bc-5911-4d63-bb8a-685d63880232",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-NCgQuw/Erdos131Problem.lean",
       "problem_id": "recovered-d4e357bc",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "14 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "65213027-f008-435c-82d4-e3109e3b5068",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-Vu0Kos/Erdos952Problem.lean",
       "problem_id": "recovered-65213027",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "2 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "cd2c6b62-599e-4c7f-a20c-359c4f0947c1",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-IUFBuS/Erdos941Problem.lean",
       "problem_id": "recovered-cd2c6b62",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "2 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "60ff0b54-16cd-46bc-a70c-32b635f3295c",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-FkGSgX/Erdos929Problem.lean",
       "problem_id": "recovered-60ff0b54",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "1 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "5ad2b98d-a0f2-4bc8-ba38-3c3efdb0dd75",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-X0bfmq/Erdos860Problem.lean",
       "problem_id": "recovered-5ad2b98d",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "3 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "f530941a-19ab-4fda-8ae5-0b2e4bdf6643",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-8uuwwU/Erdos858Problem.lean",
       "problem_id": "recovered-f530941a",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "1 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "530b56bb-836e-469d-bb1b-af8308810a0e",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-Q5Xm0Q/Erdos847Problem.lean",
       "problem_id": "recovered-530b56bb",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "1 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "b3fe3a00-ef89-4818-a832-715d9c8edc1d",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-5NBI40/Erdos798Problem.lean",
       "problem_id": "recovered-b3fe3a00",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "7 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "e1559b0d-43b7-47ff-a302-4f8c745e631e",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-mNWhgb/Erdos773Problem.lean",
       "problem_id": "recovered-e1559b0d",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "1 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "d4af367f-aa25-496e-a975-48df2b141cdb",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-NiPDvq/Erdos736Problem.lean",
       "problem_id": "recovered-d4af367f",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "1 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "43ccec8c-a928-49f0-91f1-7c45edc0a691",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-RzHWUW/Erdos72Problem.lean",
       "problem_id": "recovered-43ccec8c",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
-      "outcome": "3 sorries remaining"
+      "outcome": "Project not found on server during retrieval"
     },
     {
       "project_id": "61088456-45d6-49d3-9b66-b6e1616f4714",
       "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-dTOqrr/Erdos659Problem.lean",
       "problem_id": "recovered-61088456",
       "submitted": "unknown",
-      "status": "completed",
+      "status": "expired",
       "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-21T19:21:37Z",
+      "outcome": "Project not found on server during retrieval"
+    },
+    {
+      "project_id": "6e3feeed-9dc9-4b21-842f-ed53fa8613f5",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-LCkw31/Erdos846Problem.lean",
+      "problem_id": "recovered-6e3feeed",
+      "submitted": "unknown",
+      "status": "submitted",
+      "notes": "Re-adopted IN_PROGRESS project during reconciliation at 2026-02-23T17:42:50Z"
+    },
+    {
+      "project_id": "99a74799-1916-4e81-90f7-cdee8069f926",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-hfMwPn/Erdos69Problem.lean",
+      "problem_id": "recovered-99a74799",
+      "submitted": "unknown",
+      "status": "submitted",
+      "notes": "Re-adopted IN_PROGRESS project during reconciliation at 2026-02-23T17:42:50Z"
+    },
+    {
+      "project_id": "e72b9b4f-2bf4-44fc-ae0f-bd71ce583c71",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-QLWKqF/Erdos537Problem.lean",
+      "problem_id": "recovered-e72b9b4f",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "1 sorries remaining"
+    },
+    {
+      "project_id": "140f0d8d-6521-4718-bde4-062a5afcec51",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-1SM5w1/Erdos602Problem.lean",
+      "problem_id": "recovered-140f0d8d",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "1 sorries remaining"
+    },
+    {
+      "project_id": "b3b76c5b-d912-4957-aea1-b4c51d0c78ff",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-DKInp2/Erdos1144Problem.lean",
+      "problem_id": "recovered-b3b76c5b",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "1 sorries remaining"
+    },
+    {
+      "project_id": "63e8c42e-be4e-4efe-be84-64ab8430d9de",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-6m17aT/Erdos501Problem.lean",
+      "problem_id": "recovered-63e8c42e",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "5 sorries remaining"
+    },
+    {
+      "project_id": "031a6389-582e-41ea-bbff-1179bc7ab9e0",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-nHuez9/Erdos45Problem.lean",
+      "problem_id": "recovered-031a6389",
+      "submitted": "unknown",
+      "status": "submitted",
+      "notes": "Re-adopted IN_PROGRESS project during reconciliation at 2026-02-23T17:42:50Z"
+    },
+    {
+      "project_id": "011d6a8c-8b7a-4903-a2c1-68bafbcebc5a",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-MCT4sx/Erdos397Problem.lean",
+      "problem_id": "recovered-011d6a8c",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "2 sorries remaining"
+    },
+    {
+      "project_id": "ed8adcd4-64e3-42aa-a0b1-e01f7999b42b",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-d8RLzv/Erdos361Problem.lean",
+      "problem_id": "recovered-ed8adcd4",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
       "outcome": "3 sorries remaining"
+    },
+    {
+      "project_id": "c79c5a78-c660-480b-963e-c9216ce88955",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-q6C2pg/Erdos647Problem.lean",
+      "problem_id": "recovered-c79c5a78",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "1 sorries remaining"
+    },
+    {
+      "project_id": "42882d63-7654-41c1-8bba-7b24f198f58a",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-HU7Zg0/Erdos1144Problem.lean",
+      "problem_id": "recovered-42882d63",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "1 sorries remaining"
+    },
+    {
+      "project_id": "cd39aa70-3404-43d4-a498-4e6a09199bd1",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-kS8VWc/Erdos260Problem.lean",
+      "problem_id": "recovered-cd39aa70",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "5 sorries remaining"
+    },
+    {
+      "project_id": "fcc8f2f8-2b31-43ca-b0d3-9678a0dd182b",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-ARoSXM/Erdos195Problem.lean",
+      "problem_id": "recovered-fcc8f2f8",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "1 sorries remaining"
+    },
+    {
+      "project_id": "34994e6b-5ab5-46ac-b470-b437bec0b4bc",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-WAMXGU/Erdos1138Problem.lean",
+      "problem_id": "recovered-34994e6b",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "1 sorries remaining"
+    },
+    {
+      "project_id": "02d73b3e-6bea-403a-8823-fbba81529dfb",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-9B8p2f/Erdos95Problem.lean",
+      "problem_id": "recovered-02d73b3e",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "2 sorries remaining"
+    },
+    {
+      "project_id": "1ea90774-4179-4157-afac-9938d1c4e701",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-RBlAxm/Erdos940Problem.lean",
+      "problem_id": "recovered-1ea90774",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "2 sorries remaining"
+    },
+    {
+      "project_id": "eb04abce-a4b1-4b4a-9c70-62571d6aaaec",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-FzUo0N/Erdos719Problem.lean",
+      "problem_id": "recovered-eb04abce",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "2 sorries remaining"
+    },
+    {
+      "project_id": "0bc31afa-1e8d-42a9-9fd5-baa52cf83103",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-xKu2BN/Erdos603Problem.lean",
+      "problem_id": "recovered-0bc31afa",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "2 sorries remaining"
+    },
+    {
+      "project_id": "06b63cd1-9d93-4c3a-8ba6-fdb39ac74509",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-cjs4na/Erdos1142Problem.lean",
+      "problem_id": "recovered-06b63cd1",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "6 sorries remaining"
+    },
+    {
+      "project_id": "c2590e9d-f542-4397-817a-311c1672bcf5",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-sDlyBd/Erdos740Problem.lean",
+      "problem_id": "recovered-c2590e9d",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "1 sorries remaining"
+    },
+    {
+      "project_id": "acef3835-c00b-4339-a35f-31af2d6d5314",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-4cOdbJ/Erdos225Problem.lean",
+      "problem_id": "recovered-acef3835",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "1 sorries remaining"
+    },
+    {
+      "project_id": "41a721ce-ebcc-4edc-8dd0-25431b4a4636",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-6StfY3/Erdos910Problem.lean",
+      "problem_id": "recovered-41a721ce",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "2 sorries remaining"
+    },
+    {
+      "project_id": "d0d10bcb-6b22-43fa-9fb5-2d84908e0b14",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-rm0vz4/Erdos57Problem.lean",
+      "problem_id": "recovered-d0d10bcb",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "2 sorries remaining"
+    },
+    {
+      "project_id": "04f973e4-166c-4e0e-8bea-50ba161daf1e",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-xdXGaM/Erdos538Problem.lean",
+      "problem_id": "recovered-04f973e4",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "4 sorries remaining"
+    },
+    {
+      "project_id": "436eea33-8dab-4b5d-8c5e-e2b34531303c",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-9NFpdJ/Erdos202Problem.lean",
+      "problem_id": "recovered-436eea33",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "4 sorries remaining"
+    },
+    {
+      "project_id": "6fa5244b-cf9b-4190-8091-0e7a7b08797c",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-H2eszk/Erdos171Problem.lean",
+      "problem_id": "recovered-6fa5244b",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "2 sorries remaining"
+    },
+    {
+      "project_id": "d19d476c-6695-4f8a-be92-c5e0a57c4d3c",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-5hxuAJ/Erdos1161Problem.lean",
+      "problem_id": "recovered-d19d476c",
+      "submitted": "unknown",
+      "status": "integrated",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "3 sorries remaining"
+    },
+    {
+      "project_id": "51735abf-2927-4e41-8576-9743999ec4cd",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-j9Bwvh/Erdos647Problem.lean",
+      "problem_id": "recovered-51735abf",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "1 sorries remaining"
+    },
+    {
+      "project_id": "beb90ce2-e986-4529-8d32-865d74e2f1e3",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-l9rILH/Erdos1144Problem.lean",
+      "problem_id": "recovered-beb90ce2",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "0\n0 sorries remaining"
+    },
+    {
+      "project_id": "d9bf682d-f8e6-4dae-8be5-f9c1eea654a7",
+      "file": "/var/folders/0h/l9gwswj97wb82mh27zyw305r0000gn/T/aristotle-preprocess-ZUbtyl/Erdos1176Problem.lean",
+      "problem_id": "recovered-d9bf682d",
+      "submitted": "unknown",
+      "status": "completed",
+      "notes": "Re-adopted COMPLETE project during reconciliation at 2026-02-23T17:42:50Z",
+      "outcome": "5 sorries remaining"
     }
   ],
   "completed": [],

--- a/scripts/aristotle/find-candidates.sh
+++ b/scripts/aristotle/find-candidates.sh
@@ -3,10 +3,20 @@
 # find-candidates.sh - Find Lean files suitable for Aristotle submission
 #
 # Usage:
-#   ./find-candidates.sh              # List all candidates
+#   ./find-candidates.sh              # List all candidates (both tiers)
 #   ./find-candidates.sh --count      # Just count candidates
 #   ./find-candidates.sh --best N     # Top N candidates (fewest sorries)
 #   ./find-candidates.sh --json       # Output as JSON
+#   ./find-candidates.sh --tier1-only # Return only companion files (Tier 1)
+#
+# Two-tier candidate system:
+#   Tier 1 (preferred): *Aristotle.lean companion files
+#     - Purpose-built for Aristotle: only routine lemma sorries, no axioms
+#     - Created by Researchers alongside main proof files
+#     - Score = theorem_sorries only (no axiom penalty)
+#   Tier 2 (fallback): *Problem.lean and other existing files
+#     - Regular proof files submitted when no Tier 1 slots available
+#     - Score = theorem_sorries only
 #
 # Candidates are files that:
 #   - Have theorem/lemma sorries (something to prove)
@@ -26,12 +36,14 @@ JOBS_FILE="$PROJECT_ROOT/research/aristotle-jobs.json"
 COUNT_ONLY=false
 BEST_N=0
 JSON_OUTPUT=false
+TIER1_ONLY=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         --count) COUNT_ONLY=true; shift ;;
         --best) BEST_N="$2"; shift 2 ;;
         --json) JSON_OUTPUT=true; shift ;;
+        --tier1-only) TIER1_ONLY=true; shift ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
 done
@@ -91,8 +103,10 @@ get_blocked_files() {
 }
 
 # Analyze a single file. Returns score -1 for hard rejects.
+# Args: file, tier (1 or 2)
 analyze_file() {
     local file="$1"
+    local tier="${2:-2}"
     local basename=$(basename "$file" .lean)
 
     # Count different types of sorries
@@ -102,7 +116,7 @@ analyze_file() {
 
     # Hard reject: files with definition sorries
     if [[ "$def_sorry" -gt 0 ]]; then
-        echo "$basename|$total_sorry|$def_sorry|$axiom_count|0|-1"
+        echo "$basename|$total_sorry|$def_sorry|$axiom_count|0|-1|$tier"
         return
     fi
 
@@ -112,7 +126,7 @@ analyze_file() {
 
     # Hard reject: all theorem sorries are True placeholders
     if [[ "$thm_sorry_count" -gt 0 && "$thm_sorry_count" -eq "$true_thm_count" ]]; then
-        echo "$basename|$total_sorry|$def_sorry|$axiom_count|0|-1"
+        echo "$basename|$total_sorry|$def_sorry|$axiom_count|0|-1|$tier"
         return
     fi
 
@@ -120,24 +134,23 @@ analyze_file() {
     local thm_sorry=$((total_sorry - def_sorry))
 
     # Score: lower is better
-    # - Axioms get small penalty (auto-converted by preprocessing now, but still slightly harder)
-    # - Fewer sorries = easier to prove
-    local score=$((thm_sorry + axiom_count * 2))
+    # Axiom penalty removed — axioms are background facts, not obstacles.
+    # Companion files explicitly shouldn't have axioms; regular files are scored
+    # purely on theorem sorry count.
+    local score="$thm_sorry"
 
-    echo "$basename|$total_sorry|$def_sorry|$axiom_count|$thm_sorry|$score"
+    echo "$basename|$total_sorry|$def_sorry|$axiom_count|$thm_sorry|$score|$tier"
 }
 
-# Main logic
-main() {
-    local submitted_files
-    submitted_files=$(get_submitted_files)
+# Collect candidates from a set of files
+collect_candidates() {
+    local tier="$1"
+    local submitted_files="$2"
+    local blocked_files="$3"
+    shift 3
+    local files=("$@")
 
-    local blocked_files
-    blocked_files=$(get_blocked_files)
-
-    local candidate_data=()
-
-    for file in "$PROOFS_DIR"/Erdos*Problem.lean; do
+    for file in "${files[@]}"; do
         [[ -f "$file" ]] || continue
 
         local basename=$(basename "$file" .lean)
@@ -153,7 +166,7 @@ main() {
         fi
 
         # Analyze file
-        local analysis=$(analyze_file "$file")
+        local analysis=$(analyze_file "$file" "$tier")
         local total_sorry=$(echo "$analysis" | cut -d'|' -f2)
         local score=$(echo "$analysis" | cut -d'|' -f6)
 
@@ -167,8 +180,45 @@ main() {
             continue
         fi
 
-        candidate_data+=("$analysis")
+        echo "$analysis"
     done
+}
+
+# Main logic
+main() {
+    local submitted_files
+    submitted_files=$(get_submitted_files)
+
+    local blocked_files
+    blocked_files=$(get_blocked_files)
+
+    local candidate_data=()
+
+    # Tier 1: Companion files (*Aristotle.lean)
+    local tier1_files=()
+    while IFS= read -r f; do
+        tier1_files+=("$f")
+    done < <(find "$PROOFS_DIR" -name "*Aristotle.lean" -type f 2>/dev/null | sort)
+
+    if [[ ${#tier1_files[@]} -gt 0 ]]; then
+        while IFS= read -r line; do
+            [[ -n "$line" ]] && candidate_data+=("$line")
+        done < <(collect_candidates 1 "$submitted_files" "$blocked_files" "${tier1_files[@]}")
+    fi
+
+    # Tier 2: Regular proof files (unless --tier1-only)
+    if [[ "$TIER1_ONLY" != true ]]; then
+        local tier2_files=()
+        while IFS= read -r f; do
+            tier2_files+=("$f")
+        done < <(find "$PROOFS_DIR" -name "Erdos*Problem.lean" -type f 2>/dev/null | sort)
+
+        if [[ ${#tier2_files[@]} -gt 0 ]]; then
+            while IFS= read -r line; do
+                [[ -n "$line" ]] && candidate_data+=("$line")
+            done < <(collect_candidates 2 "$submitted_files" "$blocked_files" "${tier2_files[@]}")
+        fi
+    fi
 
     if [[ ${#candidate_data[@]} -eq 0 ]]; then
         if [[ "$COUNT_ONLY" == true ]]; then
@@ -183,9 +233,10 @@ main() {
         return
     fi
 
-    # Sort by score (lower is better)
+    # Sort: Tier 1 first (by score), then Tier 2 (by score)
+    # Use stable sort: primary key = tier, secondary key = score
     local sorted_data
-    sorted_data=$(printf '%s\n' "${candidate_data[@]}" | sort -t'|' -k6 -n)
+    sorted_data=$(printf '%s\n' "${candidate_data[@]}" | sort -t'|' -k7 -n -k6 -n)
 
     if [[ "$COUNT_ONLY" == true ]]; then
         echo "$sorted_data" | wc -l | tr -d ' '
@@ -199,7 +250,7 @@ main() {
     if [[ "$JSON_OUTPUT" == true ]]; then
         echo "["
         local first=true
-        while IFS='|' read -r name total def axiom thm score; do
+        while IFS='|' read -r name total def axiom thm score tier; do
             [[ -z "$name" ]] && continue
             if [[ "$first" == true ]]; then
                 first=false
@@ -213,7 +264,9 @@ main() {
     "def_sorries": $def,
     "axioms": $axiom,
     "theorem_sorries": $thm,
-    "score": $score
+    "score": $score,
+    "tier": $tier,
+    "companion_file": $([ "$tier" -eq 1 ] && echo "true" || echo "false")
   }
 EOF
         done <<< "$sorted_data"
@@ -222,16 +275,26 @@ EOF
     else
         echo "=== Aristotle Candidates ==="
         echo ""
-        printf "%-40s %8s %8s %8s %8s\n" "File" "Sorries" "DefSorry" "Axioms" "Score"
-        printf "%-40s %8s %8s %8s %8s\n" "----" "-------" "--------" "------" "-----"
+        printf "%-40s %5s %8s %8s %8s %8s\n" "File" "Tier" "Sorries" "DefSorry" "Axioms" "Score"
+        printf "%-40s %5s %8s %8s %8s %8s\n" "----" "----" "-------" "--------" "------" "-----"
 
-        while IFS='|' read -r name total def axiom thm score; do
+        while IFS='|' read -r name total def axiom thm score tier; do
             [[ -z "$name" ]] && continue
-            printf "%-40s %8d %8d %8d %8d\n" "$name" "$total" "$def" "$axiom" "$score"
+            local tier_label
+            [[ "$tier" -eq 1 ]] && tier_label="T1" || tier_label="T2"
+            printf "%-40s %5s %8d %8d %8d %8d\n" "$name" "$tier_label" "$total" "$def" "$axiom" "$score"
         done <<< "$sorted_data"
 
+        local total_count tier1_count tier2_count
+        total_count=$(echo "$sorted_data" | grep -c '|' 2>/dev/null; true)
+        tier1_count=$(echo "$sorted_data" | grep -c '|1$' 2>/dev/null; true)
+        tier2_count=$(echo "$sorted_data" | grep -c '|2$' 2>/dev/null; true)
+        total_count="${total_count:-0}"
+        tier1_count="${tier1_count:-0}"
+        tier2_count="${tier2_count:-0}"
         echo ""
-        echo "Total candidates: $(echo "$sorted_data" | grep -c '|' || echo 0)"
+        echo "Total candidates: $total_count (T1 companion: $tier1_count, T2 regular: $tier2_count)"
+        echo "T1 companion files are preferred. T2 files are fallback when T1 slots exhausted."
         echo "Best candidates have low score (few sorries, no def sorries)"
     fi
 }

--- a/scripts/aristotle/retrieve-integrate.sh
+++ b/scripts/aristotle/retrieve-integrate.sh
@@ -29,6 +29,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
+CYAN='\033[0;36m'
 NC='\033[0m'
 
 RETRIEVE_ONLY=false
@@ -102,6 +103,7 @@ integrate_solution() {
     local project_id=$(echo "$job" | jq -r '.project_id')
     local original_file=$(echo "$job" | jq -r '.file')
     local problem_id=$(echo "$job" | jq -r '.problem_id')
+    local is_companion=$(echo "$job" | jq -r '.companion_file // false')
 
     local basename=$(basename "$original_file" .lean)
     local solution_file="$RESULTS_DIR/${basename}-solved.lean"
@@ -118,7 +120,11 @@ integrate_solution() {
         original_path="$PROJECT_ROOT/$original_file"
     fi
 
-    echo -e "${BLUE}Processing:${NC} $problem_id ($project_id)"
+    if [[ "$is_companion" == "true" ]]; then
+        echo -e "${BLUE}Processing [companion]:${NC} $problem_id ($project_id)"
+    else
+        echo -e "${BLUE}Processing:${NC} $problem_id ($project_id)"
+    fi
 
     # Retrieve solution
     if [[ "$DRY_RUN" == true ]]; then
@@ -172,11 +178,20 @@ integrate_solution() {
 
                 echo -e "  ${GREEN}Integrated${NC}"
 
+                # For companion files, remind Researcher to incorporate into main proof
+                if [[ "$is_companion" == "true" ]]; then
+                    local main_file="${basename/Aristotle/Problem}"
+                    echo -e "  ${CYAN}[Companion file]${NC} Proved lemmas available in ${basename}.lean"
+                    echo -e "  ${CYAN}→ Researcher should incorporate into ${main_file}.lean${NC}"
+                fi
+
                 # Move to processed
                 mv "$solution_file" "$PROCESSED_DIR/"
 
                 # Update job status
-                update_job_status "$project_id" "integrated" "$new_sorries sorries remaining"
+                local outcome_note="$new_sorries sorries remaining"
+                [[ "$is_companion" == "true" ]] && outcome_note="$new_sorries sorries remaining (companion file — merge into ${basename/Aristotle/Problem}.lean)"
+                update_job_status "$project_id" "integrated" "$outcome_note"
 
                 # Create completion signal for daemon stats tracking
                 local completions_dir="$PROJECT_ROOT/.loom/signals/completions"

--- a/scripts/aristotle/submit-batch.sh
+++ b/scripts/aristotle/submit-batch.sh
@@ -12,6 +12,9 @@
 #   ARISTOTLE_API_KEY - Required for submission
 #   ARISTOTLE_TARGET  - Target number of active jobs (default 10)
 #
+# Submission order: Tier 1 companion files (*Aristotle.lean) first,
+# then Tier 2 regular files (*Problem.lean) to fill remaining slots.
+#
 
 set -euo pipefail
 
@@ -47,6 +50,9 @@ while [[ $# -gt 0 ]]; do
             echo "  --count N    Submit exactly N files"
             echo "  --target N   Maintain N active jobs (default: 10)"
             echo "  --dry-run    Show what would be submitted"
+            echo ""
+            echo "Submission order: Tier 1 companion files (*Aristotle.lean) first,"
+            echo "then Tier 2 regular files (*Problem.lean) to fill remaining slots."
             exit 0
             ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
@@ -156,9 +162,16 @@ check_server_capacity() {
 # Returns: 0=success, 1=error, 2=rate-limited (caller should stop submitting), 3=rejected by preprocessing
 submit_file() {
     local file="$1"
-    local problem_id=$(basename "$file" .lean | sed 's/Problem$//' | tr '[:upper:]' '[:lower:]' | sed 's/erdos/erdos-/')
+    local problem_id=$(basename "$file" .lean | sed 's/Problem$//' | sed 's/Aristotle$//' | tr '[:upper:]' '[:lower:]' | sed 's/erdos/erdos-/')
 
-    echo -e "${BLUE}Submitting:${NC} $file"
+    local is_companion=false
+    [[ "$file" == *Aristotle.lean ]] && is_companion=true
+
+    if [[ "$is_companion" == true ]]; then
+        echo -e "${BLUE}Submitting [T1 companion]:${NC} $file"
+    else
+        echo -e "${BLUE}Submitting [T2 regular]:${NC} $file"
+    fi
 
     # Preprocess the file (fix docstrings, reject unsuitable files)
     local preprocess_log=""
@@ -227,6 +240,8 @@ submit_file() {
     local tmp_file=$(mktemp)
     local preprocessed_flag="false"
     [[ -n "$preprocess_log" ]] && preprocessed_flag="true"
+    local companion_flag="false"
+    [[ "$is_companion" == true ]] && companion_flag="true"
 
     jq --arg pid "$project_id" \
        --arg file "$file" \
@@ -234,6 +249,7 @@ submit_file() {
        --arg now "$now" \
        --argjson preprocessed "$preprocessed_flag" \
        --arg preprocess_log "${preprocess_log:-}" \
+       --argjson companion "$companion_flag" \
        '.jobs += [{
          project_id: $pid,
          file: $file,
@@ -242,7 +258,8 @@ submit_file() {
          status: "submitted",
          preprocessed: $preprocessed,
          preprocessing_log: (if $preprocess_log != "" then $preprocess_log else null end),
-         notes: "Batch submission"
+         companion_file: $companion,
+         notes: (if $companion then "Companion file submission (T1)" else "Batch submission (T2)" end)
        }]' "$JOBS_FILE" > "$tmp_file" && mv "$tmp_file" "$JOBS_FILE"
 
     # Create completion signal for daemon stats tracking
@@ -304,7 +321,8 @@ main() {
     echo "Will submit: $to_submit files"
     echo ""
 
-    # Get best candidates
+    # Get best candidates — two-tier system:
+    # Tier 1 (companion *Aristotle.lean files) come first, then Tier 2 (regular files)
     local candidates
     candidates=$("$FIND_CANDIDATES" --json --best "$to_submit" 2>/dev/null)
 
@@ -313,7 +331,15 @@ main() {
         return 0
     fi
 
-    # Submit each candidate
+    local tier1_count
+    tier1_count=$(echo "$candidates" | jq '[.[] | select(.tier == 1)] | length')
+    local tier2_count
+    tier2_count=$(echo "$candidates" | jq '[.[] | select(.tier == 2)] | length')
+
+    echo "Candidates: $tier1_count Tier 1 companion files + $tier2_count Tier 2 regular files"
+    echo ""
+
+    # Submit each candidate (already sorted: T1 first, then T2)
     local submitted=0
     local failed=0
     local skipped=0


### PR DESCRIPTION
## Summary

- Introduces `*Aristotle.lean` companion files as the preferred Aristotle submission target — purpose-built files containing only routine supporting lemmas (not open conjectures), with no axioms
- Adds two-tier submission system: T1 companion files always submitted before T2 regular `*Problem.lean` files
- Removes broken axiom penalty from scoring formula (score = theorem_sorries only)
- Fixes TARGET_ACTIVE 20→5 in aristotle-agent.md (server hard limit is 5)

## Changes

| File | Change |
|------|--------|
| `scripts/aristotle/find-candidates.sh` | Two-tier system, `--tier1-only` flag, tier/companion_file in JSON, fixed scoring |
| `scripts/aristotle/submit-batch.sh` | T1/T2 labels, `companion_file` in job records, correct problem_id for Aristotle files |
| `scripts/aristotle/retrieve-integrate.sh` | Companion file detection, merge-reminder log message |
| `.lean/roles/aristotle-agent.md` | Fix target 20→5, document two-tier priority |
| `.lean/roles/researcher.md` | Add companion file creation step with template |
| `research/SORRY-CLASSIFICATION.md` | Replace `-provable.lean` with `*Aristotle.lean` convention |
| `CLAUDE.md` | Document companion file convention, template, updated workflow |

## Test plan

- [x] `find-candidates.sh --tier1-only` returns only `*Aristotle.lean` files
- [x] `find-candidates.sh --json --best 5` shows T1 files first with `companion_file: true`
- [x] `submit-batch.sh --dry-run` labels T1 submissions as `[T1 companion]`
- [x] Scoring verified: axiom-heavy T2 files now score by theorem_sorry count only
- [ ] End-to-end: submit a companion file, verify `companion_file: true` in jobs.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)