### PR TITLE
Research: amgm-inequality-oq-02-oq-02 - Newton log-concavity proof architecture

### DIFF
--- a/proofs/Proofs/NewtonLogConcavity.lean
+++ b/proofs/Proofs/NewtonLogConcavity.lean
@@ -1,0 +1,195 @@
+/-
+  Newton's Log-Concavity of Elementary Symmetric Polynomials
+  Research: amgm-inequality-oq-02-oq-02
+
+  Goal: Prove that for non-negative reals x₁,...,xₙ and 1 ≤ k < n:
+    (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1)) · (eₖ₊₁/C(n,k+1))
+
+  This eliminates the last axiom in the Maclaurin inequalities formalization.
+
+  Proof strategy: Induction on n using the recurrence
+    eₖ(x₁,...,xₙ₊₁) = eₖ(x₁,...,xₙ) + xₙ₊₁ · eₖ₋₁(x₁,...,xₙ)
+
+  References:
+  - Hardy-Littlewood-Pólya "Inequalities" (1934) §2.22
+-/
+
+import Proofs.AmgmInequalityOQ02
+
+open Finset Real
+
+namespace NewtonLC
+
+/-
+## Part I: Small cases verified by nlinarith
+-/
+
+/-- Newton's inequality for n=3, k=1 -/
+theorem newton_n3_k1 (a b c : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c) :
+    ((a + b + c) / 3) ^ 2 ≥ (a * b + b * c + c * a) / 3 := by
+  nlinarith [sq_nonneg (a - b), sq_nonneg (b - c), sq_nonneg (c - a)]
+
+/-- Newton's inequality for n=3, k=2 -/
+theorem newton_n3_k2 (a b c : ℝ) (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c) :
+    ((a * b + b * c + c * a) / 3) ^ 2 ≥
+    ((a + b + c) / 3) * (a * b * c) := by
+  nlinarith [sq_nonneg (a * b - b * c), sq_nonneg (b * c - c * a),
+             sq_nonneg (c * a - a * b), mul_nonneg ha hb, mul_nonneg hb hc,
+             mul_nonneg hc ha, sq_nonneg a, sq_nonneg b, sq_nonneg c]
+
+/-
+## Part II: Infrastructure for the general proof
+-/
+
+/-- C(n,k) > 0 when k ≤ n -/
+lemma choose_pos_cast {n k : ℕ} (hk : k ≤ n) : (0 : ℝ) < (Nat.choose n k : ℝ) :=
+  Nat.cast_pos.mpr (Nat.choose_pos hk)
+
+/-- elemSymm is non-negative for non-negative inputs -/
+private lemma esymm_nn {n : ℕ} (k : ℕ) (x : Fin n → ℝ) (hx : ∀ i, 0 ≤ x i) :
+    0 ≤ elemSymm k x := elemSymm_nonneg k x hx
+
+/-
+## Part III: Newton's inequality — general proof
+
+We prove this by strong induction on n (number of variables).
+
+The proof uses the recurrence:
+  eⱼ(x₁,...,xₙ₊₁) = eⱼ(x₁,...,xₙ) + xₙ₊₁ · eⱼ₋₁(x₁,...,xₙ)
+
+Setting t = xₙ₊₁ and aⱼ = eⱼ(x₁,...,xₙ), the (n+1)-variable
+elementary symmetric polynomials become:
+  eⱼ(x₁,...,xₙ₊₁) = aⱼ + t · aⱼ₋₁
+
+The Newton inequality for n+1 variables at index k becomes:
+  (aₖ + t·aₖ₋₁)² / C(n+1,k) ≥ (aₖ₋₁ + t·aₖ₋₂) · (aₖ₊₁ + t·aₖ) / (C(n+1,k-1)·C(n+1,k+1))
+
+After cross-multiplying and expanding, the difference LHS - RHS is a
+quadratic form in t. The constant, linear, and quadratic coefficients
+are all non-negative by the inductive hypothesis (Newton for n variables).
+-/
+
+/-- Newton's inequality — the main theorem.
+    For 1 ≤ k, k+1 ≤ n, non-negative x:
+    (eₖ(x)/C(n,k))² ≥ (eₖ₋₁(x)/C(n,k-1)) · (eₖ₊₁(x)/C(n,k+1)) -/
+theorem newton_ineq : ∀ (n : ℕ) (k : ℕ) (hk : 1 ≤ k) (hkn : k + 1 ≤ n)
+    (x : Fin n → ℝ) (hx : ∀ i, 0 ≤ x i),
+    (elemSymm k x / (Nat.choose n k : ℝ)) ^ 2 ≥
+    (elemSymm (k - 1) x / (Nat.choose n (k - 1) : ℝ)) *
+    (elemSymm (k + 1) x / (Nat.choose n (k + 1) : ℝ)) := by
+  -- Strong induction on n
+  intro n
+  induction n using Nat.strongRecOn with
+  | _ n ih =>
+  intro k hk hkn x hx
+  -- k=1 case: use the already-proved newton_k1
+  by_cases hk1 : k = 1
+  · subst hk1
+    exact newton_k1 (by omega : 2 ≤ n) x
+  -- k ≥ 2
+  have hk_ge2 : 2 ≤ k := by omega
+  -- Base case: n = k+1
+  -- When n = k+1, eₖ₊₁ = ∏xᵢ (only full subset), C(n,k+1) = C(k+1,k+1) = 1
+  by_cases hbase : n = k + 1
+  · -- n = k + 1
+    subst hbase
+    -- eₖ₊₁ = ∏ xᵢ
+    have h_top : elemSymm (k + 1) x = ∏ i : Fin (k + 1), x i :=
+      elemSymm_n_eq_prod x
+    -- For the base case, we use a direct argument.
+    -- eₖ has C(k+1,k) = k+1 terms, each a product of k out of k+1 variables.
+    -- eₖ = ∑ᵢ ∏_{j≠i} xⱼ = (∏ xⱼ) · ∑ᵢ (1/xᵢ) when all xᵢ > 0.
+    -- eₖ₋₁ has C(k+1,k-1) = C(k+1,2) terms.
+    -- Newton: (eₖ/(k+1))² ≥ (eₖ₋₁/C(k+1,k-1)) · (∏xᵢ/1)
+    -- This is a non-trivial algebraic identity; we sorry it for now
+    -- and focus on the inductive step.
+    sorry
+  -- Inductive step: n ≥ k + 2
+  · have hn_ge : k + 2 ≤ n := by omega
+    -- Decompose: n = m + 1 for m ≥ k + 1
+    obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+    have hm_ge : k + 1 ≤ m := by omega
+    -- y = first m variables, t = last variable
+    set y := x ∘ Fin.castSucc with hy_def
+    set t := x (Fin.last m) with ht_def
+    have ht_nn : 0 ≤ t := hx (Fin.last m)
+    have hy_nn : ∀ i, 0 ≤ y i := fun i => hx (Fin.castSucc i)
+    -- Recurrences
+    have h_rec_k : elemSymm k x = elemSymm k y + t * elemSymm (k - 1) y := by
+      have : k - 1 + 1 = k := by omega
+      have h := elemSymm_succ (k - 1) x
+      rwa [this] at h
+    have h_rec_k1 : elemSymm (k + 1) x = elemSymm (k + 1) y + t * elemSymm k y :=
+      elemSymm_succ k x
+    have h_rec_km1 : elemSymm (k - 1) x = elemSymm (k - 1) y + t * elemSymm (k - 2) y := by
+      have : k - 2 + 1 = k - 1 := by omega
+      have h := elemSymm_succ (k - 2) x
+      rwa [this] at h
+    -- IH for m variables at index k (if k + 1 ≤ m)
+    have h_ih_k : (elemSymm k y / (Nat.choose m k : ℝ)) ^ 2 ≥
+        (elemSymm (k - 1) y / (Nat.choose m (k - 1) : ℝ)) *
+        (elemSymm (k + 1) y / (Nat.choose m (k + 1) : ℝ)) := by
+      exact ih m (by omega) k hk hm_ge y hy_nn
+    -- IH for m variables at index k-1 (if k ≥ 2 and k ≤ m)
+    have h_ih_km1 : (elemSymm (k - 1) y / (Nat.choose m (k - 1) : ℝ)) ^ 2 ≥
+        (elemSymm (k - 2) y / (Nat.choose m (k - 2) : ℝ)) *
+        (elemSymm k y / (Nat.choose m k : ℝ)) := by
+      have h := ih m (by omega) (k - 1) (by omega) (by omega) y hy_nn
+      -- ih gives: (e_{k-1}/C)² ≥ (e_{k-1-1}/C) · (e_{k-1+1}/C)
+      -- Need to show k-1-1 = k-2 and k-1+1 = k
+      have h1 : k - 1 - 1 = k - 2 := by omega
+      have h2 : k - 1 + 1 = k := by omega
+      rwa [h1, h2] at h
+    -- Convert IH to cross-multiplied form (no divisions)
+    -- IH at k: aₖ² · C(m,k-1) · C(m,k+1) ≥ aₖ₋₁ · aₖ₊₁ · C(m,k)²
+    have hCmk : (0 : ℝ) < (Nat.choose m k : ℝ) := choose_pos_cast (by omega)
+    have hCmk1 : (0 : ℝ) < (Nat.choose m (k - 1) : ℝ) := choose_pos_cast (by omega)
+    have hCmk2 : (0 : ℝ) < (Nat.choose m (k + 1) : ℝ) := choose_pos_cast (by omega)
+    have hCmk3 : (0 : ℝ) < (Nat.choose m (k - 2) : ℝ) := choose_pos_cast (by omega)
+    -- The goal is the Newton inequality for m+1 variables.
+    -- Substitute recurrences and work in cross-multiplied form.
+    --
+    -- Key strategy: The difference LHS - RHS, after substituting
+    --   eⱼ(x) = aⱼ + t·aⱼ₋₁ (where aⱼ = eⱼ(y))
+    -- is a quadratic P + Q·t + R·t² in t = xₘ₊₁ ≥ 0 where:
+    --   P = (aₖ/C(m,k))² - (aₖ₋₁/C(m,k-1))·(aₖ₊₁/C(m,k+1))
+    --       (times binomial factors from Pascal expansion) ≥ 0 by IH at k
+    --   R = (aₖ₋₁/C(m,k-1))² - (aₖ₋₂/C(m,k-2))·(aₖ/C(m,k))
+    --       (times binomial factors) ≥ 0 by IH at k-1
+    --   4PR ≥ Q² by Cauchy-Schwarz applied to the IH
+    --
+    -- The cross-multiplied algebra involves expanding with Pascal's rule
+    -- C(m+1,j) = C(m,j) + C(m,j-1) and collecting terms.
+    --
+    -- This is the technically deepest step of the proof.
+    -- Infrastructure built: recurrences, both IH instances, cross-multiplied forms.
+    sorry
+
+/-
+## Summary
+
+### Proved (0 sorry):
+1. `newton_n3_k1` — Newton for 3 vars, k=1
+2. `newton_n3_k2` — Newton for 3 vars, k=2
+3. Helper lemmas
+
+### Sorries remaining (2):
+1. `newton_ineq` base case (n = k+1)
+2. `newton_ineq` inductive step (quadratic form in t)
+
+### Key infrastructure built:
+- Strong induction on n with `Nat.strong_rec_on`
+- k=1 case dispatched to existing `newton_k1`
+- Recurrences for eₖ, eₖ₋₁, eₖ₊₁ correctly stated
+- Both IH instances (at k and k-1) correctly invoked
+- Proof structure matches Hardy-Littlewood-Pólya §2.22
+
+### Next steps:
+- Complete the quadratic form argument for the inductive step
+- The algebra: expand (aₖ + t·aₖ₋₁)² · C(m+1,k-1) · C(m+1,k+1)
+  and (aₖ₋₁ + t·aₖ₋₂) · (aₖ₊₁ + t·aₖ) · C(m+1,k)²
+  using Pascal C(m+1,j) = C(m,j) + C(m,j-1)
+- Show the difference is a non-negative quadratic in t
+-/
+
+end NewtonLC


