### PR TITLE
Enrich erdos-928: deepen smooth number annotations and cross-references

### DIFF
--- a/src/data/proofs/erdos-928/annotations.json
+++ b/src/data/proofs/erdos-928/annotations.json
@@ -8,14 +8,20 @@
     },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "**Erdős Problem #928: Consecutive Smooth Numbers**\n\n**Question:** Does the density of n with P(n) < n^α and P(n+1) < (n+1)^β exist?\n\n**Status: OPEN** (partially resolved)\n\n**Known:**\n- Log density = ρ(1/α)ρ(1/β) (Teräväinen 2018)\n- Natural density under EH (Wang 2021)\n\nP(n) = largest prime factor. ρ = Dickman function.",
-    "mathContext": "A number is α-smooth if its largest prime factor is < n^α. The Dickman function ρ(u) gives the density of u⁻¹-smooth numbers.",
+    "content": "Erdős Problem #928 concerns the distribution of consecutive smooth numbers. A number $n$ is $\\alpha$-smooth if its largest prime factor $P(n) < n^\\alpha$. The question asks whether the natural density of $n$ with both $P(n) < n^\\alpha$ and $P(n+1) < (n+1)^\\beta$ exists. The logarithmic density is known (Teräväinen 2018) and equals the product $\\rho(1/\\alpha)\\rho(1/\\beta)$, suggesting independence. The natural density is known conditionally (Wang 2021, assuming Elliott-Halberstam) but remains open unconditionally.",
+    "mathContext": "$\\lim_{N \\to \\infty} \\frac{|\\{n \\le N : P(n) < n^\\alpha \\wedge P(n+1) < (n+1)^\\beta\\}|}{N} \\stackrel{?}{=} \\rho(1/\\alpha) \\cdot \\rho(1/\\beta)$",
     "significance": "key",
     "relatedConcepts": [
-      "Smooth numbers",
+      "smooth numbers",
       "Dickman function",
-      "Prime factors",
-      "Analytic number theory"
+      "prime factors",
+      "natural density",
+      "logarithmic density"
+    ],
+    "prerequisites": [
+      "prime factorization",
+      "asymptotic density",
+      "analytic number theory"
     ]
   },
   {
@@ -27,8 +33,18 @@
     },
     "type": "definition",
     "title": "Largest Prime Factor",
-    "content": "**largestPrimeFactor n:** P(n) = the largest prime divisor of n, or 1 if n ≤ 1. Also denoted P⁺(n) in the literature. Defined using Mathlib's primeFactors and List.maximum?.",
-    "significance": "key"
+    "content": "The largest prime factor $P(n) = P^+(n)$ is defined as the maximum element of the prime factorization multiset. When $n \\le 1$, we set $P(n) = 1$ by convention. The implementation uses Mathlib's `primeFactors` converted to a list, then takes `maximum?` with default 1. This is the central quantity in smooth number theory.",
+    "mathContext": "$P(n) = \\max\\{p \\text{ prime} : p \\mid n\\}$ for $n > 1$, $P(1) = 1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "prime factorization",
+      "arithmetic functions",
+      "smooth number bound"
+    ],
+    "prerequisites": [
+      "Nat.primeFactors",
+      "List.maximum?"
+    ]
   },
   {
     "id": "ann-e928-lpf-props",
@@ -39,8 +55,18 @@
     },
     "type": "technique",
     "title": "P(n) Properties",
-    "content": "**lpf_divides:** P(n) | n for n > 1. **lpf_prime:** P(n) is prime for n > 1. **lpf_of_prime:** P(p) = p for prime p. These basic properties follow from the definition as the maximum of the prime factor multiset.",
-    "significance": "supporting"
+    "content": "Three fundamental properties of the largest prime factor, axiomatized since they require working with Mathlib's multiset maximum API: (1) $P(n) \\mid n$ — the largest prime factor divides $n$; (2) $P(n)$ is prime for $n > 1$; (3) $P(p) = p$ for prime $p$. These are used implicitly throughout smooth number arguments.",
+    "mathContext": "$P(n) \\mid n$, $P(n) \\in \\text{Primes}$ for $n > 1$, $P(p) = p$ for $p$ prime",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "divisibility",
+      "prime number properties",
+      "axiomatization"
+    ],
+    "prerequisites": [
+      "Nat.Prime",
+      "divisibility"
+    ]
   },
   {
     "id": "ann-e928-smooth",
@@ -51,8 +77,18 @@
     },
     "type": "definition",
     "title": "α-Smooth Number",
