### PR TITLE
Research: friendship-theorem-oq-01 - Prove sqrt_k_sub_one_dvd_k (s|k)

### DIFF
--- a/proofs/Proofs/FriendshipTheoremOQ01.lean
+++ b/proofs/Proofs/FriendshipTheoremOQ01.lean
@@ -1470,18 +1470,98 @@ theorem k_sub_one_is_perfect_square (hF : IsFriendshipGraph G)
   -- k = 0, contradicting k ≥ 2
   linarith
 
+/-- **UFD factorization**: a monic polynomial in ℤ[X] dividing a product
+    of coprime prime powers factors into powers of those primes.
+
+    In ℤ[X]: (X-a) and (X+a) are non-associate primes for a ≥ 1.
+    If f is monic and f ∣ (X-a)^m·(X+a)^m, then f = (X-a)^b·(X+a)^c
+    with b+c = natDegree(f).
+
+    **Proof sketch**: Every irreducible factor p of f divides
+    (X-a)^m·(X+a)^m. Since p is prime (UFD), p ∣ (X-a)^m or p ∣ (X+a)^m.
+    By Prime.dvd_of_dvd_pow: p ∣ (X-a) or p ∣ (X+a). Since both are
+    prime (hence irreducible), p is an associate. For monic f, the unit
+    factor is 1. -/
+private lemma monic_dvd_coprime_prime_pow_factored (a : ℤ) (ha : a ≥ 1)
+    (f : Polynomial ℤ) (hf : f.Monic) (m : ℕ)
+    (hdvd : f ∣ (X - C a) ^ m * (X + C a) ^ m) :
+    ∃ (b c : ℕ), b + c = f.natDegree ∧ b ≤ m ∧ c ≤ m ∧
+      f = (X - C a) ^ b * (X + C a) ^ c := by
+  sorry
+
+/-- **Sub-leading coefficient of (X-a)^b·(X+a)^c** equals (c-b)·a.
+
+    From Vieta's formulas: the sum of roots (with multiplicity) is
+    b·a + c·(-a) = (b-c)·a. The sub-leading coefficient (coeff at
+    degree b+c-1) is the negative of this sum: (c-b)·a. -/
+private lemma subleading_coeff_factored (a : ℤ) (b c : ℕ)
+    (hbc : b + c ≥ 1) :
+    ((X - C a) ^ b * (X + C a) ^ c : Polynomial ℤ).coeff (b + c - 1) =
+    (↑c - ↑b : ℤ) * a := by
+  sorry
+
 /-- **s divides k** for s = √(k-1) in a k-regular friendship graph.
 
-    From f = (X-s)^a·(X+s)^b with a+b = n-1:
-    The sub-leading coefficient (b-a)·s = k, so s | k. -/
+    **Proof**: From the product identity f·f(-X) = (X²-s²)^{n-1},
+    f divides (X-s)^{n-1}·(X+s)^{n-1}. By UFD factorization in ℤ[X],
+    f = (X-s)^b·(X+s)^c with b+c = n-1. The sub-leading coefficient
+    gives (c-b)·s = k, hence s | k.
+
+    **Dependencies**: Uses `charpoly_quotient_product` (the product identity,
+    currently sorry). Once that is proved, this theorem follows. -/
 theorem sqrt_k_sub_one_dvd_k (hF : IsFriendshipGraph G)
     (u : V) (k : ℕ) (hk : k ≥ 2) (hreg : ∀ v : V, G.degree v = k)
     (s : ℕ) (hs : k - 1 = s * s) :
     s ∣ k := by
