### PR TITLE
Enrich erdos-733 + erdos-736: fix annotation types, add structural fields

### DIFF
--- a/src/data/proofs/erdos-736/annotations.json
+++ b/src/data/proofs/erdos-736/annotations.json
@@ -60,7 +60,7 @@
       "startLine": 84,
       "endLine": 96
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Taylor's Conjecture",
     "content": "If G has chromatic number ℵ₁, then for every cardinal m, there exists a graph G_m with χ(G_m) = m such that every finite subgraph of G_m appears as a subgraph of G. The finite structure of G should be 'universal'.",
     "mathContext": "χ(G) = ℵ₁ ⟹ ∀m. ∃G_m. χ(G_m) = m ∧ (finite subgraphs of G_m ⊆ finite subgraphs of G)",
@@ -78,7 +78,7 @@
       "startLine": 98,
       "endLine": 110
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Generalized Taylor Conjecture",
     "content": "The same question for any uncountable cardinal κ: if χ(G) = κ, can we build graphs of any chromatic number from G's finite subgraphs?",
     "mathContext": "For κ regular uncountable: χ(G) = κ ⟹ ∀m. ∃G_m with χ(G_m) = m and inherited finite structure",
@@ -114,7 +114,7 @@
       "startLine": 150,
       "endLine": 157
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Komjáth-Shelah Consistency Result",
     "content": "It is consistent with ZFC that Taylor's conjecture is FALSE: there exists G with χ(G) = ℵ₁ such that any H whose finite subgraphs are in G has χ(H) ≤ ℵ₂. The finite structure doesn't suffice for arbitrarily high chromatic numbers.",
     "mathContext": "Con(ZFC + ∃G. χ(G) = ℵ₁ ∧ ∀H. (fin. sub. of H ⊆ fin. sub. of G) ⟹ χ(H) ≤ ℵ₂)",
@@ -133,7 +133,7 @@
       "startLine": 171,
       "endLine": 178
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "De Bruijn-Erdős Theorem",
     "content": "If every finite subgraph of G is k-colorable, then G itself is k-colorable. This compactness principle requires the axiom of choice and shows finite chromatic number is determined by finite subgraphs.",
     "mathContext": "(∀ finite S ⊆ V. G[S] is k-colorable) ⟹ G is k-colorable",

--- a/src/data/proofs/erdos-736/meta.json
+++ b/src/data/proofs/erdos-736/meta.json
@@ -59,7 +59,16 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 6,
-    "lineCount": 242
+    "lineCount": 242,
+    "theoremCount": 2,
+    "prerequisites": [
+      "Set-theoretic graph theory: infinite chromatic numbers (ℵ₁, ℵ₂)",
+      "De Bruijn-Erdős theorem: compactness for finite chromatic numbers",
+      "ZFC independence: forcing and consistency results",
+      "Subgraph containment and finite approximation"
+    ],
+    "relatedProofs": [],
+    "crossReferences": []
   },
   "overview": {
     "historicalContext": "Walter Taylor conjectured that if a graph G has chromatic number ℵ₁, then its finite subgraphs are 'rich enough' to build graphs of any chromatic number. Komjáth and Shelah (2005) proved this is independent of ZFC, showing in some models there exists a counterexample where the bound is ℵ₂. The background to this problem lies in the De Bruijn-Erdős theorem (1951), which established that for finite chromatic numbers, colorability is determined entirely by finite subgraphs. Erdős was fascinated by whether similar compactness principles extend to uncountable chromatic numbers, and Taylor's conjecture was one attempt to make that precise at the ℵ₁ level. The Komjáth-Shelah independence result places this question firmly at the boundary between combinatorics and set-theoretic forcing.",


### PR DESCRIPTION
## Summary

### erdos-733 (Line-Compatible Sequences) — quality 99
- Added mathContext to all 9 sections
- Fixed 4 axiom→concept and 4 theorem→insight annotation types
- Added prerequisites, crossReferences, relatedProofs, theoremCount

### erdos-736 (Taylor Conjecture, ZFC Independence) — quality 98
- Fixed 4 theorem→insight annotation types
- Added prerequisites, relatedProofs, crossReferences, theoremCount

## Quality
- All JSON validated
- No axiom integrity issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)