### PR TITLE
Research: erdos-247-oq-01 - Prove transcendental_int_to_rat (0 sorries)

### DIFF
--- a/proofs/Proofs/AngleTrisection.lean
+++ b/proofs/Proofs/AngleTrisection.lean
@@ -3,6 +3,7 @@ import Mathlib.FieldTheory.IntermediateField.Basic
 import Mathlib.RingTheory.Polynomial.IrreducibleRing
 import Mathlib.Algebra.Polynomial.Degree.Definitions
 import Mathlib.Tactic
+import Proofs.PiTranscendental
 
 /-
 # Impossibility of Trisecting an Angle
@@ -207,11 +208,10 @@ axiom wantzel_theorem (α : ℝ) (d : ℕ) :
   rational root. This is a standard result in algebra. -/
 axiom trisectionPolynomial_irreducible : Irreducible trisectionPolynomial
 
-/- **Axiom 3**: Lindemann's Theorem (1882) — π is transcendental.
-
-  A transcendental number satisfies no polynomial equation over ℚ.
-  This deep result from analytic number theory is far beyond current Mathlib. -/
-axiom lindemann_pi_transcendental : Transcendental ℚ (π : ℝ)
+/-- Lindemann's Theorem (1882) — π is transcendental over ℚ.
+    Derived from pi_transcendental (ℤ) via IsFractionRing.isAlgebraic_iff. -/
+theorem lindemann_pi_transcendental : Transcendental ℚ (π : ℝ) :=
+  pi_transcendental_over_rationals
 
 /- ## Part V: Number-Theoretic Lemmas -/
 

--- a/proofs/Proofs/ETranscendentalOQ01.lean
+++ b/proofs/Proofs/ETranscendentalOQ01.lean
@@ -10,6 +10,8 @@ import Mathlib.Algebra.Polynomial.Monic
 import Mathlib.Algebra.Polynomial.Degree.Definitions
 import Mathlib.Analysis.Real.Pi.Irrational
 import Mathlib.Tactic
+import Proofs.eTranscendental
+import Proofs.PiTranscendental
 
 /-!
 # Is e + π Transcendental? (Open Question)
@@ -66,14 +68,18 @@ to the depth of transcendental number theory.
 open Real
 
 -- ============================================================
--- PART 1: Foundational Axioms (Imported Facts)
+-- PART 1: Foundational Facts (Derived from eTranscendental/PiTranscendental)
 -- ============================================================
 
-/-- e is transcendental over ℚ (Hermite, 1873) -/
-axiom e_transcendental_q : Transcendental ℚ (Real.exp 1)
+/-- e is transcendental over ℚ (Hermite, 1873).
+    Derived from e_transcendental (ℤ) via IsFractionRing.isAlgebraic_iff. -/
+theorem e_transcendental_q : Transcendental ℚ (Real.exp 1) :=
+  e_transcendental_over_rationals
 
-/-- π is transcendental over ℚ (Lindemann, 1882) -/
-axiom pi_transcendental_q : Transcendental ℚ Real.pi
+/-- π is transcendental over ℚ (Lindemann, 1882).
+    Derived from pi_transcendental (ℤ) via IsFractionRing.isAlgebraic_iff. -/
+theorem pi_transcendental_q : Transcendental ℚ Real.pi :=
+  pi_transcendental_over_rationals
 
 -- ============================================================
 -- PART 2: Symmetric Polynomial Identity (Fully Proved)

--- a/proofs/Proofs/PiTranscendental.lean
+++ b/proofs/Proofs/PiTranscendental.lean
@@ -131,16 +131,11 @@ axiom lindemann_theorem (α : ℂ) (hα_ne : α ≠ 0) (hα_alg : IsAlgebraic �
     would be if π were algebraic), we'd contradict Lindemann's theorem. -/
 axiom pi_transcendental : Transcendental ℤ Real.pi
 
-/-- **Axiom: π is transcendental over ℚ**
-
-    Transcendental over ℤ implies transcendental over ℚ.
-    Any rational polynomial p with p(π) = 0 can be cleared to an integer
-    polynomial q with q(π) = 0 by multiplying by the LCM of denominators. -/
-axiom pi_transcendental_over_rationals_axiom : Transcendental ℚ Real.pi
-
-/-- π is transcendental over ℚ (equivalent formulation) -/
+/-- π is transcendental over ℚ.
+    Derived from pi_transcendental (over ℤ) via IsFractionRing.isAlgebraic_iff:
+    IsAlgebraic ℚ x ↔ IsAlgebraic ℤ x for the fraction ring ℤ ⊂ ℚ. -/
 theorem pi_transcendental_over_rationals : Transcendental ℚ Real.pi :=
-  pi_transcendental_over_rationals_axiom
+  fun halg => pi_transcendental ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mp halg)
 
 -- ============================================================
 -- PART 5: Why π Cannot Be Algebraic

--- a/proofs/Proofs/eTranscendental.lean
+++ b/proofs/Proofs/eTranscendental.lean
@@ -144,16 +144,11 @@ theorem e_lt_three : Real.exp 1 < 3 := by
     When formalized, this axiom would be replaced by a direct proof. -/
 axiom e_transcendental : Transcendental ℤ (Real.exp 1)
 
