### PR TITLE
research: entry gap analysis + swapTails preservation for LGV (ballot-problem-oq-03)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03.lean
+++ b/proofs/Proofs/BallotProblemOQ03.lean
@@ -48,6 +48,8 @@ This is the y-offset when entering column k. Key properties:
 - [x] Vandermonde identity
 - [x] Verified examples via native_decide
 - [x] Involution infrastructure (splitAfterEast, swapTails, involutivity)
+- [x] Entry gap analysis (entryGap framework, NI preserves gap positivity)
+- [x] swapTails East step and length preservation theorems
 - [ ] Lindström involution (axiomatized — needs firstIntersectionColumn construction)
 
 ## References
@@ -1209,5 +1211,143 @@ theorem catalan_ballot_division (n : ℕ) :
     ballotSeqCount (n + 1) n * (n + 1) = Nat.choose (2 * n) n := by
   rw [← catalan_eq_ballot]
   exact catalan_formula n
+
+/-! ## Part XVII: Entry Gap Analysis and swapTails Properties
+
+This section develops the entry gap framework and proves key properties of swapTails
+that are needed for the Lindström involution.
+
+**Entry gap**: Define gap(k) = (y₂ + colEntry l₂ k) - (y₁ + colEntry l₁ k).
+When y₁ < y₂, gap(0) > 0. Non-intersection preserves gap positivity (via
+nonIntersecting_entry_order). This is used in the crossing lemma.
+
+**swapTails properties**: We prove that swapTails preserves East step counts and
+total path lengths — essential for showing swapped paths are valid pathType elements.
+
+**Toward eliminating the Lindström axiom**: The full bijection requires finding the
+first shared lattice point between intersecting paths. This requires a finer analysis
+than column-entry boundaries alone:
+- NonIntersecting uses column Y-ranges (intervals), not just boundary points
+- ¬NonIntersecting gives overlap in some column's Y-range
+- The Lindström involution swaps at the lexicographically first shared lattice point
+- This point may be in the interior of a column, not just at a boundary
+See the axiom documentation for the remaining construction needed.
+-/
+
+/-- The "gap" between path entry y-coordinates at column k.
+    Positive means P₁ is below P₂, zero or negative means they've met/crossed.
+    Defined on ℤ to handle the subtraction cleanly. -/
+def entryGap (l₁ l₂ : LPath) (y₁ y₂ : ℕ) (k : ℕ) : ℤ :=
+  (y₂ + colEntry l₂ k : ℤ) - (y₁ + colEntry l₁ k : ℤ)
+
+/-- At column 0, the gap is y₂ - y₁ -/
+theorem entryGap_zero (l₁ l₂ : LPath) (y₁ y₂ : ℕ) :
+    entryGap l₁ l₂ y₁ y₂ 0 = (y₂ : ℤ) - y₁ := by
+  simp [entryGap, colEntry_zero]
+
+/-- If paths are non-intersecting and the gap is positive at column k,
+    the gap stays positive at column k+1 (rephrasing of nonIntersecting_entry_order). -/
+theorem entryGap_pos_succ {l₁ l₂ : LPath} {m y₁ y₂ : ℕ}
+    (hni : NonIntersecting l₁ l₂ m y₁ y₂)
+    (hk : k < m)
+    (hpos : 0 < entryGap l₁ l₂ y₁ y₂ k) :
+    0 < entryGap l₁ l₂ y₁ y₂ (k + 1) := by
+  simp only [entryGap] at hpos ⊢
+  have h_entry : y₁ + colEntry l₁ k < y₂ + colEntry l₂ k := by omega
+  have h_next := nonIntersecting_entry_order hni hk h_entry
+  omega
+
+/-- **Key lemma**: If paths are non-intersecting and y₁ < y₂,
+    the gap is positive at ALL columns k ≤ m.
+    (Proved by induction using entryGap_pos_succ.) -/
+theorem entryGap_pos_all {l₁ l₂ : LPath} {m y₁ y₂ : ℕ}
+    (hni : NonIntersecting l₁ l₂ m y₁ y₂)
+    (hstart : y₁ < y₂) :
+    ∀ k ≤ m, 0 < entryGap l₁ l₂ y₁ y₂ k := by
+  intro k hkm
+  induction k with
+  | zero => rw [entryGap_zero]; omega
+  | succ k ih =>
+    apply entryGap_pos_succ hni (by omega : k < m)
+    exact ih (by omega)
+
+/-- Gap non-positive means P₁'s entry y is at or above P₂'s entry y -/
+theorem crossing_col_entry_ge {l₁ l₂ : LPath} {y₁ y₂ k : ℕ}
+    (hgap : entryGap l₁ l₂ y₁ y₂ k ≤ 0) :
+    y₂ + colEntry l₂ k ≤ y₁ + colEntry l₁ k := by
+  simp only [entryGap] at hgap; omega
+
+/-- Gap positive means P₁'s entry y is strictly below P₂'s entry y -/
+theorem crossing_col_prev_lt {l₁ l₂ : LPath} {y₁ y₂ k : ℕ}
+    (hgap : 0 < entryGap l₁ l₂ y₁ y₂ k) :
+    y₁ + colEntry l₁ k < y₂ + colEntry l₂ k := by
+  simp only [entryGap] at hgap; omega
+
+/-! ### swapTails East Step and Length Preservation -/
+
+/-- **swapTails preserves East step count** for the first resulting path.
+    Since pre₁ has k East steps and suf₂ has (m-k) East steps, their concatenation has m. -/
+theorem eastSteps_swapTails_fst (l₁ l₂ : LPath) (k m : ℕ)
+    (hk₁ : l₁.countP (· = false) = m)
+    (hk₂ : l₂.countP (· = false) = m)
+    (hkm : k ≤ m) :
+    eastSteps (swapTails l₁ l₂ k).1 = m := by
+  have heast₁ : k ≤ eastSteps l₁ := by simp only [eastSteps]; omega
+  have heast₂ : k ≤ eastSteps l₂ := by simp only [eastSteps]; omega
+  have hval : (swapTails l₁ l₂ k).1 =
+      (splitAfterEast l₁ k).1 ++ (splitAfterEast l₂ k).2 := rfl
+  rw [hval, show eastSteps ((splitAfterEast l₁ k).1 ++ (splitAfterEast l₂ k).2) =
+    eastSteps (splitAfterEast l₁ k).1 + eastSteps (splitAfterEast l₂ k).2 from by
+    simp [eastSteps, List.countP_append]]
+  have h_fst₁ := splitAfterEast_fst_eastSteps l₁ k heast₁
+  have h_sum₂ : eastSteps (splitAfterEast l₂ k).1 + eastSteps (splitAfterEast l₂ k).2 =
+      eastSteps l₂ := by
+    have h := splitAfterEast_append l₂ k
+    conv_rhs => rw [← h]
+    simp [eastSteps, List.countP_append]
+  have h_fst₂ := splitAfterEast_fst_eastSteps l₂ k heast₂
+  simp only [eastSteps] at h_fst₁ h_fst₂ h_sum₂ hk₂ ⊢; omega
+
+/-- **swapTails preserves East step count** for the second resulting path. -/
+theorem eastSteps_swapTails_snd (l₁ l₂ : LPath) (k m : ℕ)
+    (hk₁ : l₁.countP (· = false) = m)
+    (hk₂ : l₂.countP (· = false) = m)
+    (hkm : k ≤ m) :
+    eastSteps (swapTails l₁ l₂ k).2 = m := by
+  have heast₁ : k ≤ eastSteps l₁ := by simp only [eastSteps]; omega
+  have heast₂ : k ≤ eastSteps l₂ := by simp only [eastSteps]; omega
+  have hval : (swapTails l₁ l₂ k).2 =
+      (splitAfterEast l₂ k).1 ++ (splitAfterEast l₁ k).2 := rfl
+  rw [hval, show eastSteps ((splitAfterEast l₂ k).1 ++ (splitAfterEast l₁ k).2) =
+    eastSteps (splitAfterEast l₂ k).1 + eastSteps (splitAfterEast l₁ k).2 from by
+    simp [eastSteps, List.countP_append]]
+  have h_fst₂ := splitAfterEast_fst_eastSteps l₂ k heast₂
+  have h_sum₁ : eastSteps (splitAfterEast l₁ k).1 + eastSteps (splitAfterEast l₁ k).2 =
+      eastSteps l₁ := by
+    have h := splitAfterEast_append l₁ k
+    conv_rhs => rw [← h]
+    simp [eastSteps, List.countP_append]
+  have h_fst₁ := splitAfterEast_fst_eastSteps l₁ k heast₁
+  simp only [eastSteps] at h_fst₁ h_fst₂ h_sum₁ hk₁ ⊢; omega
+
+/-- **swapTails length preservation** for the first path -/
+theorem length_swapTails_fst (l₁ l₂ : LPath) (k : ℕ) :
+    (swapTails l₁ l₂ k).1.length =
+    (splitAfterEast l₁ k).1.length + (splitAfterEast l₂ k).2.length := by
+  simp [swapTails, List.length_append]
+
+/-- **swapTails length preservation** for the second path -/
+theorem length_swapTails_snd (l₁ l₂ : LPath) (k : ℕ) :
+    (swapTails l₁ l₂ k).2.length =
+    (splitAfterEast l₂ k).1.length + (splitAfterEast l₁ k).2.length := by
+  simp [swapTails, List.length_append]
+
+/-- **North steps of suffix**: northSteps of the suffix after k East steps equals
+    total northSteps minus the prefix northSteps (which equals colEntry l k). -/
+theorem northSteps_splitAfterEast_snd (l : LPath) (k : ℕ) :
+    northSteps (splitAfterEast l k).2 = northSteps l - colEntry l k := by
+  have h_sum := northSteps_splitAfterEast_sum l k
+  have h_fst := northSteps_splitAfterEast_fst l k
+  omega
 
 end LatticePathLGV