-    "content": "**isSmooth α n:** n is α-smooth if n > 0 and P(n) < n^α. Equivalently, all prime factors of n are 'small' relative to n. Example: Powers of 2 are highly smooth for any α > 0.",
-    "significance": "key"
+    "content": "A positive integer $n$ is $\\alpha$-smooth if $P(n) < n^\\alpha$. The exponent $\\alpha \\in (0,1)$ measures how 'small' the prime factors must be relative to $n$. For $\\alpha = 1/2$, this means $P(n) < \\sqrt{n}$, and Dickman's theorem gives density $\\rho(2) \\approx 0.307$. Powers of 2 are $\\alpha$-smooth for any $\\alpha > 0$, as $P(2^k) = 2$. The formalization uses `Real.rpow` for the exponentiation $n^\\alpha$.",
+    "mathContext": "$\\text{isSmooth}(\\alpha, n) \\iff n > 0 \\wedge P(n) < n^\\alpha$. Density: $\\rho(1/\\alpha)$ by Dickman's theorem.",
+    "significance": "key",
+    "relatedConcepts": [
+      "friable numbers",
+      "Dickman function",
+      "real exponentiation"
+    ],
+    "prerequisites": [
+      "Real.rpow",
+      "largestPrimeFactor"
+    ]
   },
   {
     "id": "ann-e928-friable",
@@ -63,8 +99,18 @@
     },
     "type": "definition",
     "title": "y-Friable Number",
-    "content": "**isFriable y n:** n is y-friable if P(n) ≤ y. This is an absolute bound on prime factors, versus the relative α-smooth condition. The terms 'smooth' and 'friable' are used interchangeably in much of the literature.",
-    "significance": "key"
+    "content": "A number $n$ is $y$-friable if $P(n) \\le y$. Unlike the $\\alpha$-smooth condition (which is relative to $n$), friability uses an absolute bound $y$. The counting function $\\Psi(x, y) = |\\{n \\le x : P(n) \\le y\\}|$ is the central object in the Hildebrand-Tenenbaum theory. The terms 'smooth' and 'friable' are often used interchangeably; the French school (Tenenbaum, de la Bretèche) prefers 'friable'.",
+    "mathContext": "$\\text{isFriable}(y, n) \\iff n > 0 \\wedge P(n) \\le y$. $\\Psi(x, y) = \\#\\{n \\le x : P(n) \\le y\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "smooth numbers",
+      "counting function Ψ",
+      "Hildebrand-Tenenbaum theory"
+    ],
+    "prerequisites": [
+      "largestPrimeFactor",
+      "natural number inequality"
+    ]
   },
   {
     "id": "ann-e928-dickman",
@@ -75,9 +121,19 @@
     },
     "type": "definition",
     "title": "The Dickman Function",
-    "content": "**dickman_function ρ(u):** Defined by the delay differential equation: ρ(u) = 1 for u ∈ [0, 1], and uρ'(u) = -ρ(u-1) for u > 1. Named after Karl Dickman (1930), also called the Dickman-de Bruijn function. This fundamental function governs smooth number distribution.",
-    "mathContext": "ρ(2) = 1 - ln(2) ≈ 0.307, meaning about 30.7% of integers have P(n) < √n.",
-    "significance": "key"
+    "content": "The Dickman-de Bruijn function $\\rho(u)$ is axiomatized as a function $\\mathbb{R} \\to \\mathbb{R}$ satisfying the delay differential equation $u\\rho'(u) = -\\rho(u-1)$ for $u > 1$, with $\\rho(u) = 1$ for $u \\in [0,1]$. Karl Dickman introduced it in 1930; Nicolaas de Bruijn later gave rigorous asymptotic analysis. The function is entire when extended to the complex plane and decays as $\\rho(u) \\sim u^{-u(1+o(1))}$ for large $u$.",
+    "mathContext": "$\\rho(u) = 1$ for $u \\le 1$; $u\\rho'(u) = -\\rho(u-1)$ for $u > 1$. $\\rho(2) = 1 - \\ln 2 \\approx 0.307$, $\\rho(3) \\approx 0.049$, $\\rho(10) \\approx 2.77 \\times 10^{-11}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "delay differential equations",
+      "Buchstab function",
+      "de Bruijn's refinements",
+      "smooth number asymptotics"
+    ],
+    "prerequisites": [
+      "differential equations",
+      "asymptotic analysis"
+    ]
   },
   {
     "id": "ann-e928-dickman-props",
@@ -88,8 +144,40 @@
     },
     "type": "definition",
     "title": "Dickman Function Properties",
