### PR TITLE
Research: LGV lemma - eliminate GV cancellation axiom

### DIFF
--- a/proofs/Proofs/BallotProblemOQ03OQ02.lean
+++ b/proofs/Proofs/BallotProblemOQ03OQ02.lean
@@ -23,16 +23,22 @@ where e(A,B) = C(dx + dy, dx) is the number of lattice paths from A to B.
 The identity permutation contributes ∏ e(Aᵢ,Bᵢ). Non-identity permutations
 cancel via a sign-reversing involution (Gessel-Viennot involution).
 
-## Status (1 axiom [GV cancellation], 0 sorries)
+## Status (0 axioms, 2 sorries)
 - [x] Path tuple and non-intersecting definitions
 - [x] Path weight matrix using Matrix.det
 - [x] Permutation path tuples and signed counts
 - [x] Gessel-Viennot involution infrastructure (swapTailsAt, firstNonFixed)
 - [x] Algebraic bridge: det = signed sum of perm path tuple counts (proved)
-- [x] r×r LGV lemma (proved from GV cancellation axiom)
+- [x] r×r LGV lemma (proved from GV cancellation + wellFormed hypothesis)
 - [x] Corollaries: non-negativity, r=0, r=1 special cases
-- [ ] GV involution cancellation (1 axiom: the combinatorial heart)
 - [x] PathMN cardinality C(m+n,m) (proved via double induction + Pascal)
+- [x] Tagged sigma type (TaggedPathTuple) for involution domain
+- [x] Sum decomposition: signed perm sum = sum over tagged tuples (proved)
+- [x] Non-identity permutations have inversions (proved)
+- [x] Non-identity σ-tuples always cross (proved from crossing lemma)
+- [x] Well-formedness condition (∀ i j, sources i ≤ targets j)
+- [ ] Crossing lemma: discrete IVT for lattice paths (1 sorry)
+- [ ] GV involution cancellation (1 sorry: involution bookkeeping)
 
 ## References
 - Lindström (1973): "On the Vector Representations of Induced Matroids"
@@ -486,24 +492,208 @@ theorem gv_cancellation_r_one (cfg : LGVConfig 1) :
 -- PART 8: The r×r LGV Lemma
 -- ============================================================
 
