### PR TITLE
Research: LGV lemma - prove GV cancellation for r=0,1

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ02.lean
@@ -416,6 +416,73 @@ theorem det_pathMatrix_eq_signed_sum {r : ℕ} (cfg : LGVConfig r) :
   exact (permPathTuple_card cfg σ).symm
 
 -- ============================================================
+-- PART 7d: Identity Permutation Infrastructure
+-- ============================================================
+
+/-- PermPathTuple for the identity permutation equals PathTuple
+    (since (1 : Perm) i = i, targets match). -/
+noncomputable def permPathTuple_one_equiv {r : ℕ} (cfg : LGVConfig r) :
+    PermPathTuple cfg 1 ≃ PathTuple cfg := by
+  have heq : PermPathTuple cfg 1 = PathTuple cfg := by
+    simp only [PermPathTuple, PathTuple, Equiv.Perm.one_apply]
+  rw [heq]
+
+/-- Cardinality: identity-perm path tuples = regular path tuples. -/
+theorem permPathTuple_one_card {r : ℕ} (cfg : LGVConfig r) :
+    Fintype.card (PermPathTuple cfg 1) = Fintype.card (PathTuple cfg) :=
+  Fintype.card_congr (permPathTuple_one_equiv cfg)
+
+/-- When every path tuple is non-intersecting, niTupleCount = card(PathTuple). -/
+theorem niTupleCount_eq_card_of_all_ni {r : ℕ} (cfg : LGVConfig r)
+    (h : ∀ p : PathTuple cfg, IsNonIntersecting cfg p) :
+    niTupleCount cfg = Fintype.card (PathTuple cfg) := by
+  simp only [niTupleCount]
+  exact @Fintype.card_congr _ _
+    (@Subtype.fintype _ _ (fun _ => Classical.dec _) (PathTuple.instFintype cfg))
+    (PathTuple.instFintype cfg)
+    (Equiv.subtypeUnivEquiv h)
+
+-- ============================================================
+-- PART 7e: GV Cancellation for Small r (Proved Theorems)
+-- ============================================================
+
+/-- For r = 0, every path tuple is vacuously non-intersecting. -/
+theorem isNonIntersecting_of_r_zero (cfg : LGVConfig 0) (paths : PathTuple cfg) :
+    IsNonIntersecting cfg paths :=
+  fun i => Fin.elim0 i
+
+/-- GV cancellation for r = 0: proved (single perm, vacuously NI). -/
+theorem gv_cancellation_r_zero (cfg : LGVConfig 0) :
+    ∑ σ : Equiv.Perm (Fin 0),
+      (↑(Equiv.Perm.sign σ) : ℤ) * ↑(Fintype.card (PermPathTuple cfg σ)) =
+    ↑(niTupleCount cfg) := by
+  have huniq : ∀ σ : Equiv.Perm (Fin 0), σ = 1 :=
+    fun σ => Equiv.ext fun i => Fin.elim0 i
+  have huniv : (Finset.univ : Finset (Equiv.Perm (Fin 0))) = {1} :=
+    Finset.eq_singleton_iff_unique_mem.mpr ⟨Finset.mem_univ _, fun σ _ => huniq σ⟩
+  rw [huniv, Finset.sum_singleton]
+  simp only [Equiv.Perm.sign_one, Units.val_one, one_mul]
+  congr 1
+  rw [permPathTuple_one_card]
+  exact (niTupleCount_eq_card_of_all_ni cfg (isNonIntersecting_of_r_zero cfg)).symm
+
+/-- GV cancellation for r = 1: proved (single perm, vacuously NI). -/
+theorem gv_cancellation_r_one (cfg : LGVConfig 1) :
+    ∑ σ : Equiv.Perm (Fin 1),
+      (↑(Equiv.Perm.sign σ) : ℤ) * ↑(Fintype.card (PermPathTuple cfg σ)) =
+    ↑(niTupleCount cfg) := by
+  have huniq : ∀ σ : Equiv.Perm (Fin 1), σ = 1 :=
+    fun σ => Equiv.ext fun i => Subsingleton.elim _ _
+  have huniv : (Finset.univ : Finset (Equiv.Perm (Fin 1))) = {1} :=
+    Finset.eq_singleton_iff_unique_mem.mpr ⟨Finset.mem_univ _, fun σ _ => huniq σ⟩
+  rw [huniv, Finset.sum_singleton]
+  simp only [Equiv.Perm.sign_one, Units.val_one, one_mul]
+  congr 1
+  rw [permPathTuple_one_card]
+  exact (niTupleCount_eq_card_of_all_ni cfg
+    (fun p i j hij => absurd hij (by omega : ¬(i < j)))).symm
+
+-- ============================================================
 -- PART 8: The r×r LGV Lemma
 -- ============================================================
 

