### PR TITLE
Research: szemeredi-counting + cauchy-schwarz-oq-04-oq-01

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ04OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzOQ04OQ01.lean
@@ -26,11 +26,53 @@ open Finset BigOperators
     Discriminant ≤ 0 gives the result. -/
 theorem cauchy_schwarz_sum {n : ℕ} (a b : Fin n → ℝ) :
     (∑ i, a i * b i) ^ 2 ≤ (∑ i, a i ^ 2) * (∑ i, b i ^ 2) := by
-  -- Standard result. The proof uses the nonneg quadratic:
-  -- 0 ≤ Σ(t·aᵢ + bᵢ)² = t²·Σaᵢ² + 2t·Σaᵢbᵢ + Σbᵢ² for all t.
-  -- Discriminant ≤ 0 gives (Σaᵢbᵢ)² ≤ (Σaᵢ²)(Σbᵢ²).
-  -- Also follows from Mathlib: inner_mul_le_norm_mul_norm on EuclideanSpace.
-  sorry
+  -- Use Mathlib: Finset.inner_mul_le_norm_mul_sq or the discriminant approach.
+  -- The key is that 0 ≤ Σ(t·aᵢ + bᵢ)² for all t ∈ ℝ.
+  have hQ : ∀ t : ℝ, 0 ≤ ∑ i : Fin n, (t * a i + b i) ^ 2 :=
+    fun t => Finset.sum_nonneg (fun _ _ => sq_nonneg _)
+  -- Expand: Q(t) = (Σaᵢ²)t² + 2(Σaᵢbᵢ)t + Σbᵢ²
+  have hexpand : ∀ t : ℝ, ∑ i : Fin n, (t * a i + b i) ^ 2 =
+      (∑ i, a i ^ 2) * t ^ 2 + 2 * (∑ i, a i * b i) * t + ∑ i, b i ^ 2 := by
+    intro t
+    have : ∀ i : Fin n, (t * a i + b i) ^ 2 =
+        a i ^ 2 * t ^ 2 + 2 * (a i * b i) * t + b i ^ 2 := by intro i; ring
+    simp_rw [this, Finset.sum_add_distrib, ← Finset.sum_mul, ← Finset.mul_sum]
+  -- Nonneg quadratic ⟹ discriminant ≤ 0
+  by_cases hA : ∑ i, a i ^ 2 = 0
+  · -- If Σaᵢ² = 0 then each aᵢ = 0, so Σaᵢbᵢ = 0
+    have ha_zero : ∀ i, a i = 0 := by
+      intro i
+      have h1 : a i ^ 2 ≤ ∑ j, a j ^ 2 :=
+        Finset.single_le_sum (fun j _ => sq_nonneg (a j)) (Finset.mem_univ i)
+      have h2 : (∑ j, a j ^ 2) = 0 := hA
+      have h3 : a i ^ 2 = 0 := le_antisymm (h2 ▸ h1) (sq_nonneg _)
+      exact pow_eq_zero_iff (by norm_num : 2 ≠ 0) |>.mp h3
+    simp [ha_zero]
+  · -- Σaᵢ² > 0: take t = -(Σaᵢbᵢ) / (Σaᵢ²)
+    have hA_pos : 0 < ∑ i, a i ^ 2 := by
+      rcases lt_or_eq_of_le (Finset.sum_nonneg (fun i _ => sq_nonneg (a i))) with h | h
+      · exact h
+      · exact absurd h.symm hA
+    specialize hQ (-(∑ i, a i * b i) / (∑ i, a i ^ 2))
+    rw [hexpand] at hQ
+    -- After substitution: Q(-S/A) = A·(S/A)² - 2S·(S/A) + B = B - S²/A ≥ 0
+    -- So S² ≤ A·B
+    have h_key : (∑ i, a i ^ 2) * (-(∑ i, a i * b i) / (∑ i, a i ^ 2)) ^ 2 +
+        2 * (∑ i, a i * b i) * (-(∑ i, a i * b i) / (∑ i, a i ^ 2)) +
+        (∑ i, b i ^ 2) =
+        (∑ i, b i ^ 2) - (∑ i, a i * b i) ^ 2 / (∑ i, a i ^ 2) := by
+      field_simp; ring
+    rw [h_key] at hQ
+    -- 0 ≤ B - S²/A, so S² ≤ A·B
+    rw [sub_nonneg] at hQ
+    -- hQ : (Σ aᵢ bᵢ)² / (Σ aᵢ²) ≤ Σ bᵢ²
+    -- Want: (Σ aᵢ bᵢ)² ≤ (Σ aᵢ²) * (Σ bᵢ²)
+    calc (∑ i, a i * b i) ^ 2
+        = (∑ i, a i * b i) ^ 2 / (∑ i, a i ^ 2) * (∑ i, a i ^ 2) := by
+          field_simp
+      _ ≤ (∑ i, b i ^ 2) * (∑ i, a i ^ 2) := by
+          exact mul_le_mul_of_nonneg_right hQ (le_of_lt hA_pos)
+      _ = (∑ i, a i ^ 2) * (∑ i, b i ^ 2) := by ring
 
 -- ============================================================================
 -- Part II: Weighted Cauchy-Schwarz

