### PR TITLE
Enrich 4 proofs: fix annotation types, add prerequisites and crossReferences

### DIFF
--- a/src/data/proofs/erdos-369/annotations.json
+++ b/src/data/proofs/erdos-369/annotations.json
@@ -87,7 +87,7 @@
     "id": "ann-e369-balog-wooley",
     "proofId": "erdos-369",
     "range": { "startLine": 109, "endLine": 120 },
-    "type": "theorem",
+    "type": "axiom",
     "title": "Balog-Wooley Partial Result (1998)",
     "content": "**balog_wooley_infinitely_many**: For any smoothness bound growing to $\\infty$, there are infinitely many $n$ with both $n$ and $n+1$ being smooth. This gives 'infinitely many' but not 'all sufficiently large.'",
     "significance": "critical",

--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -42,9 +42,37 @@
         "relation": "Erdős #143 studies dilation-avoiding sets, another problem where prime factorization structure controls set density"
       }
     ],
-    "axiomCount": 1
+    "axiomCount": 1,
+    "author": "Erdős-Graham (1980), Balog-Wooley (1998)",
+    "prerequisites": [
+      "smooth-numbers",
+      "Dickman-function",
+      "sieve-methods",
+      "analytic-number-theory",
+      "prime-factorization",
+      "abc-conjecture"
+    ]
   },
+  "crossReferences": [
+    {
+      "targetId": "erdos-370",
+      "relationship": "related",
+      "description": "Erdős #370 asks about smooth numbers in short intervals — a closely related distributional question about how smooth numbers cluster"
+    },
+    {
+      "targetId": "erdos-143",
+      "relationship": "related",
+      "description": "Erdős #143 studies dilation-avoiding sets, another problem where prime factorization structure controls combinatorial density"
+    }
+  ],
   "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Docstring defining Erdős Problem #369: for $\\varepsilon > 0$ and $k \\geq 2$, does $\\{1,\\ldots,n\\}$ contain $k$ consecutive $n^\\varepsilon$-smooth integers for all large $n$? References Erdős-Graham (1980), Balog-Wooley (1998). Imports Mathlib for primes, divisibility, and finite sets."
+    },
     {
       "id": "smooth-numbers",
       "title": "Part I: Smooth Numbers",


### PR DESCRIPTION
## Summary
Enrichment pass on 4 gallery entries: erdos-4, erdos-36, erdos-369, erdos-1059

### erdos-4 (Large Prime Gaps)
- Added prerequisites array
- Fixed 9 annotation types: theorem → axiom for axiomatized results

### erdos-369 (Consecutive Smooth Numbers)
- Added prerequisites, author, top-level crossReferences, header section
- Fixed balog_wooley annotation type: theorem → axiom

### erdos-1059 (Primes Minus Factorials)
- Added prerequisites, top-level crossReferences
- Fixed 3 annotation types: theorem → axiom

### erdos-36 (Minimum Overlap)
- Added prerequisites, header section
- Fixed 5 annotation types: theorem → axiom

## Quality improvements
- 18 total annotation type corrections (axioms mislabeled as theorems)
- 4 entries gained prerequisites arrays
- 3 entries gained proper crossReferences
- 2 entries gained header sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)