### PR TITLE
Enrich ballot-problem-oq-01 + Erdős 995: annotations, types, context

### DIFF
--- a/src/data/proofs/erdos-995/meta.json
+++ b/src/data/proofs/erdos-995/meta.json
@@ -21,6 +21,7 @@
     "erdosNumber": 995,
     "erdosUrl": "https://erdosproblems.com/995",
     "erdosProblemStatus": "open",
+    "dateAdded": "2026-01-18",
     "mathlib_version": "4.15.0",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Summary
Two enrichments:

**ballot-problem-oq-01** (quality 95→enriched):
- 6 new annotations (7→13 total) covering cycle lemma proof, rightmost minimum, upper/lower bounds
- Fix invalid `technique` types → `theorem`
- 5 references (Bertrand, André, Dvoretzky-Motzkin, Renault, Aigner-Ziegler)
- 3 cross-references, 12 sections (was 9), LaTeX in all summaries
- Fix sorries count 3→1 (cycle lemma now fully proved)

**erdos-995** (quality 90→enriched):
- Fix invalid annotation types: `axiom`→`theorem` (3), `context`→`concept` (1)
- Fix startLine for 2 annotations (def→theorem line)
- Add `relatedConcepts` and `prerequisites` to all 15 annotations
- Add `dateAdded` to meta.json

## Test plan
- [x] `pnpm annotations:build` passes (only pre-existing axiom/theorem warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)