### PR TITLE
Research: Multiple problems - Friendship theorem infra + Erdős 247 axiom elimination

### DIFF
--- a/proofs/Proofs/Erdos247Problem.lean
+++ b/proofs/Proofs/Erdos247Problem.lean
@@ -92,11 +92,55 @@ theorem pow2_strictMono : StrictMono (fun k => 2^k) := by
   intro a b hab
   exact Nat.pow_lt_pow_right (by omega) hab
 
-/-- Factorial grows faster than any polynomial (axiom). -/
-axiom factorial_strong_growth : HasStrongGrowth (fun k => (k + 1).factorial)
+/-- For all n, n + 1 ≤ 2^n. Proved by induction. -/
+private theorem pow2_ge_succ (n : ℕ) : n + 1 ≤ 2 ^ n := by
+  induction n with
+  | zero => norm_num
+  | succ k ih =>
+    calc k + 1 + 1 ≤ 2 * (k + 1) := by omega
+      _ ≤ 2 * 2 ^ k := by gcongr
+      _ = 2 ^ (k + 1) := by ring
 
-/-- 2^k grows faster than any polynomial (axiom). -/
-axiom pow2_strong_growth : HasStrongGrowth (fun k => 2^k)
+/-- For all k, 2^k ≤ (k+1)!. Proved by induction. -/
+private theorem factorial_ge_pow2 (k : ℕ) : 2 ^ k ≤ (k + 1).factorial := by
+  induction k with
+  | zero => norm_num
+  | succ n ih =>
+    calc 2 ^ (n + 1) = 2 * 2 ^ n := by ring
+      _ ≤ 2 * (n + 1).factorial := by gcongr
+      _ ≤ (n + 2) * (n + 1).factorial := by gcongr; omega
+      _ = (n + 1 + 1).factorial := (Nat.factorial_succ (n + 1)).symm
+
+/-- 2^k grows faster than any polynomial. Proved using explicit witness
+    k = C * (t+1)^(t+1) and a chain of inequalities. -/
+theorem pow2_strong_growth : HasStrongGrowth (fun k => 2 ^ k) := by
+  intro t ht C
+  by_cases hC : C = 0
+  · subst hC; exact ⟨1, by omega, by simp⟩
+  · have hC_pos : 0 < C := Nat.pos_of_ne_zero hC
+    set n := C * (t + 1) ^ t
+    have hn_pos : 0 < n := by positivity
+    refine ⟨n * (t + 1), Nat.mul_pos hn_pos (by omega), ?_⟩
+    -- Goal: 2 ^ (n * (t + 1)) > C * (n * (t + 1)) ^ t
+    show 2 ^ (n * (t + 1)) > C * (n * (t + 1)) ^ t
+    rw [pow_mul]
+    have h1 : n + 1 ≤ 2 ^ n := pow2_ge_succ n
+    have h2 : 0 < n ^ t := by positivity
+    -- Chain: C*(t+1)^t * n^t < (n+1)*n^t ≤ (n+1)*(n+1)^t = (n+1)^(t+1) ≤ (2^n)^(t+1)
+    calc C * (n * (t + 1)) ^ t
+        = C * (t + 1) ^ t * n ^ t := by rw [mul_pow]; ring
+      _ < (n + 1) * n ^ t := by
+          exact mul_lt_mul_of_pos_right (by omega : C * (t + 1) ^ t < n + 1) h2
+      _ ≤ (n + 1) * (n + 1) ^ t := by gcongr; omega
+      _ = (n + 1) ^ (t + 1) := by ring
+      _ ≤ (2 ^ n) ^ (t + 1) := by gcongr
+
+/-- Factorial grows faster than any polynomial. Derived from pow2_strong_growth
+    and the fact that (k+1)! ≥ 2^k. -/
+theorem factorial_strong_growth : HasStrongGrowth (fun k => (k + 1).factorial) := by
+  intro t ht C
+  obtain ⟨k, hk_pos, hk⟩ := pow2_strong_growth t ht C
+  exact ⟨k, hk_pos, lt_of_lt_of_le hk (factorial_ge_pow2 k)⟩
 
 /-- Corollary: The sum Σ 1/2^{k!} is transcendental. -/
 theorem factorial_sum_transcendental :

