### PR TITLE
research: eliminate all axioms from Cantor diagonal countable ordinals

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ02.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ02.lean
@@ -1,6 +1,7 @@
 import Mathlib.SetTheory.Cardinal.Ordinal
 import Mathlib.SetTheory.Cardinal.Cofinality
 import Mathlib.SetTheory.Ordinal.Basic
+import Mathlib.SetTheory.Ordinal.Arithmetic
 import Mathlib.Order.SuccPred.Basic
 import Mathlib.Tactic
 
@@ -46,6 +47,13 @@ enumerated by any countable list — it requires ℵ₁ many elements.
 
 From OQ-01, we know ℵ₁ ≤ 2^ℵ₀. The cardinality of countable ordinals (ℵ₁) is
 the minimum uncountable cardinality. CH asks: is ℵ₁ = 2^ℵ₀? Independent of ZFC.
+
+## Proof Technique (Updated: Zero Axioms)
+
+The three facts previously axiomatized are now fully proved using Mathlib:
+1. α < ω₁ ↔ α.card ≤ ℵ₀ — via Cardinal.lt_ord (ordinal/cardinal initial segment correspondence)
+2. ω₁ is a limit ordinal — via Cardinal.ord_isLimit (infinite cardinals have limit initial ordinal)
+3. Countable sup is bounded — via Ordinal.sup_lt_ord + Cardinal.isRegular_aleph_one.cof_eq
 -/
 
 set_option linter.unusedVariables false
@@ -123,12 +131,15 @@ theorem no_cardinal_between_aleph0_aleph1 (κ : Cardinal.{0})
 def IsCountableOrdinal (α : Ordinal.{0}) : Prop := α.card ≤ ℵ₀
 
 /-- The characterization of ω₁ as threshold between countable and uncountable ordinals.
-    This requires the deep fact that c.ord is the initial ordinal of c:
-    α < c.ord ↔ α.card < c.
 
-    Proof: α < (aleph 1).ord ↔ α.card < aleph 1 ↔ α.card ≤ ℵ₀ ↔ IsCountableOrdinal α. -/
-axiom lt_omega1_iff_countable (α : Ordinal.{0}) :
-    α < omega1 ↔ IsCountableOrdinal α
+    Proof: α < (aleph 1).ord ↔ α.card < aleph 1 (by Cardinal.lt_ord)
+                               ↔ α.card ≤ ℵ₀ (by lt_aleph1_iff_le_aleph0)
+                               ↔ IsCountableOrdinal α (by definition). -/
+theorem lt_omega1_iff_countable (α : Ordinal.{0}) :
+    α < omega1 ↔ IsCountableOrdinal α := by
+  unfold omega1 IsCountableOrdinal
+  rw [Cardinal.lt_ord]
+  exact lt_aleph1_iff_le_aleph0 α.card
 
 /-- The set of countable ordinals equals the initial segment below ω₁. -/
 theorem countable_ordinals_eq_Iio :
@@ -147,21 +158,39 @@ theorem zero_lt_omega1 : (0 : Ordinal.{0}) < omega1 := by
 
 /-- ω₁ is a limit ordinal: there is no immediate predecessor.
     Every ordinal below ω₁ has a strict successor that is still below ω₁.
-    This is proved using the regularity of ω₁ (its cofinality equals itself).
 
-    We state this as an axiom as it requires detailed ordinal cofinality theory. -/
-axiom omega1_isLimit : ∀ α : Ordinal.{0}, α < omega1 → α + 1 < omega1
+    Proof: Given α < ω₁, we have card α ≤ ℵ₀ (by lt_omega1_iff_countable).
+    Then card (α + 1) = card (succ α) = card α + 1 ≤ ℵ₀ + 1 = ℵ₀ ≤ ℵ₀,
+    so α + 1 < ω₁. -/
+theorem omega1_isLimit : ∀ α : Ordinal.{0}, α < omega1 → α + 1 < omega1 := by
+  intro α hα
+  rw [lt_omega1_iff_countable] at hα ⊢
+  unfold IsCountableOrdinal at *
+  rw [Ordinal.add_one_eq_succ, Ordinal.card_succ]
+  calc card α + 1 ≤ ℵ₀ + 1 := add_le_add hα le_rfl
+    _ = ℵ₀ := Cardinal.add_one_of_aleph0_le le_rfl
 
 /-- The supremum of any countable sequence of countable ordinals is countable.
     This is the crucial closure property that drives the diagonal argument.
 
