### PR TITLE
research: prove Hölder equality normalization (cauchy-schwarz-oq-03-oq-01)

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ03OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzOQ03OQ01.lean
@@ -399,12 +399,57 @@ theorem holder_eq_implies_power_prop {ι : Type*} (s : Finset ι) (f g : ι → 
     ∃ c : ℝ, 0 ≤ c ∧ ∀ i ∈ s, f i ^ p = c * g i ^ q := by
   -- The proportionality constant c = (∑f^p)/(∑g^q)
   use (∑ i ∈ s, f i ^ p) / (∑ i ∈ s, g i ^ q)
-  constructor
-  · exact div_nonneg (le_of_lt hFp) (le_of_lt hGq)
-  · -- Reduce to normalized case: f/‖f‖_p and g/‖g‖_q
-    -- After normalization, f_i^p = g_i^q for all i
-    -- Unscaling: f_i^p/(∑f^p) = g_i^q/(∑g^q), i.e., f_i^p = (∑f^p/∑g^q) * g_i^q
-    sorry
+  refine ⟨div_nonneg (le_of_lt hFp) (le_of_lt hGq), ?_⟩
+  -- Setup: normalization constants
+  have hp_pos : (0 : ℝ) < p := by linarith
+  have hq_pos : (0 : ℝ) < q := lt_trans one_pos (conj_one_lt_q hp hinv)
+  have hp_ne : p ≠ 0 := ne_of_gt hp_pos
+  have hq_ne : q ≠ 0 := ne_of_gt hq_pos
+  set Fp := ∑ j ∈ s, f j ^ p with hFp_def
+  set Gq := ∑ j ∈ s, g j ^ q with hGq_def
+  set a := Fp ^ (1 / p) with ha_def
+  set b := Gq ^ (1 / q) with hb_def
+  have ha_pos : 0 < a := rpow_pos_of_pos hFp _
+  have hb_pos : 0 < b := rpow_pos_of_pos hGq _
+  have ha_ne : a ≠ 0 := ne_of_gt ha_pos
+  have hb_ne : b ≠ 0 := ne_of_gt hb_pos
+  -- Key cancellation: a^p = Fp and b^q = Gq
+  have hap : a ^ p = Fp := by
+    rw [ha_def, ← rpow_mul (le_of_lt hFp)]
+    simp only [one_div, inv_mul_cancel₀ hp_ne, Real.rpow_one]
+  have hbq : b ^ q = Gq := by
+    rw [hb_def, ← rpow_mul (le_of_lt hGq)]
+    simp only [one_div, inv_mul_cancel₀ hq_ne, Real.rpow_one]
+  -- Normalization conditions
+  have hnf : ∑ j ∈ s, (f j / a) ^ p = 1 := by
+    have h : ∀ j ∈ s, (f j / a) ^ p = f j ^ p / a ^ p :=
+      fun j hj => Real.div_rpow (hf j hj) (le_of_lt ha_pos) p
+    rw [Finset.sum_congr rfl h, ← Finset.sum_div, hap, div_self (ne_of_gt hFp)]
+  have hng : ∑ j ∈ s, (g j / b) ^ q = 1 := by
+    have h : ∀ j ∈ s, (g j / b) ^ q = g j ^ q / b ^ q :=
+      fun j hj => Real.div_rpow (hg j hj) (le_of_lt hb_pos) q
+    rw [Finset.sum_congr rfl h, ← Finset.sum_div, hbq, div_self (ne_of_gt hGq)]
+  have heq' : ∑ j ∈ s, (f j / a * (g j / b)) = 1 := by
+    have h : ∀ j ∈ s, f j / a * (g j / b) = f j * g j / (a * b) :=
+      fun _ _ => by ring
+    rw [Finset.sum_congr rfl h, ← Finset.sum_div, heq,
+      div_self (mul_ne_zero ha_ne hb_ne)]
+  -- Apply normalized theorem
+  intro i hi
+  have key := holder_eq_normalized_implies_power_prop s
+    (fun j => f j / a) (fun j => g j / b) hp hinv
+    (fun j hj => div_nonneg (hf j hj) (le_of_lt ha_pos))
+    (fun j hj => div_nonneg (hg j hj) (le_of_lt hb_pos))
+    hnf hng heq' i hi
+  -- key: (f i / a)^p = (g i / b)^q
+  -- Unscale: f i^p / Fp = g i^q / Gq → f i^p = (Fp/Gq) · g i^q
+  rw [Real.div_rpow (hf i hi) (le_of_lt ha_pos) p, hap,
+    Real.div_rpow (hg i hi) (le_of_lt hb_pos) q, hbq] at key
+  -- key: f i ^ p / Fp = g i ^ q / Gq
+  rw [div_eq_div_iff (ne_of_gt hFp) (ne_of_gt hGq)] at key
+  -- key: f i ^ p * Gq = g i ^ q * Fp
+  field_simp
+  linarith
 
 -- ============================================================================
 -- Part VIII: Specialization — Recovering Cauchy-Schwarz from Hölder

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -29,13 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Extended CS equality characterization to general Hölder. Proved conjugate exponent identities, Young deficit framework, normalized Hölder equality theorem (∑fᵢgᵢ=1 with norms=1 implies fᵢ^p=gᵢ^q), and power-to-linear proportionality reduction. Young equality case axiomatized (strict convexity).",
+    "progressSummary": "PROGRESS: Proved general Hölder equality case (holder_eq_implies_power_prop). All theorem sorries eliminated except 2 axioms (Young deficit strict convexity). Full pipeline: conjugate identities → Young deficit → normalized equality → general equality via Lp/Lq normalization → p=q=2 specialization.",
     "builtItems": [
       "conj_eq_div, conj_sub_one_mul, conj_q_div_p_add_one, conj_one_lt_q, conj_add_eq_mul (conjugate identities)",
       "youngDeficit def + axioms (youngDeficit_nonneg, youngDeficit_eq_zero_iff)",
       "sum_youngDeficit, sum_youngDeficit_eq_zero_iff (structural reduction theorems)",
       "holder_eq_normalized_implies_power_prop (key theorem, fully proved)",
-      "holder_eq_implies_power_prop (general case, 1 sorry on normalization)",
+      "holder_eq_implies_power_prop (general case, FULLY PROVED via normalization)",
       "power_prop_sq_implies_prop (p=q=2 specialization, fully proved)"
     ],
     "insights": [
@@ -43,12 +43,13 @@
       "Young deficit = a^p/p + b^q/q - ab is the right abstraction for Hölder equality analysis",
       "Normalized case (∑f^p=∑g^q=1, ∑fg=1) reduces to showing ∑ Young deficits = 1/p+1/q-1 = 0",
       "Young equality reverse direction (deficit=0 → a^p=b^q) requires strict convexity, axiomatized",
-      "For p=q=2, power proportionality f^2=c·g^2 reduces to proportionality via nlinarith on (f-√c·g)²"
+      "For p=q=2, power proportionality f^2=c·g^2 reduces to proportionality via nlinarith on (f-√c·g)²",
+      "Normalization by Lp/Lq norms: set a=Fp^{1/p}, b=Gq^{1/q}, then (f/a)^p sums to 1 via rpow_mul + inv_mul_cancel₀",
+      "Real.div_rpow needs explicit exponent arg; ← Finset.sum_div factors out denominators from sums"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove Young equality reverse: use StrictConvexOn for rpow or direct derivative argument",
-      "Complete the normalization step in holder_eq_implies_power_prop (divide f,g by Lp norms)",
+      "Prove Young equality reverse: use StrictConvexOn for rpow or direct derivative argument (replaces 2 axioms)",
       "Extend to integral Hölder equality (a.e. power proportionality)"
     ]
   },
@@ -65,7 +66,7 @@
     "mathlib": []
   },
   "started": "2026-03-07T18:02:01.175Z",
-  "lastUpdate": "2026-03-07T18:02:01.175Z",
+  "lastUpdate": "2026-03-10T00:00:00.000Z",
   "significance": 6,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Prove `holder_eq_implies_power_prop` in `CauchySchwarzOQ03OQ01.lean` — the general Hölder equality case via Lp/Lq normalization
- Normalization technique: divide f by (∑f^p)^{1/p} and g by (∑g^q)^{1/q}, apply normalized theorem, unscale via `div_eq_div_iff`
- Build verified via Docker (0 new sorries)
- Update problem knowledge JSON

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.CauchySchwarzOQ03OQ01` passes
- [x] No new sorries introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)