### PR TITLE
Research system: depth over breadth priority

### DIFF
--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -74,10 +74,10 @@ fi
 
 | Total Items | Tier | Priority |
 |-------------|------|----------|
-| 0 | **EMPTY** | Highest - explore immediately |
-| 1-5 | **WEAK** | High - needs more research |
-| 6-15 | **MODERATE** | Medium - continue if promising |
-| 16+ | **RICH** | Lower - only if new approach found |
+| 6-15 | **MODERATE** | Highest - advance toward proof |
+| 16+ | **RICH** | Highest - near completion, push to finish |
+| 1-5 | **WEAK** | Medium - continue started survey |
+| 0 | **EMPTY** | Lowest - fresh problems only when nothing else |
 
 **Total Items** = insights + builtItems + mathlibGaps + nextSteps
 
@@ -88,12 +88,13 @@ fi
 .lean/scripts/knowledge-scores.sh
 ```
 
-### Selection Rule
+### Selection Rule — DEPTH OVER BREADTH
 
 When multiple problems are eligible:
-1. **Always prefer EMPTY/WEAK knowledge** over MODERATE/RICH
+1. **Always prefer MODERATE/RICH knowledge** over EMPTY/WEAK — advance existing work toward proof
 2. Among same knowledge tier, use tractability as tiebreaker
-3. Document why you chose a particular problem
+3. Only pick EMPTY problems when no MODERATE+ or WEAK problems are available
+4. Document why you chose a particular problem
 
 ---
 
@@ -214,6 +215,29 @@ Scout returns gallery proofs, techniques, Mathlib gaps, and recommended approach
    - Try manually first (should be quick)
    - Use `aristotle_prove` sync if you want instant answer
 
+### Step 5b: Advance Phase (MANDATORY)
+
+After each session, advance the problem's phase to reflect work done:
+
+```bash
+# After surveying (OBSERVE → ORIENT)
+.lean/scripts/research.sh phase "$PROBLEM_ID" "ORIENT"
+
+# After attempting proof work (ORIENT → ACT)
+.lean/scripts/research.sh phase "$PROBLEM_ID" "ACT"
+
+# After completing the proof (ACT → COMPLETED)
+.lean/scripts/research.sh phase "$PROBLEM_ID" "COMPLETED"
+```
+
+**Phase meanings:**
+- **OBSERVE**: Surveyed only — wrote knowledge.md but no proof attempt
+- **ORIENT**: Analyzed feasibility, identified approach, may have partial infrastructure
+- **ACT**: Actively writing Lean code, proof in progress
+- **COMPLETED**: Proof compiles, PR merged
+
+**Do NOT leave problems stuck at OBSERVE** — if you did any analysis beyond a basic survey, advance to ORIENT. If you wrote any Lean code, advance to ACT.
+
 ### Step 6: Release Lock & Submit Overnight Jobs
 
 ```bash
@@ -240,8 +264,8 @@ When pool is empty, we scout for new knowledge and attempt if promising.
 .lean/scripts/knowledge-scores.sh --revisit
 ```
 
-**Selection priority:**
-1. Lowest knowledge score (EMPTY > WEAK > MODERATE > RICH)
+**Selection priority (DEPTH OVER BREADTH):**
+1. Highest knowledge score (MODERATE > RICH > WEAK > EMPTY)
 2. Within same knowledge tier: `in-progress` > `surveyed` > `skipped`
 
 ### Step 2: Read Context

--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -128,14 +128,20 @@ Integrate any completed proofs before selecting new work.
 $REPO_ROOT/scripts/research/claim-problem.sh claim-random
 ```
 
-This atomically claims a random available problem based on knowledge score priority.
+This atomically claims a random available problem using **depth-first priority**: problems with MORE existing knowledge (MODERATE/RICH) are selected first, so you advance existing work toward proof rather than always grabbing fresh problems.
 
 The claim script will output:
 ```
+Selected weak-goldbach (45 available, tier: MODERATE+ (depth-first), 19 in tier)
 Claimed weak-goldbach by researcher-1
-Knowledge score: 3 (WEAK - high priority)
-Status: in-progress
+Knowledge score: 8 (MODERATE)
 ```
