### PR TITLE
fix: add status field definitions for defense in depth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,10 +258,21 @@ Structure-encoded hypotheses (fields in structures/typeclasses such as `NSAxioms
 
 **Rules for all agents:**
 - `axiomCount` in meta.json must reflect ALL assumptions: `axiom` declarations + assumption-carrying structure fields
-- A proof is `"verified"` (badge `"original"`) only if it has zero `axiom` declarations AND zero structure-encoded assumptions
-- Millennium Prize problems, Clay problems, and open conjectures must use `status: "axiomatized"`, never `"verified"`
 - When reporting "0 axioms" or "axiom-free", confirm there are no assumptions encoded in structures
 - Restructuring axioms into structures is a valid proof architecture choice, but it does not change the mathematical status
+- `grep -c "^axiom "` alone is NOT sufficient to count assumptions — always inspect structure fields too
+
+**Status field definitions** (meta.json `status` and `badge`):
+
+| Status | Badge | Meaning | Requirements |
+|--------|-------|---------|--------------|
+| `verified` | `original` or `verified` | Fully machine-checked, no assumptions | 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions |
+| `axiomatized` | `axiom` | Formalized with stated assumptions | Has `axiom` declarations OR structure-encoded assumptions |
+| `formalized` | varies | Lean formalization exists | Has sorries remaining |
+
+- Millennium Prize problems, Clay problems, and open conjectures: always `"axiomatized"` (these have unproven hypotheses by definition)
+- Never use `"conditional"` — use `"axiomatized"` and describe the conditions in the `assumptions` field
+- When in doubt, use `"axiomatized"` — overclaiming `"verified"` damages credibility
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a reference table to CLAUDE.md defining `verified`, `axiomatized`, and `formalized` status values with clear requirements
- Deprecates `"conditional"` status in favor of `"axiomatized"` + `assumptions` field
- Notes that `grep -c "^axiom "` alone is insufficient for axiom counting

Follow-up to #4037 — the status definitions were committed after the squash merge landed.

## Test plan

- [ ] `pnpm build` passes
- [ ] Grep CLAUDE.md for "Status field definitions" table

🤖 Generated with [Claude Code](https://claude.com/claude-code)