### PR TITLE
Enrich 5 proof entries: erdos-1155, cauchy-schwarz-oq-03, euler-polyhedral-oq-02, lebesgue-measure-oq-02, cauchy-schwarz-integral-oq-01

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01/annotations.json
@@ -1,47 +1,110 @@
 [
   {
-    "id": "holder-lintegral",
-    "lineStart": 42,
-    "lineEnd": 49,
+    "id": "ann-csioo-holder-lintegral",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01",
+    "range": { "startLine": 43, "endLine": 47 },
     "type": "theorem",
     "title": "Hölder's Inequality (Lintegral Form)",
-    "content": "Wraps Mathlib's ENNReal.lintegral_mul_le_Lp_mul_Lq: ∫⁻ f·g dμ ≤ (∫⁻ f^p dμ)^{1/p} · (∫⁻ g^q dμ)^{1/q} for conjugate exponents p, q.",
-    "importance": "high"
+    "content": "The main inequality: ∫⁻ f·g dμ ≤ (∫⁻ f^p dμ)^{1/p} · (∫⁻ g^q dμ)^{1/q} for Hölder conjugate p, q and AEMeasurable f, g. Directly wraps Mathlib's ENNReal.lintegral_mul_le_Lp_mul_Lq.",
+    "mathContext": "Hölder's inequality is the fundamental duality pairing in Lp theory. The proof normalizes f, g to unit Lp/Lq norms, applies Young's inequality pointwise (ab ≤ a^p/p + b^q/q), and integrates: the left side is ∫FG and the right side evaluates to 1/p + 1/q = 1. The ENNReal formulation handles infinite values correctly and works for any measure space.",
+    "significance": "The apex of the lintegral chain — all subsequent specializations (Cauchy-Schwarz, Minkowski) derive from this single inequality. It establishes the duality pairing between Lp and Lq that underlies the Riesz representation theorem.",
+    "relatedConcepts": ["ENNReal.lintegral_mul_le_Lp_mul_Lq", "Hölder conjugate", "Lp-Lq duality", "AEMeasurable"],
+    "prerequisites": ["ENNReal.lintegral_mul_le_Lp_mul_Lq", "Real.HolderConjugate"]
   },
   {
-    "id": "cs-lintegral",
-    "lineStart": 51,
-    "lineEnd": 61,
+    "id": "ann-csioo-cs-lintegral",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01",
+    "range": { "startLine": 51, "endLine": 58 },
     "type": "theorem",
-    "title": "Cauchy-Schwarz at Lintegral Level",
-    "content": "Specializes Hölder to p=q=2 using HolderConjugate 2 2 (with 3-field constructor). The p=q=2 case gives ∫⁻ f·g dμ ≤ (∫⁻ f² dμ)^{1/2} · (∫⁻ g² dμ)^{1/2}.",
-    "importance": "high"
+    "title": "Cauchy-Schwarz at Lintegral Level (p=q=2)",
+    "content": "Specializes Hölder to p = q = 2: ∫⁻ f·g dμ ≤ (∫⁻ f² dμ)^{1/2} · (∫⁻ g² dμ)^{1/2}. Constructs the (2,2) conjugate pair using the 3-field HolderConjugate constructor with norm_num.",
+    "mathContext": "The p = q = 2 specialization is the integral Cauchy-Schwarz inequality, the most frequently used case of Hölder. The HolderConjugate 2 2 proof requires three fields: 1 < 2, 1 < 2, and 1/2 + 1/2 = 1, all discharged by norm_num. This case makes L² into an inner product space via ⟨f,g⟩ = ∫fg.",
+    "significance": "The bridge between Hölder's inequality and the inner product structure of L². This lintegral-level CS is the ENNReal version; the L² inner product CS in Part III is the typed Hilbert space version.",
+    "relatedConcepts": ["Cauchy-Schwarz inequality", "HolderConjugate", "L² space", "inner product"],
+    "prerequisites": ["ENNReal.lintegral_mul_le_Lp_mul_Lq", "Real.HolderConjugate"]
   },
   {
-    "id": "elpnorm-minkowski",
-    "lineStart": 72,
-    "lineEnd": 81,
+    "id": "ann-csioo-minkowski-elpnorm",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 72 },
     "type": "theorem",
-    "title": "Minkowski in eLpNorm Form",
-    "content": "Triangle inequality using the eLpNorm API (renamed from snorm in 4.26+): eLpNorm (f+g) p μ ≤ eLpNorm f p μ + eLpNorm g p μ. Internally uses Hölder.",
-    "importance": "high"
+    "title": "Minkowski's Inequality (eLpNorm Form)",
+    "content": "The Lp triangle inequality in eLpNorm form: eLpNorm (f + g) p μ ≤ eLpNorm f p μ + eLpNorm g p μ for p ≥ 1 and AEStronglyMeasurable f, g. Wraps Mathlib's eLpNorm_add_le.",
+    "mathContext": "Minkowski's inequality (1896) is the triangle inequality that makes Lp into a normed space. The proof for p > 1 uses Hölder internally: expand ‖f+g‖_p^p = ∫|f+g|^p, split as ∫|f+g|^{p-1}·(|f|+|g|), apply Hölder to each term with exponents p and p/(p-1), then divide. The eLpNorm API (renamed from snorm in Mathlib 4.26+) computes the Lp seminorm as an extended non-negative real.",
+    "significance": "Completes the Banach space structure of Lp, enabling the full functional analytic toolkit. The eLpNorm formulation handles p = 0 and p = ∞ uniformly via the extended non-negative real framework.",
+    "relatedConcepts": ["eLpNorm_add_le", "Minkowski inequality", "Banach space", "triangle inequality"],
+    "prerequisites": ["eLpNorm_add_le", "AEStronglyMeasurable"]
   },
   {
-    "id": "l2-cs",
-    "lineStart": 88,
-    "lineEnd": 99,
+    "id": "ann-csioo-minkowski-p2",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01",
+    "range": { "startLine": 75, "endLine": 78 },
+    "type": "theorem",
+    "title": "Minkowski at p=2 (eLpNorm Specialization)",
+    "content": "The L² triangle inequality via eLpNorm: eLpNorm (f+g) 2 μ ≤ eLpNorm f 2 μ + eLpNorm g 2 μ. The 1 ≤ 2 hypothesis is discharged by norm_num.",
+    "mathContext": "The p = 2 specialization of Minkowski is the Hilbert space triangle inequality. While eLpNorm_add_le proves it using the general Hölder-based argument, Part IV provides an alternative derivation from Cauchy-Schwarz alone via the norm-squared identity — the classical Hilbert space proof.",
+    "significance": "Demonstrates the p = 2 case of Minkowski, which pairs with the alternative CS-based derivation in Part IV to give two independent proofs of the same result.",
+    "relatedConcepts": ["eLpNorm_add_le", "Hilbert space", "L² triangle inequality"],
+    "prerequisites": ["eLpNorm_add_le"]
+  },
+  {
+    "id": "ann-csioo-l2-cs",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01",
+    "range": { "startLine": 85, "endLine": 92 },
     "type": "theorem",
     "title": "L² Inner Product Cauchy-Schwarz",
-    "content": "For f, g ∈ L²(μ): |⟨f,g⟩| ≤ ‖f‖·‖g‖. Uses Mathlib's abs_real_inner_le_norm. Both sided and one-sided versions provided.",
-    "importance": "high"
+    "content": "Two versions of Cauchy-Schwarz for L²(μ) functions: |⟨f,g⟩| ≤ ‖f‖·‖g‖ (two-sided) and ⟨f,g⟩ ≤ ‖f‖·‖g‖ (one-sided). Uses Mathlib's abs_real_inner_le_norm. The one-sided version follows from le_abs_self.",
+    "mathContext": "The inner product Cauchy-Schwarz |⟨u,v⟩| ≤ ‖u‖·‖v‖ is the defining inequality of a Hilbert space. For L²(μ), the inner product is ⟨f,g⟩ = ∫fg dμ and the norm is ‖f‖ = (∫f² dμ)^{1/2}. Mathlib's abs_real_inner_le_norm proves this for any real inner product space; the L² instance comes from the Lp infrastructure.",
+    "significance": "The typed Hilbert space version of Cauchy-Schwarz, complementing the lintegral version in Part I. The one-sided version is needed for the norm-squared derivation of Minkowski in Part IV.",
+    "relatedConcepts": ["abs_real_inner_le_norm", "inner product space", "Hilbert space", "L² norm"],
+    "prerequisites": ["abs_real_inner_le_norm", "MeasureTheory.Lp"]
   },
   {
-    "id": "minkowski-from-cs",
-    "lineStart": 108,
-    "lineEnd": 117,
+    "id": "ann-csioo-minkowski-from-cs",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01",
+    "range": { "startLine": 102, "endLine": 109 },
     "type": "theorem",
-    "title": "Minkowski L² from Cauchy-Schwarz",
-    "content": "Classical derivation: ‖f+g‖² = ‖f‖² + 2⟨f,g⟩ + ‖g‖² ≤ (‖f‖+‖g‖)² via CS bound on inner product. Uses norm_add_sq_real + nlinarith + sqrt monotonicity.",
-    "importance": "medium"
+    "title": "Minkowski L² from Cauchy-Schwarz (Classical Derivation)",
+    "content": "Derives ‖f+g‖ ≤ ‖f‖+‖g‖ from Cauchy-Schwarz using the norm-squared identity: ‖f+g‖² = ‖f‖² + 2⟨f,g⟩ + ‖g‖² ≤ ‖f‖² + 2‖f‖·‖g‖ + ‖g‖² = (‖f‖+‖g‖)², then take square roots.",
+    "mathContext": "This is the standard Hilbert space proof of the triangle inequality: expand using norm_add_sq_real, bound the inner product via CS, recognize the right side as a perfect square, then apply sqrt monotonicity. The nlinarith tactic handles the algebraic step, and Real.sqrt_le_sqrt + Real.sqrt_sq complete the square root argument. This proof works only for p = 2 (where the parallelogram law holds); the general Minkowski requires the Hölder-based bootstrap.",
+    "significance": "Demonstrates the alternative proof path: while eLpNorm_add_le uses Hölder internally, this derivation shows the L² triangle inequality follows from Cauchy-Schwarz alone — the proof that works in any inner product space.",
+    "relatedConcepts": ["norm_add_sq_real", "Real.sqrt_le_sqrt", "parallelogram law", "Hilbert space triangle inequality"],
+    "prerequisites": ["l2_cauchy_schwarz_le", "norm_add_sq_real", "Real.sqrt_le_sqrt"]
+  },
+  {
+    "id": "ann-csioo-young-two",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01",
+    "range": { "startLine": 118, "endLine": 119 },
+    "type": "theorem",
+    "title": "Young's Inequality at p=q=2 (AM-GM for Squares)",
+    "content": "The elementary identity: ab ≤ a²/2 + b²/2 for all reals a, b. Proved by nlinarith from (a-b)² ≥ 0, which expands to a² - 2ab + b² ≥ 0.",
+    "mathContext": "Young's inequality at p = q = 2 is the arithmetic-geometric mean inequality in disguise: ab ≤ (a² + b²)/2 is exactly AM-GM applied to a² and b². The proof from (a-b)² ≥ 0 is the most elementary route, requiring only that squares are non-negative. This is the pointwise seed from which the entire Lp hierarchy grows: integrate to get Hölder, specialize to get CS.",
+    "significance": "The pointwise foundation of the inequality hierarchy. While the NNReal version (young_nnreal) handles the general case, the p = q = 2 version connects directly to the elementary AM-GM inequality, grounding the abstract machinery in basic algebra.",
+    "relatedConcepts": ["AM-GM inequality", "Young's inequality", "squares are non-negative"],
+    "prerequisites": ["sq_nonneg"]
+  },
+  {
+    "id": "ann-csioo-young-nnreal",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01",
+    "range": { "startLine": 122, "endLine": 124 },
+    "type": "theorem",
+    "title": "Young's Inequality (Generalized NNReal Form)",
+    "content": "For NNReal Hölder conjugate p, q: a·b ≤ a^p/p + b^q/q. Wraps Mathlib's NNReal.young_inequality, which proves this via the concavity of log.",
+    "mathContext": "The general Young inequality (1912) is proved using the concavity of logarithm: log(ab) = log a + log b, and by Jensen's inequality applied to the convex combination (1/p)·log(a^p) + (1/q)·log(b^q), we get log(ab) ≤ log(a^p/p + b^q/q). Exponentiating gives the result. The NNReal version ensures all quantities are non-negative, avoiding the sign issues of the real version.",
+    "significance": "The general pointwise foundation from which Hölder's inequality is derived by integration. The NNReal formulation is directly compatible with the ENNReal lintegral, making it the natural type for measure-theoretic applications.",
+    "relatedConcepts": ["NNReal.young_inequality", "NNReal.HolderConjugate", "concavity of log", "Jensen's inequality"],
+    "prerequisites": ["NNReal.young_inequality", "NNReal.HolderConjugate"]
+  },
+  {
+    "id": "ann-csioo-hierarchy",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01",
+    "range": { "startLine": 141, "endLine": 143 },
+    "type": "theorem",
+    "title": "Hierarchy Verification: General Lp Triangle Inequality",
+    "content": "The Lp norm triangle inequality ‖f+g‖ ≤ ‖f‖+‖g‖ for general p ≥ 1, using Mathlib's norm_add_le on the Lp type. The [Fact (1 ≤ p)] instance provides the p ≥ 1 hypothesis.",
+    "mathContext": "This theorem closes the hierarchy: Young → Hölder → CS → Minkowski → general Lp triangle inequality. Mathlib's norm_add_le on Lp is the ultimate consumer of the entire chain. The Fact typeclass mechanism passes the 1 ≤ p hypothesis through the type class system rather than as an explicit argument.",
+    "significance": "Confirms the full chain is consistent: the general Lp triangle inequality, the most downstream result, is provable by a single Mathlib lemma application, verifying that all upstream infrastructure (Hölder, Minkowski) is correctly assembled.",
+    "relatedConcepts": ["norm_add_le", "MeasureTheory.Lp", "Fact typeclass", "Banach space"],
+    "prerequisites": ["norm_add_le", "MeasureTheory.Lp", "Fact (1 ≤ p)"]
   }
 ]

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/H%C3%B6lder%27s_inequality",
     "date": "1889 (Hölder), eLpNorm formalization 2026",
