### PR TITLE
Enrich dissection-of-cubes-oq-02: add annotations, deepen overview

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-02/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/annotations.json
@@ -1,1 +1,146 @@
-[]
+[
+  {
+    "id": "ann-scissors-def",
+    "proofId": "dissection-of-cubes-oq-02",
+    "range": { "startLine": 53, "endLine": 56 },
+    "type": "definition",
+    "title": "Scissors Congruence",
+    "content": "Defines the scissors congruence relation between polyhedra. Two polyhedra P and Q are scissors congruent if P can be decomposed into finitely many polyhedral pieces that can be rearranged (via rigid motions) to form Q. This is the central equivalence relation studied in Hilbert's Third Problem. The formalization uses a simplified placeholder requiring only the existence of n pieces.",
+    "mathContext": "Two polyhedra $P$ and $Q$ are scissors congruent ($P \\sim_{\\mathrm{sc}} Q$) if there exist polyhedra $P_1, \\ldots, P_n$ and isometries $\\sigma_1, \\ldots, \\sigma_n$ such that $P = \\bigcup P_i$ and $Q = \\bigcup \\sigma_i(P_i)$.",
+    "significance": "key",
+    "relatedConcepts": ["equivalence relation", "polyhedral decomposition", "rigid motion", "congruence"],
+    "prerequisites": ["basic topology", "Euclidean geometry"]
+  },
+  {
+    "id": "ann-scissors-props",
+    "proofId": "dissection-of-cubes-oq-02",
+    "range": { "startLine": 58, "endLine": 64 },
+    "type": "technique",
+    "title": "Reflexivity and Symmetry of Scissors Congruence",
+    "content": "Proves that scissors congruence is reflexive (any polyhedron is scissors congruent to itself via the trivial 1-piece decomposition) and symmetric (if P can be cut and reassembled into Q, then Q can be cut and reassembled into P by reversing the rigid motions). Transitivity also holds but is omitted here.",
+    "mathContext": "Reflexivity: $P \\sim_{\\mathrm{sc}} P$ via the identity decomposition. Symmetry: if $P \\sim_{\\mathrm{sc}} Q$ via isometries $\\sigma_i$, then $Q \\sim_{\\mathrm{sc}} P$ via $\\sigma_i^{-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["equivalence relation", "group action", "isometry group"],
+    "prerequisites": ["basic algebra"]
+  },
+  {
+    "id": "ann-cube-angle",
+    "proofId": "dissection-of-cubes-oq-02",
+    "range": { "startLine": 70, "endLine": 78 },
+    "type": "concept",
+    "title": "Cube Dihedral Angle and Rationality",
+    "content": "Defines the dihedral angle of the cube as π/2 and proves it is a rational multiple of π. The dihedral angle is the angle between two faces meeting at an edge. For the cube, all 12 edges have identical dihedral angle π/2. The rationality of this angle (specifically 1/2 · π) is what makes the cube's Dehn invariant vanish — this is the key asymmetry exploited by Dehn's argument.",
+    "mathContext": "The cube dihedral angle is $\\theta_{\\mathrm{cube}} = \\pi/2$. Since $\\pi/2 = (1/2) \\cdot \\pi$, we have $\\theta_{\\mathrm{cube}} = q\\pi$ with $q = 1/2 \\in \\mathbb{Q}$.",
+    "significance": "key",
+    "relatedConcepts": ["dihedral angle", "rational multiple of π", "Niven's theorem", "regular polyhedra"],
+    "prerequisites": ["trigonometry", "rational numbers"]
+  },
+  {
+    "id": "ann-tetra-angle",
+    "proofId": "dissection-of-cubes-oq-02",
+    "range": { "startLine": 73, "endLine": 84 },
+    "type": "concept",
+    "title": "Tetrahedron Dihedral Angle and Irrationality",
+    "content": "Defines the dihedral angle of the regular tetrahedron as arccos(1/3) ≈ 70.53° and states (with sorry) that this is NOT a rational multiple of π. This irrationality result follows from Niven's theorem (1956), which characterizes which values of arccos are rational multiples of π. Since arccos(1/3)/π is irrational, the tetrahedron's Dehn invariant is nonzero, creating the invariant obstruction between cube and tetrahedron.",
+    "mathContext": "The regular tetrahedron dihedral angle is $\\theta_{\\mathrm{tet}} = \\arccos(1/3)$. By Niven's theorem, $\\arccos(1/3)/\\pi \\notin \\mathbb{Q}$, i.e., there is no $q \\in \\mathbb{Q}$ with $\\theta_{\\mathrm{tet}} = q\\pi$.",
+    "significance": "key",
+    "relatedConcepts": ["Niven's theorem", "transcendental number theory", "arccos function", "Platonic solids"],
+    "prerequisites": ["trigonometry", "number theory", "irrationality proofs"]
+  },
+  {
+    "id": "ann-dehn-invariant-def",
+    "proofId": "dissection-of-cubes-oq-02",
+    "range": { "startLine": 90, "endLine": 97 },
+    "type": "definition",
+    "title": "Simplified Dehn Invariant",
+    "content": "Defines a boolean-valued simplification of the Dehn invariant: a polyhedron has 'zero Dehn invariant' if all its dihedral angles are rational multiples of π. The full Dehn invariant lives in the tensor product ℝ ⊗_ℤ (ℝ/πℤ), summing length(e) ⊗ [θ(e)] over edges. This simplification captures the essential dichotomy: rational-angle polyhedra have zero invariant, irrational-angle polyhedra have nonzero invariant.",
+    "mathContext": "Full Dehn invariant: $D(P) = \\sum_{e} \\ell(e) \\otimes [\\theta(e)] \\in \\mathbb{R} \\otimes_{\\mathbb{Z}} (\\mathbb{R}/\\pi\\mathbb{Z})$. Simplified version: $D(P) = 0$ iff $\\forall e,\\; \\theta(e)/\\pi \\in \\mathbb{Q}$.",
+    "significance": "key",
+    "relatedConcepts": ["tensor product", "quotient group", "invariant theory", "algebraic K-theory"],
+    "prerequisites": ["abstract algebra", "tensor products", "group theory"]
+  },
+  {
+    "id": "ann-cube-dehn-zero",
+    "proofId": "dissection-of-cubes-oq-02",
+    "range": { "startLine": 99, "endLine": 104 },
+    "type": "technique",
+    "title": "Cube Has Zero Dehn Invariant",
+    "content": "Proves that the cube has zero Dehn invariant by showing its only dihedral angle (π/2) is a rational multiple of π. The proof unfolds the definition and applies cube_angle_rational_pi. This is one half of Dehn's obstruction argument.",
+    "mathContext": "$D(\\text{cube}) = 12 \\cdot s \\otimes [\\pi/2] = 12s \\otimes 0 = 0$ since $\\pi/2 \\in \\pi\\mathbb{Q}$, where $s$ is the edge length.",
+    "significance": "key",
+    "relatedConcepts": ["Dehn invariant", "rational angles", "cube geometry"],
+    "prerequisites": ["Dehn invariant definition", "rational multiples of π"]
+  },
+  {
+    "id": "ann-tetra-dehn-nonzero",
+    "proofId": "dissection-of-cubes-oq-02",
+    "range": { "startLine": 106, "endLine": 112 },
+    "type": "technique",
+    "title": "Tetrahedron Has Nonzero Dehn Invariant",
+    "content": "Proves that the regular tetrahedron has nonzero Dehn invariant by contradiction: if the invariant were zero, all dihedral angles would be rational multiples of π, contradicting the irrationality of arccos(1/3)/π. This is the other half of Dehn's obstruction.",
+    "mathContext": "$D(\\text{tet}) = 6 \\cdot a \\otimes [\\arccos(1/3)] \\neq 0$ since $\\arccos(1/3)/\\pi \\notin \\mathbb{Q}$, so $[\\arccos(1/3)] \\neq 0$ in $\\mathbb{R}/\\pi\\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["proof by contradiction", "Dehn invariant", "irrational angles"],
+    "prerequisites": ["Dehn invariant definition", "tetrahedron angle irrationality"]
+  },
+  {
+    "id": "ann-dehn-theorem",
+    "proofId": "dissection-of-cubes-oq-02",
+    "range": { "startLine": 118, "endLine": 126 },
+    "type": "insight",
+    "title": "Dehn's Theorem: Invariance Under Dissection",
+    "content": "States Dehn's fundamental theorem: scissors congruent polyhedra have equal Dehn invariant. This is the bridge between the algebraic invariant and the geometric equivalence relation. The proof (sorry) requires showing the Dehn invariant is additive: D(P₁ ∪ P₂) = D(P₁) + D(P₂) when P₁, P₂ share only boundary, and that it is preserved under rigid motions.",
+    "mathContext": "If $P \\sim_{\\mathrm{sc}} Q$ then $D(P) = D(Q)$. Equivalently, $D$ descends to a well-defined function on scissors congruence classes: $D: \\mathcal{P}(\\mathbb{R}^3)/\\sim_{\\mathrm{sc}} \\to \\mathbb{R} \\otimes_{\\mathbb{Z}} (\\mathbb{R}/\\pi\\mathbb{Z})$.",
+    "significance": "key",
+    "relatedConcepts": ["invariant", "additivity", "homomorphism", "scissors congruence group"],
+    "prerequisites": ["Dehn invariant definition", "scissors congruence"]
+  },
+  {
+    "id": "ann-dehn-obstruction",
+    "proofId": "dissection-of-cubes-oq-02",
+    "range": { "startLine": 144, "endLine": 149 },
+    "type": "insight",
+    "title": "Dehn Obstruction: The Core of Hilbert's Third Problem",
+    "content": "Proves the conjunction that the cube has zero Dehn invariant AND the tetrahedron has nonzero Dehn invariant. This is the mathematical core of the negative answer to Hilbert's Third Problem: since scissors congruent polyhedra must have equal Dehn invariants (Dehn's theorem), the cube and tetrahedron cannot be scissors congruent despite having equal volume. This was proved by Dehn in 1900, the same year Hilbert posed the problem — making it the first of Hilbert's 23 problems to be solved.",
+    "mathContext": "$D(\\text{cube}) = 0 \\neq D(\\text{tet})$, so by Dehn's theorem, $\\text{cube} \\not\\sim_{\\mathrm{sc}} \\text{tet}$.",
+    "significance": "key",
+    "relatedConcepts": ["Hilbert's problems", "obstruction theory", "invariant separation"],
+    "prerequisites": ["cube_dehn_zero", "tetrahedron_dehn_nonzero", "Dehn's theorem"]
+  },
+  {
+    "id": "ann-bolyai-gerwien",
+    "proofId": "dissection-of-cubes-oq-02",
+    "range": { "startLine": 155, "endLine": 175 },
+    "type": "context",
+    "title": "2D Contrast: Bolyai-Gerwien Theorem",
+    "content": "Proves that in 2D, the Dehn invariant is always zero because all interior angles of polygons are integer multiples of π (when measured as the angles relevant to the dissection). This formalizes why Hilbert's question has opposite answers in 2D vs 3D: the Bolyai-Gerwien theorem (1833) shows equal-area polygons are always scissors congruent, while Dehn's result shows this fails for polyhedra. The dimensional contrast is one of the most striking phenomena in geometric measure theory.",
+    "mathContext": "In 2D, every interior angle $\\theta$ satisfies $\\theta = n\\pi$ for some $n \\in \\mathbb{Z}$, so $D_{\\text{2D}}(P) = 0$ for all polygons $P$. Combined with the Wallace-Bolyai-Gerwien theorem: $\\text{Area}(P) = \\text{Area}(Q) \\implies P \\sim_{\\mathrm{sc}} Q$.",
+    "significance": "key",
+    "relatedConcepts": ["Bolyai-Gerwien theorem", "dimension dependence", "Wallace's theorem", "equidecomposability"],
+    "prerequisites": ["polygon geometry", "Dehn invariant in 2D"]
+  },
+  {
+    "id": "ann-dehn-sydler",
+    "proofId": "dissection-of-cubes-oq-02",
+    "range": { "startLine": 181, "endLine": 198 },
+    "type": "context",
+    "title": "Dehn-Sydler Completeness Theorem",
+    "content": "States the Dehn-Sydler theorem (1965): in 3D, volume and Dehn invariant are the COMPLETE invariants for scissors congruence. That is, two polyhedra are scissors congruent if and only if they have equal volume and equal Dehn invariant. Dehn conjectured this in 1901; Sydler proved it 64 years later using a difficult construction, and Jessen gave a simplified proof in 1968. This completeness result shows that Dehn's necessary condition is also sufficient.",
+    "mathContext": "$P \\sim_{\\mathrm{sc}} Q \\iff \\mathrm{Vol}(P) = \\mathrm{Vol}(Q) \\land D(P) = D(Q)$. In higher dimensions, the classification involves higher Dehn-type invariants (Dupont-Sah conjecture).",
+    "significance": "supporting",
+    "relatedConcepts": ["completeness theorem", "Jessen's proof", "Dupont-Sah conjecture", "higher-dimensional scissors congruence"],
+    "prerequisites": ["Dehn invariant", "scissors congruence", "measure theory"]
+  },
+  {
+    "id": "ann-other-polyhedra",
+    "proofId": "dissection-of-cubes-oq-02",
+    "range": { "startLine": 204, "endLine": 216 },
+    "type": "concept",
+    "title": "Dihedral Angles of Other Platonic Solids",
+    "content": "Defines the dihedral angles of the regular octahedron (arccos(-1/3) ≈ 109.47°) and regular icosahedron (arccos(-√5/3) ≈ 138.19°), and proves the tetrahedron's angle is positive. By Niven's theorem, the only Platonic solid with a rational dihedral angle (as a multiple of π) is the cube. Thus the octahedron, icosahedron, and dodecahedron also have nonzero Dehn invariants and are not scissors congruent to the cube.",
+    "mathContext": "Platonic solid dihedral angles: cube $\\pi/2$, tetrahedron $\\arccos(1/3)$, octahedron $\\arccos(-1/3)$, icosahedron $\\arccos(-\\sqrt{5}/3)$, dodecahedron $\\arccos(-1/\\sqrt{5})$. Only $\\pi/2$ is a rational multiple of $\\pi$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Platonic solids", "Niven's theorem", "dihedral angle classification", "regular polyhedra"],
+    "prerequisites": ["trigonometry", "arccos function"]
+  }
+]

