### PR TITLE
research: prove zp_rotation_isometry and zp_rotation_free_statement (borsuk-ulam-oq-02)

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02.lean
+++ b/proofs/Proofs/BorsukUlamOQ02.lean
@@ -178,9 +178,22 @@ noncomputable def zp_rotation (p : ℕ) (hp : 0 < p) :
 theorem zp_rotation_isometry (p : ℕ) (hp : 0 < p) :
     ∀ v : EuclideanSpace ℝ (Fin 2), ‖zp_rotation p hp v‖ = ‖v‖ := by
   intro v
-  -- The rotation matrix R_θ satisfies ‖R_θ v‖² = x²+y² = ‖v‖² by cos²+sin²=1
-  -- Technical proof via EuclideanSpace.norm_eq requires detailed unfolding
-  sorry
+  set x := v ⟨0, by omega⟩ with hx_def
+  set y := v ⟨1, by omega⟩ with hy_def
+  set θ := (2 : ℝ) * Real.pi / p with hθ_def
+  -- Key identity: rotation preserves norm via cos²θ + sin²θ = 1
+  have key : (x * Real.cos θ - y * Real.sin θ) ^ 2 +
+             (x * Real.sin θ + y * Real.cos θ) ^ 2 = x ^ 2 + y ^ 2 := by
+    linear_combination (x ^ 2 + y ^ 2) * Real.cos_sq_add_sin_sq θ
+  -- Get coordinate values of the rotated vector
+  have h0 : (zp_rotation p hp v) ⟨0, by omega⟩ = x * Real.cos θ - y * Real.sin θ := by
+    simp [zp_rotation, EuclideanSpace.equiv_symm_pi_lp_apply]
+  have h1 : (zp_rotation p hp v) ⟨1, by omega⟩ = x * Real.sin θ + y * Real.cos θ := by
+    simp [zp_rotation, EuclideanSpace.equiv_symm_pi_lp_apply, Fin.ext_iff]
+  -- Compute norms using the component formula
+  rw [EuclideanSpace.norm_eq, EuclideanSpace.norm_eq, Fin.sum_univ_two, Fin.sum_univ_two]
+  simp only [Real.norm_eq_abs, sq_abs, h0, h1, hx_def.symm, hy_def.symm]
+  exact congr_arg Real.sqrt key
 
 /-- For Z/p equivariant Borsuk-Ulam: a map f equivariant under a free Z/p rotation
     action on S^(2n-1) must vanish. Here we pass the actions explicitly as functions
@@ -206,7 +219,73 @@ theorem zp_rotation_free_statement (p : ℕ) (hp : Nat.Prime p) :
     ∀ k : ZMod p, k ≠ 0 →
     ∀ x : EuclideanSpace ℝ (Fin 2), x ∈ Metric.sphere (0 : EuclideanSpace ℝ (Fin 2)) 1 →
     zp_rotation p hp.pos x ≠ x := by
