### PR TITLE
Research: borsuk-ulam-oq-03 + pythagorean-triples - Fix API, improve axioms

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ03OQ03.lean
+++ b/proofs/Proofs/BorsukUlamOQ03OQ03.lean
@@ -25,7 +25,7 @@ YES — the proof strategy is:
 
 ## Infrastructure from Existing Files
 
-- Tucker's lemma (axiom): BorsukUlamOQ01.lean
+- Tucker's 2D lemma (axiom): grid-specific, properly constrained
 - 1D BU and Tucker: BorsukUlamOQ03.lean
 - Spheres, antipodal maps: BorsukUlamOQ01/02.lean
 
@@ -37,7 +37,8 @@ YES — the proof strategy is:
 4. Radial extension from D² to [-1,1]² preserving odd boundary (Part XXII)
 5. Grid infrastructure: vertices, edges, boundary, antipodal map (Part XXIII)
 5b. **Triangulated grid** `gridEdgesTriFin`: H/V + NE-SW diagonal edges (Part XXIII)
-6. **Main theorem**: tucker_disk_approx_zero_proved (from tuckers_lemma axiom)
+5c. **Grid antipodal properties**: involution, boundary preservation, edge preservation
+6. **Main theorem**: tucker_disk_approx_zero_proved (from tucker_2d_grid axiom)
 7. Approximate and exact 2D Borsuk-Ulam (Part XVI)
 
 ## Status: 1 axiom, 0 sorries
@@ -76,16 +77,9 @@ def IsComplementaryEdge {V : Type*} {n : ℕ} (L : SignedLabeling V n) (u v : V)
   ∃ k : Fin n, (L u = (k, true) ∧ L v = (k, false)) ∨
                (L u = (k, false) ∧ L v = (k, true))
 
-/-- Tucker's lemma (axiom, from BorsukUlamOQ01):
-    Any antipodal labeling of a triangulated ball has a complementary edge. -/
-axiom tuckers_lemma (n : ℕ) (hn : n ≥ 1)
-    (V : Type) [Fintype V] [DecidableEq V]
-    (edges : Set (V × V))
-    (boundary : Set V)
-    (antipodal_map : V → V)
-    (L : SignedLabeling V n)
-    (h_antipodal : ∀ v ∈ boundary, L (antipodal_map v) = (⟨(L v).1, !(L v).2⟩)) :
-    ∃ u v, (u, v) ∈ edges ∧ IsComplementaryEdge L u v
+-- Tucker's 2D lemma axiom is stated after the grid infrastructure (Part XXIII),
+-- since it references gridEdgesTriFin, gridBoundaryFin, and gridAntipodalFin.
+-- See `tucker_2d_grid` (after Part XXIII).
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════
@@ -102,19 +96,19 @@ This serves as a template for the 2D proof (the axiom above).
     then there exists i < n with f(i) ≠ f(i+1).
     (Discrete IVT / pigeonhole on a path.) -/
 theorem discrete_ivt (n : ℕ) (f : Fin (n + 1) → Bool) (hne : f 0 ≠ f (Fin.last n)) :
-    ∃ i : Fin n, f i.castSucc ≠ f i.castSucc.succ := by
+    ∃ i : Fin n, f i.castSucc ≠ f i.succ := by
   by_contra h
   push_neg at h
-  -- h : ∀ i, f i.castSucc = f i.castSucc.succ
+  -- h : ∀ i, f i.castSucc = f i.succ
   -- By induction, f is constant, contradicting hne
   have h_const : ∀ (j : Fin (n + 1)), f j = f 0 := by
     intro j
     induction j using Fin.induction with
     | zero => rfl
     | succ i ih =>
-      have := h i
-      rw [← ih]
-      exact this.symm
+      have := h ⟨i, by omega⟩
+      simp only [Fin.castSucc_mk, Fin.succ_mk] at this
+      rw [← ih]; exact this.symm
   exact hne (by rw [h_const (Fin.last n)])
 
 /-- 1D Tucker's lemma for signed labels:
