### PR TITLE
Enrich 5 Millennium Prize entries: sections, annotations, cross-references

### DIFF
--- a/src/data/proofs/hodge-conjecture/annotations.json
+++ b/src/data/proofs/hodge-conjecture/annotations.json
@@ -246,5 +246,44 @@
       "known cases",
       "Millennium Prize"
     ]
+  },
+  {
+    "id": "ann-absolute-hodge",
+    "proofId": "hodge-conjecture",
+    "range": { "startLine": 8699, "endLine": 8761 },
+    "type": "insight",
+    "title": "Absolute Hodge Classes: Deligne's Evidence for the Conjecture",
+    "content": "Deligne introduced the notion of absolute Hodge classes: those Hodge classes $\\alpha \\in H^{p,p}(X) \\cap H^{2p}(X, \\mathbb{Q})$ that remain Hodge under all automorphisms $\\sigma \\in \\text{Aut}(\\mathbb{C}/\\mathbb{Q})$. This is a strictly stronger condition than being Hodge. Deligne proved that for abelian varieties, every Hodge class is absolute Hodge — powerful evidence for the Hodge Conjecture since all known algebraic classes are absolute Hodge. However, absolute Hodge $\\ne$ algebraic in general; there is no known way to construct the algebraic cycle from the absolute Hodge property. The formalization axiomatizes the absolute Hodge condition and Deligne's theorem for abelian varieties.",
+    "mathContext": "Absolute Hodge: $\\alpha$ remains in $H^{p,p}(X^\\sigma)$ for all $\\sigma \\in \\text{Aut}(\\mathbb{C}/\\mathbb{Q})$; algebraic $\\implies$ absolute Hodge $\\implies$ Hodge; for abelian varieties: absolute Hodge = Hodge (Deligne)",
+    "significance": "key",
+    "relatedConcepts": ["absolute Hodge class", "Deligne's theorem", "abelian varieties", "automorphisms of ℂ", "algebraic cycles"],
+    "prerequisites": ["ann-statement"],
+    "tags": ["absolute-hodge", "deligne", "abelian-varieties"]
+  },
+  {
+    "id": "ann-tate-conjecture",
+    "proofId": "hodge-conjecture",
+    "range": { "startLine": 9531, "endLine": 9680 },
+    "type": "context",
+    "title": "The Tate Conjecture: p-adic Analogue of the Hodge Conjecture",
+    "content": "The Tate Conjecture is the arithmetic analogue of the Hodge Conjecture, replacing complex Hodge theory with $\\ell$-adic cohomology over finite fields. For a smooth projective variety $X$ over $\\mathbb{F}_q$, the conjecture asserts that the cycle class map $\\text{CH}^p(X) \\otimes \\mathbb{Q}_\\ell \\to H^{2p}_{\\text{ét}}(X, \\mathbb{Q}_\\ell(p))^{G_{\\mathbb{F}_q}}$ is surjective onto Galois-invariant classes. Tate proved it for divisors on abelian varieties over finite fields; Faltings proved it for divisors on all abelian varieties over number fields. The Hodge-Tate comparison theorem $H^n_{\\text{dR}}(X/K) \\otimes_K \\mathbb{C}_p \\cong \\bigoplus_{p+q=n} H^q(X, \\Omega^p_X) \\otimes_K \\mathbb{C}_p(p)$ connects the two worlds. The formalization axiomatizes the Tate conjecture and its relationship to the Hodge conjecture via comparison theorems.",
+    "mathContext": "Tate: $\\text{CH}^p(X) \\otimes \\mathbb{Q}_\\ell \\twoheadrightarrow H^{2p}(X, \\mathbb{Q}_\\ell(p))^{\\text{Gal}}$; proved for divisors on abelian varieties (Tate, Faltings)",
+    "significance": "key",
+    "relatedConcepts": ["Tate conjecture", "ℓ-adic cohomology", "Galois representations", "Faltings theorem", "Hodge-Tate comparison"],
+    "prerequisites": ["ann-statement"],
+    "tags": ["tate-conjecture", "p-adic", "galois", "arithmetic"]
+  },
+  {
+    "id": "ann-hms",
+    "proofId": "hodge-conjecture",
+    "range": { "startLine": 10113, "endLine": 10332 },
+    "type": "context",
+    "title": "Homological Mirror Symmetry and the Hodge Conjecture",
+    "content": "Kontsevich's homological mirror symmetry (HMS, 1994) proposes an equivalence $D^b(\\text{Coh}(X)) \\cong D^b(\\text{Fuk}(\\check{X}))$ between the derived category of coherent sheaves on $X$ and the Fukaya category of its mirror $\\check{X}$. Under mirror symmetry, Hodge classes on $X$ correspond to Lagrangian submanifolds of $\\check{X}$ — objects with a natural geometric/algebraic structure. This suggests a physical approach to the Hodge Conjecture: if mirror symmetry can produce the algebraic cycle from the Lagrangian. The formalization covers Fourier-Mukai transforms (which preserve Hodge structures), Bridgeland stability conditions, and the mirror of a Hodge class. The non-abelian Hodge correspondence (Simpson) provides an independent bridge between topology (flat connections) and algebraic geometry (Higgs bundles).",
+    "mathContext": "HMS: $D^b(\\text{Coh}(X)) \\cong D^b(\\text{Fuk}(\\check{X}))$; Hodge class $\\leftrightarrow$ Lagrangian; Fourier-Mukai preserves Hodge structure",
+    "significance": "supporting",
+    "relatedConcepts": ["homological mirror symmetry", "Kontsevich", "derived categories", "Fukaya category", "Fourier-Mukai", "Lagrangian"],
+    "prerequisites": ["ann-statement"],
+    "tags": ["mirror-symmetry", "derived-categories", "fukaya", "kontsevich"]
   }
 ]

