### PR TITLE
research: prove directed Euler theorem sorries (konigsberg-oq-02)

### DIFF
--- a/proofs/Proofs/KonigsbergOQ02.lean
+++ b/proofs/Proofs/KonigsbergOQ02.lean
@@ -36,7 +36,7 @@ indeg(v) = outdeg(v) + 1, and all other vertices have indeg = outdeg.
 - [x] Non-existence proof for unbalanced digraphs
 - [x] Symmetric digraph balanced (proved via adjacency symmetry)
 - [x] De Bruijn arc count formula
-- [ ] 2 routine sorries: eulerian_source/target_count (list/finset counting)
+- [x] eulerian_source/target_count proved (list/finset bijection)
 
 ## References
 - Euler, L. (1736). Solutio problematis ad geometriam situs pertinentis.
@@ -123,27 +123,22 @@ theorem Digraph.sum_outDegree_eq_arcCount {V : Type*} [Fintype V] [DecidableEq V
     (D : Digraph V) [DecidableRel D.adj] :
     ∑ v : V, D.outDegree v = D.arcCount := by
   unfold outDegree outNeighbors arcCount
-  -- Each side counts |{(u,v) | D.adj u v}| via different decompositions
-  -- Use Fintype.sum_card_filter_eq_card_sigma to relate them
-  rw [show (Finset.univ.filter (fun p : V × V => D.adj p.1 p.2)).card =
-    ∑ u : V, (Finset.univ.filter (D.adj u)).card from ?_]
-  · rfl
-  · -- Partition arcs by source vertex
-    rw [← Finset.card_sigma]
-    apply Finset.card_nbij (fun ⟨u, v⟩ => (u, v.1)) ?_ ?_ ?_
-    · intro ⟨u, v⟩
-      simp [Finset.mem_filter, Finset.mem_sigma]
-      exact (Finset.mem_filter.mp v.2).2
-    · intro ⟨u₁, v₁⟩ ⟨u₂, v₂⟩ _ _ h
-      simp at h
-      ext1
-      · exact h.1
-      · exact Subtype.ext (by simp_all [h.1, h.2])
-    · intro ⟨u, v⟩ hpair
-      simp [Finset.mem_filter] at hpair
-      exact ⟨⟨u, ⟨v, Finset.mem_filter.mpr ⟨Finset.mem_univ v, hpair⟩⟩⟩,
-        Finset.mem_sigma.mpr ⟨Finset.mem_univ u, (Finset.mem_filter.mpr ⟨Finset.mem_univ v, hpair⟩)⟩,
-        rfl⟩
+  -- Partition arcs by source vertex via fiberwise decomposition
+  rw [Finset.card_eq_sum_card_fiberwise (f := fun p : V × V => p.1)
+    (fun _ _ => Finset.mem_univ _)]
+  apply Finset.sum_congr rfl; intro u _
+  -- Show: (univ.filter (D.adj u)).card = (arcs.filter (fst = u)).card
+  apply Finset.card_nbij (fun (b : V) => ((u, b) : V × V)) ?_ ?_ ?_
+  · intro b hb
+    have hadj := (Finset.mem_filter.mp hb).2
+    exact Finset.mem_filter.mpr ⟨Finset.mem_filter.mpr ⟨Finset.mem_univ _, hadj⟩, rfl⟩
+  · intro b₁ b₂ _ _ h
+    exact (Prod.mk.inj h).2
+  · intro ⟨a, b⟩ h
+    have hm := Finset.mem_filter.mp h
+    have hadj := (Finset.mem_filter.mp hm.1).2
+    exact ⟨b, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hm.2 ▸ hadj⟩,
+      Prod.ext hm.2.symm rfl⟩
 
 /-- **Degree Sum Lemma (In-degree)**: Σ indeg(v) = |E|
 
@@ -156,25 +151,22 @@ theorem Digraph.sum_inDegree_eq_arcCount {V : Type*} [Fintype V] [DecidableEq V]
     (D : Digraph V) [DecidableRel D.adj] :
     ∑ v : V, D.inDegree v = D.arcCount := by
   unfold inDegree inNeighbors arcCount
-  rw [show (Finset.univ.filter (fun p : V × V => D.adj p.1 p.2)).card =
-    ∑ v : V, (Finset.univ.filter (fun u => D.adj u v)).card from ?_]
-  · rfl
-  · -- Partition arcs by target vertex
-    rw [← Finset.card_sigma]
-    apply Finset.card_nbij (fun ⟨v, u⟩ => (u.1, v)) ?_ ?_ ?_
-    · intro ⟨v, u⟩
-      simp [Finset.mem_filter, Finset.mem_sigma]
-      exact (Finset.mem_filter.mp u.2).2
-    · intro ⟨v₁, u₁⟩ ⟨v₂, u₂⟩ _ _ h
-      simp at h
-      ext1
-      · exact h.2
-      · exact Subtype.ext (by simp_all [h.1, h.2])
-    · intro ⟨u, v⟩ hpair
-      simp [Finset.mem_filter] at hpair
-      exact ⟨⟨v, ⟨u, Finset.mem_filter.mpr ⟨Finset.mem_univ u, hpair⟩⟩⟩,
-        Finset.mem_sigma.mpr ⟨Finset.mem_univ v, (Finset.mem_filter.mpr ⟨Finset.mem_univ u, hpair⟩)⟩,
-        rfl⟩
+  -- Partition arcs by target vertex via fiberwise decomposition
+  rw [Finset.card_eq_sum_card_fiberwise (f := fun p : V × V => p.2)
+    (fun _ _ => Finset.mem_univ _)]
+  apply Finset.sum_congr rfl; intro v _
+  -- Show: (univ.filter (fun u => D.adj u v)).card = (arcs.filter (snd = v)).card
+  apply Finset.card_nbij (fun (a : V) => ((a, v) : V × V)) ?_ ?_ ?_
+  · intro a ha
+    have hadj := (Finset.mem_filter.mp ha).2
+    exact Finset.mem_filter.mpr ⟨Finset.mem_filter.mpr ⟨Finset.mem_univ _, hadj⟩, rfl⟩
+  · intro a₁ a₂ _ _ h
+    exact (Prod.mk.inj h).1
+  · intro ⟨a, b⟩ h
+    have hm := Finset.mem_filter.mp h
+    have hadj := (Finset.mem_filter.mp hm.1).2
+    exact ⟨a, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hm.2 ▸ hadj⟩,
+      Prod.ext rfl hm.2.symm⟩
 
 /-- **Corollary**: Total in-degree equals total out-degree -/
 theorem Digraph.sum_inDegree_eq_sum_outDegree {V : Type*} [Fintype V] [DecidableEq V]
@@ -205,11 +197,13 @@ structure Digraph.Walk {V : Type*} (D : Digraph V) (u v : V) where
   /-- Each arc is valid in the digraph -/
   arcs_valid : ∀ a ∈ arcs, D.adj a.1 a.2
   /-- Walk starts at u -/
-  starts_at : arcs ≠ [] → (arcs.head (by assumption)).1 = u
+  starts_at : ∀ (h : arcs ≠ []), (arcs.head h).1 = u
   /-- Walk ends at v -/
-  ends_at : arcs ≠ [] → (arcs.getLast (by assumption)).2 = v
+  ends_at : ∀ (h : arcs ≠ []), (arcs.getLast h).2 = v
   /-- Consecutive arcs share endpoints -/
   consecutive : arcs.Chain' (fun a b => a.2 = b.1)
+  /-- Empty walk must be between the same vertex -/
+  empty_at : arcs = [] → u = v
 
 /-- A directed walk is Eulerian if it traverses every arc exactly once -/
 def Digraph.Walk.isEulerian {V : Type*} [Fintype V] [DecidableEq V]
@@ -227,19 +221,12 @@ private theorem chain_tail_fst_eq_dropLast_snd {α : Type*} :
   | [], _ => by simp
   | [_], _ => by simp
   | a :: b :: rest, hchain => by
-    have hab : a.2 = b.1 := by
-      rw [List.chain'_cons] at hchain; exact hchain.1
-    have hrest : (b :: rest).Chain' (fun x y => x.2 = y.1) := by
-      rw [List.chain'_cons] at hchain; exact hchain.2
-    simp only [List.tail_cons, List.map_cons]
-    constructor
-    · exact hab.symm
-    · have ih := chain_tail_fst_eq_dropLast_snd (b :: rest) hrest
-      simp only [List.tail_cons] at ih
-      rw [show (a :: b :: rest).dropLast = a :: (b :: rest).dropLast from by
-        simp [List.dropLast_cons]]
-      simp only [List.map_cons]
-      exact ⟨rfl, ih⟩
+    have hab := List.Chain'.rel_head hchain
+    have ih := chain_tail_fst_eq_dropLast_snd (b :: rest) (List.Chain'.tail hchain)
+    simp only [List.tail_cons] at ih
+    -- (a :: b :: rest).dropLast = a :: (b :: rest).dropLast definitionally
+    show (b :: rest).map Prod.fst = (a :: (b :: rest).dropLast).map Prod.snd
+    rw [List.map_cons, List.map_cons, ← hab, ← ih]
 
 /-- For a circuit walk (chain + starts at u, ends at u), the multiset of
     arc sources is a permutation of the multiset of arc targets.
@@ -250,7 +237,7 @@ private theorem circuit_fst_perm_snd {α : Type*} [DecidableEq α]
     (L : List (α × α)) (hchain : L.Chain' (fun a b => a.2 = b.1))
     (hne : L ≠ [])
     (hcirc : (L.head hne).1 = (L.getLast hne).2) :
-    L.map Prod.fst ~ L.map Prod.snd := by
+    List.Perm (L.map Prod.fst) (L.map Prod.snd) := by
   have htail := chain_tail_fst_eq_dropLast_snd L hchain
   -- Rewrite fst_list as head.1 :: tail.map fst
   have hfst : L.map Prod.fst = (L.head hne).1 :: L.tail.map Prod.fst := by
@@ -267,8 +254,28 @@ private theorem circuit_fst_perm_snd {α : Type*} [DecidableEq α]
   rw [hfst, htail, hsnd, hcirc]
   -- Goal: v₀ :: M ~ M ++ [v₀], which is [v₀] ++ M ~ M ++ [v₀]
   rw [List.perm_iff_count]; intro x
-  simp [List.count_cons, List.count_append]
-  omega
+  simp [List.count_cons, List.count_append, Nat.add_comm]
+
+/-- For a chain walk, [start] ++ map snd = map fst ++ [end].
+    This is the path analogue of circuit_fst_perm_snd: instead of the
+    source/target lists being permutations (circuit case), they differ
+    by exactly the start and end vertices. -/
+private theorem path_fst_snd_eq {α : Type*} [DecidableEq α]
+    (L : List (α × α)) (hchain : L.Chain' (fun a b => a.2 = b.1))
+    (hne : L ≠ []) :
+    [(L.head hne).1] ++ L.map Prod.snd = L.map Prod.fst ++ [(L.getLast hne).2] := by
+  have htail := chain_tail_fst_eq_dropLast_snd L hchain
+  have hfst : L.map Prod.fst = (L.head hne).1 :: L.tail.map Prod.fst := by
+    cases L with | nil => exact absurd rfl hne | cons h t => simp
+  have hsnd : L.map Prod.snd = L.dropLast.map Prod.snd ++ [(L.getLast hne).2] := by
+    cases L with
+    | nil => exact absurd rfl hne
+    | cons h t =>
+      conv_lhs => rw [show h :: t = (h :: t).dropLast ++ [(h :: t).getLast (by simp)] from
+        ((h :: t).dropLast_append_getLast (by simp)).symm]
+      simp [List.map_append]
+  rw [hfst, htail, hsnd]
+  simp [List.singleton_append, List.cons_append, List.append_assoc]
 
 /-- For an Eulerian walk, counting arcs with source v in the arc list
     gives outDegree v. The arc list is a Nodup enumeration of all edges,
@@ -277,13 +284,38 @@ private theorem circuit_fst_perm_snd {α : Type*} [DecidableEq α]
 
     Proof sketch: arcs.toFinset = edgeFinset (by Nodup + coverage), then
     filter and count via Finset.card_image_of_injective. -/
+
 private theorem eulerian_source_count {V : Type*} [Fintype V] [DecidableEq V]
     {D : Digraph V} [DecidableRel D.adj] {u v₀ : V}
     (w : D.Walk u v₀) (hw : w.isEulerian) (v : V) :
     (w.arcs.filter (fun a => decide (a.1 = v))).length = D.outDegree v := by
-  -- arcs.toFinset = edgeFinset (Nodup + coverage), filter by source,
-  -- Finset.card_image_of_injective gives the bijection with outNeighbors
-  sorry
+  unfold Digraph.outDegree Digraph.outNeighbors
+  -- Step 1: Convert filtered list length to filtered finset card (Nodup)
+  rw [show (w.arcs.filter (fun a => decide (a.1 = v))).length =
+      (w.arcs.toFinset.filter (fun a : V × V => a.1 = v)).card from by
+    rw [← List.toFinset_card_of_nodup (hw.1.filter _)]
+    congr 1; ext ⟨a, b⟩
+    simp [List.mem_toFinset, Finset.mem_filter, decide_eq_true_eq]]
+  -- Step 2: arcs.toFinset = all arcs finset (Nodup + coverage)
+  have h_arcs : w.arcs.toFinset =
+      Finset.univ.filter (fun p : V × V => D.adj p.1 p.2) := by
+    ext ⟨a, b⟩
+    simp only [List.mem_toFinset, Finset.mem_filter, Finset.mem_univ, true_and]
+    exact ⟨w.arcs_valid _, hw.2 a b⟩
+  rw [h_arcs]
+  -- Step 3: filter of filter = map of target, then card_map
+  have heq : (Finset.univ.filter (fun p : V × V => D.adj p.1 p.2)).filter
+        (fun a : V × V => a.1 = v) =
+      (Finset.univ.filter (D.adj v)).map
+        ⟨fun b => (v, b), fun _ _ h => (Prod.mk.inj h).2⟩ := by
+    ext ⟨a, b⟩
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_map,
+      Function.Embedding.coeFn_mk]
+    constructor
+    · rintro ⟨hadj, rfl⟩; exact ⟨b, hadj, rfl⟩
+    · rintro ⟨b', hadj, h⟩
+      obtain ⟨rfl, rfl⟩ := Prod.mk.inj h; exact ⟨hadj, rfl⟩
+  rw [heq, Finset.card_map]
 
 /-- Symmetric to eulerian_source_count: counting arcs with target v
     gives inDegree v. -/
@@ -291,7 +323,33 @@ private theorem eulerian_target_count {V : Type*} [Fintype V] [DecidableEq V]
     {D : Digraph V} [DecidableRel D.adj] {u v₀ : V}
     (w : D.Walk u v₀) (hw : w.isEulerian) (v : V) :
     (w.arcs.filter (fun a => decide (a.2 = v))).length = D.inDegree v := by
-  sorry
+  unfold Digraph.inDegree Digraph.inNeighbors
+  -- Step 1: Convert filtered list length to filtered finset card (Nodup)
+  rw [show (w.arcs.filter (fun a => decide (a.2 = v))).length =
+      (w.arcs.toFinset.filter (fun a : V × V => a.2 = v)).card from by
+    rw [← List.toFinset_card_of_nodup (hw.1.filter _)]
+    congr 1; ext ⟨a, b⟩
+    simp [List.mem_toFinset, Finset.mem_filter, decide_eq_true_eq]]
+  -- Step 2: arcs.toFinset = all arcs finset (Nodup + coverage)
+  have h_arcs : w.arcs.toFinset =
+      Finset.univ.filter (fun p : V × V => D.adj p.1 p.2) := by
+    ext ⟨a, b⟩
+    simp only [List.mem_toFinset, Finset.mem_filter, Finset.mem_univ, true_and]
+    exact ⟨w.arcs_valid _, hw.2 a b⟩
+  rw [h_arcs]
+  -- Step 3: filter of filter = map of target, then card_map
+  have heq : (Finset.univ.filter (fun p : V × V => D.adj p.1 p.2)).filter
+        (fun a : V × V => a.2 = v) =
+      (Finset.univ.filter (fun u => D.adj u v)).map
+        ⟨fun a => (a, v), fun _ _ h => (Prod.mk.inj h).1⟩ := by
+    ext ⟨a, b⟩
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_map,
+      Function.Embedding.coeFn_mk]
+    constructor
+    · rintro ⟨hadj, rfl⟩; exact ⟨a, hadj, rfl⟩
+    · rintro ⟨a', hadj, h⟩
+      obtain ⟨rfl, rfl⟩ := Prod.mk.inj h; exact ⟨hadj, rfl⟩
+  rw [heq, Finset.card_map]
 
 /-- **Directed Eulerian Circuit Criterion (Necessity)** (PROVED):
     If a directed graph has an Eulerian circuit, then every vertex
@@ -314,38 +372,35 @@ theorem directed_euler_circuit_necessary {V : Type*} [Fintype V] [DecidableEq V]
       unfold Digraph.outDegree Digraph.outNeighbors
       rw [Finset.card_eq_zero]
       ext w
-      simp only [Finset.not_mem_empty, Finset.mem_filter, Finset.mem_univ, true_and, iff_false]
+      simp only [Finset.notMem_empty, Finset.mem_filter, Finset.mem_univ, true_and, iff_false]
       intro hadj
       have := hw.2 v w hadj
-      rw [hempty] at this; exact List.not_mem_nil _ this
+      simp [hempty] at this
     have : D.inDegree v = 0 := by
       unfold Digraph.inDegree Digraph.inNeighbors
       rw [Finset.card_eq_zero]
       ext u
-      simp only [Finset.not_mem_empty, Finset.mem_filter, Finset.mem_univ, true_and, iff_false]
+      simp only [Finset.notMem_empty, Finset.mem_filter, Finset.mem_univ, true_and, iff_false]
       intro hadj
       have := hw.2 u v hadj
-      rw [hempty] at this; exact List.not_mem_nil _ this
+      simp [hempty] at this
     omega
   · -- Non-empty walk: use permutation argument
     have hperm := circuit_fst_perm_snd w.arcs w.consecutive
       (hempty) (by rw [w.starts_at hempty, w.ends_at hempty])
     -- From permutation: count of v in sources = count of v in targets
     have hcount := hperm.count_eq v
-    -- Relate counts to filter lengths
-    rw [List.count_map_eq_length_filter, List.count_map_eq_length_filter] at hcount
-    -- Now relate filter lengths to degrees
-    rw [← eulerian_source_count w hw v, ← eulerian_target_count w hw v]
-    -- The filter predicates may differ in form but are equivalent
-    convert hcount using 2 <;> {ext a; simp [Prod.fst, Prod.snd, BEq.beq, decide_eq_true_eq]}
-  where
-    List.count_map_eq_length_filter {α β : Type*} [DecidableEq β] {f : α → β} {l : List α} {b : β} :
+    -- Bridge: (map f l).count b = (filter (f·=b) l).length
+    have cmf : ∀ (f : (V × V) → V) (l : List (V × V)) (b : V),
         (l.map f).count b = (l.filter (fun a => decide (f a = b))).length := by
-      induction l with
+      intro f l b; induction l with
       | nil => simp
       | cons h t ih =>
         simp only [List.map_cons, List.count_cons, List.filter_cons]
-        split <;> simp_all [List.count, List.length]
+        split <;> simp_all [List.count]
+    rw [cmf, cmf] at hcount
+    rw [← eulerian_source_count w hw v, ← eulerian_target_count w hw v]
+    exact hcount.symm
 
 /-- **Directed Eulerian Circuit Criterion (Sufficiency)**:
     If a connected directed graph has in-degree = out-degree at every
@@ -372,17 +427,65 @@ A directed Eulerian path from u to v traverses every arc exactly once.
 - For all other w: indeg(w) = outdeg(w)
 -/
 
-/-- **Directed Eulerian Path Criterion (Necessity)**:
+/-- **Directed Eulerian Path Criterion (Necessity)** (PROVED):
     If a directed Eulerian path exists from u to v, then:
     - u has one more outgoing arc than incoming
     - v has one more incoming arc than outgoing
-    - All other vertices are balanced -/
-axiom directed_euler_path_necessary {V : Type*} [Fintype V] [DecidableEq V]
+    - All other vertices are balanced
+
+    Proof: The path_fst_snd_eq lemma gives [u] ++ map snd = map fst ++ [v].
+    Taking counts: δ(x=u) + inDeg(x) = outDeg(x) + δ(x=v) for each vertex x.
+    This yields the three degree conditions. -/
+theorem directed_euler_path_necessary {V : Type*} [Fintype V] [DecidableEq V]
     (D : Digraph V) [DecidableRel D.adj] {u v : V} (huv : u ≠ v)
     (w : D.Walk u v) (hw : w.isEulerian) :
     D.outDegree u = D.inDegree u + 1 ∧
     D.inDegree v = D.outDegree v + 1 ∧
-    ∀ x : V, x ≠ u → x ≠ v → D.isBalanced x
+    ∀ x : V, x ≠ u → x ≠ v → D.isBalanced x := by
+  have hne : w.arcs ≠ [] := fun h => huv (w.empty_at h)
+  have heq := path_fst_snd_eq w.arcs w.consecutive hne
+  rw [w.starts_at hne, w.ends_at hne] at heq
+  -- Bridge: (map f arcs).count x = degree x
+  have cmf : ∀ (f : (V × V) → V) (l : List (V × V)) (b : V),
+      (l.map f).count b = (l.filter (fun a => decide (f a = b))).length := by
+    intro f l b; induction l with
+    | nil => simp
+    | cons h t ih =>
+      simp only [List.map_cons, List.count_cons, List.filter_cons]
+      split <;> simp_all [List.count]
+  have hout : ∀ x : V, (w.arcs.map Prod.fst).count x = D.outDegree x := by
+    intro x; rw [cmf, eulerian_source_count w hw]
+  have hin : ∀ x : V, (w.arcs.map Prod.snd).count x = D.inDegree x := by
+    intro x; rw [cmf, eulerian_target_count w hw]
+  -- From heq: ∀ x, count x LHS = count x RHS
+  -- Expanded: count x [u] + inDeg x = outDeg x + count x [v]
+  have hbal : ∀ x : V,
+      List.count x [u] + D.inDegree x = D.outDegree x + List.count x [v] := by
+    intro x
+    have h := congrArg (List.count x) heq
+    rw [List.count_append, List.count_append, hout, hin] at h
+    exact h
+  -- Helper: compute singleton counts via BEq case split
+  have count_self : ∀ (a : V), List.count a [a] = 1 := by
+    intro a
+    simp only [List.count_cons, List.count_nil, Nat.zero_add, beq_self_eq_true, ite_true]
+  have count_ne : ∀ (a b : V), a ≠ b → List.count a [b] = 0 := by
+    intro a b hab
+    simp only [List.count_cons, List.count_nil, Nat.zero_add]
+    have : (b == a) = false := by
+      rw [beq_eq_false_iff_ne]; exact Ne.symm hab
+    simp [this]
+  refine ⟨?_, ?_, ?_⟩
+  · -- u: outDeg(u) = inDeg(u) + 1
+    have h := hbal u
+    rw [count_self, count_ne u v huv] at h; omega
+  · -- v: inDeg(v) = outDeg(v) + 1
+    have h := hbal v
+    rw [count_ne v u (Ne.symm huv), count_self] at h; omega
+  · -- other x: balanced
+    intro x hxu hxv; unfold Digraph.isBalanced
+    have h := hbal x
+    rw [count_ne x u hxu, count_ne x v hxv] at h; omega
 
 /-- **Directed Eulerian Path Criterion (Sufficiency)**:
     If a connected directed graph satisfies the degree conditions,
@@ -682,7 +785,8 @@ This formalization establishes the directed Euler path/circuit criteria:
 2. **Degree Sum Lemma**: Σ indeg = Σ outdeg = |E| (proved via partition bijection)
 3. **Circuit Necessity**: Eulerian circuit → all balanced (proved via permutation)
 4. **Circuit Sufficiency**: All balanced → circuit exists (axiomatized, Hierholzer)
-5. **Path Criterion**: Source/sink degree conditions (axiomatized both directions)
+5. **Path Necessity**: Source/sink degree conditions (proved via counting)
+6. **Path Sufficiency**: Source/sink → path exists (axiomatized)
 6. **Triangle Example**: Directed C₃ is balanced, verified by computation
 7. **Square Example**: Directed C₄ is balanced, verified by computation
 8. **Non-existence**: Unbalanced digraph has no Eulerian circuit (proved)
@@ -690,17 +794,17 @@ This formalization establishes the directed Euler path/circuit criteria:
 10. **Symmetric Digraph**: Symmetric adjacency → all balanced (proved)
 11. **De Bruijn Connection**: Arc count in balanced graphs, k^n arc formula
 
-**Remaining sorries** (2, routine list/finset counting):
-- `eulerian_source_count`: filtered arc list length = outDegree
-- `eulerian_target_count`: filtered arc list length = inDegree
-These are purely combinatorial lemmas relating Nodup list filters to Finset cardinalities.
+**All theorem sorries proved.** The only remaining `sorry`-free axioms are:
+- `directed_euler_circuit_sufficient` (Hierholzer's algorithm, sufficiency direction)
+- `directed_euler_path_sufficient` (path sufficiency)
+These are correctly axiomatized as deep algorithmic results.
 
 This answers Open Question #2 from the Königsberg gallery:
 "Directed Euler paths: in-degree equals out-degree characterization"
 -/
 
 #check @directed_euler_circuit_necessary  -- theorem (was axiom)
-#check @directed_euler_path_necessary     -- axiom (deep: walk counting)
+#check @directed_euler_path_necessary     -- theorem (was axiom, proved via counting)
 #check @Digraph.sum_outDegree_eq_arcCount -- theorem
 #check @Digraph.sum_inDegree_eq_arcCount  -- theorem
 #check @unbal_no_euler_circuit            -- theorem

--- a/src/data/research/problems/konigsberg-oq-02.json
+++ b/src/data/research/problems/konigsberg-oq-02.json
@@ -21,10 +21,10 @@
     "goal": "Eliminate remaining 2 sorries (counting lemmas) and prove path necessity"
   },
   "currentState": {
-    "phase": "PROGRESS",
+    "phase": "COMPLETE",
     "since": "2026-03-06T18:30:00.000Z",
     "iteration": 2,
-    "focus": "Proving circuit necessity direction via source/target permutation argument.",
+    "focus": "All theorem sorries proved and verified via Docker build",
     "blockers": [],
     "nextAction": "Fill in eulerian_source_count and eulerian_target_count (list/finset counting). Consider proving path necessity.",
     "attemptCounts": {
@@ -34,23 +34,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Reduced axioms from 6→4. Proved circuit necessity via permutation argument. Walk definition strengthened with Chain' consecutive property. 2 routine counting sorries remain.",
+    "progressSummary": "COMPLETE: All theorem sorries proved. Directed Euler circuit necessity proved via source/target permutation. Directed Euler path necessity proved via path counting. Only algorithmic sufficiency axioms remain (Hierholzer).",
     "builtItems": [
-      "Digraph structure with in/out-degree definitions",
-      "Walk structure with Chain' consecutive property and ends_at",
-      "chain_tail_fst_eq_dropLast_snd: chain walk list lemma",
-      "circuit_fst_perm_snd: source/target permutation for circuit walks",
-      "directed_euler_circuit_necessary: converted axiom→theorem",
-      "symmetric_digraph_balanced: new theorem for symmetric digraphs",
-      "De Bruijn arc count formula (substantive, replaces rfl placeholders)",
-      "Degree sum lemma proofs (partition bijection)"
+      "Proved eulerian_source_count via filter-map bijection",
+      "Proved eulerian_target_count via filter-map bijection",
+      "Proved directed_euler_circuit_necessary via permutation argument",
+      "Proved directed_euler_path_necessary via counting argument",
+      "Added path_fst_snd_eq helper lemma",
+      "Improved degree sum proofs with fiberwise decomposition"
     ],
     "insights": [
-      "Directed Euler circuit ↔ connected + in-degree = out-degree at all vertices",
-      "Circuit necessity proof: chain connectivity makes arc source/target lists permutations",
-      "Key insight: fst_list = v₀ :: M, snd_list = M ++ [v₀] are permutations by List.perm_append_comm",
-      "Walk definition needs Chain' for consecutive + ends_at for proper formalization",
-      "Counting lemmas (source_count = outDegree) are routine Nodup list/Finset bijection"
+      "In Docker Mathlib v4.26.0, Finset.card_nbij uses Set coercion for membership - use Finset.card_map with explicit Finset.ext instead",
+      "List.Chain has been deprecated to List.IsChain in newer Mathlib",
+      "count_map_filter helper needs same universe for both type params to avoid commitConst errors",
+      "circuit_fst_perm_snd: permutation of source/target lists follows from chain connectivity + circularity",
+      "path_fst_snd_eq: [start] ++ map snd = map fst ++ [end] is the path analogue giving degree conditions"
     ],
     "mathlibGaps": [
       "No directed Euler path formalization in Mathlib"


### PR DESCRIPTION
## Summary
- Proved all theorem sorries in the directed Euler path/circuit characterization
- Only algorithmic sufficiency axioms remain (Hierholzer's algorithm - correctly axiomatized)

## Progress
- **directed_euler_circuit_necessary**: Proved via source/target permutation argument
- **directed_euler_path_necessary**: Proved via counting argument  
- **eulerian_source_count / eulerian_target_count**: Proved via filter-map bijection
- **Degree sum proofs**: Improved with fiberwise decomposition

## Status
**Outcome**: completed
**Proved**: 6 theorems, **Remaining axioms**: 2 (sufficiency, correctly axiomatized)

🤖 Generated by researcher-1