### PR TITLE
Enrich batch: Szemeredi suite + FTC-Lebesgue + 5 Erdos entries

### DIFF
--- a/src/data/proofs/erdos-367/meta.json
+++ b/src/data/proofs/erdos-367/meta.json
@@ -27,6 +27,20 @@
       "Asymptotic analysis (big-O, little-o notation)",
       "Multiplicative number theory (multiplicative functions)",
       "Basic real analysis (logarithms, limits, sequences)"
+    ],
+    "references": [
+      {
+        "key": "ErGr80",
+        "citation": "P. Erd\u0151s and R. L. Graham, Old and New Problems and Results in Combinatorial Number Theory, Monographies de L'Enseignement Math\u00e9matique 28, Geneva, 1980."
+      },
+      {
+        "key": "vD23",
+        "citation": "W. van Doorn, On products of squareful parts, 2023. Disproved the strong bound for k \u2265 3."
+      },
+      {
+        "key": "Gol69",
+        "citation": "S. W. Golomb, Powerful numbers, Amer. Math. Monthly 77 (1970), 848\u2013855."
+      }
     ]
   },
   "overview": {


### PR DESCRIPTION
## Summary

Batch enrichment pass for 11 entries.

**High-impact (new annotations created from scratch):**
- **szemeredi-full** (q:45): 8 annotations, 5 references
- **roth-theorem-k3** (q:45): 7 annotations, 5 references
- **szemeredi-regularity** (q:43): 9 annotations, 5 references
- **fundamental-theorem-calculus-oq-01** (q:32): 8 annotations, 3 references, 6 sections, added proofRepoPath

**Reference additions & standardization (q:97):**
- **erdos-256**: Deepened history, standardized refs, fixed cross-refs
- **erdos-302**: Standardized refs, improved mathContext with LaTeX
- **erdos-315**: Standardized refs
- **erdos-367**: Added 3 references
- **erdos-383**: Added 2 references
- **erdos-384**: Added 2 references

**Also in separate PR:**
- **szemeredi-counting** (q:43): 7 annotations, 4 references (PR #4521)

🤖 Generated with [Claude Code](https://claude.com/claude-code)