### PR TITLE
Enrich erdos-205: fix all annotation line ranges, add 2 annotations

### DIFF
--- a/src/data/proofs/erdos-205/annotations.json
+++ b/src/data/proofs/erdos-205/annotations.json
@@ -2,338 +2,169 @@
   {
     "id": "ann-e205-header",
     "proofId": "erdos-205",
-    "range": {
-      "startLine": 1,
-      "endLine": 27
-    },
-    "type": "concept",
-    "title": "Problem Overview",
-    "content": "**Erd\u0151s Problem #205**: Can every large n be written as 2^k + m where \u03a9(m) < log log m?\n\n**Status**: DISPROVED (Barreto-Leeham 2026)\n\n**Counterexample**: There are infinitely many n where ALL remainders n - 2^k have \u03a9 \u2265 c\u221a(log n / log log n) prime factors.\n\nSince \u221a(log n / log log n) >> log log n, the conjecture fails.",
-    "mathContext": "\u03a9(m) counts prime factors with multiplicity (e.g., \u03a9(12) = \u03a9(2\u00b2\u00b73) = 3). The average \u03a9(n) \u2248 log log n by classical results.",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "context",
+    "title": "Problem Overview and History",
+    "content": "**Erdős Problem #205**: Can every large $n$ be written as $2^k + m$ where $\\Omega(m) < \\log \\log m$?\n\n**Status**: DISPROVED (Barreto-Leeham 2026, quantified by Tao-Alexeev)\n\n**Counterexample**: There are infinitely many $n$ where ALL remainders $n - 2^k$ have $\\Omega \\ge c\\sqrt{\\log n / \\log \\log n}$ prime factors. Since $\\sqrt{\\log n / \\log \\log n} \\gg \\log \\log n$, the conjecture fails.\n\nThe header traces the problem from Romanoff (1934) through Erdős (1950) to the 2026 disproof, listing the full progress log of the formalization.",
+    "mathContext": "$\\Omega(m)$ counts prime factors with multiplicity (e.g., $\\Omega(12) = \\Omega(2^2 \\cdot 3) = 3$). The average $\\Omega(n) \\approx \\log \\log n$ by the Hardy-Ramanujan theorem (1917).",
     "significance": "key",
-    "relatedConcepts": [
-      "prime-factors",
-      "big-omega",
-      "disproved"
-    ],
-    "tags": [
-      "number-theory",
-      "prime-factorization",
-      "counterexample",
-      "erdos-conjecture"
-    ],
-    "prerequisites": [
-      "prime factorization",
-      "covering systems",
-      "de Polignac numbers"
-    ]
+    "relatedConcepts": ["prime factors", "big-omega function", "covering systems", "de Polignac numbers"],
+    "prerequisites": ["prime factorization", "covering systems", "analytic number theory"]
   },
   {
     "id": "ann-e205-bigomega",
     "proofId": "erdos-205",
-    "range": {
-      "startLine": 37,
-      "endLine": 40
-    },
+    "range": { "startLine": 52, "endLine": 55 },
     "type": "definition",
-    "title": "The Big-\u03a9 Function",
-    "content": "**bigOmega n** = number of prime factors of n, counted WITH multiplicity.\n\n```lean\ndef bigOmega (n : \u2115) : \u2115 := n.primeFactorsList.length\n```\n\nExamples: \u03a9(12) = \u03a9(2\u00b2\u00b73) = 3, \u03a9(p) = 1, \u03a9(p^k) = k",
-    "mathContext": "Uses Mathlib's primeFactorsList which returns the list [p\u2081, p\u2082, ..., p\u2096] where n = p\u2081 \u00b7 p\u2082 \u00b7 ... \u00b7 p\u2096 (primes may repeat).",
+    "title": "The Big-Omega Function",
+    "content": "`bigOmega n` = number of prime factors of $n$, counted WITH multiplicity. Defined as `n.primeFactorsList.length`, leveraging Mathlib's `primeFactorsList` which returns the sorted list of prime factors (with repeats). For example, $\\Omega(12) = |[2, 2, 3]| = 3$.",
+    "mathContext": "$\\Omega(n) = \\sum_{p^a \\| n} a = |\\text{primeFactorsList}(n)|$. This is a completely additive arithmetic function: $\\Omega(ab) = \\Omega(a) + \\Omega(b)$.",
     "significance": "key",
-    "relatedConcepts": [
-      "prime-factorization",
-      "multiplicative-function",
-      "mathlib"
-    ],
-    "tags": [
-      "arithmetic-function",
-      "prime-factors",
-      "mathlib-api",
-      "lean4"
-    ],
-    "prerequisites": [
-      "prime factorization",
-      "Nat.Prime"
-    ]
+    "relatedConcepts": ["Nat.primeFactorsList", "completely additive function", "arithmetic function"],
+    "prerequisites": ["prime factorization", "Nat.Prime"]
   },
   {
     "id": "ann-e205-omega-theorems",
     "proofId": "erdos-205",
-    "range": {
-      "startLine": 42,
-      "endLine": 57
-    },
+    "range": { "startLine": 57, "endLine": 85 },
     "type": "insight",
-    "title": "Properties of \u03a9 (Verified)",
-    "content": "**Verified theorems**:\n- `bigOmega_one`: \u03a9(1) = 0 \u2713\n- `bigOmega_prime`: \u03a9(p) = 1 for prime p \u2713\n\n**Axioms** (provable but complex):\n- `bigOmega_prime_pow_ax`: \u03a9(p^k) = k\n- `bigOmega_mul_ax`: \u03a9(ab) = \u03a9(a) + \u03a9(b) for a,b > 0",
-    "mathContext": "\u03a9 is completely additive: \u03a9(ab) = \u03a9(a) + \u03a9(b). This follows from concatenation of prime factor lists.",
+    "title": "Properties of Omega (All Verified)",
+    "content": "All four fundamental properties of $\\Omega$ are **fully proved** (no axioms):\n\n- `bigOmega_one`: $\\Omega(1) = 0$ (by `simp`)\n- `bigOmega_prime`: $\\Omega(p) = 1$ for prime $p$ (by `simp` with `primeFactorsList_prime`)\n- `bigOmega_prime_pow`: $\\Omega(p^k) = k$ (by induction on $k$, using `perm_primeFactorsList_mul`)\n- `bigOmega_mul`: $\\Omega(ab) = \\Omega(a) + \\Omega(b)$ for $a, b > 0$ (via `perm_primeFactorsList_mul`)\n\nThese were originally axiomatized but are now proved from Mathlib, eliminating 3 axioms.",
+    "mathContext": "Complete additivity $\\Omega(ab) = \\Omega(a) + \\Omega(b)$ follows because $\\text{primeFactorsList}(ab) \\sim \\text{primeFactorsList}(a) \\mathbin{++} \\text{primeFactorsList}(b)$ (permutation equivalence).",
     "significance": "key",
-    "relatedConcepts": [
-      "simp",
-      "primeFactorsList",
-      "additive-function"
-    ],
-    "tags": [
-      "completely-additive",
-      "verified-proof",
-      "lean4-tactic",
-      "number-theory"
-    ],
-    "prerequisites": [
-      "Nat.Prime",
-      "prime power factorization"
-    ]
+    "relatedConcepts": ["complete additivity", "Nat.perm_primeFactorsList_mul", "induction"],
+    "prerequisites": ["Nat.Prime", "Nat.primeFactorsList", "List.Perm"]
   },
   {
     "id": "ann-e205-conjecture",
     "proofId": "erdos-205",
-    "range": {
-      "startLine": 61,
-      "endLine": 69
-    },
+    "range": { "startLine": 91, "endLine": 99 },
     "type": "definition",
-    "title": "The Erd\u0151s Conjecture",
-    "content": "**HasSmallOmegaRep n**: n = 2^k + m with \u03a9(m) < log log m for some k, m.\n\n**Erdos205Conjecture**: All sufficiently large n have such a representation.\n\nThe hope: most m have \u03a9(m) \u2248 log log m, so finding one with \u03a9 < log log m should be possible.",
-    "mathContext": "By probabilistic arguments, almost all n do have such representations. The question is whether ALL large n do.",
+    "title": "The Erdős Conjecture (Problem 205)",
+    "content": "`HasSmallOmegaRep n`: $n = 2^k + m$ with $\\Omega(m) < \\log \\log m$ for some $k, m$.\n\n`Erdos205Conjecture`: $\\exists N_0, \\forall n \\ge N_0$, $n$ has such a representation.\n\nThe hope was that since most $m$ have $\\Omega(m) \\approx \\log \\log m$, finding one with $\\Omega < \\log \\log m$ among $\\{n - 2^k : 2^k < n\\}$ should be easy. The disproof shows this intuition fails.",
+    "mathContext": "The condition $\\Omega(m) < \\log \\log m$ is weaker than requiring $m$ prime ($\\Omega(m) = 1$), but stronger than requiring $m$ squarefree. By probabilistic arguments, almost all $n$ DO have such representations — but not all.",
     "significance": "key",
-    "relatedConcepts": [
-      "representation",
-      "power-of-two",
-      "log-log"
-    ],
-    "tags": [
-      "erdos-conjecture",
-      "additive-representation",
-      "prime-factors",
-      "number-theory"
-    ],
-    "prerequisites": [
-      "bigOmega",
-      "Real.log"
-    ]
+    "relatedConcepts": ["additive representation", "existential quantifier", "sufficiently large"],
+    "prerequisites": ["bigOmega", "Real.log"]
   },
   {
     "id": "ann-e205-minomega",
     "proofId": "erdos-205",
-    "range": {
-      "startLine": 73,
-      "endLine": 85
-    },
+    "range": { "startLine": 105, "endLine": 117 },
     "type": "definition",
-    "title": "Minimum \u03a9 Over Remainders",
-    "content": "**minOmegaRemainder n** = min{\u03a9(n - 2^k) : 2^k < n}\n\nFor n to satisfy the conjecture, we need minOmegaRemainder(n) < log log(n - 2^k) for some valid k.\n\n**thresholdFunction n** = \u221a(log n / log log n)\n\nThe counterexample shows minOmegaRemainder \u2265 c \u00b7 thresholdFunction for infinitely many n.",
-    "mathContext": "The threshold function grows faster than log log n but slower than log n. It's the key quantity in the counterexample.",
+    "title": "Minimum Omega Over Remainders",
+    "content": "`minOmegaRemainder n` = $\\min\\{\\Omega(n - 2^k) : 2^k < n\\}$, computed via `Finset.inf'` over valid exponents $k \\le \\log_2 n$. Returns 0 for $n \\le 1$.\n\n`thresholdFunction n` = $\\sqrt{\\log n / \\log \\log n}$, the growth rate of the counterexample.\n\nThe counterexample shows $\\text{minOmegaRemainder}(n) \\ge c \\cdot \\text{thresholdFunction}(n)$ for infinitely many $n$.",
+    "mathContext": "$\\text{minOmegaRemainder}(n) = \\min_{0 \\le k \\le \\log_2 n} \\Omega(n - 2^k)$. The threshold $\\sqrt{\\log n / \\log \\log n}$ grows faster than $\\log \\log n$ since $\\frac{\\sqrt{\\log n / \\log \\log n}}{\\log \\log n} = \\frac{\\sqrt{\\log n}}{(\\log \\log n)^{3/2}} \\to \\infty$.",
     "significance": "key",
-    "relatedConcepts": [
-      "minimum",
-      "threshold",
-      "Finset.inf"
-    ],
-    "tags": [
-      "optimization",
-      "threshold-function",
-      "asymptotic-analysis",
-      "finset"
-    ],
-    "prerequisites": [
-      "Finset.inf",
-      "bigOmega"
-    ]
+    "relatedConcepts": ["Finset.inf'", "threshold function", "asymptotic growth"],
+    "prerequisites": ["Finset operations", "bigOmega", "Real.sqrt"]
   },
   {
     "id": "ann-e205-counterexample",
     "proofId": "erdos-205",
-    "range": {
-      "startLine": 87,
-      "endLine": 99
-    },
+    "range": { "startLine": 119, "endLine": 131 },
     "type": "concept",
     "title": "Barreto-Leeham Counterexample",
-    "content": "**barreto_leeham_counterexample**: There exist c > 0 and infinitely many n such that:\n\n1. minOmegaRemainder(n) \u2265 c \u00b7 \u221a(log n / log log n)\n2. All remainders n - 2^k \u2265 16 (for monotonicity)\n\nSince \u221a(log n / log log n) >> log log n, these n violate the conjecture.",
-    "mathContext": "For n = 10^100: log log n \u2248 5.3 but \u221a(log n / log log n) \u2248 6.5. The gap widens as n grows.",
+    "content": "`barreto_leeham_counterexample` (axiom): There exist $c > 0$ and infinitely many $n$ such that:\n1. $\\text{minOmegaRemainder}(n) \\ge c \\cdot \\sqrt{\\log n / \\log \\log n}$\n2. All remainders $n - 2^k \\ge 16$ (needed for $\\log \\log$ monotonicity)\n\nThe $n \\ge 16$ condition ensures the monotonicity lemma `loglog_mono_nat` applies, which is crucial for the final contradiction in the disproof.",
+    "mathContext": "For $n = 10^{100}$: $\\log \\log n \\approx 5.3$ but $\\sqrt{\\log n / \\log \\log n} \\approx 6.5$. The gap widens: for $n = 10^{10000}$, $\\log \\log n \\approx 10.1$ but the threshold $\\approx 47$.",
     "significance": "key",
-    "relatedConcepts": [
-      "counterexample",
-      "infinitely-many",
-      "lower-bound"
-    ],
-    "tags": [
-      "counterexample",
-      "disproof",
-      "sieve-theory",
-      "number-theory"
-    ],
-    "prerequisites": [
-      "covering systems",
-      "Chinese remainder theorem"
-    ]
+    "relatedConcepts": ["counterexample", "Set.Infinite", "lower bound"],
+    "prerequisites": ["covering systems", "Chinese remainder theorem", "sieve methods"]
   },
   {
     "id": "ann-e205-auxiliaries",
     "proofId": "erdos-205",
-    "range": {
-      "startLine": 101,
-      "endLine": 115
-    },
-    "type": "concept",
-    "title": "Auxiliary Lemmas",
-    "content": "**threshold_dominates_loglog**: For any c > 0, eventually c \u00b7 \u221a(log n / log log n) > log log n.\n\n**remainder_achieves_min**: minOmegaRemainder(n) \u2264 \u03a9(n - 2^k) for valid k.\n\n**loglog_mono_nat**: log log is increasing for m \u2265 16.\n\nThese lemmas connect the counterexample to the conjecture's failure.",
-    "mathContext": "The key inequality: \u221a(log n / log log n) / log log n = \u221a(log n) / (log log n)^(3/2) \u2192 \u221e",
+    "range": { "startLine": 133, "endLine": 179 },
+    "type": "technique",
+    "title": "Auxiliary Lemmas (2 proved, 1 axiom)",
+    "content": "Three lemmas connecting the counterexample to the disproof:\n\n- `threshold_dominates_loglog` (axiom): $\\forall c > 0, \\exists N_0, \\forall n \\ge N_0: c \\cdot \\sqrt{\\log n / \\log \\log n} > \\log \\log n$\n- `remainder_achieves_min` (**proved**): $\\text{minOmegaRemainder}(n) \\le \\Omega(n - 2^k)$ via `Finset.inf'_le`\n- `loglog_mono_nat` (**proved**): $\\log \\log m \\le \\log \\log n$ for $16 \\le m \\le n$ via `Real.log_le_log`\n\nThe `remainder_achieves_min` proof carefully shows $k$ is in the valid Finset range using `Nat.lt_pow_succ_log_self`.",
+    "mathContext": "The chain of inequalities in the disproof: $\\Omega(m) \\ge \\text{minOmega}(n) \\ge c \\cdot \\text{threshold}(n) > \\log \\log n \\ge \\log \\log m$. Each link uses one of these lemmas.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "monotonicity",
-      "dominance",
-      "asymptotic"
-    ],
-    "tags": [
-      "auxiliary-lemma",
-      "monotonicity",
-      "asymptotic-analysis",
-      "real-analysis"
-    ],
-    "prerequisites": [
-      "Finset operations",
-      "prime factorization"
-    ]
+    "relatedConcepts": ["Finset.inf'_le", "Real.log_le_log", "asymptotic dominance"],
+    "prerequisites": ["Finset.inf'", "Real.log monotonicity", "Nat.log"]
   },
   {
     "id": "ann-e205-disproof",
     "proofId": "erdos-205",
-    "range": {
-      "startLine": 118,
-      "endLine": 165
-    },
+    "range": { "startLine": 182, "endLine": 229 },
     "type": "insight",
     "title": "Disproof of Conjecture (Verified)",
-    "content": "**theorem erdos_205_disproved : \u00acErdos205Conjecture**\n\n**Proof outline**:\n1. Assume conjecture holds with threshold N\u2080\n2. Get counterexample constant c and threshold N\u2081 where c\u00b7threshold > log log\n3. Find n > max(N\u2080, N\u2081) from counterexample\n4. Conjecture gives n = 2^k + m with \u03a9(m) < log log m\n5. But \u03a9(m) \u2265 minOmega \u2265 c\u00b7threshold > log log n \u2265 log log m\n6. Contradiction: \u03a9(m) < log log m AND \u03a9(m) > log log m",
-    "mathContext": "Uses linarith for the final contradiction. Key: m = n - 2^k \u2264 n, so log log m \u2264 log log n by monotonicity.",
+    "content": "**theorem erdos_205_disproved : ¬Erdos205Conjecture**\n\nA 47-line verified proof by contradiction:\n1. Assume conjecture holds with threshold $N_0$\n2. Get counterexample constant $c$ and threshold $N_1$ where $c \\cdot \\text{threshold} > \\log \\log$\n3. Find $n > \\max(N_0, N_1)$ from counterexample\n4. Conjecture gives $n = 2^k + m$ with $\\Omega(m) < \\log \\log m$\n5. But $\\Omega(m) \\ge \\text{minOmega}(n) \\ge c \\cdot \\text{threshold}(n) > \\log \\log n \\ge \\log \\log m$\n6. `linarith` derives the contradiction from $\\Omega(m) < \\log \\log m$ and $\\Omega(m) > \\log \\log m$",
+    "mathContext": "The key monotonicity step: $m = n - 2^k \\le n$ and $m \\ge 16$, so $\\log \\log m \\le \\log \\log n$ by `loglog_mono_nat`. This closes the chain $\\log \\log m \\le \\log \\log n < \\Omega(m)$.",
     "significance": "key",
-    "relatedConcepts": [
-      "proof-by-contradiction",
-      "linarith",
-      "verified-disproof"
-    ],
-    "tags": [
-      "verified-proof",
-      "proof-by-contradiction",
-      "disproof",
-      "lean4-tactic"
-    ],
-    "prerequisites": [
-      "counterexample structure",
-      "axiomatized results"
-    ]
+    "relatedConcepts": ["proof by contradiction", "linarith", "verified disproof"],
+    "prerequisites": ["barreto_leeham_counterexample", "threshold_dominates_loglog", "remainder_achieves_min", "loglog_mono_nat"]
   },
   {
     "id": "ann-e205-romanoff",
     "proofId": "erdos-205",
-    "range": {
-      "startLine": 167,
-      "endLine": 180
-    },
+    "range": { "startLine": 235, "endLine": 246 },
     "type": "concept",
     "title": "Romanoff's Theorem (1934)",
-    "content": "**romanoff_positive_density**: A positive proportion \u03b4 > 0 of integers can be written as 2^k + p for prime p.\n\nThis is a POSITIVE result: asking for \u03a9(m) = 1 (m prime) works for many n.\n\nBut not all: the conjecture asked for the weaker \u03a9(m) < log log m and still failed!",
-    "mathContext": "The density \u03b4 \u2248 0.43... is known but complicated to compute exactly. Uses probabilistic methods.",
+    "content": "`romanoff_positive_density` (axiom): A positive proportion $\\delta > 0$ of integers can be written as $2^k + p$ for prime $p$.\n\nThis is a POSITIVE result: asking for $\\Omega(m) = 1$ (i.e., $m$ prime) works for many $n$. But not all — and the disproof shows even the far weaker $\\Omega(m) < \\log \\log m$ doesn't suffice universally.",
+    "mathContext": "Romanoff proved $\\delta = \\lim_{N \\to \\infty} \\frac{|\\{n \\le N : n = 2^k + p\\}|}{N} > 0$. The exact value $\\delta \\approx 0.434$ involves a product over primes and the density of powers of 2.",
     "significance": "key",
-    "relatedConcepts": [
-      "positive-density",
-      "prime-representation",
-      "romanoff"
-    ],
-    "tags": [
-      "additive-number-theory",
-      "density",
-      "prime-representation",
-      "classical-result"
-    ],
-    "prerequisites": [
-      "analytic number theory",
-      "density of sums"
-    ]
+    "relatedConcepts": ["positive density", "Goldbach-type representation", "IsPowerPlusePrime"],
+    "prerequisites": ["analytic number theory", "density of sums"]
   },
   {
-    "id": "ann-e205-covering",
+    "id": "ann-e205-covering-obstruction",
     "proofId": "erdos-205",
-    "range": {
-      "startLine": 182,
-      "endLine": 187
-    },
+    "range": { "startLine": 248, "endLine": 253 },
     "type": "concept",
-    "title": "Erd\u0151s's Covering Obstruction",
-    "content": "**erdos_covering_obstruction**: A positive density of ODD integers CANNOT be written as 2^k + p.\n\n**Method**: Covering systems - congruence classes that 'cover' all integers.\n\nExample: n \u2261 1 (mod 2) and n \u2261 0 (mod 3) may force all 2^k + (n - 2^k) to have composite remainder.",
-    "mathContext": "Erd\u0151s famously used covering systems for many number theory problems. This shows 2^k + p doesn't represent all odd numbers.",
+    "title": "Erdős's Covering Obstruction (1950)",
+    "content": "`erdos_covering_obstruction` (axiom): A positive density of ODD integers CANNOT be written as $2^k + p$ for any prime $p$. This was Erdős's breakthrough application of covering systems to additive problems.\n\nFor $n$ in a suitable arithmetic progression mod $3 \\cdot 5 \\cdot 7 \\cdot 13 \\cdot 17 \\cdot 241$, every remainder $n - 2^k$ is divisible by one of $\\{3, 5, 7, 13, 17, 241\\}$ and hence composite (since $n - 2^k > 241$).",
+    "mathContext": "Erdős showed $\\lim_{N \\to \\infty} \\frac{|\\{n \\le N : n \\text{ odd}, \\nexists k, p : n = 2^k + p\\}|}{N} = \\delta' > 0$. These are the de Polignac numbers, the smallest being 127.",
     "significance": "key",
-    "relatedConcepts": [
-      "covering-system",
-      "odd-integers",
-      "obstruction"
-    ],
-    "tags": [
-      "covering-system",
-      "modular-arithmetic",
-      "obstruction",
-      "erdos-technique"
-    ],
-    "prerequisites": [
-      "Chinese remainder theorem",
-      "modular arithmetic"
-    ]
+    "relatedConcepts": ["covering systems", "de Polignac numbers", "modular arithmetic"],
+    "prerequisites": ["Chinese remainder theorem", "multiplicative orders"]
+  },
+  {
+    "id": "ann-e205-concrete-omega",
+    "proofId": "erdos-205",
+    "range": { "startLine": 259, "endLine": 293 },
+    "type": "concept",
+    "title": "Concrete Omega Computations (12 values, native_decide)",
+    "content": "Twelve concrete values of $\\Omega$ verified by `native_decide`:\n\n$\\Omega(2) = 1$, $\\Omega(4) = 2$, $\\Omega(6) = 2$, $\\Omega(8) = 3$, $\\Omega(12) = 3$, $\\Omega(30) = 3$, $\\Omega(60) = 4$, $\\Omega(120) = 5$, $\\Omega(210) = 4$, $\\Omega(1024) = 10$, $\\Omega(2310) = 5$, $\\Omega(30030) = 6$.\n\nNotable values: $\\Omega(1024) = \\Omega(2^{10}) = 10$ (pure prime power), $\\Omega(30030) = \\Omega(2 \\cdot 3 \\cdot 5 \\cdot 7 \\cdot 11 \\cdot 13) = 6$ (primorial of 13).",
+    "mathContext": "These demonstrate $\\Omega$ on various number types: prime powers ($2^k$), primorials ($p\\#$), and products. The primorial $p\\# = \\prod_{q \\le p} q$ has $\\Omega(p\\#) = \\pi(p)$ (prime counting function).",
+    "significance": "supporting",
+    "relatedConcepts": ["native_decide", "primorial", "prime power"],
+    "prerequisites": ["bigOmega", "prime factorization"]
+  },
+  {
+    "id": "ann-e205-covering-systems",
+    "proofId": "erdos-205",
+    "range": { "startLine": 295, "endLine": 384 },
+    "type": "technique",
+    "title": "Covering Systems and de Polignac Numbers",
+    "content": "Formal verification of the covering system machinery underlying the disproof:\n\n**Covering system definition**: `IsCoveringSystem S` requires every integer is in some residue class of `S`.\n\n**Erdős modulus**: $3 \\cdot 5 \\cdot 7 \\cdot 13 \\cdot 17 \\cdot 241 = 5{,}592{,}405$, verified by `native_decide`. The orders $\\text{ord}_p(2)$ for these primes are $\\{2, 4, 3, 12, 8, 24\\}$ with $\\text{lcm} = 24$.\n\n**De Polignac number verification**: 127 and 149 are verified as de Polignac numbers by checking all remainders $n - 2^k$ are composite (14 `not_prime` theorems via `native_decide`).\n\n**Example for 127**: $127 - 1 = 126 = 2 \\cdot 3^2 \\cdot 7$, $127 - 2 = 125 = 5^3$, ..., $127 - 64 = 63 = 3^2 \\cdot 7$. All composite.",
+    "mathContext": "The covering $\\{0 \\bmod 2, 0 \\bmod 3, 1 \\bmod 4, 3 \\bmod 8, 7 \\bmod 12, 23 \\bmod 24\\}$ covers $\\{0, \\ldots, 23\\}$. For $n$ in the right AP mod $5{,}592{,}405$, each $2^k \\bmod \\text{ord}_p(2) = r$ forces $p \\mid (n - 2^k)$.",
+    "significance": "key",
+    "relatedConcepts": ["covering system", "multiplicative order", "de Polignac number", "OEIS A006285"],
+    "prerequisites": ["modular arithmetic", "Nat.Prime", "native_decide"]
   },
   {
     "id": "ann-e205-average",
     "proofId": "erdos-205",
-    "range": {
-      "startLine": 191,
-      "endLine": 205
-    },
+    "range": { "startLine": 390, "endLine": 404 },
     "type": "concept",
-    "title": "Average and Typical \u03a9",
-    "content": "**average_omega_asymptotic**: The average of \u03a9(n) for n \u2264 N is ~ log log N.\n\n**omega_concentration** (Erd\u0151s-Kac flavor): Most n have \u03a9(n) \u2248 log log n \u00b1 O(\u221a(log log n)).\n\nSo \u03a9(n) < log log n fails for about half of all n, but almost all n have some m = n - 2^k with small \u03a9.",
-    "mathContext": "The Erd\u0151s-Kac theorem says (\u03a9(n) - log log n) / \u221a(log log n) is asymptotically normal. This is the 'probabilistic' flavor of number theory.",
+    "title": "Hardy-Ramanujan Average and Erdős-Kac Concentration",
+    "content": "Two axiomatized analytic results providing context for why $\\log \\log$ is the natural threshold:\n\n`average_omega_asymptotic` (Hardy-Ramanujan 1917): $\\frac{1}{N} \\sum_{n=1}^{N} \\Omega(n) / \\log \\log N \\to 1$.\n\n`omega_concentration` (Erdős-Kac 1940): The fraction of $n \\le N$ with $|\\Omega(n) - \\log \\log n| > \\varepsilon \\sqrt{\\log \\log n}$ tends to 0. In full strength, $(\\Omega(n) - \\log \\log n) / \\sqrt{\\log \\log n} \\to N(0,1)$ in distribution.",
+    "mathContext": "The Erdős-Kac theorem is remarkable: $\\Omega(n)$ is asymptotically Gaussian despite being a deterministic arithmetic function. This makes $\\log \\log n$ the 'typical' value and explains why Erdős expected the conjecture to be true.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "erdos-kac",
-      "normal-distribution",
-      "concentration"
-    ],
-    "tags": [
-      "probabilistic-number-theory",
-      "erdos-kac",
-      "average-order",
-      "concentration-inequality"
-    ],
-    "prerequisites": [
-      "Hardy-Ramanujan theorem",
-      "prime number theorem"
-    ]
+    "relatedConcepts": ["Hardy-Ramanujan theorem", "Erdős-Kac theorem", "normal distribution", "Filter.Tendsto"],
+    "prerequisites": ["prime number theorem", "central limit theorem"]
   },
   {
     "id": "ann-e205-summary",
     "proofId": "erdos-205",
-    "range": {
-      "startLine": 207,
-      "endLine": 238
-    },
-    "type": "concept",
-    "title": "Summary and Status",
-    "content": "**Erd\u0151s Problem #205: DISPROVED**\n\n**Question**: Can all large n be written as 2^k + m with \u03a9(m) < log log m?\n**Answer**: NO (Barreto-Leeham 2026)\n\n**Verified theorem**: `erdos_205_disproved : \u00acErdos205Conjecture`\n\n**Key insight**: Some n have ALL remainders n - 2^k with \u03a9 \u2265 c\u221a(log n / log log n), which dominates log log.\n\n**Related**:\n- Romanoff: Positive density ARE 2^k + prime \u2713\n- Erd\u0151s: Positive density of odds are NOT 2^k + prime \u2717",
-    "mathContext": "The counterexample construction likely uses covering systems combined with careful sieving to ensure all remainders have many prime factors.",
+    "range": { "startLine": 406, "endLine": 444 },
+    "type": "context",
+    "title": "Summary: 6 Axioms, All Deep Results",
+    "content": "**Erdős Problem #205: DISPROVED** with `erdos_205_disproved : ¬Erdos205Conjecture`.\n\n**Proved (non-axiom)**: $\\Omega$ properties (4 theorems), `remainder_achieves_min`, `loglog_mono_nat`, the disproof itself, 12 concrete $\\Omega$ values, covering system verification, de Polignac verification for 127 and 149.\n\n**Axiomatized (6 deep results)**: Barreto-Leeham counterexample, threshold dominance, Romanoff density, Erdős covering obstruction, Hardy-Ramanujan average, Erdős-Kac concentration.\n\nThree axioms were eliminated during the formalization by proving `bigOmega_prime_pow`, `bigOmega_mul`, and `remainder_achieves_min` from Mathlib.",
+    "mathContext": "The 6 remaining axioms are all deep analytic/number-theoretic results requiring techniques (sieve methods, complex analysis, probabilistic methods) far beyond what automated proof search can currently handle.",
     "significance": "key",
-    "relatedConcepts": [
-      "problem-status",
-      "disproved",
-      "ai-assisted"
-    ],
-    "tags": [
-      "summary",
-      "disproved",
-      "covering-system",
-      "ai-assisted-proof"
-    ],
-    "prerequisites": [
-      "covering systems",
-      "analytic number theory"
-    ]
+    "relatedConcepts": ["axiom audit", "formalization status", "Mathlib integration"],
+    "prerequisites": ["all preceding sections"]
   }
 ]

