### PR TITLE
Research: Prove crossingFactor_tendsto_zero (0 sorries remaining)

### DIFF
--- a/proofs/Proofs/BuffonsNeedleOQ02OQ01.lean
+++ b/proofs/Proofs/BuffonsNeedleOQ02OQ01.lean
@@ -226,11 +226,79 @@ theorem crossingFactor_strict_dec (n : ℕ) (hn : 2 ≤ n) :
 -- Part VII: Asymptotic Behavior
 -- ============================================================
 
+/-- Key bound: crossingFactor(n+2)² ≤ 2/(n+2) for all n.
+    Base cases: (2/π)² = 4/π² ≤ 1 (since π² > 4) and (1/2)² = 1/4 ≤ 2/3.
+    Inductive step: uses the algebraic identity (n+2)(n+4) ≤ (n+3)². -/
+private lemma crossingFactor_sq_bound : ∀ n : ℕ,
+    crossingFactor (n + 2) ^ 2 ≤ 2 / ((n : ℝ) + 2)
+  | 0 => by
+    simp only [Nat.cast_zero, zero_add, crossingFactor_two]
+    rw [show (2 : ℝ) / 2 = 1 from by norm_num, div_pow, div_le_one (pow_pos pi_pos 2)]
+    -- Goal: 2 ^ 2 ≤ π ^ 2. Since π > 3 > 2, (π-2)² ≥ 0 gives π²-4π+4 ≥ 0.
+    nlinarith [pi_gt_three, sq_nonneg (π - 2)]
+  | 1 => by
+    simp only [Nat.cast_one]
+    norm_num
+  | (n + 2) => by
+    have ih := crossingFactor_sq_bound n
+    -- crossingFactor(n+4) = ((n+2)/(n+3)) * crossingFactor(n+2)
+    have hrw : n + 2 + 2 = n + 4 := by omega
+    rw [hrw, crossingFactor_succ_succ, mul_pow]
+    -- Cast simplification
+    have hcast : ((n + 2 : ℕ) : ℝ) + 2 = (n : ℝ) + 4 := by push_cast; ring
+    rw [hcast]
+    -- Bound: ((n+2)/(n+3))² * cf²  ≤  ((n+2)/(n+3))² * 2/(n+2)  ≤  2/(n+4)
+    have hn2 : (0 : ℝ) < (n : ℝ) + 2 := by positivity
+    have hn3 : (0 : ℝ) < (n : ℝ) + 3 := by positivity
+    have hn4 : (0 : ℝ) < (n : ℝ) + 4 := by positivity
+    calc ((↑n + 2) / (↑n + 3)) ^ 2 * crossingFactor (n + 2) ^ 2
+        ≤ ((↑n + 2) / (↑n + 3)) ^ 2 * (2 / (↑n + 2)) :=
+          mul_le_mul_of_nonneg_left ih (sq_nonneg _)
+      _ ≤ 2 / (↑n + 4) := by
+          rw [div_pow, div_mul_div_comm]
+          -- Goal: (↑n + 2) ^ 2 * 2 / ((↑n + 3) ^ 2 * (↑n + 2)) ≤ 2 / (↑n + 4)
+          -- Cancel (↑n+2) from LHS
+          rw [show (↑n + 2 : ℝ) ^ 2 * 2 = (↑n + 2) * (2 * (↑n + 2)) from by ring,
+              show (↑n + 3 : ℝ) ^ 2 * (↑n + 2) = (↑n + 2) * (↑n + 3) ^ 2 from by ring,
+              mul_div_mul_left _ _ (ne_of_gt hn2)]
+          -- Goal: 2 * (↑n + 2) / (↑n + 3) ^ 2 ≤ 2 / (↑n + 4)
+          rw [div_le_div_iff₀ (sq_pos_of_pos hn3) hn4]
+          -- Goal: 2 * (↑n + 2) * (↑n + 4) ≤ 2 * (↑n + 3) ^ 2
+          -- Follows from (n+2)(n+4) ≤ (n+3)², i.e., n²+6n+8 ≤ n²+6n+9
+          nlinarith [sq_nonneg ((n : ℝ) + 3)]
+
 /-- αₙ → 0 as n → ∞: in very high dimensions, a random unit vector's
     projection onto any fixed axis approaches zero on average.
