### PR TITLE
Enrich Dirichlet Function Integral (lebesgue-measure-oq-01): deepen overview and annotations

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-01/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-01/annotations.json
@@ -1,39 +1,82 @@
 [
   {
-    "lineStart": 43,
-    "lineEnd": 50,
-    "type": "insight",
-    "content": "**Countable Sets Have Measure Zero**:\n\nThe rationals ℚ, despite being dense in ℝ (between any two reals lies a rational), have Lebesgue measure zero. This is because ℚ is countable: we can list all rationals as $q_1, q_2, \\ldots$ and cover each $q_n$ with an interval of length $\\varepsilon/2^n$. The total covering has measure $\\leq \\varepsilon$, and since $\\varepsilon$ is arbitrary, the measure is 0.\n\nMathlib packages this as `Set.Countable.measure_zero`, which applies to any countable set under any atomless measure.",
-    "relatedConcepts": ["countable sets", "measure zero", "Lebesgue measure", "dense sets"]
+    "id": "ann-rationals-countable",
+    "line": 44,
+    "type": "theorem",
+    "content": "**Rationals are countable**: The image of $\\mathbb{Q}$ in $\\mathbb{R}$ via `Rat.cast` is a countable set. Proved by `Set.countable_range`, which uses the fact that $\\mathbb{Q}$ is countable (a bijection with $\\mathbb{Z} \\times \\mathbb{Z}$ exists). This is the starting point of the proof chain: countable $\\Rightarrow$ measure zero $\\Rightarrow$ ae zero $\\Rightarrow$ integral zero.",
+    "mathContext": "$\\mathbb{Q}$ is countable despite being dense in $\\mathbb{R}$. This paradox — a dense set can have measure zero — is fundamental to measure theory. The proof: list rationals as $p/q$ for $p \\in \\mathbb{Z}, q \\in \\mathbb{N}^+$, giving a surjection from $\\mathbb{Z} \\times \\mathbb{N}^+ \\to \\mathbb{Q}$. Since $\\mathbb{Z} \\times \\mathbb{N}^+$ is countable, so is $\\mathbb{Q}$.",
+    "significance": "key",
+    "relatedConcepts": ["countable sets", "Set.countable_range", "Cantor's diagonal argument"],
+    "prerequisites": ["Rat.cast", "Set.range"]
   },
   {
-    "lineStart": 62,
-    "lineEnd": 77,
+    "id": "ann-rationals-measure-zero",
+    "line": 48,
+    "type": "theorem",
+    "content": "**Rationals have measure zero**: $\\text{volume}(\\mathbb{Q}) = 0$ in $\\mathbb{R}$. The proof is one line: `rationals_countable.measure_zero volume`. The underlying argument: cover each $q_n$ with an interval of length $\\varepsilon/2^n$; total measure $\\leq \\varepsilon \\sum 2^{-n} = \\varepsilon$; take $\\varepsilon \\to 0$.",
+    "mathContext": "For any countable set $S = \\{s_1, s_2, \\ldots\\}$ and atomless measure $\\mu$: $\\mu(S) \\leq \\sum_{n=1}^\\infty \\mu(\\{s_n\\}) = 0$ since singletons have measure zero in atomless measures. This applies to Lebesgue measure, which is the unique translation-invariant Borel measure on $\\mathbb{R}$ with $\\lambda([0,1]) = 1$.",
+    "significance": "critical",
+    "relatedConcepts": ["measure zero", "Lebesgue measure", "countable sets", "atomless measure"],
+    "prerequisites": ["rationals_countable", "Set.Countable.measure_zero"]
+  },
+  {
+    "id": "ann-dirichlet-def",
+    "line": 64,
     "type": "definition",
-    "content": "**The Dirichlet Function**:\n\nDefined as $\\mathbf{1}_{\\mathbb{Q}}(x)$, the indicator (characteristic) function of the rationals:\n$$f(x) = \\begin{cases} 1 & \\text{if } x \\in \\mathbb{Q} \\\\ 0 & \\text{if } x \\notin \\mathbb{Q} \\end{cases}$$\n\nThis function is the canonical example of a bounded function that is not Riemann integrable. Since both ℚ and ℝ\\ℚ are dense in ℝ, every interval contains both rationals and irrationals, so the upper Darboux sum is always 1 and the lower sum always 0.",
-    "relatedConcepts": ["indicator function", "Dirichlet function", "Riemann integrability", "dense sets"],
-    "mathContext": "Dirichlet function $\\mathbf{1}_{\\mathbb{Q}}$: the simplest example of a non-Riemann-integrable function"
+    "content": "**Dirichlet function**: Defined as `Set.indicator (Set.range Rat.cast) (fun _ => 1)`, the indicator of $\\mathbb{Q}$ in $\\mathbb{R}$. Equals 1 on rationals, 0 on irrationals. This is the canonical example of a bounded function that is not Riemann integrable: every interval contains both values, so upper Darboux sum = 1 and lower = 0 on any partition.",
+    "mathContext": "$$\\mathbf{1}_{\\mathbb{Q}}(x) = \\begin{cases} 1 & x \\in \\mathbb{Q} \\\\ 0 & x \\notin \\mathbb{Q} \\end{cases}$$\nThe function is bounded ($0 \\leq f \\leq 1$) but its oscillation $\\omega(f, I) = 1$ on every interval $I$, making every point a discontinuity. By Lebesgue's criterion (1901), $f$ is not Riemann integrable since its discontinuity set (all of $\\mathbb{R}$) has positive measure.",
+    "significance": "critical",
+    "relatedConcepts": ["indicator function", "Dirichlet function", "Riemann integrability", "Darboux sums", "oscillation"],
+    "prerequisites": ["Set.indicator", "Set.range", "Rat.cast"]
   },
   {
-    "lineStart": 86,
-    "lineEnd": 90,
-    "type": "technique",
-    "content": "**The ae Filter and compl_mem_ae_iff**:\n\nThe almost everywhere (ae) filter captures properties that hold outside a measure-zero set. The key lemma `compl_mem_ae_iff` states:\n$$S^c \\in \\text{ae}(\\mu) \\iff \\mu(S) = 0$$\n\nSo from `volume(ℚ) = 0` we get `ℚᶜ ∈ ae(volume)`, meaning 'for almost every x, x ∉ ℚ'. Combined with `filter_upwards`, this gives us: for a.e. x, the indicator $\\mathbf{1}_{\\mathbb{Q}}(x) = 0$.",
-    "relatedConcepts": ["ae filter", "compl_mem_ae_iff", "filter_upwards", "measure zero"],
-    "mathContext": "compl_mem_ae_iff bridges measure zero and almost everywhere"
+    "id": "ann-ae-zero",
+    "line": 86,
+    "type": "theorem",
+    "content": "**Dirichlet function is zero a.e.**: $\\forall^\\mu x, \\mathbf{1}_{\\mathbb{Q}}(x) = 0$. The proof uses `compl_mem_ae_iff.mpr` to convert '$\\mathbb{Q}$ has measure zero' into '$\\mathbb{Q}^c$ is in the ae filter,' then `filter_upwards` to get: for a.e. $x$, $x \\notin \\mathbb{Q}$, hence $\\mathbf{1}_{\\mathbb{Q}}(x) = 0$. This is the crucial bridge between measure theory and integration.",
+    "mathContext": "The `ae` filter on a measure space $(X, \\mu)$ consists of all sets whose complement has measure zero: $S \\in \\text{ae}(\\mu) \\iff \\mu(S^c) = 0$. The lemma `compl_mem_ae_iff` gives the equivalence $S^c \\in \\text{ae} \\iff \\mu(S) = 0$. With `filter_upwards`, one can work with ae properties as if they hold everywhere.",
+    "significance": "critical",
+    "relatedConcepts": ["ae filter", "compl_mem_ae_iff", "filter_upwards", "almost everywhere"],
+    "prerequisites": ["rationals_measure_zero", "compl_mem_ae_iff", "Set.indicator_of_notMem"]
   },
   {
-    "lineStart": 113,
-    "lineEnd": 117,
-    "type": "keyStep",
-    "content": "**The Main Proof: integral_eq_zero_of_ae**:\n\nThe entire proof chain is remarkably short:\n1. `rationals_measure_zero`: $\\mu(\\mathbb{Q}) = 0$\n2. `compl_mem_ae_iff.mpr`: $\\mathbb{Q}^c \\in \\text{ae}(\\mu)$\n3. `filter_upwards`: for a.e. $x$, $\\mathbf{1}_{\\mathbb{Q}}(x) = 0$\n4. `ae_restrict_of_ae`: same holds for $\\mu|_{[0,1]}$\n5. `integral_eq_zero_of_ae`: therefore $\\int_{[0,1]} \\mathbf{1}_{\\mathbb{Q}} = 0$\n\nThis resolves the axiom `dirichlet_integral_zero` from the parent Lebesgue Measure proof.",
-    "relatedConcepts": ["integral_eq_zero_of_ae", "ae_restrict_of_ae", "axiom elimination"]
+    "id": "ann-ae-restrict",
+    "line": 93,
+    "type": "theorem",
+    "content": "**Restriction to $[0,1]$**: The ae-zero property passes from the full measure to the restricted measure $\\mu|_{[0,1]}$ via `ae_restrict_of_ae`. This is needed because the main theorem integrates over $[0,1]$, not all of $\\mathbb{R}$. The proof is one line: `ae_restrict_of_ae` applied to `dirichletFunction_ae_zero`.",
+    "mathContext": "If $P$ holds $\\mu$-a.e. on $X$, then $P$ holds $\\mu|_S$-a.e. for any measurable $S \\subseteq X$. This is because $\\mu|_S(A) = \\mu(A \\cap S) \\leq \\mu(A)$, so null sets for $\\mu$ remain null for $\\mu|_S$.",
+    "significance": "supporting",
+    "relatedConcepts": ["measure restriction", "ae_restrict_of_ae", "Icc"],
+    "prerequisites": ["dirichletFunction_ae_zero", "ae_restrict_of_ae"]
   },
   {
-    "lineStart": 148,
-    "lineEnd": 195,
-    "type": "insight",
-    "content": "**Nowhere Continuous via Measure Theory**:\n\nThe Dirichlet function is discontinuous at every point. The proof uses a measure-theoretic argument:\n\n- **At rationals**: If $x \\in \\mathbb{Q}$, then $f(x) = 1$. Any ball $B(x, \\delta)$ has positive measure ($2\\delta > 0$), but $\\mathbb{Q}$ has measure zero, so $B(x,\\delta) \\not\\subseteq \\mathbb{Q}$. Thus there exists an irrational $y$ near $x$ with $f(y) = 0$, giving $|f(x) - f(y)| = 1$.\n\n- **At irrationals**: If $x \\notin \\mathbb{Q}$, then $f(x) = 0$. By density of $\\mathbb{Q}$ (via `exists_rat_near`), every ball contains a rational $y$ with $f(y) = 1$, giving $|f(x) - f(y)| = 1$.\n\nBy Lebesgue's criterion, a bounded function is Riemann integrable iff its discontinuity set has measure zero. Since the Dirichlet function is discontinuous everywhere, it is not Riemann integrable.",
-    "relatedConcepts": ["continuity", "density of rationals", "Lebesgue criterion", "Riemann integrability"]
+    "id": "ann-main-theorem",
+    "line": 113,
+    "type": "theorem",
+    "content": "**Main theorem**: $\\int_{[0,1]} \\mathbf{1}_{\\mathbb{Q}} \\, d\\lambda = 0$. The proof applies `integral_eq_zero_of_ae` to `dirichletFunction_ae_zero_restrict`. This resolves the axiom `dirichlet_integral_zero` from the parent `LebesgueMeasure.lean`. The 3-step chain (countable $\\to$ null $\\to$ ae zero $\\to$ integral zero) is remarkably short for such a historically significant result.",
+    "mathContext": "`integral_eq_zero_of_ae` states: if $f = 0$ $\\mu$-a.e., then $\\int f \\, d\\mu = 0$. This is the Bochner integral version; for the Lebesgue integral (`lintegral`), the analogous result is `lintegral_eq_zero_iff`. The theorem answers Lebesgue's original motivating question: what is $\\int_0^1 \\mathbf{1}_{\\mathbb{Q}}$?",
+    "significance": "critical",
+    "relatedConcepts": ["integral_eq_zero_of_ae", "Bochner integral", "axiom elimination", "Lebesgue integral"],
+    "prerequisites": ["dirichletFunction_ae_zero_restrict", "integral_eq_zero_of_ae"]
+  },
+  {
+    "id": "ann-extension-any-set",
+    "line": 129,
+    "type": "theorem",
+    "content": "**Extension to arbitrary sets**: $\\int_S \\mathbf{1}_{\\mathbb{Q}} = 0$ for any set $S \\subseteq \\mathbb{R}$. The proof is the same pattern: `ae_restrict_of_ae` then `integral_eq_zero_of_ae`. This shows the result is not special to $[0,1]$ — the Dirichlet function integrates to zero over any subset of $\\mathbb{R}$.",
+    "mathContext": "For any measurable $S$: $\\int_S \\mathbf{1}_{\\mathbb{Q}} = \\int \\mathbf{1}_{\\mathbb{Q}} \\cdot \\mathbf{1}_S = \\int 0 = 0$ since $\\mathbf{1}_{\\mathbb{Q}} = 0$ a.e. implies $\\mathbf{1}_{\\mathbb{Q}} \\cdot \\mathbf{1}_S = 0$ a.e.",
+    "significance": "supporting",
+    "relatedConcepts": ["measure restriction", "integral over subsets", "generalization"],
+    "prerequisites": ["dirichletFunction_ae_zero", "ae_restrict_of_ae"]
+  },
+  {
+    "id": "ann-nowhere-continuous",
+    "line": 148,
+    "type": "theorem",
+    "content": "**Nowhere continuous**: $\\mathbf{1}_{\\mathbb{Q}}$ is discontinuous at every $x \\in \\mathbb{R}$. The proof splits into two cases using measure-theoretic and density arguments:\n\n**At rationals** ($f(x) = 1$): Any ball $B(x, \\delta)$ has positive measure ($2\\delta$ by `Real.volume_ball`) but $\\mathbb{Q}$ has measure zero, so $B(x,\\delta) \\not\\subseteq \\mathbb{Q}$. Hence $\\exists$ irrational $y$ near $x$ with $|f(x) - f(y)| = 1$.\n\n**At irrationals** ($f(x) = 0$): By `exists_rat_near`, every ball contains a rational $y$ with $f(y) = 1$, giving $|f(x) - f(y)| = 1$.",
+    "mathContext": "By Lebesgue's criterion (1901): a bounded $f : [a,b] \\to \\mathbb{R}$ is Riemann integrable $\\iff$ the set of discontinuities has measure zero. Since $\\mathbf{1}_{\\mathbb{Q}}$ is discontinuous everywhere, its discontinuity set is $\\mathbb{R}$ (measure $\\infty$), confirming non-Riemann-integrability. But it is Lebesgue integrable since it is bounded and measurable.",
+    "significance": "key",
+    "relatedConcepts": ["continuity", "density of rationals", "Lebesgue criterion", "Riemann integrability", "Real.volume_ball"],
+    "prerequisites": ["Metric.continuousAt_iff", "rationals_measure_zero", "exists_rat_near", "Real.volume_ball"]
   }
 ]

