### PR TITLE
Enrich Erdős 924, 990, Derangements OQ-02 OQ-01: fix schema, add references

### DIFF
--- a/src/data/proofs/derangements-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/derangements-oq-02-oq-01/annotations.json
@@ -7,7 +7,7 @@
     "title": "Fixed-Point Count Preserved by permCongr",
     "content": "**Theorem** `fixedPoint_count_permCongr`:\n```\nFintype.card {x : α // σ x = x} = Fintype.card {y : β // (e.permCongr σ) y = y}\n```\n\nFor any equivalence `e : α ≃ β`, conjugating a permutation `σ : Perm α` by `e` preserves the number of fixed points. The proof constructs an explicit bijection between the fixed-point subtypes:\n- **Forward**: `⟨x, hx⟩ ↦ ⟨e x, proof that e.permCongr σ (e x) = e x⟩`\n- **Backward**: `⟨y, hy⟩ ↦ ⟨e.symm y, proof that σ (e.symm y) = e.symm y⟩`\n\nThe key computation: `e.permCongr σ (e x) = e (σ (e.symm (e x))) = e (σ x) = e x` when `σ x = x`.",
     "mathContext": "|\\text{Fix}(\\sigma)| = |\\text{Fix}(e \\circ \\sigma \\circ e^{-1})|",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["permCongr", "conjugation", "fixed-points", "Fintype.card_congr"]
   },
   {
@@ -18,7 +18,7 @@
     "title": "k-Fixed Filter Bijection via permCongr",
     "content": "**Theorem** `card_kfixed_permCongr`:\n```\n|{σ : Perm α | |Fix(σ)| = k}| = |{τ : Perm β | |Fix(τ)| = k}|\n```\n\nTransports the entire k-fixed-point filter between Perm α and Perm β. The bijection sends `σ ↦ e.permCongr σ` and uses `fixedPoint_count_permCongr` to verify the fixed-point count is preserved.\n\nThe round-trip proofs use:\n- `e.symm.permCongr ∘ e.permCongr = id` (left inverse)\n- `e.permCongr ∘ e.symm.permCongr = id` (right inverse)\n\nBoth close by `simp [Equiv.permCongr_apply]` after pointwise extensionality.",
     "mathContext": "\\{\\sigma \\in \\text{Perm}\\; \\alpha \\mid |\\text{Fix}(\\sigma)| = k\\} \\cong \\{\\tau \\in \\text{Perm}\\; \\beta \\mid |\\text{Fix}(\\tau)| = k\\}",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["Fintype.card_congr", "permCongr", "filter", "cardinality"]
   },
   {
@@ -29,18 +29,29 @@
     "title": "Main Theorem: S(α,k) = C(|α|,k)·D(|α|-k)",
     "content": "**Theorem** `card_perms_with_kfixed_fintype` (for `hk : k ≤ Fintype.card α`):\n```\n|{σ : Perm α | |Fix(σ)| = k}| = C(|α|, k) · numDerangements(|α| - k)\n```\n\nThe proof is remarkably concise — just two lines:\n1. `rw [card_kfixed_permCongr (Fintype.equivFin α) k]` — transport from Perm α to Perm (Fin |α|)\n2. `exact PartialDerangements.card_perms_with_kfixed ...` — apply the Fin n result\n\nThis demonstrates the power of the transport approach: once the filter bijection is established, the general result follows immediately from the special case.",
     "mathContext": "S(\\alpha, k) = \\binom{|\\alpha|}{k} \\cdot D(|\\alpha| - k)",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["Fintype.equivFin", "transport", "numDerangements", "binomial coefficient"]
   },
   {
     "id": "ann-corollaries",
     "proofId": "derangements-oq-02-oq-01",
-    "range": {"startLine": 84, "endLine": 109},
+    "range": {"startLine": 86, "endLine": 109},
     "type": "theorem",
     "title": "Corollaries: Special Cases and Sum Identity",
     "content": "Three corollaries, each proved by a single transport + application:\n\n**S(α, |α|-1) = 0** (`permsWithCardMinus1Fixed_eq_zero`, for |α| ≥ 2):\nImpossible to fix exactly |α|-1 elements. If all but one element is fixed, that remaining element must map to itself too.\n\n**S(α, |α|) = 1** (`permsWithAllFixed_eq_one`):\nThe only permutation fixing all elements is the identity.\n\n**∑ S(α,k) = |α|!** (`sum_kfixed_eq_factorial`):\nEvery permutation has a definite fixed-point count, so the filter classes partition Perm α.\n\nAll three follow the same pattern: `rw [card_kfixed_permCongr (Fintype.equivFin α)]` then apply the Fin n corollary.",
     "mathContext": "S(\\alpha, |\\alpha|-1) = 0, \\quad S(\\alpha, |\\alpha|) = 1, \\quad \\sum_k S(\\alpha,k) = |\\alpha|!",
     "significance": "key",
     "relatedConcepts": ["identity permutation", "card_support_ne_one", "factorial", "partition"]
+  },
+  {
+    "id": "ann-transport-methodology",
+    "proofId": "derangements-oq-02-oq-01",
+    "range": {"startLine": 111, "endLine": 123},
+    "type": "context",
+    "title": "Transport Methodology: Fin n to Arbitrary Fintype",
+    "content": "The proof's summary highlights a reusable pattern for Mathlib: prove a permutation-counting result for Fin n, then transport to arbitrary Fintype α via `Fintype.equivFin`. The key insight is that `permCongr` preserves the combinatorial invariant (here, fixed-point count), so the Fin n result lifts for free.\n\nThis three-step pattern — (1) prove invariance under permCongr, (2) establish filter bijection, (3) instantiate with equivFin — applies to any permutation statistic preserved by conjugation: cycle type, descent count, inversion number, etc.",
+    "mathContext": "\\text{Perm}\\;\\alpha \\xrightarrow{\\text{permCongr}(e)} \\text{Perm}\\;(\\text{Fin}\\;|\\alpha|)",
+    "significance": "supporting",
+    "relatedConcepts": ["Fintype.equivFin", "permCongr", "transport", "Mathlib methodology"]
   }
 ]

