### PR TITLE
Enrich erdos-541: add prerequisites, cross-references, 5th keyInsight

### DIFF
--- a/src/data/proofs/erdos-541/annotations.json
+++ b/src/data/proofs/erdos-541/annotations.json
@@ -9,13 +9,10 @@
     "type": "concept",
     "title": "Problem Overview",
     "content": "**Erdős Problem #541** asks about the structure of sequences with uniform zero-sum behavior.\n\nGiven p residues modulo a prime p, suppose every nonempty zero-sum subset has the SAME cardinality r. Graham conjectured this forces at most 2 distinct residues in the sequence.\n\nThis was proved for large primes by Erdős-Szemerédi (1976) and for all moduli by Gao-Hamidoune-Wang (2010).",
-    "mathContext": "If ∀S⊆[p], S≠∅, Σᵢ∈S aᵢ≡0 (mod p) ⟹ |S|=r, then |{a₁,...,aₚ}| ≤ 2.",
+    "mathContext": "If $\\forall S \\subseteq [p],\\; S \\neq \\emptyset,\\; \\sum_{i \\in S} a_i \\equiv 0 \\pmod{p} \\Rightarrow |S| = r$, then $|\\{a_1, \\ldots, a_p\\}| \\leq 2$.",
     "significance": "key",
