### PR TITLE
Enrich erdos-138: references, prerequisites, mathContext

### DIFF
--- a/src/data/proofs/erdos-138/annotations.json
+++ b/src/data/proofs/erdos-138/annotations.json
@@ -15,7 +15,8 @@
       "van der Waerden's theorem",
       "Ramsey theory",
       "arithmetic progressions"
-    ]
+    ],
+    "prerequisites": ["van der Waerden's theorem", "Finset.Icc", "arithmetic progressions"]
   },
   {
     "id": "ann-coloring-def",
@@ -33,7 +34,8 @@
       "proper coloring",
       "hypergraph coloring",
       "Finset"
-    ]
+    ],
+    "prerequisites": ["Finset.Icc", "Fin"]
   },
   {
     "id": "ann-monochromatic-ap",
@@ -51,7 +53,8 @@
       "arithmetic progression",
       "Szemerédi's theorem",
       "density conditions"
-    ]
+    ],
+    "prerequisites": ["Coloring", "Fin", "Finset.Icc"]
   },
   {
     "id": "ann-vdw-theorem",
@@ -69,7 +72,8 @@
       "Ramsey theory",
       "compactness argument",
       "finite unions theorem"
-    ]
+    ],
+    "prerequisites": ["Coloring", "HasMonochromaticAP"]
   },
   {
     "id": "ann-guarantee-set",
@@ -87,7 +91,8 @@
       "threshold function",
       "upward closed set",
       "infimum"
-    ]
+    ],
+    "prerequisites": ["Coloring", "HasMonochromaticAP", "van_der_waerden_theorem"]
   },
   {
     "id": "ann-vdw-number",
@@ -105,7 +110,8 @@
       "Ramsey number",
       "threshold function",
       "extremal combinatorics"
-    ]
+    ],
+    "prerequisites": ["GuaranteeSet", "Nat.sInf"]
   },
   {
     "id": "ann-berlekamp",
@@ -123,7 +129,8 @@
       "discrete logarithm",
       "finite field",
       "multiplicative group"
-    ]
+    ],
+    "prerequisites": ["W", "Nat.Prime"]
   },
   {
     "id": "ann-gowers",
@@ -141,7 +148,8 @@
       "tower function",
       "Szemerédi's theorem",
       "Gowers uniformity norms"
-    ]
+    ],
+    "prerequisites": ["W"]
   },
   {
     "id": "ann-kozik-shabanov",
@@ -159,7 +167,8 @@
       "Lovász Local Lemma",
       "probabilistic method",
       "hypergraph coloring"
-    ]
+    ],
+    "prerequisites": ["W"]
   },
   {
     "id": "ann-small-values",
@@ -177,7 +186,8 @@
       "SAT solving",
       "exhaustive search",
       "computational complexity"
-    ]
+    ],
+    "prerequisites": ["W"]
   },
   {
     "id": "ann-main-conjecture",
@@ -195,7 +205,8 @@
       "growth rate",
       "exponential growth",
       "Filter.Tendsto"
-    ]
+    ],
+    "prerequisites": ["W", "Filter.Tendsto", "Filter.atTop"]
   },
   {
     "id": "ann-related-questions",
@@ -213,7 +224,8 @@
       "growth comparison",
       "consecutive ratios",
       "divergence"
-    ]
+    ],
+    "prerequisites": ["W", "Filter.Tendsto", "Erdos138Conjecture"]
   },
   {
     "id": "ann-implication",
@@ -231,7 +243,8 @@
       "limit comparison",
       "growth rate hierarchy",
       "contrapositive"
-    ]
+    ],
+    "prerequisites": ["Erdos138Conjecture", "ExponentialDiverges", "Filter.Tendsto"]
   },
   {
     "id": "ann-summary",
@@ -249,6 +262,7 @@
       "open problem",
       "research frontier",
       "Erdős prize"
-    ]
+    ],
+    "prerequisites": ["all definitions and bounds above"]
   }
 ]

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -16,6 +16,56 @@
       "van-der-waerden",
       "arithmetic-progressions"
     ],
