### PR TITLE
fix: flatten conclusion.implications arrays to strings (batch 3)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-01/meta.json
@@ -190,12 +190,7 @@
   },
   "conclusion": {
     "summary": "Complete formalization of equality characterizations for Cauchy-Schwarz, general Hölder, and integral Hölder inequalities. CS via Lagrange identity with full iff proportionality. Hölder via Young deficit reduction with both directions. Integral case via normalization and integral_eq_zero_iff_of_nonneg_ae. All 835 lines, zero axioms, zero sorries.",
-    "implications": [
-      "The equality characterization is foundational for projection theory: in inner product spaces, CS equality determines when one vector lies in the span of another",
-      "The Young deficit framework provides a template for characterizing equality in other convexity-based inequalities",
-      "The integral Hölder equality f^p =ᵃᵉ c·g^q characterizes extremizers of the Hölder inequality, relevant to sharp constant problems in functional analysis",
-      "The normalization technique (dividing by Lp norms) is a general strategy for reducing inequality equality cases to the unit-ball case"
-    ],
+    "implications": "The equality characterization is foundational for projection theory: in inner product spaces, CS equality determines when one vector lies in the span of another\nThe Young deficit framework provides a template for characterizing equality in other convexity-based inequalities\nThe integral Hölder equality f^p =ᵃᵉ c·g^q characterizes extremizers of the Hölder inequality, relevant to sharp constant problems in functional analysis\nThe normalization technique (dividing by Lp norms) is a general strategy for reducing inequality equality cases to the unit-ball case",
     "openQuestions": [
       "Can the strict convexity argument for Young's equality be replaced by a purely algebraic proof?",
       "Can the integral equality characterization be extended to the endpoint cases p=1 and p=∞?",

--- a/src/data/proofs/chinese-remainder-constructive/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive/meta.json
@@ -204,12 +204,7 @@
   ],
   "conclusion": {
     "summary": "This formalization provides a complete treatment of the Chinese Remainder Theorem, from the abstract existence/uniqueness results to concrete computational examples. The constructive approach using Bezout coefficients gives explicit formulas for solutions. Extensions to three and four moduli demonstrate the iterative nature of the algorithm, while the ring isomorphism section establishes the algebraic structure underlying CRT.",
-    "implications": [
-      "RSA decryption uses CRT to split modular exponentiation into two smaller computations, achieving ~4x speedup",
-      "Residue Number Systems enable parallel arithmetic: add/multiply componentwise in the product ring, reconstruct via CRT",
-      "The ring isomorphism Z/mnZ -> Z/mZ x Z/nZ is the prototype for decomposition theorems in commutative algebra (e.g., structure of Z/nZ for arbitrary n)",
-      "CRT-based polynomial interpolation (Lagrange interpolation is CRT over polynomial rings) is fundamental to error-correcting codes and secret sharing"
-    ],
+    "implications": "RSA decryption uses CRT to split modular exponentiation into two smaller computations, achieving ~4x speedup\nResidue Number Systems enable parallel arithmetic: add/multiply componentwise in the product ring, reconstruct via CRT\nThe ring isomorphism Z/mnZ -> Z/mZ x Z/nZ is the prototype for decomposition theorems in commutative algebra (e.g., structure of Z/nZ for arbitrary n)\nCRT-based polynomial interpolation (Lagrange interpolation is CRT over polynomial rings) is fundamental to error-correcting codes and secret sharing",
     "openQuestions": [
       "What are the best algorithms for computing Bezout coefficients in multi-precision arithmetic?",
       "How does CRT generalize to non-coprime moduli (see chinese-remainder-non-coprime)?",

--- a/src/data/proofs/chinese-remainder-non-coprime/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime/meta.json
@@ -178,12 +178,7 @@
   ],
   "conclusion": {
     "summary": "This formalization provides the complete generalization of the Chinese Remainder Theorem to non-coprime moduli. Every theorem is fully proved (0 sorries) using constructive methods based on Bezout's identity. The key results are: the gcd divisibility characterization of solvability, uniqueness modulo lcm, recovery of the classical CRT, and extension to three moduli.",
-    "implications": [
-      "In algebraic number theory, the non-coprime CRT arises when working with ideals in rings where unique factorization may fail",
-      "Redundant residue number systems (coding theory) use non-coprime moduli for error detection and correction",
-      "Scheduling problems with cycles sharing common periods require the non-coprime CRT to determine if alignment is possible",
-      "The lcm-based uniqueness gives strictly tighter bounds than the naive product when moduli share factors"
-    ],
+    "implications": "In algebraic number theory, the non-coprime CRT arises when working with ideals in rings where unique factorization may fail\nRedundant residue number systems (coding theory) use non-coprime moduli for error detection and correction\nScheduling problems with cycles sharing common periods require the non-coprime CRT to determine if alignment is possible\nThe lcm-based uniqueness gives strictly tighter bounds than the naive product when moduli share factors",
     "openQuestions": [
       "Can the construction be made more computationally efficient for large moduli?",
       "How does the non-coprime CRT extend to polynomial rings and general PIDs?",

--- a/src/data/proofs/dissection-of-cubes/meta.json
+++ b/src/data/proofs/dissection-of-cubes/meta.json
@@ -159,12 +159,7 @@
   ],
   "conclusion": {
     "summary": "Littlewood's proof elegantly shows that cube dissection into different-sized cubes is impossible through infinite descent. The smallest cube on any 'floor' creates a new floor above it with even smaller cubes, leading to infinitely many cubes — contradicting finiteness. The proof is remarkably short: the main theorem is just 3 lines of Lean + omega.",
-    "implications": [
-      "The 2D analog (squaring the square) IS possible — the first solution (1940) had 69 squares, the smallest simple one has 21 squares",
-      "The impossibility extends to all dimensions >= 3 and to rectangular boxes",
-      "The proof pattern (infinite descent via pigeonhole on chain length) appears in Erdős-Szekeres, Ramsey theory, and Dilworth's theorem",
-      "The axiomatized geometric covering step (smaller_cube_above) is the remaining gap — it requires formal 3D tiling theory"
-    ],
+    "implications": "The 2D analog (squaring the square) IS possible — the first solution (1940) had 69 squares, the smallest simple one has 21 squares\nThe impossibility extends to all dimensions >= 3 and to rectangular boxes\nThe proof pattern (infinite descent via pigeonhole on chain length) appears in Erdős-Szekeres, Ramsey theory, and Dilworth's theorem\nThe axiomatized geometric covering step (smaller_cube_above) is the remaining gap — it requires formal 3D tiling theory",
     "openQuestions": [
       "Minimum number of repeated sizes needed in a cube dissection",
       "Generalizations to other 3D shapes (e.g., can a tetrahedron be dissected into tetrahedra of all different sizes?)",

--- a/src/data/proofs/erdos-1007-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01/meta.json
@@ -224,12 +224,7 @@
   },
   "conclusion": {
     "summary": "We significantly extend the minEdges formalization with a constructive simplex embedding (K_n in ℝⁿ), prove the complete graph optimality conjecture implies monotonicity, introduce and analyze the deficiency function, and verify d=4 is the unique anomaly for d≤5. All theorems are fully proved (no sorries), with 10 axioms for the minEdges function and known values.",
-    "implications": [
-      "The simplex embedding construction provides a concrete geometric witness for the upper bound minEdges(d) ≤ C(d+1,2), useful as a starting point for dimension computations",
-      "The conditional monotonicity theorem demonstrates that resolving the complete graph optimality conjecture would simultaneously resolve the monotonicity question",
-      "The deficiency reformulation (δ(d) = 0 iff K_{d+1} optimal) reduces an infinite family of graph-theoretic questions to a numerical condition checkable dimension by dimension",
-      "The d=4 anomaly analysis suggests that bipartite structures may provide more efficient dimension-achieving graphs in higher dimensions"
-    ],
+    "implications": "The simplex embedding construction provides a concrete geometric witness for the upper bound minEdges(d) ≤ C(d+1,2), useful as a starting point for dimension computations\nThe conditional monotonicity theorem demonstrates that resolving the complete graph optimality conjecture would simultaneously resolve the monotonicity question\nThe deficiency reformulation (δ(d) = 0 iff K_{d+1} optimal) reduces an infinite family of graph-theoretic questions to a numerical condition checkable dimension by dimension\nThe d=4 anomaly analysis suggests that bipartite structures may provide more efficient dimension-achieving graphs in higher dimensions",
     "openQuestions": [
       "Is minEdges monotone in d?",
       "Does minEdges(d) = Θ(d²)?",

--- a/src/data/proofs/erdos-1026/meta.json
+++ b/src/data/proofs/erdos-1026/meta.json
@@ -192,13 +192,7 @@
   ],
   "conclusion": {
     "summary": "Erdős Problem #1026 asked for the maximum sum over monotonic subsequences. The optimal constant is c = 1: every sequence has a monotonic subsequence with sum at least (1-o(1)) · totalSum/√n. This follows from the weighted Erdős-Szekeres theorem proved by Tidor-Wang-Yang (2016). Cambie's construction shows the bound is tight.",
-    "implications": [
-      "Extends Erdős-Szekeres from length bounds to weighted (sum) bounds — a qualitative strengthening",
-      "Connects to Dilworth's theorem: the decomposition bounds come from antichain decomposition in the product order",
-      "Wagner's alternative proof via tournament coloring reveals a connection to directed graph theory",
-      "Algorithmic applications: finding optimal monotonic subsequences in O(n log n) via patience sorting",
-      "Random sequences achieve the extremal bounds asymptotically, connecting to probabilistic combinatorics"
-    ],
+    "implications": "Extends Erdős-Szekeres from length bounds to weighted (sum) bounds — a qualitative strengthening\nConnects to Dilworth's theorem: the decomposition bounds come from antichain decomposition in the product order\nWagner's alternative proof via tournament coloring reveals a connection to directed graph theory\nAlgorithmic applications: finding optimal monotonic subsequences in O(n log n) via patience sorting\nRandom sequences achieve the extremal bounds asymptotically, connecting to probabilistic combinatorics",
     "openQuestions": [
       "What is the exact extremal construction for small n?",
       "Does the bound extend to approximate monotonicity?",

--- a/src/data/proofs/erdos-1149/meta.json
+++ b/src/data/proofs/erdos-1149/meta.json
@@ -164,19 +164,17 @@
   ],
   "conclusion": {
     "summary": "This formalization captures Erdős #1149, proved by Bergelson-Richter (2017). The density of integers n coprime to ⌊n^α⌋ is 6/π² for non-integer α > 0. All theorems compile with 0 sorries. The 2 axioms capture deep results: the Bergelson-Richter theorem (ergodic theory) and classical coprime density (Euler product).",
-    "implications": [
-      "The result reveals that the deterministic function n ↦ ⌊n^α⌋ exhibits 'pseudorandom' behavior in the coprimality sense, connecting deterministic number theory to probabilistic heuristics",
-      "The proof technique (multiplicative functions along polynomial sequences) has applications beyond coprimality — it extends to other arithmetic functions evaluated at ⌊n^α⌋",
-      "The connection to ζ(2) = π²/6 places this result in the broader context of the Riemann zeta function and its role in counting problems",
-      "The integer exclusion argument shows that the non-integer hypothesis is not just technical but reflects a genuine phase transition in arithmetic behavior"
-    ],
+    "implications": "The result reveals that the deterministic function n ↦ ⌊n^α⌋ exhibits 'pseudorandom' behavior in the coprimality sense, connecting deterministic number theory to probabilistic heuristics\nThe proof technique (multiplicative functions along polynomial sequences) has applications beyond coprimality — it extends to other arithmetic functions evaluated at ⌊n^α⌋\nThe connection to ζ(2) = π²/6 places this result in the broader context of the Riemann zeta function and its role in counting problems\nThe integer exclusion argument shows that the non-integer hypothesis is not just technical but reflects a genuine phase transition in arithmetic behavior",
     "openQuestions": [
       "What is the density for more general functions f(n) replacing ⌊n^α⌋?",
       "Can the convergence rate be quantified (error term)?",
       "Does the result extend to gcd(n, ⌊n^α⌋) = d for d > 1?"
     ],
     "crossReferences": [
-      { "proofId": "erdos-37", "relationship": "Both involve density concepts (Schnirelmann vs natural density) and number-theoretic structure." }
+      {
+        "proofId": "erdos-37",
+        "relationship": "Both involve density concepts (Schnirelmann vs natural density) and number-theoretic structure."
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Flatten `conclusion.implications` from `string[]` to `string` in 7 meta.json files
- Fixes build failure caused by enricher creating arrays where `ProofConclusion` type expects strings
- Affected proofs: erdos-1026, erdos-1149, erdos-1007-oq-01, dissection-of-cubes, chinese-remainder-constructive, chinese-remainder-non-coprime, cauchy-schwarz-oq-03-oq-01

## Test plan
- [x] `pnpm build` passes after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)