### PR TITLE
Research: erdos-177-oq-04 - Prove optimalDisc 1 = 1

### DIFF
--- a/proofs/Proofs/Erdos177OQ04.lean
+++ b/proofs/Proofs/Erdos177OQ04.lean
@@ -105,11 +105,11 @@ theorem alternating_d2_all_same (a k : ℕ) :
     simp only [apPartialSum, Finset.sum_range_succ] at *
     rw [ih]
     unfold alternating
+    have h : (-1 : ℤ) ^ (a + n * 2) = (-1 : ℤ) ^ a := by
+      rw [pow_add, mul_comm n 2, pow_mul, neg_one_sq, one_pow, mul_one]
     push_cast
-    ring_nf
-    congr 1
-    ring_nf
-    rfl
+    rw [h]
+    ring
 
 -- ============================================================================
 -- Part III: Constant and Random Colorings
@@ -138,7 +138,6 @@ def modColoring (m : ℕ) : Coloring := fun n =>
 theorem mod2_is_alternating_like (n : ℕ) :
     modColoring 2 n = if n % 2 = 0 then 1 else -1 := by
   simp [modColoring]
-  omega
 
 -- ============================================================================
 -- Part V: Discrepancy Bounds
@@ -231,8 +230,34 @@ theorem h1_is_1 :
       ∀ a k : ℕ, k ≥ 1 → (apPartialSum f a 1 k).natAbs ≤ 1 := by
   exact ⟨alternating, alternating_valid, fun a k _ => alternating_d1_bound a k⟩
 
-/-- Simple verification: alternating sum for 3 consecutive terms starting at 0. -/
-example : apPartialSum alternating 0 1 3 = -1 := by
+/-- **Exact computation: optimalDisc 1 = 1**
+
+The alternating coloring achieves discrepancy 1 for d=1 (upper bound),
+and no valid coloring can achieve discrepancy 0 since |f(a)| = 1 (lower bound).
+This is an axiom-free exact result via sInf characterization. -/
+theorem optimalDisc_one : optimalDisc 1 = 1 := by
+  unfold optimalDisc
+  apply le_antisymm
+  · -- sInf S ≤ 1: alternating witnesses 1 ∈ S
+    apply csInf_le ⟨0, fun x _ => Nat.zero_le x⟩
+    exact ⟨alternating, alternating_valid, fun a k _ => alternating_d1_bound a k⟩
+  · -- 1 ≤ sInf S: every k ∈ S satisfies k ≥ 1
+    apply le_csInf
+    · exact ⟨1, alternating, alternating_valid, fun a k _ => alternating_d1_bound a k⟩
+    · intro k ⟨f, hf, hbound⟩
+      have h1 := disc_length_1 f hf 0 1
+      have h2 := hbound 0 1 (by omega)
+      omega
+
+/-- The alternating coloring is optimal for d=1. -/
+theorem alternating_isOptimal_d1 : IsOptimal alternating 1 := by
+  refine ⟨alternating_valid, fun a n hn => ?_⟩
+  rw [optimalDisc_one]
+  exact alternating_d1_bound a n
+
+/-- Simple verification: alternating sum for 3 consecutive terms starting at 0.
+    1 + (-1) + 1 = 1. -/
+example : apPartialSum alternating 0 1 3 = 1 := by
   simp [apPartialSum, alternating, Finset.sum_range_succ]
 
 /-- Simple verification: alternating sum for 4 consecutive terms starting at 0. -/
@@ -250,6 +275,8 @@ example : apPartialSum alternating 0 1 4 = 0 := by
 #check beck_improved_upper
 #check rudin_shapiro_bound
 #check IsOptimal
+#check optimalDisc_one
+#check alternating_isOptimal_d1
 #check discrepancy_gap
 
 end Erdos177OQ04

--- a/research/problems/erdos-177-oq-04/knowledge.md
+++ b/research/problems/erdos-177-oq-04/knowledge.md
@@ -41,3 +41,33 @@ but proved theorems about `h` would need a different definition.
 
 ### Files Modified
 - `proofs/Proofs/Erdos177Problem.lean` — fixed imports, added Part I.5
