### PR TITLE
Enrich Hall's Theorem (lagrange-theorem-oq-03): fix types, expand coverage

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-03/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-03/annotations.json
@@ -135,7 +135,7 @@
       "startLine": 134,
       "endLine": 158
     },
-    "type": "technique",
+    "type": "theorem",
     "title": "Normal Hall Subgroups are Unique",
     "content": "When a Hall subgroup H is also normal, conjugacy forces uniqueness: any other Hall subgroup K of the same order satisfies K = gHg^{-1} = H (since normality means gHg^{-1} = H for all g). The proof carefully unfolds the conjugation map, using normality in both directions to show the map from H to itself is surjective. This is the group-theoretic analogue of how a normal Sylow subgroup is the unique Sylow p-subgroup.",
     "mathContext": "H \\trianglelefteq G, \\; H \\text{ Hall}, \\; |K| = |H| \\implies K = H",
@@ -179,7 +179,7 @@
       "startLine": 198,
       "endLine": 207
     },
-    "type": "technique",
+    "type": "theorem",
     "title": "Index-2 Subgroups and the Hall Condition",
     "content": "A subgroup of index 2 is Hall precisely when its order is odd. Since the index is 2, the coprimality condition becomes gcd(|H|, 2) = 1, which means |H| must be odd. This gives a simple criterion: in a group of order 2k with k odd, any index-2 subgroup is automatically a Hall subgroup. The proof uses the characterization of coprimality with 2 via non-divisibility by the prime 2.",
     "mathContext": "[G:H] = 2, \\; 2 \\nmid |H| \\implies \\gcd(|H|, 2) = 1",
@@ -201,7 +201,7 @@
       "startLine": 219,
       "endLine": 227
     },
-    "type": "context",
+    "type": "concept",
     "title": "The Sylow-Hall Hierarchy",
     "content": "Hall's theorem strictly generalizes Sylow's first theorem for solvable groups. Sylow guarantees subgroups of prime-power order p^k (where p^k exactly divides |G|), while Hall guarantees subgroups whose order is any product of prime powers forming a coprime part of |G|. For example, in a solvable group of order 60 = 2^2 * 3 * 5, Sylow gives subgroups of order 4, 3, and 5, while Hall additionally gives subgroups of order 12, 15, 20, and 60.",
     "mathContext": "p^k \\mid |G|, \\; \\gcd(p^k, |G|/p^k) = 1 \\implies \\exists H \\leq G, \\; |H| = p^k",
