### PR TITLE
Enrich 7 gallery entries: sections, annotations, cross-refs, context

### DIFF
--- a/src/data/proofs/erdos-316/meta.json
+++ b/src/data/proofs/erdos-316/meta.json
@@ -53,6 +53,14 @@
       {
         "id": "erdos-315",
         "relationship": "Adjacent problem in the Erdős unit fractions series"
+      },
+      {
+        "id": "erdos-305",
+        "relationship": "Another Erdős problem on arithmetic structure of natural number subsets"
+      },
+      {
+        "id": "erdos-317",
+        "relationship": "Adjacent problem in the Erdős conjecture series; explores related partitioning questions"
       }
     ],
     "references": [
@@ -73,14 +81,15 @@
     "axiomCount": 1
   },
   "overview": {
-    "historicalContext": "This problem was posed by Erdős and Graham in their 1980 monograph on problems in combinatorial number theory. The question asks whether a simple partitioning property holds for sets of natural numbers based on their reciprocal sums.\n\nThe conjecture remained open for 17 years until Csaba Sándor disproved it in 1997 in his paper \"On a problem of Erdős\" published in the Journal of Number Theory. Sándor not only found a counterexample but proved a more general negative result.\n\nThe minimal counterexample set {2, 3, 4, 5, 6, 7, 10, 11, 13, 14, 15} was discovered by Tom Stobart through computational search. This 11-element set has reciprocal sum approximately 1.9586, yet any partition into two parts must have at least one part with reciprocal sum ≥ 1.",
+    "historicalContext": "This problem belongs to the rich tradition of **Egyptian fraction** problems — the study of representations of rationals as sums of distinct unit fractions $1/n$. The ancient Egyptians used such representations exclusively, and the modern study was revitalized by Erdős, who made dozens of conjectures about unit fraction sums.\n\nErdős and Graham posed this specific question in their influential 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*. The conjecture seemed natural: if a set's reciprocal sum is below 2, the 'spare capacity' should allow a balanced bisection. This intuition works for most random sets but fails for carefully constructed ones.\n\nThe conjecture remained open for 17 years until Csaba Sándor disproved it in 1997 in his paper \"On a problem of Erdős\" published in the *Journal of Number Theory*. Sándor not only found a counterexample but proved a more general negative result: for every $n \\ge 2$, there exists a set with reciprocal sum $< n$ that resists $n$-partition.\n\nThe minimal counterexample set $\\{2, 3, 4, 5, 6, 7, 10, 11, 13, 14, 15\\}$ was discovered by Tom Stobart through computational search over subsets of $\\{2, \\ldots, 15\\}$. This 11-element set has reciprocal sum $4234829/2162160 \\approx 1.9586$, yet any partition into two parts must have at least one part with reciprocal sum $\\ge 1$. The gap of $2 - 1.9586 \\approx 0.041$ is precisely too small for any balanced split.",
     "problemStatement": "**Conjecture (Erdős-Graham)**: Is it true that if $A \\subseteq \\mathbb{N} \\setminus \\{1\\}$ is a finite set with $\\sum_{n \\in A} \\frac{1}{n} < 2$, then there exists a partition $A = A_1 \\sqcup A_2$ such that $\\sum_{n \\in A_i} \\frac{1}{n} < 1$ for $i = 1, 2$?\n\n**Answer**: NO. The set $\\{2, 3, 4, 5, 6, 7, 10, 11, 13, 14, 15\\}$ is a counterexample.",
     "proofStrategy": "The proof is a constructive disproof by counterexample. We exhibit the specific finite set A = {2, 3, 4, 5, 6, 7, 10, 11, 13, 14, 15} and prove two things:\n\n1. The sum of reciprocals satisfies ∑(1/n) = 4234829/2162160 ≈ 1.9586 < 2\n\n2. For every possible partition of A into two disjoint subsets, at least one subset has reciprocal sum ≥ 1\n\nThe second claim is verified exhaustively by checking all 2^11 = 2048 possible subsets. For each subset B ⊆ A with ∑_{n ∈ B}(1/n) < 1, we verify that the complement A \\ B has ∑_{n ∈ A\\B}(1/n) ≥ 1. This exhaustive verification is performed using Lean's `decide +kernel` tactic.",
     "keyInsights": [
       "**Unit fractions**: Reciprocals of natural numbers (1/2, 1/3, 1/4, ...) have special properties in additive combinatorics. The harmonic series diverges but specific finite sums have structured behavior.",
       "**Greedy fails**: One might expect that a set with total < 2 could always be split near the midpoint. The counterexample shows this intuition fails: the 11 elements are arranged such that any subset summing to < 1 leaves too much for its complement.",
       "**Exhaustive verification**: With only 2048 possible subsets, Lean can verify all cases computationally. This is a clean example of proof by exhaustive search.",
-      "**Generalization**: Sándor proved that for any n ≥ 2, there exists a set with sum < n that cannot be partitioned into n parts each with sum < 1. The case n = 2 is what we formalize here."
+      "**Generalization**: Sándor proved that for any n ≥ 2, there exists a set with sum < n that cannot be partitioned into n parts each with sum < 1. The case n = 2 is what we formalize here.",
+      "**Certified computation**: The `decide +kernel` tactic performs a verified exhaustive search of all 2048 subsets, producing a kernel-level proof certificate. This is fundamentally different from a pen-and-paper 'check all cases' argument — the Lean kernel independently verifies every step, eliminating the possibility of computational error."
     ]
   },
   "sections": [


### PR DESCRIPTION
## Summary

Enrichment batch from enricher-1 covering 7 gallery entries:

### 1. yang-mills-mass-gap (quality 45 → improved)
- 12 new sections covering Parts XV-CLXII (30,575-line file previously covered through ~6,623)
- 7 new annotations: asymptotic freedom, Källén-Lehmann, theta vacuum, dual superconductor, Schwinger model, Fradkin-Shenker
- 3 new keyInsights

### 2. prob-method-applications (quality 95)
- 2 new annotations: unbalancing lights, Property B
- 5 cross-references, 1 new keyInsight, 2 new openQuestions

### 3. erdos-316 (quality 96)
- Deepened historicalContext with Egyptian fraction tradition
- Added keyInsight on certified computation, 2 new relatedProblems

### 4. erdos-646 (quality 96)
- Rewrote historicalContext with Legendre/Kummer/Berend context
- Added mathContext/relatedConcepts/prerequisites to 6 annotations

### 5. erdos-668 (quality 96)
- Fixed incorrect cross-references (erdos-646 → erdos-90, 186, 200)
- Rewrote historicalContext with Spencer-Szemerédi-Trotter bound

### 6. erdos-678 (quality 96)
- Deepened historicalContext with prime power mechanism
- Improved relatedProblems, added Bertrand's postulate connection

### 7. divisibility-truncation-general-oq-01 (quality 95)
- Added annotation for sanity checks section
- Added references (Ramaswami Aiyar 1907, Martin Gardner)

## Test plan
- [x] All JSON files validate
- [x] No new annotation errors in build for any enriched entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)