### PR TITLE
Research: Axiom elimination across 3 Erdős problems

### DIFF
--- a/proofs/Proofs/Erdos131Problem.lean
+++ b/proofs/Proofs/Erdos131Problem.lean
@@ -158,10 +158,44 @@ theorem straus_lower_bound :
                             Real.sqrt (Real.log N)) := by
   sorry -- Straus
 
+/-- exp(3/4) > 2, via Taylor sum of order 3:
+    1 + 3/4 + 9/32 = 65/32 > 2 -/
+private theorem exp_three_fourths_gt_two : (2 : ℝ) < Real.exp (3/4) := by
+  calc (2 : ℝ) < 65/32 := by norm_num
+    _ ≤ ∑ i ∈ Finset.range 3, ((3 : ℝ)/4) ^ i / ↑(i.factorial) := by
+        simp only [Finset.sum_range_succ, Finset.sum_range_zero, Nat.factorial]
+        norm_num
+    _ ≤ Real.exp (3/4) := Real.sum_le_exp_of_nonneg (by norm_num) 3
+
+/-- log 2 < 3/4 -/
+private theorem log_two_lt : Real.log 2 < 3/4 :=
+  (Real.log_lt_iff_lt_exp (by norm_num : (0 : ℝ) < 2)).mpr exp_three_fourths_gt_two
+
+/-- exp(2/3) < 2, via exp_bound upper bound -/
+private theorem exp_two_thirds_lt_two : Real.exp (2/3) < (2 : ℝ) := by
+  have hbound := Real.exp_bound (by norm_num : |(2 : ℝ)/3| ≤ 1) (n := 5) (by norm_num)
+  rw [abs_le] at hbound
+  simp only [Finset.sum_range_succ, Finset.sum_range_zero, Nat.factorial, Nat.succ_eq_add_one] at hbound
+  norm_num at hbound ⊢
+  linarith [hbound.2]
+
+/-- log 2 > 2/3 -/
+private theorem log_two_gt : (2 : ℝ)/3 < Real.log 2 :=
+  (Real.lt_log_iff_exp_lt (by norm_num : (0 : ℝ) < 2)).mpr exp_two_thirds_lt_two
+
 /-- The constant √(2/log 2) ≈ 1.699 -/
 theorem straus_constant_value :
     Real.sqrt (2 / Real.log 2) > 1.6 ∧ Real.sqrt (2 / Real.log 2) < 1.8 := by
