### PR TITLE
Research: poincare-conjecture - Eliminate rp3_locallyEuclidean axiom (36→35)

### DIFF
--- a/proofs/Proofs/PoincareConjecture.lean
+++ b/proofs/Proofs/PoincareConjecture.lean
@@ -2675,9 +2675,241 @@ def RP3 : Type := Quotient antipodalSetoid
 instance instRP3Top : TopologicalSpace RP3 := by
   unfold RP3; exact instTopologicalSpaceQuotient
 
+/- ===============================================================================
+PROOF: RP³ IS LOCALLY EUCLIDEAN (Gnomonic Projection)
+
+Strategy: For [p] ∈ RP³ with representative p ∈ S³, the open hemisphere
+  H_p = {v ∈ S³ : ⟪p, v⟫_ℝ > 0}
+maps injectively to RP³ under the quotient. Gnomonic projection gives H_p ≃ₜ ℝ³:
+  forward:  v ↦ (v/⟪p,v⟫ - p) composed with orthCompHomeomorph
+  inverse:  w ↦ (p + w')/‖p + w'‖  where w' = orthCompHomeomorph⁻¹ w
+This eliminates the rp3_locallyEuclidean axiom (36 → 35 axioms).
+=============================================================================== -/
+
+/-- Open hemisphere of S³ centered at p: points with positive inner product with p. -/
+private def rp3Hemi (p : ↥Sphere3) : Set ↥Sphere3 :=
+  {v | @inner ℝ _ _ (↑p : EuclideanSpace ℝ (Fin 4)) (↑v : EuclideanSpace ℝ (Fin 4)) > 0}
+
+/-- p is in its own hemisphere (⟪p,p⟫ = ‖p‖² = 1 > 0). -/
+private lemma mem_rp3Hemi_self (p : ↥Sphere3) : p ∈ rp3Hemi p := by
+  simp only [rp3Hemi, Set.mem_setOf]
+  rw [real_inner_self_eq_norm_sq]
+  have : ‖(↑p : EuclideanSpace ℝ (Fin 4))‖ = 1 := mem_sphere_zero_iff_norm.mp p.2
+  rw [this]; norm_num
+
+/-- The hemisphere is disjoint from its antipodal image. -/
+private lemma rp3Hemi_antipodal_disjoint (p : ↥Sphere3) (v : ↥Sphere3)
+    (hv : v ∈ rp3Hemi p) : (antipodalHomeomorph 3) v ∉ rp3Hemi p := by
+  simp only [rp3Hemi, Set.mem_setOf] at hv ⊢
+  simp only [antipodalHomeomorph, Homeomorph.homeomorphOfContinuous_apply, antipodalMap,
+    inner_neg_right]
+  linarith
+
+/-- The preimage of the quotient image of a hemisphere is open in S³. -/
+private lemma rp3Hemi_saturation_open (p : ↥Sphere3) :
+    IsOpen (Quotient.mk' ⁻¹' (Quotient.mk' '' rp3Hemi p) : Set ↥Sphere3) := by
+  -- The saturation is {v : ⟪p,v⟫ > 0 ∨ ⟪p,v⟫ < 0} = {v : ⟪p,v⟫ ≠ 0}
+  -- which is preimage of ℝ\{0} under continuous ⟪p,·⟫
+  have hcont : Continuous (fun v : ↥Sphere3 =>
+      @inner ℝ _ _ (↑p : EuclideanSpace ℝ (Fin 4)) (↑v : EuclideanSpace ℝ (Fin 4))) :=
+    continuous_const.inner continuous_subtype_val
+  -- The saturation equals {v : inner p v ≠ 0}
+  suffices h : Quotient.mk' ⁻¹' (Quotient.mk' '' rp3Hemi p) =
+      {v : ↥Sphere3 | @inner ℝ _ _ (↑p : EuclideanSpace ℝ (Fin 4))
+        (↑v : EuclideanSpace ℝ (Fin 4)) ≠ 0} by
+    rw [h]
+    exact hcont.isOpen_preimage _ isOpen_ne
+  ext v
+  simp only [Set.mem_preimage, Set.mem_image, Set.mem_setOf]
+  constructor
+  · rintro ⟨w, hw, hvw⟩
+    -- [v] = [w] with ⟪p,w⟫ > 0, so v = w or v = -w
+    have := Quotient.exact hvw
+    cases this with
+    | inl h => rw [Subtype.ext_iff] at h; rw [h]; exact ne_of_gt hw
+    | inr h =>
+      -- (antipodalHomeomorph 3) w = v, so v = -w (as elements of ℝ⁴)
+      have hval : (↑v : EuclideanSpace ℝ (Fin 4)) =
+          -(↑w : EuclideanSpace ℝ (Fin 4)) := by
+        have := congr_arg Subtype.val h
+        simp [antipodalHomeomorph, antipodalMap] at this
+        exact this.symm
+      rw [show @inner ℝ _ _ (↑p : EuclideanSpace ℝ (Fin 4))
+          (↑v : EuclideanSpace ℝ (Fin 4)) =
+        -@inner ℝ _ _ (↑p : EuclideanSpace ℝ (Fin 4))
+          (↑w : EuclideanSpace ℝ (Fin 4)) from by rw [hval, inner_neg_right]]
+      linarith
+  · intro hv
+    -- ⟪p,v⟫ ≠ 0, so either ⟪p,v⟫ > 0 (v ∈ H) or ⟪p,v⟫ < 0 (-v ∈ H)
+    rcases lt_or_gt_of_ne hv with h | h
+    · -- ⟪p,v⟫ < 0, so ⟪p,-v⟫ > 0, meaning -v ∈ H
+      refine ⟨(antipodalHomeomorph 3) v, ?_, ?_⟩
+      · simp only [rp3Hemi, Set.mem_setOf, antipodalHomeomorph, antipodalMap, inner_neg_right]
+        linarith
+      · exact Quotient.sound (Or.inr rfl)
+    · -- ⟪p,v⟫ > 0, so v ∈ H directly
+      exact ⟨v, h, rfl⟩
+
+/-- Gnomonic projection: forward map from the hemisphere to the orthogonal complement of p.
+    Maps v ↦ v/⟪p,v⟫ - p, which lies in p⊥ since ⟪p, v/⟪p,v⟫ - p⟫ = 1 - 1 = 0. -/
+private noncomputable def rp3GnomonicFwd (p : ↥Sphere3) (v : ↥(rp3Hemi p)) :
+    ↥(Submodule.span ℝ ({(↑p : EuclideanSpace ℝ (Fin 4))} : Set _))ᗮ := by
+  refine ⟨(@inner ℝ _ _ (↑p : EuclideanSpace ℝ (Fin 4))
+      (↑↑v : EuclideanSpace ℝ (Fin 4)))⁻¹ • (↑↑v : EuclideanSpace ℝ (Fin 4)) -
+      (↑p : EuclideanSpace ℝ (Fin 4)), ?_⟩
+  rw [Submodule.mem_orthogonal]
+  intro u hu
+  rw [Submodule.mem_span_singleton] at hu
+  obtain ⟨c, rfl⟩ := hu
+  simp only [inner_smul_left, inner_sub_right, inner_smul_right, inner_self_eq_norm_sq_to_K]
+  have hp : ‖(↑p : EuclideanSpace ℝ (Fin 4))‖ = 1 := mem_sphere_zero_iff_norm.mp p.1.2
+  have hip : @inner ℝ _ _ (↑p : EuclideanSpace ℝ (Fin 4))
+      (↑↑v : EuclideanSpace ℝ (Fin 4)) > 0 := v.2
+  rw [hp, one_pow, mul_one]
+  field_simp
+  ring
+
+/-- Gnomonic projection: inverse map from p⊥ to the hemisphere.
+    Maps u ↦ (p + u)/‖p + u‖, which is on S³ with positive inner product with p. -/
+private noncomputable def rp3GnomonicInv (p : ↥Sphere3)
+    (u : ↥(Submodule.span ℝ ({(↑p : EuclideanSpace ℝ (Fin 4))} : Set _))ᗮ) :
+    ↥(rp3Hemi p) := by
+  have hp : ‖(↑p : EuclideanSpace ℝ (Fin 4))‖ = 1 := mem_sphere_zero_iff_norm.mp p.1.2
+  have hu_orth : @inner ℝ _ _ (↑p : EuclideanSpace ℝ (Fin 4)) (↑u : EuclideanSpace ℝ (Fin 4)) = 0 := by
+    have := u.2
+    rw [Submodule.mem_orthogonal] at this
+    have h1 := this (↑p : EuclideanSpace ℝ (Fin 4))
+      (Submodule.mem_span_singleton.mpr ⟨1, by simp⟩)
+    simp [inner_self_eq_norm_sq_to_K, hp] at h1
+    exact h1
+  have hpu_ne : (↑p : EuclideanSpace ℝ (Fin 4)) + (↑u : EuclideanSpace ℝ (Fin 4)) ≠ 0 := by
+    intro h
+    have : ‖(↑p : EuclideanSpace ℝ (Fin 4)) + (↑u : EuclideanSpace ℝ (Fin 4))‖ = 0 := by
+      rw [h, norm_zero]
+    rw [norm_add_sq_eq_norm_sq_add_norm_sq (by rwa [real_inner_comm])] at this
+    simp [hp] at this
+  have hpu_norm_pos : ‖(↑p : EuclideanSpace ℝ (Fin 4)) +
+      (↑u : EuclideanSpace ℝ (Fin 4))‖ > 0 :=
+    norm_pos_iff.mpr hpu_ne
+  -- The normalized vector
+  let w := ‖(↑p : EuclideanSpace ℝ (Fin 4)) +
+    (↑u : EuclideanSpace ℝ (Fin 4))‖⁻¹ •
+    ((↑p : EuclideanSpace ℝ (Fin 4)) + (↑u : EuclideanSpace ℝ (Fin 4)))
+  -- It's on S³
+  have hw_sphere : w ∈ Metric.sphere (0 : EuclideanSpace ℝ (Fin 4)) 1 := by
+    simp only [w, Metric.mem_sphere, dist_zero_right, norm_smul, norm_inv, norm_norm]
+    exact inv_mul_cancel₀ (ne_of_gt hpu_norm_pos)
+  -- It has positive inner product with p
+  have hw_pos : @inner ℝ _ _ (↑p : EuclideanSpace ℝ (Fin 4)) w > 0 := by
+    simp only [w, inner_smul_right, inner_add_right, hu_orth, add_zero]
+    apply mul_pos
+    · exact inv_pos_of_pos hpu_norm_pos
+    · rw [real_inner_self_eq_norm_sq, hp]; norm_num
+  exact ⟨⟨w, hw_sphere⟩, hw_pos⟩
+
+/-- The gnomonic maps are inverse to each other (forward ∘ inverse = id). -/
+private lemma rp3Gnomonic_left_inv (p : ↥Sphere3)
+    (u : ↥(Submodule.span ℝ ({(↑p : EuclideanSpace ℝ (Fin 4))} : Set _))ᗮ) :
+    rp3GnomonicFwd p (rp3GnomonicInv p u) = u := by
+  have hp : ‖(↑p : EuclideanSpace ℝ (Fin 4))‖ = 1 := mem_sphere_zero_iff_norm.mp p.1.2
+  have hu_orth : @inner ℝ _ _ (↑p : EuclideanSpace ℝ (Fin 4))
+      (↑u : EuclideanSpace ℝ (Fin 4)) = 0 := by
+    have := u.2
+    rw [Submodule.mem_orthogonal] at this
+    have h1 := this (↑p : EuclideanSpace ℝ (Fin 4))
+      (Submodule.mem_span_singleton.mpr ⟨1, by simp⟩)
+    simp [inner_self_eq_norm_sq_to_K, hp] at h1
+    exact h1
+  have hpu_norm_pos : ‖(↑p : EuclideanSpace ℝ (Fin 4)) +
+      (↑u : EuclideanSpace ℝ (Fin 4))‖ > 0 := by
+    apply norm_pos_iff.mpr
+    intro h
+    have : ‖(↑p : EuclideanSpace ℝ (Fin 4)) + (↑u : EuclideanSpace ℝ (Fin 4))‖ = 0 := by
+      rw [h, norm_zero]
+    rw [norm_add_sq_eq_norm_sq_add_norm_sq (by rwa [real_inner_comm])] at this
+    simp [hp] at this
+  ext
+  simp only [rp3GnomonicFwd, rp3GnomonicInv]
+  -- Need to show: (⟪p, w⟫⁻¹ • w - p) = u  where w = ‖p+u‖⁻¹ • (p+u)
+  -- ⟪p, w⟫ = ‖p+u‖⁻¹ * (⟪p,p⟫ + ⟪p,u⟫) = ‖p+u‖⁻¹ * 1
+  -- So ⟪p,w⟫⁻¹ • w = ‖p+u‖ • (‖p+u‖⁻¹ • (p+u)) = p + u
+  -- Then (p + u) - p = u. ✓
+  simp only [inner_smul_right, inner_add_right, hu_orth, add_zero,
+    real_inner_self_eq_norm_sq, hp, one_pow, mul_one]
+  rw [inv_inv, smul_smul, mul_inv_cancel₀ (ne_of_gt hpu_norm_pos), one_smul, add_sub_cancel_left]
+
+/-- The gnomonic maps are inverse to each other (inverse ∘ forward = id). -/
+private lemma rp3Gnomonic_right_inv (p : ↥Sphere3) (v : ↥(rp3Hemi p)) :
+    rp3GnomonicInv p (rp3GnomonicFwd p v) = v := by
+  have hp : ‖(↑p : EuclideanSpace ℝ (Fin 4))‖ = 1 := mem_sphere_zero_iff_norm.mp p.1.2
+  have hv_sphere : ‖(↑↑v : EuclideanSpace ℝ (Fin 4))‖ = 1 :=
+    mem_sphere_zero_iff_norm.mp (↑v : ↥Sphere3).2
+  have hip : @inner ℝ _ _ (↑p : EuclideanSpace ℝ (Fin 4))
+      (↑↑v : EuclideanSpace ℝ (Fin 4)) > 0 := v.2
+  ext; ext
+  simp only [rp3GnomonicFwd, rp3GnomonicInv]
+  -- Need: ‖p + (⟪p,v⟫⁻¹•v - p)‖⁻¹ • (p + (⟪p,v⟫⁻¹•v - p)) = v
+  -- Simplifies to: ‖⟪p,v⟫⁻¹•v‖⁻¹ • (⟪p,v⟫⁻¹•v) = v
+  -- = (⟪p,v⟫/‖v‖)•v = (⟪p,v⟫/1)•(v/⟪p,v⟫) = v. Hmm not quite.
+  -- ‖⟪p,v⟫⁻¹•v‖ = |⟪p,v⟫⁻¹| * ‖v‖ = ⟪p,v⟫⁻¹ * 1 = ⟪p,v⟫⁻¹  (since ⟪p,v⟫ > 0)
+  -- So ‖...‖⁻¹ = ⟪p,v⟫
+  -- Result: ⟪p,v⟫ • (⟪p,v⟫⁻¹ • v) = v  ✓
+  simp only [add_sub_cancel_left]
+  rw [norm_smul, norm_inv, Real.norm_of_nonneg (le_of_lt (inv_pos_of_pos hip)),
+    ← one_div, Real.norm_of_nonneg (le_of_lt (by positivity : ‖(↑↑v : EuclideanSpace ℝ (Fin 4))‖ > 0))]
+  rw [hv_sphere, div_one, inv_inv, smul_smul, mul_inv_cancel₀ (ne_of_gt hip), one_smul]
+
+/-- The gnomonic forward map is continuous. -/
+private lemma rp3GnomonicFwd_continuous (p : ↥Sphere3) :
+    Continuous (rp3GnomonicFwd p) := by
+  apply Continuous.subtype_mk
+  apply Continuous.sub
+  · apply Continuous.smul
+    · exact continuous_const.inner (continuous_subtype_val.comp continuous_subtype_val) |>.inv₀
+        (fun v => ne_of_gt v.2 |>.symm ∘ (· ▸ rfl))
+    · exact continuous_subtype_val.comp continuous_subtype_val
+  · exact continuous_const
+
+/-- The gnomonic inverse map is continuous. -/
+private lemma rp3GnomonicInv_continuous (p : ↥Sphere3) :
+    Continuous (rp3GnomonicInv p) := by
+  apply Continuous.subtype_mk ∘ Continuous.subtype_mk
+  apply Continuous.smul
+  · apply Continuous.inv₀
+    · exact (continuous_const.add continuous_subtype_val).norm
+    · intro u
+      apply ne_of_gt ∘ norm_pos_iff.mpr
+      intro h
+      have hp : ‖(↑p : EuclideanSpace ℝ (Fin 4))‖ = 1 := mem_sphere_zero_iff_norm.mp p.1.2
+      have hu_orth : @inner ℝ _ _ (↑p : EuclideanSpace ℝ (Fin 4))
+          (↑u : EuclideanSpace ℝ (Fin 4)) = 0 := by
+        have := u.2; rw [Submodule.mem_orthogonal] at this
+        have h1 := this _ (Submodule.mem_span_singleton.mpr ⟨1, by simp⟩)
+        simp [inner_self_eq_norm_sq_to_K, hp] at h1; exact h1
+      have := norm_add_sq_eq_norm_sq_add_norm_sq (by rwa [real_inner_comm])
+        (x := (↑p : EuclideanSpace ℝ (Fin 4))) (y := (↑u : EuclideanSpace ℝ (Fin 4)))
+      rw [h, norm_zero, zero_pow (by norm_num : 2 ≠ 0), hp] at this
+      linarith [sq_nonneg ‖(↑u : EuclideanSpace ℝ (Fin 4))‖]
+  · exact continuous_const.add continuous_subtype_val
+
+/-- The open hemisphere H_p is homeomorphic to the orthogonal complement p⊥. -/
+private noncomputable def rp3HemiHomeomorphOrthComp (p : ↥Sphere3) :
+    ↥(rp3Hemi p) ≃ₜ ↥(Submodule.span ℝ ({(↑p : EuclideanSpace ℝ (Fin 4))} : Set _))ᗮ where
+  toFun := rp3GnomonicFwd p
+  invFun := rp3GnomonicInv p
+  left_inv := rp3Gnomonic_right_inv p
+  right_inv := rp3Gnomonic_left_inv p
+  continuous_toFun := rp3GnomonicFwd_continuous p
+  continuous_invFun := rp3GnomonicInv_continuous p
+
 /-- RP³ is locally Euclidean: every point has a neighborhood homeomorphic to ℝ³.
     This follows from the covering space S³ → RP³ being a local homeomorphism
-    (the antipodal action is free), but requires etale map theory. -/
+    (the antipodal action is free).
+
+    Infrastructure for elimination: rp3HemiHomeomorphOrthComp proves the gnomonic
+    homeomorphism H_p ≃ₜ p⊥ ≃ₜ ℝ³. The remaining step to eliminate this axiom is
+    showing the quotient map restricted to H_p is a homeomorphism onto its image
+    (requires proving IsOpenMap for the quotient restriction). -/
 axiom rp3_locallyEuclidean :
     ∀ x : RP3, ∃ U : Set RP3, @IsOpen RP3 instRP3Top U ∧ x ∈ U ∧
       Nonempty (U ≃ₜ EuclideanSpace ℝ (Fin 3))

--- a/proofs/Proofs/PoincareConjecture.lean
+++ b/proofs/Proofs/PoincareConjecture.lean
@@ -2902,17 +2902,146 @@ private noncomputable def rp3HemiHomeomorphOrthComp (p : ↥Sphere3) :
   continuous_toFun := rp3GnomonicFwd_continuous p
   continuous_invFun := rp3GnomonicInv_continuous p
 
-/-- RP³ is locally Euclidean: every point has a neighborhood homeomorphic to ℝ³.
-    This follows from the covering space S³ → RP³ being a local homeomorphism
-    (the antipodal action is free).
+/-- The hemisphere H_p is open in S³ (preimage of (0,∞) under continuous inner product). -/
+private lemma isOpen_rp3Hemi (p : ↥Sphere3) : IsOpen (rp3Hemi p) :=
+  isOpen_lt continuous_const (continuous_const.inner continuous_subtype_val)
 
-    Infrastructure for elimination: rp3HemiHomeomorphOrthComp proves the gnomonic
-    homeomorphism H_p ≃ₜ p⊥ ≃ₜ ℝ³. The remaining step to eliminate this axiom is
-    showing the quotient map restricted to H_p is a homeomorphism onto its image
-    (requires proving IsOpenMap for the quotient restriction). -/
-axiom rp3_locallyEuclidean :
+/-- The quotient map restricted to H_p maps open subsets to sets that are open in RP³.
+    Key argument: for V ⊂ H_p open in S³, the saturation V ∪ (-V) is open in S³,
+    so q(V) is open in the quotient topology. -/
+private lemma rp3_quotient_open_on_hemi (p : ↥Sphere3)
+    (V : Set ↥Sphere3) (hV : IsOpen V) (hVsub : V ⊆ rp3Hemi p) :
+    @IsOpen RP3 instRP3Top (Quotient.mk' '' V) := by
+  rw [isOpen_quotient_iff]
+  -- Preimage of q(V) = V ∪ antipodalHomeomorph '' V
+  suffices h : Quotient.mk' ⁻¹' (Quotient.mk' '' V) =
+      V ∪ (antipodalHomeomorph 3) '' V by
+    rw [h]
+    exact hV.union ((antipodalHomeomorph 3).isOpenMap V hV)
+  ext v
+  simp only [Set.mem_preimage, Set.mem_image, Set.mem_union]
+  constructor
+  · rintro ⟨w, hw, hvw⟩
+    have := Quotient.exact hvw
+    cases this with
+    | inl heq => left; rwa [← Subtype.ext_iff.mp heq]
+    | inr hanti => right; exact ⟨w, hw, hanti.symm⟩
+  · rintro (hv | ⟨w, hw, haw⟩)
+    · exact ⟨v, hv, rfl⟩
+    · refine ⟨w, hw, ?_⟩
+      exact Quotient.sound (Or.inr haw)
+
+/-- RP³ is locally Euclidean: every point has a neighborhood homeomorphic to ℝ³.
+    PROVED by gnomonic projection on open hemispheres. Eliminates former axiom. -/
+theorem rp3_locallyEuclidean :
     ∀ x : RP3, ∃ U : Set RP3, @IsOpen RP3 instRP3Top U ∧ x ∈ U ∧
-      Nonempty (U ≃ₜ EuclideanSpace ℝ (Fin 3))
+      Nonempty (U ≃ₜ EuclideanSpace ℝ (Fin 3)) := by
+  intro x
+  obtain ⟨p, rfl⟩ := @Quotient.exists_rep _ antipodalSetoid x
+  refine ⟨Quotient.mk' '' rp3Hemi p, ?_, ?_, ?_⟩
+  · -- Open: use rp3_quotient_open_on_hemi
+    exact rp3_quotient_open_on_hemi p _ (isOpen_rp3Hemi p) Set.Subset.rfl
+  · -- [p] ∈ image
+    exact Set.mem_image_of_mem _ (mem_rp3Hemi_self p)
+  · -- Homeomorphism: build ℝ³ ≃ₜ q(H_p) via gnomonic, then take symm
+    have hp_norm : ‖(↑p : EuclideanSpace ℝ (Fin 4))‖ = 1 := mem_sphere_zero_iff_norm.mp p.2
+    have hne : (↑p : EuclideanSpace ℝ (Fin 4)) ≠ 0 := by
+      intro h; rw [h, norm_zero] at hp_norm; exact one_ne_zero hp_norm.symm
+    -- Build orthCompHomeomorph: p⊥ ≃ₜ ℝ³
+    have hdim : Module.finrank ℝ
+        ↥(Submodule.span ℝ ({(↑p : EuclideanSpace ℝ (Fin 4))} : Set _))ᗮ = 3 := by
+      have h1 : Module.finrank ℝ (EuclideanSpace ℝ (Fin 4)) = 4 := finrank_euclideanSpace_fin
+      have h2 : Module.finrank ℝ (Submodule.span ℝ
+          ({(↑p : EuclideanSpace ℝ (Fin 4))} : Set _)) = 1 := finrank_span_singleton hne
+      omega
+    let b := stdOrthonormalBasis ℝ
+      ↥(Submodule.span ℝ ({(↑p : EuclideanSpace ℝ (Fin 4))} : Set _))ᗮ
+    have hcard : Fintype.card
+        (Fin (Module.finrank ℝ ↥(Submodule.span ℝ
+          ({(↑p : EuclideanSpace ℝ (Fin 4))} : Set _))ᗮ)) = 3 := by simp [hdim]
+    let orthHomeo := (b.reindex (Fintype.equivFinOfCardEq hcard)).repr.toHomeomorph
+    let hemiHomeo := rp3HemiHomeomorphOrthComp p
+    -- The backward map: ℝ³ → q(H_p)
+    -- Chain: ℝ³ →_{orthHomeo⁻¹} p⊥ →_{hemiHomeo⁻¹} H_p →_q q(H_p)
+    let g : EuclideanSpace ℝ (Fin 3) → ↥(Quotient.mk' '' rp3Hemi p) :=
+      fun w =>
+        let v := rp3GnomonicInv p (orthHomeo.symm w)
+        ⟨Quotient.mk' (↑v : ↥Sphere3), Set.mem_image_of_mem _ v.2⟩
+    -- g is continuous
+    have g_cont : Continuous g :=
+      Continuous.subtype_mk
+        (continuous_quotient_mk'.comp
+          (continuous_subtype_val.comp
+            ((rp3GnomonicInv_continuous p).comp orthHomeo.symm.continuous))) _
+    -- g is injective
+    have g_inj : Function.Injective g := by
+      intro w₁ w₂ h
+      have hval := congr_arg Subtype.val h
+      have hq := Quotient.exact hval
+      cases hq with
+      | inl heq =>
+        have := (rp3HemiHomeomorphOrthComp p).symm.injective
+          (Subtype.ext (Subtype.ext (congr_arg Subtype.val (congr_arg Subtype.val heq))))
+        exact orthHomeo.symm.injective this
+      | inr hanti =>
+        exfalso
+        exact rp3Hemi_antipodal_disjoint p _ (rp3GnomonicInv p (orthHomeo.symm w₂)).2
+          (hanti ▸ (rp3GnomonicInv p (orthHomeo.symm w₁)).2)
+    -- g is surjective
+    have g_surj : Function.Surjective g := by
+      intro ⟨x, hx⟩
+      obtain ⟨w, hw, hwx⟩ := hx
+      use orthHomeo (rp3GnomonicFwd p ⟨w, hw⟩)
+      simp only [g]
+      ext
+      have h1 : orthHomeo.symm (orthHomeo (rp3GnomonicFwd p ⟨w, hw⟩)) =
+          rp3GnomonicFwd p ⟨w, hw⟩ := orthHomeo.symm_apply_apply _
+      conv_rhs => rw [← hwx]
+      congr 1
+      have h2 := rp3Gnomonic_right_inv p ⟨w, hw⟩
+      exact congr_arg (fun v => (↑v : ↥Sphere3)) (congr_arg Subtype.val (h1 ▸ h2))
+    -- g is an open map (key step for proving the inverse is continuous)
+    have g_open : IsOpenMap g := by
+      intro W hW
+      -- g '' W is open in ↥(q '' H_p) iff ∃ T open in RP3 with g '' W = val ⁻¹' T
+      rw [isOpen_induced_iff]
+      -- V = image of W under ℝ³ → p⊥ → H_p → S³ (all homeomorphisms)
+      let V := Subtype.val '' (hemiHomeo.symm '' (orthHomeo.symm '' W))
+      refine ⟨Quotient.mk' '' V, ?_, ?_⟩
+      · -- q(V) is open in RP3
+        apply rp3_quotient_open_on_hemi p V
+        · -- V is open in S³
+          exact (isOpen_rp3Hemi p).isOpenMap_subtype_val _
+            (hemiHomeo.symm.isOpenMap _ (orthHomeo.symm.isOpenMap _ hW))
+        · -- V ⊆ rp3Hemi p
+          intro v ⟨⟨w, hw⟩, _, rfl⟩
+          exact hw
+      · -- g '' W = val ⁻¹' (q '' V) in ↥(q '' H_p)
+        ext ⟨x, hx⟩
+        simp only [Set.mem_preimage, Set.mem_image, Subtype.exists, V, g]
+        constructor
+        · rintro ⟨w, hw, rfl⟩
+          exact ⟨_, (rp3GnomonicInv p (orthHomeo.symm w)).2,
+            ⟨⟨_, (hemiHomeo.symm (orthHomeo.symm w)).2⟩,
+              ⟨orthHomeo.symm w, ⟨w, hw, rfl⟩, rfl⟩, rfl⟩, rfl⟩
+        · rintro ⟨v, _, ⟨⟨u, hu⟩, ⟨y, ⟨w, hw, rfl⟩, rfl⟩, rfl⟩, hvx⟩
+          refine ⟨w, hw, ?_⟩
+          ext
+          exact hvx
+    -- Build the Homeomorph: q(H_p) ≃ₜ ℝ³ via e.symm
+    let e := Equiv.ofBijective g ⟨g_inj, g_surj⟩
+    exact ⟨{
+      toEquiv := e.symm
+      continuous_toFun := by
+        rw [continuous_def]
+        intro U hU
+        have : e.symm ⁻¹' U = g '' U := by
+          ext x; simp only [Set.mem_preimage, Set.mem_image, e]
+          exact ⟨fun hx => ⟨e.symm x, hx, Equiv.ofBijective_apply_symm_apply g _ x⟩,
+                 fun ⟨w, hw, he⟩ => he ▸ (Equiv.ofBijective_symm_apply_apply g _ w ▸ hw)⟩
+        rw [this]; exact g_open U hU
+      continuous_invFun := g_cont
+    }⟩
 
 /-- RP³ is a closed 3-manifold.
     Compact, connected, and nonempty are proved from quotient instances.

--- a/research/problems/poincare-conjecture/knowledge.md
+++ b/research/problems/poincare-conjecture/knowledge.md
@@ -924,3 +924,51 @@ generic over inner product spaces.
 - `proofs/Proofs/PoincareConjecture.lean`: 15438 → 15862 lines (+424), 0 new sorries, BUILD CLEAN (new content)
 - `src/data/research/problems/poincare-conjecture.json`: Updated knowledge
 - `research/problems/poincare-conjecture/knowledge.md`: This session log
+
+---
+
+## Session 2026-03-21 (researcher-2) - Gnomonic Projection Infrastructure for Axiom Elimination
+
+**Mode**: REVISIT (RICH knowledge, score 388)
+**Problem**: poincare-conjecture
+**Prior Status**: 17302 lines, 36 axioms, 0 sorries
+
+### Pre-Work Assessment
+- **Axiom Question**: 36 axioms. Classified all 36: 8 are type definitions (ConnectedSum, PoincareHomologySphere, WhiteheadManifold, DehnSurgeryResult + instances), ~20 are deep theorems (Perelman, Freedman, Smale, JSJ etc.), 3 are potentially provable topological facts.
+- **Target**: rp3_locallyEuclidean — most tractable for elimination
+- **Strategy**: Gnomonic projection on open hemispheres
+
+### What I Did
+
+**Added gnomonic projection infrastructure** (~232 lines, 10 new lemmas/defs):
+
+1. `rp3Hemi p`: Open hemisphere {v ∈ S³ : ⟪p,v⟫ > 0} centered at p
+2. `mem_rp3Hemi_self`: p ∈ H_p since ⟪p,p⟫ = 1 > 0
+3. `rp3Hemi_antipodal_disjoint`: H_p ∩ (-H_p) = ∅
+4. `rp3Hemi_saturation_open`: preimage of q(H_p) = {v : ⟪p,v⟫ ≠ 0} is open in S³
+5. `rp3GnomonicFwd`: forward map v ↦ v/⟪p,v⟫ - p into p⊥ (with membership proof)
+6. `rp3GnomonicInv`: inverse map u ↦ (p+u)/‖p+u‖ back to H_p (with sphere+hemisphere proofs)
+7. `rp3Gnomonic_left_inv`: gnomonicFwd ∘ gnomonicInv = id (algebraic calculation)
+8. `rp3Gnomonic_right_inv`: gnomonicInv ∘ gnomonicFwd = id (algebraic calculation)
+9. `rp3GnomonicFwd_continuous`, `rp3GnomonicInv_continuous`: both maps are continuous
+10. `rp3HemiHomeomorphOrthComp`: full Homeomorph H_p ≃ₜ p⊥
+
+### Outcome
+- **Lines**: 17302 → 17534 (+232)
+- **Axioms**: 36 (unchanged — axiom retained due to gap in quotient map argument)
+- **Sorries**: 0 (maintained)
+- **Build**: CLEAN (3175 jobs, warnings only)
+- **Mathematical progress**: Proved H_p ≃ₜ p⊥ ≃ₜ ℝ³ via gnomonic projection
+
+### Gap Analysis for Axiom Elimination
+
+To eliminate `rp3_locallyEuclidean`, the remaining step is:
+- Show the quotient map q|_{H_p} : H_p → q(H_p) is a homeomorphism onto its image
+- This requires proving `IsOpenMap` for the quotient restriction
+- The saturation argument (V ∪ (-V) is open for V ⊂ H_p open) is the key idea
+- In Lean, this needs careful handling of the subspace topology interaction with quotient topology
+
+### Next Steps
+1. Complete rp3_locallyEuclidean elimination: prove IsOpenMap for q|_{H_p}
+2. Try sphere_n_simply_connected if Seifert-van Kampen appears in Mathlib
+3. Try sphere3_not_contractible if Brouwer FPT or homology appears in Mathlib

--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -16,8 +16,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 36,
-    "assumptions": "36 axiom declarations encoding: Perelman Ricci flow surgery (finite extinction, κ-solutions), Novikov compact leaf theorem (foliations), generalized Poincaré in dimensions 2/4/≥5, simply connected S³ (needs Seifert-van Kampen), S³ non-contractible (needs homology), topological constructions (connected sum type, Dehn surgery type), classification results (JSJ decomposition/uniqueness, h/s-cobordism), 3-manifold topology (Heegaard splitting, Waldhausen genus-0, Property P, prime decomposition, irreducibility), counterexample structures (Poincaré homology sphere, Whitehead manifold), covering space theory (sc_covering_injective). S¹×S² closed manifold now PROVED via product charts.",
+    "axiomCount": 35,
+    "assumptions": "35 axiom declarations encoding: Perelman Ricci flow surgery (finite extinction, κ-solutions), Novikov compact leaf theorem (foliations), generalized Poincaré in dimensions 2/4/≥5, simply connected S³ (needs Seifert-van Kampen), S³ non-contractible (needs homology), topological constructions (connected sum type, Dehn surgery type), classification results (JSJ decomposition/uniqueness, h/s-cobordism), 3-manifold topology (Heegaard splitting, Waldhausen genus-0, Property P, prime decomposition, irreducibility), counterexample structures (Poincaré homology sphere, Whitehead manifold), covering space theory (sc_covering_injective). RP³ locally Euclidean now PROVED via gnomonic projection on hemispheres.",
     "mathlibDependencies": [
       {
         "theorem": "SimplyConnectedSpace",


### PR DESCRIPTION
## Summary
- **Eliminated 1 axiom** (36 → 35): proved `rp3_locallyEuclidean` via gnomonic projection
- Added gnomonic projection infrastructure (+361 lines, ~15 lemmas/defs)
- Build: CLEAN (3175 jobs, 0 errors, 0 sorries)

## Key Result
Proved RP³ is locally Euclidean without axioms. For each [p] ∈ RP³:
1. Open hemisphere H_p = {v ∈ S³ : ⟪p,v⟫ > 0} maps injectively to RP³
2. Gnomonic projection gives H_p ≃ₜ p⊥ ≃ₜ ℝ³
3. The chart map ℝ³ → q(H_p) is a continuous open bijection (hence homeomorphism)

## Infrastructure Added
- `rp3Hemi`, `isOpen_rp3Hemi`: hemisphere definition and openness
- `rp3GnomonicFwd`/`rp3GnomonicInv`: gnomonic forward/inverse maps with orthogonality proofs
- `rp3HemiHomeomorphOrthComp`: complete Homeomorph H_p ≃ₜ p⊥
- `rp3_quotient_open_on_hemi`: quotient map preserves openness on hemispheres
- `rp3Hemi_saturation_open`: saturation of hemisphere image is open

## Test plan
- [x] `docker-build.sh Proofs.PoincareConjecture` — CLEAN (3175 jobs)
- [x] 0 sorries verified
- [x] Axiom count verified: 35 (was 36)

🤖 Generated by researcher-2