### PR TITLE
Enrich Erdős 924 (Folkman-Nešetřil-Rödl): add annotations, refs, LaTeX

### DIFF
--- a/src/data/proofs/erdos-924/annotations.json
+++ b/src/data/proofs/erdos-924/annotations.json
@@ -35,7 +35,9 @@
     "title": "completeGraph",
     "content": "The complete graph K_n on n vertices, defined as the top element `⊤` in the SimpleGraph lattice — every pair of distinct vertices is adjacent.",
     "mathContext": "In Mathlib, `SimpleGraph V` forms a complete lattice where `⊤` is the complete graph and `⊥` is the empty graph. The complete graph K_n = R(l,l)-many vertices trivially has the Ramsey property (by Ramsey's theorem), but it contains all K_m for m ≤ n. The point of Folkman graphs is to achieve the Ramsey property without this triviality.",
-    "significance": "supporting"
+    "significance": "supporting",
+    "relatedConcepts": ["SimpleGraph lattice", "top element", "Ramsey threshold", "clique number"],
+    "prerequisites": ["SimpleGraph", "Fin"]
   },
   {
     "id": "ann-e924-clique-size",
@@ -65,6 +67,18 @@
     ]
   },
   {
+    "id": "ann-e924-contains-clique",
+    "proofId": "erdos-924",
+    "range": { "startLine": 66, "endLine": 67 },
+    "type": "definition",
+    "title": "ContainsClique (Semantic Alias)",
+    "content": "**Definition** `ContainsClique G n` is a semantic alias for `IsCliqueOfSize G n`, improving readability when expressing that a color class subgraph contains a copy of $K_l$. Used in `HasMonochromaticClique` to state that some color class contains $K_l$.",
+    "mathContext": "\\text{ContainsClique}(G, n) \\iff \\exists S \\subseteq V(G),\\; |S| = n \\land G[S] \\cong K_n",
+    "significance": "supporting",
+    "relatedConcepts": ["IsCliqueOfSize", "clique number", "subgraph containment"],
+    "prerequisites": ["Finset", "SimpleGraph.IsClique"]
+  },
+  {
     "id": "ann-e924-edge-coloring",
     "proofId": "erdos-924",
     "range": { "startLine": 79, "endLine": 80 },
@@ -72,7 +86,9 @@
     "title": "EdgeColoring",
     "content": "A k-coloring of G's edges: a function `G.edgeSet → Fin k` assigning one of k colors to each edge. The Ramsey property requires that every such coloring produces a monochromatic clique.",
     "mathContext": "The edge coloring is formalized as a function from `G.edgeSet` (the set of edges as `Sym2 V` elements) to `Fin k`. This is the standard Ramsey-theoretic setup: partition the edge set into k classes. Note the difference from *proper* edge coloring (where adjacent edges get different colors) — here there is no constraint on which edges share a color. The Ramsey property is a statement about *all* possible partitions.",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["partition regularity", "Sym2", "edge set", "Ramsey coloring"],
+    "prerequisites": ["SimpleGraph.edgeSet", "Fin", "Sym2"]
   },
   {
     "id": "ann-e924-mono-subgraph",
@@ -83,6 +99,18 @@
     "content": "For a coloring χ and color c, the subgraph consisting of all edges colored c. Formally a `SimpleGraph V` where `Adj u v` holds iff `G.Adj u v ∧ χ(edge(u,v)) = c`. The `symm` and `loopless` proofs verify the SimpleGraph axioms.",
     "mathContext": "Each monochromatic subgraph is a *color class* — the induced subgraph on edges of one color. The union of all k color classes gives back G. The Ramsey property asks that at least one color class contains K_l. The symmetry proof uses `Sym2.eq_swap` to handle the unordered edge representation. This is a concrete instance of the partition regularity principle: for any finite partition of edges, at least one part must contain a prescribed structure.",
     "significance": "key"
+  },
+  {
+    "id": "ann-e924-has-mono-clique",
+    "proofId": "erdos-924",
+    "range": { "startLine": 102, "endLine": 104 },
+    "type": "definition",
+    "title": "HasMonochromaticClique: Colored Clique Existence",
+    "content": "**Definition** `HasMonochromaticClique G χ l`: a coloring $\\chi$ of $G$'s edges produces a monochromatic $K_l$ if **some** color class contains a clique of size $l$. The existential quantifier over colors $c : \\text{Fin}\\, k$ is the bridge between edge colorings and the Ramsey property: `HasRamseyProperty G k l` universally quantifies over all colorings $\\chi$, each of which must satisfy `HasMonochromaticClique`.",
+    "mathContext": "\\exists c \\in [k],\\; K_l \\subseteq G_c \\quad \\text{where } G_c = \\{uv \\in E(G) : \\chi(uv) = c\\}",
+    "significance": "key",
+    "relatedConcepts": ["MonochromaticSubgraph", "ContainsClique", "partition regularity", "pigeonhole principle"],
+    "prerequisites": ["EdgeColoring", "MonochromaticSubgraph", "Fin"]
   },
   {
     "id": "ann-e924-ramsey-prop",

--- a/src/data/proofs/erdos-924/meta.json
+++ b/src/data/proofs/erdos-924/meta.json
@@ -85,6 +85,48 @@
         "targetProofId": "erdos-927",
         "relationship": "related",
         "description": "Studies distinct clique sizes in graphs — complementary perspective on clique structure"
+      },
+      {
+        "targetProofId": "ramseys-theorem",
+        "relationship": "uses",
+        "description": "The classical Ramsey theorem provides the foundation; Folkman graphs achieve Ramsey-type forcing without large cliques"
+      }
+    ],
+    "references": [
+      {
+        "authors": "J. Folkman",
+        "title": "Graphs with monochromatic complete subgraphs in every edge coloring",
+        "year": "1970",
+        "venue": "SIAM J. Appl. Math., 18, 19–24",
+        "note": "Proved k=2 case; published posthumously (Folkman died 1969). Introduced shift graph construction and Folkman graphs."
+      },
+      {
+        "authors": "J. Nešetřil, V. Rödl",
+        "title": "The Ramsey property for graphs with forbidden complete subgraphs",
+        "year": "1976",
+        "venue": "J. Combinatorial Theory Ser. B, 20(3), 243–249",
+        "note": "Proved the general case for all k ≥ 2 using Hales-Jewett theorem and partite constructions."
+      },
+      {
+        "authors": "A. W. Hales, R. I. Jewett",
+        "title": "Regularity and positional games",
+        "year": "1963",
+        "venue": "Trans. Amer. Math. Soc., 106, 222–229",
+        "note": "The Hales-Jewett theorem, a key ingredient in the Nešetřil-Rödl proof."
+      },
+      {
+        "authors": "R. L. Graham",
+        "title": "On edgewise 2-colored graphs with monochromatic triangles and containing no complete hexagon",
+        "year": "1968",
+        "venue": "J. Combinatorial Theory, 4, 300",
+        "note": "Early upper bound for f(3;2)."
+      },
+      {
+        "authors": "A. Lange, S. P. Radziszowski, X. Xu",
+        "title": "Use of MAX-CUT for Ramsey arrowing of triangles",
+        "year": "2014",
+        "venue": "J. Combinatorial Mathematics and Combinatorial Computing, 88, 61–71",
+        "note": "Contributed to establishing f(3;2) = 786."
       }
     ]
   },
