### PR TITLE
Research: abel-ruffini-oq-01 - Eliminate last sorry in InverseGaloisX4Sub2

### DIFF
--- a/proofs/Proofs/InverseGaloisX4Sub2.lean
+++ b/proofs/Proofs/InverseGaloisX4Sub2.lean
@@ -6,6 +6,7 @@ import Mathlib.FieldTheory.AbelRuffini
 import Mathlib.RingTheory.Polynomial.Eisenstein.Criterion
 import Mathlib.RingTheory.Polynomial.GaussLemma
 import Proofs.NthRootIrrationalOQ01
+import Proofs.InverseGaloisD4
 
 /-
 # Inverse Galois Problem: X⁴ - 2 and the Dihedral Group D₄
@@ -254,10 +255,11 @@ theorem two_dvd_x4_splitting_field_finrank :
     rw [← hcard]; exact four_dvd_x4_gal_card
   exact dvd_trans (⟨2, rfl⟩ : (2 : ℕ) ∣ 4) h4
 
-/-- |Gal(X⁴-2/ℚ)| = 8 (the dihedral group D₄). -/
+/-- |Gal(X⁴-2/ℚ)| = 8 (the dihedral group D₄).
+    Proved via the ℝ-embedding argument in InverseGaloisD4. -/
 theorem x_fourth_sub_2_gal_card :
-    Fintype.card (X ^ 4 - C (2 : ℚ) : ℚ[X]).Gal = 8 := by
-  sorry -- DEEP: requires ℚ(⁴√2) ⊂ ℝ argument
+    Fintype.card (X ^ 4 - C (2 : ℚ) : ℚ[X]).Gal = 8 :=
+  InverseGaloisD4.x4_sub_2_gal_card
 
 /-- |Gal(X⁴-2)| > 0. -/
 theorem x4_gal_card_pos : 0 < Fintype.card (X ^ 4 - C (2 : ℚ) : ℚ[X]).Gal :=


### PR DESCRIPTION
## Summary
- Eliminate the last sorry in `InverseGaloisX4Sub2.lean` by importing `InverseGaloisD4`
- The D4 file already proves `|Gal(X⁴-2/ℚ)| = 8` via the ℝ-embedding argument
- X4Sub2 now uses that result directly: `InverseGaloisD4.x4_sub_2_gal_card`

## Stats
- **InverseGaloisX4Sub2.lean**: 1 sorry → 0 sorries
- All 4 inverse Galois files now have 0 non-intentional sorries:
  - InverseGaloisD4.lean: 0 sorries
  - InverseGaloisF20.lean: 0 sorries (sorry only in comment)
  - InverseGaloisX4Sub2.lean: 0 sorries (fixed here)
  - InverseGalois.lean: 2 sorries (1 open conjecture, 1 Hilbert irreducibility - both intentional)

## Test plan
- [ ] Verify InverseGaloisX4Sub2 compiles with Docker build
- [ ] Confirm no regressions in dependent files

🤖 Generated by researcher-4