@@ -214,6 +214,73 @@
     "prerequisites": [
       "Hall's existence theorem",
       "Sylow's theorems"
+    ]
+  },
+  {
+    "id": "ann-coprimality-infrastructure",
+    "proofId": "lagrange-theorem-oq-03",
+    "range": {
+      "startLine": 285,
+      "endLine": 297
+    },
+    "type": "theorem",
+    "title": "Coprimality Infrastructure for Hall Divisors",
+    "content": "Three utility lemmas establishing the algebraic properties of Hall divisors: (1) $m \\cdot (n/m) = n$ when $m \\mid n$ (the complementary factorization), (2) coprimality is symmetric for Hall divisors ($\\gcd(m, n/m) = 1 \\iff \\gcd(n/m, m) = 1$), and (3) the complementary factor $n/m$ also divides $n$. These are the basic arithmetic facts needed to manipulate Hall divisors in group-theoretic arguments.",
+    "mathContext": "$m \\mid n \\implies m \\cdot (n/m) = n$, $\\gcd(m, n/m) = 1 \\iff \\gcd(n/m, m) = 1$, and $m \\mid n \\implies (n/m) \\mid n$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "divisibility",
+      "coprimality",
+      "natural number division"
+    ],
+    "prerequisites": [
+      "Nat.div_mul_cancel",
+      "Nat.Coprime.symm"
+    ]
+  },
+  {
+    "id": "ann-schur-zassenhaus",
+    "proofId": "lagrange-theorem-oq-03",
+    "range": {
+      "startLine": 308,
+      "endLine": 348
+    },
+    "type": "theorem",
+    "title": "Schur-Zassenhaus: Normal Hall Subgroups Have Complements",
+    "content": "The Schur-Zassenhaus theorem states that a normal subgroup $N \\trianglelefteq G$ with $\\gcd(|N|, [G:N]) = 1$ has a complement $K$ satisfying $NK = G$ and $N \\cap K = \\{1\\}$. Unlike Hall's full theorem, Schur-Zassenhaus does not require solvability — normality suffices. The proof uses Mathlib's `Subgroup.exists_right_complement'_of_coprime`. Additional lemmas show the complement satisfies $|N| \\cdot |K| = |G|$ and that when combined with Hall's conjugacy theorem, the normal Hall subgroup is the unique subgroup of its order.",
+    "mathContext": "$N \\trianglelefteq G$, $\\gcd(|N|, [G:N]) = 1 \\implies \\exists K \\leq G: NK = G, \\; N \\cap K = \\{1\\}$, $|N| \\cdot |K| = |G|$",
+    "significance": "key",
+    "relatedConcepts": [
+      "complement subgroup",
+      "semidirect product",
+      "normal Hall subgroup"
+    ],
+    "prerequisites": [
+      "Subgroup.exists_right_complement'_of_coprime",
+      "IsHallSubgroup",
+      "Subgroup.Normal"
+    ]
+  },
+  {
+    "id": "ann-summary",
+    "proofId": "lagrange-theorem-oq-03",
+    "range": {
+      "startLine": 362,
+      "endLine": 369
+    },
+    "type": "theorem",
+    "title": "Summary: Hall Extends Lagrange",
+    "content": "The summary theorem bundles the two core facts: (1) Lagrange's theorem — $|H|$ divides $|G|$ for any subgroup $H \\leq G$, proved by converting between `Fintype.card` and `Nat.card` to apply Mathlib's `Subgroup.card_subgroup_dvd_card`; and (2) the counterexample witness — $6 \\mid 12 = |A_4|$, demonstrated using the previously proved `a4_card` and `six_dvd_twelve`. Together these frame the narrative: Lagrange gives divisibility, but the converse requires Hall's coprimality condition.",
+    "mathContext": "$\\forall H \\leq G, \\; |H| \\mid |G|$ and $6 \\mid |A_4| = 12$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Lagrange's theorem",
+      "A4 counterexample",
+      "Hall's theorem"
+    ],
+    "prerequisites": [
+      "Subgroup.card_subgroup_dvd_card",
+      "a4_card"
     ]
   }
 ]

--- a/src/data/proofs/lagrange-theorem-oq-03/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-03/meta.json
@@ -35,6 +35,11 @@
         "theorem": "IsSolvable",
         "description": "Solvable group class",
         "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "Subgroup.exists_right_complement'_of_coprime",
