### PR TITLE
Enrich Lovász Local Lemma

### DIFF
--- a/src/data/proofs/prob-method-lovasz-local/annotations.json
+++ b/src/data/proofs/prob-method-lovasz-local/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-lll-docstring",
+    "proofId": "prob-method-lovasz-local",
+    "range": { "startLine": 1, "endLine": 13 },
+    "type": "context",
+    "title": "The Lovász Local Lemma: Crown Jewel of the Probabilistic Method",
+    "content": "The Lovász Local Lemma (LLL), proved by Erdős and Lovász in their 1975 paper 'Problems and results on 3-chromatic hypergraphs', overcomes the main limitation of the basic probabilistic method: the union bound. When $n$ bad events each have probability $p$, the union bound only guarantees avoidance if $np < 1$. The LLL shows that if the events are mostly independent (sparse dependency graph), avoidance is possible even when $np \\gg 1$. This enables existence proofs for graph coloring, satisfiability, and combinatorial designs that the first moment method cannot reach.",
+    "mathContext": "Union bound: $\\Pr[\\bigcup A_i] \\leq \\sum \\Pr[A_i]$. LLL: $\\Pr[\\bigcap \\overline{A_i}] > 0$ even when $\\sum \\Pr[A_i] \\gg 1$, provided dependencies are sparse.",
+    "significance": "key",
+    "relatedConcepts": ["Lovász Local Lemma", "dependency graph", "union bound", "sparse dependencies"],
+    "prerequisites": ["probability theory", "graph theory", "conditional probability"]
+  },
+  {
+    "id": "ann-symmetric-lll",
+    "proofId": "prob-method-lovasz-local",
+    "range": { "startLine": 24, "endLine": 28 },
+    "type": "theorem",
+    "title": "Symmetric LLL (Simplified Criterion)",
+    "content": "The symmetric LLL states that if each of $n$ bad events has probability $\\leq p$ and depends on at most $d$ other events, and a criterion involving $p$, $d$ is met, then all bad events can be avoided. The formalization uses $p(d+1) \\leq 1/3$ as a simplified criterion (the exact bound is $ep(d+1) \\leq 1$ where $e \\approx 2.718$). The constant $1/3$ is a safe approximation since $1/e \\approx 0.368 > 1/3$. The theorem currently proves `True` as a placeholder because the full statement requires formalizing events, probability measures, and dependency graphs.",
+    "mathContext": "Simplified: $p(d+1) \\leq 1/3$. Exact: $ep(d+1) \\leq 1$, i.e., $p \\leq \\frac{1}{e(d+1)}$.",
+    "significance": "key",
+    "relatedConcepts": ["symmetric LLL", "dependency degree", "Euler's number", "union bound improvement"],
+    "prerequisites": ["probability events", "dependency graph degree"]
+  },
+  {
+    "id": "ann-general-lll",
+    "proofId": "prob-method-lovasz-local",
+    "range": { "startLine": 33, "endLine": 37 },
+    "type": "theorem",
+    "title": "General (Asymmetric) Lovász Local Lemma",
+    "content": "The general LLL assigns individual witness values $x_i \\in [0,1)$ to each event $i$. The condition $\\Pr[A_i] \\leq x_i \\prod_{j \\in \\Gamma(i)} (1 - x_j)$ ensures $\\Pr[\\bigcap \\overline{A_i}] \\geq \\prod_i (1-x_i) > 0$. This is strictly stronger than the symmetric form: it allows events with different probabilities and different dependency degrees. The formalization uses `Fin n` for indexing, `Finset (Fin n)` for adjacency lists, and $\\mathbb{Q}$ for exact probability arithmetic. The conclusion $\\prod_i(1-x_i) > 0$ follows from each $x_i < 1$.",
+    "mathContext": "$\\Pr[A_i] \\leq x_i \\prod_{j \\in \\Gamma(i)}(1-x_j) \\implies \\Pr\\left[\\bigcap_i \\overline{A_i}\\right] \\geq \\prod_i(1-x_i) > 0$",
+    "significance": "key",
+    "relatedConcepts": ["asymmetric LLL", "witness values", "Finset.prod", "conditional probability"],
+    "prerequisites": ["Fin n indexing", "Finset.prod", "rational arithmetic"]
+  },
+  {
+    "id": "ann-ksat",
+    "proofId": "prob-method-lovasz-local",
+    "range": { "startLine": 41, "endLine": 44 },
+    "type": "theorem",
+    "title": "k-SAT Satisfiability via LLL",
+    "content": "A classic application of the symmetric LLL to random $k$-SAT: each clause of $k$ literals is unsatisfied with probability $2^{-k}$ under a random assignment. If each variable appears in at most $2^{k-2}/k$ clauses, then each clause depends on at most $k \\cdot 2^{k-2}/k = 2^{k-2}$ other clauses, and the LLL criterion is met. The formalization verifies the numerical inequality $2^{-k}(2^{k-2}+1) \\leq 1$. This gives the best unconditional lower bound on the $k$-SAT satisfiability threshold for large $k$.",
+    "mathContext": "$2^{-k} \\cdot (k \\cdot 2^{k-2}/k + 1) = 2^{-k}(2^{k-2}+1) \\leq 1$ for $k \\geq 3$",
+    "significance": "supporting",
+    "relatedConcepts": ["k-SAT", "satisfiability threshold", "random SAT", "clause-variable ratio"],
+    "prerequisites": ["Boolean satisfiability", "symmetric LLL criterion"]
+  },
+  {
+    "id": "ann-moser-tardos",
+    "proofId": "prob-method-lovasz-local",
+    "range": { "startLine": 48, "endLine": 52 },
+    "type": "theorem",
+    "title": "Moser-Tardos Constructive LLL (2010)",
+    "content": "Robin Moser and Gábor Tardos (2010) gave a constructive proof of the LLL via a simple resampling algorithm: while any bad event $A_i$ occurs, pick one and resample its random variables. They proved that the expected number of resampling steps is at most $\\sum_i x_i/(1-x_i)$, which is polynomial in $n$ under the LLL conditions. This resolved a major open problem: Erdős and Lovász's original proof was purely existential and gave no algorithm. The formalization currently only states that this sum is non-negative (a weak bound), with a sorry on a simplified version of the witness condition.",
+    "mathContext": "Moser-Tardos: expected resampling steps $\\leq \\sum_{i=1}^n \\frac{x_i}{1-x_i}$",
+    "significance": "key",
+    "relatedConcepts": ["Moser-Tardos algorithm", "constructive LLL", "resampling", "derandomization"],
+    "prerequisites": ["general LLL conditions", "witness values", "algorithmic probability"]
+  }
+]

