### PR TITLE
fix: remove invalid dateAdded entry from bounded-prime-gaps-oq-03 meta.json

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
@@ -48,8 +48,7 @@
       "engelsma_lower_bound: axiom encoding Engelsma's 2013 exhaustive computer search result",
       "admissible_50_tuple_min_diam: 246 is both achievable and optimal — the main theorem",
       "optimal_prime_gap_via_50_tuple: complete characterization — ∃ admissible 50-tuple of diam 246, ¬∃ admissible 50-tuple of diam < 246",
-      "API fix: Mathlib 4.26.0 changed Finset.min'_le and Finset.le_max' — nonemptiness argument removed, signature now (s b hb)",
-      "dateAdded": "02/25/26"
+      "API fix: Mathlib 4.26.0 changed Finset.min'_le and Finset.le_max' — nonemptiness argument removed, signature now (s b hb)"
     ],
     "dateAdded": "02/25/26"
   },


### PR DESCRIPTION
## Summary
- Removes an invalid `"dateAdded": "02/25/26"` key-value pair from the `originalContributions` array in `bounded-prime-gaps-oq-03/meta.json`
- This was object syntax inside a JSON array, causing a `SyntaxError: Expected , or ] after array element` that broke the build
- The `dateAdded` field is already correctly present as a top-level `meta` property

## Root Cause
The researcher agent that created PR #3277 (bounded-prime-gaps-oq-03) accidentally appended a key-value pair as the last element of the `originalContributions` array instead of a plain string. This caused all subsequent builds to fail.

## Test plan
- [x] Validated JSON with `python3 -c "import json; json.load(open(...))"` - passes
- [ ] Verify `pnpm build` succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)