### PR TITLE
Enrich erdos-315: add mathContext to sections, fix prerequisites

### DIFF
--- a/src/data/proofs/erdos-315/annotations.json
+++ b/src/data/proofs/erdos-315/annotations.json
@@ -9,7 +9,7 @@
     "mathContext": "Proved independently by Kamio (arXiv:2503.02317) and Li-Tang (arXiv:2503.12277) in 2025, solving a 45-year-old conjecture.",
     "significance": "key",
     "relatedConcepts": ["Egyptian fractions", "Vardi constant", "Greedy algorithms"],
-    "prerequisites": ["egyptian-fractions", "asymptotic-analysis", "extremal-problems", "solved-conjecture"]
+    "prerequisites": ["Egyptian fractions", "asymptotic analysis", "extremal combinatorics"]
   },
   {
     "id": "ann-e315-sylvester-def",
@@ -21,7 +21,7 @@
     "mathContext": "Also called Euclid numbers minus 1 due to connection with Euclid's proof of infinitely many primes.",
     "significance": "key",
     "relatedConcepts": ["OEIS A000058", "Recurrence relations"],
-    "prerequisites": ["recurrence-relations", "integer-sequences", "double-exponential-growth"]
+    "prerequisites": ["recurrence relations", "integer sequences"]
   },
   {
     "id": "ann-e315-values",
@@ -32,7 +32,7 @@
     "content": "**Concrete values:**\n\n- sylvester 0 = 2\n- sylvester 1 = 3 = 2² - 2 + 1\n- sylvester 2 = 7 = 3² - 3 + 1\n- sylvester 3 = 43 = 7² - 7 + 1\n- sylvester 4 = 1807 = 43² - 43 + 1\n\nAll proved by rfl (computation).",
     "significance": "supporting",
     "relatedConcepts": ["Reflexivity", "Computation"],
-    "prerequisites": ["computation", "concrete-values", "reflexivity"]
+    "prerequisites": ["Nat arithmetic", "rfl tactic"]
   },
   {
     "id": "ann-e315-strict-mono",
@@ -43,7 +43,7 @@
     "content": "**sylvester_strictMono:**\n\nSylvester's sequence is strictly increasing: m < n → sylvester m < sylvester n.\n\n**Proof idea:** By strong induction. Since u_{n+1} = u_n² - u_n + 1 and u_n ≥ 2, we have u_{n+1} > u_n.\n\nThis is needed to ensure the EgyptianSequence structure is valid.",
     "significance": "key",
     "relatedConcepts": ["Strong induction", "Monotonicity"],
-    "prerequisites": ["monotonicity", "strong-induction", "sequence-properties"]
+    "prerequisites": ["strong induction", "StrictMono"]
   },
   {
     "id": "ann-e315-identity",
@@ -54,7 +54,7 @@
     "content": "**sylvester_identity:**\n\nu_{n+1} - 1 = u_n(u_n - 1)\n\nThis identity is central to proving Σ 1/u_n = 1 via telescoping.\n\n**Proof:** Direct computation: (u² - u + 1) - 1 = u² - u = u(u-1).",
     "significance": "key",
     "relatedConcepts": ["Algebraic identities", "Telescoping"],
-    "prerequisites": ["algebraic-identity", "telescoping", "recurrence-relations"]
+    "prerequisites": ["algebraic identities", "Nat.sub_add_cancel"]
   },
   {
     "id": "ann-e315-sum-one",
@@ -66,7 +66,7 @@
     "mathContext": "1 = 1/2 + 1/3 + 1/7 + 1/43 + 1/1807 + ... This is the greedy algorithm's output for representing 1.",
     "significance": "key",
     "relatedConcepts": ["Egyptian fractions", "Infinite series"],
-    "prerequisites": ["infinite-series", "egyptian-fractions", "telescoping", "unit-fractions"]
+    "prerequisites": ["infinite series", "telescoping products", "sylvester_identity"]
   },
   {
     "id": "ann-e315-vardi",
@@ -78,7 +78,7 @@
     "mathContext": "Named after Ilan Vardi who studied it. Also appears in dynamics of iteration maps.",
     "significance": "key",
     "relatedConcepts": ["OEIS A076393", "Growth rates", "Transcendental numbers"],
-    "prerequisites": ["mathematical-constants", "growth-rates", "transcendental-numbers", "limits"]
+    "prerequisites": ["Real.rpow", "Filter.Tendsto", "sequence limits"]
   },
   {
     "id": "ann-e315-egyptian-seq",
@@ -89,7 +89,7 @@
     "content": "**EgyptianSequence:**\n\nA structure capturing sequences (a_n) satisfying:\n- strictly increasing\n- all terms positive\n- Σ 1/a_n = 1 (in the limit)\n\nThis formalizes 'any other sequence' in the conjecture statement.",
     "significance": "key",
     "relatedConcepts": ["Lean structures", "Type-theoretic encoding"],
-    "prerequisites": ["lean-structures", "formalization", "egyptian-fractions"]
+    "prerequisites": ["Lean structures", "StrictMono", "infinite series"]
   },
   {
     "id": "ann-e315-growth-rate",
@@ -100,7 +100,7 @@
     "content": "**growthRate:**\n\nFor an EgyptianSequence seq: growthRate(seq) = liminf a_n^{1/2^n}\n\nUsing liminf (not lim) allows for sequences where the limit may not exist.\n\nThe conjecture compares growthRate(seq) to vardiConstant.",
     "significance": "key",
     "relatedConcepts": ["Liminf", "Asymptotic analysis"],
-    "prerequisites": ["liminf", "asymptotic-analysis", "growth-rates"]
+    "prerequisites": ["Filter.liminf", "Real.rpow", "EgyptianSequence"]
   },
   {
     "id": "ann-e315-conjecture",
@@ -111,7 +111,7 @@
     "content": "**erdosGrahamConjecture:**\n\nFor any EgyptianSequence seq with seq.a ≠ sylvester:\n\n  growthRate(seq) < vardiConstant\n\nSylvester's sequence has the **strictly** largest growth rate among all Egyptian sequences for 1.\n\nThis formalizes Erdős Problem #315.",
     "significance": "key",
     "relatedConcepts": ["Optimality", "Extremal sequences"],
-    "prerequisites": ["extremal-problems", "optimality", "conjecture-formalization", "erdos-problems"]
+    "prerequisites": ["EgyptianSequence", "growthRate", "vardiConstant"]
   },
   {
     "id": "ann-e315-solution",
@@ -123,7 +123,7 @@
     "mathContext": "A 45-year-old conjecture resolved! The proofs use deep analysis of Egyptian fraction representations.",
     "significance": "key",
     "relatedConcepts": ["Recent results", "Independent discovery"],
-    "prerequisites": ["solved-conjecture", "independent-discovery", "recent-results", "axiomatized-result"]
+    "prerequisites": ["erdosGrahamConjecture definition"]
   },
   {
     "id": "ann-e315-double-exp",
@@ -134,7 +134,7 @@
     "content": "**sylvester_double_exponential:**\n\nFor any ε > 0, eventually |u_n^{1/2^n} - c₀| < ε.\n\nThis means u_n ~ c₀^{2^n} - doubly exponential growth.\n\n**Proof:** Direct application of vardiConstant_is_limit via Metric.tendsto_atTop.",
     "significance": "key",
     "relatedConcepts": ["Tower of exponents", "Convergence"],
-    "prerequisites": ["double-exponential-growth", "convergence", "epsilon-delta"]
+    "prerequisites": ["vardiConstant_is_limit", "Metric.tendsto_atTop"]
   },
   {
     "id": "ann-e315-summary",
@@ -145,6 +145,6 @@
     "content": "**erdos_315_summary:**\n\nCombines the main result with the Vardi constant bounds:\n\n1. erdosGrahamConjecture holds (Kamio, Li-Tang 2025)\n2. 1.264 < vardiConstant < 1.265\n\nSylvester's sequence is the unique maximizer of growth rate among Egyptian sequences for 1.",
     "significance": "key",
     "relatedConcepts": ["Main theorem", "Summary"],
-    "prerequisites": ["summary-theorem", "optimality", "vardi-constant"]
+    "prerequisites": ["kamio_li_tang_2025", "vardiConstant_bounds"]
   }
 ]

