### PR TITLE
Enrich 2 entries: erdos-619 + erdos-733 (mathContext, annotation types, structural fields)

### DIFF
--- a/src/data/proofs/erdos-733/annotations.json
+++ b/src/data/proofs/erdos-733/annotations.json
@@ -52,7 +52,7 @@
     "id": "ann-e733-szemeredi-trotter",
     "proofId": "erdos-733",
     "range": { "startLine": 113, "endLine": 123 },
-    "type": "axiom",
+    "type": "concept",
     "title": "Szemeredi-Trotter Theorem",
     "content": "**szemeredi_trotter:**\n\nFor n points and m lines, the number of incidences is:\nI(P, L) <= C * (n^{2/3} * m^{2/3} + n + m)\n\nThis is a fundamental result in combinatorial geometry, proved in 1983.\n\nIt is the key tool for the upper bound on line-compatible sequences.",
     "mathContext": "One of the most important theorems in discrete geometry.",
@@ -63,7 +63,7 @@
     "id": "ann-e733-rich-lines",
     "proofId": "erdos-733",
     "range": { "startLine": 125, "endLine": 132 },
-    "type": "axiom",
+    "type": "concept",
     "title": "Rich Lines Bound",
     "content": "**rich_lines_bound:**\n\nThe number of k-rich lines (lines with >= k points) is O(n^2/k^3 + n/k).\n\nThis is a corollary of Szemeredi-Trotter and controls the possible sequence patterns.",
     "significance": "key"
@@ -72,7 +72,7 @@
     "id": "ann-e733-lower",
     "proofId": "erdos-733",
     "range": { "startLine": 140, "endLine": 151 },
-    "type": "axiom",
+    "type": "concept",
     "title": "Lower Bound (Erdos)",
     "content": "**lower_bound:**\n\nf(n) >= exp(c * sqrt(n))\n\nErdos considered this 'easy'.\n\n**Construction:** A sqrt(n) x sqrt(n) grid has Theta(n) lines through it. Selecting different subsets of lines gives exponentially many sequences.",
     "significance": "critical"
@@ -81,7 +81,7 @@
     "id": "ann-e733-grid",
     "proofId": "erdos-733",
     "range": { "startLine": 153, "endLine": 161 },
-    "type": "theorem",
+    "type": "insight",
     "title": "Grid Construction",
     "content": "**grid_gives_lower:**\n\nA sqrt(n) x sqrt(n) integer grid has:\n- n points total\n- Theta(sqrt(n)) horizontal lines\n- Theta(sqrt(n)) vertical lines\n- Many diagonal lines\n\nTotal: Theta(n) lines, giving 2^{Theta(sqrt(n))} subsequences.",
     "significance": "key"
@@ -90,7 +90,7 @@
     "id": "ann-e733-upper",
     "proofId": "erdos-733",
     "range": { "startLine": 169, "endLine": 178 },
-    "type": "axiom",
+    "type": "concept",
     "title": "Upper Bound (Szemeredi-Trotter)",
     "content": "**upper_bound:**\n\nf(n) <= exp(C * sqrt(n))\n\nProved by Szemeredi and Trotter (1983) using their incidence theorem.\n\nThe proof controls the number of possible sequence patterns by bounding incidences.",
     "mathContext": "This was the 'difficult' direction that Erdos anticipated.",
@@ -100,7 +100,7 @@
     "id": "ann-e733-tight",
     "proofId": "erdos-733",
     "range": { "startLine": 198, "endLine": 205 },
-    "type": "theorem",
+    "type": "insight",
     "title": "Tight Bounds",
     "content": "**tight_bounds:**\n\nexp(c*sqrt(n)) <= f(n) <= exp(C*sqrt(n))\n\nCombines lower and upper bounds to show f(n) = exp(Theta(sqrt(n))).",
     "significance": "key"
@@ -109,7 +109,7 @@
     "id": "ann-e733-main",
     "proofId": "erdos-733",
     "range": { "startLine": 207, "endLine": 227 },
