### PR TITLE
Enrich First Moment Method (Probabilistic Method)

### DIFF
--- a/src/data/proofs/prob-method-expectation/annotations.json
+++ b/src/data/proofs/prob-method-expectation/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-prob-method-docstring",
+    "proofId": "prob-method-expectation",
+    "range": { "startLine": 1, "endLine": 11 },
+    "type": "context",
+    "title": "The Probabilistic Method: Historical Origins",
+    "content": "Paul Erdős introduced the probabilistic method in his 1947 paper 'Some remarks on the theory of graphs', where he proved that $R(k,k) \\geq 2^{k/2}$ by showing that a random 2-coloring of $K_n$ has no monochromatic $K_k$ with positive probability. This was revolutionary: it proved the existence of a combinatorial object without constructing one. The technique became one of the most powerful tools in combinatorics, with Erdős applying it to hundreds of problems in graph theory, number theory, and geometry over the next 50 years.",
+    "mathContext": "Probabilistic method: to show $\\exists x \\in \\Omega$ with property $P$, show $\\Pr[P(X)] > 0$ for random $X$",
+    "significance": "key",
+    "relatedConcepts": ["probabilistic method", "Ramsey theory", "existence proofs", "non-constructive mathematics"],
+    "prerequisites": ["probability theory", "combinatorics"]
+  },
+  {
+    "id": "ann-first-moment",
+    "proofId": "prob-method-expectation",
+    "range": { "startLine": 18, "endLine": 20 },
+    "type": "theorem",
+    "title": "First Moment Principle (Discrete Pigeonhole)",
+    "content": "The first moment principle is a discrete pigeonhole argument: if the average of $f$ over a nonempty Finset exceeds $t$, then some element must exceed $t$ (if all were $\\leq t$, the average would be $\\leq t$). The formalization uses $\\mathbb{Q}$ (rationals) rather than $\\mathbb{R}$ for exact arithmetic, avoiding the overhead of real analysis. This is mathematically equivalent for the finite combinatorial applications. The proof approach would be by contradiction: assume $f(a) \\leq t$ for all $a \\in s$, then bound the sum.",
+    "mathContext": "$\\frac{\\sum_{a \\in s} f(a)}{|s|} > t \\implies \\exists a \\in s,\\; f(a) > t$",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "Markov's inequality", "first moment method", "average argument"],
+    "prerequisites": ["Finset.sum", "rational arithmetic", "Finset.Nonempty"]
+  },
+  {
+    "id": "ann-linearity",
+    "proofId": "prob-method-expectation",
+    "range": { "startLine": 23, "endLine": 25 },
+    "type": "theorem",
+    "title": "Linearity of Expectation",
+    "content": "Linearity of expectation — $E[f + g] = E[f] + E[g]$ — is arguably the single most useful fact in the probabilistic method. Crucially, it holds without any independence assumptions. This is what allows counting arguments to work: to bound $E[\\sum_i X_i]$, just sum $E[X_i]$ for each indicator, regardless of correlations. In Mathlib, this is essentially `Finset.sum_add_distrib`, making the sorry likely a one-liner.",
+    "mathContext": "$\\sum_{a \\in s} (f+g)(a) = \\sum_{a \\in s} f(a) + \\sum_{a \\in s} g(a)$",
+    "significance": "key",
+    "relatedConcepts": ["linearity of expectation", "indicator random variables", "Finset.sum_add_distrib"],
+    "prerequisites": ["Finset.sum", "Pi.add_apply"]
+  },
+  {
+    "id": "ann-mono-cliques",
+    "proofId": "prob-method-expectation",
+    "range": { "startLine": 30, "endLine": 31 },
+    "type": "theorem",
+    "title": "Expected Monochromatic Cliques Count",
+    "content": "In a random 2-coloring of $K_n$, each $k$-subset has probability $2 \\cdot 2^{-\\binom{k}{2}} = 2^{1-\\binom{k}{2}}$ of being monochromatic (all edges the same color). By linearity, the expected total is $\\binom{n}{k} \\cdot 2^{1-\\binom{k}{2}}$. The current formalization only states non-negativity of this expression, not the full bound. The key application would show this is $< 1$ when $n < 2^{k/2}$, implying a good coloring exists. Note: the exponent uses $\\mathbb{Z}$ since $1 - \\binom{k}{2}$ can be negative.",
+    "mathContext": "$E[\\text{mono } K_k] = \\binom{n}{k} \\cdot 2^{1 - \\binom{k}{2}}$; this is $< 1$ when $n < 2^{k/2}$",
+    "significance": "supporting",
+    "relatedConcepts": ["indicator random variables", "union bound", "Ramsey numbers", "random coloring"],
+    "prerequisites": ["Nat.choose", "integer exponentiation"]
+  },
+  {
+    "id": "ann-ramsey-bound",
+    "proofId": "prob-method-expectation",
+    "range": { "startLine": 35, "endLine": 36 },
+    "type": "theorem",
+    "title": "Erdős Ramsey Lower Bound (1947)",
+    "content": "Erdős's 1947 result: $R(k,k) \\geq 2^{k/2}$. This means that for $n < 2^{k/2}$, the edges of $K_n$ can be 2-colored with no monochromatic $K_k$. The current formalization is simplified to an existential statement about the existence of a large enough $n$. A full formalization would combine the expected monochromatic clique count with the first moment principle's dual (if $E[X] < 1$ for a non-negative integer $X$, then $\\Pr[X = 0] > 0$). The bound $2^{k/2}$ was the best known for over 75 years until Campos et al. (2023) improved the upper bound.",
+    "mathContext": "$R(k,k) \\geq 2^{k/2}$; equivalently, $\\binom{n}{k} \\cdot 2^{1-\\binom{k}{2}} < 1$ when $n < 2^{k/2}$",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey numbers", "exponential lower bound", "random graph theory", "Campos et al. 2023"],
+    "prerequisites": ["first moment principle", "expected monochromatic cliques", "Nat.choose bounds"]
+  }
+]

