### PR TITLE
Enrich Erdős #1097: fix status, add assumptions

### DIFF
--- a/src/data/proofs/erdos-1097/meta.json
+++ b/src/data/proofs/erdos-1097/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1097",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1097Problem.lean",
     "tags": [
       "erdos",
@@ -34,7 +34,8 @@
         "relationship": "Basic arithmetic series formulas underlie the counting of arithmetic progressions in intervals"
       }
     ],
-    "axiomCount": 6
+    "axiomCount": 6,
+    "assumptions": "6 axiom declarations: katz_tao_upper (O(n^{11/6}) upper bound), erdos_spencer_lower (Ω(n log n) lower bound), erdos_ruzsa_explicit (Ω(n^{4/3}) explicit lower bound), lemm_lower (Ω(n^{1.778}) best known lower bound), alphaevolve_improvement (Ω(n^{1.822}) DeepMind AlphaEvolve result), chan_equivalence (equivalence to Bourgain sums-differences problem). All are established results from the literature."
   },
   "overview": {
     "historicalContext": "Erdős posed this problem at the 1989 Great Western Number Theory problem session in Asilomar, California. He asked: given an n-element set of integers, how many distinct common differences can three-term arithmetic progressions have? The Erdős-Spencer probabilistic argument (using random subsets of {1,...,N}) showed that Ω(n^{3/2}) is achievable, and Erdős conjectured this is the correct order. Jean Bourgain later connected the problem to his work on the Kakeya conjecture in geometric measure theory, reformulating it as a question about restricted sums and differences. In 1999, Nets Katz and Terence Tao established the best known upper bound of O(n^{11/6}) using incidence geometry techniques. Matan Lemm improved the lower bound in 2015 past n^{1.778}, and in 2025 Google DeepMind's AlphaEvolve achieved a marginal further improvement via automated search. The problem remains open, with its resolution expected to have implications for the Kakeya conjecture.",


### PR DESCRIPTION
## Summary

Enrichment pass for `erdos-1097` (quality: 77, passes: 1).

- Fixed `status` from `"formalized"` to `"axiomatized"` (0 sorries, 6 axioms per integrity policy)
- Added `assumptions` field describing all 6 axiom declarations (Katz-Tao, Erdős-Spencer, Lemm, AlphaEvolve, Chan equivalence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)