### PR TITLE
Enrich 243+ entries: batch relatedProofs + 7 annotation sets

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -122,5 +122,9 @@
       "relationship": "related",
       "description": "Both are foundational impossibility/existence results that shaped the development of mathematics"
     }
+  ],
+  "relatedProofs": [
+    "angle-trisection",
+    "infinitude-primes"
   ]
 }

--- a/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
@@ -143,5 +143,13 @@
       "relationship": "related",
       "description": "Both use Galois group structure to derive impossibility results: Abel-Ruffini shows non-solvable Galois groups block radical solutions, this file shows non-2-group Galois groups block constructibility"
     }
+  ],
+  "relatedProofs": [
+    "angle-trisection",
+    "angle-trisection-oq-02",
+    "angle-trisection-oq-02-oq-03",
+    "angle-trisection-oq-02-oq-03-oq-01",
+    "inverse-galois",
+    "abel-ruffini"
   ]
 }

--- a/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
@@ -196,5 +196,10 @@
       "Can explicit compass-and-straightedge constructions for the 17-gon (Gauss's Gaussian periods method) or 257-gon (Richelot's method) be formalized in Lean 4 as sequences of geometric operations?",
       "The connection between constructible polygons and the discrete Fourier transform (DFT): the $n$-th roots of unity form a group under multiplication, and the FFT algorithm exploits the 2-power structure. Can this connection be formalized?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "angle-trisection",
+    "angle-trisection-oq-02",
+    "combinations-formula"
+  ]
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
@@ -127,5 +127,10 @@
       "Can the isoperimetric inequality C² ≥ 4πA (with equality only for circles) be proved?",
       "Can Archimedes' original method of exhaustion (polygon approximation) be formalized as a Riemann sum that converges to ∫₀ʳ 2πρ dρ?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "area-of-circle",
+    "area-of-circle-oq-01",
+    "fundamental-theorem-calculus"
+  ]
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -167,5 +167,11 @@
       "relationship": "extends",
       "description": "Wiedijk #43: the abstract version is in IsoperimetricTheorem.lean; this file provides the OQ-chain approach"
     }
+  ],
+  "relatedProofs": [
+    "area-of-circle",
+    "area-of-circle-oq-01",
+    "area-of-circle-oq-01-oq-02",
+    "isoperimetric-theorem"
   ]
 }

--- a/src/data/proofs/area-of-circle-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01/meta.json
@@ -135,5 +135,10 @@
       "Can the integral direction be formalized: A(r) = integral from 0 to r of C(rho) drho?",
       "Can the isoperimetric inequality (C^2 >= 4*pi*A with equality only for circles) be proved?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "area-of-circle",
+    "isoperimetric-theorem",
+    "pi-transcendental"
+  ]
 }

--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -118,5 +118,9 @@
       "Can the result be extended to arbitrary (not necessarily ±1/-k) sequences via a more abstract cycle lemma?",
       "Can the lattice path interpretation be formally connected: bijection between good rotations and Dyck-like paths?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "ballot-problem-oq-01",
+    "ballot-problem"
+  ]
 }

--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -212,5 +212,9 @@
       "relationship": "related",
       "description": "The Catalan number Cₙ = C(2n,n)/(n+1) counts non-crossing lattice paths (Dyck paths). This proof unifies Catalan and ballot formulas via catalan_eq_ballot."
     }
+  ],
+  "relatedProofs": [
+    "ballot-problem",
+    "catalan-numbers"
   ]
 }

--- a/src/data/proofs/ballot-problem/meta.json
+++ b/src/data/proofs/ballot-problem/meta.json
@@ -118,5 +118,10 @@
       "relationship": "co-listed",
       "description": "Both appear in Wiedijk's 100 Theorems list; infinitude of primes is #11, ballot problem is #30"
     }
+  ],
+  "relatedProofs": [
+    "fair-games-theorem",
+    "binomial-theorem",
+    "infinitude-primes"
   ]
 }

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -85,11 +85,43 @@
     ]
   },
   "crossReferences": [
-    {"id": "bezout-identity", "relationship": "ancestor", "description": "The root formalization of Bézout's identity, which establishes the extended Euclidean algorithm used here"},
-    {"id": "bezout-identity-oq-02", "relationship": "ancestor", "description": "Euclid's lemma via coprimality — the classical (noncomputable) version that this entry makes computable"},
-    {"id": "bezout-identity-oq-02-oq-02-oq-01", "relationship": "parent", "description": "The direct parent: constructive divisibility via Bézout coefficients using classical choice (`hdvd.choose`)"},
-    {"id": "bezout-identity-oq-02-oq-02", "relationship": "related", "description": "Euclid's lemma in Bézout domains and PIDs — the abstract algebraic generalization"},
-    {"id": "bezout-identity-oq-02-oq-01", "relationship": "related", "description": "The Fundamental Theorem of Arithmetic from Euclid's lemma — a key application of the divisibility result made computable here"},
-    {"id": "chinese-remainder-non-coprime", "relationship": "related", "description": "The Chinese Remainder Theorem uses similar coprimality and Bézout coefficient techniques"}
+    {
+      "id": "bezout-identity",
+      "relationship": "ancestor",
+      "description": "The root formalization of Bézout's identity, which establishes the extended Euclidean algorithm used here"
+    },
+    {
+      "id": "bezout-identity-oq-02",
+      "relationship": "ancestor",
+      "description": "Euclid's lemma via coprimality — the classical (noncomputable) version that this entry makes computable"
+    },
+    {
+      "id": "bezout-identity-oq-02-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "The direct parent: constructive divisibility via Bézout coefficients using classical choice (`hdvd.choose`)"
+    },
+    {
+      "id": "bezout-identity-oq-02-oq-02",
+      "relationship": "related",
+      "description": "Euclid's lemma in Bézout domains and PIDs — the abstract algebraic generalization"
+    },
+    {
+      "id": "bezout-identity-oq-02-oq-01",
+      "relationship": "related",
+      "description": "The Fundamental Theorem of Arithmetic from Euclid's lemma — a key application of the divisibility result made computable here"
+    },
+    {
+      "id": "chinese-remainder-non-coprime",
+      "relationship": "related",
+      "description": "The Chinese Remainder Theorem uses similar coprimality and Bézout coefficient techniques"
+    }
+  ],
+  "relatedProofs": [
+    "bezout-identity",
+    "bezout-identity-oq-02",
+    "bezout-identity-oq-02-oq-02-oq-01",
+    "bezout-identity-oq-02-oq-02",
+    "bezout-identity-oq-02-oq-01",
+    "chinese-remainder-non-coprime"
   ]
 }

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
@@ -233,5 +233,12 @@
       "relationship": "related",
       "description": "Fermat's two-squares theorem uses coprimality and descent arguments closely related to the Bézout-based divisibility machinery formalized here"
     }
+  ],
+  "relatedProofs": [
+    "bezout-identity",
+    "bezout-identity-oq-02",
+    "chinese-remainder-constructive",
+    "infinitude-primes",
+    "fermat-two-squares"
   ]
 }

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/meta.json
@@ -178,5 +178,13 @@
       "Prove cardinality preservation: |ZMod (∏nᵢ)| = ∏|ZMod nᵢ| = ∏nᵢ for the k-fold case",
       "Connect to the Pi-type formulation: ZMod (∏ nᵢ) ≅ (i : Fin k) → ZMod (ns i)"
     ]
-  }
+  },
+  "relatedProofs": [
+    "bezout-identity",
+    "bezout-identity-oq-03",
+    "fundamental-arithmetic",
+    "euler-totient",
+    "primitive-roots",
+    "chinese-remainder-non-coprime"
+  ]
 }

--- a/src/data/proofs/borsuk-ulam/meta.json
+++ b/src/data/proofs/borsuk-ulam/meta.json
@@ -179,5 +179,8 @@
       "Can the theorem be made constructive (intuitionistic)?",
       "What are the higher categorical analogues of the covering space argument?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "brouwer-fixed-point"
+  ]
 }

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
@@ -115,5 +115,12 @@
       "relationship": "related",
       "description": "The twin prime conjecture is the k=2 case of this framework, asking whether D(2) = 2 is achievable infinitely often"
     }
+  ],
+  "relatedProofs": [
+    "bounded-prime-gaps",
+    "bounded-prime-gaps-oq-03",
+    "prime-number-theorem",
+    "infinitude-primes",
+    "twin-primes-special"
   ]
 }

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-01/meta.json
@@ -8,16 +8,42 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/First_uncountable_ordinal",
     "date": "1895",
     "status": "verified",
-    "tags": ["set-theory", "ordinals", "cardinals", "classic", "research"],
+    "tags": [
+      "set-theory",
+      "ordinals",
+      "cardinals",
+      "classic",
+      "research"
+    ],
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ02OQ01.lean",
     "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
-      {"theorem": "Cardinal.aleph_lt_aleph", "description": "ℵ_α < ℵ_β ↔ α < β", "module": "Mathlib.SetTheory.Cardinal.Ordinal"},
-      {"theorem": "Cardinal.aleph_succ", "description": "ℵ_(succ α) = succ(ℵ_α)", "module": "Mathlib.SetTheory.Cardinal.Ordinal"},
-      {"theorem": "Cardinal.isRegular_aleph_one", "description": "ℵ₁ is regular", "module": "Mathlib.SetTheory.Cardinal.Cofinality"},
-      {"theorem": "Cardinal.card_ord", "description": "card(c.ord) = c", "module": "Mathlib.SetTheory.Cardinal.Ordinal"},
-      {"theorem": "Cardinal.lt_ord", "description": "α < c.ord ↔ card(α) < c", "module": "Mathlib.SetTheory.Cardinal.Ordinal"}
+      {
+        "theorem": "Cardinal.aleph_lt_aleph",
+        "description": "ℵ_α < ℵ_β ↔ α < β",
+        "module": "Mathlib.SetTheory.Cardinal.Ordinal"
+      },
+      {
+        "theorem": "Cardinal.aleph_succ",
+        "description": "ℵ_(succ α) = succ(ℵ_α)",
+        "module": "Mathlib.SetTheory.Cardinal.Ordinal"
+      },
+      {
+        "theorem": "Cardinal.isRegular_aleph_one",
+        "description": "ℵ₁ is regular",
+        "module": "Mathlib.SetTheory.Cardinal.Cofinality"
+      },
+      {
+        "theorem": "Cardinal.card_ord",
+        "description": "card(c.ord) = c",
+        "module": "Mathlib.SetTheory.Cardinal.Ordinal"
+      },
+      {
+        "theorem": "Cardinal.lt_ord",
+        "description": "α < c.ord ↔ card(α) < c",
+        "module": "Mathlib.SetTheory.Cardinal.Ordinal"
+      }
     ],
     "originalContributions": [
       "Aleph hierarchy: ℵ_α < ℵ_(α+1) for all ordinals α",
@@ -28,8 +54,16 @@
       "ω₁ is not countable: ¬(card((ℵ₁).ord) ≤ ℵ₀)"
     ],
     "references": [
-      {"authors": "G. Cantor", "title": "Beiträge zur Begründung der transfiniten Mengenlehre", "year": "1895"},
-      {"authors": "F. Hausdorff", "title": "Grundzüge einer Theorie der geordneten Mengen", "year": "1908"}
+      {
+        "authors": "G. Cantor",
+        "title": "Beiträge zur Begründung der transfiniten Mengenlehre",
+        "year": "1895"
+      },
+      {
+        "authors": "F. Hausdorff",
+        "title": "Grundzüge einer Theorie der geordneten Mengen",
+        "year": "1908"
+      }
     ],
     "dateAdded": "03/21/26",
     "axiomCount": 0
@@ -47,12 +81,48 @@
     ]
   },
   "sections": [
-    {"id": "preamble", "title": "Imports and Setup", "summary": "Imports Mathlib's cardinal-ordinal theory, cofinality theory, and ordinal arithmetic. Opens the `Cardinal` and `Ordinal` namespaces.", "startLine": 1, "endLine": 27},
-    {"id": "hierarchy", "title": "Part I: Aleph Hierarchy", "summary": "Proves the aleph function $\\alpha \\mapsto \\aleph_\\alpha$ is strictly monotone and injective. Derives $\\aleph_\\alpha < \\aleph_{\\alpha+1}$ for all ordinals $\\alpha$ and verifies the concrete chain $\\aleph_0 < \\aleph_1 < \\aleph_2$.", "startLine": 28, "endLine": 49},
-    {"id": "regularity", "title": "Part II: Cofinality and Regularity", "summary": "Establishes that $\\aleph_1$ is a regular cardinal: $\\text{cof}(\\omega_1) = \\aleph_1$, hence $\\text{cof}(\\omega_1) > \\aleph_0$. This means $\\omega_1$ cannot be expressed as a countable union of countable ordinals.", "startLine": 51, "endLine": 68},
-    {"id": "cardinal", "title": "Part III: Cardinal Properties", "summary": "Characterizes $\\aleph_1 = \\text{succ}(\\aleph_0)$ and derives the equivalence $\\kappa < \\aleph_1 \\iff \\kappa \\leq \\aleph_0$: a cardinal is countable if and only if it is at most $\\aleph_0$.", "startLine": 70, "endLine": 88},
-    {"id": "ordinal", "title": "Part IV: Ordinal of $\\aleph_1$", "summary": "Proves $|\\omega_1| = \\aleph_1$, $\\omega < \\omega_1$, and the characterization $\\alpha < \\omega_1 \\iff |\\alpha| \\leq \\aleph_0$. Concludes that $\\omega_1$ itself is not countable.", "startLine": 90, "endLine": 112},
-    {"id": "summary", "title": "Part V: Summary", "summary": "Bundles the four main properties (aleph hierarchy, regularity, uncountable cofinality, $\\omega < \\omega_1$) into a single conjunction theorem `omega1_properties_summary`.", "startLine": 114, "endLine": 130}
+    {
+      "id": "preamble",
+      "title": "Imports and Setup",
+      "summary": "Imports Mathlib's cardinal-ordinal theory, cofinality theory, and ordinal arithmetic. Opens the `Cardinal` and `Ordinal` namespaces.",
+      "startLine": 1,
+      "endLine": 27
+    },
+    {
+      "id": "hierarchy",
+      "title": "Part I: Aleph Hierarchy",
+      "summary": "Proves the aleph function $\\alpha \\mapsto \\aleph_\\alpha$ is strictly monotone and injective. Derives $\\aleph_\\alpha < \\aleph_{\\alpha+1}$ for all ordinals $\\alpha$ and verifies the concrete chain $\\aleph_0 < \\aleph_1 < \\aleph_2$.",
+      "startLine": 28,
+      "endLine": 49
+    },
+    {
+      "id": "regularity",
+      "title": "Part II: Cofinality and Regularity",
+      "summary": "Establishes that $\\aleph_1$ is a regular cardinal: $\\text{cof}(\\omega_1) = \\aleph_1$, hence $\\text{cof}(\\omega_1) > \\aleph_0$. This means $\\omega_1$ cannot be expressed as a countable union of countable ordinals.",
+      "startLine": 51,
+      "endLine": 68
+    },
+    {
+      "id": "cardinal",
+      "title": "Part III: Cardinal Properties",
+      "summary": "Characterizes $\\aleph_1 = \\text{succ}(\\aleph_0)$ and derives the equivalence $\\kappa < \\aleph_1 \\iff \\kappa \\leq \\aleph_0$: a cardinal is countable if and only if it is at most $\\aleph_0$.",
+      "startLine": 70,
+      "endLine": 88
+    },
+    {
+      "id": "ordinal",
+      "title": "Part IV: Ordinal of $\\aleph_1$",
+      "summary": "Proves $|\\omega_1| = \\aleph_1$, $\\omega < \\omega_1$, and the characterization $\\alpha < \\omega_1 \\iff |\\alpha| \\leq \\aleph_0$. Concludes that $\\omega_1$ itself is not countable.",
+      "startLine": 90,
+      "endLine": 112
+    },
+    {
+      "id": "summary",
+      "title": "Part V: Summary",
+      "summary": "Bundles the four main properties (aleph hierarchy, regularity, uncountable cofinality, $\\omega < \\omega_1$) into a single conjunction theorem `omega1_properties_summary`.",
+      "startLine": 114,
+      "endLine": 130
+    }
   ],
   "crossReferences": [
     {
@@ -79,5 +149,10 @@
       "Can König's theorem ($\\text{cof}(\\aleph_\\omega) > \\aleph_0$) be proved for singular cardinals?",
       "Can Aronszajn's theorem (there exists an $\\aleph_1$-tree with no uncountable branch) be formalized using these $\\omega_1$ properties?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "cantor-diagonalization",
+    "cantor-diagonalization-oq-02",
+    "continuum-hypothesis"
+  ]
 }