+    "dateAdded": "03/12/26",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sInf",
+        "description": "Infimum on natural numbers, used to define W(k) as minimum of the guarantee set",
+        "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      },
+      {
+        "theorem": "Filter.Tendsto",
+        "description": "Filter-based limit for stating the main conjecture and related divergence",
+        "module": "Mathlib.Order.Filter.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Formalization of van der Waerden numbers via GuaranteeSet and sInf",
+      "Axiomatized Berlekamp, Gowers, and Kozik-Shabanov bounds",
+      "Filter.Tendsto formulation of Erdős's growth rate conjecture",
+      "Hierarchy of related growth rate conjectures (quotient, difference, exponential)",
+      "Proof schema: main conjecture implies ExponentialDiverges"
+    ],
+    "references": [
+      {
+        "authors": "Bartel L. van der Waerden",
+        "title": "Beweis einer Baudetschen Vermutung",
+        "year": "1927",
+        "venue": "Nieuw Archief voor Wiskunde",
+        "note": "Original proof of the van der Waerden theorem"
+      },
+      {
+        "authors": "Elwyn R. Berlekamp",
+        "title": "A construction for partitions which avoid long arithmetic progressions",
+        "year": "1968",
+        "venue": "Canadian Mathematical Bulletin",
+        "note": "Finite field construction giving W(p+1) ≥ p·2^p for primes p"
+      },
+      {
+        "authors": "W. Timothy Gowers",
+        "title": "A new proof of Szemerédi's theorem",
+        "year": "2001",
+        "venue": "Geometric and Functional Analysis",
+        "note": "Analytic proof yielding tower-of-height-5 upper bound"
+      },
+      {
+        "authors": "Jakub Kozik, Dmitry Shabanov",
+        "title": "Improved algorithms for colorings of simple hypergraphs and applications",
+        "year": "2016",
+        "venue": "Journal of Combinatorial Theory, Series B",
+        "note": "Best general lower bound W(k) ≫ 2^k via Lovász Local Lemma"
+      }
+    ],
     "badge": "wip",
     "sorries": 5,
     "erdosNumber": 138,
