### PR TITLE
Enrich 6 proofs + fix 212 status metadata entries

### DIFF
--- a/src/data/proofs/erdos-10/meta.json
+++ b/src/data/proofs/erdos-10/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/10",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos10Problem.lean",
     "leanFile": "Proofs/Erdos10Problem.lean",
     "tags": [
@@ -17,7 +17,7 @@
       "powers of 2",
       "density"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 10,
     "erdosUrl": "https://erdosproblems.com/10",

--- a/src/data/proofs/erdos-101/meta.json
+++ b/src/data/proofs/erdos-101/meta.json
@@ -5,7 +5,7 @@
   "description": "Given n points in ℝ² with no five collinear, is the number of lines containing exactly four points o(n²)? Grünbaum: ≫ n^{3/2}. Solymosi–Stojaković: n^{2−O(1/√log n)}. Open.",
   "meta": {
     "erdosNumber": 101,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "combinatorial-geometry",

--- a/src/data/proofs/erdos-1012/meta.json
+++ b/src/data/proofs/erdos-1012/meta.json
@@ -7,7 +7,7 @@
     "author": "Woodall (1972)",
     "sourceUrl": "https://erdosproblems.com/1012",
     "date": "1972",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1012Problem.lean",
     "tags": [
       "graph-theory",

--- a/src/data/proofs/erdos-1013/meta.json
+++ b/src/data/proofs/erdos-1013/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdos",
     "sourceUrl": "https://erdosproblems.com/1013",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1013Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "Mycielski construction",
       "Ramsey theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1013,
     "erdosUrl": "https://erdosproblems.com/1013",

--- a/src/data/proofs/erdos-1014/meta.json
+++ b/src/data/proofs/erdos-1014/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "erdosNumber": 1014,
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1014Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1016/meta.json
+++ b/src/data/proofs/erdos-1016/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdos, Bondy",
     "sourceUrl": "https://erdosproblems.com/1016",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1016Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "extremal graph theory",
       "Hamiltonian graphs"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1016,
     "erdosUrl": "https://erdosproblems.com/1016",

--- a/src/data/proofs/erdos-102/meta.json
+++ b/src/data/proofs/erdos-102/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Purdy",
     "sourceUrl": "https://erdosproblems.com/102",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos102Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "collinearity",
       "Szemerédi-Trotter"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 102,
     "erdosUrl": "https://erdosproblems.com/102",

--- a/src/data/proofs/erdos-1032/meta.json
+++ b/src/data/proofs/erdos-1032/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1032",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1032Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "critical-graphs",
       "minimum-degree"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1032,
     "erdosUrl": "https://erdosproblems.com/1032",

--- a/src/data/proofs/erdos-1035/meta.json
+++ b/src/data/proofs/erdos-1035/meta.json
@@ -15,7 +15,7 @@
       "extremal-graph-theory",
       "minimum-degree"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1035,
     "erdosUrl": "https://erdosproblems.com/1035",

--- a/src/data/proofs/erdos-1051/meta.json
+++ b/src/data/proofs/erdos-1051/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1051",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1051Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1055/meta.json
+++ b/src/data/proofs/erdos-1055/meta.json
@@ -5,7 +5,7 @@
   "description": "Classify primes by the factorization depth of p+1. Class 1: p+1 is 3-smooth. Class r: all prime factors of p+1 have class ≤ r-1. Are there infinitely many primes in each class? How does p_r^{1/r} grow? Status: OPEN.",
   "meta": {
     "erdosNumber": 1055,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",

--- a/src/data/proofs/erdos-1056/meta.json
+++ b/src/data/proofs/erdos-1056/meta.json
@@ -5,7 +5,7 @@
   "description": "For k ≥ 2, does there exist a prime p and k consecutive intervals whose products are all ≡ 1 (mod p)? Known for k=2 (p=11, Erdős 1979) and k=3 (p=17, Makowski 1983). Guy's Problem A15. Status: OPEN.",
   "meta": {
     "erdosNumber": 1056,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",

--- a/src/data/proofs/erdos-1062/meta.json
+++ b/src/data/proofs/erdos-1062/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1062",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1062Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1068/meta.json
+++ b/src/data/proofs/erdos-1068/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Hajnal",
     "sourceUrl": "https://erdosproblems.com/1068",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1068Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1071/meta.json
+++ b/src/data/proofs/erdos-1071/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Tóth",
     "sourceUrl": "https://erdosproblems.com/1071",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1071Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "packing",
       "maximal-independent-set"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1071,
     "erdosUrl": "https://erdosproblems.com/1071",

--- a/src/data/proofs/erdos-1072/meta.json
+++ b/src/data/proofs/erdos-1072/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Hardy–Subbarao",
     "sourceUrl": "https://erdosproblems.com/1072",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1072Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1084/meta.json
+++ b/src/data/proofs/erdos-1084/meta.json
@@ -5,7 +5,7 @@
   "description": "Let f_d(n) be the maximum number of unit-distance pairs among n points in ℝ^d with all pairwise distances ≥ 1. For d=2, Harborth gave the exact formula. For d=3, Erdős conjectured f_3(n) = 6n - Θ(n^{2/3}). Status: OPEN (d ≥ 3).",
   "meta": {
     "erdosNumber": 1084,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "discrete-geometry",

--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Hajnal–Szemerédi",
     "sourceUrl": "https://erdosproblems.com/1092",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1092Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1093/meta.json
+++ b/src/data/proofs/erdos-1093/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Lacampagne–Selfridge",
     "sourceUrl": "https://erdosproblems.com/1093",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1093Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1094/meta.json
+++ b/src/data/proofs/erdos-1094/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1094",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1094Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1097/meta.json
+++ b/src/data/proofs/erdos-1097/meta.json
@@ -15,7 +15,7 @@
       "Kakeya conjecture",
       "Bourgain"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1097,
     "erdosUrl": "https://erdosproblems.com/1097",

--- a/src/data/proofs/erdos-1103/meta.json
+++ b/src/data/proofs/erdos-1103/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1103",
     "date": "c. 1970s",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1103Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "growth-rates",
       "additive-combinatorics"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1103,
     "erdosUrl": "https://erdosproblems.com/1103",

--- a/src/data/proofs/erdos-1117/meta.json
+++ b/src/data/proofs/erdos-1117/meta.json
@@ -5,7 +5,7 @@
   "description": "For a non-monomial entire f, let ν(r) count maximum modulus points on |z|=r. Can lim sup ν(r) = ∞? YES (Herzog–Piranian 1968). Can lim inf ν(r) = ∞? OPEN. Approximate answer by Glücksam–Pardo-Simón (2024).",
   "meta": {
     "erdosNumber": 1117,
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1117Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1120/meta.json
+++ b/src/data/proofs/erdos-1120/meta.json
@@ -16,7 +16,7 @@
       "path-length",
       "geometry"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1120,
     "erdosUrl": "https://erdosproblems.com/1120",

--- a/src/data/proofs/erdos-1130/meta.json
+++ b/src/data/proofs/erdos-1130/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1130",
     "date": "1947",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1130Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "analysis",
       "lebesgue-function"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1130,
     "erdosUrl": "https://erdosproblems.com/1130",

--- a/src/data/proofs/erdos-1131/meta.json
+++ b/src/data/proofs/erdos-1131/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Szabados, Varma, Vértesi",
     "sourceUrl": "https://erdosproblems.com/1131",
     "date": "1994",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1131Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-114/meta.json
+++ b/src/data/proofs/erdos-114/meta.json
@@ -5,7 +5,7 @@
   "description": "For monic degree-n polynomials p(z), is the arc length of {|p(z)|=1} maximized by z^n-1? Tao (2025) proved this for large n. Solved for n=2 (Eremenko-Hayman 1999). $250 bounty. Status: OPEN (all n).",
   "meta": {
     "erdosNumber": 114,
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos114Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-115/meta.json
+++ b/src/data/proofs/erdos-115/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/115",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos115Problem.lean",
     "tags": [
       "erdos",
@@ -14,7 +14,7 @@
       "polynomials",
       "complex analysis"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 115,
     "erdosUrl": "https://erdosproblems.com/115",

--- a/src/data/proofs/erdos-1159/meta.json
+++ b/src/data/proofs/erdos-1159/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdos",
     "sourceUrl": "https://erdosproblems.com/1159",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1159Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-116/meta.json
+++ b/src/data/proofs/erdos-116/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Herzog, Piranian",
     "sourceUrl": "https://erdosproblems.com/116",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos116Problem.lean",
     "tags": [
       "erdos",
@@ -14,7 +14,7 @@
       "polynomial theory",
       "measure theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 116,
     "erdosUrl": "https://erdosproblems.com/116",

--- a/src/data/proofs/erdos-117/meta.json
+++ b/src/data/proofs/erdos-117/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1990, 1997)",
     "sourceUrl": "https://erdosproblems.com/117",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos117Problem.lean",
     "leanFile": "Proofs/Erdos117Problem.lean",
     "tags": [
@@ -16,7 +16,7 @@
       "covering-number",
       "Ramsey-theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 117,
     "erdosUrl": "https://erdosproblems.com/117",

--- a/src/data/proofs/erdos-1177/meta.json
+++ b/src/data/proofs/erdos-1177/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdos, Galvin, Hajnal",
     "sourceUrl": "https://erdosproblems.com/1177",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1177Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "set theory",
       "open problem"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1177,
     "erdosUrl": "https://erdosproblems.com/1177",

--- a/src/data/proofs/erdos-118/meta.json
+++ b/src/data/proofs/erdos-118/meta.json
@@ -5,7 +5,7 @@
   "description": "Does α → (α,3)² imply α → (α,n)² for all n ≥ 3? DISPROVED by Schipperus (1999/2010) and Darby (1999). Larson's counterexample: ω^(ω²) → (ω^(ω²),3)² but ω^(ω²) ↛ (ω^(ω²),5)².",
   "meta": {
     "erdosNumber": 118,
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos118Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-119/meta.json
+++ b/src/data/proofs/erdos-119/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/119",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos119Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "unit-circle",
       "extremal-problems"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 119,
     "erdosUrl": "https://erdosproblems.com/119",

--- a/src/data/proofs/erdos-120/meta.json
+++ b/src/data/proofs/erdos-120/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/120",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos120Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-121/meta.json
+++ b/src/data/proofs/erdos-121/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/121",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos121Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "multiplicative number theory",
       "extremal"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 121,
     "erdosUrl": "https://erdosproblems.com/121",

--- a/src/data/proofs/erdos-122/meta.json
+++ b/src/data/proofs/erdos-122/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/122",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos122Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-124/meta.json
+++ b/src/data/proofs/erdos-124/meta.json
@@ -7,7 +7,7 @@
     "author": "Burr, Erdős, Graham, Li",
     "sourceUrl": "https://erdosproblems.com/124",
     "date": "1996",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos124Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "additive-combinatorics",
       "complete-sequences"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 124,
     "erdosUrl": "https://erdosproblems.com/124",

--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/125",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos125Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-127/meta.json
+++ b/src/data/proofs/erdos-127/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/127",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos127Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-129/meta.json
+++ b/src/data/proofs/erdos-129/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Gyárfás",
     "sourceUrl": "https://erdosproblems.com/129",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos129Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "combinatorics",
       "edge-coloring"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 129,
     "erdosUrl": "https://erdosproblems.com/129",

--- a/src/data/proofs/erdos-130/meta.json
+++ b/src/data/proofs/erdos-130/meta.json
@@ -5,7 +5,7 @@
   "description": "Given an infinite set A ⊆ ℝ² with no 3 collinear and no 4 cocircular points, form the integer distance graph G(A). Can χ(G(A)) be infinite? Anning–Erdős shows the clique number must be finite. Open.",
   "meta": {
     "erdosNumber": 130,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "combinatorial-geometry",

--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/14",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos14Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "sumsets",
       "sidon-sets"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 14,
     "erdosUrl": "https://erdosproblems.com/14",

--- a/src/data/proofs/erdos-142/meta.json
+++ b/src/data/proofs/erdos-142/meta.json
@@ -5,7 +5,7 @@
   "description": "Prove an asymptotic formula for r_k(N), the maximum size of a subset of {1,...,N} with no non-trivial k-term AP. The gap between Behrend's lower bound and Kelley–Meka's upper bound remains enormous even for k=3. Open ($10,000).",
   "meta": {
     "erdosNumber": 142,
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos142Problem.lean",
     "badge": "axiom",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-15/meta.json
+++ b/src/data/proofs/erdos-15/meta.json
@@ -7,7 +7,7 @@
     "author": "Tao (2023, conditional)",
     "sourceUrl": "https://erdosproblems.com/15",
     "date": "2023",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos15Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-151/meta.json
+++ b/src/data/proofs/erdos-151/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/151",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos151Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "independence number",
       "Ramsey theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 151,
     "erdosUrl": "https://erdosproblems.com/151",

--- a/src/data/proofs/erdos-152/meta.json
+++ b/src/data/proofs/erdos-152/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/152",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos152Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-153/meta.json
+++ b/src/data/proofs/erdos-153/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/153",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos153Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-155/meta.json
+++ b/src/data/proofs/erdos-155/meta.json
@@ -5,7 +5,7 @@
   "description": "Let F(N) be the largest Sidon subset of {1,...,N}. Is F(N+k) ≤ F(N)+1 for all sufficiently large N, for every fixed k? Possibly even for k ≈ ε√N. F(N) ~ √N. Status: OPEN.",
   "meta": {
     "erdosNumber": 155,
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos155Problem.lean",
     "badge": "axiom",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -7,7 +7,7 @@
     "author": "Tuza (1981), Haxell-Kohayakawa (1998)",
     "sourceUrl": "https://erdosproblems.com/167",
     "date": "1981",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos167Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-181/meta.json
+++ b/src/data/proofs/erdos-181/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Burr, Erdős (1975)",
     "sourceUrl": "https://erdosproblems.com/181",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos181Problem.lean",
     "leanFile": "Proofs/Erdos181Problem.lean",
     "tags": [
@@ -15,7 +15,7 @@
       "ramsey-theory",
       "hypercube"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 181,
     "erdosUrl": "https://erdosproblems.com/181",

--- a/src/data/proofs/erdos-187/meta.json
+++ b/src/data/proofs/erdos-187/meta.json
@@ -6,12 +6,12 @@
   "meta": {
     "erdosNumber": 187,
     "author": "Erdős",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos187Problem.lean",
     "sourceUrl": "https://erdosproblems.com/187",
     "erdosUrl": "https://erdosproblems.com/187",
     "erdosProblemStatus": "open",
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-190/meta.json
+++ b/src/data/proofs/erdos-190/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/190",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos190Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-193/meta.json
+++ b/src/data/proofs/erdos-193/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Gerver–Ramsey (attributed by Erdős)",
     "sourceUrl": "https://erdosproblems.com/193",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos193Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "lattice walks",
       "collinearity"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 193,
     "erdosUrl": "https://erdosproblems.com/193",

--- a/src/data/proofs/erdos-196/meta.json
+++ b/src/data/proofs/erdos-196/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Graham",
     "sourceUrl": "https://erdosproblems.com/196",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos196Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "arithmetic progressions",
       "monotone subsequences"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 196,
     "erdosUrl": "https://erdosproblems.com/196",

--- a/src/data/proofs/erdos-2/meta.json
+++ b/src/data/proofs/erdos-2/meta.json
@@ -7,7 +7,7 @@
     "author": "Hough, Balister-Bollobás-Morris-Sahasrabudhe-Tiba",
     "sourceUrl": "https://erdosproblems.com/2",
     "date": "2015, 2022",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos2Problem.lean",
     "leanFile": "Proofs/Erdos2Problem.lean",
     "tags": [

--- a/src/data/proofs/erdos-201/meta.json
+++ b/src/data/proofs/erdos-201/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/201",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos201Problem.lean",
     "tags": [
       "erdos",
@@ -14,7 +14,7 @@
       "arithmetic progressions",
       "Szemerédi"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 201,
     "erdosUrl": "https://erdosproblems.com/201",

--- a/src/data/proofs/erdos-205/meta.json
+++ b/src/data/proofs/erdos-205/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/205",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos205Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-218/meta.json
+++ b/src/data/proofs/erdos-218/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1955-1985)",
     "sourceUrl": "https://erdosproblems.com/218",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos218Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-234/meta.json
+++ b/src/data/proofs/erdos-234/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/234",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos234Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-238/meta.json
+++ b/src/data/proofs/erdos-238/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/238",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos238Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-241/meta.json
+++ b/src/data/proofs/erdos-241/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/241",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos241Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/25",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos25Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-261/meta.json
+++ b/src/data/proofs/erdos-261/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/261",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos261Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "representations",
       "binary-arithmetic"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 261,
     "erdosUrl": "https://erdosproblems.com/261",

--- a/src/data/proofs/erdos-267/meta.json
+++ b/src/data/proofs/erdos-267/meta.json
@@ -7,7 +7,7 @@
     "author": "Good (1974), Bicknell-Hoggatt (1976), André-Jeannin (1989)",
     "sourceUrl": "https://erdosproblems.com/267",
     "date": "1989",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos267Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-273/meta.json
+++ b/src/data/proofs/erdos-273/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/273",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos273Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-276/meta.json
+++ b/src/data/proofs/erdos-276/meta.json
@@ -10,7 +10,7 @@
     "erdosUrl": "https://erdosproblems.com/276",
     "erdosProblemStatus": "open",
     "date": "1964",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos276Problem.lean",
     "leanFile": "Proofs/Erdos276Problem.lean",
     "badge": "axiom",

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/278",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos278Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "density",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 278,
     "erdosUrl": "https://erdosproblems.com/278",

--- a/src/data/proofs/erdos-279/meta.json
+++ b/src/data/proofs/erdos-279/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Graham",
     "sourceUrl": "https://erdosproblems.com/279",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos279Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "primes",
       "arithmetic-progressions"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 279,
     "erdosUrl": "https://erdosproblems.com/279",

--- a/src/data/proofs/erdos-281/meta.json
+++ b/src/data/proofs/erdos-281/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/281",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos281Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "density",
       "congruences"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 281,
     "erdosUrl": "https://erdosproblems.com/281",

--- a/src/data/proofs/erdos-282/meta.json
+++ b/src/data/proofs/erdos-282/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Stein (conjecture), Fibonacci (1202), Graham (1964)",
     "erdosNumber": 282,
-    "status": "formalized",
+    "status": "axiomatized",
     "badge": "axiom",
     "sorries": 0,
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-286/meta.json
+++ b/src/data/proofs/erdos-286/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Graham (1980)",
     "sourceUrl": "https://erdosproblems.com/286",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos286Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "egyptian-fractions",
       "solved"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 286,
     "erdosUrl": "https://erdosproblems.com/286",

--- a/src/data/proofs/erdos-288/meta.json
+++ b/src/data/proofs/erdos-288/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/288",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos288Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-289/meta.json
+++ b/src/data/proofs/erdos-289/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Graham",
     "sourceUrl": "https://erdosproblems.com/289",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos289Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "intervals",
       "harmonic series"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 289,
     "erdosUrl": "https://erdosproblems.com/289",

--- a/src/data/proofs/erdos-296/meta.json
+++ b/src/data/proofs/erdos-296/meta.json
@@ -8,7 +8,7 @@
     "sourceUrl": "https://erdosproblems.com/296",
     "erdosUrl": "https://erdosproblems.com/296",
     "date": "2021",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos296Problem.lean",
     "leanFile": "Proofs/Erdos296Problem.lean",
     "tags": [

--- a/src/data/proofs/erdos-301/meta.json
+++ b/src/data/proofs/erdos-301/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/301",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos301Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "extremal-combinatorics",
       "egyptian-fractions"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 301,
     "erdosUrl": "https://erdosproblems.com/301",

--- a/src/data/proofs/erdos-313/meta.json
+++ b/src/data/proofs/erdos-313/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Graham (1980)",
     "sourceUrl": "https://erdosproblems.com/313",
     "erdosUrl": "https://erdosproblems.com/313",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos313Problem.lean",
     "leanFile": "Proofs/Erdos313Problem.lean",
     "tags": [

--- a/src/data/proofs/erdos-319/meta.json
+++ b/src/data/proofs/erdos-319/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Graham (1980)",
     "sourceUrl": "https://erdosproblems.com/319",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos319Problem.lean",
     "leanFile": "Proofs/Erdos319Problem.lean",
     "tags": [
@@ -16,7 +16,7 @@
       "combinatorics",
       "signed-sums"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 319,
     "erdosUrl": "https://erdosproblems.com/319",

--- a/src/data/proofs/erdos-324/meta.json
+++ b/src/data/proofs/erdos-324/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Graham (1980)",
     "sourceUrl": "https://erdosproblems.com/324",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos324Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-327/meta.json
+++ b/src/data/proofs/erdos-327/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/327",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos327Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "extremal-combinatorics",
       "divisibility"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 327,
     "erdosUrl": "https://erdosproblems.com/327",

--- a/src/data/proofs/erdos-332/meta.json
+++ b/src/data/proofs/erdos-332/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/332",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos332Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "syndetic-sets",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 332,
     "erdosUrl": "https://erdosproblems.com/332",

--- a/src/data/proofs/erdos-335/meta.json
+++ b/src/data/proofs/erdos-335/meta.json
@@ -8,7 +8,7 @@
     "sourceUrl": "https://erdosproblems.com/335",
     "erdosUrl": "https://erdosproblems.com/335",
     "date": "1980",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos335Problem.lean",
     "leanFile": "Proofs/Erdos335Problem.lean",
     "tags": [

--- a/src/data/proofs/erdos-340/meta.json
+++ b/src/data/proofs/erdos-340/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Graham",
     "sourceUrl": "https://erdosproblems.com/340",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos340Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-342/meta.json
+++ b/src/data/proofs/erdos-342/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/342",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos342Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-346/meta.json
+++ b/src/data/proofs/erdos-346/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/346",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos346Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "golden ratio",
       "Fibonacci numbers"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 346,
     "erdosUrl": "https://erdosproblems.com/346",

--- a/src/data/proofs/erdos-347/meta.json
+++ b/src/data/proofs/erdos-347/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Graham",
     "sourceUrl": "https://erdosproblems.com/347",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos347Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-367/meta.json
+++ b/src/data/proofs/erdos-367/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/367",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos367Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -5,7 +5,7 @@
   "description": "For ε > 0 and k ≥ 2, does {1,…,n} contain k consecutive n^ε-smooth integers for all large n? Open even for k=2. Balog-Wooley: infinitely many exist. OPEN.",
   "meta": {
     "erdosNumber": 369,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",

--- a/src/data/proofs/erdos-380/meta.json
+++ b/src/data/proofs/erdos-380/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/380",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos380Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "intervals",
       "analytic-number-theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 380,
     "erdosUrl": "https://erdosproblems.com/380",

--- a/src/data/proofs/erdos-384/meta.json
+++ b/src/data/proofs/erdos-384/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős-Selfridge, solved by Ecklund (1969)",
     "sourceUrl": "https://erdosproblems.com/384",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos384Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-386/meta.json
+++ b/src/data/proofs/erdos-386/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Graham",
     "sourceUrl": "https://erdosproblems.com/386",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos386Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-388/meta.json
+++ b/src/data/proofs/erdos-388/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/388",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos388Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "factorials",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 388,
     "erdosUrl": "https://erdosproblems.com/388",

--- a/src/data/proofs/erdos-389/meta.json
+++ b/src/data/proofs/erdos-389/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Straus",
     "sourceUrl": "https://erdosproblems.com/389",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos389Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "consecutive integers",
       "products"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 389,
     "erdosUrl": "https://erdosproblems.com/389",

--- a/src/data/proofs/erdos-390/meta.json
+++ b/src/data/proofs/erdos-390/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/390",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos390Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "asymptotics",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 390,
     "erdosUrl": "https://erdosproblems.com/390",

--- a/src/data/proofs/erdos-396/meta.json
+++ b/src/data/proofs/erdos-396/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Graham",
     "sourceUrl": "https://erdosproblems.com/396",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos396Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "divisibility",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",

--- a/src/data/proofs/erdos-40/meta.json
+++ b/src/data/proofs/erdos-40/meta.json
@@ -5,7 +5,7 @@
   "description": "For which g(N) → ∞ does |A ∩ {1,...,N}| >> N^{1/2}/g(N) imply limsup r_A(n) = ∞? Solving for any g → ∞ implies the Erdős–Turán conjecture (Problem #28). $500 bounty. Status: OPEN.",
   "meta": {
     "erdosNumber": 40,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",

--- a/src/data/proofs/erdos-406/meta.json
+++ b/src/data/proofs/erdos-406/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/406",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos406Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "digit-problems",
       "S-unit-equations"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 406,
     "erdosUrl": "https://erdosproblems.com/406",

--- a/src/data/proofs/erdos-409/meta.json
+++ b/src/data/proofs/erdos-409/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdos, Graham, Finucane",
     "sourceUrl": "https://erdosproblems.com/409",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos409Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "primes",
       "dynamical-systems"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 409,
     "erdosUrl": "https://erdosproblems.com/409",

--- a/src/data/proofs/erdos-411/meta.json
+++ b/src/data/proofs/erdos-411/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/411",
     "date": "1980",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos411Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-42/meta.json
+++ b/src/data/proofs/erdos-42/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/42",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos42Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "additive-combinatorics",
       "difference-sets"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 42,
     "erdosUrl": "https://erdosproblems.com/42",

--- a/src/data/proofs/erdos-422/meta.json
+++ b/src/data/proofs/erdos-422/meta.json
@@ -16,7 +16,7 @@
       "recursion",
       "self-referential"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 422,
     "erdosUrl": "https://erdosproblems.com/422",

--- a/src/data/proofs/erdos-423/meta.json
+++ b/src/data/proofs/erdos-423/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/423",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos423Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-424/meta.json
+++ b/src/data/proofs/erdos-424/meta.json
@@ -16,7 +16,7 @@
       "density",
       "multiplicative-combinatorics"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 424,
     "erdosUrl": "https://erdosproblems.com/424",

--- a/src/data/proofs/erdos-428/meta.json
+++ b/src/data/proofs/erdos-428/meta.json
@@ -19,7 +19,7 @@
       "analytic-number-theory",
       "liminf-limsup"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 428,
     "erdosUrl": "https://erdosproblems.com/428",

--- a/src/data/proofs/erdos-430/meta.json
+++ b/src/data/proofs/erdos-430/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdos, Graham, Selfridge",
     "sourceUrl": "https://erdosproblems.com/430",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos430Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "rough-numbers",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 430,
     "erdosUrl": "https://erdosproblems.com/430",

--- a/src/data/proofs/erdos-436/meta.json
+++ b/src/data/proofs/erdos-436/meta.json
@@ -7,7 +7,7 @@
     "author": "Lehmer-Lehmer (1962), Hildebrand (1991), Graham (1964)",
     "sourceUrl": "https://erdosproblems.com/436",
     "date": "1962",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos436Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "analytic-number-theory",
       "partially-solved"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 436,
     "erdosUrl": "https://erdosproblems.com/436",

--- a/src/data/proofs/erdos-450/meta.json
+++ b/src/data/proofs/erdos-450/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/450",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos450Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-46/meta.json
+++ b/src/data/proofs/erdos-46/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1970s), solved by Croot (2003)",
     "sourceUrl": "https://erdosproblems.com/46",
     "date": "1970",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos46Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "colouring",
       "solved"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 46,
     "erdosUrl": "https://erdosproblems.com/46",

--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/460",
     "date": "1977",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos460Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-462/meta.json
+++ b/src/data/proofs/erdos-462/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős–Graham",
     "sourceUrl": "https://erdosproblems.com/462",
     "date": "1980",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos462Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "analytic-number-theory",
       "sieve-methods"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 462,
     "erdosUrl": "https://erdosproblems.com/462",

--- a/src/data/proofs/erdos-466/meta.json
+++ b/src/data/proofs/erdos-466/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Ronald Graham, András Sárközy",
     "erdosNumber": 466,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",
@@ -24,7 +24,7 @@
       "Konyagin, S.V. (2001): Upper bound N(X,δ) ≪ X^{1/2} for Problem #465, matching Sárközy's lower bound",
       "https://erdosproblems.com/466"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/466",
     "erdosUrl": "https://erdosproblems.com/466",

--- a/src/data/proofs/erdos-467/meta.json
+++ b/src/data/proofs/erdos-467/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Graham",
     "sourceUrl": "https://erdosproblems.com/467",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos467Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "combinatorial-number-theory",
       "chinese-remainder-theorem"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 467,
     "erdosUrl": "https://erdosproblems.com/467",

--- a/src/data/proofs/erdos-468/meta.json
+++ b/src/data/proofs/erdos-468/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Graham (1980)",
     "sourceUrl": "https://erdosproblems.com/468",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos468Problem.lean",
     "leanFile": "Proofs/Erdos468Problem.lean",
     "tags": [
@@ -16,7 +16,7 @@
       "partial-sums",
       "combinatorial-number-theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 468,
     "erdosUrl": "https://erdosproblems.com/468",

--- a/src/data/proofs/erdos-47/meta.json
+++ b/src/data/proofs/erdos-47/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (conjecture); Bloom (2021, proof); Liu–Sawhney (2024, improvement); Pomerance (lower bound)",
     "sourceUrl": "https://erdosproblems.com/47",
     "date": "1960s",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos47Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-472/meta.json
+++ b/src/data/proofs/erdos-472/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Ulam (attributed by Erdős)",
     "sourceUrl": "https://erdosproblems.com/472",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos472Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "greedy-algorithms",
       "ulam"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 472,
     "erdosUrl": "https://erdosproblems.com/472",

--- a/src/data/proofs/erdos-477/meta.json
+++ b/src/data/proofs/erdos-477/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Graham",
     "sourceUrl": "https://erdosproblems.com/477",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos477Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "tilings",
       "polynomials"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 477,
     "erdosUrl": "https://erdosproblems.com/477",

--- a/src/data/proofs/erdos-478/meta.json
+++ b/src/data/proofs/erdos-478/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Graham (1980); Grebennikov–Sagdeev–Semchankau–Vasilevskii (2024); Klurman–Munsch (2017)",
     "sourceUrl": "https://erdosproblems.com/478",
     "date": "1980",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos478Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-488/meta.json
+++ b/src/data/proofs/erdos-488/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/488",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos488Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "density",
       "inclusion-exclusion"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 488,
     "erdosUrl": "https://erdosproblems.com/488",

--- a/src/data/proofs/erdos-49/meta.json
+++ b/src/data/proofs/erdos-49/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/49",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos49Problem.lean",
     "tags": [
       "erdos",
@@ -23,7 +23,7 @@
       "Euler (1763): Euler's totient function φ(n)",
       "https://erdosproblems.com/49"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 49,
     "erdosUrl": "https://erdosproblems.com/49",

--- a/src/data/proofs/erdos-496/meta.json
+++ b/src/data/proofs/erdos-496/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Oppenheim",
     "sourceUrl": "https://erdosproblems.com/496",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos496Problem.lean",
     "tags": [
       "erdos",
@@ -24,7 +24,7 @@
       "Dani–Margulis (1989): measure-theoretic approach via Raghunathan's conjecture",
       "https://erdosproblems.com/496"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 496,
     "erdosUrl": "https://erdosproblems.com/496",

--- a/src/data/proofs/erdos-497/meta.json
+++ b/src/data/proofs/erdos-497/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/497",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos497Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "Sperner theory",
       "Dedekind numbers"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 497,
     "erdosUrl": "https://erdosproblems.com/497",

--- a/src/data/proofs/erdos-498/meta.json
+++ b/src/data/proofs/erdos-498/meta.json
@@ -5,7 +5,7 @@
   "description": "For complex z₁,...,zₙ with |zᵢ| ≥ 1, at most C(n,⌊n/2⌋) signed sums Σεᵢzᵢ fall in any unit disc. Solved by Kleitman (1965), generalized to Hilbert spaces (1970).",
   "meta": {
     "erdosNumber": 498,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "combinatorics",

--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/5",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos5Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "analytic-number-theory",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 5,
     "erdosUrl": "https://erdosproblems.com/5",

--- a/src/data/proofs/erdos-50/meta.json
+++ b/src/data/proofs/erdos-50/meta.json
@@ -7,7 +7,7 @@
     "author": "Schoenberg (1928, density existence); Erdős (pure singularity, $250 prize question)",
     "sourceUrl": "https://erdosproblems.com/50",
     "date": "1930s",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos50Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-500/meta.json
+++ b/src/data/proofs/erdos-500/meta.json
@@ -7,7 +7,7 @@
     "author": "Turán (1941, construction); de Caen (1994, upper bound); Razborov (2010, flag algebras); Erdős (problem formulation)",
     "sourceUrl": "https://erdosproblems.com/500",
     "date": "1941",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos500Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-502/meta.json
+++ b/src/data/proofs/erdos-502/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Coxeter",
     "sourceUrl": "https://erdosproblems.com/502",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos502Problem.lean",
     "tags": [
       "erdos",
@@ -25,7 +25,7 @@
     ],
     "leanFile": "Proofs/Erdos502Problem.lean",
     "sorries": 0,
-    "badge": "formalized",
+    "badge": "axiom",
     "erdosUrl": "https://erdosproblems.com/502",
     "erdosProblemStatus": "solved",
     "axiomCount": 7

--- a/src/data/proofs/erdos-503/meta.json
+++ b/src/data/proofs/erdos-503/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős–Kelly (1947, n=2); Croft (1962, n=3); Blokhuis (1984, upper bound); Alweiss (lower bound); Weisenberg (improvement)",
     "sourceUrl": "https://erdosproblems.com/503",
     "date": "1947",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos503Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-505/meta.json
+++ b/src/data/proofs/erdos-505/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Borsuk",
     "sourceUrl": "https://erdosproblems.com/505",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos505Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "Borsuk conjecture",
       "partition problems"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 505,
     "erdosUrl": "https://erdosproblems.com/505",

--- a/src/data/proofs/erdos-506/meta.json
+++ b/src/data/proofs/erdos-506/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/506",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos506Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "circles",
       "incidence geometry"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 506,
     "erdosUrl": "https://erdosproblems.com/506",

--- a/src/data/proofs/erdos-507/meta.json
+++ b/src/data/proofs/erdos-507/meta.json
@@ -7,7 +7,7 @@
     "author": "Heilbronn (original problem, 1940s); Erdős (1/n² lower bound); Komlós–Pintz–Szemerédi (1981, 1982); Cohen–Pohoata–Zakharov (2024)",
     "sourceUrl": "https://erdosproblems.com/507",
     "date": "1940s",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos507Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-508/meta.json
+++ b/src/data/proofs/erdos-508/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Hadwiger (1945), Nelson (1950)",
     "sourceUrl": "https://erdosproblems.com/508",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos508Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "unit-distance",
       "open-problem"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 508,
     "erdosUrl": "https://erdosproblems.com/508",

--- a/src/data/proofs/erdos-51/meta.json
+++ b/src/data/proofs/erdos-51/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/51",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos51Problem.lean",
     "leanFile": "Proofs/Erdos51Problem.lean",
     "tags": [
@@ -18,7 +18,7 @@
       "carmichael-conjecture",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 51,
     "erdosUrl": "https://erdosproblems.com/51",

--- a/src/data/proofs/erdos-510/meta.json
+++ b/src/data/proofs/erdos-510/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Chowla, Erdős",
     "erdosNumber": 510,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "harmonic-analysis",

--- a/src/data/proofs/erdos-52/meta.json
+++ b/src/data/proofs/erdos-52/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/52",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos52Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Salem, Zygmund",
     "erdosNumber": 524,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "analysis",

--- a/src/data/proofs/erdos-53/meta.json
+++ b/src/data/proofs/erdos-53/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Szemerédi",
     "sourceUrl": "https://erdosproblems.com/53",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos53Problem.lean",
     "tags": [
       "erdos",
@@ -14,7 +14,7 @@
       "additive combinatorics",
       "sum-product phenomenon"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 53,
     "erdosUrl": "https://erdosproblems.com/53",

--- a/src/data/proofs/erdos-530/meta.json
+++ b/src/data/proofs/erdos-530/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Riddell",
     "sourceUrl": "https://erdosproblems.com/530",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos530Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "additive combinatorics",
       "extremal combinatorics"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 530,
     "erdosUrl": "https://erdosproblems.com/530",

--- a/src/data/proofs/erdos-533/meta.json
+++ b/src/data/proofs/erdos-533/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Hajnal, Simonovits, Sós, Szemerédi",
     "sourceUrl": "https://erdosproblems.com/533",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos533Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "ramsey-theory",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 533,
     "erdosUrl": "https://erdosproblems.com/533",

--- a/src/data/proofs/erdos-536/meta.json
+++ b/src/data/proofs/erdos-536/meta.json
@@ -16,7 +16,7 @@
       "density",
       "combinatorics"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 536,
     "erdosUrl": "https://erdosproblems.com/536",

--- a/src/data/proofs/erdos-54/meta.json
+++ b/src/data/proofs/erdos-54/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1995), solved by Conlon–Fox–Pham (2021)",
     "sourceUrl": "https://erdosproblems.com/54",
     "date": "1995",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos54Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "additive-combinatorics",
       "solved"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 54,
     "erdosUrl": "https://erdosproblems.com/54",

--- a/src/data/proofs/erdos-542/meta.json
+++ b/src/data/proofs/erdos-542/meta.json
@@ -15,7 +15,7 @@
       "reciprocal-sums",
       "extremal-combinatorics"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 542,
     "erdosUrl": "https://erdosproblems.com/542",

--- a/src/data/proofs/erdos-544/meta.json
+++ b/src/data/proofs/erdos-544/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/544",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos544Problem.lean",
     "tags": [
       "erdos",
@@ -14,7 +14,7 @@
       "Ramsey theory",
       "Ramsey numbers"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 544,
     "erdosUrl": "https://erdosproblems.com/544",

--- a/src/data/proofs/erdos-55/meta.json
+++ b/src/data/proofs/erdos-55/meta.json
@@ -7,7 +7,7 @@
     "author": "Conlon-Fox-Pham",
     "sourceUrl": "https://erdosproblems.com/55",
     "date": "2021",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos55Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-563/meta.json
+++ b/src/data/proofs/erdos-563/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/563",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos563Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "probabilistic method",
       "edge coloring"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 563,
     "erdosUrl": "https://erdosproblems.com/563",

--- a/src/data/proofs/erdos-575/meta.json
+++ b/src/data/proofs/erdos-575/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Simonovits",
     "sourceUrl": "https://erdosproblems.com/575",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos575Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "bipartite graphs",
       "combinatorics"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 575,
     "erdosUrl": "https://erdosproblems.com/575",

--- a/src/data/proofs/erdos-579/meta.json
+++ b/src/data/proofs/erdos-579/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Hajnal, Sós, Szemerédi",
     "sourceUrl": "https://erdosproblems.com/579",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos579Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "turan-theory",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 579,
     "erdosUrl": "https://erdosproblems.com/579",

--- a/src/data/proofs/erdos-58/meta.json
+++ b/src/data/proofs/erdos-58/meta.json
@@ -7,7 +7,7 @@
     "author": "Gyárfás",
     "sourceUrl": "https://erdosproblems.com/58",
     "date": "1992",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos58Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-585/meta.json
+++ b/src/data/proofs/erdos-585/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/585",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos585Problem.lean",
     "tags": [
       "erdos",
@@ -14,7 +14,7 @@
       "extremal graph theory",
       "cycles"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 585,
     "erdosUrl": "https://erdosproblems.com/585",

--- a/src/data/proofs/erdos-590/meta.json
+++ b/src/data/proofs/erdos-590/meta.json
@@ -7,7 +7,7 @@
     "author": "Chang (1972), Specker (1957), Larson (1973)",
     "sourceUrl": "https://erdosproblems.com/590",
     "date": "1972",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos590Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-593/meta.json
+++ b/src/data/proofs/erdos-593/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/593",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos593Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-598/meta.json
+++ b/src/data/proofs/erdos-598/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/598",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos598Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-62/meta.json
+++ b/src/data/proofs/erdos-62/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Hajnal, Shelah",
     "sourceUrl": "https://erdosproblems.com/62",
     "date": "1974",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos62Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-621/meta.json
+++ b/src/data/proofs/erdos-621/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Tibor Gallai, Zsolt Tuza, Sergey Norin, Hehui Wu",
     "sourceUrl": "https://erdosproblems.com/621",
     "date": "1996-2016",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos621Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-63/meta.json
+++ b/src/data/proofs/erdos-63/meta.json
@@ -7,7 +7,7 @@
     "author": "Mihók-Erdős",
     "sourceUrl": "https://erdosproblems.com/63",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos63Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/638",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos638Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "infinite combinatorics",
       "cardinals"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 638,
     "erdosUrl": "https://erdosproblems.com/638",

--- a/src/data/proofs/erdos-640/meta.json
+++ b/src/data/proofs/erdos-640/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/640",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos640Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-65/meta.json
+++ b/src/data/proofs/erdos-65/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős & Hajnal",
     "sourceUrl": "https://erdosproblems.com/65",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos65Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-655/meta.json
+++ b/src/data/proofs/erdos-655/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Pach",
     "sourceUrl": "https://erdosproblems.com/655",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos655Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "concyclicity",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 655,
     "erdosUrl": "https://erdosproblems.com/655",

--- a/src/data/proofs/erdos-661/meta.json
+++ b/src/data/proofs/erdos-661/meta.json
@@ -5,7 +5,7 @@
   "description": "Do there exist point sets x₁,...,xₙ and y₁,...,yₙ in ℝ² with o(n/√log n) distinct bipartite distances? Is F(2n) = o(f(2n))? In ℝ⁴ all distances can be equal (Lenz). $50 reward. Open.",
   "meta": {
     "erdosNumber": 661,
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos661Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-663/meta.json
+++ b/src/data/proofs/erdos-663/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/663",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos663Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "consecutive-products",
       "asymptotic-bounds"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 663,
     "erdosUrl": "https://erdosproblems.com/663",

--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/667",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos667Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "extremal graph theory",
       "clique numbers"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 667,
     "erdosUrl": "https://erdosproblems.com/667",

--- a/src/data/proofs/erdos-675/meta.json
+++ b/src/data/proofs/erdos-675/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/675",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos675Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "combinatorics",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 675,
     "erdosUrl": "https://erdosproblems.com/675",

--- a/src/data/proofs/erdos-677/meta.json
+++ b/src/data/proofs/erdos-677/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/677",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos677Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "consecutive-integers",
       "prime-factors"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 677,
     "erdosUrl": "https://erdosproblems.com/677",

--- a/src/data/proofs/erdos-680/meta.json
+++ b/src/data/proofs/erdos-680/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1979)",
     "sourceUrl": "https://erdosproblems.com/680",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos680Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "prime-gaps",
       "least-prime-factor"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 680,
     "erdosUrl": "https://erdosproblems.com/680",

--- a/src/data/proofs/erdos-685/meta.json
+++ b/src/data/proofs/erdos-685/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/685",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos685Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "binomial-coefficients",
       "prime-factors"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 685,
     "erdosUrl": "https://erdosproblems.com/685",

--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/687",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos687Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "prime gaps",
       "sieve theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 687,
     "erdosUrl": "https://erdosproblems.com/687",

--- a/src/data/proofs/erdos-688/meta.json
+++ b/src/data/proofs/erdos-688/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/688",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos688Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "congruences",
       "sieve theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 688,
     "erdosUrl": "https://erdosproblems.com/688",

--- a/src/data/proofs/erdos-689/meta.json
+++ b/src/data/proofs/erdos-689/meta.json
@@ -5,7 +5,7 @@
   "description": "For large n, can we choose a_p for each prime p ≤ n so that every m ∈ [1,n] satisfies m ≡ a_p (mod p) for at least 2 primes? Generalizes to r-fold covering. Open.",
   "meta": {
     "erdosNumber": 689,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",
@@ -21,7 +21,7 @@
     "leanFile": "Proofs/Erdos689Problem.lean",
     "proofRepoPath": "Proofs/Erdos689Problem.lean",
     "sorries": 0,
-    "badge": "formalized",
+    "badge": "axiom",
     "sourceUrl": "https://erdosproblems.com/689",
     "erdosUrl": "https://erdosproblems.com/689",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-690/meta.json
+++ b/src/data/proofs/erdos-690/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/690",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos690Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "unimodality",
       "analytic number theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 690,
     "erdosUrl": "https://erdosproblems.com/690",

--- a/src/data/proofs/erdos-691/meta.json
+++ b/src/data/proofs/erdos-691/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/691",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos691Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "sieve-theory",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 691,
     "erdosUrl": "https://erdosproblems.com/691",

--- a/src/data/proofs/erdos-70/meta.json
+++ b/src/data/proofs/erdos-70/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Rado",
     "sourceUrl": "https://erdosproblems.com/70",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos70Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-700/meta.json
+++ b/src/data/proofs/erdos-700/meta.json
@@ -5,7 +5,7 @@
   "description": "Study f(n) = min_{1<k≤n/2} gcd(n, C(n,k)). When does f(n) = n/P(n)? Are there ∞ many n with f(n) > √n? Is f(n) ≪ n/(log n)^A? Known: f(pq) = p, f(p²) ≥ p. Open.",
   "meta": {
     "erdosNumber": 700,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",
@@ -22,7 +22,7 @@
     "leanFile": "Proofs/Erdos700Problem.lean",
     "proofRepoPath": "Proofs/Erdos700Problem.lean",
     "sorries": 0,
-    "badge": "formalized",
+    "badge": "axiom",
     "sourceUrl": "https://erdosproblems.com/700",
     "erdosUrl": "https://erdosproblems.com/700",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-706/meta.json
+++ b/src/data/proofs/erdos-706/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/706",
     "date": "1981",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos706Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-71/meta.json
+++ b/src/data/proofs/erdos-71/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Burr (conjecture), Bollobás (1977, proof)",
     "sourceUrl": "https://erdosproblems.com/71",
     "date": "1977",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos71Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-723/meta.json
+++ b/src/data/proofs/erdos-723/meta.json
@@ -7,7 +7,7 @@
     "author": "Bruck-Ryser (1949), Lam (1997)",
     "sourceUrl": "https://erdosproblems.com/723",
     "date": "1949",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos723Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-730/meta.json
+++ b/src/data/proofs/erdos-730/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Graham, Ruzsa, Straus",
     "sourceUrl": "https://erdosproblems.com/730",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos730Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "prime divisors",
       "central binomials"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 730,
     "erdosUrl": "https://erdosproblems.com/730",

--- a/src/data/proofs/erdos-731/meta.json
+++ b/src/data/proofs/erdos-731/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Graham, Ruzsa, Straus",
     "sourceUrl": "https://erdosproblems.com/731",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos731Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "divisibility",
       "asymptotic-analysis"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 731,
     "erdosUrl": "https://erdosproblems.com/731",

--- a/src/data/proofs/erdos-735/meta.json
+++ b/src/data/proofs/erdos-735/meta.json
@@ -7,7 +7,7 @@
     "author": "Ackerman, Buchin, Knauer, Pinchasi, Rote",
     "sourceUrl": "https://erdosproblems.com/735",
     "date": "2008",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos735Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-738/meta.json
+++ b/src/data/proofs/erdos-738/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Gyárfás",
     "sourceUrl": "https://erdosproblems.com/738",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos738Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "triangle-free",
       "induced-subgraphs"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 738,
     "erdosUrl": "https://erdosproblems.com/738",

--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Burr, Erdős (1994)",
     "sourceUrl": "https://erdosproblems.com/741",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos741Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "open",
       "partition-regularity"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 741,
     "erdosUrl": "https://erdosproblems.com/741",

--- a/src/data/proofs/erdos-749/meta.json
+++ b/src/data/proofs/erdos-749/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/749",
     "date": "1994",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos749Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-75/meta.json
+++ b/src/data/proofs/erdos-75/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Hajnal, Szemerédi",
     "sourceUrl": "https://erdosproblems.com/75",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos75Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "infinite-combinatorics",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 75,
     "erdosUrl": "https://erdosproblems.com/75",

--- a/src/data/proofs/erdos-776/meta.json
+++ b/src/data/proofs/erdos-776/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Trotter",
     "sourceUrl": "https://erdosproblems.com/776",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos776Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "antichains",
       "sperner-theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 776,
     "erdosUrl": "https://erdosproblems.com/776",

--- a/src/data/proofs/erdos-78/meta.json
+++ b/src/data/proofs/erdos-78/meta.json
@@ -5,8 +5,8 @@
   "description": "Give a constructive proof that R(k) > C^k. Equivalently, build explicit graphs with no clique/independent set of size c·log n. Best: Li (2023) achieves (log n)^C. Open ($100).",
   "meta": {
     "erdosNumber": 78,
-    "status": "formalized",
-    "badge": "formalized",
+    "status": "axiomatized",
+    "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos78Problem.lean",
     "erdosProblemStatus": "open",
     "tags": [

--- a/src/data/proofs/erdos-783/meta.json
+++ b/src/data/proofs/erdos-783/meta.json
@@ -5,7 +5,7 @@
   "description": "Given budget C on reciprocal sums, which pairwise coprime A ⊆ {2,...,n} minimizes unsieved integers? Conjectured: first k primes with Σ 1/p_i ≤ C. Status: OPEN.",
   "meta": {
     "erdosNumber": 783,
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos783Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "prime-numbers",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "references": [
       "Erdős (1973): original problem",
       "https://erdosproblems.com/783"

--- a/src/data/proofs/erdos-810/meta.json
+++ b/src/data/proofs/erdos-810/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Burr, Erdős, Graham, Sós",
     "sourceUrl": "https://erdosproblems.com/810",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos810Problem.lean",
     "tags": [
       "erdos",
@@ -14,7 +14,7 @@
       "ramsey-theory",
       "edge-coloring"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 810,
     "erdosUrl": "https://erdosproblems.com/810",

--- a/src/data/proofs/erdos-825/meta.json
+++ b/src/data/proofs/erdos-825/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/825",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos825Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "weird numbers",
       "semiperfect numbers"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 825,
     "erdosUrl": "https://erdosproblems.com/825",

--- a/src/data/proofs/erdos-827/meta.json
+++ b/src/data/proofs/erdos-827/meta.json
@@ -15,7 +15,7 @@
       "circumradii",
       "ramsey-type"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 827,
     "erdosUrl": "https://erdosproblems.com/827",

--- a/src/data/proofs/erdos-850/meta.json
+++ b/src/data/proofs/erdos-850/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/850",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos850Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "abc-conjecture",
       "erdos-woods"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 850,
     "erdosUrl": "https://erdosproblems.com/850",

--- a/src/data/proofs/erdos-852/meta.json
+++ b/src/data/proofs/erdos-852/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/852",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos852Problem.lean",
     "leanFile": "Proofs/Erdos852Problem.lean",
     "tags": [
@@ -16,7 +16,7 @@
       "sieve-theory",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 852,
     "erdosUrl": "https://erdosproblems.com/852",

--- a/src/data/proofs/erdos-853/meta.json
+++ b/src/data/proofs/erdos-853/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1985)",
     "sourceUrl": "https://erdosproblems.com/853",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos853Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "prime-gaps",
       "analytic-number-theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 853,
     "erdosUrl": "https://erdosproblems.com/853",

--- a/src/data/proofs/erdos-854/meta.json
+++ b/src/data/proofs/erdos-854/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/854",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos854Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "jacobsthal-function",
       "coprime-residues"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 854,
     "erdosUrl": "https://erdosproblems.com/854",

--- a/src/data/proofs/erdos-856/meta.json
+++ b/src/data/proofs/erdos-856/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/856",
     "date": "1970",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos856Problem.lean",
     "leanFile": "Proofs/Erdos856Problem.lean",
     "tags": [

--- a/src/data/proofs/erdos-863/meta.json
+++ b/src/data/proofs/erdos-863/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Berend, Freud",
     "sourceUrl": "https://erdosproblems.com/863",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos863Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-864/meta.json
+++ b/src/data/proofs/erdos-864/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Freud",
     "sourceUrl": "https://erdosproblems.com/864",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos864Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "sum-representations",
       "extremal-problems"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 864,
     "erdosUrl": "https://erdosproblems.com/864",

--- a/src/data/proofs/erdos-87/meta.json
+++ b/src/data/proofs/erdos-87/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/87",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos87Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "probabilistic-method",
       "counterexample"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 87,
     "erdosUrl": "https://erdosproblems.com/87",

--- a/src/data/proofs/erdos-889/meta.json
+++ b/src/data/proofs/erdos-889/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Selfridge",
     "sourceUrl": "https://erdosproblems.com/889",
     "date": "1967",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos889Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-890/meta.json
+++ b/src/data/proofs/erdos-890/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/890",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos890Problem.lean",
     "leanFile": "Proofs/Erdos890Problem.lean",
     "tags": [

--- a/src/data/proofs/erdos-892/meta.json
+++ b/src/data/proofs/erdos-892/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős, Sárközy, Szemerédi",
     "sourceUrl": "https://erdosproblems.com/892",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos892Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-893/meta.json
+++ b/src/data/proofs/erdos-893/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/893",
     "date": "1998",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos893Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "mersenne-numbers",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 893,
     "erdosUrl": "https://erdosproblems.com/893",

--- a/src/data/proofs/erdos-896/meta.json
+++ b/src/data/proofs/erdos-896/meta.json
@@ -15,7 +15,7 @@
       "product-sets",
       "asymptotic-bounds"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 896,
     "erdosUrl": "https://erdosproblems.com/896",

--- a/src/data/proofs/erdos-90/meta.json
+++ b/src/data/proofs/erdos-90/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/90",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos90Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "incidence-geometry",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 90,
     "erdosUrl": "https://erdosproblems.com/90",

--- a/src/data/proofs/erdos-905/meta.json
+++ b/src/data/proofs/erdos-905/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Bollobás, Erdős; solved by Edwards, Hadziivanov-Nikiforov",
     "sourceUrl": "https://erdosproblems.com/905",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos905Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-913/meta.json
+++ b/src/data/proofs/erdos-913/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/913",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos913Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-931/meta.json
+++ b/src/data/proofs/erdos-931/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/931",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos931Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-935/meta.json
+++ b/src/data/proofs/erdos-935/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/935",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos935Problem.lean",
     "tags": [
       "erdos",
@@ -14,7 +14,7 @@
       "powerful-numbers",
       "consecutive-products"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 935,
     "erdosUrl": "https://erdosproblems.com/935",

--- a/src/data/proofs/erdos-943/meta.json
+++ b/src/data/proofs/erdos-943/meta.json
@@ -8,7 +8,7 @@
     "proofRepoPath": "Proofs/Erdos943Problem.lean",
     "badge": "axiom",
     "erdosNumber": 943,
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "erdos",
       "number-theory",

--- a/src/data/proofs/erdos-949/meta.json
+++ b/src/data/proofs/erdos-949/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/949",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos949Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-950/meta.json
+++ b/src/data/proofs/erdos-950/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/950",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos950Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-954/meta.json
+++ b/src/data/proofs/erdos-954/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Rosen",
     "sourceUrl": "https://erdosproblems.com/954",
     "date": "1977",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos954Problem.lean",
     "leanFile": "Proofs/Erdos954Problem.lean",
     "tags": [
@@ -19,7 +19,7 @@
       "open-problem",
       "sidon-sets"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 954,
     "erdosUrl": "https://erdosproblems.com/954",

--- a/src/data/proofs/erdos-963/meta.json
+++ b/src/data/proofs/erdos-963/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/963",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos963Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "subset sums",
       "number theory"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 963,
     "erdosUrl": "https://erdosproblems.com/963",

--- a/src/data/proofs/erdos-98/meta.json
+++ b/src/data/proofs/erdos-98/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/98",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos98Problem.lean",
     "tags": [
       "erdos",
@@ -14,7 +14,7 @@
       "distinct-distances",
       "incidence-geometry"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 98,
     "erdosUrl": "https://erdosproblems.com/98",


### PR DESCRIPTION
## Summary

### Enrichments (6 proofs)
1. **Archimedes Pi Bounds** — 9 annotations, fixed axiomCount 0→2, sorries 2→0, status→axiomatized
2. **Wantzel-Galois** — 7 annotations, fixed axiomCount 2→0, status→verified
3. **2D Hockey Stick** — 6 annotations, expanded historicalContext, added references
4. **Vandermonde Identity** — Added full overview section (was missing)
5. **Power Mean Monotonicity** — Added context annotation, fixed annotation types
6. **Tuza's Conjecture** — Fixed status, improved section summaries

### Batch Metadata Fix (212 entries)
Fixed entries that had `status: "formalized"` with `axiomCount > 0` and `sorries: 0`.
Per project policy, these should be `"axiomatized"` with `badge: "axiom"`.

## Test plan
- [x] All JSON files validate
- [x] Axiom counts verified via grep for enriched entries
- [x] Batch fix only changes status/badge fields (no content changes)
- [x] 212 files changed with exactly 318 line insertions = 318 deletions (clean swap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)