--- a/src/data/proofs/lebesgue-measure-oq-01/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01/meta.json
@@ -29,7 +29,7 @@
       },
       {
         "theorem": "Set.Countable.measure_zero",
-        "description": "Countable sets have measure zero w.r.t. any atomless measure.",
+        "description": "Countable sets have measure zero w.r.t. any atomless measure (e.g., Lebesgue measure).",
         "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Basic"
       },
       {
@@ -49,13 +49,13 @@
       },
       {
         "theorem": "exists_rat_near",
-        "description": "For any x ∈ ℝ and ε > 0, there exists q ∈ ℚ with |x - q| < ε.",
+        "description": "For any x ∈ ℝ and ε > 0, there exists q ∈ ℚ with |x - q| < ε (density of ℚ).",
         "module": "Mathlib.Data.Rat.Dense"
       }
     ],
     "originalContributions": [
       "Complete proof that ∫₀¹ 𝟙_ℚ = 0, replacing the axiom in LebesgueMeasure.lean",
-      "Proof that the Dirichlet function is zero a.e. via compl_mem_ae_iff and Q measure zero",
+      "Proof that the Dirichlet function is zero a.e. via compl_mem_ae_iff and ℚ measure zero",
       "Extension: integral is zero over any measurable set, not just [0,1]",
       "Proof that the Dirichlet function is nowhere continuous (discontinuous at every point)"
     ],
