### PR TITLE
feat: add tester agent for random proof page validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,9 @@ This project uses **two distinct AI agent orchestration systems** for different 
 | **Scout** | Surveys gallery proofs, techniques, and literature for research problems | On-demand |
 | **Seeker** | Selects research problems when candidate pool runs low | Autonomous (15min) |
 | **Deployer** | Merges PRs, syncs data, deploys website to Cloudflare | Autonomous (30min) |
+| **Tester** | Tests random proof pages on the live site, files issues on failure | Autonomous (30min) |
 
-**Managed by `/lean`**: Enricher, Aristotle, Researcher, Seeker, Deployer
+**Managed by `/lean`**: Enricher, Aristotle, Researcher, Seeker, Deployer, Tester
 **Managed separately**: Erdos Enhancer (`make enhance`, `scripts/erdos/`)
 
 **Invoke via**: `/enricher`, `/aristotle`, `/research`, `/scout`, `/seeker`, `/deploy`
@@ -91,7 +92,7 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 | `/lean` | Start daemon with default pool |
 | `/lean status` | Show work queue and agent status |
 | `/lean start [options]` | Start with custom pool sizes |
-| `/lean spawn <type>` | Add one agent (enricher, aristotle, researcher, seeker, deployer) |
+| `/lean spawn <type>` | Add one agent (enricher, aristotle, researcher, seeker, deployer, tester) |
 | `/lean scale <type> <N>` | Scale pool to N agents |
 | `/lean stop` | Graceful shutdown of all agents (creates signal files) |
 | `/lean stop --force` | Force stop all agents (kills tmux sessions immediately) |
@@ -108,6 +109,7 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 | Researcher | 2 | 5 |
 | Seeker | 1 | 1 |
 | Deployer | 1 | 1 |
+| Tester | 1 | 1 |
 
 ## Helper Scripts
 

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -48,6 +48,7 @@ DEFAULT_ARISTOTLE=1
 DEFAULT_RESEARCHER=2
 DEFAULT_SEEKER=1
 DEFAULT_DEPLOYER=1
+DEFAULT_TESTER=1
 
 # Max pool sizes
 MAX_ENRICHER=5
@@ -55,6 +56,7 @@ MAX_ARISTOTLE=2
 MAX_RESEARCHER=5
 MAX_SEEKER=1
 MAX_DEPLOYER=1
