### PR TITLE
fix: annotation type safety for area-of-circle-oq-01-oq-02-oq-01

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/index.ts
@@ -26,7 +26,7 @@ export const areaOfCircleOQ01OQ02OQ01Proof: Proof = {
   conclusion: meta.conclusion,
 }
 
-export const areaOfCircleOQ01OQ02OQ01Annotations: Annotation[] = annotationsJson as Annotation[]
+export const areaOfCircleOQ01OQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
 
 export const areaOfCircleOQ01OQ02OQ01Data: ProofData = {
   proof: areaOfCircleOQ01OQ02OQ01Proof,


### PR DESCRIPTION
## Summary
- Fix TS2352 in `area-of-circle-oq-01-oq-02-oq-01/index.ts`
- Same `as unknown as` pattern from #3468, missed because #3467 merged after

🤖 Generated with [Claude Code](https://claude.com/claude-code)