@@ -73,60 +73,82 @@
         "year": "1829",
         "venue": "Journal für die reine und angewandte Mathematik",
         "note": "Original introduction of the everywhere-discontinuous indicator function"
+      },
+      {
+        "authors": "Bernhard Riemann",
+        "title": "Über die Darstellbarkeit einer Function durch eine trigonometrische Reihe",
+        "year": "1854",
+        "venue": "Habilitationsschrift, Göttingen (published 1867)",
+        "note": "Formulated the Riemann integral, under which the Dirichlet function is not integrable"
       }
     ],
-    "historicalContext": "Peter Gustav Lejeune Dirichlet introduced his indicator function 𝟙_ℚ in 1829 as an example of a function that cannot be integrated by Riemann's method: the upper Darboux sum is always 1 and the lower sum always 0 on any interval, since both rationals and irrationals are dense. Henri Lebesgue's 1902 integral resolved this by measuring the range rather than the domain — since ℚ has measure zero, the function equals zero almost everywhere, yielding ∫₀¹ 𝟙_ℚ = 0. This example is a cornerstone of measure theory pedagogy, demonstrating that Lebesgue's integral strictly extends Riemann's."
+    "historicalContext": "Peter Gustav Lejeune Dirichlet introduced his indicator function 𝟙_ℚ in 1829 as an example of a function that cannot be integrated by Riemann's method: the upper Darboux sum is always 1 and the lower sum always 0 on any interval, since both rationals and irrationals are dense. This exposed a fundamental limitation of Riemann's 1854 integral. Henri Lebesgue's 1902 integral resolved this by measuring the range rather than the domain — since ℚ is countable and hence has Lebesgue measure zero, the function equals zero almost everywhere, yielding ∫₀¹ 𝟙_ℚ = 0. Lebesgue's criterion (1901) later gave a complete characterization: a bounded function is Riemann integrable iff its discontinuity set has measure zero. Since the Dirichlet function is discontinuous everywhere, it is not Riemann integrable — but it is Lebesgue integrable."
+  },
+  "overview": {
+    "historicalContext": "**Dirichlet** (1829) introduced $\\mathbf{1}_{\\mathbb{Q}}$ to show that not all functions are representable by Fourier series, and it later became the canonical counterexample to Riemann integrability. **Riemann** (1854) formalized his integral, under which $\\mathbf{1}_{\\mathbb{Q}}$ fails: the upper Darboux sum is 1 and the lower is 0 on every subinterval, since both $\\mathbb{Q}$ and $\\mathbb{R} \\setminus \\mathbb{Q}$ are dense. **Lebesgue** (1902) resolved this with his measure-theoretic integral: since $\\mathbb{Q}$ is countable (hence measure zero), $\\mathbf{1}_{\\mathbb{Q}} = 0$ almost everywhere, giving $\\int_0^1 \\mathbf{1}_{\\mathbb{Q}} = 0$. This example demonstrates the strict superiority of Lebesgue's integral over Riemann's.",
+    "problemStatement": "**Open Question #1** from the Lebesgue Measure gallery: Can the axiom `dirichlet_integral_zero` be replaced by a full proof using Mathlib's `integral_eq_zero_of_ae` and the countability of $\\mathbb{Q}$?",
+    "proofStrategy": "The proof follows a clean 3-step chain: (1) $\\mathbb{Q}$ is countable ($\\Rightarrow$ `Set.countable_range`), hence has Lebesgue measure zero ($\\Rightarrow$ `Countable.measure_zero`). (2) Convert measure zero to almost everywhere via `compl_mem_ae_iff`: since $\\mu(\\mathbb{Q}) = 0$, for a.e. $x$, $x \\notin \\mathbb{Q}$, so $\\mathbf{1}_{\\mathbb{Q}}(x) = 0$. (3) Apply `integral_eq_zero_of_ae`: a function that is zero a.e. has integral zero. Extensions: generalize to arbitrary sets via `ae_restrict_of_ae`, and prove nowhere continuity via measure-theoretic arguments (balls have positive measure but $\\mathbb{Q}$ has measure zero).",
+    "keyInsights": [
+      "**Countable $\\Rightarrow$ measure zero $\\Rightarrow$ ae zero $\\Rightarrow$ integral zero**: The entire proof is a 3-step logical chain. Each step uses one Mathlib lemma: `Countable.measure_zero`, `compl_mem_ae_iff`, `integral_eq_zero_of_ae`. The remarkable brevity (3 lines of proof) contrasts with the historical difficulty of the problem.",
+      "**The ae filter as bridge**: Mathlib's `ae` filter connects measure theory (sets of measure zero) to integration (functions equal a.e.). The key lemma `compl_mem_ae_iff` translates '$\\mathbb{Q}$ has measure zero' into 'for a.e. $x$, $x \\notin \\mathbb{Q}$,' which is the form needed for `integral_eq_zero_of_ae`.",
+      "**Nowhere continuity via positive measure**: The discontinuity proof at rational points uses a measure-theoretic argument rather than explicit construction: any ball $B(x, \\delta)$ has positive Lebesgue measure ($2\\delta > 0$) while $\\mathbb{Q}$ has measure zero, so the ball cannot be contained in $\\mathbb{Q}$ — hence contains an irrational.",
+      "**Density of $\\mathbb{Q}$ for the irrational case**: Discontinuity at irrational points uses `exists_rat_near`: for any $\\varepsilon > 0$, there exists $q \\in \\mathbb{Q}$ with $|x - q| < \\varepsilon$. This is the density of $\\mathbb{Q}$ in $\\mathbb{R}$, complementary to the measure-zero property.",
+      "**Extension to arbitrary sets is free**: Once $\\mathbf{1}_{\\mathbb{Q}} = 0$ a.e. is established for the full measure, restriction to any subset preserves the property via `ae_restrict_of_ae`. The integral is zero over $[0,1]$, over $[0, 100]$, over any Borel set, and over all of $\\mathbb{R}$."
+    ],
+    "prerequisites": [
+      "Lebesgue measure (volume) on ℝ",
+      "Countability of ℚ",
+      "Almost everywhere (ae) filter",
+      "Bochner integral (integral_eq_zero_of_ae)",
+      "Parent proof: Lebesgue Measure"
+    ]
   },
   "sections": [
     {
       "id": "measure-zero",
       "title": "Measure Zero Properties",
-      "summary": "Establishes that ℚ is countable and therefore has Lebesgue measure zero in ℝ. Also proves a general principle that subsets of null sets have measure zero.",
+      "summary": "Establishes that $\\mathbb{Q}$ embedded in $\\mathbb{R}$ is countable (`Set.countable_range`) and hence has Lebesgue measure zero (`Countable.measure_zero`). Also proves the monotonicity principle: subsets of null sets are null.",
       "startLine": 39,
       "endLine": 56
     },
     {
       "id": "dirichlet-function",
       "title": "The Dirichlet Function",
-      "summary": "Defines the Dirichlet function as Set.indicator of the rationals, with characterization lemmas: it equals 1 on ℚ and 0 on irrationals.",
+      "summary": "Defines $\\mathbf{1}_{\\mathbb{Q}} : \\mathbb{R} \\to \\mathbb{R}$ as `Set.indicator` of $\\text{range}(\\text{Rat.cast})$ with constant value 1. Characterization lemmas: equals 1 on rationals (`indicator_of_mem`) and 0 on irrationals (`indicator_of_notMem`).",
       "startLine": 58,
       "endLine": 77
     },
     {
       "id": "almost-everywhere",
       "title": "Almost Everywhere Zero",
-      "summary": "The core technical result: the Dirichlet function is zero almost everywhere, using compl_mem_ae_iff to convert 'ℚ has measure zero' into 'ℚᶜ is in the ae filter'. Also derives the restricted version for [0,1].",
+      "summary": "The core technical result: $\\mathbf{1}_{\\mathbb{Q}} = 0$ a.e. via `compl_mem_ae_iff.mpr` (converts $\\mu(\\mathbb{Q}) = 0$ to $\\mathbb{Q}^c \\in \\text{ae}$) and `filter_upwards`. Restricted version for $[0,1]$ via `ae_restrict_of_ae`.",
       "startLine": 79,
       "endLine": 96
     },
     {
       "id": "main-theorem",
-      "title": "The Main Theorem",
-      "summary": "Proves ∫ x in [0,1], 𝟙_ℚ(x) = 0 by applying integral_eq_zero_of_ae to the a.e. zero result. This resolves the axiom dirichlet_integral_zero from the parent LebesgueMeasure proof.",
+      "title": "The Main Theorem: $\\int_0^1 \\mathbf{1}_{\\mathbb{Q}} = 0$",
+      "summary": "Applies `integral_eq_zero_of_ae` to the a.e.-zero result. This resolves the axiom `dirichlet_integral_zero` from the parent proof. Two equivalent formulations: one using the raw indicator, one using the named `dirichletFunction`.",
       "startLine": 98,
       "endLine": 122
     },
     {
       "id": "extensions",
-      "title": "Extensions",
-      "summary": "Extends the integral-zero result to arbitrary sets and all of ℝ. Proves the Dirichlet function is nowhere continuous using measure-theoretic arguments: any ball contains irrationals (by positive measure vs ℚ measure zero) and rationals (by density of ℚ).",
+      "title": "Extensions and Nowhere Continuity",
+      "summary": "Generalizes to arbitrary sets and all of $\\mathbb{R}$. Proves `dirichletFunction_not_continuous_at` for every $x \\in \\mathbb{R}$: at rationals, balls contain irrationals (by positive measure vs null $\\mathbb{Q}$); at irrationals, balls contain rationals (by `exists_rat_near`). Each case shows $|f(x) - f(y)| = 1$ for nearby $y$.",
       "startLine": 124,
       "endLine": 197
     }
   ],
