### PR TITLE
Enrich greens-theorem-oq-03: fix annotation types and startLine

### DIFF
--- a/src/data/proofs/dissection-of-cubes/meta.json
+++ b/src/data/proofs/dissection-of-cubes/meta.json
@@ -90,6 +90,13 @@
       "summary": "No dissection can have all different sizes."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "dissection-of-cubes-oq-01",
+      "relationship": "extends",
+      "description": "OQ01 formalizes collision pairs and minimum collision lower bounds, advancing the proof of the main theorem"
+    }
+  ],
   "conclusion": {
     "summary": "Littlewood's proof elegantly shows that cube dissection into different-sized cubes is impossible through infinite descent. The smallest cube on any 'floor' creates a new floor above it with even smaller cubes, leading to infinitely many cubes.",
     "implications": "**Contrast with 2D:**\n\nThe surprising fact is that squaring the square IS possible! The first solution was found in 1940 and had 69 squares. The smallest 'simple' squared square has 21 squares.\n\n**Why the difference?**\n\nIn 2D, squares near the edge don't need to be completely surrounded, allowing complex interlocking patterns that prevent infinite descent.\n\n**Generalizations:**\n\n- No rectangular box can be cubed with all different sizes\n- The same impossibility holds in all dimensions >= 3",


### PR DESCRIPTION
Fix annotation validation errors in greens-theorem-oq-03:
- ann-oq03-02-structure: type 'proof'→'definition', startLine 56→45 (section comment, avoids structure declaration conflict)
- ann-oq03-03-rectangles: type 'proof'→'technique'
- ann-oq03-04-area: type 'proof'→'technique'
- ann-oq03-05-iterated-integral: type 'proof'→'technique'

All annotation types now use valid schema values (definition/technique/context). Build passes annotations:build validation.