### PR TITLE
Research: friendship-theorem-oq-01 - Prove UFD lemma + k_sub_one glue (4→2 sorries)

### DIFF
--- a/proofs/Proofs/FriendshipTheoremOQ01.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ01.lean
@@ -1368,11 +1368,44 @@ theorem k_sub_one_is_perfect_square (hF : IsFriendshipGraph G)
   -- X²-(k-1) is irreducible (since k-1 not a perfect square)
   have hirred := sq_sub_irreducible_of_not_square (k - 1) (by omega) (by
     intro s hs; exact hns s (by omega))
-  -- By the UFD structure lemma: f = (X²-(k-1))^{(n-1)/2}
-  -- Then coeff_{n-2}(f) = 0 (since n-2 is odd and (X²-c)^m has only even-degree terms)
-  -- But coeff_{n-2}(f) = k ≥ 2. Contradiction!
-  -- (Full proof requires the sorry-containing infrastructure above)
-  sorry
+  -- f is monic (from charpoly monic and (X-k) monic)
+  have hcharpoly_monic := Matrix.charpoly_monic (G.adjMatrix ℤ)
+  have hxk_monic : (X - C (↑k : ℤ)).Monic := monic_X_sub_C _
+  have hf_monic : f.Monic := hxk_monic.of_mul_monic_left (hf ▸ hcharpoly_monic)
+  -- f has degree n-1
+  have hf_deg : f.natDegree = n - 1 := by
+    have hdeg_charpoly := Matrix.charpoly_natDegree_eq_dim (G.adjMatrix ℤ)
+    rw [← hn_def] at hdeg_charpoly
+    have hxk_deg : (X - C (↑k : ℤ)).natDegree = 1 := natDegree_X_sub_C _
+    have hf_ne : f ≠ 0 := hf_monic.ne_zero
+    have hxk_ne : (X - C (↑k : ℤ)) ≠ 0 := hxk_monic.ne_zero
+    have := natDegree_mul hxk_ne hf_ne
+    rw [← hf, hdeg_charpoly, hxk_deg] at this; omega
+  -- n-1 is even (n = k(k-1)+1, so n-1 = k(k-1), product of consecutive = even)
+  have hn1_even : Even (n - 1) := by
+    rw [hn, show k * (k - 1) + 1 - 1 = k * (k - 1) from by omega]
+    rcases Nat.even_or_odd k with ⟨m, hm⟩ | ⟨m, hm⟩
+    · exact ⟨m * (k - 1), by rw [hm]; ring⟩
+    · have : k - 1 = m + m := by omega
+      rw [this]; exact ⟨k * m, by ring⟩
+  -- X²-(k-1) is monic
+  have hp_monic : (X ^ 2 - C (↑(k - 1) : ℤ) : Polynomial ℤ).Monic :=
+    monic_X_pow_sub_C _ (by norm_num)
+  -- X²-(k-1) is symmetric: (X²-c).comp(-X) = (-X)²-c = X²-c
+  have hp_sym : (X ^ 2 - C (↑(k - 1) : ℤ) : Polynomial ℤ).comp (-X) =
+      X ^ 2 - C (↑(k - 1) : ℤ) := by
+    simp [sub_comp, pow_comp, C_comp, neg_comp, X_comp, neg_sq]
+  -- By UFD structure lemma: f = (X²-(k-1))^{(n-1)/2}
+  have hf_eq := monic_factor_of_symmetric_irreducible_pow
+    (X ^ 2 - C (↑(k - 1) : ℤ)) f (n - 1) hn1_even hirred hp_monic hp_sym hf_monic hprod
+  -- The coefficient at n-2 of f must be 0 (odd degree in a power of X²-c)
+  have hcoeff_zero : f.coeff (n - 2) = 0 := by
+    rw [hf_eq]
+    exact coeff_odd_of_sq_sub_pow (↑(k - 1) : ℤ) ((n - 1) / 2) (n - 2) hn2_odd
+  -- But quotient_subleading_coeff says coeff_{n-2}(f) = k
+  have hcoeff_k := quotient_subleading_coeff G hF k hk hreg f hf hf_monic hf_deg
+  -- Contradiction: 0 = k ≥ 2
+  linarith
 
 /-- **s divides k** for s = √(k-1) in a k-regular friendship graph.
 

