### PR TITLE
Enrich Lawvere's Fixed-Point Theorem (cantors-theorem-oq-02)

### DIFF
--- a/src/data/proofs/cantors-theorem-oq-02/annotations.json
+++ b/src/data/proofs/cantors-theorem-oq-02/annotations.json
@@ -4,55 +4,83 @@
     "proofId": "cantors-theorem-oq-02",
     "range": { "startLine": 1, "endLine": 45 },
     "type": "context",
-    "content": "**Lawvere's Fixed-Point Theorem (1969)** provides the categorical unification of Cantor, Russell, Gödel, and Girard.\n\nThe key insight: ALL diagonal arguments have the same structure. Given f : α → (α → β), the 'diagonal map' q x = g(f x x) witnesses the impossibility of certain surjections when g is fixed-point-free.\n\nThis file proves 15 theorems across 6 parts with 0 sorries and 0 axioms.",
-    "summary": "Overview of the Lawvere framework as the categorical unification of diagonal arguments"
+    "content": "**Lawvere's Fixed-Point Theorem (1969)** provides the categorical unification of Cantor, Russell, Gödel, and Girard.\n\nThe key insight: ALL diagonal arguments have the same structure. Given f : α → (α → β), the 'diagonal map' q x = g(f x x) witnesses the impossibility of certain surjections when g is fixed-point-free.\n\nThis file proves 15 theorems across 6 parts with 0 sorries and 0 axioms. The imports pull in `Function.Surjective` from Mathlib and basic set theory, plus general-purpose tactics.",
+    "summary": "Overview of the Lawvere framework as the categorical unification of diagonal arguments",
+    "mathContext": "The file formalizes the theorem: if $f : \\alpha \\to (\\alpha \\to \\beta)$ is surjective and $g : \\beta \\to \\beta$ is fixed-point-free ($\\forall b,\\; g(b) \\neq b$), we reach a contradiction. All classical impossibility results follow by choosing appropriate $\\alpha$, $\\beta$, and $g$.",
+    "significance": "context",
+    "relatedConcepts": ["cartesian closed categories", "diagonal argument", "fixed-point theorem", "type universes"],
+    "prerequisites": ["surjective functions", "propositional logic", "function extensionality"]
   },
   {
     "id": "ann-cantor-oq02-02-russell",
     "proofId": "cantors-theorem-oq-02",
     "range": { "startLine": 46, "endLine": 72 },
-    "type": "mathematical",
-    "content": "**The Seed Theorem**: Negation has no fixed point.\n\n```\nneg_no_fixed_point : ¬∃ p : Prop, p ↔ ¬p\n```\n\nProof: If p ↔ ¬p, then:\n- Assume p holds → ¬p holds (by forward direction) → contradiction\n- So ¬p holds (from above) → p holds (by backward direction) → contradiction\n\nThis is the simplest instance of the diagonal argument and the engine behind ALL the classical paradoxes.",
-    "summary": "neg_no_fixed_point: the seed theorem driving Cantor, Russell, Gödel"
+    "type": "insight",
+    "content": "**The Seed Theorem**: Negation has no fixed point.\n\n```\nneg_no_fixed_point : ¬∃ p : Prop, p ↔ ¬p\n```\n\nProof: If p ↔ ¬p, then:\n- Assume p holds → ¬p holds (by forward direction) → contradiction\n- So ¬p holds (from above) → p holds (by backward direction) → contradiction\n\nThis is the simplest instance of the diagonal argument and the engine behind ALL the classical paradoxes. Russell discovered the set-theoretic version in 1902 when he observed that the predicate $x \\notin x$ applied to itself yields $R \\in R \\iff R \\notin R$.",
+    "summary": "neg_no_fixed_point: the seed theorem driving Cantor, Russell, Gödel",
+    "mathContext": "$\\neg\\exists\\, p : \\text{Prop},\\; p \\leftrightarrow \\neg p$. Equivalently, the function $\\neg : \\text{Prop} \\to \\text{Prop}$ has no fixed point. The set-theoretic form states $\\neg\\exists\\, R \\subseteq \\text{Prop},\\; \\forall p,\\; p \\in R \\leftrightarrow p \\notin R$.",
+    "significance": "key",
+    "relatedConcepts": ["Russell's paradox", "liar paradox", "Curry's paradox", "fixed-point-free maps"],
+    "prerequisites": ["propositional logic", "proof by contradiction", "iff elimination"]
   },
   {
     "id": "ann-cantor-oq02-03-lawvere",
     "proofId": "cantors-theorem-oq-02",
     "range": { "startLine": 73, "endLine": 117 },
-    "type": "mathematical",
-    "content": "**Lawvere's Fixed-Point Theorem**:\n\n```\nIf f : α → (α → β) is surjective,\nthen every g : β → β has a fixed point b with g b = b.\n```\n\nProof by the diagonal construction:\n1. Define q : α → β by **q x = g(f x x)**\n2. Since f is surjective, ∃ a : α, f a = q\n3. Then: **g(f a a) = q a = (f a) a = f a a** ✓\n\nSo b = f a a is the fixed point. The proof needs only surjectivity and function application — no cardinality, no ordinals, no choice.",
-    "summary": "The diagonal construction q x = g(f x x) is the abstract essence of all diagonal arguments"
+    "type": "technique",
+    "content": "**Lawvere's Fixed-Point Theorem**:\n\n```\nIf f : α → (α → β) is surjective,\nthen every g : β → β has a fixed point b with g b = b.\n```\n\nProof by the diagonal construction:\n1. Define q : α → β by **q x = g(f x x)**\n2. Since f is surjective, ∃ a : α, f a = q\n3. Then: **g(f a a) = q a = (f a) a = f a a** ✓\n\nSo b = f a a is the fixed point. The proof needs only surjectivity and function application — no cardinality, no ordinals, no choice. In categorical language, this says any retract of a hom-object in a cartesian closed category has the fixed-point property.",
+    "summary": "The diagonal construction q x = g(f x x) is the abstract essence of all diagonal arguments",
+    "mathContext": "If $f : \\alpha \\to (\\alpha \\to \\beta)$ is surjective, then $\\forall g : \\beta \\to \\beta,\\; \\exists b : \\beta,\\; g(b) = b$. The diagonal map is $q(x) = g(f(x)(x))$, and the fixed point is $b = f(a)(a)$ where $f(a) = q$. The contrapositive states: if $g$ is fixed-point-free, then no $f : \\alpha \\to (\\alpha \\to \\beta)$ is surjective.",
+    "significance": "key",
+    "relatedConcepts": ["Y combinator", "Knaster-Tarski fixed-point theorem", "Scott's fixed-point theorem", "cartesian closed categories", "lambda calculus"],
+    "prerequisites": ["surjective functions", "function extensionality", "congr_fun"]
   },
   {
     "id": "ann-cantor-oq02-04-cantor",
     "proofId": "cantors-theorem-oq-02",
     "range": { "startLine": 118, "endLine": 148 },
-    "type": "mathematical",
-    "content": "**Cantor from Lawvere** (one line!):\n\nInstantiate Lawvere's theorem with:\n- β = Prop\n- g = ¬ (which has no fixed points by neg_no_fixed_point)\n\nConclusion: no f : α → (α → Prop) is surjective.\n\nSince Set α = α → Prop, this immediately gives: no f : α → Set α is surjective — Cantor's theorem.\n\nThe Lawvere proof is more abstract than Cantor's original diagonal set construction, but reveals the underlying structure clearly.",
-    "summary": "Cantor's theorem as a one-line corollary of Lawvere + neg_no_fixed_point"
+    "type": "technique",
+    "content": "**Cantor from Lawvere** (one line!):\n\nInstantiate Lawvere's theorem with:\n- β = Prop\n- g = ¬ (which has no fixed points by neg_no_fixed_point)\n\nConclusion: no f : α → (α → Prop) is surjective.\n\nSince Set α = α → Prop, this immediately gives: no f : α → Set α is surjective — Cantor's theorem.\n\nThe Lawvere proof is more abstract than Cantor's original diagonal set construction, but reveals the underlying structure clearly. Note that `cantor_from_lawvere` is a term-mode proof — no tactics needed, just a direct application of `lawvere_contrapositive`.",
+    "summary": "Cantor's theorem as a one-line corollary of Lawvere + neg_no_fixed_point",
+    "mathContext": "$\\forall \\alpha,\\; \\nexists f : \\alpha \\to (\\alpha \\to \\text{Prop}),\\; f \\text{ surjective}$. Since $\\text{Set}\\;\\alpha \\cong \\alpha \\to \\text{Prop}$, this is Cantor's theorem: $|\\alpha| < |\\mathcal{P}(\\alpha)|$. The term-mode proof is: `lawvere_contrapositive Not (\\lambda p\\, hp \\Rightarrow \\text{neg\\_no\\_fixed\\_point}\\;\\langle p, hp\\rangle) f`.",
+    "significance": "key",
+    "relatedConcepts": ["Cantor's theorem", "power set", "cardinality", "Schröder-Bernstein theorem", "characteristic functions"],
+    "prerequisites": ["Lawvere's fixed-point theorem", "negation has no fixed point", "Set α = α → Prop identification"]
   },
   {
     "id": "ann-cantor-oq02-05-godel",
     "proofId": "cantors-theorem-oq-02",
     "range": { "startLine": 149, "endLine": 185 },
-    "type": "mathematical",
-    "content": "**Gödel's Diagonalization** in type-theoretic form:\n\n```\ngodel_diagonalization:\nFor any f : ℕ → (ℕ → Prop), the predicate\nD n = ¬(f n n) is NOT in range(f)\n```\n\nProof: If D = f k, then D k = f k k, so ¬(f k k) = f k k, giving a fixed point of ¬ — contradiction.\n\nThis is the Gödel diagonal: 'the statement that says about itself that it is unprovable.' The full incompleteness theorem requires arithmetic coding of syntax, but the core mechanism is captured here.\n\n**Bool version**: For f : ℕ → (ℕ → Bool), the sequence d n = !(f n n) is always missing. Note: the explicit type annotation '! (f n n) = f n n' fails in Lean 4 because '!' parses as Prop negation in annotation context — use 'have hdiag := congr_fun h n' instead.",
-    "summary": "Gödel diagonalization: D n = ¬(f n n) escapes every enumeration, including the Bool version"
+    "type": "technique",
+    "content": "**Gödel's Diagonalization** in type-theoretic form:\n\n```\ngodel_diagonalization:\nFor any f : ℕ → (ℕ → Prop), the predicate\nD n = ¬(f n n) is NOT in range(f)\n```\n\nProof: If D = f k, then D k = f k k, so ¬(f k k) = f k k, giving a fixed point of ¬ — contradiction.\n\nThis is the Gödel diagonal: 'the statement that says about itself that it is unprovable.' The full incompleteness theorem requires arithmetic coding of syntax, but the core mechanism is captured here.\n\n**Bool version**: For f : ℕ → (ℕ → Bool), the sequence d n = !(f n n) is always missing. The proof uses `cases` on `Bool` values followed by `simp`, since Bool disjointness is decidable.\n\n**Tarski's undefinability**: As a corollary, no total function enumerates all predicates on ℕ. This is the type-theoretic analog of Tarski's theorem that truth is not arithmetically definable.",
+    "summary": "Gödel diagonalization: D n = ¬(f n n) escapes every enumeration, including the Bool version",
+    "mathContext": "For any $f : \\mathbb{N} \\to (\\mathbb{N} \\to \\text{Prop})$, define $D(n) = \\neg f(n)(n)$. Then $\\forall k,\\; D \\neq f(k)$. The Bool version: for $f : \\mathbb{N} \\to (\\mathbb{N} \\to \\text{Bool})$, the sequence $d(n) = \\lnot(f(n)(n))$ satisfies $\\forall k,\\; d \\neq f(k)$. Tarski form: $\\neg\\exists f : \\mathbb{N} \\to (\\mathbb{N} \\to \\text{Prop}),\\; \\forall P,\\; \\exists n,\\; f(n) = P$.",
+    "significance": "key",
+    "relatedConcepts": ["Gödel's incompleteness theorems", "Tarski's undefinability theorem", "halting problem", "Rice's theorem", "Gödel numbering"],
+    "prerequisites": ["Lawvere's fixed-point theorem", "negation has no fixed point", "Bool case analysis", "congr_fun"]
   },
   {
     "id": "ann-cantor-oq02-06-diagonal-witness",
     "proofId": "cantors-theorem-oq-02",
     "range": { "startLine": 186, "endLine": 218 },
-    "type": "mathematical",
-    "content": "**The Original Cantor Diagonal** (Cantor, 1891):\n\nExplicit witness: given f : α → Set α, the set\n```\nD = {x | x ∉ f x}   (the anti-diagonal)\n```\nis never in range(f).\n\nProof: If f a = D, then:\n- a ∈ f a ↔ a ∈ D = {x | x ∉ f x} ↔ a ∉ f a\n\nThis gives a ∈ f a ↔ a ∉ f a, which is a fixed point of ¬ applied to the proposition (a ∈ f a) — contradiction by neg_no_fixed_point.\n\nThis is the historically original proof, now appearing as Part V after the more abstract Lawvere framework.",
-    "summary": "The anti-diagonal set D = {x | x ∉ f x} is the explicit witness for Cantor's non-surjection"
+    "type": "technique",
+    "content": "**The Original Cantor Diagonal** (Cantor, 1891):\n\nExplicit witness: given f : α → Set α, the set\n```\nD = {x | x ∉ f x}   (the anti-diagonal)\n```\nis never in range(f).\n\nProof: If f a = D, then:\n- a ∈ f a ↔ a ∈ D = {x | x ∉ f x} ↔ a ∉ f a\n\nThis gives a ∈ f a ↔ a ∉ f a, which is a fixed point of ¬ applied to the proposition (a ∈ f a) — contradiction by neg_no_fixed_point.\n\nCantor first published this argument in 1891 in \"Über eine elementare Frage der Mannigfaltigkeitslehre\" to prove the uncountability of the reals. Here it appears as Part V, after the more general Lawvere framework, to highlight that the classical construction is a special case.",
+    "summary": "The anti-diagonal set D = {x | x ∉ f x} is the explicit witness for Cantor's non-surjection",
+    "mathContext": "Given $f : \\alpha \\to \\mathcal{P}(\\alpha)$, define $D = \\{x \\in \\alpha \\mid x \\notin f(x)\\}$. Then $\\forall a : \\alpha,\\; f(a) \\neq D$. The proof reduces to $a \\in f(a) \\iff a \\notin f(a)$, i.e., $\\neg$ has a fixed point applied to the proposition $a \\in f(a)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cantor's 1891 paper", "uncountability of the reals", "power set axiom", "complement operation", "Russell's paradox"],
+    "prerequisites": ["set membership", "set builder notation", "proof by contradiction", "neg_no_fixed_point"]
   },
   {
     "id": "ann-cantor-oq02-07-girard",
     "proofId": "cantors-theorem-oq-02",
-    "range": { "startLine": 219, "endLine": 290 },
+    "range": { "startLine": 219, "endLine": 281 },
     "type": "context",
-    "content": "**Girard's Paradox and Type Universes**:\n\nGirard (1972) showed that 'Type : Type' (type theory with a universe in itself) leads to inconsistency. The connection to Lawvere:\n\n- 'Type : Type' would give a type U with U ≅ U → U\n- Instantiating Lawvere with α = β = U and f : U → (U → U) surjective\n- Every g : U → U would have a fixed point\n- But we can construct fixed-point-free functions on rich enough types\n\n**Lean 4's solution**: The universe hierarchy `Type u : Type (u+1)` prevents this by ensuring no type contains itself as a value. This is not mere formalism — it encodes the mathematical content of Lawvere's theorem.\n\n**lawvere_cantor_unity** bundles all three main results:\n1. ∀ α f, ¬Surjective (f : α → (α → Prop)) [Cantor]\n2. ¬∃ p : Prop, p ↔ ¬p [Russell]\n3. ∀ f : ℕ → (ℕ → Prop), ∃ D, ∀ n, D ≠ f n [Gödel]",
-    "summary": "Girard's paradox explained via Lawvere, and the lawvere_cantor_unity summary theorem"
+    "content": "**Girard's Paradox and Type Universes**:\n\nGirard (1972) showed that 'Type : Type' (type theory with a universe in itself) leads to inconsistency. The connection to Lawvere:\n\n- 'Type : Type' would give a type U with U ≅ U → U\n- Instantiating Lawvere with α = β = U and f : U → (U → U) surjective\n- Every g : U → U would have a fixed point\n- But we can construct fixed-point-free functions on rich enough types\n\n**Lean 4's solution**: The universe hierarchy `Type u : Type (u+1)` prevents this by ensuring no type contains itself as a value. This is not mere formalism — it encodes the mathematical content of Lawvere's theorem.\n\nThe `diagonal_argument_schema` theorem captures the abstract template: surjection + fixed-point-free endomorphism → contradiction. The final `lawvere_cantor_unity` bundles Cantor, Russell, and Gödel as a single conjunction, showing they are all consequences of the Lawvere framework.\n\nHistorically, Martin-Löf's original 1971 type theory had Type : Type and was shown inconsistent by Girard. The stratified universe hierarchy (Type₀ : Type₁ : Type₂ : ⋯) was introduced to fix this, paralleling the cumulative hierarchy in ZFC set theory.",
+    "summary": "Girard's paradox explained via Lawvere, the diagonal_argument_schema, and lawvere_cantor_unity",
+    "mathContext": "Girard's paradox: if $U : U$, then there exists a surjection $f : U \\to (U \\to U)$, so by Lawvere every $g : U \\to U$ has a fixed point. But $\\lambda x.\\, x + 1 : \\mathbb{N} \\to \\mathbb{N}$ is fixed-point-free, contradiction. The unity theorem: $(\\forall \\alpha\\, f,\\; \\neg\\text{Surjective}(f : \\alpha \\to (\\alpha \\to \\text{Prop}))) \\wedge (\\neg\\exists p,\\; p \\leftrightarrow \\neg p) \\wedge (\\forall f : \\mathbb{N} \\to (\\mathbb{N} \\to \\text{Prop}),\\; \\exists D,\\; \\forall n,\\; D \\neq f(n))$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Girard's paradox", "universe polymorphism", "cumulative hierarchy", "Martin-Löf type theory", "System U", "Burali-Forti paradox"],
+    "prerequisites": ["Lawvere's fixed-point theorem", "type universes in Lean 4", "universe stratification"]
   }
 ]