+
+## Session 2026-03-21 (researcher-4) - Exact optimalDisc computation + build fixes
+
+**Mode**: REVISIT (depth-first, RICH knowledge score 18)
+**Outcome**: progress - 2 new theorems proved, 3 pre-existing build errors fixed
+
+### New Theorems Proved
+
+1. **`optimalDisc_one : optimalDisc 1 = 1`** — Axiom-free exact computation.
+   - Upper bound: `csInf_le` with alternating coloring as witness (via `alternating_d1_bound`)
+   - Lower bound: `le_csInf` — every k in the set satisfies k ≥ 1 because `disc_length_1` shows |f(a)| = 1 for any valid f
+   - This is the first exact value computed for `optimalDisc`
+
+2. **`alternating_isOptimal_d1 : IsOptimal alternating 1`** — Corollary: alternating coloring is optimal for d=1.
+   - Uses `optimalDisc_one` to rewrite the bound, then applies `alternating_d1_bound`
+
+### Pre-existing Build Errors Fixed (Mathlib compat)
+
+Three proofs broke due to Mathlib API changes:
+
+1. **`alternating_d2_all_same`**: `ring_nf; congr 1; ring_nf; rfl` → Need to manually prove `(-1)^(a+n*2) = (-1)^a` via `pow_add/pow_mul/neg_one_sq/one_pow`
+2. **`mod2_is_alternating_like`**: `simp; omega` → `simp` now closes goal alone (remove redundant `omega`)
+3. **Example `apPartialSum alternating 0 1 3`**: Wrong value `-1` → corrected to `1` (1+(-1)+1=1)
+
+### Stats After Changes
+- 280 lines, 3 axioms, 14 proved theorems, 0 sorries
+- Docker build passes (warnings only: unused simp args for `pow_mul`)
+
+### Files Modified
+- `proofs/Proofs/Erdos177OQ04.lean` — new theorems + build fixes

--- a/src/data/research/problems/erdos-177-oq-04.json
+++ b/src/data/research/problems/erdos-177-oq-04.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added 10 proved infrastructure theorems (apSum properties, alternating coloring validity, triangle inequality). Fixed pre-existing import errors. Docker build clean.",
+    "progressSummary": "COMPLETED: Proved optimalDisc 1 = 1 (exact axiom-free computation via csInf). Added alternating_isOptimal_d1. Fixed 3 pre-existing Mathlib-compat build errors.",
     "builtItems": [
       "alternating coloring with validity proof",
       "disc_trivial_upper: |sum| ≤ k proved by induction",
@@ -41,7 +41,9 @@
       "valid_abs_eq_one, valid_sq_eq_one: valid coloring properties",
       "apSum_abs_le: triangle inequality |apSum| ≤ k",
       "alternating: definition and validity proof",
-      "alternating_apSum_d1_even: even-length APs sum to 0"
+      "alternating_apSum_d1_even: even-length APs sum to 0",
+      "optimalDisc_one: exact computation optimalDisc 1 = 1 via csInf_le/le_csInf",
+      "alternating_isOptimal_d1: alternating coloring is optimal for d=1"
     ],
     "insights": [
       "Alternating coloring optimal for d=1 but terrible for d=2",
@@ -50,7 +52,9 @@
       "alternating_d1_bound proved via pair cancellation: consecutive (-1)^n terms sum to zero, so by strong induction reducing k by 2, we only need k=0 (sum=0) and k=1 (sum=(-1)^a, natAbs=1)",
       "Example had wrong value: apPartialSum alternating 0 1 3 = 1, not -1 (1+(-1)+1=1)",
       "sSup/sInf on ℕ is problematic for unbounded sets — discrepancy definition returns 0 for the all-1s coloring",
-      "Fixed pre-existing build errors: Real.sqrt and Nat.factorial need heavier imports"
+      "Fixed pre-existing build errors: Real.sqrt and Nat.factorial need heavier imports",
+      "optimalDisc 1 = 1 is provable axiom-free: upper bound from alternating_d1_bound, lower bound from disc_length_1 (any valid f has |f(a)|=1)",
+      "(-1)^(a+n*2) = (-1)^a via pow_add/pow_mul/neg_one_sq/one_pow — needed for alternating_d2_all_same Mathlib compat fix"
     ],
     "mathlibGaps": [],
     "nextSteps": []


### PR DESCRIPTION
## Summary
- Proved `optimalDisc_one : optimalDisc 1 = 1` — first exact value of the optimal discrepancy function, axiom-free
- Proved `alternating_isOptimal_d1 : IsOptimal alternating 1` — alternating coloring is optimal for d=1
- Fixed 3 pre-existing Mathlib-compat build errors in Erdos177OQ04.lean

## Progress
- **2 new proved theorems** (axiom-free)
- **3 build errors fixed** (Mathlib API changes: `ring_nf`/`omega` behavior, wrong example value)
- Docker build passes clean (warnings only)

## Proof Technique
`optimalDisc 1 = 1` via `le_antisymm`:
- Upper: `csInf_le` with alternating coloring as witness
- Lower: `le_csInf` — any valid coloring f has `disc_length_1 f = 1`, so k ≥ 1

## Status
**Outcome**: progress
**Next Steps**: All 3 axioms (Roth, Beck, Rudin-Shapiro) are deep results not provable from Mathlib

Generated by researcher-4