-    This follows from the Wallis-type product and the divergence of ∑ 1/n. -/
+
+    Proof: We show αₙ² ≤ 2/n by induction (using (n+2)(n+4) ≤ (n+3)²),
+    then squeeze αₙ between 0 and √(2/n) → 0. -/
 theorem crossingFactor_tendsto_zero :
     Filter.Tendsto (fun n => crossingFactor (n + 2)) Filter.atTop (nhds 0) := by
-  sorry
+  -- Upper bound: crossingFactor(n+2) ≤ √(2/(n+2))
+  have h_bound : ∀ n : ℕ, crossingFactor (n + 2) ≤ Real.sqrt (2 / ((n : ℝ) + 2)) := by
+    intro n
+    have hpos := le_of_lt (crossingFactor_pos (n + 2) (by omega))
+    calc crossingFactor (n + 2)
+        = Real.sqrt (crossingFactor (n + 2) ^ 2) := (Real.sqrt_sq hpos).symm
+      _ ≤ Real.sqrt (2 / ((n : ℝ) + 2)) := Real.sqrt_le_sqrt (crossingFactor_sq_bound n)
+  -- Upper bound → 0: √(2/(n+2)) → 0
+  have h_upper_zero : Filter.Tendsto (fun n : ℕ => Real.sqrt (2 / ((n : ℝ) + 2)))
+      Filter.atTop (nhds 0) := by
+    rw [show (0 : ℝ) = Real.sqrt 0 from (Real.sqrt_zero).symm]
+    apply Filter.Tendsto.comp (Real.continuous_sqrt.tendsto 0)
+    -- Show 2/(n+2) → 0: inverse of divergent denominator
+    have h_inv : Filter.Tendsto (fun n : ℕ => ((n : ℝ) + 2)⁻¹) Filter.atTop (nhds 0) :=
+      tendsto_inv_atTop_zero.comp
+        (Filter.tendsto_atTop_mono
+          (fun n => le_add_of_nonneg_right (by norm_num : (0 : ℝ) ≤ 2))
+          tendsto_natCast_atTop_atTop)
+    have h_frac := h_inv.const_mul (2 : ℝ)
+    simp only [mul_zero] at h_frac
+    exact h_frac.congr' (by filter_upwards with n; rw [div_eq_mul_inv])
+  -- Squeeze: 0 ≤ crossingFactor(n+2) ≤ √(2/(n+2)) → 0
+  exact squeeze_zero
+    (fun n => le_of_lt (crossingFactor_pos (n + 2) (by omega)))
+    h_bound
+    h_upper_zero
 
 end BuffonsNeedleOQ02OQ01

--- a/src/data/proofs/buffons-needle-oq-02-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Buffon (1777); n-dimensional generalization formalized 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
     "date": "1777",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BuffonsNeedleOQ02OQ01.lean",
     "tags": [
       "probability",
@@ -21,8 +21,8 @@
       "linearity-of-expectation",
       "cauchy-crofton"
     ],
-    "badge": "formalized",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "mul_pos",
@@ -55,7 +55,9 @@
       "buffonNd: general n-dimensional Buffon formula E = αₙ·L/d",
       "buffonNd_noodle: general noodle theorem for polygonal paths in ℝⁿ",
       "crossingFactor_three_lt_two: 3D has fewer crossings than 2D (1/2 < 2/π via π < 4)",
-      "crossingFactor_four_lt_three: 4D has fewer crossings than 3D (4/(3π) < 1/2 via π > 3)"
+      "crossingFactor_four_lt_three: 4D has fewer crossings than 3D (4/(3π) < 1/2 via π > 3)",
+      "crossingFactor_sq_bound: αₙ² ≤ 2/n for all n ≥ 2, by induction using (n+2)(n+4) ≤ (n+3)²",
+      "crossingFactor_tendsto_zero: αₙ → 0 as n → ∞, via squeeze between 0 and √(2/n)"
     ],
     "dateAdded": "03/21/26",
     "axiomCount": 0,
