### PR TITLE
research: prove 4 isoperimetric sorry-lemmas (area-of-circle-oq-01-oq-03)

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ03.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ03.lean
@@ -25,7 +25,7 @@
   - Parseval's identity: available (tsum_sq_fourierCoeff)
   - The assembled Wirtinger proof would be ~200-300 lines
 
-  What This File Proves (26 theorems, 2 axioms, 6 sorry-lemmas):
+  What This File Proves (26 theorems, 2 axioms, 2 sorry-lemmas):
   1. Equality for circles: C² = 4πA  (ring computation)
   2. Strict inequality for squares: C² > 4πA  (π < 4)
   3. The isoperimetric ratio: A/(C²/4π) and its circle value
@@ -484,10 +484,31 @@ lemma wirtinger_sum_sq_bound (γ : SmoothClosedCurve) (c : ℝ) (hc : 0 < c)
   -- Apply Wirtinger to x and y
   have wx := wirtinger_inequality γ.x γ.smooth_x γ.periodic_x hzx
   have wy := wirtinger_inequality γ.y γ.smooth_y γ.periodic_y hzy
-  -- The RHS equals ∫(x'²+y'²) = ∫c² = 2πc²
-  -- Need: ∫(x²+y²) ≤ ∫(x'²+y'²) [from wx, wy + integral linearity]
-  -- And:  ∫(x'²+y'²) = 2πc² [from hspeed + integral_const]
-  sorry -- integral linearity + constant speed computation
+  -- Integrability from C¹ smoothness
+  have hx2 : IntervalIntegrable (fun t => γ.x t ^ 2) MeasureTheory.volume 0 (2 * π) :=
+    (γ.smooth_x.continuous.pow 2).intervalIntegrable 0 (2 * π)
+  have hy2 : IntervalIntegrable (fun t => γ.y t ^ 2) MeasureTheory.volume 0 (2 * π) :=
+    (γ.smooth_y.continuous.pow 2).intervalIntegrable 0 (2 * π)
+  have hdx_cont : Continuous (deriv γ.x) := by
+    have h := (contDiff_succ_iff_deriv (n := 0)).mp γ.smooth_x
+    exact h.2.2.continuous
+  have hdy_cont : Continuous (deriv γ.y) := by
+    have h := (contDiff_succ_iff_deriv (n := 0)).mp γ.smooth_y
+    exact h.2.2.continuous
+  have hdx2 : IntervalIntegrable (fun t => deriv γ.x t ^ 2) MeasureTheory.volume 0 (2 * π) :=
+    (hdx_cont.pow 2).intervalIntegrable 0 (2 * π)
+  have hdy2 : IntervalIntegrable (fun t => deriv γ.y t ^ 2) MeasureTheory.volume 0 (2 * π) :=
+    (hdy_cont.pow 2).intervalIntegrable 0 (2 * π)
+  -- Step 1: ∫(x²+y²) = ∫x² + ∫y² and ∫(x'²+y'²) = ∫x'² + ∫y'²
+  rw [intervalIntegral.integral_add hx2 hy2]
+  -- Step 2: ∫x² + ∫y² ≤ ∫x'² + ∫y'² (from Wirtinger)
+  have h_sum := add_le_add wx wy
+  -- Step 3: ∫x'² + ∫y'² = ∫(x'²+y'²) = ∫c² = 2πc²
+  rw [← intervalIntegral.integral_add hdx2 hdy2] at h_sum
+  have h_speed_eq : (fun t => deriv γ.x t ^ 2 + deriv γ.y t ^ 2) = fun _ => c ^ 2 :=
+    funext hspeed
+  rw [h_speed_eq, intervalIntegral.integral_const, smul_eq_mul, sub_zero] at h_sum
+  linarith
 
 /-- **Integral Cauchy-Schwarz on [0, 2π]**: For a non-negative function f,
     (∫₀²π f)² ≤ 2π · ∫₀²π f².
@@ -499,7 +520,58 @@ lemma integral_cauchy_schwarz_interval (f : ℝ → ℝ)
     (hf2_int : IntervalIntegrable (fun t => f t ^ 2) MeasureTheory.MeasureSpace.volume 0 (2 * π)) :
     (∫ t in (0 : ℝ)..(2 * π), f t) ^ 2 ≤
     2 * π * ∫ t in (0 : ℝ)..(2 * π), f t ^ 2 := by
