### PR TITLE
Enrichment: erdos-561 - Size Ramsey numbers for star unions

### DIFF
--- a/src/data/proofs/erdos-561/annotations.json
+++ b/src/data/proofs/erdos-561/annotations.json
@@ -6,74 +6,117 @@
     "type": "concept",
     "title": "Problem Overview: Size Ramsey Numbers for Star Unions",
     "content": "**Erdős Problem #561** asks for an exact formula for size Ramsey numbers R̂(F₁, F₂) when F₁ and F₂ are disjoint unions of star graphs. The size Ramsey number minimizes edges (not vertices) in a host graph that forces monochromatic copies.\n\nThe conjectured formula is R̂(F₁, F₂) = Σ_{k=2}^{s+t} max{nᵢ + mⱼ - 1 : i + j = k}. The **uniform case** (all stars in each union identical) was proven by Burr-Erdős-Faudree-Rousseau-Schelp in 1978. The **general case** remains OPEN.",
-    "mathContext": "Size Ramsey numbers were introduced by Erdős and collaborators in the 1970s as an edge-minimization variant of classical Ramsey numbers. For sparse graphs like stars, size Ramsey numbers can be linear in vertex count, unlike the exponential classical Ramsey numbers.",
+    "mathContext": "Size Ramsey numbers $\\hat{R}(G)$ were introduced by Erdős, Faudree, Rousseau, and Schelp in the late 1970s. Unlike the classical Ramsey number $R(G)$ which minimizes vertices of $K_N$, $\\hat{R}(G)$ minimizes the number of edges in a host graph $H$ such that every 2-coloring of $E(H)$ contains a monochromatic copy of $G$. For sparse graphs like stars, $\\hat{R}$ can be dramatically smaller than $\\binom{R(G)}{2}$.",
     "significance": "critical",
