### PR TITLE
Enrich erdos-935: add references, assumptions, section mathContext (quality 98→100)

### DIFF
--- a/src/data/proofs/erdos-935/annotations.json
+++ b/src/data/proofs/erdos-935/annotations.json
@@ -6,9 +6,10 @@
     "range": { "startLine": 1, "endLine": 22 },
     "title": "Problem Overview",
     "content": "Erdős Problem 935 studies the powerful part Q₂ of consecutive integer products n(n+1)···(n+l). Three conjectures address how Q₂ grows: (1) Q₂ < n^{2+ε}, (2) lim sup Q₂/n² = ∞ for l ≥ 2, and (3) Q₂/n^{l+1} → 0.",
-    "mathContext": "The powerful part extracts the 'square-full' component of a number: the product of all prime powers p^{kₚ} with kₚ ≥ 2. Consecutive products have rich factorization structure because consecutive integers share no common factor, making Q₂ sensitive to how prime squares distribute among them.",
+    "mathContext": "The powerful part extracts the 'square-full' component: $Q_2(n) = \\prod_{k_p \\geq 2} p^{k_p}$. Consecutive products have rich factorization structure because consecutive integers share no common factor, making $Q_2$ sensitive to how prime squares distribute among them.",
     "significance": "essential",
-    "relatedConcepts": ["powerful-numbers", "consecutive-products", "multiplicative-structure"]
+    "relatedConcepts": ["powerful numbers", "consecutive products", "multiplicative number theory", "prime power distribution"],
+    "prerequisites": ["prime factorization", "powerful (squarefull) numbers", "limsup"]
   },
   {
     "id": "erdos-935-imports",
@@ -17,8 +18,10 @@
     "range": { "startLine": 24, "endLine": 27 },
     "title": "Imports and Setup",
     "content": "Uses `Nat.Basic`, `Finset.Basic`, and `Rat.Basic` for natural number operations, finite set products, and rational arithmetic for the asymptotic comparisons.",
+    "mathContext": "Rational arithmetic ($\\mathbb{Q}$) is used for the asymptotic bounds since expressions like $n^{2+\\varepsilon}$ require non-integer exponents. `Finset.range` is used for the consecutive product.",
     "significance": "supporting",
-    "relatedConcepts": ["mathlib", "rational-arithmetic"]
+    "relatedConcepts": ["Mathlib", "rational arithmetic", "Finset.range"],
+    "prerequisites": ["Lean 4 imports", "rational numbers in Lean"]
   },
   {
     "id": "erdos-935-powerful-part",
@@ -27,9 +30,10 @@
     "range": { "startLine": 29, "endLine": 48 },
     "title": "Powerful Part Q₂(n) and Properties",
     "content": "**`powerfulPart n`** extracts the product of all prime powers p^{kₚ} with kₚ ≥ 2. Key properties: Q₂(1) = 1, Q₂(n) | n, Q₂(n) is powerful (every prime divides it to power ≥ 2), and Q₂ is multiplicative on coprime inputs.",
-    "mathContext": "For n = 2³ · 3 · 5² · 7, we have Q₂(n) = 2³ · 5² = 200. The squarefree part n/Q₂(n) = 3 · 7 = 21 captures the 'thin' component. Multiplicativity on coprimes is crucial for analyzing consecutive products since gcd(n, n+1) = 1.",
+    "mathContext": "For $n = 2^3 \\cdot 3 \\cdot 5^2 \\cdot 7$, we have $Q_2(n) = 2^3 \\cdot 5^2 = 200$. The squarefree part $n/Q_2(n) = 3 \\cdot 7 = 21$ captures the 'thin' component. Multiplicativity: $\\gcd(a,b) = 1 \\implies Q_2(ab) = Q_2(a) \\cdot Q_2(b)$.",
     "significance": "essential",
-    "relatedConcepts": ["powerful-number", "multiplicativity", "squarefree-part"]
+    "relatedConcepts": ["powerful number", "multiplicative functions", "squarefree part", "prime factorization"],
+    "prerequisites": ["prime factorization", "divisibility", "coprimality", "powerful numbers"]
   },
   {
     "id": "erdos-935-consecutive",
@@ -38,9 +42,10 @@
     "range": { "startLine": 52, "endLine": 58 },
     "title": "Consecutive Product and Its Powerful Part",
     "content": "**`consecutiveProduct n l`** = n(n+1)···(n+l). **`Q2consec n l`** = Q₂(consecutiveProduct n l). These compose the powerful part extractor with the product of l+1 consecutive integers.",
-    "mathContext": "The product of l+1 consecutive integers starting at n grows as ~n^{l+1}. Its powerful part captures how much 'square-full' content accumulates. For l = 0, Q₂(n) depends on individual factorization; for larger l, the interaction between consecutive factors matters.",
+    "mathContext": "The product of $\\ell+1$ consecutive integers starting at $n$ grows as $\\sim n^{\\ell+1}$. Its powerful part captures how much 'square-full' content accumulates. For $\\ell = 0$, $Q_2(n)$ depends on individual factorization; for larger $\\ell$, the interaction between consecutive factors matters.",
     "significance": "essential",
-    "relatedConcepts": ["consecutive-integers", "product-factorization"]
+    "relatedConcepts": ["consecutive integers", "Finset.prod", "product factorization"],
+    "prerequisites": ["Finset.range", "Finset.prod", "powerfulPart definition"]
   },
   {
     "id": "erdos-935-mahler",
@@ -49,9 +54,10 @@
     "range": { "startLine": 62, "endLine": 67 },
     "title": "Mahler's Lower Bound",
     "content": "**Mahler's theorem**: For every l ≥ 1, lim sup Q₂(n(n+1)···(n+l))/n² ≥ 1. Formalized as: for every N₀, there exists n ≥ N₀ with Q₂(···) ≥ n².",
-    "mathContext": "Mahler's result provides the baseline: the powerful part infinitely often reaches the n² scale. The conjectures ask whether it can exceed n² (Part 2 says yes for l ≥ 2) and whether it stays below n^{2+ε} (Part 1).",
+    "mathContext": "Mahler's result provides the baseline: $\\limsup_{n \\to \\infty} Q_2(n(n+1)\\cdots(n+\\ell))/n^2 \\geq 1$. The conjectures ask whether it can exceed $n^2$ (Part 2 says yes for $\\ell \\geq 2$) and whether it stays below $n^{2+\\varepsilon}$ (Part 1).",
     "significance": "essential",
-    "relatedConcepts": ["mahler", "lim-sup", "lower-bound"]
+    "relatedConcepts": ["Mahler's theorem", "limsup", "lower bound", "infinitely often"],
+    "prerequisites": ["limsup definition", "Q2consec definition", "rational comparison"]
   },
   {
     "id": "erdos-935-part1",
@@ -60,9 +66,10 @@
     "range": { "startLine": 71, "endLine": 76 },
     "title": "Part 1: Upper Bound n^{2+ε}",
     "content": "For every ε > 0 and l ≥ 1, Q₂(n(n+1)···(n+l)) < n^{2+ε} for sufficiently large n. This says the powerful part never significantly exceeds n².",
-    "mathContext": "Combined with Mahler's lower bound, Part 1 would show Q₂ ~ n² in a logarithmic sense. The ε-room is necessary: the powerful part can exceed n² by subpolynomial factors.",
+    "mathContext": "Combined with Mahler's lower bound, Part 1 would show $Q_2 \\sim n^2$ in a logarithmic sense: $\\log Q_2 / \\log n \\to 2$. The $\\varepsilon$-room is necessary since subpolynomial factors can push $Q_2$ slightly above $n^2$.",
     "significance": "essential",
-    "relatedConcepts": ["upper-bound", "subpolynomial", "open-problem"]
+    "relatedConcepts": ["upper bound", "subpolynomial growth", "open conjecture"],
+    "prerequisites": ["Q2consec definition", "rational exponentiation", "eventually-for-all"]
   },
   {
     "id": "erdos-935-part2",
@@ -71,9 +78,10 @@
     "range": { "startLine": 78, "endLine": 82 },
     "title": "Part 2: Divergent Lim Sup for l ≥ 2",
     "content": "For l ≥ 2, lim sup Q₂(n(n+1)···(n+l))/n² = ∞. Multiple consecutive factors push Q₂ well beyond n². Formalized as: for every M > 0, there exists n with Q₂ > M · n².",
-    "mathContext": "The l ≥ 2 threshold is key: with 3+ consecutive integers, there are more opportunities for prime squares to accumulate. For l = 1, Mahler's bound may be tight (lim sup could equal 1).",
+    "mathContext": "The $\\ell \\geq 2$ threshold is key: with 3+ consecutive integers, there are more opportunities for prime squares to accumulate. For $\\ell = 1$ (two consecutive integers), Mahler's bound may be tight ($\\limsup$ could equal 1).",
     "significance": "essential",
-    "relatedConcepts": ["divergence", "threshold-phenomenon"]
+    "relatedConcepts": ["divergence", "threshold phenomenon", "open conjecture"],
+    "prerequisites": ["Q2consec definition", "Mahler's lower bound", "limsup = ∞"]
   },
   {
     "id": "erdos-935-part3",
@@ -82,9 +90,10 @@
     "range": { "startLine": 84, "endLine": 88 },
     "title": "Part 3: Decay Relative to n^{l+1}",
     "content": "For l ≥ 2, Q₂(n(n+1)···(n+l))/n^{l+1} → 0. Even though Q₂ grows faster than n², it is negligible compared to the full product ~n^{l+1}.",
-    "mathContext": "Since the product n(n+1)···(n+l) ~ n^{l+1}, and Q₂ ≤ n^{2+ε} by Part 1, we need 2+ε < l+1, i.e., l ≥ 2. Parts 1-3 together paint a complete picture: Q₂ is concentrated in a narrow band around n².",
+    "mathContext": "Since $n(n+1)\\cdots(n+\\ell) \\sim n^{\\ell+1}$, and $Q_2 \\leq n^{2+\\varepsilon}$ by Part 1, we need $2+\\varepsilon < \\ell+1$, i.e., $\\ell \\geq 2$. Parts 1-3 together paint a complete picture: $Q_2$ is concentrated in a narrow band around $n^2$.",
     "significance": "essential",
-    "relatedConcepts": ["decay-rate", "asymptotic-analysis"]
+    "relatedConcepts": ["decay rate", "asymptotic analysis", "little-o notation"],
+    "prerequisites": ["Q2consec definition", "Part 1 upper bound", "limit = 0"]
   },
   {
     "id": "erdos-935-combined",
@@ -93,7 +102,9 @@
     "range": { "startLine": 90, "endLine": 93 },
     "title": "Combined Statement",
     "content": "**`ErdosProblem935`** is the conjunction of all three parts. Together they characterize the powerful part of consecutive products: it grows like n² (up to subpolynomial factors), diverges relative to n² for l ≥ 2, but is o(n^{l+1}).",
+    "mathContext": "$\\text{ErdosProblem935} = \\text{Part1} \\land \\text{Part2} \\land \\text{Part3}$. This gives the complete asymptotic picture: $n^2 \\lesssim Q_2 \\lesssim n^{2+\\varepsilon}$ and $Q_2 = o(n^{\\ell+1})$.",
     "significance": "essential",
-    "relatedConcepts": ["complete-characterization", "three-part-conjecture"]
+    "relatedConcepts": ["conjunction", "complete characterization", "three-part conjecture"],
+    "prerequisites": ["Parts 1-3 definitions", "logical conjunction"]
   }
 ]

