### PR TITLE
Research: 2D Sperner — prove parity lemma + boundary constraints (1 sorry eliminated)

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ02OQ01.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ02OQ01.lean
@@ -232,7 +232,72 @@ theorem fully_colored_one_door {n : ℕ} (c : Coloring n)
     (t : GridTriangle n) (hfc : IsFullyColored c t) :
     ∃! (e : Fin 3 × Fin 3), e.1 < e.2 ∧
       IsDoor c (t.vertices e.1) (t.vertices e.2) := by
-  sorry
+  -- Step 1: The coloring restricted to this triangle is surjective (image = Fin 3)
+  have hsurj : Function.Surjective (c ∘ t.vertices) := by
+    intro y
+    have : y ∈ Finset.image (c ∘ t.vertices) Finset.univ := by
+      unfold IsFullyColored at hfc; rw [hfc]; fin_cases y <;> simp
+    simpa using this
+  -- Step 2: Surjective endomorphism on finite type is injective
+  have hinj : Function.Injective (c ∘ t.vertices) :=
+    Finite.injective_iff_surjective.mpr hsurj
+  -- Step 3: Find the vertices with colors 0 and 1
+  obtain ⟨i₀, hi₀⟩ := hsurj (0 : Fin 3)
+  obtain ⟨i₁, hi₁⟩ := hsurj (1 : Fin 3)
+  have hne : i₀ ≠ i₁ := by
+    intro h; subst h; exact absurd (hi₀.symm.trans hi₁) (by decide)
+  -- Step 4: Any door must connect the unique 0-vertex and 1-vertex
+  have unique : ∀ (a b : Fin 3), IsDoor c (t.vertices a) (t.vertices b) →
+      (a = i₀ ∧ b = i₁) ∨ (a = i₁ ∧ b = i₀) := by
+    intro a b hdoor
+    rcases hdoor with ⟨ha, hb⟩ | ⟨ha, hb⟩
+    · left; exact ⟨hinj (ha.trans hi₀.symm), hinj (hb.trans hi₁.symm)⟩
+    · right; exact ⟨hinj (ha.trans hi₁.symm), hinj (hb.trans hi₀.symm)⟩
+  -- Step 5: Construct the unique door edge (ordered)
+  rcases hne.lt_or_lt with h_lt | h_lt
+  · -- i₀ < i₁: door is (i₀, i₁)
+    refine ⟨(i₀, i₁), ⟨h_lt, Or.inl ⟨hi₀, hi₁⟩⟩, ?_⟩
+    rintro ⟨a, b⟩ ⟨hab, hdoor⟩
+    rcases unique a b hdoor with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩
+    · rfl
+    · exfalso; omega
+  · -- i₁ < i₀: door is (i₁, i₀)
+    refine ⟨(i₁, i₀), ⟨h_lt, Or.inr ⟨hi₁, hi₀⟩⟩, ?_⟩
+    rintro ⟨a, b⟩ ⟨hab, hdoor⟩
+    rcases unique a b hdoor with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩
+    · exfalso; omega
+    · rfl
+
+-- Helper: No {0,1}-doors on left-boundary edges (colors ∈ {0,2})
+private lemma no_door_left_boundary {n : ℕ} (hn : 0 < n) (c : Coloring n)
+    (hc : IsSperner hn c) (j : ℕ) (hj : j > 0) (hj' : j < n) :
+    ¬ IsDoor c ⟨0, j, by omega⟩ ⟨0, j + 1, by omega⟩ := by
+  obtain ⟨_, _, _, _, hleft, _⟩ := hc
+  intro hdoor
+  rcases hdoor with ⟨_, h1⟩ | ⟨_, h1⟩
+  · exact hleft ⟨0, j + 1, by omega⟩ rfl (by omega) (by omega) h1
+  · exact hleft ⟨0, j, by omega⟩ rfl (by omega) (by omega) h1
+
+-- Helper: No {0,1}-doors on hypotenuse edges (colors ∈ {1,2})
+private lemma no_door_hypotenuse {n : ℕ} (hn : 0 < n) (c : Coloring n)
+    (hc : IsSperner hn c) (i j : ℕ) (hi : i > 0) (hj : j > 0)
+    (hsum1 : i + j = n) (hsum2 : (i - 1) + (j + 1) = n) :
+    ¬ IsDoor c ⟨i, j, by omega⟩ ⟨i - 1, j + 1, by omega⟩ := by
+  obtain ⟨_, _, _, _, _, hhyp⟩ := hc
+  intro hdoor
+  rcases hdoor with ⟨h0, _⟩ | ⟨_, h0⟩
+  · exact hhyp ⟨i, j, by omega⟩ hsum1 hi hj h0
+  · exact hhyp ⟨i - 1, j + 1, by omega⟩ hsum2 (by omega) (by omega) h0
+
+-- Proof strategy for sperner_2d:
+-- 1. bottomTransitions c is odd (from bottom_transitions_odd)
+-- 2. Boundary {0,1}-doors appear ONLY on the bottom edge
+--    (left edge: colors ∈ {0,2}, no color 1 → no doors)
+--    (hypotenuse: colors ∈ {1,2}, no color 0 → no doors)
+-- 3. Double-counting: ∑_T doorCount(T) = 2·|interior doors| + |boundary doors|
+-- 4. Each fully-colored triangle has exactly 1 door (fully_colored_one_door)
+-- 5. Each non-fully-colored triangle has 0 or 2 doors (even)
+-- 6. Therefore: #FC ≡ bottomTransitions ≡ 1 (mod 2), so #FC ≥ 1
 
 theorem sperner_2d {n : ℕ} (hn : 0 < n) (c : Coloring n) (hc : IsSperner hn c) :
     ∃ t : GridTriangle n, IsFullyColored c t := by

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -1,0 +1,48 @@
+{
+  "slug": "amgm-inequality-oq-02-oq-01",
+  "title": "Symmetric Polynomial Identity: (∑xᵢ)² = ∑xᵢ² + 2·e₂ via elemSymm Recurrence",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "(∑ i : Fin n, x i) ^ 2 = ∑ i : Fin n, (x i) ^ 2 + 2 * elemSymm 2 x",
+    "plain": "The square of the sum of variables equals the sum of their squares plus twice the second elementary symmetric polynomial.",
+    "whyMatters": []
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-03-22T02:40:00Z",
+    "iteration": 1,
+    "focus": "Already proved in AmgmInequalityOQ02Defs.lean as sq_sum_eq_sum_sq_add_two_elemSymm"
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED: Already formalized as sq_sum_eq_sum_sq_add_two_elemSymm in AmgmInequalityOQ02Defs.lean:195. Proved by induction on n using elemSymm recurrence. 0 sorries, 0 axioms.",
+    "builtItems": [
+      "sq_sum_eq_sum_sq_add_two_elemSymm: (∑xᵢ)² = ∑xᵢ² + 2·e₂ (induction via elemSymm_two_succ)",
+      "Also used in maclaurin_sq_m1_ge_m2_general for the Maclaurin inequality M₁ ≥ M₂"
+    ],
+    "insights": [
+      "Proof uses elemSymm_two_succ recurrence: e₂(x₀,...,xₙ) = e₂(x₀,...,xₙ₋₁) + xₙ·e₁(x₀,...,xₙ₋₁)",
+      "The inductive step closes via nlinarith with sq_nonneg hints"
+    ],
+    "nextSteps": []
+  },
+  "tags": ["seeker-selected", "algebra", "inequalities", "symmetric-polynomials"],
+  "started": "2026-03-22T02:40:00Z",
+  "lastUpdate": "2026-03-22T02:40:00Z",
+  "significance": 6,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/AmgmInequalityOQ02Defs.lean",
+      "filename": "AmgmInequalityOQ02Defs.lean",
+      "lineCount": 325,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false
+    }
+  ]
+}

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-21T17:07:38.705Z",
-    "iteration": 1,
-    "focus": "2D Sperner infrastructure built, proofs outlined",
+    "iteration": 2,
+    "focus": "Proved fully_colored_one_door, added boundary lemmas. 2 sorries remain.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,34 +29,39 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created BrouwerFixedPointOQ02OQ01.lean (213 lines). Grid triangulation, Sperner coloring, door-counting proof architecture. 5 sorries (all with proof outlines). Next: prove transitions_parity_aux, then bottom_transitions_odd, then sperner_2d.",
+    "progressSummary": "PROGRESS: 2 sorries remain (down from 3). Proved fully_colored_one_door via bijection+case-analysis. Added boundary no-door lemmas for left edge and hypotenuse. Detailed proof strategy for sperner_2d documented.",
     "builtItems": [
       "BrouwerFixedPointOQ02OQ01.lean: 213 lines, grid triangulation + Sperner coloring + 2D lemma statement",
       "GridVertex, GridTriangle, TriType: core triangulation types",
       "IsSperner: Sperner boundary coloring condition",
       "IsFullyColored, IsDoor: key predicates for door-counting proof",
       "sperner_2d: main existence theorem (sorry, proof outlined)",
-      "approximate_fixed_point_2d: application to continuous maps (sorry)"
+      "approximate_fixed_point_2d: application to continuous maps (sorry)",
+      "fully_colored_one_door: proved via surjectivity\u2192injectivity\u2192uniqueness argument",
+      "no_door_left_boundary: left boundary has no {0,1}-doors (colors in {0,2})",
+      "no_door_hypotenuse: hypotenuse has no {0,1}-doors (colors in {1,2})"
     ],
     "insights": [
       "Mathlib has NO SimplicialComplex or Sperner infrastructure",
-      "Existing BrouwerFixedPointOQ02.lean has 1D Sperner (discrete IVT), PPAD structure — 0 sorries",
-      "BrouwerFixedPointOQ02Ext.lean has contraction uniqueness, error bounds, 1D Sperner — 0 sorries",
+      "Existing BrouwerFixedPointOQ02.lean has 1D Sperner (discrete IVT), PPAD structure \u2014 0 sorries",
+      "BrouwerFixedPointOQ02Ext.lean has contraction uniqueness, error bounds, 1D Sperner \u2014 0 sorries",
       "Higher-dim Sperner requires: triangulation definition, coloring, boundary conditions, parity argument",
       "2D Sperner is tractable but needs ~200-300 lines of new definitions",
       "Standard proof uses path-following on dual graph of boundary edges",
-      "Grid triangulation approach: GridVertex(i,j) with i+j≤n, two triangle types (lower/upper) per grid cell",
+      "Grid triangulation approach: GridVertex(i,j) with i+j\u2264n, two triangle types (lower/upper) per grid cell",
       "Sperner coloring: vertex conditions at corners + edge exclusion conditions",
-      "Door-counting proof structure: 01-doors on boundary (odd) + interior (pair up) → fully-colored triangles (odd)",
-      "transitions_parity_aux: telescoping in ZMod 2 — #transitions ≡ f(n)+f(0) mod 2"
+      "Door-counting proof structure: 01-doors on boundary (odd) + interior (pair up) \u2192 fully-colored triangles (odd)",
+      "transitions_parity_aux: telescoping in ZMod 2 \u2014 #transitions \u2261 f(n)+f(0) mod 2",
+      "Key proof technique: surjectivity of c\u2218t.vertices on Fin 3 (from image={0,1,2}=univ) implies injectivity via Finite.injective_iff_surjective",
+      "Uniqueness of door: any {0,1}-edge must connect the unique 0-colored and 1-colored vertices; ordering determines the edge",
+      "Boundary analysis complete: only bottom-edge doors exist (left: no color 1; hypotenuse: no color 0)",
+      "sperner_2d proof strategy: parity argument via double-counting. \u2211doorCount(T) = 2*interior + boundary. FC contributes 1, non-FC contributes 0 or 2. So #FC \u2261 bottomTransitions \u2261 1 mod 2."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove transitions_parity_aux (ZMod 2 telescoping by induction)",
-      "Prove bottom_transitions_odd using transitions_parity_aux",
-      "Prove fully_colored_one_door (counting argument on Fin 3 colors)",
-      "Prove sperner_2d via door-counting + parity",
-      "Prove approximate_fixed_point_2d using sperner_2d + continuity"
+      "Prove sperner_2d via ZMod 2 double-counting (key: enumerate triangles, classify edges as interior/boundary)",
+      "Alternative: row-sweep approach processing strips j\u2192j+1, telescoping htrans(0)+htrans(n) = 1+0 = 1",
+      "Prove approximate_fixed_point_2d from sperner_2d (construct Sperner coloring from continuous map)"
     ]
   },
   "tags": [
@@ -74,7 +79,7 @@
     "mathlib": []
   },
   "started": "2026-03-21T17:07:38.705Z",
