### PR TITLE
Research: Roth k=3 - Prove norm bound and main theorem (roth-theorem-k3)

### DIFF
--- a/proofs/Proofs/RothTheorem.lean
+++ b/proofs/Proofs/RothTheorem.lean
@@ -103,7 +103,26 @@ noncomputable def fourierCoeff {N : ℕ} (A : Finset (ZMod N)) (r : ZMod N) : �
     |Â(r)| ≤ |A|. -/
 theorem fourierCoeff_norm_le {N : ℕ} (A : Finset (ZMod N)) (r : ZMod N) :
     ‖fourierCoeff A r‖ ≤ A.card := by
-  sorry
+  unfold fourierCoeff
+  set f := fun x : ZMod N =>
+    Complex.exp (2 * ↑Real.pi * Complex.I * (↑(ZMod.val (r * x)) / ↑N))
+  -- Each exponential has norm 1 (purely imaginary argument)
+  have hf : ∀ x ∈ A, ‖f x‖ ≤ 1 := by
+    intro x _
+    simp only [f, Complex.norm_exp]
+    have hre : (2 * ↑Real.pi * Complex.I * (↑(ZMod.val (r * x)) / ↑N)).re = 0 := by
+      have : 2 * ↑Real.pi * Complex.I * (↑(ZMod.val (r * x)) / ↑N) =
+             ↑(2 * Real.pi * ((ZMod.val (r * x) : ℝ) / (N : ℝ))) * Complex.I := by
+        push_cast; ring
+      rw [this, Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im,
+          Complex.I_re, Complex.I_im]
+      ring
+    rw [hre, Real.exp_zero]
+  -- Triangle inequality: ‖∑ f‖ ≤ ∑ ‖f‖ ≤ ∑ 1 = |A|
+  calc ‖A.sum f‖
+      ≤ A.sum (fun x => ‖f x‖) := norm_sum_le _ _
+    _ ≤ A.sum (fun _ => (1 : ℝ)) := Finset.sum_le_sum hf
+    _ = ↑A.card := by simp [Finset.sum_const]
 
 /-- Parseval's identity on Z/NZ: Σ_r |Â(r)|² = |A| · N.
     The total energy of the Fourier transform equals |A| times the group order.
@@ -228,6 +247,44 @@ theorem density_iteration (delta : ℝ) (hdelta : 0 < delta) :
 theorem roth_density_bound (delta : ℝ) (hdelta : 0 < delta) (hdelta1 : delta ≤ 1) :
     ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ → ∀ A : Finset (ZMod N),
       (A.card : ℝ) ≥ delta * N → ¬APFree A := by
