### PR TITLE
Enrich bezout-identity-oq-02-oq-02-oq-01: add prerequisites, crossReferences

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
@@ -94,9 +94,15 @@
         "note": "Section 4.5.2: Modern treatment of the extended Euclidean algorithm with complexity analysis"
       }
     ],
-    "historicalContext": "The Euclidean algorithm (Elements, ~300 BCE) is the oldest nontrivial algorithm still in use. Bachet (1624) extended it to compute Bézout coefficients, and Bézout (1779) formalized the identity au + bv = gcd(a,b). While Euclid's lemma has been known since antiquity, its constructive content — actually computing the quotient from Bézout coefficients — highlights the algorithmic power implicit in the classical proof.",
     "dateAdded": "2026-03-06",
-    "axiomCount": 0
+    "axiomCount": 0,
+    "prerequisites": [
+      "The Euclidean algorithm and GCD computation",
+      "Bézout's identity: au + bv = gcd(a,b)",
+      "Coprimality and Euclid's lemma",
+      "Commutative ring axioms and integral domains",
+      "Lean 4 well-founded recursion and termination proofs"
+    ]
   },
   "overview": {
     "summary": "Combines the extended Euclidean algorithm with Bézout's identity to construct an explicit divisibility algorithm: given coprime a, b and a proof that a divides b*c, compute the quotient q = c/a. The core formula q = u*c + v*k (where u*a + v*b = 1 and b*c = a*k) works in any commutative ring, and is instantiated over ℕ/ℤ via the extended GCD.",
@@ -193,5 +199,27 @@
       "Can the complexity bound $O(\\log \\min(a,b))$ for extGcd be formalized in Lean?",
       "Can the quotient formula be generalized to non-commutative rings (e.g., matrix rings) where Euclid's lemma fails?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity",
+      "relationship": "extends",
+      "description": "Root formalization of Bézout's identity; this entry extends it with a constructive divisibility algorithm using the Bézout coefficients"
+    },
+    {
+      "targetId": "bezout-identity-oq-02",
+      "relationship": "extends",
+      "description": "Parent open question about Euclid's lemma; this entry resolves the sub-question about constructive quotient computation"
+    },
+    {
+      "targetId": "chinese-remainder-constructive",
+      "relationship": "related",
+      "description": "Both use the extended Euclidean algorithm constructively: CRT for simultaneous congruences, this for explicit quotient extraction"
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "related",
+      "description": "Euclid's lemma (proved constructively here) is a key ingredient in many proofs about prime distribution and factorization"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Added `prerequisites` array with 5 mathematical prerequisites
- Added 4 top-level `crossReferences` (bezout-identity, bezout-identity-oq-02, chinese-remainder-constructive, infinitude-primes)
- Removed duplicate `historicalContext` from meta (already in overview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)