--- a/src/data/proofs/cantors-theorem-oq-02/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-02/meta.json
@@ -160,5 +160,13 @@
       "Does the Lawvere framework extend to ω-consistency and Rosser's strengthening of Gödel's theorem?",
       "What types admit Lawvere fixed-point theorems? (Any pointed dcpo satisfies a version — connection to Scott's fixed-point theorem)"
     ]
-  }
+  },
+  "relatedProofs": [
+    "cantors-theorem",
+    "cantors-theorem-oq-01",
+    "cantor-diagonalization",
+    "godel-incompleteness",
+    "brouwer-fixed-point",
+    "schauder-fixed-point"
+  ]
 }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
@@ -161,5 +161,10 @@
       "Extend to n-variable Cauchy-Schwarz using Finset.sum and induction",
       "Formalize the full power mean inequality chain: min ≤ HM ≤ GM ≤ AM ≤ QM ≤ max"
     ]
-  }
+  },
+  "relatedProofs": [
+    "cauchy-schwarz-integral-oq-01-oq-01",
+    "cauchy-schwarz-integral",
+    "amgm-inequality"
+  ]
 }

--- a/src/data/proofs/cauchy-schwarz-oq-04/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-04/meta.json
@@ -8,17 +8,43 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Cauchy%E2%80%93Schwarz_inequality",
     "date": "1821",
     "status": "verified",
-    "tags": ["analysis", "inner-product-spaces", "cauchy-schwarz", "extension", "research"],
+    "tags": [
+      "analysis",
+      "inner-product-spaces",
+      "cauchy-schwarz",
+      "extension",
+      "research"
+    ],
     "proofRepoPath": "Proofs/CauchySchwarzOQ04.lean",
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [
-      { "theorem": "abs_real_inner_le_norm", "description": "Cauchy-Schwarz for real inner products", "module": "Mathlib.Analysis.InnerProductSpace.Basic" },
-      { "theorem": "real_inner_self_eq_norm_sq", "description": "Inner product of v with itself equals norm squared", "module": "Mathlib.Analysis.InnerProductSpace.Basic" },
-      { "theorem": "norm_add_sq_real", "description": "Norm squared expansion for sum of vectors", "module": "Mathlib.Analysis.InnerProductSpace.Basic" },
-      { "theorem": "div_mul_cancel₀", "description": "Division-multiplication cancellation for nonzero divisor", "module": "Mathlib.Algebra.Order.Field.Basic" },
-      { "theorem": "sum_eq_zero_iff_of_nonneg", "description": "Sum of nonneg terms is zero iff all terms are zero", "module": "Mathlib.Algebra.BigOperators.Group.Finset" }
+      {
+        "theorem": "abs_real_inner_le_norm",
+        "description": "Cauchy-Schwarz for real inner products",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "real_inner_self_eq_norm_sq",
+        "description": "Inner product of v with itself equals norm squared",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "norm_add_sq_real",
+        "description": "Norm squared expansion for sum of vectors",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "div_mul_cancel₀",
+        "description": "Division-multiplication cancellation for nonzero divisor",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "sum_eq_zero_iff_of_nonneg",
+        "description": "Sum of nonneg terms is zero iff all terms are zero",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      }
     ],
     "originalContributions": [
       "projCoeff: orthogonal projection coefficient u onto v = inner u v / norm v^2",
@@ -32,8 +58,20 @@
       "existential_constant_is_projCoeff: bridge to base CauchySchwarz.lean existential result"
     ],
     "references": [
-      {"authors": "A.-L. Cauchy", "title": "Cours d'Analyse de l'École Royale Polytechnique", "year": "1821", "venue": "Paris", "note": "Original discrete inequality with equality case noted"},
-      {"authors": "J. M. Steele", "title": "The Cauchy-Schwarz Master Class", "year": "2004", "venue": "Cambridge University Press", "note": "Chapter 2: detailed treatment of equality conditions"}
+      {
+        "authors": "A.-L. Cauchy",
+        "title": "Cours d'Analyse de l'École Royale Polytechnique",
+        "year": "1821",
+        "venue": "Paris",
+        "note": "Original discrete inequality with equality case noted"
+      },
+      {
+        "authors": "J. M. Steele",
+        "title": "The Cauchy-Schwarz Master Class",
+        "year": "2004",
+        "venue": "Cambridge University Press",
+        "note": "Chapter 2: detailed treatment of equality conditions"
+      }
     ],
     "dateAdded": "03/19/26"
   },
@@ -125,5 +163,9 @@
       "Can the finite sum version be extended to weighted inner products sum(w_i * a_i * b_i)?",
       "Can the projection coefficient be connected to Mathlib's orthogonalProjection for Hilbert subspaces?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "cauchy-schwarz",
+    "cauchy-schwarz-oq-03"
+  ]
 }

--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -199,5 +199,12 @@
       "Can Hölder's inequality be formalized as a generalization, recovering Cauchy-Schwarz for $p=q=2$?",
       "[RESOLVED] The equality condition has been strengthened to give the exact proportionality constant $c = \\langle u,v\\rangle/\\|v\\|^2$ - see `cauchy-schwarz-oq-04` proof."
     ]
-  }
+  },
+  "relatedProofs": [
+    "cauchy-schwarz-integral",
+    "triangle-inequality",
+    "amgm-inequality",
+    "hurwitz-theorem",
+    "yang-mills"
+  ]
 }

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
@@ -142,5 +142,11 @@
       "relationship": "related",
       "description": "The categorical/monoid structure of distributions under convolution is the algebraic framework underlying triplet addition"
     }
+  ],
+  "relatedProofs": [
+    "central-limit-theorem",
+    "central-limit-theorem-oq-01",
+    "central-limit-theorem-oq-01-oq-01",
+    "central-limit-theorem-oq-03"
   ]
 }

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
@@ -113,5 +113,9 @@
       "What is the geometric interpretation of non-equal weights in terms of the arc division?",
       "Can the weight-product formula be used to give a new proof of the spherical Gauss-Bonnet theorem?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "cevas-theorem",
+    "cevas-theorem-oq-02"
+  ]
 }

--- a/src/data/proofs/cramers-rule/meta.json
+++ b/src/data/proofs/cramers-rule/meta.json
@@ -200,5 +200,11 @@
       "id": "cauchy-schwarz",
       "relationship": "Both are foundational linear algebra results formalized via Mathlib's abstract algebraic infrastructure. Cauchy-Schwarz works in inner product spaces while Cramer's rule works over commutative rings, showcasing Mathlib's generality."
     }
+  ],
+  "relatedProofs": [
+    "cayley-hamilton",
+    "cayley-hamilton-minpoly",
+    "cauchy-schwarz",
+    "fundamental-arithmetic"
   ]
 }

--- a/src/data/proofs/de-moivre/meta.json
+++ b/src/data/proofs/de-moivre/meta.json
@@ -167,5 +167,10 @@
       "Prove the connection to Chebyshev polynomials: T_n(cos θ) = cos(nθ) via De Moivre",
       "Extend to fractional exponents and the multi-valued nature of z^{p/q} for complex z"
     ]
-  }
+  },
+  "relatedProofs": [
+    "euler-identity",
+    "law-of-cosines",
+    "angle-trisection"
+  ]
 }

--- a/src/data/proofs/denumerability-rationals-oq-03/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-03/meta.json
@@ -167,5 +167,8 @@
     "axiomCount": 0,
     "theoremCount": 22,
     "definitionCount": 7
-  }
+  },
+  "relatedProofs": [
+    "denumerability-rationals"
+  ]
 }

--- a/src/data/proofs/denumerability-rationals/meta.json
+++ b/src/data/proofs/denumerability-rationals/meta.json
@@ -213,5 +213,12 @@
       "Can the Cantor pairing function be replaced by a more efficient encoding (e.g., the Stern-Brocot tree) while maintaining the same formal properties in Lean's type system?",
       "Is there a constructive proof of the denumerability of the algebraic numbers $\\overline{\\mathbb{Q}}$ that avoids the axiom of choice, and can it be formalized using Lean's `Denumerable` typeclass?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "cantor-diagonalization",
+    "cantors-theorem",
+    "schroeder-bernstein",
+    "continuum-hypothesis",
+    "sqrt2-irrational"
+  ]
 }

--- a/src/data/proofs/derangements/meta.json
+++ b/src/data/proofs/derangements/meta.json
@@ -189,5 +189,10 @@
       "id": "birthday-problem",
       "relationship": "Both are classic combinatorial probability problems. The birthday problem counts collisions in random mappings, while derangements count fixed-point-free permutations. Both exhibit surprising threshold behavior."
     }
+  ],
+  "relatedProofs": [
+    "inclusion-exclusion",
+    "euler-totient",
+    "fundamental-arithmetic"
   ]
 }

--- a/src/data/proofs/dirichlets-theorem/meta.json
+++ b/src/data/proofs/dirichlets-theorem/meta.json
@@ -135,5 +135,11 @@
       "Generalized Riemann Hypothesis for Dirichlet L-functions: All non-trivial zeros have real part 1/2.",
       "Effective bounds: What is the best constant in Linnik's theorem? Conjecturally L = 2."
     ]
-  }
+  },
+  "relatedProofs": [
+    "sophie-germain",
+    "infinitude-primes",
+    "fermats-last-theorem",
+    "chinese-remainder-non-coprime"
+  ]
 }

--- a/src/data/proofs/divisibility-truncation-general-oq-01/meta.json
+++ b/src/data/proofs/divisibility-truncation-general-oq-01/meta.json
@@ -126,5 +126,8 @@
       "What is the relationship between the osculator and the continued fraction expansion of 1/d?",
       "Can multi-digit truncation (removing k digits at a time) be unified similarly?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "divisibility-truncation-general"
+  ]
 }

--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -130,5 +130,9 @@
       "Is e a normal number?",
       "What is the exact irrationality measure of e?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "pi-transcendental",
+    "leibniz-pi"
+  ]
 }

--- a/src/data/proofs/erdos-100/meta.json
+++ b/src/data/proofs/erdos-100/meta.json
@@ -145,5 +145,11 @@
       "relationship": "related",
       "description": "Erdős #1007 (graph dimension and unit distance embedding) connects to the geometric embedding questions underlying restricted distance sets."
     }
+  ],
+  "relatedProofs": [
+    "erdos-89",
+    "erdos-104",
+    "erdos-1066",
+    "erdos-1007"
   ]
 }

--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -139,5 +139,11 @@
       "relationship": "related",
       "description": "Erdős #1002 (weighted fractional sums) studies Diophantine approximation distribution functions, sharing the analytic framework of Cassels' work."
     }
+  ],
+  "relatedProofs": [
+    "erdos-1001",
+    "erdos-1003",
+    "erdos-1004",
+    "erdos-1002"
   ]
 }

--- a/src/data/proofs/erdos-1001/meta.json
+++ b/src/data/proofs/erdos-1001/meta.json
@@ -179,5 +179,12 @@
       "relationship": "related",
       "description": "Hurwitz's theorem gives the optimal constant 1/√5 for Diophantine approximation quality, providing context for the approximability threshold A/y² used here"
     }
+  ],
+  "relatedProofs": [
+    "prime-reciprocal-divergence",
+    "infinitude-primes",
+    "lebesgue-measure",
+    "basel-problem",
+    "hurwitz-theorem"
   ]
 }

--- a/src/data/proofs/erdos-1008/meta.json
+++ b/src/data/proofs/erdos-1008/meta.json
@@ -114,5 +114,10 @@
       "relationship": "related",
       "description": "Erdős #1006 (robust acyclic orientations) uses the probabilistic method in graph theory, sharing the dependent random choice technique."
     }
+  ],
+  "relatedProofs": [
+    "erdos-1009",
+    "erdos-613",
+    "erdos-1006"
   ]
 }

--- a/src/data/proofs/erdos-1014/meta.json
+++ b/src/data/proofs/erdos-1014/meta.json
@@ -124,5 +124,9 @@
       "Can the Mattheus-Verstraëte (2024) improved R(3,l) lower bound help establish ratio convergence?",
       "Is there a probabilistic or algebraic approach that gives ratio convergence without full asymptotics?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-1030",
+    "erdos-544"
+  ]
 }

--- a/src/data/proofs/erdos-1020/meta.json
+++ b/src/data/proofs/erdos-1020/meta.json
@@ -151,5 +151,10 @@
       "relationship": "related",
       "description": "Erdős #530 (maximum Sidon subsets) studies analogous extremal problems in additive combinatorics, where the probabilistic deletion method parallels the matching conjecture approach."
     }
+  ],
+  "relatedProofs": [
+    "erdos-1021",
+    "erdos-1008",
+    "erdos-530"
   ]
 }

--- a/src/data/proofs/erdos-1036/meta.json
+++ b/src/data/proofs/erdos-1036/meta.json
@@ -180,5 +180,10 @@
       "relationship": "related",
       "description": "Erdős #88 studies Ramsey-theoretic questions about graph colorings, connecting to the non-Ramsey graph framework underlying Problem 1036."
     }
+  ],
+  "relatedProofs": [
+    "erdos-1031",
+    "erdos-szekeres",
+    "erdos-88"
   ]
 }

--- a/src/data/proofs/erdos-1037/meta.json
+++ b/src/data/proofs/erdos-1037/meta.json
@@ -145,5 +145,9 @@
       "relationship": "related",
       "description": "Erdős #1031 (induced regular subgraphs in non-Ramsey graphs) studies universality properties of non-Ramsey graphs. Problem 1037 shows that degree diversity, unlike Ramsey deficiency, does not force structural complexity."
     }
+  ],
+  "relatedProofs": [
+    "erdos-1036",
+    "erdos-1031"
   ]
 }

--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -152,5 +152,9 @@
       "relationship": "related",
       "description": "Erdős #1040 (transfinite diameter and sublevel set measure) connects to Problem 1039 through potential theory: the transfinite diameter controls the Green's function, which in turn bounds both the sublevel set measure and the inscribed disc radius."
     }
+  ],
+  "relatedProofs": [
+    "erdos-1038",
+    "erdos-1040"
   ]
 }

--- a/src/data/proofs/erdos-104/meta.json
+++ b/src/data/proofs/erdos-104/meta.json
@@ -117,5 +117,9 @@
       "relationship": "related",
       "description": "Erdős #105 (lines avoiding a point set) studies related point-line incidence questions in discrete geometry, complementing the point-circle incidence focus of Problem 104."
     }
+  ],
+  "relatedProofs": [
+    "erdos-102",
+    "erdos-105"
   ]
 }

--- a/src/data/proofs/erdos-1048/meta.json
+++ b/src/data/proofs/erdos-1048/meta.json
@@ -210,5 +210,14 @@
       "relationship": "related",
       "description": "Erdős #1040 asks whether the measure of L(f,1) is determined by the transfinite diameter of the root set — connecting to the same potential-theoretic framework (logarithmic capacity, transfinite diameter) that underlies #1048's diameter bounds."
     }
+  ],
+  "relatedProofs": [
+    "erdos-1047",
+    "erdos-1046",
+    "erdos-1042",
+    "erdos-1039",
+    "erdos-1041",
+    "erdos-1038",
+    "erdos-1040"
   ]
 }

--- a/src/data/proofs/erdos-1050/meta.json
+++ b/src/data/proofs/erdos-1050/meta.json
@@ -192,5 +192,10 @@
       "relationship": "related",
       "description": "Problem #257 asks whether ∑_{n∈A} 1/(2^n - 1) is irrational for every infinite set A of positive integers. This is a 'subset selection' variant of the Lambert series that Erdős proved irrational in 1948 (the case A = ℕ), which is T(2, -1) in our framework."
     }