--- a/src/data/proofs/prob-method-expectation/meta.json
+++ b/src/data/proofs/prob-method-expectation/meta.json
@@ -59,43 +59,43 @@
   "sections": [
     {
       "id": "introduction",
-      "title": "Introduction",
+      "title": "Module Docstring and Imports",
       "startLine": 1,
-      "endLine": 25,
-      "summary": "Overview of the probabilistic method and the first moment principle.",
-      "mathContext": "The probabilistic method: to prove existence, show a random object has the desired property with positive probability. The first moment method is the simplest form: $E[X] > t$ implies $\\exists \\omega, X(\\omega) > t$."
-    },
-    {
-      "id": "finite-probability",
-      "title": "Finite Probability Framework",
-      "startLine": 27,
-      "endLine": 65,
-      "summary": "Definitions for finite probability spaces, expectation as Finset averages, and basic properties.",
-      "mathContext": "For a finite set $\\Omega$ and $f: \\Omega \\to \\mathbb{R}$, define $E[f] = \\frac{1}{|\\Omega|} \\sum_{\\omega \\in \\Omega} f(\\omega)$. This Finset-based definition avoids measure theory while supporting the key probabilistic arguments."
+      "endLine": 14,
+      "summary": "Overview of the first moment method: if E[X] > t on a finite probability space, some outcome exceeds t. Lists key results: first moment principle, linearity of expectation, and Erdos's 1947 Ramsey bound.",
+      "mathContext": "$E[X] > t \\implies \\exists \\omega,\\; X(\\omega) > t$"
     },
     {
       "id": "first-moment",
       "title": "First Moment Principle",
-      "startLine": 67,
-      "endLine": 105,
-      "summary": "If the average exceeds a threshold, some element exceeds it. Dual: if the average is below a threshold, some element is below it.",
-      "mathContext": "First moment principle: if $E[f] > t$ over a nonempty finite set $\\Omega$, then $\\exists \\omega \\in \\Omega$ with $f(\\omega) > t$. Equivalently, $\\max_{\\omega} f(\\omega) \\geq E[f]$. The dual gives $\\min_{\\omega} f(\\omega) \\leq E[f]$."
+      "startLine": 16,
+      "endLine": 20,
+      "summary": "If the sum f(a) over a Finset s divided by |s| exceeds t, then some element a in s has f(a) > t. Uses ℚ (rationals) for exact arithmetic. Currently sorry'd — provable by contradiction using Finset.sum_le_sum.",
+      "mathContext": "$\\frac{\\sum_{a \\in s} f(a)}{|s|} > t \\implies \\exists a \\in s,\\; f(a) > t$"
     },
     {
       "id": "linearity",
       "title": "Linearity of Expectation",
-      "startLine": 107,
-      "endLine": 148,
-      "summary": "Linearity of expectation for finite sums, requiring no independence assumptions.",
-      "mathContext": "For any functions $f_1, \\ldots, f_m: \\Omega \\to \\mathbb{R}$, $E[\\sum_i f_i] = \\sum_i E[f_i]$. This holds regardless of dependencies between the $f_i$, which is what makes the probabilistic method so powerful."
+      "startLine": 22,
+      "endLine": 25,
+      "summary": "Linearity of expectation for Finset sums: the sum of (f + g) equals the sum of f plus the sum of g. Currently sorry'd — follows directly from Finset.sum_add_distrib in Mathlib.",
+      "mathContext": "$\\sum_{a \\in s} (f + g)(a) = \\sum_{a \\in s} f(a) + \\sum_{a \\in s} g(a)$"
     },
     {
-      "id": "ramsey-application",
-      "title": "Ramsey Application: R(k,k) >= 2^(k/2)",
-      "startLine": 150,
-      "endLine": 210,
-      "summary": "Erdos's 1947 proof that Ramsey numbers grow exponentially, via random 2-coloring of complete graphs.",
-      "mathContext": "Color edges of $K_n$ uniformly at random with 2 colors. For each $k$-subset $S$, let $X_S = 1$ if $S$ is monochromatic. Then $E[\\sum_S X_S] = \\binom{n}{k} \\cdot 2^{1-\\binom{k}{2}}$. When $n < 2^{k/2}$, this is less than 1, so by the first moment principle (dual form), some coloring has no monochromatic $K_k$."
+      "id": "mono-cliques",
+      "title": "Expected Monochromatic Cliques",
+      "startLine": 27,
+      "endLine": 31,
+      "summary": "The expected number of monochromatic k-cliques in a random 2-coloring of K_n is C(n,k) · 2^(1-C(k,2)). Currently only states non-negativity of this expression (sorry'd). The full application would show this is < 1 when n < 2^(k/2).",
+      "mathContext": "$E[\\text{mono } K_k] = \\binom{n}{k} \\cdot 2^{1 - \\binom{k}{2}}$"
+    },
+    {
+      "id": "ramsey-bound",
+      "title": "Erdos Ramsey Lower Bound",
+      "startLine": 33,
+      "endLine": 38,
+      "summary": "Simplified version of Erdos's 1947 result: R(k,k) >= 2^(k/2). Currently sorry'd as an existential statement — the full proof would combine the expected monochromatic clique count with the first moment principle.",
+      "mathContext": "$R(k,k) \\geq 2^{k/2}$"
     }
   ],
   "crossReferences": [
@@ -124,8 +124,10 @@
     "summary": "The first moment method formalizes the simplest yet most fundamental technique of the probabilistic method: if the expected value of a quantity exceeds a threshold, some outcome must exceed it. Combined with linearity of expectation, this yields Erdos's celebrated 1947 lower bound R(k,k) >= 2^(k/2) on Ramsey numbers.",
     "implications": "This formalization provides:\n\n**1. Foundation for the Probabilistic Method Library**\nThe finite probability framework and first moment principle serve as the base layer for the alteration method, second moment method, and Lovasz Local Lemma formalizations.\n\n**2. Ramsey Theory Bounds**\nThe exponential lower bound on diagonal Ramsey numbers is one of the most important results in combinatorics, and this formalization makes it machine-checkable.\n\n**3. Template for Counting Arguments**\nThe linearity-of-expectation technique demonstrated here applies to hundreds of combinatorial existence proofs.\n\n**4. Bridge to Erdos Problems**\nMany Erdos problems in the gallery involve probabilistic method arguments, and this library provides the formal tools to attack them.",
     "openQuestions": [
-      "Can the framework extend to infinite probability spaces?",
-      "What is the tightest Ramsey bound achievable via the first moment method alone?"
+      "Can this Finset-based framework extend to infinite probability spaces via Mathlib's MeasureTheory?",
+      "What is the tightest Ramsey bound achievable via the first moment method alone?",
+      "Prove linearity_of_expectation using Finset.sum_add_distrib — likely a one-liner",
+      "Can the expected_mono_cliques result be strengthened to show the count is < 1 for n < 2^(k/2)?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
Enrichment pass for `prob-method-expectation` (quality 45 → enriched, 0 prior passes).

- **5 annotations** created covering first moment principle, linearity of expectation, monochromatic clique counting, Erdos Ramsey bound
- **Sections fixed**: line ranges corrected from fictional 25-210 to actual file extent (39 lines)
- **openQuestions** expanded from 2 → 4
- Noted that `linearity_of_expectation` sorry is likely provable via `Finset.sum_add_distrib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)