### PR TITLE
Enrich Alteration Method (Probabilistic Method): add annotations, fix sections

### DIFF
--- a/src/data/proofs/prob-method-alteration/annotations.json
+++ b/src/data/proofs/prob-method-alteration/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-alteration-imports",
+    "proofId": "prob-method-alteration",
+    "range": { "startLine": 1, "endLine": 14 },
+    "type": "context",
+    "title": "Alteration Method Overview",
+    "content": "The module header introduces the alteration (deletion) method, a two-phase probabilistic technique: first construct a random object, then deterministically remove the few violations. The Mathlib import provides access to Finset, simple graph definitions, and integer arithmetic needed for the expectation arguments.",
+    "mathContext": "The alteration method: given a random variable $X$ on a probability space with value function $v(X)$ and defect count $d(X)$, if $\\mathbb{E}[v(X) - d(X)] > 0$, then there exists an outcome whose alteration (removing defects) has positive value.",
+    "significance": "context",
+    "relatedConcepts": ["probabilistic method", "first moment method", "expected value", "Finset"],
+    "prerequisites": ["probability theory", "finite combinatorics", "Lean 4 basics"]
+  },
+  {
+    "id": "ann-alteration-principle",
+    "proofId": "prob-method-alteration",
+    "range": { "startLine": 18, "endLine": 21 },
+    "type": "insight",
+    "title": "Alteration Principle (Deterministic Core)",
+    "content": "This theorem captures the deterministic essence of the alteration method. Given a nonempty finite set $S$ and integer-valued functions `good` and `bad`, if the net good value summed over $S$ is positive, then some element achieves positive net good value. This is essentially a pigeonhole argument: if every element had non-positive net value, the sum could not be positive.\n\nThe formalization uses integer coercions ($\\mathbb{Z}$) to handle the subtraction cleanly, since natural number subtraction in Lean truncates at zero.",
+    "mathContext": "If $\\sum_{a \\in S} \\text{good}(a) - \\sum_{a \\in S} \\text{bad}(a) > 0$ over a nonempty finite set $S$, then $\\exists a \\in S$ such that $\\text{good}(a) - \\text{bad}(a) > 0$. This is the first moment method in disguise: if the average of $\\text{good} - \\text{bad}$ is positive, some element exceeds the average.",
+    "significance": "key",
+    "relatedConcepts": ["first moment method", "pigeonhole principle", "expected value linearity", "integer coercion in Lean"],
+    "prerequisites": ["Finset.sum", "integer arithmetic", "existential quantification"]
+  },
+  {
+    "id": "ann-independent-set",
+    "proofId": "prob-method-alteration",
+    "range": { "startLine": 25, "endLine": 26 },
+    "type": "insight",
+    "title": "Independent Set Bound via Vertex Deletion",
+    "content": "The classic application of the alteration method to independent sets: in a $d$-regular graph on $n$ vertices, select each vertex with probability $p = 1/d$. The expected number of selected vertices is $n/d$, and the expected number of edges within the selection is $nd p^2/2 = n/(2d)$. Deleting one endpoint per edge yields an independent set of expected size $\\geq n/d - n/(2d) = n/(2d)$.\n\nThe formalization simplifies the statement to the existence of a positive integer $k \\geq \\lfloor n/(2d) \\rfloor$, sidestepping the need for a formal graph type. A fuller formalization would state this as $\\alpha(G) \\geq n/(2d)$ using Mathlib's `SimpleGraph.IndependentSet`.",
+    "mathContext": "For a $d$-regular graph $G$ on $n$ vertices: $\\alpha(G) \\geq \\frac{n}{2d}$. More generally, for a graph with $m$ edges: $\\alpha(G) \\geq \\frac{n^2}{2m + n}$, obtained by optimizing $p = \\frac{n}{2m+n}$ in the bound $np - mp^2$.",
+    "significance": "key",
+    "relatedConcepts": ["independence number", "regular graphs", "greedy algorithms", "Turán's theorem"],
+    "prerequisites": ["graph theory basics", "expected value", "optimization of quadratic"]
+  },
+  {
+    "id": "ann-property-b",
+    "proofId": "prob-method-alteration",
+    "range": { "startLine": 29, "endLine": 30 },
+    "type": "concept",
+    "title": "Property B of Hypergraphs (Placeholder)",
+    "content": "Property B, introduced by Miller (1937) and extensively studied by Erdős, asks whether a hypergraph's vertices can be 2-colored so that no edge is monochromatic. The alteration argument: randomly 2-color all vertices, then for each monochromatic edge, recolor one vertex. If the expected number of monochromatic edges is less than the number of vertices we can sacrifice, the alteration succeeds.\n\nThis formalization is currently a placeholder (`True`) because Lean 4/Mathlib lacks a standard hypergraph type. The mathematical content is captured in the bound: a $k$-uniform hypergraph with $m < 2^{k-1}$ edges has Property B.",
+    "mathContext": "For a $k$-uniform hypergraph $\\mathcal{H}$ with $m$ edges, randomly 2-color vertices. Each edge is monochromatic with probability $2 \\cdot (1/2)^k = 2^{1-k}$. By linearity, $\\mathbb{E}[\\text{monochromatic edges}] = m \\cdot 2^{1-k}$. If $m < 2^{k-1}$, then $\\mathbb{E}[\\text{mono}] < 1$, so some 2-coloring has zero monochromatic edges.",
+    "significance": "key",
+    "relatedConcepts": ["hypergraph coloring", "Property B", "Erdős-Hajnal conjecture", "set system coloring"],
+    "prerequisites": ["hypergraph definitions", "uniform hypergraphs", "probabilistic method"]
+  },
+  {
+    "id": "ann-namespace-structure",
+    "proofId": "prob-method-alteration",
+    "range": { "startLine": 14, "endLine": 14 },
+    "type": "context",
+    "title": "Namespace Organization",
+    "content": "The proof is organized under `ProbMethod.Alteration`, following a hierarchical convention shared with `ProbMethod.Expectation`, `ProbMethod.LovaszLocal`, etc. This structure mirrors the textbook organization of the probabilistic method, where the alteration method is typically Chapter 3 after the first and second moment methods.",
+    "mathContext": "The probabilistic method family: first moment (expectation), second moment (variance), alteration (deletion), and Lovász Local Lemma form an increasing hierarchy of sophistication for proving existence results.",
+    "significance": "context",
+    "relatedConcepts": ["probabilistic method hierarchy", "Lean 4 namespace convention", "proof organization"],
+    "prerequisites": ["Lean 4 namespace system"]
+  }
+]

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -50,41 +50,42 @@
       "The two-phase approach (random + deterministic fix) handles constraints that pure randomness cannot satisfy simultaneously",
       "Deleting defects is often cheaper than avoiding them: if expected defects are few, the altered structure retains most of the random construction's value",
       "The independent set bound n^2/(2m+n) is tight for regular graphs and was the best known for general sparse graphs for decades",
