### PR TITLE
fix: use unknown cast for angle-trisection-oq-02-oq-03 index.ts (TS2352)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-03/index.ts
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/AngleTrisectionOQ02OQ03.lean?raw'
 
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string


### PR DESCRIPTION
## Summary
- Fix TypeScript TS2352 error in angle-trisection-oq-02-oq-03/index.ts
- Change `metaJson as {` to `metaJson as unknown as {` to avoid type overlap error
- Same pattern used across other proof index.ts files in the codebase

## Test plan
- [ ] TypeScript build passes without TS2352 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)