--- a/src/data/proofs/hodge-conjecture/meta.json
+++ b/src/data/proofs/hodge-conjecture/meta.json
@@ -121,6 +121,62 @@
       "startLine": 1510,
       "endLine": 1560,
       "summary": "Mixed Hodge structures with weight filtration, Deligne's theorem, and pure-to-mixed embedding."
+    },
+    {
+      "id": "absolute-hodge-deligne",
+      "title": "Part LXIX: Absolute Hodge Classes and Deligne's Approach",
+      "startLine": 8699,
+      "endLine": 8761,
+      "summary": "Deligne's notion of absolute Hodge classes: those stable under all automorphisms of ℂ. Deligne proved: for abelian varieties, all Hodge classes are absolute Hodge. This is evidence for the Hodge Conjecture but does not prove it — absolute Hodge ≠ algebraic in general."
+    },
+    {
+      "id": "standard-conjectures",
+      "title": "Part LXX: Grothendieck's Standard Conjectures",
+      "startLine": 8762,
+      "endLine": 8840,
+      "summary": "Grothendieck's four standard conjectures (Lefschetz, Künneth, Hodge, and algebraicity of numerical equivalence) would imply the Hodge Conjecture. They provide the motivic framework: the category of pure motives would be semisimple and abelian."
+    },
+    {
+      "id": "known-cases",
+      "title": "Part LXXI: Known Cases of the Hodge Conjecture",
+      "startLine": 8850,
+      "endLine": 8920,
+      "summary": "Survey of proven cases: divisors (Lefschetz 1,1 theorem, 1924), curves and surfaces, abelian varieties of CM type (Deligne), products of elliptic curves, K3 surfaces, varieties of dimension ≤ 3 in codimension 1. Each case uses different techniques."
+    },
+    {
+      "id": "tate-conjecture",
+      "title": "Part LXXVII: The Tate Conjecture — p-adic Analogue",
+      "startLine": 9531,
+      "endLine": 9680,
+      "summary": "The Tate Conjecture is the p-adic/arithmetic analogue of the Hodge Conjecture: for varieties over finite fields, the cycle class map to ℓ-adic cohomology is surjective onto Galois-invariant classes. Proved for divisors on abelian varieties (Tate, Faltings). The Hodge-Tate comparison theorem connects the two."
+    },
+    {
+      "id": "derived-categories-hms",
+      "title": "Part LXXX: Derived Categories and Homological Mirror Symmetry",
+      "startLine": 10113,
+      "endLine": 10332,
+      "summary": "Kontsevich's homological mirror symmetry: D^b(Coh(X)) ≅ D^b(Fuk(Y)) for mirror pairs. Fourier-Mukai transforms preserve Hodge structures. Bridgeland stability conditions. The mirror of a Hodge class is a Lagrangian cycle — providing a potential physical approach to the Hodge Conjecture."
+    },
+    {
+      "id": "non-abelian-hodge",
+      "title": "Part LXXXI: Non-abelian Hodge Theory and Simpson Correspondence",
+      "startLine": 10333,
+      "endLine": 10555,
+      "summary": "Simpson's non-abelian Hodge correspondence: a diffeomorphism between the moduli of flat connections and the moduli of Higgs bundles. The Hitchin fibration provides an integrable system structure. The P=W conjecture (now theorem) identifies the perverse and weight filtrations."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "yang-mills-mass-gap",
+      "relationship": "Fellow Millennium Prize Problem. Hodge theory connects to the de Rham cohomology of gauge bundles; the Hodge decomposition underlies the Yang-Mills equations on compact manifolds."
+    },
+    {
+      "proofId": "riemann-hypothesis",
+      "relationship": "Fellow Millennium Prize Problem. The Weil conjectures (proved by Deligne) relate to both: they concern the zeta function of varieties over finite fields and use Hodge-theoretic methods."
+    },
+    {
+      "proofId": "birch-swinnerton-dyer",
+      "relationship": "Fellow Millennium Prize Problem. Both concern algebraic cycles: BSD relates to 0-cycles on elliptic curves, while Hodge concerns general algebraic cycles on projective varieties."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Enrichment pass across 5 Millennium Prize Problem entries, adding sections for uncovered parts, annotations with full mathContext/significance/prerequisites/tags, and cross-references linking the entries.

### Yang-Mills Mass Gap
- +8 sections (K-strings, SVZ, entanglement, large-N, KKN, glasma, stochastic)
- +4 annotations (K-string sine law, vacuum condensates, entanglement entropy, KKN 2+1D)
- Sections: 67→75, Annotations: 49→53

### Poincaré Conjecture
- +14 sections (homology sphere, Dehn surgery, lens spaces, foliations, Casson, HF, L-space, Chern-Simons, sphere theorems, Kneser-Milnor, finite extinction, panorama)
- +5 annotations, +3 cross-references
- Sections: 17→31, Annotations: 22→28, Cross-refs: 1→4

### Riemann Hypothesis
- +6 sections (counterexample, Montgomery/RMT, Weil, zero-free, Selberg class)
- +5 annotations, +4 cross-references
- Sections: 7→13, Annotations: 16→21, Cross-refs: 0→4

### Navier-Stokes Existence
- +6 sections (Tao barrier, Kolmogorov, Euler, attractors, primitive equations, regularization)
- +4 annotations, +3 cross-references
- Sections: 16→22, Annotations: 10→14, Related: 0→3

### Hodge Conjecture
- +6 sections (absolute Hodge, Standard Conjectures, known cases, Tate, HMS, non-abelian Hodge)
- +3 annotations, +3 cross-references
- Sections: 10→16, Annotations: 14→17, Cross-refs: 0→3

## Test plan
- [x] All JSON files validate (node JSON.parse)
- [x] All new annotations have mathContext, significance, relatedConcepts, prerequisites

🤖 Generated with [Claude Code](https://claude.com/claude-code)