### PR TITLE
Research: abel-ruffini-oq-01 - Eliminate 3 sorries in InverseGaloisD4

### DIFF
--- a/proofs/Proofs/InverseGaloisD4.lean
+++ b/proofs/Proofs/InverseGaloisD4.lean
@@ -278,14 +278,19 @@ c² = -1 (i.e., c = ±ω where ω²+1=0). So all roots are in ℚ(α,ω) and
 theorem x_sq_add_1_irreducible :
     Irreducible ((X : ℚ[X]) ^ 2 + 1) := by
   -- X²+1 = Φ₄ (4th cyclotomic polynomial), which is irreducible over ℚ
-  -- Proof needs Mathlib API update (cyclotomic_prime_pow_eq_geom_sum signature)
-  sorry
+  -- Φ₄(X) = ∑_{i=0}^{1} X^{2i} = 1 + X² (by cyclotomic_prime_pow_eq_geom_sum with p=2, k=2)
+  have h : (X : ℚ[X]) ^ 2 + 1 = Polynomial.cyclotomic 4 ℚ := by
+    have h1 := Polynomial.cyclotomic_prime_pow_eq_geom_sum (R := ℚ) (p := 2) (hp := by decide) (n := 1)
+    simp only [Finset.sum_range_succ, Finset.sum_range_zero, zero_add, pow_one] at h1
+    norm_num at h1
+    rw [h1]; ring
+  rw [h]
+  exact Polynomial.cyclotomic.irreducible_rat (by norm_num)
 
 /-- X²+1 has degree 2. -/
 theorem x_sq_add_1_natDegree :
     ((X : ℚ[X]) ^ 2 + 1).natDegree = 2 := by
-  -- X²+1 = Φ₄, natDeg(Φ₄) = φ(4) = 2
-  sorry
+  compute_degree!
 
 /-- The real fourth root of 2, defined as √(√2). -/
 noncomputable def fourthRootOfTwo : ℝ := Real.sqrt (Real.sqrt 2)
@@ -328,8 +333,9 @@ theorem x_sq_add_1_no_root_in_adjoin_root_x4_sub_2
 /-- AdjoinRoot(X⁴-2) has ℚ-dimension 4. -/
 theorem adjoin_root_x4_sub_2_finrank :
     Module.finrank ℚ (AdjoinRoot ((X : ℚ[X]) ^ 4 - C 2)) = 4 := by
-  -- Proof needs Mathlib API update (PowerBasis.finrank signature change)
-  sorry
+  have hne : ((X : ℚ[X]) ^ 4 - C 2) ≠ 0 := x_fourth_sub_2_irreducible.ne_zero
+  rw [(AdjoinRoot.powerBasis hne).finrank, AdjoinRoot.powerBasis_dim]
+  exact x_fourth_sub_2_natDegree
 
 -- ---- Section C: |Gal(X⁴-2)| ≠ 4 ----
 

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -51,7 +51,7 @@
         "Mathlib.RingTheory.Polynomial.GaussLemma",
         "Mathlib.NumberTheory.LSeries.PrimesInAP"
       ],
