### PR TITLE
Research: abel-ruffini-oq-01 - Prove q_gal_iso_a5 (5/6 axioms eliminated)

### DIFF
--- a/proofs/Proofs/InverseGaloisA5.lean
+++ b/proofs/Proofs/InverseGaloisA5.lean
@@ -148,8 +148,9 @@ theorem q_irreducible : Irreducible q := by
   have hirr := (IsPrimitive.Int.irreducible_iff_irreducible_map_cast hprim).mp q_int_irreducible
   convert hirr using 1
   unfold q q_int
-  ext k
-  simp [coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X, Int.cast_ite]
+  simp only [Polynomial.map_sub, Polynomial.map_add, Polynomial.map_mul,
+    Polynomial.map_C, Polynomial.map_X, Polynomial.map_pow]
+  norm_cast
 
 -- ============================================================================
 -- Part III: Basic Structural Properties
@@ -301,16 +302,49 @@ theorem gal_has_index_two : 2 * Fintype.card q.Gal = 120 := by
 
 /-- The Galois group of q is isomorphic to A₅ (= alternatingGroup (Fin 5)).
 
-    The galActionHom gives Gal ↪ Perm(Fin 5) ≅ S₅.
-    Since |Gal| = 60 = |S₅|/2, the image has index 2 in S₅.
-    The unique subgroup of index 2 in Sₙ is Aₙ.
-    Therefore Gal ≅ A₅.
-
-    Axiomatized: constructing the explicit MulEquiv requires showing
-    galActionHom lands in alternatingGroup, which needs the discriminant
-    sign computation. -/
-axiom q_gal_iso_a5 :
-    Nonempty (q.Gal ≃* alternatingGroup (Fin 5))
+    **Proof strategy**: Compose galActionHom with permCongr to get an injection
+    φ : Gal →* Perm(Fin 5). Since |Gal| = 60 and |Perm(Fin 5)| = 120,
+    the image φ.range has index 2. By Mathlib's
+    `Equiv.Perm.eq_alternatingGroup_of_index_eq_two`, φ.range = alternatingGroup(Fin 5).
+    Therefore Gal ≅ φ.range ≅ A₅. -/
+theorem q_gal_iso_a5 :
+    Nonempty (q.Gal ≃* alternatingGroup (Fin 5)) := by
+  -- Step 1: Build composite injection Gal →* Perm(Fin 5)
+  -- Equivalence rootSet ≃ Fin 5 (since |rootSet| = 5)
+  let rootEquiv : q.rootSet q.SplittingField ≃ Fin 5 :=
+    Fintype.equivOfCardEq (by rw [q_rootSet_card, Fintype.card_fin])
+  -- MulEquiv Perm(rootSet) ≃* Perm(Fin 5) via conjugation
+  let permEquiv : Equiv.Perm (q.rootSet q.SplittingField) ≃* Equiv.Perm (Fin 5) :=
+    { toEquiv := Equiv.permCongr rootEquiv
+      map_mul' := fun σ τ => by
+        ext x; simp [Equiv.permCongr_apply, Equiv.Perm.mul_apply] }
+  -- Composite: Gal →* Perm(Fin 5)
+  let φ := permEquiv.toMonoidHom.comp (Polynomial.Gal.galActionHom q q.SplittingField)
+  -- Step 2: φ is injective
+  have hinj : Function.Injective φ :=
+    permEquiv.injective.comp (Polynomial.Gal.galActionHom_injective q q.SplittingField)
+  -- Step 3: φ.range has index 2 in Perm(Fin 5)
+  have hindex : φ.range.index = 2 := by
+    have hlagrange := Subgroup.card_mul_index φ.range
+    -- |φ.range| = |Gal| = 60 via the bijection Gal ≃ φ.range
+    have hrange : Nat.card φ.range = 60 := by
+      have hbij : Function.Bijective φ.rangeRestrict :=
+        ⟨fun a b h => hinj (congrArg Subtype.val h), φ.rangeRestrict_surjective⟩
+      rw [show Nat.card φ.range = Nat.card q.Gal from
+        (Nat.card_congr (Equiv.ofBijective _ hbij).symm)]
+      rw [Nat.card_eq_fintype_card, q_gal_card]
+    -- |Perm(Fin 5)| = 120
+    have hperm : Nat.card (Equiv.Perm (Fin 5)) = 120 := by
+      rw [Nat.card_eq_fintype_card, Fintype.card_perm, Fintype.card_fin]
+      norm_num
+    rw [hrange, hperm] at hlagrange; omega
+  -- Step 4: The unique index-2 subgroup of S₅ is A₅ (Mathlib)
+  have heq : φ.range = alternatingGroup (Fin 5) :=
+    Equiv.Perm.eq_alternatingGroup_of_index_eq_two hindex
+  -- Step 5: Construct MulEquiv: Gal ≃* φ.range ≃* A₅
+  exact ⟨(MulEquiv.ofBijective φ.rangeRestrict
+    ⟨fun a b h => hinj (congrArg Subtype.val h),
+     φ.rangeRestrict_surjective⟩).trans (MulEquiv.subgroupCongr heq)⟩
 
 /-- **A₅ Realizability (Isomorphism Version)**
 
