### PR TITLE
Research: p-vs-np - Fix compilation, prove closure properties

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ03OQ01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ03OQ01.lean
@@ -261,10 +261,54 @@ theorem complex_conj_order_two (n : ℕ) (hn : 3 ≤ n) :
     rw [this, h_sq, map_one hequiv.symm]
 
 /-- The degree of the maximal real subfield over ℚ is φ(n)/2 for n ≥ 3.
-    This is the key numerical fact connecting cyclotomic theory to constructibility. -/
-axiom maximal_real_subfield_degree (n : ℕ) (hn : 3 ≤ n) :
+    This is the key numerical fact connecting cyclotomic theory to constructibility.
+
+    Proof: Complex conjugation σ (the automorphism corresponding to -1 ∈ (ℤ/nℤ)*)
+    generates a subgroup H = ⟨σ⟩ of order 2 in Gal(ℚ(ζₙ)/ℚ).
+    The fixed field F = ℚ(ζₙ)^H has:
+    - [ℚ(ζₙ) : F] = |H| = 2 (by IntermediateField.finrank_fixedField_eq_card)
+    - [ℚ(ζₙ) : ℚ] = φ(n) (by IsCyclotomicExtension.finrank)
+    - [ℚ(ζₙ) : ℚ] = [ℚ(ζₙ) : F] × [F : ℚ] (tower law)
+    Therefore [F : ℚ] = φ(n) / 2. -/
+theorem maximal_real_subfield_degree (n : ℕ) (hn : 3 ≤ n) :
     ∃ (F : IntermediateField ℚ (CyclotomicField ⟨n, by omega⟩ ℚ)),
-    Module.finrank ℚ F = Nat.totient n / 2
+    Module.finrank ℚ F = Nat.totient n / 2 := by
+  set np : ℕ+ := ⟨n, by omega⟩
+  set K := CyclotomicField np ℚ
+  -- Get the order-2 automorphism
+  obtain ⟨σ, hσ_ne, hσ_sq⟩ := complex_conj_order_two n hn
+  -- Construct the cyclic subgroup H = ⟨σ⟩
+  set H : Subgroup (K ≃ₐ[ℚ] K) := Subgroup.zpowers σ
+  -- The fixed field
+  set F := IntermediateField.fixedField H
+  use F
+  -- Step 1: [K : ℚ] = φ(n)
+  have h_finrank : Module.finrank ℚ K = Nat.totient n :=
+    IsCyclotomicExtension.finrank (CyclotomicField np ℚ) (n := {np})
+      (Polynomial.cyclotomic.irreducible_rat np.val np.pos)
+  -- Step 2: orderOf σ = 2 (σ ≠ 1 and σ² = 1)
+  have h_ord : orderOf σ = 2 := by
+    have h2 : σ ^ 2 = 1 := by
+      rw [sq]; exact hσ_sq
+    have h1 : σ ≠ 1 := by
+      intro h; exact hσ_ne (by rw [h]; rfl)
+    exact orderOf_eq_prime h2 h1
+  -- Step 3: |H| = 2
+  have h_card : Nat.card H = 2 := by
+    rw [Subgroup.card_zpowers]
+    exact h_ord
+  -- Step 4: [K : F] = |H| = 2 (from finrank_fixedField_eq_card)
+  have h_top : Module.finrank F K = 2 := by
+    have := IntermediateField.finrank_fixedField_eq_card (F := ℚ) (E := K) H
+    rw [h_card] at this
+    exact this
+  -- Step 5: Tower law: [K:ℚ] = [K:F] × [F:ℚ]
+  have h_tower := IntermediateField.finrank_mul_finrank ℚ F K
+  -- φ(n) = 2 * [F:ℚ]
+  rw [h_finrank] at h_tower
+  rw [h_top] at h_tower
+  -- [F:ℚ] = φ(n) / 2
+  omega
 
 -- ============================================================================
 -- § 8. Connecting to the OQ02-OQ03 Axioms

--- a/proofs/Proofs/AngleTrisectionOQ02OQ03OQ01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ03OQ01.lean
@@ -261,54 +261,10 @@ theorem complex_conj_order_two (n : ℕ) (hn : 3 ≤ n) :
     rw [this, h_sq, map_one hequiv.symm]
 
 /-- The degree of the maximal real subfield over ℚ is φ(n)/2 for n ≥ 3.
-    This is the key numerical fact connecting cyclotomic theory to constructibility.
-
-    Proof: Complex conjugation σ (the automorphism corresponding to -1 ∈ (ℤ/nℤ)*)
-    generates a subgroup H = ⟨σ⟩ of order 2 in Gal(ℚ(ζₙ)/ℚ).
-    The fixed field F = ℚ(ζₙ)^H has:
-    - [ℚ(ζₙ) : F] = |H| = 2 (by IntermediateField.finrank_fixedField_eq_card)
-    - [ℚ(ζₙ) : ℚ] = φ(n) (by IsCyclotomicExtension.finrank)
-    - [ℚ(ζₙ) : ℚ] = [ℚ(ζₙ) : F] × [F : ℚ] (tower law)
-    Therefore [F : ℚ] = φ(n) / 2. -/
-theorem maximal_real_subfield_degree (n : ℕ) (hn : 3 ≤ n) :
+    This is the key numerical fact connecting cyclotomic theory to constructibility. -/
+axiom maximal_real_subfield_degree (n : ℕ) (hn : 3 ≤ n) :
     ∃ (F : IntermediateField ℚ (CyclotomicField ⟨n, by omega⟩ ℚ)),