@@ -122,7 +116,7 @@ theorem discrete_ivt (n : ℕ) (f : Fin (n + 1) → Bool) (hne : f 0 ≠ f (Fin.
 theorem tucker_1d (N : ℕ) (hN : 0 < N)
     (L : Fin (2 * N + 1) → Bool)
     (h_antipodal : L 0 ≠ L (Fin.last (2 * N))) :
-    ∃ i : Fin (2 * N), L i.castSucc ≠ L i.castSucc.succ :=
+    ∃ i : Fin (2 * N), L i.castSucc ≠ L i.succ :=
   discrete_ivt (2 * N) L h_antipodal
 
 /-
@@ -686,12 +680,12 @@ theorem approx_to_exact (f : ℝ × ℝ → ℝ × ℝ) (hf : Continuous f)
     ✓ Mesh refinement principle for compact sets (Part XXI)
     ✓ Radial extension D² → [-1,1]² preserving oddness (Part XXII)
     ✓ Grid infrastructure: Fin-based vertices, edges, boundary, antipodal (Part XXIII)
-    ✓ tucker_disk_approx_zero_proved (from tuckers_lemma)
+    ✓ tucker_disk_approx_zero_proved (from tucker_2d_grid)
     ✓ Approximate → exact BU via compactness
     ✓ Full 2D Borsuk-Ulam: borsuk_ulam_2d_corrected
 
     REMAINING:
-    - Tucker's lemma (1 axiom) — deep combinatorial/topological result -/
+    - tucker_2d_grid (1 axiom) — Tucker's 2D lemma for triangulated grid -/
 theorem formalization_status : True := trivial
 
 /-
@@ -1040,7 +1034,7 @@ This follows from Tucker's lemma (axiom, Part I) + dominantComponentLabel
     Mesh refinement (mesh_refinement_principle) then gives ‖g(w)‖ < δ.
 
     This is proved in tucker_disk_approx_zero_proved (Part XXIII) using
-    tuckers_lemma (Part I), complementary_edge_approx_dominant (Part XX),
+    tucker_2d_grid (Part I), complementary_edge_approx_dominant (Part XX),
     mesh_refinement_principle (Part XXI), and radial extension (Part XXII). -/
 
 /- The approximate and exact 2D BU theorems are stated after
@@ -1569,7 +1563,7 @@ theorem complementary_edge_approx_in_square_snd
 PART XXI: UNIFORM CONTINUITY ON COMPACT DISK
 
 The final analytical ingredient for proving `tucker_disk_approx_zero` from
-`tuckers_lemma`: uniform continuity of g on the compact disk D̄².
+`tucker_2d_grid`: uniform continuity of g on the compact disk D̄².
 
 Combined with the corrected complementary edge theorem (Part XX), this gives:
   mesh → 0 ⟹ dist(u,w) → 0 ⟹ dist(g(u), g(w)) → 0 ⟹ ‖g(w)‖ → 0
@@ -1613,7 +1607,7 @@ theorem disk_continuity_bound (g : ℝ × ℝ → ℝ × ℝ) (hg : Continuous g
     for each mesh size, Tucker gives a complementary edge, and this theorem
     converts it to an approximate zero.
 
-    What remains to prove `tucker_disk_approx_zero` from `tuckers_lemma`:
+    What remains to prove `tucker_disk_approx_zero` from `tucker_2d_grid`:
     1. Instantiate the grid triangulation as a TriangulatedDisk2D (Fintype boilerplate)
     2. Connect dominant-component labeling to Tucker's antipodal condition
     3. Apply this theorem to the Tucker output
@@ -1640,7 +1634,7 @@ theorem mesh_refinement_principle (g : ℝ × ℝ → ℝ × ℝ) (hg : Continuo
 ═══════════════════════════════════════════════════════════════════════════════
 PART XXII: RADIAL EXTENSION AND GRID ELIMINATION OF tucker_disk_approx_zero
 
-Strategy to prove tucker_disk_approx_zero from tuckers_lemma:
+Strategy to prove tucker_disk_approx_zero from tucker_2d_grid:
 
 1. Define radialExtend g: equals g(x) for ‖x‖₂ ≤ 1, equals g(x/‖x‖₂)
    for ‖x‖₂ > 1. This "freezes" g at its S¹ values outside the disk.
@@ -1915,6 +1909,99 @@ theorem gridAntipodalFin_eq_neg (N : ℕ) (hN : 0 < N)
   have hj : v.2.val ≤ 2 * N := by omega
   exact gridVertex_antipodal N hN v.1.val v.2.val hi hj
 
+/-- The grid antipodal map is an involution: applying it twice returns the original vertex.
+    This follows from Fin.rev being an involution. -/
+theorem gridAntipodalFin_involution (N : ℕ) (v : Fin (2 * N + 1) × Fin (2 * N + 1)) :
+    gridAntipodalFin N (gridAntipodalFin N v) = v := by
+  simp only [gridAntipodalFin, Fin.rev_rev]
+
+/-- The grid antipodal map preserves the boundary.
+    If v is on the boundary (has a coordinate at 0 or 2N), so is its antipodal. -/
+theorem gridAntipodalFin_maps_boundary (N : ℕ) (v : Fin (2 * N + 1) × Fin (2 * N + 1))
+    (hv : v ∈ gridBoundaryFin N) :
+    gridAntipodalFin N v ∈ gridBoundaryFin N := by
+  simp only [gridBoundaryFin, Set.mem_setOf_eq, gridAntipodalFin] at hv ⊢
+  have h1 : v.1.rev.val = 2 * N - v.1.val := by simp [Fin.rev]
+  have h2 : v.2.rev.val = 2 * N - v.2.val := by simp [Fin.rev]
+  rcases hv with h | h | h | h
+  · right; left; omega
+  · left; omega
+  · right; right; right; omega
+  · right; right; left; omega
+
+/-- The grid antipodal map preserves the triangulated edge set.
+    If (u, v) is a triangulated grid edge, so is (A(u), A(v)). -/
+theorem gridAntipodalFin_preserves_edges (N : ℕ)
+    (u v : Fin (2 * N + 1) × Fin (2 * N + 1))
+    (he : (u, v) ∈ gridEdgesTriFin N) :
+    (gridAntipodalFin N u, gridAntipodalFin N v) ∈ gridEdgesTriFin N := by
+  simp only [gridEdgesTriFin, Set.mem_setOf_eq, gridAntipodalFin] at he ⊢
+  have hu1 : u.1.rev.val = 2 * N - u.1.val := by simp [Fin.rev]
+  have hu2 : u.2.rev.val = 2 * N - u.2.val := by simp [Fin.rev]
+  have hv1 : v.1.rev.val = 2 * N - v.1.val := by simp [Fin.rev]
+  have hv2 : v.2.rev.val = 2 * N - v.2.val := by simp [Fin.rev]
+  rcases he with ⟨heq, hor⟩ | ⟨heq, hor⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · -- Horizontal: same row, adjacent columns → reversed: same row, adjacent columns
+    left; constructor
+    · ext; omega
+    · rcases hor with h | h <;> [right; left] <;> omega
+  · -- Vertical: same column, adjacent rows → reversed: same column, adjacent rows
+    right; left; constructor
+    · ext; omega
+    · rcases hor with h | h <;> [right; left] <;> omega
+  · -- Diagonal (i,j)→(i+1,j+1) → reversed diagonal (2N-i-1,2N-j-1)→(2N-i,2N-j)
+    -- which is (rev(i+1), rev(j+1))→(rev(i), rev(j)), a reverse-direction diagonal
+    right; right; right; constructor <;> omega
+  · -- Reverse diagonal
+    right; right; left; constructor <;> omega
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+TUCKER'S 2D LEMMA (AXIOM)
+
+Now that all grid infrastructure is defined, we can state Tucker's 2D lemma
+for the specific triangulated grid.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Tucker's 2D lemma for the triangulated grid (axiom).
+
+    Any antipodal labeling of the triangulated grid on [-1,1]² has a complementary
+    edge. This is stated specifically for gridEdgesTriFin (with NE-SW diagonals),
+    gridBoundaryFin, and gridAntipodalFin (Fin.rev × Fin.rev), rather than for
+    an arbitrary abstract graph.
+
+    The previous axiom `tuckers_lemma` was overly general: it accepted arbitrary
+    (V, edges, boundary, antipodal_map) without requiring proper triangulation,
+    so it was false for some inputs (e.g., empty edge set). This version is
+    properly constrained to the specific triangulated grid where the theorem holds.
+
+    **Proof roadmap** (any of these equivalent approaches):
+
+    1. **Path-following / complementary pivoting** (~500-1000 lines):
+       Define a pivot rule on triangles, follow from boundary to interior.
+       Each triangle has at most 2 "doors" (edges meeting the pivot criterion).
+       Boundary has odd door count → path terminates at complementary edge.
+
+    2. **Hex theorem reduction** (~300 lines + Hex proof):
+       Color vertices by label component (0 or 1). By the Hex theorem,
+       one color connects opposite boundary sides. Along that connected
+       component, the antipodal condition forces both signs to appear.
+       By discrete_ivt on the connected subgraph, a sign change = complementary edge.
+       Requires: Hex theorem for triangulated grids (itself ~300-500 lines).
+
+    3. **Poincaré-Miranda / intersection theory** (~300-500 lines):
+       Zero sets of the two label components connect opposite boundary arcs.
+       Two such arcs must intersect (discrete Jordan curve theorem).
+       At the intersection → complementary edge.
+
+    All three are equivalent to Brouwer's FPT in 2D.
+    See end-of-file comments for detailed analysis. -/
+axiom tucker_2d_grid (N : ℕ) (hN : 0 < N)
+    (L : SignedLabeling (Fin (2 * N + 1) × Fin (2 * N + 1)) 2)
+    (h_antipodal : ∀ v ∈ gridBoundaryFin N,
+      L (gridAntipodalFin N v) = (⟨(L v).1, !(L v).2⟩)) :
+    ∃ u v, (u, v) ∈ gridEdgesTriFin N ∧ IsComplementaryEdge L u v
+
 /-- Grid boundary vertices of [-1,1]² have at least one coordinate with |·| = 1,
     hence Euclidean norm squared ≥ 1. -/
 theorem gridBoundary_euclidNormSq_ge_one (N : ℕ) (hN : 0 < N)
@@ -2041,8 +2128,7 @@ theorem grid_tri_edge_dist (N : ℕ) (hN : 0 < N)
         linarith
       rw [this]; norm_num
 
-/-- **Main theorem**: tucker_disk_approx_zero follows from tuckers_lemma.
-    This eliminates one of the two remaining axioms.
+/-- **Main theorem**: tucker_disk_approx_zero follows from tucker_2d_grid.
 
     Proof outline:
     1. Let h = radialExtend g (odd outside D̄², equals g on D̄²)
@@ -2110,16 +2196,8 @@ theorem tucker_disk_approx_zero_proved
       -- Transport via dcl_congr, then apply antipodal lemma
       rw [dcl_congr _ _ _ h_neg_ne h_val_eq]
       exact dominantComponentLabel_antipodal (h (gridVertexFin N v)) (h_all_nonzero v) h_neg_ne
-    -- Step 7: Apply Tucker's lemma (using TRIANGULATED grid, not just H/V edges)
-    -- NOTE: Tucker's lemma requires a triangulated grid. The non-triangulated
-    -- gridEdgesFin admits counterexamples (e.g., 5×5 grid with all top-row
-    -- component-0-true, bottom-row component-0-false, sides component-1, and
-    -- interior labels chosen to avoid complementary H/V edges — but the diagonal
-    -- (2,2)→(3,3) IS complementary). The triangulated grid gridEdgesTriFin
-    -- adds NE-SW diagonals, making each cell a pair of triangles.
-    obtain ⟨u_fin, v_fin, he, hcomp⟩ := tuckers_lemma 2 (by omega)
-      (Fin (2 * N + 1) × Fin (2 * N + 1))
-      (gridEdgesTriFin N) (gridBoundaryFin N) (gridAntipodalFin N) L h_antipodal
+    -- Step 7: Apply Tucker's 2D lemma on the triangulated grid
+    obtain ⟨u_fin, v_fin, he, hcomp⟩ := tucker_2d_grid N hN.1 L h_antipodal
     -- Step 8: Extract the complementary edge info
     obtain ⟨k, hk⟩ := hcomp
     -- Grid vertices are in [-1,1]²
@@ -2197,50 +2275,57 @@ AXIOM STATUS SUMMARY
 This file has **1 axiom** and **0 sorries**.
 
 Remaining axiom:
-  tuckers_lemma (Part I): Tucker's lemma for antipodal labelings.
+  tucker_2d_grid (Part I): Tucker's 2D lemma for the triangulated grid.
   This is the ONLY unproved assumption. Everything else is proved from it.
 
-IMPORTANT (soundness fix, 2026-03-14):
-  Tucker's lemma is now applied to `gridEdgesTriFin` (triangulated grid with
-  H/V + diagonal edges), NOT the original `gridEdgesFin` (H/V only).
+  Unlike the previous `tuckers_lemma` axiom (which was overly general and false
+  for some inputs like empty edge sets), `tucker_2d_grid` is properly constrained
+  to the specific triangulated grid (gridEdgesTriFin), boundary (gridBoundaryFin),
+  and antipodal map (gridAntipodalFin) where the theorem is true.
 
-  The non-triangulated grid admits counterexamples to Tucker's lemma:
-  - 5×5 grid (N=2) with antipodal labeling: top row all (0,true), bottom row
-    all (0,false), sides all component 1, interior chosen to avoid ALL
-    complementary H/V edges. But the diagonal (2,2)→(3,3) IS complementary.
-  - This shows gridEdgesFin is insufficient; proper triangulation is needed.
-
-  The triangulated grid `gridEdgesTriFin` adds NE-SW diagonals: each cell
-  (i,j)-(i+1,j)-(i+1,j+1)-(i,j+1) is split into two triangles by the
-  diagonal (i,j)-(i+1,j+1). This diagonal is antipodally symmetric.
-
-  The edge distance bound is unchanged: diagonal edges have L∞ distance
-  1/N (same as H/V edges), so the mesh refinement argument is unaffected.
+Infrastructure for proving tucker_2d_grid (Part XXIII):
+  - gridAntipodalFin_involution: antipodal map is an involution
+  - gridAntipodalFin_maps_boundary: antipodal map preserves boundary
+  - gridAntipodalFin_preserves_edges: antipodal map preserves edge set
+  These properties are prerequisites for any proof approach.
 
 Proof chain:
-  tuckers_lemma → tucker_disk_approx_zero_proved → approx_borsuk_ulam_2d_corrected
+  tucker_2d_grid → tucker_disk_approx_zero_proved → approx_borsuk_ulam_2d_corrected
     → borsuk_ulam_2d_corrected (exact 2D BU from Tucker)
 
-Approaches to eliminate tuckers_lemma (for the triangulated grid):
-  1. Path-following argument (combinatorial, ~500-1000 lines):
-     - Use the NE-SW triangulation of each cell (already in gridEdgesTriFin)
-     - Define "complementary edge paths" through dual graph
-     - Prove boundary has odd number of path endpoints
-     - Therefore at least one interior complementary edge exists
-     Difficulty: Needs detailed finite graph bookkeeping in Lean 4.
+KEY DEAD END (2026-03-14 analysis):
+  Single-path arguments (diagonal, row, column) CANNOT prove Tucker 2D.
+  Example: on the diagonal path (0,0)→(1,1)→...→(2N,2N), labels can avoid
+  complementary edges entirely:
+    (0,T)→(1,F)→(0,F) has 0 complementary edges despite complementary endpoints.
+  At each edge, both the component AND sign can change simultaneously,
+  defeating the discrete IVT argument. A parity count shows:
+    - Sign changes = ODD (forced by antipodal condition)
+    - Component changes = EVEN (start/end have same component)
+    - But sign changes CAN coincide with component changes (Ce = 0 is consistent)
+  CONCLUSION: Tucker 2D requires a genuinely 2D argument.
 
-  2. Winding number / degree theory (~500 lines):
-     - If g ≠ 0 on D², then g/|g| : D² → S¹ extends from boundary
-     - Odd map S¹ → S¹ has odd degree
-     - Map extending over D² has degree 0 → contradiction
-     Difficulty: Needs winding number definition + basic properties.
+Approaches to eliminate tucker_2d_grid:
+  1. Path-following / complementary pivoting (~500-1000 lines):
+     Define a pivot rule on triangles. Start from boundary, follow pivoting path.
+     Boundary has odd door count → path terminates at complementary edge.
+     Difficulty: Detailed finite graph bookkeeping.
+
+  2. Hex theorem reduction (~300 lines proof + Hex):
+     Color vertices by label component. By Hex theorem, one color connects
+     opposite boundary sides. Within that connected component, antipodal
+     condition forces both signs. By IVT → complementary edge.
+     KEY SUBTLETY: the connected component might be monochromatic; need
+     to show the antipodal's sign-flip vertex is in the same component
+     or use a separation argument.
+     Difficulty: Hex theorem itself (~300-500 lines).
 
   3. Poincaré-Miranda / intersection theory (~300-500 lines):
-     - Zero sets Z₁ = {g₁ = 0} and Z₂ = {g₂ = 0} connect opposite boundary arcs
-     - Two arcs connecting opposite sides of a square must intersect
-     Difficulty: Needs discrete Jordan curve theorem.
+     Component-0 boundary connects left-right, component-1 connects top-bottom.
+     By discrete Jordan curve theorem, they intersect → complementary edge.
+     Difficulty: Discrete Jordan curve theorem.
 
-  All three are equivalent to Brouwer's FPT in 2D. Each is a multi-session project.
+  All three are equivalent to Brouwer's FPT in 2D. Multi-session project.
 ═══════════════════════════════════════════════════════════════════════════════ -/
 
 /-

--- a/research/problems/borsuk-ulam-oq-03-oq-03/knowledge.md
+++ b/research/problems/borsuk-ulam-oq-03-oq-03/knowledge.md
@@ -1,50 +1,61 @@
 # Knowledge Base: borsuk-ulam-oq-03-oq-03
 
-## Problem Summary
+## Problem Understanding
 
-Constructive 2D Borsuk-Ulam via Tucker's Lemma.
+The 2D Borsuk-Ulam theorem proved via Tucker's lemma. File has main theorem
+`borsuk_ulam_2d_corrected` with complete proof chain modulo axioms.
 
-## Current State
+## Key Finding: False Axiom
 
-**Status**: 1 axiom (Tucker's 2D lemma), 0 sorries, 2318 lines
-**File**: `proofs/Proofs/BorsukUlamOQ03OQ03.lean`
+`complementary_edge_gives_approximate_zero` was FALSE as stated.
+Counterexample: g(x,y)=(x,y), u=(0.01,1), v=(-0.01,1), delta=0.02, k=0.
+The bound 0.02*(2*sup) ~ 0.08 but ||g(w)||_1 >= 0.98 for any w near u.
 
-## Key Results (All Proved)
+Fix: require k to be the dominant component (as Tucker's labeling guarantees).
 
-- Dominant component labeling is antipodal (Part II)
-- Complementary edge → approximate zero via IVT (Parts XVIII-XX)
-- Mesh refinement gives arbitrarily small zeros (Part XXI)
-- Grid infrastructure: vertices, edges, boundary, antipodal (Part XXIII)
-- Triangulated grid (`gridEdgesTriFin`) with NE-SW diagonals (Part XXIII)
-- tucker_disk_approx_zero_proved (from axiom)
-- Approximate and exact 2D Borsuk-Ulam (Part XXIV)
-- 1D Tucker proved as discrete IVT
+## Axiom Status
 
-## The One Remaining Axiom
+### Current (session 9, 2026-03-14)
+- `tucker_2d_grid` -- 1 remaining axiom, properly constrained to triangulated grid
+- Previous `tuckers_lemma` was overly general (false for empty edges)
 
-`tuckers_lemma` (line 81): For any antipodal labeling of a triangulated disk,
-there exists a complementary edge.
+### Infrastructure Added (session 9)
+- `gridAntipodalFin_involution`: antipodal map is an involution (proved)
+- `gridAntipodalFin_maps_boundary`: preserves boundary (proved)
+- `gridAntipodalFin_preserves_edges`: preserves edge set (proved)
+- Fixed Fin API breakage in `discrete_ivt` and `tucker_1d`
 
-### Why It's Hard
+### Previously Eliminated
+- `complementary_edge_gives_approximate_zero` -- ELIMINATED (was false)
+- `tucker_disk_approx_zero` -- ELIMINATED (reordered file)
+- `x_cube_sub_2_gal_iso_s3` -- ELIMINATED (from InverseGalois)
 
-Eliminating this axiom is equivalent to proving Brouwer's FPT in 2D. Three approaches:
-1. **Path-following** (~500-1000 lines): dual graph parity argument
-2. **Winding number** (~500 lines): degree theory on S¹
-3. **Poincaré-Miranda** (~300-500 lines): needs discrete Jordan curve theorem
+## Dead Ends
 
-### What Would Help
+### Single-path arguments for Tucker 2D (CONFIRMED DEAD END)
+A single path through the grid (diagonal, row, column) CANNOT prove Tucker 2D.
 
-- Mathlib adding Sperner's lemma or combinatorial topology infrastructure
-- A dedicated multi-session effort on the path-following approach
+Labels from {(0,T), (0,F), (1,T), (1,F)} allow complementary-free paths:
+  (0,T) -> (1,F) -> (0,F) has 0 complementary edges despite complementary endpoints.
 
-## Session Log
+Parity analysis on diagonal path (0,0) -> (2N,2N):
+- Sign changes (Ce + Cb) = ODD (antipodal condition)
+- Component changes (Co + Cb) = EVEN (same start/end component)
+- Ce - Co = ODD, but Ce = 0 is consistent (all sign changes coincide with component changes)
 
-### Session 2026-03-14 (researcher-6) - Assessment
+### Row-by-row 1D Tucker (CONFIRMED DEAD END)
+Bottom row sign change NOT guaranteed from boundary conditions.
+The antipodal condition links (0,j) <-> (2N, 2N-j), not same-row endpoints.
 
-**Mode**: REVISIT
-**Outcome**: surveyed — assessed axiom elimination approaches
+### Hex theorem (PARTIALLY VIABLE)
+Hex gives connected same-component path. But monochromatic case
+needs additional argument: must show antipodal vertex is in same
+connected component, or use separation/Jordan curve theorem.
 
-**Findings**: All three approaches require 300-1000 lines of new infrastructure.
-The file has comprehensive infrastructure built around the axiom. The axiom is
-used once (line 2120) on the specific triangulated grid. No tractable single-session
-path to eliminate it.
+## Proof Approaches for tucker_2d_grid
+
+All three are equivalent to Brouwer FPT in 2D. Multi-session project.
+
+1. **Path-following / complementary pivoting** (~500-1000 lines)
+2. **Hex theorem reduction** (~300 lines + Hex proof ~300-500 lines)
+3. **Poincare-Miranda / intersection theory** (~300-500 lines)

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "DEEP_DIVE",
     "since": "2026-03-14",
-    "iteration": 8,
-    "focus": "Eliminated tucker_disk_approx_zero axiom, added triangulated grid. 1 axiom remains (tuckers_lemma).",
+    "iteration": 9,
+    "focus": "Improved axiom to grid-specific tucker_2d_grid, fixed Fin API breakage, added infrastructure",
     "activeApproach": "Tucker 2D lemma proof: path-following, degree theory, or Hex approach (~500-1000 lines)",
     "blockers": [
       "tuckers_lemma axiom: requires path-following (~500-1000 lines), degree theory, or intersection theory — each equivalent to Brouwer FPT in 2D"
     ],
-    "nextAction": "Prove Tucker 2D - requires building dual graph infrastructure (~500 lines)",
+    "nextAction": "Prove Tucker 2D lemma for n=2 on triangulated grid",
     "attemptCounts": {
       "total": 5,
       "currentApproach": 1,
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM ELIMINATED: tucker_disk_approx_zero removed by reordering file (main theorems moved after proved version). Added gridEdgesTriFin (triangulated grid with NE-SW diagonals) for soundness. File now has 1 axiom (tuckers_lemma), 0 sorries. Full proof chain: tuckers_lemma → tucker_disk_approx_zero_proved → approx_borsuk_ulam_2d_corrected → borsuk_ulam_2d_corrected.",
+    "progressSummary": "AXIOM IMPROVED: Replaced overly general tuckers_lemma with grid-specific tucker_2d_grid. Fixed Mathlib v4.26.0 Fin API breakage in discrete_ivt and tucker_1d. Added 3 infrastructure lemmas for antipodal map. File: 1 axiom, 0 sorries, builds clean.",
     "builtItems": [
       "non_dominant_at_zero_bound_snd (symmetric IVT bound, Part XX)",
       "complementary_edge_approx_dominant_fst/snd (corrected IVT+dominant theorems)",
@@ -54,7 +54,13 @@
       "grid_tri_edge_dist: Edge distance bound ≤ 1/N for all triangulated edges (H/V and diagonal)",
       "gridEdgesFin_subset_tri: H/V edges are a subset of triangulated edges",
       "discrete_ivt: 1D discrete IVT - if f(0) ≠ f(n) then ∃ i, f(i) ≠ f(i+1)",
-      "tucker_1d: 1D Tucker lemma for grid {0,...,2N} with antipodal boundary"
+      "tucker_1d: 1D Tucker lemma for grid {0,...,2N} with antipodal boundary",
+      "tucker_2d_grid: properly constrained Tucker 2D axiom for gridEdgesTriFin N (replaces overly general tuckers_lemma)",
+      "gridAntipodalFin_involution: Fin.rev is involution (proved)",
+      "gridAntipodalFin_maps_boundary: antipodal map preserves boundary (proved)",
+      "gridAntipodalFin_preserves_edges: antipodal map preserves triangulated edge set (proved)",
+      "discrete_ivt: fixed Fin API breakage (Fin.castSucc.succ → Fin.succ)",
+      "tucker_1d: fixed Fin API breakage"
     ],
     "insights": [
       "CRITICAL: axiom complementary_edge_gives_approximate_zero was FALSE. Counterexample: g(x,y)=(x,y), u=(0.01,1), v=(-0.01,1). The bound δ*C ≈ 0.08 but |g(w).2| ≥ 0.98 for any w near u.",
@@ -73,14 +79,17 @@
       "File structure: Parts I-XVI (S² infrastructure), Part XVII-XXIII (grid infrastructure + tucker_disk_approx_zero_proved), Part XXIV (main theorems using proved version)",
       "CONFIRMED: Bottom row sign change is NOT guaranteed from boundary conditions. Counter-example: L(0,0)=(0,T), L(2N,0)=(1,T) is consistent with antipodal L(2N,2N)=(0,F), L(0,2N)=(1,F). The 2D Tucker proof requires global dual-graph parity, not row-by-row 1D Tucker.",
       "1D Tucker proof pattern: by_contra + Fin.induction shows function is constant, contradicting boundary",
-      "Session 8 assessment: File is very mature (2318 lines, 1 axiom, 0 sorries). The only axiom (tuckers_lemma) requires 500-1000 lines of dual graph infrastructure, path-following, and parity argument. This is a multi-session project. No quick wins available."
+      "Replaced overly general tuckers_lemma axiom (false for empty edges) with grid-specific tucker_2d_grid axiom",
+      "Fixed Mathlib v4.26.0 API breakage: Fin.castSucc.succ → Fin.succ in discrete_ivt and tucker_1d",
+      "Added gridAntipodalFin_involution, gridAntipodalFin_maps_boundary, gridAntipodalFin_preserves_edges",
+      "DEAD END CONFIRMED: Single-path arguments (diagonal, row, column) cannot prove Tucker 2D. Parity analysis shows complementary edges Ce=0 is consistent when all sign changes coincide with component changes",
+      "Hex theorem reduction analyzed: if C connects left-right, C monochromatic, need to show antipodal vertex is in same connected component. Requires additional separation argument beyond bare Hex statement"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove radialExtend_continuous: piecewise continuity, both branches agree at euclidNormSq = 1",
-      "Prove grid_edge_dist: adjacent Fin values → 1/N distance in Prod metric",
-      "Complete main theorem composition: construct SignedLabeling from dominantComponentLabel, verify Tucker antipodal condition, apply Tucker, connect complementary edge to mesh_refinement_square",
-      "Once all 3 sorries filled, replace axiom tucker_disk_approx_zero with tucker_disk_approx_zero_proved"
+      "Prove tucker_2d_grid via path-following (~500-1000 lines), Hex reduction (~300 lines + Hex proof), or Poincare-Miranda (~300-500 lines)",
+      "All approaches equivalent to Brouwer FPT in 2D - multi-session project",
+      "Key infrastructure already in place: grid definitions, antipodal properties, discrete_ivt, 1D Tucker"
     ],
     "markdown": "# Knowledge Base: borsuk-ulam-oq-03-oq-03\n\n## Problem Understanding\n\nThe 2D Borsuk-Ulam theorem proved via Tucker's lemma. File has main theorem\n`borsuk_ulam_2d_corrected` with complete proof chain modulo axioms.\n\n## Key Finding: False Axiom\n\n`complementary_edge_gives_approximate_zero` was FALSE as stated.\nCounterexample: g(x,y)=(x,y), u=(0.01,1), v=(-0.01,1), δ=0.02, k=0.\nThe bound 0.02·(2·sup) ≈ 0.08 but ‖g(w)‖₁ ≥ 0.98 for any w near u.\n\nFix: require k to be the dominant component (as Tucker's labeling guarantees).\n\n## Axiom Status (after this session)\n\n- `tuckers_lemma` — HARD to eliminate (deep combinatorial, path-following)\n- `tucker_disk_approx_zero` — TRACTABLE to eliminate (grid Fintype + our proved theorems)\n- ~~`complementary_edge_gives_approximate_zero`~~ — ELIMINATED (was false, replaced with proved theorems)\n\n## Dead Ends\n\n- The original axiom bound δ·(2·sup{‖g‖+1}) is too weak without dominant-component hypothesis\n"
   },
@@ -99,7 +108,7 @@
     "mathlib": []
   },
   "started": "2026-03-07T18:02:01.175Z",
-  "lastUpdate": "2026-03-14T18:00:00.000Z",
+  "lastUpdate": "2026-03-13T00:30:00.000Z",
   "significance": 7,
   "tractability": 6
 }

--- a/src/data/research/problems/pythagorean-triples-oq-01.json
+++ b/src/data/research/problems/pythagorean-triples-oq-01.json
@@ -32,21 +32,21 @@
   "currentState": {
     "phase": "DEEP_DIVE",
     "since": "2026-03-12T05:32:38.520Z",
-    "iteration": 6,
-    "focus": "Proved coprime sector growth, per-column equality, axiom decomposition",
+    "iteration": 7,
+    "focus": "Fixed Mathlib API breakage, assessed boundary analysis paths",
     "blockers": [
       "Formalizing CRT independence of coprimality sieve and parity requires analytic NT infrastructure",
       "Connecting square EO=OE to sector EO=OE requires circle boundary analysis"
     ],
-    "nextAction": "Prove boundary discrepancy sub-linearity or EO/coprime→1/3",
+    "nextAction": "All 3 axioms require Mathlib analytic NT infrastructure - consider marking completed",
     "attemptCounts": {
-      "total": 3,
-      "currentApproach": 2,
+      "total": 4,
+      "currentApproach": 3,
       "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 6 new theorems proved. Coprime sector count grows to infinity. Parity axiom decomposed into geometric (boundary discrepancy vanishes) + arithmetic (EO density = 1/3). Full-column OE=OO equality proved for small columns.",
+    "progressSummary": "MAINTENANCE: Fixed 6 Mathlib v4.26.0 API breakages. File builds clean: 0 errors, 0 sorries, 3 axioms.",
     "builtItems": [
       "bothOddCoprimeCount: counting function for both-odd coprime pairs",
       "coprime_sector_partition: exact partition identity (coprime = primitive + bothOdd)",
@@ -117,7 +117,10 @@
       "Full-column OE=OO equality proved: when m²+(m-1)²≤N, the involution covers the entire column so sectorOE=sectorOO exactly",
       "Parity axiom decomposed into 2 independent pieces: (1) boundary discrepancy vanishes (geometric) + (2) EO/coprime→1/3 (arithmetic from coprime_eo_iff)",
       "The boundary region between triangle and sector is NOT O(√N) as previously stated — it can be O(N). The DISCREPANCY (bdryOO-bdryOE) is what needs to be sub-linear, not the total boundary size.",
-      "Session 6 assessment: All 3 remaining axioms (sector density, coprime fraction, bothOdd fraction) require analytic number theory infrastructure not in Mathlib. File is mature (2058 lines, 0 sorries, 33 built items). The parity axiom decomposition into column_density + boundary_vanishing is complete but both sub-axioms still need analytic bounds."
+      "Session 6 assessment: All 3 remaining axioms (sector density, coprime fraction, bothOdd fraction) require analytic number theory infrastructure not in Mathlib. File is mature (2058 lines, 0 sorries, 33 built items). The parity axiom decomposition into column_density + boundary_vanishing is complete but both sub-axioms still need analytic bounds.",
+      "Session 7: Fixed 6 Mathlib API breakages: Filter.Tendsto.atTop_nonneg, Nat.le anonymous constructor, paren syntax, Finset.card_Icc, push_cast, Tendsto.congr",
+      "Session 7: per-column discrepancy bound of 1 confirmed FALSE. Global boundary discrepancy requires character sum bounds not in Mathlib.",
+      "Session 7 assessment: File mature at 2019 lines. All 3 axioms need analytic NT absent from Mathlib. Consider marking completed."
     ],
     "mathlibGaps": [
       "No Mathlib formalization of Gauss circle problem asymptotics",
@@ -167,7 +170,7 @@
     ]
   },
   "started": "2026-03-12T05:34:54.574Z",
-  "lastUpdate": "2026-03-14T19:40:00.000Z",
+  "lastUpdate": "2026-03-14T23:30:00.000Z",
   "significance": 7,
   "tractability": 6
 }

--- a/src/data/research/problems/pythagorean-triples-oq-01.json
+++ b/src/data/research/problems/pythagorean-triples-oq-01.json
@@ -32,8 +32,8 @@
   "currentState": {
     "phase": "DEEP_DIVE",
     "since": "2026-03-12T05:32:38.520Z",
-    "iteration": 7,
-    "focus": "Fixed Mathlib API breakage, assessed boundary analysis paths",
+    "iteration": 8,
+    "focus": "Fixed additional API breakage, verified build",
     "blockers": [
       "Formalizing CRT independence of coprimality sieve and parity requires analytic NT infrastructure",
       "Connecting square EO=OE to sector EO=OE requires circle boundary analysis"
@@ -46,7 +46,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "MAINTENANCE: Fixed 6 Mathlib v4.26.0 API breakages. File builds clean: 0 errors, 0 sorries, 3 axioms.",
+    "progressSummary": "MAINTENANCE: Fixed additional Mathlib v4.26.0 API breakage (omega→nlinarith for nonlinear bound). File builds clean: 0 errors, 0 sorries, 3 axioms. All axioms blocked on Mathlib analytic NT gaps.",
     "builtItems": [
       "bothOddCoprimeCount: counting function for both-odd coprime pairs",
       "coprime_sector_partition: exact partition identity (coprime = primitive + bothOdd)",
@@ -120,7 +120,8 @@
       "Session 6 assessment: All 3 remaining axioms (sector density, coprime fraction, bothOdd fraction) require analytic number theory infrastructure not in Mathlib. File is mature (2058 lines, 0 sorries, 33 built items). The parity axiom decomposition into column_density + boundary_vanishing is complete but both sub-axioms still need analytic bounds.",
       "Session 7: Fixed 6 Mathlib API breakages: Filter.Tendsto.atTop_nonneg, Nat.le anonymous constructor, paren syntax, Finset.card_Icc, push_cast, Tendsto.congr",
       "Session 7: per-column discrepancy bound of 1 confirmed FALSE. Global boundary discrepancy requires character sum bounds not in Mathlib.",
-      "Session 7 assessment: File mature at 2019 lines. All 3 axioms need analytic NT absent from Mathlib. Consider marking completed."
+      "Session 7 assessment: File mature at 2019 lines. All 3 axioms need analytic NT absent from Mathlib. Consider marking completed.",
+      "Session 8: Fixed omega failure in sectorOE_eq_sectorOO_full_column - le_self_mul signature changed, replaced with nlinarith for m≤m² bound. Also replaced by omega goals for n<N+1 with hn_range (n<m) + hm_le_N (m≤N)."
     ],
     "mathlibGaps": [
       "No Mathlib formalization of Gauss circle problem asymptotics",


### PR DESCRIPTION
## Summary
- **borsuk-ulam-oq-03**: Replace overly general `tuckers_lemma` axiom (false for empty edges) with properly constrained `tucker_2d_grid` axiom. Fix Fin API breakage. Add 3 infrastructure lemmas.
- **pythagorean-triples-oq-01**: Fix omega→nlinarith API breakage in nonlinear bound.

## Progress
- Both files build verified: 0 sorries
- Documented dead ends for Tucker 2D (single-path arguments fail, confirmed by parity analysis)

## Files Modified
- `proofs/Proofs/BorsukUlamOQ03OQ03.lean` - axiom replacement, API fix, infrastructure
- `proofs/Proofs/PythagoreanTriplesOQ01.lean` - API breakage fix
- Knowledge files updated

## Status
**Outcome**: progress (borsuk-ulam), maintenance (pythagorean-triples)

🤖 Generated by researcher-7