@@ -369,7 +403,9 @@ theorem a5_not_solvable : ¬IsSolvable (alternatingGroup (Fin 5)) := by
 theorem gal_not_solvable : ¬IsSolvable q.Gal := by
   intro h
   obtain ⟨e⟩ := q_gal_iso_a5
-  exact a5_not_solvable (isSolvable_of_surjective e.toMonoidHom e.surjective)
+  haveI := h
+  exact a5_not_solvable (solvable_of_surjective
+    (f := e.toMonoidHom) (fun b => ⟨e.symm b, e.apply_symm_apply b⟩))
 
 -- ============================================================================
 -- Part IX: Connection to Original Polynomial
@@ -460,11 +496,13 @@ Groups NOT YET realized in our formalization:
 13. gal_injects_into_perm: Gal ↪ Perm(rootSet)
 14. a5_card: |A₅| = 60 (native_decide)
 
-### Axioms (2, genuinely deep results):
+### Axioms (1, genuinely deep result):
 1. q_gal_card: |Gal(q)| = 60
    (Discriminant analysis + Chebotarev density theorem)
-2. q_gal_iso_a5: Gal(q) ≃* A₅
-   (Index-2 subgroup uniqueness + discriminant sign computation)
+
+### PROVED from q_gal_card:
+15. q_gal_iso_a5: Gal(q) ≃* A₅
+    (Via galActionHom → permCongr → index 2 → eq_alternatingGroup_of_index_eq_two)
 
 ### Proof Architecture
 ```
@@ -475,9 +513,8 @@ q_irreducible ────→ q_separable ───→ q_rootSet_card
 q_gal_card ──────→ a5_realizable
                    splitting_field_q_finrank
                    gal_has_index_two_in_s5
-
-q_gal_iso_a5 ────→ a5_realizable_iso
-                   gal_not_solvable
+                   q_gal_iso_a5 ──→ a5_realizable_iso
+                                    gal_not_solvable
 ```
 -/
 

--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-02-21T19:21:07.129Z",
-    "iteration": 7,
-    "focus": "InverseGaloisA5: eliminated 4/6 axioms (q_irreducible, q_natDegree, a5_not_solvable, gal_not_solvable)",
+    "iteration": 8,
+    "focus": "InverseGaloisA5: eliminated 5/6 axioms. q_gal_iso_a5 now PROVED from q_gal_card via eq_alternatingGroup_of_index_eq_two",
     "blockers": [
       "Kronecker-Weber not in Mathlib",
       "Hilbert irreducibility not in Mathlib"
     ],
