### PR TITLE
fix: copy .env to deployer worktree for Cloudflare account pinning

### DIFF
--- a/scripts/deploy/launch-agent.sh
+++ b/scripts/deploy/launch-agent.sh
@@ -85,6 +85,12 @@ create_worktree() {
 
             git stash pop 2>/dev/null || true
         )
+
+        # Refresh .env for Cloudflare account pinning (gitignored, not in worktree)
+        if [[ -f "$REPO_ROOT/.env" ]]; then
+            cp "$REPO_ROOT/.env" "$WORKTREE_PATH/.env"
+        fi
+
         return 0
     fi
 
@@ -105,6 +111,14 @@ create_worktree() {
         rm -rf "$WORKTREE_PATH/proofs/.lake" 2>/dev/null || true
         ln -s "$REPO_ROOT/proofs/.lake" "$WORKTREE_PATH/proofs/.lake"
         print_info "Linked .lake for fast Lean builds"
+    fi
+
+    # Copy .env for Cloudflare account pinning (gitignored, won't be in worktree)
+    if [[ -f "$REPO_ROOT/.env" ]]; then
+        cp "$REPO_ROOT/.env" "$WORKTREE_PATH/.env"
+        print_info "Copied .env for Cloudflare account pinning"
+    else
+        print_warning "No .env found - deploys will fail without CLOUDFLARE_ACCOUNT_ID"
     fi
 
     # Install node dependencies in worktree


### PR DESCRIPTION
## Summary
- Copy `.env` to deployer worktree on both creation and sync paths in `launch-agent.sh`
- `.env` is gitignored so it was missing from the worktree, leaving the `CLOUDFLARE_ACCOUNT_ID` guard in `sync-and-deploy.sh` ineffective
- Deploys were working only because wrangler OAuth happened to point at the personal account — this adds the explicit pin as a second safety layer

## Test plan
- [ ] Verify `.env` is present in `.loom/worktrees/deployer/` after next deployer respawn
- [ ] Verify deploy logs show `Account: 251e6e8626d921603fdc3f0d75576bc6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)