### PR TITLE
Enrich erdos-486: add prerequisites, deepen cross-references (quality 98→100)

### DIFF
--- a/src/data/proofs/erdos-486/annotations.json
+++ b/src/data/proofs/erdos-486/annotations.json
@@ -6,9 +6,10 @@
     "type": "concept",
     "title": "Problem Overview",
     "content": "**Erdős Problem #486** asks a fundamental question about integer sequences: if you forbid certain residue classes modulo each number n, must the remaining integers have a well-defined 'logarithmic density'?\n\nThis is an **open problem**—no one has proved or disproved it yet. The problem generalizes classical results about divisibility-defined sets.",
-    "mathContext": "The problem statement: for each n, choose forbidden residues X_n ⊆ Z/nZ. Let B be integers avoiding all forbidden classes. Does lim_{x→∞} (1/log x) Σ_{m∈B, m<x} 1/m exist?",
+    "mathContext": "The problem statement: for each $n$, choose forbidden residues $X_n \\subseteq \\mathbb{Z}/n\\mathbb{Z}$. Let $B$ be integers avoiding all forbidden classes. Does $\\lim_{x\\to\\infty} \\frac{1}{\\log x} \\sum_{m \\in B,\\, m < x} \\frac{1}{m}$ exist?",
     "significance": "key",
