### PR TITLE
Enrich Shannon Source Coding Theorem

### DIFF
--- a/src/data/proofs/shannon-source-coding/annotations.json
+++ b/src/data/proofs/shannon-source-coding/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header-context",
+    "proofId": "shannon-source-coding",
+    "range": { "startLine": 1, "endLine": 11 },
+    "type": "context",
+    "title": "Shannon Source Coding Theorem",
+    "content": "This module formalizes Shannon's source coding theorem (1948): the entropy $H(X)$ is the fundamental limit of lossless data compression. Data from a source with entropy $H$ can be compressed to $H + \\varepsilon$ bits per symbol, but not below $H - \\varepsilon$, with asymptotically zero error probability. This is the 'data compression' half of Shannon's foundational 1948 paper, complementing the channel coding theorem.",
+    "mathContext": "Shannon source coding: for an i.i.d. source with entropy $H(X) = -\\sum_x p(x)\\log p(x)$, lossless compression to rate $R$ bits/symbol is achievable iff $R > H(X)$.",
+    "significance": "context",
+    "relatedConcepts": ["entropy", "data compression", "typical sequences", "AEP", "Kraft inequality"],
+    "prerequisites": ["Shannon entropy", "probability distributions", "Fintype", "logarithms"]
+  },
+  {
+    "id": "ann-aep",
+    "proofId": "shannon-source-coding",
+    "range": { "startLine": 15, "endLine": 18 },
+    "type": "technique",
+    "title": "Asymptotic Equipartition Property (AEP)",
+    "content": "The AEP states that for i.i.d. sequences, the normalized log-probability converges to the entropy: $-\\frac{1}{n}\\log p(X_1,\\ldots,X_n) \\to H(X)$ in probability. This is the information-theoretic analogue of the law of large numbers. The AEP partitions sequences into a 'typical set' of roughly $2^{nH}$ sequences that carry almost all the probability, and an 'atypical set' of negligible probability. Currently a placeholder.",
+    "mathContext": "$-\\frac{1}{n}\\log p(X_1^n) \\xrightarrow{P} H(X)$ as $n \\to \\infty$. By the WLLN applied to $-\\log p(X_i)$, since $E[-\\log p(X)] = H(X)$.",
+    "significance": "key",
+    "relatedConcepts": ["law of large numbers", "typical set", "information-theoretic convergence", "entropy rate"],
+    "prerequisites": ["i.i.d. sequences", "weak law of large numbers", "entropy definition"]
+  },
+  {
+    "id": "ann-typical-set",
+    "proofId": "shannon-source-coding",
+    "range": { "startLine": 22, "endLine": 26 },
+    "type": "technique",
+    "title": "Typical Set Size Bound",
+    "content": "The typical set $A_\\varepsilon^{(n)}$ contains sequences whose empirical entropy is within $\\varepsilon$ of $H(X)$. Two key properties: (1) $|A_\\varepsilon^{(n)}| \\leq 2^{n(H+\\varepsilon)}$, bounding the number of typical sequences; (2) $P[A_\\varepsilon^{(n)}] \\to 1$ as $n \\to \\infty$. Together these mean that almost all probability concentrates on a set of size roughly $2^{nH}$, which is exponentially smaller than $|\\mathcal{X}|^n$ when $H < \\log|\\mathcal{X}|$.",
+    "mathContext": "$A_\\varepsilon^{(n)} = \\{x^n : |{-\\frac{1}{n}\\log p(x^n)} - H| < \\varepsilon\\}$. Then $|A_\\varepsilon^{(n)}| \\leq 2^{n(H+\\varepsilon)}$ and $\\Pr[A_\\varepsilon^{(n)}] \\to 1$.",
+    "significance": "key",
+    "relatedConcepts": ["typical set", "entropy coding", "high-probability set", "exponential growth rate"],
+    "prerequisites": ["AEP", "cardinality bounds from probability", "exponential functions"]
+  },
+  {
+    "id": "ann-achievability",
+    "proofId": "shannon-source-coding",
+    "range": { "startLine": 30, "endLine": 34 },
+    "type": "technique",
+    "title": "Source Coding Achievability",
+    "content": "Achievability: assign unique $n(H+\\varepsilon)$-bit codewords to each typical sequence (there are at most $2^{n(H+\\varepsilon)}$ of them). Atypical sequences get a generic error symbol. Since $P[\\text{atypical}] \\to 0$, the error probability vanishes and the rate $H + \\varepsilon$ is achievable for any $\\varepsilon > 0$. This is the fundamental reason entropy measures compressibility.",
+    "mathContext": "For rate $R > H(X)$: encode typical sequences with $\\lceil n(H+\\varepsilon) \\rceil$ bits. Error probability $= \\Pr[X^n \\notin A_\\varepsilon^{(n)}] \\to 0$.",
+    "significance": "key",
+    "relatedConcepts": ["fixed-to-variable coding", "Huffman coding", "arithmetic coding", "typical set coding"],
+    "prerequisites": ["typical set size bound", "binary encoding", "rate definition"]
+  },
+  {
+    "id": "ann-converse",
+    "proofId": "shannon-source-coding",
+    "range": { "startLine": 38, "endLine": 42 },
+    "type": "technique",
+    "title": "Source Coding Converse",
+    "content": "The converse shows rates below entropy are impossible: any code with rate $R < H - \\varepsilon$ has error probability bounded away from 0. The proof uses the AEP: the typical set has at least $2^{n(H-\\varepsilon)}$ elements, but a rate-$R$ code can only distinguish $2^{nR}$ messages. When $R < H$, the code cannot represent all typical sequences, so decoding error persists.",
+    "mathContext": "For rate $R < H(X)$: the typical set has $|A_\\varepsilon^{(n)}| \\geq (1-\\varepsilon)2^{n(H-\\varepsilon)}$ elements but only $2^{nR}$ codewords are available. Error probability $\\geq 1 - 2^{nR}/2^{n(H-\\varepsilon)} \\to 1$.",
+    "significance": "key",
+    "relatedConcepts": ["counting argument", "pigeonhole principle", "entropy as compression limit", "converse bound"],
+    "prerequisites": ["typical set lower bound", "rate vs typical set size", "AEP"]
+  }
+]

