### PR TITLE
Enrich Erdos 36 (Minimum Overlap): fix annotation type

### DIFF
--- a/src/data/proofs/erdos-36/annotations.json
+++ b/src/data/proofs/erdos-36/annotations.json
@@ -51,7 +51,7 @@
     "id": "ann-e36-limit-exists",
     "proofId": "erdos-36",
     "range": { "startLine": 44, "endLine": 47 },
-    "type": "theorem",
+    "type": "axiom",
     "title": "Erdős Problem #36: Asymptotic Constant",
     "content": "**erdos_36_limit_exists**: The limit $c = \\lim_{N \\to \\infty} M(N)/N$ exists and is positive. The problem asks to determine the exact value of $c$. Currently known: $0.379005 < c < 0.380876$.",
     "significance": "key",


### PR DESCRIPTION
## Summary
- Fixed annotation type mismatch for axiom declaration (`theorem` → `axiom`)

## Quality improvements
- Annotation errors: 1 → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)