### PR TITLE
research: fix Power Mean Limit proof for Lean 4.26 (amgm-inequality-oq-03-oq-02)

### DIFF
--- a/proofs/Proofs/PowerMeanLimitOQ.lean
+++ b/proofs/Proofs/PowerMeanLimitOQ.lean
@@ -82,21 +82,25 @@ private lemma sum_weighted_rpow_pos
     Differentiate the finite sum term-by-term. -/
 theorem hasDerivAt_sum_weighted_rpow_zero
     (hz : ∀ i ∈ s, 0 < z i)
-    (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (_hw : ∀ i ∈ s, 0 ≤ w i) :
     HasDerivAt (fun (r : ℝ) => ∑ i ∈ s, w i * z i ^ r)
                (∑ i ∈ s, w i * Real.log (z i)) 0 := by
-  apply HasDerivAt.sum
-  intro i hi
-  have hzi : (0 : ℝ) < z i := hz i hi
-  -- d/dr[zᵢ^r]|_{r=0} = zᵢ^0 · log(zᵢ) = log(zᵢ)
-  have hderiv : HasDerivAt (fun (r : ℝ) => z i ^ r) (Real.log (z i)) 0 := by
-    have h := (Real.hasStrictDerivAt_const_rpow hzi 0).hasDerivAt
-    simp only [Real.rpow_zero, one_mul] at h
-    exact h
-  -- d/dr[wᵢ · zᵢ^r]|_{r=0} = wᵢ · log(zᵢ)
-  have hmul := hderiv.const_mul (w i)
-  simp only [mul_comm (w i)] at hmul
-  exact hmul
+  -- Prove derivative for each term individually
+  have hterm : ∀ i ∈ s, HasDerivAt (fun (r : ℝ) => w i * z i ^ r)
+      (w i * Real.log (z i)) (0 : ℝ) := by
+    intro i hi
+    have hzi : (0 : ℝ) < z i := hz i hi
+    have hderiv : HasDerivAt (fun (r : ℝ) => z i ^ r) (Real.log (z i)) 0 := by
+      have h := (Real.hasStrictDerivAt_const_rpow hzi 0).hasDerivAt
+      simp only [Real.rpow_zero, one_mul] at h
+      exact h
+    exact hderiv.const_mul (w i)
+  -- Combine: sum of individual HasDerivAt gives HasDerivAt of the sum
+  have hsum := HasDerivAt.sum hterm
+  -- Convert (∑ i, f_i) to (fun r => ∑ i, f_i r) using Finset.sum_apply
+  rwa [show (∑ i ∈ s, fun (r : ℝ) => w i * z i ^ r) =
+       (fun r => ∑ i ∈ s, w i * z i ^ r) from
+       funext fun r => Finset.sum_apply r s _] at hsum
 
 /-
 ## Part II: The Log Identity f(0) = 0
@@ -104,8 +108,8 @@ theorem hasDerivAt_sum_weighted_rpow_zero
 
 /-- The function r ↦ log(∑ wᵢ zᵢ^r) has value 0 at r = 0 (when ∑ wᵢ = 1). -/
 theorem log_sum_weighted_rpow_zero
-    (hz : ∀ i ∈ s, 0 < z i)
-    (hw : ∀ i ∈ s, 0 ≤ w i)
+    (_hz : ∀ i ∈ s, 0 < z i)
+    (_hw : ∀ i ∈ s, 0 ≤ w i)
     (hw' : ∑ i ∈ s, w i = 1) :
     Real.log (∑ i ∈ s, w i * z i ^ (0 : ℝ)) = 0 := by
   simp only [Real.rpow_zero, mul_one]
@@ -134,7 +138,7 @@ private lemma hasDerivAt_log_sum_weighted_rpow
   have hh := hasDerivAt_sum_weighted_rpow_zero s w z hz hw
   -- Apply chain rule via Real.hasDerivAt_log.comp: (log ∘ h)' = h'(0) / h(0)
   have hlog := (Real.hasDerivAt_log hh_ne).comp (0 : ℝ) hh
-  simp only [Function.comp, smul_eq_mul, hh_zero, inv_one, one_mul] at hlog
+  simp only [hh_zero, inv_one, one_mul] at hlog
   exact hlog
 
 /-
@@ -167,11 +171,9 @@ theorem tendsto_log_sum_div_rpow
   rw [hasDerivAt_iff_tendsto_slope] at hg_deriv
   -- slope g 0 r = (g r - g 0) / (r - 0) = g r / r  (since g 0 = 0)
   -- equality holds for all r (including r = 0 where both sides = 0)
-  apply hg_deriv.congr'
-  apply Filter.eventually_of_forall
-  intro r
-  simp only [slope, sub_zero, hg_zero, smul_eq_mul]
-  ring
+  exact hg_deriv.congr (fun r => by
+    simp only [slope, vsub_eq_sub, sub_zero, hg_zero, smul_eq_mul]
+    ring)
 
 /-
 ## Part V: Supporting Identities
@@ -180,7 +182,7 @@ theorem tendsto_log_sum_div_rpow
 /-- The geometric mean can be written as exp(∑ wᵢ log zᵢ). -/
 theorem geomMean_eq_exp_sum_log
     (hz : ∀ i ∈ s, 0 < z i)
-    (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (_hw : ∀ i ∈ s, 0 ≤ w i) :
     ∏ i ∈ s, z i ^ w i = Real.exp (∑ i ∈ s, w i * Real.log (z i)) := by
   have hprod_pos : 0 < ∏ i ∈ s, z i ^ w i :=
     Finset.prod_pos (fun i hi => Real.rpow_pos_of_pos (hz i hi) (w i))
@@ -193,8 +195,8 @@ theorem geomMean_eq_exp_sum_log
 
 /-- For r = 1, the power mean equals the arithmetic mean. -/
 theorem powerMean_one_eq_arithMean
-    (hw : ∀ i ∈ s, 0 ≤ w i)
-    (hz : ∀ i ∈ s, 0 ≤ z i) :
+    (_hw : ∀ i ∈ s, 0 ≤ w i)
+    (_hz : ∀ i ∈ s, 0 ≤ z i) :
     (∑ i ∈ s, w i * z i ^ (1 : ℝ)) = ∑ i ∈ s, w i * z i := by
   simp [Real.rpow_one]
 
@@ -208,7 +210,7 @@ theorem powerMean_eq_exp_log
     (hz : ∀ i ∈ s, 0 < z i)
     (hw : ∀ i ∈ s, 0 ≤ w i)
     (hw' : ∑ i ∈ s, w i = 1)
-    {r : ℝ} (hr : r ≠ 0) :
+    {r : ℝ} (_hr : r ≠ 0) :
     (∑ i ∈ s, w i * z i ^ r) ^ (1 / r) =
     Real.exp ((1 / r) * Real.log (∑ i ∈ s, w i * z i ^ r)) := by
   have hsum_pos : 0 < ∑ i ∈ s, w i * z i ^ r :=
@@ -233,27 +235,20 @@ theorem tendsto_powerMean_zero
     (hw' : ∑ i ∈ s, w i = 1)
     (hz : ∀ i ∈ s, 0 < z i) :
     Filter.Tendsto
-      (fun r => (∑ i ∈ s, w i * z i ^ r) ^ (1 / r))
+      (fun (r : ℝ) => (∑ i ∈ s, w i * z i ^ r) ^ (1 / r))
       (nhdsWithin 0 ({0}ᶜ))
       (nhds (∏ i ∈ s, z i ^ w i)) := by
-  -- Step 1: exp(f(r)/r) → exp(∑ wᵢ log zᵢ) by continuity of exp
+  -- Step 1: f(r)/r → ∑ wᵢ log zᵢ
   have hL := tendsto_log_sum_div_rpow s w z hz hw hw'
-  have hexp_lim : Filter.Tendsto
-      (fun (r : ℝ) => Real.exp (Real.log (∑ i ∈ s, w i * z i ^ r) / r))
-      (nhdsWithin 0 ({0}ᶜ))
-      (nhds (Real.exp (∑ i ∈ s, w i * Real.log (z i)))) :=
-    Real.continuous_exp.continuousAt.tendsto.comp hL
-  -- Step 2: Rewrite GM target to exp form so it matches hexp_lim
+  -- Step 2: Rewrite GM target to exp form
   rw [geomMean_eq_exp_sum_log s w z hz hw]
-  -- Step 3: Convert M_r to exp form on the filter (using r ≠ 0 and sum > 0)
-  apply hexp_lim.congr'
-  -- equality holds for all r: at r=0 both sides = 1 (since 1/0=0 in ℝ), at r≠0 by rpow_def
-  apply Filter.eventually_of_forall
-  intro r
-  -- (∑ wᵢ zᵢ^r)^(1/r) = exp(log(∑ wᵢ zᵢ^r) * (1/r)) = exp(log(∑ wᵢ zᵢ^r) / r)
-  have hsum_pos := sum_weighted_rpow_pos s w z hz hw hw' r
-  rw [Real.rpow_def_of_pos hsum_pos]
-  congr 1; ring
+  -- Step 3: Rewrite power mean to exp form under the binder
+  have h_eq : ∀ r : ℝ, (∑ i ∈ s, w i * z i ^ r) ^ (1 / r) =
+      Real.exp (Real.log (∑ i ∈ s, w i * z i ^ r) / r) := fun r => by
+    rw [Real.rpow_def_of_pos (sum_weighted_rpow_pos s w z hz hw hw' r)]
+    congr 1; ring
+  -- Step 4: Use tendsto_congr to switch from rpow to exp form
+  exact (Filter.tendsto_congr h_eq).mpr (continuous_exp.continuousAt.tendsto.comp hL)
 
 /-
 ## Part VIII: HM ≤ GM ≤ AM (Completing the Power Mean Chain)

--- a/research/problems/amgm-inequality-oq-03-oq-02/knowledge.md
+++ b/research/problems/amgm-inequality-oq-03-oq-02/knowledge.md
@@ -1,0 +1,46 @@
+# Power Mean Limit: lim_{r→0} M_r = GM
+
+**Problem ID**: amgm-inequality-oq-03-oq-02
+**Status**: COMPLETED
+**File**: `proofs/Proofs/PowerMeanLimitOQ.lean`
+
+## Summary
+
+Proved that the weighted power mean M_r(z,w) = (sum w_i z_i^r)^(1/r) converges
+to the weighted geometric mean GM(z,w) = prod z_i^{w_i} as r -> 0.
+
+10 theorems, 0 sorries, 0 axioms. Fully verified via Docker build (Lean 4.26.0).
+
+## Session 2026-03-05 (Session 1) - Mathlib Compatibility Fix
+
+**Mode**: FRESH
+**Outcome**: completed
+
+### What I Did
+- Fixed 4 Mathlib API compatibility issues in PowerMeanLimitOQ.lean for Lean 4.26.0
+- Fixed `slope`/`vsub` simplification: `vsub_zero` -> `vsub_eq_sub` + `ring`
+- Fixed `HasDerivAt.const_mul` argument order: now produces `w * z^r` directly (no rewrite needed)
+- Fixed `HasDerivAt.sum` form conversion: `Finset.sum_apply` converts sum-of-functions to function-of-sum
+- Fixed `Filter.Tendsto.congr`: use `(Filter.tendsto_congr h_eq).mpr` (iff form) with explicit `(r : ℝ)` annotation
+- Cleaned up all unused variable warnings with `_` prefix
+
+### Key Findings
+- `HasDerivAt.const_mul (w i)` in current Mathlib already produces `fun y => w * z^y` (correct order)
+- `HasDerivAt.sum` returns `HasDerivAt (sum i, f_i)` not `HasDerivAt (fun r => sum i, f_i r)` — use `Finset.sum_apply` to convert
+- `slope` now uses `vsub_eq_sub` instead of `vsub_zero` for subtraction
+- `Filter.tendsto_congr` (iff version) is more flexible than `Filter.Tendsto.congr` for rewriting
+
+### Files Modified
+- `proofs/Proofs/PowerMeanLimitOQ.lean`
+
+### Proof Architecture
+1. `sum_weighted_rpow_pos` — positivity of weighted sum
+2. `hasDerivAt_sum_weighted_rpow_zero` — derivative of sum at r=0
+3. `log_sum_weighted_rpow_zero` — f(0) = 0
+4. `hasDerivAt_log_sum_weighted_rpow` — chain rule for log(sum)
+5. `tendsto_log_sum_div_rpow` — f(r)/r -> f'(0) via derivative definition
+6. `geomMean_eq_exp_sum_log` — GM = exp(sum w_i log z_i)
+7. `powerMean_one_eq_arithMean` — M_1 = AM
+8. `powerMean_eq_exp_log` — M_r = exp(log(sum)/r)
+9. `tendsto_powerMean_zero` — MAIN: M_r -> GM
+10. `powerMean_neg1_le_geomMean_le_arithMean` — HM <= GM <= AM

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -1,41 +1,73 @@
 {
   "slug": "amgm-inequality-oq-03-oq-02",
   "title": "Power Mean Limit: lim_{r→0} M_r = GM (Geometric Mean as a Limit)",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "AVAILABLE.",
-    "whyMatters": []
+    "formal": "Filter.Tendsto (fun r => (∑ i ∈ s, w i * z i ^ r) ^ (1 / r)) (nhdsWithin 0 ({0}ᶜ)) (nhds (∏ i ∈ s, z i ^ w i))",
+    "plain": "The weighted power mean M_r(z,w) = (∑ wᵢ zᵢ^r)^(1/r) converges to the geometric mean GM(z,w) = ∏ zᵢ^wᵢ as r → 0.",
+    "whyMatters": [
+      "Completes the power mean chain HM ≤ GM ≤ AM by defining GM as M_0 = lim M_r",
+      "Fundamental result connecting the continuous family of power means"
+    ]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "tendsto_powerMean_zero: M_r → GM as r → 0",
+      "powerMean_neg1_le_geomMean_le_arithMean: HM ≤ GM ≤ AM",
+      "hasDerivAt_sum_weighted_rpow_zero: d/dr[∑ wᵢ zᵢ^r]|₀ = ∑ wᵢ log zᵢ",
+      "tendsto_log_sum_div_rpow: log(∑ wᵢ zᵢ^r)/r → ∑ wᵢ log zᵢ",
+      "geomMean_eq_exp_sum_log: GM = exp(∑ wᵢ log zᵢ)"
+    ],
     "open": [],
-    "goal": ""
+    "goal": "Prove lim_{r→0} M_r = GM — COMPLETED"
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-02-24T12:34:25.509Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "COMPLETE",
+    "since": "2026-03-05T00:00:00.000Z",
+    "iteration": 2,
+    "focus": "All theorems proved, 0 sorries, verified build.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None - problem fully solved.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: 10 theorems, 0 sorries, 0 axioms. Power mean limit and HM≤GM≤AM chain fully proved.",
+    "builtItems": [
+      "sum_weighted_rpow_pos in PowerMeanLimitOQ.lean:54",
+      "hasDerivAt_sum_weighted_rpow_zero in PowerMeanLimitOQ.lean:83",
+      "log_sum_weighted_rpow_zero in PowerMeanLimitOQ.lean:110",
+      "hasDerivAt_log_sum_weighted_rpow in PowerMeanLimitOQ.lean:125",
+      "tendsto_log_sum_div_rpow in PowerMeanLimitOQ.lean:155",
+      "geomMean_eq_exp_sum_log in PowerMeanLimitOQ.lean:183",
+      "powerMean_one_eq_arithMean in PowerMeanLimitOQ.lean:197",
+      "powerMean_eq_exp_log in PowerMeanLimitOQ.lean:209",
+      "tendsto_powerMean_zero in PowerMeanLimitOQ.lean:233",
+      "powerMean_neg1_le_geomMean_le_arithMean in PowerMeanLimitOQ.lean:262"
+    ],
+    "insights": [
+      "HasDerivAt.const_mul in Lean 4.26 produces correct multiplication order directly",
+      "HasDerivAt.sum returns sum-of-functions form; use Finset.sum_apply to convert to function-of-sum",
+      "Filter.tendsto_congr (iff) is more flexible than Filter.Tendsto.congr for rewriting under Tendsto",
+      "slope uses vsub_eq_sub for subtraction in current Mathlib (not vsub_zero)"
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },
-  "approaches": [],
+  "approaches": [
+    {
+      "name": "exp/log derivative approach",
+      "description": "Write M_r = exp(f(r)/r) where f(r) = log(∑ wᵢ zᵢ^r). Since f(0) = 0 and f'(0) = ∑ wᵢ log zᵢ, the ratio f(r)/r → f'(0) by definition of derivative. Then M_r → exp(f'(0)) = GM.",
+      "status": "succeeded",
+      "outcome": "All 10 theorems proved with 0 sorries"
+    }
+  ],
   "tags": [
     "analysis",
     "inequalities",
@@ -43,14 +75,25 @@
     "limits",
     "seeker-selected"
   ],
-  "relatedProofs": [],
+  "relatedProofs": [
+    "AmgmInequalityOQ02.lean",
+    "AmgmInequalityOQ03.lean"
+  ],
   "references": {
-    "papers": [],
+    "papers": [
+      "Hardy, Littlewood, Pólya - Inequalities (1934), §2.9"
+    ],
     "urls": [],
-    "mathlib": []
+    "mathlib": [
+      "Real.hasStrictDerivAt_const_rpow",
+      "Real.geom_mean_le_arith_mean_weighted",
+      "hasDerivAt_iff_tendsto_slope",
+      "HasDerivAt.sum",
+      "Finset.sum_apply"
+    ]
   },
   "started": "2026-02-25T19:36:59.224Z",
-  "lastUpdate": "2026-02-25T19:36:59.224Z",
+  "lastUpdate": "2026-03-05T00:00:00.000Z",
   "significance": 6,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Fix 4 Mathlib API compatibility issues in `PowerMeanLimitOQ.lean` for Lean 4.26.0
- `HasDerivAt.sum` form conversion via `Finset.sum_apply`
- `slope`/`vsub` simplification update (`vsub_eq_sub`)
- `Filter.Tendsto.congr` iff form with explicit type annotation
- Clean up unused variable warnings

## Results
- **10 theorems, 0 sorries, 0 axioms**
- Verified via Docker build (Lean 4.26.0)
- Main theorem: `tendsto_powerMean_zero` — lim_{r→0} M_r = GM
- Bonus: `powerMean_neg1_le_geomMean_le_arithMean` — HM ≤ GM ≤ AM

## Test plan
- [x] Docker build passes with zero errors and zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)