### PR TITLE
Enrich Cantor Diagonalization and Continuum Hypothesis (cantor-diagonalization-oq-01)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-cantor-oq01-01-header",
+    "proofId": "cantor-diagonalization-oq-01",
+    "range": { "startLine": 1, "endLine": 57 },
+    "type": "context",
+    "title": "Open Question: What Can Diagonalization Prove About CH?",
+    "content": "The header frames the central question: Cantor's diagonal argument proves the gap aleph_0 < 2^aleph_0, but can it determine whether any cardinal lies between them? The Continuum Hypothesis (CH), posed in 1878, is Hilbert's Problem 1. The file imports Cardinal.Basic (Cantor's theorem), Cardinal.Ordinal (aleph numbers), Cardinal.Cofinality (for König's theorem), and local helpers CantorDiagonalization and ContinuumHypothesis. The header gives a clean table of what the diagonal CAN prove (cantor_gap, aleph_one_le_continuum, beth_strictly_increasing, ch_iff_no_intermediate) vs. what it CANNOT (the exact value of 2^aleph_0 in the aleph hierarchy).",
+    "mathContext": "The Cantor-Bernstein hierarchy: $\\aleph_0 < \\aleph_1 \\leq 2^{\\aleph_0} < 2^{2^{\\aleph_0}} < \\cdots$. CH states $2^{\\aleph_0} = \\aleph_1$. Gödel (1940): ZFC + CH is consistent. Cohen (1963): ZFC + ¬CH is consistent. So CH is independent of ZFC.",
+    "significance": "context",
+    "relatedConcepts": ["Continuum Hypothesis", "Cantor diagonalization", "Gödel constructible universe", "Cohen forcing", "ZFC independence"],
+    "prerequisites": ["cardinal arithmetic", "aleph numbers", "Lean 4 Mathlib set theory"]
+  },
+  {
+    "id": "ann-cantor-oq01-02-diagonal-gap",
+    "proofId": "cantor-diagonalization-oq-01",
+    "range": { "startLine": 63, "endLine": 94 },
+    "type": "theorem",
+    "title": "The Fundamental Diagonal Gap: cantor_gap and General Inequality",
+    "content": "cantor_gap is a one-line theorem: Cardinal.cantor aleph_0. Cardinal.cantor states the general diagonal inequality kappa < 2^kappa for any cardinal. Three additional results follow: continuum := 2^aleph_0 (def), aleph_zero_lt_continuum (alias for cantor_gap), diagonal_strict_inequality kappa := Cardinal.cantor kappa (the general case), and diagonal_argument_holds — a functional formulation using CantorDiagonalization.cantor_diagonalization showing every enumeration f : N -> (N -> Bool) misses the anti-diagonal sequence. These establish the gap in both cardinal-order and functional-witness forms.",
+    "mathContext": "Cantor's theorem: $\\forall \\kappa, \\kappa < 2^\\kappa$. At $\\kappa = \\aleph_0$: no $f: \\mathbb{N} \\to \\{0,1\\}^\\mathbb{N}$ is surjective. The diagonal witness: $d_n = 1 - f(n)(n)$ satisfies $\\forall n, d \\neq f(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Cardinal.cantor", "diagonal argument", "binary sequences", "CantorDiagonalization module"],
+    "prerequisites": ["Mathlib.SetTheory.Cardinal.Basic", "CantorDiagonalization", "Cardinal.{0} universe"]
+  },
+  {
+    "id": "ann-cantor-oq01-03-aleph-one",
+    "proofId": "cantor-diagonalization-oq-01",
+    "range": { "startLine": 99, "endLine": 127 },
+    "type": "definition",
+    "title": "aleph_one and the ZFC Bracket: aleph_0 < aleph_1 <= 2^aleph_0",
+    "content": "aleph_one := Cardinal.aleph 1. aleph_one_eq_succ_aleph_zero proves aleph_1 = Order.succ aleph_0 via Cardinal.aleph_succ and the ordinal identity 1 = succ 0. aleph_one_le_continuum then uses Order.succ_le_of_lt applied to cantor_gap. aleph_zero_lt_aleph_one uses Order.lt_succ directly. fundamental_zfc_bounds packages both into a conjunction aleph_0 < aleph_1 AND aleph_1 <= 2^aleph_0. This establishes the ZFC-provable bracket: regardless of CH, 2^aleph_0 is bounded below by the first uncountable aleph.",
+    "mathContext": "$\\aleph_1 = \\text{succ}(\\aleph_0)$ (smallest cardinal $> \\aleph_0$). Since $\\aleph_0 < 2^{\\aleph_0}$ and $\\aleph_1$ is minimal above $\\aleph_0$: $\\aleph_1 \\leq 2^{\\aleph_0}$. This is ZFC-provable and independent of CH.",
+    "significance": "key",
+    "relatedConcepts": ["Cardinal.aleph_succ", "Order.succ_le_of_lt", "Order.lt_succ", "minimal uncountable"],
+    "prerequisites": ["ordinal successor", "Cardinal.aleph", "Order.succ API"]
+  },
+  {
+    "id": "ann-cantor-oq01-04-beth-tower",
+    "proofId": "cantor-diagonalization-oq-01",
+    "range": { "startLine": 132, "endLine": 186 },
+    "type": "insight",
+    "title": "Beth Number Tower: Infinite Cardinal Hierarchy from Iterated Diagonalization",
+    "content": "beth is defined by recursion: beth 0 = aleph_0, beth (n+1) = 2^(beth n). beth_strictly_increasing proves beth n < beth (n+1) in one line by Cardinal.cantor (beth n) — the diagonal at each level. beth_lt_of_lt proves strict monotonicity for all n < m by induction using lt_trans. beth_generates_infinite_hierarchy shows the diagonal generates infinitely many distinct cardinals. This demonstrates that the diagonal argument does not stop at one gap but iterates forever, each level transcending the previous by a new diagonal argument.",
+    "mathContext": "$\\beth_n$: $\\beth_0 = \\aleph_0$, $\\beth_1 = 2^{\\aleph_0}$, $\\beth_2 = 2^{2^{\\aleph_0}}$. Strict monotonicity: $\\beth_n < \\beth_{n+1}$ by $\\kappa < 2^\\kappa$. The beth hierarchy is distinct from the aleph hierarchy unless the Generalized CH holds ($\\beth_n = \\aleph_n$ for all $n$).",
+    "significance": "supporting",
+    "relatedConcepts": ["beth numbers", "Cardinal.cantor", "strict monotonicity", "Generalized Continuum Hypothesis"],
+    "prerequisites": ["Cardinal.cantor", "structural recursion", "Nat.lt_succ_iff_lt_or_eq", "lt_trans"]
+  },
+  {
+    "id": "ann-cantor-oq01-05-ch-analysis",
+    "proofId": "cantor-diagonalization-oq-01",
+    "range": { "startLine": 192, "endLine": 276 },
+    "type": "insight",
+    "title": "CH Analysis: The Equivalence CH iff No Intermediate Cardinal",
+    "content": "CH := continuum = aleph_one. HasIntermediateCardinal := exists kappa, aleph_0 < kappa < continuum. ch_implies_no_intermediate: if CH then continuum = Order.succ aleph_0, so kappa < continuum forces kappa <= aleph_0 by Order.lt_succ_iff, contradicting aleph_0 < kappa. not_ch_means_gap: if not-CH then aleph_1 < continuum by lt_or_eq_of_le. not_ch_has_intermediate: aleph_1 is explicitly intermediate under not-CH. ch_iff_no_intermediate proves the bidirectional equivalence using le_antisymm with by_contra. This section formalizes the logical content of CH without forcing.",
+    "mathContext": "CH $\\iff 2^{\\aleph_0} = \\aleph_1 \\iff \\neg\\text{HasIntermediate}$. Under CH: $\\kappa < \\text{succ}(\\aleph_0)$ implies $\\kappa \\leq \\aleph_0$ (Order.lt_succ_iff). Under ¬CH: $\\aleph_1 < 2^{\\aleph_0}$ gives explicit intermediate $\\aleph_1$.",
+    "significance": "key",
+    "relatedConcepts": ["Continuum Hypothesis", "Order.lt_succ_iff", "le_antisymm", "by_contra", "push_neg"],
+    "prerequisites": ["aleph_one_eq_succ_aleph_zero", "Order.succ API", "aleph_one_le_continuum"]
+  },
+  {
+    "id": "ann-cantor-oq01-06-konig",
+    "proofId": "cantor-diagonalization-oq-01",
+    "range": { "startLine": 282, "endLine": 321 },
+    "type": "insight",
+    "title": "König's Theorem: cf(2^aleph_0) > aleph_0 Rules Out Singular Alephs",
+    "content": "König's cofinality bound is axiomatized: aleph_0 < cof(continuum.ord). Two axioms are used: konig_cofinality_bound and aleph_omega_cofinality_is_aleph_zero. From these, konig_rules_out_aleph_omega proves continuum != aleph_omega by contradiction: if continuum = aleph_omega then cof(continuum) = cof(aleph_omega) = aleph_0, contradicting König's bound. This shows that even without deciding CH, ZFC rules out all singular cardinals (those with countable cofinality) as possible values of 2^aleph_0. König's proof uses the general lemma sum_i kappa_i < prod_i lambda_i when kappa_i < lambda_i.",
+    "mathContext": "König's theorem: $\\text{cf}(2^{\\aleph_0}) > \\aleph_0$. Since $\\text{cf}(\\aleph_\\omega) = \\aleph_0$, we get $2^{\\aleph_0} \\neq \\aleph_\\omega$. More generally: $2^{\\aleph_0} \\neq \\aleph_\\lambda$ for any limit ordinal $\\lambda$ with $\\text{cf}(\\lambda) = \\omega$.",
+    "significance": "supporting",
+    "relatedConcepts": ["König's theorem", "cofinality", "singular cardinals", "aleph_omega", "Cardinal.Cofinality"],
+    "prerequisites": ["Ordinal.cof", "Cardinal.Cofinality module", "König's cardinal lemma"]
+  },
+  {
+    "id": "ann-cantor-oq01-07-summary",
+    "proofId": "cantor-diagonalization-oq-01",
+    "range": { "startLine": 326, "endLine": 434 },
+    "type": "insight",
+    "title": "The Limit of Diagonalization: ZFC vs. Independence",
+    "content": "The section doc enumerates 4 ZFC-provable facts vs. 3 ZFC-undecidable facts. diagonal_reaches_its_limit packages the ZFC-provable chain as a conjunction. cantor_diagonal_open_question_summary is the comprehensive four-part result: cantor_gap + aleph_one_le_continuum + (forall n, beth n < beth (n+1)) + ch_iff_no_intermediate. The conclusion comment summarizes: the diagonal reveals the gap exists and generates the beth tower, but cannot measure the width of the first gap — that question requires the forcing machinery of Cohen 1963. This file is unique in providing the formal statement of what ZFC can and cannot prove about CH in Lean 4.",
+    "mathContext": "ZFC proves: $\\aleph_0 < \\aleph_1 \\leq 2^{\\aleph_0}$, $\\text{cf}(2^{\\aleph_0}) > \\aleph_0$, $\\beth_n$ strictly increasing. ZFC does not prove: $2^{\\aleph_0} = \\aleph_1$ (Con(ZFC+CH), Gödel 1940) or $2^{\\aleph_0} > \\aleph_1$ (Con(ZFC+¬CH), Cohen 1963).",
+    "significance": "supporting",
+    "relatedConcepts": ["ZFC independence", "Gödel-Cohen", "beth_strictly_increasing", "forcing", "large cardinal axioms"],
+    "prerequisites": ["ch_iff_no_intermediate", "aleph_one_le_continuum", "König's bound", "Woodin's Ultimate-L"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass for cantor-diagonalization-oq-01

Added 7 annotations (was 0) covering all 7 sections of CantorDiagonalizationOQ01.lean.
Every annotation includes mathContext (LaTeX), significance, relatedConcepts, prerequisites.

**Annotations:**
1. Header (lines 1-57): CH independence context, Gödel 1940/Cohen 1963, what diagonal can/cannot prove
2. Diagonal gap (lines 63-94): Cardinal.cantor one-liner, general kappa < 2^kappa, functional witness form
3. aleph_1 <= 2^aleph_0 (lines 99-127): Order.succ_le_of_lt, ZFC bracket aleph_0 < aleph_1 <= 2^aleph_0
4. Beth tower (lines 132-186): Iterated diagonalization, strict monotonicity via induction + lt_trans
5. CH analysis (lines 192-276): CH definition, HasIntermediateCardinal, ch_iff_no_intermediate via Order.lt_succ_iff
6. König's constraint (lines 282-321): cf(2^aleph_0) > aleph_0, rules out aleph_omega and all singular alephs
7. Summary (lines 326-434): Four-part cantor_diagonal_open_question_summary, ZFC vs. independence table

Zero new build errors introduced.