### PR TITLE
Research: hodge-conjecture - Prove direct sum construction (3 axioms eliminated)

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ03.lean
+++ b/proofs/Proofs/BorsukUlamOQ03.lean
@@ -1068,4 +1068,207 @@ theorem borsuk_ulam_n1
     provides a combinatorial/constructive foundation for 1D. -/
 theorem bu_complete_summary : True := trivial
 
+/-
+## Section XXVII: Tucker's Parity Lemma
+
+The number of sign-change edges in a Boolean sequence on {0, ..., n}
+always has the same parity as the endpoint comparison. When endpoints
+differ (Tucker's hypothesis), the count is ODD — strictly stronger
+than "at least one exists."
+
+This is the combinatorial heart of why Tucker's lemma is true:
+the parity of sign changes is a topological invariant determined
+entirely by the boundary data.
+-/
+
+/-- Count adjacent transitions (disagreements) in a Boolean sequence on {0, ..., n}. -/
+def countTransitions (s : ℕ → Bool) : ℕ → ℕ
+  | 0 => 0
+  | n + 1 => countTransitions s n + if s n != s (n + 1) then 1 else 0
+
+@[simp] theorem countTransitions_zero (s : ℕ → Bool) :
+    countTransitions s 0 = 0 := rfl
+
+theorem countTransitions_succ (s : ℕ → Bool) (n : ℕ) :
+    countTransitions s (n + 1) =
+      countTransitions s n + if s n != s (n + 1) then 1 else 0 := rfl
+
+/-- Boolean parity step: adding a transition flips the parity correctly.
+    This is verified by exhaustive case analysis on the 8 Boolean combinations.
+    The inner `% 2` on the delta term arises from `Nat.add_mod`. -/
+private theorem bool_parity_mod2 (a b c : Bool) :
+    ((if a == b then 0 else 1 : ℕ) + (if b != c then 1 else 0) % 2) % 2 =
+    if a == c then 0 else 1 := by
+  cases a <;> cases b <;> cases c <;> decide
+
+/-- **Tucker's Parity Lemma**: The transition count has the same parity as
+    the endpoint comparison.
+
+    - If s(0) = s(n): EVEN number of transitions
+    - If s(0) ≠ s(n): ODD number of transitions (hence ≥ 1)
+
+    This is strictly stronger than Tucker's 1D lemma (which only asserts
+    existence of at least one sign change when endpoints differ).
+
+    **Proof**: By induction on n. The base case is trivial. For the inductive
+    step, adding a transition flips the parity, and the Boolean XOR identity
+    (a⊕b)⊕(b⊕c) = a⊕c ensures consistency. -/
+theorem tucker_parity (s : ℕ → Bool) : ∀ n : ℕ,
+    countTransitions s n % 2 = if s 0 == s n then 0 else 1 := by
+  intro n
+  induction n with
+  | zero => simp [countTransitions]
+  | succ n ih =>
+    rw [countTransitions_succ, Nat.add_mod, ih]
+    exact bool_parity_mod2 (s 0) (s n) (s (n + 1))
+
+/-- **Corollary**: When endpoints differ, the transition count is ODD (hence ≥ 1).
+    This gives Tucker's 1D lemma as an immediate corollary, but with the
+    stronger parity information. -/
+theorem tucker_count_odd (s : ℕ → Bool) (n : ℕ) (h : s 0 ≠ s n) :
+    countTransitions s n % 2 = 1 := by
+  rw [tucker_parity]
+  simp [h]
+
+/-- **Corollary**: When endpoints agree, the transition count is EVEN.
+    In particular, there is no topological obstruction to having zero transitions. -/
+theorem tucker_count_even (s : ℕ → Bool) (n : ℕ) (h : s 0 = s n) :
+    countTransitions s n % 2 = 0 := by
+  rw [tucker_parity]
+  simp [h]
+
+/-- The transition count is monotone: extending the sequence doesn't decrease it. -/
+theorem countTransitions_mono (s : ℕ → Bool) : ∀ n : ℕ,
+    countTransitions s n ≤ countTransitions s (n + 1) := by
+  intro n
+  rw [countTransitions_succ]
+  omega
+
+/-- The transition count is bounded by n (at most one transition per position). -/
+theorem countTransitions_le (s : ℕ → Bool) : ∀ n : ℕ,
+    countTransitions s n ≤ n := by
+  intro n
+  induction n with
+  | zero => simp [countTransitions]
+  | succ n ih =>
+    rw [countTransitions_succ]
+    split <;> omega
+
+/-- When endpoints differ, there are at least 1 and at most n transitions.
+    The parity says the exact count is odd, so the minimum is 1.
+    Combined with the upper bound, we get 1 ≤ count ≤ n. -/
+theorem tucker_count_bounds (s : ℕ → Bool) (n : ℕ) (hn : 0 < n) (h : s 0 ≠ s n) :
+    1 ≤ countTransitions s n ∧ countTransitions s n ≤ n := by
+  constructor
+  · -- count is odd, hence ≥ 1
+    have hodd := tucker_count_odd s n h
+    omega
+  · exact countTransitions_le s n
+
+/-
+## Section XXVIII: Non-Trivial Lusternik-Schnirelman for S¹
+
+The 1D LS theorem (Section XV) uses the trivial witness x = 0 (which
+is its own antipodal on the interval). On the circle S¹, no point is
+self-antipodal (Section IX), making LS genuinely non-trivial.
+
+Here we prove the circle LS from the circle BU theorem using the
+metric distance to the complement of a set.
+
+**Theorem**: If two closed sets A, B cover S¹, at least one contains
+an antipodal pair.
+
+**Proof idea**: Define f(p) = infDist(p, A) for p ∈ ℝ². By circle BU,
+∃ antipodal pair with equal f-values. If f = 0 at both: both in A.
+If f > 0 at both: both outside A, hence in B.
+-/
+
+/-- **Lusternik-Schnirelman for S¹**: If two closed sets A, B cover the
+    unit circle (parametrically), at least one contains an antipodal pair.
+
+    Unlike the interval LS (Section XV), this is genuinely non-trivial:
+    no point on S¹ is its own antipodal, so the proof must use BU.
+
+    **Proof**: Apply circle BU to f(p) = infDist(p, A). The common value
+    at an antipodal pair is either 0 (both in A) or positive (both in B). -/
+theorem lusternik_schnirelman_S1
+    (A B : Set (ℝ × ℝ))
+    (hA : IsClosed A) (hB : IsClosed B)
+    (hAne : A.Nonempty)
+    (hcover : ∀ θ : ℝ, (Real.cos θ, Real.sin θ) ∈ A ∨ (Real.cos θ, Real.sin θ) ∈ B) :
+    (∃ θ ∈ Icc 0 Real.pi,
+      (Real.cos θ, Real.sin θ) ∈ A ∧ (-Real.cos θ, -Real.sin θ) ∈ A) ∨
+    (∃ θ ∈ Icc 0 Real.pi,
+      (Real.cos θ, Real.sin θ) ∈ B ∧ (-Real.cos θ, -Real.sin θ) ∈ B) := by
+  -- Define f(p) = infDist(p, A), continuous on ℝ²
+  have hf_cont : Continuous (fun p : ℝ × ℝ => Metric.infDist p A) := by fun_prop
+  -- By circle BU, ∃ antipodal pair with f equal
+  obtain ⟨θ, hθ, hθ_eq⟩ := borsuk_ulam_circle_param _ hf_cont
+  -- Helper: infDist = 0 ↔ in A (for closed, nonempty A)
+  have mem_of_zero : ∀ p : ℝ × ℝ, Metric.infDist p A = 0 → p ∈ A := by
+    intro p hp
+    have := (Metric.mem_closure_iff_infDist_zero hAne).mpr hp
+    rwa [hA.closure_eq] at this
+  -- Extract the equality as infDist equality
+  have hθ_infDist : Metric.infDist (Real.cos θ, Real.sin θ) A =
+      Metric.infDist (-Real.cos θ, -Real.sin θ) A := hθ_eq
+  by_cases h0 : Metric.infDist (Real.cos θ, Real.sin θ) A = 0
+  · -- f = 0 at (cos θ, sin θ): both in A
+    left; refine ⟨θ, hθ, mem_of_zero _ h0, mem_of_zero _ ?_⟩
+    linarith [hθ_infDist]
+  · -- f > 0 at both: both outside A, hence in B by covering
+    right; refine ⟨θ, hθ, ?_, ?_⟩
+    · have hnotA : (Real.cos θ, Real.sin θ) ∉ A := by
+        intro ha; exact h0 (Metric.infDist_zero_of_mem ha)
+      exact (hcover θ).resolve_left hnotA
+    · have hnotA' : (-Real.cos θ, -Real.sin θ) ∉ A := by
+        intro ha
+        exact h0 (by linarith [Metric.infDist_zero_of_mem ha, hθ_infDist])
+      -- (-cos θ, -sin θ) = (cos(θ+π), sin(θ+π)), use hcover (θ + π)
+      have hantipodal : (Real.cos (θ + Real.pi), Real.sin (θ + Real.pi)) =
+          (-Real.cos θ, -Real.sin θ) :=
+        Prod.ext (Real.cos_add_pi θ) (Real.sin_add_pi θ)
+      have hcov := (hcover (θ + Real.pi)).resolve_left (by rwa [hantipodal])
+      rwa [hantipodal] at hcov
+
+/-- **LS for S¹ when A could be empty**: If A is empty, B covers everything
+    and trivially contains an antipodal pair. -/
+theorem lusternik_schnirelman_S1' (A B : Set (ℝ × ℝ))
+    (hA : IsClosed A) (hB : IsClosed B)
+    (hcover : ∀ θ : ℝ, (Real.cos θ, Real.sin θ) ∈ A ∨ (Real.cos θ, Real.sin θ) ∈ B) :
+    (∃ θ ∈ Icc 0 Real.pi,
+      (Real.cos θ, Real.sin θ) ∈ A ∧ (-Real.cos θ, -Real.sin θ) ∈ A) ∨
+    (∃ θ ∈ Icc 0 Real.pi,
+      (Real.cos θ, Real.sin θ) ∈ B ∧ (-Real.cos θ, -Real.sin θ) ∈ B) := by
+  by_cases hAne : A.Nonempty
+  · exact lusternik_schnirelman_S1 A B hA hB hAne hcover
+  · -- A empty, B covers everything
+    rw [Set.not_nonempty_iff_eq_empty] at hAne
+    right; refine ⟨0, by constructor <;> linarith [Real.pi_pos], ?_, ?_⟩
+    · exact (hcover 0).resolve_left (by simp [hAne])
+    · have := (hcover Real.pi).resolve_left (by simp [hAne])
+      rwa [show (-Real.cos 0, -Real.sin 0) = (Real.cos Real.pi, Real.sin Real.pi) from by
+        simp [Real.cos_zero, Real.cos_pi, Real.sin_zero, Real.sin_pi]]
+
+/-
+## Section XXIX: Updated Summary
+-/
+
+/-- Updated constructive status:
+
+    **NEW in this session (Section XXVII)**:
+    - Tucker's Parity Lemma: transition count mod 2 = endpoint XOR
+    - Corollaries: odd count when endpoints differ, even when they agree
+    - Monotonicity and upper bound for transition counts
+    - Tucker's 1D lemma re-derived from parity (stronger result)
+
+    **NEW in this session (Section XXVIII)**:
+    - Non-trivial Lusternik-Schnirelman for S¹ via infDist + circle BU
+    - Unlike interval LS (trivial x=0 witness), circle LS uses BU genuinely
+    - Both A-nonempty and A-possibly-empty variants proved
+
+    The file now contains a complete constructive toolkit for 1D
+    Borsuk-Ulam and its combinatorial/topological consequences. -/
+theorem bu_updated_summary : True := trivial
+
 end BorsukUlamOQ03

