### PR TITLE
Append [automated post] tag to Herald posts

### DIFF
--- a/scripts/herald/post-mathstodon.sh
+++ b/scripts/herald/post-mathstodon.sh
@@ -60,6 +60,11 @@ if [[ -z "$TEXT" ]]; then
     exit 1
 fi
 
+# Append automated post tag
+TEXT="${TEXT}
+
+[automated post]"
+
 # Validate character limit
 CHAR_COUNT=${#TEXT}
 if [[ $CHAR_COUNT -gt $MAX_CHARS ]]; then


### PR DESCRIPTION
## Summary
- Appends `[automated post]` to every Herald Mathstodon post
- Tag is added before character limit validation so it counts toward the 500-char max

🤖 Generated with [Claude Code](https://claude.com/claude-code)