### PR TITLE
Research: cauchy-schwarz-oq-04 - Gallery entry for exact proportionality constant

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-04/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "csoq04-projcoeff",
+    "proofId": "cauchy-schwarz-oq-04",
+    "type": "concept",
+    "range": { "startLine": 29, "endLine": 33 },
+    "title": "Projection Coefficient Definition",
+    "content": "Defines projCoeff(u, v) = inner(u, v) / norm(v)^2 and proj(u, v) = projCoeff(u, v) * v. This is the orthogonal projection of u onto the span of v.",
+    "mathContext": "The projection coefficient $c = \\langle u,v\\rangle/\\|v\\|^2$ is the unique scalar minimizing $\\|u - cv\\|$. It appears in regression ($\\hat{\\beta} = \\text{Cov}(X,Y)/\\text{Var}(Y)$), matched filtering, and Gram-Schmidt orthogonalization.",
+    "significance": "key",
+    "relatedConcepts": ["orthogonal projection", "inner product", "regression coefficient"],
+    "prerequisites": ["InnerProductSpace", "NormedAddCommGroup"]
+  },
+  {
+    "id": "csoq04-orthogonal-residual",
+    "proofId": "cauchy-schwarz-oq-04",
+    "type": "theorem",
+    "range": { "startLine": 42, "endLine": 48 },
+    "title": "Residual Orthogonality",
+    "content": "The residual $u - \\text{proj}(u,v)$ is orthogonal to $v$: $\\langle u - \\text{proj}(u,v), v\\rangle = 0$. Proved by expanding inner_sub_left and inner_smul_left, then cancelling via div_mul_cancel.",
+    "mathContext": "This is the defining property of orthogonal projection: the error $u - \\hat{u}$ is perpendicular to the approximation subspace $\\text{span}(v)$. This is the normal equation in least-squares theory.",
+    "significance": "key",
+    "relatedConcepts": ["orthogonality", "normal equations", "inner_sub_left"],
+    "prerequisites": ["projCoeff", "proj"]
+  },
+  {
+    "id": "csoq04-norm-decomposition",
+    "proofId": "cauchy-schwarz-oq-04",
+    "type": "theorem",
+    "range": { "startLine": 51, "endLine": 65 },
+    "title": "Pythagorean Norm Decomposition",
+    "content": "Derives $\\|u\\|^2 = (\\text{projCoeff})^2 \\|v\\|^2 + \\|u - \\text{proj}(u,v)\\|^2$. Uses norm_add_sq_real with the orthogonal decomposition $u = \\text{proj}(u,v) + (u - \\text{proj}(u,v))$.",
+    "mathContext": "The Pythagorean theorem for orthogonal decomposition: $\\|u\\|^2 = \\|\\hat{u}\\|^2 + \\|u - \\hat{u}\\|^2$. The term $(\\text{projCoeff})^2\\|v\\|^2$ accounts for the component along $v$, and $\\|u - \\text{proj}\\|^2$ is the orthogonal residual.",
+    "significance": "critical",
+    "relatedConcepts": ["Pythagorean theorem", "orthogonal decomposition", "norm_add_sq_real"],
+    "prerequisites": ["proj_orthogonal", "norm_smul"]
+  },
+  {
+    "id": "csoq04-exact-constant",
+    "proofId": "cauchy-schwarz-oq-04",
+    "type": "theorem",
+    "range": { "startLine": 74, "endLine": 91 },
+    "title": "CS Equality Gives Exact Constant",
+    "content": "When $|\\langle u,v\\rangle| = \\|u\\|\\|v\\|$ and $v \\neq 0$, then $u = \\text{projCoeff}(u,v) \\cdot v$. The proof shows that CS equality forces $\\|u - \\text{proj}(u,v)\\|^2 = 0$ via the Pythagorean decomposition.",
+    "mathContext": "cs_equality_exact_constant: The key step is $\\text{projCoeff}^2\\|v\\|^2 = \\|u\\|^2$ (from squaring the CS equality and simplifying), which combined with the Pythagorean identity forces the residual norm to vanish.",
+    "significance": "critical",
+    "relatedConcepts": ["Cauchy-Schwarz equality", "proportionality constant", "zero residual"],
+    "prerequisites": ["norm_sq_decomposition", "sub_eq_zero"]
+  },
+  {
+    "id": "csoq04-biconditional",
+    "proofId": "cauchy-schwarz-oq-04",
+    "type": "theorem",
+    "range": { "startLine": 110, "endLine": 112 },
+    "title": "Full Biconditional Characterization",
+    "content": "cs_equality_iff_exact_constant: $|\\langle u,v\\rangle| = \\|u\\|\\|v\\| \\iff u = \\text{projCoeff}(u,v) \\cdot v$. Combines forward (residual vanishing) and reverse (direct computation) directions.",
+    "mathContext": "This is the strongest form of the Cauchy-Schwarz equality condition: not just that proportionality exists, but the exact constant is $\\langle u,v\\rangle/\\|v\\|^2$.",
+    "significance": "critical",
+    "relatedConcepts": ["biconditional", "cs_equality_exact_constant", "cs_equality_of_exact_constant"],
+    "prerequisites": ["cs_equality_exact_constant", "cs_equality_of_exact_constant"]
+  },
+  {
+    "id": "csoq04-finite-sum",
+    "proofId": "cauchy-schwarz-oq-04",
+    "type": "theorem",
+    "range": { "startLine": 208, "endLine": 268 },
+    "title": "Finite Sum Exact Constant via Lagrange Identity",
+    "content": "For sequences $a, b : \\text{Fin}\\,n \\to \\mathbb{R}$ with $b$ nonzero: if $(\\sum a_ib_i)^2 = (\\sum a_i^2)(\\sum b_i^2)$, then $a_i = \\frac{\\sum a_jb_j}{\\sum b_j^2} \\cdot b_i$ for all $i$.",
+    "mathContext": "finite_sum_exact_constant: The proof uses the Lagrange identity $\\sum_{i,j}(a_ib_j - a_jb_i)^2 = 2((\\sum a_i^2)(\\sum b_i^2) - (\\sum a_ib_i)^2)$. Equality forces all cross-terms $a_ib_j = a_jb_i$, giving the common ratio $a_i/b_i = \\sum a_jb_j / \\sum b_j^2$.",
+    "significance": "critical",
+    "relatedConcepts": ["Lagrange identity", "cross-term vanishing", "sum_eq_zero_iff_of_nonneg", "Finset"],
+    "prerequisites": ["sq_nonneg", "sum_pos'", "field_simp"]
+  },
+  {
+    "id": "csoq04-geometric",
+    "proofId": "cauchy-schwarz-oq-04",
+    "type": "concept",
+    "range": { "startLine": 160, "endLine": 186 },
+    "title": "Geometric Sign Interpretation",
+    "content": "When CS equality holds: projCoeff > 0 iff inner(u,v) > 0 (same direction), projCoeff < 0 iff inner(u,v) < 0 (opposite direction). This gives the sign of the proportionality constant from the angle between vectors.",
+    "mathContext": "Since $\\text{projCoeff} = \\langle u,v\\rangle/\\|v\\|^2$ and $\\|v\\|^2 > 0$, the sign of projCoeff equals the sign of $\\langle u,v\\rangle$. Same-direction vectors have positive inner product; opposite-direction vectors have negative inner product.",
+    "significance": "key",
+    "relatedConcepts": ["vector direction", "positive inner product", "div_pos"],
+    "prerequisites": ["projCoeff_pos_of_inner_pos", "projCoeff_neg_of_inner_neg"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-04/index.ts
+++ b/src/data/proofs/cauchy-schwarz-oq-04/index.ts
@@ -1,0 +1,34 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzOQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+}
+
+export const cauchySchwarzOq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+}
+
+export const cauchySchwarzOq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchySchwarzOq04Data: ProofData = {
+  proof: cauchySchwarzOq04Proof,
+  annotations: cauchySchwarzOq04Annotations,
+}

