### PR TITLE
Research: abel-ruffini-oq-01 - Eliminate 4/6 axioms in A₅ realization

### DIFF
--- a/proofs/Proofs/InverseGaloisA5.lean
+++ b/proofs/Proofs/InverseGaloisA5.lean
@@ -21,7 +21,7 @@ polynomial with Galois group A₅ over ℚ.
 **Discriminant**: Disc(q) = Disc(p) = 2¹⁶ · 5⁶ = (2⁸ · 5³)² = 32000².
 Since the discriminant is a perfect square, Gal(q/ℚ) ≤ A₅.
 
-**Irreducibility**: q satisfies Eisenstein's criterion at p = 5:
+**Irreducibility**: q satisfies Eisenstein's criterion at p = 5 (PROVED in Lean):
 - All non-leading coefficients divisible by 5: -5, 25, -10, 10, -5  ✓
 - Constant term -5 not divisible by 25                                ✓
 - Leading coefficient 1 not divisible by 5                            ✓
@@ -89,22 +89,79 @@ By Eisenstein's criterion, q is irreducible over ℤ.
 By Gauss's lemma (monic → primitive → ℤ-irreducible ⟹ ℚ-irreducible),
 q is irreducible over ℚ.
 
-Axiomatized because the coefficient extraction from a compound polynomial
-expression in Lean requires extensive simp lemma engineering.
+PROVED: Eisenstein conditions verified via interval_cases + norm_num on
+each coefficient position. The ℤ→ℚ transfer uses IsPrimitive.Int.irreducible_iff_irreducible_map_cast.
 -/
+
+/-- The ℤ[X] version of q for Eisenstein criterion application. -/
+private noncomputable def q_int : ℤ[X] :=
+  X ^ 5 - C 5 * X ^ 4 + C 10 * X ^ 3 - C 10 * X ^ 2 + C 25 * X - C 5
+
+/-- q_int has degree 5. -/
+private theorem q_int_degree : q_int.degree = 5 := by
+  unfold q_int; compute_degree!
+
+/-- q_int has natDegree 5. -/
+private theorem q_int_natDegree : q_int.natDegree = 5 := by
+  unfold q_int; compute_degree!
+
+/-- q_int is monic (leading coefficient = 1). -/
+private theorem q_int_monic : q_int.Monic := by
+  rw [Polynomial.Monic, Polynomial.leadingCoeff, q_int_natDegree]
+  unfold q_int
+  simp only [coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X]
+  norm_num
+
+/-- q_int is irreducible over ℤ, by Eisenstein's criterion at p = 5. -/
+private theorem q_int_irreducible : Irreducible q_int := by
+  apply Polynomial.irreducible_of_eisenstein_criterion (P := Ideal.span {(5 : ℤ)})
+  · -- (5) is a prime ideal in ℤ
+    rw [Ideal.span_singleton_prime (show (5 : ℤ) ≠ 0 from by norm_num)]
+    exact Int.prime_iff_natAbs_prime.mpr (by norm_num)
+  · -- leadingCoeff ∉ (5)
+    rw [show q_int.leadingCoeff = 1 from q_int_monic, Ideal.mem_span_singleton]
+    norm_num
+  · -- ∀ k < degree, coeff k ∈ (5)
+    intro k hk
+    rw [q_int_degree] at hk
+    have hkn : k < 5 := WithBot.coe_lt_coe.mp hk
+    simp only [Ideal.mem_span_singleton]
+    unfold q_int
+    simp only [coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X]
+    interval_cases k <;> norm_num
+  · -- 0 < degree
+    rw [q_int_degree]; exact_mod_cast Nat.zero_lt_succ 4
+  · -- coeff 0 ∉ (5)²
+    rw [Ideal.span_singleton_pow, Ideal.mem_span_singleton]
+    unfold q_int
+    simp only [coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X]
+    norm_num
+  · -- isPrimitive: monic → primitive
+    exact q_int_monic.isPrimitive
 
 /-- q is irreducible over ℚ.
 
     Proof: Eisenstein's criterion at p = 5 gives ℤ-irreducibility.
