### PR TITLE
Research: poincare-conjecture - Fix build errors and quality improvements

### DIFF
--- a/proofs/Proofs/PoincareConjecture.lean
+++ b/proofs/Proofs/PoincareConjecture.lean
@@ -6726,8 +6726,7 @@ theorem poincare_for_spherical_forms (s : SphericalSpaceForm)
 /-- Poincaré homology sphere is NOT simply connected (|π₁| = 120 ≠ 1). -/
 theorem phs_not_trivial_form :
     poincareHomologySphereForm.pi1_order ≠ 1 := by
-  simp [poincareHomologySphereForm, SphericalSpaceForm.pi1_order,
-        SphericalGroupType.order]
+  simp [poincareHomologySphereForm]
 
 /-- There are exactly 5 families of spherical space forms,
     distinguished by their group structure. -/
@@ -9307,7 +9306,7 @@ inductive FoliationType
     information and detect topology. -/
 structure TautFoliation3 extends Foliation3 where
   /-- No Reeb components -/
-  noReebComponents : ¬ ∃ (_ : ReebComponent), True
+  noReebComponents : ¬ Nonempty ReebComponent
   /-- Every leaf intersects a closed transversal -/
   hasClosedTransversal : Prop
   /-- Taut foliations are automatically C⁰ -/
@@ -9338,7 +9337,7 @@ axiom novikov_compact_leaf :
   -- This is the fundamental obstruction: S³ is "too simple"
   -- for taut foliations
   ∀ (F : Foliation3), F.regularity ≥ 2 →
-    ∃ (_ : ReebComponent), True
+    Nonempty ReebComponent
 
 /-- Corollary: S³ admits no taut foliation.
     Since taut foliations have no Reeb components, and Novikov says
@@ -9353,9 +9352,8 @@ theorem s3_no_taut_foliation :
     ¬ (∃ (F : TautFoliation3), F.regularity ≥ 2) := by
   intro ⟨F, hreg⟩
   -- By Novikov, any C² foliation of S³ has a Reeb component
-  have ⟨R, _⟩ := novikov_compact_leaf F.toFoliation3 hreg
   -- But taut foliations have no Reeb components — contradiction
-  exact F.noReebComponents ⟨R, trivial⟩
+  exact F.noReebComponents (novikov_compact_leaf F.toFoliation3 hreg)
 
 /-- Reeb stability theorem (1952): If a foliation of a closed
     3-manifold has a compact leaf L with finite π₁(L), then all
@@ -9991,11 +9989,11 @@ def lspacePHS : LSpaceDef where
 /-- L-space verification: S³, L(2,1), L(3,1), L(5,1), Σ(2,3,5)
     are all L-spaces (rk HF = |H₁|). -/
 theorem lspace_examples_verified :
-    lspaceS3.is_Lspace ∧
-    (lspaceLens 2 (by omega)).is_Lspace ∧
-    (lspaceLens 3 (by omega)).is_Lspace ∧
-    (lspaceLens 5 (by omega)).is_Lspace ∧
-    lspacePHS.is_Lspace := ⟨rfl, rfl, rfl, rfl, rfl⟩
+    lspaceS3.hf.totalRank = 1 ∧
+    (lspaceLens 2 (by omega)).hf.totalRank = 2 ∧
+    (lspaceLens 3 (by omega)).hf.totalRank = 3 ∧
+    (lspaceLens 5 (by omega)).hf.totalRank = 5 ∧
+    lspacePHS.hf.totalRank = 1 := ⟨rfl, rfl, rfl, rfl, rfl⟩
 
 /-- T³ is NOT an L-space: rk ĤF(T³) = 8 but T³ is not even
     a rational homology sphere (b₁ = 3 ≠ 0). -/
@@ -10147,12 +10145,12 @@ def hfkFigureEight : KnotFloerData where
   top_is_genus := fun _ => by omega
 
 /-- ĤFK of the (2,2p+1) torus knot T(2,2p+1): genus p, rank 2p+1. -/
-def hfkTorusKnot (p : ℕ) (hp : p ≥ 1) : KnotFloerData where
+def hfkTorusKnot (p : ℕ) (_hp : p ≥ 1) : KnotFloerData where
   genus := p
   totalRank := 2 * p + 1
   topRank := 1
   rank_pos := by omega
-  top_is_genus := fun _ => hp
+  top_is_genus := fun _ => Nat.zero_le p
 
 /-- Genus detection theorem (Ozsváth-Szabó 2004):
     Knot Floer homology detects the Seifert genus. -/
@@ -10210,7 +10208,7 @@ def tauFigureEight : TauInvariant where
   tau_le_genus := Nat.zero_le 1
 
 /-- τ(T_{2,3}) = 1, τ(T_{2,5}) = 2: positive torus knots. -/
-def tauTorusKnot (n : ℕ) (hn : n ≥ 1) : TauInvariant where
+def tauTorusKnot (n : ℕ) (_hn : n ≥ 1) : TauInvariant where
   tau := n
   genus := n
   tau_le_genus := le_refl n
@@ -10902,7 +10900,7 @@ end ContactStructuresAndDichotomy
 -- ═══════════════════════════════════════════════════════════════════
 -- CUMULATIVE SUMMARY (Parts I - LXXX)
 -- ═══════════════════════════════════════════════════════════════════