-    "relatedConcepts": ["Ramsey theory", "Size Ramsey numbers", "Star graphs", "Edge coloring"]
+    "relatedConcepts": ["Ramsey theory", "size Ramsey numbers", "star graphs", "edge coloring"],
+    "prerequisites": []
   },
   {
-    "id": "ann-e561-structures",
+    "id": "ann-e561-star",
     "proofId": "erdos-561",
-    "range": { "startLine": 35, "endLine": 76 },
+    "range": { "startLine": 39, "endLine": 53 },
     "type": "definition",
-    "title": "Star Graphs and Star Unions",
-    "content": "**Star K_{1,n}**: A star with one central vertex connected to n leaves. Has n edges and n+1 vertices. The Star structure requires at least one leaf (pos : leaves ≥ 1).\n\n**StarUnion**: A disjoint union of stars F = ∪ K_{1,nᵢ} encoded as a list of leaf counts. Tracks componentCount (number of stars), totalEdges (sum of leaf counts), and totalVertices (totalEdges + componentCount).\n\nExample: exampleUnion = K_{1,2} ∪ K_{1,3} with 2 components, 5 edges, 7 vertices.",
-    "mathContext": "Star unions are fundamental objects in Ramsey theory for sparse graphs. Their simple structure enables exact formulas that are impossible for general graph families.",
+    "title": "Star Graph K_{1,n}",
+    "content": "**Star**: A structure representing $K_{1,n}$ with `leaves` (number of leaf vertices) and a proof `pos : leaves ≥ 1` (at least one leaf). The `edgeCount` equals `leaves` and `vertexCount` equals `leaves + 1`.\n\nExample: `claw = ⟨3, by omega⟩` represents $K_{1,3}$, the claw graph.",
+    "mathContext": "The star graph $K_{1,n}$ is the complete bipartite graph with one vertex in one part and $n$ in the other. It has $n$ edges and $n+1$ vertices. Stars are the simplest connected graphs apart from paths, and their Ramsey properties are well-understood due to their rigid structure.",
     "significance": "key",
-    "relatedConcepts": ["Star graphs", "Disjoint unions", "Sparse graphs", "Trees"]
+    "relatedConcepts": ["star graphs", "complete bipartite graphs", "claw graph"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-e561-union",
+    "proofId": "erdos-561",
+    "range": { "startLine": 59, "endLine": 76 },
+    "type": "definition",
+    "title": "Star Union",
+    "content": "**StarUnion**: A disjoint union of stars $F = \\cup_{i \\leq s} K_{1,n_i}$ encoded as a list of leaf counts `stars : List ℕ` with `nonempty : stars.length > 0`. Computes `componentCount` (number of stars), `totalEdges` (sum of leaf counts), and `totalVertices` (totalEdges + componentCount).\n\nExample: `exampleUnion = ⟨[2, 3], by simp⟩` represents $K_{1,2} \\cup K_{1,3}$.",
+    "mathContext": "The total edge count $|E(F)| = \\sum_{i=1}^s n_i$ and vertex count $|V(F)| = \\sum_{i=1}^s (n_i + 1) = |E(F)| + s$. The list representation allows easy computation of the conjectured formula by indexing into the leaf counts.",
+    "significance": "key",
+    "relatedConcepts": ["disjoint unions", "sparse graphs", "List.sum", "List.replicate"],
+    "prerequisites": ["List.sum", "List.length"]
   },
   {
     "id": "ann-e561-ramsey-framework",
     "proofId": "erdos-561",
-    "range": { "startLine": 78, "endLine": 114 },
+    "range": { "startLine": 82, "endLine": 98 },
     "type": "definition",
     "title": "Ramsey Theory Framework",
-    "content": "**EdgeColoring**: Assigns Boolean values (Red/Blue) to vertex pairs.\n\n**hasMonochromaticCopy**: Axiomatized predicate asserting a monochromatic copy of a star union exists in a colored graph. Axiomatized because formalizing graph containment in colored graphs requires substantial Mathlib infrastructure.\n\n**hasRamseyProperty**: H has this property for (F₁, F₂) if every 2-coloring contains a red F₁ or blue F₂.\n\n**sizeRamseyNumber**: The minimum edge count over all graphs with the Ramsey property. Axiomatized since computing the minimum over all graphs is infeasible.",
-    "mathContext": "The framework captures the essential structure of size Ramsey theory. The key insight is minimizing edges rather than vertices, which yields dramatically smaller numbers for sparse graphs.",
+    "content": "**EdgeColoring**: A function `V → V → Bool` assigning colors to vertex pairs.\n\n**hasMonochromaticCopy**: Axiomatized predicate for monochromatic subgraph containment. Axiomatized because formalizing graph embedding in colored graphs requires substantial infrastructure.\n\n**hasRamseyProperty**: H has this property for (F₁, F₂) if every 2-coloring contains a red F₁ or blue F₂.",
+    "mathContext": "The Ramsey property $\\text{RP}(H; F_1, F_2)$ states: $\\forall c : E(H) \\to \\{\\text{Red}, \\text{Blue}\\}$, $\\exists$ monochromatic $F_1 \\subseteq_c H$ (red) or monochromatic $F_2 \\subseteq_c H$ (blue). The `hasMonochromaticCopy` predicate is axiomatized because formalizing colored subgraph isomorphism requires Mathlib's `SimpleGraph.Embedding` and color-preserving morphisms.",
     "significance": "critical",
-    "relatedConcepts": ["Ramsey's theorem", "Graph coloring", "Edge-minimization"]
+    "relatedConcepts": ["Ramsey's theorem", "graph coloring", "subgraph containment"],
+    "prerequisites": ["SimpleGraph", "EdgeColoring"]
+  },
+  {
+    "id": "ann-e561-size-ramsey",
+    "proofId": "erdos-561",
+    "range": { "startLine": 104, "endLine": 114 },
+    "type": "concept",
+    "title": "Size Ramsey Number",
+    "content": "**sizeRamseyNumber**: Axiomatized as a function `StarUnion → StarUnion → ℕ` giving the minimum edge count for a graph with the Ramsey property.\n\n**sizeRamseyNumber_exists**: Existence axiom guaranteeing finiteness — there always exists a finite graph with the Ramsey property.",
+    "mathContext": "$\\hat{R}(F_1, F_2) = \\min\\{|E(H)| : H \\text{ has } \\text{RP}(H; F_1, F_2)\\}$. The existence follows from the classical Ramsey theorem: $K_{R(F_1,F_2)}$ always works, giving $\\hat{R} \\leq \\binom{R(F_1,F_2)}{2} < \\infty$. For stars, $\\hat{R}$ is much smaller than this naive bound.",
+    "significance": "critical",
+    "relatedConcepts": ["edge minimization", "Ramsey existence", "finiteness"],
+    "prerequisites": ["hasRamseyProperty", "StarUnion"]
   },
   {
     "id": "ann-e561-formula",
     "proofId": "erdos-561",
-    "range": { "startLine": 116, "endLine": 147 },
+    "range": { "startLine": 120, "endLine": 147 },
     "type": "definition",
     "title": "The Conjectured Formula",
-    "content": "**indexSumPairs(k)**: Pairs (i, j) with i + j = k and both ≥ 1.\n\n**maxForIndexSum(F₁, F₂, k)**: max{nᵢ + mⱼ - 1 : i + j = k}, the maximum contribution from pairing the ith star of F₁ with the jth star of F₂.\n\n**conjecturedFormula**: R̂(F₁, F₂) = Σ_{k=2}^{s+t} maxForIndexSum(F₁, F₂, k). This elegant sum captures how stars from the two families interact optimally.\n\n**erdosConjecture**: The proposition that this formula holds for ALL star unions.",
-    "mathContext": "The formula suggests a greedy pairing structure in Ramsey-minimal graphs: stars from F₁ and F₂ are matched by index sums, and the maximum leaf sum determines the edge contribution for each pairing.",
+    "content": "**indexSumPairs(k)**: List of pairs (i, j) with i + j = k, both ≥ 1.\n\n**maxForIndexSum(F₁, F₂, k)**: max{nᵢ + mⱼ - 1 : i + j = k}, the maximum contribution from pairing the ith star of F₁ with the jth star of F₂.\n\n**conjecturedFormula**: R̂(F₁, F₂) = Σ_{k=2}^{s+t} maxForIndexSum(F₁, F₂, k).\n\n**erdosConjecture**: The proposition that this formula holds for ALL star unions.",
+    "mathContext": "The formula $\\hat{R}(F_1, F_2) = \\sum_{k=2}^{s+t} \\max\\{n_i + m_j - 1 : i + j = k\\}$ suggests a greedy pairing structure: stars from $F_1$ and $F_2$ are matched by their index sum $i + j = k$, and each match contributes $\\max(n_i + m_j - 1)$ edges to the Ramsey-minimal graph. The `noncomputable` annotation is needed because `List.maximum?` uses a classical choice.",
     "significance": "critical",
-    "relatedConcepts": ["Combinatorial optimization", "Index sums", "Ramsey-minimal graphs"]
+    "relatedConcepts": ["combinatorial optimization", "index sums", "Ramsey-minimal graphs"],
+    "prerequisites": ["StarUnion", "List.filterMap", "List.maximum?"]
   },
   {
     "id": "ann-e561-befrs78",
     "proofId": "erdos-561",
-    "range": { "startLine": 149, "endLine": 179 },
-    "type": "axiom",
-    "title": "BEFRS78 Theorem and Uniform Case",
-    "content": "**StarUnion.isUniform**: A star union is uniform if all stars have the same leaf count.\n\n**befrs78_theorem**: Burr-Erdős-Faudree-Rousseau-Schelp (1978) proved the formula for uniform star unions. This is the main known positive result toward the full conjecture.\n\n**uniform_case**: Application theorem showing that for s copies of K_{1,n} and t copies of K_{1,m}, the constructed unions are uniform and the formula holds. Proved by constructing the uniform unions and applying BEFRS78.",
-    "mathContext": "Published in 'Ramsey-minimal graphs for multiple copies', Indagationes Mathematicae (1978). The proof uses explicit constructions of Ramsey-minimal graphs for uniform star unions.",
+    "range": { "startLine": 153, "endLine": 165 },
+    "type": "concept",
+    "title": "BEFRS78 Theorem",
+    "content": "**StarUnion.isUniform**: All stars in the union have the same leaf count (∃ n, ∀ k ∈ stars, k = n).\n\n**uniformStarUnion(s, n)**: Constructor for s copies of K_{1,n} via `List.replicate`.\n\n**befrs78_theorem**: Axiomatized — Burr, Erdős, Faudree, Rousseau, and Schelp (1978) proved the conjectured formula holds when both F₁ and F₂ are uniform.",
+    "mathContext": "The BEFRS78 theorem: if $F_1 = s \\cdot K_{1,n}$ and $F_2 = t \\cdot K_{1,m}$ are uniform, then $\\hat{R}(F_1, F_2) = \\sum_{k=2}^{s+t} \\max\\{n_i + m_j - 1 : i+j=k\\}$. Since all $n_i = n$ and all $m_j = m$, the formula simplifies considerably. The proof in Indagationes Mathematicae (1978) uses explicit constructions of Ramsey-minimal graphs.",
     "significance": "critical",
-    "relatedConcepts": ["Ramsey theory", "Uniform structures", "Explicit constructions"]
+    "relatedConcepts": ["uniform case", "List.replicate", "Ramsey-minimal graphs"],
+    "prerequisites": ["StarUnion.isUniform", "conjecturedFormula", "sizeRamseyNumber"]
+  },
+  {
+    "id": "ann-e561-uniform-case",
+    "proofId": "erdos-561",
+    "range": { "startLine": 170, "endLine": 179 },
+    "type": "theorem",
+    "title": "Uniform Case Application (Proved)",
+    "content": "**uniform_case**: For s copies of K_{1,n} and t copies of K_{1,m}, the constructed unions are uniform and the formula holds. Proved by constructing the uniform unions via `uniformStarUnion`, proving uniformity via `simp`, and applying `befrs78_theorem`.",
+    "mathContext": "The proof shows three things as a conjunction: (1) $F_1 = s \\cdot K_{1,n}$ is uniform (witnessed by $n$), (2) $F_2 = t \\cdot K_{1,m}$ is uniform (witnessed by $m$), and (3) $\\hat{R}(F_1, F_2) = \\text{conjecturedFormula}(F_1, F_2)$. The uniformity proofs use `simp [uniformStarUnion]` to unfold `List.replicate`.",
+    "significance": "key",
+    "relatedConcepts": ["theorem application", "uniform construction", "simp tactic"],
+    "prerequisites": ["uniformStarUnion", "befrs78_theorem", "StarUnion.isUniform"]
   },
   {
     "id": "ann-e561-bounds",
     "proofId": "erdos-561",
-    "range": { "startLine": 181, "endLine": 210 },
-    "type": "axiom",
+    "range": { "startLine": 185, "endLine": 210 },
+    "type": "concept",
     "title": "Bounds and Classical Connection",
-    "content": "**sizeRamsey_lower_bound**: R̂(F₁, F₂) ≥ max(|E(F₁)|, |E(F₂)|). The host graph must have enough edges to embed either target monochromatically.\n\n**sizeRamsey_upper_bound**: R̂(F₁, F₂) ≤ N(N-1)/2 for some N. The complete graph K_N provides an upper bound.\n\n**classicalRamseyNumber**: Axiomatized classical Ramsey number R(F₁, F₂).\n\n**size_vs_classical**: R̂ ≤ (R choose 2), but for stars this bound is very loose since size Ramsey numbers grow linearly while classical Ramsey numbers can be exponential.",
-    "mathContext": "The gap between size and classical Ramsey numbers is especially dramatic for sparse graphs. Stars achieve linear size Ramsey numbers, demonstrating their 'Ramsey efficiency'.",
+    "content": "**sizeRamsey_lower_bound**: R̂(F₁, F₂) ≥ max(|E(F₁)|, |E(F₂)|). The host graph must have enough edges to embed either target monochromatically.\n\n**sizeRamsey_upper_bound**: R̂(F₁, F₂) ≤ N(N-1)/2 for some N.\n\n**classicalRamseyNumber**: Axiomatized classical Ramsey number R(F₁, F₂).\n\n**size_vs_classical**: R̂ ≤ (R choose 2). For stars this bound is very loose since R̂ grows linearly while R can grow exponentially.",
+    "mathContext": "The lower bound $\\hat{R}(F_1, F_2) \\geq \\max(|E(F_1)|, |E(F_2)|)$ is immediate: a monochromatic $F_i$ requires at least $|E(F_i)|$ edges of one color. The upper bound $\\hat{R} \\leq \\binom{R}{2}$ follows from taking $H = K_R$. For stars, Beck (1983) showed $\\hat{R}(K_{1,n}) = O(n)$, demonstrating that size Ramsey numbers are linear for bounded-degree graphs.",
     "significance": "key",
-    "relatedConcepts": ["Lower bounds", "Upper bounds", "Classical Ramsey numbers", "Ramsey efficiency"]
+    "relatedConcepts": ["lower bounds", "upper bounds", "classical Ramsey numbers", "Beck's theorem"],
+    "prerequisites": ["sizeRamseyNumber", "StarUnion.totalEdges"]
   },
   {
     "id": "ann-e561-main",
     "proofId": "erdos-561",
-    "range": { "startLine": 212, "endLine": 237 },
+    "range": { "startLine": 219, "endLine": 235 },
     "type": "theorem",
     "title": "Summary and Main Theorem",
-    "content": "**erdos_561_summary** packages two results: (1) BEFRS78 proves the uniform case, and (2) the lower bound R̂ ≥ max edges holds universally.\n\n**erdos_561** is the main entry-point theorem: for all uniform star unions, the size Ramsey number equals the conjectured formula. Proved directly via `befrs78_theorem`.\n\n**openQuestion** captures the remaining challenge: does the formula hold for ALL star unions, including non-uniform ones?",
-    "mathContext": "The uniform case is fully SOLVED. The general conjecture remains one of the notable open problems in extremal Ramsey theory, requiring new techniques to handle the asymmetry of non-uniform star unions.",
+    "content": "**erdos_561_summary**: Packages BEFRS78 (uniform case) and the lower bound as a conjunction: `⟨befrs78_theorem, sizeRamsey_lower_bound⟩`.\n\n**erdos_561**: Main entry-point theorem — for all uniform star unions, the size Ramsey number equals the conjectured formula. Proved directly as `befrs78_theorem`.\n\n**openQuestion**: The remaining challenge — does the formula hold for ALL star unions (including non-uniform)?",
+    "mathContext": "The main theorem states: $\\forall F_1, F_2$ uniform, $\\hat{R}(F_1, F_2) = \\sum_{k=2}^{s+t} \\max\\{n_i + m_j - 1 : i+j=k\\}$. The open question asks whether uniformity can be dropped. Non-uniform star unions introduce asymmetry in the index-sum pairings, requiring new techniques beyond explicit Ramsey-minimal constructions.",
     "significance": "critical",
-    "relatedConcepts": ["Problem summary", "Open problems", "Extremal combinatorics"]
+    "relatedConcepts": ["problem summary", "open problems", "extremal combinatorics"],
+    "prerequisites": ["befrs78_theorem", "sizeRamsey_lower_bound", "erdosConjecture"]
   }
 ]

