### PR TITLE
Enrich Shannon Entropy

### DIFF
--- a/src/data/proofs/shannon-entropy/annotations.json
+++ b/src/data/proofs/shannon-entropy/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-entropy-def",
+    "proofId": "shannon-entropy",
+    "range": { "startLine": 22, "endLine": 24 },
+    "type": "definition",
+    "title": "Shannon Entropy Definition",
+    "content": "Defines Shannon entropy $H(X) = -\\sum_x p(x) \\ln p(x)$ for a discrete probability distribution on a `Fintype`. The definition uses `Real.log` (natural logarithm), not $\\log_2$, so entropy is measured in nats rather than bits. The convention $0 \\cdot \\ln 0 = 0$ is handled by the `if p x = 0 then 0` guard, which is mathematically correct since $\\lim_{t \\to 0^+} t \\ln t = 0$. The definition is `noncomputable` because `Real.log` is noncomputable.",
+    "mathContext": "$H(X) = -\\sum_{x \\in \\mathcal{X}} p(x) \\ln p(x)$ with $0 \\ln 0 := 0$",
+    "significance": "key",
+    "relatedConcepts": ["Shannon entropy", "information content", "0 log 0 convention", "bits vs nats"],
+    "prerequisites": ["Fintype", "Real.log", "Finset.sum"]
+  },
+  {
+    "id": "ann-entropy-nonneg",
+    "proofId": "shannon-entropy",
+    "range": { "startLine": 27, "endLine": 29 },
+    "type": "theorem",
+    "title": "Entropy Non-Negativity",
+    "content": "Shannon entropy is non-negative: $H(X) \\geq 0$. This follows from the fact that $0 \\leq p(x) \\leq 1$ implies $\\ln p(x) \\leq 0$, so $-p(x) \\ln p(x) \\geq 0$ for each term. The proof requires showing that $p(x) \\leq 1$ (from $p(x) \\geq 0$ and $\\sum p = 1$) and then using `Real.log_nonpos` for $0 < p(x) \\leq 1$. Currently sorry'd.",
+    "mathContext": "$H(X) \\geq 0$ with equality iff $X$ is deterministic ($p(x_0) = 1$ for some $x_0$)",
+    "significance": "key",
+    "relatedConcepts": ["non-negativity", "deterministic distributions", "log properties"],
+    "prerequisites": ["Real.log_nonpos", "Finset.sum_nonneg"]
+  },
+  {
+    "id": "ann-max-entropy",
+    "proofId": "shannon-entropy",
+    "range": { "startLine": 32, "endLine": 34 },
+    "type": "theorem",
+    "title": "Maximum Entropy Principle",
+    "content": "The uniform distribution maximizes entropy: $H(X) \\leq \\ln |\\mathcal{X}|$ for any distribution on $\\mathcal{X}$. This is the information-theoretic formulation of 'maximum uncertainty = maximum entropy'. The proof follows from the Gibbs inequality with $q = $ uniform: $D(p \\| \\text{unif}) \\geq 0$ gives $H(p) \\leq -\\sum p(x) \\ln(1/|\\mathcal{X}|) = \\ln |\\mathcal{X}|$. Currently sorry'd.",
+    "mathContext": "$H(X) \\leq \\ln |\\mathcal{X}|$ with equality iff $p(x) = 1/|\\mathcal{X}|$ for all $x$",
+    "significance": "key",
+    "relatedConcepts": ["maximum entropy principle", "uniform distribution", "Jaynes principle"],
+    "prerequisites": ["Gibbs inequality", "Fintype.card", "Real.log"]
+  },
+  {
+    "id": "ann-gibbs",
+    "proofId": "shannon-entropy",
+    "range": { "startLine": 37, "endLine": 40 },
+    "type": "theorem",
+    "title": "Gibbs Inequality (KL Divergence Non-Negativity)",
+    "content": "The Gibbs inequality states $H(p) \\leq -\\sum p(x) \\ln q(x)$, equivalently $D(p \\| q) = \\sum p(x) \\ln(p(x)/q(x)) \\geq 0$. This is the master inequality of information theory — essentially all entropy inequalities follow from it. The proof uses Jensen's inequality: $-\\ln$ is convex, so $\\sum p(x) (-\\ln q(x)) \\geq -\\ln(\\sum p(x) q(x))$, but actually the standard proof uses $\\ln t \\leq t - 1$ (equivalent to Jensen for $-\\ln$). The requirement $q(x) > 0$ for all $x$ avoids division by zero. Currently sorry'd.",
+    "mathContext": "$D(p \\| q) = \\sum_x p(x) \\ln \\frac{p(x)}{q(x)} \\geq 0$ (Gibbs inequality / information inequality)",
+    "significance": "key",
+    "relatedConcepts": ["Gibbs inequality", "KL divergence", "Jensen's inequality", "relative entropy"],
+    "prerequisites": ["Real.log_le_sub_one_of_le", "Finset.sum", "probability distributions"]
+  },
+  {
+    "id": "ann-log-sum",
+    "proofId": "shannon-entropy",
+    "range": { "startLine": 43, "endLine": 46 },
+    "type": "theorem",
+    "title": "Log-Sum Inequality",
+    "content": "The log-sum inequality: $\\sum a_i \\ln(a_i/b_i) \\geq (\\sum a_i) \\ln((\\sum a_i)/(\\sum b_i))$ for non-negative $a_i$ and positive $b_i$. This is a generalization of the Gibbs inequality and is proved using the convexity of $f(t) = t \\ln t$ (or equivalently, Jensen's inequality). It implies Gibbs when $a_i = p(x_i)$ and $b_i = q(x_i)$. The log-sum inequality is the key tool for proving the data processing inequality and strong subadditivity. Currently sorry'd.",
+    "mathContext": "$\\sum_i a_i \\ln \\frac{a_i}{b_i} \\geq \\left(\\sum_i a_i\\right) \\ln \\frac{\\sum_i a_i}{\\sum_i b_i}$",
+    "significance": "key",
+    "relatedConcepts": ["log-sum inequality", "convexity of t log t", "data processing inequality", "strong subadditivity"],
+    "prerequisites": ["convexity", "Jensen's inequality", "Finset.sum"]
+  }
+]

