### PR TITLE
Enrich 10 gallery proofs: prerequisites, cross-references, status fixes

### DIFF
--- a/src/data/proofs/erdos-16/annotations.json
+++ b/src/data/proofs/erdos-16/annotations.json
@@ -10,11 +10,16 @@
     "title": "Problem Overview",
     "content": "**Erdős Problem #16**: Odd Integers Not of the Form 2^k + p\n\n**Question**: Is the set of odd integers NOT representable as 2^k + p the union of an arithmetic progression and a density-0 set?\n\n**Status**: SOLVED (DISPROVED - Chen 2023)\n\n**Answer**: NO. The exceptional set has more complex structure.\n\nErdős called this conjecture 'rather silly' - and he was right to be skeptical!",
     "mathContext": "OEIS A006285 lists the exceptional odd integers: 1, 127, 149, 251, 331, 337, 373, 509, 599, 701, ...",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "romanoff-type",
       "covering-congruences",
       "chen-2023"
+    ],
+    "prerequisites": [
+      "number theory basics",
+      "prime numbers",
+      "powers of 2"
     ]
   },
   {
@@ -33,6 +38,11 @@
       "romanoff-1934",
       "exceptional-set",
       "OEIS-A006285"
+    ],
+    "prerequisites": [
+      "Romanoff's theorem",
+      "exceptional sets",
+      "asymptotic density"
     ]
   },
   {
@@ -46,11 +56,16 @@
     "title": "Romanoff Numbers and Exceptional Set",
     "content": "**IsRomanoff n**: ∃ k ≥ 1, ∃ prime p, n = 2^k + p\n\n**ExceptionalSet** = { n : Odd n ∧ ¬IsRomanoff n }\n\nThe odd integers that cannot be written as a power of 2 plus a prime.",
     "mathContext": "The condition k ≥ 1 ensures 2^k ≥ 2. For n to be Romanoff, we need n - 2^k prime for some valid k.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "romanoff",
       "exceptional",
       "odd-integers"
+    ],
+    "prerequisites": [
+      "prime numbers",
+      "powers of 2",
+      "odd integers"
     ]
   },
   {
@@ -69,6 +84,10 @@
       "characterization",
       "composite",
       "test"
+    ],
+    "prerequisites": [
+      "ExceptionalSet",
+      "primality testing"
     ]
   },
   {
@@ -87,6 +106,11 @@
       "asymptotic-density",
       "lower-density",
       "romanoff-theorem"
+    ],
+    "prerequisites": [
+      "asymptotic density",
+      "liminf",
+      "Romanoff's theorem"
     ]
   },
   {
@@ -100,11 +124,16 @@
     "title": "Covering Congruences",
     "content": "**IsCoveringSystem residues**: The residue classes cover all integers.\n∀ n : ℤ, ∃ (r, m) ∈ residues, n ≡ r (mod m)\n\n**Erdős (1950)**: Using covering congruences, proved the exceptional set CONTAINS an infinite arithmetic progression.\n\n**axiom exceptional_contains_progression**: ∃ a, d > 0 such that a + md ∈ ExceptionalSet for all m.",
     "mathContext": "Covering congruences ensure that for any n in the constructed progression, n - 2^k is divisible by some small prime for every k.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "covering-system",
       "erdos-1950",
       "arithmetic-progression"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "Chinese Remainder Theorem",
+      "covering systems"
     ]
   },
   {
@@ -118,11 +147,16 @@
     "title": "The Conjecture (FALSE)",
     "content": "**ErdosConjecture16**: ExceptionalSet = (arithmetic progression) ∪ (density-0 set)\n\n∃ a, d > 0 such that lowerDensity(ExceptionalSet \\ {a + md}) = 0\n\n**axiom chen_disproof : ¬ErdosConjecture16**\n\nChen (2023) proved this is FALSE - the exceptional set is more complex!",
     "mathContext": "Erdős hoped the exceptional set had simple structure. Chen showed it contains multiple 'essentially different' parts with positive density.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "chen-2023",
       "disproved",
       "complex-structure"
+    ],
+    "prerequisites": [
+      "arithmetic progressions",
+      "density-0 sets",
+      "set decomposition"
     ]
   },
   {
@@ -141,6 +175,10 @@
       "structure",
       "multiple-progressions",
       "chen"
+    ],
+    "prerequisites": [
+      "Chen's theorem (2023)",
+      "ExceptionalSet structure"
     ]
   },
   {
@@ -159,6 +197,10 @@
       "127",
       "verification",
       "OEIS"
+    ],
+    "prerequisites": [
+      "primality testing",
+      "OEIS sequences"
     ]
   },
   {
@@ -177,6 +219,11 @@
       "covering-system",
       "moduli",
       "construction"
+    ],
+    "prerequisites": [
+      "covering systems",
+      "modular arithmetic",
+      "divisibility"
     ]
   },
   {
@@ -195,6 +242,11 @@
       "density",
       "bounds",
       "positive"
+    ],
+    "prerequisites": [
+      "asymptotic density",
+      "Romanoff's theorem",
+      "covering congruences"
     ]
   },
   {
@@ -213,6 +265,10 @@
       "erdos-9",
       "erdos-10",
       "erdos-11"
+    ],
+    "prerequisites": [
+      "Romanoff-type problems",
+      "Erdős problems #9-#11"
     ]
   },
   {
@@ -231,6 +287,11 @@
       "multiple",
       "independent",
       "positive-density"
+    ],
+    "prerequisites": [
+      "arithmetic progressions",
+      "density",
+      "Chen's disproof"
     ]
   },
   {
@@ -244,11 +305,14 @@
     "title": "Summary and Status",
     "content": "**Erdős Problem #16: SOLVED (DISPROVED)**\n\n**Timeline**:\n- 1934: Romanoff proves positive density are representable\n- 1950: Erdős uses covering congruences to find AP in exceptional set\n- 2023: Chen proves the conjecture is FALSE\n\n**Key Results**:\n- ExceptionalSet has density ~0.09\n- Contains arithmetic progressions\n- NOT just one AP + noise (Chen)\n- Has multiple 'independent' parts\n\n**References**: Romanoff (1934), Erdős (1950), Chen (2023), OEIS A006285",
     "mathContext": "Erdős was right to call his conjecture 'rather silly' - the exceptional set turned out to have rich, complex structure.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": [
       "problem-status",
       "disproved",
       "timeline"
+    ],
+    "prerequisites": [
+      "all preceding definitions and theorems"
     ]
   }
 ]

