### PR TITLE
Enrich 4 entries: FTA, infinitude-primes, pythagorean-theorem + fixes

### DIFF
--- a/src/data/proofs/borsuk-ulam/annotations.json
+++ b/src/data/proofs/borsuk-ulam/annotations.json
@@ -9,6 +9,7 @@
     "type": "concept",
     "title": "The Theorem That Connects Temperature to Topology",
     "content": "The Borsuk-Ulam Theorem states: for any continuous function f: S^n -> R^n, there exist antipodal points x and -x with f(x) = f(-x).\n\nThe intuition is captivating: at any moment, there are two points on opposite sides of Earth with exactly the same temperature AND pressure. You can continuously measure any n quantities on an n-sphere, and somewhere, antipodal points match.\n\nThis 1933 result by Karol Borsuk (answering Stanislaw Ulam's question) became a cornerstone of algebraic topology with surprising applications from graph theory to fair division.\n\nThis formalization presents the conceptual structure. The full proof requires covering space theory, which we axiomatize to focus on the logical flow.",
+    "mathContext": "For any continuous $f: S^n \\to \\mathbb{R}^n$, $\\exists x \\in S^n$ such that $f(x) = f(-x)$. Equivalently, there is no continuous antipode-preserving map $S^n \\to S^{n-1}$.",
     "significance": "critical",
     "relatedConcepts": [
       "antipodal points",
@@ -26,6 +27,7 @@
     "type": "definition",
     "title": "The Antipodal Map: Flipping the Sphere",
     "content": "The **antipodal map** A: S^n -> S^n sends each point to its diametrically opposite point: A(x) = -x.\n\nKey properties:\n- **Involution**: A(A(x)) = x (applying twice returns to original)\n- **No fixed points**: A(x) != x for all x (you can't be your own opposite)\n- **Isometry**: Preserves distances on the sphere\n- **Free Z_2 action**: The two-element group {1, A} acts freely on S^n\n\nThe quotient space S^n / Z_2 (identifying x with -x) is **real projective space** RP^n. This quotient is central to the proof:\n- RP^n has fundamental group Z_2\n- The quotient map p: S^n -> RP^n is a 2-sheeted covering\n- This covering space structure is what makes the theorem work",
+    "mathContext": "The antipodal map $A: S^n \\to S^n$ is defined by $A(x) = -x$. Since $\\|-x\\| = \\|x\\| = 1$, $A$ preserves $S^n$. The quotient $S^n / \\langle A \\rangle \\cong \\mathbb{R}P^n$ with $\\pi_1(\\mathbb{R}P^n) \\cong \\mathbb{Z}/2\\mathbb{Z}$.",
     "significance": "key",
     "relatedConcepts": [
       "involution",
@@ -64,6 +66,7 @@
     "type": "concept",
     "title": "Covering Spaces: The Topological Machinery",
     "content": "**Covering space theory** is the algebraic topology machinery that powers the proof.\n\n**Key ideas**:\n1. **Real Projective Space**: RP^n = S^n / Z_2 (identify antipodal points)\n2. **Covering Map**: p: S^n -> RP^n is a 2-sheeted covering\n3. **Fundamental Group**: pi_1(RP^n) = Z_2 for n >= 1\n\n**Why this matters**:\n- An odd map h: S^n -> S^(n-1) respects the antipodal action\n- So h induces a map h_bar: RP^n -> RP^(n-1)\n- On fundamental groups: h_bar*: Z_2 -> Z_2\n- The covering structure forces h_bar* to be injective\n- But S^n is simply connected (n >= 2), so h_bar* must be trivial\n- Injective AND trivial? Only if Z_2 = 0. Contradiction!\n\nFor n=1, a direct argument using the intermediate value theorem works.",
+    "mathContext": "The covering $p: S^n \\to \\mathbb{R}P^n$ has $\\pi_1(\\mathbb{R}P^n) \\cong \\mathbb{Z}/2\\mathbb{Z}$. An odd map $h: S^n \\to S^{n-1}$ induces $\\bar{h}_*: \\pi_1(\\mathbb{R}P^n) \\to \\pi_1(\\mathbb{R}P^{n-1})$ which must be both injective (by covering theory) and trivial (since $\\pi_1(S^n) = 0$ for $n \\geq 2$), a contradiction.",
     "significance": "critical",
     "prerequisites": [
       "ann-sphere",

--- a/src/data/proofs/pythagorean-theorem/annotations.json
+++ b/src/data/proofs/pythagorean-theorem/annotations.json
@@ -91,7 +91,7 @@
     "id": "ann-main-theorem",
     "proofId": "pythagorean-theorem",
     "range": {
-      "startLine": 86,
+      "startLine": 94,
       "endLine": 107
     },
     "type": "theorem",
@@ -113,8 +113,8 @@
     "id": "ann-right-triangle",
     "proofId": "pythagorean-theorem",
     "range": {
-      "startLine": 132,
-      "endLine": 132
+      "startLine": 113,
+      "endLine": 121
     },
     "type": "definition",
     "title": "Right Triangle Structure",
@@ -130,8 +130,8 @@
     "id": "ann-classical",
     "proofId": "pythagorean-theorem",
     "range": {
-      "startLine": 138,
-      "endLine": 152
+      "startLine": 123,
+      "endLine": 132
     },
     "type": "theorem",
     "title": "Classical Formulation: a² + b² = c²",
@@ -151,8 +151,8 @@
     "id": "ann-triples",
     "proofId": "pythagorean-theorem",
     "range": {
-      "startLine": 138,
-      "endLine": 152
+      "startLine": 125,
+      "endLine": 132
     },
     "type": "concept",
     "title": "Pythagorean Triples",
@@ -166,28 +166,32 @@
     ]
   },
   {
-    "id": "ann-native-decide",
+    "id": "ann-generalized",
     "proofId": "pythagorean-theorem",
     "range": {
       "startLine": 171,
       "endLine": 209
     },
-    "type": "tactic",
-    "title": "Computational Verification",
-    "content": "Lean can **compute** that these are valid Pythagorean triples using `native_decide`. This tactic evaluates the arithmetic and checks that both sides equal the same value.\n\nFor $(3, 4, 5)$:\n- Left side: $3^2 + 4^2 = 9 + 16 = 25$\n- Right side: $5^2 = 25$\n- Equal? Yes! Proof complete.\n\nThis is one of Lean's strengths: verifiable computation meets rigorous proof.",
-    "significance": "supporting",
+    "type": "theorem",
+    "title": "Generalized Pythagorean Theorem for n Vectors",
+    "content": "`pythagorean_sum`: for mutually perpendicular vectors $v_1, \\ldots, v_k$:\n$$\\|\\sum_i v_i\\|^2 = \\sum_i \\|v_i\\|^2$$\n\nThe proof uses `Finset.induction_on`: base case is trivial (empty sum), inductive step shows $v_a \\perp \\sum_{i \\in s'} v_i$ by distributing the inner product over the sum (`inner_sum`), then applies the two-vector Pythagorean theorem.\n\nThis generalization is the foundation of orthogonal decomposition in functional analysis and quantum mechanics.",
+    "mathContext": "For mutually orthogonal $\\{v_i\\}_{i \\in s}$: $\\|\\sum_{i \\in s} v_i\\|^2 = \\sum_{i \\in s} \\|v_i\\|^2$. The key step: $\\langle v_a, \\sum_{i \\in s'} v_i \\rangle = \\sum_{i \\in s'} \\langle v_a, v_i \\rangle = 0$.",
+    "significance": "key",
+    "prerequisites": [
+      "ann-main-theorem"
+    ],
     "relatedConcepts": [
-      "decidability",
-      "computation in type theory",
-      "reflection"
+      "Parseval's identity",
+      "orthogonal decomposition",
+      "Finset induction"
     ]
   },
   {
     "id": "ann-converse",
     "proofId": "pythagorean-theorem",
     "range": {
-      "startLine": 171,
-      "endLine": 209
+      "startLine": 138,
+      "endLine": 152
     },
     "type": "theorem",
     "title": "The Converse Theorem",
@@ -204,8 +208,8 @@
     "id": "ann-history",
     "proofId": "pythagorean-theorem",
     "range": {
-      "startLine": 171,
-      "endLine": 209
+      "startLine": 158,
+      "endLine": 169
     },
     "type": "concept",
     "title": "4000 Years of History",

--- a/src/data/proofs/pythagorean-theorem/meta.json
+++ b/src/data/proofs/pythagorean-theorem/meta.json
@@ -14,7 +14,7 @@
       "classic",
       "beginner"
     ],
-    "proofRepoPath": "Proofs/Pythagorean.lean",
+    "proofRepoPath": "Proofs/PythagoreanTheorem.lean",
     "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
@@ -37,7 +37,8 @@
       "Norm and distance definitions"
     ],
     "wiedijkNumber": 4,