-  "overview": {
-    "summary": "The Dirichlet function 𝟙_ℚ assigns 1 to every rational and 0 to every irrational. Despite being discontinuous at every point (making Riemann integration impossible), its Lebesgue integral over [0,1] is simply 0. The proof exploits the fundamental measure-theoretic fact that ℚ has Lebesgue measure zero: the set where 𝟙_ℚ ≠ 0 is negligible, so the integral vanishes.",
-    "keyIdea": "Since ℚ is countable, it has Lebesgue measure zero. Therefore 𝟙_ℚ = 0 almost everywhere, and integral_eq_zero_of_ae gives ∫₀¹ 𝟙_ℚ = 0.",
-    "prerequisites": [
-      "Lebesgue measure and integration",
-      "Countable sets and measure zero",
-      "Almost everywhere (ae) filter in Mathlib"
-    ]
-  },
   "conclusion": {
-    "summary": "We have completely resolved the axiom dirichlet_integral_zero from the parent Lebesgue Measure proof, replacing it with a 3-line proof chain: ℚ countable → ℚ measure zero → 𝟙_ℚ = 0 a.e. → ∫ 𝟙_ℚ = 0. The proof extends naturally to any set and also establishes the classical result that the Dirichlet function is discontinuous everywhere.",
+    "summary": "Complete resolution of the axiom dirichlet_integral_zero from the parent Lebesgue Measure proof, via the 3-step chain: ℚ countable → ℚ measure zero → 𝟙_ℚ = 0 a.e. → ∫ 𝟙_ℚ = 0. The proof extends to arbitrary sets and also establishes the classical result that the Dirichlet function is discontinuous at every point of ℝ. All proofs are complete with 0 sorries.",
+    "implications": "This formalization demonstrates the power of Lebesgue's integral over Riemann's: a function that is completely intractable for Riemann (oscillating between 0 and 1 at every scale) becomes trivially integrable via measure theory. The 3-line proof chain (countable → null → ae zero → integral zero) is a template for integrating any function supported on a countable set. The nowhere-continuity proof showcases measure-theoretic reasoning as an alternative to explicit ε-δ constructions.",
     "openQuestions": [
-      "Can the modified Dirichlet function f(x) = 1/q for x = p/q in lowest terms, f(x) = 0 for irrational x, be shown Riemann integrable via Lebesgue's criterion?"
+      "Can the modified Dirichlet function $f(x) = 1/q$ for $x = p/q$ in lowest terms, $f(x) = 0$ for irrational $x$, be shown Riemann integrable via Lebesgue's criterion (discontinuity set = ℚ, which has measure zero)?",
+      "Can the Thomae function (modified Dirichlet function) integral be computed explicitly using Mathlib's Bochner integral?"
+    ],
+    "crossReferences": [
+      { "proofId": "lebesgue-measure", "relationship": "Parent proof — this resolves Open Question #1 (Dirichlet function integral axiom)." }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Added `proofStrategy` (3-step chain) and 5 `keyInsights` to overview
- Deepened `historicalContext` with Dirichlet 1829, Riemann 1854, Lebesgue 1901-1902 timeline
- Added Riemann (1854) reference
- Rebuilt annotations from 5 (non-standard `lineStart/lineEnd`, types `technique`/`keyStep`) to 8 with standard `line` format
- Added annotations for: rationals countable, measure restriction, extension to arbitrary sets
- All annotations have full mathContext, significance, relatedConcepts, prerequisites
- Added cross-reference to parent proof
- Enhanced conclusion with implications

## Test plan
- [x] `pnpm annotations:build` passes with no errors for lebesgue-measure-oq-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)