### PR TITLE
Enrich 11 entries: sections, line ranges, prerequisites, mathContext (quality 98→100)

### DIFF
--- a/src/data/proofs/erdos-776/meta.json
+++ b/src/data/proofs/erdos-776/meta.json
@@ -62,32 +62,44 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 27,
+      "summary": "Module docstring presenting Erdős Problem #776 on antichains with set-size multiplicity constraints. States the key results for $r = 1$ and $r > 1$, references Erdős–Trotter and Griggs. Imports `Finset.Basic`, `Finset.Powerset`, `Order.Antichain`, and `Tactic`. Opens the `Finset` namespace.",
+      "mathContext": "Problem: for $r \\geq 2$, determine threshold $N(r)$ such that $\\forall n \\geq N(r)$, the max distinct sizes in a multiplicity-$r$ antichain in $2^{[n]}$ is $n - 3$. Key contrast: $r = 1 \\Rightarrow n - 2$, $r > 1 \\Rightarrow n - 3$."
+    },
+    {
       "id": "definitions",
       "title": "Core Definitions",
-      "startLine": 22,
+      "startLine": 28,
       "endLine": 53,
-      "summary": "Defines `SubsetFamily n` as `Finset (Finset (Fin n))`, `IsAntichain` via pairwise non-containment, `distinctSizes` via `Finset.image Finset.card`, `HasMultiplicity F r` requiring each size to appear $\\geq r$ times, and `maxDistinctSizes n r` as the supremum over all valid families."
+      "summary": "Defines `SubsetFamily n` as `Finset (Finset (Fin n))`, `IsAntichain` via pairwise non-containment, `distinctSizes` via `Finset.image Finset.card`, `HasMultiplicity F r` requiring each size to appear $\\geq r$ times, and `maxDistinctSizes n r` as the supremum over all valid families.",
+      "mathContext": "$\\mathcal{F} \\subseteq 2^{[n]}$, antichain $\\iff \\forall A \\neq B \\in \\mathcal{F}: A \\not\\subseteq B$, $d(\\mathcal{F}) = |\\{|A| : A \\in \\mathcal{F}\\}|$, multiplicity $\\geq r$ $\\iff$ each size appears $\\geq r$ times. $\\text{maxDistinctSizes}(n,r) = \\max_\\mathcal{F} d(\\mathcal{F})$."
     },
     {
       "id": "results",
       "title": "Erdős-Trotter Results",
       "startLine": 55,
       "endLine": 81,
-      "summary": "Axiomatizes `erdos_trotter_r1` ($r = 1$: max is $n - 2$ for $n > 3$), `erdos_trotter_upper` ($r > 1$: max $\\leq n - 3$ for large $n$), and `erdos_trotter_achievable` ($r > 1$: max $\\geq n - 3$ for large $n$). Proves `erdos_trotter_exact` combining the bounds via `omega`."
+      "summary": "Axiomatizes `erdos_trotter_r1` ($r = 1$: max is $n - 2$ for $n > 3$), `erdos_trotter_upper` ($r > 1$: max $\\leq n - 3$ for large $n$), and `erdos_trotter_achievable` ($r > 1$: max $\\geq n - 3$ for large $n$). Proves `erdos_trotter_exact` combining the bounds via `omega`.",
+      "mathContext": "$r = 1: \\text{max} = n - 2$. $r > 1: \\exists N_1,\\, n \\geq N_1 \\Rightarrow \\text{max} \\leq n-3$ and $\\exists N_2,\\, n \\geq N_2 \\Rightarrow \\text{max} \\geq n-3$. **Proved**: $n \\geq \\max(N_1, N_2) \\Rightarrow \\text{max} = n - 3$ via `omega`."
     },
     {
       "id": "conjecture",
       "title": "Threshold Conjecture",
       "startLine": 83,
       "endLine": 93,
-      "summary": "Axiomatizes `erdos_776_threshold`: for each $r \\geq 2$, there exists a smallest $N(r)$ such that `maxDistinctSizes n r = n - 3` for all $n \\geq N(r)$. The minimality clause ensures $N$ is optimal."
+      "summary": "Axiomatizes `erdos_776_threshold`: for each $r \\geq 2$, there exists a smallest $N(r)$ such that `maxDistinctSizes n r = n - 3` for all $n \\geq N(r)$. The minimality clause ensures $N$ is optimal.",
+      "mathContext": "$\\forall r \\geq 2,\\, \\exists N(r) \\text{ minimal}: n \\geq N(r) \\Rightarrow \\text{maxDistinctSizes}(n,r) = n - 3$ and $\\forall M < N(r),\\, \\exists n \\geq M: \\text{maxDistinctSizes}(n,r) \\neq n - 3$."
     },
     {
       "id": "structural",
       "title": "Structural Observations",
       "startLine": 94,
       "endLine": 119,
-      "summary": "Axiomatizes Sperner's theorem ($|\\mathcal{F}| \\leq \\binom{n}{\\lfloor n/2 \\rfloor}$), the middle layer antichain (one size, maximum cardinality), the size-variety tradeoff ($|\\mathcal{F}| \\geq r \\cdot d$), and the size availability condition ($\\binom{n}{k} \\geq r$ needed for layer $k$)."
+      "summary": "Axiomatizes Sperner's theorem ($|\\mathcal{F}| \\leq \\binom{n}{\\lfloor n/2 \\rfloor}$), the middle layer antichain (one size, maximum cardinality), the size-variety tradeoff ($|\\mathcal{F}| \\geq r \\cdot d$), and the size availability condition ($\\binom{n}{k} \\geq r$ needed for layer $k$).",
+      "mathContext": "Sperner: $|\\mathcal{F}| \\leq \\binom{n}{\\lfloor n/2\\rfloor}$. Middle layer: $d = 1$, $|\\mathcal{F}| = \\binom{n}{\\lfloor n/2\\rfloor}$. Tradeoff: $|\\mathcal{F}| \\geq r \\cdot d$. Availability: layer $k$ usable iff $\\binom{n}{k} \\geq r$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/kummer-theorem/annotations.json
+++ b/src/data/proofs/kummer-theorem/annotations.json
@@ -11,7 +11,8 @@
     "content": "The proof uses:\n\n- **Nat.Multiplicity**: Contains `Nat.Prime.multiplicity_choose`, the core theorem\n- **Choose.Lucas**: Lucas' theorem for binomial coefficients mod p\n- **Tactic**: Standard proof tactics",
     "mathContext": "These imports bring in the full machinery for working with p-adic valuations and binomial coefficients.",
     "significance": "supporting",
-    "relatedConcepts": ["Mathlib", "multiplicity", "Lucas theorem"]
+    "relatedConcepts": ["Mathlib", "multiplicity", "Lucas theorem"],
+    "prerequisites": ["Lean 4 import system", "Mathlib library structure"]
   },
   {
     "id": "ann-historical",
@@ -25,7 +26,8 @@
     "content": "Ernst Kummer discovered this theorem while investigating cyclotomic fields and reciprocity laws. He was trying to prove Fermat's Last Theorem for certain primes.\n\nThe theorem reveals a beautiful connection: prime divisibility of binomial coefficients is determined by carries in base-p arithmetic!",
     "mathContext": "Kummer (1852): \"Über die Ergänzungssätze zu den allgemeinen Reciprocitätsgesetzen\"",
     "significance": "key",
-    "relatedConcepts": ["Kummer", "cyclotomic fields", "Fermat's Last Theorem"]
+    "relatedConcepts": ["Kummer", "cyclotomic fields", "Fermat's Last Theorem"],
+    "prerequisites": ["prime numbers", "binomial coefficients", "19th century number theory"]
   },
   {
     "id": "ann-carry-condition",
@@ -39,7 +41,8 @@
     "content": "When adding k and (n-k) in base p, a **carry** at position i occurs when:\n\n$$k \\mod p^i + (n-k) \\mod p^i \\geq p^i$$\n\nThis means the \"low-order bits\" (digits below position i) overflow into position i.\n\n**Example**: Adding 3 + 3 = 6 in base 2:\n- 3 = 011₂, 3 = 011₂\n- Position 1: 1 + 1 = 2 ≥ 2 → carry!\n- Position 2: 3 + 3 = 6 ≥ 4 → carry!\n- Result: 110₂ = 6, with 2 carries",
     "mathContext": "Carry at position $i$: $k \\mod p^i + (n-k) \\mod p^i \\geq p^i$",
     "significance": "critical",
-    "relatedConcepts": ["positional arithmetic", "base-p representation", "carries"]
+    "relatedConcepts": ["positional arithmetic", "base-p representation", "carries"],
+    "prerequisites": ["base-p numeral systems", "modular arithmetic", "binary addition"]
   },
   {
     "id": "ann-main-theorem",
@@ -53,7 +56,8 @@
     "content": "**The Main Result**: The multiplicity (p-adic valuation) of prime p in C(n,k) equals the number of carry positions when adding k and (n-k) in base p.\n\n$$\\nu_p\\binom{n}{k} = |\\{i : p^i \\leq k \\mod p^i + (n-k) \\mod p^i\\}|$$\n\nThis is `Nat.Prime.multiplicity_choose` from Mathlib—the theorem is already proven there!",
     "mathContext": "multiplicity $p$ $\\binom{n}{k}$ = (filtered count of carry positions)",
     "significance": "critical",
-    "relatedConcepts": ["multiplicity", "p-adic valuation", "binomial coefficient"]
+    "relatedConcepts": ["multiplicity", "p-adic valuation", "binomial coefficient"],
+    "prerequisites": ["p-adic valuation", "Nat.Prime", "Finset.filter", "carry definition"]
   },
   {
     "id": "ann-alternative",
@@ -67,7 +71,8 @@
     "content": "An equivalent statement for C(n+k, k): the multiplicity equals carries when adding k and n in base p.\n\nThis form is sometimes more convenient because both numbers being added are non-negative and their sum is exactly n+k.",
     "mathContext": "$\\nu_p\\binom{n+k}{k} = $ carries when adding $k + n$ in base $p$",
     "significance": "supporting",
-    "relatedConcepts": ["alternative formulation", "symmetry"]
+    "relatedConcepts": ["alternative formulation", "symmetry"],
+    "prerequisites": ["kummer theorem", "Nat.add_comm"]
   },
   {
     "id": "ann-example-10-4",
@@ -81,7 +86,8 @@
     "content": "Let's verify Kummer's theorem:\n\n**C(10, 4) = 210 = 2 × 3 × 5 × 7**\n\nFor p = 2: Adding 4 + 6 in binary:\n- 4 = 100₂, 6 = 110₂\n- 100 + 110 = 1010₂ (one carry)\n- ν₂(210) = 1 ✓\n\nFor p = 3: Adding 4 + 6 in base 3:\n- 4 = 11₃, 6 = 20₃\n- 11 + 20 = 101₃ (one carry)\n- ν₃(210) = 1 ✓",
     "mathContext": "$C(10,4) = 210 = 2 \\times 3 \\times 5 \\times 7$",
     "significance": "supporting",
-    "relatedConcepts": ["computation", "verification"]
+    "relatedConcepts": ["computation", "verification"],
+    "prerequisites": ["prime factorization", "base-2 and base-3 arithmetic", "native_decide"]
   },
   {
     "id": "ann-example-6-3",
@@ -95,7 +101,8 @@
     "content": "**C(6, 3) = 20 = 4 × 5 = 2² × 5**\n\nFor p = 2: Adding 3 + 3 in binary:\n- 3 = 11₂, 3 = 11₂\n- 11 + 11 = 110₂ (two carries at positions 1 and 2)\n- ν₂(20) = 2 ✓\n\nThe central binomial coefficient C(2n, n) often has high 2-adic valuation!",
     "mathContext": "$C(6,3) = 20 = 2^2 \\times 5$, two carries in binary addition",
     "significance": "supporting",
-    "relatedConcepts": ["central binomial coefficient", "binary addition"]
+    "relatedConcepts": ["central binomial coefficient", "binary addition"],
+    "prerequisites": ["binary arithmetic", "factorization"]
   },
   {
     "id": "ann-prime-divides",
@@ -109,7 +116,8 @@
     "content": "A classic result: for 0 < k < p (prime), we have p | C(p, k).\n\nKummer's theorem explains why: in base p, k and p-k sum to p = 10ₚ, which always has exactly one carry (at position 1).\n\nSo ν_p(C(p, k)) ≥ 1, meaning p divides C(p, k).",
     "mathContext": "For $0 < k < p$: $p \\mid \\binom{p}{k}$",
     "significance": "key",
-    "relatedConcepts": ["prime divisibility", "Pascal's triangle"]
+    "relatedConcepts": ["prime divisibility", "Pascal's triangle"],
+    "prerequisites": ["prime numbers", "binomial coefficient definition", "base-p representation"]
   },
   {
     "id": "ann-prime-power",
@@ -123,7 +131,8 @@
     "content": "For 0 < k < p^n, the prime p divides C(p^n, k).\n\nIn base p, p^n = 10...0 (1 followed by n zeros). Adding any k < p^n to p^n - k produces at least one carry.\n\nThis generalizes the result that p | C(p, k) for 0 < k < p.",
     "mathContext": "$0 < k < p^n \\Rightarrow p \\mid \\binom{p^n}{k}$",
     "significance": "key",
-    "relatedConcepts": ["prime power", "generalization"]
+    "relatedConcepts": ["prime power", "generalization"],
+    "prerequisites": ["prime_dvd_choose_pow", "base-p representation of p^n"]
   },
   {
     "id": "ann-lucas",
@@ -137,7 +146,8 @@
     "content": "**Lucas' Theorem**: C(n, k) ≡ ∏ᵢ C(nᵢ, kᵢ) (mod p)\n\nwhere nᵢ, kᵢ are the i-th digits of n, k in base p.\n\nKummer's theorem explains the \"why\": if any digit kᵢ > nᵢ, then C(nᵢ, kᵢ) = 0, making the whole product 0 mod p.\n\nEach such \"digit overflow\" corresponds to a carry, and the number of carries gives the exact multiplicity.",
     "mathContext": "Lucas: $\\binom{n}{k} \\equiv \\prod_i \\binom{n_i}{k_i} \\pmod{p}$",
     "significance": "key",
-    "relatedConcepts": ["Lucas' theorem", "digit-wise computation"]
+    "relatedConcepts": ["Lucas' theorem", "digit-wise computation"],
+    "prerequisites": ["base-p digit extraction", "modular arithmetic", "product over Finset.range"]
   },
   {
     "id": "ann-digit-sum",
@@ -151,7 +161,8 @@
     "content": "An equivalent formulation using digit sums:\n\n$$(p-1) \\cdot \\nu_p\\binom{n}{k} = S_p(k) + S_p(n-k) - S_p(n)$$\n\nwhere S_p(m) is the sum of digits of m in base p.\n\nThis follows from Legendre's formula: ν_p(n!) = (n - S_p(n))/(p-1).\n\nEach carry \"costs\" exactly p-1 in the digit sum equation!",
     "mathContext": "$(p-1) \\cdot \\nu_p\\binom{n}{k} = S_p(k) + S_p(n-k) - S_p(n)$",
     "significance": "key",
-    "relatedConcepts": ["Legendre's formula", "digit sum", "factorial multiplicity"]
+    "relatedConcepts": ["Legendre's formula", "digit sum", "factorial multiplicity"],
+    "prerequisites": ["Legendre's formula", "Nat.digits", "factorial", "multiplicity function"]
   },
   {
     "id": "ann-applications",
@@ -165,6 +176,7 @@
     "content": "**Practical Applications**:\n\n1. **Efficient computation**: Find ν_p(C(n,k)) by counting carries—no need to compute the (potentially huge) binomial coefficient\n\n2. **Pascal's triangle mod p**: Creates beautiful fractal patterns (Sierpiński triangle for p = 2)\n\n3. **Catalan numbers**: Similar analysis applies to C_n = C(2n,n)/(n+1)\n\n4. **Generalization**: Extends to multinomial coefficients and q-analogs",
     "mathContext": "Applications in computation, combinatorics, and number theory",
     "significance": "supporting",
-    "relatedConcepts": ["Sierpiński triangle", "Catalan numbers", "applications"]
+    "relatedConcepts": ["Sierpiński triangle", "Catalan numbers", "applications"],
+    "prerequisites": ["Kummer's theorem", "Pascal's triangle", "fractal geometry basics"]
   }
 ]