-    "axiomCount": 0
+    "axiomCount": 0,
+    "lineCount": 215
   },
   "overview": {
     "historicalContext": "The Pythagorean theorem is arguably the most recognized result in all of mathematics. While named after the Greek mathematician Pythagoras (c. 570-495 BCE), evidence suggests the theorem was known to Babylonian mathematicians over 1000 years earlier—clay tablet Plimpton 322 (c. 1800 BCE) contains a list of Pythagorean triples.\n\nPythagoras, or more likely his school, is credited with providing the first general proof. The theorem appears as Proposition 47 in Book I of Euclid's Elements (c. 300 BCE), where it's proved using areas of squares constructed on the triangle's sides.\n\nBy 1940, mathematician Elisha Loomis had catalogued 367 distinct proofs, and new proofs continue to be discovered. James Garfield, before becoming the 20th US President, published an original proof in 1876.",
@@ -54,82 +55,59 @@
   "sections": [
     {
       "id": "header",
-      "title": "Introduction",
+      "title": "Imports and Module Docstring",
       "startLine": 1,
-      "endLine": 13,
-      "summary": "Overview of the theorem and its historical significance, from ancient Babylon through Pythagoras to modern formalization.",
-      "mathContext": "The Pythagorean theorem: $a^2 + b^2 = c^2$ for right triangles, proved via inner product spaces in Lean 4"
-    },
-    {
-      "id": "real-numbers",
-      "title": "Real Number Foundations",
-      "startLine": 15,
-      "endLine": 32,
-      "summary": "Setting up the real number type and basic operations needed for geometric quantities.",
-      "mathContext": "Uses $\\mathbb{R}$ from Mathlib with field operations. Defines `Vec2` as a pair $(x, y) \\in \\mathbb{R}^2$"
+      "endLine": 44,
+      "summary": "Five Mathlib imports (InnerProductSpace.Basic, PiL2, Real.Basic, Real.Sqrt, Tactic), the module docstring covering the theorem statement, inner product approach, and Mathlib dependencies. Opens `RealInnerProductSpace` scoped instance.",
+      "mathContext": "The file uses Mathlib's `InnerProductSpace` over $\\mathbb{R}$ with `EuclideanSpace \\mathbb{R} (\\text{Fin}\\ 2)$ as the concrete $\\mathbb{R}^2$. Key API: `inner`, `norm`, `real_inner_self_eq_norm_mul_norm`, `inner_add_left/right`."
     },
     {
       "id": "vector-space",
-      "title": "Vector Space Structure",
-      "startLine": 34,
-      "endLine": 54,
-      "summary": "Defining 2D vectors and vector operations (addition, subtraction) for representing geometric points.",
-      "mathContext": "Vector addition $(v_1 + w_1, v_2 + w_2)$, subtraction, and scalar multiplication on $\\mathbb{R}^2$"
-    },
-    {
-      "id": "inner-product",
-      "title": "The Inner Product",
-      "startLine": 56,
-      "endLine": 73,
-      "summary": "Introducing the dot product and norm—the algebraic tools that encode geometry.",
-      "mathContext": "$\\langle v, w \\rangle = v_1 w_1 + v_2 w_2$, $\\|v\\|^2 = \\langle v, v \\rangle = v_1^2 + v_2^2$"
+      "title": "Vector Space and Inner Product",
+      "startLine": 46,
+      "endLine": 65,
+      "summary": "Parts 1–2: defines `Vec2 := EuclideanSpace ℝ (Fin 2)`, checks inner product type, and proves `norm_sq_eq_inner`: $\\|v\\|^2 = \\langle v, v \\rangle$.",
+      "mathContext": "$\\text{Vec2} = \\mathbb{R}^2$ via `EuclideanSpace`. The norm-inner product relation $\\|v\\|^2 = \\langle v, v \\rangle$ is proved from `real_inner_self_eq_norm_mul_norm`."
     },
     {
       "id": "perpendicularity",
       "title": "Perpendicularity",
-      "startLine": 75,
-      "endLine": 85,
-      "summary": "Defining perpendicular vectors as those with zero inner product—the key to the theorem.",
-      "mathContext": "$v \\perp w \\iff \\langle v, w \\rangle = 0$. Perpendicularity is symmetric: $\\langle v, w \\rangle = 0 \\iff \\langle w, v \\rangle = 0$"
+      "startLine": 67,
+      "endLine": 80,
+      "summary": "Part 3: defines `perpendicular v w := inner v w = 0`, notation `v ⊥ w`, and proves symmetry `perp_symm` via `real_inner_comm`.",
+      "mathContext": "$v \\perp w \\iff \\langle v, w \\rangle = 0$. Symmetry: $\\langle v, w \\rangle = \\langle w, v \\rangle$ (real inner products are symmetric)."
     },
     {
       "id": "main-theorem",
       "title": "The Pythagorean Theorem",
-      "startLine": 87,
-      "endLine": 117,
-      "summary": "The main proof using bilinearity of inner products and the perpendicularity condition.",
-      "mathContext": "$v \\perp w \\implies \\|v + w\\|^2 = \\|v\\|^2 + \\|w\\|^2$. Proof: expand by bilinearity, cross terms $\\langle v, w \\rangle = 0$ vanish"
+      "startLine": 82,
+      "endLine": 107,
+      "summary": "Part 4: `pythagorean_theorem` — if $v \\perp w$ then $\\|v + w\\|^2 = \\|v\\|^2 + \\|w\\|^2$. Proof: expand $\\langle v+w, v+w \\rangle$ by `inner_add_left/right`, use perpendicularity to zero cross terms, finish with `ring`.",
+      "mathContext": "$\\|v + w\\|^2 = \\langle v+w, v+w \\rangle = \\langle v,v \\rangle + \\langle v,w \\rangle + \\langle w,v \\rangle + \\langle w,w \\rangle = \\|v\\|^2 + 0 + 0 + \\|w\\|^2$"
     },
     {
-      "id": "geometric-interpretation",
-      "title": "Geometric Interpretation",
-      "startLine": 119,
-      "endLine": 147,
-      "summary": "Connecting the vector formulation to the classical triangle with sides a, b, c.",
-      "mathContext": "For triangle with vertices $A, B, C$ and right angle at $C$: legs $a = \\|B - C\\|$, $b = \\|A - C\\|$, hypotenuse $c = \\|A - B\\|$, giving $a^2 + b^2 = c^2$"
-    },
-    {
-      "id": "pythagorean-triples",
-      "title": "Pythagorean Triples",
-      "startLine": 149,
-      "endLine": 177,
-      "summary": "Integer solutions like (3,4,5), verified computationally, and the generating formula.",
-      "mathContext": "Integer solutions $(a, b, c)$: $(3, 4, 5)$, $(5, 12, 13)$, $(8, 15, 17)$. Parametrization: $a = m^2 - n^2$, $b = 2mn$, $c = m^2 + n^2$"
+      "id": "classical",
+      "title": "Classical Formulation and Triples",
+      "startLine": 109,
+      "endLine": 132,
+      "summary": "Part 5: `RightTriangle` structure (legs a, b, hypotenuse c with positivity and $a^2 + b^2 = c^2$), then three Pythagorean triples verified by `norm_num`: $(3,4,5)$, $(5,12,13)$, $(8,15,17)$.",
+      "mathContext": "Pythagorean triples verified: $3^2 + 4^2 = 9 + 16 = 25 = 5^2$, etc. All primitive triples are generated by $a = m^2-n^2$, $b = 2mn$, $c = m^2+n^2$."
     },
     {
       "id": "converse",
       "title": "The Converse",
-      "startLine": 179,
-      "endLine": 195,
-      "summary": "If a² + b² = c², then the triangle has a right angle—Euclid's Proposition 48."
+      "startLine": 134,
+      "endLine": 152,
+      "summary": "Part 6: `pythagorean_converse` — if $\\|v+w\\|^2 = \\|v\\|^2 + \\|w\\|^2$ then $v \\perp w$. Proof: expand, cancel the self-inner products, deduce $2\\langle v,w \\rangle = 0$ by `linarith`.",
+      "mathContext": "Euclid's Proposition I.48: $a^2 + b^2 = c^2 \\Rightarrow$ right angle. The converse: expanding gives $\\langle v,v \\rangle + 2\\langle v,w \\rangle + \\langle w,w \\rangle = \\langle v,v \\rangle + \\langle w,w \\rangle$, so $\\langle v,w \\rangle = 0$."
     },
     {
-      "id": "history",
-      "title": "Historical Context",
-      "startLine": 197,
-      "endLine": 225,
-      "summary": "Timeline from Babylon to modern times, proof methods, and generalizations.",
-      "mathContext": "From Babylonian tablet Plimpton 322 (~1800 BCE) to Euclid's Elements I.47 (~300 BCE) to modern inner product space proofs"
+      "id": "generalization",
+      "title": "Generalized Pythagorean Theorem",
+      "startLine": 154,
+      "endLine": 215,
+      "summary": "Part 7: `pythagorean_sum` — for mutually perpendicular vectors $\\{v_i\\}$, $\\|\\sum v_i\\|^2 = \\sum \\|v_i\\|^2$. Proved by `Finset.induction_on` with the key step showing $\\langle v_a, \\sum_{s'} v_i \\rangle = 0$ via `inner_sum`.",
+      "mathContext": "The $n$-dimensional Pythagorean theorem: $\\|\\sum_{i=1}^k v_i\\|^2 = \\sum_{i=1}^k \\|v_i\\|^2$ when $\\langle v_i, v_j \\rangle = 0$ for $i \\neq j$. This is the foundation of Parseval's identity in Hilbert spaces."
     }
   ],
   "conclusion": {
@@ -163,9 +141,27 @@
       "targetId": "area-of-circle",
       "relationship": "related",
       "description": "Both are fundamental results in Euclidean geometry. The Pythagorean theorem relates side lengths; the area formula uses πr² which depends on the same metric structure"
+    },
+    {
+      "targetId": "angle-trisection",
+      "relationship": "related",
+      "description": "The Pythagorean theorem underpins compass-and-straightedge constructions — every constructible length arises from iterated application of the theorem via circle-line intersections"
+    },
+    {
+      "targetId": "fermats-last-theorem",
+      "relationship": "foundational",
+      "description": "FLT generalizes the Pythagorean equation: while a²+b²=c² has infinitely many integer solutions, aⁿ+bⁿ=cⁿ has none for n≥3"
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "Both are consequences of inner product space structure: Pythagorean theorem uses orthogonality (⟨v,w⟩=0), Cauchy-Schwarz bounds the general case (|⟨v,w⟩| ≤ ‖v‖‖w‖)"
     }
   ],
   "relatedProofs": [
-    "area-of-circle"
+    "area-of-circle",
+    "angle-trisection",
+    "fermats-last-theorem",
+    "cauchy-schwarz"
   ]
 }


### PR DESCRIPTION
## Summary
Deep enrichment of 4 classic proofs with line range corrections, cross-references, and quality improvements.

### fundamental-theorem-algebra
- Fixed 4 annotations with wrong ranges (3 shared the same range 81-100)
- Rewrote all 8 annotations, 6 sections + 1 new
- Added proofRepoPath, lineCount, references, 4 cross-refs

### infinitude-primes
- Fixed 9 annotation ranges (3 duplicate-range pairs resolved)
- Added 4 cross-references: bertrands-postulate, PNT, FTA, twin-primes

### pythagorean-theorem
- **Fixed proofRepoPath** "Proofs/Pythagorean.lean" → "Proofs/PythagoreanTheorem.lean"
- Fixed 6 annotation ranges, replaced incorrect ann-native-decide
- Rewrote 7 sections to match actual file structure
- Added 3 cross-references: angle-trisection, FLT, cauchy-schwarz

## Test plan
- [x] JSON validates (verified locally)
- [ ] pnpm build passes