### PR TITLE
fix: handle stale chunk loading errors gracefully

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,17 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { AuthProvider } from '@/contexts/AuthContext'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
+import { lazyWithRetry } from '@/utils/lazyWithRetry'
 
-// Lazy load pages for code splitting
-const HomePage = lazy(() => import('@/pages/HomePage').then(m => ({ default: m.HomePage })))
-const ProofPage = lazy(() => import('@/pages/ProofPage').then(m => ({ default: m.ProofPage })))
-const ResearchPage = lazy(() => import('@/pages/ResearchPage').then(m => ({ default: m.ResearchPage })))
-const ResearchProblemPage = lazy(() => import('@/pages/ResearchProblemPage').then(m => ({ default: m.ResearchProblemPage })))
-const SubmitPage = lazy(() => import('@/pages/SubmitPage').then(m => ({ default: m.SubmitPage })))
-const AboutPage = lazy(() => import('@/pages/AboutPage').then(m => ({ default: m.AboutPage })))
-const ErdosPage = lazy(() => import('@/pages/ErdosPage').then(m => ({ default: m.ErdosPage })))
+// Lazy load pages with auto-reload on stale chunk errors
+const HomePage = lazyWithRetry(() => import('@/pages/HomePage').then(m => ({ default: m.HomePage })))
+const ProofPage = lazyWithRetry(() => import('@/pages/ProofPage').then(m => ({ default: m.ProofPage })))
+const ResearchPage = lazyWithRetry(() => import('@/pages/ResearchPage').then(m => ({ default: m.ResearchPage })))
+const ResearchProblemPage = lazyWithRetry(() => import('@/pages/ResearchProblemPage').then(m => ({ default: m.ResearchProblemPage })))
+const SubmitPage = lazyWithRetry(() => import('@/pages/SubmitPage').then(m => ({ default: m.SubmitPage })))
+const AboutPage = lazyWithRetry(() => import('@/pages/AboutPage').then(m => ({ default: m.AboutPage })))
+const ErdosPage = lazyWithRetry(() => import('@/pages/ErdosPage').then(m => ({ default: m.ErdosPage })))
 
 function LoadingSpinner() {
   return (

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -28,27 +28,54 @@ export class ErrorBoundary extends Component<Props, State> {
     console.error('ErrorBoundary caught an error:', error, errorInfo)
   }
 
+  private isChunkLoadError(): boolean {
+    const msg = this.state.error?.message || ''
+    return (
+      msg.includes('dynamically imported module') ||
+      msg.includes('Failed to fetch') ||
+      msg.includes('Loading chunk') ||
+      msg.includes('Loading CSS chunk')
+    )
+  }
+
   render() {
     if (this.state.hasError) {
       if (this.props.fallback) {
         return this.props.fallback
       }
 
+      const isChunkError = this.isChunkLoadError()
+
       return (
         <div className="h-screen flex flex-col items-center justify-center gap-4 p-8">
           <div className="text-center max-w-md">
-            <h1 className="text-2xl font-bold mb-2 text-red-400">Something went wrong</h1>
+            <h1 className="text-2xl font-bold mb-2 text-red-400">
+              {isChunkError ? 'Page update available' : 'Something went wrong'}
+            </h1>
             <p className="text-muted-foreground mb-4">
-              An error occurred while rendering this page.
+              {isChunkError
+                ? 'The site was recently updated. Reload to get the latest version.'
+                : 'An error occurred while rendering this page.'}
             </p>
-            {this.state.error && (
-              <pre className="text-left text-xs bg-muted p-4 rounded-lg overflow-auto max-h-48 mb-4">
-                {this.state.error.message}
-              </pre>
+            {isChunkError ? (
+              <button
+                onClick={() => window.location.reload()}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-annotation text-white rounded-lg hover:opacity-90 transition-opacity mb-4"
+              >
+                Reload page
+              </button>
+            ) : (
+              this.state.error && (
+                <pre className="text-left text-xs bg-muted p-4 rounded-lg overflow-auto max-h-48 mb-4">
+                  {this.state.error.message}
+                </pre>
+              )
             )}
-            <a href="/" className="text-annotation hover:underline">
-              ← Back to home
-            </a>
+            <div>
+              <a href="/" className="text-annotation hover:underline">
+                ← Back to home
+              </a>
+            </div>
           </div>
         </div>
       )

--- a/src/utils/lazyWithRetry.ts
+++ b/src/utils/lazyWithRetry.ts
@@ -1,0 +1,36 @@
+import { lazy } from 'react'
+
+/**
+ * Wraps React.lazy with retry logic for chunk loading failures.
+ * When a deployment changes asset hashes, cached HTML may reference
+ * stale chunk URLs. This detects the failure and reloads the page once
+ * to pick up the new HTML with correct chunk references.
+ */
+export function lazyWithRetry<T extends React.ComponentType<unknown>>(
+  factory: () => Promise<{ default: T }>
+) {
+  return lazy(() =>
+    factory().catch((error: unknown) => {
+      const isChunkError =
+        error instanceof Error &&
+        (error.message.includes('dynamically imported module') ||
+         error.message.includes('Failed to fetch') ||
+         error.message.includes('Loading chunk') ||
+         error.message.includes('Loading CSS chunk'))
+
+      if (isChunkError) {
+        const key = 'chunk-reload-ts'
+        const lastReload = sessionStorage.getItem(key)
+        const now = Date.now()
+
+        // Only auto-reload once per 30 seconds to avoid infinite loops
+        if (!lastReload || now - Number(lastReload) > 30_000) {
+          sessionStorage.setItem(key, String(now))
+          window.location.reload()
+        }
+      }
+
+      throw error
+    })
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `lazyWithRetry` utility that wraps `React.lazy` to auto-reload the page once when a chunk load fails due to stale asset hashes after deployment
- Updates `ErrorBoundary` to detect chunk loading errors and show a friendly "Reload page" button instead of the cryptic "error loading dynamically imported module" message
- Affects all lazily-loaded pages (Home, Proof, Research, Submit, About, Erdos)

## Problem
After each deployment, Cloudflare serves new JS chunks with different hashes. Users with cached HTML reference old chunk URLs that no longer exist, causing a broken error page on every lazily-loaded route — not just `/research/gcd-algorithm-oq-01-oq-03`.

## Test plan
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Verify site builds and deploys successfully
- [ ] After next deployment, visit a page with stale cache — should auto-reload or show "Reload page" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)