### PR TITLE
research: fix dimensional error in 2D Borsuk-Ulam formalization

### DIFF
--- a/proofs/Proofs/BirchSwinnertonDyerAristotle.lean
+++ b/proofs/Proofs/BirchSwinnertonDyerAristotle.lean
@@ -17,17 +17,17 @@ namespace BSDAristotle
 -- Section 1: Elliptic Curve Point Counting (Hasse bound)
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- Hasse bound: |a_p| ≤ 2√p where a_p = p + 1 - #E(F_p) -/
--- For specific small primes:
+/- Hasse bound: |a_p| ≤ 2√p where a_p = p + 1 - #E(F_p)
+   For specific small primes: -/
 
 /-- a_p for 11a1 at p=2: #E(F_2)=5, a_2 = 2+1-5 = -2, |a_2|=2 ≤ 2√2 ≈ 2.83 -/
-theorem hasse_check_11a_p2 : |(-2 : ℤ)| ≤ 2 * 2 := by sorry
+theorem hasse_check_11a_p2 : |(-2 : ℤ)| ≤ 2 * 2 := by norm_num
 
 /-- a_p for 11a1 at p=3: #E(F_3)=5, a_3 = 3+1-5 = -1, |a_3|=1 ≤ 2√3 ≈ 3.46 -/
-theorem hasse_check_11a_p3 : |(-1 : ℤ)| ≤ 2 * 2 := by sorry
+theorem hasse_check_11a_p3 : |(-1 : ℤ)| ≤ 2 * 2 := by norm_num
 
 /-- a_p for 11a1 at p=5: #E(F_5)=5, a_5 = 5+1-5 = 1, |a_5|=1 ≤ 2√5 ≈ 4.47 -/
-theorem hasse_check_11a_p5 : |(1 : ℤ)| ≤ 2 * 3 := by sorry
+theorem hasse_check_11a_p5 : |(1 : ℤ)| ≤ 2 * 3 := by norm_num
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 2: Discriminant and Conductor Computations
@@ -35,30 +35,30 @@ theorem hasse_check_11a_p5 : |(1 : ℤ)| ≤ 2 * 3 := by sorry
 
 /-- Discriminant of y² = x³ - x is Δ = -64 -/
 -- For Weierstrass form y² = x³ + ax + b: Δ = -16(4a³ + 27b²)
-theorem disc_minus_x : -16 * (4 * (-1 : ℤ)^3 + 27 * 0^2) = 64 := by sorry
+theorem disc_minus_x : -16 * (4 * (-1 : ℤ)^3 + 27 * 0^2) = 64 := by norm_num
 
 /-- Discriminant of y² + y = x³ - x² (11a1): Δ = -11 -/
 -- After Weierstrass normalization
-theorem disc_11a1_sign : (-11 : ℤ) < 0 := by sorry
+theorem disc_11a1_sign : (-11 : ℤ) < 0 := by norm_num
 
 /-- Conductor 37 is prime -/
-theorem conductor_37_prime : Nat.Prime 37 := by sorry
+theorem conductor_37_prime : Nat.Prime 37 := by norm_num
 
 /-- Conductor 389 is prime -/
-theorem conductor_389_prime : Nat.Prime 389 := by sorry
+theorem conductor_389_prime : Nat.Prime 389 := by norm_num
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 3: Tunnell's Theorem Computations
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- Tunnell: n=1 is a congruent number iff #{x,y,z: 2x²+y²+8z²=1} = 2·#{2x²+y²+32z²=1} -/
--- These are finite sums that can be verified computationally
+/- Tunnell: n=1 is a congruent number iff #{x,y,z: 2x²+y²+8z²=1} = 2·#{2x²+y²+32z²=1}
+   These are finite sums that can be verified computationally -/
 
-/-- For n=5: #{2x²+y²+8z²=5} can be computed -/
--- The point is that these are decidable predicates over bounded ranges
+/- For n=5: #{2x²+y²+8z²=5} can be computed
+   The point is that these are decidable predicates over bounded ranges -/
 
 /-- For n=6: #{2x²+y²+8z²=6} = 2, #{2x²+y²+32z²=6} = 1, so 2 = 2·1 ✓ -/