-    "content": "Key properties: ρ(1) = 1 (all n are 1-smooth), ρ(2) ≈ 1 - ln(2) ≈ 0.307, ρ is positive for u > 0, and strictly decreasing for u > 1. The function ρ(u) ~ u^{-u} for large u.",
-    "significance": "key"
+    "content": "Four key properties are axiomatized: (1) $\\rho(1) = 1$ — every positive integer is 1-smooth; (2) $\\rho(2) \\approx 1 - \\ln 2$ — about 30.7% of integers have $P(n) < \\sqrt{n}$; (3) $\\rho(u) > 0$ for $u > 0$ — the density is always positive; (4) $\\rho$ is strictly decreasing for $u > 1$. The approximate equality for $\\rho(2)$ uses an absolute error bound $< 0.001$.",
+    "mathContext": "$\\rho(1) = 1$, $|\\rho(2) - (1-\\ln 2)| < 0.001$, $\\rho(u) > 0$ for $u > 0$, $u < v \\implies \\rho(v) < \\rho(u)$ for $u > 1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "monotone functions",
+      "positivity",
+      "approximate computation"
+    ],
+    "prerequisites": [
+      "Real.log",
+      "absolute value"
+    ]
+  },
+  {
+    "id": "ann-e928-psi",
+    "proofId": "erdos-928",
+    "range": {
+      "startLine": 116,
+      "endLine": 121
+    },
+    "type": "definition",
+    "title": "Counting Function Ψ(x, y)",
+    "content": "The smooth number counting function $\\Psi(x, y) = |\\{n \\le x : P(n) \\le y\\}|$ is defined concretely by filtering the range $\\{1, \\ldots, \\lfloor x \\rfloor\\}$ and counting those with $P(n) \\le \\lfloor y \\rfloor$. This function is the central object connecting smooth numbers to the Dickman function via the asymptotic $\\Psi(x, x^\\alpha) / x \\to \\rho(1/\\alpha)$.",
+    "mathContext": "$\\Psi(x, y) = |\\{n \\le x : n > 0 \\wedge P(n) \\le y\\}|$. Defined using `Finset.range` and `Finset.filter`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "counting functions",
+      "Finset.filter",
+      "smooth number distribution"
+    ],
+    "prerequisites": [
+      "Finset.range",
+      "Nat.floor"
+    ]
   },
   {
     "id": "ann-e928-dickman-thm",
@@ -100,9 +188,19 @@
     },
     "type": "theorem",
     "title": "Dickman's Theorem (1930)",
-    "content": "**dickman_theorem:** Ψ(x, x^α) / x → ρ(1/α) as x → ∞. The density of α-smooth numbers is ρ(1/α). This is the foundational result on smooth number distribution, connecting the counting function Ψ(x,y) to the Dickman function.",
-    "mathContext": "For example, ρ(2) ≈ 0.307 means about 30.7% of integers have P(n) < √n.",
-    "significance": "key"
+    "content": "The foundational theorem of smooth number theory: the proportion of integers up to $x$ that are $x^\\alpha$-smooth converges to $\\rho(1/\\alpha)$. Formalized as an $\\varepsilon$-$X$ limit statement. Dickman proved this in 1930 using what is now called the 'Dickman method'; Ramaswami (1949) and de Bruijn (1951) gave modern proofs. The formalization axiomatizes this since the proof requires detailed sieve-theoretic estimates.",
+    "mathContext": "$\\forall \\varepsilon > 0,\\, \\exists X,\\, \\forall x > X:\\, \\left|\\frac{\\Psi(x, x^\\alpha)}{x} - \\rho(1/\\alpha)\\right| < \\varepsilon$",
+    "significance": "key",
+    "relatedConcepts": [
+      "asymptotic density",
+      "limit definition",
+      "sieve methods"
+    ],
+    "prerequisites": [
+      "epsilon-delta limits",
+      "Dickman function",
+      "psi counting function"
+    ]
   },
   {
     "id": "ann-e928-consec",
@@ -113,8 +211,18 @@
     },
     "type": "definition",
     "title": "Consecutive Smooth Numbers",
