### PR TITLE
Enrich desargues-theorem-oq-04: 12 annotations, 12 sections

### DIFF
--- a/src/data/proofs/desargues-theorem-oq-04/annotations.json
+++ b/src/data/proofs/desargues-theorem-oq-04/annotations.json
@@ -1,8 +1,22 @@
 [
   {
+    "id": "ann-cross3-def",
+    "proofId": "desargues-theorem-oq-04",
+    "range": { "startLine": 44, "endLine": 49 },
+    "type": "definition",
+    "title": "Cross Product in K³",
+    "content": "Defines the cross product `cross3 a b` for vectors in $K^3$ over an arbitrary `CommRing K`. This is the fundamental operation for both joining two points (to get the line through them) and meeting two lines (to get their intersection point) in homogeneous coordinates.",
+    "mathContext": "$(a \\times b)_i = \\begin{cases} a_1 b_2 - a_2 b_1 & i=0 \\\\ a_2 b_0 - a_0 b_2 & i=1 \\\\ a_0 b_1 - a_1 b_0 & i=2 \\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": ["cross product", "homogeneous coordinates", "join and meet"],
+    "prerequisites": ["CommRing", "Fin 3 → K"]
+  },
+  {
     "id": "ann-collinear-eq-concurrent",
-    "line": 93,
+    "proofId": "desargues-theorem-oq-04",
+    "range": { "startLine": 87, "endLine": 91 },
     "type": "theorem",
+    "title": "Collinear = Concurrent (by rfl)",
     "content": "The fundamental observation underlying projective duality: collinearity (det(p,q,r) = 0) and concurrence (det(l,m,n) = 0) are the SAME predicate in homogeneous coordinates. This is proved by `rfl` — they are definitionally identical.",
     "mathContext": "In homogeneous coordinates, both points and lines are elements of $K^3$. A point $p$ lies on a line $l$ iff $p \\cdot l = 0$. The collinearity of three points and concurrence of three lines are both expressed as $\\det(u,v,w) = 0$.",
     "significance": "critical",
@@ -10,9 +24,23 @@
     "prerequisites": ["threeVecMat", "Matrix.det"]
   },
   {
-    "id": "ann-dual-config",
-    "line": 126,
+    "id": "ann-config-structure",
+    "proofId": "desargues-theorem-oq-04",
+    "range": { "startLine": 97, "endLine": 116 },
     "type": "definition",
+    "title": "Desargues Configuration and Perspective Predicates",
+    "content": "Defines `DesarguesConfig` (two triangles ABC and A'B'C'), `perspFromPoint` (joining lines AA', BB', CC' are concurrent), and `perspFromLine` (intersection points P = AB∩A'B', Q = BC∩B'C', R = CA∩C'A' are collinear). These are the two conditions in Desargues's theorem.",
+    "mathContext": "Perspective from a point: $\\det(A \\times A', B \\times B', C \\times C') = 0$. Perspective from a line: $\\det((AB \\cap A'B'), (BC \\cap B'C'), (CA \\cap C'A')) = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Desargues configuration", "perspectivity", "projective triangles"],
+    "prerequisites": ["cross3", "collinear", "concurrent"]
+  },
+  {
+    "id": "ann-dual-config",
+    "proofId": "desargues-theorem-oq-04",
+    "range": { "startLine": 131, "endLine": 139 },
+    "type": "definition",
+    "title": "Dual Configuration",
     "content": "The dual configuration: vertices of the dual triangles are the sides (cross products) of the original triangles. If the original has vertices A,B,C and A',B',C', the dual has vertices AB, BC, CA and A'B', B'C', C'A'.",
     "mathContext": "Under projective duality, the sides of a triangle (lines through pairs of vertices) become the vertices of the dual triangle. The cross product $A \\times B$ gives the line through $A$ and $B$, which becomes a point in the dual.",
     "significance": "key",
@@ -21,8 +49,10 @@
   },
   {
     "id": "ann-dual-persp",
-    "line": 137,
+    "proofId": "desargues-theorem-oq-04",
+    "range": { "startLine": 141, "endLine": 146 },
     "type": "theorem",
+    "title": "Self-Duality: dual(perspFromPoint) = perspFromLine (by rfl)",
     "content": "The key self-duality result: 'perspective from a point' of the dual configuration equals 'perspective from a line' of the original, proved by `rfl`. The joining lines of the dual's vertex pairs are exactly the intersection points of the original's corresponding sides.",
     "mathContext": "If the dual's vertices are the sides of the original, then: $\\text{cross3}(\\text{dual}.A, \\text{dual}.A') = \\text{cross3}(A \\times B, A' \\times B')$ which is the intersection point $P = AB \\cap A'B'$. So the concurrent condition on the dual's joining lines IS the collinear condition on the original's intersection points.",
     "significance": "critical",
@@ -30,19 +60,47 @@
     "prerequisites": ["DesarguesConfig.dual", "perspFromPoint", "perspFromLine"]
   },
   {
-    "id": "ann-desargues-identity",
-    "line": 171,
+    "id": "ann-lagrange-cross",
+    "proofId": "desargues-theorem-oq-04",
+    "range": { "startLine": 154, "endLine": 169 },
     "type": "theorem",
+    "title": "Lagrange Cross Product Identity",
+    "content": "The Lagrange identity expresses the cross product of two cross products as a linear combination of the original vectors: $\\text{cross3}(a \\times b, c \\times d) = \\det(a,b,d) \\cdot c - \\det(a,b,c) \\cdot d$. This is the algebraic engine behind the Desargues identity, reducing the degree-9 polynomial to manageable factors.",
+    "mathContext": "$(a \\times b) \\times (c \\times d) = \\det(a,b,d) \\cdot c - \\det(a,b,c) \\cdot d$. Proved component-wise using `ring` after expanding via `cross3_zero/one/two` and `threeVecMat_det_explicit`.",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange identity", "vector triple product", "BAC-CAB rule"],
+    "prerequisites": ["cross3", "threeVecMat_det_explicit"]
+  },
+  {
+    "id": "ann-desargues-identity",
+    "proofId": "desargues-theorem-oq-04",
+    "range": { "startLine": 174, "endLine": 204 },
+    "type": "theorem",
+    "title": "The Desargues Identity",
     "content": "The Desargues identity: det(P,Q,R) = det(AA',BB',CC') · det(ABC) · det(A'B'C'). This algebraic identity over any CommRing K is the engine behind both the forward direction and the self-duality. The RHS is manifestly symmetric in the two triangles.",
-    "mathContext": "$$\\det(P,Q,R) = \\det(AA', BB', CC') \\cdot \\det(A,B,C) \\cdot \\det(A',B',C')$$\nwhere $P = AB \\cap A'B'$, $Q = BC \\cap B'C'$, $R = CA \\cap C'A'$. The proof uses the Lagrange cross product identity and degree-9 polynomial arithmetic.",
+    "mathContext": "$$\\det(P,Q,R) = \\det(AA', BB', CC') \\cdot \\det(A,B,C) \\cdot \\det(A',B',C')$$\nwhere $P = AB \\cap A'B'$, $Q = BC \\cap B'C'$, $R = CA \\cap C'A'$. The proof substitutes Lagrange identity results, reduces to a polynomial identity in 6 auxiliary determinants $d_1, \\ldots, d_6$.",
     "significance": "critical",
     "relatedConcepts": ["Desargues identity", "Lagrange identity", "polynomial identity"],
     "prerequisites": ["lagrange_cross", "threeVecMat_det_explicit"]
   },
   {
-    "id": "ann-persp-swap",
-    "line": 268,
+    "id": "ann-desargues-forward",
+    "proofId": "desargues-theorem-oq-04",
+    "range": { "startLine": 210, "endLine": 217 },
     "type": "theorem",
+    "title": "Forward Direction: perspFromPoint → perspFromLine",
+    "content": "Desargues's theorem (forward): perspective from a point implies perspective from a line, over any CommRing K. A one-line proof: substitute $\\det(AA',BB',CC') = 0$ into the Desargues identity to get $\\det(P,Q,R) = 0 \\cdot (\\det(ABC) \\cdot \\det(A'B'C')) = 0$.",
+    "mathContext": "$\\det(AA',BB',CC') = 0 \\implies \\det(P,Q,R) = 0 \\cdot \\det(ABC) \\cdot \\det(A'B'C') = 0$",
+    "significance": "critical",
+    "relatedConcepts": ["Desargues theorem", "projective geometry", "one-line proof"],
+    "prerequisites": ["desargues_identity", "perspFromPoint", "perspFromLine"]
+  },
+  {
+    "id": "ann-persp-swap",
+    "proofId": "desargues-theorem-oq-04",
+    "range": { "startLine": 267, "endLine": 275 },
+    "type": "theorem",
+    "title": "Perspectivity Symmetric Under Triangle Swap",
     "content": "Self-duality of perspectivity: if lines AA', BB', CC' are concurrent, so are the lines A'A, B'B, C'C (they are the same lines). Proved by showing the perspectivity determinant negates under swap (each row flips sign via cross product anticommutativity), so det = 0 is preserved.",
     "mathContext": "The perspectivity determinant satisfies $\\det(A'A, B'B, C'C) = -\\det(AA', BB', CC')$ because $A' \\times A = -(A \\times A')$ for each row. Since $\\det = 0 \\iff -\\det = 0$, concurrence is preserved under swap.",
     "significance": "key",
@@ -50,13 +108,39 @@
     "prerequisites": ["cross3_anticomm", "perspectivity_det_swap"]
   },
   {
-    "id": "ann-algebraic-converse",
-    "line": 322,
+    "id": "ann-perspFromLine-swap",
+    "proofId": "desargues-theorem-oq-04",
+    "range": { "startLine": 296, "endLine": 303 },
     "type": "theorem",
+    "title": "Line Perspective Symmetric Under Swap",
+    "content": "If intersection points P, Q, R are collinear, then the 'swapped' intersection points (computed as A'B'∩AB instead of AB∩A'B') are also collinear. Uses the same anticommutativity argument: each row of the collinearity matrix negates, giving $\\det' = -\\det$, preserving the zero condition.",
+    "mathContext": "$\\det((A'B' \\cap AB), (B'C' \\cap BC), (C'A' \\cap CA)) = -\\det((AB \\cap A'B'), (BC \\cap B'C'), (CA \\cap C'A'))$",
+    "significance": "supporting",
+    "relatedConcepts": ["collinearity", "anticommutativity", "swap symmetry"],
+    "prerequisites": ["collinearity_det_swap", "perspFromLine"]
+  },
+  {
+    "id": "ann-algebraic-converse",
+    "proofId": "desargues-theorem-oq-04",
+    "range": { "startLine": 333, "endLine": 343 },
+    "type": "theorem",
+    "title": "Algebraic Converse Over Integral Domains",
     "content": "The algebraic converse over integral domains: if both triangles are non-degenerate and in perspective from a line, then in perspective from a point. Uses the Desargues identity and zero-product property of integral domains.",
     "mathContext": "From $\\det(P,Q,R) = \\det(AA',BB',CC') \\cdot \\det(ABC) \\cdot \\det(A'B'C')$, if $\\det(P,Q,R) = 0$ and $\\det(ABC) \\cdot \\det(A'B'C') \\neq 0$, then $\\det(AA',BB',CC') = 0$ in an integral domain.",
     "significance": "key",
     "relatedConcepts": ["integral domain", "zero-product property", "non-degeneracy"],
     "prerequisites": ["desargues_identity", "IsDomain"]
+  },
+  {
+    "id": "ann-desargues-iff",
+    "proofId": "desargues-theorem-oq-04",
+    "range": { "startLine": 345, "endLine": 349 },
+    "type": "theorem",
+    "title": "Biconditional: perspFromPoint ↔ perspFromLine",
+    "content": "The full biconditional form of Desargues's theorem over integral domains: for non-degenerate triangles, perspective from a point if and only if perspective from a line. Combines the forward direction (which works over any CommRing) with the converse (which requires IsDomain and non-degeneracy).",
+    "mathContext": "For $\\det(ABC) \\cdot \\det(A'B'C') \\neq 0$: $\\text{perspFromPoint} \\iff \\text{perspFromLine}$",
+    "significance": "key",
+    "relatedConcepts": ["biconditional", "Desargues theorem", "non-degeneracy"],
+    "prerequisites": ["desargues_forward", "desargues_converse", "IsDomain"]
   }
 ]

