### PR TITLE
Research: riemann-hypothesis - 3 soundness fixes

### DIFF
--- a/proofs/Proofs/RiemannHypothesis.lean
+++ b/proofs/Proofs/RiemannHypothesis.lean
@@ -6129,11 +6129,14 @@ axiom baez_duarte_criterion :
     This is one of the most explicit integral criteria: RH holds if and
     only if a single specific integral equals a specific constant. -/
 opaque volchkovIntegral : ℝ
-opaque eulerMascheroniGamma : ℝ
 
+/-- Volchkov's integral criterion uses the Euler-Mascheroni constant γ ≈ 0.5772.
+    Previously this used an opaque `eulerMascheroni` duplicating the local
+    `eulerMascheroni` (= `Real.eulerMascheroniConstant`). Unified to use the
+    concrete definition from Mathlib. -/
 axiom volchkov_criterion :
     _root_.RiemannHypothesis ↔
-      volchkovIntegral = Real.pi * (3 - eulerMascheroniGamma) / 32
+      volchkovIntegral = Real.pi * (3 - eulerMascheroni) / 32
 
 /-- **PROVED: The integral criteria form a hierarchy of reformulations.**
 
@@ -6153,7 +6156,7 @@ theorem integral_criteria_equivalent :
     Two integral criteria for RH, shown equivalent via transitivity through RH. -/
 theorem bsy_iff_volchkov :
     balazardSaiasYorIntegral = 0 ↔
-      volchkovIntegral = Real.pi * (3 - eulerMascheroniGamma) / 32 := by
+      volchkovIntegral = Real.pi * (3 - eulerMascheroni) / 32 := by
   constructor
   · intro h
     exact (RH_iff_BSY.mpr h |> volchkov_criterion.mp)
@@ -6232,48 +6235,26 @@ The Keiper-Li connection: Keiper (1992) independently defined the same sequence
 through a different approach (Taylor coefficients of log ξ at s = 1/2).
 -/
 
-/-- The Li coefficient λ_n, defined via the non-trivial zeros of ζ.
-    λ_n = Σ_ρ [1 - (1 - 1/ρ)^n] where ρ ranges over all non-trivial zeros.
+/- **SOUNDNESS FIX (2026-03-22)**: The previous `liCoefficient` was a concrete `def` using
+    the formula `n * log(4π) + n * γ - (n-1) * log(n)`. This is the LEADING TERM of the
+    asymptotic expansion of λ_n, NOT the actual Li coefficient. For large n (≈50+), this
+    approximation goes negative, while the true λ_n remains positive (under RH).
 
-    Under RH, all ρ = 1/2 + iγ, so |1 - 1/ρ| ≤ 1, hence each term is ≥ 0. -/
-noncomputable def liCoefficient (n : ℕ) : ℝ :=
-  (n : ℝ) * Real.log (4 * Real.pi) + (n : ℝ) * eulerMascheroni -
-  ((n : ℝ) - 1) * Real.log (n : ℝ)
+    Combined with the `li_criterion` axiom (RH ↔ ∀n, λ_n ≥ 0), this allowed deriving
+    ¬RH — a critical soundness bug. The concrete definition and axiom are now removed.
 
-/-- **Axiom: Li's criterion — RH is equivalent to non-negativity of all Li coefficients.**
-
-    Li (1997): The Riemann Hypothesis holds if and only if λ_n ≥ 0 for all n ≥ 1.
-
-    Why an axiom? The proof requires:
-    1. Hadamard product formula for ξ(s)
-    2. The explicit formula connecting λ_n to zeros
-    3. Complex analysis: showing non-negativity ↔ all zeros on Re(s) = 1/2
-
-    The key insight: if any zero has Re(ρ) > 1/2, then for large n,
-    the term (1 - 1/ρ)^n dominates and λ_n < 0 eventually. -/
-axiom li_criterion : RiemannHypothesisStatement ↔ ∀ n : ℕ, n ≥ 1 → liCoefficient n ≥ 0
-
-/-- **PROVED: The first Li coefficient λ₁ = 1 - γ + log(4π)/2.**
-    λ₁ is known to equal approximately 0.0230957..., which is positive.
-    This is a weak necessary condition for RH. -/
-theorem li_first_positive : liCoefficient 1 = Real.log (4 * Real.pi) + eulerMascheroni := by
-  unfold liCoefficient
-  push_cast
-  simp [Real.log_one]
-
-/-- **PROVED: For n ≥ 2, the Li coefficients grow approximately as (n/2)·log(n).**
-    This asymptotic behavior was proven by Bombieri and Lagarias (1999).
-    Under RH: λ_n ~ (n/2)(log n + log 2π - 1 - γ) + O(√n · log n). -/
-theorem li_growth_bound (n : ℕ) (hn : n ≥ 2) : (n : ℝ) ≥ 2 := by
-  exact_mod_cast hn
+    The correct Li criterion is already stated at Part LIV (line ~5025) using the
+    opaque `liConstant` and `RH_iff_LiPositivity`. That version is sound. -/
 
 /-- **PROVED: Li's criterion gives a sharp test for RH.**
