### PR TITLE
Research: borsuk-ulam-oq-03-oq-03 - Cleanup and false axiom removal

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ03OQ01.lean
+++ b/proofs/Proofs/BorsukUlamOQ03OQ01.lean
@@ -312,17 +312,24 @@ theorem multi_function_interval_bu (ι : Type*) (f : ι → ℝ → ℝ) :
     ∃ x ∈ Icc (-1:ℝ) 1, ∀ i, f i x = f i (-x) :=
   ⟨0, by norm_num, fun i => by rw [neg_zero]⟩
 
-/-- **Two-function circle BU**: For two continuous functions f, g: ℝ² → ℝ,
-    there exists θ such that both f and g agree at antipodal points.
+/-- **WARNING: This axiom is FALSE.** It claims two continuous functions
+    f, g: ℝ² → ℝ must simultaneously agree at antipodal points on S¹.
 
-    This is the 2D Borsuk-Ulam theorem for S^1 → ℝ², which is deeper
-    than the 1D version. We axiomatize it since the proof requires
-    the full Borsuk-Ulam for S^1 → ℝ^1 applied to F = (f,g). -/
-axiom two_function_circle_bu
-    (f g : ℝ × ℝ → ℝ) (hf : Continuous f) (hg : Continuous g) :
-    ∃ θ : ℝ, θ ∈ Icc 0 Real.pi ∧
-    f (cos θ, sin θ) = f (-cos θ, -sin θ) ∧
-    g (cos θ, sin θ) = g (-cos θ, -sin θ)
+    Counterexample: f(x,y) = x, g(x,y) = y.
+    f(cos θ, sin θ) = cos θ = f(-cos θ, -sin θ) = -cos θ requires cos θ = 0, i.e., θ = π/2.
+    But g(0, 1) = 1 ≠ -1 = g(0, -1), so g does NOT agree at this θ.
+
+    The error is dimensional: BU for S^n → ℝ^n requires domain S^n, but two scalar
+    functions on S¹ form a map S¹ → ℝ², needing BU for S² → ℝ² (not S¹ → ℝ²).
+    The correct version would use S² as domain, not S¹.
+
+    This axiom is UNUSED in the file and introduces no inconsistency.
+    Retained (commented out) for documentation of the corrected understanding. -/
+-- axiom two_function_circle_bu
+--     (f g : ℝ × ℝ → ℝ) (hf : Continuous f) (hg : Continuous g) :
+--     ∃ θ : ℝ, θ ∈ Icc 0 Real.pi ∧
+--     f (cos θ, sin θ) = f (-cos θ, -sin θ) ∧
+--     g (cos θ, sin θ) = g (-cos θ, -sin θ)
 
 /-
 ## Section IX: Quantitative Non-Injectivity

--- a/proofs/Proofs/BorsukUlamOQ03OQ03.lean
+++ b/proofs/Proofs/BorsukUlamOQ03OQ03.lean
@@ -29,12 +29,21 @@ YES — the proof strategy is:
 - 1D BU and Tucker: BorsukUlamOQ03.lean
 - Spheres, antipodal maps: BorsukUlamOQ01/02.lean
 
-## What This File Builds
+## What This File Proves
 
-1. The "dominant component labeling" from continuous functions to signed labels
-2. Tucker's 2D specialization: complementary edges in labeled 2D disk triangulations
-3. The bridge: Tucker complementary edge → approximate BU solution
-4. The limiting argument: mesh refinement → exact BU solution (axiomatized)
+1. The "dominant component labeling" is antipodal (Part II)
+2. Tucker complementary edge → approximate zero via IVT (Parts XVIII-XX)
+3. Mesh refinement on compact sets gives arbitrarily small zeros (Part XXI)
+4. Radial extension from D² to [-1,1]² preserving odd boundary (Part XXII)
+5. Grid infrastructure: vertices, edges, boundary, antipodal map (Part XXIII)
+6. **Main theorem**: tucker_disk_approx_zero_proved (from tuckers_lemma axiom)
+7. Approximate and exact 2D Borsuk-Ulam (Part XVI)
+
+## Status: 1 axiom, 0 sorries
+
+The entire proof chain is complete modulo Tucker's lemma (Part I).
+Eliminating this axiom requires path-following, degree theory, or intersection
+theory — each equivalent to Brouwer's FPT in 2D.
 -/
 
 set_option maxHeartbeats 400000
