### PR TITLE
feat: add wake command to lean orchestration system

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -3586,11 +3586,12 @@
     },
     {
       "slug": "cauchy-schwarz-oq-03",
-      "phase": "NEW",
+      "phase": "BREAKTHROUGH",
       "path": "full",
       "started": "2026-02-25T19:36:59.225Z",
-      "status": "active",
-      "lastUpdate": "2026-02-25T19:36:59.225Z"
+      "status": "graduated",
+      "lastUpdate": "2026-02-26T18:10:25.579Z",
+      "completed": "2026-02-26T18:10:25.579Z"
     },
     {
       "slug": "cayley-hamilton-minpoly-oq-01",
@@ -3647,11 +3648,12 @@
     },
     {
       "slug": "area-of-circle-oq-03",
-      "phase": "NEW",
+      "phase": "BREAKTHROUGH",
       "path": "full",
       "started": "2026-02-26T17:08:50.304Z",
-      "status": "active",
-      "lastUpdate": "2026-02-26T17:08:50.304Z"
+      "status": "graduated",
+      "lastUpdate": "2026-02-26T18:10:25.577Z",
+      "completed": "2026-02-26T18:10:25.576Z"
     },
     {
       "slug": "arithmetic-series-oq-02",
@@ -3746,11 +3748,12 @@
     },
     {
       "slug": "derangements-oq-03",
-      "phase": "NEW",
+      "phase": "BREAKTHROUGH",
       "path": "fast",
       "started": "2026-02-26T17:08:50.306Z",
-      "status": "active",
-      "lastUpdate": "2026-02-26T17:08:50.306Z"
+      "status": "graduated",
+      "lastUpdate": "2026-02-26T18:10:25.580Z",
+      "completed": "2026-02-26T18:10:25.580Z"
     },
     {
       "slug": "desargues-theorem-oq-02",


### PR DESCRIPTION
## Summary

- Add `/lean wake <type>` command to signal sleeping agents to start their next cycle immediately
- Fix long-standing bug where Aristotle's companion file submissions were silently failing due to wrong working directory

## Changes

**`scripts/lean/launch.sh`** — `cmd_wake` creates `.loom/signals/wake-<agent>` files for `all`, `aristotle`, `researcher`, `deployer`, `seeker`, `enricher`

**`scripts/aristotle/aristotle-agent.sh`** — two fixes:
- Add `check_wake_signal()` with a `break` in the 30-second sleep loop → wake responds within 30s
- Fix `submit-batch.sh` being called from the worktree CWD (`.loom/worktrees/aristotle`), where relative paths like `proofs/Proofs/*.lean` don't exist — wrap call in `(cd "$PROJECT_ROOT" && ...)`. This was causing all companion file submissions to silently fail with "preprocessing rejected"

**`scripts/agents/claude-wrapper.sh`** — add `check_wake_signal()` and replace blocking `sleep $MAX_BACKOFF` with a 30s-increment loop that checks both signals, covering researchers/deployer/seeker in their API-error retry state

**`CLAUDE.md`** — document the new command

## Test plan

- [x] `/lean wake aristotle` creates `.loom/signals/wake-aristotle` and Aristotle picks it up within 30s
- [x] Aristotle successfully submitted 3 companion files after the CWD fix (was 0/3 before)
- [ ] `/lean wake researcher` / `deployer` / `seeker` interrupt their backoff sleep (covered by wrapper change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)