--- 80 parts, ~11000 lines, 38 axioms
+-- 80 parts, 10926 lines, 38 axioms, 564 theorems, 130 structures, 189 definitions
 -- The formalization covers:
 --   - The Poincaré conjecture statement and Perelman's proof strategy
 --   - Thurston's Geometrization and all 8 model geometries

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -17,7 +17,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 38,
-    "assumptions": "38 axiom declarations: Perelman Ricci flow surgery (finite extinction), Novikov compact leaf theorem (foliations), generalized Poincare in dimensions 2/4/≥5, topological constructions (connected sum, Dehn surgery), classification results (JSJ, h/s-cobordism), 3-manifold topology (Heegaard, Waldhausen, Property P, prime decomposition), counterexample structures (Poincare homology sphere, Whitehead manifold). No new axioms added in Parts LXXVIII-LXXIX.",
+    "assumptions": "38 axiom declarations: Perelman Ricci flow surgery (finite extinction), Novikov compact leaf theorem (foliations), generalized Poincaré in dimensions 2/4/≥5, simply connected S³ (needs Seifert-van Kampen), S³ non-contractible (needs homology), topological constructions (connected sum type, Dehn surgery type), classification results (JSJ decomposition/uniqueness, h/s-cobordism), 3-manifold topology (Heegaard splitting, Waldhausen genus-0, Property P, prime decomposition, irreducibility), counterexample structures (Poincaré homology sphere, Whitehead manifold), covering space theory (sc_covering_injective).",
     "mathlibDependencies": [
       {
         "theorem": "SimplyConnectedSpace",
@@ -70,19 +70,19 @@
       "Papakyriakopoulos trilogy: Dehn's lemma, loop theorem, sphere theorem (axiomatized)",
       "Haken hierarchy, equivariant Dehn's lemma, Smith conjecture connection",
       "Scalar curvature maximum principle and Schoenflies theorem infrastructure",
-      "587 theorems proved, 107 structures defined, 185 definitions, 80 parts across 10955 lines"
+      "564 theorems proved, 130 structures defined, 189 definitions, 80 parts across 10926 lines"
     ],
     "leanFile": {
-      "lineCount": 10955,
-      "theoremCount": 587,
-      "lemmaCount": 2,
-      "defCount": 185,
-      "axiomCount": 41,
+      "lineCount": 10926,
+      "theoremCount": 564,
+      "lemmaCount": 0,
+      "defCount": 189,
+      "axiomCount": 38,
       "sorryCount": 0,
-      "structureCount": 107,
+      "structureCount": 130,
       "instanceCount": 21,
       "parts": 80,
-      "note": "Single file formalization. 80 parts covering: topology of S³ and S^n, closed manifolds, simple connectivity, Perelman's proof strategy, counterexamples, geometrization, connected sum theory, covering spaces, Hopf fibration, knot surgery, JSJ decomposition, foliations, Papakyriakopoulos results."
+      "note": "Single file formalization. 80 parts covering: topology of S³ and S^n, closed manifolds, simple connectivity, Perelman's proof strategy, counterexamples, geometrization, connected sum theory, covering spaces, Hopf fibration, knot surgery, JSJ decomposition, foliations, Papakyriakopoulos results, Heegaard Floer homology, L-space conjecture, contact structures."
     },
     "dateAdded": "12/29/25",
     "millenniumProblem": "poincare"
@@ -241,7 +241,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The Poincaré Conjecture is SOLVED (Perelman, 2002–2003): every simply connected, closed 3-manifold is homeomorphic to S³. The formalization provides ~10560 lines covering 79 parts, with 546 theorems/lemmas and 38 axioms. Coverage includes Ricci flow, surgery theory, κ-solutions, normal surfaces, taut foliations, Casson invariant, Heegaard Floer homology, the L-space conjecture, and computational complexity.",
+    "summary": "The Poincaré Conjecture is SOLVED (Perelman, 2002–2003): every simply connected, closed 3-manifold is homeomorphic to S³. The formalization provides 10926 lines covering 80 parts, with 564 theorems and 38 axioms. Coverage includes Ricci flow, surgery theory, κ-solutions, normal surfaces, taut foliations, Casson invariant, Heegaard Floer homology, the L-space conjecture, contact structures, and computational complexity.",
     "implications": "Perelman's proof also established Thurston's Geometrization Conjecture, revolutionizing 3-manifold topology. The Ricci flow technique has since been applied to the differentiable sphere theorem (Brendle–Schoen 2009), classification of manifolds with positive isotropic curvature, and the study of Kähler–Ricci flow in complex geometry.",
     "openQuestions": [
       "The smooth 4-dimensional Poincaré conjecture: is every smooth homotopy 4-sphere diffeomorphic to $S^4$?",


### PR DESCRIPTION
## Summary
- Fix 3 build errors in PoincareConjecture.lean (Parts LXXVIII-LXXIX)
- Eliminate 2 True placeholders in foliation structures
- Update meta.json with accurate statistics

## Progress
- **lspace_examples_verified**: Fixed type mismatch — `.is_Lspace` is a proof term, not a Prop. Replaced with concrete rank equalities
- **hfkTorusKnot.top_is_genus**: Fixed `p ≥ 1` → `p ≥ 0` type mismatch with `Nat.zero_le p`
- **tauTorusKnot**: Fixed unused variable warning (`hn` → `_hn`)
- **phs_not_trivial_form**: Removed unused simp arguments
- **noReebComponents/novikov_compact_leaf**: Replaced `∃ (_ : ReebComponent), True` with `Nonempty ReebComponent`
- **meta.json**: Updated to accurate stats (564 thms, 130 structures, 189 defs, 38 axioms, 10926 lines)

## Findings
- Build errors were in Heegaard Floer homology section (Part LXXVIII)
- True placeholders in foliation structures (Part LXXVI) were fixable with Nonempty
- All 38 remaining axioms are either type declarations, deep topology theorems, or blocked on Mathlib gaps

## Status
**Outcome**: progress
**Next Steps**: sphere3_simply_connected and sphere3_not_contractible remain blocked on Mathlib (needs Seifert-van Kampen and homology respectively)

🤖 Generated by researcher-4