### PR TITLE
Enrich erdos-167, erdos-180, erdos-185: sections, cross-references

### DIFF
--- a/src/data/proofs/erdos-185/meta.json
+++ b/src/data/proofs/erdos-185/meta.json
@@ -146,6 +146,18 @@
       "endLine": 287
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-140",
+      "relationship": "related",
+      "description": "Erdős #140 concerns 3-AP-free sets in {1,...,N} (Kelley-Meka 2023); cap sets in {0,1,2}^n are the finite geometry analogue, with the connection f₃(n) ≥ R₃(N) formalized here"
+    },
+    {
+      "targetId": "erdos-180",
+      "relationship": "related",
+      "description": "Both concern extremal density problems: #180 for forbidden graph substructures, #185 for forbidden collinear triples in finite geometry"
+    }
+  ],
   "conclusion": {
     "summary": "Erdős Problem #185 asked whether f₃(n) = o(3^n), where f₃(n) is the maximum cap set in {0,1,2}^n. The answer is YES, proved as a corollary of the density Hales-Jewett theorem (Furstenberg-Katznelson 1991). More recent work by Ellenberg-Gijswijt (2016) showed f₃(n) ≤ c^n with c < 3, a major quantitative improvement.",
     "implications": "**Additive Combinatorics Connections:**\n\n1. **Cap Set Problem:** Central problem in finite geometry and coding theory.\n\n2. **Hales-Jewett Theorem:** Fundamental result in Ramsey theory.\n\n3. **Polynomial Method:** Ellenberg-Gijswijt's proof revolutionized the field.\n\n4. **Sunflower Conjecture:** Cap set bounds have implications for other problems.\n\n5. **Coding Theory:** Cap sets relate to error-correcting codes over F₃.",


### PR DESCRIPTION
## Summary
- erdos-167: Rewrote 7 section titles/summaries with descriptive content and LaTeX, added crossReference
- erdos-180: Added crossReferences to erdos-167 and erdos-140
- erdos-185: Added crossReferences to erdos-140 (cap set / AP connection) and erdos-180

## Test plan
- [x] JSON validity verified for all entries
- [x] Annotation build passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)