### PR TITLE
fix: correct gallery entry imports for angle-trisection and yang-mills

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/index.ts
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/index.ts
@@ -1,10 +1,45 @@
-import type { ProofEntry } from "../../types";
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-const entry: ProofEntry = {
-  ...meta,
-  annotations: annotations.annotations,
-};
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
 
-export default entry;
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/AngleTrisectionOQ02OQ03OQ01.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+const rawAnnotations = annotationsJson as unknown as { annotations: Annotation[] } | Annotation[]
+export const annotations: Annotation[] = Array.isArray(rawAnnotations) ? rawAnnotations : rawAnnotations.annotations
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/yang-mills-mass-gap/index.ts
+++ b/src/data/proofs/yang-mills-mass-gap/index.ts
@@ -1,10 +1,45 @@
-import type { ProofEntry } from "../../types";
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-const entry: ProofEntry = {
-  ...meta,
-  annotations: annotations.annotations,
-};
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
 
-export default entry;
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/YangMillsMassGap.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '', // Loaded dynamically
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+const rawAnnotations = annotationsJson as unknown as { annotations: Annotation[] } | Annotation[]
+export const annotations: Annotation[] = Array.isArray(rawAnnotations) ? rawAnnotations : rawAnnotations.annotations
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData


### PR DESCRIPTION
## Summary
- Fix broken `index.ts` for `angle-trisection-oq-02-oq-03-oq-01` and `yang-mills-mass-gap` gallery entries
- Replace non-existent `ProofEntry` type with standard `@/types/proof` imports
- Handle wrapped annotations format (`{annotations: [...]}` vs `[...]`)

## Test plan
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)