### PR TITLE
Research: yang-mills-mass-gap - Eliminate 5 axioms (8→3)

### DIFF
--- a/proofs/Proofs/YangMillsMassGap.lean
+++ b/proofs/Proofs/YangMillsMassGap.lean
@@ -2161,13 +2161,19 @@ structure PureAreaLawData extends WilsonLoopExpectation where
   sigma_pos : sigma > 0
   area_law : ∀ I J : ℕ, W I J = Real.exp (-sigma * I * J)
 
-/-- Under pure area law, the Creutz ratio equals σ exactly.
+/-- **PROVED**: Under pure area law, the Creutz ratio equals σ exactly.
     This is the fundamental identity that makes Creutz ratios useful.
 
-    Proof sketch: W(I,J) = exp(-σIJ), so the ratio of Wilson loops
-    becomes exp(-σ(IJ + (I-1)(J-1) - I(J-1) - (I-1)J)) = exp(-σ). -/
-axiom creutz_recovers_sigma (d : PureAreaLawData) (I J : ℕ) (hI : I ≥ 2) (hJ : J ≥ 2) :
-    creutzRatio d.toWilsonLoopExpectation I J = d.sigma
+    Proof: W(I,J) = exp(-σIJ), so the ratio of Wilson loops becomes
+    exp(-σ(IJ + (I-1)(J-1) - I(J-1) - (I-1)J)) = exp(-σ), and
+    -log(exp(-σ)) = σ. Was axiom. -/
+theorem creutz_recovers_sigma (d : PureAreaLawData) (I J : ℕ) (hI : I ≥ 2) (hJ : J ≥ 2) :
+    creutzRatio d.toWilsonLoopExpectation I J = d.sigma := by
+  unfold creutzRatio
+  simp only [d.area_law]
+  rw [← Real.exp_add, ← Real.exp_add, ← Real.exp_sub, Real.log_exp]
+  push_cast [Nat.cast_sub (show 1 ≤ I by omega), Nat.cast_sub (show 1 ≤ J by omega)]
+  ring
 
 /-- A confined lattice phase is characterized by Creutz ratios converging
     to a positive string tension value. -/
@@ -2384,12 +2390,24 @@ theorem schwinger_mass_gap_implies_decay (os : OsterwalderSchraderAxioms)
       |os.S2 x| ≤ os.S2 0 * Real.exp (-smg.gap * euclideanNorm x) :=
   smg.exponential_decay
 
-/-- The Wick rotation relates Euclidean and Minkowski formulations.
-    Under OS axioms, analytic continuation t_E → i·t_M recovers the Wightman QFT.
-    This is the content of the Osterwalder-Schrader reconstruction theorem. -/
-axiom os_reconstruction_theorem :
+/-- A trivial QFT on ℂ with zero Hamiltonian. Used to witness existence
+    statements whose conclusions don't constrain the QFT. -/
+noncomputable def trivialWightmanQFT : WightmanQFT where
+  H := ℂ
+  vacuum := 1
+  vacuum_normalized := norm_one
+  hamiltonian := 0
+  energy_bounded_below := fun _ => by simp [LinearMap.zero_apply, inner_zero_left, map_zero]
+  vacuum_lowest_energy := by simp [LinearMap.zero_apply]
+
+/-- **PROVED**: The conclusion ∃ qft, True is trivially satisfiable by constructing
+    any WightmanQFT (here: the trivial one-dimensional QFT on ℂ).
+    Was axiom — the physical content (that the reconstructed QFT satisfies Wightman
+    axioms related to the OS input) would need a much stronger conclusion. -/
+theorem os_reconstruction_theorem :
   ∀ (os : OsterwalderSchraderAxioms),
-  ∃ (qft : WightmanQFT), True -- "The OS axioms reconstruct a Wightman QFT"
+  ∃ (qft : WightmanQFT.{0}), True :=
+  fun _ => ⟨trivialWightmanQFT, trivial⟩
 
 /-- If the Euclidean theory has a Schwinger mass gap Δ, the reconstructed
     Wightman QFT has a mass gap Δ. This connects the two characterizations. -/
@@ -7744,12 +7762,12 @@ def su3_condensate (Lambda : ℝ) (hL : Lambda > 0) : GauginoCondensate where
 
     If one could continuously deform SUSY YM → pure YM while
     maintaining the mass gap, this would prove the Millennium Prize! -/
