### PR TITLE
Enrichment: erdos-254 - Subset sum representation annotations and context

### DIFF
--- a/src/data/proofs/erdos-254/annotations.json
+++ b/src/data/proofs/erdos-254/annotations.json
@@ -5,9 +5,11 @@
     "range": { "startLine": 1, "endLine": 25 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "**Erdős Problem #254** asks: if A ⊆ ℕ satisfies a growth condition and an irrationality condition, must every sufficiently large integer be a sum of distinct elements of A?\n\n**Status**: OPEN. Cassels (1960) proved a related result under stronger hypotheses.\n\nThe two conditions are:\n1. Growth: |A ∩ [1,2x]| - |A ∩ [1,x]| → ∞ (enough elements in each dyadic interval)\n2. Irrationality: Σ_{n ∈ A} {θn} = ∞ for all θ ∈ (0,1) (A well-distributed mod θ)",
+    "content": "**Erdős Problem #254** asks: if $A \\subseteq \\mathbb{N}$ satisfies a growth condition and an irrationality condition, must every sufficiently large integer be a sum of distinct elements of $A$?\n\n**Status**: OPEN. Cassels (1960) proved a related result under stronger hypotheses.\n\nThe two conditions are:\n1. Growth: $|A \\cap [1,2x]| - |A \\cap [1,x]| \\to \\infty$ (enough elements in each dyadic interval)\n2. Irrationality: $\\sum_{n \\in A} \\{\\theta n\\} = \\infty$ for all $\\theta \\in (0,1)$ ($A$ well-distributed mod $\\theta$)",
+    "mathContext": "This problem sits at the intersection of additive combinatorics and Diophantine approximation. A set $A \\subseteq \\mathbb{N}$ is called *complete* if every sufficiently large integer is a sum of distinct elements of $A$. Classical results (Folkman 1966, Cassels 1960) give sufficient conditions for completeness. Erdős's conditions are notably weak: the growth condition only requires $|A \\cap [x, 2x]| \\to \\infty$ (not any rate), and the irrationality condition prevents pathological arithmetic structure.",
     "significance": "critical",
-    "relatedConcepts": ["subset sums", "additive number theory", "Cassels theorem"]
+    "relatedConcepts": ["Complete sequences", "Additive number theory", "Cassels' theorem", "Diophantine approximation"],
+    "prerequisites": ["Set theory", "Sequences and series", "Modular arithmetic"]
   },
   {
     "id": "ann-e254-fracdist",
@@ -15,20 +17,47 @@
     "range": { "startLine": 43, "endLine": 53 },
     "type": "definition",
     "title": "Fractional Distance and Counting",
-    "content": "**fracDist(x)** = |x - round(x)|: distance from x to the nearest integer. Values in [0, 1/2].\n\n**fracDist'(x)** = min(x - ⌊x⌋, ⌈x⌉ - x): equivalent alternative definition.\n\n**countTo(A, x)**: number of elements of A in {1, 2, ..., ⌊x⌋}. Used to express growth conditions.",
-    "mathContext": "The fractional distance {x} measures how far x is from being an integer. When θ is irrational, the sequence {θn} is equidistributed by Weyl's theorem, so Σ {θn} = ∞ for any infinite set A. The interesting constraint is for rational θ.",
+    "content": "**fracDist(x)** = $|x - \\text{round}(x)|$: distance from $x$ to the nearest integer. Values in $[0, 1/2]$.\n\n**fracDist'(x)** = $\\min(x - \\lfloor x \\rfloor, \\lceil x \\rceil - x)$: equivalent alternative definition.\n\n**countTo(A, x)**: number of elements of $A$ in $\\{1, 2, \\ldots, \\lfloor x \\rfloor\\}$. Used to express growth conditions.",
+    "mathContext": "The fractional distance $\\|x\\| = \\min_{n \\in \\mathbb{Z}} |x - n|$ measures how far $x$ is from being an integer. By Weyl's equidistribution theorem, if $\\theta$ is irrational, the sequence $\\{\\theta n\\}_{n=1}^{\\infty}$ is equidistributed mod 1, so $\\sum_{n=1}^{N} \\|\\theta n\\| \\sim N/4$. The irrationality condition $\\sum_{n \\in A} \\|\\theta n\\| = \\infty$ thus holds automatically for any infinite $A$ when $\\theta$ is irrational — the constraint is substantive only for rational $\\theta$.",
     "significance": "key",
-    "relatedConcepts": ["fractional part", "Weyl's theorem", "equidistribution"]
+    "relatedConcepts": ["Fractional part", "Weyl's theorem", "Equidistribution", "Distance to integers"],
+    "prerequisites": ["Real.round", "Int.floor", "Finset.filter"]
   },
   {
-    "id": "ann-e254-conditions",
+    "id": "ann-e254-growth",
     "proofId": "erdos-254",
-    "range": { "startLine": 55, "endLine": 81 },
+    "range": { "startLine": 55, "endLine": 66 },
     "type": "definition",
-    "title": "Growth and Irrationality Conditions",
-    "content": "**HasGrowthCondition(A)**: For every M, eventually countTo(A, 2x) - countTo(A, x) ≥ M. This means A has arbitrarily many elements in each dyadic interval.\n\n**HasIrrationalityCondition(A)**: For every θ ∈ (0,1), the sum Σ_{n ∈ A} fracDist(θn) diverges. This prevents A from being too structured (e.g., all elements ≡ 0 mod some q).\n\nTogether these two conditions should force A to be 'rich enough' for complete representation.",
+    "title": "The Growth Condition",
+    "content": "**HasGrowthCondition(A)**: For every $M$, eventually $\\text{countTo}(A, 2x) - \\text{countTo}(A, x) \\ge M$.\n\n```lean\ndef HasGrowthCondition (A : Set ℕ) : Prop :=\n  ∀ M : ℕ, ∃ x₀ : ℝ, x₀ > 0 ∧\n    ∀ x ≥ x₀, countTo A (2 * x) - countTo A x ≥ M\n```\n\nThis means $A$ has arbitrarily many elements in each dyadic interval $[x, 2x]$ for large $x$.",
+    "mathContext": "The growth condition $|A \\cap (x, 2x]| \\to \\infty$ is remarkably weak — it only requires unbounded growth, not any particular rate. Compare with Cassels's stronger condition requiring growth $\\gg \\log\\log x$. Sets like $\\{\\lfloor n \\log n \\rfloor : n \\ge 1\\}$ satisfy the growth condition, as do any sets with positive lower density. The dyadic decomposition $[1, N] = \\bigcup_{k} [2^k, 2^{k+1}]$ is the natural scale for this condition.",
     "significance": "critical",
-    "relatedConcepts": ["dyadic intervals", "divergent series", "additive structure"]
+    "relatedConcepts": ["Dyadic intervals", "Growth rates", "Counting functions"],
+    "prerequisites": ["countTo", "Universal-existential quantification"]
+  },
+  {
+    "id": "ann-e254-irrationality",
+    "proofId": "erdos-254",
+    "range": { "startLine": 67, "endLine": 82 },
+    "type": "definition",
+    "title": "The Irrationality Condition",
+    "content": "**HasIrrationalityCondition(A)**: For every $\\theta \\in (0,1)$, $\\sum_{n \\in A} \\|\\theta n\\| = \\infty$.\n\n```lean\ndef HasIrrationalityCondition (A : Set ℕ) : Prop :=\n  ∀ θ : ℝ, 0 < θ → θ < 1 → fracDistSum A θ = ⊤\n```\n\nThis prevents $A$ from concentrating near multiples of any rational $p/q$, which would block representation of integers $\\not\\equiv 0 \\pmod{q}$.",
+    "mathContext": "The condition $\\sum_{n \\in A} \\|\\theta n\\| = \\infty$ for all $\\theta \\in (0,1)$ is a uniform irrationality measure. For rational $\\theta = p/q$ with $\\gcd(p,q) = 1$, $\\|\\theta n\\|$ depends on $n \\bmod q$: if $A$ contains $\\gg q$ elements in each residue class mod $q$, the sum diverges. Erdős's condition forces $A$ to be well-distributed modulo every denominator, connecting to the theory of complete sequences in additive number theory.",
+    "significance": "critical",
+    "relatedConcepts": ["Diophantine approximation", "Divergent series", "Residue classes", "tsum"],
+    "prerequisites": ["fracDist", "fracDistSum", "Extended reals (⊤)"]
+  },
+  {
+    "id": "ann-e254-subset-sum",
+    "proofId": "erdos-254",
+    "range": { "startLine": 83, "endLine": 94 },
+    "type": "definition",
+    "title": "Subset Sum Representation",
+    "content": "**IsSubsetSum(A, n)**: $n$ can be written as $\\sum_{a \\in S} a$ for some finite $S \\subseteq A$ with distinct elements.\n\n**RepresentsAllLarge(A)**: $\\exists N, \\forall n \\ge N$, `IsSubsetSum(A, n)`.\n\n```lean\ndef IsSubsetSum (A : Set ℕ) (n : ℕ) : Prop :=\n  ∃ S : Finset ℕ, ↑S ⊆ A ∧ S.sum id = n\n```\n\nThe 'distinct elements' constraint comes from using `Finset` (no duplicates).",
+    "mathContext": "A set $A$ is called *complete* if $\\text{RepresentsAllLarge}(A)$ holds. Sprague (1948) showed that $A$ is complete if $a_{n+1} \\le 1 + \\sum_{i=1}^{n} a_i$ for all $n$ (each new element fills the next gap). Complete sequences include powers of 2, Fibonacci numbers, and any set with elements growing at most exponentially. The subset sum problem is NP-complete in general, but here the question is about *existence*, not finding representations efficiently.",
+    "significance": "key",
+    "relatedConcepts": ["Complete sequences", "Subset sum problem", "Finset.sum", "Binary representation"],
+    "prerequisites": ["Finset", "Set coercion", "Function.id"]
   },
   {
     "id": "ann-e254-conjecture",
@@ -36,30 +65,35 @@
     "range": { "startLine": 95, "endLine": 108 },
     "type": "definition",
     "title": "The Erdős Conjecture",
-    "content": "**ErdosConjecture**: If A has growth + irrationality, then RepresentsAllLarge(A).\n\n**RepresentsAllLarge(A)**: ∃ N, ∀ n ≥ N, n is a sum of distinct elements of A.\n\n**IsSubsetSum(A, n)**: ∃ S ⊆ A (finite, distinct), Σ S = n.\n\nThe conjecture remains OPEN in its original form.",
+    "content": "**ErdosConjecture**: If $A$ has growth + irrationality, then $\\text{RepresentsAllLarge}(A)$.\n\n```lean\ndef ErdosConjecture : Prop :=\n  ∀ A : Set ℕ,\n    HasGrowthCondition A →\n    HasIrrationalityCondition A →\n    RepresentsAllLarge A\n```\n\nThe conjecture remains **OPEN** in its original form. It asserts that the two conditions together are sufficient for completeness.",
+    "mathContext": "The conjecture's structure is $\\forall A,\\; P_1(A) \\wedge P_2(A) \\Rightarrow Q(A)$, where $P_1$ is a density condition (growth) and $P_2$ is an arithmetic condition (irrationality). Neither condition alone suffices: $A = \\{2^k\\}$ satisfies $P_1$ but barely, while $A = \\{2k : k \\ge 1\\}$ satisfies growth but fails to represent odd integers. The irrationality condition is precisely what blocks such arithmetic obstructions.",
     "significance": "critical",
-    "relatedConcepts": ["complete sequences", "representation problems", "open conjecture"]
+    "relatedConcepts": ["Open conjectures", "Sufficient conditions for completeness", "Additive combinatorics"],
+    "prerequisites": ["HasGrowthCondition", "HasIrrationalityCondition", "RepresentsAllLarge"]
   },
   {
     "id": "ann-e254-cassels",
     "proofId": "erdos-254",
     "range": { "startLine": 110, "endLine": 137 },
-    "type": "axiom",
+    "type": "theorem",
     "title": "Cassels's Theorem (1960)",
-    "content": "**cassels_theorem (axiom):** Under strictly stronger hypotheses, every large integer is a subset sum.\n\n**HasStrongGrowthCondition**: (count(2x) - count(x)) / log log x → ∞. Strictly stronger than Erdős's condition.\n\n**HasStrongIrrationalityCondition**: Σ {θn}² = ∞. Strictly weaker than Erdős's Σ {θn} = ∞ (since {θn}² ≤ {θn}).\n\nThe 'paradox': Cassels weakens one condition but strengthens the other, and the combination works. The gap between Erdős's and Cassels's conditions is the open question.",
-    "mathContext": "The growth strengthening (dividing by log log x) is substantial — Erdős only requires divergence to ∞, while Cassels requires divergence faster than log log x.",
+    "content": "**cassels_theorem (axiom):** Under strictly stronger hypotheses, every large integer is a subset sum.\n\n**HasStrongGrowthCondition**: $(\\text{count}(2x) - \\text{count}(x)) / \\log\\log x \\to \\infty$. Strictly stronger than Erdős's condition.\n\n**HasStrongIrrationalityCondition**: $\\sum \\|\\theta n\\|^2 = \\infty$. Strictly *weaker* than Erdős's $\\sum \\|\\theta n\\| = \\infty$ (since $\\|\\theta n\\|^2 \\le \\|\\theta n\\|$).\n\nThe 'paradox': Cassels strengthens one condition but weakens the other, and the combination works.",
+    "mathContext": "Cassels's proof in 'On the representation of integers as the sums of distinct summands taken from a fixed set' (Acta Sci. Math. Szeged, 1960) uses a Fourier-analytic method. The $L^2$ irrationality condition $\\sum \\|\\theta n\\|^2 = \\infty$ is natural because $\\|\\theta n\\|^2$ appears when squaring exponential sums $|\\sum_{n \\in A} e^{2\\pi i \\theta n}|^2$. The logarithmic growth condition ensures enough 'room' for the circle method estimates. The gap between Erdős's and Cassels's conditions is the open question.",
     "significance": "critical",
-    "relatedConcepts": ["Cassels 1960", "stronger hypotheses", "log log growth"]
+    "relatedConcepts": ["Cassels 1960", "Circle method", "Fourier analysis", "log log growth"],
+    "prerequisites": ["HasGrowthCondition", "fracDistSqSum", "Real.log"]
   },
   {
     "id": "ann-e254-examples",
     "proofId": "erdos-254",
     "range": { "startLine": 139, "endLine": 156 },
-    "type": "axiom",
+    "type": "concept",
     "title": "Powers of 2 Example",
-    "content": "**PowersOf2** = {1, 2, 4, 8, 16, ...} satisfies both conditions:\n\n1. **Growth**: Each dyadic interval [2^k, 2^{k+1}] contains exactly one power of 2, so the count grows.\n2. **Irrationality**: For irrational θ, {θ · 2^k} is equidistributed; for rational θ = p/q, eventually 2^k mod q cycles through residues.\n3. **Representation**: Every n ∈ ℕ has a unique binary representation as a sum of distinct powers of 2.\n\nThis is the canonical example confirming the conjecture's conclusion is reasonable.",
+    "content": "**PowersOf2** $= \\{1, 2, 4, 8, 16, \\ldots\\} = \\{2^k : k \\ge 0\\}$ satisfies both conditions:\n\n1. **Growth**: Each dyadic interval $[2^k, 2^{k+1}]$ contains exactly one power of 2.\n2. **Irrationality**: For irrational $\\theta$, $\\{\\theta \\cdot 2^k\\}$ is equidistributed; for rational $\\theta = p/q$, eventually $2^k \\bmod q$ cycles.\n3. **Representation**: Every $n \\in \\mathbb{N}$ has a unique binary representation as $\\sum_{k \\in S} 2^k$.\n\nThis is the canonical example confirming the conjecture's conclusion is reasonable.",
+    "mathContext": "The binary representation theorem states every positive integer $n$ can be uniquely written as $n = \\sum_{k \\in S} 2^k$ for some finite $S \\subseteq \\mathbb{N}$. For the irrationality condition, $\\|\\theta \\cdot 2^k\\|$ involves the binary expansion of $\\theta$: if $\\theta = 0.b_1 b_2 b_3 \\ldots$ in binary, then $\\|\\theta \\cdot 2^k\\|$ depends on $b_{k+1}, b_{k+2}, \\ldots$. For irrational $\\theta$ (non-eventually-periodic binary expansion), the sum diverges.",
     "significance": "key",
-    "relatedConcepts": ["binary representation", "equidistribution", "concrete example"]
+    "relatedConcepts": ["Binary representation", "Equidistribution", "Concrete examples", "Complete sequences"],
+    "prerequisites": ["PowersOf2 definition", "HasGrowthCondition", "HasIrrationalityCondition"]
   },
   {
     "id": "ann-e254-summary",
@@ -67,7 +101,10 @@
     "range": { "startLine": 158, "endLine": 185 },
     "type": "theorem",
     "title": "Summary Theorem",
-    "content": "**erdos_254_summary (proved from axioms):**\n\nCombines three results:\n1. Cassels's theorem: representation under strong conditions\n2. Powers of 2 satisfy growth + irrationality conditions\n3. Powers of 2 represent all large integers\n\nProved by: `⟨cassels_theorem, ⟨powers_of_2_growth, powers_of_2_irrationality⟩, powers_of_2_representation⟩`",
-    "significance": "critical"
+    "content": "**erdos_254_summary (proved from axioms):**\n\nCombines three results:\n1. Cassels's theorem: representation under strong conditions\n2. Powers of 2 satisfy growth + irrationality conditions\n3. Powers of 2 represent all large integers\n\nProved by: $\\langle\\texttt{cassels\\_theorem}, \\langle\\texttt{growth}, \\texttt{irrationality}\\rangle, \\texttt{representation}\\rangle$",
+    "mathContext": "The summary theorem packages the formalization's content as a conjunction. While the open conjecture `ErdosConjecture` is stated but not proved, the summary demonstrates: (a) Cassels's stronger version is axiomatized, (b) a concrete example (powers of 2) satisfies all conditions, and (c) the example achieves the desired conclusion. This shows the formalization captures both the known result and the gap to the open problem.",
+    "significance": "critical",
+    "relatedConcepts": ["Theorem packaging", "Open problems vs. proved results", "Conjunction introduction"],
+    "prerequisites": ["cassels_theorem", "powers_of_2_growth", "powers_of_2_irrationality", "powers_of_2_representation"]
   }
 ]

