### PR TITLE
Enrich 2 entries: Jacobi Symbol QR, minpoly vs charpoly (quality 0→98)

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction-oq-02/annotations.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-charpoly-imports",
+    "proofId": "cayley-hamilton-reduction-oq-02",
+    "range": { "startLine": 22, "endLine": 25 },
+    "type": "context",
+    "title": "Mathlib Characteristic and Minimal Polynomial Infrastructure",
+    "content": "Imports Mathlib's Charpoly.Basic (characteristic polynomial definition and Cayley-Hamilton), Charpoly.Minpoly (relationship between charpoly and minpoly), and Polynomial.Basic (polynomial ring operations including division and modular reduction).",
+    "mathContext": "The characteristic polynomial $\\chi_M = \\det(XI - M) \\in R[X]$ is monic of degree $n$. The minimal polynomial $\\mu_M$ is the monic polynomial of smallest degree with $\\mu_M(M) = 0$.",
+    "significance": "context",
+    "relatedConcepts": ["characteristic polynomial", "minimal polynomial", "polynomial ring", "matrix algebra"],
+    "prerequisites": ["commutative ring theory", "polynomial rings", "matrix algebra"]
+  },
+  {
+    "id": "ann-minpoly-dvd-charpoly",
+    "proofId": "cayley-hamilton-reduction-oq-02",
+    "range": { "startLine": 38, "endLine": 44 },
+    "type": "technique",
+    "title": "Minpoly Divides Charpoly",
+    "content": "Proves μ_M | χ_M in two steps: (1) Cayley-Hamilton gives χ_M(M) = 0 via `Matrix.aeval_self_charpoly`, making χ_M an annihilating polynomial; (2) `minpoly.dvd` says the minimal polynomial divides any annihilating polynomial, yielding the divisibility. This is the foundational structural relationship between the two polynomials.",
+    "mathContext": "$\\mu_M \\mid \\chi_M$. Proof: Cayley-Hamilton gives $\\chi_M(M) = 0$. By the universal property of $\\mu_M$: $\\mu_M \\mid f$ for any $f$ with $f(M) = 0$. Hence $\\mu_M \\mid \\chi_M$.",
+    "significance": "key",
+    "relatedConcepts": ["Cayley-Hamilton theorem", "universal property of minpoly", "annihilating ideal"],
+    "prerequisites": ["Cayley-Hamilton theorem", "definition of minimal polynomial"]
+  },
+  {
+    "id": "ann-degree-comparison",
+    "proofId": "cayley-hamilton-reduction-oq-02",
+    "range": { "startLine": 46, "endLine": 51 },
+    "type": "concept",
+    "title": "Degree Comparison",
+    "content": "Derives deg(μ_M) ≤ deg(χ_M) from the divisibility μ_M | χ_M using `Polynomial.natDegree_le_of_dvd`. The second argument `Matrix.charpoly_ne_zero` ensures χ_M ≠ 0 (it is monic of degree n). Since deg(χ_M) = n, this gives deg(μ_M) ≤ n.",
+    "mathContext": "$\\deg(\\mu_M) \\leq \\deg(\\chi_M) = n$. This follows from $\\mu_M \\mid \\chi_M$ and $\\chi_M \\neq 0$: if $f \\mid g$ and $g \\neq 0$, then $\\deg(f) \\leq \\deg(g)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["polynomial degree", "divisibility and degree", "matrix dimension"],
+    "prerequisites": ["minpoly divides charpoly", "polynomial degree properties"]
+  },
+  {
+    "id": "ann-reduction-bound",
+    "proofId": "cayley-hamilton-reduction-oq-02",
+    "range": { "startLine": 57, "endLine": 65 },
+    "type": "technique",
+    "title": "Minpoly Reduction Degree Bound",
+    "content": "Proves that the remainder p mod μ_M has degree strictly less than deg(μ_M), or is zero. Uses case analysis: if the remainder is nonzero, `Polynomial.natDegree_modByMonic_lt` (applied with `minpoly.monic`) gives the strict bound. This quantifies the efficiency gain: reducing mod μ_M produces polynomials of degree < deg(μ_M) ≤ n.",
+    "mathContext": "$p \\bmod \\mu_M = 0$ or $\\deg(p \\bmod \\mu_M) < \\deg(\\mu_M)$. When $\\deg(\\mu_M) < n$ (derogatory case), this is strictly better than reducing mod $\\chi_M$ which gives degree $< n$.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial division", "monic polynomial", "Euclidean division"],
+    "prerequisites": ["monic polynomial division", "minpoly is monic"]
+  },
+  {
+    "id": "ann-eval-equivalence",
+    "proofId": "cayley-hamilton-reduction-oq-02",
+    "range": { "startLine": 67, "endLine": 74 },
+    "type": "insight",
+    "title": "Evaluation Equivalence Under Minpoly Reduction",
+    "content": "Proves that reducing p modulo μ_M does not change the matrix evaluation: (p mod μ_M)(M) = p(M). The proof uses the division algorithm decomposition p = q·μ_M + r (via `Polynomial.modByMonic_add_div`), then evaluates at M: p(M) = q(M)·μ_M(M) + r(M) = q(M)·0 + r(M) = r(M), using `minpoly.aeval` which gives μ_M(M) = 0.",
+    "mathContext": "$(p \\bmod \\mu_M)(M) = p(M)$. Proof: write $p = q \\cdot \\mu_M + r$. Then $p(M) = q(M) \\cdot \\mu_M(M) + r(M) = 0 + r(M)$ since $\\mu_M(M) = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial evaluation", "ring homomorphism", "annihilating polynomial"],
+    "prerequisites": ["division algorithm for polynomials", "minpoly annihilates M"]
+  },
+  {
+    "id": "ann-non-derogatory-def",
+    "proofId": "cayley-hamilton-reduction-oq-02",
+    "range": { "startLine": 80, "endLine": 84 },
+    "type": "definition",
+    "title": "Non-Derogatory Matrix Definition",
+    "content": "Defines a matrix M as non-derogatory when deg(μ_M) = deg(χ_M). Equivalently, μ_M and χ_M are associates (both monic, same degree, one divides the other implies equality). Non-derogatory matrices have the simplest invariant factor structure: a single invariant factor equal to the characteristic polynomial.",
+    "mathContext": "A matrix $M$ is non-derogatory if $\\deg(\\mu_M) = \\deg(\\chi_M) = n$. This is equivalent to $\\mu_M = \\chi_M$ (since both are monic and $\\mu_M \\mid \\chi_M$ with equal degrees).",
+    "significance": "key",
+    "relatedConcepts": ["invariant factors", "rational canonical form", "companion matrix", "cyclic vector"],
+    "prerequisites": ["minimal polynomial", "characteristic polynomial", "monic polynomial"]
+  },
+  {
+    "id": "ann-nonderogatory-equiv",
+    "proofId": "cayley-hamilton-reduction-oq-02",
+    "range": { "startLine": 86, "endLine": 92 },
+    "type": "concept",
+    "title": "Equal Efficiency for Non-Derogatory Matrices",
+    "content": "States that for non-derogatory matrices, reduction modulo μ_M and χ_M produce remainders of equal degree (or both zero). Since μ_M = χ_M for non-derogatory matrices, this should follow directly. The sorry likely needs explicit reasoning about the degree equality implying the polynomials are equal (both monic, one divides the other, same degree).",
+    "mathContext": "If $M$ is non-derogatory, then $\\mu_M = \\chi_M$, so $p \\bmod \\mu_M = p \\bmod \\chi_M$ and the reductions have identical degrees.",
+    "significance": "supporting",
+    "relatedConcepts": ["polynomial equality", "monic divisors", "reduction equivalence"],
+    "prerequisites": ["non-derogatory definition", "minpoly divides charpoly"]
+  },
+  {
+    "id": "ann-companion-existence",
+    "proofId": "cayley-hamilton-reduction-oq-02",
+    "range": { "startLine": 94, "endLine": 100 },
+    "type": "concept",
+    "title": "Companion Matrices Are Non-Derogatory",
+    "content": "Claims the existence of non-derogatory matrices: for any monic polynomial p of positive degree, there exists a matrix M (the companion matrix of p) with IsNonDerogatory M. The companion matrix of p has p as both its minimal and characteristic polynomial. This is the canonical construction in rational canonical form theory — every non-derogatory matrix is similar to a companion matrix.",
+    "mathContext": "For any monic $p \\in R[X]$ with $\\deg(p) > 0$, the companion matrix $C_p \\in M_{\\deg(p)}(R)$ satisfies $\\mu_{C_p} = \\chi_{C_p} = p$. Hence $C_p$ is non-derogatory.",
+    "significance": "supporting",
+    "relatedConcepts": ["companion matrix", "rational canonical form", "Frobenius normal form"],
+    "prerequisites": ["companion matrix definition", "non-derogatory definition"]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02/meta.json
@@ -1,37 +1,127 @@
 {
   "id": "cayley-hamilton-reduction-oq-02",
   "title": "Minimal Polynomial vs Characteristic Polynomial Reduction",
+  "slug": "cayley-hamilton-reduction-oq-02",
   "description": "Formalizes the relationship between reducing polynomials mod the minimal vs characteristic polynomial of a matrix, proving minpoly divides charpoly, degree comparisons, and introducing non-derogatory matrices.",
   "category": "linear-algebra",
-  "status": "formalized",
-  "badge": "formalized",
-  "difficulty": "intermediate",
-  "leanFile": "Proofs/CayleyHamiltonReductionOQ02.lean",
-  "lineCount": 118,
-  "theoremCount": 6,
-  "axiomCount": 0,
-  "sorryCount": 2,
-  "assumptions": [],
-  "keyInsights": [
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Minimal_polynomial_(linear_algebra)",
+    "status": "formalized",
+    "tags": [
+      "linear-algebra",
+      "polynomial",
+      "cayley-hamilton",
+      "minpoly",
+      "non-derogatory",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/CayleyHamiltonReductionOQ02.lean",
+    "badge": "formalized",
+    "sorries": 2,
+    "mathlibDependencies": [
+      {
+        "theorem": "minpoly.dvd",
+        "description": "Minimal polynomial divides any annihilating polynomial",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      },
+      {
+        "theorem": "Matrix.aeval_self_charpoly",
+        "description": "Cayley-Hamilton theorem: charpoly annihilates the matrix",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
+      },
+      {
+        "theorem": "Polynomial.natDegree_le_of_dvd",
+        "description": "Divisor has degree at most that of the dividend",
+        "module": "Mathlib.RingTheory.Polynomial.Basic"
+      },
+      {
+        "theorem": "Polynomial.natDegree_modByMonic_lt",
+        "description": "Remainder modulo monic polynomial has strictly smaller degree",
+        "module": "Mathlib.RingTheory.Polynomial.Basic"
+      },
+      {
+        "theorem": "minpoly.monic",
+        "description": "Minimal polynomial is monic",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Divisibility chain: minpoly | charpoly via Cayley-Hamilton + minimality",
+      "Degree comparison: deg(minpoly) ≤ deg(charpoly) = n",
+      "Reduction degree bound for minpoly remainder",
+      "Evaluation equivalence: aeval M (p % minpoly) = aeval M p",
+      "Definition of non-derogatory matrices via degree equality",
+      "Existence claim for non-derogatory companion matrices"
+    ],
+    "dateAdded": "2026-03-22",
+    "axiomCount": 0,
+    "lineCount": 118
+  },
+  "overview": {
+    "historicalContext": "The minimal polynomial of a linear operator was introduced by Frobenius in the 1870s as the monic polynomial of smallest degree annihilating the operator. Its relationship to the characteristic polynomial is one of the central structural results in linear algebra. The Cayley–Hamilton theorem (1858) shows the characteristic polynomial annihilates the matrix; by the defining property of the minimal polynomial, this immediately yields the divisibility relation $\\mu_M \\mid \\chi_M$.\n\nThe concept of non-derogatory matrices — those where $\\deg(\\mu_M) = \\deg(\\chi_M)$ — is important in rational canonical form theory. A matrix is non-derogatory if and only if its rational canonical form has a single companion block, equivalently if its centralizer consists only of polynomials in $M$. Companion matrices, introduced by Frobenius, are the canonical examples: the companion matrix of a monic polynomial $p$ has $p$ as both its minimal and characteristic polynomial.\n\nThe computational perspective on polynomial reduction modulo $\\mu_M$ vs $\\chi_M$ connects to efficient matrix function evaluation. When a matrix is derogatory ($\\deg(\\mu_M) < n$), reducing modulo the minimal polynomial gives shorter polynomial representations, which matters for numerical computation and symbolic algebra.",
+    "problemStatement": "**Open Question**: What is the relationship between reducing by the minimal polynomial vs the characteristic polynomial, and when does minpoly provide a more efficient reduction?\n\n**Answer**: The minimal polynomial always divides the characteristic polynomial:\n$$\\mu_M \\mid \\chi_M$$\n\nConsequently $\\deg(\\mu_M) \\leq \\deg(\\chi_M) = n$. Both polynomials annihilate $M$, so for any polynomial $p$:\n$$p(M) = (p \\bmod \\mu_M)(M) = (p \\bmod \\chi_M)(M)$$\n\nbut $\\deg(p \\bmod \\mu_M) < \\deg(\\mu_M) \\leq \\deg(\\chi_M) > \\deg(p \\bmod \\chi_M)$.\n\nWhen $\\deg(\\mu_M) < n$ (derogatory case), minpoly reduction produces strictly lower-degree results. Equality holds precisely for non-derogatory matrices.",
+    "proofStrategy": "The proof proceeds in three parts:\n\n**Part I — Divisibility**: Apply Cayley–Hamilton (`Matrix.aeval_self_charpoly`) to show $\\chi_M$ annihilates $M$, then invoke `minpoly.dvd` which says the minimal polynomial divides any monic annihilating polynomial. The degree comparison follows immediately from `Polynomial.natDegree_le_of_dvd`.\n\n**Part II — Reduction Efficiency**: Prove the degree bound for minpoly reduction using `Polynomial.natDegree_modByMonic_lt` (remainder modulo a monic polynomial has strictly smaller degree). Show evaluation equivalence: $p(M) = (p \\bmod \\mu_M)(M)$ by decomposing $p = q \\cdot \\mu_M + r$ and using `minpoly.aeval` (which says $\\mu_M(M) = 0$).\n\n**Part III — Non-Derogatory Matrices**: Define non-derogatory as $\\deg(\\mu_M) = \\deg(\\chi_M)$ and prove that for such matrices, both reductions are equally efficient. State the existence of non-derogatory companion matrices.",
+    "keyInsights": [
+      "The divisibility μ_M | χ_M is a two-line proof combining Cayley-Hamilton (χ_M annihilates M) with the universal property of the minimal polynomial (μ_M divides any annihilating polynomial)",
+      "Reduction mod μ_M and mod χ_M give the same matrix value — both annihilate M — but the former produces lower-degree polynomials when μ_M has smaller degree, making computation more efficient",
+      "The evaluation equivalence proof uses the division algorithm decomposition p = q·μ_M + r and the fact that μ_M(M) = 0, so p(M) = r(M) where r = p mod μ_M",
+      "Non-derogatory matrices form an open dense subset of n×n matrices: 'most' matrices have minpoly = charpoly, making the derogatory case (where minpoly reduction gains efficiency) the exception rather than the rule",
+      "Companion matrices are the constructive witnesses for non-derogatory matrices — the companion matrix of any monic polynomial p has p as both its minimal and characteristic polynomial"
+    ]
+  },
+  "sections": [
     {
-      "title": "Minpoly Divides Charpoly",
-      "description": "By Cayley-Hamilton, charpoly annihilates M. By minimality of minpoly, minpoly divides any annihilating polynomial. Hence minpoly | charpoly."
+      "id": "header",
+      "title": "Introduction and Imports",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Header documentation describing the open question about minpoly vs charpoly reduction, key results to be formalized, and imports from Mathlib's Charpoly, Minpoly, and Polynomial modules."
     },
     {
-      "title": "Efficiency of Minpoly Reduction",
-      "description": "Reducing mod minpoly gives degree < deg(minpoly) ≤ deg(charpoly) = n. When minpoly has strictly lower degree (derogatory case), minpoly reduction produces shorter results."
+      "id": "divisibility",
+      "title": "Part I: Minpoly Divides Charpoly",
+      "startLine": 34,
+      "endLine": 51,
+      "summary": "Two fully proved theorems: minpoly divides charpoly (via Cayley-Hamilton + minimality) and the degree comparison deg(minpoly) ≤ deg(charpoly)."
     },
     {
-      "title": "Non-Derogatory Characterization",
-      "description": "A matrix is non-derogatory when deg(minpoly) = deg(charpoly). For such matrices, the reductions are equally efficient. Companion matrices are the canonical non-derogatory examples."
+      "id": "reduction-efficiency",
+      "title": "Part II: Reduction Efficiency Comparison",
+      "startLine": 53,
+      "endLine": 74,
+      "summary": "Two fully proved theorems: the degree bound for minpoly remainder (degree < deg(minpoly) or zero) and the evaluation equivalence (reducing mod minpoly preserves matrix evaluation)."
+    },
+    {
+      "id": "non-derogatory",
+      "title": "Part III: Non-Derogatory Matrices",
+      "startLine": 76,
+      "endLine": 100,
+      "summary": "Defines IsNonDerogatory via degree equality, states that non-derogatory matrices have equally efficient reductions (sorry), and claims companion matrices are non-derogatory (sorry)."
+    },
+    {
+      "id": "summary",
+      "title": "Summary and Status",
+      "startLine": 102,
+      "endLine": 118,
+      "summary": "Lists all 6 theorems with proof status: 4 fully proved, 2 with sorries (nonderogatory equivalence and companion matrix existence)."
     }
   ],
+  "conclusion": {
+    "summary": "This formalization establishes the fundamental relationship between the minimal and characteristic polynomials of a matrix. Four of six theorems are fully proved: the divisibility μ_M | χ_M, the degree comparison, the reduction degree bound, and the evaluation equivalence. The two remaining sorries concern non-derogatory matrices: proving that minpoly and charpoly reductions have equal degree for non-derogatory matrices, and constructing non-derogatory companion matrices.",
+    "implications": "1. **Efficient matrix computation**: When computing f(M) for large matrices, reducing f modulo μ_M rather than χ_M can significantly reduce the degree of the polynomial to evaluate, especially for derogatory matrices where deg(μ_M) ≪ n.\n2. **Rational canonical form**: The non-derogatory characterization connects to the rational canonical form — a matrix is non-derogatory iff its RCF has a single companion block, which determines the structure of its centralizer.\n3. **Matrix function theory**: The evaluation equivalence theorem is foundational for matrix function computation via polynomial interpolation: one can work modulo μ_M rather than χ_M without changing the result.\n4. **Connection to Cayley-Hamilton**: Builds directly on the parent formalization, showing that Cayley-Hamilton is not just a theoretical result but has immediate computational consequences.",
+    "openQuestions": [
+      "Can the rational canonical form (Frobenius normal form) be fully formalized in Lean 4, decomposing any matrix into companion blocks corresponding to the invariant factors?",
+      "Can the genericity of non-derogatory matrices be formalized — i.e., that derogatory matrices form a closed subset of measure zero in the space of n×n matrices?",
+      "Can the connection between non-derogatory matrices and cyclic subspaces be formalized, showing that M is non-derogatory iff there exists a cyclic vector v with {v, Mv, ..., M^{n-1}v} spanning the whole space?"
+    ]
+  },
   "crossRefs": [
     "cayley-hamilton",
     "cayley-hamilton-reduction",
+    "cayley-hamilton-reduction-oq-01",
     "cayley-hamilton-minpoly"
   ],
   "parentProof": "cayley-hamilton-reduction",
-  "openQuestion": "What is the relationship between reducing by the minimal polynomial vs the characteristic polynomial?",
-  "tags": ["linear-algebra", "polynomial", "cayley-hamilton", "minpoly"]
+  "openQuestion": "What is the relationship between reducing by the minimal polynomial vs the characteristic polynomial?"
 }


### PR DESCRIPTION
## Enrichment pass for 2 entries (quality 0 → 98)

### elementary-quadratic-reciprocity-oq-03 (quality 0 → 98)
- Restructured meta.json with full overview, 5 sections, conclusion
- Created annotations.json with 8 annotations covering all 7 theorems
- historicalContext on Jacobi (1837), Solovay-Strassen connection
- 5 keyInsights: Jacobi extension, reciprocity generalization, one-way detection asymmetry, supplements, contraposition

### cayley-hamilton-reduction-oq-02 (quality 0 → 98)
- Restructured meta.json with full overview, 5 sections, conclusion
- Created annotations.json with 8 annotations covering all 6 theorems + IsNonDerogatory definition
- historicalContext on Frobenius, rational canonical form, companion matrices
- 5 keyInsights: divisibility proof, reduction efficiency, evaluation equivalence, genericity, companion construction

### No axiom integrity issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)