--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -55,7 +55,12 @@
       "lgvDet_swap_sources/targets: antisymmetry of LGV determinant",
       "lgvDet_nonneg: non-negativity under proper ordering (via LGV lemma)",
       "catalan_eq_ballot: Cn(n) = ballotSeqCount(n+1, n) (Catalan-Ballot unification)",
-      "catalan_ballot_division: ballotSeqCount(n+1,n)*(n+1) = C(2n,n)"
+      "catalan_ballot_division: ballotSeqCount(n+1,n)*(n+1) = C(2n,n)",
+      "entryGap: gap between path entry y-coordinates at column boundaries",
+      "entryGap_pos_succ: NI + positive gap at k → positive gap at k+1",
+      "entryGap_pos_all: NI + y₁ < y₂ → gap positive at all columns ≤ m",
+      "eastSteps_swapTails_fst/snd: swapTails preserves East step count = m",
+      "northSteps_splitAfterEast_snd: suffix North steps = total - colEntry"
     ],
     "dateAdded": "2026-02-26",
     "mathlib_version": "4.26.0"
@@ -73,7 +78,9 @@
       "pathFlip (l.map (!·)) transposes the grid: m East + n North ↔ n East + m North, giving C(m+n,m) = C(m+n,n) combinatorially",
       "lgvDet is antisymmetric in both sources and targets: swapping negates, double swap recovers original",
       "lgvDet_nonneg follows from lgv_lemma_2x2 since niPairCount is a natural number cast to ℤ",
