### PR TITLE
Enrich erdos-773, erdos-825, erdos-995: add prerequisites, cross-references

### DIFF
--- a/src/data/proofs/erdos-995/annotations.json
+++ b/src/data/proofs/erdos-995/annotations.json
@@ -9,7 +9,7 @@
     "mathContext": "The problem sits at the interface of harmonic analysis ($\\sum e(\\alpha n_k)$ Weyl sums), probability (LIL, CLT for quasi-independent variables), and ergodic theory (Birkhoff averages along subsequences). The 75-year gap between $(\\log\\log N)^{1/2}$ and $(\\log N)^{1/2}$ is one of the longest-standing open problems in metric number theory.",
     "significance": "context",
     "relatedConcepts": ["metric number theory", "Weyl sums", "LIL", "ergodic theory", "Mathlib imports"],
-    "prerequisites": ["Mathlib.Analysis.SpecialFunctions.Log", "Mathlib.MeasureTheory.Measure.Lebesgue"]
+    "prerequisites": ["metric number theory", "Lebesgue measure and almost-everywhere statements", "harmonic analysis on the circle"]
   },
   {
     "id": "ann-995-frac",
@@ -21,7 +21,7 @@
     "mathContext": "The fractional part map $x \\mapsto \\{x\\} = x - \\lfloor x \\rfloor$ is the canonical projection $\\mathbb{R} \\to \\mathbb{R}/\\mathbb{Z} \\cong [0,1)$. For irrational $\\alpha$, the sequence $\\{\\alpha\\}, \\{2\\alpha\\}, \\{3\\alpha\\}, \\ldots$ is equidistributed by Weyl's theorem (1916). For lacunary sequences, $\\{\\alpha n_k\\}$ inherits stronger independence properties — the terms behave almost like i.i.d. uniform random variables on $[0,1)$.",
     "significance": "supporting",
     "relatedConcepts": ["Weyl equidistribution", "floor function", "mod 1 arithmetic", "circle rotation"],
-    "prerequisites": ["Int.floor", "Real.sub"]
+    "prerequisites": ["floor function", "modular arithmetic on the reals"]
   },
   {
     "id": "ann-995-lacunary",
@@ -33,7 +33,7 @@
     "mathContext": "Lacunary (or Hadamard gap) sequences were introduced by Hadamard in his study of power series convergence (1892). The gap condition $n_{k+1}/n_k \\geq q > 1$ ensures exponential growth: $n_k \\geq n_1 \\cdot q^{k-1}$. This exponential spacing destroys correlations between $\\cos(2\\pi n_k \\alpha)$ for different $k$ — the Fourier coefficients of $f(\\{\\alpha n_k\\})$ become nearly orthogonal. This 'quasi-independence' is formalized in Kac's CLT (1946): $\\sum \\cos(2\\pi n_k \\alpha)/\\sqrt{N} \\to \\mathcal{N}(0, 1/2)$ in distribution. The lacunarity ratio $q$ can be arbitrarily close to 1; even $q = 1 + \\varepsilon$ suffices for most results.",
     "significance": "key",
     "relatedConcepts": ["Hadamard gap condition", "exponential growth", "quasi-independence", "Kac CLT", "power series convergence"],
-    "prerequisites": ["Nat.cast_le", "Real.lt_iff_lt"]
+    "prerequisites": ["exponential growth of sequences", "Hadamard gap condition", "power series convergence theory"]
   },
   {
     "id": "ann-995-sum",
@@ -57,7 +57,7 @@
     "mathContext": "The conjecture $o(N\\sqrt{\\log\\log N})$ corresponds precisely to the scale of the Law of the Iterated Logarithm (LIL). For independent random variables $X_k$ with variance $\\sigma^2$, the LIL (Khintchine 1924) says $\\limsup S_N / \\sqrt{2N\\sigma^2 \\log \\log N} = 1$ a.s. Since lacunary sums mimic independent sums, Erdős conjectured that the LIL-scale bound holds. The measure-theoretic 'almost all $\\alpha$' formulation uses $\\forall^{\\text{m}} \\alpha \\partial(\\text{volume.restrict}(\\text{Set.Icc}\\; 0\\; 1))$, asserting the statement for Lebesgue-a.e. $\\alpha \\in [0,1]$. The `ErdosQuestion` universally quantifies over all lacunary sequences and $L^2$ functions.",
     "significance": "key",
     "relatedConcepts": ["Law of the Iterated Logarithm", "Khintchine", "almost everywhere", "MeasureTheory.ae", "little-o notation"],
-    "prerequisites": ["MeasureTheory.volume", "Set.Icc", "Real.sqrt", "Real.log", "Filter.Eventually"]
+    "prerequisites": ["Lebesgue measure on [0,1]", "Law of the Iterated Logarithm", "little-o asymptotic notation"]
   },
   {
     "id": "ann-995-lower",
@@ -69,7 +69,7 @@
     "mathContext": "In 'On the strong law of large numbers' (1949), Erdős constructed specific lacunary sequences where the sum $\\sum f(\\{\\alpha n_k\\})$ exceeds $N(\\log\\log N)^{1/2-\\varepsilon}$ infinitely often for a.e. $\\alpha$. The construction exploits resonances between the lacunary ratios and the Fourier coefficients of $f$. The $\\limsup = \\top$ formulation (using the extended real line $\\overline{\\mathbb{R}}$) means the ratio $|S_N| / (N(\\log\\log N)^{1/2-\\varepsilon})$ is unbounded along a subsequence. This shows the sum must grow at least as fast as $N(\\log\\log N)^{1/2-\\varepsilon}$, ruling out any bound better than $O(N(\\log\\log N)^{1/2})$.",
     "significance": "key",
     "relatedConcepts": ["Filter.limsup", "extended reals", "constructive lower bound", "resonance", "Fourier coefficients"],
-    "prerequisites": ["Filter.limsup", "Filter.atTop", "MeasureTheory.ae", "IsLacunarySeq"]
+    "prerequisites": ["limit superior", "Fourier analysis", "constructive lower bound techniques"]
   },
   {
     "id": "ann-995-upper",
@@ -81,7 +81,7 @@
     "mathContext": "The upper bound $o(N(\\log N)^{1/2+\\varepsilon})$ is proved using second-moment methods and exponential sum estimates. The key input is that for lacunary $\\{n_k\\}$, the Weyl sums $|\\sum e(\\alpha n_k)|^2$ have controlled second moments over $\\alpha \\in [0,1]$. The proof uses Parseval's identity and the near-orthogonality of exponentials at lacunary frequencies. The $(\\log N)^{1/2+\\varepsilon}$ factor arises from the maximal inequality needed to pass from $L^2$ bounds to almost sure bounds. This is universal — it holds for ALL lacunary sequences and ALL $L^2$ functions, unlike the lower bound which is existential.",
     "significance": "key",
     "relatedConcepts": ["Weyl sums", "Parseval identity", "maximal inequality", "second moment method", "exponential sums"],
-    "prerequisites": ["IsLacunarySeq", "MeasureTheory.ae", "Real.log", "Real.rpow"]
+    "prerequisites": ["second moment method", "exponential sum estimates", "maximal inequalities"]
   },
   {
     "id": "ann-995-gap",
@@ -93,7 +93,7 @@
     "mathContext": "The gap between $(\\log\\log N)^{1/2}$ and $(\\log N)^{1/2}$ is qualitatively immense: at $N = 10^{10^{10}}$, $\\log N \\approx 2.3 \\times 10^{10}$ while $\\log\\log N \\approx 23.8$. So $(\\log N)^{1/2} \\approx 151{,}000$ while $(\\log\\log N)^{1/2} \\approx 4.9$ — a factor of $30{,}000$. Closing this gap has resisted 75+ years of effort. The existential lower bound ($\\exists f, n$) vs universal upper bound ($\\forall f, n$) structure means the true answer could depend on the specific lacunary sequence.",
     "significance": "key",
     "relatedConcepts": ["iterated logarithm", "existential vs universal bounds", "open problem", "metric number theory"],
-    "prerequisites": ["LowerBoundGrowth", "UpperBoundGrowth", "IsLacunarySeq"]
+    "prerequisites": ["iterated logarithm comparison", "lower and upper bound axioms", "lacunary sequence definition"]
   },
   {
     "id": "ann-995-exponent-gap",

--- a/src/data/proofs/erdos-995/meta.json
+++ b/src/data/proofs/erdos-995/meta.json
@@ -126,38 +126,45 @@
     ],
     "crossReferences": [
       {
-        "targetProofId": "erdos-996",
+        "targetId": "erdos-996",
         "relationship": "related",
         "description": "Companion problem on the Strong Law of Large Numbers for lacunary sums — same setup ∑f({αn_k}) but studies almost sure convergence of ergodic averages"
       },
       {
-        "targetProofId": "erdos-992",
+        "targetId": "erdos-992",
         "relationship": "uses-same-technique",
         "description": "Discrepancy of sequences mod 1 — the Erdős-Gál theorem gives discrepancy bounds for lacunary sequences, directly measuring equidistribution of fractional parts"
       },
       {
-        "targetProofId": "erdos-987",
+        "targetId": "erdos-987",
         "relationship": "uses-same-technique",
         "description": "Exponential sums and sequence discrepancy — Erdős-Turán inequality controls equidistribution via Weyl sums, the main analytic tool for lacunary sequence problems"
       },
       {
-        "targetProofId": "erdos-994",
+        "targetId": "erdos-994",
         "relationship": "related",
         "description": "Khintchine's equidistribution conjecture (disproved) — explores limits of equidistribution theory for fractional parts {αn_k}"
       },
       {
-        "targetProofId": "erdos-999",
+        "targetId": "erdos-999",
         "relationship": "related",
         "description": "Duffin-Schaeffer conjecture (solved 2020) — metric Diophantine approximation for almost all α, connected through the measure-theoretic framework of fractional part distribution"
       },
       {
-        "targetProofId": "laws-of-large-numbers",
+        "targetId": "laws-of-large-numbers",
         "relationship": "generalizes",
         "description": "Classical Strong Law of Large Numbers — lacunary sums satisfy analogous laws due to quasi-independence of {αn_k} terms"
       }
     ],
     "axiomCount": 5,