-  sorry -- Requires analyzing when cos(2π/p)=1 and sin(2π/p)=0 simultaneously, which fails for 1 ≤ k < p
+  intro _k _hk x hx heq
+  -- The sphere condition: ‖x‖ = 1
+  rw [Metric.mem_sphere, dist_zero_right] at hx
+  -- The rotation by θ = 2π/p fixes x iff (cosθ-1)*(x₀²+x₁²) = 0 and sin θ can be resolved
+  -- For prime p ≥ 2, cos(2π/p) ≠ 1, so the rotation has no fixed points on S¹
+  set x₀ := x ⟨0, by omega⟩ with hx₀
+  set x₁ := x ⟨1, by omega⟩ with hx₁
+  set θ := (2 : ℝ) * Real.pi / p with hθ
+  -- From heq: components must be equal
+  have heq0 : (zp_rotation p hp.pos x) ⟨0, by omega⟩ = x₀ := by
+    exact congr_fun (congrArg _ heq) ⟨0, by omega⟩
+  have heq1 : (zp_rotation p hp.pos x) ⟨1, by omega⟩ = x₁ := by
+    exact congr_fun (congrArg _ heq) ⟨1, by omega⟩
+  -- Get the rotation values
+  simp only [zp_rotation, EuclideanSpace.equiv_symm_pi_lp_apply, hx₀, hx₁] at heq0 heq1
+  -- heq0 : x₀ * cos θ - x₁ * sin θ = x₀
+  -- heq1 : x₀ * sin θ + x₁ * cos θ = x₁
+  -- cos(2π/p) ≠ 1 for prime p ≥ 2: since 2π/p ∈ (0, 2π), Real.cos_eq_one_iff gives
+  -- cos(θ) = 1 iff θ = 2π*n for integer n, but 2π/p < 2π for p ≥ 2
+  have hcos_ne_one : Real.cos θ ≠ 1 := by
+    intro h
+    rw [Real.cos_eq_one_iff] at h
+    obtain ⟨n, hn⟩ := h
+    -- hn : (n : ℝ) * (2 * Real.pi) = θ = 2 * Real.pi / p
+    have hpi_pos : (0 : ℝ) < Real.pi := Real.pi_pos
+    have hp_pos : (0 : ℝ) < p := Nat.cast_pos.mpr hp.pos
+    have : (n : ℝ) * p = 1 := by
+      field_simp [ne_of_gt hpi_pos, ne_of_gt hp_pos] at hn ⊢
+      linarith [hn.symm]
+    -- n * p = 1 but p ≥ 2, contradiction
+    have hp2 : (p : ℝ) ≥ 2 := by exact_mod_cast hp.two_le
+    have habs : (n : ℝ) * p ≥ 2 ∨ (n : ℝ) * p ≤ -2 ∨ n = 0 := by
+      rcases le_or_lt 1 n with h | h
+      · left; nlinarith
+      · rcases le_or_lt n (-1) with h2 | h2
+        · right; left; nlinarith
+        · right; right; exact_mod_cast Int.le_antisymm (by exact_mod_cast le_of_lt h2) (by exact_mod_cast le_of_lt h)
+    rcases habs with h | h | h
+    · linarith
+    · linarith
+    · simp [h] at this; linarith [hp2]
+  -- Now from heq0: x₀ * (cos θ - 1) = x₁ * sin θ
+  -- From heq1: x₀ * sin θ = x₁ * (1 - cos θ)
+  -- Multiplying: x₀² * sin θ * (cos θ - 1) = x₁² * sin θ * (1 - cos θ)
+  -- So (x₀² + x₁²) * sin θ * (1 - cos θ) = 0
+  -- Since ‖x‖ = 1, x₀² + x₁² = 1, so sin θ * (1 - cos θ) = 0
+  -- But 1 - cos θ ≠ 0 (since cos θ ≠ 1), so sin θ = 0
+  -- But sin²θ + cos²θ = 1 and sin θ = 0 → cos θ = ±1
+  -- cos θ ≠ 1 means cos θ = -1; but then from heq0: -2x₀ = 0 → x₀ = 0
+  -- and from heq1: x₁ * (-1-1) = 0 → x₁ = 0; but x₀²+x₁²=1, contradiction.
+  -- The norm condition gives x₀² + x₁² = 1
+  have hnorm : x₀ ^ 2 + x₁ ^ 2 = 1 := by
+    have := hx
+    rw [EuclideanSpace.norm_eq, Fin.sum_univ_two] at this
+    simp only [Real.norm_eq_abs, sq_abs] at this
+    nlinarith [Real.sqrt_eq_one'.mp this, sq_nonneg x₀, sq_nonneg x₁,
+               Real.sq_sqrt (by positivity : (0 : ℝ) ≤ x₀ ^ 2 + x₁ ^ 2)]
+  -- From the fixed-point equations:
+  have heq0' : x₀ * Real.cos θ - x₁ * Real.sin θ = x₀ := by
+    simpa [Fin.ext_iff] using heq0
+  have heq1' : x₀ * Real.sin θ + x₁ * Real.cos θ = x₁ := by
+    simpa [Fin.ext_iff] using heq1
+  -- (x₀² + x₁²) * (1 - cos θ) = 0
+  have hdet : (x₀ ^ 2 + x₁ ^ 2) * (1 - Real.cos θ) = 0 := by nlinarith [heq0', heq1',
+    sq_nonneg x₀, sq_nonneg x₁]
+  rw [hnorm, one_mul] at hdet
+  exact hcos_ne_one (by linarith)
 
 -- ============================================================
 -- PART 4: Dold's Theorem (Cohomological Index)

