### PR TITLE
Research: szemeredi-counting - Neighborhood infrastructure for counting lemma

### DIFF
--- a/proofs/Proofs/SzemerediCounting.lean
+++ b/proofs/Proofs/SzemerediCounting.lean
@@ -13,10 +13,74 @@
   Ruzsa-Szemeredi (1978), Komlos-Simonovits (1996)
 -/
 import Mathlib
+import Proofs.SzemerediRegularity
 
 namespace Szemeredi.Counting
 
+open Classical
+
 variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- INFRASTRUCTURE: NEIGHBORHOODS AND DENSITY
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- The neighborhood of a vertex v within a set B: {b ∈ B : G.Adj v b}. -/
+noncomputable def neighborhoodIn (G : SimpleGraph V) [DecidableRel G.Adj]
+    (v : V) (B : Finset V) : Finset V :=
+  B.filter (fun b => G.Adj v b)
+
+/-- Neighborhood is a subset of the target set. -/
+theorem neighborhoodIn_subset (G : SimpleGraph V) [DecidableRel G.Adj]
+    (v : V) (B : Finset V) : neighborhoodIn G v B ⊆ B :=
+  Finset.filter_subset _ _
+
+/-- Neighborhood cardinality is bounded by the target set. -/
+theorem neighborhoodIn_card_le (G : SimpleGraph V) [DecidableRel G.Adj]
+    (v : V) (B : Finset V) : (neighborhoodIn G v B).card ≤ B.card :=
+  Finset.card_filter_le _ _
+
+/-- The set of "bad" vertices whose neighborhood is too small.
+    A vertex a ∈ A is bad if |N_B(a)| < threshold * |B|. -/
+noncomputable def badVertices (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B : Finset V) (threshold : ℚ) : Finset V :=
+  A.filter (fun a => (neighborhoodIn G a B).card < threshold * B.card)
+
+/-- Bad vertices is a subset of A. -/
+theorem badVertices_subset (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B : Finset V) (t : ℚ) : badVertices G A B t ⊆ A :=
+  Finset.filter_subset _ _
+
+/-- The set of "good" vertices whose neighborhood is large enough. -/
+noncomputable def goodVertices (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B : Finset V) (threshold : ℚ) : Finset V :=
+  A.filter (fun a => (neighborhoodIn G a B).card ≥ threshold * B.card)
+
+/-- Good vertices complement bad vertices within A. -/
+theorem good_union_bad (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B : Finset V) (t : ℚ) :
+    goodVertices G A B t ∪ badVertices G A B t = A := by
+  ext a
+  simp only [Finset.mem_union, goodVertices, badVertices, Finset.mem_filter]
+  constructor
+  · rintro (⟨ha, _⟩ | ⟨ha, _⟩) <;> exact ha
+  · intro ha
+    by_cases h : (↑(neighborhoodIn G a B).card : ℚ) ≥ t * ↑B.card
+    · left; exact ⟨ha, h⟩
+    · right; exact ⟨ha, lt_of_not_ge h⟩
+
+/-- If (A,B) is ε-regular and d(A,B) ≥ ε, then the set of bad vertices
+    (those with |N_B(a)| < (d-ε)|B|) has fewer than ε|A| elements.
+    This is the key lemma connecting vertex neighborhoods to regularity. -/
+theorem bad_vertices_small (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (heps : 0 < eps)
+    (A B : Finset V)
+    (hreg : Szemeredi.Regularity.IsEpsilonRegular G eps A B)
+    (hdensity : Szemeredi.Regularity.edgeDensity G A B ≥ eps)
+    (hA : (0 : ℚ) < A.card) (hB : (0 : ℚ) < B.card) :
+    ((badVertices G A B (Szemeredi.Regularity.edgeDensity G A B - eps)).card : ℚ)
+      < eps * A.card := by
+  sorry
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART I: COUNTING LEMMA FOR REGULAR TRIPLES
@@ -58,10 +122,11 @@ theorem counting_lemma (G : SimpleGraph V) [DecidableRel G.Adj]
 noncomputable def edgeSet (G : SimpleGraph V) [DecidableRel G.Adj] : Finset (V × V) :=
   (Finset.univ.product Finset.univ).filter (fun p => G.Adj p.1 p.2)
 
-/-- A graph obtained by removing a set of edges from G. -/
+/-- A graph obtained by removing a set of edge pairs from G.
+    Both orientations (v,w) and (w,v) are removed to maintain symmetry. -/
 def removeEdges (G : SimpleGraph V) (R : Set (V × V)) : SimpleGraph V where
-  Adj v w := G.Adj v w ∧ (v, w) ∉ R
-  symm v w h := ⟨G.symm h.1, fun hr => h.2 (by rwa [Set.mem_setOf_eq])⟩
+  Adj v w := G.Adj v w ∧ (v, w) ∉ R ∧ (w, v) ∉ R
+  symm v w h := ⟨G.symm h.1, h.2.2, h.2.1⟩
   loopless v h := G.loopless v h.1
 
 /-- **Triangle Removal Lemma**: For every delta > 0, there exists gamma > 0

--- a/proofs/Proofs/SzemerediRegularity.lean
+++ b/proofs/Proofs/SzemerediRegularity.lean
@@ -15,6 +15,8 @@ import Mathlib
 
 namespace Szemeredi.Regularity
 
+open Classical
+
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
 -- ═══════════════════════════════════════════════════════════════════
@@ -49,6 +51,30 @@ def IsRegularPartition (G : SimpleGraph V) [DecidableRel G.Adj]
   ((parts.product parts).filter (fun pq =>
     pq.1 ≠ pq.2 ∧ ¬IsEpsilonRegular G eps pq.1 pq.2)).card ≤
     eps * (parts.card * (parts.card - 1))
+
+/-- Edge density is non-negative. -/
+theorem edgeDensity_nonneg (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B : Finset V) : 0 ≤ edgeDensity G A B := by
+  unfold edgeDensity
+  split_ifs
+  · exact le_refl 0
+  · positivity
+
+/-- Edge density is at most 1. -/
+theorem edgeDensity_le_one (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B : Finset V) : edgeDensity G A B ≤ 1 := by
+  unfold edgeDensity
+  split_ifs with h
+  · exact zero_le_one
+  · have hne : (A.card : ℚ) * B.card ≠ 0 := h
+    have hpos : (0 : ℚ) < (A.card : ℚ) * B.card :=
+      lt_of_le_of_ne (by positivity) hne.symm
+    rw [div_le_one hpos]
+    have h1 : {p ∈ A.product B | G.Adj p.1 p.2}.card ≤ A.card * B.card := by
+      calc {p ∈ A.product B | G.Adj p.1 p.2}.card
+          ≤ (A.product B).card := Finset.card_filter_le _ _
+        _ = A.card * B.card := Finset.card_product A B
+    exact_mod_cast h1
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART II: PARTITION ENERGY AND ENERGY INCREMENT
@@ -95,7 +121,33 @@ theorem partitionEnergy_le_one (G : SimpleGraph V) [DecidableRel G.Adj]
     (hdisjoint : ∀ P Q : Finset V, P ∈ parts → Q ∈ parts → P ≠ Q →
       Disjoint P Q) :
     partitionEnergy G parts ≤ 1 := by
-  sorry
+  unfold partitionEnergy
+  split_ifs with h
+  · exact zero_le_one
+  · -- Each d(P,Q)² ≤ 1, and there are k² terms, so Σ d² ≤ k²
+    -- Therefore (1/k²) * Σ d² ≤ (1/k²) * k² = 1
+    have hk2_ne : (↑(parts.card ^ 2) : ℚ) ≠ 0 :=
+      Nat.cast_ne_zero.mpr (pow_ne_zero 2 h)
+    have hsum : (parts.product parts).sum (fun pq => (edgeDensity G pq.1 pq.2) ^ 2)
+        ≤ ↑(parts.card ^ 2) := by
+      calc (parts.product parts).sum (fun pq => (edgeDensity G pq.1 pq.2) ^ 2)
+          ≤ (parts.product parts).sum (fun _ => (1 : ℚ)) := by
+            apply Finset.sum_le_sum; intro x _
+            have h1 := edgeDensity_nonneg G x.1 x.2
+            have h2 := edgeDensity_le_one G x.1 x.2
+            have : (edgeDensity G x.1 x.2) ^ 2 ≤ edgeDensity G x.1 x.2 := by
+              rw [sq]; exact mul_le_of_le_one_right h1 h2
+            linarith
+        _ = ↑(parts.product parts).card := by
+            simp [Finset.sum_const, nsmul_eq_mul]
+        _ = ↑(parts.card ^ 2) := by
+            congr 1
+            exact (Finset.card_product parts parts).trans (by ring)
+    calc (1 : ℚ) / ↑(parts.card ^ 2) *
+          (parts.product parts).sum (fun pq => (edgeDensity G pq.1 pq.2) ^ 2)
+        ≤ 1 / ↑(parts.card ^ 2) * ↑(parts.card ^ 2) :=
+          mul_le_mul_of_nonneg_left hsum (by positivity)
+      _ = 1 := by field_simp
 
 /-- **Szemeredi Regularity Lemma**: For every epsilon > 0, every
     sufficiently large graph admits an epsilon-regular partition into

--- a/src/data/proofs/szemeredi-counting/meta.json
+++ b/src/data/proofs/szemeredi-counting/meta.json
@@ -17,7 +17,7 @@
       "marquee-phase-3"
     ],
     "badge": "formalized",
