### PR TITLE
enrich: add annotations for euler-polyhedral-formula-oq-02

### DIFF
--- a/src/data/proofs/euler-polyhedral-formula-oq-02/annotations.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02/annotations.json
@@ -1,60 +1,122 @@
-{
-  "annotations": [
-    {
-      "id": "polyhedral-surface-def",
-      "type": "definition",
-      "line": 60,
-      "content": "A polyhedral surface bundles V, E, F, \u03c7, the Euler formula, the total face angle sum (= (2E-2F)\u03c0 by polygon angle sum), and the total angular deficiency (= 2\u03c0V - total face angles). This encapsulates both combinatorial and angular data.",
-      "importance": "high"
-    },
-    {
-      "id": "discrete-gauss-bonnet",
-      "type": "theorem",
-      "line": 90,
-      "content": "The central result: \u03a3\u03b4(v) = 2\u03c0\u03c7. The proof rewrites using deficiency_sum and angle_sum_identity, then factors out 2\u03c0 and applies Euler's formula V-E+F=\u03c7. Purely algebraic.",
-      "importance": "critical"
-    },
-    {
-      "id": "descartes-theorem",
-      "type": "theorem",
-      "line": 101,
-      "content": "Descartes' theorem (1630): for convex polyhedra with \u03c7=2, total angular deficiency equals 4\u03c0. This was discovered 128 years before Euler's formula.",
-      "importance": "high"
-    },
-    {
-      "id": "genus-generalization",
-      "type": "theorem",
-      "line": 120,
-      "content": "For orientable surfaces of genus g (\u03c7=2-2g): \u03a3\u03b4(v) = 2\u03c0(2-2g). Sphere: 4\u03c0, torus: 0, double torus: -4\u03c0. Higher genus \u2192 more negative curvature.",
-      "importance": "high"
-    },
-    {
-      "id": "curvature-sign-topology",
-      "type": "insight",
-      "line": 147,
-      "content": "The sign of total curvature completely determines the topology: positive \u2192 \u03c7>0 (sphere), zero \u2192 \u03c7=0 (torus), negative \u2192 \u03c7<0 (higher genus). This is a complete characterization.",
-      "importance": "high"
-    },
-    {
-      "id": "topological-invariance",
-      "type": "theorem",
-      "line": 356,
-      "content": "Total deficiency depends only on \u03c7, not on the specific polyhedral realization. Face and edge subdivisions preserve deficiency because they preserve \u03c7.",
-      "importance": "medium"
-    },
-    {
-      "id": "platonic-computations",
-      "type": "computation",
-      "line": 210,
-      "content": "All five Platonic solids verified: tetrahedron (V=4, \u03b4=\u03c0), cube (V=8, \u03b4=\u03c0/2), octahedron (V=6, \u03b4=2\u03c0/3), dodecahedron (V=20, \u03b4=\u03c0/5), icosahedron (V=12, \u03b4=\u03c0/3). All give 4\u03c0 total.",
-      "importance": "medium"
-    },
-    {
-      "id": "five-regular-polyhedra",
-      "type": "theorem",
-      "line": 440,
-      "content": "The Schl\u00e4fli constraint pq < 2p+2q with p,q \u2265 3 has exactly 5 solutions: {3,3}, {3,4}, {3,5}, {4,3}, {5,3}. This classifies all regular polyhedra from curvature.",
-      "importance": "high"
-    }
-  ]
-}
+[
+  {
+    "id": "ann-polyhedral-surface",
+    "proofId": "euler-polyhedral-formula-oq-02",
+    "range": {"startLine": 44, "endLine": 55},
+    "type": "definition",
+    "title": "Polyhedral Surface Structure",
+    "content": "The formalization encodes a polyhedral surface as a structure carrying vertex count V, edge count E, face count F, and Euler characteristic chi, together with the Euler relation V - E + F = chi. Crucially, it also bundles the total face angle sum and a field totalDeficiency with the algebraic identity linking deficiency to the angle sum. This bundled design avoids carrying hypotheses through every theorem and makes the algebraic proof entirely self-contained.",
+    "mathContext": "\\chi = V - E + F,\\quad \\delta_{\\text{total}} = 2\\pi V - \\Sigma_{\\text{face angles}}",
+    "significance": "key",
+    "relatedConcepts": ["Euler characteristic", "angular deficiency", "polyhedral surface"],
+    "prerequisites": ["linear algebra over reals", "basic topology"]
+  },
+  {
+    "id": "ann-double-counting",
+    "proofId": "euler-polyhedral-formula-oq-02",
+    "range": {"startLine": 73, "endLine": 79},
+    "type": "technique",
+    "title": "Double-Counting Identity for Face Angles",
+    "content": "The double-counting argument is the combinatorial engine of the proof. Each edge is shared by exactly two faces, so summing the number of sides over all faces gives 2E. Since a p-gon has interior angle sum (p-2)pi, the total face angle sum simplifies to (2E - 2F)pi. This algebraic identity eliminates all individual face data and reduces the problem to a relation among V, E, and F alone.",
+    "mathContext": "\\sum_F p_F = 2E \\implies \\text{total face angles} = (2E - 2F)\\pi",
+    "significance": "key",
+    "relatedConcepts": ["handshaking lemma", "face-edge incidence", "polygon angle sum"],
+    "prerequisites": ["polygon interior angle sum formula"]
+  },
+  {
+    "id": "ann-gauss-bonnet-core",
+    "proofId": "euler-polyhedral-formula-oq-02",
+    "range": {"startLine": 85, "endLine": 98},
+    "type": "theorem",
+    "title": "The Discrete Gauss-Bonnet Theorem",
+    "content": "The central result: the total angular deficiency equals 2 pi times the Euler characteristic. The Lean proof proceeds by rewriting the deficiency using its definition, substituting the angle sum identity, then showing the resulting expression equals 2 pi chi via the Euler relation. The key tactic sequence is a cast from integers to reals (exact_mod_cast) followed by a ring computation that cancels terms and factors out 2 pi.",
+    "mathContext": "\\sum_v \\delta(v) = 2\\pi\\chi,\\quad \\text{where } \\delta(v) = 2\\pi - \\sum_{f \\ni v} \\theta(v,f)",
+    "significance": "key",
+    "relatedConcepts": ["Gauss-Bonnet theorem", "curvature integral", "Euler characteristic"],
+    "prerequisites": ["Euler relation V - E + F = chi", "double-counting identity"]
+  },
+  {
+    "id": "ann-descartes",
+    "proofId": "euler-polyhedral-formula-oq-02",
+    "range": {"startLine": 100, "endLine": 114},
+    "type": "theorem",
+    "title": "Descartes' Theorem and the Torus Case",
+    "content": "Specializing the discrete Gauss-Bonnet theorem to chi = 2 yields Descartes' theorem: every convex polyhedron has total angular deficiency exactly 4 pi. Dually, setting chi = 0 gives the torus case where total deficiency vanishes. These corollaries illustrate how a single algebraic identity captures qualitatively different geometric behavior -- convex polyhedra have positive curvature everywhere, while toroidal surfaces balance positive and negative curvature to zero.",
+    "mathContext": "\\chi = 2 \\implies \\sum \\delta = 4\\pi;\\quad \\chi = 0 \\implies \\sum \\delta = 0",
+    "significance": "key",
+    "relatedConcepts": ["Descartes total angle defect", "convex polyhedra", "toroidal polyhedra"],
+    "prerequisites": ["discrete Gauss-Bonnet theorem"]
+  },
+  {
+    "id": "ann-genus-generalization",
+    "proofId": "euler-polyhedral-formula-oq-02",
+    "range": {"startLine": 120, "endLine": 163},
+    "type": "insight",
+    "title": "Genus Generalization and Curvature Sign",
+    "content": "Extending the theorem to orientable surfaces of genus g uses chi = 2 - 2g, yielding total deficiency 2 pi (2 - 2g). This gives a trichotomy: genus 0 (sphere-type) has positive total curvature 4 pi, genus 1 (torus) has zero total curvature, and genus >= 2 has strictly negative total curvature. The proof that higher-genus surfaces have non-positive curvature uses nlinarith with the positivity of pi, demonstrating how the algebraic framework handles the sign analysis cleanly.",
+    "mathContext": "\\sum \\delta = 2\\pi(2 - 2g) = 4\\pi(1 - g)",
+    "significance": "key",
+    "relatedConcepts": ["genus", "orientable surface", "curvature sign"],
+    "prerequisites": ["discrete Gauss-Bonnet", "Euler characteristic for orientable surfaces"]
+  },
+  {
+    "id": "ann-curvature-topology",
+    "proofId": "euler-polyhedral-formula-oq-02",
+    "range": {"startLine": 165, "endLine": 205},
+    "type": "insight",
+    "title": "Curvature-Topology Correspondence",
+    "content": "This section establishes that the sign of total curvature completely determines the topological type. Positive total deficiency forces chi > 0 and hence genus 0; zero deficiency forces chi = 0 and genus 1; negative deficiency forces chi < 0 and genus >= 2. The proof of the negative case uses a clever contradiction argument: assuming genus < 2 means genus is 0 or 1, but sphere deficiency is 4 pi > 0 and torus deficiency is 0, both contradicting negative deficiency. This is a discrete analogue of the classification of closed surfaces by Gaussian curvature.",
+    "mathContext": "\\sum \\delta > 0 \\iff g = 0;\\quad \\sum \\delta = 0 \\iff g = 1;\\quad \\sum \\delta < 0 \\iff g \\geq 2",
+    "significance": "key",
+    "relatedConcepts": ["surface classification", "topological invariant", "Gaussian curvature"],
+    "prerequisites": ["genus generalization", "positivity of pi"]
+  },
+  {
+    "id": "ann-platonic-verification",
+    "proofId": "euler-polyhedral-formula-oq-02",
+    "range": {"startLine": 222, "endLine": 315},
+    "type": "context",
+    "title": "Platonic Solid Verifications",
+    "content": "All five Platonic solids are constructed as concrete PolyhedralSurface instances with their V-E-F data, and each is verified to satisfy discrete Gauss-Bonnet. The per-vertex deficiency computations show the face-angle data: tetrahedron has deficiency pi per vertex (3 equilateral triangles), cube has pi/2 (3 squares), octahedron has 2 pi/3 (4 triangles), dodecahedron has pi/5 (3 pentagons), and icosahedron has pi/3 (5 triangles). The product V times per-vertex deficiency always yields 4 pi, confirming Descartes' theorem.",
+    "mathContext": "V \\cdot \\delta_{\\text{vertex}} = 4\\pi \\text{ for each Platonic solid}",
+    "significance": "supporting",
+    "relatedConcepts": ["Platonic solids", "regular polyhedra", "vertex deficiency"],
+    "prerequisites": ["Descartes' theorem", "polygon interior angle sum"]
+  },
+  {
+    "id": "ann-topological-invariance",
+    "proofId": "euler-polyhedral-formula-oq-02",
+    "range": {"startLine": 353, "endLine": 373},
+    "type": "theorem",
+    "title": "Topological Invariance of Total Deficiency",
+    "content": "The total angular deficiency is a topological invariant: any two polyhedral surfaces with the same Euler characteristic have the same total deficiency, regardless of their combinatorial structure. This is proved by simply applying the discrete Gauss-Bonnet theorem to both surfaces and using the hypothesis that their chi values agree. The subdivision preservation theorems (face splits, edge splits) are immediate corollaries, since subdivisions preserve the Euler characteristic.",
+    "mathContext": "\\chi(S_1) = \\chi(S_2) \\implies \\sum \\delta(S_1) = \\sum \\delta(S_2)",
+    "significance": "key",
+    "relatedConcepts": ["topological invariant", "mesh refinement", "subdivision"],
+    "prerequisites": ["discrete Gauss-Bonnet theorem"]
+  },
+  {
+    "id": "ann-schlafli-classification",
+    "proofId": "euler-polyhedral-formula-oq-02",
+    "range": {"startLine": 462, "endLine": 487},
+    "type": "theorem",
+    "title": "Classification of Regular Polyhedra via Schlafli Constraint",
+    "content": "The Schlafli inequality pq < 2p + 2q (equivalently 1/p + 1/q > 1/2) arises from requiring positive angular deficiency at each vertex of a regular {p,q} polyhedron. The proof that only five pairs (p,q) with p,q >= 3 satisfy this uses interval_cases to enumerate all cases with p,q <= 5 (the bound derived from nlinarith), then omega to verify each. The complementary theorems show p >= 6 or q >= 6 immediately violates the inequality, blocking any larger regular polyhedra.",
+    "mathContext": "pq < 2p + 2q \\iff \\frac{1}{p} + \\frac{1}{q} > \\frac{1}{2},\\quad p,q \\geq 3",
+    "significance": "key",
+    "relatedConcepts": ["Schlafli symbol", "regular polyhedra classification", "Platonic solids"],
+    "prerequisites": ["positive curvature condition", "discrete Gauss-Bonnet"]
+  },
+  {
+    "id": "ann-vertex-bounds",
+    "proofId": "euler-polyhedral-formula-oq-02",
+    "range": {"startLine": 415, "endLine": 444},
+    "type": "technique",
+    "title": "Vertex Count Bounds from Curvature",
+    "content": "For convex polyhedra (chi = 2), if every vertex has deficiency at least delta_min, then V <= 4 pi / delta_min. This gives a concrete upper bound on the number of vertices from a lower bound on per-vertex curvature. The average deficiency is 4 pi / V, and for V >= 4 the average is at most pi. These bounds demonstrate the quantitative power of the Gauss-Bonnet theorem: the total curvature budget of 4 pi constrains how many vertices a convex polyhedron can have.",
+    "mathContext": "V \\leq \\frac{4\\pi}{\\delta_{\\min}},\\quad \\text{average } \\delta = \\frac{4\\pi}{V}",
+    "significance": "supporting",
+    "relatedConcepts": ["curvature budget", "isoperimetric bounds", "vertex count"],
+    "prerequisites": ["Descartes' theorem", "division inequalities"]
+  }
+]


### PR DESCRIPTION
## Summary
- Replaces old-format annotations with 10 detailed annotations using the proper schema (range, proofId, mathContext, significance, relatedConcepts, prerequisites)
- Covers the full proof: polyhedral surface definition, double-counting technique, discrete Gauss-Bonnet theorem, Descartes' theorem, genus generalization, curvature-topology correspondence, Platonic solid verifications, topological invariance, and Schlafli classification
- Each annotation includes LaTeX mathContext and precise line ranges from the Lean source

## Test plan
- [ ] Verify `pnpm build` succeeds with updated annotations
- [ ] Check annotations render correctly on the proof gallery page

🤖 Generated with [Claude Code](https://claude.com/claude-code)