-    "type": "theorem",
+    "type": "insight",
     "title": "Erdos Problem #733: SOLVED",
     "content": "**erdos_733:**\n\nComplete solution: f(n) = exp(Theta(sqrt(n)))\n\nFor n >= 4, there exist c, C > 0 such that:\nexp(c*sqrt(n)) <= f(n) <= exp(C*sqrt(n))\n\nThe Szemeredi-Trotter theorem is the key tool.",
     "significance": "critical"
@@ -128,7 +128,7 @@
     "id": "ann-e733-summary",
     "proofId": "erdos-733",
     "range": { "startLine": 259, "endLine": 289 },
-    "type": "theorem",
+    "type": "insight",
     "title": "Complete Summary",
     "content": "**erdos_733_summary:**\n\n1. Line-compatible sequences counted by f(n)\n2. Lower: f(n) >= exp(c*sqrt(n)) (grid construction)\n3. Upper: f(n) <= exp(C*sqrt(n)) (Szemeredi-Trotter)\n4. Together: f(n) = exp(Theta(sqrt(n)))\n\n**erdos_733_answer:** Confirms the complete bounds.",
     "significance": "critical"

--- a/src/data/proofs/erdos-733/meta.json
+++ b/src/data/proofs/erdos-733/meta.json
@@ -61,7 +61,16 @@
       "limitConstant definition: Erdos's follow-up question"
     ],
     "axiomCount": 5,