-theorem tunnell_6_check : 2 = 2 * (1 : ℕ) := by sorry
+theorem tunnell_6_check : 2 = 2 * (1 : ℕ) := by norm_num
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 4: L-function Special Values (Rational Arithmetic)
@@ -66,44 +66,44 @@ theorem tunnell_6_check : 2 = 2 * (1 : ℕ) := by sorry
 
 /-- BSD leading coefficient: L(E,1)/Ω = |Sha|·∏c_p·R/(#E(Q)_tors²)
     For 11a1: L(E,1)/Ω = 1/5 with #tors = 5, so numerator = 5²/5 = 5 -/
-theorem bsd_11a_torsion_sq : (5 : ℕ)^2 = 25 := by sorry
+theorem bsd_11a_torsion_sq : (5 : ℕ)^2 = 25 := by norm_num
 
-/-- For 37a1: rank = 1, so L(E,1) = 0 -/
--- The analytic rank 1 case
+/- For 37a1: rank = 1, so L(E,1) = 0
+   The analytic rank 1 case -/
 
-/-- Manin constant conjecture: c = 1 for optimal curves -/
--- For small conductors this is verified
+/- Manin constant conjecture: c = 1 for optimal curves
+   For small conductors this is verified -/
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 5: Mordell-Weil Rank Bounds
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- 2-Selmer bound: rank E(Q) ≤ dim_F₂ Sel²(E/Q) -/
--- This is a standard inequality from Galois cohomology
+/- 2-Selmer bound: rank E(Q) ≤ dim_F₂ Sel²(E/Q)
+   This is a standard inequality from Galois cohomology -/
 
 /-- For 11a1: rank = 0, torsion = Z/5Z, so #E(Q) = 5 -/
-theorem rank0_torsion5 : (5 : ℕ) > 0 := by sorry
+theorem rank0_torsion5 : (5 : ℕ) > 0 := by norm_num
 
 /-- For 37a1: rank = 1, generator P = (0, 0) -/
 -- The point (0,0) is on y² + y = x³ - x iff 0+0 = 0-0 = 0 ✓
-theorem point_on_37a : (0 : ℤ)^3 - 0 = 0 := by sorry
+theorem point_on_37a : (0 : ℤ)^3 - 0 = 0 := by norm_num
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 6: Modular Form Computations
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- Level 11 modular form: dimension of S₂(Γ₀(11)) = 1 -/
--- The dimension formula for weight-2 cusp forms:
--- dim S₂(Γ₀(N)) = genus(X₀(N))
--- For N=11 (prime): genus = (N-13)/12 + corrections
--- genus(X₀(11)) = 1
+/- Level 11 modular form: dimension of S₂(Γ₀(11)) = 1
+   The dimension formula for weight-2 cusp forms:
+   dim S₂(Γ₀(N)) = genus(X₀(N))
+   For N=11 (prime): genus = (N-13)/12 + corrections
+   genus(X₀(11)) = 1 -/
 
-/-- Level 37: genus(X₀(37)) = 2 -/
--- So dim S₂(Γ₀(37)) = 2, there are two newforms
+/- Level 37: genus(X₀(37)) = 2
+   So dim S₂(Γ₀(37)) = 2, there are two newforms -/
 
 /-- Level 2: genus(X₀(2)) = 0, so S₂(Γ₀(2)) = {0} -/
 -- This is the key fact for Ribet's proof → FLT
-theorem level2_genus_zero : (0 : ℕ) = 0 := by sorry
+theorem level2_genus_zero : (0 : ℕ) = 0 := by rfl
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 7: Galois Representation Properties
@@ -111,49 +111,49 @@ theorem level2_genus_zero : (0 : ℕ) = 0 := by sorry
 
 /-- det(ρ_{E,ℓ}) = cyclotomic character: det has order ℓ-1 in (Z/ℓZ)* -/
 -- For ℓ = 2: (Z/2Z)* has order 1
-theorem galois_det_order_2 : 2 - 1 = (1 : ℕ) := by sorry
+theorem galois_det_order_2 : 2 - 1 = (1 : ℕ) := by norm_num
 
 /-- For ℓ = 3: (Z/3Z)* has order 2 -/
-theorem galois_det_order_3 : 3 - 1 = (2 : ℕ) := by sorry
+theorem galois_det_order_3 : 3 - 1 = (2 : ℕ) := by norm_num
 
 /-- For ℓ = 5: (Z/5Z)* has order 4 -/
-theorem galois_det_order_5 : 5 - 1 = (4 : ℕ) := by sorry
+theorem galois_det_order_5 : 5 - 1 = (4 : ℕ) := by norm_num
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 8: Symmetric Power L-function Degrees
 -- ═══════════════════════════════════════════════════════════════════
 
 /-- Sym^n L-function has degree n+1 -/
-theorem sym1_degree : 1 + 1 = (2 : ℕ) := by sorry
-theorem sym2_degree : 2 + 1 = (3 : ℕ) := by sorry
-theorem sym3_degree : 3 + 1 = (4 : ℕ) := by sorry
-theorem sym4_degree : 4 + 1 = (5 : ℕ) := by sorry
+theorem sym1_degree : 1 + 1 = (2 : ℕ) := by norm_num
+theorem sym2_degree : 2 + 1 = (3 : ℕ) := by norm_num
+theorem sym3_degree : 3 + 1 = (4 : ℕ) := by norm_num
+theorem sym4_degree : 4 + 1 = (5 : ℕ) := by norm_num
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 9: Height Pairing and Regulator
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- Néron-Tate height is non-negative: ĥ(P) ≥ 0 -/
--- This follows from the limit definition and properties of intersection theory
+/- Néron-Tate height is non-negative: ĥ(P) ≥ 0
+   This follows from the limit definition and properties of intersection theory -/
 
-/-- ĥ(P) = 0 iff P is torsion (for elliptic curves over Q) -/
--- This is a theorem of Néron
+/- ĥ(P) = 0 iff P is torsion (for elliptic curves over Q)
+   This is a theorem of Néron -/
 
-/-- Regulator of rank-1 curve: R = ĥ(P) for generator P -/
--- For 37a1: R = ĥ((0,0)) ≈ 0.0511...
+/- Regulator of rank-1 curve: R = ĥ(P) for generator P
+   For 37a1: R = ĥ((0,0)) ≈ 0.0511... -/
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 10: Iwasawa Theory Parameters
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- μ-invariant conjecture: μ = 0 for E/Q (proved by Kato) -/
--- For the p-adic L-function, the μ-invariant vanishes
+/- μ-invariant conjecture: μ = 0 for E/Q (proved by Kato)
+   For the p-adic L-function, the μ-invariant vanishes -/
 
-/-- λ-invariant: λ ≥ rank E(Q) (Iwasawa theory bound) -/
--- The λ-invariant of the p-adic L-function is at least the Mordell-Weil rank
+/- λ-invariant: λ ≥ rank E(Q) (Iwasawa theory bound)
+   The λ-invariant of the p-adic L-function is at least the Mordell-Weil rank -/
 
 /-- For 11a1 at p=5: μ=0, λ=0 (rank 0 curve, ordinary at p=5) -/
-theorem iwasawa_11a_p5_mu : (0 : ℕ) = 0 := by sorry
-theorem iwasawa_11a_p5_lambda_bound : (0 : ℕ) ≥ 0 := by sorry
+theorem iwasawa_11a_p5_mu : (0 : ℕ) = 0 := by rfl
+theorem iwasawa_11a_p5_lambda_bound : (0 : ℕ) ≥ 0 := by norm_num
 
 end BSDAristotle

--- a/proofs/Proofs/BorsukUlamOQ03OQ03.lean
+++ b/proofs/Proofs/BorsukUlamOQ03OQ03.lean
@@ -211,31 +211,29 @@ axiom complementary_edge_gives_approximate_zero
 PART VI: THE MAIN BRIDGE: TUCKER → 2D BORSUK-ULAM
 ═══════════════════════════════════════════════════════════════════════════════ -/
 
-/-- **Approximate 2D Borsuk-Ulam from Tucker's Lemma**
+/-- **DIMENSIONAL ERROR**: The original statement below uses S¹ → ℝ² which is FALSE.
+    Counterexample: f(x) = x (identity). Then dist(x, -x) = 2 for all x ∈ S¹.
 
-    For any continuous f : ℝ² → ℝ² and any ε > 0, there exists a point
-    on the unit circle S¹ ⊂ ℝ² where |f(x) - f(-x)| < ε.
+    The correct 2D Borsuk-Ulam theorem is f : S² → ℝ² (sphere in ℝ³, not circle in ℝ²).
+    BU dimension matching: S^n → ℝ^n.
+    - n=1: S¹ → ℝ (true, by IVT) ← proved in BorsukUlamOQ03.lean
+    - n=2: S² → ℝ² (true) ← what this file SHOULD formalize
 
-    Proof strategy:
-    1. Form g(x) = f(x) - f(-x) (odd function)
-    2. Triangulate the unit disk with mesh size δ ≪ ε
-    3. Label vertices by dominant component of g
-    4. Tucker's lemma gives complementary edge
-    5. Along this edge, g changes sign → g ≈ 0 nearby
+    The proof infrastructure (dominantComponentLabel, Tucker's lemma, odd functions,
+    compactness arguments) is correct for the codomain ℝ², but the domain must be
+    S² ⊂ ℝ³, not S¹ ⊂ ℝ².
 
-    This is the constructive content: given δ, we can computably find
-    an approximate antipodal pair. -/
+    To fix: change domain to ℝ × ℝ × ℝ with constraint x₁²+x₂²+x₃²=1,
+    use hemisphere projection (x,y,z) ↦ (x,y) for z≥0 to reduce S² → D²,
+    then apply Tucker 2D on D². See approx_borsuk_ulam_2d_corrected below. -/
 theorem approx_borsuk_ulam_2d_from_tucker
     (f : ℝ × ℝ → ℝ × ℝ) (hf : Continuous f)
     (ε : ℝ) (hε : 0 < ε) :
     ∃ x : ℝ × ℝ, x.1 ^ 2 + x.2 ^ 2 = 1 ∧
       dist (f x) (f (Prod.map Neg.neg Neg.neg x)) < ε := by
-  -- The proof requires:
-  -- 1. Construct a triangulation with mesh size δ = ε / (2C) where C = sup ‖g‖
-  -- 2. Label vertices via dominantComponentLabel
-  -- 3. Apply Tucker's lemma to get complementary edge
-  -- 4. Use continuity to find approximate zero
-  -- Full construction needs explicit triangulation builder
+  -- FALSE as stated: S¹ → ℝ² BU does not hold.
+  -- Counterexample: f = id gives dist(x, -x) = 2 for all x on S¹.
+  -- See approx_borsuk_ulam_2d_corrected for the correct S² → ℝ² version.
   sorry
 
 /-
@@ -243,14 +241,8 @@ theorem approx_borsuk_ulam_2d_from_tucker
 PART VII: EXACT 2D BORSUK-ULAM (LIMITING ARGUMENT)
 ═══════════════════════════════════════════════════════════════════════════════ -/
 
-/-- **Exact 2D Borsuk-Ulam from Tucker's Lemma (via compactness)**
-
-    By taking a sequence of triangulations with mesh size → 0, the
-    approximate antipodal pairs form a sequence on S¹ (compact).
-    By Bolzano-Weierstrass, a subsequence converges, and the limit
-    point satisfies f(x) = f(-x) exactly by continuity.
-
-    This is the full constructive proof of 2D BU via Tucker. -/
+/-- **DIMENSIONAL ERROR**: Same issue as approx_borsuk_ulam_2d_from_tucker.
+    S¹ → ℝ² BU is false. See borsuk_ulam_2d_corrected for the corrected S² → ℝ² version. -/
 theorem borsuk_ulam_2d_from_tucker
     (f : ℝ × ℝ → ℝ × ℝ) (hf : Continuous f) :
     ∃ x : ℝ × ℝ, x.1 ^ 2 + x.2 ^ 2 = 1 ∧
@@ -556,5 +548,144 @@ PART XV: VERIFICATION
 #check @circle_bounded
 #check @continuous_on_circle_bounded
 #check @approx_to_exact
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART XVI: CORRECTED 2D BORSUK-ULAM (S² → ℝ²)
+
+The correct statement uses S² ⊂ ℝ³ as the domain, not S¹ ⊂ ℝ².
+BU dimension matching: f : S^n → ℝ^n requires domain dimension = codomain dimension.
+For the 2D case: f : S² → ℝ² where S² = {(x,y,z) ∈ ℝ³ : x²+y²+z²=1}.
+
+The proof strategy via Tucker is:
+1. Given continuous f : ℝ³ → ℝ², define g(x) = f(x) - f(-x)
+2. g is odd (g(-x) = -g(x)) and continuous
+3. Project the upper hemisphere H⁺ = {(x,y,z) ∈ S² : z ≥ 0} to D² via (x,y,z) → (x,y)
+4. Define g̃(u,v) = g(u, v, √(1-u²-v²)) on D²
+5. On ∂D² (where z=0), the lifted point is on the equator, and g̃(-u,-v) = -g̃(u,v)
+6. Label vertices by dominantComponentLabel(g̃(v))
+7. Tucker 2D gives complementary edge → approximate zero of g̃ → approximate BU
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Negation in ℝ³ (as ℝ × ℝ × ℝ). -/
+abbrev neg3 : ℝ × ℝ × ℝ → ℝ × ℝ × ℝ := fun x => (-x.1, -x.2.1, -x.2.2)
+
+/-- Negation in ℝ³ is an involution. -/
+theorem neg3_neg3 (x : ℝ × ℝ × ℝ) : neg3 (neg3 x) = x := by
+  simp [neg3]
+
+/-- Negation preserves the sphere S². -/
+theorem neg3_preserves_sphere (x : ℝ × ℝ × ℝ)
+    (hx : x.1 ^ 2 + x.2.1 ^ 2 + x.2.2 ^ 2 = 1) :
+    (neg3 x).1 ^ 2 + (neg3 x).2.1 ^ 2 + (neg3 x).2.2 ^ 2 = 1 := by
+  simp only [neg3]; ring_nf; linarith
+
+/-- On S², the antipodal map has no fixed points. -/
+theorem no_fixed_point_on_sphere (x : ℝ × ℝ × ℝ)
+    (hx : x.1 ^ 2 + x.2.1 ^ 2 + x.2.2 ^ 2 = 1) :
+    neg3 x ≠ x := by
+  intro h
+  have h1 : -x.1 = x.1 := congr_arg Prod.fst h
+  have h2 : -x.2.1 = x.2.1 := congr_arg (Prod.fst ∘ Prod.snd) h
+  have h3 : -x.2.2 = x.2.2 := congr_arg (Prod.snd ∘ Prod.snd) h
+  have hx1 : x.1 = 0 := by linarith
+  have hx2 : x.2.1 = 0 := by linarith
+  have hx3 : x.2.2 = 0 := by linarith
+  rw [hx1, hx2, hx3] at hx; norm_num at hx
+
+/-- Negation in ℝ³ is continuous. -/
+theorem neg3_continuous : Continuous neg3 := by
+  simp only [neg3]; fun_prop
+
+/-- The antisymmetric difference for f : ℝ³ → ℝ². -/
+def antisymmetricDiff3 (f : ℝ × ℝ × ℝ → ℝ × ℝ) : ℝ × ℝ × ℝ → ℝ × ℝ :=
+  fun x => ((f x).1 - (f (neg3 x)).1, (f x).2 - (f (neg3 x)).2)
+
+/-- antisymmetricDiff3 is odd: g(-x) = -g(x). -/
+theorem antisymmetricDiff3_odd (f : ℝ × ℝ × ℝ → ℝ × ℝ) (x : ℝ × ℝ × ℝ) :
+    antisymmetricDiff3 f (neg3 x) =
+      Prod.map Neg.neg Neg.neg (antisymmetricDiff3 f x) := by
+  simp only [antisymmetricDiff3, neg3, neg3_neg3, Prod.map]
+  ext <;> simp <;> ring
+
+/-- antisymmetricDiff3 is continuous when f is. -/
+theorem antisymmetricDiff3_continuous (f : ℝ × ℝ × ℝ → ℝ × ℝ) (hf : Continuous f) :
+    Continuous (antisymmetricDiff3 f) := by
+  unfold antisymmetricDiff3 neg3
+  fun_prop
+
+/-- antisymmetricDiff3 zero iff f(x) = f(-x). -/
+theorem antisymmetricDiff3_eq_zero_iff (f : ℝ × ℝ × ℝ → ℝ × ℝ) (x : ℝ × ℝ × ℝ) :
+    antisymmetricDiff3 f x = (0, 0) ↔ f x = f (neg3 x) := by
+  simp only [antisymmetricDiff3, Prod.mk.injEq]
+  constructor
+  · rintro ⟨h1, h2⟩; exact Prod.ext (by linarith) (by linarith)
+  · intro h; exact ⟨by have := congr_arg Prod.fst h; simp at this; linarith,
+                     by have := congr_arg Prod.snd h; simp at this; linarith⟩
+
+/-- S² is compact. -/
+theorem sphere_isCompact :
+    IsCompact {x : ℝ × ℝ × ℝ | x.1 ^ 2 + x.2.1 ^ 2 + x.2.2 ^ 2 = 1} := by
+  apply (isCompact_closedBall (0 : ℝ × ℝ × ℝ) 1).of_isClosed_subset
+  · exact isClosed_eq (by fun_prop) continuous_const
+  · intro ⟨x, y, z⟩ hxyz
+    simp only [Set.mem_setOf_eq] at hxyz
+    simp only [Metric.mem_closedBall, dist_zero_right]
+    rw [Prod.norm_def, Prod.norm_def]
+    apply max_le
+    · rw [Real.norm_eq_abs]; nlinarith [sq_nonneg x, sq_abs x, sq_nonneg y, sq_nonneg z]
+    · apply max_le <;> rw [Real.norm_eq_abs] <;>
+        nlinarith [sq_nonneg x, sq_nonneg y, sq_nonneg z, sq_abs y, sq_abs z]
+
+/-- S² is nonempty. -/
+theorem sphere_nonempty :
+    Set.Nonempty {x : ℝ × ℝ × ℝ | x.1 ^ 2 + x.2.1 ^ 2 + x.2.2 ^ 2 = 1} :=
+  ⟨(1, 0, 0), by norm_num⟩
+
+/-- **Corrected approximate 2D Borsuk-Ulam from Tucker's Lemma**
+
+    For any continuous f : ℝ³ → ℝ² and any ε > 0, there exists a point
+    on S² where |f(x) - f(-x)| < ε.
+
+    This is the correct statement using S² ⊂ ℝ³ (not S¹ ⊂ ℝ²). -/
+theorem approx_borsuk_ulam_2d_corrected
+    (f : ℝ × ℝ × ℝ → ℝ × ℝ) (hf : Continuous f)
+    (ε : ℝ) (hε : 0 < ε) :
+    ∃ x : ℝ × ℝ × ℝ, x.1 ^ 2 + x.2.1 ^ 2 + x.2.2 ^ 2 = 1 ∧
+      dist (f x) (f (neg3 x)) < ε := by
+  -- Strategy: minimize dist(f(x), f(-x)) on compact S²; minimum is ≤ ε for all ε
+  -- by Tucker's lemma + complementary edge argument on the projected disk.
+  -- Full proof requires: hemisphere projection, disk triangulation, Tucker application.
+  sorry
+
+/-- **Corrected exact 2D Borsuk-Ulam from Tucker's Lemma**
+
+    By taking triangulations with mesh size → 0, the approximate solutions
+    converge (by compactness of S²) to an exact solution. -/
+theorem borsuk_ulam_2d_corrected
+    (f : ℝ × ℝ × ℝ → ℝ × ℝ) (hf : Continuous f) :
+    ∃ x : ℝ × ℝ × ℝ, x.1 ^ 2 + x.2.1 ^ 2 + x.2.2 ^ 2 = 1 ∧
+      f x = f (neg3 x) := by
+  -- Minimize d(x) = dist(f(x), f(-x)) on compact S²
+  have hd : Continuous (fun x : ℝ × ℝ × ℝ => dist (f x) (f (neg3 x))) :=
+    Continuous.dist hf (hf.comp neg3_continuous)
+  obtain ⟨x₀, hx₀S, hx₀min⟩ :=
+    sphere_isCompact.exists_isMinOn sphere_nonempty hd.continuousOn
+  refine ⟨x₀, hx₀S, dist_eq_zero.mp (le_antisymm ?_ dist_nonneg)⟩
+  by_contra hgt
+  push_neg at hgt
+  obtain ⟨x₁, hx₁on, hx₁lt⟩ := approx_borsuk_ulam_2d_corrected f hf _ hgt
+  exact absurd hx₁lt (not_lt.mpr (hx₀min hx₁on))
+
+-- Type-check corrected results
+#check @neg3
+#check @neg3_preserves_sphere
+#check @no_fixed_point_on_sphere
+#check @antisymmetricDiff3
+#check @antisymmetricDiff3_odd
+#check @antisymmetricDiff3_eq_zero_iff
+#check @sphere_isCompact
+#check @approx_borsuk_ulam_2d_corrected
+#check @borsuk_ulam_2d_corrected
 
 end BorsukUlamTucker2D

--- a/proofs/Proofs/Erdos1049Problem.lean
+++ b/proofs/Proofs/Erdos1049Problem.lean
@@ -41,11 +41,13 @@ theorem tau_one : τ 1 = 1 := by
 
 /-- τ(p) = 2 for prime p. -/
 theorem tau_prime (p : ℕ) (hp : p.Prime) : τ p = 2 := by
-  sorry
+  unfold tau
+  rw [hp.divisors, Finset.card_insert_of_not_mem (by simp [hp.one_lt.ne]),
+      Finset.card_singleton]
 
 /-- τ(p^k) = k + 1 for prime p. -/
 theorem tau_prime_pow (p k : ℕ) (hp : p.Prime) : τ (p ^ k) = k + 1 := by
-  sorry
+  simp [tau, Nat.divisors_prime_pow hp]
 
 /-- τ is multiplicative: τ(mn) = τ(m)τ(n) for coprime m, n. -/
 theorem tau_multiplicative (m n : ℕ) (hmn : m.Coprime n) :
@@ -54,11 +56,13 @@ theorem tau_multiplicative (m n : ℕ) (hmn : m.Coprime n) :
 
 /-- τ(n) ≥ 1 for n ≥ 1. -/
 theorem tau_pos (n : ℕ) (hn : n ≥ 1) : τ n ≥ 1 := by
-  sorry
+  simp only [tau, ge_iff_le]
+  exact Finset.card_pos.mpr ⟨1, Nat.one_mem_divisors.mpr (Nat.pos_iff_ne_zero.mp hn)⟩
 
 /-- τ(n) ≤ n for all n. -/
 theorem tau_le (n : ℕ) : τ n ≤ n := by
-  sorry
+  simp only [tau]
+  exact Nat.card_divisors_le_self n
 
 /-
 ## Part II: The Series
@@ -76,12 +80,12 @@ noncomputable def D (t : ℝ) : ℝ :=
 
 /-- The series converges for t > 1. -/
 theorem S_summable (t : ℝ) (ht : t > 1) :
-    Summable (fun n : ℕ => if n = 0 then 0 else 1 / (t ^ n - 1)) := by
+    Summable (fun n : ℕ => if n = 0 then (0 : ℝ) else 1 / (t ^ n - 1)) := by
   sorry
 
 /-- The divisor series converges for t > 1. -/
 theorem D_summable (t : ℝ) (ht : t > 1) :
-    Summable (fun n : ℕ => if n = 0 then 0 else (τ n : ℝ) / t ^ n) := by
+    Summable (fun n : ℕ => if n = 0 then (0 : ℝ) else (τ n : ℝ) / t ^ n) := by
   sorry
 
 /-
@@ -102,13 +106,13 @@ theorem S_eq_D (t : ℝ) (ht : t > 1) : S t = D t := by
 
 /-- The double sum interpretation. -/
 theorem double_sum_identity (t : ℝ) (ht : t > 1) :
-    ∑' (d : ℕ) (m : ℕ), if d = 0 ∨ m = 0 then 0 else 1 / t ^ (d * m) =
-    ∑' n : ℕ, if n = 0 then 0 else (τ n : ℝ) / t ^ n := by
+    (∑' d : ℕ, ∑' m : ℕ, if d = 0 ∨ m = 0 then (0 : ℝ) else 1 / t ^ (d * m)) =
+    ∑' n : ℕ, if n = 0 then (0 : ℝ) else (τ n : ℝ) / t ^ n := by
   sorry
 
 /-- Geometric series for each d: ∑_{m≥1} 1/t^{dm} = 1/(t^d - 1). -/
 theorem geometric_divisor (t : ℝ) (d : ℕ) (ht : t > 1) (hd : d ≥ 1) :
-    ∑' m : ℕ, if m = 0 then 0 else 1 / t ^ (d * m) = 1 / (t ^ d - 1) := by
+    (∑' m : ℕ, if m = 0 then (0 : ℝ) else 1 / t ^ (d * m)) = 1 / (t ^ d - 1) := by
   sorry
 
 /-
@@ -130,7 +134,8 @@ theorem S_at_2_irrational : Irrational S_at_2 :=
 
 /-- S(2) starts with 1 + 1/3 + 1/7 + 1/15 + ... -/
 theorem S_at_2_first_terms :
-    S_at_2 = 1 + 1/3 + 1/7 + 1/15 + ∑' n : ℕ, if n ≤ 4 then 0 else 1 / (2^n - 1) := by
+    S_at_2 = 1 + 1/3 + 1/7 + 1/15 +
+    ∑' n : ℕ, if n ≤ 4 then (0 : ℝ) else 1 / ((2 : ℝ)^n - 1) := by
   sorry
 
 /-
@@ -203,8 +208,8 @@ The series is a Lambert series.
 -/
 
 /-- A Lambert series is ∑ a_n q^n/(1 - q^n). -/
-def isLambertSeries (f : ℕ → ℝ) (q : ℝ) : ℝ :=
-  ∑' n : ℕ, if n = 0 then 0 else f n * q^n / (1 - q^n)
+noncomputable def isLambertSeries (f : ℕ → ℝ) (q : ℝ) : ℝ :=
+  ∑' n : ℕ, if n = 0 then (0 : ℝ) else f n * q^n / (1 - q^n)
 
 /-- S(t) = Lambert series with a_n = 1 and q = 1/t. -/
 theorem S_as_lambert (t : ℝ) (ht : t > 1) :

--- a/proofs/Proofs/Erdos1070Problem.lean
+++ b/proofs/Proofs/Erdos1070Problem.lean
@@ -195,7 +195,29 @@ theorem f_from_chromatic : ∀ n : ℕ, (f n : ℝ) ≥ n / 7 := by
   intro n
   have h1 : (f n : ℝ) ≥ n / chromaticNumberPlane := independence_chromatic_relation n
   have h2 : chromaticNumberPlane ≤ 7 := chromatic_upper_bound
-  sorry -- Follows from h1 and h2
+  have h3 := de_grey_lower_bound  -- chromaticNumberPlane ≥ 5
+  have hχ_pos : (0 : ℝ) < (chromaticNumberPlane : ℝ) := by
+    exact_mod_cast (show 0 < chromaticNumberPlane by omega)
+  have hle : (↑chromaticNumberPlane : ℝ) ≤ 7 := by exact_mod_cast h2
+  have hfn_nonneg : (0 : ℝ) ≤ ↑(f n) := Nat.cast_nonneg
+  have hχ_ne : (↑chromaticNumberPlane : ℝ) ≠ 0 := ne_of_gt hχ_pos
+  -- Clear fraction in h1: n/χ ≤ f(n) → n ≤ f(n) * χ
+  have h1' : (↑n : ℝ) ≤ ↑(f n) * ↑chromaticNumberPlane := by
+    have h := (ge_iff_le.mp h1)
+    have := mul_le_mul_of_nonneg_right h (le_of_lt hχ_pos)
+    rwa [div_mul_cancel₀ _ hχ_ne] at this
+  -- n ≤ f(n) * 7 by transitivity
+  have hn7 : (↑n : ℝ) ≤ ↑(f n) * 7 := by
+    calc (↑n : ℝ) ≤ ↑(f n) * ↑chromaticNumberPlane := h1'
+      _ ≤ ↑(f n) * 7 := mul_le_mul_of_nonneg_left hle hfn_nonneg
+  -- Prove n/7 ≤ f(n) by multiplying hn7 by 7⁻¹
+  show (f n : ℝ) ≥ ↑n / 7
+  rw [ge_iff_le]
+  have h7inv : (0 : ℝ) ≤ (7 : ℝ)⁻¹ := by positivity
+  have key := mul_le_mul_of_nonneg_right hn7 h7inv
+  have eq1 : (↑(f n) : ℝ) * 7 * (7 : ℝ)⁻¹ = ↑(f n) := by ring
+  have eq2 : (↑n : ℝ) / 7 = ↑n * (7 : ℝ)⁻¹ := by ring
+  linarith
 
 /- ## Summary
 

--- a/proofs/Proofs/Erdos131Problem.lean
+++ b/proofs/Proofs/Erdos131Problem.lean
@@ -38,6 +38,8 @@ import Mathlib
 
 namespace Erdos131
 
+open scoped Classical
+
 /- ## Basic Definitions -/
 
 /-- A set A is non-dividing if no a ∈ A divides the sum of any
@@ -170,13 +172,26 @@ theorem two_three_nondividing : IsNonDividing {2, 3} := by
   intro a ha S hS hCard
   simp only [Finset.mem_insert, Finset.mem_singleton] at ha
   rcases ha with rfl | rfl
-  · -- a = 2: need to show 2 ∤ sum of subset of {3}
-    -- S ⊆ {2,3}.erase 2 = {3}, but |S| ≥ 2, contradiction
-    simp at hS
-    sorry
-  · -- a = 3: need to show 3 ∤ sum of subset of {2}
-    simp at hS
-    sorry
+  · -- a = 2: S ⊆ {2,3}.erase 2 = {3}, but |S| ≥ 2, contradiction
+    have hle : S.card ≤ 1 := by
+      have : S ⊆ {3} := by
+        intro x hx
+        have := hS hx
+        simp [Finset.mem_erase] at this
+        exact this.2
+      calc S.card ≤ ({3} : Finset ℕ).card := Finset.card_le_card this
+        _ = 1 := by rfl
+    omega
+  · -- a = 3: S ⊆ {2,3}.erase 3 = {2}, but |S| ≥ 2, contradiction
+    have hle : S.card ≤ 1 := by
+      have : S ⊆ {2} := by
+        intro x hx
+        have := hS hx
+        simp [Finset.mem_erase] at this
+        exact this.2
+      calc S.card ≤ ({2} : Finset ℕ).card := Finset.card_le_card this
+        _ = 1 := by rfl
+    omega
 
 /-- Primes form a non-dividing set in their range -/
 theorem primes_nondividing_example :

--- a/proofs/Proofs/Erdos175Problem.lean
+++ b/proofs/Proofs/Erdos175Problem.lean
@@ -22,11 +22,7 @@
   Tags: binomial-coefficients, squarefree, prime-powers, number-theory
 -/
 
-import Mathlib.Data.Nat.Choose.Basic
-import Mathlib.Data.Nat.Prime.Basic
-import Mathlib.Data.Nat.Squarefree
-import Mathlib.NumberTheory.Padics.PadicVal
-import Mathlib.Data.Real.Basic
+import Mathlib
 
 namespace Erdos175
 
@@ -47,7 +43,7 @@ def IsSquarefree (m : ℕ) : Prop :=
 
 /-- The maximum prime power exponent dividing C(2n, n) -/
 noncomputable def maxPrimePowerExp (n : ℕ) : ℕ :=
-  Nat.find ⟨1, fun _ _ => rfl⟩
+  Nat.find (⟨1, trivial⟩ : ∃ _ : ℕ, True)
 
 /-
 ## Part 2: Divisibility by 4
@@ -59,7 +55,7 @@ noncomputable def maxPrimePowerExp (n : ℕ) : ℕ :=
 axiom kummer_theorem (p m n : ℕ) (hp : Nat.Prime p) :
     padicValNat p (Nat.choose (m + n) m) =
     -- number of carries in base-p addition of m and n
-    Classical.choose (⟨0, fun _ => rfl⟩ : ∃ k : ℕ, True)
+    Classical.choose (⟨0, trivial⟩ : ∃ k : ℕ, True)
 
 /-- For C(2n, n), v_2 = number of 1s in binary expansion of n -/
 axiom v2_central_binom (n : ℕ) :
@@ -101,7 +97,7 @@ f(n) = max{k : p^k | C(2n,n) for some prime p}.
 /-- Maximum prime power exponent dividing a number -/
 noncomputable def f (n : ℕ) : ℕ :=
   -- max over primes p of v_p(C(2n, n))
-  Nat.find ⟨1, fun _ _ => rfl⟩
+  Nat.find (⟨1, trivial⟩ : ∃ _ : ℕ, True)
 
 /-- f(n) → ∞ as n → ∞ (Sander 1992) -/
 axiom sander_1992_f_unbounded :
@@ -140,7 +136,8 @@ axiom power_of_two_odd_prime_square (k : ℕ) (hk : k ≥ 3) :
 /-- The key cases: n = 8, 16, 32, ... -/
 example : ¬IsSquarefree (centralBinom 8) := by
   -- C(16, 8) = 12870 = 2 × 3² × 5 × 11 × 13
-  sorry
+  intro h
+  exact h 3 (by norm_num) (by native_decide)
 
 /-
 ## Part 6: Related Results

--- a/proofs/Proofs/Erdos34Problem.lean
+++ b/proofs/Proofs/Erdos34Problem.lean
@@ -197,7 +197,11 @@ theorem S_upper_bound (n : ℕ) (π : Perm n) :
 theorem consecutiveSum_pos (n : ℕ) (hn : n ≥ 1) (π : Perm n)
     (u v : Fin n) (huv : u ≤ v) :
     consecutiveSum n π u v ≥ 1 := by
-  sorry
+  simp only [consecutiveSum, if_pos huv]
+  have hne : (Finset.Icc u v).Nonempty := ⟨u, Finset.mem_Icc.mpr ⟨le_refl u, huv⟩⟩
+  have := Finset.sum_pos (fun i (_ : i ∈ Finset.Icc u v) =>
+    show 0 < (π i).val + 1 from Nat.succ_pos _) hne
+  omega
 
 /-
 ## Summary

--- a/proofs/Proofs/Erdos371Problem.lean
+++ b/proofs/Proofs/Erdos371Problem.lean
@@ -25,49 +25,60 @@
   Tags: number-theory, prime-factors, density, analytic-number-theory
 -/
 
-import Mathlib.NumberTheory.Primorial
-import Mathlib.Data.Nat.Prime.Basic
-import Mathlib.Analysis.SpecialFunctions.Log.Basic
-import Mathlib.Topology.Instances.Real
-import Mathlib.Tactic
+import Mathlib
 
 namespace Erdos371
 
-open Nat Real Filter Finset
+open scoped Classical
+open Nat Real Filter Finset Topology
 
 /- ## Part I: Greatest Prime Factor -/
 
 /-- The greatest prime factor of n, or 0 if n ≤ 1. -/
 noncomputable def P (n : ℕ) : ℕ :=
   if h : n ≤ 1 then 0
-  else (n.primeFactors).max' (Nat.primeFactors_nonempty (Nat.one_lt_iff_ne_one.mpr
-    (fun hn => h (le_of_eq hn))))
+  else (n.primeFactors).max' (by
+    rw [Finset.nonempty_iff_ne_empty]
+    intro he
+    have h1 : 1 < n := by omega
+    have ⟨p, hp, hpd⟩ := Nat.exists_prime_and_dvd (by omega : n ≠ 1)
+    exact absurd (Nat.mem_primeFactors.mpr ⟨hp, hpd, by omega⟩) (he ▸ Finset.not_mem_empty p))
 
 /-- P(n) divides n for n > 1. -/
 theorem P_dvd (n : ℕ) (hn : n > 1) : P n ∣ n := by
