### PR TITLE
Enrich binomial-theorem-oq-03 (Binomial Distribution): deepen overview, annotations, conclusion

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-03/annotations.json
@@ -1,50 +1,142 @@
 [
   {
-    "lineNumber": 29,
-    "content": "The binomial PMF is defined as a real-valued function, not a measure-theoretic probability. This algebraic approach avoids the complexity of sigma-algebras while still proving all the key identities.",
+    "id": "binom-pmf",
+    "line": 28,
     "type": "definition",
-    "tags": ["probability", "binomial-distribution"]
+    "content": "**binomPMF**: The binomial probability mass function $P(X=k) = \\binom{n}{k} p^k (1-p)^{n-k}$. Defined as a real-valued function on $\\mathbb{N}$, not a measure-theoretic probability. This algebraic approach avoids sigma-algebras while capturing all combinatorial identities. Returns 0 for $k > n$ since $\\binom{n}{k} = 0$.",
+    "mathContext": "For $X \\sim \\text{Bin}(n,p)$: $P(X=k) = \\binom{n}{k} p^k (1-p)^{n-k}$, $k = 0, 1, \\ldots, n$. The boundary values $P(0) = (1-p)^n$ and $P(n) = p^n$ follow from $\\binom{n}{0} = \\binom{n}{n} = 1$. Non-negativity holds for $p \\in [0,1]$ since all three factors are non-negative.",
+    "significance": "critical",
+    "relatedConcepts": ["Nat.choose", "probability mass function", "Bernoulli trials", "combinatorics"],
+    "prerequisites": ["Nat.choose (binomial coefficients)", "Real-valued powers"]
   },
   {
-    "lineNumber": 54,
-    "content": "Normalization is a one-line consequence of the binomial theorem: substitute q = 1-p, use add_sub_cancel to get 1^n = 1. This is the heart of the OQ-03 answer.",
-    "type": "key-step",
-    "tags": ["normalization", "binomial-theorem"]
+    "id": "binomial-expansion",
+    "line": 48,
+    "type": "theorem",
+    "content": "**binomial_expansion**: The algebraic binomial theorem $(p+q)^n = \\sum_{k=0}^{n} \\binom{n}{k} p^k q^{n-k}$, proved by rewriting Mathlib's `add_pow`. This is the foundational identity from which every property of the binomial distribution follows.",
+    "mathContext": "Mathlib's `add_pow` gives $(p+q)^n = \\sum_k \\binom{n}{k} p^k q^{n-k}$ using `Commute.add_pow`. The proof rewrites this into the desired summation form with a `congr` and `ring` step.",
+    "significance": "critical",
+    "relatedConcepts": ["add_pow", "Finset.sum_range", "polynomial identity"],
+    "prerequisites": ["Mathlib's Commute.add_pow", "ring tactic"]
   },
   {
-    "lineNumber": 78,
-    "content": "The absorption identity (k+1)C(n+1,k+1) = (n+1)C(n,k) is the key algebraic tool for computing the mean. It converts each term k*PMF(k) into (n+1)*p times a degree-(n-1) binomial term.",
-    "type": "technique",
-    "tags": ["absorption-identity", "mean"]
+    "id": "normalization",
+    "line": 53,
+    "type": "theorem",
+    "content": "**binomPMF_sum_eq_one**: The PMF sums to 1. The proof is a one-line consequence of the binomial theorem: substitute $q = 1-p$ to get $(p + (1-p))^n = 1^n = 1$. This is the heart of the OQ-03 answer — the binomial theorem IS normalization.",
+    "mathContext": "Setting $q = 1-p$ in $(p+q)^n = \\sum \\binom{n}{k} p^k q^{n-k}$: $1^n = \\sum_{k=0}^{n} \\binom{n}{k} p^k (1-p)^{n-k} = \\sum_{k=0}^{n} \\text{PMF}(k)$. The `add_sub_cancel` lemma gives $p + (1-p) = 1$.",
+    "significance": "critical",
+    "relatedConcepts": ["binomial theorem", "probability axioms", "partition of unity"],
+    "prerequisites": ["binomial_expansion", "add_sub_cancel"]
   },
   {
-    "lineNumber": 182,
-    "content": "The PGF E[t^X] = (pt + 1-p)^n follows directly from replacing p by pt in the binomial expansion. Setting t=1 recovers normalization; differentiating at t=1 gives the mean.",
-    "type": "insight",
-    "tags": ["generating-function", "pgf"]
+    "id": "absorption",
+    "line": 77,
+    "type": "theorem",
+    "content": "**absorption**: The absorption identity $(k+1)\\binom{n+1}{k+1} = (n+1)\\binom{n}{k}$. This is the key algebraic tool for computing the mean: it converts each weighted term $k \\cdot \\text{PMF}(k)$ into $(n+1)p$ times a degree-$(n-1)$ binomial term, reducing the moment calculation to normalization.",
+    "mathContext": "The absorption identity is equivalent to $k\\binom{n}{k} = n\\binom{n-1}{k-1}$ (shift indices by 1). It arises from the factorial representation: $k \\cdot \\frac{n!}{k!(n-k)!} = n \\cdot \\frac{(n-1)!}{(k-1)!(n-k)!}$. Proved from Mathlib's `Nat.add_one_mul_choose_eq` with `linarith`.",
+    "significance": "critical",
+    "relatedConcepts": ["Nat.add_one_mul_choose_eq", "factorial cancellation", "moment computation"],
+    "prerequisites": ["Nat.choose definition", "factorial identities"]
   },
   {
-    "lineNumber": 209,
-    "content": "Double absorption: (k+2)(k+1)C(n+2,k+2) = (n+2)(n+1)C(n,k). Two applications of absorption give the second factorial moment E[X(X-1)] = n(n-1)p^2, from which Var(X) = np(1-p) follows algebraically.",
-    "type": "technique",
-    "tags": ["double-absorption", "variance", "second-moment"]
+    "id": "binomial-mean",
+    "line": 83,
+    "type": "theorem",
+    "content": "**binomial_mean**: $E[X] = np$ for $n \\geq 1$. The proof strips the $k=0$ term (which vanishes), applies absorption to convert each $(k+1) \\cdot \\text{PMF}(k+1)$ into $(n+1)p \\cdot [\\text{degree-}(n-1) \\text{ binomial term}]$, factors out $np$, and uses normalization on the remaining sum.",
+    "mathContext": "$E[X] = \\sum_{k=0}^{n} k \\cdot \\binom{n}{k} p^k (1-p)^{n-k} = np \\sum_{j=0}^{n-1} \\binom{n-1}{j} p^j (1-p)^{n-1-j} = np \\cdot 1 = np$. The index shift $j = k-1$ and absorption $k\\binom{n}{k} = n\\binom{n-1}{k-1}$ are the two key steps.",
+    "significance": "critical",
+    "relatedConcepts": ["expected value", "absorption identity", "index shift", "Finset.sum_range_succ'"],
+    "prerequisites": ["absorption identity", "binomPMF_sum_eq_one (normalization)"]
   },
   {
-    "lineNumber": 276,
-    "content": "Vandermonde's identity sum_j C(n,j)*C(m,k-j) = C(n+m,k) translates to the convolution property: the sum of independent Bin(n,p) and Bin(m,p) random variables has distribution Bin(n+m,p).",
-    "type": "key-step",
-    "tags": ["vandermonde", "convolution", "independence"]
+    "id": "fair-coin",
+    "line": 132,
+    "type": "theorem",
+    "content": "**binomPMF_fair_coin**: When $p = 1/2$, $P(k) = \\binom{n}{k}/2^n$. The proof uses $(1/2)^k \\cdot (1/2)^{n-k} = (1/2)^n = 1/2^n$. This is the classical equi-probable model: each of the $2^n$ binary sequences has equal probability, and $\\binom{n}{k}$ of them have exactly $k$ ones.",
+    "mathContext": "For the fair coin: $P(X=k) = \\binom{n}{k} (1/2)^k (1/2)^{n-k} = \\binom{n}{k} / 2^n$. The $2^n$ denominator appears because there are $2^n$ equally likely outcomes in $n$ tosses, and $\\binom{n}{k}$ of these have exactly $k$ heads.",
+    "significance": "supporting",
+    "relatedConcepts": ["equi-probable model", "coin tossing", "pow_add"],
+    "prerequisites": ["binomPMF definition", "arithmetic with 1/2"]
   },
   {
-    "lineNumber": 398,
-    "content": "The classical limit (1+x/n)^n -> exp(x) is proved from first principles: the derivative of log at 1 gives log(1+h)/h -> 1 as h -> 0, composing with h = x/n gives n*log(1+x/n) -> x, and continuity of exp completes the proof. This result is not in Mathlib v4.26.0.",
-    "type": "key-step",
-    "tags": ["exponential-limit", "compound-interest", "analysis"]
+    "id": "binomial-pgf",
+    "line": 181,
+    "type": "theorem",
+    "content": "**binomial_pgf**: The probability generating function $E[t^X] = (pt + 1-p)^n$. Proved by replacing $p$ with $pt$ in the binomial expansion — each term $t^k \\cdot \\text{PMF}(k) = \\binom{n}{k} (pt)^k (1-p)^{n-k}$. The PGF encodes the entire distribution: setting $t=1$ gives normalization, differentiating at $t=1$ gives the mean.",
+    "mathContext": "The PGF $G(t) = E[t^X] = \\sum_{k=0}^{n} t^k \\binom{n}{k} p^k (1-p)^{n-k} = (pt + (1-p))^n$ by the binomial theorem. $G(1) = 1$ (normalization), $G'(1) = np$ (mean), $G''(1) + G'(1) - (G'(1))^2 = np(1-p)$ (variance). The PGF completely characterizes any distribution on $\\mathbb{N}$.",
+    "significance": "key",
+    "relatedConcepts": ["generating functions", "moment generating function", "binomial_expansion"],
+    "prerequisites": ["binomial_expansion", "ring tactic"]
   },
   {
-    "lineNumber": 523,
-    "content": "The Poisson limit theorem is proved by induction on k using the ratio of consecutive PMF terms. The base case (k=0) reduces to (1-r/n)^n -> e^(-r), which follows from the (1+x/n)^n limit. The inductive step uses the factoring binomPMF(k+1) = binomPMF(k) * ratio, where the ratio converges to r/(k+1).",
-    "type": "key-step",
-    "tags": ["poisson-limit", "induction", "convergence"]
+    "id": "double-absorption",
+    "line": 203,
+    "type": "theorem",
+    "content": "**double_absorption**: $(k+2)(k+1)\\binom{n+2}{k+2} = (n+2)(n+1)\\binom{n}{k}$. Two applications of the absorption identity. This gives the second factorial moment $E[X(X-1)] = n(n-1)p^2$, from which the variance formula $\\text{Var}(X) = np(1-p)$ follows algebraically.",
+    "mathContext": "Apply absorption twice: $(k+2)\\binom{n+2}{k+2} = (n+2)\\binom{n+1}{k+1}$, then $(k+1)\\binom{n+1}{k+1} = (n+1)\\binom{n}{k}$. Multiplying: $(k+2)(k+1)\\binom{n+2}{k+2} = (n+2)(n+1)\\binom{n}{k}$. Proved via `nlinarith` from two instances of the single absorption identity.",
+    "significance": "key",
+    "relatedConcepts": ["factorial moments", "variance computation", "nlinarith"],
+    "prerequisites": ["absorption identity (single)", "Nat.choose"]
+  },
+  {
+    "id": "binomial-variance",
+    "line": 255,
+    "type": "theorem",
+    "content": "**binomial_variance**: $\\text{Var}(X) = np(1-p)$ for $n \\geq 2$. Uses the identity $\\text{Var}(X) = E[X^2] - (E[X])^2 = (E[X(X-1)] + E[X]) - (E[X])^2 = n(n-1)p^2 + np - n^2p^2 = np(1-p)$. The second factorial moment avoids the $E[X^2]$ computation directly.",
+    "mathContext": "$\\text{Var}(X) = E[X(X-1)] + E[X] - (E[X])^2 = n(n-1)p^2 + np - (np)^2 = np - np^2 = np(1-p)$. The detour through $E[X(X-1)]$ instead of $E[X^2]$ is standard because the falling factorial $k(k-1)$ pairs naturally with the double absorption identity.",
+    "significance": "key",
+    "relatedConcepts": ["variance", "second factorial moment", "falling factorial", "ring tactic"],
+    "prerequisites": ["binomial_second_factorial_moment", "binomial_mean"]
+  },
+  {
+    "id": "vandermonde-convolution",
+    "line": 283,
+    "type": "theorem",
+    "content": "**binomPMF_convolution**: The reproductive property $\\sum_j \\text{PMF}_n(j) \\cdot \\text{PMF}_m(k-j) = \\text{PMF}_{n+m}(k)$. The sum of independent $\\text{Bin}(n,p)$ and $\\text{Bin}(m,p)$ has distribution $\\text{Bin}(n+m,p)$. Proved by factoring out $p^k(1-p)^{n+m-k}$ and applying Vandermonde's identity.",
+    "mathContext": "Vandermonde: $\\binom{n+m}{k} = \\sum_{j=0}^{k} \\binom{n}{j}\\binom{m}{k-j}$. Each convolution term: $\\binom{n}{j}p^j(1-p)^{n-j} \\cdot \\binom{m}{k-j}p^{k-j}(1-p)^{m-k+j} = \\binom{n}{j}\\binom{m}{k-j} \\cdot p^k(1-p)^{n+m-k}$. Summing over $j$ gives $\\binom{n+m}{k} p^k (1-p)^{n+m-k}$.",
+    "significance": "critical",
+    "relatedConcepts": ["Vandermonde identity", "convolution", "independence", "reproductive property"],
+    "prerequisites": ["vandermonde_range", "binomPMF definition", "power laws"]
+  },
+  {
+    "id": "compound-interest-limit",
+    "line": 335,
+    "type": "theorem",
+    "content": "**tendsto_one_plus_div_pow_exp**: The classical limit $(1 + x/n)^n \\to e^x$, proved from first principles. The strategy: (A) $\\text{HasDerivAt}(\\log(1+t), 1, 0)$ gives $\\log(1+h)/h \\to 1$ as $h \\to 0$; (B) compose with $h = x/n \\to 0$ to get $n\\log(1+x/n) \\to x$; (C) continuity of $\\exp$ gives $\\exp(n\\log(1+x/n)) = (1+x/n)^n \\to e^x$. This result was not in Mathlib v4.26.0.",
+    "mathContext": "The limit $(1+x/n)^n \\to e^x$ is the foundation of compound interest ($x > 0$) and the Poisson limit ($x = -r < 0$). The proof uses the characterization $e^x = \\lim_{n\\to\\infty}(1+x/n)^n$, which is equivalent to $\\exp = $ the unique solution of $f' = f$, $f(0) = 1$. The key analytic inputs are `Real.hasDerivAt_log` and `Real.continuous_exp`.",
+    "significance": "critical",
+    "relatedConcepts": ["compound interest", "exponential function", "HasDerivAt", "slope", "nhdsWithin", "Filter.Tendsto"],
+    "prerequisites": ["Real.hasDerivAt_log", "Real.continuous_exp", "tendsto_const_div_atTop_nhds_zero_nat"]
+  },
+  {
+    "id": "poisson-pmf",
+    "line": 411,
+    "type": "definition",
+    "content": "**poissonPMF**: The Poisson probability mass function $P(X=k) = e^{-r} r^k / k!$. This is the limiting distribution of $\\text{Bin}(n, r/n)$ as $n \\to \\infty$, modeling the count of rare events occurring at rate $r$.",
+    "mathContext": "For $X \\sim \\text{Poi}(r)$: $P(X=k) = e^{-r} r^k / k!$ for $k = 0, 1, 2, \\ldots$. The Poisson family is also reproductive ($\\text{Poi}(r_1) * \\text{Poi}(r_2) = \\text{Poi}(r_1+r_2)$) and is the unique distribution whose PGF is $e^{r(t-1)}$. The recurrence $P(k+1) = P(k) \\cdot r/(k+1)$ is used in the inductive proof.",
+    "significance": "key",
+    "relatedConcepts": ["Poisson distribution", "law of rare events", "exponential function", "factorial"],
+    "prerequisites": ["Real.exp", "Nat.factorial"]
+  },
+  {
+    "id": "poisson-limit",
+    "line": 527,
+    "type": "theorem",
+    "content": "**poisson_limit**: For each fixed $k$ and $r > 0$, $\\text{Bin}(n, r/n)(k) \\to \\text{Poi}(r)(k)$ as $n \\to \\infty$. Proved by induction on $k$: the base case $(1-r/n)^n \\to e^{-r}$ is the compound interest limit; the inductive step uses the PMF ratio $\\text{PMF}(k+1)/\\text{PMF}(k) = (n-k)(r/n)/((k+1)(1-r/n)) \\to r/(k+1)$, matching the Poisson recurrence.",
+    "mathContext": "The Poisson limit theorem: if $n \\to \\infty$ and $np_n \\to r$, then $\\binom{n}{k}p_n^k(1-p_n)^{n-k} \\to e^{-r}r^k/k!$ for each fixed $k$. Here $p_n = r/n$. The inductive proof avoids Stirling's approximation by using the ratio $P(k+1)/P(k) = (n-k)p/((k+1)(1-p))$, which converges to $r/(k+1)$ by `poisson_ratio_tendsto`.",
+    "significance": "critical",
+    "relatedConcepts": ["Poisson approximation", "law of rare events", "induction", "Filter.Tendsto.mul"],
+    "prerequisites": ["tendsto_one_plus_div_pow_exp", "poissonPMF_succ", "binomPMF_succ_eq", "poisson_ratio_tendsto"]
+  },
+  {
+    "id": "summary-theorem",
+    "line": 564,
+    "type": "theorem",
+    "content": "**binomial_oq03_extended_summary**: A single conjunction theorem packaging all seven main results: normalization ($\\sum \\text{PMF} = 1$), mean ($np$), variance ($np(1-p)$), PGF ($(pt+1-p)^n$), fair coin ($\\binom{n}{k}/2^n$), convolution (Vandermonde), and the Poisson limit. This serves as the machine-checkable answer to OQ-03.",
+    "mathContext": "The theorem statement is a 7-tuple conjunction, proved by applying each individual theorem. It demonstrates that every listed property of $\\text{Bin}(n,p)$ follows from the algebraic binomial theorem with 0 sorries and 0 axioms.",
+    "significance": "key",
+    "relatedConcepts": ["conjunction", "proof summary", "research question"],
+    "prerequisites": ["All preceding theorems in the file"]
   }
 ]

