### PR TITLE
Enrich Density of Primitive Pythagorean Triples

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-01/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-01/annotations.json
@@ -119,6 +119,42 @@
       "significance": "supporting",
       "relatedConcepts": ["GCD properties", "column decomposition", "parity sieve", "inclusion-exclusion"],
       "prerequisites": ["Nat.Coprime", "Finset.sum", "Finset.card_bij"]
+    },
+    {
+      "id": "mathlib-parametrization",
+      "proofId": "pythagorean-triples-oq-01",
+      "type": "technique",
+      "range": { "startLine": 606, "endLine": 660 },
+      "title": "Connection to Mathlib's PythagoreanTriple.IsPrimitiveClassified",
+      "content": "Links the counting function to Mathlib's canonical parametrization via PythagoreanTriple.IsPrimitiveClassified. This confirms the counting function counts the mathematically correct objects: every primitive Pythagorean triple $(a,b,c)$ with $a^2+b^2=c^2$, $\\gcd(a,b,c)=1$ corresponds to a unique parameter pair $(m,n)$ counted by primitiveTripleCount. The bridge validates the formalization against Mathlib's established number theory.",
+      "mathContext": "Mathlib's parametrization: primitive $(a,b,c)$ with $a^2+b^2=c^2$ $\\leftrightarrow$ $(m,n)$ with $m>n>0$, $\\gcd(m,n)=1$, $m \\not\\equiv n \\pmod{2}$, via $a=m^2-n^2$, $b=2mn$, $c=m^2+n^2$.",
+      "significance": "supporting",
+      "relatedConcepts": ["Euclid's parametrization", "bijective correspondence", "Mathlib integration"],
+      "prerequisites": ["PythagoreanTriple", "PythagoreanTriple.IsPrimitiveClassified"]
+    },
+    {
+      "id": "additional-axioms",
+      "proofId": "pythagorean-triples-oq-01",
+      "type": "context",
+      "range": { "startLine": 2029, "endLine": 2120 },
+      "title": "Additional Axioms: r₂ and Landau Counting",
+      "content": "Four additional axioms encode deeper analytic number theory: (1) r₂ positivity criterion — the number of representations of $n$ as a sum of two squares is positive iff all prime factors $\\equiv 3 \\pmod{4}$ appear to even powers, (2) r₂ average order — $\\sum_{n \\le N} r_2(n) \\sim \\pi N$, (3) Landau two-squares counting — $\\#\\{n \\le N : r_2(n) > 0\\} \\sim C \\cdot N/\\sqrt{\\ln N}$ (the Landau-Ramanujan theorem), and (4) primitive-by-leg density. These support alternative approaches and extensions of the main result.",
+      "mathContext": "$r_2(n) = \\#\\{(a,b) \\in \\mathbb{Z}^2 : a^2 + b^2 = n\\}$; Landau-Ramanujan: $\\#\\{n \\le N : r_2(n) > 0\\} \\sim \\frac{C \\cdot N}{\\sqrt{\\ln N}}$ where $C = \\frac{1}{\\sqrt{2}} \\prod_{p \\equiv 3 \\pmod{4}} (1 - p^{-2})^{-1/2}$",
+      "significance": "supporting",
+      "relatedConcepts": ["sum-of-two-squares theorem", "Landau-Ramanujan constant", "r₂ arithmetic function"],
+      "prerequisites": ["analytic number theory", "sieve methods", "Dirichlet series"]
+    },
+    {
+      "id": "monotonicity-growth",
+      "proofId": "pythagorean-triples-oq-01",
+      "type": "proof-step",
+      "range": { "startLine": 222, "endLine": 375 },
+      "title": "Monotonicity and Growth of Counting Functions",
+      "content": "Establishes that all counting functions are monotone non-decreasing: if $M \\le N$, then $\\text{count}(M) \\le \\text{count}(N)$. Also proves that the intermediate coprime sector count tends to infinity ($\\text{coprimeInSectorCount}(N) \\to \\infty$), which is needed for the telescoping ratio argument — you cannot divide by the coprime count unless it is eventually nonzero.",
+      "mathContext": "$M \\le N \\Rightarrow \\text{primitiveTripleCount}(M) \\le \\text{primitiveTripleCount}(N)$; $\\text{coprimeInSectorCount}(N) \\to \\infty$ as $N \\to \\infty$",
+      "significance": "technical",
+      "relatedConcepts": ["Finset.card_le_card", "Filter.Tendsto.atTop", "monotone function"],
+      "prerequisites": ["Finset.card_le_card", "Finset.filter_subset"]
     }
   ]
 }

