### PR TITLE
fix: add missing tags and unknown cast for greens-theorem-oq-03

### DIFF
--- a/src/data/proofs/greens-theorem-oq-03/index.ts
+++ b/src/data/proofs/greens-theorem-oq-03/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/GreensTheoremOQ03.lean?raw'
-const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion }
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion }
 export const greensTheoremOQ03Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion }
 export const greensTheoremOQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 export const greensTheoremOQ03Data: ProofData = { proof: greensTheoremOQ03Proof, annotations: greensTheoremOQ03Annotations }

--- a/src/data/proofs/greens-theorem-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-03/meta.json
@@ -47,7 +47,14 @@
       "typeI_area_is_iterated_one: Area = iterated integral of constant 1",
       "greens_theorem_typeI: axiom stating Green's theorem for TypeI regions with concrete boundary decomposition"
     ],
-    "dateAdded": "02/26/26"
+    "dateAdded": "02/26/26",
+    "tags": [
+      "analysis",
+      "calculus",
+      "integration",
+      "green-theorem",
+      "research"
+    ]
   },
   "sections": [
     {


### PR DESCRIPTION
## Summary
- Add missing `tags` array to `greens-theorem-oq-03/meta.json` (required by `ProofMeta` type)
- Fix `index.ts` to use `as unknown as` cast pattern for type compatibility

## Root Cause
The enricher agent created this proof entry without the `tags` field, which is required by `ProofMeta`. This caused a TypeScript build failure blocking all deployments.

## Test plan
- [ ] `pnpm build` completes without TS2352 error for greens-theorem-oq-03
- [ ] Deployment proceeds normally