### PR TITLE
Enrich 2 proof entries: binomial-theorem-oq-02 and euler-polyhedral-formula-oq-01

### DIFF
--- a/src/data/proofs/basel-problem-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-01/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "ann-zeta-imports",
+    "proofId": "basel-problem-oq-01",
+    "range": { "startLine": 37, "endLine": 46 },
+    "type": "context",
+    "title": "Mathlib Imports for Series and Number Theory",
+    "content": "The file imports six Mathlib modules. `Mathlib.Analysis.PSeries` provides `Real.summable_nat_rpow_inv` (the p-series criterion: ∑ 1/n^p converges iff p > 1). `Mathlib.NumberTheory.ZetaValues` provides `hasSum_zeta_two` (ζ(2) = π²/6) and `hasSum_zeta_four` (ζ(4) = π⁴/90) — these are used as upper bounds for ζ(5). `Mathlib.Topology.Algebra.InfiniteSum.Basic` supplies `hasSum_ite_eq` (the indicator function has sum equal to the pointed value). `Mathlib.Topology.Algebra.InfiniteSum.Order` provides `hasSum_le` (comparison of infinite sums). `Mathlib.NumberTheory.Real.Irrational` gives the `Irrational` predicate used in the Apéry/Rivoal/Zudilin axioms.",
+    "mathContext": "The p-series criterion: $\\sum_{n=1}^\\infty \\frac{1}{n^p}$ converges if and only if $p > 1$. For $p=5$: summable. Note that in Lean, $\\sum' n : \\mathbb{N}, 1/n^5$ includes the $n=0$ term, which is $0$ by Lean's division-by-zero convention, so this equals $\\sum_{n=1}^\\infty 1/n^5 = \\zeta(5)$.",
+    "significance": "context",
+    "relatedConcepts": ["p-series", "Irrational predicate", "hasSum", "tsum notation"],
+    "prerequisites": ["Lean 4 infinite sums (tsum)", "p-series convergence", "Riemann zeta function"]
+  },
+  {
+    "id": "ann-zeta-def-convergence",
+    "proofId": "basel-problem-oq-01",
+    "range": { "startLine": 52, "endLine": 64 },
+    "type": "definition",
+    "title": "zetaFive: Definition and Summability via P-Series",
+    "content": "The `zetaFive` definition uses `∑' n : ℕ, 1 / n^5` (Lean's `tsum` notation for unconditional convergence in complete topological groups). The `noncomputable` keyword is needed because real number computations are not computable in Lean's type theory. The summability proof `summable_one_div_pow_five` applies `Real.summable_nat_rpow_inv` (which proves summability for `rpow` form, i.e. $n^{-p}$ with $p > 1$) and then uses `convert` to bridge the difference between the `rpow` and natural number `HPow.hPow` forms. The `term_nonneg` lemma proves $1/n^5 \\geq 0$ using the `positivity` tactic.",
+    "mathContext": "The Dirichlet series $\\zeta(s) = \\sum_{n=1}^\\infty n^{-s}$ converges absolutely for $\\text{Re}(s) > 1$. For $s=5$: $\\zeta(5) = 1 + \\frac{1}{32} + \\frac{1}{243} + \\cdots \\approx 1.0369$. The p-series criterion is a special case of the integral test: $\\sum 1/n^p$ converges iff $\\int_1^\\infty 1/x^p dx < \\infty$ iff $p > 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["noncomputable definition", "tsum vs sum", "rpow vs pow", "positivity tactic"],
+    "prerequisites": ["Lean 4 tsum notation", "Real.summable_nat_rpow_inv", "type conversion in Lean"]
+  },
+  {
+    "id": "ann-lower-bound",
+    "proofId": "basel-problem-oq-01",
+    "range": { "startLine": 70, "endLine": 84 },
+    "type": "technique",
+    "title": "Lower Bound ζ(5) ≥ 1 via Indicator Function Trick",
+    "content": "The theorem `zetaFive_ge_one` proves $\\zeta(5) \\geq 1$ using a non-obvious Mathlib API pattern. The natural approach would be to use `sum_le_tsum` (extract the $n=1$ term), but this lemma is not available for ℝ in Mathlib v4.26.0 (only for `ENNReal`). Instead, the proof uses `hasSum_ite_eq (1 : ℕ) (1 : ℝ)` which shows that the sum of the indicator function at 1 equals 1. Then `hasSum_le` compares termwise: at $n=1$, the actual term $1/1^5 = 1$ matches the indicator; for all other $n$, the actual term is nonneg while the indicator is 0. This is a key Mathlib idiom for lower-bounding infinite sums in ℝ when `sum_le_tsum` is unavailable.",
+    "mathContext": "Indicator function approach: $\\sum_{n=0}^\\infty \\mathbf{1}_{\\{1\\}}(n) = 1$. Comparing termwise: $1/n^5 \\geq \\mathbf{1}_{\\{1\\}}(n)$ for all $n$ (equals 1 at $n=1$, otherwise 0 vs nonneg). By `hasSum_le`: $1 \\leq \\zeta(5)$. The key insight: work with HasSum structures directly for comparison arguments in ℝ.",
+    "significance": "key",
+    "relatedConcepts": ["hasSum_ite_eq", "hasSum_le", "indicator function", "lower bound for tsum"],
+    "prerequisites": ["hasSum vs tsum in Mathlib", "Lean 4 split_ifs tactic", "indicator function idiom"]
+  },
+  {
+    "id": "ann-upper-bounds",
+    "proofId": "basel-problem-oq-01",
+    "range": { "startLine": 86, "endLine": 133 },
+    "type": "technique",
+    "title": "Upper Bounds via Term-by-Term Comparison with ζ(4) and ζ(2)",
+    "content": "The upper bounds use `hasSum_le` with the known sums $\\zeta(4) = \\pi^4/90$ and $\\zeta(2) = \\pi^2/6$. The key lemma `pow_succ_le_of_ge_one` proves $n^k \\leq n^{k+1}$ for $n \\geq 1$ by multiplying both sides of $n^k \\geq 0$ by $n \\geq 1$. This lemma is applied repeatedly: $1/n^5 \\leq 1/n^4$ follows from $n^4 \\leq n^5$ via `one_div_le_one_div_of_le`; for the weaker bound the chain $n^2 \\leq n^3 \\leq n^4 \\leq n^5$ gives $1/n^5 \\leq 1/n^2$. The $n=0$ case is handled separately since both the $n^k$ and denominator expressions equal 0 by Lean's convention.",
+    "mathContext": "Term-by-term comparison: for $n \\geq 1$, $1/n^5 \\leq 1/n^4$ (since $n^4 \\leq n^5$). Thus $\\zeta(5) \\leq \\zeta(4) = \\pi^4/90 \\approx 1.0823$. Similarly $\\zeta(5) \\leq \\zeta(2) = \\pi^2/6 \\approx 1.6449$. The actual value $\\zeta(5) \\approx 1.0369$ is much closer to $\\zeta(4)$ than to $\\zeta(2)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["hasSum_zeta_four", "hasSum_zeta_two", "one_div_le_one_div_of_le", "comparison test"],
+    "prerequisites": ["hasSum_le for upper bounds", "Mathlib ZetaValues module", "pow monotonicity"]
+  },
+  {
+    "id": "ann-open-conjecture",
+    "proofId": "basel-problem-oq-01",
+    "range": { "startLine": 135, "endLine": 151 },
+    "type": "concept",
+    "title": "The Open Conjecture: ζ(5) Irrational (sorry — genuine open problem)",
+    "content": "The theorem `zeta_five_irrational` formally states the open conjecture `Irrational zetaFive` with a `sorry` proof — representing genuine mathematical ignorance, not a gap in formalization. The `Irrational x` predicate in Mathlib means $x$ cannot be written as a ratio of integers. Apéry's 1978 proof of $\\zeta(3)$ irrationality used a specific hypergeometric series whose denominators (when cleared of factors of $n^3$) grow slowly enough to violate the rationality criterion. No analogous series is known for $\\zeta(5)$. The value $\\zeta(5) \\approx 1.0369$ is extremely close to 1, making it particularly difficult to distinguish from simple fractions numerically.",
+    "mathContext": "Irrationality criterion (Legendre): $x \\in \\mathbb{R}$ is irrational if $\\exists$ infinitely many $p/q \\in \\mathbb{Q}$ with $|x - p/q| < 1/q^2$. Apéry proved $\\zeta(3)$ irrational by finding rationals $p_n/q_n$ with $|\\zeta(3) - p_n/q_n| < q_n^{-\\mu}$ ($\\mu > 1$) where the $q_n$ grow like $(1+\\sqrt{2})^{4n}$ — fast but controlled. For $\\zeta(5)$, no such approximation sequence is known.",
+    "significance": "key",
+    "relatedConcepts": ["Irrational predicate", "Apéry's method", "sorry in Lean", "hypergeometric series"],
+    "prerequisites": ["Irrational predicate in Mathlib", "Apéry's theorem", "irrationality criteria"]
+  },
+  {
+    "id": "ann-axiomatized-theorems",
+    "proofId": "basel-problem-oq-01",
+    "range": { "startLine": 152, "endLine": 186 },
+    "type": "insight",
+    "title": "Axiomatized Landmark Theorems: Apéry, Rivoal, Zudilin",
+    "content": "Three landmark theorems are axiomatized here, since their proofs require sophisticated methods not yet in Mathlib. `apery_theorem` states $\\zeta(3)$ is irrational — Apéry's 1978 result that shocked the mathematical community. `rivoal_theorem` formalizes the set $\\{k : \\mathbb{N} \\mid \\text{Irr}(\\zeta(2k+1))\\}$ as infinite (using `Set.Infinite`). `zudilin_theorem` is the disjunctive statement that at least one of $\\zeta(5), \\zeta(7), \\zeta(9), \\zeta(11)$ is irrational, encoded as a four-way `∨`. The `axiom` keyword in Lean 4 allows postulating propositions without proof — appropriate here for theorems whose proofs require Padé approximants and hypergeometric identities beyond current Mathlib scope.",
+    "mathContext": "Rivoal (2000): $|\\{k \\leq n : \\zeta(2k+1) \\notin \\mathbb{Q}\\}| \\geq \\frac{1 + o(1)}{2} \\log(2n+1)$. So asymptotically half of all odd zeta values are irrational. Zudilin (2001) improved to: at least one of $\\{\\zeta(5), \\zeta(7), \\zeta(9), \\zeta(11)\\}$ is irrational. Both proofs use linear independence criteria for hypergeometric series evaluated at rational points.",
+    "significance": "key",
+    "relatedConcepts": ["Lean 4 axiom declaration", "Set.Infinite", "Apéry's theorem", "Rivoal 2000", "Zudilin 2001"],
+    "prerequisites": ["Lean 4 axiom keyword", "Set.Infinite in Mathlib", "Padé approximants"]
+  },
+  {
+    "id": "ann-consequences",
+    "proofId": "basel-problem-oq-01",
+    "range": { "startLine": 191, "endLine": 222 },
+    "type": "technique",
+    "title": "Consequences: Formal Witnesses and Non-Rationality Results",
+    "content": "The consequences section derives useful results from the axiomatized theorems using standard Lean 4 tactics. `exists_irrational_odd_zeta` uses `Set.Infinite.nonempty` to extract an element from Rivoal's infinite set. `not_all_of_four_rational` uses `rcases zudilin_theorem with h | h | h | h` to case-split on the four-way disjunction and apply each component of the negation hypothesis to reach a contradiction. `zudilin_witness` constructs an explicit existential: it matches on each case of `zudilin_theorem` and pairs the irrational value with its membership in `{5, 7, 9, 11}`, using `by decide` for the membership proofs.",
+    "mathContext": "From `zudilin_theorem`: $\\text{Irr}(\\zeta(5)) \\vee \\text{Irr}(\\zeta(7)) \\vee \\text{Irr}(\\zeta(9)) \\vee \\text{Irr}(\\zeta(11))$. The negation $\\neg(\\text{Irr}(\\zeta(5))) \\wedge \\neg(\\text{Irr}(\\zeta(7))) \\wedge \\neg(\\text{Irr}(\\zeta(9))) \\wedge \\neg(\\text{Irr}(\\zeta(11)))$ combined with the disjunction gives a contradiction via modus tollens applied four times.",
+    "significance": "supporting",
+    "relatedConcepts": ["Set.Infinite.nonempty", "rcases on disjunctions", "by decide for Finset"],
+    "prerequisites": ["Lean 4 rcases tactic", "Set.Infinite API in Mathlib", "Finset membership decidability"]
+  },
+  {
+    "id": "ann-research-summary",
+    "proofId": "basel-problem-oq-01",
+    "range": { "startLine": 228, "endLine": 243 },
+    "type": "insight",
+    "title": "Summary Theorem: Complete Formal Knowledge About ζ(5)",
+    "content": "The `zetaFive_research_summary` theorem bundles the five proved properties into a single conjunction: summability, positivity, lower bound $\\geq 1$, and two upper bounds. The proof is the tuple `⟨summable_one_div_pow_five, zetaFive_pos, zetaFive_ge_one, zetaFive_le_zeta_four, zetaFive_le_zeta_two⟩`. This serves as a 'checkpoint theorem' documenting the complete state of formal knowledge: everything that can be proved about $\\zeta(5)$ without resolving the irrationality conjecture is captured here. The single remaining sorry (`zeta_five_irrational`) represents the entire open question.",
+    "mathContext": "Complete formal knowledge: $\\zeta(5) \\in [1, \\pi^4/90]$ where $\\pi^4/90 \\approx 1.0823$. True value: $\\zeta(5) = \\sum_{n=1}^\\infty n^{-5} = 1 + 1/32 + 1/243 + 1/1024 + \\cdots \\approx 1.0369$. The gap between the proved bounds and the open question: irrationality of $\\zeta(5)$ requires a fundamentally new technique beyond current mathematics, not merely more careful Lean formalization.",
+    "significance": "supporting",
+    "relatedConcepts": ["conjunction introduction", "summary theorems in Lean", "open problem formalization"],
+    "prerequisites": ["conjunction and And.intro in Lean 4", "Irrational vs transcendental distinction"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02/annotations.json
@@ -1,1 +1,122 @@
-[]
+[
+  {
+    "id": "ann-imports",
+    "proofId": "binomial-theorem-oq-02",
+    "range": { "startLine": 1, "endLine": 4 },
+    "type": "context",
+    "title": "Mathlib Imports: Multinomial and Binomial Infrastructure",
+    "content": "The file requires four Mathlib modules. `Mathlib.Data.Nat.Choose.Multinomial` provides the core multinomial coefficient theory, including `Nat.multinomial`, `Nat.multinomial_insert`, `Nat.binomial_eq_choose`, and the central `Finset.sum_pow_eq_sum_piAntidiag`. `Mathlib.Data.Nat.Choose.Sum` supplies `add_pow` (the classical binomial theorem) and `Nat.sum_range_choose`. `Mathlib.Algebra.BigOperators.Ring.Finset` enables the Σ/∏ notation over finite sets. `Mathlib.Tactic` provides the full Lean 4 tactic library for the ring, simp, and decide tactics used in the proofs.",
+    "mathContext": "The key dependency chain: $\\text{Finset.sum\\_pow\\_eq\\_sum\\_piAntidiag}$ proves $(\\sum_{i \\in s} f(i))^n = \\sum_{k \\in s.\\text{piAntidiag}(n)} \\text{multinomial}(s,k) \\cdot \\prod_i f(i)^{k(i)}$, which is the multinomial theorem in Lean's universe-polymorphic form.",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib", "piAntidiag", "BigOperators", "CommSemiring"],
+    "prerequisites": ["Lean 4 import system", "Mathlib library structure", "type class hierarchy"]
+  },
+  {
+    "id": "ann-module-doc",
+    "proofId": "binomial-theorem-oq-02",
+    "range": { "startLine": 6, "endLine": 50 },
+    "type": "concept",
+    "title": "Module Documentation: Proof Strategy for the Multinomial Theorem",
+    "content": "The module docstring establishes the mathematical context and outlines the inductive proof strategy. The binomial theorem (2-variable case) drives the multinomial proof at each inductive step: when expanding $(\\sum_{\\{a\\} \\cup s} f)^n = (f(a) + \\sum_s f)^n$, applying the binomial theorem yields a sum over $j$ from 0 to $n$ of $\\binom{n}{j}(f(a))^j (\\sum_s f)^{n-j}$. The induction hypothesis then handles each $(\\sum_s f)^{n-j}$ term, and the multinomial recurrence assembles the result. This is exactly how multinomial coefficients are defined recursively via binomial coefficients.",
+    "mathContext": "The inductive step: $(f(a) + \\sum_s f)^n = \\sum_{j=0}^n \\binom{n}{j} f(a)^j \\left(\\sum_s f\\right)^{n-j}$, then by IH $= \\sum_{j=0}^n \\binom{n}{j} f(a)^j \\sum_{k' \\in s.\\text{piAntidiag}(n-j)} \\text{multinomial}(s,k') \\prod_{s} f^{k'}$, assembled via $\\text{multinomial}(\\{a\\} \\cup s, k) = \\binom{k(a)+\\sum_s k}{k(a)} \\cdot \\text{multinomial}(s,k)$.",
+    "significance": "key",
+    "relatedConcepts": ["induction on finset size", "multinomial recurrence", "Pascal's identity", "combinatorial proof"],
+    "prerequisites": ["binomial theorem", "induction principle", "finset operations in Lean"]
+  },
+  {
+    "id": "ann-multinomial-theorem",
+    "proofId": "binomial-theorem-oq-02",
+    "range": { "startLine": 58, "endLine": 69 },
+    "type": "technique",
+    "title": "multinomial_theorem: Direct Wrapper Around Mathlib's Core Result",
+    "content": "The theorem `multinomial_theorem` is a thin wrapper around Mathlib's `Finset.sum_pow_eq_sum_piAntidiag`. The statement is fully universe-polymorphic: it works for any `DecidableEq` type `α`, any `CommSemiring R`, any finite set `s : Finset α`, any function `f : α → R`, and any `n : ℕ`. The proof is a one-liner (`exact Finset.sum_pow_eq_sum_piAntidiag s f n`), showing this is really a naming and documentation exercise — we are surfacing a major Mathlib theorem with a clear name and docstring. The `piAntidiag n` notation denotes the finset of all functions `k : α → ℕ` with support in `s` summing to `n`.",
+    "mathContext": "$(\\sum_{i \\in s} f(i))^n = \\sum_{\\substack{k : \\alpha \\to \\mathbb{N} \\\\ \\text{supp}(k) \\subseteq s,\\; \\sum_{i \\in s} k(i) = n}} \\binom{n}{k_1, k_2, \\ldots} \\prod_{i \\in s} f(i)^{k(i)}$ where $\\binom{n}{k_1,\\ldots,k_m} = \\frac{n!}{k_1! \\cdots k_m!}$.",
+    "significance": "key",
+    "relatedConcepts": ["piAntidiag", "CommSemiring", "finset power", "multinomial coefficient"],
+    "prerequisites": ["finset theory in Mathlib", "bigoperators notation", "semiring axioms"]
+  },
+  {
+    "id": "ann-multinomial-recurrence",
+    "proofId": "binomial-theorem-oq-02",
+    "range": { "startLine": 79, "endLine": 88 },
+    "type": "insight",
+    "title": "Multinomial Recurrence: The Binomial–Multinomial Bridge",
+    "content": "The theorem `multinomial_recurrence` expresses how multinomial coefficients build from binomial coefficients inductively. When we add one new element `a` to a set `s`, the multinomial coefficient factors as a binomial coefficient times the multinomial for the remaining set. This is analogous to Pascal's identity $\\binom{n+1}{k} = \\binom{n}{k} + \\binom{n}{k-1}$ but in the 'column-wise' direction: it shows how to compute the whole Pascal-like triangle from its lower-dimensional faces. The Lean proof is again a one-liner delegating to `Nat.multinomial_insert`.",
+    "mathContext": "For $a \\notin s$: $\\text{multinomial}(\\{a\\} \\cup s, k) = \\binom{k(a) + \\sum_{i \\in s} k(i)}{k(a)} \\cdot \\text{multinomial}(s, k)$. Compare Pascal: $\\binom{n}{k} = \\binom{n-1}{k-1} + \\binom{n-1}{k}$. The multinomial analogue iterates this splitting across all variables.",
+    "significance": "key",
+    "relatedConcepts": ["Pascal's identity", "binomial coefficient recurrence", "Finset.insert", "inductive definition"],
+    "prerequisites": ["binomial coefficients", "multinomial coefficients", "finset membership in Lean"]
+  },
+  {
+    "id": "ann-multinomial-eq-binomial",
+    "proofId": "binomial-theorem-oq-02",
+    "range": { "startLine": 90, "endLine": 98 },
+    "type": "insight",
+    "title": "Multinomial = Binomial: The 2-Variable Special Case",
+    "content": "The theorem `multinomial_eq_binomial` proves the precise algebraic equality between multinomial and binomial coefficients for 2-element sets. For `s = {a, b}` with `a ≠ b`, the multinomial coefficient `Nat.multinomial {a,b} k` equals `Nat.choose (f a + f b) (f a)`, i.e., $\\binom{f(a)+f(b)}{f(a)}$. This is the crucial bridge: it shows that the multinomial theorem with 2 variables is literally the same formula as the binomial theorem. One can view the binomial coefficient $\\binom{n}{k}$ as the multinomial coefficient $\\binom{n}{k, n-k}$ where the two 'slots' sum to $n$.",
+    "mathContext": "For $a \\neq b$: $\\text{multinomial}(\\{a,b\\}, k) = \\binom{k(a) + k(b)}{k(a)} = \\binom{n}{k}$ when $k(a)+k(b)=n$ and $k(a)=k$. The factorial formula $\\frac{n!}{k!(n-k)!}$ is recovered from $\\frac{(k(a)+k(b))!}{k(a)! \\cdot k(b)!}$.",
+    "significance": "key",
+    "relatedConcepts": ["binomial coefficient", "Nat.choose", "2-element finset", "choose vs multinomial"],
+    "prerequisites": ["binomial coefficient definition", "Nat.choose in Mathlib", "2-element finset operations"]
+  },
+  {
+    "id": "ann-multinomial-total",
+    "proofId": "binomial-theorem-oq-02",
+    "range": { "startLine": 107, "endLine": 116 },
+    "type": "insight",
+    "title": "Sum Identity: Total Multinomials Equal |s|^n",
+    "content": "The theorem `multinomial_total` proves that the sum of all multinomial coefficients for degree $n$ over a set of size $m$ equals $m^n$. The proof strategy is elegant: substitute $f \\equiv 1$ (the constant-1 function) into the multinomial theorem. The left side becomes $|s|^n$ (since $\\sum_{i \\in s} 1 = |s|$ and $1^n = |s|^n$). The right side simplifies because $\\prod_i f(i)^{k(i)} = \\prod_i 1 = 1$, leaving just $\\sum_k \\text{multinomial}(s,k)$. The `nsmul_eq_mul` simp lemma handles the numeric cast. This generalizes $\\sum_{k=0}^n \\binom{n}{k} = 2^n$ (the $|s|=2$ case).",
+    "mathContext": "Setting $f \\equiv 1$: $\\left(\\sum_{i \\in s} 1\\right)^n = |s|^n = \\sum_{k \\in s.\\text{piAntidiag}(n)} \\text{multinomial}(s,k) \\cdot \\prod_i 1^{k(i)} = \\sum_k \\text{multinomial}(s,k)$. For $|s|=2$: $\\sum_{k=0}^n \\binom{n}{k} = 2^n$. For $|s|=3$: $\\sum_{k_1+k_2+k_3=n} \\binom{n}{k_1,k_2,k_3} = 3^n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sum of binomial coefficients", "counting arrangements", "constant function substitution"],
+    "prerequisites": ["multinomial theorem", "finset cardinality", "nsmul vs mul in semirings"]
+  },
+  {
+    "id": "ann-bool-indexed",
+    "proofId": "binomial-theorem-oq-02",
+    "range": { "startLine": 166, "endLine": 187 },
+    "type": "technique",
+    "title": "Bool-Indexed Multinomial: Proving Multinomial Implies Binomial",
+    "content": "The theorem `multinomial_bool_form_eq_binomial` is the centrepiece of the generalization relationship. It uses `s = {false, true} : Finset Bool` and `f(b) = if b then y else x` to apply the multinomial theorem, then shows both sides equal $(x+y)^n$. The key technical trick is using `fun b => if b then y else x` (rather than `if b = false then x else y`) so that `f false = x` and `f true = y` reduce *definitionally* via `rfl`, enabling `simp` to simplify the sums and products over the 2-element Bool set. The conclusion `h.symm.trans (binomial_theorem x y n)` chains the equalities: multinomial expansion = $(x+y)^n$ = binomial expansion.",
+    "mathContext": "With $s = \\{F, T\\}$, $f(F)=x$, $f(T)=y$: multinomial theorem gives $(x+y)^n = \\sum_{k \\in \\{F,T\\}.\\text{piAntidiag}(n)} \\text{multinomial}(\\{F,T\\},k) \\cdot x^{k(F)} \\cdot y^{k(T)}$. Since $\\text{multinomial}(\\{F,T\\},k) = \\binom{k(F)+k(T)}{k(F)} = \\binom{n}{k(F)}$, summing over $k(F) \\in \\{0,\\ldots,n\\}$ recovers $\\sum_{j=0}^n \\binom{n}{j} x^j y^{n-j}$.",
+    "significance": "key",
+    "relatedConcepts": ["Bool finset", "definitional reduction", "sum_pair", "prod_pair", "trans equality"],
+    "prerequisites": ["Bool type in Lean 4", "Finset.sum_pair", "definitional equality vs propositional equality"]
+  },
+  {
+    "id": "ann-native-decide",
+    "proofId": "binomial-theorem-oq-02",
+    "range": { "startLine": 198, "endLine": 216 },
+    "type": "technique",
+    "title": "Concrete Verifications with native_decide",
+    "content": "Five concrete examples verify the multinomial coefficient formula using Lean's `native_decide` tactic, which compiles the proposition to native code and evaluates it. The examples check: $\\binom{3}{1,1,1} = 6$ (all-distinct arrangement of 3 items from 3 slots), $\\binom{4}{2,1,1} = 12$ (one slot gets 2, others 1 each), $\\binom{6}{2,2,2} = 90$ (three equal slots of 2). The sum identities $\\sum \\text{multinomial}(\\text{Fin}3, 2) = 9 = 3^2$ and $\\sum \\text{multinomial}(\\text{Fin}4, 3) = 64 = 4^3$ verify `multinomial_total` for specific small cases. `native_decide` works here because the finsets are computable and the arithmetic is decidable.",
+    "mathContext": "$\\binom{3}{1,1,1} = \\frac{3!}{1! \\cdot 1! \\cdot 1!} = 6$, $\\binom{4}{2,1,1} = \\frac{4!}{2! \\cdot 1! \\cdot 1!} = 12$, $\\binom{6}{2,2,2} = \\frac{6!}{2! \\cdot 2! \\cdot 2!} = 90$. These are the number of distinct permutations of multisets $\\{a,b,c\\}$, $\\{a,a,b,c\\}$, $\\{a,a,b,b,c,c\\}$ respectively.",
+    "significance": "supporting",
+    "relatedConcepts": ["native_decide tactic", "decidable propositions", "Fin type", "univ finset"],
+    "prerequisites": ["Lean 4 decision procedures", "Fin type", "Finset.univ", "array literal notation for Fin"]
+  },
+  {
+    "id": "ann-trinomial",
+    "proofId": "binomial-theorem-oq-02",
+    "range": { "startLine": 218, "endLine": 229 },
+    "type": "definition",
+    "title": "Trinomial Square and Cube via Ring",
+    "content": "The theorems `trinomial_square` and `trinomial_cube` give explicit polynomial expansions of $(x+y+z)^2$ and $(x+y+z)^3$ in any commutative semiring, proved by the `ring` tactic. These are instances of the multinomial theorem: the square has multinomial coefficients $1$ (for $x^2, y^2, z^2$) and $2$ (for $xy, xz, yz$), while the cube has coefficients $1$ (for $x^3, y^3, z^3$), $3$ (for $x^2y, x^2z$, etc.), and $6$ (for $xyz$). The `ring` tactic handles commutativity and associativity automatically, making these trivial once the formula is known.",
+    "mathContext": "$(x+y+z)^2 = x^2+y^2+z^2+2xy+2xz+2yz$: coefficients $\\binom{2}{2,0,0}=1$, $\\binom{2}{1,1,0}=2$. $(x+y+z)^3$: coefficients $\\binom{3}{3,0,0}=1$, $\\binom{3}{2,1,0}=3$, $\\binom{3}{1,1,1}=6$. In general, $\\binom{n}{k_1,k_2,k_3} = \\frac{n!}{k_1!k_2!k_3!}$ counts permutations of the multiset.",
+    "significance": "technical",
+    "relatedConcepts": ["ring tactic", "trinomial expansion", "commutative semiring", "polynomial identity"],
+    "prerequisites": ["ring axioms", "multinomial coefficients for small cases"]
+  },
+  {
+    "id": "ann-triple-recurrence",
+    "proofId": "binomial-theorem-oq-02",
+    "range": { "startLine": 245, "endLine": 253 },
+    "type": "technique",
+    "title": "Three-Variable Multinomial via Double Recurrence",
+    "content": "The theorem `multinomial_triple` computes the multinomial coefficient for a 3-element set `{a,b,c}` by applying `Nat.multinomial_insert` twice. First, `a ∉ {b,c}` is verified, and then `{a,b,c}` is rewritten as `insert a {b,c}`. One application of `Nat.multinomial_insert` factors the 3-variable multinomial into a binomial coefficient times a 2-variable multinomial. A second application (via `Nat.binomial_eq_choose`) reduces the 2-variable multinomial to a binomial coefficient. The result is $\\binom{f(a)+f(b)+f(c)}{f(a)} \\cdot \\binom{f(b)+f(c)}{f(b)}$, which is the standard formula for trinomial coefficients.",
+    "mathContext": "$\\text{multinomial}(\\{a,b,c\\}, k) = \\binom{k_a+k_b+k_c}{k_a} \\cdot \\binom{k_b+k_c}{k_b} = \\frac{(k_a+k_b+k_c)!}{k_a! \\cdot (k_b+k_c)!} \\cdot \\frac{(k_b+k_c)!}{k_b! \\cdot k_c!} = \\frac{n!}{k_a! k_b! k_c!}$. This telescoping product generalizes: $\\text{multinomial}(s, k) = \\prod_{i=1}^{m} \\binom{\\sum_{j \\geq i} k_j}{k_i}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["multinomial recurrence", "telescoping product", "Finset.insert", "sum_pair"],
+    "prerequisites": ["multinomial recurrence theorem", "binomial_eq_choose", "Finset membership proofs in Lean"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02/meta.json
@@ -39,7 +39,8 @@
       "**Induction drives the generalization**: The multinomial theorem proof proceeds by induction on $|s|$. The inductive step uses the binomial theorem to split $(f(a) + \\sum_s f)^n$, then the induction hypothesis applies to $(\\sum_s f)^m$ for each $m \\leq n$. The key recurrence `multinomial_recurrence` (Nat.multinomial_insert) parallels Pascal's identity for binomial coefficients",
       "**Linearity of the multinomial sum**: Setting all $f(i) = 1$ gives $|s|^n = \\sum_{k: \\Sigma k = n} \\text{multinomial}(s, k)$ — the total count of exponent distributions equals $|s|^n$. This generalizes $\\sum_{k=0}^n \\binom{n}{k} = 2^n$",
       "**The Bool-indexed form is the bridge**: The formal connection between multinomial and binomial is cleanest via $s = \\{\\text{false}, \\text{true}\\}$: `multinomial_bool_form_eq_binomial` shows the multinomial expansion over Bool equals the classical binomial sum. This is the precise statement that the multinomial theorem implies the binomial theorem",
-      "**Definitional reduction avoids Bool equality issues**: Instead of `if b = false then x else y` (which requires `true ≠ false` to evaluate symbolically), using `if b then y else x` reduces definitionally for Bool values, enabling clean `rfl`-level proofs in simp"
+      "**Definitional reduction avoids Bool equality issues**: Instead of `if b = false then x else y` (which requires `true ≠ false` to evaluate symbolically), using `if b then y else x` reduces definitionally for Bool values, enabling clean `rfl`-level proofs in simp",
+      "**Multinomial coefficients telescope to factorials**: The recurrence `multinomial(insert a s, k) = C(k(a)+Σk, k(a)) · multinomial(s, k)` applied $m$ times to reduce from $m$ variables to 0 yields a telescoping product that equals $n! / (k_1! \\cdots k_m!)$, the combinatorial formula for arrangements of a multiset. This makes the formal multinomial coefficient definition consistent with the combinatorial interpretation."
     ]
   },
   "sections": [
@@ -122,6 +123,11 @@
       "Is there a clean proof of the Vandermonde identity ∑_k C(m,k)C(n,r-k) = C(m+n,r) using multinomial coefficient identities?",
       "Can the q-multinomial theorem (quantum generalization) be formalized using Mathlib's q-analog infrastructure?",
       "Is there a direct Lean proof of the multinomial theorem by induction on |s| that avoids delegating to Finset.sum_pow_eq_sum_piAntidiag?"
+    ],
+    "crossReferences": [
+      {"id": "binomial-theorem", "relation": "specializes", "note": "The classical binomial theorem (x+y)^n = Σ C(n,k) x^k y^(n-k) is the 2-variable special case of the multinomial theorem proved here"},
+      {"id": "combinations-formula", "relation": "uses", "note": "The binomial coefficient C(n,k) = n!/(k!(n-k)!) is a special case of the multinomial coefficient n!/(k_1!···k_m!)"},
+      {"id": "pascals-hexagon", "relation": "related", "note": "Pascal's hexagon theorem connects to Pascal's triangle, whose rows are the binomial coefficients summed by the multinomial theorem"}
     ]
   }
 }