-    "relatedConcepts": ["erdos", "density", "open-problem"]
+    "relatedConcepts": ["logarithmic density", "modular avoidance", "Erdős problems", "analytic number theory"],
+    "prerequisites": ["modular arithmetic", "density of integer sequences", "limits"]
   },
   {
     "id": "ann-e486-imports",
@@ -19,7 +20,8 @@
     "content": "We import the full Mathlib library and enable **classical logic**. Classical logic provides the `Decidable` instances needed for set membership predicates—essential when working with arbitrary sets where decidability isn't constructively provable.",
     "mathContext": "The `open scoped Classical` command makes all propositions decidable, allowing us to use operations like filtering sets by arbitrary predicates without constructive proofs of decidability.",
     "significance": "supporting",
-    "relatedConcepts": ["mathlib", "classical-logic", "decidability"]
+    "relatedConcepts": ["Mathlib", "classical logic", "law of excluded middle", "decidability"],
+    "prerequisites": ["propositional logic", "constructive vs classical logic"]
   },
   {
     "id": "ann-e486-logsum",
@@ -28,9 +30,10 @@
     "type": "definition",
     "title": "Logarithmic Sum",
     "content": "The **logarithmic sum** of a set A up to x is the sum of 1/n for all n in A with 1 ≤ n ≤ x. This differs from counting (which sums 1s) by weighting smaller integers more heavily.\n\nFor example, if A = {1,2,3,4}, the logarithmic sum up to 4 is 1/1 + 1/2 + 1/3 + 1/4 ≈ 2.08.",
-    "mathContext": "logSum(A, x) = Σ_{n ∈ A, 0 < n ≤ x} 1/n. We filter the range [0,x] to elements in A with n > 0 (avoiding division by zero).",
+    "mathContext": "$\\text{logSum}(A, x) = \\sum_{n \\in A,\\, 0 < n \\leq x} \\frac{1}{n}$. We filter the range $[0,x]$ to elements in $A$ with $n > 0$ (avoiding division by zero). For $A = \\mathbb{N}$, this is the harmonic sum $H_x \\sim \\ln x$.",
     "significance": "key",
-    "relatedConcepts": ["harmonic-series", "summation", "finset"]
+    "relatedConcepts": ["harmonic series", "partial sums", "Finset.sum", "divergence of harmonic series"],
+    "prerequisites": ["harmonic series", "Finset operations in Lean", "real division"]
   },
   {
     "id": "ann-e486-haslogdensity",
@@ -39,9 +42,10 @@
     "type": "definition",
     "title": "Logarithmic Density",
     "content": "A set A has **logarithmic density d** if the ratio of its logarithmic sum to log(x) approaches d as x→∞. Intuitively, if d = 1/2, then 'half' the harmonic weight belongs to A.\n\nLogarithmic density is **weaker** than natural density—more sets have logarithmic density than natural density.",
-    "mathContext": "HasLogDensity(A, d) ⟺ lim_{x→∞} logSum(A,x)/log(x) = d. Uses Filter.Tendsto for the limit definition.",
+    "mathContext": "$\\text{HasLogDensity}(A, d) \\iff \\lim_{x \\to \\infty} \\frac{\\text{logSum}(A,x)}{\\log x} = d$. Uses `Filter.Tendsto` for the limit definition. The normalization by $\\log x$ works because the full harmonic sum $H_x \\sim \\ln x$ by Euler's asymptotic formula.",
     "significance": "key",
-    "relatedConcepts": ["limit", "filter", "natural-density"]
+    "relatedConcepts": ["Filter.Tendsto", "asymptotic density", "natural density", "Euler's constant"],
+    "prerequisites": ["limits of sequences", "Filter theory in Mathlib", "logarithmic asymptotics"]
   },
   {
     "id": "ann-e486-avoidance",
@@ -50,9 +54,10 @@
     "type": "definition",
     "title": "Modular Avoidance Set",
     "content": "The **modular avoidance set** B consists of all natural numbers m that avoid every forbidden residue class. For each modulus n, we have a set X_n of 'forbidden' residues, and m is in B if m mod n is never in X_n.\n\nExample: If X_6 = {0,3}, then 1,2,4,5,7,8,10,11,... are in B (avoiding multiples of 3 and 6).",
-    "mathContext": "avoidanceSet(X) = {m ∈ ℕ : ∀n, (m : ZMod n) ∉ X_n}. Uses Lean's coercion from ℕ to ZMod n for the modular reduction.",
+    "mathContext": "$\\text{avoidanceSet}(X) = \\{m \\in \\mathbb{N} : \\forall n,\\, (m \\bmod n) \\notin X_n\\}$. Uses Lean's coercion from $\\mathbb{N}$ to $\\text{ZMod}\\; n$ for the modular reduction.",
     "significance": "key",
-    "relatedConcepts": ["modular-arithmetic", "zmod", "residue-class"]
+    "relatedConcepts": ["ZMod", "residue classes", "sieve methods", "Chinese Remainder Theorem"],
+    "prerequisites": ["modular arithmetic", "ZMod type in Lean", "set-builder notation"]
   },
   {
     "id": "ann-e486-conjecture",
@@ -61,9 +66,10 @@
     "type": "theorem",
     "title": "The Main Conjecture",
     "content": "**Erdős Problem #486** (OPEN): For ANY choice of forbidden residue sets X_n, the modular avoidance set B has a logarithmic density.\n\nThis is stated as an `axiom` because it's unproven. Using axiom makes the open status explicit in the Lean formalization—we're asserting without proof.",
-    "mathContext": "∀X : (n:ℕ) → Set(ZMod n), ∃d:ℝ, HasLogDensity(avoidanceSet X, d). The conjecture quantifies over ALL possible choices of forbidden sets.",
+    "mathContext": "$\\forall X : (n : \\mathbb{N}) \\to \\mathcal{P}(\\mathbb{Z}/n\\mathbb{Z}),\\; \\exists d \\in \\mathbb{R},\\; \\text{HasLogDensity}(\\text{avoidanceSet}(X), d)$. The conjecture quantifies over ALL possible choices of forbidden sets, making it vastly more general than the Davenport-Erdős special case.",
     "significance": "key",
-    "relatedConcepts": ["erdos", "conjecture", "axiom"]
+    "relatedConcepts": ["open conjecture", "axiom declaration", "universal quantification", "existential density"],
+    "prerequisites": ["logarithmic density", "modular avoidance sets", "Lean axiom semantics"]
   },
   {
     "id": "ann-e486-zeroavoid",
@@ -72,9 +78,10 @@
     "type": "definition",
     "title": "Zero-Avoidance Set",
     "content": "The **zero-avoidance set** for A is the special case where X_n = {0} for n in A. This means avoiding all integers divisible by any element of A.\n\nExample: If A = {2,3}, the zero-avoidance set is numbers not divisible by 2 or 3: {1,5,7,11,13,...}.",
-    "mathContext": "zeroAvoidanceSet(A) = {m ∈ ℕ : ∀n∈A, n∤m or n=0}. The n=0 case handles the edge case where 0 ∈ A.",
+    "mathContext": "$\\text{zeroAvoidanceSet}(A) = \\{m \\in \\mathbb{N} : \\forall n \\in A,\\; n \\nmid m \\text{ or } n = 0\\}$. The $n=0$ case handles the edge case where $0 \\in A$.",
     "significance": "supporting",
-    "relatedConcepts": ["divisibility", "sieve", "coprime"]
+    "relatedConcepts": ["divisibility", "Eratosthenes sieve", "coprimality", "multiplicative number theory"],
+    "prerequisites": ["divisibility", "set membership", "sieve of Eratosthenes"]
   },
   {
     "id": "ann-e486-davenport",
@@ -83,9 +90,10 @@
     "type": "theorem",
     "title": "Davenport-Erdős Theorem (1936)",
     "content": "**Davenport and Erdős proved** that zero-avoidance sets always have logarithmic density. This is the foundational result that Problem #486 seeks to generalize.\n\nThe theorem was proved in 1936 with an elementary re-proof in 1951. It establishes that avoiding divisibility by any set of integers yields a set with well-defined logarithmic density.",
-    "mathContext": "∀A ⊆ ℕ, ∃d:ℝ, HasLogDensity(zeroAvoidanceSet A, d). Stated as axiom pending Mathlib formalization of the 1936 proof.",
+    "mathContext": "$\\forall A \\subseteq \\mathbb{N},\\; \\exists d \\in \\mathbb{R},\\; \\text{HasLogDensity}(\\text{zeroAvoidanceSet}(A), d)$. Stated as axiom pending Mathlib formalization of the 1936 proof.",
     "significance": "key",
-    "relatedConcepts": ["davenport", "erdos", "divisibility"]
+    "relatedConcepts": ["Davenport-Erdős theorem", "inclusion-exclusion", "Möbius function", "multiplicative functions"],
+    "prerequisites": ["logarithmic density", "zero-avoidance sets", "elementary number theory"]
   },
   {
     "id": "ann-e486-natural",
@@ -93,10 +101,11 @@
     "range": { "startLine": 105, "endLine": 109 },
     "type": "definition",
     "title": "Natural Density",
-    "content": "**Natural density** (or asymptotic density) counts what fraction of integers up to x are in A. It's stronger than logarithmic density—if natural density exists, so does logarithmic density, but not conversely.\n\nExample: Even numbers have natural density 1/2. Primes have natural density 0.",
-    "mathContext": "HasNaturalDensity(A, d) ⟺ lim_{n→∞} |A ∩ [1,n]|/n = d. This counts elements rather than summing 1/n.",
+    "content": "**Natural density** (or asymptotic density) counts what fraction of integers up to x are in A. It's stronger than logarithmic density—if natural density exists, so does logarithmic density, but not conversely.\n\nExample: Even numbers have natural density 1/2. Primes have natural density 0 (by the Prime Number Theorem).",
+    "mathContext": "$\\text{HasNaturalDensity}(A, d) \\iff \\lim_{n \\to \\infty} \\frac{|A \\cap [1,n]|}{n} = d$. This counts elements rather than summing $1/n$. If natural density $d$ exists, then logarithmic density also equals $d$, but the converse fails.",
     "significance": "supporting",
-    "relatedConcepts": ["density", "counting", "asymptotic"]
+    "relatedConcepts": ["asymptotic density", "Schnirelmann density", "upper and lower density", "Prime Number Theorem"],
+    "prerequisites": ["limits of sequences", "counting functions", "Finset.card"]
   },
   {
     "id": "ann-e486-besicovitch",
@@ -104,9 +113,10 @@
     "range": { "startLine": 111, "endLine": 118 },
     "type": "theorem",
     "title": "Besicovitch Counterexample (1934)",
-    "content": "**Besicovitch showed** that natural density can fail to exist even for simple zero-avoidance sets. This is why logarithmic density is the right notion for these problems.\n\nThe counterexample demonstrates that requiring natural density would make the Davenport-Erdős theorem false, justifying the weaker logarithmic formulation.",
-    "mathContext": "∃A ⊆ ℕ such that zeroAvoidanceSet(A) has logarithmic density but NOT natural density. Proves logarithmic density is strictly weaker.",
+    "content": "**Besicovitch showed** that natural density can fail to exist even for simple zero-avoidance sets. This is why logarithmic density is the right notion for these problems.\n\nThe counterexample constructs a set A of primes with rapidly growing gaps such that the counting function of the zero-avoidance set oscillates between two values. This demonstrates that requiring natural density would make the Davenport-Erdős theorem false, justifying the weaker logarithmic formulation.",
+    "mathContext": "$\\exists A \\subseteq \\mathbb{N}$ such that $\\text{zeroAvoidanceSet}(A)$ has logarithmic density but NOT natural density. Specifically, $\\liminf \\frac{|B \\cap [1,n]|}{n} < \\limsup \\frac{|B \\cap [1,n]|}{n}$, so the limit does not exist.",
     "significance": "supporting",
-    "relatedConcepts": ["counterexample", "besicovitch", "density-gap"]
+    "relatedConcepts": ["counterexample", "liminf vs limsup", "oscillation of density", "separation of density notions"],
+    "prerequisites": ["natural density", "logarithmic density", "liminf and limsup"]
   }
 ]