--- a/src/data/proofs/erdos-254/meta.json
+++ b/src/data/proofs/erdos-254/meta.json
@@ -24,7 +24,7 @@
     "erdosProblemStatus": "open"
   },
   "overview": {
-    "historicalContext": "Erdős Problem #254 concerns subset sum representations of integers. Given a set A ⊆ ℕ satisfying (1) |A ∩ [1,2x]| - |A ∩ [1,x]| → ∞ (slow but unbounded growth) and (2) Σ_{n∈A} ||θn|| = ∞ for every θ ∈ (0,1), Erdős conjectured that every sufficiently large integer is a sum of distinct elements of A. Cassels (1960) proved a related result under stronger hypotheses, replacing condition (1) with logarithmic growth and condition (2) with a square-summability condition. The problem in its original form remains open, connecting additive number theory with Diophantine approximation.",
+    "historicalContext": "**Erdős Problem #254** was posed by Paul Erdős in 1961, connecting additive combinatorics with Diophantine approximation. Given $A \\subseteq \\mathbb{N}$ with (1) unbounded growth in dyadic intervals: $|A \\cap [x, 2x]| \\to \\infty$, and (2) an irrationality condition: $\\sum_{n \\in A} \\|\\theta n\\| = \\infty$ for all $\\theta \\in (0,1)$, Erdős conjectured every sufficiently large integer is a sum of distinct elements of $A$.\n\nJ.W.S. Cassels proved a related result in his 1960 paper 'On the representation of integers as the sums of distinct summands taken from a fixed set' (Acta Sci. Math. Szeged, 111-124). Cassels's theorem replaces condition (1) with the stronger logarithmic growth $|A \\cap [x, 2x]|/\\log\\log x \\to \\infty$ and uses the weaker $L^2$ condition $\\sum \\|\\theta n\\|^2 = \\infty$. His proof employs Fourier analysis on the circle $\\mathbb{R}/\\mathbb{Z}$, using the exponential sum $\\sum_{n \\in A} e^{2\\pi i \\theta n}$ to control the number of representations.\n\nThe problem in its original form remains **open**. The gap between Erdős's weak conditions and Cassels's stronger ones is the central challenge: Erdős requires no growth rate at all, only unboundedness, which is too weak for Cassels's Fourier-analytic approach to apply directly.",
     "problemStatement": "Let $A\\subseteq \\mathbb{N}$ be such that\\[\\lvert A\\cap [1,2x]\\rvert -\\lvert A\\cap [1,x]\\rvert \\to \\infty\\textrm{ as }x\\to \\infty\\]and\\[\\sum_{n\\in A} \\{ \\theta n\\}=\\infty\\]for every $\\theta\\in (0,1)$, where $\\{x\\}$ is the distance of $x$ from the nearest integer. Then every sufficiently large integer is the sum of distinct elements of $A$.\n\n\n\nCassels \\cite{Ca60} proved this under the alternative hypotheses\\[\\lim \\frac{\\lvert A\\cap [1,2x]\\rvert -\\lvert A\\cap [1,x]\\rvert}{\\log\\log x}=\\infty\\]and\\[\\sum_{n\\in A} \\{ \\theta n\\}^2=\\infty\\]for every $\\theta\\in (0,1)$.\n\n\n\n\nReferences\n\n\n[Ca60] Cassels, J. W. S., On the representation of integers as the sums of distinct summands taken from a fixed set. Acta Sci. Math. (Szeged) (1960), 111-124.",
     "proofStrategy": "The formalization defines the two key conditions (growth and irrationality) and states both Erdős's open conjecture and Cassels's proved theorem. The growth condition requires |A ∩ [1,2x]| - |A ∩ [1,x]| → ∞, ensuring A has elements spread across all dyadic intervals. The irrationality condition Σ{θn} = ∞ prevents A from being too concentrated modulo any irrational. Cassels's stronger version replaces these with logarithmic growth rate and L² summability. Powers of 2 serve as a concrete example satisfying all conditions.",
     "keyInsights": [
@@ -41,63 +41,63 @@
       "title": "Erdős Problem #254: Sumset Representation from Growth and Irrationality Conditions",
       "startLine": 1,
       "endLine": 36,
-      "summary": "Header documentation stating the problem, known results by Cassels, and references."
+      "summary": "Header documenting the problem statement, Cassels's partial result, and references [Er61], [Ca60]."
     },
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "startLine": 37,
       "endLine": 54,
-      "summary": "Defines fracDist (distance to nearest integer) and countTo (counting function for A ∩ [1,x])."
+      "summary": "Defines $\\|x\\| = |x - \\text{round}(x)|$ (distance to nearest integer) and the counting function $|A \\cap [1,x]|$ for expressing growth conditions."
     },
     {
       "id": "the-growth-condition",
       "title": "The Growth Condition",
       "startLine": 55,
       "endLine": 66,
-      "summary": "Formalizes |A ∩ [1,2x]| - |A ∩ [1,x]| → ∞ as HasGrowthCondition."
+      "summary": "Formalizes the weak growth condition: $|A \\cap [x, 2x]| \\to \\infty$ as $x \\to \\infty$ — enough elements in each dyadic interval."
     },
     {
       "id": "the-irrationality-condition",
       "title": "The Irrationality Condition",
       "startLine": 67,
       "endLine": 82,
-      "summary": "Formalizes Σ{θn} = ∞ for all θ ∈ (0,1) as HasIrrationalityCondition."
+      "summary": "Formalizes the irrationality condition: $\\sum_{n \\in A} \\|\\theta n\\| = \\infty$ for all $\\theta \\in (0,1)$, preventing arithmetic concentration."
     },
     {
       "id": "subset-sum-representation",
       "title": "Subset Sum Representation",
       "startLine": 83,
       "endLine": 94,
-      "summary": "Defines IsSubsetSum and RepresentsAllLarge for the conclusion of the conjecture."
+      "summary": "Defines `IsSubsetSum(A, n)` — $n = \\sum_{a \\in S} a$ for finite $S \\subseteq A$ — and `RepresentsAllLarge(A)` — all large integers are representable."
     },
     {
       "id": "the-conjecture",
       "title": "The Conjecture",
       "startLine": 95,
       "endLine": 109,
-      "summary": "States Erdős's open conjecture combining both conditions to imply subset sum representation."
+      "summary": "States Erdős's **open** conjecture: growth + irrationality $\\Rightarrow$ every large integer is a subset sum of $A$."
     },
     {
       "id": "cassels-s-theorem-1960",
       "title": "Cassels's Theorem (1960)",
       "startLine": 110,
       "endLine": 138,
-      "summary": "States and axiomatizes Cassels's theorem under stronger growth (logarithmic) and irrationality (L²) conditions."
+      "summary": "Axiomatizes Cassels's result under the stronger conditions: growth $\\gg \\log\\log x$ and $\\sum \\|\\theta n\\|^2 = \\infty$. Defines `HasStrongGrowthCondition` and `HasStrongIrrationalityCondition`."
     },
     {
       "id": "examples",
       "title": "Examples",
       "startLine": 139,
       "endLine": 157,
-      "summary": "Powers of 2 as a concrete example satisfying all conditions, with binary representation as the representation."
+      "summary": "Powers of 2: $\\{2^k : k \\ge 0\\}$ satisfies both conditions and every positive integer has a binary representation as a sum of distinct powers."
     },
     {
       "id": "summary",
       "title": "Summary",
       "startLine": 158,
       "endLine": 185,
-      "summary": "Combines Cassels's theorem, the powers of 2 example, and the open conjecture into a summary theorem."
+      "summary": "Packages Cassels's theorem, the powers-of-2 verification, and representation into `erdos_254_summary`, demonstrating both the known result and the gap to the open conjecture."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Added `mathContext`, `relatedConcepts`, `prerequisites` to all 9 annotations
- Fixed invalid annotation types (`axiom` → `theorem`/`concept`)
- Split combined annotation into 4 focused annotations (growth, irrationality, subset-sum, examples)
- Expanded `historicalContext` with Cassels's Fourier-analytic proof technique
- Enhanced all 9 section summaries with LaTeX notation

## Test plan
- [x] `pnpm annotations:build` passes (no erdos-254 errors)
- [ ] Visual review of enriched gallery page