### PR TITLE
Enrich Second Moment Method (Probabilistic Method): add annotations, fix sections

### DIFF
--- a/src/data/proofs/prob-method-second-moment/annotations.json
+++ b/src/data/proofs/prob-method-second-moment/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-smm-imports",
+    "proofId": "prob-method-second-moment",
+    "range": { "startLine": 1, "endLine": 14 },
+    "type": "context",
+    "title": "Module Setup and Namespace",
+    "content": "The file imports the full Mathlib library and works within the `ProbMethod.SecondMoment` namespace. The formalization uses finite probability spaces modeled over `Finset α` with rational-valued random variables (`α → ℚ`), giving exact arithmetic without floating-point concerns. This discrete framework suffices for combinatorial applications where the sample space is finite.",
+    "mathContext": "A finite probability space $(\\Omega, \\Pr)$ is modeled as a `Finset α` with uniform measure: $\\Pr[A] = |A|/|\\Omega|$. Expectations become finite sums: $E[X] = \\frac{1}{|\\Omega|} \\sum_{\\omega \\in \\Omega} X(\\omega)$.",
+    "significance": "context",
+    "relatedConcepts": ["finite probability space", "uniform measure", "rational arithmetic"],
+    "prerequisites": ["Finset", "Lean 4 type theory"]
+  },
+  {
+    "id": "ann-smm-chebyshev",
+    "proofId": "prob-method-second-moment",
+    "range": { "startLine": 18, "endLine": 22 },
+    "type": "theorem",
+    "title": "Chebyshev's Inequality (Finite Version)",
+    "content": "Formalizes Chebyshev's inequality for finite probability spaces. The mean $\\mu$ and variance $\\operatorname{Var}[X]$ are computed as finite sums over a `Finset`. The bound states that the fraction of elements deviating from the mean by at least $t$ is at most $\\operatorname{Var}[X]/t^2$. This is proved by applying Markov's inequality to the non-negative random variable $(X - \\mu)^2$, which is the standard textbook approach lifted to the Finset setting.",
+    "mathContext": "Chebyshev: $\\Pr[|X - \\mu| \\geq t] \\leq \\frac{\\operatorname{Var}[X]}{t^2}$ where $\\mu = E[X]$ and $\\operatorname{Var}[X] = E[(X - \\mu)^2]$. In the Finset model: $|\\{a \\in s : |f(a) - \\mu| \\geq t\\}| \\leq |s| \\cdot \\operatorname{Var}[f] / t^2$.",
+    "significance": "key",
+    "relatedConcepts": ["Markov's inequality", "concentration inequality", "variance", "tail bound"],
+    "prerequisites": ["Markov's inequality", "variance definition", "finite expectation"]
+  },
+  {
+    "id": "ann-smm-paley-zygmund",
+    "proofId": "prob-method-second-moment",
+    "range": { "startLine": 26, "endLine": 29 },
+    "type": "theorem",
+    "title": "Paley-Zygmund Inequality",
+    "content": "Formalizes the Paley-Zygmund inequality, which provides a lower bound on $\\Pr[X > 0]$ for non-negative random variables. While Chebyshev bounds deviation probabilities from above, Paley-Zygmund bounds positivity probability from below — making it the key tool for existence proofs. The proof uses the Cauchy-Schwarz inequality: $E[X]^2 = E[X \\cdot \\mathbf{1}_{X>0}]^2 \\leq E[X^2] \\cdot \\Pr[X > 0]$. This formalization states the qualitative version: if $E[X] > 0$ and $X \\geq 0$, then $X$ is positive on a non-empty subset.",
+    "mathContext": "Paley-Zygmund: For $X \\geq 0$ with $E[X] > 0$, $\\Pr[X > 0] \\geq \\frac{(E[X])^2}{E[X^2]}$. The quantitative form gives: $\\Pr[X > \\theta E[X]] \\geq (1 - \\theta)^2 \\frac{(E[X])^2}{E[X^2]}$ for $0 \\leq \\theta \\leq 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy-Schwarz inequality", "lower tail bound", "existence proof", "indicator random variable"],
+    "prerequisites": ["Cauchy-Schwarz inequality", "non-negative random variable", "second moment"]
+  },
+  {
+    "id": "ann-smm-existence",
+    "proofId": "prob-method-second-moment",
+    "range": { "startLine": 33, "endLine": 37 },
+    "type": "theorem",
+    "title": "Second Moment Existence Theorem",
+    "content": "The main application theorem: if the second moment $E[X^2]$ is at most $2(E[X])^2/|s|$, then at least half the sample space has $X > 0$. This is the workhorse of the second moment method in combinatorics — it converts a variance bound into a quantitative existence guarantee. The factor of 2 comes from the Paley-Zygmund bound: $\\Pr[X > 0] \\geq (E[X])^2/E[X^2] \\geq 1/2$. In random graph theory, this is exactly how one proves that $G(n,p)$ contains a given subgraph with high probability when $p$ is above the threshold.",
+    "mathContext": "If $E[X^2] \\cdot |s| \\leq 2(E[X])^2$, equivalently $\\frac{E[X^2]}{(E[X])^2} \\leq \\frac{2}{|s|}$, then by Paley-Zygmund: $|\\{a \\in s : X(a) > 0\\}| \\geq |s|/2$. In the random graph setting with $X = \\sum_i X_i$ counting copies of $H$, this requires $\\operatorname{Var}[X] = o((E[X])^2)$.",
+    "significance": "key",
+    "relatedConcepts": ["threshold function", "random graph G(n,p)", "subgraph containment", "high probability event"],
+    "prerequisites": ["Paley-Zygmund inequality", "indicator sum variance", "random graph model"]
+  },
+  {
+    "id": "ann-smm-sorry-strategy",
+    "proofId": "prob-method-second-moment",
+    "range": { "startLine": 18, "endLine": 37 },
+    "type": "theorem",
+    "title": "Proof Status and Formalization Approach",
+    "content": "All three theorems currently use `sorry` placeholders. The proof strategies are well-understood: Chebyshev follows from Markov applied to $(X-\\mu)^2$, Paley-Zygmund from Cauchy-Schwarz, and the existence theorem from direct application of Paley-Zygmund. The formalization uses `Finset.filter` to model events and `Finset.sum` for expectations, keeping everything in the decidable `ℚ` arithmetic. Completing these proofs would involve finite summation manipulations and algebraic rearrangement — routine but requiring careful interaction with Mathlib's `Finset` API.",
+    "mathContext": "The proof chain is: Markov $\\Rightarrow$ Chebyshev $\\Rightarrow$ Paley-Zygmund $\\Rightarrow$ existence theorem. Each step is a standard inequality derivation over finite sums.",
+    "significance": "supporting",
+    "relatedConcepts": ["sorry placeholder", "Lean 4 tactics", "Finset API", "algebraic manipulation"],
+    "prerequisites": ["Lean 4 proof tactics", "Finset.sum", "Finset.filter"]
+  }
+]

