### PR TITLE
fix: normalize legacy annotation format missing range field

### DIFF
--- a/src/data/proofs/index.ts
+++ b/src/data/proofs/index.ts
@@ -57,6 +57,19 @@ export async function getProofAsync(slug: string): Promise<ProofData | undefined
     const proofData: ProofData = module.default || module[exportName] ||
       Object.keys(module).filter(k => k.endsWith('Data')).map(k => module[k]).find(v => v?.proof)
 
+    // Normalize annotations: convert legacy {lineNumber} format to {range}
+    if (proofData?.annotations) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      proofData.annotations = proofData.annotations.filter((ann: any) => {
+        if (ann.range) return true
+        if (ann.lineNumber != null) {
+          ann.range = { startLine: ann.lineNumber, endLine: ann.lineNumber }
+          return true
+        }
+        return false // drop annotations with neither range nor lineNumber
+      })
+    }
+
     // Load the source code if getProofSource is available
     if (module.getProofSource && proofData?.proof) {
       const source = await module.getProofSource()


### PR DESCRIPTION
## Summary
- 21 proofs have annotations with `{lineNumber}` instead of `{range: {startLine, endLine}}`
- This caused `can't access property "startLine", i.range is undefined` crash
- Normalize legacy format to `{range}` on load in `getProofAsync`

## Test plan
- [ ] https://leangenius.org/proof/area-of-circle-oq-01-oq-02-oq-01 loads without error
- [ ] Other proofs still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)