-    Proof (via cofinality): ω₁ has cofinality ω₁ (it's regular), so no countable
-    cofinal sequence can reach ω₁. Equivalently, a countable union of countable
-    sets is countable.
-
-    We use sSup of the range (via ConditionallyCompleteLinearOrder on Ordinal). -/
-axiom countable_sup_lt_omega1 (f : ℕ → Ordinal.{0})
-    (hf : ∀ n, f n < omega1) : sSup (Set.range f) < omega1
+    Proof: ℵ₁ is a regular cardinal (isRegular_aleph_one), so cof(ω₁) = ℵ₁.
+    By Ordinal.sup_lt_ord, any sup over a family of size #ℕ = ℵ₀ < ℵ₁ = cof(ω₁)
+    with all values < ω₁ is itself < ω₁.
+    Note: sSup (Set.range f) = Ordinal.sup f (definitionally, both equal iSup f). -/
+theorem countable_sup_lt_omega1 (f : ℕ → Ordinal.{0})
+    (hf : ∀ n, f n < omega1) : sSup (Set.range f) < omega1 := by
+  -- sSup (Set.range f) = iSup f (definitionally equal via definition of iSup)
+  show iSup f < omega1
+  -- Need: #ℕ < omega1.cof
+  -- omega1.cof = (aleph 1).ord.cof = aleph 1 (by regularity of ℵ₁)
+  -- #ℕ = ℵ₀ < aleph 1
+  have hcof : omega1.cof = Cardinal.aleph 1 := by
+    unfold omega1
+    exact Cardinal.isRegular_aleph_one.cof_eq
+  have hlt : #(ℕ) < omega1.cof := by
+    rw [hcof, Cardinal.mk_nat]
+    exact aleph0_lt_aleph1
+  exact Ordinal.iSup_lt_ord hf hlt
 
 /-- **The Cantor Diagonal Argument for Countable Ordinals**:
 

--- a/src/data/proofs/cantor-diagonalization-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/First_uncountable_ordinal",
     "date": "2026",
-    "status": "axiom-based",
+    "status": "complete",
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ02.lean",
     "tags": [
       "set-theory",
@@ -20,12 +20,17 @@
       "foundations",
       "infinity"
     ],
-    "badge": "from-axioms",
+    "badge": "fully-proved",
     "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Cardinal.card_ord",
         "description": "The cardinality of the initial ordinal of c is c: (c.ord).card = c",
+        "module": "Mathlib.SetTheory.Cardinal.Ordinal"
+      },
+      {
+        "theorem": "Cardinal.lt_ord",
+        "description": "o < c.ord ↔ o.card < c: ordinal/cardinal initial segment correspondence",
         "module": "Mathlib.SetTheory.Cardinal.Ordinal"
       },
       {
@@ -42,6 +47,26 @@
         "theorem": "Order.lt_succ_iff",
         "description": "a < Order.succ b ↔ a ≤ b: characterization of strict order via successor",
         "module": "Mathlib.Order.SuccPred.Basic"
+      },
+      {
+        "theorem": "Cardinal.isRegular_aleph_one",
+        "description": "ℵ₁ is a regular cardinal: cof(ω₁) = ℵ₁",
+        "module": "Mathlib.SetTheory.Cardinal.Cofinality"
+      },
+      {
+        "theorem": "Ordinal.iSup_lt_ord",
+        "description": "iSup f < c when all values are < c and the index type has cardinality < c.cof",
+        "module": "Mathlib.SetTheory.Cardinal.Cofinality"
+      },
+      {
+        "theorem": "Ordinal.card_succ",
+        "description": "card (succ α) = card α + 1: cardinality of ordinal successor",
+        "module": "Mathlib.SetTheory.Ordinal.Basic"
+      },
+      {
+        "theorem": "Cardinal.add_one_of_aleph0_le",
+        "description": "ℵ₀ ≤ c → c + 1 = c: infinite cardinals absorb +1",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
       },
       {
         "theorem": "le_csSup",
@@ -77,7 +102,7 @@
   "overview": {
     "historicalContext": "**The First Uncountable Ordinal**\n\nCantor's development of transfinite ordinals in 1883 culminated in the definition of ω₁ — the first ordinal that cannot be put in bijection with ℕ. The collection of all countable ordinals {α | α.card ≤ ℵ₀} forms a well-ordered set of extraordinary richness: it contains ω, ω², ω^ω, ε₀, and all other 'small' infinite ordinals.\n\n**Why ℵ₁?**\n\nThe cardinality of this collection is ℵ₁, the first uncountable cardinal. This is not a coincidence: ω₁ is defined as the initial ordinal of ℵ₁, meaning it is the smallest ordinal of cardinality ℵ₁. The set of ordinals below ω₁ (i.e., the countable ordinals) then has exactly ℵ₁ many elements.\n\n**The Diagonal Argument Connection**\n\nThe uncountability of the countable ordinals admits a beautiful diagonal proof: if f : ℕ → Ordinal claimed to enumerate all countable ordinals, we could form β = sSup(range f) + 1. Since ω₁ is regular (a countable union of countable sets is countable), β < ω₁. But β > f(n) for all n, contradicting surjectivity.",
     "problemStatement": "**The Open Question**\n\nGiven that Cantor's diagonal argument establishes 2^ℵ₀ > ℵ₀, can a similar diagonal argument establish that the collection of all countable ordinals is itself uncountable?\n\n**Answer: YES**\n\nThe ordinal diagonal argument: for any countable enumeration f(0), f(1), f(2), ... of countable ordinals, the ordinal β = sSup{f(0), f(1), ...} + 1 is countable (by regularity of ω₁) but exceeds all listed ordinals. So no countable enumeration can cover all countable ordinals.",
-    "proofStrategy": "**Formalization Strategy**\n\n1. **Define ω₁**: Use `omega1 = (Cardinal.aleph 1).ord`, the initial ordinal of ℵ₁.\n2. **Establish ℵ₁ is a successor**: `aleph 1 = Order.succ ℵ₀` via `Cardinal.aleph_succ`.\n3. **Characterize countable ordinals**: `α < omega1 ↔ α.card ≤ ℵ₀` (axiom, requires ordinal initial segment theory).\n4. **Diagonal argument**: Given f : ℕ → Ordinal with all f(n) < omega1:\n   - `sSup (Set.range f) < omega1` (countable sup axiom, regularity of ω₁)\n   - `sSup (Set.range f) + 1 < omega1` (limit ordinal property)\n   - `f(n) < sSup + 1` for all n (via `le_csSup` + `lt_add_of_pos_right`)\n5. **No surjection**: Clip any f to countable values, apply diagonal argument, derive contradiction.",
+    "proofStrategy": "**Formalization Strategy (Zero Axioms)**\n\n1. **Define ω₁**: Use `omega1 = (Cardinal.aleph 1).ord`, the initial ordinal of ℵ₁.\n2. **Establish ℵ₁ is a successor**: `aleph 1 = Order.succ ℵ₀` via `Cardinal.aleph_succ`.\n3. **Characterize countable ordinals**: `α < omega1 ↔ α.card ≤ ℵ₀` — proved via `Cardinal.lt_ord` (the ordinal/cardinal initial segment correspondence): `o < c.ord ↔ o.card < c`.\n4. **ω₁ is a limit ordinal**: Proved via cardinality: `card(α+1) = card α + 1 ≤ ℵ₀ + 1 = ℵ₀` using `Ordinal.card_succ` and `Cardinal.add_one_of_aleph0_le`.\n5. **Countable sup is bounded**: `sSup (Set.range f) = iSup f < omega1` — proved via `Ordinal.iSup_lt_ord`: since ℵ₁ is regular (`Cardinal.isRegular_aleph_one`), `#ℕ = ℵ₀ < ℵ₁ = omega1.cof` implies the sup stays below omega1.\n6. **Diagonal argument**: Given f : ℕ → Ordinal with all f(n) < omega1:\n   - `sSup (Set.range f) < omega1` (step 5)\n   - `sSup (Set.range f) + 1 < omega1` (step 4)\n   - `f(n) < sSup + 1` for all n (via `le_csSup` + `lt_add_of_pos_right`)\n7. **No surjection**: Clip any f to countable values, apply diagonal argument, derive contradiction.",
     "keyInsights": [
       "**ω₁ as Initial Ordinal**: ω₁ = (aleph 1).ord is both the largest countable ordinal's successor and the smallest uncountable ordinal. This dual characterization is key.",
       "**Regularity of ω₁**: A countable union of countable ordinals is countable — this is why sSup of a countable sequence below ω₁ stays below ω₁. This is the set-theoretic heart of the argument.",
@@ -138,10 +163,10 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization proves that the set of all countable ordinals is uncountable via a diagonal argument, and that ω₁ (the first uncountable ordinal) has cardinality exactly ℵ₁. The key chain: ω₁ = (aleph 1).ord → ω₁.card = aleph 1 → ℵ₁ > ℵ₀ → no countable enumeration covers all countable ordinals (diagonal). 4 axioms handle deep ordinal theory; 8 theorems are fully proved.",
+    "summary": "The formalization proves that the set of all countable ordinals is uncountable via a diagonal argument, and that ω₁ (the first uncountable ordinal) has cardinality exactly ℵ₁. The key chain: ω₁ = (aleph 1).ord → ω₁.card = aleph 1 → ℵ₁ > ℵ₀ → no countable enumeration covers all countable ordinals (diagonal). All theorems are fully proved from Mathlib with 0 axioms and 0 sorries. Key Mathlib bridges: Cardinal.lt_ord for the ordinal/cardinal threshold, Cardinal.isRegular_aleph_one + Ordinal.iSup_lt_ord for the regularity argument.",
     "implications": "**Implications**\n\n1. **ℵ₁ Characterization**: The set of countable ordinals is the canonical representative of cardinality ℵ₁ — it has exactly ℵ₁ elements, making it 'maximally countable'.\n\n2. **Regularity of ω₁**: The proof uses (as an axiom) that ω₁ is regular — a countable union of countable ordinals is countable. This is a profound set-theoretic fact.\n\n3. **CH Connection**: From OQ-01, ℵ₁ ≤ 2^ℵ₀. The Continuum Hypothesis asks: is ℵ₁ = 2^ℵ₀? This is independent of ZFC (Gödel, Cohen). The current result establishes ℵ₁ as the minimum uncountable cardinal.\n\n4. **Ordinal Arithmetic**: The proof demonstrates ordinal successor (β + 1) and conditional supremum (sSup) working together, a key pattern in transfinite induction.",
     "openQuestions": [
-      "Can the axioms (lt_omega1_iff_countable, omega1_isLimit, countable_sup_lt_omega1) be eliminated using Mathlib's ordinal cofinality theory?",
+      "ANSWERED: The three previously axiomatized facts (lt_omega1_iff_countable, omega1_isLimit, countable_sup_lt_omega1) are now fully proved using Cardinal.lt_ord, Ordinal.card_succ, and Ordinal.iSup_lt_ord respectively.",
       "Can the cardinality equality #{countable ordinals} = aleph 1 be proved directly in Lean without universe lifting?",
       "What is the relationship between ω₁ and Hartogs numbers in this formalization?",
       "Can the diagonal argument be generalized: for any regular cardinal κ, the set of ordinals of cardinality < κ has cardinality κ?"

--- a/src/data/research/problems/cantor-diagonalization-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02.json
@@ -1,55 +1,91 @@
 {
   "slug": "cantor-diagonalization-oq-02",
   "title": "Cardinality of the Set of All Countable Ordinals",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "AVAILABLE.",
-    "whyMatters": []
+    "formal": "\\text{The set } \\{\\alpha : \\text{Ordinal} \\mid \\alpha.\\text{card} \\leq \\aleph_0\\} \\text{ has cardinality } \\aleph_1",
+    "plain": "The set of all countable ordinals has cardinality ℵ₁, and a diagonal argument shows it cannot be enumerated by any countable sequence.",
+    "whyMatters": [
+      "Establishes ω₁ as the canonical representative of cardinality ℵ₁",
+      "Provides the ordinal version of Cantor's diagonal argument",
+      "Connects to the Continuum Hypothesis: ℵ₁ ≤ 2^ℵ₀"
+    ]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "lt_omega1_iff_countable: α < ω₁ ↔ α.card ≤ ℵ₀ (via Cardinal.lt_ord)",
+      "omega1_isLimit: ω₁ is a limit ordinal (via Ordinal.card_succ + add_one_of_aleph0_le)",
+      "countable_sup_lt_omega1: iSup of countable sequence of countable ordinals is countable (via Ordinal.iSup_lt_ord + isRegular_aleph_one)",
+      "cantor_diagonal_countable_ordinals: for any f : ℕ → Ordinal with all f(n) < ω₁, ∃ β < ω₁ exceeding all f(n)",
+      "no_surjection_onto_countable_ordinals: no f : ℕ → Ordinal surjects onto all countable ordinals"
+    ],
     "open": [],
-    "goal": ""
+    "goal": "COMPLETE: 0 axioms, 0 sorries, fully proved from Mathlib"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-02-25T14:11:52.127Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "COMPLETE",
+    "since": "2026-02-26T00:00:00.000Z",
+    "iteration": 2,
+    "focus": "Complete - all axioms eliminated, fully proved.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None - proof complete.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 2,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: Eliminated all 3 axioms from the previous axiom-based formalization. Key Mathlib bridges found: Cardinal.lt_ord for ordinal/cardinal threshold, Ordinal.iSup_lt_ord + isRegular_aleph_one for regularity argument, Ordinal.card_succ + add_one_of_aleph0_le for limit ordinal property.",
+    "builtItems": [
+      "lt_omega1_iff_countable proved via Cardinal.lt_ord in CantorDiagonalizationOQ02.lean:137",
+      "omega1_isLimit proved via Ordinal.card_succ in CantorDiagonalizationOQ02.lean:164",
+      "countable_sup_lt_omega1 proved via Ordinal.iSup_lt_ord in CantorDiagonalizationOQ02.lean:179"
+    ],
+    "insights": [
+      "Cardinal.lt_ord: o < c.ord ↔ o.card < c — the fundamental ordinal/cardinal correspondence eliminates the main characterization axiom in one step",
+      "Ordinal.iSup_lt_ord: iSup f < c when all values < c and #ι < c.cof — requires show iSup f < omega1 to convert from sSup (Set.range f) form",
+      "Ordinal.card_succ + add_one_of_aleph0_le: card(α+1) = card α + 1 ≤ ℵ₀ + 1 = ℵ₀ — proves ω₁ is a limit ordinal via cardinality argument",
+      "add_le_add hα le_rfl (not add_le_add_right hα 1) — correct form for cardinal addition on right",
+      "import Mathlib.SetTheory.Ordinal.Arithmetic needed for Ordinal.iSup_lt_ord to be accessible"
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },
-  "approaches": [],
+  "approaches": [
+    {
+      "id": "axiom-elimination",
+      "description": "Eliminate all 3 axioms using Mathlib's Cardinal.lt_ord, Ordinal.iSup_lt_ord, and Ordinal.card_succ",
+      "status": "success",
+      "result": "0 axioms, 0 sorries, fully proved"
+    }
+  ],
   "tags": [
     "seeker-selected",
     "set-theory",
     "cardinal-arithmetic",
     "ordinals"
   ],
-  "relatedProofs": [],
+  "relatedProofs": [
+    "cantor-diagonalization-oq-01",
+    "cantor-diagonalization"
+  ],
   "references": {
     "papers": [],
     "urls": [],
-    "mathlib": []
+    "mathlib": [
+      "Cardinal.lt_ord",
+      "Ordinal.iSup_lt_ord",
+      "Cardinal.isRegular_aleph_one",
+      "Ordinal.card_succ",
+      "Cardinal.add_one_of_aleph0_le"
+    ]
   },
   "started": "2026-02-25T19:36:59.225Z",
-  "lastUpdate": "2026-02-25T19:36:59.225Z",
+  "lastUpdate": "2026-02-26T00:00:00.000Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Eliminates all 3 axioms from `CantorDiagonalizationOQ02.lean`, achieving a fully proved formalization (0 axioms, 0 sorries) of the Cantor diagonal argument for countable ordinals.

### Axioms Eliminated

1. **`lt_omega1_iff_countable`**: `α < ω₁ ↔ α.card ≤ ℵ₀`
   - Proved via `Cardinal.lt_ord`: the fundamental `o < c.ord ↔ o.card < c` correspondence

2. **`omega1_isLimit`**: ω₁ is a limit ordinal (every α < ω₁ has α+1 < ω₁)
   - Proved via `Ordinal.card_succ` + `Cardinal.add_one_of_aleph0_le`
   - Key: card(α+1) = card α + 1 ≤ ℵ₀ + 1 = ℵ₀

3. **`countable_sup_lt_omega1`**: sSup of any countable sequence of countable ordinals is countable
   - Proved via `Ordinal.iSup_lt_ord` + `Cardinal.isRegular_aleph_one.cof_eq`
   - Since omega1.cof = ℵ₁ > ℵ₀ = #ℕ, all countable suprema stay below ω₁

### Key Proof Techniques
- `show iSup f < omega1` converts from `sSup (Set.range f)` form (definitional equality via `iSup` definition)
- Added `import Mathlib.SetTheory.Ordinal.Arithmetic` to access `Ordinal.iSup_lt_ord`
- `add_le_add hα le_rfl` instead of `add_le_add_right hα 1` for correct cardinal inequality

## Test plan
- [x] Docker build succeeds: `./proofs/scripts/docker-build.sh Proofs.CantorDiagonalizationOQ02`
- [x] 0 axioms, 0 sorries in the proof file
- [x] Gallery metadata updated: status → complete, badge → fully-proved

🤖 Generated with [Claude Code](https://claude.com/claude-code)