+  ],
+  "relatedProofs": [
+    "erdos-1049",
+    "erdos-1051",
+    "erdos-257"
   ]
 }

--- a/src/data/proofs/erdos-1052/meta.json
+++ b/src/data/proofs/erdos-1052/meta.json
@@ -167,5 +167,10 @@
       "What constraints exist on the prime factorization of unitary perfect numbers?",
       "Are there infinitely many odd abundant numbers (σ*(n) > 2n) that are squarefree?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-544",
+    "erdos-987",
+    "euclid-euler"
+  ]
 }

--- a/src/data/proofs/erdos-1058/meta.json
+++ b/src/data/proofs/erdos-1058/meta.json
@@ -116,5 +116,8 @@
       "What about n!+1 being a prime power (Brocard's problem)?",
       "Can the techniques extend to other factorial-based expressions?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "wilsons-theorem"
+  ]
 }

--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -143,5 +143,8 @@
       "Are there infinitely many n with f(n) = 1?",
       "What is the maximum of f(n) for n ≤ N?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-1058"
+  ]
 }

--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -174,5 +174,8 @@
       "What is g_4(3)? No exact values are known beyond d = 3.",
       "Is the ratio g_d(n)/d^{n-1} monotone in d, which would imply convergence?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-1083"
+  ]
 }

--- a/src/data/proofs/erdos-1090/meta.json
+++ b/src/data/proofs/erdos-1090/meta.json
@@ -201,5 +201,10 @@
       "Explore the higher-dimensional analogue with hyperplanes",
       "Study the problem with additional geometric constraints (convexity, lattice points)"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-618",
+    "hales-jewett",
+    "erdos-22"
+  ]
 }

--- a/src/data/proofs/erdos-1094/meta.json
+++ b/src/data/proofs/erdos-1094/meta.json
@@ -146,5 +146,13 @@
       "relationship": "foundation",
       "description": "The combinatorial formula C(n,k) = n!/(k!(n-k)!) underlies all prime factor analysis of binomial coefficients"
     }
+  ],
+  "relatedProofs": [
+    "erdos-384",
+    "erdos-1093",
+    "erdos-1095",
+    "kummer-theorem",
+    "bertrands-postulate",
+    "combinations-formula"
   ]
 }

--- a/src/data/proofs/erdos-1098/meta.json
+++ b/src/data/proofs/erdos-1098/meta.json
@@ -179,5 +179,9 @@
       "Extensions to other algebraic structures (rings, semigroups)",
       "Tight bounds for specific group families (nilpotent, solvable)"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-22",
+    "erdos-134"
+  ]
 }

--- a/src/data/proofs/erdos-1103/meta.json
+++ b/src/data/proofs/erdos-1103/meta.json
@@ -165,5 +165,10 @@
       "What is the exact growth threshold — is there a sharp transition between possible and impossible growth rates?",
       "Does the exponent 11/15 in Konyagin's finite bound have a natural interpretation in terms of the Chinese Remainder Theorem structure of squarefree residues?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "infinitude-primes",
+    "bertrands-postulate",
+    "prime-number-theorem"
+  ]
 }

--- a/src/data/proofs/erdos-1104/meta.json
+++ b/src/data/proofs/erdos-1104/meta.json
@@ -128,5 +128,12 @@
       "relationship": "related",
       "description": "Problem 1015 on partitioning 2-colored complete graphs uses Ramsey number R(t, t-1), connecting to R(3,k) in this problem"
     }
+  ],
+  "relatedProofs": [
+    "ramseys-theorem",
+    "erdos-58",
+    "four-color-theorem",
+    "erdos-1105",
+    "erdos-1015"
   ]
 }

--- a/src/data/proofs/erdos-1122/meta.json
+++ b/src/data/proofs/erdos-1122/meta.json
@@ -183,5 +183,9 @@
       "Is the bounded prime values condition in Mangerel's theorem necessary?",
       "What is the relationship between this problem and Erdős #491 on short intervals?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-491",
+    "erdos-1052"
+  ]
 }

--- a/src/data/proofs/erdos-1126/meta.json
+++ b/src/data/proofs/erdos-1126/meta.json
@@ -146,5 +146,9 @@
       "Can the theorem be quantified: if $f(x+y) = f(x) + f(y)$ fails on a set of measure $\\varepsilon$, how large can the set $\\{x : f(x) \\neq g(x)\\}$ be?",
       "What is the analogue for functions on $\\mathbb{R}^n$ or on locally compact abelian groups?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-1166",
+    "erdos-994"
+  ]
 }

--- a/src/data/proofs/erdos-1130/meta.json
+++ b/src/data/proofs/erdos-1130/meta.json
@@ -161,5 +161,9 @@
       "Are there analogues of the Υ functional for multivariate polynomial interpolation on higher-dimensional domains?",
       "Can the equioscillation characterization be extended to weighted Lebesgue functions Λ_w(x) = Σ w(x_k)|l_k(x)|?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "taylor-theorem",
+    "fourier-series"
+  ]
 }

--- a/src/data/proofs/erdos-1136/meta.json
+++ b/src/data/proofs/erdos-1136/meta.json
@@ -170,5 +170,11 @@
       "Is Müller's set essentially the unique optimal construction, or do other sets also achieve density $1/2$ while avoiding power-of-two sums?",
       "What happens if lower density is replaced by upper density $\\overline{d}(A) = \\limsup |A \\cap [0,N)|/N$? Is the optimal bound still $1/2$?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-984",
+    "erdos-107",
+    "erdos-527",
+    "partition-theorem"
+  ]
 }

--- a/src/data/proofs/erdos-1138/meta.json
+++ b/src/data/proofs/erdos-1138/meta.json
@@ -162,5 +162,12 @@
       "relationship": "foundational",
       "description": "The infinitude of primes is the most basic prerequisite; Erdős #1138 asks about the fine quantitative distribution of these infinitely many primes"
     }
+  ],
+  "relatedProofs": [
+    "bertrands-postulate",
+    "prime-number-theorem",
+    "riemann-hypothesis",
+    "prime-reciprocal-divergence",
+    "infinitude-primes"
   ]
 }

--- a/src/data/proofs/erdos-1142/meta.json
+++ b/src/data/proofs/erdos-1142/meta.json
@@ -150,5 +150,8 @@
       "relationship": "strengthens",
       "description": "Problem #236 asks whether the count of prime n − 2^k is o(log n), which is the stronger conjecture formalized here"
     }
+  ],
+  "relatedProofs": [
+    "erdos-236"
   ]
 }

--- a/src/data/proofs/erdos-1148/meta.json
+++ b/src/data/proofs/erdos-1148/meta.json
@@ -186,5 +186,10 @@
       "relationship": "technique",
       "description": "The Fermat–Euler theorem on sums of two squares is the key theoretical tool for the structural equivalence proved in this formalization"
     }
+  ],
+  "relatedProofs": [
+    "erdos-1094",
+    "pythagorean-triples",
+    "sum-of-squares"
   ]
 }

--- a/src/data/proofs/erdos-1157/meta.json
+++ b/src/data/proofs/erdos-1157/meta.json
@@ -146,5 +146,13 @@
       "relationship": "related",
       "description": "Problem #1078 (minimum degree for K_r in r-partite graphs) studies BES-type thresholds in the multipartite setting, solved by Haxell (2001)"
     }
+  ],
+  "relatedProofs": [
+    "erdos-716",
+    "erdos-1076",
+    "erdos-714",
+    "erdos-1075",
+    "erdos-1155",
+    "erdos-1078"
   ]
 }

--- a/src/data/proofs/erdos-1159/meta.json
+++ b/src/data/proofs/erdos-1159/meta.json
@@ -119,5 +119,10 @@
       "relationship": "foundation",
       "description": "The Fano plane (order 2, the smallest projective plane) is a trivial case where C = 3 suffices"
     }
+  ],
+  "relatedProofs": [
+    "erdos-664",
+    "erdos-1104",
+    "fano-plane"
   ]
 }

--- a/src/data/proofs/erdos-1173/meta.json
+++ b/src/data/proofs/erdos-1173/meta.json
@@ -140,5 +140,9 @@
       "relationship": "related",
       "description": "Erdős Problem #112 concerns directed Ramsey theory, which shares the combinatorial theme of finding large structured subsets under constraints"
     }
+  ],
+  "relatedProofs": [
+    "erdos-1094",
+    "erdos-112"
   ]
 }

--- a/src/data/proofs/erdos-1175/meta.json
+++ b/src/data/proofs/erdos-1175/meta.json
@@ -128,5 +128,12 @@
       "relationship": "context",
       "description": "The Four Color Theorem provides foundational context: χ(G) ≤ 4 for planar graphs is a universal finite bound, contrasting with #1175 where uncountable chromatic numbers resist such structural control"
     }
+  ],
+  "relatedProofs": [
+    "erdos-1068",
+    "erdos-1013",
+    "erdos-1067",
+    "erdos-1092",
+    "four-color-theorem"
   ]
 }

--- a/src/data/proofs/erdos-1177/meta.json
+++ b/src/data/proofs/erdos-1177/meta.json
@@ -116,5 +116,10 @@
       "Does nonemptiness of F_G transfer between all uncountable cardinals?",
       "Are these conjectures provable in ZFC or do they depend on set-theoretic axioms?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-1176",
+    "erdos-1171",
+    "erdos-1104"
+  ]
 }

--- a/src/data/proofs/erdos-1179/meta.json
+++ b/src/data/proofs/erdos-1179/meta.json
@@ -169,5 +169,8 @@
       "What is the optimal dependence on ε? How does g_ε(N) behave as ε → 0?",
       "Can the probabilistic argument be derandomized to give an explicit construction of ε-uniform sets of size (1+o(1)) log₂ N?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-543"
+  ]
 }

--- a/src/data/proofs/erdos-134/meta.json
+++ b/src/data/proofs/erdos-134/meta.json
@@ -187,5 +187,12 @@
       "Extensions to K_r-free graphs for r > 3 — does the critical exponent change with the forbidden clique size?",
       "For the counterexample at degree C√n, what is the exact constant C where the transition occurs?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-618",
+    "erdos-133",
+    "erdos-612",
+    "erdos-742",
+    "erdos-22"
+  ]
 }

--- a/src/data/proofs/erdos-140/meta.json
+++ b/src/data/proofs/erdos-140/meta.json
@@ -149,5 +149,10 @@
       "Is r₃(N) = Θ(N/exp(c√log N)) matching Behrend?",
       "Can Kelley-Meka techniques improve k ≥ 4 bounds?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-16",
+    "szemeredi-theorem",
+    "ramseys-theorem"
+  ]
 }

--- a/src/data/proofs/erdos-16/meta.json
+++ b/src/data/proofs/erdos-16/meta.json
@@ -176,5 +176,11 @@
       "relationship": "uses",
       "description": "Density bounds on the exceptional set use the prime number theorem and sieve estimates"
     }
+  ],
+  "relatedProofs": [
+    "erdos-17",
+    "erdos-205",
+    "infinitude-primes",
+    "prime-number-theorem"
   ]
 }

--- a/src/data/proofs/erdos-163/meta.json
+++ b/src/data/proofs/erdos-163/meta.json
@@ -172,5 +172,12 @@
       "relationship": "related",
       "description": "The Erdős-Hajnal Conjecture also connects graph structure (being $H$-free) to Ramsey-type coloring properties, complementing the degeneracy-based approach"
     }
+  ],
+  "relatedProofs": [
+    "ramseys-theorem",
+    "szemeredi-theorem",
+    "four-color-theorem",
+    "erdos-569",
+    "erdos-61"
   ]
 }

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -115,5 +115,9 @@
       "relationship": "related",
       "description": "Both are graph coloring/structure problems from Erdős. #136 concerns the Erdős-Gyárfás function f(n,4,5) relating graph size to clique/independence structure, #167 concerns triangle substructure"
     }
+  ],
+  "relatedProofs": [
+    "erdos-140",
+    "erdos-136"
   ]
 }

--- a/src/data/proofs/erdos-17/meta.json
+++ b/src/data/proofs/erdos-17/meta.json
@@ -193,5 +193,14 @@
       "relationship": "related",
       "description": "Bertrand's postulate guarantees a prime in $(n, 2n)$, bounding prime gaps from above. Small prime gaps help the cluster property, but Bertrand's gap bound of $n$ is too weak — cluster primes need gaps on the order of $\\log p$"
     }
+  ],
+  "relatedProofs": [
+    "bounded-prime-gaps",
+    "erdos-16",
+    "twin-primes-special",
+    "infinitude-primes",
+    "dirichlets-theorem",
+    "prime-number-theorem",
+    "bertrands-postulate"
   ]
 }

--- a/src/data/proofs/erdos-185/meta.json
+++ b/src/data/proofs/erdos-185/meta.json
@@ -168,5 +168,9 @@
       "Is there an explicit construction of cap sets of size $c^n$ for any $c > 2.217$?",
       "Does the density Hales-Jewett theorem have a purely combinatorial proof (avoiding ergodic theory)?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-140",
+    "erdos-180"
+  ]
 }

--- a/src/data/proofs/erdos-204/meta.json
+++ b/src/data/proofs/erdos-204/meta.json
@@ -165,5 +165,8 @@
       "Can Adenwalla's argument be extended to weighted covering systems or multi-dimensional analogues?",
       "What is the connection between the MaxCoverableDensity function and the arithmetic structure of n's divisor lattice?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-543"
+  ]
 }

--- a/src/data/proofs/erdos-205/meta.json
+++ b/src/data/proofs/erdos-205/meta.json
@@ -223,5 +223,14 @@
       "relationship": "related",
       "description": "The Erdős-Kac theorem (axiomatized here) is a number-theoretic analogue of the CLT: Ω(n) is asymptotically Gaussian, paralleling the classical CLT for independent random variables"
     }
+  ],
+  "relatedProofs": [
+    "erdos-16",
+    "prime-number-theorem",
+    "infinitude-primes",
+    "erdos-203",
+    "erdos-9",
+    "chinese-remainder-constructive",
+    "central-limit-theorem"
   ]
 }

--- a/src/data/proofs/erdos-222/meta.json
+++ b/src/data/proofs/erdos-222/meta.json
@@ -156,5 +156,11 @@
       "relationship": "foundational",
       "description": "Dirichlet's theorem on primes in arithmetic progressions (specifically $p \\equiv 1, 3 \\pmod{4}$) underlies both Fermat's criterion and the density computation"
     }
+  ],
+  "relatedProofs": [
+    "prime-number-theorem",
+    "prime-reciprocal-divergence",
+    "infinitude-primes",
+    "dirichlets-theorem"
   ]
 }

--- a/src/data/proofs/erdos-226/meta.json
+++ b/src/data/proofs/erdos-226/meta.json
@@ -189,5 +189,9 @@
       "relationship": "related",
       "description": "Both involve the boundary between algebraic and transcendental: Abel-Ruffini shows polynomial roots can be non-algebraic in radicals, while Problem 226 shows only transcendental functions can biject rationals"
     }
+  ],
+  "relatedProofs": [
+    "dirichlets-theorem",
+    "abel-ruffini"
   ]
 }

--- a/src/data/proofs/erdos-234/meta.json
+++ b/src/data/proofs/erdos-234/meta.json
@@ -125,5 +125,10 @@
       "Can Gallagher's conditional result be strengthened to require weaker assumptions than full RH (e.g., density hypothesis or quasi-RH)?",
       "What is the rate of convergence: how fast does $\\text{gapProportion}(N, c)$ approach $f(c)$, and does this depend on $c$?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "prime-number-theorem",
+    "bertrands-postulate",
+    "twin-primes-special"
+  ]
 }

--- a/src/data/proofs/erdos-238/meta.json
+++ b/src/data/proofs/erdos-238/meta.json
@@ -162,5 +162,10 @@
       "key": "BHP2001",
       "citation": "R. C. Baker, G. Harman, J. Pintz, 'The difference between consecutive primes, II', Proc. London Math. Soc. 83 (2001), 532-562"
     }