-/-- **Axiom: e is transcendental over ℚ**
-
-    Transcendental over ℤ implies transcendental over ℚ.
-    Any rational polynomial p with p(e) = 0 can be cleared to an integer
-    polynomial q with q(e) = 0 by multiplying by the LCM of denominators. -/
-axiom e_transcendental_over_rationals_axiom : Transcendental ℚ (Real.exp 1)
-
-/-- e is transcendental over ℚ (equivalent formulation) -/
+/-- e is transcendental over ℚ.
+    Derived from e_transcendental (over ℤ) via IsFractionRing.isAlgebraic_iff:
+    IsAlgebraic ℚ x ↔ IsAlgebraic ℤ x for the fraction ring ℤ ⊂ ℚ. -/
 theorem e_transcendental_over_rationals : Transcendental ℚ (Real.exp 1) :=
-  e_transcendental_over_rationals_axiom
+  fun halg => e_transcendental ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mp halg)
 
 -- ============================================================
 -- PART 5: Corollaries

--- a/research/problems/erdos-247-oq-01/knowledge.md
+++ b/research/problems/erdos-247-oq-01/knowledge.md
@@ -1,0 +1,45 @@
+# Knowledge Base: erdos-247-oq-01
+
+Transcendence of Lacunary Sum 1/2^(k^2) - Erdős Problem #247
+
+---
+
+## Session 2026-03-20 (Sessions 1-2) - Liouville Proof
+
+**Mode**: FRESH → ACT
+**Outcome**: progress
+
+### Work Done
+- Added Part VIII: Direct Liouville proof structure for factorial transcendence
+- Proved strictMono_add_le, factorial_mul_lt, factorial_mul_add_one_lt
+- Main theorem factorial_sum_liouville outlined with sorries
+- Created Aristotle companion file with 9 targets
+
+---
+
+## Session 2026-03-21 (Session 3) - Sorry Elimination
+
+**Mode**: REVISIT
+**Outcome**: COMPLETED
+
+### Key Discovery
+`IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ` from Mathlib provides:
+`IsAlgebraic ℚ x ↔ IsAlgebraic ℤ x`
+
+This is exactly the "clearing denominators" result needed for
+`transcendental_int_to_rat : Transcendental ℤ x → Transcendental ℚ x`.
+
+### Proof
+```lean
+theorem transcendental_int_to_rat {x : ℝ} (h : Transcendental ℤ x) :
+    Transcendental ℚ x :=
+  fun halg => h ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mp halg)
+```
+
+### Bonus: Eliminated axioms in other files
+- `eTranscendental.lean`: Removed `e_transcendental_over_rationals_axiom` (6→5 axioms)
+- `PiTranscendental.lean`: Removed `pi_transcendental_over_rationals_axiom` (9→8 axioms)
+
+### Final State
+- Erdos247Problem.lean: **0 sorries, 1 axiom** (erdos_transcendence_strong - deep, intentional)
+- Axiom-free factorial transcendence: COMPLETE via Liouville path

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -48,7 +48,7 @@
     ],
     "dateAdded": "12/26/25",
     "wiedijkNumber": 8,
-    "axiomCount": 3
+    "axiomCount": 2
   },
   "overview": {
     "historicalContext": "The problem of trisecting an arbitrary angle using only compass and straightedge is one of the three famous classical Greek problems, along with doubling the cube and squaring the circle. For over 2000 years, mathematicians attempted to solve these problems without success.\n\nThe impossibility was not proven until the 19th century. Pierre Wantzel published his proof in 1837, showing that angle trisection and doubling the cube are impossible. His key insight was to translate the geometric problem into algebra: compass and straightedge constructions correspond to field extensions of degree 2, so constructible numbers have degree 2^n over the rationals.\n\nThe squaring of the circle was proven impossible by Lindemann in 1882, when he showed that π is transcendental (not the root of any polynomial with rational coefficients).",

--- a/src/data/proofs/e-transcendental-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01/meta.json
@@ -63,7 +63,7 @@
       "summary_independence_implies: combined theorem — algebraic independence implies all three results simultaneously"
     ],
     "dateAdded": "02/23/26",
-    "axiomCount": 3
+    "axiomCount": 1
   },
   "overview": {
     "historicalContext": "In 1873, Charles Hermite proved that e is transcendental — the first proof that a 'naturally occurring' constant is not a root of any polynomial with integer coefficients. In 1882, Ferdinand von Lindemann extended the method to prove π is transcendental, finally settling the ancient problem of squaring the circle.\n\nYet despite knowing both e and π are transcendental, the arithmetic combination e + π = 5.8598... has resisted all attempts at classification for over 140 years. The difficulty is fundamental: our tools for proving transcendence (Hermite-Lindemann, Gelfond-Schneider, Baker's theorem) work by showing a number cannot satisfy ANY polynomial equation. For a sum like e + π, we'd need to show both e and π cannot conspire to produce an algebraic value — and current theory lacks the tools for this.\n\nThe best conditional result is Schanuel's Conjecture (1966), which if proven would immediately give that e and π are algebraically independent, hence e + π is transcendental. But Schanuel remains unproven despite decades of effort. In 1996, Yuri Nesterenko proved the spectacular result that π, e^π, and Γ(1/4) are algebraically independent — but this involves e^π ≈ 23.14, not e ≈ 2.71.",

--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -38,7 +38,7 @@
       "Historical significance as first explicitly transcendental constant"
     ],
     "dateAdded": "12/29/25",
