### PR TITLE
Enrich erdos-17: fix crossRef schema, add annotations and sections

### DIFF
--- a/src/data/proofs/erdos-17/annotations.json
+++ b/src/data/proofs/erdos-17/annotations.json
@@ -168,6 +168,42 @@
     "prerequisites": ["prime gaps", "bounded gaps between primes"]
   },
   {
+    "id": "ann-e17-cluster-count",
+    "proofId": "erdos-17",
+    "range": { "startLine": 139, "endLine": 141 },
+    "type": "definition",
+    "title": "Cluster Prime Counting Function",
+    "content": "`clusterPrimeCount x` counts cluster primes up to x by filtering primesUpTo x with a classical decidability instance. This is noncomputable since it uses Classical.dec for the cluster predicate, which involves quantifying over all even numbers and all prime pairs.",
+    "mathContext": "$\\pi_{\\text{cluster}}(x) = |\\{p \\le x : p \\text{ is a cluster prime}\\}|$. The bounds of Blecksmith-Erdős-Selfridge and Elsholtz bound this counting function from above.",
+    "significance": "supporting",
+    "relatedConcepts": ["prime counting function", "Classical.dec", "Finset.filter"],
+    "prerequisites": ["IsClusterPrime", "classical decidability"]
+  },
+  {
+    "id": "ann-e17-tao-difficult",
+    "proofId": "erdos-17",
+    "range": { "startLine": 220, "endLine": 223 },
+    "type": "insight",
+    "title": "Tao's Assessment and Unboundedness",
+    "content": "Axiomatizes that for any bound $A > 0$, there exists a cluster prime $p > A$. This is equivalent to the set of cluster primes being unbounded (and hence infinite). Note: this is the main conjecture restated — it axiomatizes the positive answer to Erdős's question.",
+    "mathContext": "$\\forall A > 0, \\exists p$ cluster prime with $p > A$. Equivalently, $\\sup\\{p : p \\text{ cluster}\\} = +\\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["unbounded sets", "Terence Tao", "Set.Infinite"],
+    "prerequisites": ["IsClusterPrime", "real bounds"]
+  },
+  {
+    "id": "ann-e17-heuristic",
+    "proofId": "erdos-17",
+    "range": { "startLine": 232, "endLine": 236 },
+    "type": "context",
+    "title": "Probabilistic Heuristic for Infinitely Many",
+    "content": "If primes were randomly distributed with density $1/\\log n$, the expected number of cluster primes up to $x$ would grow like $\\log x$ — slowly but unboundedly. The axiom states this heuristic prediction: there exists a function $f(x) > 0$ with $f(x)/\\log x \\to 1$. This is NOT a proof — just a formalization of the heuristic argument supporting infinitude.",
+    "mathContext": "Heuristic: $\\mathbb{E}[\\pi_{\\text{cluster}}(x)] \\sim \\log x$ under the random prime model. If correct, this would mean cluster primes are sparser than primes in any AP (density $\\sim 1/\\varphi(d) \\cdot x/\\log x$) but still infinite.",
+    "significance": "context",
+    "relatedConcepts": ["Cramér model", "random primes", "heuristic arguments"],
+    "prerequisites": ["cluster prime counting", "prime density"]
+  },
+  {
     "id": "ann-e17-oeis",
     "proofId": "erdos-17",
     "range": { "startLine": 203, "endLine": 205 },

--- a/src/data/proofs/erdos-17/meta.json
+++ b/src/data/proofs/erdos-17/meta.json
@@ -128,9 +128,23 @@
     {
       "id": "prime-gaps",
       "title": "Connection to Prime Gaps",
-      "summary": "Relationship between gaps and cluster property",
+      "summary": "primeGap definition and small_gaps_help_cluster: small gaps between consecutive primes help the cluster property",
       "startLine": 178,
       "endLine": 192
+    },
+    {
+      "id": "oeis-sequence",
+      "title": "OEIS Sequence and Known Cluster Primes",
+      "summary": "knownClusterPrimes list (all 24 primes up to 89) and axiom that they are all cluster primes. References OEIS A038133/A038134.",
+      "startLine": 194,
+      "endLine": 209
+    },
+    {
+      "id": "difficulty-heuristics",
+      "title": "Difficulty Assessment and Heuristics",
+      "summary": "Tao's assessment that the problem is 'difficult', requiring control of all prime differences simultaneously. Probabilistic heuristic suggesting ~log x cluster primes up to x.",
+      "startLine": 211,
+      "endLine": 268
     }
   ],
   "conclusion": {
@@ -145,24 +159,24 @@
   },
   "crossReferences": [
     {
-      "proofId": "bounded-prime-gaps",
+      "targetId": "bounded-prime-gaps",
       "relationship": "related",
-      "note": "Bounded prime gaps (Maynard-Tao) ensure small differences exist, but cluster primes require ALL small even differences — a much stronger condition"
+      "description": "Bounded prime gaps (Maynard-Tao) ensure small differences exist, but cluster primes require ALL small even differences — a much stronger condition"
     },
     {
-      "proofId": "erdos-16",
+      "targetId": "erdos-16",
       "relationship": "related",
-      "note": "Both are Erdős problems about prime distribution: #16 concerns representing odds as 2^k + p, while #17 concerns covering even differences with prime pairs"
+      "description": "Both are Erdős problems about prime distribution: #16 concerns representing odds as $2^k + p$, while #17 concerns covering even differences with prime pairs"
     },
     {
-      "proofId": "twin-primes-special",
+      "targetId": "twin-primes-special",
       "relationship": "related",
-      "note": "Twin primes (p, p+2) provide the smallest prime differences; cluster primes require ALL small even differences to be realized, making it a much stronger condition"
+      "description": "Twin primes $(p, p+2)$ provide the smallest prime differences; cluster primes require ALL small even differences to be realized, making it a much stronger condition"
     },
     {
-      "proofId": "infinitude-primes",
+      "targetId": "infinitude-primes",
       "relationship": "uses",
-      "note": "The infinitude of primes is a prerequisite; the cluster prime question asks whether a specific sparse subset of primes is also infinite"
+      "description": "The infinitude of primes is a prerequisite; the cluster prime question asks whether a specific sparse subset of primes is also infinite"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fixed `crossReferences` field names (`proofId` → `targetId`, `note` → `description`) to match gallery schema
- Added 3 new annotations: `clusterPrimeCount` definition, Tao's difficulty assessment, probabilistic heuristic
- Added 2 new sections covering lines 194-268 (OEIS sequence, difficulty/heuristics/summary)
- Total annotations: 13 → 16, sections: 7 → 9

## Test plan
- [x] `meta.json` validates as well-formed JSON
- [x] `annotations.json` validates as well-formed JSON (16 annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)