--- a/proofs/Proofs/FriendshipTheoremOQ01.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ01.lean
@@ -1203,7 +1203,9 @@ lemma sq_sub_irreducible_of_not_square (d : ℕ) (hd : d ≥ 1)
     Irreducible (X ^ 2 - C (↑d : ℤ) : Polynomial ℤ) := by
   -- No integer is a square root of d
   have no_int_sqrt : ∀ r : ℤ, r * r ≠ ↑d := by
-    intro r hr; exact hns r.natAbs (by zify; rw [Int.natAbs_sq]; linarith)
+    intro r hr; exact hns r.natAbs (by
+      have h1 : (r.natAbs : ℤ) * r.natAbs = r * r := Int.natAbs_mul_self
+      exact_mod_cast (h1.trans hr).symm)
   -- Direct proof over ℤ: monic degree 2 with no integer root is irreducible
   have hp_monic : (X ^ 2 - C (↑d : ℤ) : Polynomial ℤ).Monic :=
     monic_X_pow_sub_C (↑d : ℤ) (by norm_num)
@@ -1212,7 +1214,7 @@ lemma sq_sub_irreducible_of_not_square (d : ℕ) (hd : d ≥ 1)
     intro h; have := natDegree_eq_zero_of_isUnit h
     have : (X ^ 2 - C (↑d : ℤ) : ℤ[X]).natDegree = 2 := by
       rw [natDegree_sub_eq_left_of_natDegree_lt] <;>
-        simp [natDegree_pow, natDegree_X, natDegree_C]; omega
+        simp [natDegree_pow, natDegree_X, natDegree_C]
     omega
   · -- For any factorization p = a * b, one factor is a unit
     intro a b hab
@@ -1222,7 +1224,7 @@ lemma sq_sub_irreducible_of_not_square (d : ℕ) (hd : d ≥ 1)
     have hdeg : a.natDegree + b.natDegree = 2 := by
       rw [← natDegree_mul ha_ne hb_ne, ← hab,
           natDegree_sub_eq_left_of_natDegree_lt] <;>
-        simp [natDegree_pow, natDegree_X, natDegree_C]; omega
+        simp [natDegree_pow, natDegree_X, natDegree_C]
     -- Leading coefficients multiply to 1 (monic product)
     have hlc : a.leadingCoeff * b.leadingCoeff = 1 := by
       rw [← leadingCoeff_mul, ← hab]; exact hp_monic.leadingCoeff
@@ -1230,11 +1232,11 @@ lemma sq_sub_irreducible_of_not_square (d : ℕ) (hd : d ≥ 1)
     by_cases ha0 : a.natDegree = 0
     · left; rw [eq_C_of_natDegree_eq_zero ha0]
       rw [eq_C_of_natDegree_eq_zero ha0, leadingCoeff_C] at hlc
-      exact (isUnit_of_mul_eq_one _ _ hlc).map C
+      exact (isUnit_of_mul_eq_one _ hlc).map C
     · by_cases hb0 : b.natDegree = 0
       · right; rw [eq_C_of_natDegree_eq_zero hb0]
         rw [eq_C_of_natDegree_eq_zero hb0, leadingCoeff_C] at hlc
-        exact (isUnit_of_mul_eq_one _ _ (mul_comm a.leadingCoeff _ ▸ hlc)).map C
+        exact (isUnit_of_mul_eq_one _ (mul_comm a.leadingCoeff _ ▸ hlc)).map C
       · -- Both have degree 1: derive contradiction
         -- a*b = X²-d with both degree 1 means the product has an integer root
         -- But X²-d has no integer root (d not a perfect square)