-    "status": "verified",
+    "status": "complete",
     "tags": ["analysis", "measure-theory", "inequalities", "holder", "cauchy-schwarz", "lp-spaces"],
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
     "badge": "original",
@@ -29,14 +29,15 @@
     "dateAdded": "2026-03-06"
   },
   "overview": {
-    "historicalContext": "Otto Hölder (1889) proved the integral generalization of the Cauchy-Schwarz inequality. The case p=q=2 recovers Cauchy-Schwarz, while Minkowski (1896) used Hölder to derive the Lp triangle inequality.\n\nIn Mathlib 4.26+, `snorm` was renamed to `eLpNorm` (extended Lp norm). This formalization demonstrates the full inequality hierarchy using the modern API naming.",
-    "problemStatement": "Can the snorm-based Hölder inequality be formalized using the renamed API in Mathlib 4.26+?\n\nAnswer: YES — all key lemmas (lintegral_mul_le_Lp_mul_Lq, eLpNorm_add_le, abs_real_inner_le_norm, NNReal.young_inequality) exist and connect cleanly.",
-    "proofStrategy": "Build the hierarchy bottom-up: (1) Young's inequality (pointwise), (2) Hölder at lintegral level, (3) Specialize to p=q=2 for CS, (4) Minkowski via eLpNorm_add_le, (5) Connect to L² inner product CS, (6) Derive Minkowski L² from CS via norm-squared identity.",
+    "historicalContext": "Otto Hölder proved his inequality for finite sums in 1889, generalizing Cauchy's inequality (1821) and Schwarz's integral version (1885) from the p = q = 2 case to arbitrary conjugate exponents satisfying 1/p + 1/q = 1. William Henry Young (1912) provided the pointwise foundation: ab ≤ a^p/p + b^q/q follows from the concavity of logarithm via the weighted AM-GM inequality. Hermann Minkowski (1896) used Hölder's inequality in a bootstrap argument to prove the Lp triangle inequality ‖f + g‖_p ≤ ‖f‖_p + ‖g‖_p, completing the Banach space structure of Lp.\n\nThe formalization uses Mathlib 4.26+, where the `snorm` API was renamed to `eLpNorm` (extended Lp norm). This renaming reflects the conceptual shift: `eLpNorm` computes the Lp seminorm as an extended non-negative real, handling the p = 0 and p = ∞ cases uniformly. The underlying mathematical content — Hölder, Cauchy-Schwarz, Minkowski — is unchanged, but the formalization serves as a demonstration that the modern API is complete and coherent.\n\nThe proof chain Young → Hölder → Cauchy-Schwarz → Minkowski recapitulates the historical development: each inequality is logically derived from the previous one. The dual derivation of Minkowski — both from the general eLpNorm_add_le and from Cauchy-Schwarz via the norm-squared identity — illustrates the two canonical proof strategies for the Lp triangle inequality.",
+    "problemStatement": "Formalize the complete hierarchy of Lp space inequalities using Mathlib 4.26+ eLpNorm API: Young's inequality (pointwise) → Hölder's inequality (lintegral) → Cauchy-Schwarz (p = q = 2 specialization) → Minkowski (triangle inequality). Demonstrate both the general eLpNorm formulation and the L² inner product specialization, confirming the renamed API is fully functional.",
+    "proofStrategy": "Build the hierarchy in two parallel chains: (1) The lintegral chain: Hölder via lintegral_mul_le_Lp_mul_Lq, then specialize to p = q = 2 for Cauchy-Schwarz using the 3-field HolderConjugate constructor. (2) The eLpNorm chain: Minkowski via eLpNorm_add_le for general p, then specialize to p = 2. (3) The L² chain: inner product Cauchy-Schwarz via abs_real_inner_le_norm, then derive Minkowski L² from CS using the norm-squared expansion ‖f+g‖² = ‖f‖² + 2⟨f,g⟩ + ‖g‖² ≤ (‖f‖+‖g‖)². Finally, Young's inequality at the NNReal level provides the pointwise foundation.",
     "keyInsights": [
-      "eLpNorm in Mathlib 4.26+ replaces snorm — the API is functionally identical",
-      "Hölder's inequality at the lintegral level directly specializes to CS via HolderConjugate 2 2",
-      "The L² inner product CS and the lintegral CS are different formulations of the same result",
-      "Minkowski (triangle inequality) can be derived from CS alone in L²"
+      "The eLpNorm rename from snorm in Mathlib 4.26+ is a clean API migration — all inequality lemmas (lintegral_mul_le_Lp_mul_Lq, eLpNorm_add_le) are preserved with identical mathematical content",
+      "Hölder's inequality at the lintegral level directly specializes to Cauchy-Schwarz via the 3-field HolderConjugate 2 2 constructor (1 < 2, 1 < 2, 1/2 + 1/2 = 1), resolved by norm_num",
+      "The L² inner product Cauchy-Schwarz (|⟨f,g⟩| ≤ ‖f‖·‖g‖) and the lintegral Cauchy-Schwarz (∫⁻ fg ≤ (∫⁻ f²)^½·(∫⁻ g²)^½) are different formulations connected by the L² norm-integral relationship",
+      "Minkowski's inequality in L² can be derived from Cauchy-Schwarz alone via the norm-squared identity, bypassing the general Hölder-based proof — this is the classical Hilbert space argument",
+      "Young's inequality a·b ≤ a²/2 + b²/2 at p = q = 2 reduces to the elementary AM-GM inequality (a-b)² ≥ 0, connecting the abstract Lp machinery to basic algebra"
     ]
   },
   "sections": [
@@ -48,8 +49,16 @@
     {"id": "hierarchy", "title": "Part VI: Complete Hierarchy", "startLine": 134, "endLine": 149, "summary": "Summary and API verification confirming all key Mathlib 4.26+ lemmas exist."}
   ],
   "conclusion": {
-    "summary": "YES — the snorm-based Hölder inequality is fully formalizable using Mathlib 4.26+ eLpNorm API. The complete hierarchy Young → Hölder → CS → Minkowski is demonstrated. Zero sorries.",
-    "implications": "The eLpNorm rename from snorm is a clean API migration. All inequality lemmas are preserved. The formalization confirms that measure-theoretic analysis in Lean 4 has a complete and coherent API for the fundamental Lp space inequalities.",
-    "openQuestions": []
+    "summary": "The complete Lp inequality hierarchy Young → Hölder → Cauchy-Schwarz → Minkowski is fully formalized using Mathlib 4.26+ eLpNorm API, with zero sorries. Both the general eLpNorm formulation and the L² inner product specialization are demonstrated, confirming the renamed API is complete and coherent.",
+    "implications": [
+      "The eLpNorm API migration from snorm is mathematically transparent — all fundamental Lp inequality lemmas exist and compose correctly, validating the Mathlib 4.26+ refactoring",
+      "The dual Minkowski derivation (general eLpNorm_add_le vs. CS-based norm-squared argument) provides two independent verification paths for the L² triangle inequality",
+      "The L² inner product Cauchy-Schwarz bridges measure-theoretic integration (lintegral) with Hilbert space structure (inner product), connecting two foundational Mathlib libraries",
+      "The complete hierarchy demonstrates that Lean 4 with Mathlib has a production-ready formalization of Lp space theory sufficient for functional analysis applications"
+    ],
+    "openQuestions": [
+      "Can the sharp constant and equality conditions for eLpNorm Hölder be formalized?",
+      "Can the Riesz representation theorem (Lp)* ≅ Lq be derived from the eLpNorm Hölder inequality?"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
Enriches 5 proof gallery entries to full quality:

- **erdos-1155-oq-01** (quality 45→enriched): Triangle removal process asymptotics. Fixed status, restructured overview, 10 rich annotations.
- **cauchy-schwarz-oq-03-oq-01** (quality 55→enriched): Cauchy-Schwarz/Hölder equality characterization. Restructured overview, 10 rich annotations.
- **euler-polyhedral-formula-oq-02-oq-01** (quality 55→enriched): Smooth Gauss-Bonnet theorem. Restructured overview, 10 rich annotations.
- **lebesgue-measure-oq-02** (quality 58→enriched): Hölder's inequality for Lebesgue integration. Restructured overview, 8 rich annotations.
- **cauchy-schwarz-integral-oq-01-oq-01** (quality 60→enriched): Hölder eLpNorm hierarchy. Deepened overview, 9 rich annotations, fixed conclusion format.

### Changes per entry
- Restructure `meta.json` overview to standard format (historicalContext, problemStatement, proofStrategy, keyInsights)
- Add `conclusion.implications` as array (4 items each)
- Rewrite `annotations.json` with full fields (id, proofId, range, type, title, content, mathContext, significance, relatedConcepts, prerequisites)
- All builds pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)