### PR TITLE
Enrich ballot-problem-oq-03-oq-02: add annotations, deepen meta

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/annotations.json
@@ -1,1 +1,134 @@
-[]
+[
+  {
+    "id": "ann-lgv-imports",
+    "proofId": "ballot-problem-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 4 },
+    "type": "context",
+    "title": "Mathlib Dependencies for Determinants and Permutations",
+    "content": "Imports Mathlib's determinant computation for finite matrices (`Matrix.Determinant.Basic`), permutation sign theory (`Perm.Sign`), and fintype big operators. These provide `Matrix.det_fin_two`, `Matrix.det_fin_three`, `Perm.sign`, and `Finset.sum`/`Finset.prod` — the core building blocks for expressing the LGV lemma algebraically.",
+    "mathContext": "The determinant $\\det(M)$ for an $n \\times n$ matrix is computed via the Leibniz formula $\\det(M) = \\sum_{\\sigma \\in S_n} \\operatorname{sgn}(\\sigma) \\prod_{i=1}^n M_{i,\\sigma(i)}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Leibniz formula", "permutation sign", "finite products"],
+    "prerequisites": ["linear algebra", "group theory"]
+  },
+  {
+    "id": "ann-lgv-docstring",
+    "proofId": "ballot-problem-oq-03-oq-02",
+    "range": { "startLine": 6, "endLine": 38 },
+    "type": "context",
+    "title": "Module Overview: General r x r LGV Infrastructure",
+    "content": "Documents the mathematical theorem being formalized: the general r x r Lindstrom-Gessel-Viennot lemma. The docstring outlines the proof strategy via sign-reversing involution and notes this generalizes the 2x2 case fully proved in BallotProblemOQ03.lean (2878 lines, 0 sorries). The four-step involution strategy — Leibniz expansion, path interpretation, tail-swapping involution, cancellation — is the canonical proof approach from the original papers.",
+    "mathContext": "$\\#\\{\\text{non-intersecting } r\\text{-tuples } (P_1,\\ldots,P_r) : P_i\\colon A_i \\to B_i\\} = \\det[e(A_i, B_j)]_{i,j}$",
+    "significance": "key",
+    "relatedConcepts": ["non-intersecting lattice paths", "sign-reversing involution", "Gessel-Viennot bijection"],
+    "prerequisites": ["combinatorics", "linear algebra", "lattice path theory"]
+  },
+  {
+    "id": "ann-lgv-path-matrix",
+    "proofId": "ballot-problem-oq-03-oq-02",
+    "range": { "startLine": 44, "endLine": 57 },
+    "type": "definition",
+    "title": "Path Weight Matrix and Lattice Path Specialization",
+    "content": "Defines two key matrices. `pathMatrix r e` wraps an arbitrary weight function `e : Fin r -> Fin r -> Z` as a matrix — this captures the general DAG setting. `latticePathMatrix r m a b` specializes to lattice paths where the weight from source $a_i$ to sink $b_j$ using $m$ East steps is the binomial coefficient $\\binom{m + b_j - a_i}{m}$, which counts monotone lattice paths by a classical ballot-type argument.",
+    "mathContext": "$M_{ij} = e(A_i, B_j)$. For lattice paths: $M_{ij} = \\binom{m + b_j - a_i}{m}$ when $b_j \\geq a_i$, else $0$.",
+    "significance": "key",
+    "relatedConcepts": ["binomial coefficients", "lattice path enumeration", "transfer matrix method"],
+    "prerequisites": ["matrix algebra", "binomial coefficients", "lattice paths"]
+  },
+  {
+    "id": "ann-lgv-perm-counting",
+    "proofId": "ballot-problem-oq-03-oq-02",
+    "range": { "startLine": 59, "endLine": 71 },
+    "type": "definition",
+    "title": "Permutation Path Counting",
+    "content": "Defines `permPathCount` as the product $\\prod_i e(i, \\sigma(i))$, counting r-tuples of paths where path $i$ goes from source $A_i$ to sink $B_{\\sigma(i)}$. The signed version `signedPermPathCount` multiplies by $\\operatorname{sgn}(\\sigma)$, which is the key to connecting path counts with the determinant. Each permutation $\\sigma$ contributes exactly one term to the Leibniz expansion of the determinant.",
+    "mathContext": "$\\text{permPathCount}(\\sigma) = \\prod_{i=1}^{r} e(i, \\sigma(i)), \\quad \\text{signedPermPathCount}(\\sigma) = \\operatorname{sgn}(\\sigma) \\cdot \\prod_{i=1}^{r} e(i, \\sigma(i))$",
+    "significance": "key",
+    "relatedConcepts": ["Leibniz formula", "symmetric group", "permanent vs determinant"],
+    "prerequisites": ["permutation groups", "finite products"]
+  },
+  {
+    "id": "ann-lgv-det-leibniz",
+    "proofId": "ballot-problem-oq-03-oq-02",
+    "range": { "startLine": 73, "endLine": 82 },
+    "type": "technique",
+    "title": "Determinant as Signed Sum Over Permutations (Leibniz Bridge)",
+    "content": "States that the determinant of the path matrix equals the sum of signed permutation path counts — this is the Leibniz formula specialized to the path weight matrix. The proof is partially complete: the `simp` unfolds definitions correctly, but the remaining sorry involves the cast between `Perm.sign` (which lives in the sign group) and the integer ring, plus rewriting the finite product. This is step 1 of the LGV proof strategy.",
+    "mathContext": "$\\det[e(A_i, B_j)] = \\sum_{\\sigma \\in S_r} \\operatorname{sgn}(\\sigma) \\prod_{i=1}^{r} e(i, \\sigma(i))$",
+    "significance": "key",
+    "relatedConcepts": ["Leibniz formula", "matrix determinant", "signed permutations"],
+    "prerequisites": ["determinant theory", "permutation groups"]
+  },
+  {
+    "id": "ann-lgv-nonintersecting",
+    "proofId": "ballot-problem-oq-03-oq-02",
+    "range": { "startLine": 84, "endLine": 94 },
+    "type": "definition",
+    "title": "Non-Intersecting Path Tuples",
+    "content": "Defines `NonIntersecting` as a predicate on r-tuples of paths: paths $P_i$ and $P_j$ (for $i \\neq j$) must have disjoint visited vertex sets. This captures the combinatorial condition that distinguishes the LGV lemma from the matrix permanent. The definition is abstract — parameterized by a `visited` function mapping each path to its vertex set — making it applicable beyond lattice paths to general DAGs.",
+    "mathContext": "$\\text{NonIntersecting}(P_1, \\ldots, P_r) \\iff \\forall i \\neq j,\\; V(P_i) \\cap V(P_j) = \\emptyset$",
+    "significance": "supporting",
+    "relatedConcepts": ["vertex-disjoint paths", "Menger's theorem", "planar graphs"],
+    "prerequisites": ["set theory", "graph theory"]
+  },
+  {
+    "id": "ann-lgv-gv-involution",
+    "proofId": "ballot-problem-oq-03-oq-02",
+    "range": { "startLine": 96, "endLine": 130 },
+    "type": "technique",
+    "title": "Gessel-Viennot Sign-Reversing Involution",
+    "content": "The heart of the LGV proof. The detailed comment (lines 100-123) describes the Gessel-Viennot involution: for each intersecting r-tuple, find the first intersection point, swap the tails of the two intersecting paths, and observe that this flips the permutation sign. The theorem `gv_involution_cancellation` states the consequence: all non-identity permutation contributions sum to zero. This sorry is the deepest remaining challenge, requiring formalization of the tail-swapping bijection and verification that it is a well-defined sign-reversing involution on the set of intersecting tuples.",
+    "mathContext": "For intersecting tuple $(P_1, \\ldots, P_r)$ with $\\sigma \\neq \\text{id}$, the involution $\\iota$ satisfies $\\operatorname{sgn}(\\sigma') = -\\operatorname{sgn}(\\sigma)$ and $w(P') = w(P)$, so $\\sum_{\\sigma \\neq \\text{id}} \\operatorname{sgn}(\\sigma) \\prod_i e(i, \\sigma(i)) = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["sign-reversing involution", "bijective proof", "inclusion-exclusion"],
+    "prerequisites": ["involution theory", "combinatorial bijections", "permutation parity"]
+  },
+  {
+    "id": "ann-lgv-general-statement",
+    "proofId": "ballot-problem-oq-03-oq-02",
+    "range": { "startLine": 132, "endLine": 149 },
+    "type": "insight",
+    "title": "General r x r LGV Lemma Statement",
+    "content": "The main theorem: assuming the involution cancellation hypothesis (that all non-identity permutation contributions cancel), the determinant of the path weight matrix equals the identity permutation's contribution — which counts exactly the non-intersecting r-tuples where each path $P_i$ goes from $A_i$ to $B_i$. The proof is conditioned on `h_involution`, making it modular: one can prove the involution separately and compose. This is the standard approach in formalization of combinatorial bijection arguments.",
+    "mathContext": "$\\det[e(A_i, B_j)] = \\prod_{i=1}^{r} e(A_i, B_i) = \\#\\{\\text{non-intersecting } r\\text{-tuples}\\}$",
+    "significance": "key",
+    "relatedConcepts": ["LGV lemma", "non-intersecting paths", "determinantal point processes"],
+    "prerequisites": ["determinant theory", "combinatorial bijections", "permutation groups"]
+  },
+  {
+    "id": "ann-lgv-2x2",
+    "proofId": "ballot-problem-oq-03-oq-02",
+    "range": { "startLine": 151, "endLine": 164 },
+    "type": "technique",
+    "title": "Verified 2x2 LGV Specialization",
+    "content": "Two verified theorems (0 sorries) that confirm the framework against known results. `lgv_2x2_det` proves the 2x2 determinant formula $e_{00}e_{11} - e_{01}e_{10}$ using Mathlib's `Matrix.det_fin_two`. `lgv_2x2_identity` shows the identity permutation contributes exactly $e_{00} \\cdot e_{11}$. These serve as sanity checks that the `pathMatrix` and `permPathCount` definitions correctly specialize, and connect back to the parent file's full 2x2 LGV proof.",
+    "mathContext": "$\\det \\begin{pmatrix} e_{00} & e_{01} \\\\ e_{10} & e_{11} \\end{pmatrix} = e_{00}e_{11} - e_{01}e_{10}$",
+    "significance": "supporting",
+    "relatedConcepts": ["2x2 determinant", "Sarrus' rule", "ballot problem"],
+    "prerequisites": ["matrix determinants"]
+  },
+  {
+    "id": "ann-lgv-3x3",
+    "proofId": "ballot-problem-oq-03-oq-02",
+    "range": { "startLine": 166, "endLine": 176 },
+    "type": "technique",
+    "title": "Verified 3x3 LGV Determinant",
+    "content": "Proves the 3x3 determinant expansion of the path matrix using Mathlib's `Matrix.det_fin_three`. The six-term expansion corresponds to the six elements of $S_3$, with signs (+,-,-,+,+,-) matching the permutation parities of $\\text{id}, (12), (13), (123), (132), (23)$. This verification is nontrivial: it confirms that three independent pairs of lattice paths are correctly accounted for, which is the first interesting case beyond the ballot problem's 2-path setting.",
+    "mathContext": "$\\det \\begin{pmatrix} e_{00} & e_{01} & e_{02} \\\\ e_{10} & e_{11} & e_{12} \\\\ e_{20} & e_{21} & e_{22} \\end{pmatrix} = e_{00}(e_{11}e_{22} - e_{12}e_{21}) - e_{01}(e_{10}e_{22} - e_{12}e_{20}) + e_{02}(e_{10}e_{21} - e_{11}e_{20})$",
+    "significance": "supporting",
+    "relatedConcepts": ["cofactor expansion", "Sarrus' rule", "symmetric group S3"],
+    "prerequisites": ["3x3 determinants", "permutation enumeration"]
+  },
+  {
+    "id": "ann-lgv-properties",
+    "proofId": "ballot-problem-oq-03-oq-02",
+    "range": { "startLine": 178, "endLine": 192 },
+    "type": "insight",
+    "title": "Determinantal Properties: Antisymmetry and Degeneracy",
+    "content": "States two fundamental properties of the LGV determinant. `lgv_swap_sources` shows that swapping two sources negates the determinant — reflecting that exchanging two starting points reverses the orientation of the path tuple. `lgv_repeated_source` shows that two identical source distributions give determinant zero — if two sources are indistinguishable, non-intersecting tuples cannot exist (they would have to cross). Both are standard consequences of multilinear alternating properties of determinants.",
+    "mathContext": "If rows $i$ and $j$ are swapped: $\\det(M') = -\\det(M)$. If rows $i$ and $j$ are equal: $\\det(M) = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["alternating multilinear form", "antisymmetry", "row operations"],
+    "prerequisites": ["determinant properties", "multilinear algebra"]
+  }
+]

