### PR TITLE
Enrich cauchy-schwarz-oq-01-oq-01 and yang-mills-mass-gap

### DIFF
--- a/src/data/proofs/yang-mills-mass-gap/annotations.json
+++ b/src/data/proofs/yang-mills-mass-gap/annotations.json
@@ -1,719 +1,1667 @@
-{
-  "annotations": [
-    {
-      "id": "gauge-group-typeclass",
-      "proofId": "yang-mills-mass-gap",
-      "type": "definition",
-      "range": { "startLine": 59, "endLine": 78 },
-      "title": "CompactSimpleGaugeGroup Typeclass",
-      "content": "Introduces a custom typeclass `CompactSimpleGaugeGroup` capturing the essential properties of gauge groups: $G$ is a compact, connected Lie group with simple (non-abelian) Lie algebra. Simplicity means the only normal subgroups are trivial ($\\bot$) or the whole group ($\\top$). This allows all 273+ theorems to be polymorphic over the gauge group, applying equally to $\\mathrm{SU}(2)$, $\\mathrm{SU}(3)$, or any compact simple group.",
-      "mathContext": "$G$ compact connected, $\\forall H \\trianglelefteq G,\\ H = \\{e\\} \\lor H = G$; Lie algebra $\\mathfrak{g}$ is the space of traceless anti-Hermitian matrices for $\\mathrm{SU}(n)$",
-      "significance": "key",
-      "relatedConcepts": ["Lie group", "simple group", "compact group", "gauge symmetry"],
-      "prerequisites": ["Group", "TopologicalSpace", "CompactSpace", "Subgroup.Normal"],
-      "tags": ["gauge-theory", "typeclass", "lie-group"]
+[
+  {
+    "id": "gauge-group-typeclass",
+    "proofId": "yang-mills-mass-gap",
+    "type": "definition",
+    "range": {
+      "startLine": 59,
+      "endLine": 78
     },
-    {
-      "id": "minkowski-metric",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 82, "endLine": 147 },
-      "title": "Minkowski Metric Formalization",
-      "content": "The Minkowski metric $\\eta_{\\mu\\nu}$ with signature $(-,+,+,+)$ is formalized with fully proved properties: diagonality ($\\eta_{\\mu\\nu} = 0$ for $\\mu \\ne \\nu$), symmetry, $\\eta_{00} = -1$, $\\eta_{ii} = 1$ for $i \\ge 1$, trace $\\eta^\\mu_\\mu = 2$, and Lorentzian signature $(1,3)$. The squared norm $s^2 = -t^2 + x^2 + y^2 + z^2$ distinguishes spacelike, timelike, and lightlike separations.",
-      "mathContext": "$\\eta = \\text{diag}(-1, 1, 1, 1)$, $\\text{tr}(\\eta) = 2$, signature $(1,3)$",
-      "significance": "supporting",
-      "relatedConcepts": ["special relativity", "Lorentzian geometry", "metric signature", "Minkowski space"],
-      "prerequisites": ["Matrix", "Fin 4", "Real"],
-      "tags": ["special-relativity", "metric", "spacetime"]
+    "title": "CompactSimpleGaugeGroup Typeclass",
+    "content": "Introduces a custom typeclass `CompactSimpleGaugeGroup` capturing the essential properties of gauge groups: $G$ is a compact, connected Lie group with simple (non-abelian) Lie algebra. Simplicity means the only normal subgroups are trivial ($\\bot$) or the whole group ($\\top$). This allows all 273+ theorems to be polymorphic over the gauge group, applying equally to $\\mathrm{SU}(2)$, $\\mathrm{SU}(3)$, or any compact simple group.",
+    "mathContext": "$G$ compact connected, $\\forall H \\trianglelefteq G,\\ H = \\{e\\} \\lor H = G$; Lie algebra $\\mathfrak{g}$ is the space of traceless anti-Hermitian matrices for $\\mathrm{SU}(n)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lie group",
+      "simple group",
+      "compact group",
+      "gauge symmetry"
+    ],
+    "prerequisites": [
+      "Group",
+      "TopologicalSpace",
+      "CompactSpace",
+      "Subgroup.Normal"
+    ],
+    "tags": [
+      "gauge-theory",
+      "typeclass",
+      "lie-group"
+    ]
+  },
+  {
+    "id": "minkowski-metric",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 82,
+      "endLine": 147
     },
-    {
-      "id": "yang-mills-equations",
-      "proofId": "yang-mills-mass-gap",
-      "type": "context",
-      "range": { "startLine": 197, "endLine": 251 },
-      "title": "The Classical Yang-Mills Equations",
-      "content": "Formalizes the Yang-Mills action $S[A] = -\\frac{1}{4g^2} \\int \\text{Tr}(F_{\\mu\\nu} F^{\\mu\\nu})$ and the classical equations of motion $D_\\mu F^{\\mu\\nu} = 0$ (Yang-Mills equation) and $D_{[\\mu} F_{\\nu\\rho]} = 0$ (Bianchi identity). Unlike Maxwell's equations, these are non-linear because the covariant derivative $D$ involves the gauge field $A$ itself, with the commutator $[A_\\mu, A_\\nu]$ in the field strength. This non-linearity gives rise to gluon self-interactions, asymptotic freedom, and confinement.",
-      "mathContext": "$S[A] = -\\frac{1}{4g^2} \\int \\text{Tr}(F^2)$, $D_\\mu F^{\\mu\\nu} = 0$, $F_{\\mu\\nu} = \\partial_\\mu A_\\nu - \\partial_\\nu A_\\mu + [A_\\mu, A_\\nu]$",
-      "significance": "key",
-      "relatedConcepts": ["gauge field", "field strength tensor", "covariant derivative", "non-linear PDE"],
-      "prerequisites": ["GaugeLieAlgebra", "killingForm", "MeasureTheory.Integral.Bochner"],
-      "tags": ["yang-mills", "classical-field-theory", "equations-of-motion"]
+    "title": "Minkowski Metric Formalization",
+    "content": "The Minkowski metric $\\eta_{\\mu\\nu}$ with signature $(-,+,+,+)$ is formalized with fully proved properties: diagonality ($\\eta_{\\mu\\nu} = 0$ for $\\mu \\ne \\nu$), symmetry, $\\eta_{00} = -1$, $\\eta_{ii} = 1$ for $i \\ge 1$, trace $\\eta^\\mu_\\mu = 2$, and Lorentzian signature $(1,3)$. The squared norm $s^2 = -t^2 + x^2 + y^2 + z^2$ distinguishes spacelike, timelike, and lightlike separations.",
+    "mathContext": "$\\eta = \\text{diag}(-1, 1, 1, 1)$, $\\text{tr}(\\eta) = 2$, signature $(1,3)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "special relativity",
+      "Lorentzian geometry",
+      "metric signature",
+      "Minkowski space"
+    ],
+    "prerequisites": [
+      "Matrix",
+      "Fin 4",
+      "Real"
+    ],
+    "tags": [
+      "special-relativity",
+      "metric",
+      "spacetime"
+    ]
+  },
+  {
+    "id": "yang-mills-equations",
+    "proofId": "yang-mills-mass-gap",
+    "type": "context",
+    "range": {
+      "startLine": 197,
+      "endLine": 251
     },
-    {
-      "id": "gauge-invariance-group",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 252, "endLine": 308 },
-      "title": "Gauge Transformations Form a Group",
-      "content": "Proves that gauge transformations $g(x): \\mathbb{R}^4 \\to G$ form an infinite-dimensional group under pointwise multiplication, with the action invariant: $S[A^g] = S[A]$. Properties proved include identity element, associativity, and double inversion. This gauge symmetry is the defining feature of Yang-Mills theory and the reason gauge fixing (Faddeev-Popov, Part XXXVII) is needed for quantization. The gauge orbit of a connection $A$ is the set $\\{A^g : g \\in \\mathcal{G}\\}$.",
-      "mathContext": "$A^g_\\mu = g A_\\mu g^{-1} + g \\partial_\\mu g^{-1}$, $S[A^g] = S[A]$",
-      "significance": "key",
-      "relatedConcepts": ["gauge symmetry", "group action", "principal bundle", "gauge orbit"],
-      "prerequisites": ["CompactSimpleGaugeGroup", "Group"],
-      "tags": ["gauge-theory", "symmetry", "group-action"]
+    "title": "The Classical Yang-Mills Equations",
+    "content": "Formalizes the Yang-Mills action $S[A] = -\\frac{1}{4g^2} \\int \\text{Tr}(F_{\\mu\\nu} F^{\\mu\\nu})$ and the classical equations of motion $D_\\mu F^{\\mu\\nu} = 0$ (Yang-Mills equation) and $D_{[\\mu} F_{\\nu\\rho]} = 0$ (Bianchi identity). Unlike Maxwell's equations, these are non-linear because the covariant derivative $D$ involves the gauge field $A$ itself, with the commutator $[A_\\mu, A_\\nu]$ in the field strength. This non-linearity gives rise to gluon self-interactions, asymptotic freedom, and confinement.",
+    "mathContext": "$S[A] = -\\frac{1}{4g^2} \\int \\text{Tr}(F^2)$, $D_\\mu F^{\\mu\\nu} = 0$, $F_{\\mu\\nu} = \\partial_\\mu A_\\nu - \\partial_\\nu A_\\mu + [A_\\mu, A_\\nu]$",
+    "significance": "key",
+    "relatedConcepts": [
+      "gauge field",
+      "field strength tensor",
+      "covariant derivative",
+      "non-linear PDE"
+    ],
+    "prerequisites": [
+      "GaugeLieAlgebra",
+      "killingForm",
+      "MeasureTheory.Integral.Bochner"
+    ],
+    "tags": [
+      "yang-mills",
+      "classical-field-theory",
+      "equations-of-motion"
+    ]
+  },
+  {
+    "id": "gauge-invariance-group",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 252,
+      "endLine": 308
     },
-    {
-      "id": "instantons",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 479, "endLine": 526 },
-      "title": "Instantons and the Bogomolny Bound",
-      "content": "Defines instantons as (anti-)self-dual solutions of the Yang-Mills equations: $F = \\pm *F$, where $*$ is the Hodge dual. These minimize the action in a given topological sector classified by the topological charge $k \\in \\mathbb{Z}$ (second Chern number). The Bogomolny bound $S[A] \\ge 8\\pi^2|k|/g^2$ is saturated precisely by (anti-)instantons. Discovered by Belavin, Polyakov, Schwartz, and Tyupkin (1975), instantons are non-perturbative solutions that mediate tunneling between topologically distinct vacua and play a key role in understanding the QCD vacuum structure.",
-      "mathContext": "$F = \\pm *F$ (self-dual/anti-self-dual), $k = \\frac{1}{8\\pi^2} \\int \\text{Tr}(F \\wedge F) \\in \\mathbb{Z}$, $S[A] \\ge \\frac{8\\pi^2|k|}{g^2}$",
-      "significance": "supporting",
-      "relatedConcepts": ["self-dual connection", "topological charge", "Chern number", "vacuum tunneling", "Donaldson theory"],
-      "prerequisites": ["YangMillsAction", "fieldStrength"],
-      "tags": ["instantons", "topology", "non-perturbative"]
+    "title": "Gauge Transformations Form a Group",
+    "content": "Proves that gauge transformations $g(x): \\mathbb{R}^4 \\to G$ form an infinite-dimensional group under pointwise multiplication, with the action invariant: $S[A^g] = S[A]$. Properties proved include identity element, associativity, and double inversion. This gauge symmetry is the defining feature of Yang-Mills theory and the reason gauge fixing (Faddeev-Popov, Part XXXVII) is needed for quantization. The gauge orbit of a connection $A$ is the set $\\{A^g : g \\in \\mathcal{G}\\}$.",
+    "mathContext": "$A^g_\\mu = g A_\\mu g^{-1} + g \\partial_\\mu g^{-1}$, $S[A^g] = S[A]$",
+    "significance": "key",
+    "relatedConcepts": [
+      "gauge symmetry",
+      "group action",
+      "principal bundle",
+      "gauge orbit"
+    ],
+    "prerequisites": [
+      "CompactSimpleGaugeGroup",
+      "Group"
+    ],
+    "tags": [
+      "gauge-theory",
+      "symmetry",
+      "group-action"
+    ]
+  },
+  {
+    "id": "instantons",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 479,
+      "endLine": 526
     },
-    {
-      "id": "wightman-structure",
-      "proofId": "yang-mills-mass-gap",
-      "type": "definition",
-      "range": { "startLine": 376, "endLine": 406 },
-      "title": "Wightman QFT Axioms as Lean Structure",
-      "content": "Encodes the Wightman axioms as a Lean structure with fields: Hilbert space $\\mathcal{H}$, vacuum state $\\Omega$, Hamiltonian $H$, field operators, Poincaré covariance, spectral condition ($E \\ge 0$), and locality (spacelike commutativity). `QuantumYangMills` extends this with gauge field operators, capturing the mathematical framework for rigorous QFT as formulated by Wightman and Gårding (1964). The spectral condition ensures physical states have non-negative energy.",
-      "mathContext": "$(\\mathcal{H}, \\Omega, H, \\phi(f))$ with $H\\Omega = 0$, $\\text{spec}(H) \\subseteq [0,\\infty)$, $[\\phi(x), \\phi(y)] = 0$ for $(x-y)^2 < 0$",
-      "significance": "key",
-      "relatedConcepts": ["Wightman axioms", "Hilbert space", "spectral condition", "Poincaré group"],
-      "prerequisites": ["InnerProductSpace", "LinearMap", "Spectrum"],
-      "tags": ["wightman-axioms", "quantum-field-theory", "axiomatics"]
+    "title": "Instantons and the Bogomolny Bound",
+    "content": "Defines instantons as (anti-)self-dual solutions of the Yang-Mills equations: $F = \\pm *F$, where $*$ is the Hodge dual. These minimize the action in a given topological sector classified by the topological charge $k \\in \\mathbb{Z}$ (second Chern number). The Bogomolny bound $S[A] \\ge 8\\pi^2|k|/g^2$ is saturated precisely by (anti-)instantons. Discovered by Belavin, Polyakov, Schwartz, and Tyupkin (1975), instantons are non-perturbative solutions that mediate tunneling between topologically distinct vacua and play a key role in understanding the QCD vacuum structure.",
+    "mathContext": "$F = \\pm *F$ (self-dual/anti-self-dual), $k = \\frac{1}{8\\pi^2} \\int \\text{Tr}(F \\wedge F) \\in \\mathbb{Z}$, $S[A] \\ge \\frac{8\\pi^2|k|}{g^2}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "self-dual connection",
+      "topological charge",
+      "Chern number",
+      "vacuum tunneling",
+      "Donaldson theory"
+    ],
+    "prerequisites": [
+      "YangMillsAction",
+      "fieldStrength"
+    ],
+    "tags": [
+      "instantons",
+      "topology",
+      "non-perturbative"
+    ]
+  },
+  {
+    "id": "wightman-structure",
+    "proofId": "yang-mills-mass-gap",
+    "type": "definition",
+    "range": {
+      "startLine": 376,
+      "endLine": 406
     },
-    {
-      "id": "mass-gap-definition",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 407, "endLine": 450 },
-      "title": "The Mass Gap: Spectrum Has a Gap",
-      "content": "Defines mass gap $\\Delta > 0$: all states orthogonal to the vacuum have energy $\\ge \\Delta$. Equivalently, the Hamiltonian spectrum is $\\{0\\} \\cup [\\Delta, \\infty)$. Proved properties include: any $\\Delta' < \\Delta$ is also a mass gap (monotonicity), and vacuum energy is zero. The mass gap explains why the nuclear force is short-range: gluons, though classically massless, form bound states (glueballs) with mass $\\ge \\Delta$, so the force decays exponentially at distances $\\gtrsim 1/\\Delta$.",
-      "mathContext": "$\\text{spec}(H) = \\{0\\} \\cup [\\Delta, \\infty)$ with $\\Delta > 0$; equivalently $\\langle \\psi | H | \\psi \\rangle \\ge \\Delta$ for $\\psi \\perp \\Omega$",
-      "significance": "key",
-      "relatedConcepts": ["spectral gap", "correlation length", "exponential decay of correlations", "glueball mass"],
-      "prerequisites": ["WightmanQFT", "Spectrum", "InnerProductSpace"],
-      "tags": ["mass-gap", "millennium-prize", "spectral-theory"]
+    "title": "Wightman QFT Axioms as Lean Structure",
+    "content": "Encodes the Wightman axioms as a Lean structure with fields: Hilbert space $\\mathcal{H}$, vacuum state $\\Omega$, Hamiltonian $H$, field operators, Poincar\u00e9 covariance, spectral condition ($E \\ge 0$), and locality (spacelike commutativity). `QuantumYangMills` extends this with gauge field operators, capturing the mathematical framework for rigorous QFT as formulated by Wightman and G\u00e5rding (1964). The spectral condition ensures physical states have non-negative energy.",
+    "mathContext": "$(\\mathcal{H}, \\Omega, H, \\phi(f))$ with $H\\Omega = 0$, $\\text{spec}(H) \\subseteq [0,\\infty)$, $[\\phi(x), \\phi(y)] = 0$ for $(x-y)^2 < 0$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Wightman axioms",
+      "Hilbert space",
+      "spectral condition",
+      "Poincar\u00e9 group"
+    ],
+    "prerequisites": [
+      "InnerProductSpace",
+      "LinearMap",
+      "Spectrum"
+    ],
+    "tags": [
+      "wightman-axioms",
+      "quantum-field-theory",
+      "axiomatics"
+    ]
+  },
+  {
+    "id": "mass-gap-definition",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 407,
+      "endLine": 450
     },
-    {
-      "id": "wilson-area-perimeter",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 527, "endLine": 612 },
-      "title": "Area Law vs Perimeter Law: Confinement Criterion",
-      "content": "Formalizes Wilson's confinement criterion (1974): $W(C) \\sim \\exp(-\\sigma \\cdot \\text{Area})$ indicates confinement (quarks permanently bound by a linear potential), while $W(C) \\sim \\exp(-\\kappa \\cdot \\text{Perimeter})$ indicates deconfinement (free quarks, Coulomb-like potential). A key proved theorem shows these are mutually exclusive for large loops: area grows as $L^2$ while perimeter grows as $L$, so both cannot hold simultaneously. The string tension $\\sigma$ measures the energy per unit length of the chromoelectric flux tube between quarks.",
-      "mathContext": "Area law: $\\langle W(C) \\rangle \\le e^{-\\sigma \\cdot \\text{Area}(C)}$; Perimeter law: $\\langle W(C) \\rangle \\ge e^{-\\kappa \\cdot \\text{Perimeter}(C)}$",
-      "significance": "key",
-      "relatedConcepts": ["Wilson loop", "quark confinement", "string tension", "lattice gauge theory"],
-      "prerequisites": ["WilsonLoop", "LoopSpace", "Real.exp"],
-      "tags": ["confinement", "wilson-loop", "area-law"]
+    "title": "The Mass Gap: Spectrum Has a Gap",
+    "content": "Defines mass gap $\\Delta > 0$: all states orthogonal to the vacuum have energy $\\ge \\Delta$. Equivalently, the Hamiltonian spectrum is $\\{0\\} \\cup [\\Delta, \\infty)$. Proved properties include: any $\\Delta' < \\Delta$ is also a mass gap (monotonicity), and vacuum energy is zero. The mass gap explains why the nuclear force is short-range: gluons, though classically massless, form bound states (glueballs) with mass $\\ge \\Delta$, so the force decays exponentially at distances $\\gtrsim 1/\\Delta$.",
+    "mathContext": "$\\text{spec}(H) = \\{0\\} \\cup [\\Delta, \\infty)$ with $\\Delta > 0$; equivalently $\\langle \\psi | H | \\psi \\rangle \\ge \\Delta$ for $\\psi \\perp \\Omega$",
+    "significance": "key",
+    "relatedConcepts": [
+      "spectral gap",
+      "correlation length",
+      "exponential decay of correlations",
+      "glueball mass"
+    ],
+    "prerequisites": [
+      "WightmanQFT",
+      "Spectrum",
+      "InnerProductSpace"
+    ],
+    "tags": [
+      "mass-gap",
+      "millennium-prize",
+      "spectral-theory"
+    ]
+  },
+  {
+    "id": "wilson-area-perimeter",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 527,
+      "endLine": 612
     },
-    {
-      "id": "lattice-gauge",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 613, "endLine": 869 },
-      "title": "Lattice Gauge Theory: Wilson's Non-Perturbative Framework",
-      "content": "Formalizes Wilson's lattice gauge theory (1974): space-time is discretized on a hypercubic lattice, gauge fields live on links as group elements $U_{\\mu}(x) \\in G$, and the action $S_W = \\beta \\sum_P (1 - \\frac{1}{N} \\text{Re\\,Tr}\\, U_P)$ sums over plaquettes $P$. The continuum limit recovers Yang-Mills as lattice spacing $a \\to 0$. Also formalizes the lattice mass gap via transfer matrix eigenvalues: $\\Delta_{\\text{lat}} = -\\ln(\\lambda_1/\\lambda_0)/a$ where $\\lambda_0 > \\lambda_1$ are the two largest eigenvalues. The lattice approach is the basis for numerical Monte Carlo simulations that provide strong evidence for confinement and a mass gap.",
-      "mathContext": "$S_W = \\beta \\sum_P (1 - \\frac{1}{N} \\text{Re\\,Tr}\\, U_P)$, $\\beta = 2N/g^2$; $\\Delta_{\\text{lat}} = -\\ln(\\lambda_1/\\lambda_0)/a$",
-      "significance": "key",
-      "relatedConcepts": ["lattice gauge theory", "Wilson action", "plaquette", "transfer matrix", "continuum limit"],
-      "prerequisites": ["CompactSimpleGaugeGroup", "Matrix.trace", "Real.exp"],
-      "tags": ["lattice", "non-perturbative", "wilson-action"]
+    "title": "Area Law vs Perimeter Law: Confinement Criterion",
+    "content": "Formalizes Wilson's confinement criterion (1974): $W(C) \\sim \\exp(-\\sigma \\cdot \\text{Area})$ indicates confinement (quarks permanently bound by a linear potential), while $W(C) \\sim \\exp(-\\kappa \\cdot \\text{Perimeter})$ indicates deconfinement (free quarks, Coulomb-like potential). A key proved theorem shows these are mutually exclusive for large loops: area grows as $L^2$ while perimeter grows as $L$, so both cannot hold simultaneously. The string tension $\\sigma$ measures the energy per unit length of the chromoelectric flux tube between quarks.",
+    "mathContext": "Area law: $\\langle W(C) \\rangle \\le e^{-\\sigma \\cdot \\text{Area}(C)}$; Perimeter law: $\\langle W(C) \\rangle \\ge e^{-\\kappa \\cdot \\text{Perimeter}(C)}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Wilson loop",
+      "quark confinement",
+      "string tension",
+      "lattice gauge theory"
+    ],
+    "prerequisites": [
+      "WilsonLoop",
+      "LoopSpace",
+      "Real.exp"
+    ],
+    "tags": [
+      "confinement",
+      "wilson-loop",
+      "area-law"
+    ]
+  },
+  {
+    "id": "lattice-gauge",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 613,
+      "endLine": 869
     },
-    {
-      "id": "migdal-2d",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 870, "endLine": 972 },
-      "title": "2D Yang-Mills: The Exactly Solvable Case",
-      "content": "In 2D, Yang-Mills is exactly solvable via Migdal's formula: Wilson loop expectations reduce to finite-dimensional group integrals weighted by heat kernel. The partition function $Z = \\sum_R (\\dim R)^2 \\exp(-C_2(R) \\cdot A / (2\\beta))$ sums over irreducible representations $R$ of $G$, where $C_2(R)$ is the quadratic Casimir and $A$ is the area. This provides the only dimension where the mass gap can be computed explicitly: $\\Delta_{\\text{2D}} = C_2(\\text{adj}) \\cdot a^2 / (2\\beta)$. The 2D case serves as a testing ground for non-perturbative methods and was rigorously constructed by Driver (1989) and Sengupta (1997).",
-      "mathContext": "$Z_{\\text{2D}} = \\sum_R (\\dim R)^2 e^{-C_2(R) A / 2\\beta}$, where $C_2(R)$ is the quadratic Casimir of representation $R$",
-      "significance": "key",
-      "relatedConcepts": ["Migdal formula", "heat kernel", "representation theory", "partition function", "exactly solvable model"],
-      "prerequisites": ["CompactSimpleGaugeGroup", "Casimir operator", "Real.exp"],
-      "tags": ["2d-yang-mills", "exact-solution", "migdal-formula"]
+    "title": "Lattice Gauge Theory: Wilson's Non-Perturbative Framework",
+    "content": "Formalizes Wilson's lattice gauge theory (1974): space-time is discretized on a hypercubic lattice, gauge fields live on links as group elements $U_{\\mu}(x) \\in G$, and the action $S_W = \\beta \\sum_P (1 - \\frac{1}{N} \\text{Re\\,Tr}\\, U_P)$ sums over plaquettes $P$. The continuum limit recovers Yang-Mills as lattice spacing $a \\to 0$. Also formalizes the lattice mass gap via transfer matrix eigenvalues: $\\Delta_{\\text{lat}} = -\\ln(\\lambda_1/\\lambda_0)/a$ where $\\lambda_0 > \\lambda_1$ are the two largest eigenvalues. The lattice approach is the basis for numerical Monte Carlo simulations that provide strong evidence for confinement and a mass gap.",
+    "mathContext": "$S_W = \\beta \\sum_P (1 - \\frac{1}{N} \\text{Re\\,Tr}\\, U_P)$, $\\beta = 2N/g^2$; $\\Delta_{\\text{lat}} = -\\ln(\\lambda_1/\\lambda_0)/a$",
+    "significance": "key",
+    "relatedConcepts": [
+      "lattice gauge theory",
+      "Wilson action",
+      "plaquette",
+      "transfer matrix",
+      "continuum limit"
+    ],
+    "prerequisites": [
+      "CompactSimpleGaugeGroup",
+      "Matrix.trace",
+      "Real.exp"
+    ],
+    "tags": [
+      "lattice",
+      "non-perturbative",
+      "wilson-action"
+    ]
+  },
+  {
+    "id": "migdal-2d",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 870,
+      "endLine": 972
     },
-    {
-      "id": "center-symmetry",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 1288, "endLine": 1457 },
-      "title": "Center Symmetry Z_N Classifies Confinement",
-      "content": "The center $Z_N$ of $\\mathrm{SU}(N)$ acts on Polyakov loops $P$ by multiplication: $P \\to \\omega P$. In the confined phase ($Z_N$ unbroken), $\\langle P \\rangle = 0$—the free energy of an isolated quark is infinite. In the deconfined phase, $Z_N$ is spontaneously broken: $\\langle P \\rangle \\ne 0$, and quarks are free. For $\\mathrm{SU}(2)$, $Z_2 = \\{1,-1\\}$ with the key theorem: $\\omega^2=1$ and $|\\omega|=1$ implies $\\omega \\in \\{1,-1\\}$. This gives an order parameter for the confinement-deconfinement phase transition, analogous to magnetization in the Ising model.",
-      "mathContext": "$Z_N = \\{e^{2\\pi i k/N} I : k = 0, \\ldots, N-1\\}$; confined $\\iff$ $\\langle P \\rangle = 0$ $\\iff$ $Z_N$ unbroken",
-      "significance": "supporting",
-      "relatedConcepts": ["center of group", "Polyakov loop", "spontaneous symmetry breaking", "phase transition", "order parameter"],
-      "prerequisites": ["CompactSimpleGaugeGroup", "Complex", "Finset"],
-      "tags": ["center-symmetry", "confinement", "phase-transition"]
+    "title": "2D Yang-Mills: The Exactly Solvable Case",
+    "content": "In 2D, Yang-Mills is exactly solvable via Migdal's formula: Wilson loop expectations reduce to finite-dimensional group integrals weighted by heat kernel. The partition function $Z = \\sum_R (\\dim R)^2 \\exp(-C_2(R) \\cdot A / (2\\beta))$ sums over irreducible representations $R$ of $G$, where $C_2(R)$ is the quadratic Casimir and $A$ is the area. This provides the only dimension where the mass gap can be computed explicitly: $\\Delta_{\\text{2D}} = C_2(\\text{adj}) \\cdot a^2 / (2\\beta)$. The 2D case serves as a testing ground for non-perturbative methods and was rigorously constructed by Driver (1989) and Sengupta (1997).",
+    "mathContext": "$Z_{\\text{2D}} = \\sum_R (\\dim R)^2 e^{-C_2(R) A / 2\\beta}$, where $C_2(R)$ is the quadratic Casimir of representation $R$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Migdal formula",
+      "heat kernel",
+      "representation theory",
+      "partition function",
+      "exactly solvable model"
+    ],
+    "prerequisites": [
+      "CompactSimpleGaugeGroup",
+      "Casimir operator",
+      "Real.exp"
+    ],
+    "tags": [
+      "2d-yang-mills",
+      "exact-solution",
+      "migdal-formula"
+    ]
+  },
+  {
+    "id": "center-symmetry",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 1288,
+      "endLine": 1457
     },
-    {
-      "id": "osterwalder-schrader",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 2315, "endLine": 2458 },
-      "title": "Osterwalder-Schrader Reconstruction",
-      "content": "Formalizes the Osterwalder-Schrader (OS) framework that connects Euclidean QFT (imaginary time) to physical Minkowski QFT. The key axiom is reflection positivity: under time reflection $\\theta$, the inner product $\\langle \\theta f, f \\rangle \\ge 0$ ensures the reconstructed Hilbert space has a positive-definite inner product. The OS reconstruction theorem shows that Euclidean correlation functions satisfying OS axioms uniquely determine a Wightman QFT, providing a pathway from lattice/constructive methods (naturally Euclidean) to the physical theory. This is the mathematical bridge between the lattice mass gap and the Millennium Prize mass gap.",
-      "mathContext": "Reflection positivity: $\\langle \\theta f, f \\rangle_{\\text{Eucl}} \\ge 0$; OS reconstruction: Euclidean correlators $\\to$ Wightman QFT via analytic continuation $t \\to it$",
-      "significance": "key",
-      "relatedConcepts": ["Wick rotation", "reflection positivity", "Euclidean QFT", "analytic continuation"],
-      "prerequisites": ["InnerProductSpace", "MeasureTheory"],
-      "tags": ["osterwalder-schrader", "euclidean-qft", "reconstruction"]
+    "title": "Center Symmetry Z_N Classifies Confinement",
+    "content": "The center $Z_N$ of $\\mathrm{SU}(N)$ acts on Polyakov loops $P$ by multiplication: $P \\to \\omega P$. In the confined phase ($Z_N$ unbroken), $\\langle P \\rangle = 0$\u2014the free energy of an isolated quark is infinite. In the deconfined phase, $Z_N$ is spontaneously broken: $\\langle P \\rangle \\ne 0$, and quarks are free. For $\\mathrm{SU}(2)$, $Z_2 = \\{1,-1\\}$ with the key theorem: $\\omega^2=1$ and $|\\omega|=1$ implies $\\omega \\in \\{1,-1\\}$. This gives an order parameter for the confinement-deconfinement phase transition, analogous to magnetization in the Ising model.",
+    "mathContext": "$Z_N = \\{e^{2\\pi i k/N} I : k = 0, \\ldots, N-1\\}$; confined $\\iff$ $\\langle P \\rangle = 0$ $\\iff$ $Z_N$ unbroken",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "center of group",
+      "Polyakov loop",
+      "spontaneous symmetry breaking",
+      "phase transition",
+      "order parameter"
+    ],
+    "prerequisites": [
+      "CompactSimpleGaugeGroup",
+      "Complex",
+      "Finset"
+    ],
+    "tags": [
+      "center-symmetry",
+      "confinement",
+      "phase-transition"
+    ]
+  },
+  {
+    "id": "osterwalder-schrader",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 2315,
+      "endLine": 2458
     },