--- a/src/data/proofs/kummer-theorem/meta.json
+++ b/src/data/proofs/kummer-theorem/meta.json
@@ -64,11 +64,19 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Imports",
+      "startLine": 1,
+      "endLine": 4,
+      "summary": "Imports `Nat.Multiplicity` (Kummer's theorem via `multiplicity_choose`), `Choose.Lucas` (Lucas' theorem), and `Tactic`.",
+      "mathContext": "Core dependency: `Nat.Prime.multiplicity_choose` provides $\\nu_p\\binom{n}{k}$ as a carry count, and `Choose.lucas_theorem` gives $\\binom{n}{k} \\equiv \\prod_i \\binom{n_i}{k_i} \\pmod{p}$."
+    },
+    {
       "id": "intro",
       "title": "Introduction and Context",
       "startLine": 5,
-      "endLine": 58,
-      "summary": "Historical background, statement of Kummer's theorem, and its relationship to Lucas' theorem.",
+      "endLine": 63,
+      "summary": "Module docstring with historical background, statement of Kummer's theorem, its relationship to Lucas' theorem, proof approach, and Mathlib dependencies. Opens the `KummerTheorem` namespace and `Nat Finset`.",
       "mathContext": "Kummer (1852): $\\nu_p\\binom{n}{k}$ = number of carries when adding $k$ and $n-k$ in base $p$. Equivalently: $(p-1)\\nu_p\\binom{n}{k} = S_p(k) + S_p(n-k) - S_p(n)$ where $S_p$ is the digit sum."
     },
     {
@@ -110,6 +118,14 @@
       "endLine": 170,
       "summary": "The equivalent formula using digit sums: (p-1)·ν_p(C(n,k)) = S_p(k) + S_p(n-k) - S_p(n).",
       "mathContext": "Legendre-Kummer: $(p-1)\\nu_p\\binom{n}{k} = S_p(k) + S_p(n-k) - S_p(n)$. Each carry reduces the digit sum by $p-1$, so carries $= (S_p(k) + S_p(n-k) - S_p(n))/(p-1)$."
+    },
+    {
+      "id": "applications",
+      "title": "Applications and Closing",
+      "startLine": 172,
+      "endLine": 191,
+      "summary": "Discusses computational, structural, and mathematical applications of Kummer's theorem: efficient $\\nu_p$ computation, Pascal's triangle mod $p$ (Sierpiński triangle), Catalan numbers, and generalizations to multinomials and $q$-analogs. Includes `#check` verification of the three main theorems.",
+      "mathContext": "Applications: (1) compute $\\nu_p\\binom{n}{k}$ in $O(\\log_p n)$ time via carry counting, (2) $\\binom{n}{k} \\not\\equiv 0 \\pmod{p} \\iff$ no carries $\\iff$ each digit of $k \\leq$ corresponding digit of $n$ (fractal structure of Pascal's triangle mod $p$)."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/lhopital/annotations.json
+++ b/src/data/proofs/lhopital/annotations.json
@@ -66,6 +66,29 @@
     ]
   },
   {
+    "id": "ann-atbot",
+    "proofId": "lhopital",
+    "range": {
+      "startLine": 105,
+      "endLine": 117
+    },
+    "type": "technique",
+    "title": "Limit at Negative Infinity",
+    "content": "L'Hopital's Rule for $x \\to -\\infty$: if $f$ and $g$ are differentiable on $(-\\infty, a)$, both tend to 0 as $x \\to -\\infty$, $g'(x) \\neq 0$, and $f'(x)/g'(x) \\to c$, then $f(x)/g(x) \\to c$. This completes the four directional variants: right ($a^+$), left ($b^-$), $+\\infty$, and $-\\infty$.",
+    "mathContext": "Lean uses `Tendsto f atBot (𝓝 0)` for $\\lim_{x \\to -\\infty} f(x) = 0$ and `Iio a` for the domain $(-\\infty, a)$",
+    "significance": "supporting",
+    "prerequisites": [
+      "ann-main-theorem",
+      "atBot filter",
+      "Iio intervals"
+    ],
+    "relatedConcepts": [
+      "negative infinity limits",
+      "atBot filter",
+      "symmetry with atTop"
+    ]
+  },
+  {
     "id": "ann-mvt",
     "proofId": "lhopital",
     "range": {

--- a/src/data/proofs/lhopital/meta.json
+++ b/src/data/proofs/lhopital/meta.json
@@ -78,9 +78,9 @@
       "id": "zero-form",
       "title": "The 0/0 Form",
       "startLine": 51,
-      "endLine": 103,
-      "summary": "L'Hopital's rule for right limits, left limits, and limits at infinity.",
-      "mathContext": "Four variants: $\\lim_{x \\to a^+}$, $\\lim_{x \\to b^-}$, $\\lim_{x \\to +\\infty}$, $\\lim_{x \\to -\\infty}$ all for the $0/0$ form"
+      "endLine": 118,
+      "summary": "All four directional variants of L'Hopital's rule for the $0/0$ indeterminate form: right limit on $(a,b)$, left limit on $(a,b)$, limit at $+\\infty$ on $(a,\\infty)$, and limit at $-\\infty$ on $(-\\infty,a)$. Each wraps the corresponding Mathlib theorem.",
+      "mathContext": "Four variants: $\\lim_{x \\to a^+}$, $\\lim_{x \\to b^-}$, $\\lim_{x \\to +\\infty}$, $\\lim_{x \\to -\\infty}$ for the $0/0$ form. Domains: $\\text{Ioo}\\,a\\,b$, $\\text{Ioi}\\,a$, $\\text{Iio}\\,a$."
     },
     {
       "id": "why-it-works",
@@ -95,8 +95,16 @@
       "title": "Applications",
       "startLine": 134,
       "endLine": 146,
-      "summary": "Common use cases including sin(x)/x and exponential limits.",
+      "summary": "Common use cases including sin(x)/x and exponential limits. Notes on the $\\infty/\\infty$ form.",
       "mathContext": "$\\lim_{x \\to 0} \\frac{\\sin x}{x} = 1$, $\\lim_{x \\to 0} \\frac{e^x - 1}{x} = 1$, $\\lim_{x \\to 0^+} x \\ln x = 0$"
+    },
+    {
+      "id": "verification",
+      "title": "Verification and Closing",
+      "startLine": 147,
+      "endLine": 155,
+      "summary": "Verifies all four theorem variants via `#check` and closes the `LHopital` namespace.",
+      "mathContext": "Confirms the four variants are well-typed: `lhopital_zero_right`, `lhopital_zero_left`, `lhopital_zero_atTop`, `lhopital_zero_atBot`."
     }
   ],
   "crossReferences": [
@@ -120,6 +128,12 @@
       "relationship": "related",
       "description": "The Leibniz series involves limits and series convergence, areas where L'Hopital's rule provides useful asymptotic tools"
     }