--- a/src/data/proofs/erdos-16/meta.json
+++ b/src/data/proofs/erdos-16/meta.json
@@ -7,7 +7,7 @@
     "author": "Romanoff (1934), Erdős (1950), Chen (2023)",
     "sourceUrl": "https://erdosproblems.com/16",
     "date": "1950",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos16Problem.lean",
     "tags": [
       "erdos",
@@ -21,7 +21,21 @@
     "erdosNumber": 16,
     "erdosUrl": "https://erdosproblems.com/16",
     "erdosProblemStatus": "solved",
-    "axiomCount": 14
+    "axiomCount": 14,
+    "relatedProblems": [
+      {
+        "id": "bertrands-postulate",
+        "relationship": "Both concern the distribution of primes: Bertrand's postulate guarantees primes in intervals, while Problem #16 asks about representing odd numbers as 2^k + p"
+      },
+      {
+        "id": "prime-number-theorem",
+        "relationship": "The prime density results underlying Romanoff's theorem (positive proportion of odd integers are 2^k + p) depend on prime counting estimates"
+      },
+      {
+        "id": "erdos-1001",
+        "relationship": "Both are solved Erdős problems in analytic number theory with density/measure-theoretic conclusions"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "Romanoff (1934) proved a positive proportion of odd integers can be written as 2^k + p. Erdős (1950) used covering congruences to show the 'exceptional set' (odd integers NOT of this form) contains an infinite arithmetic progression. He conjectured the exceptional set is essentially just this progression plus negligible noise. Chen (2023) disproved this conjecture.",


### PR DESCRIPTION
## Summary
Enrichment pass across 10 gallery entries:

| Entry | Key Changes |
|-------|-------------|
| sqrt2-examples | +2 annotations, +4 cross-refs, +3 tags |
| erdos-151 | Status fix (formalized→axiomatized), +5 cross-refs, +prerequisites on all 8 annotations |
| birthday-problem | +2 annotations, +3 cross-refs, +prerequisites on all 9 annotations |
| binomial-theorem-oq-01 | Status fix (research→verified), updated proof claims (axiom→proved), +3 cross-refs |
| desargues-theorem-oq-04 | +problemStatement, tag fix, +1 cross-ref |
| erdos-1001 | +prerequisites on all 17 annotations, +3 cross-refs, significance fixes |
| erdos-1033 | +3 cross-refs |
| area-of-circle-oq-01-oq-02-oq-01 | +2 cross-refs |
| ballot-problem-oq-03 | +3 cross-refs, tag fix |
| erdos-16 | Status fix (formalized→axiomatized), +prerequisites on all 14 annotations, +3 cross-refs |

## Common improvements
- Added `prerequisites` arrays to annotations that lacked them
- Fixed non-standard `significance` values (critical/essential → key)
- Added `relatedProblems` cross-references
- Corrected status/badge per axiom integrity policy

## Test plan
- [x] All JSON validates
- [x] `pnpm annotations:build` passes (warnings are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)