### PR TITLE
Research: szemeredi-theorem - Axiom reduction to k>=4 only

### DIFF
--- a/proofs/Proofs/SzemerediTheorem.lean
+++ b/proofs/Proofs/SzemerediTheorem.lean
@@ -4,12 +4,13 @@
 Every subset of natural numbers with positive upper density contains
 arbitrarily long arithmetic progressions.
 
-**Status**: COMPLETED for k=3 (Roth's theorem via Mathlib)
+**Status**: Full theorem proved by cases (axiom reduced to k≥4 only)
 - General k-AP definition and formal statement
-- Trivial cases k=1,2 proved
+- Trivial cases k=1,2 proved (including density versions)
 - k=3 (Roth's theorem): PROVED using Mathlib's corner theorem chain
 - Equivalence between our IsAPFree and Mathlib's ThreeAPFree
-- k≥4: Still requires hypergraph regularity (stated as axiom)
+- k≥4: Axiomatized (requires hypergraph regularity, not in Mathlib)
+- Full SzemerediTheorem assembled from k=1,2,3 proofs + k≥4 axiom
 
 **What's in Mathlib already**:
 - `AddSalemSpencer`: Sets without 3-term APs (Mathlib.Combinatorics.Additive.SalemSpencer)
@@ -106,24 +107,22 @@ theorem szemeredi_k2 (S : Finset ℕ) (h : S.card ≥ 2) : hasAPOfLengthFinset S
       exact ha
 
 /-!
-## Full Theorem (Axiom)
+## Axiom Reduction
 
-The full proof for k ≥ 3 requires:
-1. k=3: Roth's theorem (in Mathlib via corners theorem)
-2. k≥4: Hypergraph regularity (NOT in Mathlib)
+The full Szemerédi theorem holds for all k ≥ 1:
+- k=1: Trivial (any nonempty set has a 1-AP)
+- k=2: Trivial (any set with ≥2 elements has a 2-AP)
+- k=3: Roth's theorem (proved in Mathlib via corners chain)
+- k≥4: Requires hypergraph regularity (NOT in Mathlib)
 
-We state the full theorem as an axiom.
+We axiomatize ONLY k ≥ 4 and prove the full theorem by combining all cases.
 -/
 
-/-- The full Szemerédi theorem (1975) -/
-axiom szemeredi_theorem : SzemerediTheorem
-
-/-- Corollary: every dense set contains arbitrarily long APs -/
-theorem dense_set_has_long_ap (k : ℕ) (δ : ℝ) (hk : k ≥ 1) (hδ : δ > 0) :
+/-- Szemerédi's theorem for k ≥ 4 (axiom — requires hypergraph regularity, not in Mathlib) -/
+axiom szemeredi_k_ge_4 : ∀ (k : ℕ) (δ : ℝ), k ≥ 4 → δ > 0 →
     ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ →
       ∀ S : Finset ℕ, S ⊆ Finset.range N → (S.card : ℝ) ≥ δ * N →
-        hasAPOfLengthFinset S k :=
-  szemeredi_theorem k δ hk hδ
+        hasAPOfLengthFinset S k
 
 /-!
 ## Connection to Mathlib's ThreeAPFree
@@ -269,5 +268,68 @@ theorem roth_theorem_via_mathlib : RothTheorem := by
   have hfree : ThreeAPFree (S : Set ℕ) := (threeAPFree_iff_isAPFree S).mpr hnoAP
   -- Apply Mathlib's Roth theorem
   exact roth_3ap_theorem_nat δ hδ hN S hS hcard hfree
+
+/-!
+## Full Theorem (Proved by Cases)
+
+We assemble the full Szemerédi theorem from:
+- k=1: `szemeredi_k1` (trivial)
+- k=2: `szemeredi_k2` (trivial)
+- k=3: `roth_theorem_via_mathlib` (Mathlib's corners chain)
+- k≥4: `szemeredi_k_ge_4` (axiom)
+-/
+
+/-- k=1 density version: any δ-dense subset of [N] has a 1-AP -/
+theorem szemeredi_k1_density (δ : ℝ) (hδ : δ > 0) :
+    ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ →
+      ∀ S : Finset ℕ, S ⊆ Finset.range N → (S.card : ℝ) ≥ δ * N →
+        hasAPOfLengthFinset S 1 := by
+  use 1
+  intro N hN S _ hcard
+  have hN_pos : (0 : ℝ) < ↑N := by exact_mod_cast (show 0 < N by omega)
+  have hcard_pos : 0 < S.card := by
+    by_contra h
+    push_neg at h
+    have : S.card = 0 := Nat.le_zero.mp h
+    rw [this, Nat.cast_zero] at hcard
+    linarith [mul_pos hδ hN_pos]
+  exact szemeredi_k1 (↑S) (Finset.coe_nonempty.mpr (Finset.card_pos.mp hcard_pos))
+
+/-- k=2 density version: any δ-dense subset of [N] has a 2-AP -/
+theorem szemeredi_k2_density (δ : ℝ) (hδ : δ > 0) :
+    ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ →
+      ∀ S : Finset ℕ, S ⊆ Finset.range N → (S.card : ℝ) ≥ δ * N →
+        hasAPOfLengthFinset S 2 := by
+  use ⌈2 / δ⌉₊
+  intro N hN S _ hcard
+  have hN_ge : (N : ℝ) ≥ 2 / δ := by
+    calc (N : ℝ) ≥ (⌈2 / δ⌉₊ : ℝ) := by exact_mod_cast hN
+    _ ≥ 2 / δ := Nat.le_ceil (2 / δ)
+  have h2 : S.card ≥ 2 := by
+    suffices h : (2 : ℝ) ≤ (S.card : ℝ) by exact_mod_cast h
+    calc (2 : ℝ) = δ * (2 / δ) := by field_simp
+    _ ≤ δ * ↑N := by nlinarith
+    _ ≤ ↑S.card := hcard
+  exact szemeredi_k2 S h2
+
+/-- **Szemerédi's Theorem** (proved by cases).
+The full theorem, with only k ≥ 4 axiomatized.
+k=1,2 are trivial, k=3 is Roth via Mathlib. -/
+theorem szemeredi_theorem : SzemerediTheorem := by
+  intro k δ hk hδ
+  rcases Nat.lt_or_ge k 4 with hlt | hge
+  · -- k ∈ {1, 2, 3}
+    interval_cases k
+    · exact szemeredi_k1_density δ hδ
+    · exact szemeredi_k2_density δ hδ
+    · exact roth_theorem_via_mathlib δ hδ
+  · exact szemeredi_k_ge_4 k δ hge hδ
+
+/-- Corollary: every dense set contains arbitrarily long APs -/
+theorem dense_set_has_long_ap (k : ℕ) (δ : ℝ) (hk : k ≥ 1) (hδ : δ > 0) :
+    ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ →
+      ∀ S : Finset ℕ, S ⊆ Finset.range N → (S.card : ℝ) ≥ δ * N →
+        hasAPOfLengthFinset S k :=
+  szemeredi_theorem k δ hk hδ
 
 end Szemeredi

--- a/src/data/proofs/szemeredi-theorem/meta.json
+++ b/src/data/proofs/szemeredi-theorem/meta.json
@@ -35,9 +35,10 @@
     ],
     "originalContributions": [
       "General k-AP definition and formal statement",
-      "Trivial cases k=1, k=2 proved directly",
+      "Trivial cases k=1, k=2 proved directly (including density versions)",
       "Equivalence between IsAPFree and ThreeAPFree",
       "Roth's theorem via Mathlib's corners chain",
+      "Axiom reduction: full theorem proved from k=1,2,3 proofs + k>=4 axiom",
       "Framework for k >= 4 (requires hypergraph regularity)"
     ],
     "dateAdded": "12/31/25"
@@ -45,7 +46,7 @@
   "overview": {
     "historicalContext": "Szemeredi's theorem is one of the crown jewels of combinatorics. The progression of proofs reflects major developments:\n\n- 1936: Erdos-Turan conjecture formulated\n- 1953: Roth proves k=3 (analytic method)\n- 1969: Szemeredi proves k=4 (combinatorial tour de force)\n- 1975: Szemeredi proves general case (regularity lemma)\n- 1977: Furstenberg proves via ergodic theory\n- 2001: Gowers proves with improved bounds (Fourier analysis)\n\nThe regularity lemma, developed for this proof, became a fundamental tool in combinatorics.",
     "problemStatement": "**Szemeredi's Theorem (1975)**: For any k >= 1 and delta > 0, there exists N_0 such that any subset of {1,...,N} with at least delta*N elements contains a k-term arithmetic progression.\n\n**k-term AP**: A sequence a, a+d, a+2d, ..., a+(k-1)d with d > 0.\n\n**Special Cases**:\n- k=1: Trivial (any element is a 1-AP)\n- k=2: Trivial (any two distinct elements form a 2-AP)\n- k=3: Roth's theorem (1953) - PROVED in Mathlib\n- k>=4: Requires hypergraph regularity (not in Mathlib)",
-    "proofStrategy": "**Mathlib's Chain for k=3**:\n\nRegularity Lemma -> Triangle Removal -> Corners Theorem -> Roth's Theorem\n\nThis formalization:\n1. Defines general k-AP predicate `HasAPOfLength`\n2. Proves trivial cases k=1, k=2 directly\n3. Proves equivalence between our `IsAPFree` and Mathlib's `ThreeAPFree`\n4. Applies `roth_3ap_theorem_nat` for the k=3 case\n\nThe full theorem (k >= 4) is stated as an axiom.",
+    "proofStrategy": "**Mathlib's Chain for k=3**:\n\nRegularity Lemma -> Triangle Removal -> Corners Theorem -> Roth's Theorem\n\nThis formalization:\n1. Defines general k-AP predicate `HasAPOfLength`\n2. Proves trivial cases k=1, k=2 directly (including density versions)\n3. Proves equivalence between our `IsAPFree` and Mathlib's `ThreeAPFree`\n4. Applies `roth_3ap_theorem_nat` for the k=3 case\n5. Assembles full theorem by cases: k=1,2,3 proved + k>=4 axiom\n\nOnly k >= 4 remains axiomatized (requires hypergraph regularity).",
     "keyInsights": [
       "The regularity lemma decomposed sparse graphs into 'regular' pieces",
       "Corners theorem bridges 2D grid patterns to 1D progressions",
@@ -81,10 +82,17 @@
       "startLine": 188,
       "endLine": 271,
       "summary": "The k=3 case via Mathlib's roth_3ap_theorem_nat."
+    },
+    {
+      "id": "axiom-reduction",
+      "title": "Full Theorem (Proved by Cases)",
+      "startLine": 273,
+      "endLine": 335,
+      "summary": "Assembles full SzemerediTheorem from k=1,2 density lemmas, k=3 Roth, and k>=4 axiom."
     }
   ],
   "conclusion": {
-    "summary": "This formalization proves Szemeredi's theorem for the important k=3 case (Roth's theorem) by connecting our definitions to Mathlib's infrastructure. The key achievement is the equivalence `threeAPFree_iff_isAPFree`, which allows us to apply Mathlib's complete proof chain.\n\nThe full theorem (k >= 4) remains as an axiom, awaiting formalization of hypergraph regularity in Mathlib.",
+    "summary": "This formalization proves Szemeredi's theorem by combining proved cases (k=1,2 trivial, k=3 Roth via Mathlib) with an axiom for k>=4. The key achievements are: the equivalence `threeAPFree_iff_isAPFree` connecting to Mathlib, density lemmas for k=1,2, and axiom reduction from the full theorem to just k>=4.\n\nOnly k >= 4 remains axiomatized, awaiting hypergraph regularity in Mathlib.",
     "implications": "**Theoretical Significance**\n\nSzemeredi's theorem has deep connections to:\n1. **Ergodic Theory**: Furstenberg's proof initiated the field of ergodic Ramsey theory\n2. **Fourier Analysis**: Gowers' proof introduced influential new techniques\n3. **Regularity Lemma**: Became a fundamental tool in graph theory\n\n**The Green-Tao Theorem**\n\nBuilding on Szemeredi, Green and Tao (2004) proved the primes contain arbitrarily long arithmetic progressions. This is one of the most celebrated results in 21st century mathematics.",
     "openQuestions": [
       "What is the optimal bound for Szemeredi's theorem?",

--- a/src/data/research/problems/szemeredi-theorem.json
+++ b/src/data/research/problems/szemeredi-theorem.json
@@ -20,7 +20,7 @@
   "currentState": {
     "phase": "COMPLETED",
     "since": "2025-12-31T16:00:00-08:00",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "",
     "blockers": [],
     "nextAction": "",
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "PROGRESS: Axiom reduction - replaced blanket szemeredi_theorem axiom with szemeredi_k_ge_4 (k>=4 only). Full theorem now proved by cases: k=1,2 trivial density lemmas + k=3 Roth via Mathlib + k>=4 axiom.",
     "builtItems": [
       {
         "name": "HasAPOfLength S k",
@@ -67,6 +67,26 @@
         "name": "szemeredi_theorem",
         "description": "full Szemerédi theorem as axiom",
         "proven": true
+      },
+      {
+        "name": "szemeredi_k_ge_4",
+        "description": "weaker axiom covering only k>=4 case",
+        "proven": false
+      },
+      {
+        "name": "szemeredi_k1_density",
+        "description": "k=1 density version for SzemerediTheorem",
+        "proven": true
+      },
+      {
+        "name": "szemeredi_k2_density",
+        "description": "k=2 density version using Nat.ceil bound",
+        "proven": true
+      },
+      {
+        "name": "szemeredi_theorem (proved)",
+        "description": "full theorem assembled from k=1,2,3 proofs + k>=4 axiom",
+        "proven": true
       }
     ],
     "insights": [
@@ -76,7 +96,10 @@
       "SzemerediTheorem",
       "szemeredi_k1",
       "szemeredi_k2",
-      "szemeredi_theorem"
+      "szemeredi_theorem",
+      "Axiom reduced: szemeredi_theorem was a blanket axiom, now proved from szemeredi_k_ge_4",
+      "k=1 density: N0=1 suffices since any delta-dense set with N>=1 is nonempty",
+      "k=2 density: N0=ceil(2/delta) ensures delta*N >= 2 so S.card >= 2"
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
- Reduced axiom from full `szemeredi_theorem` to `szemeredi_k_ge_4` (k≥4 only)
- Proved density lemmas for k=1 (N₀=1) and k=2 (N₀=⌈2/δ⌉₊)
- Assembled full `SzemerediTheorem` by cases: k=1,2 trivial + k=3 Roth via Mathlib + k≥4 axiom

## Progress
- **Axiom before**: `axiom szemeredi_theorem : SzemerediTheorem` (covers all k≥1)
- **Axiom after**: `axiom szemeredi_k_ge_4` (covers only k≥4)
- **New theorems**: `szemeredi_k1_density`, `szemeredi_k2_density`, `szemeredi_theorem` (now proved)
- Build verified via Docker

## Findings
- k=1 density: N₀=1 suffices since δ·N > 0 for N≥1, giving S nonempty
- k=2 density: N₀=⌈2/δ⌉₊ ensures δ·N ≥ 2, giving S.card ≥ 2
- `interval_cases k` cleanly handles the case split with 1 ≤ k < 4

## Status
**Outcome**: completed
**Next Steps**: k≥4 requires hypergraph regularity (not in Mathlib)

🤖 Generated by researcher-7