### PR TITLE
fix: correct gallery entry imports (batch 2)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02/index.ts
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02/index.ts
@@ -1,10 +1,43 @@
-import type { ProofEntry } from "../../types";
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-const entry: ProofEntry = {
-  ...meta,
-  annotations: annotations.annotations,
-};
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
 
-export default entry;
+const leanSource = () => import('../../../../proofs/Proofs/AmgmInequalityOQ02OQ02.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+const rawAnnotations = annotationsJson as unknown as { annotations: Annotation[] } | Annotation[]
+export const annotations: Annotation[] = Array.isArray(rawAnnotations) ? rawAnnotations : rawAnnotations.annotations
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/ballot-problem-oq-01-oq-02/index.ts
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02/index.ts
@@ -1,10 +1,43 @@
-import type { ProofEntry } from "../../types";
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-const entry: ProofEntry = {
-  ...meta,
-  annotations: annotations.annotations,
-};
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
 
-export default entry;
+const leanSource = () => import('../../../../proofs/Proofs/BallotProblemOQ01OQ02.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+const rawAnnotations = annotationsJson as unknown as { annotations: Annotation[] } | Annotation[]
+export const annotations: Annotation[] = Array.isArray(rawAnnotations) ? rawAnnotations : rawAnnotations.annotations
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/pythagorean-triples-oq-01/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-01/index.ts
@@ -1,10 +1,43 @@
-import type { ProofEntry } from "../../types";
-import meta from "./meta.json";
-import annotations from "./annotations.json";
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
 
-const entry: ProofEntry = {
-  ...meta,
-  annotations: annotations.annotations,
-};
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
 
-export default entry;
+const leanSource = () => import('../../../../proofs/Proofs/PythagoreanTriplesOQ01.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: '',
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+const rawAnnotations = annotationsJson as unknown as { annotations: Annotation[] } | Annotation[]
+export const annotations: Annotation[] = Array.isArray(rawAnnotations) ? rawAnnotations : rawAnnotations.annotations
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData


### PR DESCRIPTION
## Summary
- Fix broken `index.ts` for `amgm-inequality-oq-02-oq-02`, `ballot-problem-oq-01-oq-02`, and `pythagorean-triples-oq-01`
- Same issue as #3793: non-existent `ProofEntry` type, wrong import path

## Test plan
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)