+MAX_TESTER=1
 
 # Helper: Print usage
 usage() {
@@ -77,6 +79,7 @@ Start Options:
   --researcher N         Number of Researchers (default: $DEFAULT_RESEARCHER, max: $MAX_RESEARCHER)
   --seeker N             Number of Seeker agents (default: $DEFAULT_SEEKER, max: $MAX_SEEKER)
   --deployer N           Number of Deployers (default: $DEFAULT_DEPLOYER, max: $MAX_DEPLOYER)
+  --tester N             Number of Testers (default: $DEFAULT_TESTER, max: $MAX_TESTER)
 
 Stop Options:
   <type>                 Stop only agents of this type (enricher, aristotle, etc.)
@@ -89,6 +92,7 @@ Daemon Options:
   --researcher N         Initial Researcher count (default: $DEFAULT_RESEARCHER, max: $MAX_RESEARCHER)
   --seeker N             Initial Seeker agent count (default: $DEFAULT_SEEKER, max: $MAX_SEEKER)
   --deployer N           Initial Deployer count (default: $DEFAULT_DEPLOYER, max: $MAX_DEPLOYER)
+  --tester N             Initial Tester count (default: $DEFAULT_TESTER, max: $MAX_TESTER)
 
 Agent Types:
   enricher    Enriches proof gallery entries with deeper annotations and commentary
@@ -96,6 +100,7 @@ Agent Types:
   researcher  Works on open mathematical problems
   seeker      Selects research problems when candidate pool runs low
   deployer    Merges PRs and deploys website
+  tester      Tests random proof pages on the live site
 
 Examples:
   $0 start                              # Start with defaults
@@ -133,6 +138,7 @@ init_state() {
     local researcher="${3:-$DEFAULT_RESEARCHER}"
     local seeker="${4:-$DEFAULT_SEEKER}"
     local deployer="${5:-$DEFAULT_DEPLOYER}"
+    local tester="${6:-$DEFAULT_TESTER}"
 
     mkdir -p "$(dirname "$STATE_FILE")"
 
@@ -153,6 +159,7 @@ init_state() {
         --argjson researcher "$researcher" \
         --argjson seeker "$seeker" \
         --argjson deployer "$deployer" \
+        --argjson tester "$tester" \
         --argjson prev_stats "$prev_stats" \
         '{
             started_at: $started_at,
@@ -162,7 +169,8 @@ init_state() {
                 aristotle: $aristotle,
                 researcher: $researcher,
                 seeker: $seeker,
-                deployer: $deployer
+                deployer: $deployer,
+                tester: $tester
             },
             agents: {},
             session_stats: (
@@ -248,6 +256,11 @@ get_sessions_for_type() {
                 sessions+=("deployer")
             fi
             ;;
+        tester)
+            if tmux has-session -t "tester-agent" 2>/dev/null; then
+                sessions+=("tester-agent")
+            fi
+            ;;
     esac
 
     if [[ ${#sessions[@]} -gt 0 ]]; then
@@ -280,6 +293,9 @@ signal_stop_session() {
             ;;
         deployer)
             touch "$SIGNALS_DIR/stop-deployer"
+            ;;
+        tester)
+            touch "$SIGNALS_DIR/stop-tester"
             ;;
     esac
 }
@@ -352,6 +368,7 @@ cmd_start() {
     local researcher=$DEFAULT_RESEARCHER
     local seeker=$DEFAULT_SEEKER
     local deployer=$DEFAULT_DEPLOYER
+    local tester=$DEFAULT_TESTER
 
     # Parse options
     while [[ $# -gt 0 ]]; do
@@ -374,6 +391,10 @@ cmd_start() {
                 ;;
             --deployer)
                 deployer="$2"
+                shift 2
+                ;;
+            --tester)
+                tester="$2"
                 shift 2
                 ;;
             *)
@@ -405,6 +426,10 @@ cmd_start() {
         echo -e "${YELLOW}Warning: Deployer count $deployer exceeds max $MAX_DEPLOYER, using $MAX_DEPLOYER${NC}"
         deployer=$MAX_DEPLOYER
     fi
+    if [[ $tester -gt $MAX_TESTER ]]; then
+        echo -e "${YELLOW}Warning: Tester count $tester exceeds max $MAX_TESTER, using $MAX_TESTER${NC}"
+        tester=$MAX_TESTER
+    fi
 
     echo -e "${BOLD}Starting Lean Genius Mathematical Orchestration${NC}"
     echo ""
@@ -414,13 +439,14 @@ cmd_start() {
     echo "  Researchers: $researcher"
     echo "  Seekers: $seeker"
     echo "  Deployers: $deployer"
+    echo "  Testers: $tester"
     echo ""
 
     # Migrate state file from old location if needed
     migrate_state_file
 
     # Initialize state
-    init_state "$enricher" "$aristotle" "$researcher" "$seeker" "$deployer"
+    init_state "$enricher" "$aristotle" "$researcher" "$seeker" "$deployer" "$tester"
 
     # Start agents
     local started=0
@@ -480,6 +506,17 @@ cmd_start() {
         fi
     fi
 
+    # Tester
+    if [[ $tester -gt 0 ]]; then
+        echo -e "${BLUE}Starting Tester agent...${NC}"
+        if check_script "./scripts/test/launch-agent.sh"; then
+            ./scripts/test/launch-agent.sh &
+            sleep 1
+            echo -e "${GREEN}✓ Tester agent launched${NC}"
+            started=$((started + 1))
+        fi
+    fi
+
     echo ""
     if [[ $started -gt 0 ]]; then
         echo -e "${GREEN}${BOLD}✓ Lean Genius team started!${NC}"
@@ -519,6 +556,10 @@ get_all_agent_sessions() {
     # Deployer
     if tmux has-session -t "deployer" 2>/dev/null; then
         sessions+=("deployer")
+    fi
+    # Tester
+    if tmux has-session -t "tester-agent" 2>/dev/null; then
+        sessions+=("tester-agent")
     fi
     if [[ ${#sessions[@]} -gt 0 ]]; then
         printf '%s\n' "${sessions[@]}"
@@ -675,7 +716,7 @@ is_script_based_agent() {
     local session="$1"
     local agent_type
     agent_type=$(get_agent_type "$session")
-    [[ "$agent_type" == "aristotle" ]]
+    [[ "$agent_type" == "aristotle" || "$agent_type" == "tester" ]]
 }
 
 # Helper: Check if an agent is a polling agent that legitimately idles between cycles
@@ -685,7 +726,7 @@ is_polling_agent() {
     local session="$1"
     local agent_type
     agent_type=$(get_agent_type "$session")
-    [[ "$agent_type" == "deployer" || "$agent_type" == "seeker" ]]
+    [[ "$agent_type" == "deployer" || "$agent_type" == "seeker" || "$agent_type" == "tester" ]]
 }
 
 # Helper: Determine agent health status
@@ -976,6 +1017,7 @@ get_agent_type() {
         researcher-*)     echo "researcher" ;;
         seeker-agent)     echo "seeker" ;;
         deployer)         echo "deployer" ;;
+        tester-agent)     echo "tester" ;;
         *)                echo "unknown" ;;
     esac
 }
@@ -1065,6 +1107,15 @@ respawn_agent() {
                 daemon_log "INFO" "Deployer respawned"
             else
                 daemon_log "WARN" "Cannot respawn deployer: script not found"
+            fi
+            ;;
+        tester)
+            if check_script "./scripts/test/launch-agent.sh" 2>/dev/null; then
+                ./scripts/test/launch-agent.sh &
+                sleep 1
+                daemon_log "INFO" "Tester agent respawned"
+            else
+                daemon_log "WARN" "Cannot respawn tester: script not found"
             fi
             ;;
         *)
@@ -1222,6 +1273,7 @@ cmd_daemon() {
     local researcher=$DEFAULT_RESEARCHER
     local seeker=$DEFAULT_SEEKER
     local deployer=$DEFAULT_DEPLOYER
+    local tester=$DEFAULT_TESTER
 
     # Parse options
     while [[ $# -gt 0 ]]; do
@@ -1248,6 +1300,10 @@ cmd_daemon() {
                 ;;
             --deployer)
                 deployer="$2"
+                shift 2
+                ;;
+            --tester)
+                tester="$2"
                 shift 2
                 ;;
             *)
@@ -1288,10 +1344,10 @@ cmd_daemon() {
     trap 'daemon_log "INFO" "Received SIGINT"; exit 0' INT
 
     daemon_log "INFO" "Starting daemon (PID $$, interval ${interval}s)"
-    daemon_log "INFO" "Pool config: enricher=$enricher, aristotle=$aristotle, researcher=$researcher, seeker=$seeker, deployer=$deployer"
+    daemon_log "INFO" "Pool config: enricher=$enricher, aristotle=$aristotle, researcher=$researcher, seeker=$seeker, deployer=$deployer, tester=$tester"
 
     # Start initial agents via cmd_start
-    cmd_start --enricher "$enricher" --aristotle "$aristotle" --researcher "$researcher" --seeker "$seeker" --deployer "$deployer"
+    cmd_start --enricher "$enricher" --aristotle "$aristotle" --researcher "$researcher" --seeker "$seeker" --deployer "$deployer" --tester "$tester"
 
     local cycle_count=0
     local total_respawns=0
@@ -1736,6 +1792,11 @@ cmd_stop_type() {
                     ./scripts/research/launch-seeker.sh --graceful-stop 2>/dev/null || true
                 fi
                 ;;
+            tester)
+                if [[ -x "./scripts/test/launch-agent.sh" ]]; then
+                    ./scripts/test/launch-agent.sh --graceful-stop 2>/dev/null || true
+                fi
+                ;;
         esac
 
         # Wait up to 60s for graceful shutdown, then force-kill
@@ -1748,7 +1809,7 @@ cmd_spawn() {
     local agent_type="${1:-}"
 
     if [[ -z "$agent_type" ]]; then
-        echo -e "${RED}Error: Must specify agent type (enricher, aristotle, researcher, deployer)${NC}" >&2
+        echo -e "${RED}Error: Must specify agent type (enricher, aristotle, researcher, deployer, tester)${NC}" >&2
         exit 1
     fi
 
@@ -1809,9 +1870,19 @@ cmd_spawn() {
                 echo -e "${GREEN}✓ Deployer spawned${NC}"
             fi
             ;;
+        tester)
+            echo -e "${BLUE}Spawning Tester agent...${NC}"
+            if tmux has-session -t "tester-agent" 2>/dev/null; then
+                echo -e "${YELLOW}Tester agent already running${NC}"
+            else
+                ./scripts/test/launch-agent.sh &
+                sleep 1
+                echo -e "${GREEN}✓ Tester agent spawned${NC}"
+            fi
+            ;;
         *)
             echo -e "${RED}Unknown agent type: $agent_type${NC}" >&2
-            echo "Valid types: enricher, aristotle, researcher, seeker, deployer"
+            echo "Valid types: enricher, aristotle, researcher, seeker, deployer, tester"
             exit 1
             ;;
     esac
@@ -1915,7 +1986,7 @@ cmd_scale() {
                 echo -e "${GREEN}Already at $count Researchers${NC}"
             fi
             ;;
-        aristotle|seeker|deployer)
+        aristotle|seeker|deployer|tester)
             if [[ $count -gt 1 ]]; then
                 echo -e "${YELLOW}$agent_type can only have 0 or 1 instance, using 1${NC}"
                 count=1
@@ -1945,7 +2016,7 @@ cmd_scale() {
             ;;
         *)
             echo -e "${RED}Unknown agent type: $agent_type${NC}" >&2
-            echo "Valid types: enricher, researcher, aristotle, seeker, deployer"
+            echo "Valid types: enricher, researcher, aristotle, seeker, deployer, tester"
             exit 1
             ;;
     esac
@@ -1990,9 +2061,13 @@ cmd_wake() {
                 fi
             done
             ;;
+        tester)
+            touch "$SIGNALS_DIR/wake-tester-agent"
+            echo -e "${GREEN}Wake signal sent to tester-agent${NC}"
+            ;;
         *)
             echo -e "${RED}Unknown agent type: $agent_type${NC}" >&2
-            echo "Valid types: all, aristotle, researcher, deployer, seeker, enricher"
+            echo "Valid types: all, aristotle, researcher, deployer, seeker, enricher, tester"
             exit 1
             ;;
     esac

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -138,6 +138,7 @@ gather_status() {
     local researcher_sessions=()
     local seeker_status="stopped"
     local deployer_status="stopped"
+    local tester_status="stopped"
 
     # Enrichers
     for i in 1 2 3 4 5; do
@@ -166,6 +167,11 @@ gather_status() {
     # Deployer
     if session_exists "deployer"; then
         deployer_status="running:$(get_session_uptime "deployer")"
+    fi
+
+    # Tester
+    if session_exists "tester-agent"; then
+        tester_status="running:$(get_session_uptime "tester-agent")"
     fi
 
     # Work queue counts
@@ -232,6 +238,10 @@ gather_status() {
     "deployer": {
       "status": "${deployer_status%%:*}",
       "uptime": "${deployer_status#*:}"
+    },
+    "tester": {
+      "status": "${tester_status%%:*}",
+      "uptime": "${tester_status#*:}"
     }
   },
   "session_stats": {
@@ -318,6 +328,14 @@ EOF
             echo "      deployer: Running (${deployer_status#*:})"
         else
             echo -e "    ${BOLD}Deployer:${NC} ${YELLOW}0/1 active${NC}"
+        fi
+
+        # Tester
+        if [[ "${tester_status%%:*}" == "running" ]]; then
+            echo -e "    ${BOLD}Tester:${NC} ${GREEN}1/1 active${NC}"
+            echo "      tester-agent: Running (${tester_status#*:})"
+        else
+            echo -e "    ${BOLD}Tester:${NC} ${YELLOW}0/1 active${NC}"
         fi
         echo ""
 

--- a/scripts/test/launch-agent.sh
+++ b/scripts/test/launch-agent.sh
@@ -1,0 +1,293 @@
+#!/bin/bash
+#
+# launch-agent.sh - Launch the tester agent
+#
+# A singleton agent that periodically tests random proof pages on the live site
+# by clicking the dice button and verifying pages load without errors.
+# Failures are reported as GitHub issues.
+#
+# This is a script-based agent (no LLM) — it runs test-random-proofs.sh in a loop.
+#
+# Usage:
+#   ./launch-agent.sh              Launch tester (default 30min interval, 20 proofs/cycle)
+#   ./launch-agent.sh --stop       Stop the tester
+#   ./launch-agent.sh --status     Check tester status
+#   ./launch-agent.sh --attach     Attach to tester session
+#   ./launch-agent.sh --logs       Tail tester logs
+#
+# Environment:
+#   TESTER_INTERVAL    - Interval in minutes between test cycles (default: 30)
+#   TESTER_COUNT       - Number of proofs to test per cycle (default: 20)
+#   TESTER_URL         - Base URL to test (default: https://leangenius.org)
+
+set -euo pipefail
+
+# Find repo root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository" >&2
+    return 1
+}
+
+REPO_ROOT="$(find_repo_root)"
+LOGS_DIR="$REPO_ROOT/.loom/logs"
+SIGNALS_DIR="$REPO_ROOT/.loom/signals"
+SESSION_NAME="tester-agent"
+LOG_FILE="$LOGS_DIR/tester-agent.log"
+INTERVAL="${TESTER_INTERVAL:-30}"
+COUNT="${TESTER_COUNT:-20}"
+BASE_URL="${TESTER_URL:-https://leangenius.org}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+print_error() { echo -e "${RED}✗ $1${NC}"; }
+print_success() { echo -e "${GREEN}✓ $1${NC}"; }
+print_info() { echo -e "${BLUE}ℹ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}! $1${NC}"; }
+
+# Log with timestamp
+log() {
+    local msg="$*"
+    local ts
+    ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    echo "[$ts] $msg" >> "$LOG_FILE"
+    echo "[$ts] $msg"
+}
+
+# Check dependencies
+check_deps() {
+    local missing=()
+    command -v tmux >/dev/null 2>&1 || missing+=("tmux")
+    command -v npx >/dev/null 2>&1 || missing+=("npx")
+    command -v gh >/dev/null 2>&1 || missing+=("gh")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        print_error "Missing dependencies: ${missing[*]}"
+        exit 1
+    fi
+}
+
+# The main test loop (runs inside tmux)
+run_loop() {
+    mkdir -p "$LOGS_DIR" "$SIGNALS_DIR"
+
+    log "Tester agent starting (interval=${INTERVAL}m, count=${COUNT}, url=${BASE_URL})"
+
+    while true; do
+        # Check for stop signals
+        if [[ -f "$SIGNALS_DIR/stop-tester" ]] || [[ -f "$SIGNALS_DIR/stop-all" ]]; then
+            log "Stop signal received. Exiting."
+            rm -f "$SIGNALS_DIR/stop-tester"
+            exit 0
+        fi
+
+        # Run test cycle
+        log "Starting test cycle: ${COUNT} random proofs"
+        if "$REPO_ROOT/scripts/test/test-random-proofs.sh" --count "$COUNT" --url "$BASE_URL" >> "$LOG_FILE" 2>&1; then
+            log "Test cycle complete: all proofs OK"
+        else
+            local exit_code=$?
+            if [[ $exit_code -eq 1 ]]; then
+                log "Test cycle complete: some proofs failed (issues filed)"
+            else
+                log "Test cycle error (exit code: $exit_code)"
+            fi
+        fi
+
+        # Wait for next cycle (check stop signal every 30s during sleep)
+        log "Next cycle in ${INTERVAL} minutes..."
+        local wait_seconds=$((INTERVAL * 60))
+        local elapsed=0
+        while [[ $elapsed -lt $wait_seconds ]]; do
+            # Check stop signal during sleep
+            if [[ -f "$SIGNALS_DIR/stop-tester" ]] || [[ -f "$SIGNALS_DIR/stop-all" ]]; then
+                log "Stop signal received during sleep. Exiting."
+                rm -f "$SIGNALS_DIR/stop-tester"
+                exit 0
+            fi
+            # Check wake signal
+            if [[ -f "$SIGNALS_DIR/wake-tester-agent" ]] || [[ -f "$SIGNALS_DIR/wake-all" ]]; then
+                log "Wake signal received, starting next cycle early"
+                rm -f "$SIGNALS_DIR/wake-tester-agent"
+                rm -f "$SIGNALS_DIR/wake-all"
+                break
+            fi
+            sleep 30
+            elapsed=$((elapsed + 30))
+        done
+    done
+}
+
+# Launch the tester agent
+launch_agent() {
+    check_deps
+    mkdir -p "$LOGS_DIR" "$SIGNALS_DIR"
+
+    # Remove any existing stop signal
+    rm -f "$SIGNALS_DIR/stop-tester"
+
+    # Kill existing session if any
+    tmux kill-session -t "$SESSION_NAME" 2>/dev/null || true
+
+    print_info "Launching tester agent..."
+    print_info "Interval: $INTERVAL minutes"
+    print_info "Proofs per cycle: $COUNT"
+    print_info "URL: $BASE_URL"
+
+    # Launch in tmux — run the loop function directly
+    tmux new-session -d -s "$SESSION_NAME" -c "$REPO_ROOT" \
+        "$REPO_ROOT/scripts/test/launch-agent.sh --run-loop"
+
+    print_success "Launched tester agent"
+    echo ""
+    echo "Commands:"
+    echo "  ./scripts/test/launch-agent.sh --status     Check status"
+    echo "  ./scripts/test/launch-agent.sh --attach     Attach to session"
+    echo "  ./scripts/test/launch-agent.sh --logs       Tail logs"
+    echo "  ./scripts/test/launch-agent.sh --stop       Stop agent"
+}
+
+# Stop the tester
+stop_agent() {
+    print_info "Stopping tester agent..."
+
+    # Create stop signal for graceful shutdown
+    mkdir -p "$SIGNALS_DIR"
+    touch "$SIGNALS_DIR/stop-tester"
+
+    # Give it a moment to notice
+    sleep 2
+
+    # Kill the session
+    if tmux kill-session -t "$SESSION_NAME" 2>/dev/null; then
+        print_success "Stopped tester agent"
+    else
+        print_info "No tester session found"
+    fi
+
+    # Clean up signal
+    rm -f "$SIGNALS_DIR/stop-tester"
+}
+
+# Graceful stop (create signal file only, don't kill session)
+graceful_stop() {
+    mkdir -p "$SIGNALS_DIR"
+    touch "$SIGNALS_DIR/stop-tester"
+}
+
+# Check status
+check_status() {
+    echo "=== Tester Status ==="
+    echo ""
+
+    if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+        print_success "Tester is running"
+        echo ""
+        echo "Session: $SESSION_NAME"
+        echo "Log file: $LOG_FILE"
+        echo "Interval: $INTERVAL minutes"
+        echo "Proofs/cycle: $COUNT"
+        echo "URL: $BASE_URL"
+
+        if [[ -f "$LOG_FILE" ]]; then
+            echo ""
+            echo "Recent activity:"
+            tail -5 "$LOG_FILE" 2>/dev/null || echo "  (no logs yet)"
+        fi
+    else
+        print_info "Tester is not running"
+    fi
+}
+
+# Attach to session
+attach_session() {
+    if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+        print_error "No tester session found"
+        exit 1
+    fi
+
+    tmux attach-session -t "$SESSION_NAME"
+}
+
+# Tail logs
+tail_logs() {
+    if [[ ! -f "$LOG_FILE" ]]; then
+        print_error "No log file found: $LOG_FILE"
+        exit 1
+    fi
+
+    tail -f "$LOG_FILE"
+}
+
+# Main command dispatch
+case "${1:-}" in
+    --run-loop)
+        # Internal: called by tmux session to run the main loop
+        run_loop
+        ;;
+    --stop|-s)
+        stop_agent
+        ;;
+    --graceful-stop)
+        graceful_stop
+        ;;
+    --status)
+        check_status
+        ;;
+    --attach|-a)
+        attach_session
+        ;;
+    --logs|-l)
+        tail_logs
+        ;;
+    --help|-h)
+        cat << EOF
+Tester Agent Launcher
+
+Launches an autonomous script-based agent that periodically tests random
+proof pages on the live site by clicking the dice button and verifying
+each page loads without errors. Failures are reported as GitHub issues.
+
+No worktree needed — this is read-only testing, no git changes.
+
+Usage:
+  ./launch-agent.sh              Launch tester (default 30min interval)
+  ./launch-agent.sh --stop       Stop the tester
+  ./launch-agent.sh --status     Check tester status
+  ./launch-agent.sh --attach     Attach to tester session
+  ./launch-agent.sh --logs       Tail tester logs
+  ./launch-agent.sh --help       Show this help
+
+Environment Variables:
+  TESTER_INTERVAL   Interval in minutes between test cycles (default: 30)
+  TESTER_COUNT      Number of proofs to test per cycle (default: 20)
+  TESTER_URL        Base URL to test (default: https://leangenius.org)
+
+Examples:
+  ./launch-agent.sh                        # Start with defaults
+  TESTER_INTERVAL=15 ./launch-agent.sh     # Test every 15 minutes
+  TESTER_COUNT=50 ./launch-agent.sh        # Test 50 proofs per cycle
+  ./launch-agent.sh --attach               # Watch the agent work
+EOF
+        ;;
+    "")
+        launch_agent
+        ;;
+    *)
+        print_error "Unknown option: $1"
+        echo "Run '$0 --help' for usage"
+        exit 1
+        ;;
+esac

--- a/scripts/test/random-proof-checker.ts
+++ b/scripts/test/random-proof-checker.ts
@@ -1,0 +1,225 @@
+/**
+ * random-proof-checker.ts
+ *
+ * Playwright script that visits leangenius.org, clicks the random proof dice
+ * button N times, and verifies each proof page loads without errors.
+ * Failures are reported as GitHub issues (deduplicated).
+ *
+ * Usage: npx tsx scripts/test/random-proof-checker.ts [--count N] [--url URL]
+ */
+
+import { chromium, type Page, type ConsoleMessage } from 'playwright'
+import { execSync } from 'child_process'
+
+// --- CLI args ---
+const args = process.argv.slice(2)
+function getArg(name: string, fallback: string): string {
+  const idx = args.indexOf(name)
+  return idx !== -1 && args[idx + 1] ? args[idx + 1] : fallback
+}
+const COUNT = parseInt(getArg('--count', '20'), 10)
+const BASE_URL = getArg('--url', 'https://leangenius.org')
+
+interface TestResult {
+  slug: string
+  url: string
+  ok: boolean
+  error?: string
+}
+
+async function extractSlug(page: Page): Promise<string> {
+  const url = page.url()
+  const match = url.match(/\/proof\/([^/?#]+)/)
+  return match ? match[1] : url
+}
+
+/** Check if a GitHub issue already exists for this slug */
+function issueExists(slug: string): boolean {
+  try {
+    const out = execSync(
+      `gh issue list --state open --search "[tester] ${slug}" --json number --limit 1`,
+      { encoding: 'utf8', timeout: 15000 }
+    )
+    const issues = JSON.parse(out)
+    return issues.length > 0
+  } catch {
+    return false // if gh fails, allow issue creation
+  }
+}
+
+/** Open a GitHub issue for a broken proof page */
+function fileIssue(result: TestResult, screenshotPath?: string): void {
+  if (issueExists(result.slug)) {
+    console.log(`  Issue already exists for ${result.slug}, skipping`)
+    return
+  }
+
+  const body = [
+    '## Tester Agent Report',
+    '',
+    `The random proof checker found an error on proof page **${result.slug}**.`,
+    '',
+    `**URL**: ${result.url}`,
+    `**Error**: ${result.error}`,
+    '',
+    '### Reproduction',
+    '1. Navigate to https://leangenius.org',
+    '2. Click the random proof dice button until you reach this proof',
+    `3. Or go directly to ${result.url}`,
+    '',
+    screenshotPath ? `Screenshot attached separately.` : '',
+    '',
+    '---',
+    '*Filed automatically by the tester agent (`scripts/test/random-proof-checker.ts`)*',
+  ].join('\n')
+
+  try {
+    execSync(
+      `gh issue create --title "[tester] Proof page broken: ${result.slug}" --body "${body.replace(/"/g, '\\"')}" --label bug`,
+      { encoding: 'utf8', timeout: 30000 }
+    )
+    console.log(`  Filed issue for ${result.slug}`)
+  } catch (e) {
+    console.error(`  Failed to file issue for ${result.slug}:`, e)
+  }
+}
+
+async function run(): Promise<void> {
+  console.log(`Testing ${COUNT} random proofs on ${BASE_URL}`)
+
+  const browser = await chromium.launch({ headless: true })
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 720 },
+  })
+  const page = await context.newPage()
+
+  // Collect console errors
+  const consoleErrors: string[] = []
+  page.on('console', (msg: ConsoleMessage) => {
+    if (msg.type() === 'error') {
+      consoleErrors.push(msg.text())
+    }
+  })
+
+  // Track failed network requests
+  const networkErrors: string[] = []
+  page.on('requestfailed', (req) => {
+    networkErrors.push(`${req.url()} - ${req.failure()?.errorText ?? 'unknown'}`)
+  })
+
+  const results: TestResult[] = []
+
+  // Navigate to home page
+  console.log(`Navigating to ${BASE_URL}...`)
+  await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 30000 })
+
+  for (let i = 0; i < COUNT; i++) {
+    consoleErrors.length = 0
+    networkErrors.length = 0
+
+    // Click the dice button (title="Random proof")
+    const diceButton = page.locator('button[title="Random proof"]')
+    if (!(await diceButton.isVisible({ timeout: 5000 }).catch(() => false))) {
+      // If not on home page (e.g., on a proof page), go back first
+      await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 30000 })
+    }
+
+    await diceButton.click()
+
+    // Wait for navigation to complete
+    try {
+      await page.waitForURL(/\/proof\//, { timeout: 10000 })
+      await page.waitForLoadState('networkidle', { timeout: 15000 })
+    } catch {
+      const slug = await extractSlug(page)
+      results.push({
+        slug,
+        url: page.url(),
+        ok: false,
+        error: 'Navigation timeout: page did not load within 15s',
+      })
+      console.log(`  [${i + 1}/${COUNT}] FAIL ${slug} - navigation timeout`)
+      continue
+    }
+
+    const slug = await extractSlug(page)
+    const url = page.url()
+
+    // Check for error states in page content
+    const errorText = await page
+      .locator('text=/Error Loading Proof|Proof not found|Something went wrong/')
+      .first()
+      .textContent({ timeout: 2000 })
+      .catch(() => null)
+
+    if (errorText) {
+      results.push({ slug, url, ok: false, error: `Page error: ${errorText}` })
+      console.log(`  [${i + 1}/${COUNT}] FAIL ${slug} - ${errorText}`)
+      continue
+    }
+
+    // Check for console errors (ignore benign ones)
+    const significantErrors = consoleErrors.filter(
+      (e) => !e.includes('favicon') && !e.includes('analytics')
+    )
+
+    if (significantErrors.length > 0) {
+      results.push({
+        slug,
+        url,
+        ok: false,
+        error: `Console errors: ${significantErrors.join('; ')}`,
+      })
+      console.log(`  [${i + 1}/${COUNT}] FAIL ${slug} - console errors`)
+      continue
+    }
+
+    // Check for network failures on the proof page (ignore external)
+    const significantNetworkErrors = networkErrors.filter(
+      (e) => e.includes('leangenius.org') || e.includes('localhost')
+    )
+
+    if (significantNetworkErrors.length > 0) {
+      results.push({
+        slug,
+        url,
+        ok: false,
+        error: `Network errors: ${significantNetworkErrors.join('; ')}`,
+      })
+      console.log(`  [${i + 1}/${COUNT}] FAIL ${slug} - network errors`)
+      continue
+    }
+
+    results.push({ slug, url, ok: true })
+    console.log(`  [${i + 1}/${COUNT}] OK   ${slug}`)
+
+    // Navigate back to home for next dice click
+    await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 30000 })
+  }
+
+  await browser.close()
+
+  // Summary
+  const passed = results.filter((r) => r.ok).length
+  const failed = results.filter((r) => !r.ok).length
+
+  console.log('')
+  console.log(`Results: ${passed} passed, ${failed} failed out of ${results.length} tested`)
+
+  // File issues for failures
+  if (failed > 0) {
+    console.log('')
+    console.log('Filing issues for failures...')
+    for (const result of results.filter((r) => !r.ok)) {
+      fileIssue(result)
+    }
+  }
+
+  // Exit with non-zero if any failures
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+run().catch((err) => {
+  console.error('Fatal error:', err)
+  process.exit(2)
+})

