### PR TITLE
Research: abel-ruffini-oq-01 - Resultant-based axiom elimination

### DIFF
--- a/proofs/Proofs/InverseGaloisA5.lean
+++ b/proofs/Proofs/InverseGaloisA5.lean
@@ -1506,9 +1506,35 @@ theorem prod_eval_derivative_eq_resultant :
 
 /-- Res(q, q') = disc(q) over ℚ (for monic q with degree 5).
     From `resultant_deriv`: Res = (-1)^10 · 1 · disc = disc. -/
+private theorem q_derivative_natDegree : (Polynomial.derivative q).natDegree = 4 := by
+  unfold q; simp only [Polynomial.derivative_sub, Polynomial.derivative_add,
+    Polynomial.derivative_C_mul, Polynomial.derivative_pow,
+    Polynomial.derivative_X, Polynomial.derivative_C]
+  compute_degree!
+
 theorem resultant_eq_disc_q :
     Polynomial.resultant q (Polynomial.derivative q) = Polynomial.discr q := by
-  sorry
+  -- Resultant default args are natDegree, need to match resultant_deriv's bounds
+  -- resultant_deriv uses q.natDegree and (q.natDegree - 1)
+  -- We need (derivative q).natDegree = q.natDegree - 1 = 4
+  have hnd : (Polynomial.derivative q).natDegree = q.natDegree - 1 := by
+    rw [q_natDegree, q_derivative_natDegree]
+  -- Unfold default args to explicit bounds
+  show q.resultant (Polynomial.derivative q) q.natDegree (Polynomial.derivative q).natDegree =
+    Polynomial.discr q
+  rw [hnd]
+  -- Now: q.resultant q' q.natDegree (q.natDegree - 1) = disc q
+  have hdeg : (0 : WithBot ℕ) < q.degree := by unfold q; compute_degree!
+  have h := Polynomial.resultant_deriv hdeg
+  -- h : q.resultant q' q.natDegree (q.natDegree - 1) = (-1)^{n(n-1)/2} * lc * disc
+  rw [q_natDegree] at h ⊢
+  simp only [show 5 * (5 - 1) / 2 = 10 from by norm_num] at h
+  rw [pow_succ, pow_succ, pow_succ, pow_succ, pow_succ,
+    pow_succ, pow_succ, pow_succ, pow_succ, pow_succ, pow_zero,
+    neg_one_mul, neg_neg, neg_one_mul, neg_neg, neg_one_mul, neg_neg,
+    neg_one_mul, neg_neg, neg_one_mul, neg_neg, one_mul] at h
+  rw [q_monic.leadingCoeff, one_mul] at h
+  exact h
 
 -- Step H: Discriminant computation
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1517,7 +1543,11 @@ theorem resultant_eq_disc_q :
     The discriminant of X⁵ - 5X⁴ + 10X³ - 10X² + 25X - 5
     equals 2¹⁶ · 5⁶ = 1024000000. -/
 theorem disc_q_val : Polynomial.discr q = (1024000000 : ℚ) := by
-  sorry
+  -- disc(q) = Res(q, q') · (-1)^{n(n-1)/2} / lc(q)
+  -- For monic q degree 5: disc = Res(q, q')
+  -- Res is a 9×9 Sylvester matrix determinant over ℚ
+  -- native_decide should handle this (computable determinant)
+  native_decide
 
 -- Step I: Transfer resultant through algebraMap
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1527,7 +1557,15 @@ theorem disc_q_val : Polynomial.discr q = (1024000000 : ℚ) := by
 theorem resultant_transfer :
     Polynomial.resultant q_SF (Polynomial.derivative q_SF) =
     algebraMap ℚ SF (Polynomial.resultant q (Polynomial.derivative q)) := by
-  sorry
+  -- q_SF = map (algebraMap ℚ SF) q
+  -- derivative(q_SF) = map (algebraMap ℚ SF) (derivative q) [derivative commutes with map]
+  -- resultant_map_map: Res(map φ f, map φ g) m n = φ(Res(f,g) m n)
+  show (Polynomial.map (algebraMap ℚ SF) q).resultant
+    (Polynomial.derivative (Polynomial.map (algebraMap ℚ SF) q)) =
+    algebraMap ℚ SF (q.resultant (Polynomial.derivative q))
+  rw [Polynomial.derivative_map]
+  exact Polynomial.resultant_map_map q (Polynomial.derivative q)
+    q.natDegree (Polynomial.derivative q).natDegree (algebraMap ℚ SF)
 
 -- Step J: Assemble the proof
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/proofs/Proofs/InverseGaloisA5.lean
+++ b/proofs/Proofs/InverseGaloisA5.lean
@@ -1394,4 +1394,166 @@ vandermondeProduct_sq_eq, which asserts disc(f) = Δ² for monic polynomials.
 a standard identity but not yet available in Mathlib.
 -/
 
+-- ============================================================================
+-- Part XV: Eliminating vandermondeProduct_sq_eq Axiom
+-- ============================================================================
+
+/-
+## Proof Strategy
+
+The axiom `vandermondeProduct_sq_eq` states:
+  Δ² = algebraMap ℤ SF 1024000000
+where Δ = ∏_{i<j} (rootEnum j - rootEnum i).
+
+We eliminate it using Mathlib's resultant API:
+
+1. **resultant_deriv**: Res(q, q') = (-1)^{n(n-1)/2} · lc(q) · disc(q)
+   For monic q with n=5: Res(q, q') = disc(q)
+
+2. **resultant_map_map**: Res(map φ f, map φ g) = φ(Res(f, g))
+   Transfers the resultant from ℚ to SplittingField
+
+3. **resultant_eq_prod_eval**: Res(f, g) = lc(f)^deg(g) · ∏ eval αᵢ g
+   For monic splitting f: Res(f, g) = ∏ eval αᵢ g
+
+4. **Derivative at root**: q'(αᵢ) = ∏_{j≠i} (αᵢ - αⱼ)
+   From q = (X - αᵢ) · r, so q' = r + (X - αᵢ) · r', eval αᵢ gives r(αᵢ)
+
+5. **Pairing**: ∏_i ∏_{j≠i} (αᵢ - αⱼ) = vandermondeProduct²
+   Since ∏_{i≠j} (αᵢ - αⱼ) = (-1)^{C(5,2)} · vandermondeProduct² = vandermondeProduct²
+
+Chain: vandermondeProduct² = ∏_{i≠j} (αᵢ - αⱼ) = ∏ q'(αᵢ) = Res(q, q') = disc(q) = 1024000000
+-/
+
+section VandermondeElimination
+
+-- Abbreviation for the splitting field
+private abbrev SF := q.SplittingField
+
+-- The mapped polynomial in the splitting field
+private noncomputable abbrev q_SF : Polynomial SF := Polynomial.map (algebraMap ℚ SF) q
+
+-- Step A: The ordered product ∏_{i≠j} (αᵢ - αⱼ) equals vandermondeProduct²
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- The product over all ordered pairs (i,j) with i≠j of (rootEnum i - rootEnum j)
+    equals the Vandermonde product squared. For n=5, (-1)^{C(5,2)} = 1. -/
+theorem ordered_root_diff_prod_eq_vandermonde_sq :
+    (∏ i : Fin 5, ∏ j in Finset.univ.erase i, (rootEnum i - rootEnum j)) =
+    vandermondeProduct ^ 2 := by
+  -- vandermondeProduct = det(vandermonde(rootEnum)) = ∏_{i<j} (rootEnum j - rootEnum i)
+  unfold vandermondeProduct
+  rw [Matrix.det_vandermonde]
+  -- Goal: ∏_i ∏_{j≠i} (αᵢ - αⱼ) = (∏_{i<j} (αⱼ - αᵢ))²
+  -- Split ordered pairs into i<j and i>j, then pair up
+  sorry
+
+-- Step B: Connect derivative evaluation to root differences
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- For a monic polynomial that factors as (X - α) * r in the splitting field,
+    the derivative evaluated at α equals r(α). -/
+theorem eval_derivative_at_root_of_factor {K : Type*} [Field K]
+    (f r : Polynomial K) (α : K) (hf : f = (X - C α) * r) :
+    Polynomial.eval α (Polynomial.derivative f) = Polynomial.eval α r := by
+  rw [hf, Polynomial.derivative_mul]
+  simp only [Polynomial.eval_add, Polynomial.eval_mul, Polynomial.derivative_sub,
+    Polynomial.derivative_X, Polynomial.derivative_C, sub_zero,
+    Polynomial.eval_sub, Polynomial.eval_X, Polynomial.eval_C,
+    Polynomial.eval_one, sub_self, zero_mul, add_zero, one_mul]
+
+-- Step C: q splits as product of linear factors
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- q mapped to its splitting field splits as ∏ (X - rootEnum i). -/
+theorem q_SF_eq_prod_linear :
+    q_SF = ∏ i : Fin 5, (X - C (rootEnum i)) := by
+  sorry
+
+-- Step D: Derivative at rootEnum i gives the product of root differences
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- The derivative of q_SF evaluated at rootEnum i equals
+    ∏_{j≠i} (rootEnum i - rootEnum j). -/
+theorem eval_derivative_q_at_root (i : Fin 5) :
+    Polynomial.eval (rootEnum i) (Polynomial.derivative q_SF) =
+    ∏ j in Finset.univ.erase i, (rootEnum i - rootEnum j) := by
+  sorry
+
+-- Step E: Product of derivative evaluations = ordered root difference product
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- ∏_i q'(αᵢ) = ∏_i ∏_{j≠i} (αᵢ - αⱼ). -/
+theorem prod_eval_derivative_eq_ordered_diff :
+    (∏ i : Fin 5, Polynomial.eval (rootEnum i)
+      (Polynomial.derivative q_SF)) =
+    ∏ i : Fin 5, ∏ j in Finset.univ.erase i, (rootEnum i - rootEnum j) := by
+  congr 1; ext i; exact eval_derivative_q_at_root i
+
+-- Step F: Connect to resultant via Mathlib
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- The product of derivative evaluations equals Res(q_SF, q'_SF).
+    Uses `resultant_eq_prod_eval` from Mathlib. -/
+theorem prod_eval_derivative_eq_resultant :
+    (∏ i : Fin 5, Polynomial.eval (rootEnum i)
+      (Polynomial.derivative q_SF)) =
+    Polynomial.resultant q_SF (Polynomial.derivative q_SF) := by
+  sorry
+
+-- Step G: Resultant to discriminant
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- Res(q, q') = disc(q) over ℚ (for monic q with degree 5).
+    From `resultant_deriv`: Res = (-1)^10 · 1 · disc = disc. -/
+theorem resultant_eq_disc_q :
+    Polynomial.resultant q (Polynomial.derivative q) = Polynomial.discr q := by
+  sorry
+
+-- Step H: Discriminant computation
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- disc(q) = 1024000000 over ℚ.
+    The discriminant of X⁵ - 5X⁴ + 10X³ - 10X² + 25X - 5
+    equals 2¹⁶ · 5⁶ = 1024000000. -/
+theorem disc_q_val : Polynomial.discr q = (1024000000 : ℚ) := by
+  sorry
+
+-- Step I: Transfer resultant through algebraMap
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- Res(q_SF, q'_SF) = algebraMap ℚ SF (Res(q, q')).
+    From `resultant_map_map`. -/
+theorem resultant_transfer :
+    Polynomial.resultant q_SF (Polynomial.derivative q_SF) =
+    algebraMap ℚ SF (Polynomial.resultant q (Polynomial.derivative q)) := by
+  sorry
+
+-- Step J: Assemble the proof
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/-- **Main theorem**: vandermondeProduct² = algebraMap ℤ SF 1024000000.
+    Eliminates the `vandermondeProduct_sq_eq` axiom via Mathlib's resultant API.
+
+    Proof chain:
+    VP² = ∏_{i≠j}(αᵢ-αⱼ) = ∏ q'(αᵢ) = Res(q,q') = disc(q) = 1024000000 -/
+theorem vandermondeProduct_sq_eq_proved :
+    vandermondeProduct ^ 2 = algebraMap ℤ SF 1024000000 := by
+  -- Chain: VP² = ∏_{i≠j} diff = ∏ q'(αᵢ) = Res(q_SF, q'_SF)
+  --        = algebraMap ℚ SF (Res(q,q')) = algebraMap ℚ SF (disc q) = algebraMap ℚ SF 1024000000
+  calc vandermondeProduct ^ 2
+      = ∏ i : Fin 5, ∏ j in Finset.univ.erase i, (rootEnum i - rootEnum j) :=
+        (ordered_root_diff_prod_eq_vandermonde_sq).symm
+    _ = ∏ i : Fin 5, Polynomial.eval (rootEnum i) (Polynomial.derivative q_SF) :=
+        (prod_eval_derivative_eq_ordered_diff).symm
+    _ = Polynomial.resultant q_SF (Polynomial.derivative q_SF) :=
+        prod_eval_derivative_eq_resultant
+    _ = algebraMap ℚ SF (Polynomial.resultant q (Polynomial.derivative q)) :=
+        resultant_transfer
+    _ = algebraMap ℚ SF (Polynomial.discr q) := by rw [resultant_eq_disc_q]
+    _ = algebraMap ℚ SF 1024000000 := by rw [disc_q_val]
+    _ = algebraMap ℤ SF 1024000000 := by simp only [map_intCast]
+
+end VandermondeElimination
+
 end InverseGaloisA5

--- a/proofs/Proofs/InverseGaloisA5.lean
+++ b/proofs/Proofs/InverseGaloisA5.lean
@@ -1482,13 +1482,19 @@ theorem ordered_root_diff_prod_eq_vandermonde_sq :
   congr 1
   -- Need: ∏_i ∏_{j>i} (αᵢ-αⱼ) = ∏_i ∏_{j>i} (αⱼ-αᵢ)
   -- Each factor (αᵢ-αⱼ) = -(αⱼ-αᵢ), and there are 10 such factors
-  -- (-1)^10 = 1, so the products are equal
-  have h_neg : ∀ i j : Fin 5, rootEnum i - rootEnum j = -(rootEnum j - rootEnum i) := by
-    intros; ring
-  simp_rw [h_neg]
-  simp only [Finset.prod_neg_distrib, neg_neg]
-  -- Goal: (-1)^|Ioi i| for each i, then product = (-1)^(total) · VP = VP
-  sorry
+  -- Each (αᵢ-αⱼ) = -(αⱼ-αᵢ), factor out negatives
+  simp_rw [show ∀ i j : Fin 5, rootEnum i - rootEnum j = -(rootEnum j - rootEnum i) from
+    fun _ _ => by ring]
+  simp only [Finset.prod_neg]
+  -- Each inner product becomes (-1)^|Ioi i| * ∏_{j>i} (αⱼ-αᵢ)
+  rw [Finset.prod_mul_distrib]
+  -- Need: (∏_i (-1)^|Ioi i|) * VP = VP, i.e., (-1)^(∑|Ioi i|) = 1
+  suffices h : ∏ i : Fin 5, (-1 : q.SplittingField) ^ (Finset.Ioi i).card = 1 by
+    rw [h, one_mul]
+  rw [Finset.prod_pow_eq_pow_sum]
+  -- ∑ i : Fin 5, |Ioi i| = 4+3+2+1+0 = 10
+  have hsum : ∑ i : Fin 5, (Finset.Ioi i).card = 10 := by decide
+  rw [hsum, show (10 : ℕ) = 2 * 5 from by norm_num, pow_mul, neg_one_sq, one_pow]
 
 -- Step B: Connect derivative evaluation to root differences
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/proofs/Proofs/InverseGaloisA5.lean
+++ b/proofs/Proofs/InverseGaloisA5.lean
@@ -1516,6 +1516,13 @@ theorem eval_derivative_at_root_of_factor {K : Type*} [Field K]
 /-- q mapped to its splitting field splits as ∏ (X - rootEnum i). -/
 theorem q_SF_eq_prod_linear :
     q_SF = ∏ i : Fin 5, (X - C (rootEnum i)) := by
+  -- Uses: C_leadingCoeff_mul_prod_multiset_X_sub_C (for q_SF with roots.card = 5)
+  -- Then: convert Multiset.prod to Finset.prod via rootSet ≃ Fin 5
+  -- Key ingredients:
+  --   q_monic.map: q_SF is monic (lc = 1)
+  --   SplittingField.splits: q_SF splits
+  --   q_rootSet_card: rootSet has card 5
+  --   rootEnum defined via Fintype.equivOfCardEq on rootSet ≃ Fin 5
   sorry
 
 -- Step D: Derivative at rootEnum i gives the product of root differences

--- a/proofs/Proofs/InverseGaloisA5.lean
+++ b/proofs/Proofs/InverseGaloisA5.lean
@@ -1438,14 +1438,56 @@ private noncomputable abbrev q_SF : Polynomial SF := Polynomial.map (algebraMap 
 
 /-- The product over all ordered pairs (i,j) with i≠j of (rootEnum i - rootEnum j)
     equals the Vandermonde product squared. For n=5, (-1)^{C(5,2)} = 1. -/
+/-- General lemma: for a function v : Fin n → R in a commutative ring,
+    the product ∏_i ∏_{j<i} (v i - v j) equals the Vandermonde product ∏_{i<j} (v j - v i).
+    This is because swapping indices (i,j) ↔ (j,i) just relabels the same set of pairs. -/
+private theorem prod_Iio_eq_vandermonde {n : ℕ} {R : Type*} [CommRing R]
+    (v : Fin n → R) :
+    (∏ i : Fin n, ∏ j in Finset.Iio i, (v i - v j)) =
+    ∏ i : Fin n, ∏ j in Finset.Ioi i, (v j - v i) := by
+  -- Both sides are products over the same set of pairs {(i,j) : i > j} vs {(i,j) : i < j}
+  -- related by (i,j) → (j,i) and (v i - v j) → (v j' - v i') where i'=j, j'=i
+  rw [Finset.prod_sigma', Finset.prod_sigma']
+  apply Finset.prod_nbij (fun ⟨i, j⟩ => ⟨j, i⟩)
+  · intro ⟨i, j⟩ h
+    simp only [Finset.mem_sigma, Finset.mem_univ, Finset.mem_Ioi, Finset.mem_Iio, true_and] at h ⊢
+    exact h
+  · intro ⟨i₁, j₁⟩ ⟨i₂, j₂⟩ _ _ h
+    simp only [Sigma.mk.inj_iff] at h
+    exact Sigma.mk.inj_iff.mpr ⟨h.2, h.1⟩
+  · intro ⟨i, j⟩ h
+    simp only [Finset.mem_sigma, Finset.mem_univ, Finset.mem_Ioi, true_and] at h
+    exact ⟨⟨j, i⟩, by simp [Finset.mem_sigma, Finset.mem_Iio, h], by simp⟩
+  · intro ⟨i, j⟩ _; rfl
+
 theorem ordered_root_diff_prod_eq_vandermonde_sq :
     (∏ i : Fin 5, ∏ j in Finset.univ.erase i, (rootEnum i - rootEnum j)) =
     vandermondeProduct ^ 2 := by
-  -- vandermondeProduct = det(vandermonde(rootEnum)) = ∏_{i<j} (rootEnum j - rootEnum i)
   unfold vandermondeProduct
-  rw [Matrix.det_vandermonde]
-  -- Goal: ∏_i ∏_{j≠i} (αᵢ - αⱼ) = (∏_{i<j} (αⱼ - αᵢ))²
-  -- Split ordered pairs into i<j and i>j, then pair up
+  rw [Matrix.det_vandermonde, sq]
+  -- Split erase i = Iio i ∪ Ioi i (partition of {j ≠ i})
+  conv_lhs =>
+    arg 2; ext i
+    rw [show Finset.univ.erase i = Finset.Iio i ∪ Finset.Ioi i from by
+      ext j; simp [Finset.mem_erase, Finset.mem_Iio, Finset.mem_Ioi, ne_iff_lt_or_gt]]
+    rw [Finset.prod_union (by
+      rw [Finset.disjoint_left]; intro j hj1 hj2
+      simp [Finset.mem_Iio] at hj1; simp [Finset.mem_Ioi] at hj2; omega)]
+  rw [Finset.prod_mul_distrib]
+  -- LHS = (∏_i ∏_{j<i} (αᵢ-αⱼ)) * (∏_i ∏_{j>i} (αᵢ-αⱼ))
+  -- First factor: ∏_i ∏_{j<i} (αᵢ-αⱼ) = VP (index swap bijection)
+  rw [prod_Iio_eq_vandermonde]
+  -- Second factor: ∏_i ∏_{j>i} (αᵢ-αⱼ) = ∏_i ∏_{j>i} -(αⱼ-αᵢ)
+  --   = (-1)^10 · VP = VP (since C(5,2)=10, even)
+  congr 1
+  -- Need: ∏_i ∏_{j>i} (αᵢ-αⱼ) = ∏_i ∏_{j>i} (αⱼ-αᵢ)
+  -- Each factor (αᵢ-αⱼ) = -(αⱼ-αᵢ), and there are 10 such factors
+  -- (-1)^10 = 1, so the products are equal
+  have h_neg : ∀ i j : Fin 5, rootEnum i - rootEnum j = -(rootEnum j - rootEnum i) := by
+    intros; ring
+  simp_rw [h_neg]
+  simp only [Finset.prod_neg_distrib, neg_neg]
+  -- Goal: (-1)^|Ioi i| for each i, then product = (-1)^(total) · VP = VP
   sorry
 
 -- Step B: Connect derivative evaluation to root differences

--- a/research/problems/abel-ruffini-oq-01/knowledge.md
+++ b/research/problems/abel-ruffini-oq-01/knowledge.md
@@ -4,6 +4,72 @@
 
 The Inverse Galois Problem (IGP) asks: for every finite group G, does there exist a Galois extension K/ℚ with Gal(K/ℚ) ≅ G?
 
+## Session 2026-03-20 (researcher-2) - Axiom Elimination via Resultant API
+
+**Mode**: REVISIT (RICH knowledge, score 127)
+**Outcome**: progress — complete proof architecture for eliminating vandermondeProduct_sq_eq axiom
+
+### Key Discovery: Mathlib's Resultant API
+
+Mathlib (v4.26.0) has exactly the API needed to eliminate the `vandermondeProduct_sq_eq` axiom:
+
+1. **`Polynomial.resultant_eq_prod_eval`**: Res(f,g) = lc(f)^n · ∏ eval αᵢ g (for splitting f)
+2. **`Polynomial.resultant_deriv`**: Res(f,f') = (-1)^{n(n-1)/2} · lc(f) · disc(f)
+3. **`Polynomial.resultant_map_map`**: Res(map φ f, map φ g) m n = φ(Res(f,g) m n)
+4. **`Polynomial.resultant_prod_left`**: Res(∏ fᵢ, g) = ∏ Res(fᵢ, g)
+5. **`Polynomial.resultant_X_sub_C_left`**: Res(X-r, g) = eval r g
+
+**Important**: `Polynomial.resultant` takes 4 args (f, g, m, n) with defaults m=natDegree f, n=natDegree g.
+
+### Proof Chain
+
+vandermondeProduct² = ∏_{i≠j}(αᵢ-αⱼ) = ∏ᵢ q'(αᵢ) = Res(q,q') = disc(q) = 1024000000
+
+Steps:
+- A: ∏_{i≠j}(αᵢ-αⱼ) = VP² [pairing, (-1)^10 = 1]
+- B: f=(X-α)·r ⟹ f'(α) = r(α) [derivative product rule]
+- C: q_SF = ∏(X - rootEnum i) [splitting]
+- D: q'(αᵢ) = ∏_{j≠i}(αᵢ-αⱼ) [from B+C]
+- E: ∏ q'(αᵢ) = ∏_{i≠j}(αᵢ-αⱼ) [product over i of step D]
+- F: ∏ q'(αᵢ) = Res(q_SF, q'_SF) [resultant_eq_prod_eval]
+- G: Res(q,q') = disc(q) [resultant_deriv, n=5, (-1)^10=1]
+- H: disc(q) = 1024000000 [computation]
+- I: Res(q_SF, q'_SF) = algebraMap(Res(q,q')) [resultant_map_map]
+
+### What Was Built (Part XV, ~130 lines)
+
+| Theorem | Status | Description |
+|---------|--------|-------------|
+| `ordered_root_diff_prod_eq_vandermonde_sq` | sorry | ∏_{i≠j}diff = VP² |
+| `eval_derivative_at_root_of_factor` | proved | f=(X-α)r → f'(α)=r(α) |
+| `q_SF_eq_prod_linear` | sorry | q splits as ∏(X-αᵢ) |
+| `eval_derivative_q_at_root` | sorry | q'(αᵢ) = ∏_{j≠i}(αᵢ-αⱼ) |
+| `prod_eval_derivative_eq_ordered_diff` | proved | ∏q'(αᵢ) = ∏∏(diff) |
+| `prod_eval_derivative_eq_resultant` | sorry | ∏q'(αᵢ) = Res |
+| `resultant_eq_disc_q` | sorry | Res = disc(q) |
+| `disc_q_val` | sorry | disc(q) = 1024000000 |
+| `resultant_transfer` | sorry | Res transfer via algebraMap |
+| `vandermondeProduct_sq_eq_proved` | sorry (uses above) | Final assembly via calc |
+
+Docker build: 0 errors, 7 sorries in Part XV, 2 axioms (unchanged)
+
+### Remaining Sorries — Specific Mathlib API Paths
+
+1. **ordered_root_diff_prod_eq_vandermonde_sq**: Algebraic pairing of Fin 5 products
+2. **q_SF_eq_prod_linear**: From `Polynomial.roots_eq_multiset_of_monic_of_splits` + rootEnum
+3. **eval_derivative_q_at_root**: Factor q_SF = (X-αᵢ)·r, apply eval_derivative_at_root_of_factor
+4. **prod_eval_derivative_eq_resultant**: Apply `resultant_eq_prod_eval` with proper bounds
+5. **resultant_eq_disc_q**: Apply `resultant_deriv` with q.degree > 0
+6. **disc_q_val**: Compute disc(q) via Sylvester matrix determinant (9×9 over ℤ)
+7. **resultant_transfer**: Apply `resultant_map_map` with algebraMap ℚ SF
+
+### Files Modified
+- `proofs/Proofs/InverseGaloisA5.lean`: Added Part XV (~130 lines)
+- `src/data/research/problems/abel-ruffini-oq-01.json`: Updated knowledge
+- `research/problems/abel-ruffini-oq-01/knowledge.md`: This file
+
+---
+
 ## Session 2026-03-19 (researcher-6) - Stats Audit and Axiom Elimination Attempt
 
 **Mode**: REVISIT (RICH knowledge score 122)

--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -229,7 +229,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Eliminate gal_card_dvd_60 axiom: fix elaboration by rewriting gal_permutes_roots without change+rfl (use TestGalApi.lean approach with gal_smul_val)",
+      "Eliminate gal_card_dvd_60 axiom: Parts XII-XIV have forward dependency on a5_card (defined in Part V). Two options: (a) extract gal_card_dvd_60_of_all_even chain (no a5_card dep) to before Part IV, or (b) split into InverseGaloisA5Vandermonde.lean",
       "three_dvd_gal_card axiom requires Dedekind theorem — not in Mathlib",
       "vandermondeProduct_sq_eq requires connecting Polynomial.disc with Matrix.det_vandermonde",
       "Q8 realization requires quaternion extension (non-cyclotomic)",


### PR DESCRIPTION
## Summary
- Built complete proof chain (Part XV, ~130 lines) to eliminate `vandermondeProduct_sq_eq` axiom from InverseGaloisA5.lean
- Discovered Mathlib v4.26.0 has `resultant_eq_prod_eval`, `resultant_deriv`, `resultant_map_map` — the complete API needed
- Proof chain: VP² = ∏_{i≠j}diff = ∏q'(αᵢ) = Res(q,q') = disc(q) = 1024000000

## Progress
- 10 new theorems decomposing the opaque axiom into specific Mathlib API calls
- `eval_derivative_at_root_of_factor` fully proved
- 7 remaining sorries, each mapped to a specific Mathlib lemma
- Docker build: 0 errors

## Status
**Outcome**: progress — proof architecture complete, sorries remain
**Next Steps**: Fill 7 sorries using Mathlib resultant API (each is a well-defined gap)

🤖 Generated by researcher-2