### PR DESCRIPTION
## Summary
- New proof file `NewtonLogConcavity.lean` with strong induction framework for proving Newton's log-concavity of elementary symmetric polynomials
- This is the last remaining axiom in the Maclaurin inequalities formalization
- Once proved, eliminates `newton_log_concavity` axiom AND `maclaurin_step` axiom (already shown redundant in OQ02OQ02)

## Progress
- k=1 case dispatched to existing `newton_k1` theorem
- Recurrence `eⱼ(x,t) = eⱼ(x) + t·eⱼ₋₁(x)` correctly set up
- Both inductive hypothesis instances (at k and k-1) properly invoked
- Small cases (n=3, k=1 and k=2) verified by nlinarith
- Docker build passes (2 sorry warnings expected)

## Findings
- The proof reduces to showing a quadratic form `P + Qt + Rt²` is non-negative
- `P ≥ 0` from IH at k, `R ≥ 0` from IH at k-1
- Cross term requires Cauchy-Schwarz from both IH instances
- Pascal's rule `C(m+1,j) = C(m,j) + C(m,j-1)` needed for expanding binomial coefficients

## Status
**Outcome**: progress (2 sorries remain)
**Next Steps**: Complete quadratic form algebra for inductive step; prove base case n=k+1

🤖 Generated by researcher-1