+  ],
+  "relatedProofs": [
+    "erdos-218",
+    "bounded-prime-gaps",
+    "erdos-219"
   ]
 }

--- a/src/data/proofs/erdos-240/meta.json
+++ b/src/data/proofs/erdos-240/meta.json
@@ -224,5 +224,12 @@
       "relationship": "related",
       "description": "Bertrand's postulate guarantees primes in [n, 2n], relevant to understanding prime density and the 'sparseness' condition Tijdeman requires"
     }
+  ],
+  "relatedProofs": [
+    "infinitude-primes",
+    "prime-number-theorem",
+    "erdos-205",
+    "erdos-4",
+    "bertrands-postulate"
   ]
 }

--- a/src/data/proofs/erdos-241/meta.json
+++ b/src/data/proofs/erdos-241/meta.json
@@ -110,5 +110,10 @@
       "relationship": "related",
       "description": "Problem #840 studies quasi-Sidon sets (relaxed B₂ condition). The B₃ problem similarly asks about the extremal size under additive uniqueness constraints, but for triples instead of pairs."
     }
+  ],
+  "relatedProofs": [
+    "erdos-30",
+    "erdos-153",
+    "erdos-840"
   ]
 }

--- a/src/data/proofs/erdos-249/meta.json
+++ b/src/data/proofs/erdos-249/meta.json
@@ -179,5 +179,10 @@
       "relationship": "related",
       "description": "Both concern exact values of infinite series with number-theoretic significance (∑ 1/n² = π²/6 vs ∑ φ(n)/2^n ≈ 1.324)"
     }
+  ],
+  "relatedProofs": [
+    "infinitude-primes",
+    "erdos-23",
+    "basel-problem"
   ]
 }

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -94,5 +94,8 @@
       "relationship": "specialization",
       "description": "Problem #486 is the general version: does logarithmic density exist for a broader class of sieve constructions? Problem #25 is a special case with congruence exclusions."
     }
+  ],
+  "relatedProofs": [
+    "erdos-486"
   ]
 }

--- a/src/data/proofs/erdos-252/meta.json
+++ b/src/data/proofs/erdos-252/meta.json
@@ -196,5 +196,12 @@
       "Is there a uniform proof for all $k$ that avoids reliance on Schinzel's Hypothesis H or the prime $k$-tuples conjecture?",
       "Can the formalization be extended to prove $\\sigma_k(p) = 1 + p^k$ and the convergence bound $\\sigma_k(n) \\leq n^{k+1}$ directly in Lean, rather than axiomatizing them?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-250",
+    "erdos-251",
+    "perfect-numbers",
+    "sqrt2-irrational",
+    "pi-transcendental"
+  ]
 }

--- a/src/data/proofs/erdos-256/meta.json
+++ b/src/data/proofs/erdos-256/meta.json
@@ -203,5 +203,9 @@
       "relationship": "related",
       "description": "Both involve evaluating or bounding special functions on the complex plane; Basel problem concerns ζ(2) while #256 concerns products on |z|=1"
     }
+  ],
+  "relatedProofs": [
+    "erdos-150",
+    "basel-problem"
   ]
 }

--- a/src/data/proofs/erdos-267/meta.json
+++ b/src/data/proofs/erdos-267/meta.json
@@ -191,5 +191,10 @@
       "relationship": "related",
       "description": "Another Erdős irrationality problem: #259 concerns Σ μ(n)²n/2^n. Both probe when 'natural' arithmetic series produce irrational sums"
     }
+  ],
+  "relatedProofs": [
+    "erdos-249",
+    "erdos-250",
+    "erdos-259"
   ]
 }

--- a/src/data/proofs/erdos-288/meta.json
+++ b/src/data/proofs/erdos-288/meta.json
@@ -161,5 +161,11 @@
       "relationship": "uses",
       "description": "The divergence of the harmonic series is foundational context: harmonic partial sums H(1,n) grow without bound, making the finiteness question for integer values nontrivial"
     }
+  ],
+  "relatedProofs": [
+    "erdos-285",
+    "erdos-286",
+    "erdos-289",
+    "harmonic-divergence"
   ]
 }

--- a/src/data/proofs/erdos-289/meta.json
+++ b/src/data/proofs/erdos-289/meta.json
@@ -97,5 +97,10 @@
       "What is the minimum max(hᵢ) needed as a function of k? The spreading lemma gives Ω(k) but the true growth rate is unknown.",
       "Is there an efficient algorithm for constructing valid decompositions, or is the problem computationally hard?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "harmonic-divergence",
+    "geometric-series",
+    "bertrands-postulate"
+  ]
 }

--- a/src/data/proofs/erdos-302/meta.json
+++ b/src/data/proofs/erdos-302/meta.json
@@ -224,5 +224,11 @@
       "relationship": "related",
       "description": "The coloring version of #302: can {1,...,N} be 2-colored with no monochromatic solution to 1/a = 1/b + 1/c? Solved by Brown-Rödl (1991)"
     }
+  ],
+  "relatedProofs": [
+    "erdos-23",
+    "erdos-285",
+    "erdos-288",
+    "erdos-303"
   ]
 }

--- a/src/data/proofs/erdos-315/meta.json
+++ b/src/data/proofs/erdos-315/meta.json
@@ -205,5 +205,10 @@
       "relationship": "related",
       "description": "Both concern Egyptian fraction structure: #285 studies asymptotics of Egyptian fraction representations, #315 characterizes the optimal growth rate among all Egyptian sequences for 1"
     }
+  ],
+  "relatedProofs": [
+    "erdos-288",
+    "erdos-267",
+    "erdos-285"
   ]
 }

--- a/src/data/proofs/erdos-333/meta.json
+++ b/src/data/proofs/erdos-333/meta.json
@@ -176,5 +176,9 @@
       "relationship": "related",
       "description": "Directly related: #806 asks about small bases for sumsets (B+B covering). Both explore the minimum size of B needed so that A ⊆ B+B"
     }
+  ],
+  "relatedProofs": [
+    "erdos-302",
+    "erdos-806"
   ]
 }

--- a/src/data/proofs/erdos-334/meta.json
+++ b/src/data/proofs/erdos-334/meta.json
@@ -172,5 +172,10 @@
       "relationship": "related",
       "description": "Both concern additive representations of integers: #333 asks about sumset covering A ⊆ B+B, #334 asks about representing n = a + b with smooth summands"
     }
+  ],
+  "relatedProofs": [
+    "prime-number-theorem",
+    "infinitude-primes",
+    "erdos-333"
   ]
 }

--- a/src/data/proofs/erdos-340/meta.json
+++ b/src/data/proofs/erdos-340/meta.json
@@ -86,5 +86,9 @@
       "relationship": "related",
       "description": "Problem #156 concerns the slow growth of maximal Sidon subsets. Both problems study how construction methods affect Sidon set density."
     }
+  ],
+  "relatedProofs": [
+    "erdos-30",
+    "erdos-156"
   ]
 }

--- a/src/data/proofs/erdos-341/meta.json
+++ b/src/data/proofs/erdos-341/meta.json
@@ -81,5 +81,8 @@
       "relationship": "specialization",
       "description": "Problem #340 concerns the greedy Sidon (Mian-Chowla) sequence, which is the Dickson extension starting from {1}. Problem #341 generalizes to arbitrary starting sets."
     }
+  ],
+  "relatedProofs": [
+    "erdos-340"
   ]
 }

--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -167,5 +167,10 @@
       "relationship": "complement",
       "description": "Erdős #30 on Sidon sets (B₂ sequences with unique pairwise sums) represents the opposite extreme — maximizing distinctness of differences"
     }
+  ],
+  "relatedProofs": [
+    "erdos-335",
+    "erdos-66",
+    "erdos-30"
   ]
 }

--- a/src/data/proofs/erdos-367/meta.json
+++ b/src/data/proofs/erdos-367/meta.json
@@ -31,15 +31,15 @@
     "references": [
       {
         "key": "ErGr80",
-        "citation": "P. Erd\u0151s and R. L. Graham, Old and New Problems and Results in Combinatorial Number Theory, Monographies de L'Enseignement Math\u00e9matique 28, Geneva, 1980."
+        "citation": "P. Erdős and R. L. Graham, Old and New Problems and Results in Combinatorial Number Theory, Monographies de L'Enseignement Mathématique 28, Geneva, 1980."
       },
       {
         "key": "vD23",
-        "citation": "W. van Doorn, On products of squareful parts, 2023. Disproved the strong bound for k \u2265 3."
+        "citation": "W. van Doorn, On products of squareful parts, 2023. Disproved the strong bound for k ≥ 3."
       },
       {
         "key": "Gol69",
-        "citation": "S. W. Golomb, Powerful numbers, Amer. Math. Monthly 77 (1970), 848\u2013855."
+        "citation": "S. W. Golomb, Powerful numbers, Amer. Math. Monthly 77 (1970), 848–855."
       }
     ]
   },
@@ -169,5 +169,10 @@
       "relationship": "related",
       "description": "Both study prime factor structure of consecutive integers: #368 asks about the largest prime factor of n(n+1), while #367 concerns the 2-full part"
     }
+  ],
+  "relatedProofs": [
+    "erdos-366",
+    "erdos-369",
+    "erdos-368"
   ]
 }

--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -138,5 +138,9 @@
       "Is the problem easier for k = 2 with a specific ε (e.g., ε = 1/2, requiring √n-smoothness)?",
       "Can the Dickman function heuristic be made rigorous via moment methods or the circle method adapted to smooth numbers?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-370",
+    "erdos-143"
+  ]
 }

--- a/src/data/proofs/erdos-370/meta.json
+++ b/src/data/proofs/erdos-370/meta.json
@@ -188,5 +188,11 @@
       "Can the main infinitude theorem be proved in Lean by showing infinitely many $m = 2^k$ yield $\\operatorname{gpf}((2^k-1)(2^k+1)) < 2^k$?",
       "What is the exact critical exponent below which the Erdős-Graham problem requires constructive rather than density-based proofs?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-1136",
+    "erdos-984",
+    "erdos-527",
+    "prime-reciprocal-divergence"
+  ]
 }

--- a/src/data/proofs/erdos-383/meta.json
+++ b/src/data/proofs/erdos-383/meta.json
@@ -180,5 +180,10 @@
       "relationship": "related",
       "description": "Both concern the largest prime factor of products of consecutive integers: #368 studies P(n(n+1)), #383 studies P(∏(p²+i))"
     }
+  ],
+  "relatedProofs": [
+    "erdos-382",
+    "erdos-334",
+    "erdos-368"
   ]
 }

--- a/src/data/proofs/erdos-384/meta.json
+++ b/src/data/proofs/erdos-384/meta.json
@@ -165,5 +165,9 @@
       "relationship": "related",
       "description": "Both concern largest prime divisors of number-theoretic products: #383 studies P(∏(p²+i)), #384 studies small primes dividing C(n,k)"
     }
+  ],
+  "relatedProofs": [
+    "erdos-382",
+    "erdos-383"
   ]
 }

--- a/src/data/proofs/erdos-386/meta.json
+++ b/src/data/proofs/erdos-386/meta.json
@@ -102,5 +102,8 @@
       "relationship": "related",
       "description": "Problem #384 concerns prime divisors of C(n,k) exceeding n/2 (Sylvester–Schur theorem). Both problems study the prime factorization structure of binomial coefficients."
     }
+  ],
+  "relatedProofs": [
+    "erdos-384"
   ]
 }

--- a/src/data/proofs/erdos-4/meta.json
+++ b/src/data/proofs/erdos-4/meta.json
@@ -251,5 +251,11 @@
       "relationship": "uses",
       "description": "The Prime Number Theorem gives the average gap log n and the asymptotic p_n ~ n log n used in average_gap_asymptotic"
     }
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-369",
+    "bertrands-postulate",
+    "prime-number-theorem"
   ]
 }

--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -166,5 +166,9 @@
       "relationship": "related",
       "description": "Both involve prime divisibility of factorial/binomial quantities: #384 studies prime divisors of C(n,k), #404 studies p-adic valuation of Σ a_i!"
     }
+  ],
+  "relatedProofs": [
+    "erdos-382",
+    "erdos-384"
   ]
 }

--- a/src/data/proofs/erdos-406/meta.json
+++ b/src/data/proofs/erdos-406/meta.json
@@ -166,5 +166,12 @@
       "What is the distribution of the ternary digit 2 in $2^n$ as $n \\to \\infty$? Is it equidistributed with frequency $1/3$?",
       "Does the analogous problem for other base pairs (e.g., powers of 2 with only digits $\\{0,1\\}$ in base 5) have finitely many solutions?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-407",
+    "erdos-9",
+    "erdos-10",
+    "erdos-125",
+    "erdos-851"
+  ]
 }

--- a/src/data/proofs/erdos-411/meta.json
+++ b/src/data/proofs/erdos-411/meta.json
@@ -175,5 +175,12 @@
       "relationship": "uses",
       "description": "The foundational theorem $a^{\\varphi(n)} \\equiv 1 \\pmod{n}$ underlies the properties of $\\varphi$ used throughout #411"
     }
+  ],
+  "relatedProofs": [
+    "erdos-410",
+    "erdos-412",
+    "erdos-413",
+    "erdos-414",
+    "euler-totient"
   ]
 }

--- a/src/data/proofs/erdos-416/meta.json
+++ b/src/data/proofs/erdos-416/meta.json
@@ -94,5 +94,9 @@
       "What is the exact value of the leading constant in the Maier–Pomerance formula?",
       "Does the analogous counting function for the sum-of-divisors function $\\sigma$ have similar asymptotic behavior?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-419",
+    "erdos-462"
+  ]
 }

--- a/src/data/proofs/erdos-417/meta.json
+++ b/src/data/proofs/erdos-417/meta.json
@@ -152,5 +152,10 @@
       "relationship": "thematic",
       "description": "Parallel Erdős problem on growth rates of multiplicative arithmetic functions (iterated sum of divisors)"
     }
+  ],
+  "relatedProofs": [
+    "erdos-416",
+    "euler-totient",
+    "erdos-410"
   ]
 }

--- a/src/data/proofs/erdos-419/meta.json
+++ b/src/data/proofs/erdos-419/meta.json
@@ -273,5 +273,15 @@
       "What is the distribution of ratios among the possible limit points?",
       "How quickly does the ratio approach each limit point along the relevant subsequences?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-415",
+    "erdos-414",
+    "kummer-theorem",
+    "erdos-728-factorial-divisibility",
+    "stirling-formula",
+    "erdos-400",
+    "dirichlets-theorem",
+    "prime-number-theorem"
+  ]
 }

--- a/src/data/proofs/erdos-423/meta.json
+++ b/src/data/proofs/erdos-423/meta.json
@@ -117,5 +117,8 @@
       "relationship": "related",
       "description": "Both concern greedy/constructive integer sequences: #342 studies the Ulam sequence, #423 studies a sequence built from sums of consecutive terms"
     }
+  ],
+  "relatedProofs": [
+    "erdos-342"
   ]
 }

--- a/src/data/proofs/erdos-425/meta.json
+++ b/src/data/proofs/erdos-425/meta.json
@@ -155,5 +155,10 @@
       "relationship": "thematic",
       "description": "Distinct polynomial pair sums; maximal sumset property parallels the multiplicative Sidon condition"
     }
+  ],
+  "relatedProofs": [
+    "erdos-30",
+    "erdos-340",
+    "erdos-324"
   ]
 }

--- a/src/data/proofs/erdos-428/meta.json
+++ b/src/data/proofs/erdos-428/meta.json
@@ -196,5 +196,11 @@
       "relationship": "related",
       "description": "AllOffsetsPrime {2} n gives twin primes; the $k$-tuple conjecture generalizes the twin prime conjecture"
     }
+  ],
+  "relatedProofs": [
+    "prime-number-theorem",
+    "bertrands-postulate",
+    "erdos-427",
+    "twin-primes-special"
   ]
 }

--- a/src/data/proofs/erdos-434/meta.json
+++ b/src/data/proofs/erdos-434/meta.json
@@ -240,5 +240,8 @@
       "Connection to numerical semigroups: how does the genus of the optimal semigroup grow?",
       "Is the topK set unique, or can other sets achieve the same count?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-433"
