### PR TITLE
fix: remove empty problem JSON and harden sync

### DIFF
--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -381,8 +381,12 @@ updated = 0
 for problem_file in problems_dir.glob("*.json"):
     slug = problem_file.stem
 
-    with open(problem_file) as f:
-        problem = json.load(f)
+    try:
+        with open(problem_file) as f:
+            problem = json.load(f)
+    except (json.JSONDecodeError, ValueError):
+        print(f"  WARN: skipping invalid JSON: {problem_file.name}")
+        continue
 
     knowledge = problem.get("knowledge", {})
     insights = len(knowledge.get("insights", []))


### PR DESCRIPTION
## Summary
- Remove `erdos-1138-oq-03.json` (0 bytes, committed empty in PR #3380), which breaks the deploy pipeline sync step
- Add try/except to skip invalid JSON problem files in `sync-and-deploy.sh` to prevent future breakage

## Test plan
- [ ] Deploy pipeline sync step completes without JSON decode error
- [ ] Build and deploy succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)