@@ -104,63 +146,63 @@
     {
       "id": "graph-basics",
       "title": "Basic Graph Concepts",
-      "summary": "completeGraph via ⊤, IsCliqueOfSize via Finset/IsClique, IsCliqueFree, ContainsClique",
+      "summary": "Defines `completeGraph` as $\\top$ in the `SimpleGraph` lattice, `IsCliqueOfSize` via `Finset`/`IsClique`, `IsCliqueFree` ($\\neg \\text{IsCliqueOfSize}$), and `ContainsClique` (semantic alias).",
       "startLine": 36,
       "endLine": 67
     },
     {
       "id": "edge-colorings",
       "title": "Edge Colorings",
-      "summary": "EdgeColoring as G.edgeSet → Fin k, MonochromaticSubgraph with symm/loopless proofs, HasMonochromaticClique",
+      "summary": "`EdgeColoring` as $G.\\text{edgeSet} \\to \\text{Fin}\\, k$, `MonochromaticSubgraph` with `symm`/`loopless` proofs via `Sym2.eq_swap`, and `HasMonochromaticClique` ($\\exists c,\\; K_l \\subseteq G_c$).",
       "startLine": 69,
       "endLine": 104
     },
     {
       "id": "ramsey-property",
       "title": "The Ramsey Property",
-      "summary": "HasRamseyProperty (∀ colorings, ∃ monochromatic K_l), ErdosHajnalQuestion (∃ K_{l+1}-free with Ramsey property)",
+      "summary": "`HasRamseyProperty`: $\\forall \\chi,\\; \\exists c,\\; K_l \\subseteq G_c$. `ErdosHajnalQuestion`: $\\exists G,\\; \\omega(G) \\le l \\land G \\to (K_l)^k_2$.",
       "startLine": 106,
       "endLine": 125
     },
     {
       "id": "folkman-graphs",
       "title": "Folkman Graphs",
-      "summary": "IsFolkmanGraph = IsCliqueFree ∧ HasRamseyProperty, FolkmanNumber via Nat.find",
+      "summary": "`IsFolkmanGraph` $= \\text{IsCliqueFree}\\, G\\, (l+1) \\land \\text{HasRamseyProperty}\\, G\\, k\\, l$. `FolkmanNumber` $f(l;k)$ defined via `Nat.find` from the existence guarantee.",
       "startLine": 127,
       "endLine": 145
     },
     {
       "id": "known-results",
       "title": "Known Results",
-      "summary": "folkman_1970 axiom (k=2), nesetril_rodl_1976 axiom (general k ≥ 2)",
+      "summary": "Axioms: `folkman_1970` ($k=2$, $\\forall l \\ge 3$) and `nesetril_rodl_1976` ($\\forall k \\ge 2, l \\ge 3$). The general theorem completely solves the Erdős-Hajnal question.",
       "startLine": 147,
       "endLine": 165
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "summary": "FolkmanNumber_3_2, graham_upper_bound (≤ 941), folkman_3_2_exact (= 786)",
+      "summary": "`FolkmanNumber_3_2` definition, Graham's upper bound $f(3;2) \\le 941$, and exact value $f(3;2) = 786$ (Lange-Radziszowski-Xu 2014).",
       "startLine": 167,
       "endLine": 196
     },
     {
       "id": "ramsey-connection",
       "title": "Connection to Ramsey Theory",
-      "summary": "RamseyNumber definition, folkman_vs_ramsey comparison",
+      "summary": "`RamseyNumber` $R(l,l)$ definition via `Nat.find`. Comparison: $K_n$ for $n \\ge R(l,l)$ trivially has the Ramsey property but contains all $K_m$; Folkman graphs achieve forcing with $\\omega(G) \\le l$.",
       "startLine": 198,
       "endLine": 220
     },
     {
       "id": "proof-techniques",
       "title": "Proof Techniques",
-      "summary": "Hales-Jewett method, partite construction, shift graphs, GeneralizedFolkmanNumber",
+      "summary": "Three proof techniques: Hales-Jewett ($[m]^n$ cubes), partite construction (controlling $\\omega(G)$), shift graphs (Folkman's original). Also `GeneralizedFolkmanNumber` $f(l_1, \\ldots, l_k; r)$ for asymmetric parameters.",
       "startLine": 222,
       "endLine": 265
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_924_summary (proved), erdos_924 = nesetril_rodl_1976 (proved), erdos_924_answer (proved)",
+      "summary": "`erdos_924_summary` combines three results in a single conjunction. `erdos_924 := nesetril_rodl_1976` identifies the solution. `erdos_924_answer` unpacks the existential for downstream use.",
       "startLine": 268,
       "endLine": 317
     }


### PR DESCRIPTION
## Summary
- Added 2 new annotations: `ContainsClique` and `HasMonochromaticClique` (18 total)
- Added `relatedConcepts`/`prerequisites` to `EdgeColoring` and `completeGraph` annotations
- Added 5 references: Folkman 1970, Nešetřil-Rödl 1976, Hales-Jewett 1963, Graham 1968, Lange-Radziszowski-Xu 2014
- Added cross-reference to ramseys-theorem
- Added LaTeX to all 9 section summaries

## Quality Improvements
- **Annotation coverage**: Now covers ContainsClique and HasMonochromaticClique definitions
- **References**: 5 foundational references from the Folkman graph literature
- **Section clarity**: LaTeX formulas in section summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)