### PR TITLE
research: prove grid vertex axioms in Borsuk-Ulam Tucker (borsuk-ulam-oq-03-oq-03)

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ03OQ03.lean
+++ b/proofs/Proofs/BorsukUlamOQ03OQ03.lean
@@ -339,22 +339,53 @@ def gridVertex (N : ℕ) (i j : ℕ) : ℝ × ℝ :=
 /-- The center vertex maps to the origin. -/
 theorem gridVertex_center (N : ℕ) (hN : 0 < N) :
     gridVertex N N N = (0, 0) := by
-  simp [gridVertex, div_self (Nat.cast_ne_zero.mpr (Nat.not_eq_zero_of_lt hN))]
+  simp only [gridVertex]
+  have hN_ne : (N : ℝ) ≠ 0 := ne_of_gt (Nat.cast_pos.mpr hN)
+  rw [div_self hN_ne]
+  norm_num
 
 /-- Grid vertices are in [-1,1]² when indices are in {0,...,2N}.
     Proof: i/N ∈ [0,2] so i/N - 1 ∈ [-1,1]. -/
-axiom gridVertex_in_range (N : ℕ) (hN : 0 < N) (i j : ℕ) (hi : i ≤ 2 * N) (hj : j ≤ 2 * N) :
+theorem gridVertex_in_range (N : ℕ) (hN : 0 < N) (i j : ℕ) (hi : i ≤ 2 * N) (hj : j ≤ 2 * N) :
     -1 ≤ (gridVertex N i j).1 ∧ (gridVertex N i j).1 ≤ 1 ∧
-    -1 ≤ (gridVertex N i j).2 ∧ (gridVertex N i j).2 ≤ 1
+    -1 ≤ (gridVertex N i j).2 ∧ (gridVertex N i j).2 ≤ 1 := by
+  have hN_pos : (0 : ℝ) < N := Nat.cast_pos.mpr hN
+  have hi_r : (i : ℝ) ≤ 2 * N := by exact_mod_cast hi
+  have hj_r : (j : ℝ) ≤ 2 * N := by exact_mod_cast hj
+  simp only [gridVertex]
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · -- -1 ≤ i/N - 1  ⟺  0 ≤ i/N
+    linarith [div_nonneg (Nat.cast_nonneg i) (le_of_lt hN_pos)]
+  · -- i/N - 1 ≤ 1  ⟺  i/N ≤ 2  ⟺  i ≤ 2N
+    have : (i : ℝ) / N ≤ 2 := by rw [div_le_iff₀ hN_pos]; linarith
+    linarith
+  · -- -1 ≤ j/N - 1  ⟺  0 ≤ j/N
+    linarith [div_nonneg (Nat.cast_nonneg j) (le_of_lt hN_pos)]
+  · -- j/N - 1 ≤ 1  ⟺  j/N ≤ 2  ⟺  j ≤ 2N
+    have : (j : ℝ) / N ≤ 2 := by rw [div_le_iff₀ hN_pos]; linarith
+    linarith
 
 /-- The antipodal map on grid vertices negates coordinates:
     v(2N-i, 2N-j) = -v(i,j).
     This ensures that for an odd function g, the labeling of grid boundary
     vertices satisfies Tucker's antipodal condition.
     (Arithmetic proof requires careful Nat→ℝ cast handling.) -/
-axiom gridVertex_antipodal (N : ℕ) (hN : 0 < N) (i j : ℕ) (hi : i ≤ 2 * N) (hj : j ≤ 2 * N) :
+theorem gridVertex_antipodal (N : ℕ) (hN : 0 < N) (i j : ℕ) (hi : i ≤ 2 * N) (hj : j ≤ 2 * N) :
     gridVertex N (2 * N - i) (2 * N - j) =
