### PR TITLE
enrich: ballot-problem, greens-theorem-oq-03

### DIFF
--- a/src/data/proofs/ballot-problem/annotations.json
+++ b/src/data/proofs/ballot-problem/annotations.json
@@ -7,6 +7,7 @@
     "title": "The Ballot Problem: Wiedijk #30",
     "content": "The Ballot Problem (Bertrand, 1887): in an election where candidate A receives $p$ votes and B receives $q$ votes ($p > q$), what is the probability that A leads throughout the counting? The answer is $P = (p-q)/(p+q)$. The elegant **reflection principle** (Désiré André, 1887) makes this tractable: any 'bad' path (where A ties or falls behind) corresponds bijectively to a path ending at the reflected endpoint.",
     "mathContext": "$P = \\frac{p - q}{p + q}$ for $p > q$. Example: $p=5, q=3$ gives $P = \\frac{5-3}{5+3} = \\frac{1}{4}$. The formula emerges from the reflection bijection counting $\\binom{p+q}{p} - \\binom{p+q}{q}$ good paths out of $\\binom{p+q}{p}$ total.",
+    "summary": "Bertrand's ballot problem: P(A leads throughout) = (p-q)/(p+q) via the reflection principle.",
     "significance": "key",
     "relatedConcepts": ["reflection principle", "Bertrand ballot problem", "conditional probability", "Wiedijk 100 theorems"],
     "prerequisites": ["probability theory", "combinatorics", "integer sequences"]
@@ -19,6 +20,7 @@
     "title": "Vote Sequence Model",
     "content": "Modeling vote counting as integer sequences: +1 = vote for A, -1 = vote for B. The set `countedSequence p q` contains all lists of integers with exactly $p$ ones and $q$ minus-ones (representing all orderings of the vote count). The predicate `staysPositive` holds when every prefix has positive partial sum (A leads throughout). Count: $|\\text{countedSequence}\\, p\\, q| = \\binom{p+q}{p}$.",
     "mathContext": "Vote sequences: elements of $\\{+1, -1\\}^{p+q}$ with exactly $p$ values $+1$. The predicate 'staysPositive' formalizes $\\forall i \\geq 1,\\, \\sum_{j=1}^{i} v_j > 0$. Total count: $\\binom{p+q}{p}$.",
+    "summary": "Vote sequences as integer lists with +1/-1; countedSequence and staysPositive predicates.",
     "significance": "key",
     "relatedConcepts": ["countedSequence", "staysPositive", "binomial coefficient", "List ℤ in Lean"],
     "prerequisites": ["List ℤ", "Finset.card", "partial sums", "List.sum"]
@@ -31,6 +33,7 @@
     "title": "The Ballot Theorem",
     "content": "The main result: `condCount (countedSequence p q) staysPositive = (p - q) / (p + q)`. The conditional probability of A leading throughout (given a fixed vote count of $p$ for A and $q$ for B) equals $(p-q)/(p+q)$. The proof builds on the Mathlib Archive formalization using the reflection principle to count good vs bad lattice paths.",
     "mathContext": "$P(A \\text{ leads throughout} \\mid p, q) = \\frac{p-q}{p+q}$. Derived as ratio of cardinalities: $\\frac{\\binom{p+q}{p} - \\binom{p+q}{q}}{\\binom{p+q}{p}} = \\frac{p-q}{p+q}$ via algebraic simplification of binomial coefficients.",
+    "summary": "condCount (countedSequence p q) staysPositive = (p-q)/(p+q) via Mathlib's formalization.",
     "significance": "key",
     "relatedConcepts": ["condCount", "reflection principle", "Archive.Wiedijk100Theorems", "conditional probability"],
     "prerequisites": ["countedSequence", "staysPositive", "Ballot.ballot_problem from Mathlib"]
@@ -43,6 +46,7 @@
     "title": "Edge Cases",
     "content": "Unanimous vote ($q = 0$): probability is 1 — if B gets no votes, A always leads. Verification: $(p-0)/(p+0) = 1$. Tied election base case ($p = q$): probability is 0 — equal votes must eventually tie. Verification: $(p-p)/(2p) = 0$. These boundary cases demonstrate the formula's extremal behavior.",
     "mathContext": "$\\frac{p - 0}{p + 0} = 1$ (unanimous), $\\frac{p - p}{p + p} = 0$ (tie). The probability $(p-q)/(p+q) \\in [0, 1]$ for $0 \\leq q \\leq p$.",
+    "summary": "Edge cases: unanimous vote (P=1) and tied election (P=0) verify extremal behavior.",
     "significance": "supporting",
     "relatedConcepts": ["edge cases", "probability 0 and 1", "degenerate cases"],
     "prerequisites": ["ballot_problem", "norm_num", "Nat.div"]
