### PR TITLE
Enrich cevas-theorem-oq-02: add 7 annotations

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-02/annotations.json
+++ b/src/data/proofs/cevas-theorem-oq-02/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-cevas-oq02-01-header",
+    "proofId": "cevas-theorem-oq-02",
+    "range": { "startLine": 7, "endLine": 41 },
+    "type": "context",
+    "title": "Ceva-Menelaus Duality and Gauss-Bonnet in Non-Euclidean Geometry",
+    "content": "The header establishes the scope: this file extends non-Euclidean Ceva theory with Menelaus duality, angle excess/defect, and Gauss-Bonnet. Four main contributions: (1) Non-Euclidean Menelaus (product of signed sin-ratios or sinh-ratios = -1 for transversals), (2) Ceva-Menelaus duality (negating one ratio converts concurrent to collinear configuration), (3) spherical excess (α+β+γ - π = area, Girard's theorem), (4) hyperbolic defect (π - (α+β+γ) = area). The measure function ρ unifies all three geometries: ρ=id (Euclidean), ρ=sin (spherical), ρ=sinh (hyperbolic). Status is complete (no sorries). Imports are minimal: Real.Basic, trigonometric functions.",
+    "mathContext": "**Ceva's theorem** (1678): three cevians from vertices of a triangle are concurrent $\\iff$ $\\frac{BD}{DC} \\cdot \\frac{CE}{EA} \\cdot \\frac{AF}{FB} = 1$. **Menelaus's theorem** (~100 AD): a transversal line cuts the sides at $D, E, F$ $\\iff$ signed product $= -1$. **Non-Euclidean generalization**: replace ratios $BD/DC$ with $\\sin(BD)/\\sin(DC)$ (spherical) or $\\sinh(BD)/\\sinh(DC)$ (hyperbolic). **Gauss-Bonnet** (triangle form): $\\alpha + \\beta + \\gamma = \\pi + \\kappa \\cdot A$ where $\\kappa$ is Gaussian curvature.",
+    "significance": "context",
+    "relatedConcepts": ["Ceva's theorem", "Menelaus's theorem", "Gauss-Bonnet theorem", "spherical geometry", "hyperbolic geometry"],
+    "prerequisites": ["Real.sin_pos_of_pos_of_lt_pi", "Real.sinh_eq", "Real.pi", "non-Euclidean geometry"]
+  },
+  {
+    "id": "ann-cevas-oq02-02-signed-config",
+    "proofId": "cevas-theorem-oq-02",
+    "range": { "startLine": 49, "endLine": 106 },
+    "type": "definition",
+    "title": "SignedRatioConfig: Algebraic Framework for Ceva-Menelaus Conditions",
+    "content": "SignedRatioConfig is a structure with three nonzero reals r₁, r₂, r₃ (signed ratios) and nonzero proofs. signedProduct := r₁ * r₂ * r₃. menelausCondition := signedProduct = -1 (transversal). cevaCondition := signedProduct = 1 (concurrent). menelaus_product_characterization and ceva_product_characterization are one-line Iff.rfl proofs — the conditions ARE the product equations. The distinction between Ceva and Menelaus is purely algebraic: sign of the product. The signed ratios allow for external division points (negative ratios), which occur when the transversal cuts an extension rather than the side itself. For Menelaus, exactly one or three ratios are negative.",
+    "mathContext": "**Signed ratio convention**: if $D$ divides $BC$ internally, $BD/DC > 0$; if externally, $BD/DC < 0$. **Menelaus sign rule**: a transversal cuts exactly one or three sides externally, giving an odd number of negative ratios, so the signed product is negative. $(-1)^1 \\cdot (\\text{positive product}) = -1$ or $(-1)^3 \\cdot (\\text{positive product}) = -1$. **Ceva sign rule**: three concurrent cevians cut all sides internally (or all three extended sides), giving even negative count, so signed product is positive.",
+    "significance": "key",
+    "relatedConcepts": ["SignedRatioConfig", "menelausCondition", "cevaCondition", "signedProduct", "external division"],
+    "prerequisites": ["structure syntax", "Iff.rfl", "nonzero proofs in structures", "signed ratios"]
+  },
+  {
+    "id": "ann-cevas-oq02-03-duality",
+    "proofId": "cevas-theorem-oq-02",
+    "range": { "startLine": 111, "endLine": 167 },
+    "type": "insight",
+    "title": "Ceva-Menelaus Duality: Negating One Ratio Converts Between Conditions",
+    "content": "ceva_to_menelaus_by_negation: given cevaCondition cfg (product = 1), negating r₁ gives menelausCondition cfg' (product = -1). Proved by simp on both conditions then linarith. menelaus_to_ceva_by_negation: symmetric. ceva_menelaus_exclusive: a config cannot satisfy both (since 1 ≠ -1 leads to contradiction via linarith). ceva_menelaus_sign_duality: cevaCondition ↔ signedProduct = 1 (trivially Iff.rfl). The geometric interpretation: if three cevians from A, B, C to points D, E, F on BC, CA, AB are concurrent (Ceva), then 'reflecting' cevian AD to the external point D' on the extension gives a Menelaus transversal through D', E, F.",
+    "mathContext": "**Algebraic duality**: if $r_1 r_2 r_3 = 1$, then $(-r_1) r_2 r_3 = -1$. This is the key algebraic identity. **Geometric interpretation**: negating $r_1 = BD/DC$ means replacing $D$ (internal division point) with $D'$ on the extension of $BC$ with $BD'/D'C = -BD/DC$ (external division). **Exclusivity**: $r_1 r_2 r_3 = 1$ and $r_1 r_2 r_3 = -1$ are incompatible since $1 \\neq -1$. In projective geometry, Ceva and Menelaus are truly dual via the pole-polar relationship.",
+    "significance": "key",
+    "relatedConcepts": ["ceva_to_menelaus_by_negation", "menelaus_to_ceva_by_negation", "ceva_menelaus_exclusive", "neg_ne_zero", "linarith"],
+    "prerequisites": ["cevaCondition", "menelausCondition", "SignedRatioConfig", "neg_ne_zero.mpr", "linarith"]
+  },
+  {
+    "id": "ann-cevas-oq02-04-generalized-menelaus",
+    "proofId": "cevas-theorem-oq-02",
+    "range": { "startLine": 172, "endLine": 272 },
+    "type": "insight",
+    "title": "Non-Euclidean Menelaus: Spherical (sin) and Hyperbolic (sinh) Forms",
+    "content": "MenelausConfig has six positive measures bd, dc, ce, ea, af, fb with positivity proofs. menelausUnsignedProduct := (bd/dc) * (ce/ea) * (af/fb). generalized_menelaus: unsigned product = 1 ↔ bd·ce·af = dc·ea·fb, proved by div_mul_div_comm, div_mul_div_comm, and div_eq_one_iff_eq. spherical_menelaus: sin(bd)/sin(dc) * sin(ce)/sin(ea) * sin(af)/sin(fb) = 1 ↔ sin(bd)·sin(ce)·sin(af) = sin(dc)·sin(ea)·sin(fb), with arcs in (0,π) ensuring sin > 0 via Real.sin_pos_of_pos_of_lt_pi. hyperbolic_menelaus: sinh version with sinh_pos_of_pos' helper proved via Real.sinh_eq and exp_strictMono. Both prove the same algebraic structure via div_eq_one_iff_eq.",
+    "mathContext": "**Spherical Menelaus**: on a great circle transversal, arcs $BD, DC, CE, EA, AF, FB$ satisfy $\\frac{\\sin BD}{\\sin DC} \\cdot \\frac{\\sin CE}{\\sin EA} \\cdot \\frac{\\sin AF}{\\sin FB} = -1$ (signed). Since all arcs are in $(0,\\pi)$, $\\sin > 0$, and the sign comes from external division. **Hyperbolic Menelaus**: replace $\\sin$ by $\\sinh$. $\\sinh(x) > 0$ for $x > 0$ (proved via $\\sinh(x) = (e^x - e^{-x})/2$ and $e^x > 1$). **Key lemma**: $a/b = 1 \\iff a = b$ when $b \\neq 0$.",
+    "significance": "key",
+    "relatedConcepts": ["MenelausConfig", "spherical_menelaus", "hyperbolic_menelaus", "Real.sin_pos_of_pos_of_lt_pi", "sinh_pos_of_pos'"],
+    "prerequisites": ["div_mul_div_comm", "div_eq_one_iff_eq", "Real.sin_pos_of_pos_of_lt_pi", "Real.sinh_eq"]
+  },
+  {
+    "id": "ann-cevas-oq02-05-excess-defect",
+    "proofId": "cevas-theorem-oq-02",
+    "range": { "startLine": 278, "endLine": 347 },
+    "type": "insight",
+    "title": "Spherical Excess and Hyperbolic Defect: Angle Sum Encodes Curvature",
+    "content": "sphericalExcess α β γ := α + β + γ - π. sphericalTriangleArea := sphericalExcess (Girard's theorem: area = excess on unit sphere). spherical_excess_pos: if α,β,γ ∈ (0,π) and sum > π, then excess > 0 by linarith. euclidean_zero_excess: if sum = π, excess = 0. hyperbolicDefect α β γ := π - (α + β + γ). hyperbolicTriangleArea := hyperbolicDefect. hyperbolic_defect_pos: if sum < π, defect > 0. euclidean_zero_defect: if sum = π, defect = 0. All proofs are by linarith after unfolding — the angle sum conditions completely determine excess/defect. The positivity hypotheses capture the geometry: spherical triangles have angle sum > π, hyperbolic < π.",
+    "mathContext": "**Girard's theorem (1629)**: the area of a spherical triangle on the unit sphere equals its spherical excess $E = \\alpha + \\beta + \\gamma - \\pi$. For an octant (all angles $\\pi/2$): $E = 3\\pi/2 - \\pi = \\pi/2$, and area $= \\pi/2$ (1/8 of sphere of area $4\\pi$). **Hyperbolic defect**: for curvature $\\kappa = -1$, area $= \\pi - (\\alpha+\\beta+\\gamma)$. **Ideal triangle** ($\\alpha=\\beta=\\gamma=0$, vertices at $\\infty$): defect $= \\pi$, maximum area in hyperbolic plane.",
+    "significance": "key",
+    "relatedConcepts": ["sphericalExcess", "hyperbolicDefect", "Girard's theorem", "sphericalTriangleArea", "hyperbolicTriangleArea"],
+    "prerequisites": ["Real.pi", "linarith", "Girard's theorem", "angle sum in non-Euclidean geometry"]
+  },
+  {
+    "id": "ann-cevas-oq02-06-gauss-bonnet",
+    "proofId": "cevas-theorem-oq-02",
+    "range": { "startLine": 352, "endLine": 460 },
+    "type": "insight",
+    "title": "Gauss-Bonnet: Unified Curvature-Area-Angle Formula and Sign Consistency",
+    "content": "gaussBonnetTriangle κ α β γ area : Prop := α + β + γ = π + κ · area. gauss_bonnet_spherical: if gaussBonnetTriangle 1 α β γ area, then sphericalExcess = area (linarith). gauss_bonnet_hyperbolic: if gaussBonnetTriangle (-1), then hyperbolicDefect = area (linarith). gauss_bonnet_euclidean: κ=0 gives α+β+γ = π (linarith). ceva_menelaus_dichotomy: for any positive measure function ρ, proves (1) unsigned product = 1 ↔ numerator product = denominator product; (2) product = 1 → product ≠ -1. gauss_bonnet_sign_consistency: if area > 0, then κ > 0 ↔ angle sum > π, κ = 0 ↔ sum = π, κ < 0 ↔ sum < π (via nlinarith and linarith).",
+    "mathContext": "**Gauss-Bonnet (triangle form)**: $\\alpha + \\beta + \\gamma = \\pi + \\kappa A$ where $\\kappa$ is Gaussian curvature and $A$ area. Sign of $\\kappa$: $\\kappa > 0$ sphere, $\\kappa = 0$ plane, $\\kappa < 0$ hyperbolic. **Unified Ceva-Menelaus**: the dichotomy theorem holds for any positive measure function $\\rho$ — the proof is purely algebraic (div operations). This shows the measure-theoretic structure is irrelevant; only positivity of $\\rho$ matters. **nlinarith**: needed for nonlinear reasoning ($\\kappa \\cdot A > 0$ when both $\\kappa, A > 0$).",
+    "significance": "key",
+    "relatedConcepts": ["gaussBonnetTriangle", "gauss_bonnet_spherical", "ceva_menelaus_dichotomy", "gauss_bonnet_sign_consistency", "nlinarith"],
+    "prerequisites": ["gaussBonnetTriangle definition", "sphericalExcess", "hyperbolicDefect", "nlinarith tactic"]
+  },
+  {
+    "id": "ann-cevas-oq02-07-numerical",
+    "proofId": "cevas-theorem-oq-02",
+    "range": { "startLine": 465, "endLine": 501 },
+    "type": "insight",
+    "title": "Numerical Verifications: Octant, Right Hyperbolic, and Ideal Triangles",
+    "content": "Three concrete examples verify the theory. equilateral_spherical_excess: sphericalExcess (π/2) (π/2) (π/2) = π/2, proved by ring — the octant of the unit sphere has all angles π/2 and area π/2. sample_hyperbolic_defect: hyperbolicDefect (π/4) (π/4) (π/6) = π/3, proved by ring — angles π/4, π/4, π/6 sum to 2π/3 < π, giving defect π - 2π/3 = π/3. ideal_triangle_area: hyperbolicDefect 0 0 0 = π, proved by ring — the ideal triangle with all angles 0 (vertices at infinity in hyperbolic plane) has maximum area π. All three are pure ring computations using the definitions of sphericalExcess and hyperbolicDefect as linear functions of angles.",
+    "mathContext": "**Spherical octant**: triangle with vertices $(1,0,0), (0,1,0), (0,0,1)$ on the unit sphere. All three angles are $\\pi/2$, excess $= 3\\pi/2 - \\pi = \\pi/2$, area $= \\pi/2$ (one-eighth of total sphere area $4\\pi$). **Ideal hyperbolic triangle**: all vertices at infinity in the Poincaré disk model. Angles all $0$ (geodesics meet tangentially). Area $= \\pi$ (maximal for bounded hyperbolic regions). **ring tactic**: since excess and defect are linear in angles, all specific numerical values follow from ring arithmetic.",
+    "significance": "supporting",
+    "relatedConcepts": ["equilateral_spherical_excess", "sample_hyperbolic_defect", "ideal_triangle_area", "ring tactic", "Poincaré disk"],
+    "prerequisites": ["sphericalExcess", "hyperbolicDefect", "Real.pi arithmetic", "ring tactic"]
+  }
+]


### PR DESCRIPTION
## Summary
- Added 7 annotations to `cevas-theorem-oq-02` (previously empty)
- Covers: Ceva-Menelaus duality context, SignedRatioConfig framework, sign-flip duality theorem (1↔-1), non-Euclidean Menelaus for spherical (sin) and hyperbolic (sinh), spherical excess + hyperbolic defect, Gauss-Bonnet unified formula + sign consistency, numerical examples (octant/ideal triangle)
- All annotations include mathContext (LaTeX), significance, relatedConcepts, prerequisites

## Test plan
- [x] `pnpm annotations:build` passes with no errors for this proof
- [x] 7 annotations covering all 501 lines of the Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)