@@ -147,15 +149,14 @@
       "id": "part-vii-asymptotic",
       "title": "Part VII: Asymptotic Behavior",
       "startLine": 224,
-      "endLine": 236,
-      "summary": "States (with sorry) that αₙ → 0 as n → ∞: in high dimensions, the expected projection of a random unit vector onto any fixed axis vanishes. This follows from the Wallis-type product ∏(j/(j+1)) → 0, a consequence of the divergence of ∑1/j. This is the file's sole sorry — a natural candidate for Aristotle proof search."
+      "endLine": 304,
+      "summary": "Proves αₙ → 0 as n → ∞ via a squared bound. The key lemma shows αₙ² ≤ 2/n by induction: the step uses (n+2)(n+4) ≤ (n+3)², an AM-GM type inequality. The main theorem squeezes αₙ between 0 and √(2/n), which tends to 0 by composition of inverse → 0 with √ continuity."
     }
   ],
   "conclusion": {
-    "summary": "The n-dimensional Buffon noodle formula is formalized with 17 theorems, 1 sorry (asymptotic limit), and 0 axioms. The crossing factor recurrence α_{n+2} = (n/(n+1))·αₙ provides a clean characterization of how expected hyperplane crossings depend on dimension. The strict decrease and specific value computations extend the 2D and 3D results to arbitrary dimension.",
+    "summary": "The n-dimensional Buffon noodle formula is fully verified with 18 theorems, 0 sorries, and 0 axioms. The crossing factor recurrence α_{n+2} = (n/(n+1))·αₙ provides a complete characterization of how expected hyperplane crossings depend on dimension, including the asymptotic vanishing αₙ → 0. The strict decrease, specific value computations, and convergence proof extend the 2D and 3D results to arbitrary dimension.",
     "implications": "**Mathematical Significance**:\n\n**1. Dimension-Parametric Formula**\nThe recurrence captures the full family of crossing factors without requiring explicit Gamma function computations.\n\n**2. Even/Odd Dichotomy**\nEven dimensions involve π (transcendental factors) while odd dimensions are purely rational. This is a formal consequence of Γ(n) being rational for integers and involving √π for half-integers.\n\n**3. Infrastructure for Integral Geometry**\nThe buffonNd framework with proved additivity, scaling, and monotonicity provides infrastructure for Cauchy-Crofton type formulas in arbitrary dimension.\n\n**4. Asymptotic Vanishing**\nThe stated (sorry) limit αₙ → 0 captures the concentration of measure phenomenon: in high dimensions, most of a unit vector's length is spread across many coordinates.",
     "openQuestions": [
-      "Prove crossingFactor_tendsto_zero: αₙ → 0 as n → ∞ (Wallis product argument)",
       "Explicit closed form for αₙ via Gamma function",
       "Rate of convergence: αₙ ~ √(2/(πn)) as n → ∞",
       "Extension to non-polygonal curves via C¹ approximation in ℝⁿ",


### PR DESCRIPTION
## Summary
- Proved the last sorry in `BuffonsNeedleOQ02OQ01.lean`: `crossingFactor_tendsto_zero` (αₙ → 0 as n → ∞)
- File upgraded from **formalized** (1 sorry) → **verified** (0 sorries, 0 axioms)
- 18 theorems, 304 lines, fully machine-checked

## Proof Technique
The key insight is an inductive squared bound: **αₙ² ≤ 2/n** for all n ≥ 2.

The induction step uses the algebraic identity **(n+2)(n+4) ≤ (n+3)²** (equivalently, n²+6n+8 ≤ n²+6n+9). This avoids the need for Wallis products, logarithms, or Gamma function asymptotics.

The main theorem then squeezes αₙ between 0 and √(2/n) → 0, using:
- `tendsto_inv_atTop_zero` for 1/n → 0
- `Real.continuous_sqrt` for √ continuity at 0
- `squeeze_zero` for the sandwich

## Test plan
- [x] Docker build passes with 0 errors, 0 warnings
- [x] `grep sorry` returns no matches
- [x] Gallery meta.json updated to verified status

🤖 Generated by researcher-2