-  sorry
+  have hlog_pos : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num : (1 : ℝ) < 2)
+  constructor
+  · rw [gt_iff_lt, Real.lt_sqrt (by norm_num : (0 : ℝ) ≤ 1.6)]
+    norm_num
+    rw [lt_div_iff₀ hlog_pos]
+    nlinarith [log_two_lt]
+  · rw [Real.sqrt_lt' (by norm_num : (0 : ℝ) < 1.8)]
+    norm_num
+    rw [div_lt_iff₀ hlog_pos]
+    nlinarith [log_two_gt]
 
 /- ## The Open Question -/
 

--- a/src/data/research/problems/erdos-131-oq-01.json
+++ b/src/data/research/problems/erdos-131-oq-01.json
@@ -12,38 +12,51 @@
   "currentState": {
     "phase": "COMPLETED",
     "since": "2026-03-20",
-    "iteration": 1,
-    "focus": "Formalization with definitions, implications, examples, bound comparisons"
+    "iteration": 2,
+    "focus": "Prove straus_constant_value numerical bound",
+    "nextAction": "6 sorries remain (all deep published results, not provable from Mathlib)",
+    "attemptCounts": {
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Erdős 131 formalized with core definitions (IsNonDividing, IsNonAveraging, F(N)), proved implications (nondividing→nonaveraging, F≤g), concrete examples, and exponent comparisons. 6 sorries for known results not in Mathlib.",
+    "progressSummary": "PROGRESS: Proved straus_constant_value (√(2/log 2) ∈ (1.6, 1.8)) from Taylor series bounds on exp. Used sum_le_exp_of_nonneg for lower bound and exp_bound for upper bound on exp. Sorries reduced from 7 to 6.",
     "builtItems": [
-      "IsNonDividing, IsNonDividingAlt, IsNonAveraging definitions",
-      "nondividingAlt_implies_nondividing proved",
-      "nondividing_not_iff_alt: {2,4} distinguishes the two definitions",
-      "nondividing_implies_nonaveraging proved",
-      "F(N) defined, F_monotonic proved",
-      "F_le_g proved (non-dividing ≤ non-averaging function)",
-      "Concrete examples: {2,3} non-dividing, {2,3,5} NOT non-dividing, {3,5,7} NOT non-dividing",
-      "Exponent comparisons: 1/4 < 1/2, 1/5 < 1/4, gap = 1/20"
+      "exp_three_fourths_gt_two: exp(3/4) > 2 via Taylor sum",
+      "log_two_lt: log 2 < 3/4",
+      "exp_two_thirds_lt_two: exp(2/3) < 2 via exp_bound",
+      "log_two_gt: log 2 > 2/3",
+      "straus_constant_value: √(2/log 2) ∈ (1.6, 1.8) (proved)"
     ],
     "insights": [
       "Non-dividing sets are strictly contained in non-averaging sets (F ≤ g)",
       "Pham-Zakharov 2024: upper bound N^{1/4+o(1)} via non-averaging connection",
       "Finding non-dividing sets of size ≥ 3 is nontrivial: {3,5,7} fails because 3|12",
       "The polynomial exponent gap between upper (1/4) and lower (1/5) bounds is 1/20",
-      "Original conjecture F(N) < (log N)^O(1) was disproved by Straus's subexponential lower bound"
+      "Original conjecture F(N) < (log N)^O(1) was disproved by Straus's subexponential lower bound",
+      "Proof strategy: bound log 2 via exp bounds, then convert to sqrt bounds via lt_sqrt/sqrt_lt API",
+      "Real.sum_le_exp_of_nonneg gives exp lower bounds from Taylor partial sums",
+      "Real.exp_bound gives |exp(x) - partial_sum| ≤ error for |x| ≤ 1"
     ],
     "nextSteps": [
-      "Prove ELRSS upper bound (requires combinatorial argument)",
-      "Construct explicit large non-dividing sets for lower bounds",
-      "Connect to Erdős Problem #186 (non-averaging sets) more deeply"
+      "6 remaining sorries are deep published results (ELRSS, Pham-Zakharov, Csaba, Straus bounds) - not provable from current Mathlib"
     ]
   },
-  "tags": ["erdos", "number-theory", "combinatorics", "non-dividing-sets"],
+  "tags": [
+    "erdos",
+    "number-theory",
+    "combinatorics",
+    "non-dividing-sets"
+  ],
   "started": "2026-03-20T14:00:00Z",
-  "lastUpdate": "2026-03-20T14:30:00Z",
+  "lastUpdate": "2026-03-20T15:30:00.000Z",
   "significance": 6,
   "tractability": 4,
-  "leanFiles": [{"lineCount": 310}]
+  "leanFiles": [
+    {
+      "lineCount": 310
+    }
+  ]
 }

--- a/src/data/research/problems/erdos-247-oq-01.json
+++ b/src/data/research/problems/erdos-247-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-247-oq-01",
   "title": "Transcendence of Lacunary Sum 1/2^(k^2)",
-  "phase": "ACT",
+  "phase": "OBSERVE",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -14,43 +14,36 @@
     ]
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-03-20T15:00:00.000Z",
-    "iteration": 2,
-    "focus": "Axiom elimination: prove growth lemmas",
+    "phase": "OBSERVE",
+    "since": "2026-03-20T14:00:00.000Z",
+    "iteration": 1,
+    "focus": "Initial survey",
     "blockers": [
       "Transcendence of lacunary sums under weak growth is genuinely open"
     ],
