### PR TITLE
Fix build: add missing implications field to cauchy-schwarz conclusion

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
@@ -101,6 +101,7 @@
   ],
   "conclusion": {
     "summary": "A collection of fundamental inequalities proved from first principles. 8 theorems proved, 2 sorries (Young-ε and Schur). All proofs use algebraic identities and nlinarith.",
+    "implications": "Establishes a toolkit of fundamental inequalities in Lean 4, demonstrating that classical competition-mathematics results can be formalized from first principles using nlinarith and algebraic identities.",
     "openQuestions": [
       "Prove Young with epsilon via sqrt substitution",
       "Prove Schur's inequality via SOS decomposition",


### PR DESCRIPTION
## Summary
- Adds missing `implications` field to `cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json` conclusion
- PR #4468 added a `conclusion` object without the required `implications` property, causing TypeScript build failure

## Test plan
- [x] Build should pass with this fix

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>