-    {
-      "id": "gribov-copies",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 3876, "endLine": 4027 },
-      "title": "Gribov Copies: Global Gauge Fixing Is Impossible",
-      "content": "Formalizes Singer's theorem (axiomatized): for non-abelian gauge theories, no global gauge-fixing condition can uniquely select one representative from each gauge orbit. The Gribov region $\\Omega$ (where the Faddeev-Popov operator is positive-definite) has a boundary $\\partial\\Omega$ where $\\det(\\text{FP}) = 0$, creating copies. This is a fundamental obstruction to the perturbative path integral and motivates non-perturbative approaches like lattice gauge theory. Gribov discovered this in 1978; it shows that quantization of non-abelian gauge theories is fundamentally more complex than the abelian (QED) case.",
-      "mathContext": "$\\Omega = \\{A : -\\partial_\\mu D_\\mu > 0\\}$; $\\partial\\Omega$: $\\det(-\\partial_\\mu D_\\mu) = 0$ (Gribov horizon)",
-      "significance": "supporting",
-      "relatedConcepts": ["gauge fixing", "Faddeev-Popov procedure", "BRST symmetry", "Singer theorem"],
-      "prerequisites": ["GaugeTransformation", "Determinant"],
-      "tags": ["gribov-copies", "gauge-fixing", "non-perturbative"]
+    "title": "Osterwalder-Schrader Reconstruction",
+    "content": "Formalizes the Osterwalder-Schrader (OS) framework that connects Euclidean QFT (imaginary time) to physical Minkowski QFT. The key axiom is reflection positivity: under time reflection $\\theta$, the inner product $\\langle \\theta f, f \\rangle \\ge 0$ ensures the reconstructed Hilbert space has a positive-definite inner product. The OS reconstruction theorem shows that Euclidean correlation functions satisfying OS axioms uniquely determine a Wightman QFT, providing a pathway from lattice/constructive methods (naturally Euclidean) to the physical theory. This is the mathematical bridge between the lattice mass gap and the Millennium Prize mass gap.",
+    "mathContext": "Reflection positivity: $\\langle \\theta f, f \\rangle_{\\text{Eucl}} \\ge 0$; OS reconstruction: Euclidean correlators $\\to$ Wightman QFT via analytic continuation $t \\to it$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Wick rotation",
+      "reflection positivity",
+      "Euclidean QFT",
+      "analytic continuation"
+    ],
+    "prerequisites": [
+      "InnerProductSpace",
+      "MeasureTheory"
+    ],
+    "tags": [
+      "osterwalder-schrader",
+      "euclidean-qft",
+      "reconstruction"
+    ]
+  },
+  {
+    "id": "gribov-copies",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 3876,
+      "endLine": 4027
     },
-    {
-      "id": "adscft",
-      "proofId": "yang-mills-mass-gap",
-      "type": "context",
-      "range": { "startLine": 5283, "endLine": 5496 },
-      "title": "AdS/CFT and Holographic Mass Gap",
-      "content": "Formalizes aspects of Maldacena's AdS/CFT correspondence (1997), which maps $\\mathcal{N}=4$ $\\mathrm{SU}(N)$ Yang-Mills to type IIB string theory on $\\text{AdS}_5 \\times S^5$. While $\\mathcal{N}=4$ SYM is conformal (no mass gap), deformations that break conformal symmetry can produce a mass gap. The holographic approach provides non-perturbative insights via the strong/weak coupling duality: when gauge theory is strongly coupled, the gravity dual is weakly coupled and tractable. This represents one of the most promising routes to understanding the 4D mass gap, though it has not yet produced a rigorous proof.",
-      "mathContext": "$\\mathcal{N}=4$ SYM on $\\partial(\\text{AdS}_5)$ $\\longleftrightarrow$ strings on $\\text{AdS}_5 \\times S^5$; mass gap requires conformal symmetry breaking",
-      "significance": "context",
-      "relatedConcepts": ["Maldacena conjecture", "holography", "conformal field theory", "string theory", "strong-weak duality"],
-      "prerequisites": ["CompactSimpleGaugeGroup", "WightmanQFT"],
-      "tags": ["adscft", "holography", "string-theory"]
+    "title": "Gribov Copies: Global Gauge Fixing Is Impossible",
+    "content": "Formalizes Singer's theorem (axiomatized): for non-abelian gauge theories, no global gauge-fixing condition can uniquely select one representative from each gauge orbit. The Gribov region $\\Omega$ (where the Faddeev-Popov operator is positive-definite) has a boundary $\\partial\\Omega$ where $\\det(\\text{FP}) = 0$, creating copies. This is a fundamental obstruction to the perturbative path integral and motivates non-perturbative approaches like lattice gauge theory. Gribov discovered this in 1978; it shows that quantization of non-abelian gauge theories is fundamentally more complex than the abelian (QED) case.",
+    "mathContext": "$\\Omega = \\{A : -\\partial_\\mu D_\\mu > 0\\}$; $\\partial\\Omega$: $\\det(-\\partial_\\mu D_\\mu) = 0$ (Gribov horizon)",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "gauge fixing",
+      "Faddeev-Popov procedure",
+      "BRST symmetry",
+      "Singer theorem"
+    ],
+    "prerequisites": [
+      "GaugeTransformation",
+      "Determinant"
+    ],
+    "tags": [
+      "gribov-copies",
+      "gauge-fixing",
+      "non-perturbative"
+    ]
+  },
+  {
+    "id": "adscft",
+    "proofId": "yang-mills-mass-gap",
+    "type": "context",
+    "range": {
+      "startLine": 5283,
+      "endLine": 5496
     },
-    {
-      "id": "constructive-qft",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 5497, "endLine": 5775 },
-      "title": "Constructive QFT: Rigorous 2D Yang-Mills",
-      "content": "Constructive QFT provides mathematically rigorous definitions of quantum field theories, as pioneered by Glimm, Jaffe, and others in the 1960s-70s. In 2D, Yang-Mills has been rigorously constructed (Driver 1989, Sengupta 1997), unlike 4D where it remains the Millennium Prize target. The formalization covers the lattice-to-continuum limit, gauge-invariant observables, and the connection to Migdal's exact solution. The approach uses probability measures on the space of connections, showing the lattice measures converge weakly as the lattice spacing $a \\to 0$.",
-      "mathContext": "Rigorous construction: lattice $\\to$ continuum limit exists for 2D YM; 4D remains the Millennium Prize target",
-      "significance": "supporting",
-      "relatedConcepts": ["constructive QFT", "Glimm-Jaffe", "lattice continuum limit", "functional measure"],
-      "prerequisites": ["MeasureTheory", "latticeYangMillsAction"],
-      "tags": ["constructive-qft", "rigorous", "continuum-limit"]
+    "title": "AdS/CFT and Holographic Mass Gap",
+    "content": "Formalizes aspects of Maldacena's AdS/CFT correspondence (1997), which maps $\\mathcal{N}=4$ $\\mathrm{SU}(N)$ Yang-Mills to type IIB string theory on $\\text{AdS}_5 \\times S^5$. While $\\mathcal{N}=4$ SYM is conformal (no mass gap), deformations that break conformal symmetry can produce a mass gap. The holographic approach provides non-perturbative insights via the strong/weak coupling duality: when gauge theory is strongly coupled, the gravity dual is weakly coupled and tractable. This represents one of the most promising routes to understanding the 4D mass gap, though it has not yet produced a rigorous proof.",
+    "mathContext": "$\\mathcal{N}=4$ SYM on $\\partial(\\text{AdS}_5)$ $\\longleftrightarrow$ strings on $\\text{AdS}_5 \\times S^5$; mass gap requires conformal symmetry breaking",
+    "significance": "context",
+    "relatedConcepts": [
+      "Maldacena conjecture",
+      "holography",
+      "conformal field theory",
+      "string theory",
+      "strong-weak duality"
+    ],
+    "prerequisites": [
+      "CompactSimpleGaugeGroup",
+      "WightmanQFT"
+    ],
+    "tags": [
+      "adscft",
+      "holography",
+      "string-theory"
+    ]
+  },
+  {
+    "id": "constructive-qft",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 5497,
+      "endLine": 5775
     },
-    {
-      "id": "asymptotic-freedom",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 3706, "endLine": 3723 },
-      "title": "Asymptotic Freedom and the Running Coupling",
-      "content": "Formalizes the one-loop beta function coefficient $\\beta_0 = (11N - 2N_f)/3$, which is positive for pure Yang-Mills (making the theory asymptotically free). The running coupling $\\alpha_s(Q^2) = 1/(\\beta_0 \\ln(Q^2/\\Lambda^2))$ vanishes logarithmically at high energies, allowing perturbative calculations in deep inelastic scattering. Conversely, the coupling grows at low energies, signaling the onset of confinement. This was discovered by Gross, Wilczek, and Politzer (1973, Nobel Prize 2004) and remains the cornerstone of perturbative QCD. The formalization proves $\\beta_0 > 0$ for SU(2) and SU(3), and defines the QCD scale $\\Lambda_{\\text{QCD}}$.",
-      "mathContext": "$\\beta_0 = \\frac{11N - 2N_f}{3}$; $\\alpha_s(Q^2) \\sim \\frac{1}{\\beta_0 \\ln(Q^2/\\Lambda^2)} \\to 0$ as $Q^2 \\to \\infty$",
-      "significance": "key",
-      "relatedConcepts": ["beta function", "running coupling", "dimensional transmutation", "Λ_QCD", "renormalization group"],
-      "prerequisites": ["CompactSimpleGaugeGroup", "Real.log"],
-      "tags": ["asymptotic-freedom", "beta-function", "nobel-prize"]
+    "title": "Constructive QFT: Rigorous 2D Yang-Mills",
+    "content": "Constructive QFT provides mathematically rigorous definitions of quantum field theories, as pioneered by Glimm, Jaffe, and others in the 1960s-70s. In 2D, Yang-Mills has been rigorously constructed (Driver 1989, Sengupta 1997), unlike 4D where it remains the Millennium Prize target. The formalization covers the lattice-to-continuum limit, gauge-invariant observables, and the connection to Migdal's exact solution. The approach uses probability measures on the space of connections, showing the lattice measures converge weakly as the lattice spacing $a \\to 0$.",
+    "mathContext": "Rigorous construction: lattice $\\to$ continuum limit exists for 2D YM; 4D remains the Millennium Prize target",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "constructive QFT",
+      "Glimm-Jaffe",
+      "lattice continuum limit",
+      "functional measure"
+    ],
+    "prerequisites": [
+      "MeasureTheory",
+      "latticeYangMillsAction"
+    ],
+    "tags": [
+      "constructive-qft",
+      "rigorous",
+      "continuum-limit"
+    ]
+  },
+  {
+    "id": "asymptotic-freedom",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 3706,
+      "endLine": 3723
     },
-    {
-      "id": "chiral-anomaly",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 3984, "endLine": 4099 },
-      "title": "Chiral Anomaly and the Atiyah-Singer Index Theorem",
-      "content": "Formalizes the Adler-Bell-Jackiw chiral anomaly: $\\partial_\\mu j^5_\\mu = \\frac{g^2 N_f}{16\\pi^2} F \\tilde{F}$, a quantum violation of classical chiral symmetry. Remarkably, the Adler-Bardeen theorem proves this is exact to all orders — higher-loop corrections vanish identically, making the anomaly coefficient scheme-independent. The Atiyah-Singer index theorem provides a deep topological interpretation: the integrated anomaly equals $Q = n^+ - n^-$, the difference of chiral zero modes of the Dirac operator, which equals the instanton number. This triple connection — anomaly $\\leftrightarrow$ topology $\\leftrightarrow$ instantons — is one of the most beautiful bridges between quantum physics and pure mathematics.",
-      "mathContext": "$\\partial_\\mu j^5_\\mu = \\frac{g^2 N_f}{16\\pi^2} \\text{Tr}(F \\tilde{F})$; index theorem: $\\int \\frac{g^2}{32\\pi^2} F\\tilde{F} = n^+ - n^- = Q \\in \\mathbb{Z}$",
-      "significance": "key",
-      "relatedConcepts": ["chiral symmetry", "axial anomaly", "Atiyah-Singer index theorem", "instanton number", "topology of gauge fields"],
-      "prerequisites": ["AnomalyCoefficient", "IndexTheorem", "fieldStrength"],
-      "tags": ["anomaly", "index-theorem", "topology"]
+    "title": "Asymptotic Freedom and the Running Coupling",
+    "content": "Formalizes the one-loop beta function coefficient $\\beta_0 = (11N - 2N_f)/3$, which is positive for pure Yang-Mills (making the theory asymptotically free). The running coupling $\\alpha_s(Q^2) = 1/(\\beta_0 \\ln(Q^2/\\Lambda^2))$ vanishes logarithmically at high energies, allowing perturbative calculations in deep inelastic scattering. Conversely, the coupling grows at low energies, signaling the onset of confinement. This was discovered by Gross, Wilczek, and Politzer (1973, Nobel Prize 2004) and remains the cornerstone of perturbative QCD. The formalization proves $\\beta_0 > 0$ for SU(2) and SU(3), and defines the QCD scale $\\Lambda_{\\text{QCD}}$.",
+    "mathContext": "$\\beta_0 = \\frac{11N - 2N_f}{3}$; $\\alpha_s(Q^2) \\sim \\frac{1}{\\beta_0 \\ln(Q^2/\\Lambda^2)} \\to 0$ as $Q^2 \\to \\infty$",
+    "significance": "key",
+    "relatedConcepts": [
+      "beta function",
+      "running coupling",
+      "dimensional transmutation",
+      "\u039b_QCD",
+      "renormalization group"
+    ],
+    "prerequisites": [
+      "CompactSimpleGaugeGroup",
+      "Real.log"
+    ],
+    "tags": [
+      "asymptotic-freedom",
+      "beta-function",
+      "nobel-prize"
+    ]
+  },
+  {
+    "id": "chiral-anomaly",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 3984,
+      "endLine": 4099
     },
-    {
-      "id": "dual-superconductor-model",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 4120, "endLine": 4263 },
-      "title": "Dual Superconductor: Monopole Condensation Confines Quarks",
-      "content": "'t Hooft and Mandelstam's dual superconductor model explains confinement by analogy with the Meissner effect. In ordinary superconductors, electric charge condensation (Cooper pairs) expels magnetic flux into Abrikosov vortices. In QCD, the roles are interchanged: magnetic monopole condensation confines color-electric flux into thin tubes between quarks, producing a linear potential $V(r) = \\sigma r$. The formalization defines the Meissner effect structure, the dual superconductor model with monopole density and string tension $\\sigma_{\\text{QCD}} \\approx (440\\,\\text{MeV})^2$, and 't Hooft's abelian projection $\\mathrm{SU}(N) \\to \\mathrm{U}(1)^{N-1}$ that makes monopoles visible.",
-      "mathContext": "Dual map: electric condensate $\\to$ magnetic confinement becomes magnetic condensate $\\to$ electric confinement; $V(r) = \\sigma r$ from flux tube",
-      "significance": "supporting",
-      "relatedConcepts": ["Meissner effect", "Abrikosov vortex", "magnetic monopole", "abelian projection", "confinement mechanism"],
-      "prerequisites": ["MeissnerEffect", "DualSuperconductorModel", "AbelianProjection"],
-      "tags": ["dual-superconductor", "monopole", "confinement"]
+    "title": "Chiral Anomaly and the Atiyah-Singer Index Theorem",
+    "content": "Formalizes the Adler-Bell-Jackiw chiral anomaly: $\\partial_\\mu j^5_\\mu = \\frac{g^2 N_f}{16\\pi^2} F \\tilde{F}$, a quantum violation of classical chiral symmetry. Remarkably, the Adler-Bardeen theorem proves this is exact to all orders \u2014 higher-loop corrections vanish identically, making the anomaly coefficient scheme-independent. The Atiyah-Singer index theorem provides a deep topological interpretation: the integrated anomaly equals $Q = n^+ - n^-$, the difference of chiral zero modes of the Dirac operator, which equals the instanton number. This triple connection \u2014 anomaly $\\leftrightarrow$ topology $\\leftrightarrow$ instantons \u2014 is one of the most beautiful bridges between quantum physics and pure mathematics.",
+    "mathContext": "$\\partial_\\mu j^5_\\mu = \\frac{g^2 N_f}{16\\pi^2} \\text{Tr}(F \\tilde{F})$; index theorem: $\\int \\frac{g^2}{32\\pi^2} F\\tilde{F} = n^+ - n^- = Q \\in \\mathbb{Z}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "chiral symmetry",
+      "axial anomaly",
+      "Atiyah-Singer index theorem",
+      "instanton number",
+      "topology of gauge fields"
+    ],
+    "prerequisites": [
+      "AnomalyCoefficient",
+      "IndexTheorem",
+      "fieldStrength"
+    ],
+    "tags": [
+      "anomaly",
+      "index-theorem",
+      "topology"
+    ]
+  },
+  {
+    "id": "dual-superconductor-model",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 4120,
+      "endLine": 4263
     },
-    {
-      "id": "schwinger-model",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 6583, "endLine": 6719 },
-      "title": "The Schwinger Model: An Exactly Solvable Mass Gap",
-      "content": "The Schwinger model (QED in 1+1 dimensions, Schwinger 1962) is one of the few quantum field theories with an exactly known mass gap. The formalization proves $m = e/\\sqrt{\\pi} > 0$, where $e$ is the coupling constant, with the remarkable feature that this mass arises entirely from the chiral anomaly — there is no classical mass term. The string tension $\\sigma = e^2/(2\\pi)$ is also proved positive. The model exhibits confinement: the linear potential $V(r) = \\sigma \\cdot r$ binds charges. As a 2D QFT with a rigorous mass gap, it serves as the primary testing ground for methods aimed at the 4D Millennium Prize Problem.",
-      "mathContext": "$m = e/\\sqrt{\\pi}$, $m^2 = e^2/\\pi$, $\\sigma = e^2/(2\\pi)$; all proved positive in Lean",
-      "significance": "key",
-      "relatedConcepts": ["Schwinger model", "QED in 2D", "exact mass gap", "chiral anomaly", "confinement in 2D"],
-      "prerequisites": ["SchwingerParams", "Real.sqrt", "Real.pi"],
-      "tags": ["schwinger-model", "exact-solution", "mass-gap"]
+    "title": "Dual Superconductor: Monopole Condensation Confines Quarks",
+    "content": "'t Hooft and Mandelstam's dual superconductor model explains confinement by analogy with the Meissner effect. In ordinary superconductors, electric charge condensation (Cooper pairs) expels magnetic flux into Abrikosov vortices. In QCD, the roles are interchanged: magnetic monopole condensation confines color-electric flux into thin tubes between quarks, producing a linear potential $V(r) = \\sigma r$. The formalization defines the Meissner effect structure, the dual superconductor model with monopole density and string tension $\\sigma_{\\text{QCD}} \\approx (440\\,\\text{MeV})^2$, and 't Hooft's abelian projection $\\mathrm{SU}(N) \\to \\mathrm{U}(1)^{N-1}$ that makes monopoles visible.",
+    "mathContext": "Dual map: electric condensate $\\to$ magnetic confinement becomes magnetic condensate $\\to$ electric confinement; $V(r) = \\sigma r$ from flux tube",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Meissner effect",
+      "Abrikosov vortex",
+      "magnetic monopole",
+      "abelian projection",
+      "confinement mechanism"
+    ],
+    "prerequisites": [
+      "MeissnerEffect",
+      "DualSuperconductorModel",
+      "AbelianProjection"
+    ],
+    "tags": [
+      "dual-superconductor",
+      "monopole",
+      "confinement"
+    ]
+  },
+  {
+    "id": "schwinger-model",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 6583,
+      "endLine": 6719
     },
-    {
-      "id": "gradient-flow",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 6748, "endLine": 6888 },
-      "title": "Yang-Mills Gradient Flow: A Non-Perturbative UV Regulator",
-      "content": "Lüscher's gradient flow (2010) evolves gauge fields along a diffusion equation in a fictitious flow time $t$, smoothing them over a radius $r = \\sqrt{8t}$. The formalization proves: (1) the smoothing radius is non-negative and positive at $t > 0$, (2) the Yang-Mills action monotonically decreases along the flow ($dS/dt \\le 0$), so the flow always moves toward classical solutions — instantons or vacuum. The key physical insight is that operators evaluated at $t > 0$ are automatically UV finite (no renormalization needed), making the gradient flow a powerful non-perturbative tool for scale setting, topology measurement, and defining a running coupling on the lattice.",
-      "mathContext": "$\\partial_t B_\\mu = D_\\nu G_{\\nu\\mu}$ (flow equation); $r = \\sqrt{8t}$ (smoothing radius); $dS/dt = -2\\int |D_\\nu G_{\\nu\\mu}|^2 \\le 0$",
-      "significance": "supporting",
-      "relatedConcepts": ["gradient flow", "Lüscher flow", "UV finiteness", "scale setting", "diffusion equation"],
-      "prerequisites": ["GradientFlowParams", "Real.sqrt"],
-      "tags": ["gradient-flow", "non-perturbative", "uv-finite"]
+    "title": "The Schwinger Model: An Exactly Solvable Mass Gap",
+    "content": "The Schwinger model (QED in 1+1 dimensions, Schwinger 1962) is one of the few quantum field theories with an exactly known mass gap. The formalization proves $m = e/\\sqrt{\\pi} > 0$, where $e$ is the coupling constant, with the remarkable feature that this mass arises entirely from the chiral anomaly \u2014 there is no classical mass term. The string tension $\\sigma = e^2/(2\\pi)$ is also proved positive. The model exhibits confinement: the linear potential $V(r) = \\sigma \\cdot r$ binds charges. As a 2D QFT with a rigorous mass gap, it serves as the primary testing ground for methods aimed at the 4D Millennium Prize Problem.",
+    "mathContext": "$m = e/\\sqrt{\\pi}$, $m^2 = e^2/\\pi$, $\\sigma = e^2/(2\\pi)$; all proved positive in Lean",
+    "significance": "key",
+    "relatedConcepts": [
+      "Schwinger model",
+      "QED in 2D",
+      "exact mass gap",
+      "chiral anomaly",
+      "confinement in 2D"
+    ],
+    "prerequisites": [
+      "SchwingerParams",
+      "Real.sqrt",
+      "Real.pi"
+    ],
+    "tags": [
+      "schwinger-model",
+      "exact-solution",
+      "mass-gap"
+    ]
+  },
+  {
+    "id": "gradient-flow",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 6748,
+      "endLine": 6888
     },
-    {
-      "id": "resurgence-trans-series",
-      "proofId": "yang-mills-mass-gap",
-      "type": "context",
-      "range": { "startLine": 15304, "endLine": 15597 },
-      "title": "Resurgence: Non-Perturbative Completion of QCD",
-      "content": "Perturbation theory in QCD is an asymptotic series with zero radius of convergence — coefficients grow as $a_n \\sim n!$. Far from a defect, this factorial divergence encodes non-perturbative physics via resurgence. Trans-series extend the perturbative expansion with instanton sectors: $E(g^2) = \\sum a_n g^{2n} + e^{-A/g^2} \\sum b_n g^{2n} + \\cdots$. The formalization covers: the beta function coefficient $\\beta_0 = 11N/3$ for pure YM (proved positive for $N \\ge 1$, with $\\beta_0 = 11$ for SU(3)), the one-loop running coupling $\\alpha_s(Q^2) = 1/(\\beta_0 \\ln(Q^2/\\Lambda^2))$, IR renormalons (Borel singularities at $t = 2k/\\beta_0$ producing power corrections $\\sim \\Lambda^{2p}/Q^{2p}$), and the resurgent structure connecting perturbative and instanton sectors via Stokes automorphisms.",
-      "mathContext": "$a_n \\sim n! A^{-n}$; trans-series: $\\sum a_n g^{2n} + e^{-A/g^2} \\sum b_n g^{2n} + e^{-2A/g^2} \\sum c_n g^{2n} + \\cdots$",
-      "significance": "supporting",
-      "relatedConcepts": ["asymptotic series", "Borel summation", "renormalon", "instanton", "trans-series", "Stokes phenomenon"],
-      "prerequisites": ["Real.exp", "Real.log", "betaZeroPure"],
-      "tags": ["resurgence", "trans-series", "non-perturbative"]
+    "title": "Yang-Mills Gradient Flow: A Non-Perturbative UV Regulator",
+    "content": "L\u00fcscher's gradient flow (2010) evolves gauge fields along a diffusion equation in a fictitious flow time $t$, smoothing them over a radius $r = \\sqrt{8t}$. The formalization proves: (1) the smoothing radius is non-negative and positive at $t > 0$, (2) the Yang-Mills action monotonically decreases along the flow ($dS/dt \\le 0$), so the flow always moves toward classical solutions \u2014 instantons or vacuum. The key physical insight is that operators evaluated at $t > 0$ are automatically UV finite (no renormalization needed), making the gradient flow a powerful non-perturbative tool for scale setting, topology measurement, and defining a running coupling on the lattice.",
+    "mathContext": "$\\partial_t B_\\mu = D_\\nu G_{\\nu\\mu}$ (flow equation); $r = \\sqrt{8t}$ (smoothing radius); $dS/dt = -2\\int |D_\\nu G_{\\nu\\mu}|^2 \\le 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "gradient flow",
+      "L\u00fcscher flow",
+      "UV finiteness",
+      "scale setting",
+      "diffusion equation"
+    ],
+    "prerequisites": [
+      "GradientFlowParams",
+      "Real.sqrt"
+    ],
+    "tags": [
+      "gradient-flow",
+      "non-perturbative",
+      "uv-finite"
+    ]
+  },
+  {
+    "id": "resurgence-trans-series",
+    "proofId": "yang-mills-mass-gap",
+    "type": "context",
+    "range": {
+      "startLine": 15304,
+      "endLine": 15597
     },
-    {
-      "id": "balaban-rg",
-      "proofId": "yang-mills-mass-gap",
-      "type": "context",
-      "range": { "startLine": 25187, "endLine": 25435 },
-      "title": "Balaban's Renormalization Group: Closest Rigorous Approach",
-      "content": "Tadeusz Balaban's block-spin renormalization group program (1980s-90s) represents the closest existing rigorous mathematical approach to constructing 4D Yang-Mills theory. The formalization defines: effective lattice spacing $a_k = 2^k \\cdot a_0$ (proved to grow and remain positive), the running coupling at each RG step $g^2(k) = g_0^2 + \\beta_0 g_0^4 k \\ln 2 + O(g_0^6)$, and a key theorem that the coupling remains controlled ($g^2(k) < 2g_0^2$) for $k \\le 1/(\\beta_0 g_0^2)$ RG steps. Balaban proved ultraviolet stability for finitely many block-spin steps in $d \\le 4$. The gap to the Millennium Prize: extending from finitely many to infinitely many RG steps and controlling the infinite-volume and continuum limits simultaneously.",
-      "mathContext": "$a_k = 2^k a_0$; $g^2(k) = g_0^2 + \\beta_0 g_0^4 k \\ln 2$; controlled for $k \\le 1/(\\beta_0 g_0^2)$",
-      "significance": "supporting",
-      "relatedConcepts": ["block-spin RG", "ultraviolet stability", "lattice gauge theory", "asymptotic freedom", "continuum limit"],
-      "prerequisites": ["BlockSpinRGParams", "Real.log", "pow_pos"],
-      "tags": ["balaban", "renormalization-group", "rigorous"]
+    "title": "Resurgence: Non-Perturbative Completion of QCD",
+    "content": "Perturbation theory in QCD is an asymptotic series with zero radius of convergence \u2014 coefficients grow as $a_n \\sim n!$. Far from a defect, this factorial divergence encodes non-perturbative physics via resurgence. Trans-series extend the perturbative expansion with instanton sectors: $E(g^2) = \\sum a_n g^{2n} + e^{-A/g^2} \\sum b_n g^{2n} + \\cdots$. The formalization covers: the beta function coefficient $\\beta_0 = 11N/3$ for pure YM (proved positive for $N \\ge 1$, with $\\beta_0 = 11$ for SU(3)), the one-loop running coupling $\\alpha_s(Q^2) = 1/(\\beta_0 \\ln(Q^2/\\Lambda^2))$, IR renormalons (Borel singularities at $t = 2k/\\beta_0$ producing power corrections $\\sim \\Lambda^{2p}/Q^{2p}$), and the resurgent structure connecting perturbative and instanton sectors via Stokes automorphisms.",
+    "mathContext": "$a_n \\sim n! A^{-n}$; trans-series: $\\sum a_n g^{2n} + e^{-A/g^2} \\sum b_n g^{2n} + e^{-2A/g^2} \\sum c_n g^{2n} + \\cdots$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "asymptotic series",
+      "Borel summation",
+      "renormalon",
+      "instanton",
+      "trans-series",
+      "Stokes phenomenon"
+    ],
+    "prerequisites": [
+      "Real.exp",
+      "Real.log",
+      "betaZeroPure"
+    ],
+    "tags": [
+      "resurgence",
+      "trans-series",
+      "non-perturbative"
+    ]
+  },
+  {
+    "id": "balaban-rg",
+    "proofId": "yang-mills-mass-gap",
+    "type": "context",
+    "range": {
+      "startLine": 25187,
+      "endLine": 25435
     },
-    {
-      "id": "maxwell-u1-specialization",
-      "proofId": "yang-mills-mass-gap",
-      "type": "context",
-      "range": { "startLine": 309, "endLine": 375 },
-      "title": "Maxwell's Equations as U(1) Yang-Mills",
-      "content": "Demonstrates that classical electromagnetism is the abelian specialization of Yang-Mills theory: when the gauge group is $\\mathrm{U}(1)$, the Lie bracket $[A_\\mu, A_\\nu]$ vanishes and the field strength reduces to $F_{\\mu\\nu} = \\partial_\\mu A_\\nu - \\partial_\\nu A_\\mu$, recovering the standard electromagnetic tensor. The formalization defines `AbelianGaugeTheory` with antisymmetric field strength and `MaxwellEquations` as the Euler-Lagrange equation $\\partial_\\mu F^{\\mu\\nu} = 0$ summed with the Minkowski metric. The electromagnetic tensor has exactly 6 independent components (3 electric + 3 magnetic), proved by `native_decide`. This abelian embedding establishes Yang-Mills as a non-abelian generalization of Maxwell — making the non-linearity and self-interaction of gluons the essential new physics.",
-      "mathContext": "$F_{\\mu\\nu} = \\partial_\\mu A_\\nu - \\partial_\\nu A_\\mu$ (abelian), $\\partial_\\mu F^{\\mu\\nu} = 0$ (Maxwell), $\\binom{4}{2} = 6$ independent components",
-      "significance": "supporting",
-      "relatedConcepts": ["electromagnetism", "abelian gauge theory", "electromagnetic tensor", "Maxwell equations", "U(1) gauge invariance"],
-      "prerequisites": ["AbelianGaugeTheory", "minkowskiMetric", "Finset"],
-      "tags": ["maxwell", "abelian", "electromagnetism"]
+    "title": "Balaban's Renormalization Group: Closest Rigorous Approach",
+    "content": "Tadeusz Balaban's block-spin renormalization group program (1980s-90s) represents the closest existing rigorous mathematical approach to constructing 4D Yang-Mills theory. The formalization defines: effective lattice spacing $a_k = 2^k \\cdot a_0$ (proved to grow and remain positive), the running coupling at each RG step $g^2(k) = g_0^2 + \\beta_0 g_0^4 k \\ln 2 + O(g_0^6)$, and a key theorem that the coupling remains controlled ($g^2(k) < 2g_0^2$) for $k \\le 1/(\\beta_0 g_0^2)$ RG steps. Balaban proved ultraviolet stability for finitely many block-spin steps in $d \\le 4$. The gap to the Millennium Prize: extending from finitely many to infinitely many RG steps and controlling the infinite-volume and continuum limits simultaneously.",
+    "mathContext": "$a_k = 2^k a_0$; $g^2(k) = g_0^2 + \\beta_0 g_0^4 k \\ln 2$; controlled for $k \\le 1/(\\beta_0 g_0^2)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "block-spin RG",
+      "ultraviolet stability",
+      "lattice gauge theory",
+      "asymptotic freedom",
+      "continuum limit"
+    ],
+    "prerequisites": [
+      "BlockSpinRGParams",
+      "Real.log",
+      "pow_pos"
+    ],
+    "tags": [
+      "balaban",
+      "renormalization-group",
+      "rigorous"
+    ]
+  },
+  {
+    "id": "maxwell-u1-specialization",
+    "proofId": "yang-mills-mass-gap",
+    "type": "context",
+    "range": {
+      "startLine": 309,
+      "endLine": 375
     },
-    {
-      "id": "faddeev-popov-ghosts",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 3738, "endLine": 3769 },
-      "title": "Faddeev-Popov Ghost Fields and Gauge Fixing",
-      "content": "Formalizes the Faddeev-Popov quantization procedure: to define the path integral over gauge-inequivalent configurations, one fixes a gauge (e.g., Feynman gauge $\\xi = 1$ or Landau gauge $\\xi = 0$) and introduces anticommuting scalar 'ghost' fields $c, \\bar{c}$ that cancel unphysical gauge degrees of freedom in loop diagrams. The formalization defines: gauge-fixing parameter $\\xi$, ghost propagator structure, ghost count for $\\mathrm{SU}(2)$ and $\\mathrm{SU}(3)$ ($N^2 - 1$ ghosts for $\\mathrm{SU}(N)$), BRST charge, the gluon propagator structure with transverse/longitudinal decomposition, and the Faddeev-Popov determinant. A key proved identity: ghost loop and gluon contributions sum to the full beta function coefficient, $\\beta_0^{\\text{gluon}} + \\beta_0^{\\text{ghost}} = \\beta_0$, essential for the consistency of asymptotic freedom. The Slavnov-Taylor identities are also formalized, ensuring gauge invariance of the quantum theory.",
-      "mathContext": "$\\mathcal{L}_{\\text{ghost}} = \\bar{c}^a (-\\partial_\\mu D_\\mu^{ab}) c^b$; $N^2 - 1$ ghost fields for $\\mathrm{SU}(N)$; $\\beta_0 = \\beta_0^{\\text{gluon}} + \\beta_0^{\\text{ghost}}$",
-      "significance": "supporting",
-      "relatedConcepts": ["Faddeev-Popov procedure", "ghost fields", "BRST symmetry", "gauge fixing", "Slavnov-Taylor identity"],
-      "prerequisites": ["GaugeFixingParameter", "BRSTCharge", "GluonPropagator"],
-      "tags": ["faddeev-popov", "ghost-fields", "brst", "gauge-fixing"]
+    "title": "Maxwell's Equations as U(1) Yang-Mills",
+    "content": "Demonstrates that classical electromagnetism is the abelian specialization of Yang-Mills theory: when the gauge group is $\\mathrm{U}(1)$, the Lie bracket $[A_\\mu, A_\\nu]$ vanishes and the field strength reduces to $F_{\\mu\\nu} = \\partial_\\mu A_\\nu - \\partial_\\nu A_\\mu$, recovering the standard electromagnetic tensor. The formalization defines `AbelianGaugeTheory` with antisymmetric field strength and `MaxwellEquations` as the Euler-Lagrange equation $\\partial_\\mu F^{\\mu\\nu} = 0$ summed with the Minkowski metric. The electromagnetic tensor has exactly 6 independent components (3 electric + 3 magnetic), proved by `native_decide`. This abelian embedding establishes Yang-Mills as a non-abelian generalization of Maxwell \u2014 making the non-linearity and self-interaction of gluons the essential new physics.",
+    "mathContext": "$F_{\\mu\\nu} = \\partial_\\mu A_\\nu - \\partial_\\nu A_\\mu$ (abelian), $\\partial_\\mu F^{\\mu\\nu} = 0$ (Maxwell), $\\binom{4}{2} = 6$ independent components",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "electromagnetism",
+      "abelian gauge theory",
+      "electromagnetic tensor",
+      "Maxwell equations",
+      "U(1) gauge invariance"
+    ],
+    "prerequisites": [
+      "AbelianGaugeTheory",
+      "minkowskiMetric",
+      "Finset"
+    ],
+    "tags": [
+      "maxwell",
+      "abelian",
+      "electromagnetism"
+    ]
+  },
+  {
+    "id": "faddeev-popov-ghosts",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 3738,
+      "endLine": 3769
     },
