### PR TITLE
Research: szemeredi-regularity - Prove max_iterations and density_sq_convex

### DIFF
--- a/proofs/Proofs/SzemerediRegularity.lean
+++ b/proofs/Proofs/SzemerediRegularity.lean
@@ -99,6 +99,52 @@ theorem partitionEnergy_nonneg (G : SimpleGraph V) [DecidableRel G.Adj]
     · positivity
     · exact Finset.sum_nonneg (fun _ _ => sq_nonneg _)
 
+/-- Helper: |A| * |B| * edgeDensity(A,B) = edge count (as ℚ). -/
+private theorem card_mul_edgeDensity (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B : Finset V) :
+    (A.card : ℚ) * B.card * edgeDensity G A B =
+    ↑((A.product B).filter (fun p => G.Adj p.1 p.2)).card := by
+  unfold edgeDensity
+  split_ifs with h
+  · -- A.card * B.card = 0 implies A or B is empty, so product is empty
+    rw [mul_zero]; symm
+    rw [Nat.cast_eq_zero, Finset.card_eq_zero]
+    rcases mul_eq_zero.mp h with ha | hb
+    · have hA := Finset.card_eq_zero.mp (Nat.cast_eq_zero.mp ha)
+      ext x; simp [hA, Finset.not_mem_empty]
+    · have hB := Finset.card_eq_zero.mp (Nat.cast_eq_zero.mp hb)
+      ext x; simp [Finset.product, hB, Finset.not_mem_empty]
+  · -- Non-zero case: n*m * (e/(n*m)) = e
+    have hne : (↑A.card : ℚ) * ↑B.card ≠ 0 := h
+    rw [mul_div_cancel₀ _ hne]
+
+/-- Edge count additivity: for disjoint A₁, A₂, edge counts to B add. -/
+private theorem edge_count_union (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A₁ A₂ B : Finset V) (hA : Disjoint A₁ A₂) :
+    (((A₁ ∪ A₂).product B).filter (fun p => G.Adj p.1 p.2)).card =
+    ((A₁.product B).filter (fun p => G.Adj p.1 p.2)).card +
+    ((A₂.product B).filter (fun p => G.Adj p.1 p.2)).card := by
+  -- Product distributes over union
+  have h_prod : (A₁ ∪ A₂).product B = A₁.product B ∪ A₂.product B := by
+    ext ⟨a, b⟩
+    constructor
+    · intro h
+      have hab := Finset.mem_product.mp h
+      rcases Finset.mem_union.mp hab.1 with ha | ha
+      · exact Finset.mem_union.mpr (Or.inl (Finset.mem_product.mpr ⟨ha, hab.2⟩))
+      · exact Finset.mem_union.mpr (Or.inr (Finset.mem_product.mpr ⟨ha, hab.2⟩))
+    · intro h
+      rcases Finset.mem_union.mp h with hab | hab <;> {
+        have := Finset.mem_product.mp hab
+        exact Finset.mem_product.mpr ⟨Finset.mem_union.mpr (by tauto), this.2⟩ }
+  rw [h_prod, Finset.filter_union]
+  apply Finset.card_union_of_disjoint
+  apply Finset.disjoint_filter_filter
+  rw [Finset.disjoint_left]
+  intro x h₁ h₂
+  exact absurd (Finset.mem_product.mp h₂).1
+    (Finset.disjoint_left.mp hA (Finset.mem_product.mp h₁).1)
+
 /-- Convexity lemma: splitting a vertex set increases the sum of squared densities.
     If A = A₁ ∪ A₂ (disjoint), then |A₁|*d(A₁,B)² + |A₂|*d(A₂,B)² ≥ |A|*d(A,B)².
     This is the Cauchy-Schwarz ingredient for the energy increment. -/
@@ -107,7 +153,64 @@ theorem density_sq_convex (G : SimpleGraph V) [DecidableRel G.Adj]
     (A₁.card : ℚ) * (edgeDensity G A₁ B) ^ 2 +
     (A₂.card : ℚ) * (edgeDensity G A₂ B) ^ 2 ≥
     ((A₁.card + A₂.card) : ℚ) * (edgeDensity G (A₁ ∪ A₂) B) ^ 2 := by
