### PR TITLE
Enrich erdos-218: expand historicalContext, remove tags, add LaTeX

### DIFF
--- a/src/data/proofs/erdos-218/annotations.json
+++ b/src/data/proofs/erdos-218/annotations.json
@@ -3,132 +3,200 @@
     "id": "erdos-218-header",
     "proofId": "erdos-218",
     "type": "context",
-    "range": { "startLine": 1, "endLine": 30 },
+    "range": {
+      "startLine": 1,
+      "endLine": 30
+    },
     "title": "Problem Overview",
     "content": "Erdős Problem #218: Let d_n = p_{n+1} - p_n. Conjectures: (1) {n : d_{n+1} ≥ d_n} has density 1/2, (2) {n : d_{n+1} ≤ d_n} has density 1/2, (3) infinitely many n have d_n = d_{n+1}. All three OPEN. Terence Tao: 'looks difficult'.",
     "mathContext": "From Erdős [Er55c], [Er57], [Er61], [Er65b], [Er85c]. Conjecture 3 equivalent to infinitely many 3-term APs of consecutive primes.",
     "significance": "essential",
-    "relatedConcepts": ["prime gaps", "natural density", "arithmetic progressions", "Prime Number Theorem"],
-    "tags": ["prime-gaps", "natural-density", "open-problem", "erdos"]
+    "relatedConcepts": [
+      "prime gaps",
+      "natural density",
+      "arithmetic progressions",
+      "Prime Number Theorem"
+    ]
   },
   {
     "id": "erdos-218-nthprime",
     "proofId": "erdos-218",
     "type": "definition",
-    "range": { "startLine": 43, "endLine": 67 },
+    "range": {
+      "startLine": 43,
+      "endLine": 67
+    },
     "title": "Prime Enumeration",
     "content": "nthPrime(n) = Nat.nth Nat.Prime n gives the n-th prime (0-indexed). Properties: always prime, strictly increasing. Specific values: nthPrime 0 = 2, nthPrime 1 = 3, nthPrime 2 = 5.",
     "mathContext": "nthPrime n = Nat.nth Nat.Prime n. nthPrime_prime: (nthPrime n).Prime. nthPrime_strictMono: StrictMono nthPrime.",
     "significance": "essential",
-    "relatedConcepts": ["Nat.nth", "prime enumeration", "Nat.Prime"],
-    "tags": ["prime-enumeration", "strict-monotonicity", "number-theory"]
+    "relatedConcepts": [
+      "Nat.nth",
+      "prime enumeration",
+      "Nat.Prime"
+    ]
   },
   {
     "id": "erdos-218-primegap",
     "proofId": "erdos-218",
     "type": "definition",
-    "range": { "startLine": 69, "endLine": 100 },
+    "range": {
+      "startLine": 69,
+      "endLine": 100
+    },
     "title": "Prime Gap Function",
     "content": "primeGap(n) = nthPrime(n+1) - nthPrime(n) = d_n. primeGap_pos: proved (gaps always positive, from strict monotonicity). Specific values: primeGap 0 = 1, primeGap 1 = 2, primeGap 2 = 2, primeGap 3 = 4.",
     "mathContext": "primeGap n = nthPrime(n+1) - nthPrime n. By PNT, average gap ~ log(p_n).",
     "significance": "essential",
-    "relatedConcepts": ["prime gaps", "Prime Number Theorem", "natural number subtraction"],
-    "tags": ["prime-gaps", "prime-number-theorem", "analytic-number-theory"]
+    "relatedConcepts": [
+      "prime gaps",
+      "Prime Number Theorem",
+      "natural number subtraction"
+    ]
   },
   {
     "id": "erdos-218-density",
     "proofId": "erdos-218",
     "type": "definition",
-    "range": { "startLine": 102, "endLine": 126 },
+    "range": {
+      "startLine": 102,
+      "endLine": 126
+    },
     "title": "Natural Density",
     "content": "HasDensity(S, d): lim_{N→∞} |S ∩ [0,N)| / N = d via Tendsto/nhds. upperDensity via limsup, lowerDensity via liminf. hasDensity_iff_upper_lower: density exists iff upper = lower = d.",
     "mathContext": "HasDensity S d ≡ Tendsto (fun N => (Finset.filter (· ∈ S) (Finset.range N)).card / N) atTop (nhds d).",
     "significance": "essential",
-    "relatedConcepts": ["asymptotic density", "Tendsto", "limsup", "liminf"],
-    "tags": ["natural-density", "asymptotic-analysis", "limits", "measure-theory"]
+    "relatedConcepts": [
+      "asymptotic density",
+      "Tendsto",
+      "limsup",
+      "liminf"
+    ]
   },
   {
     "id": "erdos-218-keysets",
     "proofId": "erdos-218",
     "type": "definition",
-    "range": { "startLine": 128, "endLine": 171 },
+    "range": {
+      "startLine": 128,
+      "endLine": 171
+    },
     "title": "The Key Sets",
     "content": "gapIncreasingSet = {n : d_n ≤ d_{n+1}}. gapDecreasingSet = {n : d_{n+1} ≤ d_n}. gapEqualSet = {n : d_n = d_{n+1}}. gapEqualSet_eq_inter: proved (equal = increasing ∩ decreasing). Examples: 0 ∈ increasing, 1 ∈ equal.",
     "mathContext": "gapEqualSet = gapIncreasingSet ∩ gapDecreasingSet. Proved by le_antisymm.",
     "significance": "essential",
-    "relatedConcepts": ["set intersection", "gap comparisons", "le_antisymm"],
-    "tags": ["set-theory", "prime-gaps", "gap-comparison", "formalization"]
+    "relatedConcepts": [
+      "set intersection",
+      "gap comparisons",
+      "le_antisymm"
+    ]
   },
   {
     "id": "erdos-218-conjectures",
     "proofId": "erdos-218",
     "type": "conjecture",
-    "range": { "startLine": 173, "endLine": 202 },
+    "range": {
+      "startLine": 173,
+      "endLine": 202
+    },
     "title": "The Three Conjectures (OPEN)",
     "content": "erdos_218a (axiom): HasDensity gapIncreasingSet (1/2). erdos_218b (axiom): HasDensity gapDecreasingSet (1/2). erdos_218c (axiom): gapEqualSet.Infinite. All three remain OPEN.",
     "mathContext": "Conjectures 1+2 together imply gapEqualSet has density 0 (equality rare). Symmetry heuristic supports density 1/2.",
     "significance": "essential",
-    "relatedConcepts": ["open problems", "natural density", "symmetry arguments"],
-    "tags": ["open-problem", "conjecture", "natural-density", "erdos"]
+    "relatedConcepts": [
+      "open problems",
+      "natural density",
+      "symmetry arguments"
+    ]
   },
   {
     "id": "erdos-218-ap",
     "proofId": "erdos-218",
     "type": "result",
-    "range": { "startLine": 204, "endLine": 235 },
+    "range": {
+      "startLine": 204,
+      "endLine": 235
+    },
     "title": "Connection to Arithmetic Progressions",
     "content": "threePrimesInAP(n): p_n + p_{n+2} = 2·p_{n+1}. gapEqual_iff_ap (axiom): n ∈ gapEqualSet ↔ threePrimesInAP n. infinitely_many_3ap_from_218c: proved (gapEqualSet.Infinite → apTriples.Infinite, via convert).",
     "mathContext": "d_n = d_{n+1} ⟺ p_n, p_{n+1}, p_{n+2} form an AP. Example: 3, 5, 7 with difference 2.",
     "significance": "essential",
-    "relatedConcepts": ["arithmetic progressions", "consecutive primes", "Green-Tao"],
-    "tags": ["arithmetic-progressions", "consecutive-primes", "equivalence", "number-theory"]
+    "relatedConcepts": [
+      "arithmetic progressions",
+      "consecutive primes",
+      "Green-Tao"
+    ]
   },
   {
     "id": "erdos-218-greentao",
     "proofId": "erdos-218",
     "type": "context",
-    "range": { "startLine": 237, "endLine": 248 },
+    "range": {
+      "startLine": 237,
+      "endLine": 248
+    },
     "title": "Green-Tao Theorem",
     "content": "green_tao (axiom): For any k, ∃ a d > 0, ∀ i < k, (a + i·d).Prime. This gives arbitrarily long APs of primes, but they need not be consecutive. Does not directly imply Conjecture 3.",
     "mathContext": "Green-Tao (2008) is much stronger than needed but addresses a different question (non-consecutive vs consecutive primes).",
     "significance": "supporting",
-    "relatedConcepts": ["Szemerédi's theorem", "additive combinatorics", "arbitrarily long APs"],
-    "tags": ["green-tao", "additive-combinatorics", "arithmetic-progressions"]
+    "relatedConcepts": [
+      "Szemerédi's theorem",
+      "additive combinatorics",
+      "arbitrarily long APs"
+    ]
   },
   {
     "id": "erdos-218-partial",
     "proofId": "erdos-218",
     "type": "result",
-    "range": { "startLine": 250, "endLine": 271 },
+    "range": {
+      "startLine": 250,
+      "endLine": 271
+    },
     "title": "Partial Results",
     "content": "gapIncreasingSet_infinite (axiom): gaps must increase infinitely often (PNT: gaps grow on average). gapDecreasingSet_infinite (axiom): after large gaps, smaller gaps follow. average_gap_growth (axiom): gap/log(p) bounded.",
     "mathContext": "Both sets infinite, but exact density 1/2 unknown. Whether gapEqualSet is infinite also unknown.",
     "significance": "essential",
-    "relatedConcepts": ["Prime Number Theorem", "infinite sets", "gap growth"],
-    "tags": ["prime-number-theorem", "partial-results", "infinite-sets", "prime-gaps"]
+    "relatedConcepts": [
+      "Prime Number Theorem",
+      "infinite sets",
+      "gap growth"
+    ]
   },
   {
     "id": "erdos-218-symmetry",
     "proofId": "erdos-218",
     "type": "context",
-    "range": { "startLine": 273, "endLine": 300 },
+    "range": {
+      "startLine": 273,
+      "endLine": 300
+    },
     "title": "Symmetry Heuristic and Partition",
     "content": "Heuristic: if gap comparisons were random, density 1/2 for each direction. partition (proved): strictlyIncreasing ∪ strictlyDecreasing ∪ gapEqualSet = Set.univ. The difficulty is that primes have subtle correlations.",
     "mathContext": "partition: proved by cases on Nat.lt_or_ge and le_antisymm. Decomposition of ℕ by gap comparison.",
     "significance": "supporting",
-    "relatedConcepts": ["probabilistic models", "prime randomness", "Cramér model"],
-    "tags": ["probabilistic-heuristic", "cramer-model", "partition", "prime-randomness"]
+    "relatedConcepts": [
+      "probabilistic models",
+      "prime randomness",
+      "Cramér model"
+    ]
   },
   {
     "id": "erdos-218-summary",
     "proofId": "erdos-218",
     "type": "result",
-    "range": { "startLine": 302, "endLine": 342 },
+    "range": {
+      "startLine": 302,
+      "endLine": 342
+    },
     "title": "Summary: OPEN",
     "content": "erdos_218_summary: (gapIncreasingSet.Infinite ∧ gapDecreasingSet.Infinite) ∧ (gapEqualSet.Infinite ↔ apTriples.Infinite). Proved from axioms. erdos_218_open: True (trivial). All three density conjectures remain OPEN.",
     "mathContext": "Summary combines known results: both sets infinite (axioms), equal gaps ↔ 3-term APs (from gapEqual_iff_ap axiom).",
     "significance": "essential",
-    "relatedConcepts": ["open problems", "prime gaps", "arithmetic progressions"],
-    "tags": ["summary", "open-problem", "prime-gaps", "arithmetic-progressions"]
+    "relatedConcepts": [
+      "open problems",
+      "prime gaps",
+      "arithmetic progressions"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-218/meta.json
+++ b/src/data/proofs/erdos-218/meta.json
@@ -32,7 +32,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "Erdős Problem #218 studies the local behavior of prime gaps, appearing across papers from 1955-1985. While the Prime Number Theorem describes average gap growth, this problem asks about the statistical distribution of local gap comparisons. Terence Tao assessed this as 'looks difficult'.",
+    "historicalContext": "Erd\u0151s posed this problem across several papers from 1955-1985, asking about the local statistical behavior of prime gaps $d_n = p_{n+1} - p_n$. While the Prime Number Theorem (Hadamard, de la Vall\u00e9e-Poussin 1896) shows $d_n \\sim \\log p_n$ on average, the local behavior \u2014 whether consecutive gaps tend to increase, decrease, or stay equal \u2014 is far subtler. Cram\u00e9r's probabilistic model (1936) suggests that gap comparisons should behave like independent coin flips, yielding density $1/2$ for both increasing and decreasing gaps. However, primes exhibit nontrivial correlations (e.g., the Hardy-Littlewood prime $k$-tuples conjecture) that could affect local gap statistics. The equal-gap conjecture ($d_n = d_{n+1}$ infinitely often) is equivalent to asking for infinitely many 3-term arithmetic progressions of consecutive primes. The Green-Tao theorem (2004) gives arbitrarily long APs in primes, but not of consecutive primes. Terence Tao assessed this problem as 'looks difficult' on his blog.",
     "problemStatement": "Let d_n = p_{n+1} - p_n. Conjectures: (1) {n : d_{n+1} ≥ d_n} has density 1/2, (2) {n : d_{n+1} ≤ d_n} has density 1/2, (3) infinitely many n have d_n = d_{n+1}. All three remain OPEN. Conjecture 3 is equivalent to infinitely many 3-term APs of consecutive primes.",
     "proofStrategy": "The formalization defines nthPrime (via Nat.nth), primeGap, HasDensity (via Tendsto), and the three key sets (gapIncreasingSet, gapDecreasingSet, gapEqualSet). The three conjectures are axioms. Key proved results: primeGap_pos, gapEqualSet_eq_inter, partition of ℕ by gap comparison. The connection gapEqual ↔ threePrimesInAP is axiomatized. Green-Tao theorem is stated for context.",
     "keyInsights": [
@@ -125,12 +125,13 @@
   ],
   "conclusion": {
     "summary": "Erdős Problem #218 asks about the natural density of indices where consecutive prime gaps increase, decrease, or stay equal. All three parts remain OPEN. The equal gap conjecture is equivalent to infinitely many 3-term APs of consecutive primes. Green-Tao gives arbitrarily long APs in primes but not necessarily consecutive.",
-    "implications": "Understanding local gap behavior versus average behavior of primes. Equal gaps correspond to 3-term APs of consecutive primes. Tests our understanding of pseudo-random behavior of primes.",
+    "implications": "Resolution would reveal whether local prime gap statistics match the Cram\u00e9r random model or exhibit deeper correlations. The equal-gap conjecture connects to the Hardy-Littlewood prime $k$-tuples conjecture (for $k=3$): if the $k$-tuples conjecture is true, then infinitely many consecutive prime triples form APs. This tests the boundary between what the Green-Tao methods can reach and what remains beyond current technology.",
     "openQuestions": [
-      "Do the sets {n : d_{n+1} ≥ d_n} and {n : d_{n+1} ≤ d_n} have density 1/2?",
-      "Are there infinitely many n with d_n = d_{n+1}?",
-      "What is the density of the equal gap set (expected to be 0)?",
-      "Can Green-Tao methods be adapted to consecutive primes?"
+      "Do the sets $\\{n : d_{n+1} \\geq d_n\\}$ and $\\{n : d_{n+1} \\leq d_n\\}$ each have natural density $1/2$?",
+      "Are there infinitely many $n$ with $d_n = d_{n+1}$ (i.e., infinitely many 3-term APs of consecutive primes)?",
+      "What is the natural density of $\\{n : d_n = d_{n+1}\\}$? Expected to be 0 by Hardy-Littlewood heuristics",
+      "Can sieve methods or the Green-Tao machinery be adapted to consecutive primes?",
+      "What is the distribution of $d_{n+1}/d_n$? Is it concentrated near 1 (as Cram\u00e9r predicts)?"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Enrichment pass for `erdos-218` (Erdős Problem #218: Prime Gap Densities). Quality 97 → enriched.

### Changes

- **historicalContext**: Expanded from 288 to ~900 chars with Cramér model (1936), PNT (1896), Hardy-Littlewood k-tuples, Green-Tao (2004), Tao's assessment
- **annotations.json**: Removed non-schema `tags` field from all 11 annotations
- **openQuestions**: Added LaTeX, connected to Hardy-Littlewood k-tuples and Cramér model
- **conclusion**: Expanded implications with k-tuples connection

## Test plan

- [x] JSON validates
- [x] No non-schema fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)