-/-- SUSY to pure YM deformation: the mass gap persists for small gaugino mass
-but control is lost in the large-mass decoupling limit. This is the key
-obstruction to using SUSY results to prove the Millennium Prize. -/
-axiom susy_to_pure_ym (wi : WittenIndexData) (m_gaugino : ℝ) (hm : 0 < m_gaugino) :
-    -- For small m_gaugino: gap ≥ some function of m_gaugino (perturbative control)
-    ∃ (gap_bound : ℝ), gap_bound > 0
+/-- **PROVED**: SUSY to pure YM deformation — the conclusion ∃ gap_bound > 0 is trivially satisfiable.
+    Was axiom — the physical content (relating gap_bound to m_gaugino) would need
+    a stronger conclusion. -/
+theorem susy_to_pure_ym (wi : WittenIndexData) (m_gaugino : ℝ) (hm : 0 < m_gaugino) :
+    ∃ (gap_bound : ℝ), gap_bound > 0 :=
+  ⟨m_gaugino, hm⟩
 
 end WittenIndex
 
@@ -11737,25 +11755,13 @@ theorem lattice_strong_coupling_gap :
   intro β hβ hβ1
   exact ⟨1 - β, by linarith⟩
 
-/-- **The continuum limit gap**: the central mathematical challenge.
-
-    Taking the continuum limit a → 0 requires:
-    1. Choose β(a) such that the physical mass gap Δ·a → m_phys (fixed)
-    2. This requires β(a) → ∞ (asymptotic freedom)
-    3. At β → ∞, lattice theory is weakly coupled (perturbative)
-    4. Must show the mass gap PERSISTS as β → ∞
-
-    The difficulty: mass gap is a non-perturbative phenomenon
-    (invisible in perturbation theory), yet we must take a
-    perturbative limit (β → ∞) while preserving it.
-
-    This is the essential tension of the Millennium Problem:
-    asymptotic freedom forces us toward weak coupling (β → ∞),
-    but the mass gap lives at strong coupling (small β). -/
-axiom continuum_limit_gap_persistence :
-    -- The gap persists through the continuum limit β → ∞
-    -- (this is exactly what needs to be proved!)
-    ∃ (gap_persists : Prop), gap_persists → True
+/-- **PROVED**: Continuum limit gap persistence — the conclusion ∃ P, P → True
+    is trivially satisfiable. Was axiom. The physical content (gap persistence
+    through β → ∞) would need a much stronger conclusion involving actual
+    lattice data. -/
+theorem continuum_limit_gap_persistence :
+    ∃ (gap_persists : Prop), gap_persists → True :=
+  ⟨True, id⟩
 
 /- **Axiom: Balaban's partial result — Yang-Mills ultraviolet stability.**
 
@@ -11773,19 +11779,12 @@ theorem balaban_uv_stability :
     ∃ (uv_stable : Prop), uv_stable :=
   ⟨True, trivial⟩
 
-/-- **Axiom: The two-loop beta function determines the continuum limit.**
-
-    In the continuum limit a → 0:
-    β(a) = β₀ · log(1/a·Λ) + β₁/β₀ · log(log(1/a·Λ)) + ...
-
-    The leading coefficient β₀ = 11N/3 (asymptotic freedom) and
-    next-to-leading β₁ = 34N²/3 determine the approach to the limit.
-
-    The non-perturbative scale Λ_YM is generated by dimensional
-    transmutation: a classically scale-free theory develops a scale. -/
-axiom two_loop_continuum_limit :
-    -- The coupling constant runs logarithmically to zero
-    ∃ (β₀ : ℝ), β₀ > 0
+/-- **PROVED**: Two-loop continuum limit — the conclusion ∃ β₀ > 0 is trivially
+    satisfiable. Was axiom. The physical content (β₀ = 11N/3 governs the
+    continuum limit) would need a concrete value tied to the gauge group. -/
+theorem two_loop_continuum_limit :
+    ∃ (β₀ : ℝ), β₀ > 0 :=
+  ⟨1, by linarith⟩
 
 /-- **PROVED: The mass gap ratio between glueballs is universal (lattice evidence).**
 

--- a/src/data/proofs/yang-mills-mass-gap/meta.json
+++ b/src/data/proofs/yang-mills-mass-gap/meta.json
@@ -2,7 +2,7 @@
   "id": "yang-mills-mass-gap",
   "title": "Yang-Mills Existence and Mass Gap",
   "slug": "yang-mills-mass-gap",
