### PR TITLE
enrich: add annotations for cayley-hamilton-minpoly-oq-02-oq-01

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01/annotations.json
@@ -1,1 +1,152 @@
-[]
+[
+  {
+    "id": "ann-abstract-invariance",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01",
+    "range": {
+      "startLine": 45,
+      "endLine": 62
+    },
+    "type": "theorem",
+    "title": "Abstract Invariance of Minimal Polynomials",
+    "content": "The two foundational results from Mathlib are re-exported here: minpoly.algEquiv_eq states that the minimal polynomial is invariant under K-algebra equivalences, and minpoly.algHom_eq extends this to injective K-algebra homomorphisms. These results establish that the minimal polynomial is not a matrix-specific concept but a general K-algebra invariant, preserved by any structure-respecting injective map.",
+    "mathContext": "$\\text{minpoly}(K, \\varphi(x)) = \\text{minpoly}(K, x)$ for $\\varphi : S \\xrightarrow{\\sim} T$ a $K$-algebra isomorphism",
+    "significance": "key",
+    "relatedConcepts": ["algebra equivalence", "algebra homomorphism", "minimal polynomial", "K-algebra"],
+    "prerequisites": ["ring theory", "polynomial algebra", "field extensions"]
+  },
+  {
+    "id": "ann-algequiv-vs-alghom",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 60
+    },
+    "type": "insight",
+    "title": "AlgEquiv vs AlgHom: Injective Homomorphisms Suffice",
+    "content": "The theorem minpoly_invariant_algHom is strictly more general than minpoly_invariant_algEquiv: it only requires an injective algebra homomorphism, not a full isomorphism. This matters because subalgebra inclusions are injective homomorphisms but not isomorphisms. The injectivity condition is essential: a non-injective homomorphism can collapse distinct elements, potentially changing the kernel of the evaluation map and thus the minimal polynomial.",
+    "mathContext": "$\\varphi : S \\to_{\\text{alg}} T$ injective $\\Longrightarrow \\text{minpoly}(K, \\varphi(x)) = \\text{minpoly}(K, x)$",
+    "significance": "key",
+    "relatedConcepts": ["injective homomorphism", "subalgebra inclusion", "kernel of evaluation"],
+    "prerequisites": ["algebra homomorphisms", "polynomial evaluation"]
+  },
+  {
+    "id": "ann-conjalgequiv-construction",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 116
+    },
+    "type": "technique",
+    "title": "Constructing Conjugation as an AlgEquiv",
+    "content": "The definition conjAlgEquiv upgrades conjugation from an AlgHom (as used in OQ-02) to a full AlgEquiv. This requires proving five fields: left_inv, right_inv, map_mul', map_add', and commutes'. The invertibility proofs use the unit identities P * P^{-1} = 1 and P^{-1} * P = 1, while the algebra-compatibility proofs show that conjugation distributes over addition, multiplication, and scalar multiplication. The upgrade to AlgEquiv is mathematically significant because it makes the invertibility of the conjugation map explicit in the type system.",
+    "mathContext": "$\\text{conjAlgEquiv}(P) : A \\mapsto P^{-1}AP$, with inverse $A \\mapsto PAP^{-1}$",
+    "significance": "key",
+    "relatedConcepts": ["algebra automorphism", "conjugation", "invertible matrix", "units group"],
+    "prerequisites": ["matrix multiplication", "units in a ring", "algebra equivalence"]
+  },
+  {
+    "id": "ann-map-mul-proof",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01",
+    "range": {
+      "startLine": 98,
+      "endLine": 106
+    },
+    "type": "technique",
+    "title": "Multiplicativity of Conjugation",
+    "content": "The map_mul' field proves that conjugation is a ring homomorphism: P^{-1}(AB)P = (P^{-1}AP)(P^{-1}BP). The key step is inserting the identity PP^{-1} = 1 between A and B in the expanded product. This telescoping trick -- inserting a resolved identity in a strategic location -- is a standard technique in algebra. The proof uses only associativity and the unit identity, making it entirely algebraic.",
+    "mathContext": "$P^{-1}(AB)P = (P^{-1}AP)(P^{-1}BP)$ via insertion of $PP^{-1} = 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["ring homomorphism", "matrix associativity", "telescoping identity"],
+    "prerequisites": ["matrix multiplication associativity", "unit identities"]
+  },
+  {
+    "id": "ann-commutes-scalars",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01",
+    "range": {
+      "startLine": 111,
+      "endLine": 115
+    },
+    "type": "technique",
+    "title": "Scalar Commutativity: Why Conjugation is an Algebra Map",
+    "content": "The commutes' field proves that conjugation fixes the image of the structure map algebraMap K (Matrix n n K). Since scalar matrices c * I commute with all matrices, P^{-1}(cI)P = cI. This uses the Lean identity algebraMap c = c \\smul 1 together with smul_mul_assoc and mul_smul_comm to factor out the scalar. The proof that P^{-1}P = 1 then closes the goal. This field is what distinguishes an AlgEquiv from a mere RingEquiv.",
+    "mathContext": "$P^{-1}(cI)P = cI$ for all $c \\in K$",
+    "significance": "supporting",
+    "relatedConcepts": ["algebra map", "scalar matrices", "center of matrix ring"],
+    "prerequisites": ["algebra structure map", "scalar-matrix commutativity"]
+  },
+  {
+    "id": "ann-main-corollary",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01",
+    "range": {
+      "startLine": 122,
+      "endLine": 124
+    },
+    "type": "theorem",
+    "title": "Matrix Similarity Preserves Minpoly: The One-Line Corollary",
+    "content": "The theorem minpoly_similar_via_abstract derives the matrix similarity result as a single application of minpoly.algEquiv_eq to conjAlgEquiv P. Where OQ-02 proved this from scratch using minpoly.unique (requiring construction of a division algorithm argument), this file obtains it in one line by recognizing conjugation as an AlgEquiv. This demonstrates the power of abstraction: lifting a concrete matrix problem to the K-algebra level collapses the entire proof.",
+    "mathContext": "$\\text{minpoly}(K, A) = \\text{minpoly}(K, P^{-1}AP)$",
+    "significance": "key",
+    "relatedConcepts": ["similar matrices", "minimal polynomial", "proof by abstraction"],
+    "prerequisites": ["conjAlgEquiv construction", "minpoly.algEquiv_eq"]
+  },
+  {
+    "id": "ann-inverse-variant",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01",
+    "range": {
+      "startLine": 127,
+      "endLine": 133
+    },
+    "type": "lemma",
+    "title": "The Inverse Convention Variant",
+    "content": "The theorem minpoly_conj_inv_via_abstract proves that minpoly(PAP^{-1}) = minpoly(A), the variant where P appears on the left. The proof works by recognizing that PAP^{-1} is conjugation by P^{-1} (not P), then applying the main result. The key rewriting step uses inv_inv to show that (P^{-1})^{-1} = P. This variant is needed because different textbooks use different conventions for matrix similarity: some write P^{-1}AP and others write PAP^{-1}.",
+    "mathContext": "$\\text{minpoly}(K, PAP^{-1}) = \\text{minpoly}(K, A)$ via $\\text{conjAlgEquiv}(P^{-1})$",
+    "significance": "supporting",
+    "relatedConcepts": ["inverse convention", "unit inversion", "similarity convention"],
+    "prerequisites": ["conjAlgEquiv", "inv_inv for units"]
+  },
+  {
+    "id": "ann-subalgebra-invariance",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01",
+    "range": {
+      "startLine": 159,
+      "endLine": 161
+    },
+    "type": "theorem",
+    "title": "Subalgebra Inclusion Preserves Minimal Polynomial",
+    "content": "The theorem minpoly_subalgebra_eq shows that the minimal polynomial computed within a subalgebra S of Mat(n,K) agrees with the one computed in the full matrix algebra. The proof uses minpoly.algHom_eq applied to the subalgebra inclusion map S.val, which is injective by Subtype.val_injective. This result is important in representation theory where one often works within subalgebras generated by specific matrices.",
+    "mathContext": "$\\text{minpoly}_S(K, x) = \\text{minpoly}_{M_n(K)}(K, x)$ for $x \\in S \\subseteq M_n(K)$",
+    "significance": "key",
+    "relatedConcepts": ["subalgebra", "inclusion map", "representation theory"],
+    "prerequisites": ["subalgebra structure", "Subtype.val_injective", "minpoly.algHom_eq"]
+  },
+  {
+    "id": "ann-indistinguishable",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01",
+    "range": {
+      "startLine": 169,
+      "endLine": 175
+    },
+    "type": "insight",
+    "title": "Similar Matrices Are Algebraically Indistinguishable",
+    "content": "The theorem minpoly_similar_under_algHom shows that similar matrices A and P^{-1}AP remain indistinguishable under any injective K-algebra homomorphism into any target algebra R. This is a categorically strong statement: similarity is not just a matrix-level equivalence but persists through any structure-preserving embedding. The proof combines the abstract homomorphism invariance with the concrete similarity result, showing they compose cleanly.",
+    "mathContext": "$\\text{minpoly}(K, \\varphi(A)) = \\text{minpoly}(K, \\varphi(P^{-1}AP))$ for any injective $\\varphi : M_n(K) \\to_{\\text{alg}} R$",
+    "significance": "key",
+    "relatedConcepts": ["categorical invariance", "functorial property", "algebra homomorphism"],
+    "prerequisites": ["minpoly.algHom_eq", "minpoly_similar_via_abstract"]
+  },
+  {
+    "id": "ann-group-homomorphism",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-01",
+    "range": {
+      "startLine": 185,
+      "endLine": 193
+    },
+    "type": "theorem",
+    "title": "Conjugation Composition is a Group Homomorphism",
+    "content": "The theorem conjAlgEquiv_trans proves that composing conjugation by P with conjugation by Q yields conjugation by PQ. This means the map P to conjAlgEquiv(P) is a group homomorphism from the unit group (Matrix n n K)^x to the automorphism group Aut_K(Mat(n,K)). The proof expands both sides, uses mul_inv_rev to show (PQ)^{-1} = Q^{-1}P^{-1}, and then verifies equality by associativity. This connects the multiplicative structure of invertible matrices to the composition structure of algebra automorphisms.",
+    "mathContext": "$\\text{conjAlgEquiv}(P) \\circ \\text{conjAlgEquiv}(Q) = \\text{conjAlgEquiv}(PQ)$",
+    "significance": "key",
+    "relatedConcepts": ["group homomorphism", "automorphism group", "Skolem-Noether theorem"],
+    "prerequisites": ["AlgEquiv.trans", "mul_inv_rev", "Units.val_mul"]
+  }
+]


