### PR TITLE
Enrich cevas-theorem-oq-04 and sophie-germain

### DIFF
--- a/src/data/proofs/sophie-germain/annotations.json
+++ b/src/data/proofs/sophie-germain/annotations.json
@@ -11,7 +11,8 @@
     "content": "Sophie Germain primes are named after the French mathematician who used them in her work on Fermat's Last Theorem.\n\nA prime p is a Sophie Germain prime if 2p + 1 is also prime. The sequence begins: 2, 3, 5, 11, 23, 29, 41, 53, 83, 89...\n\nThis file proves the structure theorem: for p > 3, Sophie Germain primes must satisfy p ≡ 5 (mod 6).",
     "mathContext": "Sophie Germain (1776-1831) used these primes to prove special cases of Fermat's Last Theorem.",
     "significance": "supporting",
-    "relatedConcepts": ["Sophie Germain", "safe primes", "Fermat's Last Theorem"]
+    "relatedConcepts": ["Sophie Germain", "safe primes", "Fermat's Last Theorem"],
+    "prerequisites": ["prime numbers", "basic number theory"]
   },
   {
     "id": "ann-definition",
@@ -25,7 +26,8 @@
     "content": "The formal definition:\n\n`IsSophieGermainPrime p` holds when both p and 2p + 1 are prime.\n\nExamples:\n- p = 2: 2·2+1 = 5 (prime) ✓\n- p = 11: 2·11+1 = 23 (prime) ✓\n- p = 7: 2·7+1 = 15 = 3×5 ✗",
     "mathContext": "IsSophieGermainPrime p := Nat.Prime p ∧ Nat.Prime (2 * p + 1)",
     "significance": "critical",
-    "relatedConcepts": ["prime", "definition"]
+    "relatedConcepts": ["twin primes", "prime numbers"],
+    "prerequisites": ["Nat.Prime", "multiplication"]
   },
   {
     "id": "ann-safe-prime-def",
@@ -39,7 +41,8 @@
     "content": "A **safe prime** is a prime q of the form q = 2p + 1 where p is also prime.\n\nSafe primes are important in cryptography because (q-1)/2 = p is prime, giving the multiplicative group a large prime-order subgroup.\n\nExamples: 5, 7, 11, 23, 47, 59, 83, 107, 167, 179...",
     "mathContext": "IsSafePrime q := Nat.Prime q ∧ q % 2 = 1 ∧ Nat.Prime ((q - 1) / 2)",
     "significance": "key",
-    "relatedConcepts": ["cryptography", "safe prime", "Diffie-Hellman"]
+    "relatedConcepts": ["cryptography", "safe prime", "Diffie-Hellman", "multiplicative groups", "primitive roots"],
+    "prerequisites": ["Nat.Prime", "odd numbers"]
   },
   {
     "id": "ann-examples",
@@ -53,7 +56,8 @@
     "content": "We verify 10 Sophie Germain primes computationally:\n\n| p | 2p+1 | Status |\n|---|------|--------|\n| 2 | 5 | ✓ |\n| 3 | 7 | ✓ |\n| 5 | 11 | ✓ |\n| 11 | 23 | ✓ |\n| 23 | 47 | ✓ |\n| 29 | 59 | ✓ |\n| 41 | 83 | ✓ |\n| 53 | 107 | ✓ |\n| 83 | 167 | ✓ |\n| 89 | 179 | ✓ |\n\nEach is proven using Lean's `decide` tactic which computationally verifies primality.",
     "mathContext": "constructor <;> decide",
     "significance": "supporting",
-    "relatedConcepts": ["computation", "verification", "decide tactic"]
+    "relatedConcepts": ["primality testing", "decide tactic", "computational verification"],
+    "prerequisites": ["IsSophieGermainPrime definition", "decide tactic"]
   },
   {
     "id": "ann-non-examples",
@@ -67,7 +71,8 @@
     "content": "Several primes are NOT Sophie Germain primes:\n\n| p | 2p+1 | Why not prime |\n|---|------|---------------|\n| 7 | 15 | 15 = 3 × 5 |\n| 13 | 27 | 27 = 3³ |\n| 17 | 35 | 35 = 5 × 7 |\n| 19 | 39 | 39 = 3 × 13 |\n\nNotice that 15, 27, 35, 39 are all ≡ 3 (mod 6) or composite for other reasons.",
     "mathContext": "Proof by contradiction: assume IsSophieGermainPrime p, then show 2p+1 is not prime",
     "significance": "supporting",
-    "relatedConcepts": ["counterexamples", "divisibility"]
+    "relatedConcepts": ["composite numbers", "primality testing", "factorization"],
+    "prerequisites": ["divisibility", "prime definition"]
   },
   {
     "id": "ann-prime-mod-six",
@@ -81,7 +86,8 @@
     "content": "**Lemma**: Every prime p > 3 satisfies p ≡ 1 or 5 (mod 6).\n\n**Proof**: The residue classes mod 6 are {0, 1, 2, 3, 4, 5}.\n- 0, 2, 4: divisible by 2\n- 0, 3: divisible by 3\n\nThis eliminates 0, 2, 3, 4. Only 1 and 5 remain.\n\nThis is the key lemma for the structure theorem.",
     "mathContext": "prime_mod_six: Nat.Prime p → p > 3 → p % 6 = 1 ∨ p % 6 = 5",
     "significance": "key",
-    "relatedConcepts": ["modular arithmetic", "prime residues"]
+    "relatedConcepts": ["Dirichlet's theorem", "prime residue classes", "sieve of Eratosthenes"],
+    "prerequisites": ["modular arithmetic", "divisibility by 2 and 3"]
   },
   {
     "id": "ann-mod-one-divisibility",
@@ -95,7 +101,8 @@
     "content": "**Critical insight**: If p ≡ 1 (mod 6), then 2p + 1 ≡ 3 (mod 6).\n\nCalculation: 2·1 + 1 = 3 (mod 6)\n\nThis means 3 divides 2p + 1! Since 2p + 1 > 3 for p > 1, this composite number cannot be prime.\n\nThis eliminates the p ≡ 1 (mod 6) case entirely.",
     "mathContext": "mod_one_implies_two_p_plus_one_div_three: p % 6 = 1 → 3 ∣ (2 * p + 1)",
     "significance": "critical",
-    "relatedConcepts": ["modular arithmetic", "divisibility", "key insight"]
+    "relatedConcepts": ["modular arithmetic", "divisibility criteria", "case elimination"],
+    "prerequisites": ["prime_mod_six lemma", "modular arithmetic"]
   },
   {
     "id": "ann-structure-theorem",
@@ -109,7 +116,8 @@
     "content": "**Main Result**: For p > 3, if p is a Sophie Germain prime, then p ≡ 5 (mod 6).\n\n**Proof outline**:\n1. By prime_mod_six, p ≡ 1 or 5 (mod 6)\n2. If p ≡ 1: Then 3 | (2p+1), so 2p+1 is composite—contradiction\n3. Therefore p ≡ 5 (mod 6)\n\nThis means Sophie Germain primes > 3 have the form p = 6k - 1.",
     "mathContext": "sophie_germain_mod_six: IsSophieGermainPrime p → p > 3 → p % 6 = 5",
     "significance": "critical",
-    "relatedConcepts": ["structure theorem", "classification", "main result"]
+    "relatedConcepts": ["Dirichlet's theorem on primes", "prime classification", "congruence conditions"],
+    "prerequisites": ["prime_mod_six", "mod_one_implies_two_p_plus_one_div_three"]
   },
   {
     "id": "ann-form-corollary",
@@ -123,7 +131,8 @@
     "content": "**Corollary**: Sophie Germain primes > 3 have the form p = 6k - 1 for some k ≥ 1.\n\nExamples:\n- 5 = 6·1 - 1 (k = 1)\n- 11 = 6·2 - 1 (k = 2)\n- 23 = 6·4 - 1 (k = 4)\n- 29 = 6·5 - 1 (k = 5)\n- 41 = 6·7 - 1 (k = 7)\n\nThis provides a simple characterization for searching.",
     "mathContext": "sophie_germain_form: ∃ k : ℕ, k ≥ 1 ∧ p = 6 * k - 1",
     "significance": "key",
-    "relatedConcepts": ["form", "characterization", "search"]
+    "relatedConcepts": ["arithmetic progressions", "prime-generating forms", "sieving"],
+    "prerequisites": ["sophie_germain_mod_six", "modular arithmetic"]
   },
   {
     "id": "ann-safe-prime-mod-12",
@@ -137,7 +146,8 @@
     "content": "**Theorem**: For a Sophie Germain prime p > 3, the safe prime 2p+1 satisfies q ≡ 11 (mod 12).\n\n**Proof**: Since p ≡ 5 (mod 6), we have p = 6k + 5 for some k.\nThen 2p + 1 = 12k + 11 ≡ 11 (mod 12).\n\nThis further constrains the structure of safe primes.",
     "mathContext": "safe_prime_mod_twelve: IsSophieGermainPrime p → p > 3 → (2 * p + 1) % 12 = 11",
     "significance": "key",
-    "relatedConcepts": ["safe prime", "modular structure"]
+    "relatedConcepts": ["safe primes in cryptography", "modular structure of primes"],
+    "prerequisites": ["sophie_germain_mod_six", "linear congruences"]
   },
   {
     "id": "ann-equivalence",
@@ -151,7 +161,8 @@
     "content": "**Equivalence**: p is a Sophie Germain prime if and only if p is prime and 2p+1 is a safe prime.\n\nThis shows the two concepts are two sides of the same coin:\n- Sophie Germain primes generate safe primes\n- Safe primes come from Sophie Germain primes\n\nThe relationship is bijective.",
     "mathContext": "sophie_germain_iff_safe: IsSophieGermainPrime p ↔ Nat.Prime p ∧ IsSafePrime (2 * p + 1)",
     "significance": "key",
-    "relatedConcepts": ["equivalence", "bijection", "duality"]
+    "relatedConcepts": ["iff characterization", "Sophie Germain-safe prime duality", "prime pair relationships"],
+    "prerequisites": ["IsSophieGermainPrime", "IsSafePrime"]
   },
   {
     "id": "ann-cunningham-chain",
@@ -165,6 +176,7 @@
     "content": "**Cunningham Chains**: A sequence where each term is 2p+1 of the previous.\n\nThe chain 2 → 5 → 11 → 23 shows this cascade:\n- 2 is SG: 2·2+1 = 5 ✓\n- 5 is SG: 2·5+1 = 11 ✓\n- 11 is SG: 2·11+1 = 23 ✓\n- 23 is SG: 2·23+1 = 47 ✓\n\nBut 47 is NOT Sophie Germain (2·47+1 = 95 = 5×19), ending the chain.\n\nLong Cunningham chains are rare and of interest in cryptography.",
     "mathContext": "sg_chain_2_5_11_23: IsSophieGermainPrime 2 ∧ IsSophieGermainPrime 5 ∧ IsSophieGermainPrime 11 ∧ IsSophieGermainPrime 23",
     "significance": "supporting",
-    "relatedConcepts": ["Cunningham chains", "cascading primes", "cryptography"]
+    "relatedConcepts": ["Cunningham chains", "cascading primes", "cryptography"],
+    "prerequisites": ["IsSophieGermainPrime", "iterated 2p+1 mapping"]
   }
 ]

