### PR TITLE
Enrich erdos-780: add preamble section, fix significance, fill prerequisites

### DIFF
--- a/src/data/proofs/erdos-780/annotations.json
+++ b/src/data/proofs/erdos-780/annotations.json
@@ -7,9 +7,9 @@
     "title": "Problem Overview",
     "content": "**Erdős Problem #780: Chromatic Number of Kneser Hypergraphs**\n\nIf $n \\geq kr + (t-1)(k-1)$, any $t$-coloring of $r$-sets has $k$ monochromatic disjoint edges.\n\n**Status:** SOLVED (Alon-Frankl-Lovász 1986)\n**Special case $k=2$:** Kneser's conjecture, proved by Lovász 1978 using the Borsuk-Ulam theorem.",
     "mathContext": "The Kneser hypergraph $KG^r(n,k)$ has $r$-element subsets of $[n]$ as vertices and $k$-tuples of pairwise disjoint $r$-sets as hyperedges. Its chromatic number $\\chi(KG^r(n,k)) = \\lceil (n - r(k-1))/(k-1) \\rceil$. The $k=2$ case gives the classical Kneser graph $KG(n,r)$ with $\\chi = n - 2r + 2$. The problem connects to topological combinatorics via the Borsuk-Ulam theorem and the nerve/connectivity of the independence complex.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["Kneser graph", "chromatic number", "Borsuk-Ulam theorem", "intersecting families", "topological combinatorics"],
-    "prerequisites": []
+    "prerequisites": ["graph coloring", "hypergraph basics", "set operations"]
   },
   {
     "id": "ann-e780-imports",
@@ -21,7 +21,7 @@
     "mathContext": "The formalization works within Lean 4's `Finset` framework, using finite subsets of `Fin n` to model the ground set $[n] = \\{0, 1, \\ldots, n-1\\}$. Hyperedges are represented as `{S : Finset (Fin n) // S.card = r}`, leveraging subtype for the uniformity constraint.",
     "significance": "supporting",
     "relatedConcepts": ["Finset", "SetFamily.Intersecting", "SimpleGraph", "Nat.choose"],
-    "prerequisites": []
+    "prerequisites": ["Mathlib Finset framework", "Fin type", "subtype notation"]
   },
   {
     "id": "ann-e780-hypergraph",
@@ -55,7 +55,7 @@
     "title": "Kneser Hypergraph Structure",
     "content": "**`KneserHypergraph n r k`**: A structure encoding the Kneser hypergraph $KG^r(n,k)$ with fields for vertices ($r$-subsets), edges ($k$-tuples of pairwise disjoint $r$-sets), uniformity, and inclusion constraints.\n\n**`chromaticNumber n r k`** (axiom): The chromatic number of $KG^r(n,k)$.",
     "mathContext": "The Kneser hypergraph $KG^r(n,k)$ has vertex set $\\binom{[n]}{r}$ and edge set consisting of all collections of $k$ pairwise disjoint $r$-subsets. Its chromatic number $\\chi(KG^r(n,k))$ is the minimum $t$ such that $\\binom{[n]}{r}$ can be $t$-colored with no monochromatic $k$-matching. The AFL theorem shows $\\chi(KG^r(n,k)) = \\lceil (n - r(k-1))/(k-1) \\rceil$. The `chromaticNumber` is axiomatized since defining it requires quantification over all colorings.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["Kneser hypergraph", "chromatic number", "vertex coloring", "independence number"],
     "prerequisites": ["ann-e780-pairwise"]
   },
@@ -67,7 +67,7 @@
     "title": "The Threshold Function",
     "content": "**`threshold k r t`** $= kr + (t-1)(k-1)$: the exact threshold for $n$. For $n \\geq n_0$, a monochromatic $k$-matching exists in every $t$-coloring. For $n < n_0$, a $t$-coloring avoiding it exists.",
     "mathContext": "$n_0(k, r, t) = kr + (t-1)(k-1) = k(r + t - 2) + 1 - (t-1)$. For $k = 2$: $n_0 = 2r + t - 1$, and $\\chi(KG(n,r)) = n - 2r + 2$. The threshold emerges from a pigeonhole argument combined with topological connectivity: Lovász showed the independence complex of $KG(n,r)$ is $(n - 2r)$-connected, which forces $\\chi \\geq n - 2r + 2$.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["threshold function", "pigeonhole principle", "topological connectivity"],
     "prerequisites": ["ann-e780-pairwise"]
   },
@@ -79,7 +79,7 @@
     "title": "Alon-Frankl-Lovász Main Theorem (1986)",
     "content": "**`alon_frankl_lovasz_1986`** (axiom): For $n \\geq kr + (t-1)(k-1)$ with $r \\geq 1$, $k \\geq 2$, $t \\geq 1$, any $t$-coloring of $K_n^{(r)}$ contains a monochromatic $k$-matching.\n\n**`kneser_hypergraph_chromatic_number`** (axiom): Equivalent formulation as $\\chi(KG^r(n,k)) = \\lceil (n - r(k-1))/(k-1) \\rceil$.",
     "mathContext": "The AFL proof proceeds by: (1) reducing to a topological problem about the connectivity of the independence complex $\\text{Ind}(KG^r(n,k))$, (2) applying a generalized Borsuk-Ulam theorem to show this complex is sufficiently connected, (3) deducing the chromatic lower bound from the Lusternik-Schnirelmann category. The paper appeared in *Transactions AMS* 298 (1986), 359-370. The formula uses `Nat.ceil` of an integer division since $\\chi$ must be an integer.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["Borsuk-Ulam theorem", "independence complex", "Lusternik-Schnirelmann", "topological lower bound"],
     "prerequisites": ["ann-e780-threshold", "ann-e780-kneser-structure"]
   },
