### PR TITLE
Enrich Desargues OQ-02 (Moulton Plane): 12 annotations, deeper context

### DIFF
--- a/src/data/proofs/desargues-theorem-oq-02/annotations.json
+++ b/src/data/proofs/desargues-theorem-oq-02/annotations.json
@@ -1,44 +1,146 @@
 [
   {
-    "lineNumber": 51,
-    "content": "The MLine inductive type captures the three kinds of Moulton lines. A bent line with parameter (m, b) where m < 0 uses slope m for x ≤ 0 and slope 2m for x > 0, creating a 'bend' at the y-axis.",
+    "id": "ann-desargues-oq02-mpoint-mline",
+    "proofId": "desargues-theorem-oq-02",
+    "range": { "startLine": 32, "endLine": 38 },
     "type": "definition",
-    "tags": ["moulton-plane", "incidence-geometry"]
+    "title": "Moulton Points and Lines",
+    "content": "Defines the Moulton plane's primitives: points are rational pairs $\\mathbb{Q} \\times \\mathbb{Q}$, and lines come in three flavors — standard (slope $m$, intercept $b$), bent (negative slope that doubles for $x > 0$), and vertical. Using $\\mathbb{Q}$ instead of $\\mathbb{R}$ enables exact arithmetic verification via `norm_num`, eliminating any approximation issues in the counterexample.",
+    "mathContext": "An `MLine` is either $y = mx + b$ (standard), piecewise $y = mx + b$ for $x \\leq 0$ and $y = 2mx + b$ for $x > 0$ (bent), or $x = a$ (vertical). The bent constructor is the distinctive feature of the Moulton plane.",
+    "significance": "critical",
+    "relatedConcepts": ["incidence geometry", "affine planes", "projective planes", "non-Desarguesian geometry"],
+    "prerequisites": ["rational arithmetic", "inductive types"]
   },
   {
-    "lineNumber": 57,
-    "content": "The disjunctive definition ensures that for bent lines, a point must satisfy exactly one branch depending on its x-coordinate. This piecewise structure is what breaks Desargues's theorem.",
+    "id": "ann-desargues-oq02-online",
+    "proofId": "desargues-theorem-oq-02",
+    "range": { "startLine": 40, "endLine": 50 },
+    "type": "definition",
+    "title": "Moulton Incidence and Collinearity",
+    "content": "Defines the incidence relation `onLine` and Moulton-collinearity. For bent lines, incidence is a disjunction: either the point lies on the left branch ($x \\leq 0$, slope $m$) or the right branch ($x > 0$, slope $2m$). This piecewise structure is the precise mechanism that breaks Desargues's theorem — the doubled slope for positive $x$ shifts intersection points away from their Euclidean positions.",
+    "mathContext": "For bent line $(m, b)$: $\\text{onLine}((x,y), \\text{bent}\\, m\\, b) \\iff (x \\leq 0 \\wedge y = mx + b) \\vee (x > 0 \\wedge y = 2mx + b)$. Three points are Moulton-collinear iff $\\exists l : \\text{MLine},\\ \\text{onLine}(p, l) \\wedge \\text{onLine}(q, l) \\wedge \\text{onLine}(r, l)$.",
+    "significance": "critical",
+    "relatedConcepts": ["piecewise functions", "incidence relation", "collinearity", "affine geometry"],
+    "prerequisites": ["disjunctive definitions", "slope-intercept form"]
+  },
+  {
+    "id": "ann-desargues-oq02-config",
+    "proofId": "desargues-theorem-oq-02",
+    "range": { "startLine": 65, "endLine": 71 },
+    "type": "definition",
+    "title": "Counterexample Configuration",
+    "content": "Defines the seven key points: center of perspectivity $O = (-4, 12)$ and two triangles $\\triangle ABC$ and $\\triangle A'B'C'$. All vertices have $x \\leq 0$, which is crucial — the perspectivity lines (connecting corresponding vertices through $O$) are unaffected by Moulton bending. Only the side lines that cross the $y$-axis with negative slope trigger the bending.",
+    "mathContext": "Center $O = (-4, 12)$. Triangle: $A = (-8, 8)$, $B = (-5, 8)$, $C = (-4, 6)$. Primed triangle: $A' = (-14, 2)$, $B' = (-7, 0)$, $C' = (-4, 3)$. Since all $x$-coordinates are $\\leq 0$, the perspectivity relations use only the left branch of bent lines.",
+    "significance": "key",
+    "relatedConcepts": ["perspectivity", "triangle", "center of perspectivity", "Desargues configuration"],
+    "prerequisites": ["coordinate geometry", "rational coordinates"]
+  },
+  {
+    "id": "ann-desargues-oq02-perspectivity",
+    "proofId": "desargues-theorem-oq-02",
+    "range": { "startLine": 78, "endLine": 105 },
+    "type": "definition",
+    "title": "Perspectivity from Point O",
+    "content": "Proves that the two triangles are in perspective from $O$: lines $AA'$, $BB'$, $CC'$ all pass through $O$. Line $OA$ has slope 1 (standard), $OB$ has slope 4 (standard), and $OC$ is vertical ($x = -4$). All incidences are verified by `norm_num`. The `perspective_from_point` theorem bundles all 9 incidence statements.",
+    "mathContext": "Lines: $\\overline{OAA'}: y = x + 16$, $\\overline{OBB'}: y = 4x + 28$, $\\overline{OCC'}: x = -4$. All three are standard or vertical (non-negative slopes or vertical), so Moulton bending does not affect the perspectivity verification.",
+    "significance": "key",
+    "relatedConcepts": ["perspectivity from a point", "concurrent lines", "Desargues's theorem hypothesis"],
+    "prerequisites": ["slope-intercept form", "concurrency"]
+  },
+  {
+    "id": "ann-desargues-oq02-side-lines",
+    "proofId": "desargues-theorem-oq-02",
+    "range": { "startLine": 111, "endLine": 145 },
+    "type": "definition",
+    "title": "Side Lines and Classification",
+    "content": "Defines and verifies all six side lines. Three have negative slope and are bent: $A'B'$ (slope $-2/7$), $BC$ (slope $-2$), $CA$ (slope $-1/2$). Three have non-negative slope and are standard: $AB$ (slope 0), $B'C'$ (slope 1), $C'A'$ (slope $1/10$). Only $CA$ crosses the $y$-axis with negative slope in a way that affects the counterexample, because its intersection with $C'A'$ occurs at $x = 6/11 > 0$.",
+    "mathContext": "Side lines: $AB: y = 8$ (horizontal), $A'B': y = -\\frac{2}{7}x - 2$ (bent), $BC: y = -2x - 2$ (bent), $B'C': y = x + 7$ (standard), $CA: y = -\\frac{1}{2}x + 4$ (bent), $C'A': y = \\frac{1}{10}x + \\frac{17}{5}$ (standard). Each vertex incidence is proved by `norm_num` or `bent_left`.",
+    "significance": "key",
+    "relatedConcepts": ["side lines of a triangle", "slope classification", "incidence verification"],
+    "prerequisites": ["slope computation", "line equations"]
+  },
+  {
+    "id": "ann-desargues-oq02-beta",
+    "proofId": "desargues-theorem-oq-02",
+    "range": { "startLine": 160, "endLine": 169 },
     "type": "insight",
-    "tags": ["moulton-plane", "incidence"]
+    "title": "The Critical Intersection: Beta",
+    "content": "The intersection $\\beta = CA \\cap C'A' = (6/11, 38/11)$ is the heart of the counterexample. Line $CA$ has Moulton slope $-1/2$, and since $\\beta$ has $x = 6/11 > 0$, the bent branch activates: the effective slope becomes $2 \\times (-1/2) = -1$. In the Euclidean plane, $CA \\cap C'A' = (1, 7/2)$; the Moulton bending shifts this to $(6/11, 38/11)$, breaking the collinearity with the other two intersection points.",
+    "mathContext": "On $CA$ (bent, $m = -1/2$, $b = 4$) at $x = 6/11 > 0$: $y = 2(-1/2)(6/11) + 4 = -6/11 + 4 = 38/11$. On $C'A'$ (standard, $m = 1/10$, $b = 17/5$): $y = (1/10)(6/11) + 17/5 = 6/110 + 374/110 = 380/110 = 38/11$. Confirmed: $\\beta = (6/11, 38/11)$.",
+    "significance": "critical",
+    "relatedConcepts": ["piecewise intersection", "Euclidean vs Moulton geometry", "slope doubling"],
+    "prerequisites": ["line intersection", "piecewise linear functions"]
   },
   {
-    "lineNumber": 109,
-    "content": "All six side lines are explicitly classified: AB (horizontal), B'C' and C'A' have positive/zero slope (standard), while A'B' (slope -2/7), BC (slope -2), and CA (slope -1/2) have negative slope (bent). Only CA's bending affects the counterexample.",
-    "type": "observation",
-    "tags": ["side-lines", "slope-analysis"]
+    "id": "ann-desargues-oq02-alpha-gamma",
+    "proofId": "desargues-theorem-oq-02",
+    "range": { "startLine": 151, "endLine": 178 },
+    "type": "theorem",
+    "title": "All Three Intersection Points",
+    "content": "Computes the three side-intersection points: $\\alpha = BC \\cap B'C' = (-3, 4)$, $\\beta = CA \\cap C'A' = (6/11, 38/11)$, and $\\gamma = AB \\cap A'B' = (-35, 8)$. Points $\\alpha$ and $\\gamma$ have $x \\leq 0$, so their intersections use the standard (unbent) part of the lines. Only $\\beta$ has $x > 0$, triggering the slope doubling.",
+    "mathContext": "$\\alpha = (-3, 4)$: $BC$ bent at $x = -3 \\leq 0$, so $y = -2(-3) - 2 = 4$; $B'C'$ standard gives $y = -3 + 7 = 4$. $\\gamma = (-35, 8)$: $AB$ standard gives $y = 8$; $A'B'$ bent at $x = -35 \\leq 0$, so $y = -\\frac{2}{7}(-35) - 2 = 8$.",
+    "significance": "key",
+    "relatedConcepts": ["corresponding sides", "line intersection", "Desargues axis"],
+    "prerequisites": ["system of linear equations", "bent line evaluation"]
   },
   {
-    "lineNumber": 153,
-    "content": "The critical computation: line CA has Moulton slope -1/2, so for x > 0 the effective slope is 2×(-1/2) = -1. The intersection with C'A' (slope 1/10) at x = 6/11 gives y = 38/11 instead of the Euclidean value 7/2.",
-    "type": "key-computation",
-    "tags": ["moulton-bending", "intersection-shift"]
+    "id": "ann-desargues-oq02-noncollinear",
+    "proofId": "desargues-theorem-oq-02",
+    "range": { "startLine": 190, "endLine": 224 },
+    "type": "theorem",
+    "title": "Non-Collinearity Proof",
+    "content": "Proves $\\neg \\text{MoultonCollinear}(\\alpha, \\beta, \\gamma)$ by exhaustive case analysis over the three `MLine` constructors. For standard lines: the system $4 = -3m + b$, $38/11 = (6/11)m + b$, $8 = -35m + b$ is inconsistent ($m = -1/8$, $b = 29/8$ satisfies the first and third but gives $313/88 \\neq 304/88$ for the second). For bent lines: $\\alpha$ and $\\gamma$ force the left branch ($m = -1/8$, $b = 29/8$), but $\\beta$ uses the right branch where $2(-1/8)(6/11) + 29/8 = 307/88 \\neq 304/88$. For vertical: $x$-coordinates $-3 \\neq 6/11$.",
+    "mathContext": "Standard case: the overdetermined system has discrepancy $313/88 - 304/88 = 9/88$. Bent case: discrepancy $307/88 - 304/88 = 3/88$. Both contradictions are derived by `linarith`. The bent case yields the tighter gap because the doubled slope partially compensates, but not enough.",
+    "significance": "critical",
+    "relatedConcepts": ["proof by contradiction", "case analysis", "overdetermined linear systems", "linarith tactic"],
+    "prerequisites": ["linear algebra over rationals", "exhaustive case analysis"]
   },
   {
-    "lineNumber": 210,
-    "content": "The non-collinearity proof works by contradiction: assume some MLine l passes through all three points, then case-split on l's constructor. For standard and bent lines, linear algebra (linarith) derives a contradiction from the overdetermined system. For vertical lines, the x-coordinates disagree.",
-    "type": "proof-strategy",
-    "tags": ["non-collinearity", "case-analysis"]
+    "id": "ann-desargues-oq02-main",
+    "proofId": "desargues-theorem-oq-02",
+    "range": { "startLine": 233, "endLine": 250 },
+    "type": "theorem",
+    "title": "Desargues Fails in the Moulton Plane",
+    "content": "The culminating theorem: assembles all components into a single 13-conjunct statement showing Desargues's theorem fails. The first 9 conjuncts establish perspectivity from $O$, the next 6 verify that $\\alpha, \\beta, \\gamma$ lie on the correct side-intersection pairs, and the final conjunct negates Moulton-collinearity. This is a constructive counterexample: all data is explicit and all verification is by computation.",
+    "mathContext": "The theorem states: two triangles $\\triangle ABC$, $\\triangle A'B'C'$ are perspective from point $O$ (three concurrent line triples), the three side-intersection points are correctly computed ($\\alpha, \\beta, \\gamma$), yet $\\neg \\text{MoultonCollinear}(\\alpha, \\beta, \\gamma)$. Desargues's theorem would require collinearity.",
+    "significance": "critical",
+    "relatedConcepts": ["Desargues's theorem", "counterexample", "incidence theorem failure", "projective geometry"],
+    "prerequisites": ["perspectivity", "collinearity", "Moulton plane"]
   },
   {
-    "lineNumber": 263,
-    "content": "The main theorem assembles 13 conjuncts: 9 perspectivity incidences, 6 side-intersection incidences (grouped as 3 pairs), and the non-collinearity negation. This is the complete formal statement that Desargues fails in the Moulton plane.",
-    "type": "theorem-summary",
-    "tags": ["main-theorem", "desargues-failure"]
+    "id": "ann-desargues-oq02-nondegen",
+    "proofId": "desargues-theorem-oq-02",
+    "range": { "startLine": 256, "endLine": 308 },
+    "type": "theorem",
+    "title": "Non-Degeneracy of Both Triangles",
+    "content": "Proves that both triangles are non-degenerate: vertices are pairwise distinct and the three vertices of each triangle are not Moulton-collinear. The non-collinearity proofs follow the same structure as the main non-collinearity theorem — case analysis over MLine constructors with `linarith` deriving contradictions from overdetermined systems. This ensures the counterexample is genuine (not a degenerate configuration).",
+    "mathContext": "$A \\neq B \\neq C \\neq A$ and $A' \\neq B' \\neq C' \\neq A'$ (6 distinctness conditions). $\\neg \\text{MoultonCollinear}(A, B, C)$ and $\\neg \\text{MoultonCollinear}(A', B', C')$ (neither triangle degenerates to a line).",
+    "significance": "supporting",
+    "relatedConcepts": ["non-degeneracy", "general position", "triangle inequality"],
+    "prerequisites": ["vertex distinctness", "collinearity test"]
   },
   {
-    "lineNumber": 325,
-    "content": "The gap of 3/88 is the exact arithmetic discrepancy: the Moulton line through α and γ (bent, slope -1/8) evaluates to 307/88 at x = 6/11, while β has y = 38/11 = 304/88. This tiny gap (≈ 0.034) is enough to break Desargues.",
-    "type": "computation",
-    "tags": ["gap", "arithmetic-verification"]
+    "id": "ann-desargues-oq02-euclidean",
+    "proofId": "desargues-theorem-oq-02",
+    "range": { "startLine": 317, "endLine": 321 },
+    "type": "insight",
+    "title": "Euclidean Collinearity Contrast",
+    "content": "Demonstrates that in the standard Euclidean plane (all lines standard), the same three intersection points ARE collinear — they all lie on $y = -x/8 + 29/8$. The Euclidean $\\beta$ would be $(1, 7/2)$ instead of $(6/11, 38/11)$. This proves the non-collinearity is purely a consequence of the Moulton bending, not an artifact of the chosen coordinates.",
+    "mathContext": "Euclidean collinearity: $\\alpha = (-3, 4)$, $\\beta_{\\text{Euc}} = (1, 7/2)$, $\\gamma = (-35, 8)$ all satisfy $y = -\\frac{1}{8}x + \\frac{29}{8}$. The line $y = -x/8 + 29/8$ passes through all three: $4 = 3/8 + 29/8 = 32/8$, $7/2 = -1/8 + 29/8 = 28/8$, $8 = 35/8 + 29/8 = 64/8$.",
+    "significance": "key",
+    "relatedConcepts": ["Euclidean geometry", "collinearity", "Desargues's theorem validity", "comparison geometry"],
+    "prerequisites": ["standard line equations", "collinearity criterion"]
+  },
+  {
+    "id": "ann-desargues-oq02-gap",
+    "proofId": "desargues-theorem-oq-02",
+    "range": { "startLine": 327, "endLine": 330 },
+    "type": "theorem",
+    "title": "The 3/88 Moulton Gap",
+    "content": "Quantifies the exact arithmetic discrepancy caused by Moulton bending: the bent line through $\\alpha$ and $\\gamma$ (slope $-1/8$) evaluates to $307/88$ at $x = 6/11$ using the doubled slope, while $\\beta_y = 38/11 = 304/88$. The gap of $3/88 \\approx 0.034$ is the precise obstruction to Desargues's theorem. This makes the counterexample not just qualitative but quantitatively sharp.",
+    "mathContext": "Gap computation: $2 \\cdot (-1/8) \\cdot (6/11) + 29/8 = -12/88 + 319/88 = 307/88$. Beta: $38/11 = 304/88$. Discrepancy: $307/88 - 304/88 = 3/88$.",
+    "significance": "key",
+    "relatedConcepts": ["arithmetic verification", "exact computation", "norm_num", "quantitative obstruction"],
+    "prerequisites": ["rational arithmetic", "Moulton slope doubling"]
   }
 ]