--- a/src/data/proofs/prob-method-second-moment/meta.json
+++ b/src/data/proofs/prob-method-second-moment/meta.json
@@ -45,7 +45,7 @@
     "axiomCount": 0
   },
   "overview": {
-    "historicalContext": "The second moment method extends the first moment method by incorporating variance to prove that random variables are concentrated near their expectation. While the first moment method can only guarantee that a maximum or minimum exists, the second moment method shows that typical outcomes are close to the mean -- and in particular, that a positive-mean random variable is positive with substantial probability.\n\nChebyshev's inequality (1867) is the foundation: Pr[|X - E[X]| >= t] <= Var[X]/t^2. For existence proofs, the Paley-Zygmund inequality is often more useful: if X >= 0, then Pr[X > 0] >= (E[X])^2/E[X^2]. This lower bound on positive probability is exactly what combinatorial existence proofs require.\n\nThe second moment method became indispensable in the study of random graphs after Erdos and Renyi's foundational 1959 paper. It is the standard tool for proving threshold phenomena: a graph property either holds with probability tending to 0 or to 1 as the number of vertices grows, with a sharp transition at a critical edge probability.",
+    "historicalContext": "The second moment method extends the first moment method by incorporating variance to prove that random variables are concentrated near their expectation. While the first moment method can only guarantee that a maximum or minimum exists, the second moment method shows that typical outcomes are close to the mean — and in particular, that a positive-mean random variable is positive with substantial probability.\n\nChebyshev's inequality, published by Pafnuty Chebyshev in 1867, is the foundation: $\\Pr[|X - E[X]| \\geq t] \\leq \\operatorname{Var}[X]/t^2$. The inequality was proved using Chebyshev's elegant application of Markov's inequality to the squared deviation. Irénée-Jules Bienaymé had stated a version earlier (1853), so the result is sometimes called the Bienaymé-Chebyshev inequality.\n\nThe Paley-Zygmund inequality, due to Raymond Paley and Antoni Zygmund (1932), provides a complementary lower bound: for $X \\geq 0$, $\\Pr[X > 0] \\geq (E[X])^2/E[X^2]$. While Chebyshev bounds the probability of large deviations from above, Paley-Zygmund bounds the probability of positivity from below — exactly what combinatorial existence proofs require.\n\nThe second moment method became indispensable in the study of random graphs after Erdős and Rényi's foundational 1959 paper 'On Random Graphs I,' which introduced the $G(n,p)$ model. Their key insight was that many graph properties exhibit sharp thresholds: a property either holds with probability tending to 0 or to 1, with a sharp transition at a critical edge probability $p^*(n)$. The second moment method is the standard tool for establishing these thresholds. Bollobás, Friedgut, and others later developed the theory of sharp thresholds into a rich field connecting probability, combinatorics, and statistical physics.",
     "problemStatement": "Chebyshev's Inequality: For any random variable $X$ with finite variance, $\\Pr[|X - E[X]| \\geq t] \\leq \\operatorname{Var}[X] / t^2$.\n\nPaley-Zygmund Inequality: For a non-negative random variable $X$, $\\Pr[X > 0] \\geq (E[X])^2 / E[X^2]$.\n\nApplication: If the expected number of copies of a subgraph $H$ in a random graph $G(n,p)$ tends to infinity and the variance is controlled, then $G(n,p)$ contains $H$ with high probability.",
     "proofStrategy": "The formalization builds the second moment toolkit:\n\n1. **Variance definition**: $\\operatorname{Var}[X] = E[X^2] - (E[X])^2$ for finite probability spaces, with the Finset-based computation framework.\n\n2. **Chebyshev's inequality**: From Markov's inequality applied to $(X - E[X])^2$. This gives an upper bound on the probability of large deviations.\n\n3. **Paley-Zygmund inequality**: By Cauchy-Schwarz, $E[X]^2 = E[X \\cdot \\mathbf{1}_{X>0}]^2 \\leq E[X^2] \\cdot \\Pr[X > 0]$. Rearranging gives the lower bound on $\\Pr[X > 0]$.\n\n4. **Application to indicator sums**: For $X = \\sum_i X_i$ with indicators $X_i$, compute $\\operatorname{Var}[X] = \\sum_i \\operatorname{Var}[X_i] + \\sum_{i \\neq j} \\operatorname{Cov}[X_i, X_j]$. When the covariance sum is small relative to $(E[X])^2$, the second moment method yields strong concentration.",
     "keyInsights": [
@@ -59,59 +59,71 @@
   "sections": [
     {
       "id": "introduction",
-      "title": "Introduction",
+      "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 20,
-      "summary": "Overview of the second moment method and its role in probabilistic combinatorics.",
+      "endLine": 14,
+      "summary": "Documentation header listing the key results (Chebyshev, Paley-Zygmund, threshold application) and Mathlib import for the full library.",
       "mathContext": "The second moment method uses variance to prove concentration: if $\\operatorname{Var}[X]$ is small relative to $(E[X])^2$, then $X$ is close to its mean with high probability, and in particular $\\Pr[X > 0]$ is large."
     },
     {
       "id": "chebyshev",
       "title": "Chebyshev's Inequality",
-      "startLine": 22,
-      "endLine": 68,
-      "summary": "Formalization of variance, Markov's inequality, and Chebyshev's inequality for finite probability spaces.",
-      "mathContext": "Markov: $\\Pr[Y \\geq t] \\leq E[Y]/t$ for $Y \\geq 0$. Chebyshev: $\\Pr[|X - \\mu| \\geq t] \\leq \\sigma^2/t^2$ where $\\mu = E[X]$ and $\\sigma^2 = \\operatorname{Var}[X]$. Follows from Markov applied to $Y = (X - \\mu)^2$."
+      "startLine": 16,
+      "endLine": 22,
+      "summary": "Finite Chebyshev inequality: the number of elements in a Finset deviating from the mean by at least $t$ is bounded by $|s| \\cdot \\operatorname{Var}[f] / t^2$. Uses rational arithmetic for exact computation.",
+      "mathContext": "Chebyshev: $|\\{a \\in s : |f(a) - \\mu| \\geq t\\}| \\leq |s| \\cdot \\operatorname{Var}[f] / t^2$ where $\\mu = \\frac{1}{|s|}\\sum_{a \\in s} f(a)$ and $\\operatorname{Var}[f] = \\frac{1}{|s|}\\sum_{a \\in s}(f(a) - \\mu)^2$. Follows from Markov applied to $Y = (X - \\mu)^2$."
     },
     {
       "id": "paley-zygmund",
       "title": "Paley-Zygmund Inequality",
-      "startLine": 70,
-      "endLine": 110,
-      "summary": "Lower bound on Pr[X > 0] in terms of the first two moments.",
-      "mathContext": "Paley-Zygmund: for $X \\geq 0$, $\\Pr[X > 0] \\geq (E[X])^2 / E[X^2]$. Equivalently, $\\Pr[X > 0] \\geq (E[X])^2 / ((E[X])^2 + \\operatorname{Var}[X])$. Proof via Cauchy-Schwarz: $E[X] = E[X \\cdot \\mathbf{1}_{X>0}] \\leq \\sqrt{E[X^2]} \\cdot \\sqrt{\\Pr[X > 0]}$."
+      "startLine": 24,
+      "endLine": 29,
+      "summary": "Qualitative Paley-Zygmund: for a non-negative function on a Finset with positive sum, there exists an element where the function is positive. This is the existential core of the second moment method.",
+      "mathContext": "Paley-Zygmund: for $X \\geq 0$ with $E[X] > 0$, $\\Pr[X > 0] > 0$. The quantitative form gives $\\Pr[X > 0] \\geq (E[X])^2 / E[X^2]$. Proof via Cauchy-Schwarz: $E[X]^2 = E[X \\cdot \\mathbf{1}_{X>0}]^2 \\leq E[X^2] \\cdot \\Pr[X > 0]$."
     },
     {
-      "id": "threshold-applications",
-      "title": "Threshold Applications",
-      "startLine": 112,
-      "endLine": 165,
-      "summary": "Application to subgraph containment thresholds in random graphs.",
-      "mathContext": "In $G(n,p)$, let $X$ count copies of a fixed graph $H$ with $v$ vertices and $e$ edges. Then $E[X] = \\Theta(n^v p^e)$. The second moment method shows that if $E[X] \\to \\infty$ and $\\operatorname{Var}[X] = o((E[X])^2)$, then $\\Pr[X > 0] \\to 1$, establishing the threshold at $p = n^{-v/e}$."
+      "id": "existence-theorem",
+      "title": "Second Moment Existence Theorem",
+      "startLine": 31,
+      "endLine": 39,
+      "summary": "Quantitative existence: if the second moment is controlled ($E[X^2] \\cdot |s| \\leq 2(E[X])^2$), then at least half the elements have $X > 0$. This is the theorem that drives threshold proofs in random graph theory.",
+      "mathContext": "If $E[X^2] \\cdot |s| \\leq 2(E[X])^2$, then $|\\{a \\in s : f(a) > 0\\}| \\geq |s|/2$. In $G(n,p)$ with $X$ counting copies of $H$: $E[X] = \\Theta(n^v p^e)$, and showing $\\operatorname{Var}[X] = o((E[X])^2)$ establishes the threshold at $p = n^{-v/e}$."
     }
   ],
   "crossReferences": [
     {
       "targetId": "prob-method-expectation",
       "relationship": "depends-on",
-      "description": "The second moment method builds on the first moment framework and extends it with variance analysis"
+      "description": "The second moment method builds on the first moment framework, extending Markov's inequality with variance analysis to get concentration"
     },
     {
       "targetId": "prob-method-lovasz-local",
       "relationship": "related",
-      "description": "Both the second moment method and the LLL handle dependencies, but via different mechanisms: variance bounds vs dependency graphs"
+      "description": "Both handle dependencies in probabilistic arguments: the second moment method via variance/covariance control, the LLL via dependency graph structure"
     },
     {
       "targetId": "prob-method-applications",
       "relationship": "used-by",
-      "description": "Threshold results from the second moment method are applied in the random graph and Ramsey applications"
+      "description": "Threshold results from the second moment method are applied in random graph and Ramsey theory applications"
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "depends-on",
+      "description": "The Paley-Zygmund inequality is proved via the Cauchy-Schwarz inequality applied to $X \\cdot \\mathbf{1}_{X>0}$"
+    },
+    {
+      "targetId": "prob-method-alteration",
+      "relationship": "related",
+      "description": "The alteration method often combines with second moment bounds: first prove a structure exists with high probability, then alter it to achieve additional properties"
     }
   ],
   "conclusion": {
     "summary": "The second moment method formalizes Chebyshev's inequality and the Paley-Zygmund inequality as tools for proving that random variables are concentrated near their mean. When applied to indicator sums counting combinatorial structures, it yields quantitative lower bounds on the probability of positive outcomes, enabling threshold phenomena proofs in random graph theory.",
     "implications": "This formalization provides:\n\n**1. Concentration Toolkit**\nChebyshev and Paley-Zygmund inequalities are the standard tools for proving that random variables do not deviate far from their expectations.\n\n**2. Threshold Phenomena**\nThe second moment method is the primary tool for establishing sharp thresholds in random graph theory, a central topic in probabilistic combinatorics.\n\n**3. Variance Computation Framework**\nThe indicator sum variance decomposition into individual variances and pairwise covariances is a reusable component for any counting argument.\n\n**4. Complement to LLL**\nWhere the Lovasz Local Lemma handles rare events with sparse dependencies, the second moment method handles common events with controlled variance.",
     "openQuestions": [
-      "What random graph threshold results can be proved via the second moment method?"
+      "Can the quantitative Paley-Zygmund inequality (with threshold parameter $\\theta$) be formalized and applied to prove sharper concentration bounds?",
+      "Can the variance computation for indicator sums be formalized generically to handle subgraph counting in $G(n,p)$ and derive specific threshold functions?",
+      "How does the second moment method extend to higher moments (e.g., the fourth moment method), and can Kim-Vu polynomial concentration be formalized in Lean 4?"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Created `annotations.json` with 5 annotations covering all theorems (Chebyshev, Paley-Zygmund, existence)
- Each annotation has `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- Fixed section line ranges to match actual 39-line Lean file (were incorrectly referencing lines up to 165)
- Deepened `historicalContext` with Bienaymé-Chebyshev (1853/1867), Paley-Zygmund (1932), Erdős-Rényi (1959), Bollobás/Friedgut
- Added cross-references to `cauchy-schwarz` and `prob-method-alteration`
- Expanded `openQuestions` from 1 to 3 (quantitative Paley-Zygmund, indicator sum variance, Kim-Vu higher moments)

## Quality improvements
- Annotations: 0 → 5 (with full metadata)
- Sections: fixed line ranges to match actual file
- historicalContext: expanded with specific dates, mathematicians, and paper references
- openQuestions: 1 → 3
- crossReferences: 3 → 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)