### PR TITLE
fix: remove duplicate leanFiles field in ResearchProblem type

### DIFF
--- a/src/types/research.ts
+++ b/src/types/research.ts
@@ -343,8 +343,6 @@ export interface ResearchProblem {
 
   significance?: number
   tractability?: number
-
-  leanFiles?: LeanFileInfo[]
 }
 
 /**


### PR DESCRIPTION
Remove duplicate leanFiles field added by parallel PRs #4021 and #4023