### PR TITLE
Research: LGV lemma - Prove pathMN_card (0 sorries)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ02.lean
@@ -23,7 +23,7 @@ where e(A,B) = C(dx + dy, dx) is the number of lattice paths from A to B.
 The identity permutation contributes ∏ e(Aᵢ,Bᵢ). Non-identity permutations
 cancel via a sign-reversing involution (Gessel-Viennot involution).
 
-## Status (1 axiom [GV cancellation], 1 sorry [pathMN cardinality])
+## Status (1 axiom [GV cancellation], 0 sorries)
 - [x] Path tuple and non-intersecting definitions
 - [x] Path weight matrix using Matrix.det
 - [x] Permutation path tuples and signed counts
@@ -32,7 +32,7 @@ cancel via a sign-reversing involution (Gessel-Viennot involution).
 - [x] r×r LGV lemma (proved from GV cancellation axiom)
 - [x] Corollaries: non-negativity, r=0, r=1 special cases
 - [ ] GV involution cancellation (1 axiom: the combinatorial heart)
-- [ ] PathMN cardinality C(m+n,m) (1 sorry: standard combinatorial identity)
+- [x] PathMN cardinality C(m+n,m) (proved via double induction + Pascal)
 
 ## References
 - Lindström (1973): "On the Vector Representations of Induced Matroids"
