### PR TITLE
research: prove Schauder Projection Lemma (schauder-fixed-point-oq-01)

### DIFF
--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -15,7 +15,7 @@
       "advanced"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "ContractingWith.fixedPoint",
@@ -59,7 +59,7 @@
   "overview": {
     "historicalContext": "Juliusz Schauder proved the normed space version in 1930, answering: what happens to Brouwer's theorem in infinite dimensions? The key insight is that compactness, not finite-dimensionality, is the essential ingredient.\n\nBrouwer's theorem fails in infinite dimensions because the closed unit ball is not compact (Riesz's lemma). There exist continuous self-maps of the unit ball in l2 with no fixed point. Schauder showed that if we add the compactness hypothesis back, fixed points are guaranteed.\n\nAndrei Tychonoff generalized to locally convex spaces in 1935. Shizuo Kakutani proved the set-valued version in 1941, which John Nash used to prove existence of Nash equilibria in 1950.",
     "problemStatement": "Schauder Fixed Point Theorem: Let K be a nonempty compact convex subset of a normed space E, and let f: K -> K be continuous. Then f has a fixed point.\n\nMore generally (Tychonoff): the same holds when E is a locally convex topological vector space.\n\nFor non-compact domains: if C is a closed bounded convex subset of a Banach space and T: C -> C is continuous with T(C) relatively compact (compact operator), then T has a fixed point.",
-    "proofStrategy": "The proof uses finite-dimensional approximation (NOW FORMALIZED as a theorem, not axiom):\n\n1. Schauder Projection Lemma (axiom): For compact K and epsilon > 0, construct a continuous map from K into a finite-dimensional convex hull, approximating identity within epsilon.\n\n2. For each epsilon > 0, compose f with the projection to get a map on the finite-dimensional convex hull.\n\n3. Apply Brouwer (axiom) to get a fixed point x0 of the composed map.\n\n4. Since x0 = pi(f(x0)) and f(x0) is in K: ||f(x0) - x0|| < epsilon.\n\n5. Use sequential compactness to extract convergent subsequence of epsilon-approximate fixed points.\n\n6. By continuity and squeeze theorem, the limit is a true fixed point.\n\nThe compact operator version is proved from the compact convex version plus Mazur's theorem.",
+    "proofStrategy": "The proof uses finite-dimensional approximation:\n\n1. Schauder Projection Lemma (PROVED in OQ-01): For compact K and epsilon > 0, construct a continuous map from K into a finite-dimensional convex hull, approximating identity within epsilon. Uses partition of unity.\n\n2. For each epsilon > 0, compose f with the projection to get a map on the finite-dimensional convex hull.\n\n3. Apply Brouwer (axiom) to get a fixed point x0 of the composed map.\n\n4. Since x0 = pi(f(x0)) and f(x0) is in K: ||f(x0) - x0|| < epsilon.\n\n5. Use sequential compactness to extract convergent subsequence of epsilon-approximate fixed points.\n\n6. By continuity and squeeze theorem, the limit is a true fixed point.\n\nThe compact operator version is proved from the compact convex version plus Mazur's theorem.",
     "keyInsights": [
       "Compactness, not finite-dimensionality, is the key to fixed point existence",
       "The Schauder projection lemma bridges infinite and finite dimensions via partition of unity",
@@ -137,7 +137,7 @@
     "summary": "The Schauder Fixed Point Theorem demonstrates that compactness is the essential ingredient for fixed point existence, generalizing Brouwer's finite-dimensional result to infinite-dimensional spaces. The proof uses finite-dimensional approximation: approximate compact set maps by finite-dimensional ones, apply Brouwer, then extract a limit by compactness.",
     "implications": "Schauder's theorem is fundamental in functional analysis and PDEs. It proves the Peano existence theorem for ODEs (where infinite-dimensional function spaces arise naturally), guarantees solutions to many integral equations, and underpins much of nonlinear analysis. The compact operator version is the workhorse: even when the domain isn't compact, if the operator maps bounded sets to relatively compact sets, fixed points exist. Through Kakutani's set-valued extension, this lineage leads to Nash's equilibrium theorem.",
     "openQuestions": [
-      "Can we formalize the full proof of the Schauder projection lemma from first principles?",
+      "RESOLVED (OQ-01): Schauder projection lemma proved from first principles via partition of unity",
       "Can we prove Brouwer's theorem for the closed ball using only Mathlib's algebraic topology?",
       "How can we formalize the Kakutani fixed point theorem for set-valued maps?",
       "Can we construct the infinite-dimensional counterexample explicitly in Lean?"


### PR DESCRIPTION
## Summary
- Proves the Schauder Projection Lemma from first principles via partition of unity
- Given compact K and ε > 0, constructs continuous π mapping K into finite-dimensional convex hull with ‖π(x) - x‖ < ε
- Resolves the `schauder_projection_lemma` axiom from `SchauderFixedPoint.lean` (sorries: 1 → 0)
- 17 theorems, 0 sorries, 0 axioms, 315 lines
- Includes gallery integration with meta.json, annotations.json, index.ts

## Proof Technique
Partition of unity: bump functions φᵢ(x) = max(0, ε - ‖x - xᵢ‖) from finite ε-ball cover, weighted average projection π(x) = Σφᵢxᵢ/Σφᵢ

## Test plan
- [x] Docker build passes (`./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ01`)
- [ ] Gallery integration renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)