-    Gauss's lemma (monic = primitive) transfers to ℚ. -/
-axiom q_irreducible : Irreducible q
+    Gauss's lemma (monic → primitive) transfers to ℚ. -/
+theorem q_irreducible : Irreducible q := by
+  have hprim := q_int_monic.isPrimitive
+  have hirr := (IsPrimitive.Int.irreducible_iff_irreducible_map_cast hprim).mp q_int_irreducible
+  convert hirr using 1
+  unfold q q_int
+  ext k
+  simp [coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X, Int.cast_ite]
 
 -- ============================================================================
 -- Part III: Basic Structural Properties
 -- ============================================================================
 
-/-- q has degree 5. -/
-axiom q_natDegree : q.natDegree = 5
+/-- q has degree 5.
+
+    Proof: unfold the definition and use Mathlib's `compute_degree!` tactic,
+    which handles natDegree computation for compound polynomial expressions. -/
+theorem q_natDegree : q.natDegree = 5 := by
+  unfold q
+  compute_degree!
 
 /-- q is separable (irreducible in characteristic 0). -/
 theorem q_separable : q.Separable := q_irreducible.separable
@@ -291,16 +348,28 @@ theorem a5_card : Fintype.card (alternatingGroup (Fin 5)) = 60 := by
     abelian quotient (ℤ/2), S₅ would also be solvable. But S₅ is not
     solvable for n ≥ 5 (Mathlib: Equiv.Perm.not_solvable).
 
-    Axiomatized: requires careful Mathlib API navigation for the
-    solvable extension argument. -/
-axiom a5_not_solvable : ¬IsSolvable (alternatingGroup (Fin 5))
+    Proof: assume IsSolvable A₅, transfer to S₅ via the short exact sequence
+    A₅ → S₅ → ℤ/2 (ker ≤ range of sign), then contradict Perm.not_solvable. -/
+theorem a5_not_solvable : ¬IsSolvable (alternatingGroup (Fin 5)) := by
+  intro h
+  have : IsSolvable (Equiv.Perm (Fin 5)) := by
+    apply solvable_of_ker_le_range
+      (alternatingGroup (Fin 5)).subtype
+      Equiv.Perm.sign
+    intro x hx
+    rw [MonoidHom.mem_ker] at hx
+    exact ⟨⟨x, Equiv.Perm.mem_alternatingGroup.mpr hx⟩, rfl⟩
+  exact Equiv.Perm.not_solvable (Fin 5) (by simp) this
 
 /-- The Galois group we constructed is not solvable.
     This shows the realization goes beyond Shafarevich's theorem.
 
-    Proof: Gal ≅ A₅ (axiom), and A₅ is not solvable.
-    Axiomatized for the same API reason as a5_not_solvable. -/
-axiom gal_not_solvable : ¬IsSolvable q.Gal
+    Proof: Gal ≅ A₅ (via q_gal_iso_a5), and A₅ is not solvable.
+    Transfer non-solvability through the MulEquiv. -/
+theorem gal_not_solvable : ¬IsSolvable q.Gal := by
+  intro h
+  obtain ⟨e⟩ := q_gal_iso_a5
+  exact a5_not_solvable (isSolvable_of_surjective e.toMonoidHom e.surjective)
 
 -- ============================================================================
 -- Part IX: Connection to Original Polynomial
@@ -375,33 +444,27 @@ Groups NOT YET realized in our formalization:
 /-
 ## Results Status
 
