### PR TITLE
Enrich 8 proofs: prerequisites, section summaries, crossReferences, history

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -4720,11 +4720,12 @@
     },
     {
       "slug": "area-of-circle-oq-03-oq-02",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-21T17:10:19.183Z",
-      "status": "active",
-      "lastUpdate": "2026-03-21T17:10:19.183Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T01:43:26.796Z",
+      "completed": "2026-03-22T01:43:26.795Z"
     },
     {
       "slug": "bounded-prime-gaps-oq-03-oq-01",

--- a/src/data/proofs/erdos-140/annotations.json
+++ b/src/data/proofs/erdos-140/annotations.json
@@ -66,7 +66,7 @@
     "type": "definition",
     "title": "The Roth Number r\u2083(N)",
     "content": "**r3 N** = max{ |A| : A \u2286 {0,...,N}, A is 3-AP-free }\n\nDefined as the supremum over all valid subsets.\n\n**theorem r3_achieved** \u2713: The supremum is achieved by some finite set.\n\n**Proof**: The set of achievable cardinalities is nonempty (\u2205 works) and bounded by N+1, so the supremum exists and is achieved.",
-    "mathContext": "This is Roth's original quantity. Understanding r\u2083(N) is central to additive combinatorics and Ramsey theory.",
+    "mathContext": "$r_3(N) = \\max\\{|A| : A \\subseteq \\{0,\\ldots,N\\},\\, A \\text{ is 3-AP-free}\\}$. The proof of `r3_achieved` uses finiteness: the set of achievable cardinalities is a nonempty subset of $\\{0,\\ldots,N+1\\}$, so $\\text{sSup}$ is a maximum. This is Roth's original quantity, and understanding its growth rate is one of the central problems in additive combinatorics.",
     "significance": "key",
     "relatedConcepts": [
       "roth-number",
@@ -94,7 +94,7 @@
     "type": "axiom",
     "title": "Roth's Theorem (1953)",
     "content": "**axiom roth_theorem**: r\u2083(N) = o(N)\n\nThe first non-trivial upper bound showing 3-AP-free sets have density 0.\n\n**Explicit bound**: r\u2083(N) \u2264 C\u00b7N / log log N\n\nRoth won the Fields Medal in part for this work.",
-    "mathContext": "Roth used Fourier-analytic methods (circle method) to prove this. It showed that large 3-AP-free sets cannot exist.",
+    "mathContext": "Roth's proof uses the density increment strategy on $\\mathbb{Z}/N\\mathbb{Z}$: if $A \\subseteq \\{1,\\ldots,N\\}$ has density $\\alpha$ and no 3-AP, then either $A$ has a large Fourier coefficient $|\\hat{1}_A(r)| \\geq \\delta(\\alpha)$, or the count of 3-APs $\\sum_{a,d} 1_A(a)1_A(a+d)1_A(a+2d)$ is positive. The large Fourier coefficient forces $A$ to have density $\\geq \\alpha + c(\\alpha)$ on some subprogression, and iterating gives the bound $r_3(N) \\leq CN/\\log\\log N$.",
     "significance": "key",
     "relatedConcepts": [
       "roth-1953",
@@ -123,7 +123,7 @@
     "type": "axiom",
     "title": "Historical Progress",
     "content": "**Bourgain (2008)**: r\u2083(N) = O(N / \u221a(log log N))\nImproved Roth using deeper Fourier analysis.\n\n**Sanders (2011)**: r\u2083(N) = O(N (log log N)\u2075 / log N)\nFirst bound with log N in denominator!\n\n**Bloom-Sisask (2020)**: r\u2083(N) = O(N / (log N)^{1+c}) for some c > 0\nBreakthrough: power > 1 in log exponent.",
-    "mathContext": "Each improvement required new techniques. Sanders introduced nilsequences; Bloom-Sisask used entropy-based methods.",
+    "mathContext": "Bourgain refined the $L^p$ estimates on exponential sums over 3-AP-free sets. Sanders used Bogolyubov's lemma and Plünnecke-Ruzsa sumset estimates: if $A$ is 3-AP-free, then $2A - 2A$ is large, and by iterating, the density increment is $\\Omega(1/(\\log N)^{O(1)})$ rather than $\\Omega(1/\\log\\log N)$. Bloom-Sisask introduced an entropy increment replacing the density increment: they tracked Shannon entropy of $A$'s distribution on subprogressions, yielding $r_3(N) \\leq CN/(\\log N)^{1+c}$ for an absolute $c > 0$.",
     "significance": "key",
     "relatedConcepts": [
       "bourgain",
@@ -151,7 +151,7 @@
     "type": "axiom",
     "title": "Kelley-Meka Theorem (2023)",
     "content": "**KelleyMekaTheorem**: \u2200 C > 0, \u2203 K > 0, \u2200 N \u2265 3:\n  r\u2083(N) \u2264 K\u00b7N / (log N)^C\n\n**axiom kelley_meka**: KelleyMekaTheorem\n\n**theorem erdos_140_solved** = kelley_meka\n\nThis resolves Erd\u0151s Problem #140 and the $500 prize!",
-    "mathContext": "Kelley-Meka's proof uses a novel approach combining spectral methods with graph theory. The paper appeared in 2023.",
+    "mathContext": "Kelley and Meka's key innovation is a spectral density increment: they show that if $A \\subseteq \\{1,\\ldots,N\\}$ is 3-AP-free with $|A| \\geq \\delta N$, then $A$ must have large $\\ell^2$-mass on a structured set of Fourier coefficients. This spectral structure forces a density increment of $\\delta \\mapsto \\delta + \\Omega(\\delta/(\\log(1/\\delta))^C)$ on a subprogression, which iterates to give $r_3(N) \\leq KN/(\\log N)^C$ for any $C > 0$. The formal statement $\\forall C > 0,\\, \\exists K > 0,\\, \\forall N \\geq 3:\\; r_3(N) \\leq KN/(\\log N)^C$ captures the full strength.",
     "significance": "key",
     "relatedConcepts": [
       "kelley-meka-2023",
@@ -208,7 +208,7 @@
     "type": "axiom",
     "title": "Behrend Lower Bound",
     "content": "**axiom behrend_lower_bound**:\n  r\u2083(N) \u2265 N \u00b7 exp(-c \u00b7 \u221a(log N))\n\nThis is the best known LOWER bound (1946).\n\n**The Gap**:\n- Upper: O(N / (log N)^C) for all C\n- Lower: \u03a9(N / exp(c \u221alog N))\n\nThe true order of r\u2083(N) remains unknown!",
-    "mathContext": "Behrend constructed 3-AP-free sets in a d-dimensional sphere. The gap between bounds is a major open problem.",
+    "mathContext": "Behrend's construction embeds $\\{1,\\ldots,N\\}$ into $\\mathbb{Z}^d$ (choosing $d \\approx \\sqrt{\\log N}$) and selects elements lying on a sphere $\\{x : |x|^2 = r\\}$. Points on a sphere cannot form a 3-AP (by the parallelogram law), giving a 3-AP-free set of size $\\Omega(N \\cdot \\exp(-c\\sqrt{\\log N}))$. This has been the best lower bound for over 75 years. The gap between Kelley-Meka's $O(N/(\\log N)^C)$ and Behrend's $\\Omega(N/\\exp(c\\sqrt{\\log N}))$ remains one of the most important open problems in additive combinatorics.",
     "significance": "key",
     "relatedConcepts": [
       "behrend-1946",
@@ -292,7 +292,7 @@
     "type": "definition",
     "title": "k-term AP Generalization",
     "content": "**IsAPk k vals**: k values form an arithmetic progression\n  vals(i) = a + i\u00b7d for some a, d with d \u2260 0\n\n**FinsetkAPFree k A**: No k elements of A form a k-AP\n\n**rk k N**: Maximum size of k-AP-free subset of {0,...,N}\n\n**ErdosAPConjecture**: For all k \u2265 3, C > 0:\n  r_k(N) = O(N / (log N)^C)\n\nThis is OPEN for k \u2265 4!",
-    "mathContext": "Szemer\u00e9di's theorem (1975) shows r_k(N) = o(N), but the quantitative bounds are much weaker for k \u2265 4.",
+    "mathContext": "Szemer\u00e9di's theorem (1975) gives $r_k(N) = o(N)$ for all $k$, but the best quantitative bound for $k \\geq 4$ is far weaker: Gowers (2001) proved $r_k(N) \\leq N/(\\log\\log N)^{c_k}$ using higher-order Fourier analysis and the Gowers $U^{k-1}$-norm. For $k = 4$, Green-Tao (2017) improved this to $r_4(N) \\leq N/(\\log N)^{c}$. Erd\u0151s's generalized conjecture $r_k(N) = O(N/(\\log N)^C)$ for all $C > 0$ and $k \\geq 4$ remains completely open.",
     "significance": "key",
     "relatedConcepts": [
       "k-AP",

--- a/src/data/proofs/erdos-140/meta.json
+++ b/src/data/proofs/erdos-140/meta.json
@@ -32,16 +32,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "Roth (1953) proved r₃(N) = o(N), showing 3-AP-free sets have density 0. Decades of improvements followed: Bourgain (2008), Sanders (2011), Bloom-Sisask (2020). Kelley-Meka (2023) finally proved Erdős's conjecture that r₃(N) = O(N/(log N)^C) for all C > 0, resolving the $500 prize.",
+    "historicalContext": "Roth (1953) proved $r_3(N) = o(N)$ using Fourier analysis on $\\mathbb{Z}/N\\mathbb{Z}$ — the density increment argument. His method showed that any dense set either has a large Fourier coefficient (yielding a density increment on a subprogression) or contains a 3-AP. This earned him the Fields Medal (1958). Bourgain (1999, 2008) refined the Fourier approach to $O(N/\\sqrt{\\log\\log N})$. Sanders (2011) introduced Bogolyubov's method and iterated Plünnecke-Ruzsa estimates to achieve $O(N(\\log\\log N)^5/\\log N)$ — the first bound with $\\log N$ in the denominator. Bloom-Sisask (2020) used entropy increment methods to reach $O(N/(\\log N)^{1+c})$. Finally, Kelley and Meka (2023) proved the full conjecture $r_3(N) = O(N/(\\log N)^C)$ for all $C > 0$, using a novel spectral approach: they showed that 3-AP-free sets must have spectral structure that forces their density to concentrate, contradicting the assumed density bound. This resolved Erdős's $500 prize after 70 years.",
     "problemStatement": "Define r₃(N) = max{ |A| : A ⊆ {1,...,N}, A contains no non-trivial 3-term arithmetic progression }. Erdős conjectured that r₃(N) ≪ N/(log N)^C for every C > 0. Kelley and Meka (2023) proved this is true.",
-    "proofStrategy": "The formalization defines 3-APs, the Roth number r₃(N), and proves it's achieved by some set. Historical bounds by Roth, Bourgain, Sanders, and Bloom-Sisask are recorded as axioms. The Kelley-Meka theorem is the main axiom resolving the problem. Corollaries about density decay and the k-term generalization are included.",
+    "proofStrategy": "The formalization proceeds in layers. First, 3-APs are defined via the condition $2b = a + c$ with $a < b < c$, and $r_3(N)$ is defined as the supremum over cardinalities of 3-AP-free subsets of $\\{0,\\ldots,N\\}$. The key verified result is `r3_achieved`: this supremum is attained, proved by showing the set of cardinalities is nonempty (contains 0 from $\\emptyset$) and bounded by $N+1$. Historical bounds are axiomatized as a progression of upper bounds. The Kelley-Meka theorem is stated as $\\forall C > 0,\\, \\exists K > 0,\\, \\forall N \\geq 3:\\; r_3(N) \\leq KN/(\\log N)^C$, and used to derive corollaries about density decay. The $k$-term generalization connects to Szemerédi's theorem via the definitions of $r_k(N)$ and `ErdosAPConjecture`.",
     "keyInsights": [
-      "r₃(N) is well-defined and achieved (verified theorem)",
-      "Historical progression: o(N) → O(N/√log log N) → O(N log log N⁵/log N) → O(N/(log N)^{1+c})",
-      "Kelley-Meka (2023): r₃(N) = O(N/(log N)^C) for ALL C > 0",
-      "Behrend lower bound: r₃(N) ≥ N/exp(c√log N) - gap remains open",
-      "{1,2,4,5,10,11,13,14} is verified 3-AP-free (first 8 of greedy sequence)",
-      "k ≥ 4 case remains OPEN"
+      "The supremum defining $r_3(N)$ is achieved — a clean application of finiteness of $\\{0,\\ldots,N\\}$ (verified theorem `r3_achieved`)",
+      "Each historical bound required fundamentally new techniques: Fourier analysis (Roth), nilsequences (Sanders), entropy methods (Bloom-Sisask), spectral density (Kelley-Meka)",
+      "Kelley-Meka's bound $r_3(N) = O(N/(\\log N)^C)$ for ALL $C > 0$ is qualitatively the strongest possible bound of this form — it means $r_3(N)$ decays faster than any fixed power of $\\log N$",
+      "The Behrend construction gives $r_3(N) \\geq N \\cdot \\exp(-c\\sqrt{\\log N})$ using 3-AP-free sets on high-dimensional spheres — the gap between this and Kelley-Meka remains a central open problem in additive combinatorics",
+      "The formalization verifies $\\{1,2,4,5,10,11,13,14\\}$ is 3-AP-free by exhaustive case analysis — these are the first 8 elements of the greedy sequence A003278, whose growth rate is approximately $n^{\\log 2/\\log 3}$",
+      "The equivalence `r3 N = rk 3 N` bridges the specific and general definitions, enabling the Kelley-Meka theorem to resolve the $k=3$ case of Erdős's generalized conjecture while $k \\geq 4$ remains wide open"
     ]
   },
   "sections": [
@@ -125,14 +125,29 @@
   ],
   "crossReferences": [
     {
-      "targetId": "erdos-16",
+      "targetId": "szemeredi-theorem",
+      "relationship": "generalization",
+      "description": "Szemerédi's theorem generalizes Roth's theorem to k-term APs: every dense set contains arbitrarily long APs. Erdős #140 is the quantitative refinement for k=3"
+    },
+    {
+      "targetId": "erdos-1097",
       "relationship": "related",
-      "description": "Erdős #16 concerns Szemerédi regularity and density of arithmetic progressions — the same circle of problems that includes 3-AP density bounds"
+      "description": "Erdős #1097 studies common differences in three-term APs within finite sets — a complementary structural question about the same 3-AP objects"
+    },
+    {
+      "targetId": "erdos-1134",
+      "relationship": "related",
+      "description": "Erdős #1134 concerns density of sets closed under affine maps — related density-theoretic techniques in additive combinatorics"
+    },
+    {
+      "targetId": "erdos-125",
+      "relationship": "related",
+      "description": "Erdős #125 asks about positive density of digit-restricted sumsets — another problem at the intersection of density and additive structure"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #140 is SOLVED (Kelley-Meka 2023). The maximum size of a 3-AP-free subset of {1,...,N} satisfies r₃(N) = O(N/(log N)^C) for all C > 0. This 70-year problem from Roth's 1953 breakthrough was resolved with a novel spectral approach.",
-    "implications": "The Kelley-Meka theorem is a major breakthrough in additive combinatorics. It essentially determines the order of r₃(N) up to the gap with Behrend's lower bound. The techniques may apply to other Ramsey-type problems.",
+    "summary": "Erdős Problem #140 is SOLVED (Kelley-Meka 2023). The maximum size of a 3-AP-free subset of $\\{1,\\ldots,N\\}$ satisfies $r_3(N) = O(N/(\\log N)^C)$ for all $C > 0$. This 70-year journey from Roth's 1953 Fourier-analytic breakthrough was completed with a novel spectral density approach.",
+    "implications": "The Kelley-Meka theorem is a landmark in additive combinatorics. It pins $r_3(N)$ between $N \\cdot \\exp(-c\\sqrt{\\log N})$ (Behrend) and $N/(\\log N)^C$ for any $C$ — a narrow but stubborn gap. Their spectral techniques have influenced subsequent work on cap sets in $\\mathbb{F}_3^n$ and other Ramsey-type density problems. The formalization's bridge between $r_3$ and $r_k$ via `r3_eq_rk_3` makes precise the relationship between the solved $k=3$ case and the open generalized Erdős conjecture for $k \\geq 4$.",
     "openQuestions": [
       "What is the true order of r₃(N)? (Behrend gap)",
       "Does r_k(N) = O(N/(log N)^C) hold for k ≥ 4?",


### PR DESCRIPTION
## Summary

Enrichment passes for seven gallery entries.

| Entry | Key Improvements |
|-------|-----------------|
| erdos-140 | +prerequisites (13 ann), +3 cross-refs, history→979 chars |
| erdos-16 | Fixed 12 section summaries, history→1114 chars |
| erdos-167 | Fixed 7 section summaries, history→1031 chars, +2 cross-refs |
| erdos-17 | History→1246 chars (cluster prime details) |
| erdos-180 | +prerequisites (7 ann), +3 cross-refs, history→1147 chars |
| erdos-185 | History→1111 chars (cap set/CLP), +1 cross-ref |
| erdos-188 | +prerequisites (13 ann), +3 cross-refs, history→1257 chars |

**Axiom integrity**: All verified correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)