-  sorry
+  have h : ¬(n ≤ 1) := by omega
+  simp only [P, dif_neg h]
+  exact (Nat.mem_primeFactors.mp (Finset.max'_mem _ _)).2.1
 
 /-- P(n) is prime for n > 1. -/
 theorem P_prime (n : ℕ) (hn : n > 1) : (P n).Prime := by
-  sorry
+  have h : ¬(n ≤ 1) := by omega
+  simp only [P, dif_neg h]
+  exact (Nat.mem_primeFactors.mp (Finset.max'_mem _ _)).1
 
 /-- P(n) is the maximum prime dividing n. -/
 theorem P_is_max (n : ℕ) (hn : n > 1) (p : ℕ) (hp : p.Prime) (hdvd : p ∣ n) :
     p ≤ P n := by
-  sorry
+  have h : ¬(n ≤ 1) := by omega
+  simp only [P, dif_neg h]
+  exact Finset.le_max' _ _ (Nat.mem_primeFactors.mpr ⟨hp, hdvd, by omega⟩)
 
 /-- P(p) = p for prime p. -/
 theorem P_prime_eq (p : ℕ) (hp : p.Prime) : P p = p := by
-  sorry
+  apply le_antisymm
+  · exact Nat.le_of_dvd hp.pos (P_dvd p hp.one_lt)
+  · exact P_is_max p hp.one_lt p hp (dvd_refl p)
 
 /-- P(n) ≤ n for all n. -/
 theorem P_le (n : ℕ) : P n ≤ n := by
-  sorry
+  by_cases h : n ≤ 1
+  · simp [P, h]
+  · exact Nat.le_of_dvd (by omega) (P_dvd n (by omega))
 
 /- ## Part II: Natural Density -/
 
 /-- The counting function for a set of naturals. -/
-def countingFunction (S : Set ℕ) (x : ℕ) : ℕ :=
+noncomputable def countingFunction (S : Set ℕ) (x : ℕ) : ℕ :=
   (Finset.range x).filter (· ∈ S) |>.card
 
 /-- A set has natural density d if #{n < x : n ∈ S}/x → d. -/
@@ -247,31 +258,55 @@ theorem theoretical_density_zero :
 /- ## Part XII: Small Examples -/
 
 /-- P(2) = 2. -/
-theorem P_2 : P 2 = 2 := by sorry
+theorem P_2 : P 2 = 2 := P_prime_eq 2 (by norm_num)
 
 /-- P(3) = 3. -/
-theorem P_3 : P 3 = 3 := by sorry
+theorem P_3 : P 3 = 3 := P_prime_eq 3 (by norm_num)
 
 /-- P(4) = 2. -/
-theorem P_4 : P 4 = 2 := by sorry
+theorem P_4 : P 4 = 2 := by
+  have hp := P_prime 4 (by omega)
+  have hdvd := P_dvd 4 (by omega)
+  have h4 : (4 : ℕ) = 2 ^ 2 := by norm_num
+  rw [h4] at hdvd
+  have hdvd2 : P 4 ∣ 2 := hp.dvd_of_dvd_pow hdvd
+  have hle : P 4 ≤ 2 := Nat.le_of_dvd (by omega) hdvd2
+  have hge : P 4 ≥ 2 := hp.two_le
+  omega
 
 /-- P(5) = 5. -/
-theorem P_5 : P 5 = 5 := by sorry
+theorem P_5 : P 5 = 5 := P_prime_eq 5 (by norm_num)
 
 /-- P(6) = 3. -/
-theorem P_6 : P 6 = 3 := by sorry
+theorem P_6 : P 6 = 3 := by
+  have hp := P_prime 6 (by omega)
+  have hdvd := P_dvd 6 (by omega)
+  apply le_antisymm
+  · -- P(6) ≤ 3: P(6) is prime and divides 6 = 2 * 3
+    have h6 : (6 : ℕ) = 2 * 3 := by norm_num
+    rw [h6] at hdvd
+    rcases hp.dvd_mul.mp hdvd with h2 | h3
+    · exact le_trans (Nat.le_of_dvd (by omega) h2) (by omega)
+    · exact Nat.le_of_dvd (by omega) h3
+  · exact P_is_max 6 (by omega) 3 (by norm_num) (by norm_num)
 
 /-- 2 ∈ SetPIncreasing since P(2) = 2 < P(3) = 3. -/
 theorem two_in_set : 2 ∈ SetPIncreasing := by
-  sorry
+  constructor
+  · omega
+  · rw [P_2, P_3]; omega
 
 /-- 4 ∈ SetPIncreasing since P(4) = 2 < P(5) = 5. -/
 theorem four_in_set : 4 ∈ SetPIncreasing := by
-  sorry
+  constructor
+  · omega
+  · rw [P_4, P_5]; omega
 
 /-- 5 ∈ SetPDecreasing since P(5) = 5 > P(6) = 3. -/
 theorem five_in_complement : 5 ∈ SetPDecreasing := by
-  sorry
+  constructor
+  · omega
+  · rw [P_5, P_6]; omega
 
 /- ## Part XIII: Related Problems -/
 
@@ -293,7 +328,10 @@ def isOEIS_A070089 (n : ℕ) : Prop := n ∈ SetPIncreasing
 theorem even_often_in_set (n : ℕ) (hn : n ≥ 2) (heven : Even n)
     (hodd_next : Odd (n + 1)) (hn1_prime : (n + 1).Prime) :
     n ∈ SetPIncreasing := by
-  sorry
+  refine ⟨hn, ?_⟩
+  calc P n ≤ n := P_le n
+    _ < n + 1 := by omega
+    _ = P (n + 1) := (P_prime_eq (n + 1) hn1_prime).symm
 
 end Erdos371
 

--- a/proofs/Proofs/Erdos451Problem.lean
+++ b/proofs/Proofs/Erdos451Problem.lean
@@ -18,23 +18,20 @@ n_8=22, n_9=65, n_10=220, n_12=338, n_20=550.
 Reference: https://erdosproblems.com/451
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Nat.Prime.Basic
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Rat.Basic
-import Mathlib.Tactic
+import Mathlib
 
-open Finset in
+open Finset Real
+
 /-- The product (n-1)(n-2)⋯(n-k) for n > k. -/
 def descendingProduct (n k : ℕ) : ℕ :=
-    (Icc 1 k).prod (fun i => n - i)
+    (Finset.Icc 1 k).prod (fun i => n - i)
 
 /-- A prime p is in the interval (k, 2k). -/
 def IsInBertrandRange (p k : ℕ) : Prop :=
     k < p ∧ p < 2 * k ∧ p.Prime
 
-instance : DecidablePred (fun p => IsInBertrandRange p k) :=
-  fun p => And.decidable
+instance (p k : ℕ) : Decidable (IsInBertrandRange p k) :=
+  show Decidable (k < p ∧ p < 2 * k ∧ p.Prime) from inferInstance
 
 /-- The product has no prime factor in (k, 2k). -/
 def AvoidsBertrandPrimes (n k : ℕ) : Prop :=
@@ -64,70 +61,94 @@ axiom nk_avoids (k : ℕ) (hk : 1 ≤ k) : AvoidsBertrandPrimes (nk k) k
 axiom nk_minimal (k : ℕ) (hk : 1 ≤ k) (n : ℕ) (hn : 2 * k < n)
     (ha : AvoidsBertrandPrimes n k) : nk k ≤ n
 
-/- ## CRT structural lemmas
-
-For prime p in (k, 2k), the product (n-1)(n-2)⋯(n-k) is divisible by p
-iff at least one of n-1, n-2, ..., n-k is divisible by p. Since k < p,
-at most one of these k consecutive integers can be divisible by p.
-
-So p | ∏(n-i) iff n ≡ j (mod p) for some j ∈ {1, ..., k}.
-To avoid p, we need n mod p ∈ {0, k+1, k+2, ..., p-1}. -/
+/- ## CRT structural lemmas -/
 
 /-- For prime p > k, at most one of n-1, ..., n-k is divisible by p.
     If p | (n-i) and p | (n-j) then p | (i-j), but |i-j| < k < p. -/
 theorem at_most_one_div (n k p : ℕ) (hp : Nat.Prime p) (hpk : k < p)
     (i j : ℕ) (hi : i ∈ Finset.Icc 1 k) (hj : j ∈ Finset.Icc 1 k)
     (hdi : p ∣ (n - i)) (hdj : p ∣ (n - j)) (hn : k < n) :
-    i = j := by sorry
+    i = j := by
+  rw [Finset.mem_Icc] at hi hj
+  by_contra hij
+  rcases Nat.lt_or_gt_of_ne hij with h | h
+  · -- Case i < j
+    have hdiff : p ∣ (n - i) - (n - j) := Nat.dvd_sub hdi hdj
+    have heq : (n - i) - (n - j) = j - i := by omega
+    rw [heq] at hdiff
+    exact absurd (Nat.le_of_dvd (by omega) hdiff) (by omega)
+  · -- Case j < i
+    have hdiff : p ∣ (n - j) - (n - i) := Nat.dvd_sub hdj hdi
+    have heq : (n - j) - (n - i) = i - j := by omega
+    rw [heq] at hdiff
+    exact absurd (Nat.le_of_dvd (by omega) hdiff) (by omega)
 
 /-- p divides the descending product iff p divides some factor. -/
 theorem prime_dvd_descendingProduct (n k p : ℕ) (hp : Nat.Prime p)
-    (hn : k < n) :
+    (_hn : k < n) :
     p ∣ descendingProduct n k ↔
-    ∃ i ∈ Finset.Icc 1 k, p ∣ (n - i) := by sorry
+    ∃ i ∈ Finset.Icc 1 k, p ∣ (n - i) := by
+  simp only [descendingProduct]
+  constructor
+  · intro h
+    have hprime : Prime p := hp.prime
+    have : ∃ i ∈ Finset.Icc 1 k, p ∣ (fun i => n - i) i := by
+      exact hprime.exists_mem_finset_dvd h
+    simpa using this
+  · intro ⟨i, hi, hd⟩
+    exact dvd_trans hd (Finset.dvd_prod_of_mem _ hi)
 
 /-- The number of safe residues is p - k when k < p < 2k. -/
-theorem card_safeResidues (k p : ℕ) (hp : Nat.Prime p) (hpk : k < p)
+theorem card_safeResidues (k p : ℕ) (_hp : Nat.Prime p) (hpk : k < p)
     (hpk2 : p < 2 * k) :
-    (safeResidues k p).card = p - k := by sorry
+    (safeResidues k p).card = p - k := by
+  simp only [safeResidues]
+  have h0_notin : (0 : ℕ) ∉ Finset.Icc (k + 1) (p - 1) := by
+    simp only [Finset.mem_Icc]; omega
+  have hdisj : Disjoint ({0} : Finset ℕ) (Finset.Icc (k + 1) (p - 1)) := by
+    rw [Finset.disjoint_left]
+    intro x hx
+    rw [Finset.mem_singleton] at hx
+    subst hx; exact h0_notin
+  rw [Finset.card_union_of_disjoint hdisj, Finset.card_singleton, Nat.card_Icc]
+  omega
 
 /- ## Known bounds -/
 
 /-- Erdős–Graham lower bound: n_k > k^{1+c} for some constant c > 0. -/
 axiom erdos_graham_lower :
-    ∃ c : ℚ, 0 < c ∧ ∃ k₀ : ℕ, ∀ k : ℕ, k₀ ≤ k →
-      (k : ℚ) ^ (1 + c) < (nk k : ℚ)
+    ∃ c : ℝ, 0 < c ∧ ∃ k₀ : ℕ, ∀ k : ℕ, k₀ ≤ k →
+      (k : ℝ) ^ (1 + c) < (nk k : ℝ)
 
 /-- Adenwalla upper bound: n_k ≤ ∏_{k < p < 2k} p = e^{O(k)}.
     By CRT, taking n ≡ 0 (mod p) for all primes p in (k,2k). -/
 axiom adenwalla_upper :
-    ∃ C : ℚ, 0 < C ∧ ∃ k₀ : ℕ, ∀ k : ℕ, k₀ ≤ k →
-      (nk k : ℚ) ≤ (2 : ℚ) ^ (C * (k : ℚ))
+    ∃ C : ℝ, 0 < C ∧ ∃ k₀ : ℕ, ∀ k : ℕ, k₀ ≤ k →
+      (nk k : ℝ) ≤ (2 : ℝ) ^ (C * (k : ℝ))
 
 /-- The trivial lower bound: n_k > 2k (by definition). -/
-theorem nk_trivial_lower (k : ℕ) (hk : 1 ≤ k) : (2 * k : ℚ) < (nk k : ℚ) := by
+theorem nk_trivial_lower (k : ℕ) (hk : 1 ≤ k) : (2 * k : ℝ) < (nk k : ℝ) := by
   have := nk_gt_2k k hk
   exact_mod_cast this
 
 /-- Adenwalla's bound via CRT: n_k ≤ product of primes in (k, 2k). -/
-theorem adenwalla_crt_idea (k : ℕ) (hk : 1 ≤ k) :
-    let M := (bertrandPrimes k).prod id
-    2 * k < M →
-    AvoidsBertrandPrimes M k →
-    nk k ≤ M :=
-  fun hM hAvoids => nk_minimal k hk M hM hAvoids
+theorem adenwalla_crt_idea (k : ℕ) (hk : 1 ≤ k)
+    (hM : 2 * k < (bertrandPrimes k).prod id)
+    (hAvoids : AvoidsBertrandPrimes ((bertrandPrimes k).prod id) k) :
+    nk k ≤ (bertrandPrimes k).prod id :=
+  nk_minimal k hk _ hM hAvoids
 
 /- ## Main conjectures (OPEN) -/
 
 /-- Conjecture 1: n_k > k^d for every constant d. -/
 def ErdosProblem451_superpolynomial : Prop :=
-    ∀ (d : ℚ) (hd : 0 < d), ∃ k₀ : ℕ, ∀ k : ℕ, k₀ ≤ k →
-      (k : ℚ) ^ d < (nk k : ℚ)
+    ∀ (d : ℝ) (_ : 0 < d), ∃ k₀ : ℕ, ∀ k : ℕ, k₀ ≤ k →
+      (k : ℝ) ^ d < (nk k : ℝ)
 
 /-- Conjecture 2: n_k < e^{o(k)}, i.e. n_k is sub-exponential. -/
 def ErdosProblem451_subexponential : Prop :=
-    ∀ (ε : ℚ) (hε : 0 < ε), ∃ k₀ : ℕ, ∀ k : ℕ, k₀ ≤ k →
-      (nk k : ℚ) < (2 : ℚ) ^ (ε * (k : ℚ))
+    ∀ (ε : ℝ) (_ : 0 < ε), ∃ k₀ : ℕ, ∀ k : ℕ, k₀ ≤ k →
+      (nk k : ℝ) < (2 : ℝ) ^ (ε * (k : ℝ))
 
 /-- Erdős Problem 451: n_k is superpolynomial but sub-exponential. -/
 def ErdosProblem451 : Prop :=

--- a/proofs/Proofs/Erdos541Problem.lean
+++ b/proofs/Proofs/Erdos541Problem.lean
@@ -53,20 +53,6 @@ The intuition: if there are 3 or more distinct values, one can construct
 zero-sum subsets of different sizes by mixing elements appropriately.
 -/
 
-/-- **Graham's Conjecture** (Erdős Problem #541)
-
-If a sequence of p residues modulo p has the property that all nonempty
-zero-sum subsets have the same cardinality, then at most 2 distinct
-residues appear in the sequence.
-
-This was first posed by Graham, proved for large p by Erdős-Szemerédi (1976),
-and fully resolved by Gao-Hamidoune-Wang (2010). -/
-theorem graham_conjecture (p : ℕ) [hp : Fact p.Prime] (a : Fin p → ZMod p)
-    (h : HasSomeUniqueZeroSumLength p a) : distinctCount p a ≤ 2 := by
-  -- The full proof uses combinatorial arguments about zero-sum sequences
-  -- and was resolved by Gao, Hamidoune, and Wang in 2010
-  sorry
-
 /-
 ## Special Cases and Variants
 -/
@@ -81,6 +67,20 @@ axiom erdos_szemeredi_large_primes :
 This is the most general form of Graham's conjecture. -/
 axiom gao_hamidoune_wang (n : ℕ) (a : Fin n → ZMod n)
     (h : HasSomeUniqueZeroSumLength n a) : distinctCount n a ≤ 2
+
+/-- **Graham's Conjecture** (Erdős Problem #541)
+
+If a sequence of p residues modulo p has the property that all nonempty
+zero-sum subsets have the same cardinality, then at most 2 distinct
+residues appear in the sequence.
+
+This was first posed by Graham, proved for large p by Erdős-Szemerédi (1976),
+and fully resolved by Gao-Hamidoune-Wang (2010).
+
+Follows directly from the general result of Gao-Hamidoune-Wang. -/
+theorem graham_conjecture (p : ℕ) [hp : Fact p.Prime] (a : Fin p → ZMod p)
+    (h : HasSomeUniqueZeroSumLength p a) : distinctCount p a ≤ 2 :=
+  gao_hamidoune_wang p a h
 
 /-
 ## Examples

--- a/proofs/Proofs/Erdos673Problem.lean
+++ b/proofs/Proofs/Erdos673Problem.lean
@@ -20,11 +20,7 @@
   Tags: number-theory, divisors, analytic-number-theory
 -/
 
-import Mathlib.NumberTheory.Divisors
-import Mathlib.NumberTheory.ArithmeticFunction
-import Mathlib.Data.Real.Basic
-import Mathlib.Topology.Instances.Real
-import Mathlib.Tactic
+import Mathlib
 
 namespace Erdos673
 
@@ -62,7 +58,8 @@ noncomputable def G (n : ℕ) : ℝ :=
 
 /-- G(1) = 0 (no consecutive pairs). -/
 theorem G_one : G 1 = 0 := by
-  sorry
+  unfold G tau
+  simp [Nat.divisors_one]
 
 /-- G(p) = 1/p for prime p. -/
 theorem G_prime (p : ℕ) (hp : p.Prime) : G p = 1 / p := by

--- a/proofs/Proofs/Erdos703Problem.lean
+++ b/proofs/Proofs/Erdos703Problem.lean
@@ -109,7 +109,16 @@ theorem large_sets_avoid_1 (n : ℕ) (A B : Finset ℕ)
     (hA : A ⊆ Finset.range n) (hB : B ⊆ Finset.range n)
     (hAsize : A.card > (n + 1) / 2) (hBsize : B.card > (n + 1) / 2) :
     (A ∩ B).card ≠ 1 := by
-  sorry
+  intro h
+  -- By inclusion-exclusion: |A ∪ B| + |A ∩ B| = |A| + |B|
+  have hie := Finset.card_union_add_card_inter A B
+  -- |A ∪ B| ≤ n since A, B ⊆ range n
+  have hunion : (A ∪ B).card ≤ n := by
+    calc (A ∪ B).card ≤ (Finset.range n).card :=
+          Finset.card_le_card (Finset.union_subset hA hB)
+      _ = n := Finset.card_range n
+  -- |A| + |B| = |A ∪ B| + 1 ≤ n + 1, but |A| + |B| > n + 1. Contradiction.
+  omega
 
 /-
 ## Part IV: Frankl-Füredi Optimal Families

--- a/proofs/Proofs/NavierStokesAristotle.lean
+++ b/proofs/Proofs/NavierStokesAristotle.lean
@@ -18,67 +18,67 @@ namespace NavierStokesAristotle
 -- ═══════════════════════════════════════════════════════════════════
 
 /-- Sobolev conjugate in 3D: p* = 3p/(3-p). For p=2: p*=6 -/
-theorem sobolev_star_p2 : 3 * (2 : ℚ) / (3 - 2) = 6 := by sorry
+theorem sobolev_star_p2 : 3 * (2 : ℚ) / (3 - 2) = 6 := by norm_num
 
 /-- For p=3/2: p*=3 (critical for NS) -/
-theorem sobolev_star_p32 : 3 * (3 / 2 : ℚ) / (3 - 3 / 2) = 3 := by sorry
+theorem sobolev_star_p32 : 3 * (3 / 2 : ℚ) / (3 - 3 / 2) = 3 := by norm_num
 
 /-- For p=1: p*=3/2 -/
-theorem sobolev_star_p1 : 3 * (1 : ℚ) / (3 - 1) = 3 / 2 := by sorry
+theorem sobolev_star_p1 : 3 * (1 : ℚ) / (3 - 1) = 3 / 2 := by norm_num
 
 /-- For p=6/5: p*=2 -/
-theorem sobolev_star_p65 : 3 * (6 / 5 : ℚ) / (3 - 6 / 5) = 2 := by sorry
+theorem sobolev_star_p65 : 3 * (6 / 5 : ℚ) / (3 - 6 / 5) = 2 := by norm_num
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 2: Serrin Exponent Pairs
 -- ═══════════════════════════════════════════════════════════════════
 
 /-- Serrin condition: 2/q + 3/p = 1. Check p=6, q=3 -/
-theorem serrin_p6_q3 : 2 / (3 : ℚ) + 3 / 6 = 1 := by sorry
+theorem serrin_p6_q3 : 2 / (3 : ℚ) + 3 / 6 = 1 := by sorry -- statement is false: 2/3 + 1/2 = 7/6 ≠ 1
 
 /-- Check p=4, q=8: 2/8 + 3/4 = 1/4 + 3/4 = 1 -/
-theorem serrin_p4_q8 : 2 / (8 : ℚ) + 3 / 4 = 1 := by sorry
+theorem serrin_p4_q8 : 2 / (8 : ℚ) + 3 / 4 = 1 := by norm_num
 
 /-- Check p=∞ (formally), q=2: 2/2 + 0 = 1 -/
-theorem serrin_pinf_q2 : 2 / (2 : ℚ) + 0 = 1 := by sorry
+theorem serrin_pinf_q2 : 2 / (2 : ℚ) + 0 = 1 := by norm_num
 
 /-- Check energy space: 2/2 + 3/6 = 1 + 1/2 = 3/2 (NOT ≤ 1, so insufficient) -/
-theorem energy_serrin_value : 2 / (2 : ℚ) + 3 / 6 = 3 / 2 := by sorry
+theorem energy_serrin_value : 2 / (2 : ℚ) + 3 / 6 = 3 / 2 := by norm_num
 
 /-- The Serrin gap: 3/2 - 1 = 1/2 -/
-theorem serrin_gap : (3 : ℚ) / 2 - 1 = 1 / 2 := by sorry
+theorem serrin_gap : (3 : ℚ) / 2 - 1 = 1 / 2 := by norm_num
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 3: Kolmogorov Scaling Relations
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- K41 energy spectrum exponent: E(k) ~ k^{-5/3} -/
--- The exponent -5/3 satisfies dimensional analysis:
--- [E(k)] = [velocity²/wavenumber] = L³/T², [k] = 1/L
--- E(k) = C_K ε^{2/3} k^{-5/3}: check dimensions
+/- K41 energy spectrum exponent: E(k) ~ k^{-5/3}
+   The exponent -5/3 satisfies dimensional analysis:
+   [E(k)] = [velocity²/wavenumber] = L³/T², [k] = 1/L
+   E(k) = C_K ε^{2/3} k^{-5/3}: check dimensions -/
 
-/-- K41 dissipation scale: η = (ν³/ε)^{1/4} -/
--- This is the Kolmogorov microscale
+/- K41 dissipation scale: η = (ν³/ε)^{1/4}
+   This is the Kolmogorov microscale -/
 
-/-- Reynolds number scaling: Re = UL/ν -/
--- Re is dimensionless
+/- Reynolds number scaling: Re = UL/ν
+   Re is dimensionless -/
 
 /-- Kolmogorov 4/5 law exponent check: 4 + 1 = 5 -/
-theorem kolmogorov_45 : 4 + 1 = (5 : ℕ) := by sorry
+theorem kolmogorov_45 : 4 + 1 = (5 : ℕ) := by norm_num
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 4: Onsager Conjecture Threshold
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- Onsager critical exponent: α = 1/3 -/
--- For Hölder C^α solutions:
--- α > 1/3: energy is conserved (Constantin-E-Titi 1994)
--- α < 1/3: energy can dissipate (Isett 2018)
+/- Onsager critical exponent: α = 1/3
+   For Hölder C^α solutions:
+   α > 1/3: energy is conserved (Constantin-E-Titi 1994)
+   α < 1/3: energy can dissipate (Isett 2018) -/
 
 /-- K41-Onsager connection: spectrum 5/3 ↔ Hölder 1/3 -/
 -- E(k) ~ k^{-5/3} ⟹ velocity increments |δu(r)| ~ r^{1/3}
 -- Exponent relation: (5/3 - 1)/2 = 1/3
-theorem onsager_k41_connection : ((5 : ℚ) / 3 - 1) / 2 = 1 / 3 := by sorry
+theorem onsager_k41_connection : ((5 : ℚ) / 3 - 1) / 2 = 1 / 3 := by norm_num
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 5: She-Lévêque Intermittency Model
@@ -87,14 +87,14 @@ theorem onsager_k41_connection : ((5 : ℚ) / 3 - 1) / 2 = 1 / 3 := by sorry
 /-- She-Lévêque: ζ_p = p/9 + 2(1 - (2/3)^{p/3}) -/
 -- Check ζ_3 = 1:
 -- ζ_3 = 3/9 + 2(1 - 2/3) = 1/3 + 2/3 = 1
-theorem she_levesque_zeta3 : (3 : ℚ) / 9 + 2 * (1 - 2 / 3) = 1 := by sorry
+theorem she_levesque_zeta3 : (3 : ℚ) / 9 + 2 * (1 - 2 / 3) = 1 := by norm_num
 
 /-- Check ζ_6 = 16/9:
     ζ_6 = 6/9 + 2(1 - (2/3)²) = 2/3 + 2(1 - 4/9) = 2/3 + 10/9 = 16/9 -/
-theorem she_levesque_zeta6 : (6 : ℚ) / 9 + 2 * (1 - (2 / 3) ^ 2) = 16 / 9 := by sorry
+theorem she_levesque_zeta6 : (6 : ℚ) / 9 + 2 * (1 - (2 / 3) ^ 2) = 16 / 9 := by norm_num
 
 /-- Intermittency correction at p=6: ζ_6 - p/3 = 16/9 - 2 = -2/9 -/
-theorem intermittency_correction_6 : (16 : ℚ) / 9 - 2 = -2 / 9 := by sorry
+theorem intermittency_correction_6 : (16 : ℚ) / 9 - 2 = -2 / 9 := by norm_num
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 6: Besov Space Exponents
@@ -102,60 +102,64 @@ theorem intermittency_correction_6 : (16 : ℚ) / 9 - 2 = -2 / 9 := by sorry
 
 /-- Critical Besov smoothness: s_crit = -1 + 3/p -/
 -- For p=2: s_crit = -1 + 3/2 = 1/2
-theorem besov_crit_p2 : -1 + 3 / (2 : ℚ) = 1 / 2 := by sorry
+theorem besov_crit_p2 : -1 + 3 / (2 : ℚ) = 1 / 2 := by norm_num
 
 -- For p=3: s_crit = -1 + 1 = 0
-theorem besov_crit_p3 : -1 + 3 / (3 : ℚ) = 0 := by sorry
+theorem besov_crit_p3 : -1 + 3 / (3 : ℚ) = 0 := by norm_num
 
 -- For p=∞ (formally): s_crit = -1 + 0 = -1
-theorem besov_crit_pinf : -1 + (0 : ℚ) = -1 := by sorry
+theorem besov_crit_pinf : -1 + (0 : ℚ) = -1 := by norm_num
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 7: Caffarelli-Kohn-Nirenberg Partial Regularity
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- CKN: singular set has parabolic Hausdorff dimension ≤ 1 -/
--- The parabolic dimension counts time as 2 spatial dimensions:
--- dim_p = dim_space + 2·dim_time
--- For points: dim_p = 0, for curves: dim_p = 1 or 2
+/- CKN: singular set has parabolic Hausdorff dimension ≤ 1
+   The parabolic dimension counts time as 2 spatial dimensions:
+   dim_p = dim_space + 2·dim_time
+   For points: dim_p = 0, for curves: dim_p = 1 or 2 -/
 
-/-- Parabolic scaling: [x] = 1, [t] = 2, so 1D set in spacetime
-    has parabolic dimension ≤ 1 -/
+/- Parabolic scaling: [x] = 1, [t] = 2, so 1D set in spacetime
+   has parabolic dimension ≤ 1 -/
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 8: Lions-Feireisl Threshold
 -- ═══════════════════════════════════════════════════════════════════
 
 /-- Lions gamma threshold: 9/5 = 1.8 -/
-theorem lions_gamma : (9 : ℚ) / 5 = 9 / 5 := by sorry
+theorem lions_gamma : (9 : ℚ) / 5 = 9 / 5 := by rfl
 
 /-- Feireisl improved to γ > 3/2 = 1.5 -/
-theorem feireisl_gamma : (3 : ℚ) / 2 = 3 / 2 := by sorry
+theorem feireisl_gamma : (3 : ℚ) / 2 = 3 / 2 := by rfl
 
 /-- 3/2 < 9/5: Feireisl is strictly weaker threshold -/
-theorem feireisl_weaker : (3 : ℚ) / 2 < 9 / 5 := by sorry
+theorem feireisl_weaker : (3 : ℚ) / 2 < 9 / 5 := by norm_num
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section 9: Real Analysis Supporting Lemmas
 -- ═══════════════════════════════════════════════════════════════════
 
 /-- Triangle inequality for real numbers -/
-theorem real_triangle (a b : ℝ) : |a + b| ≤ |a| + |b| := by sorry
+theorem real_triangle (a b : ℝ) : |a + b| ≤ |a| + |b| := by exact abs_add_le a b
 
 /-- Young's inequality: ab ≤ a^p/p + b^q/q for 1/p + 1/q = 1 -/
 -- For p=q=2: ab ≤ a²/2 + b²/2
-theorem young_p2 (a b : ℝ) : a * b ≤ a ^ 2 / 2 + b ^ 2 / 2 := by sorry
+theorem young_p2 (a b : ℝ) : a * b ≤ a ^ 2 / 2 + b ^ 2 / 2 := by nlinarith [sq_nonneg (a - b)]
 
 /-- Cauchy-Schwarz for sums (2 elements) -/
 theorem cauchy_schwarz_2 (a₁ a₂ b₁ b₂ : ℝ) :
-    (a₁ * b₁ + a₂ * b₂) ^ 2 ≤ (a₁ ^ 2 + a₂ ^ 2) * (b₁ ^ 2 + b₂ ^ 2) := by sorry
+    (a₁ * b₁ + a₂ * b₂) ^ 2 ≤ (a₁ ^ 2 + a₂ ^ 2) * (b₁ ^ 2 + b₂ ^ 2) := by
+  nlinarith [sq_nonneg (a₁ * b₂ - a₂ * b₁)]
 
 /-- AM-GM inequality: √(ab) ≤ (a+b)/2 for a,b ≥ 0 -/
 theorem am_gm (a b : ℝ) (ha : a ≥ 0) (hb : b ≥ 0) :
-    Real.sqrt (a * b) ≤ (a + b) / 2 := by sorry
+    Real.sqrt (a * b) ≤ (a + b) / 2 := by
+  have h1 : (a + b) / 2 ≥ 0 := by linarith
+  rw [← Real.sqrt_sq h1]
+  exact Real.sqrt_le_sqrt (by nlinarith [sq_nonneg (a - b)])
 
 /-- Power mean inequality: (a²+b²)/2 ≥ ((a+b)/2)² -/
 theorem power_mean_2 (a b : ℝ) :
-    (a ^ 2 + b ^ 2) / 2 ≥ ((a + b) / 2) ^ 2 := by sorry
+    (a ^ 2 + b ^ 2) / 2 ≥ ((a + b) / 2) ^ 2 := by nlinarith [sq_nonneg (a - b)]
 
 end NavierStokesAristotle

--- a/proofs/Proofs/RiemannHypothesis.lean
+++ b/proofs/Proofs/RiemannHypothesis.lean
@@ -738,22 +738,52 @@ non-trivial zeros come in quadruples: {ρ, conj(ρ), 1-ρ, 1-conj(ρ)}.
 Under RH, all four coincide on the critical line.
 -/
 
-/-- **Axiom: Conjugation symmetry of the Riemann zeta function**
+/-- For n : ℕ, the argument of (n : ℂ) is not π (since n ≥ 0 and arg(x) = 0 for x ≥ 0). -/
+private lemma natCast_arg_ne_pi (n : ℕ) : (n : ℂ).arg ≠ π := by
+  rw [natCast_arg]
+  exact ne_of_lt Real.pi_pos
+
+/-- For n : ℕ, conj((n : ℂ)^s) = (n : ℂ)^(conj s).
+Natural numbers are self-conjugate and have arg = 0 ≠ π. -/
+private lemma conj_natCast_cpow (n : ℕ) (s : ℂ) :
+    starRingEnd ℂ ((n : ℂ) ^ s) = (n : ℂ) ^ (starRingEnd ℂ s) := by
+  have h := cpow_conj (n : ℂ) s (natCast_arg_ne_pi n)
+  rw [conj_natCast] at h
+  exact h.symm
+
+/-- **Conjugation symmetry of ζ(s) for Re(s) > 1** (PROVEN)
+
+ζ(conj(s)) = conj(ζ(s)) when Re(s) > 1.
+
+**Proof**: In this region, ζ(s) = Σ 1/n^s converges absolutely. Conjugating
+term-by-term using:
+1. `conj_tsum`: conjugation commutes with convergent infinite sums
+2. `conj_natCast`: natural numbers are self-conjugate (conj(n) = n)
+3. `cpow_conj`: for non-negative real x with arg ≠ π, conj(x^s) = x^(conj s)
+
+This gives conj(Σ 1/n^s) = Σ 1/n^(conj s) = ζ(conj s). -/
+theorem zeta_conj_of_one_lt_re {s : ℂ} (hs : 1 < s.re) :
+    riemannZeta (starRingEnd ℂ s) = starRingEnd ℂ (riemannZeta s) := by
+  have hs' : 1 < (starRingEnd ℂ s).re := by rwa [Complex.conj_re]
+  rw [zeta_eq_tsum_one_div_nat_cpow hs, zeta_eq_tsum_one_div_nat_cpow hs',
+      Complex.conj_tsum]
+  congr 1
+  ext n
+  simp only [map_div₀, map_one, conj_natCast_cpow]
+
+/-- **Axiom: Conjugation symmetry of the Riemann zeta function (full)**
 
 ζ(conj(s)) = conj(ζ(s)) for all s ∈ ℂ.
 
-This follows from the fact that the Dirichlet series ζ(s) = Σ n^(-s) has real
-coefficients (all equal to 1), so conj(n^(-s)) = n^(-conj(s)). For Re(s) > 1 this
-is immediate from term-by-term conjugation of the absolutely convergent series.
-The identity extends to all s by the identity theorem for holomorphic functions.
-
-**Status**: Not yet in Mathlib but mathematically straightforward. The completed zeta
-function is defined via the Hurwitz zeta function and Gamma function, both of which
-satisfy analogous conjugation identities.
+**Partially proved**: `zeta_conj_of_one_lt_re` proves this for Re(s) > 1 via the
+Dirichlet series. The full result extends to all s by the identity theorem for
+holomorphic functions: both sides are meromorphic on ℂ \ {1} and agree on the
+half-plane Re(s) > 1. Formalizing the identity theorem argument requires showing
+that conj ∘ ζ ∘ conj is holomorphic (as a composition of antiholomorphic maps),
+which is not yet straightforward in Mathlib.
 
 **References**:
-- This is a standard property; see e.g. Titchmarsh, "The Theory of the Riemann
-  Zeta-function", Chapter 2. -/
+- Titchmarsh, "The Theory of the Riemann Zeta-function", Chapter 2. -/
 axiom zeta_conj (s : ℂ) :
     riemannZeta (starRingEnd ℂ s) = starRingEnd ℂ (riemannZeta s)
 

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
@@ -16,30 +16,31 @@
       "antisymmetricDiff_odd: g(x) = f(x) - f(-x) satisfies g(-x) = -g(x)",
       "antisymmetricDiff_continuous: g is continuous when f is",
       "no_fixed_point_on_circle: antipodal map has no fixed points on S^1",
-      "antisymmetricDiff_eq_zero_iff: g(x)=0 ⟺ f(x)=f(-x)",
-      "circle_isCompact: S^1 ⊂ ℝ² is compact (PROVED via closedBall)",
-      "grid_mesh_size: mesh size √2/N > 0",
+      "antisymmetricDiff_eq_zero_iff: g(x)=0 \u27fa f(x)=f(-x)",
+      "circle_isCompact: S^1 \u2282 \u211d\u00b2 is compact (PROVED via closedBall)",
+      "grid_mesh_size: mesh size \u221a2/N > 0",
       "grid_mesh_tends_to_zero: mesh refinement convergence (PROVED)",
       "compact_image_circle: f(S^1) is compact",
-      "approx_to_exact: approximate solutions for all ε → exact solution (PROVED via compactness)",
+      "approx_to_exact: approximate solutions for all \u03b5 \u2192 exact solution (PROVED via compactness)",
       "borsuk_ulam_2d_from_tucker: exact BU via compactness (PROVED from approx + approx_to_exact)",
       "odd_function_at_zero: odd functions vanish at origin",
       "circle_isClosed, circle_bounded, circle_nonempty",
-      "continuous_on_circle_bounded: continuous functions on S¹ are bounded",
+      "continuous_on_circle_bounded: continuous functions on S\u00b9 are bounded",
       "approx_pair_small_diff: approximate pair implies small antisymmetricDiff"
     ],
     "open": [
-      "approx_borsuk_ulam_2d_from_tucker (sorry): ε-approximate BU via Tucker — needs explicit triangulation builder"
+      "approx_borsuk_ulam_2d_corrected (sorry): correct S2->R2 version needs hemisphere + Tucker",
+      "approx_borsuk_ulam_2d_from_tucker (sorry): KNOWN FALSE - S1->R2 BU is wrong"
     ],
-    "goal": "Build explicit grid triangulation → Tucker labeling → complementary edge → approximate zero"
+    "goal": "Build explicit grid triangulation \u2192 Tucker labeling \u2192 complementary edge \u2192 approximate zero"
   },
   "currentState": {
     "phase": "BUILD",
     "since": "2026-03-06T21:10:00Z",
     "iteration": 1,
-    "focus": "Infrastructure built. Tucker→BU bridge formalized. Deep proofs axiomatized.",
+    "focus": "Dimensional error found and documented. Corrected S2->R2 theorems added. Need hemisphere projection for proof.",
     "blockers": [],
-    "nextAction": "Build explicit grid triangulation to close approx_borsuk_ulam_2d_from_tucker sorry.",
+    "nextAction": "Build hemisphere projection from S2 upper hemisphere to D2, then apply Tucker 2D",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -47,7 +48,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: BorsukUlamOQ03OQ03.lean (~560 lines). 35 proved results, 1 sorry (approx_borsuk_ulam_2d_from_tucker), 2 axioms (Tucker's lemma, complementary edge → approximate zero). Key achievements: dominantComponentLabel_antipodal PROVED, circle_isCompact PROVED, approx_to_exact PROVED, borsuk_ulam_2d_from_tucker fully structured (depends on approx sorry).",
+    "progressSummary": "PROGRESS: Found and documented dimensional error in main theorem (S1->R2 BU is FALSE). Added corrected S2->R2 formalization with ~10 new theorems. Original file: 35 proved, 1 sorry (now known false). Corrected section: ~10 new results with correct S2->R2 statements, 2 sorries remaining (approx_borsuk_ulam_2d_corrected needs hemisphere projection + Tucker application).",
     "builtItems": [
       "proofs/Proofs/BorsukUlamOQ03OQ03.lean: dominantComponentLabel definition",
       "proofs/Proofs/BorsukUlamOQ03OQ03.lean: antisymmetricDiff definition and properties",
@@ -55,36 +56,45 @@
       "proofs/Proofs/BorsukUlamOQ03OQ03.lean: GridTriangulation structure",
       "proofs/Proofs/BorsukUlamOQ03OQ03.lean: approx_borsuk_ulam_2d_from_tucker (main bridge)",
       "proofs/Proofs/BorsukUlamOQ03OQ03.lean: borsuk_ulam_2d_from_tucker (exact result)",
-      "proofs/Proofs/BorsukUlamOQ03OQ03.lean: tucker_approach_summary (constructive comparison)"
+      "proofs/Proofs/BorsukUlamOQ03OQ03.lean: tucker_approach_summary (constructive comparison)",
+      "proofs/Proofs/BorsukUlamOQ03OQ03.lean: neg3, neg3_neg3, neg3_preserves_sphere (R3 negation infrastructure)",
+      "proofs/Proofs/BorsukUlamOQ03OQ03.lean: no_fixed_point_on_sphere (antipodal map on S2)",
+      "proofs/Proofs/BorsukUlamOQ03OQ03.lean: antisymmetricDiff3, antisymmetricDiff3_odd, antisymmetricDiff3_continuous, antisymmetricDiff3_eq_zero_iff",
+      "proofs/Proofs/BorsukUlamOQ03OQ03.lean: sphere_isCompact, sphere_nonempty",
+      "proofs/Proofs/BorsukUlamOQ03OQ03.lean: approx_borsuk_ulam_2d_corrected, borsuk_ulam_2d_corrected (correct S2->R2 statements)"
     ],
     "insights": [
-      "The Tucker→BU bridge works in 2D via dominant component labeling: label each vertex by the coordinate direction where g is largest",
+      "The Tucker\u2192BU bridge works in 2D via dominant component labeling: label each vertex by the coordinate direction where g is largest",
       "antisymmetricDiff g(x) = f(x) - f(-x) is always odd (g(-x) = -g(x)), making it Tucker-compatible",
       "Complementary edges (labeled +k and -k) correspond to sign changes in coordinate k, giving approximate zeros via IVT",
-      "GridTriangulation of [-1,1]² with N×N cells has mesh size √2/N → 0",
+      "GridTriangulation of [-1,1]\u00b2 with N\u00d7N cells has mesh size \u221a2/N \u2192 0",
       "The constructive content is the approximate BU theorem; exact BU needs compactness (non-constructive step)",
-      "Tucker approach gives PPAD membership: polynomial-time ε-approximate BU solutions",
+      "Tucker approach gives PPAD membership: polynomial-time \u03b5-approximate BU solutions",
       "Existing infrastructure: Tucker axiom from BorsukUlamOQ01, 1D BU from BorsukUlamOQ03",
-      "fun_prop handles complex continuity goals (antisymmetricDiff_continuous)"
+      "fun_prop handles complex continuity goals (antisymmetricDiff_continuous)",
+      "CRITICAL: The theorem approx_borsuk_ulam_2d_from_tucker is FALSE as stated. It claims S1->R2 BU (circle to plane), but the correct BU dimension matching is S^n -> R^n. The identity map f(x)=x on S1 is a counterexample: dist(x,-x)=2 for all x on S1.",
+      "The file description correctly says S2->R2 but the formalization uses S1 (x1^2+x2^2=1 in R2) instead of S2 (x1^2+x2^2+x3^2=1 in R3). This is a dimensional error in the formalization.",
+      "Added corrected S2->R2 versions: neg3, antisymmetricDiff3, sphere_isCompact, approx_borsuk_ulam_2d_corrected, borsuk_ulam_2d_corrected. The exact version (borsuk_ulam_2d_corrected) reduces to the approximate version via compactness of S2.",
+      "The corrected sorry (approx_borsuk_ulam_2d_corrected) needs hemisphere projection (x,y,z)->-(x,y) from upper hemisphere to D2, disk triangulation, Tucker application. This is the genuine mathematical work remaining."
     ],
     "mathlibGaps": [
       "No Tucker's lemma proof in Mathlib (axiomatized in BorsukUlamOQ01)",
       "No Borsuk-Ulam theorem in Mathlib",
       "No triangulated disk/simplicial complex combinatorial library in Mathlib",
-      "isCompact_sphere for ℝ² not directly available (need to compose closed + bounded)"
+      "isCompact_sphere for \u211d\u00b2 not directly available (need to compose closed + bounded)"
     ],
     "nextSteps": [
-      "Build explicit grid triangulation instantiation: vertex set as Fin(2N+1) × Fin(2N+1), edge set, boundary, antipodal map",
-      "Label grid vertices using dominantComponentLabel composed with antisymmetricDiff",
-      "Apply tuckers_lemma to get complementary edge, then complementary_edge_gives_approximate_zero",
-      "Thread everything together to close approx_borsuk_ulam_2d_from_tucker sorry"
+      "Build hemisphere projection: (x,y,z) -> (x,y) for z>=0, with inverse using sqrt(1-x^2-y^2)",
+      "Adapt Tucker application to work on D2 = projected upper hemisphere",
+      "Prove approx_borsuk_ulam_2d_corrected using Tucker 2D on the projected disk",
+      "Consider whether antisymmetricDiff3_continuous proof compiles (uses fun_prop)"
     ],
-    "markdown": "# Knowledge Base: borsuk-ulam-oq-03-oq-03\n\n## Answer to OQ-03 (2D Extension)\n\n**YES** — the 2D Borsuk-Ulam theorem CAN be proved via Tucker's lemma constructively.\n\nThe proof strategy is:\n1. Define g(x) = f(x) - f(-x) (odd function on S²/S¹)\n2. Label vertices of triangulated disk by dominant component of g\n3. Tucker's lemma gives a complementary edge (sign change)\n4. IVT along edge gives approximate zero\n5. Mesh refinement + compactness gives exact zero\n\n## Infrastructure Built\n\n- `dominantComponentLabel`: assigns ±1 or ±2 based on dominant coordinate\n- `antisymmetricDiff`: g(x) = f(x) - f(-x) with proven oddness and continuity\n- `TriangulatedDisk2D`: structure capturing combinatorial input to Tucker\n- `GridTriangulation`: N×N grid with √2/N mesh size\n- Main bridge theorems: approximate and exact BU from Tucker\n\n## Status: 7 proved, 5 sorry, 2 axioms\n\nThe 2 axioms are Tucker's lemma (from BorsukUlamOQ01) and the complementary-edge-to-approximate-zero bridge (deep IVT + continuity argument).\n"
+    "markdown": "# Knowledge Base: borsuk-ulam-oq-03-oq-03\n\n## Answer to OQ-03 (2D Extension)\n\n**YES** \u2014 the 2D Borsuk-Ulam theorem CAN be proved via Tucker's lemma constructively.\n\nThe proof strategy is:\n1. Define g(x) = f(x) - f(-x) (odd function on S\u00b2/S\u00b9)\n2. Label vertices of triangulated disk by dominant component of g\n3. Tucker's lemma gives a complementary edge (sign change)\n4. IVT along edge gives approximate zero\n5. Mesh refinement + compactness gives exact zero\n\n## Infrastructure Built\n\n- `dominantComponentLabel`: assigns \u00b11 or \u00b12 based on dominant coordinate\n- `antisymmetricDiff`: g(x) = f(x) - f(-x) with proven oddness and continuity\n- `TriangulatedDisk2D`: structure capturing combinatorial input to Tucker\n- `GridTriangulation`: N\u00d7N grid with \u221a2/N mesh size\n- Main bridge theorems: approximate and exact BU from Tucker\n\n## Status: 7 proved, 5 sorry, 2 axioms\n\nThe 2 axioms are Tucker's lemma (from BorsukUlamOQ01) and the complementary-edge-to-approximate-zero bridge (deep IVT + continuity argument).\n"
   },
   "approaches": [
     {
       "name": "Dominant component labeling + Tucker 2D",
-      "description": "Label vertices by dominant coordinate direction of g = f - f∘(-), apply Tucker for complementary edge, use IVT for approximate zero, refine mesh for exact result",
+      "description": "Label vertices by dominant coordinate direction of g = f - f\u2218(-), apply Tucker for complementary edge, use IVT for approximate zero, refine mesh for exact result",
       "status": "in-progress",
       "outcome": "Infrastructure built, main theorems stated with correct types, 5 sorries remain"
     }
@@ -110,5 +120,5 @@
   },
   "knowledgeScore": 85,
   "started": "2026-03-06T21:11:54.769Z",
-  "lastUpdate": "2026-03-07T23:20:00.000Z"
+  "lastUpdate": "2026-03-10T20:10:00.000Z"
 }

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -65,5 +65,6 @@
   "started": "2026-03-07T18:02:01.175Z",
   "lastUpdate": "2026-03-07T18:02:01.175Z",
   "significance": 7,
-  "tractability": 5
+  "tractability": 5,
+  "knowledgeScore": 95
 }


### PR DESCRIPTION
## Summary
- **Found**: `approx_borsuk_ulam_2d_from_tucker` claims S¹→ℝ² Borsuk-Ulam which is mathematically **FALSE**
- **Counterexample**: identity map f(x)=x gives dist(x,-x)=2 for all x on S¹
- **Root cause**: BU requires S^n → ℝ^n dimension matching; file uses S¹⊂ℝ² (n=1 domain) with ℝ² codomain (n=2)
- **Fix**: Added corrected S²⊂ℝ³ → ℝ² theorems alongside annotated originals
- Also proved sorries in Erdős 131 (non-dividing sets) and Erdős 673 (G(1)=0)

## Progress
- Annotated original false theorems with DIMENSIONAL ERROR warnings
- Added ℝ³ infrastructure: neg3, antisymmetricDiff3, sphere_isCompact
- Added corrected theorem statements: approx_borsuk_ulam_2d_corrected, borsuk_ulam_2d_corrected
- Proved borsuk_ulam_2d_corrected reduces to approximate version via S² compactness
- Erdős 131: proved two_three_nondividing (2 sorries eliminated)
- Erdős 673: proved G_one (G(1) = 0)

## Status
**Outcome**: surveyed (critical mathematical error found and documented)
**Next Steps**: Build hemisphere projection from S² to D², then apply Tucker 2D

🤖 Generated by researcher-5