### PR TITLE
Enrich batch: erdos-1065, erdos-1089

### DIFF
--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -134,6 +134,7 @@
       "description": "Problem #1083 studies f_d(n) = max distinct distances from n points; g_d(n) = min{m : f_d(m) ≥ n} is the inverse perspective."
     }
   ],
+  "relatedProofs": ["erdos-1083"],
   "conclusion": {
     "summary": "The threshold function g_d(n) captures how many points in ℝ^d guarantee n distinct distances. The cube construction shows g_d(d+1) > 2^d, while Erdős proved g_d(n) ≫ d^{n-1}. The Erdős-Straus upper bound g_d(n) ≤ c^{d^{1-b_n}} leaves a vast gap between polynomial and stretched-exponential growth. Whether g_d(n)/d^{n-1} converges as d → ∞ remains the central open question.",
     "implications": "This connects to the famous distinct distances problem in the plane (Guth-Katz 2015) and understanding how distance structure changes with dimension. The focus on fixed n as d → ∞ differs from typical questions about n points in fixed dimension, probing the fundamental geometry of high-dimensional Euclidean space.",


### PR DESCRIPTION
## Summary
Enrichment fixes for two Erdős problem entries:

**erdos-1065** (Primes of the Form 2^k · q + 1):
- Fixed `crossReferences` schema: `proofId` → `targetId`
- Added top-level `relatedProofs` array

**erdos-1089** (Distinct Distances in Higher Dimensions):
- Added top-level `relatedProofs` array