### PR TITLE
Research: Inverse Galois A5 — prove q_derivative_eq, 0 sorries

### DIFF
--- a/proofs/Proofs/InverseGaloisA5.lean
+++ b/proofs/Proofs/InverseGaloisA5.lean
@@ -1293,14 +1293,10 @@ theorem prod_eval_derivative_eq_resultant :
 /-- q'(x) = 5x⁴ - 20x³ + 30x² - 20x + 25. -/
 private theorem q_derivative_eq :
     Polynomial.derivative q = C 5 * X ^ 4 - C 20 * X ^ 3 + C 30 * X ^ 2 - C 20 * X + C 25 := by
-  unfold q
   ext n
-  simp only [q, Polynomial.coeff_derivative, Polynomial.coeff_sub, Polynomial.coeff_add,
-    Polynomial.coeff_mul_C, Polynomial.coeff_C_mul, Polynomial.coeff_X_pow,
-    Polynomial.coeff_C, Polynomial.coeff_one, Polynomial.coeff_X]
-  -- Trivial derivative computation, needs Mathlib API adaptation for v4.26.0
-  -- Verified numerically: d/dx(x⁵-5x⁴+10x³-10x²+25x-5) = 5x⁴-20x³+30x²-20x+25
-  sorry
+  unfold q
+  simp only [coeff_derivative, coeff_sub, coeff_add, coeff_C_mul, coeff_X_pow, coeff_C, coeff_X]
+  rcases n with _ | _ | _ | _ | _ | n <;> simp <;> ring
 
 private theorem q_derivative_natDegree :
     (Polynomial.derivative q).natDegree = 4 := by
@@ -1338,26 +1334,7 @@ private theorem eval_derivative_factored (x : SF) :
 -- Step F2: Sophie Germain identity
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-/-- disc(q) = 1024000000 over ℚ.
-    The discriminant of X⁵ - 5X⁴ + 10X³ - 10X² + 25X - 5
-    equals 2¹⁶ · 5⁶ = 1024000000.
-
-    **Verified approach** (Session 2026-03-21):
-    1. disc(q) = Res(q, q') = det(sylvester q q' 5 4) — 9×9 Sylvester matrix.
-    2. `native_decide` on 9×9 `Matrix.det` stack-overflows in Lean 4 (even with
-       `LEAN_STACK_SIZE=256MB`). So does `decide`. 9! = 362880 permutations exceeds
-       the compiler's recursion limit.
-    3. Double cofactor expansion along column 0 reduces to 5 unique 7×7 determinants,
-       all verified by `native_decide` on `Matrix (Fin 7) (Fin 7) ℤ`:
-       - A₀ = 1924000000, A₃ = 256000000, A₄ = -1012000000
-       - B₁ = 1012000000, B₄ = 420000000
-    4. det(M) = 1·(A₀ + 20·A₃ + 5·A₄) + 5·(-5·A₃ - B₁ + 5·B₄)
-             = 1984000000 + 5·(-192000000) = 1024000000 ✓
-    5. Remaining: connect `Polynomial.sylvester` entries to explicit 7×7 ℤ matrices
-       via `Matrix.det_succ_column_zero` and `Polynomial.coeff` lemmas (~200 lines).
-
-    **Actual proof**: See `disc_q_val` after `vandermondeProduct_sq_eq_proved`. -/
-theorem disc_q_val : Polynomial.discr q = (1024000000 : ℚ) := by sorry -- proved below
+-- disc(q) = 1024000000: See `disc_q_val_proved` after `vandermondeProduct_sq_eq_proved`.
 
 /-- Sophie Germain: y⁴ + 4 = (y²+2y+2)(y²-2y+2). -/
 private theorem sophie_germain {R : Type*} [CommRing R] (y : R) :
@@ -1600,6 +1577,9 @@ theorem disc_q_val_proved : Polynomial.discr q = (1024000000 : ℚ) := by
   rw [vandermondeProduct_sq_eq_proved]
   rw [show (1024000000 : ℚ) = ((1024000000 : ℤ) : ℚ) from by norm_cast]
   exact (IsScalarTower.algebraMap_apply ℤ ℚ q.SplittingField 1024000000).symm
+
+/-- Alias for backward compatibility. -/
+theorem disc_q_val : Polynomial.discr q = (1024000000 : ℚ) := disc_q_val_proved
 
 -- Section E: Axiom Replacement Summary
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -51,7 +51,7 @@
         "Mathlib.RingTheory.Polynomial.GaussLemma",
         "Mathlib.NumberTheory.LSeries.PrimesInAP"
       ],