-    "content": "**consecutiveSmooth α β N:** The set of n ≤ N where both n is α-smooth and n+1 is β-smooth. This is the counting set for the main problem.",
-    "significance": "key"
+    "content": "The counting set for Erdős's problem: all $n \\le N$ where $n$ is $\\alpha$-smooth AND $n+1$ is $\\beta$-smooth. The key subtlety is that $\\alpha$ and $\\beta$ can differ — the smoothness parameters for $n$ and $n+1$ are independent. Since $\\gcd(n, n+1) = 1$, the prime factorizations of $n$ and $n+1$ share no common factors, which is the heuristic basis for the independence conjecture.",
+    "mathContext": "$C(\\alpha, \\beta, N) = \\{n \\le N : n > 0 \\wedge P(n) < n^\\alpha \\wedge P(n+1) < (n+1)^\\beta\\}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "coprimality of consecutive integers",
+      "bivariate density",
+      "independence heuristic"
+    ],
+    "prerequisites": [
+      "isSmooth",
+      "Finset.filter"
+    ]
   },
   {
     "id": "ann-e928-density",
@@ -125,8 +233,40 @@
     },
     "type": "definition",
     "title": "Density Existence",
-    "content": "**densityExists α β:** The natural density limit exists: lim_{N→∞} |{n ≤ N : P(n) < n^α ∧ P(n+1) < (n+1)^β}| / N. The main question asks whether this limit exists for all α, β ∈ (0,1).",
-    "significance": "key"
+    "content": "The natural density is defined via the standard $\\varepsilon$-$N_0$ formulation: there exists a limit $d$ such that $|C(\\alpha, \\beta, N)|/N$ is within $\\varepsilon$ of $d$ for all sufficiently large $N$. This is stronger than logarithmic density (which weights by $1/n$) and corresponds to the Cesàro average. The gap between logarithmic and natural density is precisely what makes Erdős #928 difficult.",
+    "mathContext": "$\\exists d \\in \\mathbb{R},\\, \\forall \\varepsilon > 0,\\, \\exists N_0,\\, \\forall N \\ge N_0:\\, \\left|\\frac{|C(\\alpha,\\beta,N)|}{N} - d\\right| < \\varepsilon$",
+    "significance": "key",
+    "relatedConcepts": [
+      "natural density",
+      "Cesàro mean",
+      "logarithmic density",
+      "asymptotic analysis"
+    ],
+    "prerequisites": [
+      "limit definition",
+      "consecutiveSmooth"
+    ]
+  },
+  {
+    "id": "ann-e928-question",
+    "proofId": "erdos-928",
+    "range": {
+      "startLine": 154,
+      "endLine": 160
+    },
+    "type": "definition",
+    "title": "The Main Question",
+    "content": "Erdős Problem #928 formally: for ALL $\\alpha, \\beta \\in (0,1)$, does the natural density exist? The universal quantification over both parameters is essential — the problem asks for a uniform result, not just specific values. The hypothesis $0 < \\alpha < 1$ and $0 < \\beta < 1$ excludes the trivial cases: $\\alpha \\ge 1$ makes every number smooth, and $\\alpha \\le 0$ makes no number smooth.",
+    "mathContext": "$\\text{erdos928Question} \\iff \\forall \\alpha, \\beta \\in (0,1),\\, \\text{densityExists}(\\alpha, \\beta)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "universal quantification",
+      "parameter ranges",
+      "open problems"
+    ],
+    "prerequisites": [
+      "densityExists"
+    ]
   },
   {
     "id": "ann-e928-indep",
@@ -137,8 +277,19 @@
     },
     "type": "definition",
     "title": "Independence Conjecture",
