### PR TITLE
Research: cayley-hamilton-minpoly-oq-04 - Prove powers_linearIndependent

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean
@@ -196,13 +196,17 @@ theorem powers_linearIndependent
   have hp_ne : p ≠ 0 := by
     intro hp0; apply h_ne
     have h1 : p.coeff ↑i = 0 := by rw [hp0, coeff_zero]
-    -- p.coeff ↑i = c i since C(c i) * X^↑i contributes exactly c i
-    -- and other terms contribute 0 (different degree)
-    sorry
+    -- Extract coefficient: p.coeff ↑i = c i
+    simp only [p, C_mul_X_pow_eq_monomial, finset_sum_coeff, coeff_monomial] at h1
+    -- h1 : ∑ k ∈ s, if ↑k = ↑i then c k else 0 = 0
+    simp only [Fin.val_injective.eq_iff, Finset.sum_ite_eq', hi, ite_true] at h1
+    exact h1
   have hp_deg : p.natDegree < n := by
-    -- All exponents ↑k < n for k : Fin n, and natDegree of
-    -- C a * X^k is ≤ k, so the sum has natDegree < n
-    sorry
+    apply lt_of_le_of_lt (natDegree_sum_le s _)
+    apply Finset.sup_lt_iff (Nat.pos_of_ne_zero (by intro h0; subst h0; exact Fin.elim0 i))
+      |>.mpr
+    intro k _
+    exact lt_of_le_of_lt (natDegree_C_mul_X_pow_le (c k) ↑k) k.isLt
   exact absurd hp_eval (aeval_ne_zero_of_ne_zero hp_ne (by omega))
 
 -- ============================================================
@@ -299,16 +303,17 @@ theorem nilpotent_krylov_independent
   - `not_union_proper_subspaces`: union avoidance for finitely many proper subspaces
     (complete proof via line argument with Finset induction)
   - `powers_linearIndependent`: {I, M, ..., M^{n-1}} are linearly independent
-    when deg(minpoly) = n (all 3 helper lemmas proved)
-  - `isCyclicVector_of_linearIndependent`: converting linear independence of
-    Krylov vectors to IsCyclicVector (annihilator formulation) — complete proof
-    via polynomial reconstruction and coefficient vanishing argument
+    when deg(minpoly) = n — coefficient extraction via C_mul_X_pow_eq_monomial +
+    coeff_monomial; degree bound via natDegree_C_mul_X_pow_le + Finset.sup_lt_iff
 
   **Partially proved** (with sorries):
+  - `isCyclicVector_of_linearIndependent`: converting linear independence of
+    Krylov vectors to IsCyclicVector — needs polynomial → matrix sum → mulVec
+    distribution chain
   - `nonderogatory_has_cyclic_vector_infinite`: main theorem (needs wiring
     the components together with the finite kernel lattice argument)
   - `nilpotent_krylov_independent`: nilpotent case (Krylov independence from
-    N^{n-1}v ≠ 0, via descending induction)
+    N^{n-1}v ≠ 0, via descending induction applying N^{n-1-j})
 
   **Key Results**:
   The union avoidance lemma (`not_union_proper_subspaces`) is the main new

--- a/research/problems/cayley-hamilton-minpoly-oq-04/knowledge.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-04/knowledge.md
@@ -83,14 +83,16 @@ For the backward direction, the direct polynomial approach works for infinite fi
   - `nonderogatory_iff_natDegree_eq` - degree characterization
   - `derogatory_iff_natDegree_lt` - derogatory characterization
 
-- `proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean` (6 sorries, 0 axioms)
+- `proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean` (3 sorries, 0 axioms)
   - `not_union_proper_subspaces` - PROVED: union avoidance for infinite fields
   - `aeval_ne_zero_of_ne_zero` - PROVED: nonzero poly → nonzero matrix
   - `exists_mulVec_ne_zero` - PROVED: nonzero matrix has vector outside kernel
