### PR TITLE
enrich: add annotations for parallel-postulate-independence-oq-02

### DIFF
--- a/src/data/proofs/parallel-postulate-independence-oq-02/annotations.json
+++ b/src/data/proofs/parallel-postulate-independence-oq-02/annotations.json
@@ -1,1 +1,110 @@
-[]
+[
+  {
+    "id": "ann-ppioq02-header",
+    "proofId": "parallel-postulate-independence-oq-02",
+    "range": { "startLine": 1, "endLine": 23 },
+    "type": "context",
+    "title": "Historical Background: The Parallel Postulate Problem",
+    "content": "For over two millennia, mathematicians tried to prove Euclid's Fifth Postulate from the other four axioms. The breakthrough came in the 19th century when Bolyai and Lobachevsky independently developed hyperbolic geometry, and Beltrami (1868) proved its consistency by constructing concrete models within Euclidean geometry. This formalization uses the Beltrami-Klein disk model to give an explicit, coordinate-geometric proof of independence, replacing axiom-based arguments with direct computation.",
+    "mathContext": "Euclid's Fifth Postulate (equivalent to Playfair's axiom): through any point not on a line, there exists exactly one parallel line. Independence means the postulate can neither be proved nor disproved from the remaining axioms.",
+    "significance": "key",
+    "relatedConcepts": ["Euclid's axioms", "Non-Euclidean geometry", "Consistency proofs", "Model theory"],
+    "prerequisites": ["Basic Euclidean geometry", "Axiomatic systems"]
+  },
+  {
+    "id": "ann-ppioq02-disk-model",
+    "proofId": "parallel-postulate-independence-oq-02",
+    "range": { "startLine": 35, "endLine": 54 },
+    "type": "definition",
+    "title": "Beltrami-Klein Disk Model: Points, Lines, and Parallelism",
+    "content": "The Beltrami-Klein model represents hyperbolic geometry inside the open unit disk. A DiskPoint is a pair (x, y) with x^2 + y^2 < 1. A Chord is a Euclidean line ax + by + c = 0 restricted to the disk interior, requiring nondegeneracy (a^2 + b^2 > 0) and that it actually intersects the disk. OnChord and ChordParallel define incidence and parallelism: two chords are parallel if they share no interior disk point.",
+    "mathContext": "In the BK model, geodesics are straight chords of the disk. Two chords are 'parallel' when their Euclidean extensions intersect only outside (or on the boundary of) the unit disk: $\\forall p \\in D^\\circ,\\; \\lnot(p \\in \\ell_1 \\cap \\ell_2)$.",
+    "significance": "key",
+    "relatedConcepts": ["Open unit disk", "Hyperbolic geodesics", "Incidence geometry", "Projective geometry"],
+    "prerequisites": ["Coordinate geometry", "Linear equations"]
+  },
+  {
+    "id": "ann-ppioq02-constructions",
+    "proofId": "parallel-postulate-independence-oq-02",
+    "range": { "startLine": 60, "endLine": 90 },
+    "type": "technique",
+    "title": "Explicit Witness Construction for Hyperbolic Parallels",
+    "content": "The proof constructs specific objects: the x-axis chord (y = 0), point P = (0, 1/2), and two chords through P with equations x - 4y + 2 = 0 (slope 1/4) and x + 4y - 2 = 0 (slope -1/4). These chords have shallow slopes, so their extensions cross the x-axis at x = -2 and x = 2 respectively, both well outside the unit disk. This explicit construction avoids existential reasoning entirely.",
+    "mathContext": "The chord $x - 4y + 2 = 0$ passes through $(0, 1/2)$ and meets $y = 0$ at $x = -2$. Since $(-2)^2 + 0^2 = 4 > 1$, this intersection lies outside the disk, making the chords BK-parallel.",
+    "significance": "key",
+    "relatedConcepts": ["Witness construction", "Slope analysis", "Line intersection"],
+    "prerequisites": ["Linear equations", "Solving simultaneous equations"]
+  },
+  {
+    "id": "ann-ppioq02-parallelism-proof",
+    "proofId": "parallel-postulate-independence-oq-02",
+    "range": { "startLine": 120, "endLine": 138 },
+    "type": "technique",
+    "title": "Parallelism via Disk Exterior Intersection",
+    "content": "The proofs of par1_parallel_xaxis and par2_parallel_xaxis follow the same strategy: assume a DiskPoint p lies on both chords, derive that p.y = 0 (from the x-axis equation), then solve for p.x = -2 or p.x = 2. The nlinarith tactic then derives a contradiction from p.in_disk (which says p.x^2 + p.y^2 < 1) since the putative intersection has norm 4. The key insight is that showing chords are parallel reduces to checking that their Euclidean intersection lies outside the unit disk.",
+    "mathContext": "If $p \\in \\ell_1 \\cap \\ell_2$ with $p \\in D^\\circ$, then $p = (\\pm 2, 0)$, but $|\\pm 2|^2 = 4 \\not< 1$, contradiction.",
+    "significance": "key",
+    "relatedConcepts": ["Proof by contradiction", "nlinarith tactic", "Norm bounds"],
+    "prerequisites": ["Linear algebra", "Quadratic inequalities"]
+  },
+  {
+    "id": "ann-ppioq02-hyperbolic-property",
+    "proofId": "parallel-postulate-independence-oq-02",
+    "range": { "startLine": 147, "endLine": 155 },
+    "type": "theorem",
+    "title": "Hyperbolic Parallel Property: The Core Existential Witness",
+    "content": "The theorem hyperbolic_parallel_property assembles all verified components into a single existential statement: there exist a chord l, a point p not on l, and two distinct chords through p both parallel to l. The proof is purely structural -- it supplies xaxis, P, par1, par2, and the previously proved lemmas as witnesses. This is the fundamental property distinguishing hyperbolic from Euclidean geometry.",
+    "mathContext": "$$\\exists\\, \\ell,\\, p \\notin \\ell,\\, m_1 \\neq m_2 :\\; p \\in m_1 \\cap m_2 \\;\\land\\; m_1 \\parallel \\ell \\;\\land\\; m_2 \\parallel \\ell$$",
+    "significance": "key",
+    "relatedConcepts": ["Existential witness", "Hyperbolic geometry", "Multiple parallels"],
+    "prerequisites": ["Beltrami-Klein model definitions"]
+  },
+  {
+    "id": "ann-ppioq02-playfair-violation",
+    "proofId": "parallel-postulate-independence-oq-02",
+    "range": { "startLine": 163, "endLine": 178 },
+    "type": "insight",
+    "title": "Playfair Violation via Uniqueness Contradiction",
+    "content": "BKPlayfair asserts that through any off-chord point there is exactly one parallel chord. The proof of bk_not_playfair applies this to xaxis and P, obtaining some unique chord m. By the uniqueness clause, both par1 and par2 must equal m, forcing par1 = par2. But par1_ne_par2 was already proved (their b-coefficients differ: -4 vs 4), giving a contradiction. This is a clean application of the uniqueness half of the existential-unique quantifier.",
+    "mathContext": "From $\\exists! m$ we get $\\text{par}_1 = m = \\text{par}_2$, contradicting $\\text{par}_1 \\neq \\text{par}_2$ since their $b$-coefficients are $-4$ and $4$.",
+    "significance": "key",
+    "relatedConcepts": ["Playfair's axiom", "Existential uniqueness", "Uniqueness contradiction"],
+    "prerequisites": ["Existential unique quantifier", "Proof by contradiction"]
+  },
+  {
+    "id": "ann-ppioq02-noncollinear",
+    "proofId": "parallel-postulate-independence-oq-02",
+    "range": { "startLine": 186, "endLine": 202 },
+    "type": "lemma",
+    "title": "Three Non-Collinear Points: Model Non-Degeneracy",
+    "content": "The proof that O = (0,0), A = (1/2, 0), B = (0, 1/2) are not collinear proceeds by supposing some chord l passes through all three. From O on l we get l.c = 0; from A on l we get l.a = 0; from B on l we get l.b = 0. But the nondegeneracy condition a^2 + b^2 > 0 is then violated. This establishes that the BK disk is a genuine geometry, not a degenerate pencil of concurrent lines.",
+    "mathContext": "If $\\ell: ax + by + c = 0$ passes through $(0,0)$, $(1/2, 0)$, $(0, 1/2)$, then $c = 0$, $a/2 = 0$, $b/2 = 0$, so $a^2 + b^2 = 0$, contradicting nondegeneracy.",
+    "significance": "supporting",
+    "relatedConcepts": ["Collinearity", "Incidence axioms", "Model verification"],
+    "prerequisites": ["Linear algebra basics"]
+  },
+  {
+    "id": "ann-ppioq02-independence",
+    "proofId": "parallel-postulate-independence-oq-02",
+    "range": { "startLine": 257, "endLine": 261 },
+    "type": "theorem",
+    "title": "Independence Theorem: Two Models, Opposite Verdicts",
+    "content": "The final independence theorem states that some incidence geometry satisfies Playfair's axiom (Euclidean, axiomatized) while another violates it (Beltrami-Klein, proved). This is the standard model-theoretic technique for independence: if an axiom holds in one model and fails in another, it is independent of the shared axioms. The BK side is fully proved; the Euclidean side is axiomatized as a standard result.",
+    "mathContext": "Independence: $(\\exists G.\\; \\text{Playfair}(G)) \\;\\land\\; (\\exists G.\\; \\lnot\\text{Playfair}(G))$. The first witness is Euclidean geometry; the second is the Beltrami-Klein disk.",
+    "significance": "key",
+    "relatedConcepts": ["Model-theoretic independence", "Axiomatic method", "Consistency and independence"],
+    "prerequisites": ["Incidence geometry", "Model theory basics"]
+  },
+  {
+    "id": "ann-ppioq02-secant-example",
+    "proofId": "parallel-postulate-independence-oq-02",
+    "range": { "startLine": 292, "endLine": 310 },
+    "type": "insight",
+    "title": "Secant Example: Not All Chords Through P Are Parallel",
+    "content": "The secant chord y = x + 1/2 through P meets the x-axis at (-1/2, 0), which lies inside the disk since 1/4 < 1. This provides a concrete non-parallel chord, demonstrating that parallelism in the BK model is selective -- it depends on the slope. Shallow slopes (1/4) produce parallels because their x-intercepts escape the disk; steep slopes (1) do not. The existential witness for the intersection point makes the proof fully constructive.",
+    "mathContext": "The chord $y = x + 1/2$ meets $y = 0$ at $x = -1/2$. Since $(-1/2)^2 = 1/4 < 1$, the point $(-1/2, 0)$ is in $D^\\circ$, so the chords intersect inside the disk.",
+    "significance": "supporting",
+    "relatedConcepts": ["Constructive existence", "Secant lines", "Slope-dependent parallelism"],
+    "prerequisites": ["BK model definitions", "Intersection computation"]
+  }
+]


