### PR TITLE
fix: unwrap loose list paragraphs for proper list formatting

### DIFF
--- a/src/components/ui/markdown-math.tsx
+++ b/src/components/ui/markdown-math.tsx
@@ -10,6 +10,33 @@ interface MarkdownMathProps {
 }
 
 /**
+ * Rehype plugin: unwrap <p> inside <li> (caused by "loose" markdown lists
+ * with blank lines between items). Prevents list markers from detaching
+ * from paragraph content when using list-inside positioning.
+ */
+function rehypeUnwrapListParagraphs() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (tree: any) => {
+    function walk(node: any) {
+      if (!node.children) return
+      for (const child of node.children) walk(child)
+      if (node.tagName === 'li') {
+        const flat: any[] = []
+        for (const child of node.children) {
+          if (child.type === 'element' && child.tagName === 'p') {
+            flat.push(...child.children)
+          } else {
+            flat.push(child)
+          }
+        }
+        node.children = flat
+      }
+    }
+    walk(tree)
+  }
+}
+
+/**
  * Renders markdown text with LaTeX math support.
  *
  * Supports:
@@ -25,7 +52,7 @@ export function MarkdownMath({ children, className }: MarkdownMathProps) {
     <div className={className}>
       <ReactMarkdown
         remarkPlugins={[remarkMath]}
-        rehypePlugins={[rehypeKatex]}
+        rehypePlugins={[rehypeUnwrapListParagraphs, rehypeKatex]}
         components={{
           // Style paragraphs to match existing design
           p: ({ children }: { children?: ReactNode }) => (
@@ -69,7 +96,7 @@ export function MarkdownMathInline({ children, className }: MarkdownMathProps) {
     <span className={className}>
       <ReactMarkdown
         remarkPlugins={[remarkMath]}
-        rehypePlugins={[rehypeKatex]}
+        rehypePlugins={[rehypeUnwrapListParagraphs, rehypeKatex]}
         components={{
           // Remove paragraph wrapper for inline use
           p: ({ children }: { children?: ReactNode }) => <>{children}</>,


### PR DESCRIPTION
## Summary

- Fixes broken formatting in the "Proof Strategy" section on ~650 proof pages (e.g., [erdos-188](https://leangenius.org/proof/erdos-188))
- Numbered lists with blank lines between items ("loose lists") caused `<p>` tags inside `<li>`, which detached list markers from text and added excessive spacing
- Adds a `rehypeUnwrapListParagraphs` plugin to `markdown-math.tsx` that flattens `<p>` wrappers inside `<li>` at the HTML AST level before React rendering

## Root cause

Markdown like this (very common in our proof data):
```markdown
1. **Coloring:** PlaneColoring := C -> Bool

2. **Constraints:** RedUnitDistanceFree
```

Produces loose list HTML: `<li><p><strong>...</strong>...</p></li>`. With `list-inside` positioning, the decimal marker detaches from the `<p>` block, and the `<p>`'s `mb-3` margin creates excessive vertical gaps.

## Test plan

- [ ] Visit https://leangenius.org/proof/erdos-188 — "Proof Strategy" should show a clean numbered list
- [ ] Spot-check other proofs with numbered strategies (erdos-794, erdos-707, erdos-239)
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)