### PR TITLE
Enrich 14 entries: add mathContext and crossReferences (quality 98→100)

### DIFF
--- a/src/data/proofs/kummer-theorem/meta.json
+++ b/src/data/proofs/kummer-theorem/meta.json
@@ -61,42 +61,48 @@
       "title": "Introduction and Context",
       "startLine": 5,
       "endLine": 58,
-      "summary": "Historical background, statement of Kummer's theorem, and its relationship to Lucas' theorem."
+      "summary": "Historical background, statement of Kummer's theorem, and its relationship to Lucas' theorem.",
+      "mathContext": "Kummer (1852): $\\nu_p\\binom{n}{k}$ = number of carries when adding $k$ and $n-k$ in base $p$. Equivalently: $(p-1)\\nu_p\\binom{n}{k} = S_p(k) + S_p(n-k) - S_p(n)$ where $S_p$ is the digit sum."
     },
     {
       "id": "main-theorem",
       "title": "The Main Theorem",
       "startLine": 64,
       "endLine": 90,
-      "summary": "Kummer's theorem: multiplicity equals the count of carry positions when adding k and n-k in base p."
+      "summary": "Kummer's theorem: multiplicity equals the count of carry positions when adding k and n-k in base p.",
+      "mathContext": "`Nat.Prime.multiplicity_choose`: for prime $p$ and $k \\leq n$, $\\nu_p\\binom{n}{k}$ equals the number of positions where adding $k$ and $n-k$ in base $p$ produces a carry."
     },
     {
       "id": "examples",
       "title": "Concrete Examples",
       "startLine": 92,
       "endLine": 129,
-      "summary": "Verification with specific binomial coefficients: C(10,4), C(6,3), C(4,2), C(5,2), C(8,2)."
+      "summary": "Verification with specific binomial coefficients: C(10,4), C(6,3), C(4,2), C(5,2), C(8,2).",
+      "mathContext": "Example: $\\binom{10}{4} = 210 = 2 \\cdot 3 \\cdot 5 \\cdot 7$. Adding $4 + 6$ in base 2: $100 + 110 = 1010$ with 1 carry, so $\\nu_2(210) = 1$."
     },
     {
       "id": "prime-power",
       "title": "Prime Power Case",
       "startLine": 131,
       "endLine": 138,
-      "summary": "Special case: p divides C(p^n, k) for 0 < k < p^n."
+      "summary": "Special case: p divides C(p^n, k) for 0 < k < p^n.",
+      "mathContext": "$p \\mid \\binom{p^n}{k}$ for $0 < k < p^n$: adding $k + (p^n - k)$ in base $p$ always produces a carry from the lowest nonzero digit of $k$."
     },
     {
       "id": "lucas-connection",
       "title": "Connection to Lucas' Theorem",
       "startLine": 140,
       "endLine": 154,
-      "summary": "How Kummer's theorem relates to Lucas' theorem on binomial coefficients mod p."
+      "summary": "How Kummer's theorem relates to Lucas' theorem on binomial coefficients mod p.",
+      "mathContext": "Lucas: $\\binom{n}{k} \\equiv \\prod_i \\binom{n_i}{k_i} \\pmod{p}$ where $n = \\sum n_i p^i$, $k = \\sum k_i p^i$. Kummer explains this: $p \\mid \\binom{n}{k} \\iff$ at least one carry $\\iff$ some $k_i > n_i$."
     },
     {
       "id": "digit-sum",
       "title": "Digit Sum Formulation",
       "startLine": 156,
       "endLine": 170,
-      "summary": "The equivalent formula using digit sums: (p-1)·ν_p(C(n,k)) = S_p(k) + S_p(n-k) - S_p(n)."
+      "summary": "The equivalent formula using digit sums: (p-1)·ν_p(C(n,k)) = S_p(k) + S_p(n-k) - S_p(n).",
+      "mathContext": "Legendre-Kummer: $(p-1)\\nu_p\\binom{n}{k} = S_p(k) + S_p(n-k) - S_p(n)$. Each carry reduces the digit sum by $p-1$, so carries $= (S_p(k) + S_p(n-k) - S_p(n))/(p-1)$."
     }
   ],
   "conclusion": {
@@ -107,5 +113,21 @@
       "How does the theorem generalize to q-binomial coefficients?",
       "What patterns emerge in Pascal's triangle mod p^k for k > 1?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-776",
+      "relationship": "applied-in",
+      "description": "Kummer's theorem determines which layers have enough sets for multiplicity r, since layer availability depends on binomial coefficient divisibility"
+    },
+    {
+      "targetId": "binomial-theorem-oq-01",
+      "relationship": "related",
+      "description": "Both study properties of binomial coefficients — Kummer's theorem addresses divisibility while the binomial theorem addresses evaluation"
+    }
+  ],
+  "relatedProofs": [
+    "erdos-776",
+    "binomial-theorem-oq-01"
+  ]
 }