--- a/proofs/Proofs/FriendshipTheoremOQ01.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ01.lean
@@ -1411,4 +1411,80 @@ The 6 sorry-containing lemmas fall into 3 categories:
    Standard connections between eigenvalues, roots of charpoly, and trace.
 -/
 
+-- ============================================================================
+-- Part XVIII: Adjacency Matrix Symmetry and Spectral Preparation
+-- ============================================================================
+
+/-
+## Part XVIII: Matrix Symmetry and Commutation Properties
+
+The adjacency matrix A of a simple graph is symmetric: A = Aᵀ. Over ℝ, this
+means A is Hermitian, so its eigenvalues are all real. This is the entry point
+to the spectral theorem used in the axiom elimination path.
+
+Also: J commutes with A for regular graphs (JA = AJ = kJ).
+-/
+
+/-- The adjacency matrix is symmetric: Aᵢⱼ = Aⱼᵢ.
+    Follows from G.adj_comm: G.Adj u v ↔ G.Adj v u. -/
+theorem adjMatrix_symmetric :
+    (G.adjMatrix ℤ).transpose = G.adjMatrix ℤ := by
+  ext i j
+  simp [Matrix.transpose_apply, SimpleGraph.adjMatrix_apply, G.adj_comm]
+
+/-- **JA = kJ** for k-regular graphs (dual of AJ = kJ).
+    Since A is symmetric and AJ = kJ: JA = (AJ)ᵀ = (kJ)ᵀ = kJᵀ = kJ. -/
+theorem onesMatrix_mul_adjMatrix (k : ℕ) (hreg : ∀ v : V, G.degree v = k) :
+    onesMatrix V * G.adjMatrix ℤ = ↑k • onesMatrix V := by
+  -- Column sums equal k too (by symmetry of A and row sums = k)
+  ext i j
+  simp only [Matrix.mul_apply, onesMatrix, Matrix.of_apply, one_mul,
+    Matrix.smul_apply, smul_eq_mul, mul_one, SimpleGraph.adjMatrix_apply]
+  trans ↑((Finset.univ.filter fun w => G.Adj w j).card)
+  · rw [← Finset.sum_boole]
+  · have : (Finset.univ.filter fun w => G.Adj w j) =
+        (Finset.univ.filter fun w => G.Adj j w) := by
+      ext w; simp [G.adj_comm]
+    rw [this]
+    have : (Finset.univ.filter fun w => G.Adj j w) = G.neighborFinset j := by
+      ext w; simp [SimpleGraph.mem_neighborFinset]
+    rw [this, ← SimpleGraph.degree, hreg j]; ring
+
+/-- J commutes with A for k-regular graphs: AJ = JA = kJ. -/
+theorem onesMatrix_adjMatrix_comm (k : ℕ) (hreg : ∀ v : V, G.degree v = k) :
+    G.adjMatrix ℤ * onesMatrix V = onesMatrix V * G.adjMatrix ℤ := by
+  rw [adjMatrix_mul_ones G k hreg, onesMatrix_mul_adjMatrix G k hreg]
+
+/-- A² commutes with J (since A² = (k-1)I + J and both I,J commute with J). -/
+theorem adjMatrix_sq_comm_onesMatrix (hF : IsFriendshipGraph G) (k : ℕ) (hk : k ≥ 1)
+    (hreg : ∀ v : V, G.degree v = k) :
+    (G.adjMatrix ℤ * G.adjMatrix ℤ) * onesMatrix V =
+    onesMatrix V * (G.adjMatrix ℤ * G.adjMatrix ℤ) := by
+  rw [adjMatrix_sq_eq G hF k hk hreg, add_mul, mul_add,
+    smul_mul_assoc, mul_smul_comm, Matrix.one_mul, Matrix.mul_one]
+
+/-- The number of vertices n = k(k-1)+1 satisfies n ≥ 3 for k ≥ 2.
+    This ensures the graph has at least 3 vertices. -/
+theorem friendship_card_ge_three (hF : IsFriendshipGraph G) (u : V)
+    (k : ℕ) (hk : k ≥ 2) (hreg : ∀ v : V, G.degree v = k) :
+    Fintype.card V ≥ 3 := by
+  have hcard := regular_friendship_card G hF u k hreg (by omega)
+  have h1 : k - 1 ≥ 1 := by omega
+  have h2 : k * (k - 1) ≥ 2 * 1 := Nat.mul_le_mul hk h1
+  omega
+
+/-- Part XVIII summary:
+    1. adjMatrix_symmetric: A = Aᵀ (PROVED, foundation for spectral theorem)
+    2. onesMatrix_mul_adjMatrix: JA = kJ (PROVED, dual of AJ = kJ)
+    3. onesMatrix_adjMatrix_comm: AJ = JA (PROVED, J commutes with A)
+    4. adjMatrix_sq_comm_onesMatrix: A²J = JA² (PROVED, commutation)
+    5. friendship_card_ge_three: n ≥ 3 (PROVED from n = k(k-1)+1)
+
+    These prepare the ground for spectral analysis:
+    - A symmetric → eigenvalues real (via IsHermitian)
+    - J commutes with A → J preserves eigenspaces of A
+    - A²J = JA² → eigenspaces of A² are stable under J
+    - Combined with A² = (k-1)I + J → eigenspace decomposition -/
+theorem part_xviii_summary : (5 : ℕ) = 5 := rfl
+
 end FriendshipTheoremOQ01

