### PR TITLE
fix: flatten conclusion.implications arrays (batch 2, 3 proofs)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
@@ -167,12 +167,7 @@
   ],
   "conclusion": {
     "summary": "This file generalizes the 2D area-circumference integral relation A = ∫C to arbitrary dimensions with zero sorries. The main theorem V_n(r) = ∫₀ʳ S_n(ρ) dρ follows cleanly from the polynomial structure of V_n and the Fundamental Theorem of Calculus. Rich consequences include shell volumes, scaling laws, and the surface-to-volume ratio n/r.",
-    "implications": [
-      "The volume-surface duality V_n' = S_n is the foundation of geometric measure theory in n dimensions",
-      "The ratio S_n/V_n = n/r explains concentration of measure in high dimensions — the 'curse of dimensionality'",
-      "Completes the Wiedijk #9 open question chain: circle area → circumference-area duality → n-dimensional integration",
-      "The polynomial structure V_n = ω_n·r^n suggests that similar integral relations hold for other homogeneous geometric quantities"
-    ],
+    "implications": "The volume-surface duality V_n' = S_n is the foundation of geometric measure theory in n dimensions The ratio S_n/V_n = n/r explains concentration of measure in high dimensions — the 'curse of dimensionality' Completes the Wiedijk #9 open question chain: circle area → circumference-area duality → n-dimensional integration The polynomial structure V_n = ω_n·r^n suggests that similar integral relations hold for other homogeneous geometric quantities",
     "openQuestions": [
       "Can the Gamma function values ω_n be computed for all n via a recursive formula ω_{n+2} = (2π/n)·ω_n?",
       "Can the isoperimetric inequality be formalized using these volume/surface area definitions?",

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
@@ -8,18 +8,53 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm",
     "date": "~300 BCE (constructive formalization 2026)",
     "status": "verified",
-    "tags": ["number-theory", "constructive-mathematics", "algorithms", "bezout", "divisibility", "euclid"],
+    "tags": [
+      "number-theory",
+      "constructive-mathematics",
+      "algorithms",
+      "bezout",
+      "divisibility",
+      "euclid"
+    ],
     "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
     "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
-      {"theorem": "Nat.gcd", "description": "Natural number GCD computation", "module": "Mathlib.Data.Nat.GCD.Basic"},
-      {"theorem": "IsCoprime", "description": "Coprimality via Bézout coefficients", "module": "Mathlib.RingTheory.Coprime.Basic"},
-      {"theorem": "IsCoprime.dvd_of_dvd_mul_left", "description": "Euclid's lemma via IsCoprime", "module": "Mathlib.RingTheory.Coprime.Basic"},
-      {"theorem": "mul_left_cancel₀", "description": "Left cancellation in integral domains", "module": "Mathlib.Algebra.GroupWithZero.Basic"},
-      {"theorem": "Nat.mod_lt", "description": "Modular reduction decreases", "module": "Mathlib.Data.Nat.Defs"},
-      {"theorem": "Nat.div_add_mod", "description": "Division algorithm: a = (a/b)*b + a%b", "module": "Mathlib.Data.Nat.Defs"},
-      {"theorem": "linear_combination", "description": "Tactic for proving linear equalities from hypotheses", "module": "Mathlib.Tactic.LinearCombination"}
+      {
+        "theorem": "Nat.gcd",
+        "description": "Natural number GCD computation",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "IsCoprime",
+        "description": "Coprimality via Bézout coefficients",
+        "module": "Mathlib.RingTheory.Coprime.Basic"
+      },
+      {
+        "theorem": "IsCoprime.dvd_of_dvd_mul_left",
+        "description": "Euclid's lemma via IsCoprime",
+        "module": "Mathlib.RingTheory.Coprime.Basic"
+      },
+      {
+        "theorem": "mul_left_cancel₀",
+        "description": "Left cancellation in integral domains",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      },
+      {
+        "theorem": "Nat.mod_lt",
+        "description": "Modular reduction decreases",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "Nat.div_add_mod",
+        "description": "Division algorithm: a = (a/b)*b + a%b",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "linear_combination",
+        "description": "Tactic for proving linear equalities from hypotheses",
+        "module": "Mathlib.Tactic.LinearCombination"
+      }
     ],
     "originalContributions": [
       "extGcd: Self-contained extended Euclidean algorithm with full correctness proofs (Bézout identity + GCD)",
@@ -142,12 +177,7 @@
   ],
   "conclusion": {
     "summary": "The answer is YES: Bézout coefficients from extGcd combine with the quotient formula to give a constructive divisibility algorithm. The explicit quotient q = u*c + v*k is correct in any CommRing, computed over ℕ via the extended Euclidean algorithm, and unique in integral domains. Zero sorries.",
-    "implications": [
-      "Completes the bezout-identity open question chain with a fully constructive algorithm",
-      "The ring-axiomatic quotient formula works in polynomial rings, Gaussian integers, and any Bézout domain",
-      "Demonstrates that classical existence proofs in number theory often contain implicit algorithms that can be extracted",
-      "The extended GCD provides modular inverses: when gcd(a,b) = 1, the Bézout coefficient u is the inverse of a mod b"
-    ],
+    "implications": "Completes the bezout-identity open question chain with a fully constructive algorithm The ring-axiomatic quotient formula works in polynomial rings, Gaussian integers, and any Bézout domain Demonstrates that classical existence proofs in number theory often contain implicit algorithms that can be extracted The extended GCD provides modular inverses: when gcd(a,b) = 1, the Bézout coefficient u is the inverse of a mod b",
     "openQuestions": [
       "Can the noncomputable annotation be removed by making the divisibility witness computable (e.g., via decidable divisibility)?",
       "Can the algorithm be extended to multivariate Bézout identities in polynomial rings?",

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -191,12 +191,7 @@
   },
   "conclusion": {
     "summary": "Complete formalization of the structural relationship between BFL's n^{3/2+o(1)} result and Erdős's Θ(n^{3/2}) conjecture. All theorems fully proved (0 sorries). Includes BFL sandwich, exact exponent characterization, conjecture decomposition, Mantel connection, hierarchy of bounds, and ratio tightness characterization.",
-    "implications": [
-      "Any proof of the full conjecture must establish that f(n)/n^{3/2} has a compact limit set in (0, ∞) — a qualitative strengthening of BFL's sub-polynomial bounds",
-      "The O and Ω bounds can be pursued independently; proving either one is progress toward the full conjecture",
-      "The hierarchy Conjecture ⟹ BFL ⟹ Grable provides a roadmap for incremental progress: each strengthening requires tighter control of the multiplicative constants",
-      "Connecting to differential equation methods (as in BFL's proof) may be the most promising route to extracting explicit constants"
-    ],
+    "implications": "Any proof of the full conjecture must establish that f(n)/n^{3/2} has a compact limit set in (0, ∞) — a qualitative strengthening of BFL's sub-polynomial bounds The O and Ω bounds can be pursued independently; proving either one is progress toward the full conjecture The hierarchy Conjecture ⟹ BFL ⟹ Grable provides a roadmap for incremental progress: each strengthening requires tighter control of the multiplicative constants Connecting to differential equation methods (as in BFL's proof) may be the most promising route to extracting explicit constants",
     "openQuestions": [
       "Does f(n)/n^{3/2} converge? If so, to what constant?",
       "Can the lower Θ-bound be established independently of the upper?",


### PR DESCRIPTION
## Summary
- Three more enricher PRs introduced `conclusion.implications` as `string[]` instead of `string`
- Same fix as #3534: joins array elements with space separator

## Affected proofs
area-of-circle-oq-01-oq-02-oq-01, bezout-identity-oq-02-oq-02-oq-01, erdos-1155-oq-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)