### PR TITLE
Enrich Erdős 1007 OQ-01, 995, 990: annotations and cross-refs

### DIFF
--- a/src/data/proofs/erdos-1007-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1007-oq-01/annotations.json
@@ -5,10 +5,10 @@
     "range": { "startLine": 42, "endLine": 56 },
     "type": "definition",
     "title": "Unit Distance Embedding and Graph Dimension",
-    "content": "Defines `UnitDistanceEmbedding'` as a structure with an embedding map `V → Fin n → ℝ` satisfying the unit-edge condition: for every adjacent pair `u v`, the Euclidean distance `√(∑ᵢ(embed u i - embed v i)²) = 1`. The graph dimension `graphDimension'` is defined as the minimum `n` admitting such an embedding via `Nat.find`.\n\nThe existence axiom `hasUnitEmbedding_exists'` asserts every finite graph has some embedding dimension. This is geometrically obvious (embed in ℝ^|V|) but axiomatized since constructing the witness requires solving distance equations. The `open Classical` on `graphDimension'` is needed because `Nat.find` uses classical logic to extract the minimum.",
+    "content": "Defines `UnitDistanceEmbedding'` as a structure with an embedding map `V → Fin n → ℝ` satisfying the unit-edge condition: for every adjacent pair `u v`, the Euclidean distance `√(∑ᵢ(embed u i - embed v i)²) = 1`. The graph dimension `graphDimension'` is defined as the minimum `n` admitting such an embedding via `Nat.find`.\n\nThe existence axiom `hasUnitEmbedding_exists'` asserts every finite graph has some embedding dimension. This is geometrically obvious (embed in ℝ^|V|) but axiomatized since constructing the witness requires solving distance equations. The `open Classical` on `graphDimension'` is needed because `Nat.find` uses classical logic to extract the minimum.\n\nThe unit-distance graph framework connects to a rich history: Erdős himself posed many problems about unit-distance graphs in the plane (the Hadwiger–Nelson problem on the chromatic number of the unit-distance graph of $\\mathbb{R}^2$, resolved to be between 5 and 7). The higher-dimensional generalization studied here asks a dual question: instead of fixing the dimension and asking about graph properties, we fix the graph and minimize the required dimension.",
     "mathContext": "\\text{dim}(G) = \\min\\{n \\in \\mathbb{N} : \\exists f : V \\to \\mathbb{R}^n,\\; \\forall uv \\in E(G),\\; \\|f(u)-f(v)\\| = 1\\}",
     "significance": "key",