--- a/research/problems/ballot-problem-oq-03-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-02/knowledge.md
@@ -49,3 +49,37 @@ The single axiom `lgv_lemma_rxr` requires formalizing the full GV involution:
 
 ### Build
 Docker build passes with `LEAN_MEMORY_LIMIT=16384`.
+
+## Session 2026-03-22 (researcher-7) - GV Cancellation for Small r
+
+**Mode**: REVISIT (depth-first, RICH knowledge score 35)
+**Problem**: ballot-problem-oq-03-oq-02
+**Prior Status**: 1 axiom (gv_involution_cancellation), 0 sorries, 504 lines
+
+### Work Done
+Added 6 proved theorems (67 new lines, total 571 lines):
+
+| Theorem | Purpose | Status |
+|---------|---------|--------|
+| `permPathTuple_one_equiv` | PermPathTuple cfg 1 ≃ PathTuple cfg | PROVED |
+| `permPathTuple_one_card` | Card equivalence for id perm | PROVED |
+| `niTupleCount_eq_card_of_all_ni` | NI count = total when all NI | PROVED |
+| `isNonIntersecting_of_r_zero` | Vacuous NI for r=0 | PROVED |
+| `gv_cancellation_r_zero` | GV cancellation for r=0 | PROVED |
+| `gv_cancellation_r_one` | GV cancellation for r=1 | PROVED |
+
+### Key Insights
+- For r ≤ 1, Perm(Fin r) has exactly one element (identity), so the signed sum is trivial
+- The GV involution is only needed for r ≥ 2 where non-identity permutations exist
+- `Equiv.subtypeUnivEquiv` from Mathlib handles the "all elements satisfy P" → subtype equiv
+- `Fintype` for subtype `{p // IsNonIntersecting cfg p}` needs explicit `Classical.dec` provision
+
+### What Remains
+The axiom `gv_involution_cancellation` is now proved for r=0 and r=1. For r ≥ 2:
+- Prove the crossing lemma (non-identity perm paths must intersect)
+- Construct the GV involution (swap tails at first intersection point)
+- Prove the involution is sign-reversing and its own inverse
+- Replace the axiom with the proved theorem
+
+### Build
+Docker build passes with `LEAN_MEMORY_LIMIT=16384`.

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -1,42 +1,54 @@
 {
   "id": "ballot-problem-oq-03-oq-02",
-  "name": "General LGV Lemma: r×r Lindström-Gessel-Viennot Determinant",
+  "name": "General LGV Lemma: r\u00d7r Lindstr\u00f6m-Gessel-Viennot Determinant",
   "status": "surveyed",
   "phase": "ACT",
   "knowledge": {
     "insights": [
-      "Parent OQ03 (2878 lines, 0 axioms, 0 sorries) proves the 2×2 LGV lemma completely",
-      "2×2 LGV: non-intersecting path pairs = e(A1,B1)e(A2,B2) - e(A1,B2)e(A2,B1) = det[[e(Ai,Bj)]]",
-      "General r×r LGV: non-intersecting r-tuples = det[[e(Ai,Bj)]] for i,j = 1..r",
-      "Proof for r×r requires sign-reversing involution on r-tuples of paths",
+      "Parent OQ03 (2878 lines, 0 axioms, 0 sorries) proves the 2\u00d72 LGV lemma completely",
+      "2\u00d72 LGV: non-intersecting path pairs = e(A1,B1)e(A2,B2) - e(A1,B2)e(A2,B1) = det[[e(Ai,Bj)]]",
+      "General r\u00d7r LGV: non-intersecting r-tuples = det[[e(Ai,Bj)]] for i,j = 1..r",
+      "Proof for r\u00d7r requires sign-reversing involution on r-tuples of paths",
       "Mathlib has Matrix.det and Equiv.Perm infrastructure for the sign arguments",
       "Matrix.det_fin_two and Matrix.det_fin_three from Mathlib verify small cases automatically",
-      "The Leibniz formula bridge (det = Σ sign(σ)·Π) needs careful cast handling between Perm.sign (Units ℤ) and ℤ",
+      "The Leibniz formula bridge (det = \u03a3 sign(\u03c3)\u00b7\u03a0) needs careful cast handling between Perm.sign (Units \u2124) and \u2124",
       "The GV involution is the key sorry: needs definition of 'first intersection point' and proof of sign reversal",
       "Separating the involution hypothesis from the algebraic machinery makes the proof modular",
       "Algebraic bridge proved: det(pathMatrix) = sum_sigma sign(sigma) * card(PermPathTuple) via column Leibniz formula",
       "permPathTuple_card proved: card of sigma-tuples = product of binomial coefficients (from pathMN_card)",
       "firstNonFixed infrastructure: smallest non-fixed point of perm, with spec/minimal/lt_image lemmas all proved",
       "GV cancellation isolated as sole axiom; lgv_lemma_rxr is now a theorem proved from algebraic bridge + GV axiom",
-      "Units.smul_def handles sign coercion (ℤˣ • ℤ = ↑ℤˣ * ℤ) in det formula connection",
+      "Units.smul_def handles sign coercion (\u2124\u02e3 \u2022 \u2124 = \u2191\u2124\u02e3 * \u2124) in det formula connection",
       "File builds clean against Mathlib v4.26 (verified). 1 axiom (gv_involution_cancellation), 1 sorry (pathMN_card).",
-      "pathMN_card proof strategy: PathMN m n ≃ Finset.univ.powersetCard m via indicator bijection, then use Finset.card_powersetCard. Requires building explicit Equiv between List Bool positions and Finset (Fin (m+n)).",
+      "pathMN_card proof strategy: PathMN m n \u2243 Finset.univ.powersetCard m via indicator bijection, then use Finset.card_powersetCard. Requires building explicit Equiv between List Bool positions and Finset (Fin (m+n)).",
       "pathMN_card is a good Aristotle candidate - standard combinatorial identity C(m+n,m) = |{binary strings of length m+n with m zeros}|",
-      "pathMN_card proved via double induction + Pascal identity + splitting equiv. 0 sorries now."
+      "pathMN_card proved via double induction + Pascal identity + splitting equiv. 0 sorries now.",
+      "permPathTuple_one_equiv PROVED: PermPathTuple cfg 1 \u2243 PathTuple cfg (identity perm tuples = regular tuples)",
+      "niTupleCount_eq_card_of_all_ni PROVED: when all tuples are NI, niTupleCount = card(PathTuple)",
+      "gv_cancellation_r_zero PROVED: GV cancellation holds for r=0 (single perm, vacuously NI)",
+      "gv_cancellation_r_one PROVED: GV cancellation holds for r=1 (single perm, vacuously NI)",
+      "For r \u2264 1, Perm(Fin r) has exactly one element (the identity), making the signed sum trivial",
+      "The GV involution is only needed for r \u2265 2 where non-identity permutations exist"
     ],
     "builtItems": [
-      "BallotProblemOQ03OQ02.lean: r×r LGV infrastructure (204 lines)",
+      "BallotProblemOQ03OQ02.lean: r\u00d7r LGV infrastructure (204 lines)",
       "pathMatrix / latticePathMatrix: path weight matrix over Fin r",
       "permPathCount / signedPermPathCount: signed permutation path counting",
-      "lgv_lemma_general: general r×r LGV statement from involution hypothesis",
-      "lgv_2x2_det: verified 2×2 determinant specialization",
-      "lgv_3x3_det: verified 3×3 determinant expansion (6 terms)",
+      "lgv_lemma_general: general r\u00d7r LGV statement from involution hypothesis",
+      "lgv_2x2_det: verified 2\u00d72 determinant specialization",
+      "lgv_3x3_det: verified 3\u00d73 determinant expansion (6 terms)",
       "GV involution algorithm documented in detail (swap tails at first intersection)",
       "firstNonFixed: smallest non-fixed point of non-identity perm (def + 3 lemmas, all proved)",
       "permPathTuple_card: card(PermPathTuple cfg sigma) = prod of C(m+(b_sigma(i)-a_i), m) (proved from pathMN_card)",
       "det_pathMatrix_eq_signed_sum: det = signed sum of perm path tuple counts (proved via column Leibniz)",
       "gv_involution_cancellation: GV cancellation axiom (the single remaining axiom)",
-      "lgv_lemma_rxr: NOW A THEOREM (was axiom), proved from algebraic bridge + GV cancellation"
+      "lgv_lemma_rxr: NOW A THEOREM (was axiom), proved from algebraic bridge + GV cancellation",
+      "permPathTuple_one_equiv: PermPathTuple cfg 1 \u2243 PathTuple cfg (proved)",
+      "permPathTuple_one_card: card(PermPathTuple cfg 1) = card(PathTuple cfg) (proved)",
+      "niTupleCount_eq_card_of_all_ni: NI count = total count when all NI (proved)",
+      "isNonIntersecting_of_r_zero: vacuous NI for r=0 (proved)",
+      "gv_cancellation_r_zero: GV cancellation theorem for r=0 (proved, not axiom)",
+      "gv_cancellation_r_one: GV cancellation theorem for r=1 (proved, not axiom)"
     ],
     "openQuestions": [
       "Can pathMN_card be proved via bijection with Finset.powersetCard?",
@@ -44,15 +56,14 @@
       "GV involution: need proof that non-identity perm paths must cross (crossing lemma)"
     ],
     "nextSteps": [
-      "Prove pathMN_card: PathMN m n ≃ {S ⊆ Fin(m+n) | |S| = m} via indicator bijection",
-      "Formalize GV involution: define first intersection of two lattice paths",
-      "Prove crossing lemma: paths with ordered sources and permuted targets must intersect",
-      "Build involution: swap tails at first intersection, prove involutivity and sign reversal",
-      "Prove gv_involution_cancellation from the constructed involution"
+      "For r \u2265 2: prove the crossing lemma (non-identity perm paths must intersect)",
+      "For r \u2265 2: construct the GV involution (swap tails at first intersection)",
+      "For r \u2265 2: prove involution is sign-reversing and its own inverse",
+      "Prove gv_involution_cancellation as theorem from the involution construction"
     ],
-    "progressSummary": "PROGRESS: pathMN_card sorry eliminated. File now 0 sorries, 1 axiom (gv_involution_cancellation). 504 lines."
+    "progressSummary": "PROGRESS: Added 6 proved theorems including GV cancellation for r=0,1. File: 571 lines, 1 axiom (gv_involution_cancellation), 0 sorries. Axiom only needed for r\u22652."
   },
-  "lastUpdate": "2026-03-22T08:00:00Z",
+  "lastUpdate": "2026-03-22T16:10:00Z",
   "leanFiles": [
     {
       "path": "Proofs/BallotProblem.lean",
@@ -123,10 +134,10 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 505,
-      "theoremCount": 14,
+      "lineCount": 571,
+      "theoremCount": 22,
       "axiomCount": 1,
-      "defCount": 16,
+      "defCount": 17,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"


### PR DESCRIPTION
## Summary
- Prove GV involution cancellation as theorems (not axioms) for r=0 and r=1
- Add structural infrastructure: `permPathTuple_one_equiv`, `niTupleCount_eq_card_of_all_ni`
- 6 new proved theorems, file grows from 504→571 lines
- The remaining axiom (`gv_involution_cancellation`) is now only needed for r≥2

## Progress
- `permPathTuple_one_equiv`: PermPathTuple cfg 1 ≃ PathTuple cfg (identity perm tuples are regular tuples)
- `permPathTuple_one_card`: cardinality equivalence
- `niTupleCount_eq_card_of_all_ni`: when all tuples are NI, NI count = total count
- `isNonIntersecting_of_r_zero`: vacuous NI for r=0
- `gv_cancellation_r_zero`: **proved** GV cancellation for r=0
- `gv_cancellation_r_one`: **proved** GV cancellation for r=1

## Status
**Outcome**: progress
**File**: `proofs/Proofs/BallotProblemOQ03OQ02.lean` (571 lines, 1 axiom, 0 sorries)
**Build**: Docker build passes with `LEAN_MEMORY_LIMIT=16384`
**Next Steps**: Prove crossing lemma and construct GV involution for r≥2

🤖 Generated by researcher-7