### PR TITLE
Enrich erdos-269: add mathContext, prerequisites, fix significance

### DIFF
--- a/src/data/proofs/erdos-269/annotations.json
+++ b/src/data/proofs/erdos-269/annotations.json
@@ -7,8 +7,9 @@
     "title": "Problem Overview",
     "content": "**Erdos Problem #269: LCM Series Irrationality**\n\nLet P be a finite set of primes with |P| >= 2.\nLet {a_n} be the P-smooth numbers (all prime factors in P).\nLet L_n = [a_0,...,a_{n-1}] be the partial LCM.\n\n**Question:** Is the series sum 1/L_n irrational?\n\n**Status:**\n- Finite P: OPEN\n- Infinite P: SOLVED (always irrational)\n- Distinct terms: SOLVED (irrational)",
     "mathContext": "From Erdos's letter to Fibonacci Quarterly (1973). Published in Vol. 12 (1974), p. 335. Related work in [ErGr80] and [Er88c].",
-    "significance": "critical",
-    "relatedConcepts": ["smooth numbers", "irrationality", "LCM", "infinite series"]
+    "significance": "key",
+    "relatedConcepts": ["smooth numbers", "irrationality", "LCM", "infinite series"],
+    "prerequisites": ["prime numbers", "LCM", "irrationality"]
   },
   {
     "id": "ann-e269-psmooth",
@@ -18,8 +19,9 @@
     "title": "P-smooth Numbers",
     "content": "**IsPSmooth P n:** n is P-smooth (all prime divisors in P).\n\n```lean\ndef IsPSmooth (P : Set N) (n : N) : Prop :=\n  n > 0 and forall p, p.Prime -> p | n -> p in P\n```\n\n**Examples for P = {2, 3}:**\n1, 2, 3, 4, 6, 8, 9, 12, 16, 18, 24, 27, ...\n\n**Properties:**\n- 1 is P-smooth for any P (vacuously true)\n- If p in P and p prime, then p is P-smooth\n- Product of P-smooth numbers is P-smooth",
     "mathContext": "Also called P-friable numbers. Fundamental in computational number theory (factorization algorithms, number field sieve).",
-    "significance": "critical",
-    "relatedConcepts": ["friable numbers", "regular numbers", "multiplicative semigroups"]
+    "significance": "key",
+    "relatedConcepts": ["friable numbers", "regular numbers", "multiplicative semigroups"],
+    "prerequisites": ["Nat.Prime", "Nat.dvd", "Set membership"]
   },
   {
     "id": "ann-e269-sequence",
@@ -29,7 +31,8 @@
     "title": "The P-smooth Sequence",
     "content": "**smoothSeq P:** Enumeration of P-smooth numbers.\n\n```lean\nnoncomputable def smoothSeq (P : Set N) : N -> N :=\n  Nat.nth (IsPSmooth P)\n```\n\n**For P = {2, 3}:**\n- smoothSeq P 0 = 1\n- smoothSeq P 1 = 2\n- smoothSeq P 2 = 3\n- smoothSeq P 3 = 4\n- smoothSeq P 4 = 6\n- ...\n\nThe sequence is strictly increasing and exhausts all P-smooth numbers.",
     "significance": "key",
-    "relatedConcepts": ["enumeration", "increasing sequences", "Nat.nth"]
+    "relatedConcepts": ["enumeration", "increasing sequences", "Nat.nth"],
+    "prerequisites": ["Nat.nth", "IsPSmooth definition"]
   },
   {
     "id": "ann-e269-lcm",
@@ -39,8 +42,9 @@
     "title": "Partial LCM",
     "content": "**partialLcm P n = L_n = [a_0,...,a_{n-1}]**\n\n```lean\nnoncomputable def partialLcm (P : Set N) (n : N) : N :=\n  (Finset.range n).lcm (smoothSeq P)\n```\n\n**Key Properties:**\n- L_0 = 1 (empty LCM)\n- L_1 = 1 (just a_0 = 1)\n- L_{n+1} = lcm(L_n, a_n)\n- L_n is monotone non-decreasing\n- L_n is P-smooth\n\n**For P = {2,3}:**\nL_1=1, L_2=2, L_3=6, L_4=12, L_5=12 (duplicate!), ...",
     "mathContext": "The key insight is that L_n stays constant when a_n | L_{n-1}. These 'duplicate' terms complicate the analysis.",
-    "significance": "critical",
-    "relatedConcepts": ["LCM", "lattice operations", "Finset.lcm"]
+    "significance": "key",
+    "relatedConcepts": ["LCM", "lattice operations", "Finset.lcm"],
+    "prerequisites": ["Finset.lcm", "smoothSeq definition"]
   },
   {
     "id": "ann-e269-series",
@@ -49,8 +53,9 @@
     "type": "definition",
     "title": "The LCM Series",
     "content": "**lcmSeries P = sum 1/L_n**\n\n```lean\nnoncomputable def lcmSeries (P : Set N) : R :=\n  tsum (fun n => (1 : R) / (partialLcm P n))\n```\n\n**Properties:**\n- Always converges (L_n grows at least exponentially)\n- Always positive\n- For P = {2,3}: S ~ 1 + 1/2 + 1/6 + 1/12 + 1/12 + ...\n\nThe series includes duplicate terms when L_n = L_{n-1}.",
-    "significance": "critical",
-    "relatedConcepts": ["infinite series", "convergence", "tsum"]
+    "significance": "key",
+    "relatedConcepts": ["infinite series", "convergence", "tsum"],
+    "prerequisites": ["tsum", "partialLcm definition"]
   },
   {
     "id": "ann-e269-main",
@@ -60,8 +65,9 @@
     "title": "The Main Conjecture (OPEN)",
     "content": "**erdos_269 (OPEN):**\n\n```lean\naxiom erdos_269 (P : Finset N) (hPrime : forall p in P, p.Prime)\n    (hCard : P.card >= 2) :\n    Irrational (lcmSeries (P : Set N))\n```\n\n**Statement:**\nFor any finite set P of at least 2 primes, the LCM series is irrational.\n\n**What Makes It Hard:**\nThe duplicate terms (when L_n = L_{n-1}) create a complex pattern that depends on the specific primes in P.",
     "mathContext": "The finite case remains open. Understanding the duplicate pattern is the key challenge.",
-    "significance": "critical",
-    "relatedConcepts": ["irrationality", "open problems", "finite sets of primes"]
+    "significance": "key",
+    "relatedConcepts": ["irrationality", "open problems", "finite sets of primes"],
+    "prerequisites": ["Irrational", "lcmSeries definition", "Finset"]
   },
   {
     "id": "ann-e269-infinite",
@@ -71,8 +77,9 @@
     "title": "Infinite P Case (SOLVED)",
     "content": "**erdos_269_infinite:**\n\n```lean\naxiom erdos_269_infinite (P : Set N)\n    (hPrime : forall p in P, p.Prime) (hInf : P.Infinite) :\n    Irrational (lcmSeries P)\n```\n\n**Erdos called this 'a simple exercise'.**\n\n**Why It's Easier:**\nWith infinitely many primes, there are infinitely many 'new contributions' at each p-adic level, preventing the series from being rational.\n\nThe finite case lacks this infinite source of irrationality.",
     "mathContext": "The infinite case was solved by Erdos. The key difference is that infinite P provides endless new structure.",
-    "significance": "critical",
-    "relatedConcepts": ["infinite sets", "p-adic contributions", "solved cases"]
+    "significance": "key",
+    "relatedConcepts": ["infinite sets", "p-adic contributions", "solved cases"],
+    "prerequisites": ["Set.Infinite", "lcmSeries definition"]
   },
   {
     "id": "ann-e269-examples",
@@ -82,7 +89,8 @@
     "title": "Example: P = {2, 3}",
     "content": "**The 3-smooth Numbers:**\n\n```lean\ndef twoThreeSmooth : Set N := {2, 3}\n```\n\n**Sequence:** 1, 2, 3, 4, 6, 8, 9, 12, 16, 18, 24, 27, ...\n\n**Partial LCMs:**\n- L_1 = 1\n- L_2 = 2\n- L_3 = lcm(2,3) = 6\n- L_4 = lcm(6,4) = 12\n- L_5 = lcm(12,6) = 12 (duplicate!)\n- L_6 = lcm(12,8) = 24\n- ...\n\n**Note:** a_4 = 6 divides L_3 = 6, so L_4 = L_5.",
     "significance": "key",
-    "relatedConcepts": ["3-smooth numbers", "regular numbers", "Babylonian mathematics"]
+    "relatedConcepts": ["3-smooth numbers", "regular numbers", "Babylonian mathematics"],
+    "prerequisites": ["IsPSmooth", "partialLcm", "Nat.lcm"]
   },
   {
     "id": "ann-e269-padic",
@@ -93,7 +101,8 @@
     "content": "**lcmPadicVal p n P = v_p(L_n)**\n\nThe p-adic valuation of the partial LCM.\n\n**Key Properties:**\n- Non-decreasing in n (for p in P)\n- Increases when a new power of p enters the sequence\n- v_p(L_n) = max{v_p(a_i) : i < n}\n\n**Insight:**\nThe LCM L_n 'records' the highest power of each prime seen so far. When p^k first appears in the sequence, v_p(L_n) jumps from k-1 to k.",
     "mathContext": "P-adic valuations are fundamental tools in number theory. They measure how divisible a number is by prime powers.",
     "significance": "key",
-    "relatedConcepts": ["p-adic valuation", "prime factorization", "LCM structure"]
+    "relatedConcepts": ["p-adic valuation", "prime factorization", "LCM structure"],
+    "prerequisites": ["Nat.padicValNat", "partialLcm definition"]
   },
   {
     "id": "ann-e269-distinct",
@@ -103,8 +112,9 @@
     "title": "Distinct Terms Case (SOLVED)",
     "content": "**erdos_269_distinct:**\n\nIf we remove duplicate terms (where L_n = L_{n-1}), the series is irrational.\n\n```lean\ndef distinctLcmTerms (P : Set N) : Set N :=\n  { n | n = 0 or partialLcm P n != partialLcm P (n - 1) }\n\naxiom erdos_269_distinct (P : Finset N) ... :\n    Irrational (distinctLcmSeries (P : Set N))\n```\n\n**Note by Erdos:**\nThe series without duplicates is irrational. The difficulty is precisely the duplicate terms!",
     "mathContext": "This partial result shows that duplicates are the key obstacle. The 'cleaned' series is tractable.",
-    "significance": "critical",
-    "relatedConcepts": ["duplicate removal", "partial results", "series manipulation"]
+    "significance": "key",
+    "relatedConcepts": ["duplicate removal", "partial results", "series manipulation"],
+    "prerequisites": ["partialLcm", "Irrational", "tsum"]
   },
   {
     "id": "ann-e269-summary",
@@ -113,7 +123,8 @@
     "type": "theorem",
     "title": "Summary",
     "content": "**Erdos Problem #269: Summary**\n\n```lean\ntheorem erdos_269_summary :\n    -- Infinite case is solved\n    (forall P, primes in P -> P.Infinite -> Irrational (lcmSeries P)) and\n    -- Distinct case is solved\n    (forall P finite primes, |P|>=2 -> Irrational (distinctLcmSeries P)) and\n    -- General finite case is open\n    True\n```\n\n**State of Knowledge:**\n1. Infinite P: SOLVED (irrational)\n2. Finite P, distinct: SOLVED (irrational)\n3. Finite P, full: OPEN",
-    "significance": "critical",
-    "relatedConcepts": ["open problems", "partial solutions", "research directions"]
+    "significance": "key",
+    "relatedConcepts": ["open problems", "partial solutions", "research directions"],
+    "prerequisites": ["erdos_269", "erdos_269_infinite", "erdos_269_distinct"]
   }
 ]