--- a/src/data/proofs/bounded-prime-gaps/annotations.json
+++ b/src/data/proofs/bounded-prime-gaps/annotations.json
@@ -1,1 +1,110 @@
-[]
+[
+  {
+    "id": "ann-admissible-def",
+    "proofId": "bounded-prime-gaps",
+    "range": { "startLine": 57, "endLine": 60 },
+    "type": "definition",
+    "title": "IsAdmissible: The Core Combinatorial Object",
+    "content": "The `IsAdmissible` predicate is the heart of the GPY/Zhang/Maynard-Tao approach to bounded prime gaps. A finite set H ⊆ ℕ is admissible if for every prime p, the residues {h mod p : h ∈ H} do not cover all of ℤ/pℤ. In Lean: `(H.image (· % p)).card < p`. This condition ensures there is no 'local obstruction' to n + H containing many primes: if H covered all residues mod p, then for every n, one element of n + H would always be divisible by p, preventing simultaneous primality. The admissibility condition is a Decidable property for any specific finite set, making it amenable to `decide` and `native_decide` verification.",
+    "mathContext": "A set $H$ is admissible $\\iff$ $\\forall p$ prime, $|\\{h \\bmod p : h \\in H\\}| < p$. Equivalently, $H$ is not a covering congruence system. The set $\\{0, 1, 2\\}$ is NOT admissible (mod 3: covers $\\{0, 1, 2\\}$). The twin prime tuple $\\{0, 2\\}$ IS admissible: mod 2 gives $\\{0\\}$ (card 1 < 2), mod $p \\geq 3$ gives at most 2 residues (card $\\leq 2 < 3 \\leq p$).",
+    "significance": "key",
+    "relatedConcepts": ["covering congruences", "admissible k-tuples", "Dickson conjecture", "GPY sieve"],
+    "prerequisites": ["Finset.image in Mathlib", "ZMod arithmetic", "prime residue classes"]
+  },
+  {
+    "id": "ann-admissible-basic",
+    "proofId": "bounded-prime-gaps",
+    "range": { "startLine": 66, "endLine": 94 },
+    "type": "technique",
+    "title": "Basic Admissibility: Empty, Singleton, Subset Properties",
+    "content": "Three foundational lemmas establish the structural properties of admissibility. `admissible_empty` is trivial: the empty set has no residues, so the image always has card 0 < p. `admissible_singleton` proves a single element is always admissible: it has exactly one residue mod any prime, and all primes are ≥ 2 > 1. `admissible_subset` uses `Finset.card_le_card (Finset.image_subset_image h)` to show that a subset's image is contained in the full image, hence has smaller cardinality. `admissible_of_card_lt_two` handles the case |H| < 2 via the chain |image(H)| ≤ |H| < 2 ≤ p.",
+    "mathContext": "The subset property is key: if $H_1 \\subseteq H_2$ and $H_2$ is admissible, then $H_1$ is admissible. Admissibility is 'anti-monotone' in set inclusion — smaller sets satisfy it more easily. Contrapositive: if $H_1$ is NOT admissible (covers all residues mod some prime), then any superset $H_2 \\supseteq H_1$ is also NOT admissible.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.card_image_le", "Finset.image_subset_image", "Nat.Prime.two_le"],
+    "prerequisites": ["Lean 4 Finset.image", "Finset.card_le_card", "prime.two_le"]
+  },
+  {
+    "id": "ann-twin-prime-admissible",
+    "proofId": "bounded-prime-gaps",
+    "range": { "startLine": 103, "endLine": 130 },
+    "type": "insight",
+    "title": "Admissibility of {0,2}: The Twin Prime Tuple",
+    "content": "The proof that {0,2} is admissible uses a three-way case split on the prime p. For p=2, the image {0 mod 2, 2 mod 2} = {0} has card 1 < 2, verified by `decide`. For p=3, the image {0, 2} has card 2 < 3, verified by `decide`. For p ≥ 5, the image has card at most 2 (since |H| = 2), which is < 5 ≤ p. The proof that p ≥ 5 from 'prime, not 2, not 3' uses `hp.eq_two_or_odd`. This pattern — handle small primes by `decide`, large primes by cardinality — is the standard technique for verifying admissibility of specific tuples throughout the file.",
+    "mathContext": "The twin prime tuple $\\{0, 2\\}$ is admissible because: mod 2, both 0 and 2 are even (only residue 0 hit). For all odd primes $p \\geq 3$, only 2 elements means at most 2 distinct residues, always fewer than $p \\geq 3$. Dickson conjecture for $\\{0, 2\\}$ would imply the twin prime conjecture: infinitely many $n$ with both $n$ and $n+2$ prime.",
+    "significance": "key",
+    "relatedConcepts": ["twin prime conjecture", "Dickson conjecture", "prime.eq_two_or_odd", "decide tactic"],
+    "prerequisites": ["Nat.Prime.two_le", "Nat.Prime.eq_two_or_odd", "Finset.card_image_le"]
+  },
+  {
+    "id": "ann-main-axioms",
+    "proofId": "bounded-prime-gaps",
+    "range": { "startLine": 215, "endLine": 236 },
+    "type": "technique",
+    "title": "Three Sieve-Theoretic Axioms: Polymath 8b, Maynard-Tao, EH",
+    "content": "Three axioms encode the deep sieve-theoretic results beyond current Mathlib scope. `polymath_bounded_gaps_246` (Polymath 8b, 2014): for every N, there exists a prime index n ≥ N with gap ≤ 246. `maynard_tao_m_tuples` (2015): for any m ≥ 2, there exists a constant C such that infinitely many intervals of length C contain m primes. `bounded_gaps_conditional_EH`: assuming the Elliott-Halberstam conjecture, the gap drops to 12. The proof of `polymath_bounded_gaps_246` from first principles would require: (1) existence of an admissible 50-tuple of diameter ≤ 246 (proved constructively), plus (2) the Maynard-Tao sieve showing such a tuple produces 2 primes in infinitely many translates — this step is the axiom.",
+    "mathContext": "The Polymath 8b proof strategy: find an admissible 50-tuple $H$ with $\\text{diam}(H) \\leq 246$. The Maynard-Tao sieve guarantees: for any admissible $k$-tuple with $k \\geq k_0$ (where $k_0 \\leq 50$ by Polymath optimization), infinitely many translates $n+H$ contain $\\geq 2$ primes. Two primes $n + h_i, n + h_j \\in n + H$ with $h_i < h_j$ are consecutive primes only if $h_j - h_i \\leq 246$, giving the bounded gap.",
+    "significance": "key",
+    "relatedConcepts": ["Maynard-Tao sieve", "Polymath 8b", "Elliott-Halberstam conjecture", "Lean 4 axiom keyword"],
+    "prerequisites": ["nthPrime and primeGap definitions", "GPY sieve theory", "Lean 4 axiom vs theorem"]
+  },
+  {
+    "id": "ann-zhang-consequences",
+    "proofId": "bounded-prime-gaps",
+    "range": { "startLine": 219, "endLine": 255 },
+    "type": "insight",
+    "title": "Zhang's 70M and Liminf: Consequences from Polymath Axiom",
+    "content": "Several consequences are derived from the Polymath axiom. `zhang_bounded_gaps_70M` follows in three lines: extract a gap ≤ 246 from the axiom, then note 246 ≤ 70000000 by `omega`. `infinitely_many_small_gaps` is just a renaming. `liminf_prime_gaps_finite` packages the result: there EXISTS H = 246 such that for every N, some n ≥ N has gap ≤ H. `bounded_intervals_k_primes` delegates directly to `maynard_tao_m_tuples`. These derivations illustrate the logical cleanness of the axiomatic approach: all consequences are purely elementary arithmetic once the sieve theory is packaged as an axiom.",
+    "mathContext": "Bound hierarchy: $12 \\leq 246 \\leq 600 \\leq 4680 \\leq 70000000$. EH $\\Rightarrow$ gap $\\leq 12$. Polymath 8b (unconditional) $\\Rightarrow$ gap $\\leq 246$. Maynard (unconditional, simpler proof) $\\Rightarrow$ gap $\\leq 600$. Polymath 8a $\\Rightarrow$ gap $\\leq 4680$. Zhang (original) $\\Rightarrow$ gap $\\leq 70000000$. In $\\liminf$ language: $\\liminf_{n \\to \\infty}(p_{n+1}-p_n) \\leq 246$.",
+    "significance": "supporting",
+    "relatedConcepts": ["omega tactic", "liminf of prime gaps", "proof by weakening"],
+    "prerequisites": ["omega arithmetic in Lean", "Filter.liminf", "existential introduction"]
+  },
+  {
+    "id": "ann-dickson-conjecture",
+    "proofId": "bounded-prime-gaps",
+    "range": { "startLine": 261, "endLine": 289 },
+    "type": "concept",
+    "title": "Dickson Conjecture: The Strong Form of Prime Constellations",
+    "content": "The `DicksonConjecture H` formalizes the strong statement: if H is admissible, then infinitely many translates n have ALL elements of n + H simultaneously prime. This is much stronger than the bounded gaps theorem (which only requires ≥ 2 primes in n + H). The theorem `maynard_tao_implies_twin_primes` shows that `MaynardTaoDensity {0,2} 2` implies the twin prime conjecture: if infinitely many n have both n and n+2 prime (which is what density 2 over a 2-element set means), that IS the twin prime conjecture. The proof uses `Finset.eq_of_subset_of_card_le` to show the prime filter equals all of {0,2}.",
+    "mathContext": "Logical hierarchy: Dickson (all of $n+H$ prime) $\\Rightarrow$ Maynard density (most of $n+H$ prime) $\\Rightarrow$ bounded gaps ($\\exists$ 2 primes in $n+H$). What IS proved: bounded gaps $\\leq 246$. What is open: Dickson for any $|H| \\geq 2$ (twin prime conjecture is the $H = \\{0,2\\}$ case). Gap: the Maynard-Tao sieve proves density but not full Dickson.",
+    "significance": "key",
+    "relatedConcepts": ["Dickson conjecture", "MaynardTaoDensity", "Finset.eq_of_subset_of_card_le", "twin prime conjecture"],
+    "prerequisites": ["Finset.filter in Lean", "Finset.card_le_card", "prime density arguments"]
+  },
+  {
+    "id": "ann-polymath-50-tuple",
+    "proofId": "bounded-prime-gaps",
+    "range": { "startLine": 297, "endLine": 372 },
+    "type": "technique",
+    "title": "Polymath 50-Tuple: Constructive Admissibility via native_decide",
+    "content": "The `polymath50Tuple` is the explicit Engelsma/Polymath narrowest admissible 50-tuple {0, 4, 6, 16, 30, ..., 244, 246}. Its admissibility proof uses a 16-deep nested case split on small primes (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47), each checked by `native_decide`. For primes p ≥ 53, the image card ≤ 50 < 53 ≤ p suffices. The proof that p ≥ 53 from 'prime, not in {2,...,47}' uses `interval_cases p` to enumerate all candidates in [2, 52] and rules out each by primality or equality. The `exists_admissible_50_tuple_246` theorem wraps this into the existential statement needed for the main theorem.",
+    "mathContext": "The Engelsma 50-tuple achieves the minimum diameter for a 50-admissible tuple: diameter 246. This is a result of computational optimization. The Maynard-Tao sieve guarantees 2 simultaneous primes in translates of any admissible $k$-tuple with $k \\geq 50$, which is why the Polymath bound equals $\\text{diam}(\\text{Engelsma-50}) = 246$.",
+    "significance": "supporting",
+    "relatedConcepts": ["native_decide for large computations", "interval_cases tactic", "Engelsma tuple optimization"],
+    "prerequisites": ["native_decide in Lean 4", "interval_cases tactic", "Nat.Prime for specific numbers"]
+  },
+  {
+    "id": "ann-nth-prime-infrastructure",
+    "proofId": "bounded-prime-gaps",
+    "range": { "startLine": 378, "endLine": 400 },
+    "type": "definition",
+    "title": "nthPrime Infrastructure: Mathlib's Nat.nth for Primes",
+    "content": "The `nthPrime n` definition uses Mathlib's `Nat.nth Nat.Prime n` — the n-th natural number satisfying a predicate P, well-defined when P holds for infinitely many naturals. `nthPrime_prime` uses `Nat.nth_mem_of_infinite Nat.infinite_setOf_prime` (primes form an infinite set). `nthPrime_strictMono` follows from `Nat.nth_strictMono` (nth of an infinite set is strictly increasing). The `primeGap n = nthPrime (n+1) - nthPrime n` uses natural number subtraction, which is safe because primes are strictly increasing. The `primeGap_pos` theorem proves gaps are positive via strict monotonicity.",
+    "mathContext": "Mathlib's `Nat.nth P n` for an infinite set $\\{n : P(n)\\}$ satisfies: (1) $P(\\text{nth}(P,n))$ — membership; (2) $\\text{nth}(P,m) < \\text{nth}(P,n)$ when $m < n$ — strict monotonicity. For primes: $p_0 = 2$, $p_1 = 3$, $p_2 = 5$, etc. Prime gap: $g(n) = p_{n+1} - p_n \\geq 1$, with $g(n) \\geq 2$ for $n \\geq 1$ (since $p_n$ and $p_{n+1}$ are both odd).",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.nth in Mathlib", "Nat.infinite_setOf_prime", "StrictMono", "primeGap"],
+    "prerequisites": ["Nat.nth Mathlib API", "Nat.infinite_setOf_prime", "StrictMono API"]
+  },
+  {
+    "id": "ann-gap-oscillation",
+    "proofId": "bounded-prime-gaps",
+    "range": { "startLine": 641, "endLine": 660 },
+    "type": "insight",
+    "title": "Oscillation: Bounded Liminf AND Unbounded Limsup",
+    "content": "The `prime_gaps_unbounded` theorem proves that for every N, there exists a prime index n with gap ≥ N. The proof uses the classical factorial construction: N! + k is composite for 2 ≤ k ≤ N (since k divides both k and N!), giving N-1 consecutive composites. Combined with `liminf_prime_gaps_finite` (gap ≤ 246 infinitely often), the `prime_gaps_oscillate` theorem shows the prime gap function oscillates: it achieves both small (≤ 246) and arbitrarily large values infinitely often. This is a non-trivial result: $\\liminf = 2$ (conjectured) or $\\leq 246$ (proved), while $\\limsup = \\infty$ (elementary).",
+    "mathContext": "Factorial construction: for $2 \\leq k \\leq N$, $k \\mid N!$ and $k \\mid k$, so $k \\mid (N! + k)$ and $N! + k$ is composite. The run $N!+2, N!+3, \\ldots, N!+N$ has length $N-1$. In general $g(n) = O(p_n \\log p_n)$ (Cramér's conjecture: $g(n) = O((\\log p_n)^2)$). The oscillation: $\\liminf_{n \\to \\infty} g(n) \\leq 246$ (Polymath) and $\\limsup_{n \\to \\infty} g(n) = \\infty$ (elementary).",
+    "significance": "supporting",
+    "relatedConcepts": ["factorial construction", "prime_gaps_oscillate", "liminf vs limsup", "Cramér's conjecture"],
+    "prerequisites": ["Nat.factorial in Mathlib", "divisibility in ℕ", "composites in factorial gaps"]
+  }
+]

