### PR TITLE
Enrich Erdos 1065 (2^k*q+1 Primes): fix annotations, add cross-references

### DIFF
--- a/src/data/proofs/erdos-36/annotations.json
+++ b/src/data/proofs/erdos-36/annotations.json
@@ -51,7 +51,7 @@
     "id": "ann-e36-limit-exists",
     "proofId": "erdos-36",
     "range": { "startLine": 44, "endLine": 47 },
-    "type": "theorem",
+    "type": "axiom",
     "title": "Erdős Problem #36: Asymptotic Constant",
     "content": "**erdos_36_limit_exists**: The limit $c = \\lim_{N \\to \\infty} M(N)/N$ exists and is positive. The problem asks to determine the exact value of $c$. Currently known: $0.379005 < c < 0.380876$.",
     "significance": "key",


### PR DESCRIPTION
## Summary
- Fixed 2 annotation type mismatches (`theorem` → `axiom`)
- Added `crossReferences` to `infinitude-primes` and `fermat-two-squares`

## Quality improvements
- Annotation errors: 2 → 0
- crossReferences: 0 → 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)