### PR TITLE
Enrich Shannon Noisy Channel Coding Theorem

### DIFF
--- a/src/data/proofs/shannon-channel-coding/annotations.json
+++ b/src/data/proofs/shannon-channel-coding/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-shannon-docstring",
+    "proofId": "shannon-channel-coding",
+    "range": { "startLine": 1, "endLine": 10 },
+    "type": "context",
+    "title": "Shannon's 1948 Revolution",
+    "content": "Claude Shannon's 1948 paper 'A Mathematical Theory of Communication' is one of the most influential scientific papers ever written. It established information theory as a mathematical discipline and answered the fundamental question of telecommunications: can we communicate reliably over a noisy channel? Shannon's surprising answer was yes — at any rate below channel capacity. This overturned the engineering intuition that noise forces arbitrarily slow communication. The paper introduced entropy, mutual information, and channel capacity as rigorous mathematical quantities.",
+    "mathContext": "Shannon (1948): reliable communication is possible at rate $R$ iff $R < C = \\max_{p(x)} I(X;Y)$",
+    "significance": "key",
+    "relatedConcepts": ["information theory", "channel capacity", "Shannon entropy", "coding theory"],
+    "prerequisites": ["probability theory", "entropy", "mutual information"]
+  },
+  {
+    "id": "ann-channel-capacity",
+    "proofId": "shannon-channel-coding",
+    "range": { "startLine": 17, "endLine": 19 },
+    "type": "definition",
+    "title": "Channel Capacity Definition",
+    "content": "Channel capacity is defined as $C = \\max_{p(x)} I(X;Y)$, the maximum mutual information over all input distributions. The function is `noncomputable` because the optimization over the probability simplex requires the axiom of choice (existence of a maximum of a continuous function on a compact set). The channel is represented as a transition matrix $W : \\alpha \\to \\beta \\to \\mathbb{R}$ where $W(x)(y) = p(y|x)$. The sorry'd definition needs the full mutual information formula $I(X;Y) = \\sum_{x,y} p(x) W(x)(y) \\log \\frac{W(x)(y)}{\\sum_{x'} p(x') W(x')(y)}$.",
+    "mathContext": "$C = \\max_{p(x)} I(X;Y) = \\max_{p(x)} \\left[ H(Y) - H(Y|X) \\right]$",
+    "significance": "key",
+    "relatedConcepts": ["mutual information", "optimization on simplex", "concavity", "noncomputable"],
+    "prerequisites": ["mutual information", "probability simplex", "Fintype"]
+  },
+  {
+    "id": "ann-fano",
+    "proofId": "shannon-channel-coding",
+    "range": { "startLine": 23, "endLine": 27 },
+    "type": "theorem",
+    "title": "Fano's Inequality (Placeholder)",
+    "content": "Fano's inequality (Robert Fano, 1961) is the key tool for the converse of the channel coding theorem. It states that $H(X|Y) \\leq h(P_e) + P_e \\log(|\\mathcal{X}|-1)$, where $P_e = \\Pr[X \\neq \\hat{X}]$ is the error probability and $h$ is the binary entropy function. Intuitively: if decoding error is small, then $Y$ must carry most of the information about $X$, so conditional entropy $H(X|Y)$ is small. The formalization currently proves `True` because stating the full inequality requires defining conditional entropy and the binary entropy function.",
+    "mathContext": "$H(X|Y) \\leq h(P_e) + P_e \\log(|\\mathcal{X}|-1)$ where $h(p) = -p\\log p - (1-p)\\log(1-p)$",
+    "significance": "key",
+    "relatedConcepts": ["Fano's inequality", "conditional entropy", "binary entropy", "data processing inequality"],
+    "prerequisites": ["conditional entropy", "binary entropy function", "joint distributions"]
+  },
+  {
+    "id": "ann-achievability",
+    "proofId": "shannon-channel-coding",
+    "range": { "startLine": 31, "endLine": 36 },
+    "type": "theorem",
+    "title": "Channel Coding Achievability (Random Coding)",
+    "content": "The achievability half of the channel coding theorem: for any rate $R < C$, codes exist with vanishing error probability. Shannon's original proof uses random coding — generate $2^{nR}$ codewords i.i.d. from the capacity-achieving input distribution and decode using joint typicality. The error probability vanishes exponentially fast: $P_e \\leq 2^{-n(C-R-\\delta)}$ for any $\\delta > 0$. This is a probabilistic method argument avant la lettre: a random codebook works, so a good deterministic codebook exists. Currently proves `True`.",
+    "mathContext": "$R < C \\implies \\exists$ code sequence with $P_e^{(n)} \\leq 2^{-n(C-R-\\delta)} \\to 0$",
+    "significance": "key",
+    "relatedConcepts": ["random coding", "joint typicality", "error exponent", "probabilistic method"],
+    "prerequisites": ["channel capacity", "i.i.d. sequences", "typical sets"]
+  },
+  {
+    "id": "ann-converse",
+    "proofId": "shannon-channel-coding",
+    "range": { "startLine": 40, "endLine": 45 },
+    "type": "theorem",
+    "title": "Channel Coding Converse (via Fano)",
+    "content": "The converse half: for rates above capacity, error probability cannot vanish. The proof chains: data processing inequality shows $I(W; \\hat{W}) \\leq nC$ (where $W$ is the message, $\\hat{W}$ the decoded message), while Fano's inequality gives $H(W|\\hat{W}) \\leq 1 + P_e nR$. Since $H(W) = nR$, combining gives $nR \\leq nC + 1 + P_e nR$, so $P_e \\geq 1 - C/R - 1/(nR) \\to 1 - C/R > 0$ when $R > C$. Currently proves `True`.",
+    "mathContext": "$R > C \\implies \\liminf_{n \\to \\infty} P_e^{(n)} \\geq 1 - C/R > 0$",
+    "significance": "key",
+    "relatedConcepts": ["weak converse", "strong converse", "data processing inequality", "Fano's inequality"],
+    "prerequisites": ["Fano's inequality", "data processing inequality", "channel capacity"]
+  },
+  {
+    "id": "ann-bsc",
+    "proofId": "shannon-channel-coding",
+    "range": { "startLine": 49, "endLine": 51 },
+    "type": "theorem",
+    "title": "Binary Symmetric Channel Capacity",
+    "content": "The binary symmetric channel BSC(p) flips each bit independently with probability $p$. Its capacity is $C = 1 - h(p)$ bits per channel use, where $h(p) = -p \\log_2 p - (1-p) \\log_2(1-p)$ is the binary entropy function. At $p = 0$ (noiseless), $C = 1$; at $p = 1/2$ (pure noise), $C = 0$. The BSC is the simplest non-trivial channel model and is the standard example in every information theory textbook. Currently proves `True`.",
+    "mathContext": "$C_{\\text{BSC}}(p) = 1 - h(p) = 1 + p\\log_2 p + (1-p)\\log_2(1-p)$",
+    "significance": "supporting",
+    "relatedConcepts": ["binary symmetric channel", "binary entropy function", "channel capacity computation"],
+    "prerequisites": ["binary entropy", "Real.log", "channel capacity definition"]
+  }
+]

