### PR TITLE
Research: Prove 3 core Shannon entropy inequalities (6→3 sorries)

### DIFF
--- a/proofs/Proofs/ShannonEntropy.lean
+++ b/proofs/Proofs/ShannonEntropy.lean
@@ -231,12 +231,83 @@ theorem log_sum_inequality {n : ℕ} {a b : Fin n → ℝ}
 -- Mutual Information and Conditioning (sorry — candidates for Aristotle)
 -- ============================================================
 
--- Mutual information is non-negative
+-- Marginal is positive when joint is positive at some point
+private lemma marginal_pos_of_joint_pos {α β : Type*} [Fintype α] [Fintype β]
+    {pXY : α × β → ℝ} (hp : ∀ xy, 0 ≤ pXY xy)
+    {x : α} {y : β} (hxy : 0 < pXY (x, y)) :
+    0 < ∑ y' : β, pXY (x, y') := by
+  calc 0 < pXY (x, y) := hxy
+    _ ≤ ∑ y' : β, pXY (x, y') :=
+      Finset.single_le_sum (f := fun y' => pXY (x, y'))
+        (fun y' _ => hp (x, y')) (Finset.mem_univ y)
+
+-- Convert flat product sum to nested sum
+private lemma sum_prod_eq_nested {α β : Type*} [Fintype α] [Fintype β]
+    {f : α × β → ℝ} :
+    ∑ xy : α × β, f xy = ∑ x : α, ∑ y : β, f (x, y) := by
+  rw [← Finset.univ_product_univ, Finset.sum_product]
+
+-- Product of marginals sums to 1 when joint sums to 1
+private lemma product_marginals_sum_one {α β : Type*} [Fintype α] [Fintype β]
+    {pXY : α × β → ℝ}
+    (hsum : ∑ xy : α × β, pXY xy = 1) :
+    ∑ x : α, ∑ y : β,
+      (∑ y' : β, pXY (x, y')) * (∑ x' : α, pXY (x', y)) =  1 := by
+  have hsum' : ∑ x : α, ∑ y : β, pXY (x, y) = 1 := by
+    rw [← sum_prod_eq_nested]; exact hsum
+  have hmarg_x : ∑ x : α, (∑ y' : β, pXY (x, y')) = 1 := hsum'
+  have hmarg_y : ∑ y : β, (∑ x' : α, pXY (x', y)) = 1 := by
+    rw [Finset.sum_comm]; exact hsum'
+  rw [Finset.sum_comm]
+  simp_rw [← Finset.sum_mul, ← Finset.mul_sum]
+  rw [hmarg_y, mul_one, hmarg_x]
+
+-- Mutual information is non-negative: I(X;Y) = D(pXY || pX⊗pY) ≥ 0
+-- Proof: same pointwise bound technique as KL divergence non-negativity.
 theorem mutual_info_nonneg {α β : Type*} [Fintype α] [Fintype β]
     [DecidableEq α] [DecidableEq β]
     {pXY : α × β → ℝ} (hp : ∀ xy, 0 ≤ pXY xy)
     (hsum : ∑ xy : α × β, pXY xy = 1) :
-    0 ≤ mutualInformation pXY := by sorry
+    0 ≤ mutualInformation pXY := by
+  unfold mutualInformation
+  -- Each term: if p(x,y)=0 then 0, else p(x,y)·log(p(x,y)/(pX(x)·pY(y)))
+  -- Bound: each term ≥ p(x,y) - pX(x)·pY(y)
+  -- Sum: Σ (p(x,y) - pX(x)·pY(y)) = 1 - 1 = 0
+  set q : α → β → ℝ := fun x y =>
+    (∑ y' : β, pXY (x, y')) * (∑ x' : α, pXY (x', y)) with hq_def
+  suffices h : ∑ x : α, ∑ y : β, (pXY (x, y) - q x y) ≤
+      ∑ x : α, ∑ y : β,
+        if pXY (x, y) = 0 then 0
+        else pXY (x, y) * Real.log (pXY (x, y) / q x y) by
+    have hzero : ∑ x : α, ∑ y : β, (pXY (x, y) - q x y) = 0 := by
+      have h1 : ∑ x : α, ∑ y : β, pXY (x, y) = 1 := by
+        rw [← sum_prod_eq_nested]; exact hsum
+      have h2 : ∑ x : α, ∑ y : β, q x y = 1 :=
+        product_marginals_sum_one hsum
+      simp_rw [Finset.sum_sub_distrib]
+      rw [h1, h2, sub_self]
+    linarith
+  apply Finset.sum_le_sum
+  intro x _
+  apply Finset.sum_le_sum
+  intro y _
+  by_cases hpxy : pXY (x, y) = 0
+  · simp [hpxy]
+    exact mul_nonneg
+      (Finset.sum_nonneg (fun y' _ => hp (x, y')))
+      (Finset.sum_nonneg (fun x' _ => hp (x', y)))
+  · simp [hpxy]
+    have hpxy_pos : 0 < pXY (x, y) :=
+      lt_of_le_of_ne (hp (x, y)) (Ne.symm hpxy)
+    have hq_pos : 0 < q x y := by
+      simp only [hq_def]
+      exact mul_pos
+        (marginal_pos_of_joint_pos hp hpxy_pos)
+        (calc 0 < pXY (x, y) := hpxy_pos
+          _ ≤ ∑ x' : α, pXY (x', y) :=
+            Finset.single_le_sum (f := fun x' => pXY (x', y))
+              (fun x' _ => hp (x', y)) (Finset.mem_univ x))
+    linarith [kl_term_bound hpxy_pos hq_pos]
 
 -- Conditioning reduces entropy: H(X|Y) ≤ H(X)
 theorem conditioning_reduces_entropy {α β : Type*} [Fintype α] [Fintype β]

