### PR TITLE
Enrich Erdős #151 + Birthday Problem + Newton Binomial + Desargues OQ04

### DIFF
--- a/src/data/proofs/desargues-theorem-oq-04/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-04/meta.json
@@ -65,7 +65,21 @@
     ],
     "historicalContext": "Girard Desargues stated his theorem in the 1639 'Brouillon project,' but his cryptic notation delayed its recognition until rediscovery by Poncelet (1822). Projective duality — systematically developed by Poncelet and Gergonne in the 1820s — states that every theorem in projective geometry has a dual, obtained by interchanging 'point' and 'line'. Desargues's theorem is the premier example of a self-dual theorem: its dual is its own converse. Hilbert's 'Grundlagen der Geometrie' (1899) showed that Desargues's theorem characterizes Desarguesian planes (those embeddable in projective 3-space), establishing a deep connection between incidence geometry and coordinatization by division rings. Moulton's non-Desarguesian plane (1902) demonstrated that Desargues's theorem is genuinely independent of the other projective axioms in dimension 2.",
     "dateAdded": "03/12/26",
-    "axiomCount": 0
+    "axiomCount": 0,
+    "relatedProblems": [
+      {
+        "id": "desargues-theorem",
+        "relationship": "Base formalization of Desargues's theorem; this extension proves its self-duality in projective geometry"
+      },
+      {
+        "id": "desargues-theorem-oq-01",
+        "relationship": "Another extension of the base Desargues formalization"
+      },
+      {
+        "id": "desargues-theorem-oq-02",
+        "relationship": "Another extension of the base Desargues formalization"
+      }
+    ]
   },
   "sections": [
     {


### PR DESCRIPTION
## Summary

Enrichment pass for four proof entries.

### erdos-151 (quality: 93 → improved)
- Fixed "critical"/"essential" significance → "key"
- Added prerequisites to 6 annotations, deepened historicalContext
- Added 5th keyInsight, 2 new sections, cross-reference to ramseys-theorem

### birthday-problem (quality: 97 → improved)
- Fixed 3 "critical" significance → "key"
- Added prerequisites to 7 annotations
- Added 2 new annotations: expected pairs + 99% threshold
- Added relatedProblems cross-reference

### binomial-theorem-oq-01 (quality: 97 → improved)
- Fixed stale "axiom" references in 4 places — main theorem is now fully proved
- Added relatedProblems cross-reference

### desargues-theorem-oq-04 (quality: 97 → improved)
- Added relatedProblems cross-references to 3 related Desargues proofs

## Axiom integrity
All entries verified consistent ✓