-    {
-      "id": "stochastic-quantization",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 4747, "endLine": 4895 },
-      "title": "Stochastic Quantization: Parisi-Wu Approach",
-      "content": "Formalizes the Parisi-Wu stochastic quantization (1981): quantum field configurations are generated by a Langevin equation in a fictitious stochastic time $\\tau$, where $\\partial\\phi/\\partial\\tau = -\\delta S/\\delta\\phi + \\eta$ with white noise $\\eta$. The equilibrium distribution $P_{\\text{eq}} \\propto e^{-S}$ reproduces the Euclidean path integral without gauge fixing — a remarkable advantage over the Faddeev-Popov approach. Zwanziger's gauge-covariant extension (1981) $\\partial A_\\mu/\\partial\\tau = -D_\\nu F_{\\nu\\mu} + D_\\mu\\alpha + \\eta_\\mu$ preserves gauge invariance and naturally avoids the Gribov problem. The formalization proves exponential convergence to equilibrium: $|\\langle O \\rangle_\\tau - \\langle O \\rangle_{\\text{eq}}| \\le C \\cdot e^{-\\Delta_{\\text{FP}} \\tau}$, where $\\Delta_{\\text{FP}}$ is the Fokker-Planck spectral gap. This provides yet another characterization of the mass gap: the Langevin process has exponential mixing if and only if a mass gap exists.",
-      "mathContext": "$\\partial\\phi/\\partial\\tau = -\\delta S/\\delta\\phi + \\eta$; $P_{\\text{eq}} \\propto e^{-S}$; convergence rate $\\sim e^{-\\Delta_{\\text{FP}} \\tau}$",
-      "significance": "supporting",
-      "relatedConcepts": ["Langevin equation", "Fokker-Planck equation", "stochastic PDE", "Hairer regularity structures", "Parisi-Wu method"],
-      "prerequisites": ["LangevinDynamics", "FokkerPlanckSpectralGap", "Real.exp"],
-      "tags": ["stochastic-quantization", "langevin", "parisi-wu"]
+    "title": "Faddeev-Popov Ghost Fields and Gauge Fixing",
+    "content": "Formalizes the Faddeev-Popov quantization procedure: to define the path integral over gauge-inequivalent configurations, one fixes a gauge (e.g., Feynman gauge $\\xi = 1$ or Landau gauge $\\xi = 0$) and introduces anticommuting scalar 'ghost' fields $c, \\bar{c}$ that cancel unphysical gauge degrees of freedom in loop diagrams. The formalization defines: gauge-fixing parameter $\\xi$, ghost propagator structure, ghost count for $\\mathrm{SU}(2)$ and $\\mathrm{SU}(3)$ ($N^2 - 1$ ghosts for $\\mathrm{SU}(N)$), BRST charge, the gluon propagator structure with transverse/longitudinal decomposition, and the Faddeev-Popov determinant. A key proved identity: ghost loop and gluon contributions sum to the full beta function coefficient, $\\beta_0^{\\text{gluon}} + \\beta_0^{\\text{ghost}} = \\beta_0$, essential for the consistency of asymptotic freedom. The Slavnov-Taylor identities are also formalized, ensuring gauge invariance of the quantum theory.",
+    "mathContext": "$\\mathcal{L}_{\\text{ghost}} = \\bar{c}^a (-\\partial_\\mu D_\\mu^{ab}) c^b$; $N^2 - 1$ ghost fields for $\\mathrm{SU}(N)$; $\\beta_0 = \\beta_0^{\\text{gluon}} + \\beta_0^{\\text{ghost}}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Faddeev-Popov procedure",
+      "ghost fields",
+      "BRST symmetry",
+      "gauge fixing",
+      "Slavnov-Taylor identity"
+    ],
+    "prerequisites": [
+      "GaugeFixingParameter",
+      "BRSTCharge",
+      "GluonPropagator"
+    ],
+    "tags": [
+      "faddeev-popov",
+      "ghost-fields",
+      "brst",
+      "gauge-fixing"
+    ]
+  },
+  {
+    "id": "stochastic-quantization",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 4747,
+      "endLine": 4895
     },
-    {
-      "id": "susy-seiberg-witten",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 5041, "endLine": 5219 },
-      "title": "Supersymmetric Yang-Mills and Seiberg-Witten Theory",
-      "content": "Formalizes two landmark results in supersymmetric gauge theory. For $\\mathcal{N}=1$ $\\mathrm{SU}(N)$ SYM: the gluino condensate $\\langle\\lambda\\lambda\\rangle = N\\Lambda^3 e^{2\\pi ik/N}$ with $k = 0, \\ldots, N-1$ gives $N$ degenerate vacua from the spontaneous breaking $\\mathbb{Z}_{2N} \\to \\mathbb{Z}_2$. The Witten index $\\text{Tr}(-1)^F = N$ is proved positive, demonstrating SUSY is unbroken — a topological invariant unchanged by continuous deformations. For $\\mathcal{N}=2$ $\\mathrm{SU}(2)$ SYM: the Seiberg-Witten curve $y^2 = (x-u)(x-\\Lambda^2)(x+\\Lambda^2)$ determines the exact low-energy effective action via period integrals. The curve degenerates at $u = \\pm\\Lambda^2$ (monopole and dyon points — both proved), where monopole condensation produces confinement with a mass gap. The BPS mass formula $M = |n_e a + n_m a_D|$ is also formalized. This is the only known example of exact confinement from first principles, providing a concrete mechanism (monopole condensation) that may underlie non-supersymmetric Yang-Mills confinement.",
-      "mathContext": "$\\text{Tr}(-1)^F = N > 0$ (SUSY unbroken); SW curve: $y^2 = (x-u)(x-\\Lambda^2)(x+\\Lambda^2)$; $\\Delta = 0$ at $u = \\pm\\Lambda^2$",
-      "significance": "key",
-      "relatedConcepts": ["supersymmetry", "Witten index", "Seiberg-Witten theory", "gluino condensate", "BPS states", "monopole condensation"],
-      "prerequisites": ["GluinoCondensate", "WittenIndex", "SeibergWittenCurve", "BPSMass"],
-      "tags": ["susy", "seiberg-witten", "exact-solution", "confinement"]
+    "title": "Stochastic Quantization: Parisi-Wu Approach",
+    "content": "Formalizes the Parisi-Wu stochastic quantization (1981): quantum field configurations are generated by a Langevin equation in a fictitious stochastic time $\\tau$, where $\\partial\\phi/\\partial\\tau = -\\delta S/\\delta\\phi + \\eta$ with white noise $\\eta$. The equilibrium distribution $P_{\\text{eq}} \\propto e^{-S}$ reproduces the Euclidean path integral without gauge fixing \u2014 a remarkable advantage over the Faddeev-Popov approach. Zwanziger's gauge-covariant extension (1981) $\\partial A_\\mu/\\partial\\tau = -D_\\nu F_{\\nu\\mu} + D_\\mu\\alpha + \\eta_\\mu$ preserves gauge invariance and naturally avoids the Gribov problem. The formalization proves exponential convergence to equilibrium: $|\\langle O \\rangle_\\tau - \\langle O \\rangle_{\\text{eq}}| \\le C \\cdot e^{-\\Delta_{\\text{FP}} \\tau}$, where $\\Delta_{\\text{FP}}$ is the Fokker-Planck spectral gap. This provides yet another characterization of the mass gap: the Langevin process has exponential mixing if and only if a mass gap exists.",
+    "mathContext": "$\\partial\\phi/\\partial\\tau = -\\delta S/\\delta\\phi + \\eta$; $P_{\\text{eq}} \\propto e^{-S}$; convergence rate $\\sim e^{-\\Delta_{\\text{FP}} \\tau}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Langevin equation",
+      "Fokker-Planck equation",
+      "stochastic PDE",
+      "Hairer regularity structures",
+      "Parisi-Wu method"
+    ],
+    "prerequisites": [
+      "LangevinDynamics",
+      "FokkerPlanckSpectralGap",
+      "Real.exp"
+    ],
+    "tags": [
+      "stochastic-quantization",
+      "langevin",
+      "parisi-wu"
+    ]
+  },
+  {
+    "id": "susy-seiberg-witten",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 5041,
+      "endLine": 5219
     },
-    {
-      "id": "polyakov-loop-finite-temp",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 6915, "endLine": 7119 },
-      "title": "Polyakov Loop and Deconfinement Phase Transition",
-      "content": "Formalizes the Polyakov loop — the Wilson line wrapping around the thermal (Euclidean time) circle of circumference $\\beta = 1/T$ — as the order parameter for the confinement-deconfinement transition. The expectation value $\\langle P \\rangle = 0$ in the confined phase (infinite quark free energy $F_q = -T \\ln\\langle P\\rangle$), while $\\langle P \\rangle \\ne 0$ signals deconfinement. The formalization classifies the transition by gauge group: $\\mathrm{SU}(2)$ has a second-order (continuous) transition at $T_c \\approx 312$ MeV in the 3D Ising universality class ($\\mathbb{Z}_2$ center), while $\\mathrm{SU}(3)$ has a first-order transition at $T_c \\approx 270$ MeV in the 3D $\\mathbb{Z}_3$ Potts class. The effective potential $V_{\\text{eff}}(P) = -a_2|P|^2 - a_3(P^N + \\bar{P}^N) + a_4|P|^4 + \\cdots$ is constrained by $\\mathbb{Z}_N$ symmetry: the cubic $a_3$ term exists only for $N \\ge 3$, explaining why $\\mathrm{SU}(3)$ is first-order (Landau theory) while $\\mathrm{SU}(2)$ is continuous.",
-      "mathContext": "$\\langle P \\rangle = 0 \\iff$ confined; $F_q = -T\\ln\\langle P\\rangle = \\infty$; $T_c^{\\mathrm{SU}(2)} \\approx 312$ MeV (2nd order), $T_c^{\\mathrm{SU}(3)} \\approx 270$ MeV (1st order)",
-      "significance": "key",
-      "relatedConcepts": ["Polyakov loop", "deconfinement", "phase transition", "universality class", "Potts model", "center symmetry"],
-      "prerequisites": ["ThermalYM", "PolyakovExpectation", "DeconfinementTransition"],
-      "tags": ["polyakov-loop", "finite-temperature", "phase-transition", "deconfinement"]
+    "title": "Supersymmetric Yang-Mills and Seiberg-Witten Theory",
+    "content": "Formalizes two landmark results in supersymmetric gauge theory. For $\\mathcal{N}=1$ $\\mathrm{SU}(N)$ SYM: the gluino condensate $\\langle\\lambda\\lambda\\rangle = N\\Lambda^3 e^{2\\pi ik/N}$ with $k = 0, \\ldots, N-1$ gives $N$ degenerate vacua from the spontaneous breaking $\\mathbb{Z}_{2N} \\to \\mathbb{Z}_2$. The Witten index $\\text{Tr}(-1)^F = N$ is proved positive, demonstrating SUSY is unbroken \u2014 a topological invariant unchanged by continuous deformations. For $\\mathcal{N}=2$ $\\mathrm{SU}(2)$ SYM: the Seiberg-Witten curve $y^2 = (x-u)(x-\\Lambda^2)(x+\\Lambda^2)$ determines the exact low-energy effective action via period integrals. The curve degenerates at $u = \\pm\\Lambda^2$ (monopole and dyon points \u2014 both proved), where monopole condensation produces confinement with a mass gap. The BPS mass formula $M = |n_e a + n_m a_D|$ is also formalized. This is the only known example of exact confinement from first principles, providing a concrete mechanism (monopole condensation) that may underlie non-supersymmetric Yang-Mills confinement.",
+    "mathContext": "$\\text{Tr}(-1)^F = N > 0$ (SUSY unbroken); SW curve: $y^2 = (x-u)(x-\\Lambda^2)(x+\\Lambda^2)$; $\\Delta = 0$ at $u = \\pm\\Lambda^2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "supersymmetry",
+      "Witten index",
+      "Seiberg-Witten theory",
+      "gluino condensate",
+      "BPS states",
+      "monopole condensation"
+    ],
+    "prerequisites": [
+      "GluinoCondensate",
+      "WittenIndex",
+      "SeibergWittenCurve",
+      "BPSMass"
+    ],
+    "tags": [
+      "susy",
+      "seiberg-witten",
+      "exact-solution",
+      "confinement"
+    ]
+  },
+  {
+    "id": "polyakov-loop-finite-temp",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 6915,
+      "endLine": 7119
     },
-    {
-      "id": "glueball-spectrum",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 7141, "endLine": 7260 },
-      "title": "Glueball Spectrum: Physical Manifestation of the Mass Gap",
-      "content": "Glueballs are bound states of pure gluons, classified by quantum numbers $J^{PC}$ (spin, parity, charge conjugation). They are the physical particles of pure Yang-Mills theory and the lightest glueball mass IS the mass gap. The formalization defines three established glueball states from lattice QCD: scalar $0^{++}$ at $\\approx 1730$ MeV, tensor $2^{++}$ at $\\approx 2400$ MeV, and pseudoscalar $0^{-+}$ at $\\approx 2590$ MeV. The mass hierarchy $m(0^{++}) < m(2^{++}) < m(0^{-+})$ is proved, as is the positivity of the lightest mass. The dimensionless mass ratios $m/\\sqrt{\\sigma}$ (scalar $\\approx 3.98$, tensor $\\approx 5.48$, pseudoscalar $\\approx 5.93$) are physical predictions from lattice QCD that any rigorous proof of the mass gap would need to reproduce. Large-$N$ scaling shows glueball masses are $O(1)$ as $N \\to \\infty$ while decay widths are $O(1/N^2)$ — the mass gap survives the large-$N$ limit, and glueballs become narrow, non-interacting states.",
-      "mathContext": "$m(0^{++}) \\approx 1730$ MeV $< m(2^{++}) \\approx 2400$ MeV $< m(0^{-+}) \\approx 2590$ MeV; $m(0^{++})/\\sqrt{\\sigma} \\approx 3.98$",
-      "significance": "key",
-      "relatedConcepts": ["glueball", "bound state", "lattice QCD", "mass hierarchy", "large-N limit", "string tension"],
-      "prerequisites": ["GlueballState", "GlueballRatio", "scalar_glueball"],
-      "tags": ["glueball", "mass-gap", "lattice-qcd", "spectrum"]
+    "title": "Polyakov Loop and Deconfinement Phase Transition",
+    "content": "Formalizes the Polyakov loop \u2014 the Wilson line wrapping around the thermal (Euclidean time) circle of circumference $\\beta = 1/T$ \u2014 as the order parameter for the confinement-deconfinement transition. The expectation value $\\langle P \\rangle = 0$ in the confined phase (infinite quark free energy $F_q = -T \\ln\\langle P\\rangle$), while $\\langle P \\rangle \\ne 0$ signals deconfinement. The formalization classifies the transition by gauge group: $\\mathrm{SU}(2)$ has a second-order (continuous) transition at $T_c \\approx 312$ MeV in the 3D Ising universality class ($\\mathbb{Z}_2$ center), while $\\mathrm{SU}(3)$ has a first-order transition at $T_c \\approx 270$ MeV in the 3D $\\mathbb{Z}_3$ Potts class. The effective potential $V_{\\text{eff}}(P) = -a_2|P|^2 - a_3(P^N + \\bar{P}^N) + a_4|P|^4 + \\cdots$ is constrained by $\\mathbb{Z}_N$ symmetry: the cubic $a_3$ term exists only for $N \\ge 3$, explaining why $\\mathrm{SU}(3)$ is first-order (Landau theory) while $\\mathrm{SU}(2)$ is continuous.",
+    "mathContext": "$\\langle P \\rangle = 0 \\iff$ confined; $F_q = -T\\ln\\langle P\\rangle = \\infty$; $T_c^{\\mathrm{SU}(2)} \\approx 312$ MeV (2nd order), $T_c^{\\mathrm{SU}(3)} \\approx 270$ MeV (1st order)",
+    "significance": "key",
+    "relatedConcepts": [
+      "Polyakov loop",
+      "deconfinement",
+      "phase transition",
+      "universality class",
+      "Potts model",
+      "center symmetry"
+    ],
+    "prerequisites": [
+      "ThermalYM",
+      "PolyakovExpectation",
+      "DeconfinementTransition"
+    ],
+    "tags": [
+      "polyakov-loop",
+      "finite-temperature",
+      "phase-transition",
+      "deconfinement"
+    ]
+  },
+  {
+    "id": "glueball-spectrum",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 7141,
+      "endLine": 7260
     },
-    {
-      "id": "lattice-monte-carlo",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 4284, "endLine": 4519 },
-      "title": "Lattice Monte Carlo: Computational Evidence for Confinement",
-      "content": "Formalizes the computational framework that provides the strongest numerical evidence for the mass gap. The Wilson plaquette action $S_\\square = \\beta(1 - \\text{Re\\,Tr}\\,U_\\square/N)$ is bounded: $0 \\le S_\\square \\le 2\\beta$ (proved). In 4D, there are 6 plaquettes per site (proved by `norm_num`). The Metropolis algorithm with acceptance probability $P = \\min(1, e^{-\\Delta S})$ satisfies detailed balance; the key theorem proves improvements are always accepted ($\\Delta S \\le 0 \\implies P = 1$). This machinery enables numerical measurement of Wilson loops, string tension, and glueball masses — the quantitative evidence that the community relies on while awaiting a rigorous proof.",
-      "mathContext": "$S_\\square = \\beta(1 - \\text{Re\\,Tr}\\,U_\\square/N)$, $0 \\le S_\\square \\le 2\\beta$; Metropolis: $P_{\\text{accept}} = \\min(1, e^{-\\Delta S})$; 4D: $\\binom{4}{2} = 6$ plaquettes/site",
-      "significance": "supporting",
-      "relatedConcepts": ["Monte Carlo method", "Metropolis algorithm", "detailed balance", "importance sampling", "Wilson action"],
-      "prerequisites": ["WilsonPlaquetteAction", "MetropolisStep", "Real.exp"],
-      "tags": ["lattice", "monte-carlo", "metropolis", "numerical"]
+    "title": "Glueball Spectrum: Physical Manifestation of the Mass Gap",
+    "content": "Glueballs are bound states of pure gluons, classified by quantum numbers $J^{PC}$ (spin, parity, charge conjugation). They are the physical particles of pure Yang-Mills theory and the lightest glueball mass IS the mass gap. The formalization defines three established glueball states from lattice QCD: scalar $0^{++}$ at $\\approx 1730$ MeV, tensor $2^{++}$ at $\\approx 2400$ MeV, and pseudoscalar $0^{-+}$ at $\\approx 2590$ MeV. The mass hierarchy $m(0^{++}) < m(2^{++}) < m(0^{-+})$ is proved, as is the positivity of the lightest mass. The dimensionless mass ratios $m/\\sqrt{\\sigma}$ (scalar $\\approx 3.98$, tensor $\\approx 5.48$, pseudoscalar $\\approx 5.93$) are physical predictions from lattice QCD that any rigorous proof of the mass gap would need to reproduce. Large-$N$ scaling shows glueball masses are $O(1)$ as $N \\to \\infty$ while decay widths are $O(1/N^2)$ \u2014 the mass gap survives the large-$N$ limit, and glueballs become narrow, non-interacting states.",
+    "mathContext": "$m(0^{++}) \\approx 1730$ MeV $< m(2^{++}) \\approx 2400$ MeV $< m(0^{-+}) \\approx 2590$ MeV; $m(0^{++})/\\sqrt{\\sigma} \\approx 3.98$",
+    "significance": "key",
+    "relatedConcepts": [
+      "glueball",
+      "bound state",
+      "lattice QCD",
+      "mass hierarchy",
+      "large-N limit",
+      "string tension"
+    ],
+    "prerequisites": [
+      "GlueballState",
+      "GlueballRatio",
+      "scalar_glueball"
+    ],
+    "tags": [
+      "glueball",
+      "mass-gap",
+      "lattice-qcd",
+      "spectrum"
+    ]
+  },
+  {
+    "id": "lattice-monte-carlo",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 4284,
+      "endLine": 4519
     },
-    {
-      "id": "complexity-barriers",
-      "proofId": "yang-mills-mass-gap",
-      "type": "context",
-      "range": { "startLine": 4921, "endLine": 5012 },
-      "title": "Complexity Barriers and the Spectral Gap Undecidability",
-      "content": "The spectral gap problem for general translation-invariant Hamiltonians on $\\mathbb{Z}^2$ is undecidable (Cubitt-Perez-Garcia-Wolf 2015) — no algorithm can determine whether $\\Delta > 0$ or $\\Delta = 0$. However, Yang-Mills is NOT a general Hamiltonian: gauge symmetry (Gauss law), asymptotic freedom (specific $\\beta$-function), and confining dynamics impose strong structural constraints, analogous to how specific Diophantine equations may be decidable even though Hilbert's 10th problem is undecidable. The local Hamiltonian ground-state energy problem is QMA-complete (Kitaev 1999), but for Yang-Mills the ground-state energy is 0 by construction — the question is about the gap above it. Pure Yang-Mills also avoids the fermion sign problem ($e^{-S_W} > 0$ for all configurations), enabling reliable Monte Carlo computation.",
-      "mathContext": "General spectral gap undecidable on $\\mathbb{Z}^2$ (Cubitt et al.); Yang-Mills: specific structure may evade undecidability; no sign problem for pure YM",
-      "significance": "context",
-      "relatedConcepts": ["undecidability", "QMA-completeness", "sign problem", "Hilbert's 10th problem", "computational complexity"],
-      "prerequisites": ["SpectralGapUndecidability", "QMAHardness"],
-      "tags": ["complexity", "undecidability", "sign-problem", "qma"]
+    "title": "Lattice Monte Carlo: Computational Evidence for Confinement",
+    "content": "Formalizes the computational framework that provides the strongest numerical evidence for the mass gap. The Wilson plaquette action $S_\\square = \\beta(1 - \\text{Re\\,Tr}\\,U_\\square/N)$ is bounded: $0 \\le S_\\square \\le 2\\beta$ (proved). In 4D, there are 6 plaquettes per site (proved by `norm_num`). The Metropolis algorithm with acceptance probability $P = \\min(1, e^{-\\Delta S})$ satisfies detailed balance; the key theorem proves improvements are always accepted ($\\Delta S \\le 0 \\implies P = 1$). This machinery enables numerical measurement of Wilson loops, string tension, and glueball masses \u2014 the quantitative evidence that the community relies on while awaiting a rigorous proof.",
+    "mathContext": "$S_\\square = \\beta(1 - \\text{Re\\,Tr}\\,U_\\square/N)$, $0 \\le S_\\square \\le 2\\beta$; Metropolis: $P_{\\text{accept}} = \\min(1, e^{-\\Delta S})$; 4D: $\\binom{4}{2} = 6$ plaquettes/site",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Monte Carlo method",
+      "Metropolis algorithm",
+      "detailed balance",
+      "importance sampling",
+      "Wilson action"
+    ],
+    "prerequisites": [
+      "WilsonPlaquetteAction",
+      "MetropolisStep",
+      "Real.exp"
+    ],
+    "tags": [
+      "lattice",
+      "monte-carlo",
+      "metropolis",
+      "numerical"
+    ]
+  },
+  {
+    "id": "complexity-barriers",
+    "proofId": "yang-mills-mass-gap",
+    "type": "context",
+    "range": {
+      "startLine": 4921,
+      "endLine": 5012
     },
-    {
-      "id": "functional-rg-gluon-propagator",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 5776, "endLine": 5835 },
-      "title": "Functional RG: Fixed Points and Gluon Propagator IR Behavior",
-      "content": "Formalizes RG fixed points and the deep infrared behavior of the gluon propagator, central to understanding how the mass gap arises dynamically. The Gaussian fixed point $g^* = 0$ is UV (asymptotic freedom); the absence of a perturbative IR fixed point means the coupling grows without bound at large distances, driving confinement. Two competing IR behaviors are formalized: the decoupling solution $D(p^2) \\to D_0 > 0$ as $p \\to 0$ (massive-type gluon, consistent with lattice data, implies mass gap) and the scaling solution $D(p^2) \\sim (p^2)^{2\\kappa-1}$ with $\\kappa \\approx 0.595$ (Gribov-type suppression, $D(0) = 0$, satisfies Kugo-Ojima confinement criterion). Current consensus favors the decoupling solution, providing dynamical mass generation as the physical origin of the mass gap.",
-      "mathContext": "Gaussian FP: $g^* = 0$ (UV); decoupling: $D(0) > 0$ (mass gap); scaling: $D(p^2) \\sim (p^2)^{2\\kappa-1}$, $\\kappa \\approx 0.595$",
-      "significance": "supporting",
-      "relatedConcepts": ["renormalization group", "Wetterich equation", "gluon propagator", "dynamical mass generation", "Kugo-Ojima criterion"],
-      "prerequisites": ["RGFixedPoint", "GluonPropagatorIR", "DynamicalMassGeneration"],
-      "tags": ["functional-rg", "gluon-propagator", "mass-generation"]
+    "title": "Complexity Barriers and the Spectral Gap Undecidability",
+    "content": "The spectral gap problem for general translation-invariant Hamiltonians on $\\mathbb{Z}^2$ is undecidable (Cubitt-Perez-Garcia-Wolf 2015) \u2014 no algorithm can determine whether $\\Delta > 0$ or $\\Delta = 0$. However, Yang-Mills is NOT a general Hamiltonian: gauge symmetry (Gauss law), asymptotic freedom (specific $\\beta$-function), and confining dynamics impose strong structural constraints, analogous to how specific Diophantine equations may be decidable even though Hilbert's 10th problem is undecidable. The local Hamiltonian ground-state energy problem is QMA-complete (Kitaev 1999), but for Yang-Mills the ground-state energy is 0 by construction \u2014 the question is about the gap above it. Pure Yang-Mills also avoids the fermion sign problem ($e^{-S_W} > 0$ for all configurations), enabling reliable Monte Carlo computation.",
+    "mathContext": "General spectral gap undecidable on $\\mathbb{Z}^2$ (Cubitt et al.); Yang-Mills: specific structure may evade undecidability; no sign problem for pure YM",
+    "significance": "context",
+    "relatedConcepts": [
+      "undecidability",
+      "QMA-completeness",
+      "sign problem",
+      "Hilbert's 10th problem",
+      "computational complexity"
+    ],
+    "prerequisites": [
+      "SpectralGapUndecidability",
+      "QMAHardness"
+    ],
+    "tags": [
+      "complexity",
+      "undecidability",
+      "sign-problem",
+      "qma"
+    ]
+  },
+  {
+    "id": "functional-rg-gluon-propagator",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 5776,
+      "endLine": 5835
     },
