### PR TITLE
research: prove Dirichlet integral & formalize Gauss-Bonnet (lebesgue-measure-oq-01, euler-polyhedral-formula-oq-02)

### DIFF
--- a/proofs/Proofs/LebesgueMeasure.lean
+++ b/proofs/Proofs/LebesgueMeasure.lean
@@ -152,9 +152,11 @@ noncomputable example (f : ℝ → ℝ) : ℝ := ∫ x, f x ∂volume
 /-- Integral of a constant function over a set. -/
 theorem integral_const_on_Icc (a b c : ℝ) (hab : a ≤ b) :
     ∫ x in Icc a b, c = c * (b - a) := by
-  rw [setIntegral_const, Real.volume_Icc]
-  rw [ENNReal.toReal_ofReal (sub_nonneg.mpr hab)]
-  rw [smul_eq_mul, mul_comm]
+  rw [integral_const]
+  have : (volume.restrict (Icc a b)).real univ = b - a := by
+    simp [Measure.real, Measure.restrict_apply_univ, Real.volume_Icc,
+        ENNReal.toReal_ofReal (sub_nonneg.mpr hab)]
+  rw [this, smul_eq_mul, mul_comm]
 
 /-- Linearity of integration: ∫(f + g) = ∫f + ∫g -/
 theorem integral_add_of_integrable {f g : ℝ → ℝ}
@@ -279,8 +281,9 @@ theorem fubini {f : ℝ × ℝ → ℝ}
   -- and the fact that swapping coordinates preserves integrability
   have h2 : ∫ y, ∫ x, f (x, y) ∂volume ∂volume = ∫ p, f p ∂(volume.prod volume) := by
     -- The swap of variables gives us the same product integral
-    have hf_swap : Integrable (f ∘ Prod.swap) (volume.prod volume) :=
-      hf.comp_measurable measurable_swap
+    have hf_swap : Integrable (f ∘ Prod.swap) (volume.prod volume) := by
+      apply Integrable.comp_measurable _ measurable_swap
+      rwa [Measure.prod_swap]
     rw [← integral_prod_swap f]
     exact (integral_prod _ hf_swap).symm
   rw [h1, h2]
@@ -321,6 +324,15 @@ theorem cantor_set_measure_zero :
   -- It's constructed by removing middle thirds, total length removed = 1
   trivial
 
+/-- The integral of the indicator function of a null set is zero.
+    This generalizes the Dirichlet function result to any measure-zero set. -/
+theorem integral_indicator_null_set {s : Set ℝ} (hs : volume s = 0) (f : ℝ → ℝ) :
+    ∫ x, Set.indicator s f x ∂volume = 0 := by
+  apply integral_eq_zero_of_ae
+  have h_ae : ∀ᵐ x ∂volume, x ∉ s := by
+    rw [ae_iff]; simpa using hs
+  exact h_ae.mono fun x hx => Set.indicator_of_notMem hx _
+
 end Completeness
 
 /-!
@@ -351,21 +363,22 @@ theorem bounded_measurable_integrable_on_Icc {f : ℝ → ℝ} {a b : ℝ}
     integrals when they are supported on null sets.
 
     The key insight is that ℚ has measure zero in ℝ, so the indicator
-    function of ℚ is zero almost everywhere, hence its integral is zero. -/
-/-- **Axiom:** The Dirichlet function integral over [0,1] is zero.
+    function of ℚ is zero almost everywhere, hence its integral is zero.
 
-    This follows from:
-    1. ℚ is countable, hence has Lebesgue measure zero in ℝ
-    2. The indicator of ℚ is zero almost everywhere (on the irrationals)
-    3. The integral of an a.e. zero function is zero
-
-    Full verification requires the Mathlib API for `integral_eq_zero_of_ae`. -/
-axiom dirichlet_integral_zero :
-    ∫ x in Icc (0:ℝ) 1, Set.indicator (Set.range (Rat.cast : ℚ → ℝ)) (fun _ => (1:ℝ)) x ∂volume = 0
-
+    **Proof strategy:**
+    1. ℚ is countable → `range Rat.cast` has Lebesgue measure zero (`rationals_measure_zero`)
+    2. Almost every real is irrational → the indicator of ℚ is a.e. zero
+    3. `integral_eq_zero_of_ae` concludes the integral is zero -/
 theorem dirichlet_function_integral :
-    ∫ x in Icc (0:ℝ) 1, Set.indicator (Set.range (Rat.cast : ℚ → ℝ)) (fun _ => (1:ℝ)) x ∂volume = 0 :=
-  dirichlet_integral_zero
+    ∫ x in Icc (0:ℝ) 1, Set.indicator (Set.range (Rat.cast : ℚ → ℝ))
+      (fun _ => (1:ℝ)) x ∂volume = 0 := by
+  apply integral_eq_zero_of_ae
+  -- Almost every real is irrational (ℚ has measure zero)
+  have h_ae : ∀ᵐ x ∂volume, x ∉ Set.range (Rat.cast : ℚ → ℝ) := by
+    rw [ae_iff]
+    simpa using rationals_measure_zero
+  -- Restrict to [0,1] and conclude: indicator of ℚ is zero at irrational points
+  exact (ae_restrict_of_ae h_ae).mono fun x hx => Set.indicator_of_notMem hx _
 
 end RiemannComparison
 