--- a/proofs/Proofs/HodgeConjecture.lean
+++ b/proofs/Proofs/HodgeConjecture.lean
@@ -60,6 +60,8 @@ This file does NOT prove the Hodge Conjecture. It provides:
 | Extreme codimension (0, top) | PROVEN from case axioms |
 | Hodge-Tate equivalence (abelian) | PROVEN from axioms |
 | Conjecture hierarchy SC ⟹ GHC ⟹ HC ⟹ MT | PROVEN from axioms |
+| Direct sum of Hodge structures | PROVEN (was axiom) |
+| Injection morphisms ι₁, ι₂ into direct sum | PROVEN (was axiom) |
 | General case for higher codimension | **CONJECTURE** |
 | Integral Hodge conjecture | FALSE (Atiyah-Hirzebruch) |
 
@@ -92,6 +94,7 @@ We provide abstract structures that capture the essential mathematics.
 - IsScalarTower ℚ ℂ V_ℂ ensures rational scalars act via ℚ ↪ ℂ
 - Hodge symmetry is proved from the conjugation axiom
 - ℚ-scalar closure of Hodge components proved (was axiom, now theorem)
+- Direct sum construction proved (3 axioms → defs): directSumHodge, directSum_inl, directSum_inr
 - See each axiom's docstring for mathematical justification
 
 ## References
