### PR TITLE
Enrich Complex L2 Cauchy-Schwarz: full schema upgrade

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-03/annotations.json
@@ -1,32 +1,98 @@
 [
   {
-    "lineNumber": 20,
-    "content": "**Bridge Theorem**: `L2.inner_def` equates the abstract L2 inner product `⟪f,g⟫_ℂ` with the integral `∫ ⟪f(x), g(x)⟫_ℂ dμ`. This is the key connection enabling transfer of abstract Cauchy-Schwarz to integral form.",
-    "type": "insight"
+    "id": "ann-cs-oq03-bridge",
+    "proofId": "cauchy-schwarz-integral-oq-03",
+    "range": { "startLine": 19, "endLine": 21 },
+    "type": "theorem",
+    "title": "Bridge Theorem: Abstract to Integral",
+    "content": "The bridge theorem `complex_L2_inner_eq_integral` equates the abstract $L^2$ inner product $\\langle f, g \\rangle_{\\mathbb{C}}$ with the integral $\\int \\langle f(x), g(x) \\rangle_{\\mathbb{C}} \\, d\\mu$ of pointwise inner products. This single identity, proved by invoking Mathlib's `L2.inner_def`, is the key that transfers all abstract inner product space results to integral form. Without it, abstract Cauchy-Schwarz and the concrete integral inequality live in separate worlds.",
+    "mathContext": "$\\langle f, g \\rangle_{L^2} = \\int_\\alpha \\langle f(x), g(x) \\rangle_{\\mathbb{C}} \\, d\\mu(x)$",
+    "significance": "key",
+    "relatedConcepts": ["L2.inner_def", "Bochner integral", "pointwise inner product"],
+    "prerequisites": ["InnerProductSpace ℂ (Lp ℂ 2 μ)", "MeasureTheory.integral"]
   },
   {
-    "lineNumber": 30,
-    "content": "**Explicit Conjugation**: For complex L2, the inner product involves conjugation: `⟪f,g⟫_ℂ = ∫ conj(f(x)) · g(x) dμ`. This is the standard physics convention (conjugate-linear in the first argument).",
-    "type": "proof-technique"
+    "id": "ann-cs-oq03-conjugation",
+    "proofId": "cauchy-schwarz-integral-oq-03",
+    "range": { "startLine": 24, "endLine": 35 },
+    "type": "theorem",
+    "title": "Explicit Conjugation Form",
+    "content": "Two theorems making the conjugation explicit: `complex_inner_eq_conj_mul` shows $\\langle z, w \\rangle_{\\mathbb{C}} = \\bar{z} \\cdot w$ (the physics convention, conjugate-linear in the first argument), and `complex_L2_inner_eq_integral_star` lifts this to $L^2$: $\\langle f, g \\rangle = \\int \\bar{f}(x) \\cdot g(x) \\, d\\mu$. The star notation `starRingEnd ℂ` is Mathlib's conjugation operator. These forms are essential for computational applications where the explicit $\\bar{f} g$ product appears.",
+    "mathContext": "$\\langle f, g \\rangle_{L^2} = \\int_\\alpha \\overline{f(x)} \\cdot g(x) \\, d\\mu(x)$, using $\\langle z, w \\rangle_{\\mathbb{C}} = \\bar{z} w$.",
+    "significance": "key",
+    "relatedConcepts": ["Complex.inner_apply", "starRingEnd", "sesquilinearity"],
+    "prerequisites": ["complex_L2_inner_eq_integral", "starRingEnd ℂ"]
   },
   {
-    "lineNumber": 47,
-    "content": "**Complex Bunyakovsky-Schwarz**: The integral form `‖∫ ⟪f(x),g(x)⟫_ℂ dμ‖ ≤ ‖f‖·‖g‖` follows directly from the bridge theorem and abstract Cauchy-Schwarz. The norm on the left handles the complex-valued integral.",
-    "type": "proof-technique"
+    "id": "ann-cs-oq03-complex-cs",
+    "proofId": "cauchy-schwarz-integral-oq-03",
+    "range": { "startLine": 41, "endLine": 62 },
+    "type": "theorem",
+    "title": "Complex Cauchy-Schwarz in Four Forms",
+    "content": "Four progressively concrete formulations of Cauchy-Schwarz for complex $L^2$: (1) abstract form $\\|\\langle f, g \\rangle\\| \\leq \\|f\\| \\cdot \\|g\\|$ via `norm_inner_le_norm`, (2) integral form with pointwise inner products, (3) integral form with explicit conjugation $\\|\\int \\bar{f} g \\, d\\mu\\| \\leq \\|f\\| \\cdot \\|g\\|$, and (4) squared form $\\|\\langle f, g \\rangle\\|^2 \\leq \\|f\\|^2 \\cdot \\|g\\|^2$. The squared form uses `nlinarith` to square the basic inequality, exploiting positivity of norms.",
+    "mathContext": "$\\|\\langle f, g \\rangle_{\\mathbb{C}}\\| \\leq \\|f\\|_{L^2} \\cdot \\|g\\|_{L^2}$, equivalently $\\left|\\int \\bar{f} g \\, d\\mu\\right|^2 \\leq \\int |f|^2 \\, d\\mu \\cdot \\int |g|^2 \\, d\\mu$.",
+    "significance": "key",
+    "relatedConcepts": ["norm_inner_le_norm", "Bunyakovsky inequality", "squared Cauchy-Schwarz"],
+    "prerequisites": ["complex_L2_inner_eq_integral", "complex_L2_inner_eq_integral_star"]
   },
   {
-    "lineNumber": 69,
-    "content": "**Self-Inner Product**: `⟪f,f⟫_ℂ = ‖f‖²` is always real and non-negative, despite being computed in ℂ. This follows from `inner_self_eq_norm_sq_to_K` and is essential for interpreting L2 norms.",
-    "type": "insight"
+    "id": "ann-cs-oq03-self-inner",
+    "proofId": "cauchy-schwarz-integral-oq-03",
+    "range": { "startLine": 69, "endLine": 91 },
+    "type": "theorem",
+    "title": "Self-Inner Product Properties",
+    "content": "Four properties of $\\langle f, f \\rangle_{\\mathbb{C}}$: (1) equals $\\|f\\|^2$ as a complex number (via `inner_self_eq_norm_sq_to_K`), (2) has zero imaginary part (the self-inner product is always real despite living in $\\mathbb{C}$), (3) has non-negative real part ($\\text{Re}\\langle f, f \\rangle \\geq 0$), and (4) equals the integral $\\int \\|f(x)\\|^2 \\, d\\mu$ (connecting abstract norm to pointwise norm integral). These establish that the complex $L^2$ norm is well-behaved as a real quantity.",
+    "mathContext": "$\\langle f, f \\rangle_{\\mathbb{C}} = \\|f\\|^2 \\in \\mathbb{R}_{\\geq 0}$, and $\\langle f, f \\rangle = \\int |f(x)|^2 \\, d\\mu$.",
+    "significance": "key",
+    "relatedConcepts": ["inner_self_eq_norm_sq_to_K", "positive definiteness", "L2 norm"],
+    "prerequisites": ["complex_L2_inner_eq_integral", "sq_nonneg"]
   },
   {
-    "lineNumber": 117,
-    "content": "**Equality Characterization**: Equality `‖⟪f,g⟫_ℂ‖ = ‖f‖·‖g‖` holds iff `f = c·g` for some `c : ℂ`. Uses `norm_inner_eq_norm_iff` from Mathlib's inner product space theory.",
-    "type": "proof-technique"
+    "id": "ann-cs-oq03-re-im-bounds",
+    "proofId": "cauchy-schwarz-integral-oq-03",
+    "range": { "startLine": 98, "endLine": 110 },
+    "type": "theorem",
+    "title": "Real and Imaginary Part Bounds",
+    "content": "Two component-wise bounds: $\\text{Re}\\langle f, g \\rangle \\leq \\|f\\| \\cdot \\|g\\|$ and $|\\text{Im}\\langle f, g \\rangle| \\leq \\|f\\| \\cdot \\|g\\|$. Both follow from the chain $|\\text{Re}(z)| \\leq |z|$ (resp. $|\\text{Im}(z)| \\leq |z|$) composed with Cauchy-Schwarz. The `calc` blocks make the reasoning transparent: real/imaginary part $\\leq$ absolute value $\\leq$ complex norm $\\leq$ product of norms.",
+    "mathContext": "$\\text{Re}\\langle f, g \\rangle \\leq \\|f\\| \\|g\\|$ and $|\\text{Im}\\langle f, g \\rangle| \\leq \\|f\\| \\|g\\|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Complex.abs_re_le_abs", "Complex.abs_im_le_abs", "calc blocks"],
+    "prerequisites": ["norm_inner_le_norm", "Complex norm properties"]
   },
   {
-    "lineNumber": 135,
-    "content": "**RCLike Unification**: The `RCLike` typeclass (covering both `ℝ` and `ℂ`) allows stating Cauchy-Schwarz once for all scalar fields. This is the most general form in the development.",
-    "type": "insight"
+    "id": "ann-cs-oq03-equality",
+    "proofId": "cauchy-schwarz-integral-oq-03",
+    "range": { "startLine": 117, "endLine": 128 },
+    "type": "theorem",
+    "title": "Equality Characterization via Linear Dependence",
+    "content": "Equality $\\|\\langle f, g \\rangle\\| = \\|f\\| \\cdot \\|g\\|$ holds if and only if $f = cg$ for some $c \\in \\mathbb{C}$. The forward direction uses Mathlib's `norm_inner_eq_norm_iff` to get $g = rf$ for some $r$, then inverts to get $f = r^{-1}g$. The reverse direction computes $\\langle cf, f \\rangle = \\bar{c} \\|f\\|^2$ and verifies $\\|\\bar{c}\\| \\cdot \\|f\\|^2 = |c| \\cdot \\|f\\|^2 = \\|cf\\| \\cdot \\|f\\|$. This is the complex analogue of the classical characterization: proportional functions saturate Cauchy-Schwarz.",
+    "mathContext": "$\\|\\langle f, g \\rangle\\| = \\|f\\| \\|g\\| \\iff \\exists c \\in \\mathbb{C}, \\; f = cg$.",
+    "significance": "key",
+    "relatedConcepts": ["norm_inner_eq_norm_iff", "linear dependence", "equality conditions"],
+    "prerequisites": ["norm_inner_le_norm", "inner_smul_left", "inner_self_eq_norm_sq_to_K"]
+  },
+  {
+    "id": "ann-cs-oq03-rclike",
+    "proofId": "cauchy-schwarz-integral-oq-03",
+    "range": { "startLine": 135, "endLine": 154 },
+    "type": "theorem",
+    "title": "Uniform RCLike Formulation",
+    "content": "Three theorems parameterized by `RCLike 𝕜` (Mathlib's typeclass unifying $\\mathbb{R}$ and $\\mathbb{C}$): the bridge theorem, abstract Cauchy-Schwarz, and integral Cauchy-Schwarz. By working over an arbitrary `RCLike` field, these statements simultaneously cover real and complex $L^2$ without duplication. The `RCLike` typeclass provides conjugation, norm, and completeness properties needed for inner product space theory. This is the most general formulation in the development.",
+    "mathContext": "For any `RCLike` field $\\mathbb{K}$ (covering $\\mathbb{R}$ and $\\mathbb{C}$): $\\|\\langle f, g \\rangle_{\\mathbb{K}}\\| \\leq \\|f\\|_{L^2} \\cdot \\|g\\|_{L^2}$.",
+    "significance": "key",
+    "relatedConcepts": ["RCLike typeclass", "uniform formulation", "type polymorphism"],
+    "prerequisites": ["L2.inner_def", "norm_inner_le_norm", "RCLike"]
+  },
+  {
+    "id": "ann-cs-oq03-real-recovery",
+    "proofId": "cauchy-schwarz-integral-oq-03",
+    "range": { "startLine": 161, "endLine": 172 },
+    "type": "theorem",
+    "title": "Real L2 Recovery",
+    "content": "Specializing the complex framework back to $\\mathbb{R}$ recovers the original Bunyakovsky-Schwarz inequality: $\\langle f, g \\rangle_{\\mathbb{R}} = \\int f(x) g(x) \\, d\\mu$ (no conjugation needed since $\\bar{r} = r$ for $r \\in \\mathbb{R}$) and $|\\int f g \\, d\\mu| \\leq \\|f\\| \\cdot \\|g\\|$. The real bridge theorem uses `simp [mul_comm]` to simplify the trivial conjugation. This closes the circle: the complex extension specializes back to the real case, confirming consistency.",
+    "mathContext": "$\\left|\\int f(x) g(x) \\, d\\mu\\right| \\leq \\|f\\|_{L^2} \\cdot \\|g\\|_{L^2}$ for real-valued $f, g \\in L^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Bunyakovsky-Schwarz inequality", "real inner product", "specialization"],
+    "prerequisites": ["L2.inner_def", "abs_real_inner_le_norm"]
   }
 ]

