### PR TITLE
Enrich erdos-225 (trig polynomial L1 norm): full proof coverage

### DIFF
--- a/src/data/proofs/erdos-225/annotations.json
+++ b/src/data/proofs/erdos-225/annotations.json
@@ -2,122 +2,145 @@
   {
     "id": "ann-e225-header",
     "proofId": "erdos-225",
-    "range": {
-      "startLine": 1,
-      "endLine": 26
-    },
+    "range": { "startLine": 1, "endLine": 38 },
     "type": "concept",
-    "title": "Problem Overview",
-    "content": "**Erdős Problem #225**: If a trigonometric polynomial has all roots on the unit circle and supremum norm 1, then its L¹ norm is at most 4. Solved by Kristiansen (1974) and Saff-Sheil-Small (1973).",
-    "mathContext": "f(θ) = Σₖ cₖ e^(ikθ) with all roots of P(z) = Σ cₖ zᵏ on |z| = 1. If max|f| = 1, then ∫|f| ≤ 4.",
+    "title": "Problem Overview and Aristotle Contributions",
+    "content": "**Erdős Problem #225**: If a trigonometric polynomial $f(\\theta) = \\sum c_k e^{ik\\theta}$ has all roots on the unit circle and $\\|f\\|_\\infty = 1$, then $\\|f\\|_1 \\leq 4$. **Solved** by Kristiansen (1974) and Saff–Sheil-Small (1973). Aristotle (Harmonic) proved the optimality theorem and found a **formalization bug**: the main theorem is false for constant polynomials, which vacuously satisfy `HasUnitCircleRoots`.",
+    "mathContext": "The problem connects two fundamental norms in harmonic analysis: the $L^\\infty$ norm (supremum) and the $L^1$ norm (integral) of a trigonometric polynomial. The constraint that all roots of $P(z) = \\sum c_k z^k$ lie on $|z| = 1$ severely restricts the polynomial, preventing large $L^1$ norm. The sharp bound of 4 was conjectured by Erdős in the 1940s and listed as Problem 4.20 in Hayman's *Research Problems in Function Theory* (1974). Note: 'real roots' is a misnomer — it refers to roots on the **unit circle** $|z| = 1$, not on $\\mathbb{R}$.",
     "significance": "critical",
-    "relatedConcepts": [
-      "trigonometric-polynomials",
-      "unit-circle",
-      "L1-norm"
-    ]
+    "relatedConcepts": ["trigonometric polynomials", "unit circle", "L1 norm", "L-infinity norm", "Hayman's problem list", "Aristotle proof search"],
+    "prerequisites": ["complex exponential", "Fourier analysis basics", "polynomial roots"]
+  },
+  {
+    "id": "ann-e225-imports",
+    "proofId": "erdos-225",
+    "range": { "startLine": 40, "endLine": 44 },
+    "type": "concept",
+    "title": "Imports and Measure Theory Setup",
+    "content": "Imports the full **Mathlib** library and opens `MeasureTheory` namespace for integration. The `MeasureTheory` import provides Bochner integration (`∫`) and `Set.Icc` intervals needed for $L^1$ norms.",
+    "mathContext": "Lean's `∫ θ in Set.Icc 0 (2π), ‖f(θ)‖` uses Bochner integration over the Lebesgue measure. The `noncomputable` keyword on norm definitions reflects that suprema and integrals over $\\mathbb{R}$ are not computationally decidable in general.",
+    "significance": "supporting",
+    "relatedConcepts": ["Bochner integration", "MeasureTheory", "Lebesgue measure", "noncomputable"],
+    "prerequisites": ["Lean 4 import system", "measure theory basics", "Bochner integral"]
   },
   {
     "id": "ann-e225-trigpoly",
     "proofId": "erdos-225",
-    "range": {
-      "startLine": 34,
-      "endLine": 44
-    },
+    "range": { "startLine": 48, "endLine": 56 },
     "type": "definition",
-    "title": "Trigonometric Polynomials",
-    "content": "**TrigPoly(n)**: A trigonometric polynomial of degree n with coefficients cₖ ∈ ℂ. **eval**: Evaluates f(θ) = Σₖ cₖ e^(ikθ).",
-    "mathContext": "Trigonometric polynomials are Fourier series with finitely many terms, fundamental in harmonic analysis.",
+    "title": "Trigonometric Polynomial Definition and Evaluation",
+    "content": "**TrigPoly n** is defined as `Fin (n+1) → ℂ` — a function mapping indices $0, 1, \\ldots, n$ to complex coefficients. **TrigPoly.eval** computes $f(\\theta) = \\sum_{k=0}^{n} c_k e^{ik\\theta}$ using `Finset.sum` over `Fin (n+1)`.",
+    "mathContext": "Trigonometric polynomials are finite Fourier series: elements of $\\text{span}\\{e^{ik\\theta} : 0 \\leq k \\leq n\\}$. Unlike general Fourier series, they have finitely many terms and are entire functions. The representation via `Fin (n+1) → ℂ` makes the degree explicit in the type, enabling degree-dependent arguments. Evaluation uses `Complex.exp (I * k * θ)` which equals $e^{ik\\theta}$.",
     "significance": "key",
-    "relatedConcepts": [
-      "fourier-series",
-      "complex-exponential"
-    ]
+    "relatedConcepts": ["Fourier series", "complex exponential", "finite-dimensional function space", "Fin type"],
+    "prerequisites": ["complex numbers", "complex exponential", "Finset.sum", "function types"]
   },
   {
     "id": "ann-e225-unitcircle",
     "proofId": "erdos-225",
-    "range": {
-      "startLine": 46,
-      "endLine": 60
-    },
+    "range": { "startLine": 60, "endLine": 72 },
     "type": "definition",
-    "title": "Unit Circle Roots",
-    "content": "**OnUnitCircle**: z lies on the unit circle if ‖z‖ = 1. **HasUnitCircleRoots**: All roots of the associated polynomial P(z) = Σ cₖ zᵏ satisfy |z| = 1.",
-    "mathContext": "The key constraint: 'real roots' in the problem statement means roots on the unit circle |z| = 1, not real numbers.",
+    "title": "Unit Circle Roots Condition",
+    "content": "**OnUnitCircle z** holds when $\\|z\\| = 1$. **HasUnitCircleRoots p** requires that every root of $P(z) = \\sum c_k z^k$ satisfies $|z| = 1$. This formalizes the 'real roots' condition from the problem statement.",
+    "mathContext": "The terminology 'real roots' in Erdős's original formulation is misleading. It means the roots of $P(z)$ are of the form $z = e^{i\\alpha}$ for real $\\alpha$, i.e., they lie on the unit circle $S^1 \\subset \\mathbb{C}$. **Aristotle's insight**: constant polynomials ($n = 0$) vacuously satisfy `HasUnitCircleRoots` because they have **no roots** — the condition $\\forall z, P(z) = 0 \\to \\|z\\| = 1$ is vacuously true when $P$ is never zero. This creates a loophole in the main theorem statement.",
     "significance": "critical",
-    "relatedConcepts": [
-      "polynomial-roots",
-      "unit-circle"
-    ]
+    "relatedConcepts": ["polynomial roots", "unit circle", "vacuous truth", "formalization bug"],
+    "prerequisites": ["complex norm", "polynomial root definition", "universal quantification"]
   },
   {
     "id": "ann-e225-norms",
     "proofId": "erdos-225",
-    "range": {
-      "startLine": 62,
-      "endLine": 74
-    },
+    "range": { "startLine": 76, "endLine": 86 },
     "type": "definition",
-    "title": "Norm Definitions",
-    "content": "**supNorm**: The L∞ norm sup_{θ∈[0,2π]} |f(θ)|. **l1Norm**: The L¹ norm ∫₀^(2π) |f(θ)| dθ.",
-    "mathContext": "The problem relates these two norms under the unit-circle-roots constraint.",
+    "title": "Supremum and $L^1$ Norm Definitions",
+    "content": "**supNorm**: $\\|f\\|_\\infty = \\sup_{\\theta \\in [0, 2\\pi]} \\|f(\\theta)\\|$, using `iSup` over `Set.Icc`. **l1Norm**: $\\|f\\|_1 = \\int_0^{2\\pi} \\|f(\\theta)\\| \\, d\\theta$, using Bochner integration.",
+    "mathContext": "The supremum norm uses `⨆ θ : Set.Icc 0 (2π), ‖p.eval θ‖`, taking the supremum over the compact subtype. The $L^1$ norm uses `∫ θ in Set.Icc 0 (2π), ‖p.eval θ‖` with Lebesgue measure. Both are `noncomputable` since computing exact real-valued suprema and integrals requires non-constructive principles. The problem asks: given $\\|f\\|_\\infty = 1$, how large can $\\|f\\|_1$ be under the unit-circle-roots constraint?",
     "significance": "key",
-    "relatedConcepts": [
-      "sup-norm",
-      "L1-norm",
-      "measure-theory"
-    ]
+    "relatedConcepts": ["supremum norm", "L1 norm", "iSup", "Bochner integral", "compact interval"],
+    "prerequisites": ["real analysis (supremum)", "Lebesgue integration", "norm of complex number"]
   },
   {
     "id": "ann-e225-main",
     "proofId": "erdos-225",
-    "range": {
-      "startLine": 76,
-      "endLine": 87
-    },
+    "range": { "startLine": 90, "endLine": 108 },
     "type": "theorem",
-    "title": "Main Theorem",
-    "content": "**erdos_225_main**: For any trigonometric polynomial p with unit circle roots and supNorm = 1, we have l1Norm ≤ 4.",
-    "mathContext": "The bound 4 is sharp and cannot be improved. This was proved by Kristiansen (1974) for real coefficients and Saff-Sheil-Small (1973) for complex coefficients.",
+    "title": "Main Theorem (Contains Sorry — Formalization Bug)",
+    "content": "**erdos_225_main**: For any trigonometric polynomial $p$ with `HasUnitCircleRoots` and `supNorm = 1`, the $L^1$ norm is $\\leq 4$. **Contains `sorry`** due to a formalization bug discovered by Aristotle: the statement is **false** for constant polynomials, which have $L^1$ norm $= 2\\pi > 4$.",
+    "mathContext": "The mathematical theorem (Kristiansen 1974, Saff–Sheil-Small 1973) is correct when the polynomial has **degree $\\geq 1$** (i.e., at least one root). The formalization needs an additional hypothesis `n ≥ 1` or an explicit non-constant condition. This is a classic formalization subtlety: the informal statement implicitly excludes trivial cases that formal logic does not. The `sorry` marks the incomplete proof, not a mathematical gap.",
     "significance": "critical",
-    "relatedConcepts": [
-      "harmonic-analysis",
-      "norm-bounds"
-    ]
+    "relatedConcepts": ["formalization gap", "vacuous truth", "sorry", "Kristiansen theorem", "Saff–Sheil-Small"],
+    "prerequisites": ["HasUnitCircleRoots", "supNorm", "l1Norm", "degree condition"]
   },
   {
     "id": "ann-e225-optimal",
     "proofId": "erdos-225",
-    "range": {
-      "startLine": 110,
-      "endLine": 129
-    },
+    "range": { "startLine": 112, "endLine": 129 },
     "type": "theorem",
-    "title": "Optimality",
-    "content": "**erdos_225_optimal**: The bound 4 is optimal - there exist polynomials with L¹ norm arbitrarily close to 4.",
-    "mathContext": "Sharpness results show the bound cannot be improved to 4-ε for any ε > 0.",
+    "title": "Optimality: Bound 4 is Sharp (Proved by Aristotle)",
+    "content": "**erdos_225_optimal**: For every $\\varepsilon > 0$, there exists a polynomial with unit-circle roots, $\\|f\\|_\\infty = 1$, and $\\|f\\|_1 > 4 - \\varepsilon$. **Fully proved** by Aristotle (Harmonic) — the witness is the constant polynomial $f = 1$, which has $L^1$ norm $= 2\\pi > 4 > 4 - \\varepsilon$.",
+    "mathContext": "Ironically, Aristotle's proof of optimality uses the same constant polynomial that **disproves** the main theorem as formalized. The constant polynomial $f(\\theta) = 1$ has $\\|f\\|_\\infty = 1$ and $\\|f\\|_1 = 2\\pi \\approx 6.28 > 4$, so it trivially satisfies $\\|f\\|_1 > 4 - \\varepsilon$ for any $\\varepsilon > 0$. The proof uses `ciSup_const` for the supremum and `Real.pi_gt_three` to show $2\\pi > 4$.",
     "significance": "key",
-    "relatedConcepts": [
-      "extremal-problems",
-      "sharpness"
-    ]
+    "relatedConcepts": ["sharpness", "extremal polynomial", "constant function", "ciSup_const", "pi bounds"],
+    "prerequisites": ["ciSup properties", "Real.pi_gt_three", "norm_num tactic"]
+  },
+  {
+    "id": "ann-e225-special",
+    "proofId": "erdos-225",
+    "range": { "startLine": 131, "endLine": 141 },
+    "type": "theorem",
+    "title": "Special Cases and Examples",
+    "content": "**constant_l1_norm**: $2\\pi > 4$, proved via `Real.pi_gt_three` and `linarith`. This confirms the constant polynomial's $L^1$ norm exceeds the bound, demonstrating the formalization bug.",
+    "mathContext": "The computation $2\\pi > 4$ follows from $\\pi > 3$ (available as `Real.pi_gt_three` in Mathlib), giving $2\\pi > 6 > 4$. This is the simplest demonstration that a polynomial can vacuously satisfy `HasUnitCircleRoots` while violating the $L^1 \\leq 4$ bound.",
+    "significance": "supporting",
+    "relatedConcepts": ["pi bounds", "linarith tactic", "counterexample"],
+    "prerequisites": ["Real.pi_gt_three", "linarith"]
+  },
+  {
+    "id": "ann-e225-equiv",
+    "proofId": "erdos-225",
+    "range": { "startLine": 145, "endLine": 151 },
+    "type": "definition",
+    "title": "Equivalent Polynomial Formulation",
+    "content": "**PolynomialHasUnitCircleRoots**: An alternative formulation using the algebraic polynomial $P(z) = \\sum c_k z^k$ directly. Identical to `HasUnitCircleRoots` — both require all roots to satisfy $\\|z\\| = 1$.",
+    "mathContext": "The equivalence between the trigonometric formulation ($f(\\theta) = \\sum c_k e^{ik\\theta}$) and the algebraic one ($P(z) = \\sum c_k z^k$) arises from the substitution $z = e^{i\\theta}$. The roots of $P(z)$ correspond to the zeros of $f(\\theta)$: $f(\\theta_0) = 0 \\iff P(e^{i\\theta_0}) = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["polynomial representation", "z = e^(iθ) substitution", "equivalent formulations"],
+    "prerequisites": ["complex polynomial", "unit circle parameterization"]
+  },
+  {
+    "id": "ann-e225-supequiv",
+    "proofId": "erdos-225",
+    "range": { "startLine": 158, "endLine": 189 },
+    "type": "theorem",
+    "title": "Supremum Equivalence on Unit Circle (Proved by Aristotle)",
+    "content": "**sup_on_circle_eq_trig_sup**: The $L^\\infty$ norm of $P(z)$ on the unit circle equals the supremum of $|f(\\theta)|$ over $[0, 2\\pi]$. **Fully proved** by Aristotle (Harmonic) using a bijection between $S^1$ and $[0, 2\\pi]$.",
+    "mathContext": "The proof establishes a bijection: for every $z$ with $\\|z\\| = 1$, there exists $\\theta \\in [0, 2\\pi]$ with $z = e^{i\\theta}$, and vice versa. This uses `Complex.norm_eq_one_iff` and floor-division to normalize $\\theta$ into $[0, 2\\pi]$. The key steps are: (1) `le_antisymm` to prove equality of suprema, (2) `ciSup_le` to bound one supremum by the other, (3) `le_ciSup` with compactness (`IsCompact.bddAbove`) to reverse the inequality.",
+    "significance": "key",
+    "relatedConcepts": ["unit circle parameterization", "supremum equality", "Complex.norm_eq_one_iff", "compactness argument"],
+    "prerequisites": ["ciSup_le", "le_ciSup", "IsCompact.bddAbove", "Complex.exp_eq_exp_iff_exists_int"]
   },
   {
     "id": "ann-e225-fejer",
     "proofId": "erdos-225",
-    "range": {
-      "startLine": 191,
-      "endLine": 199
-    },
-    "type": "axiom",
-    "title": "Fejér-Riesz Connection",
-    "content": "**fejer_riesz**: Non-negative trigonometric polynomials can be written as |g(θ)|² for some polynomial g.",
-    "mathContext": "The Fejér-Riesz theorem is a fundamental tool in the analysis of trigonometric polynomials and relates to sum-of-squares representations.",
+    "range": { "startLine": 193, "endLine": 199 },
+    "type": "theorem",
+    "title": "Fejér–Riesz Theorem (Axiomatized)",
+    "content": "**fejer_riesz**: If $f(\\theta) \\geq 0$ for all $\\theta$, then $f(\\theta) = |g(\\theta)|^2$ for some trigonometric polynomial $g$. This classical 1915 result connects non-negativity to sum-of-squares representations.",
+    "mathContext": "The Fejér–Riesz theorem (1915) is a cornerstone of harmonic analysis: every non-negative trigonometric polynomial admits a **spectral factorization** $f = |g|^2$. It generalizes to operator-valued functions (Rosenblum's theorem) and matrix-valued settings. The theorem is relevant to Problem #225 because the unit-circle-roots condition can be analyzed via factorization of $|f|^2$. Axiomatized because its proof requires the fundamental theorem of algebra and careful root analysis.",
+    "significance": "key",
+    "relatedConcepts": ["Fejér–Riesz theorem", "spectral factorization", "sum of squares", "non-negative trigonometric polynomial"],
+    "prerequisites": ["trigonometric polynomial evaluation", "non-negativity condition", "polynomial factorization"]
+  },
+  {
+    "id": "ann-e225-littlewood",
+    "proofId": "erdos-225",
+    "range": { "startLine": 201, "endLine": 215 },
+    "type": "theorem",
+    "title": "Littlewood's Conjecture (Now Theorem)",
+    "content": "**littlewood_lower_bound**: For unimodular polynomials ($|c_k| = 1$ for all $k$), the $L^1$ norm on the unit circle is $\\geq C \\log n$. This provides a **lower bound** on $L^1$ norms, complementing Erdős #225's **upper bound**.",
+    "mathContext": "Littlewood conjectured in 1966 that $\\int_0^{2\\pi} |\\sum_{k=0}^{n-1} c_k e^{ik\\theta}| \\, d\\theta \\geq C \\log n$ when all $|c_k| = 1$. Proved by McGehee, Pigno, and Smith (1981) and independently by Konyagin (1981). The result shows that unimodular polynomials have $L^1$ mass growing logarithmically. By contrast, Erdős #225 shows that unit-circle-root polynomials have $L^1$ norms **bounded** by 4 regardless of degree.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "fejer-riesz",
-      "sum-of-squares"
-    ]
+    "relatedConcepts": ["Littlewood conjecture", "unimodular polynomial", "L1 lower bound", "McGehee–Pigno–Smith"],
+    "prerequisites": ["unimodular coefficients", "logarithmic growth", "Bochner integral"]
   }
 ]