--- a/proofs/Proofs/ShannonEntropy.lean
+++ b/proofs/Proofs/ShannonEntropy.lean
@@ -107,20 +107,119 @@ noncomputable def mutualInformation {α β : Type*} [Fintype α] [Fintype β]
       ((∑ y' : β, pXY (x, y')) * (∑ x' : α, pXY (x', y))))
 
 -- ============================================================
--- Entropy Bounds (axiomatized for Aristotle)
+-- Key Inequality: log(x) ≤ x - 1
 -- ============================================================
 
--- Entropy is maximized by uniform distribution
-theorem entropy_le_log_card {α : Type*} [Fintype α] [DecidableEq α]
-    {p : α → ℝ} (hp : ∀ x, 0 ≤ p x) (hsum : ∑ x, p x = 1) :
-    shannonEntropy p ≤ Real.log (Fintype.card α) := by sorry
+-- For positive reals, p * log(p/q) ≥ p - q
+-- This is the pointwise bound underlying KL divergence non-negativity.
+-- Proof: log(q/p) ≤ q/p - 1, multiply by p, negate.
+private lemma kl_term_bound {p q : ℝ} (hp : 0 < p) (hq : 0 < q) :
+    p * Real.log (p / q) ≥ p - q := by
+  have h1 : Real.log (q / p) ≤ q / p - 1 :=
+    Real.log_le_sub_one_of_pos (div_pos hq hp)
+  have h2 : p * Real.log (q / p) ≤ q - p :=
+    calc p * Real.log (q / p)
+        ≤ p * (q / p - 1) := by
+          apply mul_le_mul_of_nonneg_left h1 (le_of_lt hp)
+      _ = q - p := by field_simp
+  have h3 : Real.log (p / q) = -Real.log (q / p) := by
+    rw [Real.log_div (ne_of_gt hp) (ne_of_gt hq),
+        Real.log_div (ne_of_gt hq) (ne_of_gt hp)]
+    ring
+  have h4 : p * Real.log (p / q) = -(p * Real.log (q / p)) := by
+    rw [h3]; ring
+  linarith
 
--- Gibbs inequality: H(p) ≤ -Σ p(x) log q(x) (= H(p) + D(p||q))
--- Equivalently: KL divergence D(p||q) ≥ 0
+-- ============================================================
+-- KL Divergence Non-negativity
+-- ============================================================
+
+-- KL divergence is non-negative: D(p||q) ≥ 0
+-- Proof: each term p(x)*log(p(x)/q(x)) ≥ p(x)-q(x), sum to get Σp - Σq = 0.
+theorem kl_divergence_nonneg {α : Type*} [Fintype α] [DecidableEq α]
+    {p q : α → ℝ} (hp : ∀ x, 0 ≤ p x) (hq : ∀ x, 0 < q x)
+    (hpsum : ∑ x, p x = 1) (hqsum : ∑ x, q x = 1) :
+    0 ≤ klDivergence p q := by
+  unfold klDivergence
+  -- Each KL term ≥ p(x) - q(x), so the sum ≥ Σ(p-q) = 0
+  suffices h : (∑ x : α, (p x - q x)) ≤
+      ∑ x : α, if p x = 0 then 0 else p x * Real.log (p x / q x) by
+    have hzero : ∑ x : α, (p x - q x) = 0 := by
+      rw [Finset.sum_sub_distrib, hpsum, hqsum, sub_self]
+    linarith
+  apply Finset.sum_le_sum
+  intro x _
+  by_cases hpx : p x = 0
+  · simp [hpx]
+    exact le_of_lt (hq x)
+  · simp [hpx]
+    linarith [kl_term_bound (lt_of_le_of_ne (hp x) (Ne.symm hpx)) (hq x)]
+
+-- ============================================================
+-- Gibbs Inequality
+-- ============================================================
+
+-- Gibbs inequality: H(p) ≤ -Σ p(x) log q(x), equivalent to D(p||q) ≥ 0.
+-- Proof: decompose each KL term as (if p=0 then 0 else p*log p) - p*log q,
+-- then sum to get D(p||q) = Σ(if ..) - Σ p*log q ≥ 0.
 theorem gibbs_inequality {α : Type*} [Fintype α] [DecidableEq α]
     {p q : α → ℝ} (hp : ∀ x, 0 ≤ p x) (hq : ∀ x, 0 < q x)
     (hpsum : ∑ x, p x = 1) (hqsum : ∑ x, q x = 1) :