-  "lastUpdate": "2026-03-21T17:07:38.705Z",
+  "lastUpdate": "2026-03-22T02:30:00Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Research session covering 3 problems:
1. **brouwer-fixed-point-oq-02-oq-01** (2D Sperner): proved fully_colored_one_door + boundary lemmas
2. **amgm-inequality-oq-02-oq-01**: documented as already solved (sq_sum_eq_sum_sq_add_two_elemSymm)
3. **cauchy-schwarz-integral-oq-02-oq-01** (Strict Minkowski): new formalization, main iff theorem proved

## Progress
- **Proved `fully_colored_one_door`**: In a fully-colored triangle, exactly one edge is a "door" (colors {0,1}). Proof via surjectivity→injectivity on Fin 3 + uniqueness argument.
- **Proved `no_door_left_boundary`** and **`no_door_hypotenuse`**: Sperner boundary constraints.
- **Created `CauchySchwarzIntegralOQ02OQ01.lean`**: Strict Minkowski inequality ‖f+g‖ = ‖f‖+‖g‖ ↔ ‖f‖•g = ‖g‖•f. Main theorem proved, 2 algebra helper sorries remain.
- **Documented amgm-inequality-oq-02-oq-01** as already completed.

## Status
**Outcome**: progress
**Sorries eliminated**: 1 (Sperner fully_colored_one_door)
**New sorries**: 2 (Strict Minkowski algebra helpers) + 2 (Sperner sperner_2d, approximate_fixed_point_2d)

🤖 Generated by researcher-5