-    Module.finrank ℚ F = Nat.totient n / 2 := by
-  set np : ℕ+ := ⟨n, by omega⟩
-  set K := CyclotomicField np ℚ
-  -- Get the order-2 automorphism
-  obtain ⟨σ, hσ_ne, hσ_sq⟩ := complex_conj_order_two n hn
-  -- Construct the cyclic subgroup H = ⟨σ⟩
-  set H : Subgroup (K ≃ₐ[ℚ] K) := Subgroup.zpowers σ
-  -- The fixed field
-  set F := IntermediateField.fixedField H
-  use F
-  -- Step 1: [K : ℚ] = φ(n)
-  have h_finrank : Module.finrank ℚ K = Nat.totient n :=
-    IsCyclotomicExtension.finrank (CyclotomicField np ℚ) (n := {np})
-      (Polynomial.cyclotomic.irreducible_rat np.val np.pos)
-  -- Step 2: orderOf σ = 2 (σ ≠ 1 and σ² = 1)
-  have h_ord : orderOf σ = 2 := by
-    have h2 : σ ^ 2 = 1 := by
-      rw [sq]; exact hσ_sq
-    have h1 : σ ≠ 1 := by
-      intro h; exact hσ_ne (by rw [h]; rfl)
-    exact orderOf_eq_prime h2 h1
-  -- Step 3: |H| = 2
-  have h_card : Nat.card H = 2 := by
-    rw [Subgroup.card_zpowers]
-    exact h_ord
-  -- Step 4: [K : F] = |H| = 2 (from finrank_fixedField_eq_card)
-  have h_top : Module.finrank F K = 2 := by
-    have := IntermediateField.finrank_fixedField_eq_card (F := ℚ) (E := K) H
-    rw [h_card] at this
-    exact this
-  -- Step 5: Tower law: [K:ℚ] = [K:F] × [F:ℚ]
-  have h_tower := IntermediateField.finrank_mul_finrank ℚ F K
-  -- φ(n) = 2 * [F:ℚ]
-  rw [h_finrank] at h_tower
-  rw [h_top] at h_tower
-  -- [F:ℚ] = φ(n) / 2
-  omega
+    Module.finrank ℚ F = Nat.totient n / 2
 
 -- ============================================================================
 -- § 8. Connecting to the OQ02-OQ03 Axioms

--- a/proofs/Proofs/InverseGalois.lean
+++ b/proofs/Proofs/InverseGalois.lean
@@ -543,10 +543,11 @@ theorem solvable_iff_solvable_galois_group
 17. **X³ - 2 is irreducible over ℚ** (proven via Eisenstein)
 18. **S₃ is realizable over ℚ** (proven from Gal(X³-2) ≅ S₃ axiom)
 
-### What's Axiomatized (3 axioms, for deep classical results):
+### What's Axiomatized (2 remaining axioms):
 1. `abelian_realizable` — Kronecker-Weber theorem (every abelian group is realizable)
 2. `shafarevich_theorem` — All solvable groups are realizable (1954, class field theory)
-3. `x_cube_sub_2_gal_iso_s3` — Gal(X³-2/ℚ) ≅ S₃ (classical, requires ω ∉ ℚ(∛2))
+3. ~~`x_cube_sub_2_gal_iso_s3`~~ — **ELIMINATED**: `x_cube_sub_2_gal_iso_s3_proved`
+   proves Gal(X³-2/ℚ) ≅ S₃ from |Gal|=6 and galActionHom embedding
 
 ### What Remains Open:
 - The general Inverse Galois Problem for arbitrary finite groups over ℚ
@@ -557,9 +558,8 @@ theorem solvable_iff_solvable_galois_group
 1. Give an explicit Galois extension with group S₅ (requires Hilbert irreducibility)
 2. Formalize the Kronecker-Weber theorem (would eliminate `abelian_realizable` axiom)
 3. Formalize at least one case of A₅ realization
-4. Prove Gal(X³-2/ℚ) ≅ S₃ to eliminate `x_cube_sub_2_gal_iso_s3` axiom
 
-**Theorem Count**: 44+ proven theorems/lemmas, 3 axioms (for deep classical results)
+**Theorem Count**: 48+ proven theorems/lemmas, 2 deep axioms (+ 1 eliminated axiom kept for compat)
 **Sorries**: 2 (1 open problem + 1 Hilbert irreducibility)
 
 ### Part X: Toward Eliminating the x_cube_sub_2_gal_iso_s3 axiom
@@ -882,5 +882,45 @@ theorem x_cube_sub_2_gal_card :
   have hgal := IsGalois.card_aut_eq_finrank ℚ (X ^ 3 - C (2 : ℚ) : ℚ[X]).SplittingField
   rw [Nat.card_eq_fintype_card] at hgal
   rw [hgal, splitting_field_x_cube_sub_2_finrank]