-    shannonEntropy p ≤ -∑ x, p x * Real.log (q x) := by sorry
+    shannonEntropy p ≤ -∑ x, p x * Real.log (q x) := by
+  have hkl := kl_divergence_nonneg hp hq hpsum hqsum
+  unfold klDivergence at hkl
+  unfold shannonEntropy
+  rw [neg_le_neg_iff]
+  -- Goal: ∑ p·log q ≤ ∑ (if p=0 then 0 else p·log p)
+  -- Decompose each KL term: (if p=0 then 0 else p·log(p/q)) = (if .. else p·log p) - p·log q
+  have h_split : ∀ x : α,
+      (if p x = 0 then 0 else p x * Real.log (p x / q x)) =
+      (if p x = 0 then 0 else p x * Real.log (p x)) - p x * Real.log (q x) := by
+    intro x
+    by_cases hpx : p x = 0
+    · simp [hpx]
+    · simp [hpx]
+      have hpx_pos : 0 < p x := lt_of_le_of_ne (hp x) (Ne.symm hpx)
+      rw [Real.log_div (ne_of_gt hpx_pos) (ne_of_gt (hq x))]
+      ring
+  simp_rw [h_split, Finset.sum_sub_distrib] at hkl
+  linarith
+
+-- ============================================================
+-- Maximum Entropy
+-- ============================================================
+
+-- Entropy is maximized by uniform distribution: H(X) ≤ log |X|
+-- Proof: Apply Gibbs with q = uniform(1/|X|).
+theorem entropy_le_log_card {α : Type*} [Fintype α] [DecidableEq α]
+    {p : α → ℝ} (hp : ∀ x, 0 ≤ p x) (hsum : ∑ x, p x = 1) :
+    shannonEntropy p ≤ Real.log (Fintype.card α) := by
+  -- Derive that α is nonempty (since Σ p = 1 ≠ 0)
+  have hcard_pos : (0 : ℝ) < Fintype.card α := by
+    have hne : Fintype.card α ≠ 0 := by
+      intro hzero
+      haveI : IsEmpty α := Fintype.card_eq_zero_iff.mp hzero
+      simp [Finset.univ_eq_empty] at hsum
+    exact_mod_cast Nat.pos_of_ne_zero hne
+  -- Define uniform distribution q(x) = 1/|X|
+  set q : α → ℝ := fun _ => (Fintype.card α : ℝ)⁻¹ with hq_def
+  have hq_pos : ∀ x : α, 0 < q x := fun _ => inv_pos.mpr hcard_pos
+  have hq_sum : ∑ x : α, q x = 1 := by
+    simp only [hq_def, Finset.sum_const, Finset.card_univ, nsmul_eq_mul]
+    exact mul_inv_cancel₀ (ne_of_gt hcard_pos)
+  -- Apply Gibbs inequality, then simplify -Σ p·log(1/|X|) = log |X|
+  have hgibbs := gibbs_inequality hp hq_pos hsum hq_sum
+  suffices hsuff : -∑ x, p x * Real.log (q x) = Real.log (Fintype.card α) by
+    linarith
+  simp only [hq_def]
+  have h1 : ∑ x : α, p x * Real.log ((Fintype.card α : ℝ)⁻¹) =
+      Real.log ((Fintype.card α : ℝ)⁻¹) * ∑ x : α, p x := by
+    rw [Finset.mul_sum]; congr 1; ext x; ring
+  rw [h1, hsum, mul_one, Real.log_inv, neg_neg]
+
+-- ============================================================
+-- Log-Sum Inequality (sorry — candidate for Aristotle)
+-- ============================================================
 
 -- Log-sum inequality: Σ aᵢ log(aᵢ/bᵢ) ≥ (Σ aᵢ) log(Σ aᵢ / Σ bᵢ)
 theorem log_sum_inequality {n : ℕ} {a b : Fin n → ℝ}
@@ -128,11 +227,9 @@ theorem log_sum_inequality {n : ℕ} {a b : Fin n → ℝ}
     ∑ i, a i * Real.log (a i / b i) ≥
     (∑ i, a i) * Real.log ((∑ i, a i) / ∑ i, b i) := by sorry
 
--- KL divergence is non-negative (Gibbs inequality restated)
-theorem kl_divergence_nonneg {α : Type*} [Fintype α] [DecidableEq α]
-    {p q : α → ℝ} (hp : ∀ x, 0 ≤ p x) (hq : ∀ x, 0 < q x)
-    (hpsum : ∑ x, p x = 1) (hqsum : ∑ x, q x = 1) :
-    0 ≤ klDivergence p q := by sorry
+-- ============================================================
+-- Mutual Information and Conditioning (sorry — candidates for Aristotle)
+-- ============================================================
 
 -- Mutual information is non-negative
 theorem mutual_info_nonneg {α β : Type*} [Fintype α] [Fintype β]