-    "content": "**independenceConjecture α β:** The density (if it exists) equals ρ(1/α) · ρ(1/β). This reflects the heuristic that since gcd(n, n+1) = 1, the smoothness of n and n+1 should be independent events.",
-    "significance": "key"
+    "content": "The conjectured value of the density: $\\rho(1/\\alpha) \\cdot \\rho(1/\\beta)$. This product form reflects probabilistic independence — the event '$n$ is $\\alpha$-smooth' should be independent of '$n+1$ is $\\beta$-smooth'. The heuristic justification is that $\\gcd(n, n+1) = 1$, so the prime factorizations of consecutive integers are 'unrelated'. The formalization combines the density value with the limit existence in a single statement.",
+    "mathContext": "$d = \\rho(1/\\alpha) \\cdot \\rho(1/\\beta)$ and $|C(\\alpha,\\beta,N)|/N \\to d$. Independence: $\\Pr[A \\cap B] = \\Pr[A] \\cdot \\Pr[B]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "probabilistic independence",
+      "coprimality",
+      "multiplicative functions",
+      "product densities"
+    ],
+    "prerequisites": [
+      "Dickman function",
+      "probability independence"
+    ]
   },
   {
     "id": "ann-e928-inf-many",
@@ -149,8 +300,18 @@
     },
     "type": "theorem",
     "title": "Infinitely Many Exist (Schinzel/Meza)",
-    "content": "**infinitely_many_exist:** For any α, β ∈ (0,1), infinitely many n exist with both P(n) < n^α and P(n+1) < (n+1)^β. This follows from Schinzel's result that P(n(n+1)) ≤ n^{O(1/log log n)} infinitely often.",
-    "significance": "key"
+    "content": "For any $\\alpha, \\beta \\in (0,1)$, infinitely many $n$ exist with both $P(n) < n^\\alpha$ and $P(n+1) < (n+1)^\\beta$. This is the weakest positive result — it says the set is infinite but says nothing about its density. It follows from Schinzel's 1967 result that $P(n(n+1)) \\le n^{O(1/\\log\\log n)}$ for infinitely many $n$. Formalized as: for every $N$, there exists $n > N$ satisfying both smoothness conditions.",
+    "mathContext": "$\\forall N \\in \\mathbb{N},\\, \\exists n > N:\\, P(n) < n^\\alpha \\wedge P(n+1) < (n+1)^\\beta$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Schinzel's sieve results",
+      "infinitude arguments",
+      "P(n(n+1))"
+    ],
+    "prerequisites": [
+      "isSmooth",
+      "Schinzel's theorem"
+    ]
   },
   {
     "id": "ann-e928-terav",
@@ -161,8 +322,19 @@
     },
     "type": "theorem",
     "title": "Teräväinen (2018): Logarithmic Density",
-    "content": "**teravainen_log_density:** The LOGARITHMIC density exists and equals ρ(1/α) · ρ(1/β). Log density = lim (1/log N) · Σ_{n ≤ N} 1/n. This is weaker than natural density but represents significant progress from 'On binary correlations of multiplicative functions'.",
-    "significance": "key"
+    "content": "Joni Teräväinen proved that the logarithmic density exists and equals $\\rho(1/\\alpha) \\cdot \\rho(1/\\beta)$. The logarithmic density $\\delta_L(A) = \\lim_{N\\to\\infty} \\frac{1}{\\log N} \\sum_{n \\le N, n \\in A} \\frac{1}{n}$ is weaker than natural density but easier to establish because the $1/n$ weighting smooths out fluctuations. This appeared in 'On binary correlations of multiplicative functions' (2018). The technique uses the pretentious approach to multiplicative functions developed by Granville-Soundararajan.",
+    "mathContext": "$\\delta_L = \\lim_{N\\to\\infty} \\frac{1}{\\log N} \\sum_{\\substack{n \\le N \\\\ P(n) < n^\\alpha \\\\ P(n+1) < (n+1)^\\beta}} \\frac{1}{n} = \\rho(1/\\alpha) \\cdot \\rho(1/\\beta)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "logarithmic density",
+      "binary correlations",
+      "pretentious multiplicative functions",
+      "Granville-Soundararajan"
+    ],
+    "prerequisites": [
+      "logarithmic density",
+      "multiplicative function theory"
+    ]
   },
   {
     "id": "ann-e928-wang",
@@ -173,8 +345,18 @@
     },
     "type": "theorem",
     "title": "Wang (2021): Conditional Natural Density",
