### PR TITLE
Enricher-3 batch 2: deep enrichment across 5 entries

### DIFF
--- a/src/data/proofs/erdos-556/meta.json
+++ b/src/data/proofs/erdos-556/meta.json
@@ -133,28 +133,32 @@
       "title": "Small Cases",
       "startLine": 154,
       "endLine": 171,
-      "summary": "R(C_3;3) = 17, R(C_4;3) = 8, R(C_5;3) = 17."
+      "summary": "R(C_3;3) = 17, R(C_4;3) = 8, R(C_5;3) = 17.",
+      "mathContext": "$R(C_3; 3) = R(K_3; 3) = 17$ (Schur number + 1). $R(C_4; 3) = 8 = 2 \\cdot 4$. $R(C_5; 3) = 17 = 4 \\cdot 5 - 3$."
     },
     {
       "id": "regularity-method",
       "title": "The Regularity Method",
       "startLine": 173,
       "endLine": 188,
-      "summary": "Szemerédi Regularity Lemma and Blow-up Lemma in proofs."
+      "summary": "Szemerédi Regularity Lemma and Blow-up Lemma in proofs.",
+      "mathContext": "Szemerédi Regularity Lemma partitions $V(K_m)$ into $\\varepsilon$-regular pairs. Blow-up Lemma embeds $C_n$ into the regular cluster graph. Both are key tools in modern Ramsey theory."
     },
     {
       "id": "two-vs-three",
       "title": "Connection to 2-Color Ramsey",
       "startLine": 190,
       "endLine": 202,
-      "summary": "Comparison with 2-color Ramsey numbers for cycles."
+      "summary": "Comparison with 2-color Ramsey numbers for cycles.",
+      "mathContext": "$R(C_n; 2)$: for odd $n \\geq 3$, $R(C_n; 2) = 2n - 1$; for even $n \\geq 4$, $R(C_n; 2) = \\frac{3n}{2} - 1$. The 3-color case amplifies the parity effect."
     },
     {
       "id": "main-results",
       "title": "Main Results Summary",
       "startLine": 204,
       "endLine": 219,
-      "summary": "The erdos_556 theorem combining all results."
+      "summary": "The erdos_556 theorem combining all results.",
+      "mathContext": "`erdos_556`: $\\forall n \\geq 3$, Bondy-Erdős holds: $R(C_n; 3) \\leq 4n - 3$. Combines KSS (odd, exact) + Benevides-Skokan (even, $2n < 4n-3$) + small cases."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Continuation of enrichment work (batch 2, after PR #4620 was merged):

- **erdos-517**: Fixed all section/annotation line ranges for 176-line file (post-Aristotle), badge wip→axiom, added references
- **erdos-536**: Fixed status enhanced→axiomatized, standardized references format, added section mathContext
- **erdos-541**: Added references (Erdős-Szemerédi, Gao-Hamidoune-Wang, EGZ), section mathContext
- **erdos-549**: Fixed badge verified→wip (has 14 sorries), added mathContext to all 9 sections, standardized formats
- **erdos-556**: Added mathContext to all 10 sections, fixed last section endLine

### Common fixes
- Section mathContext fields added
- Invalid significance "critical" → "key"
- Standardized references/crossReferences/relatedProofs formats

## Test plan
- [x] All meta.json and annotations.json validate as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)