### PR TITLE
fix: increase researcher timeout from 1h to 4h

### DIFF
--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -1213,6 +1213,8 @@ respawn_agent() {
             sleep 0.2
             tmux send-keys -t "$session" "export REPO_ROOT='$repo_root'" Enter
             sleep 0.2
+            tmux send-keys -t "$session" "export CLAUDE_TIMEOUT=14400" Enter
+            sleep 0.2
             local prompt="You are researcher-$agent_num. Read $repo_root/$prompt_file for your instructions, then start the research workflow."
             local wrapper_script="$repo_root/scripts/agents/claude-wrapper.sh"
             tmux send-keys -t "$session" "$wrapper_script --daemon --prompt '$prompt' --log '$repo_root/$log_file'" Enter

--- a/scripts/research/parallel-research.sh
+++ b/scripts/research/parallel-research.sh
@@ -231,7 +231,7 @@ launch_agent() {
     # Launch in tmux with resilient wrapper for error handling
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
     tmux new-session -d -s "$session_name" -c "$worktree_path" \
-        "ENHANCER_ID=researcher-$agent_num REPO_ROOT=$REPO_ROOT $wrapper_script --daemon --prompt 'You are researcher-$agent_num. Read $prompt_file for your instructions, then start the research workflow.' --log '$log_file'"
+        "ENHANCER_ID=researcher-$agent_num REPO_ROOT=$REPO_ROOT CLAUDE_TIMEOUT=14400 $wrapper_script --daemon --prompt 'You are researcher-$agent_num. Read $prompt_file for your instructions, then start the research workflow.' --log '$log_file'"
 
     print_success "Launched $session_name (worktree: $worktree_path)"
 }


### PR DESCRIPTION
## Summary

Researchers working on large problems (yang-mills at 22K+ lines, 145 parts) consistently hit the 1-hour CLAUDE_TIMEOUT. With Opus 4.6's 1M token context, these files are well within capacity — the timeout was the bottleneck, not the model.

Sets `CLAUDE_TIMEOUT=14400` (4h) for researchers in both:
- `scripts/research/parallel-research.sh` (initial spawn)
- `scripts/lean/launch.sh` (daemon respawn)

## Test plan

- [ ] Researchers no longer show as STUCK after 1h
- [ ] Yang-mills deep dives complete without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)