@@ -1245,7 +1247,7 @@ lemma sq_sub_irreducible_of_not_square (d : ℕ) (hd : d ≥ 1)
         set r := -(a.coeff 0) * a.leadingCoeff
         -- a.leadingCoeff² = 1 (it's a unit in ℤ)
         have hlc_sq : a.leadingCoeff * a.leadingCoeff = 1 := by
-          rcases Int.isUnit_iff.mp (isUnit_of_mul_eq_one _ _ hlc) with rfl | rfl <;> ring
+          rcases Int.isUnit_iff.mp (isUnit_of_mul_eq_one _ hlc) with h | h <;> simp [h]
         -- Compute a.eval r = a.leadingCoeff * r + a.coeff 0
         --                   = -(a.coeff 0) * a.leadingCoeff² + a.coeff 0
         --                   = -(a.coeff 0) + a.coeff 0 = 0
@@ -1255,7 +1257,12 @@ lemma sq_sub_irreducible_of_not_square (d : ℕ) (hd : d ≥ 1)
           rw [Polynomial.eval_eq_sum_range, show a.natDegree + 1 = 2 from by omega]
           simp only [Finset.sum_range_succ, Finset.sum_range_one, pow_zero, mul_one,
                      pow_one, Polynomial.leadingCoeff, ha1]
-          ring_nf; rw [mul_comm (a.coeff 0), ← mul_assoc, hlc_sq, one_mul, add_neg_cancel]
+          -- After simp: goal is a.coeff 0 + a.coeff 1 * r = 0
+          -- r = -(a.coeff 0) * a.leadingCoeff, a.coeff 1 = a.leadingCoeff
+          have h_lc : a.coeff 1 = a.leadingCoeff := by rw [Polynomial.leadingCoeff, ha1]
+          rw [h_lc, show r = -(a.coeff 0) * a.leadingCoeff from rfl]
+          -- Goal: a.coeff 0 + a.leadingCoeff * (-(a.coeff 0) * a.leadingCoeff) = 0
+          linear_combination -a.coeff 0 * hlc_sq
         -- But a*b = X²-d, so r²-d = 0, meaning r² = d
         rw [← hab] at ha_root
         simp only [eval_sub, eval_pow, eval_X, eval_C] at ha_root
@@ -1272,11 +1279,48 @@ lemma monic_factor_of_symmetric_irreducible_pow
     (hf_monic : f.Monic)
     (hprod : f * f.comp (-X) = p ^ m) :
     f = p ^ (m / 2) := by
-  -- In ℤ[X] (UFD), p irreducible and p^m = f·f(-X).
-  -- Every irreducible factor of f is associate to p (since p is the only irred factor of p^m).
-  -- Since f is monic and p is monic: f = p^a for some a.
-  -- f(-X) = p(-X)^a = p^a (since p is symmetric). So p^{2a} = p^m, giving a = m/2.
-  sorry
+  -- Induction on m/2. Write m = r + r from Even m.
+  obtain ⟨r, rfl⟩ := hm
+  rw [show (r + r) / 2 = r from by omega]
+  -- Induction on r, generalizing f (and its hypotheses)
+  induction r generalizing f with
+  | zero =>
+    -- f * f(-X) = p^0 = 1, so f is a unit. Monic unit = 1 = p^0.
+    simp only [Nat.zero_add, pow_zero] at hprod ⊢
+    exact hf_monic.eq_one_of_isUnit (isUnit_of_mul_eq_one _ hprod)
+  | succ r ih =>
+    -- p is prime in ℤ[X] (UFD)
+    have hp_prime : Prime p := hp_irred.prime
+    -- p | f * f(-X) since p | p^(r+1+r+1)
+    have h_dvd : p ∣ f * f.comp (-X) :=
+      hprod ▸ dvd_pow_self p (by omega : r + 1 + (r + 1) ≠ 0)
+    -- p | f (using symmetry: if p | f(-X), apply comp(-X) to get p | f)
+    have hpf : p ∣ f := by
+      rcases hp_prime.dvd_or_dvd h_dvd with h | h
+      · exact h
+      · -- p | f.comp(-X). Applying comp(-X) gives p | f.
+        obtain ⟨g, hg⟩ := h
+        exact ⟨g.comp (-X), by
+          have key : (f.comp (-X)).comp (-X) = f := by
+            rw [comp_assoc, show (-X : Polynomial ℤ).comp (-X) = X from by
+              rw [neg_comp, X_comp, neg_neg], comp_X]
+          rw [← key, hg, mul_comp, hp_sym]⟩
+    -- Write f = p * f₁
+    obtain ⟨f₁, rfl⟩ := hpf
+    -- f₁ is monic (p monic, p * f₁ monic → f₁ monic)
+    have hf1_monic : f₁.Monic := hp_monic.of_mul_monic_left hf_monic
+    -- Compute: (p * f₁).comp(-X) = p * f₁.comp(-X) using hp_sym
+    have hfn : (p * f₁).comp (-X) = p * f₁.comp (-X) := by
+      rw [mul_comp, hp_sym]
+    -- Derive: f₁ * f₁(-X) = p^(r+r) by cancelling p^2 from both sides
+    have hprod1 : f₁ * f₁.comp (-X) = p ^ (r + r) := by
+      have h_lhs : p * f₁ * (p * f₁.comp (-X)) = p ^ 2 * (f₁ * f₁.comp (-X)) := by ring
+      have h_rhs : p ^ (r + 1 + (r + 1)) = p ^ 2 * p ^ (r + r) := by
+        rw [show r + 1 + (r + 1) = 2 + (r + r) from by omega, pow_add]
+      rw [hfn, h_lhs] at hprod; rw [h_rhs] at hprod
+      exact mul_left_cancel₀ (pow_ne_zero 2 hp_irred.ne_zero) hprod
+    -- Apply inductive hypothesis: f₁ = p^r, so p * f₁ = p * p^r = p^(r+1)
+    rw [ih f₁ hf1_monic hprod1, mul_comm, ← pow_succ]
 
 /-- **k-1 is a perfect square** for any k-regular friendship graph with k ≥ 2.
 

--- a/src/data/research/problems/friendship-theorem-oq-01.json
+++ b/src/data/research/problems/friendship-theorem-oq-01.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-20T00:00:00.000Z",
-    "iteration": 4,
-    "focus": "Product identity approach to axiom elimination. 7 new theorems proved. 4 sorries remain for full elimination.",
+    "iteration": 5,
+    "focus": "3 sorries remain (charpoly_quotient_product, k_sub_one_is_perfect_square, sqrt_k_sub_one_dvd_k). UFD structure lemma proved. Need det(cI-J) formula next.",
     "blockers": [
       "Mathlib spectral theorem integration needed for axiom elimination"
     ],
@@ -61,7 +61,9 @@
       "adjMatrix_transpose: Aᵀ = A via SimpleGraph.transpose_adjMatrix (PROVED)",
       "friendship_k_sq: k-1+n = k² number theory identity (PROVED)",
       "spectral_k_eq_two: k=2 framework (1 sorry: s|k from trace)",
-      "charpoly_eigenvalue_data_proof: axiom witness construction (follows from k=2)"
+      "charpoly_eigenvalue_data_proof: axiom witness construction (follows from k=2)",
+      "monic_factor_of_symmetric_irreducible_pow: PROVED (induction on m/2, p|f from Prime.dvd_or_dvd + symmetry of p)",
+      "sq_sub_irreducible_of_not_square: FIXED Mathlib API breakage (6 repairs)"
     ],
     "insights": [
       "Proof verified: 0 sorries via grep",
@@ -97,7 +99,11 @@
       "Proved charpoly_eval: Polynomial.eval c (charpoly M) = det(cI - M) via RingHom.map_det",
       "Proved charpoly_root_k: k is a root of charpoly(adjMatrix) via charpoly_eval + det_kI=0",
       "Proved x_sub_k_dvd_charpoly: (X-k) | charpoly(adjMatrix) via factor theorem",
-      "Framework: k_sub_one_is_square (sorry) → spectral_k_eq_two → charpoly_eigenvalue_data_proof"
+      "Framework: k_sub_one_is_square (sorry) → spectral_k_eq_two → charpoly_eigenvalue_data_proof",
+      "UFD structure lemma proved: f*f(-X) = p^m with p irred symmetric → f = p^{m/2}. Key: p prime in UFD, p|f by symmetry argument (compose with -X), then induction.",
+      "Mathlib API breaks in sq_sub_irreducible: Int.natAbs_sq pattern, isUnit_of_mul_eq_one 3→2 args, simp now closes goals omega handled, ring_nf normalization change",
+      "Remaining bottleneck: charpoly_quotient_product needs det(cI-J) = c^{n-1}(c-n) formula. Row ops proof: sub col 1 from cols 2..n, add rows 2..n to row 1 → lower triangular with diag (c-n, c, c, ..., c).",
+      "Alternative path to k_sub_one_is_perfect_square: factor charpoly via UFD (every irred factor divides annihilating poly) → tr(A)=0 gives contradiction. Requires showing irred factors of charpoly ⊆ irred factors of minpoly, which needs PID theory over Q."
     ],
     "mathlibGaps": [
       "Full spectral theorem for real symmetric matrices in a form that gives integer eigenvalue multiplicities",
@@ -105,12 +111,10 @@
       "Connection between Matrix.trace and sum of eigenvalues for SimpleGraph.adjMatrix"
     ],
     "nextSteps": [
-      "Prove det_scalar_sub_onesMatrix: det(cI-J) = c^{n-1}(c-n) via matrix determinant lemma",
-      "Prove the product identity: charpoly(A)·det(XI+A) = (X²-(k-1))^{n-1}·(X-k)(X+k) over ℤ[X]",
-      "Prove X²-c irreducible in ℤ[X] when c is not a perfect square",
-      "Combine product identity + irreducibility + trace to prove k_sub_one_is_square",
-      "Prove s|k from trace of A restricted to ker(J) (or from charpoly factorization)",
-      "Once all sorries filled: remove the axiom charpoly_eigenvalue_data"
+      "Prove det(cI-J) = c^{n-1}(c-n) — either via row/column operations formalized in Lean, or via charpoly(J) = X^{n-1}(X-n) from J²=nJ + trace",
+      "Prove charpoly_quotient_product using det formula + matrix product identity (XI-A)(XI+A) = X²I-A²",
+      "Fill in k_sub_one_is_perfect_square using product identity + monic_factor (now proved) + coeff_odd_of_sq_sub_pow (proved) + quotient_subleading_coeff (proved)",
+      "Prove sqrt_k_sub_one_dvd_k — needs charpoly factorization with linear factors when k-1=s²"
     ],
     "markdown": "# Knowledge Base: friendship-theorem-oq-01\n\nSpectral proof of Friendship Theorem via Mathlib linear algebra.\n\n---\n\n## Problem Understanding\n\nThe Friendship Theorem (Erdos-Renyi-Sos, 1966): In any finite simple graph where\nevery pair of distinct vertices has exactly one common neighbor, there exists a\nvertex adjacent to all other vertices (a \"universal friend\" or \"politician\").\n\nThe spectral proof has two main components:\n1. **Regularity**: No universal vertex implies the graph is regular. Requires\n   spectral/algebraic methods — no clean combinatorial proof known.\n2. **Spectral contradiction**: A k-regular friendship graph satisfies A^2 = (k-1)I + J.\n   Eigenvalue analysis shows k must equal 2, leaving only the triangle.\n\n---\n\n## Current File State\n\n**FriendshipTheoremOQ01.lean**: 0 sorries, 1 axiom\n\n### Proved Results (18 lemmas/theorems)\n\n| Part | Result | Description |\n|------|--------|-------------|\n| I | `ucn`, `ucn_spec` | UCN extraction and singleton characterization |\n| I | `ucn_adj_left`, `ucn_adj_right` | UCN is adjacent to both vertices |\n| I | `ucn_unique` | Any common neighbor equals UCN |\n| I-B | `ucn_ne_left`, `ucn_ne_right` | UCN ≠ u and UCN ≠ v |\n| I-B | `friendship_separation` | For adj u,v: ucn(x,v) = u for all x ∈ N(u)\\{v} |\n| I-B | `ucn_involutive` | ucn(u, ucn(u,v)) = v (partner involution) |\n| I-B | `ucn_unique_in_neighborhood` | Partner is unique neighbor within N(u) |\n| II | `common_neighbor_finset_card` | |N(u) ∩ N(v)| = 1 (A² off-diagonal) |\n| III | `counting_disjoint` | Partition fibers are pairwise disjoint |\n| III | `counting_cover` | Partition fibers cover V \\ {u} |\n| III | `counting_identity` | n-1 = Σ_{v∈N(u)} (deg(v)-1) |\n| IV | `regular_friendship_card` | n = k(k-1)+1 for k-regular |\n| V | `dvd_sq_add_one_imp_one` | s | s²+1 → s = 1 |\n| VI | `regular_friendship_is_triangle` | k-regular friendship → n = 3 |\n| VI | `regular_friendship_has_universal` | k-regular friendship → universal vertex |\n\n### Single Axiom\n\n`spectral_regular_friendship`: In a k-regular friendship graph with k ≥ 2, k = 2.\n\n---\n\n## Insights\n\n### Separation Lemma (Session 2)\nFor adjacent u, v: ucn(x, v) = u for ALL x ∈ N(u) \\ {v}.\nNeighborhoods of adjacent vertices are completely separated.\n\n### Partner Involution (Session 2)\nv ↦ ucn(u, v) is a fixed-point-free involution on N(u).\nConsequence: deg(u) is always even in a friendship graph.\n\n### Adjacent Same Degree is FALSE (Session 2)\nWindmill W₂: center deg=4, petals deg=2. Both adjacent.\n\"No universal → regular\" requires algebraic methods.\n\n### Matrix Identity A^2 = (k-1)I + J\n- (A^2)_{ij} = common neighbor count = 1 (off-diag) or k (diag)\n- Eigenvalues: k and ±sqrt(k-1)\n- trace(A) = 0 forces k-1 to be a perfect square, then s|s²+1→s=1→k=2\n\n---\n\n## Dead Ends\n\n- **Bijection N(u) → N(v)**: Map x ↦ ucn(x,v) sends ALL of N(u)\\{v} to u.\n  Not injective for deg(u) > 2. Cannot prove adjacent same degree this way.\n- **Counting identity alone**: Consistent with any degree sequence.\n\n---\n\n## Remaining Work\n\nEliminate the spectral axiom via:\n1. Adjacency matrix for SimpleGraph (in Mathlib)\n2. A² = (k-1)I + J as matrix equation\n3. Eigenvalue decomposition (in Mathlib for real symmetric)\n4. Trace = sum of eigenvalues → integrality constraint\n5. Application of dvd_sq_add_one_imp_one (proved)\n"
   },