--- a/src/data/proofs/erdos-269/meta.json
+++ b/src/data/proofs/erdos-269/meta.json
@@ -85,79 +85,90 @@
     {
       "id": "psmooth",
       "title": "P-smooth Numbers",
-      "summary": "IsPSmooth definition, basic properties",
+      "summary": "Defines IsPSmooth: $n$ is $P$-smooth if all prime divisors of $n$ lie in $P$. Proves basic properties including closure under multiplication and primality checks.",
       "startLine": 34,
-      "endLine": 72
+      "endLine": 72,
+      "mathContext": "$\\text{IsPSmooth}(P, n) \\iff n > 0 \\wedge \\forall p \\mid n,\\; p \\text{ prime} \\implies p \\in P$"
     },
     {
       "id": "sequence",
       "title": "The P-smooth Sequence",
-      "summary": "smoothSeq enumeration and properties",
+      "summary": "Enumerates $P$-smooth numbers in increasing order as `smoothSeq P`. Properties: strictly increasing, all terms are $P$-smooth.",
       "startLine": 74,
-      "endLine": 92
+      "endLine": 92,
+      "mathContext": "$a_0 < a_1 < a_2 < \\cdots$ where $\\{a_n\\} = \\{n \\in \\mathbb{N} : n \\text{ is } P\\text{-smooth}\\}$"
     },
     {
       "id": "partial-lcm",
       "title": "Partial LCM",
-      "summary": "L_n = [a_0,...,a_{n-1}] definition and properties",
+      "summary": "Defines $L_n = \\text{lcm}(a_0, \\ldots, a_{n-1})$ as the cumulative LCM of the first $n$ smooth numbers. Properties: divisibility chain $L_n \\mid L_{n+1}$, growth bounds.",
       "startLine": 94,
-      "endLine": 128
+      "endLine": 128,
+      "mathContext": "$L_n = [a_0, a_1, \\ldots, a_{n-1}]$ with $L_n \\mid L_{n+1}$ and $L_n = \\prod_{p \\in P} p^{\\lfloor \\log_p a_{n-1} \\rfloor}$"
     },
     {
       "id": "series",
       "title": "The Series",
-      "summary": "lcmSeries definition, convergence, positivity",
+      "summary": "Defines the LCM series $S = \\sum_{n=1}^{\\infty} 1/L_n$. Axiomatizes convergence and positivity. This is the central object whose irrationality is questioned.",
       "startLine": 130,
-      "endLine": 151
+      "endLine": 151,
+      "mathContext": "$S_P = \\sum_{n=1}^{\\infty} \\frac{1}{L_n}$, where $L_n$ grows at least exponentially"
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture (OPEN)",
-      "summary": "erdos_269 axiom for finite P",
+      "summary": "Axiom erdos_269: for any finite $P$ with $|P| \\geq 2$, the series $S_P$ is irrational. This is the open problem.",
       "startLine": 153,
-      "endLine": 175
+      "endLine": 175,
+      "mathContext": "$|P| \\geq 2,\\; P \\text{ finite} \\implies S_P \\notin \\mathbb{Q}$"
     },
     {
       "id": "infinite-case",
       "title": "The Infinite Case (SOLVED)",
-      "summary": "erdos_269_infinite axiom",
+      "summary": "Axiom erdos_269_infinite: when $P$ is the set of all primes, $S_P$ is always irrational. This resolved case uses that $L_n = \\text{lcm}(1, \\ldots, n) \\sim e^n$.",
       "startLine": 177,
-      "endLine": 192
+      "endLine": 192,
+      "mathContext": "$P = \\{\\text{all primes}\\} \\implies L_n = \\text{lcm}(1, \\ldots, n)$ and $\\sum 1/L_n \\notin \\mathbb{Q}$"
     },
     {
       "id": "examples",
       "title": "Examples",
-      "summary": "P = {2,3} worked examples",
+      "summary": "Worked examples for $P = \\{2,3\\}$: smooth sequence is 1, 2, 3, 4, 6, 8, 9, 12, ...; LCMs and series partial sums computed explicitly.",
       "startLine": 194,
-      "endLine": 228
+      "endLine": 228,
+      "mathContext": "$P = \\{2,3\\}$: $L_1 = 1, L_2 = 2, L_3 = 6, L_4 = 12, \\ldots$"
     },
     {
       "id": "padic",
       "title": "Structural Properties",
-      "summary": "P-adic valuation analysis",
+      "summary": "$p$-adic valuation analysis of $L_n$: $v_p(L_n) = \\max\\{v_p(a_i) : i < n\\}$ for each $p \\in P$. This determines when $L_n$ increases.",
       "startLine": 230,
-      "endLine": 256
+      "endLine": 256,
+      "mathContext": "$v_p(L_n) = \\max_{i < n} v_p(a_i) = \\lfloor \\log_p(a_{n-1}) \\rfloor$ for $p \\in P$"
     },
     {
       "id": "difficulty",
       "title": "Why It's Hard",
-      "summary": "Analysis of the finite P difficulty",
+      "summary": "Analysis of why the finite $P$ case resists known irrationality techniques. The $P$-smooth numbers have multiplicative structure that complicates standard approaches (Nesterenko, Zudilin, etc.).",
       "startLine": 258,
-      "endLine": 282
+      "endLine": 282,
+      "mathContext": "For finite $P$, consecutive $L_n$ ratios are bounded, unlike the infinite case where $L_{n+1}/L_n$ can be any prime"
     },
     {
       "id": "partial-result",
       "title": "Known Partial Result",
-      "summary": "Distinct terms case is solved",
+      "summary": "The distinct-terms case is solved: if duplicate LCM values are removed, the resulting series is irrational. Axiom erdos_269_distinct_terms.",
       "startLine": 284,
-      "endLine": 306
+      "endLine": 306,
+      "mathContext": "$\\sum_{L_n \\neq L_{n-1}} \\frac{1}{L_n} \\notin \\mathbb{Q}$ (dropping repeated terms preserves irrationality)"
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_269_summary theorem",
+      "summary": "erdos_269_summary: combines the open finite case, solved infinite case, and solved distinct-terms case into one theorem.",
       "startLine": 308,
-      "endLine": 340
+      "endLine": 340,
+      "mathContext": "Finite $P$ (OPEN) $\\wedge$ Infinite $P$ (irrational) $\\wedge$ Distinct terms (irrational)"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Added `mathContext` (LaTeX) to all 11 sections
- Added `prerequisites` to all 11 annotations with Lean definition references
- Fixed `significance` from non-standard "critical" to schema "key"

## Test plan
- [x] JSON validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)