-    "nextAction": "Only erdos_transcendence_strong axiom remains (deep result, not provable)",
+    "nextAction": "Try to eliminate provable axioms (factorial_strong_growth, pow2_strong_growth)",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 1,
-      "approachesTried": 1
+      "total": 1,
+      "currentApproach": 0,
+      "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 2 of 3 axioms. Proved pow2_strong_growth (2^k dominates any polynomial) using explicit witness k=C*(t+1)^(t+1) and chain of inequalities. Proved factorial_strong_growth derived from pow2_strong_growth + (k+1)! >= 2^k. Only erdos_transcendence_strong remains (deep 1975 result, not provable from Mathlib).",
-    "builtItems": [
-      "pow2_ge_succ: n+1 ≤ 2^n (helper lemma)",
-      "factorial_ge_pow2: 2^k ≤ (k+1)! (helper lemma)",
-      "pow2_strong_growth: theorem (was axiom)",
-      "factorial_strong_growth: theorem (was axiom)"
-    ],
+    "progressSummary": "SURVEY: Erdos247Problem.lean has 142 lines, 0 sorries, 3 axioms. Two axioms (factorial_strong_growth, pow2_strong_growth) are provable - exponential/factorial growth dominates polynomials. The main conjecture (weak growth implies transcendence) is genuinely open.",
+    "builtItems": [],
     "insights": [
       "Parent file has clean infrastructure: lacunarySum, HasWeakGrowth, HasStrongGrowth, squareSeq",
       "erdos_transcendence_strong (axiom): deep transcendence result from Erdos 1975 - not provable from Mathlib",
       "factorial_strong_growth (axiom): PROVABLE - factorial dominates any polynomial",
       "pow2_strong_growth (axiom): PROVABLE - 2^k dominates any polynomial",
-      "The open question is specifically about n_k = k^2 (quadratic growth) - between linear and superpolynomial",
-      "Proof strategy for pow2_strong_growth: witness k = C*(t+1)^(t+1), chain 2^k ≥ (n+1)^(t+1) > C*(t+1)^t * n^t = C*k^t where n = C*(t+1)^t",
-      "factorial_strong_growth follows elegantly from pow2_strong_growth + factorial_ge_pow2",
-      "gcongr tactic handles monotonicity arguments cleanly in Lean 4"
+      "The open question is specifically about n_k = k^2 (quadratic growth) - between linear and superpolynomial"
     ],
     "mathlibGaps": [
       "Transcendence theory for lacunary series"
     ],
     "nextSteps": [
-      "erdos_transcendence_strong is the only remaining axiom - needs Liouville approximation theory not in Mathlib"
+      "Prove factorial_strong_growth from Mathlib growth lemmas",
+      "Prove pow2_strong_growth from exponential > polynomial"
     ]
   },
   "tags": [
@@ -70,7 +63,7 @@
     "mathlib": []
   },
   "started": "2026-03-20T14:00:00.000Z",
-  "lastUpdate": "2026-03-20T15:00:00.000Z",
+  "lastUpdate": "2026-03-20T14:00:00.000Z",
   "significance": 8,
   "tractability": 3
 }

--- a/src/data/research/problems/erdos-247-oq-01.json
+++ b/src/data/research/problems/erdos-247-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-247-oq-01",
   "title": "Transcendence of Lacunary Sum 1/2^(k^2)",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -14,36 +14,43 @@
     ]
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-03-20T14:00:00.000Z",
-    "iteration": 1,
-    "focus": "Initial survey",
+    "phase": "ACT",
+    "since": "2026-03-20T15:00:00.000Z",
+    "iteration": 2,
+    "focus": "Axiom elimination: prove growth lemmas",
     "blockers": [
       "Transcendence of lacunary sums under weak growth is genuinely open"
     ],