--- a/src/data/proofs/cantors-theorem-oq-02/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-02/meta.json
@@ -52,12 +52,12 @@
     "problemStatement": "**Open Question (cantors-theorem-oq-02)**: How does Cantor's theorem relate to type-theoretic universes and Girard's paradox? Is there a unified framework for Cantor, Russell, and Gödel?\n\n**Answer**: YES. Lawvere's Fixed-Point Theorem provides the unified categorical framework.\n\n**Lawvere's theorem**: If f : α → (α → β) is surjective, then every g : β → β has a fixed point b with g b = b.\n\n**Corollary**: If g : β → β has NO fixed point, then no f : α → (α → β) can be surjective. This is the abstract form of all classical impossibility results.\n\n**For type universes**: The Lean 4 hierarchy (Type u : Type (u+1)) prevents Girard's paradox by blocking self-reference. A 'Type : Type' universe would give a surjection Type → (Type → Type), forcing every endofunction on Type to have a fixed point — including ¬, which is impossible.",
     "proofStrategy": "We formalize the Lawvere framework in six parts:\n\n**Part I: Russell's Paradox** — Show negation has no fixed point (neg_no_fixed_point). This is the seed from which all diagonal arguments grow.\n\n**Part II: Lawvere's Fixed-Point Theorem** — The diagonal construction: q x = g(f x x). If f is surjective, q = f a for some a, so g(f a a) = q a = f a a. No abstract machinery needed — pure lambda calculus.\n\n**Part III: Cantor from Lawvere** — Instantiate Lawvere with β = Prop, g = ¬. Since ¬ has no fixed point, no f : α → (α → Prop) is surjective.\n\n**Part IV: Gödel Diagonalization** — The predicate D n = ¬(f n n) is never in range(f). Same proof, specialized to ℕ-indexed predicates.\n\n**Part V: Direct Diagonal** — Classical Cantor construction: D = {x | x ∉ f x}. Shown as a corollary of the Lawvere framework.\n\n**Part VI: Type-Universe Commentary** — How Lean 4's universe hierarchy prevents Girard's paradox by blocking the Lawvere hypothesis.",
     "keyInsights": [
-      "All diagonal arguments are instances of Lawvere's theorem: surjection f + fixed-point-free g → contradiction",
-      "The 'magic' of diagonalization: q x = g(f x x) is the canonical diagonal map in any cartesian closed category",
-      "Negation on Prop (¬) having no fixed point is the mathematical engine behind ALL the classical paradoxes",
-      "Girard's paradox: 'Type : Type' would force every g : Prop → Prop to have a fixed point, but ¬ has none",
-      "Lean 4's universe hierarchy is not just syntax — it encodes the mathematical content that prevents self-reference",
-      "Lean 4 gotcha: '! (f n n) = f n n' in a type annotation parses '!' as Prop negation, not Bool.not — use 'have h := congr_fun' without explicit annotation"
+      "All diagonal arguments are instances of Lawvere's theorem: surjection f + fixed-point-free g → contradiction — this was Lawvere's 1969 breakthrough in 'Diagonal Arguments and Cartesian Closed Categories'",
+      "The 'magic' of diagonalization is the single formula q x = g(f x x): this is the canonical diagonal map in any cartesian closed category, and every impossibility theorem in foundations reduces to it",
+      "Negation on Prop (¬) having no fixed point is the mathematical engine behind ALL the classical paradoxes — Cantor, Russell, Gödel, and Tarski all reduce to the impossibility of p ↔ ¬p",
+      "Girard's paradox: 'Type : Type' would force every g : Prop → Prop to have a fixed point, but ¬ has none — Lean 4's universe hierarchy (Type u : Type (u+1)) is the mathematical fix, paralleling the cumulative hierarchy in ZFC",
+      "The Lawvere framework works constructively: no excluded middle or choice is needed, only surjectivity and function application — making it valid in intuitionistic, classical, and realizability settings alike",
+      "The Bool diagonal (cantor_diagonal_bool) shows the argument works even with finite codomains: two-element types suffice because Bool.not is fixed-point-free, connecting to the undecidability of the halting problem"
     ]
   },
   "sections": [
@@ -66,49 +66,88 @@
       "title": "Problem Statement and Overview",
       "startLine": 1,
       "endLine": 45,
-      "summary": "Header comment explaining Lawvere's Fixed-Point Theorem and how it unifies Cantor, Russell, Gödel, and Girard. Imports: Mathlib.Logic.Function.Basic, Mathlib.Data.Set.Function, Mathlib.Tactic."
+      "summary": "Header comment explaining Lawvere's Fixed-Point Theorem and how it unifies Cantor, Russell, Gödel, and Girard. Imports: Mathlib.Logic.Function.Basic, Mathlib.Data.Set.Function, Mathlib.Tactic.",
+      "mathContext": "Framing the open question: can Cantor, Russell, Gödel, and Girard be unified? The answer is Lawvere's theorem: surjective $f : \\alpha \\to (\\alpha \\to \\beta)$ forces every $g : \\beta \\to \\beta$ to have a fixed point."
     },
     {
       "id": "russell-paradox",
       "title": "Part I: Russell's Paradox — Negation Has No Fixed Point",
       "startLine": 46,
       "endLine": 72,
-      "summary": "neg_no_fixed_point: ¬∃ p : Prop, p ↔ ¬p — negation has no fixed point. russell_no_self_membership_set: ¬∃ R : Set Prop, ∀ p, p ∈ R ↔ p ∉ R — the Russell set doesn't exist."
+      "summary": "neg_no_fixed_point: ¬∃ p : Prop, p ↔ ¬p — negation has no fixed point. russell_no_self_membership_set: ¬∃ R : Set Prop, ∀ p, p ∈ R ↔ p ∉ R — the Russell set doesn't exist.",
+      "mathContext": "$\\neg\\exists\\, p : \\text{Prop},\\; p \\leftrightarrow \\neg p$ and $\\neg\\exists\\, R \\subseteq \\text{Prop},\\; \\forall p,\\; p \\in R \\leftrightarrow p \\notin R$."
     },
     {
       "id": "lawvere-theorem",
       "title": "Part II: Lawvere's Fixed-Point Theorem",
       "startLine": 73,
       "endLine": 117,
-      "summary": "lawvere_fixed_point: surjective f : α → (α → β) forces every g : β → β to have a fixed point. Proof via diagonal q x = g(f x x): if f a = q then g(f a a) = q a = f a a. lawvere_contrapositive: fixed-point-free g implies no surjection exists."
+      "summary": "lawvere_fixed_point: surjective f : α → (α → β) forces every g : β → β to have a fixed point. Proof via diagonal q x = g(f x x): if f a = q then g(f a a) = q a = f a a. lawvere_contrapositive: fixed-point-free g implies no surjection exists.",
+      "mathContext": "$\\text{Surjective}(f) \\implies \\forall g : \\beta \\to \\beta,\\; \\exists b,\\; g(b) = b$. Contrapositive: $(\\forall b,\\; g(b) \\neq b) \\implies \\neg\\text{Surjective}(f)$."
     },
     {
       "id": "cantor-from-lawvere",
       "title": "Part III: Cantor's Theorem Derived from Lawvere",
       "startLine": 118,
       "endLine": 148,
-      "summary": "cantor_from_lawvere: no f : α → (α → Prop) is surjective — instantiate Lawvere with g = ¬ (which has no fixed points). cantor_no_surjection_sets: no f : α → Set α is surjective. cantor_power_type_strictly_larger: ¬∃ f : α → (α → Prop), Surjective f."
+      "summary": "cantor_from_lawvere: no f : α → (α → Prop) is surjective — instantiate Lawvere with g = ¬ (which has no fixed points). cantor_no_surjection_sets: no f : α → Set α is surjective. cantor_power_type_strictly_larger: ¬∃ f : α → (α → Prop), Surjective f.",
+      "mathContext": "$\\forall \\alpha,\\; \\nexists f : \\alpha \\to \\mathcal{P}(\\alpha)$ surjective. Equivalent to $|\\alpha| < |2^\\alpha|$ (Cantor's theorem)."
     },
     {
       "id": "godel-diagonalization",
       "title": "Part IV: Gödel Diagonalization",
       "startLine": 149,
       "endLine": 185,
-      "summary": "godel_diagonalization: for any f : ℕ → (ℕ → Prop), the predicate D n = ¬(f n n) is not in range(f). cantor_diagonal_bool: no enumeration ℕ → (ℕ → Bool) is surjective — Bool version using cases on Bool values. tarski_undefinability: no enumeration exhausts all predicates on ℕ."
+      "summary": "godel_diagonalization: for any f : ℕ → (ℕ → Prop), the predicate D n = ¬(f n n) is not in range(f). cantor_diagonal_bool: no enumeration ℕ → (ℕ → Bool) is surjective — Bool version using cases on Bool values. tarski_undefinability: no enumeration exhausts all predicates on ℕ.",
+      "mathContext": "$\\forall f : \\mathbb{N} \\to (\\mathbb{N} \\to \\text{Prop}),\\; \\exists D,\\; \\forall n,\\; D \\neq f(n)$ where $D(n) = \\neg f(n)(n)$."
     },
     {
       "id": "direct-diagonal",
       "title": "Part V: Cantor's Theorem via Direct Diagonal Construction",
       "startLine": 186,
       "endLine": 218,
-      "summary": "cantor_diagonal_witness: the anti-diagonal set D = {x | x ∉ f x} is never in range(f). cantor_diagonal_not_surjective: f : α → Set α fails surjectivity, witnessed explicitly by D."
+      "summary": "cantor_diagonal_witness: the anti-diagonal set D = {x | x ∉ f x} is never in range(f). cantor_diagonal_not_surjective: f : α → Set α fails surjectivity, witnessed explicitly by D.",
+      "mathContext": "Given $f : \\alpha \\to \\mathcal{P}(\\alpha)$, the set $D = \\{x \\mid x \\notin f(x)\\}$ satisfies $\\forall a,\\; f(a) \\neq D$."
     },
     {
       "id": "type-universe",
       "title": "Part VI: Type-Theoretic Universe Hierarchy and Girard's Paradox",
       "startLine": 219,
-      "endLine": 290,
-      "summary": "lawvere_no_self_surjection: no α → (α → α) surjection when g has no fixed points. diagonal_argument_schema: the abstract template unifying all diagonal arguments. lawvere_cantor_unity: summary theorem bundling Cantor (no surjection α → (α → Prop)), Russell (¬ has no fixed point), and Gödel (diagonal predicate always escapes enumeration)."
+      "endLine": 281,
+      "summary": "lawvere_no_self_surjection: no α → (α → α) surjection when g has no fixed points. diagonal_argument_schema: the abstract template unifying all diagonal arguments. lawvere_cantor_unity: summary theorem bundling Cantor (no surjection α → (α → Prop)), Russell (¬ has no fixed point), and Gödel (diagonal predicate always escapes enumeration).",
+      "mathContext": "The unity theorem: $(\\forall \\alpha\\, f,\\; \\neg\\text{Surj}(f : \\alpha \\to (\\alpha \\to \\text{Prop}))) \\wedge (\\neg\\exists p,\\; p \\leftrightarrow \\neg p) \\wedge (\\forall f,\\; \\exists D,\\; \\forall n,\\; D \\neq f(n))$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "cantors-theorem",
+      "relationship": "parent",
+      "description": "The base Cantor's theorem proof; this entry derives it as a corollary of Lawvere's fixed-point theorem"
+    },
+    {
+      "id": "cantors-theorem-oq-01",
+      "relationship": "sibling",
+      "description": "OQ-01 explores cardinality aspects of Cantor's theorem; OQ-02 explores the categorical unification via Lawvere"
+    },
+    {
+      "id": "cantor-diagonalization",
+      "relationship": "related",
+      "description": "The direct diagonalization proof for uncountability of the reals; Part V of this entry reproduces the diagonal witness construction"
+    },
+    {
+      "id": "godel-incompleteness",
+      "relationship": "related",
+      "description": "Gödel's incompleteness theorem; Part IV of this entry shows the core diagonal mechanism underlying it"
+    },
+    {
+      "id": "brouwer-fixed-point",
+      "relationship": "contrast",
+      "description": "Brouwer's fixed-point theorem guarantees fixed points for continuous maps on compact convex sets — a topological analog, whereas Lawvere's theorem forces fixed points from surjectivity"
+    },
+    {
+      "id": "schauder-fixed-point",
+      "relationship": "contrast",
+      "description": "Schauder's fixed-point theorem extends Brouwer to infinite dimensions; both contrast with Lawvere's algebraic/categorical fixed-point result"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Added `mathContext`, `significance`, `relatedConcepts`, `prerequisites` to all 7 annotations with LaTeX formulas
- Added `mathContext` to all 7 sections in meta.json
- Added 6 cross-references to related gallery entries (cantors-theorem, cantor-diagonalization, godel-incompleteness, brouwer-fixed-point, schauder-fixed-point)
- Deepened `keyInsights` with constructive validity observation and Bool diagonal connection to halting problem
- Fixed section VI endLine to match actual Lean file (281 lines)
- Improved annotation types from generic "mathematical" to specific "insight"/"technique"

## Test plan
- [x] `pnpm annotations:build` passes with no errors for this entry
- [x] JSON is well-formed and structurally valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)