-/-- **Gessel-Viennot involution cancellation** (the combinatorial heart):
+-- ============================================================
+-- PART 7d: Tagged Path Tuples (Sigma Type)
+-- ============================================================
+
+/-- A tagged path tuple: a permutation σ together with a σ-path tuple.
+    This is the disjoint union ⨆_σ PermPathTuple(cfg, σ) on which the
+    GV involution operates. -/
+def TaggedPathTuple {r : ℕ} (cfg : LGVConfig r) : Type :=
+  Σ σ : Equiv.Perm (Fin r), PermPathTuple cfg σ
+
+noncomputable instance TaggedPathTuple.instFintype {r : ℕ} (cfg : LGVConfig r) :
+    Fintype (TaggedPathTuple cfg) :=
+  Sigma.instFintype
+
+/-- The signed weight of a tagged path tuple. -/
+def taggedWeight {r : ℕ} {cfg : LGVConfig r} (t : TaggedPathTuple cfg) : ℤ :=
+  (Equiv.Perm.sign t.1 : ℤ)
+
+/-- The sum over tagged tuples equals the sum over permutations of
+    signed cardinalities. This is the key reformulation that allows
+    us to work at the element level. -/
+theorem sum_tagged_eq_sum_perm {r : ℕ} (cfg : LGVConfig r) :
+    ∑ t : TaggedPathTuple cfg, taggedWeight t =
+      ∑ σ : Equiv.Perm (Fin r),
+        (↑(Equiv.Perm.sign σ) : ℤ) * ↑(Fintype.card (PermPathTuple cfg σ)) := by
+  change ∑ t : (Σ σ : Equiv.Perm (Fin r), PermPathTuple cfg σ),
+      (↑(Equiv.Perm.sign t.1) : ℤ) = _
+  rw [Fintype.sum_sigma]
+  congr 1; ext σ
+  have : ∀ (x : PermPathTuple cfg σ),
+      (↑(Equiv.Perm.sign (⟨σ, x⟩ : Σ _, PermPathTuple cfg _).1) : ℤ) =
+        (↑(Equiv.Perm.sign σ) : ℤ) := fun _ => rfl
+  simp only [this, Finset.sum_const, nsmul_eq_mul, mul_comm, Fintype.card]
+
+/-- Coerce a σ-path tuple to an identity-path tuple when σ = 1. -/
+def PermPathTuple.toPathTuple {r : ℕ} {cfg : LGVConfig r}
+    {σ : Equiv.Perm (Fin r)} (h : σ = 1) (p : PermPathTuple cfg σ) :
+    PathTuple cfg :=
+  fun i => cast (by rw [PermPathTuple] at *; congr 1; simp [h]) (p i)
+
+/-- A tagged path tuple is a "fixed point" of the GV involution iff
+    it is an identity-permutation tuple that is non-intersecting. -/
+def IsGVFixedPoint {r : ℕ} {cfg : LGVConfig r} (t : TaggedPathTuple cfg) : Prop :=
+  ∃ (h : t.1 = 1), IsNonIntersecting cfg (t.2.toPathTuple h)
+
+-- ============================================================
+-- PART 7e: Crossing Lemma
+-- ============================================================
+
+/-- **Lattice path y-coordinate at column boundary.**
+    The y-coordinate of a path starting at y₀ when entering column x. -/
+def yAtCol (l : LPath) (y₀ : ℕ) (x : ℕ) : ℕ := y₀ + colEntry l x
+
+/-- At column 0, the y-coordinate is the starting position. -/
+theorem yAtCol_zero (l : LPath) (y₀ : ℕ) : yAtCol l y₀ 0 = y₀ := by
+  simp [yAtCol, colEntry]
+
+/-- **Crossing lemma for lattice paths (discrete IVT).**
+    If path P starts strictly below path Q (y₁ < y₂) but P ends at
+    or above Q at column m, then their column y-ranges overlap at some
+    column — i.e., the paths share a lattice point.
+
+    This is the combinatorial engine of the GV involution: it ensures
+    that non-identity permutation path tuples always have crossings,
+    so the involution is total on non-fixed-point tuples. -/
+theorem lattice_paths_must_cross {m : ℕ} {n₁ n₂ : ℕ} {y₁ y₂ : ℕ}
+    (P : PathMN m n₁) (Q : PathMN m n₂)
+    (hstart : y₁ < y₂)
+    (hend : y₂ + n₂ ≤ y₁ + n₁) :
+    ¬NonIntersecting P.val Q.val m y₁ y₂ := by
+  intro ⟨hdisjoint, hfinal⟩
+  -- The y-ranges are nested intervals at each column.
+  -- Since P starts below Q but ends at or above Q,
+  -- by a discrete intermediate value argument on the
+  -- difference of y-coordinates, the ranges must overlap.
+  sorry
+
+-- ============================================================
+-- PART 7f: GV Involution Construction
+-- ============================================================
+
+/-- **Well-formedness**: every source-target pair is reachable by lattice paths.
+    This is stronger than `source_le_target` (which only covers identity pairing).
+    Required because Nat subtraction makes `PathMN m 0` represent horizontal paths
+    even when the target is below the source, giving wrong path counts.
+    Equivalent to `sources (Fin.last) ≤ targets 0` when both are strictly mono. -/
+def LGVConfig.wellFormed {r : ℕ} (cfg : LGVConfig r) : Prop :=
+  ∀ i j : Fin r, cfg.sources i ≤ cfg.targets j
+
+theorem LGVConfig.wellFormed_iff_max_le_min {r : ℕ} (cfg : LGVConfig r) (hr : 0 < r) :
+    cfg.wellFormed ↔ cfg.sources ⟨r - 1, by omega⟩ ≤ cfg.targets ⟨0, hr⟩ := by
+  constructor
+  · intro h; exact h _ _
+  · intro h i j
+    calc cfg.sources i ≤ cfg.sources ⟨r - 1, by omega⟩ :=
+          cfg.sources_strictMono.monotone (by omega : i.val ≤ r - 1)
+      _ ≤ cfg.targets ⟨0, hr⟩ := h
+      _ ≤ cfg.targets j := cfg.targets_strictMono.monotone (Nat.zero_le j.val)
+
+/-- **Non-identity permutations have inversions when domain is strictly ordered.**
+    If σ ≠ 1 and f is strictly monotone, then there exist i < j with
+    f(σ(i)) > f(σ(j)). In other words, σ is not order-preserving. -/
+theorem perm_ne_one_has_inversion {r : ℕ} (σ : Equiv.Perm (Fin r)) (hσ : σ ≠ 1)
+    {f : Fin r → ℕ} (hf : StrictMono f) :
+    ∃ i j : Fin r, i < j ∧ f (σ j) < f (σ i) := by
+  -- Since σ ≠ 1, it has a non-fixed point. By firstNonFixed_lt_image,
+  -- i < σ(i). Take j = σ(i), so σ(j) ≠ j (σ is not identity on j's orbit).
+  -- The strict monotonicity of f turns the permutation disorder into
+  -- a numeric inversion.
+  have hi := firstNonFixed_spec σ hσ
+  have hlt := firstNonFixed_lt_image σ hσ
+  -- Let i₀ = firstNonFixed, then i₀ < σ(i₀)
+  -- Since σ fixes all j < i₀, and σ(i₀) ≠ i₀, there's a cycle.
+  -- In that cycle, some pair must be inverted w.r.t. the natural order.
+  -- Specifically, take the first non-fixed point i₀. Then i₀ < σ(i₀).
+  -- Consider σ⁻¹(i₀). If σ⁻¹(i₀) > i₀, then we have j = σ⁻¹(i₀) > i₀
+  -- with σ(j) = i₀ < σ(i₀), giving an inversion at (i₀, j).
+  -- If σ⁻¹(i₀) < i₀, that contradicts minimality (σ fixes all below i₀,
+  -- so σ(σ⁻¹(i₀)) = i₀ means σ⁻¹(i₀) is not fixed, but it's below i₀).
+  -- If σ⁻¹(i₀) = i₀, then σ(i₀) = i₀, contradiction.
+  set i₀ := firstNonFixed σ hσ with hi₀_def
+  have hinv_ne : σ⁻¹ i₀ ≠ i₀ := by
+    intro h
+    have : σ (σ⁻¹ i₀) = σ i₀ := by rw [h]
+    simp at this
+    exact hi this.symm
+  have hinv_ge : σ⁻¹ i₀ ≥ i₀ := by
+    by_contra hlt'
+    push_neg at hlt'
+    have hfixed := firstNonFixed_minimal σ hσ (σ⁻¹ i₀) hlt'
+    have : σ (σ⁻¹ i₀) = σ⁻¹ i₀ := hfixed
+    simp at this
+    exact hinv_ne this.symm
+  have hinv_gt : i₀ < σ⁻¹ i₀ := lt_of_le_of_ne hinv_ge (Ne.symm hinv_ne)
+  refine ⟨i₀, σ⁻¹ i₀, hinv_gt, ?_⟩
+  simp
+  exact hf hlt
+
+/-- **Non-identity σ-path tuples always have crossing paths.**
+    For a non-identity permutation σ with strictly ordered sources and targets,
+    any σ-path tuple must contain a pair of intersecting paths. This ensures
+    the GV involution is defined on all non-fixed-point tuples. -/
+theorem nonid_perm_paths_cross {r : ℕ} (cfg : LGVConfig r)
+    (hwf : cfg.wellFormed)
+    (σ : Equiv.Perm (Fin r)) (hσ : σ ≠ 1)
+    (paths : PermPathTuple cfg σ) :
+    ∃ i j : Fin r, i < j ∧
+      ¬NonIntersecting (paths i).val (paths j).val cfg.m
+        (cfg.sources i) (cfg.sources j) := by
+  -- By perm_ne_one_has_inversion, ∃ i < j with targets(σ j) < targets(σ i).
+  obtain ⟨i, j, hij, hinv⟩ := perm_ne_one_has_inversion σ hσ cfg.targets_strictMono
+  refine ⟨i, j, hij, ?_⟩
+  -- Path i starts at sources(i), ends at targets(σ i)
+  -- Path j starts at sources(j), ends at targets(σ j)
+  -- sources(i) < sources(j) and targets(σ j) < targets(σ i)
+  -- So path i starts lower and ends higher → must cross
+  have hsrc := cfg.sources_strictMono hij
+  -- With well-formedness, Nat subtraction gives correct values:
+  -- sources(k) + (targets(σ k) - sources(k)) = targets(σ k)
+  have hwf_i := hwf i (σ i)
+  have hwf_j := hwf j (σ j)
+  apply lattice_paths_must_cross (paths i) (paths j) hsrc
+  -- Need: sources(j) + (targets(σ j) - sources(j)) ≤ sources(i) + (targets(σ i) - sources(i))
+  -- i.e., targets(σ j) ≤ targets(σ i)
+  omega
+
+-- ============================================================
+-- PART 7g: GV Involution Cancellation (Structured Proof)
+-- ============================================================
+
+/-- **Gessel-Viennot involution cancellation** (the combinatorial heart).
 
     The signed sum of permutation path tuple cardinalities equals
     the number of non-intersecting identity path tuples.
 
-    This follows from a sign-reversing involution on the disjoint
-    union ⨆_σ PermPathTuple(cfg, σ), where fixed points are exactly
-    the non-intersecting identity tuples.
+    **Proof structure** (3 components):
+    1. `sum_tagged_eq_sum_perm`: reformulate as sum over tagged sigma type
+    2. `nonid_perm_paths_cross`: non-identity tuples always have crossings
+    3. Sign-reversing involution on tagged tuples (tail-swap at first crossing)
 
-    The involution: for a non-identity σ-tuple (or intersecting
-    id-tuple), find the smallest non-fixed index i of σ, swap
-    tails of paths Pᵢ and P_{σ⁻¹(i)} at their first shared
-    lattice point. This maps σ-tuples to ((i σ⁻¹i)·σ)-tuples
-    with opposite sign. -/
-axiom gv_involution_cancellation {r : ℕ} (cfg : LGVConfig r) :
+    The involution maps (σ, P) ↦ (σ ∘ (i j), P') where (i,j) is the
+    first crossing pair and P' is the tail-swapped tuple. Fixed points
+    are exactly non-intersecting identity tuples.
+
+    Components 1-2 are proved above. Component 3 (the involution
+    bookkeeping) requires defining "first crossing point" and proving
+    the tail-swap preserves path validity. -/
+theorem gv_involution_cancellation {r : ℕ} (cfg : LGVConfig r)
+    (hwf : cfg.wellFormed) :
     ∑ σ : Equiv.Perm (Fin r),
       (↑(Equiv.Perm.sign σ) : ℤ) * ↑(Fintype.card (PermPathTuple cfg σ)) =
-    ↑(niTupleCount cfg)
+    ↑(niTupleCount cfg) := by
+  -- Reformulate as sum over tagged tuples
+  rw [← sum_tagged_eq_sum_perm]
+  -- The proof now requires building the sign-reversing involution
+  -- on TaggedPathTuple and showing its fixed points are exactly
+  -- the NI identity tuples.
+  -- Key ingredients:
+  -- 1. nonid_perm_paths_cross hwf: non-id tuples always have crossings
+  -- 2. Tail-swap involution at first crossing point (to be constructed)
+  -- 3. Fixed points = NI identity tuples
+  sorry
 
 /-- **The r×r LGV Lemma** (Lindström 1973, Gessel-Viennot 1985):
 
@@ -514,10 +704,10 @@ axiom gv_involution_cancellation {r : ℕ} (cfg : LGVConfig r) :
     Proved by combining the algebraic bridge (det = signed perm sum)
     with the GV involution cancellation (signed sum = NI count).
     This generalizes the 2×2 case proved in BallotProblemOQ03.lean. -/
-theorem lgv_lemma_rxr {r : ℕ} (cfg : LGVConfig r) :
+theorem lgv_lemma_rxr {r : ℕ} (cfg : LGVConfig r) (hwf : cfg.wellFormed) :
     (niTupleCount cfg : ℤ) = (pathMatrix cfg).det := by
   rw [det_pathMatrix_eq_signed_sum]
-  exact (gv_involution_cancellation cfg).symm
+  exact (gv_involution_cancellation cfg hwf).symm
 
 -- ============================================================
 -- PART 9: Corollaries
@@ -528,10 +718,10 @@ theorem niTupleCount_nonneg {r : ℕ} (cfg : LGVConfig r) :
     0 ≤ (niTupleCount cfg : ℤ) :=
   Int.natCast_nonneg _
 
-/-- The path matrix determinant is non-negative. -/
-theorem pathMatrix_det_nonneg {r : ℕ} (cfg : LGVConfig r) :
+/-- The path matrix determinant is non-negative (for well-formed configs). -/
+theorem pathMatrix_det_nonneg {r : ℕ} (cfg : LGVConfig r) (hwf : cfg.wellFormed) :
     0 ≤ (pathMatrix cfg).det := by
-  rw [← lgv_lemma_rxr cfg]
+  rw [← lgv_lemma_rxr cfg hwf]
   exact niTupleCount_nonneg cfg
 
 /-- For r = 1, every path tuple is vacuously non-intersecting
@@ -564,8 +754,8 @@ theorem isNonIntersecting_of_r_one (cfg : LGVConfig 1) (paths : PathTuple cfg) :
        plane partitions in a box can be proved using the LGV lemma
        with appropriate source/target configurations. -/
 theorem lgv_universality :
-    ∀ (r : ℕ) (cfg : LGVConfig r),
+    ∀ (r : ℕ) (cfg : LGVConfig r) (hwf : cfg.wellFormed),
       (niTupleCount cfg : ℤ) = (pathMatrix cfg).det :=
-  fun _ cfg => lgv_lemma_rxr cfg
+  fun _ cfg hwf => lgv_lemma_rxr cfg hwf
 
 end LGV

--- a/proofs/Proofs/InclusionExclusionOQ03.lean
+++ b/proofs/Proofs/InclusionExclusionOQ03.lean
@@ -130,41 +130,42 @@ theorem signed_sum_subsets (S : Finset α) :
 private theorem inner_sum_eq (S U : Finset α) (hU : U ⊆ S) :
     (∑ T ∈ S.powerset.filter (U ⊆ ·), (-1 : ℤ) ^ (S \ T).card) =
       if U = S then 1 else 0 := by
-  -- Bijection: T ↦ T \ U from {T : U⊆T⊆S} to (S\U).powerset
-  -- Under this bijection: |S\T| = |(S\U) \ (T\U)|
-  conv_lhs => arg 2; ext T
-    rw [show (S \ T).card = ((S \ U) \ (T \ U)).card from by
-      congr 1; ext x
-      simp only [Finset.mem_sdiff]
-      tauto]
-  rw [← Finset.sum_bij (fun T _ => T \ U)
+  -- Key insight: the sets {T : U⊆T⊆S} and (S\U).powerset are in bijection via T ↦ T\U.
+  -- Under this bijection |S\T| = |(S\U)\(T\U)|, so the sum equals signed_sum_subsets(S\U).
+  -- First establish: S\U = ∅ ↔ U = S
+  have sdiff_empty_iff : S \ U = ∅ ↔ U = S := by
+    rw [Finset.sdiff_eq_empty_iff_subset]; exact ⟨fun h => le_antisymm hU h, fun h => h ▸ le_refl _⟩
+  -- Rewrite each term: |S\T| = |(S\U)\(T\U)| when U ⊆ T ⊆ S
+  have card_eq : ∀ T ∈ S.powerset.filter (U ⊆ ·),
+      (S \ T).card = ((S \ U) \ (T \ U)).card := by
+    intro T hT
+    simp only [Finset.mem_filter, Finset.mem_powerset] at hT
+    congr 1; ext x; simp only [Finset.mem_sdiff]; tauto
+  conv_lhs => arg 2; ext T; rw [card_eq T (by assumption)]
+  -- Bijection via sum_nbij: T ↦ T\U from {T:U⊆T⊆S} to (S\U).powerset
+  rw [Finset.sum_nbij (fun T => T \ U)
     (fun T hT => by
       simp only [Finset.mem_filter, Finset.mem_powerset] at hT ⊢
       exact Finset.sdiff_subset_sdiff_left hT.1)
     (fun T₁ hT₁ T₂ hT₂ h => by
       simp only [Finset.mem_filter, Finset.mem_powerset] at hT₁ hT₂
-      ext x
-      by_cases hx : x ∈ U
+      ext x; by_cases hx : x ∈ U
       · exact ⟨fun _ => hT₂.2 hx, fun _ => hT₁.2 hx⟩
       · have := Finset.ext_iff.mp h x
         simp only [Finset.mem_sdiff] at this
-        exact this.mp.mt (fun hn => ⟨hn, hx⟩) |>.imp_left fun h' => ⟨h', hx⟩ |>.symm
-        sorry)
+        constructor
+        · intro hx1; exact (this.mp ⟨hx1, hx⟩).1
+        · intro hx2; exact (this.mpr ⟨hx2, hx⟩).1)
     (fun W hW => by
       simp only [Finset.mem_powerset] at hW
       exact ⟨W ∪ U, by
         simp only [Finset.mem_filter, Finset.mem_powerset]
-        exact ⟨Finset.union_subset (hW.trans (Finset.sdiff_subset)) hU, Finset.subset_union_right⟩,
+        exact ⟨Finset.union_subset (hW.trans Finset.sdiff_subset) hU, Finset.subset_union_right⟩,
         by ext x; simp only [Finset.mem_sdiff, Finset.mem_union]; tauto⟩)
     (fun T _ => rfl)]
-  exact signed_sum_subsets (S \ U) |>.trans (by
-    split_ifs with h1 h2 h2
-    · rfl
-    · exfalso; exact h2 (Finset.sdiff_eq_empty_of_subset (h1 ▸ le_refl _) |>.symm ▸ rfl)
-      sorry
-    · exfalso; exact h1 (by rw [Finset.sdiff_eq_empty_iff_subset] at h2; exact le_antisymm hU h2)
-      sorry
-    · rfl)
+  -- Now goal: ∑ W ∈ (S\U).powerset, (-1)^|(S\U)\W| = if U = S then 1 else 0
+  rw [signed_sum_subsets]
+  simp [sdiff_empty_iff]
 
 theorem mobius_inverts_zeta (f : SubsetFn α) :
     mobiusTransform (zetaTransform f) = f := by

--- a/proofs/Proofs/InclusionExclusionOQ03.lean
+++ b/proofs/Proofs/InclusionExclusionOQ03.lean
@@ -124,19 +124,68 @@ theorem signed_sum_subsets (S : Finset α) :
 
 /-- **Möbius inversion theorem**: μ ∘ ζ = id on subset functions.
     For any f : 2^α → ℤ, if g = ζf then μg = f. -/
+/-- Inner sum identity: ∑_{T: U⊆T⊆S} (-1)^|S\T| = [U = S].
+    Via bijection T ↦ T\U between {T : U⊆T⊆S} and (S\U).powerset,
+    this reduces to signed_sum_subsets. -/
+private theorem inner_sum_eq (S U : Finset α) (hU : U ⊆ S) :
+    (∑ T ∈ S.powerset.filter (U ⊆ ·), (-1 : ℤ) ^ (S \ T).card) =
+      if U = S then 1 else 0 := by
+  -- Bijection: T ↦ T \ U from {T : U⊆T⊆S} to (S\U).powerset
+  -- Under this bijection: |S\T| = |(S\U) \ (T\U)|
+  conv_lhs => arg 2; ext T
+    rw [show (S \ T).card = ((S \ U) \ (T \ U)).card from by
+      congr 1; ext x
+      simp only [Finset.mem_sdiff]
+      tauto]
+  rw [← Finset.sum_bij (fun T _ => T \ U)
+    (fun T hT => by
+      simp only [Finset.mem_filter, Finset.mem_powerset] at hT ⊢
+      exact Finset.sdiff_subset_sdiff_left hT.1)
+    (fun T₁ hT₁ T₂ hT₂ h => by
+      simp only [Finset.mem_filter, Finset.mem_powerset] at hT₁ hT₂
+      ext x
+      by_cases hx : x ∈ U
+      · exact ⟨fun _ => hT₂.2 hx, fun _ => hT₁.2 hx⟩
+      · have := Finset.ext_iff.mp h x
+        simp only [Finset.mem_sdiff] at this
+        exact this.mp.mt (fun hn => ⟨hn, hx⟩) |>.imp_left fun h' => ⟨h', hx⟩ |>.symm
+        sorry)
+    (fun W hW => by
+      simp only [Finset.mem_powerset] at hW
+      exact ⟨W ∪ U, by
+        simp only [Finset.mem_filter, Finset.mem_powerset]
+        exact ⟨Finset.union_subset (hW.trans (Finset.sdiff_subset)) hU, Finset.subset_union_right⟩,
+        by ext x; simp only [Finset.mem_sdiff, Finset.mem_union]; tauto⟩)
+    (fun T _ => rfl)]
+  exact signed_sum_subsets (S \ U) |>.trans (by
+    split_ifs with h1 h2 h2
+    · rfl
+    · exfalso; exact h2 (Finset.sdiff_eq_empty_of_subset (h1 ▸ le_refl _) |>.symm ▸ rfl)
+      sorry
+    · exfalso; exact h1 (by rw [Finset.sdiff_eq_empty_iff_subset] at h2; exact le_antisymm hU h2)
+      sorry
+    · rfl)
+
 theorem mobius_inverts_zeta (f : SubsetFn α) :
     mobiusTransform (zetaTransform f) = f := by
   ext S
   simp only [mobiusTransform, zetaTransform]
-  -- PROOF STRATEGY (requires Fubini exchange of finite sums):
-  -- (μ(ζf))(S) = ∑_{T ⊆ S} (-1)^|S\T| · ∑_{U ⊆ T} f(U)
-  -- After distributing and exchanging summation order:
-  -- = ∑_{U ⊆ S} f(U) · (∑_{T: U⊆T⊆S} (-1)^|S\T|)
-  -- The inner sum = signed_sum_subsets(S\U) via bijection T ↦ T\U:
-  --   {T : U⊆T⊆S} ≅ {W : W⊆S\U}, and |S\T| = |(S\U)\W|
-  -- By signed_sum_subsets: inner sum = [S\U = ∅] = [U = S]
-  -- So the total = f(S) · 1 + ∑_{U⊊S} f(U) · 0 = f(S)
-  sorry
+  simp_rw [Finset.mul_sum]
+  rw [Finset.sum_comm' (s' := S.powerset)
+    (t' := fun U => S.powerset.filter (U ⊆ ·))
+    (h := fun T U => by
+      simp only [Finset.mem_powerset, Finset.mem_filter]
+      exact ⟨fun ⟨hTS, hUT⟩ => ⟨hUT.trans hTS, hTS, hUT⟩,
+             fun ⟨_, hTS, hUT⟩ => ⟨hTS, hUT⟩⟩)]
+  conv_lhs => arg 2; ext U; rw [← Finset.sum_mul]; rw [mul_comm]
+  have : ∀ U ∈ S.powerset,
+      f U * (∑ T ∈ S.powerset.filter (U ⊆ ·), (-1 : ℤ) ^ (S \ T).card) =
+        if U = S then f S else 0 := by
+    intro U hU
+    rw [inner_sum_eq S U (Finset.mem_powerset.mp hU)]
+    split_ifs with h <;> simp [h]
+  rw [Finset.sum_congr rfl this]
+  simp [Finset.sum_ite_eq', Finset.mem_powerset]
 
 -- ============================================================
 -- PART 4: Connection to Inclusion-Exclusion

--- a/research/problems/ballot-problem-oq-03-oq-02/knowledge.md
+++ b/research/problems/ballot-problem-oq-03-oq-02/knowledge.md
@@ -10,76 +10,57 @@
 Created `BallotProblemOQ03OQ02.lean` (284 lines, 1 axiom, 0 sorries, 7 theorems, 17 defs).
 
 ### Architecture
-The file formalizes the r×r LGV lemma infrastructure:
+The file formalizes the r×r LGV lemma infrastructure with algebraic bridge
+and combinatorial foundations.
 
-| Component | Type | Status |
-|-----------|------|--------|
-| `LGVConfig` | structure | r sources, r targets, strict mono |
-| `PathTuple` | def | Dependent r-tuple of PathMN |
-| `PermPathTuple` | def | σ-path tuples for permutation σ |
-| `pathMatrix` | def | r×r matrix M_{i,j} = C(m+(bⱼ-aᵢ),m) |
-| `niTupleCount` | def | Cardinality of NI path tuples |
-| `swapTailsAt` | def | Tail-swap operation for GV involution |
-| `lgv_lemma_rxr` | axiom | Main theorem: niTupleCount = det(pathMatrix) |
-| `gessel_viennot_transposition_sign` | theorem | PROVED: sign(swap∘σ) = -sign(σ) |
-| `isNonIntersecting_of_r_one` | theorem | PROVED: every 1-tuple is vacuously NI |
-| `pathMatrix_det_nonneg` | theorem | PROVED: 0 ≤ det(pathMatrix) |
+---
 
-### Key Technical Challenges
-1. **Dependent Pi Fintype**: `(i : Fin r) → PathMN m (f i)` doesn't get automatic
-   Fintype synthesis. Solution: `unfold PathTuple; infer_instance` after the definition
-   has been unfolded to expose the Pi type structure.
-
-2. **Involution formulation**: The GV involution works on individual tuples, not
-   aggregate counts. A σ-tuple maps to a τ-tuple (not σ-cardinality = τ-cardinality).
-   The correct approach expands det, maps each tuple to its sign-reversed partner,
-   and shows the only unpaired contributions are NI id-tuples.
-
-3. **Permutation sign**: `Equiv.Perm.sign_swap` needs `Ne.symm hi` (not `hi`) because
-   the swap is `Equiv.swap i (σ i)` and the hypothesis is `σ i ≠ i`, but sign_swap
-   expects `i ≠ σ i`.
-
-### What Remains
-The single axiom `lgv_lemma_rxr` requires formalizing the full GV involution:
-- For each non-identity σ, find first non-fixed point i
-- Show paths Pᵢ and P_{σ(i)} must intersect (crossing lemma)
-- Build the tail-swap bijection at first intersection point
-- Show it maps σ-tuples to (swap ∘ σ)-tuples (sign reversal)
-- Show non-NI id-tuples also pair with some non-id σ-tuples
-
-### Build
-Docker build passes with `LEAN_MEMORY_LIMIT=16384`.
-
-## Session 2026-03-22 (researcher-7) - GV Cancellation for Small r
+## Session 2026-03-22 (researcher-3) - Axiom Elimination
 
 **Mode**: REVISIT (depth-first, RICH knowledge score 35)
 **Problem**: ballot-problem-oq-03-oq-02
-**Prior Status**: 1 axiom (gv_involution_cancellation), 0 sorries, 504 lines
+**Prior Status**: 0 sorries, 1 axiom (gv_involution_cancellation)
 
 ### Work Done
-Added 6 proved theorems (67 new lines, total 571 lines):
+Converted the `gv_involution_cancellation` axiom to a theorem with structured
+sorry decomposition. 0 axioms, 2 sorries remain. File: 688 lines.
 
-| Theorem | Purpose | Status |
-|---------|---------|--------|
-| `permPathTuple_one_equiv` | PermPathTuple cfg 1 ≃ PathTuple cfg | PROVED |
-| `permPathTuple_one_card` | Card equivalence for id perm | PROVED |
-| `niTupleCount_eq_card_of_all_ni` | NI count = total when all NI | PROVED |
-| `isNonIntersecting_of_r_zero` | Vacuous NI for r=0 | PROVED |
-| `gv_cancellation_r_zero` | GV cancellation for r=0 | PROVED |
-| `gv_cancellation_r_one` | GV cancellation for r=1 | PROVED |
+### Key Results
 
-### Key Insights
-- For r ≤ 1, Perm(Fin r) has exactly one element (identity), so the signed sum is trivial
-- The GV involution is only needed for r ≥ 2 where non-identity permutations exist
-- `Equiv.subtypeUnivEquiv` from Mathlib handles the "all elements satisfy P" → subtype equiv
-- `Fintype` for subtype `{p // IsNonIntersecting cfg p}` needs explicit `Classical.dec` provision
+| Component | Status | Description |
+|-----------|--------|-------------|
+| `TaggedPathTuple` | **Proved** | Sigma type Σ_σ PermPathTuple(σ) with Fintype |
+| `sum_tagged_eq_sum_perm` | **Proved** | Signed perm sum = sum over tagged tuples |
+| `perm_ne_one_has_inversion` | **Proved** | Non-id perms have inversions (via firstNonFixed) |
+| `nonid_perm_paths_cross` | **Proved** | Non-id σ-tuples always cross (uses crossing lemma) |
+| `LGVConfig.wellFormed` | **Proved** | ∀ i j, sources i ≤ targets j; iff characterization |
+| `lattice_paths_must_cross` | **Sorry** | Discrete IVT for lattice paths |
+| `gv_involution_cancellation` | **Sorry** | Involution bookkeeping (depends on crossing lemma) |
+
+### Critical Discovery: Well-Formedness Requirement
+
+The original axiom was stated without a well-formedness condition. This is WRONG
+for some configs: when `targets(σ i) < sources(i)`, Nat subtraction gives
+`PathMN m 0` (horizontal paths) instead of an empty type (no valid paths).
+This causes pathMatrix entries to be 1 instead of 0, making the determinant
+incorrect.
+
+**Fix**: Added `LGVConfig.wellFormed` condition: `∀ i j, sources i ≤ targets j`.
+Equivalent to `sources(r-1) ≤ targets(0)` for strictly mono sequences.
+
+### NonIntersecting Definition Concern
+
+The `NonIntersecting` definition checks:
+1. Disjoint `colYRange` at each column x < m
+2. Different y-positions at column m boundary
+
+It does NOT check lattice points in the "trailing" segment (North steps after
+the last East step). This may be incomplete for paths where trailing steps
+cause overlap. Needs investigation.
 
 ### What Remains
-The axiom `gv_involution_cancellation` is now proved for r=0 and r=1. For r ≥ 2:
-- Prove the crossing lemma (non-identity perm paths must intersect)
-- Construct the GV involution (swap tails at first intersection point)
-- Prove the involution is sign-reversing and its own inverse
-- Replace the axiom with the proved theorem
-
-### Build
-Docker build passes with `LEAN_MEMORY_LIMIT=16384`.
+1. **Crossing lemma** (`lattice_paths_must_cross`): Need discrete IVT argument
+   showing paths that start with P below Q but end with P above Q must share
+   a lattice point. Challenge: colEntry may not capture trailing North steps.
+2. **GV involution** (`gv_involution_cancellation`): Build sign-reversing
+   involution on TaggedPathTuple using first-crossing finder + tail-swap.

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -1,54 +1,55 @@
 {
   "id": "ballot-problem-oq-03-oq-02",
-  "name": "General LGV Lemma: r\u00d7r Lindstr\u00f6m-Gessel-Viennot Determinant",
+  "name": "General LGV Lemma: r×r Lindström-Gessel-Viennot Determinant",
   "status": "surveyed",
   "phase": "ACT",
   "knowledge": {
     "insights": [
-      "Parent OQ03 (2878 lines, 0 axioms, 0 sorries) proves the 2\u00d72 LGV lemma completely",
-      "2\u00d72 LGV: non-intersecting path pairs = e(A1,B1)e(A2,B2) - e(A1,B2)e(A2,B1) = det[[e(Ai,Bj)]]",
-      "General r\u00d7r LGV: non-intersecting r-tuples = det[[e(Ai,Bj)]] for i,j = 1..r",
-      "Proof for r\u00d7r requires sign-reversing involution on r-tuples of paths",
+      "Parent OQ03 (2878 lines, 0 axioms, 0 sorries) proves the 2×2 LGV lemma completely",
+      "2×2 LGV: non-intersecting path pairs = e(A1,B1)e(A2,B2) - e(A1,B2)e(A2,B1) = det[[e(Ai,Bj)]]",
+      "General r×r LGV: non-intersecting r-tuples = det[[e(Ai,Bj)]] for i,j = 1..r",
+      "Proof for r×r requires sign-reversing involution on r-tuples of paths",
       "Mathlib has Matrix.det and Equiv.Perm infrastructure for the sign arguments",
       "Matrix.det_fin_two and Matrix.det_fin_three from Mathlib verify small cases automatically",
-      "The Leibniz formula bridge (det = \u03a3 sign(\u03c3)\u00b7\u03a0) needs careful cast handling between Perm.sign (Units \u2124) and \u2124",
+      "The Leibniz formula bridge (det = Σ sign(σ)·Π) needs careful cast handling between Perm.sign (Units ℤ) and ℤ",
       "The GV involution is the key sorry: needs definition of 'first intersection point' and proof of sign reversal",
       "Separating the involution hypothesis from the algebraic machinery makes the proof modular",
       "Algebraic bridge proved: det(pathMatrix) = sum_sigma sign(sigma) * card(PermPathTuple) via column Leibniz formula",
       "permPathTuple_card proved: card of sigma-tuples = product of binomial coefficients (from pathMN_card)",
       "firstNonFixed infrastructure: smallest non-fixed point of perm, with spec/minimal/lt_image lemmas all proved",
       "GV cancellation isolated as sole axiom; lgv_lemma_rxr is now a theorem proved from algebraic bridge + GV axiom",
-      "Units.smul_def handles sign coercion (\u2124\u02e3 \u2022 \u2124 = \u2191\u2124\u02e3 * \u2124) in det formula connection",
+      "Units.smul_def handles sign coercion (ℤˣ • ℤ = ↑ℤˣ * ℤ) in det formula connection",
       "File builds clean against Mathlib v4.26 (verified). 1 axiom (gv_involution_cancellation), 1 sorry (pathMN_card).",
-      "pathMN_card proof strategy: PathMN m n \u2243 Finset.univ.powersetCard m via indicator bijection, then use Finset.card_powersetCard. Requires building explicit Equiv between List Bool positions and Finset (Fin (m+n)).",
+      "pathMN_card proof strategy: PathMN m n ≃ Finset.univ.powersetCard m via indicator bijection, then use Finset.card_powersetCard. Requires building explicit Equiv between List Bool positions and Finset (Fin (m+n)).",
       "pathMN_card is a good Aristotle candidate - standard combinatorial identity C(m+n,m) = |{binary strings of length m+n with m zeros}|",
       "pathMN_card proved via double induction + Pascal identity + splitting equiv. 0 sorries now.",
-      "permPathTuple_one_equiv PROVED: PermPathTuple cfg 1 \u2243 PathTuple cfg (identity perm tuples = regular tuples)",
-      "niTupleCount_eq_card_of_all_ni PROVED: when all tuples are NI, niTupleCount = card(PathTuple)",
-      "gv_cancellation_r_zero PROVED: GV cancellation holds for r=0 (single perm, vacuously NI)",
-      "gv_cancellation_r_one PROVED: GV cancellation holds for r=1 (single perm, vacuously NI)",
-      "For r \u2264 1, Perm(Fin r) has exactly one element (the identity), making the signed sum trivial",
-      "The GV involution is only needed for r \u2265 2 where non-identity permutations exist"
+      "GV cancellation requires well-formedness: ∀ i j, sources i ≤ targets j (Nat subtraction gives wrong path counts otherwise)",
+      "Axiom eliminated: gv_involution_cancellation converted to theorem with structured sorry decomposition",
+      "sum_tagged_eq_sum_perm proved: signed perm sum = sum over sigma type Σ_σ PermPathTuple(σ)",
+      "perm_ne_one_has_inversion proved: non-id perms on strictly ordered domain have inversions (via firstNonFixed)",
+      "nonid_perm_paths_cross proved (modulo crossing lemma): uses inversion + crossing lemma + omega",
+      "wellFormed condition: equivalent to sources(r-1) ≤ targets(0) when both strictly mono",
+      "NonIntersecting definition may be incomplete: does not check trailing North steps after last East step"
     ],
     "builtItems": [
-      "BallotProblemOQ03OQ02.lean: r\u00d7r LGV infrastructure (204 lines)",
+      "BallotProblemOQ03OQ02.lean: r×r LGV infrastructure (204 lines)",
       "pathMatrix / latticePathMatrix: path weight matrix over Fin r",
       "permPathCount / signedPermPathCount: signed permutation path counting",
-      "lgv_lemma_general: general r\u00d7r LGV statement from involution hypothesis",
-      "lgv_2x2_det: verified 2\u00d72 determinant specialization",
-      "lgv_3x3_det: verified 3\u00d73 determinant expansion (6 terms)",
+      "lgv_lemma_general: general r×r LGV statement from involution hypothesis",
+      "lgv_2x2_det: verified 2×2 determinant specialization",
+      "lgv_3x3_det: verified 3×3 determinant expansion (6 terms)",
       "GV involution algorithm documented in detail (swap tails at first intersection)",
       "firstNonFixed: smallest non-fixed point of non-identity perm (def + 3 lemmas, all proved)",
       "permPathTuple_card: card(PermPathTuple cfg sigma) = prod of C(m+(b_sigma(i)-a_i), m) (proved from pathMN_card)",
       "det_pathMatrix_eq_signed_sum: det = signed sum of perm path tuple counts (proved via column Leibniz)",
       "gv_involution_cancellation: GV cancellation axiom (the single remaining axiom)",
       "lgv_lemma_rxr: NOW A THEOREM (was axiom), proved from algebraic bridge + GV cancellation",
-      "permPathTuple_one_equiv: PermPathTuple cfg 1 \u2243 PathTuple cfg (proved)",
-      "permPathTuple_one_card: card(PermPathTuple cfg 1) = card(PathTuple cfg) (proved)",
-      "niTupleCount_eq_card_of_all_ni: NI count = total count when all NI (proved)",
-      "isNonIntersecting_of_r_zero: vacuous NI for r=0 (proved)",
-      "gv_cancellation_r_zero: GV cancellation theorem for r=0 (proved, not axiom)",
-      "gv_cancellation_r_one: GV cancellation theorem for r=1 (proved, not axiom)"
+      "TaggedPathTuple: sigma type Σ_σ PermPathTuple(cfg, σ) with Fintype instance (688 lines total)",
+      "sum_tagged_eq_sum_perm: algebraic sum decomposition (proved)",
+      "perm_ne_one_has_inversion: inversion existence for non-id perms (proved)",
+      "nonid_perm_paths_cross: non-id σ-tuples cross (proved from crossing lemma)",
+      "LGVConfig.wellFormed: necessary condition for GV cancellation (proved iff characterization)",
+      "PermPathTuple.toPathTuple: cast from σ=1 perm tuple to identity path tuple"
     ],
     "openQuestions": [
       "Can pathMN_card be proved via bijection with Finset.powersetCard?",
@@ -56,110 +57,12 @@
       "GV involution: need proof that non-identity perm paths must cross (crossing lemma)"
     ],
     "nextSteps": [
-      "For r \u2265 2: prove the crossing lemma (non-identity perm paths must intersect)",
-      "For r \u2265 2: construct the GV involution (swap tails at first intersection)",
-      "For r \u2265 2: prove involution is sign-reversing and its own inverse",
-      "Prove gv_involution_cancellation as theorem from the involution construction"
+      "Prove lattice_paths_must_cross (crossing lemma): discrete IVT for lattice paths. Key challenge: colEntry may not capture trailing North steps.",
+      "Prove gv_involution_cancellation: build sign-reversing involution on TaggedPathTuple. Needs first-crossing finder + tail-swap construction.",
+      "Investigate NonIntersecting definition completeness: does it handle trailing North steps correctly?",
+      "Consider strengthening NonIntersecting to check all lattice points, not just column y-ranges"
     ],
-    "progressSummary": "PROGRESS: Added 6 proved theorems including GV cancellation for r=0,1. File: 571 lines, 1 axiom (gv_involution_cancellation), 0 sorries. Axiom only needed for r\u22652."
+    "progressSummary": "PROGRESS: Axiom eliminated. gv_involution_cancellation converted from axiom to theorem. 2 sorries remain (crossing lemma + involution bookkeeping). 5 new theorems proved. Well-formedness condition discovered and formalized. File: 688 lines, 0 axioms, 2 sorries."
   },
-  "lastUpdate": "2026-03-22T16:10:00Z",
-  "leanFiles": [
-    {
-      "path": "Proofs/BallotProblem.lean",
-      "filename": "BallotProblem.lean",
-      "lineCount": 256,
-      "theoremCount": 7,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblem.lean"
-    },
-    {
-      "path": "Proofs/BallotProblemOQ01.lean",
-      "filename": "BallotProblemOQ01.lean",
-      "lineCount": 711,
-      "theoremCount": 44,
-      "axiomCount": 0,
-      "defCount": 8,
-      "sorryCount": 2,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01.lean"
-    },
-    {
-      "path": "Proofs/BallotProblemOQ01OQ01.lean",
-      "filename": "BallotProblemOQ01OQ01.lean",
-      "lineCount": 131,
-      "theoremCount": 3,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 2,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ01.lean"
-    },
-    {
-      "path": "Proofs/BallotProblemOQ01OQ02.lean",
-      "filename": "BallotProblemOQ01OQ02.lean",
-      "lineCount": 935,
-      "theoremCount": 36,
-      "axiomCount": 1,
-      "defCount": 18,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
-    },
-    {
-      "path": "Proofs/BallotProblemOQ02.lean",
-      "filename": "BallotProblemOQ02.lean",
-      "lineCount": 340,
-      "theoremCount": 8,
-      "axiomCount": 2,
-      "defCount": 3,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ02.lean"
-    },
-    {
-      "path": "Proofs/BallotProblemOQ03.lean",
-      "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2879,
-      "theoremCount": 119,
-      "axiomCount": 0,
-      "defCount": 31,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03.lean"
-    },
-    {
-      "path": "Proofs/BallotProblemOQ03OQ02.lean",
-      "filename": "BallotProblemOQ03OQ02.lean",
-      "lineCount": 571,
-      "theoremCount": 22,
-      "axiomCount": 1,
-      "defCount": 17,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"
-    },
-    {
-      "path": "Proofs/BallotProblemOQ03OQ03.lean",
-      "filename": "BallotProblemOQ03OQ03.lean",
-      "lineCount": 139,
-      "theoremCount": 8,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ03.lean"
-    }
-  ],
-  "relatedProofs": [
-    "ballot-problem",
-    "ballot-problem-oq-01",
-    "ballot-problem-oq-01-oq-01",
-    "ballot-problem-oq-02",
-    "ballot-problem-oq-03",
-    "ballot-problem-oq-03-oq-02"
-  ]
+  "lastUpdate": "2026-03-22T08:00:00Z"
 }

--- a/src/data/research/problems/inclusion-exclusion-oq-03.json
+++ b/src/data/research/problems/inclusion-exclusion-oq-03.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "COMPLETED",
     "since": "2026-03-21T21:14:00-07:00",
     "iteration": 2,
-    "focus": "Proved main M\u00f6bius inversion structure via Finset.sum_comm' exchange",
+    "focus": "All sorries filled. mobius_inverts_zeta fully proved.",
     "blockers": [],
-    "nextAction": "Fill 3 remaining sorries in inner_sum_eq: bijection injectivity and sdiff_eq_empty matching",
+    "nextAction": "None - problem completed",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved main structure of mobius_inverts_zeta using Finset.sum_comm' for Fubini exchange. Factored into inner_sum_eq helper. 3 small sorries remain in bijection details.",
+    "progressSummary": "COMPLETED: InclusionExclusionOQ03.lean now has 0 sorries, 0 axioms. Proved mobius_inverts_zeta (M\u00f6bius inversion) via Finset.sum_comm' exchange + sum_nbij bijection + signed_sum_subsets.",
     "builtItems": [
       "InclusionExclusionOQ03.lean: Zeta/M\u00f6bius transforms (209 lines, 0 axioms, 4 sorries)",
       "zetaTransform: (\u03b6f)(S) = \u2211_{T\u2286S} f(T)",
@@ -42,9 +42,14 @@
       "mobius_subset_lattice: proved via Finset.sum_eq_single isolating T=\u2205",
       "odd_even_subset_balance: proved via Finset.card_bij with parity-flipping involution",
       {
-        "name": "mobius_inverts_zeta (structure)",
-        "description": "Main proof structure complete: distribute \u2192 sum_comm' \u2192 factor \u2192 inner_sum_eq \u2192 sum_ite_eq'",
-        "proven": false
+        "name": "mobius_inverts_zeta",
+        "description": "\u03bc \u2218 \u03b6 = id (M\u00f6bius inversion on subset lattice) - fully proved",
+        "proven": true
+      },
+      {
+        "name": "inner_sum_eq",
+        "description": "Sum exchange bijection: {T:U\u2286T\u2286S} \u2194 (S\\U).powerset, reduces to signed_sum_subsets",
+        "proven": true
       }
     ],
     "insights": [
@@ -57,13 +62,11 @@
       "Finset.prod_add gives the multilinear expansion \u220f(f+g) = \u03a3 (\u220ff)(\u220fg), perfect for signed sums",
       "The involution T\u21a6(erase/insert a) is cleaner to formalize than symmDiff for bijection proofs",
       "mobius_inverts_zeta requires Fubini-type sum exchange (sum_comm with dependent indices) - nontrivial in Lean",
-      "Finset.sum_comm' handles the dependent-index Fubini exchange for \u2211_{T\u2286S} \u2211_{U\u2286T} \u2192 \u2211_{U\u2286S} \u2211_{T: U\u2286T\u2286S}"
+      "Finset.sum_comm' handles the dependent-index Fubini exchange for \u2211_{T\u2286S} \u2211_{U\u2286T} \u2192 \u2211_{U\u2286S} \u2211_{T: U\u2286T\u2286S}",
+      "Finset.sum_nbij handles the bijection proof with explicit injection/surjection on Finset subtraction"
     ],
     "mathlibGaps": [],
-    "nextSteps": [
-      "Fill inner_sum_eq bijection injectivity: T\u2081 \\ U = T\u2082 \\ U and U \u2286 T\u2081, U \u2286 T\u2082 \u2192 T\u2081 = T\u2082",
-      "Fill sdiff_eq_empty \u2194 subset matching in the if-then-else"
-    ],
+    "nextSteps": [],
     "markdown": "# Knowledge Base: inclusion-exclusion-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [],
@@ -76,7 +79,7 @@
     "mathlib": []
   },
   "started": "2026-03-22T04:19:59.477Z",
-  "lastUpdate": "2026-03-22T16:00:00.000Z",
+  "lastUpdate": "2026-03-22T16:30:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/InclusionExclusion.lean",

--- a/src/data/research/problems/inclusion-exclusion-oq-03.json
+++ b/src/data/research/problems/inclusion-exclusion-oq-03.json
@@ -18,10 +18,10 @@
   "currentState": {
     "phase": "OBSERVE",
     "since": "2026-03-21T21:14:00-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "Proved main M\u00f6bius inversion structure via Finset.sum_comm' exchange",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Fill 3 remaining sorries in inner_sum_eq: bijection injectivity and sdiff_eq_empty matching",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,34 +29,40 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved 3 of 4 sorries (signed_sum_subsets via prod_add, mobius_subset_lattice via sum_eq_single, odd_even_subset_balance via card_bij). 1 sorry remains (mobius_inverts_zeta - needs Fubini exchange).",
+    "progressSummary": "PROGRESS: Proved main structure of mobius_inverts_zeta using Finset.sum_comm' for Fubini exchange. Factored into inner_sum_eq helper. 3 small sorries remain in bijection details.",
     "builtItems": [
-      "InclusionExclusionOQ03.lean: Zeta/Möbius transforms (209 lines, 0 axioms, 4 sorries)",
-      "zetaTransform: (ζf)(S) = ∑_{T⊆S} f(T)",
-      "mobiusTransform: (μg)(S) = ∑_{T⊆S} (-1)^|S\\T| g(T)",
-      "zetaStep: single-element DP step for O(n·2^n) computation",
+      "InclusionExclusionOQ03.lean: Zeta/M\u00f6bius transforms (209 lines, 0 axioms, 4 sorries)",
+      "zetaTransform: (\u03b6f)(S) = \u2211_{T\u2286S} f(T)",
+      "mobiusTransform: (\u03bcg)(S) = \u2211_{T\u2286S} (-1)^|S\\T| g(T)",
+      "zetaStep: single-element DP step for O(n\u00b72^n) computation",
       "zetaTransform_empty, zetaTransform_singleton: proved",
       "mobiusTransform_empty: proved",
       "zetaStep_not_mem, zetaStep_mem: proved",
       "signed_sum_subsets: proved via Finset.prod_add expansion (product of (1+(-1))=0)",
-      "mobius_subset_lattice: proved via Finset.sum_eq_single isolating T=∅",
-      "odd_even_subset_balance: proved via Finset.card_bij with parity-flipping involution"
+      "mobius_subset_lattice: proved via Finset.sum_eq_single isolating T=\u2205",
+      "odd_even_subset_balance: proved via Finset.card_bij with parity-flipping involution",
+      {
+        "name": "mobius_inverts_zeta (structure)",
+        "description": "Main proof structure complete: distribute \u2192 sum_comm' \u2192 factor \u2192 inner_sum_eq \u2192 sum_ite_eq'",
+        "proven": false
+      }
     ],
     "insights": [
-      "Möbius inversion on Boolean lattice reduces to signed_sum_subsets: ∑_{T⊆S} (-1)^|S\\T| = [S=∅]",
-      "The involution T ↦ T △ {a} for fixed a∈S changes |S\\T| parity — this is the key cancellation",
-      "Fast SOS computes zetaTransform in O(n·2^n) by processing one element at a time (zetaStep)",
+      "M\u00f6bius inversion on Boolean lattice reduces to signed_sum_subsets: \u2211_{T\u2286S} (-1)^|S\\T| = [S=\u2205]",
+      "The involution T \u21a6 T \u25b3 {a} for fixed a\u2208S changes |S\\T| parity \u2014 this is the key cancellation",
+      "Fast SOS computes zetaTransform in O(n\u00b72^n) by processing one element at a time (zetaStep)",
       "signed_sum_subsets proof strategy: use powerset_insert to split into halves that cancel",
       "mobius_inverts_zeta depends on signed_sum_subsets via Fubini-type argument",
       "odd_even_subset_balance is independent - involution T to T delta {a}",
-      "Finset.prod_add gives the multilinear expansion ∏(f+g) = Σ (∏f)(∏g), perfect for signed sums",
-      "The involution T↦(erase/insert a) is cleaner to formalize than symmDiff for bijection proofs",
-      "mobius_inverts_zeta requires Fubini-type sum exchange (sum_comm with dependent indices) - nontrivial in Lean"
+      "Finset.prod_add gives the multilinear expansion \u220f(f+g) = \u03a3 (\u220ff)(\u220fg), perfect for signed sums",
+      "The involution T\u21a6(erase/insert a) is cleaner to formalize than symmDiff for bijection proofs",
+      "mobius_inverts_zeta requires Fubini-type sum exchange (sum_comm with dependent indices) - nontrivial in Lean",
+      "Finset.sum_comm' handles the dependent-index Fubini exchange for \u2211_{T\u2286S} \u2211_{U\u2286T} \u2192 \u2211_{U\u2286S} \u2211_{T: U\u2286T\u2286S}"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove mobius_inverts_zeta via Fubini exchange (Finset.sum_comm or sum_sigma approach)",
-      "Alternative: prove via induction on S using signed_sum_subsets in the step"
+      "Fill inner_sum_eq bijection injectivity: T\u2081 \\ U = T\u2082 \\ U and U \u2286 T\u2081, U \u2286 T\u2082 \u2192 T\u2081 = T\u2082",
+      "Fill sdiff_eq_empty \u2194 subset matching in the if-then-else"
     ],
     "markdown": "# Knowledge Base: inclusion-exclusion-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -70,7 +76,7 @@
     "mathlib": []
   },
   "started": "2026-03-22T04:19:59.477Z",
-  "lastUpdate": "2026-03-22T04:19:59.494Z",
+  "lastUpdate": "2026-03-22T16:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/InclusionExclusion.lean",
@@ -104,17 +110,6 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionOQ01.lean"
-    },
-    {
-      "path": "Proofs/InclusionExclusionOQ03.lean",
-      "filename": "InclusionExclusionOQ03.lean",
-      "lineCount": 288,
-      "theoremCount": 11,
-      "axiomCount": 0,
-      "defCount": 3,
-      "sorryCount": 1,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionOQ03.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Research session covering 3 problems:

### 1. ballot-problem-oq-03-oq-02 (LGV Lemma)
- Convert `gv_involution_cancellation` from **axiom to theorem**
- 5 new proved theorems, well-formedness condition discovered
- **Before**: 504 lines, 0 sorries, 1 axiom → **After**: 688 lines, 2 sorries, 0 axioms

### 2. chinese-remainder-non-coprime-oq-03 (CRT)
- Add 3 Bézout-based helper lemmas for GCD-LCM distributive law
- Finding: `DistribLattice(Associates R)` needs `NormalizedGCDMonoid`, unavailable for general ED

### 3. szemeredi-counting (Counting Lemma)
- Add infrastructure: `doublyGoodVertices`, `vertexTriangles`, `triangleCount_eq_sum`
- Document 3-step proof strategy for counting lemma

## Key Findings
- LGV lemma requires `wellFormed` condition (∀ i j, sources i ≤ targets j) for Nat subtraction correctness
- Associates lattice approach for GCD-LCM distributive law needs `NormalizedGCDMonoid` (not available for general `EuclideanDomain` in Mathlib v4.26)

🤖 Generated by researcher-3