### PR TITLE
fix: add axiom integrity policy to agent instructions

### DIFF
--- a/.lean/roles/enricher.md
+++ b/.lean/roles/enricher.md
@@ -244,3 +244,7 @@ git checkout main && git pull && git checkout -B feature/enricher-N main
 5. **Note interesting proof techniques** - What tactics or strategies are noteworthy?
 6. **Historical accuracy** - Cite real mathematicians, real dates, real results
 7. **Open questions** - Point to genuine open problems or extensions, not trivial ones
+
+## Axiom Integrity When Enriching
+
+When enriching a proof page, verify that `status`, `badge`, and `axiomCount` in meta.json accurately reflect the actual Lean file. Structure-encoded assumptions (fields in structures like `NSAxioms`, `SelbergClassAxioms`, etc.) count as assumptions -- a proof that encodes its hypotheses in structure fields is NOT axiom-free. If you find `axiomCount: 0` or `status: "verified"` on a file that uses assumption-carrying structures, flag the discrepancy in your PR description rather than silently propagating it.

--- a/.lean/roles/herald.md
+++ b/.lean/roles/herald.md
@@ -6,7 +6,7 @@ You are the **Herald** — the public voice of Lean Genius on Mathstodon (@rjwal
 
 ### Tier 1 — Always Post
 
-- **Full proof completion**: A proof with 0 axioms and 0 sorries (fully verified by Lean)
+- **Full proof completion**: A proof with 0 axioms, 0 sorries, AND 0 structure-encoded assumptions (fully verified by Lean). "0 axioms" means zero `axiom` declarations AND zero assumption-carrying structure fields (e.g., `NSAxioms`, `SelbergClassAxioms`). If hypotheses were moved into structures, the proof is NOT axiom-free.
 - **Freek 100 entry**: A theorem from the Freek 100 list has been formalized
 - **Soundness catch**: A proof attempt revealed an error or false assumption (interesting failure)
 
@@ -24,6 +24,7 @@ You are the **Herald** — the public voice of Lean Genius on Mathstodon (@rjwal
 ### Never Post
 
 - Axiom decomposition (splitting axioms into smaller ones without eliminating them)
+- Claims of "0 axioms" or "axiom-free" when assumptions were moved into structure fields (e.g., `NSAxioms`, `SelbergClassAxioms`) -- this is restructuring, not elimination
 - Enrichment batches (gallery metadata improvements)
 - Build fixes, CI changes, data syncs
 - Partial progress (e.g., "reduced from 5 to 3 axioms" — wait for completion)

--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -349,6 +349,16 @@ End each session with:
 - Block without assessing buildability
 - Make commits without meaningful progress
 
+## Axiom Integrity
+
+When setting `status`, `axiomCount`, or `badge` in meta.json, count ALL assumptions -- not just Lean `axiom` declarations. Structure-encoded hypotheses (fields in structures like `NSAxioms`, `SelbergClassAxioms`, `RHAxioms`, etc.) are assumptions that the proof depends on. Moving axioms into structure fields does not eliminate them.
+
+**Rules:**
+- `axiomCount` = number of `axiom` declarations + number of assumption-carrying structure fields
+- Millennium Prize / Clay problems and open conjectures: use `status: "axiomatized"`, never `"verified"`
+- A proof is only `"verified"` (0 axioms) if it has zero `axiom` declarations AND zero structure-encoded assumptions
+- When creating or updating meta.json, inspect the actual Lean file for both forms of assumptions
+
 ## Observability
 
 **Log your actions** to enable monitoring without TUI access:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,19 @@ $ lake build Proofs.Something
 
 ---
 
+# Axiom Integrity Policy
+
+Structure-encoded hypotheses (fields in structures/typeclasses such as `NSAxioms`, `SelbergClassAxioms`, `RHAxioms`) are mathematical assumptions. Moving `axiom` declarations into structure fields does not reduce the assumption count -- it only changes where they are declared.
+
+**Rules for all agents:**
+- `axiomCount` in meta.json must reflect ALL assumptions: `axiom` declarations + assumption-carrying structure fields
+- A proof is `"verified"` (badge `"original"`) only if it has zero `axiom` declarations AND zero structure-encoded assumptions
+- Millennium Prize problems, Clay problems, and open conjectures must use `status: "axiomatized"`, never `"verified"`
+- When reporting "0 axioms" or "axiom-free", confirm there are no assumptions encoded in structures
+- Restructuring axioms into structures is a valid proof architecture choice, but it does not change the mathematical status
+
+---
+
 # Aristotle (Proof Search)
 
 Aristotle is an external proof search tool for Lean 4. It can automatically prove theorem sorries by searching for proofs.


### PR DESCRIPTION
## Summary

Our Millennium Prize and open problem formalizations were claiming "0 axioms" or "verified" status by moving assumptions from Lean `axiom` declarations into structure fields (e.g., `NSAxioms`, `SelbergClassAxioms`). This is mathematically equivalent -- the assumptions are unchanged -- but agents reported them as axiom-free. This PR adds guardrails to prevent future overclaiming by updating agent instructions.

- **CLAUDE.md**: Added "Axiom Integrity Policy" section (between Lean Proofs and Aristotle) defining rules for all agents
- **.lean/roles/researcher.md**: Added "Axiom Integrity" section with rules for counting assumptions and setting status
- **.lean/roles/enricher.md**: Added "Axiom Integrity When Enriching" section instructing enrichers to verify status/badge/axiomCount against actual Lean files
- **.lean/roles/herald.md**: Strengthened Tier 1 criteria to require zero structure-encoded assumptions for "full proof completion"; added structure-field overclaiming to "Never Post" list

## Files Modified

- `CLAUDE.md` -- New "Axiom Integrity Policy" section (~12 lines)
- `.lean/roles/researcher.md` -- New "Axiom Integrity" section (~10 lines)
- `.lean/roles/enricher.md` -- New "Axiom Integrity When Enriching" section (~4 lines)
- `.lean/roles/herald.md` -- Updated Tier 1 criteria + new Never Post item (~3 lines)

## Test plan

- [ ] `grep -r "Axiom Integrity" CLAUDE.md .lean/roles/` finds all four new sections
- [ ] `pnpm build` passes (no JSON or code changes, only markdown)
- [ ] No meta.json files were modified (that is a separate PR)