--- a/src/data/proofs/erdos-247/meta.json
+++ b/src/data/proofs/erdos-247/meta.json
@@ -21,7 +21,7 @@
     "erdosNumber": 247,
     "erdosUrl": "https://erdosproblems.com/247",
     "erdosProblemStatus": "partially-solved",
-    "axiomCount": 3
+    "axiomCount": 1
   },
   "overview": {
     "historicalContext": "Erdős posed this problem about transcendental numbers in the context of lacunary series - infinite sums where the terms become increasingly sparse. The study of transcendental numbers began with Liouville (1844) who constructed the first explicit examples. Hermite (1873) proved e is transcendental, and Lindemann (1882) proved π is transcendental. Erdős's problem asks about a family of numbers defined by their binary expansions: when n_k grows quickly, the number Σ 1/2^{n_k} has 1s at increasingly sparse positions in its binary expansion. In 1975, Erdős proved transcendence under the strong condition that n_k grows faster than any polynomial. The general conjecture (just faster-than-linear growth) remains open and was described by Erdős in 1988 as 'hopeless at present'.",
@@ -68,12 +68,12 @@
       "id": "examples",
       "title": "Examples and Corollaries",
       "startLine": 83,
-      "endLine": 109,
-      "summary": "Factorial and exponential sequences yield transcendental sums"
+      "endLine": 152,
+      "summary": "Growth rate proofs and corollaries: factorial and exponential sequences yield transcendental sums"
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #247 on the transcendence of lacunary sums. Erdős's 1975 theorem (axiomatized here) establishes transcendence under superpolynomial growth. The general conjecture for just-faster-than-linear growth remains one of the tantalizing open problems in transcendental number theory.",
+    "summary": "This formalization captures Erdős Problem #247 on the transcendence of lacunary sums. Erdős's 1975 theorem (axiomatized) establishes transcendence under superpolynomial growth. The growth rate lemmas (factorial and exponential dominate any polynomial) are fully proved. The general conjecture for just-faster-than-linear growth remains one of the tantalizing open problems in transcendental number theory.",
     "implications": "If the full conjecture were proved, it would establish a clean characterization: any infinite binary number with 1s growing faster than linearly sparse must be transcendental. This would connect the arithmetic complexity (algebraic vs transcendental) to the combinatorial sparseness of the binary representation.",
     "openQuestions": [
       "Is Σ 1/2^{k²} transcendental? (The simplest open case)",

--- a/src/data/research/problems/erdos-247-oq-01.json
+++ b/src/data/research/problems/erdos-247-oq-01.json
@@ -1,0 +1,69 @@
+{
+  "slug": "erdos-247-oq-01",
+  "title": "Transcendence of Lacunary Sum 1/2^(k^2)",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Is sum(k=1..inf) 1/2^(k^2) transcendental? More generally, for n_k with lim sup n_k/k = inf, is sum 1/2^(n_k) transcendental?",
+    "plain": "Erdos 247: Is the sum 1/2 + 1/16 + 1/512 + 1/65536 + ... transcendental?",
+    "whyMatters": [
+      "Connects to Liouville-type approximation theory",
+      "Gap between weak and strong growth conditions for lacunary sums"
+    ]
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-03-20T14:00:00.000Z",
+    "iteration": 1,
+    "focus": "Initial survey",
+    "blockers": [
+      "Transcendence of lacunary sums under weak growth is genuinely open"
+    ],
+    "nextAction": "Try to eliminate provable axioms (factorial_strong_growth, pow2_strong_growth)",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SURVEY: Erdos247Problem.lean has 142 lines, 0 sorries, 3 axioms. Two axioms (factorial_strong_growth, pow2_strong_growth) are provable - exponential/factorial growth dominates polynomials. The main conjecture (weak growth implies transcendence) is genuinely open.",
+    "builtItems": [],
+    "insights": [
+      "Parent file has clean infrastructure: lacunarySum, HasWeakGrowth, HasStrongGrowth, squareSeq",
+      "erdos_transcendence_strong (axiom): deep transcendence result from Erdos 1975 - not provable from Mathlib",
+      "factorial_strong_growth (axiom): PROVABLE - factorial dominates any polynomial",
+      "pow2_strong_growth (axiom): PROVABLE - 2^k dominates any polynomial",
+      "The open question is specifically about n_k = k^2 (quadratic growth) - between linear and superpolynomial"
+    ],
+    "mathlibGaps": [
+      "Transcendence theory for lacunary series"
+    ],
+    "nextSteps": [
+      "Prove factorial_strong_growth from Mathlib growth lemmas",
+      "Prove pow2_strong_growth from exponential > polynomial"
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "number-theory",
+    "transcendence",
+    "erdos"
+  ],
+  "relatedProofs": [
+    "erdos-247"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://erdosproblems.com/247"
+    ],
+    "mathlib": []
+  },
+  "started": "2026-03-20T14:00:00.000Z",
+  "lastUpdate": "2026-03-20T14:00:00.000Z",
+  "significance": 8,
+  "tractability": 3
+}

--- a/src/data/research/problems/erdos-247-oq-01.json
+++ b/src/data/research/problems/erdos-247-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-247-oq-01",
   "title": "Transcendence of Lacunary Sum 1/2^(k^2)",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -14,36 +14,43 @@
     ]
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-03-20T14:00:00.000Z",
-    "iteration": 1,
-    "focus": "Initial survey",
+    "phase": "ACT",
+    "since": "2026-03-20T15:00:00.000Z",
+    "iteration": 2,
+    "focus": "Axiom elimination: prove growth lemmas",
     "blockers": [
       "Transcendence of lacunary sums under weak growth is genuinely open"
     ],
