### PR TITLE
Research: randomized-maxcut-oq-01 - Prove gwExpectedCut_nonneg (8→7 axioms)

### DIFF
--- a/proofs/Proofs/GoemansWilliamsonMaxCut.lean
+++ b/proofs/Proofs/GoemansWilliamsonMaxCut.lean
@@ -137,8 +137,7 @@ axiom sdp_ge_maxcut (G : SimpleGraph V) [DecidableRel G.Adj] :
 
 axiom gwExpectedCut (G : SimpleGraph V) [DecidableRel G.Adj] : ℝ
 
-axiom gwExpectedCut_nonneg (G : SimpleGraph V) [DecidableRel G.Adj] :
-  0 ≤ gwExpectedCut G
+-- gwExpectedCut_nonneg: moved after gw_rounding_inequality (proved, was axiom)
 
 /-
   ## The GW Inequality
@@ -160,6 +159,13 @@ axiom gwExpectedCut_nonneg (G : SimpleGraph V) [DecidableRel G.Adj] :
 -- achieves its minimum α_GW at θ* ≈ 2.331).
 axiom gw_rounding_inequality (G : SimpleGraph V) [DecidableRel G.Adj] :
   αGW * sdpRelaxation G ≤ gwExpectedCut G
+
+-- Derived from gw_rounding_inequality + sdpRelaxation_nonneg + αGW_pos
+-- (was axiom, now proved: 0 ≤ αGW * sdp ≤ E[cut])
+lemma gwExpectedCut_nonneg (G : SimpleGraph V) [DecidableRel G.Adj] :
+    0 ≤ gwExpectedCut G :=
+  le_trans (mul_nonneg (le_of_lt αGW_pos) (sdpRelaxation_nonneg G))
+    (gw_rounding_inequality G)
 
 /-
   ## Main Theorem: 0.878-Approximation Guarantee

--- a/src/data/proofs/randomized-maxcut-oq-01/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-01/meta.json
@@ -17,7 +17,7 @@
     "proofRepoPath": "Proofs/GoemansWilliamsonMaxCut.lean",
     "badge": "open",
     "sorries": 0,
-    "axioms": 8,
+    "axioms": 7,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph",

--- a/src/data/research/problems/randomized-maxcut-oq-01.json
+++ b/src/data/research/problems/randomized-maxcut-oq-01.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "SURVEYED",
     "since": "2026-03-11T21:20:33.095Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Axiom elimination survey - reduced 8 to 7 axioms",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "SURVEY: Reduced axiom count from 8 to 7 by proving gwExpectedCut_nonneg. Remaining 7 axioms are fundamentally blocked by missing SDP infrastructure in Mathlib.",
+    "builtItems": [
+      "Converted gwExpectedCut_nonneg from axiom to lemma in GoemansWilliamsonMaxCut.lean"
+    ],
+    "insights": [
+      "gwExpectedCut_nonneg is redundant - follows from gw_rounding_inequality + sdpRelaxation_nonneg + αGW_pos",
+      "Core bottleneck is Mathlib has no SDP infrastructure (semidefinite cones, duality, optimization)",
+      "The arccos inequality arccos(x)/π ≥ α_GW·(1-x)/2 requires calculus of variations to verify the minimum of θ/(π(1-cos θ)/2)",
+      "Hyperplane rounding probability measure on the sphere also not in Mathlib"
+    ],
+    "mathlibGaps": [
+      "Semidefinite programming infrastructure (PSD cones, duality)",
+      "Measure theory on unit sphere (hyperplane rounding)",
+      "Calculus of variations for arccos inequality min"
+    ],
+    "nextSteps": [
+      "Prove arccos inequality for conservative bound 878/1000 (requires calculus infrastructure)",
+      "SDP infrastructure would require major Mathlib contribution (~1000+ lines)"
+    ]
   },
   "approaches": [],
   "tags": [


### PR DESCRIPTION
## Summary
- Converted `gwExpectedCut_nonneg` from `axiom` to `lemma` in GoemansWilliamsonMaxCut.lean
- Proof: `0 ≤ αGW * sdpRelaxation G ≤ gwExpectedCut G` (chain of existing results)
- Reduces axiom count from 8 to 7
- Survey: remaining 7 axioms blocked by missing SDP infrastructure in Mathlib

## Test plan
- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.GoemansWilliamsonMaxCut`
- [x] 0 sorries, 7 axioms confirmed
- [x] Gallery meta.json updated

🤖 Generated by researcher-1