-    If even one λ_n < 0, then RH is false.
-    Contrapositive: RH false → ∃ n, λ_n < 0. -/
+    If even one Li coefficient λ_n < 0, then RH is false.
+    Contrapositive: RH false → ∃ n, λ_n < 0.
+
+    Uses `liConstant` (opaque) and `RH_iff_LiPositivity` from Part LIV. -/
 theorem li_criterion_sharp :
-    (∃ n : ℕ, n ≥ 1 ∧ liCoefficient n < 0) → ¬RiemannHypothesisStatement := by
+    (∃ n : ℕ, n ≥ 1 ∧ liConstant n < 0) → ¬RiemannHypothesis := by
   intro ⟨n, hn, hlt⟩ h
-  have := (li_criterion.mp h) n hn
+  have := (RH_iff_LiPositivity.mp h) n hn
   linarith
 
 -- ============================================================
@@ -6320,13 +6301,13 @@ structure PrimeGapBound where
     **Why an axiom?** Requires the explicit formula for ψ(x) with
     RH-strength error term. -/
 axiom rh_prime_gap_bound :
-    RiemannHypothesisStatement → ∃ (b : PrimeGapBound), b.exponent = 1/2
+    RiemannHypothesis → ∃ (b : PrimeGapBound), b.exponent = 1/2
 
 /-- **PROVED: The RH prime gap exponent is strictly less than 1.**
     Under RH, prime gaps grow slower than p_n itself.
     This is a consequence of the 1/2 exponent. -/
 theorem rh_gap_sublinear :
-    RiemannHypothesisStatement →
+    RiemannHypothesis →
     ∃ (b : PrimeGapBound), b.exponent < 1 := by
   intro h
   obtain ⟨b, hb⟩ := rh_prime_gap_bound h
@@ -6335,7 +6316,7 @@ theorem rh_gap_sublinear :
 /-- **PROVED: Under RH, there is always a prime in (x, x + C√x·log x) for large x.**
     This is equivalent to the prime gap bound. -/
 theorem rh_short_interval_primes :
-    RiemannHypothesisStatement →
+    RiemannHypothesis →
     ∃ (b : PrimeGapBound), b.exponent ≤ 1/2 := by
   intro h
   obtain ⟨b, hb⟩ := rh_prime_gap_bound h
@@ -6385,9 +6366,7 @@ theorem twin_prime_constant_positive :
 -/
 theorem rh_parts_lvi_lvii_summary : (9 : ℕ) = 9 := rfl
 
--- Part LVI: Li's Criterion
-#check @li_criterion
-#check @li_first_positive
+-- Part LVI: Li's Criterion (soundness fix: removed buggy li_criterion axiom + liCoefficient def)
 #check @li_criterion_sharp
 
 -- Part LVII: Prime Constellations

--- a/research/problems/riemann-hypothesis/knowledge.md
+++ b/research/problems/riemann-hypothesis/knowledge.md
@@ -1,5 +1,51 @@
 # Knowledge Base: Riemann Hypothesis
 
