### PR TITLE
fix: increase liveness timeout to 300s

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -389,7 +389,7 @@ check_cwd_exists() {
 
 # Liveness check: if claude produces 0 bytes of output after this many seconds,
 # assume it's hung on startup and kill it early (instead of waiting full CLAUDE_TIMEOUT).
-LIVENESS_TIMEOUT="${LIVENESS_TIMEOUT:-120}"  # 2 minutes
+LIVENESS_TIMEOUT="${LIVENESS_TIMEOUT:-300}"  # 5 minutes (large CLAUDE.md + prompts need time)
 
 # Run Claude once and return exit code
 run_claude_once() {


### PR DESCRIPTION
## Summary
The 120s liveness timeout was killing healthy claude processes. With the 37KB CLAUDE.md + research prompts, claude connects to the API but needs >2 min to process context before first output. Increase to 300s.

## Test plan
- [ ] Agents stop getting "Liveness check failed" on every cycle
- [ ] Genuine hangs (no API connection) still get killed within 5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)