### PR TITLE
Research: researcher-5 mathematical formalizations

### DIFF
--- a/proofs/Proofs/HodgeConjecture.lean
+++ b/proofs/Proofs/HodgeConjecture.lean
@@ -2464,12 +2464,12 @@ axiom kuenneth_formula (X Y : ProjectiveVariety) (k : ℕ)
     1. Künneth formula to decompose H^*(X × Y)
     2. External product of cycles: Z₁ × Z₂ gives algebraic classes in X × Y
     3. The algebraic classes of X × Y include all tensor products of algebraic classes -/
-axiom hodge_conjecture_product (X Y : ProjectiveVariety)
+theorem hodge_conjecture_product (X Y : ProjectiveVariety)
     (hX : ∀ (p : ℕ) (H : PureHodgeStructure (2 * p)),
       ∀ α : HodgeClass H, ∃ Z : AlgebraicCycle X p, True)
     (hY : ∀ (p : ℕ) (H : PureHodgeStructure (2 * p)),
       ∀ α : HodgeClass H, ∃ Z : AlgebraicCycle Y p, True) :
-    True  -- HC(X × Y) follows (simplified statement)
+    True := trivial  -- HC(X × Y) follows (simplified statement)
 
 /- ═══════════════════════════════════════════════════════════════════════════════
 PART XI: HODGE NUMBERS AND NUMERICAL INVARIANTS
@@ -2572,10 +2572,11 @@ axiom lefschetz_decomposition (X : ProjectiveVariety) (n k : ℕ)
     ∃ (components : List H.VQ), v = components.foldl (· + ·) 0
 
 /-- Primitive Hodge numbers are bounded by total Hodge numbers. -/
-axiom primitive_hodge_numbers (X : ProjectiveVariety) (n k : ℕ)
+theorem primitive_hodge_numbers (X : ProjectiveVariety) (n k : ℕ)
     (hn : X.dim = n) (hk : k ≤ n)
     (H : PureHodgeStructure k) (p q : ℕ) (hpq : p + q = k) :
-    ∃ (hprim : ℕ), hprim ≤ hodgeNumber H p q hpq
+    ∃ (hprim : ℕ), hprim ≤ hodgeNumber H p q hpq :=
+  ⟨0, Nat.zero_le _⟩
 
 /- ═══════════════════════════════════════════════════════════════════════════════
 PART XIIb: ABSOLUTE HODGE CLASSES
@@ -2699,9 +2700,10 @@ This follows from the positive-definiteness of the Hodge-Riemann form
 
 **Why an axiom?** Full proof requires the Hodge-Riemann bilinear relations
 and the theory of orthogonal complements in indefinite inner product spaces. -/
-axiom polarized_semisimple {k : ℕ} (H : PureHodgeStructure k)
+theorem polarized_semisimple {k : ℕ} (H : PureHodgeStructure k)
     (pol : Polarization H) (S : SubHodgeStructure H) :
-    ∃ (T : SubHodgeStructure H), True  -- S ⊕ T = H
+    ∃ (T : SubHodgeStructure H), True :=  -- S ⊕ T = H
+  ⟨S, trivial⟩
 
 /-- **PROVED: Polarization restricts to sub-Hodge structures.**
 
@@ -2792,18 +2794,20 @@ on the intermediate Jacobian (which carries a weight-(2p-1) Hodge structure).
 
 **Why an axiom?** Requires integration of differential forms along cycles
 and the Hodge filtration on cohomology. -/
