### PR TITLE
Enrich Gauss-Wantzel Theorem: rewrite annotations

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/annotations.json
@@ -1,84 +1,74 @@
-{
-  "annotations": [
-    {
-      "id": "euler-formula-bridge",
-      "type": "insight",
-      "targetLines": [30, 78],
-      "title": "Euler's Formula Bridge",
-      "content": "The fundamental connection ζₙ = exp(2πi/n) = cos(2π/n) + i·sin(2π/n) bridges complex exponentials to trigonometric functions. This decomposition enables extracting the real part cos(2π/n) from the algebraic object ζₙ.",
-      "tags": ["complex-analysis", "euler-formula", "roots-of-unity"]
-    },
-    {
-      "id": "conjugation-inverse",
-      "type": "technique",
-      "targetLines": [50, 70],
-      "title": "Conjugation as Inversion on the Unit Circle",
-      "content": "For |ζₙ| = 1, complex conjugation equals inversion: conj(ζₙ) = ζₙ⁻¹. This gives the crucial identity ζₙ + ζₙ⁻¹ = 2cos(2π/n), connecting the cyclotomic field element to the real cosine value.",
-      "tags": ["unit-circle", "conjugation", "cyclotomic-fields"]
-    },
-    {
-      "id": "zeta-pow-unity",
-      "type": "proof-step",
-      "targetLines": [79, 111],
-      "title": "Primitive Root of Unity",
-      "content": "ζₙⁿ = exp(2πi·n/n) = exp(2πi) = 1. This fundamental property makes ζₙ a root of xⁿ - 1, hence algebraic over ℚ. The proof uses Euler's formula and the periodicity of exp.",
-      "tags": ["roots-of-unity", "algebraicity"]
-    },
-    {
-      "id": "chebyshev-connection",
-      "type": "insight",
-      "targetLines": [154, 186],
-      "title": "Chebyshev Polynomial Framework",
-      "content": "Mathlib's Chebyshev polynomials satisfy Tₙ(cos θ) = cos(nθ). This provides an explicit polynomial relationship: if cos(2π/n) = c, then Tₙ(c) = cos(2π) = 1. So cos(2π/n) is a root of Tₙ(x) - 1, giving algebraicity via a concrete polynomial.",
-      "tags": ["chebyshev-polynomials", "trigonometry", "algebraicity"]
-    },
-    {
-      "id": "cyclotomic-degree",
-      "type": "proof-step",
-      "targetLines": [187, 204],
-      "title": "Cyclotomic Polynomial Degree",
-      "content": "The cyclotomic polynomial Φₙ(x) has degree φ(n) and is irreducible over ℚ. These are deep results from Mathlib (natDegree_cyclotomic and cyclotomic.irreducible_rat) that establish [ℚ(ζₙ):ℚ] = φ(n).",
-      "tags": ["cyclotomic-polynomials", "euler-totient", "irreducibility"]
-    },
-    {
-      "id": "complex-conj-order-two",
-      "type": "insight",
-      "targetLines": [206, 261],
-      "title": "Complex Conjugation Has Order 2 via Galois Theory",
-      "content": "The key proved result: using galCyclotomicEquivUnitsZMod (Gal(ℚ(ζₙ)/ℚ) ≅ (ℤ/nℤ)*), the element -1 ∈ (ℤ/nℤ)* corresponds to complex conjugation. For n ≥ 3, -1 ≠ 1 in (ℤ/nℤ)* (since n ∤ 2), giving a non-trivial automorphism σ with σ² = id. This is the deepest result proved without axioms.",
-      "tags": ["galois-theory", "conjugation", "automorphism", "cyclotomic-fields"]
-    },
-    {
-      "id": "galois-isomorphism",
-      "type": "technique",
-      "targetLines": [220, 240],
-      "title": "galCyclotomicEquivUnitsZMod in Action",
-      "content": "Mathlib's galCyclotomicEquivUnitsZMod provides the isomorphism Gal(ℚ(ζₙ)/ℚ) ≅ (ℤ/nℤ)*. This transforms the abstract question 'does conjugation have order 2?' into the concrete arithmetic question 'is -1 ≠ 1 in (ℤ/nℤ)*?', which reduces to 'does n divide 2?'.",
-      "tags": ["galois-theory", "mathlib", "cyclotomic-fields"]
-    },
-    {
-      "id": "axiom-chain",
-      "type": "insight",
-      "targetLines": [262, 371],
-      "title": "Three-Axiom Dependency Chain",
-      "content": "The remaining axioms form a clear chain: (1) maximal_real_subfield_degree: [ℚ(ζₙ)⁺:ℚ] = φ(n)/2, (2) cos_minimal_poly_degree: minimal polynomial of cos(2π/n) has degree φ(n)/2, (3) cos_extension_is_galois: ℚ(cos(2π/n))/ℚ is Galois. Each depends on the previous, requiring ~490 lines of Galois theory to eliminate.",
-      "tags": ["axioms", "galois-theory", "constructibility"]
-    },
-    {
-      "id": "cos-algebraic",
-      "type": "proof-step",
-      "targetLines": [340, 371],
-      "title": "cos(2π/n) is Algebraic over ℚ",
-      "content": "The final derived result: cos(2π/n) = (ζₙ + ζₙ⁻¹)/2 is algebraic over ℚ because ζₙ is algebraic (root of Φₙ) and algebraic numbers form a field. This connects cyclotomic theory to constructibility: the degree of the minimal polynomial determines whether cos(2π/n) is constructible.",
-      "tags": ["algebraicity", "constructibility", "cyclotomic-fields"]
-    },
-    {
-      "id": "constructibility-criterion",
-      "type": "context",
-      "targetLines": [1, 30],
-      "title": "The Gauss-Wantzel Constructibility Criterion",
-      "content": "A regular n-gon is constructible by compass and straightedge iff n is a product of a power of 2 and distinct Fermat primes (primes of the form 2^(2^k) + 1). Equivalently, cos(2π/n) is constructible iff its minimal polynomial has degree a power of 2, which happens iff φ(n)/2 is a power of 2. This file builds the algebraic infrastructure connecting cyclotomic fields to this criterion.",
-      "tags": ["constructibility", "gauss-wantzel", "fermat-primes"]
-    }
-  ]
-}
+[
+  {
+    "id": "ann-cyclotomic-setup",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-01",
+    "range": { "startLine": 42, "endLine": 55 },
+    "type": "theorem",
+    "title": "Cyclotomic Field Infrastructure",
+    "content": "Establishes that $\\mathbb{Q}(\\zeta_n)$ is a Galois extension of $\\mathbb{Q}$ with $[\\mathbb{Q}(\\zeta_n):\\mathbb{Q}] = \\varphi(n)$ (Euler's totient). All three results come directly from Mathlib's `IsCyclotomicExtension` API. The `abstractZeta` definition uses Mathlib's canonical primitive $n$-th root of unity, which is essential for `fromZetaAut` compatibility.",
+    "mathContext": "$[\\mathbb{Q}(\\zeta_n) : \\mathbb{Q}] = \\varphi(n)$; $\\zeta_n$ is a primitive $n$-th root of unity",
+    "significance": "key",
+    "relatedConcepts": ["cyclotomic extension", "Euler totient", "Galois extension", "primitive root of unity"],
+    "prerequisites": ["IsCyclotomicExtension", "Polynomial.cyclotomic.irreducible_rat", "Module.finrank"]
+  },
+  {
+    "id": "ann-conj-aut",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-01",
+    "range": { "startLine": 63, "endLine": 72 },
+    "type": "definition",
+    "title": "Complex Conjugation Automorphism",
+    "content": "Defines $\\sigma : \\mathbb{Q}(\\zeta_n) \\to \\mathbb{Q}(\\zeta_n)$ as the automorphism sending $\\zeta_n \\mapsto \\zeta_n^{-1}$. This is the algebraic analogue of complex conjugation: since $|\\zeta_n| = 1$, we have $\\overline{\\zeta_n} = \\zeta_n^{-1}$. Constructed via `fromZetaAut` with the inverse primitive root, which gives the action on $\\zeta$ immediately from the spec.",
+    "mathContext": "$\\sigma(\\zeta_n) = \\zeta_n^{-1} = \\overline{\\zeta_n}$ (complex conjugation on the unit circle)",
+    "significance": "key",
+    "relatedConcepts": ["complex conjugation", "AlgEquiv", "fromZetaAut", "unit circle"],
+    "prerequisites": ["IsCyclotomicExtension.fromZetaAut", "IsPrimitiveRoot.inv"]
+  },
+  {
+    "id": "ann-conj-ne-one",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-01",
+    "range": { "startLine": 75, "endLine": 90 },
+    "type": "theorem",
+    "title": "Conjugation is Non-Trivial for n >= 3",
+    "content": "Proves $\\sigma \\neq \\text{id}$ when $n \\geq 3$. The key idea: if $\\sigma = \\text{id}$ then $\\zeta_n^{-1} = \\zeta_n$, so $\\zeta_n^2 = 1$, meaning $\\text{ord}(\\zeta_n) \\mid 2$. But $\\text{ord}(\\zeta_n) = n \\geq 3$, contradiction. This argument elegantly uses the order of a primitive root to derive a numerical impossibility ($n \\mid 2$ fails for $n \\geq 3$).",
+    "mathContext": "$n \\geq 3 \\implies \\sigma \\neq \\text{id}$, because $\\zeta_n = \\zeta_n^{-1}$ would force $n \\mid 2$",
+    "significance": "key",
+    "relatedConcepts": ["order of elements", "primitive roots", "proof by contradiction"],
+    "prerequisites": ["orderOf_dvd_of_pow_eq_one", "IsPrimitiveRoot.eq_orderOf"]
+  },
+  {
+    "id": "ann-conj-sq",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-01",
+    "range": { "startLine": 94, "endLine": 119 },
+    "type": "theorem",
+    "title": "Conjugation Squares to Identity",
+    "content": "Proves $\\sigma^2 = \\text{id}$ via the Galois group isomorphism $\\text{Aut}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}) \\cong (\\mathbb{Z}/n\\mathbb{Z})^*$. The automorphism $\\sigma$ corresponds to $-1 \\in (\\mathbb{Z}/n\\mathbb{Z})^*$ (shown by computing that $\\zeta_n^{u+1} = 1$ forces $n \\mid (u+1)$, hence $u = -1 \\pmod{n}$). Since $(-1)^2 = 1$ in the group, $\\sigma^2 = \\text{id}$. This is the deepest technical result, using the full power of `autEquivPow`.",
+    "mathContext": "$\\sigma \\leftrightarrow -1 \\in (\\mathbb{Z}/n\\mathbb{Z})^*$ via $\\text{autEquivPow}$; $(-1)^2 = 1$ gives $\\sigma^2 = \\text{id}$",
+    "significance": "key",
+    "relatedConcepts": ["autEquivPow", "Galois group isomorphism", "ZMod units", "group algebra"],
+    "prerequisites": ["IsCyclotomicExtension.autEquivPow", "ZMod.val_lt", "eq_neg_iff_add_eq_zero"]
+  },
+  {
+    "id": "ann-order-two",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-01",
+    "range": { "startLine": 122, "endLine": 127 },
+    "type": "theorem",
+    "title": "Order Exactly 2",
+    "content": "Combines $\\sigma \\neq \\text{id}$ and $\\sigma^2 = \\text{id}$ to conclude $\\text{ord}(\\sigma) = 2$ using Mathlib's `orderOf_eq_prime`. This is the crux needed for the fixed field argument: the subgroup $\\langle \\sigma \\rangle$ has order 2, so the fixed field has index 2.",
+    "mathContext": "$\\sigma \\neq 1$ and $\\sigma^2 = 1 \\implies \\text{ord}(\\sigma) = 2$",
+    "significance": "key",
+    "relatedConcepts": ["order of automorphism", "prime order elements", "fixed field index"],
+    "prerequisites": ["orderOf_eq_prime", "conjAut_ne_one", "conjAut_sq"]
+  },
+  {
+    "id": "ann-fixed-field",
+    "proofId": "angle-trisection-oq-02-oq-03-oq-01",
+    "range": { "startLine": 134, "endLine": 136 },
+    "type": "definition",
+    "title": "Fixed Field of Complex Conjugation",
+    "content": "Defines $H = \\langle \\sigma \\rangle$ as the cyclic subgroup of $\\text{Aut}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q})$ generated by conjugation. The fixed field $\\mathbb{Q}(\\zeta_n)^H$ is the maximal real subfield (all elements fixed by complex conjugation). By the fundamental theorem of Galois theory, $[\\mathbb{Q}(\\zeta_n) : \\mathbb{Q}(\\zeta_n)^H] = |H| = 2$, so $[\\mathbb{Q}(\\zeta_n)^H : \\mathbb{Q}] = \\varphi(n)/2$.",
+    "mathContext": "$H = \\langle \\sigma \\rangle \\leq \\text{Aut}(K/\\mathbb{Q})$, $|H| = 2$; $[K^H : \\mathbb{Q}] = \\varphi(n)/2$",
+    "significance": "key",
+    "relatedConcepts": ["Galois correspondence", "fixed field", "maximal real subfield", "tower law"],
+    "prerequisites": ["Subgroup.zpowers", "IntermediateField.fixedField"]
+  }
+]


### PR DESCRIPTION
## Summary
Enrichment pass for `angle-trisection-oq-02-oq-03-oq-01` (quality 45 → enriched, 0 prior passes).

- **Rewrote all annotations** from old format (targetLines, no proofId/mathContext) to proper schema
- **6 annotations** covering: cyclotomic setup, conjAut definition, σ≠id proof, σ²=id proof via autEquivPow, order-2 result, fixed field subgroup
- All annotations have `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- Fixed `{annotations:[]}` wrapper to flat `[]` array

## Notes
- `status: "verified"` with 0 sorries is correct (but meta says axiomCount: 0 while description says "3 axioms" — may need investigation)
- Sections and meta.json already comprehensive, left unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)