### PR TITLE
Enrich Zolotarev QR (OQ-01): 11 annotations, fix axiom status, correct sections

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01/annotations.json
@@ -1,32 +1,134 @@
 [
   {
-    "lineNumber": 45,
-    "content": "**Multiplication Permutation**: For a unit $a \\in (\\mathbb{Z}/p\\mathbb{Z})^\\times$, the map $x \\mapsto ax$ is a bijection on the units. The inverse is $x \\mapsto a^{-1}x$. This is the central object in Zolotarev's approach — its permutation signature encodes the Legendre symbol.",
-    "type": "definition"
+    "id": "ann-zolotarev-mulperm",
+    "proofId": "elementary-quadratic-reciprocity-oq-01",
+    "range": { "startLine": 43, "endLine": 65 },
+    "type": "definition",
+    "title": "Multiplication Permutation and Homomorphism",
+    "content": "Defines `mulPerm a` as the permutation $x \\mapsto ax$ on $(\\mathbb{Z}/p\\mathbb{Z})^\\times$, with inverse $x \\mapsto a^{-1}x$. Proves it respects multiplication (`mulPerm_mul`) and maps the identity to the identity permutation (`mulPerm_one`), then packages these into `mulPermHom`: a group homomorphism $(\\mathbb{Z}/p\\mathbb{Z})^\\times \\to \\mathrm{Perm}((\\mathbb{Z}/p\\mathbb{Z})^\\times)$. This is the left regular representation of the multiplicative group.",
+    "mathContext": "$\\sigma_a : (\\mathbb{Z}/p\\mathbb{Z})^\\times \\to (\\mathbb{Z}/p\\mathbb{Z})^\\times$ defined by $\\sigma_a(x) = ax$. Key property: $\\sigma_{ab} = \\sigma_a \\circ \\sigma_b$ (the map $a \\mapsto \\sigma_a$ is a homomorphism). This is the central object in Zolotarev's 1872 approach.",
+    "significance": "critical",
+    "relatedConcepts": ["regular representation", "Cayley's theorem", "group homomorphism", "permutation group"],
+    "prerequisites": ["group theory", "ZMod", "Equiv.Perm"]
   },
   {
-    "lineNumber": 62,
-    "content": "**Group Homomorphism Property**: The map $a \\mapsto \\sigma_a$ (where $\\sigma_a(x) = ax$) is a group homomorphism $(\\mathbb{Z}/p\\mathbb{Z})^\\times \\to \\mathrm{Perm}((\\mathbb{Z}/p\\mathbb{Z})^\\times)$. This is the regular representation of the multiplicative group.",
-    "type": "insight"
+    "id": "ann-zolotarev-sign-character",
+    "proofId": "elementary-quadratic-reciprocity-oq-01",
+    "range": { "startLine": 72, "endLine": 93 },
+    "type": "definition",
+    "title": "Sign Character and Square Detection",
+    "content": "Defines `signMulHom = sign ∘ mulPerm` as a group homomorphism $(\\mathbb{Z}/p\\mathbb{Z})^\\times \\to \\{\\pm 1\\}$. Proves three key properties: (1) it squares to 1, (2) it is multiplicative, and (3) squares have positive sign. The square detection theorem shows that if $a = b^2$, then $\\sigma_a = \\sigma_b^2$, so $\\mathrm{sign}(\\sigma_a) = \\mathrm{sign}(\\sigma_b)^2 = +1$.",
+    "mathContext": "$\\chi(a) = \\mathrm{sign}(\\sigma_a) \\in \\{\\pm 1\\}$. Key: $\\chi(b^2) = \\mathrm{sign}(\\sigma_b \\circ \\sigma_b) = \\mathrm{sign}(\\sigma_b)^2 = 1$, so all squares map to $+1$. Since $\\chi$ is a quadratic character, exactly half the units map to $-1$ when $p > 2$.",
+    "significance": "critical",
+    "relatedConcepts": ["quadratic character", "permutation sign", "homomorphism composition", "quadratic residues"],
+    "prerequisites": ["permutation sign", "group homomorphisms", "Int.units"]
   },
   {
-    "lineNumber": 74,
-    "content": "**Sign Character**: Composing `mulPerm` with the permutation sign gives a homomorphism to $\\{\\pm 1\\}$. Since $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ is cyclic of even order $p-1$, it has exactly one non-trivial quadratic character — which must be the Legendre symbol.",
-    "type": "insight"
+    "id": "ann-zolotarev-cyclic-infra",
+    "proofId": "elementary-quadratic-reciprocity-oq-01",
+    "range": { "startLine": 455, "endLine": 482 },
+    "type": "theorem",
+    "title": "Cyclic Group Infrastructure",
+    "content": "Proves three foundational facts about $(\\mathbb{Z}/p\\mathbb{Z})^\\times$: (1) cardinality equals $p - 1$ (from Euler's totient), (2) for odd $p$, the order is even (so quadratic characters exist), and (3) a primitive root (generator) exists. The even-order result uses contradiction: if $p$ were even, primality forces $p = 2$.",
+    "mathContext": "$|(\\mathbb{Z}/p\\mathbb{Z})^\\times| = \\varphi(p) = p - 1$ for prime $p$. For odd $p$: $2 \\mid (p-1)$, so the group has elements of order 2 and non-trivial quadratic characters exist. A generator $g$ satisfies $\\langle g \\rangle = (\\mathbb{Z}/p\\mathbb{Z})^\\times$ with $\\mathrm{ord}(g) = p - 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler's totient", "primitive roots", "cyclic groups", "IsCyclic"],
+    "prerequisites": ["prime numbers", "group theory", "Nat.totient"]
   },
   {
-    "lineNumber": 89,
-    "content": "**Square Detection**: If $a = b^2$ is a square, then $\\sigma_a = \\sigma_b \\circ \\sigma_b = \\sigma_b^2$, so $\\mathrm{sign}(\\sigma_a) = \\mathrm{sign}(\\sigma_b)^2 = +1$. This gives a permutation-theoretic proof that quadratic residues have Legendre symbol $+1$.",
-    "type": "proof-technique"
+    "id": "ann-zolotarev-mulperm-analysis",
+    "proofId": "elementary-quadratic-reciprocity-oq-01",
+    "range": { "startLine": 495, "endLine": 509 },
+    "type": "theorem",
+    "title": "Multiplication Permutation Analysis",
+    "content": "Proves two structural properties: (1) `mulPerm a` has no fixed points when $a \\neq 1$ (since $ax = x \\Rightarrow a = 1$, making $\\sigma_a$ a derangement), and (2) `mulPermHom` is injective (evaluate at 1: if $\\sigma_a = \\sigma_b$ then $a \\cdot 1 = b \\cdot 1$). The no-fixed-point property is essential for the cycle analysis of generators.",
+    "mathContext": "For $a \\neq 1$: $\\sigma_a$ is fixed-point-free (a derangement). The support of $\\sigma_a$ equals all of $(\\mathbb{Z}/p\\mathbb{Z})^\\times$. Injectivity: $\\sigma_a = \\sigma_b \\Rightarrow a = b$ (faithful action).",
+    "significance": "key",
+    "relatedConcepts": ["derangement", "fixed-point-free permutation", "faithful group action", "Cayley's theorem"],
+    "prerequisites": ["group actions", "permutation support"]
   },
   {
-    "lineNumber": 124,
-    "content": "**Zolotarev's Lemma (Axiomatized)**: The key result $\\left(\\frac{a}{p}\\right) = \\mathrm{sign}(x \\mapsto ax)$ is axiomatized here. The full proof requires: (1) finding a primitive root $g$ of $(\\mathbb{Z}/p\\mathbb{Z})^\\times$, (2) analyzing the cycle structure of $\\sigma_g$, (3) showing both sides define the same quadratic character. This is a natural target for Aristotle proof search.",
-    "type": "axiom"
+    "id": "ann-zolotarev-char-uniqueness",
+    "proofId": "elementary-quadratic-reciprocity-oq-01",
+    "range": { "startLine": 534, "endLine": 577 },
+    "type": "theorem",
+    "title": "Character Uniqueness on Cyclic Groups",
+    "content": "The key algebraic reduction. Proves: (1) a homomorphism $G \\to \\mathbb{Z}^\\times$ on a cyclic group is determined by its value on a generator, (2) any surjective such homomorphism must send the generator to $-1$ (otherwise the image is trivial), and (3) two surjective homomorphisms $G \\to \\mathbb{Z}^\\times$ are identical. This reduces Zolotarev's Lemma to two surjectivity claims.",
+    "mathContext": "For cyclic $G = \\langle g \\rangle$ and $\\varphi, \\psi: G \\to \\{\\pm 1\\}$ surjective: $\\varphi(g) = -1 = \\psi(g)$ (forced by surjectivity), so $\\varphi(g^n) = (-1)^n = \\psi(g^n)$ for all $n$, giving $\\varphi = \\psi$. This is the uniqueness of the non-trivial quadratic character.",
+    "significance": "critical",
+    "relatedConcepts": ["character theory", "quadratic characters", "cyclic group automorphisms", "Pontryagin duality"],
+    "prerequisites": ["cyclic groups", "group homomorphisms", "surjectivity"]
   },
   {
-    "lineNumber": 177,
-    "content": "**QR from Mathlib**: The QR statement $\\left(\\frac{q}{p}\\right)\\left(\\frac{p}{q}\\right) = (-1)^{\\frac{p-1}{2}\\frac{q-1}{2}}$ comes from Mathlib's `legendreSym.quadratic_reciprocity`. The Zolotarev proof would derive this by analyzing the permutation on $\\mathbb{Z}/pq\\mathbb{Z} \\cong \\mathbb{Z}/p\\mathbb{Z} \\times \\mathbb{Z}/q\\mathbb{Z}$ via CRT.",
-    "type": "insight"
+    "id": "ann-zolotarev-cycle-analysis",
+    "proofId": "elementary-quadratic-reciprocity-oq-01",
+    "range": { "startLine": 147, "endLine": 179 },
+    "type": "theorem",
+    "title": "Generator Cycle Analysis",
+    "content": "Proves that $\\sigma_g$ for a generator $g$ is a single $(p-1)$-cycle, and its sign is $(-1)^{p-2} = -1$ for odd $p$. Every element $y = g^n$ is in the orbit of 1 under $\\sigma_g$ (since $\\sigma_g^n(1) = g^n$), so $\\sigma_g$ has a single orbit of size $p - 1$. The sign of an $n$-cycle is $(-1)^{n-1}$.",
+    "mathContext": "$\\sigma_g$ is a single $(p-1)$-cycle: $1 \\to g \\to g^2 \\to \\cdots \\to g^{p-2} \\to 1$. Sign: $\\mathrm{sign}((p-1)\\text{-cycle}) = (-1)^{p-2}$. For odd $p$: $p - 2$ is odd, so $\\mathrm{sign}(\\sigma_g) = -1$.",
+    "significance": "critical",
+    "relatedConcepts": ["cycle decomposition", "permutation sign", "primitive roots", "cyclic permutations"],
+    "prerequisites": ["cycle structure", "permutation sign formula", "primitive roots"]
+  },
+  {
+    "id": "ann-zolotarev-lemma-proof",
+    "proofId": "elementary-quadratic-reciprocity-oq-01",
+    "range": { "startLine": 295, "endLine": 321 },
+    "type": "theorem",
+    "title": "Zolotarev's Lemma (Proved)",
+    "content": "The central theorem: $\\left(\\frac{a}{p}\\right) = \\mathrm{sign}(\\sigma_a)$ for all units $a \\in (\\mathbb{Z}/p\\mathbb{Z})^\\times$. The proof applies character uniqueness: both `signMulHom` and `legendreCharOnUnits` are surjective homomorphisms $(\\mathbb{Z}/p\\mathbb{Z})^\\times \\to \\mathbb{Z}^\\times$, so they must be equal. A bridge lemma connects `legendreSym p (unitToInt a)` to `quadraticChar (ZMod p) a` via the val round-trip.",
+    "mathContext": "$\\left(\\frac{a}{p}\\right) = \\mathrm{sign}(x \\mapsto ax)$ for all $a \\in (\\mathbb{Z}/p\\mathbb{Z})^\\times$. Proof chain: (1) $\\mathrm{sign} \\circ \\sigma$ is surjective (generator analysis), (2) Legendre character is surjective (non-residues exist), (3) unique quadratic character $\\Rightarrow$ they agree.",
+    "significance": "critical",
+    "relatedConcepts": ["Zolotarev's lemma", "Legendre symbol", "quadratic character", "character uniqueness"],
+    "prerequisites": ["character uniqueness", "cycle analysis", "quadratic non-residues"]
+  },
+  {
+    "id": "ann-zolotarev-consequences",
+    "proofId": "elementary-quadratic-reciprocity-oq-01",
+    "range": { "startLine": 328, "endLine": 347 },
+    "type": "theorem",
+    "title": "Consequences of Zolotarev's Lemma",
+    "content": "Derives two consequences from Zolotarev's Lemma: (1) multiplicativity of the Legendre symbol follows from permutation sign multiplicativity, and (2) squares are quadratic residues because $\\mathrm{sign}(\\sigma_{b^2}) = +1$. These give a purely permutation-theoretic proof of classical Legendre symbol properties.",
+    "mathContext": "Multiplicativity: $\\left(\\frac{ab}{p}\\right) = \\mathrm{sign}(\\sigma_{ab}) = \\mathrm{sign}(\\sigma_a) \\cdot \\mathrm{sign}(\\sigma_b) = \\left(\\frac{a}{p}\\right)\\left(\\frac{b}{p}\\right)$. Square detection: $\\left(\\frac{b^2}{p}\\right) = \\mathrm{sign}(\\sigma_b^2) = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["multiplicativity", "completely multiplicative function", "quadratic residues"],
+    "prerequisites": ["Zolotarev's lemma", "permutation sign multiplicativity"]
+  },
+  {
+    "id": "ann-zolotarev-qr",
+    "proofId": "elementary-quadratic-reciprocity-oq-01",
+    "range": { "startLine": 370, "endLine": 387 },
+    "type": "theorem",
+    "title": "Quadratic Reciprocity and Proof Comparison",
+    "content": "States QR and compares Eisenstein and Zolotarev proof methods. The formula $\\left(\\frac{q}{p}\\right)\\left(\\frac{p}{q}\\right) = (-1)^{\\frac{p-1}{2}\\cdot\\frac{q-1}{2}}$ uses Mathlib's `legendreSym.quadratic_reciprocity`. The `two_proof_methods` theorem bundles QR with Zolotarev's Lemma and sign multiplicativity, demonstrating the complete Zolotarev framework.",
+    "mathContext": "For distinct odd primes $p, q$: $\\left(\\frac{q}{p}\\right)\\left(\\frac{p}{q}\\right) = (-1)^{\\frac{p-1}{2} \\cdot \\frac{q-1}{2}}$. Eisenstein counts lattice points below $y = qx/p$; Zolotarev analyzes the permutation on $\\mathbb{Z}/pq\\mathbb{Z} \\cong \\mathbb{Z}/p\\mathbb{Z} \\times \\mathbb{Z}/q\\mathbb{Z}$ via CRT.",
+    "significance": "critical",
+    "relatedConcepts": ["quadratic reciprocity", "Eisenstein proof", "Gauss's golden theorem", "Chinese Remainder Theorem"],
+    "prerequisites": ["Legendre symbol", "odd primes", "Zolotarev's lemma"]
+  },
+  {
+    "id": "ann-zolotarev-supplements",
+    "proofId": "elementary-quadratic-reciprocity-oq-01",
+    "range": { "startLine": 399, "endLine": 408 },
+    "type": "theorem",
+    "title": "First and Second Supplements",
+    "content": "Restates the supplements to QR with permutation-theoretic motivation. First supplement: $-1$ is a square mod $p$ iff $p \\not\\equiv 3 \\pmod{4}$ — via Zolotarev, $\\sigma_{-1}$ is the inversion map with $(p-1)/2$ transpositions. Second supplement: $2$ is a square mod $p$ iff $p \\equiv \\pm 1 \\pmod{8}$ — the cycle structure of $\\sigma_2$ depends on $p \\bmod 8$.",
+    "mathContext": "First: $-1 \\in (\\mathbb{Z}/p\\mathbb{Z})^{\\times 2} \\iff p \\not\\equiv 3 \\pmod{4}$. Second: $2 \\in (\\mathbb{Z}/p\\mathbb{Z})^{\\times 2} \\iff p \\equiv \\pm 1 \\pmod{8}$.",
+    "significance": "key",
+    "relatedConcepts": ["supplements to QR", "quadratic residues", "inversion permutation"],
+    "prerequisites": ["quadratic reciprocity", "modular arithmetic"]
+  },
+  {
+    "id": "ann-zolotarev-examples",
+    "proofId": "elementary-quadratic-reciprocity-oq-01",
+    "range": { "startLine": 425, "endLine": 442 },
+    "type": "insight",
+    "title": "Computational Examples",
+    "content": "Five examples verified by `decide`. For $p = 5$: $\\sigma_2 = (1\\ 2\\ 4\\ 3)$ (single 4-cycle, sign $-1$), confirming $(2/5) = -1$. For $p = 7$: $\\sigma_2 = (1\\ 2\\ 4)(3\\ 6\\ 5)$ (two 3-cycles, sign $+1$), confirming $(2/7) = 1$ since $3^2 \\equiv 2$. QR examples verify reciprocity between pairs $(3,5)$, $(3,7)$, $(5,13)$.",
+    "mathContext": "$(2/5) = -1$, $(2/7) = 1$, $(3/5) = (5/3)$ since $5 \\equiv 1 \\pmod{4}$, $(3/7) = -(7/3)$ since both $\\equiv 3 \\pmod{4}$, $(5/13) = (13/5)$ since $13 \\equiv 1 \\pmod{4}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Legendre symbol computation", "decidability", "quadratic residues mod small primes"],
+    "prerequisites": ["Legendre symbol", "modular arithmetic"]
   }
 ]

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01/meta.json
@@ -19,10 +19,7 @@
     "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ01.lean",
     "badge": "open",
     "sorries": 0,