-    {
-      "id": "transfer-matrix-mass-gap",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 6249, "endLine": 6328 },
-      "title": "Transfer Matrix: The Finite-Volume Mass Gap Is a Theorem",
-      "content": "On any finite lattice, the mass gap is a proved theorem (not a conjecture). The Perron-Frobenius theorem guarantees a unique largest eigenvalue $\\lambda_0 > 0$ of the transfer matrix, with a strict spectral gap: $\\lambda_0 > \\lambda_1 > 0$. The finite-volume mass gap $\\Delta = \\ln(\\lambda_0/\\lambda_1)$ is proved strictly positive. The physical mass gap $m = \\Delta/a$ is also proved positive. Correlation functions decay exponentially: $\\langle O(t)O(0)\\rangle / \\langle O(0)^2\\rangle \\to (\\lambda_1/\\lambda_0)^n = e^{-n\\Delta}$, giving the physical interpretation of the mass gap as the rate of exponential correlation decay. The deep open problem is whether this gap survives the joint continuum ($a \\to 0$) and infinite-volume ($L \\to \\infty$) limit.",
-      "mathContext": "$\\Delta = \\ln(\\lambda_0/\\lambda_1) > 0$ (proved); $m = \\Delta/a > 0$ (proved); $\\langle O(t)O(0)\\rangle \\sim e^{-n\\Delta}$; open: $\\lim_{a\\to 0, L\\to\\infty} \\Delta/a > 0$?",
-      "significance": "key",
-      "relatedConcepts": ["Perron-Frobenius theorem", "transfer matrix", "spectral gap", "exponential decay", "continuum limit"],
-      "prerequisites": ["LatticeTransferMatrix", "PerronFrobeniusData", "Real.log"],
-      "tags": ["transfer-matrix", "perron-frobenius", "finite-volume", "spectral-gap"]
+    "title": "Functional RG: Fixed Points and Gluon Propagator IR Behavior",
+    "content": "Formalizes RG fixed points and the deep infrared behavior of the gluon propagator, central to understanding how the mass gap arises dynamically. The Gaussian fixed point $g^* = 0$ is UV (asymptotic freedom); the absence of a perturbative IR fixed point means the coupling grows without bound at large distances, driving confinement. Two competing IR behaviors are formalized: the decoupling solution $D(p^2) \\to D_0 > 0$ as $p \\to 0$ (massive-type gluon, consistent with lattice data, implies mass gap) and the scaling solution $D(p^2) \\sim (p^2)^{2\\kappa-1}$ with $\\kappa \\approx 0.595$ (Gribov-type suppression, $D(0) = 0$, satisfies Kugo-Ojima confinement criterion). Current consensus favors the decoupling solution, providing dynamical mass generation as the physical origin of the mass gap.",
+    "mathContext": "Gaussian FP: $g^* = 0$ (UV); decoupling: $D(0) > 0$ (mass gap); scaling: $D(p^2) \\sim (p^2)^{2\\kappa-1}$, $\\kappa \\approx 0.595$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "renormalization group",
+      "Wetterich equation",
+      "gluon propagator",
+      "dynamical mass generation",
+      "Kugo-Ojima criterion"
+    ],
+    "prerequisites": [
+      "RGFixedPoint",
+      "GluonPropagatorIR",
+      "DynamicalMassGeneration"
+    ],
+    "tags": [
+      "functional-rg",
+      "gluon-propagator",
+      "mass-generation"
+    ]
+  },
+  {
+    "id": "transfer-matrix-mass-gap",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 6249,
+      "endLine": 6328
     },
-    {
-      "id": "large-n-thooft",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 2060, "endLine": 2124 },
-      "title": "Large-N Limit and 't Hooft Coupling",
-      "content": "Formalizes the 't Hooft large-$N$ limit: the theory is organized by the 't Hooft coupling $\\lambda = g^2N$ (held fixed as $N \\to \\infty$). The Casimir per color $C_2(\\text{fund})/N = (N^2-1)/(2N^2)$ approaches $1/2$ from below (proved $< 1/2$ for all finite $N \\ge 2$). The adjoint Casimir per color $C_2(\\text{adj})/N = 1$ exactly (proved). The Casimir ratio $C_2(\\text{adj})/C_2(\\text{fund}) \\ge 2$ for all $N \\ge 2$ (proved), converging to exactly 2 as $N \\to \\infty$. The 't Hooft string tension $\\sigma_{\\text{fund}} = \\lambda(N^2-1)/(2N^3)$ is proved positive; the rescaled string tension $\\sigma N = \\lambda(N^2-1)/(2N^2) < \\lambda/2$ is proved bounded. These results show the mass gap and string tension survive the large-$N$ limit with controlled behavior.",
-      "mathContext": "$\\lambda = g^2N$; $C_2(\\text{fund})/N = (N^2-1)/(2N^2) < 1/2$; $C_2(\\text{adj})/C_2(\\text{fund}) \\ge 2$; $\\sigma N < \\lambda/2$",
-      "significance": "key",
-      "relatedConcepts": ["'t Hooft limit", "planar limit", "1/N expansion", "Casimir operator", "string tension"],
-      "prerequisites": ["suNCasimirFundamental", "suNCasimirAdjoint", "tHooftStringTension"],
-      "tags": ["large-n", "thooft", "casimir", "string-tension"]
+    "title": "Transfer Matrix: The Finite-Volume Mass Gap Is a Theorem",
+    "content": "On any finite lattice, the mass gap is a proved theorem (not a conjecture). The Perron-Frobenius theorem guarantees a unique largest eigenvalue $\\lambda_0 > 0$ of the transfer matrix, with a strict spectral gap: $\\lambda_0 > \\lambda_1 > 0$. The finite-volume mass gap $\\Delta = \\ln(\\lambda_0/\\lambda_1)$ is proved strictly positive. The physical mass gap $m = \\Delta/a$ is also proved positive. Correlation functions decay exponentially: $\\langle O(t)O(0)\\rangle / \\langle O(0)^2\\rangle \\to (\\lambda_1/\\lambda_0)^n = e^{-n\\Delta}$, giving the physical interpretation of the mass gap as the rate of exponential correlation decay. The deep open problem is whether this gap survives the joint continuum ($a \\to 0$) and infinite-volume ($L \\to \\infty$) limit.",
+    "mathContext": "$\\Delta = \\ln(\\lambda_0/\\lambda_1) > 0$ (proved); $m = \\Delta/a > 0$ (proved); $\\langle O(t)O(0)\\rangle \\sim e^{-n\\Delta}$; open: $\\lim_{a\\to 0, L\\to\\infty} \\Delta/a > 0$?",
+    "significance": "key",
+    "relatedConcepts": [
+      "Perron-Frobenius theorem",
+      "transfer matrix",
+      "spectral gap",
+      "exponential decay",
+      "continuum limit"
+    ],
+    "prerequisites": [
+      "LatticeTransferMatrix",
+      "PerronFrobeniusData",
+      "Real.log"
+    ],
+    "tags": [
+      "transfer-matrix",
+      "perron-frobenius",
+      "finite-volume",
+      "spectral-gap"
+    ]
+  },
+  {
+    "id": "large-n-thooft",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 2060,
+      "endLine": 2124
     },
-    {
-      "id": "running-coupling-lambda-qcd",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 2463, "endLine": 2560 },
-      "title": "Running Coupling, Λ_QCD, and the Trace Anomaly",
-      "content": "Formalizes the one-loop running coupling $1/g^2(\\mu) = 1/g^2(\\mu_0) + (\\beta_0/(8\\pi^2)) \\ln(\\mu/\\mu_0)$ as a `RunningCoupling` structure. The central theorem `asymptotic_freedom` proves that for $\\mu > \\mu_0$, the inverse coupling increases ($g$ decreases) — this IS asymptotic freedom in a single inequality. The QCD scale $\\Lambda_{\\text{QCD}} = \\mu_0 \\exp(-8\\pi^2/(\\beta_0 g_0^2))$ is the scale where the perturbative coupling formally diverges; the formalization proves $\\Lambda_{\\text{QCD}} > 0$ and $\\Lambda_{\\text{QCD}} < \\mu_0$ (confinement scale below the reference scale). The trace anomaly structure formalizes dimensional transmutation: the classically conformal Yang-Mills theory develops a mass scale $\\Lambda_{\\text{QCD}} \\sim 200{-}300$ MeV through quantum effects. The anomalous trace $T^\\mu_\\mu \\propto \\beta_0 g^2$ is proved positive — conformal symmetry IS broken, which is necessary for a mass gap to exist.",
-      "mathContext": "$1/g^2(\\mu) = 1/g_0^2 + \\frac{\\beta_0}{8\\pi^2} \\ln(\\mu/\\mu_0)$; $\\Lambda_{\\text{QCD}} = \\mu_0 e^{-8\\pi^2/(\\beta_0 g_0^2)}$; $T^\\mu_\\mu = \\frac{\\beta_0 g^2}{32\\pi^2} \\text{Tr}(F^2) \\ne 0$",
-      "significance": "key",
-      "relatedConcepts": ["running coupling", "dimensional transmutation", "trace anomaly", "conformal symmetry breaking", "Λ_QCD"],
-      "prerequisites": ["RunningCoupling", "betaZero", "Real.exp", "Real.log"],
-      "tags": ["running-coupling", "lambda-qcd", "trace-anomaly", "dimensional-transmutation"]
+    "title": "Large-N Limit and 't Hooft Coupling",
+    "content": "Formalizes the 't Hooft large-$N$ limit: the theory is organized by the 't Hooft coupling $\\lambda = g^2N$ (held fixed as $N \\to \\infty$). The Casimir per color $C_2(\\text{fund})/N = (N^2-1)/(2N^2)$ approaches $1/2$ from below (proved $< 1/2$ for all finite $N \\ge 2$). The adjoint Casimir per color $C_2(\\text{adj})/N = 1$ exactly (proved). The Casimir ratio $C_2(\\text{adj})/C_2(\\text{fund}) \\ge 2$ for all $N \\ge 2$ (proved), converging to exactly 2 as $N \\to \\infty$. The 't Hooft string tension $\\sigma_{\\text{fund}} = \\lambda(N^2-1)/(2N^3)$ is proved positive; the rescaled string tension $\\sigma N = \\lambda(N^2-1)/(2N^2) < \\lambda/2$ is proved bounded. These results show the mass gap and string tension survive the large-$N$ limit with controlled behavior.",
+    "mathContext": "$\\lambda = g^2N$; $C_2(\\text{fund})/N = (N^2-1)/(2N^2) < 1/2$; $C_2(\\text{adj})/C_2(\\text{fund}) \\ge 2$; $\\sigma N < \\lambda/2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "'t Hooft limit",
+      "planar limit",
+      "1/N expansion",
+      "Casimir operator",
+      "string tension"
+    ],
+    "prerequisites": [
+      "suNCasimirFundamental",
+      "suNCasimirAdjoint",
+      "tHooftStringTension"
+    ],
+    "tags": [
+      "large-n",
+      "thooft",
+      "casimir",
+      "string-tension"
+    ]
+  },
+  {
+    "id": "running-coupling-lambda-qcd",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 2463,
+      "endLine": 2560
     },
-    {
-      "id": "su-n-casimir-formulas",
-      "proofId": "yang-mills-mass-gap",
-      "type": "definition",
-      "range": { "startLine": 1600, "endLine": 1700 },
-      "title": "General SU(N) Casimir Formulas and Representation Theory",
-      "content": "Formalizes the universal Casimir eigenvalue formulas for $\\mathrm{SU}(N)$: the fundamental representation has $C_2(\\text{fund}) = (N^2-1)/(2N)$, verified for $\\mathrm{SU}(2)$, $\\mathrm{SU}(3)$, $\\mathrm{SU}(4)$ by `norm_num`. The adjoint representation has $C_2(\\text{adj}) = N$, verified for $\\mathrm{SU}(2)$ and $\\mathrm{SU}(3)$. Positivity is proved: $C_2(\\text{fund}) > 0$ for $N \\ge 2$, $C_2(\\text{adj}) > 0$ for $N \\ge 1$. The inequality $C_2(\\text{adj}) > C_2(\\text{fund})$ (proved for all $N \\ge 2$) means adjoint strings have higher tension than fundamental strings — physically, gluons are more tightly confined than quarks. The ratio $C_2(\\text{adj})/C_2(\\text{fund}) = 2N^2/(N^2-1)$ decreases from $8/3$ ($\\mathrm{SU}(2)$) toward 2 (large $N$), a key prediction of Casimir scaling verified on the lattice.",
-      "mathContext": "$C_2(\\text{fund}) = (N^2-1)/(2N)$; $C_2(\\text{adj}) = N$; ratio $= 2N^2/(N^2-1) \\to 2$",
-      "significance": "supporting",
-      "relatedConcepts": ["Casimir operator", "representation theory", "Casimir scaling", "string tension ratio", "lattice verification"],
-      "prerequisites": ["suNCasimirFundamental", "suNCasimirAdjoint"],
-      "tags": ["casimir", "representation-theory", "su-n", "string-tension"]
+    "title": "Running Coupling, \u039b_QCD, and the Trace Anomaly",
+    "content": "Formalizes the one-loop running coupling $1/g^2(\\mu) = 1/g^2(\\mu_0) + (\\beta_0/(8\\pi^2)) \\ln(\\mu/\\mu_0)$ as a `RunningCoupling` structure. The central theorem `asymptotic_freedom` proves that for $\\mu > \\mu_0$, the inverse coupling increases ($g$ decreases) \u2014 this IS asymptotic freedom in a single inequality. The QCD scale $\\Lambda_{\\text{QCD}} = \\mu_0 \\exp(-8\\pi^2/(\\beta_0 g_0^2))$ is the scale where the perturbative coupling formally diverges; the formalization proves $\\Lambda_{\\text{QCD}} > 0$ and $\\Lambda_{\\text{QCD}} < \\mu_0$ (confinement scale below the reference scale). The trace anomaly structure formalizes dimensional transmutation: the classically conformal Yang-Mills theory develops a mass scale $\\Lambda_{\\text{QCD}} \\sim 200{-}300$ MeV through quantum effects. The anomalous trace $T^\\mu_\\mu \\propto \\beta_0 g^2$ is proved positive \u2014 conformal symmetry IS broken, which is necessary for a mass gap to exist.",
+    "mathContext": "$1/g^2(\\mu) = 1/g_0^2 + \\frac{\\beta_0}{8\\pi^2} \\ln(\\mu/\\mu_0)$; $\\Lambda_{\\text{QCD}} = \\mu_0 e^{-8\\pi^2/(\\beta_0 g_0^2)}$; $T^\\mu_\\mu = \\frac{\\beta_0 g^2}{32\\pi^2} \\text{Tr}(F^2) \\ne 0$",
+    "significance": "key",
+    "relatedConcepts": [
+      "running coupling",
+      "dimensional transmutation",
+      "trace anomaly",
+      "conformal symmetry breaking",
+      "\u039b_QCD"
+    ],
+    "prerequisites": [
+      "RunningCoupling",
+      "betaZero",
+      "Real.exp",
+      "Real.log"
+    ],
+    "tags": [
+      "running-coupling",
+      "lambda-qcd",
+      "trace-anomaly",
+      "dimensional-transmutation"
+    ]
+  },
+  {
+    "id": "su-n-casimir-formulas",
+    "proofId": "yang-mills-mass-gap",
+    "type": "definition",
+    "range": {
+      "startLine": 1600,
+      "endLine": 1700
     },
-    {
-      "id": "anomaly-matching-gksw",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 7262, "endLine": 7339 },
-      "title": "'t Hooft Anomaly Matching: Non-Perturbative IR Constraints",
-      "content": "'t Hooft's anomaly matching (1980) is one of the most powerful non-perturbative constraints in QFT: if a global symmetry has an anomaly in the UV, the same anomaly must appear in the IR. The formalization covers the Gaiotto-Kapustin-Seiberg-Willett (GKSW, 2017) mixed anomaly between the 1-form center symmetry $\\mathbb{Z}_N$ and 0-form chiral symmetry in pure $\\mathrm{SU}(N)$ Yang-Mills. The anomaly coefficient is proved to be 1 (mod $N$) for all $N \\ge 2$, and nontrivial ($1 \\mod N \\ne 0$ for $N \\ge 2$). This proves the vacuum CANNOT be trivially gapped: either there must be massless particles (conformal phase), spontaneous symmetry breaking (Goldstone bosons), or $N$ degenerate vacua (confinement). For pure Yang-Mills, the last option is realized: $N$ degenerate vacua separated by domain walls, consistent with both confinement and a mass gap. The formalization proves $\\mathrm{SU}(2)$ has 2 vacua and $\\mathrm{SU}(3)$ has 3.",
-      "mathContext": "GKSW anomaly: coefficient $= 1 \\pmod{N}$, nontrivial for $N \\ge 2$; $N$ degenerate vacua from $\\mathbb{Z}_{2N} \\to \\mathbb{Z}_2$",
-      "significance": "key",
-      "relatedConcepts": ["'t Hooft anomaly matching", "1-form symmetry", "center symmetry", "domain walls", "vacuum degeneracy"],
-      "prerequisites": ["AnomalyMatchingData", "MixedAnomaly", "Nat.mod"],
-      "tags": ["anomaly-matching", "gksw", "non-perturbative", "vacuum-structure"]
+    "title": "General SU(N) Casimir Formulas and Representation Theory",
+    "content": "Formalizes the universal Casimir eigenvalue formulas for $\\mathrm{SU}(N)$: the fundamental representation has $C_2(\\text{fund}) = (N^2-1)/(2N)$, verified for $\\mathrm{SU}(2)$, $\\mathrm{SU}(3)$, $\\mathrm{SU}(4)$ by `norm_num`. The adjoint representation has $C_2(\\text{adj}) = N$, verified for $\\mathrm{SU}(2)$ and $\\mathrm{SU}(3)$. Positivity is proved: $C_2(\\text{fund}) > 0$ for $N \\ge 2$, $C_2(\\text{adj}) > 0$ for $N \\ge 1$. The inequality $C_2(\\text{adj}) > C_2(\\text{fund})$ (proved for all $N \\ge 2$) means adjoint strings have higher tension than fundamental strings \u2014 physically, gluons are more tightly confined than quarks. The ratio $C_2(\\text{adj})/C_2(\\text{fund}) = 2N^2/(N^2-1)$ decreases from $8/3$ ($\\mathrm{SU}(2)$) toward 2 (large $N$), a key prediction of Casimir scaling verified on the lattice.",
+    "mathContext": "$C_2(\\text{fund}) = (N^2-1)/(2N)$; $C_2(\\text{adj}) = N$; ratio $= 2N^2/(N^2-1) \\to 2$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Casimir operator",
+      "representation theory",
+      "Casimir scaling",
+      "string tension ratio",
+      "lattice verification"
+    ],
+    "prerequisites": [
+      "suNCasimirFundamental",
+      "suNCasimirAdjoint"
+    ],
+    "tags": [
+      "casimir",
+      "representation-theory",
+      "su-n",
+      "string-tension"
+    ]
+  },
+  {
+    "id": "anomaly-matching-gksw",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 7262,
+      "endLine": 7339
     },
-    {
-      "id": "conformal-window-banks-zaks",
-      "proofId": "yang-mills-mass-gap",
-      "type": "context",
-      "range": { "startLine": 7341, "endLine": 7450 },
-      "title": "Conformal Window and Banks-Zaks Fixed Point",
-      "content": "The mass gap is NOT automatic — it depends on the matter content. For $\\mathrm{SU}(N_c)$ with $N_f$ massless fermion flavors, the theory exhibits three distinct phases. In the confining phase ($N_f$ small, e.g., $0 \\le N_f \\lesssim 8$ for $\\mathrm{SU}(3)$), there is a mass gap $\\Delta > 0$. In the conformal window ($N_f^* < N_f < 11N_c/2$), the theory flows to a non-trivial IR fixed point (Banks-Zaks, 1982) with no mass gap: correlation functions decay as power laws, not exponentially. Above the conformal window ($N_f \\ge 11N_c/2$), asymptotic freedom is lost ($\\beta_0 \\le 0$). The formalization defines $\\beta_0(N_c, N_f) = (11N_c - 2N_f)/3$ and proves key results: $\\beta_0 > 0$ iff $N_f < 11N_c/2$ (asymptotic freedom), and for $\\mathrm{SU}(3)$: the conformal window boundary $N_f = 16$ gives $\\beta_0 = 1/3 > 0$ (barely AF). Pure Yang-Mills ($N_f = 0$) is deep in the confining phase, far from the conformal window.",
-      "mathContext": "$\\beta_0 = (11N_c - 2N_f)/3$; AF $\\iff N_f < 11N_c/2$; conformal window: $N_f^* < N_f < 11N_c/2$ (no mass gap); $N_f = 0$: confined",
-      "significance": "supporting",
-      "relatedConcepts": ["conformal window", "Banks-Zaks fixed point", "IR fixed point", "asymptotic freedom", "conformal field theory"],
-      "prerequisites": ["betaZeroWithFlavors"],
-      "tags": ["conformal-window", "banks-zaks", "phase-diagram", "matter-content"]
+    "title": "'t Hooft Anomaly Matching: Non-Perturbative IR Constraints",
+    "content": "'t Hooft's anomaly matching (1980) is one of the most powerful non-perturbative constraints in QFT: if a global symmetry has an anomaly in the UV, the same anomaly must appear in the IR. The formalization covers the Gaiotto-Kapustin-Seiberg-Willett (GKSW, 2017) mixed anomaly between the 1-form center symmetry $\\mathbb{Z}_N$ and 0-form chiral symmetry in pure $\\mathrm{SU}(N)$ Yang-Mills. The anomaly coefficient is proved to be 1 (mod $N$) for all $N \\ge 2$, and nontrivial ($1 \\mod N \\ne 0$ for $N \\ge 2$). This proves the vacuum CANNOT be trivially gapped: either there must be massless particles (conformal phase), spontaneous symmetry breaking (Goldstone bosons), or $N$ degenerate vacua (confinement). For pure Yang-Mills, the last option is realized: $N$ degenerate vacua separated by domain walls, consistent with both confinement and a mass gap. The formalization proves $\\mathrm{SU}(2)$ has 2 vacua and $\\mathrm{SU}(3)$ has 3.",
+    "mathContext": "GKSW anomaly: coefficient $= 1 \\pmod{N}$, nontrivial for $N \\ge 2$; $N$ degenerate vacua from $\\mathbb{Z}_{2N} \\to \\mathbb{Z}_2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "'t Hooft anomaly matching",
+      "1-form symmetry",
+      "center symmetry",
+      "domain walls",
+      "vacuum degeneracy"
+    ],
+    "prerequisites": [
+      "AnomalyMatchingData",
+      "MixedAnomaly",
+      "Nat.mod"
+    ],
+    "tags": [
+      "anomaly-matching",
+      "gksw",
+      "non-perturbative",
+      "vacuum-structure"
+    ]
+  },
+  {
+    "id": "conformal-window-banks-zaks",
+    "proofId": "yang-mills-mass-gap",
+    "type": "context",
+    "range": {
+      "startLine": 7341,
+      "endLine": 7450
     },
-    {
-      "id": "seiberg-witten-bps-spectrum",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 13007, "endLine": 13100 },
-      "title": "Seiberg-Witten BPS Spectrum and Monopole Condensation",
-      "content": "Formalizes the exact BPS mass spectrum of $\\mathcal{N}=2$ $\\mathrm{SU}(2)$ super-Yang-Mills. The BPS mass formula $M = |n_e a + n_m a_D|$ is defined for charges $(n_e, n_m) \\in \\mathbb{Z}^2$. Three key particles are proved: the W-boson $(2,0)$ with mass $|2a|$, the 't Hooft-Polyakov monopole $(0,1)$ with mass $|a_D|$, and the Julia-Zee dyon $(1,1)$ with mass $|a + a_D|$. The crucial theorem proves that at the singular point $u = \\Lambda^2$ of the Seiberg-Witten curve, $a_D = 0$ and the monopole becomes massless ($M = 0$). Near this point, monopole condensation triggers confinement via the dual Meissner effect. The Dirac quantization conditions $n_e n_m' - n_m n_e' \\in \\mathbb{Z}$ are verified for all particle pairs. This represents the only known example of exact confinement from first principles — monopole condensation provides a concrete microscopic mechanism for the mass gap.",
-      "mathContext": "$M = |n_e a + n_m a_D|$; W-boson: $(2,0)$, $M = |2a|$; monopole: $(0,1)$, $M = |a_D|$; at $u = \\Lambda^2$: $a_D = 0$, monopole massless",
-      "significance": "key",
-      "relatedConcepts": ["BPS states", "monopole condensation", "Seiberg-Witten curve", "Dirac quantization", "dual Meissner effect"],
-      "prerequisites": ["swBpsMass", "SpecialGeometry"],
-      "tags": ["seiberg-witten", "bps", "monopole", "exact-confinement"]
+    "title": "Conformal Window and Banks-Zaks Fixed Point",
+    "content": "The mass gap is NOT automatic \u2014 it depends on the matter content. For $\\mathrm{SU}(N_c)$ with $N_f$ massless fermion flavors, the theory exhibits three distinct phases. In the confining phase ($N_f$ small, e.g., $0 \\le N_f \\lesssim 8$ for $\\mathrm{SU}(3)$), there is a mass gap $\\Delta > 0$. In the conformal window ($N_f^* < N_f < 11N_c/2$), the theory flows to a non-trivial IR fixed point (Banks-Zaks, 1982) with no mass gap: correlation functions decay as power laws, not exponentially. Above the conformal window ($N_f \\ge 11N_c/2$), asymptotic freedom is lost ($\\beta_0 \\le 0$). The formalization defines $\\beta_0(N_c, N_f) = (11N_c - 2N_f)/3$ and proves key results: $\\beta_0 > 0$ iff $N_f < 11N_c/2$ (asymptotic freedom), and for $\\mathrm{SU}(3)$: the conformal window boundary $N_f = 16$ gives $\\beta_0 = 1/3 > 0$ (barely AF). Pure Yang-Mills ($N_f = 0$) is deep in the confining phase, far from the conformal window.",
+    "mathContext": "$\\beta_0 = (11N_c - 2N_f)/3$; AF $\\iff N_f < 11N_c/2$; conformal window: $N_f^* < N_f < 11N_c/2$ (no mass gap); $N_f = 0$: confined",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "conformal window",
+      "Banks-Zaks fixed point",
+      "IR fixed point",
+      "asymptotic freedom",
+      "conformal field theory"
+    ],
+    "prerequisites": [
+      "betaZeroWithFlavors"
+    ],
+    "tags": [
+      "conformal-window",
+      "banks-zaks",
+      "phase-diagram",
+      "matter-content"
+    ]
+  },
+  {
+    "id": "seiberg-witten-bps-spectrum",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 13007,
+      "endLine": 13100
     },
-    {
-      "id": "witten-veneziano-topology",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 9493, "endLine": 9578 },
-      "title": "Witten-Veneziano: Topological Susceptibility and the η' Mass",
-      "content": "The Witten-Veneziano relation $m_{\\eta'}^2 = 2N_f \\chi_t / f_\\pi^2$ connects the mass of the $\\eta'$ meson to the topological susceptibility $\\chi_t$ of the pure Yang-Mills vacuum. Since $\\chi_t > 0$ (non-trivial topological fluctuations, i.e., instantons), the $\\eta'$ acquires a mass far above the pion: $m_{\\eta'} \\approx 958$ MeV vs $m_\\pi \\approx 140$ MeV. This is proved by showing all factors ($2N_f$, $\\chi_t$, $1/f_\\pi^2$) are positive. The formalization also proves: (1) positive $\\chi_t$ implies non-trivial vacuum structure (instantons contribute), (2) large-$N$ scaling $\\chi_t \\sim 1/N^2$ shows the $\\eta'$ becomes a Goldstone boson at $N = \\infty$, and (3) the instanton density $n_I \\sim \\Lambda^4 e^{-8\\pi^2/g^2}$ is exponentially small but positive. This chain connects the topological structure of the Yang-Mills vacuum directly to the physical mass spectrum.",
-      "mathContext": "$m_{\\eta'}^2 = 2N_f \\chi_t / f_\\pi^2 > 0$; $\\chi_t \\sim O(1/N^2)$; $n_I \\sim \\Lambda^4 e^{-S_{\\text{inst}}} > 0$",
-      "significance": "supporting",
-      "relatedConcepts": ["topological susceptibility", "eta prime meson", "instanton density", "chiral symmetry", "vacuum topology"],
-      "prerequisites": ["WittenVenezianoRelation", "TopSusceptibility", "Real.exp"],
-      "tags": ["witten-veneziano", "topology", "eta-prime", "instantons"]
+    "title": "Seiberg-Witten BPS Spectrum and Monopole Condensation",
+    "content": "Formalizes the exact BPS mass spectrum of $\\mathcal{N}=2$ $\\mathrm{SU}(2)$ super-Yang-Mills. The BPS mass formula $M = |n_e a + n_m a_D|$ is defined for charges $(n_e, n_m) \\in \\mathbb{Z}^2$. Three key particles are proved: the W-boson $(2,0)$ with mass $|2a|$, the 't Hooft-Polyakov monopole $(0,1)$ with mass $|a_D|$, and the Julia-Zee dyon $(1,1)$ with mass $|a + a_D|$. The crucial theorem proves that at the singular point $u = \\Lambda^2$ of the Seiberg-Witten curve, $a_D = 0$ and the monopole becomes massless ($M = 0$). Near this point, monopole condensation triggers confinement via the dual Meissner effect. The Dirac quantization conditions $n_e n_m' - n_m n_e' \\in \\mathbb{Z}$ are verified for all particle pairs. This represents the only known example of exact confinement from first principles \u2014 monopole condensation provides a concrete microscopic mechanism for the mass gap.",
+    "mathContext": "$M = |n_e a + n_m a_D|$; W-boson: $(2,0)$, $M = |2a|$; monopole: $(0,1)$, $M = |a_D|$; at $u = \\Lambda^2$: $a_D = 0$, monopole massless",
+    "significance": "key",
+    "relatedConcepts": [
+      "BPS states",
+      "monopole condensation",
+      "Seiberg-Witten curve",
+      "Dirac quantization",
+      "dual Meissner effect"
+    ],
+    "prerequisites": [
+      "swBpsMass",
+      "SpecialGeometry"
+    ],
+    "tags": [
+      "seiberg-witten",
+      "bps",
+      "monopole",
+      "exact-confinement"
+    ]
+  },
+  {
+    "id": "witten-veneziano-topology",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 9493,
+      "endLine": 9578
     },
-    {
-      "id": "vafa-witten-parity",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 22007, "endLine": 22080 },
-      "title": "Vafa-Witten Theorem: Parity Cannot Spontaneously Break",
-      "content": "The Vafa-Witten theorem (1984) proves that in vector-like gauge theories (e.g., QCD with equal-mass quarks), parity and charge conjugation cannot spontaneously break. The proof hinges on the path integral measure being positive: $e^{-S_{\\text{gauge}}} |\\det(D\\!\\!/ + m)|^2 \\ge 0$. Under parity $P$, this measure is invariant but a parity-odd operator $O$ maps to $-O$, forcing $\\langle O \\rangle = -\\langle O \\rangle = 0$. The formalization defines `VWVectorLikeTheory` with positive quark mass, proves the fermion determinant squared is positive, proves the measure positivity $e^{-S} \\cdot |\\det|^2 \\ge 0$, and derives the main theorem: $\\langle O_{\\text{odd}} \\rangle = 0$. This constrains the QCD vacuum: it must be parity-even, ruling out spontaneous parity violation. The theta vacuum energy $E(\\theta) = -\\chi_t \\cos\\theta$ is minimized at $\\theta = 0$ (parity-even) when $\\chi_t > 0$. The theorem also extends to charge conjugation and combined CP.",
-      "mathContext": "$\\langle O_{\\text{odd}} \\rangle = 0$; proof: $\\langle O \\rangle = \\langle P(O) \\rangle = -\\langle O \\rangle \\implies \\langle O \\rangle = 0$; $E(\\theta)$ minimized at $\\theta = 0$",
-      "significance": "supporting",
-      "relatedConcepts": ["parity symmetry", "vector-like theory", "fermion determinant", "theta vacuum", "CP symmetry"],
-      "prerequisites": ["VWVectorLikeTheory", "Real.exp", "Real.cos"],
-      "tags": ["vafa-witten", "parity", "discrete-symmetry", "vacuum-structure"]
+    "title": "Witten-Veneziano: Topological Susceptibility and the \u03b7' Mass",
+    "content": "The Witten-Veneziano relation $m_{\\eta'}^2 = 2N_f \\chi_t / f_\\pi^2$ connects the mass of the $\\eta'$ meson to the topological susceptibility $\\chi_t$ of the pure Yang-Mills vacuum. Since $\\chi_t > 0$ (non-trivial topological fluctuations, i.e., instantons), the $\\eta'$ acquires a mass far above the pion: $m_{\\eta'} \\approx 958$ MeV vs $m_\\pi \\approx 140$ MeV. This is proved by showing all factors ($2N_f$, $\\chi_t$, $1/f_\\pi^2$) are positive. The formalization also proves: (1) positive $\\chi_t$ implies non-trivial vacuum structure (instantons contribute), (2) large-$N$ scaling $\\chi_t \\sim 1/N^2$ shows the $\\eta'$ becomes a Goldstone boson at $N = \\infty$, and (3) the instanton density $n_I \\sim \\Lambda^4 e^{-8\\pi^2/g^2}$ is exponentially small but positive. This chain connects the topological structure of the Yang-Mills vacuum directly to the physical mass spectrum.",
+    "mathContext": "$m_{\\eta'}^2 = 2N_f \\chi_t / f_\\pi^2 > 0$; $\\chi_t \\sim O(1/N^2)$; $n_I \\sim \\Lambda^4 e^{-S_{\\text{inst}}} > 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "topological susceptibility",
+      "eta prime meson",
+      "instanton density",
+      "chiral symmetry",
+      "vacuum topology"
+    ],
+    "prerequisites": [
+      "WittenVenezianoRelation",
+      "TopSusceptibility",
+      "Real.exp"
+    ],
+    "tags": [
+      "witten-veneziano",
+      "topology",
+      "eta-prime",
+      "instantons"
+    ]
+  },
+  {
+    "id": "vafa-witten-parity",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 22007,
+      "endLine": 22080
     },