--- a/proofs/Proofs/ShannonEntropyAristotle.lean
+++ b/proofs/Proofs/ShannonEntropyAristotle.lean
@@ -8,6 +8,10 @@
   - Known result likely in Mathlib (Jensen, convexity, etc.)
   - Clean theorem statement with no definition sorries
   - No axioms (use theorem ... := by sorry instead)
+
+  Status: 2 targets remaining (log_sum_inequality, conditioning_reduces_entropy)
+  Already proved in main file: kl_divergence_nonneg, gibbs_inequality,
+  entropy_le_log_card, mutual_info_nonneg
 -/
 import Mathlib
 
@@ -25,34 +29,13 @@ theorem log_sum_inequality {n : ℕ} {a b : Fin n → ℝ}
     (∑ i, a i) * Real.log ((∑ i, a i) / ∑ i, b i) := by sorry
 
 -- ============================================================
--- Mutual Information Non-negativity
+-- Conditioning Reduces Entropy
 -- ============================================================
 
 -- Shannon entropy for finite distributions (reproduced for self-containment)
 noncomputable def shannonEntropy {α : Type*} [Fintype α] [DecidableEq α]
     (p : α → ℝ) : ℝ :=
   -∑ x : α, if p x = 0 then 0 else p x * Real.log (p x)
-
--- Mutual information I(X;Y) = Σ p(x,y) log(p(x,y)/(p(x)p(y)))
-noncomputable def mutualInformation {α β : Type*} [Fintype α] [Fintype β]
-    [DecidableEq α] [DecidableEq β]
-    (pXY : α × β → ℝ) : ℝ :=
-  ∑ x : α, ∑ y : β,
-    if pXY (x, y) = 0 then 0
-    else pXY (x, y) * Real.log (pXY (x, y) /
-      ((∑ y' : β, pXY (x, y')) * (∑ x' : α, pXY (x', y))))
-
--- Mutual information is non-negative: I(X;Y) ≥ 0
--- This is essentially D(p(x,y) || p(x)p(y)) ≥ 0, a KL divergence.
-theorem mutual_info_nonneg {α β : Type*} [Fintype α] [Fintype β]
-    [DecidableEq α] [DecidableEq β]
-    {pXY : α × β → ℝ} (hp : ∀ xy, 0 ≤ pXY xy)
-    (hsum : ∑ xy : α × β, pXY xy = 1) :
-    0 ≤ mutualInformation pXY := by sorry
-
--- ============================================================
--- Conditioning Reduces Entropy
--- ============================================================
 
 -- Conditional entropy H(X|Y) = -Σ_x Σ_y p(x,y) log(p(x,y)/p(y))
 noncomputable def conditionalEntropy {α β : Type*} [Fintype α] [Fintype β]
@@ -64,6 +47,8 @@ noncomputable def conditionalEntropy {α β : Type*} [Fintype α] [Fintype β]
 
 -- Conditioning reduces entropy: H(X|Y) ≤ H(X)
 -- Follows from I(X;Y) = H(X) - H(X|Y) ≥ 0.
+-- Proof strategy: decompose MI as sum of H(X) term and H(X|Y) term,
+-- use mutual_info_nonneg (already proved) to conclude.
 theorem conditioning_reduces_entropy {α β : Type*} [Fintype α] [Fintype β]
     [DecidableEq α] [DecidableEq β]
     {pXY : α × β → ℝ} (hp : ∀ xy, 0 ≤ pXY xy)

