### PR TITLE
Enrich Hölder's Inequality (lebesgue-measure-oq-02): deepen overview and annotations

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-02/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-02/annotations.json
@@ -1,38 +1,102 @@
 [
   {
-    "lineStart": 29,
-    "lineEnd": 43,
-    "type": "definition",
-    "content": "**Hölder Conjugate Exponents**:\n\nTwo exponents $p, q > 1$ are Hölder conjugate if $\\frac{1}{p} + \\frac{1}{q} = 1$, equivalently $q = \\frac{p}{p-1}$. The most important case is $p = q = 2$ (Cauchy-Schwarz). The pair $(1, \\infty)$ is a limiting case.\n\nIn Mathlib, `Real.HolderConjugate p q` encodes the three conditions: $1 < p$, $1 < q$, and $p^{-1} + q^{-1} = 1$.",
-    "relatedConcepts": ["conjugate exponents", "dual exponents", "Lp-Lq duality"]
+    "id": "ann-conjugate-two",
+    "line": 44,
+    "type": "theorem",
+    "content": "**Hölder conjugate $(2,2)$**: Proves that $p = q = 2$ satisfies the Hölder conjugate condition $1/p + 1/q = 1$. The proof is `constructor <;> norm_num`, which verifies $1 < 2$, $1 < 2$, and $1/2 + 1/2 = 1$ by normalization. This is the Cauchy-Schwarz case — the most important conjugate pair in analysis.",
+    "mathContext": "The Hölder conjugate condition $1/p + 1/q = 1$ with $p, q > 1$ parameterizes a family of inequalities. Key pairs: $(2,2)$ for Cauchy-Schwarz and $L^2$ theory, $(1, \\infty)$ as limiting case, $(4/3, 4)$ in Sobolev embedding theory. In Mathlib, `Real.HolderConjugate p q` encodes all three conditions as a structure.",
+    "significance": "supporting",
+    "relatedConcepts": ["conjugate exponents", "Cauchy-Schwarz", "Lp-Lq duality", "HolderConjugate"],
+    "prerequisites": ["Real.HolderConjugate"]
   },
   {
-    "lineStart": 55,
-    "lineEnd": 63,
-    "type": "technique",
-    "content": "**Young's Inequality**:\n\nFor conjugate $p, q > 1$ and non-negative $a, b$:\n$$ab \\leq \\frac{a^p}{p} + \\frac{b^q}{q}$$\n\nThis follows from the concavity of $\\log$: since $\\log$ is concave, $\\frac{1}{p}\\log(a^p) + \\frac{1}{q}\\log(b^q) \\leq \\log\\left(\\frac{a^p}{p} + \\frac{b^q}{q}\\right)$, and the left side equals $\\log(ab)$.\n\nYoung's inequality is the pointwise engine of Hölder: normalize $f, g$ to unit Lp/Lq norms, apply Young to each point, then integrate.",
-    "relatedConcepts": ["Young's inequality", "weighted AM-GM", "concavity of log"],
-    "mathContext": "Young's inequality is the pointwise foundation of Hölder's inequality"
+    "id": "ann-conjugate-general",
+    "line": 48,
+    "type": "theorem",
+    "content": "**General conjugate construction**: For any $p > 1$, the conjugate $q = p/(p-1)$ satisfies $1/p + 1/q = 1$. Uses Mathlib's `conjExponent` which constructs $q$ and verifies the conjugate condition automatically. The map $p \\mapsto p/(p-1)$ is a decreasing involution on $(1, \\infty)$ with fixed point $p = 2$.",
+    "mathContext": "$q = \\frac{p}{p-1}$ satisfies $\\frac{1}{p} + \\frac{p-1}{p} = 1$. As $p \\to 1^+$, $q \\to \\infty$; as $p \\to \\infty$, $q \\to 1^+$. The symmetry $p \\leftrightarrow q$ reflects the duality $(L^p)^* \\cong L^q$.",
+    "significance": "supporting",
+    "relatedConcepts": ["conjugate exponent construction", "involution", "duality"],
+    "prerequisites": ["Real.HolderConjugate.conjExponent"]
   },
   {
-    "lineStart": 85,
-    "lineEnd": 93,
-    "type": "keyStep",
-    "content": "**Hölder's Inequality (Integral Form)**:\n\nFor Hölder conjugate $p, q$ and non-negative measurable $f, g$:\n$$\\int f \\cdot g \\, d\\mu \\leq \\left(\\int f^p \\, d\\mu\\right)^{1/p} \\cdot \\left(\\int g^q \\, d\\mu\\right)^{1/q}$$\n\nThe proof normalizes: let $F = f / \\|f\\|_p$ and $G = g / \\|g\\|_q$. Then $\\|F\\|_p = \\|G\\|_q = 1$. Apply Young pointwise: $F(x)G(x) \\leq F(x)^p/p + G(x)^q/q$. Integrate: $\\int FG \\leq 1/p + 1/q = 1$. Scale back to get the full inequality.\n\nThis is `ENNReal.lintegral_mul_le_Lp_mul_Lq` in Mathlib.",
-    "relatedConcepts": ["Hölder inequality", "Lp norm", "Lebesgue integral", "normalization trick"]
+    "id": "ann-young",
+    "line": 67,
+    "type": "theorem",
+    "content": "**Young's inequality** (ENNReal): For conjugate $p, q$ and non-negative $a, b \\in \\mathbb{R}_{\\geq 0}^\\infty$: $ab \\leq a^p/p + b^q/q$. This is the *pointwise engine* of Hölder's inequality. The proof uses the concavity of $\\log$: $\\log(ab) = \\frac{1}{p}\\log(a^p) + \\frac{1}{q}\\log(b^q) \\leq \\log(a^p/p + b^q/q)$ by Jensen. Wraps `ENNReal.young_inequality`.",
+    "mathContext": "Young's inequality is a weighted AM-GM: $ab = (a^p)^{1/p}(b^q)^{1/q} \\leq \\frac{1}{p}a^p + \\frac{1}{q}b^q$ where $1/p + 1/q = 1$ are the weights. Equality holds iff $a^p = b^q$. The ENNReal version handles $\\infty$ gracefully: $\\infty \\cdot 0 = 0 \\leq \\infty$.",
+    "significance": "critical",
+    "relatedConcepts": ["Young's inequality", "weighted AM-GM", "concavity of log", "Jensen's inequality"],
+    "prerequisites": ["Real.HolderConjugate", "ENNReal.young_inequality"]
   },
   {
-    "lineStart": 116,
-    "lineEnd": 124,
-    "type": "insight",
-    "content": "**Cauchy-Schwarz from Hölder**:\n\nSetting $p = q = 2$ (which satisfies $1/2 + 1/2 = 1$) in Hölder gives:\n$$\\int f \\cdot g \\, d\\mu \\leq \\left(\\int f^2 \\, d\\mu\\right)^{1/2} \\cdot \\left(\\int g^2 \\, d\\mu\\right)^{1/2}$$\n\nThis is the integral Cauchy-Schwarz inequality, which makes $L^2(\\mu)$ into an inner product space via $\\langle f, g \\rangle = \\int fg \\, d\\mu$. It is the foundation of Hilbert space theory and Fourier analysis.",
-    "relatedConcepts": ["Cauchy-Schwarz", "L2 space", "inner product", "Hilbert space"]
+    "id": "ann-holder-lintegral",
+    "line": 94,
+    "type": "theorem",
+    "content": "**Hölder's inequality** (Lebesgue integral): For conjugate $p, q$ and non-negative measurable $f, g$: $\\int^- fg \\, d\\mu \\leq (\\int^- f^p \\, d\\mu)^{1/p} (\\int^- g^q \\, d\\mu)^{1/q}$. This is the central theorem of the file. The proof in Mathlib normalizes $f, g$ to unit $L^p/L^q$ norms, applies Young pointwise, and integrates: $\\int FG \\leq 1/p + 1/q = 1$.",
+    "mathContext": "Proof outline: (1) If $\\|f\\|_p = 0$ or $\\|g\\|_q = 0$, the product is a.e. zero and the inequality is trivial. (2) Otherwise, set $F = f/\\|f\\|_p$, $G = g/\\|g\\|_q$. Then $\\int F^p = 1$ and $\\int G^q = 1$. (3) Young: $F(x)G(x) \\leq F(x)^p/p + G(x)^q/q$ pointwise. (4) Integrate: $\\int FG \\leq 1/p + 1/q = 1$. (5) Scale back: $\\int fg = \\|f\\|_p \\|g\\|_q \\int FG \\leq \\|f\\|_p \\|g\\|_q$.",
+    "significance": "critical",
+    "relatedConcepts": ["Hölder inequality", "Lebesgue integral", "normalization trick", "Lp norm"],
+    "prerequisites": ["Real.HolderConjugate", "AEMeasurable", "ENNReal.lintegral_mul_le_Lp_mul_Lq"]
   },
   {
-    "lineStart": 140,
-    "lineEnd": 152,
-    "type": "insight",
-    "content": "**Minkowski's Inequality (Lp Triangle Inequality)**:\n\nFor $p \\geq 1$ and $f, g \\in L^p$:\n$$\\|f + g\\|_p \\leq \\|f\\|_p + \\|g\\|_p$$\n\nThis is the triangle inequality that makes $L^p$ a normed space (and, with completeness, a Banach space). The proof for $p > 1$ cleverly uses Hölder:\n$$\\|f+g\\|_p^p = \\int |f+g|^p \\leq \\int |f+g|^{p-1}|f| + \\int |f+g|^{p-1}|g|$$\nApply Hölder to each term with exponents $p$ and $q = p/(p-1)$, then divide by $\\|f+g\\|_p^{p/q}$.\n\nIn Mathlib, this is captured by `norm_add_le` on the `Lp E p μ` type.",
-    "relatedConcepts": ["Minkowski inequality", "triangle inequality", "Banach space", "Lp space"]
+    "id": "ann-holder-lebesgue",
+    "line": 103,
+    "type": "theorem",
+    "content": "**Hölder on $\\mathbb{R}$**: Specialization to the real line with Lebesgue measure (`volume`). One-line proof: `holder_lintegral volume hpq hf hg`. This is the classical setting for Fourier analysis and PDE theory, where $f, g : \\mathbb{R} \\to \\mathbb{R}_{\\geq 0}^\\infty$.",
+    "mathContext": "On $(\\mathbb{R}, \\text{Lebesgue})$: $\\int_\\mathbb{R} fg \\, dx \\leq \\|f\\|_{L^p(\\mathbb{R})} \\cdot \\|g\\|_{L^q(\\mathbb{R})}$. This is the form used in Fourier analysis ($\\int \\hat{f} g \\leq \\|\\hat{f}\\|_p \\|g\\|_q$) and Sobolev embedding theory.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lebesgue measure", "volume", "Fourier analysis", "Sobolev spaces"],
+    "prerequisites": ["holder_lintegral", "volume (Lebesgue measure on ℝ)"]
+  },
+  {
+    "id": "ann-cauchy-schwarz",
+    "line": 124,
+    "type": "theorem",
+    "content": "**Cauchy-Schwarz for Lebesgue integral**: Setting $p = q = 2$ in Hölder gives $\\int^- fg \\leq (\\int^- f^2)^{1/2}(\\int^- g^2)^{1/2}$. One-line proof composing `holder_lintegral` with `holderConj_two_two`. This makes $L^2(\\mu)$ an inner product space via $\\langle f, g \\rangle = \\int fg \\, d\\mu$, which is the foundation of Hilbert space theory.",
+    "mathContext": "The Cauchy-Schwarz inequality $|\\langle f, g \\rangle|^2 \\leq \\langle f, f \\rangle \\langle g, g \\rangle$ is the defining property of an inner product. For $L^2$: $\\langle f, g \\rangle = \\int fg$ and $\\|f\\|_2 = (\\int f^2)^{1/2}$. Equality holds iff $f = \\lambda g$ a.e. This is the starting point for orthogonal projections, Fourier series, and spectral theory.",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy-Schwarz", "inner product space", "L² space", "Hilbert space", "Fourier analysis"],
+    "prerequisites": ["holder_lintegral", "holderConj_two_two"]
+  },
+  {
+    "id": "ann-minkowski",
+    "line": 151,
+    "type": "theorem",
+    "content": "**Minkowski's inequality**: $\\|f + g\\|_p \\leq \\|f\\|_p + \\|g\\|_p$ for $p \\geq 1$. This is the triangle inequality making $L^p$ a normed space (Banach for $1 \\leq p \\leq \\infty$). The proof for $p > 1$ uses Hölder internally: expand $\\|f+g\\|_p^p$, split via triangle inequality, apply Hölder to each term with exponents $p$ and $q = p/(p-1)$, then divide. In Lean: `norm_add_le f g`.",
+    "mathContext": "The Hölder-based proof: $\\int|f+g|^p \\leq \\int|f+g|^{p-1}|f| + \\int|f+g|^{p-1}|g|$. Apply Hölder: $\\int|f+g|^{p-1}|f| \\leq \\||f+g|^{p-1}\\|_q \\|f\\|_p = \\|f+g\\|_p^{p/q} \\|f\\|_p$. Sum and divide by $\\|f+g\\|_p^{p/q}$, using $p - p/q = 1$. The case $p = 1$ is just the triangle inequality for integrals.",
+    "significance": "key",
+    "relatedConcepts": ["Minkowski inequality", "triangle inequality", "Banach space", "Lp completeness"],
+    "prerequisites": ["holder_lintegral", "norm_add_le", "MeasureTheory.Lp"]
+  },
+  {
+    "id": "ann-proper-holder",
+    "line": 179,
+    "type": "theorem",
+    "content": "**Proper Hölder statement**: Replaces the `True` placeholder in `LebesgueMeasure.lean`. The original placeholder was `theorem holder_inequality_statement ... : True := by trivial`. This theorem provides the real content: $\\int^- fg \\leq (\\int^- f^p)^{1/p}(\\int^- g^q)^{1/q}$ with proper Real exponents and the `HolderConjugate` condition.",
+    "mathContext": "The key difficulty was bridging exponent types: the original placeholder used `ENNReal` exponents ($p, q : \\mathbb{R}_{\\geq 0}^\\infty$) while Mathlib's Hölder uses `Real.HolderConjugate` ($p, q : \\mathbb{R}$ with $p > 1$). This theorem uses the Real convention, which is the natural one since the conjugate condition $1/p + 1/q = 1$ involves division.",
+    "significance": "key",
+    "relatedConcepts": ["placeholder replacement", "ENNReal vs Real exponents", "parent proof integration"],
+    "prerequisites": ["ENNReal.lintegral_mul_le_Lp_mul_Lq", "Real.HolderConjugate"]
+  },
+  {
+    "id": "ann-l2-inner-product",
+    "line": 207,
+    "type": "concept",
+    "content": "**$L^2$ as inner product space**: Lean's type class inference verifies that `Lp ℝ 2 μ` is an `InnerProductSpace ℝ` via `inferInstance`. This means Mathlib has already registered the instance: the inner product $\\langle f, g \\rangle = \\int fg \\, d\\mu$ satisfies all axioms (bilinearity, symmetry, positive-definiteness, Cauchy-Schwarz). The `noncomputable` keyword is needed because the inner product involves integration.",
+    "mathContext": "$L^2(\\mu)$ is simultaneously a Banach space (via Minkowski for $p=2$) and a Hilbert space (via the inner product). It is the unique $L^p$ space with this dual structure. The completeness of $L^2$ (Riesz-Fischer theorem) makes it the natural home for Fourier series, spectral theory, and quantum mechanics.",
+    "significance": "key",
+    "relatedConcepts": ["inner product space", "Hilbert space", "Riesz-Fischer theorem", "Fourier analysis", "inferInstance"],
+    "prerequisites": ["MeasureTheory.Lp", "InnerProductSpace", "cauchy_schwarz_lintegral"]
+  },
+  {
+    "id": "ann-lp-norm-nonneg",
+    "line": 219,
+    "type": "theorem",
+    "content": "**$L^p$ norm non-negativity**: $\\|f\\|_p \\geq 0$ for any $f \\in L^p$. Proved by `norm_nonneg f`, which is an axiom of normed spaces. While trivial, this completes the verification that the $L^p$ norm satisfies all norm axioms: non-negativity, definiteness ($\\|f\\| = 0 \\iff f = 0$ a.e.), homogeneity, and the triangle inequality (Minkowski).",
+    "mathContext": "The $L^p$ norm $\\|f\\|_p = (\\int |f|^p \\, d\\mu)^{1/p}$ is well-defined for $p \\geq 1$. Non-negativity follows from the non-negativity of the integral. Combined with Minkowski (triangle inequality) and Riesz-Fischer (completeness), this makes $L^p$ a Banach space for $1 \\leq p \\leq \\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": ["norm axioms", "Lp space", "Banach space", "norm_nonneg"],
+    "prerequisites": ["MeasureTheory.Lp", "norm_nonneg"]
   }
 ]