-    "relatedConcepts": [
-      "erdos",
-      "zero-sum",
-      "graham-conjecture"
-    ]
+    "relatedConcepts": ["Graham's conjecture", "zero-sum subsequences", "additive combinatorics"],
+    "prerequisites": ["modular arithmetic", "finite abelian groups", "subset sum problems"]
   },
   {
     "id": "ann-e541-imports",
@@ -29,11 +26,8 @@
     "content": "We import Mathlib and enable classical logic. The key types used are:\n\n- **Fin p**: indices 1 to p\n- **ZMod p**: integers modulo p as a ring\n- **Finset**: finite sets for subset operations",
     "mathContext": "Classical logic allows us to work with arbitrary predicates on sets without explicit decidability proofs.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "mathlib",
-      "classical-logic",
-      "ZMod"
-    ]
+    "relatedConcepts": ["ZMod ring structure", "classical decidability", "Fin indexing"],
+    "prerequisites": ["Lean 4 type theory", "classical vs constructive logic"]
   },
   {
     "id": "ann-e541-uniquelength",
@@ -45,13 +39,10 @@
     "type": "definition",
     "title": "HasUniqueZeroSumLength",
     "content": "**HasUniqueZeroSumLength(p, a, r)** captures the key constraint: every nonempty subset S with Σᵢ∈S aᵢ = 0 has exactly |S| = r elements.\n\nThis is a very strong uniformity condition. Most sequences have zero-sum subsets of varying sizes; having them all be the same size r is highly restrictive.",
-    "mathContext": "∀S : Finset(Fin p), S ≠ ∅ → (Σᵢ∈S aᵢ = 0) → S.card = r",
+    "mathContext": "$\\forall S : \\text{Finset}(\\text{Fin}\\; p),\\; S \\neq \\emptyset \\to \\sum_{i \\in S} a_i = 0 \\to S.\\text{card} = r$",
     "significance": "key",
-    "relatedConcepts": [
-      "zero-sum",
-      "cardinality",
-      "uniformity"
-    ]
+    "relatedConcepts": ["zero-sum uniformity", "Finset cardinality constraints", "extremal combinatorics"],
+    "prerequisites": ["Finset.sum over ZMod", "cardinality of finite sets"]
   },
   {
     "id": "ann-e541-someunique",
@@ -63,12 +54,10 @@
     "type": "definition",
     "title": "HasSomeUniqueZeroSumLength",
     "content": "**HasSomeUniqueZeroSumLength(p, a)** asserts there EXISTS some r with the uniformity property.\n\nThis is the hypothesis for Graham's conjecture: we don't specify what r is, just that all zero-sum subsets have the same cardinality.",
-    "mathContext": "∃r, HasUniqueZeroSumLength(p, a, r)",
+    "mathContext": "$\\exists r,\\; \\text{HasUniqueZeroSumLength}(p, a, r)$",
     "significance": "supporting",
-    "relatedConcepts": [
-      "existential",
-      "hypothesis"
-    ]
+    "relatedConcepts": ["existential quantification", "hypothesis abstraction"],
+    "prerequisites": ["HasUniqueZeroSumLength definition"]
   },
   {
     "id": "ann-e541-distinctcount",
@@ -80,13 +69,10 @@
     "type": "definition",
     "title": "Distinct Count",
     "content": "**distinctCount(p, a)** counts how many distinct residues appear in the sequence.\n\nWe use `Set.range a` to get all values taken by a, then `ncard` for the cardinality. This is noncomputable since it involves supremum over potentially infinite sets (though here the range is finite).",
-    "mathContext": "distinctCount(p, a) = |{a(i) : i ∈ Fin p}| = (Set.range a).ncard",
+    "mathContext": "$\\text{distinctCount}(p, a) = |\\{a(i) : i \\in \\text{Fin}\\; p\\}| = (\\text{Set.range}\\; a).\\text{ncard}$",
     "significance": "key",
-    "relatedConcepts": [
-      "Set.range",
-      "ncard",
-      "noncomputable"
-    ]
+    "relatedConcepts": ["Set.range", "Set.ncard", "image cardinality"],
+    "prerequisites": ["Set.ncard for noncomputable cardinality", "Set.range of a function"]
   },
   {
     "id": "ann-e541-graham",
@@ -98,13 +84,10 @@
     "type": "theorem",
     "title": "Graham's Conjecture",
     "content": "**The Main Result**: If all nonempty zero-sum subsets have the same cardinality, then at most 2 distinct residues appear in the sequence.\n\nIntuitively: the uniformity constraint is so strong that it forces the sequence to be 'almost constant'. With 3+ distinct values, one could construct zero-sum subsets of different sizes.\n\nMarked with `sorry` as the full proof is complex.",
-    "mathContext": "HasSomeUniqueZeroSumLength(p, a) → distinctCount(p, a) ≤ 2",
+    "mathContext": "$\\text{HasSomeUniqueZeroSumLength}(p, a) \\to \\text{distinctCount}(p, a) \\leq 2$",
     "significance": "key",
-    "relatedConcepts": [
-      "graham",
-      "main-theorem",
-      "sorry"
-    ]
+    "relatedConcepts": ["structural rigidity", "additive combinatorics extremal results", "Graham's conjecture"],
+    "prerequisites": ["HasSomeUniqueZeroSumLength", "distinctCount", "combinatorial case analysis"]
   },
   {
     "id": "ann-e541-erdosszemeredi",
@@ -116,13 +99,10 @@
     "type": "axiom",
     "title": "Erdős-Szemerédi (1976)",
     "content": "**For sufficiently large primes p**, Graham's conjecture holds.\n\nErdős and Szemerédi proved this using combinatorial arguments that work when p exceeds some threshold. The exact threshold depends on the proof technique.",
-    "mathContext": "∀ᶠ p in atTop, p.Prime → (HasSomeUniqueZeroSumLength p a → distinctCount p a ≤ 2)",
+    "mathContext": "$\\forall^{\\infty} p$ in atTop, $p$ prime $\\to (\\text{HasSomeUniqueZeroSumLength}(p, a) \\to \\text{distinctCount}(p, a) \\leq 2)$",
     "significance": "key",
-    "relatedConcepts": [
-      "erdos-szemeredi",
-      "1976",
-      "large-primes"
-    ]
+    "relatedConcepts": ["Erdős-Szemerédi theorem", "eventually-for-large-primes", "Filter.Eventually"],
+    "prerequisites": ["Graham's conjecture statement", "Filter.Eventually in Mathlib"]
   },
   {
     "id": "ann-e541-gaohamidounewang",
@@ -134,13 +114,10 @@
     "type": "axiom",
     "title": "Gao-Hamidoune-Wang (2010)",
     "content": "**The Full Result**: Graham's conjecture holds for ALL moduli n, not just primes!\n\nThis 2010 result generalized beyond the prime case, showing the phenomenon is arithmetic rather than purely prime-specific. The proof uses deep techniques from additive combinatorics.",
-    "mathContext": "∀n, HasSomeUniqueZeroSumLength(n, a) → distinctCount(n, a) ≤ 2",
+    "mathContext": "$\\forall n,\\; \\text{HasSomeUniqueZeroSumLength}(n, a) \\to \\text{distinctCount}(n, a) \\leq 2$",
     "significance": "key",
-    "relatedConcepts": [
-      "gao-hamidoune-wang",
-      "2010",
-      "generalization"
-    ]
+    "relatedConcepts": ["Gao-Hamidoune-Wang theorem", "generalization to composite moduli", "zero-sum theory"],
+    "prerequisites": ["Graham's conjecture statement", "ZMod for general n"]
   },
   {
     "id": "ann-e541-constant-example",
@@ -152,13 +129,10 @@
     "type": "theorem",
     "title": "Constant Sequence Example",
     "content": "**The trivial case**: if a₁ = a₂ = ... = aₚ = c (all the same), then distinctCount ≤ 1.\n\nFor constant sequences, Σᵢ∈S aᵢ = |S|·c ≡ 0 iff |S| ≡ 0 mod ord(c). All zero-sum subsets have cardinality divisible by the order of c.",
-    "mathContext": "distinctCount(p, λ_ ↦ c) = |{c}| = 1 ≤ 1",
+    "mathContext": "$\\text{distinctCount}(p, \\lambda\\_ \\mapsto c) = |\\{c\\}| = 1 \\leq 1$",
     "significance": "supporting",
-    "relatedConcepts": [
-      "constant",
-      "trivial-case",
-      "example"
-    ]
+    "relatedConcepts": ["constant sequence", "trivial bound", "Set.range singleton"],
+    "prerequisites": ["Set.range of constant function", "Set.ncard_le_one"]
   },
   {
     "id": "ann-e541-twovalue-example",
@@ -170,13 +144,10 @@
     "type": "theorem",
     "title": "Two-Value Example",
     "content": "**Two distinct values also work**: alternating between c and d gives distinctCount ≤ 2.\n\nThe proof shows the range is contained in {c, d}, then uses Set.ncard properties to bound the cardinality.\n\nNote: this doesn't prove the sequence HAS the unique zero-sum length property, just that if it did, distinctCount ≤ 2 would hold.",
-    "mathContext": "range(λi ↦ if i%2=0 then c else d) ⊆ {c,d} → ncard ≤ 2",
+    "mathContext": "$\\text{range}(\\lambda i \\mapsto \\text{if } i\\%2=0 \\text{ then } c \\text{ else } d) \\subseteq \\{c,d\\} \\to \\text{ncard} \\leq 2$",
     "significance": "supporting",
-    "relatedConcepts": [
-      "two-values",
-      "alternating",
-      "ncard"
-    ]
+    "relatedConcepts": ["two-element range", "Set.ncard monotonicity", "constructive examples"],
+    "prerequisites": ["Set.ncard_le_of_subset", "Set.Finite.ncard_le"]
   },
   {
     "id": "ann-e541-keyinsight",
@@ -188,13 +159,10 @@
     "type": "concept",
     "title": "Why 3+ Values Fail",
     "content": "**The Key Insight**: With 3 or more distinct values {a, b, c}, one can construct zero-sum subsets of DIFFERENT cardinalities.\n\nThe argument involves:\n1. Using copies of a alone (if a·k ≡ 0)\n2. Mixing a's and b's in different proportions\n3. Introducing c's to create new combinations\n\nThese lead to zero-sums of varying sizes, contradicting the uniformity hypothesis.",
-    "mathContext": "3+ distinct values → ∃S,T with Σᵢ∈S aᵢ = Σᵢ∈T aᵢ = 0 but |S| ≠ |T|",
+    "mathContext": "3+ distinct values $\\Rightarrow \\exists S, T$ with $\\sum_{i \\in S} a_i = \\sum_{i \\in T} a_i = 0$ but $|S| \\neq |T|$",
     "significance": "key",
-    "relatedConcepts": [
-      "combinatorics",
-      "contradiction",
-      "structure"
-    ]
+    "relatedConcepts": ["proof by contradiction", "combinatorial flexibility of 3+ generators", "pigeonhole principle"],
+    "prerequisites": ["zero-sum subset construction", "modular arithmetic in cyclic groups"]
   },
   {
     "id": "ann-e541-zerosumexists",
@@ -206,13 +174,10 @@
     "type": "theorem",
     "title": "Zero-Sum Existence (Olson)",
     "content": "**Zero-sum subsequences always exist** in Z/pZ by the pigeonhole principle.\n\nConsider partial sums s₀=0, s₁=a₁, s₂=a₁+a₂, ..., sₚ=Σaᵢ. These p+1 values in Z/pZ (which has p elements) must have a collision: sᵢ = sⱼ for some i < j. Then Σₖ∈{i+1,...,j} aₖ = sⱼ - sᵢ = 0.\n\nMarked `sorry` as the detailed proof is nontrivial.",
-    "mathContext": "∃S ⊆ Fin(p), S ≠ ∅ ∧ Σᵢ∈S aᵢ = 0",
+    "mathContext": "$\\exists S \\subseteq \\text{Fin}(p),\\; S \\neq \\emptyset \\wedge \\sum_{i \\in S} a_i = 0$",
     "significance": "supporting",
-    "relatedConcepts": [
-      "olson",
-      "pigeonhole",
-      "partial-sums"
-    ]
+    "relatedConcepts": ["pigeonhole principle on partial sums", "Olson's theorem", "telescoping sums"],
+    "prerequisites": ["pigeonhole principle in ZMod p", "partial sums of sequences"]
   },
   {
     "id": "ann-e541-historical",
@@ -224,13 +189,10 @@
     "type": "concept",
     "title": "Historical Context",
     "content": "**Zero-Sum Theory**: This problem belongs to additive combinatorics, studying when subsets of abelian groups must contain zero-sum subsequences.\n\n**Key Results**:\n- **Davenport constant**: minimum length ensuring zero-sum exists\n- **Erdős-Ginzburg-Ziv (1961)**: 2n-1 integers contain n with sum ≡ 0 (mod n)\n- **Olson's work**: bounds on zero-sum subsequence lengths\n\nGraham's question captures an extremal phenomenon: strong uniformity forces simplicity.",
-    "mathContext": "Zero-sum theory: when must subsets of (Z/nZ)^k contain zero-sum subsequences?",
+    "mathContext": "Zero-sum theory: when must subsets of $(\\mathbb{Z}/n\\mathbb{Z})^k$ contain zero-sum subsequences?",
     "significance": "supporting",
-    "relatedConcepts": [
-      "davenport-constant",
-      "additive-combinatorics",
-      "history"
-    ]
+    "relatedConcepts": ["Davenport constant", "Erdős-Ginzburg-Ziv theorem", "zero-sum Ramsey theory"],
+    "prerequisites": ["abelian group theory", "additive combinatorics foundations"]
   },
   {
     "id": "ann-e541-egz",
@@ -242,12 +204,9 @@
     "type": "axiom",
     "title": "Erdős-Ginzburg-Ziv Theorem",
     "content": "**The EGZ Theorem (1961)**: Among any 2n-1 integers, some n of them have sum divisible by n.\n\nThis is a foundational result in zero-sum theory. It's tight: 2n-2 integers may avoid having n sum to 0 mod n (e.g., n-1 copies of 0 and n-1 copies of 1).\n\nStated as an axiom since the proof is nontrivial.",
-    "mathContext": "∀a : Fin(2n-1) → ZMod(n), ∃S with |S|=n and Σᵢ∈S aᵢ = 0",
+    "mathContext": "$\\forall a : \\text{Fin}(2n-1) \\to \\mathbb{Z}/n\\mathbb{Z},\\; \\exists S,\\; |S| = n \\wedge \\sum_{i \\in S} a_i = 0$",
     "significance": "key",
-    "relatedConcepts": [
-      "egz",
-      "1961",
-      "fundamental"
-    ]
+    "relatedConcepts": ["Erdős-Ginzburg-Ziv theorem", "optimal bound 2n-1", "Chevalley-Warning theorem approach"],
+    "prerequisites": ["zero-sum theory fundamentals", "modular arithmetic"]
   }
 ]

