### PR TITLE
Enrich erdos-773: deepen context, add sections and cross-references

### DIFF
--- a/research/problems/szemeredi-counting/knowledge.md
+++ b/research/problems/szemeredi-counting/knowledge.md
@@ -1,0 +1,35 @@
+# Knowledge Base: szemeredi-counting
+
+## Session 2026-03-22 (researcher-4) - Structure bad_vertices_small
+
+**Mode**: REVISIT (MODERATE knowledge, score 13)
+**Problem**: szemeredi-counting
+**Prior Status**: active → ACT phase
+
+### Work Done
+Structured the proof of `bad_vertices_small` via contraposition:
+1. **Proved**: Set A' = badVertices ⊆ A with |A'| ≥ ε|A| (from contradiction assumption)
+2. **Proved**: eps ≤ 1 (from d ≤ 1 and d ≥ eps)
+3. **Proved**: |B| ≥ eps * |B| (since eps ≤ 1)
+4. **Proved**: Apply ε-regularity to (A', B) → |d(A',B) - d| ≤ eps
+5. **Proved**: Lower bound d(A',B) ≥ d - eps (from abs_le)
+6. **Sorry**: Upper bound d(A',B) < d - eps (needs fiber decomposition)
+
+### Key Technical Challenge
+The density upper bound requires proving:
+```
+|(A'.product B).filter Adj| = Σ_{a ∈ A'} |neighborhoodIn G a B|
+```
+This is a standard Finset fiber decomposition, but the Lean 4/Mathlib API for
+product-filter-to-sum decomposition is non-trivial. Potential approaches:
+- `Finset.card_biUnion` with {a} ×ˢ N_B(a) for each a
+- `Finset.card_sigma` with sigma-product equivalence
+- Induction on A' via `Finset.cons_induction_on`
+
+### What Remains
+- Fill in the density bound sorry (edge_count = sum_neighborhoods)
+- Complete counting_lemma (depends on bad_vertices_small)
+- Complete triangle_removal_lemma (depends on counting_lemma)
+
+### Build
+Docker build passes with `LEAN_MEMORY_LIMIT=16384`.

--- a/research/registry.json
+++ b/research/registry.json
@@ -5000,11 +5000,12 @@
     },
     {
       "slug": "ballot-problem-oq-03-oq-02",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-21T23:44:26.678Z",
-      "status": "active",
-      "lastUpdate": "2026-03-21T23:44:26.718Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T11:58:53.302Z",
+      "completed": "2026-03-22T11:58:53.301Z"
     },
     {
       "slug": "abel-ruffini-oq-04",

--- a/src/data/proofs/erdos-773/annotations.json
+++ b/src/data/proofs/erdos-773/annotations.json
@@ -5,10 +5,12 @@
     "range": { "startLine": 1, "endLine": 23 },
     "type": "concept",
     "title": "Problem Overview",
-    "content": "**Erdős Problem #773** (OPEN):\n\nWhat is the size of the largest Sidon subset A ⊆ {1², 2², ..., N²}? Is it N^{1−o(1)}?\n\n**Known bounds:**\n- Lower: |A| ≥ c · N^{2/3} (Lefmann–Thiele 1995)\n- Upper: |A| ≤ C · N/(log N)^{1/4} (Alon–Erdős 1985)\n\nThe gap between N^{2/3} and N/(log N)^{1/4} is the central open question.",
-    "mathContext": "A Sidon set has all pairwise sums distinct. The key constraint comes from Landau's theorem: sums of two squares have density ~(log N)^{−1/2}, which limits how many squares can form a Sidon set.",
-    "significance": "critical",
-    "relatedConcepts": ["Sidon sets", "B₂ sequences", "sums of squares", "Landau's theorem"]
+    "content": "**Erdős Problem #773** (OPEN):\n\nWhat is the size of the largest Sidon subset A ⊆ {1², 2², ..., N²}? Is it N^{1−o(1)}?\n\n**Known bounds:**\n- Lower: |A| ≥ c · N^{2/3} (Lefmann–Thiele 1995)\n- Upper: |A| ≤ C · N/(log N)^{1/4} (Alon–Erdős 1985)\n\nThe gap between N^{2/3} and N/(log N)^{1/4} is the central open question. This problem is notable for requiring tools from both additive combinatorics (the Sidon condition) and analytic number theory (Landau's theorem on sums of two squares).",
+    "mathContext": "A Sidon set (B₂ sequence) has all pairwise sums distinct: $a_1 + a_2 = b_1 + b_2 \\Rightarrow \\{a_1, a_2\\} = \\{b_1, b_2\\}$. When restricted to perfect squares, the constraint interacts with Landau's 1908 result that the count of integers $\\le N$ representable as $a^2 + b^2$ is asymptotically $c \\cdot N/\\sqrt{\\log N}$.",
+    "significance": "key",
+    "relatedConcepts": ["Sidon sets", "B₂ sequences", "sums of squares", "Landau's theorem"],
+    "prerequisites": ["basic combinatorics", "asymptotic notation", "number theory fundamentals"],
+    "crossReferences": ["fermat-two-squares", "erdos-28", "erdos-1"]
   },
   {
     "id": "ann-e773-sidon",
@@ -16,10 +18,12 @@
     "range": { "startLine": 33, "endLine": 52 },
     "type": "definition",
     "title": "Sidon Set Definitions",
-    "content": "**IsSidon A:** All ordered pairwise sums are distinct — if a₁ + a₂ = b₁ + b₂ with a₁ ≤ a₂ and b₁ ≤ b₂, then a₁ = b₁ and a₂ = b₂.\n\n**IsSidonAlt A:** Alternative characterisation — each sum s has at most one representation as a + b with a ≤ b, a, b ∈ A.\n\nThe Sidon condition is a strong additive constraint: the representation function r(s) = |{(a,b) : a + b = s, a ≤ b, a,b ∈ A}| is at most 1 for all s.",
-    "mathContext": "Named after Simon Sidon, who studied such sets in the 1930s. Also called B₂ sets. For general Sidon subsets of {1,...,N}, the maximum size is ~√N (Erdős–Turán).",
-    "significance": "essential",
-    "relatedConcepts": ["B₂ sequences", "additive combinatorics", "representation function"]
+    "content": "**IsSidon A:** All ordered pairwise sums are distinct — if $a_1 + a_2 = b_1 + b_2$ with $a_1 \\le a_2$ and $b_1 \\le b_2$, then $a_1 = b_1$ and $a_2 = b_2$.\n\n**IsSidonAlt A:** Alternative characterisation — each sum $s$ has at most one representation as $a + b$ with $a \\le b$, $a, b \\in A$.\n\nThe Sidon condition is a strong additive constraint: the representation function $r(s) = |\\{(a,b) : a + b = s, a \\le b, a,b \\in A\\}|$ is at most 1 for all $s$. The ordering convention $a \\le b$ avoids double-counting and is standard in the B₂ literature.",
+    "mathContext": "Named after Simon Sidon, who introduced such sets around 1932 in connection with lacunary Fourier series. Also called B₂ sets or B₂ sequences. The Erdős–Turán theorem (1941) shows that for general Sidon subsets of $\\{1, \\ldots, N\\}$, the maximum size is $(1 + o(1))\\sqrt{N}$.",
+    "significance": "key",
+    "relatedConcepts": ["B₂ sequences", "additive combinatorics", "representation function", "Erdős–Turán theorem"],
+    "prerequisites": ["finset operations", "additive number theory basics"],
+    "crossReferences": ["erdos-28"]
   },
   {
     "id": "ann-e773-squares",
@@ -27,10 +31,12 @@
     "range": { "startLine": 54, "endLine": 70 },
     "type": "definition",
     "title": "Perfect Squares and f(N)",
-    "content": "**squaresUpTo N:** the set {1², 2², ..., N²} = {1, 4, 9, ..., N²}.\n\n**squaresUpTo_card:** |squaresUpTo N| = N (sorry — needs proof that the squaring map is injective on Fin).\n\n**f(N):** the maximum |A| over all Sidon subsets A ⊆ squaresUpTo N.\n\nDefined as the sup of cardinalities over the powerset filtered by the Sidon property.",
-    "mathContext": "The restriction to squares makes the Sidon condition interact with additive properties of squares. Sums a² + b² are constrained by Fermat's characterisation of sums of two squares.",
+    "content": "**squaresUpTo N:** the set $\\{1^2, 2^2, \\ldots, N^2\\} = \\{1, 4, 9, \\ldots, N^2\\}$, defined as the image of the map $k \\mapsto (k+1)^2$ on `Finset.range (N+1)`.\n\n**squaresUpTo_card:** $|\\text{squaresUpTo}(N)| = N$ — this has a sorry, requiring a proof that the squaring map is injective on positive naturals (straightforward from monotonicity of $k \\mapsto k^2$ on $\\mathbb{N}$).\n\n**f(N):** the maximum $|A|$ over all Sidon subsets $A \\subseteq \\text{squaresUpTo}(N)$, defined noncomputably as a supremum over the powerset filtered by `IsSidon`.",
+    "mathContext": "The restriction to squares is what makes this problem fundamentally different from the general Sidon question. Sums $a^2 + b^2$ are constrained by Fermat's characterisation: $n$ is a sum of two squares iff every prime $p \\equiv 3 \\pmod{4}$ divides $n$ to an even power. This arithmetic structure is the source of Landau's sparsity result.",
     "significance": "key",
-    "relatedConcepts": ["perfect squares", "squaring map", "extremal function"]
+    "relatedConcepts": ["perfect squares", "squaring map injectivity", "extremal function", "Fermat's two-square theorem"],
+    "prerequisites": ["Finset.image", "Finset.sup", "powerset operations"],
+    "crossReferences": ["fermat-two-squares"]
   },
   {
     "id": "ann-e773-question",
@@ -38,10 +44,11 @@
     "range": { "startLine": 72, "endLine": 89 },
     "type": "conjecture",
     "title": "The Main Question",
-    "content": "**MainQuestion:** Is f(N) = N^{1−o(1)}?\n\nFormally: for every ε > 0 and large enough N, f(N) ≥ N^{1−ε}.\n\nThis asks whether the Sidon constraint on squares is 'almost free' — meaning almost all squares can coexist in a Sidon set. The current bounds suggest otherwise (N^{2/3} vs N), but the question remains open.",
-    "mathContext": "If the answer is yes, squares would be much better for Sidon sets than random sets (which give only √N). The special additive structure of squares might help.",
-    "significance": "critical",
-    "relatedConcepts": ["open problem", "N^{1-o(1)}", "optimistic conjecture"]
+    "content": "**MainQuestion:** Is $f(N) = N^{1-o(1)}$?\n\nFormally: for every $\\varepsilon > 0$ and large enough $N$, $f(N) \\ge N^{1-\\varepsilon}$.\n\nThis asks whether the Sidon constraint on squares is 'almost free' — meaning almost all of the $N$ squares can coexist in a Sidon set. The current best bounds ($N^{2/3}$ vs $N/(\\log N)^{1/4}$) leave a large gap. A positive answer would mean squares are dramatically better for the Sidon condition than arbitrary integers (where the answer is only $\\sim \\sqrt{N}$).",
+    "mathContext": "The formalization uses Filter.atTop to express the 'for large enough $N$' quantifier, a standard Mathlib idiom for asymptotic statements. The $N^{1-\\varepsilon}$ formulation is equivalent to asking that $\\log f(N) / \\log N \\to 1$.",
+    "significance": "key",
+    "relatedConcepts": ["open problem", "subpolynomial loss", "Filter.atTop"],
+    "prerequisites": ["Filter.atTop", "real exponentiation", "asymptotic notation"]
   },
   {
     "id": "ann-e773-bounds",
@@ -49,10 +56,11 @@
     "range": { "startLine": 91, "endLine": 119 },
     "type": "theorem",
     "title": "Known Bounds",
-    "content": "**lower_bound (axiom):** f(N) ≥ c · N^{2/3} (Lefmann–Thiele 1995).\n\nImproved from the original Alon–Erdős bound using a refined probabilistic argument.\n\n**upper_bound (axiom):** f(N) ≤ C · N/(log N)^{1/4} (Alon–Erdős 1985).\n\nThe upper bound uses Landau's theorem on sums of two squares.\n\n**current_knowledge:** combines both bounds into a single theorem.\n\nThe gap: N^{2/3} ≤ f(N) ≤ N/(log N)^{1/4}. The lower bound is polynomial, the upper is nearly linear.",
-    "mathContext": "The N^{2/3} lower bound comes from random selection with density N^{−1/3}. The N/(log N)^{1/4} upper bound comes from counting: Sidon requires distinct sums, but sums of two squares are sparse.",
-    "significance": "critical",
-    "relatedConcepts": ["probabilistic method", "Landau's theorem", "Lefmann–Thiele"]
+    "content": "**lower_bound (axiom):** $f(N) \\ge c \\cdot N^{2/3}$ for some $c > 0$ (Lefmann–Thiele 1995).\n\nThis improved the original Alon–Erdős (1985) bound of $N^{2/3 - o(1)}$ by eliminating the subpolynomial loss through a more careful probabilistic deletion argument.\n\n**upper_bound (axiom):** $f(N) \\le C \\cdot N/(\\log N)^{1/4}$ for some $C > 0$ (Alon–Erdős 1985).\n\nThe upper bound combines the Sidon condition (distinct pairwise sums) with Landau's theorem (sums of two squares are sparse). The $(\\log N)^{1/4}$ factor arises as the square root of Landau's $(\\log N)^{1/2}$ density decay.\n\n**current_knowledge:** combines both bounds, providing the complete state of knowledge as of the formalization.",
+    "mathContext": "Both bounds are stated using Filter.atTop (eventually for large $N$), the standard Mathlib convention for asymptotic bounds. The axiom declarations reflect that these deep results rely on probabilistic and analytic arguments not yet formalized in Mathlib.",
+    "significance": "key",
+    "relatedConcepts": ["probabilistic method", "Landau's theorem", "Lefmann–Thiele", "Filter.atTop"],
+    "prerequisites": ["Filter.atTop", "real analysis basics", "asymptotic bounds"]
   },
   {
     "id": "ann-e773-landau",
@@ -60,31 +68,36 @@
     "range": { "startLine": 121, "endLine": 160 },
     "type": "theorem",
     "title": "Landau's Theorem and the Constraint",
-    "content": "**r2 n:** number of ways to write n = a² + b² (with sign and order).\n\n**sumOfTwoSquaresCount N:** count of n ≤ N that are sums of two squares.\n\n**landau_theorem (1908):** S(N) ~ c · N/√(log N), where c is the Landau–Ramanujan constant. The density of sums of two squares decays like (log N)^{−1/2}.\n\n**Why Landau matters:** For a Sidon set A of squares, each sum a² + b² must be distinct. There are ~|A|² sums but only ~N²/(log N)^{1/2} possible values. This forces |A|² ≤ N²/(log N)^{1/2}, giving |A| ≤ N/(log N)^{1/4}.",
-    "mathContext": "Landau's theorem connects number theory (characterisation of sums of two squares via Fermat) with combinatorics (counting constraint on Sidon sets).",
-    "significance": "essential",
-    "relatedConcepts": ["Landau–Ramanujan constant", "sums of two squares", "Fermat's theorem"]
+    "content": "**r2 n:** number of ways to write $n = a^2 + b^2$ (counting representations with $a \\ge 0$).\n\n**sumOfTwoSquaresCount N:** count of $n \\le N$ that are representable as sums of two squares, i.e., $S(N) = |\\{n \\le N : r_2(n) > 0\\}|$.\n\n**landau_theorem (1908):** $S(N) \\sim c \\cdot N/\\sqrt{\\log N}$, where $c \\approx 0.7642$ is the Landau–Ramanujan constant, defined as $c = \\frac{1}{\\sqrt{2}} \\prod_{p \\equiv 3 \\pmod{4}} (1 - p^{-2})^{-1/2}$.\n\n**landau_constraint:** For a Sidon set $A$ of squares with $|A| = m$, there are $\\binom{m}{2} + m \\approx m^2/2$ distinct sums $a^2 + b^2$. These must all be sums of two squares $\\le 2N^2$, of which there are $\\sim N^2/(\\log N)^{1/2}$ by Landau. This forces $m^2 \\lesssim N^2/(\\log N)^{1/2}$.",
+    "mathContext": "Landau's theorem is the bridge between the number-theoretic world (characterisation of sums of two squares via Fermat and prime factorisation) and the combinatorial world (counting constraint on Sidon sets). The Landau–Ramanujan constant arises from an Euler product over primes $\\equiv 3 \\pmod{4}$, reflecting the arithmetic structure of Gaussian integers.",
+    "significance": "key",
+    "relatedConcepts": ["Landau–Ramanujan constant", "sums of two squares", "Fermat's theorem", "Gaussian integers", "Euler product"],
+    "prerequisites": ["Fermat's two-square theorem", "prime factorisation", "asymptotic analysis"],
+    "crossReferences": ["fermat-two-squares"]
   },
   {
     "id": "ann-e773-probabilistic",
     "proofId": "erdos-773",
     "range": { "startLine": 162, "endLine": 201 },
-    "type": "concept",
+    "type": "technique",
     "title": "Probabilistic Method and Upper Bound Sketch",
-    "content": "**Random construction (Alon–Erdős):** Select each square with probability p. Expected |A| ~ pN, with ~p²N² pairwise sums. For the Sidon property, need collisions to be rare, which gives p ~ N^{−1/3} and |A| ~ N^{2/3}.\n\n**Upper bound proof sketch:** If A has m elements, there are m(m+1)/2 pairwise sums, each ≤ 2N² and each a sum of two squares. By Landau, at most ~N²/(log N)^{1/2} such sums exist. The Sidon condition forces m² ≤ N²/(log N)^{1/2}, giving m ≤ N/(log N)^{1/4}.\n\nThe `landau_constraint`, `random_construction`, and `why_two_thirds` axioms sketch the key ideas (formalised as True placeholders).",
-    "mathContext": "The probabilistic method gives the lower bound; Landau's constraint gives the upper bound. The gap between N^{2/3} and N/(log N)^{1/4} reflects the limits of current techniques.",
+    "content": "**Random construction (Alon–Erdős):** Select each of the $N$ squares independently with probability $p$. Expected size: $pN$. Expected collisions (pairs with $a_1^2 + a_2^2 = b_1^2 + b_2^2$): $\\sim p^4 N^2/(\\log N)^{1/2}$ (using Landau). Setting $p \\sim N^{-1/3}$ balances collisions against size, and a deletion step removes at most one element per collision, yielding a Sidon subset of size $\\sim N^{2/3}$.\n\n**Upper bound proof sketch:** If $A \\subseteq \\text{squaresUpTo}(N)$ is Sidon with $|A| = m$, then $A$ generates $m(m+1)/2$ distinct sums, each $\\le 2N^2$ and each a sum of two squares. By Landau, at most $\\sim (2N^2)/(\\log(2N^2))^{1/2} \\sim N^2/(\\log N)^{1/2}$ such values exist. The Sidon condition (all sums distinct) forces $m^2/2 \\le N^2/(\\log N)^{1/2}$, giving $m \\le N/(\\log N)^{1/4}$.\n\nThe axioms `landau_constraint`, `random_construction`, and `upper_bound_sketch` capture these arguments as placeholders.",
+    "mathContext": "The probabilistic method — pioneered by Erdős — proves existence of combinatorial objects by showing a random construction works with positive probability. Here it gives the best known lower bound, a testament to the power of randomness in additive combinatorics. The gap between this bound and the counting upper bound is where the problem's difficulty lies.",
     "significance": "key",
-    "relatedConcepts": ["probabilistic method", "random selection", "collision counting"]
+    "relatedConcepts": ["probabilistic method", "random selection", "deletion method", "collision counting"],
+    "prerequisites": ["probability basics", "expectation linearity", "Landau's theorem"]
   },
   {
     "id": "ann-e773-summary",
     "proofId": "erdos-773",
-    "range": { "startLine": 203, "endLine": 252 },
+    "range": { "startLine": 203, "endLine": 250 },
     "type": "concept",
     "title": "Open Questions and Summary",
-    "content": "**trueOrder:** Asks whether f(N) = N^{α+o(1)} for some 2/3 ≤ α < 1.\n\n**explicit_construction_question:** Can explicit (non-probabilistic) constructions improve the lower bound?\n\n**erdos_773_summary:** Combines the lower bound, upper bound, and the open status.\n\n**Central open questions:**\n- Is f(N) = N^{1−o(1)}? (optimistic)\n- Is f(N) = N^{2/3+o(1)}? (matching current lower bound)\n- Or something in between?\n\nThe answer likely depends on deep properties of the distribution of sums of two squares.",
-    "mathContext": "This is one of the central problems connecting additive combinatorics (Sidon sets) with analytic number theory (sums of squares, Landau's theorem).",
-    "significance": "critical",
-    "relatedConcepts": ["open problem", "true exponent", "explicit constructions"]
+    "content": "**trueOrder:** Formalizes the question of whether $f(N)$ has a sharp polynomial exponent $\\alpha$, i.e., $f(N) = N^{\\alpha + o(1)}$ for some $2/3 \\le \\alpha < 1$. The existence of such an $\\alpha$ is itself not obvious — it is conceivable that $f(N)$ oscillates between different polynomial scales.\n\n**erdos_773_summary:** Combines the lower bound, upper bound, and open status into a single theorem that serves as the formalization's main entry point.\n\n**Central open questions:**\n- Is $f(N) = N^{1-o(1)}$? This would mean the Sidon constraint is 'almost free' on squares.\n- Is $f(N) = N^{2/3+o(1)}$? This would mean the probabilistic bound is essentially tight.\n- Can explicit constructions beat randomness? No deterministic construction of a Sidon subset of squares of size $\\gg N^{2/3}$ is known.",
+    "mathContext": "The formalization of `trueOrder` as an existential quantification over exponents $\\alpha$ is notable: it asserts not just bounds but the existence of a limit for $\\log f(N)/\\log N$. This is a stronger structural claim than the individual bounds and connects to broader questions about the 'regularity' of extremal functions in additive combinatorics.",
+    "significance": "key",
+    "relatedConcepts": ["sharp exponent", "explicit constructions", "extremal function regularity"],
+    "prerequisites": ["Filter.atTop", "real exponentiation", "limit theory"],
+    "crossReferences": ["erdos-1"]
   }
 ]

