### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -4466,19 +4466,19 @@
     },
     {
       "slug": "partition-theorem-oq-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-03-12T05:34:54.574Z",
       "status": "active",
-      "lastUpdate": "2026-03-12T05:34:54.574Z"
+      "lastUpdate": "2026-03-15T09:39:56.882Z"
     },
     {
       "slug": "pythagorean-triples-oq-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-03-12T05:34:54.574Z",
       "status": "active",
-      "lastUpdate": "2026-03-12T05:34:54.574Z"
+      "lastUpdate": "2026-03-15T09:39:56.883Z"
     },
     {
       "slug": "randomized-maxcut-oq-01",


### PR DESCRIPTION
## Summary
- Sync research-listings.json with current iteration counts
- Updated 17 listings, total 242 iterations
- Prune stale quality snapshots and update aristotle jobs

Automated deploy sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)