-    "relatedConcepts": ["unit distance graph", "Euclidean embedding", "graph dimension", "Nat.find", "Classical.choice"],
+    "relatedConcepts": ["unit distance graph", "Euclidean embedding", "graph dimension", "Nat.find", "Classical.choice", "Hadwiger-Nelson problem"],
     "prerequisites": ["Euclidean distance", "Real.sqrt", "Fintype", "Nonempty"]
   },
   {
@@ -17,10 +17,10 @@
     "range": { "startLine": 64, "endLine": 77 },
     "type": "context",
     "title": "Axiomatization of minEdges(d)",
-    "content": "The function `minEdgesForDim : ℕ → ℕ` is axiomatized rather than computed, since extracting the minimum over all finite graphs of a given dimension requires an unbounded search over graph structures. Three axioms specify the function:\n\n1. **`minEdgesForDim_le`**: For any graph of dimension d, its edge count is at least `minEdgesForDim d` — the function is a valid lower bound.\n2. **`minEdgesForDim_achieved`**: For d > 0, some graph achieves the minimum — the bound is tight.\n3. The function itself: `minEdgesForDim : ℕ → ℕ` is declared as an axiom.\n\nThis is a standard pattern in formalized extremal combinatorics: axiomatize the extremal function when the optimization problem is not computably solvable, then prove structural theorems about its values.",
+    "content": "The function `minEdgesForDim : ℕ → ℕ` is axiomatized rather than computed, since extracting the minimum over all finite graphs of a given dimension requires an unbounded search over graph structures. Three axioms specify the function:\n\n1. **`minEdgesForDim_le`**: For any graph of dimension d, its edge count is at least `minEdgesForDim d` — the function is a valid lower bound.\n2. **`minEdgesForDim_achieved`**: For d > 0, some graph achieves the minimum — the bound is tight.\n3. The function itself: `minEdgesForDim : ℕ → ℕ` is declared as an axiom.\n\nThis is a standard pattern in formalized extremal combinatorics: axiomatize the extremal function when the optimization problem is not computably solvable, then prove structural theorems about its values. The pattern mirrors how Ramsey numbers $R(s,t)$ or Turán numbers $\\text{ex}(n,H)$ would be formalized: declare the extremal quantity, state its defining properties as axioms, and derive consequences.",
     "mathContext": "\\text{minEdges}(d) = \\min\\{|E(G)| : \\text{dim}(G) = d\\}",
     "significance": "key",
-    "relatedConcepts": ["extremal graph theory", "axiomatization", "graph dimension", "Finset.filter"],
+    "relatedConcepts": ["extremal graph theory", "axiomatization", "graph dimension", "Finset.filter", "Turán number", "Ramsey number"],
     "prerequisites": ["Fintype", "DecidableRel", "Finset.univ.filter"]
   },
   {
@@ -29,10 +29,10 @@
     "range": { "startLine": 84, "endLine": 99 },
     "type": "context",
     "title": "Known Values of minEdges for d = 0 through 5",
-    "content": "Six axioms record the known values `minEdges(0..5) = (0, 1, 3, 6, 9, 15)`. For d ≤ 3 and d = 5, the optimal graph is the complete graph K_{d+1} with C(d+1,2) edges. The d = 4 case is exceptional: the complete bipartite graph K_{3,3} achieves dimension 4 with only 9 edges, beating K₅'s 10 edges.\n\nThese values were established computationally and proved via geometric constructions:\n- d ≤ 3: Classical — K_{d+1} embeds as a regular simplex\n- d = 4: House (2013) proved K_{3,3} achieves dimension 4 with 9 edges\n- d = 5: Chaffee-Noble (2016) proved minEdges(5) = 15 = C(6,2)",
+    "content": "Six axioms record the known values `minEdges(0..5) = (0, 1, 3, 6, 9, 15)`. For d ≤ 3 and d = 5, the optimal graph is the complete graph K_{d+1} with C(d+1,2) edges. The d = 4 case is exceptional: the complete bipartite graph K_{3,3} achieves dimension 4 with only 9 edges, beating K₅'s 10 edges.\n\nThese values were established computationally and proved via geometric constructions:\n- d ≤ 3: Classical — K_{d+1} embeds as a regular simplex\n- d = 4: House (2013) proved K_{3,3} achieves dimension 4 with 9 edges\n- d = 5: Chaffee-Noble (2016) proved minEdges(5) = 15 = C(6,2)\n\nThe sequence $(0, 1, 3, 6, 9, 15)$ is almost the triangular numbers $T_n = n(n+1)/2$, deviating only at $d=4$ where $T_4 = 10$ but $\\text{minEdges}(4) = 9$. This near-triangular structure is a manifestation of the close-to-optimal behavior of complete graphs.",
     "mathContext": "\\text{minEdges}(0,1,2,3,4,5) = (0, 1, 3, 6, 9, 15)",
     "significance": "key",
-    "relatedConcepts": ["complete graph", "complete bipartite graph", "K_{3,3}", "regular simplex"],
+    "relatedConcepts": ["complete graph", "complete bipartite graph", "K_{3,3}", "regular simplex", "triangular numbers"],
     "prerequisites": ["Nat.choose"]
   },
   {
@@ -77,10 +77,10 @@
     "range": { "startLine": 131, "endLine": 146 },
     "type": "concept",
     "title": "General Bounds: Rigidity Lower Bound and Complete Graph Upper Bound",
-    "content": "Two axioms establish the asymptotic sandwich for minEdges(d):\n\n1. **`minEdges_lower_bound`**: d ≤ minEdges(d) for d ≥ 1. This follows from rigidity theory: a graph of dimension exactly d requires at least d independent distance constraints (edges) to prevent collapsing to a lower-dimensional embedding. In the language of rigidity theory, d edges are needed to determine d degrees of freedom.\n\n2. **`minEdges_upper_bound`**: minEdges(d) ≤ C(d+1,2). The complete graph K_{d+1} always achieves dimension d (embeddable as a regular simplex in ℝ^d with unit edges), providing the upper bound.\n\nThe theorem `values_are_nondecreasing_small` verifies monotonicity for d = 1..5 by direct computation from known values, establishing the pattern before the general conjecture.\n\nTogether, d ≤ minEdges(d) ≤ d(d+1)/2 gives the growth rate Ω(d) and O(d²). The quadratic growth conjecture asserts the tighter Θ(d²).",
+    "content": "Two axioms establish the asymptotic sandwich for minEdges(d):\n\n1. **`minEdges_lower_bound`**: d ≤ minEdges(d) for d ≥ 1. This follows from rigidity theory: a graph of dimension exactly d requires at least d independent distance constraints (edges) to prevent collapsing to a lower-dimensional embedding. More precisely, Laman's theorem (1970) characterizes rigidity in 2D, and its higher-dimensional generalizations show that $d$ edges are the absolute minimum for $d$-dimensional rigidity.\n\n2. **`minEdges_upper_bound`**: minEdges(d) ≤ C(d+1,2). The complete graph K_{d+1} always achieves dimension d (embeddable as a regular simplex in ℝ^d with unit edges), providing the upper bound.\n\nThe theorem `values_are_nondecreasing_small` verifies monotonicity for d = 1..5 by direct computation from known values, establishing the pattern before the general conjecture.\n\nTogether, d ≤ minEdges(d) ≤ d(d+1)/2 gives the growth rate Ω(d) and O(d²). The quadratic growth conjecture asserts the tighter Θ(d²).",
     "mathContext": "d \\le \\text{minEdges}(d) \\le \\binom{d+1}{2} = \\frac{d(d+1)}{2}",
     "significance": "key",
-    "relatedConcepts": ["rigidity theory", "regular simplex", "asymptotic bounds", "extremal function sandwich"],
+    "relatedConcepts": ["rigidity theory", "Laman's theorem", "regular simplex", "asymptotic bounds", "extremal function sandwich"],
     "prerequisites": ["Nat.choose", "Fintype", "unit distance embedding"]
   },
   {
@@ -89,7 +89,7 @@
     "range": { "startLine": 169, "endLine": 181 },
     "type": "theorem",
     "title": "Quadratic Upper Bound via Nat-to-Real Casting",
-    "content": "**Theorem** `upper_bound_quadratic`: `(minEdgesForDim d : ℝ) ≤ ((d+1) * d) / 2`\n\nThe proof bridges Nat and Real arithmetic through a careful chain:\n1. `Nat.cast_le.mpr` lifts the natural number bound `minEdges_upper_bound` to reals\n2. `Nat.choose_two_right` rewrites C(d+1,2) as (d+1)*d/2\n3. A parity case split (`Nat.even_or_odd d`) establishes `2 ∣ (d+1)*d` — needed for `Nat.cast_div`\n4. `push_cast` and `ring` close the algebraic identity\n\nThis Nat→Real casting pattern (prove in ℕ, cast to ℝ, simplify) is ubiquitous in Lean formalized combinatorics where bounds involve integer division.",
+    "content": "**Theorem** `upper_bound_quadratic`: `(minEdgesForDim d : ℝ) ≤ ((d+1) * d) / 2`\n\nThe proof bridges Nat and Real arithmetic through a careful chain:\n1. `Nat.cast_le.mpr` lifts the natural number bound `minEdges_upper_bound` to reals\n2. `Nat.choose_two_right` rewrites C(d+1,2) as (d+1)*d/2\n3. A parity case split (`Nat.even_or_odd d`) establishes `2 ∣ (d+1)*d` — needed for `Nat.cast_div`\n4. `push_cast` and `ring` close the algebraic identity\n\nThis Nat→Real casting pattern (prove in ℕ, cast to ℝ, simplify) is ubiquitous in Lean formalized combinatorics where bounds involve integer division. The parity argument is needed because $\\text{Nat.cast\\_div}$ requires an explicit divisibility witness — Lean does not automatically know that the product of consecutive integers is even.",
     "mathContext": "\\text{minEdges}(d) \\le \\binom{d+1}{2} = \\frac{(d+1)d}{2}",
     "significance": "supporting",
     "relatedConcepts": ["binomial coefficient", "Nat.cast_le", "parity case split", "push_cast", "Nat.cast_div"],
@@ -113,10 +113,10 @@
     "range": { "startLine": 197, "endLine": 258 },
     "type": "definition",
     "title": "Simplex Embedding: K_n in R^n via Scaled Basis Vectors",
-    "content": "**Definition** `simplexEmbed n i j = if i = j then 1/√2 else 0`\n\nMaps vertex i to (1/√2)·eᵢ in ℝⁿ. The key distance computation (Theorem `simplexEmbed_dist_sq`):\n- For distinct i, j: the squared distance is `(1/√2)² + (-1/√2)² = 1/2 + 1/2 = 1`\n- The proof extracts the i-th and j-th terms from `Finset.univ.sum` using `Finset.add_sum_erase`, shows all other terms vanish, and concludes with `ring`\n\nThe corollaries chain:\n1. `complete_graph_unit_embedding`: K_n admits unit-distance embedding in ℝⁿ (for n ≥ 2)\n2. `complete_graph_dim_le`: graphDimension(K_n) ≤ n\n\nThe embedding places vertices at vertices of a regular simplex scaled to have edge length 1. The factor 1/√2 (rather than 1) is the unique scaling that makes all pairwise distances equal to 1 in the standard basis construction.",
+    "content": "**Definition** `simplexEmbed n i j = if i = j then 1/√2 else 0`\n\nMaps vertex i to (1/√2)·eᵢ in ℝⁿ. The key distance computation (Theorem `simplexEmbed_dist_sq`):\n- For distinct i, j: the squared distance is `(1/√2)² + (-1/√2)² = 1/2 + 1/2 = 1`\n- The proof extracts the i-th and j-th terms from `Finset.univ.sum` using `Finset.add_sum_erase`, shows all other terms vanish, and concludes with `ring`\n\nThe corollary `complete_graph_unit_embedding` chains the distance computation through `Real.sqrt_one` (since $\\sqrt{1} = 1$) to produce the full `UnitDistanceEmbedding'` structure.\n\nThe embedding places vertices at vertices of a regular simplex scaled to have edge length 1. The factor 1/√2 (rather than 1) is the unique scaling that makes all pairwise distances equal to 1 in the standard basis construction. This is because $\\|e_i - e_j\\| = \\sqrt{2}$ for standard basis vectors, so dividing by $\\sqrt{2}$ normalizes to unit distance.\n\nNote that this embeds $K_n$ in $\\mathbb{R}^n$, not the optimal $\\mathbb{R}^{n-1}$. The optimal embedding uses the centroid-shifted simplex: $v_i = e_i - \\frac{1}{n}\\sum_j e_j$, which lies in the $(n-1)$-dimensional hyperplane $\\sum x_i = 0$. Proving the optimal bound would require showing that this hyperplane copy is isometric to $\\mathbb{R}^{n-1}$.",
     "mathContext": "v_i = \\frac{1}{\\sqrt{2}} e_i \\in \\mathbb{R}^n, \\quad \\|v_i - v_j\\|^2 = \\frac{1}{2} + \\frac{1}{2} = 1",
     "significance": "key",
-    "relatedConcepts": ["regular simplex", "standard basis vectors", "Finset.add_sum_erase", "unit distance embedding"],
+    "relatedConcepts": ["regular simplex", "standard basis vectors", "Finset.add_sum_erase", "unit distance embedding", "centroid-shifted simplex"],
     "prerequisites": ["Real.sqrt", "Real.sq_sqrt", "Finset.sum", "Fin"]
   },
   {
@@ -125,11 +125,23 @@
     "range": { "startLine": 201, "endLine": 204 },
     "type": "theorem",
     "title": "Key Algebraic Identity: (1/√2)² = 1/2",
-    "content": "**Theorem** `inv_sqrt_two_sq` (private): `(1 / Real.sqrt 2) ^ 2 = 1 / 2`\n\nThe numerical linchpin of the simplex embedding. The proof:\n1. `Real.sqrt_ne_zero'.mpr (by norm_num : 0 < 2)` establishes `√2 ≠ 0`\n2. `field_simp` clears the denominator, reducing to `1² = √2 · √2 / 2`\n3. `Real.sq_sqrt (by norm_num : 0 ≤ 2)` gives `(√2)² = 2`\n\nDespite its simplicity, this identity requires careful handling because Lean's `Real.sqrt` is not syntactically invertible — one must go through the `sq_sqrt` characterization.",
+    "content": "**Theorem** `inv_sqrt_two_sq` (private): `(1 / Real.sqrt 2) ^ 2 = 1 / 2`\n\nThe numerical linchpin of the simplex embedding. The proof:\n1. `Real.sqrt_ne_zero'.mpr (by norm_num : 0 < 2)` establishes `√2 ≠ 0`\n2. `field_simp` clears the denominator, reducing to `1² = √2 · √2 / 2`\n3. `Real.sq_sqrt (by norm_num : 0 ≤ 2)` gives `(√2)² = 2`\n\nDespite its simplicity, this identity requires careful handling because Lean's `Real.sqrt` is not syntactically invertible — one must go through the `sq_sqrt` characterization. This is a common pattern when working with irrational constants in Lean: $\\sqrt{2}$ is a `noncomputable def` and cannot be evaluated by `norm_num` or `native_decide`.",
     "mathContext": "\\left(\\frac{1}{\\sqrt{2}}\\right)^2 = \\frac{1}{2}",
     "significance": "supporting",
-    "relatedConcepts": ["Real.sqrt", "Real.sq_sqrt", "field_simp", "Real.sqrt_ne_zero'"],
+    "relatedConcepts": ["Real.sqrt", "Real.sq_sqrt", "field_simp", "Real.sqrt_ne_zero'", "noncomputable"],
     "prerequisites": ["norm_num"]
+  },
+  {
+    "id": "erdos-1007-oq-01-complete-graph-dim-le",
+    "proofId": "erdos-1007-oq-01",
+    "range": { "startLine": 262, "endLine": 265 },
+    "type": "theorem",
+    "title": "Corollary: graphDimension(K_n) ≤ n",
+    "content": "**Theorem** `complete_graph_dim_le`: For $n \\ge 2$, $\\text{dim}(K_n) \\le n$.\n\nThe proof applies `Nat.find_le` to the simplex embedding witness: since `complete_graph_unit_embedding` produces a `UnitDistanceEmbedding'` of $K_n$ in $\\mathbb{R}^n$, the dimension (defined as the minimum $n$ via `Nat.find`) is at most $n$.\n\nThe `open Classical` is required because `Nat.find_le` operates on classical existence proofs. The inline proof term duplicates `simplexEmbed_dist_sq` rather than invoking `complete_graph_unit_embedding` to avoid definitional unfolding issues.\n\nThe optimal bound is $\\text{dim}(K_n) = n - 1$ (the regular simplex lives in $\\mathbb{R}^{n-1}$), but proving this requires the harder direction: showing no embedding exists in $\\mathbb{R}^{n-2}$, which involves the theory of Cayley–Menger determinants. The $n - 1$ characterization was established by Blumenthal (1953) using distance geometry.",
+    "mathContext": "\\text{dim}(K_n) \\le n \\quad (\\text{optimal: } \\text{dim}(K_n) = n-1)",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.find_le", "graph dimension", "Cayley-Menger determinant", "Blumenthal distance geometry"],
+    "prerequisites": ["simplexEmbed_dist_sq", "Real.sqrt_one", "Nat.find"]
   },
   {
     "id": "erdos-1007-oq-01-conjectures",
@@ -137,10 +149,10 @@
     "range": { "startLine": 153, "endLine": 166 },
     "type": "definition",
     "title": "Three Core Conjectures as Prop-Valued Definitions",
-    "content": "Three open conjectures formalized as `def ... : Prop`:\n\n1. **`minEdges_monotone_conjecture`**: d₁ ≤ d₂ → minEdges(d₁) ≤ minEdges(d₂)\n2. **`minEdges_quadratic_conjecture`**: ∃ c₁ c₂ > 0, c₁d² ≤ minEdges(d) ≤ c₂d² for d ≥ 1\n3. **`complete_graph_optimal_conjecture`**: For d ≠ 4, minEdges(d) = C(d+1,2)\n\nFormalizing conjectures as Prop definitions (rather than axioms) is a deliberate choice: it allows proving conditional theorems of the form `conjecture → consequence` without polluting the axiom environment. The complete graph optimality conjecture is the strongest — it implies both monotonicity (§8) and quadratic growth.",
+    "content": "Three open conjectures formalized as `def ... : Prop`:\n\n1. **`minEdges_monotone_conjecture`**: d₁ ≤ d₂ → minEdges(d₁) ≤ minEdges(d₂)\n2. **`minEdges_quadratic_conjecture`**: ∃ c₁ c₂ > 0, c₁d² ≤ minEdges(d) ≤ c₂d² for d ≥ 1\n3. **`complete_graph_optimal_conjecture`**: For d ≠ 4, minEdges(d) = C(d+1,2)\n\nFormalizing conjectures as Prop definitions (rather than axioms) is a deliberate choice: it allows proving conditional theorems of the form `conjecture → consequence` without polluting the axiom environment. The complete graph optimality conjecture is the strongest — it implies both monotonicity (§8) and quadratic growth.\n\nThis pattern of formalizing open conjectures as Prop definitions is gaining traction in the Lean mathematical community. It enables a proof graph where relationships between unsolved problems become formally verified, even when the problems themselves remain open.",
     "mathContext": "\\text{Conjectures: monotonicity, } \\Theta(d^2) \\text{ growth, } K_{d+1} \\text{ optimality}",
     "significance": "key",
-    "relatedConcepts": ["open problem", "conditional theorem", "Prop-valued definition", "extremal graph theory"],
+    "relatedConcepts": ["open problem", "conditional theorem", "Prop-valued definition", "extremal graph theory", "formal conjecture hierarchy"],
     "prerequisites": ["minEdgesForDim", "Nat.choose"]
   },
   {
@@ -161,10 +173,10 @@
     "range": { "startLine": 294, "endLine": 326 },
     "type": "theorem",
     "title": "Complete Graph Optimality Implies Monotonicity",
-    "content": "**Theorem** `optimal_implies_monotone`: `complete_graph_optimal_conjecture → minEdges_monotone_conjecture`\n\nA conditional theorem proving the logical relationship between conjectures. The proof performs a 4-way case analysis on whether d₁ = 0, d₂ = 0, d₁ = 4, d₂ = 4:\n\n- **Neither is 4**: The conjecture gives minEdges(dᵢ) = C(dᵢ+1,2), and `choose_succ_two_mono` provides monotonicity of binomial coefficients.\n- **d₁ = 4, d₂ ≠ 4**: The known value 9 is shown ≤ C(d₂+1,2) via `Nat.choose 5 2 ≤ Nat.choose (d₂+1) 2` since d₂ ≥ 5.\n- **d₁ ≠ 4, d₂ = 4**: C(d₁+1,2) ≤ C(4,2) = 6 ≤ 9 since d₁ ≤ 3.\n- **d₁ = d₂ = 4**: Trivial by reflexivity.\n\nThis demonstrates a powerful proof pattern: reducing questions about an axiomatized function to verifiable numerical inequalities at exceptional points.",
+    "content": "**Theorem** `optimal_implies_monotone`: `complete_graph_optimal_conjecture → minEdges_monotone_conjecture`\n\nA conditional theorem proving the logical relationship between conjectures. The proof performs a 4-way case analysis on whether d₁ = 0, d₂ = 0, d₁ = 4, d₂ = 4:\n\n- **Neither is 4**: The conjecture gives minEdges(dᵢ) = C(dᵢ+1,2), and `choose_succ_two_mono` provides monotonicity of binomial coefficients.\n- **d₁ = 4, d₂ ≠ 4**: The known value 9 is shown ≤ C(d₂+1,2) via `Nat.choose 5 2 ≤ Nat.choose (d₂+1) 2` since d₂ ≥ 5.\n- **d₁ ≠ 4, d₂ = 4**: C(d₁+1,2) ≤ C(4,2) = 6 ≤ 9 since d₁ ≤ 3.\n- **d₁ = d₂ = 4**: Trivial by reflexivity.\n\nThe 4-way case split is forced by the d = 4 anomaly: the function minEdges is piecewise — it agrees with $\\binom{d+1}{2}$ everywhere except $d = 4$, where it drops by 1. The proof must manually bridge this gap at the exceptional point. This demonstrates a powerful proof pattern: reducing questions about an axiomatized function to verifiable numerical inequalities at exceptional points.",
     "mathContext": "(\\forall d \\neq 4,\\; \\text{minEdges}(d) = \\binom{d+1}{2}) \\Rightarrow (d_1 \\le d_2 \\Rightarrow \\text{minEdges}(d_1) \\le \\text{minEdges}(d_2))",
     "significance": "key",
-    "relatedConcepts": ["monotonicity", "conditional theorem", "case analysis", "Nat.choose_le_choose"],
+    "relatedConcepts": ["monotonicity", "conditional theorem", "case analysis", "Nat.choose_le_choose", "exceptional point analysis"],
     "prerequisites": ["choose_two_mono", "choose_succ_two_mono", "minEdges_dim4", "native_decide"]
   },
   {
@@ -185,10 +197,10 @@
     "range": { "startLine": 353, "endLine": 371 },
     "type": "theorem",
     "title": "Growth Rate Analysis and Successive Difference Anomaly",
-    "content": "Computes successive differences Δ(d) = minEdges(d+1) - minEdges(d) for known values:\n- Δ(1) = 2, Δ(2) = 3, Δ(3) = 3, Δ(4) = 6\n\n**Theorem** `diff_anomaly`: Δ(3) = 3 < 4 = 3+1, showing the d=3→4 transition is anomalous — the difference equals 3 instead of the expected d+1 = 4.\n\n**Theorem** `optimal_diff`: Under the optimality conjecture, Δ(d) = d+1 for all d where neither d nor d+1 equals 4. The proof shows C(d+2,2) - C(d+1,2) = d+1 by expanding the binomial coefficients and using the divisibility `2 ∣ (d+1)*d`.\n\nThe growth rates minEdges(d)/d = 1, 1.5, 2, 2.25, 3 grow roughly linearly, consistent with Θ(d²).",
+    "content": "Computes successive differences Δ(d) = minEdges(d+1) - minEdges(d) for known values:\n- Δ(1) = 2, Δ(2) = 3, Δ(3) = 3, Δ(4) = 6\n\n**Theorem** `diff_anomaly`: Δ(3) = 3 < 4 = 3+1, showing the d=3→4 transition is anomalous — the difference equals 3 instead of the expected d+1 = 4.\n\n**Theorem** `optimal_diff`: Under the optimality conjecture, Δ(d) = d+1 for all d where neither d nor d+1 equals 4. The proof shows C(d+2,2) - C(d+1,2) = d+1 by expanding the binomial coefficients and using the divisibility `2 ∣ (d+1)*d`. The key step is `Nat.add_div_of_dvd_right`, which rewrites $(a + 2(d+1)) / 2 = a/2 + (d+1)$ when $2 \\mid a$.\n\nThe growth rates minEdges(d)/d = 1, 1.5, 2, 2.25, 3 grow roughly linearly, consistent with Θ(d²).",
     "mathContext": "\\Delta(d) = \\text{minEdges}(d+1) - \\text{minEdges}(d), \\quad \\Delta(3) = 3 < 4",
     "significance": "supporting",
-    "relatedConcepts": ["successive differences", "growth rate", "quadratic growth", "anomaly"],
+    "relatedConcepts": ["successive differences", "growth rate", "quadratic growth", "anomaly", "Nat.add_div_of_dvd_right"],
     "prerequisites": ["minEdges_dim1", "minEdges_dim2", "minEdges_dim3", "minEdges_dim4", "minEdges_dim5"]
   },
   {
@@ -197,10 +209,10 @@
     "range": { "startLine": 381, "endLine": 405 },
     "type": "definition",
     "title": "Deficiency Function and Equivalence with Optimality",
-    "content": "**Definition** `deficiency d = Nat.choose (d+1) 2 - minEdgesForDim d`\n\nQuantifies how much the optimal graph improves over K_{d+1}. Computed values: δ(1,2,3,5) = 0, δ(4) = 1.\n\n**Theorem** `optimal_iff_zero_deficiency`: The complete graph optimality conjecture holds iff δ(d) = 0 for all d ≠ 4.\n- Forward: The conjecture gives minEdges(d) = C(d+1,2), so δ(d) = 0.\n- Reverse: Zero deficiency means C(d+1,2) - minEdges(d) = 0. Combined with the upper bound minEdges(d) ≤ C(d+1,2), this forces equality.\n\nThe deficiency reformulation is useful because δ(d) = 0 is a simpler condition to verify computationally than the full optimality statement.",
+    "content": "**Definition** `deficiency d = Nat.choose (d+1) 2 - minEdgesForDim d`\n\nQuantifies how much the optimal graph improves over K_{d+1}. Computed values: δ(1,2,3,5) = 0, δ(4) = 1.\n\n**Theorem** `optimal_iff_zero_deficiency`: The complete graph optimality conjecture holds iff δ(d) = 0 for all d ≠ 4.\n- Forward: The conjecture gives minEdges(d) = C(d+1,2), so δ(d) = 0.\n- Reverse: Zero deficiency means C(d+1,2) - minEdges(d) = 0. Combined with the upper bound minEdges(d) ≤ C(d+1,2), this forces equality.\n\nThe deficiency reformulation is useful because δ(d) = 0 is a simpler condition to verify computationally than the full optimality statement. It also connects to the study of *excess* in rigidity theory, where one measures how many edges beyond the minimum a framework possesses.",
     "mathContext": "\\delta(d) = \\binom{d+1}{2} - \\text{minEdges}(d), \\quad \\delta(4) = 1, \\quad \\delta(d) = 0 \\text{ for } d \\in \\{1,2,3,5\\}",
     "significance": "key",
-    "relatedConcepts": ["deficiency", "equivalence", "extremal characterization", "Nat.sub"],
+    "relatedConcepts": ["deficiency", "equivalence", "extremal characterization", "Nat.sub", "rigidity excess"],
     "prerequisites": ["minEdges_upper_bound", "Nat.choose_two_right"]
   },
   {
@@ -209,10 +221,10 @@
     "range": { "startLine": 408, "endLine": 412 },
     "type": "theorem",
     "title": "d = 4 is the Unique Anomaly for d ≤ 5",
-    "content": "**Theorem** `unique_anomaly_small`: For 1 ≤ d ≤ 5, δ(d) ≠ 0 implies d = 4.\n\nThe proof uses `interval_cases d` to enumerate all five dimensions and applies the previously computed deficiency values `deficiency_dim1` through `deficiency_dim5`. The tactic `simp_all` discharges each case.\n\nThis formally confirms d = 4 as the unique anomaly among small dimensions and motivates the central open question: is d = 4 the *only* dimension where the complete graph is not optimal? The answer is unknown for d ≥ 6.",
+    "content": "**Theorem** `unique_anomaly_small`: For 1 ≤ d ≤ 5, δ(d) ≠ 0 implies d = 4.\n\nThe proof uses `interval_cases d` to enumerate all five dimensions and applies the previously computed deficiency values `deficiency_dim1` through `deficiency_dim5`. The tactic `simp_all` discharges each case.\n\nThis formally confirms d = 4 as the unique anomaly among small dimensions and motivates the central open question: is d = 4 the *only* dimension where the complete graph is not optimal? The answer is unknown for d ≥ 6. Computational evidence from Maehara's work on unit-distance graphs in higher dimensions suggests the answer is yes, but no proof exists.",
     "mathContext": "\\forall d,\\; 1 \\le d \\le 5 \\land \\delta(d) \\neq 0 \\implies d = 4",
     "significance": "supporting",
-    "relatedConcepts": ["interval_cases", "anomaly classification", "deficiency", "open problem"],
+    "relatedConcepts": ["interval_cases", "anomaly classification", "deficiency", "open problem", "Maehara"],
     "prerequisites": ["deficiency_dim1", "deficiency_dim2", "deficiency_dim3", "deficiency_dim4", "deficiency_dim5"]
   }
 ]

