### PR TITLE
Enrichment: erdos-402 - Graham's GCD Conjecture annotations and context

### DIFF
--- a/src/data/proofs/erdos-402/annotations.json
+++ b/src/data/proofs/erdos-402/annotations.json
@@ -1,124 +1,146 @@
 [
   {
+    "id": "ann-e402-imports",
+    "proofId": "erdos-402",
+    "type": "concept",
+    "range": { "startLine": 80, "endLine": 85 },
+    "title": "Imports and Namespace",
+    "content": "Imports `Mathlib` for `Nat.gcd`, `Finset`, and `Finset.gcd`/`Finset.lcm` operations. Opens `Nat` and `Finset` namespaces for concise notation throughout.",
+    "mathContext": "The formalization uses `Finset ℕ` throughout — finite subsets of naturals — since Graham's conjecture concerns finite sets. The `Nat.gcd` function and `Nat.Coprime` predicate from Mathlib provide the GCD infrastructure.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset", "Nat.gcd", "Namespace"],
+    "prerequisites": ["Lean 4 import system", "Mathlib"]
+  },
+  {
     "id": "ann-e402-header",
     "proofId": "erdos-402",
-    "range": {
-      "startLine": 1,
-      "endLine": 27
-    },
     "type": "concept",
-    "title": "Problem Overview",
-    "content": "**Erdős Problem #402 (Graham's GCD Conjecture)**: For any finite set A ⊂ ℕ, there exist a, b ∈ A such that gcd(a,b) ≤ a/|A|. Proved by Balasubramanian & Soundararajan (1996).",
-    "mathContext": "The bound relates the gcd of elements to the set's cardinality. Graham also characterized when equality holds.",
-    "significance": "key",
-    "relatedConcepts": [
-      "gcd",
-      "finite-sets",
-      "combinatorics"
-    ]
+    "range": { "startLine": 52, "endLine": 78 },
+    "title": "Problem Overview: Graham's GCD Conjecture",
+    "content": "**Erdős Problem #402 (Graham's GCD Conjecture)**: For any finite set $A \\subset \\mathbb{N}^+$, there exist $a, b \\in A$ such that $\\gcd(a,b) \\le \\lfloor a / |A| \\rfloor$. Conjectured by Graham (1970), proved by Balasubramanian and Soundararajan (1996) after partial results by Szegedy (1986) and Zaharescu (1987).",
+    "mathContext": "The conjecture emerged from Graham's study of **multiplicative structure** in finite sets. The bound $\\gcd(a,b) \\le a/|A|$ says that in any finite set of positive integers, some pair has a GCD that is small relative to the set's cardinality. Graham also conjectured a complete characterization of equality cases, which Aristotle's counterexample {1,2,4} shows requires refinement.",
+    "significance": "critical",
+    "relatedConcepts": ["GCD", "Finite sets", "Multiplicative number theory", "Extremal combinatorics"],
+    "prerequisites": ["Natural numbers", "Greatest common divisor", "Finite sets"]
   },
   {
     "id": "ann-e402-main",
     "proofId": "erdos-402",
-    "range": {
-      "startLine": 35,
-      "endLine": 46
-    },
     "type": "theorem",
-    "title": "Main Statement",
-    "content": "**Graham's GCD Conjecture**: For any finite nonempty set A of positive integers, there exist a, b ∈ A with gcd(a,b) ≤ a/|A|.",
-    "mathContext": "erdos_402_graham_conjecture (A : Finset ℕ) (hA : A.Nonempty) (hpos : ∀ x ∈ A, x > 0) : ∃ a ∈ A, ∃ b ∈ A, Nat.gcd a b ≤ a / A.card",
-    "significance": "key",
-    "relatedConcepts": [
-      "finset",
-      "nat-gcd",
-      "existence"
-    ]
+    "range": { "startLine": 95, "endLine": 99 },
+    "title": "Graham's GCD Conjecture (Main Statement)",
+    "content": "**erdos_402_graham_conjecture**: For any finite nonempty set $A$ of positive integers, $\\exists a, b \\in A: \\gcd(a,b) \\le \\lfloor a / |A| \\rfloor$. This is the central result, proved by Balasubramanian–Soundararajan (1996) but left as `sorry` in this formalization.",
+    "mathContext": "The proof by Balasubramanian–Soundararajan uses a combination of **sieve methods** and **analytic number theory**. The key idea is to analyze the prime factorization structure of elements in $A$ and show that some pair must share small factors. Szegedy's earlier approach handled sets of size $\\ge N_0$ for a computable constant $N_0$.",
+    "significance": "critical",
+    "relatedConcepts": ["Balasubramanian–Soundararajan theorem", "Sieve methods", "Floor division"],
+    "prerequisites": ["Finset.Nonempty", "Nat.gcd", "Nat.div"]
   },
   {
     "id": "ann-e402-ratio",
     "proofId": "erdos-402",
-    "range": {
-      "startLine": 48,
-      "endLine": 63
-    },
     "type": "definition",
-    "title": "Equivalent Formulation",
-    "content": "**MinGcdRatio**: The minimum ratio gcd(a,b)/a over all pairs in A. The conjecture states this is at most 1/|A|.",
-    "mathContext": "An equivalent formulation using rationals: ∃ a, b ∈ A, gcd(a,b)/a ≤ 1/|A|.",
+    "range": { "startLine": 106, "endLine": 128 },
+    "title": "Equivalent Rational Formulation",
+    "content": "**MinGcdRatio** and **erdos_402_ratio_bound**: An equivalent formulation over $\\mathbb{Q}$: $\\exists a, b \\in A: \\gcd(a,b)/a \\le 1/|A|$. The theorem was **proved by Aristotle** from the main conjecture via algebraic manipulation.",
+    "mathContext": "The rational formulation avoids the floor function, giving a cleaner inequality. The proof derives $\\gcd(a,b) \\cdot |A| \\le a$ from the integer bound, then divides by $a > 0$ to get the rational form. Aristotle's proof uses `field_simp` and `div_le_one_of_le₀` to handle the rational arithmetic.",
     "significance": "key",
-    "relatedConcepts": [
-      "rational-numbers",
-      "inf-finset"
-    ]
+    "relatedConcepts": ["Rational arithmetic", "MinGcdRatio", "Aristotle proof"],
+    "prerequisites": ["erdos_402_graham_conjecture", "Rat", "Finset.inf'"]
   },
   {
     "id": "ann-e402-singleton",
     "proofId": "erdos-402",
-    "range": {
-      "startLine": 65,
-      "endLine": 81
-    },
     "type": "theorem",
-    "title": "Special Cases",
-    "content": "**Singleton case**: For A = {a}, gcd(a,a) = a ≤ a/1 = a. **Range case**: For A = {1,...,n}, we need appropriate pair selection.",
-    "mathContext": "Base cases that verify the conjecture for simple set structures.",
+    "range": { "startLine": 132, "endLine": 137 },
+    "title": "Singleton Case",
+    "content": "**erdos_402_singleton**: For $A = \\{a\\}$, we have $\\gcd(a,a) = a = a/1 = a/|A|$, so the bound holds with equality. Proved by `simp [Nat.gcd_self]`.",
+    "mathContext": "The singleton case is the simplest verification: $\\gcd(a,a) = a$ and $|A| = 1$, so $\\gcd(a,a) = a \\le a/1 = a$. This is one of infinitely many equality cases.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "singleton",
-      "finset-range"
-    ]
+    "relatedConcepts": ["Nat.gcd_self", "Base case"],
+    "prerequisites": ["Finset.mem_singleton", "Nat.gcd_self"]
+  },
+  {
+    "id": "ann-e402-range",
+    "proofId": "erdos-402",
+    "type": "theorem",
+    "range": { "startLine": 140, "endLine": 147 },
+    "title": "Range Case {1,...,n}",
+    "content": "**erdos_402_range**: For $A = \\{1, 2, \\ldots, n\\}$, the conjecture holds. **Proved by Aristotle** via case analysis: for $n \\ge 3$, use $a = n+2$ and $b = 1$. This is one of the three primitive equality families.",
+    "mathContext": "The range case uses `rcases n` to split into small cases and a general case. For $n \\ge 3$, the pair $(n+2, 1)$ gives $\\gcd(n+2, 1) = 1 \\le (n+2)/|A|$ since $|A| \\le n+2$. The set $\\{1, \\ldots, n\\}$ is a classic equality case identified by Graham.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.range", "Case analysis", "Aristotle proof"],
+    "prerequisites": ["Finset.range", "Finset.sdiff"]
   },
   {
     "id": "ann-e402-graham-set",
     "proofId": "erdos-402",
-    "range": {
-      "startLine": 83,
-      "endLine": 102
-    },
-    "type": "theorem",
-    "title": "Graham Special Set",
-    "content": "**{2, 3, 4, 6}**: A special set mentioned by Graham. We verify gcd(4,3) = 1 ≤ 4/4 = 1, confirming the conjecture holds with equality.",
-    "mathContext": "GrahamSpecialSet = {2, 3, 4, 6}. This is one of three families achieving equality in the bound.",
+    "type": "definition",
+    "range": { "startLine": 152, "endLine": 168 },
+    "title": "Graham's Special Set {2, 3, 4, 6}",
+    "content": "**GrahamSpecialSet** $= \\{2, 3, 4, 6\\}$: the unique sporadic equality case. Verified: $\\gcd(4,3) = 1 = \\lfloor 4/4 \\rfloor$. The card is confirmed to be 4 via `native_decide`.",
+    "mathContext": "This is the only primitive equality case not belonging to an infinite family. The pair $(4, 3)$ is coprime and $4/4 = 1$, so $\\gcd(4,3) = 1 \\le 1$. Graham conjectured this, along with $\\{1,\\ldots,n\\}$ and $\\{L/1,\\ldots,L/n\\}$, are the only primitive sets achieving equality. Aristotle's counterexample {1,2,4} later showed this characterization needs refinement.",
     "significance": "key",
-    "relatedConcepts": [
-      "native-decide",
-      "equality-case"
-    ]
+    "relatedConcepts": ["Sporadic example", "native_decide", "Equality case"],
+    "prerequisites": ["Finset literal", "Nat.gcd", "native_decide"]
   },
   {
-    "id": "ann-e402-equality",
+    "id": "ann-e402-equality-defs",
     "proofId": "erdos-402",
-    "range": {
-      "startLine": 104,
-      "endLine": 135
-    },
-    "type": "theorem",
-    "title": "Equality Characterization",
-    "content": "**Graham's Equality Conjecture**: For primitive sets (gcd of all elements = 1), equality is achieved only for: {1,...,n}, {L/1,...,L/n} where L = lcm(1,...,n), or {2,3,4,6}.",
-    "mathContext": "IsGrahamEqualityCase characterizes exactly which sets achieve the bound with equality.",
+    "type": "definition",
+    "range": { "startLine": 175, "endLine": 190 },
+    "title": "Equality Characterization Definitions",
+    "content": "**HasNoCommonDivisor**: $\\gcd(A) = 1$ (primitive set). **IsGrahamEqualityCase**: $A$ is one of (1) $\\{1,\\ldots,n\\}$, (2) $\\{\\text{lcm}(1,\\ldots,n)/k : 1 \\le k \\le n\\}$, or (3) $\\{2,3,4,6\\}$.",
+    "mathContext": "A set is **primitive** if $\\gcd$ of all its elements is 1. Non-primitive sets can be reduced to primitive ones by dividing by their common factor. The three equality families are: consecutive integers $\\{1,\\ldots,n\\}$, their 'dual' $\\{L/1,\\ldots,L/n\\}$ where $L = \\text{lcm}(1,\\ldots,n)$, and the sporadic $\\{2,3,4,6\\}$. However, this characterization was shown to be incomplete by Aristotle.",
     "significance": "key",
-    "relatedConcepts": [
-      "primitive-sets",
-      "lcm",
-      "characterization"
-    ]
+    "relatedConcepts": ["Primitive sets", "Finset.gcd", "Finset.lcm", "Equality classification"],
+    "prerequisites": ["Finset.gcd", "Finset.lcm", "GrahamSpecialSet"]
   },
   {
-    "id": "ann-e402-lemmas",
+    "id": "ann-e402-counterexample",
     "proofId": "erdos-402",
-    "range": {
-      "startLine": 137,
-      "endLine": 151
-    },
+    "type": "insight",
+    "range": { "startLine": 192, "endLine": 278 },
+    "title": "Aristotle's Counterexample: {1, 2, 4} Falsifies Equality Characterization",
+    "content": "**Aristotle discovered** that the equality characterization is **false**: the set $\\{1, 2, 4\\}$ is primitive, satisfies $\\gcd(a,b) \\ge a/|A|$ for all pairs, but is **not** one of the three Graham families. This block (in a comment) contains Aristotle's full proof of the negation, including `counterexample_124_satisfies`, `counterexample_124_primitive`, and `counterexample_124_not_case`.",
+    "mathContext": "For $A = \\{1, 2, 4\\}$ with $|A| = 3$: all pairwise GCDs satisfy $\\gcd(a,b) \\ge \\lfloor a/3 \\rfloor$. Yet $\\{1,2,4\\}$ is not $\\{1,2,3\\}$, not an lcm-dual, and not $\\{2,3,4,6\\}$. This means Graham's equality characterization as stated is incomplete — additional primitive equality cases exist. The `negate_state` tactic is used to prove the negation.",
+    "significance": "critical",
+    "relatedConcepts": ["Counterexample", "negate_state tactic", "Aristotle negation", "Falsification"],
+    "prerequisites": ["HasNoCommonDivisor", "IsGrahamEqualityCase", "SatisfiesGrahamCondition"]
+  },
+  {
+    "id": "ann-e402-equality-theorem",
+    "proofId": "erdos-402",
     "type": "theorem",
-    "title": "Key Lemmas",
-    "content": "**gcd_one_suffices**: For coprime a, b with |A| ≤ a, gcd(a,b) = 1 ≤ a/|A|. **one_in_singleton_set**: The singleton {1} satisfies the conjecture.",
-    "mathContext": "Helper lemmas showing that coprime pairs and small sets satisfy the bound.",
+    "range": { "startLine": 284, "endLine": 289 },
+    "title": "Equality Cases Theorem (Sorry)",
+    "content": "**erdos_402_equality_cases**: The surviving theorem statement after Aristotle's negation. States that primitive sets with $\\gcd(a,b) \\ge a/|A|$ for all pairs are Graham equality cases. Left as `sorry` — the characterization likely needs to include additional families like $\\{1, 2, 4\\}$.",
+    "mathContext": "The theorem as stated is **false** (shown by Aristotle's counterexample). The `sorry` masks this issue. A correct formulation would either add $\\{1, 2, 4\\}$ and potentially other families to `IsGrahamEqualityCase`, or weaken the hypothesis. This is a known issue in the formalization.",
+    "significance": "key",
+    "relatedConcepts": ["False theorem", "Counterexample", "Formalization gap"],
+    "prerequisites": ["HasNoCommonDivisor", "IsGrahamEqualityCase"]
+  },
+  {
+    "id": "ann-e402-coprime-lemma",
+    "proofId": "erdos-402",
+    "type": "theorem",
+    "range": { "startLine": 294, "endLine": 299 },
+    "title": "Coprime Pair Sufficiency Lemma",
+    "content": "**gcd_one_suffices**: If $a, b$ are coprime and $|A| \\le a$, then $\\gcd(a,b) = 1 \\le \\lfloor a/|A| \\rfloor$. Proved constructively using `Nat.one_le_div_iff`.",
+    "mathContext": "This lemma reduces the problem to finding coprime pairs in large sets: if any coprime pair $(a,b)$ exists with $a \\ge |A|$, the conjecture holds immediately. The proof rewrites `Nat.Coprime a b` as $\\gcd(a,b) = 1$, then uses $1 \\le \\lfloor a/|A| \\rfloor \\iff |A| \\le a$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.Coprime", "Coprime pairs", "Nat.one_le_div_iff"],
+    "prerequisites": ["Nat.Coprime", "Nat.one_le_div_iff"]
+  },
+  {
+    "id": "ann-e402-one-singleton",
+    "proofId": "erdos-402",
+    "type": "theorem",
+    "range": { "startLine": 302, "endLine": 305 },
+    "title": "Singleton {1} Verification",
+    "content": "**one_in_singleton_set**: For $A = \\{1\\}$, $\\gcd(1,1) = 1 \\le 1/1 = 1$. A minimal sanity check proved by `simp [Nat.gcd_self]`.",
+    "mathContext": "Combined with `erdos_402_singleton`, this confirms the conjecture for the smallest possible set. The proof is automatic via simplification of $\\gcd(1,1) = 1$ and $|\\{1\\}| = 1$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "coprime",
-      "one-le-div"
-    ]
+    "relatedConcepts": ["Singleton verification", "Nat.gcd_self"],
+    "prerequisites": ["Finset.mem_singleton", "Nat.gcd_self"]
   }
 ]

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -4,9 +4,9 @@
   "slug": "erdos-402",
   "description": "For any finite set A ⊂ ℕ, there exist a, b ∈ A such that gcd(a, b) ≤ a/|A|. Graham's conjecture was proved by Balasubramanian and Soundararajan in 1996.",
   "meta": {
-    "author": "Graham",
+    "author": "Graham (1970), solved by Balasubramanian–Soundararajan (1996)",
     "sourceUrl": "https://erdosproblems.com/402",
-    "date": "",
+    "date": "1970",
     "status": "axiom",
     "proofRepoPath": "Proofs/Erdos402Problem.lean",
     "tags": [
@@ -16,21 +16,70 @@
       "combinatorics",
       "solved"
     ],
-    "badge": "wip",
-    "sorries": 5,
+    "badge": "axiom",
+    "sorries": 2,
     "erdosNumber": 402,
     "erdosUrl": "https://erdosproblems.com/402",
-    "erdosProblemStatus": "solved"
+    "erdosProblemStatus": "solved",
+    "dateAdded": "2026-01-19",
+    "mathlib_version": "4.15.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.gcd",
+        "description": "Greatest common divisor on natural numbers",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Finset.gcd",
+        "description": "GCD over a finite set",
+        "module": "Mathlib.Data.Finset.GCD"
+      },
+      {
+        "theorem": "Finset.lcm",
+        "description": "LCM over a finite set",
+        "module": "Mathlib.Data.Finset.GCD"
+      }
+    ],
+    "references": [
+      {
+        "cite": "Graham 1970",
+        "title": "Unsolved problem 5749",
+        "year": 1970,
+        "relevance": "Original conjecture on GCD bounds in finite sets"
+      },
+      {
+        "cite": "Szegedy 1986",
+        "title": "On a conjecture of R. L. Graham",
+        "year": 1986,
+        "relevance": "Proved the conjecture for sufficiently large sets"
+      },
+      {
+        "cite": "Balasubramanian–Soundararajan 1996",
+        "title": "On a conjecture of R. L. Graham",
+        "year": 1996,
+        "relevance": "Complete proof of the conjecture for all finite sets of positive integers"
+      }
+    ],
+    "originalContributions": [
+      "Main conjecture formalization with Finset and Nat.gcd",
+      "MinGcdRatio equivalent rational formulation",
+      "GrahamSpecialSet {2,3,4,6} verification",
+      "IsGrahamEqualityCase characterization (3 families)",
+      "gcd_one_suffices coprime reduction lemma",
+      "Aristotle: ratio_bound proof, range case proof",
+      "Aristotle: {1,2,4} counterexample falsifying equality characterization"
+    ]
   },
   "overview": {
-    "historicalContext": "This problem originated as a conjecture of Graham (1970). Szegedy (1986) and Zaharescu (1987) independently proved it for sufficiently large sets. Balasubramanian and Soundararajan (1996) completed the proof for all finite sets.",
+    "historicalContext": "Graham posed this conjecture in 1970 as an **extremal problem** on GCD structure in finite sets. The conjecture attracted attention because it connects the multiplicative structure (GCD) of a set to its combinatorial size. **Szegedy** (1986) proved the conjecture for sets larger than an effective constant $N_0$, using a probabilistic argument on prime factorizations. **Zaharescu** (1987) obtained an independent proof for large sets via analytic methods. **Balasubramanian and Soundararajan** (1996) completed the proof for all finite sets by a refined sieve argument, handling the difficult small-set cases. Graham also conjectured that equality $\\gcd(a,b) = \\lfloor a/|A| \\rfloor$ for the optimal pair occurs only for three families of primitive sets, but Aristotle's automated proof search discovered that $\\{1, 2, 4\\}$ is a counterexample to this characterization.",
     "problemStatement": "For any finite set A ⊂ ℕ with positive elements, prove there exist a, b ∈ A such that gcd(a, b) ≤ a/|A|.",
     "proofStrategy": "We formalize the main statement and prove special cases: singleton sets, the Graham special set {2,3,4,6}, and derive a key lemma that coprime pairs suffice when |A| ≤ a.",
     "keyInsights": [
-      "The bound gcd(a,b) ≤ a/|A| is tight for certain families",
-      "Equality cases: {1,...,n}, {L/1,...,L/n}, or {2,3,4,6}",
-      "For coprime elements, gcd = 1 which is ≤ a/|A| when |A| ≤ a",
-      "The Graham special set {2,3,4,6} achieves equality with gcd(4,3)=1 and 4/4=1"
+      "**GCD bound**: $\\forall A \\subseteq \\mathbb{N}^+$ finite, $\\exists a,b \\in A: \\gcd(a,b) \\le \\lfloor a/|A| \\rfloor$ — proved by Balasubramanian–Soundararajan (1996)",
+      "**Coprime reduction**: if $\\gcd(a,b) = 1$ and $|A| \\le a$, the bound holds immediately — finding coprime pairs in large sets suffices",
+      "**Equality families**: $\\{1,\\ldots,n\\}$, $\\{L/1,\\ldots,L/n\\}$, and $\\{2,3,4,6\\}$ are primitive sets achieving equality",
+      "**Counterexample discovery**: Aristotle proved that $\\{1,2,4\\}$ satisfies the equality condition but is not a Graham equality case — the characterization is incomplete",
+      "**Equivalent rational form**: $\\exists a,b \\in A: \\gcd(a,b)/a \\le 1/|A|$ — cleaner formulation avoiding the floor function, proved by Aristotle from the main conjecture"
     ]
   },
   "sections": [
@@ -39,7 +88,7 @@
       "title": "Main Statement",
       "startLine": 35,
       "endLine": 46,
-      "summary": "Graham's GCD Conjecture: for any finite set A, there exist elements with small gcd.",
+      "summary": "**Graham's GCD Conjecture**: $\\forall A \\subseteq \\mathbb{N}^+$ finite, $\\exists a,b \\in A: \\gcd(a,b) \\le \\lfloor a/|A| \\rfloor$. Main theorem left as `sorry`.",
       "mathContext": "$\\forall A \\subseteq \\mathbb{N}^+,\\, A \\ne \\emptyset: \\exists a, b \\in A: \\gcd(a,b) \\le \\lfloor a / |A| \\rfloor$. Proved by Balasubramanian-Soundararajan (1996)."
     },
     {
@@ -47,7 +96,7 @@
       "title": "Equivalent Formulation",
       "startLine": 48,
       "endLine": 63,
-      "summary": "The minimum gcd ratio is at most 1/|A|.",
+      "summary": "**MinGcdRatio** and equivalent formulation: $\\exists a,b \\in A: \\gcd(a,b)/a \\le 1/|A|$ over $\\mathbb{Q}$. Proved by Aristotle from the main conjecture.",
       "mathContext": "$\\min_{a,b \\in A} \\frac{\\gcd(a,b)}{a} \\le \\frac{1}{|A|}$. Equivalent rational formulation of Graham's conjecture."
     },
     {
@@ -55,7 +104,7 @@
       "title": "Special Cases",
       "startLine": 65,
       "endLine": 81,
-      "summary": "Singleton sets and range {1,...,n} cases.",
+      "summary": "**Singleton**: $\\gcd(a,a) = a \\le a/1$. **Range** $\\{1,\\ldots,n\\}$: proved by Aristotle via case analysis on $n$.",
       "mathContext": "Singleton: $\\gcd(a,a) = a = a/1$. Range $\\{1,\\ldots,n\\}$: $\\gcd(1,n) = 1 \\le 1/n$ (taking $a = 1$, $b = n$)."
     },
     {
@@ -63,7 +112,7 @@
       "title": "The {2, 3, 4, 6} Example",
       "startLine": 83,
       "endLine": 102,
-      "summary": "Graham's special set that achieves equality in the bound.",
+      "summary": "**GrahamSpecialSet** $= \\{2,3,4,6\\}$ with $|A| = 4$. Verified: $\\gcd(4,3) = 1 = \\lfloor 4/4 \\rfloor$ — sporadic equality case.",
       "mathContext": "$A = \\{2,3,4,6\\}$: $\\gcd(4,3) = 1 = \\lfloor 4/4 \\rfloor$. Equality case: one of three primitive families achieving $\\gcd(a,b) = \\lfloor a/|A| \\rfloor$."
     },
     {
@@ -71,7 +120,7 @@
       "title": "Graham's Equality Characterization",
       "startLine": 104,
       "endLine": 135,
-      "summary": "The only primitive sets achieving equality are three specific families.",
+      "summary": "**HasNoCommonDivisor** ($\\gcd(A) = 1$) and **IsGrahamEqualityCase**: three primitive families. Aristotle discovered $\\{1,2,4\\}$ counterexample — characterization incomplete.",
       "mathContext": "Primitive equality cases: $\\{1,\\ldots,n\\}$, $\\{\\text{lcm}(1,\\ldots,n)/1, \\ldots, \\text{lcm}(1,\\ldots,n)/n\\}$, or $\\{2,3,4,6\\}$. A set is primitive if $\\gcd(A) = 1$."
     },
     {
@@ -79,17 +128,24 @@
       "title": "Key Lemmas",
       "startLine": 137,
       "endLine": 151,
-      "summary": "Coprime elements suffice; singleton containing 1 works.",
+      "summary": "**gcd_one_suffices**: $\\gcd(a,b) = 1 \\wedge |A| \\le a \\implies 1 \\le \\lfloor a/|A| \\rfloor$. **one_in_singleton_set**: $\\{1\\}$ trivially satisfies the bound.",
       "mathContext": "$\\gcd(a,b) = 1 \\wedge |A| \\le a \\implies \\gcd(a,b) = 1 \\le \\lfloor a/|A| \\rfloor$. Finding a coprime pair suffices when the set is small relative to its elements."
     }
   ],
   "conclusion": {
-    "summary": "We formalize Graham's GCD Conjecture (Erdős #402). For any finite set A of positive integers, there exist a, b in A with gcd(a,b) ≤ a/|A|. The proof was completed by Balasubramanian and Soundararajan in 1996.",
-    "implications": "This result connects combinatorial properties of finite sets to the structure of their greatest common divisors, with applications in additive combinatorics.",
+    "summary": "We formalize Graham's GCD Conjecture (Erdős #402). For any finite set A of positive integers, there exist a, b in A with gcd(a,b) ≤ a/|A|. The proof was completed by Balasubramanian and Soundararajan in 1996. Notably, Aristotle's automated proof search discovered a counterexample to the equality characterization.",
+    "implications": "This result connects combinatorial properties of finite sets to the structure of their greatest common divisors, with applications in additive combinatorics and multiplicative number theory.",
     "openQuestions": [
+      "What is the correct characterization of equality cases? ({1,2,4} is missing from the current formulation)",
       "Can the proof be made more constructive?",
       "What is the computational complexity of finding the optimal pair (a,b)?",
-      "Are there generalizations to other algebraic structures?"
+      "Are there generalizations to other algebraic structures (e.g., polynomial rings)?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "proofId": "erdos-403",
+      "relationship": "Problem 403 concerns related GCD and divisibility questions in finite sets, sharing the Erdős–Graham framework"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Expand from 7 to 13 annotations: add imports, Aristotle counterexample section, coprime lemma, singleton verification, equality definitions
- Add prerequisites, relatedConcepts, mathContext to all annotations
- Highlight Aristotle's {1,2,4} counterexample falsifying equality characterization
- Deepen historicalContext (Szegedy probabilistic method, Zaharescu analytic approach, Balasubramanian-Soundararajan sieve)
- Add 3 structured references, 1 cross-reference (erdos-403)
- Fix badge wip→axiom, sorries 5→2, add dateAdded/mathlib_version/mathlibDependencies/originalContributions
- LaTeX section summaries, enhanced keyInsights

## Test plan
- [x] `pnpm annotations:build` passes with no erdos-402 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)