### PR TITLE
Enrich erdos-1100 (Coprime Consecutive Divisors): deepen annotations, add context

### DIFF
--- a/src/data/proofs/erdos-1100/annotations.json
+++ b/src/data/proofs/erdos-1100/annotations.json
@@ -3,12 +3,25 @@
     "id": "ann-e1100-header",
     "proofId": "erdos-1100",
     "range": { "startLine": 1, "endLine": 24 },
-    "type": "concept",
+    "type": "context",
     "title": "Problem Overview",
     "content": "**Erdős Problem #1100: Coprime Consecutive Divisors**\n\nFor n with divisors 1 = d₁ < d₂ < ... < d_τ(n) = n, let τ⊥(n) count indices i where gcd(dᵢ, dᵢ₊₁) = 1.\n\n**Three Questions:**\n1. Does τ⊥(n)/ω(n) → ∞ for almost all n? (OPEN)\n2. Is τ⊥(n) < exp((log n)^o(1)) for all n? (OPEN)\n3. What is the growth of g(k) = max τ⊥(n) for squarefree n with k prime factors?",
-    "mathContext": "This problem connects divisor theory with coprimality, exploring how the prime structure of n constrains consecutive divisors.",
-    "significance": "critical",
-    "relatedConcepts": ["Divisor function", "Coprimality", "Almost all"]
+    "mathContext": "This problem connects divisor theory with coprimality, exploring how the prime structure of $n$ constrains consecutive divisors. The divisor list of $n$ is a total ordering of the divisor lattice, and coprime transitions correspond to 'jumps' between elements sharing no common prime factor — a condition that imposes strong combinatorial constraints on which divisor orderings can produce many coprime pairs.",
+    "significance": "essential",
+    "relatedConcepts": ["divisor function", "coprimality", "almost all", "natural density", "divisor lattice"],
+    "prerequisites": ["prime factorization", "GCD", "natural density"]
+  },
+  {
+    "id": "ann-e1100-imports",
+    "proofId": "erdos-1100",
+    "range": { "startLine": 26, "endLine": 36 },
+    "type": "context",
+    "title": "Mathlib Imports and Namespace",
+    "content": "Imports **Nat.Basic**, **Nat.Prime.Defs**, and **Nat.Factorization.Basic** for number-theoretic definitions (primes, prime factors). **Finset.Basic** provides finite set operations for filtering divisors. **Real.Basic**, **Log.Basic**, and **Pow.Real** supply the real analysis framework needed for the asymptotic statements involving $\\exp$, $\\log$, and real exponentiation.",
+    "mathContext": "The `open Real Nat Finset` directive brings these namespaces into scope, avoiding the need for qualified names throughout the file. The interplay between $\\mathbb{N}$ (for divisor counts) and $\\mathbb{R}$ (for asymptotic bounds) requires explicit coercions via $(\\cdot : \\mathbb{R})$.",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib", "namespace management", "type coercion"],
+    "prerequisites": ["Lean 4 imports", "Mathlib library structure"]
   },
   {
     "id": "ann-e1100-divisorlist",
@@ -16,9 +29,11 @@
     "range": { "startLine": 42, "endLine": 47 },
     "type": "definition",
     "title": "Divisor List",
-    "content": "**divisorList n:**\n\nThe list of divisors of n in increasing order: 1 = d₁ < d₂ < ... < d_τ(n) = n.\n\n```lean\nnoncomputable def divisorList (n : ℕ) : List ℕ :=\n  (Finset.filter (· ∣ n) (Finset.range (n + 1))).sort (· ≤ ·)\n```",
-    "significance": "key",
-    "relatedConcepts": ["Divisors", "Sorting", "Finset"]
+    "content": "**divisorList n** produces the sorted list of divisors of $n$: $1 = d_1 < d_2 < \\cdots < d_{\\tau(n)} = n$. Implemented by filtering `Finset.range (n+1)` for divisors of $n$, then sorting the result in increasing order.",
+    "mathContext": "The sorted divisor list is the key data structure for this problem. While the *set* of divisors is well-studied (via the divisor function $\\tau(n)$), the *sequential* properties of the sorted list — such as coprime consecutive pairs — depend on the multiplicative structure of $n$ in subtle ways that resist standard analytic methods.",
+    "significance": "essential",
+    "relatedConcepts": ["divisors", "Finset.sort", "Finset.filter"],
+    "prerequisites": ["divisibility", "sorting algorithms", "Finset operations"]
   },
   {
     "id": "ann-e1100-tau",
@@ -26,10 +41,11 @@
     "range": { "startLine": 49, "endLine": 52 },
     "type": "definition",
     "title": "Divisor Count τ(n)",
-    "content": "**tau n:**\n\nThe number of divisors of n, denoted τ(n) or d(n).\n\n```lean\ndef tau (n : ℕ) : ℕ := (Finset.filter (· ∣ n) (Finset.range (n + 1))).card\n```",
-    "mathContext": "For n = p₁^a₁ · ... · p_k^a_k, we have τ(n) = (a₁+1)·...·(a_k+1).",
+    "content": "**tau n** is the number of divisors of $n$, denoted $\\tau(n)$ or $d(n)$. For $n = p_1^{a_1} \\cdots p_k^{a_k}$, we have $\\tau(n) = (a_1+1) \\cdots (a_k+1)$.",
+    "mathContext": "The divisor function $\\tau$ is multiplicative: $\\tau(mn) = \\tau(m)\\tau(n)$ when $\\gcd(m,n) = 1$. For squarefree $n$ with $k$ prime factors, $\\tau(n) = 2^k$, so the divisor list has $2^k$ elements — the vertices of a Boolean lattice. The function $\\tau^{\\perp}(n)$ counts coprime transitions in a maximal chain of this lattice, which is bounded above by $\\tau(n) - 1 = 2^k - 1$.",
     "significance": "supporting",
-    "relatedConcepts": ["Divisor function", "Multiplicative functions"]
+    "relatedConcepts": ["divisor function", "multiplicative functions", "Boolean lattice"],
+    "prerequisites": ["prime factorization", "multiplicative functions"]
   },
   {
     "id": "ann-e1100-omega",
@@ -37,10 +53,11 @@
     "range": { "startLine": 54, "endLine": 57 },
     "type": "definition",
     "title": "Distinct Prime Divisors ω(n)",
-    "content": "**omega n:**\n\nThe number of distinct prime divisors of n, denoted ω(n).\n\n```lean\ndef omega (n : ℕ) : ℕ := n.primeFactors.card\n```",
-    "mathContext": "ω(n) counts prime factors without multiplicity. For almost all n, ω(n) ≈ log log n by Hardy-Ramanujan.",
-    "significance": "key",
-    "relatedConcepts": ["Prime factorization", "Additive functions"]
+    "content": "**omega n** is the number of distinct prime divisors of $n$, denoted $\\omega(n)$. Defined as the cardinality of `n.primeFactors`.",
+    "mathContext": "By the Hardy–Ramanujan theorem (1917), $\\omega(n) \\sim \\log \\log n$ for almost all $n$. This makes Question 1 ($\\tau^{\\perp}(n)/\\omega(n) \\to \\infty$) equivalent to asking whether $\\tau^{\\perp}(n)$ grows faster than $\\log \\log n$ for almost all $n$. The function $\\omega$ is additive: $\\omega(mn) = \\omega(m) + \\omega(n)$ when $\\gcd(m,n) = 1$.",
+    "significance": "essential",
+    "relatedConcepts": ["prime factorization", "additive functions", "Hardy–Ramanujan theorem"],
+    "prerequisites": ["prime numbers", "primeFactors in Mathlib"]
   },
   {
     "id": "ann-e1100-tauperp",
@@ -48,42 +65,47 @@
     "range": { "startLine": 63, "endLine": 71 },
     "type": "definition",
     "title": "Coprime Consecutive Divisors τ⊥(n)",
-    "content": "**tauPerp n:**\n\nCount of indices i where gcd(dᵢ, dᵢ₊₁) = 1.\n\n```lean\nnoncomputable def tauPerp (n : ℕ) : ℕ :=\n  let divs := divisorList n\n  (List.range (divs.length - 1)).filter\n    (fun i => Nat.gcd (divs.getD i 0) (divs.getD (i + 1) 0) = 1)\n  |>.length\n```",
-    "mathContext": "Consecutive divisors being coprime means they share no prime factors - a strong constraint given they both divide n.",
-    "significance": "critical",
-    "relatedConcepts": ["GCD", "Coprimality", "Consecutive elements"]
+    "content": "**tauPerp n** counts the number of indices $i$ where $\\gcd(d_i, d_{i+1}) = 1$ in the sorted divisor list of $n$. Implemented by iterating over `List.range (divs.length - 1)` and filtering for coprime adjacent pairs.",
+    "mathContext": "Two consecutive divisors $d_i < d_{i+1}$ being coprime means they share no prime factor — a strong constraint since both divide $n$. Geometrically, in the divisor lattice of $n$, a coprime consecutive pair corresponds to two elements on a maximal chain that lie in 'orthogonal' sublattices. The sparsity of such pairs is what makes $\\tau^{\\perp}(n)$ typically small relative to $\\tau(n)$.",
+    "significance": "essential",
+    "relatedConcepts": ["GCD", "coprimality", "consecutive elements", "divisor lattice chains"],
+    "prerequisites": ["Nat.gcd", "List.getD", "List.filter"]
   },
   {
     "id": "ann-e1100-lower-bound",
     "proofId": "erdos-1100",
     "range": { "startLine": 73, "endLine": 77 },
     "type": "axiom",
-    "title": "Basic Lower Bound",
-    "content": "**tau_perp_lower_bound:**\n\nτ⊥(n) ≥ ω(n) trivially. At minimum, consecutive prime powers contribute coprime pairs.\n\nThis is tight for infinitely many n (equality achieved).",
-    "mathContext": "The prime powers p^a in the divisor list create natural 'barriers' where coprimality occurs.",
+    "title": "Basic Lower Bound: τ⊥(n) ≥ ω(n)",
+    "content": "**tau_perp_lower_bound**: $\\tau^{\\perp}(n) \\geq \\omega(n)$ for all $n > 0$. Each prime $p \\mid n$ contributes at least one coprime transition in the divisor list, since the divisor $p^{v_p(n)}$ (highest power of $p$ dividing $n$) must be adjacent to a divisor coprime to it.",
+    "mathContext": "The intuition is that the prime power $p^a$ in the divisor list is 'bracketed' by elements with different prime factorizations, forcing at least one coprime adjacency per prime. This bound is tight when $n$ is a primorial $p_1 \\cdots p_k$ and the divisor list happens to minimize coprime transitions.",
     "significance": "key",
-    "relatedConcepts": ["Prime powers", "Lower bounds"]
+    "relatedConcepts": ["prime powers", "lower bounds", "tight bounds"],
+    "prerequisites": ["GCD properties", "divisor list structure"]
   },
   {
     "id": "ann-e1100-equality",
     "proofId": "erdos-1100",
     "range": { "startLine": 79, "endLine": 84 },
     "type": "axiom",
-    "title": "Equality Infinitely Often",
-    "content": "**tau_perp_equality_infinitely_often:**\n\nThere exist infinitely many n with τ⊥(n) = ω(n).\n\nThis shows the lower bound is tight - but the question is whether this is rare.",
+    "title": "Equality Achieved Infinitely Often",
+    "content": "**tau_perp_equality_infinitely_often**: there exist infinitely many $n$ with $\\tau^{\\perp}(n) = \\omega(n)$. This shows the lower bound is tight — but Question 1 asks whether such equality is *rare* (density zero).",
+    "mathContext": "The infinite family achieving equality includes numbers like $n = 2^a \\cdot 3^b$ where the divisor list interleaves powers of 2 and 3 in a way that minimizes coprime adjacencies. The existential statement $\\forall N, \\exists n > N$ with $\\tau^{\\perp}(n) = \\omega(n)$ is the standard Lean formulation of 'infinitely many'.",
     "significance": "key",
-    "relatedConcepts": ["Sharpness", "Infinite families"]
+    "relatedConcepts": ["sharpness of bounds", "infinite families", "density zero sets"],
+    "prerequisites": ["infinitely many quantifier pattern"]
   },
   {
     "id": "ann-e1100-question1",
     "proofId": "erdos-1100",
-    "range": { "startLine": 86, "endLine": 102 },
+    "range": { "startLine": 86, "endLine": 107 },
     "type": "definition",
     "title": "Question 1: Almost All Growth (OPEN)",
-    "content": "**question1_almost_all_growth:**\n\nDoes τ⊥(n)/ω(n) → ∞ for almost all n?\n\n\"Almost all\" means the set of exceptions has density 0.\n\n```lean\ndef question1_almost_all_growth : Prop :=\n  ∀ M : ℝ, M > 0 →\n    ∀ ε > 0, ∃ X : ℕ, ∀ x : ℕ, x ≥ X →\n      (density of n with τ⊥(n)/ω(n) < M) < ε\n```",
-    "mathContext": "This asks if typically τ⊥(n) greatly exceeds ω(n), even though equality holds infinitely often.",
-    "significance": "critical",
-    "relatedConcepts": ["Almost all", "Natural density", "Asymptotic behavior"]
+    "content": "**question1_almost_all_growth**: Does $\\tau^{\\perp}(n)/\\omega(n) \\to \\infty$ for almost all $n$? Formalized as: for every $M > 0$ and $\\varepsilon > 0$, there exists $X$ such that for $x \\geq X$, the proportion of $n \\leq x$ with $\\tau^{\\perp}(n)/\\omega(n) < M$ is less than $\\varepsilon$.",
+    "mathContext": "This is a natural density statement. 'Almost all' in number theory means the exceptional set has density zero: $\\lim_{x \\to \\infty} \\frac{1}{x} |\\{n \\leq x : \\tau^{\\perp}(n)/\\omega(n) < M\\}| = 0$ for every fixed $M$. Since $\\omega(n) \\sim \\log \\log n$ for almost all $n$ by Hardy–Ramanujan, an affirmative answer would mean $\\tau^{\\perp}(n)$ typically grows much faster than $\\log \\log n$.",
+    "significance": "essential",
+    "relatedConcepts": ["natural density", "almost all", "Hardy–Ramanujan theorem", "asymptotic behavior"],
+    "prerequisites": ["natural density definition", "ratio limits"]
   },
   {
     "id": "ann-e1100-question2",
@@ -91,84 +113,94 @@
     "range": { "startLine": 109, "endLine": 121 },
     "type": "definition",
     "title": "Question 2: Upper Bound (OPEN)",
-    "content": "**question2_upper_bound:**\n\nIs τ⊥(n) < exp((log n)^o(1)) for all n?\n\nThis asks if τ⊥(n) grows slower than any fixed power of log n.\n\n```lean\ndef question2_upper_bound : Prop :=\n  ∀ ε > 0, ∃ N : ℕ, ∀ n : ℕ, n ≥ N →\n    (tauPerp n : ℝ) < exp ((log n)^ε)\n```",
-    "mathContext": "The o(1) exponent makes this a very slow growth - sub-polylogarithmic.",
-    "significance": "critical",
-    "relatedConcepts": ["Sublogarithmic growth", "Little-o notation"]
+    "content": "**question2_upper_bound**: Is $\\tau^{\\perp}(n) < \\exp((\\log n)^{o(1)})$ for all $n$? Formalized as: for every $\\varepsilon > 0$, eventually $\\tau^{\\perp}(n) < \\exp((\\log n)^{\\varepsilon})$.",
+    "mathContext": "The $o(1)$ exponent means $\\tau^{\\perp}(n)$ would grow slower than any fixed power of $\\log n$ — 'sub-polylogarithmic' growth. This is a worst-case bound (for all $n$), complementing Question 1's typical-case question. The two questions together would paint a complete picture: $\\tau^{\\perp}$ typically exceeds $\\omega(n)$ by a large factor, but never grows faster than sub-polylogarithmically.",
+    "significance": "essential",
+    "relatedConcepts": ["sub-polylogarithmic growth", "little-o notation", "worst-case bounds"],
+    "prerequisites": ["exponential function", "logarithm", "asymptotic notation"]
   },
   {
     "id": "ann-e1100-erdos-hall",
     "proofId": "erdos-1100",
     "range": { "startLine": 123, "endLine": 130 },
     "type": "axiom",
-    "title": "Erdős-Hall Lower Bound on Maximum",
-    "content": "**erdos_hall_max_lower_bound:**\n\nFor all ε > 0 and sufficiently large x:\n  max_{n<x} τ⊥(n) > exp((log log x)^(2-ε))\n\nThis shows the maximum grows at least double-logarithmically with a power approaching 2.",
-    "mathContext": "From Erdős-Hall 1978: 'On some unconventional problems on the divisors of integers'.",
+    "title": "Erdős–Hall Lower Bound on Maximum",
+    "content": "**erdos_hall_max_lower_bound**: For all $\\varepsilon > 0$ and sufficiently large $x$: $\\max_{n < x} \\tau^{\\perp}(n) > \\exp((\\log \\log x)^{2-\\varepsilon})$. This shows the maximum grows at least doubly-logarithmically with a power approaching 2.",
+    "mathContext": "From Erdős and Hall's 1978 paper *On some unconventional problems on the divisors of integers*. The double logarithm $\\log \\log x$ arises naturally because the number of prime factors of typical integers is $\\sim \\log \\log n$, and the construction exploits numbers with many small prime factors. The gap between this lower bound and the conjectured upper bound in Question 2 remains enormous.",
     "significance": "key",
-    "relatedConcepts": ["Maximum function", "Double logarithm", "Extremal values"]
+    "relatedConcepts": ["maximum function", "double logarithm", "extremal values", "Erdős–Hall 1978"],
+    "prerequisites": ["iterated logarithms", "extremal number theory"]
   },
   {
     "id": "ann-e1100-g-function",
     "proofId": "erdos-1100",
-    "range": { "startLine": 144, "endLine": 145 },
+    "range": { "startLine": 139, "endLine": 145 },
     "type": "definition",
-    "title": "The Function g(k)",
-    "content": "**g k:**\n\nMaximum τ⊥(n) among squarefree n with exactly k distinct prime factors.\n\n```lean\nnoncomputable def g (k : ℕ) : ℕ :=\n  sSup { tauPerp n | n : ℕ, Squarefree n ∧ omega n = k }\n```",
-    "mathContext": "Restricting to squarefree numbers simplifies the divisor structure while preserving the essential combinatorics.",
-    "significance": "key",
-    "relatedConcepts": ["Squarefree numbers", "Extremal functions", "Supremum"]
+    "title": "The Extremal Function g(k)",
+    "content": "**g k** is the maximum of $\\tau^{\\perp}(n)$ among squarefree $n$ with exactly $k$ distinct prime factors. Defined as `sSup` (supremum) over the set $\\{\\tau^{\\perp}(n) : n \\text{ squarefree}, \\omega(n) = k\\}$.",
+    "mathContext": "Restricting to squarefree $n$ makes $\\tau(n) = 2^k$ and the divisor lattice a Boolean lattice $2^{\\{p_1,\\ldots,p_k\\}}$. The sorted divisor list is then a specific linear extension of this Boolean lattice, and $g(k)$ counts the maximum coprime adjacencies in any such linear extension achievable by choosing primes. This reduction makes the problem purely combinatorial, though the answer depends on which primes are chosen.",
+    "significance": "essential",
+    "relatedConcepts": ["squarefree numbers", "extremal functions", "Boolean lattice", "linear extension"],
+    "prerequisites": ["sSup in Lean", "Squarefree predicate"]
   },
   {
     "id": "ann-e1100-simonovits",
     "proofId": "erdos-1100",
-    "range": { "startLine": 147, "endLine": 158 },
+    "range": { "startLine": 147, "endLine": 157 },
     "type": "axiom",
-    "title": "Erdős-Simonovits Bounds",
-    "content": "**erdos_simonovits_bounds:**\n\n(√2 + o(1))^k < g(k) < (2-c)^k for some constant c > 0.\n\nThis establishes that g(k) grows exponentially with base strictly between √2 ≈ 1.414 and 2.",
-    "mathContext": "The gap between √2 and 2 suggests the true base is somewhere in between, but its exact value remains unknown.",
-    "significance": "critical",
-    "relatedConcepts": ["Exponential bounds", "Growth rates", "Erdős-Simonovits"]
+    "title": "Erdős–Simonovits Bounds on g(k)",
+    "content": "**erdos_simonovits_bounds**: There exists $c > 0$ such that $(\\sqrt{2} - \\varepsilon)^k < g(k) < (2-c)^k$ for large $k$. The lower bound approaches $\\sqrt{2}^k$ and the upper bound is strictly below $2^k$.",
+    "mathContext": "The lower bound $\\sqrt{2}^k$ comes from an explicit construction: choosing primes and arranging divisors to produce roughly $\\sqrt{2}^k$ coprime transitions. The upper bound $(2-c)^k$ shows that one cannot achieve $2^k - 1$ coprime transitions (which would mean *every* consecutive pair is coprime). The gap between $\\sqrt{2} \\approx 1.414$ and $2 - c$ remains wide; determining the true base is an open problem.",
+    "significance": "essential",
+    "relatedConcepts": ["exponential bounds", "growth rates", "Erdős–Simonovits", "constructive lower bounds"],
+    "prerequisites": ["real exponentiation", "limit of sequences"]
   },
   {
     "id": "ann-e1100-exponential",
     "proofId": "erdos-1100",
-    "range": { "startLine": 164, "endLine": 179 },
+    "range": { "startLine": 162, "endLine": 178 },
     "type": "theorem",
     "title": "Exponential Growth of g(k)",
-    "content": "**g_exponential_growth:**\n\nThere exist α, β with √2 ≤ α and β < 2 such that:\nα^k ≤ g(k) ≤ β^k for sufficiently large k.\n\nThis theorem combines the Erdős-Simonovits bounds into a clean statement about exponential growth.",
-    "mathContext": "The proof uses the axiomatized bounds but requires limit arguments for the o(1) terms.",
+    "content": "**g_exponential_growth**: There exist $\\alpha, \\beta \\in \\mathbb{R}$ with $\\sqrt{2} \\leq \\alpha$ and $\\beta < 2$ such that $\\alpha^k \\leq g(k) \\leq \\beta^k$ for all $k \\geq 10$. The proof extracts $\\alpha = \\sqrt{2}$ and $\\beta = 2 - c$ from the Erdős–Simonovits axiom, with two **sorries** remaining for the limit arguments handling the $o(1)$ terms.",
+    "mathContext": "The sorries arise because the Erdős–Simonovits lower bound has the form $(\\sqrt{2} + o(1))^k$, so extracting $(\\sqrt{2})^k \\leq g(k)$ for all large $k$ requires showing the $o(1)$ term is eventually nonnegative — a standard but somewhat tedious limit argument in Lean.",
     "significance": "key",
-    "relatedConcepts": ["Exponential growth", "Asymptotic bounds"]
+    "relatedConcepts": ["exponential growth", "asymptotic bounds", "sorry classification"],
+    "prerequisites": ["Real.sqrt", "real power inequalities"]
   },
   {
     "id": "ann-e1100-examples",
     "proofId": "erdos-1100",
-    "range": { "startLine": 181, "endLine": 205 },
+    "range": { "startLine": 181, "endLine": 204 },
     "type": "concept",
-    "title": "Worked Examples",
-    "content": "**Example: n = 6**\nDivisors: 1, 2, 3, 6\n- gcd(1,2) = 1 ✓\n- gcd(2,3) = 1 ✓\n- gcd(3,6) = 3 ✗\n\nτ⊥(6) = 2, ω(6) = 2 → equality\n\n**Example: n = 12**\nDivisors: 1, 2, 3, 4, 6, 12\n- gcd(1,2) = 1 ✓\n- gcd(2,3) = 1 ✓\n- gcd(3,4) = 1 ✓\n- gcd(4,6) = 2 ✗\n- gcd(6,12) = 6 ✗\n\nτ⊥(12) = 3, ω(12) = 2 → exceeds ω",
+    "title": "Worked Examples: n = 6 and n = 12",
+    "content": "**n = 6**: Divisors 1, 2, 3, 6. Coprime pairs: (1,2) and (2,3). So $\\tau^{\\perp}(6) = 2 = \\omega(6)$ — equality case.\n\n**n = 12**: Divisors 1, 2, 3, 4, 6, 12. Coprime pairs: (1,2), (2,3), (3,4). So $\\tau^{\\perp}(12) = 3 > 2 = \\omega(12)$ — strict inequality, showing the lower bound is not always tight.",
+    "mathContext": "These examples illustrate the key phenomenon: $n = 6 = 2 \\cdot 3$ achieves equality because its divisor list has few coprime transitions, while $n = 12 = 2^2 \\cdot 3$ exceeds the bound because the extra divisors 4 and 6 create an additional coprime pair (3,4). The `native_decide` tactic computes $\\omega(6) = \\omega(12) = 2$ by evaluating the prime factorization at compile time.",
     "significance": "supporting",
-    "relatedConcepts": ["Concrete examples", "Verification"]
+    "relatedConcepts": ["concrete verification", "native_decide", "equality vs strict inequality"],
+    "prerequisites": ["GCD computation", "prime factorization of small numbers"]
   },
   {
     "id": "ann-e1100-insight",
     "proofId": "erdos-1100",
-    "range": { "startLine": 207, "endLine": 221 },
+    "range": { "startLine": 207, "endLine": 219 },
     "type": "insight",
     "title": "Why This Problem Is Hard",
-    "content": "**Structural Insight:**\n\nFor n = p₁^a₁ · ... · p_k^a_k:\n- Consecutive divisors differ by multiplying/dividing by prime powers\n- Coprimality requires consecutive divisors to share no common prime\n- This creates intricate combinatorial constraints on the divisor lattice\n\nThe exponential bounds on g(k) show the structure is neither trivial (would give polynomial) nor chaotic (would give 2^k).",
-    "mathContext": "The divisor lattice has a partial order structure, and τ⊥ counts 'coprime jumps' in chains.",
+    "content": "For $n = p_1^{a_1} \\cdots p_k^{a_k}$, consecutive divisors in the sorted list differ by multiplying or dividing by prime powers. Coprimality requires them to share **no** common prime, creating intricate combinatorial constraints. The exponential bounds on $g(k)$ — strictly between polynomial and $2^k$ — show the structure is genuinely complex.",
+    "mathContext": "The difficulty lies in the interplay between the multiplicative structure (divisor lattice) and the additive/order structure (sorted list). The lattice of divisors of a squarefree number is a Boolean cube $\\{0,1\\}^k$, and $\\tau^{\\perp}$ counts coprime adjacencies in a specific linear extension determined by the sizes of the primes. Different prime choices yield different linear extensions, making the extremal problem (maximizing $\\tau^{\\perp}$) depend on the distribution of primes — a number-theoretic input into a combinatorial question.",
     "significance": "key",
-    "relatedConcepts": ["Divisor lattice", "Combinatorial constraints"]
+    "relatedConcepts": ["divisor lattice", "combinatorial constraints", "Boolean cube", "linear extensions"],
+    "prerequisites": ["lattice theory basics", "combinatorics on posets"]
   },
   {
     "id": "ann-e1100-summary",
     "proofId": "erdos-1100",
-    "range": { "startLine": 227, "endLine": 256 },
+    "range": { "startLine": 224, "endLine": 255 },
     "type": "theorem",
-    "title": "Problem Summary",
-    "content": "**erdos_1100_summary:**\n\nCombines the known results:\n\n| Property | Status |\n|----------|--------|\n| τ⊥(n) ≥ ω(n) | PROVEN (trivial) |\n| Equality infinitely often | PROVEN |\n| max_{n<x} τ⊥(n) > exp((log log x)^(2-ε)) | PROVEN (Erdős-Hall) |\n| (√2)^k < g(k) < (2-c)^k | PROVEN (Erdős-Simonovits) |\n| τ⊥(n)/ω(n) → ∞ almost always | OPEN |\n| τ⊥(n) < exp((log n)^o(1)) | OPEN |",
-    "significance": "critical",
-    "relatedConcepts": ["Known results", "Open problems", "Research frontier"]
+    "title": "Problem Summary Theorem",
+    "content": "**erdos_1100_summary** combines the three known results into a single conjunction, proved directly from the axioms:\n1. $\\tau^{\\perp}(n) \\geq \\omega(n)$ for all $n > 0$\n2. Equality $\\tau^{\\perp}(n) = \\omega(n)$ holds for infinitely many $n$\n3. $\\max_{n < x} \\tau^{\\perp}(n) > \\exp((\\log \\log x)^{2-\\varepsilon})$ for large $x$ (Erdős–Hall)",
+    "mathContext": "This summary theorem serves as a 'state of the art' snapshot: three results are proved, three questions remain open. The conjunction structure mirrors how Erdős typically presented his problems — listing what is known and what remains, inviting others to close the gaps. The proof is trivial (citing the axioms directly) but the organizational value is in collecting the results.",
+    "significance": "key",
+    "relatedConcepts": ["known results", "open problems", "conjunction of axioms"],
+    "prerequisites": ["propositional logic", "Lean tactic mode"]
   }
 ]

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -22,88 +22,90 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "This problem was posed by Erdős and Hall in their 1978 paper 'On some unconventional problems on the divisors of integers'. It explores the structure of divisor sequences by counting how often consecutive divisors are coprime. The function τ⊥(n) captures a subtle arithmetic property: how the prime factorization of n constrains the 'gaps' between consecutive divisors.",
+    "historicalContext": "This problem was posed by Erdős and R. R. Hall in their 1978 paper *On some unconventional problems on the divisors of integers* (Acta Arithmetica). Hall was a specialist in multiplicative number theory at York, and this collaboration produced several problems exploring the fine structure of divisor sequences. The function $\\tau^{\\perp}(n)$ measures how often consecutive divisors in the increasing sequence $1 = d_1 < d_2 < \\cdots < d_{\\tau(n)} = n$ are coprime — a surprisingly subtle invariant. The trivial lower bound $\\tau^{\\perp}(n) \\geq \\omega(n)$ is immediate (each prime $p \\mid n$ contributes at least one coprime transition in the divisor list), and is tight infinitely often. The deeper questions concern whether $\\tau^{\\perp}(n)$ typically exceeds $\\omega(n)$ by a large factor. The exponential bounds on $g(k)$ are due to Erdős and Simonovits, who showed $\\sqrt{2}^k \\lesssim g(k) \\lesssim (2-c)^k$, revealing that the combinatorics of coprime transitions in divisor lattices is genuinely exponential but sub-maximal.",
     "problemStatement": "Let 1 = d₁ < d₂ < ... < d_τ(n) = n be the divisors of n in increasing order. Define τ⊥(n) to count the number of indices i for which gcd(dᵢ, dᵢ₊₁) = 1.\n\n**Question 1 (OPEN):** Is it true that τ⊥(n)/ω(n) → ∞ for almost all n?\n\n**Question 2 (OPEN):** Is it true that τ⊥(n) < exp((log n)^o(1)) for all n?\n\n**Question 3:** For squarefree n with ω(n) = k prime factors, determine the growth of g(k) = max τ⊥(n).\n\n**Known results:**\n- τ⊥(n) ≥ ω(n) trivially (equality for infinitely many n)\n- Erdős-Hall: max_{n<x} τ⊥(n) > exp((log log x)^(2-ε))\n- Erdős-Simonovits: (√2 + o(1))^k < g(k) < (2-c)^k for some c > 0",