--- a/src/data/proofs/erdos-1007-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01/meta.json
@@ -122,6 +122,11 @@
         "proofId": "ramseys-theorem",
         "relationship": "related",
         "description": "Ramsey theory provides another extremal function (R(s,t)) where exact values are known for small parameters and open for large ones, paralleling the structure of minEdges(d)"
+      },
+      {
+        "proofId": "erdos-924",
+        "relationship": "related",
+        "description": "The Folkman–Nešetřil–Rödl theorem concerns Ramsey properties of graphs avoiding large cliques; both problems study the interplay between graph structure and extremal constraints, and both feature surprising exceptions to expected patterns"
       }
     ]
   },
@@ -130,70 +135,70 @@
       "id": "graph-dimension",
       "title": "Graph Dimension",
       "summary": "Defines unit distance embeddings (structure `UnitDistanceEmbedding'`) with the condition $\\sqrt{\\sum_i (f(u)_i - f(v)_i)^2} = 1$ for all edges, and the graph dimension function (`graphDimension'`) as the minimum embedding dimension via `Nat.find`.",
-      "startLine": 40,
+      "startLine": 41,
       "endLine": 56
     },
     {
       "id": "min-edge-function",
       "title": "Minimum Edge Function",
       "summary": "Axiomatizes minEdges(d) as the minimum edge count among graphs of dimension d. Three axioms: the function, the lower bound property, and the achievability.",
-      "startLine": 58,
+      "startLine": 62,
       "endLine": 77
     },
     {
       "id": "known-values",
       "title": "Known Values",
       "summary": "Records $\\text{minEdges}(0..5) = (0, 1, 3, 6, 9, 15)$ as six axioms. For $d \\le 3$ and $d=5$, these match $\\binom{d+1}{2}$; the $d=4$ value of 9 (from $K_{3,3}$) is the sole exception.",
-      "startLine": 80,
+      "startLine": 83,
       "endLine": 99
     },
     {
       "id": "structural-results",
       "title": "Structural Results",
       "summary": "Three theorems: $K_{d+1}$ optimality for $d \\le 3$ (via `interval_cases`), the $d=4$ surprise ($9 < \\binom{5}{2} = 10$), and $d=5$ matching ($15 = \\binom{6}{2}$).",
-      "startLine": 101,
+      "startLine": 105,
       "endLine": 123
     },
     {
       "id": "general-bounds",
       "title": "General Bounds",
       "summary": "Linear lower bound $d \\le \\text{minEdges}(d)$ (from rigidity) and quadratic upper bound $\\text{minEdges}(d) \\le \\binom{d+1}{2}$ (from complete graphs). Includes real-valued versions via `Nat.cast_le` and verified monotonicity for $d = 1..5$.",
-      "startLine": 125,
+      "startLine": 128,
       "endLine": 186
     },
     {
       "id": "conjectures",
       "title": "Open Questions and Conjectures",
       "summary": "Three Prop-valued definitions: monotonicity conjecture, quadratic growth conjecture (Θ(d²)), and complete graph optimality conjecture (K_{d+1} optimal for d ≠ 4).",
-      "startLine": 148,
+      "startLine": 150,
       "endLine": 166
     },
     {
       "id": "simplex-embedding",
       "title": "Simplex Embedding Construction",
       "summary": "Constructive proof that $K_n$ embeds as unit distances in $\\mathbb{R}^n$ via $v_i = \\frac{1}{\\sqrt{2}} e_i$. Key lemma: $(1/\\sqrt{2})^2 = 1/2$. Distance computation uses `Finset.add_sum_erase` to isolate the $i$-th and $j$-th terms. Corollary: $\\dim(K_n) \\le n$.",
-      "startLine": 188,
+      "startLine": 190,
       "endLine": 265
     },
     {
       "id": "conjecture-relationships",
       "title": "Conjecture Relationships",
       "summary": "Proves $K_{d+1}$ optimality implies monotonicity via 4-way case analysis on $d_1, d_2$ being 4. Building blocks: $\\binom{n}{2}$ monotonicity via `Nat.choose_le_choose` and the inequality $\\binom{d+1}{2} \\ge d$.",
-      "startLine": 267,
+      "startLine": 270,
       "endLine": 326
     },
     {
       "id": "growth-rate",
       "title": "Growth Rate Analysis",
       "summary": "Successive differences $\\Delta(d) = \\text{minEdges}(d+1) - \\text{minEdges}(d)$ for $d=1..4$. The $d=3 \\to 4$ anomaly: $\\Delta(3) = 3 < 4$. Under the optimality conjecture, $\\Delta(d) = d+1$ (proved via $\\binom{d+2}{2} - \\binom{d+1}{2} = d+1$).",
-      "startLine": 328,
+      "startLine": 330,
       "endLine": 371
     },
     {
       "id": "deficiency",
       "title": "Deficiency Function",
       "summary": "Deficiency $\\delta(d) = \\binom{d+1}{2} - \\text{minEdges}(d)$. Computed: $\\delta = 0$ for $d \\in \\{1,2,3,5\\}$, $\\delta(4) = 1$. Proves the equivalence: optimality conjecture $\\iff$ $\\delta(d) = 0$ for all $d \\neq 4$. Confirms $d = 4$ is the unique anomaly for $d \\le 5$ via `interval_cases`.",
-      "startLine": 373,
+      "startLine": 375,
       "endLine": 418
     }
   ],