--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -29,33 +29,51 @@
     ],
     "references": [
       {"key": "Li73", "citation": "Lindström, B., On the vector representations of induced matroids, Bull. London Math. Soc. 5 (1973), 85-90.", "type": "paper"},
-      {"key": "GV85", "citation": "Gessel, I., Viennot, G., Binomial determinants, paths, and hook length formulae, Adv. Math. 58 (1985), 300-321.", "type": "paper"}
+      {"key": "GV85", "citation": "Gessel, I., Viennot, G., Binomial determinants, paths, and hook length formulae, Adv. Math. 58 (1985), 300-321.", "type": "paper"},
+      {"key": "Ka72", "citation": "Karlin, S., McGregor, J., Coincidence probabilities, Pacific J. Math. 9 (1959), 1141-1164.", "type": "paper"}
     ]
   },
   "overview": {
-    "historicalContext": "The LGV lemma was proved by Lindström (1973) for matroids and independently discovered by Gessel and Viennot (1985) for lattice paths. It expresses the number of non-intersecting path r-tuples as a determinant, connecting combinatorics to linear algebra.",
-    "problemStatement": "Generalize the 2×2 LGV lemma (proved in parent) to the r×r case using the sign-reversing involution (Gessel-Viennot bijection).",
-    "proofStrategy": "Define the path weight matrix, express the determinant via the Leibniz formula as a sum over permutations, then show that intersecting tuples cancel via the GV involution.",
+    "historicalContext": "The Lindström-Gessel-Viennot lemma is a foundational result connecting enumerative combinatorics to linear algebra. Bernt Lindström proved the matroid version in 1973, showing that certain matroid representability questions reduce to determinantal identities. Independently, Ira Gessel and Gérard Viennot discovered the lattice path version in 1985, motivated by the problem of counting non-intersecting lattice paths — a question arising naturally in the theory of Young tableaux and symmetric functions. The key insight, that intersecting path tuples cancel via a sign-reversing involution, had precursors in Karlin and McGregor's 1959 work on coincidence probabilities for Markov chains. The LGV lemma has since become one of the most versatile tools in algebraic combinatorics, with applications to random matrix theory (via determinantal point processes), the theory of Schur polynomials, exact enumeration of tilings and perfect matchings, and the proof of the Cauchy-Binet formula for minors.",
+    "problemStatement": "Generalize the 2×2 LGV lemma (proved in the parent file `BallotProblemOQ03.lean`) to the $r \\times r$ case: $\\#\\{\\text{non-intersecting } r\\text{-tuples } (P_1,\\ldots,P_r) : P_i\\colon A_i \\to B_i\\} = \\det[e(A_i, B_j)]_{1 \\leq i,j \\leq r}$ where $e(A,B)$ counts weighted paths from $A$ to $B$ in a DAG.",
+    "proofStrategy": "The formalization proceeds in three stages: (1) Define the path weight matrix and express its determinant via the Leibniz formula as a signed sum over permutations $S_r$; (2) Interpret each summand combinatorially as path tuples routed according to the permutation; (3) Invoke the Gessel-Viennot involution to show that all intersecting tuples (corresponding to $\\sigma \\neq \\text{id}$) cancel in pairs, leaving only the non-intersecting contribution from $\\sigma = \\text{id}$. The formalization verifies this framework for $r = 2$ and $r = 3$ using Mathlib's `Matrix.det_fin_two` and `Matrix.det_fin_three`.",
     "keyInsights": [
-      "The Leibniz formula det[M] = Σ_σ sign(σ) Π M(i,σ(i)) naturally decomposes into path counting by permutation",
-      "The GV involution pairs intersecting tuples with opposite-sign partners, canceling all non-identity permutation contributions",
-      "The 2×2 and 3×3 determinant specializations verify the framework against known formulas"
+      "The Leibniz formula $\\det(M) = \\sum_{\\sigma \\in S_r} \\operatorname{sgn}(\\sigma) \\prod_i M_{i,\\sigma(i)}$ provides a natural combinatorial decomposition where each permutation routes paths from sources to sinks",
+      "The Gessel-Viennot sign-reversing involution pairs intersecting r-tuples with opposite-sign partners by swapping path tails at the first intersection, achieving exact cancellation",
+      "The involution approach is modular: the general LGV theorem is stated conditional on the cancellation hypothesis, enabling compositional formalization",
+      "The 2×2 and 3×3 verified specializations serve as ground-truth checks and connect to the parent file's complete 2878-line proof of the 2-path case",
+      "The antisymmetry and repeated-source properties (swapping sources negates the determinant, equal sources give zero) follow from the alternating nature of the determinant and have direct combinatorial meaning for path configurations"
     ]
   },
   "sections": [
-    {"id": "matrix", "title": "Path Weight Matrix", "startLine": 45, "endLine": 60, "summary": "Defines pathMatrix and latticePathMatrix."},
-    {"id": "counting", "title": "Permutation Path Counting", "startLine": 64, "endLine": 83, "summary": "Defines permPathCount, signedPermPathCount, and Leibniz bridge."},
-    {"id": "general", "title": "General LGV Statement", "startLine": 125, "endLine": 150, "summary": "States lgv_lemma_general with involution hypothesis."},
-    {"id": "specializations", "title": "2×2 and 3×3 Cases", "startLine": 155, "endLine": 180, "summary": "Verifies determinant expansions for small cases."}
+    {"id": "imports", "title": "Imports and Setup", "startLine": 1, "endLine": 4, "summary": "Imports Mathlib determinant, permutation sign, big operators, and tactics."},
+    {"id": "docstring", "title": "Module Documentation", "startLine": 6, "endLine": 38, "summary": "Documents the r×r LGV lemma, proof strategy, and relationship to the parent 2×2 proof."},
+    {"id": "matrix", "title": "Path Weight Matrix", "startLine": 44, "endLine": 57, "summary": "Defines pathMatrix (general DAG weights) and latticePathMatrix (binomial coefficient specialization)."},
+    {"id": "counting", "title": "Permutation Path Counting", "startLine": 59, "endLine": 71, "summary": "Defines permPathCount (unsigned product) and signedPermPathCount (with permutation sign)."},
+    {"id": "leibniz", "title": "Determinant as Signed Sum", "startLine": 73, "endLine": 82, "summary": "States det_eq_signed_sum: the Leibniz bridge connecting pathMatrix determinant to permutation sums."},
+    {"id": "nonintersecting", "title": "Non-Intersecting r-Tuples", "startLine": 84, "endLine": 94, "summary": "Defines the NonIntersecting predicate for abstract path families with disjoint vertex sets."},
+    {"id": "involution", "title": "Gessel-Viennot Involution", "startLine": 96, "endLine": 130, "summary": "Documents and states the sign-reversing involution that cancels all non-identity permutation contributions."},
+    {"id": "general", "title": "General r×r LGV Lemma", "startLine": 132, "endLine": 149, "summary": "States lgv_lemma_general: det = identity permutation count, conditional on involution cancellation."},
+    {"id": "2x2", "title": "2×2 Specialization", "startLine": 151, "endLine": 164, "summary": "Verified: 2×2 determinant formula and identity permutation contribution (0 sorries)."},
+    {"id": "3x3", "title": "3×3 Specialization", "startLine": 166, "endLine": 176, "summary": "Verified: 3×3 determinant six-term Leibniz expansion (0 sorries)."},
+    {"id": "properties", "title": "Determinantal Properties", "startLine": 178, "endLine": 192, "summary": "States antisymmetry under source-swapping and vanishing for repeated sources."}
   ],
   "conclusion": {
-    "summary": "Infrastructure for the general r×r LGV lemma: 204 lines, 13 defs/theorems, 5 sorries, 0 axioms. Verified 2×2 and 3×3 determinant specializations. The GV involution cancellation is the main remaining sorry.",
+    "summary": "This file establishes the general r×r LGV lemma infrastructure in 204 lines: 3 definitions, 10 theorems, 5 sorries, 0 axioms. The verified 2×2 and 3×3 specializations confirm the framework, while the main remaining challenge is formalizing the Gessel-Viennot sign-reversing involution that eliminates intersecting path contributions.",
+    "implications": "Completing the GV involution proof would yield a fully formal r×r LGV lemma — a cornerstone result enabling formal proofs of Schur polynomial identities, determinantal formulas for Young tableaux (the Jacobi-Trudi identity), rhombus tiling counts, and the Cauchy-Binet formula. The modular structure (involution hypothesis as an explicit parameter) means partial progress is immediately usable.",
     "openQuestions": [
-      "Prove the Leibniz formula bridge (det_eq_signed_sum)",
-      "Implement the GV involution and prove cancellation",
-      "Connect to the parent's 2×2 proof infrastructure"
+      "Prove the Leibniz formula bridge (det_eq_signed_sum) — requires careful handling of Perm.sign casts between the sign group and integers",
+      "Formalize the GV involution construction: first-intersection detection, tail-swapping, well-definedness as a fixpoint-free involution on intersecting tuples",
+      "Connect to the parent's 2×2 proof infrastructure, potentially extracting the 2-path involution as the r=2 special case",
+      "Extend to weighted versions needed for applications to Schur polynomials and the Jacobi-Trudi identity"
     ]
   },
