### PR TITLE
Enrich Prime Density in Short Intervals (bertrands-postulate-oq-03)

### DIFF
--- a/src/data/proofs/bertrands-postulate-oq-03/annotations.json
+++ b/src/data/proofs/bertrands-postulate-oq-03/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-bp-oq03-01-header",
+    "proofId": "bertrands-postulate-oq-03",
+    "range": { "startLine": 1, "endLine": 65 },
+    "type": "context",
+    "title": "Problem Setup: Density Hierarchy and Historical Context",
+    "content": "The file imports Mathlib's Bertrand machinery (Nat.bertrand, Nat.primeCounting, Nat.log) plus a local helper module PrimeGapBounds. The header block presents a four-row density hierarchy table from longest known (Bertrand: [n, 2n]) to shortest open (Cramér: [x, x+(log x)^2]), contextualizing the open question. Key dates: Bertrand conjecture 1845, Chebyshev proof 1852, Erdős elementary proof 1932 via central binomial coefficients, Legendre conjecture 1845 (still open), Cramér conjecture 1936 (still open), Baker-Harman-Pintz record 2001.",
+    "mathContext": "The central question: what is $\\inf\\{\\theta : \\text{every } [x, x+x^\\theta] \\text{ has a prime for large } x\\}$? Known: $\\leq 0.525$ (BHP). Bertrand gives $\\leq 1$. PNT predicts $h/\\ln x$ primes in $[x, x+h]$ for $h \\gg \\ln x$.",
+    "significance": "context",
+    "relatedConcepts": ["Bertrand's postulate", "prime counting function", "Baker-Harman-Pintz", "Cramér conjecture", "Legendre conjecture"],
+    "prerequisites": ["prime number theory", "analytic number theory", "Lean 4 Mathlib imports"]
+  },
+  {
+    "id": "ann-bp-oq03-02-definitions",
+    "proofId": "bertrands-postulate-oq-03",
+    "range": { "startLine": 71, "endLine": 88 },
+    "type": "definition",
+    "title": "primeCountInInterval: Prime Counting in Subintervals",
+    "content": "Three definitions establish the infrastructure. `primeCountInInterval lo hi` is defined as `Nat.primeCounting hi - Nat.primeCounting lo` — the count of primes in (lo, hi] as a natural number subtraction. `primeCounting_le_of_le` proves monotonicity of Nat.primeCounting via `Nat.count_monotone`. `primeCountInInterval_ge_iff_primeCounting` converts a condition on Nat.primeCounting into a condition on primeCountInInterval via `omega` — this bridge lemma is the key tool for all Bertrand bounds below.",
+    "mathContext": "$\\pi_{(lo,hi]} = \\pi(hi) - \\pi(lo)$ where $\\pi(n) = \\#\\{p \\leq n : p \\text{ prime}\\}$. The monotonicity $m \\leq n \\implies \\pi(m) \\leq \\pi(n)$ is foundational.",
+    "significance": "key",
+    "relatedConcepts": ["prime counting function", "Nat.primeCounting", "Nat.count_monotone", "monotonicity"],
+    "prerequisites": ["Mathlib.NumberTheory.PrimeCounting", "natural number subtraction"]
+  },
+  {
+    "id": "ann-bp-oq03-03-bertrand-bounds",
+    "proofId": "bertrands-postulate-oq-03",
+    "range": { "startLine": 94, "endLine": 123 },
+    "type": "theorem",
+    "title": "Bertrand Bounds: Single Interval and Iterated Doubling",
+    "content": "Four theorems derive from Bertrand's postulate. `bertrand_interval_nonempty` directly applies `PrimeGapBounds.primeCounting_double_ge_succ` (a pre-proved helper) to show every (n, 2n] has ≥ 1 prime. `primeCounting_pow_two_ge` applies `PrimeGapBounds.primeCounting_pow_two_mul` with n=1 to get π(2^m) ≥ m, using `decide` to check π(1)=0. `bertrand_iterated` exposes π(2^k * n) ≥ π(n) + k directly. `bertrand_iterated_density` converts this to a density statement for (n, 2^k*n]. The local helper module PrimeGapBounds is the key dependency.",
+    "mathContext": "Induction: $\\pi(2^{k+1} n) \\geq \\pi(2^k n) + 1$ (each doubling adds ≥ 1 prime by Bertrand). So $\\pi(2^m) = \\pi(2^m \\cdot 1) \\geq \\pi(1) + m = m$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.bertrand", "prime counting monotonicity", "iterated Bertrand", "PrimeGapBounds"],
+    "prerequisites": ["Bertrand's postulate", "Nat.primeCounting", "induction on natural numbers"]
+  },
+  {
+    "id": "ann-bp-oq03-04-log-bound",
+    "proofId": "bertrands-postulate-oq-03",
+    "range": { "startLine": 129, "endLine": 147 },
+    "type": "theorem",
+    "title": "Logarithmic Lower Bound: π(n) ≥ log₂(n)",
+    "content": "`bertrand_density_lower_bound` is the main proved result: π(n) ≥ log₂(n) for n ≥ 2. The proof uses `m = Nat.log 2 n` (floor log base 2), then the key chain: `2^m ≤ n` (from `Nat.pow_log_le_self`), so π(2^m) ≤ π(n) (monotonicity), and π(2^m) ≥ m (from `primeCounting_pow_two_ge`). Therefore π(n) ≥ m = log₂(n). The three-fact `omega` closes the goal. This bound is elementary but concrete: e.g., π(1024) ≥ 10.",
+    "mathContext": "Let $m = \\lfloor\\log_2 n\\rfloor$. Then $2^m \\leq n$, so $\\pi(2^m) \\leq \\pi(n)$. By iterated Bertrand, $\\pi(2^m) \\geq m$. Hence $\\pi(n) \\geq \\lfloor\\log_2 n\\rfloor$. Note: PNT gives the much stronger $\\pi(n) \\sim n/\\ln n$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.log", "Nat.pow_log_le_self", "floor logarithm", "prime counting lower bound"],
+    "prerequisites": ["primeCounting_pow_two_ge", "primeCounting_le_of_le", "omega arithmetic"]
+  },
+  {
+    "id": "ann-bp-oq03-05-axioms",
+    "proofId": "bertrands-postulate-oq-03",
+    "range": { "startLine": 153, "endLine": 191 },
+    "type": "insight",
+    "title": "Three Key Axioms: PNT, BHP, and Their Mathematical Depth",
+    "content": "Three results are axiomatized here. `pnt_ratio_form` is the Prime Number Theorem: π(x)·ln(x)/x → 1. It is axiomatized because the Lean 4 PNT proof (via the `PrimeNumberTheoremAnd` project) is not in base Mathlib. `pnt_medium_interval_density` gives the PNT-based density π(x+h) - π(x) ≈ h/ln(x) for h ≥ x^(2/3) — also an axiom. `bhp_short_interval` is the Baker-Harman-Pintz theorem: every [x, x+x^0.525] has a prime. Its proof uses ~500 pages of analytic number theory (Rosser-Iwaniec sieve + Riemann zeta zero density estimates). These axioms are mathematically solid — proven results in the literature — but too complex to formalize in Lean 4 at present.",
+    "mathContext": "BHP 2001: $h \\geq x^{0.525}$ guarantees a prime in $[x, x+h]$. PNT: $\\pi(x) = \\text{Li}(x) + O(xe^{-c\\sqrt{\\ln x}})$ where $\\text{Li}(x) = \\int_2^x dt/\\ln t \\sim x/\\ln x$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Prime Number Theorem", "Baker-Harman-Pintz", "Rosser-Iwaniec sieve", "zero density estimates", "Filter.Tendsto"],
+    "prerequisites": ["Lean 4 axiom keyword", "Filter.atTop", "Real.log", "analytic number theory"]
+  },
+  {
+    "id": "ann-bp-oq03-06-open-conjectures",
+    "proofId": "bertrands-postulate-oq-03",
+    "range": { "startLine": 197, "endLine": 226 },
+    "type": "insight",
+    "title": "Open Conjectures: Cramér (1936) and Legendre (1845)",
+    "content": "`cramer_conjecture` formalizes the 1936 conjecture: there exists C > 0 such that every prime gap p_{n+1} - p_n ≤ C·(ln p_n)^2. This captures the probabilistic heuristic that primes behave like random integers of density 1/ln x. Under RH, Cramér proved gaps are O((ln p)^2·ln ln p) — the unconditional version remains open. `legendre_conjecture` states: for every n ≥ 1, there exists a prime p with n^2 < p ≤ (n+1)^2. It has been open since 1845, yet only intervals of length ~ n^(2/3) (Ingham 1937) are proved unconditionally. `bertrand_vs_legendre_comparison` notes that Bertrand doesn't imply Legendre: the two are independent.",
+    "mathContext": "Cramér: $\\limsup_{n\\to\\infty} (p_{n+1}-p_n)/(\\log p_n)^2 \\leq 1$. Legendre: $\\forall n \\geq 1, \\exists p \\text{ prime}, n^2 < p \\leq (n+1)^2$. Best unconditional: Ingham (1937) gives primes in $[n^2, n^2 + n^{2/3+\\varepsilon}]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cramér conjecture", "Legendre conjecture", "prime gaps", "Nth prime", "open problems"],
+    "prerequisites": ["Nat.nth Nat.Prime", "prime gaps", "historical number theory"]
+  },
+  {
+    "id": "ann-bp-oq03-07-prime-gap-conjecture",
+    "proofId": "bertrands-postulate-oq-03",
+    "range": { "startLine": 232, "endLine": 329 },
+    "type": "definition",
+    "title": "PrimeGapConjecture: Formal Definition, Monotonicity, and Summary",
+    "content": "`PrimeGapConjecture θ` is defined as: for all x ≥ 2, there exists a prime p with x ≤ p ≤ x + x^θ. Three results follow: `prime_gap_conjecture_bhp` proves PrimeGapConjecture 0.525 from the BHP axiom. `prime_gap_conjecture_monotone` proves that if PrimeGapConjecture θ₁ holds and θ₂ ≥ θ₁, then PrimeGapConjecture θ₂ holds — using `Real.rpow_le_rpow_of_exponent_le`. `density_question_status` proves three simultaneous goals: BHP (θ=0.525), Bertrand (θ=1), and existence of θ < 1 with PrimeGapConjecture. The Bertrand proof applies PrimeGapBounds.bertrand_postulate to ⌊x⌋₊, then uses floor bounds to convert between real and natural number arithmetic. `prime_density_summary` gives a clean four-way conjunction of the main proved results.",
+    "mathContext": "$\\text{PrimeGapConjecture}(\\theta) \\iff \\forall x \\geq 2, \\exists p \\text{ prime}, x \\leq p \\leq x + x^\\theta$. The infimum $\\theta^* = \\inf\\{\\theta : \\text{PrimeGapConjecture}(\\theta)\\}$ satisfies $\\theta^* \\leq 0.525$ (BHP) and is conjectured to equal 0.",
+    "significance": "key",
+    "relatedConcepts": ["PrimeGapConjecture", "Real.rpow_le_rpow_of_exponent_le", "Nat.floor_le", "floor/ceiling arithmetic"],
+    "prerequisites": ["Real.rpow", "Nat.floor", "prime gap conjecture", "BHP axiom"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass for bertrands-postulate-oq-03

**Quality improvements:**
- Added 7 annotations (was 0) covering all sections of BertrandsPostulateOQ03.lean
- Every annotation includes `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`

**Annotations added:**
1. `ann-bp-oq03-01-header` (lines 1–65): Density hierarchy table, historical timeline (Bertrand 1845 → BHP 2001), open question framing
2. `ann-bp-oq03-02-definitions` (lines 71–88): `primeCountInInterval`, monotonicity, and bridge lemma for prime counting
3. `ann-bp-oq03-03-bertrand-bounds` (lines 94–123): Four theorems — Bertrand single interval, π(2^m)≥m, iterated Bertrand, iterated density
4. `ann-bp-oq03-04-log-bound` (lines 129–147): `bertrand_density_lower_bound` — π(n) ≥ log₂(n) via Nat.pow_log_le_self + monotonicity + omega
5. `ann-bp-oq03-05-axioms` (lines 153–191): Three axioms — PNT (Filter.Tendsto), PNT medium interval density, Baker-Harman-Pintz (2001) θ=0.525
6. `ann-bp-oq03-06-open-conjectures` (lines 197–226): Cramér's and Legendre's conjectures formally stated as axioms with mathematical context
7. `ann-bp-oq03-07-prime-gap-conjecture` (lines 232–329): `PrimeGapConjecture θ` definition, monotonicity, BHP instantiation, density_question_status, summary

All annotations validated — zero new build errors introduced.