### PR TITLE
Enrich: 20 entries - add crossReferences and relatedProofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -193,5 +193,15 @@
       "Extend to r×r LGV lemma for r > 2 paths using the general Lindström-Gessel-Viennot determinant",
       "Formalize the bijection between non-intersecting Dyck paths and Standard Young Tableaux"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "ballot-problem",
+      "relationship": "extends",
+      "description": "Extends the classical ballot problem with additional combinatorial identities and generalizations."
+    }
+  ],
+  "relatedProofs": [
+    "ballot-problem"
+  ]
 }

--- a/src/data/proofs/binomial-theorem-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01/meta.json
@@ -112,5 +112,15 @@
       "ODE uniqueness path: show f and (1+x)^α both satisfy (1+x)y'=αy with y(0)=1",
       "Use HasFPowerSeriesOnBall machinery to extract Taylor coefficients of (1+x)^α"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "extends",
+      "description": "Extends the basic binomial theorem to multinomial coefficients and generalized versions."
+    }
+  ],
+  "relatedProofs": [
+    "binomial-theorem"
+  ]
 }

--- a/src/data/proofs/birthday-problem/meta.json
+++ b/src/data/proofs/birthday-problem/meta.json
@@ -131,5 +131,15 @@
       "How does the problem change with non-uniform birthday distributions?",
       "What are the implications for hash function security?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "birthday-problem-oq-03",
+      "relationship": "extended-by",
+      "description": "Extended with more sophisticated probability bounds and approximations."
+    }
+  ],
+  "relatedProofs": [
+    "birthday-problem-oq-03"
+  ]
 }

--- a/src/data/proofs/knights-tour-oblique/meta.json
+++ b/src/data/proofs/knights-tour-oblique/meta.json
@@ -102,5 +102,15 @@
       "Can the uniqueness proof be made more 'mathematical' (less computational)?",
       "What is the connection to Knuth's cryptic index entry 'Pun resisted, 62, 470' in TAOCP Vol. 4A?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-polyhedral-formula",
+      "relationship": "related",
+      "description": "Both are combinatorial/graph-theoretic results with connections to Euler's work."
+    }
+  ],
+  "relatedProofs": [
+    "euler-polyhedral-formula"
+  ]
 }

--- a/src/data/proofs/law-of-cosines/meta.json
+++ b/src/data/proofs/law-of-cosines/meta.json
@@ -110,5 +110,21 @@
       "What are the hyperbolic versions of this theorem?",
       "How is this used in modern GPS and positioning systems?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "generalizes",
+      "description": "The law of cosines generalizes the Pythagorean theorem: when θ = π/2, the cos term vanishes, recovering a² + b² = c²."
+    },
+    {
+      "targetId": "triangle-inequality",
+      "relationship": "related",
+      "description": "Both are fundamental triangle relationships. The law of cosines provides the exact relationship that the triangle inequality bounds."
+    }
+  ],
+  "relatedProofs": [
+    "pythagorean-theorem",
+    "triangle-inequality"
+  ]
 }

--- a/src/data/proofs/nth-root-irrational/meta.json
+++ b/src/data/proofs/nth-root-irrational/meta.json
@@ -118,5 +118,15 @@
       "The not-a-perfect-power lemmas use case analysis bounded by the target value. Could a more uniform approach (e.g., via prime factorization) scale to larger values?",
       "What about transcendence? Numbers like pi and e are not just irrational but transcendental - they satisfy no polynomial equation over Q."
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "irrationality-sqrt2",
+      "relationship": "generalizes",
+      "description": "Generalizes the irrationality of √2 to nth roots: ⁿ√k is irrational unless k is a perfect nth power."
+    }
+  ],
+  "relatedProofs": [
+    "irrationality-sqrt2"
+  ]
 }

--- a/src/data/proofs/parallel-postulate-independence/meta.json
+++ b/src/data/proofs/parallel-postulate-independence/meta.json
@@ -106,5 +106,15 @@
       "Can the full Poincaré disk model be formalized in Lean with verified neutral geometry axioms?",
       "What other geometric axioms are independent of the standard systems?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection",
+      "relationship": "related",
+      "description": "Both concern independence/impossibility results in classical geometry. Angle trisection is impossible with compass and straightedge; the parallel postulate is independent of the other axioms."
+    }
+  ],
+  "relatedProofs": [
+    "angle-trisection"
+  ]
 }

--- a/src/data/proofs/prime-number-theorem/meta.json
+++ b/src/data/proofs/prime-number-theorem/meta.json
@@ -122,5 +122,27 @@
       "What is the true size of the error term |π(x) − Li(x)|? (Cramér's conjecture: O(√x · ln²x))",
       "Can PNT be proved elementarily with error bounds matching the analytic proof?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "strengthens",
+      "description": "The PNT provides the quantitative density π(x) ~ x/ln(x) that strengthens Euclid's qualitative result that primes are infinite."
+    },
+    {
+      "targetId": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "The Riemann Hypothesis implies the strongest known error term in the PNT: π(x) = Li(x) + O(√x log x)."
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "Both concern the distribution of primes. The Basel problem ζ(2) = π²/6 is an early evaluation of the Riemann zeta function whose zeros control prime distribution."
+    }
+  ],
+  "relatedProofs": [
+    "infinitude-primes",
+    "riemann-hypothesis",
+    "basel-problem"
+  ]
 }


### PR DESCRIPTION
## Summary
Added crossReferences and relatedProofs arrays to 20 gallery entries that were missing them.

### Classic proofs (8)
- **birthday-problem**: → birthday-problem-oq-03
- **binomial-theorem-oq-01**: → binomial-theorem
- **law-of-cosines**: → pythagorean-theorem, triangle-inequality (generalizes Pythagorean theorem)
- **prime-number-theorem**: → infinitude-primes, riemann-hypothesis, basel-problem
- **nth-root-irrational**: → irrationality-sqrt2 (generalizes √2 irrationality)
- **parallel-postulate-independence**: → angle-trisection
- **knights-tour-oblique**: → euler-polyhedral-formula
- **ballot-problem-oq-03**: → ballot-problem

### Core links (4)
- **fermat-two-squares**: → fermat-two-squares-oq-01, lagrange-four-squares, pythagorean-triples-oq-01
- **product-of-segments-of-chords**: → pythagorean-theorem
- **sqrt2-examples**: → irrationality-sqrt2
- **erdos-151**: → erdos-760

### Erdős problems (8)
- erdos-678, erdos-754, erdos-760, erdos-789, erdos-798, erdos-820, erdos-874, erdos-964

🤖 Generated with [Claude Code](https://claude.com/claude-code)