--- a/proofs/Proofs/ShannonEntropyAristotle.lean
+++ b/proofs/Proofs/ShannonEntropyAristotle.lean
@@ -1,0 +1,74 @@
+/-
+  Aristotle targets for Shannon Entropy
+  Routine supporting lemmas for automated proof search.
+  See ShannonEntropy.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture
+  - Known result likely in Mathlib (Jensen, convexity, etc.)
+  - Clean theorem statement with no definition sorries
+  - No axioms (use theorem ... := by sorry instead)
+-/
+import Mathlib
+
+namespace InformationTheory.Aristotle
+
+-- ============================================================
+-- Log-Sum Inequality
+-- ============================================================
+
+-- Log-sum inequality: Σ aᵢ log(aᵢ/bᵢ) ≥ (Σ aᵢ) log(Σ aᵢ / Σ bᵢ)
+-- This follows from Jensen's inequality applied to the convex function t ↦ t * log t.
+theorem log_sum_inequality {n : ℕ} {a b : Fin n → ℝ}
+    (ha : ∀ i, 0 ≤ a i) (hb : ∀ i, 0 < b i) :
+    ∑ i, a i * Real.log (a i / b i) ≥
+    (∑ i, a i) * Real.log ((∑ i, a i) / ∑ i, b i) := by sorry
+
+-- ============================================================
+-- Mutual Information Non-negativity
+-- ============================================================
+
+-- Shannon entropy for finite distributions (reproduced for self-containment)
+noncomputable def shannonEntropy {α : Type*} [Fintype α] [DecidableEq α]
+    (p : α → ℝ) : ℝ :=
+  -∑ x : α, if p x = 0 then 0 else p x * Real.log (p x)
+
+-- Mutual information I(X;Y) = Σ p(x,y) log(p(x,y)/(p(x)p(y)))
+noncomputable def mutualInformation {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β]
+    (pXY : α × β → ℝ) : ℝ :=
+  ∑ x : α, ∑ y : β,
+    if pXY (x, y) = 0 then 0
+    else pXY (x, y) * Real.log (pXY (x, y) /
+      ((∑ y' : β, pXY (x, y')) * (∑ x' : α, pXY (x', y))))
+
+-- Mutual information is non-negative: I(X;Y) ≥ 0
+-- This is essentially D(p(x,y) || p(x)p(y)) ≥ 0, a KL divergence.
+theorem mutual_info_nonneg {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β]
+    {pXY : α × β → ℝ} (hp : ∀ xy, 0 ≤ pXY xy)
+    (hsum : ∑ xy : α × β, pXY xy = 1) :
+    0 ≤ mutualInformation pXY := by sorry
+
+-- ============================================================
+-- Conditioning Reduces Entropy
+-- ============================================================
+
+-- Conditional entropy H(X|Y) = -Σ_x Σ_y p(x,y) log(p(x,y)/p(y))
+noncomputable def conditionalEntropy {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β]
+    (pXY : α × β → ℝ) : ℝ :=
+  -(∑ x : α, ∑ y : β,
+    if pXY (x, y) = 0 then 0
+    else pXY (x, y) * Real.log (pXY (x, y) / (∑ x' : α, pXY (x', y))))
+
+-- Conditioning reduces entropy: H(X|Y) ≤ H(X)
+-- Follows from I(X;Y) = H(X) - H(X|Y) ≥ 0.
+theorem conditioning_reduces_entropy {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β]
+    {pXY : α × β → ℝ} (hp : ∀ xy, 0 ≤ pXY xy)
+    (hsum : ∑ xy : α × β, pXY xy = 1) :
+    conditionalEntropy pXY ≤
+    shannonEntropy (fun x => ∑ y : β, pXY (x, y)) := by sorry
+
+end InformationTheory.Aristotle

--- a/research/problems/shannon-entropy/knowledge.md
+++ b/research/problems/shannon-entropy/knowledge.md
@@ -32,3 +32,35 @@
 ### Stats
 - 152 lines, 0 axioms, 6 sorries, 4 definitions, 4 proved theorems/lemmas
 
+## Session 2026-03-21 (researcher-4) - Core Inequalities
+
+**Mode**: REVISIT (MODERATE knowledge score 15)
+**Outcome**: progress — proved 3 key theorems, 3 sorries remain
+
+### What Was Done
+1. **Proved `kl_divergence_nonneg`**: D(p||q) ≥ 0 for probability distributions.
+   Key technique: `Real.log_le_sub_one_of_pos` gives log(x) ≤ x-1. Applied to q/p:
+   log(q/p) ≤ q/p - 1, multiply by p: p·log(q/p) ≤ q-p, negate: p·log(p/q) ≥ p-q.
+   Sum over all x: D(p||q) ≥ Σ(p-q) = 1-1 = 0. Helper: `kl_term_bound`.
+
+2. **Proved `gibbs_inequality`**: H(p) ≤ -Σ p(x) log q(x).
+   Derived from `kl_divergence_nonneg`. Each KL term decomposes as
+   (if p=0 then 0 else p·log p) - p·log q. Used `Finset.sum_sub_distrib` + `linarith`.
+
+3. **Proved `entropy_le_log_card`**: H(X) ≤ log|X|.
+   Applied Gibbs with uniform q = 1/|X|. Factored constant log out of sum, used
+   `mul_inv_cancel₀` for Σ(1/|X|) = 1. Derived `Nonempty α` from Σp = 1 ≠ 0.
+
+### Remaining Sorries (3)
+- `log_sum_inequality`: Σ aᵢ log(aᵢ/bᵢ) ≥ (Σ aᵢ) log(Σaᵢ/Σbᵢ) — needs Jensen for x·log(x)
+- `mutual_info_nonneg`: I(X;Y) ≥ 0 — needs KL divergence applied to joint vs product marginals
+- `conditioning_reduces_entropy`: H(X|Y) ≤ H(X) — follows from mutual_info_nonneg
+
+### Architecture Notes
+- `kl_term_bound` is the pointwise workhorse (private lemma)
+- Proof chain: kl_term_bound → kl_divergence_nonneg → gibbs_inequality → entropy_le_log_card
+- `Finset.sum_sub_distrib` for splitting sums, `Real.log_div` + `ring` for log algebra
+
+### Stats
+- ~250 lines, 0 axioms, 3 sorries, 4 definitions, 7 proved theorems/lemmas
+

--- a/research/problems/shannon-entropy/knowledge.md
+++ b/research/problems/shannon-entropy/knowledge.md
@@ -51,10 +51,22 @@
    Applied Gibbs with uniform q = 1/|X|. Factored constant log out of sum, used
    `mul_inv_cancel₀` for Σ(1/|X|) = 1. Derived `Nonempty α` from Σp = 1 ≠ 0.
 