@@ -55,6 +59,7 @@
     "title": "Concrete Examples",
     "content": "Numerical verifications: $(p,q) = (2,1)$ gives $P = 1/3$; $(3,1)$ gives $P = 1/2$; $(4,2)$ gives $P = 1/3$; $(5,2)$ gives $P = 3/7$. Explicit check for $(2,1)$: three sequences $[+1,+1,-1], [+1,-1,+1], [-1,+1,+1]$ — only $[+1,+1,-1]$ has partial sums $(1,2,1) > 0$ throughout. Probability $= 1/3 = (2-1)/(2+1)$ ✓",
     "mathContext": "$(p,q) = (2,1)$: $\\binom{3}{2} = 3$ total sequences, 1 'stays positive'. $P = 1/3$. Note: $(4,2)$ and $(2,1)$ give the same probability $1/3$ — the formula only depends on the ratio $(p-q)/(p+q)$.",
+    "summary": "Numerical checks: (2,1)→1/3, (3,1)→1/2, (4,2)→1/3, (5,2)→3/7 with exhaustive enumeration.",
     "significance": "supporting",
     "relatedConcepts": ["numerical verification", "norm_num", "exhaustive enumeration"],
     "prerequisites": ["ballot_problem", "decide tactic", "norm_num"]
@@ -67,6 +72,7 @@
     "title": "Lattice Paths and Catalan Numbers",
     "content": "Lattice path interpretation: start at $(0,0)$, $+1$ vote moves to $(x+1, y+1)$, $-1$ moves to $(x+1, y-1)$, ending at $(p+q, p-q)$. 'A leads throughout' means the path never touches $y=0$ after start. Connection to Catalan numbers: for $p = q = n$, the number of non-negative lattice paths is $C_n = \\frac{1}{n+1}\\binom{2n}{n}$. Applications: stock prices above barrier, queueing theory, branching processes.",
     "mathContext": "Lattice paths from $(0,0)$ to $(p+q, p-q)$. Good paths (strictly positive) counted by $\\binom{p+q}{p} - \\binom{p+q}{q}$. Catalan numbers: $C_n = \\frac{1}{n+1}\\binom{2n}{n}$ count weakly non-negative paths for $p = q = n$ (the Dyck path count).",
+    "summary": "Lattice path interpretation; connection to Catalan numbers C_n for p=q=n Dyck paths.",
     "significance": "supporting",
     "relatedConcepts": ["Catalan numbers", "Dyck paths", "lattice paths", "random walks"],
     "prerequisites": ["binomial coefficients", "Nat.choose", "combinatorics"]
@@ -79,6 +85,7 @@
     "title": "The Reflection Principle",
     "content": "The reflection bijection (Désiré André, 1887): for any 'bad' path (touches $y=0$), find the first time the partial sum equals 0, then reflect (swap $+1 \\leftrightarrow -1$) all votes before that point, creating a path to $(p+q, q-p)$ instead of $(p+q, p-q)$. This is a bijection: bad paths ↔ all paths to the wrong endpoint. Counting: total $\\binom{p+q}{p}$, bad $\\binom{p+q}{q}$, giving probability $(p-q)/(p+q)$.",
     "mathContext": "Reflection bijection: $\\{\\text{bad paths}\\} \\xrightarrow{\\sim} \\{\\text{paths to } (p+q, q-p)\\}$. Count of paths to $(p+q, q-p)$: $\\binom{p+q}{q}$. Good paths: $\\binom{p+q}{p} - \\binom{p+q}{q}$. Probability: $\\frac{p-q}{p+q}$.",
+    "summary": "André's reflection bijection: bad paths ↔ paths to (p+q, q-p), giving C(p+q,q) bad paths.",
     "significance": "key",
     "relatedConcepts": ["reflection principle", "Désiré André bijection", "Cycle Lemma", "bijective combinatorics"],
     "prerequisites": ["staysPositive", "countedSequence", "Finset.card", "reflection bijection construction"]

--- a/src/data/proofs/ballot-problem/meta.json
+++ b/src/data/proofs/ballot-problem/meta.json
@@ -56,35 +56,40 @@
       "title": "The Setting",
       "startLine": 93,
       "endLine": 111,