@@ -24,14 +74,15 @@
     "erdosPrizeValue": "$500"
   },
   "overview": {
-    "historicalContext": "Van der Waerden's theorem (1927) guarantees that for any k ≥ 1, there exists N such that any 2-coloring of {1,...,N} contains a monochromatic k-term arithmetic progression. The van der Waerden number W(k) is the minimum such N. Erdős posed this problem in 1980, asking whether W(k) grows faster than any exponential function. The problem connects to fundamental questions in Ramsey theory about the tradeoff between chromatic complexity and arithmetic structure.",
+    "historicalContext": "Van der Waerden proved his theorem in 1927, answering a conjecture of Baudet. The original proof gave Ackermann-type bounds on W(k). Berlekamp (1968) gave the first strong lower bounds using finite field constructions: coloring integers by discrete logarithm mod p avoids long APs. Shelah (1988) obtained the first primitive recursive upper bound, and Gowers (2001) dramatically improved it to tower-of-height-5 using his uniformity norms, winning a Fields Medal partly for this work. Kozik and Shabanov (2016) established the current best general lower bound W(k) ≫ 2^k via the Lovász Local Lemma. Erdős posed this problem in 1980 with a $500 prize, asking whether W(k) grows faster than any exponential — the vast gap between known bounds remains one of the central open problems in Ramsey theory.",
     "problemStatement": "Does W(k)^{1/k} → ∞ as k → ∞? Equivalently, do the van der Waerden numbers grow faster than any exponential c^k?",
     "proofStrategy": "The formalization defines van der Waerden numbers using Mathlib's Finset infrastructure. Known bounds are axiomatized: Berlekamp's lower bound W(p+1) ≥ p·2^p for primes p, Gowers' tower-type upper bound from his Szemerédi proof, and the Kozik-Shabanov general lower bound W(k) ≫ 2^k. The main conjecture is stated using Filter.Tendsto. Related questions from Erdős (1980-1981) about W(k+1)/W(k), W(k+1)-W(k), and W(k)/2^k are also formalized.",
     "keyInsights": [
       "The gap between exponential lower bounds and tower-type upper bounds remains vast",
       "Berlekamp's 1968 construction using finite field techniques gives strong lower bounds at prime values",
       "Gowers' 2001 analytic proof of Szemerédi's theorem yields the current best upper bound",
-      "The main conjecture W(k)^{1/k} → ∞ would imply W(k)/2^k → ∞ but is strictly stronger"
+      "The main conjecture W(k)^{1/k} → ∞ would imply W(k)/2^k → ∞ but is strictly stronger",
+      "The formalization uses Filter.Tendsto to express divergence, which is the standard Mathlib idiom and enables compositional limit arguments"
     ]
   },
   "sections": [
@@ -40,35 +91,40 @@
       "title": "Van der Waerden Numbers",
       "startLine": 36,
       "endLine": 67,
-      "summary": "Core definitions: colorings, monochromatic arithmetic progressions, and the van der Waerden function W(k)"
+      "summary": "Core definitions: colorings, monochromatic arithmetic progressions, and the van der Waerden function W(k)",
+      "mathContext": "$W(r,k) = \\inf\\{N : \\forall c : \\{1,\\ldots,N\\} \\to [r],\\; \\exists \\text{ mono } k\\text{-AP}\\}$"
     },
     {
       "id": "known-bounds",
       "title": "Known Bounds",
       "startLine": 69,
       "endLine": 85,
-      "summary": "Axiomatized bounds: Berlekamp (1968), Gowers (2001), Kozik-Shabanov (2016)"
+      "summary": "Axiomatized bounds: Berlekamp (1968), Gowers (2001), Kozik-Shabanov (2016)",
+      "mathContext": "$p \\cdot 2^p \\leq W(p+1)$ for prime $p$; $W(k) \\leq 2^{2^{2^{2^{2^{k+9}}}}}$; $W(k) \\geq c \\cdot 2^k$"
     },
     {
       "id": "small-values",
       "title": "Computed Values",
       "startLine": 87,
       "endLine": 107,
-      "summary": "Known exact values: W(3)=9, W(4)=35, W(5)=178, W(6)=1132"
+      "summary": "Known exact values: W(3)=9, W(4)=35, W(5)=178, W(6)=1132",
+      "mathContext": "$W(3)=9$, $W(4)=35$, $W(5)=178$, $W(6)=1132$. Growth ratios: $3.9\\times$, $5.1\\times$, $6.4\\times$."
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture",
       "startLine": 109,
       "endLine": 118,
-      "summary": "Erdős Problem #138: Does W(k)^{1/k} → ∞?"
+      "summary": "Erdős Problem #138: Does W(k)^{1/k} → ∞?",
+      "mathContext": "$\\lim_{k \\to \\infty} W(k)^{1/k} = \\infty$ via `Filter.Tendsto atTop atTop`"
     },
     {
       "id": "related-questions",
-      "title": "Related Questions",
+      "title": "Related Questions and Implications",
       "startLine": 120,
       "endLine": 146,
-      "summary": "Additional questions from Erdős (1980-1981) about growth rates"
+      "summary": "Additional questions from Erdős (1980-1981) about growth rates, plus the implication chain: main conjecture → ExponentialDiverges",
+      "mathContext": "$W(k)^{1/k} \\to \\infty \\implies W(k)/2^k \\to \\infty \\implies W(k+1)/W(k) \\to \\infty$"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Add `prerequisites` field to all 13 annotations
- Add 4 academic references (van der Waerden 1927, Berlekamp 1968, Gowers 2001, Kozik-Shabanov 2016)
- Add `mathlibDependencies` (Nat.sInf, Filter.Tendsto), `originalContributions` (5 items)
- Add `mathContext` to all 5 sections with LaTeX formulas
- Deepen `historicalContext`: Baudet conjecture, Shelah primitive recursive bound, Gowers Fields Medal
- Add 5th `keyInsight` on Filter.Tendsto formalization idiom
- Add `dateAdded`

## Test plan
- [x] `pnpm annotations:build` passes with 0 warnings for this target

🤖 Generated with [Claude Code](https://claude.com/claude-code)