### PR TITLE
Enrich proof gallery: cantors-theorem-oq-01 and more

### DIFF
--- a/src/data/proofs/combinations-formula/meta.json
+++ b/src/data/proofs/combinations-formula/meta.json
@@ -45,14 +45,15 @@
     "wiedijkNumber": 58
   },
   "overview": {
-    "historicalContext": "The binomial coefficient formula has been known for centuries. The notation C(n,k) comes from 'combinations', and the formula n!/(k!(n-k)!) was formalized as mathematicians developed the theory of permutations and combinations. Pascal's 1654 treatise 'Traite du triangle arithmetique' systematically explored these numbers, though the triangle itself was known earlier in China, Persia, and India.",
+    "historicalContext": "The binomial coefficient formula has roots in multiple ancient civilizations. In China, Yang Hui's triangle (1261 CE) displayed the same pattern now known as Pascal's triangle in the West. The Persian mathematician Al-Karaji (953–1029 CE) and Omar Khayyam (1048–1131) studied binomial expansions, and Pingala's Meru-prastaara from ancient India (around 200 BCE) encoded the same combinatorial structure in a different form.\n\nBlaise Pascal's 1654 treatise 'Traité du Triangle Arithmétique' gave the first systematic Western treatment, proving the recurrence C(n+1,k+1) = C(n,k) + C(n,k+1) and connecting the triangle to combinatorics, probability, and the binomial theorem. The factorial formula n!/(k!(n-k)!) emerged as the algebraic expression of the combinatorial count, with the divisibility n!/(k!(n-k)!) ∈ ℕ being a non-trivial fact requiring proof.\n\nIn modern mathematics, binomial coefficients appear throughout combinatorics (subset counting, multinomials), algebra (polynomial identities, generating functions), number theory (Lucas's theorem mod p, Kummer's theorem), and analysis (integral formulas for the Beta function, Vandermonde's identity). The Lean formalization as Wiedijk #58 uses Mathlib's `Nat.choose_eq_factorial_div_factorial` and `Finset.powersetCard` to connect the algebraic formula to the combinatorial interpretation.",
     "problemStatement": "**Theorem (Wiedijk #58)**: The number of ways to choose k elements from n elements is:\n\n$$C(n,k) = \\binom{n}{k} = \\frac{n!}{k!(n-k)!}$$\n\nThis formula counts the number of k-element subsets of an n-element set.",
     "proofStrategy": "**Factorial Interpretation:**\n\nWhen selecting k items from n:\n1. There are n! ways to arrange all n items\n2. We divide by k! because the order of selected items doesn't matter\n3. We divide by (n-k)! because the order of unselected items doesn't matter\n\nThis gives n! / (k! * (n-k)!).\n\n**Mathlib Approach:**\nThe formalization uses `Nat.choose_eq_factorial_div_factorial` which directly proves the factorial formula, combined with `Nat.factorial_mul_factorial_dvd_factorial` to ensure exact division.",
     "keyInsights": [
       "The formula arises from counting ordered selections (permutations) and removing the ordering",
       "Pascal's identity C(n+1, k+1) = C(n, k) + C(n, k+1) enables efficient computation",
       "Symmetry C(n,k) = C(n, n-k) reflects that choosing k is equivalent to choosing n-k to exclude",
-      "The binomial coefficient is always a natural number despite involving division"
+      "The binomial coefficient is always a natural number despite involving division",
+      "The generating function (1+x)^n = ∑_k C(n,k) x^k connects binomial coefficients to polynomial algebra, and Vandermonde's identity ∑_j C(m,j)C(n,k-j) = C(m+n,k) encodes convolution of subset counts — making C(n,k) a bridge between combinatorics and generating function calculus"
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass adding detailed annotations to proof gallery entries.

- cantors-theorem-oq-01: 8 annotations covering cardinal arithmetic imports, cardinality of ℝ, Cantor's diagonal argument, beth number hierarchy (with Order.succ_eq_add_one trick), aleph hierarchy/CH/¬CH, GCH conditional results, König's constraint axiom, and summary theorem