### PR TITLE
refactor: Extract SzemerediCore.lean + Shannon entropy progress

### DIFF
--- a/proofs/Proofs/ShannonEntropy.lean
+++ b/proofs/Proofs/ShannonEntropy.lean
@@ -311,13 +311,89 @@ theorem mutual_info_nonneg {α β : Type*} [Fintype α] [Fintype β]
 
 -- Chain rule: I(X;Y) = H(X) - H(X|Y)
 -- This connects mutual information (as KL divergence from product) to entropy difference.
+--
+-- Proof strategy: Expand all three definitions. The key algebraic identity is
+--   log(p(x,y)/(pX(x)*pY(y))) = log(p(x,y)/pY(y)) - log(pX(x))
+-- for p(x,y) > 0 (which forces pX(x), pY(y) > 0).
+-- Summing p(x,y)*log(pX(x)) over y yields pX(x)*log(pX(x)), connecting
+-- the mutual information sum to the difference H(X) - H(X|Y).
+--
+-- The formalization is nontrivial due to the if-then-else branches in all three
+-- definitions (0*log(0) convention). The proof works by:
+-- 1. Showing MI = sum of conditional entropy terms minus sum of marginal entropy terms
+-- 2. The conditional sum equals -H(X|Y), the marginal sum equals -H(X)
+-- 3. Therefore MI = -H(X|Y) - (-H(X)) = H(X) - H(X|Y)
 theorem chain_rule {α β : Type*} [Fintype α] [Fintype β]
     [DecidableEq α] [DecidableEq β]
     {pXY : α × β → ℝ} (hp : ∀ xy, 0 ≤ pXY xy)
     (hsum : ∑ xy : α × β, pXY xy = 1) :
     mutualInformation pXY =
     shannonEntropy (fun x => ∑ y : β, pXY (x, y)) - conditionalEntropy pXY := by
-  sorry
+  -- Step 1: Key term-by-term identity
+  -- For each (x,y): the MI term splits into a conditional entropy term minus
+  -- a marginal entropy term, using log(a/(b*c)) = log(a/c) - log(b).
+  have hterm : ∀ x y,
+      (if pXY (x, y) = 0 then (0 : ℝ)
+       else pXY (x, y) * Real.log (pXY (x, y) /
+         ((∑ y' : β, pXY (x, y')) * (∑ x' : α, pXY (x', y))))) =
+      (if pXY (x, y) = 0 then 0
+       else pXY (x, y) * Real.log (pXY (x, y) / (∑ x' : α, pXY (x', y)))) -
+      (if pXY (x, y) = 0 then 0
+       else pXY (x, y) * Real.log (∑ y' : β, pXY (x, y'))) := by
+    intro x y
+    by_cases hpxy : pXY (x, y) = 0
+    · simp [hpxy]
+    · simp [hpxy]
+      have hpxy_pos : 0 < pXY (x, y) :=
+        lt_of_le_of_ne (hp (x, y)) (Ne.symm hpxy)
+      have hpx_pos : 0 < ∑ y' : β, pXY (x, y') :=
+        calc 0 < pXY (x, y) := hpxy_pos
+          _ ≤ ∑ y' : β, pXY (x, y') :=
+            Finset.single_le_sum (f := fun y' => pXY (x, y'))
+              (fun y' _ => hp (x, y')) (Finset.mem_univ y)
+      have hpy_pos : 0 < ∑ x' : α, pXY (x', y) :=
+        calc 0 < pXY (x, y) := hpxy_pos
+          _ ≤ ∑ x' : α, pXY (x', y) :=
+            Finset.single_le_sum (f := fun x' => pXY (x', y))
+              (fun x' _ => hp (x', y)) (Finset.mem_univ x)
+      rw [Real.log_div (ne_of_gt hpxy_pos) (ne_of_gt (mul_pos hpx_pos hpy_pos)),
+          Real.log_mul (ne_of_gt hpx_pos) (ne_of_gt hpy_pos),
+          Real.log_div (ne_of_gt hpxy_pos) (ne_of_gt hpy_pos)]
+      ring
+  -- Step 2: The marginal sum telescopes
+  -- sum_y [if p(x,y)=0 then 0 else p(x,y)*log(pX(x))]
+  -- = if pX(x)=0 then 0 else pX(x)*log(pX(x))
+  have hmarg : ∀ x,
+      ∑ y : β, (if pXY (x, y) = 0 then (0 : ℝ)
+        else pXY (x, y) * Real.log (∑ y' : β, pXY (x, y'))) =
+      (if (∑ y : β, pXY (x, y)) = 0 then 0
+       else (∑ y : β, pXY (x, y)) * Real.log (∑ y : β, pXY (x, y))) := by
+    intro x
+    by_cases hpx : (∑ y : β, pXY (x, y)) = 0
+    · have hall : ∀ y, pXY (x, y) = 0 := by
+        intro y
+        have h1 := hp (x, y)
+        have h2 : pXY (x, y) ≤ ∑ y' : β, pXY (x, y') :=
+          Finset.single_le_sum (f := fun y' => pXY (x, y'))
+            (fun y' _ => hp (x, y')) (Finset.mem_univ y)
+        linarith
+      simp [hpx, hall]
+    · simp [hpx]
+      have : ∑ y : β, (if pXY (x, y) = 0 then (0 : ℝ)
+          else pXY (x, y) * Real.log (∑ y' : β, pXY (x, y'))) =
+          ∑ y : β, pXY (x, y) * Real.log (∑ y' : β, pXY (x, y')) := by
+        apply Finset.sum_congr rfl
+        intro y _
+        by_cases hpxy : pXY (x, y) = 0
+        · simp [hpxy]
+        · simp [hpxy]
+      rw [this, ← Finset.sum_mul]
+  -- Step 3: Assemble the proof
+  unfold mutualInformation shannonEntropy conditionalEntropy
+  -- Beta-reduce (fun x => ...) x that arises from shannonEntropy application
+  dsimp only
+  simp_rw [hterm, Finset.sum_sub_distrib, hmarg]
+  ring
 
 -- Conditioning reduces entropy: H(X|Y) ≤ H(X)
 -- Proof: by the chain rule, H(X) - H(X|Y) = I(X;Y) ≥ 0.

