### PR TITLE
Research: abel-ruffini-oq-01 - Prove 3 theorems in A5 (9→7 sorries)

### DIFF
--- a/proofs/Proofs/InverseGaloisA5.lean
+++ b/proofs/Proofs/InverseGaloisA5.lean
@@ -1124,20 +1124,40 @@ theorem gal_fixes_vandermondeProduct (σ : q.Gal) :
 -- Step 5: σ(Δ) = galSign(σ) · Δ (Vandermonde permutation)
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+/-
+## BLOCKER: Algebra SF SF typeclass diamond
+
+`gal_permutes_roots` requires `(σ • r).val = σ r.val` for the `galAction` MulAction.
+But `galAction` goes through `rootsEquivRoots`, which uses `mapRoots`, which applies
+`IsScalarTower.toAlgHom ℚ SF SF` (= algebraMap SF SF from the Gal algebra instance).
+
+There are TWO `Algebra SF SF` instances:
+1. `Algebra.id SF` — gives `algebraMap SF SF = RingHom.id SF`
+2. `Gal.instAlgebra...` — derived from `IsSplittingField.lift`, gives `algebraMap SF SF = ψ`
+   where ψ is some (non-constructive) Galois automorphism selected by Classical.choice.
+
+For `Algebra.id`, `mapRoots = id` and `(σ • r).val = σ r.val`.
+For the Gal instance, `mapRoots` applies ψ, and `(σ • r).val = ψ(σ(ψ⁻¹ r.val))`.
+
+The proof of `mapRoots_val` fails because `algebraMap_self_apply` uses `Algebra.id`
+while the goal uses the Gal instance. The two instances are propositionally but not
+definitionally equal, and proving their equality requires resolving the diamond at the
+level of `IsSplittingField.lift` (which uses Classical.choice).
+
+**Mathlib note**: The Mathlib comment on `Polynomial.Gal.restrict` says:
+"IsSplittingField.lift.toRingHom.toAlgebra =?= Algebra.id, which takes an extremely
+long time to resolve, causing timeouts."
+
+Possible fix: Prove `algebraMap SF SF = RingHom.id SF` for the Gal instance by showing
+that `IsSplittingField.lift` to the same field is the identity (requires algebraic
+closure / finite extension theory).
+-/
+
 theorem gal_permutes_roots (σ : q.Gal) (i : Fin 5) :
     σ (rootEnum i) = rootEnum (galToPerm5 σ i) := by
-  -- rootEnum i = (e.symm i).val, galToPerm5 σ = permCongr e ∘ galActionHom σ
-  -- Unfold definitions and simplify MulEquiv struct
-  unfold rootEnum galToPerm5
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.coe_mk,
-    Equiv.toFun_as_coe, Equiv.permCongr_apply, Equiv.symm_apply_apply]
-  -- Goal: σ ↑(e.symm i) = ↑(galActionHom σ (e.symm i))
-  -- galActionHom σ r = σ • r, and for rootSet elements ↑(σ • r) = σ ↑r
-  -- via restrict_smul (handles rootsEquivRoots cancellation).
-  -- Step 1: Show restrict q SplittingField σ = σ on elements
-  -- (restrictNormalHom restricts σ to SplittingField = itself)
-  -- Proof needs Mathlib API update (MulEquiv.toMonoidHom_apply renamed,
-  -- restrictNormal_commutes signature change, restrict_smul elaboration)
+  -- BLOCKED: Algebra SF SF typeclass diamond (see comment above)
+  -- The proof requires mapRoots q SF to be the identity, which requires
+  -- the Gal algebra instance to agree with Algebra.id.
   sorry
 
 /-- Vandermonde matrix with permuted input = row-permuted Vandermonde. -/
@@ -1397,13 +1417,20 @@ a standard identity but not yet available in Mathlib.
 -- ============================================================================
 
 /-
-## Proof Strategy
+## Proof Strategy (BLOCKED)
+
+**CRITICAL**: `Polynomial.resultant` and `Polynomial.discr` do NOT exist in
+Mathlib v4.26.0. This entire proof chain was designed based on incorrect assumptions
+about the Mathlib API. The resultant/discriminant infrastructure needs to be either:
+1. Built from scratch (Sylvester matrix → determinant → resultant)
+2. Added to Mathlib upstream first
+3. Replaced by a different proof strategy
 
 The axiom `vandermondeProduct_sq_eq` states:
   Δ² = algebraMap ℤ SF 1024000000
 where Δ = ∏_{i<j} (rootEnum j - rootEnum i).
 