-    {
-      "id": "wegner-duality-z2",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 19990, "endLine": 20080 },
-      "title": "Wegner Duality: Z₂ Gauge Theory and the Ising Model",
-      "content": "Wegner's duality (1971) maps $\\mathbb{Z}_2$ lattice gauge theory to the Ising model on the dual lattice in $d-2$ dimensions. The formalization proves a remarkable consequence: in $d=3$, the dual lattice dimension is 1, and the 1D Ising model has NO phase transition (Ising 1925) — therefore $\\mathbb{Z}_2$ gauge theory in 3D is ALWAYS confining at all couplings, with string tension $\\sigma > 0$ everywhere. This is one of the few rigorous confinement results in gauge theory. In $d=4$, the dual dimension is 2, giving the Onsager phase transition at $\\beta_c = \\ln(1+\\sqrt{2})/2 \\approx 0.4407$: below $\\beta_c$ the theory confines (mass gap $> 0$), above $\\beta_c$ it deconfines (mass gap $= 0$). The key contrast with $\\mathrm{SU}(N)$: Yang-Mills in 4D has no deconfinement transition at zero temperature — the strong-coupling and weak-coupling regimes are analytically connected, supporting the existence of a mass gap for all couplings.",
-      "mathContext": "$d=3$: dual dim $= 1$, no transition $\\implies$ always confined; $d=4$: dual dim $= 2$, Onsager $\\beta_c = \\ln(1+\\sqrt{2})/2$; $\\mathrm{SU}(N)$: no transition",
-      "significance": "supporting",
-      "relatedConcepts": ["Wegner duality", "Ising model", "Kramers-Wannier duality", "phase transition", "rigorous confinement"],
-      "prerequisites": ["z2StringTension", "z2SelfDualCoupling", "Real.tanh"],
-      "tags": ["wegner-duality", "z2-gauge", "ising-model", "confinement"]
+    "title": "Vafa-Witten Theorem: Parity Cannot Spontaneously Break",
+    "content": "The Vafa-Witten theorem (1984) proves that in vector-like gauge theories (e.g., QCD with equal-mass quarks), parity and charge conjugation cannot spontaneously break. The proof hinges on the path integral measure being positive: $e^{-S_{\\text{gauge}}} |\\det(D\\!\\!/ + m)|^2 \\ge 0$. Under parity $P$, this measure is invariant but a parity-odd operator $O$ maps to $-O$, forcing $\\langle O \\rangle = -\\langle O \\rangle = 0$. The formalization defines `VWVectorLikeTheory` with positive quark mass, proves the fermion determinant squared is positive, proves the measure positivity $e^{-S} \\cdot |\\det|^2 \\ge 0$, and derives the main theorem: $\\langle O_{\\text{odd}} \\rangle = 0$. This constrains the QCD vacuum: it must be parity-even, ruling out spontaneous parity violation. The theta vacuum energy $E(\\theta) = -\\chi_t \\cos\\theta$ is minimized at $\\theta = 0$ (parity-even) when $\\chi_t > 0$. The theorem also extends to charge conjugation and combined CP.",
+    "mathContext": "$\\langle O_{\\text{odd}} \\rangle = 0$; proof: $\\langle O \\rangle = \\langle P(O) \\rangle = -\\langle O \\rangle \\implies \\langle O \\rangle = 0$; $E(\\theta)$ minimized at $\\theta = 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "parity symmetry",
+      "vector-like theory",
+      "fermion determinant",
+      "theta vacuum",
+      "CP symmetry"
+    ],
+    "prerequisites": [
+      "VWVectorLikeTheory",
+      "Real.exp",
+      "Real.cos"
+    ],
+    "tags": [
+      "vafa-witten",
+      "parity",
+      "discrete-symmetry",
+      "vacuum-structure"
+    ]
+  },
+  {
+    "id": "wegner-duality-z2",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 19990,
+      "endLine": 20080
     },
-    {
-      "id": "susy-qm-morse-analogy",
-      "proofId": "yang-mills-mass-gap",
-      "type": "context",
-      "range": { "startLine": 27000, "endLine": 27070 },
-      "title": "SUSY Quantum Mechanics and the Morse Theory Analogy",
-      "content": "Formalizes the deep analogy between supersymmetric quantum mechanics and the Yang-Mills mass gap through Witten's Morse theory framework. In SUSY QM, partner potentials $V_\\pm(x) = W'(x)^2 \\pm W''(x)$ have identical spectra except for the ground state: if SUSY is unbroken ($E_0 = 0$), the ground state has no partner. The Witten deformation $d_t = e^{-tf} d e^{tf}$ of the de Rham complex creates a spectral gap $\\sim t$ between exponentially small eigenvalues (one per critical point of the Morse function $f$) and large eigenvalues — directly analogous to the Yang-Mills mass gap. The formalization establishes a seven-way parallel between SUSY QM and Yang-Mills: superpotential $\\leftrightarrow$ YM action, critical points $\\leftrightarrow$ instantons, Witten index $I_W \\leftrightarrow$ number of YM vacua $N$, and mass gap $\\Delta \\leftrightarrow$ Yang-Mills mass gap. The semiclassical mass gap formula $\\Delta \\approx (g^2/L) \\exp(-8\\pi^2/(Ng^2))$ for $\\mathcal{N}=1$ SYM on $\\mathbb{R}^3 \\times S^1$ is the closest known analytical mass gap formula for non-abelian gauge theory.",
-      "mathContext": "$V_\\pm = W'^2 \\pm W''$; Witten index $I_W = \\text{Tr}(-1)^F$; spectral gap $\\sim t$ (Morse); $\\Delta \\sim (g^2/L) e^{-8\\pi^2/(Ng^2)}$",
-      "significance": "supporting",
-      "relatedConcepts": ["supersymmetric quantum mechanics", "Morse theory", "Witten index", "spectral gap", "instanton tunneling"],
-      "prerequisites": ["partner_spectra_relation", "morse_spectral_gap"],
-      "tags": ["susy-qm", "morse-theory", "witten-deformation", "mass-gap-analogy"]
+    "title": "Wegner Duality: Z\u2082 Gauge Theory and the Ising Model",
+    "content": "Wegner's duality (1971) maps $\\mathbb{Z}_2$ lattice gauge theory to the Ising model on the dual lattice in $d-2$ dimensions. The formalization proves a remarkable consequence: in $d=3$, the dual lattice dimension is 1, and the 1D Ising model has NO phase transition (Ising 1925) \u2014 therefore $\\mathbb{Z}_2$ gauge theory in 3D is ALWAYS confining at all couplings, with string tension $\\sigma > 0$ everywhere. This is one of the few rigorous confinement results in gauge theory. In $d=4$, the dual dimension is 2, giving the Onsager phase transition at $\\beta_c = \\ln(1+\\sqrt{2})/2 \\approx 0.4407$: below $\\beta_c$ the theory confines (mass gap $> 0$), above $\\beta_c$ it deconfines (mass gap $= 0$). The key contrast with $\\mathrm{SU}(N)$: Yang-Mills in 4D has no deconfinement transition at zero temperature \u2014 the strong-coupling and weak-coupling regimes are analytically connected, supporting the existence of a mass gap for all couplings.",
+    "mathContext": "$d=3$: dual dim $= 1$, no transition $\\implies$ always confined; $d=4$: dual dim $= 2$, Onsager $\\beta_c = \\ln(1+\\sqrt{2})/2$; $\\mathrm{SU}(N)$: no transition",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Wegner duality",
+      "Ising model",
+      "Kramers-Wannier duality",
+      "phase transition",
+      "rigorous confinement"
+    ],
+    "prerequisites": [
+      "z2StringTension",
+      "z2SelfDualCoupling",
+      "Real.tanh"
+    ],
+    "tags": [
+      "wegner-duality",
+      "z2-gauge",
+      "ising-model",
+      "confinement"
+    ]
+  },
+  {
+    "id": "susy-qm-morse-analogy",
+    "proofId": "yang-mills-mass-gap",
+    "type": "context",
+    "range": {
+      "startLine": 27000,
+      "endLine": 27070
     },
-    {
-      "id": "dse-gluon-gap-equation",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 28970, "endLine": 29032 },
-      "title": "Dyson-Schwinger Equations: The Gluon Gap Equation",
-      "content": "The Dyson-Schwinger equations (DSE) are the quantum equations of motion — an infinite tower of coupled integral equations for correlation functions. For the gluon propagator, two self-consistent solutions are formalized: the decoupling solution $D(p^2) \\to D_0 > 0$ (massive gluon, $m_{\\text{gluon}} \\approx 500$ MeV from lattice and DSE), and the scaling solution $D(p^2) \\sim (p^2)^{2\\kappa-1}$ with $D(0) = 0$ and enhanced ghost $G(p^2) \\sim (p^2)^{-1-\\kappa}$, $\\kappa \\approx 0.595$ (Kugo-Ojima confinement criterion). Both imply confinement, but via different mechanisms. The Oehme-Zimmermann superconvergence relation $\\int_0^\\infty dp^2 \\rho(p^2) = 0$ proves the gluon spectral function $\\rho$ must go negative somewhere — positivity violation is a signature of confinement (confined particles cannot appear as asymptotic states). Current lattice data strongly favors the decoupling solution with a finite gluon mass, providing a dynamical origin for the mass gap via the Schwinger mechanism.",
-      "mathContext": "Decoupling: $D(0) > 0$, $m_{\\text{gluon}} \\approx 500$ MeV; Scaling: $D(p^2) \\sim (p^2)^{2\\kappa-1}$, $\\kappa \\approx 0.595$; OZ: $\\int \\rho(p^2) dp^2 = 0$",
-      "significance": "supporting",
-      "relatedConcepts": ["Dyson-Schwinger equations", "gluon propagator", "Schwinger mechanism", "spectral function positivity violation", "Kugo-Ojima criterion"],
-      "prerequisites": ["scalingExponent", "DSEGapEquation"],
-      "tags": ["dyson-schwinger", "gluon-mass", "confinement", "non-perturbative"]
+    "title": "SUSY Quantum Mechanics and the Morse Theory Analogy",
+    "content": "Formalizes the deep analogy between supersymmetric quantum mechanics and the Yang-Mills mass gap through Witten's Morse theory framework. In SUSY QM, partner potentials $V_\\pm(x) = W'(x)^2 \\pm W''(x)$ have identical spectra except for the ground state: if SUSY is unbroken ($E_0 = 0$), the ground state has no partner. The Witten deformation $d_t = e^{-tf} d e^{tf}$ of the de Rham complex creates a spectral gap $\\sim t$ between exponentially small eigenvalues (one per critical point of the Morse function $f$) and large eigenvalues \u2014 directly analogous to the Yang-Mills mass gap. The formalization establishes a seven-way parallel between SUSY QM and Yang-Mills: superpotential $\\leftrightarrow$ YM action, critical points $\\leftrightarrow$ instantons, Witten index $I_W \\leftrightarrow$ number of YM vacua $N$, and mass gap $\\Delta \\leftrightarrow$ Yang-Mills mass gap. The semiclassical mass gap formula $\\Delta \\approx (g^2/L) \\exp(-8\\pi^2/(Ng^2))$ for $\\mathcal{N}=1$ SYM on $\\mathbb{R}^3 \\times S^1$ is the closest known analytical mass gap formula for non-abelian gauge theory.",
+    "mathContext": "$V_\\pm = W'^2 \\pm W''$; Witten index $I_W = \\text{Tr}(-1)^F$; spectral gap $\\sim t$ (Morse); $\\Delta \\sim (g^2/L) e^{-8\\pi^2/(Ng^2)}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "supersymmetric quantum mechanics",
+      "Morse theory",
+      "Witten index",
+      "spectral gap",
+      "instanton tunneling"
+    ],
+    "prerequisites": [
+      "partner_spectra_relation",
+      "morse_spectral_gap"
+    ],
+    "tags": [
+      "susy-qm",
+      "morse-theory",
+      "witten-deformation",
+      "mass-gap-analogy"
+    ]
+  },
+  {
+    "id": "dse-gluon-gap-equation",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 28970,
+      "endLine": 29032
     },
-    {
-      "id": "thooft-loop-duality",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 7536, "endLine": 7636 },
-      "title": "'t Hooft Loop: Magnetic Dual of the Wilson Loop",
-      "content": "The 't Hooft loop $B(C)$ (1978) is the magnetic analogue of the Wilson loop $W(C)$: it creates a thin tube of center flux along $C$. Together, $W(C)$ and $B(C)$ provide a complete phase classification. In the confined phase, $W(C)$ obeys area law and $B(C)$ obeys perimeter law — quarks are confined but monopoles are free. In the Higgs phase, the roles are reversed. In the Coulomb phase, both obey perimeter law. The key theorem: $W$ and $B$ cannot both obey area law simultaneously ('t Hooft's complementarity), because their commutation relation $W(C_1) B(C_2) = \\omega^{\\text{link}(C_1,C_2)} B(C_2) W(C_1)$ (where $\\omega = e^{2\\pi i/N}$ and link is the linking number) forces a 't Hooft anomaly between the two order parameters.",
-      "mathContext": "$W(C_1) B(C_2) = \\omega^{\\text{link}(C_1,C_2)} B(C_2) W(C_1)$; confined: $W$ area, $B$ perimeter; Higgs: $W$ perimeter, $B$ area",
-      "significance": "key",
-      "relatedConcepts": ["'t Hooft loop", "Wilson loop", "electric-magnetic duality", "center flux", "phase classification"],
-      "prerequisites": ["WilsonLoop", "CenterSymmetry", "Complex"],
-      "tags": ["thooft-loop", "duality", "confinement", "phase-classification"]
+    "title": "Dyson-Schwinger Equations: The Gluon Gap Equation",
+    "content": "The Dyson-Schwinger equations (DSE) are the quantum equations of motion \u2014 an infinite tower of coupled integral equations for correlation functions. For the gluon propagator, two self-consistent solutions are formalized: the decoupling solution $D(p^2) \\to D_0 > 0$ (massive gluon, $m_{\\text{gluon}} \\approx 500$ MeV from lattice and DSE), and the scaling solution $D(p^2) \\sim (p^2)^{2\\kappa-1}$ with $D(0) = 0$ and enhanced ghost $G(p^2) \\sim (p^2)^{-1-\\kappa}$, $\\kappa \\approx 0.595$ (Kugo-Ojima confinement criterion). Both imply confinement, but via different mechanisms. The Oehme-Zimmermann superconvergence relation $\\int_0^\\infty dp^2 \\rho(p^2) = 0$ proves the gluon spectral function $\\rho$ must go negative somewhere \u2014 positivity violation is a signature of confinement (confined particles cannot appear as asymptotic states). Current lattice data strongly favors the decoupling solution with a finite gluon mass, providing a dynamical origin for the mass gap via the Schwinger mechanism.",
+    "mathContext": "Decoupling: $D(0) > 0$, $m_{\\text{gluon}} \\approx 500$ MeV; Scaling: $D(p^2) \\sim (p^2)^{2\\kappa-1}$, $\\kappa \\approx 0.595$; OZ: $\\int \\rho(p^2) dp^2 = 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Dyson-Schwinger equations",
+      "gluon propagator",
+      "Schwinger mechanism",
+      "spectral function positivity violation",
+      "Kugo-Ojima criterion"
+    ],
+    "prerequisites": [
+      "scalingExponent",
+      "DSEGapEquation"
+    ],
+    "tags": [
+      "dyson-schwinger",
+      "gluon-mass",
+      "confinement",
+      "non-perturbative"
+    ]
+  },
+  {
+    "id": "thooft-loop-duality",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 7536,
+      "endLine": 7636
     },
-    {
-      "id": "cluster-decomposition-mass-gap",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 7763, "endLine": 7982 },
-      "title": "Cluster Decomposition: Mass Gap ↔ Exponential Decay",
-      "content": "The cluster decomposition principle is the bridge between the spectral definition of the mass gap and its physical consequences. In a massive theory, connected correlators decay exponentially: $\\langle O(x) O(y) \\rangle_c \\le C \\cdot e^{-\\Delta |x-y|}$, where $\\Delta > 0$ is the mass gap. This is an equivalence: mass gap $> 0 \\iff$ exponential cluster decomposition. Massless theories (conformal window, Coulomb phase) have power-law decay $\\sim |x-y|^{-2\\Delta_{\\text{dim}}}$ instead. The key chain of implications formalized: (1) reflection positivity (OS axioms) $\\to$ physical Hilbert space $\\mathcal{H}$, (2) transfer matrix $T = e^{-aH}$ $\\to$ Hamiltonian $H$ with spectrum, (3) spectral gap $\\Delta = E_1 - E_0 > 0$ $\\to$ exponential decay of correlators at rate $\\Delta$. The correlation length $\\xi = 1/\\Delta$ diverges at a second-order phase transition where the mass gap vanishes.",
-      "mathContext": "$\\langle O(x) O(y) \\rangle_c \\le C e^{-\\Delta|x-y|}$; $\\Delta > 0 \\iff$ exponential decay; $\\xi = 1/\\Delta$",
-      "significance": "key",
-      "relatedConcepts": ["cluster decomposition", "correlation length", "exponential decay", "spectral gap", "second-order phase transition"],
-      "prerequisites": ["MassGap", "TransferMatrix", "PerronFrobeniusData"],
-      "tags": ["cluster-decomposition", "correlation-decay", "mass-gap-equivalence"]
+    "title": "'t Hooft Loop: Magnetic Dual of the Wilson Loop",
+    "content": "The 't Hooft loop $B(C)$ (1978) is the magnetic analogue of the Wilson loop $W(C)$: it creates a thin tube of center flux along $C$. Together, $W(C)$ and $B(C)$ provide a complete phase classification. In the confined phase, $W(C)$ obeys area law and $B(C)$ obeys perimeter law \u2014 quarks are confined but monopoles are free. In the Higgs phase, the roles are reversed. In the Coulomb phase, both obey perimeter law. The key theorem: $W$ and $B$ cannot both obey area law simultaneously ('t Hooft's complementarity), because their commutation relation $W(C_1) B(C_2) = \\omega^{\\text{link}(C_1,C_2)} B(C_2) W(C_1)$ (where $\\omega = e^{2\\pi i/N}$ and link is the linking number) forces a 't Hooft anomaly between the two order parameters.",
+    "mathContext": "$W(C_1) B(C_2) = \\omega^{\\text{link}(C_1,C_2)} B(C_2) W(C_1)$; confined: $W$ area, $B$ perimeter; Higgs: $W$ perimeter, $B$ area",
+    "significance": "key",
+    "relatedConcepts": [
+      "'t Hooft loop",
+      "Wilson loop",
+      "electric-magnetic duality",
+      "center flux",
+      "phase classification"
+    ],
+    "prerequisites": [
+      "WilsonLoop",
+      "CenterSymmetry",
+      "Complex"
+    ],
+    "tags": [
+      "thooft-loop",
+      "duality",
+      "confinement",
+      "phase-classification"
+    ]
+  },
+  {
+    "id": "cluster-decomposition-mass-gap",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 7763,
+      "endLine": 7982
     },
-    {
-      "id": "center-vortex-confinement",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 9592, "endLine": 9738 },
-      "title": "Center Vortex Model: Topological Mechanism for Confinement",
-      "content": "Center vortices are codimension-2 topological defects in the gauge field carrying $\\mathbb{Z}_N$ center flux. When a center vortex pierces the minimal surface bounded by a Wilson loop, the loop acquires a factor $\\omega = e^{2\\pi i/N}$ (a center element). If vortices pierce randomly with probability $p$ per unit area, the Wilson loop expectation value becomes $\\langle W(C) \\rangle = (1 - 2p)^A \\to e^{-\\sigma A}$ with string tension $\\sigma = -\\ln(1-2p)/a^2$. This produces the area law — confinement from vortex condensation. Lattice evidence is compelling: (1) removing center vortices eliminates both confinement AND chiral symmetry breaking simultaneously, (2) the center-projected theory (keeping only vortices) reproduces the full string tension to within $\\sim 5\\%$, (3) the vortex density scales correctly toward the continuum limit. The model also explains the Casimir scaling $\\to$ $N$-ality dependence crossover at large distances.",
-      "mathContext": "Vortex piercing: $W \\to \\omega \\cdot W$, $\\omega = e^{2\\pi i/N}$; random vortices: $\\langle W \\rangle = (1-2p)^A = e^{-\\sigma A}$, $\\sigma = -\\ln(1-2p)/a^2$",
-      "significance": "key",
-      "relatedConcepts": ["center vortex", "topological defect", "vortex condensation", "N-ality", "lattice evidence for confinement"],
-      "prerequisites": ["CenterSymmetry", "WilsonLoop", "Real.exp"],
-      "tags": ["center-vortex", "confinement-mechanism", "topology", "lattice-evidence"]
+    "title": "Cluster Decomposition: Mass Gap \u2194 Exponential Decay",
+    "content": "The cluster decomposition principle is the bridge between the spectral definition of the mass gap and its physical consequences. In a massive theory, connected correlators decay exponentially: $\\langle O(x) O(y) \\rangle_c \\le C \\cdot e^{-\\Delta |x-y|}$, where $\\Delta > 0$ is the mass gap. This is an equivalence: mass gap $> 0 \\iff$ exponential cluster decomposition. Massless theories (conformal window, Coulomb phase) have power-law decay $\\sim |x-y|^{-2\\Delta_{\\text{dim}}}$ instead. The key chain of implications formalized: (1) reflection positivity (OS axioms) $\\to$ physical Hilbert space $\\mathcal{H}$, (2) transfer matrix $T = e^{-aH}$ $\\to$ Hamiltonian $H$ with spectrum, (3) spectral gap $\\Delta = E_1 - E_0 > 0$ $\\to$ exponential decay of correlators at rate $\\Delta$. The correlation length $\\xi = 1/\\Delta$ diverges at a second-order phase transition where the mass gap vanishes.",
+    "mathContext": "$\\langle O(x) O(y) \\rangle_c \\le C e^{-\\Delta|x-y|}$; $\\Delta > 0 \\iff$ exponential decay; $\\xi = 1/\\Delta$",
+    "significance": "key",
+    "relatedConcepts": [
+      "cluster decomposition",
+      "correlation length",
+      "exponential decay",
+      "spectral gap",
+      "second-order phase transition"
+    ],
+    "prerequisites": [
+      "MassGap",
+      "TransferMatrix",
+      "PerronFrobeniusData"
+    ],
+    "tags": [
+      "cluster-decomposition",
+      "correlation-decay",
+      "mass-gap-equivalence"
+    ]
+  },
+  {
+    "id": "center-vortex-confinement",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 9592,
+      "endLine": 9738
     },
-    {
-      "id": "chromoelectric-flux-tube",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 9876, "endLine": 10111 },
-      "title": "Chromoelectric Flux Tubes: The Physical Picture of Confinement",
-      "content": "In a confining gauge theory, chromoelectric field lines between a quark-antiquark pair do not spread out (as in QED's $1/r^2$ Coulomb field) but instead collimate into a narrow tube of approximately constant cross-section $A \\sim 1/\\sigma$. The flux tube has: radius $r_0 \\approx 0.3$ fm (from lattice), energy per unit length $= \\sigma \\approx (440\\,\\text{MeV})^2 \\approx 0.18\\,\\text{GeV}^2$, and produces a linear potential $V(r) = \\sigma r$ (plus the Lüscher $-\\pi/(12r)$ correction). The flux tube behaves as a vibrating string at long distances — its transverse fluctuations grow logarithmically $w^2(r) \\sim \\ln(r/r_0)$ (Lüscher-Symanzik-Weisz theorem), matching the Nambu-Goto string prediction. The dual Meissner effect provides the mechanism: the confining vacuum acts as a dual superconductor that squeezes chromoelectric flux into Abrikosov-like vortices.",
-      "mathContext": "$V(r) = \\sigma r - \\frac{\\pi}{12r} + O(1/r^2)$; $\\sigma \\approx (440\\,\\text{MeV})^2$; $w^2(r) \\sim \\frac{1}{2\\pi\\sigma}\\ln(r/r_0)$",
-      "significance": "key",
-      "relatedConcepts": ["flux tube", "QCD string", "linear potential", "Lüscher term", "Nambu-Goto string", "dual Meissner effect"],
-      "prerequisites": ["stringTension", "LuscherTerm", "DualSuperconductorModel"],
-      "tags": ["flux-tube", "confinement", "qcd-string", "linear-potential"]
+    "title": "Center Vortex Model: Topological Mechanism for Confinement",
+    "content": "Center vortices are codimension-2 topological defects in the gauge field carrying $\\mathbb{Z}_N$ center flux. When a center vortex pierces the minimal surface bounded by a Wilson loop, the loop acquires a factor $\\omega = e^{2\\pi i/N}$ (a center element). If vortices pierce randomly with probability $p$ per unit area, the Wilson loop expectation value becomes $\\langle W(C) \\rangle = (1 - 2p)^A \\to e^{-\\sigma A}$ with string tension $\\sigma = -\\ln(1-2p)/a^2$. This produces the area law \u2014 confinement from vortex condensation. Lattice evidence is compelling: (1) removing center vortices eliminates both confinement AND chiral symmetry breaking simultaneously, (2) the center-projected theory (keeping only vortices) reproduces the full string tension to within $\\sim 5\\%$, (3) the vortex density scales correctly toward the continuum limit. The model also explains the Casimir scaling $\\to$ $N$-ality dependence crossover at large distances.",
+    "mathContext": "Vortex piercing: $W \\to \\omega \\cdot W$, $\\omega = e^{2\\pi i/N}$; random vortices: $\\langle W \\rangle = (1-2p)^A = e^{-\\sigma A}$, $\\sigma = -\\ln(1-2p)/a^2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "center vortex",
+      "topological defect",
+      "vortex condensation",
+      "N-ality",
+      "lattice evidence for confinement"
+    ],
+    "prerequisites": [
+      "CenterSymmetry",
+      "WilsonLoop",
+      "Real.exp"
+    ],
+    "tags": [
+      "center-vortex",
+      "confinement-mechanism",
+      "topology",
+      "lattice-evidence"
+    ]
+  },
+  {
+    "id": "chromoelectric-flux-tube",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 9876,
+      "endLine": 10111
     },
-    {
-      "id": "chiral-symmetry-banks-casher",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 10113, "endLine": 10165 },
-      "title": "Chiral Symmetry Breaking: Banks-Casher and GMOR Relations",
-      "content": "The Banks-Casher relation (1980) $\\langle\\bar{\\psi}\\psi\\rangle = -\\pi\\rho(0)$ connects the chiral condensate to the spectral density $\\rho(\\lambda)$ of the Dirac operator $D\\!\\!\\!/$ at the origin. A non-zero condensate $\\langle\\bar{\\psi}\\psi\\rangle \\ne 0$ signals spontaneous chiral symmetry breaking $\\mathrm{SU}(N_f)_L \\times \\mathrm{SU}(N_f)_R \\to \\mathrm{SU}(N_f)_V$, producing $N_f^2 - 1$ pseudo-Goldstone bosons (pions). The Gell-Mann-Oakes-Renner relation $m_\\pi^2 f_\\pi^2 = m_q |\\langle\\bar{\\psi}\\psi\\rangle|$ links the pion mass, decay constant, quark mass, and condensate. Crucially, chiral symmetry breaking and confinement are closely correlated (lattice shows they occur at the same temperature) but logically distinct — the center vortex model shows both originate from the same topological mechanism.",
-      "mathContext": "$\\langle\\bar{\\psi}\\psi\\rangle = -\\pi\\rho(0)$; GMOR: $m_\\pi^2 f_\\pi^2 = m_q |\\langle\\bar{\\psi}\\psi\\rangle|$; $\\chi\\text{SB}$: $\\mathrm{SU}(N_f)_L \\times \\mathrm{SU}(N_f)_R \\to \\mathrm{SU}(N_f)_V$",
-      "significance": "supporting",
-      "relatedConcepts": ["Banks-Casher relation", "chiral condensate", "GMOR relation", "Goldstone boson", "Dirac operator spectrum"],
-      "prerequisites": ["ChiralCondensate", "DiracOperator", "Real.pi"],
-      "tags": ["chiral-symmetry-breaking", "banks-casher", "gmor", "pion"]
+    "title": "Chromoelectric Flux Tubes: The Physical Picture of Confinement",
+    "content": "In a confining gauge theory, chromoelectric field lines between a quark-antiquark pair do not spread out (as in QED's $1/r^2$ Coulomb field) but instead collimate into a narrow tube of approximately constant cross-section $A \\sim 1/\\sigma$. The flux tube has: radius $r_0 \\approx 0.3$ fm (from lattice), energy per unit length $= \\sigma \\approx (440\\,\\text{MeV})^2 \\approx 0.18\\,\\text{GeV}^2$, and produces a linear potential $V(r) = \\sigma r$ (plus the L\u00fcscher $-\\pi/(12r)$ correction). The flux tube behaves as a vibrating string at long distances \u2014 its transverse fluctuations grow logarithmically $w^2(r) \\sim \\ln(r/r_0)$ (L\u00fcscher-Symanzik-Weisz theorem), matching the Nambu-Goto string prediction. The dual Meissner effect provides the mechanism: the confining vacuum acts as a dual superconductor that squeezes chromoelectric flux into Abrikosov-like vortices.",
+    "mathContext": "$V(r) = \\sigma r - \\frac{\\pi}{12r} + O(1/r^2)$; $\\sigma \\approx (440\\,\\text{MeV})^2$; $w^2(r) \\sim \\frac{1}{2\\pi\\sigma}\\ln(r/r_0)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "flux tube",
+      "QCD string",
+      "linear potential",
+      "L\u00fcscher term",
+      "Nambu-Goto string",
+      "dual Meissner effect"
+    ],
+    "prerequisites": [
+      "stringTension",
+      "LuscherTerm",
+      "DualSuperconductorModel"
+    ],
+    "tags": [
+      "flux-tube",
+      "confinement",
+      "qcd-string",
+      "linear-potential"
+    ]
+  },
+  {
+    "id": "chiral-symmetry-banks-casher",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 10113,
+      "endLine": 10165
     },
