### PR TITLE
Enrich Buffon's Noodle Theorem (buffons-needle-oq-01)

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01/annotations.json
+++ b/src/data/proofs/buffons-needle-oq-01/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-buffon-oq01-01-header",
+    "proofId": "buffons-needle-oq-01",
+    "range": { "startLine": 1, "endLine": 63 },
+    "type": "context",
+    "title": "Buffon's Noodle: Historical Context and Proof Strategy",
+    "content": "The header introduces the Buffon-Barbier generalization: any curve of length L dropped on a parallel line grid (spacing d) has expected crossings 2L/(pi*d), independent of shape. The key insight stated in the header is linearity of expectation: approximate the curve by N segments, apply the needle formula to each, sum up. The header documents the 1777 Buffon to 1860 Barbier history and the connection to the full Cauchy-Crofton formula in integral geometry. The file proves the polygonal case fully, and axiomatizes the smooth curve generalization pending arc length theory in Mathlib.",
+    "mathContext": "$E[\\text{crossings}] = \\frac{2L}{\\pi d}$ regardless of curve shape. Linearity: $E[\\sum_i X_i] = \\sum_i E[X_i]$ even when $X_i$ are correlated. The Cauchy-Crofton formula: $\\int_0^\\pi \\int_{-\\infty}^\\infty n(C, (\\theta,\\rho))\\,d\\rho\\,d\\theta = 2\\cdot\\text{length}(C)$.",
+    "significance": "context",
+    "relatedConcepts": ["Buffon's needle", "Barbier 1860", "linearity of expectation", "Cauchy-Crofton formula", "integral geometry"],
+    "prerequisites": ["geometric probability", "expectation", "arc length", "Lean 4 imports"]
+  },
+  {
+    "id": "ann-buffon-oq01-02-crossing-prob",
+    "proofId": "buffons-needle-oq-01",
+    "range": { "startLine": 77, "endLine": 98 },
+    "type": "definition",
+    "title": "segmentCrossingProb: The Fundamental Buffon Formula",
+    "content": "segmentCrossingProb l d = 2*l/(pi*d) defines the probability that a single segment of length l crosses a line when dropped on a parallel line grid with spacing d. Three basic properties are proved: linearity segmentCrossingProb (c*l) d = c * segmentCrossingProb l d (by ring), zero at zero length (simp), and nonnegativity when l >= 0 and d > 0 (using div_nonneg + mul_pos pi_pos). This is the axiomatic foundation — the actual Buffon's Needle proof is in BuffonsNeedle.lean; this file builds on top of it.",
+    "mathContext": "$P(\\text{crossing} \\mid \\ell, d) = \\frac{2\\ell}{\\pi d}$. This formula results from integrating $P(\\text{crossing} \\mid \\theta) = \\ell|\\cos\\theta|/d$ over $\\theta \\sim \\text{Uniform}[0,\\pi]$: $(1/\\pi)\\int_0^\\pi (\\ell|\\cos\\theta|/d)\\,d\\theta = 2\\ell/(\\pi d)$.",
+    "significance": "key",
+    "relatedConcepts": ["Buffon's needle", "geometric probability", "Real.pi_pos", "ring tactic", "div_nonneg"],
+    "prerequisites": ["Buffon's needle formula", "div_nonneg", "Real.pi_pos"]
+  },
+  {
+    "id": "ann-buffon-oq01-03-polygonal-noodle",
+    "proofId": "buffons-needle-oq-01",
+    "range": { "startLine": 110, "endLine": 130 },
+    "type": "definition",
+    "title": "PolygonalNoodle: Minimal Structure Encoding Only Lengths",
+    "content": "PolygonalNoodle n is a structure parameterized by the number of segments n, carrying segLen : Fin n -> R (segment lengths) and nonneg : forall i, 0 <= segLen i. Two noncomputable definitions follow: totalLength N = sum_i segLen i and expectedCrossings N d = sum_i segmentCrossingProb (segLen i) d. The structure is intentionally minimal — it carries only lengths, not positions or angles. This design choice reflects the theorem's content: shape information is irrelevant. totalLength_nonneg uses Finset.sum_nonneg with the nonneg field.",
+    "mathContext": "The structure models: $N = (\\ell_1, \\ldots, \\ell_n)$ with $\\ell_i \\geq 0$. $L = \\sum_i \\ell_i$ and $E[N, d] = \\sum_i \\frac{2\\ell_i}{\\pi d}$. Angles are absent by design.",
+    "significance": "key",
+    "relatedConcepts": ["Lean 4 structure", "Finset.sum_nonneg", "Fin n", "noncomputable def", "BigOperators"],
+    "prerequisites": ["Lean 4 structures", "Finset.sum", "BigOperators notation", "Fin.univ"]
+  },
+  {
+    "id": "ann-buffon-oq01-04-main-theorem",
+    "proofId": "buffons-needle-oq-01",
+    "range": { "startLine": 140, "endLine": 161 },
+    "type": "theorem",
+    "title": "Buffon's Noodle Theorem: Pure Algebraic Proof via Finset.mul_sum",
+    "content": "buffon_noodle_polygon proves N.expectedCrossings d = 2 * N.totalLength / (pi * d). The proof is 4 lines: simp only unfolds expectedCrossings, totalLength, and segmentCrossingProb. Then hrewrite : 2 * N.segLen i / (pi * d) = 2/(pi*d) * N.segLen i (by ring). Then simp_rw [hrewrite, <- Finset.mul_sum] factors the constant 2/(pi*d) outside the sum. Finally ring closes the goal. The entire content of Buffon's Noodle -- that shape doesn't matter -- reduces to pulling a constant outside a finite sum.",
+    "mathContext": "$\\sum_i \\frac{2\\ell_i}{\\pi d} = \\frac{2}{\\pi d} \\sum_i \\ell_i = \\frac{2L}{\\pi d}$. The key step uses $\\leftarrow$ `Finset.mul_sum`: $\\sum_i (c \\cdot a_i) = c \\cdot \\sum_i a_i$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.mul_sum", "ring tactic", "simp_rw", "linearity of expectation"],
+    "prerequisites": ["PolygonalNoodle definitions", "segmentCrossingProb", "Finset.mul_sum", "ring arithmetic"]
+  },
+  {
+    "id": "ann-buffon-oq01-05-shape-independence",
+    "proofId": "buffons-needle-oq-01",
+    "range": { "startLine": 169, "endLine": 203 },
+    "type": "theorem",
+    "title": "Shape Independence and Scaling: Three Elegant Corollaries",
+    "content": "buffon_noodle_shape_independence proves N1.expectedCrossings d = N2.expectedCrossings d whenever N1.totalLength = N2.totalLength — proved in one line by rw [buffon_noodle_polygon, buffon_noodle_polygon, hSameLength]. needle_equals_noodle proves a single needle equals any equal-length noodle in expected crossings. buffon_noodle_scaling proves scaling all segment lengths by c scales expected crossings by c — proved by Finset.mul_sum + congr 1 + ext i + ring. These three theorems express the shape-independence principle from different angles.",
+    "mathContext": "Shape independence: $L(N_1) = L(N_2) \\implies E[N_1, d] = E[N_2, d]$. Needle-noodle equivalence: $\\text{segCross}(L, d) = E[N, d]$ when $L(N) = L$. Scaling: $E[cN, d] = c \\cdot E[N, d]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["shape independence", "needle-noodle equivalence", "Finset.mul_sum", "scaling linearity"],
+    "prerequisites": ["buffon_noodle_polygon", "simp_rw", "ring tactic"]
+  },
+  {
+    "id": "ann-buffon-oq01-06-smooth-cauchy-crofton",
+    "proofId": "buffons-needle-oq-01",
+    "range": { "startLine": 205, "endLine": 256 },
+    "type": "insight",
+    "title": "Smooth Curve Axiom and Cauchy-Crofton: The Deeper Mathematics",
+    "content": "The smooth curve case is axiomatized as buffon_noodle_smooth (with body True as a placeholder). Formalizing it requires: (1) a SmoothCurve type with arc length, (2) Mathlib.Analysis.Calculus.ArcLength, (3) a polygonal approximation theorem, and (4) continuity of the crossing functional. The Cauchy-Crofton comment explains the deeper mathematical content: the noodle theorem is a special case of the integral formula over all lines in the plane parameterized by angle theta and signed distance rho. This connects to kinematic measures on the space of oriented lines.",
+    "mathContext": "Cauchy-Crofton: $\\int_0^\\pi \\int_{-\\infty}^\\infty n(C, l_{\\theta,\\rho})\\,d\\rho\\,d\\theta = 2\\,L(C)$. Buffon is the restriction to $\\theta=0$ (parallel lines), giving the factor $2L/(\\pi d)$. The general formula works for any measure on lines, not just parallel families.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cauchy-Crofton formula", "arc length", "integral geometry", "kinematic measure"],
+    "prerequisites": ["Mathlib.Analysis.Calculus.ArcLength", "rectifiable curves", "measure theory on lines"]
+  },
+  {
+    "id": "ann-buffon-oq01-07-examples",
+    "proofId": "buffons-needle-oq-01",
+    "range": { "startLine": 264, "endLine": 318 },
+    "type": "insight",
+    "title": "Numerical Examples: Circle, Square, Regular n-gon",
+    "content": "Three concrete instantiations verify the formula. circle_expected_crossings: circumference 2*pi*r gives expected crossings 4r/d (proved by field_simp + ring using pi_ne_zero). The result 4r/d means a circle crosses each pair of adjacent lines exactly twice on average (entering and exiting). square_expected_crossings: a 4-segment PolygonalNoodle with equal sides s uses Fin.sum_univ_four to split into 4 terms, giving 8s/(pi*d). regular_polygon_crossings: n equal sides of length s uses Finset.sum_const + Finset.card_fin + nsmul_eq_mul + push_cast + ring to get 2*n*s/(pi*d). All reduce to 2L/(pi*d).",
+    "mathContext": "Circle ($L = 2\\pi r$): $E = 4r/d$. Square ($L = 4s$): $E = 8s/(\\pi d)$. $n$-gon ($L = ns$): $E = 2ns/(\\pi d)$. Verification: a circle with $r = d/4$ crosses exactly once per line on average.",
+    "significance": "supporting",
+    "relatedConcepts": ["circle circumference", "Fin.sum_univ_four", "Finset.sum_const", "Finset.card_fin", "field_simp"],
+    "prerequisites": ["buffon_noodle_polygon", "segmentCrossingProb", "Real.pi_ne_zero", "ring arithmetic"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass for buffons-needle-oq-01

Added 7 annotations (was 0) covering all sections of BuffonsNoodle.lean.
Every annotation includes mathContext (LaTeX), significance, relatedConcepts, prerequisites.

**Annotations:**
1. Header/historical context (lines 1-63): Buffon 1777 → Barbier 1860, Cauchy-Crofton connection
2. segmentCrossingProb (lines 77-98): Formula derivation from cosine integral, linearity/zero/nonneg properties
3. PolygonalNoodle structure (lines 110-130): Minimal design carrying only lengths, not angles
4. Main theorem (lines 140-161): Finset.mul_sum factoring proves E=2L/(πd) in 4 lines
5. Shape independence + scaling (lines 169-203): Three corollaries from the main theorem
6. Smooth curve axiom + Cauchy-Crofton (lines 205-256): Open formalization requirements, kinematic measure connection
7. Numerical examples (lines 264-318): Circle (4r/d), square (8s/πd), regular n-gon (2ns/πd)

Zero new build errors introduced.