### PR TITLE
Enrich erdos-738: add mathContext to all sections, preamble annotation

### DIFF
--- a/src/data/proofs/erdos-738/annotations.json
+++ b/src/data/proofs/erdos-738/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "erdos-738-ann-preamble",
+    "proofId": "erdos-738",
+    "type": "context",
+    "range": { "startLine": 1, "endLine": 29 },
+    "title": "Problem Statement, References, and Imports",
+    "content": "Module docstring presenting Erdős Problem #738 (Gyárfás conjecture for triangle-free graphs). Lists key partial results: Kierstead-Penrice (1994) for radius-2 trees, Scott (1997) for caterpillars, and Chudnovsky-Scott-Seymour (2020) for subdivisions. Imports `SimpleGraph.Basic` (adjacency), `SimpleGraph.Clique` (CliqueFree), `SimpleGraph.Coloring` (proper colorings), `Fintype.Basic` (finite types), and `Tactic` (omega, etc.).",
+    "mathContext": "The conjecture asks whether triangle-free graphs with $\\chi(G) = \\infty$ are 'universal' for finite trees under induced subgraph containment. This sits in the broader theory of $\\chi$-bounded graph classes initiated by Gyárfás (1975).",
+    "significance": "context",
+    "relatedConcepts": ["Gyárfás conjecture", "chi-bounded classes", "SimpleGraph library", "induced subgraphs"],
+    "prerequisites": ["Mathlib SimpleGraph framework", "graph coloring theory", "tree combinatorics"]
+  },
+  {
     "id": "erdos-738-ann-trianglefree",
     "proofId": "erdos-738",
     "type": "definition",


### PR DESCRIPTION
## Summary
- Added `mathContext` to all 5 sections in meta.json (previously missing from all sections)
- Added new preamble section covering lines 1-29
- Added preamble annotation covering imports, problem statement, and key results
- Fixed section line ranges to avoid overlap

Quality: 98 → 100

## Test plan
- [x] JSON validated (node parse check)
- [x] No new annotation build errors for erdos-738