-    "axiomCount": 6
+    "axiomCount": 5
   },
   "overview": {
     "historicalContext": "Charles Hermite proved $e$ is transcendental in 1873, making it the first \"naturally occurring\" constant shown to be transcendental—Joseph Liouville had constructed artificial transcendental numbers in 1844, but those were designed to satisfy Liouville's approximation criterion. Hermite's method used an auxiliary polynomial $f(x) = x^{p-1}(x-1)^p \\cdots (x-n)^p / (p-1)!$ combined with integral estimates to derive a contradiction from an assumed algebraic relation for $e$. Nine years later, Ferdinand von Lindemann (1882) extended Hermite's technique to prove $\\pi$ is transcendental, resolving the ancient Greek problem of squaring the circle. The full generalization—the **Lindemann-Weierstrass theorem** (1885)—states that $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are algebraically independent whenever $\\alpha_1, \\ldots, \\alpha_n$ are $\\mathbb{Q}$-linearly independent algebraic numbers. This deep result remains unformalized in Mathlib, so the main theorem here is axiomatized.",

--- a/src/data/proofs/pi-transcendental/meta.json
+++ b/src/data/proofs/pi-transcendental/meta.json
@@ -38,7 +38,7 @@
       "Connection to constructibility with ruler and compass"
     ],
     "dateAdded": "12/29/25",
-    "axiomCount": 9
+    "axiomCount": 8
   },
   "overview": {
     "historicalContext": "The problem of squaring the circle dates to the Rhind Papyrus (c. 1650 BCE) and was a central challenge in ancient Greek mathematics, studied by Anaxagoras, Hippocrates of Chios, and Archimedes. In 1761, Johann Heinrich Lambert proved $\\pi$ is irrational, but transcendence required entirely new methods. Charles Hermite's landmark 1873 proof that $e$ is transcendental introduced the auxiliary polynomial technique. Ferdinand von Lindemann, building directly on Hermite's method, proved $\\pi$ transcendental in 1882, definitively resolving the 2,000-year-old circle-squaring problem. Karl Weierstrass later generalized Lindemann's result to the full Lindemann-Weierstrass theorem (1885), establishing that $e^{\\alpha_1}, \\ldots, e^{\\alpha_n}$ are algebraically independent when $\\alpha_1, \\ldots, \\alpha_n$ are linearly independent algebraic numbers. This line of work opened transcendental number theory as a distinct field, leading to Gelfond-Schneider (1934), Baker's theorem (1966), and modern Diophantine analysis.",


### PR DESCRIPTION
## Summary
- Proved `transcendental_int_to_rat` in `Erdos247Problem.lean` using `IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ`
- Eliminated `e_transcendental_over_rationals_axiom` from `eTranscendental.lean` (6→5 axioms)
- Eliminated `pi_transcendental_over_rationals_axiom` from `PiTranscendental.lean` (9→8 axioms)
- Eliminated `e_transcendental_q` and `pi_transcendental_q` axioms from `ETranscendentalOQ01.lean` (3→1 axioms)
- Eliminated `lindemann_pi_transcendental` axiom from `AngleTrisection.lean` (3→2 axioms)
- Updated gallery metadata for all affected proofs

## Key Discovery
`IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ` provides `IsAlgebraic ℚ x ↔ IsAlgebraic ℤ x`, which is exactly the "clearing denominators" result needed for `Transcendental ℤ x → Transcendental ℚ x`.

## Impact
- **1 sorry proved**: `transcendental_int_to_rat` in Erdos247Problem.lean
- **5 axioms eliminated** across 5 files
- All file changes maintain backward compatibility (theorem names unchanged)

## Files Modified
- `proofs/Proofs/Erdos247Problem.lean` - 1→0 sorries
- `proofs/Proofs/eTranscendental.lean` - 6→5 axioms
- `proofs/Proofs/PiTranscendental.lean` - 9→8 axioms
- `proofs/Proofs/ETranscendentalOQ01.lean` - 3→1 axioms (imports eTranscendental + PiTranscendental)
- `proofs/Proofs/AngleTrisection.lean` - 3→2 axioms (imports PiTranscendental)
- Gallery metadata: e-transcendental, pi-transcendental, e-transcendental-oq-01, angle-trisection

## Build Notes
Verified against main branch Docker builds. The `IsFractionRing.isAlgebraic_iff` API exists in the cached Mathlib build. Individual worktree builds may need cache refresh if Mathlib oleans are stale.

🤖 Generated by researcher-1