### PR TITLE
Research: pnp-barriers - Prove PSPACE_subset_EXP axiom

### DIFF
--- a/proofs/Proofs/PNPBarriersSound.lean
+++ b/proofs/Proofs/PNPBarriersSound.lean
@@ -36,14 +36,15 @@ This model is sound because:
 - [ ] Uses Mathlib for main result
 - [x] Pedagogical example
 
-## Axiom Summary (14 axioms, down from 17)
+## Axiom Summary (13 axioms, down from 17)
 - 1 structural: Φ_countably_many (Φ_total and Φ_deterministic now theorems)
 - 2 oracle: Φ_oracle_access, Φ_no_oracle_access
 - 2 BGS: baker_gill_solovay_eq, baker_gill_solovay_sep
 - 1 natural proofs: razborov_rudich (owf_exists_assumption now theorem)
 - 2 algebrization: algebrizing_oracle_eq, algebrizing_oracle_sep
 - 3 structural properties: P_rel_monotone, NP_rel_monotone, P_rel_subset_NP_rel
-- 3 closure properties: P_complement_closed, poly_time_compose, reduction_preserves_P
+- 2 closure properties: P_complement_closed, poly_time_compose, reduction_preserves_P
+- Note: PSPACE_subset_EXP now theorem (PSPACE and EXP have identical definitions)
 -/
 
 set_option linter.unusedVariables false
@@ -908,8 +909,14 @@ def EXP : Set (ℕ → Bool) :=
 axiom NP_subset_PSPACE : NP ⊆ PSPACE
 
 /-- PSPACE ⊆ EXP: A polynomial-space computation can have at most
-    2^{p(n)} configurations, so it must halt within exponential time. -/
-axiom PSPACE_subset_EXP : PSPACE ⊆ EXP
+    2^{p(n)} configurations, so it must halt within exponential time.
+
+    NOTE: In our abstract model, PSPACE and EXP have the same definition
+    (both track decidability without explicit space/time resource bounds),
+    so this is trivially true. A refined model would distinguish them by
+    resource bounds. -/
+theorem PSPACE_subset_EXP : PSPACE ⊆ EXP := by
+  intro f ⟨e, p, h⟩; exact ⟨e, p, h⟩
 
 /-- PH ⊆ PSPACE: Every level of the polynomial hierarchy is in PSPACE.
     Σₖ problems can be solved in PSPACE by iterating over quantifiers. -/

--- a/src/data/research/problems/pnp-barriers.json
+++ b/src/data/research/problems/pnp-barriers.json
@@ -30,7 +30,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 3 trivial axioms (Φ_total, Φ_deterministic, owf_exists_assumption) by proving them. 17→14 axioms, 0 sorries. Φ_total is simple weakening, Φ_deterministic follows from function determinism, owf_exists_assumption was True.",
+    "progressSummary": "PROGRESS: 17→13 axioms total. Session 3: proved PSPACE_subset_EXP (trivial since PSPACE=EXP by definition). Session 2: proved Φ_total, Φ_deterministic, owf_exists_assumption.",
     "builtItems": [
       {
         "name": "P_subset_NP_relative",
@@ -94,7 +94,8 @@
       },
       "Φ_total: converted axiom→theorem (simple existential weakening)",
       "Φ_deterministic: converted axiom→theorem (function determinism of opaque Φ)",
-      "owf_exists_assumption: converted axiom→theorem (was True)"
+      "owf_exists_assumption: converted axiom→theorem (was True)",
+      "PSPACE_subset_EXP converted from axiom to theorem (PSPACE and EXP have identical definitions in abstract model)"
     ],
     "insights": [
       "P_subset_NP_relative",
@@ -113,7 +114,8 @@
       "P_nontrivial proved from Φ_countably_many: countable programs cannot compute all uncountably many functions",
       "All 3 barriers (relativization, natural proofs, algebrization) formalized soundly in PNPBarriersSound.lean",
       "Φ_total was unnecessarily axiomatized: its conclusion is strictly weaker than its hypothesis. The bound s≤bound in the hypothesis is simply dropped.",
-      "Φ_deterministic follows from Φ being a Lean function: same inputs → same output, so Option.some injection gives equality."
+      "Φ_deterministic follows from Φ being a Lean function: same inputs → same output, so Option.some injection gives equality.",
+      "PSPACE and EXP have identical definitions: both are {f | ∃ e p, Solves e emptyOracle f}. The abstract model tracks decidability but not space/time resource bounds. PSPACE_subset_EXP is thus trivially true."
     ],
     "mathlibGaps": [
       "Oracle Turing machines",


### PR DESCRIPTION
## Summary
- Convert `PSPACE_subset_EXP` from axiom to theorem (14→13 axioms in PNPBarriersSound.lean)
- Both `PSPACE` and `EXP` have identical definitions in the abstract model (both are `{f | ∃ e p, Solves e emptyOracle f}`), making the subset trivially true

## Findings
- The abstract Gödel-coded model tracks decidability but not explicit space/time resource bounds
- A refined model would need separate resource tracking to distinguish PSPACE from EXP

## Status
**Outcome**: progress
**Next Steps**: Remaining 13 axioms are substantive (oracle properties, BGS, Razborov-Rudich, algebrization, structural properties)

🤖 Generated by researcher-4