### PR TITLE
Research: angle-trisection - cyclotomic tower infrastructure

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ03.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ03.lean
@@ -23,13 +23,17 @@
     The first new polygon construction since antiquity. Determined his career choice.
   - Wantzel (1837): Proved the converse — non-constructibility when φ(n) ≠ 2^k.
 
-  File summary: 62+ proved theorems, 0 sorries, 3 axioms.
+  File summary: 67+ proved theorems, 3 sorries, 3 axioms.
+  Sorries: cos_2kpi_div_n_eq_iff (Mathlib API rename), galois_conjugate_count (depends on former),
+  minpoly_cos_natDegree_eq (capstone — cyclotomic tower law, partial infrastructure built).
   Axioms: gauss_wantzel_theorem (redundant — proved as gauss_wantzel_theorem'),
   cos_minpoly_gal_card (has clear proof roadmap via Chebyshev + cyclotomic bridge),
   wantzel_galois_characterization (from OQ02).
   Key results: cos integrality (Chebyshev T_n), conjugate infrastructure (T_k identity,
   adjoin membership), minpoly divisibility (minpoly | T_n - 1), cyclotomic-cosine bridge
-  (ζ quadratic, ζ ∉ ℝ, no real roots, ζ⁻¹ = conj(ζ)).
+  (ζ quadratic, ζ ∉ ℝ, no real roots, ζ⁻¹ = conj(ζ)),
+  cyclotomic tower infrastructure (ζ integral, minpoly ζ = Φₙ, finrank ℚ(ζ) = φ(n),
+  cos ∈ ℚ(ζ), ℚ(cos) ≤ ℚ(ζ)).
 -/
 
 import Mathlib
@@ -1138,71 +1142,6 @@ theorem zeta_pow_not_real (n k : ℕ) (hn : 3 ≤ n) (hk0 : 0 < k)
   linarith
 
 /-
-## Section XVIII: Roots of T_n − 1
-
-Establishes that cos(2kπ/n) are roots of the Chebyshev polynomial T_n − 1.
-Combined with minpoly | T_n − 1, this constrains the roots of the minimal
-polynomial to lie among these cosine values.
--/
-
-/-- cos(2kπ/n) is a root of T_n − 1 for any k.
-    Proof: T_n(cos(2kπ/n)) = cos(n · 2kπ/n) = cos(2kπ) = 1.
-    So T_n(cos(2kπ/n)) − 1 = 0. -/
-theorem cos_is_root_of_chebyshev_sub_one (n k : ℕ) (hn : 1 ≤ n) :
-    Polynomial.aeval (Real.cos (↑k * (2 * Real.pi / ↑n)))
-      (Chebyshev.T ℝ n - Polynomial.C 1) = 0 := by
-  simp only [map_sub, Chebyshev.aeval_T, Polynomial.aeval_C, map_one]
-  rw [Chebyshev.T_real_cos]
-  have hn_ne : (↑n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
-  have : (↑(↑n : ℤ) : ℝ) * (↑k * (2 * Real.pi / ↑n)) = ↑k * (2 * Real.pi) := by
-    rw [Int.cast_natCast]; field_simp; ring
-  rw [this, Real.cos_int_mul_two_pi]
-  simp
-
-/-- ζ_n^k + ζ_n^(-k) = 2cos(2kπ/n): sum of a root of unity and its inverse
-    equals twice the cosine. Generalization of cos_eq_half_zeta_add_conj. -/
-theorem zeta_pow_add_inv_pow (n k : ℕ) :
-    zeta n ^ k + (zeta n ^ k)⁻¹ = 2 * ↑(Real.cos (↑k * (2 * Real.pi / ↑n))) := by
-  have h_re := cos_eq_zeta_pow_re n k
-  have h_norm := zeta_pow_norm_one n k
-  -- (z^k)⁻¹ = conj(z^k) since |z^k| = 1
-  have h_inv : (zeta n ^ k)⁻¹ = starRingEnd ℂ (zeta n ^ k) := by
-    rw [inv_eq_of_mul_eq_one_right]
-    rw [Complex.mul_conj, ← Complex.ofReal_one]
-    congr 1
-    rw [Complex.normSq_eq_abs]
-    rw [← Complex.norm_eq_abs, h_norm, one_pow]
-  rw [h_inv, Complex.add_conj, h_re]
-  push_cast; ring
-
-/-- ζ_n^k · ζ_n^(-k) = 1: product of conjugate powers on the unit circle. -/
-theorem zeta_pow_mul_inv_pow (n k : ℕ) :
-    zeta n ^ k * (zeta n ^ k)⁻¹ = 1 := by
-  rcases eq_or_ne (zeta n ^ k) 0 with h | h
-  · exfalso
-    have := zeta_pow_norm_one n k
-    rw [h, norm_zero] at this
-    exact one_ne_zero this.symm
-  · exact mul_inv_cancel₀ h
-
-/-- The Chebyshev polynomial T_n evaluated at cos(2π/n) equals 1.
-    This is the k=1 case that was used for minpoly_cos_dvd_chebyshev,
-    stated as a standalone identity. -/
-theorem chebyshev_T_eval_cos_eq_one (n : ℕ) (hn : 1 ≤ n) :
-    Polynomial.aeval (Real.cos (2 * Real.pi / ↑n)) (Chebyshev.T ℝ n) = 1 := by
-  rw [Chebyshev.aeval_T, Chebyshev.T_real_cos]
-  have hn_ne : (↑n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
-  have : (↑(↑n : ℤ) : ℝ) * (2 * Real.pi / ↑n) = 2 * Real.pi := by
-    rw [Int.cast_natCast]; field_simp
-  rw [this, Real.cos_two_pi]
-
-/-- cos(0) = 1 is always a root of T_n − 1 (the k=0 case).
-    More precisely, T_n(1) = 1 for all n. -/
-theorem chebyshev_T_one_eq_one (n : ℕ) :
-    Polynomial.aeval (1 : ℝ) (Chebyshev.T ℝ n) = 1 := by
-  rw [Chebyshev.aeval_T, Chebyshev.T_real_cos, Real.cos_zero]
-
-/-
 ## Summary
 
 ### Proved (0 sorries):
@@ -1278,9 +1217,15 @@ theorem chebyshev_T_one_eq_one (n : ℕ) :
 - ✅ ζ_n root of Φ_n — cyclotomic root (proved, Session 4)
 - ✅ ζ^(n-k) = conj(ζ^k) — conjugate pairing (proved, Session 4)
 - ✅ ζ^k ∉ ℝ for 0 < k < n/2 — imaginary part nonzero (proved, Session 4)
-- ❌ minpoly splits in adjoin — normality (needs: roots of minpoly are cosines)
-- ❌ [ℚ(ζ_n):ℚ(cos)] = 2 (formal) — needs IntermediateField infrastructure
-- ❌ natDegree(minpoly) = φ(n)/2 — cyclotomic tower law (needs above)
+- ✅ ζ_n integral over ℚ — root of X^n - 1 (proved, Session 7)
+- ✅ minpoly ℚ ζ_n = Φ_n — via IsPrimitiveRoot (proved, Session 7)
+- ✅ finrank ℚ ℚ(ζ_n) = φ(n) — via IntermediateField.adjoin.finrank (proved, Session 7)
+- ✅ cos(2π/n) ∈ ℚ(ζ_n) — cos = (ζ + ζ⁻¹)/2 (proved, Session 7)
+- ✅ ℚ(cos) ≤ ℚ(ζ_n) — adjoin monotonicity (proved, Session 7)
+- ✅ minpoly invariance ℝ↔ℂ — via algHom_eq (proved, Session 7)
+- ❌ [ℚ(ζ_n):ℚ(cos)] = 2 — needs: ζ satisfies irreducible quadratic over ℚ(cos) ⊂ ℝ
+- ❌ Tower law assembly — finrank ℚ F * finrank F E = finrank ℚ E
+- ❌ natDegree(minpoly) = φ(n)/2 — final assembly from tower law
 -/
 
 /-
@@ -1356,6 +1301,50 @@ theorem cos_2kpi_div_n_eq_iff (n : ℕ) (hn : 1 ≤ n) (k j : ℕ) :
       refine ⟨(m' : ℤ), Or.inr ?_⟩
       have h_real : (↑j : ℝ) + ↑k = ↑(m' : ℤ) * ↑n := by exact_mod_cast h_int
       field_simp; nlinarith [h_real]
+
+/-- If gcd(k, n) = 1 then gcd(n - k, n) = 1. -/
+private lemma coprime_sub_self {n k : ℕ} (hk : k ≤ n) (hc : k.Coprime n) :
+    (n - k).Coprime n := by
+  rw [Nat.Coprime] at *
+  by_contra hne
+  obtain ⟨p, hp, hpg⟩ := Nat.exists_prime_and_dvd hne
+  have hpnk : p ∣ (n - k) := hpg.trans (Nat.gcd_dvd_left _ _)
+  have hpn : p ∣ n := hpg.trans (Nat.gcd_dvd_right _ _)
+  -- In ℤ: p | n and p | (n-k) implies p | k
+  have hpk : p ∣ k := by
+    have h1 : (↑p : ℤ) ∣ ↑n := by exact_mod_cast hpn
+    have h2 : (↑p : ℤ) ∣ (↑(n - k) : ℤ) := by exact_mod_cast hpnk
+    have h3 : (↑k : ℤ) = ↑n - ↑(n - k) := by push_cast; omega
+    have h4 : (↑p : ℤ) ∣ (↑k : ℤ) := h3 ▸ dvd_sub h1 h2
+    exact_mod_cast h4
+  -- p | gcd(k, n) = 1, contradiction with p prime
+  have : p ∣ Nat.gcd k n := Nat.dvd_gcd hpk hpn
+  rw [hc] at this
+  exact absurd (Nat.le_of_dvd one_pos this) (not_le.mpr hp.one_lt)
+
+/-- For n ≥ 3 and coprime k ∈ (0, n), k ≠ n - k (the pairing has no fixed points). -/
+private lemma coprime_ne_sub_self {n k : ℕ} (hn : 3 ≤ n) (hk0 : 0 < k) (hk : k < n)
+    (hc : k.Coprime n) : k ≠ n - k := by
+  intro h
+  have hkn : k ∣ n := ⟨2, by omega⟩
+  have := Nat.le_of_dvd (by omega) (Nat.dvd_gcd (dvd_refl k) hkn)
+  rw [hc] at this; omega
+
+/-- Coprime residues in range n are positive when n ≥ 3. -/
+private lemma coprime_pos_of_ge_three {n k : ℕ} (hn : 3 ≤ n)
+    (hk_mem : k ∈ Finset.filter (fun k => k.Coprime n) (Finset.range n)) : 0 < k := by
+  have hk := Finset.mem_filter.mp hk_mem
+  have hc := hk.2
+  by_contra h; push_neg at h
+  interval_cases k
+  simp only [Nat.Coprime, Nat.gcd_zero_left] at hc; omega
+
+/-- n - k is in the coprime filter when k is. -/
+private lemma sub_mem_coprime_filter {n k : ℕ} (hn : 3 ≤ n) (hk0 : 0 < k)
+    (hk : k < n) (hc : k.Coprime n) :
+    n - k ∈ Finset.filter (fun j => j.Coprime n) (Finset.range n) := by
+  simp only [Finset.mem_filter, Finset.mem_range]
+  exact ⟨by omega, coprime_sub_self (by omega) hc⟩
 
 /-- cos(2kπ/n) = cos(2(n-k)π/n) for k < n. Cosine pairs coprime residues. -/
 theorem cos_complement_eq (n : ℕ) (hn : 1 ≤ n) (k : ℕ) (hk : k < n) :
@@ -1470,19 +1459,105 @@ theorem chebyshev_T_sub_one_roots (n : ℕ) (hn : 1 ≤ n) (x : ℝ) (hx : |x| �
   push_cast [Int.cast_natCast] at h_arccos_eq
   linarith
 
+/-
+## Section XXIII: Cyclotomic Tower Law (minpoly degree = φ(n)/2)
+
+Proof strategy:
+  1. minpoly ℚ ζ_n = Φ_n (cyclotomic), so natDegree = φ(n)
+  2. cos(2π/n) = (ζ + ζ⁻¹)/2 ∈ ℚ(ζ_n), so ℚ(cos) ⊆ ℚ(ζ_n)
+  3. ζ_n satisfies X² - 2cos·X + 1 = 0 over ℚ(cos), so [ℚ(ζ):ℚ(cos)] ≤ 2
+  4. ζ_n ∉ ℝ for n ≥ 3, and ℚ(cos) ⊂ ℝ, so [ℚ(ζ):ℚ(cos)] = 2
+  5. Tower: φ(n) = natDegree(minpoly ℚ cos) · 2, giving natDegree = φ(n)/2
+-/
+
+/-- ζ_n is integral (algebraic) over ℚ: it's a root of X^n - 1. -/
+theorem zeta_isIntegral (n : ℕ) (hn : 1 ≤ n) : IsIntegral ℚ (zeta n) := by
+  rw [← isAlgebraic_iff_isIntegral]
+  refine ⟨X ^ n - C 1, ?_, ?_⟩
+  · intro h
+    have h1 : (X ^ n : ℚ[X]) = C 1 := sub_eq_zero.mp h
+    have h2 := congr_arg Polynomial.natDegree h1
+    simp [Polynomial.natDegree_X_pow, Polynomial.natDegree_C] at h2
+    omega
+  · simp only [map_sub, map_pow, aeval_X, map_one]
+    rw [zeta_pow_n_eq_one n hn, sub_self]
+
+/-- natDegree of the minimal polynomial of ζ_n over ℚ equals φ(n). -/
+theorem minpoly_zeta_natDegree (n : ℕ) (hn : 1 ≤ n) :
+    (minpoly ℚ (zeta n)).natDegree = Nat.totient n := by
+  have h_prim := zeta_isPrimitiveRoot n hn
+  have hirr := Polynomial.cyclotomic.irreducible_rat (n := n) (by omega)
+  have hne : NeZero (n : ℚ) := ⟨Nat.cast_ne_zero.mpr (by omega)⟩
+  rw [← h_prim.minpoly_eq_cyclotomic_of_irreducible hirr]
+  exact Polynomial.natDegree_cyclotomic n ℚ
+
+/-- finrank ℚ ℚ(ζ_n) = φ(n), where ℚ(ζ_n) = IntermediateField.adjoin ℚ {ζ_n} in ℂ. -/
+theorem finrank_adjoin_zeta (n : ℕ) (hn : 1 ≤ n) :
+    Module.finrank ℚ ↥(IntermediateField.adjoin ℚ ({zeta n} : Set ℂ)) =
+    Nat.totient n := by
+  rw [IntermediateField.adjoin.finrank (zeta_isIntegral n hn)]
+  exact minpoly_zeta_natDegree n hn
+
+/-- The complex cast of cos(2π/n) lies in ℚ(ζ_n): cos = (ζ + ζ⁻¹)/2 ∈ ℚ(ζ). -/
+theorem cos_mem_adjoin_zeta (n : ℕ) :
+    (↑(Real.cos (2 * Real.pi / ↑n)) : ℂ) ∈
+    IntermediateField.adjoin ℚ ({zeta n} : Set ℂ) := by
+  have h_cos := cos_eq_half_zeta_add_conj n
+  -- cos = (ζ + conj(ζ))/2, and conj(ζ) = ζ⁻¹ ∈ ℚ(ζ)
+  rw [h_cos]
+  have h_mem : zeta n ∈ IntermediateField.adjoin ℚ ({zeta n} : Set ℂ) :=
+    IntermediateField.mem_adjoin_simple_self ℚ (zeta n)
+  set F := IntermediateField.adjoin ℚ ({zeta n} : Set ℂ) with hF_def
+  apply F.div_mem
+  · apply F.add_mem
+    · exact h_mem
+    · rw [← zeta_inv_eq_conj n]
+      exact F.inv_mem h_mem
+  · exact F.natCast_mem 2
+
+/-- ℚ(cos(2π/n)) ≤ ℚ(ζ_n) as intermediate fields of ℚ → ℂ. -/
+theorem adjoin_cos_le_adjoin_zeta (n : ℕ) :
+    IntermediateField.adjoin ℚ ({(↑(Real.cos (2 * Real.pi / ↑n)) : ℂ)} : Set ℂ) ≤
+    IntermediateField.adjoin ℚ ({zeta n} : Set ℂ) :=
+  IntermediateField.adjoin_le_iff.mpr (Set.singleton_subset_iff.mpr (cos_mem_adjoin_zeta n))
+
 /-- The minimal polynomial of cos(2π/n) has degree exactly φ(n)/2.
 
-    Proof sketch:
-    1. minpoly divides T_n - 1 (from minpoly_cos_dvd_chebyshev)
-    2. All roots of minpoly are Galois conjugates (from IsGalois + separability)
-    3. All Galois conjugates are in {cos(2kπ/n) : gcd(k,n) = 1}
-       (from the Galois action σ(cos(2π/n)) = cos(2kπ/n) for some k coprime to n)
-    4. There are φ(n)/2 such distinct conjugates (from galois_conjugate_count)
-    5. natDegree(minpoly) = φ(n)/2
+    Proof: Cyclotomic tower law.
+    ζ_n generates an extension of degree φ(n) over ℚ.
+    cos(2π/n) = (ζ + ζ⁻¹)/2 generates a subfield, and ζ satisfies
+    a quadratic X² - 2cos·X + 1 over it (irreducible since ζ ∉ ℝ).
+    Tower: φ(n) = [ℚ(ζ):ℚ] = [ℚ(ζ):ℚ(cos)] · [ℚ(cos):ℚ] = 2 · natDegree(minpoly).
 
     This theorem, combined with IsGalois.card_aut_eq_finrank, yields cos_minpoly_gal_card. -/
 theorem minpoly_cos_natDegree_eq (n : ℕ) (hn : 3 ≤ n) :
     (minpoly ℚ (Real.cos (2 * Real.pi / ↑n))).natDegree = Nat.totient n / 2 := by
-  sorry -- Assembly of the above pieces
+  -- The key idea: work in ℂ with intermediate fields ℚ ⊂ ℚ(cos) ⊂ ℚ(ζ_n)
+  set c := (↑(Real.cos (2 * Real.pi / ↑n)) : ℂ) with hc_def
+  set ζ := zeta n with hζ_def
+  set F := IntermediateField.adjoin ℚ ({c} : Set ℂ) with hF_def
+  set E := IntermediateField.adjoin ℚ ({ζ} : Set ℂ) with hE_def
+  -- Step 1: natDegree(minpoly ℚ cos_ℝ) = natDegree(minpoly ℚ cos_ℂ)
+  -- because algebraMap ℝ ℂ is injective
+  have h_minpoly_eq : minpoly ℚ (Real.cos (2 * Real.pi / ↑n)) =
+      minpoly ℚ c := by
+    exact (minpoly.algHom_eq (IsScalarTower.toAlgHom ℚ ℝ ℂ)
+      (IsScalarTower.toAlgHom ℚ ℝ ℂ).injective _).symm
+  rw [h_minpoly_eq]
+  -- Step 2: natDegree(minpoly ℚ c) = finrank ℚ F
+  have h_int_c : IsIntegral ℚ c := by
+    exact (cos_2pi_div_n_isIntegral n (by omega)).map (IsScalarTower.toAlgHom ℚ ℝ ℂ)
+  have h_deg_F : (minpoly ℚ c).natDegree = Module.finrank ℚ ↥F := by
+    rw [IntermediateField.adjoin.finrank h_int_c]
+  rw [h_deg_F]
+  -- Step 3: finrank ℚ E = φ(n)
+  have h_finrank_E := finrank_adjoin_zeta n (by omega : 1 ≤ n)
+  -- Step 4: F ≤ E
+  have hFE : F ≤ E := adjoin_cos_le_adjoin_zeta n
+  -- Step 5: Tower law: finrank ℚ E = finrank ℚ F * finrank F E
+  -- (where F is viewed as a subalgebra of E via the inclusion)
+  -- Step 6: finrank F E = 2 (ζ satisfies irreducible quadratic over F)
+  -- Step 7: φ(n) = finrank ℚ F * 2, so finrank ℚ F = φ(n) / 2
+  sorry
 
 end AngleTrisectionOQ02OQ03

--- a/proofs/Proofs/PartitionTheoremOQ01.lean
+++ b/proofs/Proofs/PartitionTheoremOQ01.lean
@@ -104,7 +104,7 @@ theorem hasMinGap_iff_pairwise (l : List ℕ) (d : ℕ) :
 
 /-- Corollary: hasMinGap d with d ≥ 1 gives strict pairwise separation.
     This follows immediately from the characterization. -/
-theorem hasMinGap_pairwise_sep (l : List ℕ) (d : ℕ) (hd : 1 ≤ d) :
+theorem hasMinGap_pairwise_sep (l : List ℕ) (d : ℕ) (_hd : 1 ≤ d) :
     hasMinGap l d = true →
     ∀ a ∈ l, ∀ b ∈ l, a ≠ b → (a + d ≤ b ∨ b + d ≤ a) := by
   intro h

--- a/proofs/Proofs/PythagoreanTriplesOQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ01.lean
@@ -888,6 +888,139 @@ theorem parity_axiom_from_equidistribution :
   exact (Filter.tendsto_congr (fun N => by rw [heq N])).mpr parity_class_equidistribution
 
 /-
+## Part XVI: Per-Column Involution
+
+For each fixed odd m, the involution n ↦ m-n on {1,...,m-1} preserves
+coprimality and swaps parity. Since m is odd, there's no fixed point
+(m-n = n ⟹ m = 2n, impossible). This gives EXACT equality of even
+and odd coprime counts in each column.
+
+This is strictly stronger than triangle_oe_eq_oo because it holds
+per-column, not just summed. It enables a cleaner reduction of
+the parity_class_equidistribution axiom.
+-/
+
+/-- Even coprimes to m in {1,...,m-1}. -/
+noncomputable def columnEvenCoprimes (m : ℕ) : Finset ℕ :=
+  (Finset.range m).filter (fun n => 0 < n ∧ Nat.Coprime m n ∧ Even n)
+
+/-- Odd coprimes to m in {1,...,m-1}. -/
+noncomputable def columnOddCoprimes (m : ℕ) : Finset ℕ :=
+  (Finset.range m).filter (fun n => 0 < n ∧ Nat.Coprime m n ∧ Odd n)
+
+/-- For odd m > 1: |{n ∈ {1,...,m-1} : gcd(m,n)=1, n even}| = |{... n odd}|.
+
+The involution n ↦ m-n preserves coprimality, swaps parity (m odd),
+and has no fixed points (m odd ⟹ m-n ≠ n). -/
+theorem column_even_eq_odd_coprimes {m : ℕ} (hm : Odd m) (hm1 : 1 < m) :
+    (columnEvenCoprimes m).card = (columnOddCoprimes m).card := by
+  apply Finset.card_bij (fun n _ => m - n)
+  · -- hi: maps columnEvenCoprimes into columnOddCoprimes
+    intro n hn
+    simp only [columnEvenCoprimes, columnOddCoprimes, Finset.mem_filter,
+      Finset.mem_range] at hn ⊢
+    obtain ⟨hn_range, hn_pos, hcop, hn_even⟩ := hn
+    refine ⟨by omega, by omega, involution_coprime hcop (by omega),
+            involution_oe_to_oo hm hn_even (by omega)⟩
+  · -- i_inj: injective
+    intro n₁ hn₁ n₂ hn₂ heq
+    simp only [columnEvenCoprimes, Finset.mem_filter, Finset.mem_range] at hn₁ hn₂
+    omega
+  · -- i_surj: surjective (preimage of odd n is m-n which is even)
+    intro n hn
+    simp only [columnOddCoprimes, columnEvenCoprimes, Finset.mem_filter,
+      Finset.mem_range] at hn ⊢
+    obtain ⟨hn_range, hn_pos, hcop, hn_odd⟩ := hn
+    exact ⟨m - n,
+      ⟨by omega, by omega, involution_coprime hcop (by omega),
+       involution_oo_to_oe hm hn_odd (by omega)⟩,
+      by omega⟩
+
+/-- Euler's totient of odd m > 1 is even: the involution n ↦ m-n pairs
+even and odd coprimes perfectly. -/
+theorem totient_even_of_odd {m : ℕ} (hm : Odd m) (hm1 : 1 < m) :
+    Even (Nat.totient m) := by
+  -- φ(m) = |{n ∈ {1,...,m-1} : gcd(m,n) = 1}| = |even coprimes| + |odd coprimes|
+  -- and even coprimes = odd coprimes by column_even_eq_odd_coprimes
+  have heq := column_even_eq_odd_coprimes hm hm1
+  -- φ(m) = 2 * |even coprimes|
+  exact ⟨(columnEvenCoprimes m).card, by omega⟩
+
+/-- Computational check: column counts for m = 3.
+Coprimes of 3 in {1,2}: {1, 2}. Even = {2}, Odd = {1}. Both have size 1. -/
+theorem column_check_3 :
+    (columnEvenCoprimes 3).card = (columnOddCoprimes 3).card := by
+  unfold columnEvenCoprimes columnOddCoprimes; native_decide
+
+/-- Computational check: column counts for m = 5.
+Coprimes of 5 in {1,2,3,4}: {1, 2, 3, 4}. Even = {2, 4}, Odd = {1, 3}. Both size 2. -/
+theorem column_check_5 :
+    (columnEvenCoprimes 5).card = (columnOddCoprimes 5).card := by
+  unfold columnEvenCoprimes columnOddCoprimes; native_decide
+
+/-- Computational check: column counts for m = 15.
+φ(15) = 8. Even = {2, 4, 7, 11}, Odd = {1, 8, 13, 14}? Both size 4. -/
+theorem column_check_15 :
+    (columnEvenCoprimes 15).card = (columnOddCoprimes 15).card := by
+  unfold columnEvenCoprimes columnOddCoprimes; native_decide
+
+/-
+## Part XVII: Sector Decomposition via Columns
+
+We decompose sector parity counts as sums over columns (fixed m values).
+For each odd m with m² < N, the OE and OO counts in column m differ
+by at most the number of "boundary" pairs where exactly one of n and
+m-n satisfies m²+n² ≤ N. This bounds |OE_sector - OO_sector|.
+-/
+
+/-- OE sector count restricted to column m. -/
+noncomputable def sectorOE_column (m N : ℕ) : ℕ :=
+  (Finset.range (N + 1)).filter (fun n =>
+    0 < n ∧ n < m ∧ Nat.Coprime m n ∧ Odd m ∧ Even n ∧ m ^ 2 + n ^ 2 ≤ N
+  ) |>.card
+
+/-- OO sector count restricted to column m. -/
+noncomputable def sectorOO_column (m N : ℕ) : ℕ :=
+  (Finset.range (N + 1)).filter (fun n =>
+    0 < n ∧ n < m ∧ Nat.Coprime m n ∧ Odd m ∧ Odd n ∧ m ^ 2 + n ^ 2 ≤ N
+  ) |>.card
+
+/-- When m² ≥ N, there are no valid pairs in the column: no n > 0 satisfies m²+n²≤N. -/
+theorem sectorOE_column_zero {m N : ℕ} (hm : N < m ^ 2) :
+    sectorOE_column m N = 0 := by
+  unfold sectorOE_column
+  apply Finset.card_eq_zero.mpr
+  apply Finset.filter_eq_empty_iff.mpr
+  intro n _
+  intro ⟨hn_pos, _, _, _, _, hle⟩
+  omega
+
+/-- When m² ≥ N, there are no valid OO pairs either. -/
+theorem sectorOO_column_zero {m N : ℕ} (hm : N < m ^ 2) :
+    sectorOO_column m N = 0 := by
+  unfold sectorOO_column
+  apply Finset.card_eq_zero.mpr
+  apply Finset.filter_eq_empty_iff.mpr
+  intro n _
+  intro ⟨hn_pos, _, _, _, _, hle⟩
+  omega
+
+/-- **Column discrepancy bound**: For each fixed odd m with m² < N,
+the OE and OO counts differ by at most 1.
+
+Proof sketch: The involution n ↦ m-n bijects even↔odd coprimes.
+For pairs where both n and m-n satisfy m²+·² ≤ N, the counts match.
+The unpaired elements are those near the boundary where exactly one
+of n, m-n lies in the sector. At most 2 elements can be unpaired
+(one from each side), giving |OE - OO| ≤ 1.
+
+(We axiomatize this bound; a full proof requires careful case analysis
+of the involution on the bounded range.) -/
+axiom column_discrepancy_bound (m N : ℕ) (hm : Odd m) (hm1 : 1 < m) :
+    (sectorOE_column m N : ℤ) - (sectorOO_column m N : ℤ) ≤ 1 ∧
+    (sectorOO_column m N : ℤ) - (sectorOE_column m N : ℤ) ≤ 1
+
+/-
 ## Summary (Updated)
 
 ### New in Part XII-XV (Parity Class Decomposition):

--- a/proofs/Proofs/TestColumnCoverage.lean
+++ b/proofs/Proofs/TestColumnCoverage.lean
@@ -159,13 +159,16 @@ theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
       | zero =>
         have hce0 : colEntry (true :: xs) 0 = 0 := rfl
         have hce1 : colEntry (true :: xs) 1 = colEntry xs 1 + 1 := colEntry_true_succ xs 0
-        -- Normalize 0 + 1 = 1 in hy_hi
-        have hy_hi' : y ≤ a + colEntry (true :: xs) 1 := by
-          convert hy_hi using 2; omega
-        have hlo' : (a + 1) + colEntry xs 0 ≤ y := by
-          simp only [colEntry]; omega
-        have hhi' : y ≤ (a + 1) + colEntry xs 1 := by linarith
-        exact visitedPoints_cons_true_of_mem xs a (0, y) (ih (a + 1) 0 y hx' hlo' hhi')
+        -- y is in range [a, a + colEntry xs 1 + 1]
+        -- If y = a, it's the start point; if y ≥ a+1, delegate to xs starting at a+1
+        by_cases hy : y = a
+        · subst hy; exact mem_visitedPoints_start _ _
+        · have hya1 : a + 1 ≤ y := by omega
+          have hlo' : (a + 1) + colEntry xs 0 ≤ y := by simp [colEntry]; omega
+          have hhi' : y ≤ (a + 1) + colEntry xs 1 := by
+            have : y ≤ a + colEntry (true :: xs) 1 := by convert hy_hi using 2; omega
+            linarith
+          exact visitedPoints_cons_true_of_mem xs a (0, y) (ih (a + 1) 0 y hx' hlo' hhi')
       | succ x' =>
         have hce_lo := colEntry_true_succ xs x'
         have hce_hi := colEntry_true_succ xs (x' + 1)
@@ -211,12 +214,15 @@ theorem visitedPoints_covers_final (l : LPath) (a : ℕ) (y : ℕ)
       | zero =>
         rw [heast, hm] at hy_lo ⊢
         simp only [colEntry] at hy_lo
-        have hhi' : y ≤ (a + 1) + northSteps xs := by linarith
-        have hlo' : (a + 1) + colEntry xs (eastSteps xs) ≤ y := by
-          rw [hm]; simp [colEntry]; omega
-        have mem := ih (a + 1) y hlo' hhi'
-        rw [hm] at mem
-        exact visitedPoints_cons_true_of_mem xs a (0, y) mem
+        -- y in [a, a + 1 + northSteps xs]. If y = a, start point. Else delegate to xs.
+        by_cases hy : y = a
+        · subst hy; exact mem_visitedPoints_start _ _
+        · have hhi' : y ≤ (a + 1) + northSteps xs := by linarith
+          have hlo' : (a + 1) + colEntry xs (eastSteps xs) ≤ y := by
+            rw [hm]; simp [colEntry]; omega
+          have mem := ih (a + 1) y hlo' hhi'
+          rw [hm] at mem
+          exact visitedPoints_cons_true_of_mem xs a (0, y) mem
       | succ m' =>
         have hce := colEntry_true_succ xs m'
         rw [heast, hm] at hy_lo ⊢

--- a/proofs/Proofs/TestColumnCoverage.lean
+++ b/proofs/Proofs/TestColumnCoverage.lean
@@ -122,8 +122,10 @@ private lemma visitedPoints_cons_true_of_mem (xs : LPath) (a : ℕ) (p : ℕ × 
     p ∈ visitedPoints (true :: xs) a := by
   simp only [visitedPoints, Finset.mem_image, Finset.mem_range] at hp ⊢
   obtain ⟨i, hi, hpi⟩ := hp
-  exact ⟨i + 1, by simp [List.length_cons]; omega,
-    by rw [posAfter_cons_succ]; simp [← hpi]; omega⟩
+  refine ⟨i + 1, by simp [List.length_cons]; omega, ?_⟩
+  rw [posAfter_cons_succ]
+  simp only [Bool.true_eq_false, ↓reduceIte, Bool.true_eq]
+  exact hpi
 
 theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
     (hx : x < eastSteps l)
@@ -138,6 +140,7 @@ theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
         simp [eastSteps, List.countP_cons]
       cases x with
       | zero =>
+        have h0 : colEntry (false :: xs) 0 = 0 := rfl
         have h1 : colEntry (false :: xs) 1 = 0 := by
           simp [colEntry, northBeforeEast]
         have : y = a := by omega

--- a/proofs/Proofs/TestColumnCoverage.lean
+++ b/proofs/Proofs/TestColumnCoverage.lean
@@ -1,0 +1,218 @@
+import Mathlib
+
+/-
+  Test file for visitedPoints_covers_column and visitedPoints_covers_final proofs.
+  Extracts minimal definitions from BallotProblemOQ03.lean.
+-/
+
+/-- A lattice path: false = East (+x), true = North (+y) -/
+abbrev LPath := List Bool
+
+/-- Count East (false) steps -/
+def eastSteps (l : LPath) : ℕ := l.countP (· = false)
+
+/-- Count North (true) steps -/
+def northSteps (l : LPath) : ℕ := l.countP (· = true)
+
+theorem eastSteps_add_northSteps (l : LPath) :
+    eastSteps l + northSteps l = l.length := by
+  induction l with
+  | nil => rfl
+  | cons x xs ih =>
+    cases x with
+    | false =>
+      have he : eastSteps (false :: xs) = eastSteps xs + 1 := by
+        simp [eastSteps, List.countP_cons]
+      have hn : northSteps (false :: xs) = northSteps xs := by
+        simp [northSteps, List.countP_cons]
+      simp only [he, hn, List.length_cons]; omega
+    | true =>
+      have he : eastSteps (true :: xs) = eastSteps xs := by
+        simp [eastSteps, List.countP_cons]
+      have hn : northSteps (true :: xs) = northSteps xs + 1 := by
+        simp [northSteps, List.countP_cons]
+      simp only [he, hn, List.length_cons]; omega
+
+lemma northSteps_cons_false (xs : LPath) : northSteps (false :: xs) = northSteps xs := by
+  simp [northSteps, List.countP_cons]
+
+lemma northSteps_cons_true (xs : LPath) : northSteps (true :: xs) = 1 + northSteps xs := by
+  simp [northSteps, List.countP_cons]; omega
+
+/-- northBeforeEast l k = # North (true) steps in l before the k-th East (false) step. -/
+def northBeforeEast : LPath → ℕ → ℕ
+  | [], _ => 0
+  | (false :: _), 0 => 0
+  | (false :: xs), (k + 1) => northBeforeEast xs k
+  | (true :: xs), k => 1 + northBeforeEast xs k
+
+theorem northBeforeEast_mono (l : LPath) (k : ℕ) :
+    northBeforeEast l k ≤ northBeforeEast l (k + 1) := by
+  induction l generalizing k with
+  | nil => simp [northBeforeEast]
+  | cons x xs ih =>
+    cases x with
+    | false =>
+      cases k with
+      | zero => simp [northBeforeEast]
+      | succ k => simp only [northBeforeEast]; exact ih k
+    | true =>
+      simp only [northBeforeEast]
+      exact Nat.add_le_add_left (ih k) 1
+
+/-- Column entry y-offset for column k -/
+def colEntry (l : LPath) : ℕ → ℕ
+  | 0 => 0
+  | (k + 1) => northBeforeEast l k
+
+theorem colEntry_mono (l : LPath) (k : ℕ) : colEntry l k ≤ colEntry l (k + 1) := by
+  cases k with
+  | zero => simp [colEntry]
+  | succ k => simp [colEntry]; exact northBeforeEast_mono l k
+
+private lemma colEntry_false_succ (xs : LPath) (k : ℕ) :
+    colEntry (false :: xs) (k + 1) = colEntry xs k := by
+  cases k with
+  | zero => simp [colEntry, northBeforeEast]
+  | succ k => simp [colEntry, northBeforeEast]
+
+private lemma colEntry_true_succ (xs : LPath) (k : ℕ) :
+    colEntry (true :: xs) (k + 1) = colEntry xs (k + 1) + 1 := by
+  simp [colEntry, northBeforeEast]; omega
+
+/-- Position after the first i steps of path l starting at (0, a). -/
+def posAfter (l : LPath) (a i : ℕ) : ℕ × ℕ :=
+  ((l.take i).countP (· = false), a + (l.take i).countP (· = true))
+
+theorem posAfter_zero (l : LPath) (a : ℕ) : posAfter l a 0 = (0, a) := by
+  simp [posAfter]
+
+theorem posAfter_length (l : LPath) (a : ℕ) :
+    posAfter l a l.length = (eastSteps l, a + northSteps l) := by
+  simp [posAfter, eastSteps, northSteps, List.take_length]
+
+/-- The set of lattice points visited by path l starting at (0, a) -/
+def visitedPoints (l : LPath) (a : ℕ) : Finset (ℕ × ℕ) :=
+  (Finset.range (l.length + 1)).image (posAfter l a)
+
+/-- Path l visits its starting point -/
+theorem mem_visitedPoints_start (l : LPath) (a : ℕ) :
+    (0, a) ∈ visitedPoints l a := by
+  rw [← posAfter_zero l a]
+  exact Finset.mem_image_of_mem _ (Finset.mem_range.mpr (by omega))
+
+-- Helper lemmas for the main proofs
+private lemma posAfter_cons_succ (b : Bool) (xs : LPath) (a i : ℕ) :
+    posAfter (b :: xs) a (i + 1) =
+    (if b = false then (posAfter xs a i).1 + 1 else (posAfter xs a i).1,
+     if b = true then (posAfter xs a i).2 + 1 else (posAfter xs a i).2) := by
+  simp only [posAfter, List.take_succ_cons, List.countP_cons]
+  cases b <;> simp [Prod.ext_iff] <;> omega
+
+private lemma visitedPoints_cons_false_of_mem (xs : LPath) (a : ℕ) (p : ℕ × ℕ)
+    (hp : p ∈ visitedPoints xs a) :
+    (p.1 + 1, p.2) ∈ visitedPoints (false :: xs) a := by
+  simp only [visitedPoints, Finset.mem_image, Finset.mem_range] at hp ⊢
+  obtain ⟨i, hi, hpi⟩ := hp
+  exact ⟨i + 1, by simp [List.length_cons]; omega,
+    by rw [posAfter_cons_succ]; simp [← hpi]⟩
+
+private lemma visitedPoints_cons_true_of_mem (xs : LPath) (a : ℕ) (p : ℕ × ℕ)
+    (hp : p ∈ visitedPoints xs (a + 1)) :
+    p ∈ visitedPoints (true :: xs) a := by
+  simp only [visitedPoints, Finset.mem_image, Finset.mem_range] at hp ⊢
+  obtain ⟨i, hi, hpi⟩ := hp
+  exact ⟨i + 1, by simp [List.length_cons]; omega,
+    by rw [posAfter_cons_succ]; simp [← hpi]; omega⟩
+
+theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
+    (hx : x < eastSteps l)
+    (hy_lo : a + colEntry l x ≤ y) (hy_hi : y ≤ a + colEntry l (x + 1)) :
+    (x, y) ∈ visitedPoints l a := by
+  induction l generalizing a x y with
+  | nil => simp [eastSteps, List.countP_nil] at hx
+  | cons b xs ih =>
+    cases b with
+    | false =>
+      have heast : eastSteps (false :: xs) = eastSteps xs + 1 := by
+        simp [eastSteps, List.countP_cons]
+      cases x with
+      | zero =>
+        have h1 : colEntry (false :: xs) 1 = 0 := by
+          simp [colEntry, northBeforeEast]
+        have : y = a := by omega
+        subst this
+        exact mem_visitedPoints_start _ _
+      | succ x' =>
+        have hx' : x' < eastSteps xs := by omega
+        have hlo : a + colEntry xs x' ≤ y := by
+          rw [← colEntry_false_succ xs x'] at hy_lo; linarith
+        have hhi : y ≤ a + colEntry xs (x' + 1) := by
+          rw [← colEntry_false_succ xs (x' + 1)] at hy_hi
+          have : x' + 1 + 1 = x' + 2 := by omega
+          rw [this] at hy_hi; linarith
+        exact visitedPoints_cons_false_of_mem xs a (x', y) (ih xs a x' y hx' hlo hhi)
+    | true =>
+      have heast : eastSteps (true :: xs) = eastSteps xs := by
+        simp [eastSteps, List.countP_cons]
+      have hx' : x < eastSteps xs := by omega
+      cases x with
+      | zero =>
+        have hce1 : colEntry (true :: xs) 1 = colEntry xs 1 + 1 := colEntry_true_succ xs 0
+        have hlo' : (a + 1) + colEntry xs 0 ≤ y := by simp [colEntry]; omega
+        have hhi' : y ≤ (a + 1) + colEntry xs 1 := by omega
+        exact visitedPoints_cons_true_of_mem xs a (0, y)
+          (ih xs (a + 1) 0 y hx' hlo' hhi')
+      | succ x' =>
+        have hce_lo : colEntry (true :: xs) (x' + 1) = colEntry xs (x' + 1) + 1 :=
+          colEntry_true_succ xs x'
+        have hce_hi : colEntry (true :: xs) (x' + 2) = colEntry xs (x' + 2) + 1 :=
+          colEntry_true_succ xs (x' + 1)
+        have hlo' : (a + 1) + colEntry xs (x' + 1) ≤ y := by omega
+        have hhi' : y ≤ (a + 1) + colEntry xs (x' + 2) := by omega
+        exact visitedPoints_cons_true_of_mem xs a (x' + 1, y)
+          (ih xs (a + 1) (x' + 1) y hx' hlo' hhi')
+
+theorem visitedPoints_covers_final (l : LPath) (a : ℕ) (y : ℕ)
+    (hy_lo : a + colEntry l (eastSteps l) ≤ y) (hy_hi : y ≤ a + northSteps l) :
+    (eastSteps l, y) ∈ visitedPoints l a := by
+  induction l generalizing a y with
+  | nil =>
+    simp [eastSteps, List.countP_nil, colEntry, northSteps] at hy_lo hy_hi ⊢
+    have : y = a := by omega
+    subst this
+    exact mem_visitedPoints_start _ _
+  | cons b xs ih =>
+    cases b with
+    | false =>
+      have heast : eastSteps (false :: xs) = eastSteps xs + 1 := by
+        simp [eastSteps, List.countP_cons]
+      have hnorth : northSteps (false :: xs) = northSteps xs := northSteps_cons_false xs
+      have hce : colEntry (false :: xs) (eastSteps (false :: xs)) = colEntry xs (eastSteps xs) := by
+        rw [heast]; exact colEntry_false_succ xs (eastSteps xs)
+      have hlo' : a + colEntry xs (eastSteps xs) ≤ y := by omega
+      have hhi' : y ≤ a + northSteps xs := by omega
+      have hmem := ih xs a y hlo' hhi'
+      rw [heast]
+      exact visitedPoints_cons_false_of_mem xs a (eastSteps xs, y) hmem
+    | true =>
+      have heast : eastSteps (true :: xs) = eastSteps xs := by
+        simp [eastSteps, List.countP_cons]
+      have hnorth : northSteps (true :: xs) = 1 + northSteps xs := northSteps_cons_true xs
+      cases hm : eastSteps xs with
+      | zero =>
+        rw [heast, hm] at hy_lo ⊢
+        simp [colEntry] at hy_lo
+        have hhi' : y ≤ (a + 1) + northSteps xs := by omega
+        have hlo' : (a + 1) + colEntry xs 0 ≤ y := by simp [colEntry]; omega
+        exact visitedPoints_cons_true_of_mem xs a (0, y)
+          (ih xs (a + 1) y hlo' hhi')
+      | succ m' =>
+        have hce : colEntry (true :: xs) (m' + 1) = colEntry xs (m' + 1) + 1 :=
+          colEntry_true_succ xs m'
+        rw [heast, hm] at hy_lo ⊢
+        have hlo' : (a + 1) + colEntry xs (m' + 1) ≤ y := by
+          rw [hce] at hy_lo; omega
+        have hhi' : y ≤ (a + 1) + northSteps xs := by omega
+        exact visitedPoints_cons_true_of_mem xs a (m' + 1, y)
+          (ih xs (a + 1) y hlo' hhi')

--- a/proofs/Proofs/TestColumnCoverage.lean
+++ b/proofs/Proofs/TestColumnCoverage.lean
@@ -17,11 +17,17 @@ theorem eastSteps_add_northSteps (l : LPath) :
   | cons x xs ih =>
     cases x with
     | false =>
-      simp only [eastSteps, northSteps, List.countP_cons, List.length_cons] at *
-      omega
+      have he : eastSteps (false :: xs) = eastSteps xs + 1 := by
+        simp [eastSteps, List.countP_cons]
+      have hn : northSteps (false :: xs) = northSteps xs := by
+        simp [northSteps, List.countP_cons]
+      simp only [he, hn, List.length_cons]; omega
     | true =>
-      simp only [eastSteps, northSteps, List.countP_cons, List.length_cons] at *
-      omega
+      have he : eastSteps (true :: xs) = eastSteps xs := by
+        simp [eastSteps, List.countP_cons]
+      have hn : northSteps (true :: xs) = northSteps xs + 1 := by
+        simp [northSteps, List.countP_cons]
+      simp only [he, hn, List.length_cons]; omega
 
 lemma northSteps_cons_false (xs : LPath) : northSteps (false :: xs) = northSteps xs := by
   simp [northSteps, List.countP_cons]
@@ -78,12 +84,12 @@ private lemma posAfter_false_succ (xs : LPath) (a i : ℕ) :
     posAfter (false :: xs) a (i + 1) =
     ((posAfter xs a i).1 + 1, (posAfter xs a i).2) := by
   simp only [posAfter, List.take_succ_cons, List.countP_cons]
-  simp [Prod.ext_iff]; omega
+  constructor <;> simp <;> omega
 
 private lemma posAfter_true_succ (xs : LPath) (a i : ℕ) :
     posAfter (true :: xs) a (i + 1) = posAfter xs (a + 1) i := by
   simp only [posAfter, List.take_succ_cons, List.countP_cons]
-  simp
+  constructor <;> simp <;> omega
 
 def visitedPoints (l : LPath) (a : ℕ) : Finset (ℕ × ℕ) :=
   (Finset.range (l.length + 1)).image (posAfter l a)
@@ -122,23 +128,28 @@ theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
         simp [eastSteps, List.countP_cons]
       cases x with
       | zero =>
-        -- colEntry (false :: xs) 0 = 0 and colEntry (false :: xs) 1 = 0
-        -- so y = a
-        simp only [colEntry, northBeforeEast] at hy_lo hy_hi
+        have h0 : colEntry (false :: xs) 0 = 0 := rfl
+        have h1 : colEntry (false :: xs) 1 = 0 := by simp [colEntry, northBeforeEast]
+        -- hy_lo: a + 0 ≤ y, hy_hi: y ≤ a + colEntry(false::xs)(0+1)
+        -- colEntry(false::xs)(0+1) = colEntry(false::xs) 1 = 0
+        have hhi : y ≤ a := by
+          calc y ≤ a + colEntry (false :: xs) (0 + 1) := hy_hi
+            _ = a + colEntry (false :: xs) 1 := by ring_nf
+            _ = a + 0 := by rw [h1]
+            _ = a := by omega
+        have hlo : a ≤ y := by linarith [h0]
         have : y = a := by omega
         subst this
         exact mem_visitedPoints_start _ _
       | succ x' =>
         have hx' : x' < eastSteps xs := by omega
-        -- colEntry (false :: xs) (x'+1) = colEntry xs x'
-        -- colEntry (false :: xs) (x'+2) = colEntry xs (x'+1)
         have hcf1 := colEntry_false_succ xs x'
         have hcf2 := colEntry_false_succ xs (x' + 1)
-        -- Need: x'+1+1 = x'+2 for the second one
-        have heq : x' + 1 + 1 = x' + 2 := by omega
-        rw [heq] at hy_hi
         have hlo : a + colEntry xs x' ≤ y := by linarith
-        have hhi : y ≤ a + colEntry xs (x' + 1) := by linarith
+        have hhi : y ≤ a + colEntry xs (x' + 1) := by
+          have : colEntry (false :: xs) (x' + 1 + 1) = colEntry (false :: xs) (x' + 2) := by
+            ring_nf
+          linarith [this]
         exact visitedPoints_cons_false_of_mem xs a (x', y) (ih a x' y hx' hlo hhi)
     | true =>
       have heast : eastSteps (true :: xs) = eastSteps xs := by
@@ -146,19 +157,22 @@ theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
       have hx' : x < eastSteps xs := by omega
       cases x with
       | zero =>
-        -- colEntry (true :: xs) 0 = 0
-        -- colEntry (true :: xs) 1 = colEntry xs 1 + 1
-        simp only [colEntry, northBeforeEast] at hy_lo hy_hi
-        have hlo' : (a + 1) + colEntry xs 0 ≤ y := by simp [colEntry]; omega
-        have hhi' : y ≤ (a + 1) + colEntry xs 1 := by simp [colEntry]; linarith
+        have hce0 : colEntry (true :: xs) 0 = 0 := rfl
+        have hce1 : colEntry (true :: xs) 1 = colEntry xs 1 + 1 := colEntry_true_succ xs 0
+        have hlo' : (a + 1) + colEntry xs 0 ≤ y := by
+          simp only [colEntry]; omega
+        have hhi' : y ≤ (a + 1) + colEntry xs 1 := by
+          have : colEntry (true :: xs) (0 + 1) = colEntry (true :: xs) 1 := by ring_nf
+          linarith [this]
         exact visitedPoints_cons_true_of_mem xs a (0, y) (ih (a + 1) 0 y hx' hlo' hhi')
       | succ x' =>
         have hce_lo := colEntry_true_succ xs x'
         have hce_hi := colEntry_true_succ xs (x' + 1)
-        have heq : x' + 1 + 1 = x' + 2 := by omega
-        rw [heq] at hy_hi
         have hlo' : (a + 1) + colEntry xs (x' + 1) ≤ y := by linarith
-        have hhi' : y ≤ (a + 1) + colEntry xs (x' + 2) := by linarith
+        have hhi' : y ≤ (a + 1) + colEntry xs (x' + 2) := by
+          have : colEntry (true :: xs) (x' + 1 + 1) = colEntry (true :: xs) (x' + 2) := by
+            ring_nf
+          linarith [this]
         exact visitedPoints_cons_true_of_mem xs a (x' + 1, y)
           (ih (a + 1) (x' + 1) y hx' hlo' hhi')
 
@@ -187,18 +201,27 @@ theorem visitedPoints_covers_final (l : LPath) (a : ℕ) (y : ℕ)
       have heast : eastSteps (true :: xs) = eastSteps xs := by
         simp [eastSteps, List.countP_cons]
       have hnorth : northSteps (true :: xs) = 1 + northSteps xs := northSteps_cons_true xs
+      -- colEntry (true :: xs) (eastSteps (true :: xs))
+      -- = colEntry (true :: xs) (eastSteps xs)
+      -- When eastSteps xs = 0: colEntry (true :: xs) 0 = 0
+      -- When eastSteps xs = m'+1: colEntry (true :: xs) (m'+1) = colEntry xs (m'+1) + 1
+      rw [heast] at hy_lo ⊢
       cases hm : eastSteps xs with
       | zero =>
-        rw [heast, hm] at hy_lo ⊢
-        simp [colEntry] at hy_lo
+        rw [hm] at hy_lo ⊢
+        simp only [colEntry] at hy_lo
         have hhi' : y ≤ (a + 1) + northSteps xs := by linarith
         have hlo' : (a + 1) + colEntry xs (eastSteps xs) ≤ y := by
           rw [hm]; simp [colEntry]; omega
-        exact visitedPoints_cons_true_of_mem xs a (0, y) (ih (a + 1) y hlo' hhi')
+        have := ih (a + 1) y hlo' hhi'
+        rw [hm] at this
+        exact visitedPoints_cons_true_of_mem xs a (0, y) this
       | succ m' =>
         have hce := colEntry_true_succ xs m'
-        rw [heast, hm] at hy_lo ⊢
+        rw [hm] at hy_lo
         have hlo' : (a + 1) + colEntry xs (eastSteps xs) ≤ y := by
           rw [hm]; linarith
         have hhi' : y ≤ (a + 1) + northSteps xs := by linarith
-        exact visitedPoints_cons_true_of_mem xs a (m' + 1, y) (ih (a + 1) y hlo' hhi')
+        have := ih (a + 1) y hlo' hhi'
+        rw [hm] at this
+        exact visitedPoints_cons_true_of_mem xs a (m' + 1, y) this

--- a/proofs/Proofs/TestColumnCoverage.lean
+++ b/proofs/Proofs/TestColumnCoverage.lean
@@ -91,6 +91,19 @@ theorem posAfter_length (l : LPath) (a : ℕ) :
     posAfter l a l.length = (eastSteps l, a + northSteps l) := by
   simp [posAfter, eastSteps, northSteps, List.take_length]
 
+/-- Key stepping lemma: after a false (East) step, x-coord increments -/
+private lemma posAfter_false_succ (xs : LPath) (a i : ℕ) :
+    posAfter (false :: xs) a (i + 1) =
+    ((posAfter xs a i).1 + 1, (posAfter xs a i).2) := by
+  simp only [posAfter, List.take_succ_cons, List.countP_cons]
+  simp [Prod.ext_iff]; omega
+
+/-- Key stepping lemma: after a true (North) step, y-coord increments -/
+private lemma posAfter_true_succ (xs : LPath) (a i : ℕ) :
+    posAfter (true :: xs) a (i + 1) = posAfter xs (a + 1) i := by
+  simp only [posAfter, List.take_succ_cons, List.countP_cons]
+  simp [Prod.ext_iff]; omega
+
 /-- The set of lattice points visited by path l starting at (0, a) -/
 def visitedPoints (l : LPath) (a : ℕ) : Finset (ℕ × ℕ) :=
   (Finset.range (l.length + 1)).image (posAfter l a)
@@ -101,31 +114,21 @@ theorem mem_visitedPoints_start (l : LPath) (a : ℕ) :
   rw [← posAfter_zero l a]
   exact Finset.mem_image_of_mem _ (Finset.mem_range.mpr (by omega))
 
--- Helper lemmas for the main proofs
-private lemma posAfter_cons_succ (b : Bool) (xs : LPath) (a i : ℕ) :
-    posAfter (b :: xs) a (i + 1) =
-    (if b = false then (posAfter xs a i).1 + 1 else (posAfter xs a i).1,
-     if b = true then (posAfter xs a i).2 + 1 else (posAfter xs a i).2) := by
-  simp only [posAfter, List.take_succ_cons, List.countP_cons]
-  cases b <;> simp [Prod.ext_iff] <;> omega
-
 private lemma visitedPoints_cons_false_of_mem (xs : LPath) (a : ℕ) (p : ℕ × ℕ)
     (hp : p ∈ visitedPoints xs a) :
     (p.1 + 1, p.2) ∈ visitedPoints (false :: xs) a := by
   simp only [visitedPoints, Finset.mem_image, Finset.mem_range] at hp ⊢
   obtain ⟨i, hi, hpi⟩ := hp
   exact ⟨i + 1, by simp [List.length_cons]; omega,
-    by rw [posAfter_cons_succ]; simp [← hpi]⟩
+    by rw [posAfter_false_succ]; rw [← hpi]⟩
 
 private lemma visitedPoints_cons_true_of_mem (xs : LPath) (a : ℕ) (p : ℕ × ℕ)
     (hp : p ∈ visitedPoints xs (a + 1)) :
     p ∈ visitedPoints (true :: xs) a := by
   simp only [visitedPoints, Finset.mem_image, Finset.mem_range] at hp ⊢
   obtain ⟨i, hi, hpi⟩ := hp
-  refine ⟨i + 1, by simp [List.length_cons]; omega, ?_⟩
-  rw [posAfter_cons_succ]
-  simp only [Bool.true_eq_false, ↓reduceIte, Bool.true_eq]
-  exact hpi
+  exact ⟨i + 1, by simp [List.length_cons]; omega,
+    by rw [posAfter_true_succ]; exact hpi⟩
 
 theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
     (hx : x < eastSteps l)
@@ -140,32 +143,31 @@ theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
         simp [eastSteps, List.countP_cons]
       cases x with
       | zero =>
+        -- colEntry (false :: xs) 0 = 0, colEntry (false :: xs) 1 = northBeforeEast (false::xs) 0 = 0
         have h0 : colEntry (false :: xs) 0 = 0 := rfl
-        have h1 : colEntry (false :: xs) 1 = 0 := by
-          simp [colEntry, northBeforeEast]
+        have h1 : colEntry (false :: xs) 1 = 0 := by simp [colEntry, northBeforeEast]
         have : y = a := by omega
         subst this
         exact mem_visitedPoints_start _ _
       | succ x' =>
         have hx' : x' < eastSteps xs := by omega
         have hlo : a + colEntry xs x' ≤ y := by
-          rw [← colEntry_false_succ xs x'] at hy_lo; linarith
+          have := colEntry_false_succ xs x'; omega
         have hhi : y ≤ a + colEntry xs (x' + 1) := by
-          rw [← colEntry_false_succ xs (x' + 1)] at hy_hi
-          have : x' + 1 + 1 = x' + 2 := by omega
-          rw [this] at hy_hi; linarith
-        exact visitedPoints_cons_false_of_mem xs a (x', y) (ih xs a x' y hx' hlo hhi)
+          have := colEntry_false_succ xs (x' + 1); omega
+        exact visitedPoints_cons_false_of_mem xs a (x', y) (ih a x' y hx' hlo hhi)
     | true =>
       have heast : eastSteps (true :: xs) = eastSteps xs := by
         simp [eastSteps, List.countP_cons]
       have hx' : x < eastSteps xs := by omega
       cases x with
       | zero =>
+        have hce0 : colEntry (true :: xs) 0 = 0 := rfl
         have hce1 : colEntry (true :: xs) 1 = colEntry xs 1 + 1 := colEntry_true_succ xs 0
-        have hlo' : (a + 1) + colEntry xs 0 ≤ y := by simp [colEntry]; omega
+        have hce0' : colEntry xs 0 = 0 := rfl
+        have hlo' : (a + 1) + colEntry xs 0 ≤ y := by omega
         have hhi' : y ≤ (a + 1) + colEntry xs 1 := by omega
-        exact visitedPoints_cons_true_of_mem xs a (0, y)
-          (ih xs (a + 1) 0 y hx' hlo' hhi')
+        exact visitedPoints_cons_true_of_mem xs a (0, y) (ih (a + 1) 0 y hx' hlo' hhi')
       | succ x' =>
         have hce_lo : colEntry (true :: xs) (x' + 1) = colEntry xs (x' + 1) + 1 :=
           colEntry_true_succ xs x'
@@ -174,7 +176,7 @@ theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
         have hlo' : (a + 1) + colEntry xs (x' + 1) ≤ y := by omega
         have hhi' : y ≤ (a + 1) + colEntry xs (x' + 2) := by omega
         exact visitedPoints_cons_true_of_mem xs a (x' + 1, y)
-          (ih xs (a + 1) (x' + 1) y hx' hlo' hhi')
+          (ih (a + 1) (x' + 1) y hx' hlo' hhi')
 
 theorem visitedPoints_covers_final (l : LPath) (a : ℕ) (y : ℕ)
     (hy_lo : a + colEntry l (eastSteps l) ≤ y) (hy_hi : y ≤ a + northSteps l) :
@@ -195,9 +197,8 @@ theorem visitedPoints_covers_final (l : LPath) (a : ℕ) (y : ℕ)
         rw [heast]; exact colEntry_false_succ xs (eastSteps xs)
       have hlo' : a + colEntry xs (eastSteps xs) ≤ y := by omega
       have hhi' : y ≤ a + northSteps xs := by omega
-      have hmem := ih xs a y hlo' hhi'
       rw [heast]
-      exact visitedPoints_cons_false_of_mem xs a (eastSteps xs, y) hmem
+      exact visitedPoints_cons_false_of_mem xs a (eastSteps xs, y) (ih a y hlo' hhi')
     | true =>
       have heast : eastSteps (true :: xs) = eastSteps xs := by
         simp [eastSteps, List.countP_cons]
@@ -208,8 +209,7 @@ theorem visitedPoints_covers_final (l : LPath) (a : ℕ) (y : ℕ)
         simp [colEntry] at hy_lo
         have hhi' : y ≤ (a + 1) + northSteps xs := by omega
         have hlo' : (a + 1) + colEntry xs 0 ≤ y := by simp [colEntry]; omega
-        exact visitedPoints_cons_true_of_mem xs a (0, y)
-          (ih xs (a + 1) y hlo' hhi')
+        exact visitedPoints_cons_true_of_mem xs a (0, y) (ih (a + 1) y hlo' hhi')
       | succ m' =>
         have hce : colEntry (true :: xs) (m' + 1) = colEntry xs (m' + 1) + 1 :=
           colEntry_true_succ xs m'
@@ -217,5 +217,4 @@ theorem visitedPoints_covers_final (l : LPath) (a : ℕ) (y : ℕ)
         have hlo' : (a + 1) + colEntry xs (m' + 1) ≤ y := by
           rw [hce] at hy_lo; omega
         have hhi' : y ≤ (a + 1) + northSteps xs := by omega
-        exact visitedPoints_cons_true_of_mem xs a (m' + 1, y)
-          (ih xs (a + 1) y hlo' hhi')
+        exact visitedPoints_cons_true_of_mem xs a (m' + 1, y) (ih (a + 1) y hlo' hhi')

--- a/proofs/Proofs/TestColumnCoverage.lean
+++ b/proofs/Proofs/TestColumnCoverage.lean
@@ -89,7 +89,7 @@ private lemma posAfter_false_succ (xs : LPath) (a i : ℕ) :
 private lemma posAfter_true_succ (xs : LPath) (a i : ℕ) :
     posAfter (true :: xs) a (i + 1) = posAfter xs (a + 1) i := by
   simp only [posAfter, List.take_succ_cons, List.countP_cons]
-  constructor <;> simp <;> omega
+  ext1 <;> simp <;> omega
 
 def visitedPoints (l : LPath) (a : ℕ) : Finset (ℕ × ℕ) :=
   (Finset.range (l.length + 1)).image (posAfter l a)
@@ -159,11 +159,12 @@ theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
       | zero =>
         have hce0 : colEntry (true :: xs) 0 = 0 := rfl
         have hce1 : colEntry (true :: xs) 1 = colEntry xs 1 + 1 := colEntry_true_succ xs 0
+        -- Normalize 0 + 1 = 1 in hy_hi
+        have hy_hi' : y ≤ a + colEntry (true :: xs) 1 := by
+          convert hy_hi using 2; omega
         have hlo' : (a + 1) + colEntry xs 0 ≤ y := by
           simp only [colEntry]; omega
-        have hhi' : y ≤ (a + 1) + colEntry xs 1 := by
-          have : colEntry (true :: xs) (0 + 1) = colEntry (true :: xs) 1 := by ring_nf
-          linarith [this]
+        have hhi' : y ≤ (a + 1) + colEntry xs 1 := by linarith
         exact visitedPoints_cons_true_of_mem xs a (0, y) (ih (a + 1) 0 y hx' hlo' hhi')
       | succ x' =>
         have hce_lo := colEntry_true_succ xs x'
@@ -205,23 +206,23 @@ theorem visitedPoints_covers_final (l : LPath) (a : ℕ) (y : ℕ)
       -- = colEntry (true :: xs) (eastSteps xs)
       -- When eastSteps xs = 0: colEntry (true :: xs) 0 = 0
       -- When eastSteps xs = m'+1: colEntry (true :: xs) (m'+1) = colEntry xs (m'+1) + 1
-      rw [heast] at hy_lo ⊢
+      -- colEntry (true :: xs) (eastSteps xs) needs to connect to colEntry xs (eastSteps xs)
       cases hm : eastSteps xs with
       | zero =>
-        rw [hm] at hy_lo ⊢
+        rw [heast, hm] at hy_lo ⊢
         simp only [colEntry] at hy_lo
         have hhi' : y ≤ (a + 1) + northSteps xs := by linarith
         have hlo' : (a + 1) + colEntry xs (eastSteps xs) ≤ y := by
           rw [hm]; simp [colEntry]; omega
-        have := ih (a + 1) y hlo' hhi'
-        rw [hm] at this
-        exact visitedPoints_cons_true_of_mem xs a (0, y) this
+        have mem := ih (a + 1) y hlo' hhi'
+        rw [hm] at mem
+        exact visitedPoints_cons_true_of_mem xs a (0, y) mem
       | succ m' =>
         have hce := colEntry_true_succ xs m'
-        rw [hm] at hy_lo
+        rw [heast, hm] at hy_lo ⊢
         have hlo' : (a + 1) + colEntry xs (eastSteps xs) ≤ y := by
           rw [hm]; linarith
         have hhi' : y ≤ (a + 1) + northSteps xs := by linarith
-        have := ih (a + 1) y hlo' hhi'
-        rw [hm] at this
-        exact visitedPoints_cons_true_of_mem xs a (m' + 1, y) this
+        have mem := ih (a + 1) y hlo' hhi'
+        rw [hm] at mem
+        exact visitedPoints_cons_true_of_mem xs a (m' + 1, y) mem

--- a/proofs/Proofs/TestColumnCoverage.lean
+++ b/proofs/Proofs/TestColumnCoverage.lean
@@ -83,7 +83,7 @@ private lemma posAfter_false_succ (xs : LPath) (a i : ℕ) :
 private lemma posAfter_true_succ (xs : LPath) (a i : ℕ) :
     posAfter (true :: xs) a (i + 1) = posAfter xs (a + 1) i := by
   simp only [posAfter, List.take_succ_cons, List.countP_cons]
-  simp [Prod.ext_iff]; omega
+  simp
 
 def visitedPoints (l : LPath) (a : ℕ) : Finset (ℕ × ℕ) :=
   (Finset.range (l.length + 1)).image (posAfter l a)
@@ -148,11 +148,9 @@ theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
       | zero =>
         -- colEntry (true :: xs) 0 = 0
         -- colEntry (true :: xs) 1 = colEntry xs 1 + 1
-        simp only [colEntry] at hy_lo
-        have hce1 := colEntry_true_succ xs 0
-        rw [hce1] at hy_hi
+        simp only [colEntry, northBeforeEast] at hy_lo hy_hi
         have hlo' : (a + 1) + colEntry xs 0 ≤ y := by simp [colEntry]; omega
-        have hhi' : y ≤ (a + 1) + colEntry xs 1 := by linarith
+        have hhi' : y ≤ (a + 1) + colEntry xs 1 := by simp [colEntry]; linarith
         exact visitedPoints_cons_true_of_mem xs a (0, y) (ih (a + 1) 0 y hx' hlo' hhi')
       | succ x' =>
         have hce_lo := colEntry_true_succ xs x'
@@ -194,11 +192,13 @@ theorem visitedPoints_covers_final (l : LPath) (a : ℕ) (y : ℕ)
         rw [heast, hm] at hy_lo ⊢
         simp [colEntry] at hy_lo
         have hhi' : y ≤ (a + 1) + northSteps xs := by linarith
-        have hlo' : (a + 1) + colEntry xs 0 ≤ y := by simp [colEntry]; omega
+        have hlo' : (a + 1) + colEntry xs (eastSteps xs) ≤ y := by
+          rw [hm]; simp [colEntry]; omega
         exact visitedPoints_cons_true_of_mem xs a (0, y) (ih (a + 1) y hlo' hhi')
       | succ m' =>
         have hce := colEntry_true_succ xs m'
         rw [heast, hm] at hy_lo ⊢
-        have hlo' : (a + 1) + colEntry xs (m' + 1) ≤ y := by linarith
+        have hlo' : (a + 1) + colEntry xs (eastSteps xs) ≤ y := by
+          rw [hm]; linarith
         have hhi' : y ≤ (a + 1) + northSteps xs := by linarith
         exact visitedPoints_cons_true_of_mem xs a (m' + 1, y) (ih (a + 1) y hlo' hhi')

--- a/proofs/Proofs/TestColumnCoverage.lean
+++ b/proofs/Proofs/TestColumnCoverage.lean
@@ -5,13 +5,9 @@ import Mathlib
   Extracts minimal definitions from BallotProblemOQ03.lean.
 -/
 
-/-- A lattice path: false = East (+x), true = North (+y) -/
 abbrev LPath := List Bool
 
-/-- Count East (false) steps -/
 def eastSteps (l : LPath) : ℕ := l.countP (· = false)
-
-/-- Count North (true) steps -/
 def northSteps (l : LPath) : ℕ := l.countP (· = true)
 
 theorem eastSteps_add_northSteps (l : LPath) :
@@ -21,17 +17,11 @@ theorem eastSteps_add_northSteps (l : LPath) :
   | cons x xs ih =>
     cases x with
     | false =>
-      have he : eastSteps (false :: xs) = eastSteps xs + 1 := by
-        simp [eastSteps, List.countP_cons]
-      have hn : northSteps (false :: xs) = northSteps xs := by
-        simp [northSteps, List.countP_cons]
-      simp only [he, hn, List.length_cons]; omega
+      simp only [eastSteps, northSteps, List.countP_cons, List.length_cons] at *
+      omega
     | true =>
-      have he : eastSteps (true :: xs) = eastSteps xs := by
-        simp [eastSteps, List.countP_cons]
-      have hn : northSteps (true :: xs) = northSteps xs + 1 := by
-        simp [northSteps, List.countP_cons]
-      simp only [he, hn, List.length_cons]; omega
+      simp only [eastSteps, northSteps, List.countP_cons, List.length_cons] at *
+      omega
 
 lemma northSteps_cons_false (xs : LPath) : northSteps (false :: xs) = northSteps xs := by
   simp [northSteps, List.countP_cons]
@@ -39,7 +29,6 @@ lemma northSteps_cons_false (xs : LPath) : northSteps (false :: xs) = northSteps
 lemma northSteps_cons_true (xs : LPath) : northSteps (true :: xs) = 1 + northSteps xs := by
   simp [northSteps, List.countP_cons]; omega
 
-/-- northBeforeEast l k = # North (true) steps in l before the k-th East (false) step. -/
 def northBeforeEast : LPath → ℕ → ℕ
   | [], _ => 0
   | (false :: _), 0 => 0
@@ -60,7 +49,6 @@ theorem northBeforeEast_mono (l : LPath) (k : ℕ) :
       simp only [northBeforeEast]
       exact Nat.add_le_add_left (ih k) 1
 
-/-- Column entry y-offset for column k -/
 def colEntry (l : LPath) : ℕ → ℕ
   | 0 => 0
   | (k + 1) => northBeforeEast l k
@@ -80,35 +68,26 @@ private lemma colEntry_true_succ (xs : LPath) (k : ℕ) :
     colEntry (true :: xs) (k + 1) = colEntry xs (k + 1) + 1 := by
   simp [colEntry, northBeforeEast]; omega
 
-/-- Position after the first i steps of path l starting at (0, a). -/
 def posAfter (l : LPath) (a i : ℕ) : ℕ × ℕ :=
   ((l.take i).countP (· = false), a + (l.take i).countP (· = true))
 
 theorem posAfter_zero (l : LPath) (a : ℕ) : posAfter l a 0 = (0, a) := by
   simp [posAfter]
 
-theorem posAfter_length (l : LPath) (a : ℕ) :
-    posAfter l a l.length = (eastSteps l, a + northSteps l) := by
-  simp [posAfter, eastSteps, northSteps, List.take_length]
-
-/-- Key stepping lemma: after a false (East) step, x-coord increments -/
 private lemma posAfter_false_succ (xs : LPath) (a i : ℕ) :
     posAfter (false :: xs) a (i + 1) =
     ((posAfter xs a i).1 + 1, (posAfter xs a i).2) := by
   simp only [posAfter, List.take_succ_cons, List.countP_cons]
   simp [Prod.ext_iff]; omega
 
-/-- Key stepping lemma: after a true (North) step, y-coord increments -/
 private lemma posAfter_true_succ (xs : LPath) (a i : ℕ) :
     posAfter (true :: xs) a (i + 1) = posAfter xs (a + 1) i := by
   simp only [posAfter, List.take_succ_cons, List.countP_cons]
   simp [Prod.ext_iff]; omega
 
-/-- The set of lattice points visited by path l starting at (0, a) -/
 def visitedPoints (l : LPath) (a : ℕ) : Finset (ℕ × ℕ) :=
   (Finset.range (l.length + 1)).image (posAfter l a)
 
-/-- Path l visits its starting point -/
 theorem mem_visitedPoints_start (l : LPath) (a : ℕ) :
     (0, a) ∈ visitedPoints l a := by
   rw [← posAfter_zero l a]
@@ -143,18 +122,23 @@ theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
         simp [eastSteps, List.countP_cons]
       cases x with
       | zero =>
-        -- colEntry (false :: xs) 0 = 0, colEntry (false :: xs) 1 = northBeforeEast (false::xs) 0 = 0
-        have h0 : colEntry (false :: xs) 0 = 0 := rfl
-        have h1 : colEntry (false :: xs) 1 = 0 := by simp [colEntry, northBeforeEast]
+        -- colEntry (false :: xs) 0 = 0 and colEntry (false :: xs) 1 = 0
+        -- so y = a
+        simp only [colEntry, northBeforeEast] at hy_lo hy_hi
         have : y = a := by omega
         subst this
         exact mem_visitedPoints_start _ _
       | succ x' =>
         have hx' : x' < eastSteps xs := by omega
-        have hlo : a + colEntry xs x' ≤ y := by
-          have := colEntry_false_succ xs x'; omega
-        have hhi : y ≤ a + colEntry xs (x' + 1) := by
-          have := colEntry_false_succ xs (x' + 1); omega
+        -- colEntry (false :: xs) (x'+1) = colEntry xs x'
+        -- colEntry (false :: xs) (x'+2) = colEntry xs (x'+1)
+        have hcf1 := colEntry_false_succ xs x'
+        have hcf2 := colEntry_false_succ xs (x' + 1)
+        -- Need: x'+1+1 = x'+2 for the second one
+        have heq : x' + 1 + 1 = x' + 2 := by omega
+        rw [heq] at hy_hi
+        have hlo : a + colEntry xs x' ≤ y := by linarith
+        have hhi : y ≤ a + colEntry xs (x' + 1) := by linarith
         exact visitedPoints_cons_false_of_mem xs a (x', y) (ih a x' y hx' hlo hhi)
     | true =>
       have heast : eastSteps (true :: xs) = eastSteps xs := by
@@ -162,19 +146,21 @@ theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
       have hx' : x < eastSteps xs := by omega
       cases x with
       | zero =>
-        have hce0 : colEntry (true :: xs) 0 = 0 := rfl
-        have hce1 : colEntry (true :: xs) 1 = colEntry xs 1 + 1 := colEntry_true_succ xs 0
-        have hce0' : colEntry xs 0 = 0 := rfl
-        have hlo' : (a + 1) + colEntry xs 0 ≤ y := by omega
-        have hhi' : y ≤ (a + 1) + colEntry xs 1 := by omega
+        -- colEntry (true :: xs) 0 = 0
+        -- colEntry (true :: xs) 1 = colEntry xs 1 + 1
+        simp only [colEntry] at hy_lo
+        have hce1 := colEntry_true_succ xs 0
+        rw [hce1] at hy_hi
+        have hlo' : (a + 1) + colEntry xs 0 ≤ y := by simp [colEntry]; omega
+        have hhi' : y ≤ (a + 1) + colEntry xs 1 := by linarith
         exact visitedPoints_cons_true_of_mem xs a (0, y) (ih (a + 1) 0 y hx' hlo' hhi')
       | succ x' =>
-        have hce_lo : colEntry (true :: xs) (x' + 1) = colEntry xs (x' + 1) + 1 :=
-          colEntry_true_succ xs x'
-        have hce_hi : colEntry (true :: xs) (x' + 2) = colEntry xs (x' + 2) + 1 :=
-          colEntry_true_succ xs (x' + 1)
-        have hlo' : (a + 1) + colEntry xs (x' + 1) ≤ y := by omega
-        have hhi' : y ≤ (a + 1) + colEntry xs (x' + 2) := by omega
+        have hce_lo := colEntry_true_succ xs x'
+        have hce_hi := colEntry_true_succ xs (x' + 1)
+        have heq : x' + 1 + 1 = x' + 2 := by omega
+        rw [heq] at hy_hi
+        have hlo' : (a + 1) + colEntry xs (x' + 1) ≤ y := by linarith
+        have hhi' : y ≤ (a + 1) + colEntry xs (x' + 2) := by linarith
         exact visitedPoints_cons_true_of_mem xs a (x' + 1, y)
           (ih (a + 1) (x' + 1) y hx' hlo' hhi')
 
@@ -195,8 +181,8 @@ theorem visitedPoints_covers_final (l : LPath) (a : ℕ) (y : ℕ)
       have hnorth : northSteps (false :: xs) = northSteps xs := northSteps_cons_false xs
       have hce : colEntry (false :: xs) (eastSteps (false :: xs)) = colEntry xs (eastSteps xs) := by
         rw [heast]; exact colEntry_false_succ xs (eastSteps xs)
-      have hlo' : a + colEntry xs (eastSteps xs) ≤ y := by omega
-      have hhi' : y ≤ a + northSteps xs := by omega
+      have hlo' : a + colEntry xs (eastSteps xs) ≤ y := by linarith
+      have hhi' : y ≤ a + northSteps xs := by linarith
       rw [heast]
       exact visitedPoints_cons_false_of_mem xs a (eastSteps xs, y) (ih a y hlo' hhi')
     | true =>
@@ -207,14 +193,12 @@ theorem visitedPoints_covers_final (l : LPath) (a : ℕ) (y : ℕ)
       | zero =>
         rw [heast, hm] at hy_lo ⊢
         simp [colEntry] at hy_lo
-        have hhi' : y ≤ (a + 1) + northSteps xs := by omega
+        have hhi' : y ≤ (a + 1) + northSteps xs := by linarith
         have hlo' : (a + 1) + colEntry xs 0 ≤ y := by simp [colEntry]; omega
         exact visitedPoints_cons_true_of_mem xs a (0, y) (ih (a + 1) y hlo' hhi')
       | succ m' =>
-        have hce : colEntry (true :: xs) (m' + 1) = colEntry xs (m' + 1) + 1 :=
-          colEntry_true_succ xs m'
+        have hce := colEntry_true_succ xs m'
         rw [heast, hm] at hy_lo ⊢
-        have hlo' : (a + 1) + colEntry xs (m' + 1) ≤ y := by
-          rw [hce] at hy_lo; omega
-        have hhi' : y ≤ (a + 1) + northSteps xs := by omega
+        have hlo' : (a + 1) + colEntry xs (m' + 1) ≤ y := by linarith
+        have hhi' : y ≤ (a + 1) + northSteps xs := by linarith
         exact visitedPoints_cons_true_of_mem xs a (m' + 1, y) (ih (a + 1) y hlo' hhi')

--- a/proofs/Proofs/TestColumnCoverage.lean
+++ b/proofs/Proofs/TestColumnCoverage.lean
@@ -166,7 +166,7 @@ theorem visitedPoints_covers_column (l : LPath) (a : ℕ) (x y : ℕ)
         · have hya1 : a + 1 ≤ y := by omega
           have hlo' : (a + 1) + colEntry xs 0 ≤ y := by simp [colEntry]; omega
           have hhi' : y ≤ (a + 1) + colEntry xs 1 := by
-            have : y ≤ a + colEntry (true :: xs) 1 := by convert hy_hi using 2; omega
+            have : y ≤ a + colEntry (true :: xs) 1 := by convert hy_hi using 2
             linarith
           exact visitedPoints_cons_true_of_mem xs a (0, y) (ih (a + 1) 0 y hx' hlo' hhi')
       | succ x' =>


### PR DESCRIPTION
## Summary
- Add 5 new proved theorems building cyclotomic tower infrastructure for proving natDegree(minpoly ℚ cos(2π/n)) = φ(n)/2
- Establish the key connection: ζ_n integral over ℚ, minpoly = Φ_n, finrank = φ(n), cos ∈ ℚ(ζ), ℚ(cos) ≤ ℚ(ζ)
- Begin assembly of capstone proof with minpoly invariance ℝ↔ℂ and tower law setup

## Progress
- **New proved theorems**: `zeta_isIntegral`, `minpoly_zeta_natDegree`, `finrank_adjoin_zeta`, `cos_mem_adjoin_zeta`, `adjoin_cos_le_adjoin_zeta`
- **Partial proof**: `minpoly_cos_natDegree_eq` has minpoly equivalence, integrality, and finrank ℚ E = φ(n) established
- **Remaining**: [ℚ(ζ):ℚ(cos)] = 2 (irreducible quadratic over ℚ(cos) ⊂ ℝ) and tower law assembly

## Findings
- Mathlib's `IsPrimitiveRoot.minpoly_eq_cyclotomic_of_irreducible` and `Polynomial.cyclotomic.irreducible_rat` provide clean connection from our concrete ζ_n to cyclotomic polynomial
- `IntermediateField.adjoin.finrank` bridges polynomial degrees to vector space dimensions
- `minpoly.algHom_eq` handles the ℝ→ℂ minpoly invariance
- `cos_2kpi_div_n_eq_iff` broken by Mathlib API rename (`Nat.cast_mod_cast` no longer exists) - independent of capstone path

## Status
**Outcome**: progress
**Next Steps**: Prove [ℚ(ζ):ℚ(cos)] = 2 by showing ζ satisfies irreducible quadratic X²-2cos·X+1 over ℚ(cos) ⊂ ℝ, then assemble tower law for final natDegree = φ(n)/2.

🤖 Generated by researcher-2