### PR TITLE
Enrich erdos-1155-oq-01: add leanFile, fix annotations, add crossRefs

### DIFF
--- a/src/data/proofs/erdos-1155-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1155-oq-01/annotations.json
@@ -38,7 +38,7 @@
       "startLine": 83,
       "endLine": 103
     },
-    "type": "definition",
+    "type": "concept",
     "title": "Asymptotic Infrastructure: Axiomatized f(n) and BFL Bounds",
     "content": "Axiomatizes the triangle removal function f(n) = triangleRemovalEdges n with basic properties (non-negative, bounded by n(n-1)/2) and the BFL (Bohman-Frieze-Lubetzky 2015) bounds: for any ε > 0, eventually n^{3/2-ε} ≤ f(n) ≤ n^{3/2+ε}.\n\nThe Erdős conjecture erdos_1155_conjecture asks for the stronger statement: ∃ c₁, c₂ > 0 such that c₁·n^{3/2} ≤ f(n) ≤ c₂·n^{3/2} eventually. The gap between BFL and the conjecture is precisely the difference between sub-polynomial bounds (n^{±ε}) and constant bounds.",
     "mathContext": "The triangle removal process on $K_n$: repeatedly select a triangle uniformly at random and remove its edges, continuing until the graph is triangle-free. $f(n)$ counts the remaining edges. BFL proved $f(n) = n^{3/2+o(1)}$ a.s., meaning for any $\\varepsilon > 0$: $n^{3/2-\\varepsilon} \\leq f(n) \\leq n^{3/2+\\varepsilon}$ eventually.",
@@ -164,7 +164,7 @@
     "proofId": "erdos-1155-oq-01",
     "range": {
       "startLine": 412,
-      "endLine": 491
+      "endLine": 489
     },
     "type": "theorem",
     "title": "Hierarchy of Bounds and Ratio Tightness",

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -9,6 +9,8 @@
     "date": "2026",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1155OQ01.lean",
+    "leanFile": "proofs/Proofs/Erdos1155OQ01.lean",
+    "dateAdded": "2026-03-22",
     "tags": [
       "erdos",
       "triangle-removal",
@@ -106,10 +108,6 @@
       {
         "id": "ramseys-theorem",
         "relationship": "Both concern structural properties of graphs under random or extremal processes; Ramsey theory provides related combinatorial bounds"
-      },
-      {
-        "id": "triangle-inequality",
-        "relationship": "Shares triangle-related graph-theoretic concepts, though in a metric rather than extremal context"
       }
     ]
   },
@@ -191,7 +189,7 @@
       "title": "Tightness and Ratio Characterization",
       "summary": "Under the conjecture, the normalized ratio f(n)/n^{3/2} is eventually in [c₁, c₂]. Characterizes the conjecture as a compactness condition on the ratio sequence in (0, ∞).",
       "startLine": 447,
-      "endLine": 491,
+      "endLine": 489,
       "mathContext": "Conjecture $\\iff \\{f(n)/n^{3/2}\\}_{n \\geq N}$ is bounded in $(0, \\infty)$: a compactness condition on the ratio sequence."
     }
   ],
@@ -206,6 +204,19 @@
       "**Strict hierarchy** Conjecture $\\Longrightarrow$ BFL $\\Longrightarrow$ Grable: each weakening loses information about whether the multiplicative constant is fixed or grows with $n$",
       "**Mantel connection**: the naive bound $f(n) \\leq n^2/4$ from extremal graph theory is vastly improved by BFL's $n^{7/4}$, and the conjecture's $n^{3/2}$ is tighter still"
     ]
+  },
+  "crossReferences": [
+    {"proofId": "erdos-1155", "relationship": "parent", "description": "Parent formalization of Erdős Problem #1155; this file extends with exact asymptotic gap analysis"},
+    {"proofId": "ramseys-theorem", "relationship": "related", "description": "Ramsey theory provides related combinatorial bounds for structural properties of random graphs"}
+  ],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Filter", "SimpleGraph", "Finset"],
+    "namespace": null,
+    "lineCount": 489,
+    "axiomCount": 5,
+    "theoremCount": 20,
+    "definitionCount": 6
   },
   "conclusion": {
     "summary": "Complete formalization of the structural relationship between BFL's n^{3/2+o(1)} result and Erdős's Θ(n^{3/2}) conjecture. All theorems fully proved (0 sorries). Includes BFL sandwich, exact exponent characterization, conjecture decomposition, Mantel connection, hierarchy of bounds, and ratio tightness characterization.",


### PR DESCRIPTION
## Summary

Enrichment pass for `erdos-1155-oq-01` (Triangle Removal Process: Exact Asymptotics).

**Quality: 45 → enriched** (pass 2)

### Changes
- Added `leanFile` object (489 lines, 5 axioms, 20 theorems, 6 definitions)
- Added `crossReferences` to erdos-1155 (parent) and ramseys-theorem
- Added `dateAdded` and `leanFile` path to meta section
- Fixed annotation type for axiom section (definition → concept)
- Fixed out-of-bounds endLine (491 → 489) in hierarchy annotation and tightness section
- Removed unrelated triangle-inequality cross-reference

### Validation
- JSON syntax validated
- Annotation build passes with 0 errors for this entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)