### PR TITLE
Enrich 3 proofs: Buffon Noodle, Yang-Mills format fix, Chords mathContext

### DIFF
--- a/src/data/proofs/product-of-segments-of-chords/annotations.json
+++ b/src/data/proofs/product-of-segments-of-chords/annotations.json
@@ -9,12 +9,14 @@
     "type": "concept",
     "title": "Intersecting Chords",
     "content": "The **Product of Segments of Chords** theorem states that when two chords of a circle intersect at a point P:\n\n$$PA \\cdot PB = PC \\cdot PD$$\n\nThis elegant result says that the product of the segments is the same for *any* chord through P. The product depends only on P's position relative to the circle, not on which direction the chord goes.",
+    "mathContext": "$PA \\cdot PB = PC \\cdot PD$ for any two chords $AB$, $CD$ intersecting at $P$. Both products equal $|\\text{pow}(P)| = |r^2 - |PO|^2|$.",
     "significance": "critical",
     "relatedConcepts": [
       "circle geometry",
       "power of a point",
       "Euclid's Elements"
-    ]
+    ],
+    "prerequisites": ["circle", "chord", "Euclidean distance"]
   },
   {
     "id": "ann-power",
@@ -62,14 +64,14 @@
     "type": "proof",
     "title": "Algebraic Approach",
     "content": "**Vieta's Formulas Approach**:\n\nParameterize points on a chord through P in direction $\\vec{d}$:\n$$Q(t) = P + t\\vec{d}$$\n\nA point is on the circle of radius r centered at origin iff:\n$$|P + t\\vec{d}|^2 = r^2$$\n\nExpanding (with $|\\vec{d}| = 1$):\n$$t^2 + 2t\\langle P, \\vec{d}\\rangle + |P|^2 - r^2 = 0$$\n\nBy **Vieta's formulas**, the product of roots is:\n$$t_1 \\cdot t_2 = |P|^2 - r^2$$\n\nSince distances are $|t_1|$ and $|t_2|$, we get $|t_1| \\cdot |t_2| = r^2 - |P|^2$ for interior points.",
-    "mathContext": "$t^2 + 2t\\langle P, \\vec{d}\\rangle + (|P|^2 - r^2) = 0$; by Vieta: $t_1 \\cdot t_2 = |P|^2 - r^2$",
+    "mathContext": "$t^2 + 2t\\langle P, \\vec{d}\\rangle + (\\|P\\|^2 - r^2) = 0$; Vieta gives $t_1 \\cdot t_2 = \\|P\\|^2 - r^2 = \\text{pow}(P)$.",
     "significance": "key",
     "relatedConcepts": [
       "Vieta's formulas",
       "quadratic equations",
       "parametric lines"
     ],
-    "prerequisites": ["inner product", "quadratic formula", "polynomial roots"]
+    "prerequisites": ["quadratic formula", "inner product", "norm"]
   },
   {
     "id": "ann-center",
@@ -81,6 +83,7 @@
     "type": "example",
     "title": "Special Case: Center",
     "content": "When P is at the **center** of the circle:\n\n- Every chord through P is a diameter\n- Both segments have length r (the radius)\n- The product is $r \\cdot r = r^2$\n\nThis confirms our formula since pow(center) = $0^2 - r^2 = -r^2$, and $|\\text{pow}| = r^2$.\n\nThis is the *maximum* value of PA * PB for any interior point.",
+    "mathContext": "At center $O$: $PA \\cdot PB = r \\cdot r = r^2$ for every chord (each is a diameter). $\\text{pow}(O) = 0 - r^2 = -r^2$.",
     "significance": "supporting",
     "relatedConcepts": [
       "diameter",
@@ -97,12 +100,14 @@
     "type": "theorem",
     "title": "The Converse",
     "content": "**Converse Theorem**:\n\nIf lines AB and CD intersect at P, and:\n$$PA \\cdot PB = PC \\cdot PD$$\n\nthen A, B, C, D all lie on a common circle (they are **concyclic**).\n\nThis is a powerful criterion for proving four points lie on a circle. The converse follows because equal products imply equal power, which determines a unique circle.",
+    "mathContext": "$PA \\cdot PB = PC \\cdot PD \\implies A, B, C, D$ are concyclic. Equal products mean equal power, determining a unique circle through any three of the four points.",
     "significance": "key",
     "relatedConcepts": [
       "concyclic points",
       "circumcircle",
       "cyclic quadrilaterals"
-    ]
+    ],
+    "prerequisites": ["power of a point", "circle through three points"]
   },
   {
     "id": "ann-examples",

--- a/src/data/proofs/product-of-segments-of-chords/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Power_of_a_point",
     "date": "~300 BCE",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "geometry",
       "circles",


### PR DESCRIPTION
## Summary

Enrichment pass for three gallery entries.

### 1. `buffons-needle-oq-02-oq-01` — N-Dimensional Buffon Noodle (quality: 45 → enriched)
- **14 annotations** covering all 7 parts, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- **Deepened historicalContext**: Added Barbier (1860), concentration of measure, Gamma derivation
- **2 new keyInsights**: π-sandwiching from dimension comparisons, Wallis product connection
- **4 cross-references** to buffons-needle, buffons-needle-oq-01, buffons-needle-oq-01-oq-01, buffons-needle-oq-02

### 2. `yang-mills-mass-gap` — Yang-Mills Existence and Mass Gap (quality: 45 → 100)
- **Fixed annotations.json format** from nested `{"annotations": [...]}` to flat `[...]` (scorer expects flat array)
- **Added 5 cross-references**: yang-mills, navier-stokes-existence, riemann-hypothesis, hodge-conjecture, poincare-conjecture
- Entry already had 55 rich annotations — the format fix alone restored 55 quality points

### 3. `product-of-segments-of-chords` — Product of Segments of Chords (quality: 96 → 100)
- **Added mathContext** to 4 annotations (ann-intro, ann-algebraic, ann-center, ann-converse)
- **Added prerequisites** to 3 annotations
- **Fixed status** from "verified" to "axiomatized" (file has 1 axiom: `converse_product_implies_concyclic_axiom`)