--- a/proofs/Proofs/SzemerediCore.lean
+++ b/proofs/Proofs/SzemerediCore.lean
@@ -1,0 +1,101 @@
+/-
+  Szemeredi Core Definitions
+
+  Shared definitions and basic lemmas for the Szemeredi regularity pipeline.
+  This module is imported by both SzemerediRegularity.lean (proof machinery)
+  and SzemerediCounting.lean (counting/removal lemmas), preventing definition
+  drift across the pipeline.
+
+  Definitions:
+  - edgeDensity: edge density between two vertex subsets
+  - IsEpsilonRegular: epsilon-regularity of a pair
+  - IsRegularPartition: epsilon-regular partition
+  - partitionEnergy: energy of a partition
+
+  Basic lemmas:
+  - edgeDensity_nonneg, edgeDensity_le_one
+  - partitionEnergy_nonneg
+
+  Szemeredi (1975), Komlos-Simonovits (1996)
+-/
+import Mathlib
+
+namespace Szemeredi.Core
+
+open Classical
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- Edge density between two disjoint vertex subsets in a simple graph.
+    d(A,B) = |E(A,B)| / (|A| * |B|). -/
+noncomputable def edgeDensity (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B : Finset V) : ℚ :=
+  if h : (A.card : ℚ) * B.card = 0 then 0
+  else ((A.product B).filter (fun p => G.Adj p.1 p.2)).card / (A.card * B.card)
+
+/-- A pair (A, B) of vertex subsets is epsilon-regular if for every
+    A' ⊆ A, B' ⊆ B with |A'| >= eps|A| and |B'| >= eps|B|, the edge
+    density d(A', B') is within eps of d(A, B). -/
+def IsEpsilonRegular (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) : Prop :=
+  ∀ A' B' : Finset V,
+    A' ⊆ A → B' ⊆ B →
+    (A'.card : ℚ) ≥ eps * A.card →
+    (B'.card : ℚ) ≥ eps * B.card →
+    |edgeDensity G A' B' - edgeDensity G A B| ≤ eps
+
+/-- An equipartition is epsilon-regular if at most epsilon * C(k,2) pairs
+    are not epsilon-regular. -/
+def IsRegularPartition (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (parts : Finset (Finset V)) : Prop :=
+  -- All parts have approximately equal size (equitable)
+  (∀ P Q : Finset V, P ∈ parts → Q ∈ parts → (P.card : ℤ) - Q.card ≤ 1) ∧
+  -- At most eps * C(k,2) pairs are irregular
+  ((parts.product parts).filter (fun pq =>
+    pq.1 ≠ pq.2 ∧ ¬IsEpsilonRegular G eps pq.1 pq.2)).card ≤
+    eps * (parts.card * (parts.card - 1))
+
+/-- The energy of a partition: E(P) = (1/k^2) * Sigma_{i,j} d(Vi, Vj)^2.
+    Energy lies in [0,1] and increases under refinement. -/
+noncomputable def partitionEnergy (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : Finset (Finset V)) : ℚ :=
+  if h : parts.card = 0 then 0
+  else (1 : ℚ) / (parts.card ^ 2) *
+    (parts.product parts).sum (fun pq => (edgeDensity G pq.1 pq.2) ^ 2)
+
+/-- Edge density is non-negative. -/
+theorem edgeDensity_nonneg (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B : Finset V) : 0 ≤ edgeDensity G A B := by
+  unfold edgeDensity
+  split_ifs
+  · exact le_refl 0
+  · positivity
+
+/-- Edge density is at most 1. -/
+theorem edgeDensity_le_one (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A B : Finset V) : edgeDensity G A B ≤ 1 := by
+  unfold edgeDensity
+  split_ifs with h
+  · exact zero_le_one
+  · have hne : (A.card : ℚ) * B.card ≠ 0 := h
+    have hpos : (0 : ℚ) < (A.card : ℚ) * B.card :=
+      lt_of_le_of_ne (by positivity) hne.symm
+    rw [div_le_one hpos]
+    have h1 : {p ∈ A.product B | G.Adj p.1 p.2}.card ≤ A.card * B.card := by
+      calc {p ∈ A.product B | G.Adj p.1 p.2}.card
+          ≤ (A.product B).card := Finset.card_filter_le _ _
+        _ = A.card * B.card := Finset.card_product A B
+    exact_mod_cast h1
+
+/-- Partition energy is non-negative. -/
+theorem partitionEnergy_nonneg (G : SimpleGraph V) [DecidableRel G.Adj]
+    (parts : Finset (Finset V)) :
+    0 ≤ partitionEnergy G parts := by
+  unfold partitionEnergy
+  split_ifs with h
+  · exact le_refl 0
+  · apply mul_nonneg
+    · positivity
+    · exact Finset.sum_nonneg (fun _ _ => sq_nonneg _)
+
+end Szemeredi.Core

--- a/proofs/Proofs/SzemerediCounting.lean
+++ b/proofs/Proofs/SzemerediCounting.lean
@@ -1,7 +1,7 @@
 /-
   Counting and Removal Lemma
 
-  The triangle removal lemma and graph counting lemma — key consequences
+  The triangle removal lemma and graph counting lemma -- key consequences
   of the Szemeredi Regularity Lemma. Regular pairs behave like random
   bipartite graphs for subgraph counting, and a graph with few triangles
   can be made triangle-free by removing few edges.
@@ -13,11 +13,12 @@
   Ruzsa-Szemeredi (1978), Komlos-Simonovits (1996)
 -/
 import Mathlib
+import Proofs.SzemerediCore
 import Proofs.SzemerediRegularity
 
 namespace Szemeredi.Counting
 
-open Classical
+open Classical Szemeredi.Core
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
@@ -107,7 +108,7 @@ theorem bad_vertices_small (G : SimpleGraph V) [DecidableRel G.Adj]
   have hdU : Szemeredi.Regularity.edgeDensity G A' B < d - eps := by
     -- Each a ∈ A' = badVertices has |N_B(a)| < (d-ε)|B|.
     -- Total edges = Σ|N_B(a)| < |A'|*(d-ε)*|B|, so density < d-ε.
-    unfold Szemeredi.Regularity.edgeDensity
+    unfold Szemeredi.Core.edgeDensity
     have hA'B_pos : (0 : ℚ) < (A'.card : ℚ) * B.card := by positivity
     rw [dif_neg (ne_of_gt hA'B_pos)]
     rw [div_lt_iff₀ hA'B_pos]

--- a/proofs/Proofs/SzemerediRegularity.lean
+++ b/proofs/Proofs/SzemerediRegularity.lean
@@ -5,101 +5,35 @@
   parts such that edges between most pairs behave pseudo-randomly.
   The fundamental structural result in graph theory.
 
-  Part I: Epsilon-regular pairs and partitions
-  Part II: Partition energy and energy increment
-  Part III: Regularity lemma (main result)
+  Core definitions (edgeDensity, IsEpsilonRegular, IsRegularPartition,
+  partitionEnergy) and basic lemmas live in SzemerediCore.lean.
+  This file contains the proof machinery:
+  - Density-squared convexity (Cauchy-Schwarz ingredient)
+  - Energy increment step
+  - Partition energy upper bound
+  - Regularity lemma (main result)
 
   Szemeredi (1975), Komlos-Simonovits (1996)
 -/
 import Mathlib
+import Proofs.SzemerediCore
 
 namespace Szemeredi.Regularity
 
-open Classical
+-- Re-export Core definitions so that downstream code referencing
+-- Szemeredi.Regularity.edgeDensity etc. continues to compile.
+export Szemeredi.Core (edgeDensity IsEpsilonRegular IsRegularPartition
+  partitionEnergy edgeDensity_nonneg edgeDensity_le_one partitionEnergy_nonneg)
+
+open Classical Szemeredi.Core
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
-
--- ═══════════════════════════════════════════════════════════════════
--- PART I: EPSILON-REGULAR PAIRS AND PARTITIONS
--- ═══════════════════════════════════════════════════════════════════
-
-/-- Edge density between two disjoint vertex subsets in a simple graph.
-    d(A,B) = |E(A,B)| / (|A| * |B|). -/
-noncomputable def edgeDensity (G : SimpleGraph V) [DecidableRel G.Adj]
-    (A B : Finset V) : ℚ :=
-  if h : (A.card : ℚ) * B.card = 0 then 0
-  else ((A.product B).filter (fun p => G.Adj p.1 p.2)).card / (A.card * B.card)
-
-/-- A pair (A, B) of vertex subsets is epsilon-regular if for every
-    A' ⊆ A, B' ⊆ B with |A'| ≥ ε|A| and |B'| ≥ ε|B|, the edge
-    density d(A', B') is within ε of d(A, B). -/
-def IsEpsilonRegular (G : SimpleGraph V) [DecidableRel G.Adj]
-    (eps : ℚ) (A B : Finset V) : Prop :=
-  ∀ A' B' : Finset V,
-    A' ⊆ A → B' ⊆ B →
-    (A'.card : ℚ) ≥ eps * A.card →
-    (B'.card : ℚ) ≥ eps * B.card →
-    |edgeDensity G A' B' - edgeDensity G A B| ≤ eps
-
-/-- An equipartition is epsilon-regular if at most epsilon * C(k,2) pairs
-    are not epsilon-regular. -/
-def IsRegularPartition (G : SimpleGraph V) [DecidableRel G.Adj]
-    (eps : ℚ) (parts : Finset (Finset V)) : Prop :=
-  -- All parts have approximately equal size (equitable)
-  (∀ P Q : Finset V, P ∈ parts → Q ∈ parts → (P.card : ℤ) - Q.card ≤ 1) ∧
-  -- At most eps * C(k,2) pairs are irregular
-  ((parts.product parts).filter (fun pq =>
-    pq.1 ≠ pq.2 ∧ ¬IsEpsilonRegular G eps pq.1 pq.2)).card ≤
-    eps * (parts.card * (parts.card - 1))
-
-/-- Edge density is non-negative. -/
-theorem edgeDensity_nonneg (G : SimpleGraph V) [DecidableRel G.Adj]
-    (A B : Finset V) : 0 ≤ edgeDensity G A B := by
-  unfold edgeDensity
-  split_ifs
-  · exact le_refl 0
-  · positivity
-
-/-- Edge density is at most 1. -/
-theorem edgeDensity_le_one (G : SimpleGraph V) [DecidableRel G.Adj]
-    (A B : Finset V) : edgeDensity G A B ≤ 1 := by
-  unfold edgeDensity
-  split_ifs with h
-  · exact zero_le_one
-  · have hne : (A.card : ℚ) * B.card ≠ 0 := h
-    have hpos : (0 : ℚ) < (A.card : ℚ) * B.card :=
-      lt_of_le_of_ne (by positivity) hne.symm
-    rw [div_le_one hpos]
-    have h1 : {p ∈ A.product B | G.Adj p.1 p.2}.card ≤ A.card * B.card := by
-      calc {p ∈ A.product B | G.Adj p.1 p.2}.card
-          ≤ (A.product B).card := Finset.card_filter_le _ _
-        _ = A.card * B.card := Finset.card_product A B
-    exact_mod_cast h1
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART II: PARTITION ENERGY AND ENERGY INCREMENT
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- The energy of a partition: E(P) = (1/k²) * Σ_{i,j} d(Vᵢ, Vⱼ)².
-    Energy lies in [0,1] and increases under refinement. -/
-noncomputable def partitionEnergy (G : SimpleGraph V) [DecidableRel G.Adj]
-    (parts : Finset (Finset V)) : ℚ :=
-  if h : parts.card = 0 then 0
-  else (1 : ℚ) / (parts.card ^ 2) *
-    (parts.product parts).sum (fun pq => (edgeDensity G pq.1 pq.2) ^ 2)
-
-/-- Partition energy is non-negative. -/
-theorem partitionEnergy_nonneg (G : SimpleGraph V) [DecidableRel G.Adj]
-    (parts : Finset (Finset V)) :
-    0 ≤ partitionEnergy G parts := by
-  unfold partitionEnergy
-  split_ifs with h
-  · exact le_refl 0
-  · apply mul_nonneg
-    · positivity
-    · exact Finset.sum_nonneg (fun _ _ => sq_nonneg _)
-
-/-- Helper: |A| * |B| * edgeDensity(A,B) = edge count (as ℚ). -/
+/-- Helper: |A| * |B| * edgeDensity(A,B) = edge count (as Q). -/
 private theorem card_mul_edgeDensity (G : SimpleGraph V) [DecidableRel G.Adj]
     (A B : Finset V) :
     (A.card : ℚ) * B.card * edgeDensity G A B =
@@ -118,7 +52,7 @@ private theorem card_mul_edgeDensity (G : SimpleGraph V) [DecidableRel G.Adj]
     have hne : (↑A.card : ℚ) * ↑B.card ≠ 0 := h
     rw [mul_div_cancel₀ _ hne]
 
-/-- Edge count additivity: for disjoint A₁, A₂, edge counts to B add. -/
+/-- Edge count additivity: for disjoint A1, A2, edge counts to B add. -/
 private theorem edge_count_union (G : SimpleGraph V) [DecidableRel G.Adj]
     (A₁ A₂ B : Finset V) (hA : Disjoint A₁ A₂) :
     (((A₁ ∪ A₂).product B).filter (fun p => G.Adj p.1 p.2)).card =
@@ -146,7 +80,7 @@ private theorem edge_count_union (G : SimpleGraph V) [DecidableRel G.Adj]
     (Finset.disjoint_left.mp hA (Finset.mem_product.mp h₁).1)
 
 /-- Convexity lemma: splitting a vertex set increases the sum of squared densities.
-    If A = A₁ ∪ A₂ (disjoint), then |A₁|*d(A₁,B)² + |A₂|*d(A₂,B)² ≥ |A|*d(A,B)².
+    If A = A1 U A2 (disjoint), then |A1|*d(A1,B)^2 + |A2|*d(A2,B)^2 >= |A|*d(A,B)^2.
     This is the Cauchy-Schwarz ingredient for the energy increment. -/
 theorem density_sq_convex (G : SimpleGraph V) [DecidableRel G.Adj]
     (A₁ A₂ B : Finset V) (hA : Disjoint A₁ A₂) :
@@ -162,7 +96,7 @@ theorem density_sq_convex (G : SimpleGraph V) [DecidableRel G.Adj]
   -- Non-negativity
   have hn₁ : 0 ≤ n₁ := Nat.cast_nonneg _
   have hn₂ : 0 ≤ n₂ := Nat.cast_nonneg _
-  -- The weighted average property: (n₁+n₂)*m*d = n₁*m*d₁ + n₂*m*d₂
+  -- The weighted average property: (n1+n2)*m*d = n1*m*d1 + n2*m*d2
   have hcard : (↑(A₁ ∪ A₂).card : ℚ) = n₁ + n₂ := by
     rw [Finset.card_union_of_disjoint hA]; push_cast; ring
   have havg : (n₁ + n₂) * ↑B.card * d = n₁ * ↑B.card * d₁ + n₂ * ↑B.card * d₂ := by
@@ -175,7 +109,7 @@ theorem density_sq_convex (G : SimpleGraph V) [DecidableRel G.Adj]
       ↑((A₂.product B).filter (fun p => G.Adj p.1 p.2)).card := by
       exact_mod_cast edge_count_union G A₁ A₂ B hA
     linarith
-  -- Case 1: B empty (card = 0) — all terms zero
+  -- Case 1: B empty (card = 0) -- all terms zero
   by_cases hB : (B.card : ℚ) = 0
   · have h0 : ∀ (S : Finset V), edgeDensity G S B = 0 := by
       intro S; unfold edgeDensity
@@ -185,15 +119,15 @@ theorem density_sq_convex (G : SimpleGraph V) [DecidableRel G.Adj]
     have hd₂0 : d₂ = 0 := h0 A₂
     have hd0 : d = 0 := h0 (A₁ ∪ A₂)
     rw [hd₁0, hd₂0, hd0]; simp
-  -- Case 2: n₁ + n₂ = 0 — both sets empty, all terms zero
+  -- Case 2: n1 + n2 = 0 -- both sets empty, all terms zero
   by_cases hnn : n₁ + n₂ = 0
   · have h1 : n₁ = 0 := le_antisymm (by linarith) hn₁
     have h2 : n₂ = 0 := le_antisymm (by linarith) hn₂
     simp [h1, h2]
-  -- Main case: B nonempty, n₁ + n₂ > 0
+  -- Main case: B nonempty, n1 + n2 > 0
   · have hnn_pos : (0 : ℚ) < n₁ + n₂ :=
       lt_of_le_of_ne (by linarith) (Ne.symm hnn)
-    -- Derive weighted average: (n₁+n₂)*d = n₁*d₁ + n₂*d₂ (cancel B.card)
+    -- Derive weighted average: (n1+n2)*d = n1*d1 + n2*d2 (cancel B.card)
     have hd_avg : (n₁ + n₂) * d = n₁ * d₁ + n₂ * d₂ := by
       have hB_ne : (B.card : ℚ) ≠ 0 := hB
       exact mul_left_cancel₀ hB_ne (show ↑B.card * ((n₁ + n₂) * d) =
@@ -201,9 +135,9 @@ theorem density_sq_convex (G : SimpleGraph V) [DecidableRel G.Adj]
     -- Rewrite d using the weighted average
     have hd_eq : d = (n₁ * d₁ + n₂ * d₂) / (n₁ + n₂) := by
       rw [eq_div_iff (ne_of_gt hnn_pos)]; linarith [hd_avg]
-    -- Goal: n₁*d₁² + n₂*d₂² ≥ (n₁+n₂)*d²
+    -- Goal: n1*d1^2 + n2*d2^2 >= (n1+n2)*d^2
     rw [ge_iff_le, ← sub_nonneg, hd_eq]
-    -- The difference equals n₁*n₂*(d₁-d₂)²/(n₁+n₂) ≥ 0
+    -- The difference equals n1*n2*(d1-d2)^2/(n1+n2) >= 0
     have key : n₁ * d₁ ^ 2 + n₂ * d₂ ^ 2 -
         (n₁ + n₂) * ((n₁ * d₁ + n₂ * d₂) / (n₁ + n₂)) ^ 2 =
         n₁ * n₂ * (d₁ - d₂) ^ 2 / (n₁ + n₂) := by
@@ -237,8 +171,8 @@ theorem partitionEnergy_le_one (G : SimpleGraph V) [DecidableRel G.Adj]
   unfold partitionEnergy
   split_ifs with h
   · exact zero_le_one
-  · -- Each d(P,Q)² ≤ 1, and there are k² terms, so Σ d² ≤ k²
-    -- Therefore (1/k²) * Σ d² ≤ (1/k²) * k² = 1
+  · -- Each d(P,Q)^2 <= 1, and there are k^2 terms, so Sigma d^2 <= k^2
+    -- Therefore (1/k^2) * Sigma d^2 <= (1/k^2) * k^2 = 1
     have hk2_ne : (↑(parts.card ^ 2) : ℚ) ≠ 0 :=
       Nat.cast_ne_zero.mpr (pow_ne_zero 2 h)
     have hsum : (parts.product parts).sum (fun pq => (edgeDensity G pq.1 pq.2) ^ 2)
@@ -264,11 +198,11 @@ theorem partitionEnergy_le_one (G : SimpleGraph V) [DecidableRel G.Adj]
 
 /-- The energy of a regular partition is finite-step achievable: since
     energy lies in [0,1] and each increment adds at least eps^5,
-    we need at most ⌈1/eps^5⌉ iterations. -/
+    we need at most ceil(1/eps^5) iterations. -/
 theorem max_iterations (eps : ℚ) (heps : 0 < eps) :
     ∃ N : ℕ, ∀ e : ℚ, 0 ≤ e → e ≤ 1 → e + N * eps ^ 5 > 1 := by
   -- By the Archimedean property, find N > 1/eps^5.
-  -- Then N * eps^5 > 1, and with e ≥ 0 we get e + N * eps^5 > 1.
+  -- Then N * eps^5 > 1, and with e >= 0 we get e + N * eps^5 > 1.
   have heps5 : (0 : ℚ) < eps ^ 5 := pow_pos heps 5
   obtain ⟨N, hN⟩ := exists_nat_gt (1 / eps ^ 5)
   exact ⟨N, fun e he0 _ => by linarith [((div_lt_iff₀ heps5).mp hN)]⟩
@@ -278,7 +212,7 @@ theorem max_iterations (eps : ℚ) (heps : 0 < eps) :
     at most M(epsilon) parts.
 
     The proof iterates: start with an arbitrary equipartition. If not
-    regular, refine to increase energy by eps^5. Since energy ∈ [0,1],
+    regular, refine to increase energy by eps^5. Since energy in [0,1],
     this terminates after at most eps^{-5} steps. -/
 theorem regularity_lemma (eps : ℚ) (heps : 0 < eps) :
     ∃ M : ℕ, ∀ (V : Type*) [Fintype V] [DecidableEq V] (G : SimpleGraph V)


### PR DESCRIPTION
## Summary

- **Extract SzemerediCore.lean**: Shared definitions (`edgeDensity`, `IsEpsilonRegular`, `IsRegularPartition`, `partitionEnergy`) and basic lemmas (`edgeDensity_nonneg`, `edgeDensity_le_one`, `partitionEnergy_nonneg`) moved from `SzemerediRegularity.lean` to a new `SzemerediCore.lean` module under `Szemeredi.Core` namespace
- **Update SzemerediRegularity.lean**: Now imports Core and re-exports all names via `export Szemeredi.Core (...)`, so `Szemeredi.Regularity.edgeDensity` etc. still resolve for downstream code
- **Update SzemerediCounting.lean**: Imports both Core and Regularity; `unfold` target updated to `Szemeredi.Core.edgeDensity`
- **Prove Shannon chain_rule**: `I(X;Y) = H(X) - H(X|Y)` proved by decomposing MI terms via `log(a/(bc)) = log(a/c) - log(b)` and telescoping the marginal sum, handling the 0*log(0) convention. This also enables `conditioning_reduces_entropy` (H(X|Y) <= H(X)). Shannon sorry count: 2 -> 1.

## Files changed

| File | Change |
|------|--------|
| `proofs/Proofs/SzemerediCore.lean` | **New** -- shared definitions and basic lemmas |
| `proofs/Proofs/SzemerediRegularity.lean` | Removed definitions, imports Core, re-exports |
| `proofs/Proofs/SzemerediCounting.lean` | Added Core import, updated unfold target |
| `proofs/Proofs/ShannonEntropy.lean` | Proved `chain_rule` theorem |

## Test plan

- [ ] Verify SzemerediCore.lean compiles (new definitions + basic lemmas)
- [ ] Verify SzemerediRegularity.lean compiles (proof machinery uses Core definitions through re-export)
- [ ] Verify SzemerediCounting.lean compiles (bad_vertices_small proof still works with updated unfold)
- [ ] Verify ShannonEntropy.lean compiles (chain_rule proof + conditioning_reduces_entropy)
- [ ] Verify no other files break (only SzemerediCounting imports SzemerediRegularity)

Generated with [Claude Code](https://claude.com/claude-code)