@@ -1322,28 +1325,85 @@ This operation, together with kernels and cokernels, makes the category of
 pure Hodge structures of weight k into an abelian category.
 -/
 
-/-- **Axiom: Direct sum of Hodge structures**
+/-- **Direct sum of Hodge structures** (PROVED - was axiom)
 
 The direct sum of two pure Hodge structures of the same weight k is a pure
-Hodge structure. The rational space is V₁_ℚ ⊕ V₂_ℚ, the complexification
-is V₁_ℂ ⊕ V₂_ℂ, and the Hodge components decompose as direct sums.
+Hodge structure. The rational space is V₁_ℚ × V₂_ℚ, the complexification
+is V₁_ℂ × V₂_ℂ, and the Hodge components decompose as products.
 
-**Why an axiom?** While the construction is straightforward in principle,
-Lean's type class system makes constructing the direct sum with all required
-instances (FiniteDimensional, IsScalarTower, etc.) highly technical. The
-mathematical content is standard. -/
-axiom directSumHodge {k : ℕ} (H₁ H₂ : PureHodgeStructure k) :
-    PureHodgeStructure k
+**Construction**: Uses Lean's product types with componentwise operations.
+The complexification map is the product of the individual complexification maps.
+Hodge components are Submodule.prod of the individual components. -/
+def directSumHodge {k : ℕ} (H₁ H₂ : PureHodgeStructure k) :
+    PureHodgeStructure k where
+  VQ := H₁.VQ × H₂.VQ
+  VC := H₁.VC × H₂.VC
+  complexify := H₁.complexify.prodMap H₂.complexify
+  complexify_injective := by
+    intro ⟨a₁, a₂⟩ ⟨b₁, b₂⟩ h
+    simp only [LinearMap.prodMap_apply, Prod.mk.injEq] at h
+    exact Prod.ext (H₁.complexify_injective h.1) (H₂.complexify_injective h.2)
+  hodgeComponent := fun p q hpq =>
+    (H₁.hodgeComponent p q hpq).prod (H₂.hodgeComponent p q hpq)
 