-  sorry
+  -- N₀ = 1 works: the argument applies for all N ≥ 1
+  refine ⟨1, fun N hN A hdensity hAP => ?_⟩
+  have hNpos : 0 < N := by omega
+  -- Iteration chain: after k density-increment steps, we get a set of
+  -- density ≥ delta + k * delta²/100 in some Z/MZ with M > 0
+  have chain : ∀ k : ℕ, ∃ (M : ℕ) (B : Finset (ZMod M)),
+      0 < M ∧ APFree B ∧ (B.card : ℝ) ≥ (delta + ↑k * delta ^ 2 / 100) * ↑M := by
+    intro k
+    induction k with
+    | zero =>
+      simp only [Nat.cast_zero, zero_mul, zero_div, add_zero]
+      exact ⟨N, A, hNpos, hAP, hdensity⟩
+    | succ k ih =>
+      obtain ⟨M, B, hMpos, hBAP, hBdens⟩ := ih
+      obtain ⟨M', B', hM'pos, hB'AP, hB'dens⟩ :=
+        density_iteration delta hdelta k M hMpos B hBAP hBdens
+      refine ⟨M', B', hM'pos, hB'AP, ?_⟩
+      push_cast at hB'dens ⊢
+      linarith
+  -- Choose K large enough that delta + K * delta²/100 > 1
+  obtain ⟨K, hK⟩ := exists_nat_gt (100 / delta ^ 2)
+  obtain ⟨M, B, hMpos, _, hBdens⟩ := chain K
+  haveI : NeZero M := ⟨by omega⟩
+  -- Clear the denominator: 100/delta² < K implies 100 < K*delta²
+  have hd2 : delta ^ 2 > 0 := by positivity
+  have h_clear : (100 : ℝ) < ↑K * delta ^ 2 := by
+    have h1 : 100 / delta ^ 2 * delta ^ 2 < ↑K * delta ^ 2 :=
+      mul_lt_mul_of_pos_right hK hd2
+    have h2 : 100 / delta ^ 2 * delta ^ 2 = 100 := by field_simp
+    linarith
+  -- The density exceeds 1, so |B| > M
+  have hgt1 : delta + ↑K * delta ^ 2 / 100 > 1 := by linarith
+  have hMcast : (0 : ℝ) < ↑M := Nat.cast_pos.mpr hMpos
+  have hBgt : (B.card : ℝ) > ↑M := by
+    calc (B.card : ℝ) ≥ (delta + ↑K * delta ^ 2 / 100) * ↑M := hBdens
+      _ > 1 * ↑M := mul_lt_mul_of_pos_right hgt1 hMcast
+      _ = ↑M := one_mul _
+  -- But |B| ≤ M for any Finset of ZMod M — contradiction
+  linarith [card_le_nat_real B]
 
 end Szemeredi.Roth

--- a/proofs/Proofs/RothTheoremAristotle.lean
+++ b/proofs/Proofs/RothTheoremAristotle.lean
@@ -8,13 +8,16 @@
   - Known result likely in Mathlib (norm bounds, Parseval, etc.)
   - Clean theorem statement with no definition sorries
   - No axioms (use theorem ... := by sorry instead)
+
+  Status: fourierCoeff_norm_le and roth_density_bound now proved in main file.
+  Remaining targets: exp norm, Parseval identity, basic ZMod lemmas.
 -/
 import Mathlib
 
 namespace Szemeredi.Roth.Aristotle
 
 -- ═══════════════════════════════════════════════════════════════════
--- Fourier coefficient bounds
+-- Fourier coefficient infrastructure
 -- ═══════════════════════════════════════════════════════════════════
 
 /-- Fourier coefficient definition (duplicated for self-containment). -/
@@ -27,19 +30,11 @@ theorem exp_term_norm_one {N : ℕ} (r x : ZMod N) :
     ‖Complex.exp (2 * Real.pi * Complex.I * (↑(ZMod.val (r * x)) / ↑N))‖ = 1 := by
   sorry
 
-/-- The Fourier coefficient at r is bounded by |A| (triangle inequality). -/
-theorem fourierCoeff_norm_le {N : ℕ} (A : Finset (ZMod N)) (r : ZMod N) :
-    ‖fourierCoeff A r‖ ≤ A.card := by
-  sorry
-
-/-- Cardinality of any subset of ZMod N is at most N. -/
-theorem card_le_zmod {N : ℕ} [NeZero N] (A : Finset (ZMod N)) :
-    A.card ≤ N := by
-  sorry
-
-/-- Cardinality bound in ℝ: (A.card : ℝ) ≤ N. -/
-theorem card_le_zmod_real {N : ℕ} [NeZero N] (A : Finset (ZMod N)) :
-    (A.card : ℝ) ≤ (N : ℝ) := by
+/-- Parseval's identity on Z/NZ: Σ_r |Â(r)|² = |A| · N.
+    The total energy of the Fourier transform equals |A| times the group order.
+    This follows from orthogonality of characters. -/
+theorem parseval_on_zmod {N : ℕ} [NeZero N] (A : Finset (ZMod N)) :
+    (Finset.univ.sum fun r => ‖fourierCoeff A r‖ ^ 2) = A.card * N := by
   sorry
 
 -- ═══════════════════════════════════════════════════════════════════