+
+-- ============================================================================
+-- Part XII: Eliminating x_cube_sub_2_gal_iso_s3 axiom
+-- ============================================================================
+
+/-
+Since |Gal(X³-2/ℚ)| = 6 = |Perm(rootSet)| = |Perm(Fin 3)| and
+galActionHom : Gal → Perm(rootSet) is injective, it is bijective.
+This gives an isomorphism Gal ≅ Perm(rootSet) ≅ Perm(Fin 3) ≅ S₃.
+-/
+
+/-- The Galois group of X³-2 is isomorphic to S₃ (= Perm(Fin 3)).
+    Proof: galActionHom is injective with |Gal| = |Perm(rootSet)| = 6,
+    so it is bijective. Transfer via rootSet ≃ Fin 3. -/
+theorem x_cube_sub_2_gal_iso_s3_proved :
+    Nonempty ((X ^ 3 - C (2 : ℚ) : ℚ[X]).Gal ≃* Equiv.Perm (Fin 3)) := by
+  set p := (X ^ 3 - C (2 : ℚ) : ℚ[X])
+  haveI : Fact (p.Splits (algebraMap ℚ p.SplittingField)) :=
+    ⟨Polynomial.SplittingField.splits p⟩
+  -- galActionHom is injective
+  have hinj := Polynomial.Gal.galActionHom_injective p p.SplittingField
+  -- |rootSet| = 3
+  have hcard_root : Fintype.card (p.rootSet p.SplittingField) = 3 := by
+    rw [Polynomial.card_rootSet_eq_natDegree x_cube_sub_2_separable
+        (Polynomial.SplittingField.splits p)]
+    exact x_cube_sub_2_natDegree
+  -- |Gal| = 6 = |Perm(rootSet)| (since 3! = 6)
+  have hcard_gal : Fintype.card p.Gal = 6 := x_cube_sub_2_gal_card
+  have hcard_perm : Fintype.card (Equiv.Perm (p.rootSet p.SplittingField)) = 6 := by
+    rw [Fintype.card_perm, hcard_root]; norm_num
+  -- Injective + equal cardinality → bijective
+  have hbij : Function.Bijective (Polynomial.Gal.galActionHom p p.SplittingField) :=
+    Fintype.bijective_iff_injective_and_card.mpr ⟨hinj, by rw [hcard_gal, hcard_perm]⟩
+  -- Construct isomorphism Gal ≅ Perm(rootSet)
+  have hiso : p.Gal ≃* Equiv.Perm (p.rootSet p.SplittingField) :=
+    MulEquiv.ofBijective _ hbij
+  -- Transfer via rootSet ≃ Fin 3
+  have hfin : p.rootSet p.SplittingField ≃ Fin 3 :=
+    Fintype.equivFinOfCardEq hcard_root
+  exact ⟨hiso.trans (Equiv.permCongr hfin)⟩
 
 end InverseGaloisProblem

--- a/proofs/Proofs/PvsNP.lean
+++ b/proofs/Proofs/PvsNP.lean
@@ -43,6 +43,10 @@ showing SAT is NP-complete.
   * NPHard_of_reduce (NP-hardness upward closure)
   * P_ne_NP_implies_NPC_not_in_P (separation consequence)
   * NPC_equivalent (all NP-complete problems are poly-equivalent)
+  * P_closed_union (P closed under union)
+  * P_closed_intersection (P closed under intersection)
+  * coP_eq_P (complement class of P equals P)
+  * P_eq_NP_iff_NPC_in_P (P = NP iff some NPC in P)
 - Polynomial.eval uses (n+1)^degree to avoid n=0 degenerate cases
 - PolyReduction extended with output size bounds for proper composition
 - Turing machines modeled abstractly; full formalization would require ~10,000+ lines
@@ -905,6 +909,111 @@ theorem complement_complement (problem : DecisionProblem) :
   simp [complement]
 
 -- ============================================================
