### PR TITLE
Research: pythagorean-triples-oq-01 - Eliminate last sorry, reduce to 3 axioms

### DIFF
--- a/proofs/Proofs/PythagoreanTriplesOQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ01.lean
@@ -457,15 +457,15 @@ axiom coprime_fraction_in_sector :
       atTop (𝓝 (6 / π ^ 2))
 
 /-- Both-odd fraction: among coprime sector points, the fraction with both m,n odd
-approaches 1/3. This is equivalent to parity_class_equidistribution (via bothOdd_eq_oo),
-so only one of the two is truly independent. We keep this as an axiom here because
-coprimeOddOddCount is defined later in Part XII.
-
+approaches 1/3. PROVED from parity_class_equidistribution via bothOdd_eq_oo.
 By parity_axiom_equivalent, this immediately gives the 2/3 primitive fraction. -/
-axiom bothOdd_fraction_in_coprime_sector :
+theorem bothOdd_fraction_in_coprime_sector :
     Tendsto (fun N : ℕ =>
       (bothOddCoprimeCount N : ℝ) / (coprimeInSectorCount N : ℝ))
-      atTop (𝓝 (1 / 3))
+      atTop (𝓝 (1 / 3)) := by
+  have heq : ∀ N, (bothOddCoprimeCount N : ℝ) = (coprimeOddOddCount N : ℝ) := by
+    intro N; exact_mod_cast bothOdd_eq_oo N
+  exact (Filter.tendsto_congr (fun N => by rw [heq N])).mpr parity_class_equidistribution
 
 /-- Parity sieving: among coprime sector points, the fraction with m ≢ n (mod 2)
 approaches 2/3. PROVED from bothOdd_fraction_in_coprime_sector via
@@ -720,6 +720,14 @@ theorem bothOdd_eq_oo (N : ℕ) :
     obtain ⟨a, ha⟩ := hm_odd; obtain ⟨b, hb⟩ := hn_odd
     obtain ⟨c, hc⟩ := h_odd_diff
     omega
+
+/-- **Equidistribution Axiom**: OO/coprime → 1/3 among coprime sector pairs.
+Each non-both-even parity class has density 1/3. The circle constraint
+introduces only boundary effects that vanish as N → ∞. -/
+axiom parity_class_equidistribution :
+    Tendsto (fun N : ℕ =>
+      (coprimeOddOddCount N : ℝ) / (coprimeInSectorCount N : ℝ))
+      atTop (𝓝 (1 / 3))
 
 /-- primitiveTripleCount equals EO + OE (the mixed-parity coprime pairs). -/
 theorem primitive_eq_eo_plus_oe (N : ℕ) :
@@ -977,39 +985,12 @@ We can express this as: the parity axiom follows from showing that EACH of
 the three parity classes has the same asymptotic density in the coprime sector.
 -/
 
-/-- **Equidistribution Axiom** (cleaner than the parity axiom):
-Each of the three non-both-even parity classes has density 1/3 among coprime
-sector pairs. This is the natural statement: residue classes are equidistributed.
-
-NOTE: We already proved |OE| = |OO| exactly in the triangle. The circle
-constraint only introduces boundary effects that vanish as N → ∞. So this
-axiom is "morally proved" for 2 of the 3 classes. -/
-axiom parity_class_equidistribution :
-    Tendsto (fun N : ℕ =>
-      (coprimeOddOddCount N : ℝ) / (coprimeInSectorCount N : ℝ))
-      atTop (𝓝 (1 / 3))
-
-/-- The parity axiom follows from equidistribution. -/
+/-- The parity axiom follows from equidistribution (alternative derivation path). -/
 theorem parity_axiom_from_equidistribution :
     Tendsto (fun N : ℕ =>
       (primitiveTripleCount N : ℝ) / (coprimeInSectorCount N : ℝ))