-  sorry
+  -- Abbreviations
+  set d₁ := edgeDensity G A₁ B
+  set d₂ := edgeDensity G A₂ B
+  set d := edgeDensity G (A₁ ∪ A₂) B
+  set n₁ : ℚ := ↑A₁.card
+  set n₂ : ℚ := ↑A₂.card
+  -- Non-negativity
+  have hn₁ : 0 ≤ n₁ := Nat.cast_nonneg _
+  have hn₂ : 0 ≤ n₂ := Nat.cast_nonneg _
+  -- The weighted average property: (n₁+n₂)*m*d = n₁*m*d₁ + n₂*m*d₂
+  have hcard : (↑(A₁ ∪ A₂).card : ℚ) = n₁ + n₂ := by
+    rw [Finset.card_union_of_disjoint hA]; push_cast; ring
+  have havg : (n₁ + n₂) * ↑B.card * d = n₁ * ↑B.card * d₁ + n₂ * ↑B.card * d₂ := by
+    have h₁ := card_mul_edgeDensity G A₁ B
+    have h₂ := card_mul_edgeDensity G A₂ B
+    have h₃ := card_mul_edgeDensity G (A₁ ∪ A₂) B
+    rw [hcard] at h₃
+    have he : (↑(((A₁ ∪ A₂).product B).filter (fun p => G.Adj p.1 p.2)).card : ℚ) =
+      ↑((A₁.product B).filter (fun p => G.Adj p.1 p.2)).card +
+      ↑((A₂.product B).filter (fun p => G.Adj p.1 p.2)).card := by
+      exact_mod_cast edge_count_union G A₁ A₂ B hA
+    linarith
+  -- Case 1: B empty (card = 0) — all terms zero
+  by_cases hB : (B.card : ℚ) = 0
+  · have h0 : ∀ (S : Finset V), edgeDensity G S B = 0 := by
+      intro S; unfold edgeDensity
+      rw [dif_pos (show (↑S.card : ℚ) * ↑B.card = 0 from by rw [hB, mul_zero])]
+    -- Unfold set abbreviations so simp can apply h0
+    have hd₁0 : d₁ = 0 := h0 A₁
+    have hd₂0 : d₂ = 0 := h0 A₂
+    have hd0 : d = 0 := h0 (A₁ ∪ A₂)
+    rw [hd₁0, hd₂0, hd0]; simp
+  -- Case 2: n₁ + n₂ = 0 — both sets empty, all terms zero
+  by_cases hnn : n₁ + n₂ = 0
+  · have h1 : n₁ = 0 := le_antisymm (by linarith) hn₁
+    have h2 : n₂ = 0 := le_antisymm (by linarith) hn₂
+    simp [h1, h2]
+  -- Main case: B nonempty, n₁ + n₂ > 0
+  · have hnn_pos : (0 : ℚ) < n₁ + n₂ :=
+      lt_of_le_of_ne (by linarith) (Ne.symm hnn)
+    -- Derive weighted average: (n₁+n₂)*d = n₁*d₁ + n₂*d₂ (cancel B.card)
+    have hd_avg : (n₁ + n₂) * d = n₁ * d₁ + n₂ * d₂ := by
+      have hB_ne : (B.card : ℚ) ≠ 0 := hB
+      exact mul_left_cancel₀ hB_ne (show ↑B.card * ((n₁ + n₂) * d) =
+        ↑B.card * (n₁ * d₁ + n₂ * d₂) from by nlinarith)
+    -- Rewrite d using the weighted average
+    have hd_eq : d = (n₁ * d₁ + n₂ * d₂) / (n₁ + n₂) := by
+      rw [eq_div_iff (ne_of_gt hnn_pos)]; linarith [hd_avg]
+    -- Goal: n₁*d₁² + n₂*d₂² ≥ (n₁+n₂)*d²
+    rw [ge_iff_le, ← sub_nonneg, hd_eq]
+    -- The difference equals n₁*n₂*(d₁-d₂)²/(n₁+n₂) ≥ 0
+    have key : n₁ * d₁ ^ 2 + n₂ * d₂ ^ 2 -
+        (n₁ + n₂) * ((n₁ * d₁ + n₂ * d₂) / (n₁ + n₂)) ^ 2 =
+        n₁ * n₂ * (d₁ - d₂) ^ 2 / (n₁ + n₂) := by
+      field_simp
+      ring
+    rw [key]
+    exact div_nonneg (mul_nonneg (mul_nonneg hn₁ hn₂) (sq_nonneg _)) (le_of_lt hnn_pos)
 
 /-- Energy increment step: if a partition has too many irregular pairs,
     refinement increases energy by at least eps^5. This is the key
