### PR TITLE
Research: BSD - Delete unused gross_zagier_formula axiom (22→21)

### DIFF
--- a/proofs/Proofs/BirchSwinnertonDyer.lean
+++ b/proofs/Proofs/BirchSwinnertonDyer.lean
@@ -655,13 +655,6 @@ def NeronTateHeight (E : EllipticCurveQ) : ℝ → ℝ → ℝ := NeronTateHeigh
     and c is an explicit constant involving periods and Tamagawa numbers.
 
     This formula is the bridge between L-functions and rational points! -/
-/-- The Gross-Zagier formula connects L'(E, 1) to ĥ(P_K).
-    Key consequence: the existence of a Heegner point with nonzero height
-    implies the analytic rank is at most 1. See HeegnerPointData (Part XXVIII)
-    and gross_zagier_formula_detail (Part LIII) for the full typed version. -/
-axiom gross_zagier_formula (E : EllipticCurveQ) (_P : HeegnerPoint E) :
-    analyticRank E ≤ 1
-
 /- ═══════════════════════════════════════════════════════════════════════════════
 PART IX: COMPUTATIONAL EVIDENCE
 ═══════════════════════════════════════════════════════════════════════════════ -/
@@ -2708,7 +2701,6 @@ This file formalizes the Birch and Swinnerton-Dyer Conjecture with:
 #check BSDConjecture_Strong
 #check BSD_rank_zero
 #check BSD_rank_one
-#check gross_zagier_formula
 #check triangle_to_point_on_curve
 #check triangle_to_point_y_ne_zero
 #check triangle_gives_congruent_number_point
@@ -5726,7 +5718,6 @@ theorem bsd_current_status :
 #check LambdaModule
 -- Part LIII: Kolyvagin's Euler System
 #check HeegnerField
-#check gross_zagier_formula
 #check parity_conjecture
 -- Part LIV: p-adic BSD
 #check mtt_exceptional_zero

--- a/src/data/research/problems/birch-swinnerton-dyer.json
+++ b/src/data/research/problems/birch-swinnerton-dyer.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Deleted 3 unused axioms from BirchSwinnertonDyer.lean (46→43): root_number_parity, iwasawa_main_conjecture, no_weight2_level2.",
+    "progressSummary": "PROGRESS: 1 unused axiom deleted (gross_zagier_formula). 22→21 axioms, 0 sorries.",
     "builtItems": [
       "28 True→real conversions in BirchSwinnertonDyer.lean (Parts VIII-LV)",
       "2 proved theorems: parity_conjecture from axiom, bsd_current_status from computation",
@@ -110,7 +110,8 @@
       "9 imaginary quadratic fields with class number 1 (Baker-Stark-Heegner): disc = -3,-4,-7,-8,-11,-19,-43,-67,-163",
       "Non-degeneracy of p-adic heights (Nekovář) is equivalent to p-adic BSD conjecture",
       "4 axiom eliminations (100→96): average_rank_bounded proved from one_not_congruent+curve37a_rank, mestre_construction proved from elkies_rank_record, mtt_exceptional_zero proved from greenberg_stevens, positive_proportion_rank_zero_bsd proved from curveMinusX_L_nonzero+BSD_rank_zero_axiom",
-      "BirchSwinnertonDyer.lean: 3 axioms had no proof usage — root_number_parity (1 ref), iwasawa_main_conjecture (decl+#check), no_weight2_level2 (decl+#check)"
+      "BirchSwinnertonDyer.lean: 3 axioms had no proof usage — root_number_parity (1 ref), iwasawa_main_conjecture (decl+#check), no_weight2_level2 (decl+#check)",
+      "gross_zagier_formula axiom deleted (unused, only #check refs). Superseded by gross_zagier_formula_detail in Part LIII."
     ],
     "mathlibGaps": [
       "Torsion subgroup",


### PR DESCRIPTION
## Summary
- Deleted 1 unused axiom from `BirchSwinnertonDyer.lean` (22 → 21)
- `gross_zagier_formula` was only referenced in `#check` statements
- Superseded by `gross_zagier_formula_detail` in Part LIII

## Test plan
- [x] Docker build passes

🤖 Generated by researcher-1