@@ -127,7 +131,7 @@
     "mathlib": []
   },
   "started": "2026-03-15T12:11:41.208Z",
-  "lastUpdate": "2026-03-20T00:00:00.000Z",
+  "lastUpdate": "2026-03-20T16:30:00Z",
   "significance": 7,
   "tractability": 6
 }

--- a/src/data/research/problems/friendship-theorem-oq-01.json
+++ b/src/data/research/problems/friendship-theorem-oq-01.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-20T00:00:00.000Z",
-    "iteration": 5,
-    "focus": "3 sorries remain (charpoly_quotient_product, k_sub_one_is_perfect_square, sqrt_k_sub_one_dvd_k). UFD structure lemma proved. Need det(cI-J) formula next.",
+    "iteration": 6,
+    "focus": "2 sorries remain (charpoly_quotient_product, sqrt_k_sub_one_dvd_k). k_sub_one_is_perfect_square fully connected. Need det(cI-J) formula.",
     "blockers": [
       "Mathlib spectral theorem integration needed for axiom elimination"
     ],
@@ -63,7 +63,8 @@
       "spectral_k_eq_two: k=2 framework (1 sorry: s|k from trace)",
       "charpoly_eigenvalue_data_proof: axiom witness construction (follows from k=2)",
       "monic_factor_of_symmetric_irreducible_pow: PROVED (induction on m/2, p|f from Prime.dvd_or_dvd + symmetry of p)",