-/-- **Axiom: Injection into direct sum**
+/-- **Injection into direct sum** (PROVED - was axiom)
 
-The canonical injections ι₁ : H₁ → H₁ ⊕ H₂ and ι₂ : H₂ → H₁ ⊕ H₂
-are morphisms of Hodge structures. -/
-axiom directSum_inl {k : ℕ} (H₁ H₂ : PureHodgeStructure k) :
-    HodgeStructureMorphism H₁ (directSumHodge H₁ H₂)
+The canonical injection ι₁ : H₁ → H₁ ⊕ H₂ is a morphism of Hodge structures.
 
-axiom directSum_inr {k : ℕ} (H₁ H₂ : PureHodgeStructure k) :
-    HodgeStructureMorphism H₂ (directSumHodge H₁ H₂)
+**Proof**: The rational and complex maps are the canonical left injections.
+Compatibility follows from the product structure of the complexification map.
+Hodge preservation follows because (x, 0) ∈ S₁ × S₂ when x ∈ S₁ and 0 ∈ S₂. -/
+def directSum_inl {k : ℕ} (H₁ H₂ : PureHodgeStructure k) :
+    HodgeStructureMorphism H₁ (directSumHodge H₁ H₂) where
+  rationalMap := LinearMap.inl ℚ H₁.VQ H₂.VQ
+  complexMap := LinearMap.inl ℂ H₁.VC H₂.VC
+  compatible := fun v => by
+    simp only [directSumHodge, LinearMap.prodMap_apply, LinearMap.inl_apply, map_zero]
+  hodge_preserve := fun p q hpq x hx => by
+    simp only [directSumHodge, LinearMap.inl_apply]
+    exact Submodule.mem_prod.mpr ⟨hx, Submodule.zero_mem _⟩
+
+/-- **Injection into direct sum (right)** (PROVED - was axiom)
+
+The canonical injection ι₂ : H₂ → H₁ ⊕ H₂ is a morphism of Hodge structures. -/
+def directSum_inr {k : ℕ} (H₁ H₂ : PureHodgeStructure k) :
+    HodgeStructureMorphism H₂ (directSumHodge H₁ H₂) where
+  rationalMap := LinearMap.inr ℚ H₁.VQ H₂.VQ
+  complexMap := LinearMap.inr ℂ H₁.VC H₂.VC
+  compatible := fun v => by
+    simp only [directSumHodge, LinearMap.prodMap_apply, LinearMap.inr_apply, map_zero]
+  hodge_preserve := fun p q hpq x hx => by
+    simp only [directSumHodge, LinearMap.inr_apply]
+    exact Submodule.mem_prod.mpr ⟨Submodule.zero_mem _, hx⟩
+
+/-- **Projection from direct sum (left)** (PROVED)
+
+The canonical projection π₁ : H₁ ⊕ H₂ → H₁ is a morphism of Hodge structures.
+
+**Proof**: The rational and complex maps are the canonical left projections.
+Hodge preservation follows because if (x, y) ∈ S₁ × S₂ then x ∈ S₁. -/
+def directSum_fst {k : ℕ} (H₁ H₂ : PureHodgeStructure k) :
+    HodgeStructureMorphism (directSumHodge H₁ H₂) H₁ where
+  rationalMap := LinearMap.fst ℚ H₁.VQ H₂.VQ
+  complexMap := LinearMap.fst ℂ H₁.VC H₂.VC
+  compatible := fun v => by
+    simp only [directSumHodge, LinearMap.prodMap_apply, LinearMap.fst_apply]
+  hodge_preserve := fun p q hpq x hx => by
+    simp only [directSumHodge, LinearMap.fst_apply] at hx ⊢
+    exact (Submodule.mem_prod.mp hx).1
+
+/-- **Projection from direct sum (right)** (PROVED)
+
+The canonical projection π₂ : H₁ ⊕ H₂ → H₂ is a morphism of Hodge structures. -/
+def directSum_snd {k : ℕ} (H₁ H₂ : PureHodgeStructure k) :
+    HodgeStructureMorphism (directSumHodge H₁ H₂) H₂ where
+  rationalMap := LinearMap.snd ℚ H₁.VQ H₂.VQ
+  complexMap := LinearMap.snd ℂ H₁.VC H₂.VC
+  compatible := fun v => by
+    simp only [directSumHodge, LinearMap.prodMap_apply, LinearMap.snd_apply]
+  hodge_preserve := fun p q hpq x hx => by
+    simp only [directSumHodge, LinearMap.snd_apply] at hx ⊢
+    exact (Submodule.mem_prod.mp hx).2
 
 /-- **HC for direct sums: if HC holds for both summands, it holds for the sum**
 
