### PR TITLE
Enricher-2 batch: enrich 2 entries (quality 98→100)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
@@ -99,6 +99,13 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble: Imports and Galois Theory Setup",
+      "startLine": 1,
+      "endLine": 20,
+      "summary": "Module header documenting the file's role in the OQ-02 axiom elimination program, followed by imports of full Mathlib (for Polynomial.Gal, IsPGroup, IntermediateField, tower law) and the parent file AngleTrisectionOQ01 (for dvd_pow_two_is_pow_two). Opens the Polynomial namespace for F[X] notation and scoped IntermediateField for F⟮α⟯ notation."
+    },
+    {
       "id": "natdegree-dvd-gal",
       "title": "Part I: natDegree Divides |Gal| for Irreducible Polynomials",
       "startLine": 22,
@@ -150,6 +157,13 @@
       "year": "1846",
       "venue": "Journal de Mathématiques Pures et Appliquées, 11, pp. 417-433",
       "note": "Posthumous publication establishing group theory foundations; the Galois group characterization of constructibility follows from this framework"
+    },
+    {
+      "authors": "Stewart, Ian",
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "Chapman and Hall/CRC, 4th edition",
+      "note": "Modern textbook treatment of the Wantzel-Galois constructibility criterion via the tower law, paralleling this formalization's proof strategy"
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary
Enrichment pass for 2 gallery entries, bringing both from quality 98 to 100.

### angle-trisection-oq-02-oq-01
- Added preamble section (lines 1-20) covering imports and Galois theory namespace setup
- Added Stewart's *Galois Theory* (4th ed.) to top-level references

### erdos-731
- Added preamble section (lines 1-24) covering imports and module header
- Added `mathlibDependencies` (Nat.choose, Nat.find, Nat.Prime)
- Added `meta.references` for EGRS (1975) and Kummer (1852)

## Test plan
- [x] JSON validates successfully for both entries
- [x] Quality scores verified at 100/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)