### PR TITLE
Enrich 5 entries: abel-ruffini, borsuk-ulam, szemeredi-regularity, roth-theorem

### DIFF
--- a/src/data/proofs/roth-theorem-k3/annotations.json
+++ b/src/data/proofs/roth-theorem-k3/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "roth-theorem-k3",
+    "range": { "startLine": 1, "endLine": 15 },
+    "type": "context",
+    "title": "Module Overview and Historical Credits",
+    "content": "Documents the four-part structure of the formalization and imports full Mathlib. Credits Roth (1953) for the original proof, Bourgain (1999) for improved bounds, and Bloom-Sisask (2020) for the near-optimal result. The Fourier-analytic approach introduced by Roth was revolutionary — before this, additive combinatorics relied primarily on combinatorial/ergodic methods. Roth's method showed that harmonic analysis could yield quantitative bounds in number-theoretic problems.",
+    "mathContext": "$r_3(N) = \\max\\{|A| : A \\subseteq [N],\\; A \\text{ AP-free}\\} = o(N)$",
+    "significance": "supporting",
+    "relatedConcepts": ["Fourier analysis", "density increment", "arithmetic progressions"],
+    "prerequisites": ["additive combinatorics", "harmonic analysis"]
+  },
+  {
+    "id": "ann-apfree-def",
+    "proofId": "roth-theorem-k3",
+    "range": { "startLine": 19, "endLine": 39 },
+    "type": "definition",
+    "title": "AP-Free Sets: Definition and Basic Properties",
+    "content": "Defines `APFree A` for $A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$: the set contains no 3-term arithmetic progression $a, a+d, a+2d$ with $d \\neq 0$. Working in $\\mathbb{Z}/N\\mathbb{Z}$ (cyclic group) rather than $[N]$ simplifies the Fourier analysis — roots of unity are naturally defined on cyclic groups. The empty set and singletons are proved AP-free as base cases. The singleton proof uses the key observation that if $a$ and $a+d$ are both $x$, then $d = 0$, contradicting the non-degeneracy condition.",
+    "mathContext": "$A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$ is AP-free: $\\forall a, d \\in \\mathbb{Z}/N\\mathbb{Z},\\; d \\neq 0 \\implies \\neg(a \\in A \\wedge a+d \\in A \\wedge a+2d \\in A)$.",
+    "significance": "key",
+    "relatedConcepts": ["arithmetic progressions", "cap sets", "Salem-Spencer sets"],
+    "prerequisites": ["modular arithmetic", "finite sets"]
+  },
+  {
+    "id": "ann-fourier",
+    "proofId": "roth-theorem-k3",
+    "range": { "startLine": 41, "endLine": 58 },
+    "type": "technique",
+    "title": "Fourier Analysis on Z/NZ: Large Coefficient from AP-Freeness",
+    "content": "Defines `fourierCoeff A r` as the discrete Fourier transform of the characteristic function $1_A$ at frequency $r$: $\\hat{1_A}(r) = \\sum_{x \\in A} e^{2\\pi i rx/N}$. The theorem `fourier_large_coefficient` states the key analytic step: if $A$ has density $\\delta$ and is AP-free, then some non-zero Fourier coefficient has magnitude at least $\\delta^2 N / 2$. The proof (sorry'd) uses the identity relating 3-AP count to Fourier coefficients: $\\Lambda_3(A) = N^{-1} \\sum_r |\\hat{1_A}(r)|^2 \\hat{1_A}(-2r)$. If $\\Lambda_3(A) = 0$ (AP-free) and $\\hat{1_A}(0) = |A| = \\delta N$ is large, the non-zero coefficients must compensate.",
+    "mathContext": "$\\hat{1_A}(r) = \\sum_{x \\in A} e^{2\\pi i rx/N}$. 3-AP count: $\\Lambda_3(A) = N^{-1} \\sum_r |\\hat{1_A}(r)|^2 \\hat{1_A}(-2r)$. Parseval: $\\sum_r |\\hat{1_A}(r)|^2 = N|A|$.",
+    "significance": "key",
+    "relatedConcepts": ["discrete Fourier transform", "Parseval's identity", "exponential sums", "Roth's method"],
+    "prerequisites": ["complex analysis", "Fourier analysis", "roots of unity"]
+  },
+  {
+    "id": "ann-density-increment",
+    "proofId": "roth-theorem-k3",
+    "range": { "startLine": 60, "endLine": 73 },
+    "type": "technique",
+    "title": "Density Increment Lemma: The Core Inductive Step",
+    "content": "States the density increment lemma: if $A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$ has density $\\delta$ and is AP-free, then there exists a subprogression of length $\\geq \\sqrt{N}$ where $A$ has density $\\geq \\delta + \\delta^2/100$. This is the heart of Roth's proof. A large Fourier coefficient at frequency $r$ means $A$ correlates with the character $e^{2\\pi i rx/N}$, which restricts to a constant on arithmetic progressions with common difference coprime to $r$. By pigeonhole, $A$ has increased density on one such progression. The $\\delta^2/100$ increment and $\\sqrt{N}$ length are not optimal but suffice for the asymptotic result.",
+    "mathContext": "AP-free + density $\\delta$ on $\\mathbb{Z}/N\\mathbb{Z}$ $\\implies$ density $\\geq \\delta + \\delta^2/100$ on some AP of length $\\geq \\sqrt{N}$.",
+    "significance": "key",
+    "relatedConcepts": ["density increment", "arithmetic progressions", "pigeonhole principle", "character sums"],
+    "prerequisites": ["Fourier analysis", "arithmetic progressions"]
+  },
+  {
+    "id": "ann-roth-main",
+    "proofId": "roth-theorem-k3",
+    "range": { "startLine": 75, "endLine": 92 },
+    "type": "insight",
+    "title": "Roth's Theorem: r₃(N) = o(N)",
+    "content": "The main theorem: for every $\\delta > 0$, sufficiently large AP-free subsets of $[N]$ do not exist. The proof iterates the density increment: starting with density $\\delta$, each application of the density increment increases density by $\\Omega(\\delta^2)$ on a subprogression of length $\\geq \\sqrt{N}$. After $O(1/\\delta)$ iterations, the density exceeds 1 — impossible. The subprogression length decreases (from $N$ to $\\sqrt{N}$ to $N^{1/4}$ etc.), but as long as it remains $> 1$, the argument continues. The bound $N_0$ depends on $\\delta$: one needs $N$ large enough that $O(1/\\delta)$ squarings still leave a positive length.",
+    "mathContext": "$\\forall \\delta > 0,\\; \\exists N_0$: $\\forall N \\geq N_0,\\; |A| \\geq \\delta N \\implies A$ contains a 3-AP. Equivalently: $r_3(N)/N \\to 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Szemer\u00e9di's theorem", "density Hales-Jewett", "Green-Tao theorem"],
+    "prerequisites": ["density increment", "iteration arguments"]
+  }
+]

