### PR TITLE
Enrich PAC Learning and VC Dimension

### DIFF
--- a/src/data/proofs/pac-learning-bounds/annotations.json
+++ b/src/data/proofs/pac-learning-bounds/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-pac-docstring",
+    "proofId": "pac-learning-bounds",
+    "range": { "startLine": 1, "endLine": 9 },
+    "type": "context",
+    "title": "PAC Learning Theory Overview",
+    "content": "PAC (Probably Approximately Correct) learning was introduced by Leslie Valiant in his seminal 1984 paper 'A theory of the learnable'. The framework asks: given $m$ labeled examples drawn i.i.d. from an unknown distribution, can we find a hypothesis with low error with high probability? The VC dimension (Vapnik-Chervonenkis, 1971) provides the answer: learnability is equivalent to finite combinatorial complexity of the hypothesis class. This is considered the most fundamental result in statistical learning theory.",
+    "mathContext": "PAC learnability: $\\forall \\varepsilon, \\delta > 0$, $\\exists m$ such that $m$ i.i.d. samples suffice for $\\Pr[\\text{err}(h) > \\varepsilon] < \\delta$",
+    "significance": "key",
+    "relatedConcepts": ["PAC learning", "VC dimension", "computational learning theory", "statistical learning theory"],
+    "prerequisites": ["probability theory", "combinatorics", "set systems"]
+  },
+  {
+    "id": "ann-growth-function",
+    "proofId": "pac-learning-bounds",
+    "range": { "startLine": 19, "endLine": 19 },
+    "type": "definition",
+    "title": "Growth Function (Shattering Coefficient)",
+    "content": "The growth function $\\Pi_{\\mathcal{H}}(n)$ counts the maximum number of distinct labelings that $\\mathcal{H}$ can produce on any set of $n$ points. If $\\Pi_{\\mathcal{H}}(n) = 2^n$ for some $n$, then $\\mathcal{H}$ shatters an $n$-element set. The VC dimension is the largest $n$ for which this holds. The definition is sorry'd because it requires a maximization over all $n$-element subsets of the domain, which needs a careful formalization of 'restrictions of a set family to a finite set'.",
+    "mathContext": "$\\Pi_{\\mathcal{H}}(n) = \\max_{|S|=n} |\\{h \\cap S : h \\in \\mathcal{H}\\}|$; $\\operatorname{VCdim}(\\mathcal{H}) = \\max\\{n : \\Pi_{\\mathcal{H}}(n) = 2^n\\}$",
+    "significance": "key",
+    "relatedConcepts": ["shattering", "VC dimension", "trace", "set system projection"],
+    "prerequisites": ["Finset operations", "set restrictions", "maximization"]
+  },
+  {
+    "id": "ann-sauer-shelah",
+    "proofId": "pac-learning-bounds",
+    "range": { "startLine": 22, "endLine": 23 },
+    "type": "theorem",
+    "title": "Sauer-Shelah Lemma",
+    "content": "The Sauer-Shelah lemma (independently proved by Sauer, Shelah, and Perles, all in 1972) is the combinatorial engine of learning theory. It states that if $\\operatorname{VCdim}(\\mathcal{H}) = d$, then the growth function is bounded by $\\sum_{i=0}^d \\binom{n}{i}$, which is $O(n^d)$. This polynomial bound (versus the naive $2^n$) is what makes generalization from finite samples possible. The standard proof uses induction on $n + d$: fix a point $x$, split $\\mathcal{H}$ into sets containing and not containing $x$, and apply the inductive hypothesis to each half.",
+    "mathContext": "$\\Pi_{\\mathcal{H}}(n) \\leq \\sum_{i=0}^{d} \\binom{n}{i}$ for $\\operatorname{VCdim}(\\mathcal{H}) = d$, $n \\geq d$",
+    "significance": "key",
+    "relatedConcepts": ["Sauer-Shelah lemma", "growth function", "polynomial dichotomy", "Pajor's lemma"],
+    "prerequisites": ["binomial coefficients", "induction", "VC dimension"]
+  },
+  {
+    "id": "ann-sauer-shelah-bound",
+    "proofId": "pac-learning-bounds",
+    "range": { "startLine": 26, "endLine": 27 },
+    "type": "theorem",
+    "title": "Sauer-Shelah Polynomial Corollary",
+    "content": "This corollary simplifies the exact Sauer-Shelah bound $\\sum_{i=0}^d \\binom{n}{i}$ to the cleaner $(n+1)^d$. The standard tighter bound is $(en/d)^d$ (using the inequality $\\sum_{i=0}^d \\binom{n}{i} \\leq (en/d)^d$ from the binomial theorem applied to $(1 + d/n)^n$). The $(n+1)^d$ bound used here is looser but sufficient for the sample complexity result and easier to formalize.",
+    "mathContext": "$\\sum_{i=0}^{d} \\binom{n}{i} \\leq (n+1)^d \\leq \\left(\\frac{en}{d}\\right)^d$ for $n \\geq d \\geq 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["binomial sum bounds", "polynomial growth", "asymptotic analysis"],
+    "prerequisites": ["binomial coefficient inequalities", "Nat.choose"]
+  },
+  {
+    "id": "ann-pac-sample-complexity",
+    "proofId": "pac-learning-bounds",
+    "range": { "startLine": 32, "endLine": 35 },
+    "type": "theorem",
+    "title": "PAC Sample Complexity Bound",
+    "content": "The sample complexity theorem states that $m = \\lceil 8d/\\varepsilon + 4\\log(2/\\delta)/\\varepsilon \\rceil$ samples suffice for $(\\varepsilon, \\delta)$-PAC learning when the VC dimension is $d$. The $d/\\varepsilon$ term comes from Sauer-Shelah (bounding the effective hypothesis class size), while the $\\log(1/\\delta)/\\varepsilon$ term is a confidence boost via a union bound. The standard tighter bound replaces $1/\\varepsilon$ with $1/\\varepsilon^2$; the formulation here uses a slightly different parameterization. Note: the bound uses `Nat.ceil` to convert the real-valued expression to a natural number.",
+    "mathContext": "$m(\\varepsilon, \\delta) \\leq \\left\\lceil \\frac{8d}{\\varepsilon} + \\frac{4\\log(2/\\delta)}{\\varepsilon} \\right\\rceil$",
+    "significance": "key",
+    "relatedConcepts": ["sample complexity", "PAC learning", "uniform convergence", "Hoeffding's inequality"],
+    "prerequisites": ["Real.log", "Nat.ceil", "VC dimension", "probability bounds"]
+  },
+  {
+    "id": "ann-fundamental-theorem",
+    "proofId": "pac-learning-bounds",
+    "range": { "startLine": 39, "endLine": 41 },
+    "type": "theorem",
+    "title": "Fundamental Theorem of Statistical Learning (Placeholder)",
+    "content": "The fundamental theorem states that the following are equivalent for a hypothesis class $\\mathcal{H}$: (1) finite VC dimension, (2) uniform convergence property, (3) PAC learnability, (4) ERM consistency. This is currently a `True` placeholder because the full statement requires defining PAC learnability as a proposition (involving quantification over all distributions, target concepts, and accuracy parameters) and ERM as a learning algorithm type. The equivalence proof requires the symmetrization argument (Vapnik-Chervonenkis), epsilon-nets (Haussler-Welzl), and the no-free-lunch theorem for the reverse direction.",
+    "mathContext": "$(1) \\iff (2) \\iff (3) \\iff (4)$: finite VCdim $\\iff$ uniform convergence $\\iff$ PAC learnable $\\iff$ ERM consistent",
+    "significance": "key",
+    "relatedConcepts": ["fundamental theorem of statistical learning", "ERM", "uniform convergence", "no free lunch theorem"],
+    "prerequisites": ["PAC learning definition", "ERM definition", "VC dimension", "Sauer-Shelah"]
+  }
+]