--- a/src/data/proofs/desargues-theorem-oq-02/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-02/meta.json
@@ -41,7 +41,7 @@
     "dateAdded": "02/26/26"
   },
   "overview": {
-    "historicalContext": "Forest Ray Moulton introduced the Moulton plane in 1902 as a counterexample to Desargues's theorem in incidence geometry. While Desargues's theorem holds in all projective planes coordinatizable by a division ring (as shown in OQ-01), the Moulton plane demonstrates that modifying the line structure — even over the same point set — can break this fundamental theorem. The Moulton plane has the same points as ℝ² but 'bends' lines with negative slope at the y-axis, doubling their slope for positive x-values.",
+    "historicalContext": "Girard Desargues stated his theorem around 1639 in the context of perspective drawing and projective geometry. The theorem — that two triangles in perspective from a point are also in perspective from a line — holds in every projective plane coordinatizable by a division ring, a result formalized in OQ-01 using cross-product algebra. Forest Ray Moulton (1902) constructed the first concrete counterexample: an affine plane with the same point set as $\\mathbb{R}^2$ but modified lines, where negative slopes double upon crossing the $y$-axis. This showed that Desargues's theorem is not a consequence of the incidence axioms alone — it depends on the algebraic structure of the coordinate system. The Hessenberg-Artin theorem (Karl Hessenberg 1905, Emil Artin 1957) later proved the converse: a projective plane is Desarguesian if and only if it is coordinatizable by a division ring. The Moulton plane thus occupies a central place in the classification of projective planes and serves as the canonical example in most modern textbooks on incidence geometry (e.g., Hartshorne's *Foundations of Projective Geometry*).",
     "problemStatement": "**Open Question (OQ-02):** How can we formalize non-Desarguesian planes in Lean to demonstrate when Desargues's theorem fails?\n\n**Answer:** Construct the Moulton plane over ℚ with an explicit counterexample:\n- **Points:** ℚ × ℚ (rational coordinates)\n- **Lines:** Standard (slope ≥ 0), bent (slope < 0, doubles for x > 0), or vertical\n- **Counterexample:** Two triangles perspective from O = (-4, 12) whose side-intersections fail to be Moulton-collinear\n\nThe bending of line CA (slope -1/2 → -1 for x > 0) shifts one intersection point, breaking the alignment by 3/88.",
     "proofStrategy": "The proof has three components:\n\n**1. Moulton Plane Definitions:** An inductive type `MLine` with three constructors (standard, bent, vertical) and a piecewise incidence relation `onLine` that doubles negative slopes for x > 0.\n\n**2. Counterexample Construction:** Six vertices forming two triangles, all at x ≤ 0 (so the perspectivity lines are unaffected by bending). The side line CA has slope -1/2, which becomes -1 for x > 0, shifting the intersection CA ∩ C'A' from (1, 7/2) to (6/11, 38/11).\n\n**3. Non-Collinearity Proof:** Exhaustive case analysis over all three MLine constructors shows no Moulton line passes through all three intersection points. The key arithmetic: any line through α=(-3,4) and γ=(-35,8) misses β=(6/11,38/11) — by 9/88 for standard lines and 3/88 for bent lines.",
     "keyInsights": [
@@ -57,57 +57,57 @@
       "id": "moulton-plane",
       "title": "The Moulton Plane",
       "startLine": 1,
-      "endLine": 60,
-      "summary": "Definitions: MPoint (ℚ²), MLine (standard/bent/vertical), onLine incidence relation, MoultonCollinear."
+      "endLine": 59,
+      "summary": "Defines the Moulton plane primitives: $\\text{MPoint} = \\mathbb{Q} \\times \\mathbb{Q}$, the inductive `MLine` type (standard/bent/vertical), the piecewise incidence relation `onLine` where bent lines use slope $m$ for $x \\leq 0$ and $2m$ for $x > 0$, and `MoultonCollinear` (three points on a common Moulton line)."
     },
     {
       "id": "configuration",
       "title": "Counterexample Configuration",
-      "startLine": 62,
-      "endLine": 72,
-      "summary": "The seven points: center O and two triangles ABC, A'B'C', all with x ≤ 0."
+      "startLine": 61,
+      "endLine": 71,
+      "summary": "Seven rational points: center $O = (-4, 12)$ and two triangles $\\triangle ABC = \\{(-8,8), (-5,8), (-4,6)\\}$, $\\triangle A'B'C' = \\{(-14,2), (-7,0), (-4,3)\\}$. All vertices have $x \\leq 0$, ensuring perspectivity lines avoid Moulton bending."
     },
     {
       "id": "perspectivity",
       "title": "Perspectivity from Point O",
-      "startLine": 74,
+      "startLine": 73,
       "endLine": 105,
-      "summary": "Three perspectivity lines (standard slope 1, standard slope 4, vertical) all pass through O and corresponding vertex pairs."
+      "summary": "Proves $AA'$, $BB'$, $CC'$ all pass through $O$: $\\overline{OAA'}: y = x + 16$ (standard), $\\overline{OBB'}: y = 4x + 28$ (standard), $\\overline{OCC'}: x = -4$ (vertical). Bundles all 9 incidences into `perspective_from_point`."
     },
     {
       "id": "side-lines",
       "title": "Side Lines and Vertex Verification",
       "startLine": 107,
-      "endLine": 143,
-      "summary": "Six side lines (3 bent, 3 standard) with verified vertex incidences."
+      "endLine": 145,
+      "summary": "Defines 6 side lines: bent $A'B'$ ($m = -2/7$), $BC$ ($m = -2$), $CA$ ($m = -1/2$); standard $AB$ ($m = 0$), $B'C'$ ($m = 1$), $C'A'$ ($m = 1/10$). Verifies 12 vertex incidences. Only $CA$'s bending affects the counterexample at $\\beta$."
     },
     {
       "id": "intersections",
       "title": "Moulton Intersection Points",
-      "startLine": 145,
-      "endLine": 195,
-      "summary": "Three intersection points: α=(-3,4), β=(6/11,38/11), γ=(-35,8). Beta uses the bent branch of line CA."
+      "startLine": 147,
+      "endLine": 178,
+      "summary": "Computes $\\alpha = BC \\cap B'C' = (-3, 4)$, $\\beta = CA \\cap C'A' = (6/11, 38/11)$, $\\gamma = AB \\cap A'B' = (-35, 8)$. The critical computation: $CA$ has Moulton slope $-1/2$, so at $x = 6/11 > 0$ the effective slope is $-1$, giving $y = 38/11$ instead of the Euclidean $7/2$."
     },
     {
       "id": "non-collinearity",
       "title": "Non-Collinearity Proof",
-      "startLine": 197,
-      "endLine": 245,
-      "summary": "Exhaustive case analysis over MLine constructors proves no Moulton line passes through all three intersection points."
+      "startLine": 180,
+      "endLine": 224,
+      "summary": "Proves $\\neg \\text{MoultonCollinear}(\\alpha, \\beta, \\gamma)$ by case analysis over `MLine` constructors. Standard lines: overdetermined system gives $313/88 \\neq 304/88$ (gap $9/88$). Bent lines: right branch gives $307/88 \\neq 304/88$ (gap $3/88$). Vertical: $x$-coordinates $-3 \\neq 6/11$."
     },
     {
       "id": "main-theorem",
-      "title": "Main Theorem",
-      "startLine": 247,
-      "endLine": 280,
-      "summary": "desargues_fails_in_moulton: complete statement combining perspectivity, side-intersections, and non-collinearity."
+      "title": "Main Theorem: Desargues Fails",
+      "startLine": 226,
+      "endLine": 250,
+      "summary": "`desargues_fails_in_moulton`: 13-conjunct theorem assembling perspectivity (9 incidences), side-intersections (6 incidences), and $\\neg \\text{MoultonCollinear}(\\alpha, \\beta, \\gamma)$. Complete formal statement that Desargues's theorem fails in the Moulton plane."
     },
     {
       "id": "structural",
-      "title": "Structural Properties",
-      "startLine": 282,
+      "title": "Structural Properties and Comparison",
+      "startLine": 252,
       "endLine": 332,
-      "summary": "Non-degeneracy of both triangles, vertex distinctness, Euclidean comparison, and gap computation."
+      "summary": "Non-degeneracy: both triangles are non-collinear and vertices are pairwise distinct. Euclidean comparison: the same $\\alpha, \\beta_{\\text{Euc}} = (1, 7/2), \\gamma$ ARE collinear on $y = -x/8 + 29/8$, proving the failure is caused by Moulton bending. Moulton gap: the exact arithmetic discrepancy is $3/88$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Replaced 7 old-format annotations with 12 proper annotations (id, range, mathContext, significance, etc.)
- Each annotation includes LaTeX `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- Deepened `historicalContext` (~750 chars) with Desargues (1639), Hessenberg-Artin theorem, Hartshorne reference
- Enriched all 8 section summaries with LaTeX notation and corrected line ranges
- Key annotations cover: Moulton bending mechanism, beta intersection shift from $(1, 7/2)$ to $(6/11, 38/11)$, the $3/88$ gap, exhaustive non-collinearity proof, Euclidean contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)