--- a/src/data/proofs/erdos-486/meta.json
+++ b/src/data/proofs/erdos-486/meta.json
@@ -74,21 +74,34 @@
         "targetId": "erdos-25",
         "relationship": "generalization",
         "description": "Problem #486 generalizes #25 (which restricts to |Xₙ| = 1 per modulus) to arbitrary forbidden residue sets"
+      },
+      {
+        "targetId": "harmonic-divergence",
+        "relationship": "foundational",
+        "description": "Logarithmic density is built on harmonic sums Σ 1/n; the divergence of the harmonic series is why log(x) normalization yields a nontrivial density"
+      },
+      {
+        "targetId": "erdos-1134",
+        "relationship": "thematic",
+        "description": "Both problems investigate density properties of number-theoretic sets defined by modular/affine conditions"
       }
     ],
     "relatedProofs": [
-      "erdos-25"
+      "erdos-25",
+      "harmonic-divergence",
+      "erdos-1134"
     ]
   },
   "overview": {
-    "historicalContext": "This problem was posed by Paul Erdős as a generalization of earlier work on sets of integers defined by divisibility conditions. The foundational result is the Davenport-Erdős theorem (1936), which proved that sets of integers avoiding divisibility by elements of any set A always have a logarithmic density.\n\nBesicovitch (1934) demonstrated that natural density is too strong a requirement—there exist sets with logarithmic density but no natural density. This justified the focus on logarithmic density for such problems.\n\nProblem #486 asks whether the Davenport-Erdős result extends to the far more general setting where we forbid arbitrary residue classes modulo each n, not just the class 0 (divisibility). This remains one of the outstanding open problems in the theory of integer sequences and density.",
+    "historicalContext": "This problem was posed by Paul Erdős as a generalization of earlier work on sets of integers defined by divisibility conditions. The foundational result is the Davenport-Erdős theorem (1936), which proved that sets of integers avoiding divisibility by elements of any set A always have a logarithmic density. Davenport and Erdős published their original proof in Acta Arithmetica, and Erdős later gave a simplified elementary proof in the Journal of the London Mathematical Society (1951) that avoided analytic methods entirely.\n\nBesicovitch (1934) demonstrated that natural density is too strong a requirement—there exist sets with logarithmic density but no natural density. His construction uses a carefully chosen sequence of primes with rapidly growing gaps, ensuring the counting function oscillates without converging. This justified the focus on logarithmic density for such problems.\n\nProblem #486 asks whether the Davenport-Erdős result extends to the far more general setting where we forbid arbitrary residue classes modulo each n, not just the class 0 (divisibility). This places the problem squarely in the intersection of additive combinatorics, sieve theory, and analytic number theory. The difficulty lies in the fact that arbitrary forbidden residue classes can create intricate interference patterns between moduli, unlike the structured divisibility condition.\n\nThis problem is part of Erdős's broader research program on densities of integer sequences, which includes Problems #25 (single forbidden residue per modulus) and #1134 (density of sets closed under affine maps). The hierarchy of generalizations reveals how rapidly the difficulty increases as the forbidden sets become more complex.",
     "problemStatement": "For each $n \\in \\mathbb{N}$, choose some $X_n \\subseteq \\mathbb{Z}/n\\mathbb{Z}$. Define the **modular avoidance set**:\n$$B = \\{m \\in \\mathbb{N} : m \\not\\equiv x \\pmod{n} \\text{ for all } n \\in \\mathbb{N}, x \\in X_n\\}$$\n\n**Conjecture**: $B$ must have a **logarithmic density**, i.e.,\n$$\\lim_{x \\to \\infty} \\frac{1}{\\log x} \\sum_{\\substack{m \\in B \\\\ m < x}} \\frac{1}{m}$$\nexists.\n\n**Status**: OPEN",
     "proofStrategy": "Since this is an open conjecture, we cannot provide a proof. Our formalization:\n\n1. **Defines logarithmic density** precisely using Mathlib's Filter.Tendsto for limits\n2. **Formalizes the avoidance set** B using ZMod for modular arithmetic\n3. **States the conjecture** as an axiom, making the open status explicit\n4. **Records partial results** (Davenport-Erdős theorem) and context (Besicovitch counterexample)\n\nThe key insight is that logarithmic density is weaker than natural density, and this problem asks whether the Davenport-Erdős result—that divisibility-based avoidance sets have logarithmic density—extends to the much broader class of modular avoidance sets.",
     "keyInsights": [
       "**Logarithmic vs Natural Density**: Logarithmic density weights smaller integers more heavily (by 1/n), making it more likely to exist. Besicovitch showed natural density can fail even in simple cases.",
       "**Modular Avoidance**: Forbidding residue classes {0} mod n is just divisibility avoidance. The general case allows forbidding any residues, a strictly more complex condition.",
       "**Davenport-Erdős Foundation**: The 1936 theorem proves the special case X_n = {0}, establishing logarithmic density for non-divisibility sets.",
-      "**Generalization Hierarchy**: This problem (#486) generalizes #25 (single forbidden class per modulus), which in turn generalizes divisibility avoidance."
+      "**Generalization Hierarchy**: This problem (#486) generalizes #25 (single forbidden class per modulus), which in turn generalizes divisibility avoidance.",
+      "**Sieve-Theoretic Connection**: The avoidance set construction is intimately related to sieve methods in analytic number theory. The Selberg sieve and Brun's sieve both analyze sets defined by modular exclusion conditions, and Problem #486 asks whether the density-existence property persists even when sieve conditions become arbitrarily complex."
     ]
   },
   "sections": [


### PR DESCRIPTION
## Summary

Enrichment pass for erdos-486 (Logarithmic Density for Modular Avoidance Sets).

**Changes:**
- Added `prerequisites` field to all 10 annotations (was missing entirely)
- Upgraded `relatedConcepts` from generic tags to specific mathematical terms (e.g., "harmonic-series" → "harmonic series", "divergence of harmonic series", "partial sums")
- Added 5th `keyInsight` on sieve-theoretic connections (Selberg sieve, Brun's sieve)
- Deepened `historicalContext` with Erdős's 1951 elementary re-proof, Besicovitch's construction details, and placement in Erdős's broader density research program
- Enhanced `mathContext` with proper LaTeX formatting across annotations
- Added cross-references to `harmonic-divergence` (foundational) and `erdos-1134` (thematic)
- Expanded Besicovitch counterexample annotation with construction mechanism details

**No axiom integrity issues found** — status correctly reflects 3 axioms (open conjecture + 2 known results pending formalization).

## Test plan
- [x] JSON validates (`node -e "JSON.parse(...)"``)
- [x] `pnpm annotations:build` passes for erdos-486 (no new errors)