--- a/src/data/proofs/erdos-541/meta.json
+++ b/src/data/proofs/erdos-541/meta.json
@@ -79,8 +79,28 @@
         "note": "Foundational result: 2n-1 integers contain n summing to 0 mod n"
       }
     ],
-    "crossReferences": [],
-    "relatedProofs": []
+    "crossReferences": [
+      {
+        "targetId": "erdos-1",
+        "relationship": "thematic",
+        "description": "Both concern structural constraints on subset sums — #1 asks when all 2^n subset sums are distinct, #541 asks what happens when all zero-sum subsets have the same cardinality"
+      },
+      {
+        "targetId": "erdos-1179",
+        "relationship": "thematic",
+        "description": "Both study uniform subset sum properties in abelian groups — #1179 estimates the threshold for uniform representations"
+      },
+      {
+        "targetId": "erdos-109",
+        "relationship": "thematic",
+        "description": "Both involve additive structure in integer sequences — #109 concerns sumsets B+C from dense sets, #541 concerns zero-sum subsequences with uniform cardinality"
+      }
+    ],
+    "relatedProofs": [
+      "erdos-1",
+      "erdos-1179",
+      "erdos-109"
+    ]
   },
   "overview": {
     "historicalContext": "Zero-sum problems form a central topic in additive combinatorics. The study asks: given a sequence of elements from an abelian group, when must there exist a subsequence summing to zero?\n\nGraham posed a structural question: if we impose that ALL nonempty zero-sum subsets have the SAME cardinality r, what does this constrain about the sequence? His conjecture was that such rigid structure forces the sequence to use at most 2 distinct residues.\n\nErdős and Szemerédi (1976) proved this for sufficiently large primes. The full result came from Gao, Hamidoune, and Wang (2010), who proved it for ALL moduli n, not just primes.\n\nThis connects to the Erdős-Ginzburg-Ziv theorem (1961), which guarantees that among 2n-1 integers, some n have sum divisible by n.",
@@ -90,7 +110,8 @@
       "**Uniformity Implies Simplicity**: If all zero-sum subsets have the same size, the sequence cannot be 'rich' in distinct values. Three or more distinct residues would allow constructing zero-sums of different cardinalities.",
       "**Connection to Pigeonhole**: Zero-sum subsequences always exist by the pigeonhole principle on partial sums. Graham asks about the converse constraint.",
       "**Beyond Primes**: Gao-Hamidoune-Wang's generalization to arbitrary moduli n shows the phenomenon is arithmetic rather than purely prime-specific.",
-      "**Erdős-Ginzburg-Ziv Link**: The EGZ theorem (2n-1 integers contain n summing to 0 mod n) provides the foundation for zero-sum theory."
+      "**Erdős-Ginzburg-Ziv Link**: The EGZ theorem (2n-1 integers contain n summing to 0 mod n) provides the foundation for zero-sum theory.",
+      "**Davenport Constant Connection**: The Davenport constant $D(G)$ is the smallest $\\ell$ such that every sequence of length $\\ell$ over an abelian group $G$ contains a nonempty zero-sum subsequence. Graham's problem asks a complementary question: when zero-sum subsequences exist but are all the same length, what structure is forced on the sequence?"
     ]
   },
   "sections": [


### PR DESCRIPTION
## Summary

Enrichment pass for erdos-541 (Graham's Conjecture on Zero-Sum Subsequences).

- Added `prerequisites` arrays to all 12 annotations
- Improved `relatedConcepts` with specific mathematical terms (Graham's conjecture, Davenport constant, Erdős-Ginzburg-Ziv theorem, Chevalley-Warning approach)
- Added 5th `keyInsight` on Davenport constant connection
- Added cross-references to erdos-1 (distinct subset sums), erdos-1179 (uniform representations), erdos-109 (sumset conjecture)
- Upgraded `mathContext` fields to proper LaTeX notation

## Test plan
- [x] `pnpm annotations:build` passes with no erdos-541 errors
- [x] JSON validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)