-      Prod.map Neg.neg Neg.neg (gridVertex N i j)
+      Prod.map Neg.neg Neg.neg (gridVertex N i j) := by
+  simp only [gridVertex, Prod.map]
+  have hN_ne : (N : ℝ) ≠ 0 := ne_of_gt (Nat.cast_pos.mpr hN)
+  ext
+  · -- First component: (2N-i)/N - 1 = -(i/N - 1) = 1 - i/N
+    show (↑(2 * N - i) : ℝ) / ↑N - 1 = -(↑i / ↑N - 1)
+    rw [Nat.cast_sub hi, Nat.cast_mul]
+    field_simp
+    ring
+  · -- Second component: (2N-j)/N - 1 = -(j/N - 1) = 1 - j/N
+    show (↑(2 * N - j) : ℝ) / ↑N - 1 = -(↑j / ↑N - 1)
+    rw [Nat.cast_sub hj, Nat.cast_mul]
+    field_simp
+    ring
 
 /-- A grid vertex is on the boundary when it lies on the edge of [-1,1]². -/
 def IsGridBoundary (N : ℕ) (i j : ℕ) : Prop :=

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
@@ -44,18 +44,18 @@
   "currentState": {
     "phase": "BUILD",
     "since": "2026-03-11T11:10:00Z",
-    "iteration": 3,
-    "focus": "Grid vertex infrastructure added (gridVertex, gridVertex_center, antipodal, boundary). Next: connect grid labeling to Tucker's lemma.",
+    "iteration": 4,
+    "focus": "Proved gridVertex_in_range and gridVertex_antipodal axioms, reducing axiom count from 5 to 3.",
     "blockers": [],
-    "nextAction": "Use gridVertex + dominantComponentLabel to construct explicit Tucker labeling on grid. Prove boundary antipodality from gridVertex_antipodal + diskFunction_antipodal_on_boundary. Apply tuckers_lemma. Goal: prove tucker_disk_approx_zero from infrastructure.",
+    "nextAction": "Connect grid labeling to Tucker lemma. Prove tucker_disk_approx_zero from infrastructure.",
     "attemptCounts": {
-      "total": 3,
-      "currentApproach": 3,
+      "total": 4,
+      "currentApproach": 4,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Grid vertex infrastructure added (Part X.5). gridVertex maps lattice points to [-1,1]², gridVertex_center proved, antipodal_preserves_boundary proved. Combined with hemisphere projection (Part XVII) and corrected S²→ℝ² versions (Part XVI). File: 924 lines, 2 sorries (both FALSE S¹ versions), ~20 axioms, ~40 proved theorems. Remaining: connect gridVertex + dominantComponentLabel to Tucker labeling.",
+    "progressSummary": "PROGRESS: Proved gridVertex_in_range and gridVertex_antipodal (axiom→theorem). Also fixed gridVertex_center API compatibility. Axiom count: 5→3. Docker build verified.",
     "builtItems": [
       "proofs/Proofs/BorsukUlamOQ03OQ03.lean: dominantComponentLabel definition",
       "proofs/Proofs/BorsukUlamOQ03OQ03.lean: antisymmetricDiff definition and properties",
@@ -75,7 +75,10 @@
       "proofs/Proofs/BorsukUlamOQ03OQ03.lean: gridVertex definition (lattice → [-1,1]² mapping)",
       "proofs/Proofs/BorsukUlamOQ03OQ03.lean: gridVertex_center (PROVED: center vertex = origin)",
       "proofs/Proofs/BorsukUlamOQ03OQ03.lean: gridVertex_in_range, gridVertex_antipodal (axioms: range bounds and antipodal negation)",
-      "proofs/Proofs/BorsukUlamOQ03OQ03.lean: IsGridBoundary predicate + antipodal_preserves_boundary (PROVED)"
+      "proofs/Proofs/BorsukUlamOQ03OQ03.lean: IsGridBoundary predicate + antipodal_preserves_boundary (PROVED)",
+      "proofs/Proofs/BorsukUlamOQ03OQ03.lean: gridVertex_in_range PROVED (was axiom)",
+      "proofs/Proofs/BorsukUlamOQ03OQ03.lean: gridVertex_antipodal PROVED (was axiom)",
+      "proofs/Proofs/BorsukUlamOQ03OQ03.lean: gridVertex_center fixed for Docker Mathlib compatibility"
     ],
     "insights": [
       "The Tucker→BU bridge works in 2D via dominant component labeling: label each vertex by the coordinate direction where g is largest",
@@ -91,7 +94,10 @@
       "This means dominantComponentLabel applied to g∘diskLift satisfies Tucker's antipodal boundary condition",
       "Remaining gap: need to construct TriangulatedDisk2D instance from GridTriangulation N, define labeling, apply Tucker, extract approximate zero. This is the combinatorial core (~100-200 lines).",
       "gridVertex(N,i,j) = (i/N - 1, j/N - 1) maps {0,...,2N}² to [-1,1]². Center is (N,N)→(0,0). Antipodal: (2N-i,2N-j)→-v.",
-      "gridVertex_in_range and gridVertex_antipodal axiomatized due to Nat→ℝ cast arithmetic complexity (would need push_cast + field_simp + ring)"
+      "gridVertex_in_range and gridVertex_antipodal axiomatized due to Nat→ℝ cast arithmetic complexity (would need push_cast + field_simp + ring)",
+      "gridVertex_in_range: proved via div_nonneg + div_le_iff₀ with Nat→ℝ casts",
+      "gridVertex_antipodal: proved via Nat.cast_sub + field_simp + ring",
+      "Nat.not_eq_zero_of_lt unavailable in Docker Mathlib v4.26.0; use ne_of_gt (Nat.cast_pos.mpr hN) instead"
     ],
     "mathlibGaps": [
       "No Tucker's lemma proof in Mathlib (axiomatized in BorsukUlamOQ01)",
@@ -137,5 +143,5 @@
   },
   "knowledgeScore": 90,
   "started": "2026-03-06T21:11:54.769Z",
-  "lastUpdate": "2026-03-11T12:00:00.000Z"
+  "lastUpdate": "2026-03-11T14:45:00.000Z"
 }


### PR DESCRIPTION
## Summary
- Prove `gridVertex_in_range` axiom (→ theorem) via `div_nonneg` + `div_le_iff₀`
- Prove `gridVertex_antipodal` axiom (→ theorem) via `Nat.cast_sub` + `field_simp` + `ring`
- Fix `gridVertex_center` for Docker Mathlib v4.26.0 API compatibility
- Axiom count: 5 → 3 (remaining: `tuckers_lemma`, `complementary_edge_gives_approximate_zero`, `tucker_disk_approx_zero`)

## Test plan
- [x] Docker build verified: `./proofs/scripts/docker-build.sh Proofs.BorsukUlamOQ03OQ03`
- [x] Problem knowledge JSON updated

🤖 Generated by researcher-1