--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -29,25 +29,48 @@
     ],
     "references": [
       {"key": "De00", "citation": "Dehn, M., Ueber den Rauminhalt, Mathematische Annalen 55 (1900), 465-478.", "type": "paper"},
-      {"key": "Sy65", "citation": "Sydler, J.-P., Conditions nécessaires et suffisantes pour l'équivalence des polyèdres de l'espace euclidien à trois dimensions, Comment. Math. Helv. 40 (1965), 43-80.", "type": "paper"}
+      {"key": "Sy65", "citation": "Sydler, J.-P., Conditions nécessaires et suffisantes pour l'équivalence des polyèdres de l'espace euclidien à trois dimensions, Comment. Math. Helv. 40 (1965), 43-80.", "type": "paper"},
+      {"key": "Ni56", "citation": "Niven, I., Irrational Numbers, Carus Math. Monographs No. 11, MAA (1956). Contains the theorem that arccos(r) is a rational multiple of π only for r ∈ {0, ±1/2, ±1}.", "type": "book"},
+      {"key": "Je68", "citation": "Jessen, B., The algebra of polyhedra and the Dehn-Sydler theorem, Math. Scand. 22 (1968), 241-256.", "type": "paper"}
+    ]
+  },
+  "overview": {
+    "historicalContext": "Hilbert's Third Problem, posed by David Hilbert in 1900 as the third of his famous 23 problems, asked whether two polyhedra of equal volume are always scissors congruent — that is, whether one can always be cut into finitely many polyhedral pieces and reassembled into the other. In 2D, the Bolyai-Gerwien theorem (proved independently by Farkas Bolyai and Paul Gerwien around 1833, with earlier work by William Wallace in 1807) shows the answer is yes: any two equal-area polygons are scissors congruent. Hilbert suspected the 3D case would be different. Max Dehn, Hilbert's student, confirmed this in 1900 by introducing an algebraic invariant — now called the Dehn invariant — that is preserved under polyhedral dissection. Since the cube and regular tetrahedron have different Dehn invariants (zero vs nonzero), they cannot be scissors congruent despite having equal volume. This made Hilbert's Third the first of the 23 problems to be solved. The story was completed in 1965 when Jean-Pierre Sydler proved the converse: volume and Dehn invariant are the complete set of scissors congruence invariants in 3D.",
+    "problemStatement": "Given a cube and a regular tetrahedron of equal volume, prove they are not scissors congruent. Formally: there is no decomposition of the cube into finitely many polyhedral pieces that can be rearranged via rigid motions to form the tetrahedron. The proof uses the Dehn invariant $D(P) = \\sum_e \\ell(e) \\otimes [\\theta(e)] \\in \\mathbb{R} \\otimes_{\\mathbb{Z}} (\\mathbb{R}/\\pi\\mathbb{Z})$.",
+    "proofStrategy": "The proof proceeds by invariant separation. First, define a simplified Dehn invariant that checks whether all dihedral angles are rational multiples of π. Then: (1) prove the cube has zero Dehn invariant since its dihedral angle π/2 = (1/2)π is rational; (2) prove the regular tetrahedron has nonzero Dehn invariant since arccos(1/3)/π is irrational (by Niven's theorem); (3) conclude by Dehn's theorem that scissors congruent polyhedra have equal Dehn invariant, so the cube and tetrahedron cannot be scissors congruent. The proof also establishes the 2D contrast via the Bolyai-Gerwien theorem.",
+    "keyInsights": [
+      "The Dehn invariant lives in the tensor product ℝ ⊗_ℤ (ℝ/πℤ), a subtle algebraic structure where edge lengths tensor with dihedral angle classes mod π — this is what makes it sensitive to the arithmetic nature of angles",
+      "The cube is the only Platonic solid whose dihedral angle is a rational multiple of π (by Niven's theorem), making it uniquely 'scissors-friendly' among regular polyhedra",
+      "The dimensional contrast is striking: equal-area polygons are always scissors congruent (Bolyai-Gerwien), but equal-volume polyhedra are not — the obstruction appears precisely in the passage from 2D to 3D",
+      "Dehn's invariant was the first example of what would become a major theme in algebraic K-theory: using tensor product constructions to detect obstructions to geometric equivalence",
+      "Hilbert's Third Problem was the first of his 23 problems to be solved — Dehn answered it the same year (1900) it was posed, using purely algebraic methods to resolve a geometric question"
     ]
   },
   "sections": [
-    {"id": "scissors", "title": "Scissors Congruence", "startLine": 47, "endLine": 60, "summary": "Defines ScissorsCongruent and proves reflexivity and symmetry."},
-    {"id": "angles", "title": "Dihedral Angles", "startLine": 64, "endLine": 84, "summary": "Defines cube (π/2) and tetrahedron (arccos(1/3)) dihedral angles. Proves cube angle is rational multiple of π."},
-    {"id": "dehn", "title": "Dehn Invariant", "startLine": 88, "endLine": 115, "summary": "Defines dehnInvariantZero predicate. Proves cube has zero and tetrahedron has nonzero Dehn invariant."},
-    {"id": "hilbert", "title": "Hilbert's Third Problem", "startLine": 119, "endLine": 150, "summary": "States Hilbert's 3rd problem and dehn_obstruction theorem."},
-    {"id": "2d", "title": "2D Contrast (Bolyai-Gerwien)", "startLine": 154, "endLine": 175, "summary": "Proves polygon_dehn_zero: all 2D shapes have zero Dehn invariant."}
+    {"id": "scissors", "title": "Scissors Congruence", "startLine": 47, "endLine": 64, "summary": "Defines the ScissorsCongruent relation (existence of a finite polyhedral decomposition) and proves reflexivity and symmetry, establishing it as a pre-equivalence relation on polyhedra."},
+    {"id": "angles", "title": "Dihedral Angles of Common Polyhedra", "startLine": 66, "endLine": 84, "summary": "Defines the dihedral angles of the cube (π/2) and regular tetrahedron (arccos(1/3)). Proves the cube angle is a rational multiple of π and states (sorry) the tetrahedron angle is irrational over π, via Niven's theorem."},
+    {"id": "dehn", "title": "The Dehn Invariant", "startLine": 86, "endLine": 112, "summary": "Defines a simplified boolean Dehn invariant (dehnInvariantZero) testing whether all dihedral angles are rational multiples of π. Proves cube_dehn_zero and tetrahedron_dehn_nonzero — the two halves of the invariant obstruction."},
+    {"id": "dehn-theorem", "title": "Dehn's Theorem (Invariance Under Dissection)", "startLine": 114, "endLine": 126, "summary": "States Dehn's fundamental theorem: scissors congruent polyhedra have equal Dehn invariant. This sorry requires proving additivity of the invariant under polyhedral decomposition."},
+    {"id": "hilbert", "title": "Hilbert's Third Problem", "startLine": 128, "endLine": 149, "summary": "States and proves the Dehn obstruction theorem: cube and tetrahedron have different Dehn invariants. The main hilbert_third_problem theorem (sorry) would follow from combining this with Dehn's theorem."},
+    {"id": "bolyai-gerwien", "title": "2D Contrast: Bolyai-Gerwien Theorem", "startLine": 151, "endLine": 176, "summary": "Proves polygon_dehn_zero: in 2D all interior angles are integer multiples of π, so the Dehn invariant vanishes for all polygons. This formalizes the dimensional contrast between 2D (always scissors congruent) and 3D (not always)."},
+    {"id": "dehn-sydler", "title": "Dehn-Sydler Completeness", "startLine": 178, "endLine": 198, "summary": "States the Dehn-Sydler theorem (1965): volume and Dehn invariant are the complete scissors congruence invariants in 3D. Two polyhedra are scissors congruent iff they have equal volume and equal Dehn invariant."},
+    {"id": "specific-angles", "title": "Dihedral Angles of Other Platonic Solids", "startLine": 200, "endLine": 226, "summary": "Defines dihedral angles for the regular octahedron (arccos(-1/3)) and icosahedron (arccos(-√5/3)). Proves positivity of the tetrahedron angle. Provides verification checks for the main results."}
   ],
   "conclusion": {
-    "summary": "Formalizes the Dehn invariant approach to scissors congruence with 3 sorries, 0 axioms. Key proved: cube_dehn_zero, tetrahedron_dehn_nonzero (modulo angle irrationality), dehn_obstruction, polygon_dehn_zero.",
-    "implications": "Provides a machine-checked formalization of Hilbert's Third Problem via the Dehn invariant, demonstrating that equal-volume polyhedra need not be scissors congruent — unlike the 2D case (Bolyai-Gerwien theorem).",
+    "summary": "Formalizes the Dehn invariant approach to Hilbert's Third Problem with 3 sorries and 0 axioms. The core proved results are cube_dehn_zero and tetrahedron_dehn_nonzero (modulo the irrationality sorry), combined in dehn_obstruction to show the invariant separation. The 2D contrast via polygon_dehn_zero demonstrates why the phenomenon is dimension-specific. The formalization covers 8 sections spanning scissors congruence, Dehn invariants, Hilbert's Third Problem, and the Dehn-Sydler completeness theorem.",
+    "implications": "This formalization provides a machine-checked account of one of the most elegant results in geometric combinatorics: the negative answer to Hilbert's Third Problem. It demonstrates that equal-volume polyhedra need not be scissors congruent, in stark contrast to the 2D case. The simplified Dehn invariant approach makes the key ideas accessible while pointing toward the deep algebraic K-theory connections. The three remaining sorries correspond to genuinely hard results: Niven's theorem (number theory), additivity of the Dehn invariant (geometric measure theory), and the main theorem synthesis.",
     "openQuestions": [
-      "Prove tetrahedron_angle_irrational_pi (Niven's theorem: arccos(1/3)/π is irrational)",
-      "Formalize the full tensor product Dehn invariant in ℝ ⊗_ℤ (ℝ/πℤ)",
-      "Prove the Dehn-Sydler completeness theorem"
+      "Prove tetrahedron_angle_irrational_pi via Niven's theorem — this requires showing arccos(1/3)/π is irrational, which involves Chebyshev polynomials and cyclotomic field theory",
+      "Formalize the full tensor product Dehn invariant D(P) ∈ ℝ ⊗_ℤ (ℝ/πℤ) with proper edge-length weighting, moving beyond the simplified boolean version",
+      "Prove the Dehn-Sydler completeness theorem: volume + Dehn invariant are the complete scissors congruence invariants in 3D",
+      "Extend to higher dimensions: formalize the Dupont-Sah conjecture relating scissors congruence in dimension n to algebraic K-theory groups",
+      "Determine Dehn invariants for all Archimedean solids and classify which pairs are scissors congruent"
     ]
   },