--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -61,43 +61,51 @@
   "sections": [
     {
       "id": "introduction",
-      "title": "Introduction",
+      "title": "Module Docstring and Imports",
       "startLine": 1,
-      "endLine": 32,
-      "summary": "Historical significance and statement of the noisy channel coding theorem.",
-      "mathContext": "Shannon (1948): reliable communication at rate $R$ is possible iff $R \\leq C = \\max_{p(x)} I(X;Y)$. This is the central result of information theory, establishing that noise does not preclude reliable communication."
-    },
-    {
-      "id": "channel-model",
-      "title": "Discrete Memoryless Channel",
-      "startLine": 34,
-      "endLine": 78,
-      "summary": "Formal definition of a discrete memoryless channel, codes, and error probability.",
-      "mathContext": "A discrete memoryless channel (DMC) is specified by finite alphabets $\\mathcal{X}, \\mathcal{Y}$ and transition probabilities $p(y|x)$. An $(M, n)$ code consists of an encoder $\\{1,\\ldots,M\\} \\to \\mathcal{X}^n$ and a decoder $\\mathcal{Y}^n \\to \\{1,\\ldots,M\\}$. The rate is $R = \\frac{\\log M}{n}$ bits per channel use."
+      "endLine": 13,
+      "summary": "Overview of the noisy channel coding theorem: reliable communication at any rate below channel capacity C = max I(X;Y). Attribution to Claude Shannon (1948).",
+      "mathContext": "Shannon (1948): reliable communication at rate $R$ is possible iff $R < C = \\max_{p(x)} I(X;Y)$."
     },
     {
       "id": "capacity-definition",
-      "title": "Channel Capacity",
-      "startLine": 80,
-      "endLine": 120,
-      "summary": "Definition of channel capacity as the maximum mutual information over input distributions.",
-      "mathContext": "Channel capacity $C = \\max_{p(x)} I(X;Y) = \\max_{p(x)} [H(Y) - H(Y|X)]$. Since $H(Y|X) = \\sum_x p(x) H(Y|X=x)$ depends only on the channel (not the input distribution), maximizing $I(X;Y)$ reduces to maximizing $H(Y)$. The maximum exists by compactness and concavity."
+      "title": "Channel Capacity Definition",
+      "startLine": 15,
+      "endLine": 19,
+      "summary": "Defines channel capacity as a noncomputable real number. The definition takes a channel transition matrix W : α → β → ℝ and should return the maximum mutual information over input distributions. Currently sorry'd because formalizing the optimization over the probability simplex requires measure theory.",
+      "mathContext": "$C = \\max_{p(x)} I(X;Y) = \\max_{p(x)} [H(Y) - H(Y|X)]$"
     },
     {
-      "id": "random-coding",
-      "title": "Random Coding Achievability",
-      "startLine": 122,
-      "endLine": 198,
-      "summary": "Proof that rates below capacity are achievable using randomly generated codebooks and joint typicality decoding.",
-      "mathContext": "Generate $2^{nR}$ codewords i.i.d. from $p^*(x)$ (capacity-achieving distribution). Decode $y^n$ to the unique $x^n(w)$ jointly typical with $y^n$. Error events: (1) true pair not jointly typical (probability $\\to 0$ by joint AEP); (2) wrong codeword jointly typical (probability $\\leq 2^{nR} \\cdot 2^{-nI(X;Y)} \\to 0$ when $R < C$)."
+      "id": "fano-inequality",
+      "title": "Fano's Inequality",
+      "startLine": 21,
+      "endLine": 27,
+      "summary": "Fano's inequality bounds conditional entropy H(X|Y) in terms of error probability. Currently proves True (placeholder). The full statement requires defining conditional entropy and binary entropy function h(P_e).",
+      "mathContext": "$H(X|Y) \\leq h(P_e) + P_e \\cdot \\log(|\\mathcal{X}| - 1)$"
     },
     {
-      "id": "fano-converse",
-      "title": "Fano Inequality and Converse",
-      "startLine": 200,
-      "endLine": 265,
-      "summary": "Fano's inequality bounds error probability from below, proving rates above capacity are impossible.",
-      "mathContext": "Fano's inequality: $H(W|\\hat{W}) \\leq 1 + P_e \\log(M-1)$ where $W$ is the message and $\\hat{W}$ is the decoded message. Combined with $H(W|\\hat{W}) \\geq H(W|Y^n) \\geq H(W) - nC = nR - nC$, this gives $P_e \\geq 1 - \\frac{nC + 1}{nR} \\to 1 - C/R > 0$ when $R > C$."
+      "id": "achievability",
+      "title": "Channel Coding Achievability",
+      "startLine": 29,
+      "endLine": 36,
+      "summary": "Achievability half: for any rate R < C, there exists a code with vanishing error probability as block length grows. Currently proves True (placeholder). The full proof would construct a random codebook and use joint typicality decoding.",
+      "mathContext": "$R < C \\implies \\exists$ code sequence with $P_e^{(n)} \\to 0$"
+    },
+    {
+      "id": "converse",
+      "title": "Channel Coding Converse",
+      "startLine": 38,
+      "endLine": 45,
+      "summary": "Converse half: for any rate R > C, error probability is bounded away from zero. Currently proves True (placeholder). Uses Fano's inequality to show error probability cannot vanish.",
+      "mathContext": "$R > C \\implies P_e^{(n)} \\not\\to 0$"
+    },
+    {
+      "id": "bsc-capacity",
+      "title": "Binary Symmetric Channel Capacity",
+      "startLine": 47,
+      "endLine": 53,
+      "summary": "Computes the capacity of the binary symmetric channel BSC(p): C = 1 - h(p) bits, where h is the binary entropy function. Currently proves True (placeholder). This is the most important concrete channel capacity computation.",
+      "mathContext": "$C_{\\text{BSC}}(p) = 1 - h(p) = 1 + p\\log p + (1-p)\\log(1-p)$"
     }
   ],
   "crossReferences": [
@@ -121,8 +129,10 @@
     "summary": "The noisy channel coding theorem establishes that reliable communication at rate R is possible if and only if R is below the channel capacity C = max I(X;Y). The achievability proof via random coding and joint typicality decoding is one of the most celebrated probabilistic existence arguments in mathematics. The converse via Fano's inequality provides the matching impossibility result.",
     "implications": "This formalization provides:\n\n**1. The Central Result of Information Theory**\nChannel capacity as the fundamental limit of reliable communication, with both achievability and converse proofs machine-checked.\n\n**2. Random Coding as Probabilistic Method**\nThe random coding proof is historically one of the first and most influential uses of the probabilistic method, predating even Erdos's 1947 Ramsey bound.\n\n**3. Fano's Inequality**\nA reusable converse tool that converts entropy bounds into error probability bounds, applicable far beyond channel coding.\n\n**4. Foundation for Modern Coding Theory**\nThe gap between Shannon's existential proof and practical capacity-achieving codes (turbo codes, LDPC, polar codes) drove decades of engineering and mathematical research.\n\n**5. Connection to Computational Complexity**\nChannel coding has deep connections to computational complexity via list decoding and pseudorandomness.",
     "openQuestions": [
-      "Can specific channel capacities (BSC, BEC, AWGN) be computed formally?",
-      "What is the connection to the probabilistic method (random coding)?"
+      "Can specific channel capacities (BSC, BEC, AWGN) be computed formally beyond the placeholder True statements?",
+      "Formalize the random coding argument using Mathlib's probability theory — requires joint typicality and the AEP",
+      "Can Fano's inequality be stated with the full H(X|Y) <= h(P_e) + P_e*log(|X|-1) rather than as True?",
+      "Formalize the binary entropy function h(p) = -p*log(p) - (1-p)*log(1-p) and its properties"
     ]
   }
 }


### PR DESCRIPTION
## Summary
Enrichment pass for `shannon-channel-coding` (quality 45 → enriched, 0 prior passes).

- **6 annotations** created covering capacity definition, Fano's inequality, achievability, converse, BSC capacity
- **Sections fixed**: line ranges corrected from fictional 32-265 to actual file extent (53 lines)
- **openQuestions** expanded from 2 → 4
- All `True` placeholders noted in annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)