### PR TITLE
Enrich binomial-theorem-oq-04-oq-02: add overview, references, crossRefs

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02/meta.json
@@ -14,7 +14,9 @@
     "sorries": 0,
     "mathlibDependencies": [
       {"theorem": "Nat.add_choose_eq", "description": "Vandermonde identity (antidiagonal form)", "module": "Mathlib.Data.Nat.Choose.Sum"},
-      {"theorem": "Polynomial.coeff_mul", "description": "Cauchy product for polynomial coefficients", "module": "Mathlib.Algebra.Polynomial.Coeff"}
+      {"theorem": "Polynomial.coeff_mul", "description": "Cauchy product for polynomial coefficients", "module": "Mathlib.Algebra.Polynomial.Coeff"},
+      {"theorem": "pow_add", "description": "Monoid exponent law a^(m+n) = a^m · a^n", "module": "Mathlib.Algebra.Group.Defs"},
+      {"theorem": "Nat.choose_succ_succ", "description": "Pascal's rule for binomial coefficients", "module": "Mathlib.Data.Nat.Choose.Basic"}
     ],
     "originalContributions": [
       "Exponent law: (1+X)^(m+n) = (1+X)^m · (1+X)^n in ℕ[X]",
@@ -23,21 +25,86 @@
       "Algebraic proof structure: coefficient comparison of exponent law",
       "Symmetry, special cases, Pascal's rule as corollaries"
     ],
+    "references": [
+      {
+        "authors": "Vandermonde, Alexandre-Théophile",
+        "title": "Mémoire sur des irrationnelles de différens ordres avec une application au cercle",
+        "year": "1772",
+        "venue": "Mémoires de l'Académie Royale des Sciences de Paris",
+        "note": "First explicit statement of the convolution identity for binomial coefficients"
+      },
+      {
+        "authors": "Chu, Shih-Chieh",
+        "title": "Precious Mirror of the Four Elements (四元玉鉴)",
+        "year": "1303",
+        "venue": "Yuan dynasty China",
+        "note": "Contains early instances of the identity, predating Vandermonde by nearly 500 years"
+      },
+      {
+        "authors": "Knuth, Donald E.",
+        "title": "The Art of Computer Programming, Vol. 1: Fundamental Algorithms",
+        "year": "1968",
+        "venue": "Addison-Wesley",
+        "note": "Section 1.2.6: comprehensive treatment of binomial coefficient identities including Vandermonde"
+      }
+    ],
     "dateAdded": "03/22/26",
