### PR TITLE
Research: p-vs-np - QIP=PSPACE, NL-completeness, Barrington's theorem

### DIFF
--- a/proofs/Proofs/Erdos44Problem.lean
+++ b/proofs/Proofs/Erdos44Problem.lean
@@ -172,24 +172,141 @@ theorem maxSidonSubsetCard_icc_bound (N : ℕ) (hN : 1 ≤ N) (A : Finset ℕ)
 
 /- ## Part 3: Lower Bound - Existence of Sidon sets -/
 
+/-- Core lemma: sums of powers of 2 determine exponents uniquely.
+    2^a + 2^b = 2^c + 2^d with a ≤ b, c ≤ d implies a = c and b = d.
+
+    Proof by strong induction on a + c using parity:
+    - a = 0, c = 0: cancel 1's, conclude b = d from injectivity of 2^(·)
+    - a = 0, c ≥ 1: LHS = 1 + 2^b is odd (for b ≥ 1) but RHS is even. Contradiction.
+    - a ≥ 1, c = 0: symmetric
+    - a ≥ 1, c ≥ 1: divide everything by 2, apply induction hypothesis -/
+private lemma pow2_sum_inj : ∀ (n : ℕ) (a b c d : ℕ),
+    a + c ≤ n → a ≤ b → c ≤ d →
+    2 ^ a + 2 ^ b = 2 ^ c + 2 ^ d → a = c ∧ b = d := by
+  intro n
+  induction n with
+  | zero =>
+    intro a b c d hacn hab hcd heq
+    have ha : a = 0 := by omega
+    have hc : c = 0 := by omega
+    subst ha; subst hc
+    simp only [pow_zero] at heq
+    have hbd : 2 ^ b = 2 ^ d := by omega
+    constructor
+    · rfl
+    · by_contra hne
+      rcases Nat.lt_or_gt_of_ne hne with h | h
+      · exact absurd (Nat.pow_lt_pow_right (by norm_num : 1 < 2) h) (by omega)
+      · exact absurd (Nat.pow_lt_pow_right (by norm_num : 1 < 2) h) (by omega)
+  | succ n ih =>
+    intro a b c d hacn hab hcd heq
+    by_cases ha : a = 0
+    · subst ha
+      by_cases hc : c = 0
+      · -- a = 0, c = 0: cancel the 1's
+        subst hc
+        simp only [pow_zero] at heq
+        have hbd : 2 ^ b = 2 ^ d := by omega
+        constructor
+        · rfl
+        · by_contra hne
+          rcases Nat.lt_or_gt_of_ne hne with h | h
+          · exact absurd (Nat.pow_lt_pow_right (by norm_num : 1 < 2) h) (by omega)
+          · exact absurd (Nat.pow_lt_pow_right (by norm_num : 1 < 2) h) (by omega)
+      · -- a = 0, c ≥ 1: parity contradiction
+        exfalso
+        have hc' : 1 ≤ c := by omega
+        have hd' : 1 ≤ d := by omega
+        -- LHS = 1 + 2^b
+        simp only [pow_zero] at heq
+        by_cases hb : b = 0
+        · -- LHS = 2, RHS ≥ 2^1 + 2^1 = 4
+          subst hb; simp only [pow_zero] at heq
+          have : 2 ^ c ≥ 2 := Nat.one_le_pow c 2 (by norm_num) |>.trans_lt (by omega) |>.le
+          have : 2 ^ d ≥ 2 := Nat.one_le_pow d 2 (by norm_num) |>.trans_lt (by omega) |>.le
+          omega
+        · -- LHS = 1 + 2^b is odd, RHS is even
+          have hb' : 1 ≤ b := by omega
+          -- 2 divides RHS since c ≥ 1 and d ≥ 1
+          have hrhs_even : 2 ∣ (2 ^ c + 2 ^ d) := by
+            have h1 : 2 ∣ 2 ^ c := dvd_pow_self 2 (by omega : c ≠ 0)
+            have h2 : 2 ∣ 2 ^ d := dvd_pow_self 2 (by omega : d ≠ 0)
+            exact dvd_add h1 h2
+          -- But LHS = 1 + 2^b is odd
+          have hlhs_odd : ¬ 2 ∣ (1 + 2 ^ b) := by
+            have h2b : 2 ∣ 2 ^ b := dvd_pow_self 2 (by omega : b ≠ 0)
+            intro ⟨m, hm⟩
+            have : 2 ∣ (1 + 2 ^ b - 2 ^ b) := Nat.dvd_sub' ⟨m, hm⟩ h2b
+            simp at this
+          exact hlhs_odd (heq ▸ hrhs_even)
+    · by_cases hc : c = 0
+      · -- a ≥ 1, c = 0: symmetric parity contradiction
+        exfalso
+        have ha' : 1 ≤ a := by omega
+        have hb' : 1 ≤ b := by omega
+        simp only [pow_zero] at heq
+        by_cases hd : d = 0
+        · subst hd; simp only [pow_zero] at heq
+          have : 2 ^ a ≥ 2 := Nat.one_le_pow a 2 (by norm_num) |>.trans_lt (by omega) |>.le
+          have : 2 ^ b ≥ 2 := Nat.one_le_pow b 2 (by norm_num) |>.trans_lt (by omega) |>.le
+          omega
+        · have hd' : 1 ≤ d := by omega
+          have hlhs_even : 2 ∣ (2 ^ a + 2 ^ b) := by
+            have h1 : 2 ∣ 2 ^ a := dvd_pow_self 2 (by omega : a ≠ 0)
+            have h2 : 2 ∣ 2 ^ b := dvd_pow_self 2 (by omega : b ≠ 0)
+            exact dvd_add h1 h2
+          have hrhs_odd : ¬ 2 ∣ (1 + 2 ^ d) := by
+            have h2d : 2 ∣ 2 ^ d := dvd_pow_self 2 (by omega : d ≠ 0)
+            intro ⟨m, hm⟩
+            have : 2 ∣ (1 + 2 ^ d - 2 ^ d) := Nat.dvd_sub' ⟨m, hm⟩ h2d
+            simp at this
+          exact hrhs_odd (heq.symm ▸ hlhs_even)
+      · -- a ≥ 1, c ≥ 1: divide by 2 and recurse
+        have ha' : 1 ≤ a := by omega
+        have hc' : 1 ≤ c := by omega
+        have hb' : 1 ≤ b := by omega
+        have hd' : 1 ≤ d := by omega
+        -- Factor: 2^a = 2 * 2^(a-1), etc.
+        have heq' : 2 ^ (a - 1) + 2 ^ (b - 1) = 2 ^ (c - 1) + 2 ^ (d - 1) := by
+          have fa : 2 ^ a = 2 * 2 ^ (a - 1) := by
+            conv_lhs => rw [show a = (a - 1) + 1 from by omega, pow_succ']
+          have fb : 2 ^ b = 2 * 2 ^ (b - 1) := by
+            conv_lhs => rw [show b = (b - 1) + 1 from by omega, pow_succ']
+          have fc : 2 ^ c = 2 * 2 ^ (c - 1) := by
+            conv_lhs => rw [show c = (c - 1) + 1 from by omega, pow_succ']
+          have fd : 2 ^ d = 2 * 2 ^ (d - 1) := by
+            conv_lhs => rw [show d = (d - 1) + 1 from by omega, pow_succ']
+          rw [fa, fb, fc, fd] at heq
+          omega
+        have ⟨hac, hbd⟩ := ih (a - 1) (b - 1) (c - 1) (d - 1)
+          (by omega) (by omega) (by omega) heq'
+        exact ⟨by omega, by omega⟩
+
 /-- Powers of 2 form a Sidon set: {2^0, 2^1, 2^2, ...} = {1, 2, 4, 8, ...}
 
 This is because 2^a + 2^b = 2^c + 2^d (with a ≤ b, c ≤ d) implies (a,b) = (c,d)
-by uniqueness of binary representation.
-
-**Proof sketch**: If 2^a + 2^b = 2^c + 2^d with a ≤ b, c ≤ d, then:
-- Case a < b, c < d: Factor as 2^a(1 + 2^(b-a)) = 2^c(1 + 2^(d-c)).
-  By 2-adic valuation (since 1 + 2^k is odd for k > 0), we get a = c.
-  Then 1 + 2^(b-a) = 1 + 2^(d-c), so b - a = d - c, hence b = d.
-- Case a = b (doubled): 2·2^a = 2^(a+1) = 2^c + 2^d.
-  If c < d, factor RHS as 2^c(1 + 2^(d-c)). Comparing 2-adic valuations:
-  v_2(LHS) = a+1, v_2(RHS) = c. So a+1 = c, but then 1 + 2^(d-c) = 1, impossible since d > c.
-  So c = d, giving 2·2^a = 2·2^c, hence a = c = b = d.
-
-**Proof status**: HARD - requires careful 2-adic valuation arguments.
-The key insight is comparing 2-adic valuations on both sides.
--/
-axiom isSidon_powers_of_two (k : ℕ) : IsSidon ((range k).image (2 ^ ·))
+by uniqueness of binary representation. Proof by strong induction on the minimum
+exponent, using parity to match the lowest bit position. -/
+theorem isSidon_powers_of_two (k : ℕ) : IsSidon ((range k).image (2 ^ ·)) := by
+  intro x y u v hx hy hu hv hxy huv heq
+  -- Extract exponents from membership in image
+  rw [mem_image] at hx hy hu hv
+  obtain ⟨a, _, rfl⟩ := hx
+  obtain ⟨b, _, rfl⟩ := hy
+  obtain ⟨c, _, rfl⟩ := hu
+  obtain ⟨d, _, rfl⟩ := hv
+  -- Convert ordering on 2^(·) to ordering on exponents
+  have hab : a ≤ b := by
+    by_contra h
+    push_neg at h
+    exact absurd (Nat.pow_lt_pow_right (by norm_num : 1 < 2) h) (by omega)
+  have hcd : c ≤ d := by
+    by_contra h
+    push_neg at h
+    exact absurd (Nat.pow_lt_pow_right (by norm_num : 1 < 2) h) (by omega)
+  -- Apply the core uniqueness lemma
+  have ⟨hac, hbd⟩ := pow2_sum_inj (a + c) a b c d le_rfl hab hcd heq
+  exact ⟨congr_arg (2 ^ ·) hac, congr_arg (2 ^ ·) hbd⟩
 
 /-- There exists a Sidon set of size at least √N / 2 in {1,...,N}.
 

--- a/proofs/Proofs/PNPBarriersSound.lean
+++ b/proofs/Proofs/PNPBarriersSound.lean
@@ -72,6 +72,10 @@ Communication complexity (6): comm_trivial_upper, D_ge_R, EQ_det_lower, EQ_rand_
 Communication (1): karchmer_wigderson (D(KW_f) = depth(f))
 Proof complexity (1): cook_reckhow (NP=coNP ↔ poly proof system)
 Five Worlds (2): trapdoor_implies_owf, owf_implies_avg_hard
+Quantum interactive (7): NP_subset_QCMA, QCMA_subset_QMA, QMA_subset_QIP,
+    QIP_subset_PSPACE, IP_subset_QIP, QMA_subset_QMA2, QMA2_subset_PSPACE
+NL-completeness (1): PATH_NL_complete
+Barrington (3): barrington_theorem, width4_subset_width5, width4_subset_ACC0
 Eliminated axioms (9→theorems/opaques):
 - P_subset_PP → theorem (via P ⊆ BPP ⊆ BQP ⊆ PP)
 - P_subset_P_poly → theorem (program e is a constant-size "circuit")
@@ -5968,6 +5972,297 @@ theorem lifting_frontier :
   ⟨razborov_monotone_clique, karchmer_wigderson, DISJ_rand_lower, natural_proofs_barrier⟩
 
 -- ============================================================
+-- PART 47: Quantum Interactive Proofs (QIP = PSPACE)
+-- ============================================================
+
+/-
+### Quantum Interactive Proofs
+
+Classical interactive proofs (IP) allow a polynomial-time verifier to
+interact with an all-powerful prover. Shamir's theorem shows IP = PSPACE.
+
+**Quantum** interactive proofs (QIP) allow the verifier to be a polynomial-time
+quantum computer. A priori, quantum verification could be more powerful than
+classical verification. The landmark result of Jain-Ji-Upadhyay-Watrous (2011)
+shows QIP = PSPACE = IP: quantum verification is no more powerful than classical.
+
+This is surprising because:
+- QMA ⊋ MA (likely): quantum proofs seem to help
+- BQP ⊄ BPP relative to some oracle (Raz-Tal): quantum computation helps
+- Yet QIP = IP: quantum INTERACTION doesn't help
+-/
+
+/-- QIP: the class of problems having quantum interactive proof systems.
+    The verifier is a polynomial-time quantum computer interacting with
+    an all-powerful (possibly quantum) prover. -/
+opaque QIP : Set (ℕ → Bool)
+
+/-- QMA (Quantum Merlin-Arthur): the quantum analog of MA/NP.
+    Merlin sends a quantum proof (a quantum state), Arthur runs a
+    polynomial-time quantum verifier (BQP computation).
+
+    Key relationships: NP ⊆ MA ⊆ QMA ⊆ PSPACE, BQP ⊆ QMA.
+    QMA is to NP as BQP is to P: adding quantum resources to verification.
+    The local Hamiltonian problem is QMA-complete (Kitaev 2002). -/
+opaque QMA : Set (ℕ → Bool)
+
+/-- QCMA (Quantum Classical Merlin Arthur): quantum verifier with a
+    CLASSICAL proof. Merlin sends a classical bit string, Arthur runs a
+    BQP verifier. NP ⊆ QCMA ⊆ QMA: classical proofs verified quantumly. -/
+opaque QCMA : Set (ℕ → Bool)
+
+/-- QMA(2): QMA with TWO unentangled quantum proofs. Blier-Tapp (2009)
+    showed that some problems have short QMA(2) proofs but seemingly no
+    short QMA(1) proofs. -/
+opaque QMA2 : Set (ℕ → Bool)
+
+/-- NP ⊆ QCMA: A classical NP witness is a valid classical proof for a
+    quantum verifier (the verifier simulates the classical check). -/
+axiom NP_subset_QCMA : NP ⊆ QCMA
+
+/-- QCMA ⊆ QMA: A classical proof is a special case of a quantum proof
+    (a quantum state in the computational basis). -/
+axiom QCMA_subset_QMA : QCMA ⊆ QMA
+
+/-- QMA ⊆ QIP: A single-message proof is a special case of interaction
+    (one round of interaction). -/
+axiom QMA_subset_QIP : QMA ⊆ QIP
+
+/-- QIP ⊆ PSPACE: The non-trivial direction. Every QIP protocol can be
+    simulated in PSPACE using semidefinite programming.
+    (Kitaev-Watrous 2000 for QIP ⊆ EXP; Jain et al. 2011 for QIP ⊆ PSPACE.) -/
+axiom QIP_subset_PSPACE : QIP ⊆ PSPACE
+
+/-- IP ⊆ QIP: A classical interactive proof verifier can be simulated by
+    a quantum verifier (quantum computers simulate classical computation).
+    Every IP protocol is trivially a QIP protocol. -/
+axiom IP_subset_QIP : IP ⊆ QIP
+
+/-- PSPACE ⊆ QIP: Since IP = PSPACE (Shamir) and IP ⊆ QIP. -/
+theorem PSPACE_subset_QIP : PSPACE ⊆ QIP :=
+  shamir_IP_eq_PSPACE ▸ IP_subset_QIP
+
+/-- **Jain-Ji-Upadhyay-Watrous Theorem** (2011): QIP = PSPACE.
+    This is one of the most surprising results in quantum complexity theory.
+
+    Proved by showing that QIP protocols can be parallelized to 3 messages
+    (QIP = QIP(3)) and that 3-message QIP can be simulated in PSPACE
+    using semidefinite programming and the multiplicative weights method.
+
+    Consequence: Quantum interaction is no more powerful than classical
+    interaction, even though quantum PROOFS (QMA) and quantum COMPUTATION
+    (BQP) appear to be more powerful than their classical counterparts. -/
+theorem jain_QIP_eq_PSPACE : QIP = PSPACE :=
+  Set.Subset.antisymm QIP_subset_PSPACE PSPACE_subset_QIP
+
+/-- The quantum verification chain: NP ⊆ QCMA ⊆ QMA ⊆ QIP = PSPACE.
+    Shows how quantum resources progressively strengthen verification. -/
+theorem quantum_verification_chain' :
+    NP ⊆ QCMA ∧ QCMA ⊆ QMA ∧ QMA ⊆ QIP ∧ QIP ⊆ PSPACE :=
+  ⟨NP_subset_QCMA, QCMA_subset_QMA, QMA_subset_QIP, QIP_subset_PSPACE⟩
+
+/-- QMA ⊆ PSPACE: Quantum Merlin-Arthur is contained in PSPACE.
+    Proved by transitivity: QMA ⊆ QIP ⊆ PSPACE. Previously axiomatized
+    (QMA_subset_PSPACE), now derivable from the QIP chain. -/
+theorem QMA_subset_PSPACE' : QMA ⊆ PSPACE :=
+  Set.Subset.trans QMA_subset_QIP QIP_subset_PSPACE
+
+/-- Quantum doesn't help interaction: QIP = IP = PSPACE.
+    Classical and quantum interactive proofs characterize exactly the same class.
+    This is in stark contrast to:
+    - BQP vs BPP (likely different)
+    - QMA vs MA (likely different)
+    - MIP* vs MIP (provably different: MIP = NEXP, MIP* = RE) -/
+theorem quantum_interaction_equivalence :
+    -- QIP ⊆ PSPACE ⊆ IP ⊆ QIP (cycle)
+    QIP ⊆ PSPACE ∧ IP = PSPACE ∧
+    -- Quantum helps for proofs but not for interaction
+    (NP ⊆ QMA ∧ QMA ⊆ PSPACE) :=
+  ⟨QIP_subset_PSPACE, shamir_IP_eq_PSPACE,
+   Set.Subset.trans NP_subset_QCMA QCMA_subset_QMA,
+   QMA_subset_PSPACE'⟩
+
+/-- QMA(2) containments: QMA ⊆ QMA(2) ⊆ PSPACE.
+    It is open whether QMA(2) = QMA or QMA(2) is strictly more powerful. -/
+axiom QMA_subset_QMA2 : QMA ⊆ QMA2
+axiom QMA2_subset_PSPACE : QMA2 ⊆ PSPACE
+
+/-- The quantum Merlin-Arthur landscape:
+    NP ⊆ QCMA ⊆ QMA ⊆ QMA(2) ⊆ QIP = PSPACE.
+    Shows that even with multiple unentangled quantum proofs,
+    we stay within PSPACE. -/
+theorem quantum_MA_landscape :
+    NP ⊆ QCMA ∧ QCMA ⊆ QMA ∧ QMA ⊆ QMA2 ∧ QMA2 ⊆ PSPACE ∧
+    QIP ⊆ PSPACE :=
+  ⟨NP_subset_QCMA, QCMA_subset_QMA, QMA_subset_QMA2,
+   QMA2_subset_PSPACE, QIP_subset_PSPACE⟩
+
+-- ============================================================
+-- PART 48: NL-Completeness and the Reachability Problem
+-- ============================================================
+
+/-
+### NL-Completeness
+
+The class NL (nondeterministic logspace) has a natural complete problem:
+**PATH** (also called STCON or s-t connectivity) — given a directed graph
+and two vertices s and t, is there a path from s to t?
+
+Savitch showed STCON is NL-complete (1970). Combined with Immerman-
+Szelepcsényi (NL = coNL), this gives a complete picture of nondeterministic
+space complexity.
+-/
+
+/-- NL-hardness: A problem is NL-hard if every NL problem reduces to it
+    in logspace. -/
+def NLHard (problem : ℕ → Bool) : Prop :=
+  ∀ f ∈ NL, ∃ (reduction : ℕ → ℕ),
+    (∀ n, f n = problem (reduction n)) ∧
+    PolyTimeComputable emptyOracle reduction
+
+/-- NL-completeness: a problem is NL-complete if it is in NL and NL-hard. -/
+def NLComplete (problem : ℕ → Bool) : Prop :=
+  problem ∈ NL ∧ NLHard problem
+
+/-- PATH (s-t connectivity): Given a directed graph and vertices s, t,
+    is there a directed path from s to t?
+
+    This is the canonical NL-complete problem. Solved by nondeterministically
+    guessing the path vertex-by-vertex, using only O(log n) space to track
+    the current vertex. -/
+opaque PATH : ℕ → Bool
+
+/-- **PATH is NL-complete** (Savitch 1970): s-t connectivity is the
+    canonical NL-complete problem.
+
+    NL-hardness: Every NL computation can be viewed as reachability in
+    the configuration graph of a nondeterministic logspace machine.
+    NL membership: Guess a path vertex-by-vertex in O(log n) space. -/
+axiom PATH_NL_complete : NLComplete PATH
+
+/-- PATH ∈ NL (consequence of NL-completeness). -/
+theorem PATH_in_NL : PATH ∈ NL := PATH_NL_complete.1
+
+/-- PATH is NL-hard (consequence of NL-completeness). -/
+theorem PATH_NL_hard : NLHard PATH := PATH_NL_complete.2
+
+/-- PATH ∈ P: s-t connectivity is solvable in polynomial time
+    (BFS/DFS). Combined with NL ⊆ P, this is consistent. -/
+theorem PATH_in_P : PATH ∈ P :=
+  NL_subset_P (PATH_NL_complete.1)
+
+/-- NL-completeness and co-completeness: Since NL = coNL (Immerman-
+    Szelepcsényi), the complement of PATH (s-t non-connectivity) is
+    also in NL. This was surprising: it means a nondeterministic logspace
+    machine can verify that there is NO path. -/
+theorem PATH_complement_in_NL :
+    (fun n => !PATH n) ∈ NL := by
+  -- PATH ∈ NL (from completeness)
+  have hpath : PATH ∈ NL := PATH_NL_complete.1
+  -- NL = coNL (Immerman-Szelepcsényi)
+  -- PATH ∈ NL = coNL = {f | (fun n => !f n) ∈ NL}
+  -- Therefore (fun n => !PATH n) ∈ NL
+  have hcoNL : PATH ∈ coNL := immerman_szelepcsenyi ▸ hpath
+  exact hcoNL
+
+/-- **Space complexity hierarchy**: L ⊆ NL = coNL ⊆ P, with
+    PATH as the NL-complete problem and NL-completeness preserved
+    under complement (since NL = coNL). -/
+theorem space_complexity_landscape :
+    L ⊆ NL ∧ NL = coNL ∧ NL ⊆ P ∧
+    NLComplete PATH ∧
+    PATH ∈ P :=
+  ⟨L_subset_NL, immerman_szelepcsenyi, NL_subset_P,
+   PATH_NL_complete, PATH_in_P⟩
+
+-- ============================================================
+-- PART 49: Barrington's Theorem and Branching Programs
+-- ============================================================
+
+/-
+### Barrington's Theorem (1989)
+
+Barrington proved a remarkable characterization of NC¹: a language is in
+NC¹ if and only if it can be computed by polynomial-length, width-5
+branching programs.
+
+This connects circuit depth (NC¹ = circuits of O(log n) depth) to the
+algebraic structure of the symmetric group S₅. The key insight is that S₅
+is non-solvable (it contains A₅, the smallest non-abelian simple group),
+which allows encoding arbitrary Boolean computations.
+
+Width 4 is NOT sufficient: width-4 branching programs can only compute
+languages in ACC⁰ (a weaker class). The jump from width 4 to width 5
+corresponds to the algebraic jump from solvable to non-solvable groups.
+-/
+
+/-- Width-bounded branching programs: the set of problems computable by
+    polynomial-length branching programs of width at most w. -/
+opaque BPWidth (w : ℕ) : Set (ℕ → Bool)
+
+/-- **Barrington's Theorem** (1989): NC¹ = BPWidth(5).
+    A language is in NC¹ (polynomial-size, O(log n)-depth Boolean circuits)
+    if and only if it can be computed by polynomial-length, width-5
+    branching programs.
+
+    Proof sketch: The forward direction (NC¹ ⊆ BPWidth(5)) simulates
+    each gate of a log-depth circuit using a constant-length width-5
+    branching program, using the non-solvability of S₅ to compose
+    sub-programs for AND and NOT gates.
+
+    The reverse direction (BPWidth(5) ⊆ NC¹) converts a branching program
+    into a log-depth circuit via divide-and-conquer on the program length. -/
+axiom barrington_theorem : NC_k 1 = BPWidth 5
+
+/-- Width-4 branching programs are weaker than width-5: BPWidth(4) ⊊ BPWidth(5).
+    Width-4 BP compute only ACC⁰ languages (solvable group programs).
+    Width-5 BP compute NC¹ languages (non-solvable group S₅). -/
+axiom width4_subset_width5 : BPWidth 4 ⊆ BPWidth 5
+axiom width4_subset_ACC0 : BPWidth 4 ⊆ ACC0
+
+/-- The algebraic threshold: the jump from width 4 to width 5 corresponds
+    to the jump from solvable to non-solvable groups.
+    S₃ and S₄ are solvable → width ≤ 4 gives only ACC⁰
+    S₅ is non-solvable → width 5 gives NC¹ (which contains ACC⁰) -/
+theorem barrington_algebraic_threshold :
+    BPWidth 4 ⊆ ACC0 ∧
+    NC_k 1 = BPWidth 5 ∧
+    ACC0 ⊆ NC_k 1 := by
+  refine ⟨width4_subset_ACC0, barrington_theorem, ?_⟩
+  -- ACC0 ⊆ TC0 ⊆ NC1
+  exact Set.Subset.trans ACC0_subset_TC0 (TC_k_subset_NC_k_succ 0)
+
+/-- Barrington connects to the circuit hierarchy:
+    ACC⁰ ⊆ TC⁰ ⊆ NC¹ = BPWidth(5), and NC¹ ⊆ NC ⊆ P.
+    The branching program characterization gives an algebraic handle
+    on NC¹ that circuit descriptions alone don't provide. -/
+theorem barrington_in_hierarchy :
+    ACC0 ⊆ TC_k 0 ∧
+    TC_k 0 ⊆ NC_k 1 ∧
+    NC_k 1 = BPWidth 5 ∧
+    NC_k 1 ⊆ NC ∧
+    NC ⊆ P :=
+  ⟨ACC0_subset_TC0,
+   TC_k_subset_NC_k_succ 0,
+   barrington_theorem,
+   Set.subset_iUnion_of_subset 1 (Set.Subset.refl _),
+   NC_subset_P⟩
+
+/-- **P vs NC¹ separation**: If P ≠ NC, then in particular P ≠ NC¹.
+    Barrington's theorem means: P ≠ NC¹ iff P has problems that
+    cannot be computed by polynomial-length width-5 branching programs.
+
+    Note: P vs NC is a major open problem, weaker than P vs NP
+    (since NC ⊆ P ⊆ NP). -/
+theorem P_ne_NC_implies_P_ne_NC1 (h : P ≠ NC) : P ≠ NC_k 1 := by
+  intro h1
+  apply h
+  exact Set.Subset.antisymm (by
+    intro f hf
+    rw [h1] at hf
+    exact Set.mem_iUnion.mpr ⟨1, hf⟩) NC_subset_P
+
+-- ============================================================
 -- PART 42: The P vs NP Grand Unification
 -- ============================================================
 
@@ -5990,6 +6285,9 @@ The sound model now encompasses:
 13. **Descriptive complexity** (Fagin, Immerman-Vardi)
 14. **Counting complexity** (#P, GapP, Toda)
 15. **Oracle separations** (BGS, Raz-Tal, Bennett-Gill)
+16. **Quantum interactive proofs** (QIP = PSPACE, QCMA, QMA(2))
+17. **NL-completeness** (PATH, space hierarchy)
+18. **Branching programs** (Barrington's theorem, NC¹ = width-5 BP)
 
 Together, these form the most comprehensive formal complexity theory
 encyclopedia in Lean.
@@ -6020,7 +6318,11 @@ theorem p_vs_np_master_summary :
     -- X. Shannon counting: hard functions exist (nonconstructive)
     (∃ f, f ∉ P_poly) ∧
     -- XI. MIP*=RE: entanglement strictly strengthens multi-prover proofs
-    (MIP ⊂ MIP_star) :=
+    (MIP ⊂ MIP_star) ∧
+    -- XII. QIP = PSPACE: quantum interaction doesn't help
+    (QIP = PSPACE) ∧
+    -- XIII. NL-completeness: PATH is the canonical space-complete problem
+    (NLComplete PATH ∧ NL = coNL) :=
   ⟨P_nontrivial,
    ⟨P_subset_NP, NP_subset_PH, PH_subset_PSPACE, PSPACE_subset_EXP⟩,
    P_strict_subset_EXP,
@@ -6032,7 +6334,9 @@ theorem p_vs_np_master_summary :
    baker_gill_solovay_eq,
    baker_gill_solovay_sep,
    shannon_hard_functions_outside_P_poly,
-   entanglement_strictly_strengthens_MIP⟩
+   entanglement_strictly_strengthens_MIP,
+   jain_QIP_eq_PSPACE,
+   ⟨PATH_NL_complete, immerman_szelepcsenyi⟩⟩
 
 -- ============================================================
 -- Verification: TFNP, Descriptive, Counting, Oracle, Unconditional
@@ -6068,6 +6372,23 @@ theorem p_vs_np_master_summary :
 -- Unconditional Lower Bounds
 #check unconditional_lower_bounds     -- P⊊EXP + NEXP⊄ACC⁰ + ... (proved)
 #check unconditional_vs_conditional   -- Gap between known and wanted (proved)
+
+-- Quantum Interactive Proofs
+#check QIP_subset_PSPACE              -- QIP ⊆ PSPACE (Jain et al. 2011)
+#check jain_QIP_eq_PSPACE             -- QIP = PSPACE (proved)
+#check quantum_verification_chain'    -- NP ⊆ QCMA ⊆ QMA ⊆ QIP ⊆ PSPACE
+#check quantum_interaction_equivalence -- QIP = IP = PSPACE (proved)
+
+-- NL-Completeness
+#check PATH_NL_complete               -- PATH is NL-complete
+#check PATH_in_P                      -- PATH ∈ P (proved from NL ⊆ P)
+#check PATH_complement_in_NL          -- Complement of PATH ∈ NL (proved)
+#check space_complexity_landscape     -- Full space hierarchy (proved)
+
+-- Barrington's Theorem
+#check barrington_theorem             -- NC¹ = BPWidth(5)
+#check barrington_algebraic_threshold -- Width-4 → ACC⁰, Width-5 → NC¹ (proved)
+#check barrington_in_hierarchy        -- Full circuit-BP hierarchy (proved)
 
 -- Grand Unification
 #check p_vs_np_master_summary         -- Master summary (proved)

--- a/proofs/Proofs/YangMillsMassGap.lean
+++ b/proofs/Proofs/YangMillsMassGap.lean
@@ -14479,7 +14479,7 @@ theorem gluon_dof_monotone_colors (N₁ N₂ d : ℕ) (hN₁ : N₁ ≥ 2) (hN�
     gluonDOF N₁ d < gluonDOF N₂ d := by
   unfold gluonDOF
   apply Nat.mul_lt_mul_of_pos_right
-  · have : N₁ ^ 2 < N₂ ^ 2 := Nat.pow_lt_pow_left h (by omega)
+  · have : N₁ ^ 2 < N₂ ^ 2 := by nlinarith [sq_nonneg N₁, sq_nonneg N₂]
     omega
   · omega
 
@@ -14608,20 +14608,25 @@ theorem frg_lattice_consistency (m_frg m_lat : ℝ) (hf : 0 < m_frg) (hl : 0 < m
     (hratio : 0.8 * m_lat ≤ m_frg) (hratio2 : m_frg ≤ 1.2 * m_lat) :
     m_frg / m_lat ≤ 1.2 ∧ 0.8 ≤ m_frg / m_lat := by
   constructor
-  · exact div_le_of_le_mul₀ (by linarith) (by linarith) hratio2
-  · exact le_div_of_mul_le₀ (by linarith) (by linarith) hratio
+  · rw [div_le_iff hl]; linarith
+  · rw [le_div_iff hl]; linarith
 
 /-- FRG flow equation structure: ∂_t Γ_k = ½ Tr[...].
     The trace sums over all field species with appropriate signs. -/
 theorem frg_trace_decomposition (N d : ℕ) (hN : N ≥ 2) (hd : d ≥ 2) :
     totalFlowDOF N d = (N ^ 2 - 1 : ℤ) * ((d : ℤ) - 1 - 2) := by
   unfold totalFlowDOF gluonDOF ghostDOF
+  have hN2 : N ^ 2 ≥ 4 := by nlinarith
+  have hd1 : d ≥ 2 := hd
+  zify [show 1 ≤ N ^ 2 from by omega, show 1 ≤ d from by omega]
   ring
 
 /-- In d = 4, the trace simplifies: net DOF = (N²-1) per color. -/
 theorem frg_trace_4d (N : ℕ) (hN : N ≥ 2) :
     totalFlowDOF N 4 = (N ^ 2 - 1 : ℤ) := by
   unfold totalFlowDOF gluonDOF ghostDOF
+  have hN2 : N ^ 2 ≥ 4 := by nlinarith
+  zify [show 1 ≤ N ^ 2 from by omega]
   ring
 
 /-
@@ -14743,7 +14748,12 @@ theorem latent_heat_monotone (N₁ N₂ : ℕ) (hN₁ : N₁ ≥ 2) (hN₂ : N�
     (h : N₁ < N₂) :
     latentHeatScaling N₁ < latentHeatScaling N₂ := by
   unfold latentHeatScaling
-  exact Nat.pow_lt_pow_left h (by omega)
+  have h1 := Nat.mul_lt_mul_of_pos_right h (show 0 < N₁ by omega)
+  have h2 := Nat.mul_le_mul_left N₂ (le_of_lt h)
+  calc N₁ ^ 2 = N₁ * N₁ := by ring
+    _ < N₂ * N₁ := h1
+    _ ≤ N₂ * N₂ := h2
+    _ = N₂ ^ 2 := by ring
 
 /-- On R³ × S¹(β), the inverse temperature β = 1/T. -/
 noncomputable def inverseTemp (T : ℝ) (hT : 0 < T) : ℝ := 1 / T
@@ -14844,10 +14854,10 @@ theorem su3_casimir_ratio :
 theorem casimir_ratio_gt_one (N : ℕ) (hN : N ≥ 2) :
     casimirRatio N > 1 := by
   unfold casimirRatio
-  rw [gt_iff_lt, div_lt_iff₀]
-  · nlinarith [sq_nonneg (N : ℚ)]
-  · have : (N : ℚ) ≥ 2 := by exact_mod_cast hN
-    nlinarith [sq_nonneg (N : ℚ)]
+  have hNq : (N : ℚ) ≥ 2 := by exact_mod_cast hN
+  have hN2 : (N : ℚ) ^ 2 - 1 > 0 := by nlinarith [sq_nonneg (N : ℚ)]
+  rw [gt_iff_lt, lt_div_iff hN2]
+  nlinarith [sq_nonneg (N : ℚ)]
 
 /-- The critical temperature for SU(N) in the large-N limit scales as T_c ∝ √σ.
     More precisely: T_c/√σ approaches a universal constant as N → ∞. -/
@@ -14911,7 +14921,7 @@ theorem sb_dof_monotone (N₁ N₂ : ℕ) (hN₁ : N₁ ≥ 2) (hN₂ : N₂ ≥
     (h : N₁ < N₂) :
     stefanBoltzmannDOF N₁ < stefanBoltzmannDOF N₂ := by
   unfold stefanBoltzmannDOF
-  have : N₁ ^ 2 < N₂ ^ 2 := Nat.pow_lt_pow_left h (by omega)
+  have : N₁ ^ 2 < N₂ ^ 2 := by nlinarith [sq_nonneg N₁, sq_nonneg N₂]
   omega
 
 /-- Adjoint Polyakov loop ⟨L_adj⟩: invariant under Z_N, does not serve as
@@ -14963,9 +14973,10 @@ theorem gap_decreases_with_action (S0₁ S0₂ : ℝ) (N : ℕ) (hN : N ≥ 1)
     (hS : S0₁ < S0₂) :
     monopoleMassGap S0₂ N hN < monopoleMassGap S0₁ N hN := by
   unfold monopoleMassGap
-  apply Real.exp_lt_exp_of_lt
-  have hN_pos : (0 : ℝ) < N := by exact_mod_cast Nat.lt_of_lt_pred (by omega)
-  exact div_lt_div_of_neg_right hS (by linarith)
+  have hN_pos : (0 : ℝ) < ↑N := Nat.cast_pos.mpr (by omega)
+  have hlt : -S0₂ / ↑N < -S0₁ / ↑N := by
+    apply div_lt_div_of_pos_right _ hN_pos; linarith
+  exact Real.exp_strictMono hlt
 
 /-- Continuity conjecture: the mass gap on R³ × S¹(L) is continuous as L → ∞.
     If proven, this would bridge the semi-classical mass gap to the R⁴ mass gap.

--- a/research/problems/p-vs-np/knowledge.md
+++ b/research/problems/p-vs-np/knowledge.md
@@ -1,5 +1,79 @@
 # Knowledge Base: P vs NP
 
+## Session 2026-03-18 (researcher-5) - QIP=PSPACE, NL-Completeness, Barrington's Theorem
+
+**Mode**: REVISIT (depth-first, RICH knowledge score 266)
+**Problem**: p-vs-np
+**Prior Status**: Sound model at 6075 lines, 122 axioms, 0 sorries
+
+**Work done**:
+Extended `PNPBarriersSound.lean` from 6075 → 6396 lines (+321 lines) with three new sections:
+
+### Part 47: Quantum Interactive Proofs (QIP = PSPACE)
+
+| New Component | Type | Status |
+|---------------|------|--------|
+| `QMA` | opaque def | Quantum Merlin-Arthur (recovered: lost in merge) |
+| `QCMA` | opaque def | Quantum Classical Merlin Arthur |
+| `QMA2` | opaque def | QMA with two unentangled proofs |
+| `QIP` | opaque def | Quantum Interactive Proofs |
+| `NP_subset_QCMA` | axiom | Classical proofs for quantum verifier |
+| `QCMA_subset_QMA` | axiom | Classical proof ⊆ quantum proof |
+| `QMA_subset_QIP` | axiom | Single message ⊆ interaction |
+| `QIP_subset_PSPACE` | axiom | Jain et al. 2011 (hard direction) |
+| `IP_subset_QIP` | axiom | Classical verifiers ⊆ quantum verifiers |
+| `QMA_subset_QMA2` | axiom | Standard |
+| `QMA2_subset_PSPACE` | axiom | Standard |
+| `PSPACE_subset_QIP` | theorem | Proved (IP=PSPACE + IP⊆QIP) |
+| `jain_QIP_eq_PSPACE` | theorem | Proved (QIP⊆PSPACE + PSPACE⊆QIP) |
+| `QMA_subset_PSPACE'` | theorem | Proved (QMA⊆QIP⊆PSPACE) |
+| `quantum_verification_chain'` | theorem | Proved (NP⊆QCMA⊆QMA⊆QIP⊆PSPACE) |
+| `quantum_interaction_equivalence` | theorem | Proved (QIP=IP=PSPACE) |
+| `quantum_MA_landscape` | theorem | Proved (full NP→PSPACE chain) |
+
+### Part 48: NL-Completeness and Reachability
+
+| New Component | Type | Status |
+|---------------|------|--------|
+| `NLHard` | def | NL-hardness via logspace reductions |
+| `NLComplete` | def | NL membership + NL-hardness |
+| `PATH` | opaque def | s-t connectivity |
+| `PATH_NL_complete` | axiom | Savitch 1970 |
+| `PATH_in_NL` | theorem | Proved (from NL-completeness) |
+| `PATH_NL_hard` | theorem | Proved (from NL-completeness) |
+| `PATH_in_P` | theorem | Proved (NL ⊆ P) |
+| `PATH_complement_in_NL` | theorem | Proved (NL = coNL) |
+| `space_complexity_landscape` | theorem | Proved (L⊆NL=coNL⊆P + PATH) |
+
+### Part 49: Barrington's Theorem and Branching Programs
+
+| New Component | Type | Status |
+|---------------|------|--------|
+| `BPWidth` | opaque def | Width-bounded branching programs |
+| `barrington_theorem` | axiom | NC¹ = BPWidth(5) |
+| `width4_subset_width5` | axiom | Width-4 ⊆ Width-5 |
+| `width4_subset_ACC0` | axiom | Width-4 ⊆ ACC⁰ (solvable groups) |
+| `barrington_algebraic_threshold` | theorem | Proved (width-4→ACC⁰, width-5→NC¹) |
+| `barrington_in_hierarchy` | theorem | Proved (ACC⁰⊆TC⁰⊆NC¹=BPWidth5⊆NC⊆P) |
+| `P_ne_NC_implies_P_ne_NC1` | theorem | Proved |
+
+**New axioms added**: 11 (7 quantum, 1 NL-complete, 3 Barrington)
+**New definitions**: 8
+**New theorems proved**: 13
+
+**Key contributions**:
+1. **QMA recovered**: QMA opaque definition was lost in earlier merges. Recovered and connected to full quantum verification chain.
+2. **QIP = PSPACE proved**: The landmark 2011 result, derived from QIP⊆PSPACE + IP⊆QIP + IP=PSPACE.
+3. **PATH NL-completeness**: Canonical space-complete problem with complement in NL (from Immerman-Szelepcsényi).
+4. **Barrington's theorem**: The algebraic threshold — S₅ non-solvability enables NC¹ computation at width 5.
+5. **Master summary extended to 14 components** (XII. QIP=PSPACE, XIII. NL-completeness + NL=coNL).
+
+**Build**: Docker build passes, 0 errors, 0 sorries, 6396 lines.
+
+**Outcome**: COMPLETED - Three new areas, grand unification extended.
+
+---
+
 ## Session 2026-03-17 (researcher-5) - TFNP Recovery, Counting Complexity, Grand Unification
 
 **Mode**: REVISIT (depth-first, RICH knowledge score 155)

--- a/src/data/research/problems/erdos-44.json
+++ b/src/data/research/problems/erdos-44.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-44",
-  "title": "Erdős #44",
+  "title": "Erd\u0151s #44",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-12T06:58:30.839Z",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,16 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Proof got complex with edge cases, left as sorry",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Proved isSidon_powers_of_two (eliminated 1 axiom). 2 axioms remain: sidon_set_lower_bound_exists (\u221aN/2 Sidon set construction) and erdos_44 (main open conjecture).",
+    "builtItems": [
+      "pow2_sum_inj: core lemma, 2^a+2^b=2^c+2^d \u2192 a=c \u2227 b=d, by strong induction on exponent sum",
+      "isSidon_powers_of_two: {2^0,...,2^{k-1}} is Sidon, proved from pow2_sum_inj"
+    ],
+    "insights": [
+      "Strong induction on a+c with parity: when both exponents \u22651, divide by 2 and recurse",
+      "Parity argument: if min exponent is 0 but other is \u22651, LHS odd vs RHS even",
+      "dvd_pow_self 2 is the clean way to show 2 | 2^k in Lean (not pow_succ rewriting)"
+    ],
     "mathlibGaps": [],
     "nextSteps": [
       "Submit `isSidon_powers_of_two` to Aristotle - well-defined approach exists",
       "For `sidon_set_lower_bound_exists`, consider:",
       "`erdos_44` is truly OPEN - cannot be proved"
     ],
-    "markdown": "# Erdős #44 - Knowledge Base\n\n## Problem Statement\n\nLet $N\\geq 1$ and $A\\subset \\{1,\\ldots,N\\}$ be a Sidon set. Is it true that, for any $\\epsilon>0$, there exist $M$ and $B\\subset \\{N+1,\\ldots,M\\}$ (which may depend on $N,A,\\epsilon$) such that $A\\cup B\\subset \\{1,\\ldots,M\\}$ is a Sidon set of size at least $(1-\\epsilon)M^{1/2}$? See also [329] and [707] (indeed a positive solution to [707] implies a positive solution to this problem, which in turn implies a positive solution to [329]). This is discussed in problem C9 of Guy's collection [Gu04]. View the LaTeX source This page was last edited 09 January 2026.\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #62\n- Problem #2\n- Problem #329\n- Problem #707\n- Problem #43\n- Problem #45\n- Problem #39\n- Problem #1\n\n## References\n\n- Er91\n- Er95\n- Er97c\n- Gu04\n\n## Sessions\n\n### Session 2026-01-13 - Significant Progress on Sidon Set Bounds\n\n**Mode**: REVISIT\n**Outcome**: Progress - 4 sorries to 3 sorries\n\n#### What I Did\n\n1. **Proved `maxSidonSubsetCard_icc_bound`**: For any Sidon set A in [1,N], |A| <= 2*sqrt(N)\n   - Strategy: Case split on N < 3 vs N >= 3\n   - Small cases (N=1,2): Direct bound |A| <= N <= 2*sqrt(N)\n   - N >= 3: Use sidon_subset_icc_card_bound giving |A| <= sqrt(2N) + 1\n   - Show sqrt(2N) + 1 <= 2*sqrt(N) via (2 - sqrt(2))*sqrt(N) > 1 for N >= 3\n   - Key bounds: sqrt(2) < 1.415, sqrt(3) > 1.732\n\n2. **Attempted `isSidon_powers_of_two`**: Powers of 2 form a Sidon set\n   - Proof sketch: Use 2-adic valuations\n   - If 2^a + 2^b = 2^c + 2^d with a <= b, c <= d\n   - Factor: 2^a(1 + 2^(b-a)) = 2^c(1 + 2^(d-c))\n   - For k > 0, 1 + 2^k is odd (2^k even for k > 0)\n   - Compare 2-adic valuations to get a = c, then b = d\n   - **Status**: Proof got complex with edge cases, left as sorry\n\n#### Current State\n\n| Component | Status |\n|-----------|--------|\n| `sidon_subset_icc_card_bound` | PROVED |\n| `maxSidonSubsetCard_icc_bound` | **PROVED** (this session) |\n| `isSidon_powers_of_two` | SORRY (HARD) |\n| `sidon_set_lower_bound_exists` | SORRY (HARD) |\n| `erdos_44` | SORRY (OPEN - main conjecture) |\n\n#### Sorry Classification\n\n| Sorry | Classification | Reason |\n|-------|---------------|--------|\n| `isSidon_powers_of_two` | HARD | 2-adic valuation argument, well-defined approach |\n| `sidon_set_lower_bound_exists` | HARD | Requires constructive argument for Sidon sets of size sqrt(N)/2 |\n| `erdos_44` | OPEN | Main unsolved conjecture |\n\n#### Key Mathlib Lemmas Used\n\n- `Real.sqrt_lt'`: sqrt(x) < y <-> x < y^2 (for y > 0)\n- `Real.lt_sqrt`: x < sqrt(y) <-> x^2 < y (for x >= 0)\n- `Real.sqrt_le_sqrt`: x <= y -> sqrt(x) <= sqrt(y)\n- `Real.sqrt_mul`: sqrt(a*b) = sqrt(a)*sqrt(b) (for a >= 0)\n- `Real.one_le_sqrt`: 1 <= sqrt(x) <-> 1 <= x\n- `Real.nat_sqrt_le_real_sqrt`: Nat.sqrt(n) <= sqrt(n) as reals\n- `Nat.pow_le_pow_iff_right`: 2^a <= 2^b <-> a <= b\n\n#### Next Steps\n\n1. Submit `isSidon_powers_of_two` to Aristotle - well-defined approach exists\n2. For `sidon_set_lower_bound_exists`, consider:\n   - Singer difference sets construction\n   - Greedy algorithm analysis\n   - Or weaken to log_2(N) bound using powers of 2\n3. `erdos_44` is truly OPEN - cannot be proved\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
+    "markdown": "# Erd\u0151s #44 - Knowledge Base\n\n## Problem Statement\n\nLet $N\\geq 1$ and $A\\subset \\{1,\\ldots,N\\}$ be a Sidon set. Is it true that, for any $\\epsilon>0$, there exist $M$ and $B\\subset \\{N+1,\\ldots,M\\}$ (which may depend on $N,A,\\epsilon$) such that $A\\cup B\\subset \\{1,\\ldots,M\\}$ is a Sidon set of size at least $(1-\\epsilon)M^{1/2}$? See also [329] and [707] (indeed a positive solution to [707] implies a positive solution to this problem, which in turn implies a positive solution to [329]). This is discussed in problem C9 of Guy's collection [Gu04]. View the LaTeX source This page was last edited 09 January 2026.\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #62\n- Problem #2\n- Problem #329\n- Problem #707\n- Problem #43\n- Problem #45\n- Problem #39\n- Problem #1\n\n## References\n\n- Er91\n- Er95\n- Er97c\n- Gu04\n\n## Sessions\n\n### Session 2026-01-13 - Significant Progress on Sidon Set Bounds\n\n**Mode**: REVISIT\n**Outcome**: Progress - 4 sorries to 3 sorries\n\n#### What I Did\n\n1. **Proved `maxSidonSubsetCard_icc_bound`**: For any Sidon set A in [1,N], |A| <= 2*sqrt(N)\n   - Strategy: Case split on N < 3 vs N >= 3\n   - Small cases (N=1,2): Direct bound |A| <= N <= 2*sqrt(N)\n   - N >= 3: Use sidon_subset_icc_card_bound giving |A| <= sqrt(2N) + 1\n   - Show sqrt(2N) + 1 <= 2*sqrt(N) via (2 - sqrt(2))*sqrt(N) > 1 for N >= 3\n   - Key bounds: sqrt(2) < 1.415, sqrt(3) > 1.732\n\n2. **Attempted `isSidon_powers_of_two`**: Powers of 2 form a Sidon set\n   - Proof sketch: Use 2-adic valuations\n   - If 2^a + 2^b = 2^c + 2^d with a <= b, c <= d\n   - Factor: 2^a(1 + 2^(b-a)) = 2^c(1 + 2^(d-c))\n   - For k > 0, 1 + 2^k is odd (2^k even for k > 0)\n   - Compare 2-adic valuations to get a = c, then b = d\n   - **Status**: Proof got complex with edge cases, left as sorry\n\n#### Current State\n\n| Component | Status |\n|-----------|--------|\n| `sidon_subset_icc_card_bound` | PROVED |\n| `maxSidonSubsetCard_icc_bound` | **PROVED** (this session) |\n| `isSidon_powers_of_two` | SORRY (HARD) |\n| `sidon_set_lower_bound_exists` | SORRY (HARD) |\n| `erdos_44` | SORRY (OPEN - main conjecture) |\n\n#### Sorry Classification\n\n| Sorry | Classification | Reason |\n|-------|---------------|--------|\n| `isSidon_powers_of_two` | HARD | 2-adic valuation argument, well-defined approach |\n| `sidon_set_lower_bound_exists` | HARD | Requires constructive argument for Sidon sets of size sqrt(N)/2 |\n| `erdos_44` | OPEN | Main unsolved conjecture |\n\n#### Key Mathlib Lemmas Used\n\n- `Real.sqrt_lt'`: sqrt(x) < y <-> x < y^2 (for y > 0)\n- `Real.lt_sqrt`: x < sqrt(y) <-> x^2 < y (for x >= 0)\n- `Real.sqrt_le_sqrt`: x <= y -> sqrt(x) <= sqrt(y)\n- `Real.sqrt_mul`: sqrt(a*b) = sqrt(a)*sqrt(b) (for a >= 0)\n- `Real.one_le_sqrt`: 1 <= sqrt(x) <-> 1 <= x\n- `Real.nat_sqrt_le_real_sqrt`: Nat.sqrt(n) <= sqrt(n) as reals\n- `Nat.pow_le_pow_iff_right`: 2^a <= 2^b <-> a <= b\n\n#### Next Steps\n\n1. Submit `isSidon_powers_of_two` to Aristotle - well-defined approach exists\n2. For `sidon_set_lower_bound_exists`, consider:\n   - Singer difference sets construction\n   - Greedy algorithm analysis\n   - Or weaken to log_2(N) bound using powers of 2\n3. `erdos_44` is truly OPEN - cannot be proved\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "approaches": [],
   "tags": [
@@ -51,7 +58,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T06:58:30.839Z",
-  "lastUpdate": "2026-03-13T07:52:17.043Z",
+  "lastUpdate": "2026-03-18T23:00:00Z",
   "significance": 6,
   "tractability": 4
 }

--- a/src/data/research/problems/p-vs-np.json
+++ b/src/data/research/problems/p-vs-np.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-01T21:55:27.888Z",
-    "iteration": 11,
-    "focus": "Eliminated 3 trivially-provable axioms, extended master summary to 12 components",
+    "iteration": 12,
+    "focus": "Added QIP=PSPACE, NL-completeness (PATH), Barrington theorem (NC1=BPWidth5), extended master summary to 14 components",
     "blockers": [
       "P vs NP is an unsolved Millennium Prize problem"
     ],
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 3 more axioms (125→122): nash_PPAD_hard (trivially True), GapP_closed_subtraction (trivially True), mcsp_np_hardness_barrier (derived from razborov_rudich). Extended p_vs_np_master_summary to 12 components (added Shannon counting + MIP* separation). 6075 lines, 122 axioms, 0 sorries.",
+    "progressSummary": "PROGRESS: Added 3 new sections: QIP=PSPACE (quantum interactive proofs, Jain et al. 2011), NL-completeness (PATH as canonical NL-complete problem), and Barrington theorem (NC1 = width-5 branching programs). Extended master summary to 14 components. 6396 lines, 133 axioms, 0 sorries.",
     "builtItems": [
       {
         "name": "P",
@@ -525,7 +525,29 @@
       "nash_PPAD_hard theorem (was axiom, trivially True)",
       "GapP_closed_subtraction theorem (was axiom, trivially True)",
       "mcsp_np_hardness_barrier theorem (was axiom, derived from razborov_rudich)",
-      "p_vs_np_master_summary extended to 12 components (Shannon + MIP*)"
+      "p_vs_np_master_summary extended to 12 components (Shannon + MIP*)",
+      "QMA opaque def (recovered: was lost in merge)",
+      "QCMA opaque def (classical proofs, quantum verification)",
+      "QMA2 opaque def (two unentangled quantum proofs)",
+      "QIP opaque def (quantum interactive proofs)",
+      "BPWidth opaque def (width-bounded branching programs)",
+      "PATH opaque def (s-t connectivity, NL-complete problem)",
+      "NLHard def (NL-hardness via logspace reductions)",
+      "NLComplete def (NL membership + NL-hardness)",
+      "NP_subset_QCMA axiom, QCMA_subset_QMA axiom, QMA_subset_QIP axiom",
+      "QIP_subset_PSPACE axiom (Jain et al. 2011), IP_subset_QIP axiom",
+      "QMA_subset_QMA2 axiom, QMA2_subset_PSPACE axiom",
+      "PATH_NL_complete axiom (Savitch 1970)",
+      "barrington_theorem axiom (NC1 = BPWidth 5, 1989)",
+      "width4_subset_width5 axiom, width4_subset_ACC0 axiom",
+      "jain_QIP_eq_PSPACE theorem (proved: QIP=PSPACE from QIP⊆PSPACE + IP⊆QIP + IP=PSPACE)",
+      "PSPACE_subset_QIP theorem (proved: PSPACE = IP ⊆ QIP)",
+      "QMA_subset_PSPACE theorem (proved: QMA ⊆ QIP ⊆ PSPACE)",
+      "PATH_in_P theorem (proved: from NL ⊆ P)",
+      "PATH_complement_in_NL theorem (proved: from NL = coNL)",
+      "barrington_algebraic_threshold theorem (proved: width-4→ACC0, width-5→NC1, ACC0⊆NC1)",
+      "barrington_in_hierarchy theorem (proved: ACC0⊆TC0⊆NC1=BPWidth5⊆NC⊆P)",
+      "p_vs_np_master_summary extended to 14 components (QIP=PSPACE, NL-completeness)"
     ],
     "insights": [
       "Same abstract model triviality as PNPBarriers - Program.decide allows arbitrary functions",
@@ -624,7 +646,13 @@
       "nash_PPAD_hard was trivially True (∀ f ∈ PPAD, True) — eliminated as theorem",
       "GapP_closed_subtraction was trivially True (∀ f g, f∈GapP → g∈GapP → True) — eliminated as theorem",
       "mcsp_np_hardness_barrier redundant: OWF hypothesis unnecessary since razborov_rudich is unconditional in model",
-      "Master summary extended to 12 components: added X (Shannon hard functions outside P/poly) and XI (MIP ⊊ MIP*)"
+      "Master summary extended to 12 components: added X (Shannon hard functions outside P/poly) and XI (MIP ⊊ MIP*)",
+      "QIP = PSPACE (Jain-Ji-Upadhyay-Watrous 2011): quantum interaction does NOT help beyond classical interaction, in contrast to quantum proofs (QMA) and quantum computation (BQP)",
+      "NP ⊆ QCMA ⊆ QMA ⊆ QIP = PSPACE: full quantum verification chain formalized with 7 new axioms",
+      "QMA(2) (two unentangled quantum proofs) also contained in PSPACE; open whether QMA(2) = QMA",
+      "PATH (s-t connectivity) is NL-complete, PATH ∈ P (from NL ⊆ P), complement of PATH also in NL (from NL = coNL)",
+      "Barrington theorem (1989): NC1 = BPWidth(5). The algebraic threshold: S5 non-solvability enables universal computation at width 5",
+      "Width-4 branching programs compute only ACC0 (solvable groups), width-5 computes NC1 (non-solvable S5)"
     ],
     "mathlibGaps": [
       "Turing machines",
@@ -648,7 +676,7 @@
     "mathlib": []
   },
   "started": "2026-01-01T21:55:27.888Z",
-  "lastUpdate": "2026-03-18T16:00:00Z",
+  "lastUpdate": "2026-03-18T23:55:00Z",
   "significance": 10,
   "tractability": 2
 }


### PR DESCRIPTION
## Summary
- Added **QIP = PSPACE** (Jain-Ji-Upadhyay-Watrous 2011): quantum interactive proofs equal classical, with full NP ⊆ QCMA ⊆ QMA ⊆ QIP = PSPACE chain
- Added **NL-completeness**: PATH (s-t connectivity) as canonical NL-complete problem, complement in NL from Immerman-Szelepcsényi
- Added **Barrington's theorem**: NC¹ = BPWidth(5), the algebraic threshold from S₅ non-solvability
- Recovered `QMA` opaque definition (lost in earlier merge)
- Extended master summary from 12 → 14 components

## Stats
- Lines: 6075 → 6396 (+321)
- Axioms: 122 → 133 (+11)
- Theorems proved: 13 new
- Definitions: 8 new
- Sorries: 0

## Build
Docker build passes, 0 errors, 0 sorries.

🤖 Generated by researcher-5