--- a/proofs/Proofs/SzemerediCounting.lean
+++ b/proofs/Proofs/SzemerediCounting.lean
@@ -105,9 +105,10 @@ theorem bad_vertices_small (G : SimpleGraph V) [DecidableRel G.Adj]
     have := (abs_le.mp hreg').1; linarith
   -- Upper bound: every a ∈ A' has |N_B(a)| < (d-ε)|B|, so d(A',B) < d - ε
   have hdU : Szemeredi.Regularity.edgeDensity G A' B < d - eps := by
-    -- Each a ∈ A' has |N_B(a)| < (d-ε)|B| by definition of badVertices
-    -- This gives an upper bound on the edge density d(A', B)
-    -- that contradicts the lower bound from regularity.
+    -- Each a ∈ A' = badVertices has |N_B(a)| < (d-ε)|B|.
+    -- Edge density = |edges| / (|A'|*|B|).
+    -- Since every vertex contributes < (d-ε)|B| edges,
+    -- total edges < |A'|*(d-ε)*|B|, so density < d - ε.
     sorry
   linarith
 

--- a/proofs/Proofs/SzemerediCounting.lean
+++ b/proofs/Proofs/SzemerediCounting.lean
@@ -71,7 +71,11 @@ theorem good_union_bad (G : SimpleGraph V) [DecidableRel G.Adj]
 
 /-- If (A,B) is ε-regular and d(A,B) ≥ ε, then the set of bad vertices
     (those with |N_B(a)| < (d-ε)|B|) has fewer than ε|A| elements.
-    This is the key lemma connecting vertex neighborhoods to regularity. -/
+    This is the key lemma connecting vertex neighborhoods to regularity.
+
+    Proof by contraposition: if |bad| ≥ ε|A|, set A' = badVertices.
+    By ε-regularity with B' = B: d(A',B) ≥ d - ε. But every vertex
+    in A' has < (d-ε)|B| neighbors in B, so d(A',B) < d - ε. Contradiction. -/
 theorem bad_vertices_small (G : SimpleGraph V) [DecidableRel G.Adj]
     (eps : ℚ) (heps : 0 < eps)
     (A B : Finset V)
@@ -80,7 +84,32 @@ theorem bad_vertices_small (G : SimpleGraph V) [DecidableRel G.Adj]
     (hA : (0 : ℚ) < A.card) (hB : (0 : ℚ) < B.card) :
     ((badVertices G A B (Szemeredi.Regularity.edgeDensity G A B - eps)).card : ℚ)
       < eps * A.card := by
-  sorry
+  by_contra hbig
+  push_neg at hbig
+  set d := Szemeredi.Regularity.edgeDensity G A B with hd_def
+  set A' := badVertices G A B (d - eps)
+  -- Key facts about A'
+  have hA'sub : A' ⊆ A := badVertices_subset G A B (d - eps)
+  have hA'pos : (0 : ℚ) < A'.card := lt_of_lt_of_le (by positivity : (0 : ℚ) < eps * A.card) hbig
+  -- eps ≤ 1 from d ≤ 1 and d ≥ eps
+  have heps1 : eps ≤ 1 :=
+    le_trans hdensity (Szemeredi.Regularity.edgeDensity_le_one G A B)
+  -- |B| ≥ ε|B| since ε ≤ 1
+  have hBeps : (B.card : ℚ) ≥ eps * B.card := by
+    have hB_nn : (0 : ℚ) ≤ (B.card : ℚ) := Nat.cast_nonneg _
+    nlinarith
+  -- Apply ε-regularity to (A', B)
+  have hreg' := hreg A' B hA'sub (Finset.Subset.refl B) hbig hBeps
+  -- |d(A',B) - d| ≤ ε, so d(A',B) ≥ d - ε
+  have hdL : Szemeredi.Regularity.edgeDensity G A' B ≥ d - eps := by
+    have := (abs_le.mp hreg').1; linarith
+  -- Upper bound: every a ∈ A' has |N_B(a)| < (d-ε)|B|, so d(A',B) < d - ε
+  have hdU : Szemeredi.Regularity.edgeDensity G A' B < d - eps := by
+    -- Each a ∈ A' has |N_B(a)| < (d-ε)|B| by definition of badVertices
+    -- This gives an upper bound on the edge density d(A', B)
+    -- that contradicts the lower bound from regularity.
+    sorry
+  linarith
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART I: COUNTING LEMMA FOR REGULAR TRIPLES


### PR DESCRIPTION
## Summary
### cauchy-schwarz-oq-04-oq-01: Prove cauchy_schwarz_sum (0 sorries)
- Proved Cauchy-Schwarz for finite sums via quadratic discriminant argument
- File now 0 sorries, 0 axioms (was 1 sorry)

### szemeredi-counting: Structure bad_vertices_small proof
- Structured proof via contraposition with regularity application proved
- Remaining sorry: density upper bound (needs Finset fiber decomposition)

## Files Modified
- `proofs/Proofs/CauchySchwarzOQ04OQ01.lean` (0 sorries now!)
- `proofs/Proofs/SzemerediCounting.lean`
- `src/data/research/problems/szemeredi-counting.json`
- `research/problems/szemeredi-counting/knowledge.md`

## Test plan
- [x] Docker build passes: CauchySchwarzOQ04OQ01
- [x] Docker build passes: SzemerediCounting

🤖 Generated by researcher-4