### PR TITLE
enrich: add annotations for partition-theorem-oq-01

### DIFF
--- a/src/data/proofs/partition-theorem-oq-01/annotations.json
+++ b/src/data/proofs/partition-theorem-oq-01/annotations.json
@@ -1,1 +1,122 @@
-[]
+[
+  {
+    "id": "hasMinGap-definition",
+    "proofId": "partition-theorem-oq-01",
+    "range": { "startLine": 41, "endLine": 47 },
+    "type": "definition",
+    "title": "Computable Gap Condition on Lists",
+    "content": "The hasMinGap function checks whether a sorted (decreasing) list of natural numbers has a minimum gap of d between consecutive elements. It is implemented as a recursive Boolean-valued function, making it decidable and usable in computational verification. This is the core building block for defining the Rogers-Ramanujan partition sets.",
+    "mathContext": "A list $[a_1, a_2, \\ldots, a_k]$ with $a_1 \\geq a_2 \\geq \\cdots \\geq a_k$ satisfies $\\texttt{hasMinGap}(l, d)$ if $a_i - a_{i+1} \\geq d$ for all consecutive pairs.",
+    "significance": "key",
+    "relatedConcepts": ["partition gap conditions", "decidable predicates", "recursive functions on lists"],
+    "prerequisites": ["List recursion in Lean 4", "Boolean decidability"]
+  },
+  {
+    "id": "partition-extensions",
+    "proofId": "partition-theorem-oq-01",
+    "range": { "startLine": 53, "endLine": 71 },
+    "type": "context",
+    "title": "Noncomputable Partition Predicates via Multiset Sorting",
+    "content": "The predicates partHasMinGap, partSmallestPart, and partAllModIn lift the list-level gap condition to Nat.Partition by converting the multiset of parts to a sorted list. This requires the noncomputable section because Multiset.sort produces a list from a multiset, which is not computationally canonical. The modular condition check partAllModIn is the key predicate for the congruence side of the Rogers-Ramanujan identities.",
+    "mathContext": "For a partition $\\lambda \\vdash n$ with parts multiset $\\{\\lambda_1, \\ldots, \\lambda_k\\}$, sorting produces the sequence $\\lambda_1 \\geq \\lambda_2 \\geq \\cdots \\geq \\lambda_k$ on which gap and modular conditions are checked.",
+    "significance": "supporting",
+    "relatedConcepts": ["Multiset.sort", "Nat.Partition", "noncomputable definitions", "modular arithmetic on parts"],
+    "prerequisites": ["Mathlib Nat.Partition type", "Multiset API", "noncomputable in Lean 4"]
+  },
+  {
+    "id": "rr1-partition-sets",
+    "proofId": "partition-theorem-oq-01",
+    "range": { "startLine": 77, "endLine": 94 },
+    "type": "definition",
+    "title": "Rogers-Ramanujan Partition Set Definitions",
+    "content": "Four partition sets are defined for the two Rogers-Ramanujan identities. rr1GapPartitions selects partitions with gap at least 2 between consecutive parts, while rr1Mod5Partitions selects partitions whose parts are all congruent to 1 or 4 modulo 5. The RR2 variants additionally require the smallest part to be at least 2 (gap side) or restrict to residues 2 and 3 modulo 5 (congruence side). All sets are defined as filtered Finsets over the universe of Nat.Partition n.",
+    "mathContext": "RR1: $|\\{\\lambda \\vdash n : \\lambda_i - \\lambda_{i+1} \\geq 2\\}| = |\\{\\lambda \\vdash n : \\text{all parts} \\equiv 1,4 \\pmod{5}\\}|$. RR2: same with $\\lambda_k \\geq 2$ and residues $\\{2,3\\}$ mod 5.",
+    "significance": "key",
+    "relatedConcepts": ["Rogers-Ramanujan identities", "partition gap conditions", "modular partition classes", "Finset.filter"],
+    "prerequisites": ["Finset.univ for Nat.Partition", "Fintype instance for partitions"]
+  },
+  {
+    "id": "rr-axioms",
+    "proofId": "partition-theorem-oq-01",
+    "range": { "startLine": 100, "endLine": 106 },
+    "type": "insight",
+    "title": "Rogers-Ramanujan Identities as Axioms",
+    "content": "The two Rogers-Ramanujan identities are stated as axioms rather than proved theorems. This is a deliberate formalization choice: proving these identities requires either q-series manipulation (the Jacobi triple product and related machinery, not yet available in Mathlib) or intricate bijective proofs such as the Garsia-Milne involution principle, which would require 500+ lines of combinatorial construction each. The axiom-based approach lets the formalization establish the structural framework and prove consequences without waiting for the deep proof infrastructure.",
+    "mathContext": "The RR1 identity has the q-series form: $\\sum_{k=0}^{\\infty} \\frac{q^{k^2}}{(q;q)_k} = \\prod_{n=0}^{\\infty} \\frac{1}{(1-q^{5n+1})(1-q^{5n+4})}$",
+    "significance": "key",
+    "relatedConcepts": ["q-series", "Jacobi triple product", "Garsia-Milne involution", "axiom-based formalization"],
+    "prerequisites": ["formal power series", "partition generating functions"]
+  },
+  {
+    "id": "schur-identity",
+    "proofId": "partition-theorem-oq-01",
+    "range": { "startLine": 112, "endLine": 125 },
+    "type": "theorem",
+    "title": "Schur's Partition Identity (1926)",
+    "content": "Schur's identity equates two classes of partitions of n: those into distinct parts congruent to 1 or 2 modulo 3 (the mod side), and those with minimum gap 3 between consecutive parts and distinctness (the gap side). The formalization uses Nodup on both sides to enforce distinctness. Like the Rogers-Ramanujan identities, Schur's identity is stated as an axiom, as it requires similarly deep combinatorial or analytic machinery to prove.",
+    "mathContext": "Schur (1926): $|\\{\\lambda \\vdash n : \\text{distinct, parts} \\equiv \\pm 1 \\pmod{3}\\}| = |\\{\\lambda \\vdash n : \\text{gap} \\geq 3, \\text{distinct}\\}|$",
+    "significance": "key",
+    "relatedConcepts": ["Schur's theorem", "distinct partitions", "modular partition identities", "List.Nodup"],
+    "prerequisites": ["partition theory fundamentals", "modular arithmetic"]
+  },
+  {
+    "id": "gap-two-pairwise-gt",
+    "proofId": "partition-theorem-oq-01",
+    "range": { "startLine": 131, "endLine": 147 },
+    "type": "technique",
+    "title": "Gap >= 2 Implies Pairwise Strict Inequality",
+    "content": "This private lemma is the technical heart of the structural results. It proves that if a list has minimum gap 2 between consecutive elements, then all elements are pairwise strictly decreasing. The proof proceeds by induction on the list, using pattern matching to handle the base cases (empty and singleton lists). For the inductive step, it shows that the head is greater than every element in the tail by combining the direct gap with the inductively established pairwise relation on the tail, using omega to discharge the arithmetic.",
+    "mathContext": "If $a_i - a_{i+1} \\geq 2$ for all consecutive pairs in a decreasing list, then $a_i > a_j$ for all $i < j$, establishing $\\texttt{List.Pairwise}\\;(\\cdot > \\cdot)$.",
+    "significance": "key",
+    "relatedConcepts": ["List.Pairwise", "structural induction", "omega tactic", "strict monotonicity"],
+    "prerequisites": ["List induction in Lean 4", "Pairwise relation on lists"]
+  },
+  {
+    "id": "rr1-gap-distinct",
+    "proofId": "partition-theorem-oq-01",
+    "range": { "startLine": 149, "endLine": 161 },
+    "type": "theorem",
+    "title": "Gap >= 2 Partitions Have Distinct Parts",
+    "content": "This theorem establishes that every RR1 gap partition (consecutive parts differ by at least 2) is also a distinct partition. The proof chains the pairwise strict inequality lemma through ne_of_gt to get a Nodup property on the sorted list, then uses Multiset.sort_eq to transfer the Nodup back to the original multiset of parts. This is one of the key original contributions of the formalization, placing gap partitions in the correct containment hierarchy.",
+    "mathContext": "If $\\lambda_i - \\lambda_{i+1} \\geq 2$ for all $i$, then all $\\lambda_i$ are distinct, i.e., $\\lambda \\in \\mathcal{D}(n)$ (the set of partitions into distinct parts).",
+    "significance": "key",
+    "relatedConcepts": ["Nat.Partition.distincts", "Multiset.coe_nodup", "Multiset.sort_eq", "partition containment hierarchy"],
+    "prerequisites": ["List.Pairwise implies Nodup", "Multiset.sort properties"]
+  },
+  {
+    "id": "rr2-subset-rr1",
+    "proofId": "partition-theorem-oq-01",
+    "range": { "startLine": 163, "endLine": 169 },
+    "type": "theorem",
+    "title": "RR2 Gap Partitions are a Subset of RR1 Gap Partitions",
+    "content": "This theorem proves the natural containment: every RR2 gap partition is also an RR1 gap partition. Since RR2 partitions require both the gap-2 condition and a minimum part of 2, they form a strictly smaller class than RR1 partitions which only require the gap condition. The proof uses simp to unfold the filter definitions and tauto to dispatch the logical implication from a conjunction to one of its components.",
+    "mathContext": "The containment hierarchy: $\\text{RR2\\_gap}(n) \\subseteq \\text{RR1\\_gap}(n) \\subseteq \\mathcal{D}(n) \\subseteq \\mathcal{P}(n)$ where $\\mathcal{D}(n)$ is distinct partitions and $\\mathcal{P}(n)$ is all partitions.",
+    "significance": "supporting",
+    "relatedConcepts": ["set containment", "partition hierarchy", "Rogers-Ramanujan gap conditions", "tauto tactic"],
+    "prerequisites": ["Finset subset relation", "Boolean conjunction properties"]
+  },
+  {
+    "id": "false-theorem-counterexample",
+    "proofId": "partition-theorem-oq-01",
+    "range": { "startLine": 171, "endLine": 172 },
+    "type": "insight",
+    "title": "Identifying a False Containment: Mod-5 Partitions Are Not Necessarily Distinct",
+    "content": "This comment documents an important negative result discovered during formalization: the conjecture that rr1Mod5Partitions is contained in the distinct partitions is FALSE. The counterexample is the partition 1+1+1 = 3, where every part is congruent to 1 modulo 5 (so it belongs to rr1Mod5Partitions) but the partition has repeated parts (so it is not distinct). This illustrates the asymmetry between the gap and congruence sides of the Rogers-Ramanujan identity: gap conditions force distinctness, but modular conditions do not.",
+    "mathContext": "Counterexample: $3 = 1+1+1$. Each part satisfies $1 \\equiv 1 \\pmod{5}$, so $\\lambda \\in \\text{RR1\\_mod5}(3)$, but $\\lambda \\notin \\mathcal{D}(3)$ since parts repeat.",
+    "significance": "key",
+    "relatedConcepts": ["counterexample discovery", "partition distinctness", "gap vs congruence asymmetry"],
+    "prerequisites": ["modular arithmetic", "distinct partitions"]
+  },
+  {
+    "id": "formalization-summary",
+    "proofId": "partition-theorem-oq-01",
+    "range": { "startLine": 193, "endLine": 217 },
+    "type": "context",
+    "title": "Formalization Status and Future Directions",
+    "content": "The summary section catalogs the full scope of the formalization: 6 partition set definitions, 3 axiomatized identities, and 3 fully proved structural theorems with 0 sorries. The axiomatization is justified by the infrastructure gap in Mathlib: proving the Rogers-Ramanujan identities would require either formal power series q-series manipulation or bijective combinatorial constructions (Garsia-Milne, Bressoud) of substantial complexity. The formalization demonstrates that significant structural theory can be developed around axiomatized core results.",
+    "mathContext": "The q-series proof requires the Jacobi triple product formula and manipulations with $(q;q)_k = \\prod_{i=1}^k (1-q^i)$. The bijective proofs involve weight-preserving involutions on pairs of partitions.",
+    "significance": "supporting",
+    "relatedConcepts": ["axiom-based formalization methodology", "Mathlib infrastructure gaps", "q-series", "bijective combinatorics"],
+    "prerequisites": ["formal power series in Lean", "Mathlib Combinatorics.Enumerative"]
+  }
+]


