### PR TITLE
Research: abel-ruffini-oq-01 - Remove dead sorry, document typeclass diamond

### DIFF
--- a/proofs/Proofs/InverseGaloisA5.lean
+++ b/proofs/Proofs/InverseGaloisA5.lean
@@ -1303,11 +1303,17 @@ theorem gal_permutes_roots (σ : q.Gal) (i : Fin 5) :
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, Equiv.permCongr_apply,
     Equiv.symm_apply_apply]
   -- Goal: σ ↑r = ↑(galActionHom σ r) where r : rootSet q SF
-  -- Mathematically: the Galois action on rootSet lifts to the field,
-  -- i.e., (σ • r).val = σ r.val. This is the definition of the SMul
-  -- instance on rootSet, but the coercion path through galActionHom →
-  -- MulAction.toPerm → SMul doesn't reduce to rfl after Mathlib v4.26.0.
-  -- Previously closed by `rfl`.
+  -- Mathematically: (σ • r).val = σ r.val. The galActionHom resolves to
+  -- galAction (not galActionAux) when E = SF, wrapping through rootsEquivRoots.
+  -- The proof requires showing algebraMap SF SF = id for the Gal-derived
+  -- Algebra SF SF instance (IsSplittingField.lift), which differs from Algebra.id.
+  -- Approach: galActionHom_restrict + restrict q SF σ = σ (AlgEquiv.ext via
+  -- restrictNormal_commutes + Algebra.algebraMap_self), but this hits a typeclass
+  -- diamond between Algebra.id SF and Gal.instAlgebra... (from IsSplittingField.lift).
+  -- The MonoidHom.mk' coercion also doesn't reduce by rfl; use erw [MonoidHom.mk'_apply]
+  -- to bridge it. The diamond can be resolved via Algebra.algebra_ext + showing
+  -- algebraMap SF SF r = r for the lift instance (needs IsSplittingField.lift specifics).
+  -- Previously closed by `rfl` when galActionAux was resolved instead of galAction.
   sorry
 
 /-- Vandermonde matrix with permuted input = row-permuted Vandermonde. -/
@@ -1356,12 +1362,8 @@ theorem gal_acts_on_vandermondeProduct (σ : q.Gal) :
     exact gal_map_vandermonde_entry σ i j
   · -- Step 3: det(V(rootEnum ∘ π)) = sign(π) · det(V)
     exact vandermonde_perm_det rootEnum (galToPerm5 σ)
-
-  -- σ(det V) = det(V(rootEnum ∘ π)) = sign(π) · det(V)
-  -- Proof: RingHom.map_det + gal_permutes_roots + vandermonde_perm_det
-  -- Blocked by coercion alignment: RingHom.map_det produces mapMatrix form,
-  -- while gal_permutes_roots provides Matrix.map form.
-  sorry
+  -- Note: Both trans branches close their goals. The sorry that was here
+  -- was dead code (confirmed: "No goals to be solved" on Docker build).
 
 -- Step 6: galSign(σ) = 1 for all σ
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Part XIX session - audited and corrected stats (5276 lines, 280 thms, 5 axiom declarations [4 independent], 2 sorries). Documented that gal_card_dvd_60 axiom is DERIVABLE from vandermondeProduct_sq_eq but elimination refactoring is blocked by Lean elaboration context sensitivity.",
+    "progressSummary": "Removed dead sorry from gal_acts_on_vandermondeProduct (1 actual sorry remains). Documented typeclass diamond blocking gal_permutes_roots.",
     "builtItems": [
       "InverseGalois.lean: cyclotomic Galois theory, S₃ realization via Gal(X³-2)≅S₃ (905 lines, builds)",
       "InverseGaloisD4.lean: D₄ realization via |Gal(X⁴-2)| = 8 (666 lines, builds)",
@@ -164,7 +164,8 @@
       "all_gal_signs_positive: ∀ σ, galSign σ = 1 (from chain)",
       "gal_card_dvd_60_proved: |Gal| ∣ 60 proved from transparent axiom",
       "Fixed Mathlib v4.26.0 API breaks: Subgroup.card_dvd_of_le (Nat.card→Fintype.card), Finset.prod_ne_zero",
-      "meta.json: corrected stats to 5276 lines, 280 thms, 5 axiom declarations (4 independent)"
+      "meta.json: corrected stats to 5276 lines, 280 thms, 5 axiom declarations (4 independent)",
+      "Removed dead sorry from gal_acts_on_vandermondeProduct (was dead code)"
     ],
     "insights": [
       "Cyclotomic irreducibility over ℚ IS in Mathlib: Polynomial.cyclotomic.irreducible_rat",
@@ -225,7 +226,9 @@
       "MulAction.toPermHom is the underlying API for galActionHom on rootSet - needs careful coercion work",
       "sq_sub_sq gives (a+b)(a-b)=0 for domain reasoning without linear order",
       "Moving the Vandermonde chain (Parts XIII-XIV) before q_gal_card causes elaboration failures: the change+rfl proof in gal_permutes_roots depends on instance resolution context that differs at the earlier file position",
-      "The (Z/nZ)* cyclotomic approach is exhausted for abelian groups up to order 24; remaining groups (C3^2, C4^2, C2^4, Q8) require Galois correspondence or non-cyclotomic constructions"
+      "The (Z/nZ)* cyclotomic approach is exhausted for abelian groups up to order 24; remaining groups (C3^2, C4^2, C2^4, Q8) require Galois correspondence or non-cyclotomic constructions",
+      "Removed dead sorry from gal_acts_on_vandermondeProduct - reducing actual sorry count to 1",
+      "gal_permutes_roots blocked by typeclass diamond: Algebra.id vs IsSplittingField.lift instance"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- Removed dead sorry from `gal_acts_on_vandermondeProduct` in InverseGaloisA5.lean
- Documented the typeclass diamond blocking `gal_permutes_roots` proof
- Actual sorry count reduced from 2 to 1 in InverseGaloisA5.lean

## Progress
- **Dead sorry removed**: The sorry at line 1364 in `gal_acts_on_vandermondeProduct` was dead code — both `trans` branches fully close their goals (confirmed by Docker: "No goals to be solved")
- **Typeclass diamond documented**: `gal_permutes_roots` is blocked by a diamond between `Algebra.id SF` and `Gal.instAlgebra...` (constructed via `IsSplittingField.lift`). The `MonoidHom.mk'` coercion also doesn't reduce by `rfl` (needs `erw [MonoidHom.mk'_apply]`). Previously worked when `galActionAux` was resolved; now `galAction` wraps through `rootsEquivRoots`.

## Findings
- `galActionHom q q.SplittingField` resolves to `galAction` (not `galActionAux`) in Mathlib v4.26.0, adding a `rootsEquivRoots` wrapper
- `restrict q SF σ = σ` proof requires bridging `MonoidHom.mk'` coercion (via `erw`) + resolving `Algebra.id SF ≠ Gal.instAlgebra...` diamond (via `Algebra.algebra_ext` + showing `algebraMap SF SF = id` for the lift instance)
- The diamond goal `Algebra.id SF = Gal.instAlgebra...` requires showing `IsSplittingField.lift SF q h` is the identity, which needs Mathlib-specific API

## Status
**Outcome**: progress
**Next Steps**: Resolve the typeclass diamond, possibly by finding a Mathlib lemma showing `IsSplittingField.lift` to the same splitting field is identity

Generated by researcher-5