### PR TITLE
Enrich 6 gallery entries: annotations, format fixes, axiom corrections

### DIFF
--- a/src/data/proofs/divisibility-truncation-general-oq-01/annotations.json
+++ b/src/data/proofs/divisibility-truncation-general-oq-01/annotations.json
@@ -7,8 +7,9 @@
     "title": "Unified Osculator Theorem",
     "content": "The single theorem that subsumes both positive and negative osculator rules:\n\n```lean\ntheorem unified_osculator (d : N) (c : Z) (n : N)\n    (hcop : IsCoprime (d : Z) 10)\n    (hc : (d : Z) | 10 * c - 1) :\n    (d : Z) | n <-> (d : Z) | (n/10 + c * (n%10))\n```\n\nFor $c > 0$ this gives the positive osculator (\"add $c$ times the last digit\").\nFor $c < 0$ this gives the negative osculator (\"subtract $|c|$ times the last digit\").\n\nThe proof uses the identity $10 \\cdot (n/10 + c \\cdot (n\\%10)) = n + (10c-1) \\cdot (n\\%10)$.",
     "mathContext": "$d | n \\iff d | (\\lfloor n/10 \\rfloor + c \\cdot (n \\bmod 10))$ when $d | (10c - 1)$",
-    "significance": "critical",
-    "relatedConcepts": ["osculator", "divisibility", "coprimality", "modular arithmetic"]
+    "significance": "key",
+    "relatedConcepts": ["osculator", "divisibility", "coprimality", "modular arithmetic"],
+    "prerequisites": ["IsCoprime", "Int.dvd_sub", "Nat.div_add_mod"]
   },
   {
     "id": "ann-neg-from-unified",
@@ -18,8 +19,9 @@
     "title": "Negative Osculator as Corollary",
     "content": "The negative osculator rule is a one-line corollary of the unified theorem:\n\n```lean\ntheorem neg_osculator_from_unified (d : N) (c : Z) (n : N)\n    (hcop : IsCoprime (d : Z) 10)\n    (hc : (d : Z) | 10 * c + 1) :\n    (d : Z) | n <-> (d : Z) | (n/10 - c * (n%10))\n```\n\nThe proof converts $d | (10c+1)$ to $d | (10(-c)-1)$ and applies the unified theorem with osculator $-c$.",
     "mathContext": "$d | (10c + 1) \\implies d | (10(-c) - 1)$",
-    "significance": "important",
-    "relatedConcepts": ["sign absorption", "osculator duality"]
+    "significance": "supporting",
+    "relatedConcepts": ["sign absorption", "osculator duality"],
+    "prerequisites": ["unified_osculator theorem", "integer negation"]
   },
   {
     "id": "ann-concrete-cases",
@@ -29,8 +31,9 @@
     "title": "Concrete Divisibility Rules",
     "content": "All five classical rules recovered from the unified framework:\n\n| Divisor | Osculator | Type | Rule |\n|---------|-----------|------|------|\n| 7 | c=-2 | negative | $7|n \\iff 7|(n/10 - 2(n\\%10))$ |\n| 11 | c=-1 | negative | $11|n \\iff 11|(n/10 - (n\\%10))$ |\n| 13 | c=4 | positive | $13|n \\iff 13|(n/10 + 4(n\\%10))$ |\n| 17 | c=-5 | negative | $17|n \\iff 17|(n/10 - 5(n\\%10))$ |\n| 19 | c=2 | positive | $19|n \\iff 19|(n/10 + 2(n\\%10))$ |",
     "mathContext": "Instantiation of the unified theorem for specific divisors",
-    "significance": "interesting",
-    "relatedConcepts": ["divisibility rules", "mental arithmetic"]
+    "significance": "context",
+    "relatedConcepts": ["divisibility rules", "mental arithmetic"],
+    "prerequisites": ["norm_num", "decide"]
   },
   {
     "id": "ann-dual-sum",
@@ -40,7 +43,8 @@
     "title": "Dual Osculator Sum Theorem",
     "content": "For any $d$ coprime to 10, the positive osculator $c_+$ and negative osculator $c_-$ satisfy $d | (c_+ + c_-)$.\n\nThis follows from $10c_+ \\equiv 1$ and $10c_- \\equiv -1 \\pmod{d}$, so $10(c_+ + c_-) \\equiv 0 \\pmod{d}$, and coprimality gives $d | (c_+ + c_-)$.\n\nFor minimal osculators, $c_+ + c_- = d$ (e.g., 5+2=7, 4+9=13, 12+5=17).",
     "mathContext": "$d | (c_+ + c_-)$ where $10c_+ \\equiv 1$ and $10c_- \\equiv -1 \\pmod{d}$",
-    "significance": "important",
-    "relatedConcepts": ["modular inverses", "osculator pairs"]
+    "significance": "supporting",
+    "relatedConcepts": ["modular inverses", "osculator pairs"],
+    "prerequisites": ["IsCoprime.dvd_of_dvd_mul_left", "modular arithmetic"]
   }
 ]


### PR DESCRIPTION
## Summary
Enrichment pass across 6 gallery entries, fixing annotation formats, adding missing annotations, and correcting axiom integrity.

### Entries enriched:
1. **triangular-reciprocals-oq-03** - Added 9 annotations (was empty), deepened historicalContext and keyInsights
2. **fermat-two-squares-oq-01** - Added 12 annotations (was empty), added composition algebra hierarchy insight
3. **angle-trisection-oq-02-oq-03-oq-01** - Rewrote annotations to proper schema, extended coverage from 371→740 lines, corrected "3 axioms" to "0 axioms"
4. **pythagorean-triples-oq-01** - Fixed wrapper format, corrected status "verified"→"axiomatized" (has 3 axioms)
5. **yang-mills-mass-gap** - Fixed wrapper format, fixed 3 annotation type/line warnings
6. **divisibility-truncation-general-oq-01** - Fixed non-standard significance values, added prerequisites

### Quality improvements:
- Total annotations added/fixed: ~55
- Format conversions (wrapper → flat array): 3 entries
- Axiom integrity corrections: 2 entries
- Annotation type/line/significance fixes: 5 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)