### PR TITLE
Add Herald agent for autonomous Mathstodon posting

### DIFF
--- a/.lean/roles/herald.md
+++ b/.lean/roles/herald.md
@@ -1,0 +1,117 @@
+# Herald Agent
+
+You are the **Herald** — the public voice of Lean Genius on Mathstodon (@rjwalters@mathstodon.xyz). You scan recent research activity and post noteworthy achievements to share formal mathematics progress with the community.
+
+## Significance Criteria
+
+### Tier 1 — Always Post
+
+- **Full proof completion**: A proof with 0 axioms and 0 sorries (fully verified by Lean)
+- **Freek 100 entry**: A theorem from the Freek 100 list has been formalized
+- **Soundness catch**: A proof attempt revealed an error or false assumption (interesting failure)
+
+### Tier 2 — Post If Notable
+
+- **Major axiom elimination**: Axiom count reduced to 0 from a non-trivial starting point (e.g., 5→0)
+- **Named theorem formalization**: A well-known theorem (not just a lemma) has been formalized
+- **Aristotle success**: Automated proof search closed all sorries in a file
+
+### Tier 3 — Weekly Only
+
+- **Cumulative stats**: "This week: N proofs completed, M axioms eliminated" style roundup
+- Post at most one Tier 3 per week
+
+### Never Post
+
+- Axiom decomposition (splitting axioms into smaller ones without eliminating them)
+- Enrichment batches (gallery metadata improvements)
+- Build fixes, CI changes, data syncs
+- Partial progress (e.g., "reduced from 5 to 3 axioms" — wait for completion)
+- Agent infrastructure changes
+
+## Rate Limits
+
+- **Max 1 post per scan cycle** (6 hours default)
+- **Max 2 posts per calendar day (UTC)**
+- If multiple Tier 1 results exist, pick the most significant one; save others for next cycle
+
+## Post Style Guide
+
+### Tone
+- Enthusiastic but precise. This is a math audience.
+- First person plural ("We proved..." / "We formalized...")
+- Include the mathematical content, not just "we did a thing"
+
+### Structure
+- Lead with the result: "Proved the Intermediate Value Theorem in Lean 4..."
+- Include key details: axiom/sorry count, technique used, problem origin
+- End with a link to the gallery page or PR when available
+- Use #LeanProver and #FormalMath hashtags
+
+### Length
+- Target 200-400 characters. Max 500 (Mastodon limit).
+- Shorter is better. Don't pad.
+
+### Examples
+
+Good:
+```
+Fully verified: the Intermediate Value Theorem in Lean 4. Zero axioms, zero sorries — every step checked by the kernel.
+
+Live proof: https://lean-genius.com/proofs/intermediate-value-theorem
+
+#LeanProver #FormalMath
+```
+
+Good:
+```
+Aristotle (our automated proof search) just closed all 10 sorries in the motivic flag maps formalization. 1,416 lines of machine-generated proof, verified by Lean 4.
+
+#LeanProver #FormalMath
+```
+
+Good:
+```
+This week in Lean Genius: 4 proofs completed, 12 axioms eliminated, 3 new Erdos problems formalized. The gallery now has 247 fully verified entries.
+
+#LeanProver #FormalMath
+```
+
+Bad (too vague):
+```
+Made some progress on formalizing math today!
+```
+
+Bad (not noteworthy):
+```
+Updated gallery metadata for 15 entries with better cross-references.
+```
+
+## State Management
+
+Track posted milestones in `.loom/state/herald-posts.json`:
+```json
+{
+  "posts": [
+    {
+      "subject": "ivt-full-proof",
+      "text": "Fully verified: the Intermediate Value Theorem...",
+      "url": "https://mathstodon.xyz/@rjwalters/12345",
+      "posted_at": "2026-03-14T10:30:00Z"
+    }
+  ],
+  "daily_counts": {
+    "2026-03-14": 1
+  }
+}
+```
+
+- Use `subject` as a dedup key (e.g., proof slug or PR number)
+- Clean up `daily_counts` entries older than 7 days periodically
+
+## Tools
+
+- `./scripts/herald/post-mathstodon.sh "text"` — Post to Mathstodon
+- `./scripts/herald/post-mathstodon.sh --dry-run "text"` — Preview without posting
+- `git log --oneline --since="7 hours ago"` — Recent commits
+- `jq` — Parse state files and meta.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,9 @@ This project uses **two distinct AI agent orchestration systems** for different 
 | **Seeker** | Selects research problems when candidate pool runs low | Autonomous (15min) |
 | **Deployer** | Merges PRs, syncs data, deploys website to Cloudflare | Autonomous (30min) |
 | **Tester** | Tests random proof pages on the live site, files issues on failure | Autonomous (30min) |
+| **Herald** | Posts noteworthy research results to Mathstodon | Autonomous (6h) |
 
-**Managed by `/lean`**: Enricher, Aristotle, Researcher, Seeker, Deployer, Tester
+**Managed by `/lean`**: Enricher, Aristotle, Researcher, Seeker, Deployer, Tester, Herald
 **Managed separately**: Erdos Enhancer (`make enhance`, `scripts/erdos/`)
 
 **Invoke via**: `/enricher`, `/aristotle`, `/research`, `/scout`, `/seeker`, `/deploy`