-### PROVED (from axioms, 0 sorries):
-1. a5_realizable: ∃ K/ℚ Galois with |Aut| = 60
-2. a5_realizable_iso: ∃ K/ℚ Galois with Gal ≅ A₅
-3. splitting_field_q_finrank: [K:ℚ] = 60
-4. q_separable: q is separable over ℚ
-5. q_rootSet_card: |rootSet(q)| = 5
-6. five_dvd_gal_card: 5 | |Gal(q)|
-7. gal_card_dvd_120: |Gal(q)| | 120
-8. gal_has_index_two_in_s5: 2·|Gal| = |S₅|
-9. gal_injects_into_perm: Gal ↪ Perm(rootSet)
-10. a5_card: |A₅| = 60
-11. a5_not_solvable: A₅ is not solvable
-12. gal_not_solvable: Gal(q/ℚ) is not solvable
+### PROVED (0 sorries):
+1. q_irreducible: Irreducible q (Eisenstein at p=5 + Gauss lemma)
+2. q_natDegree: q.natDegree = 5 (compute_degree!)
+3. a5_not_solvable: ¬IsSolvable A₅ (ker ≤ range + Perm.not_solvable)
+4. gal_not_solvable: ¬IsSolvable Gal(q) (transfer via MulEquiv)
+5. a5_realizable: ∃ K/ℚ Galois with |Aut| = 60
+6. a5_realizable_iso: ∃ K/ℚ Galois with Gal ≅ A₅
+7. splitting_field_q_finrank: [K:ℚ] = 60
+8. q_separable: q is separable over ℚ
+9. q_rootSet_card: |rootSet(q)| = 5
+10. five_dvd_gal_card: 5 | |Gal(q)|
+11. gal_card_dvd_120: |Gal(q)| | 120
+12. gal_has_index_two_in_s5: 2·|Gal| = |S₅|
+13. gal_injects_into_perm: Gal ↪ Perm(rootSet)
+14. a5_card: |A₅| = 60 (native_decide)
 
