### PR TITLE
Raise researcher slot range from 5 to 7

### DIFF
--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -53,7 +53,7 @@ DEFAULT_TESTER=1
 # Max pool sizes
 MAX_ENRICHER=5
 MAX_ARISTOTLE=2
-MAX_RESEARCHER=5
+MAX_RESEARCHER=7
 MAX_SEEKER=1
 MAX_DEPLOYER=1
 MAX_TESTER=1
@@ -240,7 +240,7 @@ get_sessions_for_type() {
             fi
             ;;
         researcher)
-            for i in 1 2 3 4 5; do
+            for i in $(seq 1 $MAX_RESEARCHER); do
                 if tmux has-session -t "researcher-$i" 2>/dev/null; then
                     sessions+=("researcher-$i")
                 fi
@@ -544,7 +544,7 @@ get_all_agent_sessions() {
         sessions+=("aristotle-agent")
     fi
     # Researchers
-    for i in 1 2 3 4 5; do
+    for i in $(seq 1 $MAX_RESEARCHER); do
         if tmux has-session -t "researcher-$i" 2>/dev/null; then
             sessions+=("researcher-$i")
         fi
@@ -1496,8 +1496,10 @@ cmd_daemon() {
         fi
 
         local enricher_active=0 researcher_active=0 aristotle_active=0 seeker_active=0 deployer_active=0
-        for i in 1 2 3 4 5; do
+        for i in $(seq 1 $MAX_ENRICHER); do
             tmux has-session -t "enricher-$i" 2>/dev/null && enricher_active=$((enricher_active + 1))
+        done
+        for i in $(seq 1 $MAX_RESEARCHER); do
             tmux has-session -t "researcher-$i" 2>/dev/null && researcher_active=$((researcher_active + 1))
         done
         tmux has-session -t "aristotle-agent" 2>/dev/null && aristotle_active=1
@@ -1522,7 +1524,7 @@ cmd_daemon() {
         if [[ $researcher_active -lt $researcher ]]; then
             local missing_res=$((researcher - researcher_active))
             daemon_log "INFO" "Pool gap: researcher has $researcher_active/$researcher, spawning $missing_res"
-            for i in $(seq 1 5); do
+            for i in $(seq 1 $MAX_RESEARCHER); do
                 [[ $missing_res -le 0 ]] && break
                 if ! tmux has-session -t "researcher-$i" 2>/dev/null; then
                     if is_cooldown_elapsed "researcher-$i"; then
@@ -1873,7 +1875,7 @@ cmd_spawn() {
             ;;
         researcher)
             echo -e "${BLUE}Spawning additional Researcher...${NC}"
-            for i in 1 2 3 4 5; do
+            for i in $(seq 1 $MAX_RESEARCHER); do
                 if ! tmux has-session -t "researcher-$i" 2>/dev/null; then
                     ./scripts/research/parallel-research.sh 1 &
                     sleep 2
@@ -2000,7 +2002,7 @@ cmd_scale() {
             fi
 
             local current=0
-            for i in 1 2 3 4 5; do
+            for i in $(seq 1 $MAX_RESEARCHER); do
                 if tmux has-session -t "researcher-$i" 2>/dev/null; then
                     current=$((current + 1))
                 fi
@@ -2071,7 +2073,7 @@ cmd_wake() {
             echo -e "${GREEN}Wake signal sent to aristotle-agent${NC}"
             ;;
         researcher)
-            for i in 1 2 3 4 5; do
+            for i in $(seq 1 $MAX_RESEARCHER); do
                 if tmux has-session -t "researcher-$i" 2>/dev/null; then
                     touch "$SIGNALS_DIR/wake-researcher-$i"
                     echo -e "${GREEN}Wake signal sent to researcher-$i${NC}"

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -152,8 +152,8 @@ gather_status() {
         aristotle_status="running:$(get_session_uptime "aristotle-agent")"
     fi
 
-    # Researchers
-    for i in 1 2 3 4 5; do
+    # Researchers (up to 7 supported)
+    for i in 1 2 3 4 5 6 7; do
         if session_exists "researcher-$i"; then
             researcher_sessions+=("researcher-$i:$(get_session_uptime "researcher-$i")")
         fi

--- a/scripts/research/parallel-research.sh
+++ b/scripts/research/parallel-research.sh
@@ -3,7 +3,7 @@
 # parallel-research.sh - Launch parallel research agents
 #
 # Usage:
-#   ./parallel-research.sh [count]           Launch N agents (default: 2, max: 5)
+#   ./parallel-research.sh [count]           Launch N agents (default: 2, max: 7)
 #   ./parallel-research.sh --status          Show running agents and claims
 #   ./parallel-research.sh --graceful-stop   Signal agents to stop after current work
 #   ./parallel-research.sh --stop            Force stop all agents immediately
@@ -242,7 +242,7 @@ launch_agents() {
     local wait_interval="${RESEARCHER_WAIT_INTERVAL:-15}"
 
     # Validate count
-    if [[ $count -lt 1 || $count -gt 5 ]]; then
+    if [[ $count -lt 1 || $count -gt 7 ]]; then
         print_error "Agent count must be between 1 and 5 (got: $count)"
         exit 1
     fi
@@ -451,7 +451,7 @@ Launch multiple Claude Code agents to work on research problems concurrently.
 Each agent works in its own git worktree with a dedicated branch.
 
 Usage:
-  ./parallel-research.sh [count]            Launch N agents (default: 2, max: 5)
+  ./parallel-research.sh [count]            Launch N agents (default: 2, max: 7)
   ./parallel-research.sh --status           Show running agents and claims
   ./parallel-research.sh --continue         Resume all agents after API limits reset
   ./parallel-research.sh --continue N       Resume agent N specifically


### PR DESCRIPTION
## Summary
- Raises `MAX_RESEARCHER` from 5 to 7 in `launch.sh`
- Replaces hardcoded `for i in 1 2 3 4 5` loops with `$(seq 1 $MAX_RESEARCHER)` for all researcher iterations (spawn, scale, wake, daemon respawn, session detection)
- Splits the shared enricher+researcher counting loop in the daemon into separate loops so each uses its own max
- Updates `parallel-research.sh` cap from 5 to 7
- Updates `status.sh` researcher loop to include slots 6 and 7

Enricher loops remain at 5 (correct max for that agent type).

## Test plan
- [ ] `./scripts/lean/launch.sh spawn researcher` finds slots 6-7 when 1-5 are full
- [ ] `./scripts/lean/status.sh` displays researchers 6 and 7
- [ ] `./scripts/lean/launch.sh scale researcher 7` counts all 7 slots
- [ ] `./scripts/lean/launch.sh wake researcher` sends wake signals to all active researchers

🤖 Generated with [Claude Code](https://claude.com/claude-code)