-      "summary": "Modeling vote counting as sequences of +1 and -1."
+      "summary": "Modeling vote counting as sequences of +1 and -1.",
+      "mathContext": "Vote sequences: elements of $\\{+1, -1\\}^{p+q}$ with exactly $p$ values $+1$ and $q$ values $-1$. `countedSequence p q` is the Finset of all such lists, with $|\\text{countedSequence}\\, p\\, q| = \\binom{p+q}{p}$. `staysPositive` holds when $\\forall i \\geq 1,\\, \\sum_{j=1}^{i} v_j > 0$."
     },
     {
       "id": "key-properties",
       "title": "Key Properties",
       "startLine": 113,
       "endLine": 130,
-      "summary": "Properties of counted sequences and their cardinalities."
+      "summary": "Properties of counted sequences and their cardinalities.",
+      "mathContext": "Cardinality: $|\\text{countedSequence}\\, p\\, q| = \\binom{p+q}{p}$. The good paths (where A leads throughout) number $\\binom{p+q}{p} - \\binom{p+q}{q}$. This uses the algebraic identity $\\frac{\\binom{p+q}{p} - \\binom{p+q}{q}}{\\binom{p+q}{p}} = \\frac{p-q}{p+q}$ for $p > q$."
     },
     {
       "id": "main-theorem",
       "title": "The Ballot Theorem",
       "startLine": 132,
       "endLine": 152,
-      "summary": "The main result: probability of A leading throughout equals (p-q)/(p+q)."
+      "summary": "The main result: probability of A leading throughout equals (p-q)/(p+q).",
+      "mathContext": "$\\text{condCount}(\\text{countedSequence}\\, p\\, q,\\, \\text{staysPositive}) = \\frac{p-q}{p+q}$ for $p > q$. The conditional probability is computed as the ratio $\\frac{|\\{s \\in \\text{countedSequence}\\, p\\, q \\mid \\text{staysPositive}(s)\\}|}{|\\text{countedSequence}\\, p\\, q|}$."
     },
     {
       "id": "edge-cases",
       "title": "Edge Cases",
       "startLine": 154,
       "endLine": 166,
-      "summary": "Special cases: unanimous vote and tied election."
+      "summary": "Special cases: unanimous vote and tied election.",
+      "mathContext": "Unanimous ($q = 0$): $\\frac{p-0}{p+0} = 1$. Tied ($p = q$): $\\frac{p-p}{2p} = 0$. These verify the formula at its extremes: $P \\in [0, 1]$ for $0 \\leq q \\leq p$. Numerical examples: $(2,1) \\to 1/3$, $(3,1) \\to 1/2$, $(4,2) \\to 1/3$, $(5,2) \\to 3/7$."
     },
     {
       "id": "reflection-principle",
       "title": "The Reflection Principle",
       "startLine": 216,
       "endLine": 249,
-      "summary": "Detailed explanation of the bijective proof technique."
+      "summary": "Detailed explanation of the bijective proof technique.",
+      "mathContext": "André's reflection bijection: for any 'bad' path (first touching $y=0$ at step $k$), reflect all votes before step $k$ ($+1 \\leftrightarrow -1$). This maps bad paths ending at $(p+q, p-q)$ bijectively to ALL paths ending at $(p+q, q-p)$. Count: $\\binom{p+q}{q}$ bad paths, so good paths $= \\binom{p+q}{p} - \\binom{p+q}{q}$."
     }
   ],
   "conclusion": {
@@ -95,5 +100,22 @@
       "Continuous-time versions of the ballot problem",
       "Higher-dimensional lattice path problems"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "fair-games-theorem",
+      "relationship": "related",
+      "description": "Both use conditional probability over finite sample spaces; the ballot problem's staysPositive predicate connects to fair game stopping conditions"
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "uses",
+      "description": "The ballot formula relies on binomial coefficients C(p+q,p) and C(p+q,q) for counting lattice paths"
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "co-listed",
+      "description": "Both appear in Wiedijk's 100 Theorems list; infinitude of primes is #11, ballot problem is #30"
+    }
+  ]
 }

--- a/src/data/proofs/greens-theorem-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-03/meta.json
@@ -113,7 +113,8 @@
   "conclusion": {
     "summary": "OQ-03 is answered YES: the abstract `GreenRegion where dummy : Unit` is replaced by `TypeIRegion`, a concrete structure with 4 real-valued fields and 2 proof obligations. The area formula ∫_a^b (g-f) dx is fully proved (0 sorries), Green's theorem is stated as a meaningful non-trivial axiom with the correct curved-boundary formula.",
     "significance": "Demonstrates that Lean 4's type system can model the standard Apostol/Rudin definition of simply-connected regions, enabling future work on the full Green's theorem proof via FTC + chain rule for parametric boundaries.",
-    "futureWork": [
+    "implications": "Enables formalization of vector calculus on curved-boundary domains. The TypeIRegion structure provides the geometric foundation for proving area formulas, double integrals, and eventually the full divergence theorem in Lean 4.",
+    "openQuestions": [
       "Prove greens_theorem_typeI: apply FTC to inner integral ∫_{f(x)}^{g(x)} ∂P/∂y dy, then FTC + Fubini to outer",
       "Define Type II regions (horizontally simple) and prove Green's theorem for them",
       "Decomposition theorem: any simply-connected region = union of TypeI and TypeII regions",


### PR DESCRIPTION
## Summary
- **ballot-problem**: Add `summary` to all 7 annotations, `mathContext` to 5 sections, 3 `crossReferences`
- **greens-theorem-oq-03**: Add `summary` to 6 annotations, `mathContext` to 5 sections, fix annotation type, 2 `crossReferences`

## Test plan
- [x] `pnpm annotations:build` passes with no ballot-problem or greens-theorem-oq-03 errors
- [x] JSON validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)