### PR TITLE
Research: angle-trisection - Prove Gauss-Wantzel, eliminate 2 axioms

### DIFF
--- a/research/problems/angle-trisection-oq-02-oq-03-oq-01/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-03-oq-01/knowledge.md
@@ -1,4 +1,74 @@
 # Knowledge Base: angle-trisection-oq-02-oq-03-oq-01
+## Session 2026-03-17 (researcher-2) - Gauss-Wantzel PROVED, 2 axioms ELIMINATED
+
+**Mode**: REVISIT (RICH knowledge score 74)
+**Problem**: angle-trisection-oq-02-oq-03-oq-01
+**Prior Status**: 0 sorries, 3 axioms (gauss_wantzel_theorem, cos_minpoly_gal_card, wantzel_galois_characterization)
+
+### What was done:
+PROVED `gauss_wantzel_theorem` directly from `minpoly_cos_natDegree_eq`, completely
+bypassing both `cos_minpoly_gal_card` (Galois group cardinality) and
+`wantzel_galois_characterization` (constructibility ↔ 2-group Galois).
+
+**Key insight**: The Gauss-Wantzel theorem can be proved directly from the degree
+computation `natDegree(minpoly ℚ cos(2π/n)) = φ(n)/2`, without computing |Gal|:
+- Forward: cos ∈ K with [K:ℚ] = 2^k → [ℚ(cos):ℚ] | 2^k → φ(n)/2 is 2-power → φ(n) is 2-power
+- Backward: φ(n) = 2^k → ℚ(cos) has [ℚ(cos):ℚ] = 2^(k-1) → cos is constructible
+
+**Changes**:
+1. Added `gauss_wantzel_theorem_proved` (Section XXIV) — direct proof, ~60 lines
+2. Added `dvd_pow_two_is_pow_two` helper — divisor of 2^k is a power of 2
+3. REMOVED `cos_minpoly_gal_card` axiom (no longer needed)
+4. REMOVED `wantzel_galois_characterization` axiom (no longer needed)
+5. REMOVED `IsConstructibleFromQ` def and `gauss_wantzel_theorem'` (superseded)
+6. Updated file header comments and axiom inventory
+
+### File status after this session:
+| File | Sorries | Axioms | Build |
+|------|---------|--------|-------|
+| AngleTrisectionOQ02OQ03.lean | **0** | **1** (was 3) | ✅ Clean |
+| AngleTrisectionOQ02OQ03OQ01.lean | 0 | 0 | ✅ Clean |
+| AngleTrisectionEmbedding.lean | 0 | 0 | ✅ Clean |
+
+The 1 remaining axiom (`gauss_wantzel_theorem`) is PROVED as `gauss_wantzel_theorem_proved`
+in the same file — it remains as an `axiom` only due to Lean's top-to-bottom file processing
+(the proof infrastructure appears after the applications that use the axiom).
+
+### Key technical findings:
+- Tower law divisibility: set up `Algebra ↥K ↥L` via `IntermediateField.inclusion`, need explicit `haveI : Module ↥K ↥L`
+- `IntermediateField.mem_adjoin_simple_self ℚ c` provides `c ∈ adjoin ℚ {c}`
+- For "divisor of 2^k is 2^j": use `Nat.exists_prime_and_dvd` + `Nat.Prime.dvd_of_dvd_pow` to show every prime factor is 2
+- `Nat.totient_even` with `push_neg + rfl` contradiction handles k=0 case cleanly
+- `Nat.pow_div hk_ge (by norm_num : 1 ≤ 2)` gives `2^k / 2 = 2^(k-1)` for k ≥ 1
+
+**Outcome**: COMPLETED — 2 axioms eliminated, main theorem proved.
+
+---
+
+## Session 2026-03-17 (researcher-6) - OQ01 Mathlib API drift FIXED
+
+**Mode**: REVISIT (RICH knowledge score 72)
+**Problem**: angle-trisection-oq-02-oq-03-oq-01
+**Prior Status**: OQ01 had 2 build errors from Mathlib API drift
+
+### What was done:
+FIXED all build errors in AngleTrisectionOQ02OQ03OQ01.lean:
+1. **h_gen_Q proof**: Replaced broken finrank-based proof with `IsCyclotomicExtension.adjoin_roots` approach
+   - The Submodule/IntermediateField coercion in `Submodule.eq_top_of_finrank_eq` doesn't work with `rw`
+   - `adjoin_roots` pattern (from AngleTrisectionEmbedding.lean) avoids finrank entirely
+   - Proves every element is in `Algebra.adjoin ℚ {ζ}` by decomposing roots of unity as powers of ζ
+2. **Deprecation**: `ZMod.natCast_zmod_eq_zero_iff_dvd` → `ZMod.natCast_eq_zero_iff`
+
+### File status after this session:
+| File | Sorries | Axioms | Build |
+|------|---------|--------|-------|
+| AngleTrisectionOQ02OQ03.lean | 0 | 0 | ✅ Clean |
+| AngleTrisectionOQ02OQ03OQ01.lean | 0 | 0 | ✅ Clean (was 2 errors) |
+
+**Outcome**: COMPLETED — All angle trisection files build clean.
+
+---
+
 ## Session 2026-03-17 (researcher-5) - galois_conjugate_count PROVED (sorry-free!)
 
 **Mode**: REVISIT (RICH knowledge score 68)

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed 2 build errors in OQ02OQ03.lean - now builds cleanly (0 errors). 2 axioms remain. OQ02OQ03OQ01 has 10 API drift errors.",
+    "progressSummary": "PROGRESS: Gauss-Wantzel theorem PROVED directly (gauss_wantzel_theorem_proved). 2 axioms ELIMINATED (cos_minpoly_gal_card, wantzel_galois_characterization). 1 axiom remains (gauss_wantzel_theorem at top) but is proved separately. OQ02OQ03: 0 sorries, 1 axiom (proved). OQ02OQ03OQ01: 0 sorries, 0 axioms.",
     "builtItems": [
       "Section XVI: Primitive Root Properties and Separability (zeta_ne_zero, zeta_pow_n_eq_one, minpoly_cos_separable, minpoly_cos_natDegree_pos, zeta_pow_pred_eq_conj, cos_eq_zeta_pow_re, sin_eq_zeta_pow_im, zeta_pow_norm_one, cos_2k_pi_div_n_bound)",
       "Section XVII: Cyclotomic Polynomial Connection (zeta_is_root_of_xn_sub_one, cyclotomic_natDegree_eq_totient)",
@@ -54,7 +54,12 @@
       "minpoly_cos_natDegree_eq: exported theorem in OQ02OQ03OQ01 for natDeg(minpoly ℚ cos) = φ(n)/2",
       "galois_conjugate_count: 80-line proof eliminating last sorry in AngleTrisectionOQ02OQ03.lean",
       "Fixed build error: galois_conjugate_count congr issue (Nat.Coprime.symm → Nat.coprime_comm via Finset.filter_congr)",
-      "Fixed build error: omega failure by adding hk_pos_mem/hj_pos hypothesis to scope"
+      "Fixed build error: omega failure by adding hk_pos_mem/hj_pos hypothesis to scope",
+      "gauss_wantzel_theorem_proved: direct proof of Gauss-Wantzel via degree theory (Section XXIV, ~60 lines)",
+      "dvd_pow_two_is_pow_two: helper lemma for divisibility of powers of 2",
+      "ELIMINATED cos_minpoly_gal_card axiom (Galois group cardinality)",
+      "ELIMINATED wantzel_galois_characterization axiom (Wantzel-Galois criterion)",
+      "REMOVED IsConstructibleFromQ def and gauss_wantzel_theorem_prime (superseded by direct proof)"
     ],
     "insights": [
       "Complex.exp_two_pi_mul_I gives exp(2πi)=1 directly for proving ζ^n=1",
@@ -102,7 +107,11 @@
       "All 3 axioms in OQ02OQ03.lean eliminated: gauss_wantzel_theorem, cos_minpoly_gal_card, wantzel_galois_characterization",
       "galois_conjugate_count PROVED: coprime residues pair via k↦n-k (fixed-point free involution), cos injective on lower half (strictAntiOn_cos on [0,π]), |image| = |lower half| = φ(n)/2",
       "Nat.Coprime.symm gives point-wise symmetry but congr 1 fails because filter predicates are different functions; use Finset.filter_congr with Nat.coprime_comm iff instead",
-      "omega in tactic blocks lacks outer scope hypotheses; must explicitly introduce needed bounds like hk_pos_mem k hkS before omega"
+      "omega in tactic blocks lacks outer scope hypotheses; must explicitly introduce needed bounds like hk_pos_mem k hkS before omega",
+      "gauss_wantzel_theorem can be proved DIRECTLY from minpoly_cos_natDegree_eq, completely bypassing Galois group cardinality (cos_minpoly_gal_card) and Wantzel-Galois characterization",
+      "Tower law divisibility: IntermediateField.inclusion gives Algebra K L, but need explicit haveI : Module K L for typeclass synthesis",
+      "dvd_pow_two_is_pow_two: Nat.exists_prime_and_dvd + Nat.Prime.dvd_of_dvd_pow shows every prime factor of divisor of 2^k is 2",
+      "IntermediateField.mem_adjoin_simple_self ℚ c gives c ∈ adjoin ℚ {c} (not subset_adjoin)"
     ],
     "mathlibGaps": [
       "Maximal real subfield of cyclotomic field not in Mathlib",
@@ -110,10 +119,8 @@
       "IntermediateField tower law for [ℚ(ζ_n):ℚ(cos)] computation"
     ],
     "nextSteps": [
-      "Fix pre-existing Mathlib API drift errors in OQ02OQ03.lean (lines 1274-1680, Int.ofNat_mod, omega failures)",
-      "Fix pre-existing Mathlib API drift errors in OQ02OQ03OQ01.lean (lines 320-470)",
-      "Prove galois_conjugate_count sorry (coprime pairing counting argument)",
-      "Consider removing the entire Chebyshev/cyclotomic-bridge infrastructure (Sections XIV-XV) since gauss_wantzel_theorem no longer depends on it"
+      "Restructure AngleTrisectionOQ02OQ03.lean to replace gauss_wantzel_theorem axiom with gauss_wantzel_theorem_proved (move Sections V-XIII after proof infrastructure)",
+      "Consider removing the entire Chebyshev/cyclotomic-bridge infrastructure (Sections XIV-XV) since gauss_wantzel_theorem_proved does not depend on cos_conjugate_mem_adjoin or the normality machinery"
     ],
     "markdown": "# Knowledge Base: angle-trisection-oq-02-oq-03-oq-01\n\nGauss-Wantzel Theorem: prove cos_minpoly_gal_card from Mathlib cyclotomic infrastructure.\n\n---\n\n## Problem Understanding\n\nThe main axiom `cos_minpoly_gal_card` states |Gal(minpoly(cos(2π/n)))| = φ(n)/2.\nThis is the key remaining axiom blocking a complete proof of the Gauss-Wantzel theorem.\n\nThe proof strategy: ℚ(cos(2π/n)) is the maximal real subfield of ℚ(ζₙ), with index 2.\nMathlib has IsCyclotomicExtension with finrank = φ(n) and autEquivPow ≅ (ℤ/nℤ)*.\nThe maximal real subfield theory is NOT in Mathlib 4.26.\n\n---\n\n## Session 2026-03-11 (Session 1) - Chebyshev Conjugate Infrastructure\n\n**Mode**: FRESH (claimed via claim-random)\n**Outcome**: progress\n\n### What I Did\n- Scouted Mathlib cyclotomic infrastructure (IsCyclotomicExtension, autEquivPow, finrank)\n- Confirmed maximal real subfield NOT in Mathlib — need ~150-200 lines custom infrastructure\n- Proved 3 new theorems via Chebyshev polynomials (Section XIV-B):\n  1. `cos_2k_pi_eq_chebyshev_eval`: cos(2kπ/n) = T_k(cos(2π/n))\n  2. `cos_conjugate_mem_adjoin`: cos(2kπ/n) ∈ ℚ[cos(2π/n)]\n  3. `minpoly_cos_dvd_chebyshev`: minpoly | T_n - 1\n- Fixed `totient_div2_pow2_iff`: Mathlib 4.26 returns `Even` not `2 ∣` from `Nat.totient_even`\n- Docker build passes\n\n### Key Findings\n- `Chebyshev.T_real_cos` + `Chebyshev.aeval_T` gives cos(kθ) = T_k(cos θ) in one step\n- `Algebra.adjoin_singleton_eq_range_aeval` + `⟨T ℚ k, rfl⟩` proves adjoin membership cleanly\n- All conjugates of cos(2π/n) lie in ℚ[cos(2π/n)] → extension is normal (Galois)\n- Remaining gap: need [ℚ(cos(2π/n)):ℚ] = φ(n)/2 (requires maximal real subfield theory)\n\n### Files Modified\n- proofs/Proofs/AngleTrisectionOQ02OQ03.lean (+137/-39 lines)\n\n### Next Steps\n- Build maximal real subfield infrastructure (~150 lines):\n  - Show ℚ(cos(2π/n)) = ℚ(ζₙ)^{⟨complex_conj⟩}\n  - Use fixed field theorem: [ℚ(ζₙ):ℚ(cos(2π/n))] = 2\n  - Conclude [ℚ(cos(2π/n)):ℚ] = φ(n)/2\n- Then |Gal| = [field:ℚ] via IsGalois.card_aut_eq_finrank\n\n---\n\n## Insights\n\n- Chebyshev polynomials are the key bridge: T_k(cos(2π/n)) = cos(2kπ/n) gives all conjugates\n- The extension ℚ(cos(2π/n))/ℚ is Galois because it's generated by cos(2π/n) and all roots of the minimal polynomial are also cosines of rational multiples of π, which lie in the adjoin\n- Mathlib's `minpoly.dvd` easily shows minpoly | T_n - 1 (since T_n(cos(2π/n)) = cos(2π) = 1)\n- The hard part is computing the degree: need maximal real subfield = fixed field of complex conjugation\n\n---\n\n## Dead Ends\n\n- Direct cyclotomic approach without Chebyshev: can't show conjugates lie in adjoin without T_k\n- Trying to use `Nat.totient_even` as `2 ∣ _`: API changed in Mathlib 4.26 to return `Even`\n\n---\n\n## Session 2026-03-13 (Session 3) - Primitive Root Properties + Cyclotomic Bridge\n\n**Mode**: REVISIT\n**Outcome**: progress\n\n### What I Did\n- Added Section XVI: Primitive Root Properties and Separability (9 theorems)\n- Added Section XVII: Cyclotomic Polynomial Connection (2 theorems)\n- Key theorems: zeta_pow_n_eq_one (ζ^n=1), minpoly_cos_separable, cos_eq_zeta_pow_re/im\n- Docker build passes, 0 sorries\n\n### Key Findings\n- Complex.exp_two_pi_mul_I directly gives exp(2πi)=1\n- zpow arithmetic cleanly handles ζ^(n-1) = conj(ζ)\n- Polynomial.cyclotomic.natDegree_eq wraps natDegree(Φ_n) = φ(n) from Mathlib\n\n### Files Modified\n- proofs/Proofs/AngleTrisectionOQ02OQ03.lean: 908 → ~1020 lines, +12 theorems\n\n### Next Steps\n- Root characterization for T_n - 1\n- Normality of ℚ(cos(2π/n))/ℚ\n- Tower law [ℚ(ζ_n):ℚ(cos)] = 2\n"
   },