-### Remaining Sorries (3)
+### Remaining Sorries (3→2 after second session)
 - `log_sum_inequality`: Σ aᵢ log(aᵢ/bᵢ) ≥ (Σ aᵢ) log(Σaᵢ/Σbᵢ) — needs Jensen for x·log(x)
-- `mutual_info_nonneg`: I(X;Y) ≥ 0 — needs KL divergence applied to joint vs product marginals
-- `conditioning_reduces_entropy`: H(X|Y) ≤ H(X) — follows from mutual_info_nonneg
+- ~~`mutual_info_nonneg`~~: PROVED in session 2 (researcher-4)
+- `conditioning_reduces_entropy`: H(X|Y) ≤ H(X) — needs algebraic identity I = H - H|Y
+
+## Session 2026-03-21 (researcher-4, second pass) - Mutual Information
+
+**Mode**: REVISIT
+**Outcome**: proved `mutual_info_nonneg`, 2 sorries remain
+
+### What Was Done
+4. **Proved `mutual_info_nonneg`**: I(X;Y) ≥ 0.
+   Same `kl_term_bound` technique as KL nonneg. Key helpers:
+   - `sum_prod_eq_nested`: convert Σ_{α×β} to Σ_α Σ_β via `Finset.univ_product_univ`
+   - `marginal_pos_of_joint_pos`: p(x,y)>0 ⟹ p_X(x)>0 (via Finset.single_le_sum)
+   - `product_marginals_sum_one`: Σ p_X·p_Y = (Σp_X)·(Σp_Y) = 1·1 = 1
 
 ### Architecture Notes
 - `kl_term_bound` is the pointwise workhorse (private lemma)

--- a/src/data/proofs/shannon-entropy/meta.json
+++ b/src/data/proofs/shannon-entropy/meta.json
@@ -16,7 +16,7 @@
       "advanced"
     ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "Analysis.SpecialFunctions.Log.Basic",

--- a/src/data/proofs/shannon-entropy/meta.json
+++ b/src/data/proofs/shannon-entropy/meta.json
@@ -79,7 +79,7 @@
       "title": "Maximum Entropy (Uniform Distribution)",
       "startLine": 31,
       "endLine": 34,
-      "summary": "Entropy is maximized by the uniform distribution: H(p) <= log|X|. Sorry'd — the proof uses Gibbs inequality with q = uniform.",
+      "summary": "Entropy is maximized by the uniform distribution: H(p) <= log|X|. Proved via Gibbs inequality with q = uniform.",
       "mathContext": "$H(X) \\leq \\ln |\\mathcal{X}|$ with equality iff $p$ is uniform"
     },
     {
@@ -87,7 +87,7 @@
       "title": "Gibbs Inequality",
       "startLine": 36,
       "endLine": 40,
-      "summary": "H(p) <= -sum p(x) log q(x) for any distribution q, equivalently D(p||q) >= 0. Sorry'd — proof via Jensen's inequality on -log (convex).",
+      "summary": "H(p) <= -sum p(x) log q(x) for any distribution q, equivalently D(p||q) >= 0. Proved from KL divergence non-negativity using the inequality log(x) <= x - 1.",
       "mathContext": "$D(p \\| q) = \\sum_x p(x) \\ln \\frac{p(x)}{q(x)} \\geq 0$ (Gibbs inequality)"
     },
     {

--- a/src/data/research/problems/shannon-entropy.json
+++ b/src/data/research/problems/shannon-entropy.json
@@ -21,7 +21,7 @@
     "focus": "Proved entropy_nonneg and entropy_point_mass. Added KL divergence, conditional entropy, mutual information definitions. 6 sorries remain for deeper inequalities."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved kl_divergence_nonneg, gibbs_inequality, entropy_le_log_card (3 sorries eliminated). 3 sorries remain: log_sum_inequality, mutual_info_nonneg, conditioning_reduces_entropy.",
+    "progressSummary": "PROGRESS: Proved 4 of 6 sorry theorems. Proved kl_divergence_nonneg, gibbs_inequality, entropy_le_log_card, mutual_info_nonneg. 2 sorries remain: log_sum_inequality (Jensen), conditioning_reduces_entropy (needs I=H-H|Y identity).",
     "builtItems": [
       {
         "name": "shannonEntropy",
@@ -72,6 +72,26 @@
         "name": "entropy_le_log_card",
         "description": "H(X) <= log|X| (max entropy for uniform)",
         "proven": true
+      },
+      {
+        "name": "sum_prod_eq_nested",
+        "description": "Convert Σ_{α×β} to Σ_α Σ_β (product sum decomposition)",
+        "proven": true
+      },
+      {
+        "name": "marginal_pos_of_joint_pos",
+        "description": "p(x,y)>0 implies p_X(x)>0",
+        "proven": true
+      },
+      {
+        "name": "product_marginals_sum_one",
+        "description": "Σ_{x,y} p_X(x)·p_Y(y) = 1 when Σ p = 1",
+        "proven": true
+      },
+      {
+        "name": "mutual_info_nonneg",
+        "description": "I(X;Y) ≥ 0 via pointwise KL bound",
+        "proven": true
       }
     ],
     "insights": [
@@ -83,13 +103,14 @@
       "kl_term_bound: multiply log(q/p) <= q/p - 1 by p to get p*log(p/q) >= p-q",
       "KL nonneg: sum term-by-term bound p-q, then Σ(p-q) = 1-1 = 0",
       "Gibbs from KL: decompose each KL term as (if p=0 then 0 else p*log p) - p*log q, use Finset.sum_sub_distrib",
-      "Max entropy: apply Gibbs with uniform q=1/|X|, factor constant log out of sum"
+      "Max entropy: apply Gibbs with uniform q=1/|X|, factor constant log out of sum",
+      "sum_prod_eq_nested via Finset.univ_product_univ + Finset.sum_product converts between flat and nested sums",
+      "mutual_info_nonneg: same kl_term_bound technique, but p_Y(y) > 0 when p(x,y) > 0 since marginal sums include the joint",
+      "product_marginals_sum_one: uses Finset.sum_comm to swap sum order + factorization Σ(f·g) = (Σf)·(Σg) when one factor is constant per outer variable"
     ],
     "nextSteps": [
-      "Prove mutual_info_nonneg (relate to KL divergence of joint vs product of marginals)",
-      "Prove conditioning_reduces_entropy (H(X|Y) <= H(X), follows from mutual_info_nonneg)",
-      "Prove log_sum_inequality (Jensen for x*log(x), harder — good Aristotle candidate)",
-      "Create Aristotle companion file for remaining sorries"
+      "Prove conditioning_reduces_entropy: needs algebraic identity I(X;Y) = H(X) - H(X|Y) — extensive log algebra with nested if-then-else",
+      "Prove log_sum_inequality: Jensen for x·log(x) — good Aristotle candidate"
     ]
   },
   "tags": [
@@ -105,8 +126,8 @@
   "tractability": 8,
   "leanFiles": [
     {
-      "sorryCount": 3,
-      "theoremCount": 11
+      "sorryCount": 2,
+      "theoremCount": 15
     }
   ]
 }