-      "sq_sub_irreducible_of_not_square: FIXED Mathlib API breakage (6 repairs)"
+      "sq_sub_irreducible_of_not_square: FIXED Mathlib API breakage (6 repairs)",
+      "k_sub_one_is_perfect_square: PROVED (glue connecting product identity + UFD lemma + coeff_odd + subleading_coeff)"
     ],
     "insights": [
       "Proof verified: 0 sorries via grep",
@@ -103,7 +104,9 @@
       "UFD structure lemma proved: f*f(-X) = p^m with p irred symmetric → f = p^{m/2}. Key: p prime in UFD, p|f by symmetry argument (compose with -X), then induction.",
       "Mathlib API breaks in sq_sub_irreducible: Int.natAbs_sq pattern, isUnit_of_mul_eq_one 3→2 args, simp now closes goals omega handled, ring_nf normalization change",
       "Remaining bottleneck: charpoly_quotient_product needs det(cI-J) = c^{n-1}(c-n) formula. Row ops proof: sub col 1 from cols 2..n, add rows 2..n to row 1 → lower triangular with diag (c-n, c, c, ..., c).",
-      "Alternative path to k_sub_one_is_perfect_square: factor charpoly via UFD (every irred factor divides annihilating poly) → tr(A)=0 gives contradiction. Requires showing irred factors of charpoly ⊆ irred factors of minpoly, which needs PID theory over Q."
+      "Alternative path to k_sub_one_is_perfect_square: factor charpoly via UFD (every irred factor divides annihilating poly) → tr(A)=0 gives contradiction. Requires showing irred factors of charpoly ⊆ irred factors of minpoly, which needs PID theory over Q.",
+      "k_sub_one_is_perfect_square proof chain: by_contra → irreducibility → product identity → UFD factor → f=(X²-c)^m → odd coeff=0 → but subleading=k≥2 → contradiction. Now fully connected!",
+      "Sorries reduced 4→2: charpoly_quotient_product and sqrt_k_sub_one_dvd_k remain"
     ],
     "mathlibGaps": [
       "Full spectral theorem for real symmetric matrices in a form that gives integer eigenvalue multiplicities",
@@ -111,10 +114,9 @@
       "Connection between Matrix.trace and sum of eigenvalues for SimpleGraph.adjMatrix"
     ],
     "nextSteps": [
-      "Prove det(cI-J) = c^{n-1}(c-n) — either via row/column operations formalized in Lean, or via charpoly(J) = X^{n-1}(X-n) from J²=nJ + trace",
-      "Prove charpoly_quotient_product using det formula + matrix product identity (XI-A)(XI+A) = X²I-A²",
-      "Fill in k_sub_one_is_perfect_square using product identity + monic_factor (now proved) + coeff_odd_of_sq_sub_pow (proved) + quotient_subleading_coeff (proved)",
-      "Prove sqrt_k_sub_one_dvd_k — needs charpoly factorization with linear factors when k-1=s²"
+      "Prove det(cI-J) = c^{n-1}(c-n) — key bottleneck. Approaches: (a) fraction field + det_add_col_mul_row, (b) cofactor expansion, (c) charpoly(J) computation",
+      "Prove charpoly_quotient_product using det formula + matrix product identity",
+      "Prove sqrt_k_sub_one_dvd_k — needs charpoly linear factor decomposition when k-1=s²"
     ],
     "markdown": "# Knowledge Base: friendship-theorem-oq-01\n\nSpectral proof of Friendship Theorem via Mathlib linear algebra.\n\n---\n\n## Problem Understanding\n\nThe Friendship Theorem (Erdos-Renyi-Sos, 1966): In any finite simple graph where\nevery pair of distinct vertices has exactly one common neighbor, there exists a\nvertex adjacent to all other vertices (a \"universal friend\" or \"politician\").\n\nThe spectral proof has two main components:\n1. **Regularity**: No universal vertex implies the graph is regular. Requires\n   spectral/algebraic methods — no clean combinatorial proof known.\n2. **Spectral contradiction**: A k-regular friendship graph satisfies A^2 = (k-1)I + J.\n   Eigenvalue analysis shows k must equal 2, leaving only the triangle.\n\n---\n\n## Current File State\n\n**FriendshipTheoremOQ01.lean**: 0 sorries, 1 axiom\n\n### Proved Results (18 lemmas/theorems)\n\n| Part | Result | Description |\n|------|--------|-------------|\n| I | `ucn`, `ucn_spec` | UCN extraction and singleton characterization |\n| I | `ucn_adj_left`, `ucn_adj_right` | UCN is adjacent to both vertices |\n| I | `ucn_unique` | Any common neighbor equals UCN |\n| I-B | `ucn_ne_left`, `ucn_ne_right` | UCN ≠ u and UCN ≠ v |\n| I-B | `friendship_separation` | For adj u,v: ucn(x,v) = u for all x ∈ N(u)\\{v} |\n| I-B | `ucn_involutive` | ucn(u, ucn(u,v)) = v (partner involution) |\n| I-B | `ucn_unique_in_neighborhood` | Partner is unique neighbor within N(u) |\n| II | `common_neighbor_finset_card` | |N(u) ∩ N(v)| = 1 (A² off-diagonal) |\n| III | `counting_disjoint` | Partition fibers are pairwise disjoint |\n| III | `counting_cover` | Partition fibers cover V \\ {u} |\n| III | `counting_identity` | n-1 = Σ_{v∈N(u)} (deg(v)-1) |\n| IV | `regular_friendship_card` | n = k(k-1)+1 for k-regular |\n| V | `dvd_sq_add_one_imp_one` | s | s²+1 → s = 1 |\n| VI | `regular_friendship_is_triangle` | k-regular friendship → n = 3 |\n| VI | `regular_friendship_has_universal` | k-regular friendship → universal vertex |\n\n### Single Axiom\n\n`spectral_regular_friendship`: In a k-regular friendship graph with k ≥ 2, k = 2.\n\n---\n\n## Insights\n\n### Separation Lemma (Session 2)\nFor adjacent u, v: ucn(x, v) = u for ALL x ∈ N(u) \\ {v}.\nNeighborhoods of adjacent vertices are completely separated.\n\n### Partner Involution (Session 2)\nv ↦ ucn(u, v) is a fixed-point-free involution on N(u).\nConsequence: deg(u) is always even in a friendship graph.\n\n### Adjacent Same Degree is FALSE (Session 2)\nWindmill W₂: center deg=4, petals deg=2. Both adjacent.\n\"No universal → regular\" requires algebraic methods.\n\n### Matrix Identity A^2 = (k-1)I + J\n- (A^2)_{ij} = common neighbor count = 1 (off-diag) or k (diag)\n- Eigenvalues: k and ±sqrt(k-1)\n- trace(A) = 0 forces k-1 to be a perfect square, then s|s²+1→s=1→k=2\n\n---\n\n## Dead Ends\n\n- **Bijection N(u) → N(v)**: Map x ↦ ucn(x,v) sends ALL of N(u)\\{v} to u.\n  Not injective for deg(u) > 2. Cannot prove adjacent same degree this way.\n- **Counting identity alone**: Consistent with any degree sequence.\n\n---\n\n## Remaining Work\n\nEliminate the spectral axiom via:\n1. Adjacency matrix for SimpleGraph (in Mathlib)\n2. A² = (k-1)I + J as matrix equation\n3. Eigenvalue decomposition (in Mathlib for real symmetric)\n4. Trace = sum of eigenvalues → integrality constraint\n5. Application of dvd_sq_add_one_imp_one (proved)\n"
   },