-    "lineCount": 232
+    "lineCount": 232,
+    "relatedProofs": [
+      "erdos-996",
+      "erdos-992",
+      "erdos-987",
+      "erdos-994",
+      "erdos-999"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős Problem #995 originated from Erdős's 1949 paper 'On the strong law of large numbers', where he discovered that sums ∑f({α n_k}) along lacunary sequences exhibit quasi-random behavior. A sequence n₁ < n₂ < ⋯ is lacunary (Hadamard gap condition) if n_{k+1}/n_k ≥ q > 1.\n\nThe connection to probability runs deep: Kac (1946) proved that cos(2πn_kα) behaves like independent random variables for lacunary {n_k}, satisfying a Central Limit Theorem. This suggested that lacunary sums should obey the Law of the Iterated Logarithm (LIL), giving the conjectured o(N√(log log N)) bound.\n\nErdős established both bounds: a constructive lower bound showing some lacunary sums grow as fast as N(log log N)^{1/2-ε}, and a universal upper bound of o(N(log N)^{1/2+ε}). In his 1964 Diophantine approximation paper, he stated his belief that the lower bound is closer to the truth.\n\nThe gap between (log log N)^{1/2} and (log N)^{1/2} has resisted 75+ years of effort. Partial progress by Berkes (1975), Philipp-Stout (1975), and Aistleitner-Berkes (2010) improved the upper bound in special cases, but the general gap remains one of the longest-standing open problems in metric number theory.",


### PR DESCRIPTION
## Summary

Enrichment pass for three entries:

### erdos-773 (Sidon Subsets of Perfect Squares)
- Added `mathContext` to all 6 sections
- Added `prerequisites` arrays to all 8 annotations
- Fixed non-standard `significance` values
- Added cross-references to erdos-30, erdos-329, erdos-155

### erdos-825 (Abundancy Bound for Weird Numbers)
- Added `prerequisites` arrays to all 8 annotations
- Added 5th `keyInsight` on subset-sum phase transition
- Added cross-references to erdos-470, erdos-824, erdos-826

### erdos-995 (Lacunary Sequences and Fractional Parts)
- Fixed `prerequisites` on 7 annotations from Mathlib module paths to mathematical concepts
- Standardized `crossReferences`: targetProofId → targetId (schema compliance)
- Added `relatedProofs` array

## Test plan
- [x] `pnpm annotations:build` passes (no blocking errors)
- [x] JSON validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)