### PR TITLE
Enrich 5 proofs: Cauchy-Schwarz equality, Erdos 1155, Vector MVT, Hölder inequality, N-dim volume

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/annotations.json
@@ -1,22 +1,122 @@
 [
   {
-    "lineNumber": 37,
-    "content": "**Unit Ball Volume**: ω_n = π^(n/2)/Γ(n/2+1) is the volume of the unit n-ball. Key values: ω_0=1, ω_1=2, ω_2=π, ω_3=4π/3. Computing these requires Gamma function identities: Γ(1)=1, Γ(1/2)=√π, Γ(3/2)=√π/2, Γ(5/2)=3√π/4.",
-    "type": "definition"
+    "id": "ann-ndvol-unit-ball-volume",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 33,
+      "endLine": 49
+    },
+    "type": "definition",
+    "title": "Volume and Surface Area Definitions",
+    "content": "Three core definitions anchor the file: unitBallVolume n = π^(n/2)/Γ(n/2+1) gives the volume of the unit n-ball; nBallVol n r = ω_n · r^n gives the n-ball of radius r; nSphereArea n r = n · ω_n · r^(n-1) gives the (n-1)-sphere surface area. The polynomial structure V_n(r) = ω_n · r^n is crucial — it makes differentiation and integration routine via the power rule.",
+    "mathContext": "The unit ball volume $\\omega_n = \\frac{\\pi^{n/2}}{\\Gamma(n/2+1)}$ uses the Gamma function to interpolate factorials to half-integers. Key values: $\\omega_0 = 1$, $\\omega_1 = 2$, $\\omega_2 = \\pi$, $\\omega_3 = 4\\pi/3$. The formula arises from integrating $V_n(r) = \\int_{B_n(r)} 1 \\, dV$ in polar coordinates.",
+    "significance": "critical",
+    "relatedConcepts": ["unit ball volume", "n-ball", "Gamma function", "polar coordinates"],
+    "prerequisites": ["Real.Gamma", "rpow"]
   },
   {
-    "lineNumber": 117,
-    "content": "**Key Derivative**: d/dr[V_n(r)] = S_n(r) is the n-dimensional generalization of dA/dr = C = 2πr. Since V_n(r) = ω_n·r^n is polynomial, this is just the power rule. The constant ω_n multiplies through via `HasDerivAt.const_mul`.",
-    "type": "proof-technique"
+    "id": "ann-ndvol-gamma-computations",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 51,
+      "endLine": 104
+    },
+    "type": "technique",
+    "title": "Gamma Function Computations for ω_n",
+    "content": "Computing ω_n for specific n requires evaluating the Gamma function at half-integer points. The key identities are Γ(1) = 1, Γ(1/2) = √π, and the recurrence Γ(x+1) = x·Γ(x). From these: Γ(3/2) = (1/2)·√π = √π/2 and Γ(5/2) = (3/2)·Γ(3/2) = 3√π/4.\n\nThe proofs are intricate because field_simp and ring must negotiate with square roots and divisions. The positivity of ω_n follows from π > 0 (rpow_pos_of_pos) and Γ > 0 for positive arguments (Gamma_pos_of_pos).",
+    "mathContext": "The Gamma function $\\Gamma(x) = \\int_0^\\infty t^{x-1} e^{-t} dt$ satisfies $\\Gamma(n+1) = n!$ for integers and $\\Gamma(1/2) = \\sqrt{\\pi}$ (Euler's reflection formula). Computing $\\omega_1 = \\pi^{1/2}/\\Gamma(3/2) = \\sqrt{\\pi}/(\\sqrt{\\pi}/2) = 2$ requires careful manipulation of these identities in Lean.",
+    "significance": "supporting",
+    "relatedConcepts": ["Gamma function", "half-integer evaluation", "Gamma recurrence", "sqrt π"],
+    "prerequisites": ["Gamma_one", "Gamma_one_half_eq", "Gamma_add_one", "Gamma_pos_of_pos"]
   },
   {
-    "lineNumber": 148,
-    "content": "**Main Theorem**: V_n(r) = ∫₀ʳ S_n(ρ) dρ via FTC Part 2 (`integral_eq_sub_of_hasDerivAt`). The proof is: ∫₀ʳ V_n'(ρ) dρ = V_n(r) - V_n(0) = V_n(r) - 0 = V_n(r). The zero boundary condition V_n(0) = 0 comes from r^n = 0 for n ≥ 1.",
-    "type": "proof-technique"
+    "id": "ann-ndvol-derivative-relation",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 106,
+      "endLine": 131
+    },
+    "type": "theorem",
+    "title": "The Key Derivative: d/dr[V_n(r)] = S_n(r)",
+    "content": "The n-dimensional generalization of dA/dr = C = 2πr. Since V_n(r) = ω_n · r^n is polynomial in r, the derivative is S_n(r) = n · ω_n · r^(n-1) by the power rule. The constant ω_n multiplies through via HasDerivAt.const_mul.\n\nThis is the central structural insight: because V_n is a pure power function, the volume-surface duality is an instance of the power rule. Continuity of both V_n and S_n follows from the continuity of polynomial functions.",
+    "mathContext": "The derivative relation $\\frac{d}{dr} V_n(r) = S_n(r)$ says that the rate of volume growth equals the surface area. Geometrically: adding an infinitesimal shell of thickness $dr$ to the $n$-ball of radius $r$ increases volume by $S_n(r) \\cdot dr$. This is the $n$-dimensional \"onion peeling\" principle.",
+    "significance": "key",
+    "relatedConcepts": ["power rule", "volume-surface duality", "onion peeling", "HasDerivAt"],
+    "prerequisites": ["hasDerivAt_pow", "HasDerivAt.const_mul"]
   },
   {
-    "lineNumber": 248,
-    "content": "**Surface-to-Volume Ratio**: S_n(r)/V_n(r) = n/r grows linearly with dimension. This explains why high-dimensional balls have 'thin shells' — most of the volume is concentrated near the boundary. For n=2: 2/r (circumference/area), for n=3: 3/r (surface/volume).",
-    "type": "insight"
+    "id": "ann-ndvol-main-theorem",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 133,
+      "endLine": 165
+    },
+    "type": "theorem",
+    "title": "Main Theorem: V_n(r) = ∫₀ʳ S_n(ρ) dρ via FTC",
+    "content": "The main result: V_n(r) = ∫₀ʳ S_n(ρ) dρ, proved via FTC Part 2 (integral_eq_sub_of_hasDerivAt). The proof uses three ingredients: (1) the derivative relation d/dr[V_n] = S_n at each point in [0,r]; (2) the interval integrability of S_n (from continuity); (3) the boundary condition V_n(0) = 0 (since r^n = 0 for n ≥ 1).\n\nThe companion result deriv_volume_integral recovers S_n from the integral via FTC Part 1 (integral_hasDerivAt_right), completing the circle: differentiation and integration are inverse operations on these smooth functions.",
+    "mathContext": "FTC Part 2: if $F' = f$ on $[a,b]$ and $f$ is integrable, then $\\int_a^b f = F(b) - F(a)$. Here $F = V_n$, $f = S_n$, $a = 0$, $b = r$. Since $V_n(0) = \\omega_n \\cdot 0^n = 0$ for $n \\geq 1$: $\\int_0^r S_n(\\rho) \\, d\\rho = V_n(r) - 0 = V_n(r)$.",
+    "significance": "critical",
+    "relatedConcepts": ["fundamental theorem of calculus", "FTC Part 1", "FTC Part 2", "interval integral"],
+    "prerequisites": ["intervalIntegral.integral_eq_sub_of_hasDerivAt", "intervalIntegral.integral_hasDerivAt_right", "IntervalIntegrable"]
+  },
+  {
+    "id": "ann-ndvol-special-cases",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 167,
+      "endLine": 212
+    },
+    "type": "insight",
+    "title": "Special Cases: Recovering Classical Formulas",
+    "content": "Instantiating the general theorem for n = 1, 2, 3 recovers all familiar formulas: n=1 gives ∫₀ʳ 2 dρ = 2r (interval length); n=2 gives ∫₀ʳ 2πρ dρ = πr² (circle area from circumference); n=3 gives ∫₀ʳ 4πρ² dρ = (4π/3)r³ (sphere volume from surface area). The explicit formulas S₂(r) = 2πr, S₃(r) = 4πr², V₃(r) = (4π/3)r³ are proved by substituting the computed values of ω_n.\n\nThe n=2 case is exactly the classical A(r) = ∫₀ʳ C(ρ) dρ from Wiedijk #9, closing the open question chain.",
+    "mathContext": "The chain of open questions: Wiedijk #9 proves $A = \\pi r^2$. OQ01 derives $C = dA/dr = 2\\pi r$. OQ02 reverses this: $A = \\int_0^r C(\\rho) \\, d\\rho$. This file (OQ01 of OQ02) generalizes to $n$ dimensions, with the $n=2$ case recovering the original result.",
+    "significance": "supporting",
+    "relatedConcepts": ["Wiedijk 100 theorems", "circle area", "sphere volume", "dimensional analysis"],
+    "prerequisites": ["unitBallVolume_two", "unitBallVolume_three"]
+  },
+  {
+    "id": "ann-ndvol-shell-volumes",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 213,
+      "endLine": 230
+    },
+    "type": "theorem",
+    "title": "Shell/Annulus Volume Generalization",
+    "content": "Generalizes the integral formula to shells (annuli): ∫_{r₁}^{r₂} S_n(ρ) dρ = V_n(r₂) - V_n(r₁). This is the natural extension of FTC Part 2 without the V_n(0) = 0 simplification. The 3D case gives the volume of a spherical shell: ∫_{r₁}^{r₂} 4πρ² dρ = (4π/3)(r₂³ - r₁³).\n\nThe proof is identical to the main theorem but with arbitrary endpoints r₁, r₂ instead of 0 and r.",
+    "mathContext": "The shell volume formula $V_n(r_2) - V_n(r_1) = \\omega_n(r_2^n - r_1^n)$ is the basis of the \"shell method\" in calculus. For thin shells ($r_2 = r_1 + dr$): $\\Delta V \\approx S_n(r_1) \\cdot dr$, recovering the derivative relation.",
+    "significance": "supporting",
+    "relatedConcepts": ["shell method", "annulus", "spherical shell", "FTC Part 2"],
+    "prerequisites": ["intervalIntegral.integral_eq_sub_of_hasDerivAt", "hasDerivAt_nBallVol"]
+  },
+  {
+    "id": "ann-ndvol-scaling-ratio",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 232,
+      "endLine": 262
+    },
+    "type": "theorem",
+    "title": "Scaling Laws and Surface-to-Volume Ratio",
+    "content": "Two scaling laws: V_n(cr) = c^n · V_n(r) and S_n(cr) = c^(n-1) · S_n(r). These reflect the dimensional analysis principle: volume scales as length^n and surface area as length^(n-1).\n\nThe surface-to-volume ratio S_n(r)/V_n(r) = n/r is proved by algebraic manipulation with field_simp and pow_sub₀. This ratio grows linearly with dimension n, which explains the concentration of measure phenomenon: in high dimensions, most of the ball's volume is concentrated near the boundary (within a thin shell of thickness ~r/n).",
+    "mathContext": "The ratio $S_n/V_n = n/r$ has profound consequences in high-dimensional geometry. For $n = 100$ and $r = 1$: the shell of thickness $0.01$ (from $r = 0.99$ to $1$) contains fraction $1 - 0.99^{100} \\approx 63\\%$ of the total volume. This is the \"curse of dimensionality\" in a geometric guise.",
+    "significance": "key",
+    "relatedConcepts": ["dimensional analysis", "concentration of measure", "curse of dimensionality", "thin shell phenomenon"],
+    "prerequisites": ["pow_sub₀", "field_simp", "Gamma_pos_of_pos"]
+  },
+  {
+    "id": "ann-ndvol-summary-chain",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 264,
+      "endLine": 290
+    },
+    "type": "insight",
+    "title": "The Open Question Chain: From Circle Area to N-Dimensional Integration",
+    "content": "The summary section traces the full chain of open questions: AreaOfCircle (Wiedijk #9, A = πr²) → OQ01 (C = dA/dr = 2πr) → OQ02 (A = ∫₀ʳ C(ρ) dρ) → OQ01 of OQ02 (V_n = ∫₀ʳ S_n(ρ) dρ, this file). Each step generalizes the previous: OQ01 finds the derivative, OQ02 reverses via FTC, and this file lifts both to n dimensions.\n\nThe key insight across the chain: the polynomial structure V_n(r) = ω_n · r^n makes everything routine. Differentiation gives surface area, FTC gives the integral formula, and scaling laws follow from homogeneity.",
+    "mathContext": "This is a complete mathematical narrative from a single classical result ($A = \\pi r^2$) through three levels of generalization to a result about $n$-dimensional geometry. The polynomial structure means that no analytic difficulties arise — the proofs are algebraic rather than analytic, despite using the full machinery of measure-theoretic integration.",
+    "significance": "supporting",
+    "relatedConcepts": ["Wiedijk 100 theorems", "open question chain", "mathematical generalization"],
+    "prerequisites": []
   }
 ]

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
@@ -39,6 +39,16 @@
         "theorem": "Real.Gamma_pos_of_pos",
         "description": "Gamma function is positive for positive arguments",
         "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Gamma_add_one",