### PR DESCRIPTION
## Summary
- Add 9 annotations to the Beltrami-Klein disk model proof of parallel postulate independence
- Covers: historical context, model definitions (DiskPoint/Chord/ChordParallel), explicit witness construction, parallelism proofs via disk exterior intersection, hyperbolic parallel property, Playfair violation via uniqueness contradiction, non-collinearity verification, independence theorem, and the secant counterexample
- All annotations include LaTeX mathContext, line ranges from the actual Lean source, significance ratings, and cross-references

## Annotations
| # | Lines | Type | Title |
|---|-------|------|-------|
| 1 | 1-23 | context | Historical Background: The Parallel Postulate Problem |
| 2 | 35-54 | definition | Beltrami-Klein Disk Model: Points, Lines, and Parallelism |
| 3 | 60-90 | technique | Explicit Witness Construction for Hyperbolic Parallels |
| 4 | 120-138 | technique | Parallelism via Disk Exterior Intersection |
| 5 | 147-155 | theorem | Hyperbolic Parallel Property: The Core Existential Witness |
| 6 | 163-178 | insight | Playfair Violation via Uniqueness Contradiction |
| 7 | 186-202 | lemma | Three Non-Collinear Points: Model Non-Degeneracy |
| 8 | 257-261 | theorem | Independence Theorem: Two Models, Opposite Verdicts |
| 9 | 292-310 | insight | Secant Example: Not All Chords Through P Are Parallel |

## Test plan
- [ ] Verify JSON is valid and parseable
- [ ] Verify all line ranges correspond to actual Lean source content
- [ ] Verify gallery renders annotations correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)