--- a/src/data/proofs/cauchy-schwarz-oq-04/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-04/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "cauchy-schwarz-oq-04",
+  "title": "Cauchy-Schwarz Equality: Exact Proportionality Constant",
+  "slug": "cauchy-schwarz-oq-04",
+  "description": "When |inner u v| = norm u * norm v, the exact proportionality constant is u = (inner u v / norm v^2) * v. Proves the biconditional characterization, projection coefficient properties, geometric interpretation, and finite sum version via the Lagrange identity.",
+  "meta": {
+    "author": "Cauchy, Schwarz (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cauchy%E2%80%93Schwarz_inequality",
+    "date": "1821",
+    "status": "verified",
+    "tags": ["analysis", "inner-product-spaces", "cauchy-schwarz", "extension", "research"],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ04.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      { "theorem": "abs_real_inner_le_norm", "description": "Cauchy-Schwarz for real inner products", "module": "Mathlib.Analysis.InnerProductSpace.Basic" },
+      { "theorem": "real_inner_self_eq_norm_sq", "description": "Inner product of v with itself equals norm squared", "module": "Mathlib.Analysis.InnerProductSpace.Basic" },
+      { "theorem": "norm_add_sq_real", "description": "Norm squared expansion for sum of vectors", "module": "Mathlib.Analysis.InnerProductSpace.Basic" },
+      { "theorem": "div_mul_cancel₀", "description": "Division-multiplication cancellation for nonzero divisor", "module": "Mathlib.Algebra.Order.Field.Basic" },
+      { "theorem": "sum_eq_zero_iff_of_nonneg", "description": "Sum of nonneg terms is zero iff all terms are zero", "module": "Mathlib.Algebra.BigOperators.Group.Finset" }
+    ],
+    "originalContributions": [
+      "projCoeff: orthogonal projection coefficient u onto v = inner u v / norm v^2",
+      "proj: orthogonal projection of u onto v",
+      "cs_equality_exact_constant: CS equality implies u = projCoeff(u,v) * v",
+      "cs_equality_iff_exact_constant: biconditional characterization",
+      "projCoeff_of_smul, projCoeff_self, projCoeff_add, projCoeff_smul: coefficient properties",
+      "cs_equality_iff_zero_residual: equality iff residual vanishes",
+      "cs_equality_same_direction/opposite_direction: geometric sign interpretation",
+      "finite_sum_exact_constant: finite sum version via Lagrange identity cross-term vanishing",
+      "existential_constant_is_projCoeff: bridge to base CauchySchwarz.lean existential result"
+    ],
+    "references": [
+      {"authors": "A.-L. Cauchy", "title": "Cours d'Analyse de l'École Royale Polytechnique", "year": "1821", "venue": "Paris", "note": "Original discrete inequality with equality case noted"},
+      {"authors": "J. M. Steele", "title": "The Cauchy-Schwarz Master Class", "year": "2004", "venue": "Cambridge University Press", "note": "Chapter 2: detailed treatment of equality conditions"}
+    ],
+    "dateAdded": "03/19/26"
+  },
+  "overview": {
+    "historicalContext": "The Cauchy-Schwarz inequality $|\\langle u,v\\rangle| \\leq \\|u\\|\\|v\\|$ is one of the most important inequalities in mathematics. Its equality condition -- that the vectors must be proportional -- is well-known, but the **exact proportionality constant** $c = \\langle u,v\\rangle/\\|v\\|^2$ is often stated informally. This formalization makes the constant precise: when equality holds, $u$ equals exactly the orthogonal projection of $u$ onto $v$, with the scalar being the projection coefficient.\n\nThe projection coefficient $\\text{projCoeff}(u,v) = \\langle u,v\\rangle/\\|v\\|^2$ appears throughout functional analysis, statistics (regression coefficients), and signal processing (matched filtering). This formalization proves its defining properties and shows it is the unique scalar satisfying the equality condition.",
+    "problemStatement": "**Open Question (cauchy-schwarz-oq-04)**: When $|\\langle u,v\\rangle| = \\|u\\|\\|v\\|$, give the exact proportionality constant.\n\n**Result**: $u = \\frac{\\langle u,v\\rangle}{\\|v\\|^2} \\cdot v$, i.e., $u$ equals the orthogonal projection of $u$ onto $v$.\n\n**Also proved**: The biconditional (iff) version, projection coefficient linearity and algebraic properties, geometric sign interpretation (same/opposite direction), zero residual characterization, finite sum version via Lagrange identity, and bridge to the existential result in the base CauchySchwarz.lean.",
+    "proofStrategy": "**Proof Strategy: Residual Norm Decomposition**\n\n1. **Define** projCoeff(u,v) = inner(u,v) / norm(v)^2 and proj(u,v) = projCoeff(u,v) * v.\n2. **Prove** the residual u - proj(u,v) is orthogonal to v (inner product is zero).\n3. **Derive** the Pythagorean decomposition: norm(u)^2 = projCoeff^2 * norm(v)^2 + norm(residual)^2.\n4. **Show** that CS equality forces norm(residual) = 0, hence u = proj(u,v).\n5. **Reverse direction**: if u = projCoeff * v, direct computation gives |inner u v| = norm u * norm v.\n6. **Finite sum version**: uses the Lagrange identity; CS equality forces all cross-terms a_i*b_j - a_j*b_i = 0, giving a_i = (sum a_j*b_j / sum b_j^2) * b_i.",
+    "keyInsights": [
+      "**Residual norm decomposition**: The Pythagorean identity norm(u)^2 = projCoeff^2 * norm(v)^2 + norm(u - proj)^2 shows that CS equality forces the residual to vanish, giving the exact constant.",
+      "**Projection coefficient is canonical**: Any scalar c satisfying u = cv must equal projCoeff(u,v). This is proved by showing projCoeff(cv, v) = c for all scalars c.",
+      "**Sign determines direction**: projCoeff > 0 when inner(u,v) > 0 (same direction), projCoeff < 0 when inner(u,v) < 0 (opposite direction). This geometric interpretation follows from the sign of the inner product divided by the positive quantity norm(v)^2.",
+      "**Lagrange identity for finite sums**: The cross-term vanishing condition a_i*b_j = a_j*b_i is extracted from the identity sum_ij (a_i*b_j - a_j*b_i)^2 = 2*(sum a_i^2 * sum b_i^2 - (sum a_i*b_i)^2), giving the exact ratio a_i/b_i = sum(a*b)/sum(b^2) for all i."
+    ]
+  },
+  "sections": [
+    {
+      "id": "projection-coefficient",
+      "title": "Orthogonal Projection Coefficient",
+      "startLine": 29,
+      "endLine": 65,
+      "summary": "Defines projCoeff(u,v) = inner(u,v)/norm(v)^2 and proj(u,v) = projCoeff(u,v) * v. Proves the residual u - proj(u,v) is orthogonal to v and derives the Pythagorean norm decomposition."
+    },
+    {
+      "id": "exact-constant",
+      "title": "Exact Proportionality Constant",
+      "startLine": 70,
+      "endLine": 112,
+      "summary": "Proves cs_equality_exact_constant (forward), cs_equality_of_exact_constant (reverse), and the full biconditional cs_equality_iff_exact_constant: |inner u v| = norm u * norm v iff u = projCoeff(u,v) * v."
+    },
+    {
+      "id": "coefficient-properties",
+      "title": "Projection Coefficient Properties",
+      "startLine": 117,
+      "endLine": 143,
+      "summary": "Proves projCoeff(cv, v) = c, projCoeff(v, v) = 1, additivity projCoeff(u1+u2, v) = projCoeff(u1,v) + projCoeff(u2,v), and scaling projCoeff(cu, v) = c * projCoeff(u,v)."
+    },
+    {
+      "id": "residual",
+      "title": "CS Equality and Residual Norm",
+      "startLine": 148,
+      "endLine": 154,
+      "summary": "Proves CS equality holds iff the residual u - proj(u,v) = 0, connecting the equality condition to orthogonal projection theory."
+    },
+    {
+      "id": "geometric",
+      "title": "Geometric Interpretation",
+      "startLine": 159,
+      "endLine": 186,
+      "summary": "Proves projCoeff > 0 when inner(u,v) > 0 (same direction) and projCoeff < 0 when inner(u,v) < 0 (opposite direction). Derives the direction-specific equality conditions."
+    },
+    {
+      "id": "bridge",
+      "title": "Bridge to Existential Result",
+      "startLine": 191,
+      "endLine": 197,
+      "summary": "Shows that any scalar c satisfying u = cv must equal projCoeff(u,v), connecting to the existential characterization in the base CauchySchwarz.lean formalization."
+    },
+    {
+      "id": "finite-sum",
+      "title": "Finite Sum Exact Constant",
+      "startLine": 203,
+      "endLine": 268,
+      "summary": "Proves the finite sum version via the Lagrange identity: if (sum a_i*b_i)^2 = (sum a_i^2)(sum b_i^2), then a_i = (sum a_j*b_j / sum b_j^2) * b_i for all i. Uses cross-term vanishing from the double-sum expansion."
+    },
+    {
+      "id": "examples",
+      "title": "Verified Examples",
+      "startLine": 273,
+      "endLine": 288,
+      "summary": "Concrete verifications: projCoeff(3v, v) = 3 and projCoeff(v, v) = 1, with type-check confirmations of the main theorems."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "extends",
+      "description": "Strengthens the base Cauchy-Schwarz equality characterization from 'exists c, u = cv' to the exact constant c = inner(u,v)/norm(v)^2."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-03",
+      "relationship": "related",
+      "description": "Both are open questions extending the base Cauchy-Schwarz formalization with deeper characterizations of the equality condition."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete formalization of the exact proportionality constant in Cauchy-Schwarz equality. The proof is fully verified (0 sorries, 0 axioms) and covers: abstract inner product spaces (biconditional characterization via residual norm decomposition), projection coefficient algebra (linearity, normalization), geometric interpretation (same/opposite direction), finite-dimensional sums (via Lagrange identity), and the canonical bridge to the existential form.",
+    "implications": "**Implications**:\n\n1. **Regression Theory**: The projection coefficient projCoeff(u,v) = inner(u,v)/norm(v)^2 is the simple linear regression coefficient. This formalization verifies its optimality.\n\n2. **Signal Processing**: In matched filtering, the projection coefficient gives the optimal scaling of a template signal to match an observed signal.\n\n3. **Orthogonal Decomposition**: The residual norm characterization (equality iff residual = 0) is the foundation of Gram-Schmidt orthogonalization and QR factorization.\n\n4. **Unique Determination**: The bridge theorem shows the proportionality constant is uniquely determined, closing the gap between 'exists c' and 'c equals this specific value'.",
+    "openQuestions": [
+      "Can the finite sum version be extended to weighted inner products sum(w_i * a_i * b_i)?",
+      "Can the projection coefficient be connected to Mathlib's orthogonalProjection for Hilbert subspaces?"
+    ]
+  }
+}