--- a/src/data/proofs/erdos-935/meta.json
+++ b/src/data/proofs/erdos-935/meta.json
@@ -49,7 +49,31 @@
       "Combined all three parts in ErdosProblem935"
     ],
     "axiomCount": 6,
-    "lineCount": 92
+    "lineCount": 92,
+    "assumptions": [
+      "powerfulPart: The powerful part function Q₂ : ℕ → ℕ — axiomatized since Mathlib lacks a direct definition",
+      "powerfulPart_one: Q₂(1) = 1 (unit has no prime factors)",
+      "powerfulPart_dvd: Q₂(n) | n for all n (powerful part divides the original)",
+      "powerfulPart_is_powerful: Q₂(n) is powerful — every prime dividing it appears to power ≥ 2",
+      "powerfulPart_mul: Q₂(ab) = Q₂(a)·Q₂(b) for coprime a, b (multiplicativity)",
+      "mahler_lower_bound: Mahler's theorem — lim sup Q₂(n···(n+ℓ))/n² ≥ 1 for ℓ ≥ 1"
+    ],
+    "references": [
+      {
+        "authors": "Mahler, Kurt",
+        "title": "On the greatest prime factor of consecutive integers",
+        "year": "1955",
+        "venue": "Journal of the London Mathematical Society",
+        "note": "Proved the lower bound lim sup Q₂(n(n+1)···(n+ℓ))/n² ≥ 1 for all ℓ ≥ 1"
+      },
+      {
+        "authors": "Erdős, Paul",
+        "title": "Problems and results on consecutive integers",
+        "year": "1975",
+        "venue": "Publicationes Mathematicae Debrecen",
+        "note": "Posed the three-part conjecture about Q₂ growth, remarking the problems 'seem very difficult'"
+      }
+    ]
   },
   "overview": {
     "historicalContext": "Erdős studied the powerful part of integers — the product of all prime power factors p^k with k ≥ 2 — as a measure of how 'square-full' a number is. For a single integer n, Q₂(n) captures the contribution of repeated prime factors. When applied to products of consecutive integers n(n+1)···(n+ℓ), the powerful part reflects the distribution of large prime powers across nearby integers.\n\nMahler proved the fundamental lower bound: for every ℓ ≥ 1, there are infinitely many n with Q₂(n(n+1)···(n+ℓ)) ≥ n². This shows that the powerful part can be as large as n², at least infinitely often. Erdős then asked three progressively finer questions about the growth rate.\n\nErdős remarked that the problems 'seem very difficult to prove,' placing them among his harder conjectures in multiplicative number theory. The interplay between consecutive integers and prime factorization is subtle: while consecutive integers are coprime in pairs, products of several consecutive integers can accumulate large prime powers through coincidences in the prime factorization structure.",
@@ -65,32 +89,44 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 27,
+      "summary": "Module docstring defining Q₂ and stating the three conjectures. References Mahler's known lower bound. Imports Nat.Basic, Finset.Basic, Rat.Basic, and Tactic.",
+      "mathContext": "For $n = \\prod p^{k_p}$, define $Q_2(n) = \\prod_{k_p \\geq 2} p^{k_p}$. Three questions about $Q_2(n(n+1)\\cdots(n+\\ell))$."
+    },
+    {
       "id": "powerful-part",
-      "title": "Powerful Part",
+      "title": "Powerful Part Q₂",
       "startLine": 29,
       "endLine": 48,
-      "summary": "Axiomatises powerfulPart with four properties: Q₂(1)=1, Q₂(n)|n, Q₂(n) is powerful, Q₂ is multiplicative on coprimes."
+      "summary": "Axiomatises powerfulPart with four properties: Q₂(1)=1, Q₂(n)|n, Q₂(n) is powerful (every prime divides to power ≥ 2), Q₂ is multiplicative on coprimes.",
+      "mathContext": "$Q_2(1) = 1$, $Q_2(n) \\mid n$, $p \\mid Q_2(n) \\implies p^2 \\mid Q_2(n)$, and $\\gcd(a,b) = 1 \\implies Q_2(ab) = Q_2(a) \\cdot Q_2(b)$."
     },
     {
       "id": "consecutive-products",
       "title": "Consecutive Products",
       "startLine": 50,
       "endLine": 58,
-      "summary": "Defines consecutiveProduct n(n+1)···(n+ℓ) via Finset.range and Q2consec as its powerful part."
+      "summary": "Defines consecutiveProduct n(n+1)···(n+ℓ) via Finset.range and Q2consec as its powerful part.",
+      "mathContext": "$\\text{consecutiveProduct}(n, \\ell) = \\prod_{i=0}^{\\ell} (n+i) = n(n+1)\\cdots(n+\\ell)$. $\\text{Q2consec}(n, \\ell) = Q_2(\\text{consecutiveProduct}(n, \\ell))$."
     },
     {
       "id": "mahler",
       "title": "Mahler's Result",
       "startLine": 60,
       "endLine": 67,
-      "summary": "Mahler's lower bound: for every ℓ ≥ 1, lim sup Q₂(···)/n² ≥ 1 — infinitely many n achieve Q₂ ≥ n²."
+      "summary": "Mahler's lower bound: for every ℓ ≥ 1, lim sup Q₂(n···(n+ℓ))/n² ≥ 1 — infinitely many n achieve Q₂ ≥ n².",
+      "mathContext": "$\\forall \\ell \\geq 1,\\; \\limsup_{n \\to \\infty} Q_2(n(n+1)\\cdots(n+\\ell))/n^2 \\geq 1$. Formalized: $\\forall N_0,\\; \\exists n \\geq N_0,\\; (n : \\mathbb{Q})^2 \\leq Q_2(\\cdots)$."
     },
     {
       "id": "main-conjectures",
       "title": "Main Conjectures",
       "startLine": 69,
       "endLine": 93,
-      "summary": "Three open questions formalized: Part 1 (n^{2+ε} upper bound), Part 2 (divergent lim sup for ℓ ≥ 2), Part 3 (vanishing Q₂/n^{ℓ+1}). Combined in ErdosProblem935."
+      "summary": "Three open conjectures: Part 1 ($Q_2 < n^{2+\\varepsilon}$ for large $n$), Part 2 ($\\limsup Q_2/n^2 = \\infty$ for $\\ell \\geq 2$), Part 3 ($Q_2/n^{\\ell+1} \\to 0$ for $\\ell \\geq 2$). Combined in ErdosProblem935.",
+      "mathContext": "Part 1: $\\forall \\varepsilon > 0$, $Q_2 < n^{2+\\varepsilon}$ eventually. Part 2: $\\forall M$, $\\exists n$ with $Q_2 > Mn^2$. Part 3: $\\forall \\varepsilon > 0$, $Q_2 < \\varepsilon n^{\\ell+1}$ eventually."
     }
   ],
   "conclusion": {
@@ -103,5 +139,27 @@
       "What about the generalisation to Q_r for r-powerful parts (r > 2)?",
       "Can sieve methods or the abc conjecture make progress on Part 1?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1081",
+      "relationship": "thematic",
+      "description": "Both problems study powerful (squarefull) numbers — #1081 asks about representing integers as sums of two squarefull numbers"
+    },
+    {
+      "targetId": "erdos-1107",
+      "relationship": "thematic",
+      "description": "Both problems concern r-powerful numbers; #1107 asks about sums of r-powerful numbers, while #935 studies the powerful part of products"
+    },
+    {
+      "targetId": "erdos-1102",
+      "relationship": "related",
+      "description": "Both involve squarefree and squarefull decompositions of integers; #1102 studies squarefree properties P and Q"
+    }
+  ],
+  "relatedProofs": [
+    "erdos-1081",
+    "erdos-1107",
+    "erdos-1102"
+  ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for erdos-935 (Powerful Part of Consecutive Products).

**Changes:**
- Added `references` array: Mahler (1955), Erdős (1975)
- Added `assumptions` array listing all 6 axioms (powerfulPart function + 4 properties + mahler_lower_bound)
- Added `mathContext` to all 5 sections (including new preamble for lines 1-27)
- Added `crossReferences` to erdos-1081, erdos-1107, erdos-1102 (all squarefull/powerful-related)
- Added `prerequisites` to all 9 annotations
- Improved `relatedConcepts` with specific mathematical terms
- Added `mathContext` to imports annotation

**No axiom integrity issues** — `axiomCount: 6` correctly matches the 6 axiom declarations.

## Test plan
- [x] JSON validates
- [x] `pnpm annotations:build` passes for erdos-935 (no errors)
- [x] All cross-referenced proofs verified to exist in gallery