### PR TITLE
Enrich CS/AM-GM/Nesbitt/Titu: full annotations, history, references

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/annotations.json
@@ -1,1 +1,122 @@
-[]
+[
+  {
+    "id": "ann-cs-oq01-oq01-oq01-00-preamble",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 26 },
+    "type": "context",
+    "title": "Imports and Setup",
+    "content": "Imports the full Mathlib library and opens the Real namespace. The file works entirely with explicit real-valued coordinates rather than abstract inner product spaces, making all proofs accessible to nlinarith's polynomial arithmetic.",
+    "mathContext": "By working in $\\mathbb{R}^n$ with explicit coordinates $(a_1, \\ldots, a_n)$ rather than abstract inner product spaces, each inequality reduces to a polynomial identity that `nlinarith` can verify via sum-of-squares certificates.",
+    "significance": "context",
+    "relatedConcepts": ["nlinarith", "Real namespace", "polynomial arithmetic"],
+    "prerequisites": ["Lean 4 syntax", "Mathlib"]
+  },
+  {
+    "id": "ann-cs-oq01-oq01-oq01-01-cs-r2",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
+    "range": { "startLine": 31, "endLine": 36 },
+    "type": "concept",
+    "title": "Cauchy-Schwarz for $\\mathbb{R}^2$ via Lagrange Identity",
+    "content": "Proves $(a_1 b_1 + a_2 b_2)^2 \\leq (a_1^2 + a_2^2)(b_1^2 + b_2^2)$ in a single line: the hint `sq_nonneg (a₁ * b₂ - a₂ * b₁)` tells nlinarith that the cross-term $(a_1 b_2 - a_2 b_1)^2 \\geq 0$, which is exactly the gap between RHS and LHS in the Lagrange identity.",
+    "mathContext": "The **Lagrange identity** states $(a_1 b_1 + a_2 b_2)^2 + (a_1 b_2 - a_2 b_1)^2 = (a_1^2 + a_2^2)(b_1^2 + b_2^2)$. Since the cross-term square is nonneg, CS follows immediately. This is the $n=2$ case; geometrically, $(a_1 b_2 - a_2 b_1)^2 = \\|\\mathbf{a} \\times \\mathbf{b}\\|^2$.",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange identity", "cross product", "sq_nonneg", "inner product"],
+    "prerequisites": ["real arithmetic", "squares are nonneg"]
+  },
+  {
+    "id": "ann-cs-oq01-oq01-oq01-02-cs-r3",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
+    "range": { "startLine": 38, "endLine": 45 },
+    "type": "concept",
+    "title": "Cauchy-Schwarz for $\\mathbb{R}^3$",
+    "content": "The 3D Cauchy-Schwarz requires three cross-term squares as nlinarith hints: $(a_1 b_2 - a_2 b_1)^2$, $(a_1 b_3 - a_3 b_1)^2$, and $(a_2 b_3 - a_3 b_2)^2$. These are exactly the three components of the vector cross product $\\mathbf{a} \\times \\mathbf{b}$ in $\\mathbb{R}^3$.",
+    "mathContext": "The generalized Lagrange identity for $\\mathbb{R}^3$: $(\\sum a_i b_i)^2 + \\sum_{i<j}(a_i b_j - a_j b_i)^2 = (\\sum a_i^2)(\\sum b_i^2)$. The $\\binom{3}{2} = 3$ cross-terms account for all $2 \\times 2$ minors of the $2 \\times 3$ matrix $\\begin{pmatrix} a_1 & a_2 & a_3 \\\\ b_1 & b_2 & b_3 \\end{pmatrix}$.",
+    "significance": "key",
+    "relatedConcepts": ["Binet-Cauchy formula", "cross product components", "Gram determinant"],
+    "prerequisites": ["Lagrange identity", "vector cross product"]
+  },
+  {
+    "id": "ann-cs-oq01-oq01-oq01-03-young",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
+    "range": { "startLine": 51, "endLine": 54 },
+    "type": "concept",
+    "title": "Young's Inequality ($p = q = 2$)",
+    "content": "Young's inequality $ab \\leq a^2/2 + b^2/2$ is proved from the single hint $(a-b)^2 \\geq 0$, which expands to $a^2 - 2ab + b^2 \\geq 0$, i.e., $ab \\leq (a^2 + b^2)/2$. This is the $p = q = 2$ case of the general Young inequality $ab \\leq a^p/p + b^q/q$ for conjugate exponents.",
+    "mathContext": "**Young's inequality** (1912): $ab \\leq \\frac{a^p}{p} + \\frac{b^q}{q}$ for $\\frac{1}{p} + \\frac{1}{q} = 1$. At $p = q = 2$: $ab \\leq \\frac{a^2}{2} + \\frac{b^2}{2}$. This is the starting point for proving Hölder's inequality via duality.",
+    "significance": "key",
+    "relatedConcepts": ["Young's inequality", "conjugate exponents", "Hölder inequality", "AM-GM"],
+    "prerequisites": ["real arithmetic"]
+  },
+  {
+    "id": "ann-cs-oq01-oq01-oq01-04-young-eps",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 60 },
+    "type": "technique",
+    "title": "Young's Inequality with $\\varepsilon$ (sorry)",
+    "content": "The parametric form $ab \\leq \\varepsilon a^2/2 + b^2/(2\\varepsilon)$ is essential in PDE energy estimates. Follows from applying the base Young inequality to $\\sqrt{\\varepsilon}\\,a$ and $b/\\sqrt{\\varepsilon}$. Currently sorry'd — the substitution requires careful handling of the square root.",
+    "mathContext": "For $\\varepsilon > 0$: $ab = (\\sqrt{\\varepsilon}\\,a)(b/\\sqrt{\\varepsilon}) \\leq \\frac{(\\sqrt{\\varepsilon}\\,a)^2}{2} + \\frac{(b/\\sqrt{\\varepsilon})^2}{2} = \\frac{\\varepsilon a^2}{2} + \\frac{b^2}{2\\varepsilon}$. This is used extensively in Sobolev embedding and elliptic regularity proofs.",
+    "significance": "supporting",
+    "relatedConcepts": ["PDE energy estimates", "epsilon-delta", "Sobolev spaces"],
+    "prerequisites": ["Young's inequality", "square root properties"]
+  },
+  {
+    "id": "ann-cs-oq01-oq01-oq01-05-amgm",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
+    "range": { "startLine": 66, "endLine": 77 },
+    "type": "concept",
+    "title": "AM-GM: Two Equivalent Forms",
+    "content": "Two forms of AM-GM for nonneg reals: (1) `amgm_two`: $\\sqrt{ab} \\leq (a+b)/2$, proved via `sqrt_le_sqrt` after showing $ab \\leq ((a+b)/2)^2$; (2) `amgm_sq`: $ab \\leq ((a+b)/2)^2$, a direct algebraic form proved from $(a-b)^2 \\geq 0$. The first form requires square root manipulation; the second is purely polynomial.",
+    "mathContext": "The AM-GM inequality $\\sqrt{ab} \\leq \\frac{a+b}{2}$ is equivalent to $(\\sqrt{a} - \\sqrt{b})^2 \\geq 0$. The quadratic form $ab \\leq \\left(\\frac{a+b}{2}\\right)^2$ avoids square roots entirely and is the form most useful in algebraic contexts.",
+    "significance": "key",
+    "relatedConcepts": ["arithmetic mean", "geometric mean", "power mean hierarchy"],
+    "prerequisites": ["squares nonneg", "Real.sqrt_le_sqrt"]
+  },
+  {
+    "id": "ann-cs-oq01-oq01-oq01-06-qm-am",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
+    "range": { "startLine": 79, "endLine": 83 },
+    "type": "concept",
+    "title": "QM-AM Inequality",
+    "content": "The Quadratic Mean–Arithmetic Mean inequality: $(a+b)^2/4 \\leq (a^2+b^2)/2$, or equivalently $\\text{AM}(a,b) \\leq \\text{QM}(a,b)$. Proved from the single hint $(a-b)^2 \\geq 0$. Together with AM-GM, this gives the chain $\\text{GM} \\leq \\text{AM} \\leq \\text{QM}$.",
+    "mathContext": "The power mean inequality chain: $\\min \\leq \\text{HM} \\leq \\text{GM} \\leq \\text{AM} \\leq \\text{QM} \\leq \\max$. QM-AM is the $M_1 \\leq M_2$ case, where $M_p = \\left(\\frac{a^p + b^p}{2}\\right)^{1/p}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["power mean", "quadratic mean", "Jensen's inequality"],
+    "prerequisites": ["AM-GM"]
+  },
+  {
+    "id": "ann-cs-oq01-oq01-oq01-07-titu",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
+    "range": { "startLine": 89, "endLine": 99 },
+    "type": "technique",
+    "title": "Titu's Lemma (Engel Form of Cauchy-Schwarz)",
+    "content": "Titu's lemma: $\\frac{a_1^2}{b_1} + \\frac{a_2^2}{b_2} \\geq \\frac{(a_1+a_2)^2}{b_1+b_2}$ for $b_i > 0$. The proof first combines fractions via `div_add_div`, then reduces to `div_le_div_iff₀` to clear denominators, and finally uses `nlinarith` with the key hint $(a_1 b_2 - a_2 b_1)^2 \\geq 0$. This is the CS inequality applied to vectors $(a_i/\\sqrt{b_i})$ and $(\\sqrt{b_i})$.",
+    "mathContext": "**Titu's lemma** (also Engel form or Sedrakyan's inequality): $\\sum_i \\frac{a_i^2}{b_i} \\geq \\frac{(\\sum a_i)^2}{\\sum b_i}$. Obtained from Cauchy-Schwarz by setting $x_i = a_i/\\sqrt{b_i}$, $y_i = \\sqrt{b_i}$: $(\\sum x_i y_i)^2 \\leq (\\sum x_i^2)(\\sum y_i^2)$ gives $\\frac{(\\sum a_i)^2}{\\sum b_i} \\leq \\sum \\frac{a_i^2}{b_i}$.",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy-Schwarz", "Sedrakyan's inequality", "competition mathematics", "div_le_div_iff"],
+    "prerequisites": ["Cauchy-Schwarz", "positive denominators"]
+  },
+  {
+    "id": "ann-cs-oq01-oq01-oq01-08-nesbitt",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
+    "range": { "startLine": 109, "endLine": 123 },
+    "type": "technique",
+    "title": "Nesbitt's Inequality via field_simp and SOS",
+    "content": "Nesbitt's inequality: $\\frac{a}{b+c} + \\frac{b}{a+c} + \\frac{c}{a+b} \\geq \\frac{3}{2}$ for $a,b,c > 0$. The proof rewrites via `ge_iff_le` and `sub_nonneg`, then uses `field_simp` to clear the triple denominator $(b+c)(a+c)(a+b)$, reducing to a polynomial inequality. The SOS certificate uses three difference squares $(a-b)^2, (b-c)^2, (a-c)^2$ plus products $ab, bc, ac > 0$ for the mixed terms.",
+    "mathContext": "Nesbitt's inequality (1903) is equivalent to $\\sum_{\\text{cyc}} \\frac{a}{b+c} = \\sum_{\\text{cyc}} \\left(\\frac{a+b+c}{b+c} - 1\\right) = (a+b+c)\\sum_{\\text{cyc}} \\frac{1}{b+c} - 3 \\geq \\frac{3}{2}$, which by Cauchy-Schwarz (or AM-HM) gives $(a+b+c) \\cdot \\frac{9}{2(a+b+c)} = \\frac{9}{2}$, so the sum $\\geq \\frac{9}{2} - 3 = \\frac{3}{2}$.",
+    "significance": "key",
+    "relatedConcepts": ["symmetric inequalities", "field_simp", "SOS decomposition", "AM-HM"],
+    "prerequisites": ["field_simp tactic", "positivity", "nlinarith"]
+  },
+  {
+    "id": "ann-cs-oq01-oq01-oq01-09-schur",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
+    "range": { "startLine": 129, "endLine": 137 },
+    "type": "concept",
+    "title": "Schur's Inequality (sorry)",
+    "content": "Schur's inequality at $t=1$: $a(a-b)(a-c) + b(b-a)(b-c) + c(c-a)(c-b) \\geq 0$ for $a,b,c \\geq 0$. Currently sorry'd because the SOS decomposition is non-trivial — the standard proof assumes WLOG $a \\geq b \\geq c$ and rewrites as $a(a-b)(a-c) + c(b-c)(a-c) + b(a-b)(b-c) \\geq 0$, which requires case analysis on the sign of $(a-c)$.",
+    "mathContext": "**Schur's inequality** (1923): For $a,b,c \\geq 0$ and $t \\geq 0$, $a^t(a-b)(a-c) + b^t(b-a)(b-c) + c^t(c-a)(c-b) \\geq 0$. At $t=1$ this is equivalent to $a^3 + b^3 + c^3 + abc \\geq ab(a+b) + bc(b+c) + ca(c+a)$, a standard olympiad inequality.",
+    "significance": "supporting",
+    "relatedConcepts": ["Schur's inequality", "Muirhead", "symmetric functions", "olympiad inequalities"],
+    "prerequisites": ["WLOG ordering", "SOS decomposition"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
@@ -33,80 +33,133 @@
       "titu_two: Titu's lemma (Engel form of CS) for 2 terms",
       "nesbitt: Nesbitt's inequality a/(b+c)+b/(a+c)+c/(a+b) ≥ 3/2"
     ],
-    "crossReferences": [
+    "mathlibDependencies": [
       {
-        "proofId": "cauchy-schwarz-integral-oq-01-oq-01",
-        "relationship": "extends",
-        "description": "Extends the measure-theoretic Hölder hierarchy with concrete finite-dimensional applications"
+        "theorem": "sq_nonneg",
+        "description": "For any x, x² ≥ 0 — the fundamental SOS certificate used by nlinarith",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
       },
       {
-        "proofId": "cauchy-schwarz-integral",
-        "relationship": "related",
-        "description": "The original integral Cauchy-Schwarz inequality"
+        "theorem": "Real.sqrt_le_sqrt",
+        "description": "Monotonicity of square root: a ≤ b → √a ≤ √b — used in AM-GM proof",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       },
       {
-        "proofId": "amgm-inequality",
-        "relationship": "related",
-        "description": "The general AM-GM inequality"
+        "theorem": "div_add_div",
+        "description": "a/b + c/d = (ad + bc)/(bd) — used to combine fractions in Titu's lemma",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "div_le_div_iff₀",
+        "description": "a/b ≤ c/d ↔ ad ≤ bc for positive denominators — clears fractions in Titu and Nesbitt",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ],
+    "references": [
+      {
+        "authors": "Cauchy, Augustin-Louis",
+        "title": "Cours d'analyse de l'École Royale Polytechnique",
+        "year": "1821",
+        "venue": "Paris",
+        "note": "First statement of the discrete Cauchy inequality for finite sums"
+      },
+      {
+        "authors": "Schwarz, Hermann Amandus",
+        "title": "Über ein die Flächen kleinsten Flächeninhalts betreffendes Problem der Variationsrechnung",
+        "year": "1885",
+        "venue": "Acta Societatis Scientiarum Fennicae 15, pp. 315-362",
+        "note": "Extended Cauchy's inequality to the integral (L²) setting"
+      },
+      {
+        "authors": "Nesbitt, A. M.",
+        "title": "Problem 15114",
+        "year": "1903",
+        "venue": "Educational Times",
+        "note": "Original statement of the inequality a/(b+c)+b/(a+c)+c/(a+b) ≥ 3/2"
       }
     ]
   },
   "overview": {
-    "historicalContext": "These inequalities form the core toolkit of mathematical olympiad problem-solving and analysis. Cauchy-Schwarz (1821/1885) is the most frequently used inequality in competition mathematics. Titu's lemma, named after Titu Andreescu, is the Engel form of CS widely used in inequality proofs. Nesbitt's inequality (1903) is a classic symmetric inequality challenge.",
-    "problemStatement": "Prove fundamental inequalities in finite dimensions from first principles using algebraic identities and sum-of-squares decompositions.",
-    "proofStrategy": "All proofs use nlinarith with explicit sum-of-squares witnesses. The key insight is the Lagrange identity: (Σaᵢbᵢ)² = (Σaᵢ²)(Σbᵢ²) - Σᵢ<ⱼ(aᵢbⱼ-aⱼbᵢ)², making CS a consequence of squares being nonneg.",
+    "historicalContext": "Cauchy first stated the finite sum inequality $(\\sum a_i b_i)^2 \\leq (\\sum a_i^2)(\\sum b_i^2)$ in his 1821 Cours d'analyse. Schwarz extended it to integrals in 1885, and Bunyakovsky independently proved the integral form in 1859. Young's inequality (1912) arose from the study of conjugate exponents in $L^p$ spaces and became a key tool in functional analysis and PDE theory. Titu's lemma, popularized by Romanian mathematician Titu Andreescu for olympiad use, is actually a special case of Cauchy-Schwarz dating to Engel. Nesbitt's inequality appeared as Problem 15114 in the 1903 Educational Times. Together, these inequalities form the core toolkit of both competition mathematics and analysis — Cauchy-Schwarz alone appears in virtually every branch of mathematics from inner product spaces to probability theory to quantum mechanics.",
+    "problemStatement": "Prove fundamental inequalities in finite dimensions from first principles:\n\n1. **Cauchy-Schwarz** ($\\mathbb{R}^2$, $\\mathbb{R}^3$): $(\\sum a_i b_i)^2 \\leq (\\sum a_i^2)(\\sum b_i^2)$\n2. **Young**: $ab \\leq a^2/2 + b^2/2$\n3. **AM-GM**: $\\sqrt{ab} \\leq (a+b)/2$\n4. **QM-AM**: $\\frac{(a+b)^2}{4} \\leq \\frac{a^2+b^2}{2}$\n5. **Titu**: $\\frac{a_1^2}{b_1} + \\frac{a_2^2}{b_2} \\geq \\frac{(a_1+a_2)^2}{b_1+b_2}$\n6. **Nesbitt**: $\\frac{a}{b+c}+\\frac{b}{a+c}+\\frac{c}{a+b} \\geq \\frac{3}{2}$",
+    "proofStrategy": "All proofs use `nlinarith` with explicit sum-of-squares (SOS) witnesses. The unifying insight is that every inequality here reduces to asserting some expression of the form $\\sum c_i s_i^2 \\geq 0$ where $s_i$ are polynomial expressions and $c_i \\geq 0$. By providing `sq_nonneg` hints for the right cross-terms, `nlinarith` can verify the polynomial identity automatically. For rational-function inequalities (Titu, Nesbitt), `field_simp` or manual `div_le_div_iff₀` first clears denominators to reduce to the polynomial case.",
     "keyInsights": [
-      "Cauchy-Schwarz in coordinates reduces to the Lagrange identity",
-      "AM-GM follows from CS via √(ab) ≤ ((a+b)/2)² = a²+b²+2ab ≥ 4ab",
-      "Titu's lemma is proved by clearing denominators and applying CS",
-      "Nesbitt's inequality uses field_simp to clear fractions then SOS"
+      "The Lagrange identity $(\\sum a_i b_i)^2 + \\sum_{i<j}(a_i b_j - a_j b_i)^2 = (\\sum a_i^2)(\\sum b_i^2)$ makes CS a one-line consequence of squares being nonneg",
+      "Every inequality in this file has a sum-of-squares certificate: the difference RHS - LHS can be written as a nonneg combination of squares",
+      "AM-GM requires two distinct proofs: the square root form needs sqrt_le_sqrt (monotonicity), while the quadratic form is purely algebraic",
+      "Titu's lemma is the 'Schur complement' of Cauchy-Schwarz: applying CS to vectors $(a_i/\\sqrt{b_i})$ and $(\\sqrt{b_i})$",
+      "Nesbitt's proof strategy — rewrite as (sum) - 3/2 ≥ 0, clear denominators via field_simp, then apply nlinarith — generalizes to many symmetric inequality problems"
     ]
   },
   "sections": [
     {
       "id": "part-i-cs",
       "title": "Part I: Cauchy-Schwarz in Coordinates",
-      "startLine": 24,
-      "endLine": 41,
-      "summary": "Proves CS for ℝ² and ℝ³ using nlinarith with Lagrange identity cross-terms."
+      "startLine": 27,
+      "endLine": 45,
+      "summary": "Proves CS for ℝ² and ℝ³ using nlinarith with Lagrange identity cross-terms as SOS witnesses."
     },
     {
       "id": "part-ii-young",
       "title": "Part II: Young's Inequality",
-      "startLine": 43,
+      "startLine": 47,
       "endLine": 60,
-      "summary": "Proves Young ab ≤ a²/2+b²/2 from (a-b)²≥0. Young-ε version is sorry."
+      "summary": "Young's inequality ab ≤ a²/2 + b²/2 from (a-b)² ≥ 0. Young with ε is sorry'd (needs sqrt substitution)."
     },
     {
       "id": "part-iii-amgm",
       "title": "Part III: AM-GM Inequalities",
       "startLine": 62,
-      "endLine": 88,
-      "summary": "AM-GM, quadratic AM-GM, and QM-AM, all from SOS decompositions."
+      "endLine": 83,
+      "summary": "Three mean inequalities: AM-GM via sqrt monotonicity, quadratic AM-GM from (a-b)² ≥ 0, and QM-AM."
     },
     {
       "id": "part-iv-titu",
-      "title": "Part IV: Titu's Lemma",
-      "startLine": 90,
-      "endLine": 103,
-      "summary": "Titu's lemma (Engel form CS) for 2 terms via denominator clearing."
+      "title": "Part IV: Titu's Lemma (Engel Form)",
+      "startLine": 85,
+      "endLine": 99,
+      "summary": "Titu's lemma for 2 terms via div_add_div to combine fractions, div_le_div_iff₀ to clear denominators, and nlinarith with (a₁b₂ - a₂b₁)² ≥ 0."
     },
     {
       "id": "part-v-nesbitt",
       "title": "Part V: Nesbitt's Inequality",
-      "startLine": 105,
-      "endLine": 124,
-      "summary": "Nesbitt's a/(b+c)+b/(a+c)+c/(a+b)≥3/2 via field_simp and SOS."
+      "startLine": 101,
+      "endLine": 123,
+      "summary": "Nesbitt's inequality a/(b+c)+b/(a+c)+c/(a+b) ≥ 3/2 via ge_iff_le, sub_nonneg, field_simp to clear the triple denominator, then nlinarith with three difference squares."
+    },
+    {
+      "id": "part-vi-schur",
+      "title": "Part VI: Schur's Inequality",
+      "startLine": 125,
+      "endLine": 139,
+      "summary": "Schur's inequality at t=1: a(a-b)(a-c)+b(b-a)(b-c)+c(c-a)(c-b) ≥ 0 for nonneg reals. Currently sorry'd — requires WLOG ordering and non-trivial SOS decomposition."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-integral-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Extends the measure-theoretic Hölder hierarchy with concrete finite-dimensional applications and competition-mathematics results"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral",
+      "relationship": "related",
+      "description": "The original integral Cauchy-Schwarz inequality $\\left(\\int fg\\right)^2 \\leq \\int f^2 \\cdot \\int g^2$. This entry proves the discrete coordinate versions."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "The general AM-GM inequality for $n$ variables. This entry proves the $n=2$ case from first principles as a corollary of Cauchy-Schwarz."
     }
   ],
   "conclusion": {
-    "summary": "A collection of fundamental inequalities proved from first principles. 8 theorems proved, 2 sorries (Young-ε and Schur). All proofs use algebraic identities and nlinarith.",
-    "implications": "Establishes a toolkit of fundamental inequalities in Lean 4, demonstrating that classical competition-mathematics results can be formalized from first principles using nlinarith and algebraic identities.",
+    "summary": "A toolkit of 8 fundamental inequalities (plus 2 sorry'd) proved from first principles using nlinarith with sum-of-squares certificates. Covers the Cauchy-Schwarz → Young → AM-GM → Titu → Nesbitt chain, demonstrating that the nlinarith tactic with explicit SOS hints can handle most classical competition inequalities.",
+    "implications": "**For formalization**: Demonstrates that nlinarith + SOS witnesses is a practical strategy for formalizing polynomial inequalities, reducing each proof to identifying the right cross-term squares.\n\n**For competition mathematics**: Provides machine-verified proofs of core olympiad tools, establishing a foundation for formalizing harder competition results.\n\n**For analysis**: Young's inequality with ε (when proved) would connect to PDE energy estimates and Sobolev embedding proofs.",
     "openQuestions": [
-      "Prove Young with epsilon via sqrt substitution",
-      "Prove Schur's inequality via SOS decomposition",
-      "Extend to n-variable Cauchy-Schwarz (Finset.sum version)",
-      "Power mean inequality chain: min ≤ HM ≤ GM ≤ AM ≤ QM ≤ max"
+      "Prove Young with epsilon via the substitution a → √ε·a, b → b/√ε",
+      "Prove Schur's inequality via WLOG ordering and SOS decomposition with case analysis",
+      "Extend to n-variable Cauchy-Schwarz using Finset.sum and induction",
+      "Formalize the full power mean inequality chain: min ≤ HM ≤ GM ≤ AM ≤ QM ≤ max"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Created 10 comprehensive annotations covering all proof sections (previously empty)
- Expanded `historicalContext` with Cauchy (1821), Bunyakovsky (1859), Schwarz (1885), Nesbitt (1903)
- Added `mathlibDependencies` (sq_nonneg, sqrt_le_sqrt, div_add_div, div_le_div_iff₀)
- Added `references` (Cauchy 1821, Schwarz 1885, Nesbitt 1903)
- Moved `crossReferences` from nested `meta` to top-level field
- Added Part VI (Schur) section, fixed all section line ranges
- Deepened `keyInsights` with SOS certificates and Schur complement interpretation
- Expanded `conclusion` with implications for formalization, competition math, and analysis

## Test plan
- [x] `meta.json` validates as well-formed JSON
- [x] `annotations.json` validates as well-formed JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)