--- a/src/data/proofs/lebesgue-measure-oq-02/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "lebesgue-measure-oq-02",
   "title": "Hölder's Inequality for Lebesgue Integration",
   "slug": "lebesgue-measure-oq-02",
-  "description": "A complete formalization of Hölder's inequality in the measure-theoretic setting, replacing the placeholder in the parent Lebesgue Measure proof. Covers Young's inequality, the Lebesgue integral Hölder bound, Cauchy-Schwarz as the p=q=2 specialization, and Minkowski's inequality for Lp spaces.",
+  "description": "A complete formalization of Hölder's inequality in the measure-theoretic setting, replacing the placeholder in the parent Lebesgue Measure proof. Covers Young's inequality, the Lebesgue integral Hölder bound, Cauchy-Schwarz as the p=q=2 specialization, Minkowski's inequality for Lp spaces, and L² as an inner product space. 10 theorems, 0 sorries.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/H%C3%B6lder%27s_inequality",
@@ -36,18 +36,23 @@
       },
       {
         "theorem": "Real.HolderConjugate",
-        "description": "Definition of Hölder conjugate exponents: 1/p + 1/q = 1 with p, q > 1.",
+        "description": "Hölder conjugate exponents: 1/p + 1/q = 1 with p, q > 1.",
         "module": "Mathlib.Analysis.MeanInequalities"
       },
       {
         "theorem": "norm_add_le",
-        "description": "Minkowski's inequality on Lp spaces: ‖f+g‖ ≤ ‖f‖+‖g‖.",
-        "module": "Mathlib.MeasureTheory.Function.LpSpace.Basic"
+        "description": "Triangle inequality for normed spaces, instantiated on Lp to give Minkowski's inequality.",
+        "module": "Mathlib.Analysis.Normed.Group.Basic"
       },
       {
         "theorem": "Real.HolderConjugate.conjExponent",
         "description": "For p > 1, constructs the conjugate exponent q = p/(p-1).",
         "module": "Mathlib.Analysis.MeanInequalities"
+      },
+      {
+        "theorem": "InnerProductSpace (instance for Lp ℝ 2 μ)",
+        "description": "L² is an inner product space with ⟨f,g⟩ = ∫ fg dμ, verified by type class inference.",
+        "module": "Mathlib.MeasureTheory.Function.L2Space"
       }
     ],
     "originalContributions": [
@@ -64,7 +69,7 @@
         "title": "Ueber einen Mittelwerthssatz",
         "year": "1889",
         "venue": "Nachrichten von der Königlichen Gesellschaft der Wissenschaften zu Göttingen",
-        "note": "Original statement and proof of the inequality for finite sums"
+        "note": "Original statement and proof for finite sums, generalizing Cauchy-Schwarz to arbitrary conjugate exponents"
       },
       {
         "authors": "Frigyes Riesz",
@@ -79,76 +84,98 @@
         "year": "1896",
         "venue": "Teubner, Leipzig",
         "note": "The triangle inequality for Lp norms, proved using Hölder's inequality"
+      },
+      {
+        "authors": "William Henry Young",
+        "title": "On classes of summable functions and their Fourier series",
+        "year": "1912",
+        "venue": "Proceedings of the Royal Society of London",
+        "note": "Young's inequality ab ≤ a^p/p + b^q/q, the pointwise engine behind Hölder"
       }
     ],