--- a/src/data/proofs/pythagorean-triples-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-01/meta.json
@@ -23,8 +23,28 @@
     "mathlibDependencies": [
       {
         "theorem": "PythagoreanTriple",
-        "description": "Definition of Pythagorean triples",
+        "description": "Definition and parametrization of Pythagorean triples",
         "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      },
+      {
+        "theorem": "Finset.card_bij",
+        "description": "Cardinality equality via bijection between finite sets",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Filter.Tendsto",
+        "description": "Filter-based limit convergence for the asymptotic density",
+        "module": "Mathlib.Order.Filter.Basic"
+      },
+      {
+        "theorem": "Nat.Coprime",
+        "description": "Coprimality predicate and basic properties (gcd = 1)",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Real.pi_pos",
+        "description": "π > 0, used in density constant positivity",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
       }
     ],
     "originalContributions": [
@@ -75,7 +95,7 @@
   "overview": {
     "historicalContext": "**Density of Primitive Pythagorean Triples**\n\nPythagorean triples have been studied since Babylonian times (the tablet Plimpton 322, c. 1800 BCE, lists 15 triples). Euclid gave the first complete parametrization in Book X of the *Elements*: every primitive triple $(a,b,c)$ with $a^2+b^2=c^2$ and $\\gcd(a,b,c)=1$ corresponds to a unique pair $(m,n)$ with $m>n>0$, $\\gcd(m,n)=1$, $m \\not\\equiv n \\pmod{2}$, via $a=m^2-n^2$, $b=2mn$, $c=m^2+n^2$.\n\nThe asymptotic density question—how many primitive triples have hypotenuse $c \\le N$?—was answered by D. N. Lehmer in 1900 and refined by subsequent work connecting it to the Gauss circle problem and the density of coprime integers. The result $N/(2\\pi)$ combines three classical facts: lattice point counting in circular sectors (Gauss, 1801), the probability $6/\\pi^2$ that two random integers are coprime (Euler/Cesàro, 1883), and the parity structure of coprime pairs. This formalization appears to be the first mechanized proof of this density result.",
     "problemStatement": "**Theorem**: lim_{N→∞} primitiveTripleCount(N) · (2π)/N = 1. That is, the number of primitive Pythagorean triples with hypotenuse ≤ N grows as N/(2π).",
-    "proofStrategy": "The proof decomposes into three factors:\n\n1. **Sector area** (Part VIII-B, axiom): The quarter-disk sector {(x,y): 0<y<x, x²+y²≤N} contains ~πN/8 lattice points\n2. **Coprime density** (Part VIII-B, axiom): Among lattice points in the sector, ~6/π² fraction are coprime\n3. **Parity correction** (Part VIII-B, axiom + Parts XIII-XIX): Among coprime pairs, 2/3 have opposite parity (m≢n mod 2)\n\nProduct: πN/8 × 6/π² × 2/3 = N/(2π)",
+    "proofStrategy": "The proof decomposes the density into three independent factors, then telescopes their limits:\n\n1. **Sector lattice density** (axiom): The sector $\\{(m,n) : 0 < n < m,\\, m^2+n^2 \\le N\\}$ contains $\\sim \\pi N/8$ lattice points (from the Gauss circle problem — the sector is $1/8$ of the full disk of area $\\pi N$)\n2. **Coprime density** (axiom): Among lattice points in the sector, the fraction with $\\gcd(m,n)=1$ tends to $6/\\pi^2 = 1/\\zeta(2)$ (from Möbius inversion on the Euler product)\n3. **Parity correction** (axiom + proved structure): Among coprime pairs, $2/3$ have $m \\not\\equiv n \\pmod{2}$. This is reduced to showing the both-odd fraction is $1/3$, then verified structurally via the involution $(m,n) \\mapsto (m, m-n)$ which bijects OE and OO classes\n\n**Telescoping**: $\\frac{\\text{count}(N)}{N} = \\frac{\\text{count}}{\\text{coprime}} \\cdot \\frac{\\text{coprime}}{\\text{sector}} \\cdot \\frac{\\text{sector}}{N} \\to \\frac{2}{3} \\cdot \\frac{6}{\\pi^2} \\cdot \\frac{\\pi}{8} = \\frac{1}{2\\pi}$\n\nThe proof also verifies the algebraic identity and establishes growth/monotonicity of intermediate counting functions needed for the ratio convergence.",
     "keyInsights": [
       "The three-factor decomposition $\\pi N/8 \\times 6/\\pi^2 \\times 2/3 = N/(2\\pi)$ cleanly separates geometry (lattice counting), number theory (coprime density via $\\zeta(2)$), and combinatorics (parity sieving) into independent ingredients",
       "The parity involution $(m,n) \\mapsto (m, m-n)$ preserves coprimality and swaps EO$\\leftrightarrow$OO classes, giving an exact bijection rather than just an asymptotic estimate",


### PR DESCRIPTION
## Summary

Enrichment pass for `pythagorean-triples-oq-01` (quality: 45 → enriched, passes: 0 → 1).

**Key improvements:**
- Added 3 new annotations (Mathlib PythagoreanTriple connection, additional r₂/Landau axioms, monotonicity/growth lemmas) — total now 14
- Expanded `mathlibDependencies` from 1 to 5 entries (Finset.card_bij, Filter.Tendsto, Nat.Coprime, Real.pi_pos)
- Deepened `proofStrategy` with explicit telescoping formula and growth requirements
- All annotations have `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`

(Previous PRs on this branch: #4294 angle-trisection, #4295 triangular-reciprocals — both closed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)