--- a/src/data/research/problems/shannon-entropy.json
+++ b/src/data/research/problems/shannon-entropy.json
@@ -8,7 +8,11 @@
   "problemStatement": {
     "formal": "H(X) = -Σ p(x) log p(x); prove non-negativity, max entropy, Gibbs inequality",
     "plain": "Formalize Shannon entropy and prove its fundamental properties: non-negativity, maximum entropy for uniform distribution, Gibbs inequality (KL divergence non-negativity), and the log-sum inequality.",
-    "whyMatters": ["Foundation of information theory", "Enables Shannon coding theorems", "Bridge between CS and mathematics"]
+    "whyMatters": [
+      "Foundation of information theory",
+      "Enables Shannon coding theorems",
+      "Bridge between CS and mathematics"
+    ]
   },
   "currentState": {
     "phase": "ACT",
@@ -17,32 +21,92 @@
     "focus": "Proved entropy_nonneg and entropy_point_mass. Added KL divergence, conditional entropy, mutual information definitions. 6 sorries remain for deeper inequalities."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved entropy non-negativity and point mass entropy=0. Added klDivergence, conditionalEntropy, mutualInformation definitions. 6 sorry theorems remain (Gibbs, log-sum, max entropy, KL nonneg, MI nonneg, conditioning).",
+    "progressSummary": "PROGRESS: Proved kl_divergence_nonneg, gibbs_inequality, entropy_le_log_card (3 sorries eliminated). 3 sorries remain: log_sum_inequality, mutual_info_nonneg, conditioning_reduces_entropy.",
     "builtItems": [
-      {"name": "shannonEntropy", "description": "Shannon entropy H(X) = -Σ p(x) log p(x)", "proven": true},
-      {"name": "klDivergence", "description": "KL divergence D(p||q) = Σ p(x) log(p(x)/q(x))", "proven": true},
-      {"name": "conditionalEntropy", "description": "H(X|Y) via joint distribution", "proven": true},
-      {"name": "mutualInformation", "description": "I(X;Y) = Σ p(x,y) log(p(x,y)/(p(x)p(y)))", "proven": true},
-      {"name": "entropy_nonneg", "description": "H(X) ≥ 0", "proven": true},
-      {"name": "entropy_point_mass", "description": "H(δ_a) = 0", "proven": true}
+      {
+        "name": "shannonEntropy",
+        "description": "Shannon entropy H(X) = -Σ p(x) log p(x)",
+        "proven": true
+      },
+      {
+        "name": "klDivergence",
+        "description": "KL divergence D(p||q) = Σ p(x) log(p(x)/q(x))",
+        "proven": true
+      },
+      {
+        "name": "conditionalEntropy",
+        "description": "H(X|Y) via joint distribution",
+        "proven": true
+      },
+      {
+        "name": "mutualInformation",
+        "description": "I(X;Y) = Σ p(x,y) log(p(x,y)/(p(x)p(y)))",
+        "proven": true
+      },
+      {
+        "name": "entropy_nonneg",
+        "description": "H(X) ≥ 0",
+        "proven": true
+      },
+      {
+        "name": "entropy_point_mass",
+        "description": "H(δ_a) = 0",
+        "proven": true
+      },
+      {
+        "name": "kl_term_bound",
+        "description": "Pointwise bound: p*log(p/q) >= p-q using log(x) <= x-1",
+        "proven": true
+      },
+      {
+        "name": "kl_divergence_nonneg",
+        "description": "KL divergence D(p||q) >= 0",
+        "proven": true
+      },
+      {
+        "name": "gibbs_inequality",
+        "description": "H(p) <= -Σ p(x) log q(x)",
+        "proven": true
+      },
+      {
+        "name": "entropy_le_log_card",
+        "description": "H(X) <= log|X| (max entropy for uniform)",
+        "proven": true
+      }
     ],
     "insights": [
       "entropy_nonneg proof: each term -p(x)log(p(x)) ≥ 0 because 0 < p(x) ≤ 1 implies log(p(x)) ≤ 0",
       "entropy_point_mass: when p concentrated at a, p(a)=1 so log(1)=0, all other terms vanish",
       "Key remaining: Gibbs inequality needs Jensen's inequality on -log (convex function), or direct log-sum inequality",
-      "Mathlib has Real.log_nonpos, Finset.sum_nonpos — sufficient for basic proofs"
+      "Mathlib has Real.log_nonpos, Finset.sum_nonpos — sufficient for basic proofs",
+      "Key inequality: Real.log_le_sub_one_of_pos gives log(x) <= x-1, foundation for KL divergence nonneg proof",
+      "kl_term_bound: multiply log(q/p) <= q/p - 1 by p to get p*log(p/q) >= p-q",
+      "KL nonneg: sum term-by-term bound p-q, then Σ(p-q) = 1-1 = 0",
+      "Gibbs from KL: decompose each KL term as (if p=0 then 0 else p*log p) - p*log q, use Finset.sum_sub_distrib",
+      "Max entropy: apply Gibbs with uniform q=1/|X|, factor constant log out of sum"
     ],
     "nextSteps": [
-      "Prove log_sum_inequality (foundation for Gibbs and max entropy)",
-      "Prove gibbs_inequality from log_sum or Jensen",
-      "Prove entropy_le_log_card from Gibbs with q = uniform",
-      "Prove kl_divergence_nonneg (equivalent to Gibbs)",
-      "Submit remaining sorries to Aristotle"
+      "Prove mutual_info_nonneg (relate to KL divergence of joint vs product of marginals)",
+      "Prove conditioning_reduces_entropy (H(X|Y) <= H(X), follows from mutual_info_nonneg)",
+      "Prove log_sum_inequality (Jensen for x*log(x), harder — good Aristotle candidate)",
+      "Create Aristotle companion file for remaining sorries"
     ]
   },
