### PR TITLE
Enrich 4 entries: area-of-circle-oq-03-oq-02, angle-trisection-oq-02-oq-01, amgm-oq-03-oq-01, bezout-oq-03-oq-01-oq-01

### DIFF
--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-bezout-oq03-oq01-oq01-00-preamble",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "context",
+    "title": "Imports and Setup",
+    "content": "Imports `ZMod.Basic` (the 2-fold CRT), `Int.GCD` (integer GCD), `Coprime.Basic` (coprimality and `RingEquiv.prodCongr`), and Mathlib tactics. Sets `maxHeartbeats 800000` for the computationally intensive `by decide` coprimality checks.",
+    "mathContext": "The key imports provide: `ZMod.chineseRemainder` ($\\mathbb{Z}/mn\\mathbb{Z} \\cong \\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}$ for $\\gcd(m,n)=1$), `Nat.Coprime.mul_right` (coprimality propagation), and `RingEquiv.prodCongr` (lifting isomorphisms into products).",
+    "significance": "context",
+    "relatedConcepts": ["ZMod", "Nat.Coprime", "maxHeartbeats"],
+    "prerequisites": ["Lean 4 syntax", "Mathlib ZMod"]
+  },
+  {
     "id": "ann-bezout-oq03-oq01-oq01-01",
     "proofId": "bezout-identity-oq-03-oq-01-oq-01",
     "range": { "startLine": 33, "endLine": 60 },
@@ -34,5 +46,29 @@
     "significance": "supporting",
     "relatedConcepts": ["Euler totient", "Nat.totient_mul", "multiplicative functions"],
     "prerequisites": ["coprimality", "Nat.totient"]
+  },
+  {
+    "id": "ann-bezout-oq03-oq01-oq01-04-explicit",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-01",
+    "range": { "startLine": 62, "endLine": 98 },
+    "type": "definition",
+    "title": "Explicit 3-fold and 4-fold CRT",
+    "content": "**crt3**: $\\mathbb{Z}/(abc)\\mathbb{Z} \\cong \\mathbb{Z}/a\\mathbb{Z} \\times (\\mathbb{Z}/b\\mathbb{Z} \\times \\mathbb{Z}/c\\mathbb{Z})$\n\nComposed from two 2-fold CRTs: first split $a(bc) \\to a \\times bc$, then split $bc \\to b \\times c$.\n\n**crt4**: $\\mathbb{Z}/(abcd)\\mathbb{Z} \\cong \\mathbb{Z}/a\\mathbb{Z} \\times (\\mathbb{Z}/b\\mathbb{Z} \\times (\\mathbb{Z}/c\\mathbb{Z} \\times \\mathbb{Z}/d\\mathbb{Z}))$\n\nComposed from three 2-fold CRTs. Uses `ring` to prove $\\mathbb{N}$ associativity and `Nat.Coprime.mul_right` for coprimality propagation.",
+    "mathContext": "The explicit constructions avoid the `CRTProd` recursive type by using right-associated nested pairs directly. The $\\mathbb{N}$ associativity $abc = a(bc)$ requires proof because $\\mathbb{N}$ multiplication is not definitionally associative in Lean 4 (it is computationally, but the kernel needs a proof term).",
+    "significance": "supporting",
+    "relatedConcepts": ["ring tactic", "associativity", "RingEquiv.prodCongr", "composition"],
+    "prerequisites": ["ZMod.chineseRemainder", "Nat.Coprime.mul_right"]
+  },
+  {
+    "id": "ann-bezout-oq03-oq01-oq01-05-examples",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-01",
+    "range": { "startLine": 210, "endLine": 225 },
+    "type": "theorem",
+    "title": "Concrete Examples: $\\mathbb{Z}/30\\mathbb{Z}$ and $\\mathbb{Z}/210\\mathbb{Z}$",
+    "content": "**crt_kfold_2_3_5**: $\\mathbb{Z}/30\\mathbb{Z} \\cong \\mathbb{Z}/2\\mathbb{Z} \\times \\mathbb{Z}/3\\mathbb{Z} \\times \\mathbb{Z}/5\\mathbb{Z}$ (via general k-fold)\n\n**crt_explicit_2_3_5_7**: $\\mathbb{Z}/210\\mathbb{Z} \\cong \\mathbb{Z}/2\\mathbb{Z} \\times \\mathbb{Z}/3\\mathbb{Z} \\times \\mathbb{Z}/5\\mathbb{Z} \\times \\mathbb{Z}/7\\mathbb{Z}$ (via explicit crt4)\n\n**totient_30**: $\\varphi(30) = \\varphi(2) \\cdot \\varphi(3) \\cdot \\varphi(5) = 1 \\cdot 2 \\cdot 4 = 8$\n\nAll coprimality conditions verified by `decide` (computable in Lean 4).",
+    "mathContext": "$30 = 2 \\times 3 \\times 5$ and $210 = 2 \\times 3 \\times 5 \\times 7$ are the smallest products of the first 3 and 4 primes. The CRT decomposes $\\mathbb{Z}/30\\mathbb{Z}$ into three 'coordinates': residue mod 2, mod 3, and mod 5. For example, $7 \\bmod 30$ maps to $(1, 1, 2) \\in \\mathbb{Z}/2 \\times \\mathbb{Z}/3 \\times \\mathbb{Z}/5$.",
+    "significance": "supporting",
+    "relatedConcepts": ["primorial", "by decide", "totient computation"],
+    "prerequisites": ["crt3", "crt4", "crtKFold", "totient_prod_pairwise_coprime"]
   }
 ]

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/meta.json
@@ -100,6 +100,23 @@
       "summary": "Concrete instances: ℤ/30ℤ ≅ ℤ/2ℤ × ℤ/3ℤ × ℤ/5ℤ and ℤ/210ℤ ≅ ℤ/2ℤ × ℤ/3ℤ × ℤ/5ℤ × ℤ/7ℤ. Totient example: φ(30) = φ(2)·φ(3)·φ(5)."
     }
   ],
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity",
+      "relationship": "extends",
+      "description": "The root formalization: Bézout's identity ($\\gcd(a,b) = ax + by$). The CRT builds on coprimality ($\\gcd = 1$), which is the Bézout case yielding $1 = ax + by$."
+    },
+    {
+      "targetId": "bezout-identity-oq-03",
+      "relationship": "extends",
+      "description": "Direct grandparent: explores the 2-fold CRT and its ring-theoretic formulation. This entry generalizes to arbitrary $k$-fold products."
+    },
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "related",
+      "description": "The Fundamental Theorem of Arithmetic (unique prime factorization) provides the canonical pairwise coprime decomposition $n = p_1^{a_1} \\cdots p_k^{a_k}$, making the $k$-fold CRT applicable to any modulus."
+    }
+  ],
   "conclusion": {
     "summary": "This formalization proves the k-fold Chinese Remainder Theorem with 0 axioms and 0 sorries: ZMod (∏ nᵢ) ≅ ∏ᵢ ZMod nᵢ for pairwise coprime nᵢ. The proof constructs the isomorphism by induction using Mathlib's 2-fold chineseRemainder, with explicit specializations for 3 and 4 moduli. The k-fold Euler totient multiplicativity follows as a corollary.",
     "implications": "**For number theory**: The k-fold CRT provides the foundation for prime factorization-based decompositions, Hensel lifting, and number-theoretic algorithms.\n\n**For algebra**: Demonstrates the pattern of building k-ary constructions from binary ones using induction on lists.\n\n**For Mathlib**: Could be contributed as a generalization of the existing ZMod.chineseRemainder.",


### PR DESCRIPTION
## Summary
Batch enrichment of 4 gallery entries with annotations, cross-references, and deepened metadata.

### area-of-circle-oq-03-oq-02 (Archimedes Pi Bounds)
- Created 6 annotations from empty: Niven/Dalzell integral, inscribed polygon bound proof walkthrough
- Deepened historicalContext with Archimedes' doubling method, half-angle formulas
- Added cross-references to area-of-circle family

### angle-trisection-oq-02-oq-01 (Wantzel-Galois via Mathlib)
- Created 6 annotations from empty: tower law proof walkthrough, 2-group divisibility, constructibility bridge
- Deepened historicalContext with Wantzel (1837) and Galois (1832) background
- Added cross-references to angle-trisection family and abel-ruffini

### amgm-inequality-oq-03-oq-01 (Negative Power Mean)
- Added 2 annotations: HM ≤ GM theorem, interpolation chain summary
- Added cross-references to amgm-inequality family, new HM-GM section

### bezout-identity-oq-03-oq-01-oq-01 (k-fold CRT)
- Added 3 annotations: preamble, explicit 3/4-fold CRT, concrete examples
- Added cross-references to bezout-identity, fundamental-arithmetic

## Test plan
- [x] All 4 meta.json files validate as JSON
- [x] All 4 annotations.json files validate as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)