--- a/src/data/proofs/sophie-germain/meta.json
+++ b/src/data/proofs/sophie-germain/meta.json
@@ -42,10 +42,11 @@
     "problemStatement": "**Definition**: A prime p is a **Sophie Germain prime** if 2p + 1 is also prime.\n\nThe prime q = 2p + 1 is called a **safe prime**.\n\n**Examples**: 2, 3, 5, 11, 23, 29, 41, 53, 83, 89, ...\n\n**Structure Theorem**: For p > 3, if p is a Sophie Germain prime, then p ≡ 5 (mod 6).\n\nEquivalently, Sophie Germain primes greater than 3 have the form 6k - 1.",
     "proofStrategy": "The structure theorem follows from modular arithmetic:\n\n1. **All primes > 3 are ≡ 1 or 5 (mod 6)**: Since primes > 3 are not divisible by 2 or 3, they avoid residue classes 0, 2, 3, 4 (mod 6).\n\n2. **If p ≡ 1 (mod 6)**: Then 2p + 1 ≡ 2·1 + 1 ≡ 3 (mod 6), so 3 | (2p + 1). But 2p + 1 > 3 for p > 1, so 2p + 1 cannot be prime.\n\n3. **Therefore p ≡ 5 (mod 6)**: The only remaining possibility.\n\nThis gives the form p = 6k - 1 for some k ≥ 1.",
     "keyInsights": [
-      "Sophie Germain primes connect to Fermat's Last Theorem",
-      "The structure theorem eliminates half of potential candidates",
-      "Safe primes q = 2p + 1 satisfy q ≡ 11 (mod 12)",
-      "Cunningham chains show how Sophie Germain primes can cascade"
+      "Sophie Germain primes connect directly to Fermat's Last Theorem: Germain proved the first case of FLT holds for exponent p when p is a Sophie Germain prime",
+      "The structure theorem eliminates half of potential candidates: primes ≡ 1 (mod 6) are ruled out because 2p+1 ≡ 3 (mod 6) is composite",
+      "Safe primes q = 2p + 1 satisfy q ≡ 11 (mod 12) — this further constrains the search space and is important in cryptographic applications",
+      "Cunningham chains (cascading Sophie Germain primes via iterated 2p+1) are rare and of interest in computational number theory",
+      "The Sophie Germain ↔ safe prime duality is a bijection: every Sophie Germain prime generates exactly one safe prime and vice versa, connecting two important classes in cryptography"
     ]
   },
   "sections": [
@@ -54,42 +55,75 @@
       "title": "Definitions",
       "startLine": 35,
       "endLine": 45,
-      "summary": "Formal definitions of Sophie Germain primes, safe primes, and the conjecture."
+      "summary": "Formal definitions of Sophie Germain primes, safe primes, and the conjecture.",
+      "mathContext": "$\\text{IsSophieGermainPrime}(p) := \\text{Prime}(p) \\wedge \\text{Prime}(2p+1)$. $\\text{IsSafePrime}(q) := \\text{Prime}(q) \\wedge q \\equiv 1 \\pmod{2} \\wedge \\text{Prime}((q-1)/2)$."
     },
     {
       "id": "examples",
       "title": "Verified Examples",
       "startLine": 53,
       "endLine": 95,
-      "summary": "Computational verification of 10 Sophie Germain primes: 2, 3, 5, 11, 23, 29, 41, 53, 83, 89."
+      "summary": "Computational verification of 10 Sophie Germain primes: 2, 3, 5, 11, 23, 29, 41, 53, 83, 89.",
+      "mathContext": "Each $p$ in $\\{2, 3, 5, 11, 23, 29, 41, 53, 83, 89\\}$ is verified: both $p$ and $2p+1$ are prime, proved by `decide`."
     },
     {
       "id": "non-examples",
       "title": "Non-Examples",
       "startLine": 103,
       "endLine": 125,
-      "summary": "Primes that are NOT Sophie Germain: 7, 13, 17, 19."
+      "summary": "Primes that are NOT Sophie Germain: 7, 13, 17, 19.",
+      "mathContext": "$2 \\cdot 7 + 1 = 15 = 3 \\times 5$, $2 \\cdot 13 + 1 = 27 = 3^3$, $2 \\cdot 17 + 1 = 35 = 5 \\times 7$, $2 \\cdot 19 + 1 = 39 = 3 \\times 13$."
     },
     {
       "id": "structure-theorem",
       "title": "Structure Theorem",
       "startLine": 127,
       "endLine": 212,
-      "summary": "The main result: Sophie Germain primes > 3 must satisfy p ≡ 5 (mod 6)."
+      "summary": "The main result: Sophie Germain primes > 3 must satisfy p ≡ 5 (mod 6). Key lemma: primes > 3 are ≡ 1 or 5 (mod 6), and p ≡ 1 implies 3 | (2p+1).",
+      "mathContext": "$p > 3 \\wedge \\text{IsSophieGermainPrime}(p) \\implies p \\equiv 5 \\pmod{6}$. Proof: $p \\equiv 1 \\pmod{6} \\implies 2p+1 \\equiv 3 \\pmod{6} \\implies 3 \\mid (2p+1)$, contradiction."
     },
     {
       "id": "safe-primes",
       "title": "Safe Prime Structure",
       "startLine": 214,
       "endLine": 244,
-      "summary": "Properties of safe primes: q ≡ 11 (mod 12) and the Sophie Germain ↔ safe prime equivalence."
+      "summary": "Properties of safe primes: q ≡ 11 (mod 12) and the Sophie Germain ↔ safe prime equivalence.",
+      "mathContext": "$p > 3 \\wedge \\text{IsSophieGermainPrime}(p) \\implies (2p+1) \\equiv 11 \\pmod{12}$. Equivalence: $\\text{IsSophieGermainPrime}(p) \\iff \\text{Prime}(p) \\wedge \\text{IsSafePrime}(2p+1)$."
     },
     {
       "id": "chain",
       "title": "Cunningham Chain",
       "startLine": 282,
       "endLine": 294,
-      "summary": "The chain 2 → 5 → 11 → 23 where each is 2p+1 of the previous."
+      "summary": "The chain 2 → 5 → 11 → 23 where each is 2p+1 of the previous.",
+      "mathContext": "$2 \\xrightarrow{2p+1} 5 \\xrightarrow{2p+1} 11 \\xrightarrow{2p+1} 23 \\xrightarrow{2p+1} 47$. Each element is a Sophie Germain prime; $47$ is not ($2 \\cdot 47 + 1 = 95$)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "fermats-last-theorem",
+      "relationship": "related",
+      "description": "Sophie Germain's original motivation: she proved the first case of FLT holds for Sophie Germain prime exponents"
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "related",
+      "description": "Whether there are infinitely many Sophie Germain primes remains open, analogous to the infinitude of primes result"
+    },
+    {
+      "id": "twin-primes-special",
+      "relationship": "related",
+      "description": "The Sophie Germain prime conjecture is analogous to the twin prime conjecture — both ask about structured prime pairs"
+    },
+    {
+      "id": "dirichlets-theorem",
+      "relationship": "related",
+      "description": "Dirichlet's theorem on primes in arithmetic progressions provides the framework for understanding primes ≡ 5 (mod 6)"
+    },
+    {
+      "id": "wilsons-theorem",
+      "relationship": "related",
+      "description": "Wilson's theorem provides another primality criterion; safe primes have special properties under Wilson's characterization"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

### cevas-theorem-oq-04
- Rewrote annotations.json with correct schema (range.startLine/endLine, proofId, title, summary)
- Added mathContext, significance, relatedConcepts, prerequisites to all 7 annotations
- Fixed annotation types from non-standard to standard
- Added mathContext to all 6 sections in meta.json
- Added 4 cross-references
- Deepened historicalContext with Archimedes, Möbius (1827), Ceva (1678)

### sophie-germain
- Added prerequisites field to all 12 annotations
- Replaced generic relatedConcepts with real mathematical concepts
- Added mathContext (LaTeX) to all 6 sections in meta.json
- Added 5 cross-references (fermats-last-theorem, infinitude-primes, twin-primes-special, dirichlets-theorem, wilsons-theorem)
- Deepened keyInsights from 4 to 5 entries

## Test plan
- [x] `pnpm annotations:build` passes with no errors for both entries
- [x] JSON is well-formed and structurally valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)