### PR TITLE
Fix missing title in erdos-701 and erdos-487 sections

### DIFF
--- a/src/data/proofs/erdos-487/meta.json
+++ b/src/data/proofs/erdos-487/meta.json
@@ -40,43 +40,50 @@
       "id": "density-lcm",
       "startLine": 47,
       "endLine": 82,
-      "summary": "Definitions for positive upper density, positive lower density, LCM triples, and divisibility chains."
+      "summary": "Definitions for positive upper density, positive lower density, LCM triples, and divisibility chains.",
+      "title": "Definitions for positive upper density, positive lower density, LCM triples, and divisibility chains."
     },
     {
       "id": "union-free",
       "startLine": 83,
       "endLine": 109,
-      "summary": "Definition of union-free collections and the prime factorization bijection connecting LCM to set union."
+      "summary": "Definition of union-free collections and the prime factorization bijection connecting LCM to set union.",
+      "title": "Definition of union-free collections and the prime factorization bijection connecting LCM to set union."
     },
     {
       "id": "davenport-erdos",
       "startLine": 110,
       "endLine": 156,
-      "summary": "The 1936 Davenport-Erdős result and the coprime multipliers LCM triple construction."
+      "summary": "The 1936 Davenport-Erdős result and the coprime multipliers LCM triple construction.",
+      "title": "The 1936 Davenport-Erdős result and the coprime multipliers LCM triple construction."
     },
     {
       "id": "kleitman",
       "startLine": 158,
       "endLine": 221,
-      "summary": "Kleitman's 1971 theorem bounding union-free collections, plus the o(2^n) corollary."
+      "summary": "Kleitman's 1971 theorem bounding union-free collections, plus the o(2^n) corollary.",
+      "title": "Kleitman's 1971 theorem bounding union-free collections, plus the o(2^n) corollary."
     },
     {
       "id": "main-result",
       "startLine": 223,
       "endLine": 243,
-      "summary": "The main theorem: dense sets contain LCM triples, plus infinitely many such triples."
+      "summary": "The main theorem: dense sets contain LCM triples, plus infinitely many such triples.",
+      "title": "The main theorem: dense sets contain LCM triples, plus infinitely many such triples."
     },
     {
       "id": "examples",
       "startLine": 245,
       "endLine": 310,
-      "summary": "Concrete examples including multiples of 6 (LCM triples exist) and powers of 2 (no LCM triples, but density 0)."
+      "summary": "Concrete examples including multiples of 6 (LCM triples exist) and powers of 2 (no LCM triples, but density 0).",
+      "title": "Concrete examples including multiples of 6 (LCM triples exist) and powers of 2 (no LCM triples, but density 0)."
     },
     {
       "id": "summary",
       "startLine": 335,
       "endLine": 368,
-      "summary": "Summary combining LCM triple existence and Kleitman's theorem."
+      "summary": "Summary combining LCM triple existence and Kleitman's theorem.",
+      "title": "Summary combining LCM triple existence and Kleitman's theorem."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-701/meta.json
+++ b/src/data/proofs/erdos-701/meta.json
@@ -39,37 +39,43 @@
       "id": "hereditary",
       "startLine": 42,
       "endLine": 71,
-      "summary": "Definitions of hereditary families with examples (power set, bounded cardinality)."
+      "summary": "Definitions of hereditary families with examples (power set, bounded cardinality).",
+      "title": "Definitions of hereditary families with examples (power set, bounded cardinality)."
     },
     {
       "id": "intersecting",
       "startLine": 72,
       "endLine": 99,
-      "summary": "Definitions of intersecting families with examples (empty, singleton)."
+      "summary": "Definitions of intersecting families with examples (empty, singleton).",
+      "title": "Definitions of intersecting families with examples (empty, singleton)."
     },
     {
       "id": "stars",
       "startLine": 100,
       "endLine": 129,
-      "summary": "Definition of stars and proofs that stars are intersecting and are subfamilies."
+      "summary": "Definition of stars and proofs that stars are intersecting and are subfamilies.",
+      "title": "Definition of stars and proofs that stars are intersecting and are subfamilies."
     },
     {
       "id": "conjecture",
       "startLine": 130,
       "endLine": 151,
-      "summary": "Statement of Chvátal's conjecture as a definition and axiom recording its open status."
+      "summary": "Statement of Chvátal's conjecture as a definition and axiom recording its open status.",
+      "title": "Statement of Chvátal's conjecture as a definition and axiom recording its open status."
     },
     {
       "id": "partial",
       "startLine": 152,
       "endLine": 218,
-      "summary": "Partial results: Sterboul conditions, Frankl-Kupavskii (covering number 2), Borg's weighted version."
+      "summary": "Partial results: Sterboul conditions, Frankl-Kupavskii (covering number 2), Borg's weighted version.",
+      "title": "Partial results: Sterboul conditions, Frankl-Kupavskii (covering number 2), Borg's weighted version."
     },
     {
       "id": "ekr",
       "startLine": 221,
       "endLine": 265,
-      "summary": "Connection to Erdős-Ko-Rado; proof that uniform families are not hereditary."
+      "summary": "Connection to Erdős-Ko-Rado; proof that uniform families are not hereditary.",
+      "title": "Connection to Erdős-Ko-Rado; proof that uniform families are not hereditary."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- ProofSection type requires `title` field but erdos-701 and erdos-487 meta.json had sections without it
- Added `title` from `summary` field to fix build error

## Test plan
- [x] `pnpm build` succeeds locally