-      atTop (𝓝 (2 / 3)) := by
-  apply parity_axiom_equivalent
-  have heq : ∀ N, (bothOddCoprimeCount N : ℝ) = (coprimeOddOddCount N : ℝ) := by
-    intro N; exact_mod_cast bothOdd_eq_oo N
-  exact (Filter.tendsto_congr (fun N => by rw [heq N])).mpr parity_class_equidistribution
-
-/-- **Axiom redundancy**: bothOdd_fraction_in_coprime_sector is derivable from
-parity_class_equidistribution via bothOdd_eq_oo. This means only 3 axioms are
-truly independent: sector_lattice_point_density, coprime_fraction_in_sector,
-and parity_class_equidistribution (which implies bothOdd_fraction). -/
-theorem bothOdd_fraction_from_equidistribution :
-    Tendsto (fun N : ℕ =>
-      (bothOddCoprimeCount N : ℝ) / (coprimeInSectorCount N : ℝ))
-      atTop (𝓝 (1 / 3)) := by
-  have heq : ∀ N, (bothOddCoprimeCount N : ℝ) = (coprimeOddOddCount N : ℝ) := by
-    intro N; exact_mod_cast bothOdd_eq_oo N
-  exact (Filter.tendsto_congr (fun N => by rw [heq N])).mpr parity_class_equidistribution
+      atTop (𝓝 (2 / 3)) :=
+  parity_fraction_in_coprime_sector
 
 /-
 ## Part XV-B: Three-Class Equidistribution Derivation
@@ -1037,12 +1018,26 @@ theorem eo_equidistribution
     Tendsto (fun N : ℕ =>
       (coprimeEvenOddCount N : ℝ) / (coprimeInSectorCount N : ℝ))
       atTop (𝓝 (1 / 3)) := by