-  sorry -- standard integral Cauchy-Schwarz (set g = 1 in ∫fg ≤ √(∫f²·∫g²))
+  -- Discriminant method: for all α ∈ ℝ, ∫₀²π (α·f(t) - 1)² dt ≥ 0.
+  -- Expanding: α²·∫f² - 2α·∫f + 2π ≥ 0 for all α.
+  -- Non-negative quadratic ⟹ discriminant ≤ 0 ⟹ (∫f)² ≤ 2π·∫f².
+  set I := ∫ t in (0 : ℝ)..(2 * π), f t
+  set J := ∫ t in (0 : ℝ)..(2 * π), f t ^ 2
+  -- Step 1: For all α, the expanded integral ≥ 0
+  have hQ : ∀ α : ℝ, 0 ≤ α ^ 2 * J - 2 * α * I + 2 * π := by
+    intro α
+    have h_nn : 0 ≤ ∫ t in (0 : ℝ)..(2 * π), (α * f t - 1) ^ 2 :=
+      intervalIntegral.integral_nonneg (by linarith [pi_pos]) (fun t _ => sq_nonneg _)
+    -- Expand (α·f(t) - 1)² = α²·f(t)² + (-2α·f(t) + 1)
+    have hexp : ∀ t, (α * f t - 1) ^ 2 = α ^ 2 * f t ^ 2 + (-2 * α * f t + 1) := by
+      intro t; ring
+    simp_rw [hexp] at h_nn
+    rw [intervalIntegral.integral_add (hf2_int.const_mul _)
+        ((hf_int.const_mul _).add intervalIntegrable_const)] at h_nn
+    rw [intervalIntegral.integral_add (hf_int.const_mul _) intervalIntegrable_const] at h_nn
+    simp only [intervalIntegral.integral_const_mul, intervalIntegral.integral_const,
+               smul_eq_mul, sub_zero] at h_nn
+    linarith
+  -- Step 2: J ≥ 0 (integral of non-negative function)
+  have hJ : 0 ≤ J :=
+    intervalIntegral.integral_nonneg (by linarith [pi_pos]) (fun t _ => sq_nonneg _)
+  -- Step 3: Discriminant argument
+  -- If J = 0: from hQ at α = 1: J - 2I + 2π ≥ 0 and α = -1: J + 2I + 2π ≥ 0
+  -- giving |I| ≤ π + J/2. Also I² ≤ 0 since 2πJ = 0. Use direct bound.
+  by_cases hJ0 : J = 0
+  · -- J = 0: from hQ, ∀ α, α²·0 - 2αI + 2π ≥ 0, i.e., 2αI ≤ 2π for all α.
+    -- If I ≠ 0, evaluate at α = (π+1)/I: 2(π+1) ≤ 2π, contradiction.
+    suffices hI0 : I = 0 by simp [hI0, hJ0]
+    by_contra hI_ne
+    have h := hQ ((π + 1) / I)
+    have hJ_z : ((π + 1) / I) ^ 2 * J = 0 := by rw [hJ0, mul_zero]
+    rw [hJ_z, zero_sub] at h
+    -- h : 0 ≤ -(2 * ((π+1)/I) * I) + 2π, i.e., 2·((π+1)/I)·I ≤ 2π
+    have hcancel : (π + 1) / I * I = π + 1 := div_mul_cancel₀ _ hI_ne
+    have hval : 2 * ((π + 1) / I) * I = 2 * (π + 1) := by rw [mul_assoc, hcancel]
+    linarith
+  · -- J > 0: evaluate quadratic at α = I/J, multiply by J to clear denominators
+    have hJ_pos : 0 < J := lt_of_le_of_ne hJ (Ne.symm hJ0)
+    have hJ_ne : J ≠ 0 := ne_of_gt hJ_pos
+    have h1 := hQ (I / J)
+    -- Multiply by J (positive) to clear fractions
+    have h2 := mul_le_mul_of_nonneg_right h1 hJ_pos.le
+    simp only [zero_mul] at h2
+    -- Algebraically simplify to -I² + 2πJ ≥ 0
+    have key : ((I / J) ^ 2 * J - 2 * (I / J) * I + 2 * π) * J =
+               -(I ^ 2) + 2 * π * J := by
+      field_simp
+      ring
+    rw [key] at h2
+    linarith
 
 /-- **Area bound from 2D Cauchy-Schwarz + constant speed**:
     For a constant-speed-c curve, 2·area ≤ c · ∫₀²π √(x²+y²).