-      "Property B results demonstrate that the alteration method applies beyond graph theory to hypergraph coloring"
+      "Property B results demonstrate that the alteration method applies beyond graph theory to hypergraph coloring",
+      "The alteration method can be derandomized via the method of conditional expectations, converting the existence proof into an efficient deterministic algorithm — this is the algorithmic significance of keeping the alteration step simple"
     ]
   },
   "sections": [
     {
-      "id": "introduction",
-      "title": "Introduction",
+      "id": "module-header",
+      "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 22,
-      "summary": "Overview of the alteration method as a two-phase probabilistic technique.",
-      "mathContext": "The alteration method: start with a random construction, then deterministically remove defects. If expected value minus expected defects exceeds $t$, the desired structure exists with value exceeding $t$."
+      "endLine": 14,
+      "summary": "Documentation header describing the alteration/deletion method and its key results, followed by Mathlib import and namespace declaration.",
+      "mathContext": "The alteration method is a refinement of the probabilistic method: construct a random object, then deterministically remove violations to obtain a valid structure."
     },
     {
       "id": "alteration-principle",
       "title": "Alteration Principle",
-      "startLine": 24,
-      "endLine": 58,
-      "summary": "Formal statement and proof of the alteration principle for finite structures.",
-      "mathContext": "Alteration Principle: for random variable $V$ (value) and $D$ (defects) on a finite sample space, $E[V - D] \\geq t$ implies $\\exists \\omega$ with an altered version having value $\\geq t$ and no defects. This follows from the first moment principle applied to $V - D$."
+      "startLine": 16,
+      "endLine": 21,
+      "summary": "Core theorem: if the sum of a 'good' function minus a 'bad' function over a nonempty finite set is positive, then some element has positive net good value.",
+      "mathContext": "For functions $\\text{good}, \\text{bad} : \\alpha \\to \\mathbb{N}$ on a nonempty finite set $S$, if $\\sum_{a \\in S} \\text{good}(a) - \\sum_{a \\in S} \\text{bad}(a) > 0$, then $\\exists a \\in S$ with $\\text{good}(a) - \\text{bad}(a) > 0$. This is the deterministic core of the alteration method, reducing the probabilistic argument to a pigeonhole-type statement."
     },
     {
-      "id": "independent-set",
-      "title": "Independent Set Application",
-      "startLine": 60,
-      "endLine": 115,
-      "summary": "Every graph with n vertices and m edges has an independent set of size at least n^2/(2m+n).",
-      "mathContext": "Select each vertex with probability $p$. Expected selected vertices: $np$. Expected edges in selected set: $mp^2$. After deleting one endpoint per edge, expected independent set size $\\geq np - mp^2$. Optimizing at $p = n/(2m+n)$ gives $\\alpha(G) \\geq n^2/(2m+n)$."
+      "id": "independent-set-bound",
+      "title": "Independent Set Bound via Alteration",
+      "startLine": 23,
+      "endLine": 26,
+      "summary": "Application to regular graphs: every $d$-regular graph on $n$ vertices has an independent set of size at least $\\lfloor n/(2d) \\rfloor$.",
+      "mathContext": "For a $d$-regular graph on $n$ vertices, include each vertex independently with probability $p = 1/(d+1)$. The expected number of selected vertices is $np$ and the expected edges in the selected set is $\\frac{nd}{2} p^2$. Deleting one endpoint per edge yields expected independent set size $\\geq np - \\frac{nd}{2}p^2 \\geq n/(2d)$."
     },
     {
       "id": "property-b",
       "title": "Property B of Hypergraphs",
-      "startLine": 117,
-      "endLine": 165,
-      "summary": "Existence of 2-colorings for uniform hypergraphs with bounded degree, via the alteration method.",
-      "mathContext": "A hypergraph has Property B if its vertices can be 2-colored with no monochromatic edge. For a $k$-uniform hypergraph with $m$ edges, random 2-coloring yields $E[\\text{mono edges}] = m \\cdot 2^{1-k}$. If $m < 2^{k-1}$, alteration shows Property B holds."
+      "startLine": 28,
+      "endLine": 32,
+      "summary": "Placeholder for Property B: a $k$-uniform hypergraph with fewer than $2^{k-1}$ edges is 2-colorable.",
+      "mathContext": "Property B states that the vertices of a hypergraph can be 2-colored with no monochromatic edge. For $k$-uniform hypergraphs, a random 2-coloring makes each edge monochromatic with probability $2^{1-k}$. If $m < 2^{k-1}$, the expected number of monochromatic edges $m \\cdot 2^{1-k} < 1$, so alteration yields a valid 2-coloring."
     }
   ],
   "crossReferences": [
@@ -102,13 +103,25 @@
       "targetId": "prob-method-applications",
       "relationship": "used-by",
       "description": "The alteration method is applied in the independent set and Property B results of the applications module"
+    },
+    {
+      "targetId": "prob-method-second-moment",
+      "relationship": "related",
+      "description": "The second moment method provides concentration results that can sharpen alteration bounds by showing the random construction is close to its expectation"
+    },
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Ramsey-type problems are a primary motivation for the alteration method — the probabilistic lower bound on Ramsey numbers uses an alteration argument to handle edge colorings"
     }
   ],
   "conclusion": {
     "summary": "The alteration method extends the probabilistic method by introducing a deterministic correction phase after random construction. This two-step approach yields the classical independent set bound alpha(G) >= n^2/(2m+n) and Property B results for hypergraphs, demonstrating that approximate random solutions can be efficiently repaired.",
     "implications": "This formalization provides:\n\n**1. Independent Set Bounds**\nThe bound alpha(G) >= n^2/(2m+n) is foundational in graph theory and algorithmic applications.\n\n**2. Hypergraph Coloring**\nProperty B results connect to set system colorability, a central topic in combinatorial set theory.\n\n**3. Algorithmic Paradigm**\nThe alteration method directly inspires randomized algorithms: generate a random solution, then greedily fix violations.\n\n**4. Bridge to Erdos Problems**\nMany Erdos problems on graph coloring and Ramsey multiplicity use alteration arguments that this library formalizes.",
     "openQuestions": [
-      "How does the alteration method compare to the Lovasz Local Lemma for sparse structures?"
+      "How does the alteration method compare to the Lovász Local Lemma for sparse dependency structures? The LLL avoids alteration entirely by showing that a good object exists with positive probability, but requires a more delicate dependency analysis.",
+      "Can the independent set bound $\\alpha(G) \\geq n^2/(2m+n)$ be improved for triangle-free graphs? Shearer (1983) showed $\\alpha(G) \\geq \\Omega(n \\sqrt{\\log d}/d)$ for triangle-free $d$-regular graphs, but the optimal constant remains open.",
+      "What is the minimum number of edges in a $k$-uniform hypergraph without Property B? Erdős conjectured the threshold is $\\Theta(k^2 \\cdot 2^k)$, which was resolved by Radhakrishnan and Srinivasan (2000) up to logarithmic factors, but the exact constant is still unknown."
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Created `annotations.json` with 5 annotations covering all Lean constructs (alteration principle, independent set bound, Property B, namespace, imports)
- Each annotation includes `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`
- Fixed `sections` line ranges to match actual 32-line Lean file (were pointing to non-existent lines 24-165)
- Added 5th keyInsight on derandomization via method of conditional expectations
- Expanded `openQuestions` from 1 to 3 (LLL comparison, Shearer's triangle-free bound, Property B threshold)
- Added cross-references to `prob-method-second-moment` and `ramseys-theorem`

## Test plan
- [x] `pnpm annotations:build` passes with zero warnings for `prob-method-alteration`
- [ ] Visual check on gallery page after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)