-    "axiomCount": 0
+    "axiomCount": 0,
+    "crossReferences": [
+      {
+        "proofId": "binomial-theorem",
+        "title": "The Binomial Theorem",
+        "relationship": "parent",
+        "note": "The binomial theorem (1+X)^n = Σ C(n,k) X^k provides the coefficient extraction that connects polynomial identities to combinatorial ones"
+      },
+      {
+        "proofId": "arithmetic-series-oq-02-oq-02",
+        "title": "2D Hockey Stick Identity",
+        "relationship": "related",
+        "note": "Uses the parallel Vandermonde identity Σ_{i+j=n} C(i+a,a)·C(j+b,b) = C(n+a+b+1,a+b+1), a shifted variant of the standard Vandermonde"
+      },
+      {
+        "proofId": "combinations-formula",
+        "title": "Formula for the Number of Combinations",
+        "relationship": "uses",
+        "note": "The foundation C(n,k) = n!/(k!(n-k)!) upon which the identity is built"
+      },
+      {
+        "proofId": "pascals-hexagon",
+        "title": "Pascal's Hexagon Theorem",
+        "relationship": "related",
+        "note": "Another deep structural property of Pascal's triangle derived from binomial coefficient identities"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Vandermonde's identity $\\binom{m+n}{r} = \\sum_{i+j=r} \\binom{m}{i}\\binom{n}{j}$ was published by Alexandre-Théophile Vandermonde in 1772, though instances appear in Chu Shih-Chieh's 'Precious Mirror of the Four Elements' (1303). The identity is one of the most fundamental in combinatorics, encoding the fact that choosing $r$ items from $m+n$ objects is equivalent to choosing some from the first $m$ and the rest from the last $n$. The algebraic proof via coefficient comparison — factoring $(1+X)^{m+n}$ as $(1+X)^m \\cdot (1+X)^n$ and equating coefficients of $X^r$ — is perhaps the most elegant approach, reducing the combinatorial identity to the monoid law $a^{m+n} = a^m \\cdot a^n$ and the Cauchy product formula for polynomial multiplication. This proof technique, sometimes called the 'generating function method', has become a standard tool in algebraic combinatorics.",
+    "problemStatement": "**Vandermonde's Identity**: For all natural numbers $m$, $n$, $r$:\n$$\\binom{m+n}{r} = \\sum_{i+j=r} \\binom{m}{i} \\cdot \\binom{n}{j}$$\n\nProved algebraically by comparing coefficients of $X^r$ in the polynomial identity $(1+X)^{m+n} = (1+X)^m \\cdot (1+X)^n$.",
+    "proofStrategy": "The proof has three layers: (1) The **exponent law** $(1+X)^{m+n} = (1+X)^m \\cdot (1+X)^n$ in the polynomial ring $\\mathbb{N}[X]$, via the general monoid law `pow_add`. (2) The **Cauchy product** formula $[X^r](f \\cdot g) = \\sum_{i+j=r} f_i \\cdot g_j$, which translates polynomial multiplication into a convolution sum. (3) **Coefficient comparison**: since $(1+X)^n$ has $r$-th coefficient $\\binom{n}{r}$, equating the two sides yields Vandermonde's identity. Mathlib's `Nat.add_choose_eq` provides the identity directly; the formalization shows how it arises from the polynomial algebra structure.",
+    "keyInsights": [
+      "The entire proof reduces to three facts: the monoid exponent law, the Cauchy product formula, and coefficient extraction from (1+X)^n — all available in Mathlib.",
+      "Vandermonde's identity is the coefficient-level shadow of the exponent law in the polynomial ring ℕ[X] — a single algebraic identity encodes the entire combinatorial argument.",
+      "Symmetry (swapping m and n) follows from commutativity of addition, not from manipulating the sum — the algebraic proof makes symmetry trivial.",
+      "Pascal's rule C(n+1, r+1) = C(n,r) + C(n, r+1) is the m=1 case of Vandermonde, unifying the recursive structure of Pascal's triangle with the convolution formula.",
+      "The self-convolution case m=n gives C(2n,r) = Σ C(n,i)·C(n,j), which for r=n yields the Chu-Vandermonde identity C(2n,n) = Σ C(n,k)², connecting to central binomial coefficients."
+    ]
   },
   "sections": [
-    {"id": "exponent-law", "title": "Exponent Law", "summary": "The polynomial identity (1+X)^(m+n) = (1+X)^m · (1+X)^n.", "startLine": 30, "endLine": 38},
-    {"id": "vandermonde", "title": "Vandermonde's Identity", "summary": "The antidiagonal convolution formula and its symmetry.", "startLine": 43, "endLine": 57},
-    {"id": "cauchy", "title": "Cauchy Product", "summary": "Polynomial coefficient multiplication equals antidiagonal sum.", "startLine": 62, "endLine": 82},
-    {"id": "corollaries", "title": "Corollaries", "summary": "Equal parameters case and Pascal's rule.", "startLine": 87, "endLine": 98}
+    {"id": "header", "title": "Module Documentation", "summary": "States the open question (can the algebraic coefficient-comparison proof be formalized?), outlines the four components, and lists references.", "startLine": 1, "endLine": 24},
+    {"id": "exponent-law", "title": "Exponent Law", "summary": "The polynomial identity (1+X)^(m+n) = (1+X)^m · (1+X)^n, proved in one line via pow_add — the monoid exponent law applied to ℕ[X].", "startLine": 28, "endLine": 36},
+    {"id": "vandermonde", "title": "Vandermonde's Identity", "summary": "The antidiagonal convolution formula C(m+n,r) = Σ_{i+j=r} C(m,i)·C(n,j) via Nat.add_choose_eq, plus the symmetry theorem.", "startLine": 38, "endLine": 54},
+    {"id": "cauchy", "title": "Cauchy Product Structure", "summary": "The Cauchy product formula, coefficient comparison principle, and the algebraic proof structure connecting all three layers.", "startLine": 56, "endLine": 77},
+    {"id": "corollaries", "title": "Corollaries", "summary": "Equal parameters case C(2n,r) = Σ C(n,i)·C(n,j) and Pascal's rule as the m=1 specialization of Vandermonde.", "startLine": 79, "endLine": 92},
+    {"id": "summary", "title": "Summary", "summary": "Packaging theorem bundling the exponent law, Vandermonde identity, and Cauchy product into a single conjunction.", "startLine": 94, "endLine": 111}
   ],
   "conclusion": {
-    "summary": "10 theorems proved with 0 sorries, 0 axioms. The algebraic proof of Vandermonde's identity via polynomial coefficient comparison is fully formalized.",
-    "implications": "Establishes the polynomial coefficient comparison technique as a reusable proof strategy for combinatorial identities in Lean 4.",
+    "summary": "10 theorems proved with 0 sorries and 0 axioms. The algebraic proof of Vandermonde's identity via polynomial coefficient comparison is fully formalized, demonstrating how a single algebraic fact (the monoid exponent law) generates a fundamental combinatorial identity through the Cauchy product structure of polynomial multiplication.",
+    "implications": "Establishes the polynomial coefficient comparison technique as a reusable proof strategy for combinatorial identities in Lean 4. The same method applies to any identity derivable from polynomial algebra: the q-binomial theorem, Lucas' theorem, and Dixon's identity all admit similar algebraic proofs. The formalization also validates that Mathlib's polynomial library is mature enough for generating-function-style arguments.",
     "openQuestions": [
-      "Can the q-Vandermonde identity for Gaussian binomial coefficients be formalized?",
-      "Can the Lindström-Gessel-Viennot lemma be derived from this algebraic framework?"
+      "Can the q-Vandermonde identity for Gaussian binomial coefficients be formalized using the same coefficient-comparison technique with q-polynomials?",
+      "Can the Lindström-Gessel-Viennot lemma (determinantal formula for non-intersecting lattice paths) be derived from this algebraic framework?",
+      "Can the Chu-Vandermonde identity C(2n,n) = Σ C(n,k)² be given a direct combinatorial proof (double-counting) alongside this algebraic one?",
+      "Can the proof technique be automated: given a polynomial identity, automatically extract the coefficient-level combinatorial identity?"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Enrichment pass for **Vandermonde Identity: Algebraic Proof via Coefficient Comparison** (`binomial-theorem-oq-04-oq-02`).

### Enrichment
- Added full **overview** section: historicalContext (Vandermonde 1772, Chu Shih-Chieh 1303), problemStatement with LaTeX, proofStrategy (3-layer algebraic approach), 5 keyInsights
- Added **3 references** (Vandermonde 1772, Chu Shih-Chieh 1303, Knuth 1968)
- Added **4 cross-references** (binomial theorem, 2D hockey stick, combinations formula, Pascal's hexagon)
- Added 2 `mathlibDependencies` (pow_add, Nat.choose_succ_succ)
- Expanded `sections` from 4 → 6 covering full file (lines 1–111)
- Expanded `conclusion` with deeper implications and 4 open questions

Annotations (9 existing) were already good quality — no changes needed.

## Test plan
- [x] JSON validated (`python3 -m json.tool`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)