-    "lineCount": 291
+    "lineCount": 291,
+    "theoremCount": 3,
+    "prerequisites": [
+      "Combinatorial geometry: point-line incidences",
+      "Szemerédi-Trotter incidence theorem",
+      "Counting arguments and exponential bounds",
+      "Grid constructions in discrete geometry"
+    ],
+    "crossReferences": [],
+    "relatedProofs": []
   },
   "overview": {
     "historicalContext": "**Erdos Problem #733**\n\nThis problem concerns the combinatorics of point-line incidences.\n\n**Key History:**\n- Erdos posed the problem about counting line-compatible sequences\n- He noted the lower bound exp(c*sqrt(n)) was 'easy' via grid constructions\n- Szemeredi-Trotter (1983) proved the matching upper bound\n\n**Related Problems:**\n- Problem #607: Similar problem without multiplicities\n- Problem #732: Related incidence problem\n\n**The Szemeredi-Trotter Theorem:**\nThe key tool is their incidence theorem: n points and m lines have O(n^{2/3}m^{2/3} + n + m) incidences.",
@@ -77,60 +86,76 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "summary": "Module docstring, imports for Finset, List.Sort, Real.log, Real.sqrt.",
+      "startLine": 1,
+      "endLine": 38,
+      "mathContext": "The problem counts 'line-compatible' sequences: sorted lists of point counts on lines that can be realized by some $n$-point configuration in $\\mathbb{R}^2$."
+    },
+    {
       "id": "point-configurations",
       "title": "Point Configurations",
-      "summary": "PointSet, lineThrough, pointsOnLine, richLines",
+      "summary": "PointSet (Finset (ℝ × ℝ)), lineThrough, pointsOnLine, richLines.",
       "startLine": 39,
-      "endLine": 72
+      "endLine": 72,
+      "mathContext": "A PointSet is a finite subset of $\\mathbb{R}^2$. A $k$-rich line has $\\geq k$ points from the set. The incidence structure between points and lines is the fundamental object."
     },
     {
       "id": "line-compatible",
       "title": "Line-Compatible Sequences",
-      "summary": "isLineCompatible, countLineCompatible",
+      "summary": "isLineCompatible: sorted sequences realizable by some point configuration. countLineCompatible: f(n).",
       "startLine": 74,
-      "endLine": 105
+      "endLine": 105,
+      "mathContext": "A sorted sequence $2 \\leq X_1 \\leq \\cdots \\leq X_m \\leq n$ is line-compatible if some $n$-point set has exactly these point counts on its lines. $f(n) = |\\{\\text{line-compatible sequences}\\}|$."
     },
     {
       "id": "szemeredi-trotter",
-      "title": "The Szemeredi-Trotter Theorem",
-      "summary": "szemeredi_trotter axiom, rich_lines_bound",
+      "title": "The Szemerédi-Trotter Theorem",
+      "summary": "Axiomatized incidence bound and k-rich lines corollary.",
       "startLine": 107,
-      "endLine": 132
+      "endLine": 132,
+      "mathContext": "$I(P, L) \\leq C(n^{2/3}m^{2/3} + n + m)$ for $n$ points and $m$ lines. Corollary: $\\leq O(n^2/k^3 + n/k)$ lines with $\\geq k$ points."
     },
     {
       "id": "lower-bound",
       "title": "Lower Bound",
-      "summary": "lower_bound axiom, grid_gives_lower",
+      "summary": "f(n) ≥ exp(c√n) via grid construction.",
       "startLine": 134,
-      "endLine": 161
+      "endLine": 161,
+      "mathContext": "A $\\sqrt{n} \\times \\sqrt{n}$ integer grid has $\\Theta(n)$ lines. Choosing subsets gives $2^{\\Theta(\\sqrt{n})} = \\exp(\\Theta(\\sqrt{n}))$ distinct sequences."
     },
     {
       "id": "upper-bound",
       "title": "Upper Bound",
-      "summary": "upper_bound axiom, incidence_control",
+      "summary": "f(n) ≤ exp(C√n) via Szemerédi-Trotter.",
       "startLine": 163,
-      "endLine": 190
+      "endLine": 190,
+      "mathContext": "Szemerédi-Trotter limits the number of $k$-rich lines, which bounds the possible sequence patterns to $\\exp(O(\\sqrt{n}))$."
     },
     {
       "id": "main-result",
       "title": "The Main Result",
-      "summary": "tight_bounds, erdos_733",
+      "summary": "tight_bounds combining lower and upper, erdos_733 main theorem.",
       "startLine": 192,
-      "endLine": 227
+      "endLine": 227,
+      "mathContext": "$\\exp(c\\sqrt{n}) \\leq f(n) \\leq \\exp(C\\sqrt{n})$, i.e., $f(n) = \\exp(\\Theta(\\sqrt{n}))$."
     },
     {
       "id": "limit-question",
       "title": "The Limit Question",
-      "summary": "limitConstant, limit_bounds",
+      "summary": "limitConstant: does lim log(f(n))/√n exist? What is its value?",
       "startLine": 229,
-      "endLine": 253
+      "endLine": 253,
+      "mathContext": "$\\lim_{n \\to \\infty} \\frac{\\log f(n)}{\\sqrt{n}} \\in [c, C]$ if the limit exists. An interesting follow-up posed by Erdős."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_733_summary, erdos_733_answer",
+      "summary": "Complete solution summary and erdos_733_answer theorem.",
       "startLine": 255,
-      "endLine": 291
+      "endLine": 291,
+      "mathContext": "Erdős #733 fully resolved: $f(n) = \\exp(\\Theta(\\sqrt{n}))$ by Szemerédi-Trotter (1983)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

### 1. erdos-619 (Triangle-Free Graph Diameter) — quality 99
- Added mathContext to all 9 sections
- Fixed 3 axiom→concept and 1 theorem→insight annotation types
- Added prerequisites, relatedProofs, crossReferences, theoremCount

### 2. erdos-733 (Line-Compatible Sequences) — quality 99
- Added mathContext to all 9 sections (added header section)
- Fixed 4 axiom→concept and 4 theorem→insight annotation types
- Added prerequisites, crossReferences, relatedProofs, theoremCount

## Quality
- All JSON validated
- No axiom integrity issues
- Fixed annotation type violations (axiom, theorem → valid schema types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)