### PR TITLE
Enrichment: erdos-344 - Subcomplete sequences

### DIFF
--- a/src/data/proofs/erdos-344/annotations.json
+++ b/src/data/proofs/erdos-344/annotations.json
@@ -6,9 +6,10 @@
     "type": "concept",
     "title": "Problem Overview: Subcomplete Sequences",
     "content": "**Erdős Problem #344: SOLVED**\n\nIf A ⊆ ℕ has |A ∩ {1,...,N}| ≫ N^{1/2}, must P(A) (the set of all finite subset sums) contain an infinite arithmetic progression?\n\n**Answer:** YES (Szemerédi-Vu, 2006)\n\n**History:**\n- Folkman: Proved for N^{1/2+ε} density\n- Szemerédi-Vu: Proved for exact √N density\n- Open: Is √(2N) the optimal threshold?",
-    "mathContext": "This problem connects additive combinatorics with density conditions. The subset sums of a set form a rich additive structure.",
+    "mathContext": "This problem sits at the interface of additive combinatorics and density Ramsey theory. Given $A \\subseteq \\mathbb{N}$, the subset sum set $P(A) = \\{\\sum_{n \\in B} n : B \\subseteq A \\text{ finite}\\}$ encodes the additive structure of $A$. Subcompleteness asks whether $P(A)$ is 'large' in the sense of containing an infinite arithmetic progression $\\{a, a+d, a+2d, \\ldots\\}$.",
     "significance": "critical",