@@ -1571,7 +1631,9 @@ PART XVII: SUMMARY OF NEW RESULTS
    preserve algebraicity
 6. **Sub-Hodge structures** - Defined with Hodge compatibility
 7. **Kernel is sub-Hodge** - Proved: kernel of a morphism is a sub-Hodge structure
-8. **Direct sums** - Axiomatized: direct sum of Hodge structures
+8. **Direct sums** - PROVED: direct sum of Hodge structures (was axiom)
+8a. **Injection morphisms** - PROVED: canonical injections ι₁, ι₂ (were axioms)
+8b. **Projection morphisms** - PROVED: canonical projections π₁, π₂ (new)
 9. **Polarizations** - Defined with (−1)^k-symmetry
 10. **Even weight symmetry** - Proved: polarization is symmetric for even weight
 11. **Odd weight antisymmetry** - Proved: polarization is antisymmetric for odd weight
@@ -1586,6 +1648,12 @@ theorem structural_summary : True := trivial
 #check HodgeStructureMorphism.comp
 #check morphism_preserves_hodge_class
 #check morphism_preserves_algebraic_class
+-- Direct sums (PROVED - were axioms)
+#check directSumHodge
+#check directSum_inl
+#check directSum_inr
+#check directSum_fst
+#check directSum_snd
 -- Sub-Hodge structures
 #check SubHodgeStructure
 #check kernel_is_subHodge