+  ]
 }

--- a/src/data/proofs/erdos-435/meta.json
+++ b/src/data/proofs/erdos-435/meta.json
@@ -166,5 +166,9 @@
       "Are there analogous results for q-binomial coefficients (Gaussian binomial coefficients) or multinomial coefficients?",
       "Can the Apéry set of S_n be computed explicitly, yielding a complete description of which numbers below the Frobenius number are non-representable?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "combinations-formula",
+    "erdos-1063"
+  ]
 }

--- a/src/data/proofs/erdos-439/meta.json
+++ b/src/data/proofs/erdos-439/meta.json
@@ -164,5 +164,12 @@
       "relationship": "methodological",
       "description": "Both use the Szemerédi regularity lemma. #1031 applies regularity to find induced regular subgraphs in non-Ramsey graphs; #439 uses regularity to count square-sum representations in arithmetic progressions."
     }
+  ],
+  "relatedProofs": [
+    "erdos-438",
+    "erdos-877",
+    "erdos-613",
+    "erdos-625",
+    "erdos-1031"
   ]
 }

--- a/src/data/proofs/erdos-447/meta.json
+++ b/src/data/proofs/erdos-447/meta.json
@@ -204,5 +204,9 @@
       "relationship": "generalizes",
       "description": "Problem 1023 asks about strong union-free families, a harder variant where no set is the union of any number of others"
     }
+  ],
+  "relatedProofs": [
+    "erdos-487",
+    "erdos-1023"
   ]
 }

--- a/src/data/proofs/erdos-453/meta.json
+++ b/src/data/proofs/erdos-453/meta.json
@@ -205,5 +205,12 @@
       "Is there an explicit constructive sequence of counterexamples (not just an existence proof)? The Lean axiom `pomerance_1979` is non-constructive.",
       "Can the full argument be formalized in Lean without any `axiom` or `sorry`, using only Mathlib's PNT and real analysis lemmas?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "bertrands-postulate",
+    "erdos-216",
+    "erdos-233",
+    "erdos-218",
+    "erdos-203"
+  ]
 }

--- a/src/data/proofs/erdos-455/meta.json
+++ b/src/data/proofs/erdos-455/meta.json
@@ -149,5 +149,10 @@
       "How many distinct monotone-gap prime sequences exist beginning with a given prime?",
       "Can the problem be generalized to other arithmetic conditions on gaps (e.g., gaps forming an arithmetic progression)?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "prime-number-theorem",
+    "bertrands-postulate",
+    "infinitude-primes"
+  ]
 }

--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -187,5 +187,11 @@
       "Do the restricted sums (smallPrimeDivisibleSum and largePrimeSum) individually diverge?",
       "Does the least-prime-factor filtered sum f(n) diverge?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-203",
+    "erdos-246",
+    "erdos-248",
+    "erdos-233"
+  ]
 }

--- a/src/data/proofs/erdos-462/meta.json
+++ b/src/data/proofs/erdos-462/meta.json
@@ -161,5 +161,11 @@
       "Can Selberg sieve methods or exponential sum techniques establish the conjecture?",
       "Is there a Maier-type phenomenon for the least prime factor sum?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-461",
+    "erdos-463",
+    "erdos-460",
+    "prime-number-theorem"
+  ]
 }

--- a/src/data/proofs/erdos-466/meta.json
+++ b/src/data/proofs/erdos-466/meta.json
@@ -127,5 +127,9 @@
       "relationship": "related",
       "description": "Both study extremal point configurations under distance constraints; #1089 in higher dimensions, #466 with fractional separation"
     }
+  ],
+  "relatedProofs": [
+    "erdos-465",
+    "erdos-1089"
   ]
 }

--- a/src/data/proofs/erdos-483/meta.json
+++ b/src/data/proofs/erdos-483/meta.json
@@ -108,5 +108,10 @@
       "relationship": "related",
       "description": "Both are extremal problems about sets avoiding specific equations: #302 avoids 1/a=1/b+1/c, #483 avoids a+b=c in colorings"
     }
+  ],
+  "relatedProofs": [
+    "ramseys-theorem",
+    "erdos-360",
+    "erdos-302"
   ]
 }

--- a/src/data/proofs/erdos-487/meta.json
+++ b/src/data/proofs/erdos-487/meta.json
@@ -126,5 +126,8 @@
       "relationship": "related",
       "description": "Both are Erdős problems about additive/multiplicative structure forced by density: #483 studies Schur numbers (avoiding a+b=c), #487 studies LCM triples in dense sets"
     }
+  ],
+  "relatedProofs": [
+    "erdos-483"
   ]
 }

--- a/src/data/proofs/erdos-50/meta.json
+++ b/src/data/proofs/erdos-50/meta.json
@@ -152,5 +152,9 @@
       "What is the modulus of continuity of f? Is f Hölder continuous, and if so, with what exponent?",
       "Do analogous distribution functions for other multiplicative functions (e.g., σ(n)/n) exhibit similar singularity?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "euler-totient",
+    "erdos-409"
+  ]
 }

--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -139,5 +139,10 @@
       "Can the binary threshold phenomenon be understood via a deeper structural principle, perhaps related to Turán-type extremal theory?",
       "For which values of N are the optimal configurations achieving $\\alpha_N$ unique up to similarity?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-507",
+    "erdos-506",
+    "erdos-1026"
+  ]
 }

--- a/src/data/proofs/erdos-537/meta.json
+++ b/src/data/proofs/erdos-537/meta.json
@@ -156,5 +156,8 @@
       "relationship": "related",
       "description": "Erdős #536 asks whether dense sets contain two numbers with equal prime products. Problem #537 was posed as a stepping stone — a positive answer would have implied #536. Ruzsa's counterexample blocks this approach."
     }
+  ],
+  "relatedProofs": [
+    "erdos-536"
   ]
 }

--- a/src/data/proofs/erdos-539/meta.json
+++ b/src/data/proofs/erdos-539/meta.json
@@ -151,5 +151,8 @@
       "relationship": "related",
       "description": "Both are extremal problems about structured subsets: #302 studies maximum sum-free sets, #539 studies minimum GCD quotient sets"
     }
+  ],
+  "relatedProofs": [
+    "erdos-302"
   ]
 }

--- a/src/data/proofs/erdos-547/meta.json
+++ b/src/data/proofs/erdos-547/meta.json
@@ -177,5 +177,10 @@
       "relationship": "related",
       "description": "Bipartite variant: #549 studies bipartite tree Ramsey numbers with sharper structural constraints"
     }
+  ],
+  "relatedProofs": [
+    "ramseys-theorem",
+    "erdos-548",
+    "erdos-549"
   ]
 }

--- a/src/data/proofs/erdos-578/meta.json
+++ b/src/data/proofs/erdos-578/meta.json
@@ -166,5 +166,8 @@
       "relationship": "related",
       "description": "Both concern guaranteed substructures: Ramsey theory guarantees monochromatic complete graphs, #578 guarantees hypercube subgraphs in random graphs"
     }
+  ],
+  "relatedProofs": [
+    "ramseys-theorem"
   ]
 }

--- a/src/data/proofs/erdos-596/meta.json
+++ b/src/data/proofs/erdos-596/meta.json
@@ -136,5 +136,8 @@
       "relationship": "related",
       "description": "Both concern Ramsey-type structure: Ramsey's theorem guarantees monochromatic complete subgraphs, #596 asks about Ramsey dichotomy for forbidden subgraph pairs"
     }
+  ],
+  "relatedProofs": [
+    "ramseys-theorem"
   ]
 }

--- a/src/data/proofs/erdos-603/meta.json
+++ b/src/data/proofs/erdos-603/meta.json
@@ -160,5 +160,8 @@
       "relationship": "related",
       "description": "Both concern coloring/partition problems: Ramsey theory partitions edges, #603 partitions hypergraph vertices (set families) avoiding intersection conditions"
     }
+  ],
+  "relatedProofs": [
+    "ramseys-theorem"
   ]
 }

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -148,5 +148,8 @@
       "relationship": "related",
       "description": "Both are Erdős problems with prize money: #483 concerns Schur numbers ($250), #604 concerns pinned distances ($500)"
     }
+  ],
+  "relatedProofs": [
+    "erdos-483"
   ]
 }

--- a/src/data/proofs/erdos-606/meta.json
+++ b/src/data/proofs/erdos-606/meta.json
@@ -145,5 +145,11 @@
       "relationship": "uses",
       "description": "The maximum line count C(n,2) = n(n-1)/2 is the binomial coefficient formalized in the combinations formula"
     }
+  ],
+  "relatedProofs": [
+    "erdos-607",
+    "erdos-604",
+    "erdos-605",
+    "combinations-formula"
   ]
 }

--- a/src/data/proofs/erdos-609/meta.json
+++ b/src/data/proofs/erdos-609/meta.json
@@ -183,5 +183,12 @@
       "relationship": "methodological",
       "description": "Both use extremal combinatorics and counting arguments on complete-like graphs. #622 studies cycle-spanning subsets in regular graphs; #609 studies forced odd cycles in edge-colored complete graphs."
     }
+  ],
+  "relatedProofs": [
+    "erdos-613",
+    "erdos-883",
+    "erdos-1091",
+    "erdos-625",
+    "erdos-622"
   ]
 }

--- a/src/data/proofs/erdos-622/meta.json
+++ b/src/data/proofs/erdos-622/meta.json
@@ -167,5 +167,9 @@
       "Can the absorbing method proof of DKM 2025 be formalized in Lean using Mathlib's graph theory library?",
       "Is there an efficient algorithm to approximately count cycle-spanned subsets in Erdős-Faudree graphs, exploiting the regularity structure?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "friendship-theorem",
+    "erdos-1036"
+  ]
 }

--- a/src/data/proofs/erdos-637/meta.json
+++ b/src/data/proofs/erdos-637/meta.json
@@ -158,5 +158,8 @@
       "relationship": "uses",
       "description": "The problem concerns graphs with no large cliques or independent sets — precisely the regime where Ramsey theory applies"
     }
+  ],
+  "relatedProofs": [
+    "ramseys-theorem"
   ]
 }

--- a/src/data/proofs/erdos-670/meta.json
+++ b/src/data/proofs/erdos-670/meta.json
@@ -161,5 +161,8 @@
       "relationship": "related",
       "description": "Both concern point configurations with distance constraints: #604 studies pinned distances, #670 studies diameter of sets with distinct pairwise distances"
     }
+  ],
+  "relatedProofs": [
+    "erdos-604"
   ]
 }

--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -146,5 +146,8 @@
       "relationship": "related",
       "description": "Both concern multiplicative structure of consecutive integers: #367 studies products of powerful parts, #678 studies LCM of consecutive intervals"
     }
+  ],
+  "relatedProofs": [
+    "erdos-367"
   ]
 }

--- a/src/data/proofs/erdos-68/meta.json
+++ b/src/data/proofs/erdos-68/meta.json
@@ -177,5 +177,8 @@
       "relationship": "related",
       "description": "Both are Erdős irrationality problems about natural arithmetic series: #267 concerns Fibonacci reciprocal sums, #68 concerns factorial reciprocal sums with perturbation"
     }
+  ],
+  "relatedProofs": [
+    "erdos-267"
   ]
 }

--- a/src/data/proofs/erdos-686/meta.json
+++ b/src/data/proofs/erdos-686/meta.json
@@ -127,5 +127,8 @@
       "relationship": "related",
       "description": "Both concern products of consecutive integers: #678 studies LCM, #686 studies ratios of products"
     }
+  ],
+  "relatedProofs": [
+    "erdos-678"
   ]
 }

--- a/src/data/proofs/erdos-689/meta.json
+++ b/src/data/proofs/erdos-689/meta.json
@@ -97,5 +97,9 @@
       "relationship": "related",
       "description": "The infinitude of primes ensures that more primes become available as n grows, making r-fold covering increasingly plausible"
     }
+  ],
+  "relatedProofs": [
+    "prime-number-theorem",
+    "infinitude-primes"
   ]
 }

--- a/src/data/proofs/erdos-692/meta.json
+++ b/src/data/proofs/erdos-692/meta.json
@@ -190,5 +190,12 @@
       "Can the prime boundary oscillation mechanism be made quantitative enough to predict the exact locations of local maxima?",
       "What is the analog of Cambie's result for the 'at least k divisors' density δ_k(n,m) with k ≥ 2?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-446",
+    "erdos-690",
+    "erdos-693",
+    "erdos-648",
+    "erdos-691"
+  ]
 }

--- a/src/data/proofs/erdos-693/meta.json
+++ b/src/data/proofs/erdos-693/meta.json
@@ -132,5 +132,8 @@
       "relationship": "related",
       "description": "Both study multiplicative structure in intervals: #367 studies powerful parts, #693 studies divisors in intervals"
     }
+  ],
+  "relatedProofs": [
+    "erdos-367"
   ]
 }

--- a/src/data/proofs/erdos-695/meta.json
+++ b/src/data/proofs/erdos-695/meta.json
@@ -156,5 +156,8 @@
       "relationship": "related",
       "description": "Both study prime factor structure of integers: #368 concerns largest prime factor of n(n+1), #695 concerns prime chains with divisibility"
     }
+  ],
+  "relatedProofs": [
+    "erdos-368"
   ]
 }

--- a/src/data/proofs/erdos-697/meta.json
+++ b/src/data/proofs/erdos-697/meta.json
@@ -174,5 +174,9 @@
       "Generalizations to other congruence conditions?",
       "Higher-order asymptotics near the threshold?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-696",
+    "erdos-698"
+  ]
 }

--- a/src/data/proofs/erdos-698/meta.json
+++ b/src/data/proofs/erdos-698/meta.json
@@ -179,5 +179,8 @@
       "relationship": "related",
       "description": "Both concern prime divisibility of binomial coefficients: #384 studies small prime divisors, #698 studies GCD of pairs"
     }
+  ],
+  "relatedProofs": [
+    "erdos-384"
   ]
 }

--- a/src/data/proofs/erdos-700/meta.json
+++ b/src/data/proofs/erdos-700/meta.json
@@ -110,5 +110,10 @@
       "relationship": "related",
       "description": "The prime factorization structure underlying f(n) relies on the infinitude and distribution of primes"
     }
+  ],
+  "relatedProofs": [
+    "kummer-theorem",
+    "wolstenholme-theorem",
+    "infinitude-primes"
   ]
 }

--- a/src/data/proofs/erdos-701/meta.json
+++ b/src/data/proofs/erdos-701/meta.json
@@ -110,5 +110,8 @@
       "relationship": "related",
       "description": "Both concern set family combinatorics: #603 studies colorings of set families, #701 studies intersecting subfamilies"
     }
+  ],
+  "relatedProofs": [
+    "erdos-603"
   ]
 }

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -145,5 +145,9 @@
       "Can the two remaining sorries (T_n_0 and large_sets_avoid_1) be closed with current Mathlib?",
       "Does the Frankl-Wilson polynomial method extend to give tight bounds on T(n,r) in the middle range?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-702",
+    "erdos-1030"
+  ]
 }

--- a/src/data/proofs/erdos-71/meta.json
+++ b/src/data/proofs/erdos-71/meta.json
@@ -141,5 +141,8 @@
       "relationship": "related",
       "description": "Both concern arithmetic progressions in combinatorial structures: #219 studies APs of primes, #71 studies cycle lengths from APs"
     }
+  ],
+  "relatedProofs": [
+    "erdos-219"
   ]
 }

--- a/src/data/proofs/erdos-717/meta.json
+++ b/src/data/proofs/erdos-717/meta.json
@@ -186,5 +186,8 @@
       "relationship": "related",
       "description": "Both concern structural properties of graphs with bounded clique/independence: #637 studies distinct degrees, #717 studies chromatic-stability ratio"
     }
+  ],
+  "relatedProofs": [
+    "erdos-637"
   ]
 }

--- a/src/data/proofs/erdos-723/meta.json
+++ b/src/data/proofs/erdos-723/meta.json
@@ -153,5 +153,8 @@
       "relationship": "related",
       "description": "Both are fundamental combinatorics problems with long history: #483 studies Schur numbers, #723 asks about projective plane orders"
     }
