### PR TITLE
fix: exclude NOT_STARTED zombies from Aristotle capacity check

### DIFF
--- a/scripts/aristotle/submit-batch.sh
+++ b/scripts/aristotle/submit-batch.sh
@@ -89,8 +89,8 @@ check_server_capacity() {
     local active=0
     local breakdown=""
 
-    # Query active statuses via CLI: QUEUED, IN_PROGRESS, NOT_STARTED
-    for status in QUEUED IN_PROGRESS NOT_STARTED; do
+    # Query active statuses via CLI (exclude NOT_STARTED — these are old zombies that will never run)
+    for status in QUEUED IN_PROGRESS; do
         local output
         output=$(uvx --from aristotlelib aristotle list --status "$status" --limit 100 2>&1) || {
             echo -e "${RED}Server capacity check failed for status $status${NC}" >&2


### PR DESCRIPTION
## Summary

100 NOT_STARTED zombie projects on the Aristotle server are blocking all new submissions. They can't be cancelled (server returns 404). Fix: only count QUEUED and IN_PROGRESS toward capacity limit.

One-line change in `scripts/aristotle/submit-batch.sh`.

## Test plan

- [ ] `check_server_capacity()` no longer counts NOT_STARTED
- [ ] Aristotle agent starts submitting new jobs on next cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)