--- a/proofs/Proofs/HodgeConjecture.lean
+++ b/proofs/Proofs/HodgeConjecture.lean
@@ -1405,6 +1405,44 @@ def directSum_snd {k : ℕ} (H₁ H₂ : PureHodgeStructure k) :
     simp only [directSumHodge, LinearMap.snd_apply] at hx ⊢
     exact (Submodule.mem_prod.mp hx).2
 
+/-- **Retraction: π₁ ∘ ι₁ = id** (PROVED)
+
+The composition of the left injection with the left projection is the identity
+morphism on H₁. This shows the direct sum is a genuine biproduct. -/
+theorem directSum_fst_inl {k : ℕ} (H₁ H₂ : PureHodgeStructure k)
+    (v : H₁.VQ) :
+    (directSum_fst H₁ H₂).rationalMap ((directSum_inl H₁ H₂).rationalMap v) = v := by
+  show LinearMap.fst ℚ H₁.VQ H₂.VQ (LinearMap.inl ℚ H₁.VQ H₂.VQ v) = v
+  simp only [LinearMap.inl_apply, LinearMap.fst_apply]
+
+/-- **Retraction: π₂ ∘ ι₂ = id** (PROVED)
+
+The composition of the right injection with the right projection is the identity
+morphism on H₂. -/
+theorem directSum_snd_inr {k : ℕ} (H₁ H₂ : PureHodgeStructure k)
+    (v : H₂.VQ) :
+    (directSum_snd H₁ H₂).rationalMap ((directSum_inr H₁ H₂).rationalMap v) = v := by
+  show LinearMap.snd ℚ H₁.VQ H₂.VQ (LinearMap.inr ℚ H₁.VQ H₂.VQ v) = v
+  simp only [LinearMap.inr_apply, LinearMap.snd_apply]
+
+/-- **Cross retraction: π₁ ∘ ι₂ = 0** (PROVED)
+
+The composition of the right injection with the left projection is the zero map. -/
+theorem directSum_fst_inr {k : ℕ} (H₁ H₂ : PureHodgeStructure k)
+    (v : H₂.VQ) :
+    (directSum_fst H₁ H₂).rationalMap ((directSum_inr H₁ H₂).rationalMap v) = 0 := by
+  show LinearMap.fst ℚ H₁.VQ H₂.VQ (LinearMap.inr ℚ H₁.VQ H₂.VQ v) = 0
+  simp only [LinearMap.inr_apply, LinearMap.fst_apply]
+
+/-- **Cross retraction: π₂ ∘ ι₁ = 0** (PROVED)
+
+The composition of the left injection with the right projection is the zero map. -/
+theorem directSum_snd_inl {k : ℕ} (H₁ H₂ : PureHodgeStructure k)
+    (v : H₁.VQ) :
+    (directSum_snd H₁ H₂).rationalMap ((directSum_inl H₁ H₂).rationalMap v) = 0 := by
+  show LinearMap.snd ℚ H₁.VQ H₂.VQ (LinearMap.inl ℚ H₁.VQ H₂.VQ v) = 0
+  simp only [LinearMap.inl_apply, LinearMap.snd_apply]
+
 /-- **HC for direct sums: if HC holds for both summands, it holds for the sum**
 
 This is an important structural property: the Hodge Conjecture is "additive"

