### PR TITLE
enrich: add annotations for borsuk-ulam-oq-03-oq-03

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-03/annotations.json
@@ -1,1 +1,122 @@
-[]
+[
+  {
+    "id": "tucker-labeling-infrastructure",
+    "proofId": "borsuk-ulam-oq-03-oq-03",
+    "range": { "startLine": 48, "endLine": 72 },
+    "type": "definition",
+    "title": "Tucker's Lemma and Signed Labelings",
+    "content": "Defines the signed labeling type $V \\to \\text{Fin}\\,n \\times \\text{Bool}$, encoding labels from $\\{\\pm 1, \\ldots, \\pm n\\}$. A complementary edge is a pair of adjacent vertices labeled $+k$ and $-k$ for some coordinate $k$. Tucker's lemma (stated as an axiom) guarantees that any antipodal labeling of a triangulated ball contains at least one complementary edge. This is the combinatorial engine driving the entire proof.",
+    "mathContext": "Tucker's lemma (1946): For any triangulation $T$ of the closed ball $\\bar{B}^n$ that is symmetric on $\\partial B^n$, and any labeling $L : V(T) \\to \\{\\pm 1, \\ldots, \\pm n\\}$ satisfying $L(-v) = -L(v)$ on boundary vertices, there exists an edge $(u, v)$ in $T$ with $L(u) = -L(v)$.",
+    "significance": "key",
+    "relatedConcepts": ["Tucker's lemma", "signed labeling", "complementary edge", "antipodal condition", "triangulated ball"],
+    "prerequisites": ["combinatorial topology", "simplicial complexes", "antipodal maps"]
+  },
+  {
+    "id": "dominant-component-labeling",
+    "proofId": "borsuk-ulam-oq-03-oq-03",
+    "range": { "startLine": 74, "endLine": 118 },
+    "type": "technique",
+    "title": "Dominant Component Labeling",
+    "content": "Defines and verifies the dominant component labeling, the key bridge between continuous functions and Tucker's combinatorial framework. Given a nonzero vector $v \\in \\mathbb{R}^2$, the label is determined by which coordinate has the larger absolute value and its sign: if $|v_1| \\geq |v_2|$, the label is $\\pm 1$ (based on the sign of $v_1$); otherwise $\\pm 2$ (based on the sign of $v_2$). The theorem `dominantComponentLabel_antipodal` proves this labeling is automatically antipodal for odd functions: if $g(-x) = -g(x)$, then $L(-x) = -L(x)$.",
+    "mathContext": "For $v \\neq 0$ in $\\mathbb{R}^2$, define $L(v) = \\operatorname{sgn}(v_k) \\cdot k$ where $k = \\arg\\max_i |v_i|$. If $g(-x) = -g(x)$, then $L(g(-x)) = L(-g(x)) = -L(g(x))$, satisfying Tucker's antipodal boundary condition.",
+    "significance": "key",
+    "relatedConcepts": ["dominant coordinate", "sign encoding", "antipodal labeling", "discretization of continuous maps"],
+    "prerequisites": ["absolute value properties", "case analysis on real numbers"]
+  },
+  {
+    "id": "triangulated-disk-and-grid",
+    "proofId": "borsuk-ulam-oq-03-oq-03",
+    "range": { "startLine": 120, "endLine": 399 },
+    "type": "definition",
+    "title": "Triangulated Disk and Grid Construction",
+    "content": "Defines the `TriangulatedDisk2D` structure encoding a 2D triangulated disk with boundary, interior, antipodal map, and mesh size. Then constructs the concrete $N \\times N$ grid triangulation of $[-1,1]^2$, where vertex $(i,j)$ maps to real coordinates $((i-N)/N, (j-N)/N)$. Key properties verified: the center maps to the origin, vertices lie in $[-1,1]^2$, the antipodal map $(i,j) \\mapsto (2N-i, 2N-j)$ negates coordinates, and boundary vertices are preserved under the antipodal map. The mesh size $\\sqrt{2}/N$ is shown to tend to zero.",
+    "mathContext": "Grid triangulation with $(2N+1)^2$ vertices. Vertex coordinates: $v(i,j) = \\bigl(\\tfrac{i}{N} - 1,\\; \\tfrac{j}{N} - 1\\bigr) \\in [-1,1]^2$. Antipodal map: $v(2N-i, 2N-j) = -v(i,j)$. Mesh size: $\\delta_N = \\sqrt{2}/N \\to 0$ as $N \\to \\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": ["grid triangulation", "mesh refinement", "antipodal symmetry", "Nat-to-Real casting"],
+    "prerequisites": ["Fintype", "lattice geometry", "limits of sequences"]
+  },
+  {
+    "id": "antisymmetric-difference",
+    "proofId": "borsuk-ulam-oq-03-oq-03",
+    "range": { "startLine": 155, "endLine": 177 },
+    "type": "technique",
+    "title": "Antisymmetric Difference (Odd-ification)",
+    "content": "Defines the antisymmetric difference $g(x) = f(x) - f(-x)$ for a function $f : \\mathbb{R}^2 \\to \\mathbb{R}^2$. This 'odd-ification' automatically satisfies $g(-x) = -g(x)$ for any $f$, making it compatible with Tucker's antipodal condition. Continuity of $g$ follows from continuity of $f$ via `fun_prop`. The construction is the standard reduction from Borsuk-Ulam to finding zeros of odd functions: $f(x) = f(-x)$ if and only if $g(x) = 0$.",
+    "mathContext": "Given $f : \\mathbb{R}^2 \\to \\mathbb{R}^2$, set $g(x) = f(x) - f(-x)$. Then $g(-x) = f(-x) - f(x) = -g(x)$ (odd), and $g(x) = 0 \\iff f(x) = f(-x)$ (antipodal pair). Finding a zero of the odd function $g$ is equivalent to finding an antipodal pair for $f$.",
+    "significance": "key",
+    "relatedConcepts": ["odd function", "antisymmetry", "zero finding", "Borsuk-Ulam reduction"],
+    "prerequisites": ["continuity of composition", "ring arithmetic in product types"]
+  },
+  {
+    "id": "corrected-s2-framework",
+    "proofId": "borsuk-ulam-oq-03-oq-03",
+    "range": { "startLine": 595, "endLine": 682 },
+    "type": "insight",
+    "title": "Corrected S^2 Domain and Dimensional Analysis",
+    "content": "The file explicitly documents and corrects a dimensional error present in earlier versions. The 2D Borsuk-Ulam theorem requires domain $S^2 \\subset \\mathbb{R}^3$ mapping to $\\mathbb{R}^2$, not $S^1 \\subset \\mathbb{R}^2$ to $\\mathbb{R}^2$. The latter is false: the identity map on $S^1$ shows $f(x) \\neq f(-x)$ for all $x$. This section introduces negation in $\\mathbb{R}^3$ (`neg3`), proves it is an involution preserving $S^2$ with no fixed points, and establishes $S^2$ is compact. The antisymmetric difference is extended to $f : \\mathbb{R}^3 \\to \\mathbb{R}^2$.",
+    "mathContext": "Borsuk-Ulam dimension matching: $f : S^n \\to \\mathbb{R}^n$. For $n = 2$: $S^2 = \\{(x,y,z) \\in \\mathbb{R}^3 : x^2 + y^2 + z^2 = 1\\}$ and $f : S^2 \\to \\mathbb{R}^2$. Counterexample for $S^1 \\to \\mathbb{R}^2$: $f = \\text{id}$, so $\\|f(x) - f(-x)\\| = 2$ for all $x \\in S^1$.",
+    "significance": "key",
+    "relatedConcepts": ["dimensional analysis", "sphere S^2", "antipodal involution", "compactness"],
+    "prerequisites": ["norm bounds on spheres", "compact subsets of Euclidean space"]
+  },
+  {
+    "id": "hemisphere-projection",
+    "proofId": "borsuk-ulam-oq-03-oq-03",
+    "range": { "startLine": 688, "endLine": 912 },
+    "type": "technique",
+    "title": "Hemisphere Projection: Disk-to-Sphere Lift",
+    "content": "Defines the hemisphere projection $(u,v) \\mapsto (u, v, \\sqrt{1 - u^2 - v^2})$ lifting the closed disk $\\bar{D}^2$ to the upper hemisphere of $S^2$. The crucial property is that on the boundary $\\partial D^2$ (where $u^2 + v^2 = 1$, corresponding to the equator of $S^2$), negating the disk point produces the antipodal sphere point: $\\text{lift}(-u,-v) = -\\text{lift}(u,v)$. This ensures that an odd function on $S^2$ induces an antipodal labeling on the disk boundary, making Tucker's lemma directly applicable.",
+    "mathContext": "Hemisphere projection: $\\phi(u,v) = (u, v, \\sqrt{1 - u^2 - v^2})$. On $\\partial D^2$ (equator, $z = 0$): $\\phi(-u,-v) = (-u, -v, 0) = -\\phi(u,v)$. For odd $g : S^2 \\to \\mathbb{R}^2$ with $g(-x) = -g(x)$, the composed function $\\tilde{g} = g \\circ \\phi$ satisfies $\\tilde{g}(-p) = -\\tilde{g}(p)$ on $\\partial D^2$.",
+    "significance": "key",
+    "relatedConcepts": ["hemisphere projection", "stereographic-like map", "boundary antipodality", "equator of S^2"],
+    "prerequisites": ["square root properties", "sphere and disk geometry", "continuity of algebraic maps"]
+  },
+  {
+    "id": "approx-and-exact-bu",
+    "proofId": "borsuk-ulam-oq-03-oq-03",
+    "range": { "startLine": 791, "endLine": 826 },
+    "type": "theorem",
+    "title": "Approximate and Exact 2D Borsuk-Ulam",
+    "content": "The culminating theorems of the formalization. `approx_borsuk_ulam_2d_corrected` shows that for any continuous $f : \\mathbb{R}^3 \\to \\mathbb{R}^2$ and any $\\varepsilon > 0$, there exists $x \\in S^2$ with $\\|f(x) - f(-x)\\| < \\varepsilon$. The proof composes Tucker on the disk with hemisphere projection. `borsuk_ulam_2d_corrected` then derives the exact result $f(x) = f(-x)$ by minimizing $d(x) = \\text{dist}(f(x), f(-x))$ over compact $S^2$; the minimum must be zero since approximate solutions exist for all $\\varepsilon > 0$.",
+    "mathContext": "Approximate BU: $\\forall \\varepsilon > 0, \\exists x \\in S^2, \\|f(x) - f(-x)\\| < \\varepsilon$. Exact BU: The distance function $d(x) = \\|f(x) - f(-x)\\|$ is continuous on compact $S^2$, so attains its minimum. If $\\min d > 0$, choosing $\\varepsilon = \\min d$ gives a contradiction with the approximate result.",
+    "significance": "key",
+    "relatedConcepts": ["Borsuk-Ulam theorem", "compactness argument", "minimum on compact set", "epsilon-delta bridge"],
+    "prerequisites": ["IsCompact.exists_isMinOn", "continuity of distance", "Tucker disk axiom"]
+  },
+  {
+    "id": "ivt-on-segments",
+    "proofId": "borsuk-ulam-oq-03-oq-03",
+    "range": { "startLine": 921, "endLine": 1077 },
+    "type": "technique",
+    "title": "IVT on Line Segments and Complementary Edge Zero-Finding",
+    "content": "Formalizes the Intermediate Value Theorem on line segments in $\\mathbb{R}^2$, which extracts approximate zeros from Tucker's complementary edges. The parametrization $w(t) = (1-t)u + tv$ for $t \\in [0,1]$ traces the segment from $u$ to $v$. When a complementary edge has labels $+k$ and $-k$, the $k$-th component of $g$ changes sign along the edge, so IVT gives $t^*$ with $g(w(t^*))_k = 0$. The theorem `complementary_edge_zero_fst` packages this: given opposite signs, it produces a point $w$ on the segment with $g(w)_k = 0$ and $\\text{dist}(w, u) \\leq \\text{dist}(u, v)$.",
+    "mathContext": "Parametrize segment: $\\gamma(t) = (1-t)u + tv$ for $t \\in [0,1]$. If $g(u)_k \\cdot g(v)_k \\leq 0$ (opposite signs), IVT on $h(t) = g(\\gamma(t))_k$ gives $t^* \\in [0,1]$ with $h(t^*) = 0$. The zero-crossing point satisfies $\\text{dist}(\\gamma(t^*), u) \\leq \\text{dist}(u, v) \\leq \\delta_N$ (mesh size).",
+    "significance": "supporting",
+    "relatedConcepts": ["intermediate value theorem", "line segment parametrization", "zero crossing", "sign change"],
+    "prerequisites": ["intermediate_value_Icc", "continuity of projections", "distance estimates"]
+  },
+  {
+    "id": "modulus-of-continuity-bound",
+    "proofId": "borsuk-ulam-oq-03-oq-03",
+    "range": { "startLine": 1079, "endLine": 1138 },
+    "type": "insight",
+    "title": "Modulus of Continuity and Convergence to Zero",
+    "content": "Establishes the quantitative convergence argument: at an IVT zero $w$ with $g(w)_k = 0$, the non-dominant component $|g(w)_{3-k}|$ is bounded by $2 \\cdot \\text{dist}(g(u), g(w))$, which in turn is bounded by the modulus of continuity at scale $\\delta$ (mesh size). As mesh refinement drives $\\delta \\to 0$, uniform continuity on compact domains ensures both components of $g(w)$ tend to zero. The theorem `non_dominant_at_zero_bound` uses the reverse triangle inequality and the dominant component condition to derive this.",
+    "mathContext": "At the IVT zero: $g(w)_k = 0$. Dominant component condition: $|g(u)_k| \\geq |g(u)_{3-k}|$. Then $|g(w)_{3-k}| \\leq |g(u)_{3-k}| + |g(w)_{3-k} - g(u)_{3-k}| \\leq |g(u)_k - g(w)_k| + |g(w)_{3-k} - g(u)_{3-k}| \\leq 2\\,\\omega_g(\\delta)$ where $\\omega_g$ is the modulus of continuity.",
+    "significance": "supporting",
+    "relatedConcepts": ["modulus of continuity", "uniform continuity", "mesh refinement", "convergence rate", "reverse triangle inequality"],
+    "prerequisites": ["triangle inequality", "sup-norm on product spaces", "compactness implies uniform continuity"]
+  },
+  {
+    "id": "constructive-vs-classical",
+    "proofId": "borsuk-ulam-oq-03-oq-03",
+    "range": { "startLine": 530, "endLine": 572 },
+    "type": "context",
+    "title": "Constructive-Classical Bridge and PPAD Membership",
+    "content": "The proof highlights a fundamental dichotomy in the Tucker approach to Borsuk-Ulam. The combinatorial core (Tucker's lemma, dominant component labeling, grid construction) is fully constructive and yields polynomial-time approximate solutions -- placing the problem in the PPAD complexity class. The only non-constructive step is the compactness/limiting argument that converts arbitrarily good approximations into an exact solution. This contrasts with the standard algebraic topology proof via degree theory, which is non-constructive from the outset (contradiction argument, homology or integration).",
+    "mathContext": "The Tucker approach gives PPAD membership: for any $\\varepsilon > 0$, an $\\varepsilon$-approximate antipodal pair can be found in time polynomial in $1/\\varepsilon$ via path-following in the Tucker labeling. The exact solution requires: $\\forall \\varepsilon > 0, \\exists x_\\varepsilon \\in S^2$ with $\\|g(x_\\varepsilon)\\| < \\varepsilon$ $\\implies$ $\\exists x^* \\in S^2$ with $g(x^*) = 0$ (by compactness of $S^2$).",
+    "significance": "supporting",
+    "relatedConcepts": ["constructive mathematics", "PPAD complexity class", "compactness argument", "degree theory", "algebraic topology"],
+    "prerequisites": ["computational complexity basics", "compactness in metric spaces"]
+  }
+]


### PR DESCRIPTION
## Summary
- Add 10 annotations for the **Constructive 2D Borsuk-Ulam via Tucker's Lemma** proof
- Covers Tucker labeling infrastructure, dominant component labeling, grid triangulation, antisymmetric difference, corrected S^2 domain, hemisphere projection, approximate/exact BU theorems, IVT on segments, modulus of continuity bounds, and the constructive-classical bridge
- Annotations align with the sections defined in `meta.json` and reference accurate line numbers from the Lean source

## Test plan
- [ ] Verify `annotations.json` is valid JSON
- [ ] Verify line ranges match the Lean source in `proofs/Proofs/BorsukUlamOQ03OQ03.lean`
- [ ] Verify `pnpm build` succeeds with the new annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)