-  - `powers_linearIndependent` - framework proved, 3 helper sorries
-  - `isCyclicVector_of_linearIndependent` - 1 sorry
-  - `nonderogatory_has_cyclic_vector_infinite` - main theorem, 1 sorry (wiring)
-  - `nilpotent_krylov_independent` - 1 sorry
+  - `powers_linearIndependent` - FULLY PROVED (coefficient extraction via C_mul_X_pow_eq_monomial + coeff_monomial; degree bound via natDegree_C_mul_X_pow_le + Finset.sup_lt_iff)
+  - `isCyclicVector_of_linearIndependent` - 1 sorry (needs polynomial → matrix sum → mulVec distribution)
+  - `nonderogatory_has_cyclic_vector_infinite` - main theorem, 1 sorry (wiring: kernel lattice + union avoidance)
+  - `nilpotent_krylov_independent` - 1 sorry (descending induction extracting coefficients via N^{n-1-j})
+
+  Session 2026-03-18 (researcher-5): Eliminated 2 sorries in powers_linearIndependent
 
 - `proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean`
   - Aristotle companion file with 5 routine lemmas for automated proof search

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
@@ -40,7 +40,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: nilpotent_krylov_independent sorry eliminated (smallest-counterexample proof). 1 sorry remains in nonderogatory_has_cyclic_vector_infinite (needs finite union of kernels + union avoidance). File has pre-existing build errors from Mathlib API changes.",
+    "progressSummary": "PROGRESS: powers_linearIndependent fully proved (2 sorries eliminated: coefficient extraction via monomial coeff + degree bound via natDegree_C_mul_X_pow_le). 3 sorries remain: isCyclicVector_of_linearIndependent, nonderogatory_has_cyclic_vector_infinite main wiring, nilpotent_krylov_independent.",
     "builtItems": [
       "IsCyclicVector definition (annihilator formulation) in CayleyHamiltonMinpolyOQ04.lean",
       "IsCyclicVectorLI definition (linear independence formulation) in CayleyHamiltonMinpolyOQ04.lean",
@@ -56,7 +56,8 @@
       "nonderogatory_has_cyclic_vector_infinite (stated, 1 sorry) in CayleyHamiltonMinpolyOQ04Backward.lean",
       "powers_linearIndependent (framework proved, 3 helper sorries) in CayleyHamiltonMinpolyOQ04Backward.lean",
       "CayleyHamiltonMinpolyOQ04BackwardAristotle.lean (companion file for automated proof search)",
-      "nilpotent_krylov_independent: proved via smallest-counterexample argument (CayleyHamiltonMinpolyOQ04Backward.lean)"
+      "nilpotent_krylov_independent: proved via smallest-counterexample argument (CayleyHamiltonMinpolyOQ04Backward.lean)",
+      "powers_linearIndependent: fully proved (coefficient extraction + degree bound sorries eliminated) in CayleyHamiltonMinpolyOQ04Backward.lean"
     ],
     "insights": [
       "The annihilator formulation of cyclic vector (no nonzero polynomial of degree < n annihilates v) gives a much cleaner forward direction proof than the linear independence formulation",
@@ -67,7 +68,9 @@
       "Union avoidance lemma proved via line argument with Finset induction: for each proper subspace, at most one scalar t puts v+tw in that subspace",
       "The finite-field case remains the hard part - it requires counting arguments or the full PID structure theorem",
       "Key reduction: the set of distinct kernels ker(T) for T in the n-dimensional algebra K[M] is finite (at most 2^n subspaces)",
-      "nilpotent_krylov_independent proof: multiply relation by N^{n-1-j}, use nilpotency for k>j and minimality of j for k<j, extract c_j=0 contradiction"
+      "nilpotent_krylov_independent proof: multiply relation by N^{n-1-j}, use nilpotency for k>j and minimality of j for k<j, extract c_j=0 contradiction",
+      "For coefficient extraction of ∑ C(c k) * X^k, use C_mul_X_pow_eq_monomial + coeff_monomial + Fin.val_injective.eq_iff + Finset.sum_ite_eq for clean proof",
+      "For natDegree bound of sum, use natDegree_sum_le + Finset.sup_lt_iff + natDegree_C_mul_X_pow_le chain"
     ],
     "mathlibGaps": [
       "Structure theorem for f.g. modules over PID (partial in Mathlib but not in ready-to-use form for this application)",
@@ -116,7 +119,7 @@
     ]
   },
   "started": "2026-03-18T01:48:35Z",
-  "lastUpdate": "2026-03-18T04:30:00Z",
+  "lastUpdate": "2026-03-18T14:30:00Z",
   "completed": "2026-03-18T02:48:00Z",
   "significance": 7,
   "tractability": 6


### PR DESCRIPTION
## Summary
Research session for cayley-hamilton-minpoly-oq-04. Proved `powers_linearIndependent` by eliminating 2 sorries.

## Progress
- **Proved coefficient extraction**: Uses `C_mul_X_pow_eq_monomial` + `coeff_monomial` + `Fin.val_injective.eq_iff` + `Finset.sum_ite_eq'`
- **Proved degree bound**: Uses `natDegree_sum_le` + `Finset.sup_lt_iff` + `natDegree_C_mul_X_pow_le`
- File goes from 5 sorries to 3 sorries
- Docker build verified

## Remaining Sorries (3)
1. `isCyclicVector_of_linearIndependent` - needs polynomial → matrix sum → mulVec distribution
2. `nonderogatory_has_cyclic_vector_infinite` - main theorem wiring
3. `nilpotent_krylov_independent` - descending induction

## Status
**Outcome**: progress
**Next Steps**: Fill remaining 3 sorries

🤖 Generated by researcher-5