-      "note": "Total across 6 files: InverseGalois.lean (1881 lines, 143 thms, 2 axioms, 2 sorries), InverseGaloisA5.lean (1924 lines, 102 thms, 1 axiom, 0 sorries), InverseGaloisD4.lean (682 lines, 29 thms, 0 axioms, 0 sorries), InverseGaloisF20.lean (529 lines, 27 thms, 0 axioms, 0 sorries), AbelRuffiniGaloisExtensions.lean (534 lines, 62 thms, 0 sorries), AbelRuffini.lean (185 lines, 11 thms, 0 sorries). vandermondeProduct_sq_eq PROVED via ℂ embedding + Sophie Germain identity. 3 dead sorry theorems removed (abandoned resultant approach)."
+      "note": "Total across 6 files: InverseGalois.lean (1881 lines, 143 thms, 2 axioms, 2 sorries), InverseGaloisA5.lean (1993 lines, 102 thms, 1 axiom, 0 sorries), InverseGaloisD4.lean (682 lines, 29 thms, 0 axioms, 0 sorries), InverseGaloisF20.lean (529 lines, 27 thms, 0 axioms, 0 sorries), AbelRuffiniGaloisExtensions.lean (534 lines, 62 thms, 0 sorries), AbelRuffini.lean (185 lines, 11 thms, 0 sorries). vandermondeProduct_sq_eq PROVED via ℂ embedding + Sophie Germain identity. q_derivative_eq PROVED via ext + coefficient case analysis. disc_q_val sorry removed (proved as disc_q_val_proved via Vandermonde chain)."
     },
     "mathlibDependencies": [
       {

--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: All 7×7 cofactor subterms verified. 8×8 dets proved. Blocked on 9→8 det_succ_row pattern matching (Fin representation issue).",
+    "progressSummary": "PROGRESS: Eliminated all sorries from InverseGaloisA5.lean. q_derivative_eq proved via ext + coefficient case analysis. disc_q_val sorry removed (dead code, disc_q_val_proved exists). File now has 0 sorries, 1 axiom (three_dvd_gal_card). Only remaining work: prove three_dvd_gal_card (needs Dedekind theorem).",
     "builtItems": [
       "InverseGalois.lean: cyclotomic Galois theory, S₃ realization via Gal(X³-2)≅S₃ (905 lines, builds)",
       "InverseGaloisD4.lean: D₄ realization via |Gal(X⁴-2)| = 8 (666 lines, builds)",
@@ -198,7 +198,9 @@
       "prod_eval_derivative_eq_resultant: ∏ eval αᵢ q'_SF = Res(q_SF, q'_SF) via resultant_prod_left",
       "InverseGaloisA5Resultant2.lean: Sylvester matrix rows 5-8 verified (9 fin_cases each)",
       "InverseGaloisA5Resultant.lean: Sylvester matrix rows 0-4 verified",
-      "InverseGaloisA5ResultantDet.lean: 5 independent 7×7 determinants proved via native_decide (420M, 1012M, 256M, -1012M, 1924M)"
+      "InverseGaloisA5ResultantDet.lean: 5 independent 7×7 determinants proved via native_decide (420M, 1012M, 256M, -1012M, 1924M)",
+      "q_derivative_eq: proved derivative of q via coefficient comparison (line 1294)",
+      "disc_q_val: sorry removed, aliased to disc_q_val_proved (line 1600)"
     ],
     "insights": [
       "Cyclotomic irreducibility over ℚ IS in Mathlib: Polynomial.cyclotomic.irreducible_rat",
@@ -285,7 +287,10 @@
       "8×8 det(M84)=-192M and det(M88)=1984M proved via det_succ_row + per-term native_decide + vector sum native_decide",
       "Remaining blocker: connecting 9×9 det to 8×8 submatrices via det_succ_row. After fin_cases j, rw cannot find M.submatrix pattern — Fin representation mismatch",
       "Workaround tried: conv_lhs, simp only, explicit shows — all fail on pattern matching for nonzero cofactor terms",
-      "Key verified fact: det(sylvM) = 5*(-192M) + 1984M = 1024000000 (5 independent 7×7 native_decide + arithmetic)"
+      "Key verified fact: det(sylvM) = 5*(-192M) + 1984M = 1024000000 (5 independent 7×7 native_decide + arithmetic)",
+      "q_derivative_eq PROVED via ext + coefficient case analysis (rcases n with _ | _ | _ | _ | _ | n, simp for each case)",
+      "disc_q_val sorry REMOVED — was dead code, disc_q_val_proved exists via Vandermonde chain",
+      "After this session: InverseGaloisA5.lean has 0 sorries, 1 axiom (three_dvd_gal_card)"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- Prove `q_derivative_eq` — the last sorry on the critical path of the A5 inverse Galois proof
- Remove dead `disc_q_val` sorry (replaced by `disc_q_val_proved` via Vandermonde chain)
- `InverseGaloisA5.lean` now has **0 sorries**, 1 axiom (`three_dvd_gal_card`)

## Progress
- `q_derivative_eq`: Proved via `ext n` + coefficient case analysis (`rcases n with _ | _ | _ | _ | _ | n <;> simp <;> ring`)
- `disc_q_val`: Removed sorry version, added alias to `disc_q_val_proved` after the proof
- Docker build verified: builds cleanly with 0 errors

## Findings
- The derivative computation `ring` failed because it can't fold `C a * C b` into `C (a*b)` — coefficient-by-coefficient comparison via `ext` is more robust
- The entire vandermondeProduct proof chain (VP² = disc(q) = 1024000000) is now sorry-free

## Status
**Outcome**: completed
**Next Steps**: Only `three_dvd_gal_card` axiom remains (needs Dedekind's theorem, not in Mathlib)

🤖 Generated by researcher-4