--- a/src/data/proofs/derangements-oq-02-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-01/meta.json
@@ -36,6 +36,16 @@
         "theorem": "numDerangements",
         "description": "The derangement number D(n): count of fixed-point-free permutations of Fin n",
         "module": "Mathlib.Combinatorics.Derangements.Finite"
+      },
+      {
+        "theorem": "Fintype.card_congr",
+        "description": "Types with an equivalence have equal cardinality: α ≃ β → card α = card β",
+        "module": "Mathlib.Data.Fintype.Basic"
+      },
+      {
+        "theorem": "Fintype.card_subtype",
+        "description": "Cardinality of a subtype equals filter cardinality",
+        "module": "Mathlib.Data.Fintype.Basic"
       }
     ],
     "originalContributions": [
@@ -48,24 +58,39 @@
     ],
     "references": [
       {
-        "authors": "Various",
-        "title": "Derangements (Combinatorics)",
-        "year": "classical",
-        "venue": "Wikipedia",
-        "note": "Standard formula for permutations with exactly k fixed points"
+        "authors": "P. R. de Montmort",
+        "title": "Essay d'Analyse sur les Jeux de Hazard",
+        "year": "1708",
+        "venue": "Quillau, Paris",
+        "note": "First study of the problème des rencontres (matching problem), introducing derangement counting"
+      },
+      {
+        "authors": "L. Euler",
+        "title": "Calcul de la probabilité dans le jeu de rencontre",
+        "year": "1753",
+        "venue": "Mémoires de l'Académie des Sciences de Berlin",
+        "note": "Derived the alternating series formula D(n) = n! Σ (-1)^k/k! and the recurrence D(n) = (n-1)(D(n-1) + D(n-2))"
+      },
+      {
+        "authors": "R. P. Stanley",
+        "title": "Enumerative Combinatorics, Volume 1",
+        "year": "2012",
+        "venue": "Cambridge University Press",
+        "note": "Chapter 2: standard treatment of permutation statistics including fixed-point counting and the partial derangement formula"
       }
     ],
