### PR TITLE
Research: friendship-theorem-oq-01 - Prove last sorry (0 sorries!)

### DIFF
--- a/research/problems/friendship-theorem-oq-01/knowledge.md
+++ b/research/problems/friendship-theorem-oq-01/knowledge.md
@@ -121,3 +121,27 @@ Both cast to ℚ via RingHom.map_det, equality in ℚ → equality in ℤ by inj
 
 **Outcome**: PROGRESS — 4 new helper lemmas proved, clear path for remaining 3 sorries
 **Files Modified**: `proofs/Proofs/FriendshipTheoremOQ01.lean`, `src/data/research/problems/friendship-theorem-oq-01.json`
+
+### Session 2026-03-21 (researcher-5)
+
+**Mode**: DEEP DIVE — Prove the last sorry (charpoly_quotient_product)
+**Decision**: DEEP DIVE — tractable path found via evaluation + Polynomial.funext
+
+**Result**: charpoly_quotient_product PROVED (0 sorries remain!)
+
+**Proof Strategy**:
+1. For all a : ℤ, evaluate both sides of f*f(-X) = (X²-(k-1))^{n-1}
+2. Use g(a)*g(-a) = det(aI-A)*det(-aI-A) = det(A²-a²I) [Matrix.det_mul]
+3. A² = (k-1)I + J gives det(A²-a²I) = (-1)^n * (a²-(k-1))^{n-1} * (a²-k²)
+4. Multiply both sides by (a²-k²) to avoid division (cross terms cancel since n odd)
+5. Use Polynomial.funext over ℤ (infinite integral domain) to lift point-wise identity to polynomial identity
+6. Cancel X²-k² in ℤ[X] (integral domain) via mul_left_cancel₀
+
+**Key Technical Challenges Solved**:
+- Matrix product (aI-A)(-aI-A) = A²-a²I: entry-by-entry via Finset.sum_ite_eq + ring
+- det_scalar_sub_onesMatrix typeclass resolution: @-notation with explicit Nonempty V
+- Nat.cast of (k-1 : ℕ) vs (k : ℤ) - 1: omega-based casting lemma
+- Finset.sum_ite_eq vs sum_ite_eq': correct variant based on variable position in condition
+
+**Outcome**: COMPLETED — 0 sorries, axiom-free proof path complete
+**Files Modified**: `proofs/Proofs/FriendshipTheoremOQ01.lean` (85 new lines)


### PR DESCRIPTION
## Summary
- **PROVED** `charpoly_quotient_product` — the last sorry in `FriendshipTheoremOQ01.lean`
- File now has **0 sorries** and a complete axiom-free proof path for k=2

## Progress
- Proved the key product identity: `f * f.comp(-X) = (X² - (k-1))^{n-1}`
- Proof via determinant evaluation at all integers + `Polynomial.funext` + UFD cancellation in ℤ[X]
- 85 new lines of proof, Docker build verified

## Proof Strategy
1. For all `a : ℤ`, compute `g(a)*g(-a)` via `Matrix.det_mul`
2. Use `A² = (k-1)I + J` and `det_scalar_sub_onesMatrix` to get closed form
3. Multiply by `(a²-k²)` to avoid division, cross terms cancel (n odd)
4. `Polynomial.funext` lifts pointwise identity to polynomial identity over ℤ
5. Cancel `X²-k²` in ℤ[X] (integral domain) via `mul_left_cancel₀`

## Status
**Outcome**: completed
**Next Steps**: The `charpoly_eigenvalue_data` axiom is now redundant (unused by the new path)

🤖 Generated by researcher-5