--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -52,35 +52,40 @@
       "title": "Euler's Four-Square Identity",
       "startLine": 44,
       "endLine": 69,
-      "summary": "The key algebraic identity showing the product of two sums-of-four-squares is itself a sum of four squares. This is quaternion norm multiplicativity."
+      "summary": "The key algebraic identity showing the product of two sums-of-four-squares is itself a sum of four squares. This is quaternion norm multiplicativity.",
+      "mathContext": "$(a^2+b^2+c^2+d^2)(x^2+y^2+z^2+w^2) = A^2+B^2+C^2+D^2$ where $A,B,C,D$ are bilinear in $(a,b,c,d)$ and $(x,y,z,w)$. This is $|q_1 \\cdot q_2|^2 = |q_1|^2 |q_2|^2$ for quaternions."
     },
     {
       "id": "three-vs-four",
       "title": "Why Four Squares and Not Three?",
       "startLine": 71,
       "endLine": 78,
-      "summary": "Numbers of the form 4^k(8m+7) cannot be sums of three squares, but four always suffice."
+      "summary": "Numbers of the form 4^k(8m+7) cannot be sums of three squares, but four always suffice.",
+      "mathContext": "$n \\equiv 7 \\pmod{8}$ (e.g., $7, 15, 23$) cannot be written as $a^2 + b^2 + c^2$. Legendre's three-square theorem: $n = a^2+b^2+c^2 \\iff n \\neq 4^k(8m+7)$."
     },
     {
       "id": "main-theorem",
       "title": "The Main Theorem",
       "startLine": 80,
       "endLine": 102,
-      "summary": "Lagrange's theorem: every natural number is a sum of four squares. Uses Mathlib's Nat.sum_four_squares."
+      "summary": "Lagrange's theorem: every natural number is a sum of four squares. Uses Mathlib's Nat.sum_four_squares.",
+      "mathContext": "`Nat.sum_four_squares`: $\\forall n \\in \\mathbb{N},\\, \\exists a,b,c,d \\in \\mathbb{N}: n = a^2 + b^2 + c^2 + d^2$. Waring's problem for $k=2$, $g(2) = 4$."
     },
     {
       "id": "examples",
       "title": "Specific Examples",
       "startLine": 104,
       "endLine": 127,
-      "summary": "Concrete decompositions of small numbers, including the notorious 7 which needs all four squares."
+      "summary": "Concrete decompositions of small numbers, including the notorious 7 which needs all four squares.",
+      "mathContext": "$7 = 1^2 + 1^2 + 1^2 + 2^2$ (needs 4 squares). $6 = 1^2 + 1^2 + 2^2 + 0^2$ (3 suffice). $15 = 1^2 + 1^2 + 2^2 + 3^2$ (needs 4)."
     },
     {
       "id": "two-squares-connection",
       "title": "Connection to Two Squares Theorem",
       "startLine": 129,
       "endLine": 138,
-      "summary": "Cross-reference to Fermat's Two Squares Theorem showing the contrast between universal four squares and restrictive two squares."
+      "summary": "Cross-reference to Fermat's Two Squares Theorem showing the contrast between universal four squares and restrictive two squares.",
+      "mathContext": "Fermat: $n = a^2 + b^2 \\iff$ every prime $p \\equiv 3 \\pmod{4}$ divides $n$ to even power. Two squares is far more restrictive than four."
     }
   ],
   "conclusion": {
@@ -91,5 +96,15 @@
       "How do representations distribute among the possible orderings?",
       "What are the connections to the theory of modular forms and theta functions?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "contrasts",
+      "description": "Two squares vs four: Fermat's theorem restricts which numbers are sums of two squares, while Lagrange's theorem says all are sums of four"
+    }
+  ],
+  "relatedProofs": [
+    "fermat-two-squares"
+  ]
 }