@@ -103,7 +103,7 @@
     "title": "Kneser's Conjecture ($k = 2$)",
     "content": "**`kneser_conjecture`** (axiom): $\\chi(KG(n,r)) = n - 2r + 2$ for $n \\geq 2r$. Conjectured by Kneser (1955), proved by Lovász (1978).\n\n**`KneserGraph n r`**: The Kneser graph with $r$-subsets of $[n]$ as vertices.\n\n**`kneserAdj`**: Two $r$-sets are adjacent iff disjoint.",
     "mathContext": "Lovász's 1978 proof in *J. Comb. Theory A* 25, 319-324 was the first application of algebraic topology (specifically the Borsuk-Ulam theorem) to combinatorics. He showed the neighborhood complex $\\mathcal{N}(KG(n,r))$ is $(n - 2r)$-connected, giving $\\chi(KG(n,r)) \\geq n - 2r + 2$. The upper bound follows from the coloring: assign color $\\min(e)$ if $\\min(e) \\leq n - 2r + 1$, else a final color. Schrijver (1978) strengthened this to the stable Kneser graph (vertex-critical subgraph).",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["Kneser conjecture", "Lovász 1978", "neighborhood complex", "Schrijver graph"],
     "prerequisites": ["ann-e780-afl"]
   },
@@ -139,7 +139,7 @@
     "title": "Main Result Theorem",
     "content": "**`erdos_780_main`**: Restates the AFL theorem as a proved `theorem` (trivially from the axiom). For $n \\geq kr + (t-1)(k-1)$, any $t$-coloring contains a monochromatic $k$-matching.",
     "mathContext": "This is a thin wrapper: `erdos_780_main ... := alon_frankl_lovasz_1986 ...`. The distinction between `axiom` and `theorem` matters for Aristotle proof search: axioms are skipped, but this `theorem` is already proved (by invoking the axiom). The formalization pattern of axiomatizing deep results and wrapping them in proved theorems is standard for Lean formalizations of results not yet in Mathlib.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["axiom wrapper", "formal verification", "Aristotle-friendly"],
     "prerequisites": ["ann-e780-afl"]
   },
@@ -151,7 +151,7 @@
     "title": "Summary Theorem",
     "content": "**`erdos_780_summary`**: Combines the AFL main theorem with Kneser's conjecture into a single conjunction. **Proved** via `⟨alon_frankl_lovasz_1986 ..., kneser_conjecture ...⟩`. Status: SOLVED.",
     "mathContext": "The summary bundles two results: (1) the general AFL theorem for all $n, r, k, t$ above threshold, and (2) the $k=2$ special case giving $\\chi(KG(n,r)) = n - 2r + 2$. This provides a single theorem capturing the full resolution of Erdős Problem #780. Both components are derived from axioms, so 0 sorries remain.",
-    "significance": "critical",
+    "significance": "key",
     "relatedConcepts": ["summary theorem", "problem resolution", "0 sorries"],
     "prerequisites": ["ann-e780-main", "ann-e780-kneser"]
   }

--- a/src/data/proofs/erdos-780/meta.json
+++ b/src/data/proofs/erdos-780/meta.json
@@ -78,6 +78,13 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Problem Statement and Imports",
+      "summary": "Module docstring presenting Erdős Problem #780 and the AFL theorem. Imports `SetFamily.Intersecting`, `SimpleGraph.Basic`, `Finset.Basic`, `Nat.Choose.Basic`, and `Tactic`. Opens the `Finset` namespace.",
+      "startLine": 1,
+      "endLine": 35
+    },
+    {
       "id": "definitions",
       "title": "Hypergraph Definitions",
       "summary": "Defines `UniformHypergraph`, `completeHypergraph`, `disjointEdges` via `Disjoint`, `PairwiseDisjoint` for $k$-matchings, `EdgeColoring` as $c : K_n^{(r)} \\to \\text{Fin}\\, t$, and `colorClass` $C_i = c^{-1}(i)$.",


### PR DESCRIPTION
## Enrichment pass for erdos-780 (Chromatic Number of Kneser Hypergraphs)

### Changes
- **sections**: Added missing preamble section (lines 1-35)
- **significance**: Fixed 7 non-standard "critical" values to "key" per schema
- **prerequisites**: Filled 2 empty prerequisite arrays

### Axiom integrity check
- `axiomCount: 10` matches Lean file
- `status: "axiomatized"` and `badge: "axiom"` correct
- `sorries: 0` confirmed (2 proved theorems: `erdos_780_main`, `erdos_780_summary`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)