+  ],
+  "relatedProofs": [
+    "mean-value-theorem",
+    "fundamental-theorem-calculus",
+    "taylor-theorem",
+    "leibniz-pi"
   ],
   "conclusion": {
     "summary": "L'Hopital's Rule is fully verified using Mathlib's calculus infrastructure. We provide the theorem in multiple forms: right limits, left limits, and limits at infinity.",

--- a/src/data/proofs/prob-method-alteration/annotations.json
+++ b/src/data/proofs/prob-method-alteration/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-alteration-imports",
     "proofId": "prob-method-alteration",
-    "range": { "startLine": 1, "endLine": 14 },
+    "range": { "startLine": 1, "endLine": 18 },
     "type": "context",
     "title": "Alteration Method Overview",
     "content": "The module header introduces the alteration (deletion) method, a two-phase probabilistic technique: first construct a random object, then deterministically remove the few violations. The Mathlib import provides access to Finset, simple graph definitions, and integer arithmetic needed for the expectation arguments.",
@@ -14,7 +14,7 @@
   {
     "id": "ann-alteration-principle",
     "proofId": "prob-method-alteration",
-    "range": { "startLine": 18, "endLine": 21 },
+    "range": { "startLine": 24, "endLine": 38 },
     "type": "insight",
     "title": "Alteration Principle (Deterministic Core)",
     "content": "This theorem captures the deterministic essence of the alteration method. Given a nonempty finite set $S$ and integer-valued functions `good` and `bad`, if the net good value summed over $S$ is positive, then some element achieves positive net good value. This is essentially a pigeonhole argument: if every element had non-positive net value, the sum could not be positive.\n\nThe formalization uses integer coercions ($\\mathbb{Z}$) to handle the subtraction cleanly, since natural number subtraction in Lean truncates at zero.",
@@ -26,7 +26,7 @@
   {
     "id": "ann-independent-set",
     "proofId": "prob-method-alteration",
-    "range": { "startLine": 25, "endLine": 26 },
+    "range": { "startLine": 44, "endLine": 50 },
     "type": "insight",
     "title": "Independent Set Bound via Vertex Deletion",
     "content": "The classic application of the alteration method to independent sets: in a $d$-regular graph on $n$ vertices, select each vertex with probability $p = 1/d$. The expected number of selected vertices is $n/d$, and the expected number of edges within the selection is $nd p^2/2 = n/(2d)$. Deleting one endpoint per edge yields an independent set of expected size $\\geq n/d - n/(2d) = n/(2d)$.\n\nThe formalization simplifies the statement to the existence of a positive integer $k \\geq \\lfloor n/(2d) \\rfloor$, sidestepping the need for a formal graph type. A fuller formalization would state this as $\\alpha(G) \\geq n/(2d)$ using Mathlib's `SimpleGraph.IndependentSet`.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-property-b",
     "proofId": "prob-method-alteration",
-    "range": { "startLine": 29, "endLine": 30 },
+    "range": { "startLine": 56, "endLine": 59 },
     "type": "concept",
     "title": "Property B of Hypergraphs (Placeholder)",
     "content": "Property B, introduced by Miller (1937) and extensively studied by Erdős, asks whether a hypergraph's vertices can be 2-colored so that no edge is monochromatic. The alteration argument: randomly 2-color all vertices, then for each monochromatic edge, recolor one vertex. If the expected number of monochromatic edges is less than the number of vertices we can sacrifice, the alteration succeeds.\n\nThis formalization is currently a placeholder (`True`) because Lean 4/Mathlib lacks a standard hypergraph type. The mathematical content is captured in the bound: a $k$-uniform hypergraph with $m < 2^{k-1}$ edges has Property B.",
@@ -50,7 +50,7 @@
   {
     "id": "ann-namespace-structure",
     "proofId": "prob-method-alteration",
-    "range": { "startLine": 14, "endLine": 14 },
+    "range": { "startLine": 16, "endLine": 18 },
     "type": "context",
     "title": "Namespace Organization",
     "content": "The proof is organized under `ProbMethod.Alteration`, following a hierarchical convention shared with `ProbMethod.Expectation`, `ProbMethod.LovaszLocal`, etc. This structure mirrors the textbook organization of the probabilistic method, where the alteration method is typically Chapter 3 after the first and second moment methods.",

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -64,36 +64,36 @@
   },
   "sections": [
     {
-      "id": "module-header",
+      "id": "preamble",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 14,
-      "summary": "Documentation header describing the alteration/deletion method and its key results, followed by Mathlib import and namespace declaration.",
+      "endLine": 18,
+      "summary": "Documentation header describing the alteration/deletion method and its key results (alteration principle, independent set bound, Property B). Imports Mathlib, opens `ProbMethod.Alteration` namespace and `Finset BigOperators`.",
       "mathContext": "The alteration method is a refinement of the probabilistic method: construct a random object, then deterministically remove violations to obtain a valid structure."
     },
     {
       "id": "alteration-principle",
       "title": "Alteration Principle",
-      "startLine": 16,
-      "endLine": 21,
-      "summary": "Core theorem: if the sum of a 'good' function minus a 'bad' function over a nonempty finite set is positive, then some element has positive net good value.",
-      "mathContext": "For functions $\\text{good}, \\text{bad} : \\alpha \\to \\mathbb{N}$ on a nonempty finite set $S$, if $\\sum_{a \\in S} \\text{good}(a) - \\sum_{a \\in S} \\text{bad}(a) > 0$, then $\\exists a \\in S$ with $\\text{good}(a) - \\text{bad}(a) > 0$. This is the deterministic core of the alteration method, reducing the probabilistic argument to a pigeonhole-type statement."
+      "startLine": 20,
+      "endLine": 38,
+      "summary": "Core theorem `alteration_principle`: if the $\\mathbb{Z}$-valued sum of `good` minus `bad` over a nonempty `Finset` is positive, then some element has positive net good value. Proved by contradiction using `Finset.sum_le_sum` and `linarith`.",
+      "mathContext": "For functions $\\text{good}, \\text{bad} : \\alpha \\to \\mathbb{N}$ on a nonempty finite set $S$, if $\\sum_{a \\in S} (\\text{good}(a) : \\mathbb{Z}) - \\sum_{a \\in S} (\\text{bad}(a) : \\mathbb{Z}) > 0$, then $\\exists a \\in S$ with $\\text{good}(a) > \\text{bad}(a)$."
     },
     {
       "id": "independent-set-bound",
       "title": "Independent Set Bound via Alteration",
-      "startLine": 23,
-      "endLine": 26,
-      "summary": "Application to regular graphs: every $d$-regular graph on $n$ vertices has an independent set of size at least $\\lfloor n/(2d) \\rfloor$.",
-      "mathContext": "For a $d$-regular graph on $n$ vertices, include each vertex independently with probability $p = 1/(d+1)$. The expected number of selected vertices is $np$ and the expected edges in the selected set is $\\frac{nd}{2} p^2$. Deleting one endpoint per edge yields expected independent set size $\\geq np - \\frac{nd}{2}p^2 \\geq n/(2d)$."
+      "startLine": 40,
+      "endLine": 50,
+      "summary": "Application to regular graphs: proves existence of a positive integer $k \\geq \\lfloor n/(2d) \\rfloor$ for a $d$-regular graph on $n$ vertices, as a simplified form of $\\alpha(G) \\geq n/(2d)$.",
+      "mathContext": "For a $d$-regular graph on $n$ vertices: $\\alpha(G) \\geq \\frac{n}{2d}$. Select each vertex with probability $p = 1/d$, delete one endpoint per surviving edge. Expected independent set size $\\geq np - \\frac{nd}{2}p^2 = \\frac{n}{2d}$."
     },
     {
       "id": "property-b",
       "title": "Property B of Hypergraphs",
-      "startLine": 28,
-      "endLine": 32,
-      "summary": "Placeholder for Property B: a $k$-uniform hypergraph with fewer than $2^{k-1}$ edges is 2-colorable.",
-      "mathContext": "Property B states that the vertices of a hypergraph can be 2-colored with no monochromatic edge. For $k$-uniform hypergraphs, a random 2-coloring makes each edge monochromatic with probability $2^{1-k}$. If $m < 2^{k-1}$, the expected number of monochromatic edges $m \\cdot 2^{1-k} < 1$, so alteration yields a valid 2-coloring."
+      "startLine": 52,
+      "endLine": 61,
+      "summary": "Placeholder theorem `property_b_bound`: a $k$-uniform hypergraph with $m < 2^{k-1}$ edges is 2-colorable. Currently proves `True` because Mathlib lacks a standard hypergraph type. Closes the namespace.",
+      "mathContext": "Property B: for $k$-uniform hypergraphs with $m$ edges, random 2-coloring gives $\\mathbb{E}[\\text{mono edges}] = m \\cdot 2^{1-k}$. If $m < 2^{k-1}$, alteration yields a valid 2-coloring."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/prob-method-second-moment/annotations.json
+++ b/src/data/proofs/prob-method-second-moment/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-smm-imports",
     "proofId": "prob-method-second-moment",
-    "range": { "startLine": 1, "endLine": 14 },
+    "range": { "startLine": 1, "endLine": 17 },
     "type": "context",
     "title": "Module Setup and Namespace",
     "content": "The file imports the full Mathlib library and works within the `ProbMethod.SecondMoment` namespace. The formalization uses finite probability spaces modeled over `Finset α` with rational-valued random variables (`α → ℚ`), giving exact arithmetic without floating-point concerns. This discrete framework suffices for combinatorial applications where the sample space is finite.",
@@ -14,7 +14,7 @@
   {
     "id": "ann-smm-chebyshev",
     "proofId": "prob-method-second-moment",
-    "range": { "startLine": 18, "endLine": 22 },
+    "range": { "startLine": 19, "endLine": 55 },
     "type": "theorem",
     "title": "Chebyshev's Inequality (Finite Version)",
     "content": "Formalizes Chebyshev's inequality for finite probability spaces. The mean $\\mu$ and variance $\\operatorname{Var}[X]$ are computed as finite sums over a `Finset`. The bound states that the fraction of elements deviating from the mean by at least $t$ is at most $\\operatorname{Var}[X]/t^2$. This is proved by applying Markov's inequality to the non-negative random variable $(X - \\mu)^2$, which is the standard textbook approach lifted to the Finset setting.",
@@ -26,7 +26,7 @@
   {
     "id": "ann-smm-paley-zygmund",
     "proofId": "prob-method-second-moment",
-    "range": { "startLine": 26, "endLine": 29 },
+    "range": { "startLine": 57, "endLine": 75 },
     "type": "theorem",
     "title": "Paley-Zygmund Inequality",
     "content": "Formalizes the Paley-Zygmund inequality, which provides a lower bound on $\\Pr[X > 0]$ for non-negative random variables. While Chebyshev bounds deviation probabilities from above, Paley-Zygmund bounds positivity probability from below — making it the key tool for existence proofs. The proof uses the Cauchy-Schwarz inequality: $E[X]^2 = E[X \\cdot \\mathbf{1}_{X>0}]^2 \\leq E[X^2] \\cdot \\Pr[X > 0]$. This formalization states the qualitative version: if $E[X] > 0$ and $X \\geq 0$, then $X$ is positive on a non-empty subset.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-smm-existence",
     "proofId": "prob-method-second-moment",
-    "range": { "startLine": 33, "endLine": 37 },
+    "range": { "startLine": 115, "endLine": 159 },
     "type": "theorem",
     "title": "Second Moment Existence Theorem",
     "content": "The main application theorem: if the second moment $E[X^2]$ is at most $2(E[X])^2/|s|$, then at least half the sample space has $X > 0$. This is the workhorse of the second moment method in combinatorics — it converts a variance bound into a quantitative existence guarantee. The factor of 2 comes from the Paley-Zygmund bound: $\\Pr[X > 0] \\geq (E[X])^2/E[X^2] \\geq 1/2$. In random graph theory, this is exactly how one proves that $G(n,p)$ contains a given subgraph with high probability when $p$ is above the threshold.",
@@ -48,15 +48,15 @@
     "prerequisites": ["Paley-Zygmund inequality", "indicator sum variance", "random graph model"]
   },
   {
-    "id": "ann-smm-sorry-strategy",
+    "id": "ann-smm-helpers",
     "proofId": "prob-method-second-moment",
-    "range": { "startLine": 18, "endLine": 37 },
-    "type": "theorem",
-    "title": "Proof Status and Formalization Approach",
-    "content": "All three theorems currently use `sorry` placeholders. The proof strategies are well-understood: Chebyshev follows from Markov applied to $(X-\\mu)^2$, Paley-Zygmund from Cauchy-Schwarz, and the existence theorem from direct application of Paley-Zygmund. The formalization uses `Finset.filter` to model events and `Finset.sum` for expectations, keeping everything in the decidable `ℚ` arithmetic. Completing these proofs would involve finite summation manipulations and algebraic rearrangement — routine but requiring careful interaction with Mathlib's `Finset` API.",
-    "mathContext": "The proof chain is: Markov $\\Rightarrow$ Chebyshev $\\Rightarrow$ Paley-Zygmund $\\Rightarrow$ existence theorem. Each step is a standard inequality derivation over finite sums.",
+    "range": { "startLine": 77, "endLine": 113 },
+    "type": "technique",
+    "title": "Helper Lemmas: Cauchy-Schwarz and Support",
+    "content": "Three private lemmas building toward the existence theorem:\n\n1. **Finite Cauchy-Schwarz**: $(\\sum f)^2 \\leq |s| \\cdot \\sum f^2$, proved by induction on `Finset` using the non-negativity of $\\sum (f(a) - f(b))^2$.\n\n2. **Support equality**: For $f \\geq 0$, the sum over all of $s$ equals the sum over the positive support $\\{a : f(a) > 0\\}$, since zero-valued elements contribute nothing.\n\n3. **Filter monotonicity**: $\\sum_{\\text{pos}} f^2 \\leq \\sum_s f^2$ since squares are non-negative and the filter is a subset.\n\nThese are the standard building blocks for Paley-Zygmund-type arguments in finite probability.",
+    "mathContext": "Cauchy-Schwarz: $(\\sum f)^2 \\leq |s| \\sum f^2$. Support: $f \\geq 0 \\implies \\sum_s f = \\sum_{\\{f>0\\}} f$. Monotonicity: $\\sum_{\\{f>0\\}} f^2 \\leq \\sum_s f^2$.",
     "significance": "supporting",
-    "relatedConcepts": ["sorry placeholder", "Lean 4 tactics", "Finset API", "algebraic manipulation"],
-    "prerequisites": ["Lean 4 proof tactics", "Finset.sum", "Finset.filter"]
+    "relatedConcepts": ["Cauchy-Schwarz inequality", "Finset.induction_on", "support of a function", "filter monotonicity"],
+    "prerequisites": ["Finset.induction_on", "Finset.sum_le_sum_of_subset_of_nonneg", "nlinarith"]
   }
 ]

--- a/src/data/proofs/ramseys-theorem/annotations.json
+++ b/src/data/proofs/ramseys-theorem/annotations.json
@@ -39,6 +39,7 @@
     "type": "theorem",
     "title": "R(1, s) = 1",
     "content": "Any nonempty type has a red 1-clique: just pick any vertex. A single vertex trivially forms a clique since there are no pairs to check.",
+    "mathContext": "$R(1,s) = 1$ for all $s$: a single vertex is a trivial $K_1$ in any color. This is the base case for the induction on $r + s$.",
     "significance": "key",
     "prerequisites": ["singleton-clique"],
     "relatedConcepts": ["base-case", "induction"]
@@ -68,6 +69,7 @@
     "type": "theorem",
     "title": "Red Clique Extension",
     "content": "If s is a red clique contained in v's red neighborhood and v ∉ s, then (insert v s) is also a red clique. The new edges from v to s are all red by definition of red neighborhood.",
+    "mathContext": "If $S \\subseteq N_{\\text{red}}(v)$ is a red $K_r$ and $v \\notin S$, then $S \\cup \\{v\\}$ is a red $K_{r+1}$. Key: all edges $\\{v, w\\}$ for $w \\in S$ are red since $S \\subseteq N_{\\text{red}}(v)$.",
     "significance": "critical",
     "prerequisites": ["clique-definition", "neighborhood"],
     "relatedConcepts": ["induction-step", "clique-growth"]
@@ -112,6 +114,7 @@
     "type": "insight",
     "title": "Pigeonhole Principle Application",
     "content": "With n = R(r-1,s) + R(r,s-1) vertices and v removed, the remaining n-1 vertices partition into red and blue neighborhoods. The sum of their sizes is n-1, so one must be large enough for the IH.",
+    "mathContext": "$|N_{\\text{red}}(v)| + |N_{\\text{blue}}(v)| = n - 1 = R(r-1,s) + R(r,s-1) - 1$, so $|N_{\\text{red}}| \\geq R(r-1,s)$ or $|N_{\\text{blue}}| \\geq R(r,s-1)$.",
     "significance": "key",
     "prerequisites": ["pigeonhole-principle", "neighborhood-partition"],
     "relatedConcepts": ["counting-argument", "induction"]

--- a/src/data/proofs/ramseys-theorem/meta.json
+++ b/src/data/proofs/ramseys-theorem/meta.json
@@ -67,11 +67,19 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Imports for `SimpleGraph.Clique`, `Finset.Card`, `Fintype.Basic`, `Nat.Choose.Sum`, `Fin.Basic`, and `Tactic`. Module docstring with theorem statement, proof approach, and status. Opens `RamseysTheorem` namespace and `SimpleGraph Finset`.",
+      "mathContext": "Ramsey's Theorem (Wiedijk #31): $\\forall r,s \\geq 1,\\, \\exists R(r,s)$ such that any 2-coloring of $K_{R(r,s)}$ has a red $K_r$ or blue $K_s$. Bound: $R(r,s) \\leq \\binom{r+s-2}{r-1}$."
+    },
+    {
       "id": "edge-colorings",
       "title": "Edge Colorings and Cliques",
-      "startLine": 52,
+      "startLine": 55,
       "endLine": 94,
-      "summary": "Definitions of edge 2-colorings, red/blue graphs, and the Ramsey property.",
+      "summary": "Definitions of `EdgeColoring` (symmetric Boolean function on pairs), `redGraph`/`blueGraph`, `IsRedClique`/`IsBlueClique`, and `HasRamseyProperty n r s`.",
       "mathContext": "A 2-coloring $c: E(K_n) \\to \\{\\text{red}, \\text{blue}\\}$ partitions edges. `HasRamseyProperty n r s`: every 2-coloring of $K_n$ has a red $K_r$ or blue $K_s$."
     },
     {
@@ -103,17 +111,63 @@
       "title": "Ramsey Bounds",
       "startLine": 247,
       "endLine": 265,
-      "summary": "The classical bound R(r,s) ≤ C(r+s-2, r-1) and concrete computations for small cases.",
-      "mathContext": "$R(r,s) \\leq \\binom{r+s-2}{r-1}$. Concrete: $R(3,3) \\leq \\binom{4}{2} = 6$ (tight!). $R(4,4) \\leq \\binom{6}{3} = 20$ (actual: 18)."
+      "summary": "The classical bound `ramseyBound r s = C(r+s-2, r-1)` and concrete computations for small cases via `native_decide`.",
+      "mathContext": "$R(r,s) \\leq \\binom{r+s-2}{r-1}$. Concrete: $R(3,3) \\leq 6$ (tight!), $R(3,4) \\leq 10$, $R(4,4) \\leq 20$ (actual: 18)."
+    },
+    {
+      "id": "embedding-helper",
+      "title": "Injective Functions from Finsets",
+      "startLine": 267,
+      "endLine": 289,
+      "summary": "Helper lemma `exists_embedding_of_card_ge`: if a Finset has $\\geq n$ elements, there exists an injection `Fin n ↪ β` into the Finset. Used to select elements from large neighborhoods in the inductive step.",
+      "mathContext": "If $|s| \\geq n$, then $\\exists f: \\text{Fin}\\,n \\hookrightarrow s$. Constructs embedding via `Fintype.equivFinOfCardEq` on a subset of exact cardinality $n$."
     },
     {
       "id": "main-theorem",
       "title": "Ramsey's Theorem",
-      "startLine": 283,
-      "endLine": 447,
-      "summary": "The main existence theorem using strong induction with the recurrence R(r,s) ≤ R(r-1,s) + R(r,s-1).",
+      "startLine": 290,
+      "endLine": 446,
+      "summary": "The main existence theorem `ramsey_theorem` using strong induction on $r + s$ with the recurrence $R(r,s) \\leq R(r-1,s) + R(r,s-1)$. Picks vertex $v$, partitions by color, applies pigeonhole, recurses, and extends cliques.",
       "mathContext": "Recurrence: $R(r,s) \\leq R(r-1,s) + R(r,s-1)$. Proof: pick $v$, partition into red/blue neighborhoods. By pigeonhole, $|N_{\\text{red}}| \\geq R(r-1,s)$ or $|N_{\\text{blue}}| \\geq R(r,s-1)$. Apply IH and extend."
+    },
+    {
+      "id": "pentagon-coloring",
+      "title": "Pentagon Coloring and R(3,3) Lower Bound",
+      "startLine": 447,
+      "endLine": 584,
+      "summary": "Constructive lower bound $R(3,3) > 5$ via the pentagon ($C_5$) coloring: red edges are cycle-adjacent ($|i-j| \\in \\{1,4\\}$ mod 5), blue edges are non-adjacent. Both red and blue graphs form triangle-free 5-cycles, proved by exhaustive `fin_cases`. Combined with the upper bound to establish $R(3,3) = 6$.",
+      "mathContext": "Pentagon coloring of $K_5$: $c(i,j) = \\text{red} \\iff |i-j| \\in \\{1,4\\} \\pmod{5}$. Red graph $= C_5$ (triangle-free), blue graph $= C_5$ complement (also triangle-free). Therefore $R(3,3) > 5$, and $R(3,3) \\leq 6$ from the bound, so $R(3,3) = 6$."
+    },
+    {
+      "id": "computations-and-multicolor",
+      "title": "Concrete Computations and Multicolor Extension",
+      "startLine": 585,
+      "endLine": 627,
+      "summary": "Binomial coefficient verifications ($\\binom{4}{2} = 6$, etc.), `#check` of all major theorems, and axiomatized multicolor Ramsey theorem: for $c \\geq 1$ colors and $k \\geq 1$, $\\exists n$ such that any $c$-coloring of $K_n$ has a monochromatic $K_k$.",
+      "mathContext": "Multicolor Ramsey: $\\forall c \\geq 1, k \\geq 1,\\, \\exists n$ such that any $c$-coloring of $K_n$ contains a monochromatic $K_k$. Proved by induction on $c$: group colors $0..c-2$ vs $c-1$, apply 2-color Ramsey."
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "prob-method-alteration",
+      "relationship": "related",
+      "description": "The probabilistic lower bound on Ramsey numbers R(k,k) ≥ 2^{k/2} uses an alteration/expectation argument on random 2-colorings"
+    },
+    {
+      "targetId": "pigeonhole-principle",
+      "relationship": "depends-on",
+      "description": "The neighborhood partition step relies on pigeonhole: n-1 vertices split into two sets, so one has at least ⌈(n-1)/2⌉ elements"
+    },
+    {
+      "targetId": "kummer-theorem",
+      "relationship": "related",
+      "description": "Binomial coefficient structure determines the Ramsey bound R(r,s) ≤ C(r+s-2, r-1)"
+    }
+  ],
+  "relatedProofs": [
+    "prob-method-alteration",
+    "pigeonhole-principle",
+    "kummer-theorem"
   ],
   "conclusion": {
     "summary": "This Lean formalization provides a complete, constructive proof of Ramsey's theorem for 2-colorings. The proof carefully builds up from base cases through neighborhood partitions to the main inductive argument.\n\nThe key insight is that the pigeonhole principle forces one of the two neighborhoods to be large enough to apply the induction hypothesis. Clique extension then allows us to grow cliques by adding the central vertex.\n\nAll proofs are complete with no sorries, and the formalization is self-contained within the Ramsey namespace.",

--- a/src/data/proofs/russell-1-plus-1/annotations.json
+++ b/src/data/proofs/russell-1-plus-1/annotations.json
@@ -9,6 +9,7 @@
     "type": "concept",
     "title": "The Most Famous 'Trivial' Proof",
     "content": "The claim that Principia Mathematica took 362 pages to prove $1+1=2$ has become legendary—and somewhat misleading. Those pages weren't proving a single equation; they were constructing the entire logical framework needed to give rigorous meaning to the symbols '1', '+', '=', and '2'.\n\nIn modern type theory, this proof is definitionally true: the computation $1+1$ *reduces to* $2$ by the very definitions of the symbols involved. The `rfl` tactic (reflexivity) captures this.",
+    "mathContext": "In Principia: 362 pages of logical foundations. In Lean 4: `theorem : 1 + 1 = 2 := rfl`. The difference is the choice of foundation, not the difficulty of the mathematics.",
     "significance": "key",
     "relatedConcepts": [
       "Principia Mathematica",
@@ -124,6 +125,7 @@
     "type": "insight",
     "title": "The Power of 'rfl'",
     "content": "This alternative proof using just `rfl` shows the true elegance of type theory. The term `rfl` (reflexivity) proves any goal of the form `a = a`.\n\nBut here's the magic: type theory has **definitional equality** built in. If `a` and `b` compute to the same normal form, then `a = b` is proved by `rfl`. Since `one + one` and `two` both reduce to `succ (succ zero)`, they're definitionally equal.\n\nThis is why the proof is 'trivial'—it's not that we're avoiding work, it's that the *definitions themselves* do the work.",
+    "mathContext": "`rfl : a = a`. Since `add one one` and `two` both $\\beta$-reduce to `succ (succ zero)`, they are definitionally equal and `rfl` proves `add one one = two`.",
     "significance": "key",
     "prerequisites": [
       "ann-unfold-proof"
@@ -219,6 +221,7 @@
     "type": "concept",
     "title": "Extending the Pattern",
     "content": "Once we have the machinery, more arithmetic facts fall out immediately:\n\n- $2 + 1 = 3$ — `rfl`\n- $1 + 2 = 3$ — `rfl` \n- $2 + 2 = 4$ — `rfl`\n\nAll definitionally true, requiring no proof beyond reflexivity. The pattern extends to any concrete computation with natural numbers.",
+    "mathContext": "$S(S(0)) + S(0) = S(S(S(0)))$, $S(0) + S(S(0)) = S(S(S(0)))$, $S(S(0)) + S(S(0)) = S(S(S(S(0))))$. All by `rfl`.",
     "significance": "supporting",
     "relatedConcepts": [
       "definitional equality",
@@ -235,6 +238,7 @@
     "type": "concept",
     "title": "Lean's Built-in Naturals",
     "content": "Lean's standard library defines `Nat` identically to our `Peano.ℕ`:\n\n```lean\ninductive Nat where\n  | zero : Nat\n  | succ : Nat → Nat\n```\n\nThe numeric literals `1`, `2`, etc. are notation for `Nat.succ Nat.zero`, `Nat.succ (Nat.succ Nat.zero)`, etc. And `Nat.add` is defined exactly as our `add`. So the proof `(1 : Nat) + 1 = 2` is also just `rfl`.",
+    "mathContext": "Lean's `Nat` $\\cong$ `Peano.ℕ`: `Nat.zero` $\\leftrightarrow$ `zero`, `Nat.succ` $\\leftrightarrow$ `succ`, `Nat.add` $\\leftrightarrow$ `add`. Proof: `(1 : Nat) + 1 = 2 := rfl`.",
     "significance": "supporting",
     "prerequisites": [
       "ann-peano-inductive"
@@ -254,6 +258,7 @@
     "type": "concept",
     "title": "Understanding Principia Mathematica",
     "content": "Russell and Whitehead weren't trying to prove $1+1=2$ in isolation—they were building a complete logical foundation for all of mathematics.\n\nTheir approach was radically different from ours:\n\n- **Numbers as sets:** 1 was defined as *the set of all singleton sets*, 2 as *the set of all two-element sets*\n- **Addition via unions:** $a + b$ meant taking the union of disjoint representatives\n- **Ramified type theory:** To avoid paradoxes, they used a complex type hierarchy\n\nIn contrast, modern type theory treats natural numbers as a primitive inductive type, making the foundations far simpler. We're not cheating—we've just found a better foundation.",
+    "mathContext": "Principia: $1 = \\{X : |X| = 1\\}$ (the class of singletons), $2 = \\{X : |X| = 2\\}$. Addition: $|A \\cup B| = |A| + |B|$ for disjoint $A, B$. Lean: $1 = S(0)$, $2 = S(S(0))$, addition by recursion.",
     "significance": "key",
     "relatedConcepts": [
       "Frege-Russell definition",

--- a/src/data/proofs/russell-1-plus-1/meta.json
+++ b/src/data/proofs/russell-1-plus-1/meta.json
@@ -44,58 +44,76 @@
       "id": "header",
       "title": "Introduction",
       "startLine": 1,
-      "endLine": 15,
-      "summary": "Overview of the proof and its historical significance, explaining how type theory simplifies what was once a monumental undertaking."
+      "endLine": 31,
+      "summary": "Module docstring with proof overview, approach (no Mathlib imports, self-contained Peano arithmetic), original contributions, and historical note about Principia Mathematica. Opens `Peano` namespace.",
+      "mathContext": "Goal: prove $1 + 1 = 2$ from first principles via Peano's axioms. In type theory, this is definitional: $S(0) + S(0) = S(S(0) + 0) = S(S(0)) = 2$ by `rfl`."
     },
     {
       "id": "peano-naturals",
       "title": "Building Natural Numbers",
-      "startLine": 17,
-      "endLine": 33,
-      "summary": "Defining the natural numbers from scratch using Peano's axioms: zero and successor, with numeric notation for convenience."
+      "startLine": 34,
+      "endLine": 49,
+      "summary": "Defines `Peano.ℕ` as an inductive type with constructors `zero` and `succ`. Declares numeric notation: $1 = S(0)$, $2 = S(S(0))$, $3 = S(S(S(0)))$.",
+      "mathContext": "$\\mathbb{N} ::= 0 \\mid S(n)$. Numeric abbreviations: $1 \\stackrel{\\text{def}}{=} S(0)$, $2 \\stackrel{\\text{def}}{=} S(S(0))$."
     },
     {
       "id": "addition-definition",
       "title": "Defining Addition",
-      "startLine": 35,
-      "endLine": 49,
-      "summary": "Recursive definition of addition following Peano's original formulation: n + 0 = n and n + succ(m) = succ(n + m)."
+      "startLine": 51,
+      "endLine": 61,
+      "summary": "Recursive definition of addition by pattern matching on the second argument: $n + 0 = n$, $n + S(m) = S(n + m)$.",
+      "mathContext": "$\\text{add}(n, 0) = n$, $\\text{add}(n, S(m)) = S(\\text{add}(n, m))$. Well-founded by structural recursion on the second argument."
     },
     {
       "id": "main-theorem",
       "title": "The Famous Theorem",
-      "startLine": 51,
-      "endLine": 66,
-      "summary": "The proof of 1+1=2, showing step-by-step how the definitions unfold, and the ultimate simplicity of 'rfl'."
+      "startLine": 63,
+      "endLine": 79,
+      "summary": "Proves `one_plus_one_eq_two : add one one = two` both by step-by-step unfolding and by `rfl`. The computation chain: $S(0) + S(0) \\to S(S(0) + 0) \\to S(S(0)) = 2$.",
+      "mathContext": "$S(0) + S(0) = S(S(0) + 0) = S(S(0)) = 2$. Proof: `rfl` (definitional equality in type theory)."
     },
     {
       "id": "arithmetic-properties",
       "title": "Building Up Arithmetic",
-      "startLine": 68,
+      "startLine": 81,
       "endLine": 99,
-      "summary": "Developing fundamental properties of addition: identity laws, commutativity, and associativity—the algebraic structure emerges."
+      "summary": "Proves fundamental properties: $n + 0 = n$ (by definition), $0 + n = n$ (by induction), $S(n) + m = S(n+m)$ (by induction), commutativity $n + m = m + n$, and associativity $(a+b)+c = a+(b+c)$.",
+      "mathContext": "$(\\mathbb{N}, +, 0)$ is a commutative monoid. Right identity is definitional; left identity and commutativity require induction because `add` recurses on the right argument."
     },
     {
       "id": "consequences",
       "title": "More Consequences",
       "startLine": 101,
       "endLine": 111,
-      "summary": "Extending the pattern to prove 2+1=3, 1+2=3, and 2+2=4, all following immediately from definitions."
+      "summary": "Proves $2+1=3$, $1+2=3$, and $2+2=4$, all by `rfl`.",
+      "mathContext": "All definitionally true: $S(S(0)) + S(0) = S(S(S(0)))$, etc. Each follows from the recursive unfolding of `add`."
     },
     {
       "id": "builtin-naturals",
       "title": "Using Built-in Naturals",
       "startLine": 113,
-      "endLine": 130,
-      "summary": "Demonstrating that Lean's standard library naturals work identically, with the same trivial proof."
+      "endLine": 165,
+      "summary": "Shows Lean's built-in `Nat` is isomorphic to `Peano.ℕ` with identical `add`. Proves `(1 : Nat) + 1 = 2` by `rfl`. Comments explain the correspondence.",
+      "mathContext": "Lean's `Nat` $\\cong$ `Peano.ℕ`: same inductive type, same recursive `add`. The numerals `1`, `2` are notation for `Nat.succ Nat.zero`, etc."
     },
     {
       "id": "principia-comparison",
       "title": "Why Principia Took 362 Pages",
-      "startLine": 132,
-      "endLine": 155,
-      "summary": "Historical context explaining Russell's set-theoretic approach versus modern type theory, and why the complexity was necessary in 1910."
+      "startLine": 167,
+      "endLine": 197,
+      "summary": "Explains Russell-Whitehead's set-theoretic approach: numbers as equivalence classes of equinumerous sets, addition via disjoint unions, ramified type theory. Contrasts with modern type theory's inductive definitions. Final `#check` verification of both proofs.",
+      "mathContext": "Principia: $1 = \\{X : |X| = 1\\}$, $2 = \\{X : |X| = 2\\}$, $1 + 1 = 2$ requires showing $|A \\cup B| = 2$ for disjoint singletons $A, B$. Type theory: $1 + 1 = 2$ by computation."
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements",
+      "relationship": "related",
+      "description": "Both involve natural number arithmetic formalized in Lean — derangements uses Nat.factorial and Nat.choose where this proof builds Nat from scratch"
+    }
+  ],
+  "relatedProofs": [
+    "derangements"
   ],
   "conclusion": {
     "summary": "This formalization demonstrates the dramatic simplification that type theory brings to mathematical foundations. What took Russell and Whitehead hundreds of pages is now a single rfl—not because we're cheating, but because we've chosen a cleaner foundation where natural numbers and their operations are primitive concepts rather than derived constructions.",

--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -56,54 +56,85 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring, Mathlib imports for topology, convex analysis, and normed spaces. Opens namespaces and declares variables for normed space $E$ over $\\mathbb{R}$.",
+      "mathContext": "Setting: $(E, \\|\\cdot\\|)$ a real normed space, $K \\subseteq E$ compact, $\\varepsilon > 0$. Goal: construct continuous $\\pi: E \\to \\text{conv}\\{x_1,\\ldots,x_n\\}$ with $\\|\\pi(x) - x\\| < \\varepsilon$ on $K$."
+    },
+    {
       "id": "convex-hull-compactness",
       "title": "Convex Hull Compactness",
       "startLine": 46,
       "endLine": 60,
-      "summary": "Two auxiliary results: the convex hull of a finite set is closed, and the convex hull of a finite range is compact."
+      "summary": "Two auxiliary results: the convex hull of a finite set is closed, and the convex hull of a finite range is compact.",
+      "mathContext": "$S$ finite $\\Rightarrow \\text{conv}(S)$ is closed (in finite dimensions) and compact."
     },
     {
       "id": "bump-functions",
       "title": "Bump Function Infrastructure",
       "startLine": 62,
       "endLine": 104,
-      "summary": "Defining bump functions phi(x) = max(0, eps - ||x - c||) and proving their key properties: nonnegativity, continuity, positivity in balls, and vanishing outside balls."
+      "summary": "Defines bump functions $\\varphi_i(x) = \\max(0, \\varepsilon - \\|x - c_i\\|)$ and proves: nonnegativity, continuity, positivity in $B(c_i, \\varepsilon)$, and vanishing outside $B(c_i, \\varepsilon)$.",
+      "mathContext": "$\\varphi_i(x) = \\max(0, \\varepsilon - \\|x - c_i\\|)$. Properties: $\\varphi_i \\geq 0$, $\\varphi_i$ continuous, $\\varphi_i(x) > 0 \\iff \\|x - c_i\\| < \\varepsilon$."
     },
     {
       "id": "bump-sum",
       "title": "Sum of Bumps and Positivity",
       "startLine": 106,
       "endLine": 131,
-      "summary": "The sum of bump functions over a finite covering, with continuity and positivity on the covered set."
+      "summary": "The sum $\\Phi(x) = \\sum_i \\varphi_i(x)$ is continuous and positive on $K$ (since the $\\varepsilon$-balls cover $K$).",
+      "mathContext": "$\\Phi(x) = \\sum_{i=1}^n \\varphi_i(x) > 0$ for $x \\in K$, because $\\exists i: \\|x - c_i\\| < \\varepsilon$."
     },
     {
       "id": "projection-map",
       "title": "The Schauder Projection Map",
       "startLine": 132,
       "endLine": 141,
-      "summary": "Definition of the Schauder projection as a weighted average: pi(x) = sum(phi_i(x) * x_i) / sum(phi_i(x))."
+      "summary": "Defines the Schauder projection $\\pi(x) = \\sum_i \\varphi_i(x) \\cdot c_i / \\Phi(x)$ as a weighted average of centers.",
+      "mathContext": "$\\pi(x) = \\frac{\\sum_i \\varphi_i(x) c_i}{\\sum_i \\varphi_i(x)}$, a convex combination of the centers $c_1, \\ldots, c_n$."
     },
     {
       "id": "projection-properties",
       "title": "Properties of the Projection",
       "startLine": 142,
       "endLine": 234,
-      "summary": "Three key properties: continuity on the covered set, image in the convex hull (convex combination), and epsilon-approximation bound."
+      "summary": "Three key properties proved: (1) continuity on $K$ (quotient of continuous functions with positive denominator), (2) image in convex hull (convex combination), (3) $\\varepsilon$-approximation ($\\|\\pi(x) - x\\| < \\varepsilon$ since only nearby centers contribute).",
+      "mathContext": "(1) $\\pi$ continuous on $K$. (2) $\\pi(K) \\subseteq \\text{conv}\\{c_1,\\ldots,c_n\\}$. (3) $\\|\\pi(x) - x\\| < \\varepsilon$ for $x \\in K$."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem",
       "startLine": 235,
       "endLine": 297,
-      "summary": "The Schauder projection lemma: combining compactness (finite subcover), bump function construction, and the three properties."
+      "summary": "The Schauder projection lemma: combines compactness (finite subcover), bump function construction, and the three properties into the complete result.",
+      "mathContext": "For compact $K \\subseteq E$ and $\\varepsilon > 0$: $\\exists$ finitely many $c_i \\in K$ and continuous $\\pi: E \\to \\text{conv}\\{c_i\\}$ with $\\|\\pi(x) - x\\| < \\varepsilon$ on $K$."
     },
     {
       "id": "applications",
       "title": "Applications: Convex Hull Results",
       "startLine": 298,
       "endLine": 315,
-      "summary": "Corollaries: compactness and closedness of convex hulls of finite ranges, resolving a sorry in SchauderFixedPoint.lean."
+      "summary": "Corollaries: compactness and closedness of convex hulls of finite ranges, resolving a sorry in SchauderFixedPoint.lean.",
+      "mathContext": "$f: \\text{Fin}\\,n \\to E \\Rightarrow \\text{conv}(\\text{range}\\,f)$ is compact and closed."
     }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "schauder-fixed-point",
+      "relationship": "used-by",
+      "description": "The projection lemma is the key technical ingredient for the Schauder fixed point theorem"
+    },
+    {
+      "targetId": "brouwer-fixed-point",
+      "relationship": "depends-on",
+      "description": "The Schauder theorem leverages Brouwer's theorem on the finite-dimensional convex hull produced by this projection"
+    }
+  ],
+  "relatedProofs": [
+    "schauder-fixed-point",
+    "brouwer-fixed-point"
   ],
   "conclusion": {
     "summary": "The Schauder projection lemma has been proved completely from first principles, with zero sorries and zero axioms. The proof constructs an explicit partition of unity using bump functions and verifies all required properties: continuity, convex hull membership, and epsilon-approximation.",

--- a/src/data/proofs/szemeredi-counting/meta.json
+++ b/src/data/proofs/szemeredi-counting/meta.json
@@ -84,36 +84,44 @@
   },
   "sections": [
     {
-      "id": "introduction",
+      "id": "preamble",
       "title": "Module Docstring and Imports",
       "startLine": 1,
-      "endLine": 19,
-      "summary": "Overview, imports from Mathlib, namespace and variable declarations for finite vertex type V.",
-      "mathContext": "Setting: $G = (V, E)$ simple graph, $V$ finite with decidable equality."
+      "endLine": 22,
+      "summary": "Module docstring listing Parts I–III (counting lemma, triangle removal, graph removal), references to Ruzsa-Szemerédi (1978) and Komlós-Simonovits (1996). Imports Mathlib and `Proofs.SzemerediRegularity`. Opens `Classical`, declares variables for finite vertex type $V$.",
+      "mathContext": "Setting: $G = (V, E)$ simple graph, $V$ finite with decidable equality. Depends on $\\varepsilon$-regularity from the regularity module."
+    },
+    {
+      "id": "infrastructure",
+      "title": "Neighborhood and Density Infrastructure",
+      "startLine": 24,
+      "endLine": 83,
+      "summary": "Defines `neighborhoodIn G v B` ($N_B(v)$), `badVertices` (vertices with small neighborhoods), `goodVertices` (complement). **Proves** subset and cardinality lemmas, good/bad partition (`good_union_bad`). States `bad_vertices_small`: in an $\\varepsilon$-regular pair with density $\\geq \\varepsilon$, fewer than $\\varepsilon|A|$ vertices have small neighborhoods. Sorry'd.",
+      "mathContext": "$N_B(v) = \\{b \\in B : vb \\in E\\}$. Bad vertices: $\\{a \\in A : |N_B(a)| < (d - \\varepsilon)|B|\\}$. Key lemma: $|\\text{bad}| < \\varepsilon|A|$ for $\\varepsilon$-regular pairs with $d \\geq \\varepsilon$."
     },
     {
       "id": "counting-lemma",
       "title": "Part I: Counting Lemma for Regular Triples",
-      "startLine": 21,
-      "endLine": 51,
-      "summary": "Defines triangleCount and states the counting lemma: triangles in an epsilon-regular triple are bounded below by (d_AB - eps)(d_AC - eps)(d_BC - eps)|A||B||C|. Sorry'd.",
-      "mathContext": "$T(A,B,C) \\geq (d_{AB} - \\varepsilon)(d_{AC} - \\varepsilon)(d_{BC} - \\varepsilon)|A||B||C|$"
+      "startLine": 85,
+      "endLine": 115,
+      "summary": "Defines `triangleCount G A B C` as the number of ordered triples $(a,b,c) \\in A \\times B \\times C$ with all three edges present. States the counting lemma: for $\\varepsilon$-regular pairs with densities $\\geq \\varepsilon$, $T(A,B,C) \\geq (d_{AB} - \\varepsilon)(d_{AC} - \\varepsilon)(d_{BC} - \\varepsilon)|A||B||C|$. Sorry'd.",
+      "mathContext": "$T(A,B,C) \\geq (d_{AB} - \\varepsilon)(d_{AC} - \\varepsilon)(d_{BC} - \\varepsilon)|A||B||C|$ for $\\varepsilon$-regular triples with $d \\geq \\varepsilon$."
     },
     {
       "id": "triangle-removal",
       "title": "Part II: Triangle Removal Lemma",
-      "startLine": 53,
-      "endLine": 86,
-      "summary": "Defines edgeSet and removeEdges, then states the triangle removal lemma: few triangles implies triangle-free after removing few edges. Sorry'd.",
-      "mathContext": "$T(G) \\leq \\gamma n^3 \\Rightarrow \\exists R, |R| \\leq \\delta n^2 \\wedge G \\setminus R$ triangle-free"
+      "startLine": 117,
+      "endLine": 151,
+      "summary": "Defines `edgeSet G` and `removeEdges G R` (symmetric edge removal). States the triangle removal lemma: $\\forall \\delta > 0, \\exists \\gamma > 0$ such that $T(G) \\leq \\gamma n^3 \\Rightarrow$ removable to triangle-free with $\\leq \\delta n^2$ edge deletions. Sorry'd.",
+      "mathContext": "$\\forall \\delta > 0,\\, \\exists \\gamma > 0: T(G) \\leq \\gamma n^3 \\Rightarrow \\exists R \\subseteq E,\\, |R| \\leq \\delta n^2,\\, G \\setminus R$ triangle-free."
     },
     {
       "id": "graph-removal",
       "title": "Part III: General Graph Removal Lemma",
-      "startLine": 88,
-      "endLine": 103,
-      "summary": "Stub for the general graph removal lemma for arbitrary subgraphs H on h >= 3 vertices. Currently only proves existence of gamma > 0 without the full removal property.",
-      "mathContext": "Full statement: $\\forall H$ on $h$ vertices, $\\forall \\delta > 0, \\exists \\gamma > 0$: few copies of $H$ implies cheap removal"
+      "startLine": 153,
+      "endLine": 168,
+      "summary": "States the general graph removal lemma for arbitrary subgraph $H$ on $h \\geq 3$ vertices. Currently a stub proving only $\\exists \\gamma > 0$ without the full removal property. Closes namespace.",
+      "mathContext": "$\\forall H$ on $h$ vertices, $\\forall \\delta > 0, \\exists \\gamma > 0$: $\\text{copies}(H, G) \\leq \\gamma n^h \\Rightarrow$ removable to $H$-free with $\\leq \\delta n^2$ edges."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/szemeredi-regularity/meta.json
+++ b/src/data/proofs/szemeredi-regularity/meta.json
@@ -105,33 +105,41 @@
       "id": "preamble",
       "title": "Preamble",
       "startLine": 1,
-      "endLine": 22,
-      "summary": "Module documentation, Mathlib imports, namespace Szemeredi.Regularity, and variable declarations for finite vertex type V",
-      "mathContext": "Imports `SimpleGraph`, `Finpartition`, `Finset.card` from Mathlib. Sets up namespace `Szemeredi.Regularity` with variables `{V : Type*} [Fintype V] [DecidableEq V]`."
+      "endLine": 20,
+      "summary": "Module docstring listing Parts I–III, references to Szemerédi (1975) and Komlós-Simonovits (1996). Imports Mathlib, opens `Classical`, declares finite vertex type variables.",
+      "mathContext": "Setting: $G = (V, E)$ simple graph with $V$ finite. Namespace `Szemeredi.Regularity` encapsulates all definitions."
     },
     {
       "id": "definitions",
       "title": "Part I: Epsilon-Regular Pairs and Partitions",
-      "startLine": 18,
-      "endLine": 55,
-      "summary": "Core definitions: edge density between vertex subsets, epsilon-regular pair condition, and regular partition (equitable partition with few irregular pairs).",
-      "mathContext": "$(V_i, V_j)$ is $\\varepsilon$-regular if all large sub-pairs have density close to $d(V_i, V_j)$"
+      "startLine": 22,
+      "endLine": 53,
+      "summary": "Defines `edgeDensity G A B` as $|E(A,B)|/(|A||B|)$, `IsEpsilonRegular G eps A B` (all large sub-pairs have density within $\\varepsilon$ of the pair density), and `IsRegularPartition G eps parts` (at most $\\varepsilon \\binom{k}{2}$ irregular pairs).",
+      "mathContext": "$d(A,B) = \\frac{e(A,B)}{|A||B|}$. $(A,B)$ is $\\varepsilon$-regular if $\\forall A' \\subseteq A, B' \\subseteq B$ with $|A'| \\geq \\varepsilon|A|, |B'| \\geq \\varepsilon|B|$: $|d(A',B') - d(A,B)| \\leq \\varepsilon$."
+    },
+    {
+      "id": "density-properties",
+      "title": "Density Properties",
+      "startLine": 55,
+      "endLine": 78,
+      "summary": "**Proved.** Two key density bounds: `edgeDensity_nonneg` ($d(A,B) \\geq 0$) and `edgeDensity_le_one` ($d(A,B) \\leq 1$). Both follow from the definition via `positivity` and `div_le_one`.",
+      "mathContext": "$0 \\leq d(A,B) \\leq 1$ for all $A, B$. The upper bound uses $|\\{(a,b) \\in A \\times B : ab \\in E\\}| \\leq |A||B|$."
     },
     {
       "id": "energy",
       "title": "Part II: Partition Energy and Increment",
-      "startLine": 57,
-      "endLine": 90,
-      "summary": "Partition energy function E(P) and the energy increment step: if too many irregular pairs, refinement increases energy by epsilon^5.",
-      "mathContext": "$E(\\mathcal{P}) = \\frac{1}{k^2}\\sum_{i,j} d(V_i,V_j)^2 \\in [0,1]$, refinement gives $E(\\mathcal{P}') \\geq E(\\mathcal{P}) + \\varepsilon^5$"
+      "startLine": 79,
+      "endLine": 121,
+      "summary": "Defines `partitionEnergy` $E(\\mathcal{P}) = \\frac{1}{k^2}\\sum d(V_i,V_j)^2$. **Proves** non-negativity. States `density_sq_convex` (Cauchy-Schwarz ingredient) and `energy_increment_step` (refinement adds $\\varepsilon^5$). Both sorry'd.",
+      "mathContext": "$E(\\mathcal{P}) = \\frac{1}{k^2}\\sum_{i,j} d(V_i,V_j)^2$. Increment: not $\\varepsilon$-regular $\\Rightarrow \\exists \\mathcal{P}'$ with $E(\\mathcal{P}') \\geq E(\\mathcal{P}) + \\varepsilon^5$ and $|\\mathcal{P}'| \\leq k \\cdot 2^k$."
     },
     {
       "id": "regularity-lemma",
       "title": "Part III: Regularity Lemma (Main Result)",
-      "startLine": 92,
-      "endLine": 115,
-      "summary": "The main Szemeredi Regularity Lemma: for every epsilon > 0, every large graph has an epsilon-regular partition. Proved by iterated energy increment.",
-      "mathContext": "For all $\\varepsilon > 0$, $\\exists M$: every graph on $\\geq M$ vertices has an $\\varepsilon$-regular partition into $\\leq M$ parts"
+      "startLine": 123,
+      "endLine": 186,
+      "summary": "**Proves** `partitionEnergy_le_one` ($E(\\mathcal{P}) \\leq 1$ for valid partitions). States `max_iterations` (termination bound $\\lceil 1/\\varepsilon^5 \\rceil$) and the main `regularity_lemma`: $\\forall \\varepsilon > 0, \\exists M$ such that every graph on $\\geq M$ vertices has an $\\varepsilon$-regular partition into $\\leq M$ parts. Both sorry'd.",
+      "mathContext": "$E \\leq 1$ (proved). Main: $\\forall \\varepsilon > 0, \\exists M(\\varepsilon): n \\geq M \\Rightarrow$ graph has $\\varepsilon$-regular partition into $\\leq M$ parts. Terminates in $\\leq \\lceil \\varepsilon^{-5} \\rceil$ refinement steps."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/szemeredi-theorem/meta.json
+++ b/src/data/proofs/szemeredi-theorem/meta.json
@@ -58,39 +58,60 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring with proof status: k=1,2 trivial, k=3 proved via Mathlib corner theorem chain, k$\\geq$4 axiomatized. Lists what Mathlib provides and what's missing. Imports `Nat.Prime.Basic`, `AP.Three.Defs`, `Corner.Roth`, `Tactic`.",
+      "mathContext": "Szemerédi: $\\forall k, \\delta > 0, \\exists N_0: N \\geq N_0, |S \\cap [N]| \\geq \\delta N \\Rightarrow S$ contains a $k$-AP. Status: proved for $k \\leq 3$, axiomatized for $k \\geq 4$."
+    },
+    {
       "id": "definitions",
       "title": "Arithmetic Progressions",
       "startLine": 40,
       "endLine": 71,
-      "summary": "HasAPOfLength, IsAPFree, and formal theorem statement."
+      "summary": "Defines `HasAPOfLength S k` (set contains $k$-term AP with positive common difference), `IsAPFree S k` (no $k$-AP in $S$), `hasAPOfLengthFinset`, and the formal `SzemerediTheorem` statement.",
+      "mathContext": "$S$ has a $k$-AP: $\\exists a, d > 0, \\{a, a+d, \\ldots, a+(k-1)d\\} \\subseteq S$. Szemerédi: $\\forall k, \\delta > 0, \\exists N_0$: dense subsets of $[N]$ contain a $k$-AP."
     },
     {
       "id": "trivial",
-      "title": "Trivial Cases",
+      "title": "Trivial Cases (k=1,2)",
       "startLine": 73,
-      "endLine": 106,
-      "summary": "k=1 and k=2 proved directly."
+      "endLine": 108,
+      "summary": "**Proved.** `szemeredi_k1`: any nonempty set has a 1-AP. `szemeredi_k2`: any set with $\\geq 2$ elements has a 2-AP (just pick two distinct elements).",
+      "mathContext": "$k=1$: trivial ($\\{a\\}$ is a 1-AP). $k=2$: if $|S| \\geq 2$, pick $a < b \\in S$; then $\\{a, b\\}$ is a 2-AP with $d = b - a$."
+    },
+    {
+      "id": "axiom-k4",
+      "title": "Axiom Reduction (k≥4)",
+      "startLine": 109,
+      "endLine": 126,
+      "summary": "Axiomatizes `szemeredi_k_ge_4`: Szemerédi's theorem for $k \\geq 4$, which requires hypergraph regularity not yet in Mathlib. This is the only axiom in the file.",
+      "mathContext": "Axiom: $\\forall k \\geq 4, \\delta > 0, \\exists N_0: N \\geq N_0, |S| \\geq \\delta N \\Rightarrow S$ has a $k$-AP. Proof requires hypergraph regularity or Furstenberg's ergodic approach."
     },
     {
       "id": "mathlib-connection",
       "title": "Mathlib Connection",
-      "startLine": 128,
+      "startLine": 127,
       "endLine": 186,
-      "summary": "Equivalence between IsAPFree and ThreeAPFree."
+      "summary": "**Proved.** Establishes `threeAPFree_iff_isAPFree`: equivalence between Mathlib's `ThreeAPFree` and our `IsAPFree S 3`. Bridges the two API styles.",
+      "mathContext": "`ThreeAPFree S` $\\iff$ `IsAPFree S 3`. The key step: Mathlib's 3-AP is defined via $x + z = 2y$, ours via $\\{a, a+d, a+2d\\} \\subseteq S$."
     },
     {
       "id": "roth",
-      "title": "Roth's Theorem",
+      "title": "Roth's Theorem (k=3)",
       "startLine": 188,
       "endLine": 271,
-      "summary": "The k=3 case via Mathlib's roth_3ap_theorem_nat."
+      "summary": "**Proved.** Derives `szemeredi_k3` from Mathlib's `roth_3ap_theorem_nat` via the ThreeAPFree equivalence. This is the deepest proved case.",
+      "mathContext": "Roth (1953): $\\forall \\delta > 0, \\exists N_0: |S \\cap [N]| \\geq \\delta N, N \\geq N_0 \\Rightarrow S$ has a 3-AP. Proved in Mathlib via corners $\\to$ triangle removal $\\to$ regularity."
     },
     {
-      "id": "axiom-reduction",
+      "id": "full-theorem",
       "title": "Full Theorem (Proved by Cases)",
       "startLine": 273,
       "endLine": 335,
-      "summary": "Assembles full SzemerediTheorem from k=1,2 density lemmas, k=3 Roth, and k>=4 axiom."
+      "summary": "**Proved.** Assembles `SzemerediTheorem` by case analysis on $k$: $k=1$ (trivial), $k=2$ (trivial), $k=3$ (Roth), $k \\geq 4$ (axiom). The case split uses `Nat.lt_or_ge` to dispatch to the appropriate lemma.",
+      "mathContext": "Full theorem: $\\text{SzemerediTheorem}(k, \\delta) := k \\leq 2 \\to$ trivial $\\mid k = 3 \\to$ Roth $\\mid k \\geq 4 \\to$ axiom. All glued via `Nat.lt_or_ge`."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary

Enrichment pass on 9 gallery entries (quality 98 → 100):

**erdos-776** — Antichains with Set-Size Multiplicity
- Added preamble section, `mathContext` to all sections

**kummer-theorem** — Kummer's Theorem on Binomial Coefficients
- Added preamble and applications sections for full file coverage
- Added `prerequisites` to all 12 annotations

**lhopital** — L'Hopital's Rule
- Extended zero-form section to cover atBot variant, added verification section
- Added atBot annotation, `relatedProofs`

**prob-method-alteration** — Alteration Method
- Fixed all section/annotation line ranges (off by 10-30 lines)

**prob-method-second-moment** — Second Moment Method
- Fixed annotation line ranges (some off by 80+ lines)
- Added helper-lemmas section, replaced incorrect sorry claim

**ramseys-theorem** — Ramsey's Theorem
- Added 4 sections (preamble, embedding, pentagon-coloring, multicolor)
- Added mathContext to 3 annotations, crossReferences

**russell-1-plus-1** — Russell's 1+1=2
- Added mathContext to all 8 sections and 5 annotations
- Extended sections to cover full 197-line file

**szemeredi-counting** — Counting and Removal Lemma
- Fixed all section line ranges, added infrastructure section

**szemeredi-regularity** — Regularity Lemma
- Fixed section line ranges, added density-properties section

🤖 Generated with [Claude Code](https://claude.com/claude-code)