### PR TITLE
Enrich Fundamental Theorem of Calculus: Lebesgue Generalization

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus-oq-01/annotations.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-ftc-leb-ac-definition",
+    "proofId": "fundamental-theorem-calculus-oq-01",
+    "range": { "startLine": 59, "endLine": 80 },
+    "type": "definition",
+    "title": "Absolute Continuity on an Interval",
+    "content": "Defines AbsolutelyContinuousOn, a property strictly between Lipschitz continuity and uniform continuity. A function F is absolutely continuous on [a,b] if for every ε > 0 there exists δ > 0 such that for any finite collection of pairwise disjoint subintervals with total length less than δ, the total variation is less than ε. This controls total variation on small sets, not just pointwise oscillation. The formalization uses Fin n-indexed families for the finite collections.",
+    "mathContext": "For all $\\varepsilon > 0$, $\\exists\\, \\delta > 0$ s.t. $\\sum_{k=1}^n (b_k - a_k) < \\delta \\implies \\sum_{k=1}^n |F(b_k) - F(a_k)| < \\varepsilon$ for disjoint $(a_k, b_k) \\subseteq [a,b]$.",
+    "significance": "key",
+    "relatedConcepts": ["absolute continuity", "bounded variation", "Lipschitz continuity", "uniform continuity", "total variation"],
+    "prerequisites": ["real analysis", "metric spaces", "Fin type in Lean"]
+  },
+  {
+    "id": "ann-ftc-leb-lipschitz-ac",
+    "proofId": "fundamental-theorem-calculus-oq-01",
+    "range": { "startLine": 86, "endLine": 102 },
+    "type": "technique",
+    "title": "Lipschitz Implies Absolutely Continuous",
+    "content": "Proves that K-Lipschitz functions are absolutely continuous by choosing δ = ε/(K+1). The Lipschitz condition |F(x) - F(y)| ≤ K|x - y| bounds each term in the variation sum, giving Σ|F(bₖ) - F(aₖ)| ≤ K · Σ(bₖ - aₖ) < K · ε/(K+1) < ε. The sorry is for the final arithmetic chain. This establishes the top of the continuity hierarchy: Lipschitz → AC → uniformly continuous → continuous.",
+    "mathContext": "If $|F(x) - F(y)| \\le K|x - y|$, choose $\\delta = \\varepsilon/(K+1)$. Then $\\sum |F(b_k) - F(a_k)| \\le K \\sum (b_k - a_k) < K \\cdot \\varepsilon/(K+1) < \\varepsilon$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lipschitz continuity", "contraction mapping", "Rademacher's theorem"],
+    "prerequisites": ["Lipschitz functions", "Finset.sum inequalities"]
+  },
+  {
+    "id": "ann-ftc-leb-ac-unif-cont",
+    "proofId": "fundamental-theorem-calculus-oq-01",
+    "range": { "startLine": 108, "endLine": 123 },
+    "type": "technique",
+    "title": "AC Implies Uniformly Continuous",
+    "content": "Proves that absolutely continuous functions are uniformly continuous by instantiating the AC definition with a single interval (n=1). For any ε > 0, AC provides δ > 0 such that any single interval of length less than δ has variation less than ε, which is exactly uniform continuity. The sorry is purely technical: instantiating Fin 1 and extracting the single-interval case.",
+    "mathContext": "Take $n = 1$, $(a_1, b_1) = (x, y)$ with $|x - y| < \\delta$. AC gives $|F(x) - F(y)| < \\varepsilon$.",
+    "significance": "supporting",
+    "relatedConcepts": ["uniform continuity", "Heine-Cantor theorem", "equicontinuity"],
+    "prerequisites": ["Fin 1 specialization", "AC definition"]
+  },
+  {
+    "id": "ann-ftc-leb-ftc-part1",
+    "proofId": "fundamental-theorem-calculus-oq-01",
+    "range": { "startLine": 129, "endLine": 145 },
+    "type": "concept",
+    "title": "Lebesgue FTC Part 1: A.E. Differentiability of AC Functions",
+    "content": "States as an axiom that absolutely continuous functions are differentiable almost everywhere. The proof path is: AC → BV (bounded variation) → Jordan decomposition as difference of two monotone functions → each monotone function is a.e. differentiable by Lebesgue's theorem (which uses the Vitali covering lemma). Mathlib already has Monotone.ae_differentiableAt and VitaliFamily infrastructure, so the main gaps are AC → BV and Jordan decomposition.",
+    "mathContext": "If $F$ is AC on $[a,b]$, then $\\exists\\, S \\subseteq (a,b)$ measurable with $\\mu((a,b) \\setminus S) = 0$ such that $F$ is differentiable at every $x \\in S$.",
+    "significance": "key",
+    "relatedConcepts": ["Lebesgue differentiation theorem", "Vitali covering lemma", "bounded variation", "Jordan decomposition", "Radon-Nikodym theorem"],
+    "prerequisites": ["measure theory", "Vitali covering families", "monotone function theory"]
+  },
+  {
+    "id": "ann-ftc-leb-ftc-part2",
+    "proofId": "fundamental-theorem-calculus-oq-01",
+    "range": { "startLine": 147, "endLine": 163 },
+    "type": "concept",
+    "title": "Lebesgue FTC Part 2: Integral Recovery",
+    "content": "States as an axiom that the Lebesgue integral of the a.e. derivative of an AC function recovers the net change. This is the deepest result: it says absolute continuity is not only sufficient but precisely the right condition for the fundamental theorem to hold with the Lebesgue integral. The classical FTC (integral_eq_sub_of_hasDerivAt) requires differentiability everywhere, while this version requires only a.e. differentiability plus absolute continuity.",
+    "mathContext": "$\\int_a^b F'(x)\\, dx = F(b) - F(a)$ where $F' = \\operatorname{deriv} F$ is the a.e. derivative.",
+    "significance": "key",
+    "relatedConcepts": ["Newton-Leibniz formula", "Henstock-Kurzweil integral", "Radon-Nikodym derivative", "absolute continuity of measures"],
+    "prerequisites": ["Lebesgue integration", "a.e. differentiability", "absolute continuity"]
+  },
+  {
+    "id": "ann-ftc-leb-classical-special-case",
+    "proofId": "fundamental-theorem-calculus-oq-01",
+    "range": { "startLine": 169, "endLine": 176 },
+    "type": "insight",
+    "title": "Classical FTC as Special Case",
+    "content": "Shows that the classical FTC follows immediately from the Lebesgue FTC: if F is continuously differentiable then F is Lipschitz (on a compact interval), hence AC, so the Lebesgue FTC applies. This is a one-line proof by applying lebesgue_ftc_integral. It demonstrates the strictly greater generality of the Lebesgue version: every C^1 function satisfies the hypotheses, but so do much rougher functions like the antiderivatives of L^1 functions.",
+    "mathContext": "If $F \\in C^1([a,b])$, then $F$ is Lipschitz $\\Rightarrow$ AC $\\Rightarrow \\int_a^b F'(x)\\,dx = F(b) - F(a)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["classical FTC", "C^1 regularity", "smooth analysis"],
+    "prerequisites": ["Lipschitz → AC implication", "Lebesgue FTC axiom"]
+  },
+  {
+    "id": "ann-ftc-leb-cantor-counterexample",
+    "proofId": "fundamental-theorem-calculus-oq-01",
+    "range": { "startLine": 178, "endLine": 200 },
+    "type": "insight",
+    "title": "Cantor Function Counterexample",
+    "content": "States that the Cantor function (devil's staircase) is continuous, monotone on [0,1] with F(0)=0, F(1)=1, yet not absolutely continuous. This is the canonical counterexample showing AC is necessary for the Lebesgue FTC: the Cantor function has derivative 0 almost everywhere (on the complement of the Cantor set), so ∫₀¹ F'(x)dx = 0 ≠ 1 = F(1) - F(0). The sorry is for the actual construction, which requires the iterated middle-thirds removal.",
+    "mathContext": "The Cantor function $F: [0,1] \\to [0,1]$ satisfies $F' = 0$ a.e., yet $\\int_0^1 F'(x)\\,dx = 0 \\neq 1 = F(1) - F(0)$. Therefore $F \\notin AC([0,1])$.",
+    "significance": "key",
+    "relatedConcepts": ["Cantor set", "singular measures", "devil's staircase", "measure zero", "Cantor-Lebesgue function"],
+    "prerequisites": ["Cantor set construction", "measure zero sets", "monotone functions"]
+  },
+  {
+    "id": "ann-ftc-leb-monotone-ae-diff",
+    "proofId": "fundamental-theorem-calculus-oq-01",
+    "range": { "startLine": 206, "endLine": 212 },
+    "type": "context",
+    "title": "Monotone A.E. Differentiability from Mathlib",
+    "content": "Re-exports Mathlib's Monotone.ae_differentiableAt: every monotone function ℝ → ℝ is differentiable at almost every point. This is Lebesgue's 1904 theorem and one of the foundational results of real analysis. It is a key building block for the Lebesgue FTC: once an AC function is decomposed via Jordan decomposition into a difference of monotone functions, each is a.e. differentiable by this theorem.",
+    "mathContext": "If $f: \\mathbb{R} \\to \\mathbb{R}$ is monotone, then $f$ is differentiable $\\mu$-a.e., i.e., $\\forall^{\\text{ae}}\\, x,\\, \\exists\\, f'(x)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lebesgue's theorem on monotone functions", "rising sun lemma", "Dini derivatives"],
+    "prerequisites": ["Mathlib Monotone type", "ae_differentiableAt"]
+  },
+  {
+    "id": "ann-ftc-leb-vitali-density",
+    "proofId": "fundamental-theorem-calculus-oq-01",
+    "range": { "startLine": 214, "endLine": 223 },
+    "type": "context",
+    "title": "Vitali Family and Lebesgue Density from Mathlib",
+    "content": "Notes the existence of VitaliFamily and the Lebesgue density theorem in Mathlib. The Vitali covering theorem provides the abstract framework for differentiating measures: it says that 'good' covers of a set can be refined to essentially disjoint subcovers. The Lebesgue density theorem then shows μ(S ∩ B(x,r))/μ(B(x,r)) → 1_S(x) for a.e. x, which is used in proving monotone a.e. differentiability.",
+    "mathContext": "Lebesgue density: $\\lim_{r \\to 0} \\frac{\\mu(S \\cap B(x,r))}{\\mu(B(x,r))} = \\mathbf{1}_S(x)$ for $\\mu$-a.e. $x$.",
+    "significance": "technical",
+    "relatedConcepts": ["Vitali covering lemma", "Besicovitch covering theorem", "differentiation of measures", "Lebesgue points"],
+    "prerequisites": ["Vitali families in Mathlib", "measure differentiation"]
+  }
+]

