### PR TITLE
Enrich angle-trisection-oq-02-oq-01: add 9 annotations, fix axiom integrity, cross-references

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/annotations.json
@@ -1,1 +1,110 @@
-[]
+[
+  {
+    "id": "ann-imports-context",
+    "proofId": "angle-trisection-oq-02-oq-01",
+    "range": { "startLine": 13, "endLine": 18 },
+    "type": "context",
+    "title": "Mathlib and OQ-01 Dependencies",
+    "content": "Imports the full Mathlib library (for `Polynomial.Gal`, `IsPGroup`, `Prime.dvd_of_dvd_pow`, `IntermediateField.adjoin.finrank`) and the parent file `AngleTrisectionOQ01` which provides `dvd_pow_two_is_pow_two` — the lemma that any positive divisor of $2^n$ is itself a power of 2. The `open Polynomial` and `open scoped IntermediateField` declarations bring polynomial notation `F[X]` and the intermediate field notation `F⟮α⟯` into scope.",
+    "mathContext": "The key Mathlib theorems used are: (1) `Polynomial.Gal.card_of_separable`: $|\\text{Gal}(p)| = \\text{finrank}(F, \\text{SplittingField}(p))$ for separable $p$; (2) `IsPGroup.iff_card`: $G$ is a $p$-group $\\iff |G| = p^n$; (3) `Prime.dvd_of_dvd_pow`: $p \\mid a^n \\Rightarrow p \\mid a$ for prime $p$. From OQ-01: `dvd_pow_two_is_pow_two`: $d > 0 \\wedge d \\mid 2^n \\Rightarrow \\exists k, d = 2^k$.",
+    "significance": "context",
+    "relatedConcepts": ["Polynomial.Gal", "IsPGroup", "IntermediateField", "SplittingField"],
+    "prerequisites": ["Mathlib.FieldTheory.PolynomialGaloisGroup", "Mathlib.GroupTheory.PGroup", "AngleTrisectionOQ01"]
+  },
+  {
+    "id": "ann-natdeg-dvd-gal",
+    "proofId": "angle-trisection-oq-02-oq-01",
+    "range": { "startLine": 26, "endLine": 58 },
+    "type": "technique",
+    "title": "natDegree Divides |Gal| — Tower Law Argument",
+    "content": "The central theorem of the file: for any irreducible polynomial $p$ over a CharZero field $F$, $\\text{natDegree}(p) \\mid |\\text{Gal}(p)|$. This generalizes Mathlib's `prime_degree_dvd_card` (which requires prime degree) to all degrees.\n\nThe proof uses the **tower law** on the chain $F \\subset F(\\alpha) \\subset \\text{SplittingField}(p)$, where $\\alpha$ is a root of $p$ in the splitting field. By Galois theory, $|\\text{Gal}(p)| = [\\text{SplittingField}(p) : F]$. The tower law gives $[\\text{SplittingField}(p) : F] = [\\text{SplittingField}(p) : F(\\alpha)] \\cdot [F(\\alpha) : F]$, and since $[F(\\alpha) : F] = \\deg(\\text{minpoly}(F, \\alpha)) = \\deg(p)$ (because $p$ is irreducible and $\\alpha$ is a root), we get $\\deg(p) \\mid |\\text{Gal}(p)|$.",
+    "mathContext": "Tower law: $[L:F] = [L:K] \\cdot [K:F]$ for $F \\subseteq K \\subseteq L$. Here $L = \\text{SplittingField}(p)$, $K = F(\\alpha)$, so $|\\text{Gal}(p)| = [L:F] = [L:F(\\alpha)] \\cdot [F(\\alpha):F]$, giving $\\deg(p) = [F(\\alpha):F] \\mid |\\text{Gal}(p)|$. The key subtlety: showing $\\text{minpoly}(F, \\alpha) = p$ (up to associates) uses irreducibility of $p$ plus the fact that $\\text{minpoly}(F, \\alpha) \\mid p$ (since $\\alpha$ is a root of $p$).",
+    "significance": "key",
+    "relatedConcepts": ["tower law", "splitting field", "Galois group", "minimal polynomial", "rootOfSplits", "field extension degree"],
+    "prerequisites": ["Galois theory", "field extension tower law", "polynomial splitting fields", "minimal polynomial theory"]
+  },
+  {
+    "id": "ann-root-construction",
+    "proofId": "angle-trisection-oq-02-oq-01",
+    "range": { "startLine": 40, "endLine": 44 },
+    "type": "concept",
+    "title": "Root Construction via rootOfSplits",
+    "content": "Constructs a root $\\alpha$ of $p$ in $\\text{SplittingField}(p)$ using Mathlib's `rootOfSplits`. This requires two preconditions: (1) $p$ splits in $\\text{SplittingField}(p)$ (by definition, `SplittingField.splits p`), and (2) $\\deg(p) \\neq 0$ (since irreducible polynomials have positive degree). The degree condition must be transferred through `algebraMap` using `degree_map_eq_of_injective`, since `rootOfSplits` works with the mapped polynomial $p.\\text{map}(\\text{algebraMap}\\; F\\; E)$. The integrality of $\\alpha$ over $F$ then follows from `IsIntegral.of_finite`, since $\\text{SplittingField}(p)$ is a finite extension of $F$.",
+    "mathContext": "In Mathlib, `rootOfSplits` takes a proof that $f$ splits and $\\deg(f) \\neq 0$, returning an element $\\alpha$ with $f(\\alpha) = 0$. The condition $\\deg(p \\cdot (\\text{algebraMap}\\; F\\; E)) \\neq 0$ is equivalent to $\\deg(p) \\neq 0$ by injectivity of the algebra map (characteristic zero).",
+    "significance": "supporting",
+    "relatedConcepts": ["rootOfSplits", "SplittingField", "algebraMap", "IsIntegral", "degree_map_eq_of_injective"],
+    "prerequisites": ["Mathlib.FieldTheory.SplittingField", "Mathlib.FieldTheory.IsAlgClosed"]
+  },
+  {
+    "id": "ann-minpoly-equals-p",
+    "proofId": "angle-trisection-oq-02-oq-01",
+    "range": { "startLine": 46, "endLine": 58 },
+    "type": "insight",
+    "title": "Minimal Polynomial Equals p — Irreducibility Argument",
+    "content": "The crux of the tower law argument: showing $\\text{natDegree}(\\text{minpoly}(F, \\alpha)) = \\text{natDegree}(p)$. This proceeds in two steps:\n\n1. **minpoly divides p**: Since $\\alpha$ is a root of $p$ and minpoly is the minimal such polynomial, $\\text{minpoly}(F, \\alpha) \\mid p$. This uses `minpoly.dvd` after rewriting `aeval` through `eval₂_eq_eval_map`.\n\n2. **p divides minpoly**: Since $p$ is irreducible and $\\text{minpoly}(F, \\alpha)$ is also irreducible (by `minpoly.irreducible`), and they share a divisibility relation, `Irreducible.dvd_symm` gives the reverse direction.\n\nMutual divisibility of irreducible polynomials means they are associates, so they have equal degrees.",
+    "mathContext": "For irreducible $p \\in F[X]$ and $\\alpha$ a root: $\\text{minpoly}(F, \\alpha) \\mid p$ (minimality). Since both are irreducible in a UFD, mutual divisibility implies $\\text{minpoly}(F, \\alpha) \\sim p$ (associate), hence $\\deg(\\text{minpoly}(F, \\alpha)) = \\deg(p)$. Then $[F(\\alpha):F] = \\deg(\\text{minpoly}(F, \\alpha)) = \\deg(p)$, completing the tower law decomposition.",
+    "significance": "key",
+    "relatedConcepts": ["minimal polynomial", "irreducible polynomial", "associates in UFD", "aeval", "eval₂_eq_eval_map"],
+    "prerequisites": ["Mathlib.FieldTheory.Minpoly.Basic", "unique factorization", "polynomial divisibility"]
+  },
+  {
+    "id": "ann-2group-pow2",
+    "proofId": "angle-trisection-oq-02-oq-01",
+    "range": { "startLine": 64, "endLine": 72 },
+    "type": "technique",
+    "title": "2-Group Gal → Degree Divides 2^n",
+    "content": "Chains two results: (1) `natDegree_dvd_card_gal` gives $\\deg(\\text{minpoly}(\\mathbb{Q}, \\alpha)) \\mid |\\text{Gal}(\\text{minpoly}(\\mathbb{Q}, \\alpha))|$, and (2) `IsPGroup.iff_card` gives $|\\text{Gal}| = 2^n$ when Gal is a 2-group. Transitivity of divisibility yields $\\deg \\mid 2^n$. This theorem eliminates the axiom `galois_2group_implies_degree_pow2` from OQ-02, which was one of 6 axioms in the parent formalization.",
+    "mathContext": "If $\\text{Gal}(\\text{minpoly}(\\mathbb{Q}, \\alpha))$ is a 2-group, then $|\\text{Gal}| = 2^n$ for some $n$. Combined with $\\deg(\\text{minpoly}) \\mid |\\text{Gal}|$, we get $\\deg(\\text{minpoly}) \\mid 2^n$. This is the divisibility form; the next theorem strengthens it to equality.",
+    "significance": "key",
+    "relatedConcepts": ["IsPGroup", "2-group", "divisibility transitivity", "axiom elimination"],
+    "prerequisites": ["natDegree_dvd_card_gal", "IsPGroup.iff_card", "dvd_trans"]
+  },
+  {
+    "id": "ann-2group-is-pow2",
+    "proofId": "angle-trisection-oq-02-oq-01",
+    "range": { "startLine": 74, "endLine": 82 },
+    "type": "insight",
+    "title": "Strengthening: Degree IS a Power of 2",
+    "content": "Strengthens the divisibility $\\deg \\mid 2^n$ to equality $\\deg = 2^k$ by invoking `dvd_pow_two_is_pow_two` from AngleTrisectionOQ01. The key observation: any positive integer dividing $2^n$ must itself be a power of 2 (since 2 is prime, the only divisors of $2^n$ are $1, 2, 4, \\ldots, 2^n$). The positivity condition $\\deg > 0$ follows from `Irreducible.natDegree_pos`.",
+    "mathContext": "Number-theoretic fact: if $d > 0$ and $d \\mid 2^n$, then $d = 2^k$ for some $k \\leq n$. Proof: $2^n = d \\cdot q$, and in $\\mathbb{Z}$ the only prime factor of $2^n$ is 2, so $d = 2^k$. Applied here: $\\deg(\\text{minpoly}) > 0$ (irreducible $\\Rightarrow$ degree $\\geq 1$) and $\\deg \\mid 2^n$, so $\\deg = 2^k$.",
+    "significance": "key",
+    "relatedConcepts": ["dvd_pow_two_is_pow_two", "prime factorization", "Irreducible.natDegree_pos"],
+    "prerequisites": ["AngleTrisectionOQ01.dvd_pow_two_is_pow_two", "Irreducible.natDegree_pos"]
+  },
+  {
+    "id": "ann-constructible-def",
+    "proofId": "angle-trisection-oq-02-oq-01",
+    "range": { "startLine": 88, "endLine": 94 },
+    "type": "definition",
+    "title": "IsConstructibleFromQ — Field Extension Characterization",
+    "content": "Defines constructibility of $\\alpha \\in \\mathbb{R}$: there exists an intermediate field $K$ with $\\mathbb{Q} \\subseteq K \\subseteq \\mathbb{R}$ such that $K/\\mathbb{Q}$ is finite-dimensional, $[K:\\mathbb{Q}] = 2^n$, and $\\alpha \\in K$. This is identical to the definition in OQ-02, reproduced here for self-containedness. The power-of-2 degree condition captures the geometric intuition: each compass-and-straightedge step extends the field by at most degree 2 (adding a square root).",
+    "mathContext": "$\\alpha$ is constructible $\\iff \\exists K$, $\\mathbb{Q} \\subseteq K \\subseteq \\mathbb{R}$, $[K:\\mathbb{Q}] = 2^n$, $\\alpha \\in K$. Equivalently, $\\alpha$ is reachable from $\\mathbb{Q}$ by $+, -, \\times, \\div, \\sqrt{\\cdot}$ (with real outputs). The degree-$2^n$ condition rules out cube roots ($\\sqrt[3]{2}$ has degree 3), cos(20°) (degree 3), and other algebraic numbers requiring odd-degree extensions.",
+    "significance": "supporting",
+    "relatedConcepts": ["constructible number", "field extension degree", "compass and straightedge", "IntermediateField", "Module.finrank"],
+    "prerequisites": ["IntermediateField ℚ ℝ", "FiniteDimensional", "Module.finrank"]
+  },
+  {
+    "id": "ann-galois-to-degree",
+    "proofId": "angle-trisection-oq-02-oq-01",
+    "range": { "startLine": 96, "endLine": 100 },
+    "type": "insight",
+    "title": "Galois Criterion Implies Degree Criterion",
+    "content": "The final bridge theorem: if the Galois group of $\\text{minpoly}(\\mathbb{Q}, \\alpha)$ is a 2-group, then $\\deg(\\text{minpoly}) = 2^k$. This connects the Galois-theoretic characterization of constructibility (OQ-02's approach) to the degree-theoretic characterization (OQ-01's approach), showing that the Galois criterion is at least as strong as the degree criterion. The theorem is a direct wrapper around `galois_2group_implies_degree_is_pow2`, making the logical connection explicit.",
+    "mathContext": "The two constructibility criteria are: (1) **Degree criterion** (Wantzel): $\\alpha$ constructible $\\Rightarrow [\\mathbb{Q}(\\alpha):\\mathbb{Q}] = 2^k$. (2) **Galois criterion** (refined): $\\alpha$ constructible $\\iff \\text{Gal}(\\text{minpoly}(\\mathbb{Q}, \\alpha))$ is a 2-group. This theorem proves (2) $\\Rightarrow$ (1): 2-group Gal $\\Rightarrow$ degree is $2^k$.",
+    "significance": "key",
+    "relatedConcepts": ["Wantzel theorem", "Galois characterization", "constructibility criteria equivalence"],
+    "prerequisites": ["galois_2group_implies_degree_is_pow2", "IsConstructibleFromQ"]
+  },
+  {
+    "id": "ann-summary-axiom-elimination",
+    "proofId": "angle-trisection-oq-02-oq-01",
+    "range": { "startLine": 102, "endLine": 115 },
+    "type": "context",
+    "title": "Summary: Axiom Elimination Progress",
+    "content": "The file achieves 4 theorems with 0 sorries and 0 axioms, eliminating 1 of OQ-02's 6 axioms (`galois_2group_implies_degree_pow2`). The key achievement is proving `natDegree_dvd_card_gal` — a general result not restricted to prime degree — which enables the entire 2-group-to-degree-power-of-2 chain. This demonstrates that Mathlib's `Polynomial.Gal` infrastructure, combined with the tower law, suffices for the structural argument without computing explicit Galois group orders.",
+    "mathContext": "Axiom status in the OQ-02 family: OQ-02 started with 6 axioms. This file (OQ-02-OQ-01) eliminates 1 axiom by proving the degree-divisibility implication from Mathlib. The sibling file OQ-02-OQ-03 addresses the Gauss-Wantzel direction (regular polygon constructibility). The parent OQ-02 retains 5 axioms after this contribution.",
+    "significance": "context",
+    "relatedConcepts": ["axiom elimination", "formalization progress", "Mathlib bridge"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
@@ -2,12 +2,12 @@
   "id": "angle-trisection-oq-02-oq-01",
   "title": "Wantzel-Galois Characterization from Mathlib (OQ-02-OQ-01)",
   "slug": "angle-trisection-oq-02-oq-01",
-  "description": "Connects the Galois-theoretic constructibility criteria to Mathlib's Polynomial.Gal infrastructure. Proves that irreducible polynomials with odd prime degree cannot have 2-group Galois groups, eliminating 3 of 6 axioms from the parent OQ-02 formalization without computing explicit Galois group orders.",
+  "description": "Connects the Galois-theoretic constructibility criterion to Mathlib's Polynomial.Gal infrastructure. Proves natDegree divides |Gal| for all irreducible polynomials (generalizing Mathlib's prime-degree-only result), then derives that 2-group Galois groups force degree to be a power of 2 — eliminating 1 of 6 axioms from the parent OQ-02 formalization.",
   "meta": {
     "author": "Wantzel (1837), Galois (1832)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Constructible_number",
     "date": "1837",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01.lean",
     "tags": [
       "geometry",
@@ -18,12 +18,12 @@
       "polynomial-galois-group",
       "mathlib-bridge"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
-        "theorem": "Polynomial.Gal.prime_degree_dvd_card",
-        "description": "For irreducible p with prime natDegree in CharZero: natDegree ∣ Nat.card p.Gal",
+        "theorem": "Polynomial.Gal.card_of_separable",
+        "description": "|Gal(p)| = finrank(F, SplittingField(p)) for separable p",
         "module": "Mathlib.FieldTheory.PolynomialGaloisGroup"
       },
       {
@@ -32,90 +32,116 @@
         "module": "Mathlib.GroupTheory.PGroup"
       },
       {
-        "theorem": "Prime.dvd_of_dvd_pow",
-        "description": "If p is prime and p ∣ a^n then p ∣ a",
-        "module": "Mathlib.Algebra.Prime.Basic"
+        "theorem": "IntermediateField.adjoin.finrank",
+        "description": "[F⟮α⟯:F] = natDegree(minpoly(F,α)) for integral α",
+        "module": "Mathlib.FieldTheory.Adjoin"
       },
       {
-        "theorem": "Polynomial.Gal",
-        "description": "The Galois group of a polynomial over a field",
-        "module": "Mathlib.FieldTheory.PolynomialGaloisGroup"
+        "theorem": "Module.finrank_mul_finrank",
+        "description": "[L:F] = [L:K]·[K:F] — the tower law for field extensions",
+        "module": "Mathlib.LinearAlgebra.Dimension"
+      },
+      {
+        "theorem": "rootOfSplits",
+        "description": "Constructs a root of a splitting polynomial with nonzero degree",
+        "module": "Mathlib.FieldTheory.SplittingField.Construction"
+      },
+      {
+        "theorem": "minpoly.dvd",
+        "description": "minpoly(F,α) divides any polynomial vanishing at α",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
       }
     ],
     "originalContributions": [
-      "odd_prime_degree_gal_not_2group: General framework — irreducible polynomial with odd prime degree over ℚ cannot have 2-group Galois group",
-      "x_cube_sub_2_gal_not_2group: Gal(x³-2/ℚ) is NOT a 2-group (proved from Mathlib, not axiomatized)",
-      "cos20_gal_not_2group: Gal(8x³-6x-1/ℚ) is NOT a 2-group (proved from Mathlib, not axiomatized)",
-      "prime_degree_2group_eq_two: If Gal is 2-group and degree is prime, then degree must be 2",
-      "prime_degree_2group_implies_degree_dvd_pow2: 2-group Gal + prime degree → degree divides 2^k",
-      "cubic/quintic/septic specializations: Specific non-2-group results for degrees 3, 5, 7"
+      "natDegree_dvd_card_gal: natDegree divides |Gal| for ALL irreducible polynomials over CharZero fields — generalizes Mathlib's prime-degree-only result via the tower law",
+      "galois_2group_implies_degree_pow2: 2-group Galois group implies natDegree divides 2^n — eliminates axiom from OQ-02",
+      "galois_2group_implies_degree_is_pow2: Stronger — natDegree IS a power of 2, using OQ-01's dvd_pow_two_is_pow_two",
+      "galois_criterion_implies_degree_criterion: Bridges the Galois criterion (2-group Gal) to the degree criterion (degree = 2^k)"
     ],
     "dateAdded": "03/21/26",
-    "axiomCount": 2,
-    "assumptions": "Two polynomial irreducibility axioms: x³-2 irreducible over ℚ (Eisenstein at p=2), and 8x³-6x-1 irreducible over ℚ (no rational roots)."
+    "axiomCount": 0
   },
   "overview": {
-    "historicalContext": "The Wantzel-Galois characterization of constructible numbers was axiomatized in OQ-02 with 6 axioms, including explicit Galois group orders (|Gal(x³-2)| = 6, etc.). This file demonstrates that 3 of those axioms are unnecessary: Mathlib's Polynomial.Gal infrastructure provides the key divisibility theorem prime_degree_dvd_card, which combined with 2-group theory yields the same non-constructibility results through a cleaner, more general argument.",
-    "problemStatement": "**Open Question (from OQ-02)**: Can the axiomatized Galois group order computations be replaced by proofs from Mathlib?\n\n**Answer: Partially YES** — 3 of 6 axioms can be eliminated.\n\nInstead of computing |Gal(x³-2)| = 6 (hard, requires splitting field computation), we use:\n1. natDegree ∣ |Gal| (from Mathlib, for irreducible + prime degree)\n2. 2-group → |Gal| = 2^k\n3. Odd prime ∤ 2^k (elementary number theory)\n\nThis proves Gal is NOT a 2-group without knowing the exact order.",
-    "proofStrategy": "The proof strategy shifts from 'compute the Galois group order' to 'derive a divisibility contradiction':\n\n**Step 1**: For irreducible p over ℚ with prime natDegree d, Mathlib proves d | |Gal(p)| (via prime_degree_dvd_card).\n\n**Step 2**: If Gal(p) were a 2-group, then |Gal(p)| = 2^k for some k.\n\n**Step 3**: So d | 2^k. Since d is prime, d | 2 (by Prime.dvd_of_dvd_pow). Since d ≥ 2 (prime), d = 2.\n\n**Step 4**: But d is an odd prime (d ≠ 2). Contradiction.\n\nThis argument works for ALL odd prime degrees (3, 5, 7, 11, ...), not just degree 3.",
+    "historicalContext": "Pierre Wantzel proved in 1837 that an algebraic number is constructible by compass and straightedge only if its minimal polynomial over $\\mathbb{Q}$ has degree a power of 2. Évariste Galois, whose posthumous 1846 publication established the foundations of group theory, provided the deeper characterization: constructibility is equivalent to the Galois group being a 2-group. This refinement transforms a degree computation into a group-theoretic question. The parent formalization OQ-02 axiomatized this Galois criterion with 6 axioms, including explicit Galois group order computations ($|\\text{Gal}(x^3-2)| = 6$). This file demonstrates that the axiom `galois_2group_implies_degree_pow2` is provable from Mathlib's `Polynomial.Gal` infrastructure using the tower law on $F \\subset F(\\alpha) \\subset \\text{SplittingField}(p)$, reducing the axiom count from 6 to 5. The key insight — that the divisibility $\\deg(p) \\mid |\\text{Gal}(p)|$ suffices without computing the exact order — reflects a broader trend in modern algebra: structural arguments replacing explicit computation.",
+    "problemStatement": "**Open Question (from OQ-02)**: Can the axiom `galois_2group_implies_degree_pow2` — which asserts that a 2-group Galois group forces the minimal polynomial degree to divide a power of 2 — be proved from Mathlib?\n\n**Answer: YES.** The proof uses the tower law:\n1. $\\text{natDegree}(p) \\mid |\\text{Gal}(p)|$ for irreducible $p$ (proved via $F \\subset F(\\alpha) \\subset \\text{SplittingField}(p)$)\n2. 2-group $\\Rightarrow |\\text{Gal}| = 2^k$ (from `IsPGroup.iff_card`)\n3. $d \\mid 2^k \\wedge d > 0 \\Rightarrow d = 2^j$ (from OQ-01's `dvd_pow_two_is_pow_two`)\n\nThis eliminates 1 of OQ-02's 6 axioms with a fully verified proof.",
+    "proofStrategy": "The core technique is the **tower law decomposition** on the chain $F \\subset F(\\alpha) \\subset \\text{SplittingField}(p)$:\n\n**Step 1 (Tower Law)**: Construct root $\\alpha$ of $p$ in $\\text{SplittingField}(p)$ via `rootOfSplits`. Show $\\text{minpoly}(F,\\alpha) \\sim p$ (associates) by mutual divisibility of irreducibles. Then $[\\text{SplittingField}:F] = [\\text{SplittingField}:F(\\alpha)] \\cdot [F(\\alpha):F]$ gives $\\deg(p) \\mid |\\text{Gal}(p)|$.\n\n**Step 2 (2-Group Characterization)**: If $\\text{Gal}(p)$ is a 2-group, then $|\\text{Gal}(p)| = 2^n$ by `IsPGroup.iff_card`. Transitivity gives $\\deg(p) \\mid 2^n$.\n\n**Step 3 (Number Theory)**: Since $\\deg(p) > 0$ (irreducible) and $\\deg(p) \\mid 2^n$, apply OQ-01's `dvd_pow_two_is_pow_two` to conclude $\\deg(p) = 2^k$.\n\nThis three-step argument uses Galois theory, group theory, and number theory — each contributing exactly one key fact.",
     "keyInsights": [
-      "The shift from 'compute the order' to 'derive a divisibility contradiction' is the Galois-theoretic analogue of the number-theoretic approach in OQ-01",
-      "Mathlib's prime_degree_dvd_card provides the critical bridge: for irreducible polynomials with prime degree, the degree divides the Galois group order",
-      "This approach generalizes: ANY irreducible polynomial of odd prime degree over ℚ has non-2-group Galois group — not just cubics",
-      "The remaining 2 axioms (polynomial irreducibility) are strictly weaker than the eliminated 3 (Galois group orders), representing genuine progress in formalization strength"
+      "The tower law argument ($F \\subset F(\\alpha) \\subset \\text{SplittingField}(p)$) generalizes Mathlib's `prime_degree_dvd_card` from prime-degree polynomials to ALL irreducible polynomials — a strictly stronger result suitable for upstream contribution",
+      "The proof that $\\text{minpoly}(F,\\alpha) = p$ (up to associates) is the crux: mutual divisibility between two irreducible polynomials in the UFD $F[X]$ forces them to be associates with equal degrees",
+      "Shifting from 'compute the Galois group order' to 'derive a divisibility contradiction' parallels the number-theoretic approach in OQ-01 and exemplifies a broader algebraic strategy: structural arguments replacing explicit computation",
+      "The chain natDegree | |Gal| → natDegree | 2^n → natDegree = 2^k requires three separate mathematical ingredients: Galois theory (tower law), group theory (2-group characterization), and number theory (prime factorization of powers of 2)",
+      "This file is fully verified (0 axioms, 0 sorries) despite addressing constructibility — possible because it proves the structural implication (2-group Gal ⇒ degree is 2^k) without needing to assert any specific polynomial is irreducible"
     ]
   },
   "sections": [
     {
-      "id": "general-framework",
-      "title": "General Framework: Prime Degree Galois Groups",
-      "startLine": 57,
-      "endLine": 100,
-      "summary": "The core theorem: irreducible polynomial with odd prime degree over ℚ cannot have 2-group Galois group. Uses Mathlib's prime_degree_dvd_card + Prime.dvd_of_dvd_pow. Specializations for cubics, quintics, and septics."
+      "id": "natdegree-dvd-gal",
+      "title": "Part I: natDegree Divides |Gal| for Irreducible Polynomials",
+      "startLine": 22,
+      "endLine": 58,
+      "summary": "The central generalization: for any irreducible polynomial p over a CharZero field F, natDegree(p) divides |Gal(p)|. Proved via the tower law on F ⊂ F(α) ⊂ SplittingField(p), using rootOfSplits to construct a root α, then showing minpoly(F,α) and p are associates (both irreducible, one divides the other). Generalizes Mathlib's prime_degree_dvd_card to all degrees."
     },
     {
-      "id": "degree-computations",
-      "title": "Polynomial Degree Computations",
+      "id": "2group-degree-divisibility",
+      "title": "Part II: 2-Group Galois → Degree Divides 2^n",
+      "startLine": 60,
+      "endLine": 82,
+      "summary": "Two theorems chaining the Part I result with 2-group theory: (1) galois_2group_implies_degree_pow2 — if Gal(minpoly(ℚ,α)) is a 2-group then natDegree divides 2^n, and (2) galois_2group_implies_degree_is_pow2 — the stronger result that natDegree IS a power of 2, using OQ-01's dvd_pow_two_is_pow_two. Together these eliminate the axiom galois_2group_implies_degree_pow2 from OQ-02."
+    },
+    {
+      "id": "oq02-to-oq01-bridge",
+      "title": "Part III: Connecting OQ-02 to OQ-01",
+      "startLine": 84,
+      "endLine": 100,
+      "summary": "Defines IsConstructibleFromQ (reproduced from OQ-02 for self-containedness) and proves galois_criterion_implies_degree_criterion: the Galois criterion (2-group Gal) implies the degree criterion (degree = 2^k). This bridges the two characterizations of constructibility."
+    },
+    {
+      "id": "summary",
+      "title": "Summary: Axiom Elimination",
       "startLine": 102,
       "endLine": 115,
-      "summary": "Proved: natDegree of x³-2 is 3, and natDegree of 8x³-6x-1 is 3. Pure computation from polynomial arithmetic."
-    },
-    {
-      "id": "irreducibility",
-      "title": "Irreducibility Axioms",
-      "startLine": 117,
-      "endLine": 132,
-      "summary": "Two axioms: x³-2 irreducible over ℚ (Eisenstein at p=2) and 8x³-6x-1 irreducible over ℚ (rational root test). These are the only axioms in the file."
-    },
-    {
-      "id": "non-2group",
-      "title": "Non-2-Group Results (Proved!)",
-      "startLine": 134,
-      "endLine": 148,
-      "summary": "Gal(x³-2) and Gal(8x³-6x-1) are NOT 2-groups — proved from Mathlib, replacing the axiomatized |Gal| = 6 computations in OQ-02."
-    },
-    {
-      "id": "2group-degree",
-      "title": "2-Group Implies Degree Divides 2^k",
-      "startLine": 150,
-      "endLine": 178,
-      "summary": "If Gal is a 2-group and degree is prime, then degree divides 2^k. Stronger: degree must equal 2. Proves the OQ-02 axiom for the prime degree case."
-    },
-    {
-      "id": "constructibility",
-      "title": "Non-Constructibility via Galois Groups",
-      "startLine": 180,
-      "endLine": 220,
-      "summary": "Framework connecting Galois group results to constructibility: if minpoly Galois group is not a 2-group, and constructibility implies 2-group, then not constructible."
+      "summary": "Summary of results: 4 theorems proved with 0 sorries and 0 axioms. Eliminates 1 of OQ-02's 6 axioms (galois_2group_implies_degree_pow2) by proving it from Mathlib's Polynomial.Gal infrastructure."
     }
   ],
   "conclusion": {
-    "summary": "This formalization demonstrates that the 'compute explicit Galois group orders' approach in OQ-02 can be largely replaced by a structural divisibility argument from Mathlib. Of OQ-02's 6 axioms, 3 are eliminated: the two Galois group order axioms (|Gal| = 6) and the degree-divides-power-of-2 implication. The remaining 2 axioms in this file (polynomial irreducibility) are strictly weaker assumptions than the eliminated ones.",
-    "implications": "This work answers one of OQ-02's open questions affirmatively: parts of the Galois characterization CAN be proved from Mathlib's existing infrastructure. The key Mathlib theorem `prime_degree_dvd_card` provides a powerful bridge. The approach generalizes to all odd prime degrees, not just cubics — any irreducible polynomial of odd prime degree over ℚ is automatically non-constructible (assuming the Wantzel direction).",
+    "summary": "This formalization proves that the axiom `galois_2group_implies_degree_pow2` from OQ-02 is unnecessary: the tower law on $F \\subset F(\\alpha) \\subset \\text{SplittingField}(p)$ gives $\\deg(p) \\mid |\\text{Gal}(p)|$ for all irreducible $p$, and combined with $|\\text{Gal}| = 2^n$ (2-group hypothesis), elementary number theory yields $\\deg(p) = 2^k$. The file contains 4 fully verified theorems with 0 axioms and 0 sorries.",
+    "implications": "This work answers one of OQ-02's open questions affirmatively: the degree-divides-power-of-2 implication CAN be proved from Mathlib's existing Polynomial.Gal infrastructure. The key theorem `natDegree_dvd_card_gal` is strictly more general than Mathlib's `prime_degree_dvd_card` (which requires prime degree), working for all irreducible polynomials. The tower law approach could be contributed upstream to Mathlib to strengthen the existing API.",
     "openQuestions": [
-      "Can the irreducibility axioms be proved? x³-2 via Mathlib's Eisenstein criterion, 8x³-6x-1 via rational root test formalization",
-      "Can the approach extend to non-prime degrees? Need natDegree | |Gal| for general irreducible polynomials (not just prime degree)",
-      "Can Galois group orders for specific quadratic/quartic polynomials be computed from Mathlib's splitting field infrastructure?"
+      "Can natDegree_dvd_card_gal be contributed upstream to Mathlib as a generalization of prime_degree_dvd_card? The proof is self-contained and uses only standard Mathlib APIs",
+      "Can the remaining OQ-02 axioms (polynomial irreducibility, Galois group order computations) be eliminated using similar structural arguments from Mathlib?",
+      "Can Galois group orders for specific low-degree polynomials be computed from Mathlib's splitting field infrastructure, enabling full verification of OQ-02?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection",
+      "relationship": "ancestor",
+      "description": "The original angle trisection impossibility proof using the degree criterion (deg 3 is not a power of 2). This file proves the Galois criterion implies the degree criterion, connecting the two approaches"
+    },
+    {
+      "targetId": "angle-trisection-oq-02",
+      "relationship": "parent",
+      "description": "The parent Galois-theoretic formalization with 6 axioms. This file eliminates 1 axiom (galois_2group_implies_degree_pow2) by proving it from Mathlib's tower law"
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling open question on the Gauss-Wantzel theorem for regular polygon constructibility — also addresses axiom elimination from OQ-02 but via cyclotomic theory"
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Bridges Gauss-Wantzel to Mathlib's cyclotomic infrastructure, paralleling this file's bridge between Galois groups and Mathlib's Polynomial.Gal"
+    },
+    {
+      "targetId": "inverse-galois",
+      "relationship": "related",
+      "description": "Comprehensive Galois group realizations (S₃, A₅, D₄, etc.) — the inverse direction of the Galois correspondence. Where this file asks 'what constraints does the Galois group impose?', inverse Galois asks 'which groups arise as Galois groups?'"
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "Both use Galois group structure to derive impossibility results: Abel-Ruffini shows non-solvable Galois groups block radical solutions, this file shows non-2-group Galois groups block constructibility"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for `angle-trisection-oq-02-oq-01` (Wantzel-Galois Characterization from Mathlib).

### Annotations (0 → 9)
- Added 9 annotations with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` covering all major proof sections
- Key annotations: tower law argument, root construction via `rootOfSplits`, minpoly associates proof, 2-group divisibility chain, constructibility bridge theorem

### Axiom Integrity Fix
- **status**: `axiomatized` → `verified` (file has 0 axioms, 0 sorries per Lean source)
- **badge**: `axiom` → `verified`
- **axiomCount**: 2 → 0
- The Lean file's own summary (line 105) states "0 sorries, 0 axioms" — the previous meta.json was incorrect

### Factual Corrections
- **Description**: Fixed "eliminating 3 of 6 axioms" → "eliminating 1 of 6 axioms" per Lean file summary (line 111)
- **originalContributions**: Replaced 6 non-existent theorem names with the 4 actual theorems in the 115-line file
- **sections**: Fixed line ranges that referenced lines 102-220 in a 115-line file
- **mathlibDependencies**: Updated to reflect actual Mathlib APIs used (`card_of_separable`, `adjoin.finrank`, `finrank_mul_finrank`, `rootOfSplits`, `minpoly.dvd`)

### Enrichment Additions
- Expanded `historicalContext` (200 → 1079 chars) with Wantzel (1837) and Galois (1846) history
- Added 5th `keyInsight` on verified status despite constructibility topic
- Deepened `proofStrategy` with three-step tower law decomposition
- Added 6 cross-references (parent chain + inverse-galois + abel-ruffini)
- Updated `openQuestions` to highlight upstream Mathlib contribution opportunity

## Test plan
- [x] JSON valid (python3 json.load passes)
- [x] Annotations build passes for this entry (1 type warning fixed)
- [ ] Full `pnpm build` (pre-existing failure: missing candidate-pool.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)