### PR TITLE
research: prove Hockey Stick Identity for simplicial numbers (arithmetic-series-oq-02)

### DIFF
--- a/proofs/Proofs/ArithmeticSeriesOQ02.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ02.lean
@@ -1,0 +1,209 @@
+import Mathlib.Data.Nat.Choose.Basic
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Tactic
+
+/-
+# Simplicial Numbers: Higher-Dimensional Arithmetic Series
+
+## Open Question (arithmetic-series-oq-02)
+
+"Generalize arithmetic series to higher-dimensional simplicial numbers."
+
+## Answer: The Hockey Stick Identity
+
+The k-simplex numbers are the k-fold iteration of the summation operator:
+  - 1D: natural numbers (arithmetic series terms)
+  - 2D: triangular numbers (partial sums of 1D)
+  - 3D: tetrahedral numbers (partial sums of 2D)
+  - k-D: C(n+k, k) (partial sums of (k-1)-D)
+
+The key theorem is the **Hockey Stick Identity**:
+  ∑_{i=0}^{n} C(i+k, k) = C(n+k+1, k+1)
+
+This shows that summing k-simplex numbers gives (k+1)-simplex numbers,
+making arithmetic series the 2D instance of a general dimension-raising principle.
+
+## Definitions and Key Theorems
+
+1. **simplicial k n = C(n+k, k)**: The k-th simplicial number sequence
+2. **hockey_stick_sum**: ∑_{i=0}^n simplicial k i = simplicial (k+1) n
+3. **simplicial_succ_recurrence**: simplicial (k+1) (n+1) = simplicial (k+1) n + simplicial k (n+1)
+4. **arithmetic_to_triangular**: ∑ i ∈ range (n+1), (i+1) = simplicial 2 n
+5. **triangular_to_tetrahedral**: ∑ i ∈ range (n+1), simplicial 2 i = simplicial 3 n
+6. **simplicial_one**: simplicial 1 n = n + 1 (natural numbers offset by 1)
+7. **simplicial_two_formula**: simplicial 2 n = (n+1) * (n+2) / 2 (triangular numbers)
+8. **simplicial_three_formula**: simplicial 3 n = (n+1) * (n+2) * (n+3) / 6 (tetrahedral numbers)
+-/
+
+namespace ArithmeticSeriesOQ02
+
+open Finset BigOperators
+
+/-! ## The Simplicial Number Sequence -/
+
+/-- **Simplicial numbers**: The n-th k-simplex number is C(n+k, k).
+    These are the higher-dimensional analogs of triangular and tetrahedral numbers.
+
+    - k=0: C(n,0) = 1 (constant — 0-simplex is a point)
+    - k=1: C(n+1,1) = n+1 (natural numbers — 1-simplex is a line segment)
+    - k=2: C(n+2,2) = (n+1)(n+2)/2 (triangular numbers — 2-simplex is a triangle)
+    - k=3: C(n+3,3) = (n+1)(n+2)(n+3)/6 (tetrahedral numbers — 3-simplex is a tetrahedron) -/
+def simplicial (k n : ℕ) : ℕ := Nat.choose (n + k) k
+
+/-! ## Basic Properties of Simplicial Numbers -/
+
+/-- simplicial 0 n = 1: the 0-simplex sequence is constant 1. -/
+theorem simplicial_zero (n : ℕ) : simplicial 0 n = 1 := by
+  simp [simplicial, Nat.choose_zero_right]
+
+/-- simplicial k 0 = 1: the 0th term of every simplicial sequence is 1. -/
+theorem simplicial_start (k : ℕ) : simplicial k 0 = 1 := by
+  simp [simplicial, Nat.choose_self]
+
+/-- simplicial 1 n = n + 1: the 1-simplex sequence is the natural numbers (1, 2, 3, ...). -/
+theorem simplicial_one (n : ℕ) : simplicial 1 n = n + 1 := by
+  simp [simplicial, Nat.choose_one_right]
+
+/-- The successor recurrence: simplicial (k+1) (n+1) = simplicial (k+1) n + simplicial k (n+1).
+    This is Pascal's identity applied to the simplicial sequence.
+    It says: each new value is the previous value plus the corresponding lower-dim value. -/
+theorem simplicial_succ_recurrence (k n : ℕ) :
+    simplicial (k + 1) (n + 1) = simplicial (k + 1) n + simplicial k (n + 1) := by
+  simp only [simplicial]
+  -- C(n+1+k+1, k+1) = C(n+k+1, k+1) + C(n+1+k, k)
+  -- Normalize indices and apply Pascal's identity
+  rw [show n + 1 + (k + 1) = n + k + 1 + 1 from by ring,
+      show n + (k + 1) = n + k + 1 from by ring,
+      show n + 1 + k = n + k + 1 from by ring]
+  have h := Nat.choose_succ_succ (n + k + 1) k
+  -- h : C(n+k+1, k) + C(n+k+1, k+1) = C(n+k+2, k+1)
+  linarith
+
+/-! ## The Hockey Stick Identity -/
+
+/-- **Hockey Stick Identity** (the main structural theorem):
+    The sum of the first (n+1) k-simplex numbers equals the (n+1)-th (k+1)-simplex number.
+
+      ∑_{i=0}^{n} C(i+k, k) = C(n+k+1, k+1)
+    equivalently:
+      ∑_{i=0}^{n} simplicial k i = simplicial (k+1) n
+
+    This is the key dimension-raising identity:
+    - k=1: ∑_{i=0}^n (i+1) = C(n+2,2) = triangular(n+1) (Gauss's formula restated)
+    - k=2: ∑_{i=0}^n C(i+2,2) = C(n+3,3) = tetrahedral(n+1)
+    - k=3: ∑_{i=0}^n C(i+3,3) = C(n+4,4) = pentatope(n+1)
+
+    Proof by induction: base case C(k,k)=1=C(k+1,k+1); inductive step uses Pascal's
+    identity C(n+k+1,k) + C(n+k+1,k+1) = C(n+k+2,k+1). -/
+theorem hockey_stick_sum (k : ℕ) (n : ℕ) :
+    ∑ i ∈ range (n + 1), simplicial k i = simplicial (k + 1) n := by
+  induction n with
+  | zero =>
+    simp [simplicial, Nat.choose_self]
+  | succ n ih =>
+    rw [sum_range_succ, ih]
+    -- Goal: simplicial (k+1) n + simplicial k (n+1) = simplicial (k+1) (n+1)
+    exact (simplicial_succ_recurrence k n).symm
+
+/-! ## Connection to Arithmetic Series -/
+
+/-- The arithmetic series sum ∑_{i=0}^n (i+1) equals the (n+1)-th triangular number.
+    This is Gauss's formula as a special case of the hockey stick (k=1). -/
+theorem arithmetic_to_triangular (n : ℕ) :
+    ∑ i ∈ range (n + 1), (i + 1) = simplicial 2 n := by
+  -- ∑ (i+1) = ∑ simplicial 1 i = simplicial 2 n
+  calc ∑ i ∈ range (n + 1), (i + 1)
+      = ∑ i ∈ range (n + 1), simplicial 1 i :=
+          Finset.sum_congr rfl fun i _ => (simplicial_one i).symm
+    _ = simplicial 2 n := hockey_stick_sum 1 n
+
+/-- The sum of triangular numbers gives tetrahedral numbers (hockey stick, k=2). -/
+theorem triangular_to_tetrahedral (n : ℕ) :
+    ∑ i ∈ range (n + 1), simplicial 2 i = simplicial 3 n :=
+  hockey_stick_sum 2 n
+
+/-
+  The iterated sum structure:
+    - Summing 1s gives natural numbers (simplicial 1)
+    - Summing natural numbers gives triangular numbers (simplicial 2)
+    - Summing triangular numbers gives tetrahedral numbers (simplicial 3)
+    - Summing k-simplex numbers gives (k+1)-simplex numbers
+-/
+
+/-! ## Explicit Formulas for Low Dimensions -/
+
+/-- simplicial 2 n = (n+1)(n+2)/2 — the classical triangular number formula.
+    Connects to the original ArithmeticSeries.lean: T(n+1) = (n+1)(n+2)/2.
+    Proof by induction using the recurrence simplicial 2 (n+1) = simplicial 2 n + (n+2). -/
+theorem simplicial_two_formula (n : ℕ) :
+    simplicial 2 n * 2 = (n + 1) * (n + 2) := by
+  induction n with
+  | zero => simp [simplicial, Nat.choose_self]
+  | succ n ih =>
+    rw [simplicial_succ_recurrence 1 n, simplicial_one]
+    -- Goal: (simplicial 2 n + (n + 1 + 1)) * 2 = (n + 1 + 1) * (n + 1 + 2)
+    nlinarith [ih]
+
+/-- simplicial 3 n = (n+1)(n+2)(n+3)/6 — the classical tetrahedral number formula.
+    Tetrahedral numbers: 1, 4, 10, 20, 35, 56, ...
+    Proof by induction using the recurrence and simplicial_two_formula. -/
+theorem simplicial_three_formula (n : ℕ) :
+    simplicial 3 n * 6 = (n + 1) * (n + 2) * (n + 3) := by
+  induction n with
+  | zero => simp [simplicial, Nat.choose_self]
+  | succ n ih =>
+    rw [simplicial_succ_recurrence 2 n]
+    have h2 : simplicial 2 (n + 1) * 2 = (n + 2) * (n + 3) := simplicial_two_formula (n + 1)
+    -- Goal: (simplicial 3 n + simplicial 2 (n + 1)) * 6 = (n + 2) * (n + 3) * (n + 4)
+    nlinarith [ih, h2]
+
+/-! ## Concrete Values -/
+
+/-- Triangular numbers: 1, 3, 6, 10, 15, 21, 28, 36, 45, 55 -/
+theorem triangular_10 : simplicial 2 9 = 55 := by native_decide
+
+/-- Tetrahedral numbers: 1, 4, 10, 20, 35, 56, 84, 120, 165, 220 -/
+theorem tetrahedral_10 : simplicial 3 9 = 220 := by native_decide
+
+/-- The sum of first 10 triangular numbers equals the 10th tetrahedral number -/
+theorem triangular_sum_10 : ∑ i ∈ range 10, simplicial 2 i = 220 := by native_decide
+
+/-! ## Summary: The Answer to OQ-02 -/
+
+/-
+The question was: "Generalize arithmetic series to higher-dimensional simplicial numbers."
+
+## The Complete Picture
+
+The arithmetic series ∑_{i=0}^{n} i = n(n+1)/2 is ONE INSTANCE of a general principle:
+
+**Dimension-Raising Principle** (hockey_stick_sum):
+  ∑_{i=0}^{n} S_k(i) = S_{k+1}(n)
+
+where S_k(n) = C(n+k, k) is the n-th k-simplex number.
+
+This means:
+  S_0(n) = 1          (0-simplex: points)
+  S_1(n) = n+1        (1-simplex: line segments — natural numbers)
+  S_2(n) = C(n+2,2)   (2-simplex: triangles — triangular numbers)
+  S_3(n) = C(n+3,3)   (3-simplex: tetrahedra — tetrahedral numbers)
+  S_4(n) = C(n+4,4)   (4-simplex: pentatopes — pentatope numbers)
+
+And:
+  ∑ S_0(i) = S_1(n): summing 1s gives natural numbers
+  ∑ S_1(i) = S_2(n): summing natural numbers gives triangular numbers (Gauss!)
+  ∑ S_2(i) = S_3(n): summing triangular numbers gives tetrahedral numbers
+  ∑ S_k(i) = S_{k+1}(n): general dimension-raising
+
+The hockey stick identity is proved by induction using Pascal's triangle identity
+C(m, k+1) = C(m-1, k) + C(m-1, k+1).
+-/
+
+#check hockey_stick_sum
+#check arithmetic_to_triangular
+#check triangular_to_tetrahedral
+#check simplicial_two_formula
+#check simplicial_three_formula
+
+end ArithmeticSeriesOQ02

--- a/src/data/proofs/arithmetic-series-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-imports",
+    "proofId": "arithmetic-series-oq-02",
+    "range": { "startLine": 1, "endLine": 4 },
+    "type": "context",
+    "title": "Imports: Choose, BigOperators, Tactic",
+    "content": "The proof imports `Mathlib.Data.Nat.Choose.Basic` for binomial coefficients (`Nat.choose`, `Nat.choose_self`, `Nat.choose_succ_succ`, `Nat.choose_one_right`), `Mathlib.Algebra.BigOperators.Intervals` for `Finset.sum_range_succ`, and `Mathlib.Tactic` for `linarith`, `nlinarith`, `ring`, and `simp`.",
+    "mathContext": "The key Mathlib theorem is `Nat.choose_succ_succ (n k : ℕ) : Nat.choose (n+1) (k+1) = Nat.choose n k + Nat.choose n (k+1)` — Pascal's identity. This single lemma drives both the recurrence and the hockey stick inductive step.",
+    "significance": "context",
+    "relatedConcepts": ["binomial coefficients", "Pascal's triangle", "BigOperators", "Finset.sum"],
+    "prerequisites": ["Lean 4 imports", "Nat.choose definition"]
+  },
+  {
+    "id": "ann-simplicial-def",
+    "proofId": "arithmetic-series-oq-02",
+    "range": { "startLine": 48, "endLine": 52 },
+    "type": "definition",
+    "title": "The Simplicial Number Definition",
+    "content": "The k-th simplicial number sequence is defined as `simplicial k n := Nat.choose (n + k) k`. This single definition encodes: 0-simplex (points), 1-simplex (natural numbers), 2-simplex (triangular numbers), 3-simplex (tetrahedral numbers), and all higher dimensions. The index n ranges from 0, giving simplicial k 0 = C(k,k) = 1 for all k.",
+    "mathContext": "The n-th k-simplex number counts the number of n-element multisets from a k-element set, equivalently the number of lattice paths in k-dimensional space. The formula $S_k(n) = \\binom{n+k}{k} = \\frac{(n+k)!}{n! \\cdot k!}$ is a polynomial of degree k in n.",
+    "significance": "key",
+    "relatedConcepts": ["binomial coefficients", "multisets", "lattice paths", "Pascal's triangle"],
+    "prerequisites": ["Nat.choose definition", "combinatorial interpretation"]
+  },
+  {
+    "id": "ann-basic-props",
+    "proofId": "arithmetic-series-oq-02",
+    "range": { "startLine": 55, "endLine": 70 },
+    "type": "technique",
+    "title": "Basic Properties: One-Line Simp Proofs",
+    "content": "The three basic properties — `simplicial_zero`, `simplicial_start`, `simplicial_one` — are each one-line `simp` proofs using Mathlib's choose lemmas. `simplicial_zero n : S_0(n) = 1` uses `choose_zero_right`. `simplicial_start k : S_k(0) = 1` uses `choose_self`. `simplicial_one n : S_1(n) = n+1` uses `choose_one_right`.",
+    "mathContext": "These three base cases correspond to: (1) the 0-simplex is always 1 point; (2) any simplex has 1 vertex at n=0; (3) the 1-simplex sequence counts points on a line segment from 1 to n+1.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.choose_zero_right", "Nat.choose_self", "Nat.choose_one_right"],
+    "prerequisites": ["simplicial definition", "Nat.choose boundary cases"]
+  },
+  {
+    "id": "ann-recurrence",
+    "proofId": "arithmetic-series-oq-02",
+    "range": { "startLine": 72, "endLine": 84 },
+    "type": "insight",
+    "title": "Pascal's Recurrence for Simplicial Numbers",
+    "content": "The recurrence `simplicial_succ_recurrence`: S_{k+1}(n+1) = S_{k+1}(n) + S_k(n+1). This is Pascal's identity in disguise: C(n+k+2, k+1) = C(n+k+1, k+1) + C(n+k+1, k). The proof normalizes the index arithmetic to match `Nat.choose_succ_succ (n+k+1) k`, then uses `linarith` to handle the commutativity difference: Pascal gives C(n+k+1,k)+C(n+k+1,k+1) = C(n+k+2,k+1), but the goal has the right-hand side in reversed order.",
+    "mathContext": "Pascal's identity $\\binom{n+1}{k+1} = \\binom{n}{k} + \\binom{n}{k+1}$ is equivalent to counting subsets by whether they include the largest element. Specialized to our indices: $S_{k+1}(n+1) = \\binom{n+k+2}{k+1} = \\binom{n+k+1}{k+1} + \\binom{n+k+1}{k} = S_{k+1}(n) + S_k(n+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["Pascal's identity", "Nat.choose_succ_succ", "index normalization", "linarith"],
+    "prerequisites": ["simplicial definition", "Nat.choose_succ_succ"]
+  },
+  {
+    "id": "ann-hockey-stick",
+    "proofId": "arithmetic-series-oq-02",
+    "range": { "startLine": 99, "endLine": 110 },
+    "type": "insight",
+    "title": "The Hockey Stick Identity: Inductive Proof",
+    "content": "The main theorem: ∑_{i=0}^n S_k(i) = S_{k+1}(n), proved by induction on n. Base case (n=0): ∑_{i=0}^0 S_k(i) = S_k(0) = 1 = C(k+1,k+1) = S_{k+1}(0), using `choose_self`. Inductive step: ∑_{i=0}^{n+1} S_k(i) = (∑_{i=0}^n S_k(i)) + S_k(n+1) = S_{k+1}(n) + S_k(n+1) = S_{k+1}(n+1) by the recurrence. The proof is exactly 2 lines of Lean after unfolding.",
+    "mathContext": "The Hockey Stick Identity $\\sum_{i=0}^{n} \\binom{i+k}{k} = \\binom{n+k+1}{k+1}$ is named after the shape it traces in Pascal's triangle: starting from C(k,k)=1 and summing diagonally, the result jumps to the next diagonal. It has a bijective proof: count (n+1)-element multisets from [k+1] by fixing the largest element.",
+    "significance": "key",
+    "relatedConcepts": ["Hockey Stick Identity", "Pascal's triangle diagonal sums", "simplicial_succ_recurrence", "induction"],
+    "prerequisites": ["simplicial_start", "simplicial_succ_recurrence", "sum_range_succ"]
+  },
+  {
+    "id": "ann-arithmetic-connection",
+    "proofId": "arithmetic-series-oq-02",
+    "range": { "startLine": 113, "endLine": 130 },
+    "type": "technique",
+    "title": "Connecting to Gauss's Formula",
+    "content": "`arithmetic_to_triangular` proves ∑_{i=0}^n (i+1) = S_2(n) by a calc proof with two steps: (1) rewrite (i+1) as simplicial 1 i using `Finset.sum_congr rfl` + `simplicial_one`; (2) apply `hockey_stick_sum 1 n`. The `sum_congr` approach is used instead of `simp_rw` to avoid accidentally rewriting `n+1` in `range (n+1)` to `simplicial 1 n`. `triangular_to_tetrahedral` is immediate from `hockey_stick_sum 2 n`.",
+    "mathContext": "Gauss's formula $1 + 2 + \\cdots + (n+1) = (n+1)(n+2)/2$ is the k=1 hockey stick: $\\sum_{i=0}^{n} (i+1) = \\sum_{i=0}^{n} S_1(i) = S_2(n) = \\binom{n+2}{2} = (n+1)(n+2)/2$. The tetrahedral sum $\\sum T_i = T_n^{(3)}$ is the k=2 instance.",
+    "significance": "supporting",
+    "relatedConcepts": ["Gauss's formula", "Finset.sum_congr", "hockey_stick_sum", "triangular numbers"],
+    "prerequisites": ["hockey_stick_sum", "simplicial_one", "Finset.sum_congr"]
+  },
+  {
+    "id": "ann-formulas",
+    "proofId": "arithmetic-series-oq-02",
+    "range": { "startLine": 136, "endLine": 165 },
+    "type": "technique",
+    "title": "Closed Formulas by Induction + nlinarith",
+    "content": "The closed form theorems `simplicial_two_formula` (S_2(n)*2=(n+1)(n+2)) and `simplicial_three_formula` (S_3(n)*6=(n+1)(n+2)(n+3)) are proved by induction. The key tool is `nlinarith` (nonlinear arithmetic): at each inductive step, the IH gives S_k(n)*constant = polynomial, and the recurrence reduces the step to a nonlinear inequality like `(n+1)*(n+2) + (n+2)*2 = (n+2)*(n+3)`, which `nlinarith` handles. The formulation `S_2(n)*2 = ...` avoids natural number division issues.",
+    "mathContext": "The closed forms $S_2(n) = \\binom{n+2}{2} = \\frac{(n+1)(n+2)}{2}$ and $S_3(n) = \\binom{n+3}{3} = \\frac{(n+1)(n+2)(n+3)}{6}$ follow from the definition. Working with $S_2(n) \\cdot 2 = (n+1)(n+2)$ instead of $S_2(n) = \\frac{(n+1)(n+2)}{2}$ avoids natural number division complications.",
+    "significance": "supporting",
+    "relatedConcepts": ["nlinarith tactic", "natural number division avoidance", "inductive formulas", "simplicial_succ_recurrence"],
+    "prerequisites": ["simplicial_succ_recurrence", "simplicial_one", "nlinarith"]
+  }
+]