@@ -110,6 +111,7 @@ The `/lean` skill provides a unified interface to start, stop, and scale the mat
 | Seeker | 1 | 1 |
 | Deployer | 1 | 1 |
 | Tester | 1 | 1 |
+| Herald | 1 | 1 |
 
 ## Helper Scripts
 

--- a/scripts/herald/launch-agent.sh
+++ b/scripts/herald/launch-agent.sh
@@ -1,0 +1,416 @@
+#!/bin/bash
+#
+# launch-agent.sh - Launch the Herald agent
+#
+# The Herald periodically scans for noteworthy results and posts highlights
+# to Mathstodon (@rjwalters@mathstodon.xyz). Read-only agent, no worktree needed.
+#
+# Usage:
+#   ./launch-agent.sh              Launch herald (default 6h interval)
+#   ./launch-agent.sh --stop       Stop the herald
+#   ./launch-agent.sh --status     Check herald status
+#   ./launch-agent.sh --attach     Attach to herald session
+#   ./launch-agent.sh --logs       Tail herald logs
+#   ./launch-agent.sh --graceful-stop  Signal herald to stop after current work
+#
+# Environment:
+#   HERALD_INTERVAL - Interval in minutes between scans (default: 360 = 6 hours)
+
+set -euo pipefail
+
+# Find repo root
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "Error: Not in a git repository" >&2
+    return 1
+}
+
+REPO_ROOT="$(find_repo_root)"
+LOGS_DIR="$REPO_ROOT/.loom/logs"
+SIGNALS_DIR="$REPO_ROOT/.loom/signals"
+STATE_DIR="$REPO_ROOT/.loom/state"
+SESSION_NAME="herald-agent"
+LOG_FILE="$LOGS_DIR/herald.log"
+INTERVAL="${HERALD_INTERVAL:-360}"
+STATE_FILE="$STATE_DIR/herald-posts.json"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+print_error() { echo -e "${RED}x $1${NC}"; }
+print_success() { echo -e "${GREEN}+ $1${NC}"; }
+print_info() { echo -e "${BLUE}i $1${NC}"; }
+print_warning() { echo -e "${YELLOW}! $1${NC}"; }
+
+# Check dependencies
+check_deps() {
+    local missing=()
+    command -v tmux >/dev/null 2>&1 || missing+=("tmux")
+    command -v claude >/dev/null 2>&1 || missing+=("claude")
+    command -v jq >/dev/null 2>&1 || missing+=("jq")
+    command -v curl >/dev/null 2>&1 || missing+=("curl")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        print_error "Missing dependencies: ${missing[*]}"
+        exit 1
+    fi
+
+    # Validate token
+    if [[ -f "$REPO_ROOT/.env" ]]; then
+        if ! grep -q '^MATHSTODON_TOKEN=' "$REPO_ROOT/.env"; then
+            print_error "MATHSTODON_TOKEN not found in .env"
+            exit 1
+        fi
+    else
+        print_error ".env file not found"
+        exit 1
+    fi
+}
+
+# Initialize state file if needed
+init_state() {
+    mkdir -p "$STATE_DIR"
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo '{"posts": [], "daily_counts": {}}' > "$STATE_FILE"
+        print_info "Created herald state file: $STATE_FILE"
+    fi
+}
+
+# Create prompt file for herald
+create_prompt_file() {
+    local prompt_file="$LOGS_DIR/herald-prompt.md"
+
+    cat > "$prompt_file" << 'PROMPT_EOF'
+# Herald Agent Instructions
+
+You are the **herald** agent for Lean Genius. Your mission is to post noteworthy mathematical achievements to Mathstodon (@rjwalters@mathstodon.xyz).
+
+## Environment
+
+- REPO_ROOT: ${REPO_ROOT}
+- INTERVAL: ${INTERVAL} minutes (${INTERVAL_HOURS} hours)
+- STATE_FILE: ${STATE_FILE}
+- LOG_FILE: ${LOG_FILE}
+
+## Your Workflow (Repeat Every Cycle)
+
+### 1. Check for stop signal
+```bash
+if [[ -f "${SIGNALS_DIR}/stop-herald" ]] || [[ -f "${SIGNALS_DIR}/stop-all" ]]; then
+    echo "Stop signal received. Exiting."
+    exit 0
+fi
+```
+
+### 2. Read your role definition
+```bash
+cat ${REPO_ROOT}/.lean/roles/herald.md
+```
+
+### 3. Check daily rate limit
+```bash
+TODAY=$(date -u +%Y-%m-%d)
+POSTS_TODAY=$(jq -r --arg d "$TODAY" '.daily_counts[$d] // 0' ${STATE_FILE})
+echo "Posts today: $POSTS_TODAY (max: 2)"
+```
+If already at 2 posts today, skip to sleep.
+
+### 4. Load post history (for dedup)
+```bash
+# Recent post subjects to avoid duplicates
+jq -r '.posts[-10:][].subject' ${STATE_FILE} 2>/dev/null || echo "(no history)"
+```
+
+### 5. Scan for noteworthy results
+
+Check these sources for significant events since last scan:
+
+**Git log** (research PRs merged recently):
+```bash
+git log --oneline --since="7 hours ago" --grep="Research:" --grep="Proof:" --grep="axiom" --grep="sorry" | head -20
+```
+
+**Action logs** (enricher/researcher completions):
+```bash
+ls -lt ${REPO_ROOT}/.loom/signals/completions/ 2>/dev/null | head -10
+```
+
+**Proof files** (check for zero-sorry, zero-axiom proofs):
+```bash
+# Find recently modified proof files
+find ${REPO_ROOT}/proofs/Proofs -name "*.lean" -mmin -420 -type f 2>/dev/null | head -10
+# For each, check sorry/axiom count
+```
+
+**Gallery meta.json** (check for quality scores, new entries):
+```bash
+# Recently updated gallery entries
+find ${REPO_ROOT}/src/data/proofs -name "meta.json" -mmin -420 -type f 2>/dev/null | head -10
+```
+
+### 6. Assess significance
+
+Apply the criteria from your role definition (herald.md):
+- **Tier 1 (always post)**: Full proof completion (0 axioms, 0 sorries), Freek 100 entry, soundness catch
+- **Tier 2 (if notable)**: Major axiom elimination (N→0), named theorem formalization
+- **Tier 3 (weekly max)**: Cumulative stats roundup
+
+Skip if nothing meets the threshold.
+
+### 7. Compose and post
+
+If a significant result is found:
+
+a. Compose a post (max 500 chars). Follow the style guide in herald.md.
+
+b. Check it hasn't been posted before:
+```bash
+jq --arg s "SUBJECT_KEY" '.posts[] | select(.subject == $s)' ${STATE_FILE}
+```
+
+c. Post it:
+```bash
+${REPO_ROOT}/scripts/herald/post-mathstodon.sh "Your post text here"
+```
+
+d. Update state:
+```bash
+TODAY=$(date -u +%Y-%m-%d)
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+tmp=$(mktemp)
+jq --arg subject "SUBJECT_KEY" \
+   --arg text "POST_TEXT" \
+   --arg url "POST_URL" \
+   --arg ts "$NOW" \
+   --arg day "$TODAY" \
+   '.posts += [{"subject": $subject, "text": $text, "url": $url, "posted_at": $ts}] | .daily_counts[$day] = ((.daily_counts[$day] // 0) + 1)' \
+   ${STATE_FILE} > "$tmp" && mv "$tmp" ${STATE_FILE}
+```
+
+### 8. Sleep until next cycle
+```bash
+echo "Next scan in ${INTERVAL} minutes..."
+sleep ${INTERVAL}m
+```
+
+### 9. Repeat from step 1
+
+## Important Rules
+
+- **Max 1 post per cycle, max 2 posts per day**
+- **Never post about**: build fixes, data syncs, enrichment batches, axiom decomposition
+- **Always check dedup** before posting
+- Posts must be ≤500 characters
+- Use --dry-run first if unsure about a post
+
+Good luck, herald!
+PROMPT_EOF
+
+    # Now do variable substitution (the prompt uses ${VAR} placeholders)
+    local interval_hours=$((INTERVAL / 60))
+    sed -i '' \
+        -e "s|\${REPO_ROOT}|$REPO_ROOT|g" \
+        -e "s|\${INTERVAL}|$INTERVAL|g" \
+        -e "s|\${INTERVAL_HOURS}|$interval_hours|g" \
+        -e "s|\${STATE_FILE}|$STATE_FILE|g" \
+        -e "s|\${LOG_FILE}|$LOG_FILE|g" \
+        -e "s|\${SIGNALS_DIR}|$SIGNALS_DIR|g" \
+        "$prompt_file"
+
+    echo "$prompt_file"
+}
+
+# Launch the herald agent
+launch_agent() {
+    check_deps
+    mkdir -p "$LOGS_DIR" "$SIGNALS_DIR" "$STATE_DIR"
+
+    # Remove any existing stop signal
+    rm -f "$SIGNALS_DIR/stop-herald"
+
+    # Kill existing session if any
+    tmux kill-session -t "$SESSION_NAME" 2>/dev/null || true
+
+    # Initialize state
+    init_state
+
+    # Create prompt file
+    local prompt_file
+    prompt_file=$(create_prompt_file)
+
+    local interval_hours=$((INTERVAL / 60))
+
+    print_info "Launching herald agent..."
+    print_info "Interval: ${INTERVAL}m (${interval_hours}h)"
+    print_info "State: $STATE_FILE"
+
+    # Launch in tmux — no worktree needed (read-only agent)
+    local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
+    tmux new-session -d -s "$SESSION_NAME" -c "$REPO_ROOT" \
+        "ENHANCER_ID=herald REPO_ROOT=$REPO_ROOT $wrapper_script --daemon --prompt 'You are the herald agent. Read $prompt_file for your instructions, then start the scan loop.' --log '$LOG_FILE'"
+
+    print_success "Launched herald agent"
+    echo ""
+    echo "Commands:"
+    echo "  ./scripts/herald/launch-agent.sh --status     Check status"
+    echo "  ./scripts/herald/launch-agent.sh --attach     Attach to session"
+    echo "  ./scripts/herald/launch-agent.sh --logs       Tail logs"
+    echo "  ./scripts/herald/launch-agent.sh --stop       Stop agent"
+}
+
+# Stop the herald
+stop_agent() {
+    print_info "Stopping herald agent..."
+
+    # Create stop signal for graceful shutdown
+    touch "$SIGNALS_DIR/stop-herald"
+
+    # Give it a moment to notice
+    sleep 2
+
+    # Kill the session
+    if tmux kill-session -t "$SESSION_NAME" 2>/dev/null; then
+        print_success "Stopped herald agent"
+    else
+        print_info "No herald session found"
+    fi
+
+    # Clean up signal
+    rm -f "$SIGNALS_DIR/stop-herald"
+}
+
+# Graceful stop (just create signal, don't kill)
+graceful_stop_agent() {
+    print_info "Sending graceful stop signal to herald agent..."
+    mkdir -p "$SIGNALS_DIR"
+    touch "$SIGNALS_DIR/stop-herald"
+    print_success "Stop signal created. Herald will stop after current work."
+}
+
+# Check status
+check_status() {
+    echo "=== Herald Status ==="
+    echo ""
+
+    if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+        print_success "Herald is running"
+        echo ""
+        echo "Session: $SESSION_NAME"
+        echo "Log file: $LOG_FILE"
+        echo "Interval: $INTERVAL minutes"
+
+        if [[ -f "$STATE_FILE" ]]; then
+            local total_posts
+            total_posts=$(jq '.posts | length' "$STATE_FILE" 2>/dev/null || echo "0")
+            local today
+            today=$(date -u +%Y-%m-%d)
+            local today_posts
+            today_posts=$(jq -r --arg d "$today" '.daily_counts[$d] // 0' "$STATE_FILE" 2>/dev/null || echo "0")
+            echo "Total posts: $total_posts"
+            echo "Posts today: $today_posts / 2"
+
+            if [[ "$total_posts" -gt 0 ]]; then
+                echo ""
+                echo "Last post:"
+                jq -r '.posts[-1] | "  \(.posted_at): \(.text[0:80])..."' "$STATE_FILE" 2>/dev/null || true
+            fi
+        fi
+
+        if [[ -f "$LOG_FILE" ]]; then
+            echo ""
+            echo "Recent activity:"
+            tail -5 "$LOG_FILE" 2>/dev/null || echo "  (no logs yet)"
+        fi
+    else
+        print_info "Herald is not running"
+        echo ""
+        if [[ -f "$STATE_FILE" ]]; then
+            local total_posts
+            total_posts=$(jq '.posts | length' "$STATE_FILE" 2>/dev/null || echo "0")
+            echo "Total posts: $total_posts"
+        fi
+    fi
+}
+
+# Attach to session
+attach_session() {
+    if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+        print_error "No herald session found"
+        exit 1
+    fi
+    tmux attach-session -t "$SESSION_NAME"
+}
+
+# Tail logs
+tail_logs() {
+    if [[ ! -f "$LOG_FILE" ]]; then
+        print_error "No log file found: $LOG_FILE"
+        exit 1
+    fi
+    tail -f "$LOG_FILE"
+}
+
+# Main command dispatch
+case "${1:-}" in
+    --stop|-s)
+        stop_agent
+        ;;
+    --graceful-stop)
+        graceful_stop_agent
+        ;;
+    --status)
+        check_status
+        ;;
+    --attach|-a)
+        attach_session
+        ;;
+    --logs|-l)
+        tail_logs
+        ;;
+    --help|-h)
+        cat << EOF
+Herald Agent Launcher
+
+Launches an autonomous agent that periodically scans for noteworthy
+mathematical results and posts highlights to Mathstodon.
+
+The agent runs in the main repo (read-only, no worktree needed).
+
+Usage:
+  ./launch-agent.sh              Launch herald (default 6h interval)
+  ./launch-agent.sh --stop       Stop the herald
+  ./launch-agent.sh --graceful-stop  Signal herald to stop
+  ./launch-agent.sh --status     Check herald status
+  ./launch-agent.sh --attach     Attach to herald session
+  ./launch-agent.sh --logs       Tail herald logs
+  ./launch-agent.sh --help       Show this help
+
+Environment Variables:
+  HERALD_INTERVAL    Interval in minutes between scans (default: 360 = 6 hours)
+
+Examples:
+  ./launch-agent.sh                        # Start with defaults (6h cycle)
+  HERALD_INTERVAL=60 ./launch-agent.sh     # Scan every hour
+  ./launch-agent.sh --attach               # Watch the agent work
+EOF
+        ;;
+    "")
+        launch_agent
+        ;;
+    *)
+        print_error "Unknown option: $1"
+        echo "Run '$0 --help' for usage"
+        exit 1
+        ;;
+esac