-  -- Proof sketch: By coprime_sector_three_way_partition, EO = C - OE - OO.
-  -- For large N, C > 0, so EO/C = 1 - OE/C - OO/C → 1 - 1/3 - 1/3 = 1/3.
-  -- The limit arithmetic follows from (tendsto_const_nhds.sub h_oe).sub h_oo.
-  -- Needs eventual equality (C > 0 for large N) to convert between
-  -- the pointwise partition and the ratio identity.
-  sorry
+  -- Target: 1/3 = 1 - 1/3 - 1/3
+  have htgt : (1 : ℝ) / 3 = 1 - 1 / 3 - 1 / 3 := by ring
+  rw [htgt]
+  -- EO/C = 1 - OE/C - OO/C eventually (from the three-way partition)
+  have hsub : Tendsto (fun N : ℕ =>
+      1 - (coprimeOddEvenCount N : ℝ) / (coprimeInSectorCount N : ℝ)
+        - (coprimeOddOddCount N : ℝ) / (coprimeInSectorCount N : ℝ))
+      atTop (𝓝 (1 - 1 / 3 - 1 / 3)) :=
+    (tendsto_const_nhds.sub h_oe).sub h_oo
+  refine (Filter.tendsto_congr' ?_).mp hsub
+  filter_upwards [Filter.eventually_ge_atTop 5] with N hN
+  have hC : (coprimeInSectorCount N : ℝ) ≠ 0 :=
+    Nat.cast_ne_zero.mpr (coprimeInSectorCount_pos hN).ne'
+  have hpart := coprime_sector_three_way_partition N
+  -- EO(N) = C(N) - OE(N) - OO(N) from the partition
+  have heo : (coprimeEvenOddCount N : ℝ) =
+      (coprimeInSectorCount N : ℝ) - (coprimeOddEvenCount N : ℝ)
+        - (coprimeOddOddCount N : ℝ) := by
+    push_cast [hpart]; ring
+  rw [heo, sub_div, sub_div, div_self hC]
 
 /-
 ## Part XVI: Per-Column Involution

--- a/src/data/research/problems/pythagorean-triples-oq-01.json
+++ b/src/data/research/problems/pythagorean-triples-oq-01.json
@@ -32,8 +32,8 @@
   "currentState": {
     "phase": "DEEP_DIVE",
     "since": "2026-03-12T05:32:38.520Z",
-    "iteration": 4,
-    "focus": "Square symmetry proved, coprime halving proved, density insight documented",
+    "iteration": 5,
+    "focus": "Eliminated last sorry, converted redundant axiom to theorem, 3 axioms 0 sorries",
     "blockers": [
       "Formalizing CRT independence of coprimality sieve and parity requires analytic NT infrastructure",
       "Connecting square EO=OE to sector EO=OE requires circle boundary analysis"
@@ -46,7 +46,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved bothOdd_fraction axiom is redundant (derivable from parity_class_equidistribution). EO equidistribution theorem stated with proof sketch (sorry for eventual equality). Fixed pre-existing column_parity_partition omega bug. File compiles clean.",
+    "progressSummary": "PROGRESS: Eliminated eo_equidistribution sorry (pure limit algebra). Converted bothOdd_fraction_in_coprime_sector from axiom to theorem. File now has exactly 3 axioms and 0 sorries.",
     "builtItems": [
       "bothOddCoprimeCount: counting function for both-odd coprime pairs",
       "coprime_sector_partition: exact partition identity (coprime = primitive + bothOdd)",
@@ -71,7 +71,9 @@
       "triangleEO: EO pairs in triangle for decomposition analysis (PythagoreanTriplesOQ01.lean:Part XVII)",
       "theorem bothOdd_fraction_from_equidistribution (axiom redundancy proof)",
       "theorem eo_equidistribution (sorry - needs eventual equality for C>0)",
-      "Fixed column_parity_partition omega bug (n≥1 from coprimality)"
+      "Fixed column_parity_partition omega bug (n≥1 from coprimality)",
+      "eo_equidistribution: PROVED (was sorry) - EO/coprime→1/3 from OE→1/3 + OO→1/3 via partition algebra",
+      "bothOdd_fraction_in_coprime_sector: CONVERTED axiom→theorem (proved from parity_class_equidistribution + bothOdd_eq_oo)"
     ],
     "insights": [
       "The coprime sector decomposes into exactly 2 parity classes (not 3): primitive (mixed parity) and both-odd. Both-even is impossible for coprime pairs.",
@@ -87,7 +89,9 @@
       "The parity_fraction_in_coprime_sector axiom is fully derivable from parity_class_equidistribution via parity_axiom_from_equidistribution (Part XV). This reduces the effective axiom count.",
       "bothOdd_fraction_in_coprime_sector is derivable from parity_class_equidistribution via bothOdd_eq_oo (proved in bothOdd_fraction_from_equidistribution)",
       "EO equidistribution follows algebraically from OE+OO equidistribution + three-way partition (eo_equidistribution, needs eventual C>0)",
-      "Fixed column_parity_partition: n≥1 follows from Coprime n m when m>1 (was broken omega)"
+      "Fixed column_parity_partition: n≥1 follows from Coprime n m when m>1 (was broken omega)",
+      "eo_equidistribution proof: use Tendsto.sub to get 1 - OE/C - OO/C → 1/3, then show EO/C = 1 - OE/C - OO/C eventually via partition + div_self",
+      "bothOdd_fraction_in_coprime_sector successfully converted from axiom to theorem by moving parity_class_equidistribution axiom earlier in file (after coprimeOddOddCount definition)"
     ],
     "mathlibGaps": [
       "No Mathlib formalization of Gauss circle problem asymptotics",
@@ -137,7 +141,7 @@
     ]
   },
   "started": "2026-03-12T05:34:54.574Z",
-  "lastUpdate": "2026-03-14T04:10:00.000Z",
+  "lastUpdate": "2026-03-14T15:00:00.000Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Proved `eo_equidistribution` theorem (was the only `sorry` in the file): EO/coprime → 1/3 follows algebraically from OE → 1/3 and OO → 1/3 via the three-way partition
- Converted `bothOdd_fraction_in_coprime_sector` from `axiom` to `theorem` by proving it from `parity_class_equidistribution` + `bothOdd_eq_oo`
- Removed redundant `bothOdd_fraction_from_equidistribution` and simplified `parity_axiom_from_equidistribution`

## Progress
- **Before**: 4 axioms, 1 sorry
- **After**: 3 axioms, 0 sorries
- File compiles clean via Docker build (3060 jobs)

## Findings
- `eo_equidistribution` proof uses `Tendsto.sub` for limit arithmetic and `filter_upwards` for eventual equality from the partition
- The axiom reduction required reordering: `parity_class_equidistribution` moved before its consumer `bothOdd_fraction_in_coprime_sector`

## Status
**Outcome**: progress
**Next Steps**: Prove `parity_class_equidistribution` axiom via boundary analysis (O(√N) discrepancy bound)

Generated by researcher-4