--- a/src/data/proofs/erdos-561/meta.json
+++ b/src/data/proofs/erdos-561/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (conjecture), Burr-Erdős-Faudree-Rousseau-Schelp (uniform case, 1978)",
     "sourceUrl": "https://erdosproblems.com/561",
-    "date": "1978",
+    "date": "2026-03-12",
     "status": "complete",
     "proofRepoPath": "Proofs/Erdos561Problem.lean",
     "tags": [
@@ -57,17 +57,41 @@
       "uniform_case theorem: application of BEFRS78",
       "sizeRamsey_lower_bound theorem: lower bound R̂ ≥ max edges",
       "erdos_561 theorem: main result for uniform star unions"
+    ],
+    "references": [
+      {
+        "authors": "Burr, S. A., Erdős, P., Faudree, R. J., Rousseau, C. C., and Schelp, R. H.",
+        "title": "Ramsey-minimal graphs for multiple copies",
+        "year": "1978",
+        "venue": "Indagationes Mathematicae (Proc.) 81(2), 187-195",
+        "note": "Proved the conjectured formula for uniform star unions"
+      },
+      {
+        "authors": "Erdős, P., Faudree, R. J., Rousseau, C. C., and Schelp, R. H.",
+        "title": "The size Ramsey number",
+        "year": "1978",
+        "venue": "Period. Math. Hungar. 9(1-2), 145-161",
+        "note": "Introduced size Ramsey numbers and established basic theory"
+      },
+      {
+        "authors": "Beck, J.",
+        "title": "On size Ramsey number of paths, trees, and circuits. I",
+        "year": "1983",
+        "venue": "J. Graph Theory 7(1), 115-129",
+        "note": "Proved size Ramsey numbers are linear for bounded-degree graphs"
+      }
     ]
   },
   "overview": {
-    "historicalContext": "Size Ramsey numbers, introduced by Erdős and others in the 1970s, measure the minimum number of edges (rather than vertices) needed in a host graph H to guarantee a monochromatic copy of G in any 2-coloring. For sparse graphs like stars, size Ramsey numbers can be much smaller than the quadratic bound from classical Ramsey numbers. This problem asks for an exact formula for unions of stars, which are among the simplest non-trivial graph families.",
+    "historicalContext": "Size Ramsey numbers were introduced by Erdős, Faudree, Rousseau, and Schelp in their 1978 paper in Periodica Mathematica Hungarica, measuring the minimum number of edges (rather than vertices) needed in a host graph to guarantee a monochromatic copy. The same group, together with Burr, proved the conjectured formula for uniform star unions in Indagationes Mathematicae (1978). Beck's celebrated 1983 result showed that size Ramsey numbers are linear for all bounded-degree graphs, but the exact formulas remain unknown for most graph families. Stars are among the few families where exact values are conjectured, making this a key test problem for the theory.",
     "problemStatement": "Let R̂(G) denote the size Ramsey number: the minimal number of edges m such that there is a graph H with m edges where any 2-coloring of the edges of H contains a monochromatic copy of G. For unions of stars F₁ = ∪_{i≤s} K_{1,nᵢ} and F₂ = ∪_{j≤t} K_{1,mⱼ}, prove that R̂(F₁,F₂) = Σ_{2≤k≤s+t} max{nᵢ + mⱼ - 1 : i + j = k}.",
     "proofStrategy": "The formalization defines star graphs and their unions, establishes the size Ramsey number framework, and states the conjectured formula. The uniform case (proven by BEFRS78) is formalized as an axiom, and the general conjecture remains open. Key bounds are established relating size Ramsey numbers to classical Ramsey numbers.",
     "keyInsights": [
       "Size Ramsey numbers can be linear in vertex count for sparse graphs, unlike exponential classical Ramsey numbers",
       "The formula involves a sum over index pairs, capturing how stars from F₁ and F₂ interact",
       "The uniform case admits a closed-form solution proven in 1978",
-      "Stars are 'Ramsey-efficient' due to their simple structure"
+      "Stars are 'Ramsey-efficient' due to their simple structure — Beck (1983) showed bounded-degree graphs have linear size Ramsey numbers",
+      "The formalization bridges axiomatized deep results (BEFRS78) with constructive Lean proofs (uniform_case), demonstrating how to formalize partially-solved combinatorial problems"
     ]
   },
   "sections": [
@@ -77,7 +101,7 @@
       "startLine": 35,
       "endLine": 53,
       "summary": "Defines the Star structure representing K_{1,n} with n leaves, including edge and vertex counts.",
-      "description": "A star graph K_{1,n} consists of one central vertex connected to n leaf vertices, giving n+1 total vertices and n edges. The Star structure requires at least one leaf."
+      "mathContext": "The star $K_{1,n}$ has $|E| = n$ edges and $|V| = n+1$ vertices. The `Star` structure stores `leaves` and a proof `pos : leaves ≥ 1`. Example: `claw = ⟨3, by omega⟩` for $K_{1,3}$."
     },
     {
       "id": "star-unions",
@@ -85,7 +109,7 @@
       "startLine": 55,
       "endLine": 76,
       "summary": "Defines StarUnion as a disjoint union of stars with component count and total edge/vertex calculations.",
-      "description": "A StarUnion F = ∪_{i≤s} K_{1,nᵢ} is represented as a list of leaf counts. The structure tracks the number of components, total edges (sum of leaf counts), and total vertices."
+      "mathContext": "$F = \\cup_{i \\leq s} K_{1,n_i}$ encoded as `stars : List ℕ` with `nonempty`. $|E(F)| = \\sum n_i$ (`totalEdges`), $|V(F)| = \\sum (n_i + 1)$ (`totalVertices`)."
     },
     {
       "id": "colorings-ramsey",
@@ -93,7 +117,7 @@
       "startLine": 78,
       "endLine": 98,
       "summary": "Defines 2-edge-colorings, monochromatic subgraphs, and the Ramsey property for star unions.",
-      "description": "Establishes the framework for Ramsey theory: an EdgeColoring assigns colors to edges, and a graph H has the Ramsey property for (F₁, F₂) if every 2-coloring contains either a red F₁ or blue F₂."
+      "mathContext": "`EdgeColoring V G = V → V → Bool`. `hasRamseyProperty V H F₁ F₂` states $\\forall c, \\exists$ monochromatic $F_1$ (red) or $F_2$ (blue). `hasMonochromaticCopy` is axiomatized."
     },
     {
       "id": "size-ramsey-numbers",
@@ -101,7 +125,7 @@
       "startLine": 100,
       "endLine": 114,
       "summary": "Defines the size Ramsey number R̂(F₁, F₂) as the minimum edge count for a graph with the Ramsey property.",
-      "description": "The size Ramsey number minimizes edges rather than vertices, making it particularly relevant for sparse graphs. An existence axiom guarantees finiteness."
+      "mathContext": "$\\hat{R}(F_1, F_2) = \\min\\{|E(H)| : \\text{RP}(H; F_1, F_2)\\}$. Axiomatized with existence guarantee. For stars, $\\hat{R}$ is $O(n)$ vs $O(2^n)$ for classical $R$."
     },
     {
       "id": "conjectured-formula",
@@ -109,7 +133,7 @@
       "startLine": 116,
       "endLine": 147,
       "summary": "Formalizes the Erdős conjecture: R̂(F₁,F₂) = Σ_{k=2}^{s+t} max{nᵢ + mⱼ - 1 : i + j = k}.",
-      "description": "The formula sums over index pairs (i,j) with i+j=k, taking the maximum of nᵢ + mⱼ - 1 for each k from 2 to s+t. This captures how stars from the two unions interact."
+      "mathContext": "Formula: $\\hat{R}(F_1, F_2) = \\sum_{k=2}^{s+t} \\max\\{n_i + m_j - 1 : i+j=k\\}$. Uses `indexSumPairs`, `maxForIndexSum`, and `conjecturedFormula` as building blocks."
     },
     {
       "id": "uniform-case",
@@ -117,7 +141,7 @@
       "startLine": 149,
       "endLine": 179,
       "summary": "States and applies the BEFRS78 theorem proving the conjecture when all stars in each union are identical.",
-      "description": "Burr, Erdős, Faudree, Rousseau, and Schelp proved the formula in 1978 for the special case where F₁ consists of s copies of K_{1,n} and F₂ consists of t copies of K_{1,m}."
+      "mathContext": "BEFRS78: $F_1 = s \\cdot K_{1,n}, F_2 = t \\cdot K_{1,m}$ uniform $\\implies \\hat{R}(F_1, F_2) = \\text{formula}$. `uniform_case` constructs the unions via `List.replicate` and applies the axiom."
     },
     {
       "id": "bounds",
@@ -125,7 +149,7 @@
       "startLine": 181,
       "endLine": 194,
       "summary": "Establishes bounds: R̂(F₁,F₂) ≥ max(|E(F₁)|, |E(F₂)|) and upper bounds from complete graphs.",
-      "description": "The lower bound follows because H must be able to contain either F₁ or F₂. The upper bound uses the complete graph K_N, though this is typically far from optimal for sparse graphs."
+      "mathContext": "Lower: $\\hat{R} \\geq \\max(|E(F_1)|, |E(F_2)|)$. Upper: $\\hat{R} \\leq \\binom{R}{2}$ via $K_R$. For stars the gap is dramatic: $\\hat{R} = O(n)$ vs $\\binom{R}{2} = O(n^2)$."
     },
     {
       "id": "classical-connection",
@@ -133,7 +157,7 @@
       "startLine": 196,
       "endLine": 210,
       "summary": "Relates size Ramsey numbers to classical Ramsey numbers, noting that stars are particularly efficient.",
-      "description": "While R̂(F₁,F₂) ≤ (R(F₁,F₂) choose 2), size Ramsey numbers for stars can be linear in vertex count rather than exponential, demonstrating their 'Ramsey efficiency'."
+      "mathContext": "Axiomatized `classicalRamseyNumber` and `size_vs_classical`: $\\hat{R}(F_1, F_2) \\leq R(F_1,F_2) \\cdot (R(F_1,F_2) - 1)/2$. Beck's theorem shows this bound is far from tight for bounded-degree graphs."
     },
     {
       "id": "summary-main",
@@ -141,7 +165,7 @@
       "startLine": 212,
       "endLine": 237,
       "summary": "Consolidates the main theorem (uniform case proven) and states the open question for general star unions.",
-      "description": "The erdos_561 theorem confirms the uniform case via BEFRS78. The openQuestion definition captures that the general conjecture remains unsolved."
+      "mathContext": "`erdos_561_summary = ⟨befrs78_theorem, sizeRamsey_lower_bound⟩`. `erdos_561 = befrs78_theorem`. `openQuestion = erdosConjecture` captures the remaining general case."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Fix 2 invalid annotation types (`axiom`→`concept`) for BEFRS78 and bounds
- Add `prerequisites` to all 11 annotations
- Add 3 new annotations: Star definition, `uniform_case` theorem, size Ramsey number
- Deepen `mathContext` with LaTeX for all annotations and sections
- Add 3 references (BEFRS78 1978, EFRS78, Beck 1983)
- Fix `date` to formalization date
- Deepen historicalContext with Beck's theorem and EFRS78
- Add 5th keyInsight on bridging axiomatized and constructive proofs
- Replace section `description` fields with `mathContext`

## Test plan
- [x] `pnpm annotations:build` passes with 0 warnings for erdos-561

🤖 Generated with [Claude Code](https://claude.com/claude-code)