@@ -266,17 +266,114 @@ theorem firstNonFixed_lt_image {r : ℕ} (σ : Equiv.Perm (Fin r)) (hσ : σ ≠
 -- PART 7b: PathMN Cardinality
 -- ============================================================
 
-/-- The number of lattice paths with m East steps and n North steps
-    equals C(m + n, m). A path is determined by choosing which m
-    of the m+n steps are East steps.
+-- countP helper lemmas for Bool cons
+private lemma countP_false_cons_false (xs : List Bool) :
+    (false :: xs).countP (· = false) = xs.countP (· = false) + 1 := by
+  simp [List.countP_cons]
 
-    Proof strategy: PathMN m n ≃ { S : Finset (Fin (m+n)) // S.card = m }
-    via the indicator function of East-step positions. Then
-    Finset.card_powersetCard gives the binomial coefficient.
-    Alternatively, induction on m + n with Pascal's identity. -/
+private lemma countP_false_cons_true (xs : List Bool) :
+    (true :: xs).countP (· = false) = xs.countP (· = false) := by
+  simp [List.countP_cons]
+
+private lemma bool_countP_sum (l : List Bool) :
+    l.countP (· = false) + l.countP (· = true) = l.length := by
+  induction l with
+  | nil => simp
+  | cons b xs ih =>
+    cases b
+    · -- false case
+      rw [countP_false_cons_false, List.length_cons]
+      have : (false :: xs).countP (· = true) = xs.countP (· = true) := by
+        simp [List.countP_cons]
+      rw [this]; omega
+    · -- true case
+      rw [countP_false_cons_true, List.length_cons]
+      have : (true :: xs).countP (· = true) = xs.countP (· = true) + 1 := by
+        simp [List.countP_cons]
+      rw [this]; omega
+
+/-- Splitting: PathMN (m+1) (n+1) ≃ PathMN m (n+1) ⊕ PathMN (m+1) n. -/
+private noncomputable def pathMN_split (m n : ℕ) :
+    PathMN (m + 1) (n + 1) ≃ PathMN m (n + 1) ⊕ PathMN (m + 1) n where
+  toFun := fun ⟨l, hlen, heast⟩ => by
+    match l with
+    | [] => exact absurd hlen (by simp; omega)
+    | false :: xs =>
+      have heast' : xs.countP (· = false) = m := by
+        rw [countP_false_cons_false] at heast; omega
+      exact Sum.inl ⟨xs, by simp at hlen; omega, heast'⟩
+    | true :: xs =>
+      have heast' : xs.countP (· = false) = m + 1 := by
+        rw [countP_false_cons_true] at heast; exact heast
+      exact Sum.inr ⟨xs, by simp at hlen; omega, heast'⟩
+  invFun := fun s => by
+    match s with
+    | Sum.inl ⟨xs, hlen, heast⟩ =>
+      have heast' : (false :: xs).countP (· = false) = m + 1 := by
+        rw [countP_false_cons_false]; omega
+      exact ⟨false :: xs, by simp; omega, heast'⟩
+    | Sum.inr ⟨xs, hlen, heast⟩ =>
+      have heast' : (true :: xs).countP (· = false) = m + 1 := by
+        rw [countP_false_cons_true]; exact heast
+      exact ⟨true :: xs, by simp; omega, heast'⟩
+  left_inv := fun ⟨l, hlen, _⟩ => by
+    match l with
+    | [] => exact absurd hlen (by simp; omega)
+    | false :: _ => rfl
+    | true :: _ => rfl
+  right_inv := fun s => by
+    match s with
+    | Sum.inl ⟨xs, hlen, heast⟩ => simp [countP_false_cons_false]
+    | Sum.inr ⟨xs, hlen, heast⟩ => simp [countP_false_cons_true]
+
+/-- The number of lattice paths with m East steps and n North steps
+    equals C(m + n, m). -/
 theorem pathMN_card (m n : ℕ) :
     Fintype.card (PathMN m n) = Nat.choose (m + n) m := by
-  sorry
+  induction m generalizing n with
+  | zero =>
+    simp only [Nat.zero_add, Nat.choose_zero_right]
+    apply Fintype.card_eq_one_iff.mpr
+    refine ⟨⟨List.replicate n true, by simp, by simp⟩, ?_⟩
+    intro ⟨l, hlen, heast⟩
+    apply Subtype.ext; simp only
+    apply List.ext_getElem
+    · simp [hlen]
+    · intro i hi_l _
+      rw [List.getElem_replicate]
+      rcases Bool.eq_false_or_eq_true (l[i]) with h | h
+      · exact h
+      · exfalso
+        have hmem : false ∈ l := h ▸ List.getElem_mem hi_l
+        have : 0 < l.countP (· = false) :=
+          List.countP_pos_iff.mpr ⟨false, hmem, by simp⟩
+        omega
+  | succ m ih =>
+    induction n with
+    | zero =>
+      simp only [Nat.add_zero, Nat.choose_self]
+      apply Fintype.card_eq_one_iff.mpr
+      refine ⟨⟨List.replicate (m + 1) false, by simp,
+               by simp [List.countP_replicate]⟩, ?_⟩
+      intro ⟨l, hlen, heast⟩
+      apply Subtype.ext; simp only
+      apply List.ext_getElem
+      · simp [hlen]
+      · intro i hi_l _
+        rw [List.getElem_replicate]
+        rcases Bool.eq_false_or_eq_true (l[i]) with h | h
+        · exfalso
+          have hmem : true ∈ l := h ▸ List.getElem_mem hi_l
+          have h_pos : 0 < l.countP (· = true) :=
+            List.countP_pos_iff.mpr ⟨true, hmem, by simp⟩
+          have h_sum := bool_countP_sum l
+          omega
+        · exact h
+    | succ n ih_n =>
+      rw [Fintype.card_congr (pathMN_split m n), Fintype.card_sum, ih (n + 1), ih_n,
+          show m + 1 + n = m + (n + 1) from by omega,
+          show m + 1 + (n + 1) = m + (n + 1) + 1 from by omega]
+      exact (Nat.choose_succ_succ' (m + (n + 1)) m).symm
 
 -- ============================================================
 -- PART 7c: Algebraic Bridge

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -22,7 +22,7 @@
       "File builds clean against Mathlib v4.26 (verified). 1 axiom (gv_involution_cancellation), 1 sorry (pathMN_card).",
       "pathMN_card proof strategy: PathMN m n ≃ Finset.univ.powersetCard m via indicator bijection, then use Finset.card_powersetCard. Requires building explicit Equiv between List Bool positions and Finset (Fin (m+n)).",
       "pathMN_card is a good Aristotle candidate - standard combinatorial identity C(m+n,m) = |{binary strings of length m+n with m zeros}|",
-      "pathMN_card proof approaches analyzed: (1) Bijection PathMN ≃ Finset.powersetCard via indicator positions - cleanest but requires ~50 lines building equiv and connecting List.countP to Finset.card of filter on Fin indices, (2) Induction on m,n with Pascal identity - requires decomposition equiv PathMN (m+1) (n+1) ≃ PathMN m (n+1) ⊕ PathMN (m+1) n via first-element case split, (3) Missing Mathlib bridge: List.countP p l = (Finset.univ.filter (fun i : Fin l.length => p (l.get i))).card - needed for both approaches"
+      "pathMN_card proved via double induction + Pascal identity + splitting equiv. 0 sorries now."
     ],
     "builtItems": [
       "BallotProblemOQ03OQ02.lean: r×r LGV infrastructure (204 lines)",
@@ -50,7 +50,7 @@
       "Build involution: swap tails at first intersection, prove involutivity and sign reversal",
       "Prove gv_involution_cancellation from the constructed involution"
     ],
-    "progressSummary": "PROGRESS: File builds clean. 1 axiom (GV involution cancellation - deep combinatorial). 1 sorry (pathMN_card - standard identity, proof approaches analyzed in detail). Good Aristotle candidate."
+    "progressSummary": "PROGRESS: pathMN_card sorry eliminated. File now 0 sorries, 1 axiom (gv_involution_cancellation). 504 lines."
   },
   "lastUpdate": "2026-03-22T08:00:00Z"
 }


### PR DESCRIPTION
## Summary
- Proved `pathMN_card`: `Fintype.card (PathMN m n) = Nat.choose (m+n) m`
- File now has **0 sorries** (was 1), 1 axiom (`gv_involution_cancellation`)

## Proof technique
Double induction on m, n via splitting equivalence:
- `pathMN_split`: PathMN (m+1)(n+1) ≃ PathMN m (n+1) ⊕ PathMN (m+1) n
- Base cases: uniqueness via `List.ext_getElem` + Bool case analysis
- Step: Pascal's identity `C(m+n+2, m+1) = C(m+n+1, m) + C(m+n+1, m+1)`

Adapted from the 2×2 LGV parent file (`BallotProblemOQ03.lean`).

## Stats
| Metric | Before | After |
|--------|--------|-------|
| Sorries | 1 | 0 |
| Axioms | 1 | 1 |
| Lines | ~404 | 504 |

## Test plan
- [x] Docker build passes (`Proofs.BallotProblemOQ03OQ02`)

🤖 Generated by researcher-1