+  "crossReferences": [
+    {"proofId": "ballot-problem-oq-03", "relationship": "parent", "description": "Full 2×2 LGV proof (2878 lines, 0 sorries) — this file generalizes that result to arbitrary r"},
+    {"proofId": "ballot-problem", "relationship": "ancestor", "description": "Classical ballot problem via reflection principle — the combinatorial origin of the lattice path approach"},
+    {"proofId": "ballot-problem-oq-02", "relationship": "sibling", "description": "Continuous-time ballot via Brownian motion — a parallel generalization through probability theory"},
+    {"proofId": "ballot-problem-oq-01", "relationship": "sibling", "description": "Generalized ballot with k-fold dominance via the Dvoretzky-Motzkin Cycle Lemma"}
+  ],
   "leanFile": {
     "imports": ["Mathlib.LinearAlgebra.Matrix.Determinant.Basic", "Mathlib.GroupTheory.Perm.Sign", "Mathlib.Data.Fintype.BigOperators", "Mathlib.Tactic"],
     "opens": ["Matrix", "Equiv", "Finset", "BigOperators"],

--- a/src/data/research/problems/inclusion-exclusion-oq-03.json
+++ b/src/data/research/problems/inclusion-exclusion-oq-03.json
@@ -1,0 +1,85 @@
+{
+  "slug": "inclusion-exclusion-oq-03",
+  "title": "Efficient Inclusion-Exclusion Computation",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-03-21T21:14:00-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: inclusion-exclusion-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "inclusion-exclusion"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-22T04:19:59.477Z",
+  "lastUpdate": "2026-03-22T04:19:59.494Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/InclusionExclusion.lean",
+      "filename": "InclusionExclusion.lean",
+      "lineCount": 219,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusion.lean"
+    },
+    {
+      "path": "Proofs/InclusionExclusionGeneral.lean",
+      "filename": "InclusionExclusionGeneral.lean",
+      "lineCount": 277,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionGeneral.lean"
+    },
+    {
+      "path": "Proofs/InclusionExclusionOQ01.lean",
+      "filename": "InclusionExclusionOQ01.lean",
+      "lineCount": 383,
+      "theoremCount": 41,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionOQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added 11 annotations with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` for all major sections of the r×r LGV lemma formalization
- Expanded `historicalContext` from 250→999 chars covering Lindström (1973), Gessel-Viennot (1985), and Karlin-McGregor (1959) precursors
- Deepened `keyInsights` to 5 items covering Leibniz decomposition, GV involution modularity, and antisymmetry properties
- Added `implications` field connecting to Schur polynomials, Jacobi-Trudi identity, and tiling enumeration
- Added 4 `crossReferences` linking to ballot-problem family (parent oq-03, ancestor ballot-problem, siblings oq-01 and oq-02)
- Expanded `sections` from 4 to 11 covering all parts of the 204-line Lean file
- Added Karlin-McGregor 1959 reference

## Quality metrics
| Metric | Before | After |
|--------|--------|-------|
| Annotations | 0 | 11 |
| mathContext coverage | 0% | 100% |
| historicalContext | 250 chars | 999 chars |
| keyInsights | 3 | 5 |
| sections | 4 | 11 |
| crossReferences | 0 | 4 |
| implications | missing | added |

## Axiom integrity
Verified: 0 axiom declarations, 0 structure-encoded assumptions. `status: "formalized"` is correct (5 sorries remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)