### PR TITLE
Enrich erdos-167 + erdos-17: fix annotation types, add references

### DIFF
--- a/src/data/proofs/erdos-17/meta.json
+++ b/src/data/proofs/erdos-17/meta.json
@@ -43,6 +43,22 @@
       "Connection to prime gaps formalized",
       "OEIS A038133 cluster prime sequence listed"
     ],
+    "references": [
+      {
+        "authors": "Blecksmith, Richard; Erdős, Paul; Selfridge, John L.",
+        "title": "Cluster primes",
+        "year": "1999",
+        "venue": "American Mathematical Monthly",
+        "note": "Established upper bounds showing cluster primes have density 0: count ≪ x/(log x)^A for all A"
+      },
+      {
+        "authors": "Elsholtz, Christian",
+        "title": "Cluster primes and other additive prime number properties",
+        "year": "2003",
+        "venue": "Journal of Number Theory",
+        "note": "Improved upper bound: count ≪ x·exp(-c(log log x)²) with c < 1/8"
+      }
+    ],
     "dateAdded": "01/14/25",
     "axiomCount": 12,
     "prerequisites": [
@@ -129,24 +145,24 @@
   },
   "crossReferences": [
     {
-      "targetId": "bounded-prime-gaps",
+      "proofId": "bounded-prime-gaps",
       "relationship": "related",
-      "description": "Bounded prime gaps (Maynard-Tao) ensure small differences exist, but cluster primes require ALL small even differences — a much stronger condition"
+      "note": "Bounded prime gaps (Maynard-Tao) ensure small differences exist, but cluster primes require ALL small even differences — a much stronger condition"
     },
     {
-      "targetId": "erdos-16",
+      "proofId": "erdos-16",
       "relationship": "related",
-      "description": "Both are Erdős problems about prime distribution: #16 concerns representing odds as 2^k + p, while #17 concerns covering even differences with prime pairs"
+      "note": "Both are Erdős problems about prime distribution: #16 concerns representing odds as 2^k + p, while #17 concerns covering even differences with prime pairs"
     },
     {
-      "targetId": "twin-primes-special",
+      "proofId": "twin-primes-special",
       "relationship": "related",
-      "description": "Twin primes (p, p+2) provide the smallest prime differences; cluster primes require ALL small even differences to be realized, making it a much stronger condition"
+      "note": "Twin primes (p, p+2) provide the smallest prime differences; cluster primes require ALL small even differences to be realized, making it a much stronger condition"
     },
     {
-      "targetId": "infinitude-primes",
+      "proofId": "infinitude-primes",
       "relationship": "uses",
-      "description": "The infinitude of primes is a prerequisite; the cluster prime question asks whether a specific sparse subset of primes is also infinite"
+      "note": "The infinitude of primes is a prerequisite; the cluster prime question asks whether a specific sparse subset of primes is also infinite"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for two entries:

### Erdős Problem #167: Tuza's Conjecture
- Fixed **5 annotation types**: `"theorem"` → `"technique"`, `"axiom"` → `"context"`
- Added **3 references** (Tuza 1981, Haxell-Kohayakawa 1998, Haxell 1999)
- Improved **7 section summaries** with descriptive content
- Fixed `crossReferences` format: `targetId` → `proofId`

### Erdős Problem #17: Cluster Primes
- Added **2 references** (Blecksmith-Erdős-Selfridge 1999, Elsholtz 2003)
- Fixed `crossReferences` format: `targetId` → `proofId`, `description` → `note`

## Test plan
- [x] JSON validated (`python3 -m json.tool`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)