--- a/src/data/proofs/euler-polyhedral-formula-oq-01/annotations.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01/annotations.json
@@ -1,1 +1,122 @@
-[]
+[
+  {
+    "id": "ann-euler-imports",
+    "proofId": "euler-polyhedral-formula-oq-01",
+    "range": { "startLine": 1, "endLine": 8 },
+    "type": "context",
+    "title": "Mathlib Graph Theory Imports",
+    "content": "The file imports five Mathlib modules for graph theory. `SimpleGraph.Basic` provides the `SimpleGraph` type class, adjacency predicates, and basic graph operations. `SimpleGraph.Finite` adds finiteness infrastructure. `SimpleGraph.DegreeSum` provides the handshaking lemma `sum_degrees_eq_twice_card_edges`. `SimpleGraph.Coloring` supplies the `Colorable n` predicate and `Coloring.mk` constructor. `SimpleGraph.Connectivity.Connected` provides connectivity predicates. The `Int.Basic` import is needed for integer arithmetic in Euler's formula, since V - E + F = 2 requires working in the integers to avoid natural number subtraction pitfalls.",
+    "mathContext": "The handshaking lemma: $\\sum_{v \\in V} \\deg(v) = 2|E|$. This is `G.sum_degrees_eq_twice_card_edges` in Mathlib, used to prove that $2|E| \\geq 6|V|$ when all degrees are $\\geq 6$, contradicting $|E| \\leq 3|V|-6$.",
+    "significance": "context",
+    "relatedConcepts": ["SimpleGraph", "handshaking lemma", "Colorable", "Fintype"],
+    "prerequisites": ["Lean 4 type classes", "Mathlib graph theory library", "integer arithmetic in Lean"]
+  },
+  {
+    "id": "ann-spanning-build",
+    "proofId": "euler-polyhedral-formula-oq-01",
+    "range": { "startLine": 58, "endLine": 111 },
+    "type": "technique",
+    "title": "SpanningBuild: Inductive Proof of Euler's Formula",
+    "content": "The `SpanningBuild` inductive type is the central innovation of this file. It models connected planar graph construction with three constructors: `single` (one vertex, no edges, one outer face), `addTreeEdge` (extend the spanning tree — adds a vertex and an edge, preserving face count), and `addCycleEdge` (add a non-tree edge — splits an existing face, so edges and faces each increase by 1). Euler's formula `eulerChar = 2` follows immediately by structural induction: each constructor preserves the invariant. The `single` case: 1 - 0 + 1 = 2. The `addTreeEdge` case: (V+1) - (E+1) + F = V - E + F = 2. The `addCycleEdge` case: V - (E+1) + (F+1) = V - E + F = 2. The proof requires only `push_cast` and `linarith`.",
+    "mathContext": "The spanning tree approach to Euler's formula: start with a spanning tree ($T$ on $V$ vertices has $V-1$ edges, $F=1$). Each of the $E - (V-1)$ non-tree edges adds one face. Final face count: $F = 1 + (E - V + 1) = E - V + 2$. Thus $V - E + F = V - E + (E-V+2) = 2$.",
+    "significance": "key",
+    "relatedConcepts": ["structural induction", "spanning tree", "face splitting", "connected planar graph"],
+    "prerequisites": ["inductive types in Lean 4", "Euler characteristic", "spanning tree definition"]
+  },
+  {
+    "id": "ann-platonic-examples",
+    "proofId": "euler-polyhedral-formula-oq-01",
+    "range": { "startLine": 183, "endLine": 212 },
+    "type": "definition",
+    "title": "Platonic Solids as SpanningBuild Instances",
+    "content": "The three Platonic solids are explicitly constructed as `SpanningBuild` graphs. The tetrahedron is `buildPlanarGraph 3 3`: a spanning tree on 4 vertices (3 tree edges) plus 3 cycle edges, giving (V,E,F)=(4,6,4) with 4-6+4=2. The cube is `buildPlanarGraph 7 5`: 8 vertices, 12 edges, 6 faces. The octahedron is `buildPlanarGraph 5 7`: 6 vertices, 12 edges, 8 faces. All three satisfy Euler's formula via `euler_spanning`. Notice the duality: the cube (8,12,6) and octahedron (6,12,8) have the same number of edges but swapped vertex/face counts — they are dual polyhedra, and this duality is visible directly from the `SpanningBuild` parameters.",
+    "mathContext": "Euler characteristic verification: tetrahedron $4-6+4=2$; cube $8-12+6=2$; octahedron $6-12+8=2$. The dodecahedron $(20,30,12)$ and icosahedron $(12,30,20)$ — not formalized here — similarly satisfy $V-E+F=2$ and form a dual pair. A polyhedron is dual to another when vertices and faces are exchanged: if $(V,E,F)$ satisfies Euler, so does $(F,E,V)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Platonic solids", "polyhedra duality", "buildPlanarGraph", "Euler characteristic"],
+    "prerequisites": ["SpanningBuild inductive type", "planar graph construction", "dual polyhedra"]
+  },
+  {
+    "id": "ann-degeneracy",
+    "proofId": "euler-polyhedral-formula-oq-01",
+    "range": { "startLine": 220, "endLine": 258 },
+    "type": "concept",
+    "title": "Graph Degeneracy: A Key Planar Graph Property",
+    "content": "Graph degeneracy is a stronger property than simply having one low-degree vertex: a graph is $k$-degenerate if *every* subgraph has a vertex of degree at most $k$. For planar graphs, $E \\leq 3V - 6$ implies 5-degeneracy because every subgraph of a planar graph is also planar (planarity is hereditary), so the edge bound applies recursively. The proof of `degeneracy_from_edge_bound` uses contradiction: if all vertices have degree $\\geq d$ where $d \\geq 6$, then $\\sum \\deg \\geq dV \\geq 6V$, so by the handshaking lemma $2E \\geq 6V$, i.e., $E \\geq 3V$. But $E \\leq 3V - 6 < 3V$, a contradiction. The Lean proof uses `by_contra`, `push_neg`, `Int.mul_le_mul_of_nonneg_right`, and `linarith`.",
+    "mathContext": "A graph $G$ is $k$-degenerate iff there exists an ordering $v_1, \\ldots, v_n$ of vertices such that each $v_i$ has $\\leq k$ neighbors among $\\{v_1, \\ldots, v_{i-1}\\}$. Equivalently, every subgraph has a vertex of degree $\\leq k$. For planar graphs: $k=5$ (each subgraph has $E' \\leq 3V'-6$, so by averaging some vertex has degree $\\leq 5$ in the subgraph).",
+    "significance": "key",
+    "relatedConcepts": ["k-degeneracy", "hereditary planarity", "handshaking lemma", "greedy coloring"],
+    "prerequisites": ["planar graph edge bound", "handshaking lemma", "contradiction proof technique"]
+  },
+  {
+    "id": "ann-six-color-via-degeneracy",
+    "proofId": "euler-polyhedral-formula-oq-01",
+    "range": { "startLine": 264, "endLine": 293 },
+    "type": "insight",
+    "title": "Six Color Theorem via Degeneracy Coloring",
+    "content": "The theorem `six_colorable_from_degeneracy` connects degeneracy to chromatic number: a $k$-degenerate graph is $(k+1)$-colorable. The proof strategy is greedy coloring in degeneracy order: process vertices $v_1, \\ldots, v_n$ in reverse degeneracy order (removing lowest-degree vertices last). When coloring $v_i$, it has at most $k$ already-colored neighbors, so at most $k$ colors are 'used', leaving at least one of the $k+1$ colors free. For planar graphs ($k=5$), this gives 6-colorability. The full chain is: edge bound $E \\leq 3V-6$ implies 5-degeneracy implies 6-colorability. The `degenerate_colorable_aux` theorem provides the abstract lemma that the palette is non-empty.",
+    "mathContext": "The full chain: $|E| \\leq 3|V|-6$ (planarity) $\\Rightarrow$ every subgraph has a vertex of degree $\\leq 5$ (5-degenerate) $\\Rightarrow$ 6-colorable by greedy. Compare the Five Color Theorem: same first step, but requires Kempe chain argument to reduce from 6 to 5. The Four Color Theorem requires Appel-Haken computer search (1976), re-verified by Gonthier in Coq (2005).",
+    "significance": "key",
+    "relatedConcepts": ["greedy coloring", "degeneracy ordering", "chromatic number", "Four Color Theorem"],
+    "prerequisites": ["k-degeneracy", "graph coloring", "Kempe chains (for Five Color upgrade)"]
+  },
+  {
+    "id": "ann-handshaking-low-degree",
+    "proofId": "euler-polyhedral-formula-oq-01",
+    "range": { "startLine": 353, "endLine": 383 },
+    "type": "technique",
+    "title": "Handshaking Lemma Proof of Low-Degree Vertex Existence",
+    "content": "The theorem `exists_low_degree_vertex` uses Mathlib's handshaking lemma (`G.sum_degrees_eq_twice_card_edges`) to prove the existence of a vertex with degree at most 5 in any planar graph. The proof by contradiction assumes all vertices have degree at least 6, then builds a chain: by `sum_le_sum`, the sum of degrees is at least $6|V|$. The handshaking lemma gives the sum of degrees equals $2|E|$, so $6|V| \\leq 2|E|$. Combined with the planarity bound $|E| \\leq 3|V|-6$, we get $6|V| \\leq 6|V|-12$, a contradiction. The `exists_low_degree_vertex'` variant handles graphs with fewer than 3 vertices separately using `degree_lt_card_verts`.",
+    "mathContext": "$\\sum_{v} \\deg(v) = 2|E| \\leq 2(3|V|-6) = 6|V|-12 < 6|V|$. If all $\\deg(v) \\geq 6$, then $\\sum_v \\deg(v) \\geq 6|V|$, contradicting $\\sum_v \\deg(v) < 6|V|$. Hence $\\exists v, \\deg(v) \\leq 5$. The `calc` block computes: $6|V| = \\sum_v 6 \\leq \\sum_v \\deg(v) = 2|E| \\leq 6|V|-12$.",
+    "significance": "key",
+    "relatedConcepts": ["handshaking lemma", "Finset.sum_le_sum", "degree_lt_card_verts", "averaging argument"],
+    "prerequisites": ["SimpleGraph.degree in Mathlib", "Finset.sum_const", "Finset.card_univ"]
+  },
+  {
+    "id": "ann-non-planarity",
+    "proofId": "euler-polyhedral-formula-oq-01",
+    "range": { "startLine": 437, "endLine": 461 },
+    "type": "insight",
+    "title": "Non-Planarity Certificates for K₅, K₃,₃, and Petersen",
+    "content": "Three classic non-planarity results are proved using Euler's formula and edge bounds. K₅ (V=5, E=10): for a planar triangulation (3F ≤ 2E), the edge bound gives E ≤ 3V-6 = 9 < 10. K₃,₃ (V=6, E=9): it is bipartite (no odd cycles, girth ≥ 4, so 4F ≤ 2E), giving the bipartite bound E ≤ 2V-4 = 8 < 9. Petersen graph (V=10, E=15): girth 5 (no triangles or 4-cycles) so 5F ≤ 2E = 30, giving F ≤ 6. But Euler gives F = E - V + 2 = 7, and 5·7 = 35 > 30, a contradiction. By Kuratowski's theorem, non-planarity of K₅ and K₃,₃ are the two primitive certificates for all non-planar graphs.",
+    "mathContext": "Kuratowski's theorem (1930): $G$ is planar $\\iff$ $G$ has no subdivision of $K_5$ or $K_{3,3}$. Wagner's theorem: $G$ is planar $\\iff$ $G$ has no $K_5$ or $K_{3,3}$ as a topological minor. The genus of $K_5$ is 1 (embeds in the torus), proved as `k5_min_genus` in Part 8.",
+    "significance": "supporting",
+    "relatedConcepts": ["Kuratowski's theorem", "graph minors", "bipartite edge bound", "girth"],
+    "prerequisites": ["Euler's formula", "edge bound proofs", "bipartite graphs"]
+  },
+  {
+    "id": "ann-genus-heawood",
+    "proofId": "euler-polyhedral-formula-oq-01",
+    "range": { "startLine": 467, "endLine": 534 },
+    "type": "concept",
+    "title": "Genus Theory and Heawood Chromatic Bounds",
+    "content": "For surfaces of genus $g$ (torus has $g=1$, double torus $g=2$), Euler's formula generalizes to $V - E + F = 2 - 2g$ (the Euler characteristic of the surface is $2-2g$). Combined with $3F \\leq 2E$ (triangulation), this gives the genus edge bound $E \\leq 3V + 6g - 6$. The Heawood number $H(g) = \\lfloor (7 + \\sqrt{1 + 48g})/2 \\rfloor$ bounds the chromatic number for genus-$g$ surfaces ($g \\geq 1$). For $g=1$ (torus): $H(1) = 7$, proved by `heawood_torus_bound` which shows $E \\leq 3V$ on the torus, hence average degree $< 6$, so 7 colors suffice. The Heawood conjecture was proved by Ringel and Youngs in 1968, completing the proof for all orientable surfaces $g \\geq 1$.",
+    "mathContext": "$V - E + F = 2 - 2g$. From $3F \\leq 2E$: $3(E - V + 2 - 2g) \\leq 2E$, so $E \\leq 3V + 6g - 6$. Average degree $\\leq 6 + (12g-12)/V$. Heawood numbers: $H(0)=4$ (Four Color, sphere), $H(1)=7$ (torus), $H(2)=8$ (double torus). Note $H(0)=4$ required the separate Four Color Theorem proof.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euler characteristic", "Heawood conjecture", "toroidal graphs", "Ringel-Youngs theorem"],
+    "prerequisites": ["genus of a surface", "orientable surfaces", "Euler characteristic formula"]
+  },
+  {
+    "id": "ann-local-planar",
+    "proofId": "euler-polyhedral-formula-oq-01",
+    "range": { "startLine": 725, "endLine": 767 },
+    "type": "technique",
+    "title": "LocalPlanarEmbedding: Self-Contained Planarity Structure",
+    "content": "The `LocalPlanarEmbedding` structure provides a self-contained axiomatization of planarity for a specific graph, avoiding the need for a global planarity predicate or the `planarity_hereditary` axiom. It packages three fields: `faceCount : ℕ` (the number of faces in the embedding), `face_pos : 1 ≤ faceCount` (at least the outer face), and `euler` (Euler's formula as an equality). This structure-based approach means K₅ non-planarity, the edge bound, and the Six Color Theorem can all be derived from the structure's axiom, making the results self-contained within Part 11 of the file. The `local_edge_bound_planar` theorem derives $E \\leq 3V-6$ using `linarith [emb.euler]` together with the triangulation hypothesis.",
+    "mathContext": "From `euler`: $|V| - |E| + F = 2$, so $F = |E| - |V| + 2$. From triangulation: $3F \\leq 2|E|$, substituting: $3(|E| - |V| + 2) \\leq 2|E|$, hence $|E| \\leq 3|V| - 6$. The `face_pos` field ensures $F \\geq 1$, consistent with connected graphs where $F \\geq 1$ always holds.",
+    "significance": "key",
+    "relatedConcepts": ["planar embedding", "Lean 4 structures", "self-contained proof", "Euler axiom"],
+    "prerequisites": ["Lean 4 structure types", "Euler's formula", "triangulation hypothesis in planar graphs"]
+  },
+  {
+    "id": "ann-six-color-proper",
+    "proofId": "euler-polyhedral-formula-oq-01",
+    "range": { "startLine": 773, "endLine": 830 },
+    "type": "insight",
+    "title": "Six Color Theorem: Formal Statement Using Mathlib Colorable",
+    "content": "The formal Six Color Theorem uses Mathlib's `SimpleGraph.Colorable n` predicate, which states there exists a proper $n$-coloring (a graph homomorphism $G \\to K_n$). The proof of `six_colorable_small` handles graphs with at most 6 vertices directly: assign each vertex a distinct color from `Fin (|V|)` using `Fintype.equivFin`, then apply `Colorable.mono` to embed the coloring into `Fin 6`. The `kempe_prerequisite` theorem shows that a degree-5 vertex's neighborhood cannot form K₅ in a planar graph — this is the key ingredient for the Kempe chain color swap argument that reduces from 6 to 5 colors in the Five Color Theorem proof strategy.",
+    "mathContext": "Six Color Theorem proof sketch: (1) Planar $G$ has $\\exists v, \\deg(v) \\leq 5$. (2) Delete $v$, inductively 6-color $G - v$. (3) $v$ has $\\leq 5$ neighbors, so $\\leq 5$ colors blocked among 6 available, leaving $\\geq 1$ free. (4) Color $v$ with the free color. The `Colorable n` predicate: $G$ is $n$-colorable iff $\\exists f : V \\to \\text{Fin}(n),\\ \\forall \\{u,v\\} \\in E,\\ f(u) \\neq f(v)$.",
+    "significance": "key",
+    "relatedConcepts": ["SimpleGraph.Colorable", "Colorable.mono", "Kempe chains", "Five Color Theorem"],
+    "prerequisites": ["SimpleGraph.Colorable in Mathlib", "Fintype.equivFin", "graph homomorphisms"]
+  }
+]

