### PR TITLE
Research: Fix YangMills build errors, prove isSidon_powers_of_two

### DIFF
--- a/proofs/Proofs/Erdos44Problem.lean
+++ b/proofs/Proofs/Erdos44Problem.lean
@@ -172,24 +172,141 @@ theorem maxSidonSubsetCard_icc_bound (N : ℕ) (hN : 1 ≤ N) (A : Finset ℕ)
 
 /- ## Part 3: Lower Bound - Existence of Sidon sets -/
 
+/-- Core lemma: sums of powers of 2 determine exponents uniquely.
+    2^a + 2^b = 2^c + 2^d with a ≤ b, c ≤ d implies a = c and b = d.
+
+    Proof by strong induction on a + c using parity:
+    - a = 0, c = 0: cancel 1's, conclude b = d from injectivity of 2^(·)
+    - a = 0, c ≥ 1: LHS = 1 + 2^b is odd (for b ≥ 1) but RHS is even. Contradiction.
+    - a ≥ 1, c = 0: symmetric
+    - a ≥ 1, c ≥ 1: divide everything by 2, apply induction hypothesis -/
+private lemma pow2_sum_inj : ∀ (n : ℕ) (a b c d : ℕ),
+    a + c ≤ n → a ≤ b → c ≤ d →
+    2 ^ a + 2 ^ b = 2 ^ c + 2 ^ d → a = c ∧ b = d := by
+  intro n
+  induction n with
+  | zero =>
+    intro a b c d hacn hab hcd heq
+    have ha : a = 0 := by omega
+    have hc : c = 0 := by omega
+    subst ha; subst hc
+    simp only [pow_zero] at heq
+    have hbd : 2 ^ b = 2 ^ d := by omega
+    constructor
+    · rfl
+    · by_contra hne
+      rcases Nat.lt_or_gt_of_ne hne with h | h
+      · exact absurd (Nat.pow_lt_pow_right (by norm_num : 1 < 2) h) (by omega)
+      · exact absurd (Nat.pow_lt_pow_right (by norm_num : 1 < 2) h) (by omega)
+  | succ n ih =>
+    intro a b c d hacn hab hcd heq
+    by_cases ha : a = 0
+    · subst ha
+      by_cases hc : c = 0
+      · -- a = 0, c = 0: cancel the 1's
+        subst hc
+        simp only [pow_zero] at heq
+        have hbd : 2 ^ b = 2 ^ d := by omega
+        constructor
+        · rfl
+        · by_contra hne
+          rcases Nat.lt_or_gt_of_ne hne with h | h
+          · exact absurd (Nat.pow_lt_pow_right (by norm_num : 1 < 2) h) (by omega)
+          · exact absurd (Nat.pow_lt_pow_right (by norm_num : 1 < 2) h) (by omega)
+      · -- a = 0, c ≥ 1: parity contradiction
+        exfalso
+        have hc' : 1 ≤ c := by omega
+        have hd' : 1 ≤ d := by omega
+        -- LHS = 1 + 2^b
+        simp only [pow_zero] at heq
+        by_cases hb : b = 0
+        · -- LHS = 2, RHS ≥ 2^1 + 2^1 = 4
+          subst hb; simp only [pow_zero] at heq
+          have : 2 ^ c ≥ 2 := Nat.one_le_pow c 2 (by norm_num) |>.trans_lt (by omega) |>.le
+          have : 2 ^ d ≥ 2 := Nat.one_le_pow d 2 (by norm_num) |>.trans_lt (by omega) |>.le
+          omega
+        · -- LHS = 1 + 2^b is odd, RHS is even
+          have hb' : 1 ≤ b := by omega
+          -- 2 divides RHS since c ≥ 1 and d ≥ 1
+          have hrhs_even : 2 ∣ (2 ^ c + 2 ^ d) := by
+            have h1 : 2 ∣ 2 ^ c := dvd_pow_self 2 (by omega : c ≠ 0)
+            have h2 : 2 ∣ 2 ^ d := dvd_pow_self 2 (by omega : d ≠ 0)
+            exact dvd_add h1 h2
+          -- But LHS = 1 + 2^b is odd
+          have hlhs_odd : ¬ 2 ∣ (1 + 2 ^ b) := by
+            have h2b : 2 ∣ 2 ^ b := dvd_pow_self 2 (by omega : b ≠ 0)
+            intro ⟨m, hm⟩
+            have : 2 ∣ (1 + 2 ^ b - 2 ^ b) := Nat.dvd_sub' ⟨m, hm⟩ h2b
+            simp at this
+          exact hlhs_odd (heq ▸ hrhs_even)
+    · by_cases hc : c = 0
+      · -- a ≥ 1, c = 0: symmetric parity contradiction
+        exfalso
+        have ha' : 1 ≤ a := by omega
+        have hb' : 1 ≤ b := by omega
+        simp only [pow_zero] at heq
+        by_cases hd : d = 0
+        · subst hd; simp only [pow_zero] at heq
+          have : 2 ^ a ≥ 2 := Nat.one_le_pow a 2 (by norm_num) |>.trans_lt (by omega) |>.le
+          have : 2 ^ b ≥ 2 := Nat.one_le_pow b 2 (by norm_num) |>.trans_lt (by omega) |>.le
+          omega
+        · have hd' : 1 ≤ d := by omega
+          have hlhs_even : 2 ∣ (2 ^ a + 2 ^ b) := by
+            have h1 : 2 ∣ 2 ^ a := dvd_pow_self 2 (by omega : a ≠ 0)
+            have h2 : 2 ∣ 2 ^ b := dvd_pow_self 2 (by omega : b ≠ 0)
+            exact dvd_add h1 h2
+          have hrhs_odd : ¬ 2 ∣ (1 + 2 ^ d) := by
+            have h2d : 2 ∣ 2 ^ d := dvd_pow_self 2 (by omega : d ≠ 0)
+            intro ⟨m, hm⟩
+            have : 2 ∣ (1 + 2 ^ d - 2 ^ d) := Nat.dvd_sub' ⟨m, hm⟩ h2d
+            simp at this
+          exact hrhs_odd (heq.symm ▸ hlhs_even)
+      · -- a ≥ 1, c ≥ 1: divide by 2 and recurse
+        have ha' : 1 ≤ a := by omega
+        have hc' : 1 ≤ c := by omega
+        have hb' : 1 ≤ b := by omega
+        have hd' : 1 ≤ d := by omega
+        -- Factor: 2^a = 2 * 2^(a-1), etc.
+        have heq' : 2 ^ (a - 1) + 2 ^ (b - 1) = 2 ^ (c - 1) + 2 ^ (d - 1) := by
+          have fa : 2 ^ a = 2 * 2 ^ (a - 1) := by
+            conv_lhs => rw [show a = (a - 1) + 1 from by omega, pow_succ']
+          have fb : 2 ^ b = 2 * 2 ^ (b - 1) := by
+            conv_lhs => rw [show b = (b - 1) + 1 from by omega, pow_succ']
+          have fc : 2 ^ c = 2 * 2 ^ (c - 1) := by
+            conv_lhs => rw [show c = (c - 1) + 1 from by omega, pow_succ']
+          have fd : 2 ^ d = 2 * 2 ^ (d - 1) := by
+            conv_lhs => rw [show d = (d - 1) + 1 from by omega, pow_succ']
+          rw [fa, fb, fc, fd] at heq
+          omega
+        have ⟨hac, hbd⟩ := ih (a - 1) (b - 1) (c - 1) (d - 1)
+          (by omega) (by omega) (by omega) heq'
+        exact ⟨by omega, by omega⟩
+
 /-- Powers of 2 form a Sidon set: {2^0, 2^1, 2^2, ...} = {1, 2, 4, 8, ...}
 
 This is because 2^a + 2^b = 2^c + 2^d (with a ≤ b, c ≤ d) implies (a,b) = (c,d)
-by uniqueness of binary representation.
-
-**Proof sketch**: If 2^a + 2^b = 2^c + 2^d with a ≤ b, c ≤ d, then:
-- Case a < b, c < d: Factor as 2^a(1 + 2^(b-a)) = 2^c(1 + 2^(d-c)).
-  By 2-adic valuation (since 1 + 2^k is odd for k > 0), we get a = c.
-  Then 1 + 2^(b-a) = 1 + 2^(d-c), so b - a = d - c, hence b = d.
-- Case a = b (doubled): 2·2^a = 2^(a+1) = 2^c + 2^d.
-  If c < d, factor RHS as 2^c(1 + 2^(d-c)). Comparing 2-adic valuations:
-  v_2(LHS) = a+1, v_2(RHS) = c. So a+1 = c, but then 1 + 2^(d-c) = 1, impossible since d > c.
-  So c = d, giving 2·2^a = 2·2^c, hence a = c = b = d.
-
-**Proof status**: HARD - requires careful 2-adic valuation arguments.
-The key insight is comparing 2-adic valuations on both sides.
--/
-axiom isSidon_powers_of_two (k : ℕ) : IsSidon ((range k).image (2 ^ ·))
+by uniqueness of binary representation. Proof by strong induction on the minimum
+exponent, using parity to match the lowest bit position. -/
+theorem isSidon_powers_of_two (k : ℕ) : IsSidon ((range k).image (2 ^ ·)) := by
+  intro x y u v hx hy hu hv hxy huv heq
+  -- Extract exponents from membership in image
+  rw [mem_image] at hx hy hu hv
+  obtain ⟨a, _, rfl⟩ := hx
+  obtain ⟨b, _, rfl⟩ := hy
+  obtain ⟨c, _, rfl⟩ := hu
+  obtain ⟨d, _, rfl⟩ := hv
+  -- Convert ordering on 2^(·) to ordering on exponents
+  have hab : a ≤ b := by
+    by_contra h
+    push_neg at h
+    exact absurd (Nat.pow_lt_pow_right (by norm_num : 1 < 2) h) (by omega)
+  have hcd : c ≤ d := by
+    by_contra h
+    push_neg at h
+    exact absurd (Nat.pow_lt_pow_right (by norm_num : 1 < 2) h) (by omega)
+  -- Apply the core uniqueness lemma
+  have ⟨hac, hbd⟩ := pow2_sum_inj (a + c) a b c d le_rfl hab hcd heq
+  exact ⟨congr_arg (2 ^ ·) hac, congr_arg (2 ^ ·) hbd⟩
 
 /-- There exists a Sidon set of size at least √N / 2 in {1,...,N}.
 

--- a/proofs/Proofs/YangMillsMassGap.lean
+++ b/proofs/Proofs/YangMillsMassGap.lean
@@ -14479,7 +14479,7 @@ theorem gluon_dof_monotone_colors (N₁ N₂ d : ℕ) (hN₁ : N₁ ≥ 2) (hN�
     gluonDOF N₁ d < gluonDOF N₂ d := by
   unfold gluonDOF
   apply Nat.mul_lt_mul_of_pos_right
-  · have : N₁ ^ 2 < N₂ ^ 2 := Nat.pow_lt_pow_left h (by omega)
+  · have : N₁ ^ 2 < N₂ ^ 2 := by nlinarith [sq_nonneg N₁, sq_nonneg N₂]
     omega
   · omega
 
@@ -14608,20 +14608,25 @@ theorem frg_lattice_consistency (m_frg m_lat : ℝ) (hf : 0 < m_frg) (hl : 0 < m
     (hratio : 0.8 * m_lat ≤ m_frg) (hratio2 : m_frg ≤ 1.2 * m_lat) :
     m_frg / m_lat ≤ 1.2 ∧ 0.8 ≤ m_frg / m_lat := by
   constructor
-  · exact div_le_of_le_mul₀ (by linarith) (by linarith) hratio2
-  · exact le_div_of_mul_le₀ (by linarith) (by linarith) hratio
+  · rw [div_le_iff hl]; linarith
+  · rw [le_div_iff hl]; linarith
 
 /-- FRG flow equation structure: ∂_t Γ_k = ½ Tr[...].
     The trace sums over all field species with appropriate signs. -/
 theorem frg_trace_decomposition (N d : ℕ) (hN : N ≥ 2) (hd : d ≥ 2) :
     totalFlowDOF N d = (N ^ 2 - 1 : ℤ) * ((d : ℤ) - 1 - 2) := by
   unfold totalFlowDOF gluonDOF ghostDOF
+  have hN2 : N ^ 2 ≥ 4 := by nlinarith
+  have hd1 : d ≥ 2 := hd
+  zify [show 1 ≤ N ^ 2 from by omega, show 1 ≤ d from by omega]
   ring
 
 /-- In d = 4, the trace simplifies: net DOF = (N²-1) per color. -/
 theorem frg_trace_4d (N : ℕ) (hN : N ≥ 2) :
     totalFlowDOF N 4 = (N ^ 2 - 1 : ℤ) := by
   unfold totalFlowDOF gluonDOF ghostDOF
+  have hN2 : N ^ 2 ≥ 4 := by nlinarith
+  zify [show 1 ≤ N ^ 2 from by omega]
   ring
 
 /-
@@ -14743,7 +14748,12 @@ theorem latent_heat_monotone (N₁ N₂ : ℕ) (hN₁ : N₁ ≥ 2) (hN₂ : N�
     (h : N₁ < N₂) :
     latentHeatScaling N₁ < latentHeatScaling N₂ := by
   unfold latentHeatScaling
-  exact Nat.pow_lt_pow_left h (by omega)
+  have h1 := Nat.mul_lt_mul_of_pos_right h (show 0 < N₁ by omega)
+  have h2 := Nat.mul_le_mul_left N₂ (le_of_lt h)
+  calc N₁ ^ 2 = N₁ * N₁ := by ring
+    _ < N₂ * N₁ := h1
+    _ ≤ N₂ * N₂ := h2
+    _ = N₂ ^ 2 := by ring
 
 /-- On R³ × S¹(β), the inverse temperature β = 1/T. -/
 noncomputable def inverseTemp (T : ℝ) (hT : 0 < T) : ℝ := 1 / T
@@ -14844,10 +14854,10 @@ theorem su3_casimir_ratio :
 theorem casimir_ratio_gt_one (N : ℕ) (hN : N ≥ 2) :
     casimirRatio N > 1 := by
   unfold casimirRatio
-  rw [gt_iff_lt, div_lt_iff₀]
-  · nlinarith [sq_nonneg (N : ℚ)]
-  · have : (N : ℚ) ≥ 2 := by exact_mod_cast hN
-    nlinarith [sq_nonneg (N : ℚ)]
+  have hNq : (N : ℚ) ≥ 2 := by exact_mod_cast hN
+  have hN2 : (N : ℚ) ^ 2 - 1 > 0 := by nlinarith [sq_nonneg (N : ℚ)]
+  rw [gt_iff_lt, lt_div_iff hN2]
+  nlinarith [sq_nonneg (N : ℚ)]
 
 /-- The critical temperature for SU(N) in the large-N limit scales as T_c ∝ √σ.
     More precisely: T_c/√σ approaches a universal constant as N → ∞. -/
@@ -14911,7 +14921,7 @@ theorem sb_dof_monotone (N₁ N₂ : ℕ) (hN₁ : N₁ ≥ 2) (hN₂ : N₂ ≥
     (h : N₁ < N₂) :
     stefanBoltzmannDOF N₁ < stefanBoltzmannDOF N₂ := by
   unfold stefanBoltzmannDOF
-  have : N₁ ^ 2 < N₂ ^ 2 := Nat.pow_lt_pow_left h (by omega)
+  have : N₁ ^ 2 < N₂ ^ 2 := by nlinarith [sq_nonneg N₁, sq_nonneg N₂]
   omega
 
 /-- Adjoint Polyakov loop ⟨L_adj⟩: invariant under Z_N, does not serve as
@@ -14963,9 +14973,10 @@ theorem gap_decreases_with_action (S0₁ S0₂ : ℝ) (N : ℕ) (hN : N ≥ 1)
     (hS : S0₁ < S0₂) :
     monopoleMassGap S0₂ N hN < monopoleMassGap S0₁ N hN := by
   unfold monopoleMassGap
-  apply Real.exp_lt_exp_of_lt
-  have hN_pos : (0 : ℝ) < N := by exact_mod_cast Nat.lt_of_lt_pred (by omega)
-  exact div_lt_div_of_neg_right hS (by linarith)
+  have hN_pos : (0 : ℝ) < ↑N := Nat.cast_pos.mpr (by omega)
+  have hlt : -S0₂ / ↑N < -S0₁ / ↑N := by
+    apply div_lt_div_of_pos_right _ hN_pos; linarith
+  exact Real.exp_strictMono hlt
 
 /-- Continuity conjecture: the mass gap on R³ × S¹(L) is continuous as L → ∞.
     If proven, this would bridge the semi-classical mass gap to the R⁴ mass gap.

--- a/src/data/research/problems/erdos-44.json
+++ b/src/data/research/problems/erdos-44.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-44",
-  "title": "Erdős #44",
+  "title": "Erd\u0151s #44",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-12T06:58:30.839Z",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,16 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Proof got complex with edge cases, left as sorry",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Proved isSidon_powers_of_two (eliminated 1 axiom). 2 axioms remain: sidon_set_lower_bound_exists (\u221aN/2 Sidon set construction) and erdos_44 (main open conjecture).",
+    "builtItems": [
+      "pow2_sum_inj: core lemma, 2^a+2^b=2^c+2^d \u2192 a=c \u2227 b=d, by strong induction on exponent sum",
+      "isSidon_powers_of_two: {2^0,...,2^{k-1}} is Sidon, proved from pow2_sum_inj"
+    ],
+    "insights": [
+      "Strong induction on a+c with parity: when both exponents \u22651, divide by 2 and recurse",
+      "Parity argument: if min exponent is 0 but other is \u22651, LHS odd vs RHS even",
+      "dvd_pow_self 2 is the clean way to show 2 | 2^k in Lean (not pow_succ rewriting)"
+    ],
     "mathlibGaps": [],
     "nextSteps": [
       "Submit `isSidon_powers_of_two` to Aristotle - well-defined approach exists",
       "For `sidon_set_lower_bound_exists`, consider:",
       "`erdos_44` is truly OPEN - cannot be proved"
     ],
-    "markdown": "# Erdős #44 - Knowledge Base\n\n## Problem Statement\n\nLet $N\\geq 1$ and $A\\subset \\{1,\\ldots,N\\}$ be a Sidon set. Is it true that, for any $\\epsilon>0$, there exist $M$ and $B\\subset \\{N+1,\\ldots,M\\}$ (which may depend on $N,A,\\epsilon$) such that $A\\cup B\\subset \\{1,\\ldots,M\\}$ is a Sidon set of size at least $(1-\\epsilon)M^{1/2}$? See also [329] and [707] (indeed a positive solution to [707] implies a positive solution to this problem, which in turn implies a positive solution to [329]). This is discussed in problem C9 of Guy's collection [Gu04]. View the LaTeX source This page was last edited 09 January 2026.\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #62\n- Problem #2\n- Problem #329\n- Problem #707\n- Problem #43\n- Problem #45\n- Problem #39\n- Problem #1\n\n## References\n\n- Er91\n- Er95\n- Er97c\n- Gu04\n\n## Sessions\n\n### Session 2026-01-13 - Significant Progress on Sidon Set Bounds\n\n**Mode**: REVISIT\n**Outcome**: Progress - 4 sorries to 3 sorries\n\n#### What I Did\n\n1. **Proved `maxSidonSubsetCard_icc_bound`**: For any Sidon set A in [1,N], |A| <= 2*sqrt(N)\n   - Strategy: Case split on N < 3 vs N >= 3\n   - Small cases (N=1,2): Direct bound |A| <= N <= 2*sqrt(N)\n   - N >= 3: Use sidon_subset_icc_card_bound giving |A| <= sqrt(2N) + 1\n   - Show sqrt(2N) + 1 <= 2*sqrt(N) via (2 - sqrt(2))*sqrt(N) > 1 for N >= 3\n   - Key bounds: sqrt(2) < 1.415, sqrt(3) > 1.732\n\n2. **Attempted `isSidon_powers_of_two`**: Powers of 2 form a Sidon set\n   - Proof sketch: Use 2-adic valuations\n   - If 2^a + 2^b = 2^c + 2^d with a <= b, c <= d\n   - Factor: 2^a(1 + 2^(b-a)) = 2^c(1 + 2^(d-c))\n   - For k > 0, 1 + 2^k is odd (2^k even for k > 0)\n   - Compare 2-adic valuations to get a = c, then b = d\n   - **Status**: Proof got complex with edge cases, left as sorry\n\n#### Current State\n\n| Component | Status |\n|-----------|--------|\n| `sidon_subset_icc_card_bound` | PROVED |\n| `maxSidonSubsetCard_icc_bound` | **PROVED** (this session) |\n| `isSidon_powers_of_two` | SORRY (HARD) |\n| `sidon_set_lower_bound_exists` | SORRY (HARD) |\n| `erdos_44` | SORRY (OPEN - main conjecture) |\n\n#### Sorry Classification\n\n| Sorry | Classification | Reason |\n|-------|---------------|--------|\n| `isSidon_powers_of_two` | HARD | 2-adic valuation argument, well-defined approach |\n| `sidon_set_lower_bound_exists` | HARD | Requires constructive argument for Sidon sets of size sqrt(N)/2 |\n| `erdos_44` | OPEN | Main unsolved conjecture |\n\n#### Key Mathlib Lemmas Used\n\n- `Real.sqrt_lt'`: sqrt(x) < y <-> x < y^2 (for y > 0)\n- `Real.lt_sqrt`: x < sqrt(y) <-> x^2 < y (for x >= 0)\n- `Real.sqrt_le_sqrt`: x <= y -> sqrt(x) <= sqrt(y)\n- `Real.sqrt_mul`: sqrt(a*b) = sqrt(a)*sqrt(b) (for a >= 0)\n- `Real.one_le_sqrt`: 1 <= sqrt(x) <-> 1 <= x\n- `Real.nat_sqrt_le_real_sqrt`: Nat.sqrt(n) <= sqrt(n) as reals\n- `Nat.pow_le_pow_iff_right`: 2^a <= 2^b <-> a <= b\n\n#### Next Steps\n\n1. Submit `isSidon_powers_of_two` to Aristotle - well-defined approach exists\n2. For `sidon_set_lower_bound_exists`, consider:\n   - Singer difference sets construction\n   - Greedy algorithm analysis\n   - Or weaken to log_2(N) bound using powers of 2\n3. `erdos_44` is truly OPEN - cannot be proved\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
+    "markdown": "# Erd\u0151s #44 - Knowledge Base\n\n## Problem Statement\n\nLet $N\\geq 1$ and $A\\subset \\{1,\\ldots,N\\}$ be a Sidon set. Is it true that, for any $\\epsilon>0$, there exist $M$ and $B\\subset \\{N+1,\\ldots,M\\}$ (which may depend on $N,A,\\epsilon$) such that $A\\cup B\\subset \\{1,\\ldots,M\\}$ is a Sidon set of size at least $(1-\\epsilon)M^{1/2}$? See also [329] and [707] (indeed a positive solution to [707] implies a positive solution to this problem, which in turn implies a positive solution to [329]). This is discussed in problem C9 of Guy's collection [Gu04]. View the LaTeX source This page was last edited 09 January 2026.\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #62\n- Problem #2\n- Problem #329\n- Problem #707\n- Problem #43\n- Problem #45\n- Problem #39\n- Problem #1\n\n## References\n\n- Er91\n- Er95\n- Er97c\n- Gu04\n\n## Sessions\n\n### Session 2026-01-13 - Significant Progress on Sidon Set Bounds\n\n**Mode**: REVISIT\n**Outcome**: Progress - 4 sorries to 3 sorries\n\n#### What I Did\n\n1. **Proved `maxSidonSubsetCard_icc_bound`**: For any Sidon set A in [1,N], |A| <= 2*sqrt(N)\n   - Strategy: Case split on N < 3 vs N >= 3\n   - Small cases (N=1,2): Direct bound |A| <= N <= 2*sqrt(N)\n   - N >= 3: Use sidon_subset_icc_card_bound giving |A| <= sqrt(2N) + 1\n   - Show sqrt(2N) + 1 <= 2*sqrt(N) via (2 - sqrt(2))*sqrt(N) > 1 for N >= 3\n   - Key bounds: sqrt(2) < 1.415, sqrt(3) > 1.732\n\n2. **Attempted `isSidon_powers_of_two`**: Powers of 2 form a Sidon set\n   - Proof sketch: Use 2-adic valuations\n   - If 2^a + 2^b = 2^c + 2^d with a <= b, c <= d\n   - Factor: 2^a(1 + 2^(b-a)) = 2^c(1 + 2^(d-c))\n   - For k > 0, 1 + 2^k is odd (2^k even for k > 0)\n   - Compare 2-adic valuations to get a = c, then b = d\n   - **Status**: Proof got complex with edge cases, left as sorry\n\n#### Current State\n\n| Component | Status |\n|-----------|--------|\n| `sidon_subset_icc_card_bound` | PROVED |\n| `maxSidonSubsetCard_icc_bound` | **PROVED** (this session) |\n| `isSidon_powers_of_two` | SORRY (HARD) |\n| `sidon_set_lower_bound_exists` | SORRY (HARD) |\n| `erdos_44` | SORRY (OPEN - main conjecture) |\n\n#### Sorry Classification\n\n| Sorry | Classification | Reason |\n|-------|---------------|--------|\n| `isSidon_powers_of_two` | HARD | 2-adic valuation argument, well-defined approach |\n| `sidon_set_lower_bound_exists` | HARD | Requires constructive argument for Sidon sets of size sqrt(N)/2 |\n| `erdos_44` | OPEN | Main unsolved conjecture |\n\n#### Key Mathlib Lemmas Used\n\n- `Real.sqrt_lt'`: sqrt(x) < y <-> x < y^2 (for y > 0)\n- `Real.lt_sqrt`: x < sqrt(y) <-> x^2 < y (for x >= 0)\n- `Real.sqrt_le_sqrt`: x <= y -> sqrt(x) <= sqrt(y)\n- `Real.sqrt_mul`: sqrt(a*b) = sqrt(a)*sqrt(b) (for a >= 0)\n- `Real.one_le_sqrt`: 1 <= sqrt(x) <-> 1 <= x\n- `Real.nat_sqrt_le_real_sqrt`: Nat.sqrt(n) <= sqrt(n) as reals\n- `Nat.pow_le_pow_iff_right`: 2^a <= 2^b <-> a <= b\n\n#### Next Steps\n\n1. Submit `isSidon_powers_of_two` to Aristotle - well-defined approach exists\n2. For `sidon_set_lower_bound_exists`, consider:\n   - Singer difference sets construction\n   - Greedy algorithm analysis\n   - Or weaken to log_2(N) bound using powers of 2\n3. `erdos_44` is truly OPEN - cannot be proved\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "approaches": [],
   "tags": [
@@ -51,7 +58,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T06:58:30.839Z",
-  "lastUpdate": "2026-03-13T07:52:17.043Z",
+  "lastUpdate": "2026-03-18T23:00:00Z",
   "significance": 6,
   "tractability": 4
 }


### PR DESCRIPTION
## Summary
- Fix build errors in Yang-Mills Parts XCVIII-XCIX introduced in #4017
- Prove `isSidon_powers_of_two` theorem in Erdos44Problem.lean (eliminates axiom)

## Fixes
- ℕ→ℤ cast issues in FRG trace decomposition (use `zify` + `ring`)
- `casimir_ratio_gt_one`: proper `lt_div_iff` instead of `div_lt_iff₀`
- `Nat.pow_lt_pow_left` API compatibility (use calc proofs)
- `frg_lattice_consistency`: use `div_le_iff`/`le_div_iff`
- `gap_decreases_with_action`: use `exp_strictMono` + `div_lt_div_of_pos_right`

## New Proof: isSidon_powers_of_two
- **Eliminated axiom**: Powers of 2 form a Sidon set
- **Technique**: Strong induction on exponent sum using parity argument
  - Base: a=0, c=0 → cancel 1's, conclude b=d from pow injectivity
  - Parity: a=0, c≥1 → LHS odd, RHS even, contradiction
  - Induction: a≥1, c≥1 → divide by 2, recurse with smaller exponents

## Status
**Outcome**: progress (1 axiom eliminated from Erdos44)

🤖 Generated by researcher-5