--- a/src/data/proofs/erdos-225/meta.json
+++ b/src/data/proofs/erdos-225/meta.json
@@ -21,70 +21,110 @@
     "sorries": 1,
     "erdosNumber": 225,
     "erdosUrl": "https://erdosproblems.com/225",
-    "erdosProblemStatus": "solved"
+    "erdosProblemStatus": "solved",
+    "references": [
+      "Erdős (1940, 1957, 1961): early work on trigonometric polynomial norms",
+      "Saff–Sheil-Small (1973): proved for complex coefficients",
+      "Kristiansen (1974): proved for real coefficients",
+      "Hayman (1974): Research Problems in Function Theory, Problem 4.20",
+      "McGehee–Pigno–Smith (1981): Littlewood's conjecture (related result)",
+      "Fejér–Riesz (1915): non-negative trig polynomials as |g|²",
+      "https://erdosproblems.com/225"
+    ],
+    "relatedProofs": []
   },
   "overview": {
-    "historicalContext": "This problem relates to the study of trigonometric polynomials and their norms. Solved independently by Kristiansen (1974) for real coefficients and Saff & Sheil-Small (1973) for complex coefficients. Listed as Problem 4.20 in Hayman's Research Problems in Function Theory (1974).",
-    "problemStatement": "Let f(θ) = Σₖ cₖ e^(ikθ) be a trigonometric polynomial all of whose roots are real (i.e., lie on the unit circle), such that max|f(θ)| = 1. Then ∫₀^(2π) |f(θ)| dθ ≤ 4.",
-    "proofStrategy": "We formalize trigonometric polynomials as functions from coefficients to complex-valued functions on ℝ. The condition of having 'real roots' means all roots of the associated polynomial P(z) = Σ cₖ zᵏ lie on the unit circle |z| = 1. The main theorem states the L¹ norm bound of 4.",
+    "historicalContext": "Erdős studied $L^1$ norms of trigonometric polynomials from the 1940s onward, publishing related results in 1940, 1957, and 1961. The specific conjecture — that $\\|f\\|_1 \\leq 4$ when all roots lie on the unit circle and $\\|f\\|_\\infty = 1$ — was listed by W.K. Hayman as Problem 4.20 in his influential 1974 survey *Research Problems in Function Theory*. The problem was solved independently: Saff and Sheil-Small (1973) proved it for polynomials with complex coefficients, and Kristiansen (1974) for real coefficients. The bound 4 is sharp. Notably, the automated proof search tool Aristotle discovered a formalization bug in this entry: constant polynomials vacuously satisfy the 'all roots on the unit circle' condition (having no roots), but have $L^1$ norm $2\\pi > 4$, contradicting the formalized statement. The mathematical theorem implicitly requires degree $\\geq 1$.",
+    "problemStatement": "Let $f(\\theta) = \\sum_{k=0}^{n} c_k e^{ik\\theta}$ be a trigonometric polynomial all of whose roots are real (i.e., lie on the unit circle), such that $\\max|f(\\theta)| = 1$. Then $\\int_0^{2\\pi} |f(\\theta)| \\, d\\theta \\leq 4$.",
+    "proofStrategy": "The formalization defines trigonometric polynomials as `Fin (n+1) → ℂ`, with evaluation via `Complex.exp`. The unit-circle-roots condition requires all roots of $P(z) = \\sum c_k z^k$ to satisfy $\\|z\\| = 1$. Norms use Mathlib's `iSup` and Bochner integration. The main theorem has a `sorry` due to the constant-polynomial formalization bug. Aristotle proved optimality and the supremum equivalence theorem.",
     "keyInsights": [
-      "'Real roots' means roots on the unit circle |z| = 1, not real numbers",
-      "The bound 4 is optimal and achieved by specific polynomials",
-      "Related to the Fejér-Riesz theorem for non-negative trigonometric polynomials",
-      "Distinct from Littlewood's conjecture which gives lower bounds for unimodular polynomials"
+      "**Terminological trap**: 'Real roots' means roots on the unit circle $|z| = 1$, not roots in $\\mathbb{R}$ — a common source of confusion in the literature",
+      "**Formalization bug found by Aristotle**: Constant polynomials vacuously satisfy `HasUnitCircleRoots` but have $L^1$ norm $= 2\\pi > 4$, requiring a degree $\\geq 1$ hypothesis",
+      "**Sharp bound**: The constant 4 cannot be improved to $4 - \\varepsilon$ for any $\\varepsilon > 0$, as demonstrated by explicit extremal sequences",
+      "**Contrasting results**: Erdős #225 gives an $L^1$ **upper** bound of 4 for unit-circle-root polynomials, while Littlewood's conjecture (proved 1981) gives an $L^1$ **lower** bound of $C \\log n$ for unimodular polynomials",
+      "**Fejér–Riesz connection**: Non-negative trigonometric polynomials factor as $|g|^2$, linking the problem to spectral factorization theory"
     ]
   },
   "sections": [
     {
+      "id": "aristotle-header",
+      "title": "Aristotle Contributions",
+      "startLine": 1,
+      "endLine": 11,
+      "summary": "Aristotle (Harmonic) proved `erdos_225_optimal` and `sup_on_circle_eq_trig_sup`, and discovered the formalization bug: constant polynomials are a counterexample."
+    },
+    {
+      "id": "problem-statement",
+      "title": "Problem Statement and History",
+      "startLine": 13,
+      "endLine": 38,
+      "summary": "Docstring for Erdős Problem #225: $\\|f\\|_1 \\leq 4$ when all roots on $|z| = 1$ and $\\|f\\|_\\infty = 1$. Solved by Kristiansen (1974), Saff–Sheil-Small (1973). Hayman Problem 4.20."
+    },
+    {
       "id": "trig-poly",
       "title": "Trigonometric Polynomials",
-      "startLine": 34,
-      "endLine": 44,
-      "summary": "Define trigonometric polynomials as functions f(θ) = Σₖ cₖ e^(ikθ)."
+      "startLine": 40,
+      "endLine": 56,
+      "summary": "Defines `TrigPoly n` as `Fin (n+1) → ℂ` and evaluation $f(\\theta) = \\sum c_k e^{ik\\theta}$ via `Complex.exp`."
     },
     {
       "id": "unit-circle",
       "title": "Roots on the Unit Circle",
-      "startLine": 46,
-      "endLine": 60,
-      "summary": "Define what it means for a polynomial to have all roots on the unit circle."
+      "startLine": 58,
+      "endLine": 72,
+      "summary": "Defines `OnUnitCircle z` ($\\|z\\| = 1$) and `HasUnitCircleRoots p` (all roots of $P(z) = \\sum c_k z^k$ satisfy $|z| = 1$). The vacuous truth issue for constant polynomials is noted."
     },
     {
       "id": "norms",
       "title": "Norm Definitions",
-      "startLine": 62,
-      "endLine": 74,
-      "summary": "Define the supremum norm and L¹ norm for trigonometric polynomials."
+      "startLine": 74,
+      "endLine": 86,
+      "summary": "Defines $\\|f\\|_\\infty = \\sup_{\\theta \\in [0, 2\\pi]} \\|f(\\theta)\\|$ via `iSup` and $\\|f\\|_1 = \\int_0^{2\\pi} \\|f(\\theta)\\| \\, d\\theta$ via Bochner integration."
     },
     {
       "id": "main-theorem",
-      "title": "The Main Theorem",
-      "startLine": 76,
-      "endLine": 98,
-      "summary": "State and prove the L¹ norm bound of 4 for unit-circle-root polynomials."
+      "title": "Main Theorem (Sorry — Bug)",
+      "startLine": 88,
+      "endLine": 108,
+      "summary": "States $\\|f\\|_1 \\leq 4$ under unit-circle-roots and $\\|f\\|_\\infty = 1$. Contains `sorry` due to the constant-polynomial counterexample. Needs degree $\\geq 1$ hypothesis."
+    },
+    {
+      "id": "optimality",
+      "title": "Optimality (Proved by Aristotle)",
+      "startLine": 110,
+      "endLine": 129,
+      "summary": "Aristotle proved: for all $\\varepsilon > 0$, there exists a polynomial achieving $\\|f\\|_1 > 4 - \\varepsilon$. Witness: the constant polynomial $f = 1$ with $\\|f\\|_1 = 2\\pi$."
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "startLine": 100,
-      "endLine": 110,
-      "summary": "Examples including the constant polynomial with L¹ norm 2π."
+      "startLine": 131,
+      "endLine": 141,
+      "summary": "Proves $2\\pi > 4$ via `Real.pi_gt_three`, confirming the constant polynomial exceeds the bound."
     },
     {
-      "id": "connections",
-      "title": "Related Results",
-      "startLine": 130,
-      "endLine": 154,
-      "summary": "Connections to Fejér-Riesz theorem and Littlewood's conjecture."
+      "id": "equivalences",
+      "title": "Equivalent Formulations and Supremum Equivalence",
+      "startLine": 143,
+      "endLine": 189,
+      "summary": "Defines `PolynomialHasUnitCircleRoots`. Aristotle proved `sup_on_circle_eq_trig_sup`: the $L^\\infty$ norm of $P(z)$ on $S^1$ equals $\\sup_{\\theta} |f(\\theta)|$, via bijection $z = e^{i\\theta}$."
+    },
+    {
+      "id": "related-results",
+      "title": "Related Results: Fejér–Riesz and Littlewood",
+      "startLine": 191,
+      "endLine": 241,
+      "summary": "Axiomatizes the Fejér–Riesz theorem ($f \\geq 0 \\Rightarrow f = |g|^2$) and Littlewood's lower bound ($\\|f\\|_1 \\geq C \\log n$ for unimodular coefficients). Summary section reviews the solved status."
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #225 about L¹ norms of trigonometric polynomials with unit circle roots. The bound of 4 was proved independently by Kristiansen (1974) and Saff & Sheil-Small (1973).",
-    "implications": "This connects the location of polynomial roots to integral norm bounds, with the unit circle condition being essential for the sharp bound.",
+    "summary": "Erdős Problem #225 is **solved**: the bound $\\|f\\|_1 \\leq 4$ holds for trigonometric polynomials of degree $\\geq 1$ with all roots on the unit circle and $\\|f\\|_\\infty = 1$. The formalization captures definitions, norms, and related results. Aristotle proved optimality and the supremum equivalence, and discovered that the formalized statement needs a degree $\\geq 1$ hypothesis to exclude the constant-polynomial counterexample.",
+    "implications": "The result reveals a deep connection between **root geometry** (all roots on $S^1$) and **integral norm bounds** ($\\|f\\|_1 \\leq 4$). The unit-circle constraint dramatically restricts the polynomial's behavior: without it, $\\|f\\|_1$ can be arbitrarily large even with $\\|f\\|_\\infty = 1$. The Fejér–Riesz theorem provides a structural explanation via spectral factorization.",
     "openQuestions": [
-      "What are the extremal polynomials achieving L¹ norm close to 4?",
-      "Can the result be extended to more general function spaces?",
-      "What is the rate of convergence to the bound 4?"
+      "What are the degree-$n$ extremal polynomials that maximize $\\|f\\|_1$ under the unit-circle-roots and $\\|f\\|_\\infty = 1$ constraints?",
+      "Can the formalization be completed by adding the degree $\\geq 1$ hypothesis and proving the corrected main theorem in Lean?",
+      "Does an analogous bound hold for polynomials whose roots lie on a curve other than $S^1$ (e.g., an ellipse)?",
+      "What is the precise rate at which the extremal $L^1$ norm approaches 4 as $n \\to \\infty$?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Expanded from 7 to 12 annotations covering all Lean constructs (imports, special cases, equivalences, Littlewood)
- Added `prerequisites` to all annotations; fixed `axiom`→`theorem` type for Fejér–Riesz
- Deepened mathContext with Aristotle's formalization bug discovery (constant polynomial counterexample)
- Expanded sections from 6→10 covering Aristotle contributions, supremum equivalence, and related results
- Added full citations (Saff–Sheil-Small, Kristiansen, McGehee–Pigno–Smith, Fejér–Riesz)
- Enriched keyInsights: terminological trap ("real roots" = unit circle), Erdős vs Littlewood contrast

## Test plan
- [x] `pnpm annotations:build` passes with zero warnings for erdos-225
- [x] JSON valid (meta.json, annotations.json)
- [x] All 12 annotations have `mathContext`, `significance`, `relatedConcepts`, `prerequisites`

🤖 Generated with [Claude Code](https://claude.com/claude-code)