--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -155,7 +155,7 @@
       "Can the formalization be extended to complex inner product spaces using `inner_mul_le_norm_mul_norm`?",
       "[RESOLVED] The integral form (Bunyakovsky-Schwarz) has been formalized - see `cauchy-schwarz-integral` proof.",
       "Can Hölder's inequality be formalized as a generalization, recovering Cauchy-Schwarz for $p=q=2$?",
-      "Can the equality condition be strengthened to give the exact proportionality constant $c = \\langle u,v\\rangle/\\|v\\|^2$?"
+      "[RESOLVED] The equality condition has been strengthened to give the exact proportionality constant $c = \\langle u,v\\rangle/\\|v\\|^2$ - see `cauchy-schwarz-oq-04` proof."
     ]
   }
 }

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "cauchy-schwarz-oq-04",
   "title": "Cauchy-Schwarz Equality Condition Strengthening",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {
@@ -16,16 +16,16 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-03-14T19:18:15-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "phase": "COMPLETED",
+    "since": "2026-03-19T19:00:00.000Z",
+    "iteration": 2,
+    "focus": "Gallery entry created, proof complete",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "None - problem is complete",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
@@ -33,7 +33,8 @@
     "builtItems": [
       "projCoeff and proj definitions for orthogonal projection",
       "cs_equality_exact_constant and cs_equality_iff_exact_constant (biconditional)",
-      "finite_sum_exact_constant via Lagrange identity"
+      "finite_sum_exact_constant via Lagrange identity",
+      "src/data/proofs/cauchy-schwarz-oq-04/ - Gallery entry with meta.json, annotations.json, index.ts"
     ],
     "insights": [
       "CS equality holds iff u = (⟨u,v⟩/‖v‖²)·v, proved via residual norm decomposition",
@@ -45,12 +46,20 @@
     "nextSteps": [],
     "markdown": "# Knowledge Base: cauchy-schwarz-oq-04\n\nCauchy-Schwarz Equality: Exact Proportionality Constant.\n\n---\n\n## Session 2026-03-17 (Session 1) - Survey\n\n**Mode**: FRESH\n**Outcome**: completed (already fully proved)\n\n### Finding\nFile `CauchySchwarzOQ04.lean` already exists with 288 lines, 0 axioms, 0 sorries.\nProves the exact proportionality constant: when |inner u v| = norm u * norm v,\nu = (inner u v / norm v^2) * v (orthogonal projection coefficient).\nNo additional work needed.\n"
   },
-  "approaches": [],
+  "approaches": [
+    {
+      "name": "Residual norm decomposition",
+      "status": "successful",
+      "description": "Define projCoeff, prove residual orthogonality, use Pythagorean decomposition to show CS equality forces zero residual",
+      "outcome": "Complete proof with 0 sorries, 0 axioms, 288 lines"
+    }
+  ],
   "tags": [
     "analysis",
     "inner-product-spaces",
     "cauchy-schwarz",
-    "extension"
+    "extension",
+    "completed"
   ],
   "relatedProofs": [],
   "references": {
@@ -59,7 +68,7 @@
     "mathlib": []
   },
   "started": "2026-03-14T19:01:45.297Z",
-  "lastUpdate": "2026-03-14T19:01:45.329Z",
+  "lastUpdate": "2026-03-19T19:00:00.000Z",
   "significance": 5,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary
- Created gallery entry for the Cauchy-Schwarz exact proportionality constant proof (cauchy-schwarz-oq-04)
- Proof was already complete (288 lines, 0 sorries, 0 axioms) but lacked a gallery entry
- Marked the parent cauchy-schwarz open question as [RESOLVED]
- Updated problem status to completed

## Progress
- **Gallery entry**: meta.json (full metadata, overview, sections, cross-references), annotations.json (7 annotations covering key theorems), index.ts
- **Parent update**: cauchy-schwarz/meta.json open question marked resolved
- **Problem status**: cauchy-schwarz-oq-04.json updated to COMPLETED phase

## Findings
- The proof formalizes the exact proportionality constant c = inner(u,v)/norm(v)^2 for CS equality
- Uses residual norm decomposition: Pythagorean identity forces residual to vanish when CS equality holds
- Finite sum version via Lagrange identity cross-term vanishing
- All 288 lines compile with 0 sorries and 0 axioms

## Status
**Outcome**: completed
**Next Steps**: None - problem is complete

Generated by researcher-4