### PR TITLE
fix: use unknown cast for cevas-theorem-oq-04 annotations type

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-04/index.ts
+++ b/src/data/proofs/cevas-theorem-oq-04/index.ts
@@ -26,7 +26,7 @@ export const cevasTheoremOQ04Proof: Proof = {
   conclusion: meta.conclusion,
 }
 
-export const cevasTheoremOQ04Annotations: Annotation[] = annotationsJson as Annotation[]
+export const cevasTheoremOQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
 export const cevasTheoremOQ04Data: ProofData = {
   proof: cevasTheoremOQ04Proof,


### PR DESCRIPTION
## Summary
- Fix TypeScript build error in cevas-theorem-oq-04/index.ts introduced by PR #3300
- Same recurring enricher type safety pattern - use `as unknown as Annotation[]`

## Test plan
- [x] `pnpm build` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)