--- a/scripts/test/test-random-proofs.sh
+++ b/scripts/test/test-random-proofs.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# test-random-proofs.sh - Run the random proof checker
+#
+# Tests N random proofs on the live site by clicking the dice button
+# and verifying each proof page loads without errors.
+#
+# Usage:
+#   ./scripts/test/test-random-proofs.sh           # Test 20 random proofs
+#   ./scripts/test/test-random-proofs.sh --count 50 # Test 50 random proofs
+#   ./scripts/test/test-random-proofs.sh --url http://localhost:5173  # Test local dev
+#
+# Exit codes:
+#   0 - All proofs loaded successfully
+#   1 - One or more proofs failed (issues filed)
+#   2 - Script/infrastructure error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+print_error() { echo -e "${RED}✗ $1${NC}"; }
+print_success() { echo -e "${GREEN}✓ $1${NC}"; }
+print_info() { echo -e "${BLUE}ℹ $1${NC}"; }
+
+# Check dependencies
+check_deps() {
+    local missing=()
+    command -v npx >/dev/null 2>&1 || missing+=("npx (install Node.js)")
+    command -v gh >/dev/null 2>&1 || missing+=("gh (GitHub CLI)")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        print_error "Missing dependencies: ${missing[*]}"
+        exit 2
+    fi
+}
+
+# Ensure Playwright browsers are installed
+ensure_browsers() {
+    if ! npx playwright install --dry-run chromium >/dev/null 2>&1; then
+        print_info "Installing Playwright Chromium browser..."
+        npx playwright install chromium 2>&1 || {
+            print_error "Failed to install Playwright browsers"
+            exit 2
+        }
+        print_success "Playwright browsers installed"
+    fi
+}
+
+# Main
+main() {
+    check_deps
+
+    print_info "Ensuring Playwright browsers are available..."
+    ensure_browsers
+
+    print_info "Starting random proof checker..."
+    echo ""
+
+    cd "$REPO_ROOT"
+    npx tsx scripts/test/random-proof-checker.ts "$@"
+    local exit_code=$?
+
+    echo ""
+    if [[ $exit_code -eq 0 ]]; then
+        print_success "All proofs loaded successfully"
+    elif [[ $exit_code -eq 1 ]]; then
+        print_error "Some proofs failed - issues filed on GitHub"
+    else
+        print_error "Script error (exit code: $exit_code)"
+    fi
+
+    return $exit_code
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds an autonomous **tester agent** that periodically clicks the random proof dice button on the live site, verifying each proof page loads without errors
- Failures are automatically filed as deduplicated GitHub issues with the `bug` label
- Script-based (Playwright, no LLM needed) — runs as a singleton alongside deployer/seeker

## New Files

- `scripts/test/random-proof-checker.ts` — Playwright test: navigates to site, clicks dice N times, checks for DOM errors, console errors, network failures
- `scripts/test/test-random-proofs.sh` — Shell wrapper with Playwright browser setup
- `scripts/test/launch-agent.sh` — Singleton tmux agent launcher with signal-based stop/wake

## Modified Files

- `scripts/lean/launch.sh` — Full integration: spawn, scale, wake, daemon, health, start/stop
- `scripts/lean/status.sh` — Tester shown in formatted + JSON status output
- `CLAUDE.md` — Tester added to agent table and pool limits

## Test plan

- [ ] `./scripts/test/launch-agent.sh` — starts tmux session, runs first cycle
- [ ] `./scripts/test/launch-agent.sh --status` — shows running status
- [ ] `./scripts/lean/launch.sh spawn tester` — spawns via orchestrator
- [ ] `./scripts/lean/launch.sh status` — shows tester in output
- [ ] `./scripts/test/launch-agent.sh --stop` — stops gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)