--- a/src/data/proofs/pac-learning-bounds/meta.json
+++ b/src/data/proofs/pac-learning-bounds/meta.json
@@ -60,51 +60,35 @@
   "sections": [
     {
       "id": "introduction",
-      "title": "Introduction",
+      "title": "Module Docstring and Imports",
       "startLine": 1,
-      "endLine": 30,
-      "summary": "Historical context and the central question of computational learning theory: how many examples suffice to learn?",
-      "mathContext": "The fundamental theorem of statistical learning (Vapnik-Chervonenkis, Valiant, Blumer et al.): a hypothesis class is PAC learnable iff its VC dimension is finite. Sample complexity: $\\Theta((d + \\log(1/\\delta))/\\varepsilon^2)$."
+      "endLine": 12,
+      "summary": "Overview of PAC learning theory and VC dimension, with historical attribution to Vapnik-Chervonenkis (1971) and Valiant (1984).",
+      "mathContext": "The fundamental theorem of statistical learning: $\\mathcal{H}$ is PAC learnable $\\iff$ $\\operatorname{VCdim}(\\mathcal{H}) < \\infty$."
     },
     {
-      "id": "vc-dimension",
-      "title": "VC Dimension and Shattering",
-      "startLine": 32,
-      "endLine": 82,
-      "summary": "Formal definition of shattering and VC dimension, with examples for intervals, half-spaces, and convex sets.",
-      "mathContext": "A set $S \\subseteq \\mathcal{X}$ is shattered by $\\mathcal{H}$ if $|\\{h \\cap S : h \\in \\mathcal{H}\\}| = 2^{|S|}$. The VC dimension $d = \\max\\{|S| : S \\text{ is shattered by } \\mathcal{H}\\}$. Examples: intervals on $\\mathbb{R}$ have $d = 2$; half-spaces in $\\mathbb{R}^n$ have $d = n+1$; convex $n$-gons have $d = 2n+1$."
+      "id": "growth-function",
+      "title": "Growth Function and Sauer-Shelah",
+      "startLine": 14,
+      "endLine": 27,
+      "summary": "Defines the growth function (shattering coefficient) and states the Sauer-Shelah lemma with its polynomial corollary. All three sorry'd: the growth function definition, the exact Sauer-Shelah bound, and the simplified (n+1)^d upper bound.",
+      "mathContext": "$\\Pi_{\\mathcal{H}}(n) \\leq \\sum_{i=0}^d \\binom{n}{i} \\leq (n+1)^d$ when $\\operatorname{VCdim}(\\mathcal{H}) = d$ and $n \\geq d$."
     },
     {
-      "id": "sauer-shelah",
-      "title": "Sauer-Shelah Lemma",
-      "startLine": 84,
-      "endLine": 140,
-      "summary": "The growth function of a hypothesis class with VC dimension d is bounded by a polynomial of degree d.",
-      "mathContext": "Sauer-Shelah (1972): if $\\operatorname{VCdim}(\\mathcal{H}) = d$, then the growth function $\\Pi_{\\mathcal{H}}(n) = \\max_{|S|=n} |\\{h \\cap S : h \\in \\mathcal{H}\\}| \\leq \\sum_{i=0}^d \\binom{n}{i} \\leq (en/d)^d$. Proof by induction: removing a point splits hypotheses into those that agree and disagree on it, reducing to smaller instances."
-    },
-    {
-      "id": "pac-framework",
-      "title": "PAC Learning Framework",
-      "startLine": 142,
-      "endLine": 200,
-      "summary": "Definition of PAC learnability and the ERM learning rule.",
-      "mathContext": "PAC learning: $\\mathcal{H}$ is learnable if $\\exists$ algorithm $A$ and $m(\\varepsilon, \\delta)$ such that for all distributions $D$, all $c \\in \\mathcal{H}$, given $m \\geq m(\\varepsilon, \\delta)$ i.i.d. samples, $\\Pr[\\text{err}(A(S)) > \\varepsilon] < \\delta$. ERM: output $h \\in \\mathcal{H}$ minimizing empirical error on the sample."
-    },
-    {
-      "id": "sample-complexity",
-      "title": "Sample Complexity and the Fundamental Theorem",
-      "startLine": 202,
-      "endLine": 265,
-      "summary": "Uniform convergence bounds yield the fundamental theorem: finite VC dimension iff PAC learnable.",
-      "mathContext": "Uniform convergence: $\\Pr[\\sup_{h \\in \\mathcal{H}} |\\hat{\\text{err}}(h) - \\text{err}(h)| > \\varepsilon] \\leq 4 \\Pi_{\\mathcal{H}}(2m) \\cdot e^{-m\\varepsilon^2/8}$. Setting the RHS $< \\delta$ and using Sauer-Shelah gives $m = O((d \\log(1/\\varepsilon) + \\log(1/\\delta))/\\varepsilon^2)$. Tighter analysis removes the $\\log(1/\\varepsilon)$ factor."
+      "id": "pac-complexity",
+      "title": "PAC Sample Complexity",
+      "startLine": 29,
+      "endLine": 35,
+      "summary": "States the PAC sample complexity bound: m = O(d/ε + log(1/δ)/ε) samples suffice for (ε,δ)-PAC learning with VC dimension d. Currently sorry'd.",
+      "mathContext": "$m(\\varepsilon, \\delta) \\leq \\lceil 8d/\\varepsilon + 4\\log(2/\\delta)/\\varepsilon \\rceil$"
     },
     {
       "id": "fundamental-theorem",
-      "title": "The Fundamental Theorem",
-      "startLine": 267,
-      "endLine": 310,
-      "summary": "Equivalence of finite VC dimension, PAC learnability, uniform convergence, and finite sample complexity.",
-      "mathContext": "The following are equivalent for $\\mathcal{H}$: (1) $\\operatorname{VCdim}(\\mathcal{H}) < \\infty$; (2) $\\mathcal{H}$ has the uniform convergence property; (3) $\\mathcal{H}$ is PAC learnable; (4) ERM is a consistent learner for $\\mathcal{H}$. The proof cycle is $(1) \\Rightarrow (2) \\Rightarrow (3) \\Rightarrow (4) \\Rightarrow (1)$."
+      "title": "Fundamental Theorem (Placeholder)",
+      "startLine": 37,
+      "endLine": 43,
+      "summary": "Placeholder for the fundamental theorem of statistical learning (proves True). The full statement requires defining PAC learnability, ERM, and uniform convergence as types/propositions.",
+      "mathContext": "The equivalence: finite VC dim $\\iff$ uniform convergence $\\iff$ PAC learnable $\\iff$ ERM consistent."
     }
   ],
   "crossReferences": [
@@ -128,8 +112,10 @@
     "summary": "The fundamental theorem of statistical learning establishes that a hypothesis class is PAC learnable if and only if its VC dimension is finite. The Sauer-Shelah lemma provides the combinatorial engine, bounding the effective complexity of a hypothesis class and enabling uniform convergence from finite samples. The sample complexity O((d + log(1/delta))/epsilon^2) is tight and provides practical guidance for machine learning.",
     "implications": "This formalization provides:\n\n**1. Mathematical Foundation of Machine Learning**\nThe fundamental theorem is the theoretical bedrock of statistical learning, and this formalization makes its assumptions and conclusions machine-checkable.\n\n**2. Combinatorics-Learning Bridge**\nVC dimension is a purely combinatorial quantity that determines learnability, demonstrating a deep connection between discrete mathematics and statistics.\n\n**3. Sauer-Shelah as Reusable Tool**\nThe Sauer-Shelah lemma has applications beyond learning theory: in geometry (epsilon-nets), combinatorics (set systems), and model theory (NIP theories).\n\n**4. ERM as Universal Algorithm**\nThe formalization shows that empirical risk minimization is a universal learning algorithm, requiring no distributional assumptions beyond i.i.d. sampling.\n\n**5. Foundation for Extensions**\nThe PAC framework is the starting point for agnostic learning, online learning, and learning with noise, each requiring extensions of the formalized core.",
     "openQuestions": [
-      "Can the VC dimension of specific hypothesis classes (linear classifiers, neural networks) be computed?",
-      "What is the connection to Rademacher complexity?"
+      "Can the VC dimension of specific hypothesis classes (linear classifiers, neural networks) be computed in Lean?",
+      "What is the connection to Rademacher complexity, and can the Rademacher-based generalization bound be formalized?",
+      "Formalize the full equivalence (not just the placeholder True) — requires defining PAC learnability, ERM, and uniform convergence as proper Lean types",
+      "Can the epsilon-net theorem be formalized in Lean to get the tighter sample complexity bound without the log(1/ε) factor?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
Enrichment pass for `pac-learning-bounds` (quality 45 → enriched, 0 prior passes).

- **6 annotations** created covering growth function, Sauer-Shelah lemma and corollary, PAC sample complexity, fundamental theorem placeholder
- **Sections fixed**: line ranges corrected from fictional 30-310 to actual file extent (44 lines)
- **openQuestions** expanded from 2 → 4

## Notes
- `status: "formalized"` with 5 sorries is accurate
- `axiomCount: 0` correct
- Two `True` placeholders noted in annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)