### PR TITLE
Enrich erdos-185: fix annotation type schema, add mathContext

### DIFF
--- a/src/data/proofs/erdos-185/annotations.json
+++ b/src/data/proofs/erdos-185/annotations.json
@@ -30,15 +30,17 @@
     },
     "type": "definition",
     "title": "Ternary Hypercube",
-    "content": "**TernaryHypercube(n):**\n\nThe set {0,1,2}^n represented as functions Fin n \u2192 ZMod 3.\n\n```lean\nabbrev TernaryHypercube (n : \u2115) := Fin n \u2192 ZMod 3\n```\n\nThis is the space where cap sets live.",
+    "content": "**TernaryHypercube(n):** The set {0,1,2}^n represented as functions Fin n → ZMod 3. This is the ambient space where cap sets live — a vector space over the field with 3 elements.",
+    "mathContext": "$\\{0,1,2\\}^n \\cong (\\mathbb{F}_3)^n$ has $3^n$ elements. As a vector space over $\\mathbb{F}_3$, its affine subspaces (lines) are exactly the sets $\\{a, a+d, a+2d\\}$ for $d \\neq 0$.",
     "significance": "key",
     "relatedConcepts": [
       "ZMod 3",
-      "Function types"
+      "Function types",
+      "finite vector spaces"
     ],
     "prerequisites": [
-      "combinatorics",
-      "graph theory"
+      "ZMod",
+      "Fin n → ZMod 3"
     ]
   },
   {
@@ -48,7 +50,7 @@
       "startLine": 45,
       "endLine": 51
     },
-    "type": "theorem",
+    "type": "concept",
     "title": "Hypercube Cardinality",
     "content": "**hypercube_card:** |{0,1,2}^n| = 3^n.\n\n```lean\ntheorem hypercube_card (n : \u2115) :\n    Fintype.card (TernaryHypercube n) = 3^n\n```\n\nThis is a basic counting result - each of n coordinates has 3 choices.",
     "significance": "supporting",
@@ -192,7 +194,7 @@
       "startLine": 121,
       "endLine": 128
     },
-    "type": "axiom",
+    "type": "concept",
     "title": "Lower Bound: f\u2083(n) \u2265 R\u2083(3^n)",
     "content": "**f3_geq_R3:** f\u2083(n) \u2265 R\u2083(3^n).\n\nThe embedding {1,...,3^n} \u21aa {0,1,2}^n via ternary representation maps AP-free sets to cap sets.\n\nThis shows cap sets are at least as hard as AP-free sets.",
     "mathContext": "Lines in {0,1,2}^n generalize 3-term APs in \u2124.",
@@ -213,7 +215,7 @@
       "startLine": 134,
       "endLine": 141
     },
-    "type": "axiom",
+    "type": "concept",
     "title": "Moser's Lower Bound",
     "content": "**moser_lower_bound:** f\u2083(n) \u226b 3^n/\u221an.\n\nMore precisely: \u2203 c > 0, \u2200 n \u2265 1, f\u2083(n) \u2265 c \u00b7 3^n/\u221an.\n\nThis shows cap sets can be quite large - density only decays as 1/\u221an.",
     "mathContext": "The Moser construction achieves this bound.",
@@ -255,7 +257,7 @@
       "startLine": 156,
       "endLine": 164
     },
-    "type": "axiom",
+    "type": "concept",
     "title": "Density Hales-Jewett Theorem",
     "content": "**density_hales_jewett (Furstenberg-Katznelson 1991):**\n\nFor any \u03b4 > 0 and k \u2265 3, for large enough n, any subset of [k]^n with density \u2265 \u03b4 contains a combinatorial line.\n\nThis is a deep result in Ramsey theory, proved using ergodic methods.\n\n**Implication:** Cap sets must have vanishing density.",
     "mathContext": "A landmark result that implies f\u2083(n)/3^n \u2192 0.",
@@ -277,7 +279,7 @@
       "startLine": 301,
       "endLine": 389
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Main Result: f\u2083(n) = o(3^n) [PROVED from DHJ]",
     "content": "**f3_is_little_o:** (\u03bb n, f\u2083(n)) =o[atTop] (\u03bb n, 3^n).\n\nThis is the answer to Erd\u0151s Problem #185: **YES**.\n\n**Now PROVED** (was previously axiomatized) via a chain:\n1. `isCapSet_implies_isCapSetCombinatorial`: cap sets avoid combinatorial lines\n2. `capSet_density_lt`: DHJ contrapositive gives density bound\n3. `f3_eventually_le`: bound lifts to f\u2083(n) via sSup\n4. `f3_is_little_o`: convert to asymptotic notation",
     "mathContext": "For any \u03b5 > 0, eventually f\u2083(n) < \u03b5 \u00b7 3^n. Proved from density_hales_jewett_k3.",