-    {
-      "id": "casimir-scaling-string-breaking",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 8410, "endLine": 8598 },
-      "title": "Casimir Scaling and String Breaking",
-      "content": "The Casimir scaling hypothesis predicts that at intermediate distances, the ratio of string tensions for different representations equals their Casimir ratio: $\\sigma_R/\\sigma_{\\text{fund}} = C_2(R)/C_2(\\text{fund})$. For $\\mathrm{SU}(3)$: adjoint/fundamental $= 9/4$, sextet/fundamental $= 5/2$. This is confirmed by lattice simulations to high precision at distances $r \\lesssim 1$ fm. At larger distances, the behavior depends on $N$-ality (representation modulo center): zero $N$-ality representations (like the adjoint) have strings that break via gluon pair production at distance $r_b \\sim 2M_{\\text{gluelump}}/\\sigma_{\\text{adj}}$, while non-zero $N$-ality strings (fundamental) are unbreakable — true confinement. The formalization proves: Casimir ratio $> 1$ for the adjoint, $\\sigma_{\\text{adj}} > \\sigma_{\\text{fund}}$ (adjoint strings are tighter), and the mass gap from glueball $\\Delta \\sim 4\\sqrt{\\sigma_{\\text{fund}}}$ from lattice QCD.",
-      "mathContext": "$\\sigma_R/\\sigma_{\\text{fund}} = C_2(R)/C_2(\\text{fund})$; SU(3): adj/fund $= 9/4$; string breaking at $r_b \\sim 2M_{\\text{gluelump}}/\\sigma_{\\text{adj}}$",
-      "significance": "supporting",
-      "relatedConcepts": ["Casimir scaling", "string breaking", "N-ality", "gluelump", "representation dependence"],
-      "prerequisites": ["suNCasimirFundamental", "suNCasimirAdjoint", "stringTension"],
-      "tags": ["casimir-scaling", "string-breaking", "n-ality", "lattice-verification"]
+    "title": "Chiral Symmetry Breaking: Banks-Casher and GMOR Relations",
+    "content": "The Banks-Casher relation (1980) $\\langle\\bar{\\psi}\\psi\\rangle = -\\pi\\rho(0)$ connects the chiral condensate to the spectral density $\\rho(\\lambda)$ of the Dirac operator $D\\!\\!\\!/$ at the origin. A non-zero condensate $\\langle\\bar{\\psi}\\psi\\rangle \\ne 0$ signals spontaneous chiral symmetry breaking $\\mathrm{SU}(N_f)_L \\times \\mathrm{SU}(N_f)_R \\to \\mathrm{SU}(N_f)_V$, producing $N_f^2 - 1$ pseudo-Goldstone bosons (pions). The Gell-Mann-Oakes-Renner relation $m_\\pi^2 f_\\pi^2 = m_q |\\langle\\bar{\\psi}\\psi\\rangle|$ links the pion mass, decay constant, quark mass, and condensate. Crucially, chiral symmetry breaking and confinement are closely correlated (lattice shows they occur at the same temperature) but logically distinct \u2014 the center vortex model shows both originate from the same topological mechanism.",
+    "mathContext": "$\\langle\\bar{\\psi}\\psi\\rangle = -\\pi\\rho(0)$; GMOR: $m_\\pi^2 f_\\pi^2 = m_q |\\langle\\bar{\\psi}\\psi\\rangle|$; $\\chi\\text{SB}$: $\\mathrm{SU}(N_f)_L \\times \\mathrm{SU}(N_f)_R \\to \\mathrm{SU}(N_f)_V$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Banks-Casher relation",
+      "chiral condensate",
+      "GMOR relation",
+      "Goldstone boson",
+      "Dirac operator spectrum"
+    ],
+    "prerequisites": [
+      "ChiralCondensate",
+      "DiracOperator",
+      "Real.pi"
+    ],
+    "tags": [
+      "chiral-symmetry-breaking",
+      "banks-casher",
+      "gmor",
+      "pion"
+    ]
+  },
+  {
+    "id": "casimir-scaling-string-breaking",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 8410,
+      "endLine": 8598
     },
-    {
-      "id": "polyakov-3d-confinement",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 17444, "endLine": 17649 },
-      "title": "Polyakov's 3D Confinement: Exact Non-Perturbative Mass Gap",
-      "content": "Polyakov (1977) proved that compact $\\mathrm{U}(1)$ gauge theory in 2+1 dimensions confines via monopole-instanton proliferation — one of the few rigorously understood confinement mechanisms. In 3D, monopoles are point-like instantons (finite Euclidean action $S_{\\text{monopole}} = 4\\pi/(g^2 a)$) that generate a mass for the dual photon through a Debye screening mechanism. The resulting mass gap $\\Delta \\sim g^2 \\exp(-S_{\\text{monopole}})$ is non-perturbative: invisible to all orders of perturbation theory, arising entirely from the semiclassical monopole gas. The linear potential $V(r) = \\sigma r$ between test charges is generated by the dual photon mass via $\\sigma \\sim \\Delta^2$. This 3D mechanism serves as a prototype for understanding 4D confinement: in both cases, topological excitations (monopoles in 3D, center vortices or monopoles in 4D) generate a mass gap and confine charges. The key difference is that in 3D the monopole action is finite and the dilute gas approximation is rigorously controllable, while in 4D the situation is far more complex.",
-      "mathContext": "$S_{\\text{monopole}} = 4\\pi/(g^2 a)$; $\\Delta \\sim g^2 e^{-S_{\\text{monopole}}}$; $V(r) = \\sigma r$; dual photon mass $m_{\\gamma} \\sim g^2 e^{-2\\pi/(g^2 a)}$",
-      "significance": "key",
-      "relatedConcepts": ["monopole-instanton", "Debye screening", "dual photon", "compact QED", "semiclassical confinement"],
-      "prerequisites": ["PolyakovConfinementParams", "Real.exp"],
-      "tags": ["polyakov-3d", "monopole", "exact-confinement", "non-perturbative"]
+    "title": "Casimir Scaling and String Breaking",
+    "content": "The Casimir scaling hypothesis predicts that at intermediate distances, the ratio of string tensions for different representations equals their Casimir ratio: $\\sigma_R/\\sigma_{\\text{fund}} = C_2(R)/C_2(\\text{fund})$. For $\\mathrm{SU}(3)$: adjoint/fundamental $= 9/4$, sextet/fundamental $= 5/2$. This is confirmed by lattice simulations to high precision at distances $r \\lesssim 1$ fm. At larger distances, the behavior depends on $N$-ality (representation modulo center): zero $N$-ality representations (like the adjoint) have strings that break via gluon pair production at distance $r_b \\sim 2M_{\\text{gluelump}}/\\sigma_{\\text{adj}}$, while non-zero $N$-ality strings (fundamental) are unbreakable \u2014 true confinement. The formalization proves: Casimir ratio $> 1$ for the adjoint, $\\sigma_{\\text{adj}} > \\sigma_{\\text{fund}}$ (adjoint strings are tighter), and the mass gap from glueball $\\Delta \\sim 4\\sqrt{\\sigma_{\\text{fund}}}$ from lattice QCD.",
+    "mathContext": "$\\sigma_R/\\sigma_{\\text{fund}} = C_2(R)/C_2(\\text{fund})$; SU(3): adj/fund $= 9/4$; string breaking at $r_b \\sim 2M_{\\text{gluelump}}/\\sigma_{\\text{adj}}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Casimir scaling",
+      "string breaking",
+      "N-ality",
+      "gluelump",
+      "representation dependence"
+    ],
+    "prerequisites": [
+      "suNCasimirFundamental",
+      "suNCasimirAdjoint",
+      "stringTension"
+    ],
+    "tags": [
+      "casimir-scaling",
+      "string-breaking",
+      "n-ality",
+      "lattice-verification"
+    ]
+  },
+  {
+    "id": "polyakov-3d-confinement",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 17444,
+      "endLine": 17649
     },
-    {
-      "id": "theta-vacuum-structure",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 3769, "endLine": 3786 },
-      "title": "Theta Vacuum: Topological Structure of the QCD Ground State",
-      "content": "The Yang-Mills vacuum has a rich topological structure classified by the instanton winding number $k \\in \\mathbb{Z}$: gauge field configurations fall into topologically distinct sectors related by large gauge transformations. The physical vacuum is not a single topological sector but a coherent superposition $|\\theta\\rangle = \\sum_k e^{ik\\theta} |k\\rangle$, parametrized by $\\theta \\in [0, 2\\pi)$. The vacuum energy $E(\\theta)$ depends on $\\theta$ through the instanton contribution: $E(\\theta) = E_0 - \\chi_t \\cos\\theta + O(\\cos 2\\theta)$, where $\\chi_t > 0$ is the topological susceptibility. The formalization proves: (1) instanton action bound $S \\ge 8\\pi^2|k|/g^2$ (non-negative), (2) $E(0)$ is the minimum and $E(\\pi)$ the maximum, (3) instanton effects are exponentially suppressed at weak coupling $\\sim e^{-8\\pi^2/g^2}$, and (4) the instanton moduli space has dimension $\\dim = 4Nk - N^2 + 1$ for $\\mathrm{SU}(N)$ with charge $k$. The strong CP problem — why $\\theta \\approx 0$ experimentally ($|\\theta| < 10^{-10}$) — remains one of the deepest puzzles in particle physics.",
-      "mathContext": "$|\\theta\\rangle = \\sum_k e^{ik\\theta}|k\\rangle$; $E(\\theta) \\approx -\\chi_t \\cos\\theta$; $S_{\\text{inst}} \\ge 8\\pi^2|k|/g^2$; $\\dim \\mathcal{M}_k = 4Nk - N^2 + 1$",
-      "significance": "key",
-      "relatedConcepts": ["theta parameter", "instanton vacuum", "topological susceptibility", "strong CP problem", "winding number"],
-      "prerequisites": ["instantonAction", "topologicalCharge", "Real.exp", "Real.cos"],
-      "tags": ["theta-vacuum", "topology", "vacuum-structure", "strong-cp"]
+    "title": "Polyakov's 3D Confinement: Exact Non-Perturbative Mass Gap",
+    "content": "Polyakov (1977) proved that compact $\\mathrm{U}(1)$ gauge theory in 2+1 dimensions confines via monopole-instanton proliferation \u2014 one of the few rigorously understood confinement mechanisms. In 3D, monopoles are point-like instantons (finite Euclidean action $S_{\\text{monopole}} = 4\\pi/(g^2 a)$) that generate a mass for the dual photon through a Debye screening mechanism. The resulting mass gap $\\Delta \\sim g^2 \\exp(-S_{\\text{monopole}})$ is non-perturbative: invisible to all orders of perturbation theory, arising entirely from the semiclassical monopole gas. The linear potential $V(r) = \\sigma r$ between test charges is generated by the dual photon mass via $\\sigma \\sim \\Delta^2$. This 3D mechanism serves as a prototype for understanding 4D confinement: in both cases, topological excitations (monopoles in 3D, center vortices or monopoles in 4D) generate a mass gap and confine charges. The key difference is that in 3D the monopole action is finite and the dilute gas approximation is rigorously controllable, while in 4D the situation is far more complex.",
+    "mathContext": "$S_{\\text{monopole}} = 4\\pi/(g^2 a)$; $\\Delta \\sim g^2 e^{-S_{\\text{monopole}}}$; $V(r) = \\sigma r$; dual photon mass $m_{\\gamma} \\sim g^2 e^{-2\\pi/(g^2 a)}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "monopole-instanton",
+      "Debye screening",
+      "dual photon",
+      "compact QED",
+      "semiclassical confinement"
+    ],
+    "prerequisites": [
+      "PolyakovConfinementParams",
+      "Real.exp"
+    ],
+    "tags": [
+      "polyakov-3d",
+      "monopole",
+      "exact-confinement",
+      "non-perturbative"
+    ]
+  },
+  {
+    "id": "theta-vacuum-structure",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 3769,
+      "endLine": 3786
     },
-    {
-      "id": "kugo-ojima-criterion",
-      "proofId": "yang-mills-mass-gap",
-      "type": "technique",
-      "range": { "startLine": 9740, "endLine": 9874 },
-      "title": "Kugo-Ojima Confinement Criterion via BRST Cohomology",
-      "content": "The Kugo-Ojima criterion (1979) provides a sufficient condition for color confinement within the BRST quantization framework. Physical states are defined by BRST cohomology: $Q_B|\\text{phys}\\rangle = 0$ with $|\\text{phys}\\rangle \\ne Q_B|\\text{anything}\\rangle$, where $Q_B$ is the nilpotent BRST charge ($Q_B^2 = 0$). The criterion states that confinement holds when the ghost self-energy function $u(p^2)$ satisfies $u(0) = -1$ at zero momentum. This condition implies: (1) the global color charge is BRST-exact (hence zero on physical states — color singlet confinement), (2) the Faddeev-Popov ghost propagator is infrared-enhanced $G(p^2) \\sim (p^2)^{-2}$ (more singular than free), (3) the gluon propagator satisfies $D(0) = 0$ (the scaling solution), meaning transverse gluons have zero spectral weight at zero momentum — they cannot propagate to infinity. While lattice data currently favors the decoupling solution ($D(0) > 0$) over the scaling solution, the Kugo-Ojima framework remains a central organizing principle for non-perturbative gauge theory.",
-      "mathContext": "$Q_B^2 = 0$; physical: $Q_B|\\text{phys}\\rangle = 0$; $u(0) = -1 \\implies$ color confinement; ghost: $G(p^2) \\sim (p^2)^{-2}$; gluon: $D(0) = 0$",
-      "significance": "supporting",
-      "relatedConcepts": ["BRST cohomology", "ghost propagator", "color confinement", "Faddeev-Popov ghost", "infrared behavior"],
-      "prerequisites": ["BRSTCharge", "KugoOjimaFunction", "GhostPropagator"],
-      "tags": ["kugo-ojima", "brst", "confinement-criterion", "ghost-enhancement"]
+    "title": "Theta Vacuum: Topological Structure of the QCD Ground State",
+    "content": "The Yang-Mills vacuum has a rich topological structure classified by the instanton winding number $k \\in \\mathbb{Z}$: gauge field configurations fall into topologically distinct sectors related by large gauge transformations. The physical vacuum is not a single topological sector but a coherent superposition $|\\theta\\rangle = \\sum_k e^{ik\\theta} |k\\rangle$, parametrized by $\\theta \\in [0, 2\\pi)$. The vacuum energy $E(\\theta)$ depends on $\\theta$ through the instanton contribution: $E(\\theta) = E_0 - \\chi_t \\cos\\theta + O(\\cos 2\\theta)$, where $\\chi_t > 0$ is the topological susceptibility. The formalization proves: (1) instanton action bound $S \\ge 8\\pi^2|k|/g^2$ (non-negative), (2) $E(0)$ is the minimum and $E(\\pi)$ the maximum, (3) instanton effects are exponentially suppressed at weak coupling $\\sim e^{-8\\pi^2/g^2}$, and (4) the instanton moduli space has dimension $\\dim = 4Nk - N^2 + 1$ for $\\mathrm{SU}(N)$ with charge $k$. The strong CP problem \u2014 why $\\theta \\approx 0$ experimentally ($|\\theta| < 10^{-10}$) \u2014 remains one of the deepest puzzles in particle physics.",
+    "mathContext": "$|\\theta\\rangle = \\sum_k e^{ik\\theta}|k\\rangle$; $E(\\theta) \\approx -\\chi_t \\cos\\theta$; $S_{\\text{inst}} \\ge 8\\pi^2|k|/g^2$; $\\dim \\mathcal{M}_k = 4Nk - N^2 + 1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "theta parameter",
+      "instanton vacuum",
+      "topological susceptibility",
+      "strong CP problem",
+      "winding number"
+    ],
+    "prerequisites": [
+      "instantonAction",
+      "topologicalCharge",
+      "Real.exp",
+      "Real.cos"
+    ],
+    "tags": [
+      "theta-vacuum",
+      "topology",
+      "vacuum-structure",
+      "strong-cp"
+    ]
+  },
+  {
+    "id": "kugo-ojima-criterion",
+    "proofId": "yang-mills-mass-gap",
+    "type": "technique",
+    "range": {
+      "startLine": 9740,
+      "endLine": 9874
     },
-    {
-      "id": "quantum-gauge-simulation",
-      "proofId": "yang-mills-mass-gap",
-      "type": "context",
-      "range": { "startLine": 27753, "endLine": 28124 },
-      "title": "Quantum Simulation of Lattice Gauge Theories",
-      "content": "Quantum computers offer a fundamentally new approach to the Yang-Mills mass gap by circumventing the sign problem that plagues classical Monte Carlo at finite baryon density. The formalization covers: (1) qubit-based lattice gauge theory, where group elements $U \\in \\mathrm{SU}(N)$ on links are encoded in qubit registers, (2) Trotterized time evolution $e^{-iHt} \\approx (e^{-iH_E \\delta t} e^{-iH_B \\delta t})^{t/\\delta t}$ splitting electric and magnetic Hamiltonians, and (3) the quantum advantage for real-time dynamics inaccessible to Euclidean methods. Current experimental demonstrations include trapped-ion simulations of the Schwinger model ($\\mathrm{U}(1)$ in 1+1D), showing confinement dynamics and string breaking in real time. For Yang-Mills specifically, quantum simulation could: verify the mass gap on small lattices with controlled systematics, simulate real-time flux tube formation, and eventually probe the continuum limit. The formalization proves Trotter error bounds and the polynomial scaling of qubit resources with lattice volume — quantum simulation of lattice gauge theory is in the BQP complexity class.",
-      "mathContext": "$e^{-iHt} \\approx (e^{-iH_E \\delta t} e^{-iH_B \\delta t})^{t/\\delta t}$; qubits per link $\\sim \\log(\\Lambda_{\\max})$; Trotter error $\\sim N_{\\text{links}} \\cdot (\\delta t)^2$",
-      "significance": "context",
-      "relatedConcepts": ["quantum computing", "Trotterization", "Schwinger model simulation", "sign problem", "BQP", "Hamiltonian simulation"],
-      "prerequisites": ["LatticeGaugeHamiltonian", "TrotterStep"],
-      "tags": ["quantum-simulation", "quantum-computing", "lattice-gauge", "sign-problem"]
+    "title": "Kugo-Ojima Confinement Criterion via BRST Cohomology",
+    "content": "The Kugo-Ojima criterion (1979) provides a sufficient condition for color confinement within the BRST quantization framework. Physical states are defined by BRST cohomology: $Q_B|\\text{phys}\\rangle = 0$ with $|\\text{phys}\\rangle \\ne Q_B|\\text{anything}\\rangle$, where $Q_B$ is the nilpotent BRST charge ($Q_B^2 = 0$). The criterion states that confinement holds when the ghost self-energy function $u(p^2)$ satisfies $u(0) = -1$ at zero momentum. This condition implies: (1) the global color charge is BRST-exact (hence zero on physical states \u2014 color singlet confinement), (2) the Faddeev-Popov ghost propagator is infrared-enhanced $G(p^2) \\sim (p^2)^{-2}$ (more singular than free), (3) the gluon propagator satisfies $D(0) = 0$ (the scaling solution), meaning transverse gluons have zero spectral weight at zero momentum \u2014 they cannot propagate to infinity. While lattice data currently favors the decoupling solution ($D(0) > 0$) over the scaling solution, the Kugo-Ojima framework remains a central organizing principle for non-perturbative gauge theory.",
+    "mathContext": "$Q_B^2 = 0$; physical: $Q_B|\\text{phys}\\rangle = 0$; $u(0) = -1 \\implies$ color confinement; ghost: $G(p^2) \\sim (p^2)^{-2}$; gluon: $D(0) = 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "BRST cohomology",
+      "ghost propagator",
+      "color confinement",
+      "Faddeev-Popov ghost",
+      "infrared behavior"
+    ],
+    "prerequisites": [
+      "BRSTCharge",
+      "KugoOjimaFunction",
+      "GhostPropagator"
+    ],
+    "tags": [
+      "kugo-ojima",
+      "brst",
+      "confinement-criterion",
+      "ghost-enhancement"
+    ]
+  },
+  {
+    "id": "quantum-gauge-simulation",
+    "proofId": "yang-mills-mass-gap",
+    "type": "context",
+    "range": {
+      "startLine": 27753,
+      "endLine": 28124
     },
-    {
-      "id": "millennium-prize-requirements",
-      "proofId": "yang-mills-mass-gap",
-      "type": "definition",
-      "range": { "startLine": 29732, "endLine": 29876 },
-      "title": "Constructive Quantum Yang-Mills: Precise Millennium Prize Requirements",
-      "content": "The Clay Millennium Prize Problem has two precise mathematical requirements. **Existence**: for any compact simple gauge group $G$, construct a probability measure $\\mu$ on the space of gauge connections on $\\mathbb{R}^4$ such that the resulting correlation functions satisfy the Osterwalder-Schrader axioms (including reflection positivity, Euclidean invariance, and gauge invariance). **Mass gap**: the Hamiltonian $H$ of the Wightman QFT reconstructed via OS reconstruction has spectrum $\\text{spec}(H) = \\{0\\} \\cup [\\Delta, \\infty)$ with $\\Delta > 0$. The formalization carefully distinguishes: (1) the lattice mass gap $\\Delta_{\\text{lat}} > 0$, which IS a theorem (Perron-Frobenius), (2) the finite-volume continuum mass gap, which requires the lattice-to-continuum limit ($a \\to 0$) to exist and be non-trivial, and (3) the infinite-volume mass gap, which requires the thermodynamic limit ($L \\to \\infty$). The full Millennium Prize requires ALL three limits: $\\Delta = \\lim_{L \\to \\infty} \\lim_{a \\to 0} \\Delta_{\\text{lat}}(a, L) > 0$. The measure $\\mu$ must also be non-trivial: the theory should have non-zero connected correlation functions (ruling out a free or trivial theory).",
-      "mathContext": "Existence: $\\mu$ on connections satisfying OS axioms; Mass gap: $\\text{spec}(H) = \\{0\\} \\cup [\\Delta, \\infty)$, $\\Delta > 0$; requires $\\lim_{L\\to\\infty} \\lim_{a\\to 0} \\Delta_{\\text{lat}}(a,L) > 0$",
-      "significance": "key",
-      "relatedConcepts": ["Clay Millennium Prize", "Osterwalder-Schrader axioms", "constructive QFT", "continuum limit", "thermodynamic limit"],
-      "prerequisites": ["WightmanQFT", "OSAxioms", "LatticeTransferMatrix"],
-      "tags": ["millennium-prize", "clay-institute", "constructive-qft", "precise-statement"]
+    "title": "Quantum Simulation of Lattice Gauge Theories",
+    "content": "Quantum computers offer a fundamentally new approach to the Yang-Mills mass gap by circumventing the sign problem that plagues classical Monte Carlo at finite baryon density. The formalization covers: (1) qubit-based lattice gauge theory, where group elements $U \\in \\mathrm{SU}(N)$ on links are encoded in qubit registers, (2) Trotterized time evolution $e^{-iHt} \\approx (e^{-iH_E \\delta t} e^{-iH_B \\delta t})^{t/\\delta t}$ splitting electric and magnetic Hamiltonians, and (3) the quantum advantage for real-time dynamics inaccessible to Euclidean methods. Current experimental demonstrations include trapped-ion simulations of the Schwinger model ($\\mathrm{U}(1)$ in 1+1D), showing confinement dynamics and string breaking in real time. For Yang-Mills specifically, quantum simulation could: verify the mass gap on small lattices with controlled systematics, simulate real-time flux tube formation, and eventually probe the continuum limit. The formalization proves Trotter error bounds and the polynomial scaling of qubit resources with lattice volume \u2014 quantum simulation of lattice gauge theory is in the BQP complexity class.",
+    "mathContext": "$e^{-iHt} \\approx (e^{-iH_E \\delta t} e^{-iH_B \\delta t})^{t/\\delta t}$; qubits per link $\\sim \\log(\\Lambda_{\\max})$; Trotter error $\\sim N_{\\text{links}} \\cdot (\\delta t)^2$",
+    "significance": "context",
+    "relatedConcepts": [
+      "quantum computing",
+      "Trotterization",
+      "Schwinger model simulation",
+      "sign problem",
+      "BQP",
+      "Hamiltonian simulation"
+    ],
+    "prerequisites": [
+      "LatticeGaugeHamiltonian",
+      "TrotterStep"
+    ],
+    "tags": [
+      "quantum-simulation",
+      "quantum-computing",
+      "lattice-gauge",
+      "sign-problem"
+    ]
+  },
+  {
+    "id": "millennium-prize-requirements",
+    "proofId": "yang-mills-mass-gap",
+    "type": "definition",
+    "range": {
+      "startLine": 29732,
+      "endLine": 29876
     },
-    {
-      "id": "confinement-order-params-unified",
-      "proofId": "yang-mills-mass-gap",
-      "type": "insight",
-      "range": { "startLine": 30391, "endLine": 30551 },
-      "title": "Confinement Order Parameters: A Unified Comparison",
-      "content": "The formalization concludes with a comprehensive comparison of all confinement criteria developed across the 162 parts, revealing their logical interrelationships. Nine distinct order parameters are formalized: (1) Wilson area law $\\langle W(C) \\rangle \\sim e^{-\\sigma A}$, (2) 't Hooft loop perimeter law, (3) Polyakov loop $\\langle P \\rangle = 0$, (4) center symmetry $\\mathbb{Z}_N$ unbroken, (5) Kugo-Ojima $u(0) = -1$, (6) gluon propagator $D(0) > 0$ (decoupling/massive), (7) positive string tension $\\sigma > 0$, (8) center vortex condensation, and (9) magnetic monopole condensation. Key logical relationships proved: center symmetry unbroken $\\iff$ $\\langle P \\rangle = 0$ (equivalent), Wilson area law $\\implies$ $\\sigma > 0$ (area law is strictly stronger than positive string tension), and 't Hooft complementarity constrains which combinations are consistent. The decoupling and scaling scenarios make different predictions: the decoupling solution ($D(0) > 0$, massive gluon) is self-consistent with confinement via the Schwinger mechanism, while the scaling solution ($D(0) = 0$) realizes Kugo-Ojima. This unified view highlights that confinement is a multifaceted phenomenon — no single order parameter captures everything.",
-      "mathContext": "9 criteria: $\\langle W \\rangle \\sim e^{-\\sigma A}$, $\\langle B \\rangle \\sim e^{-\\kappa P}$, $\\langle P \\rangle = 0$, $\\mathbb{Z}_N$ unbroken, $u(0)=-1$, $D(0)>0$, $\\sigma>0$, vortex condensation, monopole condensation",
-      "significance": "key",
-      "relatedConcepts": ["confinement criteria", "order parameter", "Wilson loop", "Polyakov loop", "center symmetry", "Schwinger mechanism"],
-      "prerequisites": ["WilsonLoop", "tHooftLoop", "PolyakovExpectation", "KugoOjimaFunction", "CenterSymmetry"],
-      "tags": ["confinement", "order-parameters", "unified-view", "comparison"]
-    }
-  ]
-}
+    "title": "Constructive Quantum Yang-Mills: Precise Millennium Prize Requirements",
+    "content": "The Clay Millennium Prize Problem has two precise mathematical requirements. **Existence**: for any compact simple gauge group $G$, construct a probability measure $\\mu$ on the space of gauge connections on $\\mathbb{R}^4$ such that the resulting correlation functions satisfy the Osterwalder-Schrader axioms (including reflection positivity, Euclidean invariance, and gauge invariance). **Mass gap**: the Hamiltonian $H$ of the Wightman QFT reconstructed via OS reconstruction has spectrum $\\text{spec}(H) = \\{0\\} \\cup [\\Delta, \\infty)$ with $\\Delta > 0$. The formalization carefully distinguishes: (1) the lattice mass gap $\\Delta_{\\text{lat}} > 0$, which IS a theorem (Perron-Frobenius), (2) the finite-volume continuum mass gap, which requires the lattice-to-continuum limit ($a \\to 0$) to exist and be non-trivial, and (3) the infinite-volume mass gap, which requires the thermodynamic limit ($L \\to \\infty$). The full Millennium Prize requires ALL three limits: $\\Delta = \\lim_{L \\to \\infty} \\lim_{a \\to 0} \\Delta_{\\text{lat}}(a, L) > 0$. The measure $\\mu$ must also be non-trivial: the theory should have non-zero connected correlation functions (ruling out a free or trivial theory).",
+    "mathContext": "Existence: $\\mu$ on connections satisfying OS axioms; Mass gap: $\\text{spec}(H) = \\{0\\} \\cup [\\Delta, \\infty)$, $\\Delta > 0$; requires $\\lim_{L\\to\\infty} \\lim_{a\\to 0} \\Delta_{\\text{lat}}(a,L) > 0$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Clay Millennium Prize",
+      "Osterwalder-Schrader axioms",
+      "constructive QFT",
+      "continuum limit",
+      "thermodynamic limit"
+    ],
+    "prerequisites": [
+      "WightmanQFT",
+      "OSAxioms",
+      "LatticeTransferMatrix"
+    ],
+    "tags": [
+      "millennium-prize",
+      "clay-institute",
+      "constructive-qft",
+      "precise-statement"
+    ]
+  },
+  {
+    "id": "confinement-order-params-unified",
+    "proofId": "yang-mills-mass-gap",
+    "type": "insight",
+    "range": {
+      "startLine": 30391,
+      "endLine": 30551
+    },
+    "title": "Confinement Order Parameters: A Unified Comparison",
+    "content": "The formalization concludes with a comprehensive comparison of all confinement criteria developed across the 162 parts, revealing their logical interrelationships. Nine distinct order parameters are formalized: (1) Wilson area law $\\langle W(C) \\rangle \\sim e^{-\\sigma A}$, (2) 't Hooft loop perimeter law, (3) Polyakov loop $\\langle P \\rangle = 0$, (4) center symmetry $\\mathbb{Z}_N$ unbroken, (5) Kugo-Ojima $u(0) = -1$, (6) gluon propagator $D(0) > 0$ (decoupling/massive), (7) positive string tension $\\sigma > 0$, (8) center vortex condensation, and (9) magnetic monopole condensation. Key logical relationships proved: center symmetry unbroken $\\iff$ $\\langle P \\rangle = 0$ (equivalent), Wilson area law $\\implies$ $\\sigma > 0$ (area law is strictly stronger than positive string tension), and 't Hooft complementarity constrains which combinations are consistent. The decoupling and scaling scenarios make different predictions: the decoupling solution ($D(0) > 0$, massive gluon) is self-consistent with confinement via the Schwinger mechanism, while the scaling solution ($D(0) = 0$) realizes Kugo-Ojima. This unified view highlights that confinement is a multifaceted phenomenon \u2014 no single order parameter captures everything.",
+    "mathContext": "9 criteria: $\\langle W \\rangle \\sim e^{-\\sigma A}$, $\\langle B \\rangle \\sim e^{-\\kappa P}$, $\\langle P \\rangle = 0$, $\\mathbb{Z}_N$ unbroken, $u(0)=-1$, $D(0)>0$, $\\sigma>0$, vortex condensation, monopole condensation",
+    "significance": "key",
+    "relatedConcepts": [
+      "confinement criteria",
+      "order parameter",
+      "Wilson loop",
+      "Polyakov loop",
+      "center symmetry",
+      "Schwinger mechanism"
+    ],
+    "prerequisites": [
+      "WilsonLoop",
+      "tHooftLoop",
+      "PolyakovExpectation",
+      "KugoOjimaFunction",
+      "CenterSymmetry"
+    ],
+    "tags": [
+      "confinement",
+      "order-parameters",
+      "unified-view",
+      "comparison"
+    ]
+  }
+]

--- a/src/data/proofs/yang-mills-mass-gap/meta.json
+++ b/src/data/proofs/yang-mills-mass-gap/meta.json
@@ -2,7 +2,7 @@
   "id": "yang-mills-mass-gap",
   "title": "Yang-Mills Existence and Mass Gap",
   "slug": "yang-mills-mass-gap",
