### PR TITLE
Enrich 4 entries: schema fixes and new annotations

### DIFF
--- a/src/data/proofs/erdos-4/annotations.json
+++ b/src/data/proofs/erdos-4/annotations.json
@@ -2,253 +2,460 @@
   {
     "id": "ann-e4-nthprime",
     "proofId": "erdos-4",
-    "range": { "startLine": 33, "endLine": 34 },
+    "range": {
+      "startLine": 33,
+      "endLine": 34
+    },
     "type": "definition",
     "title": "n-th Prime",
     "content": "**nthPrime n** is the $n$-th prime (0-indexed: $p_0 = 2, p_1 = 3, p_2 = 5, \\ldots$). Uses `Nat.nth` to enumerate elements satisfying `Nat.Prime`.",
     "significance": "key",
     "mathContext": "The $n$-th prime function $p_n$ is the fundamental enumeration of primes. By the Prime Number Theorem, $p_n \\sim n \\log n$. The `Nat.nth` function from Mathlib picks the $n$-th element from any decidable predicate on ℕ, here applied to `Nat.Prime`. This enumeration is noncomputable in Lean since primality testing, while decidable, requires unbounded search in the general `nth` framework.",
-    "relatedConcepts": ["Prime Number Theorem", "Nat.nth", "prime enumeration"],
-    "prerequisites": ["Nat.Prime", "Nat.nth"]
+    "relatedConcepts": [
+      "Prime Number Theorem",
+      "Nat.nth",
+      "prime enumeration"
+    ],
+    "prerequisites": [
+      "Nat.Prime",
+      "Nat.nth"
+    ]
   },
   {
     "id": "ann-e4-primegap",
     "proofId": "erdos-4",
-    "range": { "startLine": 36, "endLine": 37 },
+    "range": {
+      "startLine": 36,
+      "endLine": 37
+    },
     "type": "definition",
     "title": "Prime Gap",
     "content": "**primeGap n** = $p_{n+1} - p_n$, the gap between the $n$-th and $(n+1)$-th primes. The central object of Erdős Problem #4.",
-    "significance": "critical",
+    "significance": "key",
     "mathContext": "Prime gaps $g_n = p_{n+1} - p_n$ have been studied since Euclid. By the Prime Number Theorem, the average gap is $\\sim \\log p_n$. The twin prime conjecture asserts $g_n = 2$ infinitely often. Zhang (2013) proved $g_n \\leq 70{,}000{,}000$ infinitely often, improved by Maynard/Polymath to $g_n \\leq 246$. Problem #4 concerns the opposite extreme: how LARGE can $g_n$ be? The subtraction is well-defined in ℕ since primes are strictly increasing, so $p_{n+1} > p_n$ always.",
-    "relatedConcepts": ["twin prime conjecture", "Zhang's theorem", "Polymath 8", "maximal prime gaps"],
-    "prerequisites": ["nthPrime"]
+    "relatedConcepts": [
+      "twin prime conjecture",
+      "Zhang's theorem",
+      "Polymath 8",
+      "maximal prime gaps"
+    ],
+    "prerequisites": [
+      "nthPrime"
+    ]
   },
   {
     "id": "ann-e4-lg",
     "proofId": "erdos-4",
-    "range": { "startLine": 41, "endLine": 42 },
+    "range": {
+      "startLine": 41,
+      "endLine": 42
+    },
     "type": "definition",
     "title": "Natural Logarithm",
     "content": "**lg x** = $\\log(x)$, the natural logarithm. Wrapper around `Real.log` for notational convenience.",
     "significance": "supporting",
     "mathContext": "The natural logarithm appears throughout prime number theory. The Prime Number Theorem states $\\pi(x) \\sim x/\\log x$. The iterated logarithms $\\log\\log n$, $\\log\\log\\log n$, etc. appear in refined asymptotics for prime gaps because the sieve of Eratosthenes involves $\\log\\log$ factors (Mertens' theorem: $\\sum_{p \\leq x} 1/p \\sim \\log\\log x$).",
-    "relatedConcepts": ["Real.log", "Prime Number Theorem", "Mertens' theorem"],
-    "prerequisites": ["Real.log"]
+    "relatedConcepts": [
+      "Real.log",
+      "Prime Number Theorem",
+      "Mertens' theorem"
+    ],
+    "prerequisites": [
+      "Real.log"
+    ]
   },
   {
     "id": "ann-e4-lg234",
     "proofId": "erdos-4",
-    "range": { "startLine": 44, "endLine": 51 },
+    "range": {
+      "startLine": 44,
+      "endLine": 51
+    },
     "type": "definition",
     "title": "Iterated Logarithms",
     "content": "**lg2, lg3, lg4** = $\\log\\log x$, $\\log\\log\\log x$, $\\log\\log\\log\\log x$. These appear in the Erdős gap function.",
     "significance": "key",
     "mathContext": "Iterated logarithms arise naturally in prime gap theory from the structure of sieve methods. The connection: Rankin's method constructs large gaps by sieving an interval $[m+1, m+d]$ of all small prime residues. The number of primes $\\leq y$ available for sieving is $\\pi(y) \\sim y/\\log y$, and optimizing over the sieve parameter $y$ introduces iterated logs. Specifically, sieving with primes up to $n^{1/\\log\\log n}$ removes all composites except those with all prime factors $> n^{1/\\log\\log n}$, and the count of surviving integers involves $\\log\\log\\log n$ and $\\log\\log\\log\\log n$.",
-    "relatedConcepts": ["sieve methods", "Rankin's method", "sieve parameter optimization"],
-    "prerequisites": ["lg"]
+    "relatedConcepts": [
+      "sieve methods",
+      "Rankin's method",
+      "sieve parameter optimization"
+    ],
+    "prerequisites": [
+      "lg"
+    ]
   },
   {
     "id": "ann-e4-erdosfunc",
     "proofId": "erdos-4",
-    "range": { "startLine": 55, "endLine": 62 },
+    "range": {
+      "startLine": 55,
+      "endLine": 62
+    },
     "type": "definition",
     "title": "Erdős Function",
     "content": "**erdosFunction n** = $\\frac{\\log\\log n \\cdot \\log\\log\\log\\log n}{(\\log\\log\\log n)^2} \\cdot \\log n$. The target lower bound for large prime gaps in Problem #4.",
-    "significance": "critical",
+    "significance": "key",
     "mathContext": "This function arises from Rankin's sieve construction optimized over all parameters. The $\\log n$ factor is the 'base' average gap. The ratio $\\frac{\\log\\log n \\cdot \\log\\log\\log\\log n}{(\\log\\log\\log n)^2}$ is the 'amplification factor' that Rankin's method achieves beyond the average. It grows to $\\infty$ but very slowly — for $n = 10^{100}$, it's only about $1.5$. The function satisfies $f(n) = o((\\log n)^{1+\\varepsilon})$ for every $\\varepsilon > 0$ but $f(n) \\gg (\\log n)(\\log\\log n)^{1-\\varepsilon}$. Erdős conjectured (and offered $\\$10{,}000$) that the true maximal gap grows faster: $\\gg (\\log n)^{1+c}$ for some $c > 0$.",
-    "relatedConcepts": ["Rankin's construction", "sieve amplification", "maximal gap growth rate"],
-    "prerequisites": ["lg", "lg2", "lg3", "lg4"]
+    "relatedConcepts": [
+      "Rankin's construction",
+      "sieve amplification",
+      "maximal gap growth rate"
+    ],
+    "prerequisites": [
+      "lg",
+      "lg2",
+      "lg3",
+      "lg4"
+    ]
   },
   {
     "id": "ann-e4-rankinfunc",
     "proofId": "erdos-4",
-    "range": { "startLine": 64, "endLine": 69 },
+    "range": {
+      "startLine": 64,
+      "endLine": 69
+    },
     "type": "definition",
     "title": "Rankin Function",
     "content": "**rankinFunction n** = $\\frac{\\log\\log n}{\\log\\log\\log n} \\cdot \\log n$. Simplified version of the Erdős function, omitting the $\\log\\log\\log\\log n$ term.",
     "significance": "supporting",
     "mathContext": "This simplified function captures the dominant behavior of the Erdős function. The ratio $\\log\\log n / \\log\\log\\log n$ is the 'first-order' amplification from Rankin's method. The additional $\\log\\log\\log\\log n$ factor in the full Erdős function comes from a more refined optimization of the sieve parameters, particularly the choice of moduli in the covering congruence step.",
-    "relatedConcepts": ["covering congruences", "sieve optimization"],
-    "prerequisites": ["lg", "lg2", "lg3"]
+    "relatedConcepts": [
+      "covering congruences",
+      "sieve optimization"
+    ],
+    "prerequisites": [
+      "lg",
+      "lg2",
+      "lg3"
+    ]
   },
   {
     "id": "ann-e4-conjecture",
     "proofId": "erdos-4",
-    "range": { "startLine": 73, "endLine": 80 },
-    "type": "theorem",
+    "range": {
+      "startLine": 73,
+      "endLine": 80
+    },
+    "type": "concept",
     "title": "Erdős Problem #4 (SOLVED)",
     "content": "**erdos_4_conjecture**: For any $C > 0$, there are infinitely many $n$ such that $p_{n+1} - p_n > C \\cdot f(n)$ where $f$ is the Erdős function. SOLVED affirmatively in 2016.",
-    "significance": "critical",
+    "significance": "key",
     "mathContext": "The formalization states this as: $\\forall C > 0, \\forall N, \\exists n > N$ with $g_n > C \\cdot f(n)$. The 'for all $C$' quantifier is the crucial strengthening over Rankin's result (which only gave 'exists $C$'). Proving it for all $C$ required fundamentally new ideas: Maynard used his multidimensional sieve weights (the same innovation behind small gaps), while Ford-Green-Konyagin-Tao used a probabilistic argument based on the Selberg sieve and additive combinatorics. Erdős considered this his 'most important' prime gap conjecture and offered $\\$10{,}000$ for the related stronger statement with $(\\log n)^{1+c}$.",
-    "relatedConcepts": ["universal quantifier over C", "multidimensional sieve", "Selberg sieve", "probabilistic method"],
-    "prerequisites": ["primeGap", "erdosFunction"]
+    "relatedConcepts": [
+      "universal quantifier over C",
+      "multidimensional sieve",
+      "Selberg sieve",
+      "probabilistic method"
+    ],
+    "prerequisites": [
+      "primeGap",
+      "erdosFunction"
+    ]
   },
   {
     "id": "ann-e4-rankin",
     "proofId": "erdos-4",
-    "range": { "startLine": 84, "endLine": 96 },
-    "type": "theorem",
+    "range": {
+      "startLine": 84,
+      "endLine": 96
+    },
+    "type": "insight",
     "title": "Rankin's Theorem (1938)",
     "content": "**rankin_theorem**: There exists $C > 0$ such that infinitely many $n$ have $g_n > C \\cdot f(n)$. Rankin's original constant is $C = \\frac{1}{3}e^\\gamma \\approx 0.593$.",
     "significance": "key",
     "mathContext": "Rankin's 1938 construction was a landmark in prime gap theory. The method: (1) Choose a primorial $m = \\prod_{p \\leq y} p$. (2) By the Chinese Remainder Theorem, find residues $a_p$ mod $p$ for each prime $p \\leq y$ such that the interval $(m \\cdot q, m \\cdot q + d]$ has every integer divisible by some $p \\leq y$. (3) This creates a gap of size $d$ in the primes. Optimizing $y$ and $d$ gives the iterated-log bound. Rankin's constant $C = e^\\gamma/3$ stood for over 75 years — improving it by ANY factor was a major open problem. Erdős offered $\\$10{,}000$ for proving $C$ can be made arbitrarily large (i.e., for all $C > 0$).",
-    "relatedConcepts": ["Chinese Remainder Theorem", "primorial", "covering congruences", "Euler-Mascheroni constant"],
-    "prerequisites": ["erdos_4_conjecture"]
+    "relatedConcepts": [
+      "Chinese Remainder Theorem",
+      "primorial",
+      "covering congruences",
+      "Euler-Mascheroni constant"
+    ],
+    "prerequisites": [
+      "erdos_4_conjecture"
+    ]
   },
   {
     "id": "ann-e4-maynard",
     "proofId": "erdos-4",
-    "range": { "startLine": 100, "endLine": 107 },
-    "type": "theorem",
+    "range": {
+      "startLine": 100,
+      "endLine": 107
+    },
+    "type": "insight",
     "title": "Maynard's Theorem (2016)",
     "content": "**maynard_theorem**: Proves `erdos_4_conjecture` — for ALL $C > 0$, infinitely many prime gaps exceed $C \\cdot f(n)$. This resolves Erdős Problem #4.",
-    "significance": "critical",
+    "significance": "key",
     "mathContext": "Maynard's proof (2016) adapted his revolutionary multidimensional sieve method — the same technique that proved bounded gaps between primes (Polymath 8b). The key innovation: instead of sieving a single interval, construct a high-dimensional sieve that simultaneously tracks many residue classes. The multidimensional optimization problem yields sieve weights that are far more efficient than classical ones, allowing the constant $C$ in Rankin's bound to be made arbitrarily large. Maynard's approach is more elementary than the Ford-Green-Konyagin-Tao method, relying primarily on combinatorial sieve theory.",
-    "relatedConcepts": ["multidimensional sieve", "GPY sieve", "Maynard-Tao weights", "bounded prime gaps"],
-    "prerequisites": ["erdos_4_conjecture", "rankin_theorem"]
+    "relatedConcepts": [
+      "multidimensional sieve",
+      "GPY sieve",
+      "Maynard-Tao weights",
+      "bounded prime gaps"
+    ],
+    "prerequisites": [
+      "erdos_4_conjecture",
+      "rankin_theorem"
+    ]
   },
   {
     "id": "ann-e4-fgkt",
     "proofId": "erdos-4",
-    "range": { "startLine": 109, "endLine": 113 },
-    "type": "theorem",
+    "range": {
+      "startLine": 109,
+      "endLine": 113
+    },
+    "type": "insight",
     "title": "Ford-Green-Konyagin-Tao (2016)",
     "content": "**ford_green_konyagin_tao_theorem**: Independent proof of `erdos_4_conjecture`. Uses probabilistic number theory and additive combinatorics.",
-    "significance": "critical",
+    "significance": "key",
     "mathContext": "The FGKT approach is fundamentally different from Maynard's. Their method: (1) Use a probabilistic model for primes (Cramér's random model) to identify the right sieve parameters. (2) Apply the Selberg sieve with a novel 'hypergraph covering' lemma from additive combinatorics (related to the Green-Tao theorem machinery). (3) Use exponential sum estimates to control error terms. The independence of the two proofs — Maynard's combinatorial sieve vs FGKT's probabilistic/additive approach — is remarkable and suggests the result is 'robust.' Terence Tao announced their result on his blog, noting it was discovered simultaneously with Maynard's.",
-    "relatedConcepts": ["probabilistic number theory", "Cramér model", "hypergraph covering", "Green-Tao machinery"],
-    "prerequisites": ["erdos_4_conjecture"]
+    "relatedConcepts": [
+      "probabilistic number theory",
+      "Cramér model",
+      "hypergraph covering",
+      "Green-Tao machinery"
+    ],
+    "prerequisites": [
+      "erdos_4_conjecture"
+    ]
   },
   {
     "id": "ann-e4-solved",
     "proofId": "erdos-4",
-    "range": { "startLine": 115, "endLine": 116 },
-    "type": "theorem",
+    "range": {
+      "startLine": 115,
+      "endLine": 116
+    },
+    "type": "insight",
     "title": "Problem Solved (PROVED)",
     "content": "**erdos_4_solved**: `erdos_4_conjecture` holds, witnessed by `maynard_theorem`. A one-line proof.",
     "significance": "key",
     "mathContext": "This packages the resolution as a direct application of the axiomatized theorem. Either `maynard_theorem` or `ford_green_konyagin_tao_theorem` would suffice — Maynard's is chosen as the canonical witness.",
-    "relatedConcepts": ["problem resolution", "axiom witness"],
-    "prerequisites": ["maynard_theorem"]
+    "relatedConcepts": [
+      "problem resolution",
+      "axiom witness"
+    ],
+    "prerequisites": [
+      "maynard_theorem"
+    ]
   },
   {
     "id": "ann-e4-improved",
     "proofId": "erdos-4",
-    "range": { "startLine": 120, "endLine": 132 },
-    "type": "theorem",
+    "range": {
+      "startLine": 120,
+      "endLine": 132
+    },
+    "type": "insight",
     "title": "FGKMT Improved Bound (2018)",
     "content": "**fgkmt_improved_bound**: All five authors (Ford, Green, Konyagin, Maynard, Tao) proved a stronger bound with $\\log\\log\\log n$ in the denominator instead of $(\\log\\log\\log n)^2$, squaring the amplification factor.",
-    "significance": "critical",
+    "significance": "key",
     "mathContext": "The 2018 improvement replaces the $(\\log\\log\\log n)^2$ denominator with $\\log\\log\\log n$, effectively removing one iterated-log factor. The improved function $g(n) = \\frac{\\log\\log n \\cdot \\log\\log\\log\\log n}{\\log\\log\\log n} \\cdot \\log n$ is asymptotically larger than $f(n)$ by a factor of $\\log\\log\\log n$. The five authors combined Maynard's sieve approach with FGKT's probabilistic techniques, achieving a synergy neither team could reach alone. This is the current state of the art for large prime gap lower bounds.",
-    "relatedConcepts": ["combined sieve-probabilistic method", "iterated log improvement", "state of the art"],
-    "prerequisites": ["erdosFunction", "improvedErdosFunction"]
+    "relatedConcepts": [
+      "combined sieve-probabilistic method",
+      "iterated log improvement",
+      "state of the art"
+    ],
+    "prerequisites": [
+      "erdosFunction",
+      "improvedErdosFunction"
+    ]
   },
   {
     "id": "ann-e4-bhp",
     "proofId": "erdos-4",
-    "range": { "startLine": 136, "endLine": 147 },
-    "type": "theorem",
+    "range": {
+      "startLine": 136,
+      "endLine": 147
+    },
+    "type": "insight",
     "title": "Baker-Harman-Pintz Upper Bound (2001)",
     "content": "**baker_harman_pintz_upper_bound**: $p_{n+1} - p_n \\leq n^{0.525}$ for all large $n$. The best known unconditional upper bound on prime gaps.",
     "significance": "key",
     "mathContext": "The BHP result (2001) improved on the classical Ingham bound of $n^{5/8}$ and the Huxley bound of $n^{7/12}$. The exponent $0.525 = 21/40$ comes from estimates for exponential sums over primes (Vinogradov's method) combined with the Bombieri-Iwaniec method for short intervals. Under the Riemann Hypothesis, the exponent improves to $1/2 + \\varepsilon$: $p_{n+1} - p_n \\ll p_n^{1/2} \\log p_n$. The gap between the lower bound (iterated-log amplification of $\\log n$) and the upper bound ($n^{0.525}$) remains enormous — resolving this is one of the deepest open problems in analytic number theory.",
-    "relatedConcepts": ["Vinogradov's method", "Bombieri-Iwaniec method", "zero-free region", "Riemann Hypothesis"],
-    "prerequisites": ["primeGap"]
+    "relatedConcepts": [
+      "Vinogradov's method",
+      "Bombieri-Iwaniec method",
+      "zero-free region",
+      "Riemann Hypothesis"
+    ],
+    "prerequisites": [
+      "primeGap"
+    ]
   },
   {
     "id": "ann-e4-cramer",
     "proofId": "erdos-4",
-    "range": { "startLine": 158, "endLine": 160 },
+    "range": {
+      "startLine": 158,
+      "endLine": 160
+    },
     "type": "definition",
     "title": "Cramér's Conjecture (1936, OPEN)",
     "content": "**cramer_conjecture**: $p_{n+1} - p_n = O((\\log p_n)^2)$. The conjectured true upper bound on maximal prime gaps, based on a probabilistic model of primes.",
     "significance": "key",
     "mathContext": "Cramér (1936) modeled primes probabilistically: each integer $n$ is 'prime' independently with probability $1/\\log n$. In this model, the maximal gap among primes up to $x$ is $\\sim (\\log x)^2$ with probability 1. Cramér conjectured the same holds for actual primes. However, Granville (1995) observed that Cramér's model ignores the effect of small primes (e.g., half of all integers are even), and proposed the refined constant $2e^{-\\gamma} \\approx 1.1229$ instead of $1$. Proving Cramér's conjecture — or even $g_n = O(p_n^{1/2-\\varepsilon})$ — seems far beyond current methods. The conjecture is formalized using Mathlib's `Filter.atTop` for the 'eventually' quantifier.",
-    "relatedConcepts": ["Cramér's random model", "Granville correction", "probabilistic heuristic", "Filter.atTop"],
-    "prerequisites": ["primeGap", "nthPrime", "lg"]
+    "relatedConcepts": [
+      "Cramér's random model",
+      "Granville correction",
+      "probabilistic heuristic",
+      "Filter.atTop"
+    ],
+    "prerequisites": [
+      "primeGap",
+      "nthPrime",
+      "lg"
+    ]
   },
   {
     "id": "ann-e4-cramergranville",
     "proofId": "erdos-4",
-    "range": { "startLine": 162, "endLine": 166 },
+    "range": {
+      "startLine": 162,
+      "endLine": 166
+    },
     "type": "definition",
     "title": "Cramér-Granville Constant",
     "content": "**cramer_granville_constant** = $2e^{-\\gamma} \\approx 1.1229$ where $\\gamma$ is the Euler-Mascheroni constant. The conjectured lim sup of $g_n / (\\log p_n)^2$.",
     "significance": "supporting",
     "mathContext": "Granville's refinement comes from accounting for the 'Maier phenomenon': the Cramér model predicts prime counts in short intervals incorrectly by a factor involving $e^{-\\gamma}$. The corrected prediction is $\\limsup g_n / (\\log p_n)^2 = 2e^{-\\gamma}$ rather than $1$. The constant $2e^{-\\gamma}$ arises from the product $\\prod_p (1 - 1/p)/(1 - 1/\\log x)$ evaluated at $p \\leq \\log x$, which by Mertens' theorem equals $e^{-\\gamma}/\\log\\log x \\cdot \\log x$.",
-    "relatedConcepts": ["Euler-Mascheroni constant", "Maier's theorem", "Mertens' theorem"],
-    "prerequisites": ["cramer_conjecture"]
+    "relatedConcepts": [
+      "Euler-Mascheroni constant",
+      "Maier's theorem",
+      "Mertens' theorem"
+    ],
+    "prerequisites": [
+      "cramer_conjecture"
+    ]
   },
   {
     "id": "ann-e4-gap0",
     "proofId": "erdos-4",
-    "range": { "startLine": 170, "endLine": 171 },
-    "type": "theorem",
+    "range": {
+      "startLine": 170,
+      "endLine": 171
+    },
+    "type": "concept",
     "title": "First Prime Gap",
     "content": "**gap_0**: $g_0 = p_1 - p_0 = 3 - 2 = 1$. The unique gap of size 1 between consecutive primes.",
     "significance": "supporting",
     "mathContext": "The gap $g_0 = 1$ is the only odd prime gap, since 2 is the only even prime. All subsequent gaps $g_n$ for $n \\geq 1$ are even (since both $p_n$ and $p_{n+1}$ are odd for $n \\geq 1$).",
-    "relatedConcepts": ["parity of prime gaps", "prime 2"],
-    "prerequisites": ["primeGap"]
+    "relatedConcepts": [
+      "parity of prime gaps",
+      "prime 2"
+    ],
+    "prerequisites": [
+      "primeGap"
+    ]
   },
   {
     "id": "ann-e4-gappos",
     "proofId": "erdos-4",
-    "range": { "startLine": 173, "endLine": 174 },
-    "type": "theorem",
+    "range": {
+      "startLine": 173,
+      "endLine": 174
+    },
+    "type": "concept",
     "title": "Gaps are Positive",
     "content": "Prime gaps $g_n > 0$ for $n \\geq 1$ since primes are strictly increasing.",
     "significance": "supporting",
     "mathContext": "This follows immediately from the strict monotonicity of the prime sequence: $p_{n+1} > p_n$ for all $n$. In the natural number subtraction of Lean 4, this requires $p_{n+1} > p_n$ to avoid truncation to 0.",
-    "relatedConcepts": ["strict monotonicity", "natural subtraction"],
-    "prerequisites": ["primeGap", "nthPrime"]
+    "relatedConcepts": [
+      "strict monotonicity",
+      "natural subtraction"
+    ],
+    "prerequisites": [
+      "primeGap",
+      "nthPrime"
+    ]
   },
   {
     "id": "ann-e4-average",
     "proofId": "erdos-4",
-    "range": { "startLine": 177, "endLine": 178 },
-    "type": "theorem",
+    "range": {
+      "startLine": 177,
+      "endLine": 178
+    },
+    "type": "concept",
     "title": "Average Gap Asymptotic",
     "content": "The average prime gap near $n$ is $\\sim \\log n$, a consequence of the Prime Number Theorem: $p_n \\sim n \\log n$.",
     "significance": "supporting",
     "mathContext": "The Prime Number Theorem ($\\pi(x) \\sim x/\\log x$, equivalently $p_n \\sim n \\log n$) implies the average gap $g_n \\sim \\log p_n \\sim \\log n$. The formalization states this as $p_n / (n \\log n) \\to 1$, using `Filter.Tendsto` and `nhds 1`. Problem #4 asks about gaps exceeding this average by a factor growing with $n$ — the Erdős function grows as $\\sim (\\log\\log n / \\log\\log\\log n) \\cdot \\log n$, which is $\\omega(\\log n)$ but $o((\\log n)^{1+\\varepsilon})$.",
-    "relatedConcepts": ["Prime Number Theorem", "average gap", "Filter.Tendsto"],
-    "prerequisites": ["nthPrime", "lg"]
+    "relatedConcepts": [
+      "Prime Number Theorem",
+      "average gap",
+      "Filter.Tendsto"
+    ],
+    "prerequisites": [
+      "nthPrime",
+      "lg"
+    ]
   },
   {
     "id": "ann-e4-growth",
     "proofId": "erdos-4",
-    "range": { "startLine": 183, "endLine": 184 },
-    "type": "theorem",
+    "range": {
+      "startLine": 183,
+      "endLine": 184
+    },
+    "type": "technique",
     "title": "Erdős Function Growth Rate",
     "content": "**erdos_function_growth**: $f(n) < (\\log n)^{1+\\varepsilon}$ eventually for any $\\varepsilon > 0$. The Erdős function grows slower than any power of $\\log n$ beyond the first.",
     "significance": "supporting",
     "mathContext": "This growth rate comparison is key to understanding the hierarchy of prime gap conjectures. The Erdős function satisfies $f(n) = (\\log n) \\cdot \\omega(1)$ where $\\omega(1) = (\\log\\log n \\cdot \\log\\log\\log\\log n)/(\\log\\log\\log n)^2 \\to \\infty$ but slower than any $\\varepsilon$-power. Thus Problem #4 (solved) is strictly weaker than Erdős's $\\$10{,}000$ conjecture ($g_n > (\\log n)^{1+c}$ for some $c > 0$), which remains wide open.",
-    "relatedConcepts": ["growth rate hierarchy", "o-notation", "iterated logarithm growth"],
-    "prerequisites": ["erdosFunction"]
+    "relatedConcepts": [
+      "growth rate hierarchy",
+      "o-notation",
+      "iterated logarithm growth"
+    ],
+    "prerequisites": [
+      "erdosFunction"
+    ]
   },
   {
     "id": "ann-e4-stronger",
     "proofId": "erdos-4",
-    "range": { "startLine": 202, "endLine": 204 },
+    "range": {
+      "startLine": 202,
+      "endLine": 204
+    },
     "type": "definition",
     "title": "Erdős's Stronger Conjecture ($10,000 Prize)",
     "content": "**erdos_stronger_conjecture**: There exists $c > 0$ such that infinitely many $n$ have $g_n > (\\log n)^{1+c}$. This would be a vast strengthening of Problem #4. OPEN.",
     "significance": "key",
     "mathContext": "Erdős offered $\\$10{,}000$ for this — his largest prime gap prize — indicating he considered it extremely difficult but believed it to be true. The conjecture asserts that maximal prime gaps grow as a genuine power of $\\log n$ beyond linear. Current methods (including FGKMT 2018) only achieve iterated-log amplification, falling far short. Proving this would likely require either: (1) a fundamentally new sieve construction, (2) progress on zero-density estimates for the Riemann zeta function, or (3) new ideas from additive combinatorics. The conjecture is weaker than Cramér's conjecture (which predicts gaps $\\sim (\\log n)^2$).",
-    "relatedConcepts": ["Erdős prizes", "power-of-log growth", "zero-density estimates"],
-    "prerequisites": ["erdos_4_conjecture"]
+    "relatedConcepts": [
+      "Erdős prizes",
+      "power-of-log growth",
+      "zero-density estimates"
+    ],
+    "prerequisites": [
+      "erdos_4_conjecture"
+    ]
   },
   {
     "id": "ann-e4-firoozbakht",
     "proofId": "erdos-4",
-    "range": { "startLine": 212, "endLine": 214 },
+    "range": {
+      "startLine": 212,
+      "endLine": 214
+    },
     "type": "definition",
     "title": "Firoozbakht's Conjecture (1982, OPEN)",
     "content": "**firoozbakht_conjecture**: $p_n^{1/n}$ is strictly decreasing for $n \\geq 1$. This implies $g_n < (\\log p_n)^2 - \\log p_n$, a strong gap upper bound.",
     "significance": "key",
     "mathContext": "Firoozbakht's conjecture (1982) is one of the strongest proposed upper bounds on prime gaps. It states $p_{n+1}^{1/(n+1)} < p_n^{1/n}$, equivalently $p_{n+1} < p_n^{1+1/n}$. Since $p_n \\sim n \\log n$, this gives $g_n < p_n^{1/n} \\log p_n \\approx (\\log p_n)^2 - \\log p_n$ for large $n$. Firoozbakht's conjecture has been verified computationally for all primes up to $4 \\times 10^{18}$. It is strictly stronger than Cramér's conjecture with constant 1 (but weaker than the Cramér-Granville refinement with constant $2e^{-\\gamma}$). Note that Firoozbakht's conjecture is INCOMPATIBLE with Erdős's $\\$10{,}000$ conjecture if we believe both the upper and lower bounds — this tension highlights the uncertainty about the true growth rate of maximal gaps.",
-    "relatedConcepts": ["Firoozbakht 1982", "computational verification", "gap upper bound", "tension with Erdős conjecture"],
-    "prerequisites": ["nthPrime", "primeGap"]
+    "relatedConcepts": [
+      "Firoozbakht 1982",
+      "computational verification",
+      "gap upper bound",
+      "tension with Erdős conjecture"
+    ],
+    "prerequisites": [
+      "nthPrime",
+      "primeGap"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Enrichment passes for four entries:

### dissection-of-cubes-oq-02 (quality 20 → enriched)
- Populated `annotations.json` with 10 annotations covering all 8 parts
- Added complete `overview` block (historicalContext, problemStatement, proofStrategy, 5 keyInsights)
- Refined sections from 5 to 9
- Added relatedProofs, enriched conclusion

### erdos-1155-oq-01 (quality 45 → enriched)
- Fixed annotation types: replaced non-standard "theorem" with valid schema types
- Removed non-standard "tags" fields from all 11 annotations
- Fixed last annotation endLine
- Added `relatedProofs` cross-references

### bezout-identity-oq-02-oq-02-oq-01 (quality 65 → enriched)
- Fixed 4 annotation types from "theorem" to valid schema types (technique, insight)

### erdos-4 (quality 77 → enriched)
- Fixed 11 annotation types from "theorem" to valid schema types
- Fixed 6 significance values from "critical" to "key"
- All 21 annotations now schema-compliant

## Test plan

- [x] All JSON files validate
- [x] `pnpm annotations:build` passes for all entries