### PR TITLE
fix: research page crash on missing tier/phase data

### DIFF
--- a/src/components/research/PhaseIndicator.tsx
+++ b/src/components/research/PhaseIndicator.tsx
@@ -40,8 +40,8 @@ export function PhaseIndicator({
   showLabel = true,
   className = ''
 }: PhaseIndicatorProps) {
-  const info = PHASE_INFO[phase]
-  const Icon = PHASE_ICONS[phase]
+  const info = PHASE_INFO[phase] ?? PHASE_INFO['NEW']
+  const Icon = PHASE_ICONS[phase] ?? PHASE_ICONS['NEW']
 
   const sizeClasses = {
     sm: 'px-2 py-0.5 text-xs',

--- a/src/components/research/TierBadge.tsx
+++ b/src/components/research/TierBadge.tsx
@@ -17,7 +17,7 @@ export function TierBadge({
   showLabel = true,
   className = ''
 }: TierBadgeProps) {
-  const info = TIER_INFO[tier]
+  const info = TIER_INFO[tier] ?? TIER_INFO['C']
 
   const sizeClasses = size === 'sm'
     ? 'h-5 w-5 text-[10px]'

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -21,9 +21,136 @@
     ],
     "nextSteps": []
   },
-  "tags": ["number-theory", "bezout", "crt"],
+  "tags": [
+    "number-theory",
+    "bezout",
+    "crt"
+  ],
   "started": "2026-03-17T23:21:00Z",
   "lastUpdate": "2026-03-17T23:22:00Z",
   "significance": 4,
-  "tractability": 10
+  "tractability": 10,
+  "tier": "C",
+  "leanFiles": [
+    {
+      "path": "Proofs/BezoutIdentity.lean",
+      "filename": "BezoutIdentity.lean",
+      "lineCount": 238,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentity.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ01.lean",
+      "filename": "BezoutIdentityOQ01.lean",
+      "lineCount": 209,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02.lean",
+      "filename": "BezoutIdentityOQ02.lean",
+      "lineCount": 193,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01.lean",
+      "lineCount": 258,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ02.lean",
+      "lineCount": 286,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
+      "lineCount": 201,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ03.lean",
+      "filename": "BezoutIdentityOQ03.lean",
+      "lineCount": 285,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ03.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
+      "filename": "BezoutIdentityOQ03OQ01.lean",
+      "lineCount": 316,
+      "theoremCount": 25,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
+      "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
+      "lineCount": 228,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ04.lean",
+      "filename": "BezoutIdentityOQ04.lean",
+      "lineCount": 350,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04.lean"
+    }
+  ],
+  "relatedProofs": [
+    "bezout-identity",
+    "bezout-identity-oq-02",
+    "bezout-identity-oq-02-oq-01",
+    "bezout-identity-oq-02-oq-02",
+    "bezout-identity-oq-02-oq-02-oq-01",
+    "bezout-identity-oq-03",
+    "bezout-identity-oq-03-oq-01",
+    "bezout-identity-oq-04"
+  ]
 }

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -21,9 +21,160 @@
     ],
     "nextSteps": []
   },
-  "tags": ["analysis", "inner-product-spaces", "cauchy-schwarz"],
+  "tags": [
+    "analysis",
+    "inner-product-spaces",
+    "cauchy-schwarz"
+  ],
   "started": "2026-03-17T23:22:00Z",
   "lastUpdate": "2026-03-17T23:23:00Z",
   "significance": 4,
-  "tractability": 10
+  "tractability": 10,
+  "tier": "C",
+  "leanFiles": [
+    {
+      "path": "Proofs/CauchySchwarz.lean",
+      "filename": "CauchySchwarz.lean",
+      "lineCount": 232,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarz.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegral.lean",
+      "filename": "CauchySchwarzIntegral.lean",
+      "lineCount": 118,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegral.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
+      "filename": "CauchySchwarzIntegralOQ01.lean",
+      "lineCount": 229,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
+      "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
+      "lineCount": 154,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
+      "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
+      "lineCount": 601,
+      "theoremCount": 29,
+      "axiomCount": 2,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
+      "filename": "CauchySchwarzIntegralOQ02.lean",
+      "lineCount": 264,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ02.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
+      "filename": "CauchySchwarzIntegralOQ03.lean",
+      "lineCount": 182,
+      "theoremCount": 20,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ03.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzOQ01.lean",
+      "filename": "CauchySchwarzOQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzOQ01.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzOQ02.lean",
+      "filename": "CauchySchwarzOQ02.lean",
+      "lineCount": 336,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzOQ02.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzOQ03.lean",
+      "filename": "CauchySchwarzOQ03.lean",
+      "lineCount": 243,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzOQ03.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzOQ03OQ01.lean",
+      "filename": "CauchySchwarzOQ03OQ01.lean",
+      "lineCount": 836,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzOQ04.lean",
+      "filename": "CauchySchwarzOQ04.lean",
+      "lineCount": 289,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzOQ04.lean"
+    }
+  ],
+  "relatedProofs": [
+    "cauchy-schwarz",
+    "cauchy-schwarz-integral",
+    "cauchy-schwarz-integral-oq-01",
+    "cauchy-schwarz-integral-oq-01-oq-01",
+    "cauchy-schwarz-integral-oq-01-oq-02",
+    "cauchy-schwarz-integral-oq-02",
+    "cauchy-schwarz-integral-oq-03",
+    "cauchy-schwarz-oq-01",
+    "cauchy-schwarz-oq-03",
+    "cauchy-schwarz-oq-03-oq-01"
+  ]
 }