+  ],
+  "relatedProofs": [
+    "erdos-483"
   ]
 }

--- a/src/data/proofs/erdos-725/meta.json
+++ b/src/data/proofs/erdos-725/meta.json
@@ -206,5 +206,12 @@
       "What is the asymptotic behavior in the 'transition' regime $k \\approx n^{1/3}$ to $k \\approx n^{6/7}$ where the formula changes character?",
       "Can the permanent bounds of Godsil-McKay be sharpened to yield exact asymptotics rather than multiplicative constants?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "derangements",
+    "erdos-724",
+    "inclusion-exclusion",
+    "stirling-formula",
+    "combinations-formula"
+  ]
 }

--- a/src/data/proofs/erdos-729/meta.json
+++ b/src/data/proofs/erdos-729/meta.json
@@ -156,5 +156,10 @@
       "relationship": "related",
       "description": "The distribution of primes underlies the O(log n) bound via digit sum estimates"
     }
+  ],
+  "relatedProofs": [
+    "kummer-theorem",
+    "erdos-731",
+    "prime-number-theorem"
   ]
 }

--- a/src/data/proofs/erdos-731/meta.json
+++ b/src/data/proofs/erdos-731/meta.json
@@ -90,5 +90,10 @@
       "relationship": "related",
       "description": "The primorial asymptotic and density arguments rely on the prime number theorem"
     }
+  ],
+  "relatedProofs": [
+    "kummer-theorem",
+    "erdos-700",
+    "prime-number-theorem"
   ]
 }

--- a/src/data/proofs/erdos-732/meta.json
+++ b/src/data/proofs/erdos-732/meta.json
@@ -173,5 +173,8 @@
       "relationship": "companion",
       "description": "Problem #733 asks the analogous question for line-compatible sequences in linear spaces, a closely related combinatorial design problem."
     }
+  ],
+  "relatedProofs": [
+    "erdos-733"
   ]
 }

--- a/src/data/proofs/erdos-738/meta.json
+++ b/src/data/proofs/erdos-738/meta.json
@@ -114,5 +114,10 @@
       "relationship": "related",
       "description": "The Erdős-Hajnal conjecture relates forbidden induced subgraphs to large cliques or independent sets, a parallel structural question"
     }
+  ],
+  "relatedProofs": [
+    "ramsey-theory",
+    "four-color-theorem",
+    "erdos-hajnal-conjecture"
   ]
 }

--- a/src/data/proofs/erdos-740/meta.json
+++ b/src/data/proofs/erdos-740/meta.json
@@ -136,5 +136,10 @@
       "relationship": "broader-context",
       "description": "The Four Color Theorem is the most famous result in graph coloring. Problem #740 extends chromatic number questions to the infinite setting."
     }
+  ],
+  "relatedProofs": [
+    "erdos-58",
+    "erdos-744",
+    "four-color-theorem"
   ]
 }

--- a/src/data/proofs/erdos-754/meta.json
+++ b/src/data/proofs/erdos-754/meta.json
@@ -154,5 +154,8 @@
       "relationship": "related",
       "description": "Both concern distance geometry: #604 studies pinned distances in the plane, #754 studies equidistant neighbors in 4D"
     }
+  ],
+  "relatedProofs": [
+    "erdos-604"
   ]
 }

--- a/src/data/proofs/erdos-759/meta.json
+++ b/src/data/proofs/erdos-759/meta.json
@@ -178,5 +178,8 @@
       "relationship": "related",
       "description": "Consecutive Erdős problems in the same family of number-theoretic questions"
     }
+  ],
+  "relatedProofs": [
+    "erdos-760"
   ]
 }

--- a/src/data/proofs/erdos-760/meta.json
+++ b/src/data/proofs/erdos-760/meta.json
@@ -158,5 +158,8 @@
       "relationship": "related",
       "description": "Consecutive Erdős problems in the same family of number-theoretic questions"
     }
+  ],
+  "relatedProofs": [
+    "erdos-759"
   ]
 }

--- a/src/data/proofs/erdos-762/meta.json
+++ b/src/data/proofs/erdos-762/meta.json
@@ -150,5 +150,8 @@
       "relationship": "related",
       "description": "Both are Erdős problems in the 760s family of combinatorial number theory"
     }
+  ],
+  "relatedProofs": [
+    "erdos-760"
   ]
 }

--- a/src/data/proofs/erdos-770/meta.json
+++ b/src/data/proofs/erdos-770/meta.json
@@ -142,5 +142,10 @@
       "relationship": "related",
       "description": "When a = 2, the terms 2^n − 1 are Mersenne numbers; h(n) measures when their gcd with 3^n − 1, etc. vanishes"
     }
+  ],
+  "relatedProofs": [
+    "fermat-little-theorem",
+    "cyclotomic-polynomials",
+    "mersenne-numbers"
   ]
 }

--- a/src/data/proofs/erdos-776/meta.json
+++ b/src/data/proofs/erdos-776/meta.json
@@ -114,5 +114,10 @@
       "relationship": "related",
       "description": "Binomial coefficient structure (via Kummer's theorem) determines which layers have enough sets for multiplicity r"
     }
+  ],
+  "relatedProofs": [
+    "sperner-theorem",
+    "erdos-ko-rado",
+    "kummer-theorem"
   ]
 }

--- a/src/data/proofs/erdos-784/meta.json
+++ b/src/data/proofs/erdos-784/meta.json
@@ -183,5 +183,8 @@
       "relationship": "related",
       "description": "Both are Erdős combinatorics problems from the ErGr80 collection"
     }
+  ],
+  "relatedProofs": [
+    "erdos-760"
   ]
 }

--- a/src/data/proofs/erdos-796/meta.json
+++ b/src/data/proofs/erdos-796/meta.json
@@ -150,5 +150,8 @@
       "relationship": "companion",
       "description": "Problem #425 asks the analogous second-order question for g₂(n), the k=2 case related to primes and the Prime Number Theorem."
     }
+  ],
+  "relatedProofs": [
+    "erdos-425"
   ]
 }

--- a/src/data/proofs/erdos-801/meta.json
+++ b/src/data/proofs/erdos-801/meta.json
@@ -144,5 +144,8 @@
       "relationship": "related",
       "description": "Both are Erdős problems in the 800s about structural properties of integers"
     }
+  ],
+  "relatedProofs": [
+    "erdos-806"
   ]
 }

--- a/src/data/proofs/erdos-818/meta.json
+++ b/src/data/proofs/erdos-818/meta.json
@@ -163,5 +163,8 @@
       "relationship": "related",
       "description": "Both are Erdős problems from the 800s family of combinatorial number theory"
     }
+  ],
+  "relatedProofs": [
+    "erdos-801"
   ]
 }

--- a/src/data/proofs/erdos-834/meta.json
+++ b/src/data/proofs/erdos-834/meta.json
@@ -150,5 +150,10 @@
       "relationship": "related",
       "description": "Ramsey theory underlies many extremal hypergraph results, connecting unavoidable structures to the degree constraints in critical hypergraphs"
     }
+  ],
+  "relatedProofs": [
+    "erdos-738",
+    "four-color-theorem",
+    "ramseys-theorem"
   ]
 }

--- a/src/data/proofs/erdos-837/meta.json
+++ b/src/data/proofs/erdos-837/meta.json
@@ -135,5 +135,11 @@
       "relationship": "related",
       "description": "Problem #622 studies cycle-spanning subsets in dense regular graphs—another extremal problem where graph density forces specific substructures"
     }
+  ],
+  "relatedProofs": [
+    "erdos-833",
+    "erdos-834",
+    "erdos-1019",
+    "erdos-622"
   ]
 }

--- a/src/data/proofs/erdos-84/meta.json
+++ b/src/data/proofs/erdos-84/meta.json
@@ -156,5 +156,9 @@
       "relationship": "related",
       "description": "Problem #86 studies C₄-free subgraphs of hypercubes, another problem where specific cycle lengths interact with graph structure."
     }
+  ],
+  "relatedProofs": [
+    "erdos-85",
+    "erdos-86"
   ]
 }

--- a/src/data/proofs/erdos-847/meta.json
+++ b/src/data/proofs/erdos-847/meta.json
@@ -164,5 +164,8 @@
       "relationship": "related",
       "description": "Both are Erdős problems from the combinatorial number theory collection"
     }
+  ],
+  "relatedProofs": [
+    "erdos-818"
   ]
 }

--- a/src/data/proofs/erdos-863/meta.json
+++ b/src/data/proofs/erdos-863/meta.json
@@ -111,5 +111,10 @@
       "relationship": "related",
       "description": "Erdős #530 studies maximum Sidon subsets of finite sets, directly related to the B₂[1] baseline case where c₁ = c'₁ = 1."
     }
+  ],
+  "relatedProofs": [
+    "erdos-949",
+    "erdos-795",
+    "erdos-530"
   ]
 }

--- a/src/data/proofs/erdos-864/meta.json
+++ b/src/data/proofs/erdos-864/meta.json
@@ -129,5 +129,10 @@
       "relationship": "related",
       "description": "The Erdős-Turán conjecture on Sidon sets provides the baseline √N bound that almost-Sidon exceeds"
     }
+  ],
+  "relatedProofs": [
+    "sidon-sets",
+    "erdos-840",
+    "erdos-turan-conjecture"
   ]
 }

--- a/src/data/proofs/erdos-870/meta.json
+++ b/src/data/proofs/erdos-870/meta.json
@@ -168,5 +168,8 @@
       "relationship": "related",
       "description": "Both are Erdős problems from the 800s family"
     }
+  ],
+  "relatedProofs": [
+    "erdos-847"
   ]
 }

--- a/src/data/proofs/erdos-874/meta.json
+++ b/src/data/proofs/erdos-874/meta.json
@@ -155,5 +155,8 @@
       "relationship": "related",
       "description": "Both are Erdős problems from the 870s range"
     }
+  ],
+  "relatedProofs": [
+    "erdos-870"
   ]
 }

--- a/src/data/proofs/erdos-877/meta.json
+++ b/src/data/proofs/erdos-877/meta.json
@@ -146,5 +146,9 @@
       "Can the 5 remaining sorries (f_m_le_f, maximal_criterion, odds_construction, maximal_vs_all, erdos_877) be closed?",
       "Is there a sharp threshold for the transition from f_m(n) ≈ f(n) to f_m(n) ≪ f(n) as the maximality constraint is relaxed?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-748",
+    "erdos-863"
+  ]
 }

--- a/src/data/proofs/erdos-883/meta.json
+++ b/src/data/proofs/erdos-883/meta.json
@@ -155,5 +155,8 @@
       "relationship": "related",
       "description": "Nearby Erdős problem in the combinatorial number theory collection"
     }
+  ],
+  "relatedProofs": [
+    "erdos-882"
   ]
 }

--- a/src/data/proofs/erdos-889/meta.json
+++ b/src/data/proofs/erdos-889/meta.json
@@ -155,5 +155,10 @@
       "relationship": "related",
       "description": "Erdős #892 (primitive sequence domination) studies antichains in the divisibility order, directly relevant to understanding divisibility constraints between consecutive integers"
     }
+  ],
+  "relatedProofs": [
+    "prime-number-theorem",
+    "erdos-795",
+    "erdos-892"
   ]
 }

--- a/src/data/proofs/erdos-892/meta.json
+++ b/src/data/proofs/erdos-892/meta.json
@@ -136,5 +136,10 @@
       "relationship": "related",
       "description": "The primes form the densest primitive set; the divergence of Σ 1/(p log p) = Σ 1/p · 1/log p shows primes barely fail the necessary condition"
     }
+  ],
+  "relatedProofs": [
+    "erdos-1935-primitive",
+    "behrend-theorem",
+    "prime-harmonic-series"
   ]
 }

--- a/src/data/proofs/erdos-893/meta.json
+++ b/src/data/proofs/erdos-893/meta.json
@@ -155,5 +155,10 @@
       "relationship": "technique",
       "description": "The divergence of prime reciprocals (Euler) is an analogue: both study cumulative sums over multiplicative quantities, with the key question being whether growth is unbounded"
     }
+  ],
+  "relatedProofs": [
+    "perfect-numbers",
+    "prime-number-theorem",
+    "prime-reciprocal-divergence"
   ]
 }

--- a/src/data/proofs/erdos-898/meta.json
+++ b/src/data/proofs/erdos-898/meta.json
@@ -159,5 +159,10 @@
       "relationship": "technique",
       "description": "Ramsey-type arguments appear in generalizations of the Erdos-Mordell inequality to higher dimensions and in extremal geometry more broadly"
     }
+  ],
+  "relatedProofs": [
+    "erdos-szekeres",
+    "four-color-theorem",
+    "ramseys-theorem"
   ]
 }

--- a/src/data/proofs/erdos-90/meta.json
+++ b/src/data/proofs/erdos-90/meta.json
@@ -144,5 +144,8 @@
       "relationship": "thematic",
       "description": "Both are Erdős open problems connecting combinatorial structure to number-theoretic phenomena; #891 studies prime factors in intervals, while #90 connects unit distances to sums of two squares"
     }
+  ],
+  "relatedProofs": [
+    "erdos-891"
   ]
 }

--- a/src/data/proofs/erdos-901/meta.json
+++ b/src/data/proofs/erdos-901/meta.json
@@ -174,5 +174,10 @@
       "Is there an algorithmic version: can a proper 2-coloring be found efficiently for hypergraphs with $< m(n)$ edges?",
       "What is the relationship between $m(n)$ and the cover number $\\tau(n)$ (minimum vertices to hit all edges)?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-629",
+    "erdos-533",
+    "erdos-117"
+  ]
 }

--- a/src/data/proofs/erdos-902/meta.json
+++ b/src/data/proofs/erdos-902/meta.json
@@ -154,5 +154,8 @@
       "relationship": "related",
       "description": "Nearby Erdős problem in the combinatorial number theory collection"
     }
+  ],
+  "relatedProofs": [
+    "erdos-901"
   ]
 }

--- a/src/data/proofs/erdos-905/meta.json
+++ b/src/data/proofs/erdos-905/meta.json
@@ -116,5 +116,8 @@
       "relationship": "related",
       "description": "Nearby Erdős problem in the combinatorial number theory collection"
     }
+  ],
+  "relatedProofs": [
+    "erdos-904"
   ]
 }

--- a/src/data/proofs/erdos-910/meta.json
+++ b/src/data/proofs/erdos-910/meta.json
@@ -143,5 +143,9 @@
       "relationship": "broader-context",
       "description": "The Borsuk-Ulam theorem is a foundational result in algebraic topology, connecting to the broader study of topological properties of Euclidean space."
     }
+  ],
+  "relatedProofs": [
+    "erdos-909",
+    "borsuk-ulam"
   ]
 }

--- a/src/data/proofs/erdos-911/meta.json
+++ b/src/data/proofs/erdos-911/meta.json
@@ -149,5 +149,8 @@
       "relationship": "related",
       "description": "Nearby Erdős problem in the combinatorial number theory collection"
     }
+  ],
+  "relatedProofs": [
+    "erdos-912"
   ]
 }

--- a/src/data/proofs/erdos-913/meta.json
+++ b/src/data/proofs/erdos-913/meta.json
@@ -119,5 +119,10 @@
       "relationship": "related",
       "description": "Consecutive smooth numbers; shares the theme of prime factor constraints on consecutive integers"
     }
+  ],
+  "relatedProofs": [
+    "erdos-933",
+    "erdos-931",
+    "erdos-928"
   ]
 }

--- a/src/data/proofs/erdos-914/meta.json
+++ b/src/data/proofs/erdos-914/meta.json
@@ -134,5 +134,9 @@
       "What are the minimum degree thresholds for vertex-disjoint copies of $K_r$ in directed graphs or hypergraphs?",
       "Can the Hajnal–Szemerédi theorem be proved constructively in Lean, or does the greedy/equitable-coloring argument require classical reasoning?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-88",
+    "erdos-117"
+  ]
 }