@@ -164,9 +267,11 @@ theorem partitionEnergy_le_one (G : SimpleGraph V) [DecidableRel G.Adj]
     we need at most ⌈1/eps^5⌉ iterations. -/
 theorem max_iterations (eps : ℚ) (heps : 0 < eps) :
     ∃ N : ℕ, ∀ e : ℚ, 0 ≤ e → e ≤ 1 → e + N * eps ^ 5 > 1 := by
-  -- N = ⌈1/eps^5⌉ + 1 suffices: N * eps^5 > 1 since N > 1/eps^5,
-  -- and e ≥ 0 gives e + N * eps^5 > 1.
-  sorry
+  -- By the Archimedean property, find N > 1/eps^5.
+  -- Then N * eps^5 > 1, and with e ≥ 0 we get e + N * eps^5 > 1.
+  have heps5 : (0 : ℚ) < eps ^ 5 := pow_pos heps 5
+  obtain ⟨N, hN⟩ := exists_nat_gt (1 / eps ^ 5)
+  exact ⟨N, fun e he0 _ => by linarith [((div_lt_iff₀ heps5).mp hN)]⟩
 
 /-- **Szemeredi Regularity Lemma**: For every epsilon > 0, every
     sufficiently large graph admits an epsilon-regular partition into

--- a/research/registry.json
+++ b/research/registry.json
@@ -216,8 +216,8 @@
       "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-01T05:32:39.476Z",
-      "status": "blocked",
-      "lastUpdate": "2026-03-22T07:19:45.047Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T12:52:40.603Z",
       "completed": "2026-02-07T00:59:53.358Z"
     },
     {
@@ -5009,11 +5009,12 @@
     },
     {
       "slug": "abel-ruffini-oq-04",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-22T03:02:07.189Z",
-      "status": "active",
-      "lastUpdate": "2026-03-22T03:02:07.190Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T12:52:40.604Z",
+      "completed": "2026-03-22T12:52:40.604Z"
     },
     {
       "slug": "birthday-problem-oq-02",


### PR DESCRIPTION
## Summary
Research session for szemeredi-regularity. Proved 2 of 4 remaining sorries in the Szemerédi Regularity Lemma formalization.

## Progress
- **max_iterations**: Proved via Archimedean property (`exists_nat_gt` + `div_lt_iff₀`). Shows ⌈1/ε⁵⌉+1 iterations suffice.
- **density_sq_convex**: Proved the Cauchy-Schwarz convexity lemma for edge density splitting. Key result: when A = A₁ ∪ A₂ (disjoint), |A₁|·d(A₁,B)² + |A₂|·d(A₂,B)² ≥ |A|·d(A,B)².
- Two helper lemmas: `card_mul_edgeDensity` (n·m·d = edge_count) and `edge_count_union` (edge counts add for disjoint sets).

## Findings
- The algebraic core of `density_sq_convex` reduces to n₁·n₂·(d₁-d₂)²/(n₁+n₂) ≥ 0, verified by `field_simp` + `ring`
- Lean `set` abbreviations require explicit unfolding before `simp` can apply rewrite lemmas
- Sorries reduced from 4 → 2 (energy_increment_step + regularity_lemma remain)

## Status
**Outcome**: progress
**Next Steps**: energy_increment_step (deep: irregular pair identification + partition refinement)

🤖 Generated by researcher-3