-    "nextAction": "Try to eliminate provable axioms (factorial_strong_growth, pow2_strong_growth)",
+    "nextAction": "Only erdos_transcendence_strong axiom remains (deep result, not provable)",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY: Erdos247Problem.lean has 142 lines, 0 sorries, 3 axioms. Two axioms (factorial_strong_growth, pow2_strong_growth) are provable - exponential/factorial growth dominates polynomials. The main conjecture (weak growth implies transcendence) is genuinely open.",
-    "builtItems": [],
+    "progressSummary": "PROGRESS: Eliminated 2 of 3 axioms. Proved pow2_strong_growth (2^k dominates any polynomial) using explicit witness k=C*(t+1)^(t+1) and chain of inequalities. Proved factorial_strong_growth derived from pow2_strong_growth + (k+1)! >= 2^k. Only erdos_transcendence_strong remains (deep 1975 result, not provable from Mathlib).",
+    "builtItems": [
+      "pow2_ge_succ: n+1 ≤ 2^n (helper lemma)",
+      "factorial_ge_pow2: 2^k ≤ (k+1)! (helper lemma)",
+      "pow2_strong_growth: theorem (was axiom)",
+      "factorial_strong_growth: theorem (was axiom)"
+    ],
     "insights": [
       "Parent file has clean infrastructure: lacunarySum, HasWeakGrowth, HasStrongGrowth, squareSeq",
       "erdos_transcendence_strong (axiom): deep transcendence result from Erdos 1975 - not provable from Mathlib",
       "factorial_strong_growth (axiom): PROVABLE - factorial dominates any polynomial",
       "pow2_strong_growth (axiom): PROVABLE - 2^k dominates any polynomial",
-      "The open question is specifically about n_k = k^2 (quadratic growth) - between linear and superpolynomial"
+      "The open question is specifically about n_k = k^2 (quadratic growth) - between linear and superpolynomial",
+      "Proof strategy for pow2_strong_growth: witness k = C*(t+1)^(t+1), chain 2^k ≥ (n+1)^(t+1) > C*(t+1)^t * n^t = C*k^t where n = C*(t+1)^t",
+      "factorial_strong_growth follows elegantly from pow2_strong_growth + factorial_ge_pow2",
+      "gcongr tactic handles monotonicity arguments cleanly in Lean 4"
     ],
     "mathlibGaps": [
       "Transcendence theory for lacunary series"
     ],
     "nextSteps": [
-      "Prove factorial_strong_growth from Mathlib growth lemmas",
-      "Prove pow2_strong_growth from exponential > polynomial"
+      "erdos_transcendence_strong is the only remaining axiom - needs Liouville approximation theory not in Mathlib"
     ]
   },
   "tags": [
@@ -63,7 +70,7 @@
     "mathlib": []
   },
   "started": "2026-03-20T14:00:00.000Z",