-    "sorries": 2,
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph",

--- a/src/data/proofs/szemeredi-regularity/meta.json
+++ b/src/data/proofs/szemeredi-regularity/meta.json
@@ -17,7 +17,7 @@
       "marquee-phase-3"
     ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph",
@@ -39,6 +39,8 @@
       "Epsilon-regular pair definition for SimpleGraph bipartite subgraphs",
       "Regular partition definition with equitable partition and bounded irregularity",
       "Partition energy function and energy increment step",
+      "Edge density bounds: edgeDensity_nonneg and edgeDensity_le_one (proved)",
+      "Partition energy upper bound: partitionEnergy_le_one (proved)",
       "Regularity lemma via iterated energy refinement"
     ],
     "dateAdded": "2026-03-21",


### PR DESCRIPTION
## Summary
- Added neighborhood infrastructure (neighborhoodIn, goodVertices, badVertices) with 4 proved lemmas
- Added bad_vertices_small (sorry) as key bridge lemma connecting neighborhoods to regularity
- Fixed pre-existing removeEdges symmetry bug
- Added import for SzemerediRegularity and open Classical

## Infrastructure Added
| Item | Status |
|------|--------|
| `neighborhoodIn` definition | Proved (subset, card bounds) |
| `goodVertices`/`badVertices` definitions | Proved (good_union_bad) |
| `bad_vertices_small` | Sorry (key lemma) |
| `removeEdges` symmetry fix | Fixed |

## Next Steps
- Prove `bad_vertices_small` via contraposition with ε-regularity
- With that, `counting_lemma` follows standard textbook proof

## Test plan
- [x] Docker build passes (`Proofs.SzemerediCounting`)
- [x] No new axioms introduced

🤖 Generated by researcher-1