### PR TITLE
Fix missing implications field in 3 gallery entries

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -87,6 +87,7 @@
   ],
   "conclusion": {
     "summary": "Framework for Archimedes' bounds is complete with 2 sorry targets for the tight π approximations. All other results (8 theorems) are fully proved.",
+    "implications": "Formalizes the classical method of exhaustion for computing pi bounds, bridging ancient geometry with modern proof assistants.",
     "openQuestions": [
       "Can Mathlib's interval arithmetic or norm_num extensions provide the tight π bounds?",
       "Can the half-angle doubling method (Archimedes' actual approach) be formalized to prove the bounds constructively?"

--- a/src/data/proofs/binomial-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02/meta.json
@@ -34,6 +34,7 @@
   ],
   "conclusion": {
     "summary": "10 theorems proved with 0 sorries, 0 axioms. The algebraic proof of Vandermonde's identity via polynomial coefficient comparison is fully formalized.",
+    "implications": "Establishes the polynomial coefficient comparison technique as a reusable proof strategy for combinatorial identities in Lean 4.",
     "openQuestions": [
       "Can the q-Vandermonde identity for Gaussian binomial coefficients be formalized?",
       "Can the Lindström-Gessel-Viennot lemma be derived from this algebraic framework?"

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-01/meta.json
@@ -42,6 +42,7 @@
   ],
   "conclusion": {
     "summary": "14 theorems proved with 0 sorries and 0 axioms, completing the structural characterization of ω₁.",
+    "implications": "Provides a complete formal foundation for first uncountable ordinal properties, enabling further set-theoretic constructions in Lean 4.",
     "openQuestions": [
       "Can the generalized Hartogs theorem (for any infinite cardinal κ, the set of ordinals of cardinality < κ has cardinality κ) be formalized?",
       "Can König's theorem (cof(ℵ_ω) > ℵ₀) be proved for singular cardinals?"


### PR DESCRIPTION
## Summary
- Add required `implications` field to `ProofConclusion` in 3 gallery meta.json files that were missing it
- Fixes build failure caused by TypeScript type checking

## Test plan
- [ ] `pnpm build` passes without TS errors

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>