### PR TITLE
Fix missing slug field in research-listings sync

### DIFF
--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -373,6 +373,8 @@ if pool_file.exists():
         pool = json.load(f)
     pool_status = {c["id"]: c.get("status", "pending") for c in pool["candidates"]}
 
+# Remove entries missing required 'slug' field
+listings = [item for item in listings if "slug" in item]
 listing_slugs = {item["slug"] for item in listings}
 added = 0
 updated = 0


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'slug'` in `sync-and-deploy.sh` data sync step
- 15 entries in `research-listings.json` lack the required `slug` field, causing the sync to crash
- Filter out incomplete entries before processing

## Test plan
- [x] Verified the fix resolves the KeyError
- [x] Build and deploy succeeded after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)