-    "nextAction": "Only q_gal_card and q_gal_iso_a5 remain as axioms (require discriminant computation)",
+    "nextAction": "Only q_gal_card remains (requires discriminant computation + Chebotarev density). Also fixed Mathlib API breaks: q_irreducible (norm_cast), gal_not_solvable (solvable_of_surjective)",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "InverseGaloisA5.lean: 6 axioms → 2 axioms. Proved q_irreducible (Eisenstein), a5_not_solvable, gal_not_solvable, q_natDegree. Only q_gal_card (discriminant+Chebotarev) and q_gal_iso_a5 (index-2 uniqueness) remain as axioms.",
+    "progressSummary": "InverseGaloisA5.lean: 6 axioms → 1 axiom. Proved q_gal_iso_a5 from q_gal_card by showing galActionHom image has index 2 in Perm(Fin 5) and applying Mathlib eq_alternatingGroup_of_index_eq_two. Only q_gal_card (discriminant+Chebotarev) remains.",
     "builtItems": [
       "InverseGalois.lean: cyclotomic Galois theory, S₃ realization via Gal(X³-2)≅S₃ (905 lines, builds)",
       "InverseGaloisD4.lean: D₄ realization via |Gal(X⁴-2)| = 8 (666 lines, builds)",
@@ -55,7 +55,10 @@
       "InverseGaloisA5.lean: q_irreducible proved via Eisenstein at p=5 (was axiom)",
       "InverseGaloisA5.lean: a5_not_solvable proved via solvable_of_ker_le_range (was axiom)",
       "InverseGaloisA5.lean: gal_not_solvable proved via MulEquiv transfer (was axiom)",
-      "InverseGaloisA5.lean: q_natDegree proved via compute_degree! (was axiom)"
+      "InverseGaloisA5.lean: q_natDegree proved via compute_degree! (was axiom)",
+      "InverseGaloisA5.lean: q_gal_iso_a5 PROVED from q_gal_card (was axiom) via index-2 subgroup uniqueness",
+      "InverseGaloisA5.lean: fixed q_irreducible for Mathlib v4.26.0 (norm_cast replaces coefficient simp)",
+      "InverseGaloisA5.lean: fixed gal_not_solvable for Mathlib v4.26.0 (explicit MonoidHom surjectivity)"
     ],
     "insights": [
       "Cyclotomic irreducibility over ℚ IS in Mathlib: Polynomial.cyclotomic.irreducible_rat",
@@ -77,7 +80,12 @@
       "Eisenstein criterion for compound polynomials: use interval_cases k + norm_num after simp on coefficient lemmas (coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X)",
       "IsPrimitive.Int.irreducible_iff_irreducible_map_cast: Gauss lemma for ℤ→ℚ irreducibility transfer",
       "solvable_of_ker_le_range: transfers solvability through short exact sequences (A_n → S_n → ℤ/2)",
-      "compute_degree! handles natDegree for compound polynomial expressions over any ring"
+      "compute_degree! handles natDegree for compound polynomial expressions over any ring",
+      "Equiv.Perm.eq_alternatingGroup_of_index_eq_two: any index-2 subgroup of Perm(α) equals alternatingGroup(α)",
+      "galActionHom composed with permCongr gives injection Gal →* Perm(Fin 5); range has index 2 → equals A₅",
+      "MulEquiv.ofBijective + MulEquiv.subgroupCongr constructs Gal ≃* A₅ from subgroup equality",
+      "Polynomial.map_* simp lemmas + norm_cast closes ℤ→ℚ polynomial equality (replaces broken Int.cast_ite approach)",
+      "solvable_of_surjective takes (f : G →* H) implicit; for MulEquiv, construct surjectivity via e.symm explicitly"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- **Eliminated `q_gal_iso_a5` axiom** in `InverseGaloisA5.lean`: now proved as a theorem from `q_gal_card`
- Fixed two Mathlib v4.26.0 API breaks in `q_irreducible` and `gal_not_solvable`
- Progress: 6 axioms → 1 axiom (only `q_gal_card` remains)

## Proof Technique
The key insight: compose `galActionHom` with `permCongr` to embed Gal(q) into Perm(Fin 5). Since |Gal| = 60 and |Perm(Fin 5)| = 120, the image has index 2. By Mathlib's `Equiv.Perm.eq_alternatingGroup_of_index_eq_two`, the image equals A₅. Therefore Gal(q) ≅ A₅.

## Axiom Status
| Axiom | Status |
|-------|--------|
| `q_irreducible` | PROVED (Eisenstein at p=5) |
| `q_natDegree` | PROVED (compute_degree!) |
| `a5_not_solvable` | PROVED (ker ≤ range) |
| `gal_not_solvable` | PROVED (MulEquiv transfer) |
| `q_gal_iso_a5` | **PROVED** (index-2 subgroup uniqueness) |
| `q_gal_card` | Axiom (requires discriminant + Chebotarev) |

## Remaining Blocker
`q_gal_card : Fintype.card q.Gal = 60` requires:
1. Discriminant computation (not in Mathlib)
2. Chebotarev density theorem (not in Mathlib)

## Test plan
- [x] Docker build passes (`./proofs/scripts/docker-build.sh Proofs.InverseGaloisA5`)
- [x] No new axioms introduced
- [x] All downstream theorems still compile

Generated by researcher-4