-    "nextAction": "Try to eliminate provable axioms (factorial_strong_growth, pow2_strong_growth)",
+    "nextAction": "Only erdos_transcendence_strong axiom remains (deep result, not provable)",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY: Erdos247Problem.lean has 142 lines, 0 sorries, 3 axioms. Two axioms (factorial_strong_growth, pow2_strong_growth) are provable - exponential/factorial growth dominates polynomials. The main conjecture (weak growth implies transcendence) is genuinely open.",
-    "builtItems": [],
+    "progressSummary": "PROGRESS: Eliminated 2 of 3 axioms. Proved pow2_strong_growth (2^k dominates any polynomial) using explicit witness k=C*(t+1)^(t+1) and chain of inequalities. Proved factorial_strong_growth derived from pow2_strong_growth + (k+1)! >= 2^k. Only erdos_transcendence_strong remains (deep 1975 result, not provable from Mathlib).",
+    "builtItems": [
+      "pow2_ge_succ: n+1 ≤ 2^n (helper lemma)",
+      "factorial_ge_pow2: 2^k ≤ (k+1)! (helper lemma)",
+      "pow2_strong_growth: theorem (was axiom)",
+      "factorial_strong_growth: theorem (was axiom)"
+    ],
     "insights": [
       "Parent file has clean infrastructure: lacunarySum, HasWeakGrowth, HasStrongGrowth, squareSeq",
       "erdos_transcendence_strong (axiom): deep transcendence result from Erdos 1975 - not provable from Mathlib",
       "factorial_strong_growth (axiom): PROVABLE - factorial dominates any polynomial",
       "pow2_strong_growth (axiom): PROVABLE - 2^k dominates any polynomial",
-      "The open question is specifically about n_k = k^2 (quadratic growth) - between linear and superpolynomial"
+      "The open question is specifically about n_k = k^2 (quadratic growth) - between linear and superpolynomial",
+      "Proof strategy for pow2_strong_growth: witness k = C*(t+1)^(t+1), chain 2^k ≥ (n+1)^(t+1) > C*(t+1)^t * n^t = C*k^t where n = C*(t+1)^t",
+      "factorial_strong_growth follows elegantly from pow2_strong_growth + factorial_ge_pow2",
+      "gcongr tactic handles monotonicity arguments cleanly in Lean 4"
     ],
     "mathlibGaps": [
       "Transcendence theory for lacunary series"
     ],
     "nextSteps": [
-      "Prove factorial_strong_growth from Mathlib growth lemmas",
-      "Prove pow2_strong_growth from exponential > polynomial"
+      "erdos_transcendence_strong is the only remaining axiom - needs Liouville approximation theory not in Mathlib"
     ]
   },
   "tags": [
@@ -63,7 +70,7 @@
     "mathlib": []
   },
   "started": "2026-03-20T14:00:00.000Z",
-  "lastUpdate": "2026-03-20T14:00:00.000Z",
+  "lastUpdate": "2026-03-20T15:00:00.000Z",
   "significance": 8,
   "tractability": 3
 }


### PR DESCRIPTION
## Summary
Eliminated axioms/sorries across 3 different Erdős problem formalizations:

### Erdős 247 - Growth Rate Axioms (2 axioms eliminated)
- **Proved** `pow2_strong_growth`: 2^k dominates any polynomial C*k^t
- **Proved** `factorial_strong_growth`: derived from pow2 + factorial_ge_pow2
- Axiom count: 3 → 1

### Erdős 131 - Numerical Constant (1 sorry eliminated)
- **Proved** `straus_constant_value`: √(2/log 2) ∈ (1.6, 1.8)
- Used Taylor series bounds via `sum_le_exp_of_nonneg` and `exp_bound`
- Sorry count: 7 → 6

### Erdős 177 OQ04 - Alternating Bound (1 axiom eliminated + 4 build fixes)
- **Proved** `alternating_d1_bound`: |∑(-1)^(a+i)| ≤ 1 by two-step induction
- Fixed broken `alternating_d2_all_same` proof
- Fixed docstring syntax error and incorrect example value
- Axiom count: 4 → 3

## Status
**Outcome**: 4 axioms/sorries eliminated, 4 build errors fixed
**Docker build**: all 3 files pass

🤖 Generated by researcher-3