@@ -596,44 +605,23 @@ theorem approx_to_exact (f : ℝ × ℝ → ℝ × ℝ) (hf : Continuous f)
   obtain ⟨x₁, hx₁on, hx₁lt⟩ := happrox _ hgt
   exact absurd hx₁lt (not_lt.mpr (hx₀min hx₁on))
 
-/-- **Open question status**: The Tucker → BU bridge requires
-    explicit triangulation construction, which is the combinatorial core.
-    The topological and analytical framework is fully established.
+/-- **Formalization status** (updated 2026-03-14):
 
-    Proved:
-    - Tucker's lemma (axiom, from combinatorial topology)
-    - Dominant component labeling is antipodal
-    - S¹ is compact, closed, bounded
-    - Continuous functions on S¹ are bounded
-    - Odd function framework
-    - Approximate → exact bridge (pending compactness argument)
+    COMPLETE (modulo Tucker's lemma axiom):
+    ✓ Dominant component labeling is antipodal
+    ✓ S¹ and D² compactness, boundedness
+    ✓ Odd function framework
+    ✓ IVT on line segments → complementary edge → approximate zero (Part XX)
+    ✓ Mesh refinement principle for compact sets (Part XXI)
+    ✓ Radial extension D² → [-1,1]² preserving oddness (Part XXII)
+    ✓ Grid infrastructure: Fin-based vertices, edges, boundary, antipodal (Part XXIII)
+    ✓ tucker_disk_approx_zero_proved (from tuckers_lemma)
+    ✓ Approximate → exact BU via compactness
+    ✓ Full 2D Borsuk-Ulam: borsuk_ulam_2d_corrected
 
-    Open in this formalization:
-    - Explicit triangulation builder (N×N grid → Tucker input)
-    - Approximate BU from Tucker (needs triangulation)
-    - Exact BU from Tucker (needs approximate + compactness) -/
-theorem open_question_status : True := trivial
-
-/-
-═══════════════════════════════════════════════════════════════════════════════
-PART XV: VERIFICATION
-═══════════════════════════════════════════════════════════════════════════════ -/
-
--- Type-check main results
-#check @dominantComponentLabel
-#check @dominantComponentLabel_antipodal
-#check @antisymmetricDiff_odd
-#check @antisymmetricDiff_continuous
-#check @no_fixed_point_on_circle
-#check @antisymmetricDiff_eq_zero_iff
-#check @circle_isCompact
-#check @grid_mesh_tends_to_zero
-#check @IsOddFunction
-#check @odd_function_at_zero
-#check @antipodal_preserves_circle
-#check @circle_bounded
-#check @continuous_on_circle_bounded
-#check @approx_to_exact
+    REMAINING:
+    - Tucker's lemma (1 axiom) — deep combinatorial/topological result -/
+theorem formalization_status : True := trivial
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════
@@ -1367,19 +1355,6 @@ theorem non_dominant_at_zero_bound
   -- Combine: |g(w).2| ≤ dist + dist = 2 * dist
   linarith
 
--- Type-check Parts XVIII-XIX
-#check @segmentParam
-#check @segmentParam_zero
-#check @segmentParam_one
-#check @segmentParam_continuous
-#check @segmentParam_dist_le
-#check @ivt_segment_fst
-#check @ivt_segment_snd
-#check @complementary_edge_zero_fst
-#check @complementary_edge_zero_snd
-#check @dominant_component_small_at_zero
-#check @non_dominant_at_zero_bound
-
 /-
 ═══════════════════════════════════════════════════════════════════════════════
 PART XX: CORRECTED COMPLEMENTARY EDGE THEOREM
@@ -1650,16 +1625,6 @@ theorem mesh_refinement_principle (g : ℝ × ℝ → ℝ × ℝ) (hg : Continuo
         apply mul_lt_mul_of_pos_left _ (by norm_num : (0:ℝ) < 2)
         exact hδ u w hu hw huw
     _ = ε := by ring
-
--- Type-check Part XX-XXI
-#check @non_dominant_at_zero_bound_snd
-#check @complementary_edge_approx_dominant_fst
-#check @complementary_edge_approx_dominant_snd
-#check @complementary_edge_approx_dominant
-#check @closedDisk_isCompact
-#check @continuous_on_disk_uniformContinuousOn
-#check @disk_continuity_bound
-#check @mesh_refinement_principle
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════
@@ -2142,23 +2107,40 @@ theorem tucker_disk_approx_zero_proved
     exact radialExtend_zero_gives_disk_zero g (gridVertexFin N v₀) δ hδ
       (by rw [← hh_def, hv₀, dist_self]; exact hδ)
 
--- Type-check Part XXII-XXIII
-#check @euclidNormSq
-#check @euclidNorm
-#check @radialExtend
-#check @radialExtend_eq_on_disk
-#check @radialExtend_eq_outside
-#check @radial_proj_on_circle
-#check @radialExtend_zero_gives_disk_zero
-#check @closedSquare_isCompact
-#check @square_continuity_bound
-#check @mesh_refinement_square
-#check @gridVertexFin
-#check @gridBoundaryFin
-#check @gridEdgesFin
-#check @gridAntipodalFin
-#check @gridAntipodalFin_eq_neg
-#check @gridBoundary_euclidNormSq_ge_one
-#check @tucker_disk_approx_zero_proved
+/-
+═══════════════════════════════════════════════════════════════════════════════
+AXIOM STATUS SUMMARY
+
+This file has **1 axiom** and **0 sorries**.
+
+Remaining axiom:
+  tuckers_lemma (Part I, line 65): Tucker's lemma for antipodal labelings.
+  This is the ONLY unproved assumption. Everything else is proved from it.
+
+Proof chain:
+  tuckers_lemma → tucker_disk_approx_zero_proved → approx_borsuk_ulam_2d_corrected
+    → borsuk_ulam_2d_corrected (exact 2D BU from Tucker)
+
+Approaches to eliminate tuckers_lemma:
+  1. Path-following argument (combinatorial, ~500-1000 lines):
+     - Triangulate each grid cell into 2 triangles
+     - Define "complementary edge paths" through dual graph
+     - Prove boundary has odd number of path endpoints
+     - Therefore at least one interior complementary edge exists
+     Difficulty: Needs detailed finite graph bookkeeping in Lean 4.
+
+  2. Winding number / degree theory (~500 lines):
+     - If g ≠ 0 on D², then g/|g| : D² → S¹ extends from boundary
+     - Odd map S¹ → S¹ has odd degree
+     - Map extending over D² has degree 0 → contradiction
+     Difficulty: Needs winding number definition + basic properties.
+
+  3. Poincaré-Miranda / intersection theory (~300-500 lines):
+     - Zero sets Z₁ = {g₁ = 0} and Z₂ = {g₂ = 0} connect opposite boundary arcs
+     - Two arcs connecting opposite sides of a square must intersect
+     Difficulty: Needs discrete Jordan curve theorem.
+
+  All three are equivalent to Brouwer's FPT in 2D. Each is a multi-session project.
+═══════════════════════════════════════════════════════════════════════════════ -/
 
 end BorsukUlamTucker2D

--- a/proofs/Proofs/PNPBarriersSound.lean
+++ b/proofs/Proofs/PNPBarriersSound.lean
@@ -36,7 +36,7 @@ This model is sound because:
 - [ ] Uses Mathlib for main result
 - [x] Pedagogical example
 
-## Axiom Summary (13 axioms, down from 17)
+## Axiom Summary (18 axioms, down from 21)
 - 1 structural: Φ_countably_many (Φ_total and Φ_deterministic now theorems)
 - 2 oracle: Φ_oracle_access, Φ_no_oracle_access
 - 2 BGS: baker_gill_solovay_eq, baker_gill_solovay_sep
@@ -44,6 +44,8 @@ This model is sound because:
 - 2 algebrization: algebrizing_oracle_eq, algebrizing_oracle_sep
 - 3 structural properties: P_rel_monotone, NP_rel_monotone, P_rel_subset_NP_rel
 - 2 closure properties: P_complement_closed, poly_time_compose, reduction_preserves_P
+- 2 containment: NP_subset_PSPACE, PH_subset_PSPACE
+- 2 separation/existence: P_ne_EXP, ladner_theorem
 - Note: PSPACE_subset_EXP now theorem (PSPACE and EXP have identical definitions)
 -/
 

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
@@ -18,62 +18,65 @@
   "currentState": {
     "phase": "DEEP_DIVE",
     "since": "2026-03-12",
-    "iteration": 5,
-    "focus": "Axiom reduction: 2→1 axiom (only tuckers_lemma remains)",
-    "activeApproach": "Radial extension trick: extend g from disk to square, grid [-1,1]² for Tucker",
+    "iteration": 6,
+    "focus": "Proof complete modulo Tucker's lemma axiom. Cleanup and documentation done.",
+    "activeApproach": "Tucker's lemma elimination requires path-following, degree theory, or intersection theory",
     "blockers": [
-      "radialExtend_continuous: piecewise continuity proof (both branches agree on S¹)",
-      "grid_edge_dist: Nat↔ℝ cast arithmetic for adjacent Fin values",
-      "Main composition: construct labeling, apply Tucker, connect to analytical results"
+      "tuckers_lemma axiom: requires path-following (~500-1000 lines), degree theory, or intersection theory \u2014 each equivalent to Brouwer FPT in 2D",
+      "No shortcut exists: a single path through the grid CAN avoid complementary edges with 4 labels (counterexample: (0,T)\u2192(1,T)\u2192(0,F)), so 2D structure is essential"
     ],
-    "nextAction": "Complete the 3 remaining sorries to eliminate tucker_disk_approx_zero axiom",
+    "nextAction": "Prove Tucker 2D for the grid via path-following or degree argument (multi-session project)",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 1,
-      "approachesTried": 2
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated tucker_disk_approx_zero axiom by wiring approx_borsuk_ulam_2d_corrected to tucker_disk_approx_zero_proved. File now has only 1 axiom (tuckers_lemma) and 0 sorries.",
+    "progressSummary": "NEARLY COMPLETE: 1 axiom (tuckers_lemma), 0 sorries. Full proof chain from Tucker \u2192 approximate BU \u2192 exact BU is proved. Cleaned up #check statements. Identified and removed false axiom in OQ03OQ01. Tucker's lemma elimination requires multi-session effort.",
     "builtItems": [
       "non_dominant_at_zero_bound_snd (symmetric IVT bound, Part XX)",
       "complementary_edge_approx_dominant_fst/snd (corrected IVT+dominant theorems)",
       "complementary_edge_approx_dominant (combined for arbitrary k)",
-      "closedDisk_isCompact (D² compactness)",
-      "continuous_on_disk_uniformContinuousOn (uniform continuity on D²)",
-      "disk_continuity_bound (ε-δ form of uniform continuity)",
-      "mesh_refinement_principle (mesh→0 implies approximate zeros)",
-      "radialExtend: extends g from D² to [-1,1]² via radial projection (freezes S¹ values)",
-      "radialExtend_odd_outside: h is odd for ‖x‖₂ ≥ 1 when g is odd on S¹",
-      "radialExtend_zero_gives_disk_zero: converts h-zero to g-zero in D̄²",
-      "closedSquare_isCompact: [-1,1]² = closedBall 0 1 in L∞ norm",
-      "mesh_refinement_square: analog of mesh_refinement_principle for [-1,1]²",
-      "gridVertexFin/gridBoundaryFin/gridEdgesFin/gridAntipodalFin: Fin-based grid on [-1,1]²",
-      "gridAntipodalFin_eq_neg: antipodal map = negation in ℝ² (via Fin.rev)",
-      "gridBoundary_euclidNormSq_ge_one: boundary vertices have Euclidean norm ≥ 1",
+      "closedDisk_isCompact (D\u00b2 compactness)",
+      "continuous_on_disk_uniformContinuousOn (uniform continuity on D\u00b2)",
+      "disk_continuity_bound (\u03b5-\u03b4 form of uniform continuity)",
+      "mesh_refinement_principle (mesh\u21920 implies approximate zeros)",
+      "radialExtend: extends g from D\u00b2 to [-1,1]\u00b2 via radial projection (freezes S\u00b9 values)",
+      "radialExtend_odd_outside: h is odd for \u2016x\u2016\u2082 \u2265 1 when g is odd on S\u00b9",
+      "radialExtend_zero_gives_disk_zero: converts h-zero to g-zero in D\u0304\u00b2",
+      "closedSquare_isCompact: [-1,1]\u00b2 = closedBall 0 1 in L\u221e norm",
+      "mesh_refinement_square: analog of mesh_refinement_principle for [-1,1]\u00b2",
+      "gridVertexFin/gridBoundaryFin/gridEdgesFin/gridAntipodalFin: Fin-based grid on [-1,1]\u00b2",
+      "gridAntipodalFin_eq_neg: antipodal map = negation in \u211d\u00b2 (via Fin.rev)",
+      "gridBoundary_euclidNormSq_ge_one: boundary vertices have Euclidean norm \u2265 1",
       "tucker_disk_approx_zero_proved: main theorem with h=0 edge case completed",
       "Eliminated tucker_disk_approx_zero axiom: replaced usage in approx_borsuk_ulam_2d_corrected with tucker_disk_approx_zero_proved"
     ],
     "insights": [
-      "CRITICAL: axiom complementary_edge_gives_approximate_zero was FALSE. Counterexample: g(x,y)=(x,y), u=(0.01,1), v=(-0.01,1). The bound δ*C ≈ 0.08 but |g(w).2| ≥ 0.98 for any w near u.",
-      "The fix: require k to be the DOMINANT component (Tucker's labeling guarantees this). Then IVT zero + dominant component bound gives ‖g(w)‖ ≤ 2·dist(g(u),g(w)) → 0 by uniform continuity.",
+      "CRITICAL: axiom complementary_edge_gives_approximate_zero was FALSE. Counterexample: g(x,y)=(x,y), u=(0.01,1), v=(-0.01,1). The bound \u03b4*C \u2248 0.08 but |g(w).2| \u2265 0.98 for any w near u.",
+      "The fix: require k to be the DOMINANT component (Tucker's labeling guarantees this). Then IVT zero + dominant component bound gives \u2016g(w)\u2016 \u2264 2\u00b7dist(g(u),g(w)) \u2192 0 by uniform continuity.",
       "Pre-existing build errors in segmentParam_dist_le, complementary_edge_zero_fst/snd were present - fixed Prod subtraction handling and eq_or_lt_of_le direction.",
       "The only remaining axiom gap is tuckers_lemma (deep combinatorial, hard) and tucker_disk_approx_zero (needs grid Fintype instance, ~200 lines boilerplate).",
-      "uniform continuity on compact D² is the key analytical bridge: CompactSpace → UniformContinuousOn → ε-δ bounds on function variation.",
-      "Grid Fintype boilerplate (Fin(2N+1)×Fin(2N+1), edges, antipodal map) involves heavy Nat↔ℝ casting. Lean4 exact_mod_cast/Fin.val handling makes this ~400 lines rather than ~200. Not mathematically hard, just tedious.",
-      "KEY INSIGHT: radial extension trick avoids gridding the disk directly. Extend g to [-1,1]² by g(x/‖x‖) outside D̄². This makes h odd for ‖x‖₂ ≥ 1 (boundary of [-1,1]² has ‖x‖₂ ≥ 1). Grid the square, apply Tucker, then convert back.",
-      "The Prod norm/dist in Mathlib is L∞ (max norm), not Euclidean. Must use custom euclidNormSq/euclidNorm for disk membership.",
-      "When h vanishes at a grid vertex, we get immediate zero: either inside disk (direct) or outside (project to S¹).",
-      "tucker_disk_approx_zero_proved was already complete but the axiom was still being used by the main theorem. Simple wiring change to connect them."
+      "uniform continuity on compact D\u00b2 is the key analytical bridge: CompactSpace \u2192 UniformContinuousOn \u2192 \u03b5-\u03b4 bounds on function variation.",
+      "Grid Fintype boilerplate (Fin(2N+1)\u00d7Fin(2N+1), edges, antipodal map) involves heavy Nat\u2194\u211d casting. Lean4 exact_mod_cast/Fin.val handling makes this ~400 lines rather than ~200. Not mathematically hard, just tedious.",
+      "KEY INSIGHT: radial extension trick avoids gridding the disk directly. Extend g to [-1,1]\u00b2 by g(x/\u2016x\u2016) outside D\u0304\u00b2. This makes h odd for \u2016x\u2016\u2082 \u2265 1 (boundary of [-1,1]\u00b2 has \u2016x\u2016\u2082 \u2265 1). Grid the square, apply Tucker, then convert back.",
+      "The Prod norm/dist in Mathlib is L\u221e (max norm), not Euclidean. Must use custom euclidNormSq/euclidNorm for disk membership.",
+      "When h vanishes at a grid vertex, we get immediate zero: either inside disk (direct) or outside (project to S\u00b9).",
+      "tucker_disk_approx_zero_proved was already complete but the axiom was still being used by the main theorem. Simple wiring change to connect them.",
+      "Tucker's lemma elimination analyzed: all approaches (path-following, degree theory, intersection theory) are equivalent to Brouwer FPT in 2D. Each requires ~500-1000 lines.",
+      "CRITICAL: A single path from v to antip(v) CAN avoid complementary edges with 4 labels. Example: (0,T)\u2192(1,T)\u2192(0,F) has no complementary edge despite complementary endpoints. So 1D Tucker reduction doesn't work directly.",
+      "The no-complementary-edge assumption implies Bool is constant within each Fin-connected-component. Contradiction requires showing antipodal Fin-same boundary vertices must be connected \u2014 essentially the discrete Jordan curve theorem.",
+      "FOUND FALSE AXIOM: two_function_circle_bu in BorsukUlamOQ03OQ01.lean is FALSE. Counterexample: f(x,y)=x, g(x,y)=y. At \u03b8=\u03c0/2: f agrees but g doesn't. The error is dimensional: BU for S\u00b9\u2192\u211d\u00b2 needs S\u00b2 domain, not S\u00b9. Axiom was unused \u2014 removed."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove radialExtend_continuous: piecewise continuity, both branches agree at euclidNormSq = 1",
-      "Prove grid_edge_dist: adjacent Fin values → 1/N distance in Prod metric",
-      "Complete main theorem composition: construct SignedLabeling from dominantComponentLabel, verify Tucker antipodal condition, apply Tucker, connect complementary edge to mesh_refinement_square",
-      "Once all 3 sorries filled, replace axiom tucker_disk_approx_zero with tucker_disk_approx_zero_proved"
+      "Prove Tucker 2D for the grid: path-following approach (triangulate cells, track complementary-edge paths through dual graph, odd boundary parity \u2192 interior edge)",
+      "Alternative: degree theory approach (define winding number for PL maps on grid, prove odd map S\u00b9\u2192S\u00b9 has odd degree, map extending over D\u00b2 has degree 0)",
+      "Alternative: Poincar\u00e9-Miranda approach (two arcs connecting opposite sides must cross = discrete Jordan curve theorem)",
+      "All approaches are multi-session projects (~500-1000 lines each)"
     ],
-    "markdown": "# Knowledge Base: borsuk-ulam-oq-03-oq-03\n\n## Problem Understanding\n\nThe 2D Borsuk-Ulam theorem proved via Tucker's lemma. File has main theorem\n`borsuk_ulam_2d_corrected` with complete proof chain modulo axioms.\n\n## Key Finding: False Axiom\n\n`complementary_edge_gives_approximate_zero` was FALSE as stated.\nCounterexample: g(x,y)=(x,y), u=(0.01,1), v=(-0.01,1), δ=0.02, k=0.\nThe bound 0.02·(2·sup) ≈ 0.08 but ‖g(w)‖₁ ≥ 0.98 for any w near u.\n\nFix: require k to be the dominant component (as Tucker's labeling guarantees).\n\n## Axiom Status (after this session)\n\n- `tuckers_lemma` — HARD to eliminate (deep combinatorial, path-following)\n- `tucker_disk_approx_zero` — TRACTABLE to eliminate (grid Fintype + our proved theorems)\n- ~~`complementary_edge_gives_approximate_zero`~~ — ELIMINATED (was false, replaced with proved theorems)\n\n## Dead Ends\n\n- The original axiom bound δ·(2·sup{‖g‖+1}) is too weak without dominant-component hypothesis\n"
+    "markdown": "# Knowledge Base: borsuk-ulam-oq-03-oq-03\n\n## Status: 1 axiom (tuckers_lemma), 0 sorries\n\nThe entire proof chain from Tucker's lemma to exact 2D Borsuk-Ulam is complete.\nThe file proves: tuckers_lemma \u2192 tucker_disk_approx_zero_proved \u2192 \n  approx_borsuk_ulam_2d_corrected \u2192 borsuk_ulam_2d_corrected.\n\n## Key Findings\n\n### False Axiom Removed\n`two_function_circle_bu` in BorsukUlamOQ03OQ01.lean was FALSE.\nCounterexample: f(x,y)=x, g(x,y)=y gives no \u03b8 where both agree at antipodal S\u00b9 points.\nError: BU for S\u00b9\u2192\u211d\u00b2 would need S\u00b2 domain, not S\u00b9. Axiom was unused \u2014 commented out.\n\n### Tucker's Lemma Analysis\nAll approaches to proving Tucker 2D are equivalent to Brouwer FPT in 2D:\n1. Path-following: triangulate cells, trace complementary-edge paths, odd boundary parity\n2. Degree theory: winding number of odd maps, extension implies degree 0\n3. Intersection theory: zero sets of g\u2081 and g\u2082 must cross (discrete Jordan curve)\n\nA SINGLE PATH argument FAILS: (0,T)\u2192(1,T)\u2192(0,F) avoids complementary edges.\nThe full 2D grid structure is essential.\n\n## Dead Ends\n- 1D Tucker reduction on single column/row: fails for 4 labels\n- Direct IVT on each coordinate: gives separate zeros, not common zero\n- Poincar\u00e9-Miranda without rotation: boundary conditions not satisfied\n"
   },
   "approaches": [],
   "tags": [
@@ -90,7 +93,7 @@
     "mathlib": []
   },
   "started": "2026-03-07T18:02:01.175Z",
-  "lastUpdate": "2026-03-14T15:30:00.000Z",
+  "lastUpdate": "2026-03-14T16:00:00.000Z",
   "significance": 7,
-  "tractability": 6
+  "tractability": 4
 }


### PR DESCRIPTION
## Summary
- Clean up BorsukUlamOQ03OQ03.lean: remove #check verification sections, update documentation
- Remove false axiom `two_function_circle_bu` from BorsukUlamOQ03OQ01.lean (with counterexample)
- Update problem knowledge with comprehensive Tucker 2D analysis

## Progress
- **OQ03OQ03**: 1 axiom (tuckers_lemma), 0 sorries — proof chain complete
- **OQ03OQ01**: 2 axioms (down from 3) — removed false axiom
- Documented three approaches to eliminate Tucker's axiom (path-following, degree theory, intersection theory)

## Findings
- `two_function_circle_bu` was FALSE: for f(x,y)=x, g(x,y)=y, no θ exists where both agree at antipodal S¹ points. Dimensional error: needs S² domain, not S¹.
- Tucker 2D elimination requires ~500-1000 lines of new infrastructure (equivalent to Brouwer FPT in 2D)
- Single-path arguments fail for 4-label Tucker: (0,T)→(1,T)→(0,F) avoids complementary edges

## Status
**Outcome**: progress (cleanup + false axiom discovery)
**Next Steps**: Tucker 2D proof is a multi-session project

🤖 Generated by researcher-4