### PR TITLE
Enrich amgm-inequality-oq-02: add 8 Maclaurin inequality annotations

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "ann-amgm-oq02-preamble",
+    "proofId": "amgm-inequality-oq-02",
+    "range": { "startLine": 1, "endLine": 34 },
+    "type": "context",
+    "title": "Maclaurin's Chain: AM-GM Refined by Elementary Symmetric Polynomials",
+    "content": "The module establishes the Maclaurin inequality chain M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ for non-negative reals, where Mₖ = (eₖ/C(n,k))^(1/k) and eₖ is the k-th elementary symmetric polynomial. The endpoints are M₁ = AM (arithmetic mean) and Mₙ = GM (geometric mean), so AM ≥ GM is the coarsest case of this chain. The key proof engine is Newton's log-concavity: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1)) · (eₖ₊₁/C(n,k+1)), which implies the Maclaurin step Mₖ ≥ Mₖ₊₁. The formalization proves 13 results fully and axiomatizes 2 deep classical results (Newton log-concavity and the Maclaurin step).",
+    "mathContext": "For non-negative reals $x_1,\\ldots,x_n$: $e_k = \\sum_{|S|=k} \\prod_{i\\in S} x_i$, $M_k = (e_k/\\binom{n}{k})^{1/k}$. Chain: $M_1 \\geq M_2 \\geq \\cdots \\geq M_n$. Special cases: $M_1 = \\frac{\\sum x_i}{n}$ (AM), $M_n = (\\prod x_i)^{1/n}$ (GM). Newton's engine: $(e_k/\\binom{n}{k})^2 \\geq (e_{k-1}/\\binom{n}{k-1})(e_{k+1}/\\binom{n}{k+1})$ — log-concavity of the normalized sequence.",
+    "significance": "context",
+    "relatedConcepts": ["Maclaurin's inequality", "elementary symmetric polynomials", "Newton log-concavity", "AM-GM inequality", "Maclaurin means"],
+    "prerequisites": ["Finset.powersetCard", "Real.rpow", "Real.geom_mean_le_arith_mean_weighted"]
+  },
+  {
+    "id": "ann-amgm-oq02-elemsymm",
+    "proofId": "amgm-inequality-oq-02",
+    "range": { "startLine": 44, "endLine": 60 },
+    "type": "definition",
+    "title": "Elementary Symmetric Polynomials via Finset.powersetCard",
+    "content": "The elemSymm function defines the k-th elementary symmetric polynomial using Finset.powersetCard: eₖ(x) = ∑_{S ∈ univ.powersetCard k} ∏_{i ∈ S} xᵢ. This sums over all k-element subsets of {0,...,n-1}. Three immediate properties: elemSymm_zero (e₀ = 1, from the fact that powersetCard 0 has a single element — the empty set — with empty product = 1), elemSymm_one (e₁ = ∑ xᵢ, from powersetCard_one giving singletons), and elemSymm_nonneg (eₖ ≥ 0 for non-negative inputs, from Finset.sum_nonneg and Finset.prod_nonneg).",
+    "mathContext": "$e_k(x_1,\\ldots,x_n) = \\sum_{\\{i_1,\\ldots,i_k\\} \\subseteq \\{1,\\ldots,n\\}} x_{i_1}\\cdots x_{i_k}$. Base cases: $e_0 = 1$ (empty product over the empty set), $e_1 = x_1 + \\cdots + x_n$, $e_2 = \\sum_{i<j} x_i x_j$. Lean: `elemSymm k x = ∑ s ∈ (univ : Finset (Fin n)).powersetCard k, ∏ i ∈ s, x i`. The `powersetCard` API replaces the older `powerset_len`.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.powersetCard", "Finset.prod_nonneg", "elementary symmetric polynomial", "Fin n"],
+    "prerequisites": ["Finset.powersetCard", "Finset.sum_nonneg", "Finset.prod_nonneg", "Finset.powersetCard_zero", "Finset.powersetCard_one"]
+  },
+  {
+    "id": "ann-amgm-oq02-small-cases",
+    "proofId": "amgm-inequality-oq-02",
+    "range": { "startLine": 66, "endLine": 92 },
+    "type": "technique",
+    "title": "M₁² ≥ M₂ for n=2,3,4: Sum-of-Squares Certificates",
+    "content": "Three small-case proofs establish M₁² ≥ M₂ by explicit sum-of-squares certificates. For n=2: (a+b)/2 ≥ √(ab) is proved by showing (√a - √b)² ≥ 0, expanding via sq_sqrt, then using linarith. For n=3: (a+b+c)² ≥ 3(ab+bc+ca) follows from (a-b)² + (b-c)² + (c-a)² ≥ 0 — nlinarith closes the goal with sq_nonneg hints. For n=4: nlinarith handles (a+b+c+d)² ≥ (4/3)(ab+ac+ad+bc+bd+cd) with all 6 pairwise sq_nonneg hints. These concrete cases illustrate the sum-of-squares principle that underlies the general Cauchy-Schwarz proof.",
+    "mathContext": "n=2: $(\\sqrt{a}-\\sqrt{b})^2 \\geq 0 \\Rightarrow a + b \\geq 2\\sqrt{ab} \\Rightarrow (a+b)/2 \\geq \\sqrt{ab}$. n=3: $(a-b)^2+(b-c)^2+(c-a)^2 = 2(a^2+b^2+c^2-ab-bc-ca) \\geq 0 \\Rightarrow (a+b+c)^2 \\geq 3(ab+bc+ca)$. n=4: same with $\\binom{4}{2}=6$ pairs. General pattern: $(\\sum x_i)^2 = \\sum x_i^2 + 2e_2$ and $n\\cdot\\sum x_i^2 \\geq (\\sum x_i)^2$ (Cauchy-Schwarz) gives $\\binom{n}{2}(\\sum x_i)^2 \\geq n^2 e_2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sum-of-squares method", "nlinarith tactic", "sq_nonneg hints", "AM-GM classical proof"],
+    "prerequisites": ["Real.sqrt_mul", "Real.sq_sqrt", "sq_nonneg", "nlinarith"]
+  },
+  {
+    "id": "ann-amgm-oq02-cauchy-schwarz",
+    "proofId": "amgm-inequality-oq-02",
+    "range": { "startLine": 94, "endLine": 110 },
+    "type": "technique",
+    "title": "Cauchy-Schwarz via Double Sum: n·∑xᵢ² ≥ (∑xᵢ)²",
+    "content": "The private lemma cauchy_schwarz_sum proves n·∑xᵢ² ≥ (∑xᵢ)² for general n via the double-sum identity ∑ᵢ∑ⱼ(xᵢ-xⱼ)² = 2(n·∑xᵢ² - (∑xᵢ)²) ≥ 0. The proof expands (xᵢ-xⱼ)² = xᵢ² - 2xᵢxⱼ + xⱼ², applies simp_rw to push through the sum, and uses three auxiliary facts: h1 (∑ᵢ∑ⱼ xᵢ² = n·∑xᵢ²), h2 (∑ᵢ∑ⱼ xⱼ² = n·∑xⱼ²), h3 (∑ᵢ∑ⱼ 2xᵢxⱼ = 2(∑xᵢ)²). Combined with ring and linarith, this establishes the bound without any positivity hypotheses on x.",
+    "mathContext": "$\\sum_i\\sum_j (x_i-x_j)^2 = n\\sum_i x_i^2 + n\\sum_j x_j^2 - 2\\sum_i x_i \\cdot \\sum_j x_j = 2(n\\sum x_i^2 - (\\sum x_i)^2) \\geq 0$. Lean proof: `h3 : ∑ i j, 2*x i*x j = 2*(∑ i, x i)^2` via `rw [sq, sum_mul]; simp_rw [mul_sum]`. This Cauchy-Schwarz is weaker than the general inner product form but suffices for the Maclaurin M₁²≥M₂ inequality.",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy-Schwarz inequality", "double sum expansion", "simp_rw", "sum_add_distrib", "Finset.sum"],
+    "prerequisites": ["Finset.sum_nonneg", "sq_nonneg", "simp_rw", "sum_add_distrib", "sum_sub_distrib"]
+  },
+  {
+    "id": "ann-amgm-oq02-binomial-identity",
+    "proofId": "amgm-inequality-oq-02",
+    "range": { "startLine": 229, "endLine": 271 },
+    "type": "technique",
+    "title": "General M₁² ≥ M₂: Binomial Identity + Cauchy-Schwarz",
+    "content": "maclaurin_sq_m1_ge_m2_general proves C(n,2)·(∑xᵢ)² ≥ n²·e₂ for ALL reals (no non-negativity needed) using: (1) Cauchy-Schwarz (h_cs: n·∑xᵢ² ≥ (∑xᵢ)²); (2) Binomial identity (h_binom: (∑xᵢ)² = ∑xᵢ² + 2·e₂, proved by private theorem sq_sum_eq_sum_sq_add_two_elemSymm via induction using the recurrence e₂(succ) = e₂(castSucc) + xₙ·e₁(castSucc)); (3) Pascal identity (h_2cn2: 2·C(n,2) = n·(n-1), proved by induction via Nat.choose_succ_succ). The algebraic chain: 2·(C·S₁² - n²·e₂) = n·(n·S₂ - S₁²) ≥ 0 follows from Cauchy-Schwarz, closed by nlinarith.",
+    "mathContext": "$(\\sum_{i=1}^n x_i)^2 = \\sum_{i=1}^n x_i^2 + 2\\sum_{i<j} x_ix_j = \\sum_{i=1}^n x_i^2 + 2e_2$. Inductive proof: $(\\sum_{i=1}^{n+1} x_i)^2 = (\\sum_{i=1}^n x_i + x_{n+1})^2 = (\\sum_{i=1}^n x_i)^2 + 2x_{n+1}\\sum_{i=1}^n x_i + x_{n+1}^2 = (\\sum x_i^2 + 2e_2(x_1,\\ldots,x_n)) + 2x_{n+1}\\cdot e_1 + x_{n+1}^2$ $= \\sum_{i=1}^{n+1} x_i^2 + 2(e_2 + x_{n+1}\\cdot e_1) = \\sum_{i=1}^{n+1} x_i^2 + 2e_2(x_1,\\ldots,x_{n+1})$ using the recurrence $e_2(\\text{succ}) = e_2 + x_{n+1}\\cdot e_1$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.powersetCard_succ_insert", "Fin.castSucc", "Fin.last", "Fin.sum_univ_castSucc", "induction on Fin n"],
+    "prerequisites": ["Finset.powersetCard_succ_insert", "Fin.castSucc", "Fin.last", "Finset.sum_union", "elemSymm_two_succ"]
+  },
+  {
+    "id": "ann-amgm-oq02-newton-axiom",
+    "proofId": "amgm-inequality-oq-02",
+    "range": { "startLine": 277, "endLine": 301 },
+    "type": "insight",
+    "title": "Newton Log-Concavity and Maclaurin Means: The Axiom Engine",
+    "content": "The newton_log_concavity axiom states (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1)) · (eₖ₊₁/C(n,k+1)) for non-negative inputs — log-concavity of the normalized elementary symmetric sequence. The proof strategy is polarization + induction on n (Hardy-Littlewood-Pólya §2.22), currently not in Mathlib. The maclaurin_step axiom states Mₖ ≥ Mₖ₊₁ for consecutive Maclaurin means (following from Newton by monotonicity of t^(1/k)). The maclaurinMean definition uses Real.rpow for the (1/k) power: Mₖ = (eₖ/C(n,k))^(1/k), which is noncomputable. maclaurinMean_nonneg (fully proved) uses rpow_nonneg + elemSymm_nonneg.",
+    "mathContext": "Newton's inequality: $(e_k/\\binom{n}{k})^2 \\geq (e_{k-1}/\\binom{n}{k-1})(e_{k+1}/\\binom{n}{k+1})$ for $1 \\leq k < n$ and $x_i \\geq 0$. Classical proof: 1-variable case trivial; inductive step uses $e_k(x_1,\\ldots,x_n) = e_k(x_1,\\ldots,x_{n-1}) + x_n e_{k-1}(x_1,\\ldots,x_{n-1})$ and Cauchy-Schwarz (polarization). From log-concavity: $(e_k/\\binom{n}{k})^{1/k} \\geq (e_{k+1}/\\binom{n}{k+1})^{1/(k+1)}$ — i.e., $M_k \\geq M_{k+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["Newton's inequalities", "log-concavity", "Real.rpow", "polarization inequality", "Hardy-Littlewood-Pólya"],
+    "prerequisites": ["axiom", "Real.rpow", "Real.rpow_nonneg", "elemSymm_nonneg", "Nat.choose"]
+  },
+  {
+    "id": "ann-amgm-oq02-amgm-from-mathlib",
+    "proofId": "amgm-inequality-oq-02",
+    "range": { "startLine": 315, "endLine": 330 },
+    "type": "technique",
+    "title": "AM-GM from Mathlib's Weighted Mean Inequality",
+    "content": "amgm_from_maclaurin derives the standard AM-GM inequality ∏ xᵢ^(1/n) ≤ (∑ xᵢ)/n from Mathlib's Real.geom_mean_le_arith_mean_weighted with uniform weights 1/n. The proof establishes three prerequisites: hw (each weight 1/n ≥ 0, by positivity), hw' (weights sum to 1, by mul_one_div_cancel), and applies the weighted AM-GM to get ∏ xᵢ^(1/n) ≤ ∑ (1/n)·xᵢ = (∑ xᵢ)/n. The final calc block combines key and a ring simplification using mul_sum.",
+    "mathContext": "Mathlib's weighted AM-GM: $\\prod_{i} z_i^{w_i} \\leq \\sum_i w_i z_i$ when $w_i \\geq 0$, $\\sum w_i = 1$. With $w_i = 1/n$: $\\prod x_i^{1/n} \\leq \\sum (1/n)x_i = (\\sum x_i)/n$. This corresponds to $M_n \\leq M_1$ in Maclaurin notation, the coarsest inequality in the chain. The `positivity` tactic closes $0 \\leq 1/n$ automatically.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.geom_mean_le_arith_mean_weighted", "uniform weights", "positivity tactic", "AM-GM"],
+    "prerequisites": ["Real.geom_mean_le_arith_mean_weighted", "Finset.sum_const", "mul_one_div_cancel", "positivity"]
+  },
+  {
+    "id": "ann-amgm-oq02-maclaurin-chain",
+    "proofId": "amgm-inequality-oq-02",
+    "range": { "startLine": 366, "endLine": 391 },
+    "type": "technique",
+    "title": "Maclaurin Chain by Induction on the Gap k-j",
+    "content": "maclaurin_chain proves Mⱼ ≥ Mₖ for 0 < j ≤ k ≤ n by induction on d = k - j. The proof uses `obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le hjk` to write k = j + d, then inducts on d. Base case d=0: Mⱼ ≥ Mⱼ (le_rfl). Inductive step: Mⱼ ≥ Mⱼ₊ₑ (by ih) and Mⱼ₊ₑ ≥ Mⱼ₊ₑ₊₁ (by maclaurin_step), giving Mⱼ ≥ Mⱼ₊ₑ₊₁ via a calc block. The theorem maclaurin_m1_ge_mn (M₁ ≥ Mₙ, i.e., AM ≥ GM in Maclaurin language) is then a one-line corollary: `maclaurin_chain 1 n (by omega) (by omega) le_rfl x hx`.",
+    "mathContext": "Induction on gap: to prove $M_j \\geq M_k$ for $k = j+d$, apply $M_j \\geq M_{j+e}$ (IH) and $M_{j+e} \\geq M_{j+e+1}$ (step). The step axiom `maclaurin_step` gives $M_k \\geq M_{k+1}$ for any $0 < k < n$. Therefore $M_1 \\geq M_2 \\geq \\cdots \\geq M_n$ by transitivity. Special case: $M_1 = \\text{AM} \\geq M_n = \\text{GM}$, recovering AM-GM. The calc block in Lean: `maclaurinMean j x ≥ maclaurinMean (j+e) x := hih` then `_ ≥ maclaurinMean (j+e+1) x := hstep`.",
+    "significance": "key",
+    "relatedConcepts": ["maclaurin_step axiom", "induction on Nat.le", "Nat.exists_eq_add_of_le", "calc blocks", "transitivity"],
+    "prerequisites": ["maclaurin_step", "Nat.exists_eq_add_of_le", "GE.ge.trans", "omega"]
+  }
+]


### PR DESCRIPTION
## Summary
- Adds 8 comprehensive annotations to `amgm-inequality-oq-02` (was empty)
- Covers all key proof sections: elemSymm definition, small cases n=2,3,4, Cauchy-Schwarz, binomial identity, general M₁²≥M₂, Newton axiom, AM-GM from Mathlib, Maclaurin chain

## Test plan
- [ ] `pnpm build` passes with no errors for `amgm-inequality-oq-02`
- [ ] 8 annotations with proper schema (`type`, `title`, `content`, `mathContext`, etc.)
- [ ] Covers elemSymm via powersetCard, inductive binomial identity, and chain-by-induction technique

🤖 Generated with [Claude Code](https://claude.com/claude-code)