+  "crossReferences": [
+    {"proofId": "dissection-of-cubes", "relationship": "extends", "description": "Base impossibility result for cube dissection (Wiedijk #82). This OQ-02 extends with the Dehn invariant approach and dimensional contrast."},
+    {"proofId": "dissection-of-cubes-oq-01", "relationship": "sibling", "description": "Studies the minimum collision number in cube dissections, a quantitative refinement of the dissection impossibility."}
+  ],
   "leanFile": {
     "imports": ["Mathlib.Tactic", "Mathlib.Data.Real.Basic", "Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds", "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"],
     "namespace": "DissectionOfCubesOQ02",


### PR DESCRIPTION
## Summary
- Added 12 annotations with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` covering all 8 sections of the Lean file
- Added full `overview` block with historicalContext (800+ chars covering Hilbert, Dehn, Bolyai-Gerwien, Sydler), problemStatement with LaTeX, proofStrategy, and 5 keyInsights
- Expanded sections from 5 to 8 (added Dehn-Sydler theorem, Platonic solid angles)
- Deepened conclusion with richer implications and 5 open questions
- Added cross-references to `dissection-of-cubes` and `dissection-of-cubes-oq-01`
- Added references for Niven (1956) and Jessen (1968)

Quality: 25 → enriched (0 passes → 1 pass)

## Test plan
- [x] JSON validated (python3 json.load)
- [x] `pnpm annotations:build` passes with no errors for this entry
- [x] No axiom integrity issues (status: formalized, 3 sorries, 0 axioms matches Lean file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)