### PR TITLE
Research: Fix borsuk-ulam-oq-03-oq-03 axiom count and survey knowledge

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-03/meta.json
@@ -67,7 +67,7 @@
     ],
     "dateAdded": "2026-03-06",
     "mathlib_version": "4.26.0",
-    "axioms": 5
+    "axioms": 3
   },
   "overview": {
     "historicalContext": "Tucker's lemma (1946) is the combinatorial analog of the Borsuk-Ulam theorem. While BU states that every continuous map from S^n to R^n has an antipodal pair, Tucker's lemma states that every antipodally-labeled triangulation of the disk has a complementary edge. The connection: discretize a continuous map via Tucker labeling, apply Tucker's lemma to find complementary edges, take limits to get exact antipodal pairs. This provides a constructive/combinatorial proof of BU, avoiding algebraic topology (degree theory, homology).",

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
@@ -16,25 +16,44 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-03-06T08:22:48-08:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
-    "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "phase": "SURVEYED",
+    "since": "2026-03-12T23:55:00.000Z",
+    "iteration": 2,
+    "focus": "Deep survey: 3 axioms (not 5), tucker_disk_approx_zero derivable from other 2 but complex construction",
+    "blockers": [
+      "tuckers_lemma requires path-following in simplicial complexes (hard to formalize)",
+      "tucker_disk_approx_zero derivable from axioms 1+2 but needs grid triangulation construction as Fintype"
+    ],
+    "nextAction": "Attempt to derive tucker_disk_approx_zero from tuckers_lemma + complementary_edge_gives_approximate_zero.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Knowledge Base: borsuk-ulam-oq-03-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+    "progressSummary": "SURVEYED - File has 1153 lines, 65 theorems, 12 defs, 3 axioms (meta.json was wrong at 5), 0 sorries. Fixed meta.json axiom count. The 3 axioms are: (1) tuckers_lemma - general Tucker, (2) complementary_edge_gives_approximate_zero - IVT approximate zero, (3) tucker_disk_approx_zero - disk version. Axiom 3 is noted as derivable from 1+2 per comment.",
+    "builtItems": [
+      "Fixed meta.json axiom count from 5 to 3"
+    ],
+    "insights": [
+      "Only 3 axioms exist (tuckers_lemma, complementary_edge_gives_approximate_zero, tucker_disk_approx_zero), not 5 as meta.json claimed",
+      "tucker_disk_approx_zero is noted in comments as consequence of the other 2 axioms (Tucker + IVT approximate zero), but proving it requires constructing a grid triangulation as a Fintype with edges, boundary, and antipodal_map",
+      "tuckers_lemma is the most fundamental axiom - requires path-following in simplicial complexes, genuinely hard",
+      "complementary_edge_gives_approximate_zero may have an issue with its bound (δ * sup term seems too aggressive for large-gradient functions), needs verification",
+      "File includes computational verification of Tucker 2D for 5-vertex (64 cases, decide) and 9-vertex (1024 cases, native_decide) triangulations",
+      "BU for linear maps (R³→R²) is proved algebraically via rank-nullity without any axioms"
+    ],
+    "mathlibGaps": [
+      "Simplicial complex infrastructure (triangulations, path-following)",
+      "Tucker's lemma for general triangulations",
+      "IVT on paths in R² (for approximate zero from complementary edge)"
+    ],
+    "nextSteps": [
+      "Derive tucker_disk_approx_zero from tuckers_lemma + complementary_edge_gives_approximate_zero (requires ~150 lines of grid construction)",
+      "Verify complementary_edge_gives_approximate_zero bound is correct (may need fixing)",
+      "If Tucker path-following infrastructure appears in Mathlib, prove tuckers_lemma"
+    ]
   },
   "approaches": [],
   "tags": [

--- a/src/data/research/problems/borsuk-ulam-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03.json
@@ -16,25 +16,41 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-02-25T14:11:52.126Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "SURVEYED",
+    "since": "2026-03-12T23:50:00.000Z",
+    "iteration": 2,
+    "focus": "Deep axiom analysis - all 5 axioms genuinely blocked by missing Mathlib infrastructure",
+    "blockers": [
+      "All 5 axioms require algebraic topology (degree theory, homology, covering spaces) not in Mathlib",
+      "Deriving no_retraction/brouwer_FP/LS/invariance from borsuk_ulam_general requires substantial intermediate constructions"
+    ],
+    "nextAction": "Prove sign_change_count_parity sorry in sub-OQ BorsukUlamOQ03OQ01.lean (product telescope argument).",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED - 13 proved theorems, 1 axiom (general BU for n≥2), 0 sorries.",
+    "progressSummary": "SURVEYED - File now has 914 lines, ~30 proved theorems/lemmas, 5 axioms (borsuk_ulam_general, no_retraction, brouwer_fixed_point, lusternik_schnirelmann, invariance_of_dimension), 0 sorries. All 5 axioms are genuinely blocked. Sub-OQ file BorsukUlamOQ03OQ01.lean has 1 sorry (sign_change_count_parity) that is tractable.",
     "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# borsuk-ulam-oq-03: Constructive (Intuitionistic) Borsuk-Ulam\n\n## Problem Summary\n\n**Open Question**: Can the 1D Borsuk-Ulam theorem be proved constructively\n(without full classical logic)? What is the constructive status of\nhigher-dimensional Borsuk-Ulam?\n\n**Status**: SURVEYED - 13 proved theorems, 1 axiom (general BU for n≥2), 0 sorries.\n\n**Answer**:\n- 1D: YES, proved via IVT on antisymmetric difference\n- n≥2: Requires algebraic topology (axiomized); no known constructive proof\n\n## Session 2026-02-25 (Session 1) - Initial Formalization\n\n**Mode**: FRESH (problem had EMPTY knowledge)\n**Outcome**: surveyed/progress\n\n### What I Did\n\n- Created `proofs/Proofs/BorsukUlamOQ03.lean` with full 1D formalization\n- Proved 13 theorems covering:\n  - 1D interval BU via IVT\n  - Odd function zero lemma\n  - BU ↔ odd-zero equivalence\n  - S¹ parametric version via IVT on [0,π]\n  - Circle point on unit circle\n  - No odd map to {±1}\n  - 5 structural lemmas\n  - NSphere def + antipodal def\n  - Consequence of general BU axiom\n- Fixed key Lean 4 issue: `f (--x)` is INVALID because `--` starts a line comment;\n  must write `f (-(-x))` or restructure to avoid double negative\n- Fixed `ring` issue: after `simp only [hg_def]`, `ring` fails on `f (-(-x))` atoms;\n  add `neg_neg` to simp first\n- `Continuous.prod_mk` may not be directly accessible as a field; use `fun_prop` instead\n- Created PR #3246\n\n### Key Findings\n\n- `f (--x)` is a SYNTAX BUG: `--` starts a line comment in Lean 4!\n  Workaround: Write `f (-(-x))` or avoid double-negated function args\n- `fun_prop` tactic handles complex continuity goals automatically with `hf : Continuous f`\n- IVT API: `intermediate_value_Icc hab hg_cont ⟨ha, hb⟩` where `ha : f a ≤ 0` and `hb : 0 ≤ f b`\n- `le_or_gt` is the non-deprecated name for case split (not `le_or_lt`)\n- Constructive content: IVT uses Classical.em internally, but Bishop-style IVT holds\n\n### Files Created\n\n- `proofs/Proofs/BorsukUlamOQ03.lean` (324 lines, 13 theorems, 1 axiom, 0 sorries)\n\n### Next Steps\n\n- The higher-dimensional BU (n≥2) could potentially be proved using Tucker's lemma (combinatorial BU)\n- Tucker's lemma is more constructive than degree-theoretic approaches\n- Would require: triangulation, labeling, Tucker path → antipodal pair\n"
+    "insights": [
+      "Only borsuk_ulam_general is actually USED by other theorems (no_equivariant_map_sphere, bu_no_injective_map). The other 4 axioms are declared for completeness but never referenced.",
+      "no_retraction could theoretically be derived from borsuk_ulam_general via degree theory, but Mathlib lacks this infrastructure",
+      "brouwer_fixed_point could be derived from no_retraction via the ray-sphere intersection construction (quadratic formula for ||f(x)+t(x-f(x))||²=1), but needs ~100 lines of continuity proofs",
+      "invariance_of_dimension for n>m case: restrict φ to S^{n-1}, embed into R^{n-1}, contradicts bu_no_injective_map. For n<m case: requires invariance of domain (Brouwer), which itself needs degree theory",
+      "Sub-OQ file sorry (sign_change_count_parity) is provable via product telescope: ∏(s(i)*s(i+1)) = s(0)*s(last) = -1 implies odd number of sign changes. Requires general parity lemma by induction on sequence length."
+    ],
+    "mathlibGaps": [
+      "Algebraic topology: Brouwer degree, homology groups, covering spaces",
+      "No retraction theorem infrastructure (ball-sphere topology)",
+      "Invariance of domain (Brouwer's theorem)"
+    ],
+    "nextSteps": [
+      "Prove sign_change_count_parity in BorsukUlamOQ03OQ01.lean (50-100 lines, product telescope + parity)",
+      "If Mathlib adds degree theory, derive no_retraction from borsuk_ulam_general",
+      "If Mathlib adds SDP infra, the brouwer_fixed_point from no_retraction via ray construction is algebraically feasible"
+    ]
   },
   "approaches": [],
   "tags": [


### PR DESCRIPTION
## Summary
- Fix meta.json axiom count for `borsuk-ulam-oq-03-oq-03`: 5 → 3 (matches actual Lean file)
- Update problem JSON for `borsuk-ulam-oq-03-oq-03` with survey findings (3 axioms, 65 theorems, 0 sorries)
- Update problem JSON for `borsuk-ulam-oq-03` with deep axiom analysis (5 axioms all blocked by missing Mathlib infrastructure)
- Document that `tucker_disk_approx_zero` is noted as derivable from `tuckers_lemma` + `complementary_edge_gives_approximate_zero`

## Test plan
- [ ] Verify meta.json axiom count matches Lean file
- [ ] Gallery renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)