### PR TITLE
fix: auto-refresh candidate pool in seeker cycle

### DIFF
--- a/.lean/roles/seeker.md
+++ b/.lean/roles/seeker.md
@@ -51,6 +51,14 @@ This creates `.lean/research/problems.json` with all 400+ open problems.
 | **hard** | 🟠 | Major obstacles known | Weeks to months |
 | **moonshot** | 🔴 | Open problem, fame awaits | Years+ |
 
+## Pool Refresh (Every Cycle)
+
+Before selecting problems, refresh the candidate pool to include newly enriched gallery proofs:
+
+1. Extract problems from gallery: `npx tsx .lean/scripts/extract-problems.ts --json > .lean/research/problems.json`
+2. Sync to candidate pool: `python3 research/db/sync_pool.py`
+3. Proceed with selection from the refreshed pool
+
 ## Selection Process
 
 ### Step 1: Load Problem Registry

--- a/scripts/research/launch-seeker.sh
+++ b/scripts/research/launch-seeker.sh
@@ -154,13 +154,19 @@ You are the **seeker** agent. Your mission is to keep the research pipeline fed 
    fi
    \`\`\`
 
-2. **Check candidate pool depth**
+2. **Refresh candidate pool** (picks up newly enriched gallery proofs)
+   \`\`\`bash
+   npx tsx .lean/scripts/extract-problems.ts --json > .lean/research/problems.json 2>/dev/null
+   python3 research/db/sync_pool.py 2>/dev/null
+   \`\`\`
+
+3. **Check candidate pool depth**
    \`\`\`bash
    AVAILABLE=\$(jq '[.candidates[] | select(.status == "available")] | length' .lean/state/candidate-pool.json)
    echo "Available problems: \$AVAILABLE (threshold: $THRESHOLD)"
    \`\`\`
 
-3. **If pool is low (< $THRESHOLD available), run selection**
+4. **If pool is low (< $THRESHOLD available), run selection**
    - Use the /seeker skill to select and initialize new problems
    - Run: \`/seeker --refresh\` to extract new problems from gallery
    - Or run: \`/seeker\` to select from existing pool
@@ -175,17 +181,17 @@ You are the **seeker** agent. Your mission is to keep the research pipeline fed 
      $REPO_ROOT/scripts/lean/update-stats.sh problem-selected
      \`\`\`
 
-4. **If pool is adequate, report status and wait**
+5. **If pool is adequate, report status and wait**
    - Run: \`/seeker --status\` to generate a status report
    - Log the report
 
-5. **Wait for next interval**
+6. **Wait for next interval**
    \`\`\`bash
    echo "Next check in $INTERVAL minutes..."
    sleep ${INTERVAL}m
    \`\`\`
 
-6. **Repeat from step 1**
+7. **Repeat from step 1**
 
 ## Start Now
 


### PR DESCRIPTION
## Summary

- Closes the enricher-to-seeker loop by auto-refreshing the candidate pool at the start of every seeker cycle
- Before this change, steps 2-3 of the research pipeline (extract problems from gallery, sync to database) were manual, so the seeker selected from a stale pool that never included newly enriched gallery questions
- Adds a "Pool Refresh" step to both the seeker role definition and the launch script's prompt instructions

## Changes

- **`.lean/roles/seeker.md`**: Added "Pool Refresh (Every Cycle)" section before the Selection Process, instructing the seeker to run `extract-problems.ts` and `sync_pool.py` before each selection
- **`scripts/research/launch-seeker.sh`**: Added step 2 ("Refresh candidate pool") to the generated seeker prompt workflow, renumbered subsequent steps (3-7)

## How it works

The research pipeline flow is:

1. **Enrichers** add `openQuestions` to gallery proof `meta.json` files (5,963+ questions)
2. **Extract script** (`npx tsx .lean/scripts/extract-problems.ts --json`) pulls those into `.lean/research/problems.json`
3. **Database sync** (`python3 research/db/sync_pool.py`) regenerates the candidate pool from the database
4. **Seeker** selects from the refreshed pool

Previously steps 2-3 were manual. Now the seeker runs them automatically at the start of every cycle, before checking pool depth.

## Test plan

- [x] Verified `npx tsx .lean/scripts/extract-problems.ts --json` runs successfully (wrote 6,391 problems)
- [x] Verified `python3 research/db/sync_pool.py --dry-run` runs successfully (228 candidates)
- [x] Confirmed both commands include `2>/dev/null` in the prompt to suppress errors in worktree contexts where the database may not exist yet
- [ ] Deploy seeker agent and observe that pool refresh runs before pool depth check

Generated with [Claude Code](https://claude.com/claude-code)