--- a/research/problems/roth-theorem-k3/knowledge.md
+++ b/research/problems/roth-theorem-k3/knowledge.md
@@ -34,12 +34,51 @@ Our: ∀ a d, d ≠ 0 → a ∈ A → a+d ∈ A → a+2d ∉ A
 Mathlib: ∀ a d, a ∈ A → a+d ∈ A → a+2d ∈ A → d = 0
 These are contrapositives. An equivalence lemma would unlock Mathlib's additive combinatorics.
 
-### Sorry Classification
-| Sorry | Difficulty | Aristotle? | Notes |
-|-------|-----------|------------|-------|
-| fourierCoeff_norm_le | Easy | YES | Triangle inequality + |exp(iθ)| = 1 |
+### Sorry Classification (Updated Session 2)
+| Sorry | Difficulty | Aristotle? | Status |
+|-------|-----------|------------|--------|
+| fourierCoeff_norm_le | Easy | YES | **PROVED** (Session 2) |
 | parseval_on_zmod | Medium | MAYBE | Needs orthogonality of characters |
 | triple_count_fourier | Hard | NO | Deep identity connecting APs to Fourier |
 | fourier_large_coefficient | Hard | NO | Key analytic step, needs Parseval + counting |
 | density_increment_lemma | Hard | NO | Needs fourier_large_coefficient + pigeonhole |
-| roth_density_bound | Medium | NO | Iteration from density_increment_lemma — strategy proved but final wiring needs work |
+| roth_density_bound | Medium | NO | **PROVED** (Session 2) |
+
+## Session 2 (2026-03-22, researcher-4)
+
+### What Was Done
+1. **Proved fourierCoeff_norm_le** (triangle inequality + |exp(iθ)|=1)
+   - Key technique: rewrite exponent to `↑θ * I` form via `push_cast; ring`
+   - Show `(↑θ * I).re = 0` via `Complex.mul_re` + `Complex.I_re/I_im`
+   - Then `Real.exp_zero` gives norm = 1
+   - Triangle inequality via `norm_sum_le` + `Finset.sum_le_sum`
+2. **Proved roth_density_bound** (main theorem of the file!)
+   - Iterate `density_iteration` by induction on k: after k steps, get density ≥ δ+k·δ²/100
+   - Cast unification: `push_cast` normalizes `↑(k+1)` to `↑k+1`
+   - Choose K > 100/δ² via `exists_nat_gt`, clear denominator with `field_simp`
+   - Density > 1 implies |B| > M, contradicting `card_le_nat_real`
+3. **Updated Aristotle companion file** — removed proved lemmas, kept parseval and basic lemmas
+4. **Reduced sorry count**: 6 → 4
+
+### Proof Architecture
+The main theorem `roth_density_bound` is now fully proved from `density_increment_lemma` (sorry):
+```
+density_increment_lemma (sorry)
+  → density_increment_step (proved, session 1)
+  → density_iteration (proved, session 1)
+  → roth_density_bound (proved, session 2)
+```
+
+### Remaining Sorry Dependency Chain
+```
+parseval_on_zmod (sorry) ──────────────────────────┐
+triple_count_fourier (sorry) ──────────────────────┤
+                                                    ├→ fourier_large_coefficient (sorry)
+                                                    │    └→ density_increment_lemma (sorry)
+                                                    │         └→ roth_density_bound (PROVED)
+```
+
+### Technical Notes
+- `div_lt_iff` does NOT exist as a bare identifier in current Mathlib — use `field_simp` or `mul_lt_mul_of_pos_right` to clear denominators
+- `mul_lt_mul_of_pos_right` works for `a < b → 0 < c → a*c < b*c`
+- `NeZero M` instance from `0 < M`: `⟨by omega⟩`