--- a/src/data/proofs/erdos-205/meta.json
+++ b/src/data/proofs/erdos-205/meta.json
@@ -101,50 +101,57 @@
       "id": "omega-function",
       "title": "The Ω Function",
       "startLine": 48,
-      "endLine": 77,
-      "summary": "Definition and properties of bigOmega: Ω(1)=0, Ω(p)=1, Ω(p^k)=k, Ω(ab)=Ω(a)+Ω(b)."
+      "endLine": 85,
+      "summary": "Definition of bigOmega via primeFactorsList.length, with all four properties PROVED from Mathlib: Ω(1)=0, Ω(p)=1, Ω(p^k)=k (by induction), Ω(ab)=Ω(a)+Ω(b) (via perm_primeFactorsList_mul)"
     },
     {
       "id": "conjecture",
       "title": "The Erdős Conjecture",
-      "startLine": 79,
-      "endLine": 91,
-      "summary": "HasSmallOmegaRep and Erdos205Conjecture definitions."
+      "startLine": 87,
+      "endLine": 99,
+      "summary": "HasSmallOmegaRep (n = 2^k + m with Ω(m) < log log m) and Erdos205Conjecture (all sufficiently large n have such a representation)"
     },
     {
       "id": "counterexample",
-      "title": "The Counterexample",
-      "startLine": 93,
-      "endLine": 217,
-      "summary": "Axiomatized counterexample, remainder_achieves_min (proved), loglog_mono_nat (proved), and erdos_205_disproved."
+      "title": "The Counterexample and Disproof",
+      "startLine": 101,
+      "endLine": 229,
+      "summary": "minOmegaRemainder and thresholdFunction definitions, Barreto-Leeham counterexample (axiom), auxiliary lemmas (threshold_dominates_loglog axiom, remainder_achieves_min and loglog_mono_nat proved), and the verified 47-line disproof erdos_205_disproved"
     },
     {
       "id": "romanoff",
-      "title": "Romanoff's Theorem",
-      "startLine": 219,
-      "endLine": 241,
-      "summary": "IsPowerPlusePrime, Romanoff positive density and Erdős covering obstruction (axiomatized)."
+      "title": "Romanoff's Theorem and Covering Obstruction",
+      "startLine": 231,
+      "endLine": 253,
+      "summary": "IsPowerPlusePrime definition, Romanoff positive density (axiom: δ > 0 fraction are 2^k + p), and Erdős covering obstruction (axiom: positive density of odds are NOT 2^k + p)"
     },
     {
       "id": "concrete-omega",
       "title": "Concrete Ω Computations",
-      "startLine": 243,
-      "endLine": 281,
-      "summary": "12 verified Ω values from Ω(2)=1 to Ω(30030)=6."
+      "startLine": 255,
+      "endLine": 293,
+      "summary": "12 verified Ω values via native_decide: from Ω(2)=1 to Ω(30030)=6, including prime powers (Ω(1024)=10) and primorials (Ω(2310)=5, Ω(30030)=6)"
     },
     {
       "id": "covering-systems",
       "title": "Covering Systems and de Polignac Numbers",
-      "startLine": 283,
-      "endLine": 372,
-      "summary": "Covering system definitions, Erdős modulus, orders of 2, de Polignac verification for 127 and 149."
+      "startLine": 295,
+      "endLine": 384,
+      "summary": "IsCoveringSystem definition, Erdős modulus 5592405, orders of 2 mod {3,5,7,13,17,241} verified, LCM = 24 covering check, de Polignac numbers 127 and 149 verified (all 15 remainders proved composite via native_decide)"
     },
     {
       "id": "analytic-bounds",
       "title": "Related Analytic Bounds",
-      "startLine": 374,
-      "endLine": 392,
-      "summary": "Hardy-Ramanujan average and Erdős-Kac concentration (axiomatized)."
+      "startLine": 386,
+      "endLine": 404,
+      "summary": "Hardy-Ramanujan average (axiom: average Ω ~ log log N) and Erdős-Kac concentration (axiom: Ω(n) is asymptotically Gaussian around log log n)"
+    },
+    {
+      "id": "summary",
+      "title": "Summary and Status",
+      "startLine": 406,
+      "endLine": 444,
+      "summary": "Complete audit: 6 axioms (all deep analytic results), ~85 declarations, 0 sorries. Three axioms eliminated during formalization."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
**Critical fix**: ALL 12 annotation line ranges were wrong (shifted 15-200 lines from actual Lean code), pointing to incorrect code sections. This was a major quality issue at quality 97.

- Fixed all 12 annotation line ranges to match actual `Erdos205Problem.lean` content
- Updated `ann-e205-omega-theorems`: content incorrectly claimed `bigOmega_prime_pow` and `bigOmega_mul` were "axioms" when they are fully proved from Mathlib
- Added `ann-e205-concrete-omega`: new annotation covering 12 `native_decide` Ω computations (lines 259-293)
- Added `ann-e205-covering-systems`: new annotation covering the covering system formalization and de Polignac verification for 127/149 (lines 295-384)
- Fixed all 7 section line ranges in meta.json to match file structure
- Added summary section (lines 406-444)
- Expanded all section summaries with mathematical detail

## Test plan
- [x] JSON validated (python3 json.load)
- [x] Annotations build shows no errors for erdos-205
- [x] All annotation ranges manually verified against Lean file

🤖 Generated with [Claude Code](https://claude.com/claude-code)