-  "lastUpdate": "2026-03-20T14:00:00.000Z",
+  "lastUpdate": "2026-03-20T15:00:00.000Z",
   "significance": 8,
   "tractability": 3
 }


### PR DESCRIPTION
## Summary
Multiple research sessions on this branch:

### Erdős 247 - Axiom Elimination (latest)
- **Proved** `pow2_strong_growth`: 2^k dominates any polynomial C*k^t
- **Proved** `factorial_strong_growth`: (k+1)! dominates any polynomial
- Added helper lemmas `pow2_ge_succ` and `factorial_ge_pow2`
- Axiom count reduced from 3 to 1 (only `erdos_transcendence_strong` remains)
- Docker build passes

### Friendship Theorem - Polynomial Infrastructure (earlier)
- Proved `even_pow_coeff_odd`: (X²-c)^m has only even-degree terms
- Proved `sq_sub_pow_coeff_odd` and `coeff_product_sub_leading`
- Resolved merge conflict in FriendshipTheoremOQ01.lean

### Erdős 131 & 247 - Surveys (earlier)
- Survey of growth rate of non-dividing sets (Erdős 131)
- Survey of transcendence of lacunary sums (Erdős 247)

## Status
**Outcome**: progress (axiom elimination + infrastructure)
**Key result**: 2 axioms eliminated in Erdős 247

🤖 Generated by researcher-3