--- a/src/data/proofs/shannon-source-coding/meta.json
+++ b/src/data/proofs/shannon-source-coding/meta.json
@@ -58,44 +58,44 @@
   },
   "sections": [
     {
-      "id": "introduction",
-      "title": "Introduction",
+      "id": "header-imports",
+      "title": "Header and Imports",
       "startLine": 1,
-      "endLine": 28,
-      "summary": "Historical context and the central question of lossless compression limits.",
-      "mathContext": "Shannon source coding theorem (1948): the entropy $H(X)$ is the minimum average number of bits per symbol for lossless compression of an i.i.d. source. This is the first fundamental theorem of information theory."
+      "endLine": 11,
+      "summary": "Module docstring describing the source coding theorem: entropy as the compression limit, achievability via typical set coding, converse via AEP.",
+      "mathContext": "Shannon (1948): $H(X)$ is the minimum achievable compression rate for an i.i.d. source."
     },
     {
       "id": "aep",
       "title": "Asymptotic Equipartition Property",
-      "startLine": 30,
-      "endLine": 82,
-      "summary": "The AEP: log-probability per symbol converges to entropy, concentrating probability on a small typical set.",
-      "mathContext": "AEP: for i.i.d. $X_1, \\ldots, X_n \\sim p$, $-\\frac{1}{n} \\log p(X^n) \\xrightarrow{P} H(X)$ by the weak law of large numbers applied to $-\\log p(X_i)$, which has mean $H(X)$."
+      "startLine": 13,
+      "endLine": 18,
+      "summary": "AEP: normalized log-probability converges to entropy in probability. Placeholder proving True.",
+      "mathContext": "$-\\frac{1}{n}\\log p(X_1^n) \\xrightarrow{P} H(X)$ by the weak law of large numbers."
     },
     {
-      "id": "typical-sets",
-      "title": "Typical Sets",
-      "startLine": 84,
-      "endLine": 132,
-      "summary": "Definition and properties of the typical set: high probability, bounded cardinality.",
-      "mathContext": "The $\\varepsilon$-typical set $T_\\varepsilon^{(n)} = \\{x^n : 2^{-n(H+\\varepsilon)} \\leq p(x^n) \\leq 2^{-n(H-\\varepsilon)}\\}$ satisfies: $\\Pr[T_\\varepsilon^{(n)}] \\geq 1 - \\varepsilon$ for large $n$, $|T_\\varepsilon^{(n)}| \\leq 2^{n(H+\\varepsilon)}$, and $|T_\\varepsilon^{(n)}| \\geq (1-\\varepsilon) 2^{n(H-\\varepsilon)}$."
+      "id": "typical-set",
+      "title": "Typical Set Size Bound",
+      "startLine": 20,
+      "endLine": 26,
+      "summary": "Typical set has at most $2^{n(H+\\varepsilon)}$ elements and probability approaching 1. Placeholder.",
+      "mathContext": "$|A_\\varepsilon^{(n)}| \\leq 2^{n(H+\\varepsilon)}$ and $\\Pr[A_\\varepsilon^{(n)}] \\to 1$."
     },
     {
       "id": "achievability",
-      "title": "Achievability: Compression to H(X) Bits",
-      "startLine": 134,
-      "endLine": 185,
-      "summary": "Construction of a near-optimal code by encoding only typical sequences.",
-      "mathContext": "Achievability: index the $|T_\\varepsilon^{(n)}| \\leq 2^{n(H+\\varepsilon)}$ typical sequences with $n(H+\\varepsilon)+1$ bits. Flag atypical sequences (probability $\\leq \\varepsilon$) with a special prefix. Overall rate: $H + \\varepsilon + O(1/n) \\to H$."
+      "title": "Source Coding Achievability",
+      "startLine": 28,
+      "endLine": 34,
+      "summary": "Rates above entropy are achievable: encode typical sequences with $n(H+\\varepsilon)$ bits. Placeholder.",
+      "mathContext": "For $R > H(X)$: $P_e^{(n)} \\to 0$ as $n \\to \\infty$ by typical set coding."
     },
     {
       "id": "converse",
-      "title": "Converse: H(X) Bits Are Necessary",
-      "startLine": 187,
-      "endLine": 235,
-      "summary": "No code with rate below H(X) can achieve vanishing error probability.",
-      "mathContext": "Converse: a code mapping $\\{1, \\ldots, 2^{nR}\\}$ to $\\mathcal{X}^n$ can recover at most $2^{nR}$ source sequences. If $R < H - \\varepsilon$, these sequences have total probability at most $2^{nR} \\cdot 2^{-n(H-\\varepsilon)} = 2^{-n\\varepsilon} \\to 0$, so error probability $\\to 1$."
+      "title": "Source Coding Converse",
+      "startLine": 36,
+      "endLine": 44,
+      "summary": "Rates below entropy are impossible: error probability bounded away from 0. Placeholder.",
+      "mathContext": "For $R < H(X)$: $P_e \\geq 1 - 2^{n(R-H+\\varepsilon)} \\to 1$."
     }
   ],
   "crossReferences": [
@@ -114,7 +114,9 @@
     "summary": "The Shannon source coding theorem establishes that entropy H(X) is the fundamental limit of lossless data compression. The proof via the Asymptotic Equipartition Property shows that long i.i.d. sequences concentrate their probability mass on a typical set of approximately 2^(nH) sequences, which can be encoded with H bits per symbol. The converse shows that any code using fewer than H bits per symbol must incur vanishing reliability.",
     "implications": "This formalization provides:\n\n**1. Operational Meaning of Entropy**\nH(X) is not just an abstract measure -- it is the minimum compression rate, giving entropy a concrete operational interpretation.\n\n**2. AEP as a Fundamental Tool**\nThe Asymptotic Equipartition Property is used throughout information theory, not just in source coding. It underlies channel coding proofs, rate-distortion theory, and network information theory.\n\n**3. Typical Set Methodology**\nThe typical set construction formalized here is the template for virtually all information-theoretic achievability proofs.\n\n**4. Foundation for Lossy Compression**\nThe lossless source coding theorem is the starting point for rate-distortion theory, which characterizes lossy compression limits.",
     "openQuestions": [
-      "Can rate-distortion theory be formalized as an extension?"
+      "Can rate-distortion theory (lossy compression with distortion constraint) be formalized as an extension of the lossless theorem?",
+      "Can Huffman coding be proved optimal among prefix-free codes in Lean, providing a constructive complement to the existential source coding theorem?",
+      "Can the AEP be formalized using Mathlib's probability measure framework, connecting to the weak law of large numbers?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Created `annotations.json` with 5 annotations (AEP, typical set, achievability, converse)
- Fixed `sections`: 5 fake sections (lines to 235) → 5 accurate sections for 44-line file
- Expanded `openQuestions` from 1 to 3 (rate-distortion, Huffman, AEP formalization)

## Enrichment Details
**Target**: `shannon-source-coding` (quality: 45, passes: 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)