-  "tags": ["information-theory", "analysis", "probability", "cs-math-bridge", "marquee-phase-2"],
+  "tags": [
+    "information-theory",
+    "analysis",
+    "probability",
+    "cs-math-bridge",
+    "marquee-phase-2"
+  ],
   "started": "2026-03-21T21:00:00Z",
   "lastUpdate": "2026-03-21T21:30:00Z",
   "significance": 9,
-  "tractability": 8
+  "tractability": 8,
+  "leanFiles": [
+    {
+      "sorryCount": 3,
+      "theoremCount": 11
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Prove `kl_divergence_nonneg`: D(p||q) ≥ 0 using Real.log_le_sub_one_of_pos
- Prove `gibbs_inequality`: H(p) ≤ -Σ p(x) log q(x) from KL divergence non-negativity
- Prove `entropy_le_log_card`: H(X) ≤ log|X| via Gibbs with uniform distribution
- Add Aristotle companion file for 3 remaining sorries (log_sum, MI nonneg, conditioning)

## Progress
- **3 theorems proved** (kl_divergence_nonneg, gibbs_inequality, entropy_le_log_card)
- **1 helper lemma** (kl_term_bound: pointwise p·log(p/q) ≥ p-q)
- **Sorry count**: 6 → 3
- **Docker build**: passes with 0 errors, 3 sorry warnings

## Proof Technique
Key inequality: `Real.log_le_sub_one_of_pos` gives log(x) ≤ x-1. Applied pointwise:
- log(q/p) ≤ q/p - 1 → p·log(p/q) ≥ p - q
- Sum: D(p||q) ≥ Σ(p-q) = 1-1 = 0

Chain: kl_term_bound → kl_divergence_nonneg → gibbs_inequality → entropy_le_log_card

## Remaining Sorries
- `log_sum_inequality` — needs Jensen for x·log(x)
- `mutual_info_nonneg` — needs KL on joint vs product marginals
- `conditioning_reduces_entropy` — follows from MI nonneg

## Status
**Outcome**: progress
**Next Steps**: Aristotle companion file submitted for automated proof search

🤖 Generated by researcher-4