### PR TITLE
Research: Multi-problem axiom cleanup (62 unused axioms, 3 files)

### DIFF
--- a/proofs/Proofs/Erdos1085Problem.lean
+++ b/proofs/Proofs/Erdos1085Problem.lean
@@ -28,10 +28,7 @@
   - Clarkson et al., "Combinatorial complexity bounds..." (1990)
 -/
 
-import Mathlib.Analysis.InnerProductSpace.EuclideanDist
-import Mathlib.Data.Finset.Card
-import Mathlib.Data.Real.Basic
-import Mathlib.Data.Nat.Log
+import Mathlib.Tactic
 
 open Nat Finset
 
@@ -73,50 +70,11 @@ configurations in ℝ^d.
 This is the central function of the problem. -/
 axiom maxUnitDistances (d n : ℕ) : ℕ
 
-/-- maxUnitDistances d n is achieved by some configuration. -/
-axiom maxUnitDistances_spec (d n : ℕ) :
-  ∃ P : PointConfig d n, unitDistanceCount P = maxUnitDistances d n
-
-/-- maxUnitDistances d n is an upper bound for all configurations. -/
-axiom maxUnitDistances_bound (d n : ℕ) (P : PointConfig d n) :
-  unitDistanceCount P ≤ maxUnitDistances d n
-
 /-
-## Trivial Bounds
+## The 2D Problem Remains OPEN
 
-The number of pairs is at most n choose 2 = n(n-1)/2.
+The gap between n^(1+o(1)) and n^(4/3) has been open since the 1940s.
 -/
-
-/-- Trivial upper bound: at most n choose 2 pairs can be unit distance. -/
-axiom trivial_upper_bound (d n : ℕ) :
-  maxUnitDistances d n ≤ n * (n - 1) / 2
-
-/-- For n ≥ 2 and d ≥ 1, we can achieve at least n - 1 unit distances
-(place points on a line at integer positions). -/
-axiom linear_lower_bound (d n : ℕ) (hd : 1 ≤ d) (hn : 2 ≤ n) :
-  n - 1 ≤ maxUnitDistances d n
-
-/-
-## Dimension 2: The Classical Unit Distance Problem
-
-This is Problem #90 on erdosproblems.com (and closely related to #1085).
-The gap between n^(1+ε) and n^(4/3) has been open since the 1940s.
--/
-
-/-- **Erdős Lower Bound (1946)**: f_2(n) > n^(1 + c/log log n) for some c > 0.
-
-The construction uses a carefully chosen grid-like structure. -/
-axiom erdos_1946_lower_d2 :
-  ∃ c : ℕ, c > 0 ∧ ∀ n ≥ 16,
-    n * n / (Nat.log 2 (Nat.log 2 n) + 1) ≤ maxUnitDistances 2 n * (Nat.log 2 (Nat.log 2 n) + 1)
-
-/-- **Spencer-Szemerédi-Trotter Upper Bound (1984)**: f_2(n) = O(n^(4/3)).
-
-This landmark result uses the crossing number inequality for graphs.
-It improved Erdős's original O(n^(3/2)) bound. -/
-axiom sst_1984_upper_d2 :
-  ∃ C : ℕ, C > 0 ∧ ∀ n ≥ 1,
-    maxUnitDistances 2 n ≤ C * n * Nat.sqrt n / 10
 
 /-- The 2D problem remains OPEN: the gap between n^(1+o(1)) and n^(4/3) is unknown.
 
@@ -125,39 +83,16 @@ def erdos_1085_2d_conjecture : Prop :=
   ∃ C : ℕ, C > 0 ∧ ∀ n ≥ 16,
     maxUnitDistances 2 n ≤ C * n * n / (Nat.log 2 (Nat.log 2 n) + 1)
 
-/-- The 2D conjecture remains open. -/
-axiom erdos_1085_2d_open :
-  ¬(erdos_1085_2d_conjecture ↔ True) ∧ ¬(erdos_1085_2d_conjecture ↔ False)
-
 /-
 ## Dimension 3
 
 The 3D case is also challenging with a gap between lower and upper bounds.
 -/
 
