### PR TITLE
Enrich harmonic-divergence: add preamble section, complete mathContext

### DIFF
--- a/src/data/proofs/harmonic-divergence/annotations.json
+++ b/src/data/proofs/harmonic-divergence/annotations.json
@@ -96,6 +96,7 @@
     "type": "lemma",
     "title": "Terms are Positive",
     "content": "A simple but necessary fact: $1/n > 0$ for all $n > 0$. This ensures all our terms contribute positively to the sum.",
+    "mathContext": "$\\forall n > 0,\\; 1/(n : \\mathbb{R}) > 0$. Proved via `div_pos one_pos (Nat.cast_pos.mpr hn)`. Needed so that adding more terms always increases the partial sum.",
     "significance": "supporting",
     "relatedConcepts": [
       "positivity",

--- a/src/data/proofs/harmonic-divergence/meta.json
+++ b/src/data/proofs/harmonic-divergence/meta.json
@@ -59,6 +59,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Imports and Module Setup",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Mathlib imports for p-series analysis and infinite sums. Module docstring explaining the harmonic series, Oresme's proof (c. 1350), and the contrast with convergent p-series.",
+      "mathContext": "Imports `Mathlib.Analysis.PSeries` (contains `not_summable_one_div_natCast`, `summable_nat_rpow_inv`) and `Mathlib.Topology.Algebra.InfiniteSum.Basic` (the `Summable` predicate and `HasSum` API)."
+    },
+    {
       "id": "main-theorem",
       "title": "The Main Theorem",
       "startLine": 40,


### PR DESCRIPTION
## Summary
- Added preamble section covering lines 1-39 with mathContext
- Added mathContext to `ann-term-positive` annotation (was the only annotation missing it)

Quality: 98 → 100

## Test plan
- [x] JSON validated (node parse check)