### PR TITLE
Research: feuerbachs-theorem-oq-01 - Fix equilateral sorry, prove 15 companion lemmas

### DIFF
--- a/proofs/Proofs/FeuerbachsTheorem.lean
+++ b/proofs/Proofs/FeuerbachsTheorem.lean
@@ -716,10 +716,30 @@ theorem equilateral_R_eq_2r (s : ℝ) (hs : s > 0) :
   · unfold Triangle.circumradius; exact dist2_nonneg _ _
   · rw [h_inr]; positivity
   · -- R² = (2r)²: both equal s²/3
-    -- NOTE: This proof was broken by the Mathlib v4.26 upgrade (dist2_sq unfold issue).
-    -- The result is independently proved in FeuerbachsTheoremOQ01.lean as
-    -- equilateral_R_eq_2r_proved, which uses a different proof strategy.
-    sorry
+    rw [h_inr]
+    -- Compute circumcenter coordinates for the equilateral triangle
+    have hO1 : T.circumcenter.1 = s / 2 := by
+      unfold Triangle.circumcenter; simp only [T]
+      have hd : 2 * ((0 - s / 2) * (0 - s * Real.sqrt 3 / 2) -
+          (s - s / 2) * (0 - s * Real.sqrt 3 / 2)) = s ^ 2 * Real.sqrt 3 := by ring
+      have hd_ne : s ^ 2 * Real.sqrt 3 ≠ 0 := by positivity
+      rw [hd]; field_simp [hd_ne, ne_of_gt hs]; ring
+    have hO2 : T.circumcenter.2 = s * Real.sqrt 3 / 6 := by
+      unfold Triangle.circumcenter; simp only [T]
+      have hd : 2 * ((0 - s / 2) * (0 - s * Real.sqrt 3 / 2) -
+          (s - s / 2) * (0 - s * Real.sqrt 3 / 2)) = s ^ 2 * Real.sqrt 3 := by ring
+      have hd_ne : s ^ 2 * Real.sqrt 3 ≠ 0 := by positivity
+      have hsqrt3_ne : Real.sqrt 3 ≠ 0 := by positivity
+      rw [hd]; field_simp [hd_ne, ne_of_gt hs, hsqrt3_ne]
+      have h_key : s ^ 2 * Real.sqrt 3 ^ 2 = 3 * s ^ 2 := by nlinarith [hsq3]
+      nlinarith [h_key, sq_nonneg s, sq_nonneg (Real.sqrt 3), sq_nonneg (s * Real.sqrt 3)]
+    -- Now R² = (0 - s/2)² + (0 - s√3/6)² = s²/4 + s²·3/36 = s²/3
+    unfold Triangle.circumradius dist2
+    rw [Real.sq_sqrt (by positivity)]
+    have hA1 : T.A.1 = (0 : ℝ) := by simp only [T]
+    have hA2 : T.A.2 = (0 : ℝ) := by simp only [T]
+    rw [hA1, hA2, hO1, hO2]
+    nlinarith [hsq3, sq_nonneg s, sq_nonneg (Real.sqrt 3)]
 
 /-- For an equilateral triangle, the circumradius R = 2r where r is the inradius.
     This means R/2 = r, so the nine-point circle has the same radius as the incircle. -/

--- a/proofs/Proofs/FeuerbachsTheoremOQ01Aristotle.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ01Aristotle.lean
@@ -23,28 +23,96 @@ open Real FeuerbachsTheorem
 -- CIRCUMCENTER EQUIDISTANCE
 -- ============================================================
 
