### PR TITLE
fix: remove stray closing brace in research build script

### DIFF
--- a/scripts/research/build.ts
+++ b/scripts/research/build.ts
@@ -647,8 +647,6 @@ function build(): void {
       continue
     }
 
-    }
-
     console.log(`   Processing ${entry.slug}...`)
     const problem = processProblem(entry.slug, entry)
     if (problem) {


### PR DESCRIPTION
## Summary
- Removes an extra `}` at line 650 of `scripts/research/build.ts` that prematurely closed the for-loop in `build()`, causing a parse error at line 693
- This was blocking the entire deploy pipeline (website builds were failing)

## Test plan
- [x] `npx tsx scripts/research/build.ts` runs successfully (506 problems generated)
- [x] Build error at line 693 is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)