### PR TITLE
Enrich Erdős #36: fix status, add assumptions

### DIFF
--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -5,7 +5,7 @@
   "description": "Partition {1,...,2N} into equal sets A, B. Minimize over partitions the maximum number of pairs (a,b) with a−b=k. Determine c = lim M(N)/N. Known: 0.379 < c < 0.381. Open.",
   "meta": {
     "erdosNumber": 36,
-    "status": "enhanced",
+    "status": "axiomatized",
     "author": "Erdős (1955), Scherk (1955), White (2022), Haugland (2016)",
     "proofRepoPath": "Proofs/Erdos36Problem.lean",
     "mathlib_version": "4.24.0",
@@ -60,7 +60,8 @@
       "Recorded exact small values M(1)=1 through M(5)=3",
       "Noted Erdős's disproved c=1/2 conjecture and Fourier-analytic techniques"
     ],
-    "axiomCount": 6
+    "axiomCount": 6,
+    "assumptions": "6 axiom declarations: erdos_36_limit_exists (the limit c = lim M(N)/N exists — the main open question), erdos_lower_quarter (Erdős's 1/4 lower bound), scherk_lower (Scherk's 1−1/√2 ≈ 0.293 lower bound via Fourier), white_lower (White's 0.379 lower bound via convex optimization), upper_bound (Haugland's 0.381 upper bound), small_values (computed M(N) for small N). The limit existence and bounds are established results."
   },
   "leanFile": {
     "path": "Proofs/Erdos36Problem.lean",


### PR DESCRIPTION
## Summary

Enrichment pass for `erdos-36` (quality: 77, passes: 1).

- Fixed `status` from `"enhanced"` to `"axiomatized"` (0 sorries, 6 axioms per integrity policy)
- Added `assumptions` field describing all 6 axiom declarations (limit existence, Erdős/Scherk/White lower bounds, Haugland upper bound, small values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)