### PR TITLE
Enrich Categorical CLT: convolution monoid structure

### DIFF
--- a/scripts/enricher/find-targets.ts
+++ b/scripts/enricher/find-targets.ts
@@ -98,7 +98,8 @@ function computeQuality(galleryPath: string): { score: number; breakdown: Target
   let annotations: any[] = []
   if (fs.existsSync(annotationsPath)) {
     try {
-      annotations = JSON.parse(fs.readFileSync(annotationsPath, 'utf-8'))
+      const parsed = JSON.parse(fs.readFileSync(annotationsPath, 'utf-8'))
+      annotations = Array.isArray(parsed) ? parsed : []
     } catch { /* skip */ }
   }
 

--- a/src/data/proofs/central-limit-theorem-oq-03/annotations.json
+++ b/src/data/proofs/central-limit-theorem-oq-03/annotations.json
@@ -1,20 +1,110 @@
 [
   {
-    "id": "monoid-summary",
-    "line": 255,
-    "type": "theorem",
-    "content": "Summary theorem proving all four monoid axioms: associativity, left identity, right identity, and commutativity of probability measure convolution."
+    "id": "ann-cltoq03-probmeasure",
+    "proofId": "central-limit-theorem-oq-03",
+    "range": { "startLine": 40, "endLine": 47 },
+    "type": "definition",
+    "title": "ProbMeasure and Dirac Delta",
+    "content": "**ProbMeasure** wraps Mathlib's `Measure R` with an `IsProbabilityMeasure` typeclass constraint, ensuring total mass 1. **diracProb** constructs the Dirac delta measure $\\delta_x$ concentrated at a single point, which serves as the identity element for convolution.\n\nThis wrapping isolates the probability-specific structure from the general measure theory machinery, making the monoid axioms cleaner to state.",
+    "mathContext": "$\\delta_x(A) = \\begin{cases} 1 & x \\in A \\\\ 0 & x \\notin A \\end{cases}$, with $\\delta_0$ as the convolution identity",
+    "significance": "key",
+    "relatedConcepts": ["Probability measure", "Dirac measure", "IsProbabilityMeasure"],
+    "prerequisites": ["Measure theory", "Mathlib.MeasureTheory.Measure.Dirac"]
   },
   {
-    "id": "conv-pow-add",
-    "line": 105,
-    "type": "theorem",
-    "content": "The convolution power distributes over addition: μ^{*(m+n)} = μ^{*m} * μ^{*n}. Proved by induction on n using associativity."
+    "id": "ann-cltoq03-convolution",
+    "proofId": "central-limit-theorem-oq-03",
+    "range": { "startLine": 56, "endLine": 60 },
+    "type": "concept",
+    "title": "Convolution of Probability Measures",
+    "content": "**convolution** (axiom)\n\nConvolution of two probability measures $\\mu, \\nu$ on $\\mathbb{R}$ produces the distribution of $X + Y$ where $X \\sim \\mu$ and $Y \\sim \\nu$ independently:\n$$(\\mu * \\nu)(A) = \\iint \\mathbf{1}_A(x + y)\\, d\\mu(x)\\, d\\nu(y)$$\n\nAxiomatized because the full construction requires product measures and Fubini's theorem. The key property `convolution_isProbability` ensures the result remains a probability measure.",
+    "mathContext": "$(\\mu * \\nu)(A) = \\int \\mu(A - y)\\, d\\nu(y)$, the distribution of the sum of independent random variables",
+    "significance": "critical",
+    "relatedConcepts": ["Product measure", "Fubini's theorem", "Sum of independent random variables"],
+    "prerequisites": ["Measure theory", "Product measures"]
   },
   {
-    "id": "clt-doa",
-    "line": 229,
+    "id": "ann-cltoq03-monoid-axioms",
+    "proofId": "central-limit-theorem-oq-03",
+    "range": { "startLine": 67, "endLine": 80 },
+    "type": "concept",
+    "title": "Commutative Monoid Axioms",
+    "content": "**convolution_assoc**, **convolution_dirac_left/right**, **convolution_comm**\n\nFour axioms establishing $(\\text{ProbMeasure}, *, \\delta_0)$ as a commutative monoid:\n1. **Associativity:** $(\\mu * \\nu) * \\rho = \\mu * (\\nu * \\rho)$\n2. **Left identity:** $\\delta_0 * \\mu = \\mu$\n3. **Right identity:** $\\mu * \\delta_0 = \\mu$\n4. **Commutativity:** $\\mu * \\nu = \\nu * \\mu$\n\nThese are the algebraic backbone of the entire formalization.",
+    "mathContext": "$(\\text{ProbMeasure}, *, \\delta_0)$ is a commutative monoid",
+    "significance": "critical",
+    "relatedConcepts": ["Commutative monoid", "Banach algebra", "Convolution algebra"],
+    "prerequisites": ["Abstract algebra", "Monoid axioms"]
+  },
+  {
+    "id": "ann-cltoq03-convpow-add",
+    "proofId": "central-limit-theorem-oq-03",
+    "range": { "startLine": 107, "endLine": 113 },
     "type": "theorem",
-    "content": "The CLT stated categorically: every distribution with finite positive variance is in the domain of attraction of the Gaussian."
+    "title": "Convolution Power Distribution Law",
+    "content": "**convPow_add**\n\n$\\mu^{*(m+n)} = \\mu^{*m} * \\mu^{*n}$\n\nThe probability analogue of the law of exponents $a^{m+n} = a^m \\cdot a^n$. Proved by induction on $n$:\n- Base case ($n = 0$): $\\mu^{*m} = \\mu^{*m} * \\delta_0$ by the right identity\n- Inductive step: uses `Nat.add_succ`, `convPow` unfolding, the IH, and `convolution_assoc`\n\nThis is one of the key proved (non-axiomatized) results in the formalization.",
+    "mathContext": "$\\mu^{*(m+n)} = \\mu^{*m} * \\mu^{*n}$, proved by induction using associativity",
+    "significance": "critical",
+    "relatedConcepts": ["Law of exponents", "Induction on natural numbers", "Monoid power"],
+    "prerequisites": ["convolution_assoc", "convolution_dirac_right", "Nat.add_succ"]
+  },
+  {
+    "id": "ann-cltoq03-charfun-homo",
+    "proofId": "central-limit-theorem-oq-03",
+    "range": { "startLine": 132, "endLine": 139 },
+    "type": "theorem",
+    "title": "Characteristic Function Power Law",
+    "content": "**charFun_convPow**\n\n$\\varphi_{\\mu^{*n}}(t) = \\varphi_\\mu(t)^n$\n\nThe characteristic function of the $n$-fold convolution power is the $n$-th power of the original characteristic function. Proved by induction on $n$:\n- Base case: $\\varphi_{\\delta_0}(t) = 1 = \\varphi_\\mu(t)^0$ (using `charFun_dirac_zero`)\n- Inductive step: $\\varphi_{\\mu^{*(n+1)}}(t) = \\varphi_{\\mu^{*n}}(t) \\cdot \\varphi_\\mu(t) = \\varphi_\\mu(t)^n \\cdot \\varphi_\\mu(t) = \\varphi_\\mu(t)^{n+1}$\n\nThis transforms convolution power analysis into complex multiplication, which is the key technique behind all CLT proofs.",
+    "mathContext": "$\\varphi_{\\mu^{*n}}(t) = [\\varphi_\\mu(t)]^n$, reducing convolution powers to complex powers",
+    "significance": "critical",
+    "relatedConcepts": ["Fourier transform", "Monoid homomorphism", "Levy continuity theorem"],
+    "prerequisites": ["charFun_convolution", "charFun_dirac_zero", "pow_succ"]
+  },
+  {
+    "id": "ann-cltoq03-clt",
+    "proofId": "central-limit-theorem-oq-03",
+    "range": { "startLine": 187, "endLine": 189 },
+    "type": "concept",
+    "title": "CLT as Convergence in the Convolution Monoid",
+    "content": "**clt_convergence** (axiom)\n\nFor any probability measure $\\mu$ with positive variance, the normalized convolution powers converge to the standard Gaussian:\n$$\\frac{X_1 + \\cdots + X_n - n\\mu}{\\sigma\\sqrt{n}} \\xrightarrow{d} N(0,1)$$\n\nStated via `ConvergesInDistribution`, defined as pointwise convergence of characteristic functions (Levy's continuity theorem). The algebraic content: the Gaussian is the attractor of the normalization-convolution iteration.",
+    "mathContext": "$\\text{normalizedConvPow}(\\mu, n) \\xrightarrow{d} N(0,1)$ for all $\\mu$ with $\\text{Var}(\\mu) > 0$",
+    "significance": "critical",
+    "relatedConcepts": ["Central Limit Theorem", "Convergence in distribution", "Levy continuity theorem"],
+    "prerequisites": ["ConvergesInDistribution", "normalizedConvPow", "standardGaussian"]
+  },
+  {
+    "id": "ann-cltoq03-cramer",
+    "proofId": "central-limit-theorem-oq-03",
+    "range": { "startLine": 208, "endLine": 213 },
+    "type": "concept",
+    "title": "Cramer's Indecomposability Theorem",
+    "content": "**cramer_theorem** (axiom)\n\nIf $\\mu * \\nu$ has a Gaussian characteristic function, then both $\\mu$ and $\\nu$ are Gaussian. The Gaussian cannot be \"factored\" into non-Gaussian components in the convolution monoid.\n\nCramer proved this in 1936 using the theory of entire functions of finite order. It is the probability-theoretic analogue of primality: just as a prime number cannot be written as a product of smaller numbers, the Gaussian cannot be decomposed as a convolution of non-Gaussian distributions.",
+    "mathContext": "$\\mu * \\nu \\sim N(\\cdot, \\cdot) \\Rightarrow \\mu \\sim N(\\cdot, \\cdot)$ and $\\nu \\sim N(\\cdot, \\cdot)$",
+    "significance": "key",
+    "relatedConcepts": ["Entire functions", "Indecomposable distributions", "Primality"],
+    "prerequisites": ["Characteristic function of Gaussian", "Complex.exp"]
+  },
+  {
+    "id": "ann-cltoq03-doa",
+    "proofId": "central-limit-theorem-oq-03",
+    "range": { "startLine": 229, "endLine": 248 },
+    "type": "definition",
+    "title": "Domain of Attraction",
+    "content": "**InDomainOfAttraction** and related theorems\n\nA distribution $\\mu$ is in the domain of attraction of the Gaussian if its normalized convolution powers converge to $N(0,1)$. Three key results:\n\n1. **clt_domain_of_attraction:** Every distribution with positive variance is in the DOA\n2. **gaussian_in_own_domain:** The Gaussian is trivially in its own DOA\n3. **doa_closed_under_convolution:** If $\\mu, \\nu$ are in the DOA, so is $\\mu * \\nu$\n\nThe DOA is thus a convolution-closed subset: a sub-monoid of ProbMeasure.",
+    "mathContext": "$\\text{DOA}(N(0,1)) = \\{\\mu : \\text{normalizedConvPow}(\\mu, n) \\to N(0,1)\\}$ is closed under $*$",
+    "significance": "key",
+    "relatedConcepts": ["Domain of attraction", "Stable distributions", "Sub-monoid"],
+    "prerequisites": ["ConvergesInDistribution", "clt_convergence"]
+  },
+  {
+    "id": "ann-cltoq03-summary",
+    "proofId": "central-limit-theorem-oq-03",
+    "range": { "startLine": 260, "endLine": 271 },
+    "type": "theorem",
+    "title": "Convolution Monoid Summary",
+    "content": "**convolution_monoid_summary**\n\nPackages all four commutative monoid axioms into a single conjunction theorem: associativity $\\land$ left identity $\\land$ right identity $\\land$ commutativity.\n\nThe full algebraic picture: $(\\text{ProbMeasure}, *, \\delta_0)$ is a commutative monoid with the characteristic function as a homomorphism, the Gaussian as a fixed point and prime element, and the CLT describing the domain of attraction.",
+    "mathContext": "$(\\text{ProbMeasure}, *, \\delta_0)$: associativity $\\land$ left identity $\\land$ right identity $\\land$ commutativity",
+    "significance": "key",
+    "relatedConcepts": ["Summary theorem", "Algebraic structure verification"],
+    "prerequisites": ["All monoid axioms"]
   }
 ]

--- a/src/data/proofs/central-limit-theorem-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-03/meta.json
@@ -46,56 +46,87 @@
     {
       "id": "prob-measure",
       "title": "Probability Measure Type",
-      "summary": "Defines ProbMeasure wrapping Mathlib's Measure ℝ with probability constraint.",
-      "startLine": 37,
-      "endLine": 50
+      "summary": "Defines ProbMeasure wrapping Mathlib's Measure R with IsProbabilityMeasure constraint, and diracProb for Dirac delta measures.",
+      "startLine": 35,
+      "endLine": 47
     },
     {
       "id": "convolution",
       "title": "Convolution Operation",
-      "summary": "Axiomatizes convolution of probability measures.",
-      "startLine": 52,
-      "endLine": 62
+      "summary": "Axiomatizes convolution of probability measures and its preservation of the probability measure property.",
+      "startLine": 49,
+      "endLine": 60
     },
     {
       "id": "monoid",
       "title": "Monoid Structure",
-      "summary": "Associativity, identity (Dirac delta at 0), and commutativity axioms.",
-      "startLine": 64,
-      "endLine": 82
+      "summary": "Axioms for the commutative monoid: associativity, left/right identity (Dirac at 0), commutativity.",
+      "startLine": 62,
+      "endLine": 80
     },
     {
       "id": "conv-pow",
       "title": "Convolution Powers",
-      "summary": "Defines μ^{*n} and proves distribution law convPow_add by induction.",
-      "startLine": 84,
-      "endLine": 112
+      "summary": "Defines convPow mu n recursively, proves convPow_zero, convPow_one, and the distribution law convPow_add by induction.",
+      "startLine": 82,
+      "endLine": 113
     },
     {
-      "id": "clt-categorical",
-      "title": "CLT as Categorical Convergence",
-      "summary": "Domain of attraction, CLT as DOA membership, Gaussian stability.",
-      "startLine": 150,
-      "endLine": 260
+      "id": "char-fun",
+      "title": "Characteristic Functions",
+      "summary": "Axiomatizes the characteristic function, proves it is a monoid homomorphism (charFun_convolution, charFun_dirac_zero), and derives charFun_convPow.",
+      "startLine": 115,
+      "endLine": 144
+    },
+    {
+      "id": "normalization-clt",
+      "title": "Normalization and the CLT",
+      "summary": "Axiomatizes normalization, mean, variance, the standard Gaussian, and the CLT as convergence of normalized convolution powers.",
+      "startLine": 146,
+      "endLine": 189
+    },
+    {
+      "id": "gaussian-fixed-point",
+      "title": "Gaussian as Fixed Point",
+      "summary": "Axiomatizes Gaussian stability under all convolution powers and Cramer's indecomposability theorem.",
+      "startLine": 191,
+      "endLine": 213
+    },
+    {
+      "id": "categorical-perspective",
+      "title": "Categorical Perspective",
+      "summary": "Domain of attraction definition, CLT as DOA membership, Gaussian in its own DOA, DOA closure under convolution.",
+      "startLine": 215,
+      "endLine": 248
+    },
+    {
+      "id": "summary",
+      "title": "Summary of Algebraic Structure",
+      "summary": "Packages all four monoid axioms into convolution_monoid_summary theorem.",
+      "startLine": 250,
+      "endLine": 277
     }
   ],
   "overview": {
-    "summary": "Probability distributions on ℝ form a commutative monoid (ProbMeasure, *, δ₀) under convolution. The CLT states that every finite-variance distribution is in the 'domain of attraction' of the Gaussian: normalized convolution powers converge to N(0,1). Cramér's theorem shows the Gaussian is 'prime' in this monoid.",
-    "keyIdea": "The CLT is a fixed-point theorem: the Gaussian is the unique attractor of the normalization-convolution iteration on the convolution monoid of probability distributions.",
-    "prerequisites": [
-      "Measure theory and probability measures",
-      "Characteristic functions (Fourier transforms)",
-      "Convergence in distribution",
-      "Basic abstract algebra (monoids)"
+    "historicalContext": "The algebraic structure of probability distributions under convolution has deep roots in mathematics. Fourier (1822) and Laplace (1812) implicitly used the fact that convolution corresponds to multiplication of transforms. L\u00e9vy (1925) made the convolution monoid structure explicit in his systematic study of probability distributions, showing that characteristic functions (Fourier transforms) provide a homomorphism from the convolution monoid to the multiplicative monoid of complex-valued functions.\n\nThe Central Limit Theorem, first proved rigorously by Lindeberg (1922) and L\u00e9vy (1925), has a beautiful algebraic interpretation: the Gaussian distribution is the unique \"attractor\" of the normalization-convolution iteration. Every distribution with finite nonzero variance converges to the Gaussian under repeated convolution and renormalization\u2014a fixed-point phenomenon.\n\nCram\u00e9r's theorem (1936) revealed further algebraic structure: the Gaussian is \"indecomposable\" (prime) in the convolution monoid. If $X + Y$ is Gaussian with $X, Y$ independent, then both $X$ and $Y$ must be Gaussian. This is the analogue of primality in the integers, but for the convolution algebra of probability distributions.",
+    "problemStatement": "**Open Question #3 from the CLT gallery:**\n\nWhat algebraic/categorical structure do probability distributions carry under convolution, and how does the CLT fit into this structure?\n\n**Answer:** Probability distributions on $\\mathbb{R}$ form a commutative monoid $(\\text{ProbMeasure}, *, \\delta_0)$. The CLT states that every finite-variance distribution lies in the **domain of attraction** of the Gaussian: normalized convolution powers $\\frac{X_1 + \\cdots + X_n - n\\mu}{\\sigma\\sqrt{n}} \\to N(0,1)$. The Gaussian is both a fixed point of this iteration and indecomposable (Cram\u00e9r's theorem).",
+    "proofStrategy": "The formalization builds the algebraic structure in layers:\n\n1. **Type definitions** (\u00a71\u20132): Wrap Mathlib's `Measure R` as `ProbMeasure`, axiomatize convolution\n2. **Monoid axioms** (\u00a73): Associativity, identity ($\\delta_0$), commutativity\n3. **Convolution powers** (\u00a74): Define $\\mu^{*n}$ recursively, prove the distribution law $\\mu^{*(m+n)} = \\mu^{*m} * \\mu^{*n}$ by induction\n4. **Characteristic functions** (\u00a75): Axiomatize $\\varphi_\\mu(t) = \\int e^{itx} d\\mu$, prove it's a monoid homomorphism, derive $\\varphi_{\\mu^{*n}} = \\varphi_\\mu^n$\n5. **CLT** (\u00a76\u20137): Axiomatize normalization and the Gaussian, state the CLT as domain-of-attraction convergence, axiomatize Gaussian stability and Cram\u00e9r's theorem\n6. **Categorical assembly** (\u00a78\u20139): Define domain of attraction, prove CLT as DOA membership, DOA closure under convolution",
+    "keyInsights": [
+      "Characteristic functions provide a monoid homomorphism from $(\\text{ProbMeasure}, *)$ to $(\\mathbb{C}^{\\mathbb{R}}, \\cdot)$: $\\varphi_{\\mu * \\nu} = \\varphi_\\mu \\cdot \\varphi_\\nu$, reducing convolution to pointwise multiplication",
+      "The distribution law $\\mu^{*(m+n)} = \\mu^{*m} * \\mu^{*n}$ is the probability analogue of the law of exponents, proved by a clean induction using associativity",
+      "The CLT is a fixed-point theorem: the Gaussian is the unique attractor of the map $\\mu \\mapsto \\text{normalize}(\\mu^{*n})$ as $n \\to \\infty$",
+      "Cram\u00e9r's theorem (1936) says the Gaussian is \"prime\" in the convolution monoid: if $\\mu * \\nu$ is Gaussian, both $\\mu$ and $\\nu$ must be Gaussian\u2014analogous to primality of integers",
+      "The domain of attraction is closed under convolution: if $\\mu, \\nu$ are attracted to the Gaussian, so is $\\mu * \\nu$, giving the DOA an algebraic structure of its own"
     ]
   },
   "conclusion": {
-    "summary": "We formalize the full commutative monoid structure of probability distributions under convolution, including convolution powers with distribution law, characteristic function homomorphism, CLT as domain of attraction convergence, Gaussian stability, and Cramér's indecomposability theorem. All theorems are proved (0 sorries).",
+    "summary": "This formalization establishes the full commutative monoid structure of probability distributions under convolution, with characteristic functions as a homomorphism, convolution powers with the distribution law, the CLT as domain-of-attraction convergence to the Gaussian fixed point, Gaussian stability, and Cramer's indecomposability theorem. The key proved results are convPow_add and charFun_convPow; the deeper analytical results (CLT convergence, Cramer's theorem) are axiomatized.",
+    "implications": "**Connections to Broader Mathematics**\n\n1. **Functional Analysis:** The convolution monoid embeds into the Banach algebra $L^1(\\mathbb{R})$, connecting probability theory to harmonic analysis and the theory of Banach algebras\n2. **Stable Distributions:** The Gaussian is just one member of the family of $\\alpha$-stable distributions (L\u00e9vy, Gnedenko-Kolmogorov), each with its own domain of attraction. The full classification involves the L\u00e9vy-Khintchine representation\n3. **Information Theory:** The CLT is closely related to the entropy power inequality: convolution increases entropy, and the Gaussian maximizes entropy for given variance\n4. **Category Theory:** The convolution monoidal structure makes the category of probability measures a symmetric monoidal category, with the CLT describing the behavior of the tensor power functor\n5. **Free Probability:** Voiculescu's free CLT replaces convolution with free convolution, with the semicircle distribution replacing the Gaussian as the attractor\u2014an entirely parallel algebraic story",
     "openQuestions": [
-      "RESOLVED: The charFun_convPow sorry (charFun of Dirac = 1) has been resolved by adding the charFun_dirac_zero axiom.",
-      "Can the Gnedenko-Kolmogorov domain of attraction for stable distributions be formalized?",
-      "Can the infinitely divisible distributions (those with n-th convolution roots) be characterized?",
-      "Can Mathlib's measure convolution be connected to our axiomatized ProbMeasure convolution?"
+      "Can the Gnedenko-Kolmogorov classification of domains of attraction for all stable distributions be formalized?",
+      "Can the infinitely divisible distributions (those with n-th convolution roots for all n) be characterized in Lean?",
+      "Can Mathlib's measure convolution be connected to our axiomatized ProbMeasure convolution to reduce the axiom count?",
+      "Can the L\u00e9vy-Khintchine representation theorem be formalized to classify all infinitely divisible distributions?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- **Enriched** `central-limit-theorem-oq-03` with standard overview format: historicalContext (Fourier, Lévy, Lindeberg, Cramér), problemStatement, proofStrategy (6-layer build), and 5 keyInsights
- **Rewrote** annotations from 3 sparse entries (old format, missing range/proofId) to 9 rich annotations with mathContext, significance, relatedConcepts, and prerequisites
- **Expanded** sections from 5 to 9 covering all parts of the Lean file
- **Added** conclusion.implications connecting to functional analysis, stable distributions, information theory, category theory, free probability
- **Fixed** `find-targets.ts` crash on non-array annotations.json

## Quality improvements
- annotations: 3 sparse → 9 rich with full mathContext and significance
- historicalContext: 77 chars → 900+ chars (Fourier through Cramér)
- keyInsights: 0 → 5 substantive insights
- sections: 5 → 9 covering full Lean file
- conclusion.implications: missing → 5 connections to broader mathematics

## Test plan
- [x] `pnpm build` passes with no warnings for this entry
- [ ] Visual review of enriched content on gallery page

🤖 Generated with [Claude Code](https://claude.com/claude-code)