### PR TITLE
enrich: add annotations for euler-polyhedral-formula-oq-01-oq-01

### DIFF
--- a/src/data/proofs/euler-polyhedral-formula-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01-oq-01/annotations.json
@@ -1,1 +1,152 @@
-[]
+[
+  {
+    "id": "ann-fct-planar-embedding",
+    "proofId": "euler-polyhedral-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 52,
+      "endLine": 57
+    },
+    "type": "definition",
+    "title": "PlanarEmbedding Structure",
+    "content": "The PlanarEmbedding structure axiomatizes planarity via Euler's formula V - E + F = 2. It bundles a face count with the positivity constraint and the Euler relation. This avoids formalizing topological embeddings, instead capturing the combinatorial consequence needed for the edge bound.",
+    "mathContext": "Euler's formula $V - E + F = 2$ holds for any connected planar graph. The structure encodes this as $(|V| : \\mathbb{Z}) - |E| + F = 2$, lifting natural numbers to integers for subtraction.",
+    "significance": "key",
+    "relatedConcepts": ["Euler's formula", "planar graphs", "topological embedding", "face enumeration"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-fct-edge-bound",
+    "proofId": "euler-polyhedral-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 65
+    },
+    "type": "theorem",
+    "title": "Planar Edge Bound E <= 3V - 6",
+    "content": "The fundamental edge bound for simple planar graphs: every face is bounded by at least 3 edges, giving 3F <= 2E. Combining with Euler's formula yields E <= 3V - 6. The proof is a single linarith call from the Euler relation and the face inequality hypothesis.",
+    "mathContext": "From $V - E + F = 2$ and $3F \\le 2E$, we get $F \\le \\frac{2E}{3}$, so $V - E + \\frac{2E}{3} \\ge 2$, giving $E \\le 3V - 6$. This bound is tight for maximal planar graphs (triangulations).",
+    "significance": "key",
+    "relatedConcepts": ["planar graph bounds", "triangulation", "maximal planar graphs"],
+    "prerequisites": ["ann-fct-planar-embedding"]
+  },
+  {
+    "id": "ann-fct-low-degree",
+    "proofId": "euler-polyhedral-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 67,
+      "endLine": 84
+    },
+    "type": "theorem",
+    "title": "Every Planar Graph Has a Low-Degree Vertex",
+    "content": "Proves that every planar graph has a vertex of degree at most 5. The proof is by contradiction using the handshaking lemma: if all vertices had degree >= 6, then 6V <= sum(deg) = 2E, giving 3V <= E, which contradicts E <= 3V - 6. This is the starting point of the inductive proof.",
+    "mathContext": "The handshaking lemma $\\sum_{v} \\deg(v) = 2|E|$ is imported from Mathlib as `SimpleGraph.sum_degrees_eq_twice_card_edges`. Combined with the planar edge bound, an averaging argument forces a vertex of degree $\\le 5$.",
+    "significance": "key",
+    "relatedConcepts": ["handshaking lemma", "degree sum formula", "averaging argument", "graph coloring induction"],
+    "prerequisites": ["ann-fct-edge-bound"]
+  },
+  {
+    "id": "ann-fct-swap-colors",
+    "proofId": "euler-polyhedral-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 101,
+      "endLine": 114
+    },
+    "type": "technique",
+    "title": "Color Swap via Equiv.swap",
+    "content": "Defines color transposition as composition with Equiv.swap, Mathlib's formalization of the symmetric group transposition (c1 c2). The key insight is that proper coloring preservation follows immediately from injectivity of Equiv.swap, reducing what would be tedious case analysis to a one-line proof.",
+    "mathContext": "Given a proper coloring $f : V \\to \\text{Fin}\\, n$ and a transposition $\\sigma = (c_1\\; c_2)$, the composition $\\sigma \\circ f$ is proper because $\\sigma$ is injective: $f(u) \\ne f(v) \\implies \\sigma(f(u)) \\ne \\sigma(f(v))$.",
+    "significance": "key",
+    "relatedConcepts": ["transposition", "symmetric group", "proper coloring", "Equiv.swap", "injectivity"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-fct-kempe-chain-def",
+    "proofId": "euler-polyhedral-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 177,
+      "endLine": 189
+    },
+    "type": "definition",
+    "title": "KempeChain and kempeSwap Definitions",
+    "content": "The KempeChain structure represents a maximal connected bichromatic component: a set of vertices all colored with exactly two colors c1 and c2. The kempeSwap function applies the transposition (c1 c2) only to vertices inside the chain, leaving all other vertices unchanged. This localized swap is the core of Kempe's recoloring argument.",
+    "mathContext": "A Kempe chain for colors $c_1, c_2$ starting at vertex $u$ is the connected component of $u$ in the subgraph induced by vertices colored $c_1$ or $c_2$. Swapping $c_1 \\leftrightarrow c_2$ on this component preserves proper coloring by the maximality condition.",
+    "significance": "key",
+    "relatedConcepts": ["Kempe chains", "bichromatic subgraph", "connected component", "recoloring"],
+    "prerequisites": ["ann-fct-swap-colors"]
+  },
+  {
+    "id": "ann-fct-kempe-correctness",
+    "proofId": "euler-polyhedral-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 198,
+      "endLine": 234
+    },
+    "type": "theorem",
+    "title": "Kempe Chain Swap Correctness (Four-Case Proof)",
+    "content": "The proof that kempeSwap preserves proper coloring handles four edge cases: both endpoints in the chain (injectivity of swap), both outside (unchanged), and the two crossing cases where one endpoint is in and the other is out. The crossing cases use the maximality condition: no edge crosses the chain boundary between vertices of the same two colors.",
+    "mathContext": "The maximality hypothesis states: for any edge $(u,v)$ with $u \\in \\text{chain}$ and $v \\notin \\text{chain}$, we have $f(v) \\ne c_1$ and $f(v) \\ne c_2$. This ensures that swapping inside the chain cannot create a color conflict at the boundary, because the outside vertex uses a third color.",
+    "significance": "key",
+    "relatedConcepts": ["maximality condition", "boundary edges", "proper coloring preservation", "Equiv.swap_apply_def"],
+    "prerequisites": ["ann-fct-kempe-chain-def"]
+  },
+  {
+    "id": "ann-fct-k5-nonplanar",
+    "proofId": "euler-polyhedral-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 146,
+      "endLine": 162
+    },
+    "type": "theorem",
+    "title": "K5 Non-Planarity and the Non-Adjacent Pair",
+    "content": "Proves that K5 is not planar: with V=5 and E=10, the edge bound E <= 3V-6 = 9 is violated. The consequence is that any 5 vertices in a planar graph have fewer than 10 edges among them, so two must be non-adjacent. This is the heart of the degree-5 case in the Five Color Theorem.",
+    "mathContext": "The complete graph $K_5$ has $\\binom{5}{2} = 10$ edges, but a planar graph on 5 vertices has at most $3 \\cdot 5 - 6 = 9$ edges. Therefore any 5-vertex subgraph of a planar graph is missing at least one edge, guaranteeing a non-adjacent pair.",
+    "significance": "key",
+    "relatedConcepts": ["K5 non-planarity", "Kuratowski's theorem", "complete graph", "non-adjacent pair"],
+    "prerequisites": ["ann-fct-edge-bound"]
+  },
+  {
+    "id": "ann-fct-five-color-theorem",
+    "proofId": "euler-polyhedral-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 310,
+      "endLine": 335
+    },
+    "type": "theorem",
+    "title": "Five Color Theorem: Inductive Proof Structure",
+    "content": "The main theorem proves every planar graph is 5-colorable by induction on vertex count. The base case (at most 5 vertices) uses Fintype.equivFin to assign distinct colors. The inductive case uses the low-degree vertex, but the full connection to vertex deletion is bridged by the five_color_axiom due to Mathlib lacking vertex deletion with Fintype preservation.",
+    "mathContext": "The inductive argument: remove a vertex $v$ of degree $\\le 5$, color $G - v$ by induction. If $\\deg(v) \\le 4$, a free color exists among 5 choices. If $\\deg(v) = 5$, use Kempe chain recoloring to reduce distinct neighbor colors from 5 to 4, then assign the freed color to $v$.",
+    "significance": "key",
+    "relatedConcepts": ["strong induction", "vertex deletion", "graph coloring", "Fintype.equivFin"],
+    "prerequisites": ["ann-fct-low-degree", "ann-fct-kempe-correctness", "ann-fct-k5-nonplanar"]
+  },
+  {
+    "id": "ann-fct-kempe-algebra",
+    "proofId": "euler-polyhedral-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 360,
+      "endLine": 398
+    },
+    "type": "insight",
+    "title": "Algebraic Properties of Color Swaps",
+    "content": "A suite of fully proved algebraic properties: self-swap is identity (Equiv.swap_self), double swap is identity (involutivity via Equiv.swap_apply_self), and swap is symmetric (commutativity via Equiv.swap_comm). The kempeSwap variants show the empty chain acts as identity, outside vertices are unchanged, and inside vertices have their two colors exchanged.",
+    "mathContext": "These properties follow from the symmetric group: transpositions satisfy $\\sigma^2 = \\text{id}$ and $(c_1\\;c_2) = (c_2\\;c_1)$. The localized kempeSwap inherits these properties restricted to the chain vertices.",
+    "significance": "supporting",
+    "relatedConcepts": ["involution", "transposition algebra", "symmetric group", "Equiv.swap properties"],
+    "prerequisites": ["ann-fct-swap-colors"]
+  },
+  {
+    "id": "ann-fct-small-graph-coloring",
+    "proofId": "euler-polyhedral-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 452,
+      "endLine": 467
+    },
+    "type": "theorem",
+    "title": "Small Graph Colorability via Fintype.equivFin",
+    "content": "Two general colorability results: any graph on at most 5 vertices is 5-colorable, and any graph on n vertices is n-colorable. Both use the same clean technique: Fintype.equivFin V provides a bijection V -> Fin |V|, which is automatically a proper coloring since distinct vertices map to distinct colors, and then Colorable.mono weakens the bound.",
+    "mathContext": "The equivalence $V \\simeq \\text{Fin}\\,|V|$ gives a coloring where $f(v) \\ne f(w)$ for $v \\ne w$ (by injectivity). Since adjacent vertices are distinct ($G.\\text{ne\\_of\\_adj}$), this is a proper coloring. The bound is then relaxed from $|V|$ to any $n \\ge |V|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["graph colorability", "Fintype.equivFin", "Colorable.mono", "base case"],
+    "prerequisites": []
+  }
+]


