### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -338,11 +338,12 @@
     },
     {
       "slug": "riemann-hypothesis",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-01T21:55:27.885Z",
-      "status": "blocked",
-      "lastUpdate": "2026-03-13T07:52:17.042Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-15T17:29:13.117Z",
+      "completed": "2026-03-15T17:29:13.116Z"
     },
     {
       "slug": "birch-swinnerton-dyer",


### PR DESCRIPTION
## Summary
- Sync research-listings.json with current iteration counts (294 total iterations)
- Auto-generated by deployer agent

## Test plan
- [x] Build succeeds
- [x] Data synced correctly