### PR TITLE
Enrich Discrete IVT for Ballot Sequences (ballot-problem-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-ballot-oq01-01-imports",
+    "proofId": "ballot-problem-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "context",
+    "title": "Header: Open Question and Proof Strategy",
+    "content": "The opening block documents the open question and the Finset.max' proof strategy. The file imports `Mathlib.Tactic` (standard tactic infrastructure), `Mathlib.Data.List.Basic` (prefix sum lemmas like `List.sum_take_succ` and `List.getElem_mem`), and `Mathlib.Data.Finset.Basic` (Finset membership and max' machinery). The header records which sub-goals are solved (ballot_discrete_ivt) and which remain sketched (rightmost_is_good_rotation, integration with the lower bound).",
+    "mathContext": "The proof context is the Dvoretzky-Motzkin Cycle Lemma (1947): given $a$ copies of $+1$ and $b$ copies of $-k$ with $a > kb$, exactly $a - kb$ of the $a+b$ cyclic rotations have all partial sums positive. The prefix sum at position $i$ is $P(i) = \\sum_{j=0}^{i-1} l_j$.",
+    "significance": "context",
+    "relatedConcepts": ["Dvoretzky-Motzkin cycle lemma", "ballot sequences", "lattice paths", "cyclic rotations"],
+    "prerequisites": ["combinatorics", "prefix sums", "Lean 4 / Mathlib basics"]
+  },
+  {
+    "id": "ann-ballot-oq01-02-theorem-statement",
+    "proofId": "ballot-problem-oq-01-oq-01",
+    "range": { "startLine": 39, "endLine": 53 },
+    "type": "definition",
+    "title": "Theorem Statement: Discrete IVT for Ballot Sequences",
+    "content": "The theorem `ballot_discrete_ivt` states a discrete analogue of the intermediate value theorem for lists whose elements are restricted to $\\{+1, -k\\}$. The hypotheses are: (1) every element of `l` is either `1` or `-(k : ℤ)` (`hmem`); (2) there exists some position `i₀ ≤ l.length` with prefix sum exactly `v` (`hv_achieved`); (3) the total list sum strictly exceeds `v` (`hv_exceeded`). The conclusion is that some strict prefix (position `j < l.length`) also achieves prefix sum exactly `v`. The strict inequality `j < l.length` is crucial: it means position `j` is not the end of the list, which is what makes the corresponding rotation 'good'.",
+    "mathContext": "$\\forall l : \\{+1,-k\\}^*, \\; \\exists i_0 \\leq |l|, P(i_0)=v \\;\\land\\; v < P(|l|) \\implies \\exists j < |l|, P(j) = v$",
+    "significance": "key",
+    "relatedConcepts": ["intermediate value theorem", "prefix sums", "ballot sequences", "discrete analysis"],
+    "prerequisites": ["integer lists", "prefix sums", "List.take in Lean"]
+  },
+  {
+    "id": "ann-ballot-oq01-03-finset-construction",
+    "proofId": "ballot-problem-oq-01-oq-01",
+    "range": { "startLine": 54, "endLine": 66 },
+    "type": "tactic",
+    "title": "Finset.max' Construction: Defining S and Its Properties",
+    "content": "The proof begins by unpacking the witness `i₀` from `hv_achieved`. It then constructs the key object: the Finset `S` of all positions in `[0, l.length]` whose prefix sum is at most `v`. Membership in `S` is tested by `Finset.range (l.length + 1)` (positions 0 through l.length) filtered by the predicate `(l.take i).sum ≤ v`. Non-emptiness `hS_ne` follows immediately because `i₀ ∈ S` (its prefix sum equals `v ≤ v`). The variable `j = S.max' hS_ne` is then introduced as the rightmost (largest) position with prefix sum at most `v`. Two immediate consequences are extracted: `j ≤ l.length` (from `j ∈ Finset.range (l.length+1)`) and `P(j) ≤ v` (from the filter predicate).",
+    "mathContext": "$S = \\{i \\in \\{0,\\ldots,|l|\\} \\mid P(i) \\leq v\\}$, $j = \\max S$. Since $P(i_0)=v$, $i_0 \\in S$, so $S \\neq \\emptyset$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.max'", "extremal argument", "Finset.range", "filter predicate"],
+    "prerequisites": ["Mathlib Finset API", "Finset.max'_mem", "Finset.le_max'"]
+  },
+  {
+    "id": "ann-ballot-oq01-04-maximality",
+    "proofId": "ballot-problem-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 78 },
+    "type": "tactic",
+    "title": "Strict Bound and Maximality: j < l.length and P(j+1) > v",
+    "content": "Two critical properties of `j` are proved in this block. First, `hj_lt : j < l.length`: this is shown by contradiction — if `j = l.length`, then `P(j) = P(l.length) = l.sum > v`, contradicting `hj_le_v : P(j) ≤ v`. Second, `hj1_gt : v < P(j+1)`: by contradiction again — if `P(j+1) ≤ v`, then `j+1 ∈ S`, but `Finset.le_max'` says every element of `S` is ≤ `j`, giving `j+1 ≤ j`, a contradiction via `omega`. These two facts together pin `j` as a strict-prefix position whose successor has prefix sum exceeding `v`.",
+    "mathContext": "$j < |l|$ because $P(|l|) = l.\\text{sum} > v$ forces $|l| \\notin S$. And $P(j+1) > v$ because $j+1 > j = \\max S$ implies $j+1 \\notin S$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.le_max'", "by_contra", "omega tactic", "Nat.eq_or_lt_of_le"],
+    "prerequisites": ["Finset maximality", "proof by contradiction", "omega arithmetic"]
+  },
+  {
+    "id": "ann-ballot-oq01-05-case-split",
+    "proofId": "ballot-problem-oq-01-oq-01",
+    "range": { "startLine": 79, "endLine": 89 },
+    "type": "insight",
+    "title": "Case Split on l[j]: Why the Rightmost Position Has Prefix Sum Exactly v",
+    "content": "The central case analysis: since `l[j] ∈ l` (by `List.getElem_mem`), the hypothesis `hmem` gives either `l[j] = 1` or `l[j] = -(k : ℤ)`. If `l[j] = -k`, then `P(j+1) = P(j) + l[j] = P(j) - k ≤ v - k < v` (since `k ≥ 1`), contradicting `hj1_gt : P(j+1) > v`. Therefore `l[j] = 1`. With this, `P(j+1) = P(j) + 1 > v` gives `P(j) ≥ v`. Combined with `P(j) ≤ v`, we get `P(j) = v` exactly, completing the proof. This is the heart of the argument: the ballot sequence constraint ($l[j] \\in \\{+1, -k\\}$) forces the rightmost boundary to be a clean level-crossing rather than a jump.",
+    "mathContext": "If $l[j] = -k$ then $P(j+1) = P(j) - k \\leq v - k < v$, contradiction. So $l[j] = 1$ and $P(j+1) = P(j)+1 > v$, hence $P(j) \\geq v$. With $P(j) \\leq v$: $P(j) = v$.",
+    "significance": "key",
+    "relatedConcepts": ["List.sum_take_succ", "ballot sequence constraint", "case split", "linarith"],
+    "prerequisites": ["prefix sum recurrence", "integer arithmetic", "case analysis in Lean 4"]
+  },
+  {
+    "id": "ann-ballot-oq01-06-lower-bound-sketch",
+    "proofId": "ballot-problem-oq-01-oq-01",
+    "range": { "startLine": 91, "endLine": 108 },
+    "type": "insight",
+    "title": "Cycle Lemma Lower Bound: Informal Derivation via Discrete IVT",
+    "content": "The theorem `cycle_lemma_lower_bound_via_ivt` is a placeholder (`True := trivial`) documenting the intended argument. The docstring explains how `ballot_discrete_ivt` yields the lower bound `|goodRotations l| ≥ l.sum`. The argument is: for each level $v \\in [\\mu, \\mu + S)$ (where $\\mu$ = minimum prefix sum, $S$ = total sum), `ballot_discrete_ivt` guarantees a strict prefix achieving prefix sum $v$. The rightmost such prefix at each level is a distinct good rotation. Since there are $S = a - kb$ levels, this gives $\\geq a - kb$ good rotations. The placeholder keeps the file compilable while signaling this step requires formalization.",
+    "mathContext": "For $v \\in [\\mu, \\mu + S)$: apply `ballot_discrete_ivt` with witness $i_0 = \\text{argmin}_i P(i)$ (achieves $\\mu \\leq v$) and final sum $S > v - \\mu \\geq 0$, giving $j_v < |l|$ with $P(j_v) = v$. The map $v \\mapsto j_v$ (rightmost) is injective, giving $\\geq S$ good rotations.",
+    "significance": "supporting",
+    "relatedConcepts": ["cycle lemma lower bound", "injection into levels", "minimum prefix sum", "good rotations"],
+    "prerequisites": ["ballot_discrete_ivt", "cycle lemma infrastructure", "BallotProblemOQ01.lean"]
+  },
+  {
+    "id": "ann-ballot-oq01-07-rightmost-sketch",
+    "proofId": "ballot-problem-oq-01-oq-01",
+    "range": { "startLine": 110, "endLine": 130 },
+    "type": "insight",
+    "title": "Rightmost-is-Good-Rotation: Two-Case Argument",
+    "content": "The docstring for `rightmost_is_good_sketch` (another `True := trivial` placeholder) spells out the two cases needed to prove that the rightmost position $i$ at level $v$ is a good rotation: (1) **Non-wrapping offsets** ($1 \\leq \\text{offset} \\leq |l| - i$): the cyclic prefix sum equals $P(i + \\text{offset}) - P(i) = P(i+\\text{offset}) - v > 0$ because $i+\\text{offset} > i$ and $i$ is the rightmost position at level $v$, so $P(i+\\text{offset}) > v$. (2) **Wrapping offsets** ($\\text{offset} > |l| - i$): the cyclic prefix sum is $P(r) + S - v$ where $r = i + \\text{offset} - |l|$; this is $\\geq \\mu + S - v > 0$ since $v < \\mu + S$. The two cases together prove all cyclic prefix sums are positive, confirming the rotation at $i$ is good.",
+    "mathContext": "Non-wrapping: $\\text{cps}(\\text{off}) = P(i+\\text{off}) - v > 0$ (rightmostness). Wrapping: $\\text{cps}(\\text{off}) = P(r) + S - v \\geq \\mu + S - v > 0$ (since $v < \\mu + S$).",
+    "significance": "supporting",
+    "relatedConcepts": ["cyclic rotation", "good rotation definition", "wrapping prefix sums", "minimum prefix sum bound"],
+    "prerequisites": ["ballot_discrete_ivt", "cyclic rotation prefix sum formula", "BallotProblemOQ01.lean"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass for ballot-problem-oq-01-oq-01

**Quality improvements:**
- Added 7 annotations (was 0) covering all major sections of BallotProblemOQ01OQ01.lean
- Every annotation includes `mathContext` (LaTeX formulas), `significance`, `relatedConcepts`, and `prerequisites`
- Full coverage: imports/header, theorem statement, Finset.max' construction, maximality argument, case split on l[j], cycle lemma lower bound sketch, rightmost-is-good-rotation sketch

**Annotations added:**
1. `ann-ballot-oq01-01-imports` (lines 1–37): Block header context with historical background on Dvoretzky-Motzkin
2. `ann-ballot-oq01-02-theorem-statement` (lines 39–53): Formal theorem statement with LaTeX formulation of the discrete IVT
3. `ann-ballot-oq01-03-finset-construction` (lines 54–66): Finset.max' construction — defining S = {positions with prefix sum ≤ v} and nonemptiness
4. `ann-ballot-oq01-04-maximality` (lines 67–78): Strict bound j < l.length and P(j+1) > v via maximality of Finset.max'
5. `ann-ballot-oq01-05-case-split` (lines 79–89): Core case split — why l[j] = +1 forces P(j) = v exactly
6. `ann-ballot-oq01-06-lower-bound-sketch` (lines 91–108): How ballot_discrete_ivt yields |goodRotations| ≥ l.sum
7. `ann-ballot-oq01-07-rightmost-sketch` (lines 110–130): Two-case argument (non-wrapping and wrapping) for rightmost-is-good-rotation

All annotations validated — zero new build errors introduced.