--- a/src/data/proofs/arithmetic-series-oq-02/index.ts
+++ b/src/data/proofs/arithmetic-series-oq-02/index.ts
@@ -1,0 +1,8 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ArithmeticSeriesOQ02.lean?raw'
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion }
+export const arithmeticSeriesOQ02Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
+export const arithmeticSeriesOQ02Annotations: Annotation[] = annotationsJson as Annotation[]
+export const arithmeticSeriesOQ02Data: ProofData = { proof: arithmeticSeriesOQ02Proof, annotations: arithmeticSeriesOQ02Annotations }

--- a/src/data/proofs/arithmetic-series-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02/meta.json
@@ -1,0 +1,99 @@
+{
+  "id": "arithmetic-series-oq-02",
+  "title": "Simplicial Numbers: Higher-Dimensional Arithmetic Series",
+  "slug": "arithmetic-series-oq-02",
+  "description": "The Hockey Stick Identity: the k-th simplicial number S_k(n) = C(n+k,k) satisfies ∑_{i=0}^n S_k(i) = S_{k+1}(n). This generalizes Gauss's arithmetic series formula to all dimensions: triangular numbers (k=2), tetrahedral (k=3), and beyond.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hockey_stick_identity",
+    "date": "~300 BCE (Pascal's triangle; formalized 2026)",
+    "status": "complete",
+    "tags": ["number-theory", "combinatorics", "simplicial-numbers", "gauss", "pascal", "induction"],
+    "proofRepoPath": "Proofs/ArithmeticSeriesOQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {"theorem": "Nat.choose", "description": "Binomial coefficients C(n,k)", "module": "Mathlib.Data.Nat.Choose.Basic"},
+      {"theorem": "Nat.choose_self", "description": "C(n,n) = 1", "module": "Mathlib.Data.Nat.Choose.Basic"},
+      {"theorem": "Nat.choose_succ_succ", "description": "Pascal's identity: C(n+1,k+1) = C(n,k) + C(n,k+1)", "module": "Mathlib.Data.Nat.Choose.Basic"},
+      {"theorem": "Nat.choose_one_right", "description": "C(n,1) = n", "module": "Mathlib.Data.Nat.Choose.Basic"},
+      {"theorem": "Finset.sum_range_succ", "description": "∑_{i<n+1} f(i) = ∑_{i<n} f(i) + f(n)", "module": "Mathlib.Algebra.BigOperators.Intervals"},
+      {"theorem": "Finset.sum_congr", "description": "Rewriting the summand preserves the sum", "module": "Mathlib.Algebra.BigOperators.Group.Finset"}
+    ],
+    "originalContributions": [
+      "simplicial k n := C(n+k, k): unified definition of all simplicial number sequences",
+      "simplicial_succ_recurrence: S_{k+1}(n+1) = S_{k+1}(n) + S_k(n+1) — Pascal's identity for simplicial sequences",
+      "hockey_stick_sum: ∑_{i=0}^n S_k(i) = S_{k+1}(n) — the dimension-raising formula",
+      "arithmetic_to_triangular: ∑_{i=0}^n (i+1) = S_2(n) — Gauss's formula as hockey stick k=1 instance",
+      "triangular_to_tetrahedral: ∑_{i=0}^n S_2(i) = S_3(n) — tetrahedral from triangular",
+      "simplicial_two_formula: S_2(n) * 2 = (n+1)(n+2) — triangular number closed form",
+      "simplicial_three_formula: S_3(n) * 6 = (n+1)(n+2)(n+3) — tetrahedral number closed form"
+    ],
+    "dateAdded": "2026-02-26"
+  },
+  "overview": {
+    "historicalContext": "**Gauss's formula** (1+2+...+n = n(n+1)/2) is the most famous example of a pattern that generalizes to all dimensions. The triangular numbers 1, 3, 6, 10, 15, ... are sums of the natural numbers. The **tetrahedral numbers** 1, 4, 10, 20, 35, ... are sums of triangular numbers. More generally, the **k-simplex numbers** are the (k-1)-simplex numbers accumulated one dimension at a time.\n\nThe precise statement is the **Hockey Stick Identity** (named for the shape of Pascal's triangle it references): summing the k-th column of Pascal's triangle gives the next column:\n$$\\sum_{i=0}^{n} \\binom{i+k}{k} = \\binom{n+k+1}{k+1}$$\n\nThis single identity captures: counting (k=0), arithmetic series (k=1), triangular numbers (k=2), tetrahedral numbers (k=3), and all higher-dimensional simplicial numbers.",
+    "problemStatement": "**Open Question (arithmetic-series-oq-02)**: Can the arithmetic series formula ∑i = n(n+1)/2 be generalized to higher-dimensional simplicial numbers?\n\n**Answer: YES**, via the Hockey Stick Identity.\n\nDefine the k-simplex number: S_k(n) = C(n+k, k). Then:\n1. S_0(n) = 1 (constant — 0-simplex)\n2. S_1(n) = n+1 (natural numbers — 1-simplex)\n3. S_2(n) = C(n+2,2) = (n+1)(n+2)/2 (triangular — 2-simplex)\n4. S_3(n) = C(n+3,3) = (n+1)(n+2)(n+3)/6 (tetrahedral — 3-simplex)\n\nThe **Hockey Stick Identity**: ∑_{i=0}^n S_k(i) = S_{k+1}(n)\n\nThis means each simplicial number sequence is obtained by accumulating the previous one, with arithmetic series being the first non-trivial instance.",
+    "proofStrategy": "The proof proceeds in two main stages:\n\n**Stage 1 (Recurrence)**: `simplicial_succ_recurrence` — prove S_{k+1}(n+1) = S_{k+1}(n) + S_k(n+1). This is Pascal's identity C(n+k+2, k+1) = C(n+k+1, k+1) + C(n+k+1, k), proved by normalizing indices and applying `Nat.choose_succ_succ` then `linarith` for the commutativity.\n\n**Stage 2 (Hockey Stick)**: `hockey_stick_sum` — prove ∑_{i=0}^n S_k(i) = S_{k+1}(n) by induction. Base case: n=0 gives S_k(0) = C(k,k) = 1 = C(k+1,k+1) = S_{k+1}(0). Inductive step: ∑_{i=0}^{n+1} S_k(i) = S_{k+1}(n) + S_k(n+1) = S_{k+1}(n+1) by the recurrence.\n\n**Stage 3 (Formulas)**: Prove closed forms by induction using the recurrence: S_2(n)*2 = (n+1)(n+2) and S_3(n)*6 = (n+1)(n+2)(n+3), both using `nlinarith`.",
+    "keyInsights": [
+      "**S_k(n) = C(n+k, k)** is the right definition: it gives 1 at n=0, matches triangular and tetrahedral numbers, and makes the hockey stick a corollary of Pascal's identity.",
+      "**Induction is natural**: The hockey stick proof by induction exactly mirrors the Pascal's triangle structure — each step adds one more row.",
+      "**Recurrence before sum**: The key lemma is the recurrence S_{k+1}(n+1) = S_{k+1}(n) + S_k(n+1), which follows from Pascal's identity with careful index normalization.",
+      "**Arithmetic series is hockey stick with k=1**: Gauss's formula ∑_{i=0}^n (i+1) = (n+1)(n+2)/2 is the k=1 instance, connecting ArithmeticSeries.lean to this generalization.",
+      "**Closed forms by induction**: The triangular and tetrahedral closed forms follow from the recurrence by induction + nlinarith, without needing to unfold the binomial coefficient definition."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "Simplicial Number Definition",
+      "startLine": 48,
+      "endLine": 52,
+      "summary": "simplicial k n := Nat.choose (n+k) k. This gives: k=0 → C(n,0)=1; k=1 → C(n+1,1)=n+1; k=2 → C(n+2,2)=(n+1)(n+2)/2; k=3 → C(n+3,3)=(n+1)(n+2)(n+3)/6."
+    },
+    {
+      "id": "basic-properties",
+      "title": "Basic Properties",
+      "startLine": 55,
+      "endLine": 70,
+      "summary": "simplicial_zero: S_0(n)=1 via choose_zero_right. simplicial_start: S_k(0)=1 via choose_self. simplicial_one: S_1(n)=n+1 via choose_one_right. All three are one-line simp proofs."
+    },
+    {
+      "id": "recurrence",
+      "title": "Pascal's Recurrence for Simplicial Numbers",
+      "startLine": 72,
+      "endLine": 84,
+      "summary": "simplicial_succ_recurrence: S_{k+1}(n+1) = S_{k+1}(n) + S_k(n+1). Proof: normalize indices to n+k+1, apply Nat.choose_succ_succ (Pascal's identity C(m+1,k+1)=C(m,k)+C(m,k+1)), then linarith for commutativity."
+    },
+    {
+      "id": "hockey-stick",
+      "title": "The Hockey Stick Identity",
+      "startLine": 99,
+      "endLine": 110,
+      "summary": "hockey_stick_sum: ∑_{i=0}^n S_k(i) = S_{k+1}(n). Proved by induction. Base: S_k(0)=1=S_{k+1}(0) by choose_self. Step: IH + recurrence: ∑_{i=0}^{n+1} S_k(i) = S_{k+1}(n) + S_k(n+1) = S_{k+1}(n+1)."
+    },
+    {
+      "id": "connections",
+      "title": "Connection to Arithmetic Series",
+      "startLine": 113,
+      "endLine": 130,
+      "summary": "arithmetic_to_triangular: ∑_{i=0}^n (i+1) = S_2(n) (hockey stick at k=1, using Finset.sum_congr and simplicial_one). triangular_to_tetrahedral: ∑_{i=0}^n S_2(i) = S_3(n) (hockey stick at k=2, direct application)."
+    },
+    {
+      "id": "formulas",
+      "title": "Explicit Closed Formulas",
+      "startLine": 136,
+      "endLine": 165,
+      "summary": "simplicial_two_formula: S_2(n)*2=(n+1)(n+2). simplicial_three_formula: S_3(n)*6=(n+1)(n+2)(n+3). Both proved by induction using simplicial_succ_recurrence + nlinarith. Concrete values: triangular_10 = 55, tetrahedral_10 = 220, verified by native_decide."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization answers arithmetic-series-oq-02 affirmatively: the arithmetic series ∑i=n(n+1)/2 is the k=1 instance of the Hockey Stick Identity ∑_{i=0}^n C(i+k,k) = C(n+k+1,k+1). The proof uses Pascal's triangle structure (choose_succ_succ) and induction. Zero sorries.",
+    "implications": "The simplicial numbers form a 2D array (Pascal's triangle) with two independent indexing directions: horizontally by k (dimension) and vertically by n (position). The hockey stick identity says 'partial sums along a diagonal equal the next diagonal entry.' This connects to: (1) combinatorics — C(n+k+1,k+1) counts (n+1)-element multisets from a k+1-element set; (2) geometry — the k-simplex numbers count lattice points in k-dimensional simplices; (3) number theory — all simplicial sequences are polynomial functions of degree k.",
+    "openQuestions": [
+      "Can the hockey stick be generalized to q-binomial coefficients (Gaussian binomial coefficients), connecting to quantum groups?",
+      "What is the Lean formalization of the 2D 'hockey stick' identity ∑_{i+j≤n} C(i+k1,k1)*C(j+k2,k2) = C(n+k1+k2+1, k1+k2+1)?",
+      "Can the simplicial numbers be connected to the face numbers of simplicial complexes (f-vectors) in algebraic topology?"
+    ]
+  }
+}

