### PR TITLE
fix: correct Millennium Prize meta.json axiom counts and status

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -6,15 +6,17 @@
   "meta": {
     "author": "Birch & Swinnerton-Dyer (1965)",
     "date": "1965",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "elliptic-curves",
       "millennium-prize",
       "advanced"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
+    "axiomCount": 90,
+    "assumptions": "90 axiom declarations encoding core BSD infrastructure (algebraic rank, torsion, L-function, conductor, root number, analytic rank, periods, regulators, Sha order, Tamagawa numbers), proven BSD cases (rank 0 via Kolyvagin, rank 1 via Gross-Zagier, CM via Coates-Wiles), the Gross-Zagier formula, Hasse bound, specific curve data (cremona11a1, curve37a, curve389a L-values and ranks), congruent number results, parity conjecture, BSD generalizations (number fields, abelian varieties), Iwasawa theory, Tunnell's theorem, Sato-Tate, Cremona database verification, CM L-function factorization, and Euler system bounds. The BSD conjecture itself remains open.",
     "mathlibDependencies": [
       {
         "theorem": "WeierstrassCurve",
@@ -50,7 +52,7 @@
     "leanFile": {
       "lineCount": 5534,
       "structureCount": 72,
-      "axiomCount": 45,
+      "axiomCount": 90,
       "theoremCount": 201,
       "lemmaCount": 3,
       "defCount": 128,

--- a/src/data/proofs/hodge-conjecture/meta.json
+++ b/src/data/proofs/hodge-conjecture/meta.json
@@ -6,15 +6,17 @@
   "meta": {
     "author": "W.V.D. Hodge (1950)",
     "date": "1950",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "algebraic-geometry",
       "topology",
       "millennium-prize",
       "advanced"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
+    "axiomCount": 119,
+    "assumptions": "119 axiom declarations encoding Hodge structures (conjugation symmetry, cycle class maps, Lefschetz theorems), categorical operations (Tate twists, duals, tensor products, Kuenneth formula), known cases and counterexamples (Atiyah-Hirzebruch, Voisin), related conjectures (Standard, Mumford-Tate, Tate, Generalized Hodge), and structural results (hard Lefschetz, polarizations, intermediate Jacobians, motives). The Hodge Conjecture itself remains open.",
     "mathlibDependencies": [],
     "originalContributions": [
       "Abstract Hodge structures with complexification maps",

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -55,6 +55,7 @@
     "badge": "conditional",
     "sorries": 0,
     "axiomCount": 0,
+    "assumptions": "0 Lean axiom declarations, but the 3D regularity theorem is conditional on the NSAxioms structure (5 fields encoding physical hypotheses: Type II exponent, spectral gap, theta dynamics, blowup rate, and BKM criterion). These structure fields are mathematically equivalent to axiom declarations -- the assumptions were reorganized, not eliminated. The 2D global existence theorem (Ladyzhenskaya 1969) is genuinely unconditional. The Millennium Prize problem remains unsolved.",
     "mathlibDependencies": [
       {
         "theorem": "Real",

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Stephen Cook (1971)",
     "date": "1971",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PvsNP.lean",
     "tags": [
       "computability",
@@ -14,8 +14,10 @@
       "millennium-prize",
       "intermediate"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
+    "axiomCount": 18,
+    "assumptions": "18 axiom declarations encoding standard complexity theory results: Cook-Levin theorem (SAT is NP-complete), Ladner's theorem (NP-intermediate problems exist if P!=NP), polynomial hierarchy (sigma monotone, collapse), space complexity inclusions (NP in PSPACE, PSPACE in EXPTIME, Savitch, Immerman-Szelepcsenyi), TQBF PSPACE-completeness, BPP in PSPACE, PTAS in APX, one-way functions iff PRGs, Shamir IP=PSPACE, AM in Pi2, P in P/poly, Karp-Lipton, NC in P, and P!=EXP. The P vs NP question itself remains open.",
     "mathlibDependencies": [
       {
         "theorem": "Mathlib.Logic.Basic",

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Grigori Perelman (2002-2003)",
     "date": "2003",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PoincareConjecture.lean",
     "tags": [
       "topology",
@@ -14,8 +14,10 @@
       "millennium-prize",
       "advanced"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
+    "axiomCount": 45,
+    "assumptions": "45 axiom declarations encoding Perelman's Ricci flow surgery (finite extinction), generalized Poincare in dimensions 2, 4, and >=5 (Smale, Freedman), topological constructions (connected sum, Dehn surgery), classification results (JSJ decomposition, h/s-cobordism theorems), 3-manifold topology (Heegaard splittings, Waldhausen, Property P, prime decomposition), and counterexample structures (Poincare homology sphere, Whitehead manifold).",
     "mathlibDependencies": [
       {
         "theorem": "SimplyConnectedSpace",

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -4,7 +4,7 @@
   "slug": "riemann-hypothesis",
   "description": "A formalization of the Riemann Hypothesis, one of the seven Millennium Prize Problems. We state RH precisely using Mathlib's zeta function, prove key equivalences (Robin's inequality, Mertens bound), and document partial results like Hardy's theorem on infinitely many zeros on the critical line.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "number-theory",
       "analytic-number-theory",
@@ -13,9 +13,10 @@
       "zeta-function",
       "prime-distribution"
     ],
-    "badge": "conjecture",
+    "badge": "axiom",
     "sorries": 11,
-    "axiomCount": 1,
+    "axiomCount": 47,
+    "assumptions": "47 axiom declarations encoding RH equivalences (Robin, Mertens, Nyman-Beurling, Lagarias, Speiser, de Bruijn-Newman), partial results (Hardy, Selberg, Montgomery), Selberg class axioms, explicit estimates, and consequences. The Riemann Hypothesis itself remains an open conjecture.",
     "mathlibDependencies": [
       {
         "theorem": "riemannZeta",

--- a/src/data/proofs/yang-mills-mass-gap/meta.json
+++ b/src/data/proofs/yang-mills-mass-gap/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Yang%E2%80%93Mills_existence_and_mass_gap",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/YangMillsMassGap.lean",
     "tags": [
       "millennium-prize",
@@ -20,8 +20,10 @@
       "confinement",
       "research"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
+    "axiomCount": 16,
+    "assumptions": "16 axiom declarations encoding fundamental QFT and gauge theory results: Killing form, gauge transformations, Creutz ratio recovery, Osterwalder-Schrader reconstruction, Euclidean mass gap implies Wightman, SUSY soft-breaking, Fradkin-Shenker theorem, 't Hooft complementarity, Banks-Rabinovici phase structure, Elitzur theorem, continuum limit gap persistence, Balaban UV stability, two-loop continuum limit, Haag theorem, Gribov-Zwanziger action, and quark propagator confinement. Additionally, 262 structure declarations encode mathematical physics infrastructure. The Yang-Mills mass gap problem remains open.",
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",


### PR DESCRIPTION
## Summary

- Fix all seven Millennium Prize `meta.json` files that incorrectly claimed `"verified"` status despite relying on dozens of Lean `axiom` declarations
- Change status to `"axiomatized"`, fix `axiomCount` to match actual `grep -c "^axiom "` counts, set badge to `"axiom"`
- Add `"assumptions"` field to each file documenting what the axioms encode
- Navier-Stokes keeps `"conditional"` status (0 axiom declarations) but gains note about NSAxioms structure fields

## Changes

| Problem | Old Status | New Status | Old axiomCount | New axiomCount | Verified By |
|---------|-----------|------------|----------------|----------------|-------------|
| Riemann Hypothesis | verified | axiomatized | 1 | 47 | `grep -c "^axiom " RiemannHypothesis.lean` |
| Hodge Conjecture | verified | axiomatized | (none) | 119 | `grep -c "^axiom " HodgeConjecture.lean` |
| Poincare Conjecture | verified | axiomatized | (none) | 45 | `grep -c "^axiom " PoincareConjecture.lean` |
| Yang-Mills Mass Gap | verified | axiomatized | (none) | 16 | `grep -c "^axiom " YangMillsMassGap.lean` |
| P vs NP | verified | axiomatized | (none) | 18 | `grep -c "^axiom " PvsNP.lean` |
| Birch-Swinnerton-Dyer | verified | axiomatized | 45 | 90 | `grep -c "^axiom " BirchSwinnertonDyer.lean` |
| Navier-Stokes | conditional | conditional (kept) | 0 | 0 (kept) | 0 axiom decls; NSAxioms structure noted |

## Why this matters

Claiming "verified" status for formalizations with 16-119 axiom declarations damages credibility. Users seeing "verified" reasonably expect Lean-checked proofs, but these files encode deep mathematical assumptions as axioms. The corrected "axiomatized" status and accurate counts are honest about what the Lean files actually contain.

## Test plan

- [x] All 7 modified JSON files pass `python3 -c "import json; json.load(open(f))"` validation
- [x] `pnpm build` failure is pre-existing (missing `candidate-pool.json`), not caused by these changes
- [x] Axiom counts verified against actual Lean source files via `grep -c "^axiom "` on each `.lean` file


Generated with [Claude Code](https://claude.com/claude-code)