-    "content": "**wang_conditional:** Under the Elliott-Halberstam conjecture for friable integers, the natural density exists and equals ρ(1/α) · ρ(1/β). This is conditional on a major open conjecture in analytic number theory.",
-    "significance": "key"
+    "content": "Zhiwei Wang proved that assuming the Elliott-Halberstam conjecture for friable integers, the natural density exists and equals $\\rho(1/\\alpha) \\cdot \\rho(1/\\beta)$. This appeared in 'Three conjectures on $P^+(n)$ and $P^+(n+1)$' (2021). The Elliott-Halberstam hypothesis provides the needed uniformity in the distribution of smooth numbers across arithmetic progressions. The formalization states this as an unconditional Lean theorem that directly invokes `independenceConjecture`.",
+    "mathContext": "Assuming EH for friable integers: $\\lim_{N\\to\\infty} |C(\\alpha,\\beta,N)|/N = \\rho(1/\\alpha)\\rho(1/\\beta)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Elliott-Halberstam conjecture",
+      "conditional results",
+      "distribution in progressions"
+    ],
+    "prerequisites": [
+      "Elliott-Halberstam conjecture",
+      "independenceConjecture"
+    ]
   },
   {
     "id": "ann-e928-eh",
@@ -185,12 +367,62 @@
     },
     "type": "concept",
     "title": "Elliott-Halberstam Conjecture",
-    "content": "**elliott_halberstam_conjecture:** A strengthening of the Bombieri-Vinogradov theorem about primes in arithmetic progressions. The 'friable' version concerns smooth numbers in progressions and enables better control of error terms in sieve methods.",
+    "content": "The Elliott-Halberstam conjecture (1968) asserts that the primes are well-distributed in arithmetic progressions for moduli up to $x^{1-\\varepsilon}$, strengthening the Bombieri-Vinogradov theorem (which handles moduli up to $x^{1/2}$). The 'friable version' replaces primes with smooth numbers. This conjecture was used by Goldston-Pintz-Yıldırım in their work on small prime gaps and is a key input for Wang's result. The axiomatized form `axiom elliott_halberstam_conjecture : Prop` simply asserts its existence as a proposition.",
+    "mathContext": "$\\text{EH}: \\sum_{q \\le x^{1-\\varepsilon}} \\max_{\\gcd(a,q)=1} \\left|\\pi(x;q,a) - \\frac{\\text{li}(x)}{\\varphi(q)}\\right| \\ll \\frac{x}{(\\log x)^A}$",
     "significance": "key",
     "relatedConcepts": [
-      "Bombieri-Vinogradov",
-      "Sieve theory",
-      "Primes in progressions"
+      "Bombieri-Vinogradov theorem",
+      "sieve theory",
+      "primes in arithmetic progressions",
+      "Goldston-Pintz-Yıldırım"
+    ],
+    "prerequisites": [
+      "prime counting function",
+      "arithmetic progressions",
+      "Euler's totient"
+    ]
+  },
+  {
+    "id": "ann-e928-pplus",
+    "proofId": "erdos-928",
+    "range": {
+      "startLine": 223,
+      "endLine": 228
+    },
+    "type": "definition",
+    "title": "Alternative Notation P⁺(n)",
+    "content": "The abbreviation `Pplus := largestPrimeFactor` provides the standard notation $P^+(n)$ used in the analytic number theory literature, particularly by the French school (Tenenbaum, de la Bretèche, Drappeau). This notation distinguishes from $P^-(n)$ (smallest prime factor) and $\\Omega(n)$ (total prime factor count).",
+    "mathContext": "$P^+(n) \\equiv P(n) = \\max\\{p : p \\mid n,\\, p \\text{ prime}\\}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "notation conventions",
+      "P⁻(n)",
+      "Ω(n)"
+    ],
+    "prerequisites": [
+      "largestPrimeFactor"
+    ]
+  },
+  {
+    "id": "ann-e928-schinzel",
+    "proofId": "erdos-928",
+    "range": {
+      "startLine": 230,
+      "endLine": 237
+    },
+    "type": "theorem",
+    "title": "Schinzel's Product Result",
+    "content": "Andrzej Schinzel proved that for infinitely many $n$, the product $n(n+1)$ has its largest prime factor bounded by $n$. More precisely, his 1967 result shows $P(n(n+1)) \\le n^{O(1/\\log\\log n)}$ infinitely often. This is the key input for the `infinitely_many_exist` axiom. The axiomatized form states the simpler bound $P(n(n+1)) \\le n$ for infinitely many $n$.",
+    "mathContext": "$\\forall N,\\, \\exists n > N:\\, P(n \\cdot (n+1)) \\le n$. Schinzel's stronger result: $P(n(n+1)) \\le n^{O(1/\\log\\log n)}$ i.o.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Schinzel",
+      "products of consecutive integers",
+      "sieve methods"
+    ],
+    "prerequisites": [
+      "largestPrimeFactor",
+      "sieve theory"
     ]
   },
   {
@@ -202,8 +434,18 @@
     },
     "type": "theorem",
     "title": "Summary Theorem",
