### PR TITLE
feat(enricher-1): enrich area-of-circle-oq-01-oq-02 annotations

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/annotations.json
@@ -1,32 +1,86 @@
 [
   {
-    "id": "ftc-application",
-    "line": 80,
+    "id": "ann-area-circle-oq02-01-header",
+    "proofId": "area-of-circle-oq-01-oq-02",
+    "range": { "startLine": 8, "endLine": 47 },
+    "type": "context",
+    "title": "Archimedes' Method: Area as Integral of Circumference Rings",
+    "content": "The header establishes the Archimedes 'sum of rings' derivation: a disk of radius r can be decomposed into thin annular rings of width dρ and circumference 2πρ, so total area = ∫₀ʳ 2πρ dρ = πr². The file formalizes this via the Fundamental Theorem of Calculus: if A'(r) = C(r) = 2πr, then A(r) = ∫₀ʳ C(ρ)dρ. Both FTC directions appear: Part 2 (integral of derivative = function difference) proves the main theorem, Part 1 (derivative of integral = integrand) closes the duality. The proof is complete (no sorries). Key imports: Mathlib.Analysis.SpecialFunctions.Integrals for the real integral machinery.",
+    "mathContext": "**Archimedes (~250 BC)**: the area of a circle equals the area of a right triangle with legs $r$ (radius) and $C = 2\\pi r$ (circumference): $A = \\frac{1}{2} r \\cdot 2\\pi r = \\pi r^2$. **FTC reformulation**: since $A(r) = \\pi r^2$, we have $A'(r) = 2\\pi r = C(r)$, so $A(r) = \\int_0^r C(\\rho)\\,d\\rho$ by FTC Part 2 (with $A(0) = 0$). **FTC Part 1**: conversely, $\\frac{d}{dr}\\int_0^r C(\\rho)\\,d\\rho = C(r)$, confirming the derivative of area is circumference.",
+    "significance": "context",
+    "relatedConcepts": ["Fundamental Theorem of Calculus", "Archimedes circle area", "circleArea", "circumference", "annular rings"],
+    "prerequisites": ["Mathlib.Analysis.SpecialFunctions.Integrals", "intervalIntegral", "HasDerivAt", "Real.pi"]
+  },
+  {
+    "id": "ann-area-circle-oq02-02-definitions",
+    "proofId": "area-of-circle-oq-01-oq-02",
+    "range": { "startLine": 53, "endLine": 60 },
+    "type": "definition",
+    "title": "circleArea and circumference: The Two Linked Functions",
+    "content": "circleArea (r : ℝ) := Real.pi * r ^ 2 — the area formula as a real-valued function of radius. circumference (r : ℝ) := 2 * Real.pi * r — the perimeter formula. Both are noncomputable since Real.pi is transcendental. The relationship A'(r) = C(r) is the mathematical heart of the file: differentiation of area yields circumference. This is analogous to the sphere-ball relationship: d/dr(4πr³/3) = 4πr² (surface area). The choice of ℝ → ℝ (vs. ℝ≥0 → ℝ) allows signed arithmetic needed for the FTC proof while nonnegativity is proved separately.",
+    "mathContext": "**circleArea** $A(r) = \\pi r^2$: area of a disk of radius $r$ in $\\mathbb{R}^2$. **circumference** $C(r) = 2\\pi r$: perimeter of a circle of radius $r$. **Key relation**: $\\frac{d}{dr}A(r) = 2\\pi r = C(r)$. **Analogy**: $\\frac{d}{dr}(\\frac{4}{3}\\pi r^3) = 4\\pi r^2$ (ball volume → sphere area). **Real.pi**: Mathlib's formalization of $\\pi = 4 \\cdot \\arctan 1$, proved transcendental via the Lindemann-Weierstrass theorem.",
+    "significance": "key",
+    "relatedConcepts": ["circleArea", "circumference", "Real.pi", "noncomputable", "Real.pi_pos"],
+    "prerequisites": ["Real.pi definition", "noncomputable in Lean 4", "power notation"]
+  },
+  {
+    "id": "ann-area-circle-oq02-03-deriv",
+    "proofId": "area-of-circle-oq-01-oq-02",
+    "range": { "startLine": 61, "endLine": 77 },
     "type": "insight",
-    "text": "This is the core of the proof: FTC Part 2 (integral_eq_sub_of_hasDerivAt) turns the integration problem into a differentiation problem. Since we already proved dA/dr = C(r) in the companion entry, the FTC hands us the result directly."
+    "title": "hasDerivAt_circleArea: Formalizing A'(r) = C(r) via Power Rule",
+    "content": "hasDerivAt_circleArea (r : ℝ): HasDerivAt circleArea (circumference r) r — the derivative of πr² at r is 2πr. Proved by: unfold circleArea circumference, then use HasDerivAt for power functions: hasDerivAt_pow 2 r gives d/dr(r²) = 2r, scaled by pi via HasDerivAt.const_mul. continuous_circleArea: Continuous circleArea — follows from continuity of r² (continuous_pow) scaled by pi. continuous_circumference: Continuous circumference — linear function, continuous by continuity_const and continuity_id. These three lemmas are prerequisites for the FTC application: HasDerivAt gives the pointwise derivative, Continuous gives integrability of the integrand.",
+    "mathContext": "**HasDerivAt f f' x**: Mathlib's formalization of 'f has derivative f' at point x' using the Fréchet derivative. For $f(r) = \\pi r^2$: $f'(r) = \\pi \\cdot 2r = 2\\pi r = C(r)$. **Proof strategy**: $\\frac{d}{dr}(\\pi r^2) = \\pi \\cdot \\frac{d}{dr}(r^2) = \\pi \\cdot 2r$ using linearity of differentiation. **HasDerivAt.const_mul**: if $f$ has derivative $f'$ at $x$, then $c \\cdot f$ has derivative $c \\cdot f'$ at $x$. **Why continuous matters**: FTC requires the integrand to be integrable; for continuous functions on compact intervals this is automatic via `ContinuousOn.intervalIntegrable`.",
+    "significance": "key",
+    "relatedConcepts": ["HasDerivAt", "hasDerivAt_pow", "HasDerivAt.const_mul", "continuous_pow", "ContinuousOn.intervalIntegrable"],
+    "prerequisites": ["HasDerivAt API", "hasDerivAt_pow", "continuous_pow", "continuous_const", "continuous_id"]
   },
   {
-    "id": "integrability",
-    "line": 82,
-    "type": "technique",
-    "text": "Continuity implies integrability: any continuous function is Riemann integrable on any bounded interval. Mathlib's `Continuous.intervalIntegrable` packages this fact for us."
-  },
-  {
-    "id": "circleArea-zero",
-    "line": 85,
+    "id": "ann-area-circle-oq02-04-main-ftc",
+    "proofId": "area-of-circle-oq-01-oq-02",
+    "range": { "startLine": 79, "endLine": 96 },
     "type": "insight",
-    "text": "After applying FTC, the goal becomes circleArea r - circleArea 0 = circleArea r. The `simp [circleArea]` closes this by computing circleArea 0 = π * 0² = 0."
+    "title": "area_from_integral: Main FTC Proof That ∫₀ʳ C(ρ)dρ = A(r)",
+    "content": "area_from_integral (r : ℝ) (hr : 0 ≤ r): ∫ ρ in 0..r, circumference ρ = circleArea r. Proof uses integral_eq_sub_of_hasDerivAt (FTC Part 2): if F has derivative f on [a,b] and f is integrable, then ∫_a^b f = F(b) - F(a). Applied with F = circleArea, f = circumference, a = 0, b = r: ∫₀ʳ C = A(r) - A(0) = πr² - 0 = πr², then simp [circleArea] closes. The integrability hypothesis is discharged by continuous_circumference.continuousOn.intervalIntegrable. area_from_integral_nonneg: the integral is nonneg (by rewriting with area_from_integral and applying mul_nonneg pi_pos.le hr²).",
+    "mathContext": "**FTC Part 2 (Mathlib)**: `integral_eq_sub_of_hasDerivAt`: for $F$ with $F' = f$ on $[a,b]$ and $f$ integrable, $\\int_a^b f = F(b) - F(a)$. Applied here: $\\int_0^r C(\\rho)\\,d\\rho = A(r) - A(0) = \\pi r^2 - 0 = \\pi r^2$. **Boundary condition $A(0) = 0$**: $\\pi \\cdot 0^2 = 0$, giving the correct additive constant. **Integrability**: continuous functions on $[0,r]$ are automatically Riemann/Lebesgue integrable — `ContinuousOn.intervalIntegrable` handles this.",
+    "significance": "key",
+    "relatedConcepts": ["integral_eq_sub_of_hasDerivAt", "intervalIntegrable", "circleArea", "circumference", "mul_nonneg"],
+    "prerequisites": ["integral_eq_sub_of_hasDerivAt", "ContinuousOn.intervalIntegrable", "hasDerivAt_circleArea", "continuous_circumference"]
   },
   {
-    "id": "annulus-formula",
-    "line": 108,
-    "type": "application",
-    "text": "The annulus area formula generalizes the disk area: the area between two circles of radii r₁ and r₂ is π(r₂² - r₁²). This follows from the same FTC argument applied on [r₁, r₂] instead of [0, r]."
-  },
-  {
-    "id": "ftc-part1-duality",
-    "line": 124,
+    "id": "ann-area-circle-oq02-05-explicit-annulus",
+    "proofId": "area-of-circle-oq-01-oq-02",
+    "range": { "startLine": 98, "endLine": 122 },
     "type": "insight",
-    "text": "This theorem closes the circle (FTC duality): differentiating the integral ∫₀ˢ C(ρ) dρ recovers C(s). Combined with the main theorem, we have A = ∫C and C = A' — the full FTC package for circle geometry."
+    "title": "Explicit Formula and Annulus Area via Linearity of Integration",
+    "content": "area_from_integral_explicit (r : ℝ) (hr : 0 ≤ r): ∫ ρ in 0..r, 2 * π * ρ = π * r^2. This unfolds circumference and uses integral_comp_mul_right or integral_mul_right to get ∫₀ʳ 2πρ dρ = 2π·∫₀ʳ ρ dρ = 2π·r²/2 = πr². annulus_area_from_integral: ∫ ρ in r₁..r₂, circumference ρ = circleArea r₂ - circleArea r₁ for r₁ ≤ r₂. Proved by area_from_integral applied at r₁ and r₂ with integral_comp_sub. annulus_area_formula: the annulus area equals π(r₂² - r₁²) = π(r₂-r₁)(r₂+r₁) — the factored form. These formalize the physical intuition: a thin ring of width Δr ≈ 2πr·Δr.",
+    "mathContext": "**Annulus area**: region between circles of radii $r_1 \\leq r_2$. Area $= \\pi r_2^2 - \\pi r_1^2 = \\pi(r_2^2 - r_1^2) = \\pi(r_2-r_1)(r_2+r_1)$. **Physical limit**: for thin ring $r_2 = r_1 + \\varepsilon$: area $\\approx \\pi \\cdot 2r_1 \\cdot \\varepsilon = C(r_1) \\cdot \\varepsilon$, confirming the Archimedes 'ring' picture. **Integration of $\\rho$**: $\\int_0^r \\rho\\,d\\rho = r^2/2$, a standard Riemann sum calculation. In Mathlib: `integral_pow` or direct computation via `intervalIntegral.integral_comp_mul_right`.",
+    "significance": "supporting",
+    "relatedConcepts": ["annulus_area_from_integral", "annulus_area_formula", "integral_comp_sub", "intervalIntegral.integral_comp_mul_right", "ring lemma"],
+    "prerequisites": ["area_from_integral", "intervalIntegral additivity", "integral_pow", "mul_comm ring arithmetic"]
+  },
+  {
+    "id": "ann-area-circle-oq02-06-ftc-part1",
+    "proofId": "area-of-circle-oq-01-oq-02",
+    "range": { "startLine": 123, "endLine": 131 },
+    "type": "insight",
+    "title": "diff_area_eq_circumference: FTC Part 1 Closes the Duality",
+    "content": "diff_area_eq_circumference (r : ℝ): deriv circleArea r = circumference r. Proof: HasDerivAt.deriv applied to hasDerivAt_circleArea r — if HasDerivAt f f' x holds, then deriv f x = f' by uniqueness of derivatives. This completes the FTC loop: Part 2 (area_from_integral) says ∫₀ʳ C = A(r), and Part 1 (diff_area_eq_circumference) says d/dr(A(r)) = C(r). Together: the area function is characterized by having the circumference as its derivative with A(0) = 0. The theorem also closes the inverse relationship: differentiating ∫₀ʳ C(ρ)dρ w.r.t. r recovers C(r).",
+    "mathContext": "**FTC Part 1**: if $F(r) = \\int_0^r f(\\rho)\\,d\\rho$ and $f$ is continuous, then $F'(r) = f(r)$. Applied: $A'(r) = \\frac{d}{dr}\\int_0^r C(\\rho)\\,d\\rho = C(r)$. **Mathlib**: `HasDerivAt.deriv` converts `HasDerivAt f f' x` to `deriv f x = f'`. The `deriv` function in Lean returns 0 when the function is not differentiable, making it total; `HasDerivAt` certifies the actual derivative value. **Duality**: $\\int_0^r A'(\\rho)\\,d\\rho = A(r) - A(0)$ ↔ $\\frac{d}{dr}\\int_0^r A'(\\rho)\\,d\\rho = A'(r)$.",
+    "significance": "key",
+    "relatedConcepts": ["HasDerivAt.deriv", "deriv", "hasDerivAt_circleArea", "diff_area_eq_circumference", "FTC Part 1"],
+    "prerequisites": ["HasDerivAt.deriv uniqueness", "hasDerivAt_circleArea", "deriv API in Lean 4"]
+  },
+  {
+    "id": "ann-area-circle-oq02-07-unit-scaling",
+    "proofId": "area-of-circle-oq-01-oq-02",
+    "range": { "startLine": 133, "endLine": 145 },
+    "type": "insight",
+    "title": "Unit Disk and Scaling: Concrete Verifications of the Area Formula",
+    "content": "unit_disk_area: circleArea 1 = Real.pi — the unit disk has area π. Proved by simp [circleArea] (π * 1² = π). area_scaling (r : ℝ) (hr : 0 ≤ r): circleArea r = r ^ 2 * circleArea 1 — the area scales as r². Proved by simp [circleArea, mul_comm] — πr² = r² · π. These verify two key properties: (1) the normalization constant equals π (not 2π, 4π, etc.), and (2) the scaling law r ↦ λr sends area to λ²·area (dimensional analysis: area is 2-homogeneous). The scaling law is a special case of the general formula for how 2D measures scale under homothety.",
+    "mathContext": "**Unit disk area**: $A(1) = \\pi \\cdot 1^2 = \\pi \\approx 3.14159...$. This is both a numerical check and a definition of $\\pi$ as 'the area of the unit disk'. **Scaling law**: for homothety $T_\\lambda: x \\mapsto \\lambda x$, the 2D Lebesgue measure scales as $|T_\\lambda(E)| = \\lambda^2 |E|$. For disks: $A(\\lambda r) = \\pi(\\lambda r)^2 = \\lambda^2 \\cdot \\pi r^2 = \\lambda^2 A(r)$. Setting $r=1$: $A(\\lambda) = \\lambda^2 \\cdot A(1) = \\lambda^2 \\pi$. **Dimensional analysis**: area has dimensions $[L]^2$, so $A(cr) = c^2 A(r)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["unit_disk_area", "area_scaling", "circleArea", "Real.pi", "mul_comm", "pow_mul_comm"],
+    "prerequisites": ["circleArea definition", "simp with ring arithmetic", "Real.pi_pos", "pow_succ"]
   }
 ]


### PR DESCRIPTION
## Summary
- Replace 5 legacy-format annotations (line/type/text) with 7 full-format annotations
- Covers: Archimedes ring derivation context, circleArea/circumference definitions, hasDerivAt power rule, main FTC Part 2 theorem, explicit formula + annulus area, FTC Part 1 duality, unit disk area + scaling law
- All annotations include mathContext (LaTeX), significance, relatedConcepts, prerequisites

## Proof: area-of-circle-oq-01-oq-02 (AreaFromCircumferenceIntegral.lean)
Formalizes A(r) = ∫₀ʳ C(ρ)dρ = πr² via the Fundamental Theorem of Calculus, following Archimedes' "sum of rings" derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)