### PR TITLE
enrich: add annotations for fourier-series-oq-03

### DIFF
--- a/src/data/proofs/fourier-series-oq-03/annotations.json
+++ b/src/data/proofs/fourier-series-oq-03/annotations.json
@@ -1,1 +1,122 @@
-[]
+[
+  {
+    "id": "fourier-oq03-partial-sum-def",
+    "proofId": "fourier-series-oq-03",
+    "range": { "startLine": 62, "endLine": 68 },
+    "type": "definition",
+    "title": "Fourier Partial Sum as a Finset Sum over Icc",
+    "content": "The N-th Fourier partial sum is defined as a sum over the symmetric integer interval [-N, N] of the product of Fourier coefficients and Fourier monomials. This definition uses Mathlib's fourierCoeff and fourier from the AddCircle API, which encode the coefficients c_n(f) and the exponentials e_n(x) = exp(2*pi*i*n*x/T) respectively. The choice of Icc (rather than separate positive and negative sums) keeps the definition symmetric and simplifies the connection to the Dirichlet kernel.",
+    "mathContext": "$S_N f(x) = \\sum_{n=-N}^{N} \\hat{c}_n(f) \\cdot e_n(x)$, where $\\hat{c}_n(f) = \\frac{1}{T} \\int_0^T f(t) e^{-2\\pi i n t / T} \\, dt$.",
+    "significance": "key",
+    "relatedConcepts": ["Fourier coefficient", "Fourier monomial", "trigonometric polynomial", "AddCircle"],
+    "prerequisites": ["Mathlib.Analysis.Fourier.AddCircle", "fourierCoeff", "fourier"]
+  },
+  {
+    "id": "fourier-oq03-dirichlet-kernel",
+    "proofId": "fourier-series-oq-03",
+    "range": { "startLine": 88, "endLine": 97 },
+    "type": "definition",
+    "title": "The Dirichlet Kernel on AddCircle",
+    "content": "The Dirichlet kernel D_N(t) is the sum of all Fourier monomials from -N to N. It acts as a reproducing kernel: convolving any function f with D_N recovers exactly the N-th Fourier partial sum. In classical form, D_N(t) = sin((2N+1)t/2) / sin(t/2), but here it is defined purely in terms of the Fourier basis, which avoids dealing with the singularity at t = 0 and connects directly to Mathlib infrastructure.",
+    "mathContext": "$D_N(t) = \\sum_{n=-N}^{N} e_n(t) = \\frac{\\sin((2N+1)t/2)}{\\sin(t/2)}$ (classical closed form).",
+    "significance": "key",
+    "relatedConcepts": ["approximate identity", "convolution kernel", "Fejer kernel", "sinc function"],
+    "prerequisites": ["fourier", "AddCircle", "Finset.Icc"]
+  },
+  {
+    "id": "fourier-oq03-kernel-at-zero",
+    "proofId": "fourier-series-oq-03",
+    "range": { "startLine": 117, "endLine": 127 },
+    "type": "technique",
+    "title": "Evaluating D_N(0) via Fourier Monomial Triviality",
+    "content": "The proof that D_N(0) = 2N+1 exploits the fact that every Fourier monomial evaluates to 1 at the origin: fourier n 0 = 1. This reduces the sum to counting terms via the cardinality of Icc(-N, N). The auxiliary lemma fourier_at_zero is proved using Mathlib's fourier_apply, smul_zero, and AddCircle.toCircle_zero. This value is essential for the normalization argument in the localization lemma.",
+    "mathContext": "$D_N(0) = \\sum_{n=-N}^{N} e_n(0) = \\sum_{n=-N}^{N} 1 = 2N + 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fourier monomial at origin", "kernel normalization", "Icc cardinality"],
+    "prerequisites": ["fourier_apply", "AddCircle.toCircle_zero", "Int.card_Icc"]
+  },
+  {
+    "id": "fourier-oq03-conjugate-symmetry",
+    "proofId": "fourier-series-oq-03",
+    "range": { "startLine": 129, "endLine": 144 },
+    "type": "insight",
+    "title": "Conjugate Symmetry of the Dirichlet Kernel",
+    "content": "The identity D_N(-t) = conj(D_N(t)) is proved by showing that fourier n (-t) = conj(fourier n t), using the intermediate step fourier n (-t) = fourier (-n) t together with Mathlib's fourier_neg. The conjugate symmetry then follows by distributing the star map over the finite sum. This property reflects the real-valuedness of D_N (up to identification) and is used in the integral splitting of the localization argument.",
+    "mathContext": "$D_N(-t) = \\overline{D_N(t)}$, since $e_n(-t) = e^{-2\\pi i n t / T} = \\overline{e_n(t)}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["conjugate symmetry", "Fourier monomial parity", "star ring endomorphism"],
+    "prerequisites": ["fourier_neg", "starRingEnd", "map_sum"]
+  },
+  {
+    "id": "fourier-oq03-bv-circle",
+    "proofId": "fourier-series-oq-03",
+    "range": { "startLine": 181, "endLine": 190 },
+    "type": "definition",
+    "title": "Bounded Variation on the Circle via Lifting",
+    "content": "The predicate HasBoundedVariationCircle lifts Mathlib's BoundedVariationOn from real intervals to the additive circle by composing f with the quotient map R -> AddCircle T and checking BV on [0, T]. This design reuses Mathlib's existing BV infrastructure (eVariationOn, total variation) while adapting it to the periodic setting. The interval [0, T] is chosen as a fundamental domain; the equivalent [-T/2, T/2] would give the same result for periodic functions.",
+    "mathContext": "$f : \\mathbb{R}/T\\mathbb{Z} \\to \\mathbb{C}$ has bounded variation if $f \\circ \\iota$ has bounded variation on $[0, T]$, where $\\iota : \\mathbb{R} \\to \\mathbb{R}/T\\mathbb{Z}$ is the quotient map.",
+    "significance": "key",
+    "relatedConcepts": ["bounded variation", "total variation", "AddCircle", "quotient map", "fundamental domain"],
+    "prerequisites": ["BoundedVariationOn", "eVariationOn", "Set.Icc"]
+  },
+  {
+    "id": "fourier-oq03-one-sided-limits",
+    "proofId": "fourier-series-oq-03",
+    "range": { "startLine": 197, "endLine": 221 },
+    "type": "definition",
+    "title": "One-Sided Limits via limUnder and nhdsWithin",
+    "content": "The right and left limits of f at x_0 are defined using Mathlib's limUnder applied to the nhdsWithin filter restricted to Ioi (for right) or Iio (for left). The definitions work in the lifted setting (f composed with the quotient map), matching the BV definition. The existence axioms assert that BV functions have one-sided limits everywhere, a classical result proved via the monotone decomposition theorem (every BV function is a difference of two monotone functions).",
+    "mathContext": "$f(x_0^+) = \\lim_{x \\to x_0^+} f(x)$, $f(x_0^-) = \\lim_{x \\to x_0^-} f(x)$, defined as $\\texttt{limUnder}(\\mathcal{N}(x_0) \\cap (x_0, \\infty), f \\circ \\iota)$.",
+    "significance": "key",
+    "relatedConcepts": ["one-sided limit", "nhdsWithin", "limUnder", "monotone decomposition", "discontinuity classification"],
+    "prerequisites": ["Filter.Tendsto", "nhdsWithin", "Set.Ioi", "Set.Iio", "limUnder"]
+  },
+  {
+    "id": "fourier-oq03-main-theorem",
+    "proofId": "fourier-series-oq-03",
+    "range": { "startLine": 306, "endLine": 327 },
+    "type": "theorem",
+    "title": "Dirichlet Pointwise Convergence Theorem (Main Result)",
+    "content": "The main theorem is proved (not axiomatized) by chaining four ingredients: (1) obtain one-sided limit witnesses Lp, Lm from the BV existence axioms, (2) identify rightLimit/leftLimit with Lp/Lm via Tendsto.limUnder_eq (uniqueness of limits in Hausdorff spaces), (3) rewrite the partial sums as convolutions using fourierPartialSum_eq_convolution, and (4) apply the dirichlet_localization axiom. The proof is 12 lines of tactic mode, showing that the main theorem is a clean composition of the analytical building blocks.",
+    "mathContext": "$S_N f(x_0) \\to \\frac{f(x_0^+) + f(x_0^-)}{2}$ as $N \\to \\infty$, for all $f$ of bounded variation on $\\mathbb{R}/T\\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet convergence theorem", "Tendsto", "limUnder uniqueness", "convolution identity"],
+    "prerequisites": ["hasBV_implies_rightLimit_exists", "hasBV_implies_leftLimit_exists", "fourierPartialSum_eq_convolution", "dirichlet_localization"]
+  },
+  {
+    "id": "fourier-oq03-continuity-corollary",
+    "proofId": "fourier-series-oq-03",
+    "range": { "startLine": 360, "endLine": 374 },
+    "type": "theorem",
+    "title": "Convergence to f(x) at Continuity Points",
+    "content": "At a continuity point, both one-sided limits equal the function value, so the midpoint (f(x+) + f(x-))/2 simplifies to f(x). The proof uses the helper lemmas rightLimit_eq_of_continuousAt and leftLimit_eq_of_continuousAt, which show that nhdsWithin limits agree with the full nhds limit via mono_left nhdsWithin_le_nhds. The final simplification (f(x) + f(x))/2 = f(x) is handled by field_simp and ring.",
+    "mathContext": "If $f$ is continuous at $x_0$, then $f(x_0^+) = f(x_0^-) = f(x_0)$, so $S_N f(x_0) \\to f(x_0)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["continuity point", "nhdsWithin_le_nhds", "ContinuousAt", "field_simp"],
+    "prerequisites": ["dirichlet_pointwise_convergence", "rightLimit_eq_of_continuousAt", "leftLimit_eq_of_continuousAt"]
+  },
+  {
+    "id": "fourier-oq03-fejer-kernel",
+    "proofId": "fourier-series-oq-03",
+    "range": { "startLine": 445, "endLine": 504 },
+    "type": "context",
+    "title": "Fejer Kernel and the Sum of Odd Numbers Identity",
+    "content": "The Fejer kernel F_N is the Cesaro mean of the first N Dirichlet kernels. Unlike D_N, the Fejer kernel is non-negative and forms a genuine approximate identity, yielding uniform convergence for all continuous functions (Fejer's theorem). The proof that F_N(0) = N uses the classical identity that the sum of the first N odd numbers equals N^2: since D_k(0) = 2k+1, we get F_N(0) = (1/N) * N^2 = N. The inductive proof of sum_odd_eq_sq is a clean algebraic calculation via push_cast and ring.",
+    "mathContext": "$F_N(t) = \\frac{1}{N} \\sum_{k=0}^{N-1} D_k(t)$, $F_N(0) = \\frac{1}{N} \\sum_{k=0}^{N-1} (2k+1) = \\frac{N^2}{N} = N$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fejer kernel", "Cesaro summability", "approximate identity", "sum of odd numbers"],
+    "prerequisites": ["dirichletKernel", "dirichletKernel_at_zero", "Finset.sum_range_succ"]
+  },
+  {
+    "id": "fourier-oq03-parseval-to-rl",
+    "proofId": "fourier-series-oq-03",
+    "range": { "startLine": 631, "endLine": 700 },
+    "type": "technique",
+    "title": "Riemann-Lebesgue from Parseval via Squeeze Argument",
+    "content": "The proof that Fourier coefficients tend to zero (the L^2 Riemann-Lebesgue lemma) proceeds by a squeeze argument from Parseval's theorem. Since the partial sums of |c_n|^2 converge to ||f||^2, the consecutive differences tend to zero. Each individual |c_n|^2 is bounded by the corresponding difference (since it appears in the larger sum but not the smaller). The final step uses a proof by contradiction: if ||c_n|| >= epsilon, then ||c_n||^2 >= epsilon^2, contradicting ||c_n||^2 < epsilon^2. This is a 70-line proof that avoids any integration-by-parts machinery.",
+    "mathContext": "$\\sum_{|n| \\le N} |\\hat{c}_n|^2 \\to \\|f\\|_2^2$ (Parseval) implies $|\\hat{c}_n| \\to 0$ as $|n| \\to \\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["Riemann-Lebesgue lemma", "Parseval's theorem", "squeeze theorem", "Bessel's inequality"],
+    "prerequisites": ["parseval_theorem", "fourierCoeffSumSq_mono", "Metric.tendsto_nhds", "Filter.eventually_atBot"]
+  }
+]


### PR DESCRIPTION
## Summary
- Add 10 annotations to the Dirichlet Pointwise Convergence Theorem formalization (`fourier-series-oq-03`)
- Annotations cover key definitions (Fourier partial sum, Dirichlet kernel, BV on circle, one-sided limits), the main theorem and its continuity corollary, techniques (kernel evaluation at zero, conjugate symmetry, Parseval-to-Riemann-Lebesgue squeeze), and contextual material (Fejer kernel infrastructure)
- All annotations include line ranges tied to the actual Lean source, LaTeX mathContext, significance ratings, and prerequisite/related-concept cross-references

## Test plan
- [x] JSON validates successfully (10 entries, well-formed)
- [ ] `pnpm build` passes with new annotations
- [ ] Gallery page renders annotations correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)