### PR TITLE
Enrich erdos-487: deepen historicalContext, fix section titles

### DIFF
--- a/src/data/proofs/erdos-487/meta.json
+++ b/src/data/proofs/erdos-487/meta.json
@@ -33,7 +33,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "This problem connects divisibility in dense sets to combinatorial set theory. The key insight is a bijection between LCM triples and set unions under prime factorization. Davenport and Erdős (1936) proved that dense sets contain infinite divisibility chains. Kleitman (1971) resolved this problem by proving that union-free collections of subsets of [n] have size at most (1+o(1))·C(n, ⌊n/2⌋), which is o(2^n). This bound implies that LCM-free (hence union-free) sets cannot have positive density.",
+    "historicalContext": "This problem sits at the intersection of multiplicative number theory and extremal combinatorics. The foundational insight, recognized by Erdős, is that prime factorization creates a bijection between positive integers and finite subsets of primes (with multiplicities), under which lcm corresponds to set union. Harold Davenport and Erdős proved in 1936 that any set of integers with positive upper density contains arbitrarily long divisibility chains a₁ | a₂ | ··· | aₖ, establishing that dense sets carry rich multiplicative structure. The LCM triple question asks whether this extends to the weaker relation lcm(a,b) = c. Daniel Kleitman resolved it affirmatively in 1971 via a purely combinatorial argument: he proved that union-free families of subsets of an n-element set have size at most (1+o(1))·C(n, ⌊n/2⌋), which is exponentially smaller than 2^n. Under the prime factorization correspondence, an LCM-free set of integers maps to a union-free collection, and Kleitman's bound forces such sets to have density zero. The proof is elegant in its use of the bijection to transfer a number-theoretic question to an extremal set system result.",
     "problemStatement": "Let A ⊆ ℕ have positive density. Must there exist distinct a, b, c ∈ A such that [a,b] = c (where [a,b] is the least common multiple of a and b)?",
     "proofStrategy": "The proof works by contradiction using the prime factorization bijection. If A has positive density δ > 0 but no LCM triples, then the image of A under the prime factorization map is a union-free collection of sets. By Kleitman's theorem, such collections have size o(2^n), which translates to o(N) elements up to N. But positive density requires at least δN elements, a contradiction for large N.",
     "keyInsights": [
@@ -50,49 +50,49 @@
       "startLine": 47,
       "endLine": 82,
       "summary": "Definitions for positive upper density, positive lower density, LCM triples, and divisibility chains.",
-      "title": "Definitions for positive upper density, positive lower density, LCM triples, and divisibility chains."
+      "title": "Density and LCM Definitions"
     },
     {
       "id": "union-free",
       "startLine": 83,
       "endLine": 109,
       "summary": "Definition of union-free collections and the prime factorization bijection connecting LCM to set union.",
-      "title": "Definition of union-free collections and the prime factorization bijection connecting LCM to set union."
+      "title": "Union-Free Collections"
     },
     {
       "id": "davenport-erdos",
       "startLine": 110,
       "endLine": 156,
       "summary": "The 1936 Davenport-Erdős result and the coprime multipliers LCM triple construction.",
-      "title": "The 1936 Davenport-Erdős result and the coprime multipliers LCM triple construction."
+      "title": "Davenport-Erdős Theorem"
     },
     {
       "id": "kleitman",
       "startLine": 158,
       "endLine": 221,
       "summary": "Kleitman's 1971 theorem bounding union-free collections, plus the o(2^n) corollary.",
-      "title": "Kleitman's 1971 theorem bounding union-free collections, plus the o(2^n) corollary."
+      "title": "Kleitman's Theorem"
     },
     {
       "id": "main-result",
       "startLine": 223,
       "endLine": 243,
       "summary": "The main theorem: dense sets contain LCM triples, plus infinitely many such triples.",
-      "title": "The main theorem: dense sets contain LCM triples, plus infinitely many such triples."
+      "title": "Main Result"
     },
     {
       "id": "examples",
       "startLine": 245,
       "endLine": 310,
       "summary": "Concrete examples including multiples of 6 (LCM triples exist) and powers of 2 (no LCM triples, but density 0).",
-      "title": "Concrete examples including multiples of 6 (LCM triples exist) and powers of 2 (no LCM triples, but density 0)."
+      "title": "Examples"
     },
     {
       "id": "summary",
       "startLine": 335,
       "endLine": 368,
       "summary": "Summary combining LCM triple existence and Kleitman's theorem.",
-      "title": "Summary combining LCM triple existence and Kleitman's theorem."
+      "title": "Summary"
     }
   ],
   "conclusion": {
@@ -128,6 +128,6 @@
     }
   ],
   "relatedProofs": [
-    "erdos-483"
+    {"id": "erdos-483", "relationship": "related", "description": "Both are Erdős problems about structure forced by density: #483 studies Schur numbers (monochromatic a+b=c in colorings), #487 studies LCM triples in dense sets"}
   ]
 }


### PR DESCRIPTION
Enrichment pass for erdos-487 (LCM Triples in Dense Sets).

## Changes
- **historicalContext**: Expanded from ~400 to ~1000 chars with Davenport-Erdős 1936 divisibility chain result, Kleitman's combinatorial argument via union-free families, and the prime factorization bijection transferring number theory to extremal set theory
- **sections**: Fixed 7 section titles that duplicated their summary text (titles should be concise names like "Kleitman's Theorem", not full descriptions)
- **relatedProofs**: Converted from bare string array to structured objects with descriptions

## Axiom integrity
No changes to axiomCount (6), status (axiomatized), or badge (axiom). Consistent with Lean file (0 sorries).