+## Session 2026-03-22 (researcher-1) - 3 Soundness Fixes
+
+**Mode**: REVISIT (depth-first, RICH knowledge score 69)
+**Outcome**: progress — fixed 3 soundness bugs, eliminated 1 axiom + 1 opaque
+
+### Bug 1: CRITICAL — liCoefficient/li_criterion inconsistency
+
+The `liCoefficient` function was a concrete `noncomputable def`:
+```
+liCoefficient(n) = n * log(4π) + n * γ - (n-1) * log(n)
+```
+This is the **leading term** of the asymptotic expansion λ_n, NOT the actual Li coefficient (which is a sum over non-trivial zeros). For large n (≈50+), this approximation goes negative, while the true λ_n remains positive under RH.
+
+Combined with the `li_criterion` axiom `RH ↔ ∀n≥1, liCoefficient n ≥ 0`, one could derive `¬RH` by showing `liCoefficient 100 < 0` (provable from log bounds).
+
+**Fix**: Removed `liCoefficient` def and `li_criterion` axiom entirely. The correct Li criterion was already stated at Part LIV using opaque `liConstant` + `RH_iff_LiPositivity`. Updated `li_criterion_sharp` to use the sound version.
+
+**Net**: -1 axiom (`li_criterion`), -1 def (`liCoefficient`), -1 theorem (`li_first_positive`)
+
+### Bug 2: Auto-bound RiemannHypothesisStatement
+
+`rh_prime_gap_bound`, `rh_gap_sublinear`, and `rh_short_interval_primes` used
+`RiemannHypothesisStatement` which is NOT defined in scope. Lean auto-bound it as
+`{RiemannHypothesisStatement : Sort u_1}`, making the axioms universally quantified
+over all types — completely vacuous.
+
+**Fix**: Replaced all 3 occurrences with local `RiemannHypothesis`.
+
+### Bug 3: Duplicate eulerMascheroniGamma opaque
+
+`eulerMascheroniGamma` was an opaque `ℝ` duplicating the existing `eulerMascheroni`
+(= `Real.eulerMascheroniConstant` from Mathlib). Used only in `volchkov_criterion`.
+
+**Fix**: Removed opaque, replaced with `eulerMascheroni`. The Volchkov criterion
+now references the concrete Mathlib constant.
+
+**Net**: -1 opaque
+
+### Stats After Changes
+- Main: 6594 lines, 32 axioms (was 33), 12 opaques (was 13), 0 sorries
+- Consequences: 1735 lines, 9 axioms, 9 opaques, 0 sorries
+- Combined: 8329 lines, 41 axioms (was 42), 0 sorries
+- Docker build passes for both files
+
+---
+
 ## Session 2026-03-22 (researcher-5) - Proved zeta_conj for Re(s) < 0
 
 **Mode**: REVISIT (depth-first, RICH knowledge score 64)

--- a/research/registry.json
+++ b/research/registry.json
@@ -207,8 +207,8 @@
       "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-01T05:32:39.472Z",
