### PR TITLE
Enrich 3 entries: fix annotation types, axiom integrity (quality 98→100)

### DIFF
--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -67,7 +67,7 @@
       "id": "preamble",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 18,
+      "endLine": 19,
       "summary": "Documentation header describing the alteration/deletion method and its key results (alteration principle, independent set bound, Property B). Imports Mathlib, opens `ProbMethod.Alteration` namespace and `Finset BigOperators`.",
       "mathContext": "The alteration method is a refinement of the probabilistic method: construct a random object, then deterministically remove violations to obtain a valid structure."
     },
@@ -75,7 +75,7 @@
       "id": "alteration-principle",
       "title": "Alteration Principle",
       "startLine": 20,
-      "endLine": 38,
+      "endLine": 39,
       "summary": "Core theorem `alteration_principle`: if the $\\mathbb{Z}$-valued sum of `good` minus `bad` over a nonempty `Finset` is positive, then some element has positive net good value. Proved by contradiction using `Finset.sum_le_sum` and `linarith`.",
       "mathContext": "For functions $\\text{good}, \\text{bad} : \\alpha \\to \\mathbb{N}$ on a nonempty finite set $S$, if $\\sum_{a \\in S} (\\text{good}(a) : \\mathbb{Z}) - \\sum_{a \\in S} (\\text{bad}(a) : \\mathbb{Z}) > 0$, then $\\exists a \\in S$ with $\\text{good}(a) > \\text{bad}(a)$."
     },
@@ -83,7 +83,7 @@
       "id": "independent-set-bound",
       "title": "Independent Set Bound via Alteration",
       "startLine": 40,
-      "endLine": 50,
+      "endLine": 51,
       "summary": "Application to regular graphs: proves existence of a positive integer $k \\geq \\lfloor n/(2d) \\rfloor$ for a $d$-regular graph on $n$ vertices, as a simplified form of $\\alpha(G) \\geq n/(2d)$.",
       "mathContext": "For a $d$-regular graph on $n$ vertices: $\\alpha(G) \\geq \\frac{n}{2d}$. Select each vertex with probability $p = 1/d$, delete one endpoint per surviving edge. Expected independent set size $\\geq np - \\frac{nd}{2}p^2 = \\frac{n}{2d}$."
     },

--- a/src/data/proofs/ramseys-theorem/annotations.json
+++ b/src/data/proofs/ramseys-theorem/annotations.json
@@ -10,7 +10,7 @@
     "title": "Edge Coloring",
     "content": "An EdgeColoring assigns a Boolean color (true = red, false = blue) to each pair of distinct vertices. The color function must be symmetric and irreflexive.",
     "mathContext": "This represents a 2-coloring of the complete graph K_n where every edge is colored either red or blue.",
-    "significance": "critical",
+    "significance": "key",
     "prerequisites": ["graphs", "complete-graphs"],
     "relatedConcepts": ["graph-coloring", "ramsey-numbers"]
   },
@@ -25,7 +25,7 @@
     "title": "Ramsey Property",
     "content": "A type α has the Ramsey property (r,s) if every edge coloring of K_α contains either a red r-clique or a blue s-clique.",
     "mathContext": "This formalizes the statement that R(r,s) exists: for some n, every 2-coloring of K_n has the required monochromatic clique.",
-    "significance": "critical",
+    "significance": "key",
     "prerequisites": ["cliques", "edge-colorings"],
     "relatedConcepts": ["ramsey-numbers", "pigeonhole-principle"]
   },
@@ -36,7 +36,7 @@
       "startLine": 110,
       "endLine": 113
     },
-    "type": "theorem",
+    "type": "concept",
     "title": "R(1, s) = 1",
     "content": "Any nonempty type has a red 1-clique: just pick any vertex. A single vertex trivially forms a clique since there are no pairs to check.",
     "mathContext": "$R(1,s) = 1$ for all $s$: a single vertex is a trivial $K_1$ in any color. This is the base case for the induction on $r + s$.",