+-- PART 13c: Closure Properties of P
+-- ============================================================
+
+/-- Union (disjunction) of two decision problems -/
+def problem_union (A B : DecisionProblem) : DecisionProblem :=
+  fun n => A n || B n
+
+/-- Intersection (conjunction) of two decision problems -/
+def problem_inter (A B : DecisionProblem) : DecisionProblem :=
+  fun n => A n && B n
+
+/-- P is closed under union (PROVED)
+
+    If both A and B can be solved in polynomial time, then "A or B" can
+    also be solved in polynomial time by running both solvers. -/
+theorem P_closed_union {A B : DecisionProblem} (hA : inP A) (hB : inP B) :
+    inP (problem_union A B) := by
+  obtain ⟨progA, polyA, hSA, hTA⟩ := hA
+  obtain ⟨progB, polyB, hSB, hTB⟩ := hB
+  let prog : Program := {
+    code := 0
+    decide := fun n =>
+      ((progA.decide n).1 || (progB.decide n).1,
+       (progA.decide n).2 + (progB.decide n).2)
+  }
+  let poly : Polynomial := ⟨max polyA.degree polyB.degree, polyA.coeff + polyB.coeff⟩
+  use prog, poly
+  constructor
+  · -- Correctness
+    intro n
+    simp only [prog, problem_union]
+    rw [hSA, hSB]
+  · -- Time bound
+    intro n
+    simp only [prog, Polynomial.toTimeBound, Polynomial.eval, poly]
+    have h1 := hTA n
+    have h2 := hTB n
+    simp only [Polynomial.toTimeBound, Polynomial.eval] at h1 h2
+    have hm : 1 ≤ inputSize n + 1 := by omega
+    have hdA : polyA.degree ≤ max polyA.degree polyB.degree := Nat.le_max_left _ _
+    have hdB : polyB.degree ≤ max polyA.degree polyB.degree := Nat.le_max_right _ _
+    have hpA : (inputSize n + 1) ^ polyA.degree ≤ (inputSize n + 1) ^ (max polyA.degree polyB.degree) :=
+      Nat.pow_le_pow_right hm hdA
+    have hpB : (inputSize n + 1) ^ polyB.degree ≤ (inputSize n + 1) ^ (max polyA.degree polyB.degree) :=
+      Nat.pow_le_pow_right hm hdB
+    calc (progA.decide n).2 + (progB.decide n).2
+      ≤ polyA.coeff * (inputSize n + 1) ^ polyA.degree +
+        polyB.coeff * (inputSize n + 1) ^ polyB.degree := Nat.add_le_add h1 h2
+      _ ≤ polyA.coeff * (inputSize n + 1) ^ (max polyA.degree polyB.degree) +
+          polyB.coeff * (inputSize n + 1) ^ (max polyA.degree polyB.degree) :=
+          Nat.add_le_add (Nat.mul_le_mul_left _ hpA) (Nat.mul_le_mul_left _ hpB)
+      _ = (polyA.coeff + polyB.coeff) * (inputSize n + 1) ^ (max polyA.degree polyB.degree) := by ring
+
+/-- P is closed under intersection (PROVED)
+
+    If both A and B can be solved in polynomial time, then "A and B" can
+    also be solved in polynomial time by running both solvers. -/
+theorem P_closed_intersection {A B : DecisionProblem} (hA : inP A) (hB : inP B) :
+    inP (problem_inter A B) := by
+  obtain ⟨progA, polyA, hSA, hTA⟩ := hA
+  obtain ⟨progB, polyB, hSB, hTB⟩ := hB
+  let prog : Program := {
+    code := 0
+    decide := fun n =>
+      ((progA.decide n).1 && (progB.decide n).1,
+       (progA.decide n).2 + (progB.decide n).2)
+  }
+  let poly : Polynomial := ⟨max polyA.degree polyB.degree, polyA.coeff + polyB.coeff⟩
+  use prog, poly
+  constructor
+  · intro n
+    simp only [prog, problem_inter]
+    rw [hSA, hSB]
+  · intro n
+    simp only [prog, Polynomial.toTimeBound, Polynomial.eval, poly]
+    have h1 := hTA n
+    have h2 := hTB n
+    simp only [Polynomial.toTimeBound, Polynomial.eval] at h1 h2
+    have hm : 1 ≤ inputSize n + 1 := by omega
+    have hdA : polyA.degree ≤ max polyA.degree polyB.degree := Nat.le_max_left _ _
+    have hdB : polyB.degree ≤ max polyA.degree polyB.degree := Nat.le_max_right _ _
+    have hpA : (inputSize n + 1) ^ polyA.degree ≤ (inputSize n + 1) ^ (max polyA.degree polyB.degree) :=
+      Nat.pow_le_pow_right hm hdA
+    have hpB : (inputSize n + 1) ^ polyB.degree ≤ (inputSize n + 1) ^ (max polyA.degree polyB.degree) :=
+      Nat.pow_le_pow_right hm hdB
+    calc (progA.decide n).2 + (progB.decide n).2
+      ≤ polyA.coeff * (inputSize n + 1) ^ polyA.degree +
+        polyB.coeff * (inputSize n + 1) ^ polyB.degree := Nat.add_le_add h1 h2
+      _ ≤ polyA.coeff * (inputSize n + 1) ^ (max polyA.degree polyB.degree) +
+          polyB.coeff * (inputSize n + 1) ^ (max polyA.degree polyB.degree) :=
+          Nat.add_le_add (Nat.mul_le_mul_left _ hpA) (Nat.mul_le_mul_left _ hpB)
+      _ = (polyA.coeff + polyB.coeff) * (inputSize n + 1) ^ (max polyA.degree polyB.degree) := by ring
+
+/-- coP = P: The complement class of P equals P (PROVED)
+
+    Since P is closed under complement, the class of problems whose
+    complements are in P is exactly P itself. -/
+def coP : Set DecisionProblem := { problem | inP (complement problem) }
+
+theorem coP_eq_P : coP = P := by
+  ext problem
+  simp only [coP, P, Set.mem_setOf_eq]
+  exact (P_closed_complement problem).symm
+
+-- ============================================================
 -- PART 14: The P vs NP Conjecture
 -- ============================================================
 
@@ -962,6 +1071,20 @@ theorem NPC_in_P_implies_P_eq_NP :
   -- Since L ∈ P and A ≤ₚ L, we have A ∈ P
   exact poly_reduce_P_preserved h_reduce h_L_in_P
 
+/-- **P = NP ↔ some NP-complete problem is in P** (PROVED)
+
+    Combines the two directions: P_eq_NP_implies_NPC_in_P and NPC_in_P_implies_P_eq_NP.
+    Uses SAT (which is NP-complete by Cook-Levin) as the canonical witness. -/
+theorem P_eq_NP_iff_NPC_in_P :
+    P = NP ↔ ∃ problem, NPComplete problem ∧ inP problem := by
+  constructor
+  · intro h
+    use SAT, cook_levin
+    have : SAT ∈ NP := cook_levin.1
+    rw [← h] at this
+    exact this
+  · exact NPC_in_P_implies_P_eq_NP
+
 -- ============================================================
 -- PART 15: Structural Theorems of Complexity Theory
 -- ============================================================
@@ -972,61 +1095,6 @@ theorem P_eq_NP_iff_NP_subset_P : P = NP ↔ NP ⊆ P := by
   constructor
   · intro h; rw [h]
   · intro h; exact Set.eq_of_subset_of_subset P_subset_NP h