--- a/src/data/research/problems/borsuk-ulam-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02.json
@@ -42,10 +42,10 @@
     "goal": "Survey the landscape of equivariant Borsuk-Ulam theorems and prove accessible lemmas"
   },
   "currentState": {
-    "phase": "SURVEYED",
+    "phase": "completed",
     "since": "2026-02-24T06:30:00Z",
     "iteration": 1,
-    "focus": "Formalized equivariant framework: Z/2 case proved, Z/p and Dold axiomatized",
+    "focus": "All theorem sorries proved; axioms remain for deep results",
     "blockers": [
       "Z/p freeness proof requires analyzing when cos(2π/p)=1 simultaneously for all coordinates",
       "Cohomological index theory (Fadell-Husseini) not in Mathlib",
@@ -59,7 +59,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: Created BorsukUlamOQ02.lean with full equivariant Borsuk-Ulam landscape. Key: Z/2 case proved (from classical BU axiom via odd function reformulation), Z/p Yang-Borsuk and Dold axiomatized, basic equivariance lemmas proved (comp, id, const, orbits). 2 sorries: zp_rotation_isometry (technical EuclideanSpace unfold) and zp_rotation_free_statement (trigonometric argument).",
+    "progressSummary": "PROGRESS: All theorem sorries resolved. BorsukUlamOQ02.lean has 0 theorem sorries, 4 axioms (yang_borsuk, z2_equivariant_bu, dold, equivariant_bu_free_G). zp_rotation_isometry and zp_rotation_free_statement proved. Axioms remain for deep topological results (Yang-Borsuk theorem, Dold theorem, general G case).",
     "builtItems": [
       "BorsukUlamOQ02.lean: 8 proved theorems, 5 axioms, 2 sorries",
       "IsEquivariant def: f(g·x) = g·f(x) for G-equivariant maps",
@@ -69,7 +69,9 @@
       "classical_borsuk_ulam_from_equivariant: BU from odd function vanishing",
       "zp_rotation: noncomputable Z/p rotation on EuclideanSpace R^2",
       "yang_borsuk_theorem axiom: Z/p free equivariant maps vanish",
-      "dold_theorem axiom: cohomological obstruction (free G-space)"
+      "dold_theorem axiom: cohomological obstruction (free G-space)",
+      "zp_rotation_isometry: proved ‖R_θ v‖ = ‖v‖ via cos²+sin²=1 (linear_combination + norm_eq)",
+      "zp_rotation_free_statement: proved no fixed points on S¹ for prime p (cos(2π/p)≠1 contradiction)"
     ],
     "insights": [
       "Z/2 equivariance = odd function: f(-x) = -f(x) iff Z/2-equivariant; classical BU proved via difference function g(x)=f(x)-f(-x) which is odd",
@@ -79,7 +81,10 @@
       "Dold's theorem (1983): If G acts freely on (n-1)-connected space X and dim Y < n, then no G-equivariant map X → Y. Proof: cohomological index / Borel construction",
       "Fadell-Husseini ideal-valued cohomological index (1988): systematic approach; not in Mathlib",
       "For composite order: use Sylow subgroups — Z/p^k subgroup of Z/6 (p=2 or 3) gives Yang-Borsuk type result",
-      "The Z/p freeness on S^(2n-1): ω^k·z=z with z≠0 requires ω^k=1 in each complex coordinate, but ω=e^(2πi/p) is a primitive root, so k≡0 (mod p)"
+      "The Z/p freeness on S^(2n-1): ω^k·z=z with z≠0 requires ω^k=1 in each complex coordinate, but ω=e^(2πi/p) is a primitive root, so k≡0 (mod p)",
+      "EuclideanSpace.equiv_symm_pi_lp_apply is the key simp lemma for coordinate extraction in PiLp 2",
+      "linear_combination with cos²+sin²=1 cleanly proves rotation norm preservation",
+      "For cos(2π/p)≠1: n*p=1 has no integer solution with p≥2; use nlinarith case analysis on n=0,±1"
     ],
     "mathlibGaps": [
       "Cohomological index theory (Fadell-Husseini, 1988)",


### PR DESCRIPTION
## Summary

Research session for borsuk-ulam-oq-02 (Equivariant Borsuk-Ulam Extensions).

## Progress

Proved 2 remaining theorem sorries in `BorsukUlamOQ02.lean`:

**1. `zp_rotation_isometry`**: Z/p rotation preserves sphere norm
- Key step: `linear_combination (x² + y²) * Real.cos_sq_add_sin_sq θ` proves `(x·cosθ - y·sinθ)² + (x·sinθ + y·cosθ)² = x² + y²`
- Coordinate extraction via `EuclideanSpace.equiv_symm_pi_lp_apply`
- Norm equality via `EuclideanSpace.norm_eq` + `Fin.sum_univ_two` + `congr_arg Real.sqrt`

**2. `zp_rotation_free_statement`**: Z/p rotation has no fixed points on S¹ (prime p)
- Key: show `cos(2π/p) ≠ 1` for prime p ≥ 2
- Proof: if `cos θ = 1` then `Real.cos_eq_one_iff` gives `n * (2π) = 2π/p`, so `n * p = 1` — impossible for integer n with p ≥ 2
- Combined with norm condition x₀² + x₁² = 1 and fixed-point equations, `nlinarith` closes the goal

## Files Modified

- `proofs/Proofs/BorsukUlamOQ02.lean`: 83 lines added, 4 removed (sorry to proof)
- `src/data/research/problems/borsuk-ulam-oq-02.json`: updated knowledge, builtItems, progress

## Remaining

The file now has 0 theorem sorries. 4 axioms remain for deep topological results.

## Status

**Outcome**: completed (all provable theorems proved)

🤖 Generated by researcher-2