### PR TITLE
enrich: add annotations for randomized-maxcut-oq-01

### DIFF
--- a/src/data/proofs/randomized-maxcut-oq-01/annotations.json
+++ b/src/data/proofs/randomized-maxcut-oq-01/annotations.json
@@ -1,1 +1,122 @@
-[]
+[
+  {
+    "id": "ann-gw-overview",
+    "proofId": "randomized-maxcut-oq-01",
+    "range": {"startLine": 1, "endLine": 23},
+    "type": "context",
+    "title": "The Goemans-Williamson Breakthrough",
+    "content": "The Goemans-Williamson algorithm (1995) was a watershed moment in combinatorial optimization. Before their work, the best polynomial-time approximation for MaxCut was the trivial 1/2-approximation obtained by assigning vertices randomly. By introducing semidefinite programming (SDP) relaxation combined with random hyperplane rounding, they achieved an approximation ratio of approximately 0.878, nearly doubling the gap closed between 1/2 and 1. Under the Unique Games Conjecture (Khot et al. 2007), this ratio is conditionally optimal -- no polynomial-time algorithm can do better.",
+    "mathContext": "\\alpha_{\\text{GW}} = \\min_{0 < \\theta \\leq \\pi} \\frac{2}{\\pi} \\cdot \\frac{\\theta}{1 - \\cos\\theta} \\approx 0.878",
+    "significance": "key",
+    "relatedConcepts": ["semidefinite programming", "approximation algorithms", "MaxCut", "Unique Games Conjecture"],
+    "prerequisites": ["graph theory", "linear programming relaxations"]
+  },
+  {
+    "id": "ann-cut-structure",
+    "proofId": "randomized-maxcut-oq-01",
+    "range": {"startLine": 43, "endLine": 77},
+    "type": "definition",
+    "title": "Cut Infrastructure via GWCut Structure",
+    "content": "The GWCut structure represents a graph partition as two disjoint vertex sets A and B whose union covers all vertices. The edgeInCut predicate uses Sym2.lift to handle unordered pairs correctly, checking whether an edge's endpoints lie on opposite sides of the cut. The ofAssignment constructor builds a cut from a Boolean labeling function, with the partition and disjointness properties proved by case analysis on the Boolean value. This mirrors the infrastructure in the companion 1/2-approximation proof (RandomizedMaxCut.lean).",
+    "mathContext": "C = (A, B) \\text{ where } A \\cup B = V, A \\cap B = \\emptyset",
+    "significance": "supporting",
+    "relatedConcepts": ["graph partitioning", "Sym2", "Finset"],
+    "prerequisites": ["SimpleGraph", "Finset.univ"]
+  },
+  {
+    "id": "ann-maxcut-value",
+    "proofId": "randomized-maxcut-oq-01",
+    "range": {"startLine": 75, "endLine": 76},
+    "type": "definition",
+    "title": "MaxCut as Supremum over Boolean Assignments",
+    "content": "The gwMaxCutValue function computes the maximum cut by taking the supremum of cut sizes over all possible Boolean vertex assignments. Since Fintype V is finite, there are 2^|V| possible assignments, making this a finite optimization. The use of Finset.univ.sup ensures we consider every possible partition. This is an exact (but exponential-time) characterization of the NP-hard MaxCut problem, serving as the benchmark against which the GW approximation is measured.",
+    "mathContext": "\\text{MaxCut}(G) = \\max_{f : V \\to \\{0,1\\}} |\\{(i,j) \\in E : f(i) \\neq f(j)\\}|",
+    "significance": "key",
+    "relatedConcepts": ["NP-hardness", "combinatorial optimization", "Finset.sup"],
+    "prerequisites": ["Fintype", "SimpleGraph.edgeFinset"]
+  },
+  {
+    "id": "ann-gw-constant",
+    "proofId": "randomized-maxcut-oq-01",
+    "range": {"startLine": 78, "endLine": 98},
+    "type": "technique",
+    "title": "Conservative Rational Bound for the GW Constant",
+    "content": "The true Goemans-Williamson constant is an irrational number defined as the minimum of (2/pi)(theta/(1-cos(theta))) over (0,pi], achieved at theta* where theta*sin(theta*) + cos(theta*) = 1. Its decimal expansion begins 0.87856... The formalization uses the rational lower bound 878/1000, which is strictly less than the true value. This conservative choice is deliberate: since the main theorem proves E[cut] >= alpha_GW * MaxCut, using a smaller alpha_GW makes the inequality strictly easier to satisfy while still demonstrating the substantial improvement over 1/2.",
+    "mathContext": "\\alpha_{\\text{GW}} = \\frac{878}{1000} < 0.87856\\ldots = \\min_{0 < \\theta \\leq \\pi} \\frac{2\\theta}{\\pi(1 - \\cos\\theta)}",
+    "significance": "key",
+    "relatedConcepts": ["transcendental constants", "rational approximation", "norm_num"],
+    "prerequisites": ["real number arithmetic", "optimization"]
+  },
+  {
+    "id": "ann-sdp-relaxation",
+    "proofId": "randomized-maxcut-oq-01",
+    "range": {"startLine": 100, "endLine": 122},
+    "type": "insight",
+    "title": "SDP Relaxation: Why Axiomatization is Necessary",
+    "content": "The SDP relaxation is axiomatized rather than defined because Mathlib currently lacks semidefinite programming infrastructure (positive semidefinite cones, Schur complements, SDP duality). The axiom sdp_ge_maxcut captures the essential property that SDP_OPT upper-bounds MaxCut. This is justified because any cut (A,B) embeds into the SDP feasible set by assigning v_i = e_1 for i in A and v_i = -e_1 for i in B, achieving (1 - v_i.v_j)/2 = 1 for cut edges and 0 otherwise. The axiomatization cleanly separates the verified algebraic argument from the unformalized SDP theory.",
+    "mathContext": "\\text{MaxCut}(G) \\leq \\text{SDP}_{\\text{OPT}}(G) = \\max \\frac{1}{2}\\sum_{(i,j) \\in E}(1 - v_i \\cdot v_j)",
+    "significance": "key",
+    "relatedConcepts": ["semidefinite programming", "relaxation", "axiomatization strategy"],
+    "prerequisites": ["linear algebra", "inner product spaces", "optimization duality"]
+  },
+  {
+    "id": "ann-hyperplane-rounding",
+    "proofId": "randomized-maxcut-oq-01",
+    "range": {"startLine": 124, "endLine": 162},
+    "type": "technique",
+    "title": "Hyperplane Rounding and the Arccos Inequality",
+    "content": "The hyperplane rounding technique is the algorithmic innovation at the heart of the GW result. Given unit vectors from the SDP solution, a uniformly random hyperplane through the origin assigns each vertex to the side where its vector points. The probability that edge (i,j) is cut equals arccos(v_i.v_j)/pi, derived from the proportion of the unit sphere where the hyperplane separates v_i from v_j. The deep analytical inequality arccos(x)/pi >= alpha_GW * (1-x)/2 for x in [-1,1] then bounds this rounding probability below, connecting it to the SDP contribution for each edge.",
+    "mathContext": "\\Pr[\\text{cut}(i,j)] = \\frac{\\arccos(v_i \\cdot v_j)}{\\pi} \\geq \\alpha_{\\text{GW}} \\cdot \\frac{1 - v_i \\cdot v_j}{2}",
+    "significance": "key",
+    "relatedConcepts": ["random hyperplanes", "arccos function", "rounding schemes", "unit sphere geometry"],
+    "prerequisites": ["measure theory on spheres", "arccos properties"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "randomized-maxcut-oq-01",
+    "range": {"startLine": 174, "endLine": 179},
+    "type": "theorem",
+    "title": "Main Theorem: The calc Chain",
+    "content": "The main approximation guarantee is proved via a two-step calc chain. First, alpha_GW * MaxCut <= alpha_GW * SDP_OPT follows from the SDP relaxation bound (sdp_ge_maxcut) and monotonicity of multiplication by the positive constant alpha_GW. Second, alpha_GW * SDP_OPT <= E[cut] follows from the rounding inequality. This is the entire algebraic backbone of the GW result: the chain of inequalities E[cut] >= alpha_GW * SDP_OPT >= alpha_GW * MaxCut. The proof uses mul_le_mul_of_nonneg_left, demonstrating how Lean's ordered algebra API supports clean approximation arguments.",
+    "mathContext": "\\alpha_{\\text{GW}} \\cdot \\text{MaxCut} \\leq \\alpha_{\\text{GW}} \\cdot \\text{SDP}_{\\text{OPT}} \\leq \\mathbb{E}[|C_{\\text{GW}}|]",
+    "significance": "key",
+    "relatedConcepts": ["calc blocks", "transitivity of inequalities", "mul_le_mul_of_nonneg_left"],
+    "prerequisites": ["ordered semiring", "Lean calc tactic"]
+  },
+  {
+    "id": "ann-ratio-bound",
+    "proofId": "randomized-maxcut-oq-01",
+    "range": {"startLine": 182, "endLine": 186},
+    "type": "theorem",
+    "title": "Ratio Form of the Approximation Guarantee",
+    "content": "The gw_ratio_bound theorem reformulates the approximation guarantee as alpha_GW <= E[cut]/MaxCut, the standard way approximation ratios are stated in the algorithms literature. The proof applies le_div_iff (division characterization of inequality) to the multiplicative form, requiring the hypothesis that MaxCut > 0. This non-degeneracy condition excludes the trivial case of edgeless graphs. The ratio form directly shows that the GW algorithm achieves at least 87.8% of the optimal cut value in expectation.",
+    "mathContext": "\\alpha_{\\text{GW}} \\leq \\frac{\\mathbb{E}[|C_{\\text{GW}}|]}{\\text{MaxCut}(G)} \\quad \\text{when } \\text{MaxCut}(G) > 0",
+    "significance": "supporting",
+    "relatedConcepts": ["approximation ratio", "le_div_iff", "non-degeneracy conditions"],
+    "prerequisites": ["division in ordered fields"]
+  },
+  {
+    "id": "ann-improvement",
+    "proofId": "randomized-maxcut-oq-01",
+    "range": {"startLine": 188, "endLine": 190},
+    "type": "insight",
+    "title": "Strict Improvement over Random Assignment",
+    "content": "The theorem gw_improves_random establishes that 1/2 < alpha_GW, confirming the GW algorithm strictly outperforms the naive randomized approach. The simple 1/2-approximation assigns each vertex to a random side independently, cutting each edge with probability exactly 1/2. The GW algorithm improves this by using SDP-guided vectors that encode correlations between vertices. The gap from 0.5 to 0.878 represents a 75.6% reduction in the remaining approximation gap (from 1/2 to 1), achieved through the geometric insight of hyperplane rounding.",
+    "mathContext": "\\frac{1}{2} < \\alpha_{\\text{GW}} = \\frac{878}{1000}",
+    "significance": "supporting",
+    "relatedConcepts": ["randomized algorithms", "derandomization", "approximation gaps"],
+    "prerequisites": ["randomized MaxCut 1/2-approximation"]
+  },
+  {
+    "id": "ann-structural-bounds",
+    "proofId": "randomized-maxcut-oq-01",
+    "range": {"startLine": 197, "endLine": 217},
+    "type": "lemma",
+    "title": "Structural Bounds: MaxCut and Edge Count",
+    "content": "The structural bound gwMaxCut_le_edges proves that no cut can exceed the total number of edges, an obvious but necessary sanity check. The proof uses Finset.sup_le to reduce to showing each individual cut has size at most |E|, then applies Finset.card_filter_le. The chain of bounds gwExpectedCut_le_sdp and sdp_le_edges (axiomatized) establishes gwExpectedCut_le_edges by transitivity. These bounds ensure all quantities in the GW analysis remain within the natural range [0, |E|], preventing vacuous results.",
+    "mathContext": "0 \\leq \\text{MaxCut}(G) \\leq |E(G)| \\quad \\text{and} \\quad \\mathbb{E}[|C|] \\leq \\text{SDP}_{\\text{OPT}} \\leq |E(G)|",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sup_le", "Finset.card_filter_le", "monotonicity"],
+    "prerequisites": ["finite graph theory", "Finset API"]
+  }
+]


### PR DESCRIPTION
## Summary
- Add 10 annotations to the Goemans-Williamson 0.878-approximation for MaxCut proof
- Covers the full proof structure: SDP relaxation strategy, conservative rational bound for alpha_GW, hyperplane rounding technique, the main calc-chain approximation theorem, ratio form, and structural bounds
- Annotations include LaTeX math context, related concepts, and prerequisite knowledge

## Annotations
| ID | Lines | Type | Title |
|----|-------|------|-------|
| ann-gw-overview | 1-23 | context | The Goemans-Williamson Breakthrough |
| ann-cut-structure | 43-77 | definition | Cut Infrastructure via GWCut Structure |
| ann-maxcut-value | 75-76 | definition | MaxCut as Supremum over Boolean Assignments |
| ann-gw-constant | 78-98 | technique | Conservative Rational Bound for the GW Constant |
| ann-sdp-relaxation | 100-122 | insight | SDP Relaxation: Why Axiomatization is Necessary |
| ann-hyperplane-rounding | 124-162 | technique | Hyperplane Rounding and the Arccos Inequality |
| ann-main-theorem | 174-179 | theorem | Main Theorem: The calc Chain |
| ann-ratio-bound | 182-186 | theorem | Ratio Form of the Approximation Guarantee |
| ann-improvement | 188-190 | insight | Strict Improvement over Random Assignment |
| ann-structural-bounds | 197-217 | lemma | Structural Bounds: MaxCut and Edge Count |

## Test plan
- [ ] Verify JSON is valid (validated locally with Python)
- [ ] Verify annotations render correctly in the gallery
- [ ] Confirm line ranges match the Lean source file sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)