@@ -513,7 +585,57 @@ lemma area_bound_const_speed (γ : SmoothClosedCurve) (c : ℝ) (hc : 0 < c)
     (hspeed : ∀ t, deriv γ.x t ^ 2 + deriv γ.y t ^ 2 = c ^ 2) :
     2 * γ.area ≤
     c * ∫ t in (0 : ℝ)..(2 * π), Real.sqrt (γ.x t ^ 2 + γ.y t ^ 2) := by
-  sorry -- uses cross_product_sq_le + norm_integral_le + integral_mono
+  -- 2·area = |∫(xy'-yx')| ≤ ∫|xy'-yx'|        [integral triangle inequality]
+  -- |xy'-yx'| ≤ √(x²+y²)·√(x'²+y'²)          [2D Cauchy-Schwarz]
+  -- √(x'²+y'²) = c                             [constant speed]
+  -- ∫|xy'-yx'| ≤ c·∫√(x²+y²)                   [integral monotonicity]
+  unfold SmoothClosedCurve.area
+  -- 2 · ((1/2) · |∫ ...|) = |∫ ...|
+  have hpi_pos : (0 : ℝ) < 2 * π := by positivity
+  rw [show (2 : ℝ) * ((1 / 2) * |∫ t in (0 : ℝ)..(2 * π),
+    γ.x t * deriv γ.y t - γ.y t * deriv γ.x t|) =
+    |∫ t in (0 : ℝ)..(2 * π),
+    γ.x t * deriv γ.y t - γ.y t * deriv γ.x t| from by ring]
+  -- Pointwise bound: |xy' - yx'| ≤ c · √(x² + y²) via 2D Cauchy-Schwarz
+  have h_pw : ∀ t, |γ.x t * deriv γ.y t - γ.y t * deriv γ.x t| ≤
+      c * Real.sqrt (γ.x t ^ 2 + γ.y t ^ 2) := by
+    intro t
+    have hCS := cross_product_sq_le (γ.x t) (γ.y t) (deriv γ.x t) (deriv γ.y t)
+    rw [hspeed t] at hCS
+    have hsum_nn : 0 ≤ γ.x t ^ 2 + γ.y t ^ 2 := by positivity
+    have h_sq : (γ.x t * deriv γ.y t - γ.y t * deriv γ.x t) ^ 2 ≤
+        (c * Real.sqrt (γ.x t ^ 2 + γ.y t ^ 2)) ^ 2 := by
+      rw [mul_pow, Real.sq_sqrt hsum_nn]
+      linarith [mul_comm (γ.x t ^ 2 + γ.y t ^ 2) (c ^ 2)]
+    exact abs_le.mpr (abs_le_of_sq_le_sq' h_sq (by positivity))
+  -- Integrability
+  have hdx_cont : Continuous (deriv γ.x) :=
+    ((contDiff_succ_iff_deriv (n := 0)).mp γ.smooth_x).2.2.continuous
+  have hdy_cont : Continuous (deriv γ.y) :=
+    ((contDiff_succ_iff_deriv (n := 0)).mp γ.smooth_y).2.2.continuous
+  have hf_int : IntervalIntegrable
+      (fun t => γ.x t * deriv γ.y t - γ.y t * deriv γ.x t) MeasureTheory.volume 0 (2 * π) :=
+    ((γ.smooth_x.continuous.mul hdy_cont).sub
+     (γ.smooth_y.continuous.mul hdx_cont)).intervalIntegrable _ _
+  have hg_int : IntervalIntegrable (fun t => c * Real.sqrt (γ.x t ^ 2 + γ.y t ^ 2))
+      MeasureTheory.volume 0 (2 * π) :=
+    (continuous_const.mul ((γ.smooth_x.continuous.pow 2).add
+      (γ.smooth_y.continuous.pow 2)).sqrt).intervalIntegrable _ _
+  -- Upper bound: ∫f ≤ c·∫√ via integral monotonicity + pointwise bound
+  have h_up : ∫ t in (0 : ℝ)..(2 * π), (γ.x t * deriv γ.y t - γ.y t * deriv γ.x t) ≤
+      c * ∫ t in (0 : ℝ)..(2 * π), Real.sqrt (γ.x t ^ 2 + γ.y t ^ 2) := by
+    rw [← intervalIntegral.integral_const_mul]
+    apply intervalIntegral.integral_mono_on hpi_pos.le hf_int hg_int
+    intro t _; exact le_trans (le_abs_self _) (h_pw t)
+  -- Lower bound: -(c·∫√) ≤ ∫f via integral monotonicity + pointwise bound
+  have h_low : -(c * ∫ t in (0 : ℝ)..(2 * π), Real.sqrt (γ.x t ^ 2 + γ.y t ^ 2)) ≤
+      ∫ t in (0 : ℝ)..(2 * π), (γ.x t * deriv γ.y t - γ.y t * deriv γ.x t) := by
+    rw [← intervalIntegral.integral_const_mul, ← intervalIntegral.integral_neg]
+    apply intervalIntegral.integral_mono_on hpi_pos.le hg_int.neg hf_int
+    intro t _
+    exact le_trans (neg_le_neg (h_pw t)) (neg_abs_le _)
+  -- Combined via abs_le
+  exact abs_le.mpr ⟨h_low, h_up⟩
 
 /-- ∫₀²π √(x(t)²+y(t)²) dt ≥ 0 since the integrand is everywhere non-negative. -/
 lemma integral_sqrt_sum_sq_nonneg (γ : SmoothClosedCurve) :
@@ -536,7 +658,10 @@ theorem isoperimetric_inequality_smooth (γ : SmoothClosedCurve) :
     -- LHS = 4π · area ≥ 0, but area ≤ 0 can't happen with |·|
     -- actually area = (1/2)|∫...| ≥ 0 always, so we need 4π·area ≤ 0
     -- this requires area = 0, which happens when circumference = 0
-    sorry -- degenerate case: zero-circumference curve has zero area
+    -- circumference = ∫₀²π √(x'²+y'²) ≥ 0, so circumference ≤ 0 ⟹ circumference = 0
+    -- Then circumference = 0 ⟹ x' = y' = 0 everywhere ⟹ xy'-yx' = 0 ⟹ area = 0
+    -- This requires: continuous non-negative function with zero integral is identically zero
+    sorry -- degenerate case: circumference = 0 implies area = 0
   push_neg at hL
   -- Step 1: Get nice reparametrization (constant speed + zero mean)
   obtain ⟨γ', hL_eq, hA_eq, hspeed, hzx, hzy⟩ := exists_nice_reparam γ hL
@@ -556,8 +681,21 @@ theorem isoperimetric_inequality_smooth (γ : SmoothClosedCurve) :
     -- S = ∫f where f = √(x²+y²) ≥ 0
     -- S² ≤ 2π·∫f² = 2π·∫(x²+y²) = 2π·Sxy
     -- by integral C-S (g = 1) and (√a)² = a for a ≥ 0
-    sorry -- integral_cauchy_schwarz_interval + Real.sq_sqrt (by positivity)
-           -- the integrability conditions follow from continuity of C¹ functions
+    -- Apply integral_cauchy_schwarz_interval to f = √(x²+y²)
+    -- Then (∫√(x²+y²))² ≤ 2π·∫(√(x²+y²))² = 2π·∫(x²+y²) = 2π·Sxy
+    set g := fun t => Real.sqrt (γ'.x t ^ 2 + γ'.y t ^ 2) with hg_def
+    have hg_cont : Continuous g := ((γ'.smooth_x.continuous.pow 2).add
+      (γ'.smooth_y.continuous.pow 2)).sqrt
+    have hg_int : IntervalIntegrable g MeasureTheory.MeasureSpace.volume 0 (2 * π) :=
+      hg_cont.intervalIntegrable 0 (2 * π)
+    have hg2_int : IntervalIntegrable (fun t => g t ^ 2) MeasureTheory.MeasureSpace.volume 0 (2 * π) :=
+      (hg_cont.pow 2).intervalIntegrable 0 (2 * π)
+    have hCS_raw := integral_cauchy_schwarz_interval g hg_int hg2_int
+    -- (∫g)² ≤ 2π · ∫g². Now g² = (√(x²+y²))² = x²+y² (since arg ≥ 0)
+    have hg2_eq : ∀ t, g t ^ 2 = γ'.x t ^ 2 + γ'.y t ^ 2 := by
+      intro t; simp only [hg_def, Real.sq_sqrt (by positivity : (0 : ℝ) ≤ γ'.x t ^ 2 + γ'.y t ^ 2)]
+    simp_rw [hg2_eq] at hCS_raw
+    exact hCS_raw
   have hWirt : Sxy ≤ 2 * π * c ^ 2 :=
     wirtinger_sum_sq_bound γ' c hc_pos hspeed hzx hzy
   -- Step 5: Apply the arithmetic kernel
@@ -695,17 +833,16 @@ The main theorem is NOW PROVED modulo 4 analysis lemmas + 1 degenerate case:
 24. `isoperimetric_inequality_smooth` — 4πA ≤ L² for smooth curves
     [PROVED from analysis lemmas + arithmetic kernel]
 
-**Analysis lemmas (sorry'd, each independently provable)**:
+**Proved analysis lemmas** (reduced from 6 to 2 sorries):
+25. `wirtinger_sum_sq_bound` — ∫(x²+y²) ≤ 2πc² [PROVED: Wirtinger axiom + integral linearity]
+26. `integral_cauchy_schwarz_interval` — (∫f)² ≤ 2π·∫f² [PROVED: discriminant method]
+27. `area_bound_const_speed` — 2A ≤ c·∫√(x²+y²) [PROVED: cross_product_sq_le + abs_le]
+
+**Remaining sorries** (2):
 - `exists_nice_reparam` — arc-length reparametrization + mean shift
    (differential geometry infrastructure, ~200 lines)
-- `wirtinger_sum_sq_bound` — ∫(x²+y²) ≤ 2πc² for zero-mean constant-speed
-   (uses wirtinger_inequality axiom + integral linearity)
-- `integral_cauchy_schwarz_interval` — (∫f)² ≤ 2π·∫f² on [0,2π]
-   (standard L² Cauchy-Schwarz, ~30 lines from Mathlib)
-- `area_bound_const_speed` — 2A ≤ c·∫√(x²+y²) for constant-speed curves
-   (uses cross_product_sq_le + integral monotonicity)
 - Degenerate case: zero-circumference ⟹ zero area
-- 2 integrability conditions (continuous functions on compact intervals)
+   (requires: continuous non-negative integral = 0 implies function = 0 a.e.)
 
 ### Proof of ngon_limit_tendsto_circle:
 - `Real.hasDerivAt_tan (cos 0 ≠ 0) : HasDerivAt tan (1/cos²0) 0 = HasDerivAt tan 1 0`

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -21,7 +21,7 @@
       "isoperimetric"
     ],
     "badge": "open",
-    "sorries": 1,
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "Real.pi_lt_four",
@@ -47,7 +47,10 @@
       "Proof architecture: Wirtinger's inequality implies isoperimetric via Cauchy-Schwarz + AM-GM",
       "SmoothClosedCurve structure for parametric curves in ℝ²",
       "2D Cauchy-Schwarz (algebraic): |xv-yu|² ≤ (x²+y²)(u²+v²) proved via nlinarith",
-      "Arithmetic kernel of Hurwitz proof: from Wirtinger bounds (Sxy≤2πc², S²≤2πSxy, 2A≤cS) to 4πA≤L² — all inequalities fully proved"
+      "Arithmetic kernel of Hurwitz proof: from Wirtinger bounds (Sxy≤2πc², S²≤2πSxy, 2A≤cS) to 4πA≤L² — all inequalities fully proved",
+      "Integral Cauchy-Schwarz on [0,2π]: (∫f)² ≤ 2π·∫f² via discriminant method",
+      "Wirtinger sum-of-squares bound: ∫(x²+y²) ≤ 2πc² from Wirtinger axiom + integral linearity",
+      "Area bound: 2A ≤ c·∫√(x²+y²) via 2D Cauchy-Schwarz + abs_le + integral monotonicity"
     ],
     "dateAdded": "02/24/26"
   },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -38,17 +38,20 @@
     "attemptCounts": { "total": 2, "currentApproach": 2, "approachesTried": 1 }
   },
   "knowledge": {
-    "progressSummary": "24 theorems proved (0 sorries), 3 axioms. The sorry in isoperimetric_inequality_smooth was eliminated by adding analytical_assembly axiom (constant-speed reparametrization + integral estimates) and proving the main theorem from it via the arithmetic kernel. Also fixed a pre-existing build error in regular_ngon_isoperimetric_ratio where let-binding shadowing caused field_simp/ring to fail.",
+    "progressSummary": "27+ theorems proved (2 sorries, 2 axioms). Proved 4 of 6 sorry-lemmas: wirtinger_sum_sq_bound (Wirtinger axiom + integral linearity), integral_cauchy_schwarz_interval (discriminant method), area_bound_const_speed (2D CS + abs_le + integral monotonicity), and inline CS in main theorem. Remaining sorries: exists_nice_reparam (arc-length reparametrization) and degenerate case (zero circumference implies zero area).",
     "builtItems": [
-      "AreaOfCircleOQ01OQ03.lean (24 theorems, 0 sorries, 3 axioms)"
+      "AreaOfCircleOQ01OQ03.lean (27+ theorems, 2 sorries, 2 axioms)"
     ],
     "insights": [
       "The Hurwitz 1901 proof requires constant-speed (arc-length) parametrization",
       "Variable-speed approach fails: integral CS gives L² ≤ 2πE (wrong direction)",
       "Constant-speed makes E = L²/(2π) EXACTLY (equality not inequality)",
-      "The analytical assembly step (reparametrization + integral estimates) is cleanly axiomatizable",
       "The arithmetic kernel (isoperimetric_from_wirtinger_bounds) is pure algebra: S² ≤ (2πc)² → S ≤ 2πc → 2A ≤ 2πc² → 4πA ≤ L²",
-      "Let-binding shadowing in Lean theorems can break field_simp/ring: use 'intro' to name let-bindings explicitly, then 'show' to restate the goal with explicit terms",
+      "Integral Cauchy-Schwarz via discriminant: ∀α, ∫(αf-1)²≥0 → non-negative quadratic in α → discriminant ≤ 0",
+      "For J=0 case in discriminant: pick α=(π+1)/I to get 2(π+1)≤2π contradiction",
+      "For J>0 case: evaluate at α=I/J, multiply by J, use field_simp+ring to simplify algebra",
+      "area_bound via abs_le split: |∫f|≤∫g by showing both ∫f≤∫g and ∫(-g)≤∫f via integral_mono_on",
+      "contDiff_succ_iff_deriv (n := 0) returns nested And: need .2.2.continuous for derivative continuity",
       "Mathlib has Fourier tools to prove Wirtinger but lacks arc-length reparametrization"
     ],
     "mathlibGaps": [


### PR DESCRIPTION
## Summary
- Prove 4 of 6 sorry-lemmas in the isoperimetric inequality formalization, reducing sorry count from 6 to 2
- `wirtinger_sum_sq_bound`: ∫(x²+y²) ≤ 2πc² via Wirtinger axiom + integral linearity
- `integral_cauchy_schwarz_interval`: (∫f)² ≤ 2π·∫f² via discriminant method (non-negative quadratic → discriminant ≤ 0)
- `area_bound_const_speed`: 2A ≤ c·∫√(x²+y²) via 2D Cauchy-Schwarz + abs_le + integral_mono_on
- Inline CS sorry in main theorem: proved via integral_cauchy_schwarz_interval + Real.sq_sqrt

**Remaining 2 sorries**: `exists_nice_reparam` (arc-length reparametrization, ~200 lines) and degenerate case (zero circumference → zero area)

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.AreaOfCircleOQ01OQ03`
- [x] Only warnings (2 sorry declarations, unused variables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)