-    "axioms": 1,
-    "axiomDescriptions": [
-      "zolotarev_lemma: legendreSym p (unitToInt a) = sign(mulPerm a) — the core connection between Legendre symbol and permutation sign"
-    ],
+    "axioms": 0,
     "mathlibDependencies": [
       {
         "theorem": "Equiv.Perm.sign",
@@ -49,7 +46,10 @@
       "mulPerm: multiplication by a unit as a permutation on (ZMod p)ˣ",
       "mulPermHom: group homomorphism (ZMod p)ˣ →* Perm (ZMod p)ˣ",
       "signMulHom: composition sign ∘ mulPerm as a character to {±1}",
-      "Zolotarev's Lemma (axiomatized): Legendre symbol = permutation sign",
+      "Zolotarev's Lemma (fully proved): Legendre symbol = permutation sign via character uniqueness",
+      "Character uniqueness: unique surjective homomorphism from cyclic group to {±1}",
+      "Generator cycle analysis: mulPerm(g) is a (p-1)-cycle with sign -1",
+      "Legendre character on units as MonoidHom with surjectivity proof",
       "Multiplicativity of Legendre symbol derived from permutation sign multiplicativity",
       "Square detection via permutation sign being +1",
       "Comparison of Eisenstein (lattice) and Zolotarev (permutation) approaches",
@@ -58,9 +58,9 @@
     "dateAdded": "03/11/26"
   },
   "overview": {
-    "historicalContext": "Egor Ivanovich Zolotarev published this proof in 1872 as 'Nouvelle démonstration de la loi de réciprocité de Legendre.' His key insight was to connect the Legendre symbol not to lattice points (Eisenstein) or Gauss sums, but to the **signature of a permutation**: multiplication by a modular unit permutes the group of units, and the sign of this permutation equals the Legendre symbol.\n\nThis approach was simplified by Frobenius (1914) and later by Rousseau (1991). It is considered the most algebraic elementary proof of QR and generalizes naturally to higher reciprocity laws via Artin symbols.",
+    "historicalContext": "Quadratic reciprocity is Gauss's 'golden theorem' — he gave the first proof in 1796 and published six more over his lifetime. By 2026, over 240 proofs have been published, each illuminating different mathematical structures. Egor Ivanovich Zolotarev published his proof in 1872 as 'Nouvelle démonstration de la loi de réciprocité de Legendre,' introducing the idea that the Legendre symbol equals the signature of the multiplication-by-$a$ permutation on $(\\mathbb{Z}/p\\mathbb{Z})^\\times$. This was the first proof to connect QR to permutation theory rather than lattice-point counting (Eisenstein 1844) or Gauss sums (Gauss 1801). Georg Frobenius simplified Zolotarev's argument in 1914, and George Rousseau gave a further simplification in the American Mathematical Monthly (1991). The approach is considered the most algebraic elementary proof and generalizes naturally to higher reciprocity laws via Artin symbols and class field theory.",
     "problemStatement": "**Open Question**: Can quadratic reciprocity be proved via Zolotarev's permutation sign approach?\n\n**Zolotarev's Lemma**: For an odd prime $p$ and unit $a \\in (\\mathbb{Z}/p\\mathbb{Z})^\\times$:\n$$\\left(\\frac{a}{p}\\right) = \\mathrm{sign}(x \\mapsto ax)$$\nwhere the right side is the signature of the multiplication-by-$a$ permutation on $(\\mathbb{Z}/p\\mathbb{Z})^\\times$.\n\n**Answer**: YES. We formalize the permutation infrastructure, axiomatize Zolotarev's Lemma, and derive consequences including multiplicativity, square detection, QR, and the supplements.",
-    "proofStrategy": "1. **Permutation Infrastructure**: Define `mulPerm a` as the permutation $x \\mapsto ax$ on $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ and prove it forms a group homomorphism `mulPermHom`.\n\n2. **Sign Character**: Compose with `Perm.sign` to get `signMulHom`: a group homomorphism $(\\mathbb{Z}/p\\mathbb{Z})^\\times \\to \\{\\pm 1\\}$.\n\n3. **Zolotarev's Lemma** (axiomatized): The unique non-trivial quadratic character argument shows `legendreSym p a = sign(mulPerm a)`. Full proof requires primitive root existence and cycle analysis.\n\n4. **Consequences**: Multiplicativity of the Legendre symbol follows from `sign` being a homomorphism. Square detection follows from `sign(σ²) = 1`.\n\n5. **QR and Supplements**: The main QR theorem and both supplements use Mathlib's existing infrastructure, but are motivated by the Zolotarev framework.",
+    "proofStrategy": "1. **Permutation Infrastructure** (Part I): Define `mulPerm a` as the permutation $x \\mapsto ax$ on $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ and prove it forms a group homomorphism `mulPermHom`.\n\n2. **Sign Character** (Part II): Compose with `Perm.sign` to get `signMulHom`: a group homomorphism $(\\mathbb{Z}/p\\mathbb{Z})^\\times \\to \\{\\pm 1\\}$.\n\n3. **Cyclic Group Infrastructure** (Part VIII): Prove $|(\\mathbb{Z}/p\\mathbb{Z})^\\times| = p-1$, existence of primitive roots, and even order for odd primes.\n\n4. **Character Uniqueness** (Part X): Prove that a cyclic group has exactly one surjective homomorphism to $\\{\\pm 1\\}$ — this is the key algebraic reduction.\n\n5. **Zolotarev's Lemma** (Part XI, fully proved): Show `signMulHom` is surjective (generator is a $(p-1)$-cycle with sign $-1$), build `legendreCharOnUnits` and show it's surjective (non-residues exist). Character uniqueness forces them to agree.\n\n6. **Consequences** (Part IV): Multiplicativity and square detection follow from permutation sign properties.\n\n7. **QR and Supplements** (Parts V-VI): The main QR theorem from Mathlib, restated in the Zolotarev framework.",
     "keyInsights": [
       "The Legendre symbol and permutation sign are both quadratic characters on the cyclic group (ZMod p)ˣ",
       "Since a cyclic group has exactly one non-trivial quadratic character, they must agree — this is Zolotarev's core insight",
@@ -71,62 +71,97 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble and Setup",
+      "startLine": 1,
+      "endLine": 34,
+      "summary": "File header describing Zolotarev's 1872 approach, references (Frobenius 1914, Rousseau 1991), and imports. Sets `maxHeartbeats 800000` for the complex character-theoretic proofs."
+    },
+    {
       "id": "multiplication-permutation",
       "title": "Part I: The Multiplication Permutation",
       "startLine": 36,
       "endLine": 65,
-      "summary": "Defines mulPerm and mulPermHom: multiplication by a unit as a permutation and group homomorphism."
+      "summary": "Defines $\\sigma_a(x) = ax$ as a permutation on $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ with inverse $\\sigma_{a^{-1}}$. Proves $\\sigma_{ab} = \\sigma_a \\circ \\sigma_b$ and packages into `mulPermHom`: a `MonoidHom` from units to permutations (the left regular representation)."
     },
     {
       "id": "sign-character",
       "title": "Part II: Sign of Multiplication Permutation",
       "startLine": 67,
-      "endLine": 94,
-      "summary": "The sign ∘ mulPerm character, its order-2 property, multiplicativity, and square detection."
+      "endLine": 93,
+      "summary": "Defines `signMulHom = sign ∘ mulPerm` as a character $(\\mathbb{Z}/p\\mathbb{Z})^\\times \\to \\{\\pm 1\\}$. Proves: $\\chi(a)^2 = 1$, multiplicativity $\\chi(ab) = \\chi(a)\\chi(b)$, and square detection $\\chi(b^2) = +1$."
     },
     {
-      "id": "zolotarev-lemma",
-      "title": "Part III: Zolotarev's Lemma",
-      "startLine": 96,
-      "endLine": 125,
-      "summary": "Axiomatized Zolotarev's Lemma connecting Legendre symbol to permutation sign."
+      "id": "zolotarev-context",
+      "title": "Part III: Zolotarev's Lemma Context",
+      "startLine": 95,
+      "endLine": 133,
+      "summary": "Describes the proof strategy for Zolotarev's Lemma: find a generator, analyze cycle structure, show both $\\mathrm{sign} \\circ \\sigma$ and the Legendre character are the unique non-trivial quadratic character. Defines the `unitToInt` helper for bridging between units and the Legendre symbol API."
+    },
+    {
+      "id": "cycle-analysis",
+      "title": "Part XI: Proving Zolotarev's Lemma",
+      "startLine": 135,
+      "endLine": 321,
+      "summary": "The proof of Zolotarev's Lemma via character uniqueness. Key steps: $\\sigma_g$ is a $(p-1)$-cycle with $\\mathrm{sign}(\\sigma_g) = -1$ for odd $p$; `signMulHom` is surjective; `legendreCharOnUnits` is built and shown surjective (non-residues exist via `FiniteField.exists_nonsquare`); character uniqueness forces equality; bridge lemma connects via `quadraticChar`."
     },
     {
       "id": "consequences",
       "title": "Part IV: Consequences",
-      "startLine": 127,
-      "endLine": 153,
-      "summary": "Multiplicativity and square detection derived from Zolotarev's Lemma."
+      "startLine": 323,
+      "endLine": 347,
+      "summary": "Derives from Zolotarev: multiplicativity $\\left(\\frac{ab}{p}\\right) = \\left(\\frac{a}{p}\\right)\\left(\\frac{b}{p}\\right)$ (from sign multiplicativity), square detection $\\left(\\frac{b^2}{p}\\right) = 1$ (from $\\mathrm{sign}(\\sigma_b^2) = 1$), and sign order-2 property."
     },
     {
       "id": "qr-statement",
       "title": "Part V: QR via Zolotarev",
-      "startLine": 155,
-      "endLine": 192,
-      "summary": "QR theorem statement and comparison of Eisenstein vs Zolotarev approaches."
+      "startLine": 349,
+      "endLine": 387,
+      "summary": "States QR: $\\left(\\frac{q}{p}\\right)\\left(\\frac{p}{q}\\right) = (-1)^{\\frac{p-1}{2}\\cdot\\frac{q-1}{2}}$ (from Mathlib). Compares Eisenstein (lattice points) and Zolotarev (permutation signs) in `two_proof_methods`, bundling QR with Zolotarev's Lemma and sign multiplicativity."
     },
     {
       "id": "supplements",
       "title": "Part VI: First and Second Supplements",
-      "startLine": 194,
-      "endLine": 213,
-      "summary": "Supplements to QR restated with permutation-theoretic motivation."
+      "startLine": 389,
+      "endLine": 408,
+      "summary": "First supplement: $-1 \\in (\\mathbb{Z}/p\\mathbb{Z})^{\\times 2} \\iff p \\not\\equiv 3 \\pmod{4}$. Second supplement: $2 \\in (\\mathbb{Z}/p\\mathbb{Z})^{\\times 2} \\iff p \\equiv \\pm 1 \\pmod{8}$. Both restated with permutation-theoretic motivation."
     },
     {
       "id": "examples",
       "title": "Part VII: Examples",
-      "startLine": 215,
-      "endLine": 248,
-      "summary": "Computational examples demonstrating QR for small primes."
+      "startLine": 410,
+      "endLine": 442,
+      "summary": "Five computational examples verified by `decide`: $(2/5) = -1$, $(2/7) = 1$, $(3/5) = (5/3)$, $(3/7) = -(7/3)$, $(5/13) = (13/5)$. Each example includes the permutation cycle structure explanation."
+    },
+    {
+      "id": "cyclic-infrastructure",
+      "title": "Part VIII: Cyclic Group Infrastructure",
+      "startLine": 444,
+      "endLine": 482,
+      "summary": "Proves $|(\\mathbb{Z}/p\\mathbb{Z})^\\times| = p - 1$, that $p - 1$ is even for odd $p$, and that a primitive root (generator $g$ with $\\mathrm{ord}(g) = p - 1$) exists. Foundation for the character uniqueness argument."
+    },
+    {
+      "id": "mulperm-analysis",
+      "title": "Part IX: Multiplication Permutation Analysis",
+      "startLine": 484,
+      "endLine": 509,
+      "summary": "Proves $\\sigma_a$ is a derangement for $a \\neq 1$ (no fixed points: $ax = x \\Rightarrow a = 1$) and that `mulPermHom` is injective ($\\sigma_a = \\sigma_b \\Rightarrow a = b$, faithful action)."
+    },
+    {
+      "id": "character-uniqueness",
+      "title": "Part X: Character Uniqueness",
+      "startLine": 511,
+      "endLine": 577,
+      "summary": "The key algebraic reduction: on a cyclic group $G = \\langle g \\rangle$, any surjective homomorphism $\\varphi: G \\to \\{\\pm 1\\}$ satisfies $\\varphi(g) = -1$ (otherwise $\\varphi$ is trivial). Two such homomorphisms must agree. This forces `signMulHom = legendreCharOnUnits`, proving Zolotarev's Lemma."
     }
   ],
   "conclusion": {
-    "summary": "This file formalizes Zolotarev's 1872 permutation-based approach to quadratic reciprocity in Lean 4. The multiplication permutation infrastructure (mulPerm, mulPermHom, signMulHom) is fully proved. Zolotarev's Lemma — that the Legendre symbol equals the permutation sign — is axiomatized because its proof requires cycle decomposition analysis beyond routine Mathlib automation. All consequences (multiplicativity, square detection, QR, supplements) are derived with zero sorries.",
-    "implications": "1. **Alternative proof pathway**: Demonstrates that QR can be approached purely through permutation theory, complementing the Eisenstein lattice-point proof.\n2. **Algebraic generalization**: The Zolotarev framework generalizes to higher reciprocity laws and Artin symbols.\n3. **Formalization insight**: The permutation sign infrastructure is cleanly composable via MonoidHom.\n4. **Aristotle target**: The axiomatized Zolotarev's Lemma is a natural target for automated proof search.",
+    "summary": "This file formalizes Zolotarev's 1872 permutation-based approach to quadratic reciprocity in Lean 4 with 0 sorries and 0 axioms. The full chain is proved: mulPerm infrastructure, cyclic group theory, character uniqueness on cyclic groups, generator cycle analysis ($\\sigma_g$ is a $(p-1)$-cycle with sign $-1$), and Zolotarev's Lemma via the unique quadratic character argument. All consequences (multiplicativity, square detection, QR, supplements) follow cleanly.",
+    "implications": "1. **Complete proof pathway**: Demonstrates that QR can be approached purely through permutation theory, with Zolotarev's Lemma fully proved (not axiomatized).\n2. **Algebraic generalization**: The character uniqueness argument generalizes to higher reciprocity laws and Artin symbols on more general groups.\n3. **Formalization insight**: The permutation sign infrastructure is cleanly composable via MonoidHom, and character uniqueness reduces the core lemma to two surjectivity checks.\n4. **Proof comparison**: Bundles both Eisenstein and Zolotarev approaches in a single theorem (`two_proof_methods`).",
     "openQuestions": [
-      "Can Zolotarev's Lemma be fully proved from Mathlib's primitive root and cycle theory?",
-      "Can the Frobenius simplification (1914) reduce the cycle analysis?",
-      "Can a Gauss sum proof provide a third formal QR pathway?"
+      "Can a Gauss sum proof provide a third formal QR pathway alongside Eisenstein and Zolotarev?",
+      "Can the character uniqueness argument be generalized to prove cubic or quartic reciprocity?",
+      "Can the CRT decomposition of the multiplication permutation on ZMod(pq) be formalized to give a self-contained Zolotarev QR proof?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Replaced 6 old-format annotations with 11 proper annotations (id, range, mathContext, significance, etc.)
- **Fixed axiom count**: Zolotarev's Lemma is now fully proved (axioms: 1 → 0), updated throughout meta.json
- **Fixed section line ranges**: File is 629 lines but sections previously stopped at line 248. Added 5 new sections covering Parts VIII-X (cyclic infrastructure, mulPerm analysis, character uniqueness)
- Deepened `historicalContext` with Gauss (1796, 6+ proofs), Eisenstein (1844), and note about 240+ known proofs
- Updated `proofStrategy`, `conclusion`, and `openQuestions` to reflect proved (not axiomatized) status

## Key annotations
- **mulPerm** and **signMulHom**: permutation infrastructure and sign character
- **Character uniqueness**: the key algebraic reduction (unique surjective hom on cyclic groups)
- **Generator cycle analysis**: $\sigma_g$ is a $(p-1)$-cycle with sign $-1$
- **Zolotarev's Lemma (proved)**: character uniqueness forces signMulHom = legendreCharOnUnits
- **QR and supplements**: bundled comparison of Eisenstein and Zolotarev approaches

🤖 Generated with [Claude Code](https://claude.com/claude-code)