-    "dateAdded": "03/11/26"
+    "dateAdded": "2026-03-11"
   },
   "overview": {
-    "historicalContext": "**Generalizing the Partial Derangement Formula**\n\nThe partial derangement formula $S(n,k) = \\binom{n}{k} \\cdot D(n-k)$ counts permutations of $n$ elements with exactly $k$ fixed points. The original formalization (derangements-oq-02) proved this for $\\text{Fin}\\, n$.\n\nThe natural question is: does the same formula hold for **any** finite type $\\alpha$, not just the canonical $\\text{Fin}\\, n$? The answer is yes, by a transport argument: every finite type $\\alpha$ is equivalent to $\\text{Fin}\\, |\\alpha|$ via `Fintype.equivFin`, and permutation conjugation via `Equiv.permCongr` preserves the fixed-point count.\n\nThis generalization is important because mathematical structures rarely come labeled as $\\text{Fin}\\, n$. Graph automorphisms, symmetries of geometric objects, and group actions all involve permutations of abstract finite sets.",
+    "historicalContext": "**Generalizing the Partial Derangement Formula**\n\nThe study of derangements dates to Montmort's *problème des rencontres* (1708): if $n$ cards numbered 1 through $n$ are shuffled, what is the probability that no card lands in its original position? Euler (1753) derived the alternating series $D(n) = n! \\sum_{k=0}^n (-1)^k/k!$ and the recurrence $D(n) = (n-1)(D(n-1) + D(n-2))$.\n\nThe partial derangement formula $S(n,k) = \\binom{n}{k} \\cdot D(n-k)$ extends this to count permutations with *exactly* $k$ fixed points: choose which $k$ elements to fix, then derange the rest. The original formalization (derangements-oq-02) proved this for $\\text{Fin}\\, n$.\n\nThe natural question is: does the same formula hold for **any** finite type $\\alpha$, not just the canonical $\\text{Fin}\\, n$? The answer is yes, by a transport argument: every finite type $\\alpha$ is equivalent to $\\text{Fin}\\, |\\alpha|$ via `Fintype.equivFin`, and permutation conjugation via `Equiv.permCongr` preserves the fixed-point count.\n\nThis generalization is important because mathematical structures rarely come labeled as $\\text{Fin}\\, n$. Graph automorphisms, symmetries of geometric objects, and group actions all involve permutations of abstract finite sets.",
     "problemStatement": "**Open Question (derangements-oq-02-oq-01)**: Prove the partial derangement formula for arbitrary finite types.\n\n**Formally**: For any $\\alpha : \\text{Type}^*$ with $[\\text{Fintype}\\; \\alpha]$ $[\\text{DecidableEq}\\; \\alpha]$ and $k \\leq |\\alpha|$:\n$$\\left|\\{\\sigma \\in \\text{Perm}\\; \\alpha \\mid |\\text{Fix}(\\sigma)| = k\\}\\right| = \\binom{|\\alpha|}{k} \\cdot D(|\\alpha| - k)$$",
     "proofStrategy": "**Transport via Fintype.equivFin**\n\nThe proof has two layers:\n\n**Layer 1: Fixed-point preservation** (`fixedPoint_count_permCongr`)\nFor any equivalence $e : \\alpha \\simeq \\beta$, the conjugation $\\sigma \\mapsto e \\circ \\sigma \\circ e^{-1}$ preserves the number of fixed points. This is proved by constructing an explicit bijection between the fixed-point subtypes $\\{x : \\alpha \\mid \\sigma(x) = x\\} \\simeq \\{y : \\beta \\mid (e \\circ \\sigma \\circ e^{-1})(y) = y\\}$.\n\n**Layer 2: Filter cardinality transfer** (`card_kfixed_permCongr`)\nThe $k$-fixed-point filter on $\\text{Perm}\\; \\alpha$ bijects with the corresponding filter on $\\text{Perm}\\; \\beta$ via `permCongr`. This gives equal cardinalities.\n\n**Layer 3: Instantiation**\nApply the transport with $e = \\texttt{Fintype.equivFin}\\; \\alpha : \\alpha \\simeq \\text{Fin}\\; |\\alpha|$, then invoke the $\\text{Fin}\\; n$ result from `PartialDerangements.card_perms_with_kfixed`.",
     "keyInsights": [
       "**Transport principle**: Rather than reproving the combinatorial argument for arbitrary types, transport the existing Fin n result via Fintype.equivFin. This yields a 2-line proof of the main theorem.",
       "**permCongr preserves fixed points**: The key lemma. Conjugation σ ↦ e∘σ∘e⁻¹ sends fixed points x↦x to fixed points e(x)↦e(x), giving a bijection on fixed-point sets.",
       "**Subtype formulation for fixed points**: Using Fintype.card {x : α // σ x = x} rather than filter cardinality gives cleaner proofs via Fintype.card_congr.",
-      "**Corollaries transfer automatically**: Once the filter bijection is established, all corollaries (S(α,|α|-1)=0, S(α,|α|)=1, sum=|α|!) follow by a single rewrite."
+      "**Corollaries transfer automatically**: Once the filter bijection is established, all corollaries (S(α,|α|-1)=0, S(α,|α|)=1, sum=|α|!) follow by a single rewrite.",
+      "**Reusable methodology**: The three-step pattern (prove invariance under permCongr → establish filter bijection → instantiate with equivFin) applies to any permutation statistic preserved by conjugation: cycle type, descent count, inversion number, etc."
     ]
   },
   "sections": [


### PR DESCRIPTION
## Summary

### Erdős 924 (Folkman-Nešetřil-Rödl)
- Fix 9 annotations: `significance: "critical"` → `"key"`
- Fix 5 annotations: `type: "concept"` → `"definition"`/`"context"`
- Remove 3 annotations referencing comment blocks
- Add 5 structured references

### Erdős 990 (Erdős-Turán Inequality)
- Remove 1 annotation pointing at comment block (invalid "concept" type)
- Fix 10 annotations: `significance: "critical"` → `"key"`
- Add 5 structured references: Erdős-Turán 1950, Ganelius 1954, Soundararajan 2019, Steinerberger 2021, Erdélyi 2008

### Derangements OQ-02 OQ-01 (Partial Derangements for Arbitrary Fintype)
- Fix 3 annotations: `significance: "critical"` → `"key"`
- Fix corollaries startLine 84 → 86 (was pointing at blank line)
- Add 5th annotation on transport methodology
- Add 3 references: Montmort 1708, Euler 1753, Stanley 2012
- Add 2 mathlibDependencies: Fintype.card_congr, Fintype.card_subtype
- Expand historicalContext with Montmort's problème des rencontres
- Fix dateAdded format

## Test plan
- [x] JSON validates for all 3 proofs
- [x] `pnpm annotations:build` — no errors for any enriched proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)