### PR DESCRIPTION
## Summary
- Add 10 annotations for the Five Color Theorem via Kempe Chain Argument proof
- Covers all major sections: planar infrastructure, Kempe chain definitions and correctness, K5 non-planarity, the main theorem, algebraic properties, and small graph colorability
- Each annotation includes LaTeX math context, significance classification, related concepts, and prerequisite chains

## Annotations

| ID | Type | Lines | Title |
|----|------|-------|-------|
| ann-fct-planar-embedding | definition | 52-57 | PlanarEmbedding Structure |
| ann-fct-edge-bound | theorem | 59-65 | Planar Edge Bound E <= 3V - 6 |
| ann-fct-low-degree | theorem | 67-84 | Every Planar Graph Has a Low-Degree Vertex |
| ann-fct-swap-colors | technique | 101-114 | Color Swap via Equiv.swap |
| ann-fct-kempe-chain-def | definition | 177-189 | KempeChain and kempeSwap Definitions |
| ann-fct-kempe-correctness | theorem | 198-234 | Kempe Chain Swap Correctness (Four-Case Proof) |
| ann-fct-k5-nonplanar | theorem | 146-162 | K5 Non-Planarity and the Non-Adjacent Pair |
| ann-fct-five-color-theorem | theorem | 310-335 | Five Color Theorem: Inductive Proof Structure |
| ann-fct-kempe-algebra | insight | 360-398 | Algebraic Properties of Color Swaps |
| ann-fct-small-graph-coloring | theorem | 452-467 | Small Graph Colorability via Fintype.equivFin |

## Test plan
- [ ] Verify annotations.json is valid JSON
- [ ] Verify all line ranges correspond to actual Lean source content
- [ ] Verify `pnpm build` succeeds with the new annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)