--- a/src/data/proofs/euler-polyhedral-formula-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01/meta.json
@@ -41,7 +41,8 @@
       "**SpanningBuild captures the essence of planarity**: The inductive type separates tree edges (no new face) from cycle edges (one new face), making Euler's formula trivial by structural induction",
       "**5-degeneracy is stronger than having one low-degree vertex**: Every SUBGRAPH of a planar graph has a vertex of degree ≤ 5. This enables the greedy coloring argument for the Six Color Theorem",
       "**LocalPlanarEmbedding avoids the hereditary axiom**: By building a local structure that embeds the Euler axiom directly, K₅ non-planarity can be proved without assuming planarity is hereditary",
-      "**The Heawood formula H(g) = ⌊(5+√(1+48g))/2⌋ bounds chromatic number for genus-g surfaces**: Formalized as arithmetic bounds on E ≤ 3V + 6g - 6 and degeneracy"
+      "**The Heawood formula H(g) = ⌊(5+√(1+48g))/2⌋ bounds chromatic number for genus-g surfaces**: Formalized as arithmetic bounds on E ≤ 3V + 6g - 6 and degeneracy",
+      "**Double counting on faces unifies all edge bounds**: The theorem `face_edge_double_count` with parameter d (minimum face size) subsumes planar (d=3, E ≤ 3V-6), bipartite planar (d=4, E ≤ 2V-4), and high-girth planar (d=6, 2E ≤ 3V-6) bounds as special cases of a single arithmetic identity (d-2)E ≤ d(V-2)"
     ]
   },
   "sections": [


### PR DESCRIPTION
## Summary

Enrichment pass for two gallery entries (annotations.json was empty for both).

### binomial-theorem-oq-02: Multinomial Theorem as a Generalization of the Binomial Theorem
- Added 10 rich annotations covering all 8 proof sections
- Annotations cover: imports, module doc, multinomial_theorem, multinomial_recurrence, multinomial_eq_binomial, multinomial_total, Bool-indexed bridge, native_decide examples, trinomial formulas, three-variable recurrence
- Added 5th keyInsight about multinomial coefficient telescoping
- Added 3 crossReferences to related gallery proofs

### euler-polyhedral-formula-oq-01: Planar Graph Embedding, Spanning Tree Euler Formula, and Six Color Theorem
- Added 10 rich annotations covering all major proof sections
- Annotations cover: imports/handshaking lemma, SpanningBuild inductive type, Platonic solids, degeneracy theory, Six Color via degeneracy, low-degree vertex existence, K₅/K₃,₃/Petersen non-planarity, genus/Heawood bounds, LocalPlanarEmbedding, Six Color formal statement
- Added 5th keyInsight about face_edge_double_count unifying all edge bounds