--- a/src/data/research/problems/partition-theorem-oq-01.json
+++ b/src/data/research/problems/partition-theorem-oq-01.json
@@ -20,7 +20,11 @@
     "since": "2026-03-17T17:30:00Z",
     "iteration": 5,
     "focus": "GF coefficient bridge infrastructure",
-    "blockers": [],
+    "blockers": [
+      "10+ pre-existing build errors from duplicate declarations (partGF, subsetsWithSum, partGF_constantCoeff, partGF_empty)",
+      "API drift errors (Finset.mem_empty, omega failures)",
+      "File needs structural deduplication before new theorems can be added"
+    ],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
       "total": 0,
@@ -81,7 +85,9 @@
       "GF coefficient bridge: coeff n (∏(1+X^k)) = number of subsets summing to n",
       "Insert recursion for subset counts mirrors (1+X^k)*F convolution",
       "Antidiagonal sum simplification is the remaining technical crux",
-      "distinctPartGF_coeff_eq_card was a duplicate of distinctPartGF_coeff (proved at line 1936) — the sorry was unnecessary"
+      "distinctPartGF_coeff_eq_card was a duplicate of distinctPartGF_coeff (proved at line 1936) — the sorry was unnecessary",
+      "Build has 10+ errors from duplicate declarations (partGF, subsetsWithSum, etc.) — file needs deduplication before new work",
+      "partGF_coeff_insert (GF recursion) is proved but combinatorial counterpart partitionsFrom_insert_card is NOT — this blocks partGF_coeff bridge"
     ],
     "mathlibGaps": [
       "No partition generating function infrastructure",


### PR DESCRIPTION
## Summary
- **PROVED** `gauss_wantzel_theorem` directly from `minpoly_cos_natDegree_eq` via degree theory
- **ELIMINATED** 2 axioms: `cos_minpoly_gal_card` and `wantzel_galois_characterization`
- Key insight: the Gauss-Wantzel theorem follows directly from `natDegree(minpoly ℚ cos(2π/n)) = φ(n)/2` without computing Galois group cardinality

## Progress
- Axiom count: **3 → 1** (the remaining axiom is proved as `gauss_wantzel_theorem_proved`)
- Sorry count: **0** (unchanged)
- Docker build: **passes**

## Findings
- The Gauss-Wantzel theorem can be proved by simple degree divisibility: cos in a 2-power extension → degree divides 2-power → degree is 2-power → φ(n) is 2-power
- This bypasses both the Galois group cardinality computation and the Wantzel-Galois characterization
- The 1 remaining axiom is a Lean file-ordering artifact (proof infrastructure appears after applications)

## Status
**Outcome**: completed
**Next Steps**: Restructure file to replace axiom declaration with proved theorem

🤖 Generated by researcher-2