### PR TITLE
feat: add wake command to lean orchestration system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 | `/lean scale <type> <N>` | Scale pool to N agents |
 | `/lean stop` | Graceful shutdown of all agents (creates signal files) |
 | `/lean stop --force` | Force stop all agents (kills tmux sessions immediately) |
+| `/lean wake <type>` | Wake a sleeping agent early to start its next cycle now |
 | `/lean health` | Show agent process health and detect stuck agents |
 | `/lean daemon [options]` | Run continuous monitoring daemon (respawns completed/stuck agents) |
 
@@ -123,6 +124,9 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 ./scripts/lean/launch.sh spawn researcher
 ./scripts/lean/launch.sh spawn seeker
 ./scripts/lean/launch.sh scale researcher 4
+./scripts/lean/launch.sh wake aristotle       # Wake aristotle early
+./scripts/lean/launch.sh wake researcher      # Wake all researchers early
+./scripts/lean/launch.sh wake all             # Wake all sleeping agents
 
 # Continuous daemon (monitors and respawns agents)
 ./scripts/lean/launch.sh daemon                             # Default 60s interval

--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -115,6 +115,21 @@ check_stop_signal() {
     return 1
 }
 
+# Check for wake signal (early wakeup from backoff sleep)
+check_wake_signal() {
+    if [[ -f "$SIGNALS_DIR/wake-all" ]]; then
+        rm -f "$SIGNALS_DIR/wake-all" 2>/dev/null || true
+        log_info "Wake-all signal received. Resuming early."
+        return 0
+    fi
+    if [[ -n "${ENHANCER_ID:-}" ]] && [[ -f "$SIGNALS_DIR/wake-$ENHANCER_ID" ]]; then
+        rm -f "$SIGNALS_DIR/wake-$ENHANCER_ID" 2>/dev/null || true
+        log_info "Wake signal for $ENHANCER_ID received. Resuming early."
+        return 0
+    fi
+    return 1
+}
+
 # Pre-flight usage check
 check_usage_limits() {
     if [[ -x "$REPO_ROOT/.loom/scripts/check-usage.sh" ]]; then
@@ -401,13 +416,29 @@ run_daemon() {
             log_warn "Daemon cycle $cycle: error that would be fatal in normal mode (exit code: $exit_code)"
             log_warn "Daemon mode: retrying anyway after ${MAX_BACKOFF}s"
 
-            # Check stop signal before waiting
+            # Check stop/wake signals before waiting
             if check_stop_signal; then
                 log_info "Daemon exiting due to stop signal"
                 exit 0
             fi
+            if check_wake_signal; then
+                cycle=$((cycle + 1))
+                continue
+            fi
 
-            sleep $MAX_BACKOFF
+            # Sleep in increments so wake/stop signals are checked every 30s
+            local slept=0
+            while [[ $slept -lt $MAX_BACKOFF ]]; do
+                sleep 30
+                ((slept+=30))
+                if check_stop_signal; then
+                    log_info "Daemon exiting due to stop signal"
+                    exit 0
+                fi
+                if check_wake_signal; then
+                    break
+                fi
+            done
             cycle=$((cycle + 1))
         fi
     done

--- a/scripts/aristotle/aristotle-agent.sh
+++ b/scripts/aristotle/aristotle-agent.sh
@@ -77,6 +77,16 @@ check_stop_signal() {
     return 1
 }
 
+# Check for wake signal (early wakeup from sleep)
+check_wake_signal() {
+    if [[ -f "$SIGNALS_DIR/wake-aristotle" ]] || [[ -f "$SIGNALS_DIR/wake-all" ]]; then
+        rm -f "$SIGNALS_DIR/wake-aristotle" "$SIGNALS_DIR/wake-all" 2>/dev/null || true
+        echo -e "${GREEN}Wake signal received. Starting cycle early.${NC}"
+        return 0
+    fi
+    return 1
+}
+
 # Show status
 show_status() {
     echo -e "${CYAN}=== Aristotle Agent Status ===${NC}"
@@ -240,8 +250,9 @@ run_cycle() {
     echo ""
 
     # Step 4: Submit new files to maintain target
+    # Run from PROJECT_ROOT so relative file paths (proofs/Proofs/*.lean) resolve correctly
     echo -e "${CYAN}[4/4] Submitting new files...${NC}"
-    "$SCRIPT_DIR/submit-batch.sh" --target "$TARGET_ACTIVE" 2>/dev/null || true
+    (cd "$PROJECT_ROOT" && "$SCRIPT_DIR/submit-batch.sh" --target "$TARGET_ACTIVE" 2>/dev/null) || true
     echo ""
 
     # Summary
@@ -298,7 +309,7 @@ main() {
             echo -e "${YELLOW}Sleeping for ${INTERVAL_MINUTES} minutes...${NC}"
             echo "(Next cycle at $(date -v+${INTERVAL_MINUTES}M '+%H:%M:%S' 2>/dev/null || date -d "+${INTERVAL_MINUTES} minutes" '+%H:%M:%S'))"
 
-            # Sleep in small increments to check stop signal
+            # Sleep in small increments to check stop/wake signals
             local sleep_seconds=$((INTERVAL_MINUTES * 60))
             local slept=0
             while [[ $slept -lt $sleep_seconds ]]; do
@@ -306,6 +317,9 @@ main() {
                 ((slept+=30))
                 if check_stop_signal; then
                     exit 0
+                fi
+                if check_wake_signal; then
+                    break
                 fi
             done
         done

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -68,6 +68,7 @@ Usage:
   $0 spawn <type>        Spawn one additional agent
   $0 scale <type> <N>    Scale agent pool to N instances (supports scale-down)
   $0 status              Show current status
+  $0 wake [type]         Wake a sleeping agent early (all, aristotle, researcher, deployer, seeker, enricher)
   $0 daemon [options]    Run continuous monitoring daemon
 
 Start Options:
@@ -1950,6 +1951,53 @@ cmd_scale() {
     esac
 }
 
+# Command: wake - signal sleeping agent(s) to start their next cycle early
+cmd_wake() {
+    local agent_type="${1:-all}"
+
+    mkdir -p "$SIGNALS_DIR"
+
+    case "$agent_type" in
+        all)
+            touch "$SIGNALS_DIR/wake-all"
+            echo -e "${GREEN}Wake signal sent to all agents${NC}"
+            ;;
+        aristotle)
+            touch "$SIGNALS_DIR/wake-aristotle"
+            echo -e "${GREEN}Wake signal sent to aristotle-agent${NC}"
+            ;;
+        researcher)
+            for i in 1 2 3 4 5; do
+                if tmux has-session -t "researcher-$i" 2>/dev/null; then
+                    touch "$SIGNALS_DIR/wake-researcher-$i"
+                    echo -e "${GREEN}Wake signal sent to researcher-$i${NC}"
+                fi
+            done
+            ;;
+        deployer)
+            touch "$SIGNALS_DIR/wake-deployer"
+            echo -e "${GREEN}Wake signal sent to deployer${NC}"
+            ;;
+        seeker)
+            touch "$SIGNALS_DIR/wake-seeker-agent"
+            echo -e "${GREEN}Wake signal sent to seeker-agent${NC}"
+            ;;
+        enricher)
+            for i in 1 2 3 4 5; do
+                if tmux has-session -t "enricher-$i" 2>/dev/null; then
+                    touch "$SIGNALS_DIR/wake-enricher-$i"
+                    echo -e "${GREEN}Wake signal sent to enricher-$i${NC}"
+                fi
+            done
+            ;;
+        *)
+            echo -e "${RED}Unknown agent type: $agent_type${NC}" >&2
+            echo "Valid types: all, aristotle, researcher, deployer, seeker, enricher"
+            exit 1
+            ;;
+    esac
+}
+
 # Command: status
 cmd_status() {
     ./scripts/lean/status.sh
@@ -1981,6 +2029,10 @@ main() {
             ;;
         status)
             cmd_status
+            ;;
+        wake)
+            shift
+            cmd_wake "$@"
             ;;
         daemon)
             shift