@@ -204,7 +209,7 @@
     "proofStrategy": "The formalization proceeds in three layers: (1) **Axiomatization**: minEdges(d) is axiomatized with known values for d ≤ 5 and basic bounds (lower: d, upper: C(d+1,2)). (2) **Construction**: The simplex embedding (1/√2)·eᵢ gives a constructive proof that K_n embeds in ℝⁿ, establishing the upper bound. (3) **Conditional analysis**: The complete graph optimality conjecture is shown to imply monotonicity via case analysis on d=4, and the deficiency function δ(d) provides an equivalent reformulation. Growth rate analysis under the conjecture shows successive differences equal d+1.",
     "keyInsights": [
       "The d=4 anomaly: K_{3,3} achieves dimension 4 with 9 edges, beating K₅'s 10. This is formally verified and shown to be the unique anomaly for d ≤ 5.",
-      "The simplex embedding v_i = (1/√2)e_i is the simplest unit-distance embedding of K_n in ℝⁿ. The factor 1/√2 is forced by the requirement that ‖v_i - v_j‖ = 1.",
+      "The simplex embedding v_i = (1/√2)e_i is the simplest unit-distance embedding of K_n in ℝⁿ. The factor 1/√2 is forced by the requirement that ‖v_i - v_j‖ = 1, since standard basis vectors have ‖eᵢ - eⱼ‖ = √2.",
       "The complete graph optimality conjecture implies monotonicity — a non-obvious logical relationship between open problems. The proof reduces to sandwiching minEdges(4) = 9 between neighboring binomial coefficients.",
       "The deficiency function δ(d) = C(d+1,2) - minEdges(d) cleanly separates the anomalous d=4 case: optimality holds iff δ(d) = 0 for all d ≠ 4.",
       "Conditional theorems (conjecture → consequence) are a powerful formalization strategy: they establish logical structure among open problems without resolving any.",

--- a/src/data/proofs/erdos-990/annotations.json
+++ b/src/data/proofs/erdos-990/annotations.json
@@ -8,7 +8,8 @@
     "content": "**Erdős Problem #990: Polynomial Root Distribution and the Erdős-Turán Inequality.** For a polynomial f ∈ C[x] of degree d with n nonzero coefficients, is the angular discrepancy of its roots bounded by O(√(n log M))? The classical Erdős-Turán inequality (1950) proves O(√(d log M)); the sparse conjecture replacing d with n remains OPEN.",
     "mathContext": "The Erdős-Turán inequality is a cornerstone of *equidistribution theory* — the study of how point sets deviate from uniform distribution. For polynomial roots on the unit circle, the *discrepancy* measures the worst-case deviation between the actual root count in an angular sector and the expected count under uniformity. The classical bound O(√(d log M)) depends on the degree d, but sparse polynomials like x^d - 1 (only 2 nonzero terms) suggest that the *sparsity* n, not the degree, should control root distribution. This connects to Weyl's equidistribution criterion, exponential sum estimates, and the broader theory of *low-discrepancy sequences*.",
     "significance": "critical",
-    "relatedConcepts": ["discrepancy-theory", "equidistribution", "mahler-measure", "fourier-analysis", "polynomial-roots"],
+    "relatedConcepts": ["discrepancy theory", "equidistribution", "Mahler measure", "Fourier analysis", "polynomial roots"],
+    "prerequisites": ["Complex.arg", "Polynomial.Basic", "Finset.card"],
     "crossReferences": [
       {
         "targetProofId": "erdos-987",
@@ -35,7 +36,9 @@
     "title": "ComplexPoly",
     "content": "A complex polynomial of degree at most d, represented as a coefficient sequence `Fin (d+1) → C`. The i-th entry gives the coefficient of x^i.",
     "mathContext": "The representation `Fin (d+1) → C` is a simple coefficient vector, avoiding Mathlib's `Polynomial` type for direct formalization. This works well for the Erdős-Turán context where we need explicit access to individual coefficients (for computing sparsity and the Mahler measure M). The degree is at most d, with the actual degree determined by the highest nonzero coefficient. Mathlib's `Polynomial.C` and `Polynomial.X` provide an alternative abstract representation, but the coefficient-vector approach is more natural for coefficient-counting problems.",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["coefficient vector", "Polynomial.C", "Polynomial.X", "Fin type", "Complex numbers"],
+    "prerequisites": ["Fin", "Complex"]
   },
   {
     "id": "ann-e990-sparsity",
@@ -45,7 +48,9 @@
     "title": "nonzeroCoeffCount (Sparsity)",
     "content": "The number of nonzero coefficients n in polynomial p, computed by filtering `Finset.univ` for indices i where p(i) ≠ 0. This is the key parameter in the sparse conjecture.",
     "mathContext": "Sparsity is the central concept distinguishing this problem from the classical Erdős-Turán result. Examples: x^d - 1 has n = 2 but degree d (arbitrarily large); x^d + x^{d-1} + ... + 1 has n = d+1 (maximally dense). The sparse conjecture asserts that n, not d, controls root equidistribution. If true, this would be a dramatic improvement for lacunary (gap) polynomials. The definition uses `Finset.card ∘ Finset.filter`, giving a computable natural number. Note that `sparse_improves_dense` proves n ≤ d+1, so the sparse bound is never worse than the classical bound.",
-    "significance": "critical"
+    "significance": "critical",
+    "relatedConcepts": ["lacunary polynomial", "Finset.card", "Finset.filter", "sparse representation", "compressed sensing"],
+    "prerequisites": ["Finset.univ", "Finset.filter", "Finset.card"]
   },
   {
     "id": "ann-e990-argument",
@@ -55,7 +60,9 @@
     "title": "argument",
     "content": "The angle θ ∈ [0, 2π) of a complex number z = |z|e^{iθ}. Uses Mathlib's `Complex.arg` (which returns values in (-π, π]) and shifts negative values by 2π to normalize to [0, 2π).",
     "mathContext": "The argument function maps C* → [0, 2π), projecting each root onto the unit circle. For the Erdős-Turán inequality, only the angular position matters — the modulus |z| is irrelevant. This is because the inequality bounds the *angular discrepancy* of roots, not their radial distribution. The normalization to [0, 2π) is essential for defining intervals and counting roots in sectors. Mathlib's `arg` returns values in (-π, π], so the shift `arg z + 2π` for negative values maps to [0, 2π). The case z = 0 is handled by returning 0 (roots at the origin have undefined argument).",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["Complex.arg", "polar form", "angular projection", "branch cut"],
+    "prerequisites": ["Complex.arg", "Real.pi"]
   },
   {
     "id": "ann-e990-mahler",
@@ -65,7 +72,9 @@
     "title": "mahlerM (Normalization Factor)",
     "content": "M = (|a₀| + |a₁| + ... + |a_d|) / √(|a₀|·|a_d|). This coefficient-based measure appears in the Erdős-Turán bound. For monic polynomials with |a₀| = |a_d| = 1, M ≥ 2 (axiomatized as `mahler_ge_two`).",
     "mathContext": "The quantity M is related to but distinct from the *Mahler measure* μ(f) = |a_d| ∏ max(1, |z_i|). The M used here is a *coefficient-based* normalization that controls how 'spread out' the coefficients are relative to the leading and constant terms. The denominator √(|a₀|·|a_d|) normalizes for the scale of f. The logarithm log M appears under the square root in the bound, so M's contribution is mild — even exponentially large M only contributes √(log M). The case a₀·a_d = 0 is handled by defaulting M = 1 (degenerate case where the polynomial has a root at 0 or is of lower degree).",
-    "significance": "critical"
+    "significance": "critical",
+    "relatedConcepts": ["Mahler measure", "coefficient sum", "Jensen's formula", "normalization"],
+    "prerequisites": ["Complex.abs", "Real.sqrt", "Finset.sum"]
   },
   {
     "id": "ann-e990-rootsinterval",
@@ -75,7 +84,9 @@
     "title": "rootsInInterval",
     "content": "Count of roots with argument in [α, β]: filter the root set for roots z where α ≤ argument(z) ≤ β, then take cardinality.",
     "mathContext": "This is the *empirical counting function* N(I) for interval I = [α, β]. The discrepancy is |N(I) - |I|·d/(2π)|, measuring deviation from the uniform expectation. The counting function is piecewise constant (jumps at each root argument), while the expected count is linear in the interval length. The supremum of discrepancy over all I is the *star discrepancy* D*, a standard measure in equidistribution theory. For d-th roots of unity, N(I) = ⌊|I|·d/(2π)⌋ or ⌈|I|·d/(2π)⌉, giving discrepancy at most 1.",
-    "significance": "critical"
+    "significance": "critical",
+    "relatedConcepts": ["empirical distribution", "counting function", "Finset.filter", "star discrepancy"],
+    "prerequisites": ["Finset.filter", "Finset.card", "argument"]
   },
   {
     "id": "ann-e990-discrepancy",
@@ -85,7 +96,9 @@
     "title": "discrepancy",
     "content": "The absolute deviation |rootsInInterval(α,β) - expectedCount(α,β)| for a single interval [α, β]. Measures how far the actual root count deviates from what uniformity would predict.",
     "mathContext": "The discrepancy for a single interval is the building block of the *maximum discrepancy* (star discrepancy D*). The Erdős-Turán inequality bounds D* = sup_{0 ≤ α ≤ β ≤ 2π} discrepancy(α,β). The bound is non-trivial only when d is large — for small d, the trivial bound |discrepancy| ≤ d suffices. The discrepancy framework connects to the Koksma-Hlawka inequality in numerical integration, where the integration error is bounded by (variation of f) × (discrepancy of points).",
-    "significance": "critical"
+    "significance": "critical",
+    "relatedConcepts": ["Koksma-Hlawka inequality", "numerical integration", "absolute deviation", "variation"],
+    "prerequisites": ["rootsInInterval", "expectedCount", "abs"]
   },
   {
     "id": "ann-e990-maxdisc",
@@ -95,7 +108,9 @@
     "title": "maxDiscrepancy",
     "content": "The supremum of discrepancy over all intervals [α, β] ⊆ [0, 2π]. This is the *star discrepancy* D*(p), the central quantity bounded by the Erdős-Turán inequality.",
     "mathContext": "The supremum is taken over the set of all valid interval parameters {(α, β) : 0 ≤ α ≤ β ≤ 2π}, formalized using `sSup`. In the continuous setting, this supremum is attained (the discrepancy function is piecewise linear in α, β). The star discrepancy D* is the standard measure of equidistribution quality: D* = 0 iff the roots are perfectly uniform (only possible for roots of unity), and D* = Θ(√d) is typical for 'generic' polynomials. The Erdős-Turán bound D* ≤ C√(d log M) is tight up to the log M factor.",
-    "significance": "critical"
+    "significance": "critical",
+    "relatedConcepts": ["sSup", "star discrepancy", "equidistribution quality", "minimax"],
+    "prerequisites": ["discrepancy", "sSup", "Set.image"]
   },
   {
     "id": "ann-e990-classical",
@@ -106,6 +121,8 @@
     "content": "The foundational result: maxDiscrepancy(p) ≤ C · √(d · log M) for some universal constant C > 0. This was the first quantitative equidistribution bound for polynomial roots.",
     "mathContext": "The proof by Erdős and Turán (1950) uses *exponential sum estimates*. For the polynomial f(x) = a_d ∏(x - z_j), the power sums s_k = Σ z_j^k satisfy |s_k| ≤ (sum of |coefficients|) by Newton's identities. The discrepancy bound follows from the *Erdős-Turán inequality for sequences*: D* ≤ C/N + C Σ_{k=1}^N |s_k|/(k) for any N, optimized by choosing N ~ √(d/log M). This is the same exponential sum method used for equidistribution of sequences mod 1 (connected to Erdős #987, #992). The paper appeared in the Bulletin of the AMS (1950).",
     "significance": "critical",
+    "relatedConcepts": ["exponential sums", "Newton's identities", "power sums", "Weyl's criterion"],
+    "prerequisites": ["maxDiscrepancy", "mahlerM", "Real.sqrt", "Real.log"],
     "crossReferences": [
       {
         "targetProofId": "erdos-987",
@@ -122,7 +139,9 @@
     "title": "Ganelius Improvement (1954)",
     "content": "The constant C in the Erdős-Turán bound can be taken ≤ 8. Ganelius improved the explicit numerical constant just 4 years after the original paper.",
     "mathContext": "Improving the constant in the Erdős-Turán inequality has been a long-running project. The original Erdős-Turán paper gave C without explicit computation. Ganelius (1954) showed C ≤ 8 using sharper estimates on exponential sums. Mignotte (1992) further improved the constant. The quest culminated with Soundararajan (2019) and Steinerberger et al. (2021) determining the *sharp* (optimal) constant, showing it is related to an extremal problem involving Hilbert transforms on L²([0,1]).",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["explicit constants", "Mignotte", "Soundararajan", "optimal bounds"],
+    "prerequisites": ["erdos_turan_classical"]
   },
   {
     "id": "ann-e990-sparse",
@@ -132,7 +151,9 @@
     "title": "sparseConjecture (The Open Problem)",
     "content": "The open conjecture: maxDiscrepancy(p) ≤ C · √(n · log M) where n is the number of nonzero coefficients. This would replace the degree d with the sparsity n in the Erdős-Turán bound.",
     "mathContext": "The sparse conjecture is motivated by the observation that lacunary (gap) polynomials have much better root equidistribution than their degree suggests. The polynomial x^d - 1 has degree d but only n = 2 nonzero terms, and its roots (d-th roots of unity) are *perfectly* equidistributed. The conjecture asks whether this is a general phenomenon: does low sparsity always force good equidistribution? A proof would have significant implications for number theory (distribution of algebraic numbers), numerical analysis (interpolation with sparse polynomial bases), and signal processing (compressed sensing with polynomial measurements). The conjecture remains open even for trinomials (n = 3).",
-    "significance": "critical"
+    "significance": "critical",
+    "relatedConcepts": ["lacunary polynomial", "open conjecture", "trinomial", "compressed sensing"],
+    "prerequisites": ["nonzeroCoeffCount", "maxDiscrepancy", "mahlerM"]
   },
   {
     "id": "ann-e990-improves",
@@ -142,7 +163,9 @@
     "title": "sparse_improves_dense (Proved)",
     "content": "n ≤ d + 1 always holds: the sparsity is at most the degree plus one. Hence the sparse bound (if true) would always be at least as good as the classical bound.",
     "mathContext": "The proof is a one-liner: `Finset.card_filter_le _ _` — the cardinality of a filtered set is at most the cardinality of the original set, and `Finset.univ` for `Fin (d+1)` has cardinality d+1. This simple observation shows the sparse conjecture is a *strict strengthening* of the classical Erdős-Turán for polynomials with n < d+1 (i.e., sparse polynomials). The improvement is significant when n ≪ d, e.g., x^{1000} + x + 1 has n = 3 but d = 1000.",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["Finset.card_filter_le", "strengthening", "monotonicity"],
+    "prerequisites": ["nonzeroCoeffCount", "Finset.card_filter_le"]
   },
   {
     "id": "ann-e990-unity",
@@ -152,7 +175,9 @@
     "title": "Unity Roots Are Sparse",
     "content": "x^d - 1 has only 2 nonzero coefficients (a₀ = -1, a_d = 1) but degree d. This is the motivating example: maximally sparse yet perfectly equidistributed roots.",
     "mathContext": "The d-th roots of unity ζ_k = e^{2πik/d} for k = 0,...,d-1 are uniformly spaced at angles 2πk/d. The discrepancy is at most 1 (from integrality). Meanwhile, the classical Erdős-Turán bound gives O(√(d log 2)), which is much worse. The sparse conjecture would give O(√(2 log 2)) = O(1), correctly reflecting the near-perfect equidistribution. This example also shows that the log M factor is essential: for the polynomial x^d - c with |c| very large, M ~ √|c|, and the roots cluster near a circle of radius |c|^{1/d}, with worse angular equidistribution.",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["roots of unity", "cyclotomic polynomial", "regular polygon", "perfect equidistribution"],
+    "prerequisites": ["nonzeroCoeffCount"]
   },
   {
     "id": "ann-e990-sharp",
@@ -162,7 +187,9 @@
     "title": "Sharp Erdős-Turán Constant",
     "content": "There exists an optimal constant C_sharp such that the Erdős-Turán inequality holds with C = C_sharp but not with any smaller constant. Determined by Soundararajan (2019) and Steinerberger et al. (2021) after 70 years.",
     "mathContext": "The sharp constant is characterized by an extremal problem: C_sharp = sup over all trigonometric polynomials T of degree N of the ratio ||T||_∞ / (||T||₂ · √(N log ||T||₁)). Soundararajan connected this to the *Hilbert transform* on L²([0,1]): the optimal bound involves the operator norm of a modified Hilbert transform restricted to trigonometric polynomials. This unexpected connection between polynomial root distribution and harmonic analysis was the key breakthrough. The formalization axiomatizes the existence of C_sharp without specifying its value.",
-    "significance": "critical"
+    "significance": "critical",
+    "relatedConcepts": ["extremal problem", "operator norm", "trigonometric polynomial", "Soundararajan"],
+    "prerequisites": ["maxDiscrepancy", "mahlerM"]
   },
   {
     "id": "ann-e990-hilbert",
@@ -173,6 +200,8 @@
     "content": "The optimal constant in the Erdős-Turán inequality is determined by an extremal problem involving Hilbert transforms. Axiomatized as `True` (placeholder for the deep harmonic analysis connection).",
     "mathContext": "The *Hilbert transform* Hf(x) = PV ∫ f(t)/(x-t) dt is a fundamental operator in harmonic analysis. Soundararajan showed that the sharp constant in Erdős-Turán is related to the norm of H restricted to certain function spaces. This connects polynomial root distribution to: (1) singular integral operators, (2) Fourier multiplier theory, (3) the theory of conjugate functions. The connection arises because the discrepancy can be expressed as a Fourier series involving the polynomial's coefficients, and optimizing the bound reduces to a norm estimate for the Hilbert transform applied to this series.",
     "significance": "key",
+    "relatedConcepts": ["Hilbert transform", "singular integral", "Fourier multiplier", "conjugate function", "principal value"],
+    "prerequisites": ["sharp_erdos_turan"],
     "crossReferences": [
       {
         "targetProofId": "erdos-989",
@@ -189,7 +218,9 @@
     "title": "Roots of Unity: Perfect Equidistribution",
     "content": "The n-th roots of unity (roots of x^n - 1) are exactly uniformly distributed at angles 2πk/n. The discrepancy is at most 1 (from rounding to integers).",
     "mathContext": "This is the *ideal case*: the d-th roots of unity form a regular d-gon on the unit circle. For any arc I of length |I|, the root count satisfies |N(I) - |I|d/(2π)| ≤ 1. The axiom states that discrepancy is 0 (if the interval endpoints align with root positions) or at most 1 (from integrality). This motivates the sparse conjecture: since x^d - 1 has sparsity 2, the sparse bound √(2 log M) correctly predicts O(1) discrepancy, while the classical bound √(d log M) drastically overestimates.",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["regular polygon", "uniform distribution", "integrality", "cyclotomic roots"],
+    "prerequisites": ["maxDiscrepancy", "rootsInInterval"]
   },
   {
     "id": "ann-e990-littlewood",
@@ -199,7 +230,9 @@
     "title": "Littlewood Polynomials",
     "content": "A Littlewood polynomial has all coefficients with |a_i| = 1 or a_i = 0 (typically coefficients ±1). These have maximal sparsity n = d+1 and special root distribution properties.",
     "mathContext": "Littlewood polynomials are a classical object in analysis. The *Littlewood conjecture* (now theorem, Kahane 1985) states that for random ±1 polynomials of degree d, the roots cluster near the unit circle with discrepancy O(√(d log d)). For Littlewood polynomials, M ≤ (d+1)/1 = d+1, so log M ≤ log(d+1). The Erdős-Turán bound gives D* ≤ C√(d log(d+1)). The axiomatized bound `maxDiscrepancy ≤ √(d log d + d)` reflects the known results for this class. Littlewood polynomials appear in signal processing (binary phase codes) and number theory (Barker sequences).",
-    "significance": "supporting"
+    "significance": "supporting",
+    "relatedConcepts": ["Kahane", "random polynomial", "binary phase code", "Barker sequence", "flat polynomial"],
+    "prerequisites": ["ComplexPoly", "maxDiscrepancy"]
   },
   {
     "id": "ann-e990-lowerbound",
@@ -209,7 +242,9 @@
     "title": "Lower Bound: Tightness of √d",
     "content": "For every degree d, there exist polynomials with maxDiscrepancy ≥ (1/10)√d. This shows the √d dependence in the Erdős-Turán bound is necessary and cannot be improved to o(√d).",
     "mathContext": "The lower bound construction uses *random polynomials*: a polynomial with i.i.d. random coefficients on the unit circle has roots whose angular distribution, by the central limit theorem, exhibits Θ(√d) fluctuations from uniformity. More explicitly, one can use *Riesz products* or *Rudin-Shapiro polynomials* to construct deterministic examples with large discrepancy. The constant 1/10 is not optimal but suffices to establish the order of magnitude. Combined with the upper bound O(√(d log M)), this shows the Erdős-Turán bound is tight up to the logarithmic factor.",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["Riesz product", "Rudin-Shapiro polynomial", "random polynomial", "tightness", "central limit theorem"],
+    "prerequisites": ["maxDiscrepancy"]
   },
   {
     "id": "ann-e990-erdelyi",
@@ -219,7 +254,9 @@
     "title": "Erdélyi's One-Sided Improvement",
     "content": "The one-sided bound: rootsInInterval - expectedCount ≤ C√(d log M) (without absolute value). Roots can cluster below expectation but cannot exceed the expected count by more than C√(d log M).",
     "mathContext": "Erdélyi's result is a *refinement* of the classical Erdős-Turán, not a strengthening of the bound itself. The two-sided version says |N(I) - E(I)| ≤ C√(d log M), which implies both N(I) - E(I) ≤ C√(d log M) (excess) and E(I) - N(I) ≤ C√(d log M) (deficit). Erdélyi showed that the *excess* bound holds with a better constant or under weaker hypotheses. The Totik-Varjú corollary extends this to potential-theoretic settings. One-sided bounds are useful in applications where we care about *clustering* (too many roots in a sector) but not *voids* (too few roots).",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["one-sided bound", "Erdélyi", "Totik-Varjú", "potential theory", "root clustering"],
+    "prerequisites": ["rootsInInterval", "expectedCount", "maxDiscrepancy"]
   },
   {
     "id": "ann-e990-summary",
@@ -230,6 +267,8 @@
     "content": "The classical Erdős-Turán inequality: there exists C > 0 such that maxDiscrepancy(p) ≤ C√(d log M) for all degree-d polynomials with nonzero leading and constant coefficients. Proved by forwarding to `erdos_turan_explicit_constant`.",
     "mathContext": "The summary theorem captures the *proved* part of Problem #990 — the classical bound with degree d. The *open* part (replacing d with sparsity n) is formalized as `sparseConjecture` but not proved. The proof structure `erdos_990_summary := erdos_turan_explicit_constant` is a direct forwarding, showing that the theorem is a repackaging of the explicit-constant version. This separation between the proved classical result and the open sparse conjecture is the key organizational insight of the formalization.",
     "significance": "critical",
+    "relatedConcepts": ["theorem forwarding", "proved vs open", "organizational design"],
+    "prerequisites": ["erdos_turan_explicit_constant"],
     "crossReferences": [
       {
         "targetProofId": "erdos-991",
@@ -251,6 +290,8 @@
     "title": "erdos_turan_known (Proved)",
     "content": "The classical Erdős-Turán bound for a specific polynomial: maxDiscrepancy(p) ≤ C√(d log M). A direct application of `erdos_turan_classical`.",
     "mathContext": "This per-polynomial version complements the universal `erdos_990_summary`. While the summary gives a single universal C, this theorem states the result for a fixed polynomial with its specific hypotheses (hd : 0 < d, hp : leading ≠ 0, h0 : constant ≠ 0). The proof is a single `exact` call, demonstrating the clean modular structure of the formalization.",
-    "significance": "critical"
+    "significance": "critical",
+    "relatedConcepts": ["per-instance theorem", "modular proof", "exact tactic"],
+    "prerequisites": ["erdos_turan_classical", "ComplexPoly"]
   }
 ]

--- a/src/data/proofs/erdos-995/annotations.json
+++ b/src/data/proofs/erdos-995/annotations.json
@@ -6,8 +6,10 @@
     "type": "definition",
     "title": "frac",
     "content": "Fractional part: frac(x) = x - ⌊x⌋, the value in [0,1) representing x modulo 1.",
-    "mathContext": "The fractional part map x ↦ {x} = x - ⌊x⌋ is the canonical projection ℝ → ℝ/ℤ ≅ [0,1). For irrational α, the sequence {α}, {2α}, {3α}, ... is equidistributed by Weyl's theorem (1916). For lacunary sequences, {α n_k} inherits stronger independence properties — the terms behave almost like i.i.d. uniform random variables on [0,1).",
-    "significance": "supporting"
+    "mathContext": "The fractional part map $x \\mapsto \\{x\\} = x - \\lfloor x \\rfloor$ is the canonical projection $\\mathbb{R} \\to \\mathbb{R}/\\mathbb{Z} \\cong [0,1)$. For irrational $\\alpha$, the sequence $\\{\\alpha\\}, \\{2\\alpha\\}, \\{3\\alpha\\}, \\ldots$ is equidistributed by Weyl's theorem (1916). For lacunary sequences, $\\{\\alpha n_k\\}$ inherits stronger independence properties — the terms behave almost like i.i.d. uniform random variables on $[0,1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Weyl equidistribution", "floor function", "mod 1 arithmetic", "circle rotation"],
+    "prerequisites": ["Int.floor", "Real.sub"]
   },
   {
     "id": "ann-995-lacunary",
@@ -16,8 +18,10 @@
     "type": "definition",
     "title": "IsLacunary and IsLacunarySeq",
     "content": "A sequence is lacunary with ratio q if n_{k+1} ≥ q·n_k for all k, where q > 1. This means the sequence grows at least exponentially.",
-    "mathContext": "Lacunary (or Hadamard gap) sequences were introduced by Hadamard in his study of power series convergence (1892). The gap condition n_{k+1}/n_k ≥ q > 1 ensures exponential growth: n_k ≥ n₁·q^{k-1}. This exponential spacing destroys correlations between cos(2π n_k α) for different k — the Fourier coefficients of f({α n_k}) become nearly orthogonal. This 'quasi-independence' is formalized in Kac's CLT (1946): ∑cos(2π n_k α)/√N → N(0, 1/2) in distribution. The lacunarity ratio q can be arbitrarily close to 1; even q = 1 + ε suffices for most results.",
-    "significance": "key"
+    "mathContext": "Lacunary (or Hadamard gap) sequences were introduced by Hadamard in his study of power series convergence (1892). The gap condition $n_{k+1}/n_k \\geq q > 1$ ensures exponential growth: $n_k \\geq n_1 \\cdot q^{k-1}$. This exponential spacing destroys correlations between $\\cos(2\\pi n_k \\alpha)$ for different $k$ — the Fourier coefficients of $f(\\{\\alpha n_k\\})$ become nearly orthogonal. This 'quasi-independence' is formalized in Kac's CLT (1946): $\\sum \\cos(2\\pi n_k \\alpha)/\\sqrt{N} \\to \\mathcal{N}(0, 1/2)$ in distribution. The lacunarity ratio $q$ can be arbitrarily close to 1; even $q = 1 + \\varepsilon$ suffices for most results.",
+    "significance": "key",
+    "relatedConcepts": ["Hadamard gap condition", "exponential growth", "quasi-independence", "Kac CLT", "power series convergence"],
+    "prerequisites": ["Nat.cast_le", "Real.lt_iff_lt"]
   },
   {
     "id": "ann-995-sum",
@@ -26,8 +30,10 @@
     "type": "definition",
     "title": "lacunarySum",
     "content": "The sum ∑_{k≤N} f({α n_k}): for each k, compute the fractional part of α·n_k, apply f, and sum over k from 1 to N.",
-    "mathContext": "This sum is the core object of study: an ergodic sum along the subsequence {n_k} of the dynamical system T_α: x ↦ x + α (mod 1) on the circle ℝ/ℤ. Birkhoff's ergodic theorem (1931) guarantees that (1/N)∑f({α n_k}) → ∫₀¹ f for a.e. α, so the sum grows like N·∫f + o(N). The problem concerns the fluctuation term: how fast does |∑f({α n_k}) - N∫f| grow? For mean-zero f (∫f = 0), this is the full sum. The Finset.range N formulation computes ∑_{k=0}^{N-1}.",
-    "significance": "key"
+    "mathContext": "This sum is the core object of study: an ergodic sum along the subsequence $\\{n_k\\}$ of the dynamical system $T_\\alpha: x \\mapsto x + \\alpha \\pmod{1}$ on the circle $\\mathbb{R}/\\mathbb{Z}$. Birkhoff's ergodic theorem (1931) guarantees that $(1/N)\\sum f(\\{\\alpha n_k\\}) \\to \\int_0^1 f$ for a.e. $\\alpha$, so the sum grows like $N \\cdot \\int f + o(N)$. The problem concerns the fluctuation term: how fast does $|\\sum f(\\{\\alpha n_k\\}) - N\\int f|$ grow? For mean-zero $f$ ($\\int f = 0$), this is the full sum. The `Finset.range N` formulation computes $\\sum_{k=0}^{N-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["Birkhoff ergodic theorem", "ergodic sum", "irrational rotation", "Finset.sum", "Finset.range"],
+    "prerequisites": ["Finset.sum", "Finset.range", "frac"]
   },
   {
     "id": "ann-995-conjecture",
@@ -36,8 +42,10 @@
     "type": "definition",
     "title": "ErdosConjecture and ErdosQuestion",
     "content": "The conjecture: for a.e. α, the sum is o(N √(log log N)). The question asks if this holds for all lacunary sequences and L² functions.",
-    "mathContext": "The conjecture o(N√(log log N)) corresponds precisely to the scale of the Law of the Iterated Logarithm (LIL). For independent random variables X_k with variance σ², the LIL (Khintchine 1924) says limsup S_N / √(2Nσ² log log N) = 1 a.s. Since lacunary sums mimic independent sums, Erdős conjectured that the LIL-scale bound holds. The measure-theoretic 'almost all α' formulation uses ∀ᵐ α ∂(volume.restrict (Set.Icc 0 1)), asserting the statement for Lebesgue-a.e. α ∈ [0,1]. The ErdosQuestion universally quantifies over all lacunary sequences and L² functions.",
-    "significance": "key"
+    "mathContext": "The conjecture $o(N\\sqrt{\\log\\log N})$ corresponds precisely to the scale of the Law of the Iterated Logarithm (LIL). For independent random variables $X_k$ with variance $\\sigma^2$, the LIL (Khintchine 1924) says $\\limsup S_N / \\sqrt{2N\\sigma^2 \\log \\log N} = 1$ a.s. Since lacunary sums mimic independent sums, Erdős conjectured that the LIL-scale bound holds. The measure-theoretic 'almost all $\\alpha$' formulation uses $\\forall^{\\text{m}} \\alpha \\partial(\\text{volume.restrict}(\\text{Set.Icc}\\; 0\\; 1))$, asserting the statement for Lebesgue-a.e. $\\alpha \\in [0,1]$. The `ErdosQuestion` universally quantifies over all lacunary sequences and $L^2$ functions.",
+    "significance": "key",
+    "relatedConcepts": ["Law of the Iterated Logarithm", "Khintchine", "almost everywhere", "MeasureTheory.ae", "little-o notation"],
+    "prerequisites": ["MeasureTheory.volume", "Set.Icc", "Real.sqrt", "Real.log", "Filter.Eventually"]
   },
   {
     "id": "ann-995-lower",
@@ -46,8 +54,10 @@
     "type": "axiom",
     "title": "Erdős Lower Bound (1949)",
     "content": "Erdős constructed a lacunary sequence and f ∈ L² such that limsup of the sum divided by N(log log N)^{1/2-ε} is infinite for a.e. α.",
-    "mathContext": "In 'On the strong law of large numbers' (1949), Erdős constructed specific lacunary sequences where the sum ∑f({α n_k}) exceeds N(log log N)^{1/2-ε} infinitely often for a.e. α. The construction exploits resonances between the lacunary ratios and the Fourier coefficients of f. The limsup = ⊤ formulation (using the extended real line ℝ̄) means the ratio |S_N| / (N(log log N)^{1/2-ε}) is unbounded along a subsequence. This shows the sum must grow at least as fast as N(log log N)^{1/2-ε}, ruling out any bound better than O(N(log log N)^{1/2}).",
-    "significance": "key"
+    "mathContext": "In 'On the strong law of large numbers' (1949), Erdős constructed specific lacunary sequences where the sum $\\sum f(\\{\\alpha n_k\\})$ exceeds $N(\\log\\log N)^{1/2-\\varepsilon}$ infinitely often for a.e. $\\alpha$. The construction exploits resonances between the lacunary ratios and the Fourier coefficients of $f$. The $\\limsup = \\top$ formulation (using the extended real line $\\overline{\\mathbb{R}}$) means the ratio $|S_N| / (N(\\log\\log N)^{1/2-\\varepsilon})$ is unbounded along a subsequence. This shows the sum must grow at least as fast as $N(\\log\\log N)^{1/2-\\varepsilon}$, ruling out any bound better than $O(N(\\log\\log N)^{1/2})$.",
+    "significance": "key",
+    "relatedConcepts": ["Filter.limsup", "extended reals", "constructive lower bound", "resonance", "Fourier coefficients"],
+    "prerequisites": ["Filter.limsup", "Filter.atTop", "MeasureTheory.ae", "IsLacunarySeq"]
   },
   {
     "id": "ann-995-upper",
@@ -56,8 +66,10 @@
     "type": "axiom",
     "title": "Erdős Upper Bound",
     "content": "For every lacunary sequence and L² function, the sum is o(N(log N)^{1/2+ε}) for a.e. α. This is a universal upper bound.",
-    "mathContext": "The upper bound o(N(log N)^{1/2+ε}) is proved using second-moment methods and exponential sum estimates. The key input is that for lacunary {n_k}, the Weyl sums |∑e(α n_k)|² have controlled second moments over α ∈ [0,1]. The proof uses Parseval's identity and the near-orthogonality of exponentials at lacunary frequencies. The (log N)^{1/2+ε} factor arises from the maximal inequality needed to pass from L² bounds to almost sure bounds. This is universal — it holds for ALL lacunary sequences and ALL L² functions, unlike the lower bound which is existential.",
-    "significance": "key"
+    "mathContext": "The upper bound $o(N(\\log N)^{1/2+\\varepsilon})$ is proved using second-moment methods and exponential sum estimates. The key input is that for lacunary $\\{n_k\\}$, the Weyl sums $|\\sum e(\\alpha n_k)|^2$ have controlled second moments over $\\alpha \\in [0,1]$. The proof uses Parseval's identity and the near-orthogonality of exponentials at lacunary frequencies. The $(\\log N)^{1/2+\\varepsilon}$ factor arises from the maximal inequality needed to pass from $L^2$ bounds to almost sure bounds. This is universal — it holds for ALL lacunary sequences and ALL $L^2$ functions, unlike the lower bound which is existential.",
+    "significance": "key",
+    "relatedConcepts": ["Weyl sums", "Parseval identity", "maximal inequality", "second moment method", "exponential sums"],
+    "prerequisites": ["IsLacunarySeq", "MeasureTheory.ae", "Real.log", "Real.rpow"]
   },
   {
     "id": "ann-995-gap",
@@ -66,8 +78,10 @@
     "type": "context",
     "title": "The Bounds Gap",
     "content": "Lower bound has (log log N)^{1/2}, upper has (log N)^{1/2}. Since log log N grows much slower than log N, the gap is enormous. The axioms bound_gap_lower_exists and bound_gap_upper_universal formalize the existential/universal asymmetry.",
-    "mathContext": "The gap between (log log N)^{1/2} and (log N)^{1/2} is qualitatively immense: at N = 10^{10^{10}}, log N ≈ 2.3 × 10^{10} while log log N ≈ 23.8. So (log N)^{1/2} ≈ 151,000 while (log log N)^{1/2} ≈ 4.9 — a factor of 30,000. Closing this gap has resisted 75+ years of effort. The existential lower bound (∃ f, n) vs universal upper bound (∀ f, n) structure means the true answer could depend on the specific lacunary sequence.",
-    "significance": "key"
+    "mathContext": "The gap between $(\\log\\log N)^{1/2}$ and $(\\log N)^{1/2}$ is qualitatively immense: at $N = 10^{10^{10}}$, $\\log N \\approx 2.3 \\times 10^{10}$ while $\\log\\log N \\approx 23.8$. So $(\\log N)^{1/2} \\approx 151{,}000$ while $(\\log\\log N)^{1/2} \\approx 4.9$ — a factor of $30{,}000$. Closing this gap has resisted 75+ years of effort. The existential lower bound ($\\exists f, n$) vs universal upper bound ($\\forall f, n$) structure means the true answer could depend on the specific lacunary sequence.",
+    "significance": "key",
+    "relatedConcepts": ["iterated logarithm", "existential vs universal bounds", "open problem", "metric number theory"],
+    "prerequisites": ["LowerBoundGrowth", "UpperBoundGrowth", "IsLacunarySeq"]
   },
   {
     "id": "ann-995-exponent-gap",
@@ -76,8 +90,10 @@
     "type": "theorem",
     "title": "exponent_gap (Proved)",
     "content": "For N ≥ 3, log(log N) < log N. This formalizes the quantitative gap between the lower and upper bounds.",
-    "mathContext": "The proof uses log N < N (from Real.log_le_sub_one_of_pos) and monotonicity of log: since log N > 1 for N ≥ 3, we get log(log N) < log(N). While trivial mathematically, it formalizes the key qualitative fact: the lower bound scale (log log N)^{1/2} is strictly smaller than the upper bound scale (log N)^{1/2}, confirming the gap is genuine. Originally proved by Aristotle (automated proof search).",
-    "significance": "supporting"
+    "mathContext": "The proof uses $\\log N < N$ (from `Real.log_le_sub_one_of_pos`) and monotonicity of log: since $\\log N > 1$ for $N \\geq 3$, we get $\\log(\\log N) < \\log(N)$. While trivial mathematically, it formalizes the key qualitative fact: the lower bound scale $(\\log\\log N)^{1/2}$ is strictly smaller than the upper bound scale $(\\log N)^{1/2}$, confirming the gap is genuine. Originally proved by Aristotle (automated proof search).",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.log_le_sub_one_of_pos", "Real.log_lt_log", "Real.log_pos", "monotonicity of log"],
+    "prerequisites": ["Real.log", "Real.log_pos", "Real.log_le_sub_one_of_pos"]
   },
   {
     "id": "ann-995-geometric",
@@ -86,8 +102,10 @@
     "type": "theorem",
     "title": "geometric_is_lacunary (Proved)",
     "content": "The geometric sequence 2^k is lacunary with q = 2. Proof: 2^{k+1} = 2·2^k ≥ 2·2^k.",
-    "mathContext": "The sequence 2^k is the prototypical lacunary sequence, central to the study of Walsh series and dyadic analysis. For f(x) = cos(2πx), the lacunary sum ∑cos(2π·2^k·α) is a lacunary trigonometric series — Salem and Zygmund (1954) proved the CLT for such sums. The proof uses constructor + norm_num + ring_nf, verifying q = 2 > 1 and 2^{k+1} = 2·2^k as a Lean computation.",
-    "significance": "supporting"
+    "mathContext": "The sequence $2^k$ is the prototypical lacunary sequence, central to the study of Walsh series and dyadic analysis. For $f(x) = \\cos(2\\pi x)$, the lacunary sum $\\sum \\cos(2\\pi \\cdot 2^k \\cdot \\alpha)$ is a lacunary trigonometric series — Salem and Zygmund (1954) proved the CLT for such sums. The proof uses `constructor + norm_num + ring_nf`, verifying $q = 2 > 1$ and $2^{k+1} = 2 \\cdot 2^k$ as a Lean computation.",
+    "significance": "supporting",
+    "relatedConcepts": ["Walsh series", "dyadic analysis", "Salem-Zygmund", "geometric sequence", "norm_num"],
+    "prerequisites": ["Nat.pow", "IsLacunary"]
   },
   {
     "id": "ann-995-powers3",
@@ -96,8 +114,10 @@
     "type": "theorem",
     "title": "powers3_lacunary (Proved)",
     "content": "Powers of 3 are lacunary with q = 3: 3^{k+1} = 3·3^k.",
-    "mathContext": "The sequence 3^k has lacunarity ratio q = 3, stronger than 2^k. For the specific function f(x) = cos(2πx), the sum ∑cos(2π·3^k·α) connects to the Weierstrass function ∑3^{-s·k}cos(2π·3^k·α), whose non-differentiability (for s < 1) reflects the wildness of lacunary trigonometric sums. The problem of determining the Hausdorff dimension of the graph of such functions remains active.",
-    "significance": "supporting"
+    "mathContext": "The sequence $3^k$ has lacunarity ratio $q = 3$, stronger than $2^k$. For the specific function $f(x) = \\cos(2\\pi x)$, the sum $\\sum \\cos(2\\pi \\cdot 3^k \\cdot \\alpha)$ connects to the Weierstrass function $\\sum 3^{-s \\cdot k} \\cos(2\\pi \\cdot 3^k \\cdot \\alpha)$, whose non-differentiability (for $s < 1$) reflects the wildness of lacunary trigonometric sums. The problem of determining the Hausdorff dimension of the graph of such functions remains active.",
+    "significance": "supporting",
+    "relatedConcepts": ["Weierstrass function", "Hausdorff dimension", "nowhere differentiable functions", "norm_num"],
+    "prerequisites": ["Nat.pow", "IsLacunary"]
   },
   {
     "id": "ann-995-fib",
@@ -106,8 +126,10 @@
     "type": "definition",
     "title": "Fibonacci Sequence",
     "content": "The Fibonacci sequence is eventually lacunary with q ≈ φ = (1+√5)/2 ≈ 1.618, the golden ratio.",
-    "mathContext": "The Fibonacci sequence F_k satisfies F_{k+1}/F_k → φ = (1+√5)/2 ≈ 1.618, so it is eventually lacunary with any q < φ. This is the 'least lacunary' natural example — the ratio is as close to 1 as possible for a sequence satisfying a linear recurrence. The fractional parts {α F_k} have special structure connected to continued fraction theory: when α = 1/φ, they are maximally non-equidistributed (the 'three-distance' phenomenon).",
-    "significance": "supporting"
+    "mathContext": "The Fibonacci sequence $F_k$ satisfies $F_{k+1}/F_k \\to \\varphi = (1+\\sqrt{5})/2 \\approx 1.618$, so it is eventually lacunary with any $q < \\varphi$. This is the 'least lacunary' natural example — the ratio is as close to 1 as possible for a sequence satisfying a linear recurrence. The fractional parts $\\{\\alpha F_k\\}$ have special structure connected to continued fraction theory: when $\\alpha = 1/\\varphi$, they are maximally non-equidistributed (the 'three-distance' phenomenon).",
+    "significance": "supporting",
+    "relatedConcepts": ["golden ratio", "continued fractions", "three-distance theorem", "linear recurrence", "Zeckendorf representation"],
+    "prerequisites": ["Nat.add", "Nat.succ"]
   },
   {
     "id": "ann-995-slln",
@@ -116,8 +138,10 @@
     "type": "axiom",
     "title": "SLLN Connection",
     "content": "For mean-zero f and lacunary n, the sum has variance ~ N, behaving like a random walk with √N typical fluctuations.",
-    "mathContext": "The SLLN connection (Erdős 1949) shows that lacunary sums obey (1/N)∑f({α n_k}) → ∫₀¹ f a.s. — the ergodic average converges. The variance Var(S_N) ~ cN (where c = ‖f‖₂²) gives √N as the typical scale of fluctuations by Chebyshev. The axiom formalizes the C√N bound, which is the 'zeroth-order' estimate. The full problem asks about the precise iterated-logarithm correction beyond √N: is |S_N| ~ √(N log log N) (LIL) or could it be as large as √(N log N)?",
+    "mathContext": "The SLLN connection (Erdős 1949) shows that lacunary sums obey $(1/N)\\sum f(\\{\\alpha n_k\\}) \\to \\int_0^1 f$ a.s. — the ergodic average converges. The variance $\\text{Var}(S_N) \\sim cN$ (where $c = \\|f\\|_2^2$) gives $\\sqrt{N}$ as the typical scale of fluctuations by Chebyshev. The axiom formalizes the $C\\sqrt{N}$ bound, which is the 'zeroth-order' estimate. The full problem asks about the precise iterated-logarithm correction beyond $\\sqrt{N}$: is $|S_N| \\sim \\sqrt{N \\log\\log N}$ (LIL) or could it be as large as $\\sqrt{N \\log N}$?",
     "significance": "key",
+    "relatedConcepts": ["Strong Law of Large Numbers", "Chebyshev inequality", "variance", "random walk", "ergodic convergence"],
+    "prerequisites": ["MeasureTheory.ae", "Real.sqrt", "lacunarySum", "IsLacunarySeq"],
     "crossReferences": [
       {
         "targetProofId": "laws-of-large-numbers",
@@ -133,8 +157,10 @@
     "type": "definition",
     "title": "Erdős's Refined Conjecture",
     "content": "Erdős (1964) conjectured the upper bound can be improved from (log N)^{1/2+ε} to (log log N)^{1/2+ε}, matching the lower bound.",
-    "mathContext": "In his 1964 Diophantine approximation paper, Erdős stated his belief that the lower bound gives the correct order. The refined conjecture |S_N| = O(N(log log N)^{1/2+ε}) for a.e. α would match the LIL prediction and show that lacunary sums truly behave like independent sums at the finest scale. This would require proving that the Weyl sum maximal function has a sub-logarithmic bound — a major challenge in harmonic analysis. Partial results by Berkes (1975) and Aistleitner-Berkes (2010) improved the upper bound but the full gap remains.",
-    "significance": "key"
+    "mathContext": "In his 1964 Diophantine approximation paper, Erdős stated his belief that the lower bound gives the correct order. The refined conjecture $|S_N| = O(N(\\log\\log N)^{1/2+\\varepsilon})$ for a.e. $\\alpha$ would match the LIL prediction and show that lacunary sums truly behave like independent sums at the finest scale. This would require proving that the Weyl sum maximal function has a sub-logarithmic bound — a major challenge in harmonic analysis. Partial results by Berkes (1975) and Aistleitner-Berkes (2010) improved the upper bound but the full gap remains.",
+    "significance": "key",
+    "relatedConcepts": ["Weyl sum maximal function", "Diophantine approximation", "LIL prediction", "Berkes", "Aistleitner"],
+    "prerequisites": ["IsLacunarySeq", "MeasureTheory.ae", "Real.log", "lacunarySum"]
   },
   {
     "id": "ann-995-statement",
@@ -143,8 +169,10 @@
     "type": "theorem",
     "title": "erdos_995_statement (Proved)",
     "content": "Main statement combining: (1) existence of examples reaching the lower bound, (2) universal upper bound for all lacunary sequences.",
-    "mathContext": "The main theorem is a conjunction of two axioms: bound_gap_lower_exists ∧ bound_gap_upper_universal. This captures the complete known state of Erdős Problem #995: there exist 'bad' lacunary sequences where the sum grows as fast as N(log log N)^{1/2-ε}, and all lacunary sequences have sums bounded by o(N(log N)^{1/2+ε}). The proof is trivially ⟨bound_gap_lower_exists, bound_gap_upper_universal⟩, packaging the axioms.",
-    "significance": "key"
+    "mathContext": "The main theorem is a conjunction of two axioms: `bound_gap_lower_exists ∧ bound_gap_upper_universal`. This captures the complete known state of Erdős Problem #995: there exist 'bad' lacunary sequences where the sum grows as fast as $N(\\log\\log N)^{1/2-\\varepsilon}$, and all lacunary sequences have sums bounded by $o(N(\\log N)^{1/2+\\varepsilon})$. The proof is trivially $\\langle\\text{bound\\_gap\\_lower\\_exists}, \\text{bound\\_gap\\_upper\\_universal}\\rangle$, packaging the axioms.",
+    "significance": "key",
+    "relatedConcepts": ["And.intro", "axiom packaging", "state-of-the-art formalization"],
+    "prerequisites": ["bound_gap_lower_exists", "bound_gap_upper_universal"]
   },
   {
     "id": "ann-995-summary",
@@ -153,7 +181,9 @@
     "type": "theorem",
     "title": "erdos_995_summary (Proved)",
     "content": "Summary: Is sum o(N √(log log N))? Lower bound shows at least (log log N)^{1/2-ε} sometimes. Upper bound gives (log N)^{1/2+ε} always. Gap remains OPEN.",
-    "mathContext": "The summary theorem erdos_995_summary = erdos_995_statement captures the full state of this 75-year-old open problem. The OPEN status means this is one of the remaining unsolved Erdős problems — closing the gap between (log log N)^{1/2} and (log N)^{1/2} would be a major advance in metric number theory, with implications for understanding the fine structure of lacunary trigonometric sums, almost sure invariance principles, and connections to the Riemann zeta function on the critical line.",
-    "significance": "key"
+    "mathContext": "The summary theorem `erdos_995_summary = erdos_995_statement` captures the full state of this 75-year-old open problem. The OPEN status means this is one of the remaining unsolved Erdős problems — closing the gap between $(\\log\\log N)^{1/2}$ and $(\\log N)^{1/2}$ would be a major advance in metric number theory, with implications for understanding the fine structure of lacunary trigonometric sums, almost sure invariance principles, and connections to the Riemann zeta function on the critical line.",
+    "significance": "key",
+    "relatedConcepts": ["open Erdős problem", "metric number theory", "Riemann zeta function", "almost sure invariance principle"],
+    "prerequisites": ["erdos_995_statement"]
   }
 ]


### PR DESCRIPTION
## Summary

Enrichment pass for three gallery proofs:

### erdos-1007-oq-01 (Minimum Edges for Graph Dimension d)
- Added new annotation for `complete_graph_dim_le` corollary with Cayley–Menger determinant context
- Added cross-reference to `erdos-924` (Folkman–Nešetřil–Rödl theorem)
- Deepened existing annotations with Hadwiger–Nelson, Laman's theorem, centroid-shifted simplex
- Fixed section line ranges

### erdos-995 (Lacunary Sequences and Fractional Parts)
- Added `relatedConcepts` and `prerequisites` arrays to all 14 annotations

### erdos-990 (Polynomial Root Distribution and Erdős-Turán Inequality)
- Added `relatedConcepts` and `prerequisites` arrays to all 21 annotations

## Test plan

- [x] JSON validates
- [x] `pnpm annotations:build` passes (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)