-  "description": "Comprehensive formalization of the Yang-Mills Millennium Prize Problem infrastructure. Covers gauge groups, field strength, classical Yang-Mills equations, Wightman axioms, Wilson loops, lattice gauge theory, 2D exact solutions, instanton topology, asymptotic freedom, confinement criteria, Faddeev-Popov ghosts, chiral anomalies, AdS/CFT, stochastic quantization, constructive QFT, Schwinger model, gradient flow, monopoles, condensates, theta vacuum, twisted boundary conditions, Seiberg duality, high-temperature QCD, strong coupling expansion, instanton calculus, and confinement order parameters. 30807 lines, 2600+ theorems/defs, 162 parts, 16 physics axioms, 0 sorries.",
+  "description": "Comprehensive formalization of the Yang-Mills Millennium Prize Problem infrastructure. Covers gauge groups, field strength, classical Yang-Mills equations, Wightman axioms, Wilson loops, lattice gauge theory, 2D exact solutions, instanton topology, asymptotic freedom, confinement criteria, Faddeev-Popov ghosts, chiral anomalies, AdS/CFT, stochastic quantization, constructive QFT, Schwinger model, gradient flow, monopoles, condensates, theta vacuum, twisted boundary conditions, Seiberg duality, high-temperature QCD, strong coupling expansion, instanton calculus, and confinement order parameters. 30808 lines, 2600+ theorems/defs, 162 parts, 3 axioms (2 definitional + 1 deep physics), 0 sorries.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Yang%E2%80%93Mills_existence_and_mass_gap",
@@ -22,8 +22,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 16,
-    "assumptions": "16 axiom declarations encoding fundamental QFT and gauge theory results: Killing form, gauge transformations, Creutz ratio recovery, Osterwalder-Schrader reconstruction, Euclidean mass gap implies Wightman, SUSY soft-breaking, Fradkin-Shenker theorem, 't Hooft complementarity, Banks-Rabinovici phase structure, Elitzur theorem, continuum limit gap persistence, Balaban UV stability, two-loop continuum limit, Haag theorem, Gribov-Zwanziger action, and quark propagator confinement. Additionally, 262+ structure declarations encode mathematical physics infrastructure. The Yang-Mills mass gap problem remains open. Parts CLX-CLXII: lattice strong coupling expansion (rigorous area law, string tension monotonicity), instanton calculus (ADHM moduli, Bogomolnyi bound, calorons), and unified confinement order parameters (8 independent diagnostics). 30807 lines, 2600+ theorems/defs, 162 parts, 0 sorries.",
+    "axiomCount": 3,
+    "assumptions": "3 axiom declarations: (1) killingForm — provides the Killing form function on the Lie algebra (definitional), (2) gaugeTransform — provides gauge-transformed field (definitional), (3) euclidean_mass_gap_implies_wightman — deep physics theorem connecting Euclidean and Wightman mass gaps. 13 former axioms proved: 8 had trivially satisfiable conclusions (∃ x, P pattern), 5 more eliminated in this session including creutz_recovers_sigma (proved from definitions via exp/log algebra) and os_reconstruction_theorem (witnessed by trivial QFT on ℂ). The Yang-Mills mass gap problem remains open. 30808 lines, 2600+ theorems/defs, 162 parts, 0 sorries.",
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",

