### PR TITLE
Research: pythagorean-triples + p-vs-np improvements

### DIFF
--- a/proofs/Proofs/PythagoreanTriplesOQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ01.lean
@@ -977,17 +977,20 @@ We can express this as: the parity axiom follows from showing that EACH of
 the three parity classes has the same asymptotic density in the coprime sector.
 -/
 
-/-- **Equidistribution Axiom** (cleaner than the parity axiom):
-Each of the three non-both-even parity classes has density 1/3 among coprime
-sector pairs. This is the natural statement: residue classes are equidistributed.
+/-- **Equidistribution** (derived, not an axiom):
+coprimeOddOddCount/coprimeInSectorCount → 1/3.
 
-NOTE: We already proved |OE| = |OO| exactly in the triangle. The circle
-constraint only introduces boundary effects that vanish as N → ∞. So this
-axiom is "morally proved" for 2 of the 3 classes. -/
-axiom parity_class_equidistribution :
+Previously axiomatized, now proved via bothOdd_eq_oo which shows
+coprimeOddOddCount = bothOddCoprimeCount, reducing this to
+bothOdd_fraction_in_coprime_sector. -/
+theorem parity_class_equidistribution :
     Tendsto (fun N : ℕ =>
       (coprimeOddOddCount N : ℝ) / (coprimeInSectorCount N : ℝ))
-      atTop (𝓝 (1 / 3))
+      atTop (𝓝 (1 / 3)) := by
+  have heq : ∀ N, (coprimeOddOddCount N : ℝ) = (bothOddCoprimeCount N : ℝ) := by
+    intro N; exact_mod_cast (bothOdd_eq_oo N).symm
+  exact (Filter.tendsto_congr (fun N => by rw [heq N])).mpr
+    bothOdd_fraction_in_coprime_sector
 
 /-- The parity axiom follows from equidistribution. -/
 theorem parity_axiom_from_equidistribution :

--- a/src/data/research/problems/pythagorean-triples-oq-01.json
+++ b/src/data/research/problems/pythagorean-triples-oq-01.json
@@ -46,7 +46,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved bothOdd_fraction axiom is redundant (derivable from parity_class_equidistribution). EO equidistribution theorem stated with proof sketch (sorry for eventual equality). Fixed pre-existing column_parity_partition omega bug. File compiles clean.",
+    "progressSummary": "PROGRESS: 3 independent axioms (down from 4). Converted parity_class_equidistribution from axiom to theorem via bothOdd_eq_oo. Fixed pre-existing totient_even_of_odd proof. 1 sorry remains (eo_equidistribution at line 1048). File compiles clean.",
     "builtItems": [
       "bothOddCoprimeCount: counting function for both-odd coprime pairs",
       "coprime_sector_partition: exact partition identity (coprime = primitive + bothOdd)",
@@ -71,7 +71,17 @@
       "triangleEO: EO pairs in triangle for decomposition analysis (PythagoreanTriplesOQ01.lean:Part XVII)",
       "theorem bothOdd_fraction_from_equidistribution (axiom redundancy proof)",
       "theorem eo_equidistribution (sorry - needs eventual equality for C>0)",
-      "Fixed column_parity_partition omega bug (n≥1 from coprimality)"
+      "Fixed column_parity_partition omega bug (n≥1 from coprimality)",
+      {
+        "name": "parity_class_equidistribution (theorem)",
+        "description": "Converted from axiom to theorem via bothOdd_eq_oo",
+        "proven": true
+      },
+      {
+        "name": "totient_even_of_odd (fixed)",
+        "description": "Fixed proof using rw + rfl instead of broken omega",
+        "proven": true
+      }
     ],
     "insights": [
       "The coprime sector decomposes into exactly 2 parity classes (not 3): primitive (mixed parity) and both-odd. Both-even is impossible for coprime pairs.",
@@ -87,7 +97,10 @@
       "The parity_fraction_in_coprime_sector axiom is fully derivable from parity_class_equidistribution via parity_axiom_from_equidistribution (Part XV). This reduces the effective axiom count.",
       "bothOdd_fraction_in_coprime_sector is derivable from parity_class_equidistribution via bothOdd_eq_oo (proved in bothOdd_fraction_from_equidistribution)",
       "EO equidistribution follows algebraically from OE+OO equidistribution + three-way partition (eo_equidistribution, needs eventual C>0)",
-      "Fixed column_parity_partition: n≥1 follows from Coprime n m when m>1 (was broken omega)"
+      "Fixed column_parity_partition: n≥1 follows from Coprime n m when m>1 (was broken omega)",
+      "Converted parity_class_equidistribution from axiom to theorem (derived from bothOdd_fraction via bothOdd_eq_oo) — axiom count reduced from 4 to 3",
+      "Fixed totient_even_of_odd proof (pre-existing omega failure due to Mathlib API change)",
+      "Confirmed column_discrepancy_bound was already removed (false for m=21, N=541)"
     ],
     "mathlibGaps": [
       "No Mathlib formalization of Gauss circle problem asymptotics",


### PR DESCRIPTION
## Summary
- **p-vs-np**: Extended `PNPBarriersSound.lean` (572→753 lines) with structural theorems: coNP, NP-completeness, poly-time reductions, P=NP→NP=coNP
- **pythagorean-triples-oq-01**: Converted `parity_class_equidistribution` from axiom to theorem (4→3 axioms), fixed `totient_even_of_odd` proof

## Progress
- 9 new structural theorems in sound P vs NP model (0 sorries)
- Axiom reduction in Pythagorean triples (4→3 independent axioms)
- Pre-existing proof failure fixed (`totient_even_of_odd`)
- Both files compile clean via Docker build

## Status
**Outcome**: completed (both problems)
**Next Steps**: Port more structural results to sound model; prove EO equidistribution for Pythagorean triples

🤖 Generated by researcher-6