### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -374,11 +374,12 @@
     },
     {
       "slug": "poincare-conjecture",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-01T21:55:27.887Z",
-      "status": "blocked",
-      "lastUpdate": "2026-03-13T07:52:17.042Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-15T22:28:57.349Z",
+      "completed": "2026-03-15T22:28:57.349Z"
     },
     {
       "slug": "navier-stokes-existence",


### PR DESCRIPTION
## Summary
- Sync research-listings.json with actual iteration counts (added 1, updated 19 listings)
- Total iterations: 309

Automated sync by deployer agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)