-    "relatedConcepts": ["complete-sequences", "subset-sums", "arithmetic-progressions", "density"]
+    "relatedConcepts": ["complete-sequences", "subset-sums", "arithmetic-progressions", "density"],
+    "prerequisites": ["Finset.range", "Set", "Real.sqrt"]
   },
   {
     "id": "ann-e344-counting",
@@ -17,9 +18,10 @@
     "type": "definition",
     "title": "Counting Function",
     "content": "**countingFunction A N:**\n\n|A ∩ {1,...,N}| = number of elements of A up to N.\n\nThis measures the 'density' of A in the natural numbers.",
-    "mathContext": "The asymptotic behavior of the counting function determines many properties of A, including subcompleteness.",
+    "mathContext": "The counting function $A(N) = |A \\cap \\{1, \\ldots, N\\}|$ is the standard tool for measuring the 'thickness' of an integer set. The asymptotic growth rate of $A(N)$ determines many additive properties of $A$. Here it is implemented as `(Finset.range (N+1)).filter (· ∈ A) |>.card`.",
     "significance": "key",
-    "relatedConcepts": ["density", "asymptotic-analysis"]
+    "relatedConcepts": ["density", "asymptotic-analysis", "counting"],
+    "prerequisites": ["Finset.range", "Finset.filter", "Finset.card"]
   },
   {
     "id": "ann-e344-subset-sums",
@@ -28,9 +30,22 @@
     "type": "definition",
     "title": "Subset Sums P(A)",
     "content": "**subsetSums A:**\n\nP(A) = {∑_{n ∈ B} n : B ⊆ A finite}\n\nThe set of all possible sums of finite subsets of A.",
-    "mathContext": "Subset sums are fundamental in additive combinatorics. The structure of P(A) reveals deep properties of A.",
+    "mathContext": "The subset sum set $P(A) = \\{\\sum_{n \\in B} n : B \\subseteq A, B \\text{ finite}\\}$ is a fundamental object in additive combinatorics. It is always closed under taking sub-subsets (if $s \\in P(A)$ via $B$, then any $B' \\subseteq B$ gives $\\sum B' \\in P(A)$). The question is how 'large' $P(A)$ can be as a function of the density of $A$.",
     "significance": "critical",
-    "relatedConcepts": ["sumsets", "additive-combinatorics", "subset-sum-problem"]
+    "relatedConcepts": ["sumsets", "additive-combinatorics", "subset-sum-problem"],
+    "prerequisites": ["Finset.sum", "Set"]
+  },
+  {
+    "id": "ann-e344-arith-prog",
+    "proofId": "erdos-344",
+    "range": { "startLine": 63, "endLine": 68 },
+    "type": "definition",
+    "title": "Arithmetic Progression",
+    "content": "**arithmeticProgression a d:**\n\nThe infinite arithmetic progression {a, a+d, a+2d, ...} = {a + k·d : k ∈ ℕ}.",
+    "mathContext": "An infinite arithmetic progression $\\{a + kd : k \\in \\mathbb{N}\\}$ with $d > 0$ is an infinite set with constant gaps. Containing such a progression is a strong structural property of a set — it means the set has 'periodic' large-scale structure.",
+    "significance": "supporting",
+    "relatedConcepts": ["arithmetic-progressions", "periodicity"],
+    "prerequisites": []
   },
   {
     "id": "ann-e344-subcomplete",
@@ -39,9 +54,10 @@
     "type": "definition",
     "title": "Subcomplete Sets",
     "content": "**IsSubcomplete A:**\n\nA is subcomplete if P(A) contains an infinite arithmetic progression {a, a+d, a+2d, ...} for some a, d with d > 0.\n\nThis is weaker than 'complete' (which requires P(A) to contain all large integers).",
-    "mathContext": "Subcompleteness is a measure of how 'rich' the subset sums are. It implies P(A) has significant additive structure.",
+    "mathContext": "Subcompleteness means $\\exists a, d > 0$ such that $\\{a + kd : k \\in \\mathbb{N}\\} \\subseteq P(A)$. This is a natural weakening of completeness (where $P(A) \\supseteq \\{n : n \\geq N_0\\}$). The notion captures that $P(A)$ has significant additive structure without requiring it to represent every large integer.",
     "significance": "critical",
-    "relatedConcepts": ["complete-sequences", "arithmetic-progressions"]
+    "relatedConcepts": ["complete-sequences", "arithmetic-progressions", "additive-structure"],
+    "prerequisites": ["arithmeticProgression", "subsetSums"]
   },
   {
     "id": "ann-e344-sqrt-density",
@@ -50,9 +66,10 @@
     "type": "definition",
     "title": "Square Root Density",
     "content": "**HasSquareRootDensity A:**\n\n∃ C > 0 such that |A ∩ {1,...,N}| ≥ C√N for all N.\n\nThis is the critical density threshold for subcompleteness.",
-    "mathContext": "This density condition says A grows at least as fast as √N. Szemerédi-Vu proved this is sufficient for subcompleteness.",
+    "mathContext": "The condition $A(N) \\geq C\\sqrt{N}$ for some $C > 0$ and all $N \\geq 1$ says that $A$ grows at least as fast as $\\sqrt{N}$. This is the exact threshold proved by Szemerédi and Vu: any set satisfying this condition is subcomplete. The formalization uses `Real.sqrt` from Mathlib.",
     "significance": "critical",
-    "relatedConcepts": ["density", "growth-rate", "threshold"]
+    "relatedConcepts": ["density", "growth-rate", "threshold"],
+    "prerequisites": ["countingFunction", "Real.sqrt"]
   },
   {
     "id": "ann-e344-folkman-density",
@@ -61,42 +78,46 @@
     "type": "definition",
     "title": "Folkman Density",
     "content": "**HasFolkmanDensity A:**\n\n∃ ε > 0, C > 0 such that |A ∩ {1,...,N}| ≥ C · N^{1/2+ε} for all N.\n\nSlightly stronger than square root density.",
-    "mathContext": "Folkman proved subcompleteness under this stronger density condition. Szemerédi-Vu removed the need for the extra ε.",
+    "mathContext": "Folkman's density condition $A(N) \\geq C \\cdot N^{1/2+\\varepsilon}$ is strictly stronger than square root density because $N^{1/2+\\varepsilon} / \\sqrt{N} = N^{\\varepsilon} \\to \\infty$. The extra polynomial factor was needed in Folkman's original proof but was removed by Szemerédi and Vu.",
     "significance": "key",
-    "relatedConcepts": ["density", "Folkman"]
+    "relatedConcepts": ["density", "Folkman", "polynomial-growth"],
+    "prerequisites": ["countingFunction"]
   },
   {
     "id": "ann-e344-folkman-theorem",
     "proofId": "erdos-344",
     "range": { "startLine": 109, "endLine": 114 },
-    "type": "axiom",
+    "type": "concept",
     "title": "Folkman's Theorem",
-    "content": "**folkman_theorem:**\n\nIf |A ∩ {1,...,N}| ≫ N^{1/2+ε} for some ε > 0, then A is subcomplete.\n\nThis was the first result showing density implies subcompleteness.",
-    "mathContext": "Folkman's result was a precursor to Szemerédi-Vu. It established that sufficient density forces arithmetic structure in P(A).",
+    "content": "**folkman_theorem:**\n\nIf |A ∩ {1,...,N}| ≫ N^{1/2+ε} for some ε > 0, then A is subcomplete.\n\nThis was the first result showing density implies subcompleteness. Axiomatized as it requires deep combinatorial arguments.",
+    "mathContext": "Folkman's theorem was the first to establish that sufficient density forces arithmetic structure in $P(A)$. The proof uses a greedy algorithm combined with counting arguments: if $A$ is dense enough, one can greedily select elements whose subset sums fill out an arithmetic progression. This was later superseded by the sharper Szemerédi-Vu result.",
     "significance": "key",
-    "relatedConcepts": ["Folkman", "density-threshold"]
+    "relatedConcepts": ["Folkman", "density-threshold", "greedy-algorithms"],
+    "prerequisites": ["HasFolkmanDensity", "IsSubcomplete"]
   },
   {
     "id": "ann-e344-szemeredi-vu",
     "proofId": "erdos-344",
     "range": { "startLine": 120, "endLine": 130 },
-    "type": "axiom",
+    "type": "concept",
     "title": "Szemerédi-Vu Theorem (2006)",
-    "content": "**szemeredi_vu_2006:**\n\nIf |A ∩ {1,...,N}| ≫ N^{1/2} for all N, then A is subcomplete.\n\nThis proves Erdős's conjecture, removing the extra ε from Folkman's condition.\n\nPublished in J. Amer. Math. Soc. (2006), 119-169.",
-    "mathContext": "The Szemerédi-Vu proof uses Fourier-analytic methods and deep results from additive combinatorics.",
+    "content": "**szemeredi_vu_2006:**\n\nIf |A ∩ {1,...,N}| ≫ N^{1/2} for all N, then A is subcomplete.\n\nThis proves Erdős's conjecture, removing the extra ε from Folkman's condition. Axiomatized: the proof requires sophisticated Fourier analysis.\n\nPublished in J. Amer. Math. Soc. (2006), 119-169.",
+    "mathContext": "The Szemerédi-Vu proof uses a combination of Fourier-analytic methods (exponential sums over subset sums), the Freiman-Ruzsa inverse theorem, and a structural decomposition of the set $A$. The key insight is that if $A$ has density $\\geq C\\sqrt{N}$, then the additive energy of $A$ is large enough to force $P(A)$ to contain long arithmetic progressions.",
     "significance": "critical",
-    "relatedConcepts": ["Szemeredi", "Vu", "Fourier-analysis", "additive-combinatorics"]
+    "relatedConcepts": ["Szemeredi", "Vu", "Fourier-analysis", "additive-energy", "Freiman-Ruzsa"],
+    "prerequisites": ["HasSquareRootDensity", "IsSubcomplete"]
   },
   {
     "id": "ann-e344-optimality",
     "proofId": "erdos-344",
     "range": { "startLine": 136, "endLine": 145 },
-    "type": "axiom",
+    "type": "concept",
     "title": "Erdős's Optimality Example",
-    "content": "**erdos_optimality_example:**\n\n∃ A with |A ∩ {1,...,N}| < √(2N) that is NOT subcomplete.\n\nThis shows the threshold cannot be below √(2N).\n\nFrom Erdős (1961), Acta Arith.",
-    "mathContext": "This counterexample establishes a lower bound on the density threshold. The gap between √N (sufficient) and √(2N) (necessary) remains open.",
+    "content": "**erdos_optimality_example:**\n\n∃ A with |A ∩ {1,...,N}| < √(2N) that is NOT subcomplete.\n\nThis shows the threshold cannot be below √(2N). Axiomatized: the construction uses specific number-theoretic techniques.\n\nFrom Erdős (1961), Acta Arith.",
+    "mathContext": "Erdős constructed a set $A$ with $A(N) < \\sqrt{2N}$ for all $N$ whose subset sums avoid an arithmetic progression. The construction exploits the fact that if elements of $A$ grow sufficiently fast relative to their predecessors, the subset sums are too 'spread out' to contain a progression. This gives a lower bound $\\sqrt{2N}$ on any sufficient density threshold.",
     "significance": "critical",
-    "relatedConcepts": ["optimality", "counterexample", "threshold-gap"]
+    "relatedConcepts": ["optimality", "counterexample", "threshold-gap", "lacunary-sets"],
+    "prerequisites": ["countingFunction", "IsSubcomplete", "Real.sqrt"]
   },
   {
     "id": "ann-e344-complete",
@@ -105,9 +126,22 @@
     "type": "definition",
     "title": "Complete Sequences",
     "content": "**IsComplete A:**\n\n∃ N₀ such that every n ≥ N₀ is in P(A).\n\nComplete is stronger than subcomplete: all large integers are representable, not just an arithmetic progression.",
-    "mathContext": "Complete sequences are well-studied. Subcomplete is a natural weakening that still captures significant additive structure.",
+    "mathContext": "A set $A$ is complete if $P(A) \\supseteq \\{n : n \\geq N_0\\}$ for some $N_0$. This is strictly stronger than subcompleteness: complete implies subcomplete (take $a = N_0, d = 1$) but not conversely. Complete sequences have been extensively studied; for example, Burr proved that any set with $A(N) \\geq (1+\\varepsilon)\\sqrt{2N}$ is complete.",
     "significance": "key",
-    "relatedConcepts": ["complete-sequences", "representability"]
+    "relatedConcepts": ["complete-sequences", "representability", "Burr"],
+    "prerequisites": ["subsetSums"]
+  },
+  {
+    "id": "ann-e344-complete-implies",
+    "proofId": "erdos-344",
+    "range": { "startLine": 173, "endLine": 181 },
+    "type": "theorem",
+    "title": "Complete Implies Subcomplete (Proved)",
+    "content": "**complete_implies_subcomplete:**\n\nIf A is complete, then A is subcomplete. The proof takes N₀ from completeness and constructs the arithmetic progression {N₀, N₀+1, N₀+2, ...} (d=1) inside P(A).\n\nThis is the only fully proved theorem in the file — all other major results are axiomatized.",
+    "mathContext": "The proof is constructive: given $N_0$ such that $\\forall n \\geq N_0, n \\in P(A)$, we witness the arithmetic progression with $a = N_0$ and $d = 1$. The key step is showing $a + k \\cdot 1 = N_0 + k \\geq N_0$, which follows by `omega`. This is a clean example of how completeness (a strong property) trivially implies subcompleteness (a weaker one).",
+    "significance": "key",
+    "relatedConcepts": ["complete-sequences", "constructive-proof", "omega-tactic"],
+    "prerequisites": ["IsComplete", "IsSubcomplete", "arithmeticProgression"]
   },
   {
     "id": "ann-e344-summary",
@@ -115,9 +149,10 @@
     "range": { "startLine": 202, "endLine": 211 },
     "type": "theorem",
     "title": "Summary of Known Results",
-    "content": "**erdos_344_summary:**\n\n1. **Szemerédi-Vu:** √N density is sufficient for subcompleteness\n2. **Erdős:** √(2N) is necessary (counterexample below this)\n\nThe exact threshold in between remains open.",
-    "mathContext": "The gap between √N and √(2N) contains the true threshold. Closing this gap is an active research direction.",
+    "content": "**erdos_344_summary:**\n\n1. **Szemerédi-Vu:** √N density is sufficient for subcompleteness\n2. **Erdős:** √(2N) is necessary (counterexample below this)\n\nThe exact threshold in between remains open. The proof combines the two axiomatized results.",
+    "mathContext": "This summary theorem packages the two main results as a conjunction: $$(\\forall A, \\text{HasSquareRootDensity}(A) \\to \\text{IsSubcomplete}(A)) \\land (\\exists A, A(N) < \\sqrt{2N} \\land \\lnot\\text{IsSubcomplete}(A))$$ The gap between the sufficient condition $C\\sqrt{N}$ and the necessary condition $\\sqrt{2N}$ is the remaining open problem.",
     "significance": "critical",
-    "relatedConcepts": ["threshold", "open-problem"]
+    "relatedConcepts": ["threshold", "open-problem", "summary"],
+    "prerequisites": ["szemeredi_vu_2006", "erdos_optimality_example"]
   }
 ]