--- a/src/data/research/problems/arithmetic-series-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02.json
@@ -1,0 +1,71 @@
+{
+  "slug": "arithmetic-series-oq-02",
+  "title": "Generalize arithmetic series to higher-dimensional simplicial numbers",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETE",
+    "since": "2026-02-26T05:12:41.985Z",
+    "iteration": 1,
+    "focus": "Hockey Stick Identity proved: ∑S_k(i) = S_{k+1}(n). 7 theorems, zero sorries.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: Generalized arithmetic series to simplicial numbers via Hockey Stick Identity. 7 theorems: simplicial_succ_recurrence, hockey_stick_sum, arithmetic_to_triangular, triangular_to_tetrahedral, simplicial_two_formula, simplicial_three_formula, plus 3 basic properties.",
+    "builtItems": [
+      "simplicial k n := C(n+k, k) — unified definition",
+      "simplicial_succ_recurrence: S_{k+1}(n+1) = S_{k+1}(n) + S_k(n+1)",
+      "hockey_stick_sum: ∑_{i=0}^n S_k(i) = S_{k+1}(n)",
+      "arithmetic_to_triangular: ∑_{i=0}^n (i+1) = S_2(n)",
+      "triangular_to_tetrahedral: ∑_{i=0}^n S_2(i) = S_3(n)",
+      "simplicial_two_formula: S_2(n)*2 = (n+1)(n+2)",
+      "simplicial_three_formula: S_3(n)*6 = (n+1)(n+2)(n+3)"
+    ],
+    "insights": [
+      "S_k(n) = C(n+k,k) is the right definition — gives 1 at n=0, encodes all simplicial dimensions",
+      "Hockey Stick: ∑_{i=0}^n S_k(i) = S_{k+1}(n) — proved by induction using Pascal recurrence",
+      "Pascal recurrence S_{k+1}(n+1) = S_{k+1}(n) + S_k(n+1) follows from choose_succ_succ + linarith",
+      "Gauss formula is hockey stick k=1 instance: ∑(i+1) = S_2(n)",
+      "Closed forms S_2(n)*2=(n+1)(n+2) and S_3(n)*6=(n+1)(n+2)(n+3) proved by induction + nlinarith"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "approaches": [],
+  "tags": [
+    "number-theory",
+    "algebra",
+    "series",
+    "simplicial-numbers",
+    "classic",
+    "gauss"
+  ],
+  "relatedProofs": [],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-02-26T07:57:26.405Z",
+  "lastUpdate": "2026-02-26T09:00:00.000Z",
+  "significance": 6,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary

Research session for arithmetic-series-oq-02: Generalize arithmetic series to higher-dimensional simplicial numbers.

**Answer**: The Hockey Stick Identity — ∑_{i=0}^n S_k(i) = S_{k+1}(n) — is the complete generalization.

## Progress

- Proved 7 theorems + 3 basic properties with **zero sorries**
- Files: `proofs/Proofs/ArithmeticSeriesOQ02.lean` (210 lines)
- Gallery: `src/data/proofs/arithmetic-series-oq-02/` (meta.json, index.ts, annotations.json)
- Build verified via Docker (`ℹ [3058/3058] Built Proofs.ArithmeticSeriesOQ02`)

## Key Theorems

- **`simplicial k n := C(n+k, k)`**: Unified definition of all simplicial number sequences
- **`simplicial_succ_recurrence`**: S_{k+1}(n+1) = S_{k+1}(n) + S_k(n+1) (Pascal's identity)
- **`hockey_stick_sum`**: ∑_{i=0}^n S_k(i) = S_{k+1}(n) — the main dimension-raising formula
- **`arithmetic_to_triangular`**: ∑_{i=0}^n (i+1) = S_2(n) — Gauss's formula as k=1 instance
- **`triangular_to_tetrahedral`**: ∑_{i=0}^n S_2(i) = S_3(n) — tetrahedral from triangular
- **`simplicial_two_formula`**: S_2(n)*2 = (n+1)(n+2) — triangular closed form
- **`simplicial_three_formula`**: S_3(n)*6 = (n+1)(n+2)(n+3) — tetrahedral closed form

## Mathematical Insight

The arithmetic series ∑i = n(n+1)/2 is the **k=1 hockey stick**: summing 1-simplex numbers gives 2-simplex (triangular) numbers. Each dimension level is obtained by summing the previous one. The proof uses Pascal's identity (choose_succ_succ) and induction.

## Status

**Outcome**: completed
**Next Steps**: Possible extension to q-binomial coefficients or 2D hockey stick identity

🤖 Generated by researcher-1