### PR DESCRIPTION
## Summary
- Add 10 annotations for the Minimal Polynomial Generalization to K-Algebras proof
- Annotations cover abstract invariance theorems (AlgEquiv and AlgHom), the conjAlgEquiv construction, the one-line similarity corollary, subalgebra invariance, algebraic indistinguishability of similar matrices, and the group homomorphism property of conjugation
- Each annotation includes mathematical context (LaTeX), significance rating, related concepts, and prerequisites

## Annotations Added
| ID | Type | Title | Lines | Significance |
|----|------|-------|-------|-------------|
| ann-abstract-invariance | theorem | Abstract Invariance of Minimal Polynomials | 45-62 | key |
| ann-algequiv-vs-alghom | insight | AlgEquiv vs AlgHom: Injective Homomorphisms Suffice | 50-60 | key |
| ann-conjalgequiv-construction | technique | Constructing Conjugation as an AlgEquiv | 82-116 | key |
| ann-map-mul-proof | technique | Multiplicativity of Conjugation | 98-106 | supporting |
| ann-commutes-scalars | technique | Scalar Commutativity: Why Conjugation is an Algebra Map | 111-115 | supporting |
| ann-main-corollary | theorem | Matrix Similarity Preserves Minpoly: The One-Line Corollary | 122-124 | key |
| ann-inverse-variant | lemma | The Inverse Convention Variant | 127-133 | supporting |
| ann-subalgebra-invariance | theorem | Subalgebra Inclusion Preserves Minimal Polynomial | 159-161 | key |
| ann-indistinguishable | insight | Similar Matrices Are Algebraically Indistinguishable | 169-175 | key |
| ann-group-homomorphism | theorem | Conjugation Composition is a Group Homomorphism | 185-193 | key |

## Test plan
- [ ] Verify annotations.json is valid JSON
- [ ] Verify all line ranges correspond to actual Lean source content
- [ ] Verify gallery renders annotations correctly with `pnpm build`

Generated with [Claude Code](https://claude.com/claude-code)