--- a/src/data/proofs/erdos-920/meta.json
+++ b/src/data/proofs/erdos-920/meta.json
@@ -123,5 +123,12 @@
       "relationship": "related",
       "description": "Problem #925 studies R(3,3,m) bounds via independent sets in non-Ramsey graphs, connecting to the same Ramsey-theoretic landscape."
     }
+  ],
+  "relatedProofs": [
+    "ramseys-theorem",
+    "erdos-921",
+    "erdos-923",
+    "erdos-924",
+    "erdos-925"
   ]
 }

--- a/src/data/proofs/erdos-929/meta.json
+++ b/src/data/proofs/erdos-929/meta.json
@@ -114,5 +114,12 @@
       "relationship": "related",
       "description": "Erdős #334 on smooth number representation explores additive properties of smooth numbers"
     }
+  ],
+  "relatedProofs": [
+    "erdos-240",
+    "erdos-369",
+    "erdos-1055",
+    "erdos-218",
+    "erdos-334"
   ]
 }

--- a/src/data/proofs/erdos-948/meta.json
+++ b/src/data/proofs/erdos-948/meta.json
@@ -161,5 +161,8 @@
       "relationship": "related",
       "description": "Nearby Erdős problem in the combinatorial number theory collection"
     }
+  ],
+  "relatedProofs": [
+    "erdos-949"
   ]
 }

--- a/src/data/proofs/erdos-950/meta.json
+++ b/src/data/proofs/erdos-950/meta.json
@@ -118,5 +118,8 @@
       "relationship": "related",
       "description": "Nearby Erdős problem in the combinatorial number theory collection"
     }
+  ],
+  "relatedProofs": [
+    "erdos-951"
   ]
 }

--- a/src/data/proofs/erdos-953/meta.json
+++ b/src/data/proofs/erdos-953/meta.json
@@ -168,5 +168,9 @@
       "relationship": "related",
       "description": "Erdős #466 provides lower bounds for unit-distance-avoiding sets; Kovač adapted Sárközy's methods from this problem to obtain the $r^{0.26}$ lower bound for #953"
     }
+  ],
+  "relatedProofs": [
+    "erdos-465",
+    "erdos-466"
   ]
 }

--- a/src/data/proofs/erdos-980/meta.json
+++ b/src/data/proofs/erdos-980/meta.json
@@ -89,5 +89,8 @@
       "relationship": "uses",
       "description": "The prime number theorem π(x) ~ x/log x is foundational to interpreting the asymptotic Σ n_k(p) ~ c_k · x/log x."
     }
+  ],
+  "relatedProofs": [
+    "prime-number-theorem"
   ]
 }

--- a/src/data/proofs/erdos-987/meta.json
+++ b/src/data/proofs/erdos-987/meta.json
@@ -190,5 +190,13 @@
       "For the specific sequence xⱼ = jα mod 1 (irrational α), what is the optimal Aₖ growth rate as a function of the Diophantine type of α?",
       "Does the finite distinct case (Aₖ ≫ k^{1-ε}) extend to sequences with slowly growing ranges?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "erdos-990",
+    "erdos-992",
+    "erdos-988",
+    "erdos-989",
+    "erdos-995",
+    "fourier-series"
+  ]
 }

--- a/src/data/proofs/erdos-szekeres/meta.json
+++ b/src/data/proofs/erdos-szekeres/meta.json
@@ -120,5 +120,8 @@
       "What is the complexity of finding the actual monotonic subsequence?",
       "How does this generalize to higher dimensions (Ramsey numbers for hypergraphs)?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "ramseys-theorem"
+  ]
 }

--- a/src/data/proofs/euler-totient/meta.json
+++ b/src/data/proofs/euler-totient/meta.json
@@ -181,5 +181,11 @@
       "Can the RSA correctness proof be formalized as a direct application of Euler's theorem?",
       "Can the identity $n = \\sum_{d \\mid n} \\varphi(d)$ be proved from Mathlib's partition-of-unity results?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "chinese-remainder-non-coprime",
+    "infinitude-primes",
+    "fundamental-arithmetic",
+    "gcd-algorithm"
+  ]
 }

--- a/src/data/proofs/fair-games-theorem-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-01/meta.json
@@ -125,5 +125,9 @@
       "What is the exact variance formula via the quartic martingale?",
       "Can the continuous-time limit (Brownian motion) be formalized?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "fair-games-theorem",
+    "ballot-problem"
+  ]
 }

--- a/src/data/proofs/fair-games-theorem/meta.json
+++ b/src/data/proofs/fair-games-theorem/meta.json
@@ -114,5 +114,10 @@
       "How does the result change with biased games?",
       "What are the optimal betting strategies?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "ballot-problem",
+    "law-of-large-numbers",
+    "infinitude-primes"
+  ]
 }

--- a/src/data/proofs/fermat-two-squares-oq-01/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-01/meta.json
@@ -8,14 +8,28 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Lagrange%27s_four-square_theorem",
     "date": "1770",
     "status": "verified",
-    "tags": ["number-theory", "sum-of-squares", "quaternions", "extension", "research"],
+    "tags": [
+      "number-theory",
+      "sum-of-squares",
+      "quaternions",
+      "extension",
+      "research"
+    ],
     "proofRepoPath": "Proofs/FermatTwoSquaresOQ01.lean",
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [
-      { "theorem": "Nat.sum_four_squares", "description": "Every natural number is a sum of four squares", "module": "Mathlib.NumberTheory.SumFourSquares" },
-      { "theorem": "Nat.Prime.sq_add_sq", "description": "Two-squares characterization for primes", "module": "Mathlib.NumberTheory.SumTwoSquares" }
+      {
+        "theorem": "Nat.sum_four_squares",
+        "description": "Every natural number is a sum of four squares",
+        "module": "Mathlib.NumberTheory.SumFourSquares"
+      },
+      {
+        "theorem": "Nat.Prime.sq_add_sq",
+        "description": "Two-squares characterization for primes",
+        "module": "Mathlib.NumberTheory.SumTwoSquares"
+      }
     ],
     "originalContributions": [
       "Euler's four-square identity proved via ring tactic over arbitrary CommRing",
@@ -28,10 +42,34 @@
       "Connection between Fermat two-squares (conditional) and Lagrange four-squares (universal)"
     ],
     "references": [
-      {"authors": "J.-L. Lagrange", "title": "Démonstration d'un théorème d'arithmétique", "year": "1770", "venue": "Nouveaux Mémoires de l'Académie Royale", "note": "Original proof of the four-squares theorem"},
-      {"authors": "L. Euler", "title": "Demonstratio theorematis Fermatiani", "year": "1748", "venue": "Commentarii Academiae Scientiarum Petropolitanae", "note": "Four-square identity (quaternion norm multiplicativity)"},
-      {"authors": "A.-M. Legendre", "title": "Essai sur la theorie des nombres", "year": "1798", "venue": "", "note": "Three-square theorem: n is a sum of three squares iff n is not of the form 4^a(8b+7)"},
-      {"authors": "A. Hurwitz", "title": "Uber die Composition der quadratischen Formen von beliebig vielen Variablen", "year": "1898", "venue": "Nachrichten von der Gesellschaft der Wissenschaften zu Gottingen", "note": "Composition algebras exist only in dimensions 1, 2, 4, 8"}
+      {
+        "authors": "J.-L. Lagrange",
+        "title": "Démonstration d'un théorème d'arithmétique",
+        "year": "1770",
+        "venue": "Nouveaux Mémoires de l'Académie Royale",
+        "note": "Original proof of the four-squares theorem"
+      },
+      {
+        "authors": "L. Euler",
+        "title": "Demonstratio theorematis Fermatiani",
+        "year": "1748",
+        "venue": "Commentarii Academiae Scientiarum Petropolitanae",
+        "note": "Four-square identity (quaternion norm multiplicativity)"
+      },
+      {
+        "authors": "A.-M. Legendre",
+        "title": "Essai sur la theorie des nombres",
+        "year": "1798",
+        "venue": "",
+        "note": "Three-square theorem: n is a sum of three squares iff n is not of the form 4^a(8b+7)"
+      },
+      {
+        "authors": "A. Hurwitz",
+        "title": "Uber die Composition der quadratischen Formen von beliebig vielen Variablen",
+        "year": "1898",
+        "venue": "Nachrichten von der Gesellschaft der Wissenschaften zu Gottingen",
+        "note": "Composition algebras exist only in dimensions 1, 2, 4, 8"
+      }
     ],
     "dateAdded": "03/19/26"
   },
@@ -119,5 +157,9 @@
       "Can Hurwitz quaternions (with half-integer coordinates like $\\frac{1}{2}(1+i+j+k)$) be formalized to give a Euclidean domain proof, avoiding the descent?",
       "What is the formal relationship between the Cayley-Dickson construction (reals $\\to$ complex $\\to$ quaternions $\\to$ octonions) and the existence of $n$-square identities?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "fermat-two-squares",
+    "lagrange-four-squares"
+  ]
 }

--- a/src/data/proofs/fermats-last-theorem/meta.json
+++ b/src/data/proofs/fermats-last-theorem/meta.json
@@ -128,5 +128,11 @@
       "What about a^n + b^n = c^n over other number fields? This leads to deep questions in arithmetic geometry.",
       "The abc conjecture, if proven, would give a much shorter proof of FLT. Mochizuki claims a proof (2012) but it remains controversial."
     ]
-  }
+  },
+  "relatedProofs": [
+    "sophie-germain",
+    "infinitude-primes",
+    "chinese-remainder-non-coprime",
+    "dirichlets-theorem"
+  ]
 }

--- a/src/data/proofs/fourier-series-oq-03/meta.json
+++ b/src/data/proofs/fourier-series-oq-03/meta.json
@@ -133,5 +133,8 @@
       "How does the convergence rate depend on the total variation of f?",
       "Can the localization lemma be decomposed into smaller provable pieces for Aristotle?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "fourier-series"
+  ]
 }

--- a/src/data/proofs/fourier-series/meta.json
+++ b/src/data/proofs/fourier-series/meta.json
@@ -197,5 +197,9 @@
       "Can the Dirichlet conditions for pointwise convergence be formalized using Mathlib's piecewise-smooth framework?",
       "How does the convergence theory extend to higher-dimensional Fourier series on tori $\\mathbb{T}^n$?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "bertrands-postulate",
+    "prime-number-theorem"
+  ]
 }

--- a/src/data/proofs/fundamental-arithmetic/meta.json
+++ b/src/data/proofs/fundamental-arithmetic/meta.json
@@ -176,5 +176,11 @@
       "Can the failure of unique factorization in Z[√-5] be formalized as a counterexample showing it is not a UFD?",
       "Can the connection to the Riemann zeta function Euler product ζ(s) = Π(1-p^{-s})^{-1} be formalized as a consequence of the FTA?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "bezout-identity",
+    "gcd-algorithm",
+    "infinitude-primes",
+    "euler-totient"
+  ]
 }

--- a/src/data/proofs/gelfond-schneider/meta.json
+++ b/src/data/proofs/gelfond-schneider/meta.json
@@ -151,5 +151,9 @@
       "Does Schanuel's conjecture hold? It would subsume Hermite-Lindemann, Gelfond-Schneider, and imply $e + \\pi$ and $e \\cdot \\pi$ are transcendental.",
       "Can the Gelfond-Schneider proof be fully formalized in Lean with Siegel's lemma and analytic zero-counting?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "e-transcendental",
+    "prime-number-theorem"
+  ]
 }

--- a/src/data/proofs/greens-theorem-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-03/meta.json
@@ -159,5 +159,10 @@
       "relationship": "related",
       "description": "Heron's formula computes triangle area from side lengths; Green's theorem gives area via line integrals around the boundary"
     }
+  ],
+  "relatedProofs": [
+    "greens-theorem-oq-01",
+    "greens-theorem",
+    "herons-formula"
   ]
 }

--- a/src/data/proofs/greens-theorem/meta.json
+++ b/src/data/proofs/greens-theorem/meta.json
@@ -160,5 +160,11 @@
       "relationship": "related",
       "description": "Both theorems concern integral inequalities/equalities in analysis. Cauchy-Schwarz bounds inner products of functions, while Green's theorem equates two different integrals of vector field data."
     }
+  ],
+  "relatedProofs": [
+    "fundamental-theorem-calculus",
+    "area-of-circle",
+    "navier-stokes",
+    "cauchy-schwarz-integral"
   ]
 }

--- a/src/data/proofs/hilbert-11/meta.json
+++ b/src/data/proofs/hilbert-11/meta.json
@@ -169,5 +169,14 @@
       "relationship": "related",
       "description": "Hilbert's 12th Problem (Kronecker's Jugendtraum) seeks explicit class field theory, connecting to the reciprocity phenomena underlying quadratic form classification."
     }
+  ],
+  "relatedProofs": [
+    "quadratic-reciprocity",
+    "hilbert-9-reciprocity",
+    "lagrange-four-squares",
+    "minkowski-theorem",
+    "fermat-two-squares",
+    "pell-equation",
+    "kroneckers-jugendtraum"
   ]
 }

--- a/src/data/proofs/hilbert-16/meta.json
+++ b/src/data/proofs/hilbert-16/meta.json
@@ -153,5 +153,12 @@
       "relationship": "parallel",
       "description": "Hilbert's 21st Problem on Fuchsian systems with prescribed monodromy connects to the qualitative theory of differential equations and singular point analysis."
     }
+  ],
+  "relatedProofs": [
+    "brouwer-fixed-point",
+    "schauder-fixed-point",
+    "poincare-conjecture",
+    "hilbert-19",
+    "hilbert-21"
   ]
 }

--- a/src/data/proofs/hilbert-3/meta.json
+++ b/src/data/proofs/hilbert-3/meta.json
@@ -171,5 +171,10 @@
       "relationship": "broader-context",
       "description": "Area computation for circles relates to the 2D scissors congruence question. The Bolyai-Gerwien theorem shows all equal-area polygons are scissors congruent, contrasting with the 3D failure."
     }
+  ],
+  "relatedProofs": [
+    "euler-polyhedral-formula",
+    "hilbert-10",
+    "area-of-circle"
   ]
 }

--- a/src/data/proofs/hilbert-4/meta.json
+++ b/src/data/proofs/hilbert-4/meta.json
@@ -121,5 +121,8 @@
       "How does the theory extend to infinite-dimensional spaces?",
       "What are the connections to symplectic geometry?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "desargues-theorem"
+  ]
 }

--- a/src/data/proofs/intermediate-value-theorem-oq-01/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-01/meta.json
@@ -9,7 +9,14 @@
     "date": "1817",
     "status": "formalized",
     "proofRepoPath": "Proofs/IntermediateValueTheoremOQ01.lean",
-    "tags": ["analysis", "ivt", "bisection", "numerical-methods", "constructive", "convergence"],
+    "tags": [
+      "analysis",
+      "ivt",
+      "bisection",
+      "numerical-methods",
+      "constructive",
+      "convergence"
+    ],
     "badge": "formalized",
     "sorries": 2,
     "dateAdded": "03/21/26",
@@ -127,5 +134,9 @@
       "Connect bisectIter to Mathlib's Filter.Tendsto to prove full convergence to a root",
       "Formalize Newton's method and prove its quadratic convergence for comparison"
     ]
-  }
+  },
+  "relatedProofs": [
+    "intermediate-value-theorem",
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01"
+  ]
 }

--- a/src/data/proofs/isoperimetric-theorem/meta.json
+++ b/src/data/proofs/isoperimetric-theorem/meta.json
@@ -130,5 +130,10 @@
       "How does the inequality behave in discrete settings?",
       "What are the best constants in non-Euclidean spaces?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "area-of-circle",
+    "area-of-circle-oq-01",
+    "picks-theorem"
+  ]
 }

--- a/src/data/proofs/isosceles-triangle/meta.json
+++ b/src/data/proofs/isosceles-triangle/meta.json
@@ -164,5 +164,11 @@
       "Prove the isosceles triangle theorem in hyperbolic and spherical geometry, where the inner product space structure is unavailable",
       "Derive the formula for the area of an isosceles triangle A = (b/4)*sqrt(4a^2 - b^2) as a corollary of Heron's formula combined with Pons Asinorum"
     ]
