### PR TITLE
Research: feuerbachs-theorem-oq-01 - Euler and squared Feuerbach relations

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ01.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ01.lean
@@ -451,6 +451,182 @@ theorem inradius_pos (T : Triangle) : T.inradius > 0 := by
   unfold Triangle.inradius
   exact div_pos (area_pos T) (semiperimeter_pos T)
 
+-- ============================================================
+-- GENERAL CASE: Euler's Formula OI² = R² - 2Rr
+-- ============================================================
+
+-- Strategy: Prove OI² = R(R - 2r) as a polynomial identity.
+-- This avoids sqrt by working with squared distances throughout.
+--
+-- Key identities:
+--   OI² = R² - 2Rr  (Euler's formula)
+--   NI² = (R/2 - r)²  (Feuerbach incircle, since N = midpoint(O,H))
+--
+-- The connection: NI² = R²/4 - Rr + r² = (R/2)² - 2(R/2)r + r² = (R/2 - r)²
+-- if we can show OI² = R² - 2Rr.
+--
+-- But we also need: NI = |OI² - stuff| which requires the Euler relation.
+-- Actually: N = (O+H)/2 and H = A+B+C-2O, so N = (A+B+C)/2 - O/2.
+-- The direct path is to compute NI² directly.
+
+-- The general Feuerbach proof requires handling products of square roots
+-- (side lengths a, b, c in incenter/excenter formulas).
+-- See "Path to General Feuerbach Proof" documentation below.
+
+-- ============================================================
+-- APPROACH: Prove via power of a point
+-- ============================================================
+-- The power of the incenter I with respect to the nine-point circle is:
+--   pow(I) = NI² - (R/2)²
+-- Feuerbach's theorem states pow(I) = -(R/2 - r)(R/2 + r) + 2r·(R/2)
+-- ... this gets complicated too.
+
+-- ============================================================
+-- PRACTICAL APPROACH: Fix the equilateral sorry, leave general for later
+-- ============================================================
+-- The equilateral_R_eq_2r in the base file has a sorry at line 722.
+-- We already proved this in equilateral_R_eq_2r_proved above.
+-- Let's also fix that sorry by providing the proof.
+
+-- The equilateral sorry is: R² = (2r)² where R = circumradius, r = inradius.
+-- We need: (0 - s/2)² + (0 - s√3/6)² = (2 · s√3/6)² = s²·3/9 = s²/3
+-- LHS = s²/4 + s²·3/36 = s²/4 + s²/12 = 4s²/12 = s²/3 ✓
+
+-- The proof is in equilateral_R_eq_2r_proved above, using our equiT constructor.
+-- The base file's equilateral_R_eq_2r uses an inline let binding, making it
+-- hard to reuse our proof directly.
+
+-- ============================================================
+-- NEW CONTRIBUTION: Euler's OI² formula for WLOG triangle
+-- ============================================================
+-- Place triangle with A=(0,0), B=(c,0), C=(x,y), y>0.
+-- Then prove OI² = R² - 2Rr as a polynomial identity.
+-- This WLOG doesn't lose generality because the formula is
+-- translation and rotation invariant.
+
+-- For this session, focus on what IS tractable:
+-- 1. Prove Euler OI² = R² - 2Rr for the 3-4-5 triangle (rational sides)
+-- 2. Prove NI² = (R/2-r)² and NI_a² = (R/2+r_a)² for 3-4-5
+-- 3. Document the path to the general proof
+
+-- ============================================================
+-- 3-4-5 TRIANGLE: Euler's Formula OI² = R² - 2Rr
+-- ============================================================
+
+/-- OI² for the 3-4-5 triangle.
+    O = (3/2, 2), I = (1, 1), so OI² = (3/2-1)² + (2-1)² = 1/4 + 1 = 5/4 -/
+theorem T345_OI_sq :
+    dist2_sq triangle_345.circumcenter triangle_345.incenter = 5 / 4 := by
+  rw [triangle_345_circumcenter, triangle_345_incenter]
+  unfold dist2_sq; norm_num
+
+/-- R² for the 3-4-5 triangle = 25/4 -/
+theorem T345_R_sq :
+    triangle_345.circumradius ^ 2 = 25 / 4 := by
+  rw [triangle_345_circumradius]; norm_num
+
+/-- Euler's formula OI² = R² - 2Rr verified for 3-4-5 triangle.
+    OI² = 5/4, R² = 25/4, 2Rr = 2·(5/2)·1 = 5
+    R² - 2Rr = 25/4 - 5 = 5/4 ✓ -/
+theorem T345_euler_OI :
+    dist2_sq triangle_345.circumcenter triangle_345.incenter =
+    triangle_345.circumradius ^ 2 - 2 * triangle_345.circumradius * triangle_345.inradius := by
+  rw [T345_OI_sq, T345_R_sq, triangle_345_circumradius, triangle_345_inradius]
+  norm_num
+
+-- ============================================================
+-- 3-4-5 TRIANGLE: NI² = (R/2 - r)²
+-- ============================================================
+
+/-- NI² for the 3-4-5 triangle.
+    N = (3/4, 1), I = (1, 1), NI² = (1-3/4)² + 0² = 1/16 -/
+theorem T345_NI_sq :
+    dist2_sq triangle_345.ninePointCenter triangle_345.incenter = 1 / 16 := by
+  rw [triangle_345_ninePointCenter, triangle_345_incenter]
+  unfold dist2_sq; norm_num
+
+/-- (R/2 - r)² for 3-4-5 triangle = (5/4 - 1)² = 1/16 -/
+theorem T345_feuerbach_sq :
+    (triangle_345.ninePointRadius - triangle_345.inradius) ^ 2 = 1 / 16 := by
+  rw [triangle_345_ninePointRadius, triangle_345_inradius]; norm_num
+
+/-- NI² = (R/2 - r)² for 3-4-5 triangle — the squared Feuerbach relation. -/
+theorem T345_NI_sq_eq_feuerbach :
+    dist2_sq triangle_345.ninePointCenter triangle_345.incenter =
+    (triangle_345.ninePointRadius - triangle_345.inradius) ^ 2 := by
+  rw [T345_NI_sq, T345_feuerbach_sq]
+
+-- ============================================================
+-- 3-4-5 TRIANGLE: NI_a² = (R/2 + r_a)² (Excircle squared)
+-- ============================================================
+
+/-- NI_a² for 3-4-5 triangle = (6-3/4)² + (6-1)² = 841/16 -/
+theorem T345_NI_a_sq :
+    dist2_sq triangle_345.ninePointCenter triangle_345.excenter_a = 841 / 16 := by
+  rw [triangle_345_ninePointCenter, T345_excenter_a]
+  unfold dist2_sq; norm_num
+
+/-- (R/2 + r_a)² = (5/4 + 6)² = (29/4)² = 841/16 -/
+theorem T345_excircle_a_sq :
+    (triangle_345.ninePointRadius + triangle_345.exradius_a) ^ 2 = 841 / 16 := by
+  rw [triangle_345_ninePointRadius, T345_exradius_a]; norm_num
+
+/-- NI_a² = (R/2 + r_a)² for 3-4-5 triangle — squared excircle Feuerbach. -/
+theorem T345_NI_a_sq_eq_excircle :
+    dist2_sq triangle_345.ninePointCenter triangle_345.excenter_a =
+    (triangle_345.ninePointRadius + triangle_345.exradius_a) ^ 2 := by
+  rw [T345_NI_a_sq, T345_excircle_a_sq]
+
+-- ============================================================
+-- GENERAL FEUERBACH: Path Forward Documentation
+-- ============================================================
+
+/-
+## Path to General Feuerbach Proof
+
+### The Algebraic Obstacle
+The incenter coordinates involve side lengths a, b, c = sqrt(...).
+Products like a·b cannot be eliminated by `ring` or `field_simp`.
+
+### Viable Approaches (ranked by feasibility)
+
+1. **Polynomial identity with CAS certificate** (MOST PROMISING)
+   - Express NI² - (R/2-r)² as a polynomial in (coords, a, b, c)
+   - Use constraints a² = Pa, b² = Pb, c² = Pc to eliminate
+   - Generate a Positivstellensatz certificate using external CAS
+   - Feed certificate to `polyrith` or `nlinarith`
+   - Estimated complexity: ~200 lines of certificate data
+
+2. **Inversive distance / power-of-point approach**
+   - Feuerbach's original proof uses inversive geometry
+   - Define inversion, prove invariance properties
+   - Show incircle maps to nine-point circle under suitable inversion
+   - Estimated complexity: ~500 lines of infrastructure
+
+3. **Mathlib EuclideanGeometry approach**
+   - Reformulate using Mathlib's `EuclideanGeometry.Sphere`
+   - Would require connecting our `Triangle` to Mathlib's framework
+   - Clean but significant refactoring needed
+   - Estimated complexity: ~800 lines
+
+### What We Have Now
+- All 9 nine-point circle memberships: PROVED (general)
+- Euler line relation: PROVED (general)
+- Altitude feet on nine-point circle: PROVED (general)
+- R = 2r for equilateral: PROVED
+- Incircle tangency (3-4-5): PROVED
+- Excircle tangency A/B/C (3-4-5): PROVED
+- Euler OI² = R²-2Rr (3-4-5): PROVED
+- NI² = (R/2-r)² (3-4-5): PROVED
+- General area/semiperimeter/inradius positivity: PROVED
+
+### Remaining Axioms (4)
+1. feuerbach_incircle_distance (general)
+2. feuerbach_excircle_a_distance (general)
+3. feuerbach_excircle_b_distance (general)
+4. feuerbach_excircle_c_distance (general)
+-/
+
 -- Type-check results
 #check @foot_a_on_ninePointCircle_proved
 #check @foot_b_on_ninePointCircle_proved
@@ -462,5 +638,8 @@ theorem inradius_pos (T : Triangle) : T.inradius > 0 := by
 #check @area_pos
 #check @semiperimeter_pos
 #check @inradius_pos
+#check @T345_euler_OI
+#check @T345_NI_sq_eq_feuerbach
+#check @T345_NI_a_sq_eq_excircle
 
 end FeuerbachsTheoremOQ01

--- a/src/data/research/problems/feuerbachs-theorem-oq-01.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-01.json
@@ -44,7 +44,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Verified all 3 excircle tangency relations for 3-4-5 triangle. Proved area_pos, semiperimeter_pos, inradius_pos. Created Aristotle companion file with 15 provable supporting lemmas. Fixed pre-existing Mathlib v4.26 build breakage.",
+    "progressSummary": "PROGRESS: Proved Euler OI²=R²-2Rr, Feuerbach NI²=(R/2-r)², and excircle NI_a²=(R/2+r_a)² for 3-4-5 triangle. Cleaned up exploratory code. General proof requires polynomial identity with sqrt constraints - 3 viable approaches documented.",
     "builtItems": [
       "T345_feuerbach_excircle_a: d(N,I_a) = 29/4 = R/2 + r_a verified",
       "T345_feuerbach_excircle_b: d(N,I_b) = 17/4 = R/2 + r_b verified",
@@ -52,14 +52,20 @@
       "area_pos: Triangle area is positive (general)",
       "semiperimeter_pos: Semiperimeter is positive (general)",
       "inradius_pos: Inradius is positive (general)",
-      "FeuerbachsTheoremOQ01Aristotle.lean: 15 lemma targets for automated proof search"
+      "FeuerbachsTheoremOQ01Aristotle.lean: 15 lemma targets for automated proof search",
+      "T345_euler_OI: Euler OI²=R²-2Rr verified for 3-4-5 triangle",
+      "T345_NI_sq_eq_feuerbach: NI²=(R/2-r)² verified for 3-4-5 triangle (squared Feuerbach)",
+      "T345_NI_a_sq_eq_excircle: NI_a²=(R/2+r_a)² verified for 3-4-5 excircle A"
     ],
     "insights": [
       "General Feuerbach distance proofs blocked by sqrt in side lengths: incenter coords involve a=sqrt(...), cross terms a*b resist ring tactic",
       "NI = R/2 - r (Feuerbach incircle tangency) follows from Euler identity, but proving either requires eliminating sqrt",
       "Excircle tangency d(N,I_k) = R/2 + r_k verified numerically for 3-4-5 triangle (all 3 cases)",
       "The equilateral_R_eq_2r proof in main file was broken by Mathlib v4.26 upgrade (dist2_sq unfold change) - independently proved in OQ01",
-      "Approach for general case: introduce a^2, b^2, c^2 as polynomial constraints and use nlinarith - untested but promising"
+      "Approach for general case: introduce a^2, b^2, c^2 as polynomial constraints and use nlinarith - untested but promising",
+      "Euler formula OI²=R²-2Rr and Feuerbach NI²=(R/2-r)² are polynomial identities when side lengths are rational - verified for 3-4-5",
+      "General case requires handling sqrt side lengths: incenter coords are (a*Ax+b*Bx+c*Cx)/(a+b+c) where a,b,c=sqrt(...)",
+      "Three viable paths to general proof: (1) CAS polynomial certificate with constraints a²=Pa, (2) inversive geometry, (3) Mathlib EuclideanGeometry refactoring"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- Proved Euler's formula OI² = R² - 2Rr for the 3-4-5 triangle
- Proved squared Feuerbach relations NI² = (R/2-r)² and NI_a² = (R/2+r_a)² for the 3-4-5 triangle
- Documented 3 viable paths to the general Feuerbach proof

## Progress
- 3 new theorems proved and verified via Docker build
- Cleaned up exploratory WLOG code that was unused
- Updated problem knowledge with insights about the sqrt obstacle

## Findings
- The general Feuerbach proof is blocked by sqrt in incenter coordinates: `I = (a·A + b·B + c·C)/(a+b+c)` where `a,b,c = sqrt(...)`
- For rational-sided triangles (like 3-4-5), all Feuerbach relations reduce to `norm_num`
- Three viable paths: (1) CAS polynomial certificate with constraints a²=Pa, (2) inversive geometry, (3) Mathlib EuclideanGeometry

## Status
**Outcome**: progress
**Next Steps**: Try CAS polynomial certificate approach for general case, or investigate Mathlib inner-product formulation

🤖 Generated by researcher-2