-  "description": "Comprehensive formalization of the Yang-Mills Millennium Prize Problem infrastructure. Covers gauge groups, field strength, classical Yang-Mills equations, Wightman axioms, Wilson loops, lattice gauge theory, 2D exact solutions, instanton topology, asymptotic freedom, confinement criteria, Faddeev-Popov ghosts, chiral anomalies, AdS/CFT, stochastic quantization, constructive QFT, Schwinger model, gradient flow, monopoles, condensates, theta vacuum, twisted boundary conditions, Seiberg duality, high-temperature QCD, strong coupling expansion, instanton calculus, and confinement order parameters. 30808 lines, 2600+ theorems/defs, 162 parts, 1 axiom (gaugeTransform — definitional), 0 sorries.",
+  "description": "Comprehensive formalization of the Yang-Mills Millennium Prize Problem infrastructure. Covers gauge groups, field strength, classical Yang-Mills equations, Wightman axioms, Wilson loops, lattice gauge theory, 2D exact solutions, instanton topology, asymptotic freedom, confinement criteria, Faddeev-Popov ghosts, chiral anomalies, AdS/CFT, stochastic quantization, constructive QFT, Schwinger model, gradient flow, monopoles, condensates, theta vacuum, twisted boundary conditions, Seiberg duality, high-temperature QCD, strong coupling expansion, instanton calculus, and confinement order parameters. 30808 lines, 2600+ theorems/defs, 162 parts, 1 axiom (gaugeTransform \u2014 definitional), 0 sorries.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Yang%E2%80%93Mills_existence_and_mass_gap",
@@ -23,7 +23,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "assumptions": "1 axiom declaration: gaugeTransform — provides gauge-transformed field (definitional). 15 former axioms proved or eliminated: 8 had trivially satisfiable conclusions, 5 more eliminated including creutz_recovers_sigma and os_reconstruction_theorem, 2 more deleted as unused (killingForm — never referenced in proofs, euclidean_mass_gap_implies_wightman — only in #check). The Yang-Mills mass gap problem remains open.",
+    "assumptions": "1 axiom declaration: gaugeTransform \u2014 provides gauge-transformed field (definitional). 15 former axioms proved or eliminated: 8 had trivially satisfiable conclusions, 5 more eliminated including creutz_recovers_sigma and os_reconstruction_theorem, 2 more deleted as unused (killingForm \u2014 never referenced in proofs, euclidean_mass_gap_implies_wightman \u2014 only in #check). The Yang-Mills mass gap problem remains open.",
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",
@@ -97,27 +97,57 @@
       },
       {
         "id": "hilbert-6",
-        "relationship": "Hilbert's 6th Problem (axiomatization of physics) — constructing rigorous Yang-Mills QFT via Wightman/OS axioms is a central instance of Hilbert's program for mathematical physics"
+        "relationship": "Hilbert's 6th Problem (axiomatization of physics) \u2014 constructing rigorous Yang-Mills QFT via Wightman/OS axioms is a central instance of Hilbert's program for mathematical physics"
       },
       {
         "id": "continuum-hypothesis",
         "relationship": "Both involve foundational questions about mathematical structures; the spectral gap undecidability result (Cubitt et al. 2015) parallels the independence of CH from ZFC, though Yang-Mills' specific structure may make its mass gap decidable"
       }
+    ],
+    "references": [
+      {
+        "authors": "C. N. Yang, R. L. Mills",
+        "title": "Conservation of Isotopic Spin and Isotopic Gauge Invariance",
+        "year": "1954",
+        "venue": "Physical Review 96(1), 191-195",
+        "note": "Original non-abelian gauge theory paper"
+      },
+      {
+        "authors": "D. J. Gross, F. Wilczek",
+        "title": "Ultraviolet Behavior of Non-Abelian Gauge Theories",
+        "year": "1973",
+        "venue": "Physical Review Letters 30(26), 1343-1346",
+        "note": "Discovery of asymptotic freedom (Nobel Prize 2004)"
+      },
+      {
+        "authors": "K. G. Wilson",
+        "title": "Confinement of Quarks",
+        "year": "1974",
+        "venue": "Physical Review D 10(8), 2445-2459",
+        "note": "Lattice gauge theory and Wilson loop confinement criterion"
+      },
+      {
+        "authors": "A. Jaffe, E. Witten",
+        "title": "Quantum Yang-Mills Theory",
+        "year": "2000",
+        "venue": "Clay Mathematics Institute Millennium Problems",
+        "note": "Official Millennium Prize Problem statement"
+      }
     ]
   },
   "overview": {
     "historicalContext": "**Yang-Mills Existence and Mass Gap**\n\nC. N. Yang and Robert Mills introduced non-abelian gauge theories in 1954, generalizing Maxwell's electromagnetism from the abelian group $\\mathrm{U}(1)$ to non-abelian groups like $\\mathrm{SU}(2)$ and $\\mathrm{SU}(3)$. Initially dismissed because the gauge bosons appeared massless (contradicting nuclear physics), the theory was vindicated by the discovery of asymptotic freedom by Gross, Wilczek, and Politzer (1973, Nobel Prize 2004), which showed the coupling decreases at short distances.\n\nWilson (1974) developed lattice gauge theory, providing the first non-perturbative framework and introducing confinement via the area law criterion. 't Hooft's large-$N$ expansion (1974) revealed a connection to string theory. The rigorous mathematical status remained open: while Glimm and Jaffe constructed QFT in 2 and 3 spacetime dimensions, 4D Yang-Mills eluded all approaches.\n\nIn 2000, the Clay Mathematics Institute named the problem as one of seven Millennium Prize Problems (\\$1M prize): prove that for any compact simple gauge group $G$, a non-trivial quantum Yang-Mills theory exists on $\\mathbb{R}^4$ satisfying the Wightman axioms, with a positive mass gap $\\Delta > 0$. The mass gap implies quarks are confined and the lightest glueball has positive mass, explaining why the strong nuclear force is short-range despite being mediated by massless gluons.\n\nThis formalization builds comprehensive infrastructure across 162 parts and 30808 lines, covering classical gauge theory, quantum axiomatics, lattice methods, exact solutions, and modern approaches including AdS/CFT, stochastic quantization, constructive QFT, resurgence, and Balaban's block-spin renormalization group program.",
-    "problemStatement": "**Conjecture (Clay Millennium Problem)**: For any compact simple gauge group G, there exists a non-trivial quantum Yang-Mills theory on R⁴ satisfying the Wightman axioms, with a positive mass gap Δ > 0: the Hamiltonian H has spectrum {0} ∪ [Δ, ∞) with Δ > 0.",
+    "problemStatement": "**Conjecture (Clay Millennium Problem)**: For any compact simple gauge group G, there exists a non-trivial quantum Yang-Mills theory on R\u2074 satisfying the Wightman axioms, with a positive mass gap \u0394 > 0: the Hamiltonian H has spectrum {0} \u222a [\u0394, \u221e) with \u0394 > 0.",
     "proofStrategy": "The formalization takes an axiomatic approach, building infrastructure layer by layer:\n\n1. **Classical foundations** (Parts I-V): Gauge groups, Lie algebras, Minkowski metric, field strength, Yang-Mills action, gauge invariance, Maxwell as U(1) case\n2. **Quantum axiomatics** (Parts VI-VIII): Wightman axioms, mass gap definition, the Millennium Prize statement\n3. **Known results** (Parts IX-XII): Asymptotic freedom, lattice YM, instantons, Wilson loops\n4. **Exact solutions** (Parts XIV-XV, XLI): 2D Yang-Mills via Migdal formula and transfer matrices\n5. **Gauge group theory** (Parts XVIII-XXVII): SU(2)/SU(3) Casimir values, center symmetry, heat kernels\n6. **Lattice methods** (Parts XIII, XXX, XXXVIII, XLVI): Wilson action, Creutz ratios, strong coupling, Monte Carlo\n7. **Euclidean QFT** (Part XXXIII): Osterwalder-Schrader reconstruction\n8. **Gauge fixing** (Parts XXXVII, XLIII): Faddeev-Popov, Gribov copies\n9. **Modern approaches** (Parts L-LV): SUSY, AdS/CFT, constructive QFT, FRG, Hamiltonian lattice, Donaldson theory\n\nThe single remaining axiom (gaugeTransform) provides the gauge-transformed field and is definitional rather than encoding a deep physical principle.",
     "keyInsights": [
-      "The mass gap is equivalent to exponential decay of correlations: ⟨O(x)O(0)⟩ ~ exp(-Δ|x|), with the correlation length ξ = 1/Δ providing a physical length scale from dimensional transmutation",
-      "Wilson area law (W(C) ~ exp(-σ·Area)) characterizes confinement; perimeter law characterizes deconfinement — these are proved mutually exclusive for large loops, giving a sharp dichotomy",
+      "The mass gap is equivalent to exponential decay of correlations: \u27e8O(x)O(0)\u27e9 ~ exp(-\u0394|x|), with the correlation length \u03be = 1/\u0394 providing a physical length scale from dimensional transmutation",
+      "Wilson area law (W(C) ~ exp(-\u03c3\u00b7Area)) characterizes confinement; perimeter law characterizes deconfinement \u2014 these are proved mutually exclusive for large loops, giving a sharp dichotomy",
       "2D Yang-Mills is exactly solvable via Migdal formula: expectation values reduce to group integrals weighted by Casimir eigenvalues, providing the only dimension with an explicit mass gap formula",
-      "Center symmetry Z_N classifies confinement: unbroken ↔ confined, broken ↔ deconfined. The deconfinement transition is second-order for SU(2) (Ising universality) but first-order for SU(3) (Potts), due to the presence of a cubic term in the Polyakov loop effective potential for N ≥ 3",
-      "Seiberg-Witten theory provides the only known exact confinement mechanism: monopole condensation at the singular point u = Λ² of the elliptic curve y² = (x-u)(x-Λ²)(x+Λ²) produces a mass gap in N=2 SU(2) SYM",
-      "The lightest glueball (0⁺⁺, ≈1730 MeV) IS the mass gap — its mass in string tension units m/√σ ≈ 3.98 is a universal prediction confirmed by lattice QCD for SU(N) with N = 2,3,4,5,6,8",
+      "Center symmetry Z_N classifies confinement: unbroken \u2194 confined, broken \u2194 deconfined. The deconfinement transition is second-order for SU(2) (Ising universality) but first-order for SU(3) (Potts), due to the presence of a cubic term in the Polyakov loop effective potential for N \u2265 3",
+      "Seiberg-Witten theory provides the only known exact confinement mechanism: monopole condensation at the singular point u = \u039b\u00b2 of the elliptic curve y\u00b2 = (x-u)(x-\u039b\u00b2)(x+\u039b\u00b2) produces a mass gap in N=2 SU(2) SYM",
+      "The lightest glueball (0\u207a\u207a, \u22481730 MeV) IS the mass gap \u2014 its mass in string tension units m/\u221a\u03c3 \u2248 3.98 is a universal prediction confirmed by lattice QCD for SU(N) with N = 2,3,4,5,6,8",
       "Gribov copies obstruct global gauge fixing (Singer's theorem), but stochastic quantization (Parisi-Wu) bypasses this entirely: the Langevin process converges to the correct path integral measure without gauge fixing",
-      "Only 1 axiom remains (gaugeTransform, definitional) after aggressive elimination: 15 former axioms were either proved, shown trivially satisfiable, or deleted as unused — demonstrating that much of the QFT infrastructure can be formalized in pure Lean",
+      "Only 1 axiom remains (gaugeTransform, definitional) after aggressive elimination: 15 former axioms were either proved, shown trivially satisfiable, or deleted as unused \u2014 demonstrating that much of the QFT infrastructure can be formalized in pure Lean",
       "Balaban's block-spin RG is the closest rigorous approach: coupling remains controlled for finitely many steps, but extending to infinitely many steps in d=4 (the continuum limit) remains the central gap to the Millennium Prize"
     ]
   },
@@ -125,21 +155,21 @@
     {
       "id": "gauge-group",
       "title": "Part I: Gauge Group and Lie Algebra Infrastructure",
-      "summary": "Defines CompactSimpleGaugeGroup typeclass, LieAlgebra 𝔤, spacetime R⁴, Minkowski metric with signature (1,3), and proves diagonal/symmetric/Lorentzian properties.",
+      "summary": "Defines CompactSimpleGaugeGroup typeclass, LieAlgebra \ud835\udd24, spacetime R\u2074, Minkowski metric with signature (1,3), and proves diagonal/symmetric/Lorentzian properties.",
       "startLine": 55,
       "endLine": 148
     },
     {
       "id": "field-strength",
       "title": "Part II: Gauge Fields and Field Strength",
-      "summary": "Defines gauge field A_μ(x) ∈ 𝔤, field strength tensor F_μν, proves antisymmetry and that F has 6 independent components in 4D.",
+      "summary": "Defines gauge field A_\u03bc(x) \u2208 \ud835\udd24, field strength tensor F_\u03bc\u03bd, proves antisymmetry and that F has 6 independent components in 4D.",
       "startLine": 149,
       "endLine": 196
     },
     {
       "id": "yang-mills-action",
       "title": "Part III: Yang-Mills Action and Classical Equations",
-      "summary": "Defines Killing form, Yang-Mills action S[A] = -1/(4g²) ∫ Tr(F²), covariant derivative, Yang-Mills equations D_μ F^μν = 0, and Bianchi identity.",
+      "summary": "Defines Killing form, Yang-Mills action S[A] = -1/(4g\u00b2) \u222b Tr(F\u00b2), covariant derivative, Yang-Mills equations D_\u03bc F^\u03bc\u03bd = 0, and Bianchi identity.",
       "startLine": 197,
       "endLine": 251
     },
@@ -160,14 +190,14 @@
     {
       "id": "wightman-axioms",
       "title": "Part VI: Quantum Yang-Mills and Wightman Axioms",
-      "summary": "Defines WightmanQFT structure with Hilbert space, vacuum, Hamiltonian, Poincaré covariance, spectral condition, and locality. Specializes to QuantumYangMills.",
+      "summary": "Defines WightmanQFT structure with Hilbert space, vacuum, Hamiltonian, Poincar\u00e9 covariance, spectral condition, and locality. Specializes to QuantumYangMills.",
       "startLine": 376,
       "endLine": 406
     },
     {
       "id": "mass-gap",
       "title": "Parts VII-VIII: The Mass Gap and Millennium Problem",
-      "summary": "Defines mass gap Δ > 0 (all excited states have energy ≥ Δ), states the full Millennium Prize conjecture: existence + mass gap for any compact simple G.",
+      "summary": "Defines mass gap \u0394 > 0 (all excited states have energy \u2265 \u0394), states the full Millennium Prize conjecture: existence + mass gap for any compact simple G.",
       "startLine": 407,
       "endLine": 450
     },
@@ -181,7 +211,7 @@
     {
       "id": "instantons",
       "title": "Part X: Instanton Solutions",
-      "summary": "Defines instantons as (anti-)self-dual solutions with topological charge k ∈ ℤ. Proves Bogomolny bound S[A] ≥ 8π²|k|/g².",
+      "summary": "Defines instantons as (anti-)self-dual solutions with topological charge k \u2208 \u2124. Proves Bogomolny bound S[A] \u2265 8\u03c0\u00b2|k|/g\u00b2.",
       "startLine": 479,
       "endLine": 499
     },
@@ -195,7 +225,7 @@
     {
       "id": "lattice-gauge",
       "title": "Part XIII: Lattice Gauge Theory",
-      "summary": "Wilson's lattice formulation: plaquettes, Wilson action S_W = β Σ (1 - Re Tr U_p), continuum limit, lattice mass gap from transfer matrix eigenvalues.",
+      "summary": "Wilson's lattice formulation: plaquettes, Wilson action S_W = \u03b2 \u03a3 (1 - Re Tr U_p), continuum limit, lattice mass gap from transfer matrix eigenvalues.",
       "startLine": 613,
       "endLine": 869
     },
@@ -209,7 +239,7 @@
     {
       "id": "su2-casimir",
       "title": "Parts XVIII-XIX: SU(2) Representation Theory and Center Symmetry",
-      "summary": "SU(2) Casimir C₂(j) = j(j+1), string tension from Migdal, Casimir monotonicity, mass gap bounds. Z_N center symmetry classification of confinement phases.",
+      "summary": "SU(2) Casimir C\u2082(j) = j(j+1), string tension from Migdal, Casimir monotonicity, mass gap bounds. Z_N center symmetry classification of confinement phases.",
       "startLine": 1089,
       "endLine": 1457
     },
@@ -223,7 +253,7 @@
     {
       "id": "large-n",
       "title": "Parts XXIX-XXXI: Large-N and Planar Limit",
-      "summary": "'t Hooft coupling λ = g²N, 1/N expansion, planar limit, glueball spectrum with mass gap from spectral theory.",
+      "summary": "'t Hooft coupling \u03bb = g\u00b2N, 1/N expansion, planar limit, glueball spectrum with mass gap from spectral theory.",
       "startLine": 2060,
       "endLine": 2314
     },
@@ -237,14 +267,14 @@
     {
       "id": "asymptotic-freedom",
       "title": "Part XXXIV: Asymptotic Freedom and Beta Function",
-      "summary": "Formalizes the one-loop beta function β₀ = (11N - 2Nf)/3, running coupling, asymptotic freedom (coupling vanishes at short distances), Λ_QCD scale, and trace anomaly for SU(2) and SU(3). The 2004 Nobel Prize result by Gross, Wilczek, and Politzer.",
+      "summary": "Formalizes the one-loop beta function \u03b2\u2080 = (11N - 2Nf)/3, running coupling, asymptotic freedom (coupling vanishes at short distances), \u039b_QCD scale, and trace anomaly for SU(2) and SU(3). The 2004 Nobel Prize result by Gross, Wilczek, and Politzer.",
       "startLine": 3706,
       "endLine": 3723
     },
     {
       "id": "spectral-gap-correlation",
       "title": "Part XXXV: Spectral Gap and Correlation Length",
-      "summary": "Connects the mass gap to exponential decay of correlations via the Källén-Lehmann spectral representation. Defines correlation length ξ and proves mass gap Δ = 1/ξ. Covers lattice correlation length and the continuum limit.",
+      "summary": "Connects the mass gap to exponential decay of correlations via the K\u00e4ll\u00e9n-Lehmann spectral representation. Defines correlation length \u03be and proves mass gap \u0394 = 1/\u03be. Covers lattice correlation length and the continuum limit.",
       "startLine": 3724,
       "endLine": 3737
     },
@@ -258,14 +288,14 @@
     {
       "id": "chiral-anomaly",
       "title": "Parts XLIII-XLIV: Chiral Anomaly and Index Theorem",
-      "summary": "Formalizes the Adler-Bardeen chiral anomaly ∂_μ j⁵_μ = (g²Nf)/(16π²) F·F̃, exact to all orders by the Adler-Bardeen theorem. Connects the anomaly to topology via the Atiyah-Singer index theorem: the topological charge Q equals the difference of chiral zero modes n⁺ - n⁻.",
+      "summary": "Formalizes the Adler-Bardeen chiral anomaly \u2202_\u03bc j\u2075_\u03bc = (g\u00b2Nf)/(16\u03c0\u00b2) F\u00b7F\u0303, exact to all orders by the Adler-Bardeen theorem. Connects the anomaly to topology via the Atiyah-Singer index theorem: the topological charge Q equals the difference of chiral zero modes n\u207a - n\u207b.",
       "startLine": 3984,
       "endLine": 4099
     },
     {
       "id": "dual-superconductor",
       "title": "Parts XLV-XLVI: Dual Superconductor Model",
-      "summary": "Formalizes 't Hooft's dual superconductor mechanism for confinement. In ordinary superconductors, electric condensate confines magnetic flux (Meissner effect). In QCD, magnetic monopole condensation confines color-electric flux. Covers abelian projection SU(N) → U(1)^{N-1} and Abrikosov vortex analogy.",
+      "summary": "Formalizes 't Hooft's dual superconductor mechanism for confinement. In ordinary superconductors, electric condensate confines magnetic flux (Meissner effect). In QCD, magnetic monopole condensation confines color-electric flux. Covers abelian projection SU(N) \u2192 U(1)^{N-1} and Abrikosov vortex analogy.",
       "startLine": 4120,
       "endLine": 4263
     },
@@ -279,7 +309,7 @@
     {
       "id": "stochastic-quantization",
       "title": "Part XLVIII: Stochastic Quantization (Parisi-Wu)",
-      "summary": "Formalizes the stochastic quantization approach where quantum field configurations are generated by a Langevin equation in a fictitious time τ. The equilibrium distribution of the stochastic process reproduces the Euclidean path integral measure.",
+      "summary": "Formalizes the stochastic quantization approach where quantum field configurations are generated by a Langevin equation in a fictitious time \u03c4. The equilibrium distribution of the stochastic process reproduces the Euclidean path integral measure.",
       "startLine": 4747,
       "endLine": 4895
     },
@@ -293,7 +323,7 @@
     {
       "id": "susy-yang-mills",
       "title": "Part L: Supersymmetric Yang-Mills and Seiberg-Witten",
-      "summary": "N=1 SYM gluino condensate ⟨λλ⟩ = NΛ³ exp(2πik/N) with N vacua from Z_{2N} → Z_2 breaking. Witten index Tr(-1)^F = N proves SUSY is unbroken. N=2 SU(2) Seiberg-Witten theory gives exact low-energy effective action via an elliptic curve family.",
+      "summary": "N=1 SYM gluino condensate \u27e8\u03bb\u03bb\u27e9 = N\u039b\u00b3 exp(2\u03c0ik/N) with N vacua from Z_{2N} \u2192 Z_2 breaking. Witten index Tr(-1)^F = N proves SUSY is unbroken. N=2 SU(2) Seiberg-Witten theory gives exact low-energy effective action via an elliptic curve family.",
       "startLine": 5041,
       "endLine": 5219
     },
@@ -314,49 +344,49 @@
     {
       "id": "schwinger-model",
       "title": "Part LVIII: The Schwinger Model",
-      "summary": "QED in 1+1 dimensions — one of the few QFTs with an exactly known mass gap m = e/√π. The mass arises entirely from the chiral anomaly (no classical mass term). Also formalizes string tension σ = e²/(2π) and proves both are positive. A key testing ground for confinement ideas.",
+      "summary": "QED in 1+1 dimensions \u2014 one of the few QFTs with an exactly known mass gap m = e/\u221a\u03c0. The mass arises entirely from the chiral anomaly (no classical mass term). Also formalizes string tension \u03c3 = e\u00b2/(2\u03c0) and proves both are positive. A key testing ground for confinement ideas.",
       "startLine": 6583,
       "endLine": 6719
     },
     {
       "id": "gradient-flow",
       "title": "Part LIX: Yang-Mills Gradient Flow",
-      "summary": "Formalizes Lüscher's gradient flow: a diffusion equation that smooths gauge fields over a radius r = √(8t). The action monotonically decreases along the flow (dS/dt ≤ 0), converging to instantons or vacuum. Flowed operators are UV finite, making the flow a non-perturbative renormalization tool.",
+      "summary": "Formalizes L\u00fcscher's gradient flow: a diffusion equation that smooths gauge fields over a radius r = \u221a(8t). The action monotonically decreases along the flow (dS/dt \u2264 0), converging to instantons or vacuum. Flowed operators are UV finite, making the flow a non-perturbative renormalization tool.",
       "startLine": 6748,
       "endLine": 6888
     },
     {
       "id": "polyakov-loop",
       "title": "Part LX: Polyakov Loop and Finite Temperature",
-      "summary": "The Polyakov loop is the Wilson line wrapping around the thermal (Euclidean time) direction. Its expectation value serves as an order parameter: ⟨P⟩ = 0 in the confined phase (infinite quark free energy), ⟨P⟩ ≠ 0 in the deconfined phase.",
+      "summary": "The Polyakov loop is the Wilson line wrapping around the thermal (Euclidean time) direction. Its expectation value serves as an order parameter: \u27e8P\u27e9 = 0 in the confined phase (infinite quark free energy), \u27e8P\u27e9 \u2260 0 in the deconfined phase.",
       "startLine": 6915,
       "endLine": 7119
     },
     {
       "id": "glueball-spectrum",
       "title": "Part LXI: Glueball Spectrum",
-      "summary": "Formalizes the glueball spectrum — bound states of pure glue with quantum numbers J^{PC}. The lightest glueball (0++) has mass ≈ 1.7 GeV from lattice QCD, providing direct numerical evidence for the mass gap. Glueballs are the physical manifestation of confinement in pure Yang-Mills.",
+      "summary": "Formalizes the glueball spectrum \u2014 bound states of pure glue with quantum numbers J^{PC}. The lightest glueball (0++) has mass \u2248 1.7 GeV from lattice QCD, providing direct numerical evidence for the mass gap. Glueballs are the physical manifestation of confinement in pure Yang-Mills.",
       "startLine": 7141,
       "endLine": 7260
     },
     {
       "id": "strong-coupling",
       "title": "Part XXXVIII: Strong Coupling Expansion",
-      "summary": "Formalizes the strong coupling (large β⁻¹) expansion of lattice Yang-Mills, where the Wilson action expansion parameter u = β/(2N²) is small. In this regime, the area law is exact to leading order: W(I,J) ~ u^{I·J}, giving string tension σ = -ln(u)/a². Proves σ > 0 and that it grows with coupling. Also formalizes the coupling transition β_c between strong and weak coupling regimes, with SU(3) critical coupling greater than SU(2).",
+      "summary": "Formalizes the strong coupling (large \u03b2\u207b\u00b9) expansion of lattice Yang-Mills, where the Wilson action expansion parameter u = \u03b2/(2N\u00b2) is small. In this regime, the area law is exact to leading order: W(I,J) ~ u^{I\u00b7J}, giving string tension \u03c3 = -ln(u)/a\u00b2. Proves \u03c3 > 0 and that it grows with coupling. Also formalizes the coupling transition \u03b2_c between strong and weak coupling regimes, with SU(3) critical coupling greater than SU(2).",
       "startLine": 3754,
       "endLine": 3769
     },
     {
       "id": "running-coupling",
-      "title": "Parts XXVIII-XXXII: Running Coupling and Λ_QCD",
-      "summary": "Formalizes the one-loop running coupling, Λ_QCD scale, and the trace anomaly. Proves asymptotic freedom as a single inequality: g(μ) < g(μ₀) for μ > μ₀. Proves Λ_QCD > 0 and Λ_QCD < μ₀. The trace anomaly shows conformal symmetry is broken by quantum effects — a prerequisite for a mass gap.",
+      "title": "Parts XXVIII-XXXII: Running Coupling and \u039b_QCD",
+      "summary": "Formalizes the one-loop running coupling, \u039b_QCD scale, and the trace anomaly. Proves asymptotic freedom as a single inequality: g(\u03bc) < g(\u03bc\u2080) for \u03bc > \u03bc\u2080. Proves \u039b_QCD > 0 and \u039b_QCD < \u03bc\u2080. The trace anomaly shows conformal symmetry is broken by quantum effects \u2014 a prerequisite for a mass gap.",
       "startLine": 2463,
       "endLine": 2560
     },
     {
       "id": "anomaly-matching",
       "title": "Part LXII: 't Hooft Anomaly Matching",
-      "summary": "Formalizes the GKSW mixed anomaly (2017) between 1-form center symmetry and chiral symmetry. Proves the anomaly coefficient is 1 (mod N) and nontrivial for N ≥ 2. Implies the vacuum cannot be trivially gapped: SU(N) has N degenerate vacua from Z_{2N} → Z_2 breaking.",
+      "summary": "Formalizes the GKSW mixed anomaly (2017) between 1-form center symmetry and chiral symmetry. Proves the anomaly coefficient is 1 (mod N) and nontrivial for N \u2265 2. Implies the vacuum cannot be trivially gapped: SU(N) has N degenerate vacua from Z_{2N} \u2192 Z_2 breaking.",
       "startLine": 7262,
       "endLine": 7339
     },
@@ -370,77 +400,77 @@
     {
       "id": "witten-veneziano",
       "title": "Parts LXVI-LXVII: Witten-Veneziano and Topological Susceptibility",
-      "summary": "Connects the Yang-Mills vacuum topology to the physical mass spectrum via m²_{η'} = 2N_f·χ_t/f²_π. Proves the η' mass is positive from topological susceptibility, large-N scaling χ_t ~ 1/N², and instanton contribution to χ_t. The vacuum energy E(θ) is proved to be minimized at θ = 0.",
+      "summary": "Connects the Yang-Mills vacuum topology to the physical mass spectrum via m\u00b2_{\u03b7'} = 2N_f\u00b7\u03c7_t/f\u00b2_\u03c0. Proves the \u03b7' mass is positive from topological susceptibility, large-N scaling \u03c7_t ~ 1/N\u00b2, and instanton contribution to \u03c7_t. The vacuum energy E(\u03b8) is proved to be minimized at \u03b8 = 0.",
       "startLine": 9493,
       "endLine": 9578
     },
     {
       "id": "flux-tube-luscher",
-      "title": "Parts LXXV-LXXVI: Lüscher Term and Flux Tube Broadening",
-      "summary": "Formalizes the quark-antiquark potential V(r) = σr + μ - π(d-2)/(24r) + ..., where the 1/r correction (Lüscher term) is universal. The LSW flux tube width grows logarithmically w²(r) ~ ln(r/r₀). The Nambu-Goto string has no 1/r² correction (proved), with c₃ changing sign at the critical dimension d = 26.",
+      "title": "Parts LXXV-LXXVI: L\u00fcscher Term and Flux Tube Broadening",
+      "summary": "Formalizes the quark-antiquark potential V(r) = \u03c3r + \u03bc - \u03c0(d-2)/(24r) + ..., where the 1/r correction (L\u00fcscher term) is universal. The LSW flux tube width grows logarithmically w\u00b2(r) ~ ln(r/r\u2080). The Nambu-Goto string has no 1/r\u00b2 correction (proved), with c\u2083 changing sign at the critical dimension d = 26.",
       "startLine": 10965,
       "endLine": 11070
     },
     {
       "id": "seiberg-witten-bps",
       "title": "Part LXXXVII: Seiberg-Witten BPS Spectrum",
-      "summary": "Formalizes the exact BPS mass formula M = |n_e·a + n_m·a_D| for N=2 SU(2) SYM. Proves W-boson, monopole, and dyon masses. At the singular point u = Λ², monopoles become massless (proved), triggering condensation and confinement. Dirac quantization conditions verified for all particle pairs.",
+      "summary": "Formalizes the exact BPS mass formula M = |n_e\u00b7a + n_m\u00b7a_D| for N=2 SU(2) SYM. Proves W-boson, monopole, and dyon masses. At the singular point u = \u039b\u00b2, monopoles become massless (proved), triggering condensation and confinement. Dirac quantization conditions verified for all particle pairs.",
       "startLine": 13007,
       "endLine": 13100
     },
     {
       "id": "elitzur-fradkin-shenker",
       "title": "Parts CXII-CXIII: Elitzur's Theorem and Fradkin-Shenker",
-      "summary": "Formalizes Elitzur's theorem (1975): local gauge symmetry cannot spontaneously break. Wilson loops are the correct gauge-invariant order parameters. Fradkin-Shenker continuity: no phase boundary between confined and Higgs phases with fundamental matter. String breaking at r_b ~ 2M_q/σ. Pure gauge has true confinement with σ > 0 for all r.",
+      "summary": "Formalizes Elitzur's theorem (1975): local gauge symmetry cannot spontaneously break. Wilson loops are the correct gauge-invariant order parameters. Fradkin-Shenker continuity: no phase boundary between confined and Higgs phases with fundamental matter. String breaking at r_b ~ 2M_q/\u03c3. Pure gauge has true confinement with \u03c3 > 0 for all r.",
       "startLine": 17900,
       "endLine": 18074
     },
     {
       "id": "wegner-duality",
-      "title": "Part CXV: Wegner Duality and Z₂ Gauge Theory",
-      "summary": "Maps Z₂ gauge theory to the Ising model on the dual lattice. In d=3, the 1D Ising has no transition → Z₂ gauge ALWAYS confines (rigorous result). In d=4, the 2D Ising Onsager transition gives deconfinement. Key contrast: SU(N) has no zero-temperature transition — confinement persists at all couplings.",
+      "title": "Part CXV: Wegner Duality and Z\u2082 Gauge Theory",
+      "summary": "Maps Z\u2082 gauge theory to the Ising model on the dual lattice. In d=3, the 1D Ising has no transition \u2192 Z\u2082 gauge ALWAYS confines (rigorous result). In d=4, the 2D Ising Onsager transition gives deconfinement. Key contrast: SU(N) has no zero-temperature transition \u2014 confinement persists at all couplings.",
       "startLine": 19990,
       "endLine": 20080
     },
     {
       "id": "vafa-witten",
       "title": "Part CXXVIII: Vafa-Witten Theorem",
-      "summary": "Proves parity and charge conjugation cannot spontaneously break in vector-like gauge theories. The positive fermion determinant ensures the measure is parity-invariant. Constrains the QCD vacuum to be parity-even. Theta vacuum energy minimized at θ = 0.",
+      "summary": "Proves parity and charge conjugation cannot spontaneously break in vector-like gauge theories. The positive fermion determinant ensures the measure is parity-invariant. Constrains the QCD vacuum to be parity-even. Theta vacuum energy minimized at \u03b8 = 0.",
       "startLine": 22007,
       "endLine": 22080
     },
     {
       "id": "susy-qm-morse",
       "title": "Parts CXLVII-CXLVIII: SUSY QM and Morse Theory",
-      "summary": "Establishes a seven-way parallel between SUSY quantum mechanics and Yang-Mills. Partner potentials V± = W'² ± W'' have identical spectra except ground state. Witten's Morse theory deformation creates a spectral gap analogous to the mass gap. Semiclassical formula Δ ~ (g²/L)·exp(-8π²/(Ng²)) is the closest analytical mass gap expression.",
+      "summary": "Establishes a seven-way parallel between SUSY quantum mechanics and Yang-Mills. Partner potentials V\u00b1 = W'\u00b2 \u00b1 W'' have identical spectra except ground state. Witten's Morse theory deformation creates a spectral gap analogous to the mass gap. Semiclassical formula \u0394 ~ (g\u00b2/L)\u00b7exp(-8\u03c0\u00b2/(Ng\u00b2)) is the closest analytical mass gap expression.",
       "startLine": 27000,
       "endLine": 27070
     },
     {
       "id": "dse-gap-equation",
       "title": "Part CLV: Dyson-Schwinger Equations and the Gluon Gap Equation",
-      "summary": "DSE gives two self-consistent solutions: decoupling (D(0)>0, massive gluon ~500 MeV) and scaling (D(0)=0, ghost-enhanced). The OZ superconvergence relation forces the gluon spectral function negative somewhere — positivity violation signals confinement. Lattice favors decoupling.",
+      "summary": "DSE gives two self-consistent solutions: decoupling (D(0)>0, massive gluon ~500 MeV) and scaling (D(0)=0, ghost-enhanced). The OZ superconvergence relation forces the gluon spectral function negative somewhere \u2014 positivity violation signals confinement. Lattice favors decoupling.",
       "startLine": 28970,
       "endLine": 29032
     },
     {
       "id": "frg-wetterich",
       "title": "Part CLVI: Functional Renormalization Group (Wetterich Equation)",
-      "summary": "The Wetterich equation ∂_t Γ_k = ½ Tr[(Γ_k^(2) + R_k)⁻¹ · ∂_t R_k] interpolates from classical to quantum effective action. For Yang-Mills: gluon mass gap emerges naturally as k → 0, running coupling freezes in the IR. Quantitatively matches DSE and lattice predictions.",
+      "summary": "The Wetterich equation \u2202_t \u0393_k = \u00bd Tr[(\u0393_k^(2) + R_k)\u207b\u00b9 \u00b7 \u2202_t R_k] interpolates from classical to quantum effective action. For Yang-Mills: gluon mass gap emerges naturally as k \u2192 0, running coupling freezes in the IR. Quantitatively matches DSE and lattice predictions.",
       "startLine": 29034,
       "endLine": 29080
     },
     {
       "id": "theta-vacuum",
       "title": "Part XXXIX: Theta Vacuum and Instanton Moduli",
-      "summary": "Formalizes the theta vacuum structure: instanton action bound S ≥ 8π²|k|/g² (proved non-negative), winding number classification, theta parameter θ ∈ [0, 2π), vacuum energy E(θ) with E(0) being the minimum and E(π) the maximum. Proves instanton suppression at weak coupling. Defines the topological susceptibility χ_t and instanton moduli space dimensions: dim = 4Nk - N² + 1 for SU(N) with instanton number k.",
+      "summary": "Formalizes the theta vacuum structure: instanton action bound S \u2265 8\u03c0\u00b2|k|/g\u00b2 (proved non-negative), winding number classification, theta parameter \u03b8 \u2208 [0, 2\u03c0), vacuum energy E(\u03b8) with E(0) being the minimum and E(\u03c0) the maximum. Proves instanton suppression at weak coupling. Defines the topological susceptibility \u03c7_t and instanton moduli space dimensions: dim = 4Nk - N\u00b2 + 1 for SU(N) with instanton number k.",
       "startLine": 3769,
       "endLine": 3786
     },
     {
       "id": "complexity-barriers",
       "title": "Part XLIX: Complexity Barriers",
-      "summary": "Formalizes fundamental computational barriers: Cubitt-Perez-Garcia-Wolf (2015) undecidability of the spectral gap for general 2D lattice Hamiltonians, Kitaev's QMA-completeness of local Hamiltonian ground-state energy, the sign problem (absent for pure Yang-Mills but present at finite density), and the derandomization connection. Crucially proves Yang-Mills is NOT a general Hamiltonian — gauge symmetry, asymptotic freedom, and confinement structure may make the mass gap decidable for YM specifically.",
+      "summary": "Formalizes fundamental computational barriers: Cubitt-Perez-Garcia-Wolf (2015) undecidability of the spectral gap for general 2D lattice Hamiltonians, Kitaev's QMA-completeness of local Hamiltonian ground-state energy, the sign problem (absent for pure Yang-Mills but present at finite density), and the derandomization connection. Crucially proves Yang-Mills is NOT a general Hamiltonian \u2014 gauge symmetry, asymptotic freedom, and confinement structure may make the mass gap decidable for YM specifically.",
       "startLine": 4921,
       "endLine": 5012
     },