-  }
+  },
+  "relatedProofs": [
+    "pythagorean-theorem",
+    "triangle-angle-sum",
+    "triangle-inequality",
+    "herons-formula"
+  ]
 }

--- a/src/data/proofs/kroneckers-jugendtraum/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum/meta.json
@@ -146,5 +146,8 @@
       "What role do modular forms and automorphic functions play for higher-degree number fields?",
       "Can the CM theory approach be extended via higher-dimensional abelian varieties?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "continuum-hypothesis"
+  ]
 }

--- a/src/data/proofs/lebesgue-measure/meta.json
+++ b/src/data/proofs/lebesgue-measure/meta.json
@@ -174,5 +174,13 @@
       "targetId": "cantor-diagonalization",
       "relationship": "Cantor's theorem that $\\mathbb{R}$ is uncountable connects to the existence of uncountable null sets (like the Cantor set) and non-measurable sets (Vitali's construction)."
     }
+  ],
+  "relatedProofs": [
+    "fundamental-theorem-calculus",
+    "fourier-series",
+    "central-limit-theorem",
+    "laws-of-large-numbers",
+    "cauchy-schwarz-integral",
+    "cantor-diagonalization"
   ]
 }

--- a/src/data/proofs/minkowski-theorem/meta.json
+++ b/src/data/proofs/minkowski-theorem/meta.json
@@ -137,5 +137,10 @@
       "relationship": "related",
       "description": "The 2D application of Minkowski's theorem uses disks of area 2πp, connecting to the circle area formula A = πr²."
     }
+  ],
+  "relatedProofs": [
+    "isoperimetric-theorem",
+    "picks-theorem",
+    "area-of-circle"
   ]
 }

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -49,7 +49,13 @@
       "Mathlib.Data.Set.Basic"
     ],
     "namespace": "PNPBarriersSound",
-    "structures": ["Program", "Polynomial", "Verifier", "Reduction", "PolyReduction"],
+    "structures": [
+      "Program",
+      "Polynomial",
+      "Verifier",
+      "Reduction",
+      "PolyReduction"
+    ],
     "axioms": [
       "cook_levin_axiom",
       "time_hierarchy",
@@ -244,5 +250,11 @@
       "Is Graph Isomorphism NP-intermediate? Babai (2015) showed it's in quasi-polynomial time, but its exact complexity remains unknown.",
       "Does NP = coNP? This is closely related to P vs NP — if P ≠ NP, most complexity theorists believe NP ≠ coNP as well."
     ]
-  }
+  },
+  "relatedProofs": [
+    "halting-problem",
+    "cantors-theorem",
+    "ramseys-theorem",
+    "erdos-szekeres"
+  ]
 }

--- a/src/data/proofs/pac-learning-bounds/meta.json
+++ b/src/data/proofs/pac-learning-bounds/meta.json
@@ -149,5 +149,10 @@
       "Formalize the full equivalence (not just the placeholder True) — requires defining PAC learnability, ERM, and uniform convergence as proper Lean types",
       "Can the epsilon-net theorem be formalized in Lean to get the tighter sample complexity bound without the log(1/ε) factor?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "shannon-entropy",
+    "prob-method-expectation",
+    "prob-method-second-moment"
+  ]
 }

--- a/src/data/proofs/partition-theorem/meta.json
+++ b/src/data/proofs/partition-theorem/meta.json
@@ -171,5 +171,10 @@
       "How do Euler's partition identities generalize to overpartitions and colored partitions?",
       "Can the Glaisher bijection be formalized in Lean as a computable function?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "kummer-theorem",
+    "erdos-250",
+    "ramseys-theorem"
+  ]
 }

--- a/src/data/proofs/pell-equation/meta.json
+++ b/src/data/proofs/pell-equation/meta.json
@@ -143,5 +143,9 @@
       "What are the implications of generalizing to Pell-like equations $x^2 - Dy^2 = N$ for arbitrary $N$?",
       "How do higher-dimensional analogues (norm equations in number fields of degree > 2) behave?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "quadratic-reciprocity",
+    "continued-fractions"
+  ]
 }

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -123,5 +123,12 @@
       "Can the independent set bound $\\alpha(G) \\geq n^2/(2m+n)$ be improved for triangle-free graphs? Shearer (1983) showed $\\alpha(G) \\geq \\Omega(n \\sqrt{\\log d}/d)$ for triangle-free $d$-regular graphs, but the optimal constant remains open.",
       "What is the minimum number of edges in a $k$-uniform hypergraph without Property B? Erdős conjectured the threshold is $\\Theta(k^2 \\cdot 2^k)$, which was resolved by Radhakrishnan and Srinivasan (2000) up to logarithmic factors, but the exact constant is still unknown."
     ]
-  }
+  },
+  "relatedProofs": [
+    "prob-method-expectation",
+    "prob-method-lovasz-local",
+    "prob-method-applications",
+    "prob-method-second-moment",
+    "ramseys-theorem"
+  ]
 }

--- a/src/data/proofs/prob-method-applications/meta.json
+++ b/src/data/proofs/prob-method-applications/meta.json
@@ -160,5 +160,11 @@
       "Can the crossing number inequality be strengthened to the Szemerédi-Trotter form cr(G) >= e³/(29n²)?",
       "Formalize the full high-girth-high-chromatic result (Erdős 1959) using Mathlib's SimpleGraph API"
     ]
-  }
+  },
+  "relatedProofs": [
+    "prob-method-expectation",
+    "prob-method-alteration",
+    "prob-method-second-moment",
+    "prob-method-lovasz-local"
+  ]
 }

--- a/src/data/proofs/prob-method-expectation/meta.json
+++ b/src/data/proofs/prob-method-expectation/meta.json
@@ -133,5 +133,11 @@
       "Prove linearity_of_expectation using Finset.sum_add_distrib — likely a one-liner",
       "Can the expected_mono_cliques result be strengthened to show the count is < 1 for n < 2^(k/2)?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "prob-method-alteration",
+    "prob-method-second-moment",
+    "prob-method-lovasz-local",
+    "prob-method-applications"
+  ]
 }

--- a/src/data/proofs/prob-method-lovasz-local/meta.json
+++ b/src/data/proofs/prob-method-lovasz-local/meta.json
@@ -145,5 +145,11 @@
       "How does the lopsided LLL (where independence is replaced by negative correlation) extend the basic version?",
       "Can the LLL be applied to Erdős problems in the gallery that involve sparse dependency structures?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "prob-method-expectation",
+    "prob-method-alteration",
+    "prob-method-second-moment",
+    "prob-method-applications"
+  ]
 }

--- a/src/data/proofs/prob-method-second-moment/meta.json
+++ b/src/data/proofs/prob-method-second-moment/meta.json
@@ -125,5 +125,12 @@
       "Can the variance computation for indicator sums be formalized generically to handle subgraph counting in $G(n,p)$ and derive specific threshold functions?",
       "How does the second moment method extend to higher moments (e.g., the fourth moment method), and can Kim-Vu polynomial concentration be formalized in Lean 4?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "prob-method-expectation",
+    "prob-method-lovasz-local",
+    "prob-method-applications",
+    "cauchy-schwarz",
+    "prob-method-alteration"
+  ]
 }

--- a/src/data/proofs/product-of-segments-of-chords/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords/meta.json
@@ -140,5 +140,10 @@
       "relationship": "related",
       "description": "Circle area formalization using the same Mathlib Euclidean geometry infrastructure"
     }
+  ],
+  "relatedProofs": [
+    "ptolemys-theorem",
+    "cevas-theorem",
+    "area-of-circle"
   ]
 }

--- a/src/data/proofs/ptolemys-theorem/meta.json
+++ b/src/data/proofs/ptolemys-theorem/meta.json
@@ -161,5 +161,10 @@
       "Can the complex-number proof be formalized, showing that Ptolemy's theorem follows from the algebraic identity (z₁-z₃)(z₂-z₄) = (z₁-z₂)(z₃-z₄) + (z₁-z₄)(z₂-z₃) applied to points on a circle?",
       "Can the derivation of the sine addition formula from Ptolemy's theorem be formalized, showing the historical connection between chord tables and modern trigonometry?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "pythagorean-theorem",
+    "herons-formula",
+    "triangle-angle-sum"
+  ]
 }

--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -124,5 +124,10 @@
       "How does the density increment strategy generalize to k-APs for k > 3?",
       "Can the Fourier infrastructure be extended to handle polynomial progressions and other additive patterns?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "szemeredi-regularity",
+    "szemeredi-full",
+    "prob-method-expectation"
+  ]
 }

--- a/src/data/proofs/shannon-channel-coding/meta.json
+++ b/src/data/proofs/shannon-channel-coding/meta.json
@@ -134,5 +134,10 @@
       "Can Fano's inequality be stated with the full H(X|Y) <= h(P_e) + P_e*log(|X|-1) rather than as True?",
       "Formalize the binary entropy function h(p) = -p*log(p) - (1-p)*log(1-p) and its properties"
     ]
-  }
+  },
+  "relatedProofs": [
+    "shannon-entropy",
+    "shannon-source-coding",
+    "prob-method-expectation"
+  ]
 }

--- a/src/data/proofs/shannon-entropy/meta.json
+++ b/src/data/proofs/shannon-entropy/meta.json
@@ -123,5 +123,10 @@
       "Can differential entropy for continuous distributions be formalized?",
       "What is the relationship between Shannon entropy and Kolmogorov complexity in Lean?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "shannon-source-coding",
+    "shannon-channel-coding",
+    "prob-method-expectation"
+  ]
 }

--- a/src/data/proofs/shannon-source-coding/meta.json
+++ b/src/data/proofs/shannon-source-coding/meta.json
@@ -118,5 +118,9 @@
       "Can Huffman coding be proved optimal among prefix-free codes in Lean, providing a constructive complement to the existential source coding theorem?",
       "Can the AEP be formalized using Mathlib's probability measure framework, connecting to the weak law of large numbers?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "shannon-entropy",
+    "shannon-channel-coding"
+  ]
 }

--- a/src/data/proofs/solution-of-cubic/meta.json
+++ b/src/data/proofs/solution-of-cubic/meta.json
@@ -189,5 +189,12 @@
       "What is the computational complexity of evaluating Cardano's formula versus numerical root-finding methods?",
       "Can the connection to the quartic solution (via cubic resolvent) be formalized to chain Wiedijk #37 and #46?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "general-quartic",
+    "abel-ruffini",
+    "fundamental-theorem-algebra",
+    "de-moivre",
+    "angle-trisection"
+  ]
 }

--- a/src/data/proofs/sophie-germain/meta.json
+++ b/src/data/proofs/sophie-germain/meta.json
@@ -135,5 +135,12 @@
       "What is the distribution of Sophie Germain primes among all primes?",
       "What is the longest known Cunningham chain of Sophie Germain primes?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "fermats-last-theorem",
+    "infinitude-primes",
+    "twin-primes-special",
+    "dirichlets-theorem",
+    "wilsons-theorem"
+  ]
 }

--- a/src/data/proofs/szemeredi-counting/meta.json
+++ b/src/data/proofs/szemeredi-counting/meta.json
@@ -46,23 +46,23 @@
     "references": [
       {
         "key": "RS78",
-        "citation": "I. Z. Ruzsa and E. Szemer\u00e9di, Triple systems with no six points carrying three triangles, Combinatorics (Keszthely, 1976), Colloq. Math. Soc. J\u00e1nos Bolyai 18 (1978), 939\u2013945."
+        "citation": "I. Z. Ruzsa and E. Szemerédi, Triple systems with no six points carrying three triangles, Combinatorics (Keszthely, 1976), Colloq. Math. Soc. János Bolyai 18 (1978), 939–945."
       },
       {
         "key": "KS96",
-        "citation": "J. Koml\u00f3s and M. Simonovits, Szemer\u00e9di's regularity lemma and its applications in graph theory, Combinatorics: Paul Erd\u0151s is Eighty, vol. 2, Bolyai Soc. Math. Studies 2, 1996, pp. 295\u2013352."
+        "citation": "J. Komlós and M. Simonovits, Szemerédi's regularity lemma and its applications in graph theory, Combinatorics: Paul Erdős is Eighty, vol. 2, Bolyai Soc. Math. Studies 2, 1996, pp. 295–352."
       },
       {
         "key": "Fox11",
-        "citation": "J. Fox, A new proof of the graph removal lemma, Ann. of Math. (2) 174 (2011), 561\u2013579."
+        "citation": "J. Fox, A new proof of the graph removal lemma, Ann. of Math. (2) 174 (2011), 561–579."
       },
       {
         "key": "Sze78",
-        "citation": "E. Szemer\u00e9di, Regular partitions of graphs, Probl\u00e8mes combinatoires et th\u00e9orie des graphes (Orsay, 1976), Colloq. Internat. CNRS 260, Paris, 1978, pp. 399\u2013401."
+        "citation": "E. Szemerédi, Regular partitions of graphs, Problèmes combinatoires et théorie des graphes (Orsay, 1976), Colloq. Internat. CNRS 260, Paris, 1978, pp. 399–401."
       }
     ],
     "prerequisites": [
-      "Szemer\u00e9di Regularity Lemma",
+      "Szemerédi Regularity Lemma",
       "Epsilon-regular pairs and edge density",
       "SimpleGraph and Finset in Mathlib",
       "Triangle counting and subgraph enumeration",
@@ -141,5 +141,10 @@
       "What is the relationship between removal lemma bounds and the tower-type bounds in the regularity lemma itself?",
       "Can the removal lemma be proved without the regularity lemma (as in Fox's 2011 approach using the strong regularity lemma)?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "szemeredi-regularity",
+    "roth-theorem-k3",
+    "szemeredi-full"
+  ]
 }

--- a/src/data/proofs/szemeredi-full/meta.json
+++ b/src/data/proofs/szemeredi-full/meta.json
@@ -131,5 +131,11 @@
       "Can the proof be extended to polynomial progressions (Bergelson-Leibman theorem)?",
       "Is a formalization of the Green-Tao theorem feasible building on this infrastructure?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "roth-theorem-k3",
+    "szemeredi-regularity",
+    "szemeredi-counting",
+    "prob-method-lovasz-local"
+  ]
 }

--- a/src/data/proofs/szemeredi-regularity/meta.json
+++ b/src/data/proofs/szemeredi-regularity/meta.json
@@ -121,5 +121,11 @@
       "Can the partition refinement be made algorithmic with polynomial-time guarantees (Alon-Duke-Lefmann-Rodl-Yuster)?",
       "What is the optimal energy increment constant, and can we formalize tight bounds?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "szemeredi-counting",
+    "szemeredi-full",
+    "roth-theorem-k3",
+    "prob-method-lovasz-local"
+  ]
 }

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -214,5 +214,11 @@
       "relationship": "related",
       "description": "Fixed point theorems are used in functional analysis proofs relevant to constructive QFT and the existence of vacuum states."
     }
+  ],
+  "relatedProofs": [
+    "poincare-conjecture",
+    "riemann-hypothesis",
+    "hilbert-5",
+    "brouwer-fixed-point"
   ]
 }


### PR DESCRIPTION
## Summary

Three-part enrichment pass:

### Part 1: Batch relatedProofs (236 entries)
Populated `relatedProofs` arrays for 236 proof gallery entries that had `crossReferences` but were missing the corresponding `relatedProofs` field.

### Part 2: Deep annotations (6 entries, 32 annotations)
Created comprehensive annotations for: birthday-problem-oq-02, borsuk-ulam-oq-03-oq-01-oq-01, denumerability-rationals-oq-03, roth-theorem-k3, szemeredi-full, szemeredi-regularity.

### Part 3: FTC Lebesgue annotations (1 entry, 7 annotations)
Created annotations for `fundamental-theorem-calculus-oq-01`:
- AC definition, Lipschitz→AC, AC→UC chains
- Lebesgue FTC axioms with proof path documentation
- Cantor function counterexample
- Mathlib connections (Vitali, density theorem)
- Expanded sections from 2 to 7
- Added proofRepoPath, crossReferences

**Total: 243+ entries enriched, 39 new annotations created**

## Test plan
- [x] JSON validated for all modified files
- [x] `pnpm annotations:build` passes with no new errors