-  -- From charpoly factorization: f = (X-s)^a·(X+s)^b, a+b=n-1
-  -- Sub-leading coeff of f: -(a·s - b·s) = (b-a)·s = k
-  -- So s | k.
-  sorry
+  -- Trivial case: s ≤ 1
+  by_cases hs1 : s = 1
+  · subst hs1; omega  -- s = 1 → k = 2, and 1 | 2
+  -- s ≥ 2: use the product identity + UFD factorization
+  have hs_ge2 : s ≥ 2 := by
+    rcases s with _ | _ | s <;> simp_all; omega
+  haveI : Nonempty V := ⟨u⟩
+  -- Step 1: Get charpoly = (X-k)·f
+  obtain ⟨f, hf⟩ := X_sub_k_dvd_adjMatrix_charpoly G hF k (by omega) hreg
+  have hf_monic : f.Monic := by
+    have := (G.adjMatrix ℤ).charpoly_monic; rw [hf] at this
+    exact Polynomial.Monic.of_mul_monic_left (monic_X_sub_C _) this
+  have hn_card := regular_friendship_card G hF u k hreg (by omega)
+  have hn_ge : Fintype.card V ≥ 3 := by
+    rw [hn_card]; nlinarith [show k - 1 ≥ 1 by omega]
+  have hf_deg : f.natDegree = Fintype.card V - 1 := by
+    have := Matrix.charpoly_natDegree_eq_dim (G.adjMatrix ℤ)
+    rw [hf, Polynomial.natDegree_mul (monic_X_sub_C _).ne_zero hf_monic.ne_zero,
+      Polynomial.natDegree_X_sub_C] at this; omega
+  -- Step 2: Product identity → f divides (X-s)^{n-1}·(X+s)^{n-1}
+  have hprod := charpoly_quotient_product G hF k hk hreg f hf
+  -- Rewrite (X²-(k-1))^{n-1} = ((X-s)(X+s))^{n-1}
+  have hks : (X ^ 2 - C (↑(k - 1) : ℤ) : Polynomial ℤ) =
+      (X - C (↑s : ℤ)) * (X + C (↑s : ℤ)) := by
+    have h1 : (k - 1 : ℕ) = s * s := hs
+    have h2 : (↑(s * s) : ℤ) = (↑s : ℤ) * ↑s := by push_cast; ring
+    rw [h1, h2]; simp only [map_mul]; ring
+  rw [hks, mul_pow] at hprod
+  have hf_dvd : f ∣ (X - C (↑s : ℤ)) ^ (Fintype.card V - 1) *
+      (X + C (↑s : ℤ)) ^ (Fintype.card V - 1) :=
+    ⟨f.comp (-X), hprod.symm⟩
+  -- Step 3: UFD factorization → f = (X-s)^b·(X+s)^c
+  obtain ⟨b, c, hbc, _, _, hf_eq⟩ :=
+    monic_dvd_coprime_prime_pow_factored (↑s : ℤ) (by omega : (↑s : ℤ) ≥ 1)
+      f hf_monic (Fintype.card V - 1) hf_dvd
+  rw [hf_deg] at hbc
+  -- Step 4: Sub-leading coefficient links (c-b)·s to k
+  have hcoeff := quotient_subleading_coeff G hF k hk hreg f hf hf_monic hf_deg
+  have hvieta := subleading_coeff_factored (↑s : ℤ) b c (by omega : b + c ≥ 1)
+  -- The coeff at degree b+c-1 of the factored form equals (c-b)·s
+  -- And the coeff at degree n-2 of f equals k
+  -- Since f = (X-s)^b*(X+s)^c and b+c = n-1: n-2 = b+c-1
+  rw [hf_eq, show Fintype.card V - 2 = b + c - 1 from by omega] at hcoeff
+  -- Now hcoeff : ((X-s)^b*(X+s)^c).coeff(b+c-1) = k
+  -- And hvieta : ((X-s)^b*(X+s)^c).coeff(b+c-1) = (c-b)*s
+  rw [hvieta] at hcoeff
+  -- hcoeff : (↑c - ↑b) * ↑s = ↑k
+  have hdvd_int : (↑s : ℤ) ∣ (↑k : ℤ) := ⟨↑c - ↑b, by linarith⟩
+  exact_mod_cast hdvd_int
 
 /-- **Main theorem: k = 2 without any axiom.**
 


### PR DESCRIPTION
## Summary
- Proved `sqrt_k_sub_one_dvd_k`: s divides k for s = √(k-1) in k-regular friendship graphs
- Decomposed the proof into: product identity → UFD factorization → Vieta → divisibility
- Added 2 new helper lemmas (standard results with sorry): UFD factorization in ℤ[X] and Vieta formula

## Progress
- `sqrt_k_sub_one_dvd_k` theorem: **proved** (was sorry)
- `monic_dvd_coprime_prime_pow_factored`: new helper, sorry (standard UFD result)
- `subleading_coeff_factored`: new helper, sorry (standard Vieta result)
- Docker build: **passes**

## File Status
- 1 axiom (`charpoly_eigenvalue_data`) - unchanged
- 3 sorries (was 2): product identity + 2 new standard helpers
- Net: main theorem `sqrt_k_sub_one_dvd_k` no longer sorry

## Proof Chain (once all sorries filled)
```
charpoly_quotient_product → k_sub_one_is_perfect_square → sqrt_k_sub_one_dvd_k → k_eq_two_no_axiom
```
All but `charpoly_quotient_product` (the product identity) are now proved or have clear helper sorries.

## Next Steps
1. Prove `monic_dvd_coprime_prime_pow_factored` (UFD factorization)
2. Prove `subleading_coeff_factored` (Vieta formula)
3. Prove `charpoly_quotient_product` (main bottleneck: needs det(cI-J) formula)

🤖 Generated by researcher-5