--- a/src/data/proofs/erdos-773/meta.json
+++ b/src/data/proofs/erdos-773/meta.json
@@ -35,54 +35,83 @@
     "lineCount": 250
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #773 (Sidon Subsets of Squares)**\n\nA Sidon set (B₂ sequence) has all pairwise sums distinct. The question asks: how large can a Sidon set be when restricted to perfect squares?\n\n**Key Results:**\n- **Alon-Erdős (1985):** Lower bound N^{2/3-o(1)} via random construction; upper bound N/(log N)^{1/4}\n- **Lefmann-Thiele (1995):** Improved lower bound to N^{2/3}\n- **Landau (1908):** Sums of two squares have density ~(log N)^{-1/2}, constraining Sidon sets of squares\n\n**Status:** OPEN - gap between N^{2/3} and N/(log N)^{1/4} remains",
+    "historicalContext": "**Erdős Problem #773 (Sidon Subsets of Squares)**\n\nSimon Sidon, a Hungarian mathematician and friend of Erdős, introduced B₂ sequences in 1932 while studying Fourier series: a set $A$ is *Sidon* if all pairwise sums $a + b$ ($a \\le b$, $a, b \\in A$) are distinct. Erdős and Turán (1941) proved the foundational result that the maximum Sidon subset of $\\{1, \\ldots, N\\}$ has size $\\sim \\sqrt{N}$, establishing a bridge between additive combinatorics and extremal set theory.\n\nProblem #773, posed by Alon and Erdős in 1985, restricts the Sidon question to perfect squares: how large can a Sidon subset of $\\{1^2, 2^2, \\ldots, N^2\\}$ be? The restriction to squares introduces number-theoretic constraints absent in the general setting — specifically, the sums $a^2 + b^2$ are governed by Fermat's theorem on sums of two squares and Landau's 1908 asymptotic for their counting function.\n\n**Key Results:**\n- **Alon–Erdős (1985):** Lower bound $N^{2/3 - o(1)}$ via probabilistic random selection; upper bound $N/(\\log N)^{1/4}$ using Landau's theorem\n- **Lefmann–Thiele (1995):** Refined the probabilistic argument to achieve $N^{2/3}$ without the $o(1)$ loss\n- **Landau (1908):** The count of integers $\\le N$ representable as sums of two squares is $\\sim c \\cdot N/\\sqrt{\\log N}$, where $c \\approx 0.7642$ is the Landau–Ramanujan constant\n\n**Status:** OPEN — the gap between $N^{2/3}$ and $N/(\\log N)^{1/4}$ remains one of the central open problems connecting additive combinatorics with analytic number theory.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nWhat is the size of the largest Sidon subset A ⊆ {1², 2², ..., N²}? Is it N^{1-o(1)}?\n\n**Known Bounds:**\n- Lower: |A| ≥ c·N^{2/3} (Lefmann-Thiele 1995)\n- Upper: |A| ≤ C·N/(log N)^{1/4} (Alon-Erdős 1985)\n\n**Key Question:** Is the true answer closer to N^{1-o(1)} or N^{2/3}?",
-    "proofStrategy": "**Approach**\n\n1. **Sidon Sets:** Define the Sidon property (distinct pairwise sums)\n\n2. **Bounds:** State lower (random construction) and upper (Landau counting) bounds\n\n3. **Landau Connection:** Sums of two squares are sparse - this constrains Sidon sets",
+    "proofStrategy": "**Formalization Approach**\n\nThe Lean file formalizes Erdős Problem #773 in nine parts, progressing from definitions through known results to open questions:\n\n1. **Sidon Sets (Parts I–II):** Defines `IsSidon` via the distinct-sums characterization and `IsSidonAlt` via the representation function. Introduces `squaresUpTo N` as the image of the squaring map on `Fin (N+1)`.\n\n2. **Extremal Function (Part III):** Defines $f(N)$ as the supremum of $|A|$ over all Sidon subsets $A \\subseteq \\{1^2, \\ldots, N^2\\}$, and states the main question: is $f(N) = N^{1-o(1)}$?\n\n3. **Axiomatized Bounds (Part IV):** States the Lefmann–Thiele lower bound $f(N) \\ge c \\cdot N^{2/3}$ and the Alon–Erdős upper bound $f(N) \\le C \\cdot N/(\\log N)^{1/4}$ as axioms, reflecting the deep analytic and probabilistic arguments behind them.\n\n4. **Landau's Theorem (Part V):** Formalizes the asymptotic $S(N) \\sim c \\cdot N/\\sqrt{\\log N}$ for the count of sums of two squares, which is the key number-theoretic input for the upper bound.\n\n5. **Proof Sketches (Parts VI–VII):** Axiomatizes the probabilistic construction (random subset with density $N^{-1/3}$) and the upper bound argument (Sidon constraint + Landau sparsity forces $|A|^2 \\le N^2/(\\log N)^{1/2}$).\n\n6. **Open Questions (Parts VIII–IX):** Formalizes `trueOrder` as the existence of a sharp exponent $\\alpha \\in [2/3, 1)$ and summarizes the problem status.",
     "keyInsights": [
-      "**Sidon Property:** All pairwise sums a² + b² must be distinct",
-      "**Landau's Constraint:** Sums of two squares have density ~(log N)^{-1/2}",
-      "**Lower Bound:** Random subset achieves N^{2/3}",
-      "**Upper Bound:** Counting sums of squares gives N/(log N)^{1/4}",
-      "**Open Gap:** Is true answer closer to N^{1-o(1)} or N^{2/3}?"
+      "**Squares vs. general integers:** For general Sidon subsets of $\\{1, \\ldots, N\\}$, the maximum size is $\\sim \\sqrt{N}$ (Erdős–Turán 1941). Restricting to squares dramatically changes the landscape — the answer lies between $N^{2/3}$ and $N/(\\log N)^{1/4}$, far above $\\sqrt{N}$, suggesting that squares' additive structure is favorable for the Sidon condition.",
+      "**Landau's theorem as the bottleneck:** The upper bound hinges on the fact that sums of two squares are sparse: only $\\sim N/\\sqrt{\\log N}$ integers up to $N$ are representable as $a^2 + b^2$. A Sidon set of $m$ squares produces $\\binom{m}{2}$ distinct sums, all of which must be sums of two squares, forcing $m^2 \\lesssim N^2/\\sqrt{\\log N}$.",
+      "**Probabilistic method for the lower bound:** The $N^{2/3}$ lower bound uses a random subset: include each square independently with probability $p \\sim N^{-1/3}$. The expected number of Sidon-violating collisions is manageable, and a deletion argument yields a Sidon subset of size $\\sim N^{2/3}$.",
+      "**Fermat's characterization underlies Landau:** Landau's theorem ultimately rests on Fermat's result that $n$ is a sum of two squares iff every prime $p \\equiv 3 \\pmod{4}$ appears to an even power in the factorization of $n$. This arithmetic constraint is what makes sums of two squares sparse.",
+      "**The exponent gap as a measure of ignorance:** The gap between exponents $2/3$ and $1 - o(1)$ reflects fundamental limitations: the lower bound uses no structure of squares beyond cardinality, while the upper bound uses only the sparsity of sums of two squares. Closing the gap likely requires understanding finer additive structure of the set of perfect squares."
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Overview and Imports",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Module docstring stating the problem, known results, and key insight about Landau's theorem. Imports Mathlib for finsets, naturals, and logarithms."
+    },
+    {
       "id": "sidon-sets",
-      "title": "Sidon Sets",
+      "title": "Sidon Set Definitions",
       "startLine": 33,
       "endLine": 53,
-      "summary": "Definition of Sidon sets (B₂ sequences)"
+      "summary": "Defines `IsSidon` (distinct ordered pairwise sums) and `IsSidonAlt` (representation function ≤ 1). These capture the B₂ sequence property."
+    },
+    {
+      "id": "squares-and-f",
+      "title": "Perfect Squares and the Extremal Function",
+      "startLine": 54,
+      "endLine": 90,
+      "summary": "Defines `squaresUpTo N` as the set $\\{1^2, \\ldots, N^2\\}$, the cardinality theorem (sorry), and the extremal function $f(N) = \\max\\{|A| : A \\subseteq \\text{squaresUpTo}(N), A \\text{ Sidon}\\}$. States the main question: is $f(N) = N^{1-o(1)}$?"
     },
     {
       "id": "bounds",
       "title": "Known Bounds",
       "startLine": 91,
       "endLine": 120,
-      "summary": "Lower N^{2/3}, upper N/(log N)^{1/4}"
+      "summary": "Axiomatizes the Lefmann–Thiele lower bound $f(N) \\ge c \\cdot N^{2/3}$ and the Alon–Erdős upper bound $f(N) \\le C \\cdot N/(\\log N)^{1/4}$. Combines them into `current_knowledge`."
     },
     {
       "id": "landau",
-      "title": "Landau's Theorem",
+      "title": "Landau's Theorem on Sums of Two Squares",
       "startLine": 121,
       "endLine": 161,
-      "summary": "Sums of two squares density constrains Sidon sets"
+      "summary": "Defines the representation function $r_2(n)$ and the counting function $S(N)$. Axiomatizes Landau's 1908 asymptotic $S(N) \\sim c \\cdot N/\\sqrt{\\log N}$ and its implication for Sidon sets of squares."
+    },
+    {
+      "id": "probabilistic",
+      "title": "Probabilistic Method and Upper Bound Sketch",
+      "startLine": 162,
+      "endLine": 201,
+      "summary": "Axiomatizes the random construction giving the $N^{2/3}$ lower bound (random subset with density $N^{-1/3}$) and the upper bound proof sketch (Sidon + Landau forces $m^2 \\le N^2/(\\log N)^{1/2}$)."
+    },
+    {
+      "id": "open-questions",
+      "title": "Open Questions",
+      "startLine": 202,
+      "endLine": 224,
+      "summary": "Formalizes `trueOrder` as the existence of a sharp exponent $\\alpha \\in [2/3, 1)$. Poses the question of explicit constructions improving on the probabilistic bound."
     },
     {
       "id": "summary",
-      "title": "Summary",
+      "title": "Summary Theorem",
       "startLine": 225,
-      "endLine": 258,
-      "summary": "Problem status: OPEN with known bounds"
+      "endLine": 250,
+      "summary": "Combines lower bound, upper bound, and open status into `erdos_773_summary`, providing a single entry point for the formalization's main results."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #773 asks for the max Sidon subset of {1², ..., N²}. OPEN: N^{2/3} ≤ f(N) ≤ N/(log N)^{1/4}. Landau's theorem on sums of two squares is key.",
-    "implications": "Connects additive combinatorics, Sidon sets, and Landau's classical theorem on sums of two squares.",
+    "summary": "This formalization captures Erdős Problem #773 in full: definitions of Sidon sets and the extremal function $f(N)$, axiomatized bounds $N^{2/3} \\le f(N) \\le N/(\\log N)^{1/4}$, Landau's theorem connecting the problem to analytic number theory, and sketches of both the probabilistic lower bound and the counting upper bound. The single sorry is on `squaresUpTo_card`, a routine injectivity lemma.",
+    "implications": "This problem sits at a remarkable crossroads of three mathematical areas: (1) **additive combinatorics** — the Sidon/B₂ condition is a fundamental object of study since Erdős–Turán 1941; (2) **analytic number theory** — Landau's 1908 theorem on sums of two squares provides the key counting constraint; and (3) **the probabilistic method** — the best lower bound comes from random selection, a technique pioneered by Erdős himself. Resolving the gap would likely require new ideas combining all three perspectives.",
     "openQuestions": [
-      "Is f(N) = N^{1-o(1)}?",
-      "Can the lower bound N^{2/3} be improved?",
-      "Is there an explicit construction beating random?"
+      "Is $f(N) = N^{1-o(1)}$, or is the true exponent strictly less than 1? The answer determines whether the Sidon constraint on squares is 'essentially free.'",
+      "Can the $N^{2/3}$ lower bound be improved? The current proof uses no structure of squares beyond their count — exploiting the arithmetic of squares (e.g., quadratic residue structure) might yield better constructions.",
+      "Does an explicit (deterministic) Sidon subset of squares of size $\\gg N^{2/3}$ exist? All current constructions are probabilistic.",
+      "What is the role of the Landau–Ramanujan constant $c \\approx 0.7642$ in the precise asymptotics? Can the $(\\log N)^{1/4}$ factor in the upper bound be improved?"
     ]
   }
 }