--- a/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
@@ -12,6 +12,7 @@
       "lebesgue-integral",
       "open-question"
     ],
+    "proofRepoPath": "Proofs/FundamentalTheoremCalculusLebesgue.lean",
     "badge": "axiom",
     "sorries": 2,
     "axiomCount": 2,
@@ -42,38 +43,81 @@
     "dateAdded": "03/22/26"
   },
   "overview": {
-    "historicalContext": "The classical FTC of Newton-Leibniz requires the integrand to be continuous or the antiderivative to be differentiable everywhere. Lebesgue's generalization (early 20th century) shows that absolute continuity is the precise condition: AC functions are exactly those for which the FTC holds with the Lebesgue integral.",
-    "problemStatement": "If F : [a,b] → ℝ is absolutely continuous, then F is differentiable almost everywhere, F' is Lebesgue integrable, and ∫ₐᵇ F'(x)dx = F(b) - F(a).",
-    "proofStrategy": "Define AC functions, state the Lebesgue FTC as axioms, connect to Mathlib's existing infrastructure (Vitali families, Lebesgue density theorem, monotone a.e. differentiability). The proof path: AC → BV → Jordan decomposition → monotone a.e. differentiability → integral recovery.",
+    "historicalContext": "The Fundamental Theorem of Calculus in its classical Newton-Leibniz form (late 17th century) assumes the integrand is continuous. Throughout the 19th century, mathematicians including Cauchy, Riemann, and Darboux progressively weakened the hypotheses, but the question of the *minimal* regularity for the FTC remained open. Henri Lebesgue's 1904 thesis 'Leçons sur l'intégration et la recherche des fonctions primitives' introduced the concept of absolute continuity and proved that it is the *precise* necessary and sufficient condition: a function F satisfies ∫ₐᵇ F'(x)dx = F(b) - F(a) with the Lebesgue integral if and only if F is absolutely continuous. The sharpness of this characterization was demonstrated by the Cantor function (devil's staircase), constructed by Georg Cantor in 1884: a continuous, monotone function on [0,1] whose derivative is zero almost everywhere, yet whose net change is 1. Vitali (1905) independently arrived at similar results, and the modern proof uses the Vitali covering lemma as a key tool. The connection between absolute continuity of functions and absolute continuity of measures (via the Radon-Nikodym theorem) was later clarified by Nikodym (1930).",
+    "problemStatement": "If $F : [a,b] \\to \\mathbb{R}$ is absolutely continuous, then $F$ is differentiable almost everywhere, $F'$ is Lebesgue integrable, and $\\int_a^b F'(x)\\,dx = F(b) - F(a)$.",
+    "proofStrategy": "The formalization defines absolutely continuous functions using Fin n-indexed families of disjoint subintervals, states the Lebesgue FTC as two axioms (a.e. differentiability and integral recovery), and connects to Mathlib's existing infrastructure. The intended proof path for the axioms is: AC → BV (total variation bound from the AC definition with a single ε) → Jordan decomposition as difference of monotone functions → apply Mathlib's Monotone.ae_differentiableAt to each → integral recovery using the Vitali covering lemma and Lebesgue differentiation theorem (both available in Mathlib).",
     "keyInsights": [
-      "AC is strictly between Lipschitz and uniform continuity",
-      "The Cantor function shows AC is necessary (continuous, monotone, F'=0 a.e., but ∫F'≠F(b)-F(a))",
-      "Mathlib has the key building blocks: Vitali families, density theorem, monotone differentiability"
+      "Absolute continuity sits strictly between Lipschitz continuity and uniform continuity in the regularity hierarchy: Lipschitz → AC → uniformly continuous → continuous, with each implication strict",
+      "The Cantor function (devil's staircase) is the canonical counterexample proving AC is necessary: it is continuous and monotone with F' = 0 a.e., yet ∫₀¹ F'(x)dx = 0 ≠ 1 = F(1) - F(0)",
+      "The AC condition controls total variation on sets of small measure, not just oscillation at individual points — this is what distinguishes it from uniform continuity and makes it the right condition for integration",
+      "Mathlib already contains the hardest building blocks (Vitali covering families, Lebesgue density theorem, monotone a.e. differentiability), so the main gap is AC → BV and Jordan decomposition",
+      "Absolute continuity of functions is intimately connected to absolute continuity of measures: F is AC iff the signed measure dF is absolutely continuous with respect to Lebesgue measure, and F' is its Radon-Nikodym derivative"
     ]
   },
   "sections": [
     {
-      "id": "ac-definition",
-      "title": "Parts I-III: AC Functions",
+      "id": "imports-and-docstring",
+      "title": "Imports and Module Documentation",
       "startLine": 1,
-      "endLine": 140,
-      "summary": "Definition of AbsolutelyContinuousOn, proof that Lipschitz implies AC, proof that AC implies uniformly continuous."
+      "endLine": 51,
+      "summary": "Imports from Mathlib (interval integrals, Bochner FTC, Vitali families, differentiation, Stieltjes measures, bounded variation, derivatives, Lipschitz) and module-level documentation explaining the Lebesgue FTC and its relationship to the classical version."
     },
     {
-      "id": "lebesgue-ftc",
-      "title": "Parts IV-VI: Lebesgue FTC and Consequences",
-      "startLine": 140,
-      "endLine": 260,
-      "summary": "Lebesgue FTC axioms (a.e. differentiability and integral identity), classical FTC as special case, Cantor function counterexample, Mathlib connections."
+      "id": "ac-definition",
+      "title": "Part I: Absolutely Continuous Functions",
+      "startLine": 55,
+      "endLine": 80,
+      "summary": "Defines AbsolutelyContinuousOn using Fin n-indexed families of pairwise disjoint subintervals. The definition captures the key property that AC controls total variation on collections of intervals with small total length, placing it strictly between Lipschitz and uniform continuity."
+    },
+    {
+      "id": "lipschitz-implies-ac",
+      "title": "Part II: Lipschitz Implies AC",
+      "startLine": 82,
+      "endLine": 102,
+      "summary": "Proves that K-Lipschitz functions are absolutely continuous by choosing δ = ε/(K+1). The Lipschitz bound on each interval gives total variation ≤ K times total length, which is less than ε. Contains one sorry for the final arithmetic chain."
+    },
+    {
+      "id": "ac-implies-uniform",
+      "title": "Part III: AC Implies Uniformly Continuous",
+      "startLine": 104,
+      "endLine": 123,
+      "summary": "Proves AC implies uniform continuity by instantiating the AC definition with a single interval (n=1). Contains one sorry for the technical Fin 1 specialization."
+    },
+    {
+      "id": "lebesgue-ftc-axioms",
+      "title": "Part IV: Lebesgue FTC Axioms",
+      "startLine": 125,
+      "endLine": 163,
+      "summary": "States the two core axioms of the Lebesgue FTC: (1) AC functions are a.e. differentiable (via AC → BV → monotone decomposition → Lebesgue's theorem), and (2) the Lebesgue integral of the a.e. derivative recovers the function's net change."
+    },
+    {
+      "id": "consequences",
+      "title": "Part V: Consequences and Counterexamples",
+      "startLine": 165,
+      "endLine": 200,
+      "summary": "Derives the classical FTC as a one-line corollary of the Lebesgue FTC (C^1 → Lipschitz → AC). States the Cantor function counterexample: a continuous monotone function on [0,1] that is NOT AC, proving AC is a necessary hypothesis."
+    },
+    {
+      "id": "mathlib-connections",
+      "title": "Part VI: Mathlib Infrastructure",
+      "startLine": 202,
+      "endLine": 252,
+      "summary": "Re-exports key Mathlib results that form the building blocks for a full proof: Monotone.ae_differentiableAt (Lebesgue's 1904 theorem on monotone functions), VitaliFamily (abstract differentiation framework), and the Lebesgue density theorem."
     }
   ],
   "conclusion": {
-    "summary": "Formalizes the key definitions and statements for the Lebesgue FTC, connecting to Mathlib's measure theory infrastructure.",
-    "implications": "Completing the axioms would establish the full Lebesgue FTC in Lean 4.",
+    "summary": "This formalization establishes the key definitions and statements for the Lebesgue generalization of the FTC in Lean 4. It introduces AbsolutelyContinuousOn (not yet in Mathlib), proves the regularity hierarchy Lipschitz → AC → uniformly continuous, states the Lebesgue FTC as axioms, demonstrates the classical FTC as a corollary, and provides the Cantor function counterexample showing AC is necessary. The formalization connects to Mathlib's Vitali covering families, Lebesgue density theorem, and monotone a.e. differentiability.",
+    "implications": "Completing the two axioms would establish the full Lebesgue FTC in Lean 4, filling a significant gap in Mathlib's real analysis library. The AbsolutelyContinuousOn definition could be contributed upstream to Mathlib, where it would complement the existing MeasureTheory.Measure.AbsolutelyContinuous for measures. This would also enable formalizing the Radon-Nikodym theorem for functions (connecting function-level AC to measure-level AC) and advanced results in Sobolev space theory where AC is a key regularity condition.",
     "openQuestions": [
-      "Can AC → BV be proved directly from the AC definition?",
-      "Does Mathlib's Jordan decomposition suffice for the BV → monotone step?",
-      "Can the integral recovery be proved using Vitali + density theorem?"
+      "Can AC → BV be proved directly from the ε-δ definition, or does it require additional Mathlib infrastructure for total variation?",
+      "Does Mathlib's current Jordan decomposition for signed measures extend to functions of bounded variation in a way that yields the monotone decomposition needed here?",
+      "Can the integral recovery step (Part 2 axiom) be derived from Vitali covering + Lebesgue differentiation, or does it require additional machinery (e.g., Radon-Nikodym)?",
+      "Should AbsolutelyContinuousOn be generalized to functions between normed spaces, or is the ℝ → ℝ case sufficient for Mathlib?"
     ]
-  }
+  },
+  "relatedProofs": [
+    "fundamental-theorem-calculus",
+    "lebesgue-measure",
+    "cauchy-schwarz-integral"
+  ]
 }