-    "historicalContext": "Otto Hölder proved his inequality for finite sums in 1889, generalizing the Cauchy-Schwarz inequality (1821/1859) from the p=q=2 case to arbitrary conjugate exponents. Frigyes Riesz extended it to Lebesgue integrals in 1910, founding the theory of Lp spaces. The inequality is fundamental to functional analysis: it establishes the duality (Lp)* ≅ Lq and makes Lp spaces into Banach spaces via Minkowski's inequality."
+    "historicalContext": "Hölder's inequality is one of the central pillars of modern analysis. Cauchy (1821) proved the sum version for p=q=2 (Cauchy-Schwarz). Hölder (1889) generalized to arbitrary conjugate exponents 1/p + 1/q = 1. Riesz (1910) extended it to Lebesgue integrals, founding Lp space theory. Young (1912) isolated the pointwise inequality ab ≤ a^p/p + b^q/q that drives the proof. Minkowski (1896) used Hölder to prove the triangle inequality for Lp norms, making Lp into a Banach space. The inequality establishes the fundamental duality (Lp)* ≅ Lq (for 1 < p < ∞), which is the algebraic backbone of functional analysis, distribution theory, and Fourier analysis."
+  },
+  "overview": {
+    "historicalContext": "**Cauchy** (1821) proved $|\\sum a_i b_i|^2 \\leq \\sum a_i^2 \\cdot \\sum b_i^2$ for finite sums. **Schwarz** (1885) and **Bunyakovsky** (1859) extended this to integrals. **Hölder** (1889) generalized both to arbitrary conjugate exponents $1/p + 1/q = 1$, creating a family of inequalities parameterized by $p \\in (1, \\infty)$. **Young** (1912) isolated the pointwise inequality $ab \\leq a^p/p + b^q/q$ from the concavity of $\\log$, providing the cleanest proof. **Riesz** (1910) lifted Hölder to measure-theoretic integrals, founding $L^p$ space theory. **Minkowski** used Hölder to prove the $L^p$ triangle inequality, completing the normed space structure. The chain Young $\\to$ Hölder $\\to$ Minkowski is one of the most important deduction sequences in analysis.",
+    "problemStatement": "**Open Question #2** from the Lebesgue Measure gallery: Formalize Hölder's inequality $\\int fg \\, d\\mu \\leq \\|f\\|_p \\cdot \\|g\\|_q$ in the measure-theoretic setting, replacing the `True` placeholder in `LebesgueMeasure.lean`.",
+    "proofStrategy": "The formalization builds the Hölder tower in five stages: (1) Establish conjugate exponent pairs $(p,q)$ with $1/p + 1/q = 1$, including the $(2,2)$ Cauchy-Schwarz case. (2) State Young's inequality $ab \\leq a^p/p + b^q/q$ for ENNReal via Mathlib. (3) State Hölder for the Lebesgue integral $\\int^- fg \\leq (\\int^- f^p)^{1/p} (\\int^- g^q)^{1/q}$ via `lintegral_mul_le_Lp_mul_Lq`. (4) Specialize: Cauchy-Schwarz ($p=q=2$), Lebesgue measure on $\\mathbb{R}$. (5) Derive consequences: Minkowski's inequality (Lp triangle inequality), L² as inner product space.",
+    "keyInsights": [
+      "**Young's inequality as engine**: The entire Hölder proof reduces to integrating the pointwise bound $ab \\leq a^p/p + b^q/q$. After normalizing $f, g$ to unit $L^p, L^q$ norms, Young gives $\\int FG \\leq 1/p + 1/q = 1$. The conjugate condition $1/p + 1/q = 1$ is what makes the normalization work.",
+      "**Cauchy-Schwarz is Hölder at $p = q = 2$**: The pair $(2,2)$ satisfies $1/2 + 1/2 = 1$. Setting $p = q = 2$ in Hölder gives $\\int fg \\leq (\\int f^2)^{1/2}(\\int g^2)^{1/2}$, which is the integral Cauchy-Schwarz. This makes $L^2$ an inner product space and the natural home for Fourier analysis.",
+      "**Minkowski uses Hölder internally**: To prove $\\|f+g\\|_p \\leq \\|f\\|_p + \\|g\\|_p$, expand $\\|f+g\\|_p^p = \\int|f+g|^{p-1}|f+g|$, split, and apply Hölder to each term with exponents $p$ and $q = p/(p-1)$. The conjugate condition reappears when dividing by $\\|f+g\\|_p^{p/q}$.",
+      "**ENNReal vs Real exponents**: Mathlib's Hölder uses `Real.HolderConjugate` (requiring $p, q : \\mathbb{R}$ with $p > 1$), while $L^p$ spaces use `ℝ≥0∞` exponents. Bridging this gap requires careful type conversions, which this formalization handles.",
+      "**Zero sorries via delegation**: All 10 theorems are proved by delegating to Mathlib. The value is not in new proofs but in the organized presentation: Young $\\to$ Hölder $\\to$ Cauchy-Schwarz $\\to$ Minkowski, showing how one inequality generates the entire $L^p$ theory."
+    ],
+    "prerequisites": [
+      "Lebesgue measure and integration (lintegral)",
+      "Conjugate exponents (Real.HolderConjugate)",
+      "Lp spaces and their norms (MeasureTheory.Lp)",
+      "AEMeasurable functions",
+      "Parent proof: Lebesgue Measure"
+    ]
   },
   "sections": [
     {
       "id": "conjugate-exponents",
       "title": "Conjugate Exponents",
-      "summary": "Establishes Hölder conjugate pairs: 1/p + 1/q = 1 with p, q > 1. Proves the (2,2) pair for Cauchy-Schwarz and the general construction via conjExponent.",
+      "summary": "Establishes Hölder conjugate pairs: $1/p + 1/q = 1$ with $p, q > 1$. Proves the $(2,2)$ pair for Cauchy-Schwarz via `norm_num` and the general construction $q = p/(p-1)$ via `conjExponent`.",
       "startLine": 29,
-      "endLine": 43
+      "endLine": 50
     },
     {
       "id": "young-inequality",
       "title": "Young's Inequality",
-      "summary": "The pointwise foundation: ab ≤ a^p/p + b^q/q for conjugate p, q. Proved via weighted AM-GM / concavity of log. This is the building block integrated to get Hölder.",
-      "startLine": 45,
-      "endLine": 63
+      "summary": "The pointwise foundation: $ab \\leq a^p/p + b^q/q$ for conjugate $p, q$ and non-negative $a, b$. Proved via `ENNReal.young_inequality`. This is the building block that is normalized and integrated to get Hölder.",
+      "startLine": 52,
+      "endLine": 69
     },
     {
       "id": "holder-lintegral",
-      "title": "Hölder for Lebesgue Integral",
-      "summary": "The main inequality: ∫⁻ f·g dμ ≤ (∫⁻ f^p dμ)^(1/p) · (∫⁻ g^q dμ)^(1/q). General version for any measure space, plus specialization to Lebesgue measure on ℝ.",
-      "startLine": 65,
-      "endLine": 103
+      "title": "Hölder for the Lebesgue Integral",
+      "summary": "The main inequality: $\\int^- fg \\, d\\mu \\leq (\\int^- f^p \\, d\\mu)^{1/p} \\cdot (\\int^- g^q \\, d\\mu)^{1/q}$. General version for any measure space, plus specialization to Lebesgue measure on $\\mathbb{R}$ (`volume`).",
+      "startLine": 71,
+      "endLine": 108
     },
     {
       "id": "cauchy-schwarz",
       "title": "Cauchy-Schwarz Specialization",
-      "summary": "Setting p=q=2 in Hölder gives the integral Cauchy-Schwarz inequality, foundation of L² theory and Hilbert space methods.",
-      "startLine": 105,
-      "endLine": 124
+      "summary": "Setting $p = q = 2$ in Hölder gives $\\int^- fg \\leq (\\int^- f^2)^{1/2} (\\int^- g^2)^{1/2}$. One-line proof: `holder_lintegral μ holderConj_two_two hf hg`. Foundation of $L^2$ theory and Hilbert space methods.",
+      "startLine": 110,
+      "endLine": 129
     },
     {
       "id": "minkowski",
       "title": "Minkowski's Inequality",
-      "summary": "The triangle inequality for Lp norms: ‖f+g‖_p ≤ ‖f‖_p + ‖g‖_p. This makes Lp into a Banach space. The proof for p > 1 uses Hölder internally.",
-      "startLine": 126,
-      "endLine": 152
+      "summary": "Triangle inequality for $L^p$ norms: $\\|f+g\\|_p \\leq \\|f\\|_p + \\|g\\|_p$ for $p \\geq 1$. Makes $L^p$ into a Banach space. Proved via `norm_add_le` on the `Lp` type. The proof for $p > 1$ internally uses Hölder.",
+      "startLine": 131,
+      "endLine": 154
     },
     {
       "id": "proper-statement",
-      "title": "Replacing the Placeholder",
-      "summary": "The proper Hölder statement and proof that replaces the True placeholder in LebesgueMeasure.lean. Bridges ENNReal/Real exponent conventions.",
-      "startLine": 154,
-      "endLine": 194
+      "title": "The Proper Hölder Statement",
+      "summary": "Replaces the `True` placeholder in `LebesgueMeasure.lean` with the real theorem. Bridges the ENNReal/Real exponent conventions. Also states the $L^p$ norm version via the Bochner integral.",
+      "startLine": 156,
+      "endLine": 197
     },
     {
       "id": "applications",
-      "title": "Applications",
-      "summary": "L² as an inner product space (setting for Fourier analysis), Lp norm non-negativity, and the role of Hölder in functional analysis.",
-      "startLine": 196,
-      "endLine": 218
+      "title": "Applications: L² and Norm Properties",
+      "summary": "$L^2(\\mu)$ is an inner product space (verified by `inferInstance`). The inner product $\\langle f, g \\rangle = \\int fg \\, d\\mu$ satisfies Cauchy-Schwarz automatically. Also: $L^p$ norm is non-negative (from `norm_nonneg`).",
+      "startLine": 199,
+      "endLine": 224
     }
   ],