-    "proofStrategy": "We formalize the definitions of τ⊥(n) and g(k), axiomatize the known bounds from Erdős-Hall and Erdős-Simonovits, and state the three open questions precisely. The exponential bounds on g(k) are captured in a theorem showing the growth rate lies between √2 and 2-c.",
+    "proofStrategy": "The formalization defines the divisor list, divisor count $\\tau(n)$, distinct prime count $\\omega(n)$, and coprime consecutive divisor count $\\tau^{\\perp}(n)$. The known bounds — the trivial lower bound $\\tau^{\\perp}(n) \\geq \\omega(n)$, its tightness infinitely often, the Erdős–Hall extremal lower bound, and the Erdős–Simonovits exponential bounds on $g(k)$ — are axiomatized. The three open questions are stated as Lean propositions. A combined theorem `g_exponential_growth` packages the bounds on $g(k)$, and concrete examples verify $\\omega(6) = \\omega(12) = 2$ via `native_decide`.",
     "keyInsights": [
-      "Consecutive divisors dᵢ and dᵢ₊₁ differ by multiplying or dividing by prime powers",
-      "Coprimality of consecutive divisors creates intricate combinatorial constraints",
-      "The bounds on g(k) show structure is neither trivial nor chaotic",
-      "Questions 1 and 2 remain open despite decades of study"
+      "Consecutive divisors $d_i, d_{i+1}$ of $n$ differ by multiplying or dividing by prime powers, so coprimality $\\gcd(d_i, d_{i+1}) = 1$ forces them to lie in completely disjoint prime 'sectors' of $n$'s factorization",
+      "The trivial bound $\\tau^{\\perp}(n) \\geq \\omega(n)$ comes from prime power transitions (e.g., the step from $p^a$ to $q^b$ in the divisor list), but for typical $n$ the ratio $\\tau^{\\perp}(n)/\\omega(n)$ is conjectured to grow without bound",
+      "The Erdős–Simonovits bounds $\\sqrt{2}^k \\lesssim g(k) \\lesssim (2-c)^k$ show that the maximum number of coprime transitions grows exponentially in the number of prime factors, with a base strictly between $\\sqrt{2} \\approx 1.414$ and $2$",
+      "Questions 1 and 2 address complementary aspects: Question 1 asks about typical behavior (almost all $n$), while Question 2 asks about worst-case behavior (all $n$), and both remain open after over 45 years",
+      "Restricting to squarefree $n$ in the definition of $g(k)$ simplifies the divisor lattice to a Boolean lattice $2^{\\{p_1,\\ldots,p_k\\}}$, making the problem purely combinatorial while preserving the essential difficulty"
     ]
   },
   "sections": [
     {
-      "id": "erd-s-problem-1100-coprime-con",
-      "title": "Erdős Problem #1100: Coprime Consecutive Divisors",
+      "id": "header-and-imports",
+      "title": "Header, References, and Imports",
       "startLine": 1,
       "endLine": 37,
-      "summary": "Erdős Problem #1100: Coprime Consecutive Divisors"
+      "summary": "Problem statement documenting the three questions and known results, followed by Mathlib imports for naturals, primes, factorization, finite sets, reals, logarithms, and real powers."
     },
     {
       "id": "divisor-functions",
       "title": "Divisor Functions",
       "startLine": 38,
       "endLine": 58,
-      "summary": "Divisor Functions"
+      "summary": "Defines divisorList (sorted divisors of n), tau (divisor count τ(n)), and omega (distinct prime factor count ω(n)) using Finset filtering and sorting."
     },
     {
       "id": "coprime-consecutive-divisors",
       "title": "Coprime Consecutive Divisors",
       "startLine": 59,
       "endLine": 85,
-      "summary": "Coprime Consecutive Divisors"
+      "summary": "Defines tauPerp (count of coprime consecutive divisor pairs τ⊥(n)), axiomatizes the lower bound τ⊥(n) ≥ ω(n), and states that equality is achieved infinitely often."
     },
     {
       "id": "question-1-almost-all-growth",
-      "title": "Question 1 - Almost All Growth",
+      "title": "Question 1: Almost All Growth",
       "startLine": 86,
       "endLine": 107,
-      "summary": "Question 1 - Almost All Growth"
+      "summary": "Formalizes Question 1 as a natural density statement: for every M > 0, the density of n with τ⊥(n)/ω(n) < M tends to zero."
     },
     {
       "id": "question-2-upper-bound",
-      "title": "Question 2 - Upper Bound",
+      "title": "Question 2: Upper Bound",
       "startLine": 108,
       "endLine": 134,
-      "summary": "Question 2 - Upper Bound"
+      "summary": "Formalizes Question 2 (sub-polylogarithmic growth of τ⊥) and axiomatizes the Erdős–Hall lower bound on max_{n<x} τ⊥(n)."
     },
     {
       "id": "question-3-growth-of-g-k",
-      "title": "Question 3 - Growth of g(k)",
+      "title": "Question 3: Growth of g(k)",
       "startLine": 135,
       "endLine": 178,
-      "summary": "Question 3 - Growth of g(k)"
+      "summary": "Defines g(k) as the supremum of τ⊥(n) over squarefree n with ω(n) = k, axiomatizes the Erdős–Simonovits bounds, and proves g_exponential_growth (with two sorries for the limit arguments)."
     },
     {
       "id": "examples",
-      "title": "Examples",
+      "title": "Worked Examples",
       "startLine": 179,
       "endLine": 204,
-      "summary": "Examples"
+      "summary": "Concrete examples for n = 6 (τ⊥ = 2 = ω, equality case) and n = 12 (τ⊥ = 3 > ω = 2, strict inequality), with ω verified by native_decide."
     },
     {
       "id": "why-this-problem-is-hard",
-      "title": "Why This Problem Is Hard",
+      "title": "Structural Difficulty",
       "startLine": 205,
       "endLine": 219,
-      "summary": "Why This Problem Is Hard"
+      "summary": "Commentary on why the problem is hard: coprimality of consecutive divisors depends delicately on the factorization of n, creating intricate combinatorial constraints on the divisor lattice."
     },
     {
       "id": "summary",
-      "title": "Summary",
+      "title": "Problem Summary Theorem",
       "startLine": 220,
       "endLine": 255,
-      "summary": "Summary"
+      "summary": "The erdos_1100_summary theorem combines the three known results (lower bound, equality infinitely often, Erdős–Hall extremal bound) into a single conjunction, proved directly from the axioms."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1100 poses three questions about τ⊥(n), the count of coprime consecutive divisor pairs. While the trivial lower bound τ⊥(n) ≥ ω(n) is established, and partial exponential bounds on g(k) are known from Erdős-Simonovits, the main questions about growth rates remain open.",
-    "implications": "Understanding τ⊥(n) would illuminate the fine structure of divisor lattices and how prime factorizations constrain the ordering of divisors.",
+    "summary": "The formalization captures all three questions of Erdős Problem 1100 about τ⊥(n), the count of coprime consecutive divisor pairs. The known results — the trivial lower bound, its infinite tightness, and the Erdős–Hall and Erdős–Simonovits bounds — are axiomatized, and the exponential growth theorem for g(k) is partially proved with two remaining sorries for limit arguments.",
+    "implications": "Understanding τ⊥(n) would illuminate the fine structure of divisor lattices and how prime factorizations constrain the ordering of divisors. The function τ⊥ connects to questions about the complexity of divisor sequences that arise in multiplicative number theory and combinatorial optimization on Boolean lattices. Determining the exact exponential base for g(k) would resolve a question at the intersection of extremal combinatorics and number theory.",
     "openQuestions": [
-      "Does τ⊥(n)/ω(n) → ∞ for almost all n?",
-      "Is τ⊥(n) < exp((log n)^o(1)) for all n?",
-      "What is the exact growth rate of g(k)?"
+      "Does $\\tau^{\\perp}(n)/\\omega(n) \\to \\infty$ for almost all $n$? By the Hardy–Ramanujan theorem, $\\omega(n) \\approx \\log \\log n$ for almost all $n$, so this asks whether $\\tau^{\\perp}(n)$ typically exceeds $\\log \\log n$ by an unbounded factor.",
+      "Is $\\tau^{\\perp}(n) < \\exp((\\log n)^{o(1)})$ for all $n$? The Erdős–Hall bound shows the maximum grows at least as $\\exp((\\log \\log x)^{2-\\varepsilon})$, leaving a large gap.",
+      "What is the exact exponential base $\\alpha$ such that $g(k) \\sim \\alpha^k$? The Erdős–Simonovits bounds place it in $(\\sqrt{2}, 2)$.",
+      "Can the lower and upper bounds on $g(k)$ be tightened, e.g., is $g(k) \\gg \\phi^k$ where $\\phi = (1+\\sqrt{5})/2 \\approx 1.618$ is the golden ratio?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Expanded historicalContext with R. R. Hall collaboration and Erdős–Simonovits provenance
- Added 5th keyInsight on Boolean lattice reduction for squarefree numbers
- Fixed section summaries (were just title repetitions, now substantive descriptions)
- Added prerequisites arrays and mathContext to all 16 annotations
- Added imports annotation covering Mathlib dependencies
- Expanded openQuestions with Hardy–Ramanujan connection

## Test plan
- [x] JSON validates (`python3 -c "import json; ..."`)
- [x] `pnpm run annotations:validate` passes for erdos-1100
- [x] No pre-existing errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)