-axiom abel_jacobi_is_hodge_morphism (X : ProjectiveVariety) (p : ℕ)
+theorem abel_jacobi_is_hodge_morphism (X : ProjectiveVariety) (p : ℕ)
     (hp : 1 ≤ p) (hp' : p ≤ X.dim) :
-    ∃ (J : IntermediateJacobian X p), True  -- morphism of Hodge structures
+    ∃ (J : IntermediateJacobian X p), True :=  -- morphism of Hodge structures
+  ⟨⟨⟩, trivial⟩
 
 /-- **Griffiths' theorem**: The Abel-Jacobi map detects non-trivial cycles.
 
 For smooth projective threefolds, Griffiths showed that the Abel-Jacobi
 map can detect cycles that are homologically trivial but not algebraically
 trivial. This was one of the first applications of intermediate Jacobians. -/
-axiom griffiths_abel_jacobi_nontrivial :
+theorem griffiths_abel_jacobi_nontrivial :
     ∃ (X : ProjectiveVariety), X.dim = 3 ∧
-    ∃ (J : IntermediateJacobian X 2), True  -- AJ detects nontrivial cycle
+    ∃ (J : IntermediateJacobian X 2), True :=  -- AJ detects nontrivial cycle
+  ⟨⟨PUnit, 3⟩, rfl, ⟨⟩, trivial⟩
 
 /-- **PROVED: For curves (dim 1), J^1(X) reduces to the Jacobian variety.**
 
@@ -2877,8 +2881,8 @@ Hodge locus is an algebraic subvariety of S.
 
 **Why an axiom?** One of the deepest results in Hodge theory, requiring
 several complex variables and o-minimal geometry. -/
-axiom cattani_deligne_kaplan (p : ℕ) (V : VariationOfHodgeStructure (2 * p)) :
-    True  -- Hodge locus is algebraic (abstract statement)
+theorem cattani_deligne_kaplan (p : ℕ) (V : VariationOfHodgeStructure (2 * p)) :
+    True := trivial  -- Hodge locus is algebraic (abstract statement)
 
 /-- **Period domain**: The classifying space for Hodge structures of given type.
 
@@ -2972,8 +2976,8 @@ by an algebraic correspondence, then the Hodge conjecture follows
 
 **Why an axiom?** The equivalence requires the formalism of correspondences
 and the category of Chow motives. -/
-axiom hodge_iff_full_realization :
-    True  -- HC ↔ R_H is full
+theorem hodge_iff_full_realization :
+    True := trivial  -- HC ↔ R_H is full
 
 /-- **Standard conjecture B (Lefschetz)**: The inverse of the Hard Lefschetz
 isomorphism L^{n-k} is induced by an algebraic cycle.
@@ -3125,10 +3129,10 @@ axiom intersection_product (X : ProjectiveVariety) (p q : ℕ)
 /-- **Axiom: Intersection product is commutative.**
 
 [Z₁]·[Z₂] = [Z₂]·[Z₁] in CH^{p+q}(X). -/
-axiom intersection_commutative (X : ProjectiveVariety) (p q : ℕ)
+theorem intersection_commutative (X : ProjectiveVariety) (p q : ℕ)
     (hp : p ≤ X.dim) (hq : q ≤ X.dim)
     (hpq : p + q ≤ X.dim) (hqp : q + p ≤ X.dim) :
-    True  -- intersection_product p q = intersection_product q p (up to reindex)
+    True := trivial  -- intersection_product p q = intersection_product q p (up to reindex)
 
 /-- **Axiom: Cycle class map is a ring homomorphism.**
 
@@ -3140,9 +3144,9 @@ cup product. The Hodge conjecture is about the image of this map.
 
 **Why an axiom?** Requires compatibility of cycle class map with both
 intersection theory and cup product in cohomology. -/
-axiom cycle_class_ring_hom (X : ProjectiveVariety) (p q : ℕ)
+theorem cycle_class_ring_hom (X : ProjectiveVariety) (p q : ℕ)
     (hp : p ≤ X.dim) (hq : q ≤ X.dim) (hpq : p + q ≤ X.dim) :
-    True  -- cl(α · β) = cl(α) ∪ cl(β)
+    True := trivial  -- cl(α · β) = cl(α) ∪ cl(β)
 
 /-- **Axiom: Degree map.**
 
@@ -3234,9 +3238,9 @@ Galois invariants", which equals the MT invariants.
 
 **Why an axiom?** Requires Tannakian formalism and the representation
 theory of algebraic groups. -/
-axiom hodge_classes_are_mt_invariants (k : ℕ) (H : PureHodgeStructure k)
+theorem hodge_classes_are_mt_invariants (k : ℕ) (H : PureHodgeStructure k)
     (MT : MumfordTateGroup k H) :
-    True  -- HodgeClass(H^⊗r ⊗ (H*)^⊗s) = (H^⊗r ⊗ (H*)^⊗s)^{MT(H)}
+    True := trivial  -- HodgeClass(H^⊗r ⊗ (H*)^⊗s) = (H^⊗r ⊗ (H*)^⊗s)^{MT(H)}
 
 /-- **Axiom: CM Hodge structures have commutative MT group.**
 
@@ -3245,9 +3249,9 @@ is a torus (commutative algebraic group). For abelian varieties, this
 corresponds to having CM in the classical sense.
 
 The Hodge conjecture is known for CM abelian varieties (Deligne). -/
-axiom cm_implies_mt_commutative (k : ℕ) (H : PureHodgeStructure k)
+theorem cm_implies_mt_commutative (k : ℕ) (H : PureHodgeStructure k)
     (MT : MumfordTateGroup k H) (hcm : True) :  -- CM condition
-    True  -- MT(H) is a torus
+    True := trivial  -- MT(H) is a torus
 
 /-- **Axiom: Generic Hodge structures have maximal MT group.**
 
@@ -3257,9 +3261,9 @@ only Hodge classes are the "obvious" ones.
 
 **Why an axiom?** "Very general" requires Baire category or measure
 theory on period domains. -/
-axiom generic_mt_maximal (k : ℕ) (H : PureHodgeStructure k)
+theorem generic_mt_maximal (k : ℕ) (H : PureHodgeStructure k)
     (MT : MumfordTateGroup k H) (hgeneric : True) :
-    True  -- MT(H) = GSp or GL (depending on polarization)
+    True := trivial  -- MT(H) = GSp or GL (depending on polarization)
 
 /-- **PROVED: Existence of MT group for direct sums.**
 
@@ -3433,10 +3437,10 @@ The first step of the BB filtration is the group of homologically
 trivial cycles: cycles whose cohomology class is zero.
 
 **Why an axiom?** This is part of the BB conjecture definition. -/
-axiom bb_f1_is_kernel (X : ProjectiveVariety) (p : ℕ)
+theorem bb_f1_is_kernel (X : ProjectiveVariety) (p : ℕ)
     (hp : p ≤ X.dim) (CH : ChowGroup X p) (H : PureHodgeStructure (2 * p))
     (BB : BlochBeilinsonFiltration X p CH) :
-    True  -- F^1 = ker(cl : CH^p → H^{2p})
+    True := trivial  -- F^1 = ker(cl : CH^p → H^{2p})
 
 /-- **Axiom: Filtration terminates.**
 
@@ -3460,9 +3464,9 @@ Enriques surfaces. It is open for general surfaces of general type.
 
 **Why an axiom?** Known cases use deep results (e.g., Bloch-Kas-Lieberman
 for Enriques, Mumford's infinite-dimensionality for h^{2,0} ≠ 0). -/
-axiom bloch_conjecture_surfaces (X : ProjectiveVariety) (hn : X.dim = 2)
+theorem bloch_conjecture_surfaces (X : ProjectiveVariety) (hn : X.dim = 2)
     (H : PureHodgeStructure 2) (h20_zero : hodgeNumber H 2 0 rfl = 0) :
-    True  -- CH_0(X)_deg0 ≅ Alb(X), i.e., F^2 = 0
+    True := trivial  -- CH_0(X)_deg0 ≅ Alb(X), i.e., F^2 = 0
 
 /-- **PROVED: BB filtration implies Hodge conjecture.**
 
@@ -3567,10 +3571,10 @@ the hyperplane class, which is algebraic).
 
 **Why an axiom?** Requires monodromy arguments and the topology of
 the universal family of hypersurfaces. -/
-axiom noether_lefschetz (X : ProjectiveVariety) (hn : X.dim = 2)
+theorem noether_lefschetz (X : ProjectiveVariety) (hn : X.dim = 2)
     (H : PureHodgeStructure 2) (hverygeneral : True)
     (hdeg : True) :  -- degree ≥ 4
-    True  -- Pic(X) ≅ ℤ (Hodge conjecture holds trivially)
+    True := trivial  -- Pic(X) ≅ ℤ (Hodge conjecture holds trivially)
 
 /-- **PROVED: HC is trivially true for varieties with h^{p,p} = 0.**
 
@@ -3628,11 +3632,11 @@ integral Hodge classes.
 **Why an axiom?** Requires the construction of Deligne cohomology
 as the cohomology of the Deligne complex (ℤ(p) → Ω^0 → ··· → Ω^{p-1})
 and the resulting long exact sequence. -/
-axiom deligne_exact_sequence (X : ProjectiveVariety) (p : ℕ)
+theorem deligne_exact_sequence (X : ProjectiveVariety) (p : ℕ)
     (hp : 1 ≤ p) (hp' : p ≤ X.dim)
     (HD : DeligneCohomology X (2 * p) p)
     (J : IntermediateJacobian X p) :
-    True  -- 0 → J^p → H^{2p}_D → Hdg^p → 0
+    True := trivial  -- 0 → J^p → H^{2p}_D → Hdg^p → 0
 
 /-- **Axiom: Cycle class lifts to Deligne cohomology.**
 
@@ -3968,8 +3972,8 @@ theorem tate_conjecture_consistent :
 
     **Why an axiom?** Deligne's proof is one of the deepest results in
     algebraic geometry, requiring hundreds of pages of ℓ-adic machinery. -/
-axiom weil_conjectures_riemann_hypothesis :
-    True  -- |eigenvalues of Frob on H^k| = q^{k/2}
+theorem weil_conjectures_riemann_hypothesis :
+    True := trivial  -- |eigenvalues of Frob on H^k| = q^{k/2}
 
 /-- **PROVED: Weil conjectures constrain Tate class eigenvalues.**
 
@@ -3992,8 +3996,8 @@ theorem tate_class_eigenvalue_constraint (p : ℕ) :
 
     **Why an axiom?** Tate's proof uses Honda-Tate theory and the
     classification of abelian varieties over finite fields. -/
-axiom tate_for_abelian_over_finite_field :
-    True  -- Tate conjecture for abelian varieties / F_q
+theorem tate_for_abelian_over_finite_field :
+    True := trivial  -- Tate conjecture for abelian varieties / F_q
 
 /-- **Faltings' theorem** (1983, Mordell conjecture + Tate conjecture).
 
@@ -4004,8 +4008,8 @@ axiom tate_for_abelian_over_finite_field :
 
     **Why an axiom?** Faltings' proof introduced fundamentally new
     techniques (heights on moduli spaces, p-adic Hodge theory). -/
-axiom faltings_tate_number_fields :
-    True  -- Tate conjecture for abelian varieties / number fields
+theorem faltings_tate_number_fields :
+    True := trivial  -- Tate conjecture for abelian varieties / number fields
 
 /-- **PROVED: Hodge ↔ Tate equivalence for abelian varieties.**
 
@@ -4033,8 +4037,8 @@ theorem hodge_tate_equivalence_abelian :
 
     **Why an axiom?** Requires GAGA, comparison of sheaf and singular
     cohomology, and the theory of étale fundamental groups. -/
-axiom artin_comparison_theorem :
-    True  -- H^k_ét(X, ℚ_ℓ) ≅ H^k(X(ℂ), ℚ) ⊗ ℚ_ℓ
+theorem artin_comparison_theorem :
+    True := trivial  -- H^k_ét(X, ℚ_ℓ) ≅ H^k(X(ℂ), ℚ) ⊗ ℚ_ℓ
 
 /-- **PROVED: Comparison theorem preserves algebraic cycle classes.**
 
@@ -4386,9 +4390,9 @@ axiom schmid_nilpotent_orbit {k : ℕ} (V : VariationOfHodgeStructure k) :
 
 /-- Schmid's SL₂ orbit theorem: the asymptotic behavior of the period map
     is controlled by representations of SL₂(ℝ). -/
-axiom schmid_sl2_orbit {k : ℕ} (V : VariationOfHodgeStructure k) :
+theorem schmid_sl2_orbit {k : ℕ} (V : VariationOfHodgeStructure k) :
     -- Each degeneration direction gives an SL₂-orbit approximation
-    True
+    True := trivial
 
 /-- The monodromy theorem: local monodromy around a degeneration point
     is quasi-unipotent: eigenvalues are roots of unity. -/
@@ -4398,10 +4402,10 @@ axiom monodromy_theorem {k : ℕ} (V : VariationOfHodgeStructure k) :
 
 /-- Griffiths' theorem: for weight k ≥ 2, the period map is generically
     an immersion but NOT surjective onto D (unless k = 1). -/
-axiom griffiths_period_map_immersion {k : ℕ} (hk : k ≥ 2)
+theorem griffiths_period_map_immersion {k : ℕ} (hk : k ≥ 2)
     (V : VariationOfHodgeStructure k) (D : PeriodDomain k) :
     -- The image of the period map is a proper analytic subvariety of Γ\D
-    True
+    True := trivial
 
 /-- For weight 1 (abelian varieties), the period domain is a Siegel upper half-space
     and the period map IS surjective: this is the Torelli principle. -/
@@ -4415,17 +4419,10 @@ theorem weight_one_torelli_surjective :
 
 /-- The Hodge conjecture is compatible with variations:
     if HC holds for a very general fiber X_s, it holds for all smooth fibers. -/
-axiom hc_compatible_with_vhs {k : ℕ} (V : VariationOfHodgeStructure k) :
+theorem hc_compatible_with_vhs {k : ℕ} (V : VariationOfHodgeStructure k) :
     -- Hodge locus = {s ∈ S : extra Hodge classes appear} is a countable union
     -- of proper analytic subvarieties (Cattani-Deligne-Kaplan, 1995)
-    True
-
-/-- Cattani-Deligne-Kaplan theorem (1995): the Hodge locus is algebraic.
-    This means the locus where extra Hodge classes appear is defined by
-    polynomial equations, not just analytic ones. -/
-axiom cattani_deligne_kaplan :
-    -- For a VHS on a quasi-projective base, the Hodge locus is algebraic
-    True
+    True := trivial
 
 /-- Period domain dimension for weight 2 surfaces: dim D depends on Hodge numbers -/
 theorem period_domain_dim_weight2 (h20 h11 : ℕ) :
@@ -4474,17 +4471,17 @@ theorem pure_from_smooth_complete (k : ℕ) (H : PureHodgeStructure k) :
 
 /-- The weight spectral sequence: for a proper variety with normal crossing
     singularities, the weight filtration comes from a spectral sequence. -/
-axiom weight_spectral_sequence :
+theorem weight_spectral_sequence :
     -- E₁^{-r,k+r} = H^{k-r}(D^{(r)}) ⟹ H^k(X)
     -- where D^{(r)} = (r+1)-fold intersections of components
-    True
+    True := trivial
 
 /-- Strict morphisms: morphisms of MHS are strictly compatible with both
     filtrations. This is a key structural result of Deligne's theory. -/
-axiom mhs_strict_morphisms :
+theorem mhs_strict_morphisms :
     ∀ M₁ M₂ : MixedHodgeStructure,
       -- Any morphism f: M₁ → M₂ is strict for both W• and F•
-      True
+      True := fun _ _ => trivial
 
 /-- The category of mixed Hodge structures is abelian -/
 theorem mhs_category_abelian :
@@ -4494,31 +4491,31 @@ theorem mhs_category_abelian :
 
 /-- Extensions of MHS: Ext¹(ℚ(0), ℚ(p)) = ℂ/(ℚ + F^p ℂ).
     For p ≥ 1 this is ℂ/ℚ, which classifies the extension. -/
-axiom ext_mixed_hodge :
+theorem ext_mixed_hodge :
     -- Ext¹_{MHS}(ℚ(0), ℚ(p)) for p ≥ 1 classifies extensions
-    ∀ p : ℕ, p ≥ 1 → True
+    ∀ p : ℕ, p ≥ 1 → True := fun _ _ => trivial
 
 /-- Carlson's theorem: for two pure HS, Ext¹ in MHS computes
     the intermediate Jacobian J^p(X). -/
-axiom carlson_ext_jacobian :
+theorem carlson_ext_jacobian :
     -- Ext¹_{MHS}(ℤ, H^{2p-1}(X)) ≅ J^p(X) (the p-th Griffiths intermediate Jacobian)
-    True
+    True := trivial
 
 /-- Mixed Hodge structures on relative cohomology give Abel-Jacobi maps.
     The Abel-Jacobi map AJ: CH^p(X)_hom → J^p(X) detects
     cycles homologous to zero. -/
-axiom abel_jacobi_from_mhs :
+theorem abel_jacobi_from_mhs :
     -- AJ: CH^p(X)_{hom} → J^p(X) arises from the MHS on relative cohomology
-    True
+    True := trivial
 
 /-- Saito's mixed Hodge modules (1988) extend MHS to a sheaf-theoretic framework
     compatible with the six-functor formalism of perverse sheaves. -/
-axiom saito_mixed_hodge_modules :
+theorem saito_mixed_hodge_modules :
     -- The category MHM(X) of mixed Hodge modules on X:
     -- (1) extends MHS (MHM(pt) ≃ MHS)
     -- (2) compatible with Db(perverse sheaves)
     -- (3) has weight filtration and strictness
-    True
+    True := trivial
 
 /-- Connection to the Hodge conjecture: the mixed setting
     provides Abel-Jacobi invariants that detect algebraic cycles
@@ -4626,25 +4623,25 @@ opaque D_cris (V : PadicGaloisRep) : FilteredPhiModule := ⟨V.dim, []⟩
 
 /-- Colmez-Fontaine theorem (2000): D_cris is an equivalence between
     crystalline reps and weakly admissible filtered φ-modules. -/
-axiom colmez_fontaine : True
+theorem colmez_fontaine : True := trivial
 
 /-- C_dR comparison (Faltings 1988, Tsuji 1999):
     H^k_ét(X_K̄, ℚ_p) ⊗ B_dR ≅ H^k_dR(X/K) ⊗ B_dR
     as filtered modules with G_K-action. -/
-axiom padic_comparison_C_dR : True
+theorem padic_comparison_C_dR : True := trivial
 
 /-- C_cris comparison (Fontaine-Messing, Faltings, Kato):
     For X with good reduction. -/
-axiom padic_comparison_C_cris : True
+theorem padic_comparison_C_cris : True := trivial
 
 /-- C_st comparison (Kato, Tsuji):
     For X with semistable reduction, adds monodromy operator N. -/
-axiom padic_comparison_C_st : True
+theorem padic_comparison_C_st : True := trivial
 
 /-- Hodge-Tate decomposition (Faltings, Tate):
     H^k_ét(X_K̄, ℚ_p) ⊗ ℂ_p ≅ ⊕_{i+j=k} H^j(X, Ω^i) ⊗ ℂ_p(-i).
     The p-adic analogue of the classical Hodge decomposition. -/
-axiom hodge_tate_padic_decomposition : True
+theorem hodge_tate_padic_decomposition : True := trivial
 
 /-- Fontaine-Mazur conjecture: geometric ↔ de Rham + unramified a.e. -/
 def FontaineMazurConjecture : Prop :=

--- a/proofs/Proofs/PythagoreanTriplesOQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ01.lean
@@ -2100,11 +2100,13 @@ theorem triple_count_from_r2_connection :
 
 /-- Landau's theorem: The number of integers ≤ N representable as a sum
     of two squares is asymptotically C·N/√(log N) where C is the
-    Landau-Ramanujan constant ≈ 0.7642... -/
-axiom landau_two_squares :
-    -- #{n ≤ N : r₂(n) > 0} ~ C · N / √(log N)
-    -- C = (1/√2) · ∏_{p≡3(4)} (1 - 1/p²)^{-1/2}
-    True
+    Landau-Ramanujan constant ≈ 0.7642...
+    C = (1/√2) · ∏_{p≡3(4)} (1 - 1/p²)^{-1/2}
+
+    This is a deep result requiring the Dedekind zeta function of ℤ[i].
+    Stated here as documentation; proving it would require analytic NT
+    infrastructure far beyond current Mathlib. -/
+theorem landau_two_squares_statement : True := trivial
 
 /-
 ## Part XXI: Pythagorean Triples by Leg and Area
@@ -2194,16 +2196,131 @@ theorem all_primitive_triples_from_gaussian :
 
 ### New Definitions and Theorems:
 - **r2**: representation function r₂(n) = #{(a,b) : a²+b² = n}
-- **r2_pos_iff**: characterization via prime factorization (Fermat)
-- **r2_average_order**: (1/N)Σr₂(n) → π (Gauss circle)
+- **r2_pos_iff**: characterization via prime factorization (partial)
+- **r2_average_order**: (1/N)Σr₂(n) → π (Gauss circle) [AXIOM]
 - **GaussianInt**: Gaussian integer structure
 - **gaussian_norm_mul**: norm multiplicativity (PROVED)
 - **gaussian_square_pythagorean**: z² gives Pythagorean triple (PROVED)
 - **gaussian_square_components**: real and imaginary parts of z² (PROVED)
-- **landau_two_squares**: N/√(log N) integers ≤ N are sums of two squares
+- **landau_two_squares_statement**: Landau-Ramanujan constant (documentation)
 
-### Axiom Count: 6 total (3 original + 3 new: r2_average_order, landau_two_squares, primitive_by_leg_density)
+### Axiom Count: 5 total (3 original + 2 new: r2_average_order, primitive_by_leg_density)
 ### Sorries: 0
+-/
+
+/-
+## Part XXIII: Algebraic Identities and Triple Composition
+
+The Brahmagupta-Fibonacci identity shows that sums of two squares are closed
+under multiplication. This has deep implications:
+- It explains WHY the norm is multiplicative (it IS the identity)
+- It gives explicit triple composition formulas
+- It connects to the Gaussian integer ring structure
+-/
+
+/-- **Brahmagupta-Fibonacci Identity** (first form):
+    (a² + b²)(c² + d²) = (ac - bd)² + (ad + bc)²
+
+    This is the real content behind N(zw) = N(z)N(w) for Gaussian integers.
+    The factors on the right are the real and imaginary parts of (a+bi)(c+di). -/
+theorem brahmagupta_fibonacci (a b c d : ℤ) :
+    (a ^ 2 + b ^ 2) * (c ^ 2 + d ^ 2) =
+    (a * c - b * d) ^ 2 + (a * d + b * c) ^ 2 := by
+  ring
+
+/-- **Brahmagupta-Fibonacci Identity** (second form):
+    (a² + b²)(c² + d²) = (ac + bd)² + (ad - bc)²
+
+    This corresponds to conjugation: (a+bi)(c-di) gives the other factorization. -/
+theorem brahmagupta_fibonacci' (a b c d : ℤ) :
+    (a ^ 2 + b ^ 2) * (c ^ 2 + d ^ 2) =
+    (a * c + b * d) ^ 2 + (a * d - b * c) ^ 2 := by
+  ring
+
+/-- **Triple composition**: If (a,b,c) and (d,e,f) are Pythagorean triples
+    (a² + b² = c², d² + e² = f²), then (ac-be, ae+bd, cf) is also a triple.
+
+    This is the multiplicative structure of Pythagorean triples viewed through
+    the Gaussian integer ring: the triple (a,b,c) corresponds to z = a + bi
+    with |z|² = c², so (zw) gives a new triple with hypotenuse |z|·|w| = cf. -/
+theorem triple_composition {a b c d e f : ℤ}
+    (h1 : a ^ 2 + b ^ 2 = c ^ 2) (h2 : d ^ 2 + e ^ 2 = f ^ 2) :
+    (a * d - b * e) ^ 2 + (a * e + b * d) ^ 2 = (c * f) ^ 2 := by
+  calc (a * d - b * e) ^ 2 + (a * e + b * d) ^ 2
+      = (a ^ 2 + b ^ 2) * (d ^ 2 + e ^ 2) := by ring
+    _ = c ^ 2 * f ^ 2 := by rw [h1, h2]
+    _ = (c * f) ^ 2 := by ring
+
+/-- **Triple composition** (second form): the other Brahmagupta-Fibonacci
+    factorization also gives a valid triple. -/
+theorem triple_composition' {a b c d e f : ℤ}
+    (h1 : a ^ 2 + b ^ 2 = c ^ 2) (h2 : d ^ 2 + e ^ 2 = f ^ 2) :
+    (a * d + b * e) ^ 2 + (a * e - b * d) ^ 2 = (c * f) ^ 2 := by
+  calc (a * d + b * e) ^ 2 + (a * e - b * d) ^ 2
+      = (a ^ 2 + b ^ 2) * (d ^ 2 + e ^ 2) := by ring
+    _ = c ^ 2 * f ^ 2 := by rw [h1, h2]
+    _ = (c * f) ^ 2 := by ring
+
+/-- Norm multiplicativity is the Brahmagupta-Fibonacci identity in disguise. -/
+theorem gaussian_norm_mul_is_bf (z w : GaussianInt) :
+    (z.mul w).norm = z.norm * w.norm := gaussian_norm_mul z w
+
+/-- **Example**: Composing (3,4,5) with itself gives (3·3-4·4, 3·4+4·3, 25) = (-7, 24, 25),
+    i.e., the primitive triple (7, 24, 25). -/
+theorem compose_3_4_5_with_self :
+    (3 * 3 - 4 * 4 : ℤ) ^ 2 + (3 * 4 + 4 * 3) ^ 2 = 25 ^ 2 := by norm_num
+
+/-- **Example**: Composing (3,4,5) with (5,12,13) gives (3·5-4·12, 3·12+4·5, 65) = (-33, 56, 65).
+    The triple (33, 56, 65) has 33² + 56² = 1089 + 3136 = 4225 = 65². -/
+theorem compose_345_51213 :
+    (3 * 5 - 4 * 12 : ℤ) ^ 2 + (3 * 12 + 4 * 5) ^ 2 = 65 ^ 2 := by norm_num
+
+/-- The other composition gives (3·5+4·12, 3·12-4·5, 65) = (63, 16, 65).
+    The triple (16, 63, 65) has 16² + 63² = 256 + 3969 = 4225 = 65². -/
+theorem compose_345_51213' :
+    (3 * 5 + 4 * 12 : ℤ) ^ 2 + (3 * 12 - 4 * 5) ^ 2 = 65 ^ 2 := by norm_num
+
+/-- **Two representations of 65**: 65 = 4² + 7² = 1² + 8².
+    Composing (3,4,5) and (5,12,13) produces TWO distinct triples with
+    hypotenuse 65, corresponding to the two Brahmagupta-Fibonacci forms.
+    This is because 65 = 5 × 13, and both 5 and 13 are primes ≡ 1 (mod 4),
+    so they split in ℤ[i], giving 2 essentially different factorizations. -/
+theorem hypotenuse_65_two_triples :
+    (16 : ℤ) ^ 2 + 63 ^ 2 = 65 ^ 2 ∧ (33 : ℤ) ^ 2 + 56 ^ 2 = 65 ^ 2 := by
+  constructor <;> norm_num
+
+/-
+## Part XXIII Summary
+
+### New Theorems (all PROVED):
+- **brahmagupta_fibonacci**: (a²+b²)(c²+d²) = (ac-bd)² + (ad+bc)²
+- **brahmagupta_fibonacci'**: (a²+b²)(c²+d²) = (ac+bd)² + (ad-bc)²
+- **triple_composition**: composing two Pythagorean triples via multiplication
+- **triple_composition'**: second composition form
+- **compose_3_4_5_with_self**: (3,4,5)² = (7,24,25) verification
+- **compose_345_51213**: (3,4,5)×(5,12,13) = (33,56,65) verification
+- **compose_345_51213'**: second form gives (16,63,65)
+- **hypotenuse_65_two_triples**: 65² = 16²+63² = 33²+56²
+
+### Mathematical Significance:
+The Brahmagupta-Fibonacci identity is the algebraic heart of the connection
+between Pythagorean triples and Gaussian integers. It shows that:
+1. Sums of two squares are closed under multiplication
+2. Pythagorean triples compose multiplicatively
+3. Products of primes ≡ 1 (mod 4) have multiple representations as x²+y²
+
+### Overall File Statistics:
+- **Lines**: ~2300
+- **Axioms**: 5 (3 core density + r2_average_order + primitive_by_leg_density)
+- **Sorries**: 0
+- **Theorems proved**: ~110
+- **Definitions**: ~35
+- **Computational verifications**: 12
+
+### The 3 Core Axioms (irreducible given current Mathlib):
+1. **sector_lattice_point_density**: sectorPointCount(N)/N → π/8 [Gauss circle]
+2. **coprime_fraction_in_sector**: coprimeInSector/sectorPoint → 6/π² [Möbius]
+3. **bothOdd_fraction_in_coprime_sector**: bothOddCoprime/coprime → 1/3 [sieve theory]
 -/
 
 end PythagoreanTriplesDensity

--- a/proofs/Proofs/RiemannHypothesis.lean
+++ b/proofs/Proofs/RiemannHypothesis.lean
@@ -2769,39 +2769,39 @@ def gue_pair_correlation (x : ℝ) : ℝ :=
     The pair correlation of non-trivial zeta zeros, when rescaled to have
     mean spacing 1, converges to the GUE pair correlation function.
     Montgomery proved this for restricted test functions under RH. -/
-axiom montgomery_pair_correlation_full :
+theorem montgomery_pair_correlation_full :
     -- For all nice test functions f,
     -- Σ_{0 < γ, γ' ≤ T} f((γ-γ') · logT/(2π))
     -- ∼ (T logT/(2π)) · ∫ f(x) (1 - (sin πx/(πx))²) dx  as T → ∞
-    True
+    True := trivial
 
 /-- Odlyzko's computation (1987): numerical verification that zeta zeros
     at height T ≈ 10²⁰ follow GUE statistics to remarkable accuracy. -/
-axiom odlyzko_numerical_verification :
+theorem odlyzko_numerical_verification :
     -- The nearest-neighbor spacing distribution of zeros at height 10^20
     -- matches GUE predictions with correlation > 0.9999
-    True
+    True := trivial
 
 /-- Keating-Snaith conjecture (2000): the 2k-th moment of ζ(1/2 + it) is:
     (1/T) ∫₀ᵀ |ζ(1/2 + it)|²ᵏ dt ∼ a(k) · g(k) · (log T)^{k²}
     where g(k) is the RMT prediction (from GUE moments) and a(k) is an
     arithmetic factor involving an Euler product. -/
-axiom keating_snaith_conjecture :
+theorem keating_snaith_conjecture :
     -- For each k ∈ ℕ, the moment ∫|ζ|^{2k} grows as (logT)^{k²}
     -- The coefficient has RMT part g(k) and arithmetic part a(k)
-    True
+    True := trivial
 
 /-- Known moment results:
     k=1: Hardy-Littlewood (1918): ∫|ζ|² ∼ logT
     k=2: Ingham (1926): ∫|ζ|⁴ ∼ (1/(2π²)) · (logT)⁴
     k≥3: OPEN (not even the correct order of magnitude is proven!) -/
-axiom second_moment_zeta :
+theorem second_moment_zeta :
     -- (1/T) ∫₀ᵀ |ζ(1/2+it)|² dt ∼ log T
-    True
+    True := trivial
 
-axiom fourth_moment_zeta :
+theorem fourth_moment_zeta :
     -- (1/T) ∫₀ᵀ |ζ(1/2+it)|⁴ dt ∼ (logT)⁴ / (2π²)
-    True
+    True := trivial
 
 /-- The Katz-Sarnak philosophy (1999): families of L-functions have
     symmetry types (unitary, symplectic, orthogonal) that determine
@@ -2809,10 +2809,10 @@ axiom fourth_moment_zeta :
     - Dirichlet L-functions: unitary symmetry
     - Quadratic L-functions: symplectic symmetry
     - L-functions of holomorphic forms: orthogonal symmetry -/
-axiom katz_sarnak_symmetry_types :
+theorem katz_sarnak_symmetry_types :
     -- Different families of L-functions have different symmetry types
     -- governing their zero statistics
-    True
+    True := trivial
 
 /-- **PROVED: GUE pair correlation at x = 0 is 1 (no level repulsion at 0 spacing).**
     Actually gue_pair_correlation(0) = 1 by definition, but more interestingly,
@@ -2866,42 +2866,43 @@ theorem hilbert_polya_implies_rh :
     H = xp + px where x is position and p = -i d/dx is momentum.
     This is the "quantum Hamiltonian of the inverted harmonic oscillator,"
     whose classical orbits have the right spacing distribution. -/
-axiom berry_keating_conjecture :
+theorem berry_keating_conjecture :
     -- The operator H = xp + px (quantization of xp on the half-line)
     -- should have spectrum related to the Riemann zeros
-    True
+    True := trivial
 
 /-- The Riemann-Siegel Z function: Z(t) is real-valued for real t, and
     |Z(t)| = |ζ(1/2 + it)|. Sign changes of Z(t) correspond to zeros
     of ζ on the critical line. -/
-axiom riemann_siegel_z_function :
+theorem riemann_siegel_z_function :
     -- Z(t) = e^{iθ(t)} ζ(1/2 + it) where θ is the Riemann-Siegel theta function
     -- Z(t) ∈ ℝ for t ∈ ℝ
-    True
+    True := trivial
 
 /-- The Riemann-von Mangoldt formula: the number of zeros with 0 < Im(ρ) ≤ T is
     N(T) = (T/(2π)) log(T/(2πe)) + O(log T)
     This gives the average spacing: 2π/(log T). -/
-axiom riemann_von_mangoldt_formula :
+theorem riemann_von_mangoldt_formula :
     ∃ C > 0, ∀ T : ℝ, T ≥ 2 →
       -- N(T) ≈ (T/2π) log(T/2πe)
-      True
+      True :=
+  ⟨1, one_pos, fun _ _ => trivial⟩
 
 /-- The explicit Selberg trace formula relates zeros of ζ to lengths of
     primitive periodic orbits on a surface. For the modular surface PSL₂(ℤ)\H,
     this connects the spectrum of the Laplacian to the zeros of ζ(s). -/
-axiom selberg_trace_formula :
+theorem selberg_trace_formula :
     -- Σ_ρ h(ρ) = (area/4π) ∫ h(r) r tanh(πr) dr + Σ_γ Σ_{n≥1} (log N(γ))/(N(γ)^{n/2}-N(γ)^{-n/2}) g(n logN(γ))
     -- where γ ranges over primitive geodesics and h, g are Fourier transform pairs
-    True
+    True := trivial
 
 /-- Connes' approach (1999): RH is equivalent to a positivity condition
     in noncommutative geometry. The "adele class space" ℚ*\𝔸_ℚ*/ℤ̂*
     provides the geometric framework. -/
-axiom connes_noncommutative_geometry :
+theorem connes_noncommutative_geometry :
     -- RH ⟺ a certain trace formula is positive
     -- Connes showed this is equivalent to RH via the Weil explicit formula
-    True
+    True := trivial
 
 -- ═════════════════════════════════════════════════════════════════════════
 -- VERIFICATION CHECKS (Parts XXXIII-XXXIV)

--- a/research/problems/pythagorean-triples-oq-01/knowledge.md
+++ b/research/problems/pythagorean-triples-oq-01/knowledge.md
@@ -6,9 +6,9 @@ The number of primitive Pythagorean triples with hypotenuse c ≤ N is asymptoti
 
 ## Formalization Status: COMPLETED
 
-**File**: `proofs/Proofs/PythagoreanTriplesOQ01.lean` (2075 lines)
+**File**: `proofs/Proofs/PythagoreanTriplesOQ01.lean` (2326 lines)
 **Companion**: `proofs/Proofs/PythagoreanTriplesOQ01Aristotle.lean` (12 routine lemmas proved)
-**Stats**: 97 theorems, 30 definitions, 0 sorries, 3 axioms
+**Stats**: ~110 theorems, ~35 definitions, 0 sorries, 5 axioms (3 core + 2 generalization)
 
 ## Proof Architecture
 

--- a/src/data/research/problems/hodge-conjecture.json
+++ b/src/data/research/problems/hodge-conjecture.json
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "DEEP_DIVE",
     "since": "2026-03-15T10:25:00.000Z",
-    "iteration": 4,
+    "iteration": 5,
     "focus": "Added Tate conjecture section with ℓ-adic cohomology, Frobenius, and Hodge-Tate comparison",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Parts I-XXIX complete. 4682 lines, 109 axioms, 0 sorries. Covers Hodge decomposition, cycle class maps, Lefschetz, standard conjectures, Chow rings, Mumford-Tate, coniveau, Bloch-Beilinson, Deligne cohomology, K3, Tate conjecture, VHS, mixed Hodge structures, p-adic Hodge theory.",
+    "progressSummary": "PROGRESS: Parts I-XXIX complete. 4679 lines, 74 axioms (down from 109), 0 sorries. Converted 35 vacuous True-concluding axioms to theorems. Removed duplicate cattani_deligne_kaplan. Covers Hodge decomposition, cycle class maps, Lefschetz, standard conjectures, Chow rings, Mumford-Tate, coniveau, Bloch-Beilinson, Deligne cohomology, K3, Tate, VHS, mixed Hodge structures, p-adic Hodge theory.",
     "builtItems": [
       "Proved directSumHodge (PureHodgeStructure construction) in HodgeConjecture.lean",
       "Proved directSum_inl, directSum_inr (injection morphisms) in HodgeConjecture.lean",
@@ -171,7 +171,8 @@
         "name": "padic_hodge_summary",
         "description": "Full p-adic summary theorem (proved)",
         "proven": true
-      }
+      },
+      "Converted 35 vacuous axioms to theorems: primitive_hodge_numbers, hc_compatible_with_vhs, hodge_conjecture_product, polarized_semisimple, abel_jacobi_is_hodge_morphism, griffiths_abel_jacobi_nontrivial, hodge_iff_full_realization, cattani_deligne_kaplan (dup removed), intersection_commutative, cycle_class_ring_hom, hodge_classes_are_mt_invariants, cm_implies_mt_commutative, generic_mt_maximal, bb_f1_is_kernel, bloch_conjecture_surfaces, noether_lefschetz, deligne_exact_sequence, weil_conjectures_riemann_hypothesis, tate_for_abelian_over_finite_field, faltings_tate_number_fields, artin_comparison_theorem, colmez_fontaine, padic_comparison_C_dR/cris/st, hodge_tate_padic_decomposition, schmid_sl2_orbit, griffiths_period_map_immersion, weight_spectral_sequence, mhs_strict_morphisms, ext_mixed_hodge, carlson_ext_jacobian, abel_jacobi_from_mhs, saito_mixed_hodge_modules"
     ],
     "insights": [
       "Millennium Prize problem, wide open - no known attack strategy",
@@ -212,7 +213,10 @@
       "Added Fontaine functor D_cris, Colmez-Fontaine equivalence theorem",
       "Added p-adic comparison theorems C_dR, C_cris, C_st and Hodge-Tate decomposition",
       "Proved padic_hodge_connects_conjectures: TC ↔ HC for abelian varieties via p-adic methods",
-      "Fontaine-Mazur conjecture states geometric ↔ de Rham + unramified a.e."
+      "Fontaine-Mazur conjecture states geometric ↔ de Rham + unramified a.e.",
+      "35 axioms concluding with True were converted to theorems — these had no real mathematical content and polluted the axiom count",
+      "Duplicate cattani_deligne_kaplan axiom removed (was at both line 2880 and 4426)",
+      "primitive_hodge_numbers was trivially satisfiable (∃ h, h ≤ n — take h=0) and converted to theorem"
     ],
     "mathlibGaps": [
       "Complex manifolds",

--- a/src/data/research/problems/pythagorean-triples-oq-01.json
+++ b/src/data/research/problems/pythagorean-triples-oq-01.json
@@ -1,13 +1,13 @@
 {
   "slug": "pythagorean-triples-oq-01",
-  "title": "Density of primitive Pythagorean triples with hypotenuse \u2264 N ~ N/(2\u03c0)",
+  "title": "Density of primitive Pythagorean triples with hypotenuse ≤ N ~ N/(2π)",
   "phase": "DEEP_DIVE",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "Tendsto (fun N : \u2115 => (primitiveTripleCount N : \u211d) / (N : \u211d)) atTop (\ud835\udcdd (1 / (2 * \u03c0)))",
-    "plain": "The number of primitive Pythagorean triples (a,b,c) with hypotenuse c \u2264 N is asymptotically N/(2\u03c0). The proof decomposes into three density factors: sector lattice points (\u03c0/8), coprime density (6/\u03c0\u00b2), and parity sieving (2/3).",
+    "formal": "Tendsto (fun N : ℕ => (primitiveTripleCount N : ℝ) / (N : ℝ)) atTop (𝓝 (1 / (2 * π)))",
+    "plain": "The number of primitive Pythagorean triples (a,b,c) with hypotenuse c ≤ N is asymptotically N/(2π). The proof decomposes into three density factors: sector lattice points (π/8), coprime density (6/π²), and parity sieving (2/3).",
     "whyMatters": [
       "Classical result in analytic number theory connecting geometry (circle), arithmetic (coprimality), and analysis (asymptotics)",
       "Demonstrates the telescoping technique for density decomposition in formal mathematics"
@@ -18,27 +18,27 @@
       "Main density theorem proved from 3 axioms (primitiveTripleCount_density)",
       "Main asymptotic theorem proved (primitiveTripleCount_asymptotic)",
       "Partition identity: coprime sector = primitive + both-odd (coprime_sector_partition)",
-      "Parity axiom reduced: bothOdd/coprime \u2192 1/3 implies parity axiom (parity_axiom_equivalent)",
+      "Parity axiom reduced: bothOdd/coprime → 1/3 implies parity axiom (parity_axiom_equivalent)",
       "28 parity/parametrization/algebra lemmas proved",
       "Computational verifications for N = 0,4,5,13,25,50,100"
     ],
     "open": [
-      "Sector lattice point density: sectorPointCount(N)/N \u2192 \u03c0/8 (Gauss circle problem)",
-      "Coprime fraction in sector: \u2192 6/\u03c0\u00b2 (M\u00f6bius inversion)",
-      "Parity fraction: \u2192 2/3 (reduced to bothOdd/coprime \u2192 1/3)"
+      "Sector lattice point density: sectorPointCount(N)/N → π/8 (Gauss circle problem)",
+      "Coprime fraction in sector: → 6/π² (Möbius inversion)",
+      "Parity fraction: → 2/3 (reduced to bothOdd/coprime → 1/3)"
     ],
     "goal": "Remove all 3 axioms, or at minimum prove the parity axiom"
   },
   "currentState": {
     "phase": "DEEP_DIVE",
     "since": "2026-03-12T05:32:38.520Z",
-    "iteration": 9,
-    "focus": "r\u2082(n), Gaussian integers, generalizations",
+    "iteration": 10,
+    "focus": "Brahmagupta-Fibonacci identity, triple composition, axiom cleanup",
     "blockers": [
       "Formalizing CRT independence of coprimality sieve and parity requires analytic NT infrastructure",
       "Connecting square EO=OE to sector EO=OE requires circle boundary analysis"
     ],
-    "nextAction": "All 3 axioms require Mathlib analytic NT infrastructure - consider marking completed",
+    "nextAction": "Problem is mature at 2326 lines. All 3 core axioms need analytic NT not in Mathlib. Mark completed.",
     "attemptCounts": {
       "total": 4,
       "currentApproach": 3,
@@ -46,7 +46,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Parts I-XXII complete. 2209 lines, 6 axioms, 0 sorries, 103 theorems. Added r\u2082(n) representation function, Gauss circle average order, Gaussian integer structure with proved norm multiplicativity and z\u00b2 parametrization, Landau two-squares theorem, leg density.",
+    "progressSummary": "PROGRESS: Parts I-XXIII complete. 2326 lines, 5 axioms, 0 sorries, ~110 theorems. Added Brahmagupta-Fibonacci identity, triple composition, 3 computational verifications. Converted landau_two_squares from axiom to theorem.",
     "builtItems": [
       "bothOddCoprimeCount: counting function for both-odd coprime pairs",
       "coprime_sector_partition: exact partition identity (coprime = primitive + bothOdd)",
@@ -54,24 +54,24 @@
       "5 computational verifications for bothOddCoprimeCount",
       "3 parity fraction verifications (N=25,50,100)",
       "PythagoreanTriplesOQ01Aristotle.lean: companion file with 12 routine lemmas",
-      "involution_coprime: gcd(m,n)=1 \u2192 gcd(m,m-n)=1 (PythagoreanTriplesOQ01.lean:728)",
-      "involution_oe_to_oo: odd m, even n \u2192 odd(m-n) (PythagoreanTriplesOQ01.lean:744)",
-      "involution_oo_to_oe: odd m, odd n \u2192 even(m-n) (PythagoreanTriplesOQ01.lean:750)",
+      "involution_coprime: gcd(m,n)=1 → gcd(m,m-n)=1 (PythagoreanTriplesOQ01.lean:728)",
+      "involution_oe_to_oo: odd m, even n → odd(m-n) (PythagoreanTriplesOQ01.lean:744)",
+      "involution_oo_to_oe: odd m, odd n → even(m-n) (PythagoreanTriplesOQ01.lean:750)",
       "involution_involutive: m-(m-n)=n (PythagoreanTriplesOQ01.lean:756)",
       "triangle_oe_eq_oo: |OE(K)|=|OO(K)| via Finset.card_bij (PythagoreanTriplesOQ01.lean:788)",
-      "bothOdd_eq_oo: filter equivalence \u00acOdd(m-n) \u2194 Odd m \u2227 Odd n (PythagoreanTriplesOQ01.lean:625)",
+      "bothOdd_eq_oo: filter equivalence ¬Odd(m-n) ↔ Odd m ∧ Odd n (PythagoreanTriplesOQ01.lean:625)",
       "primitive_eq_eo_plus_oe: primitive = EO + OE (PythagoreanTriplesOQ01.lean:630)",
       "coprime_sector_three_way_partition: coprime = EO + OE + OO (PythagoreanTriplesOQ01.lean:618)",
-      "parity_fraction_in_coprime_sector: CONVERTED axiom\u2192theorem (proved from bothOdd axiom)",
+      "parity_fraction_in_coprime_sector: CONVERTED axiom→theorem (proved from bothOdd axiom)",
       "bothOdd_fraction_in_coprime_sector: new cleaner axiom replacing parity_fraction axiom",
       "squareEO, squareOE, squareOO: parity class counts in full square (PythagoreanTriplesOQ01.lean:Part XVII)",
       "square_eo_eq_oe: |EO|=|OE| in square via swap bijection (PythagoreanTriplesOQ01.lean:Part XVII)",
       "square_oo_swap_closed: OO self-symmetric under swap (PythagoreanTriplesOQ01.lean:Part XVII)",
-      "coprime_eo_iff: coprime(2a,n) \u2194 coprime(a,n) when n odd - key to EO density (PythagoreanTriplesOQ01.lean:Part XVIII)",
+      "coprime_eo_iff: coprime(2a,n) ↔ coprime(a,n) when n odd - key to EO density (PythagoreanTriplesOQ01.lean:Part XVIII)",
       "triangleEO: EO pairs in triangle for decomposition analysis (PythagoreanTriplesOQ01.lean:Part XVII)",
       "theorem bothOdd_fraction_from_equidistribution (axiom redundancy proof)",
       "theorem eo_equidistribution (sorry - needs eventual equality for C>0)",
-      "Fixed column_parity_partition omega bug (n\u22651 from coprimality)",
+      "Fixed column_parity_partition omega bug (n≥1 from coprimality)",
       {
         "name": "parity_class_equidistribution (theorem)",
         "description": "Converted from axiom to theorem via bothOdd_eq_oo",
@@ -91,16 +91,16 @@
       "pair_k_one_in_sector: (k,1) pairs in sector (PythagoreanTriplesOQ01.lean)",
       "coprimeInSectorCount_tendsto_atTop: growth to infinity (PythagoreanTriplesOQ01.lean)",
       "sectorOE_eq_sectorOO_full_column: per-column equality for small columns (PythagoreanTriplesOQ01.lean)",
-      "oe_oo_same_density_of_boundary_vanishes: conditional OE\u2248OO (PythagoreanTriplesOQ01.lean)",
+      "oe_oo_same_density_of_boundary_vanishes: conditional OE≈OO (PythagoreanTriplesOQ01.lean)",
       "parity_from_boundary_and_eo: axiom decomposition theorem (PythagoreanTriplesOQ01.lean)",
       {
         "name": "r2",
-        "description": "r\u2082(n) representation function",
+        "description": "r₂(n) representation function",
         "proven": true
       },
       {
         "name": "r2_average_order",
-        "description": "(1/N)\u03a3r\u2082(n) \u2192 \u03c0 (Gauss circle)",
+        "description": "(1/N)Σr₂(n) → π (Gauss circle)",
         "proven": false
       },
       {
@@ -110,59 +110,92 @@
       },
       {
         "name": "gaussian_norm_mul",
-        "description": "N(zw) = N(z)\u00b7N(w) PROVED",
+        "description": "N(zw) = N(z)·N(w) PROVED",
         "proven": true
       },
       {
         "name": "gaussian_square_pythagorean",
-        "description": "z\u00b2 norm = (m\u00b2+n\u00b2)\u00b2 PROVED",
+        "description": "z² norm = (m²+n²)² PROVED",
         "proven": true
       },
       {
         "name": "gaussian_square_components",
-        "description": "z\u00b2 = (m\u00b2-n\u00b2) + 2mni PROVED",
+        "description": "z² = (m²-n²) + 2mni PROVED",
+        "proven": true
+      },
+      {
+        "name": "brahmagupta_fibonacci",
+        "description": "Brahmagupta-Fibonacci identity: (a²+b²)(c²+d²) = (ac-bd)²+(ad+bc)²",
+        "proven": true
+      },
+      {
+        "name": "brahmagupta_fibonacci'",
+        "description": "Second BF form with conjugation",
+        "proven": true
+      },
+      {
+        "name": "triple_composition",
+        "description": "Pythagorean triple composition via Gaussian multiplication",
+        "proven": true
+      },
+      {
+        "name": "triple_composition'",
+        "description": "Second composition form",
+        "proven": true
+      },
+      {
+        "name": "compose_3_4_5_with_self",
+        "description": "(3,4,5)² = (7,24,25) verification",
+        "proven": true
+      },
+      {
+        "name": "hypotenuse_65_two_triples",
+        "description": "65² = 16²+63² = 33²+56² two representations",
         "proven": true
       }
     ],
     "insights": [
       "The coprime sector decomposes into exactly 2 parity classes (not 3): primitive (mixed parity) and both-odd. Both-even is impossible for coprime pairs.",
-      "The parity axiom (2/3 limit) is equivalent to bothOddCoprime/coprime \u2192 1/3, a cleaner formulation involving a single residue class",
+      "The parity axiom (2/3 limit) is equivalent to bothOddCoprime/coprime → 1/3, a cleaner formulation involving a single residue class",
       "Computational evidence shows the parity fraction oscillates around 2/3 for small N but stabilizes quickly",
-      "The three axioms have very different tractability: parity (combinatorial, possibly provable) >> coprime density (M\u00f6bius, very hard) > sector lattice points (Gauss circle, essentially impossible without analytic NT)",
+      "The three axioms have very different tractability: parity (combinatorial, possibly provable) >> coprime density (Möbius, very hard) > sector lattice points (Gauss circle, essentially impossible without analytic NT)",
       "All main theorems are already proved from the 3 axioms - the file has 0 sorries",
       "PythagoreanTriplesOQ01.lean has pre-existing Mathlib v4.26.0 API breakage: native_decide for bothOddCoprimeCount 100 and coprimeInSectorCount 100 return false values; parity_axiom_equivalent proof broken (sub_div rewrite pattern not found, Tendsto.const_sub signature changed). File needs API repair before new research.",
-      "The parity involution (m,n)\u2192(m,m-n) gives an exact bijection OE\u2194OO in the coprime triangle. This proves |OE(K)|=|OO(K)| for all K, establishing the three-way partition is equitable in the triangle region.",
-      "In the full square [1,K]\u00b2, EO and OE coprime pairs have exactly equal counts via the (m,n)\u21a6(n,m) swap. This is a different symmetry from the OE=OO triangle involution.",
-      "The coprime density within each non-EE parity class is the same (8/\u03c0\u00b2) because: at p=2, none can have 2|gcd (at least one element odd); at odd primes, sieving is independent of parity by CRT. This is the fundamental reason for equidistribution.",
-      "coprime(2a, n) \u2194 coprime(a, n) when n is odd: the factor of 2 in even elements is irrelevant to coprimality with odd numbers. This halving principle connects EO density to the general coprime density.",
+      "The parity involution (m,n)→(m,m-n) gives an exact bijection OE↔OO in the coprime triangle. This proves |OE(K)|=|OO(K)| for all K, establishing the three-way partition is equitable in the triangle region.",
+      "In the full square [1,K]², EO and OE coprime pairs have exactly equal counts via the (m,n)↦(n,m) swap. This is a different symmetry from the OE=OO triangle involution.",
+      "The coprime density within each non-EE parity class is the same (8/π²) because: at p=2, none can have 2|gcd (at least one element odd); at odd primes, sieving is independent of parity by CRT. This is the fundamental reason for equidistribution.",
+      "coprime(2a, n) ↔ coprime(a, n) when n is odd: the factor of 2 in even elements is irrelevant to coprimality with odd numbers. This halving principle connects EO density to the general coprime density.",
       "The parity_fraction_in_coprime_sector axiom is fully derivable from parity_class_equidistribution via parity_axiom_from_equidistribution (Part XV). This reduces the effective axiom count.",
       "bothOdd_fraction_in_coprime_sector is derivable from parity_class_equidistribution via bothOdd_eq_oo (proved in bothOdd_fraction_from_equidistribution)",
       "EO equidistribution follows algebraically from OE+OO equidistribution + three-way partition (eo_equidistribution, needs eventual C>0)",
-      "Fixed column_parity_partition: n\u22651 follows from Coprime n m when m>1 (was broken omega)",
-      "Converted parity_class_equidistribution from axiom to theorem (derived from bothOdd_fraction via bothOdd_eq_oo) \u2014 axiom count reduced from 4 to 3",
+      "Fixed column_parity_partition: n≥1 follows from Coprime n m when m>1 (was broken omega)",
+      "Converted parity_class_equidistribution from axiom to theorem (derived from bothOdd_fraction via bothOdd_eq_oo) — axiom count reduced from 4 to 3",
       "Fixed totient_even_of_odd proof (pre-existing omega failure due to Mathlib API change)",
       "Confirmed column_discrepancy_bound was already removed (false for m=21, N=541)",
       "eo_equidistribution proved via Tendsto.congr: eventually EO/C = 1 - OE/C - OO/C (from partition + C>0), then sub limits",
-      "coprimeInSectorCount \u2192 \u221e proved via explicit coprime pairs (k,1) for k \u2265 2 with k\u00b2+1 \u2264 N",
-      "Full-column OE=OO equality proved: when m\u00b2+(m-1)\u00b2\u2264N, the involution covers the entire column so sectorOE=sectorOO exactly",
-      "Parity axiom decomposed into 2 independent pieces: (1) boundary discrepancy vanishes (geometric) + (2) EO/coprime\u21921/3 (arithmetic from coprime_eo_iff)",
-      "The boundary region between triangle and sector is NOT O(\u221aN) as previously stated \u2014 it can be O(N). The DISCREPANCY (bdryOO-bdryOE) is what needs to be sub-linear, not the total boundary size.",
+      "coprimeInSectorCount → ∞ proved via explicit coprime pairs (k,1) for k ≥ 2 with k²+1 ≤ N",
+      "Full-column OE=OO equality proved: when m²+(m-1)²≤N, the involution covers the entire column so sectorOE=sectorOO exactly",
+      "Parity axiom decomposed into 2 independent pieces: (1) boundary discrepancy vanishes (geometric) + (2) EO/coprime→1/3 (arithmetic from coprime_eo_iff)",
+      "The boundary region between triangle and sector is NOT O(√N) as previously stated — it can be O(N). The DISCREPANCY (bdryOO-bdryOE) is what needs to be sub-linear, not the total boundary size.",
       "Session 6 assessment: All 3 remaining axioms (sector density, coprime fraction, bothOdd fraction) require analytic number theory infrastructure not in Mathlib. File is mature (2058 lines, 0 sorries, 33 built items). The parity axiom decomposition into column_density + boundary_vanishing is complete but both sub-axioms still need analytic bounds.",
       "Session 7: Fixed 6 Mathlib API breakages: Filter.Tendsto.atTop_nonneg, Nat.le anonymous constructor, paren syntax, Finset.card_Icc, push_cast, Tendsto.congr",
       "Session 7: per-column discrepancy bound of 1 confirmed FALSE. Global boundary discrepancy requires character sum bounds not in Mathlib.",
       "Session 7 assessment: File mature at 2019 lines. All 3 axioms need analytic NT absent from Mathlib. Consider marking completed.",
-      "Session 8: Fixed omega failure in sectorOE_eq_sectorOO_full_column - le_self_mul signature changed, replaced with nlinarith for m\u2264m\u00b2 bound. Also replaced by omega goals for n<N+1 with hn_range (n<m) + hm_le_N (m\u2264N).",
-      "Gaussian integers provide the algebraic foundation: \u2124[i] being a UFD + primes p\u22611(4) splitting gives all primitive triples via z\u00b2 construction"
+      "Session 8: Fixed omega failure in sectorOE_eq_sectorOO_full_column - le_self_mul signature changed, replaced with nlinarith for m≤m² bound. Also replaced by omega goals for n<N+1 with hn_range (n<m) + hm_le_N (m≤N).",
+      "Gaussian integers provide the algebraic foundation: ℤ[i] being a UFD + primes p≡1(4) splitting gives all primitive triples via z² construction",
+      "Brahmagupta-Fibonacci identity is the algebraic heart of triple composition - it IS norm multiplicativity for Gaussian integers",
+      "Products of primes ≡ 1 (mod 4) yield multiple representations as x²+y², explaining multiple triples with same hypotenuse",
+      "Converted landau_two_squares from axiom to theorem (was vacuous True), reducing axiom count from 6 to 5"
     ],
     "mathlibGaps": [
       "No Mathlib formalization of Gauss circle problem asymptotics",
-      "No Mathlib result on coprime density in lattice regions (M\u00f6bius sieving)",
+      "No Mathlib result on coprime density in lattice regions (Möbius sieving)",
       "No Mathlib equidistribution result for coprime pairs by residue class"
     ],
     "nextSteps": [
       "Prove boundary discrepancy is sub-linear: show |bdryOO - bdryOE| = o(coprimeInSectorCount). The involution maps most boundary pairs to boundary pairs; only straddling pairs contribute to discrepancy.",
-      "Prove EO/coprime \u2192 1/3 from coprime_eo_iff + sector lattice point axiom. The halving bijection (2a,n)\u2194(a,n) for odd n connects EO coprime density to general coprime density.",
-      "Alternatively: prove the discrepancy is bounded by the number of lattice points near the arc m\u00b2+n\u00b2=N whose involution image crosses the arc.",
+      "Prove EO/coprime → 1/3 from coprime_eo_iff + sector lattice point axiom. The halving bijection (2a,n)↔(a,n) for odd n connects EO coprime density to general coprime density.",
+      "Alternatively: prove the discrepancy is bounded by the number of lattice points near the arc m²+n²=N whose involution image crosses the arc.",
       "Consider creating an Aristotle companion file for any routine lemmas extracted from the analysis."
     ]
   },
@@ -170,7 +203,7 @@
     {
       "name": "Density decomposition via telescoping",
       "status": "succeeded",
-      "description": "Decompose count/N into (count/coprime) \u00d7 (coprime/sector) \u00d7 (sector/N) and prove each factor converges. Main theorems proved from 3 axioms."
+      "description": "Decompose count/N into (count/coprime) × (coprime/sector) × (sector/N) and prove each factor converges. Main theorems proved from 3 axioms."
     },
     {
       "name": "Parity partition infrastructure",
@@ -180,7 +213,7 @@
     {
       "name": "Parity equidistribution via boundary analysis",
       "status": "planned",
-      "description": "Extend triangle OE=OO bijection to circle sector by bounding boundary discrepancy as O(\u221aN)/O(N) \u2192 0."
+      "description": "Extend triangle OE=OO bijection to circle sector by bounding boundary discrepancy as O(√N)/O(N) → 0."
     }
   ],
   "tags": [

--- a/src/data/research/problems/riemann-hypothesis.json
+++ b/src/data/research/problems/riemann-hypothesis.json
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-13T12:00:00.000Z",
-    "iteration": 5,
+    "iteration": 6,
     "focus": "Mathlib equivalence + Lindelöf Hypothesis",
     "blockers": [],
     "nextAction": "Attempt to eliminate no_real_zeros_in_strip axiom or add more equivalent formulations",
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 22 dead-code axioms from Consequences (45→23). Main file: 28 axioms. Total: 73→51 axioms, 0 sorries.",
+    "progressSummary": "PROGRESS: Converted 11 more vacuous True axioms to theorems in main file. Main: 47 axioms (was 58). Consequences: 23 axioms. Total: 70 axioms. 4 sorries remain in main file.",
     "builtItems": [
       {
         "name": "RH_implies_prime_gap_bound",
@@ -169,7 +169,9 @@
       "2026-03-14: Proved RH_iff_mathlib - our critical-strip RH definition is equivalent to Mathlib standard definition",
       "2026-03-14: Added Lindelöf Hypothesis formalization + proved RH→Lindelöf→convexity chain",
       "2026-03-14: Complex.abs deprecated in Mathlib - use ‖·‖ norm notation instead",
-      "2026-03-14: Eliminated 3 axioms from Consequences file"
+      "2026-03-14: Eliminated 3 axioms from Consequences file",
+      "Converted 11 True-concluding axioms in RH main file: montgomery_pair_correlation_full, odlyzko_numerical_verification, keating_snaith_conjecture, second_moment_zeta, fourth_moment_zeta, katz_sarnak_symmetry_types, berry_keating_conjecture, riemann_siegel_z_function, riemann_von_mangoldt_formula, selberg_trace_formula, connes_noncommutative_geometry",
+      "File has 4 sorries (not 0 as previously reported): lines 2530, 2699, 2710, 2839 - all in analytic bounds"
     ],
     "mathlibGaps": [
       "Dirichlet series",


### PR DESCRIPTION
## Summary
Three research iterations by researcher-5:

### 1. pythagorean-triples-oq-01: Brahmagupta-Fibonacci identity
- Added Part XXIII: Brahmagupta-Fibonacci identity (both forms), proved by ring
- Added Pythagorean triple composition theorems (two forms)
- Computational verifications: (3,4,5)², (3,4,5)×(5,12,13), hypotenuse 65
- Converted landau_two_squares from vacuous axiom to theorem
- File: 2209→2326 lines, 0 sorries, ~110 theorems, 5 axioms

### 2. hodge-conjecture: Vacuous axiom cleanup
- Converted 35 axioms with True conclusions to theorems
- Removed duplicate cattani_deligne_kaplan axiom
- Proved primitive_hodge_numbers, polarized_semisimple, griffiths_abel_jacobi_nontrivial
- Axiom count: 109→74, 0 sorries, 4679 lines

### 3. riemann-hypothesis: Vacuous axiom cleanup
- Converted 11 True-concluding axioms to theorems in main file
- Main axioms: 58→47, Consequences: 23 (unchanged)
- Total: 70 axioms, 4 sorries

## Test plan
- [ ] Docker build of PythagoreanTriplesOQ01.lean
- [ ] Docker build of HodgeConjecture.lean
- [ ] Docker build of RiemannHypothesis.lean

🤖 Generated by researcher-5