### PR TITLE
Enrich erdos-281: fix types, add references, correct sections

### DIFF
--- a/src/data/proofs/erdos-281/annotations.json
+++ b/src/data/proofs/erdos-281/annotations.json
@@ -2,13 +2,14 @@
   {
     "id": "erdos-281-header",
     "proofId": "erdos-281",
-    "type": "context",
+    "type": "concept",
     "range": { "startLine": 1, "endLine": 23 },
     "title": "Problem Overview",
     "content": "Erdős Problem 281 asks: if a sequence of moduli has the 'full covering' property (any choice of congruence classes covers almost all integers), must there be a uniform finite approximation? Proved affirmatively via Davenport–Erdős and Rogers.",
     "mathContext": "The problem bridges covering systems (combinatorial number theory) and measure-theoretic uniformity. The key upgrade is from 'pointwise for each choice, density → 0' to 'uniformly in the choice, finitely many classes suffice for density < ε'. This is a compactness/uniformity principle.",
-    "significance": "essential",
-    "relatedConcepts": ["covering-systems", "density", "uniformity"]
+    "significance": "critical",
+    "relatedConcepts": ["covering systems", "density", "uniformity"],
+    "prerequisites": ["congruence classes", "natural density"]
   },
   {
     "id": "erdos-281-congruence-choice",
@@ -17,9 +18,10 @@
     "range": { "startLine": 35, "endLine": 46 },
     "title": "Congruence Classes and Coverage",
     "content": "**`CongruenceChoice moduli`** assigns each index i a residue aᵢ mod nᵢ. **`IsCovered`** checks if m ≡ aᵢ (mod nᵢ). **`IsCoveredByFirst k`** checks coverage by the first k classes.",
-    "mathContext": "A covering system uses congruence classes a₁ (mod n₁), ..., aₖ (mod nₖ) to cover the integers. The question is whether 'almost-covering' (density 0 uncovered) can always be achieved uniformly with finitely many classes.",
-    "significance": "essential",
-    "relatedConcepts": ["congruence-classes", "covering-systems", "CRT"]
+    "mathContext": "A covering system uses congruence classes $a_1 \\pmod{n_1}, \\ldots, a_k \\pmod{n_k}$ to cover the integers. The question is whether 'almost-covering' (density 0 uncovered) can always be achieved uniformly with finitely many classes.",
+    "significance": "key",
+    "relatedConcepts": ["congruence classes", "covering systems", "CRT"],
+    "prerequisites": ["Fin", "Int.emod"]
   },
   {
     "id": "erdos-281-counting",
@@ -28,62 +30,93 @@
     "range": { "startLine": 50, "endLine": 59 },
     "title": "Uncovered Count and Density",
     "content": "**`uncoveredCount`** counts integers in [1,N] not covered by the first k classes. **`uncoveredDensity`** normalizes by N. These measure how well finite approximations perform.",
-    "significance": "supporting",
-    "relatedConcepts": ["counting", "density", "approximation"]
+    "mathContext": "$\\text{uncoveredDensity}(k,N) = \\frac{|\\{m \\in [1,N] : m \\notin \\bigcup_{i<k} a_i \\pmod{n_i}\\}|}{N}$",
+    "significance": "key",
+    "relatedConcepts": ["counting", "natural density", "approximation"],
+    "prerequisites": ["Finset.Icc", "Finset.filter", "CongruenceChoice"]
   },
   {
     "id": "erdos-281-infrastructure",
     "proofId": "erdos-281",
-    "type": "result",
+    "type": "theorem",
     "range": { "startLine": 63, "endLine": 131 },
     "title": "Proved Infrastructure Lemmas (12 Lemmas)",
-    "content": "Twelve lemmas proved constructively by Lean: coverage monotonicity in k, zero classes cover nothing, uncovered count is antitone, trivial upper bound N, zero-class count = N, density ≤ 1, density ≥ 0, density antitone, plus structural results on strictly increasing and valid moduli.",
-    "mathContext": "These form the verified foundation. Key results: `isCoveredByFirst_mono` (more classes cover more), `uncoveredDensity_antitone` (density decreases with more classes), and `uniform_implies_full` (the easy direction of the equivalence).",
-    "significance": "essential",
-    "relatedConcepts": ["verified-lemmas", "monotonicity", "infrastructure"]
+    "content": "Twelve lemmas proved constructively: coverage monotonicity in k, zero classes cover nothing, uncovered count is antitone, trivial upper bound N, zero-class count = N, density ≤ 1, density ≥ 0, density antitone, plus structural results on strictly increasing and valid moduli.",
+    "mathContext": "Key results: `isCoveredByFirst_mono` ($k_1 \\leq k_2 \\implies$ more coverage), `uncoveredDensity_antitone` (density decreases with more classes), density bounded in $[0,1]$. All proved without sorry.",
+    "significance": "key",
+    "relatedConcepts": ["verified lemmas", "monotonicity", "infrastructure"],
+    "prerequisites": ["uncoveredCount", "uncoveredDensity", "IsCoveredByFirst"]
   },
   {
     "id": "erdos-281-full-covering",
     "proofId": "erdos-281",
     "type": "definition",
-    "range": { "startLine": 133, "endLine": 152 },
+    "range": { "startLine": 137, "endLine": 152 },
     "title": "Full Covering and Structural Predicates",
     "content": "**`HasFullCovering`**: for every choice, uncovered density → 0 as N → ∞. Supporting predicates: **`IsStrictlyIncreasing`**, **`ModuliValid`** (all ≥ 2), **`PairwiseCoprime`**.",
-    "mathContext": "Full covering is the hypothesis of the problem. The structural predicates ensure the moduli form a sensible sequence: strictly increasing (no repeated moduli), all at least 2 (non-trivial), with the coprime case as a special case.",
-    "significance": "essential",
-    "relatedConcepts": ["full-covering", "hypothesis", "structural-conditions"]
+    "mathContext": "$\\text{HasFullCovering}: \\forall \\text{choice},\\; \\forall \\varepsilon > 0,\\; \\exists N_0,\\; \\forall N \\geq N_0,\\; \\text{density} < \\varepsilon$",
+    "significance": "critical",
+    "relatedConcepts": ["full covering", "hypothesis", "structural conditions"],
+    "prerequisites": ["uncoveredDensity", "CongruenceChoice"]
   },
   {
     "id": "erdos-281-easy-direction",
     "proofId": "erdos-281",
-    "type": "result",
-    "range": { "startLine": 156, "endLine": 186 },
+    "type": "theorem",
+    "range": { "startLine": 173, "endLine": 186 },
     "title": "Easy Direction: Uniform → Full (Proved)",
     "content": "**`uniform_implies_full`**: If finitely many classes suffice uniformly, then full covering holds. This trivial direction is proved constructively using density antitone in k. The proof uses `uncoveredDensity_antitone` and `max` to handle the quantifier swap.",
-    "mathContext": "The easy direction: if ∀ε, ∃k, ∀choice, density < ε, then certainly ∀choice, ∀ε, ∃k, density < ε. The hard direction (Erdős 281) is the converse: the pointwise condition upgrades to uniform.",
-    "significance": "essential",
-    "relatedConcepts": ["easy-direction", "quantifier-swap", "proved"]
+    "mathContext": "The easy direction: if $\\forall\\varepsilon,\\; \\exists k,\\; \\forall\\text{choice},\\; \\text{density} < \\varepsilon$, then certainly $\\forall\\text{choice},\\; \\forall\\varepsilon,\\; \\exists k,\\; \\text{density} < \\varepsilon$. The hard direction (Erdős 281) is the converse.",
+    "significance": "key",
+    "relatedConcepts": ["easy direction", "quantifier swap", "proved"],
+    "prerequisites": ["HasUniformFiniteCoverage", "HasFullCovering", "uncoveredDensity_antitone"]
   },
   {
     "id": "erdos-281-divergence",
     "proofId": "erdos-281",
-    "type": "result",
+    "type": "theorem",
     "range": { "startLine": 217, "endLine": 230 },
     "title": "Divergence and Coprime Results",
     "content": "Full covering implies Σ 1/nᵢ = ∞ (necessary condition). When moduli are pairwise coprime, divergence is also sufficient (by CRT independence).",
-    "mathContext": "The divergence Σ 1/nᵢ = ∞ is necessary because if the sum converges, a probabilistic argument shows some choice leaves positive density uncovered. The coprime case reduces to independent events via the Chinese Remainder Theorem.",
-    "significance": "essential",
-    "relatedConcepts": ["divergence", "CRT", "probabilistic-argument"]
+    "mathContext": "Divergence $\\sum 1/n_i = \\infty$ is necessary because if the sum converges, a probabilistic argument shows some choice leaves positive density uncovered. The coprime case reduces to independent events via CRT.",
+    "significance": "critical",
+    "relatedConcepts": ["divergence", "CRT", "probabilistic argument"],
+    "prerequisites": ["HasFullCovering", "ModuliValid", "PairwiseCoprime", "Nat.Coprime"]
   },
   {
     "id": "erdos-281-main",
     "proofId": "erdos-281",
-    "type": "result",
-    "range": { "startLine": 233, "endLine": 263 },
-    "title": "Erdős Problem 281 (Proved) and Equivalence",
-    "content": "**Main theorem**: Full covering ↔ uniform finite coverage (for valid strictly increasing moduli). The hard direction uses Davenport–Erdős (lower density = upper density for multiplicative functions) and Rogers' theorem. The equivalence `full_covering_iff_uniform` combines both directions.",
-    "mathContext": "The proof shows that the function 'uncovered density at level k' is uniformly Cauchy over all choices. The Davenport–Erdős theorem provides the regularity needed to upgrade pointwise convergence to uniform convergence — a compactness argument in the space of congruence choices.",
-    "significance": "essential",
-    "relatedConcepts": ["davenport-erdos", "rogers", "equivalence", "compactness"]
+    "type": "definition",
+    "range": { "startLine": 241, "endLine": 243 },
+    "title": "Erdős Problem 281 Statement",
+    "content": "The formal statement of Erdős Problem 281: for valid strictly increasing moduli, full covering implies uniform finite coverage. Defined as a Prop to be proved.",
+    "mathContext": "`ErdosProblem281 moduli`: $\\text{ModuliValid} \\to \\text{IsStrictlyIncreasing} \\to \\text{HasFullCovering} \\to \\text{HasUniformFiniteCoverage}$",
+    "significance": "critical",
+    "relatedConcepts": ["Erdős problem", "covering systems", "main conjecture"],
+    "prerequisites": ["HasFullCovering", "HasUniformFiniteCoverage", "ModuliValid", "IsStrictlyIncreasing"]
+  },
+  {
+    "id": "erdos-281-proved",
+    "proofId": "erdos-281",
+    "type": "concept",
+    "range": { "startLine": 245, "endLine": 252 },
+    "title": "Problem 281 Resolved (Axiomatized)",
+    "content": "The result holds: axiomatized as `erdos_281_proved`. The proof uses the Davenport–Erdős theorem (lower density = upper density for multiplicative functions) and Rogers' theorem from Halberstam–Roth to upgrade pointwise convergence to uniform convergence.",
+    "mathContext": "The Davenport–Erdős theorem provides the regularity needed: for sets defined by congruence conditions, upper and lower density coincide. Rogers' theorem then maximizes over all choices to extract a uniform bound.",
+    "significance": "critical",
+    "relatedConcepts": ["Davenport–Erdős theorem", "Rogers' theorem", "compactness"],
+    "prerequisites": ["ErdosProblem281", "HasFullCovering"]
+  },
+  {
+    "id": "erdos-281-equivalence",
+    "proofId": "erdos-281",
+    "type": "theorem",
+    "range": { "startLine": 259, "endLine": 262 },
+    "title": "Full Covering ↔ Uniform Finite Coverage",
+    "content": "The biconditional form: for valid strictly increasing moduli, full covering is equivalent to uniform finite coverage. Forward direction is Erdős #281 (hard, axiomatized). Backward direction is `uniform_implies_full` (easy, proved).",
+    "mathContext": "$\\text{HasFullCovering} \\iff \\text{HasUniformFiniteCoverage}$ for valid strictly increasing moduli.",
+    "significance": "critical",
+    "relatedConcepts": ["biconditional", "equivalence", "main result"],
+    "prerequisites": ["erdos_281_proved", "uniform_implies_full"]
   }
 ]