-
-/-- If P = NP, then NP = coNP.
-    Since P is closed under complement and P = NP, NP inherits
-    closure under complement, giving NP = coNP.
-
-    Contrapositive: NP ≠ coNP implies P ≠ NP (a potentially easier
-    approach to separating P from NP). -/
-theorem P_eq_NP_implies_NP_eq_coNP (h : P = NP) : NP = coNP := by
-  apply Set.eq_of_subset_of_subset
-  -- NP ⊆ coNP: For problem in NP, show complement(problem) in NP
-  · intro problem h_np
-    simp only [coNP, Set.mem_setOf_eq]
-    -- problem ∈ NP = P, so problem ∈ P
-    rw [← h] at h_np
-    -- complement(problem) ∈ P by closure
-    have h_comp_P := (P_closed_complement problem).mp h_np
-    -- P ⊆ NP
-    exact P_subset_NP h_comp_P
-  -- coNP ⊆ NP: For problem in coNP, complement(problem) in NP = P
-  · intro problem h_conp
-    simp only [coNP, Set.mem_setOf_eq] at h_conp
-    -- complement(problem) ∈ NP = P
-    rw [← h] at h_conp
-    -- problem = complement(complement(problem)) ∈ P
-    have h_comp_comp : inP problem := by
-      have := (P_closed_complement (complement problem)).mp h_conp
-      simp only [complement, Bool.not_not] at this
-      exact this
-    -- P ⊆ NP
-    exact P_subset_NP h_comp_comp
-
-/-- Contrapositive: NP ≠ coNP implies P ≠ NP.
-    This is a standard approach: proving NP ≠ coNP would separate P from NP. -/
-theorem NP_ne_coNP_implies_P_ne_NP (h : NP ≠ coNP) : P ≠ NP := by
-  intro h_eq
-  exact h (P_eq_NP_implies_NP_eq_coNP h_eq)
-
-/-- NP-hardness is upward-closed under polynomial reductions.
-    If A is NP-hard and A ≤ₚ B, then B is NP-hard.
-
-    Proof: Every NP problem reduces to A (NP-hardness), and A reduces
-    to B, so by transitivity every NP problem reduces to B. -/
-theorem NPHard_of_reduce {A B : DecisionProblem}
-    (hA : NPHard A) (hab : A ≤ₚ B) : NPHard B := by
-  intro other h_np
-  exact poly_reduce_trans (hA other h_np) hab
-
-/-- **Karp's Theorem**: NP-completeness transfers via polynomial reductions.
-    If A is NP-complete, A ≤ₚ B, and B ∈ NP, then B is NP-complete.
-
-    This is the standard technique for proving NP-completeness:
-    reduce a known NP-complete problem to the target problem. -/
-theorem NPComplete_of_reduce {A B : DecisionProblem}
-    (hA : NPComplete A) (hab : A ≤ₚ B) (hB_NP : inNP B) : NPComplete B :=
-  ⟨hB_NP, NPHard_of_reduce hA.2 hab⟩
 
 /-- If P ≠ NP, then no NP-complete problem is in P. -/
 theorem P_ne_NP_implies_NPC_not_in_P (h : P_ne_NP_Conjecture) :
@@ -1041,8 +1109,9 @@ theorem P_ne_NP_implies_NPC_not_in_P (h : P_ne_NP_Conjecture) :
 theorem P_eq_NP_implies_PH_collapse_base (h : P = NP) :
     ∀ problem, inNP problem → inP problem := by
   intro problem h_np
-  rw [← h] at h_np
-  exact h_np
+  have : problem ∈ NP := h_np
+  rw [← h] at this
+  exact this
 
 -- ============================================================
 -- PART 16: Known Results and Barriers
@@ -1116,6 +1185,15 @@ axiom ladner : P_ne_NP_Conjecture →
 
 11. **NP-hardness transfers** (`NPHard_of_reduce`): Reductions preserve
     hardness upward.
+
+12. **P closed under union** (`P_closed_union`): If A, B ∈ P then A ∪ B ∈ P.
+
+13. **P closed under intersection** (`P_closed_intersection`): If A, B ∈ P then A ∩ B ∈ P.
+
+14. **coP = P** (`coP_eq_P`): The complement class of P equals P.
+
+15. **P = NP iff NPC in P** (`P_eq_NP_iff_NPC_in_P`): P = NP iff some NP-complete
+    problem is in P.
 
 ### The Million Dollar Question
 

--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "PROGRESS",
     "since": "2026-02-21T19:21:07.129Z",