@@ -51,11 +51,11 @@
       "startLine": 178,
       "endLine": 192
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "Neighborhood Partition",
     "content": "The red and blue neighborhoods of a vertex v partition all other vertices. Every vertex w ≠ v is either in v's red neighborhood (red edge to v) or blue neighborhood (blue edge to v).",
     "mathContext": "This is the key structural observation: after removing v, the remaining vertices split cleanly by edge color to v.",
-    "significance": "critical",
+    "significance": "key",
     "prerequisites": ["neighborhoods", "partition"],
     "relatedConcepts": ["pigeonhole-principle", "induction"]
   },
@@ -66,11 +66,11 @@
       "startLine": 213,
       "endLine": 229
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "Red Clique Extension",
     "content": "If s is a red clique contained in v's red neighborhood and v ∉ s, then (insert v s) is also a red clique. The new edges from v to s are all red by definition of red neighborhood.",
     "mathContext": "If $S \\subseteq N_{\\text{red}}(v)$ is a red $K_r$ and $v \\notin S$, then $S \\cup \\{v\\}$ is a red $K_{r+1}$. Key: all edges $\\{v, w\\}$ for $w \\in S$ are red since $S \\subseteq N_{\\text{red}}(v)$.",
-    "significance": "critical",
+    "significance": "key",
     "prerequisites": ["clique-definition", "neighborhood"],
     "relatedConcepts": ["induction-step", "clique-growth"]
   },
@@ -96,11 +96,11 @@
       "startLine": 291,
       "endLine": 447
     },
-    "type": "theorem",
+    "type": "technique",
     "title": "Ramsey's Theorem",
     "content": "For any r, s ≥ 1, there exists n ≥ 1 such that any 2-coloring of K_n contains a red r-clique or blue s-clique. The proof uses strong induction on r + s.",
     "mathContext": "This is Wiedijk #31: the existence of Ramsey numbers for 2-colorings of complete graphs.",
-    "significance": "critical",
+    "significance": "key",
     "prerequisites": ["base-cases", "neighborhood-partition", "clique-extension", "pigeonhole-principle"],
     "relatedConcepts": ["ramsey-theory", "combinatorics", "graph-theory"]
   },

--- a/src/data/proofs/ramseys-theorem/meta.json
+++ b/src/data/proofs/ramseys-theorem/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Frank P. Ramsey (formalized by LeanGenius)",
     "date": "1930",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/RamseysTheorem.lean",
     "tags": [
       "combinatorics",
@@ -15,7 +15,7 @@
       "pigeonhole",
       "classic"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -62,7 +62,8 @@
       "The pigeonhole principle: n-1 vertices partitioned into two sets means at least one is large enough",
       "Neighborhood partition: v's neighbors are either red-connected or blue-connected to v",
       "Clique extension: adding v to a clique in its monochromatic neighborhood preserves the clique property",
-      "The recurrence R(r,s) ≤ R(r-1,s) + R(r,s-1) mirrors Pascal's identity for binomial coefficients"
+      "The recurrence R(r,s) ≤ R(r-1,s) + R(r,s-1) mirrors Pascal's identity for binomial coefficients",
+      "The pentagon coloring of K_5 gives a constructive lower bound R(3,3) > 5: both the cycle C_5 (red) and its complement (blue) are triangle-free, so no monochromatic K_3 exists"
     ]
   },
   "sections": [


### PR DESCRIPTION
## Enrichment pass for 3 entries (quality 98 → 100)

### kummer-theorem
- Fixed annotation types: `"example"` → `"context"`, `"theorem"` → `"technique"`/`"concept"`
- Fixed significance `"critical"` → `"key"` (2 annotations)
- Added 5th keyInsight on fractal structure of Pascal's triangle mod p

### prob-method-alteration
- Made section line ranges contiguous: 1-19, 20-39, 40-51, 52-61

### ramseys-theorem
- **Axiom integrity fix**: `status` "verified" → "axiomatized", `badge` "original" → "axiom" (file has `axiom multicolor_ramsey_exists` at line 621, so cannot be "verified")
- Fixed annotation types: `"theorem"` → `"technique"`/`"concept"` (4 annotations)
- Fixed significance `"critical"` → `"key"` (5 annotations)
- Added 5th keyInsight on pentagon coloring lower bound R(3,3) > 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)