### PR TITLE
Enrich 4 proofs: annotations, cross-references, format fixes

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -73,7 +73,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "The classical ballot problem (Bertrand 1887) counts vote sequences where candidate A always leads. The 1D reflection principle (a bijection between 'bad paths' and shifted paths) provides an elegant proof. The 2D generalization by Lindström (1973) and Gessel-Viennot (1985) extends this to non-intersecting lattice path pairs, yielding the LGV determinant formula that counts NI paths as a 2×2 determinant.",
+    "historicalContext": "The classical ballot problem, posed by Joseph Bertrand in 1887, asks: if candidate A receives $p$ votes and candidate B receives $q < p$ votes, what is the probability that A leads throughout the count? Désiré André's reflection principle (1887) provided an elegant bijective proof, establishing $P = (p-q)/(p+q)$. This reflection argument became a cornerstone of combinatorial probability.\n\nBernt Lindström (1973) generalized the reflection principle to pairs of non-intersecting lattice paths, proving that the signed count of NI path pairs equals a 2×2 determinant of path counts. Ira Gessel and Gérard Viennot (1985) extended this to $r$-tuples of paths, yielding the LGV lemma: the signed count of non-intersecting path $r$-tuples equals the determinant of an $r \\times r$ matrix of individual path counts. The lemma has found applications in the theory of symmetric functions, plane partitions, and the counting of Standard Young Tableaux via the hook-length formula.",
     "problemStatement": "**Lindström-Gessel-Viennot Lemma (2×2 case)**:\nGiven sources A₁ = (0, a₁), A₂ = (0, a₂) with a₁ ≤ a₂, and targets B₁ = (m, b₁), B₂ = (m, b₂) with b₁ ≤ b₂, the count of non-intersecting path pairs equals:\n\n  niPairCount = C(m+b₁-a₁, m) · C(m+b₂-a₂, m) − C(m+b₁-a₂, m) · C(m+b₂-a₁, m)\n\n**Crossing Lemma** (proved): If y₁ < y₂ and y₁+n₁ > y₂+n₂, paths from (0,y₁) and (0,y₂) with n₁ and n₂ North steps respectively MUST share a lattice point.",
     "proofStrategy": "**Lindström Involution Approach**:\n1. **Crossing Lemma** proves all 'crossing' path pairs (A₁→B₂, A₂→B₁) are intersecting when a₁ ≤ a₂ and b₁ ≤ b₂\n2. **Path Count Formula** gives |pathType m n| = C(m+n, m) by induction (Pascal's identity)\n3. **Lindström Involution**: For any intersecting identity pair (P₁:A₁→B₁, P₂:A₂→B₂), swap tails at first meeting column to get a crossing pair; this is a bijection by Crossing Lemma\n4. **Conclusion**: NI count = all identity - intersecting = all identity - all crossing = lgvDet\n\n**Status**: Crossing Lemma and path count formula fully proved. swapTails infrastructure added. Full involution proof (lgv_lemma_2x2) remains as a sorry.",
     "keyInsights": [
@@ -201,12 +201,16 @@
   },
   "crossReferences": [
     {
-      "targetId": "ballot-problem",
-      "relationship": "extends",
-      "description": "Extends the classical ballot problem with additional combinatorial identities and generalizations."
+      "id": "ballot-problem",
+      "title": "The Ballot Problem",
+      "relationship": "extension",
+      "description": "Extends the classical ballot problem's 1D reflection principle to 2D lattice path pairs, providing the combinatorial foundation for the LGV lemma."
+    },
+    {
+      "id": "catalan-numbers",
+      "title": "Catalan Numbers",
+      "relationship": "related",
+      "description": "The Catalan number Cₙ = C(2n,n)/(n+1) counts non-crossing lattice paths (Dyck paths). This proof unifies Catalan and ballot formulas via catalan_eq_ballot."
     }
-  ],
-  "relatedProofs": [
-    "ballot-problem"
   ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for 4 gallery entries:

### buffons-needle-oq-02-oq-01 (quality 45 → ~100)
- **14 annotations** with mathContext, significance, relatedConcepts, prerequisites
- Deepened historicalContext (Buffon 1777, Barbier 1860, Laplace, concentration of measure)
- 4 cross-references to related Buffon entries
- Prerequisites field added

### yang-mills-mass-gap (quality 45 → ~100)
- **Fixed annotations.json format**: converted `{"annotations":[...]}` to bare `[...]` array (55 annotations were invisible to quality scorer)
- 5 cross-references, prerequisites field added

### sqrt2-examples (quality 96 → 100)
- Expanded 3 sections to 5 for full coverage
- 3 cross-references added

### ballot-problem-oq-03 (quality 97 → 100)
- Expanded historicalContext from 406 to 800+ chars (Bertrand, André, Lindström, Gessel-Viennot)
- Fixed crossReferences format, added Catalan numbers reference

## Test plan
- [x] All JSON validates
- [x] No new annotation build errors
- [x] No content removed, only additions and format fixes