--- a/src/data/research/problems/inclusion-exclusion-oq-03.json
+++ b/src/data/research/problems/inclusion-exclusion-oq-03.json
@@ -1,0 +1,85 @@
+{
+  "slug": "inclusion-exclusion-oq-03",
+  "title": "Efficient Inclusion-Exclusion Computation",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-03-21T21:14:00-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: inclusion-exclusion-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "inclusion-exclusion"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-22T04:19:59.477Z",
+  "lastUpdate": "2026-03-22T04:19:59.494Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/InclusionExclusion.lean",
+      "filename": "InclusionExclusion.lean",
+      "lineCount": 219,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusion.lean"
+    },
+    {
+      "path": "Proofs/InclusionExclusionGeneral.lean",
+      "filename": "InclusionExclusionGeneral.lean",
+      "lineCount": 277,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionGeneral.lean"
+    },
+    {
+      "path": "Proofs/InclusionExclusionOQ01.lean",
+      "filename": "InclusionExclusionOQ01.lean",
+      "lineCount": 383,
+      "theoremCount": 41,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionOQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Enrichment pass for `fundamental-theorem-calculus-oq-01` (quality 32 → enriched, 0 prior passes).

- Created `annotations.json` with 9 annotations covering all 6 parts of the Lean file
- All annotations include `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`
- Deepened `historicalContext` from ~270 chars to ~950 chars with real dates and mathematicians (Lebesgue 1904, Cantor 1884, Vitali 1905, Nikodym 1930)
- Expanded `keyInsights` from 3 to 5 entries (AC vs uniform continuity distinction, Radon-Nikodym connection)
- Refined `sections` from 2 coarse blocks to 7 granular sections matching the Lean file's Parts I-VI + imports
- Enriched `conclusion` with substantive implications (Mathlib upstream contribution, Sobolev spaces) and 4 open questions
- Added `relatedProofs` cross-references to `fundamental-theorem-calculus`, `lebesgue-measure`, `cauchy-schwarz-integral`
- Added missing `proofRepoPath` field

## Test plan

- [x] `meta.json` validates as JSON
- [x] `annotations.json` validates as JSON
- [x] `pnpm annotations:build` passes for this entry (no errors)