+        "description": "Gamma recurrence: Γ(x+1) = x·Γ(x)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Gamma_one_half_eq",
+        "description": "Γ(1/2) = √π (Euler's reflection formula specialization)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
       }
     ],
     "originalContributions": [
@@ -51,9 +61,34 @@
       "Surface-to-volume ratio S_n/V_n = n/r",
       "Explicit formulas: S₂ = 2πr, S₃ = 4πr², V₃ = (4π/3)r³"
     ],
+    "references": [
+      {
+        "authors": "Archimedes",
+        "title": "On the Sphere and Cylinder",
+        "year": "-225",
+        "venue": "Classical geometry",
+        "note": "First proof that the volume of a sphere is (4/3)πr³ and its surface area is 4πr², via the method of exhaustion"
+      },
+      {
+        "authors": "L. Schläfli",
+        "title": "Theorie der vielfachen Kontinuität",
+        "year": "1852",
+        "venue": "Denkschriften der Schweizerischen Naturforschenden Gesellschaft",
+        "note": "First computation of the volume of the n-dimensional ball using the Gamma function"
+      },
+      {
+        "authors": "Keith Ball",
+        "title": "An Elementary Introduction to Modern Convex Geometry",
+        "year": "1997",
+        "venue": "Flavors of Geometry, MSRI Publications",
+        "note": "Modern treatment of high-dimensional volume and the concentration of measure phenomenon"
+      }
+    ],
+    "historicalContext": "The relationship between the volume and surface area of n-dimensional balls is a fundamental result in geometric analysis. In 2D, the area of a circle equals the integral of its circumference: A(r) = ∫₀ʳ 2πρ dρ = πr². This generalizes to all dimensions via V_n(r) = ω_n r^n and the polynomial structure of the volume function. The n-ball volume formula ω_n = π^(n/2)/Γ(n/2+1) was first computed by Schläfli (1852) and exhibits the surprising behavior of vanishing as n → ∞.",
     "dateAdded": "03/11/26"
   },
   "overview": {
+    "summary": "Generalizes the 2D result A(r) = ∫₀ʳ C(ρ) dρ to n dimensions, proving V_n(r) = ∫₀ʳ S_n(ρ) dρ where S_n(ρ) = n·ω_n·ρ^(n-1) is the sphere surface area. The proof exploits the polynomial structure V_n(r) = ω_n·r^n: differentiation gives the surface area (power rule), and the Fundamental Theorem of Calculus recovers the volume as an integral. Rich consequences include shell volumes, scaling laws, and the surface-to-volume ratio n/r.",
     "historicalContext": "The relationship between the volume and surface area of n-dimensional balls is a fundamental result in geometric analysis. In 2D, the area of a circle equals the integral of its circumference: A(r) = ∫₀ʳ 2πρ dρ = πr². This generalizes to all dimensions via V_n(r) = ω_n r^n and the polynomial structure of the volume function.",
     "problemStatement": "**Open Question**: Can the 2D result A(r) = ∫₀ʳ C(ρ) dρ be generalized to n dimensions?\n\n**Answer**: YES. For any n ≥ 1, V_n(r) = ∫₀ʳ S_n(ρ) dρ where S_n(ρ) = n·ω_n·ρ^(n-1) is the (n-1)-sphere surface area. This follows from V_n(r) = ω_n·r^n being a polynomial in r, so differentiation gives d/dr[V_n] = S_n, and FTC Part 2 yields the integral formula.",
     "proofStrategy": "1. **Define** unit ball volume ω_n = π^(n/2)/Γ(n/2+1), volume V_n(r) = ω_n·r^n, surface area S_n(r) = n·ω_n·r^(n-1).\n2. **Verify** ω_n for small n: ω_0=1, ω_1=2, ω_2=π, ω_3=4π/3.\n3. **Differentiate**: d/dr[V_n(r)] = S_n(r) via the power rule (hasDerivAt_pow).\n4. **Integrate**: V_n(r) = ∫₀ʳ S_n(ρ) dρ via FTC Part 2, using V_n(0) = 0.\n5. **Generalize**: Shell volumes, scaling laws, surface-to-volume ratio.",
@@ -63,6 +98,13 @@
       "FTC Part 2 converts the derivative relation into the integral formula V_n = ∫S_n",
       "The surface-to-volume ratio S_n/V_n = n/r explains why high-dimensional balls have 'thin shells'",
       "Gamma function values Γ(3/2) = √π/2 and Γ(5/2) = 3√π/4 are key for explicit formulas"
+    ],
+    "keyIdea": "The n-ball volume V_n(r) = ω_n · r^n has polynomial structure, so the volume-surface duality d/dr[V_n] = S_n is an instance of the power rule, and FTC Part 2 immediately yields V_n = ∫S_n.",
+    "prerequisites": [
+      "Fundamental Theorem of Calculus (Parts 1 and 2)",
+      "Gamma function and half-integer evaluation",
+      "Power rule for derivatives (hasDerivAt_pow)",
+      "Interval integration in Mathlib"
     ]
   },
   "sections": [
@@ -71,57 +113,70 @@
       "title": "Volume and Surface Area Functions",
       "startLine": 33,
       "endLine": 49,
-      "summary": "Defines unit ball volume ω_n, n-ball volume V_n(r), and sphere surface area S_n(r)."
+      "summary": "Defines unit ball volume ω_n = π^(n/2)/Γ(n/2+1), n-ball volume V_n(r) = ω_n·r^n, and sphere surface area S_n(r) = n·ω_n·r^(n-1)."
     },
     {
       "id": "unit-ball-properties",
       "title": "Unit Ball Volume Properties",
       "startLine": 51,
       "endLine": 104,
-      "summary": "Proves ω_n ≥ 0 and explicit values ω_0=1, ω_1=2, ω_2=π, ω_3=4π/3."
+      "summary": "Proves ω_n ≥ 0 and explicit values ω_0=1, ω_1=2, ω_2=π, ω_3=4π/3 via Gamma function identities Γ(1/2) = √π, Γ(3/2) = √π/2, Γ(5/2) = 3√π/4."
     },
     {
       "id": "derivative-relation",
       "title": "The Derivative Relation",
       "startLine": 106,
       "endLine": 131,
-      "summary": "d/dr[V_n(r)] = S_n(r) via the power rule, plus continuity of V_n and S_n."
+      "summary": "d/dr[V_n(r)] = S_n(r) via the power rule (hasDerivAt_pow), plus continuity of V_n and S_n. This is the n-dimensional 'onion peeling' principle."
     },
     {
       "id": "integral-formula",
       "title": "The Integral Formula (Main Theorem)",
       "startLine": 133,
       "endLine": 165,
-      "summary": "V_n(r) = ∫₀ʳ S_n(ρ) dρ via FTC Part 2, and FTC Part 1 recovery."
+      "summary": "V_n(r) = ∫₀ʳ S_n(ρ) dρ via FTC Part 2, using V_n(0) = 0. Also proves FTC Part 1 recovery: d/dr[∫₀ʳ S_n] = S_n(r)."
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
       "startLine": 167,
       "endLine": 212,
-      "summary": "n=1,2,3 special cases and explicit formulas for S₂, S₃, V₂, V₃."
+      "summary": "n=1,2,3 special cases recovering classical formulas. Explicit formulas S₂=2πr, S₃=4πr², V₂=πr², V₃=(4π/3)r³ confirmed by substituting ω_n values."
     },
     {
       "id": "shell-volumes",
       "title": "Shell/Annulus Generalization",
       "startLine": 213,
       "endLine": 230,
-      "summary": "∫_{r₁}^{r₂} S_n = V_n(r₂) - V_n(r₁) for shells."
+      "summary": "∫_{r₁}^{r₂} S_n = V_n(r₂) - V_n(r₁) for shells. The 3D spherical shell formula is given as a corollary."
     },
     {
       "id": "scaling",
       "title": "Scaling Properties and Surface-to-Volume Ratio",
       "startLine": 232,
       "endLine": 262,
-      "summary": "Scaling laws and S_n/V_n = n/r ratio."
+      "summary": "Scaling laws V_n(cr) = c^n·V_n(r), S_n(cr) = c^(n-1)·S_n(r), and the key ratio S_n/V_n = n/r explaining concentration of measure in high dimensions."
+    },
+    {
+      "id": "summary",
+      "title": "Summary and Open Question Chain",
+      "startLine": 264,
+      "endLine": 290,
+      "summary": "Recapitulates all results and traces the open question chain: Wiedijk #9 (A=πr²) → OQ01 (C=dA/dr) → OQ02 (A=∫C) → this file (V_n=∫S_n)."
     }
   ],
   "conclusion": {
     "summary": "This file generalizes the 2D area-circumference integral relation A = ∫C to arbitrary dimensions with zero sorries. The main theorem V_n(r) = ∫₀ʳ S_n(ρ) dρ follows cleanly from the polynomial structure of V_n and the Fundamental Theorem of Calculus. Rich consequences include shell volumes, scaling laws, and the surface-to-volume ratio n/r.",
-    "implications": "1. **Geometric analysis**: The volume-surface duality V_n' = S_n is the foundation of geometric measure theory.\n2. **High-dimensional geometry**: The ratio S_n/V_n = n/r explains concentration of measure in high dimensions.\n3. **Proof chain**: Completes the sequence from Wiedijk #9 (circle area) through circumference-area duality to n-dimensional integration.",
+    "implications": [
+      "The volume-surface duality V_n' = S_n is the foundation of geometric measure theory in n dimensions",
+      "The ratio S_n/V_n = n/r explains concentration of measure in high dimensions — the 'curse of dimensionality'",
+      "Completes the Wiedijk #9 open question chain: circle area → circumference-area duality → n-dimensional integration",
+      "The polynomial structure V_n = ω_n·r^n suggests that similar integral relations hold for other homogeneous geometric quantities"
+    ],
     "openQuestions": [
-      "Can the Gamma function values ω_n be computed for all n via a recursive formula?",
-      "Can the isoperimetric inequality be formalized using these volume/surface area definitions?"
+      "Can the Gamma function values ω_n be computed for all n via a recursive formula ω_{n+2} = (2π/n)·ω_n?",
+      "Can the isoperimetric inequality be formalized using these volume/surface area definitions?",
+      "Can the behavior ω_n → 0 as n → ∞ (the 'thin shell' limit) be formalized?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
Batch enrichment of 5 gallery proofs:

- **cauchy-schwarz-oq-03-oq-01** (quality 55→enriched): 12 annotations with full schema, historicalContext, proofStrategy, 5 keyInsights, 13 sections covering all 772 lines
- **erdos-1155-oq-01** (quality 45→enriched): 12 annotations with full schema, historicalContext, proofStrategy, 5 keyInsights, 11 sections covering all 491 lines
- **mean-value-theorem-oq-03** (quality 55→enriched): meta.json enriched with historicalContext, proofStrategy, 5 keyInsights, 10 sections, conclusion with implications
- **lebesgue-measure-oq-02** (quality 58→enriched): 7 annotations with full schema, proofStrategy, 5 keyInsights, expanded conclusion with implications
- **area-of-circle-oq-01-oq-02-oq-01** (quality 62→enriched): 8 annotations with full schema, overview summary/keyIdea/prerequisites added, references added, implications array, 8 sections

## Changes
- annotations.json: converted from old format (lineNumber/lineStart, no id/range/significance) to new format with full schema fields (id, proofId, range, title, mathContext, significance, prerequisites)
- meta.json: added proofStrategy, keyInsights, historicalContext, keyIdea, prerequisites, references, expanded sections, conclusion with implications array and openQuestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)