### PR TITLE
Enrich erdos-995: add header section and preamble annotation (quality 98→100)

### DIFF
--- a/src/data/proofs/erdos-995/annotations.json
+++ b/src/data/proofs/erdos-995/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-995-preamble",
+    "proofId": "erdos-995",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "context",
+    "title": "File Preamble: Problem Statement and Mathlib Imports",
+    "content": "Docstring introduces Erdős Problem #995 on lacunary sums $\\sum_{k \\leq N} f(\\{\\alpha n_k\\})$. States the open conjecture $S_N = o(N\\sqrt{\\log\\log N})$ and both known bounds: the existential lower bound from Erdős (1949) involving $(\\log\\log N)^{1/2-\\varepsilon}$, and the universal upper bound involving $(\\log N)^{1/2+\\varepsilon}$. Imports Mathlib.Analysis.SpecialFunctions.Log.Basic (for $\\log$), Mathlib.MeasureTheory.Measure.Lebesgue.Basic (for Lebesgue measure, $\\forall^{\\mathrm{m}} \\alpha$), Mathlib.MeasureTheory.Function.L2Space (for $L^2([0,1])$ functions), and basic real/natural number libraries. Opens MeasureTheory and Real namespaces for concise notation.",
+    "mathContext": "The problem sits at the interface of harmonic analysis ($\\sum e(\\alpha n_k)$ Weyl sums), probability (LIL, CLT for quasi-independent variables), and ergodic theory (Birkhoff averages along subsequences). The 75-year gap between $(\\log\\log N)^{1/2}$ and $(\\log N)^{1/2}$ is one of the longest-standing open problems in metric number theory.",
+    "significance": "context",
+    "relatedConcepts": ["metric number theory", "Weyl sums", "LIL", "ergodic theory", "Mathlib imports"],
+    "prerequisites": ["Mathlib.Analysis.SpecialFunctions.Log", "Mathlib.MeasureTheory.Measure.Lebesgue"]
+  },
+  {
     "id": "ann-995-frac",
     "proofId": "erdos-995",
     "range": { "startLine": 40, "endLine": 41 },

--- a/src/data/proofs/erdos-995/meta.json
+++ b/src/data/proofs/erdos-995/meta.json
@@ -173,6 +173,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Preamble: Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "File docstring stating Erdős Problem #995: estimate ∑f({αn_k}) for lacunary sequences. Cites known bounds — lower (Erdős 1949): limsup reaches N(log log N)^{1/2-ε}; upper (Erdős): o(N(log N)^{1/2+ε}). Notes Erdős's 1964 belief that the lower bound is closer to truth. Imports Mathlib modules for logarithms, Lebesgue measure, L² spaces, and real/natural arithmetic. Opens MeasureTheory and Real namespaces."
+    },
+    {
       "id": "basic-definitions",
       "title": "Basic Definitions",
       "summary": "frac (fractional part), IsLacunary (gap condition with ratio q > 1), IsLacunarySeq (existential), lacunarySum (∑f({αn_k}))",


### PR DESCRIPTION
## Summary
- Added preamble section covering lines 1-35 (docstring, imports, namespace)
- Added annotation for file preamble with full problem context
- Full section coverage now spans entire Lean file (lines 1-228)

## Quality
- Entry: erdos-995 (Lacunary Sequences and Fractional Parts)
- Quality: 98 → 100
- Pass: 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)