--- a/src/data/proofs/hodge-conjecture/meta.json
+++ b/src/data/proofs/hodge-conjecture/meta.json
@@ -29,7 +29,9 @@
       "Sub-Hodge structures and kernel theorem (proved)",
       "Polarizations with even/odd symmetry theorems (proved)",
       "Lefschetz operator and Hard Lefschetz axiom",
-      "Mixed Hodge structures and pure-to-mixed embedding (proved)"
+      "Mixed Hodge structures and pure-to-mixed embedding (proved)",
+      "Direct sum construction proved (was 3 axioms): directSumHodge, inl, inr",
+      "Projection morphisms proved: directSum_fst, directSum_snd"
     ],
     "dateAdded": "12/29/25",
     "millenniumProblem": "hodge"

--- a/src/data/research/problems/borsuk-ulam-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03.json
@@ -29,12 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: 17+ proved theorems, 0 sorries. BU n=1 proved in general form (borsuk_ulam_n1), reducing axiom to n>=2.",
+    "progressSummary": "COMPLETED: 25+ proved theorems, 0 sorries. Tucker parity lemma + non-trivial LS for S1 added.",
     "builtItems": [
       "proofs/Proofs/BorsukUlamOQ03.lean (914 lines, 41 defs/theorems, 7 axioms, 0 sorries)",
       "src/data/proofs/borsuk-ulam-oq-03/ (gallery integration with meta.json, annotations.json, index.ts)",
       "circleParam: circle parametrization as Fin 2 → ℝ",
-      "borsuk_ulam_n1: BU for n=1 in general type"
+      "borsuk_ulam_n1: BU for n=1 in general type",
+      "Tucker parity lemma (countTransitions, tucker_parity, tucker_count_odd/even)",
+      "countTransitions_mono, countTransitions_le, tucker_count_bounds",
+      "lusternik_schnirelman_S1: Non-trivial LS for circle via infDist + circle BU",
+      "lusternik_schnirelman_S1: A-possibly-empty variant"
     ],
     "insights": [
       "1D BU proved via IVT on antisymmetric difference g(x) = f(x) - f(-x)",
@@ -44,7 +48,11 @@
       "The interval BU has trivial witness x=0 (self-antipodal); circle BU is genuinely non-trivial",
       "7 axioms needed for higher-D: general BU, no-retraction, Brouwer FP, LS covering, invariance of dimension",
       "All axioms are blocked by lack of algebraic topology in Mathlib (homology, degree theory)",
-      "borsuk_ulam_n1 proves n=1 case of general BU via circle parametrization + IVT"
+      "borsuk_ulam_n1 proves n=1 case of general BU via circle parametrization + IVT",
+      "Tucker parity lemma: count of sign-change edges has same parity as endpoint XOR (mod 2 = boundary data)",
+      "Non-trivial LS for S1 proved from circle BU via infDist(p, A): equal distance => same membership",
+      "fun_prop handles Metric.infDist continuity; Prod.ext proves product equalities from component equalities",
+      "countTransitions is monotone and bounded by n; when endpoints differ, 1 <= count <= n with count odd"
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/hodge-conjecture.json
+++ b/src/data/research/problems/hodge-conjecture.json
@@ -29,13 +29,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BLOCKED: No Lean file. Requires Hodge theory, algebraic cycles, Kähler manifolds, Dolbeault cohomology - none in Mathlib. Even stating the conjecture precisely needs thousands of lines of infrastructure.",
-    "builtItems": [],
+    "progressSummary": "PROGRESS: 3 axioms eliminated (directSumHodge, directSum_inl, directSum_inr → proved defs). Added projection morphisms. 26 axioms remain. Still blocked on Hodge theory infrastructure for further reduction.",
+    "builtItems": [
+      "Proved directSumHodge (PureHodgeStructure construction) in HodgeConjecture.lean",
+      "Proved directSum_inl, directSum_inr (injection morphisms) in HodgeConjecture.lean",
+      "Added directSum_fst, directSum_snd (projection morphisms) in HodgeConjecture.lean"
+    ],
     "insights": [
       "Millennium Prize problem, wide open - no known attack strategy",
       "Integral Hodge conjecture is FALSE (Atiyah-Hirzebruch 1962) - only rational version is conjectured",
       "Codimension 1 case (Lefschetz 1,1 theorem) is proven - most tractable partial result",
-      "Mathlib has basic scheme theory but lacks Hodge theory, algebraic cycles, Kähler manifolds entirely"
+      "Mathlib has basic scheme theory but lacks Hodge theory, algebraic cycles, Kähler manifolds entirely",
+      "Direct sum of Hodge structures proved constructively (was axiom): VQ=V1×V2, VC=V1×V2, complexify=prodMap, hodgeComponent=Submodule.prod",
+      "Injection morphisms ι₁,ι₂ and projection morphisms π₁,π₂ proved for direct sums (5 new defs total, 3 axioms eliminated)",
+      "Axiom count reduced from 29 to 26 - remaining axioms are genuinely deep mathematical results"
     ],
     "mathlibGaps": [
       "Hodge theory / Hodge decomposition",

--- a/src/data/research/problems/hodge-conjecture.json
+++ b/src/data/research/problems/hodge-conjecture.json
@@ -33,7 +33,8 @@
     "builtItems": [
       "Proved directSumHodge (PureHodgeStructure construction) in HodgeConjecture.lean",
       "Proved directSum_inl, directSum_inr (injection morphisms) in HodgeConjecture.lean",
-      "Added directSum_fst, directSum_snd (projection morphisms) in HodgeConjecture.lean"
+      "Added directSum_fst, directSum_snd (projection morphisms) in HodgeConjecture.lean",
+      "Proved 4 retraction theorems (directSum_fst_inl, snd_inr, fst_inr, snd_inl)"
     ],
     "insights": [
       "Millennium Prize problem, wide open - no known attack strategy",
@@ -42,7 +43,8 @@
       "Mathlib has basic scheme theory but lacks Hodge theory, algebraic cycles, Kähler manifolds entirely",
       "Direct sum of Hodge structures proved constructively (was axiom): VQ=V1×V2, VC=V1×V2, complexify=prodMap, hodgeComponent=Submodule.prod",
       "Injection morphisms ι₁,ι₂ and projection morphisms π₁,π₂ proved for direct sums (5 new defs total, 3 axioms eliminated)",
-      "Axiom count reduced from 29 to 26 - remaining axioms are genuinely deep mathematical results"
+      "Axiom count reduced from 29 to 26 - remaining axioms are genuinely deep mathematical results",
+      "Biproduct structure proved: π₁∘ι₁=id, π₂∘ι₂=id, π₁∘ι₂=0, π₂∘ι₁=0"
     ],
     "mathlibGaps": [
       "Hodge theory / Hodge decomposition",


### PR DESCRIPTION
## Summary
- Convert 3 axioms to proved definitions in HodgeConjecture.lean: `directSumHodge`, `directSum_inl`, `directSum_inr`
- Add 2 new projection morphisms: `directSum_fst`, `directSum_snd`
- Axiom count reduced from 29 to 26

## Progress
- **directSumHodge**: Constructed using `Prod` types with `LinearMap.prodMap` for complexification and `Submodule.prod` for Hodge components
- **directSum_inl/inr**: Proved using `LinearMap.inl`/`LinearMap.inr` with compatibility from `map_zero` and Hodge preservation from `Submodule.mem_prod`
- **directSum_fst/snd**: New projection morphisms using `LinearMap.fst`/`LinearMap.snd` (completes the direct sum categorical structure)

## Findings
- The direct sum construction was marked as axiom due to "type class complexity" but the construction is clean with Lean's `Prod` instances
- `IsScalarTower ℚ ℂ (V₁ × V₂)` works automatically from the product instances
- Remaining 26 axioms are genuinely deep mathematical results (Hodge theory, algebraic cycles, Lefschetz, Deligne, etc.)

## Status
**Outcome**: progress
**Next Steps**: Remaining axioms require Hodge theory / algebraic cycle infrastructure not in Mathlib

🤖 Generated by researcher-1