+-- Helper: the perpendicular bisector condition for AB
+private lemma perp_bisector_AB (T : Triangle) :
+    (T.B.1 - T.A.1) * (T.B.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.B.2 - T.A.2) * (T.B.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := by intro h; apply T.nondegenerate; nlinarith
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]; field_simp [hd_ne]; ring
+
+-- Helper: the perpendicular bisector condition for AC
+private lemma perp_bisector_AC (T : Triangle) :
+    (T.C.1 - T.A.1) * (T.C.1 + T.A.1 - 2 * T.circumcenter.1) +
+    (T.C.2 - T.A.2) * (T.C.2 + T.A.2 - 2 * T.circumcenter.2) = 0 := by
+  set d := 2 * ((T.A.1 - T.C.1) * (T.B.2 - T.C.2) - (T.B.1 - T.C.1) * (T.A.2 - T.C.2))
+  have hd_ne : d ≠ 0 := by intro h; apply T.nondegenerate; nlinarith
+  have hox : T.circumcenter.1 = ((T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.2 - T.C.2) -
+    (T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.2 - T.C.2)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  have hoy : T.circumcenter.2 = ((T.B.1^2 + T.B.2^2 - T.C.1^2 - T.C.2^2) * (T.A.1 - T.C.1) -
+    (T.A.1^2 + T.A.2^2 - T.C.1^2 - T.C.2^2) * (T.B.1 - T.C.1)) / d := by
+    unfold Triangle.circumcenter; dsimp
+  rw [hox, hoy]; field_simp [hd_ne]; ring
+
+-- Helper: two nonneg reals with equal squares are equal
+private lemma eq_of_sq_eq_nonneg' {a b : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b)
+    (h : a ^ 2 = b ^ 2) : a = b := by
+  have h1 : (a - b) * (a + b) = 0 := by nlinarith
+  rcases mul_eq_zero.mp h1 with hab | hab
+  · linarith
+  · linarith
+
 /-- The circumcenter is equidistant from all three vertices (B).
     dist2(O, B) = dist2(O, A) = R -/
 theorem circumcenter_equidist_B (T : Triangle) :
-    dist2 T.circumcenter T.B = dist2 T.circumcenter T.A := by sorry
+    dist2 T.circumcenter T.B = dist2 T.circumcenter T.A := by
+  apply eq_of_sq_eq_nonneg' (by unfold dist2; exact Real.sqrt_nonneg _)
+    (by unfold dist2; exact Real.sqrt_nonneg _)
+  unfold dist2
+  rw [Real.sq_sqrt (by positivity), Real.sq_sqrt (by positivity)]
+  have h := perp_bisector_AB T
+  nlinarith [sq_nonneg (T.B.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.B.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
 
 /-- The circumcenter is equidistant from all three vertices (C).
     dist2(O, C) = dist2(O, A) = R -/
 theorem circumcenter_equidist_C (T : Triangle) :
-    dist2 T.circumcenter T.C = dist2 T.circumcenter T.A := by sorry
+    dist2 T.circumcenter T.C = dist2 T.circumcenter T.A := by
+  apply eq_of_sq_eq_nonneg' (by unfold dist2; exact Real.sqrt_nonneg _)
+    (by unfold dist2; exact Real.sqrt_nonneg _)
+  unfold dist2
+  rw [Real.sq_sqrt (by positivity), Real.sq_sqrt (by positivity)]
+  have h := perp_bisector_AC T
+  nlinarith [sq_nonneg (T.C.1 - T.circumcenter.1), sq_nonneg (T.A.1 - T.circumcenter.1),
+             sq_nonneg (T.C.2 - T.circumcenter.2), sq_nonneg (T.A.2 - T.circumcenter.2)]
 
 -- ============================================================
 -- SIDE LENGTH POSITIVITY
 -- ============================================================
 
 /-- Side a = |BC| > 0 for nondegenerate triangles. -/
-theorem side_a_pos (T : Triangle) : T.side_a > 0 := by sorry
+theorem side_a_pos (T : Triangle) : T.side_a > 0 := by
+  unfold Triangle.side_a
+  apply Real.sqrt_pos_of_pos
+  by_contra h; push_neg at h
+  have hx : T.C.1 = T.B.1 := by nlinarith [sq_nonneg (T.C.1 - T.B.1), sq_nonneg (T.C.2 - T.B.2)]
+  have hy : T.C.2 = T.B.2 := by nlinarith [sq_nonneg (T.C.1 - T.B.1), sq_nonneg (T.C.2 - T.B.2)]
+  exact T.nondegenerate (by rw [hx, hy]; ring)
 
 /-- Side b = |CA| > 0 for nondegenerate triangles. -/
-theorem side_b_pos (T : Triangle) : T.side_b > 0 := by sorry
+theorem side_b_pos (T : Triangle) : T.side_b > 0 := by
+  unfold Triangle.side_b
+  apply Real.sqrt_pos_of_pos
+  by_contra h; push_neg at h
+  have hx : T.A.1 = T.C.1 := by nlinarith [sq_nonneg (T.A.1 - T.C.1), sq_nonneg (T.A.2 - T.C.2)]
+  have hy : T.A.2 = T.C.2 := by nlinarith [sq_nonneg (T.A.1 - T.C.1), sq_nonneg (T.A.2 - T.C.2)]
+  exact T.nondegenerate (by rw [hx, hy]; ring)
 
 /-- Side c = |AB| > 0 for nondegenerate triangles. -/
-theorem side_c_pos (T : Triangle) : T.side_c > 0 := by sorry
+theorem side_c_pos (T : Triangle) : T.side_c > 0 := by
+  unfold Triangle.side_c
+  apply Real.sqrt_pos_of_pos
+  by_contra h; push_neg at h
+  have hx : T.B.1 = T.A.1 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+  have hy : T.B.2 = T.A.2 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+  exact T.nondegenerate (by rw [hx, hy]; ring)
 
 -- ============================================================
 -- SQUARED SIDE LENGTHS
@@ -52,38 +120,65 @@ theorem side_c_pos (T : Triangle) : T.side_c > 0 := by sorry
 
 /-- side_a² equals the sum of squared coordinate differences. -/
 theorem side_a_sq (T : Triangle) :
-    T.side_a ^ 2 = (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 := by sorry
+    T.side_a ^ 2 = (T.C.1 - T.B.1) ^ 2 + (T.C.2 - T.B.2) ^ 2 := by
+  unfold Triangle.side_a
+  rw [Real.sq_sqrt (by positivity)]
 
 /-- side_b² equals the sum of squared coordinate differences. -/
 theorem side_b_sq (T : Triangle) :
-    T.side_b ^ 2 = (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 := by sorry
+    T.side_b ^ 2 = (T.A.1 - T.C.1) ^ 2 + (T.A.2 - T.C.2) ^ 2 := by
+  unfold Triangle.side_b
+  rw [Real.sq_sqrt (by positivity)]
 
 /-- side_c² equals the sum of squared coordinate differences. -/
 theorem side_c_sq (T : Triangle) :
-    T.side_c ^ 2 = (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 := by sorry
+    T.side_c ^ 2 = (T.B.1 - T.A.1) ^ 2 + (T.B.2 - T.A.2) ^ 2 := by
+  unfold Triangle.side_c
+  rw [Real.sq_sqrt (by positivity)]
 
 -- ============================================================
 -- DIST2 PROPERTIES
 -- ============================================================
 
 /-- dist2 is symmetric. -/
-theorem dist2_comm (P Q : Point) : dist2 P Q = dist2 Q P := by sorry
+theorem dist2_comm (P Q : Point) : dist2 P Q = dist2 Q P := by
+  unfold dist2
+  congr 1
+  nlinarith [sq_nonneg (Q.1 - P.1), sq_nonneg (Q.2 - P.2),
+             sq_nonneg (P.1 - Q.1), sq_nonneg (P.2 - Q.2)]
 
 /-- dist2(P, P) = 0 -/
-theorem dist2_self (P : Point) : dist2 P P = 0 := by sorry
+theorem dist2_self (P : Point) : dist2 P P = 0 := by
+  unfold dist2; simp [sub_self]
 
 /-- dist2 is nonneg. -/
-theorem dist2_nonneg_gen (P Q : Point) : 0 ≤ dist2 P Q := by sorry
+theorem dist2_nonneg_gen (P Q : Point) : 0 ≤ dist2 P Q := by
+  unfold dist2; exact Real.sqrt_nonneg _
 
 -- ============================================================
 -- CIRCUMRADIUS POSITIVITY
 -- ============================================================
 
 /-- The circumradius R > 0 for nondegenerate triangles. -/
-theorem circumradius_pos (T : Triangle) : T.circumradius > 0 := by sorry
+theorem circumradius_pos (T : Triangle) : T.circumradius > 0 := by
+  unfold Triangle.circumradius dist2
+  apply Real.sqrt_pos_of_pos
+  have h := perp_bisector_AB T
+  by_contra hle; push_neg at hle
+  have hx : T.circumcenter.1 = T.A.1 := by
+    nlinarith [sq_nonneg (T.A.1 - T.circumcenter.1), sq_nonneg (T.A.2 - T.circumcenter.2)]
+  have hy : T.circumcenter.2 = T.A.2 := by
+    nlinarith [sq_nonneg (T.A.1 - T.circumcenter.1), sq_nonneg (T.A.2 - T.circumcenter.2)]
+  -- Substitute O = A into perpendicular bisector: (B-A)^2 = 0
+  rw [hx, hy] at h
+  have hbx : T.B.1 = T.A.1 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+  have hby : T.B.2 = T.A.2 := by nlinarith [sq_nonneg (T.B.1 - T.A.1), sq_nonneg (T.B.2 - T.A.2)]
+  exact T.nondegenerate (by rw [hbx, hby]; ring)
 
 /-- The nine-point radius R/2 > 0 for nondegenerate triangles. -/
-theorem ninePointRadius_pos (T : Triangle) : T.ninePointRadius > 0 := by sorry
+theorem ninePointRadius_pos (T : Triangle) : T.ninePointRadius > 0 := by
+  unfold Triangle.ninePointRadius
+  exact div_pos (circumradius_pos T) (by norm_num)
 
 -- ============================================================
 -- ORTHOCENTER RELATION
@@ -92,7 +187,9 @@ theorem ninePointRadius_pos (T : Triangle) : T.ninePointRadius > 0 := by sorry
 /-- H = A + B + C - 2O (orthocenter via circumcenter). -/
 theorem orthocenter_formula (T : Triangle) :
     T.orthocenter = (T.A.1 + T.B.1 + T.C.1 - 2 * T.circumcenter.1,
-                     T.A.2 + T.B.2 + T.C.2 - 2 * T.circumcenter.2) := by sorry
+                     T.A.2 + T.B.2 + T.C.2 - 2 * T.circumcenter.2) := by
+  unfold Triangle.orthocenter
+  exact Prod.ext (by ring) (by ring)
 
 -- ============================================================
 -- NINE-POINT CENTER PROPERTIES
@@ -100,14 +197,16 @@ theorem orthocenter_formula (T : Triangle) :
 
 /-- N = (O + H) / 2 -/
 theorem ninePointCenter_midpoint (T : Triangle) :
-    T.ninePointCenter = pointMidpoint T.circumcenter T.orthocenter := by sorry
+    T.ninePointCenter = pointMidpoint T.circumcenter T.orthocenter := by
+  unfold Triangle.ninePointCenter pointMidpoint
+  exact Prod.ext (by ring) (by ring)
 
-/-- N_x = (A_x + B_x + C_x) / 2 - O_x / 2.
-    Actually N = (O + H)/2 = (O + A+B+C-2O)/2 = (A+B+C-O)/2
-    so N_x = (A_x + B_x + C_x - O_x) / 2 -/
+/-- N_x = (A_x + B_x + C_x - O_x) / 2, N_y = (A_y + B_y + C_y - O_y) / 2 -/
 theorem ninePointCenter_coords (T : Triangle) :
     T.ninePointCenter.1 = (T.A.1 + T.B.1 + T.C.1 - T.circumcenter.1) / 2 ∧
-    T.ninePointCenter.2 = (T.A.2 + T.B.2 + T.C.2 - T.circumcenter.2) / 2 := by sorry
+    T.ninePointCenter.2 = (T.A.2 + T.B.2 + T.C.2 - T.circumcenter.2) / 2 := by
+  unfold Triangle.ninePointCenter pointMidpoint Triangle.orthocenter
+  exact ⟨by dsimp; ring, by dsimp; ring⟩
 
 end FeuerbachsTheoremOQ01Aristotle
 

--- a/src/data/research/problems/feuerbachs-theorem-oq-01.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-01.json
@@ -29,22 +29,22 @@
   },
   "currentState": {
     "phase": "PROGRESS",
-    "since": "2026-03-13T07:00:00.000Z",
-    "iteration": 2,
-    "focus": "Excircle tangency verification and infrastructure",
+    "since": "2026-03-13T18:00:00.000Z",
+    "iteration": 3,
+    "focus": "Companion file lemmas proved, equilateral sorry fixed",
     "blockers": [
       "Incenter formula uses sqrt side lengths - nested sqrt makes field_simp/ring approach intractable",
       "Need alternative approach: complex coordinates, inversive geometry, or power-of-point"
     ],
-    "nextAction": "Try reformulating incenter without sqrt, or use squared distance identities directly",
+    "nextAction": "Explore squaring approach for general Feuerbach or Mathlib inner-product reformulation",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 2,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved Euler OI²=R²-2Rr, Feuerbach NI²=(R/2-r)², and excircle NI_a²=(R/2+r_a)² for 3-4-5 triangle. Cleaned up exploratory code. General proof requires polynomial identity with sqrt constraints - 3 viable approaches documented.",
+    "progressSummary": "PROGRESS: Fixed equilateral_R_eq_2r sorry in main file (0 sorries in equilateral case). Proved all 15 Aristotle companion lemmas (0 sorries). General proof still requires handling sqrt side lengths in incenter formula - fundamental algebraic obstacle analyzed in depth.",
     "builtItems": [
       "T345_feuerbach_excircle_a: d(N,I_a) = 29/4 = R/2 + r_a verified",
       "T345_feuerbach_excircle_b: d(N,I_b) = 17/4 = R/2 + r_b verified",
@@ -53,25 +53,34 @@
       "semiperimeter_pos: Semiperimeter is positive (general)",
       "inradius_pos: Inradius is positive (general)",
       "FeuerbachsTheoremOQ01Aristotle.lean: 15 lemma targets for automated proof search",
-      "T345_euler_OI: Euler OI²=R²-2Rr verified for 3-4-5 triangle",
-      "T345_NI_sq_eq_feuerbach: NI²=(R/2-r)² verified for 3-4-5 triangle (squared Feuerbach)",
-      "T345_NI_a_sq_eq_excircle: NI_a²=(R/2+r_a)² verified for 3-4-5 excircle A"
+      "T345_euler_OI: Euler OI\u00b2=R\u00b2-2Rr verified for 3-4-5 triangle",
+      "T345_NI_sq_eq_feuerbach: NI\u00b2=(R/2-r)\u00b2 verified for 3-4-5 triangle (squared Feuerbach)",
+      "T345_NI_a_sq_eq_excircle: NI_a\u00b2=(R/2+r_a)\u00b2 verified for 3-4-5 excircle A",
+      "equilateral_R_eq_2r: Fixed sorry - circumcenter coords computed inline",
+      "Aristotle companion: circumcenter_equidist_B/C proved via perpendicular bisector",
+      "Aristotle companion: side_a/b/c_pos proved for general triangles",
+      "Aristotle companion: side_a/b/c_sq proved (sqrt elimination)",
+      "Aristotle companion: dist2_comm, dist2_self, dist2_nonneg_gen proved",
+      "Aristotle companion: circumradius_pos, ninePointRadius_pos proved",
+      "Aristotle companion: orthocenter_formula, ninePointCenter_midpoint/coords proved"
     ],
     "insights": [
       "General Feuerbach distance proofs blocked by sqrt in side lengths: incenter coords involve a=sqrt(...), cross terms a*b resist ring tactic",
       "NI = R/2 - r (Feuerbach incircle tangency) follows from Euler identity, but proving either requires eliminating sqrt",
       "Excircle tangency d(N,I_k) = R/2 + r_k verified numerically for 3-4-5 triangle (all 3 cases)",
-      "The equilateral_R_eq_2r proof in main file was broken by Mathlib v4.26 upgrade (dist2_sq unfold change) - independently proved in OQ01",
+      "equilateral_R_eq_2r sorry in main file FIXED (was broken by Mathlib v4.26 upgrade, now proved inline)",
       "Approach for general case: introduce a^2, b^2, c^2 as polynomial constraints and use nlinarith - untested but promising",
-      "Euler formula OI²=R²-2Rr and Feuerbach NI²=(R/2-r)² are polynomial identities when side lengths are rational - verified for 3-4-5",
+      "Euler formula OI\u00b2=R\u00b2-2Rr and Feuerbach NI\u00b2=(R/2-r)\u00b2 are polynomial identities when side lengths are rational - verified for 3-4-5",
       "General case requires handling sqrt side lengths: incenter coords are (a*Ax+b*Bx+c*Cx)/(a+b+c) where a,b,c=sqrt(...)",
-      "Three viable paths to general proof: (1) CAS polynomial certificate with constraints a²=Pa, (2) inversive geometry, (3) Mathlib EuclideanGeometry refactoring"
+      "Three viable paths to general proof: (1) CAS polynomial certificate with constraints a\u00b2=Pa, (2) inversive geometry, (3) Mathlib EuclideanGeometry refactoring",
+      "Squaring approach analysis: (NI\u00b2-R\u00b2/4-r\u00b2)\u00b2=R\u00b2r\u00b2 reduces to polynomial identity but bare a,b terms from incenter formula cannot be eliminated - need ab as auxiliary variable with constraint \u03b3\u00b2=\u03b1\u03b2",
+      "equilateral sorry fix: key was computing circumcenter coords separately (O_x=s/2, O_y=s\u221a3/6) then nlinarith with \u221a3\u00b2=3"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Try proving general Feuerbach via polynomial identity with a^2/b^2/c^2 constraints",
-      "Wait for Aristotle results on companion file lemmas",
-      "Consider Mathlib inner-product approach instead of coordinate geometry"
+      "Explore Mathlib inner-product reformulation to avoid coordinate sqrt issues",
+      "Try introducing auxiliary variable \u03b3=ab with constraint \u03b3\u00b2=a\u00b2b\u00b2 for polynomial identity approach",
+      "Consider inversive geometry proof (Feuerbach original approach)"
     ]
   },
   "approaches": [
@@ -81,9 +90,9 @@
       "notes": "Works for altitude feet and equilateral case, fails for incircle tangency due to sqrt in incenter"
     },
     {
-      "name": "Euler formula OI²=R²-2Rr",
+      "name": "Euler formula OI\u00b2=R\u00b2-2Rr",
       "status": "planned",
-      "notes": "Could prove OI² as polynomial identity, then derive NI from midpoint relation"
+      "notes": "Could prove OI\u00b2 as polynomial identity, then derive NI from midpoint relation"
     }
   ],
   "tags": [
@@ -103,7 +112,7 @@
     "mathlib": []
   },
   "started": "2026-03-12T05:34:54.574Z",
-  "lastUpdate": "2026-03-13T07:00:00.000Z",
+  "lastUpdate": "2026-03-13T18:00:00.000Z",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary
- Fixed the `equilateral_R_eq_2r` sorry in `FeuerbachsTheorem.lean` (broken since Mathlib v4.26 upgrade)
- Proved all 15 Aristotle companion file lemmas in `FeuerbachsTheoremOQ01Aristotle.lean` (0 sorries remaining)
- Updated problem knowledge with detailed algebraic analysis of the general case

## Progress
### Equilateral Sorry Fix
The sorry at line 722 of `FeuerbachsTheorem.lean` was broken by a Mathlib v4.26 upgrade that changed `dist2_sq` unfolding behavior. Fixed by computing circumcenter coordinates inline (`O_x = s/2`, `O_y = s√3/6`) and using `nlinarith` with the identity `√3² = 3`.

### Companion File Lemmas (15 proved)
All routine supporting lemmas proved for the Aristotle automated proof search system:
- **Circumcenter equidistance**: `circumcenter_equidist_B`, `circumcenter_equidist_C`
- **Side length positivity**: `side_a_pos`, `side_b_pos`, `side_c_pos`
- **Squared side lengths**: `side_a_sq`, `side_b_sq`, `side_c_sq`
- **Distance properties**: `dist2_comm`, `dist2_self`, `dist2_nonneg_gen`
- **Radius positivity**: `circumradius_pos`, `ninePointRadius_pos`
- **Center relations**: `orthocenter_formula`, `ninePointCenter_midpoint`, `ninePointCenter_coords`

## Findings
- The general Feuerbach proof (4 remaining axioms) is fundamentally blocked by sqrt side lengths in the incenter formula
- A "squaring approach" (proving `(NI²-R²/4-r²)²=R²r²` as polynomial identity) still requires bare `a`, `b` terms that can't be eliminated
- Three viable paths remain: (1) CAS polynomial certificate with auxiliary variable `γ=ab`, (2) inversive geometry, (3) Mathlib inner-product reformulation

## Status
**Outcome**: progress
**Next Steps**: Explore Mathlib inner-product reformulation or inversive geometry approach for general case

🤖 Generated by researcher-2