### PR TITLE
Enrich erdos-486, erdos-517: add prerequisites, cross-references, keyInsights

### DIFF
--- a/src/data/proofs/erdos-517/annotations.json
+++ b/src/data/proofs/erdos-517/annotations.json
@@ -8,8 +8,8 @@
     "content": "**Erdős Problem #517** asks about value distribution of lacunary entire functions - power series with gaps in their exponents.\n\nThe main conjecture (Fabry gaps: nₖ/k → ∞) is **OPEN**. A related result by Biernacki (1928) proves the stronger Fejér gap case (∑1/nₖ < ∞). The file was partially proved by Aristotle (the HasFejerGaps.hasFabryGaps theorem).",
     "mathContext": "Lacunary series $f(z) = \\sum a_k z^{n_k}$ with gaps in exponents have special value distribution properties. Picard's theorem guarantees entire functions miss at most one value; gap conditions can force every value to be assumed infinitely often.",
     "significance": "context",
-    "relatedConcepts": ["entire-functions", "lacunary-series", "value-distribution", "picard-theorem"],
-    "prerequisites": ["Mathlib.Topology.Order.Basic", "Mathlib.Topology.Algebra.InfiniteSum.Basic"]
+    "relatedConcepts": ["entire functions", "lacunary power series", "Picard's great theorem", "value distribution theory"],
+    "prerequisites": ["complex analysis fundamentals", "power series convergence", "Picard's theorem on value omission"]
   },
   {
     "id": "ann-e517-fabry-gaps",
@@ -20,8 +20,8 @@
     "content": "A sequence has **Fabry gaps** if it is strictly increasing AND nₖ/k → ∞. This is the weaker gap condition appearing in the main conjecture.\n\nExample: nₖ = k log k has Fabry gaps since (k log k)/k = log k → ∞.",
     "mathContext": "HasFabryGaps$(n) :\\iff$ StrictMono$(n) \\wedge \\lim_{k \\to \\infty} n_k/k = \\infty$. Formalized using `Tendsto (fun k => (n k : ℝ) / k) atTop atTop`.",
     "significance": "key",
-    "relatedConcepts": ["StrictMono", "Tendsto", "gap-condition", "Fabry"],
-    "prerequisites": ["Filter.Tendsto", "Filter.atTop"]
+    "relatedConcepts": ["Fabry gap theorem", "Hadamard gaps", "natural boundary", "Ostrowski-Hadamard gap theorem"],
+    "prerequisites": ["limits of real sequences", "strictly increasing sequences", "Filter.Tendsto and Filter.atTop"]
   },
   {
     "id": "ann-e517-fejer-gaps",
@@ -32,8 +32,8 @@
     "content": "A sequence has **Fejér gaps** if it is strictly increasing AND ∑1/nₖ < ∞. This is the stronger condition for which Biernacki's theorem applies.\n\nExample: nₖ = 2^k has Fejér gaps since ∑1/2^k = 1 < ∞.",
     "mathContext": "HasFejerGaps$(n) :\\iff$ StrictMono$(n) \\wedge$ Summable$(k \\mapsto (n_k)^{-1})$. The summability condition ensures gaps grow fast enough that reciprocals form a convergent series.",
     "significance": "key",
-    "relatedConcepts": ["Summable", "convergent-series", "gap-condition", "Fejér"],
-    "prerequisites": ["Summable", "StrictMono"]
+    "relatedConcepts": ["Fejér gap condition", "convergent series of reciprocals", "comparison test", "Hadamard lacunarity"],
+    "prerequisites": ["convergence of infinite series", "Summable in Mathlib", "strictly monotone sequences"]
   },
   {
     "id": "ann-e517-implication",
@@ -44,8 +44,8 @@
     "content": "If ∑1/nₖ < ∞ then nₖ/k → ∞. The proof uses a squeeze argument: since ∑(nₖ)⁻¹ converges, the partial sums over intervals [k/2, k) bound (k/2)·(nₖ)⁻¹, and as these partial sums tend to 0, we get (nₖ)⁻¹·k → 0, hence nₖ/k → ∞.\n\nThis theorem was fully proved by Aristotle's automated proof search. The proof is intricate, using filter_upwards, squeeze lemmas, and careful norm manipulations.",
     "mathContext": "Key step: $\\sum_{i=k/2}^{k-1} (n_i)^{-1} \\geq (k/2)(n_k)^{-1}$ (since $n$ is increasing). As $k \\to \\infty$, the left side $\\to 0$ (tail of convergent series), so $(n_k)^{-1} \\cdot k \\to 0$, hence $n_k/k \\to \\infty$.",
     "significance": "key",
-    "relatedConcepts": ["squeeze theorem", "Filter.Tendsto", "convergent series tails", "Aristotle"],
-    "prerequisites": ["Summable.hasSum.tendsto_sum_nat", "squeeze_zero_norm'"]
+    "relatedConcepts": ["squeeze theorem", "Cauchy criterion for series", "tail sums of convergent series", "automated proof search"],
+    "prerequisites": ["convergent series tail estimates", "squeeze lemma for sequences", "Filter.Tendsto manipulation"]
   },
   {
     "id": "ann-e517-main-conjecture",
@@ -56,8 +56,8 @@
     "content": "**The main open problem**: If f(z) = ∑ aₖz^{nₖ} is entire with Fabry gaps (nₖ/k → ∞), does f assume every value infinitely often?\n\nStated as a `def` returning `Prop` rather than an axiom, since we want to express that this is an open question whose truth value is unknown. The statement `{z : ℂ | f z = w}.Infinite` means the preimage of any value w is an infinite set.",
     "mathContext": "`fabryGapConjecture : Prop` $:= \\forall f, n, a,\\;$ HasFabryGaps$(n) \\to (\\forall z,\\; \\text{HasSum}(k \\mapsto a_k z^{n_k}, f(z))) \\to \\forall w,\\; \\{z : f(z) = w\\}$ is infinite.",
     "significance": "key",
-    "relatedConcepts": ["open-problem", "value-distribution", "Set.Infinite", "HasSum"],
-    "prerequisites": ["HasFabryGaps", "HasSum", "Set.Infinite"]
+    "relatedConcepts": ["Nevanlinna theory", "deficiency of values", "Picard's great theorem", "infinite preimage sets"],
+    "prerequisites": ["Fabry gap condition", "entire function representation via power series", "Set.Infinite in Mathlib"]
   },
   {
     "id": "ann-e517-biernacki",
@@ -68,8 +68,8 @@
     "content": "**Solved case**: Under the stronger Fejér gap condition (∑1/nₖ < ∞), entire functions DO assume every value infinitely often.\n\nStated as an **axiom** because the proof requires deep complex analysis not in Mathlib: (1) Picard's theorem on value omission, (2) boundary behavior of lacunary series near the unit circle, (3) growth estimates from the gap condition.",
     "mathContext": "Axiom `biernacki_theorem`: HasFejerGaps$(n) \\to (\\forall z,\\; \\text{HasSum}(k \\mapsto a_k z^{n_k}, f(z))) \\to \\forall w \\in \\mathbb{C},\\; \\{z : f(z) = w\\}$ is infinite.",
     "significance": "key",
-    "relatedConcepts": ["axiom", "Fejér-gaps", "Biernacki", "Picard-theorem", "value-distribution"],
-    "prerequisites": ["HasFejerGaps", "HasSum", "Set.Infinite"]
+    "relatedConcepts": ["Biernacki's theorem", "Picard's great theorem", "lacunary boundary behavior", "growth estimates for entire functions"],
+    "prerequisites": ["Fejér gap condition", "entire function power series representation", "complex analysis beyond Mathlib"]
   },
   {
     "id": "ann-e517-exponential-example",
@@ -80,8 +80,8 @@
     "content": "Verifies that nₖ = 2^k satisfies Fejér gaps: (1) strict monotonicity via `Nat.pow_lt_pow_right`, and (2) summability via `summable_geometric_of_lt_one` since ∑(1/2)^k converges.\n\nThis constructive example demonstrates the gap conditions are satisfiable and provides a concrete application of Biernacki's theorem.",
     "mathContext": "$n_k = 2^k$: StrictMono (powers of 2 are increasing), and $\\sum 2^{-k} \\leq \\sum (1/2)^k = 2 < \\infty$ (geometric series with ratio 1/2).",
     "significance": "supporting",
-    "relatedConcepts": ["geometric series", "summable_geometric_of_lt_one", "Nat.pow_lt_pow_right"],
-    "prerequisites": ["summable_geometric_of_lt_one"]
+    "relatedConcepts": ["geometric series", "summability of exponential reciprocals", "power-of-two sequences"],
+    "prerequisites": ["geometric series convergence", "strict monotonicity of exponentials"]
   },
   {
     "id": "ann-e517-application",
@@ -92,7 +92,7 @@
     "content": "Applies Biernacki's theorem to the exponential sequence: any entire function f(z) = ∑ aₖz^{2^k} assumes every complex value infinitely often. This is a direct corollary combining `exponential_has_fejer_gaps` with `biernacki_theorem`.",
     "mathContext": "By Biernacki + exponential Fejér: $\\forall w \\in \\mathbb{C},\\; |\\{z : \\sum a_k z^{2^k} = w\\}| = \\infty$.",
     "significance": "supporting",
-    "relatedConcepts": ["application", "Biernacki", "exponential-gaps"],
-    "prerequisites": ["biernacki_theorem", "exponential_has_fejer_gaps"]
+    "relatedConcepts": ["corollary application", "Biernacki's theorem", "infinite preimage sets for lacunary series"],
+    "prerequisites": ["Biernacki's theorem", "exponential Fejér gap verification"]
   }
 ]