--- a/scripts/herald/post-mathstodon.sh
+++ b/scripts/herald/post-mathstodon.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# post-mathstodon.sh - Post a status to Mathstodon (Mastodon)
+#
+# Usage:
+#   ./post-mathstodon.sh "Your post text here"
+#   ./post-mathstodon.sh --dry-run "Test post"
+#
+# Environment:
+#   MATHSTODON_TOKEN - API access token (read from .env if not set)
+#
+
+set -euo pipefail
+
+# Config
+MASTODON_INSTANCE="https://mathstodon.xyz"
+MAX_CHARS=500
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Find repo root
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# Load token from .env if not already set
+if [[ -z "${MATHSTODON_TOKEN:-}" ]]; then
+    if [[ -f "$REPO_ROOT/.env" ]]; then
+        MATHSTODON_TOKEN=$(grep '^MATHSTODON_TOKEN=' "$REPO_ROOT/.env" | cut -d= -f2- | tr -d "'\"")
+    fi
+fi
+
+if [[ -z "${MATHSTODON_TOKEN:-}" ]]; then
+    echo -e "${RED}Error: MATHSTODON_TOKEN not set. Add it to .env or export it.${NC}" >&2
+    exit 1
+fi
+
+# Parse arguments
+DRY_RUN=false
+TEXT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        *)
+            TEXT="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$TEXT" ]]; then
+    echo "Usage: $0 [--dry-run] \"Post text\"" >&2
+    exit 1
+fi
+
+# Validate character limit
+CHAR_COUNT=${#TEXT}
+if [[ $CHAR_COUNT -gt $MAX_CHARS ]]; then
+    echo -e "${RED}Error: Post is $CHAR_COUNT chars (max $MAX_CHARS)${NC}" >&2
+    exit 1
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo -e "${YELLOW}[DRY RUN] Would post ($CHAR_COUNT chars):${NC}"
+    echo "$TEXT"
+    exit 0
+fi
+
+# Post via Mastodon API
+# Use jq for proper JSON escaping of the status text
+JSON_PAYLOAD=$(jq -n --arg status "$TEXT" '{"status": $status, "visibility": "public"}')
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+    -X POST \
+    -H "Authorization: Bearer $MATHSTODON_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$JSON_PAYLOAD" \
+    "$MASTODON_INSTANCE/api/v1/statuses")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
+    POST_URL=$(echo "$BODY" | jq -r '.url // empty')
+    POST_ID=$(echo "$BODY" | jq -r '.id // empty')
+    echo -e "${GREEN}Posted successfully ($CHAR_COUNT chars)${NC}"
+    if [[ -n "$POST_URL" ]]; then
+        echo "$POST_URL"
+    fi
+    echo "$POST_ID"
+else
+    ERROR_MSG=$(echo "$BODY" | jq -r '.error // "Unknown error"' 2>/dev/null || echo "$BODY")
+    echo -e "${RED}Error posting (HTTP $HTTP_CODE): $ERROR_MSG${NC}" >&2
+    exit 1
+fi

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -80,6 +80,7 @@ Start Options:
   --seeker N             Number of Seeker agents (default: $DEFAULT_SEEKER, max: $MAX_SEEKER)
   --deployer N           Number of Deployers (default: $DEFAULT_DEPLOYER, max: $MAX_DEPLOYER)
   --tester N             Number of Testers (default: $DEFAULT_TESTER, max: $MAX_TESTER)