+
+**When you receive a problem with existing knowledge:**
+- Read `research/problems/<id>/knowledge.md` for prior session notes
+- Read `src/data/research/problems/<id>.json` for accumulated insights
+- Build on prior work — don't re-survey from scratch
+- Advance the phase (OBSERVE → ORIENT → ACT → COMPLETED)
 
 **IMPORTANT:** After claiming, work in your worktree:
 ```bash

--- a/scripts/research/claim-problem.sh
+++ b/scripts/research/claim-problem.sh
@@ -160,12 +160,12 @@ is_claim_expired() {
 get_knowledge_score() {
     local problem_id="$1"
     local problem_file="$PROBLEMS_DIR/${problem_id}.json"
-    
+
     if [[ ! -f "$problem_file" ]]; then
         echo "0"  # No file = EMPTY knowledge
         return
     fi
-    
+
     local score
     score=$(jq -r '
         (.knowledge.insights // [] | length) +
@@ -173,7 +173,7 @@ get_knowledge_score() {
         (.knowledge.mathlibGaps // [] | length) +
         (.knowledge.nextSteps // [] | length)
     ' "$problem_file" 2>/dev/null || echo "0")
-    
+
     echo "$score"
 }
 
@@ -269,22 +269,22 @@ EOF
     fi
 }
 
-# Claim a random problem (prioritized by knowledge score)
+# Claim a random problem (depth-first: prefer higher knowledge scores)
 claim_random_problem() {
-    # Get available problems sorted by knowledge score (ascending)
+    # Get available problems with knowledge scores
     local available=()
     local scores=()
-    
+
     while IFS= read -r problem_id; do
         [[ -z "$problem_id" ]] && continue
-        
+
         # Skip if currently claimed (and not expired)
         local lock_dir="$CLAIMS_DIR/${problem_id}.lock"
         local claim_file="$CLAIMS_DIR/${problem_id}.json"
         if [[ -d "$lock_dir" ]] && ! is_claim_expired "$claim_file"; then
             continue
         fi
-        
+
         local score
         score=$(get_knowledge_score "$problem_id")
         available+=("$problem_id")
@@ -296,27 +296,44 @@ claim_random_problem() {
         return 1
     fi
 
-    # Find problems with lowest knowledge score
-    local min_score=999999
-    for score in "${scores[@]}"; do
-        if [[ $score -lt $min_score ]]; then
-            min_score=$score
-        fi
-    done
+    # DEPTH OVER BREADTH: Prefer problems with MORE knowledge (closer to proof)
+    # Tier 1 (highest priority): MODERATE+ (score >= 6) — advance existing work
+    # Tier 2: WEAK (score 1-5) — continue started surveys
+    # Tier 3 (lowest priority): EMPTY (score 0) — fresh problems only when nothing else
+    local tier1=()  # MODERATE+ (>= 6)
+    local tier2=()  # WEAK (1-5)
+    local tier3=()  # EMPTY (0)
 
-    # Collect all problems with min score
-    local candidates=()
     for i in "${!available[@]}"; do
-        if [[ ${scores[$i]} -eq $min_score ]]; then
-            candidates+=("${available[$i]}")
+        local s=${scores[$i]}
+        if [[ $s -ge 6 ]]; then
+            tier1+=("${available[$i]}")
+        elif [[ $s -ge 1 ]]; then
+            tier2+=("${available[$i]}")
+        else
+            tier3+=("${available[$i]}")
         fi
     done
 
-    # Pick random from candidates with lowest score
+    # Select from highest-priority non-empty tier
+    local candidates=()
+    local tier_name=""
+    if [[ ${#tier1[@]} -gt 0 ]]; then
+        candidates=("${tier1[@]}")
+        tier_name="MODERATE+ (depth-first)"
+    elif [[ ${#tier2[@]} -gt 0 ]]; then
+        candidates=("${tier2[@]}")
+        tier_name="WEAK (continue survey)"
+    else
+        candidates=("${tier3[@]}")
+        tier_name="EMPTY (fresh problem)"
+    fi
+
+    # Pick random from selected tier
     local random_index=$((RANDOM % ${#candidates[@]}))
     local selected="${candidates[$random_index]}"
 
-    echo "Selected $selected (${#available[@]} available, ${#candidates[@]} with lowest knowledge)"
+    echo "Selected $selected (${#available[@]} available, tier: $tier_name, ${#candidates[@]} in tier)"
 
     # Claim it
     claim_problem "$selected"
@@ -341,6 +358,38 @@ release_problem() {
 update_problem_status() {
     local problem_id="$1"
     local new_status="$2"
+
+    # Quality gate for graduation to "completed"
+    if [[ "$new_status" == "completed" ]] && [[ "${FORCE_COMPLETE:-}" != "1" ]]; then
+        local problem_file="$PROBLEMS_DIR/${problem_id}.json"
+        local gate_passed=true
+
+        if [[ -f "$problem_file" ]]; then
+            # Check for non-empty progressSummary
+            local summary
+            summary=$(jq -r '.knowledge.progressSummary // ""' "$problem_file" 2>/dev/null)
+            if [[ -z "$summary" ]]; then
+                echo "Quality gate: missing progressSummary" >&2
+                gate_passed=false
+            fi
+
+            # Check for at least 3 items across insights + builtItems
+            local item_count
+            item_count=$(jq '(.knowledge.insights // [] | length) + (.knowledge.builtItems // [] | length)' "$problem_file" 2>/dev/null || echo "0")
+            if [[ "$item_count" -lt 3 ]]; then
+                echo "Quality gate: only $item_count items in insights+builtItems (need >= 3)" >&2
+                gate_passed=false
+            fi
+        else
+            echo "Quality gate: no problem file found at $problem_file" >&2
+            gate_passed=false
+        fi
+
+        if [[ "$gate_passed" == "false" ]]; then
+            echo "Graduation blocked — auto-downgrading to 'surveyed' (bypass with FORCE_COMPLETE=1)" >&2
+            new_status="surveyed"
+        fi
+    fi
 
     _update_problem_status_inner() {
         local tmp_file
@@ -511,7 +560,7 @@ Provides atomic claiming for parallel research agents.
 
 Commands:
   claim <problem-id>         Claim a specific problem
-  claim-random               Claim random problem (knowledge-prioritized)
+  claim-random               Claim random problem (depth-first priority)
   release <problem-id>       Release a claimed problem
   update <problem-id> <status>  Update problem status in pool
   extend <problem-id>        Extend claim TTL
@@ -520,18 +569,20 @@ Commands:
   help                       Show this help
 
 Environment Variables:
-  RESEARCHER_ID   Agent identifier (default: researcher-PID)
-  CLAIM_TTL       Claim time-to-live in minutes (default: 90)
+  RESEARCHER_ID    Agent identifier (default: researcher-PID)
+  CLAIM_TTL        Claim time-to-live in minutes (default: 90)
+  FORCE_COMPLETE   Set to 1 to bypass graduation quality gate
 
-Knowledge Tiers (lower = higher priority):
-  EMPTY (0)      - No knowledge yet
-  WEAK (1-5)     - Little exploration
-  MODERATE (6-15) - Some work done
-  RICH (16+)     - Well explored
+Knowledge Tiers (DEPTH OVER BREADTH - higher = higher priority):
+  MODERATE (6-15) - Highest priority: advance toward proof
+  RICH (16+)      - Highest priority: near completion
+  WEAK (1-5)      - Medium: continue started survey
+  EMPTY (0)       - Lowest: fresh problems last
 
 Examples:
   RESEARCHER_ID=agent-1 ./claim-problem.sh claim-random
   RESEARCHER_ID=agent-1 ./claim-problem.sh update weak-goldbach in-progress
+  FORCE_COMPLETE=1 ./claim-problem.sh update problem-id completed
   ./claim-problem.sh status
 EOF
         ;;

--- a/scripts/research/launch-seeker.sh
+++ b/scripts/research/launch-seeker.sh
@@ -16,7 +16,7 @@
 #
 # Environment:
 #   SEEKER_INTERVAL - Interval in minutes between checks (default: 15)
-#   SEEKER_THRESHOLD - Minimum available problems before triggering (default: 5)
+#   SEEKER_THRESHOLD - Minimum available problems before triggering (default: 15)
 
 set -euo pipefail
 
@@ -41,7 +41,7 @@ SIGNALS_DIR="$REPO_ROOT/.loom/signals"
 SESSION_NAME="seeker-agent"
 LOG_FILE="$LOGS_DIR/seeker.log"
 INTERVAL="${SEEKER_INTERVAL:-15}"
-THRESHOLD="${SEEKER_THRESHOLD:-5}"
+THRESHOLD="${SEEKER_THRESHOLD:-15}"
 CANDIDATE_POOL="$REPO_ROOT/.lean/state/candidate-pool.json"
 WORKTREE_PATH="$WORKTREES_DIR/seeker"
 BRANCH_NAME="feature/seeker"


### PR DESCRIPTION
## Summary
- Invert claim selection: researchers now pick problems with MORE existing knowledge first (MODERATE+ → WEAK → EMPTY), advancing work toward proofs instead of perpetually surveying fresh problems
- Add graduation quality gate: completing requires progressSummary + >= 3 insights/builtItems (bypass: `FORCE_COMPLETE=1`)
- Add mandatory phase advancement step (OBSERVE → ORIENT → ACT → COMPLETED)
- Raise seeker threshold from 5 to 15 to keep pool fed

## Context
320 of 540 problems stuck at OBSERVE phase — researchers kept grabbing fresh problems instead of advancing existing work. Only 1 of 331 active problems had an actual `.lean` file.

## Pool impact
185 prematurely-graduated problems downgraded from "completed" to "surveyed" (local state, not in this diff). Only 3 legitimately passed the new quality gate.

## Test plan
- [ ] `RESEARCHER_ID=test scripts/research/claim-problem.sh claim-random` selects MODERATE+ tier
- [ ] `scripts/research/claim-problem.sh update some-empty-problem completed` auto-downgrades to surveyed
- [ ] `FORCE_COMPLETE=1 scripts/research/claim-problem.sh update some-problem completed` succeeds
- [ ] `grep THRESHOLD scripts/research/launch-seeker.sh` shows default 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)