### PR TITLE
fix: add missing index.ts for area-of-circle-oq-01

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01/index.ts
+++ b/src/data/proofs/area-of-circle-oq-01/index.ts
@@ -1,0 +1,34 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CircumferenceFromArea.lean?raw'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+export const areaOfCircleOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const areaOfCircleOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOq01Data: ProofData = {
+  proof: areaOfCircleOq01Proof,
+  annotations: areaOfCircleOq01Annotations,
+}


### PR DESCRIPTION
## Summary
- `area-of-circle-oq-01` had `meta.json` and `annotations.json` but no `index.ts`, causing "Proof not found"
- Only 1 of 1,430 proof directories was affected

## Test plan
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)