--- a/src/data/proofs/primitive-roots/meta.json
+++ b/src/data/proofs/primitive-roots/meta.json
@@ -66,42 +66,48 @@
       "title": "Definitions and Setup",
       "startLine": 55,
       "endLine": 72,
-      "summary": "Define IsPrimitiveRoot as having order equal to |G|, and prove it's equivalent to having order p-1."
+      "summary": "Define IsPrimitiveRoot as having order equal to |G|, and prove it's equivalent to having order p-1.",
+      "mathContext": "`IsPrimitiveRoot g` $\\iff \\text{orderOf}(g) = |G|$. For $(\\mathbb{Z}/p\\mathbb{Z})^*$: $\\text{orderOf}(g) = p-1$."
     },
     {
       "id": "cyclic",
       "title": "The Multiplicative Group is Cyclic",
       "startLine": 73,
       "endLine": 87,
-      "summary": "Prove (ℤ/pℤ)* is cyclic using the integral domain theorem, and that its order is p-1."
+      "summary": "Prove (ℤ/pℤ)* is cyclic using the integral domain theorem, and that its order is p-1.",
+      "mathContext": "$(\\mathbb{Z}/p\\mathbb{Z})^*$ is cyclic of order $p-1$. Uses `isCyclic_of_subgroup_isDomain`: finite subgroups of $k^*$ for integral domain $k$ are cyclic."
     },
     {
       "id": "existence",
       "title": "Existence of Primitive Roots",
       "startLine": 88,
       "endLine": 98,
-      "summary": "Since cyclic groups have generators, primitive roots exist."
+      "summary": "Since cyclic groups have generators, primitive roots exist.",
+      "mathContext": "Cyclic $\\implies$ $\\exists g$ with $\\text{orderOf}(g) = p-1$. This $g$ is a primitive root: $\\{g^0, g^1, \\ldots, g^{p-2}\\} = (\\mathbb{Z}/p\\mathbb{Z})^*$."
     },
     {
       "id": "counting",
       "title": "Counting Primitive Roots",
       "startLine": 99,
       "endLine": 131,
-      "summary": "The main theorem: there are exactly φ(p-1) primitive roots, using the cyclic group counting theorem."
+      "summary": "The main theorem: there are exactly φ(p-1) primitive roots, using the cyclic group counting theorem.",
+      "mathContext": "In a cyclic group of order $n$: $|\\{g : \\text{orderOf}(g) = d\\}| = \\varphi(d)$ for $d \\mid n$. Apply with $n = p-1$, $d = p-1$: $\\varphi(p-1)$ primitive roots."
     },
     {
       "id": "examples",
       "title": "Examples",
       "startLine": 132,
       "endLine": 155,
-      "summary": "Concrete examples: φ(1)=1, φ(2)=1, φ(4)=2, φ(6)=2, φ(10)=4, φ(12)=4."
+      "summary": "Concrete examples: φ(1)=1, φ(2)=1, φ(4)=2, φ(6)=2, φ(10)=4, φ(12)=4.",
+      "mathContext": "Examples: $\\varphi(6) = 2$ so $p = 7$ has 2 primitive roots ($3$ and $5$). $\\varphi(10) = 4$ so $p = 11$ has 4 primitive roots."
     },
     {
       "id": "generators",
       "title": "Connection to Group Theory",
       "startLine": 156,
       "endLine": 178,
-      "summary": "Prove that primitive roots are exactly the generators of (ℤ/pℤ)*."
+      "summary": "Prove that primitive roots are exactly the generators of (ℤ/pℤ)*.",
+      "mathContext": "Primitive root $g \\iff g$ generates $(\\mathbb{Z}/p\\mathbb{Z})^* \\iff \\text{orderOf}(g) = p-1 \\iff g^k \\neq 1$ for $0 < k < p-1$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/ramseys-theorem/meta.json
+++ b/src/data/proofs/ramseys-theorem/meta.json
@@ -64,42 +64,48 @@
       "title": "Edge Colorings and Cliques",
       "startLine": 52,
       "endLine": 94,
-      "summary": "Definitions of edge 2-colorings, red/blue graphs, and the Ramsey property."
+      "summary": "Definitions of edge 2-colorings, red/blue graphs, and the Ramsey property.",
+      "mathContext": "A 2-coloring $c: E(K_n) \\to \\{\\text{red}, \\text{blue}\\}$ partitions edges. `HasRamseyProperty n r s`: every 2-coloring of $K_n$ has a red $K_r$ or blue $K_s$."
     },
     {
       "id": "base-cases",
       "title": "Base Cases",
       "startLine": 95,
       "endLine": 157,
-      "summary": "Proofs that R(1,s) = R(r,1) = 1 (singleton cliques) and R(2,s) = s."
+      "summary": "Proofs that R(1,s) = R(r,1) = 1 (singleton cliques) and R(2,s) = s.",
+      "mathContext": "$R(1,s) = 1$ (any single vertex is a $K_1$). $R(2,s) = s$ (in $K_s$, either all edges are blue giving blue $K_s$, or some edge is red giving red $K_2$)."
     },
     {
       "id": "neighborhood-partition",
       "title": "Neighborhood Partitions",
       "startLine": 158,
       "endLine": 207,
-      "summary": "Red and blue neighborhood definitions, disjointness, partition theorem, and cardinality sum."
+      "summary": "Red and blue neighborhood definitions, disjointness, partition theorem, and cardinality sum.",
+      "mathContext": "For vertex $v$ in a 2-colored $K_n$: $N_{\\text{red}}(v) \\cup N_{\\text{blue}}(v) = V \\setminus \\{v\\}$ and $|N_{\\text{red}}| + |N_{\\text{blue}}| = n - 1$. Pigeonhole forces one to be large."
     },
     {
       "id": "clique-extension",
       "title": "Clique Extension",
       "startLine": 208,
       "endLine": 246,
-      "summary": "Lemmas showing that adding v to a clique in its monochromatic neighborhood yields a larger clique."
+      "summary": "Lemmas showing that adding v to a clique in its monochromatic neighborhood yields a larger clique.",
+      "mathContext": "If $S \\subseteq N_{\\text{red}}(v)$ is a red $K_r$, then $S \\cup \\{v\\}$ is a red $K_{r+1}$: $v$ is red-connected to all of $S$."
     },
     {
       "id": "ramsey-bounds",
       "title": "Ramsey Bounds",
       "startLine": 247,
       "endLine": 265,
-      "summary": "The classical bound R(r,s) ≤ C(r+s-2, r-1) and concrete computations for small cases."
+      "summary": "The classical bound R(r,s) ≤ C(r+s-2, r-1) and concrete computations for small cases.",
+      "mathContext": "$R(r,s) \\leq \\binom{r+s-2}{r-1}$. Concrete: $R(3,3) \\leq \\binom{4}{2} = 6$ (tight!). $R(4,4) \\leq \\binom{6}{3} = 20$ (actual: 18)."
     },
     {
       "id": "main-theorem",
       "title": "Ramsey's Theorem",
       "startLine": 283,
       "endLine": 447,
-      "summary": "The main existence theorem using strong induction with the recurrence R(r,s) ≤ R(r-1,s) + R(r,s-1)."
+      "summary": "The main existence theorem using strong induction with the recurrence R(r,s) ≤ R(r-1,s) + R(r,s-1).",
+      "mathContext": "Recurrence: $R(r,s) \\leq R(r-1,s) + R(r,s-1)$. Proof: pick $v$, partition into red/blue neighborhoods. By pigeonhole, $|N_{\\text{red}}| \\geq R(r-1,s)$ or $|N_{\\text{blue}}| \\geq R(r,s-1)$. Apply IH and extend."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Enriched 14 gallery entries:

### mathContext added to all sections
- **inclusion-exclusion**: 5 sections
- **kummer-theorem**: 6 sections + crossReferences
- **lagrange-four-squares**: 5 sections + crossReference
- **primitive-roots**: 6 sections
- **ramseys-theorem**: 6 sections
- **russell-1-plus-1**: 8 sections
- **schauder-fixed-point-oq-01**: 7 sections
- **szemeredi-theorem**: 5 sections
- **twin-primes-special**: 5 sections
- **erdos-340**: 4 sections
- **erdos-422**: 4 sections

### crossReferences added
- **leibniz-pi**: crossRefs to basel-problem, area-of-circle
- **lhopital**: crossRef to mean-value-theorem
- **kummer-theorem**: crossRefs to erdos-776, binomial-theorem-oq-01
- **lagrange-four-squares**: crossRef to fermat-two-squares

Quality: 98 → 100 for all entries

## Test plan
- [x] JSON validated for all entries