--- a/src/data/proofs/erdos-517/meta.json
+++ b/src/data/proofs/erdos-517/meta.json
@@ -79,8 +79,28 @@
         "note": "Proved partial results for functions of finite order, posed the conjecture for the general Fabry case"
       }
     ],
-    "crossReferences": [],
-    "relatedProofs": []
+    "crossReferences": [
+      {
+        "targetId": "erdos-1116",
+        "relationship": "thematic",
+        "description": "Both concern value distribution of entire functions — #1116 asks about extreme variation of the counting function n(r,a) across different values a"
+      },
+      {
+        "targetId": "erdos-1115",
+        "relationship": "thematic",
+        "description": "Both study growth behavior of entire functions — #1115 concerns path length to infinity, connecting order of growth to geometric properties"
+      },
+      {
+        "targetId": "erdos-1112",
+        "relationship": "thematic",
+        "description": "Both involve lacunary sequences — #1112 studies combinatorial avoidance of lacunary sequences in sumsets rather than their analytic properties"
+      }
+    ],
+    "relatedProofs": [
+      "erdos-1116",
+      "erdos-1115",
+      "erdos-1112"
+    ]
   },
   "overview": {
     "historicalContext": "This problem concerns lacunary power series - series f(z) = ∑ aₖz^{nₖ} where the exponents have gaps. The question of how these gaps affect value distribution goes back to the early 20th century.\n\nFejér (1908) proved that if ∑1/nₖ < ∞, the function assumes every value at least once. Biernacki (1928) strengthened this to show every value is assumed infinitely often under the same condition.\n\nThe Fejér-Pólya conjecture asks whether the weaker Fabry gap condition (nₖ/k → ∞) is sufficient. Pólya (1929) proved partial results for functions of finite order, but the general case remains open. This is a fundamental question connecting gap conditions in power series to complex function theory.",
@@ -90,7 +110,8 @@
       "**Lacunary series**: Power series with gaps in exponents have special properties. The 'density' of gaps determines value distribution behavior.",
       "**Gap hierarchy**: Fejér gaps (∑1/nₖ < ∞) ⊂ Fabry gaps (nₖ/k → ∞). The former is easier to analyze but more restrictive.",
       "**Value distribution**: Picard's theorem says entire functions miss at most one value. Gap conditions can force every value to be assumed infinitely often.",
-      "**The gap**: Despite 100+ years of study, we don't know if the weaker Fabry condition suffices for infinite value coverage."
+      "**The gap**: Despite 100+ years of study, we don't know if the weaker Fabry condition suffices for infinite value coverage.",
+      "**Nevanlinna-theoretic perspective**: The counting function $n(r,w)$ of $w$-points in $|z| < r$ grows without bound for each $w$ under Fejér gaps. The open question is whether Fabry gaps — which only control the *rate* of exponent growth rather than their summability — still force this growth for every value simultaneously."
     ]
   },
   "sections": [


### PR DESCRIPTION
## Summary

Enrichment pass for two entries:

### erdos-486 (Logarithmic Density for Modular Avoidance Sets)
- Added `prerequisites` arrays to all 10 annotations
- Improved `relatedConcepts` with specific mathematical terms (Davenport-Erdős theorem, Schnirelmann density, Chinese remainder theorem)
- Added 5th `keyInsight` on density notion hierarchy and CRT constraints
- Added cross-references to erdos-12 and erdos-487

### erdos-517 (Lacunary Entire Functions and Value Distribution)
- Added 5th `keyInsight` on Nevanlinna-theoretic perspective
- Added cross-references to erdos-1116, erdos-1115, erdos-1112
- Improved `relatedConcepts` across all 7 annotations (Nevanlinna theory, Picard's great theorem, Hadamard gaps)
- Fixed header prerequisites from Mathlib module paths to mathematical concepts

## Test plan
- [x] `pnpm annotations:build` passes with no errors for either entry
- [x] JSON validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)