### PR TITLE
fix: flatten conclusion.implications arrays to strings (10 proofs)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01/meta.json
@@ -8,15 +8,38 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/H%C3%B6lder%27s_inequality",
     "date": "1889 (Hölder), eLpNorm formalization 2026",
     "status": "complete",
-    "tags": ["analysis", "measure-theory", "inequalities", "holder", "cauchy-schwarz", "lp-spaces"],
+    "tags": [
+      "analysis",
+      "measure-theory",
+      "inequalities",
+      "holder",
+      "cauchy-schwarz",
+      "lp-spaces"
+    ],
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
     "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
-      {"theorem": "ENNReal.lintegral_mul_le_Lp_mul_Lq", "description": "Hölder's inequality (lintegral form)", "module": "Mathlib.MeasureTheory.Integral.MeanInequalities"},
-      {"theorem": "eLpNorm_add_le", "description": "Minkowski inequality (eLpNorm form)", "module": "Mathlib.MeasureTheory.Function.L2Space"},
-      {"theorem": "abs_real_inner_le_norm", "description": "Cauchy-Schwarz for real inner product spaces", "module": "Mathlib.Analysis.InnerProductSpace.Basic"},
-      {"theorem": "NNReal.young_inequality", "description": "Young's inequality for NNReal", "module": "Mathlib.Analysis.MeanInequalities"}
+      {
+        "theorem": "ENNReal.lintegral_mul_le_Lp_mul_Lq",
+        "description": "Hölder's inequality (lintegral form)",
+        "module": "Mathlib.MeasureTheory.Integral.MeanInequalities"
+      },
+      {
+        "theorem": "eLpNorm_add_le",
+        "description": "Minkowski inequality (eLpNorm form)",
+        "module": "Mathlib.MeasureTheory.Function.L2Space"
+      },
+      {
+        "theorem": "abs_real_inner_le_norm",
+        "description": "Cauchy-Schwarz for real inner product spaces",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "NNReal.young_inequality",
+        "description": "Young's inequality for NNReal",
+        "module": "Mathlib.Analysis.MeanInequalities"
+      }
     ],
     "originalContributions": [
       "cauchy_schwarz_lintegral: p=q=2 specialization of Hölder at the lintegral level",
@@ -41,21 +64,52 @@
     ]
   },
   "sections": [
-    {"id": "holder-lintegral", "title": "Part I: Hölder at Lintegral Level", "startLine": 38, "endLine": 61, "summary": "Hölder's inequality and its p=q=2 CS specialization at the ENNReal lintegral level."},
-    {"id": "minkowski-elpnorm", "title": "Part II: Minkowski in eLpNorm Form", "startLine": 63, "endLine": 81, "summary": "Triangle inequality for eLpNorm via eLpNorm_add_le, with p=2 specialization."},
-    {"id": "l2-cauchy-schwarz", "title": "Part III: L² Inner Product CS", "startLine": 83, "endLine": 99, "summary": "Cauchy-Schwarz for L² functions via abs_real_inner_le_norm."},
-    {"id": "minkowski-from-cs", "title": "Part IV: Minkowski from CS", "startLine": 101, "endLine": 117, "summary": "L² triangle inequality derived from CS via norm-squared identity."},
-    {"id": "young", "title": "Part V: Young's Inequality", "startLine": 119, "endLine": 132, "summary": "Young's inequality in real and NNReal forms — the pointwise foundation."},
-    {"id": "hierarchy", "title": "Part VI: Complete Hierarchy", "startLine": 134, "endLine": 149, "summary": "Summary and API verification confirming all key Mathlib 4.26+ lemmas exist."}
+    {
+      "id": "holder-lintegral",
+      "title": "Part I: Hölder at Lintegral Level",
+      "startLine": 38,
+      "endLine": 61,
+      "summary": "Hölder's inequality and its p=q=2 CS specialization at the ENNReal lintegral level."
+    },
+    {
+      "id": "minkowski-elpnorm",
+      "title": "Part II: Minkowski in eLpNorm Form",
+      "startLine": 63,
+      "endLine": 81,
+      "summary": "Triangle inequality for eLpNorm via eLpNorm_add_le, with p=2 specialization."
+    },
+    {
+      "id": "l2-cauchy-schwarz",
+      "title": "Part III: L² Inner Product CS",
+      "startLine": 83,
+      "endLine": 99,
+      "summary": "Cauchy-Schwarz for L² functions via abs_real_inner_le_norm."
+    },
+    {
+      "id": "minkowski-from-cs",
+      "title": "Part IV: Minkowski from CS",
+      "startLine": 101,
+      "endLine": 117,
+      "summary": "L² triangle inequality derived from CS via norm-squared identity."
+    },
+    {
+      "id": "young",
+      "title": "Part V: Young's Inequality",
+      "startLine": 119,
+      "endLine": 132,
+      "summary": "Young's inequality in real and NNReal forms — the pointwise foundation."
+    },
+    {
+      "id": "hierarchy",
+      "title": "Part VI: Complete Hierarchy",
+      "startLine": 134,
+      "endLine": 149,
+      "summary": "Summary and API verification confirming all key Mathlib 4.26+ lemmas exist."
+    }
   ],
   "conclusion": {
     "summary": "The complete Lp inequality hierarchy Young → Hölder → Cauchy-Schwarz → Minkowski is fully formalized using Mathlib 4.26+ eLpNorm API, with zero sorries. Both the general eLpNorm formulation and the L² inner product specialization are demonstrated, confirming the renamed API is complete and coherent.",
-    "implications": [
-      "The eLpNorm API migration from snorm is mathematically transparent — all fundamental Lp inequality lemmas exist and compose correctly, validating the Mathlib 4.26+ refactoring",
-      "The dual Minkowski derivation (general eLpNorm_add_le vs. CS-based norm-squared argument) provides two independent verification paths for the L² triangle inequality",
-      "The L² inner product Cauchy-Schwarz bridges measure-theoretic integration (lintegral) with Hilbert space structure (inner product), connecting two foundational Mathlib libraries",
-      "The complete hierarchy demonstrates that Lean 4 with Mathlib has a production-ready formalization of Lp space theory sufficient for functional analysis applications"
-    ],
+    "implications": "The eLpNorm API migration from snorm is mathematically transparent — all fundamental Lp inequality lemmas exist and compose correctly, validating the Mathlib 4.26+ refactoring The dual Minkowski derivation (general eLpNorm_add_le vs. CS-based norm-squared argument) provides two independent verification paths for the L² triangle inequality The L² inner product Cauchy-Schwarz bridges measure-theoretic integration (lintegral) with Hilbert space structure (inner product), connecting two foundational Mathlib libraries The complete hierarchy demonstrates that Lean 4 with Mathlib has a production-ready formalization of Lp space theory sufficient for functional analysis applications",
     "openQuestions": [
       "Can the sharp constant and equality conditions for eLpNorm Hölder be formalized?",
       "Can the Riesz representation theorem (Lp)* ≅ Lq be derived from the eLpNorm Hölder inequality?"

--- a/src/data/proofs/erdos-64/meta.json
+++ b/src/data/proofs/erdos-64/meta.json
@@ -28,8 +28,19 @@
       "field": "Extremal Graph Theory",
       "subfield": "Unavoidable cycle lengths under minimum degree constraints",
       "level": "research",
-      "centralObjects": ["cycle containment C_{2^k}", "minimum degree δ(G)", "powers of two set {4,8,16,...}", "finite simple graph"],
-      "keyTechniques": ["cyclic adjacency via Fin.succMod", "Liu-Montgomery even cycle theorem", "Dirac's Hamiltonian theorem", "Bondy's pancyclicity", "infinite 3-regular tree counterexample"],
+      "centralObjects": [
+        "cycle containment C_{2^k}",
+        "minimum degree δ(G)",
+        "powers of two set {4,8,16,...}",
+        "finite simple graph"
+      ],
+      "keyTechniques": [
+        "cyclic adjacency via Fin.succMod",
+        "Liu-Montgomery even cycle theorem",
+        "Dirac's Hamiltonian theorem",
+        "Bondy's pancyclicity",
+        "infinite 3-regular tree counterexample"
+      ],
       "significance": "One of the most prominent open problems in extremal graph theory, carrying a $1000 Erdős prize. The set {2^k : k ≥ 2} is exponentially sparse yet conjectured to be unavoidable for minimum degree 3. Liu-Montgomery (2020) resolved the large-degree case by showing every graph with δ(G) ≥ D contains all even cycle lengths in a geometric range, but the critical case δ = 3 remains completely open. The difficulty is concentrated entirely in the sparse regime."
     },
     "references": [
@@ -211,12 +222,7 @@
   ],
   "conclusion": {
     "summary": "Erdős Problem #64 is one of the most prominent open problems in extremal graph theory, carrying a $1000 Erdős prize. The formalization captures the main conjecture (δ ≥ 3 → ∃ C_{2^k}), the disproved Erdős-Gyárfás counter-conjecture, the Liu-Montgomery breakthrough (resolved for large degree), the infinite tree counterexample (finiteness essential), and classical supporting results (Dirac, Bondy, random graphs). The difficulty is entirely concentrated at δ = 3.",
-    "implications": [
-      "A positive resolution would establish that {4, 8, 16, ...} is unavoidable for δ = 3, a remarkable rigidity result for exponentially sparse cycle lengths",
-      "A counterexample would require a finite graph with δ ≥ 3 avoiding all 2^k-cycles, revealing deep structure about cycle avoidance",
-      "The Liu-Montgomery result shows the problem is about the sparse regime — reducing threshold D toward 3 is the path forward",
-      "Connects to unavoidable subgraph theory and the broader question of which cycle length sets are forced by degree conditions"
-    ],
+    "implications": "A positive resolution would establish that {4, 8, 16, ...} is unavoidable for δ = 3, a remarkable rigidity result for exponentially sparse cycle lengths A counterexample would require a finite graph with δ ≥ 3 avoiding all 2^k-cycles, revealing deep structure about cycle avoidance The Liu-Montgomery result shows the problem is about the sparse regime — reducing threshold D toward 3 is the path forward Connects to unavoidable subgraph theory and the broader question of which cycle length sets are forced by degree conditions",
     "openQuestions": [
       "Does the conjecture hold for minimum degree exactly 3? ($1000 Erdős prize)",
       "What is the exact threshold D from Liu-Montgomery? Can it be reduced to a small constant?",

--- a/src/data/proofs/erdos-644/meta.json
+++ b/src/data/proofs/erdos-644/meta.json
@@ -27,8 +27,19 @@
       "field": "Extremal Set Theory",
       "subfield": "Covering numbers of structured set families",
       "level": "research",
-      "centralObjects": ["covering function f(k,r)", "k-uniform family", "r-wise pair property", "coefficient sequence cᵣ"],
-      "keyTechniques": ["Helly-type conditions", "extremal constructions", "covering algorithms", "sunflower lemma connections", "asymptotic analysis"],
+      "centralObjects": [
+        "covering function f(k,r)",
+        "k-uniform family",
+        "r-wise pair property",
+        "coefficient sequence cᵣ"
+      ],
+      "keyTechniques": [
+        "Helly-type conditions",
+        "extremal constructions",
+        "covering algorithms",
+        "sunflower lemma connections",
+        "asymptotic analysis"
+      ],
       "significance": "Determines the precise covering efficiency of k-uniform set families under r-wise pair coherence. The known exact values f(k,3)=2k through f(k,6)=k reveal a decreasing coefficient sequence c₃=2, c₄=3/2, c₅=5/4, c₆=1. The open questions ask whether c₇=3/4 (crossing below the natural barrier c=1) and whether the linear-in-k behavior persists for all r."
     },
     "references": [
@@ -187,12 +198,7 @@
   ],
   "conclusion": {
     "summary": "This formalization captures Erdős Problem #644 on covering families of sets with the r-wise pair property. The function f(k,r) measures covering efficiency under structural constraints, with exact values known for r = 3, 4, 5, 6 revealing a decreasing coefficient sequence. The two open questions — whether c₇ = 3/4 and whether cᵣ exists for all r — probe the fundamental asymptotics of this covering function.",
-    "implications": [
-      "Resolution of Question 1 would determine whether the coefficient sequence crosses below the natural barrier c = 1",
-      "Resolution of Question 2 would establish whether all r-wise pair families have linear-in-k covering numbers",
-      "Understanding the limit of cᵣ as r → ∞ would reveal whether infinite coherence enables sublinear covering",
-      "Connections to the sunflower lemma suggest that improved sunflower bounds may yield progress on f(k,r)"
-    ],
+    "implications": "Resolution of Question 1 would determine whether the coefficient sequence crosses below the natural barrier c = 1 Resolution of Question 2 would establish whether all r-wise pair families have linear-in-k covering numbers Understanding the limit of cᵣ as r → ∞ would reveal whether infinite coherence enables sublinear covering Connections to the sunflower lemma suggest that improved sunflower bounds may yield progress on f(k,r)",
     "openQuestions": [
       "Is f(k,7) = (3/4 + o(1))k?",
       "Does f(k,r) = (c_r + o(1))k for all r ≥ 3?",

--- a/src/data/proofs/erdos-650/meta.json
+++ b/src/data/proofs/erdos-650/meta.json
@@ -26,8 +26,19 @@
       "field": "Multiplicative Number Theory",
       "subfield": "Divisibility covering and interval distribution",
       "level": "research",
-      "centralObjects": ["covering function f(m,N)", "countDivisible", "divisor multiples in intervals", "extremal sets A ⊆ {1,...,N}"],
-      "keyTechniques": ["pigeonhole principle", "inclusion-exclusion", "AM-HM inequality", "harmonic sum estimates", "double counting"],
+      "centralObjects": [
+        "covering function f(m,N)",
+        "countDivisible",
+        "divisor multiples in intervals",
+        "extremal sets A ⊆ {1,...,N}"
+      ],
+      "keyTechniques": [
+        "pigeonhole principle",
+        "inclusion-exclusion",
+        "AM-HM inequality",
+        "harmonic sum estimates",
+        "double counting"
+      ],
       "significance": "Determines the minimum guaranteed divisibility coverage in intervals. The Erdős-Sarányi lower bound f(m) ≥ c√m (1959) via counting arguments is established; the matching upper bound f(m) ≤ C√m remains open after 60+ years. Resolution would precisely characterize the covering efficiency of divisor sets."
     },
     "references": [
@@ -123,12 +134,7 @@
   ],
   "conclusion": {
     "summary": "This formalization captures Erdős Problem #650 on divisibility covering in intervals. The function f(m) measures the minimum guaranteed number of integers in any interval of length 2N that are divisible by distinct elements of a set A of size m. The √m lower bound is axiomatized from the Erdős-Sarányi counting argument; the matching upper bound remains one of the oldest open problems in this area.",
-    "implications": [
-      "Resolution of the upper bound would precisely characterize divisibility covering at the √m threshold",
-      "The problem connects multiplicative number theory to combinatorial covering optimization",
-      "Understanding extremal sets (those achieving f(m)) would reveal deep structure in divisor distribution",
-      "The √m barrier appears in many covering problems, suggesting a universal phenomenon"
-    ],
+    "implications": "Resolution of the upper bound would precisely characterize divisibility covering at the √m threshold The problem connects multiplicative number theory to combinatorial covering optimization Understanding extremal sets (those achieving f(m)) would reveal deep structure in divisor distribution The √m barrier appears in many covering problems, suggesting a universal phenomenon",
     "openQuestions": [
       "Is f(m) ≪ √m?",
       "What is the structure of extremal sets achieving f(m)?",

--- a/src/data/proofs/erdos-673/meta.json
+++ b/src/data/proofs/erdos-673/meta.json
@@ -26,8 +26,19 @@
       "field": "Analytic Number Theory",
       "subfield": "Divisor function asymptotics and distribution",
       "level": "research",
-      "centralObjects": ["G(n) = Σ dᵢ/dᵢ₊₁", "divisor count τ(n)", "GRatio = G(n)/τ(n)", "continuous distribution function F"],
-      "keyTechniques": ["Tao's divisor restriction argument", "Dirichlet divisor sum", "Hardy-Ramanujan normal order", "Erdős-Tenenbaum distribution theory", "density arguments"],
+      "centralObjects": [
+        "G(n) = Σ dᵢ/dᵢ₊₁",
+        "divisor count τ(n)",
+        "GRatio = G(n)/τ(n)",
+        "continuous distribution function F"
+      ],
+      "keyTechniques": [
+        "Tao's divisor restriction argument",
+        "Dirichlet divisor sum",
+        "Hardy-Ramanujan normal order",
+        "Erdős-Tenenbaum distribution theory",
+        "density arguments"
+      ],
       "significance": "Characterizes the sum of consecutive divisor ratios G(n), showing it is controlled by τ(n) via Tao's bounds τ(n/m)/m ≤ G(n) ≤ τ(n). The Erdős-Tenenbaum theorem that G(n)/τ(n) has a continuous distribution function reveals deep statistical structure in divisor sequences. The asymptotic formula Σ G(n) ~ c X log X parallels the classical Dirichlet divisor sum."
     },
     "references": [
@@ -191,12 +202,7 @@
   ],
   "conclusion": {
     "summary": "This formalization captures Erdős Problem #673 on consecutive divisor ratios. The function G(n) = Σ dᵢ/dᵢ₊₁ measures how smoothly divisors grow. Tao's bounds τ(n/m)/m ≤ G(n) ≤ τ(n) control G by the divisor function. The Erdős-Tenenbaum theorem reveals that G(n)/τ(n) has a continuous distribution, and the asymptotic formula Σ G(n) ~ c X log X parallels classical divisor sums.",
-    "implications": [
-      "G(n) provides a measure of divisor smoothness complementary to τ(n) and σ(n)",
-      "The continuous distribution of G(n)/τ(n) reveals statistical regularity in divisor sequences",
-      "The connection Σ G(n) ~ c X log X links divisor ratios to the classical Dirichlet divisor problem",
-      "Non-multiplicativity of G distinguishes it from classical arithmetic functions and requires new analytic tools"
-    ],
+    "implications": "G(n) provides a measure of divisor smoothness complementary to τ(n) and σ(n) The continuous distribution of G(n)/τ(n) reveals statistical regularity in divisor sequences The connection Σ G(n) ~ c X log X links divisor ratios to the classical Dirichlet divisor problem Non-multiplicativity of G distinguishes it from classical arithmetic functions and requires new analytic tools",
     "openQuestions": [
       "What is the exact constant c in Σ G(n) ~ c X log X?",
       "What is the explicit form of the distribution function for G(n)/τ(n)?",

--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -26,8 +26,20 @@
       "field": "Analytic Number Theory",
       "subfield": "Distribution of prime factor counts",
       "level": "research",
-      "centralObjects": ["ω(n) distinct prime factor count", "threshold (1+ε) log k / log log k", "SatisfiesProperty predicate", "Hardy-Ramanujan normal order"],
-      "keyTechniques": ["Hardy-Ramanujan theorem", "large deviation estimates for additive functions", "sieve methods", "density arguments", "probabilistic heuristics", "dichotomy principle"],
+      "centralObjects": [
+        "ω(n) distinct prime factor count",
+        "threshold (1+ε) log k / log log k",
+        "SatisfiesProperty predicate",
+        "Hardy-Ramanujan normal order"
+      ],
+      "keyTechniques": [
+        "Hardy-Ramanujan theorem",
+        "large deviation estimates for additive functions",
+        "sieve methods",
+        "density arguments",
+        "probabilistic heuristics",
+        "dichotomy principle"
+      ],
       "significance": "Probes the simultaneous distribution of ω across arithmetic progressions n-k. The main conjecture is open after 45+ years and cannot be resolved by finite computation. The disproved stronger version (O(1) error) shows the (1+ε) multiplicative slack is essential. Resolution would reveal deep structure in the correlation of prime factor counts across consecutive differences."
     },
     "references": [
@@ -207,12 +219,7 @@
   ],
   "conclusion": {
     "summary": "This formalization captures Erdős Problem #679 on simultaneous smallness of ω(n-k). The main conjecture (OPEN) asks whether infinitely many n have all predecessors with ω below (1+ε) times the extremal order. The stronger O(1) version is disproven. The problem cannot be resolved by finite computation and connects deeply to the Hardy-Ramanujan theorem and the distribution of prime factors.",
-    "implications": [
-      "Resolution would reveal whether the prime factor structure of n-1, n-2, ..., 1 can be simultaneously controlled",
-      "The disproof of the O(1) version shows the (1+ε) slack is essential and sharp",
-      "Connections to Problems #248 and #413 place this in a web of ω-distribution questions",
-      "The density bound x/log x suggests special n are at least as rare as primes"
-    ],
+    "implications": "Resolution would reveal whether the prime factor structure of n-1, n-2, ..., 1 can be simultaneously controlled The disproof of the O(1) version shows the (1+ε) slack is essential and sharp Connections to Problems #248 and #413 place this in a web of ω-distribution questions The density bound x/log x suggests special n are at least as rare as primes",
     "openQuestions": [
       "Does the main conjecture hold for any ε > 0?",
       "What is the density of special n if they exist?",

--- a/src/data/proofs/erdos-702/meta.json
+++ b/src/data/proofs/erdos-702/meta.json
@@ -28,8 +28,18 @@
       "field": "Extremal Set Theory",
       "subfield": "Forbidden intersection configurations in uniform families",
       "level": "research",
-      "centralObjects": ["k-uniform family F", "singleton intersection |A ∩ B| = 1", "extremal bound C(n-2, k-2)", "shifting operator"],
-      "keyTechniques": ["shifting (compression) technique", "extremal construction via fixed kernel", "binomial coefficient counting", "case analysis for small k"],
+      "centralObjects": [
+        "k-uniform family F",
+        "singleton intersection |A ∩ B| = 1",
+        "extremal bound C(n-2, k-2)",
+        "shifting operator"
+      ],
+      "keyTechniques": [
+        "shifting (compression) technique",
+        "extremal construction via fixed kernel",
+        "binomial coefficient counting",
+        "case analysis for small k"
+      ],
       "significance": "Resolves the Erdős-Sós conjecture on singleton intersection avoidance: the maximum k-uniform family avoiding |A ∩ B| = 1 has exactly C(n-2, k-2) sets (achieved by fixing two common elements). Frankl's proof via shifting established a paradigm for extremal set theory. The sharp threshold at k = 4 reveals a structural boundary — the theorem fails for k = 3 due to designs like Steiner triple systems."
     },
     "references": [
@@ -169,12 +179,7 @@
   ],
   "conclusion": {
     "summary": "Erdős Problem #702 (Erdős-Sós conjecture) was SOLVED by Frankl in 1977. For k ≥ 4, any k-uniform family with more than C(n-2, k-2) sets contains a singleton intersection pair. The bound is achieved by taking all k-sets through two fixed points. The proof uses the shifting technique, and the condition k ≥ 4 is necessary.",
-    "implications": [
-      "Characterizes the maximum k-uniform family avoiding singleton intersections for k ≥ 4",
-      "Establishes the shifting technique as a paradigm for extremal set theory proofs",
-      "Reveals a structural boundary at k = 4: the theorem fails for k = 3 due to combinatorial designs",
-      "The extremal family (sunflower with 2-element kernel) is the unique maximum-avoiding construction"
-    ],
+    "implications": "Characterizes the maximum k-uniform family avoiding singleton intersections for k ≥ 4 Establishes the shifting technique as a paradigm for extremal set theory proofs Reveals a structural boundary at k = 4: the theorem fails for k = 3 due to combinatorial designs The extremal family (sunflower with 2-element kernel) is the unique maximum-avoiding construction",
     "openQuestions": [
       "Characterize all extremal families achieving C(n-2, k-2) for each k ≥ 4",
       "Strengthen results for specific values of n and k",

--- a/src/data/proofs/erdos-706/meta.json
+++ b/src/data/proofs/erdos-706/meta.json
@@ -28,8 +28,18 @@
       "field": "Combinatorial Geometry",
       "subfield": "Chromatic numbers of distance graphs in the Euclidean plane",
       "level": "research",
-      "centralObjects": ["multi-distance graph G_A", "chromatic function L(r)", "distance set A ⊂ (0,∞)", "unit distance graph"],
-      "keyTechniques": ["axiomatization of L(r)", "monotonicity from subgraph inclusion", "Hadwiger-Nelson base case (de Grey)", "Frankl-Wilson exponential bounds"],
+      "centralObjects": [
+        "multi-distance graph G_A",
+        "chromatic function L(r)",
+        "distance set A ⊂ (0,∞)",
+        "unit distance graph"
+      ],
+      "keyTechniques": [
+        "axiomatization of L(r)",
+        "monotonicity from subgraph inclusion",
+        "Hadwiger-Nelson base case (de Grey)",
+        "Frankl-Wilson exponential bounds"
+      ],
       "significance": "Generalizes the Hadwiger-Nelson problem from one forbidden distance to r distances. The gap between the known exponential upper bound L(r) ≤ C^r and the conjectured polynomial bound L(r) ≤ r^{O(1)} is vast. Even the r = 1 case (5 ≤ L(1) ≤ 7) remains unsolved after 75 years, making the general question one of the hardest open problems in chromatic geometry."
     },
     "references": [
@@ -151,12 +161,7 @@
   ],
   "conclusion": {
     "summary": "Erdős Problem #706 asks whether the maximum chromatic number L(r) of multi-distance graphs in the plane grows polynomially in r. Even the single-distance case (Hadwiger-Nelson, 5 ≤ L(1) ≤ 7) is unsolved, making the general question extremely challenging. The known bounds are L(r) ≥ 5 (trivial) and L(r) ≤ C^r (exponential), with a vast gap between these and the conjectured polynomial growth.",
-    "implications": [
-      "A polynomial bound would reveal deep structure in distance graphs: many forbidden distances increase chromatic requirement only mildly",
-      "An exponential lower bound would show distance constraints interact multiplicatively in the plane",
-      "Progress on L(r) for any r > 1 would shed light on the Hadwiger-Nelson problem",
-      "Connects to the broader study of chromatic numbers of geometric graphs"
-    ],
+    "implications": "A polynomial bound would reveal deep structure in distance graphs: many forbidden distances increase chromatic requirement only mildly An exponential lower bound would show distance constraints interact multiplicatively in the plane Progress on L(r) for any r > 1 would shed light on the Hadwiger-Nelson problem Connects to the broader study of chromatic numbers of geometric graphs",
     "openQuestions": [
       "Is L(r) ≤ r^{O(1)}? (the main conjecture)",
       "What is the exact value of L(1)? (Hadwiger-Nelson: 5, 6, or 7)",

--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -28,8 +28,18 @@
       "field": "Structural Graph Theory",
       "subfield": "Regular subgraph existence under degree regularity constraints",
       "level": "research",
-      "centralObjects": ["r-regular graph", "k-regular subgraph", "HasRegularSubgraph(r,k) predicate", "regularity threshold"],
-      "keyTechniques": ["Tashkinov's cycle-combination method", "Alon-Friedland-Kalai edge-addition argument", "K₄ and Petersen graph as minimal counterexamples", "handshaking lemma for parity"],
+      "centralObjects": [
+        "r-regular graph",
+        "k-regular subgraph",
+        "HasRegularSubgraph(r,k) predicate",
+        "regularity threshold"
+      ],
+      "keyTechniques": [
+        "Tashkinov's cycle-combination method",
+        "Alon-Friedland-Kalai edge-addition argument",
+        "K₄ and Petersen graph as minimal counterexamples",
+        "handshaking lemma for parity"
+      ],
       "significance": "Resolves the Berge-Sauer question with a sharp threshold: r = 4 is the minimum regularity degree forcing a 3-regular subgraph. K₄ and the Petersen graph show r = 3 fails. The Alon-Friedland-Kalai strengthening (4-regular + one edge suffices) reveals remarkable structural rigidity in 4-regular graphs. The general threshold problem for k-regular subgraphs remains open for k ≥ 4."
     },
     "references": [
@@ -184,12 +194,7 @@
   ],
   "conclusion": {
     "summary": "Erdős Problem #715 (Berge-Sauer question) was SOLVED by Tashkinov in 1982. Every 4-regular graph contains a 3-regular subgraph, and hence every r-regular graph with r ≥ 4 does as well. The threshold is exactly 4: K₄ and the Petersen graph are minimal 3-regular graphs with no proper 3-regular subgraph. The Alon-Friedland-Kalai strengthening shows even 4-regular + one edge suffices.",
-    "implications": [
-      "The threshold for 3-regular subgraph existence is exactly r = 4, a sharp structural result",
-      "Alon-Friedland-Kalai reveals remarkable rigidity: one extra edge beyond 4-regularity forces 3-regular substructure",
-      "The Petersen graph and K₄ are the canonical minimal counterexamples below the threshold",
-      "Connects to graph factorization theory and Petersen's theorem on 2-factors"
-    ],
+    "implications": "The threshold for 3-regular subgraph existence is exactly r = 4, a sharp structural result Alon-Friedland-Kalai reveals remarkable rigidity: one extra edge beyond 4-regularity forces 3-regular substructure The Petersen graph and K₄ are the canonical minimal counterexamples below the threshold Connects to graph factorization theory and Petersen's theorem on 2-factors",
     "openQuestions": [
       "What is the threshold for k-regular subgraphs for general k ≥ 4?",
       "Can Tashkinov's proof be made constructive with polynomial-time algorithms?",

--- a/src/data/proofs/erdos-749/meta.json
+++ b/src/data/proofs/erdos-749/meta.json
@@ -28,8 +28,18 @@
       "field": "Additive Combinatorics",
       "subfield": "Sumset density and representation function bounds",
       "level": "research",
-      "centralObjects": ["representation function r_A(n)", "sumset A+A", "lower asymptotic density", "bounded representation predicate"],
-      "keyTechniques": ["Sidon set construction (bounded r(n), sparse sumset)", "Erdős-Turán conjecture boundary analysis", "density axiomatization (lim inf / lim sup)", "dichotomy formulation"],
+      "centralObjects": [
+        "representation function r_A(n)",
+        "sumset A+A",
+        "lower asymptotic density",
+        "bounded representation predicate"
+      ],
+      "keyTechniques": [
+        "Sidon set construction (bounded r(n), sparse sumset)",
+        "Erdős-Turán conjecture boundary analysis",
+        "density axiomatization (lim inf / lim sup)",
+        "dichotomy formulation"
+      ],
       "significance": "Probes the exact threshold of the Erdős-Turán phenomenon. Sidon sets show bounded r(n) is compatible with sparse sumsets. The Erdős-Turán conjecture asserts full bases must have unbounded r(n). Problem #749 asks about the boundary: can near-bases (density close to 1) still have bounded r(n)? The answer determines whether the Erdős-Turán obstruction is a sharp phase transition at density 1 or a gradual phenomenon."
     },
     "references": [
@@ -161,12 +171,7 @@
   ],
   "conclusion": {
     "summary": "Erdős Problem #749 asks whether near-basis sets (sumset density close to 1) can have bounded representation function r(n). This sits between Sidon sets (bounded r(n), sparse sumset) and the Erdős-Turán conjecture (full basis implies unbounded r(n)). Both the lower and upper density variants remain open. The answer determines whether the Erdős-Turán obstruction is a sharp phase transition at density 1.",
-    "implications": [
-      "A positive answer would show the Erdős-Turán threshold is exactly density 1: bounded r(n) is possible for any density below 1",
-      "A negative answer would quantitatively strengthen the Erdős-Turán conjecture: dense sumsets force unbounded r(n) even below density 1",
-      "The two density variants (lower vs. upper) may have different answers, revealing the role of density regularity",
-      "Connects to the broader program of understanding when additive structure forces representation growth"
-    ],
+    "implications": "A positive answer would show the Erdős-Turán threshold is exactly density 1: bounded r(n) is possible for any density below 1 A negative answer would quantitatively strengthen the Erdős-Turán conjecture: dense sumsets force unbounded r(n) even below density 1 The two density variants (lower vs. upper) may have different answers, revealing the role of density regularity Connects to the broader program of understanding when additive structure forces representation growth",
     "openQuestions": [
       "Can A+A have lower density ≥ 1-ε with bounded r(n)?",
       "Does the answer differ for upper density vs lower density?",


### PR DESCRIPTION
## Summary
- Enricher created `conclusion.implications` as `string[]` but `ProofConclusion` type expects `string`
- Fixes build failure (TS2352) in `cauchy-schwarz-integral-oq-01-oq-01` and 9 erdos proofs
- Joins array elements with space separator

## Affected proofs
cauchy-schwarz-integral-oq-01-oq-01, erdos-64, erdos-644, erdos-650, erdos-673, erdos-679, erdos-702, erdos-706, erdos-715, erdos-749

## Test plan
- [x] `pnpm build` should pass after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)