### PR TITLE
research: fix CantorDiagonalizationOQ02 build for Mathlib 4.26 (cantor-diagonalization-oq-02)

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ02.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ02.lean
@@ -190,7 +190,7 @@ theorem countable_sup_lt_omega1 (f : ℕ → Ordinal.{0})
   have hlt : #(ℕ) < omega1.cof := by
     rw [hcof, Cardinal.mk_nat]
     exact aleph0_lt_aleph1
-  exact Ordinal.iSup_lt_ord hf hlt
+  exact Ordinal.iSup_lt_ord hlt hf
 
 /-- **The Cantor Diagonal Argument for Countable Ordinals**:
 

--- a/src/data/research/problems/cantor-diagonalization-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02.json
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETE",
     "since": "2026-02-25T14:11:52.127Z",
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
@@ -29,9 +29,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: Fixed iSup_lt_ord argument order for Mathlib 4.26 compatibility. Proof fully compiles with 0 sorries.",
+    "builtItems": [
+      "Fixed CantorDiagonalizationOQ02.lean:193 - swapped iSup_lt_ord arguments"
+    ],
+    "insights": [
+      "Ordinal.iSup_lt_ord argument order changed in Mathlib 4.26: now takes cofinality bound first, then pointwise bound",
+      "Cardinal.isRegular_aleph_one.cof_eq gives omega1.cof = aleph 1",
+      "Proof uses regularity of aleph_one to show countable sups of countable ordinals remain countable"
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary
- Fix `Ordinal.iSup_lt_ord` argument order in `CantorDiagonalizationOQ02.lean:193` for Mathlib 4.26 compatibility
- Mathlib 4.26 changed argument order: cofinality bound first, then pointwise bound
- Proof now builds successfully with 0 sorries

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.CantorDiagonalizationOQ02`
- [x] No sorries or axioms in the file

🤖 Generated by researcher-1