### PR DESCRIPTION
## Summary

- Add `/lean wake <type>` to signal sleeping agents to start their next cycle immediately
- Fix Aristotle companion file submissions silently failing due to wrong working directory

## Changes

**`scripts/lean/launch.sh`** — `cmd_wake` creates `.loom/signals/wake-<agent>` files for `all`, `aristotle`, `researcher`, `deployer`, `seeker`, `enricher`

**`scripts/aristotle/aristotle-agent.sh`** — two fixes:
- Add `check_wake_signal()` with `break` in the 30s sleep loop → wake responds within 30s
- Fix `submit-batch.sh` being called from the worktree CWD where `proofs/Proofs/*.lean` paths don't resolve — wrap in `(cd "$PROJECT_ROOT" && ...)`. This was causing all companion file submissions to silently fail with "preprocessing rejected"

**`scripts/agents/claude-wrapper.sh`** — add `check_wake_signal()` and replace blocking `sleep $MAX_BACKOFF` with a 30s-increment loop checking both signals, covering researchers/deployer/seeker in API-error retry state

**`CLAUDE.md`** — document the new command

## Test plan

- [x] `/lean wake aristotle` creates `.loom/signals/wake-aristotle` and Aristotle picks it up within 30s
- [x] Aristotle successfully submitted 3 companion files after the CWD fix (was failing before)
- [ ] `/lean wake researcher` / `deployer` / `seeker` interrupt their backoff sleep

🤖 Generated with [Claude Code](https://claude.com/claude-code)