--- a/src/data/proofs/binomial-theorem-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03/meta.json
@@ -26,23 +26,63 @@
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose",
-        "description": "Binomial coefficients and their identities",
+        "description": "Binomial coefficients C(n,k) and their identities (symmetry, boundary values).",
         "module": "Mathlib.Data.Nat.Choose.Basic"
       },
       {
-        "theorem": "Nat.sum_range_choose",
-        "description": "Sum of binomial coefficients equals 2^n",
-        "module": "Mathlib.Data.Nat.Choose.Sum"
-      },
-      {
-        "theorem": "Real.hasDerivAt_log",
-        "description": "Derivative of log function, used for Poisson limit",
-        "module": "Mathlib.Analysis.SpecialFunctions.Log.Deriv"
+        "theorem": "Nat.add_one_mul_choose_eq",
+        "description": "The absorption identity: (n+1) * C(n,k) relates to (k+1) * C(n+1,k+1). The engine for computing moments.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
       },
       {
         "theorem": "Nat.add_choose_eq",
-        "description": "Vandermonde's identity for binomial coefficients",
+        "description": "Vandermonde's convolution identity: C(n+m,k) = Σ C(n,j)*C(m,k-j). Gives the reproductive property.",
         "module": "Mathlib.Data.Nat.Choose.Vandermonde"
+      },
+      {
+        "theorem": "Real.hasDerivAt_log",
+        "description": "HasDerivAt log (1/x) x for x > 0. Used to prove (1+x/n)^n → exp(x) via log'(1) = 1.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Deriv"
+      },
+      {
+        "theorem": "Real.continuous_exp",
+        "description": "Continuity of the exponential function. Composes with n·log(1+x/n) → x to give (1+x/n)^n → exp(x).",
+        "module": "Mathlib.Analysis.SpecialFunctions.ExpDeriv"
+      },
+      {
+        "theorem": "tendsto_const_div_atTop_nhds_zero_nat",
+        "description": "c/n → 0 as n → ∞. The key asymptotic input for the Poisson limit ratio convergence.",
+        "module": "Mathlib.Topology.Algebra.Order.LiminfLimsup"
+      }
+    ],
+    "references": [
+      {
+        "authors": "Jacob Bernoulli",
+        "title": "Ars Conjectandi",
+        "year": "1713",
+        "venue": "Published posthumously, Basel",
+        "note": "Established the binomial distribution and the weak law of large numbers"
+      },
+      {
+        "authors": "Siméon Denis Poisson",
+        "title": "Recherches sur la probabilité des jugements",
+        "year": "1837",
+        "venue": "Bachelier, Paris",
+        "note": "Proved the Poisson limit theorem (law of rare events): Bin(n, r/n) → Poi(r)"
+      },
+      {
+        "authors": "Alexandre-Théophile Vandermonde",
+        "title": "Mémoire sur des irrationnelles de différens ordres avec une application au cercle",
+        "year": "1772",
+        "venue": "Mémoires de l'Académie Royale des Sciences",
+        "note": "Vandermonde's identity: C(m+n,k) = Σ C(m,j)C(n,k-j)"
+      },
+      {
+        "authors": "Abraham de Moivre",
+        "title": "Approximatio ad Summam Terminorum Binomii (a+b)^n in Seriem Expansi",
+        "year": "1733",
+        "venue": "Supplementum to Miscellanea Analytica",
+        "note": "First proof of the normal approximation to the binomial (de Moivre–Laplace theorem)"
       }
     ],
     "originalContributions": [
@@ -60,16 +100,22 @@
     "axioms": 0
   },
   "overview": {
-    "historicalContext": "The binomial distribution -- the probability of k successes in n independent Bernoulli trials -- is one of the most fundamental objects in probability theory. Jacob Bernoulli established its properties in Ars Conjectandi (1713). The connection to the algebraic binomial theorem is immediate: setting x = p, y = 1-p in (x+y)^n = 1 gives normalization, and differentiating the PGF gives moments. The Poisson limit theorem (Siméon Denis Poisson, 1837) shows that rare events follow the Poisson distribution.",
-    "problemStatement": "**Open Question (OQ-03):** Can we derive the binomial distribution's key properties (normalization, mean, variance, PGF, convolution, Poisson limit) directly from the algebraic binomial theorem?\n\n**Answer:** YES. Every property follows from algebraic manipulation of (p + q)^n = sum C(n,k) p^k q^(n-k):\n- **Normalization:** Set q = 1-p to get 1 = sum PMF(k)\n- **Mean:** Use the absorption identity to factor np from sum k*PMF(k)\n- **Variance:** Use double absorption for the second factorial moment\n- **Convolution:** Vandermonde's identity gives Bin(n,p)*Bin(m,p) = Bin(n+m,p)\n- **Poisson limit:** log derivative + continuity of exp gives (1+x/n)^n -> exp(x)",
-    "proofStrategy": "The proof proceeds algebraically through 11 parts:\n\n1. **Binomial expansion:** (p+q)^n = sum C(n,k) p^k q^(n-k) proved by rewriting Mathlib's add_pow\n2. **Normalization:** Substitute q = 1-p; the sum telescopes to 1^n = 1\n3. **Mean via absorption:** (k+1)C(n+1,k+1) = (n+1)C(n,k) factors out np\n4. **Variance via double absorption:** (k+2)(k+1)C(n+2,k+2) = (n+2)(n+1)C(n,k) gives E[X(X-1)] = n(n-1)p^2\n5. **Convolution:** Vandermonde's identity sum C(n,j)C(m,k-j) = C(n+m,k)\n6. **Poisson limit:** log(1+h)/h -> 1 composed with h = x/n -> 0 gives (1+x/n)^n -> e^x, then induction on k",
+    "historicalContext": "The binomial distribution — the probability of $k$ successes in $n$ independent Bernoulli trials — is one of the most fundamental objects in probability theory and combinatorics. **Jacob Bernoulli** established its core properties in *Ars Conjectandi* (published posthumously in 1713), where he proved the weak law of large numbers for Bernoulli trials. The algebraic connection to the binomial theorem $(x+y)^n = \\sum \\binom{n}{k} x^k y^{n-k}$ was already known to **Isaac Newton** (1665) and **Blaise Pascal** (1654), but Bernoulli was the first to interpret the expansion probabilistically. **Abraham de Moivre** (1733) proved the normal approximation $\\text{Bin}(n,p) \\approx \\mathcal{N}(np, np(1-p))$ for large $n$ (later generalized by **Pierre-Simon Laplace**). **Siméon Denis Poisson** (1837) proved the law of rare events: when $n \\to \\infty$ and $p = r/n$, $\\text{Bin}(n, r/n) \\to \\text{Poi}(r)$ pointwise. The absorption identity $k\\binom{n}{k} = n\\binom{n-1}{k-1}$ was known to **Leonhard Euler** and is the algebraic engine for computing moments. **Alexandre-Théophile Vandermonde** (1772) proved his convolution identity $\\binom{m+n}{k} = \\sum_j \\binom{m}{j}\\binom{n}{k-j}$, which translates directly to the reproductive property of the binomial family. This formalization proves all these results purely algebraically from the binomial theorem, including a first-principles proof of $(1+x/n)^n \\to e^x$ via the derivative of $\\log$ at 1 — a result not available in Mathlib v4.26.0.",
+    "problemStatement": "**Open Question (OQ-03):** Can we derive the binomial distribution's key properties (normalization, mean, variance, PGF, convolution, Poisson limit) directly from the algebraic binomial theorem?\n\n**Answer:** YES. Every property follows from algebraic manipulation of $(p + q)^n = \\sum \\binom{n}{k} p^k q^{n-k}$:\n- **Normalization:** Set $q = 1-p$ to get $1 = \\sum \\text{PMF}(k)$\n- **Mean:** Use the absorption identity to factor $np$ from $\\sum k \\cdot \\text{PMF}(k)$\n- **Variance:** Use double absorption for the second factorial moment\n- **Convolution:** Vandermonde's identity gives $\\text{Bin}(n,p) * \\text{Bin}(m,p) = \\text{Bin}(n+m,p)$\n- **Poisson limit:** $\\log$ derivative + continuity of $\\exp$ gives $(1+x/n)^n \\to e^x$",
+    "proofStrategy": "The proof proceeds algebraically through 11 parts, each building on the binomial theorem $(p+q)^n = \\sum \\binom{n}{k} p^k q^{n-k}$:\n\n1. **PMF definition**: $P(X=k) = \\binom{n}{k} p^k (1-p)^{n-k}$ with boundary values $P(0) = (1-p)^n$, $P(n) = p^n$\n2. **Normalization**: Substitute $q = 1-p$; $(p + (1-p))^n = 1^n = 1$\n3. **Symmetry**: $P(k; n, p) = P(n-k; n, 1-p)$ via $\\binom{n}{k} = \\binom{n}{n-k}$\n4. **Mean via absorption**: The identity $(k+1)\\binom{n+1}{k+1} = (n+1)\\binom{n}{k}$ converts $\\sum k \\cdot \\text{PMF}(k)$ into $np \\cdot 1 = np$\n5. **Special cases**: Fair coin $P(k) = \\binom{n}{k}/2^n$, Bernoulli, certain/impossible events\n6. **Monotonicity**: $p \\leq q \\Rightarrow np \\leq nq$\n7. **PGF**: $E[t^X] = (pt + 1-p)^n$ by replacing $p$ with $pt$ in the binomial expansion\n8. **Double absorption**: $(k+2)(k+1)\\binom{n+2}{k+2} = (n+2)(n+1)\\binom{n}{k}$ gives $E[X(X-1)] = n(n-1)p^2$, hence $\\text{Var}(X) = np(1-p)$\n9. **Convolution**: Vandermonde $\\sum_j \\binom{n}{j}\\binom{m}{k-j} = \\binom{n+m}{k}$ gives $\\text{Bin}(n,p) * \\text{Bin}(m,p) = \\text{Bin}(n+m,p)$\n10. **Poisson limit**: $(1+x/n)^n \\to e^x$ from $\\log'(1) = 1$, then induction on $k$ using the PMF ratio\n11. **Summary**: All results packaged in a single conjunction theorem",
     "keyInsights": [
-      "The binomial theorem IS normalization -- they are literally the same identity with q = 1-p",
-      "The absorption identity converts a weighted sum sum k*PMF(k) into np times an unweighted sum",
-      "Double absorption gives the second factorial moment, from which variance follows algebraically",
-      "Vandermonde's identity translates to the convolution property of independent binomials",
-      "The Poisson limit follows from the derivative of log at 1: log(1+h)/h -> 1 as h -> 0",
-      "The (1+x/n)^n -> exp(x) limit was proved from first principles (not in Mathlib v4.26.0)"
+      "**Normalization = Binomial theorem**: Setting $q = 1-p$ in $(p+q)^n = \\sum \\binom{n}{k} p^k q^{n-k}$ gives $(p + (1-p))^n = 1 = \\sum \\text{PMF}(k)$. The binomial theorem and normalization are literally the same identity.",
+      "**Absorption identity as moment engine**: The identity $(k+1)\\binom{n+1}{k+1} = (n+1)\\binom{n}{k}$ converts the weighted sum $\\sum k \\cdot \\text{PMF}(k)$ into $np$ times an unweighted sum (which equals 1 by normalization). Double absorption $(k+2)(k+1)\\binom{n+2}{k+2} = (n+2)(n+1)\\binom{n}{k}$ gives the second factorial moment.",
+      "**Vandermonde = Reproductive property**: Vandermonde's convolution identity $\\binom{n+m}{k} = \\sum_j \\binom{n}{j}\\binom{m}{k-j}$ is exactly the statement that the sum of independent $\\text{Bin}(n,p)$ and $\\text{Bin}(m,p)$ is $\\text{Bin}(n+m,p)$ — the binomial family is closed under convolution.",
+      "**Compound interest limit from first principles**: The classical limit $(1+x/n)^n \\to e^x$ is proved via $\\text{HasDerivAt}(\\log(1+t), 1, 0)$, composing with $h = x/n \\to 0$ to get $n\\log(1+x/n) \\to x$, then applying continuity of $\\exp$. This result was not in Mathlib v4.26.0.",
+      "**Poisson limit by induction on $k$**: The base case $(1-r/n)^n \\to e^{-r}$ is the compound interest limit. The inductive step uses the PMF ratio $\\text{PMF}(k+1)/\\text{PMF}(k) = (n-k)p/((k+1)(1-p))$, which converges to $r/(k+1)$, matching the Poisson recurrence $\\text{Poi}(k+1) = \\text{Poi}(k) \\cdot r/(k+1)$."
+    ],
+    "prerequisites": [
+      "Binomial theorem: $(x+y)^n = \\sum \\binom{n}{k} x^k y^{n-k}$",
+      "Binomial coefficients and the absorption identity",
+      "Vandermonde's convolution identity",
+      "Derivative of $\\log$ and continuity of $\\exp$ (for Poisson limit)",
+      "Filter-based limits in Mathlib (`Filter.Tendsto`, `atTop`)"
     ]
   },
   "sections": [
@@ -78,82 +124,90 @@
       "title": "The Binomial Distribution PMF",
       "startLine": 25,
       "endLine": 44,
-      "summary": "Definition of binomPMF and basic properties: P(0), P(n), non-negativity."
+      "summary": "Defines $\\text{binomPMF}(n, p, k) = \\binom{n}{k} p^k (1-p)^{n-k}$ as a real-valued function. Proves boundary values $P(0) = (1-p)^n$, $P(n) = p^n$, and non-negativity $P(k) \\geq 0$ for $p \\in [0,1]$."
     },
     {
       "id": "normalization",
       "title": "Normalization from the Binomial Theorem",
       "startLine": 46,
       "endLine": 64,
-      "summary": "The PMF sums to 1, proved by (p + (1-p))^n = 1."
+      "summary": "Proves $\\sum_{k=0}^{n} \\text{PMF}(k) = 1$ by substituting $q = 1-p$ into the binomial expansion $(p+q)^n$, giving $(p + (1-p))^n = 1^n = 1$. Also shows the sum is independent of $p$."
     },
     {
       "id": "symmetry",
       "title": "Symmetry",
       "startLine": 66,
       "endLine": 73,
-      "summary": "P(k;n,p) = P(n-k;n,1-p) via choose symmetry."
+      "summary": "Proves $P(k; n, p) = P(n-k; n, 1-p)$ for $k \\leq n$, using the symmetry $\\binom{n}{k} = \\binom{n}{n-k}$. Swapping success and failure probabilities reflects the distribution."
     },
     {
       "id": "mean",
       "title": "Mean via Absorption Identity",
       "startLine": 75,
       "endLine": 127,
-      "summary": "E[X] = np proved using the absorption identity (k+1)C(n+1,k+1) = (n+1)C(n,k)."
+      "summary": "Proves $E[X] = np$ using the **absorption identity** $(k+1)\\binom{n+1}{k+1} = (n+1)\\binom{n}{k}$. Each term $k \\cdot \\text{PMF}(k)$ is rewritten as $(n+1)p$ times a degree-$(n-1)$ binomial term, and the resulting sum equals 1 by normalization."
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
       "startLine": 129,
       "endLine": 161,
-      "summary": "Fair coin, Bernoulli, certain event, impossible event."
+      "summary": "Four concrete instances: **fair coin** $P(k) = \\binom{n}{k}/2^n$, **Bernoulli** $P(1; 1, p) = p$ and $P(0; 1, p) = 1-p$, **certain event** $P(n; n, 1) = 1$, and **impossible event** $P(0; n, 0) = 1$."
     },
     {
       "id": "monotonicity",
       "title": "Monotonicity",
       "startLine": 163,
       "endLine": 171,
-      "summary": "The mean np is monotone in p."
+      "summary": "The mean $np$ is monotone in $p$: if $p \\leq q$ then $np \\leq nq$. A simple consequence of $n \\geq 0$."
     },
     {
       "id": "pgf",
       "title": "Probability Generating Function",
       "startLine": 173,
       "endLine": 207,
-      "summary": "PGF E[t^X] = (pt+1-p)^n, its value at t=1, and derivative interpretation."
+      "summary": "Proves $E[t^X] = (pt + 1-p)^n$ by replacing $p$ with $pt$ in the binomial expansion. Verifies: PGF at $t=1$ recovers normalization ($=1$), and the formal derivative at $t=1$ gives the mean $np$."
     },
     {
       "id": "second-factorial-moment",
       "title": "Double Absorption and Second Factorial Moment",
       "startLine": 209,
       "endLine": 268,
-      "summary": "E[X(X-1)] = n(n-1)p^2 via double absorption, then Var(X) = np(1-p)."
+      "summary": "Proves double absorption $(k+2)(k+1)\\binom{n+2}{k+2} = (n+2)(n+1)\\binom{n}{k}$, giving $E[X(X-1)] = n(n-1)p^2$. Then derives $\\text{Var}(X) = E[X^2] - (E[X])^2 = n(n-1)p^2 + np - n^2p^2 = np(1-p)$."
     },
     {
       "id": "convolution",
       "title": "Convolution via Vandermonde's Identity",
       "startLine": 270,
       "endLine": 329,
-      "summary": "Bin(n,p) * Bin(m,p) = Bin(n+m,p): sum of independent binomials is binomial."
+      "summary": "Proves Vandermonde's identity $\\binom{n+m}{k} = \\sum_{j=0}^{k} \\binom{n}{j}\\binom{m}{k-j}$ using `Nat.add_choose_eq`, then translates it to: $\\sum_j \\text{PMF}_n(j) \\cdot \\text{PMF}_m(k-j) = \\text{PMF}_{n+m}(k)$. This is the reproductive property: $\\text{Bin}(n,p) * \\text{Bin}(m,p) = \\text{Bin}(n+m,p)$."
     },
     {
       "id": "poisson-limit",
       "title": "Poisson Limit Theorem",
       "startLine": 331,
-      "endLine": 553,
-      "summary": "Full Poisson limit theorem: Bin(n,r/n) -> Poi(r) pointwise. Includes proof of (1+x/n)^n -> exp(x) from the derivative of log at 1."
+      "endLine": 558,
+      "summary": "The centerpiece: proves $(1+x/n)^n \\to e^x$ from first principles (via $\\text{HasDerivAt}(\\log(1+t), 1, 0)$ and continuity of $\\exp$), defines the Poisson PMF $e^{-r} r^k / k!$, and proves the Poisson limit theorem $\\text{Bin}(n, r/n) \\to \\text{Poi}(r)$ pointwise by induction on $k$, using the PMF ratio $\\text{PMF}(k+1)/\\text{PMF}(k) \\to r/(k+1)$."
     },
     {
       "id": "summary",
       "title": "Extended Summary",
-      "startLine": 555,
-      "endLine": 582,
-      "summary": "Summary theorem combining all results: normalization, mean, variance, PGF, fair coin, convolution, and Poisson limit."
+      "startLine": 560,
+      "endLine": 588,
+      "summary": "A single conjunction theorem packaging all seven results: normalization, mean $np$, variance $np(1-p)$, PGF $(pt+1-p)^n$, fair coin formula, Vandermonde convolution, and the Poisson limit. Serves as a machine-checkable summary of the OQ-03 answer."
     }
   ],
   "conclusion": {
-    "summary": "All key properties of the binomial distribution -- normalization, mean, variance, symmetry, generating function, special cases, convolution, and Poisson limit -- are derived purely from the algebraic binomial theorem. The classical limit (1+x/n)^n -> exp(x) is proved from first principles using the derivative of log. This is a fully verified formalization with 0 sorries and 0 axioms.",
-    "implications": "This formalization demonstrates that discrete probability distributions can be studied entirely within algebra, without measure-theoretic foundations. The Poisson limit theorem connects discrete and continuous probability, and the (1+x/n)^n -> exp(x) limit is a foundational result not currently in Mathlib.",
-    "openQuestions": []
+    "summary": "All key properties of the binomial distribution — normalization, mean $np$, variance $np(1-p)$, symmetry, PGF $(pt+1-p)^n$, convolution, and the Poisson limit — are derived purely from the algebraic binomial theorem, with 0 sorries and 0 axioms. The classical limit $(1+x/n)^n \\to e^x$ is proved from first principles using $\\log'(1) = 1$ and continuity of $\\exp$.",
+    "implications": "This formalization demonstrates that discrete probability can be studied entirely within algebra, without measure-theoretic foundations. Every result traces back to a single identity: $(p + (1-p))^n = 1$. The Poisson limit theorem bridges discrete and continuous probability — the passage from $\\text{Bin}(n, r/n)$ to $\\text{Poi}(r)$ is a prototype for all 'law of rare events' arguments. The first-principles proof of $(1+x/n)^n \\to e^x$ fills a gap in Mathlib v4.26.0 and could be contributed upstream. The algebraic approach via absorption and Vandermonde generalizes: the same techniques apply to negative binomial, hypergeometric, and multinomial distributions.",
+    "openQuestions": [
+      "Can the de Moivre-Laplace central limit theorem $\\text{Bin}(n,p) \\approx \\mathcal{N}(np, np(1-p))$ be proved using the same algebraic approach, perhaps via the moment generating function?",
+      "Can the $(1+x/n)^n \\to e^x$ limit proved here be contributed to Mathlib as `tendsto_one_plus_div_pow_exp`?",
+      "Can the multinomial distribution be formalized analogously from the multinomial theorem $(x_1 + \\cdots + x_m)^n$?"
+    ],
+    "crossReferences": [
+      { "proofId": "binomial-theorem", "relationship": "Parent proof — the algebraic binomial theorem from which all distribution properties are derived." },
+      { "proofId": "binomial-theorem-oq-01", "relationship": "Sibling OQ — another open question exploring consequences of the binomial theorem." }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Deepened `historicalContext` with Bernoulli, de Moivre, Laplace, Vandermonde, Euler, Poisson
- Added 4 references (Bernoulli 1713, Poisson 1837, Vandermonde 1772, de Moivre 1733)
- Expanded `proofStrategy` to cover all 11 parts with LaTeX
- Enriched all 11 sections with LaTeX summaries
- Rebuilt annotations from 8 non-standard (lineNumber/tags) to 14 standard format with mathContext, significance, relatedConcepts, prerequisites
- Added `openQuestions` and `crossReferences` to conclusion
- Expanded `mathlibDependencies` from 4 to 6

## Test plan
- [x] `pnpm annotations:build` passes with zero errors for this entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)