@@ -454,34 +484,34 @@
     {
       "id": "transfer-matrix",
       "title": "Part LVI: Transfer Matrix and Finite-Volume Mass Gap",
-      "summary": "Formalizes the transfer matrix approach: Perron-Frobenius theory guarantees a unique largest eigenvalue λ₀ with spectral gap Δ = log(λ₀/λ₁) > 0 for finite lattices. This finite-volume mass gap is a THEOREM (not conjecture). The physical mass gap m = Δ/a is proved positive. Correlation functions decay as (λ₁/λ₀)^n = exp(-nΔ). The open challenge is the continuum/infinite-volume limit.",
+      "summary": "Formalizes the transfer matrix approach: Perron-Frobenius theory guarantees a unique largest eigenvalue \u03bb\u2080 with spectral gap \u0394 = log(\u03bb\u2080/\u03bb\u2081) > 0 for finite lattices. This finite-volume mass gap is a THEOREM (not conjecture). The physical mass gap m = \u0394/a is proved positive. Correlation functions decay as (\u03bb\u2081/\u03bb\u2080)^n = exp(-n\u0394). The open challenge is the continuum/infinite-volume limit.",
       "startLine": 6249,
       "endLine": 6328
     },
     {
       "id": "resurgence",
       "title": "Part CI: Resurgence and Trans-Series",
-      "summary": "Perturbation theory in QCD diverges (a_n ~ n! factorial growth). Trans-series extend perturbative expansions with non-perturbative sectors: E(g²) = Σ aₙg²ⁿ + e^{-A/g²} Σ bₙg²ⁿ + .... Covers IR/UV renormalons, Borel plane singularities, and the resurgent structure connecting perturbative and instanton sectors.",
+      "summary": "Perturbation theory in QCD diverges (a_n ~ n! factorial growth). Trans-series extend perturbative expansions with non-perturbative sectors: E(g\u00b2) = \u03a3 a\u2099g\u00b2\u207f + e^{-A/g\u00b2} \u03a3 b\u2099g\u00b2\u207f + .... Covers IR/UV renormalons, Borel plane singularities, and the resurgent structure connecting perturbative and instanton sectors.",
       "startLine": 15304,
       "endLine": 15597
     },
     {
       "id": "balaban-rg",
       "title": "Parts CXLV-CXLVI: Balaban Renormalization Group",
-      "summary": "Tadeusz Balaban's block-spin RG program — the closest existing rigorous approach to 4D Yang-Mills. Formalizes the effective lattice spacing a_k = 2^k·a₀, running coupling at each RG step, and proves the coupling remains controlled at weak coupling. The gap to the Millennium Prize: extending from finitely many to infinitely many RG steps in d=4.",
+      "summary": "Tadeusz Balaban's block-spin RG program \u2014 the closest existing rigorous approach to 4D Yang-Mills. Formalizes the effective lattice spacing a_k = 2^k\u00b7a\u2080, running coupling at each RG step, and proves the coupling remains controlled at weak coupling. The gap to the Millennium Prize: extending from finitely many to infinitely many RG steps in d=4.",
       "startLine": 25187,
       "endLine": 25435
     },
     {
       "id": "dimensional-reduction",
       "title": "Part LXIV: Dimensional Reduction at High Temperature",
-      "summary": "At temperatures T >> Λ_QCD, 4D Yang-Mills reduces to 3D effective QCD (EQCD) via Kaluza-Klein decomposition. The hierarchy of scales T >> gT (electric screening) >> g²T (magnetic screening) is formalized. The magnetic sector of 3D YM is non-perturbative and confining even at arbitrarily high temperature, which is the ultimate infrared obstruction.",
+      "summary": "At temperatures T >> \u039b_QCD, 4D Yang-Mills reduces to 3D effective QCD (EQCD) via Kaluza-Klein decomposition. The hierarchy of scales T >> gT (electric screening) >> g\u00b2T (magnetic screening) is formalized. The magnetic sector of 3D YM is non-perturbative and confining even at arbitrarily high temperature, which is the ultimate infrared obstruction.",
       "startLine": 7417,
       "endLine": 7534
     },
     {
       "id": "thooft-loop",
-      "title": "Part LXV: 't Hooft Loop — Electric-Magnetic Duality",
+      "title": "Part LXV: 't Hooft Loop \u2014 Electric-Magnetic Duality",
       "summary": "The 't Hooft loop B(C) (1978) is the magnetic dual of the Wilson loop W(C). Together they classify gauge theory phases: confined (W: area law, B: perimeter law), Higgs (W: perimeter law, B: area law), Coulomb (both perimeter law). The 't Hooft-Wilson complementarity is formalized as a theorem.",
       "startLine": 7536,
       "endLine": 7636
@@ -489,69 +519,69 @@
     {
       "id": "witten-index-vacuum",
       "title": "Part LXVI: Witten Index and Vacuum Structure",
-      "summary": "The Witten index I_W = Tr[(-1)^F e^{-βH}] = n_B - n_F is a topological invariant unchanged by continuous deformations. For N=1 SU(N) SYM, I_W = N proves SUSY is unbroken and the vacuum is N-fold degenerate. Temperature independence is proved, providing a non-perturbative tool for vacuum analysis.",
+      "summary": "The Witten index I_W = Tr[(-1)^F e^{-\u03b2H}] = n_B - n_F is a topological invariant unchanged by continuous deformations. For N=1 SU(N) SYM, I_W = N proves SUSY is unbroken and the vacuum is N-fold degenerate. Temperature independence is proved, providing a non-perturbative tool for vacuum analysis.",
       "startLine": 7638,
       "endLine": 7761
     },
     {
       "id": "cluster-decomposition",
       "title": "Part LXVII: Cluster Decomposition and Exponential Decay",
-      "summary": "The cluster decomposition principle bridges Euclidean field theory and the mass gap. Connected correlators decay as ⟨O(x)O(y)⟩_c ≤ C·exp(-Δ·|x-y|) where Δ is the mass gap. Mass gap > 0 is equivalent to exponential cluster decomposition; massless theories have power-law decay. Formalizes the key chain: reflection positivity → transfer matrix → exponential decay ↔ mass gap.",
+      "summary": "The cluster decomposition principle bridges Euclidean field theory and the mass gap. Connected correlators decay as \u27e8O(x)O(y)\u27e9_c \u2264 C\u00b7exp(-\u0394\u00b7|x-y|) where \u0394 is the mass gap. Mass gap > 0 is equivalent to exponential cluster decomposition; massless theories have power-law decay. Formalizes the key chain: reflection positivity \u2192 transfer matrix \u2192 exponential decay \u2194 mass gap.",
       "startLine": 7763,
       "endLine": 7982
     },
     {
       "id": "casimir-scaling",
       "title": "Part LXXI: Casimir Scaling Hypothesis and String Breaking",
-      "summary": "The Casimir scaling hypothesis states σ_R/σ_fund = C₂(R)/C₂(fund) at intermediate distances. For SU(3): adjoint/fundamental ratio = 9/4, verified on the lattice. At large distances, adjoint strings break via gluon pair production when V(r) > 2M_gluelump, while fundamental strings are unbreakable (true confinement). The string breaking distance r_b ~ 2M_gluelump/σ_adj is formalized.",
+      "summary": "The Casimir scaling hypothesis states \u03c3_R/\u03c3_fund = C\u2082(R)/C\u2082(fund) at intermediate distances. For SU(3): adjoint/fundamental ratio = 9/4, verified on the lattice. At large distances, adjoint strings break via gluon pair production when V(r) > 2M_gluelump, while fundamental strings are unbreakable (true confinement). The string breaking distance r_b ~ 2M_gluelump/\u03c3_adj is formalized.",
       "startLine": 8410,
       "endLine": 8598
     },
     {
       "id": "luscher-term-string",
-      "title": "Part LXXIII: Lüscher Term and Effective String Theory",
-      "summary": "The Lüscher term is a universal 1/r correction to the confining potential: V(r) = σr − π(d−2)/(24r). For d=4: V(r) = σr − π/(12r). Derived from bosonic string zero-point energy. The Nambu-Goto string has no 1/r² correction (proved), with critical dimension d=26 where c₃ changes sign. Logarithmic flux tube broadening w²(r) ~ ln(r/r₀) is also formalized (LSW theorem).",
+      "title": "Part LXXIII: L\u00fcscher Term and Effective String Theory",
+      "summary": "The L\u00fcscher term is a universal 1/r correction to the confining potential: V(r) = \u03c3r \u2212 \u03c0(d\u22122)/(24r). For d=4: V(r) = \u03c3r \u2212 \u03c0/(12r). Derived from bosonic string zero-point energy. The Nambu-Goto string has no 1/r\u00b2 correction (proved), with critical dimension d=26 where c\u2083 changes sign. Logarithmic flux tube broadening w\u00b2(r) ~ ln(r/r\u2080) is also formalized (LSW theorem).",
       "startLine": 8786,
       "endLine": 9037
     },
     {
       "id": "center-vortex-model",
       "title": "Part LXXV: Center Vortex Model of Confinement",
-      "summary": "Center vortices are codimension-2 topological defects carrying Z_N center flux. When a vortex pierces the minimal surface of a Wilson loop, the loop picks up a center element ω. Random vortex piercing with probability p per unit area produces area law: ⟨W(C)⟩ = (1-2p)^A → exp(-σA) with σ = -ln(1-2p). Lattice evidence: removing vortices eliminates confinement and chiral symmetry breaking simultaneously.",
+      "summary": "Center vortices are codimension-2 topological defects carrying Z_N center flux. When a vortex pierces the minimal surface of a Wilson loop, the loop picks up a center element \u03c9. Random vortex piercing with probability p per unit area produces area law: \u27e8W(C)\u27e9 = (1-2p)^A \u2192 exp(-\u03c3A) with \u03c3 = -ln(1-2p). Lattice evidence: removing vortices eliminates confinement and chiral symmetry breaking simultaneously.",
       "startLine": 9592,
       "endLine": 9738
     },
     {
       "id": "kugo-ojima",
       "title": "Part LXXVI: Kugo-Ojima Confinement Criterion",
-      "summary": "The Kugo-Ojima criterion (1979) provides a sufficient condition for color confinement using BRST cohomology: physical states satisfy Q_B|phys⟩ = 0. The criterion u(0) = -1 (where u is the ghost self-energy at zero momentum) signals confinement. Connected to the scaling solution of the gluon propagator D(0)=0 and enhanced ghost propagator.",
+      "summary": "The Kugo-Ojima criterion (1979) provides a sufficient condition for color confinement using BRST cohomology: physical states satisfy Q_B|phys\u27e9 = 0. The criterion u(0) = -1 (where u is the ghost self-energy at zero momentum) signals confinement. Connected to the scaling solution of the gluon propagator D(0)=0 and enhanced ghost propagator.",
       "startLine": 9740,
       "endLine": 9874
     },
     {
       "id": "chromoelectric-flux-tubes",
       "title": "Part LXXVII: Chromoelectric Flux Tubes and the QCD String",
-      "summary": "In confining gauge theories, chromoelectric field lines between quarks collimate into narrow flux tubes rather than spreading. The tube has constant cross-section A ~ 1/σ, energy density concentrated in a cylinder of radius r₀ ~ 0.3 fm, and string tension σ = energy/length ~ (440 MeV)². The dual Meissner effect (monopole condensation) provides the mechanism for flux tube formation.",
+      "summary": "In confining gauge theories, chromoelectric field lines between quarks collimate into narrow flux tubes rather than spreading. The tube has constant cross-section A ~ 1/\u03c3, energy density concentrated in a cylinder of radius r\u2080 ~ 0.3 fm, and string tension \u03c3 = energy/length ~ (440 MeV)\u00b2. The dual Meissner effect (monopole condensation) provides the mechanism for flux tube formation.",
       "startLine": 9876,
       "endLine": 10111
     },
     {
       "id": "chiral-symmetry-breaking",
-      "title": "Part LXXVIII: Chiral Symmetry Breaking — Banks-Casher Relation",
-      "summary": "The Banks-Casher relation (1980) connects the spectral density ρ(0) of the Dirac operator at the origin to the chiral condensate: ⟨ψ̄ψ⟩ = -πρ(0). The GMOR relation m²_π · f²_π = m_q · |⟨ψ̄ψ⟩| links pion mass, decay constant, quark mass, and the condensate. Chiral symmetry breaking and confinement are closely connected but logically distinct phenomena.",
+      "title": "Part LXXVIII: Chiral Symmetry Breaking \u2014 Banks-Casher Relation",
+      "summary": "The Banks-Casher relation (1980) connects the spectral density \u03c1(0) of the Dirac operator at the origin to the chiral condensate: \u27e8\u03c8\u0304\u03c8\u27e9 = -\u03c0\u03c1(0). The GMOR relation m\u00b2_\u03c0 \u00b7 f\u00b2_\u03c0 = m_q \u00b7 |\u27e8\u03c8\u0304\u03c8\u27e9| links pion mass, decay constant, quark mass, and the condensate. Chiral symmetry breaking and confinement are closely connected but logically distinct phenomena.",
       "startLine": 10113,
       "endLine": 10165
     },
     {
       "id": "polyakov-3d-confinement",
-      "title": "Part CXI: Polyakov's 3D Confinement — Exact Mass Gap via Monopole-Instantons",
-      "summary": "Polyakov (1977) proved that compact QED₃ (3D gauge theory with compact U(1)) confines via monopole-instanton proliferation. The mass gap Δ ~ g²exp(-S_monopole) is generated non-perturbatively. This is one of the few rigorously understood confinement mechanisms and serves as a prototype for 4D confinement. Debye screening of the dual photon produces a massive photon.",
+      "title": "Part CXI: Polyakov's 3D Confinement \u2014 Exact Mass Gap via Monopole-Instantons",
+      "summary": "Polyakov (1977) proved that compact QED\u2083 (3D gauge theory with compact U(1)) confines via monopole-instanton proliferation. The mass gap \u0394 ~ g\u00b2exp(-S_monopole) is generated non-perturbatively. This is one of the few rigorously understood confinement mechanisms and serves as a prototype for 4D confinement. Debye screening of the dual photon produces a massive photon.",
       "startLine": 17444,
       "endLine": 17649
     },
     {
       "id": "zamolodchikov-c-theorem",
-      "title": "Part CXII: Zamolodchikov c-Theorem — Irreversibility of RG Flow",
+      "title": "Part CXII: Zamolodchikov c-Theorem \u2014 Irreversibility of RG Flow",
       "summary": "Zamolodchikov's c-theorem (1986) proves that in 2D QFT, there exists a function c(g) that decreases monotonically along RG flow and equals the central charge at fixed points: c_UV > c_IR. Cardy conjectured the 4D analogue (a-theorem), proved by Komargodski-Schwimmer (2011). For Yang-Mills: c_UV (free gluons) > c_IR (confined vacuum) implies the confining phase has fewer degrees of freedom.",
       "startLine": 17649,
       "endLine": 17842
@@ -559,49 +589,49 @@
     {
       "id": "quantum-simulation",
       "title": "Part CLII: Quantum Simulation of Lattice Gauge Theories",
-      "summary": "Quantum computers can simulate lattice gauge theories without the sign problem that plagues classical Monte Carlo at finite density. Formalizes qubit-based lattice gauge theory, Trotterized time evolution, and the quantum advantage for real-time dynamics. Current experiments with trapped ions and superconducting qubits demonstrate Schwinger model simulations — a path toward quantum verification of the mass gap.",
+      "summary": "Quantum computers can simulate lattice gauge theories without the sign problem that plagues classical Monte Carlo at finite density. Formalizes qubit-based lattice gauge theory, Trotterized time evolution, and the quantum advantage for real-time dynamics. Current experiments with trapped ions and superconducting qubits demonstrate Schwinger model simulations \u2014 a path toward quantum verification of the mass gap.",
       "startLine": 27753,
       "endLine": 28124
     },
     {
       "id": "color-superconductivity",
       "title": "Part CLIII: Color Superconductivity and the QCD Phase Diagram",
-      "summary": "At high baryon density and low temperature, quarks form Cooper pairs (color superconductivity). The color-flavor-locked (CFL) phase breaks SU(3)_color × SU(3)_flavor → SU(3)_diagonal, with a gap Δ_CFL ~ 100 MeV. The BCS mechanism is formalized. CFL phase confines at the same time — Fradkin-Shenker continuity connects it to the hadronic phase with no phase boundary.",
+      "summary": "At high baryon density and low temperature, quarks form Cooper pairs (color superconductivity). The color-flavor-locked (CFL) phase breaks SU(3)_color \u00d7 SU(3)_flavor \u2192 SU(3)_diagonal, with a gap \u0394_CFL ~ 100 MeV. The BCS mechanism is formalized. CFL phase confines at the same time \u2014 Fradkin-Shenker continuity connects it to the hadronic phase with no phase boundary.",
       "startLine": 28127,
       "endLine": 28427
     },
     {
       "id": "millennium-prize-precise",
-      "title": "Part CLIX: Constructive Quantum Yang-Mills — Millennium Prize Requirements",
-      "summary": "Precise statement of what the Clay Millennium Prize requires: (1) Existence of a measure μ on the space of connections satisfying OS axioms with gauge invariance, (2) Mass gap: the reconstructed Hamiltonian has spectrum {0} ∪ [Δ,∞) with Δ > 0. The distinction between lattice mass gap (proved) and continuum mass gap (open) is formalized. The infinite-volume and continuum limits must both exist and be non-trivial.",
+      "title": "Part CLIX: Constructive Quantum Yang-Mills \u2014 Millennium Prize Requirements",
+      "summary": "Precise statement of what the Clay Millennium Prize requires: (1) Existence of a measure \u03bc on the space of connections satisfying OS axioms with gauge invariance, (2) Mass gap: the reconstructed Hamiltonian has spectrum {0} \u222a [\u0394,\u221e) with \u0394 > 0. The distinction between lattice mass gap (proved) and continuum mass gap (open) is formalized. The infinite-volume and continuum limits must both exist and be non-trivial.",
       "startLine": 29732,
       "endLine": 29876
     },
     {
       "id": "lattice-strong-coupling-rigorous",
-      "title": "Part CLX: Lattice Strong Coupling Expansion — Rigorous Area Law",
-      "summary": "At strong coupling (small β), the lattice Yang-Mills theory has a rigorously proved area law with string tension σ = -ln(β/(2N²))/a². The cluster expansion converges for β < β_c, giving exponential decay of correlations. This is the strongest rigorous result toward the mass gap — but extending it to weak coupling (where the continuum limit lives) remains the central challenge.",
+      "title": "Part CLX: Lattice Strong Coupling Expansion \u2014 Rigorous Area Law",
+      "summary": "At strong coupling (small \u03b2), the lattice Yang-Mills theory has a rigorously proved area law with string tension \u03c3 = -ln(\u03b2/(2N\u00b2))/a\u00b2. The cluster expansion converges for \u03b2 < \u03b2_c, giving exponential decay of correlations. This is the strongest rigorous result toward the mass gap \u2014 but extending it to weak coupling (where the continuum limit lives) remains the central challenge.",
       "startLine": 29891,
       "endLine": 30087
     },
     {
       "id": "instanton-calculus",
       "title": "Part CLXI: Instanton Calculus and Semiclassical Approximation",
-      "summary": "Systematic instanton calculus: the semiclassical expansion around the k-instanton solution gives corrections O(e^{-8π²k/g²}). The instanton moduli space has dimension 4Nk (for SU(N), charge k). The 't Hooft vertex generates fermion mass terms. Instanton contributions to the vacuum energy: E_vac ~ -Λ⁴·exp(-8π²/g²)·cos(θ). The dilute gas approximation breaks down at strong coupling.",
+      "summary": "Systematic instanton calculus: the semiclassical expansion around the k-instanton solution gives corrections O(e^{-8\u03c0\u00b2k/g\u00b2}). The instanton moduli space has dimension 4Nk (for SU(N), charge k). The 't Hooft vertex generates fermion mass terms. Instanton contributions to the vacuum energy: E_vac ~ -\u039b\u2074\u00b7exp(-8\u03c0\u00b2/g\u00b2)\u00b7cos(\u03b8). The dilute gas approximation breaks down at strong coupling.",
       "startLine": 30087,
       "endLine": 30391
     },
     {
       "id": "confinement-order-parameters",
-      "title": "Part CLXII: Confinement Order Parameters — A Unified View",
-      "summary": "Comprehensive comparison of all confinement criteria formalized in this entry: Wilson area law, 't Hooft loop perimeter law, Polyakov loop ⟨P⟩ = 0, center symmetry unbroken, Kugo-Ojima u(0) = -1, gluon propagator D(0) > 0 (decoupling), positive string tension σ > 0, vortex condensation, and monopole condensation. Their logical relationships and which are necessary vs sufficient conditions for confinement.",
+      "title": "Part CLXII: Confinement Order Parameters \u2014 A Unified View",
+      "summary": "Comprehensive comparison of all confinement criteria formalized in this entry: Wilson area law, 't Hooft loop perimeter law, Polyakov loop \u27e8P\u27e9 = 0, center symmetry unbroken, Kugo-Ojima u(0) = -1, gluon propagator D(0) > 0 (decoupling), positive string tension \u03c3 > 0, vortex condensation, and monopole condensation. Their logical relationships and which are necessary vs sufficient conditions for confinement.",
       "startLine": 30391,
       "endLine": 30551
     }
   ],
   "conclusion": {
-    "summary": "This is the largest single formalization in the gallery at 30808 lines, covering 162 parts of Yang-Mills theory with 2600+ theorems and definitions. After aggressive axiom elimination, only 1 axiom remains (gaugeTransform — definitional) with 0 sorries. The formalization spans classical gauge theory, quantum axiomatics, lattice methods, exact solutions, and modern approaches including AdS/CFT, constructive QFT, and Donaldson theory.",
-    "implications": "**Significance**\n\n1. **Most complete formalization**: At 30808 lines and 162 parts, this is the most comprehensive Lean formalization of Yang-Mills theory, spanning classical gauge theory, quantum axiomatics, and modern non-perturbative approaches.\n2. **Near-axiom-free**: Only 1 axiom remains (gaugeTransform, definitional) after 15 former axioms were eliminated — demonstrating that much of the mathematical physics infrastructure can be formalized without assumptions.\n3. **Multiple approaches formalized**: Lattice, continuum, exact solutions, AdS/CFT, SUSY, constructive QFT, Schwinger model, gradient flow, monopoles, Seiberg duality — providing a comprehensive roadmap for future work on the Millennium Prize Problem.\n4. **Modular architecture**: The 162-part structure allows independent verification of each component, from classical gauge invariance through lattice mass gap to OS reconstruction.\n5. **Educational value**: Serves as a structured mathematical introduction to Yang-Mills theory, connecting each physical concept to its Lean formalization.",
+    "summary": "This is the largest single formalization in the gallery at 30808 lines, covering 162 parts of Yang-Mills theory with 2600+ theorems and definitions. After aggressive axiom elimination, only 1 axiom remains (gaugeTransform \u2014 definitional) with 0 sorries. The formalization spans classical gauge theory, quantum axiomatics, lattice methods, exact solutions, and modern approaches including AdS/CFT, constructive QFT, and Donaldson theory.",
+    "implications": "**Significance**\n\n1. **Most complete formalization**: At 30808 lines and 162 parts, this is the most comprehensive Lean formalization of Yang-Mills theory, spanning classical gauge theory, quantum axiomatics, and modern non-perturbative approaches.\n2. **Near-axiom-free**: Only 1 axiom remains (gaugeTransform, definitional) after 15 former axioms were eliminated \u2014 demonstrating that much of the mathematical physics infrastructure can be formalized without assumptions.\n3. **Multiple approaches formalized**: Lattice, continuum, exact solutions, AdS/CFT, SUSY, constructive QFT, Schwinger model, gradient flow, monopoles, Seiberg duality \u2014 providing a comprehensive roadmap for future work on the Millennium Prize Problem.\n4. **Modular architecture**: The 162-part structure allows independent verification of each component, from classical gauge invariance through lattice mass gap to OS reconstruction.\n5. **Educational value**: Serves as a structured mathematical introduction to Yang-Mills theory, connecting each physical concept to its Lean formalization.",
     "openQuestions": [
       "Can constructive QFT methods (Part LII) be extended from 2D to 4D Yang-Mills?",
       "Does the lattice mass gap (Part XIII) survive the continuum limit?",
@@ -609,8 +639,55 @@
       "Is there a path to formalizing the Osterwalder-Schrader reconstruction in full generality?",
       "Can Balaban's block-spin RG program (Parts CXLV-CXLVI) be extended from finitely many to infinitely many steps in d=4, closing the gap to a rigorous proof?",
       "Does the resurgent trans-series structure (Part CI) provide a non-perturbative completion of QCD that could constrain the mass gap from above?",
-      "Can center vortex condensation (Part LXXV) be made rigorous — proving that random vortex models produce the area law in the continuum limit?",
+      "Can center vortex condensation (Part LXXV) be made rigorous \u2014 proving that random vortex models produce the area law in the continuum limit?",
       "Will quantum simulation (Part CLII) provide the first experimental verification of the mass gap in a controlled lattice gauge theory?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "proofId": "navier-stokes-existence",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem involving existence and regularity of solutions to nonlinear PDEs"
+    },
+    {
+      "proofId": "yang-mills",
+      "relationship": "parent",
+      "description": "Base Yang-Mills formalization providing classical gauge theory foundations"
+    },
+    {
+      "proofId": "riemann-hypothesis",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem; the Riemann zeta function appears in number-theoretic aspects of gauge theory"
+    },
+    {
+      "proofId": "hodge-conjecture",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem; Hodge theory connects to the de Rham cohomology of gauge bundles"
+    },
+    {
+      "proofId": "p-vs-np",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem"
+    },
+    {
+      "proofId": "birch-swinnerton-dyer",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem"
+    },
+    {
+      "proofId": "poincare-conjecture",
+      "relationship": "related",
+      "description": "Fellow Millennium Prize Problem (solved by Perelman 2003); Ricci flow used in the proof is a geometric analogue of the Yang-Mills gradient flow"
+    },
+    {
+      "proofId": "hilbert-6",
+      "relationship": "related",
+      "description": "Hilbert's 6th Problem (axiomatization of physics) \u2014 constructing rigorous Yang-Mills QFT via Wightman/OS axioms is a central instance of Hilbert's program for mathematical physics"
+    },
+    {
+      "proofId": "continuum-hypothesis",
+      "relationship": "related",
+      "description": "Both involve foundational questions about mathematical structures; the spectral gap undecidability result (Cubitt et al. 2015) parallels the independence of CH from ZFC, though Yang-Mills' specific structure may make its mass gap decidable"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for 2 proofs:

### cauchy-schwarz-oq-01-oq-01 (quality 43 → improved)
- Added 12 annotations with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- Deepened `historicalContext` with Bunyakovsky (1859) and proof technique distinctions
- Added 5th `keyInsight` on explicit projection coefficient
- Added `crossReferences` to 4 related proofs
- Added Bunyakovsky reference and header section

### yang-mills-mass-gap (quality 45 → improved)
- Fixed annotations.json format from `{annotations:[...]}` to `[...]` (quality scorer was reading 0 annotations)
- Added top-level `crossReferences` with 9 related proofs
- Added `references` array with 4 foundational citations (Yang-Mills 1954, Gross-Wilczek 1973, Wilson 1974, Jaffe-Witten 2000)

## Test plan
- [x] JSON validation passes
- [x] `pnpm annotations:build` succeeds (non-strict warnings are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)