### PR TITLE
Research: abel-ruffini-oq-01 - Prove resultant_eq_disc_q (3→2 sorries)

### DIFF
--- a/proofs/Proofs/InverseGaloisA5.lean
+++ b/proofs/Proofs/InverseGaloisA5.lean
@@ -1696,14 +1696,23 @@ private theorem q_derivative_natDegree : (Polynomial.derivative q).natDegree = 4
 
 theorem resultant_eq_disc_q :
     Polynomial.resultant q (Polynomial.derivative q) = Polynomial.discr q := by
-  -- Resultant default args are natDegree, need to match resultant_deriv's bounds
-  -- resultant_deriv uses q.natDegree and (q.natDegree - 1)
-  -- We need (derivative q).natDegree = q.natDegree - 1 = 4
+  -- Default args: resultant q q' q.natDegree (derivative q).natDegree
+  -- resultant_deriv needs: resultant q q' q.natDegree (q.natDegree - 1)
+  -- Step 1: Show (derivative q).natDegree = q.natDegree - 1
   have hnd : (Polynomial.derivative q).natDegree = q.natDegree - 1 := by
     rw [q_natDegree, q_derivative_natDegree]
-  -- Unfold default args to explicit bounds
-  -- Proof needs q_monic lemma and Mathlib API updates
-  sorry
+  -- Step 2: Rewrite default arg to match resultant_deriv
+  show q.resultant (Polynomial.derivative q) q.natDegree (Polynomial.derivative q).natDegree = q.discr
+  rw [hnd]
+  -- Step 3: Apply resultant_deriv
+  have hdeg : (0 : WithBot ℕ) < q.degree := by
+    rw [Polynomial.degree_eq_natDegree (Polynomial.Monic.ne_zero q_monic), q_natDegree]
+    exact WithBot.coe_lt_coe.mpr (by omega)
+  have h := Polynomial.resultant_deriv hdeg
+  -- h : resultant q q' q.natDeg (q.natDeg - 1) = (-1)^(5*4/2) * lc(q) * discr(q)
+  -- For monic q: lc = 1. (-1)^10 = 1. So RHS = discr q.
+  rw [h, q_monic.leadingCoeff, q_natDegree]
+  norm_num
 
 -- Step H: Discriminant computation
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -19,7 +19,7 @@
     "phase": "ACT",
     "since": "2026-02-21T19:21:07.129Z",
     "iteration": 16,
-    "focus": "disc_q_val: verified 9x9 det = 1024000000 via 7x7 cofactor native_decide",
+    "focus": "resultant_eq_disc_q proved. 2 sorries remain: prod_eval_derivative_eq_resultant, disc_q_val",
     "blockers": [
       "Kronecker-Weber not in Mathlib",
       "Hilbert irreducibility not in Mathlib"
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved resultant_transfer (4 to 3 sorries). Remaining: prod_eval_derivative_eq_resultant, resultant_eq_disc_q, disc_q_val.",
+    "progressSummary": "PROGRESS: Proved resultant_eq_disc_q (3 to 2 sorries). Remaining: prod_eval_derivative_eq_resultant, disc_q_val.",
     "builtItems": [
       "InverseGalois.lean: cyclotomic Galois theory, S₃ realization via Gal(X³-2)≅S₃ (905 lines, builds)",
       "InverseGaloisD4.lean: D₄ realization via |Gal(X⁴-2)| = 8 (666 lines, builds)",
@@ -194,6 +194,11 @@
         "name": "q_SF_eq_prod_linear",
         "description": "q_SF = ∏ (X - C rootEnum i) via coprime divisibility + degree",
         "proven": true
+      },
+      {
+        "name": "resultant_eq_disc_q_proved",
+        "description": "Proved Res(q,q prime) = disc(q) via resultant_deriv + monic simplification",
+        "proven": true
       }
     ],
     "insights": [
@@ -274,7 +279,10 @@
       "native_decide stack-overflows on Matrix.det for Fin 8+ over Z, but Fin 7 works (3-5s)",
       "Polynomial.semiring has no executable code — native_decide cannot compute any Polynomial operation",
       "Double cofactor expansion along col 0: 9x9 -> 2x8x8 -> 6x7x7 (5 unique). All verified.",
-      "LEAN_STACK_SIZE env var does not fix native_decide stack overflow"
+      "LEAN_STACK_SIZE env var does not fix native_decide stack overflow",
+      "resultant_deriv IS in Mathlib v4.26.0: gives Res(f,f_deriv,n,n-1) = (-1)^(n(n-1)/2) * lc * disc(f)",
+      "For monic degree-5: (-1)^10 * 1 * disc = disc, so resultant = discr",
+      "show tactic reveals optParam default args, enabling rw on implicit args"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- Proved `resultant_eq_disc_q`: `Polynomial.resultant q (derivative q) = Polynomial.discr q`
- Eliminates 1 sorry from InverseGaloisA5.lean (3→2 sorries remaining)

## Proof Technique
Uses `Polynomial.resultant_deriv` from Mathlib v4.26.0:
- `show` tactic to reveal `optParam` default arguments, enabling `rw` on implicit degree bounds
- `Polynomial.degree_eq_natDegree` + `WithBot.coe_lt_coe` for degree positivity
- For monic degree-5 q: `(-1)^10 * 1 * disc = disc`, so `resultant = discr`

## Status
**Outcome**: progress (1 sorry eliminated)
**Remaining sorries**: `prod_eval_derivative_eq_resultant` (resultant-product identity), `disc_q_val` (9x9 determinant computation)

Generated by researcher-4