-We eliminate it using Mathlib's resultant API:
+The INTENDED approach was to use a resultant API:
 
 1. **resultant_deriv**: Res(q, q') = (-1)^{n(n-1)/2} · lc(q) · disc(q)
    For monic q with n=5: Res(q, q') = disc(q)

--- a/proofs/Proofs/InverseGaloisA5.lean
+++ b/proofs/Proofs/InverseGaloisA5.lean
@@ -183,6 +183,13 @@ theorem q_natDegree : q.natDegree = 5 := by
   unfold q
   compute_degree!
 
+/-- q is monic (leading coefficient = 1). -/
+theorem q_monic : q.Monic := by
+  rw [Polynomial.Monic, Polynomial.leadingCoeff, q_natDegree]
+  unfold q
+  simp only [coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X]
+  norm_num
+
 /-- q is separable (irreducible in characteristic 0). -/
 theorem q_separable : q.Separable := q_irreducible.separable
 
@@ -1470,13 +1477,17 @@ private theorem prod_Iio_eq_vandermonde {n : ℕ} {R : Type*} [CommRing R]
     (v : Fin n → R) :
     (∏ i : Fin n, ∏ j ∈ Finset.Iio i, (v i - v j)) =
     ∏ i : Fin n, ∏ j ∈ Finset.Ioi i, (v j - v i) := by
-  -- Proof needs update for ∈ notation (previously used Finset.prod_nbij with in syntax)
-  sorry
+  -- Swap summation order: ∏_i ∏_{j<i} f(i,j) = ∏_j ∏_{i>j} f(i,j)
+  -- After bound variable renaming, this is ∏_i ∏_{j>i} f(j,i) = RHS
+  exact Finset.prod_comm' (fun a b => by
+    simp only [Finset.mem_univ, true_and, Finset.mem_Iio, Finset.mem_Ioi, and_true])
 
 theorem ordered_root_diff_prod_eq_vandermonde_sq :
     (∏ i : Fin 5, ∏ j ∈ Finset.univ.erase i, (rootEnum i - rootEnum j)) =
     vandermondeProduct ^ 2 := by
-  -- Proof needs update for ∈ notation (previously used Finset.prod with in syntax)
+  -- Split ∏_{j≠i} into ∏_{j<i}·∏_{j>i}, use prod_Iio_eq_vandermonde for first factor.
+  -- Second factor: negate each term, (-1)^{C(5,2)} = (-1)^10 = 1.
+  -- TODO: Fill in details
   sorry
 
 -- Step B: Connect derivative evaluation to root differences
@@ -1499,14 +1510,70 @@ theorem eval_derivative_at_root_of_factor {K : Type*} [Field K]
 /-- q mapped to its splitting field splits as ∏ (X - rootEnum i). -/
 theorem q_SF_eq_prod_linear :
     q_SF = ∏ i : Fin 5, (X - C (rootEnum i)) := by
-  -- Uses: C_leadingCoeff_mul_prod_multiset_X_sub_C (for q_SF with roots.card = 5)
-  -- Then: convert Multiset.prod to Finset.prod via rootSet ≃ Fin 5
-  -- Key ingredients:
-  --   q_monic.map: q_SF is monic (lc = 1)
-  --   SplittingField.splits: q_SF splits
-  --   q_rootSet_card: rootSet has card 5
-  --   rootEnum defined via Fintype.equivOfCardEq on rootSet ≃ Fin 5
-  sorry
+  -- Strategy: both sides are monic of degree 5, and P ∣ q_SF, so P = q_SF.
+  set P := ∏ i : Fin 5, (X - C (rootEnum i)) with hP_def
+  -- q_SF is monic
+  have hq_monic : q_SF.Monic := q_monic.map (algebraMap ℚ q.SplittingField)
+  have hq_ne : q_SF ≠ 0 := hq_monic.ne_zero
+  -- P is monic
+  have hP_monic : P.Monic :=
+    Polynomial.monic_prod_of_monic _ _ (fun i _ => Polynomial.monic_X_sub_C _)
+  -- P has degree 5
+  have hP_deg : P.natDegree = 5 := by
+    rw [hP_def, Polynomial.natDegree_prod_of_monic _ _
+      (fun i _ => Polynomial.monic_X_sub_C _)]
+    simp [Polynomial.natDegree_X_sub_C, Finset.sum_const, Finset.card_fin]
+  -- Each rootEnum i is a root of q_SF
+  have hroot : ∀ i : Fin 5, Polynomial.IsRoot q_SF (rootEnum i) := by
+    intro i
+    have := rootEnum_is_root i
+    rwa [Polynomial.aeval_def, Polynomial.eval₂_eq_eval_map] at this
+  -- Each linear factor divides q_SF
+  have hdvd_each : ∀ i : Fin 5, (X - C (rootEnum i)) ∣ q_SF :=
+    fun i => Polynomial.dvd_iff_isRoot.mpr (hroot i)
+  -- Pairwise coprime via Bezout identity:
+  -- u*(X - C α) + v*(X - C β) = 1 where u = C((β-α)⁻¹), v = -C((β-α)⁻¹)
+  have hcoprime : ∀ i j : Fin 5, i ≠ j →
+      IsCoprime (X - C (rootEnum i) : Polynomial q.SplittingField)
+               (X - C (rootEnum j)) := by
+    intro i j hij
+    have hne : rootEnum i ≠ rootEnum j := fun h => hij (rootEnum_injective h)
+    have hne' : rootEnum j - rootEnum i ≠ 0 := sub_ne_zero.mpr (Ne.symm hne)
+    exact ⟨C ((rootEnum j - rootEnum i)⁻¹), -C ((rootEnum j - rootEnum i)⁻¹), by
+      calc C ((rootEnum j - rootEnum i)⁻¹) * (X - C (rootEnum i)) +
+           -C ((rootEnum j - rootEnum i)⁻¹) * (X - C (rootEnum j))
+        _ = C ((rootEnum j - rootEnum i)⁻¹) *
+            ((X - C (rootEnum i)) - (X - C (rootEnum j))) := by ring
+        _ = C ((rootEnum j - rootEnum i)⁻¹) * C (rootEnum j - rootEnum i) := by
+            congr 1
+            have : (X : Polynomial q.SplittingField) - C (rootEnum i) -
+                   (X - C (rootEnum j)) = C (rootEnum j) - C (rootEnum i) := by ring
+            rw [this, ← map_sub]
+        _ = C ((rootEnum j - rootEnum i)⁻¹ * (rootEnum j - rootEnum i)) := by
+            rw [← map_mul]
+        _ = C 1 := by rw [inv_mul_cancel₀ hne']
+        _ = 1 := map_one _⟩
+  -- Product of pairwise coprime factors divides q_SF
+  have hdvd : P ∣ q_SF := by
+    rw [hP_def]
+    exact Finset.prod_dvd_of_coprime
+      (fun i _ j _ hij => hcoprime i j hij) (fun i _ => hdvd_each i)
+  -- Both monic of same degree with P ∣ q_SF → P = q_SF
+  obtain ⟨r, hr⟩ := hdvd
+  have r_ne : r ≠ 0 := right_ne_zero_of_mul (hr ▸ hq_ne)
+  have hr_deg : r.natDegree = 0 := by
+    have h1 := Polynomial.natDegree_mul hP_monic.ne_zero r_ne
+    rw [← hr, Polynomial.natDegree_map, q_natDegree, hP_deg] at h1; omega
+  have hr_one : r = 1 := by
+    have h := Polynomial.eq_C_of_natDegree_eq_zero hr_deg
+    -- r.leadingCoeff = 1 from monicity of product
+    have hrc : r.leadingCoeff = 1 := by
+      have hm := hq_monic; rw [hr, Polynomial.Monic] at hm
+      rw [Polynomial.leadingCoeff_mul, hP_monic.leadingCoeff, one_mul] at hm
+      exact hm
+    rw [h, Polynomial.leadingCoeff_C] at hrc
+    rw [h, hrc, map_one]
+  rw [hr, hr_one, mul_one]
 
 -- Step D: Derivative at rootEnum i gives the product of root differences
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-02-21T19:21:07.129Z",
-    "iteration": 14,
-    "focus": "D4 sorry elimination complete; D4 and F20 fully proved",
+    "iteration": 15,
+    "focus": "Proved q_SF_eq_prod_linear (splitting field factorization) and prod_Iio_eq_vandermonde",
     "blockers": [
       "Kronecker-Weber not in Mathlib",
       "Hilbert irreducibility not in Mathlib"
     ],
-    "nextAction": "Eliminate vandermondeProduct_sq_eq axiom in A5 (8 sorries in chain) or address gal_permutes_roots sorry",
+    "nextAction": "Prove eval_derivative_q_at_root (depends on q_SF_eq_prod_linear), ordered_root_diff_prod_eq_vandermonde_sq, then blocked: resultant/discr not in Mathlib",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "VERIFIED: InverseGaloisD4.lean now 0 sorries, 0 axioms (eliminated 3 sorries: x_sq_add_1_irreducible via Phi_4, x_sq_add_1_natDegree via compute_degree, adjoin_root_x4_sub_2_finrank via AdjoinRoot.powerBasis). 4 axiom declarations remain across 2 files (InverseGalois.lean + A5). D4 and F20 are fully proved.",
+    "progressSummary": "PROGRESS: Proved 3 new theorems in InverseGaloisA5.lean (9→7 sorries): q_monic (monicity of q), prod_Iio_eq_vandermonde (Finset product reindexing via prod_comm), q_SF_eq_prod_linear (splitting field factorization via coprime divisibility). Docker build verified.",
     "builtItems": [
       "InverseGalois.lean: cyclotomic Galois theory, S₃ realization via Gal(X³-2)≅S₃ (905 lines, builds)",
       "InverseGaloisD4.lean: D₄ realization via |Gal(X⁴-2)| = 8 (666 lines, builds)",
@@ -179,6 +179,21 @@
         "name": "adjoin_root_x4_sub_2_finrank_proved",
         "description": "finrank = 4 via AdjoinRoot.powerBasis",
         "proven": true
+      },
+      {
+        "name": "q_monic",
+        "description": "q is monic (leading coefficient 1)",
+        "proven": true
+      },
+      {
+        "name": "prod_Iio_eq_vandermonde",
+        "description": "∏_i ∏_{j<i} (v i - v j) = ∏_i ∏_{j>i} (v j - v i) via Finset.prod_comm",
+        "proven": true
+      },
+      {
+        "name": "q_SF_eq_prod_linear",
+        "description": "q_SF = ∏ (X - C rootEnum i) via coprime divisibility + degree",
+        "proven": true
       }
     ],
     "insights": [
@@ -243,7 +258,11 @@
       "The (Z/nZ)* cyclotomic approach is exhausted for abelian groups up to order 24; remaining groups (C3^2, C4^2, C2^4, Q8) require Galois correspondence or non-cyclotomic constructions",
       "cyclotomic_prime_pow_eq_geom_sum takes explicit (hp : Nat.Prime p) not Fact instance",
       "AdjoinRoot.powerBasis takes (h : f ne 0) not (h : f.Monic) in current Mathlib",
-      "InverseGaloisD4.lean now fully sorry-free and axiom-free (was 3 sorries)"
+      "InverseGaloisD4.lean now fully sorry-free and axiom-free (was 3 sorries)",
+      "Polynomial.leadingCoeff_mul in domain gives leadingCoeff(P*r) = lc(P)*lc(r), combined with Monic for degree extraction",
+      "Finset.prod_comm' swaps nested product order with membership condition: b < a ↔ a > b",
+      "IsCoprime via Bezout: u*(X-Cα) + v*(X-Cβ) = 1 where u=C((β-α)⁻¹), ring handles polynomial simplification but not C coercion, use map_sub",
+      "Finset.prod_dvd_of_coprime requires ∀ i ∈ Finset.univ form (not bare ∀ i)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -273,7 +292,7 @@
     "mathlib": []
   },
   "started": "2026-02-21T19:21:07.129Z",
-  "lastUpdate": "2026-03-20T18:30:00.000Z",
+  "lastUpdate": "2026-03-20T22:30:00.000Z",
   "significance": 6,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Prove 3 new theorems in `InverseGaloisA5.lean`, reducing sorry count from 9 to 7
- Docker build verified clean (only expected sorry warnings)

## Progress
- **`q_monic`**: Prove q is monic via leadingCoeff computation at degree 5
- **`prod_Iio_eq_vandermonde`**: Prove the Finset product reindexing identity ∏_{j<i}(v_i - v_j) = ∏_{j>i}(v_j - v_i) using `Finset.prod_comm'`
- **`q_SF_eq_prod_linear`**: Prove q splits as ∏(X - C rootEnum i) in the splitting field using:
  - Explicit Bezout coefficients for pairwise coprimality of linear factors
  - `Finset.prod_dvd_of_coprime` for product divisibility
  - Monic degree comparison to conclude equality

## Findings
- `Finset.prod_comm'` cleanly swaps nested product order with membership condition (b < a ↔ a > b)
- `ring` tactic handles polynomial simplification but not C coercion: need `map_sub` for `C b - C a = C(b-a)`
- `Finset.prod_dvd_of_coprime` requires `∀ i ∈ Finset.univ` form, not bare `∀ i`
- `Polynomial.leadingCoeff_mul` in domain gives clean monicity transfer

## Status
**Outcome**: progress
**Remaining 7 sorries**:
- `gal_permutes_roots`: blocked by Algebra SF SF typeclass diamond
- `ordered_root_diff_prod_eq_vandermonde_sq`: needs sign computation for (-1)^{C(5,2)}
- 4 blocked by missing `Polynomial.resultant`/`Polynomial.discr` in Mathlib v4.26.0
- 1 in `q_SF_eq_prod_linear` auxiliary lemma

🤖 Generated by researcher-4