-/-- **Erdős Lower Bound (1960)**: f_3(n) = Ω(n^(4/3) log log n).
-
-The construction generalizes the 2D approach using spherical caps. -/
-axiom erdos_1960_lower_d3 :
-  ∃ c : ℕ, c > 0 ∧ ∀ n ≥ 16,
-    c * n * Nat.sqrt n * Nat.log 2 (Nat.log 2 n) / 1000 ≤ maxUnitDistances 3 n
-
-/-- **Clarkson-Edelsbrunner-Guibas-Sharir-Welzl Upper Bound (1990)**:
-f_3(n) = O(n^(3/2) β(n)) where β is the inverse Ackermann function.
-
-This uses sophisticated techniques from computational geometry. -/
-axiom cegsw_1990_upper_d3 :
-  ∃ C : ℕ, C > 0 ∧ ∀ n ≥ 1,
-    maxUnitDistances 3 n ≤ C * n * Nat.sqrt n
-
 /-- The 3D problem is partially open: Is f_3(n) = O(n^(4/3) log log n)? -/
 def erdos_1085_3d_open_question : Prop :=
   ∃ C : ℕ, C > 0 ∧ ∀ n ≥ 16,
     maxUnitDistances 3 n ≤ C * n * Nat.sqrt n * Nat.log 2 (Nat.log 2 n) / 100
-
-/-- The 3D tight bound question remains open. -/
-axiom erdos_1085_3d_open :
-  ¬(erdos_1085_3d_open_question ↔ True) ∧ ¬(erdos_1085_3d_open_question ↔ False)
 
 /-
 ## Dimension ≥ 4: The High-Dimensional Case
@@ -171,82 +106,6 @@ Every point on one circle is distance 1 from every point on the other circle
 (in the right configuration), giving ~n²/4 unit distances for d = 4. -/
 def lenzCoefficient (d : ℕ) : ℚ :=
   if d ≥ 2 then (d / 2 - 1 : ℕ) / (2 * (d / 2) : ℕ) else 0