--- a/src/data/proofs/shannon-entropy/meta.json
+++ b/src/data/proofs/shannon-entropy/meta.json
@@ -60,51 +60,43 @@
   "sections": [
     {
       "id": "introduction",
-      "title": "Introduction",
+      "title": "Module Docstring and Imports",
       "startLine": 1,
-      "endLine": 30,
-      "summary": "Historical context and motivation for Shannon entropy as the fundamental information measure.",
-      "mathContext": "Shannon (1948): $H(X) = -\\sum_x p(x) \\log_2 p(x)$ is the unique (up to scale) measure of information satisfying continuity, monotonicity for uniform distributions, and the grouping axiom. Measured in bits when using $\\log_2$."
+      "endLine": 18,
+      "summary": "Overview of Shannon entropy as the foundation of information theory. Lists key results: entropy definition, non-negativity, maximum entropy, Gibbs inequality, log-sum inequality.",
+      "mathContext": "$H(X) = -\\sum_x p(x) \\log p(x)$"
     },
     {
       "id": "entropy-definition",
-      "title": "Entropy Definition",
-      "startLine": 32,
-      "endLine": 72,
-      "summary": "Formal definition of Shannon entropy for discrete distributions over a Fintype, with the 0 log 0 = 0 convention.",
-      "mathContext": "For a probability mass function $p: \\mathcal{X} \\to [0,1]$ with $\\sum_x p(x) = 1$, define $\\eta(t) = -t \\log_2 t$ for $t > 0$ and $\\eta(0) = 0$. Then $H(X) = \\sum_x \\eta(p(x))$. The function $\\eta$ is concave on $[0,1]$."
+      "title": "Entropy Definition and Non-Negativity",
+      "startLine": 20,
+      "endLine": 29,
+      "summary": "Defines Shannon entropy with the 0·log(0) = 0 convention. States non-negativity H(p) >= 0 for probability distributions (sorry'd). Uses natural log (Real.log), not log₂.",
+      "mathContext": "$H(X) = -\\sum_x p(x) \\ln p(x) \\geq 0$ for $p(x) \\geq 0$, $\\sum p(x) = 1$"
     },
     {
-      "id": "conditional-entropy",
-      "title": "Conditional Entropy",
-      "startLine": 74,
-      "endLine": 118,
-      "summary": "Conditional entropy H(Y|X) and its properties, including non-negativity and conditioning reduces entropy.",
-      "mathContext": "Conditional entropy $H(Y|X) = \\sum_x p(x) H(Y|X=x) = -\\sum_{x,y} p(x,y) \\log_2 p(y|x)$. Key property: $H(Y|X) \\leq H(Y)$ with equality iff $X$ and $Y$ are independent. Conditioning reduces entropy (on average)."
+      "id": "max-entropy",
+      "title": "Maximum Entropy (Uniform Distribution)",
+      "startLine": 31,
+      "endLine": 34,
+      "summary": "Entropy is maximized by the uniform distribution: H(p) <= log|X|. Sorry'd — the proof uses Gibbs inequality with q = uniform.",
+      "mathContext": "$H(X) \\leq \\ln |\\mathcal{X}|$ with equality iff $p$ is uniform"
     },
     {
-      "id": "mutual-information",
-      "title": "Mutual Information",
-      "startLine": 120,
-      "endLine": 165,
-      "summary": "Mutual information I(X;Y) as the reduction in uncertainty, with non-negativity and symmetry.",
-      "mathContext": "Mutual information $I(X;Y) = H(X) - H(X|Y) = H(X) + H(Y) - H(X,Y) = D(p_{XY} \\| p_X p_Y) \\geq 0$. Symmetric: $I(X;Y) = I(Y;X)$. Equals zero iff $X \\perp Y$."
+      "id": "gibbs",
+      "title": "Gibbs Inequality",
+      "startLine": 36,
+      "endLine": 40,
+      "summary": "H(p) <= -sum p(x) log q(x) for any distribution q, equivalently D(p||q) >= 0. Sorry'd — proof via Jensen's inequality on -log (convex).",
+      "mathContext": "$D(p \\| q) = \\sum_x p(x) \\ln \\frac{p(x)}{q(x)} \\geq 0$ (Gibbs inequality)"
     },
     {
-      "id": "chain-rule",
-      "title": "Chain Rule",
-      "startLine": 167,
-      "endLine": 210,
-      "summary": "The chain rule for entropy and mutual information, relating joint and conditional quantities.",
-      "mathContext": "Chain rule for entropy: $H(X_1, \\ldots, X_n) = \\sum_{i=1}^n H(X_i | X_1, \\ldots, X_{i-1})$. Chain rule for mutual information: $I(X_1, \\ldots, X_n ; Y) = \\sum_{i=1}^n I(X_i; Y | X_1, \\ldots, X_{i-1})$."
-    },
-    {
-      "id": "gibbs-inequality",
-      "title": "Gibbs Inequality and KL Divergence",
-      "startLine": 212,
-      "endLine": 265,
-      "summary": "Non-negativity of KL divergence (Gibbs inequality), the master inequality of information theory.",
-      "mathContext": "Gibbs inequality: $D(p \\| q) = \\sum_x p(x) \\log \\frac{p(x)}{q(x)} \\geq 0$, with equality iff $p = q$. Proof via Jensen's inequality applied to the convex function $-\\log$. This implies: $H(X) \\leq \\log |\\mathcal{X}|$, $H(Y|X) \\leq H(Y)$, and $I(X;Y) \\geq 0$."
+      "id": "log-sum",
+      "title": "Log-Sum Inequality",
+      "startLine": 42,
+      "endLine": 48,
+      "summary": "The log-sum inequality: sum a_i log(a_i/b_i) >= (sum a_i) log((sum a_i)/(sum b_i)). A generalization of the Gibbs inequality. Sorry'd — proof via convexity of x·log(x).",
+      "mathContext": "$\\sum_i a_i \\ln \\frac{a_i}{b_i} \\geq \\left(\\sum_i a_i\\right) \\ln \\frac{\\sum_i a_i}{\\sum_i b_i}$"
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary
Enrichment pass for `shannon-entropy` (quality 45 → enriched, 0 prior passes).

- **5 annotations** covering entropy definition, non-negativity, maximum entropy, Gibbs inequality, log-sum inequality
- **Sections fixed**: line ranges from fictional 30-265 to actual 1-48
- Noted 0·log(0) convention and nats vs bits distinction

🤖 Generated with [Claude Code](https://claude.com/claude-code)