### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -357,11 +357,12 @@
     },
     {
       "slug": "hodge-conjecture",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-01T21:55:27.887Z",
-      "status": "blocked",
-      "lastUpdate": "2026-03-13T07:52:17.042Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-16T16:51:32.260Z",
+      "completed": "2026-03-16T16:51:32.259Z"
     },
     {
       "slug": "yang-mills-mass-gap",


### PR DESCRIPTION
## Summary
- Synced research-listings.json with actual iteration counts (added 1, updated 19)
- Data files pruned to current state after PR merges

## Context
Automated sync by deployer agent after merging PRs #3892 and #3891.

🤖 Generated with [Claude Code](https://claude.com/claude-code)