@@ -299,17 +301,19 @@
       "startLine": 173,
       "endLine": 178
     },
-    "type": "axiom",
-    "title": "Density \u2192 0",
-    "content": "**f3_density_tends_to_zero:** f\u2083(n)/3^n \u2192 0 as n \u2192 \u221e.\n\nEquivalent formulation of the main result.\n\nCap set density vanishes in the limit.",
+    "type": "concept",
+    "title": "Density → 0",
+    "content": "**f3_density_tends_to_zero:** f₃(n)/3^n → 0 as n → ∞. Equivalent formulation of the main result: cap set density vanishes in the limit. Combined with Moser's lower bound $f_3(n) \\gg 3^n/\\sqrt{n}$, the density decays but at most polynomially fast.",
+    "mathContext": "$\\lim_{n \\to \\infty} \\frac{f_3(n)}{3^n} = 0$. Equivalently, $f_3(n) = o(3^n)$. The Ellenberg-Gijswijt bound gives the stronger $f_3(n) \\leq (2.756\\ldots)^n$.",
     "significance": "key",
     "relatedConcepts": [
-      "Limit",
-      "Tendsto"
+      "Filter.Tendsto",
+      "nhds 0",
+      "density"
     ],
     "prerequisites": [
-      "combinatorics",
-      "graph theory"
+      "asymptotic analysis",
+      "Filter.Tendsto"
     ]
   },
   {
@@ -319,7 +323,7 @@
       "startLine": 184,
       "endLine": 189
     },
-    "type": "axiom",
+    "type": "concept",
     "title": "Meshulam Upper Bound (1995)",
     "content": "**meshulam_upper_bound:** f\u2083(n) \u2264 3^n/n for n \u2265 1.\n\nAn explicit quantitative upper bound, improving on the qualitative Hales-Jewett result.\n\nThis was the best bound before Ellenberg-Gijswijt.",
     "significance": "key",
@@ -339,7 +343,7 @@
       "startLine": 191,
       "endLine": 199
     },
-    "type": "axiom",
+    "type": "concept",
     "title": "Ellenberg-Gijswijt (2016)",
     "content": "**ellenberg_gijswijt_2016:** f\u2083(n) \u2264 c^n with c < 3 (c \u2248 2.756).\n\nA major breakthrough using the polynomial method (slice rank).\n\nThis shows cap sets grow exponentially slower than the ambient space.",
     "mathContext": "The constant c \u2248 2.756 comes from optimizing the slice rank argument.",
@@ -361,7 +365,7 @@
       "startLine": 207,
       "endLine": 234
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Small Values of f\u2083(n)",
     "content": "**Known values (OEIS A003142):**\n\n- f\u2083(1) = 2 (any 2 of {0,1,2})\n- f\u2083(2) = 4 (e.g., {00,01,10,12})\n- f\u2083(3) = 9\n- f\u2083(4) = 20\n\nThese are exact values computed by exhaustive search.",
     "significance": "supporting",
@@ -381,7 +385,7 @@
       "startLine": 256,
       "endLine": 260
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Main Theorem: erdos_185",
     "content": "**erdos_185:** f\u2083(n) = o(3^n).\n\n```lean\ntheorem erdos_185 : (fun n => (f3 n : \u211d)) =o[atTop] (fun n => (3 : \u211d)^n) :=\n  f3_is_little_o\n```\n\n**Answer to Erd\u0151s #185: YES**",
     "significance": "key",
@@ -401,7 +405,7 @@
       "startLine": 269,
       "endLine": 285
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "The Answer is YES",
     "content": "**erdos_185_answer:** \u2200 \u03b5 > 0, \u2203 n\u2080, \u2200 n \u2265 n\u2080, f\u2083(n) < \u03b5 \u00b7 3^n.\n\nThis unpacks the little-o statement into an explicit form.\n\nFor any desired error bound \u03b5, eventually all cap sets have relative density < \u03b5.",
     "significance": "key",


### PR DESCRIPTION
## Summary
- Fixed 6 annotation types from non-standard `axiom` → `concept` (schema compliance)
- Fixed 4 annotation types from non-standard `theorem` → `insight` (schema compliance)
- Added `mathContext` to TernaryHypercube and Density→0 annotations
- Improved generic prerequisites to be more specific

## Test plan
- [x] `annotations.json` validates as well-formed JSON (21 annotations)
- [x] `meta.json` validates as well-formed JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)