-      "Catalan and ballot are the same: Cn(n) = ballotSeqCount(n+1,n) = C(2n,n) - C(2n,n+1)"
+      "Catalan and ballot are the same: Cn(n) = ballotSeqCount(n+1,n) = C(2n,n) - C(2n,n+1)",
+      "Entry gap framework: entryGap(k) = (y₂+entry₂(k)) - (y₁+entry₁(k)) captures crossing analysis; NI preserves gap positivity, but positive gap does NOT imply NI (ranges are intervals, not points)",
+      "swapTails preserves East step count: pre₁ has k East steps + suf₂ has (m-k) East steps = m total"
     ]
   },
   "sections": [
@@ -167,6 +174,13 @@
       "startLine": 1190,
       "endLine": 1215,
       "summary": "FULLY PROVED: Cn(n) = ballotSeqCount(n+1,n) unifying the two reflection-based formulas. catalan_ballot_division: ballotSeqCount(n+1,n)*(n+1) = C(2n,n)."
+    },
+    {
+      "id": "entry-gap-analysis",
+      "title": "Entry Gap Analysis and swapTails Properties",
+      "startLine": 1215,
+      "endLine": 1370,
+      "summary": "FULLY PROVED: Entry gap framework (NI preserves positive gap, gap positive at all columns under NI + y₁<y₂). swapTails East step count preservation. Suffix North step count decomposition."
     }
   ],
   "conclusion": {

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -29,24 +29,34 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 0 sorries, 1 axiom (lindstrom_involution). PR #3364 eliminates all 4 prior sorries.",
+    "progressSummary": "PROGRESS: Extended with entry gap analysis (Part XVII). Proved entryGap framework (NI preserves positive gap at all columns), swapTails East step preservation, suffix North step decomposition. Still 0 sorries, 1 axiom (lindstrom_involution).",
     "builtItems": [
       "37+ theorems in BallotProblemOQ03.lean",
       "Higher-dimensional lattice paths via reflection principle",
       "2x2 LGV Lemma proved via complement counting + Lindström axiom",
       "Crossing Lemma fully proved",
       "Involution infrastructure: splitAfterEast, swapTails, involutivity",
-      "Catalan numbers, ballot formula, Vandermonde identity"
+      "Catalan numbers, ballot formula, Vandermonde identity",
+      "entryGap def, entryGap_zero, entryGap_pos_succ, entryGap_pos_all (gap analysis)",
+      "crossing_col_entry_ge, crossing_col_prev_lt (gap ↔ inequality conversion)",
+      "eastSteps_swapTails_fst/snd (swapTails preserves East step count)",
+      "length_swapTails_fst/snd, northSteps_splitAfterEast_snd (structural preservation)"
     ],
     "insights": [
       "Lindström involution requires firstIntersectionColumn construction",
       "The involution is a classical result but the Equiv construction is complex",
-      "Axiomatizing the bijection is appropriate: infrastructure is built, gap is explicit"
+      "Axiomatizing the bijection is appropriate: infrastructure is built, gap is explicit",
+      "Entry gap analysis: NI implies positive gap everywhere, but positive gap does NOT imply NI",
+      "Key subtlety: positive entry gap at boundaries doesn't give disjoint column ranges (intervals vs points)",
+      "The Lindström involution swaps at the lexicographically first shared LATTICE POINT, not column boundary",
+      "swapTails preserves East step count: pre₁(k East) ++ suf₂(m-k East) = m East steps"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Construct firstIntersectionColumn to fill the axiom",
-      "Build the explicit Equiv using existing swap infrastructure"
+      "Define lattice point membership on paths (finer than column-entry boundaries)",
+      "Prove shared lattice point exists for ¬NonIntersecting paths (from column range overlap)",
+      "Construct firstSharedLatticePoint using Nat.find on decidable predicate",
+      "Build the explicit Equiv using swapTails at the first shared point"
     ]
   },
   "approaches": [],


### PR DESCRIPTION
## Summary
- Extends `BallotProblemOQ03.lean` with Part XVII: entry gap framework and swapTails structural properties
- All new theorems fully proved (0 new sorries, axiom count unchanged at 1)
- Key insight documented: positive entry gap does NOT imply NonIntersecting (intervals vs points subtlety)

## New Theorems
- `entryGap` definition + `entryGap_zero`, `entryGap_pos_succ`, `entryGap_pos_all`
- `crossing_col_entry_ge`, `crossing_col_prev_lt` (gap ↔ inequality conversion)
- `eastSteps_swapTails_fst/snd` (swapTails preserves East step count = m)
- `length_swapTails_fst/snd`, `northSteps_splitAfterEast_snd` (structural preservation)

## Toward Eliminating lindstrom_involution Axiom
Documents that the full bijection requires:
1. Define lattice point membership on paths (finer than column-entry boundaries)
2. Prove shared lattice point exists for intersecting paths
3. Use Nat.find to get first shared point
4. Build Equiv via swapTails at that point

## Test plan
- [x] Docker build succeeds with 0 sorries, 1 axiom (unchanged)
- [x] All new theorems compile without sorry

🤖 Generated with [Claude Code](https://claude.com/claude-code)