-    "content": "**erdos_928_summary:** Combines three known results: (1) infinitely many consecutive smooth numbers exist, (2) logarithmic density = ρ(1/α)ρ(1/β), (3) conditional natural density under EH. The unconditional natural density remains OPEN.",
-    "significance": "key"
+    "content": "The summary theorem assembles all three known results into a single conjunction: (1) infinitely many consecutive smooth pairs exist; (2) logarithmic density $= \\rho(1/\\alpha)\\rho(1/\\beta)$; (3) natural density $= \\rho(1/\\alpha)\\rho(1/\\beta)$ under EH. The proof is simply the triple of the three axioms applied to the given parameters. This is the strongest known combined statement about consecutive smooth numbers.",
+    "mathContext": "$(\\text{infinitely many}) \\wedge (\\delta_L = \\rho(1/\\alpha)\\rho(1/\\beta)) \\wedge (\\text{EH} \\implies d = \\rho(1/\\alpha)\\rho(1/\\beta))$",
+    "significance": "key",
+    "relatedConcepts": [
+      "theorem aggregation",
+      "known results compilation"
+    ],
+    "prerequisites": [
+      "infinitely_many_exist",
+      "teravainen_log_density",
+      "wang_conditional"
+    ]
   },
   {
     "id": "ann-e928-main",
@@ -214,7 +456,16 @@
     },
     "type": "theorem",
     "title": "Erdős Problem #928: OPEN",