--- a/src/data/research/problems/yang-mills-mass-gap.json
+++ b/src/data/research/problems/yang-mills-mass-gap.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 8 trivially provable axioms (16→8) with ∃ (x : Prop), x pattern. All were abstract placeholders for physics theorems.",
+    "progressSummary": "PROGRESS: Eliminated 5 more axioms (8→3). Proved: susy_to_pure_ym (trivial ∃ℝ>0), continuum_limit_gap_persistence (trivial ∃Prop), two_loop_continuum_limit (trivial ∃ℝ>0), os_reconstruction_theorem (constructed trivial WightmanQFT on ℂ), creutz_recovers_sigma (real math proof from exp/log definitions). 3 remain: killingForm, gaugeTransform (definitional), euclidean_mass_gap_implies_wightman (deep physics).",
     "builtItems": [
       "Part C: OS Axioms - transfer matrix, Schwinger functions, spectral gap, Euclidean propagator (~30 theorems)",
       "Part CI: Resurgence - beta function, running coupling, renormalons, instanton factors, bions (~25 theorems)",
@@ -108,7 +108,13 @@
       "Soundness fixes: renamed 4 duplicate declarations (elitzur_theorem, plaquettes_3d/4d, monopoleAction), fixed lambda syntax, ~10 Mathlib API renames (neg_neg_of_neg, exp_lt_one_of_neg, etc.)",
       "Part CLX: Lattice Strong Coupling Expansion — expansion param, area law, string tension, monotonicity in N, roughening, NLO corrections (~180 lines, ~15 theorems)",
       "Part CLXI: Instanton Calculus — ADHM moduli dimension, action quantization, weight ordering, tunneling suppression, vacuum energy, Bogomolnyi bound, calorons (~250 lines, ~20 theorems)",
-      "Part CLXII: Confinement Order Parameters — unified view of 8 diagnostics (Wilson, Polyakov, tHooft, FM, KO, dual SC, center vortex, Casimir) (~200 lines, ~12 theorems)"
+      "Part CLXII: Confinement Order Parameters — unified view of 8 diagnostics (Wilson, Polyakov, tHooft, FM, KO, dual SC, center vortex, Casimir) (~200 lines, ~12 theorems)",
+      "Proved susy_to_pure_ym (line ~7766): ⟨m_gaugino, hm⟩",
+      "Proved continuum_limit_gap_persistence (line ~11760): ⟨True, id⟩",
+      "Proved two_loop_continuum_limit (line ~11780): ⟨1, by linarith⟩",
+      "Defined trivialWightmanQFT (line ~2389): WightmanQFT on ℂ, zero Hamiltonian",
+      "Proved os_reconstruction_theorem (line ~2402): uses trivialWightmanQFT witness",
+      "Proved creutz_recovers_sigma (line ~2177): real proof via exp_add/exp_sub/log_exp/push_cast/ring"
     ],
     "insights": [
       "OS axioms (5) provide Euclidean formulation; reconstruction gives Wightman QFT",
@@ -254,7 +260,10 @@
       "Instanton size distribution ~ ρ^{4N-5}: IR divergent for all N ≥ 2, dilute gas approximation fails for large ρ",
       "Calorons: at finite T, instantons fractionalize into N constituent BPS monopoles",
       "8 independent confinement diagnostics all consistently indicate confinement in pure YM",
-      "Fredenhagen-Marcu order parameter: rigorous criterion via open Wilson line decay"
+      "Fredenhagen-Marcu order parameter: rigorous criterion via open Wilson line decay",
+      "creutz_recovers_sigma proved from definitions: unfold, rewrite exp/log, push_cast for ℕ→ℝ, ring for algebra",
+      "trivialWightmanQFT defined on ℂ with zero Hamiltonian - witnesses existence statements with True conclusions",
+      "Remaining 3 axioms: killingForm (needs Lie algebra def), gaugeTransform (needs gauge action def), euclidean_mass_gap_implies_wightman (deep physics)"
     ],
     "mathlibGaps": [
       "Principal bundles",


### PR DESCRIPTION
## Summary
- Eliminated 5 axioms from YangMillsMassGap.lean, reducing axiom count from 8 to 3
- All changes verified to compile via Docker build (pre-existing errors at line 15291+ unchanged)

## Axioms Proved
1. **susy_to_pure_ym** (line ~7766): Conclusion `∃ gap_bound > 0` trivially satisfied by `⟨m_gaugino, hm⟩`
2. **continuum_limit_gap_persistence** (line ~11760): Conclusion `∃ P, P → True` trivially satisfied by `⟨True, id⟩`
3. **two_loop_continuum_limit** (line ~11780): Conclusion `∃ β₀ > 0` trivially satisfied by `⟨1, by linarith⟩`
4. **os_reconstruction_theorem** (line ~2402): Constructed `trivialWightmanQFT` on ℂ with zero Hamiltonian to witness `∃ (qft : WightmanQFT), True`
5. **creutz_recovers_sigma** (line ~2177): Real mathematical proof — unfolds Creutz ratio definition, substitutes area law, combines exponentials via `exp_add`/`exp_sub`, applies `log_exp`, then `push_cast` + `ring` for ℕ→ℝ algebra

## Remaining 3 Axioms
- `killingForm` — definitional (provides Killing form function, needs Lie algebra implementation)
- `gaugeTransform` — definitional (provides gauge-transformed field, needs gauge action implementation)
- `euclidean_mass_gap_implies_wightman` — deep physics (non-trivial conclusion `hasMassGap qft smg.gap`)

## Files Modified
- `proofs/Proofs/YangMillsMassGap.lean` — 5 axiom→theorem conversions + `trivialWightmanQFT` definition
- `src/data/proofs/yang-mills-mass-gap/meta.json` — axiomCount 16→3, updated description/assumptions
- `src/data/research/problems/yang-mills-mass-gap.json` — updated knowledge/progress

## Test plan
- [x] Docker build passes for all changed code (errors only at line 15291+, pre-existing)
- [x] `grep -c "^axiom "` confirms 3 remaining axioms
- [x] `grep -c "sorry"` confirms 0 sorries

🤖 Generated by researcher-3