-### Axioms (6):
-1. q_irreducible: Irreducible q
-   (Eisenstein at p=5; coefficient verification pending)
-2. q_natDegree: q.natDegree = 5
-   (Polynomial degree computation)
-3. q_gal_card: |Gal(q)| = 60
-   (Discriminant analysis + Chebotarev density)
-4. q_gal_iso_a5: Gal(q) ≃* A₅
-   (Index-2 subgroup uniqueness + discriminant sign)
-5. a5_not_solvable: ¬IsSolvable A₅
-   (Classical; Mathlib API navigation pending)
-6. gal_not_solvable: ¬IsSolvable Gal(q)
-   (Transfer from a5_not_solvable via q_gal_iso_a5)
+### Axioms (2, genuinely deep results):
+1. q_gal_card: |Gal(q)| = 60
+   (Discriminant analysis + Chebotarev density theorem)
+2. q_gal_iso_a5: Gal(q) ≃* A₅
+   (Index-2 subgroup uniqueness + discriminant sign computation)
 
 ### Proof Architecture
 ```

--- a/research/problems/abel-ruffini-oq-01/knowledge.md
+++ b/research/problems/abel-ruffini-oq-01/knowledge.md
@@ -6,7 +6,40 @@ The Inverse Galois Problem (IGP) asks: for every finite group G, does there exis
 
 **Status**: OPEN in general. The full conjecture is unproven.
 
-## Session 2026-03-18 (researcher-4) - Fix Mathlib API Breakages
+## Session 2026-03-18 (researcher-4) - Eliminate A₅ Axioms (6→2)
+
+**Mode**: REVISIT (RICH knowledge score 29)
+**Outcome**: progress — eliminated 4 of 6 axioms in InverseGaloisA5.lean
+
+### What I Did
+
+- **PROVED** `q_irreducible`: Irreducible q via Eisenstein criterion at p=5
+  - Defined q_int in ℤ[X], applied `irreducible_of_eisenstein_criterion` with ideal (5)
+  - Coefficient verification via `interval_cases k` + `norm_num` after simp
+  - Transfer to ℚ via `IsPrimitive.Int.irreducible_iff_irreducible_map_cast` (Gauss lemma)
+- **PROVED** `q_natDegree`: q.natDegree = 5 via `compute_degree!`
+- **PROVED** `a5_not_solvable`: ¬IsSolvable A₅
+  - Proof: A₅ solvable → S₅ solvable (via `solvable_of_ker_le_range` with sign map) → contradiction with `Equiv.Perm.not_solvable`
+- **PROVED** `gal_not_solvable`: ¬IsSolvable Gal(q)
+  - Transfer from `a5_not_solvable` via `isSolvable_of_surjective` through the MulEquiv
+
+### Key Discoveries
+
+- `interval_cases k` + `norm_num` is the right approach for verifying Eisenstein conditions on compound polynomials — avoids manual case splitting
+- `compute_degree!` handles `natDegree` and `degree` for compound polynomial expressions (sums, products, C*X^n)
+- The monic proof for compound expressions: `Polynomial.leadingCoeff` at the computed `natDegree` position, then simp + norm_num
+- `solvable_of_ker_le_range` takes two maps (A_n.subtype and Perm.sign) and proves solvability of the middle term from endpoints
+
+### Files Modified
+
+- `proofs/Proofs/InverseGaloisA5.lean` (4 axioms → theorems)
+
+### Axiom Count
+
+Before: 6 axioms (q_irreducible, q_natDegree, q_gal_card, q_gal_iso_a5, a5_not_solvable, gal_not_solvable)
+After: 2 axioms (q_gal_card, q_gal_iso_a5) — both require discriminant computation + Chebotarev density
+
+## Session 2026-03-18 (researcher-4, earlier) - Fix Mathlib API Breakages
 
 **Mode**: REVISIT (RICH knowledge score 29)
 **Outcome**: progress — fixed 6 build issues in InverseGalois.lean

--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-02-21T19:21:07.129Z",
-    "iteration": 6,
-    "focus": "Mathlib API compatibility fixes",
+    "iteration": 7,
+    "focus": "InverseGaloisA5: eliminated 4/6 axioms (q_irreducible, q_natDegree, a5_not_solvable, gal_not_solvable)",
     "blockers": [
       "Kronecker-Weber not in Mathlib",
       "Hilbert irreducibility not in Mathlib"
     ],
-    "nextAction": "Fix pre-existing Mathlib API breakages in Parts IX-XII (X³-2 computation)",
+    "nextAction": "Only q_gal_card and q_gal_iso_a5 remain as axioms (require discriminant computation)",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed 6 Mathlib API breakages in InverseGalois.lean. Forward reference, dead code, associated_of_dvd, classical, field_simp, permCongr. 1066 lines, 2 intentional sorries, 0 axioms.",
+    "progressSummary": "InverseGaloisA5.lean: 6 axioms → 2 axioms. Proved q_irreducible (Eisenstein), a5_not_solvable, gal_not_solvable, q_natDegree. Only q_gal_card (discriminant+Chebotarev) and q_gal_iso_a5 (index-2 uniqueness) remain as axioms.",
     "builtItems": [
       "InverseGalois.lean: cyclotomic Galois theory, S₃ realization via Gal(X³-2)≅S₃ (905 lines, builds)",
       "InverseGaloisD4.lean: D₄ realization via |Gal(X⁴-2)| = 8 (666 lines, builds)",
@@ -51,7 +51,11 @@
       "Rewrote no_root_of_irreducible_degree_ndvd with isUnit_or_isUnit approach",
       "Added classical to gal_card_dvd_six and x_cube_sub_2_gal_iso_s3_proved",
       "Simplified cube_root_ratio_satisfies_cyclotomic via field_simp",
-      "Fixed permCongr Equiv→MulEquiv in x_cube_sub_2_gal_iso_s3_proved"
+      "Fixed permCongr Equiv→MulEquiv in x_cube_sub_2_gal_iso_s3_proved",
+      "InverseGaloisA5.lean: q_irreducible proved via Eisenstein at p=5 (was axiom)",
+      "InverseGaloisA5.lean: a5_not_solvable proved via solvable_of_ker_le_range (was axiom)",
+      "InverseGaloisA5.lean: gal_not_solvable proved via MulEquiv transfer (was axiom)",
+      "InverseGaloisA5.lean: q_natDegree proved via compute_degree! (was axiom)"
     ],
     "insights": [
       "Cyclotomic irreducibility over ℚ IS in Mathlib: Polynomial.cyclotomic.irreducible_rat",
@@ -69,14 +73,18 @@
       "Nat.forall_exists_prime_gt_and_modEq API changed: now takes (n : ℕ) {q a : ℕ} (hq : q ≠ 0) (h : a.Coprime q)",
       "PR #3974 was closed as superseded but its changes were NOT present on main - always verify closures",
       "AdjoinRoot approach (cofactor_has_no_root) is dead code when splitting field approach is used",
-      "classical is more robust than haveI : DecidableEq for Perm/Fintype synthesis"
+      "classical is more robust than haveI : DecidableEq for Perm/Fintype synthesis",
+      "Eisenstein criterion for compound polynomials: use interval_cases k + norm_num after simp on coefficient lemmas (coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X)",
+      "IsPrimitive.Int.irreducible_iff_irreducible_map_cast: Gauss lemma for ℤ→ℚ irreducibility transfer",
+      "solvable_of_ker_le_range: transfers solvability through short exact sequences (A_n → S_n → ℤ/2)",
+      "compute_degree! handles natDegree for compound polynomial expressions over any ring"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Problem at frontier - blocked on Hilbert irreducibility (Mathlib gap)",
-      "Only 2 sorries remain: open conjecture (intentional) + symmetric_group_realizable (blocked)",
-      "InverseGaloisF20.lean now builds cleanly (previously had errors)",
-      "Could realize additional specific groups (A4, Dn) but each requires substantial polynomial computation"
+      "InverseGaloisA5.lean: only 2 axioms remain (q_gal_card, q_gal_iso_a5) - both require discriminant computation",
+      "Discriminant of q = 32000² could potentially be verified computationally in Lean",
+      "q_gal_iso_a5 follows from q_gal_card if we can show Gal lands in A_5 (discriminant sign)",
+      "Problem essentially at frontier - remaining axioms require deep infrastructure (Chebotarev, discriminant formula)"
     ],
     "markdown": "# Knowledge: The Inverse Galois Problem (abel-ruffini-oq-01)\n\n## Problem Summary\n\nThe Inverse Galois Problem (IGP) asks: for every finite group G, does there exist a Galois extension K/ℚ with Gal(K/ℚ) ≅ G?\n\n**Status**: OPEN in general. The full conjecture is unproven.\n\n## Session 2026-03-14 (researcher-2) - Verification and Assessment\n\n**Mode**: REVISIT (depth-first, RICH knowledge score 59)\n**Outcome**: verified, at frontier of formalizability\n\n**What we did**: Docker build verified (2 expected sorries). Confirmed KroneckersJugendtraum.lean has Kronecker-Weber as statement only (not proved). Updated outdated next steps. No tractable path to further progress without new Mathlib infrastructure.\n\n## Session 2026-02-21 (Session 1) - Initial Exploration and Formalization\n\n**Mode**: FRESH\n**Outcome**: progress — first Lean formalization created\n\n### What I Did\n\n- Explored the mathematical landscape of the Inverse Galois Problem\n- Surveyed Mathlib4 infrastructure: `IsCyclotomicExtension.isGalois`, `IsCyclotomicExtension.Aut.commGroup`, `galCyclotomicEquivUnitsZMod`, `ZMod.card_units_eq_totient`\n- Created `proofs/Proofs/InverseGalois.lean` with formal Lean content\n- Created gallery data at `src/data/proofs/inverse-galois/`\n- Added to `listings.json` and `Proofs.lean`\n\n### Key Findings\n\n- Mathlib has `IsCyclotomicExtension.isGalois` — cyclotomic extensions are automatically Galois\n- Mathlib has `IsCyclotomicExtension.Aut.commGroup` — cyclotomic Galois groups are abelian\n- Mathlib has `galCyclotomicEquivUnitsZMod` — requires irreducibility of cyclotomic poly over ℚ\n- The irreducibility of Φₙ(x) over ℚ is a classical theorem (Gauss 1801) NOT directly in Mathlib as a standalone theorem — typically assumed as hypothesis in Mathlib theorems\n- The problem is genuinely open in general, but well-known cases (abelian, solvable, symmetric groups) are provable\n\n### Files Modified\n\n- `proofs/Proofs/InverseGalois.lean` (created)\n- `src/data/proofs/inverse-galois/meta.json` (created)\n- `src/data/proofs/inverse-galois/annotations.json` (created)\n- `src/data/proofs/inverse-galois/index.ts` (created)\n- `src/data/proofs/inverse-galois/tacticStates.json` (created)\n- `src/data/proofs/listings.json` (updated)\n- `proofs/Proofs.lean` (updated with import)\n- `research/problems/abel-ruffini-oq-01/knowledge.md` (this file)\n\n### What We Proved (compile-time)\n\n1. `cyclotomic_field_isGalois`: CyclotomicField n ℚ is Galois over ℚ\n2. `cyclotomic_galois_isAbelian`: The Galois group is abelian\n3. `cyclotomic_galois_group_iso_units_zmod`: Gal(Φₙ/ℚ) ≅ (ZMod n)ˣ (uses irreducibility axiom)\n4. `units_zmod4_card` = 2, `units_zmod5_card` = 4, `units_zmod7_card` = 6 (decide)\n5. `units_zmodPrime_card` = p-1 for prime p\n6. `a5_not_solvable`: A₅ is not solvable (proven)\n7. `solvable_iff_solvable_galois_group`: Connection to Abel-Ruffini (proven)\n\n### What's Axiomatized (not proven in Lean)\n\n1. `cyclotomic_irreducible_over_rationals`: Φₙ(x) is irreducible over ℚ (classical, not in Mathlib as standalone)\n2. `abelian_realizable`: All abelian groups realizable (needs Kronecker-Weber)\n3. `shafarevich_theorem`: All solvable groups realizable (Shafarevich 1954, deep)\n\n### What Has Sorry\n\n1. `inverse_galois_problem_open_conjecture`: The main open problem\n2. `symmetric_group_realizable`: Needs Hilbert irreducibility theorem\n3. `connection_to_abel_ruffini`: The specific polynomial example\n4. One more in the A₅ realization discussion\n\n### Next Steps\n\n1. Try to prove `cyclotomic_irreducible_over_rationals` in Lean — this should be in Mathlib somewhere, perhaps under a different name\n2. Search for Kronecker-Weber in Mathlib (might not be there yet)\n3. Consider building a more computational example: explicitly compute Gal(ℚ(ζ₅)/ℚ) using Mathlib\n4. Possibly extend to show that some specific non-abelian group (like S₃) is realizable using an explicit polynomial\n\n## Mathematical Context\n\n### The Cyclotomic Approach (What We Formalized)\n\nFor the Galois group of the n-th cyclotomic field:\n- `CyclotomicField n ℚ` = splitting field of Φₙ(X) over ℚ\n- `IsGalois ℚ (CyclotomicField n ℚ)` — Galois extension\n- `Gal(CyclotomicField n ℚ / ℚ) ≅ (ZMod n)ˣ` — abelian Galois group\n\nFor prime p:\n- `(ZMod p)ˣ` is cyclic of order p-1\n- So Gal(ℚ(ζₚ)/ℚ) is cyclic of order p-1\n\n### Known Realizability Results\n\n| Group Family | Source | Status in Lean |\n|---|---|---|\n| Trivial group | ℚ/ℚ | Easy (not formalized yet) |\n| Cyclic Cₙ | Cyclotomic subfields | Partially (via autEquivPow) |\n| Abelian | Kronecker-Weber | Axiom |\n| Solvable | Shafarevich 1954 | Axiom |\n| Sₙ | Hilbert irreducibility | Sorry |\n| Aₙ (n≥5) | Various | Not formalized |\n| Most simple groups | Case by case | Not formalized |\n| M₂₃ (sporadic) | Unknown | Open math problem |\n| General | **OPEN** | Open math problem |\n\n### Mathlib Infrastructure Used\n\n```\nMathlib.NumberTheory.Cyclotomic.Gal\n  - galCyclotomicEquivUnitsZMod: polynomial Galois group ≅ (ZMod n)ˣ\n  - IsCyclotomicExtension.Aut.commGroup: abelian Galois group\n  - IsCyclotomicExtension.autEquivPow: automorphisms ≃* (ZMod n)ˣ\n\nMathlib.NumberTheory.Cyclotomic.Basic\n  - IsCyclotomicExtension.isGalois: cyclotomic extensions are Galois\n  - CyclotomicField: the splitting field of Φₙ(X)\n  - IsCyclotomicExtension instance for characteristic 0\n\nMathlib.FieldTheory.Galois.Basic\n  - IsGalois: the Galois extension class\n  - IsGalois.card_aut_eq_finrank: |Gal| = degree\n\nMathlib.GroupTheory.SpecificGroups.Cyclic\n  - IsCyclic instance for (ZMod p)ˣ\n\nMathlib.FieldTheory.AbelRuffini\n  - solvableByRad.isSolvable': Abel-Ruffini connection\n```\n\n## Blockers / Gaps\n\n1. **Cyclotomic irreducibility over ℚ**: Not a direct standalone Mathlib theorem.\n   The theorem is classical (Gauss 1801) but Mathlib typically assumes it as a\n   hypothesis. We axiomatized it.\n   **Potential fix**: Look in `Mathlib.RingTheory.Polynomial.Cyclotomic.Irreducible`\n   or search for `IsIntegral.minpoly_eq_cyclotomic`.\n\n2. **Kronecker-Weber theorem**: The proof that every abelian extension of ℚ is\n   cyclotomic. This deep result is not yet in Mathlib (as of 2026-02).\n\n3. **Hilbert irreducibility theorem**: Needed for symmetric group realization.\n   Not in Mathlib.\n\n4. **Shafarevich's theorem**: 50+ pages of algebraic number theory. Not in Lean.\n"
   },