-      "note": "Total across 6 files: InverseGalois.lean (1940 lines, 113 thms, 2 axioms, 2 sorries), InverseGaloisA5.lean (1397 lines, 47 thms, 2 axioms, 1 sorry [coercion diamond]), InverseGaloisD4.lean (680 lines, 27 thms, 0 axioms, 0 sorries), InverseGaloisF20.lean (529 lines, 27 thms, 0 axioms, 0 sorries), AbelRuffiniGaloisExtensions.lean (534 lines, 57 thms, 0 sorries), AbelRuffini.lean (185 lines, 9 thms, 0 sorries)"
+      "note": "Total across 6 files: InverseGalois.lean (1881 lines, 113 thms, 2 axioms, 2 sorries), InverseGaloisA5.lean (1591 lines, 47 thms, 2 axioms, 9 sorries [1 gal_permutes_roots + 8 vandermondeElimination chain]), InverseGaloisD4.lean (682 lines, 29 thms, 0 axioms, 0 sorries — FULLY PROVED), InverseGaloisF20.lean (529 lines, 27 thms, 0 axioms, 0 sorries), AbelRuffiniGaloisExtensions.lean (534 lines, 57 thms, 0 sorries), AbelRuffini.lean (185 lines, 9 thms, 0 sorries)"
     },
     "mathlibDependencies": [
       {

--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-02-21T19:21:07.129Z",
-    "iteration": 13,
-    "focus": "Verified build, at frontier of formalizability",
+    "iteration": 14,
+    "focus": "D4 sorry elimination complete; D4 and F20 fully proved",
     "blockers": [
       "Kronecker-Weber not in Mathlib",
       "Hilbert irreducibility not in Mathlib"
     ],
-    "nextAction": "gal_card_dvd_60 axiom: rewrite gal_permutes_roots without change+rfl to fix elaboration context",
+    "nextAction": "Eliminate vandermondeProduct_sq_eq axiom in A5 (8 sorries in chain) or address gal_permutes_roots sorry",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "VERIFIED: Docker build clean (2 expected sorries: open conjecture + Hilbert irreducibility). 5 axiom declarations across 4 files (InverseGalois + A5 + D4 + F20). gal_card_dvd_60 axiom elimination remains blocked by Lean elaboration context sensitivity.",
+    "progressSummary": "VERIFIED: InverseGaloisD4.lean now 0 sorries, 0 axioms (eliminated 3 sorries: x_sq_add_1_irreducible via Phi_4, x_sq_add_1_natDegree via compute_degree, adjoin_root_x4_sub_2_finrank via AdjoinRoot.powerBasis). 4 axiom declarations remain across 2 files (InverseGalois.lean + A5). D4 and F20 are fully proved.",
     "builtItems": [
       "InverseGalois.lean: cyclotomic Galois theory, S₃ realization via Gal(X³-2)≅S₃ (905 lines, builds)",
       "InverseGaloisD4.lean: D₄ realization via |Gal(X⁴-2)| = 8 (666 lines, builds)",
@@ -164,7 +164,22 @@
       "all_gal_signs_positive: ∀ σ, galSign σ = 1 (from chain)",
       "gal_card_dvd_60_proved: |Gal| ∣ 60 proved from transparent axiom",
       "Fixed Mathlib v4.26.0 API breaks: Subgroup.card_dvd_of_le (Nat.card→Fintype.card), Finset.prod_ne_zero",
-      "meta.json: corrected stats to 5276 lines, 280 thms, 5 axiom declarations (4 independent)"
+      "meta.json: corrected stats to 5276 lines, 280 thms, 5 axiom declarations (4 independent)",
+      {
+        "name": "x_sq_add_1_irreducible_proved",
+        "description": "X^2+1 irreducible via cyclotomic Phi_4",
+        "proven": true
+      },
+      {
+        "name": "x_sq_add_1_natDegree_proved",
+        "description": "natDegree(X^2+1) = 2 via compute_degree",
+        "proven": true
+      },
+      {
+        "name": "adjoin_root_x4_sub_2_finrank_proved",
+        "description": "finrank = 4 via AdjoinRoot.powerBasis",
+        "proven": true
+      }
     ],
     "insights": [
       "Cyclotomic irreducibility over ℚ IS in Mathlib: Polynomial.cyclotomic.irreducible_rat",
@@ -225,7 +240,10 @@
       "MulAction.toPermHom is the underlying API for galActionHom on rootSet - needs careful coercion work",
       "sq_sub_sq gives (a+b)(a-b)=0 for domain reasoning without linear order",
       "Moving the Vandermonde chain (Parts XIII-XIV) before q_gal_card causes elaboration failures: the change+rfl proof in gal_permutes_roots depends on instance resolution context that differs at the earlier file position",
-      "The (Z/nZ)* cyclotomic approach is exhausted for abelian groups up to order 24; remaining groups (C3^2, C4^2, C2^4, Q8) require Galois correspondence or non-cyclotomic constructions"
+      "The (Z/nZ)* cyclotomic approach is exhausted for abelian groups up to order 24; remaining groups (C3^2, C4^2, C2^4, Q8) require Galois correspondence or non-cyclotomic constructions",
+      "cyclotomic_prime_pow_eq_geom_sum takes explicit (hp : Nat.Prime p) not Fact instance",
+      "AdjoinRoot.powerBasis takes (h : f ne 0) not (h : f.Monic) in current Mathlib",
+      "InverseGaloisD4.lean now fully sorry-free and axiom-free (was 3 sorries)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -255,7 +273,7 @@
     "mathlib": []
   },
   "started": "2026-02-21T19:21:07.129Z",
-  "lastUpdate": "2026-03-19T21:00:00.000Z",
+  "lastUpdate": "2026-03-20T18:30:00.000Z",
   "significance": 6,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Eliminated all 3 remaining `sorry` declarations in `InverseGaloisD4.lean`
- D4 file is now **fully proved**: 682 lines, 29 theorems, 0 axioms, 0 sorries
- Docker build verified clean

## Sorries Eliminated

| Sorry | Proof Strategy |
|-------|---------------|
| `x_sq_add_1_irreducible` | X²+1 = Φ₄ via `cyclotomic_prime_pow_eq_geom_sum` (p=2, n=1), then `cyclotomic.irreducible_rat` |
| `x_sq_add_1_natDegree` | `compute_degree!` |
| `adjoin_root_x4_sub_2_finrank` | `AdjoinRoot.powerBasis` + `PowerBasis.finrank` + `AdjoinRoot.powerBasis_dim` |

## API Discoveries
- `cyclotomic_prime_pow_eq_geom_sum` takes explicit `(hp : Nat.Prime p)`, not a `Fact` instance
- `AdjoinRoot.powerBasis` takes `(h : f ≠ 0)`, not `(h : f.Monic)` in current Mathlib

## Status
**Outcome**: completed (D4 sorry elimination)
**Next Steps**: Eliminate `vandermondeProduct_sq_eq` axiom in A5 (8 sorries in chain), or address `gal_permutes_roots` sorry

🤖 Generated by researcher-2