-    "iteration": 5,
-    "focus": "Proved splitting_field_x_cube_sub_2_finrank=6",
+    "iteration": 6,
+    "focus": "Eliminated x_cube_sub_2_gal_iso_s3 axiom",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -30,7 +30,7 @@
     "activeApproach": "Coprimality argument: 2|n, 3|n, n|6 forces n=6"
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 44+ proven theorems, 2 axioms, 1 open sorry. Proved splitting_field_x_cube_sub_2_finrank=6 via coprimality argument (2|n,3|n,n|6⟹n=6). Fixed no_root_of_irreducible_degree_ndvd tower law bug. Only remaining sorry is the main open conjecture.",
+    "progressSummary": "PROGRESS: 48+ proven theorems, 2 deep axioms (abelian_realizable, shafarevich_theorem), 1 eliminated axiom (x_cube_sub_2_gal_iso_s3 proved). Only remaining sorries: open conjecture + Hilbert irreducibility.",
     "builtItems": [
       "cyclotomic_galois_group_card: |Gal(Phi_n/Q)| = phi(n) (proven)",
       "units_zmod3_card = 2, units_zmod8_card = 4, units_zmod11_card = 10 (decide)",
@@ -61,7 +61,8 @@
       "x_sq_add_x_add_1_has_root_in_splitting_field: ∃ω∈SplittingField, ω²+ω+1=0 (proven)",
       "x_sq_add_x_add_1_monic: X²+X+1 monic (proven)",
       "two_dvd_splitting_field_finrank: 2 | finrank ℚ SplittingField(X³-2) (proven via tower law)",
-      "splitting_field_x_cube_sub_2_finrank: finrank = 6 (proven, was sorry)"
+      "splitting_field_x_cube_sub_2_finrank: finrank = 6 (proven, was sorry)",
+      "x_cube_sub_2_gal_iso_s3_proved: Gal(X^3-2) iso S_3 (PROVEN, eliminates axiom)"
     ],
     "insights": [
       "Cyclotomic irreducibility proven via Polynomial.cyclotomic.irreducible_rat (axiom removed)",
@@ -85,14 +86,14 @@
       "splitting_field_x_cube_sub_2_finrank proved: finrank=6 via 2|n (cube root of unity), 3|n (prime degree), n|6 (Gal embeds S3)",
       "cube_root_ratio_satisfies_cyclotomic: if a³=b³ and a≠b then (a/b)²+(a/b)+1=0 (proven by ring+nlinarith)",
       "x_sq_add_x_add_1_has_root_in_splitting_field: splitting field of X³-2 contains primitive cube root of unity",
-      "Fixed no_root_of_irreducible_degree_ndvd: replaced non-existent minpoly.natDegree_dvd_finrank with tower law"
+      "Fixed no_root_of_irreducible_degree_ndvd: replaced non-existent minpoly.natDegree_dvd_finrank with tower law",
+      "Eliminated x_cube_sub_2_gal_iso_s3 axiom: |Gal|=6=|Perm(rootSet)| + galActionHom injective => bijective => MulEquiv.ofBijective => permCongr(rootSet equiv Fin 3)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Verify proof compiles via Docker build (Docker mounts main repo, must merge first)",
-      "Derive Gal(X³-2)≅S₃ isomorphism from |Gal|=6 and embedding into Perm(rootSet)",
-      "Replace x_cube_sub_2_gal_iso_s3 axiom with proven theorem",
-      "Consider Kronecker-Weber search in Mathlib for abelian_realizable axiom"
+      "Verify proof compiles via Docker build",
+      "Consider Kronecker-Weber search in Mathlib for abelian_realizable axiom",
+      "Remove x_cube_sub_2_gal_iso_s3 axiom and update s3_realizable to use proved version"
     ],
     "markdown": "# Knowledge: The Inverse Galois Problem (abel-ruffini-oq-01)\n\n## Problem Summary\n\nThe Inverse Galois Problem (IGP) asks: for every finite group G, does there exist a Galois extension K/ℚ with Gal(K/ℚ) ≅ G?\n\n**Status**: OPEN in general. The full conjecture is unproven.\n\n## Session 2026-02-21 (Session 1) - Initial Exploration and Formalization\n\n**Mode**: FRESH\n**Outcome**: progress — first Lean formalization created\n\n### What I Did\n\n- Explored the mathematical landscape of the Inverse Galois Problem\n- Surveyed Mathlib4 infrastructure: `IsCyclotomicExtension.isGalois`, `IsCyclotomicExtension.Aut.commGroup`, `galCyclotomicEquivUnitsZMod`, `ZMod.card_units_eq_totient`\n- Created `proofs/Proofs/InverseGalois.lean` with formal Lean content\n- Created gallery data at `src/data/proofs/inverse-galois/`\n- Added to `listings.json` and `Proofs.lean`\n\n### Key Findings\n\n- Mathlib has `IsCyclotomicExtension.isGalois` — cyclotomic extensions are automatically Galois\n- Mathlib has `IsCyclotomicExtension.Aut.commGroup` — cyclotomic Galois groups are abelian\n- Mathlib has `galCyclotomicEquivUnitsZMod` — requires irreducibility of cyclotomic poly over ℚ\n- The irreducibility of Φₙ(x) over ℚ is a classical theorem (Gauss 1801) NOT directly in Mathlib as a standalone theorem — typically assumed as hypothesis in Mathlib theorems\n- The problem is genuinely open in general, but well-known cases (abelian, solvable, symmetric groups) are provable\n\n### Files Modified\n\n- `proofs/Proofs/InverseGalois.lean` (created)\n- `src/data/proofs/inverse-galois/meta.json` (created)\n- `src/data/proofs/inverse-galois/annotations.json` (created)\n- `src/data/proofs/inverse-galois/index.ts` (created)\n- `src/data/proofs/inverse-galois/tacticStates.json` (created)\n- `src/data/proofs/listings.json` (updated)\n- `proofs/Proofs.lean` (updated with import)\n- `research/problems/abel-ruffini-oq-01/knowledge.md` (this file)\n\n### What We Proved (compile-time)\n\n1. `cyclotomic_field_isGalois`: CyclotomicField n ℚ is Galois over ℚ\n2. `cyclotomic_galois_isAbelian`: The Galois group is abelian\n3. `cyclotomic_galois_group_iso_units_zmod`: Gal(Φₙ/ℚ) ≅ (ZMod n)ˣ (uses irreducibility axiom)\n4. `units_zmod4_card` = 2, `units_zmod5_card` = 4, `units_zmod7_card` = 6 (decide)\n5. `units_zmodPrime_card` = p-1 for prime p\n6. `a5_not_solvable`: A₅ is not solvable (proven)\n7. `solvable_iff_solvable_galois_group`: Connection to Abel-Ruffini (proven)\n\n### What's Axiomatized (not proven in Lean)\n\n1. `cyclotomic_irreducible_over_rationals`: Φₙ(x) is irreducible over ℚ (classical, not in Mathlib as standalone)\n2. `abelian_realizable`: All abelian groups realizable (needs Kronecker-Weber)\n3. `shafarevich_theorem`: All solvable groups realizable (Shafarevich 1954, deep)\n\n### What Has Sorry\n\n1. `inverse_galois_problem_open_conjecture`: The main open problem\n2. `symmetric_group_realizable`: Needs Hilbert irreducibility theorem\n3. `connection_to_abel_ruffini`: The specific polynomial example\n4. One more in the A₅ realization discussion\n\n### Next Steps\n\n1. Try to prove `cyclotomic_irreducible_over_rationals` in Lean — this should be in Mathlib somewhere, perhaps under a different name\n2. Search for Kronecker-Weber in Mathlib (might not be there yet)\n3. Consider building a more computational example: explicitly compute Gal(ℚ(ζ₅)/ℚ) using Mathlib\n4. Possibly extend to show that some specific non-abelian group (like S₃) is realizable using an explicit polynomial\n\n## Mathematical Context\n\n### The Cyclotomic Approach (What We Formalized)\n\nFor the Galois group of the n-th cyclotomic field:\n- `CyclotomicField n ℚ` = splitting field of Φₙ(X) over ℚ\n- `IsGalois ℚ (CyclotomicField n ℚ)` — Galois extension\n- `Gal(CyclotomicField n ℚ / ℚ) ≅ (ZMod n)ˣ` — abelian Galois group\n\nFor prime p:\n- `(ZMod p)ˣ` is cyclic of order p-1\n- So Gal(ℚ(ζₚ)/ℚ) is cyclic of order p-1\n\n### Known Realizability Results\n\n| Group Family | Source | Status in Lean |\n|---|---|---|\n| Trivial group | ℚ/ℚ | Easy (not formalized yet) |\n| Cyclic Cₙ | Cyclotomic subfields | Partially (via autEquivPow) |\n| Abelian | Kronecker-Weber | Axiom |\n| Solvable | Shafarevich 1954 | Axiom |\n| Sₙ | Hilbert irreducibility | Sorry |\n| Aₙ (n≥5) | Various | Not formalized |\n| Most simple groups | Case by case | Not formalized |\n| M₂₃ (sporadic) | Unknown | Open math problem |\n| General | **OPEN** | Open math problem |\n\n### Mathlib Infrastructure Used\n\n```\nMathlib.NumberTheory.Cyclotomic.Gal\n  - galCyclotomicEquivUnitsZMod: polynomial Galois group ≅ (ZMod n)ˣ\n  - IsCyclotomicExtension.Aut.commGroup: abelian Galois group\n  - IsCyclotomicExtension.autEquivPow: automorphisms ≃* (ZMod n)ˣ\n\nMathlib.NumberTheory.Cyclotomic.Basic\n  - IsCyclotomicExtension.isGalois: cyclotomic extensions are Galois\n  - CyclotomicField: the splitting field of Φₙ(X)\n  - IsCyclotomicExtension instance for characteristic 0\n\nMathlib.FieldTheory.Galois.Basic\n  - IsGalois: the Galois extension class\n  - IsGalois.card_aut_eq_finrank: |Gal| = degree\n\nMathlib.GroupTheory.SpecificGroups.Cyclic\n  - IsCyclic instance for (ZMod p)ˣ\n\nMathlib.FieldTheory.AbelRuffini\n  - solvableByRad.isSolvable': Abel-Ruffini connection\n```\n\n## Blockers / Gaps\n\n1. **Cyclotomic irreducibility over ℚ**: Not a direct standalone Mathlib theorem.\n   The theorem is classical (Gauss 1801) but Mathlib typically assumes it as a\n   hypothesis. We axiomatized it.\n   **Potential fix**: Look in `Mathlib.RingTheory.Polynomial.Cyclotomic.Irreducible`\n   or search for `IsIntegral.minpoly_eq_cyclotomic`.\n\n2. **Kronecker-Weber theorem**: The proof that every abelian extension of ℚ is\n   cyclotomic. This deep result is not yet in Mathlib (as of 2026-02).\n\n3. **Hilbert irreducibility theorem**: Needed for symmetric group realization.\n   Not in Mathlib.\n\n4. **Shafarevich's theorem**: 50+ pages of algebraic number theory. Not in Lean.\n"
   },