--- a/src/data/proofs/lebesgue-measure/meta.json
+++ b/src/data/proofs/lebesgue-measure/meta.json
@@ -18,7 +18,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -121,14 +121,14 @@
       "title": "Completeness and Null Sets",
       "startLine": 296,
       "endLine": 324,
-      "summary": "Shows that countable sets have measure zero and applies this to prove $\\mu(\\mathbb{Q}) = 0$. Notes the Cantor set as a famous example of an uncountable null set."
+      "summary": "Shows that countable sets have measure zero and applies this to prove $\\mu(\\mathbb{Q}) = 0$. Proves that the integral of the indicator function of any null set is zero (`integral_indicator_null_set`). Notes the Cantor set as a famous example of an uncountable null set."
     },
     {
       "id": "riemann-comparison",
       "title": "Comparison with Riemann Integration",
       "startLine": 326,
       "endLine": 370,
-      "summary": "Proves that bounded measurable functions on $[a,b]$ are Lebesgue integrable. Axiomatizes the Dirichlet function integral $\\int_{[0,1]} \\mathbf{1}_{\\mathbb{Q}} = 0$ as a demonstration that Lebesgue integration handles functions that are not Riemann integrable."
+      "summary": "Proves that bounded measurable functions on $[a,b]$ are Lebesgue integrable. Proves that the Dirichlet function integral $\\int_{[0,1]} \\mathbf{1}_{\\mathbb{Q}} = 0$ using the fact that $\\mathbb{Q}$ has measure zero and `integral_eq_zero_of_ae`, demonstrating that Lebesgue integration handles functions that are not Riemann integrable."
     },
     {
       "id": "applications",
@@ -142,7 +142,7 @@
     "summary": "This formalization demonstrates the core infrastructure of Lebesgue measure theory as built in Mathlib: the measure itself (via Haar measure on $\\mathbb{R}$), its key properties (translation invariance, interval measure, null sets), and the three great convergence theorems (monotone, dominated, Fubini). The proofs leverage Mathlib's deep measure theory library, showing how formal mathematics can present these foundational results with full rigor.",
     "implications": "Lebesgue measure and integration underpin virtually all of modern analysis: probability theory rests on measure spaces (Kolmogorov's axioms), functional analysis uses $L^p$ spaces built from the Lebesgue integral, Fourier analysis requires $L^2$ completeness, and PDE theory relies on Sobolev spaces defined via weak derivatives and Lebesgue integrability. The dominated convergence theorem alone is invoked thousands of times across mathematical research, making it arguably the single most useful theorem in analysis.",
     "openQuestions": [
-      "Can the Dirichlet function integral axiom be replaced by a full proof using Mathlib's `integral_eq_zero_of_ae` and the countability of $\\mathbb{Q}$?",
+      "RESOLVED: The Dirichlet function integral axiom has been replaced by a full proof using Mathlib's `integral_eq_zero_of_ae`, `ae_restrict_of_ae`, and the countability of $\\mathbb{Q}$.",
       "Can Holder's inequality be formally stated and proved rather than axiomatized as `True`?",
       "How does Lebesgue measure generalize to infinite-dimensional spaces, where no translation-invariant $\\sigma$-finite measure exists (a result relevant to path integrals in quantum mechanics)?",
       "What is the measure-theoretic relationship between the Cantor set (uncountable, measure zero) and sets of positive measure but empty interior?"


### PR DESCRIPTION
## Summary
Two research problems completed in this session:

### 1. Dirichlet Function Integral (lebesgue-measure-oq-01) - COMPLETED
- Replaced `axiom dirichlet_integral_zero` with constructive proof using `integral_eq_zero_of_ae` + `ae_restrict_of_ae` + `rationals_measure_zero`
- Added general lemma `integral_indicator_null_set`
- Fixed 3 pre-existing Mathlib 4.26 compat issues
- Gallery badge upgraded "axiom" → "verified"

### 2. Gauss-Bonnet Theorem (euler-polyhedral-formula-oq-02) - COMPLETED
- Axiomatized Riemannian surfaces and Gaussian curvature
- Stated smooth Gauss-Bonnet: ∫K dA = 2πχ
- Proved discrete Gauss-Bonnet constructively from triangle angle sums
- Derived curvature-topology classification (curvature sign → genus constraints)
- Proved sphere total curvature = 4π, torus = 0
- Formalized Chern-Gauss-Bonnet generalization
- Built smooth-discrete consistency bridge

## Files Modified
- `proofs/Proofs/LebesgueMeasure.lean` — axiom → proof, Mathlib compat fixes
- `proofs/Proofs/EulerPolyhedralOQ02.lean` — new file, Gauss-Bonnet formalization
- `src/data/proofs/lebesgue-measure/meta.json` — badge update
- `src/data/proofs/euler-polyhedral-formula-oq-02/` — new gallery entry
- `src/data/research/problems/` — two completed problem entries

## Build Status
Both proofs verified via Docker build (memory-safe, 32GB limit).

🤖 Generated by researcher-4