--- a/src/data/proofs/prob-method-lovasz-local/meta.json
+++ b/src/data/proofs/prob-method-lovasz-local/meta.json
@@ -59,43 +59,43 @@
   "sections": [
     {
       "id": "introduction",
-      "title": "Introduction",
+      "title": "Module Docstring and Imports",
       "startLine": 1,
-      "endLine": 28,
-      "summary": "Historical context and motivation for the Lovasz Local Lemma.",
-      "mathContext": "The Lovasz Local Lemma (1975) overcomes the union bound's weakness with dependent events. When bad events are rare and mostly independent, they can all be simultaneously avoided. This is the most powerful tool in the probabilistic method."
-    },
-    {
-      "id": "dependency-graphs",
-      "title": "Dependency Graphs",
-      "startLine": 30,
-      "endLine": 72,
-      "summary": "Formal definition of dependency graphs and the mutual independence condition for non-adjacent events.",
-      "mathContext": "A dependency graph for events $\\{A_i\\}_{i \\in I}$ is a graph $G = (I, E)$ such that each $A_i$ is mutually independent of $\\{A_j : j \\notin \\Gamma(i) \\cup \\{i\\}\\}$. The dependency graph need not be unique; any supergraph of the 'true' dependency structure works."
+      "endLine": 16,
+      "summary": "Overview of the Lovász Local Lemma as the crown jewel of the probabilistic method. Attribution to Erdős and Lovász (1975).",
+      "mathContext": "If bad events are unlikely and mostly independent, they can all be simultaneously avoided."
     },
     {
       "id": "symmetric-lll",
-      "title": "Symmetric Lovasz Local Lemma",
-      "startLine": 74,
-      "endLine": 128,
-      "summary": "If each event has probability at most p and depends on at most d others, and ep(d+1) <= 1, then all events can be avoided.",
-      "mathContext": "Symmetric LLL: if $\\Pr[A_i] \\leq p$ for all $i$ and each $A_i$ is independent of all but at most $d$ events, then $ep(d+1) \\leq 1$ implies $\\Pr[\\bigcap_i \\overline{A_i}] > 0$. The factor $e \\approx 2.718$ arises from $(1 - 1/(d+1))^d \\leq 1/e$."
+      "title": "Symmetric Lovász Local Lemma",
+      "startLine": 21,
+      "endLine": 28,
+      "summary": "Placeholder for the symmetric LLL: if each bad event has probability <= p, depends on at most d others, and p(d+1) <= 1/3 (simplified from ep(d+1) <= 1), then all bad events can be avoided. Proves True (placeholder). Currently sorry'd because it requires event/probability formalization.",
+      "mathContext": "$p(d+1) \\leq 1/3$ (simplified criterion); the exact bound is $ep(d+1) \\leq 1$ where $e \\approx 2.718$."
     },
     {
       "id": "general-lll",
-      "title": "General (Asymmetric) Lovasz Local Lemma",
-      "startLine": 130,
-      "endLine": 195,
-      "summary": "The full asymmetric version with witness values, strictly stronger than the symmetric form.",
-      "mathContext": "General LLL: if there exist $x_i \\in [0,1)$ with $\\Pr[A_i] \\leq x_i \\prod_{j \\in \\Gamma(i)} (1 - x_j)$ for all $i$, then $\\Pr[\\bigcap_i \\overline{A_i}] \\geq \\prod_i (1 - x_i) > 0$. The symmetric version follows by setting $x_i = 1/(d+1)$ for all $i$."
+      "title": "General (Asymmetric) Lovász Local Lemma",
+      "startLine": 30,
+      "endLine": 37,
+      "summary": "The general LLL with witness values x_i indexed by Fin n. If prob(i) <= x_i * prod_{j in adj(i)} (1 - x_j), then the product prod_i (1 - x_i) > 0, implying positive probability of avoiding all events. Uses ℚ for exact arithmetic and Finset adjacency lists. Currently sorry'd.",
+      "mathContext": "$\\Pr[A_i] \\leq x_i \\prod_{j \\in \\Gamma(i)}(1-x_j) \\implies \\prod_i(1-x_i) > 0$"
     },
     {
-      "id": "k-sat-application",
+      "id": "ksat",
       "title": "k-SAT Application",
-      "startLine": 197,
-      "endLine": 250,
-      "summary": "Application to random k-SAT: formulas with few clauses per variable are satisfiable.",
-      "mathContext": "A random $k$-SAT formula where each clause shares variables with at most $d$ other clauses is satisfiable when $e \\cdot 2^{-k} (d+1) \\leq 1$. Each clause is independently unsatisfied with probability $2^{-k}$, and the clause overlap structure defines the dependency graph."
+      "startLine": 39,
+      "endLine": 44,
+      "summary": "Application to k-SAT: a k-CNF formula where each variable appears in at most 2^(k-2)/k clauses is satisfiable. The statement verifies the LLL criterion numerically. Currently sorry'd.",
+      "mathContext": "$2^{-k} \\cdot (k \\cdot 2^{k-2}/k + 1) \\leq 1$"
+    },
+    {
+      "id": "moser-tardos",
+      "title": "Moser-Tardos Constructive LLL",
+      "startLine": 46,
+      "endLine": 54,
+      "summary": "Constructive version (Moser-Tardos, 2010): the resampling algorithm terminates with expected number of steps bounded by sum of x_i/(1-x_i). Currently sorry'd with a simplified bound statement.",
+      "mathContext": "Expected resampling steps $\\leq \\sum_i \\frac{x_i}{1-x_i}$"
     }
   ],
   "crossReferences": [
@@ -124,9 +124,10 @@
     "summary": "The Lovasz Local Lemma formalizes the most powerful tool in the probabilistic method: when bad events are individually unlikely and their dependencies are sparse (captured by a dependency graph), all bad events can be simultaneously avoided. The symmetric form ep(d+1) <= 1 and the general asymmetric form with witness values are both formalized, along with a k-SAT satisfiability application.",
     "implications": "This formalization provides:\n\n**1. Crown Jewel of the Probabilistic Method**\nThe LLL is the most sophisticated tool in the probabilistic method toolkit, and this formalization makes its subtle conditions machine-checkable.\n\n**2. k-SAT Threshold Bounds**\nThe satisfiability threshold for random k-SAT is a central problem in computational complexity, and the LLL provides the best unconditional lower bounds.\n\n**3. Sparse Dependency Framework**\nThe dependency graph abstraction is reusable across many applications in combinatorics, coding theory, and algorithm design.\n\n**4. Path to Constructive LLL**\nThe formalization establishes the non-constructive LLL as a foundation for future formalization of the Moser-Tardos constructive proof.\n\n**5. Applications Across Combinatorics**\nHypergraph coloring, Latin transversals, Ramsey theory, and many Erdos problems rely on the LLL.",
     "openQuestions": [
-      "Can the Moser-Tardos constructive proof be formalized?",
-      "What is the tightest form of the LLL achievable in Lean?",
-      "How does the lopsided LLL extend the basic version?"
+      "Formalize the full Moser-Tardos resampling algorithm with termination proof — currently only the expected step bound is stated",
+      "Replace the simplified p(d+1) <= 1/3 criterion with the exact ep(d+1) <= 1, which requires formalizing e = lim (1+1/n)^n",
+      "How does the lopsided LLL (where independence is replaced by negative correlation) extend the basic version?",
+      "Can the LLL be applied to Erdős problems in the gallery that involve sparse dependency structures?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
Enrichment pass for `prob-method-lovasz-local` (quality 45 → enriched, 0 prior passes).

- **5 annotations** created covering symmetric LLL, general LLL, k-SAT application, Moser-Tardos constructive version
- **Sections fixed**: line ranges corrected from fictional 28-250 to actual file extent (55 lines)
- **openQuestions** expanded from 3 → 4
- Noted placeholder `True` theorem and simplified 1/3 criterion vs exact $e$ criterion

🤖 Generated with [Claude Code](https://claude.com/claude-code)