--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -57,46 +57,12 @@
     ]
   },
   "sections": [
-    {
-      "id": "introduction",
-      "title": "Module Docstring and Imports",
-      "startLine": 1,
-      "endLine": 16,
-      "summary": "Overview of Roth's theorem formalization covering AP-free set definitions, Fourier analysis framework, density increment lemma, and the main r_3(N) = o(N) result.",
-      "mathContext": "Every dense subset of [N] contains a 3-term arithmetic progression."
-    },
-    {
-      "id": "ap-free-sets",
-      "title": "Part I: AP-Free Set Definitions",
-      "startLine": 18,
-      "endLine": 40,
-      "summary": "Definition of AP-free subsets of Fin N and basic properties. A set is AP-free if it contains no a, a+d, a+2d with d > 0.",
-      "mathContext": "$A$ is AP-free if $\\forall a, d > 0: \\{a, a+d, a+2d\\} \\not\\subseteq A$"
-    },
-    {
-      "id": "fourier-coefficient",
-      "title": "Part II: Fourier Analysis on Z/NZ",
-      "startLine": 42,
-      "endLine": 65,
-      "summary": "Fourier coefficient of a set and the key identity connecting large Fourier coefficients to arithmetic structure.",
-      "mathContext": "$\\hat{1_A}(r) = \\sum_{x \\in A} e^{2\\pi i r x / N}$"
-    },
-    {
-      "id": "density-increment",
-      "title": "Part III: Density Increment Lemma",
-      "startLine": 67,
-      "endLine": 90,
-      "summary": "If a dense set has no 3-AP, it has increased density on a long subprogression. The key inductive step of Roth's proof.",
-      "mathContext": "No 3-AP + density $\\delta$ implies density $\\delta + \\Omega(\\delta^2)$ on a subprogression"
-    },
-    {
-      "id": "main-theorem",
-      "title": "Part IV: Roth's Theorem (Main Result)",
-      "startLine": 92,
-      "endLine": 110,
-      "summary": "The main theorem: r_3(N) = o(N). Proved by iterating the density increment until density exceeds 1.",
-      "mathContext": "$r_3(N) = o(N)$: AP-free subsets of $[N]$ have vanishing density"
-    }
+    {"id": "docstring", "title": "Module Docstring and Imports", "startLine": 1, "endLine": 15, "summary": "Documents four-part structure. Credits Roth (1953), Bourgain (1999), Bloom-Sisask (2020). Imports full Mathlib."},
+    {"id": "setup", "title": "Namespace and Setup", "startLine": 17, "endLine": 17, "summary": "Opens the Szemeredi.Roth namespace for the formalization."},
+    {"id": "ap-free", "title": "AP-Free Set Definitions", "startLine": 19, "endLine": 39, "summary": "Defines APFree on Z/NZ. Proves empty set and singletons are AP-free (0 sorries)."},
+    {"id": "fourier", "title": "Fourier Analysis on Z/NZ", "startLine": 41, "endLine": 58, "summary": "Defines fourierCoeff via discrete exponential sums. States fourier_large_coefficient (1 sorry)."},
+    {"id": "increment", "title": "Density Increment Lemma", "startLine": 60, "endLine": 73, "summary": "States density_increment_lemma: AP-free + density δ implies density δ + δ²/100 on subprogression (1 sorry)."},
+    {"id": "main", "title": "Roth's Theorem (Main Result)", "startLine": 75, "endLine": 92, "summary": "States roth_density_bound: r₃(N) = o(N) via iterated density increment (1 sorry)."}
   ],
   "crossReferences": [
     {
@@ -129,5 +95,14 @@
     "szemeredi-regularity",
     "szemeredi-full",
     "prob-method-expectation"
-  ]
+  ],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "Szemeredi.Roth",
+    "lineCount": 92,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 2
+  }
 }


### PR DESCRIPTION
## Summary
Enrichment pass for 4 gallery entries:

### abel-ruffini-oq-04 (quality 33→~80)
- 8 annotations, historicalContext 330→1141 chars, 5 keyInsights, 2 crossRefs

### borsuk-ulam-oq-03-oq-01-oq-01 (quality 36→~80)
- 9 annotations, historicalContext 350→1017 chars, 5 keyInsights, 4 crossRefs

### szemeredi-regularity (quality 43→~80)
- Created 8 annotations, expanded sections 4→8, added leanFile

### roth-theorem-k3 (quality 45→~80)
- Created 5 annotations, fixed section line ranges, added leanFile

## Axiom integrity
All entries verified: correct status/badge/axiomCount fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)