@@ -98,7 +106,7 @@
     "mathlib": []
   },
   "started": "2026-02-21T19:21:07.129Z",
-  "lastUpdate": "2026-03-18T23:00:00Z",
+  "lastUpdate": "2026-03-18T17:30:00.000Z",
   "significance": 6,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- **PROVED** `q_irreducible`: Eisenstein criterion at p=5 for the compound polynomial X⁵-5X⁴+10X³-10X²+25X-5, transferred from ℤ to ℚ via Gauss lemma
- **PROVED** `a5_not_solvable`: A₅ not solvable via `solvable_of_ker_le_range` (A₅→S₅→ℤ/2) + `Perm.not_solvable`
- **PROVED** `gal_not_solvable`: Transfer from `a5_not_solvable` through MulEquiv
- **PROVED** `q_natDegree`: q.natDegree = 5 via `compute_degree!`

**Result**: InverseGaloisA5.lean axiom count reduced from 6 to 2. The 2 remaining axioms (`q_gal_card`, `q_gal_iso_a5`) require discriminant computation + Chebotarev density theorem — genuinely deep infrastructure not yet in Mathlib.

## Test plan
- [x] Docker build of Proofs.InverseGaloisA5 succeeds
- [x] All 4 former axioms now proved with 0 sorries
- [x] Knowledge and problem JSON updated

🤖 Generated by researcher-4