### PR TITLE
enrich: add annotations for cauchy-schwarz-integral-oq-01-oq-02

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/annotations.json
@@ -1,1 +1,213 @@
-[]
+[
+  {
+    "id": "ann-rt-header-context",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
+    "type": "context",
+    "title": "Historical Context: Riesz-Thorin Interpolation",
+    "content": "Marcel Riesz proved the first interpolation theorem in 1927 for bilinear forms. In 1948, Olof Thorin dramatically simplified the proof using the Hadamard three-lines lemma from complex analysis, which connects the result to the maximum modulus principle. This formalization answers OQ-01-OQ-02: 'Can Riesz-Thorin be derived from Holder?' with a partial answer -- Holder is necessary but not sufficient alone.",
+    "mathContext": "The Riesz-Thorin theorem states: if $T: L^{p_0} \\to L^{q_0}$ with norm $M_0$ and $T: L^{p_1} \\to L^{q_1}$ with norm $M_1$, then $T: L^{p_\\theta} \\to L^{q_\\theta}$ with norm $\\leq M_0^{1-\\theta} \\cdot M_1^\\theta$ for $\\theta \\in [0,1]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "interpolation theory",
+      "Lp spaces",
+      "complex analysis",
+      "operator theory"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-rt-interp-recip",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
+    "range": {
+      "startLine": 60,
+      "endLine": 99
+    },
+    "type": "definition",
+    "title": "Interpolated Exponent Infrastructure",
+    "content": "The definitions interpRecip and interpExp encode the harmonic interpolation of Lebesgue exponents. The reciprocal formulation is preferred because it linearizes: 1/p is linear in the interpolation parameter theta, even though p itself is not. Four key properties are proved: endpoint recovery at theta=0 and theta=1, positivity of the reciprocal, positivity of the exponent, and the diagonal case where both endpoints coincide.",
+    "mathContext": "Given $p_0, p_1 > 0$ and $\\theta \\in [0,1]$, the interpolated reciprocal is $\\frac{1}{p_\\theta} = \\frac{1-\\theta}{p_0} + \\frac{\\theta}{p_1}$. This is a convex combination of reciprocals, which arises naturally from Holder's inequality and duality arguments.",
+    "significance": "key",
+    "relatedConcepts": [
+      "harmonic interpolation",
+      "convex combination",
+      "Lebesgue exponents"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-rt-conjugate-preservation",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
+    "range": {
+      "startLine": 101,
+      "endLine": 125
+    },
+    "type": "theorem",
+    "title": "Conjugate Exponents Preserved Under Interpolation",
+    "content": "This is a subtle but essential algebraic fact: if (p0, q0) and (p1, q1) are both Holder conjugate pairs (1/p + 1/q = 1), then the interpolated pair (p_theta, q_theta) is also conjugate. The proof is purely algebraic, factoring the sum as a convex combination of the conjugacy conditions at each endpoint. This guarantees that duality is maintained throughout the interpolation.",
+    "mathContext": "If $\\frac{1}{p_0} + \\frac{1}{q_0} = 1$ and $\\frac{1}{p_1} + \\frac{1}{q_1} = 1$, then $\\frac{1}{p_\\theta} + \\frac{1}{q_\\theta} = (1-\\theta)\\left(\\frac{1}{p_0} + \\frac{1}{q_0}\\right) + \\theta\\left(\\frac{1}{p_1} + \\frac{1}{q_1}\\right) = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Holder conjugate exponents",
+      "Lp-Lq duality",
+      "convex combination"
+    ],
+    "prerequisites": [
+      "ann-rt-interp-recip"
+    ]
+  },
+  {
+    "id": "ann-rt-lplq-bounded",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
+    "range": {
+      "startLine": 127,
+      "endLine": 160
+    },
+    "type": "definition",
+    "title": "Operator Norm Bound Structure (LpLqBounded)",
+    "content": "The LpLqBounded structure formalizes the notion of a bounded linear operator between Lp and Lq spaces. It bundles two pieces of data: nonnegativity of the bound M, and the operator inequality stating that the Lp seminorm of Tf is at most M times the Lp seminorm of f, for all strongly measurable f. The identity operator is shown to be bounded with norm 1, verifying the structure is non-vacuous.",
+    "mathContext": "An operator $T: L^p \\to L^q$ is bounded with norm $\\leq M$ if $\\|Tf\\|_q \\leq M \\cdot \\|f\\|_p$ for all $f \\in L^p$. This is the data at each endpoint that Riesz-Thorin interpolates between.",
+    "significance": "key",
+    "relatedConcepts": [
+      "operator norm",
+      "Lp seminorm (eLpNorm)",
+      "AEStronglyMeasurable",
+      "Mathlib measure theory"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-rt-log-convexity",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
+    "range": {
+      "startLine": 162,
+      "endLine": 246
+    },
+    "type": "technique",
+    "title": "Log-Convexity and Properties of the Interpolated Norm",
+    "content": "The interpolated norm M0^(1-theta) * M1^theta is a weighted geometric mean, and this section proves its five key properties: nonnegativity, endpoint recovery, log-convexity (log is affine in theta), monotonicity via the log comparison technique, scaling, the AM-GM inequality bounding the geometric mean by the arithmetic mean, and submultiplicativity. The monotonicity proof is notable for converting a multiplicative comparison into an additive one via the logarithm.",
+    "mathContext": "The function $M_\\theta = M_0^{1-\\theta} \\cdot M_1^\\theta$ satisfies $\\log M_\\theta = (1-\\theta) \\log M_0 + \\theta \\log M_1$, which is affine in $\\theta$. The weighted AM-GM inequality gives $M_0^{1-\\theta} \\cdot M_1^\\theta \\leq (1-\\theta) M_0 + \\theta M_1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "geometric mean",
+      "log-convexity",
+      "AM-GM inequality",
+      "Real.rpow",
+      "submultiplicativity"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-rt-three-lines",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
+    "range": {
+      "startLine": 248,
+      "endLine": 315
+    },
+    "type": "insight",
+    "title": "The Hadamard Three-Lines Lemma (Axiomatized)",
+    "content": "The Hadamard three-lines lemma is the single piece of complex analysis that separates Holder from Riesz-Thorin. It states that for an analytic function on the strip {z : 0 <= Re z <= 1}, the supremum of |F| on each vertical line is log-convex. This is axiomatized because the proof requires the Phragmen-Lindelof principle, which is not available in Mathlib. A bridge theorem (three_lines_log_convexity) derives the log formulation from the axiom.",
+    "mathContext": "For $F$ continuous on $\\overline{S} = \\{z : 0 \\leq \\operatorname{Re} z \\leq 1\\}$ and analytic on the interior, if $|F(iy)| \\leq M_0$ and $|F(1+iy)| \\leq M_1$ for all $y$, then $|F(t+iy)| \\leq M_0^{1-t} \\cdot M_1^t$ for $t \\in [0,1]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "complex analysis",
+      "maximum modulus principle",
+      "Phragmen-Lindelof principle",
+      "strip domain geometry"
+    ],
+    "prerequisites": [
+      "ann-rt-log-convexity"
+    ]
+  },
+  {
+    "id": "ann-rt-riesz-thorin-axiom",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
+    "range": {
+      "startLine": 317,
+      "endLine": 357
+    },
+    "type": "theorem",
+    "title": "The Riesz-Thorin Theorem (Axiomatized)",
+    "content": "The full Riesz-Thorin theorem is axiomatized because its proof requires the three-lines lemma, which is itself axiomatized. The statement is carefully formulated using LpLqBounded at the endpoint pairs and produces a LpLqBounded at the interpolated pair. The linearity hypothesis on T is included explicitly, reflecting the fact that the proof constructs an analytic family of operators from the linearity of T.",
+    "mathContext": "If $T$ is linear and $\\|T\\|_{L^{p_i} \\to L^{q_i}} \\leq M_i$ for $i=0,1$, then $\\|T\\|_{L^{p_\\theta} \\to L^{q_\\theta}} \\leq M_0^{1-\\theta} \\cdot M_1^\\theta$. The proof maps $z \\mapsto T_z$ to an analytic family on the strip and applies the three-lines lemma.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lp space interpolation",
+      "operator theory",
+      "analytic family of operators"
+    ],
+    "prerequisites": [
+      "ann-rt-three-lines",
+      "ann-rt-lplq-bounded"
+    ]
+  },
+  {
+    "id": "ann-rt-holder-endpoint",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
+    "range": {
+      "startLine": 359,
+      "endLine": 398
+    },
+    "type": "technique",
+    "title": "Holder's Inequality as the Endpoint Bound",
+    "content": "This section makes the connection between Holder and Riesz-Thorin explicit: Holder's inequality provides the operator norm bound at each endpoint. The theorem holder_gives_endpoint directly invokes Mathlib's ENNReal.lintegral_mul_le_Lp_mul_Lq, showing that the integral of |fg| is bounded by the product of Lp and Lq norms. The proof carefully manages the conversion between nnnorm and ENNReal representations required by Mathlib's API.",
+    "mathContext": "Holder's inequality: $\\int |fg| \\,d\\mu \\leq \\left(\\int |f|^p \\,d\\mu\\right)^{1/p} \\cdot \\left(\\int |g|^q \\,d\\mu\\right)^{1/q}$ for conjugate exponents $1/p + 1/q = 1$. This is the proven ingredient that Riesz-Thorin builds upon.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Holder's inequality",
+      "ENNReal.lintegral_mul_le_Lp_mul_Lq",
+      "nnnorm",
+      "AEMeasurable"
+    ],
+    "prerequisites": [
+      "ann-rt-lplq-bounded"
+    ]
+  },
+  {
+    "id": "ann-rt-hausdorff-young",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
+    "range": {
+      "startLine": 400,
+      "endLine": 450
+    },
+    "type": "insight",
+    "title": "Hausdorff-Young as a Corollary of Riesz-Thorin",
+    "content": "The Hausdorff-Young inequality is derived by interpolating between two known bounds on the Fourier transform: the trivial L1-to-Linfty bound (norm 1) and the Plancherel theorem L2-to-L2 (norm 1). Since both endpoint norms are 1, the interpolated norm is 1^(1-theta) * 1^theta = 1 for all theta. The exponent computation shows that p_theta = 2/(2-theta) ranges over [1,2] and q_theta = 2/theta is its conjugate.",
+    "mathContext": "For $1 \\leq p \\leq 2$, the Fourier transform satisfies $\\|\\hat{f}\\|_{p'} \\leq \\|f\\|_p$ where $\\frac{1}{p} + \\frac{1}{p'} = 1$. This interpolates between $\\|\\hat{f}\\|_\\infty \\leq \\|f\\|_1$ (trivial) and $\\|\\hat{f}\\|_2 = \\|f\\|_2$ (Plancherel).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fourier transform",
+      "Plancherel theorem",
+      "Hausdorff-Young inequality"
+    ],
+    "prerequisites": [
+      "ann-rt-riesz-thorin-axiom"
+    ]
+  },
+  {
+    "id": "ann-rt-young-convolution",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02",
+    "range": {
+      "startLine": 452,
+      "endLine": 510
+    },
+    "type": "technique",
+    "title": "Young's Convolution Inequality Exponents",
+    "content": "Young's convolution inequality is another major consequence of Riesz-Thorin. This section proves the exponent condition 1/q + 1 = 1/p + 1/r, shows q >= 1 when p, r >= 1, and verifies three concrete instances: L1*L1 to L1, L1*L2 to L2, and L^(4/3)*L2 to L4. The self-dual case (r = r') gives the clean result that the interpolated norm equals the original norm, demonstrated by the algebraic identity M^(1-theta) * M^theta = M.",
+    "mathContext": "Young's convolution inequality: $\\|f * g\\|_q \\leq \\|f\\|_p \\cdot \\|g\\|_r$ when $\\frac{1}{q} + 1 = \\frac{1}{p} + \\frac{1}{r}$. The proof interpolates between $L^1 * L^r \\to L^r$ (by Minkowski) and $L^{r'} * L^r \\to L^\\infty$ (by Holder).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "convolution",
+      "Young's inequality",
+      "Minkowski's inequality",
+      "self-dual exponents"
+    ],
+    "prerequisites": [
+      "ann-rt-riesz-thorin-axiom",
+      "ann-rt-holder-endpoint"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- Add 10 annotations for the Riesz-Thorin Interpolation from Holder's Inequality proof
- Covers all 11 parts of the formalization: interpolated exponents, conjugate preservation, LpLqBounded structure, log-convexity/AM-GM/submultiplicativity, Hadamard three-lines lemma (axiom), Riesz-Thorin theorem (axiom), Holder endpoint connection, Hausdorff-Young corollary, and Young's convolution inequality
- Each annotation includes LaTeX math context, significance rating, related concepts, and prerequisite links

## Annotations
| ID | Type | Title | Lines | Significance |
|----|------|-------|-------|-------------|
| ann-rt-header-context | context | Historical Context: Riesz-Thorin Interpolation | 1-38 | key |
| ann-rt-interp-recip | definition | Interpolated Exponent Infrastructure | 60-99 | key |
| ann-rt-conjugate-preservation | theorem | Conjugate Exponents Preserved Under Interpolation | 101-125 | key |
| ann-rt-lplq-bounded | definition | Operator Norm Bound Structure (LpLqBounded) | 127-160 | key |
| ann-rt-log-convexity | technique | Log-Convexity and Properties of the Interpolated Norm | 162-246 | key |
| ann-rt-three-lines | insight | The Hadamard Three-Lines Lemma (Axiomatized) | 248-315 | key |
| ann-rt-riesz-thorin-axiom | theorem | The Riesz-Thorin Theorem (Axiomatized) | 317-357 | key |
| ann-rt-holder-endpoint | technique | Holder's Inequality as the Endpoint Bound | 359-398 | key |
| ann-rt-hausdorff-young | insight | Hausdorff-Young as a Corollary of Riesz-Thorin | 400-450 | key |
| ann-rt-young-convolution | technique | Young's Convolution Inequality Exponents | 452-510 | supporting |

## Test plan
- [ ] Verify annotations.json is valid JSON
- [ ] Verify all line ranges correspond to actual proof content
- [ ] Verify `pnpm build` succeeds with the new annotations

Generated with [Claude Code](https://claude.com/claude-code)