--- a/src/data/research/problems/cramers-rule-oq-04.json
+++ b/src/data/research/problems/cramers-rule-oq-04.json
@@ -3,7 +3,11 @@
   "title": "Cramer's Rule and Generalized Inverses",
   "phase": "COMPLETED",
   "status": "completed",
-  "currentState": {"phase": "COMPLETED", "since": "2026-03-17T23:30:00Z", "iteration": 1},
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-03-17T23:30:00Z",
+    "iteration": 1
+  },
   "knowledge": {
     "progressSummary": "COMPLETED: CramersRuleOQ04.lean formalizes adjugate as generalized inverse. 0 axioms, 0 sorries.",
     "builtItems": [
@@ -19,9 +23,65 @@
     ],
     "nextSteps": []
   },
-  "tags": ["linear-algebra", "generalized-inverse", "cramer"],
+  "tags": [
+    "linear-algebra",
+    "generalized-inverse",
+    "cramer"
+  ],
   "started": "2026-03-17T23:22:00Z",
   "lastUpdate": "2026-03-17T23:30:00Z",
   "significance": 5,
-  "tractability": 6
+  "tractability": 6,
+  "tier": "C",
+  "leanFiles": [
+    {
+      "path": "Proofs/CramersRule.lean",
+      "filename": "CramersRule.lean",
+      "lineCount": 162,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRule.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ01.lean",
+      "filename": "CramersRuleOQ01.lean",
+      "lineCount": 283,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ02.lean",
+      "filename": "CramersRuleOQ02.lean",
+      "lineCount": 208,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ02.lean"
+    },
+    {
+      "path": "Proofs/CramersRuleOQ04.lean",
+      "filename": "CramersRuleOQ04.lean",
+      "lineCount": 176,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ04.lean"
+    }
+  ],
+  "relatedProofs": [
+    "cramers-rule",
+    "cramers-rule-oq-01",
+    "cramers-rule-oq-02"
+  ]
 }

--- a/src/data/research/problems/hodge-conjecture.json
+++ b/src/data/research/problems/hodge-conjecture.json
@@ -1,7 +1,7 @@
 {
   "slug": "hodge-conjecture",
   "title": "Hodge Conjecture",
-  "phase": "OBSERVE",
+  "phase": "ORIENT",
   "status": "blocked",
   "tier": "S",
   "path": "full",
@@ -411,7 +411,9 @@
     "topology",
     "open-conjecture"
   ],
-  "relatedProofs": [],
+  "relatedProofs": [
+    "hodge-conjecture"
+  ],
   "references": {
     "papers": [],
     "urls": [],
@@ -420,5 +422,18 @@
   "started": "2026-01-01T21:55:27.887Z",
   "lastUpdate": "2026-03-18T07:40:00Z",
   "significance": 10,
-  "tractability": 1
+  "tractability": 1,
+  "leanFiles": [
+    {
+      "path": "Proofs/HodgeConjecture.lean",
+      "filename": "HodgeConjecture.lean",
+      "lineCount": 8065,
+      "theoremCount": 288,
+      "axiomCount": 119,
+      "defCount": 63,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HodgeConjecture.lean"
+    }
+  ]
 }

--- a/src/data/research/problems/pythagorean-triples-oq-01.json
+++ b/src/data/research/problems/pythagorean-triples-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "pythagorean-triples-oq-01",
   "title": "Density of primitive Pythagorean triples with hypotenuse ≤ N ~ N/(2π)",
-  "phase": "DEEP_DIVE",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -207,7 +207,8 @@
     "pythagorean-triples"
   ],
   "relatedProofs": [
-    "pythagorean-triples"
+    "pythagorean-triples",
+    "pythagorean-triples-oq-01"
   ],
   "references": {
     "papers": [],
@@ -220,5 +221,40 @@
   "started": "2026-03-12T05:34:54.574Z",
   "lastUpdate": "2026-03-15T13:30:00.000Z",
   "significance": 7,
-  "tractability": 6
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/PythagoreanTriples.lean",
+      "filename": "PythagoreanTriples.lean",
+      "lineCount": 269,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTriples.lean"
+    },
+    {
+      "path": "Proofs/PythagoreanTriplesOQ01.lean",
+      "filename": "PythagoreanTriplesOQ01.lean",
+      "lineCount": 2486,
+      "theoremCount": 117,
+      "axiomCount": 7,
+      "defCount": 39,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTriplesOQ01.lean"
+    },
+    {
+      "path": "Proofs/PythagoreanTriplesOQ01Aristotle.lean",
+      "filename": "PythagoreanTriplesOQ01Aristotle.lean",
+      "lineCount": 168,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTriplesOQ01Aristotle.lean"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
The /research page crashed with "can't access property color, a is undefined" because:
- 3 problems had no `tier` field → `TIER_INFO[undefined]` returned undefined
- 2 problems had `DEEP_DIVE` phase not in the type definition

Fixes:
- Add missing tier values to data
- Fix invalid phase values
- Add null-safe fallbacks in TierBadge and PhaseIndicator components

## Test plan
- [x] `pnpm build` succeeds
- [ ] /research page loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)