-    "content": "**erdos_928:** The main theorem records the strongest unconditional result: infinitely many n exist with both P(n) < n^α and P(n+1) < (n+1)^β. The natural density question remains open.",
-    "significance": "key"
+    "content": "The main theorem states the strongest unconditional result: infinitely many $n$ exist with both $P(n) < n^\\alpha$ and $P(n+1) < (n+1)^\\beta$. The proof is a direct application of `infinitely_many_exist`. The gap between this (infinitely many) and the desired result (positive density) illustrates the difficulty of Erdős #928 — even proving the set is infinite required Schinzel's deep sieve theory.",
+    "mathContext": "$\\forall \\alpha, \\beta \\in (0,1),\\, \\forall N,\\, \\exists n > N:\\, P(n) < n^\\alpha \\wedge P(n+1) < (n+1)^\\beta$",
+    "significance": "key",
+    "relatedConcepts": [
+      "open problems",
+      "unconditional results",
+      "gap between existence and density"
+    ],
+    "prerequisites": [
+      "infinitely_many_exist"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-928/meta.json
+++ b/src/data/proofs/erdos-928/meta.json
@@ -64,7 +64,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #928**\n\nThis problem concerns the distribution of 'smooth numbers' - integers with small prime factors.\n\n**Key History:**\n- Dickman (1930): Density of α-smooth numbers is ρ(1/α)\n- Schinzel (1967): P(n(n+1)) can be small for infinitely many n\n- Teräväinen (2018): Logarithmic density = ρ(1/α)ρ(1/β)\n- Wang (2021): Natural density under Elliott-Halberstam\n\n**The Setting:**\nP(n) denotes the largest prime factor of n. An α-smooth number has P(n) < n^α.\n\n**Related:** Problem 370 on erdosproblems.com",
+    "historicalContext": "Smooth numbers — integers whose prime factors are all 'small' — have been central to analytic number theory since Karl Dickman's 1930 paper 'On the frequency of numbers containing prime factors of a certain relative magnitude', which established the density $\\rho(1/\\alpha)$ for $\\alpha$-smooth numbers. The Dickman function $\\rho$ was later studied rigorously by Nicolaas de Bruijn (1951), who gave precise asymptotic expansions. Erdős Problem #928 asks about a natural bivariate extension: when both $n$ and $n+1$ are smooth. The heuristic that consecutive integers should behave independently (since $\\gcd(n, n+1) = 1$) suggests density $\\rho(1/\\alpha)\\rho(1/\\beta)$. Andrzej Schinzel (1967) proved infinitely many such pairs exist using sieve methods applied to $P(n(n+1))$. The breakthrough came from Joni Teräväinen (2018), who established the logarithmic density using the pretentious approach to multiplicative functions developed by Granville and Soundararajan. Zhiwei Wang (2021) proved the natural density conditionally, assuming the Elliott-Halberstam conjecture for friable integers. The unconditional natural density remains one of the most natural open questions in the theory of smooth numbers.",
     "problemStatement": "**Problem Statement (Open)**\n\nLet α, β ∈ (0,1) and P(n) = largest prime factor of n.\n\nDoes the density of integers n such that P(n) < n^α and P(n+1) < (n+1)^β exist?\n\n**Equivalently:** Is the event 'n is α-smooth' independent of 'n+1 is β-smooth'?\n\n**Conjectured Density:** ρ(1/α) · ρ(1/β) where ρ is the Dickman function.\n\n**Known:**\n- Logarithmic density exists and equals ρ(1/α)ρ(1/β) (Teräväinen)\n- Natural density equals ρ(1/α)ρ(1/β) under EH (Wang)\n\n**Open:** Unconditional natural density existence",
     "proofStrategy": "**Formalization Approach**\n\n1. **Prime Factors:** Define largestPrimeFactor P(n)\n\n2. **Smoothness:** isSmooth α n := P(n) < n^α\n\n3. **Dickman Function:** Axiomatize ρ(u) with properties\n\n4. **Dickman's Theorem:** Ψ(x, x^α)/x → ρ(1/α)\n\n5. **Main Problem:**\n   - densityExists: natural density limit exists\n   - erdos928Question: ∀ α,β ∈ (0,1), densityExists α β\n\n6. **Results:**\n   - infinitely_many_exist (Schinzel/Meza)\n   - teravainen_log_density (2018)\n   - wang_conditional (2021 under EH)",
     "keyInsights": [
@@ -160,5 +160,19 @@
       "Extensions to k consecutive smooth numbers",
       "Effective versions with explicit error bounds"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "proofId": "bounded-prime-gaps",
+      "relationship": "Both concern the distribution of primes in structured patterns — bounded gaps uses sieve methods and the Elliott-Halberstam conjecture, the same conjecture that Wang uses for Erdős #928"
+    },
+    {
+      "proofId": "erdos-1055",
+      "relationship": "Both study prime factorization structure of integers — #1055 classifies primes by P(p+1) factorization while #928 studies the density of smooth consecutive pairs"
+    },
+    {
+      "proofId": "erdos-10",
+      "relationship": "Both concern additive/multiplicative structure involving primes — #10 asks about sums of primes and powers of 2 while #928 concerns smooth number density"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for **erdos-928** (Density of Consecutive Smooth Numbers).

- Rewrote `historicalContext` with Dickman/de Bruijn/Schinzel/Teräväinen/Wang lineage
- Added `mathContext`, `relatedConcepts`, `prerequisites` to all 20 annotations
- Added 2 new annotations: Ψ counting function, Schinzel product result
- Added `crossReferences` to `bounded-prime-gaps`, `erdos-1055`, `erdos-10`

## Test plan

- [x] JSON validated
- [x] `pnpm annotations:build` passes
- [ ] Visual check of gallery page

🤖 Generated with [Claude Code](https://claude.com/claude-code)