### PR TITLE
fix: handle 'complete' status in proof rendering

### DIFF
--- a/src/components/proof/ProofConclusion.tsx
+++ b/src/components/proof/ProofConclusion.tsx
@@ -178,11 +178,13 @@ export function ProofConclusion({ proof }: ProofConclusionProps) {
           <div className="flex items-center gap-2 text-sm text-muted-foreground bg-muted/30 rounded-lg px-4 py-3 mt-4">
             <span
               className={`px-2 py-0.5 rounded text-xs font-medium ${
-                proof.meta.status === 'verified'
+                proof.meta.status === 'verified' || proof.meta.status === 'complete'
                   ? 'bg-green-500/20 text-green-400'
                   : proof.meta.status === 'pending'
                     ? 'bg-yellow-500/20 text-yellow-400'
-                    : 'bg-red-500/20 text-red-400'
+                    : proof.meta.status === 'disputed'
+                      ? 'bg-red-500/20 text-red-400'
+                      : 'bg-blue-500/20 text-blue-400'
               }`}
             >
               {proof.meta.status}
@@ -190,9 +192,11 @@ export function ProofConclusion({ proof }: ProofConclusionProps) {
             <span>
               {proof.meta.status === 'pending'
                 ? 'This proof contains sorry statements or has not yet been verified in Lean.'
-                : proof.meta.status === 'verified'
+                : proof.meta.status === 'verified' || proof.meta.status === 'complete'
                   ? 'This proof compiles in Lean with no sorry statements.'
-                  : 'This proof is disputed and requires further analysis.'}
+                  : proof.meta.status === 'disputed'
+                    ? 'This proof is disputed and requires further analysis.'
+                    : `Status: ${proof.meta.status}`}
             </span>
           </div>
         </div>

--- a/src/components/proof/ProofOverview.tsx
+++ b/src/components/proof/ProofOverview.tsx
@@ -24,8 +24,10 @@ interface ProofOverviewProps {
 function getVersionStatusConfig(status: VersionHistoryEntry['status']) {
   const config: Record<VersionHistoryEntry['status'], { icon: typeof CheckCircle; className: string; label: string }> = {
     verified: { icon: CheckCircle, className: 'text-green-400', label: 'Verified' },
+    complete: { icon: CheckCircle, className: 'text-green-400', label: 'Complete' },
     pending: { icon: Clock, className: 'text-yellow-400', label: 'Pending' },
     disputed: { icon: AlertCircle, className: 'text-red-400', label: 'Disputed' },
+    'open-question': { icon: Clock, className: 'text-blue-400', label: 'Open Question' },
     conditional: { icon: AlertTriangle, className: 'text-orange-400', label: 'Conditional' },
     axiomatized: { icon: AlertCircle, className: 'text-purple-400', label: 'Axiomatized' },
     revised: { icon: Clock, className: 'text-blue-400', label: 'Revised' },

--- a/src/pages/ProofPage.tsx
+++ b/src/pages/ProofPage.tsx
@@ -185,7 +185,7 @@ export function ProofPage() {
           <ProofBadge badge={proof.meta.badge} />
           <span
             className={`px-2 py-0.5 rounded text-xs font-medium ${
-              proof.meta.status === 'verified'
+              proof.meta.status === 'verified' || proof.meta.status === 'complete'
                 ? 'bg-green-500/20 text-green-400'
                 : proof.meta.status === 'pending'
                   ? 'bg-yellow-500/20 text-yellow-400'

--- a/src/types/proof.ts
+++ b/src/types/proof.ts
@@ -269,7 +269,7 @@ export interface ProofMeta {
   /** Date when proof was added to the site (MM/DD/YY format) */
   dateAdded?: string
   mathlib_version?: string
-  status: 'verified' | 'pending' | 'disputed'
+  status: 'verified' | 'pending' | 'disputed' | 'complete' | 'open-question' | 'axiomatized' | 'conditional'
   tags: string[]
   /** Path to verified Lean source in proofs/ directory (e.g., "Proofs/Sqrt2Irrational.lean") */
   proofRepoPath?: string
@@ -368,7 +368,7 @@ export interface ProofListing {
   title: string
   slug: string
   description: string
-  status: 'verified' | 'pending' | 'disputed'
+  status: 'verified' | 'pending' | 'disputed' | 'complete' | 'open-question' | 'axiomatized' | 'conditional'
   badge?: ProofBadge
   tags: string[]
   dateAdded?: string
@@ -402,7 +402,7 @@ export interface VersionHistoryEntry {
   /** Date of this version (ISO format) */
   date: string
   /** Status of this version */
-  status: 'verified' | 'pending' | 'disputed' | 'conditional' | 'axiomatized' | 'revised'
+  status: 'verified' | 'pending' | 'disputed' | 'complete' | 'open-question' | 'axiomatized' | 'conditional' | 'conditional' | 'axiomatized' | 'revised'
   /** Path to version file (relative to proof data directory) */
   file: string
   /** Brief summary of changes in this version */


### PR DESCRIPTION
## Summary
- 805 proofs use `status: "complete"` but rendering only recognized `verified`/`pending`/`disputed`
- All non-matching statuses fell through to "disputed", incorrectly showing "This proof is disputed and requires further analysis"
- Added missing status values to the type system and rendering logic

## Test plan
- [x] `pnpm build` succeeds
- [x] `complete` status now renders as green (like `verified`)
- [x] Unknown statuses show neutral blue instead of red "disputed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)