### PR TITLE
Enrich Alternating Triangular Reciprocals

### DIFF
--- a/src/data/proofs/triangular-reciprocals-oq-03/annotations.json
+++ b/src/data/proofs/triangular-reciprocals-oq-03/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "ann-alt-harmonic-axiom",
+    "proofId": "triangular-reciprocals-oq-03",
+    "range": { "startLine": 31, "endLine": 36 },
+    "type": "context",
+    "title": "Alternating Harmonic Series (Axiom)",
+    "content": "Axiomatizes the Mercator series at $x = 1$: the alternating harmonic series $1 - \\frac{1}{2} + \\frac{1}{3} - \\cdots = \\ln 2$. This was first computed by Nicolaus Mercator in 1668 by integrating the geometric series $\\frac{1}{1+x} = \\sum (-x)^n$ term by term. The convergence at the boundary $x = 1$ requires Abel's theorem on power series, which is not yet available in Mathlib, hence the axiomatization.",
+    "mathContext": "$\\sum_{n=1}^{\\infty} \\frac{(-1)^{n+1}}{n} = \\ln 2$",
+    "significance": "key",
+    "relatedConcepts": ["Mercator series", "Abel's theorem", "conditional convergence", "power series boundary behavior"],
+    "prerequisites": ["power series", "logarithm", "uniform convergence"]
+  },
+  {
+    "id": "ann-shifted-harmonic-axiom",
+    "proofId": "triangular-reciprocals-oq-03",
+    "range": { "startLine": 38, "endLine": 44 },
+    "type": "context",
+    "title": "Shifted Alternating Harmonic Series (Axiom)",
+    "content": "Axiomatizes the shifted alternating harmonic series: $\\frac{1}{2} - \\frac{1}{3} + \\frac{1}{4} - \\cdots = 1 - \\ln 2$. This follows from the standard alternating harmonic series by removing the first term ($+1$) and negating all signs. The value $1 - \\ln 2 \\approx 0.3069$ is obtained from $\\ln 2 = 1 - (1 - \\ln 2)$. This axiom and the previous one together provide the building blocks for the partial fraction decomposition.",
+    "mathContext": "$\\sum_{n=1}^{\\infty} \\frac{(-1)^{n+1}}{n+1} = 1 - \\ln 2$",
+    "significance": "key",
+    "relatedConcepts": ["series manipulation", "term removal", "index shifting"],
+    "prerequisites": ["alternating harmonic series"]
+  },
+  {
+    "id": "ann-partial-fractions",
+    "proofId": "triangular-reciprocals-oq-03",
+    "range": { "startLine": 59, "endLine": 71 },
+    "type": "technique",
+    "title": "Partial Fraction Decomposition",
+    "content": "The crucial algebraic step: each term $(-1)^{n+1} \\cdot \\frac{2}{n(n+1)}$ is decomposed as $\\frac{2 \\cdot (-1)^{n+1}}{n} - \\frac{2 \\cdot (-1)^{n+1}}{n+1}$ using the partial fraction identity $\\frac{2}{n(n+1)} = \\frac{2}{n} - \\frac{2}{n+1}$. The proof uses `ext` to check pointwise equality, `field_simp` to clear denominators, and `ring` for the polynomial identity. The `positivity` tactic handles the condition $(n : \\mathbb{R}) + 1 \\neq 0$.",
+    "mathContext": "$\\frac{2}{n(n+1)} = \\frac{2}{n} - \\frac{2}{n+1}$ (partial fractions), so $(-1)^{n+1} \\cdot \\frac{2}{n(n+1)} = 2 \\cdot \\frac{(-1)^{n+1}}{n} - 2 \\cdot \\frac{(-1)^{n+1}}{n+1}$",
+    "significance": "key",
+    "relatedConcepts": ["partial fractions", "telescoping", "field_simp tactic"],
+    "prerequisites": ["rational function decomposition", "polynomial division"]
+  },
+  {
+    "id": "ann-combining-hassum",
+    "proofId": "triangular-reciprocals-oq-03",
+    "range": { "startLine": 73, "endLine": 79 },
+    "type": "technique",
+    "title": "Combining HasSum Results",
+    "content": "After the partial fraction decomposition, the proof combines the two axiomatized `HasSum` results using Mathlib's `HasSum.mul_left` (to scale each series by 2) and `HasSum.sub` (to subtract them). The algebraic simplification $2 \\cdot \\ln 2 - 2 \\cdot (1 - \\ln 2) = 4 \\ln 2 - 2$ is verified by the `ring` tactic. This is a clean demonstration of how `HasSum` composes: if $\\sum a_n = A$ and $\\sum b_n = B$, then $\\sum (a_n - b_n) = A - B$.",
+    "mathContext": "$2 \\cdot \\ln 2 - 2 \\cdot (1 - \\ln 2) = 4 \\ln 2 - 2$",
+    "significance": "key",
+    "relatedConcepts": ["HasSum linearity", "series arithmetic", "mul_left", "sub"],
+    "prerequisites": ["convergent series algebra", "Mathlib HasSum API"]
+  },
+  {
+    "id": "ann-tsum-version",
+    "proofId": "triangular-reciprocals-oq-03",
+    "range": { "startLine": 81, "endLine": 86 },
+    "type": "technique",
+    "title": "tsum Version via HasSum.tsum_eq",
+    "content": "Converts the `HasSum` statement (a proposition about convergence to a specific limit) to a `tsum` equation (an equality between the infinite sum notation and the value). In Mathlib, `HasSum f a` means the partial sums of $f$ converge to $a$, while `∑' n, f n = a` is the corresponding equation using the `tsum` (topological sum) notation. The conversion is automatic via `HasSum.tsum_eq`.",
+    "mathContext": "$\\sum' n,\\ (-1)^{n+1} \\cdot \\frac{2}{n(n+1)} = 4 \\ln 2 - 2$",
+    "significance": "technical",
+    "relatedConcepts": ["HasSum vs tsum", "topological sum", "Mathlib summation API"],
+    "prerequisites": ["topology of real numbers", "convergent series"]
+  },
+  {
+    "id": "ann-unscaled-corollary",
+    "proofId": "triangular-reciprocals-oq-03",
+    "range": { "startLine": 92, "endLine": 123 },
+    "type": "insight",
+    "title": "Unscaled Corollary: Half the Main Result",
+    "content": "Derives the unscaled version $\\sum (-1)^{n+1}/(n(n+1)) = 2 \\ln 2 - 1$ by dividing the main result by 2. Since the triangular numbers are $T_n = n(n+1)/2$, we have $1/T_n = 2/(n(n+1))$, so this corollary can also be written as $\\sum (-1)^{n+1}/(2 T_n) = 2 \\ln 2 - 1$. The proof uses `const_smul` with $2^{-1}$ to extract the factor of 2 from the `HasSum`.",
+    "mathContext": "$\\sum_{n=1}^{\\infty} \\frac{(-1)^{n+1}}{n(n+1)} = 2 \\ln 2 - 1 \\approx 0.3863$",
+    "significance": "supporting",
+    "relatedConcepts": ["triangular numbers", "scalar extraction", "const_smul"],
+    "prerequisites": ["main theorem", "HasSum scalar multiplication"]
+  },
+  {
+    "id": "ann-summability",
+    "proofId": "triangular-reciprocals-oq-03",
+    "range": { "startLine": 136, "endLine": 140 },
+    "type": "technique",
+    "title": "Summability from HasSum",
+    "content": "Derives `Summable` (the series converges to *some* value) directly from the `HasSum` result (the series converges to a *specific* value). In Mathlib, `HasSum f a → Summable f` is immediate via `HasSum.summable`. This is useful when one needs convergence without caring about the exact limit, for instance when applying comparison tests or rearrangement arguments.",
+    "mathContext": "The series $\\sum (-1)^{n+1} \\cdot \\frac{2}{n(n+1)}$ is summable (convergent).",
+    "significance": "technical",
+    "relatedConcepts": ["Summable", "absolute convergence", "Leibniz criterion"],
+    "prerequisites": ["HasSum definition"]
+  },
+  {
+    "id": "ann-partial-sums",
+    "proofId": "triangular-reciprocals-oq-03",
+    "range": { "startLine": 146, "endLine": 156 },
+    "type": "context",
+    "title": "Oscillating Partial Sums",
+    "content": "Machine-verified finite partial sums demonstrating the alternating convergence pattern: $S_1 = 1$, $S_2 = 2/3$, $S_3 = 5/6$, $S_4 = 11/15$. These oscillate around the limit $4 \\ln 2 - 2 \\approx 0.7726$ — odd partial sums approach from above, even partial sums from below. This is characteristic of alternating series satisfying Leibniz's criterion: the terms decrease in absolute value and tend to zero.",
+    "mathContext": "$S_1 = 1.0,\\ S_2 \\approx 0.667,\\ S_3 \\approx 0.833,\\ S_4 \\approx 0.733,\\ \\ldots \\to 4\\ln 2 - 2 \\approx 0.773$",
+    "significance": "context",
+    "relatedConcepts": ["Leibniz criterion", "alternating series estimation", "norm_num tactic"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/triangular-reciprocals-oq-03/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-03/meta.json
@@ -24,16 +24,22 @@
       "Unscaled corollary: ∑(-1)^{n+1}/(n(n+1)) = 2·ln(2) - 1",
       "Summability of the alternating series"
     ],
+    "references": [
+      {"authors": "N. Mercator", "title": "Logarithmotechnia", "year": "1668", "venue": "London", "note": "First computation of ln(2) via alternating harmonic series"},
+      {"authors": "G. W. Leibniz", "title": "Letter to Huygens", "year": "1673", "venue": "Correspondence", "note": "Evaluation of ∑2/(n(n+1)) = 2 via telescoping"},
+      {"authors": "N. H. Abel", "title": "Untersuchungen über die Reihe...", "year": "1826", "venue": "Journal für die reine und angewandte Mathematik", "note": "Abel's theorem on boundary convergence of power series"}
+    ],
     "dateAdded": "03/19/26"
   },
   "overview": {
-    "historicalContext": "This identity extends the classical result ∑2/(n(n+1)) = 2 (proved by Leibniz in 1673 via telescoping) to its alternating variant. The alternating harmonic series ln(2) = 1 - 1/2 + 1/3 - ⋯ was first computed by Mercator (1668) using the power series for log(1+x). The alternating triangular reciprocal series combines both ideas: partial fractions reduce it to two instances of the Mercator series.",
+    "historicalContext": "The triangular numbers $T_n = n(n+1)/2$ — 1, 3, 6, 10, 15, ... — were studied by the Pythagoreans (circa 500 BCE) as figurate numbers representing dots in triangular arrays. The sum of their reciprocals $\\sum 1/T_n = \\sum 2/(n(n+1)) = 2$ was computed by Leibniz in 1673 using partial fractions and telescoping, making it one of the earliest evaluations of an infinite series.\n\nThe alternating harmonic series $\\ln 2 = 1 - 1/2 + 1/3 - \\cdots$ was first computed by Nicolaus Mercator in 1668 by integrating the geometric series $1/(1+x) = 1 - x + x^2 - \\cdots$ and evaluating at $x = 1$. The boundary convergence at $x = 1$ is delicate — the power series for $\\ln(1+x)$ converges only conditionally there — and rigorous justification requires Abel's theorem (1826) on limits of power series at boundary points.\n\nThe alternating triangular reciprocal identity $\\sum (-1)^{n+1} \\cdot 2/(n(n+1)) = 4\\ln 2 - 2$ combines both strands: partial fractions decompose the series into two instances of the Mercator series. The appearance of $\\ln 2$ in a sum involving figurate numbers illustrates the deep connection between combinatorial number theory and transcendental analysis.",
     "problemStatement": "**Alternating Triangular Reciprocals**:\n\n$$\\sum_{n=1}^{\\infty} (-1)^{n+1} \\cdot \\frac{2}{n(n+1)} = 4\\ln 2 - 2 \\approx 0.7726$$",
     "proofStrategy": "Use partial fractions: (-1)^{n+1}·2/(n(n+1)) = 2·(-1)^{n+1}/n - 2·(-1)^{n+1}/(n+1). This splits the series into the alternating harmonic series (= ln 2) and its shifted variant (= 1 - ln 2). Combining: 2·ln(2) - 2·(1 - ln(2)) = 4·ln(2) - 2.",
     "keyInsights": [
       "Partial fractions split each alternating term into a difference of two simpler alternating terms",
       "The shifted alternating harmonic series ∑(-1)^{n+1}/(n+1) = 1 - ln(2) follows from the standard series by removing the first term and negating",
-      "The result 4·ln(2) - 2 ≈ 0.7726 shows the alternating sum converges to a transcendental number, unlike the non-alternating case which equals exactly 2"
+      "The result 4·ln(2) - 2 ≈ 0.7726 shows the alternating sum converges to a transcendental number, unlike the non-alternating case which equals exactly 2",
+      "**Abel's theorem barrier**: The axiomatization is forced by a real gap in Mathlib, not by mathematical difficulty. Abel's theorem (1826) guarantees that if ∑aₙxⁿ converges at x = R, then limₓ→R⁻ ∑aₙxⁿ = ∑aₙRⁿ. This is a fundamental result in analysis whose formalization would unlock many similar series evaluations."
     ]
   },
   "sections": [


### PR DESCRIPTION
## Summary

Enrichment pass for `triangular-reciprocals-oq-03` (Alternating Sum of Triangular Reciprocals).

**Quality: 38 → enriched** (was 0 passes, 0 annotations)

### Changes
- **Annotations**: Created 8 annotations covering all 5 sections — axioms, partial fractions, HasSum combining, corollary, summability, partial sums
- **Historical context**: Expanded with Pythagorean figurate numbers (500 BCE), Mercator's 1668 series computation, and Abel's 1826 boundary convergence theorem
- **Key insights**: Added 4th insight on Abel's theorem as the Mathlib barrier for removing the two axioms
- **References**: Added Mercator (1668), Leibniz (1673), Abel (1826)

### Axiom integrity
2 axioms encoding the Mercator series at x=1. Status `axiomatized` with badge `axiom` is correct. The axioms are clearly documented as requiring Abel's theorem.

### Note
Also includes enrichment for `fermat-two-squares-oq-01` (Lagrange's Four Squares Theorem) from prior PR #4211, which was closed when the branch was reused.