### PR TITLE
Research: birch-swinnerton-dyer - Convert 12 True placeholders to real math

### DIFF
--- a/proofs/Proofs/BirchSwinnertonDyer.lean
+++ b/proofs/Proofs/BirchSwinnertonDyer.lean
@@ -357,10 +357,12 @@ the L-function has analytic continuation and functional equation.
 structure ModularForm (k N : ℕ) where
   /-- The modular form as a function on the upper half-plane -/
   toFun : ℂ → ℂ
-  /-- Weight k transformation property -/
-  transform : True  -- Placeholder for actual transformation law
-  /-- Holomorphy at cusps -/
-  holomorphic_at_cusps : True
+  /-- Periodicity: f(τ + 1) = f(τ), the simplest consequence of the weight k
+      transformation law for (1 1; 0 1) ∈ Γ₀(N) -/
+  periodic : ∀ τ : ℂ, toFun (τ + 1) = toFun τ
+  /-- Bounded growth at cusps: |f(τ)| stays bounded as Im(τ) → ∞.
+      Equivalent to the q-expansion Σ aₙ qⁿ having no negative powers of q. -/
+  bounded_at_cusp : ∃ C : ℝ, ∀ τ : ℂ, τ.im ≥ 1 → Complex.abs (toFun τ) ≤ C
 
 /-- **The Modularity Theorem** (Wiles 1995, Breuil-Conrad-Diamond-Taylor 2001)
 
@@ -595,6 +597,11 @@ theorem BSD_rank_one (E : EllipticCurveQ)
     : algebraicRank E = 1 ∧ analyticRank E = 1 :=
   ⟨BSD_rank_one_axiom E hL0 hrank, hrank⟩
 
+/-- E has complex multiplication: End(E) ⊗ ℚ ≅ K for some imaginary quadratic K.
+    CM curves have larger endomorphism rings than the generic Z, enabling
+    L-function factorization into Hecke characters. -/
+axiom HasCM : EllipticCurveQ → Prop
+
 /-- **Axiom: CM Case (Coates-Wiles 1977)**
 
     For CM elliptic curves with L(E, 1) ≠ 0, the rank is 0.
@@ -602,7 +609,7 @@ theorem BSD_rank_one (E : EllipticCurveQ)
     quadratic field) that enables direct L-function analysis.
     This is a proven theorem (Coates-Wiles 1977). -/
 axiom BSD_CM_rank_zero_axiom (E : EllipticCurveQ)
-    (hCM : True) (hL : LFunction E 1 ≠ 0) :
+    (hCM : HasCM E) (hL : LFunction E 1 ≠ 0) :
     algebraicRank E = 0
 
 /-- **CM Case (Coates-Wiles 1977)**
@@ -612,7 +619,7 @@ axiom BSD_CM_rank_zero_axiom (E : EllipticCurveQ)
     These curves have extra structure (endomorphisms by an imaginary
     quadratic field) that makes them more tractable. -/
 theorem BSD_CM_rank_zero (E : EllipticCurveQ)
-    (hCM : True) -- Placeholder: E has CM
+    (hCM : HasCM E)
     (hL : LFunction E 1 ≠ 0) :
     algebraicRank E = 0 :=
   BSD_CM_rank_zero_axiom E hCM hL
@@ -1599,8 +1606,9 @@ structure CanonicalHeight (E : EllipticCurveQ) where
   height : ℝ → ℝ  -- Simplified: maps abstract point index to height value
   /-- ĥ(P) ≥ 0 for all P -/
   nonneg : ∀ x, height x ≥ 0
-  /-- ĥ(P) = 0 iff P is torsion -/
-  zero_iff_torsion : True  -- Placeholder for proper characterization
+  /-- Positive definiteness: ĥ(P) = 0 iff P is torsion.
+      In our simplified ℝ model (mod torsion), this says ĥ(x) = 0 → x = 0. -/
+  zero_iff : ∀ x, height x = 0 → x = 0
   /-- Quadratic: ĥ(nP) = n²·ĥ(P) -/
   quadratic : ∀ n : ℤ, ∀ x, height (n * x) = n^2 * height x
 
@@ -2920,6 +2928,12 @@ axiom lambda_ge_rank (E : EllipticCurveQ) (iw : IwasawaData E)
     (hmu : iw.mu = 0) :
     iw.lambda ≥ algebraicRank E
 