+  --herald N             Number of Heralds (default: $DEFAULT_HERALD, max: $MAX_HERALD)
 
 Stop Options:
   <type>                 Stop only agents of this type (enricher, aristotle, etc.)
@@ -93,6 +94,7 @@ Daemon Options:
   --seeker N             Initial Seeker agent count (default: $DEFAULT_SEEKER, max: $MAX_SEEKER)
   --deployer N           Initial Deployer count (default: $DEFAULT_DEPLOYER, max: $MAX_DEPLOYER)
   --tester N             Initial Tester count (default: $DEFAULT_TESTER, max: $MAX_TESTER)
+  --herald N             Initial Herald count (default: $DEFAULT_HERALD, max: $MAX_HERALD)
 
 Agent Types:
   enricher    Enriches proof gallery entries with deeper annotations and commentary
@@ -101,6 +103,7 @@ Agent Types:
   seeker      Selects research problems when candidate pool runs low
   deployer    Merges PRs and deploys website
   tester      Tests random proof pages on the live site
+  herald      Posts noteworthy results to Mathstodon
 
 Examples:
   $0 start                              # Start with defaults
@@ -139,6 +142,7 @@ init_state() {
     local seeker="${4:-$DEFAULT_SEEKER}"
     local deployer="${5:-$DEFAULT_DEPLOYER}"
     local tester="${6:-$DEFAULT_TESTER}"
+    local herald="${7:-$DEFAULT_HERALD}"
 
     mkdir -p "$(dirname "$STATE_FILE")"
 
@@ -160,6 +164,7 @@ init_state() {
         --argjson seeker "$seeker" \
         --argjson deployer "$deployer" \
         --argjson tester "$tester" \
+        --argjson herald "$herald" \
         --argjson prev_stats "$prev_stats" \
         '{
             started_at: $started_at,
@@ -170,7 +175,8 @@ init_state() {
                 researcher: $researcher,
                 seeker: $seeker,
                 deployer: $deployer,
-                tester: $tester
+                tester: $tester,
+                herald: $herald
             },
             agents: {},
             session_stats: (
@@ -261,6 +267,11 @@ get_sessions_for_type() {
                 sessions+=("tester-agent")
             fi
             ;;
+        herald)
+            if tmux has-session -t "herald-agent" 2>/dev/null; then
+                sessions+=("herald-agent")
+            fi
+            ;;
     esac
 
     if [[ ${#sessions[@]} -gt 0 ]]; then
@@ -296,6 +307,9 @@ signal_stop_session() {
             ;;
         tester)
             touch "$SIGNALS_DIR/stop-tester"
+            ;;
+        herald)
+            touch "$SIGNALS_DIR/stop-herald"
             ;;
     esac
 }
@@ -369,6 +383,7 @@ cmd_start() {
     local seeker=$DEFAULT_SEEKER
     local deployer=$DEFAULT_DEPLOYER
     local tester=$DEFAULT_TESTER
+    local herald=$DEFAULT_HERALD
 
     # Parse options
     while [[ $# -gt 0 ]]; do
@@ -395,6 +410,10 @@ cmd_start() {
                 ;;
             --tester)
                 tester="$2"
+                shift 2
+                ;;
+            --herald)
+                herald="$2"
                 shift 2
                 ;;
             *)
@@ -430,6 +449,10 @@ cmd_start() {
         echo -e "${YELLOW}Warning: Tester count $tester exceeds max $MAX_TESTER, using $MAX_TESTER${NC}"
         tester=$MAX_TESTER
     fi
+    if [[ $herald -gt $MAX_HERALD ]]; then
+        echo -e "${YELLOW}Warning: Herald count $herald exceeds max $MAX_HERALD, using $MAX_HERALD${NC}"
+        herald=$MAX_HERALD
+    fi
 
     echo -e "${BOLD}Starting Lean Genius Mathematical Orchestration${NC}"
     echo ""
@@ -440,13 +463,14 @@ cmd_start() {
     echo "  Seekers: $seeker"
     echo "  Deployers: $deployer"
     echo "  Testers: $tester"
+    echo "  Heralds: $herald"
     echo ""
 
     # Migrate state file from old location if needed
     migrate_state_file
 
     # Initialize state
-    init_state "$enricher" "$aristotle" "$researcher" "$seeker" "$deployer" "$tester"
+    init_state "$enricher" "$aristotle" "$researcher" "$seeker" "$deployer" "$tester" "$herald"
 
     # Start agents
     local started=0
@@ -517,6 +541,17 @@ cmd_start() {
         fi
     fi
 
+    # Herald
+    if [[ $herald -gt 0 ]]; then
+        echo -e "${BLUE}Starting Herald agent...${NC}"
+        if check_script "./scripts/herald/launch-agent.sh"; then
+            ./scripts/herald/launch-agent.sh &
+            sleep 1
+            echo -e "${GREEN}✓ Herald agent launched${NC}"
+            started=$((started + 1))
+        fi
+    fi
+
     echo ""
     if [[ $started -gt 0 ]]; then
         echo -e "${GREEN}${BOLD}✓ Lean Genius team started!${NC}"
@@ -560,6 +595,10 @@ get_all_agent_sessions() {
     # Tester
     if tmux has-session -t "tester-agent" 2>/dev/null; then
         sessions+=("tester-agent")
+    fi
+    # Herald
+    if tmux has-session -t "herald-agent" 2>/dev/null; then
+        sessions+=("herald-agent")
     fi
     if [[ ${#sessions[@]} -gt 0 ]]; then
         printf '%s\n' "${sessions[@]}"
@@ -726,7 +765,7 @@ is_polling_agent() {
     local session="$1"
     local agent_type
     agent_type=$(get_agent_type "$session")
-    [[ "$agent_type" == "deployer" || "$agent_type" == "seeker" || "$agent_type" == "tester" ]]
+    [[ "$agent_type" == "deployer" || "$agent_type" == "seeker" || "$agent_type" == "tester" || "$agent_type" == "herald" ]]
 }
 
 # Helper: Determine agent health status
@@ -1018,6 +1057,7 @@ get_agent_type() {
         seeker-agent)     echo "seeker" ;;
         deployer)         echo "deployer" ;;
         tester-agent)     echo "tester" ;;
+        herald-agent)     echo "herald" ;;
         *)                echo "unknown" ;;
     esac
 }
@@ -1149,6 +1189,15 @@ respawn_agent() {
                 daemon_log "INFO" "Tester agent respawned"
             else
                 daemon_log "WARN" "Cannot respawn tester: script not found"
+            fi
+            ;;
+        herald)
+            if check_script "./scripts/herald/launch-agent.sh" 2>/dev/null; then
+                ./scripts/herald/launch-agent.sh &
+                sleep 1
+                daemon_log "INFO" "Herald agent respawned"
+            else
+                daemon_log "WARN" "Cannot respawn herald: script not found"
             fi
             ;;
         *)
@@ -1307,6 +1356,7 @@ cmd_daemon() {
     local seeker=$DEFAULT_SEEKER
     local deployer=$DEFAULT_DEPLOYER
     local tester=$DEFAULT_TESTER
+    local herald=$DEFAULT_HERALD
 
     # Parse options
     while [[ $# -gt 0 ]]; do
@@ -1337,6 +1387,10 @@ cmd_daemon() {
                 ;;
             --tester)
                 tester="$2"
+                shift 2
+                ;;
+            --herald)
+                herald="$2"
                 shift 2
                 ;;
             *)
@@ -1377,10 +1431,10 @@ cmd_daemon() {
     trap 'daemon_log "INFO" "Received SIGINT"; exit 0' INT
 
     daemon_log "INFO" "Starting daemon (PID $$, interval ${interval}s)"
-    daemon_log "INFO" "Pool config: enricher=$enricher, aristotle=$aristotle, researcher=$researcher, seeker=$seeker, deployer=$deployer, tester=$tester"
+    daemon_log "INFO" "Pool config: enricher=$enricher, aristotle=$aristotle, researcher=$researcher, seeker=$seeker, deployer=$deployer, tester=$tester, herald=$herald"
 
     # Start initial agents via cmd_start
-    cmd_start --enricher "$enricher" --aristotle "$aristotle" --researcher "$researcher" --seeker "$seeker" --deployer "$deployer" --tester "$tester"
+    cmd_start --enricher "$enricher" --aristotle "$aristotle" --researcher "$researcher" --seeker "$seeker" --deployer "$deployer" --tester "$tester" --herald "$herald"
 
     local cycle_count=0
     local total_respawns=0
@@ -1493,9 +1547,10 @@ cmd_daemon() {
             researcher=$(jq -r '.config.researcher // 0' "$STATE_FILE" 2>/dev/null || echo "$researcher")
             seeker=$(jq -r '.config.seeker // 0' "$STATE_FILE" 2>/dev/null || echo "$seeker")
             deployer=$(jq -r '.config.deployer // 0' "$STATE_FILE" 2>/dev/null || echo "$deployer")
+            herald=$(jq -r '.config.herald // 0' "$STATE_FILE" 2>/dev/null || echo "$herald")
         fi
 
-        local enricher_active=0 researcher_active=0 aristotle_active=0 seeker_active=0 deployer_active=0
+        local enricher_active=0 researcher_active=0 aristotle_active=0 seeker_active=0 deployer_active=0 herald_active=0
         for i in $(seq 1 $MAX_ENRICHER); do
             tmux has-session -t "enricher-$i" 2>/dev/null && enricher_active=$((enricher_active + 1))
         done
@@ -1505,6 +1560,7 @@ cmd_daemon() {
         tmux has-session -t "aristotle-agent" 2>/dev/null && aristotle_active=1
         tmux has-session -t "seeker-agent" 2>/dev/null && seeker_active=1
         tmux has-session -t "deployer" 2>/dev/null && deployer_active=1
+        tmux has-session -t "herald-agent" 2>/dev/null && herald_active=1
 
         if [[ $enricher_active -lt $enricher ]]; then
             local missing_enricher=$((enricher - enricher_active))
@@ -1551,6 +1607,11 @@ cmd_daemon() {
         if [[ $deployer_active -lt $deployer ]] && is_cooldown_elapsed "deployer"; then
             daemon_log "INFO" "Pool gap: deployer has 0/$deployer, spawning"
             respawn_agent "deployer"
+            total_respawns=$((total_respawns + 1))
+        fi
+        if [[ $herald_active -lt $herald ]] && is_cooldown_elapsed "herald-agent"; then
+            daemon_log "INFO" "Pool gap: herald has 0/$herald, spawning"
+            respawn_agent "herald-agent"
             total_respawns=$((total_respawns + 1))
         fi
 
@@ -1605,13 +1666,13 @@ cmd_stop() {
                 force=true
                 shift
                 ;;
-            enricher|aristotle|researcher|seeker|deployer)
+            enricher|aristotle|researcher|seeker|deployer|herald)
                 agent_type="$1"
                 shift
                 ;;
             *)
                 echo -e "${RED}Unknown stop option: $1${NC}" >&2
-                echo "Usage: $0 stop [enricher|aristotle|researcher|seeker|deployer] [--force]"
+                echo "Usage: $0 stop [enricher|aristotle|researcher|seeker|deployer|herald] [--force]"
                 exit 1
                 ;;
         esac
@@ -1663,7 +1724,7 @@ cmd_stop() {
         # Safety net: kill any remaining agent sessions
         echo -e "${BLUE}Catch-all: cleaning remaining agent sessions...${NC}"
         local remaining_sessions
-        remaining_sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E '^(enricher-|researcher-|aristotle-agent$|seeker-agent$|deployer$)' || true)
+        remaining_sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E '^(enricher-|researcher-|aristotle-agent$|seeker-agent$|deployer$|herald-agent$|tester-agent$)' || true)
         if [[ -n "$remaining_sessions" ]]; then
             while IFS= read -r session; do
                 echo -e "  Killing stale session: $session"
@@ -1832,6 +1893,11 @@ cmd_stop_type() {
                     ./scripts/test/launch-agent.sh --graceful-stop 2>/dev/null || true
                 fi
                 ;;
+            herald)
+                if [[ -x "./scripts/herald/launch-agent.sh" ]]; then
+                    ./scripts/herald/launch-agent.sh --graceful-stop 2>/dev/null || true
+                fi
+                ;;
         esac
 
         # Wait up to 60s for graceful shutdown, then force-kill
@@ -1844,7 +1910,7 @@ cmd_spawn() {
     local agent_type="${1:-}"
 
     if [[ -z "$agent_type" ]]; then
-        echo -e "${RED}Error: Must specify agent type (enricher, aristotle, researcher, deployer, tester)${NC}" >&2
+        echo -e "${RED}Error: Must specify agent type (enricher, aristotle, researcher, deployer, tester, herald)${NC}" >&2
         exit 1
     fi
 
@@ -1915,9 +1981,19 @@ cmd_spawn() {
                 echo -e "${GREEN}✓ Tester agent spawned${NC}"
             fi
             ;;
+        herald)
+            echo -e "${BLUE}Spawning Herald agent...${NC}"
+            if tmux has-session -t "herald-agent" 2>/dev/null; then
+                echo -e "${YELLOW}Herald agent already running${NC}"
+            else
+                ./scripts/herald/launch-agent.sh &
+                sleep 1
+                echo -e "${GREEN}✓ Herald agent spawned${NC}"
+            fi
+            ;;
         *)
             echo -e "${RED}Unknown agent type: $agent_type${NC}" >&2
-            echo "Valid types: enricher, aristotle, researcher, seeker, deployer, tester"
+            echo "Valid types: enricher, aristotle, researcher, seeker, deployer, tester, herald"
             exit 1
             ;;
     esac
@@ -2021,7 +2097,7 @@ cmd_scale() {
                 echo -e "${GREEN}Already at $count Researchers${NC}"
             fi
             ;;
-        aristotle|seeker|deployer|tester)
+        aristotle|seeker|deployer|tester|herald)
             if [[ $count -gt 1 ]]; then
                 echo -e "${YELLOW}$agent_type can only have 0 or 1 instance, using 1${NC}"
                 count=1
@@ -2051,7 +2127,7 @@ cmd_scale() {
             ;;
         *)
             echo -e "${RED}Unknown agent type: $agent_type${NC}" >&2
-            echo "Valid types: enricher, researcher, aristotle, seeker, deployer, tester"
+            echo "Valid types: enricher, researcher, aristotle, seeker, deployer, tester, herald"
             exit 1
             ;;
     esac
@@ -2100,9 +2176,13 @@ cmd_wake() {
             touch "$SIGNALS_DIR/wake-tester-agent"
             echo -e "${GREEN}Wake signal sent to tester-agent${NC}"
             ;;
+        herald)
+            touch "$SIGNALS_DIR/wake-herald-agent"
+            echo -e "${GREEN}Wake signal sent to herald-agent${NC}"
+            ;;
         *)
             echo -e "${RED}Unknown agent type: $agent_type${NC}" >&2
-            echo "Valid types: all, aristotle, researcher, deployer, seeker, enricher, tester"
+            echo "Valid types: all, aristotle, researcher, deployer, seeker, enricher, tester, herald"
             exit 1
             ;;
     esac

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -139,6 +139,7 @@ gather_status() {
     local seeker_status="stopped"
     local deployer_status="stopped"
     local tester_status="stopped"
+    local herald_status="stopped"
 
     # Enrichers
     for i in 1 2 3 4 5; do
@@ -172,6 +173,11 @@ gather_status() {
     # Tester
     if session_exists "tester-agent"; then
         tester_status="running:$(get_session_uptime "tester-agent")"
+    fi
+
+    # Herald
+    if session_exists "herald-agent"; then
+        herald_status="running:$(get_session_uptime "herald-agent")"
     fi
 
     # Work queue counts
@@ -242,6 +248,10 @@ gather_status() {
     "tester": {
       "status": "${tester_status%%:*}",
       "uptime": "${tester_status#*:}"
+    },
+    "herald": {
+      "status": "${herald_status%%:*}",
+      "uptime": "${herald_status#*:}"
     }
   },
   "session_stats": {
@@ -336,6 +346,14 @@ EOF
             echo "      tester-agent: Running (${tester_status#*:})"
         else
             echo -e "    ${BOLD}Tester:${NC} ${YELLOW}0/1 active${NC}"
+        fi
+
+        # Herald
+        if [[ "${herald_status%%:*}" == "running" ]]; then
+            echo -e "    ${BOLD}Herald:${NC} ${GREEN}1/1 active${NC}"
+            echo "      herald-agent: Running (${herald_status#*:})"
+        else
+            echo -e "    ${BOLD}Herald:${NC} ${YELLOW}0/1 active${NC}"
         fi
         echo ""
 


### PR DESCRIPTION
## Summary
- Adds Herald agent that scans research activity and posts noteworthy achievements to Mathstodon (@rjwalters@mathstodon.xyz)
- 6-hour scan cycle, max 2 posts/day, 3-tier significance criteria (full proofs, axiom eliminations, weekly stats)
- Fully integrated with `/lean` orchestration (spawn/stop/scale/wake/daemon)

## Test plan
- [ ] `./scripts/herald/post-mathstodon.sh --dry-run "Test post"` validates posting wrapper
- [ ] `./scripts/lean/launch.sh spawn herald` spawns herald agent
- [ ] `./scripts/lean/status.sh` shows Herald status
- [ ] `./scripts/lean/launch.sh stop herald` stops herald agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)