### PR TITLE
Research: friendship-theorem-oq-01 - Prove det(kI-A)=0 via adjugate

### DIFF
--- a/proofs/Proofs/FriendshipTheoremOQ01.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ01.lean
@@ -882,4 +882,49 @@ for `Algebra ℤ (Matrix V V ℤ)` and `IsIntegral ℤ (G.adjMatrix ℤ)`.
 Optimization: provide instances explicitly or work over ℚ.
 -/
 
+-- ============================================================================
+-- Part XV: det(kI - A) = 0 (k is an eigenvalue)
+-- ============================================================================
+
+/-- Over an integral domain: if M·v = 0 and v ≠ 0, then det(M) = 0.
+    Uses the adjugate identity adj(M)·M = det(M)·I:
+    det(M)·v = adj(M)·(M·v) = adj(M)·0 = 0, and v ≠ 0 forces det(M) = 0. -/
+theorem det_eq_zero_of_mulVec_eq_zero
+    {M : Matrix V V ℤ} {v : V → ℤ} (hv : v ≠ 0) (hMv : M.mulVec v = 0) :
+    M.det = 0 := by
+  -- From adj(M) * M = det(M) • I, deduce det(M) • v = 0
+  have hdetv : M.det • v = 0 := by
+    calc M.det • v
+        = (M.det • (1 : Matrix V V ℤ)).mulVec v := by
+            simp [Matrix.smul_mulVec, Matrix.one_mulVec]
+      _ = (M.adjugate * M).mulVec v := by rw [Matrix.adjugate_mul]
+      _ = M.adjugate.mulVec (M.mulVec v) := by rw [Matrix.mulVec_mulVec]
+      _ = M.adjugate.mulVec 0 := by rw [hMv]
+      _ = 0 := by rw [Matrix.mulVec_zero]
+  -- v ≠ 0 means some entry is nonzero
+  obtain ⟨i, hi⟩ : ∃ i, v i ≠ 0 := by
+    by_contra h; push_neg at h; exact hv (funext h)
+  -- det(M) * v(i) = 0 and v(i) ≠ 0 forces det(M) = 0
+  have := congr_fun hdetv i
+  simp only [Pi.smul_apply, smul_eq_mul, Pi.zero_apply] at this
+  exact (mul_eq_zero.mp this).resolve_right hi
+
+/-- **det(kI - A) = 0**: The matrix kI - A has a nontrivial kernel (the all-ones
+    vector), so its determinant is zero.
+    This means k is a root of the characteristic polynomial det(XI - A). -/
+theorem det_kI_sub_adjMatrix_eq_zero (k : ℕ) (hreg : ∀ v : V, G.degree v = k)
+    [Nonempty V] :
+    (↑k • (1 : Matrix V V ℤ) - G.adjMatrix ℤ).det = 0 := by
+  apply det_eq_zero_of_mulVec_eq_zero (v := fun _ => (1 : ℤ))
+  · -- 𝟙 = (fun _ => 1) ≠ 0 since V is nonempty
+    intro h
+    have := congr_fun h (Classical.arbitrary V)
+    norm_num at this
+  · -- (kI - A) · 𝟙 = k𝟙 - A𝟙 = k𝟙 - k𝟙 = 0
+    ext i
+    simp only [Matrix.sub_mulVec, Matrix.smul_mulVec, Matrix.one_mulVec,
+      Pi.sub_apply, Pi.smul_apply, Pi.zero_apply, smul_eq_mul]
+    rw [adjMatrix_mulVec_ones G k hreg i]
+    ring
+
 end FriendshipTheoremOQ01

--- a/src/data/research/problems/friendship-theorem-oq-01.json
+++ b/src/data/research/problems/friendship-theorem-oq-01.json
@@ -50,7 +50,9 @@
       "charpoly_eigenvalue_data: refined axiom (replaces spectral_regular_friendship)",
       "spectral_regular_friendship: NOW A THEOREM from charpoly_eigenvalue_data",
       "annihilating_polynomial: aeval A ((X-k)(X²-(k-1))) = 0 (PROVED via Polynomial.aeval bridge)",
-      "minpoly_dvd_annihilating: minpoly ℤ A | (X-k)(X²-(k-1)) (correct but times out at 800K heartbeats)"
+      "minpoly_dvd_annihilating: minpoly ℤ A | (X-k)(X²-(k-1)) (correct but times out at 800K heartbeats)",
+      "det_eq_zero_of_mulVec_eq_zero: M·v=0, v≠0 → det(M)=0 via adjugate (PROVED)",
+      "det_kI_sub_adjMatrix_eq_zero: det(kI-A)=0 for k-regular friendship (PROVED)"
     ],
     "insights": [
       "Proof verified: 0 sorries via grep",
@@ -74,7 +76,8 @@
       "nsmul and Nat.cast are distinct in Lean 4: n•(1:ℤ) needs explicit lemma to equal ↑n",
       "Elimination path fully mapped: minpoly.dvd → irreducibility of X²-(k-1) → charpoly factorization → trace coefficient → eigenvalue existence contradiction",
       "Polynomial.aeval bridge: simp with [map_mul, map_sub, aeval_X, aeval_C, Algebra.algebraMap_eq_smul_one, sq, ← sub_smul] converts matrix equation to polynomial evaluation",
-      "minpoly.dvd over Matrix V V ℤ causes timeout due to heavy Algebra/IsIntegral instance resolution"
+      "minpoly.dvd over Matrix V V ℤ causes timeout due to heavy Algebra/IsIntegral instance resolution",
+      "det(M)=0 from nontrivial kernel over integral domain: uses adj(M)·M = det(M)·I, then det·v=0 with v≠0 forces det=0"
     ],
     "mathlibGaps": [
       "Full spectral theorem for real symmetric matrices in a form that gives integer eigenvalue multiplicities",


### PR DESCRIPTION
## Summary
- Prove `det_eq_zero_of_mulVec_eq_zero`: general theorem for integral domains using adjugate identity
- Prove `det_kI_sub_adjMatrix_eq_zero`: k is an eigenvalue of the adjacency matrix

## Progress
- **det_eq_zero_of_mulVec_eq_zero**: If M·v = 0 and v ≠ 0 over an integral domain, then det(M) = 0. Uses adj(M)·M = det(M)·I from Mathlib.
- **det_kI_sub_adjMatrix_eq_zero**: Since (kI-A)·𝟙 = 0 (from adjMatrix_mulVec_ones) and 𝟙 ≠ 0, det(kI-A) = 0.
- This establishes that k is a root of charpoly (pending the eval_det bridge connecting det(kI-A) to charpoly.eval k).

## Status
**File**: ~930 lines, 0 sorries, 1 axiom
**Outcome**: progress
**Next Steps**: Connect det(kI-A)=0 to charpoly.IsRoot k; optimize minpoly_dvd heartbeats

🤖 Generated by researcher-5