### PR TITLE
Enrich Power Mean Interpolation (amgm-inequality-oq-03)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-amgm-oq03-01-header",
+    "proofId": "amgm-inequality-oq-03",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "context",
+    "title": "Power Mean Family: Overview and Open Question",
+    "content": "The header introduces the weighted power mean family M_r(z,w) and the open question: to fully formalize the monotonicity M_r <= M_s for all r <= s in Lean 4/Mathlib. It enumerates what the file proves (7 results including new proofs of HM <= GM and M_r <= M_s for 0 < r <= s) and what remains open (the negative r case). The imports bring in Mathlib.Analysis.MeanInequalities for the weighted AM-GM inequality and Mathlib.Analysis.MeanInequalitiesPow for Jensen's power inequality.",
+    "mathContext": "$M_r(z,w) = \\left(\\sum_{i} w_i z_i^r\\right)^{1/r}$ for $r \\neq 0$; $M_0 = \\prod_i z_i^{w_i}$ (geometric mean as limit). The chain: $\\text{HM} = M_{-1} \\leq M_0 = \\text{GM} \\leq M_1 = \\text{AM} \\leq M_2 \\leq \\cdots$",
+    "significance": "context",
+    "relatedConcepts": ["AM-GM inequality", "power means", "Jensen's inequality", "Hardy-Littlewood-Pólya"],
+    "prerequisites": ["weighted inequalities", "real analysis", "Lean 4 Mathlib imports"]
+  },
+  {
+    "id": "ann-amgm-oq03-02-definitions",
+    "proofId": "amgm-inequality-oq-03",
+    "range": { "startLine": 59, "endLine": 71 },
+    "type": "definition",
+    "title": "Core Definitions: Power Mean, Geometric Mean, Arithmetic Mean",
+    "content": "Three noncomputable defs establish the formal objects. weightedPowerMean s w z p hp is (sum_i w_i z_i^p)^(1/p) (requiring p != 0 to avoid division by zero). weightedGeomMean s w z is prod_i z_i^(w_i) (the limit case M_0). weightedArithMean s w z is sum_i w_i z_i (the M_1 case). All three are noncomputable because they involve real-valued power/product/sum operations. The shared variable block gives an abstract index type, a finite index set, and weight/value functions.",
+    "mathContext": "$\\text{weightedPowerMean}: M_p = \\left(\\sum_i w_i z_i^p\\right)^{1/p}$. $\\text{weightedGeomMean}: \\text{GM} = \\prod_i z_i^{w_i}$. $\\text{weightedArithMean}: \\text{AM} = \\sum_i w_i z_i$.",
+    "significance": "key",
+    "relatedConcepts": ["noncomputable def", "Finset.sum", "Finset.prod", "Real.rpow"],
+    "prerequisites": ["Lean 4 type theory", "Finset API", "real power functions"]
+  },
+  {
+    "id": "ann-amgm-oq03-03-known-results",
+    "proofId": "amgm-inequality-oq-03",
+    "range": { "startLine": 72, "endLine": 118 },
+    "type": "theorem",
+    "title": "Known Results from Mathlib: M1=AM, AM<=Mp, GM<=AM, GM<=Mp, Jensen",
+    "content": "Four theorems wrap existing Mathlib results. power_mean_one_eq_arith_mean proves M_1 = AM by simp with Real.rpow_one. arith_mean_le_power_mean invokes Real.arith_mean_le_rpow_mean directly. geom_mean_le_arith_mean calls Real.geom_mean_le_arith_mean_weighted. geom_mean_le_power_mean_of_one_le combines the previous two via .trans. jensen_pow_ineq wraps Real.rpow_arith_mean_le_arith_mean_rpow — this is Jensen's inequality (sum w_i z_i)^p <= sum w_i z_i^p for p >= 1, and is the key tool for power_mean_monotone_pos.",
+    "mathContext": "Jensen's inequality for convex $t \\mapsto t^p$ ($p \\geq 1$): $\\left(\\sum_i w_i z_i\\right)^p \\leq \\sum_i w_i z_i^p$. Equivalently, $\\text{AM} \\leq M_p$: $\\sum_i w_i z_i \\leq \\left(\\sum_i w_i z_i^p\\right)^{1/p}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Jensen's inequality", "Real.arith_mean_le_rpow_mean", "Real.geom_mean_le_arith_mean_weighted", "convexity"],
+    "prerequisites": ["Mathlib.Analysis.MeanInequalities", "Mathlib.Analysis.MeanInequalitiesPow"]
+  },
+  {
+    "id": "ann-amgm-oq03-04-hm-le-gm",
+    "proofId": "amgm-inequality-oq-03",
+    "range": { "startLine": 120, "endLine": 167 },
+    "type": "theorem",
+    "title": "HM <= GM: Direct Proof via AM-GM on Inverse Values",
+    "content": "The main new result: harmonic_mean_le_geom_mean_direct proves (sum_i w_i z_i^(-1))^(-1) <= prod_i z_i^(w_i) assuming z_i > 0. The proof proceeds in four steps: (1) establish GM(z) > 0 via Finset.prod_pos; (2) prove GM(z^(-1)) * GM(z) = 1 using Real.mul_rpow and Finset.prod_mul_distrib; (3) apply AM-GM to z^(-1) to get GM(z^(-1)) <= sum_i w_i z_i^(-1); (4) invert algebraically to get HM <= GM. The algebraic inversion avoids div_le_iff (unavailable in this Lean/Mathlib version) by using explicit calc blocks with mul_le_mul_of_nonneg_left.",
+    "mathContext": "Chain: $\\text{GM}(z^{-1}) = \\text{GM}(z)^{-1}$ (proved from $\\text{GM}(z^{-1})\\cdot\\text{GM}(z)=1$), then $\\text{GM}(z)^{-1} \\leq \\sum_i w_i z_i^{-1}$ (AM-GM), so $1 \\leq \\text{GM}(z)\\cdot\\sum_i w_i z_i^{-1}$, hence $\\text{HM} = (\\sum_i w_i z_i^{-1})^{-1} \\leq \\text{GM}(z)$.",
+    "significance": "key",
+    "relatedConcepts": ["harmonic mean", "geometric mean", "AM-GM inequality", "Real.mul_rpow", "Finset.prod_mul_distrib"],
+    "prerequisites": ["AM-GM inequality", "real rpow arithmetic", "Finset product manipulation"]
+  },
+  {
+    "id": "ann-amgm-oq03-05-hm-gm-key-tactic",
+    "proofId": "amgm-inequality-oq-03",
+    "range": { "startLine": 131, "endLine": 167 },
+    "type": "tactic",
+    "title": "HM <= GM Proof Tactics: GM(z^-1)*GM(z)=1 and Algebraic Inversion",
+    "content": "The inner proof details: hprod_one uses simp only with Finset.prod_mul_distrib to merge the two products, then Finset.prod_eq_one with Real.mul_rpow + inv_mul_cancel0 + Real.one_rpow per index. geom_inv deduces GM(z^-1) = GM(z)^-1 via mul_right_cancel0. The final calc block constructs 1 <= GM * Sigma from GM * GM^-1 = 1 and GM^-1 <= Sigma, then applies mul_le_mul_of_nonneg_right with inv_nonneg to clear the denominator. The rwa at the end uses mul_assoc + mul_inv_cancel0 + mul_one to arrive at the goal.",
+    "mathContext": "Key identity: $\\prod_i (z_i^{-1})^{w_i} \\cdot z_i^{w_i} = \\prod_i (z_i^{-1} \\cdot z_i)^{w_i} = \\prod_i 1^{w_i} = 1$. Inversion step: from $1 \\leq \\text{GM} \\cdot \\Sigma$, multiply by $\\Sigma^{-1}$ to get $\\Sigma^{-1} \\leq \\text{GM}$.",
+    "significance": "technical",
+    "relatedConcepts": ["Real.mul_rpow", "Finset.prod_mul_distrib", "Finset.prod_eq_one", "inv_mul_cancel₀", "calc block"],
+    "prerequisites": ["Lean 4 tactics: rw, rwa, calc, simp", "Finset product lemmas", "Real.rpow arithmetic"]
+  },
+  {
+    "id": "ann-amgm-oq03-06-power-mean-mono-pos",
+    "proofId": "amgm-inequality-oq-03",
+    "range": { "startLine": 169, "endLine": 218 },
+    "type": "theorem",
+    "title": "Power Mean Monotonicity for 0 < r <= s: Jensen's Inequality Approach",
+    "content": "power_mean_monotone_pos proves M_r <= M_s for 0 < r <= s via a three-step reduction to Jensen. Step 1: derive q = s/r >= 1 using a calc block that avoids le_div_iff. Step 2: apply Real.rpow_arith_mean_le_arith_mean_rpow (Jensen) with inputs a_i = z_i^r and exponent q = s/r to get (sum w_i z_i^r)^(s/r) <= sum w_i (z_i^r)^(s/r). Step 3: simplify (z_i^r)^(s/r) = z_i^s via Real.rpow_mul, then raise both sides to 1/s > 0 using Real.rpow_le_rpow, and simplify the LHS exponent (s/r)*(1/s) = 1/r via field_simp.",
+    "mathContext": "Let $q = s/r \\geq 1$. Jensen: $(\\sum w_i z_i^r)^{s/r} \\leq \\sum w_i (z_i^r)^{s/r} = \\sum w_i z_i^s$. Raise to $1/s$: $(\\sum w_i z_i^r)^{(s/r)\\cdot(1/s)} = (\\sum w_i z_i^r)^{1/r} \\leq (\\sum w_i z_i^s)^{1/s}$.",
+    "significance": "key",
+    "relatedConcepts": ["Jensen's inequality", "Real.rpow_arith_mean_le_arith_mean_rpow", "Real.rpow_mul", "Real.rpow_le_rpow", "power mean monotonicity"],
+    "prerequisites": ["Jensen's inequality", "rpow composition", "positivity tactic", "field_simp"]
+  },
+  {
+    "id": "ann-amgm-oq03-07-axiom-summary",
+    "proofId": "amgm-inequality-oq-03",
+    "range": { "startLine": 220, "endLine": 263 },
+    "type": "insight",
+    "title": "General Monotonicity Axiom and Interpolation Chain Summary",
+    "content": "The general power_mean_monotone is stated as an axiom because the case of negative r (including M_{-1} <= M_0, i.e., HM <= GM via the power mean framework) is not currently provable with Mathlib tools. The Mathlib TODO explicitly notes 'generalized mean inequality with any p <= q, including negative numbers' as an open gap. The summary theorem power_mean_interpolation_summary (a True := trivial placeholder) catalogs what is proved vs. axiomatized. The harmonic_mean_le_geom_mean_via_power theorem bridges the direct HM <= GM proof to the power mean framework by accepting M_{-1} = HM as a hypothesis.",
+    "mathContext": "The full chain $\\min(z) \\leq \\cdots \\leq M_{-1} \\leq M_0 \\leq M_1 \\leq M_2 \\leq \\cdots \\leq \\max(z)$ is proved for $M_0 \\leq M_1$ (GM \\leq AM), $M_1 \\leq M_p$ ($p \\geq 1$), $M_r \\leq M_s$ ($0 < r \\leq s$, new), and HM \\leq GM directly. The case $r < 0$ requires extension of Mathlib's analysis infrastructure.",
+    "significance": "supporting",
+    "relatedConcepts": ["axiom in Lean 4", "open Mathlib gaps", "power mean chain", "harmonic mean"],
+    "prerequisites": ["power mean definitions", "Lean 4 axiom keyword", "Mathlib.Analysis.MeanInequalities TODO"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass for amgm-inequality-oq-03

**Quality improvements:**
- Added 7 annotations (was 0) covering all major sections of AmgmInequalityOQ03.lean
- Every annotation includes `mathContext` (LaTeX formulas), `significance`, `relatedConcepts`, and `prerequisites`

**Annotations added:**
1. `ann-amgm-oq03-01-header` (lines 1–56): Overview of power mean family, open question context, imports
2. `ann-amgm-oq03-02-definitions` (lines 59–71): Three core definitions — weightedPowerMean, weightedGeomMean, weightedArithMean
3. `ann-amgm-oq03-03-known-results` (lines 72–118): Five Mathlib wrappers — M₁=AM, AM≤Mₚ, GM≤AM, GM≤Mₚ, Jensen's inequality
4. `ann-amgm-oq03-04-hm-le-gm` (lines 120–167): Full HM≤GM proof — GM(z⁻¹)·GM(z)=1 trick, AM-GM on inverses, algebraic inversion
5. `ann-amgm-oq03-05-hm-gm-key-tactic` (lines 131–167): Inner tactic details — Finset.prod_mul_distrib, calc blocks, mul_inv_cancel₀
6. `ann-amgm-oq03-06-power-mean-mono-pos` (lines 169–218): M_r≤M_s for 0<r≤s — Jensen with exponent s/r, rpow_mul simplification
7. `ann-amgm-oq03-07-axiom-summary` (lines 220–263): General monotonicity axiom (open Mathlib gap) and interpolation chain summary

All annotations validated — zero new build errors introduced.