### PR TITLE
Enrich erdos-249 and erdos-256: fix schema, add references, deepen content

### DIFF
--- a/src/data/proofs/erdos-256/meta.json
+++ b/src/data/proofs/erdos-256/meta.json
@@ -65,13 +65,43 @@
       "primitive_root_lower_bound axiom",
       "bounds_summary axiom"
     ],
+    "references": [
+      {
+        "authors": "Erdős, Paul; Szekeres, George",
+        "title": "On the product ∏(1-z^{aᵢ})",
+        "year": "1959",
+        "venue": "Acad. Serbe Sci. Publ. Inst. Math.",
+        "note": "Initiated the study of f(n); proved the lower bound f(n) > √(2n)"
+      },
+      {
+        "authors": "Atkinson, F. V.",
+        "title": "On a problem of Erdős and Szekeres",
+        "year": "1961",
+        "venue": "Acta Sci. Math. (Szeged)",
+        "note": "Improved the upper bound to log f(n) ≪ n^{1/2} log n"
+      },
+      {
+        "authors": "Belov, Alexander S.; Konyagin, Sergei V.",
+        "title": "On an Erdős-Szekeres problem",
+        "year": "1996",
+        "venue": "arXiv/journal preprint",
+        "note": "Definitive answer: log f(n) ≪ (log n)⁴, showing f(n) grows only polylogarithmically"
+      },
+      {
+        "authors": "Bourgain, Jean; Chang, Mei-Chu",
+        "title": "On a multilinear character sum of Burgess",
+        "year": "2018",
+        "venue": "Comptes Rendus Mathématique",
+        "note": "Bounds for the distinct exponents case f*(n)"
+      }
+    ],
     "axiomCount": 10,
     "prerequisites": [
-      "Complex analysis (unit circle, modulus)",
-      "Harmonic analysis (trigonometric polynomials)",
-      "Real analysis (supremum, infimum, logarithmic growth)",
-      "Number theory (roots of unity, modular arithmetic)",
-      "Asymptotic analysis (big-O, polynomial vs polylogarithmic growth)"
+      "Complex analysis (unit circle, modulus, roots of unity)",
+      "Harmonic analysis (trigonometric polynomials, maximum modulus)",
+      "Real analysis (supremum, infimum, logarithmic growth rates)",
+      "Number theory (primitive roots of unity, modular arithmetic)",
+      "Asymptotic analysis (big-O notation, polynomial vs polylogarithmic growth)"
     ]
   },
   "overview": {
@@ -91,56 +121,56 @@
     {
       "id": "definitions",
       "title": "Basic Definitions",
-      "summary": "productPoly, maxOnUnitCircle, f(n)",
+      "summary": "Defines `productPoly` ($\\prod_i(1 - z^{a_i})$), `maxOnUnitCircle` ($\\max_{|z|=1} |P(z)|$), and $f(n) = \\inf_a \\max_{|z|=1} |P(z;a)|$. The inf-max structure captures the minimax optimization.",
       "startLine": 39,
       "endLine": 64
     },
     {
       "id": "bounds",
       "title": "Known Bounds",
-      "summary": "Erdős-Szekeres, Atkinson, Odlyzko bounds",
+      "summary": "Axiomatizes the historical bounds: Erdős-Szekeres $f(n) > \\sqrt{2n}$ (1959), Atkinson $\\log f(n) \\ll n^{1/2} \\log n$ (1961), Odlyzko $\\log f(n) \\ll n^{1/3}(\\log n)^{4/3}$ (1982). Also proves $\\lim f(n)^{1/n} = 1$.",
       "startLine": 66,
       "endLine": 103
     },
     {
       "id": "question",
       "title": "The Main Question",
-      "summary": "ErdosQuestion256 statement",
+      "summary": "Defines `ErdosQuestion256`: $\\exists c > 0,\\, \\exists C > 0,\\, \\forall n \\geq 2,\\, \\log f(n) \\geq C \\cdot n^c$. Asks whether $\\log f(n)$ grows at least as a power of $n$.",
       "startLine": 105,
       "endLine": 116
     },
     {
       "id": "answer",
       "title": "The Answer",
-      "summary": "Belov-Konyagin bound, erdos_256_answer",
+      "summary": "Axiomatizes the Belov-Konyagin bound $\\log f(n) \\leq C(\\log n)^4$ and proves `erdos_256_answer : ¬ErdosQuestion256` — the answer is NO, since $(\\log n)^4$ grows slower than $n^c$ for any $c > 0$.",
       "startLine": 118,
       "endLine": 139
     },
     {
       "id": "distinct",
       "title": "The Distinct Case",
-      "summary": "fDistinct, Bourgain-Chang bound",
+      "summary": "Defines `fDistinct(n)` for the variant with distinct exponents. Axiomatizes the Bourgain-Chang (2018) bound for this case, which has different (potentially better) growth behavior.",
       "startLine": 141,
       "endLine": 158
     },
     {
       "id": "chowla",
       "title": "Connection to Chowla Problem",
-      "summary": "chowlaMinimum, atkinson_chowla_connection",
+      "summary": "Connects to Erdős Problem #510 via `chowlaMinimum`: the minimum of $|\\sum \\cos(a_i \\theta)|$ over $\\theta$. Atkinson observed these two minimax problems are related through the logarithm of the product.",
       "startLine": 160,
       "endLine": 178
     },
     {
       "id": "properties",
       "title": "Properties of the Product",
-      "summary": "Roots of unity, lower bounds",
+      "summary": "Proves `product_at_root_of_unity`: evaluation at primitive $m$-th roots of unity. Axiomatizes `primitive_root_lower_bound`: these evaluation points provide key lower bounds on $f(n)$.",
       "startLine": 180,
       "endLine": 200
     },
     {
       "id": "summary-bounds",
       "title": "Summary of Bounds",
-      "summary": "Timeline, gap between bounds",
+      "summary": "Axiomatizes the complete bounds timeline in one theorem: $\\sqrt{2n} \\leq f(n)$ (1959) and $\\log f(n) \\leq C(\\log n)^4$ (1996). The gap between $\\frac{1}{2}\\log n$ and $(\\log n)^4$ remains open.",
       "startLine": 202,
       "endLine": 225
     },
@@ -156,10 +186,17 @@
     "summary": "Erdős Problem #256 asked whether log f(n) ≫ n^c for some c > 0, where f(n) measures the minimum achievable maximum of products ∏(1-z^{aᵢ}) on the unit circle. Belov and Konyagin (1996) proved the answer is NO: log f(n) ≪ (log n)⁴, meaning f(n) grows only polylogarithmically in n.",
     "implications": "**Analysis Connections:**\n\n1. **Unit circle dynamics:** Products of (1-z^a) have rich structure on |z|=1.\n\n2. **Harmonic analysis:** Connected to cosine sum problems and trigonometric polynomials.\n\n3. **Bounds gap:** True growth between (1/2)log n and (log n)⁴ remains open.\n\n4. **Distinct case:** Different behavior when exponents must be distinct.",
     "openQuestions": [
-      "What is the exact growth rate of log f(n) between log n and (log n)⁴?",
-      "Is f(n) = exp(Θ((log n)^α)) for some 1 ≤ α ≤ 4?",
-      "What is the optimal constant in Belov-Konyagin bound?",
-      "Analogues for products of (1 - z^a + z^{2a}) or higher order?"
+      "What is the exact growth rate of $\\log f(n)$? Known: between $\\frac{1}{2}\\log n$ and $(\\log n)^4$.",
+      "Is $f(n) = \\exp(\\Theta((\\log n)^\\alpha))$ for some $1 \\leq \\alpha \\leq 4$?",
+      "What is the optimal constant in the Belov-Konyagin bound $\\log f(n) \\leq C(\\log n)^4$?",
+      "Does the distinct exponents case $f^*(n)$ have the same growth rate as $f(n)$?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "proofId": "erdos-szekeres",
+      "relationship": "foundational",
+      "note": "Erdős and Szekeres initiated the study of $f(n)$, proving the lower bound $f(n) > \\sqrt{2n}$"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enrichment passes for 2 gallery entries:

### erdos-249 (Irrationality of Totient Power Sum)
- **Critical correction**: Old annotations falsely claimed convergence properties were axiomatized — they are actually fully proved (0 axioms)
- Fixed annotation types/significance/tags per schema
- Added prerequisites to all 10 annotations
- Added 2 references, 1 crossReference
- 6 keyInsights with LaTeX; expanded section summaries and openQuestions

### erdos-256 (Maxima of Products on the Unit Circle)
- Added 4 references (Erdős-Szekeres 1959, Atkinson 1961, Belov-Konyagin 1996, Bourgain-Chang 2018)
- Added crossReference to erdos-szekeres
- Expanded all 9 section summaries with LaTeX mathematical detail
- Added LaTeX to openQuestions

## Test plan

- [x] `annotations:build` passes for both entries
- [x] JSON validated
- [x] Axiom claims corrected for erdos-249

🤖 Generated with [Claude Code](https://claude.com/claude-code)