### PR TITLE
Enrich erdos-808: fix axiom integrity, add depth

### DIFF
--- a/src/data/proofs/erdos-808/annotations.json
+++ b/src/data/proofs/erdos-808/annotations.json
@@ -15,7 +15,8 @@
       "sumset",
       "graph edge",
       "additive combinatorics"
-    ]
+    ],
+    "prerequisites": ["Finset.image", "Cartesian products", "Graph theory basics"]
   },
   {
     "id": "ann-808-2",
@@ -33,7 +34,8 @@
       "product set",
       "multiplication",
       "sum-product phenomenon"
-    ]
+    ],
+    "prerequisites": ["Finset.image", "Natural number multiplication"]
   },
   {
     "id": "ann-808-3",
@@ -51,7 +53,8 @@
       "sum-product conjecture",
       "expansion",
       "edge density"
-    ]
+    ],
+    "prerequisites": ["graphSumset", "graphProductset", "isGraphOn", "Real.rpow"]
   },
   {
     "id": "ann-808-4",
@@ -69,7 +72,8 @@
       "counterexample",
       "arithmetic structure",
       "exponent gap"
-    ]
+    ],
+    "prerequisites": ["ErdosConjecture808", "isGraphOn", "Real.rpow"]
   },
   {
     "id": "ann-808-5",
@@ -87,7 +91,8 @@
       "exponent",
       "gap",
       "quantitative failure"
-    ]
+    ],
+    "prerequisites": ["Rational arithmetic", "norm_num tactic"]
   },
   {
     "id": "ann-808-6",
@@ -105,7 +110,8 @@
       "positive result",
       "lower bound",
       "edge-output relation"
-    ]
+    ],
+    "prerequisites": ["graphSumset", "graphProductset", "Real.rpow"]
   },
   {
     "id": "ann-808-7",
@@ -123,7 +129,8 @@
       "Problem 52",
       "complete graph",
       "Erdős-Szemerédi"
-    ]
+    ],
+    "prerequisites": ["Sum-product conjecture", "Finset.image"]
   },
   {
     "id": "ann-808-8",
@@ -141,7 +148,8 @@
       "arithmetic progression",
       "structured sets",
       "small doubling"
-    ]
+    ],
+    "prerequisites": ["Arithmetic progressions", "Sumset bounds"]
   },
   {
     "id": "ann-808-9",
@@ -159,7 +167,8 @@
       "small doubling",
       "Freiman's theorem",
       "additive structure"
-    ]
+    ],
+    "prerequisites": ["Additive structure", "Sumset definition"]
   },
   {
     "id": "ann-808-10",
@@ -177,6 +186,7 @@
       "graph structure",
       "sparse vs dense",
       "expansion phenomenon"
-    ]
+    ],
+    "prerequisites": ["ErdosConjecture808", "ars_counterexample", "ars_positive_bound"]
   }
 ]

--- a/src/data/proofs/erdos-808/meta.json
+++ b/src/data/proofs/erdos-808/meta.json
@@ -7,7 +7,7 @@
     "author": "Alon, Ruzsa, Solymosi (2020)",
     "sourceUrl": "https://erdosproblems.com/808",
     "date": "2020",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos808Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "graph-theory",
       "disproved"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 808,
     "erdosUrl": "https://erdosproblems.com/808",
@@ -60,10 +60,11 @@
     "problemStatement": "If A ⊂ ℕ with |A| = n and graph G on A has ≥ n^{1+c} edges, is max(|A +_G A|, |A ·_G A|) ≥ n^{1+c-ε}? Here A +_G A = {a+b : (a,b) ∈ G}.",
     "proofStrategy": "ARS constructed sets with arithmetic structure where many edges (n^{5/3}) produce few distinct sums/products (n^{4/3}). They also proved a positive lower bound using different techniques.",
     "keyInsights": [
-      "The conjecture is FALSE: n^{5/3} edges can yield only n^{4/3} outputs",
-      "Arithmetic structure allows many edges without many new sums",
-      "Positive result: max ≥ c · m^{3/2} · n^{-7/4} where m = edges",
-      "Graph structure fundamentally changes sum-product behavior vs complete graph"
+      "The conjecture is FALSE: n^{5/3} edges can yield only n^{4/3} outputs, an exponent gap of 1/3",
+      "Arithmetic structure (like APs with |A+A| ≤ 2|A|-1) allows many edges without many new sums",
+      "Positive result: max(|A+_G A|, |A·_G A|) ≥ c · m^{3/2} · n^{-7/4} still guarantees some expansion",
+      "Graph structure fundamentally changes sum-product behavior: sparse graphs defeat expansion that complete graphs guarantee",
+      "The complete graph case reduces to the classical Erdős-Szemerédi conjecture (Problem 52), which remains open — sparsity is the essential obstruction"
     ]
   },
   "sections": [


### PR DESCRIPTION
## Summary
- **Axiom integrity fix**: Changed status from `verified` to `axiomatized` and badge from `mathlib` to `axiom` — the Lean file has 6 axiom declarations (erdos_808_false, ars_counterexample, ars_positive_bound, complete_graph_case, construction_idea, arithmetic_structure)
- Added 5th keyInsight connecting to the classical Erdős-Szemerédi conjecture (Problem 52)
- Added `prerequisites` to all 10 annotations
- Quality: 98 → 100

## Test plan
- [x] JSON validated
- [x] Quality score confirmed at 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)