--- a/src/data/proofs/erdos-344/meta.json
+++ b/src/data/proofs/erdos-344/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/344",
-    "date": "",
+    "date": "2026-03-12",
     "status": "complete",
     "proofRepoPath": "Proofs/Erdos344Problem.lean",
     "tags": ["erdos", "number-theory", "complete-sequences", "arithmetic-progressions", "subset-sums"],
@@ -22,25 +22,58 @@
       { "theorem": "Finset.range", "description": "Finite sets of naturals up to N", "module": "Mathlib.Data.Finset.Basic" },
       { "theorem": "Finset.sum", "description": "Summation over finite sets", "module": "Mathlib.Algebra.BigOperators.Group.Finset" },
       { "theorem": "Real.sqrt", "description": "Square root on reals", "module": "Mathlib.Data.Real.Basic" },
-      { "theorem": "Set", "description": "Basic set operations", "module": "Mathlib.Data.Set.Basic" }
+      { "theorem": "Set", "description": "Basic set operations", "module": "Mathlib.Data.Set.Basic" },
+      { "theorem": "Asymptotics", "description": "Asymptotic notation for growth rates", "module": "Mathlib.Analysis.Asymptotics.Asymptotics" }
     ],
     "originalContributions": [
       "Lean formalization of subcomplete sequence definitions",
-      "Formal statement of Szemerédi-Vu theorem",
-      "Density condition hierarchy",
-      "Open conjecture about optimal threshold"
+      "Formal statement of Szemerédi-Vu theorem (2006)",
+      "Density condition hierarchy (Folkman → square root → optimal)",
+      "Constructive proof that complete implies subcomplete",
+      "Open conjecture about optimal √(2N) threshold"
+    ],
+    "references": [
+      {
+        "authors": "Szemerédi, E. and Vu, V.",
+        "title": "Long arithmetic progressions in sumsets: thresholds and bounds",
+        "year": "2006",
+        "venue": "J. Amer. Math. Soc. 19(1), 119-169",
+        "note": "Main result: √N density suffices for subcompleteness"
+      },
+      {
+        "authors": "Erdős, P.",
+        "title": "On the representation of large integers as sums of distinct summands taken from a fixed set",
+        "year": "1962",
+        "venue": "Acta Arith. 7, 345-354",
+        "note": "Optimality example: A with A(N) < √(2N) and ¬IsSubcomplete(A)"
+      },
+      {
+        "authors": "Folkman, J.",
+        "title": "On the representation of integers as sums of distinct terms from a fixed sequence",
+        "year": "1966",
+        "venue": "Canad. J. Math. 18, 643-655",
+        "note": "First density result: N^{1/2+ε} suffices"
+      },
+      {
+        "authors": "Erdős, P. and Graham, R.",
+        "title": "Old and New Problems and Results in Combinatorial Number Theory",
+        "year": "1980",
+        "venue": "Monographies de L'Enseignement Mathématique 28",
+        "note": "Problem 344 statement (p.54)"
+      }
     ],
     "dateAdded": "2026-01-19"
   },
   "overview": {
-    "historicalContext": "This problem connects additive combinatorics with density conditions on integer sequences. Erdős asked whether moderate density (√N) suffices for subcompleteness, after Folkman had proved it for slightly larger density (N^{1/2+ε}). The question was resolved by Szemerédi and Vu in 2006 using advanced Fourier-analytic techniques.",
+    "historicalContext": "Erdős posed this problem in the 1960s, asking whether moderate density ($\\sqrt{N}$) suffices for subcompleteness. The problem has roots in the classical study of complete sequences by Sprague (1937) and Folkman (1966). Folkman first proved that density $N^{1/2+\\varepsilon}$ suffices, using a greedy selection argument. The problem remained open for 40 years until Szemerédi and Vu (2006) proved the sharp result using Fourier-analytic methods and the Freiman-Ruzsa inverse theorem from additive combinatorics. Erdős himself showed in 1962 that the threshold cannot go below $\\sqrt{2N}$ by constructing an explicit counterexample, leaving the gap between $\\sqrt{N}$ and $\\sqrt{2N}$ as an open problem.",
     "problemStatement": "If A ⊆ ℕ is a set of integers such that |A ∩ {1,...,N}| ≫ N^{1/2} for all N, must A be subcomplete? That is, must the set of all finite subset sums P(A) = {∑_{n ∈ B} n : B ⊆ A finite} contain an infinite arithmetic progression?",
-    "proofStrategy": "The Szemerédi-Vu proof uses sophisticated Fourier analysis and additive combinatorics. The formalization captures the key definitions and states the main theorems as axioms, along with the related results and open conjectures.",
+    "proofStrategy": "The Szemerédi-Vu proof uses sophisticated Fourier analysis and additive combinatorics. The formalization captures the key definitions and states the main theorems as axioms, along with the related results and open conjectures. The only constructive proof is complete_implies_subcomplete, which witnesses the arithmetic progression {N₀, N₀+1, ...} inside P(A) when A is complete.",
     "keyInsights": [
-      "A set is 'subcomplete' if its subset sums contain an infinite arithmetic progression",
-      "Square root density (≫ √N) is the critical threshold for subcompleteness",
-      "Folkman proved a weaker version with density N^{1/2+ε}",
-      "The optimal threshold √(2N) remains an open conjecture"
+      "A set is 'subcomplete' if its subset sums contain an infinite arithmetic progression — weaker than completeness but still a strong structural property",
+      "Square root density (≫ √N) is the critical threshold for subcompleteness, proved by Szemerédi-Vu using Fourier analysis and additive energy estimates",
+      "Folkman proved a weaker version with density N^{1/2+ε}, using greedy selection — the extra ε was an artifact of his method",
+      "The optimal threshold lies in the gap [√N, √(2N)]: Erdős's 1962 counterexample shows √(2N) is necessary, but the exact constant is unknown",
+      "The hierarchy complete ⊃ subcomplete is strict: the formalization proves complete → subcomplete constructively using d=1"
     ]
   },
   "sections": [
@@ -49,58 +82,65 @@
       "title": "Basic Definitions",
       "startLine": 44,
       "endLine": 75,
-      "summary": "Core definitions: counting function, subset sums, arithmetic progressions, and subcomplete sets"
+      "summary": "Core definitions: counting function, subset sums, arithmetic progressions, and subcomplete sets",
+      "mathContext": "Defines $A(N) = |A \\cap \\{1,\\ldots,N\\}|$ via `Finset.range` and `filter`, subset sums $P(A)$ as $\\{\\sum_{n \\in B} n : B \\subseteq A\\}$, and subcompleteness as $\\exists a,d > 0, \\{a + kd\\} \\subseteq P(A)$."
     },
     {
       "id": "density-conditions",
       "title": "Density Conditions",
       "startLine": 77,
       "endLine": 103,
-      "summary": "Square root density, Folkman density, and optimal density conditions"
+      "summary": "Square root density, Folkman density, and optimal density conditions",
+      "mathContext": "Three density levels: $A(N) \\geq C\\sqrt{N}$ (square root), $A(N) \\geq CN^{1/2+\\varepsilon}$ (Folkman), and $A(N) \\geq \\sqrt{2N}$ (optimal). The hierarchy is Folkman ⊂ square root ⊂ optimal, with each level corresponding to a different theorem."
     },
     {
       "id": "folkman",
       "title": "Folkman's Result",
       "startLine": 105,
       "endLine": 114,
-      "summary": "Folkman's theorem for N^{1/2+ε} density"
+      "summary": "Folkman's theorem for N^{1/2+ε} density",
+      "mathContext": "Axiomatized as `folkman_theorem`: $\\text{HasFolkmanDensity}(A) \\to \\text{IsSubcomplete}(A)$. Folkman's 1966 proof was the first to show density forces arithmetic structure in subset sums."
     },
     {
       "id": "szemeredi-vu",
       "title": "Szemerédi-Vu Theorem",
       "startLine": 116,
       "endLine": 130,
-      "summary": "The main result proving Erdős's conjecture"
+      "summary": "The main result proving Erdős's conjecture",
+      "mathContext": "Axiomatized as `szemeredi_vu_2006`: $\\text{HasSquareRootDensity}(A) \\to \\text{IsSubcomplete}(A)$. Published in JAMS 2006, this removed the $\\varepsilon$ from Folkman's condition using Fourier analysis and the Freiman-Ruzsa inverse theorem."
     },
     {
       "id": "open-conjecture",
       "title": "Open Conjecture",
       "startLine": 132,
       "endLine": 154,
-      "summary": "The optimal density conjecture and Erdős's counterexample"
+      "summary": "The optimal density conjecture and Erdős's counterexample",
+      "mathContext": "Erdős's 1962 counterexample shows $\\exists A$ with $A(N) < \\sqrt{2N}$ and $\\lnot\\text{IsSubcomplete}(A)$. The `OptimalDensityConjecture` asks whether $A(N) \\geq \\sqrt{2N}$ suffices. The gap between $C\\sqrt{N}$ (sufficient) and $\\sqrt{2N}$ (necessary) remains open."
     },
     {
       "id": "related-concepts",
       "title": "Related Concepts",
       "startLine": 156,
       "endLine": 189,
-      "summary": "Complete sequences, complete_implies_subcomplete theorem, and density hierarchy"
+      "summary": "Complete sequences, complete_implies_subcomplete theorem, and density hierarchy",
+      "mathContext": "Defines `IsComplete` ($P(A) \\supseteq \\{n \\geq N_0\\}$) and proves `complete_implies_subcomplete` constructively by witnessing the AP with $a = N_0, d = 1$. Also axiomatizes `folkman_implies_sqrt_density`: the technical lemma $N^{1/2+\\varepsilon} \\geq C\\sqrt{N}$ for large $N$."
     },
     {
       "id": "summary",
       "title": "Summary",
       "startLine": 191,
       "endLine": 213,
-      "summary": "Summary combining Szemerédi-Vu theorem and Erdős optimality example"
+      "summary": "Summary combining Szemerédi-Vu theorem and Erdős optimality example",
+      "mathContext": "The theorem `erdos_344_summary` packages both main results as a conjunction, combining `szemeredi_vu_2006` and `erdos_optimality_example` into a single statement that captures the current state of knowledge."
     }
   ],
   "conclusion": {
     "summary": "Erdős Problem #344 was solved by Szemerédi and Vu in 2006. They proved that square root density |A ∩ {1,...,N}| ≫ N^{1/2} is sufficient to guarantee that the subset sums contain an infinite arithmetic progression. The optimal threshold √(2N) remains open.",
-    "implications": "This result has deep connections to additive combinatorics, Fourier analysis, and the structure of sumsets. It improved upon Folkman's earlier result requiring slightly higher density.",
+    "implications": "This result has deep connections to additive combinatorics, Fourier analysis, and the structure of sumsets. It improved upon Folkman's earlier result requiring slightly higher density, and established √N as a fundamental threshold in the theory of subset sums.",
     "openQuestions": [
       "Is the exact threshold √(2N)? (Erdős showed this would be best possible)",
-      "Can the Fourier-analytic methods be formalized in Lean?",
-      "What is the structure of the arithmetic progressions in P(A)?"
+      "Can the Fourier-analytic methods of Szemerédi-Vu be formalized in Lean?",
+      "What is the structure of the arithmetic progressions in P(A) — can the common difference d be bounded?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Fix 3 invalid annotation types (`axiom`→`concept`) for axiomatized results
- Add `prerequisites` field to all 13 annotations
- Add new annotation for `complete_implies_subcomplete` (the only proved theorem)
- Deepen `mathContext` with LaTeX for all annotations and sections
- Add 4 academic references (Szemerédi-Vu 2006, Erdős 1962, Folkman 1966, Erdős-Graham 1980)
- Add `Asymptotics` to mathlibDependencies
- Expand historicalContext with Sprague, Folkman, Freiman-Ruzsa connections
- Add 5th keyInsight on complete⊃subcomplete hierarchy
- Add `mathContext` to all 7 sections

## Test plan
- [x] `pnpm annotations:build` passes with 0 warnings for erdos-344

🤖 Generated with [Claude Code](https://claude.com/claude-code)