--- a/src/data/proofs/cauchy-schwarz-integral-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-03/meta.json
@@ -16,7 +16,7 @@
       "complex-analysis",
       "extension"
     ],
-    "proofRepoPath": "Proofs/CauchySchwarzIntegralOq03.lean",
+    "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ03.lean",
     "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
@@ -54,7 +54,7 @@
     "dateAdded": "03/11/26"
   },
   "overview": {
-    "historicalContext": "The Cauchy-Schwarz inequality in L2 spaces is foundational to functional analysis. While the real-valued case is classical, extending to complex L2 requires careful handling of conjugation in the inner product. This formalization bridges the gap between Mathlib's abstract inner product space Cauchy-Schwarz and the concrete integral inequality for complex-valued functions.",
+    "historicalContext": "The Cauchy-Schwarz inequality traces back to Augustin-Louis Cauchy (1821) for finite sums and Hermann Schwarz (1888) for integrals, with Viktor Bunyakovsky (1859) establishing the integral form independently. The extension from real to complex inner product spaces was clarified by John von Neumann's axiomatization of Hilbert spaces (1929), where the sesquilinearity of the complex inner product $\\langle f, g \\rangle = \\int \\bar{f} g \\, d\\mu$ introduces conjugation absent in the real case. The physics convention (conjugate-linear in the first argument) became standard through quantum mechanics, where $\\langle \\psi | \\phi \\rangle$ is the transition amplitude. In Mathlib, the `RCLike` typeclass (introduced to unify $\\mathbb{R}$ and $\\mathbb{C}$) enables stating the inequality once for all scalar fields. The bridge theorem `L2.inner_def` connecting abstract and integral forms is the crucial link that makes the transfer from abstract inner product space theory to concrete integral inequalities fully formal.",
     "problemStatement": "**Open Question**: Can the bridge theorem connecting L2 inner products to integrals be extended from real to complex-valued functions?\n\n**Answer**: YES. The key bridge theorem `L2.inner_def` works uniformly for any `RCLike` field (including ℂ). We derive the complex Bunyakovsky-Schwarz inequality, equality characterization, and show the real case is recovered as a specialization.",
     "proofStrategy": "1. **Bridge Theorem**: Use `L2.inner_def` to equate `⟪f,g⟫_ℂ` with `∫ conj(f(x))·g(x) dμ`.\n2. **Complex CS**: Apply abstract `norm_inner_le_norm` through the bridge to get the integral form.\n3. **Self-Inner Product**: Show `⟪f,f⟫_ℂ` is real, non-negative, and equals `∫ ‖f(x)‖² dμ`.\n4. **Equality**: Characterize equality via linear dependence using `norm_inner_eq_norm_iff`.\n5. **Uniformity**: Generalize to `RCLike 𝕜` covering both ℝ and ℂ simultaneously.\n6. **Recovery**: Specialize back to ℝ to recover the original Bunyakovsky-Schwarz.",
     "keyInsights": [
@@ -67,53 +67,60 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble and Setup",
+      "startLine": 1,
+      "endLine": 11,
+      "summary": "Imports Mathlib, sets `linter.unusedVariables false`, opens `MeasureTheory` and `InnerProductSpace` namespaces, and declares the measure space variable $\\alpha$ with measure $\\mu$."
+    },
+    {
       "id": "complex-l2-bridge",
       "title": "Complex L2 Bridge Theorem",
-      "startLine": 12,
+      "startLine": 13,
       "endLine": 36,
-      "summary": "Bridge between abstract L2 inner product and integral of pointwise complex inner products."
+      "summary": "Establishes the `InnerProductSpace ℂ (Lp ℂ 2 μ)` instance via `inferInstance`, then proves the bridge theorem $\\langle f, g \\rangle_{L^2} = \\int \\langle f(x), g(x) \\rangle_{\\mathbb{C}} \\, d\\mu$ via `L2.inner_def`. Also derives the explicit conjugation form $\\langle f, g \\rangle = \\int \\bar{f}(x) g(x) \\, d\\mu$ using `Complex.inner_apply`."
     },
     {
       "id": "complex-cs",
       "title": "Complex Cauchy-Schwarz",
       "startLine": 38,
       "endLine": 64,
-      "summary": "Cauchy-Schwarz for complex L2: abstract, integral, conjugation, and squared forms."
+      "summary": "Four formulations of Cauchy-Schwarz for complex $L^2$: (1) abstract $\\|\\langle f, g \\rangle\\| \\leq \\|f\\| \\|g\\|$, (2) integral with pointwise inner products, (3) integral with explicit $\\bar{f} g$, and (4) squared form $\\|\\langle f, g \\rangle\\|^2 \\leq \\|f\\|^2 \\|g\\|^2$ proved via `nlinarith`."
     },
     {
       "id": "self-inner-product",
       "title": "Self-Inner Product Properties",
       "startLine": 66,
       "endLine": 93,
-      "summary": "Self-inner product is real, non-negative, and equals integral of norm squared."
+      "summary": "Proves $\\langle f, f \\rangle_{\\mathbb{C}} = \\|f\\|^2$, its imaginary part vanishes, its real part is non-negative, and it equals $\\int \\|f(x)\\|^2 \\, d\\mu$. These establish that the complex $L^2$ norm behaves as a real quantity despite the complex inner product."
     },
     {
       "id": "real-part",
       "title": "Real and Imaginary Part Bounds",
       "startLine": 95,
       "endLine": 112,
-      "summary": "Bounds on real and imaginary parts of ⟪f,g⟫_ℂ."
+      "summary": "Component-wise bounds $\\text{Re}\\langle f, g \\rangle \\leq \\|f\\| \\|g\\|$ and $|\\text{Im}\\langle f, g \\rangle| \\leq \\|f\\| \\|g\\|$, proved via `calc` chains composing $|\\text{Re}(z)| \\leq |z|$ with Cauchy-Schwarz."
     },
     {
       "id": "equality",
       "title": "Equality Characterization",
       "startLine": 114,
       "endLine": 130,
-      "summary": "Equality in complex CS iff linearly dependent."
+      "summary": "Proves $\\|\\langle f, g \\rangle\\| = \\|f\\| \\|g\\|$ iff $f = cg$ for some $c \\in \\mathbb{C}$. Forward direction inverts `norm_inner_eq_norm_iff`; reverse computes $\\langle cf, f \\rangle = \\bar{c} \\|f\\|^2$ and uses `ring`."
     },
     {
       "id": "rclike-uniform",
       "title": "Uniform RCLike Formulation",
       "startLine": 132,
       "endLine": 156,
-      "summary": "Most general form using RCLike typeclass, covering both ℝ and ℂ."
+      "summary": "The most general form: bridge theorem, abstract CS, and integral CS parameterized by `RCLike 𝕜`, simultaneously covering both $\\mathbb{R}$ and $\\mathbb{C}$ via Mathlib's scalar field typeclass."
     },
     {
       "id": "real-recovery",
       "title": "Real L2 Recovery",
       "startLine": 158,
-      "endLine": 174,
-      "summary": "Specializing back to real L2 recovers original Bunyakovsky-Schwarz."
+      "endLine": 181,
+      "summary": "Specializes back to real $L^2$: the bridge becomes $\\langle f, g \\rangle_{\\mathbb{R}} = \\int f g \\, d\\mu$ (conjugation is trivial over $\\mathbb{R}$) and Cauchy-Schwarz becomes $|\\int fg \\, d\\mu| \\leq \\|f\\| \\|g\\|$, recovering the classical Bunyakovsky-Schwarz inequality."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Replace 6 old-format annotations with 8 proper-format annotations (id, range, mathContext, etc.)
- Fix invalid annotation types (`proof-technique` → `theorem`)
- Deepen historicalContext: Cauchy (1821), Schwarz (1888), Bunyakovsky (1859), von Neumann (1929)
- Add preamble section, expand all section summaries with LaTeX
- Fix proofRepoPath casing: `Oq03` → `OQ03`

## Test plan
- [x] `pnpm annotations:build` passes with no warnings for this proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)