-  "overview": {
-    "summary": "Hölder's inequality is one of the most important inequalities in analysis, generalizing Cauchy-Schwarz to arbitrary Lp spaces. For conjugate exponents p, q (1/p + 1/q = 1), it bounds the integral of a product: ∫ f·g ≤ ‖f‖_p · ‖g‖_q. This file provides a complete formalization replacing the True placeholder in the parent Lebesgue Measure proof.",
-    "keyIdea": "Hölder's inequality follows from Young's pointwise estimate ab ≤ a^p/p + b^q/q by normalizing and integrating. The conjugate condition 1/p + 1/q = 1 emerges naturally from the normalization step.",
-    "prerequisites": [
-      "Lebesgue measure and integration",
-      "Conjugate exponents (1/p + 1/q = 1)",
-      "Lp spaces and their norms",
-      "Young's inequality"
-    ]
-  },
   "conclusion": {
-    "summary": "We have replaced the True placeholder for Hölder's inequality in LebesgueMeasure.lean with a complete formalization. The proof chain Young → Hölder → Cauchy-Schwarz → Minkowski demonstrates the central role of Hölder's inequality in functional analysis. All 10 theorems are proved with zero sorries.",
+    "summary": "Complete formalization of the Hölder inequality tower: Young → Hölder → Cauchy-Schwarz → Minkowski, with 10 theorems and 0 sorries. All proofs delegate to Mathlib, with the value in the organized presentation showing how one pointwise inequality (Young) generates the entire Lp space theory. Replaces the True placeholder in the parent Lebesgue Measure proof.",
+    "implications": "Hölder's inequality is the algebraic engine of functional analysis. This formalization makes the complete chain available in Lean 4: from the pointwise Young's inequality through the integral Hölder bound to the Lp Banach space structure (via Minkowski) and L² Hilbert space structure (via Cauchy-Schwarz). The duality (Lp)* ≅ Lq, which follows from Hölder, is the foundation of distribution theory and the Hahn-Banach theorem in Lp spaces.",
     "openQuestions": [
-      "Can the sharp constant in Hölder's inequality be characterized for specific function classes?",
-      "Can the Riesz representation theorem (Lp)* ≅ Lq be formalized as a consequence?"
+      "Can the sharp constant in Hölder's inequality be characterized for specific function classes (e.g., on finite measure spaces)?",
+      "Can the Riesz representation theorem $(L^p)^* \\cong L^q$ be formalized as a consequence of the Hölder inequality proved here?",
+      "Can the weak-type Hölder inequality (Marcinkiewicz interpolation) be formalized to extend the theory to weak Lp spaces?"
+    ],
+    "crossReferences": [
+      { "proofId": "lebesgue-measure", "relationship": "Parent proof — this resolves Open Question #2 (Hölder's inequality placeholder)." },
+      { "proofId": "cauchy-schwarz-integral-oq-01-oq-01", "relationship": "Related — Cauchy-Schwarz for Lp norms (Hölder eLpNorm), proved independently." }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Added `proofStrategy` (5-stage Hölder tower) and 5 `keyInsights` to overview
- Deepened `historicalContext` with Cauchy, Schwarz, Bunyakovsky, Young, Riesz, Minkowski timeline
- Added Young (1912) reference
- Expanded `mathlibDependencies` from 5 to 6 (added L2Space instance)
- Rebuilt annotations from 5 (non-standard `lineStart/lineEnd`, non-standard types) to 10 with standard `line` format
- Added annotations for: general conjugate construction, Hölder on ℝ, proper Hölder statement, L² inner product, Lp norm non-negativity
- All annotations have full mathContext, significance, relatedConcepts, prerequisites
- Added cross-references to parent proof and cauchy-schwarz-integral-oq-01-oq-01

## Test plan
- [x] `pnpm annotations:build` passes with no errors for lebesgue-measure-oq-02

🤖 Generated with [Claude Code](https://claude.com/claude-code)