### PR TITLE
fix: enricher annotation type safety (euler-polyhedral-formula-oq-02)

### DIFF
--- a/src/data/proofs/euler-polyhedral-formula-oq-02/index.ts
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02/index.ts
@@ -26,7 +26,7 @@ export const eulerPolyhedralFormulaOq02Proof: Proof = {
   conclusion: meta.conclusion,
 }
 
-export const eulerPolyhedralFormulaOq02Annotations: Annotation[] = annotationsJson as Annotation[]
+export const eulerPolyhedralFormulaOq02Annotations: Annotation[] = (annotationsJson as unknown as { annotations: Annotation[] }).annotations
 
 export const eulerPolyhedralFormulaOq02Data: ProofData = {
   proof: eulerPolyhedralFormulaOq02Proof,


### PR DESCRIPTION
## Summary
- Fix TS2352 error in euler-polyhedral-formula-oq-02 index.ts
- annotations.json wraps annotations in `{ annotations: [...] }` but code cast directly to `Annotation[]`
- Extract `.annotations` field with proper `as unknown as` cast

## Test plan
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)