--- a/src/data/proofs/desargues-theorem-oq-04/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Desargues%27s_theorem#Self-duality",
-    "date": "2026",
+    "date": "2026-03-12",
     "status": "complete",
     "proofRepoPath": "Proofs/DesarguesTheoremOQ04.lean",
     "tags": [
@@ -20,7 +20,7 @@
       "extension",
       "research"
     ],
-    "badge": "open",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -63,13 +63,15 @@
         "note": "Axiomatic analysis of Desargues's theorem and its role in geometry"
       }
     ],
-    "historicalContext": "Projective duality was systematically developed by Poncelet (1822) and Gergonne. The principle states that every theorem in projective geometry has a dual, obtained by interchanging 'point' and 'line'. Desargues's theorem is the premier example of a self-dual theorem: its dual is its own converse. This is why the theorem and its converse are sometimes stated as a single biconditional. Hilbert (1899) showed that Desargues's theorem is equivalent to the embeddability of a projective plane in 3-space."
+    "historicalContext": "Girard Desargues stated his theorem in the 1639 'Brouillon project,' but his cryptic notation delayed its recognition until rediscovery by Poncelet (1822). Projective duality — systematically developed by Poncelet and Gergonne in the 1820s — states that every theorem in projective geometry has a dual, obtained by interchanging 'point' and 'line'. Desargues's theorem is the premier example of a self-dual theorem: its dual is its own converse. Hilbert's 'Grundlagen der Geometrie' (1899) showed that Desargues's theorem characterizes Desarguesian planes (those embeddable in projective 3-space), establishing a deep connection between incidence geometry and coordinatization by division rings. Moulton's non-Desarguesian plane (1902) demonstrated that Desargues's theorem is genuinely independent of the other projective axioms in dimension 2.",
+    "dateAdded": "03/12/26"
   },
   "sections": [
     {
       "id": "setup",
       "title": "Cross Product and Determinant Setup",
       "summary": "Defines `cross3` (K³ cross product), `threeVecMat` (3×3 row matrix), and the explicit determinant expansion. All over an arbitrary `CommRing K`.",
+      "mathContext": "$\\det(u,v,w) = u_0(v_1 w_2 - v_2 w_1) - u_1(v_0 w_2 - v_2 w_0) + u_2(v_0 w_1 - v_1 w_0)$",
       "startLine": 37,
       "endLine": 72
     },
@@ -83,9 +85,10 @@
     {
       "id": "config",
       "title": "Projective Configuration",
-      "summary": "Defines `DesarguesConfig` (two triangles), `perspFromPoint` (joining lines concurrent), `perspFromLine` (intersection points collinear), and the `dual` and `swap` transformations.",
+      "summary": "Defines `DesarguesConfig` (two triangles), `perspFromPoint` (joining lines concurrent), `perspFromLine` (intersection points collinear), and the `swap` transformation.",
+      "mathContext": "`perspFromPoint`: $\\det(AA', BB', CC') = 0$. `perspFromLine`: $\\det(P, Q, R) = 0$ where $P = AB \\cap A'B'$.",
       "startLine": 95,
-      "endLine": 140
+      "endLine": 125
     },
     {
       "id": "dual-theorem",
@@ -103,24 +106,56 @@
     },
     {
       "id": "forward",
-      "title": "Forward Direction",
-      "summary": "Desargues's theorem: perspective from a point implies perspective from a line. One-line proof: substitute $\\det(AA',BB',CC') = 0$ into the identity.",
-      "startLine": 207,
-      "endLine": 216
+      "title": "Forward Direction and Dual Forward",
+      "summary": "Desargues's theorem: perspective from a point implies perspective from a line. One-line proof: substitute $\\det(AA',BB',CC') = 0$ into the identity. Also derives the dual forward direction: applying the theorem to `cfg.dual`.",
+      "mathContext": "$\\det(AA',BB',CC') = 0 \\implies \\det(P,Q,R) = 0 \\cdot \\det(ABC) \\cdot \\det(A'B'C') = 0$",
+      "startLine": 206,
+      "endLine": 233
     },
     {
       "id": "symmetry",
-      "title": "Symmetry Results",
-      "summary": "Proves the Desargues identity is symmetric under triangle swap, perspectivity determinant negates under swap (from cross product anticommutativity), and both perspective conditions are preserved under swap.",
+      "title": "Identity Symmetry and Point Perspective Swap",
+      "summary": "Proves the Desargues identity is symmetric under triangle swap (`desargues_identity_swap`), the perspectivity determinant negates under swap ($\\det' = -\\det$), and `perspFromPoint` is preserved under swap.",
+      "mathContext": "$\\det(A'A, B'B, C'C) = -\\det(AA', BB', CC')$ via cross product anticommutativity $a' \\times a = -(a \\times a')$.",
       "startLine": 218,
-      "endLine": 310
+      "endLine": 275
+    },
+    {
+      "id": "line-perspective-swap",
+      "title": "Self-Duality of Line Perspective",
+      "summary": "Proves collinearity determinant negates under swap ($\\det' = -\\det$) and that `perspFromLine` is preserved under triangle swap.",
+      "mathContext": "$\\det((A'B' \\cap AB), (B'C' \\cap BC), (C'A' \\cap CA)) = -\\det((AB \\cap A'B'), (BC \\cap B'C'), (CA \\cap C'A'))$",
+      "startLine": 277,
+      "endLine": 303
+    },
+    {
+      "id": "forward-swap",
+      "title": "Forward Direction for Swapped Configuration",
+      "summary": "Desargues's theorem for both orderings: the forward direction holds for both (A,B,C)→(A',B',C') and (A',B',C')→(A,B,C). The self-duality chain `desargues_forward_both_orders` packages both.",
+      "startLine": 305,
+      "endLine": 323
     },
     {
       "id": "algebraic-converse",
-      "title": "Algebraic Converse",
-      "summary": "Over integral domains with non-degenerate triangles ($\\det(ABC) \\cdot \\det(A'B'C') \\neq 0$), perspective from a line implies perspective from a point. Plus the biconditional form.",
-      "startLine": 312,
-      "endLine": 345
+      "title": "Algebraic Converse and Biconditional",
+      "summary": "Over integral domains with non-degenerate triangles ($\\det(ABC) \\cdot \\det(A'B'C') \\neq 0$), perspective from a line implies perspective from a point. Combines with the forward direction for the full biconditional `desargues_iff`.",
+      "mathContext": "$\\text{perspFromPoint} \\iff \\text{perspFromLine}$ when $\\det(ABC) \\cdot \\det(A'B'C') \\neq 0$ in an `IsDomain`.",
+      "startLine": 325,
+      "endLine": 349
+    },
+    {
+      "id": "structural",
+      "title": "Structural Properties",
+      "summary": "Double swap is identity (`swap_swap` by `rfl`) and non-degeneracy is swap-invariant (`nonDegeneracy_swap` by `ring`). These complete the algebraic self-duality picture.",
+      "startLine": 351,
+      "endLine": 362
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "summary": "Comprehensive summary of all 14 results across definitional duality (2 rfl proofs), algebraic duality (Desargues identity and its symmetry), forward/converse directions, and structural lemmas — all with 0 sorries.",
+      "startLine": 364,
+      "endLine": 415
     }
   ],
   "overview": {
@@ -132,7 +167,8 @@
       "**collinear = concurrent by rfl**: In homogeneous coordinates, both predicates are `(threeVecMat u v w).det = 0`. No proof needed — they are definitionally identical.",
       "**Dual's perspFromPoint = original's perspFromLine by rfl**: The joining lines of the dual configuration's vertex pairs are the intersection points of the original's corresponding sides. This is a definitional equality, not an algebraic computation.",
       "**The Desargues identity is symmetric**: det(P,Q,R) = det(AA',BB',CC') · det(ABC) · det(A'B'C') has the two triangle determinants as a commutative product, making the identity invariant under triangle swap.",
-      "**Anticommutativity gives neg, but det=0 is preserved**: Under swap, each cross product row negates, giving an overall factor of (-1)³ = -1 in the determinant. Since -0 = 0, the zero condition is preserved."
+      "**Anticommutativity gives neg, but det=0 is preserved**: Under swap, each cross product row negates, giving an overall factor of (-1)³ = -1 in the determinant. Since -0 = 0, the zero condition is preserved.",
+      "**Integral domains give the converse**: The forward direction works over any CommRing, but the converse requires IsDomain to apply the zero-product property. Over rings with zero divisors, non-degenerate triangles can be in perspective from a line without being in perspective from a point."
     ],
     "prerequisites": [
       "Projective geometry basics",


### PR DESCRIPTION
## Summary
- Convert 6 annotations from old `line` format to `range: {startLine, endLine}` format, add `proofId` and `title` fields
- Add 6 new annotations: cross3 definition, config structure, Lagrange cross identity, forward direction, perspFromLine_swap, biconditional
- Expand from 8 to 12 sections covering full 416-line file (added Parts 9-13: line perspective swap, forward swap, algebraic converse + biconditional, structural properties, summary)
- Fix section overlaps (config vs dual-theorem, symmetry vs line-perspective-swap)
- Deepen historicalContext: Desargues 1639, Moulton non-Desarguesian plane 1902
- Add 5th keyInsight on integral domain requirement for converse
- Fix badge: open → verified (0 sorries), add dateAdded

## Test plan
- [x] `pnpm annotations:build` passes with 0 warnings for this target

🤖 Generated with [Claude Code](https://claude.com/claude-code)