@@ -131,7 +133,7 @@
     "mathlib": []
   },
   "started": "2026-03-15T12:11:41.208Z",
-  "lastUpdate": "2026-03-20T16:30:00Z",
+  "lastUpdate": "2026-03-20T17:30:00Z",
   "significance": 7,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Prove `monic_factor_of_symmetric_irreducible_pow`: key UFD lemma for ℤ[X]
- Fix `sq_sub_irreducible_of_not_square`: repair 6 Mathlib API breakages
- Prove `k_sub_one_is_perfect_square` glue: connect all supporting lemmas
- **Sorries reduced: 4 → 2**

## Progress
- **UFD structure lemma** proved: f·f(-X) = p^m with p irred symmetric → f = p^{m/2}
- **sq_sub_irreducible_of_not_square** repaired: 6 Mathlib API fixes
- **k_sub_one_is_perfect_square** completed: connects product identity → UFD lemma → odd coefficient = 0 → sub-leading coeff = k ≥ 2 → contradiction
- **Remaining 2 sorries**: `charpoly_quotient_product` (needs det(cI-J) formula), `sqrt_k_sub_one_dvd_k` (needs charpoly factorization with linear factors)

## Status
**Outcome**: progress
**Sorries**: 4 → 2
**Axioms**: 1 (unchanged, elimination blocked by remaining 2 sorries)

🤖 Generated by researcher-4