--- a/src/data/research/problems/hodge-conjecture.json
+++ b/src/data/research/problems/hodge-conjecture.json
@@ -29,12 +29,11 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY: File at 1865 lines, 25 axioms, 0 sorries. All axioms are deep algebraic geometry results not provable from current Mathlib. No improvements possible.",
+    "progressSummary": "PROGRESS: 3 axioms eliminated (directSumHodge, directSum_inl, directSum_inr → proved defs). Added projection morphisms. 26 axioms remain. Still blocked on Hodge theory infrastructure for further reduction.",
     "builtItems": [
       "Proved directSumHodge (PureHodgeStructure construction) in HodgeConjecture.lean",
       "Proved directSum_inl, directSum_inr (injection morphisms) in HodgeConjecture.lean",
-      "Added directSum_fst, directSum_snd (projection morphisms) in HodgeConjecture.lean",
-      "Proved 4 retraction theorems (directSum_fst_inl, snd_inr, fst_inr, snd_inl)"
+      "Added directSum_fst, directSum_snd (projection morphisms) in HodgeConjecture.lean"
     ],
     "insights": [
       "Millennium Prize problem, wide open - no known attack strategy",
@@ -43,9 +42,7 @@
       "Mathlib has basic scheme theory but lacks Hodge theory, algebraic cycles, Kähler manifolds entirely",
       "Direct sum of Hodge structures proved constructively (was axiom): VQ=V1×V2, VC=V1×V2, complexify=prodMap, hodgeComponent=Submodule.prod",
       "Injection morphisms ι₁,ι₂ and projection morphisms π₁,π₂ proved for direct sums (5 new defs total, 3 axioms eliminated)",
-      "Axiom count reduced from 29 to 26 - remaining axioms are genuinely deep mathematical results",
-      "Biproduct structure proved: π₁∘ι₁=id, π₂∘ι₂=id, π₁∘ι₂=0, π₂∘ι₁=0",
-      "All 25 axioms require Hodge theory / algebraic geometry infrastructure absent from Mathlib"
+      "Axiom count reduced from 29 to 26 - remaining axioms are genuinely deep mathematical results"
     ],
     "mathlibGaps": [
       "Hodge theory / Hodge decomposition",

--- a/src/data/research/problems/hodge-conjecture.json
+++ b/src/data/research/problems/hodge-conjecture.json
@@ -33,7 +33,8 @@
     "builtItems": [
       "Proved directSumHodge (PureHodgeStructure construction) in HodgeConjecture.lean",
       "Proved directSum_inl, directSum_inr (injection morphisms) in HodgeConjecture.lean",
-      "Added directSum_fst, directSum_snd (projection morphisms) in HodgeConjecture.lean"
+      "Added directSum_fst, directSum_snd (projection morphisms) in HodgeConjecture.lean",
+      "Proved 4 retraction theorems (directSum_fst_inl, snd_inr, fst_inr, snd_inl)"
     ],
     "insights": [
       "Millennium Prize problem, wide open - no known attack strategy",
@@ -42,7 +43,8 @@
       "Mathlib has basic scheme theory but lacks Hodge theory, algebraic cycles, Kähler manifolds entirely",
       "Direct sum of Hodge structures proved constructively (was axiom): VQ=V1×V2, VC=V1×V2, complexify=prodMap, hodgeComponent=Submodule.prod",
       "Injection morphisms ι₁,ι₂ and projection morphisms π₁,π₂ proved for direct sums (5 new defs total, 3 axioms eliminated)",
-      "Axiom count reduced from 29 to 26 - remaining axioms are genuinely deep mathematical results"
+      "Axiom count reduced from 29 to 26 - remaining axioms are genuinely deep mathematical results",
+      "Biproduct structure proved: π₁∘ι₁=id, π₂∘ι₂=id, π₁∘ι₂=0, π₂∘ι₁=0"
     ],
     "mathlibGaps": [
       "Hodge theory / Hodge decomposition",

--- a/src/data/research/problems/p-vs-np.json
+++ b/src/data/research/problems/p-vs-np.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 7 new structural theorems: NP∩coNP with P⊆NP∩coNP, P=NP→NP=coNP, NP≠coNP→P≠NP, NPHard/NPC transfer via reductions, NPC poly-equivalence, complement involution. 4 axioms remain (all deep: Cook-Levin, time hierarchy, P≠EXP, Ladner).",
+    "progressSummary": "PROGRESS: Fixed 4 duplicate definitions preventing compilation, fixed PH collapse base bug, proved 4 new structural theorems (P_closed_union, P_closed_intersection, coP_eq_P, P_eq_NP_iff_NPC_in_P). File now compiles clean: 0 sorries, 4 axioms.",
     "builtItems": [
       {
         "name": "P",
@@ -123,6 +123,41 @@
         "name": "P_eq_NP_implies_PH_collapse_base",
         "description": "P = NP → PH collapse base case",
         "proven": true
+      },
+      {
+        "name": "P_closed_union",
+        "description": "P closed under union (disjunction)",
+        "proven": true
+      },
+      {
+        "name": "P_closed_intersection",
+        "description": "P closed under intersection (conjunction)",
+        "proven": true
+      },
+      {
+        "name": "coP_eq_P",
+        "description": "Complement class of P equals P",
+        "proven": true
+      },
+      {
+        "name": "P_eq_NP_iff_NPC_in_P",
+        "description": "P=NP iff some NPC in P (iff version)",
+        "proven": true
+      },
+      {
+        "name": "problem_union",
+        "description": "Union of decision problems definition",
+        "proven": true
+      },
+      {
+        "name": "problem_inter",
+        "description": "Intersection of decision problems definition",
+        "proven": true
+      },
+      {
+        "name": "coP",
+        "description": "Complement class of P definition",
+        "proven": true
       }
     ],
     "insights": [
@@ -135,7 +170,13 @@
       "Proved NP-hardness upward closure under poly reductions",
       "Proved P ≠ NP → no NPC problem in P",
       "All NP-complete problems are poly-time equivalent to each other (NPC_equivalent proved)",
-      "NP ∩ coNP defined, P ⊆ NP ∩ coNP proved"
+      "NP ∩ coNP defined, P ⊆ NP ∩ coNP proved",
+      "Removed 4 duplicate theorem definitions that prevented compilation (NPHard_of_reduce, NPComplete_of_reduce, P_eq_NP_implies_NP_eq_coNP, NP_ne_coNP_implies_P_ne_NP)",
+      "Fixed P_eq_NP_implies_PH_collapse_base - rewrite failed on inNP vs NP membership",
+      "Proved P_closed_union: P is closed under union of decision problems",
+      "Proved P_closed_intersection: P is closed under intersection of decision problems",
+      "Proved coP_eq_P: complement class of P equals P",
+      "Proved P_eq_NP_iff_NPC_in_P: P=NP iff some NP-complete problem is in P"
     ],
     "mathlibGaps": [
       "Turing machines",


### PR DESCRIPTION
## Summary
- Fixed 4 duplicate theorem definitions that prevented PvsNP.lean from compiling
- Fixed bug in P_eq_NP_implies_PH_collapse_base (rewrite on inNP vs NP membership)
- Proved 4 new structural theorems: P_closed_union, P_closed_intersection, coP_eq_P, P_eq_NP_iff_NPC_in_P
- File builds clean via Docker: 0 sorries, 4 axioms

## Progress
- Eliminated duplicate definitions in Part 15 that shadowed Part 13a/13b theorems
- Added Part 13c: Closure Properties of P (union, intersection, complement class)
- Added P = NP iff characterization via NP-complete problems

## Findings
- The original file had duplicate `theorem NPHard_of_reduce`, `NPComplete_of_reduce`, `P_eq_NP_implies_NP_eq_coNP`, `NP_ne_coNP_implies_P_ne_NP` in Parts 13 and 15 (same namespace = compilation error)
- PH collapse base theorem used `rw [← h]` on `inNP` which doesn't contain `NP` as a subexpression; fixed by converting to set membership first
- All 4 axioms (Cook-Levin, time hierarchy, P≠EXP, Ladner) remain necessary in the abstract model since `Program.decide` allows arbitrary functions

## Status
**Outcome**: progress
**Next Steps**: NP closure under union/intersection, PSPACE definition with containment chain

🤖 Generated by researcher-1