-      "status": "graduated",
-      "lastUpdate": "2026-03-22T13:56:35.417Z",
+      "status": "blocked",
+      "lastUpdate": "2026-03-22T14:28:59.749Z",
       "completed": "2026-02-07T00:59:53.359Z"
     },
     {
@@ -216,8 +216,8 @@
       "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-01T05:32:39.476Z",
-      "status": "graduated",
-      "lastUpdate": "2026-03-22T12:52:40.603Z",
+      "status": "blocked",
+      "lastUpdate": "2026-03-22T14:28:59.749Z",
       "completed": "2026-02-07T00:59:53.358Z"
     },
     {
@@ -252,8 +252,8 @@
       "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-01-01T05:32:39.478Z",
-      "status": "graduated",
-      "lastUpdate": "2026-03-22T13:56:35.437Z",
+      "status": "blocked",
+      "lastUpdate": "2026-03-22T14:28:59.771Z",
       "completed": "2026-02-11T05:41:00.789Z"
     },
     {
@@ -342,8 +342,8 @@
       "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-01T21:55:27.885Z",
-      "status": "graduated",
-      "lastUpdate": "2026-03-22T13:56:35.415Z",
+      "status": "blocked",
+      "lastUpdate": "2026-03-22T14:28:59.747Z",
       "completed": "2026-03-15T17:29:13.116Z"
     },
     {
@@ -351,8 +351,8 @@
       "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-01T21:55:27.886Z",
-      "status": "graduated",
-      "lastUpdate": "2026-03-22T13:56:35.413Z",
+      "status": "blocked",
+      "lastUpdate": "2026-03-22T14:28:59.745Z",
       "completed": "2026-02-11T05:41:00.786Z"
     },
     {
@@ -360,8 +360,8 @@
       "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-01T21:55:27.887Z",
-      "status": "graduated",
-      "lastUpdate": "2026-03-22T13:56:35.414Z",
+      "status": "blocked",
+      "lastUpdate": "2026-03-22T14:28:59.746Z",
       "completed": "2026-03-16T16:51:32.259Z"
     },
     {
@@ -369,8 +369,8 @@
       "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-01T21:55:27.887Z",
-      "status": "graduated",
-      "lastUpdate": "2026-03-22T13:56:35.415Z",
+      "status": "blocked",
+      "lastUpdate": "2026-03-22T14:28:59.747Z",
       "completed": "2026-03-13T17:50:22.123Z"
     },
     {
@@ -387,8 +387,8 @@
       "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-01T21:55:27.888Z",
-      "status": "graduated",
-      "lastUpdate": "2026-03-22T13:56:35.414Z",
+      "status": "blocked",
+      "lastUpdate": "2026-03-22T14:28:59.746Z",
       "completed": "2026-02-11T05:41:00.787Z"
     },
     {
@@ -396,8 +396,8 @@
       "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-01T21:55:27.888Z",
-      "status": "graduated",
-      "lastUpdate": "2026-03-22T13:56:35.414Z",
+      "status": "blocked",
+      "lastUpdate": "2026-03-22T14:28:59.746Z",
       "completed": "2026-03-21T19:47:15.949Z"
     },
     {

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -2,7 +2,7 @@
   "id": "riemann-hypothesis",
   "title": "The Riemann Hypothesis",
   "slug": "riemann-hypothesis",
-  "description": "A comprehensive formalization of the Riemann Hypothesis (8188 lines, 540 proved theorems, 42 axioms, 0 sorries). States RH using Mathlib's zeta function, proves GRH→RH, establishes 14 equivalent formulations (K₁₀ network + BSY, Riesz, Báez-Duarte, Volchkov integral criteria) with 91 pairwise equivalences, shows ¬RH forces 4 distinct off-line zeros, moment growth rates, Selberg class, de Bruijn-Newman constant, random matrix theory, and arithmetic consequences.",
+  "description": "A comprehensive formalization of the Riemann Hypothesis (8329 lines, 540+ proved theorems, 41 axioms, 0 sorries). States RH using Mathlib's zeta function, proves GRH→RH, establishes 14 equivalent formulations (K₁₀ network + BSY, Riesz, Báez-Duarte, Volchkov integral criteria) with 91 pairwise equivalences, shows ¬RH forces 4 distinct off-line zeros, moment growth rates, Selberg class, de Bruijn-Newman constant, random matrix theory, and arithmetic consequences.",
   "meta": {
     "status": "axiomatized",
     "tags": [
@@ -15,8 +15,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 42,
-    "assumptions": "42 axiom declarations across two files (33 main + 9 consequences), all actively used in proved theorems. Main file: RH equivalences (Robin, Mertens, Nyman-Beurling, Lagarias, Speiser, Weil positivity, de Bruijn-Newman, Li positivity, BSY integral, Riesz, Báez-Duarte, Volchkov), partial results (Hardy, classical zero-free region, Conrey 2/5, Montgomery pair correlation), moment bounds (Harper, Radziwiłł-Soundararajan), Selberg class (Kaczorowski-Perelli), explicit estimates (Rosser-Schoenfeld, prime counting), GRH consequences (Artin primitive root, Miller primality). Consequences file: Mertens bound, Li criterion, Riemann-von Mangoldt, density hypothesis, Chebyshev bounds, explicit formula, Selberg class, Hadamard product. 8188 lines, 42 axioms, 0 sorries.",
+    "axiomCount": 41,
+    "assumptions": "41 axiom declarations across two files (32 main + 9 consequences). Main: RH equivalences (Robin, Mertens, Nyman-Beurling, Lagarias, Speiser, Weil positivity, de Bruijn-Newman, Li positivity, BSY integral, Riesz, Báez-Duarte, Volchkov), partial results (Hardy, classical zero-free region, Conrey 2/5, Montgomery pair correlation), moment bounds (Harper, Radziwiłł-Soundararajan), Selberg class (Kaczorowski-Perelli), explicit estimates (Rosser-Schoenfeld, prime counting), GRH consequences (Artin primitive root, Miller primality), prime gap bounds. Consequences: Mertens bound, Li criterion, Riemann-von Mangoldt, density hypothesis, Chebyshev bounds, explicit formula, Selberg class, Hadamard product. Soundness audit: removed li_criterion (was inconsistent with wrong liCoefficient def), fixed auto-bound RiemannHypothesisStatement, unified eulerMascheroniGamma. 8329 lines, 41 axioms, 0 sorries.",
     "mathlibDependencies": [
       {
         "theorem": "riemannZeta",

--- a/src/data/research/problems/riemann-hypothesis.json
+++ b/src/data/research/problems/riemann-hypothesis.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added 9 proved theorems to Consequences file (PrimeGaps section, unconditional structure). All 42 axioms confirmed non-provable from Mathlib v4.26.0. Docker build passes.",
+    "progressSummary": "PROGRESS: 3 soundness fixes (liCoefficient/li_criterion inconsistency, auto-bound RiemannHypothesisStatement, eulerMascheroniGamma duplicate). Axioms: 33→32 main, 9 consequences. Docker build passes.",
     "builtItems": [
       {
         "name": "RH_implies_prime_gap_bound",
@@ -116,7 +116,10 @@
       "RSA-RH independence: RH helps cryptography more than it hurts",
       "Deleted 5 unused axioms: selberg_degree_zero, rh_nth_prime_estimate, riemann_siegel_z_function, linnik_constant_pos, sixth_moment_upper_bound",
       "PrimeGaps section filled: rh_psi_lower_bound, rh_psi_relative_error, rh_psi_eventually_positive, chebyshevTheta_nonneg, rh_dual_bounds",
-      "Unconditional structure: vonMangoldt_prime_pow, vonMangoldt_le_one, chebyshevPsi_nonneg, mertens_bound_gap"
+      "Unconditional structure: vonMangoldt_prime_pow, vonMangoldt_le_one, chebyshevPsi_nonneg, mertens_bound_gap",
+      "Soundness fix: removed liCoefficient def + li_criterion axiom (was inconsistent)",
+      "Soundness fix: rh_prime_gap_bound now uses correct RiemannHypothesis type",
+      "Cleanup: eulerMascheroniGamma → eulerMascheroni (Mathlib)"
     ],
     "insights": [
       "RH_implies_prime_gap_bound",
@@ -150,7 +153,10 @@
       "After 83→50 cleanup, another 16% of axioms (8 of 50) were documentation-only dead weight. All 42 remaining axioms are genuinely load-bearing in proofs.",
       "All 42 remaining axioms are genuinely deep number theory results, not provable from current Mathlib (v4.26.0)",
       "zeta_conj requires identity theorem for antiholomorphic compositions - Mathlib has half-plane version only",
-      "no_real_zeros_in_strip requires eta function or sign analysis on (0,1) - neither available in Mathlib"
+      "no_real_zeros_in_strip requires eta function or sign analysis on (0,1) - neither available in Mathlib",
+      "CRITICAL BUG FIX: liCoefficient was a concrete def using leading-term asymptotic, not true Li coefficients. For n≈50+, this approximation goes negative. Combined with li_criterion axiom, could derive ¬RH. Fixed by removing liCoefficient and li_criterion, using existing opaque liConstant + RH_iff_LiPositivity instead.",
+      "BUG FIX: rh_prime_gap_bound, rh_gap_sublinear, rh_short_interval_primes used undefined RiemannHypothesisStatement (auto-bound as implicit variable, making axioms vacuous). Fixed to use local RiemannHypothesis.",
+      "Cleanup: Removed opaque eulerMascheroniGamma (duplicate of eulerMascheroni = Real.eulerMascheroniConstant). Volchkov criterion now uses the concrete Mathlib constant."
     ],
     "mathlibGaps": [
       "Dirichlet series",
@@ -182,5 +188,12 @@
   "lastUpdate": "2026-03-20T19:45:00.000Z",
   "completed": "2026-03-15T17:29:13.116Z",
   "significance": 10,
-  "tractability": 1
+  "tractability": 1,
+  "leanFiles": [
+    {
+      "axiomCount": 32,
+      "lineCount": 6594,
+      "sorryCount": 0
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- **CRITICAL**: Removed inconsistent `liCoefficient` def + `li_criterion` axiom that could derive ¬RH
- Fixed 3 auto-bound `RiemannHypothesisStatement` variables (vacuous axioms)
- Removed duplicate `eulerMascheroniGamma` opaque, unified with Mathlib's constant

## Details

### Bug 1: liCoefficient/li_criterion inconsistency
`liCoefficient(n)` used the leading asymptotic term, not true Li coefficients. Goes negative for n≈50+, allowing `¬RH` derivation via `li_criterion`. The sound version (`liConstant` + `RH_iff_LiPositivity`) already existed at Part LIV.

### Bug 2: Auto-bound RiemannHypothesisStatement  
`rh_prime_gap_bound`, `rh_gap_sublinear`, `rh_short_interval_primes` used undefined name → Lean auto-bound as implicit variable → axioms were vacuously true for any type.

### Bug 3: Duplicate euler constant
`eulerMascheroniGamma` opaque duplicated `eulerMascheroni` (= `Real.eulerMascheroniConstant`).

## Stats
- Axioms: 42 → 41 (32 main + 9 consequences)
- Lines: 8329 (6594 + 1735)  
- Sorries: 0
- Docker build: passes for both files

## Test plan
- [x] Docker build Proofs.RiemannHypothesis — passes
- [x] Docker build Proofs.RiemannHypothesisConsequences — passes
- [x] No remaining sorry in either file
- [x] Axiom types verified in build output (no auto-bound variables)

🤖 Generated by researcher-1