+        "description": "Schur-Zassenhaus: normal subgroup with coprime index has complement",
+        "module": "Mathlib.GroupTheory.SchurZassenhaus"
       }
     ],
     "originalContributions": [
@@ -49,7 +54,8 @@
       "Index-2 subgroups are Hall when half-order is odd (proved)",
       "Cauchy's theorem wrapper (from Mathlib)",
       "Hall generalizes Sylow for solvable groups (proved from existence axiom)",
-      "Coprimality infrastructure (3 lemmas, all proved)"
+      "Coprimality infrastructure (3 lemmas, all proved)",
+      "Schur-Zassenhaus complement existence, disjointness, and generation (from Mathlib)"
     ],
     "references": [
       {
@@ -71,52 +77,111 @@
     "axioms": 3
   },
   "overview": {
-    "historicalContext": "Lagrange's theorem states |H| divides |G| for any subgroup H. The converse asks: does every divisor of |G| yield a subgroup? Philip Hall (1928) proved a partial converse: in solvable groups, every 'Hall divisor' (coprime to the complementary factor) yields a subgroup.",
-    "problemStatement": "Can the converse of Lagrange's theorem be established for solvable groups via Hall's theorem? What is the precise obstruction for non-Hall divisors?",
-    "proofStrategy": "Define Hall subgroups via coprimality, state Hall's existence and conjugacy theorems as axioms (deep induction on group order), prove structural consequences including normal Hall uniqueness and the A₄ counterexample.",
+    "historicalContext": "Joseph-Louis Lagrange (1771) proved that the order of a subgroup divides the order of the group, a cornerstone of finite group theory. The natural converse — does every divisor of $|G|$ yield a subgroup? — fails dramatically: the alternating group $A_4$ (order 12) has no subgroup of order 6, despite $6 \\mid 12$. Philip Hall (1928) discovered the precise obstruction: the divisor must be coprime to its cofactor. His theorem states that in a finite solvable group, every such 'Hall divisor' yields a subgroup, and all subgroups of a given Hall order are conjugate. This simultaneously generalizes Sylow's theorems (1872) from prime-power to coprime factorizations. The Schur-Zassenhaus theorem (Schur 1904, Zassenhaus 1937) handles the special case where the subgroup is normal, without requiring solvability. Hall's theorem remains one of the deepest results in finite group theory, with its proof requiring induction on group order via the derived series. The connection to solvability is essential: $A_5$ (the smallest non-solvable group, order 60) fails to have Hall subgroups of certain orders.",
+    "problemStatement": "OQ-03: Can the converse of Lagrange's theorem be established for solvable groups via Hall's theorem?\n\nGiven a finite solvable group $G$ and a divisor $m$ of $|G|$ with $\\gcd(m, |G|/m) = 1$, does there exist a subgroup $H \\leq G$ with $|H| = m$? What is the precise obstruction for non-Hall divisors?",
+    "proofStrategy": "The formalization proceeds in layers:\n\n1. **Definition**: Hall subgroups via coprimality $\\gcd(|H|, [G:H]) = 1$\n2. **Basic properties**: Trivial subgroup is Hall, product formula, divisibility\n3. **Sylow connection**: Every Sylow $p$-subgroup is a Hall subgroup\n4. **Hall's theorem**: Existence and conjugacy axiomatized for solvable groups\n5. **Consequences**: Abelian Hall existence, normal Hall uniqueness\n6. **Counterexample**: $A_4$ has no subgroup of order 6 (axiomatized non-existence + proved $\\gcd(6,2) \\neq 1$)\n7. **Schur-Zassenhaus**: Normal Hall subgroups have complements (from Mathlib)\n8. **Summary**: Lagrange + counterexample bundled into a single theorem",
     "keyInsights": [
-      "A Hall subgroup has order coprime to its index — this is the right condition for existence",
-      "Sylow subgroups are special cases of Hall subgroups (prime-power order)",
-      "A₄ counterexample: 6|12 but gcd(6,2)=2≠1, so 6 is not a Hall divisor",
-      "Normal Hall subgroups are unique via conjugacy: gHg⁻¹ = H for all g"
+      "**Hall divisors** $m \\mid |G|$ with $\\gcd(m, |G|/m) = 1$ are exactly the divisors guaranteed to yield subgroups in solvable groups — the coprimality condition is both necessary and sufficient",
+      "**Sylow subgroups are Hall subgroups**: $p^k \\| |G|$ implies $\\gcd(p^k, |G|/p^k) = 1$, so Hall's theorem strictly generalizes Sylow's first theorem for solvable groups",
+      "**The $A_4$ counterexample** shows the converse of Lagrange fails even for solvable groups when the coprimality condition is dropped: $6 \\mid 12$ but $\\gcd(6, 2) = 2 \\neq 1$",
+      "**Normal Hall subgroups are unique**: conjugacy ($K = gHg^{-1}$) plus normality ($gHg^{-1} = H$) forces $K = H$, the group-theoretic analogue of unique Sylow $p$-subgroups",
+      "**Schur-Zassenhaus** handles normal Hall subgroups without solvability: $N \\trianglelefteq G$ with $\\gcd(|N|, [G:N]) = 1$ always has a complement $K$ with $NK = G$ and $N \\cap K = \\{1\\}$"
     ]
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble and Imports",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "File header documenting Hall's theorem formalization, imports Mathlib, opens `Fintype` and `Subgroup` namespaces, enters `noncomputable section` within the `LagrangeTheoremOQ03` namespace."
+    },
+    {
       "id": "hall-def",
       "title": "Hall Subgroup Definition",
-      "summary": "Defines IsHallSubgroup via coprimality of order and index. Proves trivial subgroup is Hall.",
       "startLine": 47,
-      "endLine": 78
+      "endLine": 55,
+      "summary": "Defines `IsHallSubgroup H` as $\\gcd(|H|, [G:H]) = 1$ using `Nat.Coprime` on `Fintype.card` values. This single coprimality condition captures exactly which divisors of $|G|$ are guaranteed to yield subgroups in solvable groups."
+    },
+    {
+      "id": "basic-properties",
+      "title": "Basic Properties",
+      "startLine": 56,
+      "endLine": 79,
+      "summary": "Proves three foundational results: the trivial subgroup $\\{e\\}$ is always Hall ($\\gcd(1, n) = 1$), Hall subgroup order divides group order, and the product formula $|G| = |H| \\times [G:H]$ from Mathlib's `Subgroup.card_mul_index`."
+    },
+    {
+      "id": "sylow-hall",
+      "title": "Sylow Subgroups are Hall Subgroups",
+      "startLine": 80,
+      "endLine": 93,
+      "summary": "Proves that if $|H| = p^k$ where $p^k$ exactly divides $|G|$, then $\\gcd(p^k, [G:H]) = 1$. This establishes Sylow subgroups as special cases of Hall subgroups, connecting the two theories."
     },
     {
       "id": "hall-theorem",
       "title": "Hall's Theorem (Axioms)",
-      "summary": "States Hall's existence and conjugacy theorems as axioms for finite solvable groups.",
       "startLine": 94,
-      "endLine": 118
+      "endLine": 119,
+      "summary": "States Hall's existence and conjugacy theorems as axioms for finite solvable groups. **Existence**: every Hall divisor $m$ of $|G|$ yields a subgroup of order $m$. **Conjugacy**: any two Hall subgroups of the same order are conjugate ($K = gHg^{-1}$). Both require solvability and are axiomatized because the proofs use strong induction on $|G|$ via the derived series."
     },
     {
       "id": "consequences",
-      "title": "Consequences",
-      "summary": "Proves abelian groups satisfy Hall, normal Hall subgroups are unique, Cauchy's theorem, and coprimality lemmas.",
+      "title": "Consequences of Hall's Theorem",
       "startLine": 120,
-      "endLine": 267
+      "endLine": 159,
+      "summary": "Derives three consequences: (1) abelian groups satisfy Hall existence (abelian $\\Rightarrow$ solvable), (2) normal Hall subgroups are unique at their order (conjugacy + normality $\\Rightarrow$ equality), proved by showing the conjugation map $g \\mapsto gHg^{-1}$ is the identity when $H \\trianglelefteq G$."
     },
     {
       "id": "counterexample",
-      "title": "A₄ Counterexample",
-      "summary": "Shows 6|12=|A₄| but gcd(6,2)≠1, and A₄ has no subgroup of order 6 (axiom).",
+      "title": "The A₄ Counterexample",
       "startLine": 160,
-      "endLine": 192
+      "endLine": 244,
+      "summary": "Establishes that $|A_4| = 12$ and $6 \\mid 12$, but $\\gcd(6, 2) = 2 \\neq 1$, so 6 is not a Hall divisor. The non-existence of a subgroup of order 6 in $A_4$ is axiomatized. The proof that every element of an index-2 subgroup must contain all squares ($g^2 \\in H$ for all $g$) provides the key structural argument, and counting shows $A_4$ has too many squares for an order-6 subgroup."
+    },
+    {
+      "id": "index-two",
+      "title": "Index-2 Subgroups",
+      "startLine": 245,
+      "endLine": 259,
+      "summary": "Proves that a subgroup of index 2 is Hall precisely when its order is odd: $[G:H] = 2$ and $2 \\nmid |H|$ implies $\\gcd(|H|, 2) = 1$. Uses the characterization of coprimality with 2 via the negation of even parity."
+    },
+    {
+      "id": "sylow-relationship",
+      "title": "Relationship to Sylow Theory",
+      "startLine": 260,
+      "endLine": 279,
+      "summary": "Wraps Cauchy's theorem from Mathlib (`exists_prime_orderOf_dvd_card`) and proves that Hall's existence theorem implies Sylow's first theorem for solvable groups: since $p^k$ is always a Hall divisor when $p^k \\| |G|$, Hall existence subsumes Sylow existence."
+    },
+    {
+      "id": "coprimality",
+      "title": "Coprimality Infrastructure",
+      "startLine": 280,
+      "endLine": 298,
+      "summary": "Three utility lemmas for Hall divisor arithmetic: $m \\cdot (n/m) = n$ when $m \\mid n$, symmetry of coprimality for Hall divisors, and $m \\mid n \\implies (n/m) \\mid n$. These are the basic number-theoretic facts underlying all Hall divisor manipulations."
+    },
+    {
+      "id": "schur-zassenhaus",
+      "title": "Schur-Zassenhaus: The Normal Hall Case",
+      "startLine": 299,
+      "endLine": 349,
+      "summary": "Proves four results about normal Hall subgroups using Mathlib's Schur-Zassenhaus: (1) complement existence ($\\exists K: NK = G, N \\cap K = \\{1\\}$), (2) trivial intersection ($N \\sqcap K = \\bot$), (3) generation ($N \\sqcup K = \\top$), and (4) $|N| \\cdot |K| = |G|$. Combines with Hall conjugacy to show normal Hall subgroups are unique and their complements are determined."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 350,
+      "endLine": 373,
+      "summary": "Bundles Lagrange's theorem ($|H| \\mid |G|$ for all $H \\leq G$) and the $A_4$ counterexample ($6 \\mid 12$) into a single summary theorem, framing the narrative: Lagrange gives divisibility, but the converse requires Hall's coprimality condition and group solvability."
     }
   ],
   "conclusion": {
-    "summary": "Hall's theorem provides the definitive partial converse of Lagrange's theorem for solvable groups. 271 lines, 0 sorries, 3 axioms for deep group theory. A₄ counterexample shows the converse fails in general.",
+    "summary": "This formalization provides a comprehensive treatment of Hall's theorem as the definitive partial converse of Lagrange's theorem for solvable groups. The 373-line file proves all structural consequences (0 sorries) while axiomatizing the three deep results requiring induction on group order (Hall existence, Hall conjugacy, A₄ non-existence). The Schur-Zassenhaus complement results are fully proved from Mathlib.",
+    "implications": "Hall's theorem is foundational for the structure theory of solvable groups, providing a complete description of which subgroup orders are realized. The Schur-Zassenhaus complement gives semidirect product decompositions $G \\cong N \\rtimes K$ for normal Hall subgroups. In applications, Hall subgroups appear in the classification of finite solvable groups (Hall's theorem is the solvable-group analogue of the Sylow theorems) and in computational group theory where finding Hall subgroups is a key algorithmic primitive.",
     "openQuestions": [
       "Can Hall existence be proved constructively in Lean using derived series induction?",
-      "Can the A₄ counterexample be computationally verified (native_decide)?",
-      "What is the relationship between Hall subgroups and Burnside's p^a·q^b theorem?"
+      "Can the A₄ counterexample be computationally verified using native_decide on the explicit group table?",
+      "What is the relationship between Hall subgroups and Burnside's p^a·q^b theorem for solvable groups of order p^a·q^b?",
+      "Can the formalization be extended to π-separable groups (Chunikhin's generalization of Hall's theorem)?"
     ]
   },
   "relatedProblems": [


### PR DESCRIPTION
## Summary
- Fix 3 invalid annotation types (`technique`→`theorem`, `context`→`concept`)
- Add 3 new annotations for Schur-Zassenhaus, coprimality infrastructure, summary
- Expand from 4 sections to 12 covering all 11 parts of the 373-line Lean file
- Deepen historicalContext with Lagrange (1771), Hall (1928), Schur-Zassenhaus
- Add `conclusion.implications` and 5th keyInsight

## Test plan
- [x] `pnpm annotations:build` passes with no warnings for this proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)