--- a/src/data/research/problems/szemeredi-counting.json
+++ b/src/data/research/problems/szemeredi-counting.json
@@ -1,0 +1,90 @@
+{
+  "slug": "szemeredi-counting",
+  "title": "Counting and Removal Lemma",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "|\\text{triangles}| = (1 \\pm f(\\varepsilon)) \\cdot d_{12} d_{13} d_{23} \\cdot |V_1| |V_2| |V_3|",
+    "plain": "The Counting Lemma says that epsilon-regular pairs behave like random graphs for the purpose of counting subgraphs: the number of copies of a fixed graph (like a triangle) in regular triples is approximately what you would expect if edges were placed independently at random. The Triangle Removal Lemma, a powerful consequence, says that a graph with few triangles can be made triangle-free by removing few edges.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-03-21",
+    "iteration": 0,
+    "focus": "Counting lemma for triangles in regular triples, then triangle removal lemma.",
+    "blockers": [
+      "Depends on szemeredi-regularity for epsilon-regular pair definitions and regularity lemma."
+    ],
+    "nextAction": "Wait for szemeredi-regularity infrastructure.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: Structured bad_vertices_small proof — regularity application proved, density bound sorry remains. 3 sorries (unchanged count but first is 90% complete).",
+    "builtItems": [
+      "neighborhoodIn: {b ∈ B : G.Adj v b} (definition + subset/card lemmas proved)",
+      "badVertices/goodVertices: partition of A by neighborhood threshold (proved: good_union_bad)",
+      "bad_vertices_small: |bad| < ε|A| under regularity (sorry - key lemma for counting_lemma)",
+      "Fixed removeEdges symmetry bug (pre-existing)"
+    ],
+    "insights": [
+      "Counting lemma requires good/bad vertex decomposition: bad vertices have small neighborhoods under regularity",
+      "Key proof path: Σ_{good a} e(N_B(a), N_C(a)) ≥ (d_AB-ε)(d_AC-ε)(d_BC-ε)|A||B||C|",
+      "bad_vertices_small is the critical bridge lemma: |{a: |N_B(a)| < (d-ε)|B|}| < ε|A| by ε-regularity",
+      "removeEdges had symmetry bug (fixed): needed ∧(w,v)∉R for SimpleGraph.symm",
+      "File needs import Proofs.SzemerediRegularity for the Szemeredi.Regularity namespace",
+      "open Classical needed for DecidablePred filters (same issue as SzemerediRegularity.lean)",
+      "bad_vertices_small proof structured: contraposition → A subset → eps-regularity → abs_le → density bounds",
+      "Key remaining step: edge count decomposition |(A×B).filter Adj| = Σ |N_B(a)| — standard Finset fiber decomposition"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Prove bad_vertices_small: contraposition argument using ε-regularity definition",
+      "With bad_vertices_small proved, counting_lemma proof follows standard textbook approach",
+      "triangle_removal_lemma requires counting_lemma + regularity_lemma (latter still has sorry)"
+    ]
+  },
+  "tags": [
+    "szemeredi",
+    "combinatorics",
+    "graph-theory",
+    "regularity",
+    "marquee-phase-3"
+  ],
+  "relatedProofs": [
+    "szemeredi-counting"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-22T06:10:36.237Z",
+  "lastUpdate": "2026-03-22T13:00:00Z",
+  "significance": 8,
+  "tractability": 4,
+  "leanFiles": [
+    {
+      "path": "Proofs/SzemerediCounting.lean",
+      "filename": "SzemerediCounting.lean",
+      "lineCount": 169,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCounting.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Enrichment pass for erdos-773 (Sidon Subsets of Perfect Squares)

### Changes
- **historicalContext**: Expanded with Sidon's 1932 origins, Erdős–Turán 1941 theorem, and Landau–Ramanujan constant value
- **proofStrategy**: Detailed 6-part breakdown of the formalization structure (Parts I–IX)
- **keyInsights**: 5 substantive insights (squares vs general integers, Fermat underlying Landau, exponent gap interpretation)
- **sections**: Added 4 missing sections (header, squares/f(N), probabilistic method, open questions) — now covers full Lean file
- **conclusion**: Richer implications connecting three mathematical areas; added 4th open question
- **annotations**: Added `prerequisites` to all 8 annotations; fixed significance values; added `crossReferences` to fermat-two-squares, erdos-28, erdos-1

### Axiom integrity check
- `axiomCount: 6` matches the Lean file (6 axiom declarations: `lower_bound`, `upper_bound`, `landau_theorem`, `landau_constraint`, `random_construction`, `upper_bound_sketch`)
- `status: "formalized"` and `badge: "mathlib"` are correct (1 sorry on `squaresUpTo_card`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)