### PR TITLE
fix: guard BADGE_INFO access for unknown badge types

### DIFF
--- a/src/components/proof/ProofOverview.tsx
+++ b/src/components/proof/ProofOverview.tsx
@@ -204,9 +204,11 @@ export function ProofOverview({ proof, versionInfo }: ProofOverviewProps) {
                   <div className="flex items-center gap-3">
                     <ProofBadge badge={meta.badge} size="md" />
                   </div>
-                  <p className="text-xs text-muted-foreground mt-2">
-                    {BADGE_INFO[meta.badge].description}
-                  </p>
+                  {BADGE_INFO[meta.badge] && (
+                    <p className="text-xs text-muted-foreground mt-2">
+                      {BADGE_INFO[meta.badge].description}
+                    </p>
+                  )}
                 </div>
               )}
 


### PR DESCRIPTION
## Summary
- ProofOverview.tsx accessed `BADGE_INFO[meta.badge].description` without checking if the badge type exists in BADGE_INFO
- Proofs with non-standard badge values like `"open"` caused a crash: `can't access property "description", (intermediate value)[i.badge] is undefined`
- Added a guard so unknown badge types gracefully skip the description line

## Test plan
- [x] Verified with Playwright: `cevas-theorem-oq-04` and `cevas-theorem-oq-02` both load successfully
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)