--- a/src/data/proofs/erdos-281/meta.json
+++ b/src/data/proofs/erdos-281/meta.json
@@ -19,61 +19,112 @@
     "sorries": 0,
     "erdosNumber": 281,
     "erdosUrl": "https://erdosproblems.com/281",
-    "erdosProblemStatus": "proved"
+    "erdosProblemStatus": "proved",
+    "date": "2026-03-12",
+    "dateAdded": "03/12/26",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_filter_le",
+        "description": "Card of filtered subset ≤ card of original, used for uncoveredCount upper bound",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "div_le_one",
+        "description": "Division bound for density ≤ 1 proof",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Formalization of covering systems via CongruenceChoice and IsCoveredByFirst",
+      "12 infrastructure lemmas proved constructively (monotonicity, antitonicity, bounds)",
+      "Easy direction (uniform → full) proved via uncoveredDensity_antitone",
+      "Axiomatization of Davenport–Erdős and Rogers theorems for the hard direction",
+      "Biconditional equivalence combining both directions"
+    ],
+    "references": [
+      {
+        "authors": "Paul Erdős",
+        "title": "Problems and results on combinatorial number theory III",
+        "year": "1980",
+        "venue": "Number Theory Day",
+        "note": "Original problem statement"
+      },
+      {
+        "authors": "Harold Davenport, Paul Erdős",
+        "title": "On sequences of positive integers",
+        "year": "1951",
+        "venue": "Acta Arithmetica",
+        "note": "Lower density = upper density for sets defined by divisibility conditions"
+      },
+      {
+        "authors": "Heini Halberstam, Klaus Roth",
+        "title": "Sequences",
+        "year": "1966",
+        "venue": "Oxford University Press",
+        "note": "Contains Rogers' theorem used in the uniformization step"
+      }
+    ]
   },
   "overview": {
-    "historicalContext": "Erdős asked whether the full-covering condition (every congruence class choice leaves a density-0 complement) automatically gives uniform finite approximation. The problem was resolved affirmatively using the Davenport–Erdős theorem on lower density and Rogers' theorem from Halberstam–Roth.",
+    "historicalContext": "Covering systems were introduced by Erdős in the 1950s. A covering system of congruences is a finite set of residue classes whose union is all integers; Erdős conjectured (and it was proved by Hough in 2015) that no covering system exists with all moduli distinct and greater than any given bound. Problem 281 is a density-theoretic variant: Erdős asked in 1980 whether the full-covering condition (every choice of congruence classes leaves density-0 uncovered) automatically gives *uniform* finite approximation. The affirmative resolution uses the Davenport–Erdős theorem (1951) — that upper and lower density coincide for divisibility-defined sets — and Rogers' maximization theorem from Halberstam–Roth's 'Sequences' (1966).",
     "problemStatement": "Let n₁ < n₂ < ⋯ be such that for any choice of classes aᵢ (mod nᵢ), the uncovered integers have density 0. Must there exist, for every ε > 0, a finite k achieving density < ε uniformly over all choices?",
     "proofStrategy": "The formalization defines congruence class assignments, coverage, and uncovered density. It axiomatises the divergence of reciprocals, the coprime special case, and the main theorem that full covering implies uniform finite approximation.",
     "keyInsights": [
       "Full covering implies Σ 1/nᵢ = ∞",
       "For pairwise coprime moduli, divergent reciprocals suffice",
       "The Davenport–Erdős theorem upgrades upper density 0 to a uniform finite bound",
-      "Rogers' theorem provides the maximization step"
+      "Rogers' theorem provides the maximization step",
+      "12 infrastructure lemmas are proved constructively, forming a verified foundation independent of the axiomatized main theorem"
     ]
   },
   "sections": [
     {
-      "id": "congruence-classes",
-      "title": "Congruence Classes and Coverage",
-      "startLine": 24,
-      "endLine": 40,
-      "summary": "Definitions of congruence choices, coverage, and coverage by the first k classes."
+      "id": "core-definitions",
+      "title": "Core Definitions",
+      "startLine": 33,
+      "endLine": 59,
+      "summary": "Defines `CongruenceChoice`, `IsCovered`, `IsCoveredByFirst`, `uncoveredCount`, and `uncoveredDensity`.",
+      "mathContext": "$\\text{uncoveredDensity}(k,N) = \\frac{|\\{m \\in [1,N] : m \\notin \\bigcup_{i<k} a_i \\pmod{n_i}\\}|}{N}$"
     },
     {
-      "id": "uncovered-density",
-      "title": "Counting Uncovered Integers",
-      "startLine": 42,
-      "endLine": 52,
-      "summary": "Count and density of integers not covered by the first k congruence classes."
+      "id": "infrastructure-lemmas",
+      "title": "Proven Infrastructure Lemmas",
+      "startLine": 61,
+      "endLine": 131,
+      "summary": "12 lemmas proved constructively: coverage monotonicity, uncovered count antitonicity, density bounds in $[0,1]$, structural properties of valid/increasing moduli.",
+      "mathContext": "$k_1 \\leq k_2 \\implies \\text{uncoveredDensity}(k_2, N) \\leq \\text{uncoveredDensity}(k_1, N) \\leq 1$"
     },
     {
       "id": "full-covering",
-      "title": "Full Covering Hypothesis",
-      "startLine": 54,
-      "endLine": 66,
-      "summary": "The sequence has full covering: every choice leaves density 0 uncovered. Auxiliary properties of valid moduli."
+      "title": "Full Covering and Structural Predicates",
+      "startLine": 133,
+      "endLine": 152,
+      "summary": "Defines `HasFullCovering`, `IsStrictlyIncreasing`, `ModuliValid`, `PairwiseCoprime`.",
+      "mathContext": "$\\text{HasFullCovering}: \\forall \\text{choice},\\; \\forall \\varepsilon > 0,\\; \\exists N_0,\\; \\forall N \\geq N_0,\\; \\text{density} < \\varepsilon$"
     },
     {
-      "id": "divergence",
-      "title": "Divergence of Reciprocals",
-      "startLine": 68,
-      "endLine": 73,
-      "summary": "Full covering implies Σ 1/nᵢ = ∞."
+      "id": "easy-direction",
+      "title": "Easy Direction (Proved)",
+      "startLine": 154,
+      "endLine": 213,
+      "summary": "Proves `uniform_implies_full` constructively and structural lemmas on moduli growth bounds. The easy direction: uniform → full via quantifier swap and density antitonicity.",
+      "mathContext": "$\\forall\\varepsilon,\\; \\exists k,\\; \\forall\\text{choice}: \\text{density} < \\varepsilon \\implies \\forall\\text{choice},\\; \\forall\\varepsilon: \\text{density} \\to 0$"
     },
     {
-      "id": "coprime-case",
-      "title": "Pairwise Coprime Case",
-      "startLine": 75,
-      "endLine": 86,
-      "summary": "When moduli are pairwise coprime, divergent reciprocals suffice for full covering."
+      "id": "divergence-coprime",
+      "title": "Divergence and Coprime Results",
+      "startLine": 215,
+      "endLine": 230,
+      "summary": "Full covering implies $\\sum 1/n_i = \\infty$. When moduli are pairwise coprime, divergence is also sufficient (by CRT).",
+      "mathContext": "$\\text{HasFullCovering} \\implies \\sum_{i} 1/n_i = \\infty$; coprime + divergence $\\implies$ full covering"
     },
     {
       "id": "main-theorem",
-      "title": "Main Theorem (Solved)",
-      "startLine": 88,
-      "endLine": 102,
-      "summary": "Erdős Problem 281: full covering implies uniform finite approximation, proved via Davenport–Erdős and Rogers."
+      "title": "Main Theorem and Equivalence",
+      "startLine": 232,
+      "endLine": 263,
+      "summary": "Erdős Problem 281 statement and axiomatized proof. The biconditional `full_covering_iff_uniform` combines hard (axiom) and easy (proved) directions.",
+      "mathContext": "$\\text{HasFullCovering} \\iff \\text{HasUniformFiniteCoverage}$ for valid strictly increasing moduli"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Fix invalid annotation types: `context` → `concept`, `result` → `theorem`/`definition`
- Fix invalid significance values: `essential` → `critical`/`key`/`supporting`
- Add `prerequisites` to all 10 annotations
- Add 3 academic references (Erdős 1980, Davenport-Erdős 1951, Halberstam-Roth 1966)
- Add `mathlibDependencies`, `originalContributions`, `dateAdded`
- Correct section line ranges to match actual 263-line Lean file
- Add `mathContext` with LaTeX to all 6 sections
- Deepen `historicalContext`: covering systems introduction, Hough 2015
- Add 5th `keyInsight` on 12 proved infrastructure lemmas
- Add equivalence annotation for `full_covering_iff_uniform`

## Test plan
- [x] `pnpm annotations:build` passes with 0 warnings for this target

🤖 Generated with [Claude Code](https://claude.com/claude-code)