-
-/-- **Lenz Lower Bound (d ≥ 4)**: f_d(n) ≥ (p-1)/(2p) · n² - O(1).
-
-Lenz's elegant construction uses orthogonal circles in ℝ^d. -/
-axiom lenz_lower_d4 (d : ℕ) (hd : 4 ≤ d) :
-  ∃ C : ℕ, ∀ n ≥ 1,
-    (d / 2 - 1) * n * n / (2 * (d / 2)) ≤ maxUnitDistances d n + C
-
-/-- **Erdős-Stone Upper Bound (d ≥ 4)**: f_d(n) ≤ ((p-1)/(2p) + o(1)) · n².
-
-This uses the Erdős-Stone theorem from extremal graph theory. -/
-axiom erdos_stone_upper_d4 (d : ℕ) (hd : 4 ≤ d) :
-  ∀ ε : ℕ, ε > 0 → ∃ N : ℕ, ∀ n ≥ N,
-    maxUnitDistances d n ≤ ((d / 2 - 1) * n * n / (2 * (d / 2))) + ε * n * n / 100
-
-/-
-## Exact Results for d ≥ 4
-
-For even dimensions ≥ 4, exact formulas are known!
--/
-
-/-- **Brass (1997)**: Exact formula for d = 4.
-f_4(n) = ⌊n²/4⌋ + n - ⌊n/2⌋ - 1 for n ≥ 3. -/
-axiom brass_1997_d4 :
-  ∀ n ≥ 3, maxUnitDistances 4 n = n * n / 4 + n - n / 2 - 1
-
-/-- **Swanepoel (2009)**: Exact formula for even d ≥ 6.
-The answer has a precise closed form. -/
-axiom swanepoel_2009_even (d : ℕ) (hd : 6 ≤ d) (heven : Even d) :
-  ∃ f : ℕ → ℕ, ∀ n ≥ 1,
-    maxUnitDistances d n = (d / 2 - 1) * n * n / (2 * (d / 2)) + f n ∧
-    f n ≤ n
-
-/-- **Erdős-Pach (1990)**: For odd d ≥ 5, tight bounds with n^(4/3) error.
-
-f_d(n) = (p-1)/(2p) · n² ± O(n^(4/3)) where p = ⌊d/2⌋. -/
-axiom erdos_pach_1990_odd (d : ℕ) (hd : 5 ≤ d) (hodd : Odd d) :
-  ∃ c₁ c₂ : ℕ, c₁ > 0 ∧ c₂ > 0 ∧ ∀ n ≥ 1,
-    (d / 2 - 1) * n * n / (2 * (d / 2)) ≤ maxUnitDistances d n + c₁ * n * Nat.sqrt n ∧
-    maxUnitDistances d n ≤ (d / 2 - 1) * n * n / (2 * (d / 2)) + c₂ * n * Nat.sqrt n
-
-/-
-## Examples and Special Values
--/
-
-/-- f_2(3) = 3: Three points forming an equilateral triangle. -/
-axiom example_d2_n3 : maxUnitDistances 2 3 = 3
-
-/-- f_2(4) = 5: The optimal configuration is not the square (which gives 4),
-but rather 4 points with 5 unit distances. -/
-axiom example_d2_n4 : maxUnitDistances 2 4 = 5
-
-/-- f_2(5) = 7: Five points can achieve 7 unit distances. -/
-axiom example_d2_n5 : maxUnitDistances 2 5 = 7
-
-/-- f_3(4) = 6: Four points forming a regular tetrahedron with edge 1. -/
-axiom example_d3_n4 : maxUnitDistances 3 4 = 6
-
-/-
-## Connections to Other Problems
-
-The unit distance problem connects to many areas:
-- Incidence geometry (point-circle incidences)
-- The distinct distances problem (Erdős Problem #35)
-- Graph drawing and the crossing number
--/
-
-/-- The unit distance graph U(n) has n vertices and f_2(n) edges.
-A key tool is the crossing number of this graph. -/
-axiom crossing_number_connection :
-  ∀ n ≥ 4, maxUnitDistances 2 n * maxUnitDistances 2 n ≤ 100 * n * n * n
-
-/-- Connection to incidence geometry: f_2(n) relates to point-circle incidences
-where all circles have radius 1. -/
-axiom incidence_bound :
-  ∀ n ≥ 1, maxUnitDistances 2 n ≤ n * n
 
 /-
 ## Summary
@@ -263,14 +122,5 @@ among n points in ℝ^d.
 
 **Main Open Question**: Is f_2(n) = n^(1+o(1)) (matching the lower bound)?
 -/
-
-/-- Summary: The high-dimensional case (d ≥ 4) is essentially solved.
-
-For d ≥ 4, f_d(n) = (p-1)/(2p) · n² + o(n²) where p = ⌊d/2⌋.
-This follows from the Lenz lower bound and Erdős-Stone upper bound. -/
-axiom high_dim_solved (d : ℕ) (hd : 4 ≤ d) :
-    ∃ C : ℕ, ∀ n ≥ 1,
-      (d / 2 - 1) * n * n / (2 * (d / 2)) ≤ maxUnitDistances d n + C ∧
-      maxUnitDistances d n ≤ (d / 2 - 1) * n * n / (2 * (d / 2)) + C * n * n / 10
 
 end Erdos1085

--- a/proofs/Proofs/Erdos305Problem.lean
+++ b/proofs/Proofs/Erdos305Problem.lean
@@ -31,11 +31,7 @@ References:
 - Erdős, Graham (1980): Problem E30 in "Old and New Problems in Combinatorics"
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Rat.Basic
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Real.Basic
-import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Tactic
 
 open Finset
 
@@ -93,18 +89,9 @@ The minimum possible maximum denominator over all Egyptian fraction
 representations of a/b.
 -/
 noncomputable def D_ab (a b : ℕ) : ℕ :=
-  if h : a < b ∧ b > 0 then
-    Nat.find (egyptian_representation_exists a b (by omega) h.1)
-    -- Actually should be: min over all representations of max denominator
+  if _ : a < b ∧ b > 0 then
+    sInf { maxDenominator S | S ∈ {S : Finset ℕ | isEgyptianRepresentation S a b} }
   else 0
-
-/--
-**D(a,b) Definition (Proper):**
-D(a,b) = min{max S : S is an Egyptian representation of a/b}
--/
-axiom D_ab_value (a b : ℕ) (hab : 0 < a) (hlt : a < b) :
-  ∃ S : Finset ℕ, isEgyptianRepresentation S a b ∧
-    ∀ T : Finset ℕ, isEgyptianRepresentation T a b → maxDenominator S ≤ maxDenominator T
 
 /--
 **D(b) Function:**
@@ -117,54 +104,7 @@ noncomputable def D_b (b : ℕ) : ℕ :=
   else 0
 
 /-
-## Part III: Known Bounds
--/
-
-/--
-**Trivial Lower Bound:**
-D(b) ≥ b for all b ≥ 2, since (b-1)/b requires denominator at least b.
--/
-axiom D_b_lower_trivial (b : ℕ) (hb : b ≥ 2) :
-  D_b b ≥ b
-
-/--
-**Lower Bound for Primes:**
-D(p) ≫ p log p for prime p.
-The representation of (p-1)/p is particularly difficult.
--/
-axiom D_prime_lower (p : ℕ) (hp : Nat.Prime p) :
-  ∃ c : ℝ, c > 0 ∧ (D_b p : ℝ) ≥ c * p * Real.log p
-
-/--
-**Bleicher-Erdős Upper Bound (1976):**
-D(b) ≪ b(log b)².
-This was the first strong upper bound.
--/
-axiom bleicher_erdos_bound :
-  ∃ C : ℝ, C > 0 ∧ ∀ b : ℕ, b ≥ 2 →
-    (D_b b : ℝ) ≤ C * b * (Real.log b)^2
-
-/--
-**Yokota's Improvement (1988):**
-D(b) ≪ b(log b)(log log b)⁴(log log log b)².
-This solved Erdős Problem #305.
--/
-axiom yokota_bound :
-  ∃ C : ℝ, C > 0 ∧ ∀ b : ℕ, b ≥ 16 →
-    (D_b b : ℝ) ≤ C * b * Real.log b *
-      (Real.log (Real.log b))^4 * (Real.log (Real.log (Real.log b)))^2
-
-/--
-**Liu-Sawhney Improvement (2024):**
-D(b) ≪ b(log b)(log log b)³(log log log b)^{O(1)}.
--/
-axiom liu_sawhney_bound :
-  ∃ C k : ℝ, C > 0 ∧ k > 0 ∧ ∀ b : ℕ, b ≥ 16 →
-    (D_b b : ℝ) ≤ C * b * Real.log b *
-      (Real.log (Real.log b))^3 * (Real.log (Real.log (Real.log b)))^k
-
-/-
-## Part IV: The Erdős Conjecture
+## Part III: The Erdős Conjecture
 -/
 
 /--
@@ -189,7 +129,7 @@ theorem erdos_305_solved : erdos305Conjecture := by
   sorry
 
 /-
-## Part V: The Greedy Algorithm
+## Part IV: The Greedy Algorithm
 -/
 
 /--
@@ -207,148 +147,8 @@ def greedyStep (a b : ℕ) : ℕ × ℕ × ℕ :=
     let newB := b * n
     (n, newA, newB)
 
-/--
-**Greedy Algorithm Terminates:**
-The greedy algorithm always terminates, giving an Egyptian fraction.
--/
-axiom greedy_terminates (a b : ℕ) (hab : 0 < a) (hlt : a < b) :
-  ∃ S : Finset ℕ, isEgyptianRepresentation S a b
-
-/--
-**Greedy Can Give Large Denominators:**
-The greedy algorithm can produce exponentially large denominators.
-Example: For 2/9, greedy gives 1/5 + 1/45 (max = 45), but
-optimal is 1/6 + 1/18 (max = 18).
--/
-axiom greedy_not_optimal :
-  ∃ a b : ℕ, ∃ S T : Finset ℕ,
-    isEgyptianRepresentation S a b ∧
-    isEgyptianRepresentation T a b ∧
-    -- S is from greedy, T is optimal
-    maxDenominator S > maxDenominator T
-
 /-
-## Part VI: Specific Cases
--/
-
-/--
-**Representation of 1:**
-1 = 1/2 + 1/3 + 1/6 (three terms)
-1 = 1/2 + 1/4 + 1/6 + 1/12 (four terms)
-Many representations exist.
--/
-axiom one_representations :
-  ∃ S : Finset ℕ, S = {2, 3, 6} ∧ unitFractionSum S = 1
-
-/--
-**4/n Conjecture (Erdős-Straus):**
-For n ≥ 2, 4/n = 1/a + 1/b + 1/c for positive integers a, b, c.
-Related but different problem from #305.
--/
-axiom erdos_straus_related (n : ℕ) (hn : n ≥ 2) :
-  ∃ a b c : ℕ, a ≥ 1 ∧ b ≥ 1 ∧ c ≥ 1 ∧
-    (4 : ℚ) / n = 1 / a + 1 / b + 1 / c
-
-/--
-**Egyptian Fractions of 1:**
-The number of ways to write 1 as an Egyptian fraction with largest
-denominator n grows superpolynomially.
--/
-axiom count_egyptian_one (n : ℕ) (hn : n ≥ 2) :
-  ∃ S : Finset ℕ, unitFractionSum S = 1 ∧ ∀ k ∈ S, k ≤ n
-
-/-
-## Part VII: Algorithmic Aspects
--/
-
-/--
-**Computing D(a,b):**
-Finding the optimal D(a,b) is computationally hard.
-No polynomial-time algorithm is known.
--/
-axiom D_ab_computational (a b : ℕ) (hab : 0 < a) (hlt : a < b) :
-  ∃ S : Finset ℕ, isEgyptianRepresentation S a b
-
-/--
-**Odd Greedy Algorithm:**
-A variant that uses only odd denominators.
-Every rational has an odd Egyptian fraction representation.
--/
-axiom odd_egyptian_exists (a b : ℕ) (hab : 0 < a) (hlt : a < b) (hb : Odd b) :
-  ∃ S : Finset ℕ, isEgyptianRepresentation S a b ∧ ∀ n ∈ S, Odd n
-
-/--
-**Binary Expansion Connection:**
-Representing 1 with denominators that are powers of 2 minus 1
-relates to binary expansions.
--/
-axiom binary_connection :
-  ∀ n : ℕ, n ≥ 1 → ∃ S : Finset ℕ, unitFractionSum S = (1 : ℚ) / n ∧
-    ∀ k ∈ S, ∃ m, k = 2^m - 1
-
-/-
-## Part VIII: History and Applications
--/
-
-/--
-**Ancient Egypt:**
-The Rhind Mathematical Papyrus (c. 1650 BCE) contains tables of
-Egyptian fraction representations, showing this is ancient mathematics.
--/
-axiom ancient_history :
-  ∃ S : Finset ℕ, S = {2, 4} ∧ unitFractionSum S = (3 : ℚ) / 4
-
-/--
-**Number Theory Applications:**
-Egyptian fractions arise in:
-- Diophantine equations
-- Partitions of unity
-- Additive combinatorics
--/
-axiom applications (a b : ℕ) (hab : 0 < a) (hlt : a < b) :
-  ∃ S : Finset ℕ, isEgyptianRepresentation S a b ∧ S.card ≤ b
-
-/--
-**Relationship to Harmonic Numbers:**
-The harmonic sum H_n = ∑_{k=1}^n 1/k is closely related.
-D(b) bounds involve logarithms because harmonic sums grow as log n.
--/
-axiom harmonic_connection (n : ℕ) (hn : n ≥ 1) :
-  (∑ k ∈ Finset.range n, (1 : ℝ) / (k + 1)) ≤ Real.log (n + 1) + 1
-
-/-
-## Part IX: Related Problems
--/
-
-/--
-**Length of Representation:**
-How many terms are needed? The greedy algorithm can use O(log log b) terms.
--/
-axiom length_bounds (a b : ℕ) (hab : 0 < a) (hlt : a < b) :
-  ∃ S : Finset ℕ, isEgyptianRepresentation S a b ∧
-    (S.card : ℝ) ≤ Real.log (Real.log b) + 10
-
-/--
-**Dense Egyptian Fractions:**
-Liu-Sawhney also proved: A ⊆ [1,N] with ∑ 1/n ≥ (log N)^{4/5+o(1)}
-contains a subset summing to 1.
--/
-axiom dense_egyptian_fractions (A : Finset ℕ) (N : ℕ) (hN : N ≥ 2)
-    (hA : ∀ a ∈ A, 1 ≤ a ∧ a ≤ N)
-    (hsum : (∑ a ∈ A, (1 : ℝ) / a) ≥ (Real.log N)^(4/5 : ℝ)) :
-  ∃ S ⊆ A, unitFractionSum S = 1
-
-/--
-**Conlon-Fox et al. (2024):**
-Independent proof of similar results using different methods.
--/
-axiom conlon_fox_result (b : ℕ) (hb : b ≥ 2) :
-  ∃ C : ℝ, C > 0 ∧ ∀ a : ℕ, 0 < a → a < b →
-    ∃ S : Finset ℕ, isEgyptianRepresentation S a b ∧
-      (S.sup id : ℝ) ≤ C * b * Real.log b * (Real.log (Real.log b))^3
-
-/-
-## Part X: Summary
+## Part V: Summary
 -/
 
 /--

--- a/proofs/Proofs/Erdos376Problem.lean
+++ b/proofs/Proofs/Erdos376Problem.lean
@@ -55,46 +55,6 @@ This ensures no carries when computing n + n in base p. -/
 def HasSmallDigits (n : ℕ) (p : ℕ) : Prop :=
   ∀ d ∈ n.digits p, d ≤ (p - 1) / 2
 
-/-- **Kummer's Theorem** (stated as axiom): The exact power of prime p dividing
-C(m,k) equals the number of carries when adding k + (m-k) in base p.
-
-The number of carries when adding a + b in base p equals the number of
-positions where a_i + b_i + carry_{i-1} ≥ p.
-
-We state a simplified version: the exact power is determined by the digit sums. -/
-axiom kummer_theorem (m k p : ℕ) (hp : p.Prime) :
-    ∃ carries : ℕ, p.factorization (m.choose k) = carries
-
-/-- Corollary: C(2n,n) coprime to p iff n has p-small digits. -/
-axiom centralBinom_coprime_iff_small_digits (n p : ℕ) (hp : p.Prime) (hp2 : 2 < p) :
-    n.centralBinom.Coprime p ↔ HasSmallDigits n p
-
-/-
-## Specific Conditions for 105 = 3 × 5 × 7
-
-For C(2n,n) coprime to 105, n must satisfy digit constraints in three bases.
--/
-
-/-- 105 = 3 × 5 × 7, the product of first three odd primes. -/
-theorem factorization_105 : 105 = 3 * 5 * 7 := by norm_num
-
-/-- C(2n,n) coprime to 105 requires coprimality to each prime factor. -/
-axiom coprime_105_iff (n : ℕ) :
-    n.centralBinom.Coprime 105 ↔
-    n.centralBinom.Coprime 3 ∧ n.centralBinom.Coprime 5 ∧ n.centralBinom.Coprime 7
-
-/-- For coprimality to 3: n must have only digits 0, 1 in base 3. -/
-axiom coprime_3_digits (n : ℕ) :
-    n.centralBinom.Coprime 3 ↔ ∀ d ∈ n.digits 3, d ≤ 1
-
-/-- For coprimality to 5: n must have only digits 0, 1, 2 in base 5. -/
-axiom coprime_5_digits (n : ℕ) :
-    n.centralBinom.Coprime 5 ↔ ∀ d ∈ n.digits 5, d ≤ 2
-
-/-- For coprimality to 7: n must have only digits 0, 1, 2, 3 in base 7. -/
-axiom coprime_7_digits (n : ℕ) :
-    n.centralBinom.Coprime 7 ↔ ∀ d ∈ n.digits 7, d ≤ 3
-
 /-
 ## The EGRS Theorem (1975)
 
@@ -127,24 +87,6 @@ theorem infinitely_coprime_35 : {n : ℕ | n.centralBinom.Coprime 35}.Infinite :
   exact egrs_theorem 5 7 Nat.prime_five Nat.prime_seven (by decide) (by decide)
 
 /-
-## Main Conjecture (OPEN)
-
-The question for three primes remains open!
--/
-
-/-- **Erdős Problem #376 (OPEN)**: Are there infinitely many n such that
-C(2n,n) is coprime to 105 = 3 × 5 × 7?
-
-This extends EGRS from two primes to three primes. -/
-axiom erdos_376_conjecture :
-    {n : ℕ | n.centralBinom.Coprime 105}.Infinite ∨
-    ¬{n : ℕ | n.centralBinom.Coprime 105}.Infinite
-
-/-- The positive answer would mean infinitely many 105-good integers exist. -/
-axiom erdos_376_positive_answer :
-    {n : ℕ | n.centralBinom.Coprime 105}.Infinite
-
-/-
 ## Known 105-Good Integers
 
 We verify specific small values of n that are 105-good.
@@ -165,29 +107,8 @@ theorem four_not_good : ¬Is105Good 4 := by
   unfold Is105Good
   native_decide
 
-/-- List of small 105-good values (verified computationally).
-These are n where C(2n,n) has no factors of 3, 5, or 7. -/
-axiom small_good_values : ({1} : Set ℕ) ⊆ GoodSet105
-
 /-
-## Density Considerations
-
-The set of 105-good integers is expected to be sparse but infinite.
--/
-
-/-- The density of n coprime to a single prime p is positive.
-In base p, roughly (1/2)^{log_p n} proportion satisfy small digits. -/
-axiom density_single_prime (p : ℕ) (hp : p.Prime) (hp2 : 2 < p) :
-    {n : ℕ | n.centralBinom.Coprime p}.Infinite
-
-/-- For product of k odd primes, density decreases exponentially with k. -/
-axiom density_decreases_with_primes :
-    ∀ k : ℕ, ∃ c : ℝ, c > 0 ∧
-    ∀ P : Finset ℕ, (∀ p ∈ P, Nat.Prime p ∧ 2 < p) → P.card = k →
-    ∃ d : ℝ, d ≥ c^k ∧ d > 0
-
-/-
-## Connection to Digit Sequences
+## Digit Sequence Definitions
 
 The problem is equivalent to finding n with simultaneously restricted digits
 in bases 3, 5, and 7.
@@ -201,51 +122,5 @@ def Base5Good : Set ℕ := {n | ∀ d ∈ n.digits 5, d ≤ 2}
 
 /-- The set of n with digits only in {0,1,2,3} in base 7. -/
 def Base7Good : Set ℕ := {n | ∀ d ∈ n.digits 7, d ≤ 3}
-
-/-- 105-good integers are exactly the intersection of the three base-good sets. -/
-axiom good_105_characterization :
-    GoodSet105 = Base3Good ∩ Base5Good ∩ Base7Good
-
-/-- Each individual base-good set is infinite. -/
-axiom base3Good_infinite : Base3Good.Infinite
-axiom base5Good_infinite : Base5Good.Infinite
-axiom base7Good_infinite : Base7Good.Infinite
-
-/-- The question is whether the intersection is also infinite. -/
-axiom intersection_question :
-    (Base3Good ∩ Base5Good ∩ Base7Good).Infinite ↔
-    {n : ℕ | n.centralBinom.Coprime 105}.Infinite
-
-/-
-## Historical Context
-
-The study of prime factors of central binomial coefficients has a rich history.
-Kummer's 1852 theorem provides the key tool, and EGRS 1975 established the
-two-prime case. The three-prime case remains open.
--/
-
-/-- For any prime p, there are infinitely many n with p | C(2n,n). -/
-axiom infinitely_many_divisible (p : ℕ) (hp : p.Prime) :
-    {n : ℕ | p ∣ n.centralBinom}.Infinite
-
-/-- C(2n,n) is always even for n ≥ 1. -/
-axiom centralBinom_even (n : ℕ) (hn : 1 ≤ n) : 2 ∣ n.centralBinom
-
-/-
-## Generalizations
-
-Erdős asked about other products of primes beyond 105.
--/
-
-/-- Generalization: For any finite set of odd primes P, is
-{n | C(2n,n) coprime to ∏ p ∈ P} infinite? -/
-axiom general_conjecture (P : Finset ℕ) (hP : ∀ p ∈ P, p.Prime ∧ 2 < p) :
-    {n : ℕ | n.centralBinom.Coprime (∏ p ∈ P, p)}.Infinite ∨
-    ¬{n : ℕ | n.centralBinom.Coprime (∏ p ∈ P, p)}.Infinite
-
-/-- For |P| = 2, the answer is YES (EGRS). -/
-axiom two_primes_solved (P : Finset ℕ) (hP : ∀ p ∈ P, p.Prime ∧ 2 < p)
-    (hcard : P.card = 2) :
-    {n : ℕ | n.centralBinom.Coprime (∏ p ∈ P, p)}.Infinite
 
 end Erdos376


### PR DESCRIPTION
## Summary
Delete 62 unused axioms from 3 Erdos Problem files + fix imports and a type mismatch bug.

## Changes
| File | Before | After | Deleted |
|------|--------|-------|---------|
| Erdos1085Problem | 23 axioms | 1 axiom | 22 |
| Erdos376Problem | 21 axioms | 1 axiom | 20 |
| Erdos305Problem | 21 axioms | 1 axiom | 20 |
| **Total** | **65** | **3** | **62** |

## Additional fixes
- Fix Mathlib imports (old paths → `Mathlib.Tactic`)
- Fix `D_ab` type mismatch in Erdos305 (`Nat.find` → `sInf`)

## Test plan
- [x] `docker-build.sh Proofs.Erdos1085Problem` passes
- [x] `docker-build.sh Proofs.Erdos376Problem` passes
- [x] `docker-build.sh Proofs.Erdos305Problem` passes

🤖 Generated by researcher-4