### PR TITLE
Enrich IBP for Fourier Coefficients: create annotations, add depth

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 21
+    },
+    "type": "context",
+    "title": "Fourier Infrastructure for the Isoperimetric Inequality",
+    "content": "This file builds a key piece of the Fourier-analytic approach to the isoperimetric inequality $L^2 \\geq 4\\pi A$. The central result is that differentiation and Fourier coefficients commute: $\\hat{c}_n(f') = in \\cdot \\hat{c}_n(f)$.\n\nThis formula is the frequency-domain view of differentiation. Just as the Fourier transform converts differentiation into multiplication by $i\\omega$, the discrete Fourier coefficient version converts differentiation of periodic functions into multiplication by $in$. Hurwitz used this in 1902 to give the first Fourier-analytic proof of the isoperimetric inequality.",
+    "mathContext": "For $f \\in C^1$ with period $2\\pi$ and $n \\neq 0$: $\\hat{c}_n(f') = in \\cdot \\hat{c}_n(f)$ where $\\hat{c}_n(g) = \\frac{1}{2\\pi}\\int_0^{2\\pi} g(t)e^{-int}\\,dt$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Fourier coefficients",
+      "isoperimetric inequality",
+      "harmonic analysis"
+    ],
+    "prerequisites": [
+      "Fourier series",
+      "integration by parts",
+      "periodic functions"
+    ]
+  },
+  {
+    "id": "ann-chain-rule",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 27,
+      "endLine": 45
+    },
+    "type": "technique",
+    "title": "Lifting Real Derivatives to Complex via the Chain Rule",
+    "content": "A technical but essential bridge: to use Mathlib's complex-valued Fourier machinery on a real-valued function $f$, we need to compose with `ofRealCLM` (the canonical embedding $\\mathbb{R} \\hookrightarrow \\mathbb{C}$).\n\nThe chain rule gives: if $f$ has derivative $f'(x)$ at $x$, then $\\text{ofReal} \\circ f$ has complex derivative $\\text{ofReal}(f'(x))$ at $x$. This uses two facts:\n1. `ofRealCLM` is a continuous linear map, so its derivative at any point is itself (with scalar $1$)\n2. `HasDerivAt.scomp` composes: $(g \\circ f)' = f' \\cdot g'$\n\nThe `convert` + `simp` at the end handles the bookkeeping: $f'(x) \\cdot \\text{ofRealCLM}(1) = f'(x) \\cdot 1 = \\text{ofReal}(f'(x))$.",
+    "mathContext": "$\\text{HasDerivAt}(\\text{ofReal} \\circ f, \\text{ofReal}(f'(x)), x)$ follows from the chain rule: $\\text{ofRealCLM}$ has derivative $\\text{ofRealCLM}(1) = 1$ at $f(x)$, composed with $f'(x)$ via `scomp`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "chain rule",
+      "continuous linear map",
+      "real-complex embedding"
+    ],
+    "prerequisites": [
+      "HasDerivAt",
+      "ContinuousLinearMap",
+      "function composition"
+    ]
+  },
+  {
+    "id": "ann-ibp-setup",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 47,
+      "endLine": 58
+    },
+    "type": "theorem",
+    "title": "The IBP Theorem for Fourier Coefficients",
+    "content": "The main theorem states that for a $C^1$ function $f: \\mathbb{R} \\to \\mathbb{R}$ with period $2\\pi$ and integer $n \\neq 0$:\n$$\\text{fourierCoeffOn}(\\text{ofReal} \\circ f', n) = I \\cdot n \\cdot \\text{fourierCoeffOn}(\\text{ofReal} \\circ f, n)$$\n\nThe hypotheses are carefully chosen:\n- **$C^1$ regularity** (`ContDiff ℝ 1 f`): ensures the derivative exists and is continuous, making both sides well-defined\n- **$2\\pi$-periodicity** (`∀ t, f(t + 2π) = f(t)`): kills the boundary term in integration by parts\n- **$n \\neq 0$**: the formula is trivially true but differently structured for $n = 0$ (the average term)",
+    "mathContext": "$\\hat{c}_n(f') = in \\cdot \\hat{c}_n(f)$ for $f \\in C^1(\\mathbb{R}/2\\pi\\mathbb{Z})$, $n \\in \\mathbb{Z} \\setminus \\{0\\}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "fourierCoeffOn",
+      "ContDiff",
+      "periodicity"
+    ],
+    "prerequisites": [
+      "ann-chain-rule"
+    ]
+  },
+  {
+    "id": "ann-ibp-proof",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 59,
+      "endLine": 80
+    },
+    "type": "technique",
+    "title": "Five-Step Proof: From Derivative Hypothesis to Algebraic Closure",
+    "content": "The proof proceeds in five clean steps:\n\n**Step 1 (Derivative)**: Establish the `HasDerivAt` hypothesis for every $x \\in [0, 2\\pi]$ using the chain rule lemma.\n\n**Step 2 (Integrability)**: Show the integrand is interval-integrable — follows from continuity of `ofReal ∘ deriv f` (composition of continuous functions).\n\n**Step 3 (Mathlib IBP)**: Apply `fourierCoeffOn_of_hasDerivAt`, which gives the IBP formula with a boundary term: $\\hat{c}_n(f') = [\\text{boundary}] + in \\cdot \\hat{c}_n(f)$.\n\n**Step 4 (Kill boundary)**: Periodicity gives $f(2\\pi) = f(0)$, so the boundary term $f(2\\pi) - f(0) = 0$ vanishes.\n\n**Step 5 (Algebra)**: After `simp` eliminates the zeros, `field_simp` and `ring` close the remaining complex arithmetic involving $\\pi$, $I$, $n$, and the coefficient formula.\n\nThe non-zero checks for $\\pi$, $I$, and $n$ (as complex numbers) are needed for `field_simp` to safely divide.",
+    "mathContext": "Integration by parts on $[0, 2\\pi]$: $\\int_0^{2\\pi} f'(t)e^{-int}\\,dt = [f(t)e^{-int}]_0^{2\\pi} + in\\int_0^{2\\pi} f(t)e^{-int}\\,dt$. Periodicity: $f(2\\pi)e^{-2\\pi in} - f(0) = f(0)(e^{-2\\pi in} - 1) = 0$ since $e^{-2\\pi in} = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "fourierCoeffOn_of_hasDerivAt",
+      "interval integrability",
+      "field_simp tactic"
+    ],
+    "prerequisites": [
+      "ann-ibp-setup",
+      "ann-chain-rule"
+    ]
+  },
+  {
+    "id": "ann-periodicity",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 68,
+      "endLine": 69
+    },
+    "type": "insight",
+    "title": "Periodicity Kills the Boundary Term",
+    "content": "The single most important simplification: $f(2\\pi) = f(0)$ from the periodicity hypothesis $f(t + 2\\pi) = f(t)$, instantiated at $t = 0$.\n\nWithout periodicity, the IBP formula has a correction term involving boundary values $f(b) - f(a)$ multiplied by exponentials. For periodic functions, this correction vanishes identically, yielding the clean formula $\\hat{c}_n(f') = in \\cdot \\hat{c}_n(f)$ without remainder.\n\nThis is why Fourier analysis works so naturally for periodic functions: the boundary terms that plague general IBP disappear entirely.",
+    "mathContext": "$f(2\\pi) - f(0) = 0$ from $f(t + 2\\pi) = f(t)$ at $t = 0$. This eliminates the boundary contribution in the IBP formula.",
+    "significance": "key",
+    "relatedConcepts": [
+      "periodic boundary conditions",
+      "integration by parts",
+      "boundary terms"
+    ],
+    "prerequisites": [
+      "ann-ibp-setup"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "area-of-circle-oq-01-oq-02-oq-02",
   "title": "IBP for Fourier Coefficients of Periodic Functions",
   "slug": "area-of-circle-oq-01-oq-02-oq-02",
-  "description": "Proves the integration by parts formula for Fourier coefficients: for a C\u00b9 periodic function f with period 2\u03c0, the Fourier coefficient of the derivative satisfies \u0109\u2099(f') = i\u00b7n\u00b7\u0109\u2099(f). This is key infrastructure for the Fourier-analytic proof of the isoperimetric inequality.",
+  "description": "Proves the integration by parts formula for Fourier coefficients: for a C¹ periodic function f with period 2π, the Fourier coefficient of the derivative satisfies ĉₙ(f') = i·n·ĉₙ(f). This is key infrastructure for the Fourier-analytic proof of the isoperimetric inequality.",
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fourier_series#Derivative",
@@ -37,17 +37,17 @@
       }
     ],
     "originalContributions": [
-      "Chain rule lemma: HasDerivAt (ofReal \u2218 f) ((ofReal \u2218 deriv f) x) x for C\u00b9 real functions",
-      "Main theorem: \u0109\u2099(f') = i\u00b7n\u00b7\u0109\u2099(f) for 2\u03c0-periodic C\u00b9 functions via Mathlib's fourierCoeffOn_of_hasDerivAt",
-      "Periodicity kills boundary term: f(2\u03c0) - f(0) = 0 simplifies IBP to a clean algebraic identity",
+      "Chain rule lemma: HasDerivAt (ofReal ∘ f) ((ofReal ∘ deriv f) x) x for C¹ real functions",
+      "Main theorem: ĉₙ(f') = i·n·ĉₙ(f) for 2π-periodic C¹ functions via Mathlib's fourierCoeffOn_of_hasDerivAt",
+      "Periodicity kills boundary term: f(2π) - f(0) = 0 simplifies IBP to a clean algebraic identity",
       "Full field_simp/ring closure of the Fourier coefficient algebra"
     ],
     "references": [
       {
         "authors": "A. Hurwitz",
-        "title": "Sur quelques applications g\u00e9om\u00e9triques des s\u00e9ries de Fourier",
+        "title": "Sur quelques applications géométriques des séries de Fourier",
         "year": "1902",
-        "venue": "Annales scientifiques de l'\u00c9cole Normale Sup\u00e9rieure",
+        "venue": "Annales scientifiques de l'École Normale Supérieure",
         "note": "First Fourier-analytic proof of the isoperimetric inequality, using this IBP formula as a key step"
       },
       {
@@ -64,7 +64,7 @@
     "relatedProblems": [
       {
         "id": "area-of-circle-oq-01-oq-02",
-        "relationship": "Parent entry proving A = \u222b C via FTC; this entry builds Fourier infrastructure for the isoperimetric generalization"
+        "relationship": "Parent entry proving A = ∫ C via FTC; this entry builds Fourier infrastructure for the isoperimetric generalization"
       },
       {
         "id": "area-of-circle-oq-01-oq-03",
@@ -78,15 +78,15 @@
     "lineCount": 82
   },
   "overview": {
-    "summary": "Proves the integration by parts formula for Fourier coefficients of periodic functions: \u0109\u2099(f') = i\u00b7n\u00b7\u0109\u2099(f) for 2\u03c0-periodic C\u00b9 functions f and n \u2260 0. The proof lifts real functions to complex via ofRealCLM, applies Mathlib's fourierCoeffOn_of_hasDerivAt, and uses periodicity f(2\u03c0) = f(0) to eliminate the boundary term.",
+    "summary": "Proves the integration by parts formula for Fourier coefficients of periodic functions: ĉₙ(f') = i·n·ĉₙ(f) for 2π-periodic C¹ functions f and n ≠ 0. The proof lifts real functions to complex via ofRealCLM, applies Mathlib's fourierCoeffOn_of_hasDerivAt, and uses periodicity f(2π) = f(0) to eliminate the boundary term.",
     "historicalContext": "The formula $\\hat{c}_n(f') = in \\cdot \\hat{c}_n(f)$ is a cornerstone of Fourier analysis. It states that differentiation in the time domain corresponds to multiplication by $in$ in the frequency domain. Adolf Hurwitz used this property in his celebrated 1902 proof of the isoperimetric inequality: by expressing the perimeter $L$ and area $A$ of a closed curve in terms of Fourier coefficients and applying the IBP formula, one derives $L^2 - 4\\pi A = \\sum_{n \\neq 0,1} (|a'_n|^2 - n^2|a_n|^2 + \\ldots) \\geq 0$, with equality only for circles.",
     "problemStatement": "**Open Question**: Can the isoperimetric inequality $C^2 \\geq 4\\pi A$ be proved using Fourier analysis?\n\n**This entry**: Proves the IBP formula for Fourier coefficients, which is the key analytical ingredient. For a $C^1$ function $f: \\mathbb{R} \\to \\mathbb{R}$ with period $2\\pi$ and $n \\neq 0$:\n$$\\hat{c}_n(f') = in \\cdot \\hat{c}_n(f)$$\nwhere $\\hat{c}_n(g) = \\frac{1}{2\\pi} \\int_0^{2\\pi} g(t) e^{-int} \\, dt$.",
-    "proofStrategy": "1. **Lift to complex**: Prove that for C\u00b9 real f, HasDerivAt (ofReal \u2218 f) ((ofReal \u2218 deriv f) x) x via the chain rule (ofRealCLM is a ContinuousLinearMap).\n2. **Apply Mathlib IBP**: Use fourierCoeffOn_of_hasDerivAt to get the Fourier IBP formula with boundary term.\n3. **Kill boundary**: Periodicity f(2\u03c0) = f(0) makes the boundary term f(2\u03c0) - f(0) = 0.\n4. **Algebraic cleanup**: field_simp and ring close the goal after simplification.",
+    "proofStrategy": "1. **Lift to complex**: Prove that for C¹ real f, HasDerivAt (ofReal ∘ f) ((ofReal ∘ deriv f) x) x via the chain rule (ofRealCLM is a ContinuousLinearMap).\n2. **Apply Mathlib IBP**: Use fourierCoeffOn_of_hasDerivAt to get the Fourier IBP formula with boundary term.\n3. **Kill boundary**: Periodicity f(2π) = f(0) makes the boundary term f(2π) - f(0) = 0.\n4. **Algebraic cleanup**: field_simp and ring close the goal after simplification.",
     "keyInsights": [
-      "The chain rule for ofRealCLM \u2218 f uses ContinuousLinearMap.hasDerivAt composed with HasDerivAt.scomp",
+      "The chain rule for ofRealCLM ∘ f uses ContinuousLinearMap.hasDerivAt composed with HasDerivAt.scomp",
       "Periodicity is the key simplification: without it, the IBP formula has a non-trivial boundary correction",
       "The proof leverages Mathlib's fourierCoeffOn_of_hasDerivAt which does the heavy integration-by-parts work",
-      "field_simp handles the complex algebra involving \u03c0, I, and n after boundary elimination"
+      "field_simp handles the complex algebra involving π, I, and n after boundary elimination"
     ],
     "keyIdea": "Differentiation in the time domain corresponds to multiplication by in in the frequency domain. For periodic functions, the IBP boundary term vanishes, giving a clean formula.",
     "prerequisites": [
@@ -100,7 +100,7 @@
     {
       "targetId": "area-of-circle-oq-01-oq-02",
       "relationship": "extends",
-      "description": "The parent entry proves A = \u222bC via FTC. This entry builds Fourier infrastructure needed for the isoperimetric generalization C\u00b2 \u2265 4\u03c0A."
+      "description": "The parent entry proves A = ∫C via FTC. This entry builds Fourier infrastructure needed for the isoperimetric generalization C² ≥ 4πA."
     },
     {
       "targetId": "area-of-circle-oq-01-oq-03",
@@ -110,26 +110,36 @@
   ],
   "sections": [
     {
+      "id": "preamble",
+      "title": "File Header and Setup",
+      "startLine": 1,
+      "endLine": 25,
+      "summary": "Module docstring, imports Mathlib, opens namespaces (Real, Filter, Topology, Complex, MeasureTheory), and declares the IsoperimetricFourier namespace.",
+      "mathContext": "Uses fourierCoeffOn from Mathlib.Analysis.Fourier.AddCircle for Fourier coefficients on intervals."
+    },
+    {
       "id": "chain-rule",
       "title": "Chain Rule for ofReal Composition",
       "startLine": 27,
       "endLine": 45,
-      "summary": "Proves HasDerivAt (ofReal \u2218 f) ((ofReal \u2218 deriv f) x) x for C\u00b9 real f. Uses ContinuousLinearMap.hasDerivAt for ofRealCLM and HasDerivAt.scomp for the chain rule."
+      "summary": "Proves HasDerivAt (ofReal ∘ f) ((ofReal ∘ deriv f) x) x for C¹ real f. Uses ContinuousLinearMap.hasDerivAt for ofRealCLM and HasDerivAt.scomp for the chain rule.",
+      "mathContext": "Chain rule: d/dx(ofReal ∘ f)(x) = ofReal(f'(x)) since ofRealCLM' = id and (g ∘ f)' = f' · g'."
     },
     {
       "id": "ibp-fourier",
       "title": "IBP for Fourier Coefficients (Main Theorem)",
       "startLine": 47,
       "endLine": 80,
-      "summary": "Proves \u0109\u2099(f') = i\u00b7n\u00b7\u0109\u2099(f) for 2\u03c0-periodic C\u00b9 functions. Applies fourierCoeffOn_of_hasDerivAt, eliminates the boundary term via periodicity, and closes with field_simp/ring."
+      "summary": "Proves ĉₙ(f') = i·n·ĉₙ(f) for 2π-periodic C¹ functions. Applies fourierCoeffOn_of_hasDerivAt, eliminates the boundary term via periodicity, and closes with field_simp/ring.",
+      "mathContext": "ĉₙ(f') = in · ĉₙ(f) via IBP: ∫₀²π f'e^{-int}dt = [fe^{-int}]₀²π (=0 by periodicity) + in∫₀²π fe^{-int}dt."
     }
   ],
   "conclusion": {
-    "summary": "This entry proves the IBP formula for Fourier coefficients of periodic functions with 0 sorries and 0 axioms in 82 lines. The formula \u0109\u2099(f') = i\u00b7n\u00b7\u0109\u2099(f) is the analytical backbone of Hurwitz's Fourier proof of the isoperimetric inequality.",
-    "implications": "This IBP formula enables the full Fourier-analytic approach to the isoperimetric inequality. Combined with Parseval's identity and the Wirtinger inequality (proved in the sibling entry), it provides all the ingredients for proving L\u00b2 \u2265 4\u03c0A with equality characterization for circles.",
+    "summary": "This entry proves the IBP formula for Fourier coefficients of periodic functions with 0 sorries and 0 axioms in 82 lines. The formula ĉₙ(f') = i·n·ĉₙ(f) is the analytical backbone of Hurwitz's Fourier proof of the isoperimetric inequality.",
+    "implications": "This IBP formula enables the full Fourier-analytic approach to the isoperimetric inequality. Combined with Parseval's identity and the Wirtinger inequality (proved in the sibling entry), it provides all the ingredients for proving L² ≥ 4πA with equality characterization for circles.",
     "openQuestions": [
-      "Can the full isoperimetric inequality C\u00b2 \u2265 4\u03c0A now be assembled from this IBP formula + Wirtinger + Parseval?",
-      "Can this be generalized to higher-order derivatives: \u0109\u2099(f^(k)) = (in)^k \u00b7 \u0109\u2099(f)?",
+      "Can the full isoperimetric inequality C² ≥ 4πA now be assembled from this IBP formula + Wirtinger + Parseval?",
+      "Can this be generalized to higher-order derivatives: ĉₙ(f^(k)) = (in)^k · ĉₙ(f)?",
       "Can the periodicity hypothesis be weakened to compact support using Fourier transforms instead of Fourier series?"
     ]
   },
@@ -137,5 +147,22 @@
     "area-of-circle-oq-01-oq-02",
     "area-of-circle-oq-01-oq-03",
     "area-of-circle-oq-01-oq-02-oq-01"
-  ]
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Topology",
+      "Complex",
+      "MeasureTheory"
+    ],
+    "namespace": "IsoperimetricFourier",
+    "lineCount": 82,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0
+  }
 }


### PR DESCRIPTION
## Summary
- Created `annotations.json` from scratch with 5 annotations covering the full proof
- All annotations include `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`
- Added `leanFile` metadata to `meta.json`
- Added `mathContext` to all sections and added preamble section

## Entry
`area-of-circle-oq-01-oq-02-oq-02` — IBP for Fourier Coefficients of Periodic Functions (quality 37 → enriched, pass 1)

*Note: Previous borsuk-ulam enrichment was force-pushed off this branch after merge/completion.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)