### PR TITLE
Enrich erdos-1089: add mathContext to all sections

### DIFF
--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -93,56 +93,64 @@
       "title": "Points and Distances",
       "summary": "Defines Point d = EuclideanSpace ℝ (Fin d), Euclidean distance via ‖p - q‖, distinctDistances via Finset.product/image/filter, and numDistinctDistances as the cardinality.",
       "startLine": 38,
-      "endLine": 57
+      "endLine": 57,
+      "mathContext": "$\\text{Point}\\,d = \\text{EuclideanSpace}\\,\\mathbb{R}\\,(\\text{Fin}\\,d)$. Distance: $d(p,q) = \\|p - q\\|$. $\\Delta(P) = \\{\\|p-q\\| : (p,q) \\in P \\times P, p \\neq q\\}$ via `Finset.image` and `Finset.filter`."
     },
     {
       "id": "gfunction",
       "title": "The Function g_d(n)",
       "summary": "Defines determinesNDistances (numDistinctDistances P ≥ n) and g d n via Nat.sInf. Axiomatizes well-definedness for n ≥ 1.",
       "startLine": 59,
-      "endLine": 75
+      "endLine": 75,
+      "mathContext": "$g_d(n) = \\inf\\{m \\in \\mathbb{N} : \\forall P \\subseteq \\mathbb{R}^d,\\,|P|=m \\implies |\\Delta(P)| \\geq n\\}$. Well-definedness ($g_d(n) < \\infty$ for $n \\geq 1$) is axiomatized."
     },
     {
       "id": "small",
       "title": "Small Cases",
       "summary": "Axiomatizes g_1(3) = 4, g_2(3) = 6, g_3(3) = 7 (Croft 1962). Proves g_d(1) = 2 (sorry'd) and axiomatizes g_d(2) = 3.",
       "startLine": 77,
-      "endLine": 97
+      "endLine": 97,
+      "mathContext": "$g_1(3)=4$, $g_2(3)=6$, $g_3(3)=7$ (Croft 1962). Trivially $g_d(1)=2$ (any two points have 1 distance) and $g_d(2)=3$ for $d \\geq 1$."
     },
     {
       "id": "lower",
       "title": "Lower Bound: Cube Construction",
       "summary": "Axiomatizes cubeVertices with 2^d vertices and ≤ d distinct distances. The sorry'd cube_lower_bound gives g_d(d+1) > 2^d. The general erdos_lower_bound axiomatizes g_d(n) ≥ c·d^{n-1}.",
       "startLine": 99,
-      "endLine": 122
+      "endLine": 122,
+      "mathContext": "$\\{0,1\\}^d$ has $2^d$ vertices with $|\\Delta| = d$ (distances $\\sqrt{1}, \\ldots, \\sqrt{d}$). Hence $g_d(d+1) > 2^d$. General: $g_d(n) \\geq c \\cdot d^{n-1}$ for fixed $n$."
     },
     {
       "id": "upper",
       "title": "Upper Bound: Erdős-Straus",
       "summary": "Axiomatizes the Erdős-Straus bound: g_d(n) ≤ c^{d^{1-b_n}} for constants c > 1, b_n > 0. This stretched-exponential upper bound creates a vast gap with the polynomial lower bound.",
       "startLine": 124,
-      "endLine": 133
+      "endLine": 133,
+      "mathContext": "$g_d(n) \\leq c^{d^{1-b_n}}$ for constants $c > 1, b_n > 0$. Gap: $d^{n-1} \\ll g_d(n) \\leq c^{d^{1-b_n}}$ (polynomial vs. stretched-exponential)."
     },
     {
       "id": "conjecture",
       "title": "The Main Conjecture",
       "summary": "Defines gRatio(d, n) = g_d(n)/d^{n-1} and erdos1089Conjecture via Filter.Tendsto. Defines ratioIsBounded as a weaker question. Proves ratio_bounded_below genuinely from the Erdős lower bound.",
       "startLine": 135,
-      "endLine": 157
+      "endLine": 157,
+      "mathContext": "$R(d,n) = g_d(n)/d^{n-1}$. Conjecture: $\\exists L \\geq 0,\\; R(d,n) \\to L$ as $d \\to \\infty$. Proved: $R(d,n) \\geq c > 0$ from the Erdős lower bound."
     },
     {
       "id": "mono",
       "title": "Monotonicity Properties",
       "summary": "Axiomatizes g_mono_n (g increasing in n: more distances need more points) and g_mono_d (g increasing in d for n ≥ 2: higher dimensions allow more few-distance configurations).",
       "startLine": 159,
-      "endLine": 171
+      "endLine": 171,
+      "mathContext": "$n_1 \\leq n_2 \\implies g_d(n_1) \\leq g_d(n_2)$ (more distances $\\Rightarrow$ more points). $d_1 \\leq d_2 \\implies g_{d_1}(n) \\leq g_{d_2}(n)$ for $n \\geq 2$ (higher dimensions allow larger few-distance sets)."
     },
     {
       "id": "inverse",
       "title": "Connection to f_d(n) and Problem #1083",
       "summary": "Defines f d n = max distinct distances from n points. Axiomatizes g_f_relationship: g_d(n) = min{m : f_d(m) ≥ n}. Names the full open problem as erdos1089OpenProblem.",
       "startLine": 173,
-      "endLine": 202
+      "endLine": 202,
+      "mathContext": "$f_d(n) = \\max\\{|\\Delta(P)| : P \\subseteq \\mathbb{R}^d, |P| = n\\}$. Duality: $g_d(n) = \\inf\\{m : f_d(m) \\geq n\\}$. Guth-Katz (2015): $f_2(n) \\geq cn/\\sqrt{\\log n}$."
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary
- Added `mathContext` with LaTeX formulas to all 7 sections in erdos-1089
- Covers: threshold function, small cases, cube construction, Erdős-Straus bound, ratio conjecture, monotonicity, and f_d(n) connection

## Test plan
- [x] meta.json validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)