+/-- Good ordinary reduction: E has good reduction at p (p ∤ N) and
+    the trace of Frobenius a_p is not divisible by p. This is the condition
+    required for the Mazur-Swinnerton-Dyer p-adic L-function and Iwasawa theory. -/
+def GoodOrdinaryReduction (E : EllipticCurveQ) (p : ℕ) [Fact (Nat.Prime p)] : Prop :=
+  ¬(p ∣ conductor E) ∧ ¬((p : ℤ) ∣ traceOfFrobenius E p)
+
 /-- The Iwasawa Main Conjecture (IMC) for elliptic curves.
 
     Let E/ℚ be an elliptic curve and p an odd prime of good ordinary reduction.
@@ -2940,13 +2954,16 @@ structure IwasawaMainConjecture (E : EllipticCurveQ) where
   hp : Nat.Prime p
   hp_odd : p ≥ 3
   /-- E has good ordinary reduction at p -/
-  good_ordinary : True
-  /-- Kato's divisibility: algebraic side divides analytic side -/
-  kato : True  -- char_Λ(X^∨) | L_p(E)
-  /-- Skinner-Urban's divisibility: analytic divides algebraic -/
-  skinner_urban : True  -- L_p(E) | char_Λ(X^∨)
-  /-- Combined: equality of ideals -/
-  main_conjecture : True  -- char_Λ(X^∨) = (L_p(E))
+  good_ordinary : @GoodOrdinaryReduction E p ⟨hp⟩
+  /-- Kato's divisibility (2004): char_Λ(X^∨) | L_p(E).
+      Key consequence: L(E,1) ≠ 0 implies rank 0 and finite Sha. -/
+  kato : LFunction E 1 ≠ 0 → algebraicRank E = 0
+  /-- Skinner-Urban divisibility (2014): L_p(E) | char_Λ(X^∨).
+      Key consequence: algebraicRank E = 0 implies L(E,1) ≠ 0. -/
+  skinner_urban : algebraicRank E = 0 → LFunction E 1 ≠ 0
+  /-- Combined: equality of characteristic ideals char_Λ(X^∨) = (L_p(E)).
+      Consequence: rank 0 ↔ L(E,1) ≠ 0 (BSD rank 0 for this curve). -/
+  main_conjecture : algebraicRank E = 0 ↔ LFunction E 1 ≠ 0
 
 /-- From the Iwasawa Main Conjecture, one can derive BSD for curves
     with analytic rank 0 or 1 (recovering Kolyvagin's results
@@ -2995,14 +3012,15 @@ structure PadicLFunction (E : EllipticCurveQ) where
   p : ℕ
   hp : Nat.Prime p
   /-- E has good ordinary reduction at p -/
-  good_ordinary : True
+  good_ordinary : @GoodOrdinaryReduction E p ⟨hp⟩
   /-- The value at s = 1 (p-adic interpolation of L(E,1)/Ω) -/
   value_at_one : ℝ  -- representing p-adic value
   /-- The order of vanishing at s = 1 -/
   ord_vanishing : ℕ
-  /-- Interpolation property: L_p(E, 1) = (1 - α_p⁻¹)² · L(E, 1)/Ω_E
-      where α_p is the unit root of x² - a_p x + p -/
-  interpolation : True
+  /-- Interpolation: the p-adic L-function vanishes at s=1 iff the complex one does.
+      This follows from L_p(E, 1) = (1 - α_p⁻¹)² · L(E, 1)/Ω_E where
+      (1 - α_p⁻¹)² ≠ 0 for good ordinary reduction. -/
+  interpolation : (ord_vanishing = 0) ↔ (LFunction E 1 ≠ 0)
 
 /-- For split multiplicative reduction, the p-adic BSD conjecture
     involves an extra factor: the ℒ-invariant.
@@ -3102,7 +3120,7 @@ by ternary quadratic forms is zero.
     BSD implies:    n squarefree, f(n) = 2g(n) ⟹ n congruent -/
 structure TunnellData (n : ℕ) where
   /-- n is squarefree -/
-  squarefree : True
+  squarefree : Squarefree n
   /-- f(n): representations by the first form -/
   f_count : ℕ
   /-- g(n): representations by the second form -/
@@ -3149,7 +3167,7 @@ axiom tunnell_reverse_conditional (n : ℕ) (hn : n > 0) (td : TunnellData n) :
     Since f(5) = 2·g(5), Tunnell's criterion predicts 5 is congruent.
     Indeed, 5 is the area of the 20/3, 3/2, 41/6 right triangle. -/
 def tunnell_5 : TunnellData 5 where
-  squarefree := trivial
+  squarefree := by decide
   f_count := 4
   g_count := 2
 
@@ -3164,7 +3182,7 @@ theorem tunnell_5_criterion : TunnellCriterion 5 tunnell_5 := by
     Actual: f(6) = 2, g(6) = 1
     So f(6) = 2·g(6), predicting 6 is congruent. ✓ -/
 def tunnell_6 : TunnellData 6 where
-  squarefree := trivial
+  squarefree := by decide
   f_count := 2
   g_count := 1
 
@@ -3178,7 +3196,7 @@ theorem tunnell_6_criterion : TunnellCriterion 6 tunnell_6 := by
     f(1) = 2 ≠ 2·2 = 2·g(1) = 4
     So 1 is NOT congruent. ✓ (consistent with one_not_congruent) -/
 def tunnell_1 : TunnellData 1 where
-  squarefree := trivial
+  squarefree := by decide
   f_count := 2
   g_count := 2
 
@@ -3192,7 +3210,7 @@ theorem tunnell_1_not_congruent : ¬TunnellCriterion 1 tunnell_1 := by
     f(2) = 2 ≠ 4 = 2·g(2)
     So 2 is NOT congruent. ✓ (consistent with two_not_congruent) -/
 def tunnell_2 : TunnellData 2 where
-  squarefree := trivial
+  squarefree := by decide
   f_count := 2
   g_count := 2
 
@@ -3209,7 +3227,7 @@ theorem tunnell_2_not_congruent : ¬TunnellCriterion 2 tunnell_2 := by
     f(3) = 4 ≠ 8 = 2·4 = 2·g(3)
     So 3 is NOT congruent. ✓ -/
 def tunnell_3 : TunnellData 3 where
-  squarefree := trivial
+  squarefree := by decide
   f_count := 4
   g_count := 4
 

--- a/research/problems/birch-swinnerton-dyer/knowledge.md
+++ b/research/problems/birch-swinnerton-dyer/knowledge.md
@@ -184,8 +184,27 @@ GrossZagierData.gross_zagier → nontorsion → analyticRank E = 1
 *Concrete definitions (2)*: modular_degree_11a and modular_degree_37a as
 ModularParametrization instances with actual numeric values
 
-**Remaining True (7 structure fields)**: MordellWeilGroup.finitely_generated,
-ModularForm.transform/holomorphic_at_cusps, CanonicalHeight.zero_iff_torsion,
-IwasawaData.kato_divisibility, IwasawaMainConjecture.kato/skinner_urban/main_conjecture.
-These require infrastructure (Module.Finite, modular transformation groups, Iwasawa algebras)
-that doesn't exist in the formalization.
+**Remaining True (7→2 after this pass)**: Previous count was 7+7=14 True fields across
+the file (7 from prior assessment + 7 more discovered). This pass converted 12:
+
+*Structure field conversions (8)*:
+- TunnellData.squarefree → Squarefree n (Mathlib type, 5 instances updated with `by decide`)
+- IwasawaMainConjecture.good_ordinary → GoodOrdinaryReduction E p (new def: p ∤ conductor ∧ p ∤ a_p)
+- PadicLFunction.good_ordinary → same GoodOrdinaryReduction predicate
+- ModularForm.transform → periodic: f(τ+1) = f(τ) (consequence of Γ₀(N) action)
+- ModularForm.holomorphic_at_cusps → bounded_at_cusp: ∃ C, Im(τ) ≥ 1 → |f(τ)| ≤ C
+- CanonicalHeight.zero_iff_torsion → zero_iff: height x = 0 → x = 0 (positive definiteness)
+- IwasawaMainConjecture.kato → L(E,1)≠0 → algebraicRank E = 0
+- IwasawaMainConjecture.skinner_urban → algebraicRank E = 0 → L(E,1) ≠ 0
+- IwasawaMainConjecture.main_conjecture → algebraicRank E = 0 ↔ L(E,1) ≠ 0
+
+*Parameter conversions (2)*:
+- BSD_CM_rank_zero_axiom: (hCM : True) → (hCM : HasCM E) via new axiom HasCM
+- BSD_CM_rank_zero: same
+
+*New interpolation field (1)*:
+- PadicLFunction.interpolation → (ord_vanishing = 0) ↔ (LFunction E 1 ≠ 0)
+
+**Remaining True (2)**: MordellWeilGroup.finitely_generated (needs Module.Finite ℤ),
+EulerSystem.norm_compatible (needs Galois cohomology infrastructure).
+These genuinely cannot be typed without infrastructure that doesn't exist in the formalization.

--- a/src/data/research/problems/birch-swinnerton-dyer.json
+++ b/src/data/research/problems/birch-swinnerton-dyer.json
@@ -29,11 +29,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Second quality pass - converted 28 True placeholders to real mathematical content (axioms with typed statements, proved theorems)",
+    "progressSummary": "PROGRESS: Third quality pass - converted 12 more True placeholders to real mathematical content. Down from 14 True fields to 2.",
     "builtItems": [
       "28 True→real conversions in BirchSwinnertonDyer.lean (Parts VIII-LV)",
       "2 proved theorems: parity_conjecture from axiom, bsd_current_status from computation",
-      "File now 6032 lines, 181 insertions / 175 deletions"
+      "File now 6032 lines, 181 insertions / 175 deletions",
+      "TunnellData.squarefree: True→Squarefree n (Mathlib type, 5 construction sites updated)",
+      "GoodOrdinaryReduction predicate: p ∤ conductor ∧ p ∤ a_p (used in IwasawaMainConjecture, PadicLFunction)",
+      "ModularForm.periodic: f(τ+1) = f(τ) (replaces transform: True)",
+      "ModularForm.bounded_at_cusp: bounded growth as Im(τ)→∞ (replaces holomorphic_at_cusps: True)",
+      "HasCM axiom predicate for EllipticCurveQ (replaces hCM: True parameters)",
+      "CanonicalHeight.zero_iff: positive definiteness ĥ(x)=0→x=0 (replaces zero_iff_torsion: True)",
+      "IwasawaMainConjecture.kato/skinner_urban/main_conjecture: L(E,1)≠0 ↔ rank=0",
+      "PadicLFunction.interpolation: ord_vanishing=0 ↔ L(E,1)≠0"
     ],
     "insights": [
       "Gross-Zagier-Kolyvagin theorem can be expressed as axiom: analyticRank E ≤ 1 → algebraicRank E = analyticRank E",
@@ -41,7 +49,10 @@
       "BSD_rank_one axiom improved: hL1:True → hrank:analyticRank E = 1 (proper typing)",
       "bsd_current_status converted from True to proved theorem using bsdStatus computation",
       "IwasawaData.kato_divisibility converted from True to lambda ≥ algebraicRank E",
-      "19 True placeholders remain - all genuine infrastructure gaps (Iwasawa ideals, modular forms, reduction types)"
+      "19 True placeholders remain - all genuine infrastructure gaps (Iwasawa ideals, modular forms, reduction types)",
+      "12 True→real conversions possible without new infrastructure; 2 remaining (finitely_generated, norm_compatible) genuinely require Module.Finite and Galois cohomology",
+      "GoodOrdinaryReduction = p ∤ conductor ∧ p ∤ traceOfFrobenius is the standard definition from arithmetic geometry",
+      "IMC kato/skinner_urban fields can be expressed as rank-0 ↔ L≠0 using existing algebraicRank/LFunction defs"
     ],
     "mathlibGaps": [
       "Torsion subgroup",
@@ -69,7 +80,7 @@
     "mathlib": []
   },
   "started": "2026-01-01T21:55:27.886Z",
-  "lastUpdate": "2026-03-18T22:00:00.000Z",
+  "lastUpdate": "2026-03-19T00:00:00Z",
   "completed": "2026-02-11T05:41:00.786Z",
   "significance": 10,
   "tractability": 1


### PR DESCRIPTION
## Summary
Third quality pass on `BirchSwinnertonDyer.lean` — converts 12 True placeholder fields/parameters to real mathematical content.

## Changes
- **TunnellData.squarefree**: `True` → `Squarefree n` (Mathlib type, 5 construction sites updated)
- **GoodOrdinaryReduction**: New predicate `¬(p ∣ conductor E) ∧ ¬((p : ℤ) ∣ traceOfFrobenius E p)` — used in `IwasawaMainConjecture` and `PadicLFunction`
- **ModularForm**: `transform: True` → `periodic: f(τ+1) = f(τ)`, `holomorphic_at_cusps: True` → `bounded_at_cusp: ∃ C, Im(τ) ≥ 1 → |f(τ)| ≤ C`
- **HasCM**: New axiomatized predicate replacing `(hCM : True)` parameters
- **CanonicalHeight.zero_iff**: Positive definiteness `h(x) = 0 → x = 0`
- **IwasawaMainConjecture**: kato/skinner_urban/main_conjecture expressed as `rank 0 ↔ L(E,1) ≠ 0`
- **PadicLFunction.interpolation**: `(ord_vanishing = 0) ↔ (LFunction E 1 ≠ 0)`

**Result**: True fields reduced from 14 → 2 (finitely_generated needs Module.Finite, norm_compatible needs Galois cohomology).

## Test plan
- [x] Docker build: 63 errors (same as main branch, all pre-existing)
- [x] No new errors introduced
- [x] No field access patterns broken (all changed structures used only as parameters)

🤖 Generated by researcher-5