### PR DESCRIPTION
## Summary
- Add 10 detailed annotations to the Rogers-Ramanujan and Schur partition identity formalization
- Annotations cover all major sections: computable gap condition definition, noncomputable partition predicates, RR1/RR2 partition set definitions, axiom justifications, Schur's identity, the key gap-2-implies-pairwise-gt lemma, structural theorems, the false-containment counterexample, and formalization summary
- Each annotation includes LaTeX math context, significance rating, related concepts, and prerequisites

## Annotations
| ID | Type | Lines | Title |
|----|------|-------|-------|
| hasMinGap-definition | definition | 41-47 | Computable Gap Condition on Lists |
| partition-extensions | context | 53-71 | Noncomputable Partition Predicates via Multiset Sorting |
| rr1-partition-sets | definition | 77-94 | Rogers-Ramanujan Partition Set Definitions |
| rr-axioms | insight | 100-106 | Rogers-Ramanujan Identities as Axioms |
| schur-identity | theorem | 112-125 | Schur's Partition Identity (1926) |
| gap-two-pairwise-gt | technique | 131-147 | Gap >= 2 Implies Pairwise Strict Inequality |
| rr1-gap-distinct | theorem | 149-161 | Gap >= 2 Partitions Have Distinct Parts |
| rr2-subset-rr1 | theorem | 163-169 | RR2 Gap Partitions are a Subset of RR1 |
| false-theorem-counterexample | insight | 171-172 | False Containment: Mod-5 Not Necessarily Distinct |
| formalization-summary | context | 193-217 | Formalization Status and Future Directions |

## Test plan
- [ ] Verify annotations.json is valid JSON
- [ ] Verify all line ranges correspond to correct source lines in PartitionTheoremOQ01.lean
- [ ] Verify gallery renders annotations correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)