--- a/src/data/proofs/erdos-315/meta.json
+++ b/src/data/proofs/erdos-315/meta.json
@@ -111,72 +111,82 @@
     {
       "id": "overview",
       "title": "Overview",
-      "summary": "Egyptian fractions and the greedy algorithm",
+      "summary": "Egyptian fractions and the greedy algorithm. Sylvester's sequence arises from always taking the largest unit fraction not exceeding the remainder.",
       "startLine": 32,
-      "endLine": 46
+      "endLine": 46,
+      "mathContext": "$1 = \\frac{1}{2} + \\frac{1}{3} + \\frac{1}{7} + \\frac{1}{43} + \\frac{1}{1807} + \\cdots$"
     },
     {
       "id": "sylvester",
       "title": "Sylvester's Sequence",
-      "summary": "Definition and basic properties",
+      "summary": "Recursive definition: sylvester 0 = 2, sylvester (n+1) = sylvester n ^ 2 - sylvester n + 1. Proved: strict monotonicity (by strong induction), all terms >= 2, first 5 values by rfl.",
       "startLine": 48,
-      "endLine": 97
+      "endLine": 97,
+      "mathContext": "$u_0 = 2,\\; u_{n+1} = u_n^2 - u_n + 1$. OEIS A000058: 2, 3, 7, 43, 1807, 3263443, ..."
     },
     {
       "id": "egyptian",
       "title": "Egyptian Fraction Property",
-      "summary": "Sum equals 1, telescoping",
+      "summary": "The key identity $u_{n+1} - 1 = u_n(u_n - 1)$ proved by direct computation, enabling the telescoping proof that $\\sum 1/u_n = 1$ (axiomatized).",
       "startLine": 99,
-      "endLine": 124
+      "endLine": 124,
+      "mathContext": "$\\frac{1}{u_n} = \\frac{1}{u_n - 1} - \\frac{1}{u_{n+1} - 1}$ telescopes to give $\\sum_{n=0}^{\\infty} \\frac{1}{u_n} = 1$"
     },
     {
       "id": "vardi",
       "title": "The Vardi Constant",
-      "summary": "c₀ ≈ 1.264085 definition and properties",
+      "summary": "Defines $c_0 = \\lim u_n^{1/2^n}$ with axiomatized existence and bounds $1.264 < c_0 < 1.265$. Named after Ilan Vardi (1991).",
       "startLine": 126,
-      "endLine": 141
+      "endLine": 141,
+      "mathContext": "$c_0 = \\lim_{n \\to \\infty} u_n^{1/2^n} \\approx 1.264085\\ldots$ (OEIS A076393)"
     },
     {
       "id": "conjecture",
       "title": "The Main Conjecture",
-      "summary": "EgyptianSequence structure, growthRate, statement",
+      "summary": "EgyptianSequence structure (strictly increasing, positive terms, sum = 1), growthRate as liminf, and the formal conjecture: for any non-Sylvester Egyptian sequence, growthRate < vardiConstant.",
       "startLine": 143,
-      "endLine": 172
+      "endLine": 172,
+      "mathContext": "$\\forall (a_n)$ with $a_n$ strictly increasing and $\\sum 1/a_n = 1$: $\\liminf a_n^{1/2^n} < c_0$ unless $a = u$"
     },
     {
       "id": "solution",
       "title": "The Solution",
-      "summary": "Kamio and Li-Tang (2025)",
+      "summary": "Axiom kamio_li_tang_2025 asserts erdosGrahamConjecture holds, citing the 2025 independent proofs by Kamio and Li-Tang.",
       "startLine": 174,
-      "endLine": 185
+      "endLine": 185,
+      "mathContext": "Solved independently: Kamio (arXiv:2503.02317), Li-Tang (arXiv:2503.12277), both 2025"
     },
     {
       "id": "special",
       "title": "Why Sylvester Is Special",
-      "summary": "Greedy property, double exponential",
+      "summary": "The greedy property (each term is the greedy choice) and proved double exponential growth: $u_n \\sim c_0^{2^n}$ derived from the Vardi constant limit.",
       "startLine": 187,
-      "endLine": 209
+      "endLine": 209,
+      "mathContext": "$\\forall \\varepsilon > 0,\\; \\exists N : n \\geq N \\implies |u_n^{1/2^n} - c_0| < \\varepsilon$"
     },
     {
       "id": "related",
       "title": "Connection to Other Problems",
-      "summary": "Erdős-Straus conjecture (4/n = 1/a + 1/b + 1/c), odd greedy expansion, OEIS references A000058 and A076393.",
+      "summary": "Links to Erdős-Straus conjecture ($4/n = 1/a + 1/b + 1/c$), odd greedy expansion, and OEIS references A000058 and A076393.",
       "startLine": 211,
-      "endLine": 227
+      "endLine": 227,
+      "mathContext": "Erdős-Straus: $\\forall n \\geq 2, \\exists a,b,c : 4/n = 1/a + 1/b + 1/c$"
     },
     {
       "id": "historical",
       "title": "Historical Note",
-      "summary": "The original [ErGr80] formulation used u₁=1, u_{n+1}=u_n(u_n+1), which doesn't satisfy Σ 1/u_n = 1. Corrected by Quanyu Tang.",
+      "summary": "The original [ErGr80] formulation used $u_1=1, u_{n+1}=u_n(u_n+1)$, which doesn't satisfy $\\sum 1/u_n = 1$. Corrected by Quanyu Tang to the standard $u_1=2$ version.",
       "startLine": 228,
-      "endLine": 236
+      "endLine": 236,
+      "mathContext": "With $u_1=1$: $\\sum 1/u_n = 1/1 + 1/2 + 1/6 + \\cdots > 1$, violating the condition"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_315 and erdos_315_summary combine the solved conjecture with Vardi constant bounds 1.264 < c₀ < 1.265.",
+      "summary": "erdos_315 and erdos_315_summary combine the solved conjecture with Vardi constant bounds $1.264 < c_0 < 1.265$. Status: SOLVED.",
       "startLine": 238,
-      "endLine": 266
+      "endLine": 266,
+      "mathContext": "$(\\text{erdosGrahamConjecture}) \\wedge (1.264 < c_0 < 1.265)$"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Added `mathContext` (LaTeX) to all 10 sections
- Expanded section summaries with mathematical detail (telescoping identity, Vardi constant, double exponential)
- Fixed annotation prerequisites from kebab-case tags to proper math concepts and Lean references

## Axiom integrity check
- `axiomCount: 6` — confirmed matches Lean file
- `status: "axiomatized"`, `badge: "axiom"` — correct

## Test plan
- [x] JSON validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)