--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -17,7 +17,7 @@
       "marquee-phase-3"
     ],
     "badge": "formalized",
-    "sorries": 6,
+    "sorries": 4,
     "mathlibDependencies": [
       {
         "theorem": "Finset.card",
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 92
+    "lineCount": 263
   },
   "overview": {
     "historicalContext": "Roth's theorem, proved by Klaus Friedrich Roth in 1953, was a landmark achievement in number theory and combinatorics. It confirmed the k=3 case of the Erdos-Turan conjecture (1936) that every dense subset of the integers contains arithmetic progressions of any length.\n\nRoth introduced Fourier-analytic methods to additive combinatorics, a revolutionary approach that opened an entirely new toolbox. His key insight was the density increment strategy: if a set A of density delta in [N] has no 3-term AP, then there exists a long arithmetic progression P where A has density at least delta + c*delta^2. Iterating this increment (which can only happen O(1/delta) times before density exceeds 1) yields a contradiction.\n\nThe quantitative bounds have been dramatically improved over the decades: Bourgain (1999, 2008), Sanders (2011), and most recently Bloom and Sisask (2020) achieved r_3(N) = O(N/(log N)^{1+c}). In 2023, Kelley and Meka achieved the breakthrough bound r_3(N) = O(N * exp(-c * (log N)^{1/12})).\n\nRoth's theorem is the natural starting point for the Szemeredi program because it introduces the core techniques (Fourier analysis, density increment) in their simplest setting.",
@@ -77,7 +77,7 @@
       "title": "Part III: Fourier Analysis on Z/NZ",
       "startLine": 93,
       "endLine": 124,
-      "summary": "Defines fourierCoeff. States norm bound, Parseval identity, and AP-Fourier identity (3 sorries)."
+      "summary": "Defines fourierCoeff. Proves norm bound via triangle inequality. States Parseval identity and AP-Fourier identity (2 sorries)."
     },
     {
       "id": "large-coeff",
@@ -98,7 +98,7 @@
       "title": "Part VI: Iteration and Main Result",
       "startLine": 164,
       "endLine": 233,
-      "summary": "Proves density_increment_step and density_iteration from density_increment_lemma (0 sorries). States roth_density_bound (1 sorry)."
+      "summary": "Proves density_increment_step, density_iteration, and roth_density_bound (the main theorem) by iterating until density > 1 yields contradiction (0 sorries)."
     }
   ],
   "crossReferences": [
@@ -139,7 +139,7 @@
     ],
     "opens": [],
     "namespace": "Szemeredi.Roth",
-    "lineCount": 233,
+    "lineCount": 263,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 3


### PR DESCRIPTION
## Summary
- Proved `fourierCoeff_norm_le`: Fourier coefficient norm ≤ |A| via triangle inequality + |exp(iθ)|=1
- Proved `roth_density_bound`: **The main theorem of Roth k=3** via iterating density increment until density > 1

## Progress
- Reduced sorry count from **6 to 4** in RothTheorem.lean
- Main theorem now fully proved (conditionally on 4 Fourier-analytic lemmas)
- Updated Aristotle companion file, gallery metadata, knowledge base

## Key Proof Techniques
- `fourierCoeff_norm_le`: Rewrite exponent to `↑θ * I` form via `push_cast; ring`, show `re = 0` via `Complex.mul_re`
- `roth_density_bound`: Induction builds chain of density-boosted sets, `exists_nat_gt(100/δ²)` + `field_simp` for denominator clearing, density > 1 contradicts `card_le_nat_real`

## Remaining Sorries
```
parseval_on_zmod → fourier_large_coefficient → density_increment_lemma
triple_count_fourier ↗
```

## Status
**Outcome**: progress (2 sorries proved, 4 remaining)
**Next Steps**: Prove parseval_on_zmod via orthogonality of ZMod characters

🤖 Generated by researcher-4